### PR TITLE
chore: codegen for several bug fixings

### DIFF
--- a/clients/client-accessanalyzer/models/index.ts
+++ b/clients/client-accessanalyzer/models/index.ts
@@ -1,11 +1,14 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
  * <p>You do not have sufficient access to perform this action.</p>
  */
 export interface AccessDeniedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AccessDeniedException";
   $fault: "client";
@@ -14,7 +17,7 @@ export interface AccessDeniedException
 
 export namespace AccessDeniedException {
   export function isa(o: any): o is AccessDeniedException {
-    return _smithy.isa(o, "AccessDeniedException");
+    return __isa(o, "AccessDeniedException");
   }
 }
 
@@ -78,7 +81,7 @@ export interface AnalyzedResource {
 
 export namespace AnalyzedResource {
   export function isa(o: any): o is AnalyzedResource {
-    return _smithy.isa(o, "AnalyzedResource");
+    return __isa(o, "AnalyzedResource");
   }
 }
 
@@ -100,7 +103,7 @@ export interface AnalyzedResourceSummary {
 
 export namespace AnalyzedResourceSummary {
   export function isa(o: any): o is AnalyzedResourceSummary {
-    return _smithy.isa(o, "AnalyzedResourceSummary");
+    return __isa(o, "AnalyzedResourceSummary");
   }
 }
 
@@ -148,7 +151,7 @@ export interface AnalyzerSummary {
 
 export namespace AnalyzerSummary {
   export function isa(o: any): o is AnalyzerSummary {
-    return _smithy.isa(o, "AnalyzerSummary");
+    return __isa(o, "AnalyzerSummary");
   }
 }
 
@@ -180,16 +183,14 @@ export interface ArchiveRuleSummary {
 
 export namespace ArchiveRuleSummary {
   export function isa(o: any): o is ArchiveRuleSummary {
-    return _smithy.isa(o, "ArchiveRuleSummary");
+    return __isa(o, "ArchiveRuleSummary");
   }
 }
 
 /**
  * <p>A conflict exception error.</p>
  */
-export interface ConflictException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface ConflictException extends __SmithyException, $MetadataBearer {
   name: "ConflictException";
   $fault: "client";
   message: string | undefined;
@@ -206,7 +207,7 @@ export interface ConflictException
 
 export namespace ConflictException {
   export function isa(o: any): o is ConflictException {
-    return _smithy.isa(o, "ConflictException");
+    return __isa(o, "ConflictException");
   }
 }
 
@@ -244,7 +245,7 @@ export interface CreateAnalyzerRequest {
 
 export namespace CreateAnalyzerRequest {
   export function isa(o: any): o is CreateAnalyzerRequest {
-    return _smithy.isa(o, "CreateAnalyzerRequest");
+    return __isa(o, "CreateAnalyzerRequest");
   }
 }
 
@@ -261,7 +262,7 @@ export interface CreateAnalyzerResponse extends $MetadataBearer {
 
 export namespace CreateAnalyzerResponse {
   export function isa(o: any): o is CreateAnalyzerResponse {
-    return _smithy.isa(o, "CreateAnalyzerResponse");
+    return __isa(o, "CreateAnalyzerResponse");
   }
 }
 
@@ -293,7 +294,7 @@ export interface CreateArchiveRuleRequest {
 
 export namespace CreateArchiveRuleRequest {
   export function isa(o: any): o is CreateArchiveRuleRequest {
-    return _smithy.isa(o, "CreateArchiveRuleRequest");
+    return __isa(o, "CreateArchiveRuleRequest");
   }
 }
 
@@ -325,7 +326,7 @@ export interface Criterion {
 
 export namespace Criterion {
   export function isa(o: any): o is Criterion {
-    return _smithy.isa(o, "Criterion");
+    return __isa(o, "Criterion");
   }
 }
 
@@ -347,7 +348,7 @@ export interface DeleteAnalyzerRequest {
 
 export namespace DeleteAnalyzerRequest {
   export function isa(o: any): o is DeleteAnalyzerRequest {
-    return _smithy.isa(o, "DeleteAnalyzerRequest");
+    return __isa(o, "DeleteAnalyzerRequest");
   }
 }
 
@@ -374,7 +375,7 @@ export interface DeleteArchiveRuleRequest {
 
 export namespace DeleteArchiveRuleRequest {
   export function isa(o: any): o is DeleteArchiveRuleRequest {
-    return _smithy.isa(o, "DeleteArchiveRuleRequest");
+    return __isa(o, "DeleteArchiveRuleRequest");
   }
 }
 
@@ -448,7 +449,7 @@ export interface Finding {
 
 export namespace Finding {
   export function isa(o: any): o is Finding {
-    return _smithy.isa(o, "Finding");
+    return __isa(o, "Finding");
   }
 }
 
@@ -527,7 +528,7 @@ export interface FindingSummary {
 
 export namespace FindingSummary {
   export function isa(o: any): o is FindingSummary {
-    return _smithy.isa(o, "FindingSummary");
+    return __isa(o, "FindingSummary");
   }
 }
 
@@ -549,7 +550,7 @@ export interface GetAnalyzedResourceRequest {
 
 export namespace GetAnalyzedResourceRequest {
   export function isa(o: any): o is GetAnalyzedResourceRequest {
-    return _smithy.isa(o, "GetAnalyzedResourceRequest");
+    return __isa(o, "GetAnalyzedResourceRequest");
   }
 }
 
@@ -567,7 +568,7 @@ export interface GetAnalyzedResourceResponse extends $MetadataBearer {
 
 export namespace GetAnalyzedResourceResponse {
   export function isa(o: any): o is GetAnalyzedResourceResponse {
-    return _smithy.isa(o, "GetAnalyzedResourceResponse");
+    return __isa(o, "GetAnalyzedResourceResponse");
   }
 }
 
@@ -584,7 +585,7 @@ export interface GetAnalyzerRequest {
 
 export namespace GetAnalyzerRequest {
   export function isa(o: any): o is GetAnalyzerRequest {
-    return _smithy.isa(o, "GetAnalyzerRequest");
+    return __isa(o, "GetAnalyzerRequest");
   }
 }
 
@@ -602,7 +603,7 @@ export interface GetAnalyzerResponse extends $MetadataBearer {
 
 export namespace GetAnalyzerResponse {
   export function isa(o: any): o is GetAnalyzerResponse {
-    return _smithy.isa(o, "GetAnalyzerResponse");
+    return __isa(o, "GetAnalyzerResponse");
   }
 }
 
@@ -624,7 +625,7 @@ export interface GetArchiveRuleRequest {
 
 export namespace GetArchiveRuleRequest {
   export function isa(o: any): o is GetArchiveRuleRequest {
-    return _smithy.isa(o, "GetArchiveRuleRequest");
+    return __isa(o, "GetArchiveRuleRequest");
   }
 }
 
@@ -641,7 +642,7 @@ export interface GetArchiveRuleResponse extends $MetadataBearer {
 
 export namespace GetArchiveRuleResponse {
   export function isa(o: any): o is GetArchiveRuleResponse {
-    return _smithy.isa(o, "GetArchiveRuleResponse");
+    return __isa(o, "GetArchiveRuleResponse");
   }
 }
 
@@ -663,7 +664,7 @@ export interface GetFindingRequest {
 
 export namespace GetFindingRequest {
   export function isa(o: any): o is GetFindingRequest {
-    return _smithy.isa(o, "GetFindingRequest");
+    return __isa(o, "GetFindingRequest");
   }
 }
 
@@ -680,7 +681,7 @@ export interface GetFindingResponse extends $MetadataBearer {
 
 export namespace GetFindingResponse {
   export function isa(o: any): o is GetFindingResponse {
-    return _smithy.isa(o, "GetFindingResponse");
+    return __isa(o, "GetFindingResponse");
   }
 }
 
@@ -703,7 +704,7 @@ export interface InlineArchiveRule {
 
 export namespace InlineArchiveRule {
   export function isa(o: any): o is InlineArchiveRule {
-    return _smithy.isa(o, "InlineArchiveRule");
+    return __isa(o, "InlineArchiveRule");
   }
 }
 
@@ -711,7 +712,7 @@ export namespace InlineArchiveRule {
  * <p>Internal server error.</p>
  */
 export interface InternalServerException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalServerException";
   $fault: "server";
@@ -724,7 +725,7 @@ export interface InternalServerException
 
 export namespace InternalServerException {
   export function isa(o: any): o is InternalServerException {
-    return _smithy.isa(o, "InternalServerException");
+    return __isa(o, "InternalServerException");
   }
 }
 
@@ -756,7 +757,7 @@ export interface ListAnalyzedResourcesRequest {
 
 export namespace ListAnalyzedResourcesRequest {
   export function isa(o: any): o is ListAnalyzedResourcesRequest {
-    return _smithy.isa(o, "ListAnalyzedResourcesRequest");
+    return __isa(o, "ListAnalyzedResourcesRequest");
   }
 }
 
@@ -778,7 +779,7 @@ export interface ListAnalyzedResourcesResponse extends $MetadataBearer {
 
 export namespace ListAnalyzedResourcesResponse {
   export function isa(o: any): o is ListAnalyzedResourcesResponse {
-    return _smithy.isa(o, "ListAnalyzedResourcesResponse");
+    return __isa(o, "ListAnalyzedResourcesResponse");
   }
 }
 
@@ -805,7 +806,7 @@ export interface ListAnalyzersRequest {
 
 export namespace ListAnalyzersRequest {
   export function isa(o: any): o is ListAnalyzersRequest {
-    return _smithy.isa(o, "ListAnalyzersRequest");
+    return __isa(o, "ListAnalyzersRequest");
   }
 }
 
@@ -827,7 +828,7 @@ export interface ListAnalyzersResponse extends $MetadataBearer {
 
 export namespace ListAnalyzersResponse {
   export function isa(o: any): o is ListAnalyzersResponse {
-    return _smithy.isa(o, "ListAnalyzersResponse");
+    return __isa(o, "ListAnalyzersResponse");
   }
 }
 
@@ -854,7 +855,7 @@ export interface ListArchiveRulesRequest {
 
 export namespace ListArchiveRulesRequest {
   export function isa(o: any): o is ListArchiveRulesRequest {
-    return _smithy.isa(o, "ListArchiveRulesRequest");
+    return __isa(o, "ListArchiveRulesRequest");
   }
 }
 
@@ -876,7 +877,7 @@ export interface ListArchiveRulesResponse extends $MetadataBearer {
 
 export namespace ListArchiveRulesResponse {
   export function isa(o: any): o is ListArchiveRulesResponse {
-    return _smithy.isa(o, "ListArchiveRulesResponse");
+    return __isa(o, "ListArchiveRulesResponse");
   }
 }
 
@@ -913,7 +914,7 @@ export interface ListFindingsRequest {
 
 export namespace ListFindingsRequest {
   export function isa(o: any): o is ListFindingsRequest {
-    return _smithy.isa(o, "ListFindingsRequest");
+    return __isa(o, "ListFindingsRequest");
   }
 }
 
@@ -936,7 +937,7 @@ export interface ListFindingsResponse extends $MetadataBearer {
 
 export namespace ListFindingsResponse {
   export function isa(o: any): o is ListFindingsResponse {
-    return _smithy.isa(o, "ListFindingsResponse");
+    return __isa(o, "ListFindingsResponse");
   }
 }
 
@@ -953,7 +954,7 @@ export interface ListTagsForResourceRequest {
 
 export namespace ListTagsForResourceRequest {
   export function isa(o: any): o is ListTagsForResourceRequest {
-    return _smithy.isa(o, "ListTagsForResourceRequest");
+    return __isa(o, "ListTagsForResourceRequest");
   }
 }
 
@@ -970,7 +971,7 @@ export interface ListTagsForResourceResponse extends $MetadataBearer {
 
 export namespace ListTagsForResourceResponse {
   export function isa(o: any): o is ListTagsForResourceResponse {
-    return _smithy.isa(o, "ListTagsForResourceResponse");
+    return __isa(o, "ListTagsForResourceResponse");
   }
 }
 
@@ -980,7 +981,7 @@ export type OrderBy = "ASC" | "DESC";
  * <p>The specified resource could not be found.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -998,7 +999,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -1014,7 +1015,7 @@ export type ResourceType =
  * <p>Service quote met error.</p>
  */
 export interface ServiceQuotaExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ServiceQuotaExceededException";
   $fault: "client";
@@ -1032,7 +1033,7 @@ export interface ServiceQuotaExceededException
 
 export namespace ServiceQuotaExceededException {
   export function isa(o: any): o is ServiceQuotaExceededException {
-    return _smithy.isa(o, "ServiceQuotaExceededException");
+    return __isa(o, "ServiceQuotaExceededException");
   }
 }
 
@@ -1054,7 +1055,7 @@ export interface SortCriteria {
 
 export namespace SortCriteria {
   export function isa(o: any): o is SortCriteria {
-    return _smithy.isa(o, "SortCriteria");
+    return __isa(o, "SortCriteria");
   }
 }
 
@@ -1077,7 +1078,7 @@ export interface StartResourceScanRequest {
 
 export namespace StartResourceScanRequest {
   export function isa(o: any): o is StartResourceScanRequest {
-    return _smithy.isa(o, "StartResourceScanRequest");
+    return __isa(o, "StartResourceScanRequest");
   }
 }
 
@@ -1099,7 +1100,7 @@ export interface TagResourceRequest {
 
 export namespace TagResourceRequest {
   export function isa(o: any): o is TagResourceRequest {
-    return _smithy.isa(o, "TagResourceRequest");
+    return __isa(o, "TagResourceRequest");
   }
 }
 
@@ -1112,7 +1113,7 @@ export interface TagResourceResponse extends $MetadataBearer {
 
 export namespace TagResourceResponse {
   export function isa(o: any): o is TagResourceResponse {
-    return _smithy.isa(o, "TagResourceResponse");
+    return __isa(o, "TagResourceResponse");
   }
 }
 
@@ -1120,7 +1121,7 @@ export namespace TagResourceResponse {
  * <p>Throttling limit exceeded error.</p>
  */
 export interface ThrottlingException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ThrottlingException";
   $fault: "client";
@@ -1133,7 +1134,7 @@ export interface ThrottlingException
 
 export namespace ThrottlingException {
   export function isa(o: any): o is ThrottlingException {
-    return _smithy.isa(o, "ThrottlingException");
+    return __isa(o, "ThrottlingException");
   }
 }
 
@@ -1157,7 +1158,7 @@ export interface UntagResourceRequest {
 
 export namespace UntagResourceRequest {
   export function isa(o: any): o is UntagResourceRequest {
-    return _smithy.isa(o, "UntagResourceRequest");
+    return __isa(o, "UntagResourceRequest");
   }
 }
 
@@ -1170,7 +1171,7 @@ export interface UntagResourceResponse extends $MetadataBearer {
 
 export namespace UntagResourceResponse {
   export function isa(o: any): o is UntagResourceResponse {
-    return _smithy.isa(o, "UntagResourceResponse");
+    return __isa(o, "UntagResourceResponse");
   }
 }
 
@@ -1203,7 +1204,7 @@ export interface UpdateArchiveRuleRequest {
 
 export namespace UpdateArchiveRuleRequest {
   export function isa(o: any): o is UpdateArchiveRuleRequest {
-    return _smithy.isa(o, "UpdateArchiveRuleRequest");
+    return __isa(o, "UpdateArchiveRuleRequest");
   }
 }
 
@@ -1242,7 +1243,7 @@ export interface UpdateFindingsRequest {
 
 export namespace UpdateFindingsRequest {
   export function isa(o: any): o is UpdateFindingsRequest {
-    return _smithy.isa(o, "UpdateFindingsRequest");
+    return __isa(o, "UpdateFindingsRequest");
   }
 }
 
@@ -1250,7 +1251,7 @@ export namespace UpdateFindingsRequest {
  * <p>Validation exception error.</p>
  */
 export interface ValidationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ValidationException";
   $fault: "client";
@@ -1268,7 +1269,7 @@ export interface ValidationException
 
 export namespace ValidationException {
   export function isa(o: any): o is ValidationException {
-    return _smithy.isa(o, "ValidationException");
+    return __isa(o, "ValidationException");
   }
 }
 
@@ -1290,7 +1291,7 @@ export interface ValidationExceptionField {
 
 export namespace ValidationExceptionField {
   export function isa(o: any): o is ValidationExceptionField {
-    return _smithy.isa(o, "ValidationExceptionField");
+    return __isa(o, "ValidationExceptionField");
   }
 }
 

--- a/clients/client-accessanalyzer/protocols/Aws_restJson1_1.ts
+++ b/clients/client-accessanalyzer/protocols/Aws_restJson1_1.ts
@@ -93,7 +93,10 @@ import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  extendedEncodeURIComponent as __extendedEncodeURIComponent
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -151,7 +154,7 @@ export async function serializeAws_restJson1_1CreateArchiveRuleCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/analyzer/{analyzerName}/archive-rule";
   if (input.analyzerName !== undefined) {
-    const labelValue: string = input.analyzerName.toString();
+    const labelValue: string = input.analyzerName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: analyzerName."
@@ -159,7 +162,7 @@ export async function serializeAws_restJson1_1CreateArchiveRuleCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{analyzerName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: analyzerName.");
@@ -200,7 +203,7 @@ export async function serializeAws_restJson1_1DeleteAnalyzerCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/analyzer/{analyzerName}";
   if (input.analyzerName !== undefined) {
-    const labelValue: string = input.analyzerName.toString();
+    const labelValue: string = input.analyzerName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: analyzerName."
@@ -208,14 +211,16 @@ export async function serializeAws_restJson1_1DeleteAnalyzerCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{analyzerName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: analyzerName.");
   }
   const query: any = {};
   if (input.clientToken !== undefined) {
-    query["clientToken"] = input.clientToken.toString();
+    query[
+      __extendedEncodeURIComponent("clientToken")
+    ] = __extendedEncodeURIComponent(input.clientToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -235,7 +240,7 @@ export async function serializeAws_restJson1_1DeleteArchiveRuleCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/analyzer/{analyzerName}/archive-rule/{ruleName}";
   if (input.analyzerName !== undefined) {
-    const labelValue: string = input.analyzerName.toString();
+    const labelValue: string = input.analyzerName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: analyzerName."
@@ -243,26 +248,28 @@ export async function serializeAws_restJson1_1DeleteArchiveRuleCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{analyzerName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: analyzerName.");
   }
   if (input.ruleName !== undefined) {
-    const labelValue: string = input.ruleName.toString();
+    const labelValue: string = input.ruleName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ruleName.");
     }
     resolvedPath = resolvedPath.replace(
       "{ruleName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ruleName.");
   }
   const query: any = {};
   if (input.clientToken !== undefined) {
-    query["clientToken"] = input.clientToken.toString();
+    query[
+      __extendedEncodeURIComponent("clientToken")
+    ] = __extendedEncodeURIComponent(input.clientToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -283,10 +290,14 @@ export async function serializeAws_restJson1_1GetAnalyzedResourceCommand(
   let resolvedPath = "/analyzed-resource";
   const query: any = {};
   if (input.analyzerArn !== undefined) {
-    query["analyzerArn"] = input.analyzerArn.toString();
+    query[
+      __extendedEncodeURIComponent("analyzerArn")
+    ] = __extendedEncodeURIComponent(input.analyzerArn);
   }
   if (input.resourceArn !== undefined) {
-    query["resourceArn"] = input.resourceArn.toString();
+    query[
+      __extendedEncodeURIComponent("resourceArn")
+    ] = __extendedEncodeURIComponent(input.resourceArn);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -306,7 +317,7 @@ export async function serializeAws_restJson1_1GetAnalyzerCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/analyzer/{analyzerName}";
   if (input.analyzerName !== undefined) {
-    const labelValue: string = input.analyzerName.toString();
+    const labelValue: string = input.analyzerName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: analyzerName."
@@ -314,7 +325,7 @@ export async function serializeAws_restJson1_1GetAnalyzerCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{analyzerName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: analyzerName.");
@@ -336,7 +347,7 @@ export async function serializeAws_restJson1_1GetArchiveRuleCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/analyzer/{analyzerName}/archive-rule/{ruleName}";
   if (input.analyzerName !== undefined) {
-    const labelValue: string = input.analyzerName.toString();
+    const labelValue: string = input.analyzerName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: analyzerName."
@@ -344,19 +355,19 @@ export async function serializeAws_restJson1_1GetArchiveRuleCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{analyzerName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: analyzerName.");
   }
   if (input.ruleName !== undefined) {
-    const labelValue: string = input.ruleName.toString();
+    const labelValue: string = input.ruleName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ruleName.");
     }
     resolvedPath = resolvedPath.replace(
       "{ruleName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ruleName.");
@@ -378,17 +389,22 @@ export async function serializeAws_restJson1_1GetFindingCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/finding/{id}";
   if (input.id !== undefined) {
-    const labelValue: string = input.id.toString();
+    const labelValue: string = input.id;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: id.");
     }
-    resolvedPath = resolvedPath.replace("{id}", encodeURIComponent(labelValue));
+    resolvedPath = resolvedPath.replace(
+      "{id}",
+      __extendedEncodeURIComponent(labelValue)
+    );
   } else {
     throw new Error("No value provided for input HTTP label: id.");
   }
   const query: any = {};
   if (input.analyzerArn !== undefined) {
-    query["analyzerArn"] = input.analyzerArn.toString();
+    query[
+      __extendedEncodeURIComponent("analyzerArn")
+    ] = __extendedEncodeURIComponent(input.analyzerArn);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -441,13 +457,19 @@ export async function serializeAws_restJson1_1ListAnalyzersCommand(
   let resolvedPath = "/analyzer";
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   if (input.type !== undefined) {
-    query["type"] = input.type.toString();
+    query[__extendedEncodeURIComponent("type")] = __extendedEncodeURIComponent(
+      input.type
+    );
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -467,7 +489,7 @@ export async function serializeAws_restJson1_1ListArchiveRulesCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/analyzer/{analyzerName}/archive-rule";
   if (input.analyzerName !== undefined) {
-    const labelValue: string = input.analyzerName.toString();
+    const labelValue: string = input.analyzerName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: analyzerName."
@@ -475,17 +497,21 @@ export async function serializeAws_restJson1_1ListArchiveRulesCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{analyzerName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: analyzerName.");
   }
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -546,7 +572,7 @@ export async function serializeAws_restJson1_1ListTagsForResourceCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/tags/{resourceArn}";
   if (input.resourceArn !== undefined) {
-    const labelValue: string = input.resourceArn.toString();
+    const labelValue: string = input.resourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: resourceArn."
@@ -554,7 +580,7 @@ export async function serializeAws_restJson1_1ListTagsForResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{resourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: resourceArn.");
@@ -602,7 +628,7 @@ export async function serializeAws_restJson1_1TagResourceCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/tags/{resourceArn}";
   if (input.resourceArn !== undefined) {
-    const labelValue: string = input.resourceArn.toString();
+    const labelValue: string = input.resourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: resourceArn."
@@ -610,7 +636,7 @@ export async function serializeAws_restJson1_1TagResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{resourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: resourceArn.");
@@ -639,7 +665,7 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/tags/{resourceArn}";
   if (input.resourceArn !== undefined) {
-    const labelValue: string = input.resourceArn.toString();
+    const labelValue: string = input.resourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: resourceArn."
@@ -647,14 +673,16 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{resourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: resourceArn.");
   }
   const query: any = {};
   if (input.tagKeys !== undefined) {
-    query["tagKeys"] = input.tagKeys;
+    query[__extendedEncodeURIComponent("tagKeys")] = input.tagKeys.map(entry =>
+      __extendedEncodeURIComponent(entry)
+    );
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -674,7 +702,7 @@ export async function serializeAws_restJson1_1UpdateArchiveRuleCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/analyzer/{analyzerName}/archive-rule/{ruleName}";
   if (input.analyzerName !== undefined) {
-    const labelValue: string = input.analyzerName.toString();
+    const labelValue: string = input.analyzerName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: analyzerName."
@@ -682,19 +710,19 @@ export async function serializeAws_restJson1_1UpdateArchiveRuleCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{analyzerName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: analyzerName.");
   }
   if (input.ruleName !== undefined) {
-    const labelValue: string = input.ruleName.toString();
+    const labelValue: string = input.ruleName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ruleName.");
     }
     resolvedPath = resolvedPath.replace(
       "{ruleName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ruleName.");
@@ -869,6 +897,7 @@ export async function deserializeAws_restJson1_1CreateArchiveRuleCommand(
   const contents: CreateArchiveRuleCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -961,6 +990,7 @@ export async function deserializeAws_restJson1_1DeleteAnalyzerCommand(
   const contents: DeleteAnalyzerCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -1039,6 +1069,7 @@ export async function deserializeAws_restJson1_1DeleteArchiveRuleCommand(
   const contents: DeleteArchiveRuleCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -1884,6 +1915,7 @@ export async function deserializeAws_restJson1_1StartResourceScanCommand(
   const contents: StartResourceScanCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -1960,6 +1992,7 @@ export async function deserializeAws_restJson1_1TagResourceCommand(
     $metadata: deserializeMetadata(output),
     __type: "TagResourceResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2036,6 +2069,7 @@ export async function deserializeAws_restJson1_1UntagResourceCommand(
     $metadata: deserializeMetadata(output),
     __type: "UntagResourceResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2114,6 +2148,7 @@ export async function deserializeAws_restJson1_1UpdateArchiveRuleCommand(
   const contents: UpdateArchiveRuleCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2192,6 +2227,7 @@ export async function deserializeAws_restJson1_1UpdateFindingsCommand(
   const contents: UpdateFindingsCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 

--- a/clients/client-acm-pca/models/index.ts
+++ b/clients/client-acm-pca/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -97,7 +100,7 @@ export interface ASN1Subject {
 
 export namespace ASN1Subject {
   export function isa(o: any): o is ASN1Subject {
-    return _smithy.isa(o, "ASN1Subject");
+    return __isa(o, "ASN1Subject");
   }
 }
 
@@ -199,7 +202,7 @@ export interface CertificateAuthority {
 
 export namespace CertificateAuthority {
   export function isa(o: any): o is CertificateAuthority {
-    return _smithy.isa(o, "CertificateAuthority");
+    return __isa(o, "CertificateAuthority");
   }
 }
 
@@ -233,7 +236,7 @@ export interface CertificateAuthorityConfiguration {
 
 export namespace CertificateAuthorityConfiguration {
   export function isa(o: any): o is CertificateAuthorityConfiguration {
-    return _smithy.isa(o, "CertificateAuthorityConfiguration");
+    return __isa(o, "CertificateAuthorityConfiguration");
   }
 }
 
@@ -257,7 +260,7 @@ export enum CertificateAuthorityType {
  * 			conditions specified in the certificate that signed it.</p>
  */
 export interface CertificateMismatchException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CertificateMismatchException";
   $fault: "client";
@@ -266,7 +269,7 @@ export interface CertificateMismatchException
 
 export namespace CertificateMismatchException {
   export function isa(o: any): o is CertificateMismatchException {
-    return _smithy.isa(o, "CertificateMismatchException");
+    return __isa(o, "CertificateMismatchException");
   }
 }
 
@@ -274,7 +277,7 @@ export namespace CertificateMismatchException {
  * <p>A previous update to your private CA is still ongoing.</p>
  */
 export interface ConcurrentModificationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ConcurrentModificationException";
   $fault: "client";
@@ -283,7 +286,7 @@ export interface ConcurrentModificationException
 
 export namespace ConcurrentModificationException {
   export function isa(o: any): o is ConcurrentModificationException {
-    return _smithy.isa(o, "ConcurrentModificationException");
+    return __isa(o, "ConcurrentModificationException");
   }
 }
 
@@ -312,7 +315,7 @@ export namespace CreateCertificateAuthorityAuditReportRequest {
   export function isa(
     o: any
   ): o is CreateCertificateAuthorityAuditReportRequest {
-    return _smithy.isa(o, "CreateCertificateAuthorityAuditReportRequest");
+    return __isa(o, "CreateCertificateAuthorityAuditReportRequest");
   }
 }
 
@@ -335,7 +338,7 @@ export namespace CreateCertificateAuthorityAuditReportResponse {
   export function isa(
     o: any
   ): o is CreateCertificateAuthorityAuditReportResponse {
-    return _smithy.isa(o, "CreateCertificateAuthorityAuditReportResponse");
+    return __isa(o, "CreateCertificateAuthorityAuditReportResponse");
   }
 }
 
@@ -382,7 +385,7 @@ export interface CreateCertificateAuthorityRequest {
 
 export namespace CreateCertificateAuthorityRequest {
   export function isa(o: any): o is CreateCertificateAuthorityRequest {
-    return _smithy.isa(o, "CreateCertificateAuthorityRequest");
+    return __isa(o, "CreateCertificateAuthorityRequest");
   }
 }
 
@@ -401,7 +404,7 @@ export interface CreateCertificateAuthorityResponse extends $MetadataBearer {
 
 export namespace CreateCertificateAuthorityResponse {
   export function isa(o: any): o is CreateCertificateAuthorityResponse {
-    return _smithy.isa(o, "CreateCertificateAuthorityResponse");
+    return __isa(o, "CreateCertificateAuthorityResponse");
   }
 }
 
@@ -439,7 +442,7 @@ export interface CreatePermissionRequest {
 
 export namespace CreatePermissionRequest {
   export function isa(o: any): o is CreatePermissionRequest {
-    return _smithy.isa(o, "CreatePermissionRequest");
+    return __isa(o, "CreatePermissionRequest");
   }
 }
 
@@ -582,7 +585,7 @@ export interface CrlConfiguration {
 
 export namespace CrlConfiguration {
   export function isa(o: any): o is CrlConfiguration {
-    return _smithy.isa(o, "CrlConfiguration");
+    return __isa(o, "CrlConfiguration");
   }
 }
 
@@ -606,7 +609,7 @@ export interface DeleteCertificateAuthorityRequest {
 
 export namespace DeleteCertificateAuthorityRequest {
   export function isa(o: any): o is DeleteCertificateAuthorityRequest {
-    return _smithy.isa(o, "DeleteCertificateAuthorityRequest");
+    return __isa(o, "DeleteCertificateAuthorityRequest");
   }
 }
 
@@ -638,7 +641,7 @@ export interface DeletePermissionRequest {
 
 export namespace DeletePermissionRequest {
   export function isa(o: any): o is DeletePermissionRequest {
-    return _smithy.isa(o, "DeletePermissionRequest");
+    return __isa(o, "DeletePermissionRequest");
   }
 }
 
@@ -663,7 +666,7 @@ export namespace DescribeCertificateAuthorityAuditReportRequest {
   export function isa(
     o: any
   ): o is DescribeCertificateAuthorityAuditReportRequest {
-    return _smithy.isa(o, "DescribeCertificateAuthorityAuditReportRequest");
+    return __isa(o, "DescribeCertificateAuthorityAuditReportRequest");
   }
 }
 
@@ -696,7 +699,7 @@ export namespace DescribeCertificateAuthorityAuditReportResponse {
   export function isa(
     o: any
   ): o is DescribeCertificateAuthorityAuditReportResponse {
-    return _smithy.isa(o, "DescribeCertificateAuthorityAuditReportResponse");
+    return __isa(o, "DescribeCertificateAuthorityAuditReportResponse");
   }
 }
 
@@ -714,7 +717,7 @@ export interface DescribeCertificateAuthorityRequest {
 
 export namespace DescribeCertificateAuthorityRequest {
   export function isa(o: any): o is DescribeCertificateAuthorityRequest {
-    return _smithy.isa(o, "DescribeCertificateAuthorityRequest");
+    return __isa(o, "DescribeCertificateAuthorityRequest");
   }
 }
 
@@ -729,7 +732,7 @@ export interface DescribeCertificateAuthorityResponse extends $MetadataBearer {
 
 export namespace DescribeCertificateAuthorityResponse {
   export function isa(o: any): o is DescribeCertificateAuthorityResponse {
-    return _smithy.isa(o, "DescribeCertificateAuthorityResponse");
+    return __isa(o, "DescribeCertificateAuthorityResponse");
   }
 }
 
@@ -753,7 +756,7 @@ export interface GetCertificateAuthorityCertificateRequest {
 
 export namespace GetCertificateAuthorityCertificateRequest {
   export function isa(o: any): o is GetCertificateAuthorityCertificateRequest {
-    return _smithy.isa(o, "GetCertificateAuthorityCertificateRequest");
+    return __isa(o, "GetCertificateAuthorityCertificateRequest");
   }
 }
 
@@ -776,7 +779,7 @@ export interface GetCertificateAuthorityCertificateResponse
 
 export namespace GetCertificateAuthorityCertificateResponse {
   export function isa(o: any): o is GetCertificateAuthorityCertificateResponse {
-    return _smithy.isa(o, "GetCertificateAuthorityCertificateResponse");
+    return __isa(o, "GetCertificateAuthorityCertificateResponse");
   }
 }
 
@@ -794,7 +797,7 @@ export interface GetCertificateAuthorityCsrRequest {
 
 export namespace GetCertificateAuthorityCsrRequest {
   export function isa(o: any): o is GetCertificateAuthorityCsrRequest {
-    return _smithy.isa(o, "GetCertificateAuthorityCsrRequest");
+    return __isa(o, "GetCertificateAuthorityCsrRequest");
   }
 }
 
@@ -809,7 +812,7 @@ export interface GetCertificateAuthorityCsrResponse extends $MetadataBearer {
 
 export namespace GetCertificateAuthorityCsrResponse {
   export function isa(o: any): o is GetCertificateAuthorityCsrResponse {
-    return _smithy.isa(o, "GetCertificateAuthorityCsrResponse");
+    return __isa(o, "GetCertificateAuthorityCsrResponse");
   }
 }
 
@@ -837,7 +840,7 @@ export interface GetCertificateRequest {
 
 export namespace GetCertificateRequest {
   export function isa(o: any): o is GetCertificateRequest {
-    return _smithy.isa(o, "GetCertificateRequest");
+    return __isa(o, "GetCertificateRequest");
   }
 }
 
@@ -858,7 +861,7 @@ export interface GetCertificateResponse extends $MetadataBearer {
 
 export namespace GetCertificateResponse {
   export function isa(o: any): o is GetCertificateResponse {
-    return _smithy.isa(o, "GetCertificateResponse");
+    return __isa(o, "GetCertificateResponse");
   }
 }
 
@@ -894,7 +897,7 @@ export namespace ImportCertificateAuthorityCertificateRequest {
   export function isa(
     o: any
   ): o is ImportCertificateAuthorityCertificateRequest {
-    return _smithy.isa(o, "ImportCertificateAuthorityCertificateRequest");
+    return __isa(o, "ImportCertificateAuthorityCertificateRequest");
   }
 }
 
@@ -902,7 +905,7 @@ export namespace ImportCertificateAuthorityCertificateRequest {
  * <p>One or more of the specified arguments was not valid.</p>
  */
 export interface InvalidArgsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidArgsException";
   $fault: "client";
@@ -911,7 +914,7 @@ export interface InvalidArgsException
 
 export namespace InvalidArgsException {
   export function isa(o: any): o is InvalidArgsException {
-    return _smithy.isa(o, "InvalidArgsException");
+    return __isa(o, "InvalidArgsException");
   }
 }
 
@@ -920,7 +923,7 @@ export namespace InvalidArgsException {
  * 			resource.</p>
  */
 export interface InvalidArnException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidArnException";
   $fault: "client";
@@ -929,7 +932,7 @@ export interface InvalidArnException
 
 export namespace InvalidArnException {
   export function isa(o: any): o is InvalidArnException {
-    return _smithy.isa(o, "InvalidArnException");
+    return __isa(o, "InvalidArnException");
   }
 }
 
@@ -938,7 +941,7 @@ export namespace InvalidArnException {
  * 			returned from your previous call to <a>ListCertificateAuthorities</a>.</p>
  */
 export interface InvalidNextTokenException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidNextTokenException";
   $fault: "client";
@@ -947,7 +950,7 @@ export interface InvalidNextTokenException
 
 export namespace InvalidNextTokenException {
   export function isa(o: any): o is InvalidNextTokenException {
-    return _smithy.isa(o, "InvalidNextTokenException");
+    return __isa(o, "InvalidNextTokenException");
   }
 }
 
@@ -956,7 +959,7 @@ export namespace InvalidNextTokenException {
  * 			and write to the bucket and find the bucket location.</p>
  */
 export interface InvalidPolicyException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidPolicyException";
   $fault: "client";
@@ -965,7 +968,7 @@ export interface InvalidPolicyException
 
 export namespace InvalidPolicyException {
   export function isa(o: any): o is InvalidPolicyException {
-    return _smithy.isa(o, "InvalidPolicyException");
+    return __isa(o, "InvalidPolicyException");
   }
 }
 
@@ -973,7 +976,7 @@ export namespace InvalidPolicyException {
  * <p>The request action cannot be performed or is prohibited.</p>
  */
 export interface InvalidRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidRequestException";
   $fault: "client";
@@ -982,7 +985,7 @@ export interface InvalidRequestException
 
 export namespace InvalidRequestException {
   export function isa(o: any): o is InvalidRequestException {
-    return _smithy.isa(o, "InvalidRequestException");
+    return __isa(o, "InvalidRequestException");
   }
 }
 
@@ -991,7 +994,7 @@ export namespace InvalidRequestException {
  * 			generated.</p>
  */
 export interface InvalidStateException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidStateException";
   $fault: "client";
@@ -1000,7 +1003,7 @@ export interface InvalidStateException
 
 export namespace InvalidStateException {
   export function isa(o: any): o is InvalidStateException {
-    return _smithy.isa(o, "InvalidStateException");
+    return __isa(o, "InvalidStateException");
   }
 }
 
@@ -1009,7 +1012,7 @@ export namespace InvalidStateException {
  * 			message field.</p>
  */
 export interface InvalidTagException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidTagException";
   $fault: "client";
@@ -1018,7 +1021,7 @@ export interface InvalidTagException
 
 export namespace InvalidTagException {
   export function isa(o: any): o is InvalidTagException {
-    return _smithy.isa(o, "InvalidTagException");
+    return __isa(o, "InvalidTagException");
   }
 }
 
@@ -1105,7 +1108,7 @@ export interface IssueCertificateRequest {
 
 export namespace IssueCertificateRequest {
   export function isa(o: any): o is IssueCertificateRequest {
-    return _smithy.isa(o, "IssueCertificateRequest");
+    return __isa(o, "IssueCertificateRequest");
   }
 }
 
@@ -1124,7 +1127,7 @@ export interface IssueCertificateResponse extends $MetadataBearer {
 
 export namespace IssueCertificateResponse {
   export function isa(o: any): o is IssueCertificateResponse {
-    return _smithy.isa(o, "IssueCertificateResponse");
+    return __isa(o, "IssueCertificateResponse");
   }
 }
 
@@ -1140,7 +1143,7 @@ export enum KeyAlgorithm {
  * 			limit that was exceeded.</p>
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -1149,7 +1152,7 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
@@ -1174,7 +1177,7 @@ export interface ListCertificateAuthoritiesRequest {
 
 export namespace ListCertificateAuthoritiesRequest {
   export function isa(o: any): o is ListCertificateAuthoritiesRequest {
-    return _smithy.isa(o, "ListCertificateAuthoritiesRequest");
+    return __isa(o, "ListCertificateAuthoritiesRequest");
   }
 }
 
@@ -1194,7 +1197,7 @@ export interface ListCertificateAuthoritiesResponse extends $MetadataBearer {
 
 export namespace ListCertificateAuthoritiesResponse {
   export function isa(o: any): o is ListCertificateAuthoritiesResponse {
-    return _smithy.isa(o, "ListCertificateAuthoritiesResponse");
+    return __isa(o, "ListCertificateAuthoritiesResponse");
   }
 }
 
@@ -1227,7 +1230,7 @@ export interface ListPermissionsRequest {
 
 export namespace ListPermissionsRequest {
   export function isa(o: any): o is ListPermissionsRequest {
-    return _smithy.isa(o, "ListPermissionsRequest");
+    return __isa(o, "ListPermissionsRequest");
   }
 }
 
@@ -1248,7 +1251,7 @@ export interface ListPermissionsResponse extends $MetadataBearer {
 
 export namespace ListPermissionsResponse {
   export function isa(o: any): o is ListPermissionsResponse {
-    return _smithy.isa(o, "ListPermissionsResponse");
+    return __isa(o, "ListPermissionsResponse");
   }
 }
 
@@ -1281,7 +1284,7 @@ export interface ListTagsRequest {
 
 export namespace ListTagsRequest {
   export function isa(o: any): o is ListTagsRequest {
-    return _smithy.isa(o, "ListTagsRequest");
+    return __isa(o, "ListTagsRequest");
   }
 }
 
@@ -1301,7 +1304,7 @@ export interface ListTagsResponse extends $MetadataBearer {
 
 export namespace ListTagsResponse {
   export function isa(o: any): o is ListTagsResponse {
-    return _smithy.isa(o, "ListTagsResponse");
+    return __isa(o, "ListTagsResponse");
   }
 }
 
@@ -1309,7 +1312,7 @@ export namespace ListTagsResponse {
  * <p>The certificate signing request is invalid.</p>
  */
 export interface MalformedCSRException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "MalformedCSRException";
   $fault: "client";
@@ -1318,7 +1321,7 @@ export interface MalformedCSRException
 
 export namespace MalformedCSRException {
   export function isa(o: any): o is MalformedCSRException {
-    return _smithy.isa(o, "MalformedCSRException");
+    return __isa(o, "MalformedCSRException");
   }
 }
 
@@ -1326,7 +1329,7 @@ export namespace MalformedCSRException {
  * <p>One or more fields in the certificate are invalid.</p>
  */
 export interface MalformedCertificateException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "MalformedCertificateException";
   $fault: "client";
@@ -1335,7 +1338,7 @@ export interface MalformedCertificateException
 
 export namespace MalformedCertificateException {
   export function isa(o: any): o is MalformedCertificateException {
-    return _smithy.isa(o, "MalformedCertificateException");
+    return __isa(o, "MalformedCertificateException");
   }
 }
 
@@ -1383,7 +1386,7 @@ export interface Permission {
 
 export namespace Permission {
   export function isa(o: any): o is Permission {
-    return _smithy.isa(o, "Permission");
+    return __isa(o, "Permission");
   }
 }
 
@@ -1391,7 +1394,7 @@ export namespace Permission {
  * <p>The designated permission has already been given to the user.</p>
  */
 export interface PermissionAlreadyExistsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "PermissionAlreadyExistsException";
   $fault: "client";
@@ -1400,7 +1403,7 @@ export interface PermissionAlreadyExistsException
 
 export namespace PermissionAlreadyExistsException {
   export function isa(o: any): o is PermissionAlreadyExistsException {
-    return _smithy.isa(o, "PermissionAlreadyExistsException");
+    return __isa(o, "PermissionAlreadyExistsException");
   }
 }
 
@@ -1408,7 +1411,7 @@ export namespace PermissionAlreadyExistsException {
  * <p>Your request has already been completed.</p>
  */
 export interface RequestAlreadyProcessedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "RequestAlreadyProcessedException";
   $fault: "client";
@@ -1417,7 +1420,7 @@ export interface RequestAlreadyProcessedException
 
 export namespace RequestAlreadyProcessedException {
   export function isa(o: any): o is RequestAlreadyProcessedException {
-    return _smithy.isa(o, "RequestAlreadyProcessedException");
+    return __isa(o, "RequestAlreadyProcessedException");
   }
 }
 
@@ -1425,7 +1428,7 @@ export namespace RequestAlreadyProcessedException {
  * <p>The request has failed for an unspecified reason.</p>
  */
 export interface RequestFailedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "RequestFailedException";
   $fault: "client";
@@ -1434,7 +1437,7 @@ export interface RequestFailedException
 
 export namespace RequestFailedException {
   export function isa(o: any): o is RequestFailedException {
-    return _smithy.isa(o, "RequestFailedException");
+    return __isa(o, "RequestFailedException");
   }
 }
 
@@ -1442,7 +1445,7 @@ export namespace RequestFailedException {
  * <p>Your request is already in progress.</p>
  */
 export interface RequestInProgressException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "RequestInProgressException";
   $fault: "client";
@@ -1451,7 +1454,7 @@ export interface RequestInProgressException
 
 export namespace RequestInProgressException {
   export function isa(o: any): o is RequestInProgressException {
-    return _smithy.isa(o, "RequestInProgressException");
+    return __isa(o, "RequestInProgressException");
   }
 }
 
@@ -1460,7 +1463,7 @@ export namespace RequestInProgressException {
  * 			found.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -1469,7 +1472,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -1487,7 +1490,7 @@ export interface RestoreCertificateAuthorityRequest {
 
 export namespace RestoreCertificateAuthorityRequest {
   export function isa(o: any): o is RestoreCertificateAuthorityRequest {
-    return _smithy.isa(o, "RestoreCertificateAuthorityRequest");
+    return __isa(o, "RestoreCertificateAuthorityRequest");
   }
 }
 
@@ -1509,7 +1512,7 @@ export interface RevocationConfiguration {
 
 export namespace RevocationConfiguration {
   export function isa(o: any): o is RevocationConfiguration {
-    return _smithy.isa(o, "RevocationConfiguration");
+    return __isa(o, "RevocationConfiguration");
   }
 }
 
@@ -1559,7 +1562,7 @@ export interface RevokeCertificateRequest {
 
 export namespace RevokeCertificateRequest {
   export function isa(o: any): o is RevokeCertificateRequest {
-    return _smithy.isa(o, "RevokeCertificateRequest");
+    return __isa(o, "RevokeCertificateRequest");
   }
 }
 
@@ -1592,7 +1595,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -1615,7 +1618,7 @@ export interface TagCertificateAuthorityRequest {
 
 export namespace TagCertificateAuthorityRequest {
   export function isa(o: any): o is TagCertificateAuthorityRequest {
-    return _smithy.isa(o, "TagCertificateAuthorityRequest");
+    return __isa(o, "TagCertificateAuthorityRequest");
   }
 }
 
@@ -1624,7 +1627,7 @@ export namespace TagCertificateAuthorityRequest {
  * 			in the exception message field.</p>
  */
 export interface TooManyTagsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyTagsException";
   $fault: "client";
@@ -1633,7 +1636,7 @@ export interface TooManyTagsException
 
 export namespace TooManyTagsException {
   export function isa(o: any): o is TooManyTagsException {
-    return _smithy.isa(o, "TooManyTagsException");
+    return __isa(o, "TooManyTagsException");
   }
 }
 
@@ -1656,7 +1659,7 @@ export interface UntagCertificateAuthorityRequest {
 
 export namespace UntagCertificateAuthorityRequest {
   export function isa(o: any): o is UntagCertificateAuthorityRequest {
-    return _smithy.isa(o, "UntagCertificateAuthorityRequest");
+    return __isa(o, "UntagCertificateAuthorityRequest");
   }
 }
 
@@ -1685,7 +1688,7 @@ export interface UpdateCertificateAuthorityRequest {
 
 export namespace UpdateCertificateAuthorityRequest {
   export function isa(o: any): o is UpdateCertificateAuthorityRequest {
-    return _smithy.isa(o, "UpdateCertificateAuthorityRequest");
+    return __isa(o, "UpdateCertificateAuthorityRequest");
   }
 }
 
@@ -1710,7 +1713,7 @@ export interface Validity {
 
 export namespace Validity {
   export function isa(o: any): o is Validity {
-    return _smithy.isa(o, "Validity");
+    return __isa(o, "Validity");
   }
 }
 

--- a/clients/client-acm-pca/protocols/Aws_json1_1.ts
+++ b/clients/client-acm-pca/protocols/Aws_json1_1.ts
@@ -631,6 +631,7 @@ export async function deserializeAws_json1_1CreatePermissionCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1CreatePermissionCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: CreatePermissionCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -720,6 +721,7 @@ export async function deserializeAws_json1_1DeleteCertificateAuthorityCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteCertificateAuthorityCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -792,6 +794,7 @@ export async function deserializeAws_json1_1DeletePermissionCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1DeletePermissionCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeletePermissionCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1262,6 +1265,7 @@ export async function deserializeAws_json1_1ImportCertificateAuthorityCertificat
       context
     );
   }
+  await collectBody(output.body, context);
   const response: ImportCertificateAuthorityCertificateCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1679,6 +1683,7 @@ export async function deserializeAws_json1_1RestoreCertificateAuthorityCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: RestoreCertificateAuthorityCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1744,6 +1749,7 @@ export async function deserializeAws_json1_1RevokeCertificateCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1RevokeCertificateCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: RevokeCertificateCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1854,6 +1860,7 @@ export async function deserializeAws_json1_1TagCertificateAuthorityCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: TagCertificateAuthorityCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1936,6 +1943,7 @@ export async function deserializeAws_json1_1UntagCertificateAuthorityCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: UntagCertificateAuthorityCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2011,6 +2019,7 @@ export async function deserializeAws_json1_1UpdateCertificateAuthorityCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: UpdateCertificateAuthorityCommandOutput = {
     $metadata: deserializeMetadata(output)
   };

--- a/clients/client-acm/models/index.ts
+++ b/clients/client-acm/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export interface AddTagsToCertificateRequest {
@@ -23,7 +26,7 @@ export interface AddTagsToCertificateRequest {
 
 export namespace AddTagsToCertificateRequest {
   export function isa(o: any): o is AddTagsToCertificateRequest {
-    return _smithy.isa(o, "AddTagsToCertificateRequest");
+    return __isa(o, "AddTagsToCertificateRequest");
   }
 }
 
@@ -202,7 +205,7 @@ export interface CertificateDetail {
 
 export namespace CertificateDetail {
   export function isa(o: any): o is CertificateDetail {
-    return _smithy.isa(o, "CertificateDetail");
+    return __isa(o, "CertificateDetail");
   }
 }
 
@@ -228,7 +231,7 @@ export interface CertificateOptions {
 
 export namespace CertificateOptions {
   export function isa(o: any): o is CertificateOptions {
-    return _smithy.isa(o, "CertificateOptions");
+    return __isa(o, "CertificateOptions");
   }
 }
 
@@ -268,7 +271,7 @@ export interface CertificateSummary {
 
 export namespace CertificateSummary {
   export function isa(o: any): o is CertificateSummary {
-    return _smithy.isa(o, "CertificateSummary");
+    return __isa(o, "CertificateSummary");
   }
 }
 
@@ -298,7 +301,7 @@ export interface DeleteCertificateRequest {
 
 export namespace DeleteCertificateRequest {
   export function isa(o: any): o is DeleteCertificateRequest {
-    return _smithy.isa(o, "DeleteCertificateRequest");
+    return __isa(o, "DeleteCertificateRequest");
   }
 }
 
@@ -317,7 +320,7 @@ export interface DescribeCertificateRequest {
 
 export namespace DescribeCertificateRequest {
   export function isa(o: any): o is DescribeCertificateRequest {
-    return _smithy.isa(o, "DescribeCertificateRequest");
+    return __isa(o, "DescribeCertificateRequest");
   }
 }
 
@@ -331,7 +334,7 @@ export interface DescribeCertificateResponse extends $MetadataBearer {
 
 export namespace DescribeCertificateResponse {
   export function isa(o: any): o is DescribeCertificateResponse {
-    return _smithy.isa(o, "DescribeCertificateResponse");
+    return __isa(o, "DescribeCertificateResponse");
   }
 }
 
@@ -397,7 +400,7 @@ export interface DomainValidation {
 
 export namespace DomainValidation {
   export function isa(o: any): o is DomainValidation {
-    return _smithy.isa(o, "DomainValidation");
+    return __isa(o, "DomainValidation");
   }
 }
 
@@ -442,7 +445,7 @@ export interface DomainValidationOption {
 
 export namespace DomainValidationOption {
   export function isa(o: any): o is DomainValidationOption {
-    return _smithy.isa(o, "DomainValidationOption");
+    return __isa(o, "DomainValidationOption");
   }
 }
 
@@ -469,7 +472,7 @@ export interface ExportCertificateRequest {
 
 export namespace ExportCertificateRequest {
   export function isa(o: any): o is ExportCertificateRequest {
-    return _smithy.isa(o, "ExportCertificateRequest");
+    return __isa(o, "ExportCertificateRequest");
   }
 }
 
@@ -495,7 +498,7 @@ export interface ExportCertificateResponse extends $MetadataBearer {
 
 export namespace ExportCertificateResponse {
   export function isa(o: any): o is ExportCertificateResponse {
-    return _smithy.isa(o, "ExportCertificateResponse");
+    return __isa(o, "ExportCertificateResponse");
   }
 }
 
@@ -568,7 +571,7 @@ export interface ExtendedKeyUsage {
 
 export namespace ExtendedKeyUsage {
   export function isa(o: any): o is ExtendedKeyUsage {
-    return _smithy.isa(o, "ExtendedKeyUsage");
+    return __isa(o, "ExtendedKeyUsage");
   }
 }
 
@@ -634,7 +637,7 @@ export interface Filters {
 
 export namespace Filters {
   export function isa(o: any): o is Filters {
-    return _smithy.isa(o, "Filters");
+    return __isa(o, "Filters");
   }
 }
 
@@ -652,7 +655,7 @@ export interface GetCertificateRequest {
 
 export namespace GetCertificateRequest {
   export function isa(o: any): o is GetCertificateRequest {
-    return _smithy.isa(o, "GetCertificateRequest");
+    return __isa(o, "GetCertificateRequest");
   }
 }
 
@@ -673,7 +676,7 @@ export interface GetCertificateResponse extends $MetadataBearer {
 
 export namespace GetCertificateResponse {
   export function isa(o: any): o is GetCertificateResponse {
-    return _smithy.isa(o, "GetCertificateResponse");
+    return __isa(o, "GetCertificateResponse");
   }
 }
 
@@ -710,7 +713,7 @@ export interface ImportCertificateRequest {
 
 export namespace ImportCertificateRequest {
   export function isa(o: any): o is ImportCertificateRequest {
-    return _smithy.isa(o, "ImportCertificateRequest");
+    return __isa(o, "ImportCertificateRequest");
   }
 }
 
@@ -725,7 +728,7 @@ export interface ImportCertificateResponse extends $MetadataBearer {
 
 export namespace ImportCertificateResponse {
   export function isa(o: any): o is ImportCertificateResponse {
-    return _smithy.isa(o, "ImportCertificateResponse");
+    return __isa(o, "ImportCertificateResponse");
   }
 }
 
@@ -733,7 +736,7 @@ export namespace ImportCertificateResponse {
  * <p>One or more of of request parameters specified is not valid.</p>
  */
 export interface InvalidArgsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidArgsException";
   $fault: "client";
@@ -742,7 +745,7 @@ export interface InvalidArgsException
 
 export namespace InvalidArgsException {
   export function isa(o: any): o is InvalidArgsException {
-    return _smithy.isa(o, "InvalidArgsException");
+    return __isa(o, "InvalidArgsException");
   }
 }
 
@@ -750,7 +753,7 @@ export namespace InvalidArgsException {
  * <p>The requested Amazon Resource Name (ARN) does not refer to an existing resource.</p>
  */
 export interface InvalidArnException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidArnException";
   $fault: "client";
@@ -759,7 +762,7 @@ export interface InvalidArnException
 
 export namespace InvalidArnException {
   export function isa(o: any): o is InvalidArnException {
-    return _smithy.isa(o, "InvalidArnException");
+    return __isa(o, "InvalidArnException");
   }
 }
 
@@ -768,7 +771,7 @@ export namespace InvalidArnException {
  *       incorrect.</p>
  */
 export interface InvalidDomainValidationOptionsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidDomainValidationOptionsException";
   $fault: "client";
@@ -777,7 +780,7 @@ export interface InvalidDomainValidationOptionsException
 
 export namespace InvalidDomainValidationOptionsException {
   export function isa(o: any): o is InvalidDomainValidationOptionsException {
-    return _smithy.isa(o, "InvalidDomainValidationOptionsException");
+    return __isa(o, "InvalidDomainValidationOptionsException");
   }
 }
 
@@ -785,7 +788,7 @@ export namespace InvalidDomainValidationOptionsException {
  * <p>An input parameter was invalid.</p>
  */
 export interface InvalidParameterException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidParameterException";
   $fault: "client";
@@ -794,7 +797,7 @@ export interface InvalidParameterException
 
 export namespace InvalidParameterException {
   export function isa(o: any): o is InvalidParameterException {
-    return _smithy.isa(o, "InvalidParameterException");
+    return __isa(o, "InvalidParameterException");
   }
 }
 
@@ -802,7 +805,7 @@ export namespace InvalidParameterException {
  * <p>Processing has reached an invalid state.</p>
  */
 export interface InvalidStateException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidStateException";
   $fault: "client";
@@ -811,7 +814,7 @@ export interface InvalidStateException
 
 export namespace InvalidStateException {
   export function isa(o: any): o is InvalidStateException {
-    return _smithy.isa(o, "InvalidStateException");
+    return __isa(o, "InvalidStateException");
   }
 }
 
@@ -820,7 +823,7 @@ export namespace InvalidStateException {
  *       cannot specify a tag value that begins with <code>aws:</code>.</p>
  */
 export interface InvalidTagException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidTagException";
   $fault: "client";
@@ -829,7 +832,7 @@ export interface InvalidTagException
 
 export namespace InvalidTagException {
   export function isa(o: any): o is InvalidTagException {
-    return _smithy.isa(o, "InvalidTagException");
+    return __isa(o, "InvalidTagException");
   }
 }
 
@@ -856,7 +859,7 @@ export interface KeyUsage {
 
 export namespace KeyUsage {
   export function isa(o: any): o is KeyUsage {
-    return _smithy.isa(o, "KeyUsage");
+    return __isa(o, "KeyUsage");
   }
 }
 
@@ -878,7 +881,7 @@ export enum KeyUsageName {
  * <p>An ACM limit has been exceeded.</p>
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -887,7 +890,7 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
@@ -922,7 +925,7 @@ export interface ListCertificatesRequest {
 
 export namespace ListCertificatesRequest {
   export function isa(o: any): o is ListCertificatesRequest {
-    return _smithy.isa(o, "ListCertificatesRequest");
+    return __isa(o, "ListCertificatesRequest");
   }
 }
 
@@ -942,7 +945,7 @@ export interface ListCertificatesResponse extends $MetadataBearer {
 
 export namespace ListCertificatesResponse {
   export function isa(o: any): o is ListCertificatesResponse {
-    return _smithy.isa(o, "ListCertificatesResponse");
+    return __isa(o, "ListCertificatesResponse");
   }
 }
 
@@ -961,7 +964,7 @@ export interface ListTagsForCertificateRequest {
 
 export namespace ListTagsForCertificateRequest {
   export function isa(o: any): o is ListTagsForCertificateRequest {
-    return _smithy.isa(o, "ListTagsForCertificateRequest");
+    return __isa(o, "ListTagsForCertificateRequest");
   }
 }
 
@@ -975,7 +978,7 @@ export interface ListTagsForCertificateResponse extends $MetadataBearer {
 
 export namespace ListTagsForCertificateResponse {
   export function isa(o: any): o is ListTagsForCertificateResponse {
-    return _smithy.isa(o, "ListTagsForCertificateResponse");
+    return __isa(o, "ListTagsForCertificateResponse");
   }
 }
 
@@ -1005,7 +1008,7 @@ export interface RemoveTagsFromCertificateRequest {
 
 export namespace RemoveTagsFromCertificateRequest {
   export function isa(o: any): o is RemoveTagsFromCertificateRequest {
-    return _smithy.isa(o, "RemoveTagsFromCertificateRequest");
+    return __isa(o, "RemoveTagsFromCertificateRequest");
   }
 }
 
@@ -1024,7 +1027,7 @@ export interface RenewCertificateRequest {
 
 export namespace RenewCertificateRequest {
   export function isa(o: any): o is RenewCertificateRequest {
-    return _smithy.isa(o, "RenewCertificateRequest");
+    return __isa(o, "RenewCertificateRequest");
   }
 }
 
@@ -1073,7 +1076,7 @@ export interface RenewalSummary {
 
 export namespace RenewalSummary {
   export function isa(o: any): o is RenewalSummary {
-    return _smithy.isa(o, "RenewalSummary");
+    return __isa(o, "RenewalSummary");
   }
 }
 
@@ -1174,7 +1177,7 @@ export interface RequestCertificateRequest {
 
 export namespace RequestCertificateRequest {
   export function isa(o: any): o is RequestCertificateRequest {
-    return _smithy.isa(o, "RequestCertificateRequest");
+    return __isa(o, "RequestCertificateRequest");
   }
 }
 
@@ -1191,7 +1194,7 @@ export interface RequestCertificateResponse extends $MetadataBearer {
 
 export namespace RequestCertificateResponse {
   export function isa(o: any): o is RequestCertificateResponse {
-    return _smithy.isa(o, "RequestCertificateResponse");
+    return __isa(o, "RequestCertificateResponse");
   }
 }
 
@@ -1200,7 +1203,7 @@ export namespace RequestCertificateResponse {
  *       issued.</p>
  */
 export interface RequestInProgressException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "RequestInProgressException";
   $fault: "client";
@@ -1209,7 +1212,7 @@ export interface RequestInProgressException
 
 export namespace RequestInProgressException {
   export function isa(o: any): o is RequestInProgressException {
-    return _smithy.isa(o, "RequestInProgressException");
+    return __isa(o, "RequestInProgressException");
   }
 }
 
@@ -1263,7 +1266,7 @@ export interface ResendValidationEmailRequest {
 
 export namespace ResendValidationEmailRequest {
   export function isa(o: any): o is ResendValidationEmailRequest {
-    return _smithy.isa(o, "ResendValidationEmailRequest");
+    return __isa(o, "ResendValidationEmailRequest");
   }
 }
 
@@ -1272,7 +1275,7 @@ export namespace ResendValidationEmailRequest {
  *       association and try again.</p>
  */
 export interface ResourceInUseException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceInUseException";
   $fault: "client";
@@ -1281,7 +1284,7 @@ export interface ResourceInUseException
 
 export namespace ResourceInUseException {
   export function isa(o: any): o is ResourceInUseException {
-    return _smithy.isa(o, "ResourceInUseException");
+    return __isa(o, "ResourceInUseException");
   }
 }
 
@@ -1290,7 +1293,7 @@ export namespace ResourceInUseException {
  *       cannot be found.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -1299,7 +1302,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -1328,7 +1331,7 @@ export interface ResourceRecord {
 
 export namespace ResourceRecord {
   export function isa(o: any): o is ResourceRecord {
-    return _smithy.isa(o, "ResourceRecord");
+    return __isa(o, "ResourceRecord");
   }
 }
 
@@ -1363,16 +1366,14 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
 /**
  * <p>A specified tag did not comply with an existing tag policy and was rejected.</p>
  */
-export interface TagPolicyException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface TagPolicyException extends __SmithyException, $MetadataBearer {
   name: "TagPolicyException";
   $fault: "client";
   message?: string;
@@ -1380,7 +1381,7 @@ export interface TagPolicyException
 
 export namespace TagPolicyException {
   export function isa(o: any): o is TagPolicyException {
-    return _smithy.isa(o, "TagPolicyException");
+    return __isa(o, "TagPolicyException");
   }
 }
 
@@ -1388,7 +1389,7 @@ export namespace TagPolicyException {
  * <p>The request contains too many tags. Try the request again with fewer tags.</p>
  */
 export interface TooManyTagsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyTagsException";
   $fault: "client";
@@ -1397,7 +1398,7 @@ export interface TooManyTagsException
 
 export namespace TooManyTagsException {
   export function isa(o: any): o is TooManyTagsException {
-    return _smithy.isa(o, "TooManyTagsException");
+    return __isa(o, "TooManyTagsException");
   }
 }
 
@@ -1423,7 +1424,7 @@ export interface UpdateCertificateOptionsRequest {
 
 export namespace UpdateCertificateOptionsRequest {
   export function isa(o: any): o is UpdateCertificateOptionsRequest {
-    return _smithy.isa(o, "UpdateCertificateOptionsRequest");
+    return __isa(o, "UpdateCertificateOptionsRequest");
   }
 }
 

--- a/clients/client-acm/protocols/Aws_json1_1.ts
+++ b/clients/client-acm/protocols/Aws_json1_1.ts
@@ -304,6 +304,7 @@ export async function deserializeAws_json1_1AddTagsToCertificateCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: AddTagsToCertificateCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -390,6 +391,7 @@ export async function deserializeAws_json1_1DeleteCertificateCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1DeleteCertificateCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteCertificateCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -880,6 +882,7 @@ export async function deserializeAws_json1_1RemoveTagsFromCertificateCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: RemoveTagsFromCertificateCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -959,6 +962,7 @@ export async function deserializeAws_json1_1RenewCertificateCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1RenewCertificateCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: RenewCertificateCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1121,6 +1125,7 @@ export async function deserializeAws_json1_1ResendValidationEmailCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: ResendValidationEmailCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1196,6 +1201,7 @@ export async function deserializeAws_json1_1UpdateCertificateOptionsCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: UpdateCertificateOptionsCommandOutput = {
     $metadata: deserializeMetadata(output)
   };

--- a/clients/client-alexa-for-business/models/index.ts
+++ b/clients/client-alexa-for-business/models/index.ts
@@ -1,11 +1,14 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
  * <p>The resource being created already exists.</p>
  */
 export interface AlreadyExistsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AlreadyExistsException";
   $fault: "client";
@@ -14,7 +17,7 @@ export interface AlreadyExistsException
 
 export namespace AlreadyExistsException {
   export function isa(o: any): o is AlreadyExistsException {
-    return _smithy.isa(o, "AlreadyExistsException");
+    return __isa(o, "AlreadyExistsException");
   }
 }
 
@@ -22,7 +25,7 @@ export namespace AlreadyExistsException {
  * <p>There is a concurrent modification of resources.</p>
  */
 export interface ConcurrentModificationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ConcurrentModificationException";
   $fault: "client";
@@ -31,7 +34,7 @@ export interface ConcurrentModificationException
 
 export namespace ConcurrentModificationException {
   export function isa(o: any): o is ConcurrentModificationException {
-    return _smithy.isa(o, "ConcurrentModificationException");
+    return __isa(o, "ConcurrentModificationException");
   }
 }
 
@@ -39,7 +42,7 @@ export namespace ConcurrentModificationException {
  * <p>The request failed because this device is no longer registered and therefore no longer managed by this account.</p>
  */
 export interface DeviceNotRegisteredException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DeviceNotRegisteredException";
   $fault: "client";
@@ -48,7 +51,7 @@ export interface DeviceNotRegisteredException
 
 export namespace DeviceNotRegisteredException {
   export function isa(o: any): o is DeviceNotRegisteredException {
-    return _smithy.isa(o, "DeviceNotRegisteredException");
+    return __isa(o, "DeviceNotRegisteredException");
   }
 }
 
@@ -71,7 +74,7 @@ export interface Filter {
 
 export namespace Filter {
   export function isa(o: any): o is Filter {
-    return _smithy.isa(o, "Filter");
+    return __isa(o, "Filter");
   }
 }
 
@@ -79,7 +82,7 @@ export namespace Filter {
  * <p>You are performing an action that would put you beyond your account's limits.</p>
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -88,16 +91,14 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
 /**
  * <p>The name sent in the request is already in use.</p>
  */
-export interface NameInUseException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface NameInUseException extends __SmithyException, $MetadataBearer {
   name: "NameInUseException";
   $fault: "client";
   Message?: string;
@@ -105,16 +106,14 @@ export interface NameInUseException
 
 export namespace NameInUseException {
   export function isa(o: any): o is NameInUseException {
-    return _smithy.isa(o, "NameInUseException");
+    return __isa(o, "NameInUseException");
   }
 }
 
 /**
  * <p>The resource is not found.</p>
  */
-export interface NotFoundException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface NotFoundException extends __SmithyException, $MetadataBearer {
   name: "NotFoundException";
   $fault: "client";
   Message?: string;
@@ -122,7 +121,7 @@ export interface NotFoundException
 
 export namespace NotFoundException {
   export function isa(o: any): o is NotFoundException {
-    return _smithy.isa(o, "NotFoundException");
+    return __isa(o, "NotFoundException");
   }
 }
 
@@ -130,7 +129,7 @@ export namespace NotFoundException {
  * <p>The resource in the request is already in use.</p>
  */
 export interface ResourceInUseException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceInUseException";
   $fault: "client";
@@ -144,7 +143,7 @@ export interface ResourceInUseException
 
 export namespace ResourceInUseException {
   export function isa(o: any): o is ResourceInUseException {
-    return _smithy.isa(o, "ResourceInUseException");
+    return __isa(o, "ResourceInUseException");
   }
 }
 
@@ -152,7 +151,7 @@ export namespace ResourceInUseException {
  * <p>The caller has no permissions to operate on the resource involved in the API call.</p>
  */
 export interface UnauthorizedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UnauthorizedException";
   $fault: "client";
@@ -161,7 +160,7 @@ export interface UnauthorizedException
 
 export namespace UnauthorizedException {
   export function isa(o: any): o is UnauthorizedException {
-    return _smithy.isa(o, "UnauthorizedException");
+    return __isa(o, "UnauthorizedException");
   }
 }
 
@@ -209,7 +208,7 @@ export interface ConferenceProvider {
 
 export namespace ConferenceProvider {
   export function isa(o: any): o is ConferenceProvider {
-    return _smithy.isa(o, "ConferenceProvider");
+    return __isa(o, "ConferenceProvider");
   }
 }
 
@@ -244,7 +243,7 @@ export interface IPDialIn {
 
 export namespace IPDialIn {
   export function isa(o: any): o is IPDialIn {
-    return _smithy.isa(o, "IPDialIn");
+    return __isa(o, "IPDialIn");
   }
 }
 
@@ -274,7 +273,7 @@ export interface MeetingSetting {
 
 export namespace MeetingSetting {
   export function isa(o: any): o is MeetingSetting {
-    return _smithy.isa(o, "MeetingSetting");
+    return __isa(o, "MeetingSetting");
   }
 }
 
@@ -306,7 +305,7 @@ export interface PSTNDialIn {
 
 export namespace PSTNDialIn {
   export function isa(o: any): o is PSTNDialIn {
-    return _smithy.isa(o, "PSTNDialIn");
+    return __isa(o, "PSTNDialIn");
   }
 }
 
@@ -344,7 +343,7 @@ export interface Audio {
 
 export namespace Audio {
   export function isa(o: any): o is Audio {
-    return _smithy.isa(o, "Audio");
+    return __isa(o, "Audio");
   }
 }
 
@@ -372,7 +371,7 @@ export interface Content {
 
 export namespace Content {
   export function isa(o: any): o is Content {
-    return _smithy.isa(o, "Content");
+    return __isa(o, "Content");
   }
 }
 
@@ -406,7 +405,7 @@ export interface SendAnnouncementRequest {
 
 export namespace SendAnnouncementRequest {
   export function isa(o: any): o is SendAnnouncementRequest {
-    return _smithy.isa(o, "SendAnnouncementRequest");
+    return __isa(o, "SendAnnouncementRequest");
   }
 }
 
@@ -420,7 +419,7 @@ export interface SendAnnouncementResponse extends $MetadataBearer {
 
 export namespace SendAnnouncementResponse {
   export function isa(o: any): o is SendAnnouncementResponse {
-    return _smithy.isa(o, "SendAnnouncementResponse");
+    return __isa(o, "SendAnnouncementResponse");
   }
 }
 
@@ -442,7 +441,7 @@ export interface Ssml {
 
 export namespace Ssml {
   export function isa(o: any): o is Ssml {
-    return _smithy.isa(o, "Ssml");
+    return __isa(o, "Ssml");
   }
 }
 
@@ -464,7 +463,7 @@ export interface Text {
 
 export namespace Text {
   export function isa(o: any): o is Text {
-    return _smithy.isa(o, "Text");
+    return __isa(o, "Text");
   }
 }
 
@@ -483,7 +482,7 @@ export interface DeleteDeviceUsageDataRequest {
 
 export namespace DeleteDeviceUsageDataRequest {
   export function isa(o: any): o is DeleteDeviceUsageDataRequest {
-    return _smithy.isa(o, "DeleteDeviceUsageDataRequest");
+    return __isa(o, "DeleteDeviceUsageDataRequest");
   }
 }
 
@@ -493,7 +492,7 @@ export interface DeleteDeviceUsageDataResponse extends $MetadataBearer {
 
 export namespace DeleteDeviceUsageDataResponse {
   export function isa(o: any): o is DeleteDeviceUsageDataResponse {
-    return _smithy.isa(o, "DeleteDeviceUsageDataResponse");
+    return __isa(o, "DeleteDeviceUsageDataResponse");
   }
 }
 
@@ -524,7 +523,7 @@ export interface AddressBook {
 
 export namespace AddressBook {
   export function isa(o: any): o is AddressBook {
-    return _smithy.isa(o, "AddressBook");
+    return __isa(o, "AddressBook");
   }
 }
 
@@ -551,7 +550,7 @@ export interface AddressBookData {
 
 export namespace AddressBookData {
   export function isa(o: any): o is AddressBookData {
-    return _smithy.isa(o, "AddressBookData");
+    return __isa(o, "AddressBookData");
   }
 }
 
@@ -565,7 +564,7 @@ export interface ApproveSkillRequest {
 
 export namespace ApproveSkillRequest {
   export function isa(o: any): o is ApproveSkillRequest {
-    return _smithy.isa(o, "ApproveSkillRequest");
+    return __isa(o, "ApproveSkillRequest");
   }
 }
 
@@ -575,7 +574,7 @@ export interface ApproveSkillResponse extends $MetadataBearer {
 
 export namespace ApproveSkillResponse {
   export function isa(o: any): o is ApproveSkillResponse {
-    return _smithy.isa(o, "ApproveSkillResponse");
+    return __isa(o, "ApproveSkillResponse");
   }
 }
 
@@ -594,7 +593,7 @@ export interface AssociateContactWithAddressBookRequest {
 
 export namespace AssociateContactWithAddressBookRequest {
   export function isa(o: any): o is AssociateContactWithAddressBookRequest {
-    return _smithy.isa(o, "AssociateContactWithAddressBookRequest");
+    return __isa(o, "AssociateContactWithAddressBookRequest");
   }
 }
 
@@ -605,7 +604,7 @@ export interface AssociateContactWithAddressBookResponse
 
 export namespace AssociateContactWithAddressBookResponse {
   export function isa(o: any): o is AssociateContactWithAddressBookResponse {
-    return _smithy.isa(o, "AssociateContactWithAddressBookResponse");
+    return __isa(o, "AssociateContactWithAddressBookResponse");
   }
 }
 
@@ -624,7 +623,7 @@ export interface AssociateDeviceWithNetworkProfileRequest {
 
 export namespace AssociateDeviceWithNetworkProfileRequest {
   export function isa(o: any): o is AssociateDeviceWithNetworkProfileRequest {
-    return _smithy.isa(o, "AssociateDeviceWithNetworkProfileRequest");
+    return __isa(o, "AssociateDeviceWithNetworkProfileRequest");
   }
 }
 
@@ -635,7 +634,7 @@ export interface AssociateDeviceWithNetworkProfileResponse
 
 export namespace AssociateDeviceWithNetworkProfileResponse {
   export function isa(o: any): o is AssociateDeviceWithNetworkProfileResponse {
-    return _smithy.isa(o, "AssociateDeviceWithNetworkProfileResponse");
+    return __isa(o, "AssociateDeviceWithNetworkProfileResponse");
   }
 }
 
@@ -654,7 +653,7 @@ export interface AssociateDeviceWithRoomRequest {
 
 export namespace AssociateDeviceWithRoomRequest {
   export function isa(o: any): o is AssociateDeviceWithRoomRequest {
-    return _smithy.isa(o, "AssociateDeviceWithRoomRequest");
+    return __isa(o, "AssociateDeviceWithRoomRequest");
   }
 }
 
@@ -664,7 +663,7 @@ export interface AssociateDeviceWithRoomResponse extends $MetadataBearer {
 
 export namespace AssociateDeviceWithRoomResponse {
   export function isa(o: any): o is AssociateDeviceWithRoomResponse {
-    return _smithy.isa(o, "AssociateDeviceWithRoomResponse");
+    return __isa(o, "AssociateDeviceWithRoomResponse");
   }
 }
 
@@ -683,7 +682,7 @@ export interface AssociateSkillGroupWithRoomRequest {
 
 export namespace AssociateSkillGroupWithRoomRequest {
   export function isa(o: any): o is AssociateSkillGroupWithRoomRequest {
-    return _smithy.isa(o, "AssociateSkillGroupWithRoomRequest");
+    return __isa(o, "AssociateSkillGroupWithRoomRequest");
   }
 }
 
@@ -693,7 +692,7 @@ export interface AssociateSkillGroupWithRoomResponse extends $MetadataBearer {
 
 export namespace AssociateSkillGroupWithRoomResponse {
   export function isa(o: any): o is AssociateSkillGroupWithRoomResponse {
-    return _smithy.isa(o, "AssociateSkillGroupWithRoomResponse");
+    return __isa(o, "AssociateSkillGroupWithRoomResponse");
   }
 }
 
@@ -712,7 +711,7 @@ export interface AssociateSkillWithSkillGroupRequest {
 
 export namespace AssociateSkillWithSkillGroupRequest {
   export function isa(o: any): o is AssociateSkillWithSkillGroupRequest {
-    return _smithy.isa(o, "AssociateSkillWithSkillGroupRequest");
+    return __isa(o, "AssociateSkillWithSkillGroupRequest");
   }
 }
 
@@ -722,7 +721,7 @@ export interface AssociateSkillWithSkillGroupResponse extends $MetadataBearer {
 
 export namespace AssociateSkillWithSkillGroupResponse {
   export function isa(o: any): o is AssociateSkillWithSkillGroupResponse {
-    return _smithy.isa(o, "AssociateSkillWithSkillGroupResponse");
+    return __isa(o, "AssociateSkillWithSkillGroupResponse");
   }
 }
 
@@ -736,7 +735,7 @@ export interface AssociateSkillWithUsersRequest {
 
 export namespace AssociateSkillWithUsersRequest {
   export function isa(o: any): o is AssociateSkillWithUsersRequest {
-    return _smithy.isa(o, "AssociateSkillWithUsersRequest");
+    return __isa(o, "AssociateSkillWithUsersRequest");
   }
 }
 
@@ -746,7 +745,7 @@ export interface AssociateSkillWithUsersResponse extends $MetadataBearer {
 
 export namespace AssociateSkillWithUsersResponse {
   export function isa(o: any): o is AssociateSkillWithUsersResponse {
-    return _smithy.isa(o, "AssociateSkillWithUsersResponse");
+    return __isa(o, "AssociateSkillWithUsersResponse");
   }
 }
 
@@ -784,7 +783,7 @@ export interface BusinessReport {
 
 export namespace BusinessReport {
   export function isa(o: any): o is BusinessReport {
-    return _smithy.isa(o, "BusinessReport");
+    return __isa(o, "BusinessReport");
   }
 }
 
@@ -801,7 +800,7 @@ export interface BusinessReportContentRange {
 
 export namespace BusinessReportContentRange {
   export function isa(o: any): o is BusinessReportContentRange {
-    return _smithy.isa(o, "BusinessReportContentRange");
+    return __isa(o, "BusinessReportContentRange");
   }
 }
 
@@ -835,7 +834,7 @@ export interface BusinessReportRecurrence {
 
 export namespace BusinessReportRecurrence {
   export function isa(o: any): o is BusinessReportRecurrence {
-    return _smithy.isa(o, "BusinessReportRecurrence");
+    return __isa(o, "BusinessReportRecurrence");
   }
 }
 
@@ -857,7 +856,7 @@ export interface BusinessReportS3Location {
 
 export namespace BusinessReportS3Location {
   export function isa(o: any): o is BusinessReportS3Location {
-    return _smithy.isa(o, "BusinessReportS3Location");
+    return __isa(o, "BusinessReportS3Location");
   }
 }
 
@@ -911,7 +910,7 @@ export interface BusinessReportSchedule {
 
 export namespace BusinessReportSchedule {
   export function isa(o: any): o is BusinessReportSchedule {
-    return _smithy.isa(o, "BusinessReportSchedule");
+    return __isa(o, "BusinessReportSchedule");
   }
 }
 
@@ -940,7 +939,7 @@ export interface Category {
 
 export namespace Category {
   export function isa(o: any): o is Category {
-    return _smithy.isa(o, "Category");
+    return __isa(o, "Category");
   }
 }
 
@@ -958,7 +957,7 @@ export interface ConferencePreference {
 
 export namespace ConferencePreference {
   export function isa(o: any): o is ConferencePreference {
-    return _smithy.isa(o, "ConferencePreference");
+    return __isa(o, "ConferencePreference");
   }
 }
 
@@ -1012,7 +1011,7 @@ export interface Contact {
 
 export namespace Contact {
   export function isa(o: any): o is Contact {
-    return _smithy.isa(o, "Contact");
+    return __isa(o, "Contact");
   }
 }
 
@@ -1061,7 +1060,7 @@ export interface ContactData {
 
 export namespace ContactData {
   export function isa(o: any): o is ContactData {
-    return _smithy.isa(o, "ContactData");
+    return __isa(o, "ContactData");
   }
 }
 
@@ -1086,7 +1085,7 @@ export interface CreateAddressBookRequest {
 
 export namespace CreateAddressBookRequest {
   export function isa(o: any): o is CreateAddressBookRequest {
-    return _smithy.isa(o, "CreateAddressBookRequest");
+    return __isa(o, "CreateAddressBookRequest");
   }
 }
 
@@ -1100,7 +1099,7 @@ export interface CreateAddressBookResponse extends $MetadataBearer {
 
 export namespace CreateAddressBookResponse {
   export function isa(o: any): o is CreateAddressBookResponse {
-    return _smithy.isa(o, "CreateAddressBookResponse");
+    return __isa(o, "CreateAddressBookResponse");
   }
 }
 
@@ -1147,7 +1146,7 @@ export interface CreateBusinessReportScheduleRequest {
 
 export namespace CreateBusinessReportScheduleRequest {
   export function isa(o: any): o is CreateBusinessReportScheduleRequest {
-    return _smithy.isa(o, "CreateBusinessReportScheduleRequest");
+    return __isa(o, "CreateBusinessReportScheduleRequest");
   }
 }
 
@@ -1161,7 +1160,7 @@ export interface CreateBusinessReportScheduleResponse extends $MetadataBearer {
 
 export namespace CreateBusinessReportScheduleResponse {
   export function isa(o: any): o is CreateBusinessReportScheduleResponse {
-    return _smithy.isa(o, "CreateBusinessReportScheduleResponse");
+    return __isa(o, "CreateBusinessReportScheduleResponse");
   }
 }
 
@@ -1200,7 +1199,7 @@ export interface CreateConferenceProviderRequest {
 
 export namespace CreateConferenceProviderRequest {
   export function isa(o: any): o is CreateConferenceProviderRequest {
-    return _smithy.isa(o, "CreateConferenceProviderRequest");
+    return __isa(o, "CreateConferenceProviderRequest");
   }
 }
 
@@ -1214,7 +1213,7 @@ export interface CreateConferenceProviderResponse extends $MetadataBearer {
 
 export namespace CreateConferenceProviderResponse {
   export function isa(o: any): o is CreateConferenceProviderResponse {
-    return _smithy.isa(o, "CreateConferenceProviderResponse");
+    return __isa(o, "CreateConferenceProviderResponse");
   }
 }
 
@@ -1263,7 +1262,7 @@ export interface CreateContactRequest {
 
 export namespace CreateContactRequest {
   export function isa(o: any): o is CreateContactRequest {
-    return _smithy.isa(o, "CreateContactRequest");
+    return __isa(o, "CreateContactRequest");
   }
 }
 
@@ -1277,7 +1276,7 @@ export interface CreateContactResponse extends $MetadataBearer {
 
 export namespace CreateContactResponse {
   export function isa(o: any): o is CreateContactResponse {
-    return _smithy.isa(o, "CreateContactResponse");
+    return __isa(o, "CreateContactResponse");
   }
 }
 
@@ -1306,7 +1305,7 @@ export interface CreateEndOfMeetingReminder {
 
 export namespace CreateEndOfMeetingReminder {
   export function isa(o: any): o is CreateEndOfMeetingReminder {
-    return _smithy.isa(o, "CreateEndOfMeetingReminder");
+    return __isa(o, "CreateEndOfMeetingReminder");
   }
 }
 
@@ -1330,7 +1329,7 @@ export interface CreateGatewayGroupRequest {
 
 export namespace CreateGatewayGroupRequest {
   export function isa(o: any): o is CreateGatewayGroupRequest {
-    return _smithy.isa(o, "CreateGatewayGroupRequest");
+    return __isa(o, "CreateGatewayGroupRequest");
   }
 }
 
@@ -1344,7 +1343,7 @@ export interface CreateGatewayGroupResponse extends $MetadataBearer {
 
 export namespace CreateGatewayGroupResponse {
   export function isa(o: any): o is CreateGatewayGroupResponse {
-    return _smithy.isa(o, "CreateGatewayGroupResponse");
+    return __isa(o, "CreateGatewayGroupResponse");
   }
 }
 
@@ -1369,7 +1368,7 @@ export interface CreateInstantBooking {
 
 export namespace CreateInstantBooking {
   export function isa(o: any): o is CreateInstantBooking {
-    return _smithy.isa(o, "CreateInstantBooking");
+    return __isa(o, "CreateInstantBooking");
   }
 }
 
@@ -1403,7 +1402,7 @@ export interface CreateMeetingRoomConfiguration {
 
 export namespace CreateMeetingRoomConfiguration {
   export function isa(o: any): o is CreateMeetingRoomConfiguration {
-    return _smithy.isa(o, "CreateMeetingRoomConfiguration");
+    return __isa(o, "CreateMeetingRoomConfiguration");
   }
 }
 
@@ -1468,7 +1467,7 @@ export interface CreateNetworkProfileRequest {
 
 export namespace CreateNetworkProfileRequest {
   export function isa(o: any): o is CreateNetworkProfileRequest {
-    return _smithy.isa(o, "CreateNetworkProfileRequest");
+    return __isa(o, "CreateNetworkProfileRequest");
   }
 }
 
@@ -1482,7 +1481,7 @@ export interface CreateNetworkProfileResponse extends $MetadataBearer {
 
 export namespace CreateNetworkProfileResponse {
   export function isa(o: any): o is CreateNetworkProfileResponse {
-    return _smithy.isa(o, "CreateNetworkProfileResponse");
+    return __isa(o, "CreateNetworkProfileResponse");
   }
 }
 
@@ -1551,7 +1550,7 @@ export interface CreateProfileRequest {
 
 export namespace CreateProfileRequest {
   export function isa(o: any): o is CreateProfileRequest {
-    return _smithy.isa(o, "CreateProfileRequest");
+    return __isa(o, "CreateProfileRequest");
   }
 }
 
@@ -1565,7 +1564,7 @@ export interface CreateProfileResponse extends $MetadataBearer {
 
 export namespace CreateProfileResponse {
   export function isa(o: any): o is CreateProfileResponse {
-    return _smithy.isa(o, "CreateProfileResponse");
+    return __isa(o, "CreateProfileResponse");
   }
 }
 
@@ -1587,7 +1586,7 @@ export interface CreateRequireCheckIn {
 
 export namespace CreateRequireCheckIn {
   export function isa(o: any): o is CreateRequireCheckIn {
-    return _smithy.isa(o, "CreateRequireCheckIn");
+    return __isa(o, "CreateRequireCheckIn");
   }
 }
 
@@ -1627,7 +1626,7 @@ export interface CreateRoomRequest {
 
 export namespace CreateRoomRequest {
   export function isa(o: any): o is CreateRoomRequest {
-    return _smithy.isa(o, "CreateRoomRequest");
+    return __isa(o, "CreateRoomRequest");
   }
 }
 
@@ -1641,7 +1640,7 @@ export interface CreateRoomResponse extends $MetadataBearer {
 
 export namespace CreateRoomResponse {
   export function isa(o: any): o is CreateRoomResponse {
-    return _smithy.isa(o, "CreateRoomResponse");
+    return __isa(o, "CreateRoomResponse");
   }
 }
 
@@ -1666,7 +1665,7 @@ export interface CreateSkillGroupRequest {
 
 export namespace CreateSkillGroupRequest {
   export function isa(o: any): o is CreateSkillGroupRequest {
-    return _smithy.isa(o, "CreateSkillGroupRequest");
+    return __isa(o, "CreateSkillGroupRequest");
   }
 }
 
@@ -1680,7 +1679,7 @@ export interface CreateSkillGroupResponse extends $MetadataBearer {
 
 export namespace CreateSkillGroupResponse {
   export function isa(o: any): o is CreateSkillGroupResponse {
-    return _smithy.isa(o, "CreateSkillGroupResponse");
+    return __isa(o, "CreateSkillGroupResponse");
   }
 }
 
@@ -1720,7 +1719,7 @@ export interface CreateUserRequest {
 
 export namespace CreateUserRequest {
   export function isa(o: any): o is CreateUserRequest {
-    return _smithy.isa(o, "CreateUserRequest");
+    return __isa(o, "CreateUserRequest");
   }
 }
 
@@ -1734,7 +1733,7 @@ export interface CreateUserResponse extends $MetadataBearer {
 
 export namespace CreateUserResponse {
   export function isa(o: any): o is CreateUserResponse {
-    return _smithy.isa(o, "CreateUserResponse");
+    return __isa(o, "CreateUserResponse");
   }
 }
 
@@ -1748,7 +1747,7 @@ export interface DeleteAddressBookRequest {
 
 export namespace DeleteAddressBookRequest {
   export function isa(o: any): o is DeleteAddressBookRequest {
-    return _smithy.isa(o, "DeleteAddressBookRequest");
+    return __isa(o, "DeleteAddressBookRequest");
   }
 }
 
@@ -1758,7 +1757,7 @@ export interface DeleteAddressBookResponse extends $MetadataBearer {
 
 export namespace DeleteAddressBookResponse {
   export function isa(o: any): o is DeleteAddressBookResponse {
-    return _smithy.isa(o, "DeleteAddressBookResponse");
+    return __isa(o, "DeleteAddressBookResponse");
   }
 }
 
@@ -1772,7 +1771,7 @@ export interface DeleteBusinessReportScheduleRequest {
 
 export namespace DeleteBusinessReportScheduleRequest {
   export function isa(o: any): o is DeleteBusinessReportScheduleRequest {
-    return _smithy.isa(o, "DeleteBusinessReportScheduleRequest");
+    return __isa(o, "DeleteBusinessReportScheduleRequest");
   }
 }
 
@@ -1782,7 +1781,7 @@ export interface DeleteBusinessReportScheduleResponse extends $MetadataBearer {
 
 export namespace DeleteBusinessReportScheduleResponse {
   export function isa(o: any): o is DeleteBusinessReportScheduleResponse {
-    return _smithy.isa(o, "DeleteBusinessReportScheduleResponse");
+    return __isa(o, "DeleteBusinessReportScheduleResponse");
   }
 }
 
@@ -1796,7 +1795,7 @@ export interface DeleteConferenceProviderRequest {
 
 export namespace DeleteConferenceProviderRequest {
   export function isa(o: any): o is DeleteConferenceProviderRequest {
-    return _smithy.isa(o, "DeleteConferenceProviderRequest");
+    return __isa(o, "DeleteConferenceProviderRequest");
   }
 }
 
@@ -1806,7 +1805,7 @@ export interface DeleteConferenceProviderResponse extends $MetadataBearer {
 
 export namespace DeleteConferenceProviderResponse {
   export function isa(o: any): o is DeleteConferenceProviderResponse {
-    return _smithy.isa(o, "DeleteConferenceProviderResponse");
+    return __isa(o, "DeleteConferenceProviderResponse");
   }
 }
 
@@ -1820,7 +1819,7 @@ export interface DeleteContactRequest {
 
 export namespace DeleteContactRequest {
   export function isa(o: any): o is DeleteContactRequest {
-    return _smithy.isa(o, "DeleteContactRequest");
+    return __isa(o, "DeleteContactRequest");
   }
 }
 
@@ -1830,7 +1829,7 @@ export interface DeleteContactResponse extends $MetadataBearer {
 
 export namespace DeleteContactResponse {
   export function isa(o: any): o is DeleteContactResponse {
-    return _smithy.isa(o, "DeleteContactResponse");
+    return __isa(o, "DeleteContactResponse");
   }
 }
 
@@ -1844,7 +1843,7 @@ export interface DeleteDeviceRequest {
 
 export namespace DeleteDeviceRequest {
   export function isa(o: any): o is DeleteDeviceRequest {
-    return _smithy.isa(o, "DeleteDeviceRequest");
+    return __isa(o, "DeleteDeviceRequest");
   }
 }
 
@@ -1854,7 +1853,7 @@ export interface DeleteDeviceResponse extends $MetadataBearer {
 
 export namespace DeleteDeviceResponse {
   export function isa(o: any): o is DeleteDeviceResponse {
-    return _smithy.isa(o, "DeleteDeviceResponse");
+    return __isa(o, "DeleteDeviceResponse");
   }
 }
 
@@ -1868,7 +1867,7 @@ export interface DeleteGatewayGroupRequest {
 
 export namespace DeleteGatewayGroupRequest {
   export function isa(o: any): o is DeleteGatewayGroupRequest {
-    return _smithy.isa(o, "DeleteGatewayGroupRequest");
+    return __isa(o, "DeleteGatewayGroupRequest");
   }
 }
 
@@ -1878,7 +1877,7 @@ export interface DeleteGatewayGroupResponse extends $MetadataBearer {
 
 export namespace DeleteGatewayGroupResponse {
   export function isa(o: any): o is DeleteGatewayGroupResponse {
-    return _smithy.isa(o, "DeleteGatewayGroupResponse");
+    return __isa(o, "DeleteGatewayGroupResponse");
   }
 }
 
@@ -1892,7 +1891,7 @@ export interface DeleteNetworkProfileRequest {
 
 export namespace DeleteNetworkProfileRequest {
   export function isa(o: any): o is DeleteNetworkProfileRequest {
-    return _smithy.isa(o, "DeleteNetworkProfileRequest");
+    return __isa(o, "DeleteNetworkProfileRequest");
   }
 }
 
@@ -1902,7 +1901,7 @@ export interface DeleteNetworkProfileResponse extends $MetadataBearer {
 
 export namespace DeleteNetworkProfileResponse {
   export function isa(o: any): o is DeleteNetworkProfileResponse {
-    return _smithy.isa(o, "DeleteNetworkProfileResponse");
+    return __isa(o, "DeleteNetworkProfileResponse");
   }
 }
 
@@ -1916,7 +1915,7 @@ export interface DeleteProfileRequest {
 
 export namespace DeleteProfileRequest {
   export function isa(o: any): o is DeleteProfileRequest {
-    return _smithy.isa(o, "DeleteProfileRequest");
+    return __isa(o, "DeleteProfileRequest");
   }
 }
 
@@ -1926,7 +1925,7 @@ export interface DeleteProfileResponse extends $MetadataBearer {
 
 export namespace DeleteProfileResponse {
   export function isa(o: any): o is DeleteProfileResponse {
-    return _smithy.isa(o, "DeleteProfileResponse");
+    return __isa(o, "DeleteProfileResponse");
   }
 }
 
@@ -1940,7 +1939,7 @@ export interface DeleteRoomRequest {
 
 export namespace DeleteRoomRequest {
   export function isa(o: any): o is DeleteRoomRequest {
-    return _smithy.isa(o, "DeleteRoomRequest");
+    return __isa(o, "DeleteRoomRequest");
   }
 }
 
@@ -1950,7 +1949,7 @@ export interface DeleteRoomResponse extends $MetadataBearer {
 
 export namespace DeleteRoomResponse {
   export function isa(o: any): o is DeleteRoomResponse {
-    return _smithy.isa(o, "DeleteRoomResponse");
+    return __isa(o, "DeleteRoomResponse");
   }
 }
 
@@ -1974,7 +1973,7 @@ export interface DeleteRoomSkillParameterRequest {
 
 export namespace DeleteRoomSkillParameterRequest {
   export function isa(o: any): o is DeleteRoomSkillParameterRequest {
-    return _smithy.isa(o, "DeleteRoomSkillParameterRequest");
+    return __isa(o, "DeleteRoomSkillParameterRequest");
   }
 }
 
@@ -1984,7 +1983,7 @@ export interface DeleteRoomSkillParameterResponse extends $MetadataBearer {
 
 export namespace DeleteRoomSkillParameterResponse {
   export function isa(o: any): o is DeleteRoomSkillParameterResponse {
-    return _smithy.isa(o, "DeleteRoomSkillParameterResponse");
+    return __isa(o, "DeleteRoomSkillParameterResponse");
   }
 }
 
@@ -2003,7 +2002,7 @@ export interface DeleteSkillAuthorizationRequest {
 
 export namespace DeleteSkillAuthorizationRequest {
   export function isa(o: any): o is DeleteSkillAuthorizationRequest {
-    return _smithy.isa(o, "DeleteSkillAuthorizationRequest");
+    return __isa(o, "DeleteSkillAuthorizationRequest");
   }
 }
 
@@ -2013,7 +2012,7 @@ export interface DeleteSkillAuthorizationResponse extends $MetadataBearer {
 
 export namespace DeleteSkillAuthorizationResponse {
   export function isa(o: any): o is DeleteSkillAuthorizationResponse {
-    return _smithy.isa(o, "DeleteSkillAuthorizationResponse");
+    return __isa(o, "DeleteSkillAuthorizationResponse");
   }
 }
 
@@ -2027,7 +2026,7 @@ export interface DeleteSkillGroupRequest {
 
 export namespace DeleteSkillGroupRequest {
   export function isa(o: any): o is DeleteSkillGroupRequest {
-    return _smithy.isa(o, "DeleteSkillGroupRequest");
+    return __isa(o, "DeleteSkillGroupRequest");
   }
 }
 
@@ -2037,7 +2036,7 @@ export interface DeleteSkillGroupResponse extends $MetadataBearer {
 
 export namespace DeleteSkillGroupResponse {
   export function isa(o: any): o is DeleteSkillGroupResponse {
-    return _smithy.isa(o, "DeleteSkillGroupResponse");
+    return __isa(o, "DeleteSkillGroupResponse");
   }
 }
 
@@ -2056,7 +2055,7 @@ export interface DeleteUserRequest {
 
 export namespace DeleteUserRequest {
   export function isa(o: any): o is DeleteUserRequest {
-    return _smithy.isa(o, "DeleteUserRequest");
+    return __isa(o, "DeleteUserRequest");
   }
 }
 
@@ -2066,7 +2065,7 @@ export interface DeleteUserResponse extends $MetadataBearer {
 
 export namespace DeleteUserResponse {
   export function isa(o: any): o is DeleteUserResponse {
-    return _smithy.isa(o, "DeleteUserResponse");
+    return __isa(o, "DeleteUserResponse");
   }
 }
 
@@ -2098,7 +2097,7 @@ export interface DeveloperInfo {
 
 export namespace DeveloperInfo {
   export function isa(o: any): o is DeveloperInfo {
-    return _smithy.isa(o, "DeveloperInfo");
+    return __isa(o, "DeveloperInfo");
   }
 }
 
@@ -2161,7 +2160,7 @@ export interface Device {
 
 export namespace Device {
   export function isa(o: any): o is Device {
-    return _smithy.isa(o, "Device");
+    return __isa(o, "Device");
   }
 }
 
@@ -2238,7 +2237,7 @@ export interface DeviceData {
 
 export namespace DeviceData {
   export function isa(o: any): o is DeviceData {
-    return _smithy.isa(o, "DeviceData");
+    return __isa(o, "DeviceData");
   }
 }
 
@@ -2265,7 +2264,7 @@ export interface DeviceEvent {
 
 export namespace DeviceEvent {
   export function isa(o: any): o is DeviceEvent {
-    return _smithy.isa(o, "DeviceEvent");
+    return __isa(o, "DeviceEvent");
   }
 }
 
@@ -2297,7 +2296,7 @@ export interface DeviceNetworkProfileInfo {
 
 export namespace DeviceNetworkProfileInfo {
   export function isa(o: any): o is DeviceNetworkProfileInfo {
-    return _smithy.isa(o, "DeviceNetworkProfileInfo");
+    return __isa(o, "DeviceNetworkProfileInfo");
   }
 }
 
@@ -2327,7 +2326,7 @@ export interface DeviceStatusDetail {
 
 export namespace DeviceStatusDetail {
   export function isa(o: any): o is DeviceStatusDetail {
-    return _smithy.isa(o, "DeviceStatusDetail");
+    return __isa(o, "DeviceStatusDetail");
   }
 }
 
@@ -2372,7 +2371,7 @@ export interface DeviceStatusInfo {
 
 export namespace DeviceStatusInfo {
   export function isa(o: any): o is DeviceStatusInfo {
-    return _smithy.isa(o, "DeviceStatusInfo");
+    return __isa(o, "DeviceStatusInfo");
   }
 }
 
@@ -2391,7 +2390,7 @@ export interface DisassociateContactFromAddressBookRequest {
 
 export namespace DisassociateContactFromAddressBookRequest {
   export function isa(o: any): o is DisassociateContactFromAddressBookRequest {
-    return _smithy.isa(o, "DisassociateContactFromAddressBookRequest");
+    return __isa(o, "DisassociateContactFromAddressBookRequest");
   }
 }
 
@@ -2402,7 +2401,7 @@ export interface DisassociateContactFromAddressBookResponse
 
 export namespace DisassociateContactFromAddressBookResponse {
   export function isa(o: any): o is DisassociateContactFromAddressBookResponse {
-    return _smithy.isa(o, "DisassociateContactFromAddressBookResponse");
+    return __isa(o, "DisassociateContactFromAddressBookResponse");
   }
 }
 
@@ -2416,7 +2415,7 @@ export interface DisassociateDeviceFromRoomRequest {
 
 export namespace DisassociateDeviceFromRoomRequest {
   export function isa(o: any): o is DisassociateDeviceFromRoomRequest {
-    return _smithy.isa(o, "DisassociateDeviceFromRoomRequest");
+    return __isa(o, "DisassociateDeviceFromRoomRequest");
   }
 }
 
@@ -2426,7 +2425,7 @@ export interface DisassociateDeviceFromRoomResponse extends $MetadataBearer {
 
 export namespace DisassociateDeviceFromRoomResponse {
   export function isa(o: any): o is DisassociateDeviceFromRoomResponse {
-    return _smithy.isa(o, "DisassociateDeviceFromRoomResponse");
+    return __isa(o, "DisassociateDeviceFromRoomResponse");
   }
 }
 
@@ -2445,7 +2444,7 @@ export interface DisassociateSkillFromSkillGroupRequest {
 
 export namespace DisassociateSkillFromSkillGroupRequest {
   export function isa(o: any): o is DisassociateSkillFromSkillGroupRequest {
-    return _smithy.isa(o, "DisassociateSkillFromSkillGroupRequest");
+    return __isa(o, "DisassociateSkillFromSkillGroupRequest");
   }
 }
 
@@ -2456,7 +2455,7 @@ export interface DisassociateSkillFromSkillGroupResponse
 
 export namespace DisassociateSkillFromSkillGroupResponse {
   export function isa(o: any): o is DisassociateSkillFromSkillGroupResponse {
-    return _smithy.isa(o, "DisassociateSkillFromSkillGroupResponse");
+    return __isa(o, "DisassociateSkillFromSkillGroupResponse");
   }
 }
 
@@ -2470,7 +2469,7 @@ export interface DisassociateSkillFromUsersRequest {
 
 export namespace DisassociateSkillFromUsersRequest {
   export function isa(o: any): o is DisassociateSkillFromUsersRequest {
-    return _smithy.isa(o, "DisassociateSkillFromUsersRequest");
+    return __isa(o, "DisassociateSkillFromUsersRequest");
   }
 }
 
@@ -2480,7 +2479,7 @@ export interface DisassociateSkillFromUsersResponse extends $MetadataBearer {
 
 export namespace DisassociateSkillFromUsersResponse {
   export function isa(o: any): o is DisassociateSkillFromUsersResponse {
-    return _smithy.isa(o, "DisassociateSkillFromUsersResponse");
+    return __isa(o, "DisassociateSkillFromUsersResponse");
   }
 }
 
@@ -2500,7 +2499,7 @@ export interface DisassociateSkillGroupFromRoomRequest {
 
 export namespace DisassociateSkillGroupFromRoomRequest {
   export function isa(o: any): o is DisassociateSkillGroupFromRoomRequest {
-    return _smithy.isa(o, "DisassociateSkillGroupFromRoomRequest");
+    return __isa(o, "DisassociateSkillGroupFromRoomRequest");
   }
 }
 
@@ -2511,7 +2510,7 @@ export interface DisassociateSkillGroupFromRoomResponse
 
 export namespace DisassociateSkillGroupFromRoomResponse {
   export function isa(o: any): o is DisassociateSkillGroupFromRoomResponse {
-    return _smithy.isa(o, "DisassociateSkillGroupFromRoomResponse");
+    return __isa(o, "DisassociateSkillGroupFromRoomResponse");
   }
 }
 
@@ -2554,7 +2553,7 @@ export interface EndOfMeetingReminder {
 
 export namespace EndOfMeetingReminder {
   export function isa(o: any): o is EndOfMeetingReminder {
-    return _smithy.isa(o, "EndOfMeetingReminder");
+    return __isa(o, "EndOfMeetingReminder");
   }
 }
 
@@ -2594,7 +2593,7 @@ export interface ForgetSmartHomeAppliancesRequest {
 
 export namespace ForgetSmartHomeAppliancesRequest {
   export function isa(o: any): o is ForgetSmartHomeAppliancesRequest {
-    return _smithy.isa(o, "ForgetSmartHomeAppliancesRequest");
+    return __isa(o, "ForgetSmartHomeAppliancesRequest");
   }
 }
 
@@ -2604,7 +2603,7 @@ export interface ForgetSmartHomeAppliancesResponse extends $MetadataBearer {
 
 export namespace ForgetSmartHomeAppliancesResponse {
   export function isa(o: any): o is ForgetSmartHomeAppliancesResponse {
-    return _smithy.isa(o, "ForgetSmartHomeAppliancesResponse");
+    return __isa(o, "ForgetSmartHomeAppliancesResponse");
   }
 }
 
@@ -2642,7 +2641,7 @@ export interface Gateway {
 
 export namespace Gateway {
   export function isa(o: any): o is Gateway {
-    return _smithy.isa(o, "Gateway");
+    return __isa(o, "Gateway");
   }
 }
 
@@ -2669,7 +2668,7 @@ export interface GatewayGroup {
 
 export namespace GatewayGroup {
   export function isa(o: any): o is GatewayGroup {
-    return _smithy.isa(o, "GatewayGroup");
+    return __isa(o, "GatewayGroup");
   }
 }
 
@@ -2696,7 +2695,7 @@ export interface GatewayGroupSummary {
 
 export namespace GatewayGroupSummary {
   export function isa(o: any): o is GatewayGroupSummary {
-    return _smithy.isa(o, "GatewayGroupSummary");
+    return __isa(o, "GatewayGroupSummary");
   }
 }
 
@@ -2734,7 +2733,7 @@ export interface GatewaySummary {
 
 export namespace GatewaySummary {
   export function isa(o: any): o is GatewaySummary {
-    return _smithy.isa(o, "GatewaySummary");
+    return __isa(o, "GatewaySummary");
   }
 }
 
@@ -2748,7 +2747,7 @@ export interface GetAddressBookRequest {
 
 export namespace GetAddressBookRequest {
   export function isa(o: any): o is GetAddressBookRequest {
-    return _smithy.isa(o, "GetAddressBookRequest");
+    return __isa(o, "GetAddressBookRequest");
   }
 }
 
@@ -2762,7 +2761,7 @@ export interface GetAddressBookResponse extends $MetadataBearer {
 
 export namespace GetAddressBookResponse {
   export function isa(o: any): o is GetAddressBookResponse {
-    return _smithy.isa(o, "GetAddressBookResponse");
+    return __isa(o, "GetAddressBookResponse");
   }
 }
 
@@ -2772,7 +2771,7 @@ export interface GetConferencePreferenceRequest {
 
 export namespace GetConferencePreferenceRequest {
   export function isa(o: any): o is GetConferencePreferenceRequest {
-    return _smithy.isa(o, "GetConferencePreferenceRequest");
+    return __isa(o, "GetConferencePreferenceRequest");
   }
 }
 
@@ -2786,7 +2785,7 @@ export interface GetConferencePreferenceResponse extends $MetadataBearer {
 
 export namespace GetConferencePreferenceResponse {
   export function isa(o: any): o is GetConferencePreferenceResponse {
-    return _smithy.isa(o, "GetConferencePreferenceResponse");
+    return __isa(o, "GetConferencePreferenceResponse");
   }
 }
 
@@ -2800,7 +2799,7 @@ export interface GetConferenceProviderRequest {
 
 export namespace GetConferenceProviderRequest {
   export function isa(o: any): o is GetConferenceProviderRequest {
-    return _smithy.isa(o, "GetConferenceProviderRequest");
+    return __isa(o, "GetConferenceProviderRequest");
   }
 }
 
@@ -2814,7 +2813,7 @@ export interface GetConferenceProviderResponse extends $MetadataBearer {
 
 export namespace GetConferenceProviderResponse {
   export function isa(o: any): o is GetConferenceProviderResponse {
-    return _smithy.isa(o, "GetConferenceProviderResponse");
+    return __isa(o, "GetConferenceProviderResponse");
   }
 }
 
@@ -2828,7 +2827,7 @@ export interface GetContactRequest {
 
 export namespace GetContactRequest {
   export function isa(o: any): o is GetContactRequest {
-    return _smithy.isa(o, "GetContactRequest");
+    return __isa(o, "GetContactRequest");
   }
 }
 
@@ -2842,7 +2841,7 @@ export interface GetContactResponse extends $MetadataBearer {
 
 export namespace GetContactResponse {
   export function isa(o: any): o is GetContactResponse {
-    return _smithy.isa(o, "GetContactResponse");
+    return __isa(o, "GetContactResponse");
   }
 }
 
@@ -2856,7 +2855,7 @@ export interface GetDeviceRequest {
 
 export namespace GetDeviceRequest {
   export function isa(o: any): o is GetDeviceRequest {
-    return _smithy.isa(o, "GetDeviceRequest");
+    return __isa(o, "GetDeviceRequest");
   }
 }
 
@@ -2870,7 +2869,7 @@ export interface GetDeviceResponse extends $MetadataBearer {
 
 export namespace GetDeviceResponse {
   export function isa(o: any): o is GetDeviceResponse {
-    return _smithy.isa(o, "GetDeviceResponse");
+    return __isa(o, "GetDeviceResponse");
   }
 }
 
@@ -2884,7 +2883,7 @@ export interface GetGatewayGroupRequest {
 
 export namespace GetGatewayGroupRequest {
   export function isa(o: any): o is GetGatewayGroupRequest {
-    return _smithy.isa(o, "GetGatewayGroupRequest");
+    return __isa(o, "GetGatewayGroupRequest");
   }
 }
 
@@ -2898,7 +2897,7 @@ export interface GetGatewayGroupResponse extends $MetadataBearer {
 
 export namespace GetGatewayGroupResponse {
   export function isa(o: any): o is GetGatewayGroupResponse {
-    return _smithy.isa(o, "GetGatewayGroupResponse");
+    return __isa(o, "GetGatewayGroupResponse");
   }
 }
 
@@ -2912,7 +2911,7 @@ export interface GetGatewayRequest {
 
 export namespace GetGatewayRequest {
   export function isa(o: any): o is GetGatewayRequest {
-    return _smithy.isa(o, "GetGatewayRequest");
+    return __isa(o, "GetGatewayRequest");
   }
 }
 
@@ -2926,7 +2925,7 @@ export interface GetGatewayResponse extends $MetadataBearer {
 
 export namespace GetGatewayResponse {
   export function isa(o: any): o is GetGatewayResponse {
-    return _smithy.isa(o, "GetGatewayResponse");
+    return __isa(o, "GetGatewayResponse");
   }
 }
 
@@ -2936,7 +2935,7 @@ export interface GetInvitationConfigurationRequest {
 
 export namespace GetInvitationConfigurationRequest {
   export function isa(o: any): o is GetInvitationConfigurationRequest {
-    return _smithy.isa(o, "GetInvitationConfigurationRequest");
+    return __isa(o, "GetInvitationConfigurationRequest");
   }
 }
 
@@ -2962,7 +2961,7 @@ export interface GetInvitationConfigurationResponse extends $MetadataBearer {
 
 export namespace GetInvitationConfigurationResponse {
   export function isa(o: any): o is GetInvitationConfigurationResponse {
-    return _smithy.isa(o, "GetInvitationConfigurationResponse");
+    return __isa(o, "GetInvitationConfigurationResponse");
   }
 }
 
@@ -2976,7 +2975,7 @@ export interface GetNetworkProfileRequest {
 
 export namespace GetNetworkProfileRequest {
   export function isa(o: any): o is GetNetworkProfileRequest {
-    return _smithy.isa(o, "GetNetworkProfileRequest");
+    return __isa(o, "GetNetworkProfileRequest");
   }
 }
 
@@ -2990,7 +2989,7 @@ export interface GetNetworkProfileResponse extends $MetadataBearer {
 
 export namespace GetNetworkProfileResponse {
   export function isa(o: any): o is GetNetworkProfileResponse {
-    return _smithy.isa(o, "GetNetworkProfileResponse");
+    return __isa(o, "GetNetworkProfileResponse");
   }
 }
 
@@ -3004,7 +3003,7 @@ export interface GetProfileRequest {
 
 export namespace GetProfileRequest {
   export function isa(o: any): o is GetProfileRequest {
-    return _smithy.isa(o, "GetProfileRequest");
+    return __isa(o, "GetProfileRequest");
   }
 }
 
@@ -3018,7 +3017,7 @@ export interface GetProfileResponse extends $MetadataBearer {
 
 export namespace GetProfileResponse {
   export function isa(o: any): o is GetProfileResponse {
-    return _smithy.isa(o, "GetProfileResponse");
+    return __isa(o, "GetProfileResponse");
   }
 }
 
@@ -3032,7 +3031,7 @@ export interface GetRoomRequest {
 
 export namespace GetRoomRequest {
   export function isa(o: any): o is GetRoomRequest {
-    return _smithy.isa(o, "GetRoomRequest");
+    return __isa(o, "GetRoomRequest");
   }
 }
 
@@ -3046,7 +3045,7 @@ export interface GetRoomResponse extends $MetadataBearer {
 
 export namespace GetRoomResponse {
   export function isa(o: any): o is GetRoomResponse {
-    return _smithy.isa(o, "GetRoomResponse");
+    return __isa(o, "GetRoomResponse");
   }
 }
 
@@ -3071,7 +3070,7 @@ export interface GetRoomSkillParameterRequest {
 
 export namespace GetRoomSkillParameterRequest {
   export function isa(o: any): o is GetRoomSkillParameterRequest {
-    return _smithy.isa(o, "GetRoomSkillParameterRequest");
+    return __isa(o, "GetRoomSkillParameterRequest");
   }
 }
 
@@ -3085,7 +3084,7 @@ export interface GetRoomSkillParameterResponse extends $MetadataBearer {
 
 export namespace GetRoomSkillParameterResponse {
   export function isa(o: any): o is GetRoomSkillParameterResponse {
-    return _smithy.isa(o, "GetRoomSkillParameterResponse");
+    return __isa(o, "GetRoomSkillParameterResponse");
   }
 }
 
@@ -3099,7 +3098,7 @@ export interface GetSkillGroupRequest {
 
 export namespace GetSkillGroupRequest {
   export function isa(o: any): o is GetSkillGroupRequest {
-    return _smithy.isa(o, "GetSkillGroupRequest");
+    return __isa(o, "GetSkillGroupRequest");
   }
 }
 
@@ -3113,7 +3112,7 @@ export interface GetSkillGroupResponse extends $MetadataBearer {
 
 export namespace GetSkillGroupResponse {
   export function isa(o: any): o is GetSkillGroupResponse {
-    return _smithy.isa(o, "GetSkillGroupResponse");
+    return __isa(o, "GetSkillGroupResponse");
   }
 }
 
@@ -3138,7 +3137,7 @@ export interface InstantBooking {
 
 export namespace InstantBooking {
   export function isa(o: any): o is InstantBooking {
-    return _smithy.isa(o, "InstantBooking");
+    return __isa(o, "InstantBooking");
   }
 }
 
@@ -3146,7 +3145,7 @@ export namespace InstantBooking {
  * <p>The Certificate Authority can't issue or revoke a certificate.</p>
  */
 export interface InvalidCertificateAuthorityException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidCertificateAuthorityException";
   $fault: "client";
@@ -3155,7 +3154,7 @@ export interface InvalidCertificateAuthorityException
 
 export namespace InvalidCertificateAuthorityException {
   export function isa(o: any): o is InvalidCertificateAuthorityException {
-    return _smithy.isa(o, "InvalidCertificateAuthorityException");
+    return __isa(o, "InvalidCertificateAuthorityException");
   }
 }
 
@@ -3163,7 +3162,7 @@ export namespace InvalidCertificateAuthorityException {
  * <p>The device is in an invalid state.</p>
  */
 export interface InvalidDeviceException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidDeviceException";
   $fault: "client";
@@ -3172,7 +3171,7 @@ export interface InvalidDeviceException
 
 export namespace InvalidDeviceException {
   export function isa(o: any): o is InvalidDeviceException {
-    return _smithy.isa(o, "InvalidDeviceException");
+    return __isa(o, "InvalidDeviceException");
   }
 }
 
@@ -3180,7 +3179,7 @@ export namespace InvalidDeviceException {
  * <p>A password in SecretsManager is in an invalid state.</p>
  */
 export interface InvalidSecretsManagerResourceException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidSecretsManagerResourceException";
   $fault: "client";
@@ -3189,7 +3188,7 @@ export interface InvalidSecretsManagerResourceException
 
 export namespace InvalidSecretsManagerResourceException {
   export function isa(o: any): o is InvalidSecretsManagerResourceException {
-    return _smithy.isa(o, "InvalidSecretsManagerResourceException");
+    return __isa(o, "InvalidSecretsManagerResourceException");
   }
 }
 
@@ -3197,7 +3196,7 @@ export namespace InvalidSecretsManagerResourceException {
  * <p>The service linked role is locked for deletion. </p>
  */
 export interface InvalidServiceLinkedRoleStateException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidServiceLinkedRoleStateException";
   $fault: "client";
@@ -3206,7 +3205,7 @@ export interface InvalidServiceLinkedRoleStateException
 
 export namespace InvalidServiceLinkedRoleStateException {
   export function isa(o: any): o is InvalidServiceLinkedRoleStateException {
-    return _smithy.isa(o, "InvalidServiceLinkedRoleStateException");
+    return __isa(o, "InvalidServiceLinkedRoleStateException");
   }
 }
 
@@ -3214,7 +3213,7 @@ export namespace InvalidServiceLinkedRoleStateException {
  * <p>The attempt to update a user is invalid due to the user's current status.</p>
  */
 export interface InvalidUserStatusException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidUserStatusException";
   $fault: "client";
@@ -3223,7 +3222,7 @@ export interface InvalidUserStatusException
 
 export namespace InvalidUserStatusException {
   export function isa(o: any): o is InvalidUserStatusException {
-    return _smithy.isa(o, "InvalidUserStatusException");
+    return __isa(o, "InvalidUserStatusException");
   }
 }
 
@@ -3242,7 +3241,7 @@ export interface ListBusinessReportSchedulesRequest {
 
 export namespace ListBusinessReportSchedulesRequest {
   export function isa(o: any): o is ListBusinessReportSchedulesRequest {
-    return _smithy.isa(o, "ListBusinessReportSchedulesRequest");
+    return __isa(o, "ListBusinessReportSchedulesRequest");
   }
 }
 
@@ -3261,7 +3260,7 @@ export interface ListBusinessReportSchedulesResponse extends $MetadataBearer {
 
 export namespace ListBusinessReportSchedulesResponse {
   export function isa(o: any): o is ListBusinessReportSchedulesResponse {
-    return _smithy.isa(o, "ListBusinessReportSchedulesResponse");
+    return __isa(o, "ListBusinessReportSchedulesResponse");
   }
 }
 
@@ -3281,7 +3280,7 @@ export interface ListConferenceProvidersRequest {
 
 export namespace ListConferenceProvidersRequest {
   export function isa(o: any): o is ListConferenceProvidersRequest {
-    return _smithy.isa(o, "ListConferenceProvidersRequest");
+    return __isa(o, "ListConferenceProvidersRequest");
   }
 }
 
@@ -3300,7 +3299,7 @@ export interface ListConferenceProvidersResponse extends $MetadataBearer {
 
 export namespace ListConferenceProvidersResponse {
   export function isa(o: any): o is ListConferenceProvidersResponse {
-    return _smithy.isa(o, "ListConferenceProvidersResponse");
+    return __isa(o, "ListConferenceProvidersResponse");
   }
 }
 
@@ -3337,7 +3336,7 @@ export interface ListDeviceEventsRequest {
 
 export namespace ListDeviceEventsRequest {
   export function isa(o: any): o is ListDeviceEventsRequest {
-    return _smithy.isa(o, "ListDeviceEventsRequest");
+    return __isa(o, "ListDeviceEventsRequest");
   }
 }
 
@@ -3356,7 +3355,7 @@ export interface ListDeviceEventsResponse extends $MetadataBearer {
 
 export namespace ListDeviceEventsResponse {
   export function isa(o: any): o is ListDeviceEventsResponse {
-    return _smithy.isa(o, "ListDeviceEventsResponse");
+    return __isa(o, "ListDeviceEventsResponse");
   }
 }
 
@@ -3375,7 +3374,7 @@ export interface ListGatewayGroupsRequest {
 
 export namespace ListGatewayGroupsRequest {
   export function isa(o: any): o is ListGatewayGroupsRequest {
-    return _smithy.isa(o, "ListGatewayGroupsRequest");
+    return __isa(o, "ListGatewayGroupsRequest");
   }
 }
 
@@ -3394,7 +3393,7 @@ export interface ListGatewayGroupsResponse extends $MetadataBearer {
 
 export namespace ListGatewayGroupsResponse {
   export function isa(o: any): o is ListGatewayGroupsResponse {
-    return _smithy.isa(o, "ListGatewayGroupsResponse");
+    return __isa(o, "ListGatewayGroupsResponse");
   }
 }
 
@@ -3418,7 +3417,7 @@ export interface ListGatewaysRequest {
 
 export namespace ListGatewaysRequest {
   export function isa(o: any): o is ListGatewaysRequest {
-    return _smithy.isa(o, "ListGatewaysRequest");
+    return __isa(o, "ListGatewaysRequest");
   }
 }
 
@@ -3437,7 +3436,7 @@ export interface ListGatewaysResponse extends $MetadataBearer {
 
 export namespace ListGatewaysResponse {
   export function isa(o: any): o is ListGatewaysResponse {
-    return _smithy.isa(o, "ListGatewaysResponse");
+    return __isa(o, "ListGatewaysResponse");
   }
 }
 
@@ -3475,7 +3474,7 @@ export interface ListSkillsRequest {
 
 export namespace ListSkillsRequest {
   export function isa(o: any): o is ListSkillsRequest {
-    return _smithy.isa(o, "ListSkillsRequest");
+    return __isa(o, "ListSkillsRequest");
   }
 }
 
@@ -3494,7 +3493,7 @@ export interface ListSkillsResponse extends $MetadataBearer {
 
 export namespace ListSkillsResponse {
   export function isa(o: any): o is ListSkillsResponse {
-    return _smithy.isa(o, "ListSkillsResponse");
+    return __isa(o, "ListSkillsResponse");
   }
 }
 
@@ -3513,7 +3512,7 @@ export interface ListSkillsStoreCategoriesRequest {
 
 export namespace ListSkillsStoreCategoriesRequest {
   export function isa(o: any): o is ListSkillsStoreCategoriesRequest {
-    return _smithy.isa(o, "ListSkillsStoreCategoriesRequest");
+    return __isa(o, "ListSkillsStoreCategoriesRequest");
   }
 }
 
@@ -3532,7 +3531,7 @@ export interface ListSkillsStoreCategoriesResponse extends $MetadataBearer {
 
 export namespace ListSkillsStoreCategoriesResponse {
   export function isa(o: any): o is ListSkillsStoreCategoriesResponse {
-    return _smithy.isa(o, "ListSkillsStoreCategoriesResponse");
+    return __isa(o, "ListSkillsStoreCategoriesResponse");
   }
 }
 
@@ -3557,7 +3556,7 @@ export interface ListSkillsStoreSkillsByCategoryRequest {
 
 export namespace ListSkillsStoreSkillsByCategoryRequest {
   export function isa(o: any): o is ListSkillsStoreSkillsByCategoryRequest {
-    return _smithy.isa(o, "ListSkillsStoreSkillsByCategoryRequest");
+    return __isa(o, "ListSkillsStoreSkillsByCategoryRequest");
   }
 }
 
@@ -3577,7 +3576,7 @@ export interface ListSkillsStoreSkillsByCategoryResponse
 
 export namespace ListSkillsStoreSkillsByCategoryResponse {
   export function isa(o: any): o is ListSkillsStoreSkillsByCategoryResponse {
-    return _smithy.isa(o, "ListSkillsStoreSkillsByCategoryResponse");
+    return __isa(o, "ListSkillsStoreSkillsByCategoryResponse");
   }
 }
 
@@ -3601,7 +3600,7 @@ export interface ListSmartHomeAppliancesRequest {
 
 export namespace ListSmartHomeAppliancesRequest {
   export function isa(o: any): o is ListSmartHomeAppliancesRequest {
-    return _smithy.isa(o, "ListSmartHomeAppliancesRequest");
+    return __isa(o, "ListSmartHomeAppliancesRequest");
   }
 }
 
@@ -3620,7 +3619,7 @@ export interface ListSmartHomeAppliancesResponse extends $MetadataBearer {
 
 export namespace ListSmartHomeAppliancesResponse {
   export function isa(o: any): o is ListSmartHomeAppliancesResponse {
-    return _smithy.isa(o, "ListSmartHomeAppliancesResponse");
+    return __isa(o, "ListSmartHomeAppliancesResponse");
   }
 }
 
@@ -3648,7 +3647,7 @@ export interface ListTagsRequest {
 
 export namespace ListTagsRequest {
   export function isa(o: any): o is ListTagsRequest {
-    return _smithy.isa(o, "ListTagsRequest");
+    return __isa(o, "ListTagsRequest");
   }
 }
 
@@ -3667,7 +3666,7 @@ export interface ListTagsResponse extends $MetadataBearer {
 
 export namespace ListTagsResponse {
   export function isa(o: any): o is ListTagsResponse {
-    return _smithy.isa(o, "ListTagsResponse");
+    return __isa(o, "ListTagsResponse");
   }
 }
 
@@ -3704,7 +3703,7 @@ export interface MeetingRoomConfiguration {
 
 export namespace MeetingRoomConfiguration {
   export function isa(o: any): o is MeetingRoomConfiguration {
-    return _smithy.isa(o, "MeetingRoomConfiguration");
+    return __isa(o, "MeetingRoomConfiguration");
   }
 }
 
@@ -3776,7 +3775,7 @@ export interface NetworkProfile {
 
 export namespace NetworkProfile {
   export function isa(o: any): o is NetworkProfile {
-    return _smithy.isa(o, "NetworkProfile");
+    return __isa(o, "NetworkProfile");
   }
 }
 
@@ -3826,7 +3825,7 @@ export interface NetworkProfileData {
 
 export namespace NetworkProfileData {
   export function isa(o: any): o is NetworkProfileData {
-    return _smithy.isa(o, "NetworkProfileData");
+    return __isa(o, "NetworkProfileData");
   }
 }
 
@@ -3856,7 +3855,7 @@ export interface PhoneNumber {
 
 export namespace PhoneNumber {
   export function isa(o: any): o is PhoneNumber {
-    return _smithy.isa(o, "PhoneNumber");
+    return __isa(o, "PhoneNumber");
   }
 }
 
@@ -3945,7 +3944,7 @@ export interface Profile {
 
 export namespace Profile {
   export function isa(o: any): o is Profile {
-    return _smithy.isa(o, "Profile");
+    return __isa(o, "Profile");
   }
 }
 
@@ -4003,7 +4002,7 @@ export interface ProfileData {
 
 export namespace ProfileData {
   export function isa(o: any): o is ProfileData {
-    return _smithy.isa(o, "ProfileData");
+    return __isa(o, "ProfileData");
   }
 }
 
@@ -4017,7 +4016,7 @@ export interface PutConferencePreferenceRequest {
 
 export namespace PutConferencePreferenceRequest {
   export function isa(o: any): o is PutConferencePreferenceRequest {
-    return _smithy.isa(o, "PutConferencePreferenceRequest");
+    return __isa(o, "PutConferencePreferenceRequest");
   }
 }
 
@@ -4027,7 +4026,7 @@ export interface PutConferencePreferenceResponse extends $MetadataBearer {
 
 export namespace PutConferencePreferenceResponse {
   export function isa(o: any): o is PutConferencePreferenceResponse {
-    return _smithy.isa(o, "PutConferencePreferenceResponse");
+    return __isa(o, "PutConferencePreferenceResponse");
   }
 }
 
@@ -4053,7 +4052,7 @@ export interface PutInvitationConfigurationRequest {
 
 export namespace PutInvitationConfigurationRequest {
   export function isa(o: any): o is PutInvitationConfigurationRequest {
-    return _smithy.isa(o, "PutInvitationConfigurationRequest");
+    return __isa(o, "PutInvitationConfigurationRequest");
   }
 }
 
@@ -4063,7 +4062,7 @@ export interface PutInvitationConfigurationResponse extends $MetadataBearer {
 
 export namespace PutInvitationConfigurationResponse {
   export function isa(o: any): o is PutInvitationConfigurationResponse {
-    return _smithy.isa(o, "PutInvitationConfigurationResponse");
+    return __isa(o, "PutInvitationConfigurationResponse");
   }
 }
 
@@ -4087,7 +4086,7 @@ export interface PutRoomSkillParameterRequest {
 
 export namespace PutRoomSkillParameterRequest {
   export function isa(o: any): o is PutRoomSkillParameterRequest {
-    return _smithy.isa(o, "PutRoomSkillParameterRequest");
+    return __isa(o, "PutRoomSkillParameterRequest");
   }
 }
 
@@ -4097,7 +4096,7 @@ export interface PutRoomSkillParameterResponse extends $MetadataBearer {
 
 export namespace PutRoomSkillParameterResponse {
   export function isa(o: any): o is PutRoomSkillParameterResponse {
-    return _smithy.isa(o, "PutRoomSkillParameterResponse");
+    return __isa(o, "PutRoomSkillParameterResponse");
   }
 }
 
@@ -4122,7 +4121,7 @@ export interface PutSkillAuthorizationRequest {
 
 export namespace PutSkillAuthorizationRequest {
   export function isa(o: any): o is PutSkillAuthorizationRequest {
-    return _smithy.isa(o, "PutSkillAuthorizationRequest");
+    return __isa(o, "PutSkillAuthorizationRequest");
   }
 }
 
@@ -4132,7 +4131,7 @@ export interface PutSkillAuthorizationResponse extends $MetadataBearer {
 
 export namespace PutSkillAuthorizationResponse {
   export function isa(o: any): o is PutSkillAuthorizationResponse {
-    return _smithy.isa(o, "PutSkillAuthorizationResponse");
+    return __isa(o, "PutSkillAuthorizationResponse");
   }
 }
 
@@ -4171,7 +4170,7 @@ export interface RegisterAVSDeviceRequest {
 
 export namespace RegisterAVSDeviceRequest {
   export function isa(o: any): o is RegisterAVSDeviceRequest {
-    return _smithy.isa(o, "RegisterAVSDeviceRequest");
+    return __isa(o, "RegisterAVSDeviceRequest");
   }
 }
 
@@ -4185,7 +4184,7 @@ export interface RegisterAVSDeviceResponse extends $MetadataBearer {
 
 export namespace RegisterAVSDeviceResponse {
   export function isa(o: any): o is RegisterAVSDeviceResponse {
-    return _smithy.isa(o, "RegisterAVSDeviceResponse");
+    return __isa(o, "RegisterAVSDeviceResponse");
   }
 }
 
@@ -4199,7 +4198,7 @@ export interface RejectSkillRequest {
 
 export namespace RejectSkillRequest {
   export function isa(o: any): o is RejectSkillRequest {
-    return _smithy.isa(o, "RejectSkillRequest");
+    return __isa(o, "RejectSkillRequest");
   }
 }
 
@@ -4209,7 +4208,7 @@ export interface RejectSkillResponse extends $MetadataBearer {
 
 export namespace RejectSkillResponse {
   export function isa(o: any): o is RejectSkillResponse {
-    return _smithy.isa(o, "RejectSkillResponse");
+    return __isa(o, "RejectSkillResponse");
   }
 }
 
@@ -4231,7 +4230,7 @@ export interface RequireCheckIn {
 
 export namespace RequireCheckIn {
   export function isa(o: any): o is RequireCheckIn {
-    return _smithy.isa(o, "RequireCheckIn");
+    return __isa(o, "RequireCheckIn");
   }
 }
 
@@ -4250,7 +4249,7 @@ export interface ResolveRoomRequest {
 
 export namespace ResolveRoomRequest {
   export function isa(o: any): o is ResolveRoomRequest {
-    return _smithy.isa(o, "ResolveRoomRequest");
+    return __isa(o, "ResolveRoomRequest");
   }
 }
 
@@ -4274,7 +4273,7 @@ export interface ResolveRoomResponse extends $MetadataBearer {
 
 export namespace ResolveRoomResponse {
   export function isa(o: any): o is ResolveRoomResponse {
-    return _smithy.isa(o, "ResolveRoomResponse");
+    return __isa(o, "ResolveRoomResponse");
   }
 }
 
@@ -4282,7 +4281,7 @@ export namespace ResolveRoomResponse {
  * <p>Another resource is associated with the resource in the request.</p>
  */
 export interface ResourceAssociatedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceAssociatedException";
   $fault: "client";
@@ -4291,7 +4290,7 @@ export interface ResourceAssociatedException
 
 export namespace ResourceAssociatedException {
   export function isa(o: any): o is ResourceAssociatedException {
-    return _smithy.isa(o, "ResourceAssociatedException");
+    return __isa(o, "ResourceAssociatedException");
   }
 }
 
@@ -4310,7 +4309,7 @@ export interface RevokeInvitationRequest {
 
 export namespace RevokeInvitationRequest {
   export function isa(o: any): o is RevokeInvitationRequest {
-    return _smithy.isa(o, "RevokeInvitationRequest");
+    return __isa(o, "RevokeInvitationRequest");
   }
 }
 
@@ -4320,7 +4319,7 @@ export interface RevokeInvitationResponse extends $MetadataBearer {
 
 export namespace RevokeInvitationResponse {
   export function isa(o: any): o is RevokeInvitationResponse {
-    return _smithy.isa(o, "RevokeInvitationResponse");
+    return __isa(o, "RevokeInvitationResponse");
   }
 }
 
@@ -4357,7 +4356,7 @@ export interface Room {
 
 export namespace Room {
   export function isa(o: any): o is Room {
-    return _smithy.isa(o, "Room");
+    return __isa(o, "Room");
   }
 }
 
@@ -4399,7 +4398,7 @@ export interface RoomData {
 
 export namespace RoomData {
   export function isa(o: any): o is RoomData {
-    return _smithy.isa(o, "RoomData");
+    return __isa(o, "RoomData");
   }
 }
 
@@ -4422,7 +4421,7 @@ export interface RoomSkillParameter {
 
 export namespace RoomSkillParameter {
   export function isa(o: any): o is RoomSkillParameter {
-    return _smithy.isa(o, "RoomSkillParameter");
+    return __isa(o, "RoomSkillParameter");
   }
 }
 
@@ -4457,7 +4456,7 @@ export interface SearchAddressBooksRequest {
 
 export namespace SearchAddressBooksRequest {
   export function isa(o: any): o is SearchAddressBooksRequest {
-    return _smithy.isa(o, "SearchAddressBooksRequest");
+    return __isa(o, "SearchAddressBooksRequest");
   }
 }
 
@@ -4482,7 +4481,7 @@ export interface SearchAddressBooksResponse extends $MetadataBearer {
 
 export namespace SearchAddressBooksResponse {
   export function isa(o: any): o is SearchAddressBooksResponse {
-    return _smithy.isa(o, "SearchAddressBooksResponse");
+    return __isa(o, "SearchAddressBooksResponse");
   }
 }
 
@@ -4517,7 +4516,7 @@ export interface SearchContactsRequest {
 
 export namespace SearchContactsRequest {
   export function isa(o: any): o is SearchContactsRequest {
-    return _smithy.isa(o, "SearchContactsRequest");
+    return __isa(o, "SearchContactsRequest");
   }
 }
 
@@ -4541,7 +4540,7 @@ export interface SearchContactsResponse extends $MetadataBearer {
 
 export namespace SearchContactsResponse {
   export function isa(o: any): o is SearchContactsResponse {
-    return _smithy.isa(o, "SearchContactsResponse");
+    return __isa(o, "SearchContactsResponse");
   }
 }
 
@@ -4579,7 +4578,7 @@ export interface SearchDevicesRequest {
 
 export namespace SearchDevicesRequest {
   export function isa(o: any): o is SearchDevicesRequest {
-    return _smithy.isa(o, "SearchDevicesRequest");
+    return __isa(o, "SearchDevicesRequest");
   }
 }
 
@@ -4603,7 +4602,7 @@ export interface SearchDevicesResponse extends $MetadataBearer {
 
 export namespace SearchDevicesResponse {
   export function isa(o: any): o is SearchDevicesResponse {
-    return _smithy.isa(o, "SearchDevicesResponse");
+    return __isa(o, "SearchDevicesResponse");
   }
 }
 
@@ -4638,7 +4637,7 @@ export interface SearchNetworkProfilesRequest {
 
 export namespace SearchNetworkProfilesRequest {
   export function isa(o: any): o is SearchNetworkProfilesRequest {
-    return _smithy.isa(o, "SearchNetworkProfilesRequest");
+    return __isa(o, "SearchNetworkProfilesRequest");
   }
 }
 
@@ -4665,7 +4664,7 @@ export interface SearchNetworkProfilesResponse extends $MetadataBearer {
 
 export namespace SearchNetworkProfilesResponse {
   export function isa(o: any): o is SearchNetworkProfilesResponse {
-    return _smithy.isa(o, "SearchNetworkProfilesResponse");
+    return __isa(o, "SearchNetworkProfilesResponse");
   }
 }
 
@@ -4700,7 +4699,7 @@ export interface SearchProfilesRequest {
 
 export namespace SearchProfilesRequest {
   export function isa(o: any): o is SearchProfilesRequest {
-    return _smithy.isa(o, "SearchProfilesRequest");
+    return __isa(o, "SearchProfilesRequest");
   }
 }
 
@@ -4724,7 +4723,7 @@ export interface SearchProfilesResponse extends $MetadataBearer {
 
 export namespace SearchProfilesResponse {
   export function isa(o: any): o is SearchProfilesResponse {
-    return _smithy.isa(o, "SearchProfilesResponse");
+    return __isa(o, "SearchProfilesResponse");
   }
 }
 
@@ -4759,7 +4758,7 @@ export interface SearchRoomsRequest {
 
 export namespace SearchRoomsRequest {
   export function isa(o: any): o is SearchRoomsRequest {
-    return _smithy.isa(o, "SearchRoomsRequest");
+    return __isa(o, "SearchRoomsRequest");
   }
 }
 
@@ -4783,7 +4782,7 @@ export interface SearchRoomsResponse extends $MetadataBearer {
 
 export namespace SearchRoomsResponse {
   export function isa(o: any): o is SearchRoomsResponse {
-    return _smithy.isa(o, "SearchRoomsResponse");
+    return __isa(o, "SearchRoomsResponse");
   }
 }
 
@@ -4819,7 +4818,7 @@ export interface SearchSkillGroupsRequest {
 
 export namespace SearchSkillGroupsRequest {
   export function isa(o: any): o is SearchSkillGroupsRequest {
-    return _smithy.isa(o, "SearchSkillGroupsRequest");
+    return __isa(o, "SearchSkillGroupsRequest");
   }
 }
 
@@ -4843,7 +4842,7 @@ export interface SearchSkillGroupsResponse extends $MetadataBearer {
 
 export namespace SearchSkillGroupsResponse {
   export function isa(o: any): o is SearchSkillGroupsResponse {
-    return _smithy.isa(o, "SearchSkillGroupsResponse");
+    return __isa(o, "SearchSkillGroupsResponse");
   }
 }
 
@@ -4879,7 +4878,7 @@ export interface SearchUsersRequest {
 
 export namespace SearchUsersRequest {
   export function isa(o: any): o is SearchUsersRequest {
-    return _smithy.isa(o, "SearchUsersRequest");
+    return __isa(o, "SearchUsersRequest");
   }
 }
 
@@ -4903,7 +4902,7 @@ export interface SearchUsersResponse extends $MetadataBearer {
 
 export namespace SearchUsersResponse {
   export function isa(o: any): o is SearchUsersResponse {
-    return _smithy.isa(o, "SearchUsersResponse");
+    return __isa(o, "SearchUsersResponse");
   }
 }
 
@@ -4917,7 +4916,7 @@ export interface SendInvitationRequest {
 
 export namespace SendInvitationRequest {
   export function isa(o: any): o is SendInvitationRequest {
-    return _smithy.isa(o, "SendInvitationRequest");
+    return __isa(o, "SendInvitationRequest");
   }
 }
 
@@ -4927,7 +4926,7 @@ export interface SendInvitationResponse extends $MetadataBearer {
 
 export namespace SendInvitationResponse {
   export function isa(o: any): o is SendInvitationResponse {
-    return _smithy.isa(o, "SendInvitationResponse");
+    return __isa(o, "SendInvitationResponse");
   }
 }
 
@@ -4949,7 +4948,7 @@ export interface SipAddress {
 
 export namespace SipAddress {
   export function isa(o: any): o is SipAddress {
-    return _smithy.isa(o, "SipAddress");
+    return __isa(o, "SipAddress");
   }
 }
 
@@ -5016,7 +5015,7 @@ export interface SkillDetails {
 
 export namespace SkillDetails {
   export function isa(o: any): o is SkillDetails {
-    return _smithy.isa(o, "SkillDetails");
+    return __isa(o, "SkillDetails");
   }
 }
 
@@ -5043,7 +5042,7 @@ export interface SkillGroup {
 
 export namespace SkillGroup {
   export function isa(o: any): o is SkillGroup {
-    return _smithy.isa(o, "SkillGroup");
+    return __isa(o, "SkillGroup");
   }
 }
 
@@ -5070,7 +5069,7 @@ export interface SkillGroupData {
 
 export namespace SkillGroupData {
   export function isa(o: any): o is SkillGroupData {
-    return _smithy.isa(o, "SkillGroupData");
+    return __isa(o, "SkillGroupData");
   }
 }
 
@@ -5078,7 +5077,7 @@ export namespace SkillGroupData {
  * <p>The skill must be linked to a third-party account.</p>
  */
 export interface SkillNotLinkedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "SkillNotLinkedException";
   $fault: "client";
@@ -5087,7 +5086,7 @@ export interface SkillNotLinkedException
 
 export namespace SkillNotLinkedException {
   export function isa(o: any): o is SkillNotLinkedException {
-    return _smithy.isa(o, "SkillNotLinkedException");
+    return __isa(o, "SkillNotLinkedException");
   }
 }
 
@@ -5125,7 +5124,7 @@ export interface SkillSummary {
 
 export namespace SkillSummary {
   export function isa(o: any): o is SkillSummary {
-    return _smithy.isa(o, "SkillSummary");
+    return __isa(o, "SkillSummary");
   }
 }
 
@@ -5183,7 +5182,7 @@ export interface SkillsStoreSkill {
 
 export namespace SkillsStoreSkill {
   export function isa(o: any): o is SkillsStoreSkill {
-    return _smithy.isa(o, "SkillsStoreSkill");
+    return __isa(o, "SkillsStoreSkill");
   }
 }
 
@@ -5211,7 +5210,7 @@ export interface SmartHomeAppliance {
 
 export namespace SmartHomeAppliance {
   export function isa(o: any): o is SmartHomeAppliance {
-    return _smithy.isa(o, "SmartHomeAppliance");
+    return __isa(o, "SmartHomeAppliance");
   }
 }
 
@@ -5233,7 +5232,7 @@ export interface Sort {
 
 export namespace Sort {
   export function isa(o: any): o is Sort {
-    return _smithy.isa(o, "Sort");
+    return __isa(o, "Sort");
   }
 }
 
@@ -5262,7 +5261,7 @@ export interface StartDeviceSyncRequest {
 
 export namespace StartDeviceSyncRequest {
   export function isa(o: any): o is StartDeviceSyncRequest {
-    return _smithy.isa(o, "StartDeviceSyncRequest");
+    return __isa(o, "StartDeviceSyncRequest");
   }
 }
 
@@ -5272,7 +5271,7 @@ export interface StartDeviceSyncResponse extends $MetadataBearer {
 
 export namespace StartDeviceSyncResponse {
   export function isa(o: any): o is StartDeviceSyncResponse {
-    return _smithy.isa(o, "StartDeviceSyncResponse");
+    return __isa(o, "StartDeviceSyncResponse");
   }
 }
 
@@ -5286,7 +5285,7 @@ export interface StartSmartHomeApplianceDiscoveryRequest {
 
 export namespace StartSmartHomeApplianceDiscoveryRequest {
   export function isa(o: any): o is StartSmartHomeApplianceDiscoveryRequest {
-    return _smithy.isa(o, "StartSmartHomeApplianceDiscoveryRequest");
+    return __isa(o, "StartSmartHomeApplianceDiscoveryRequest");
   }
 }
 
@@ -5297,7 +5296,7 @@ export interface StartSmartHomeApplianceDiscoveryResponse
 
 export namespace StartSmartHomeApplianceDiscoveryResponse {
   export function isa(o: any): o is StartSmartHomeApplianceDiscoveryResponse {
-    return _smithy.isa(o, "StartSmartHomeApplianceDiscoveryResponse");
+    return __isa(o, "StartSmartHomeApplianceDiscoveryResponse");
   }
 }
 
@@ -5319,7 +5318,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -5339,7 +5338,7 @@ export interface TagResourceRequest {
 
 export namespace TagResourceRequest {
   export function isa(o: any): o is TagResourceRequest {
-    return _smithy.isa(o, "TagResourceRequest");
+    return __isa(o, "TagResourceRequest");
   }
 }
 
@@ -5349,7 +5348,7 @@ export interface TagResourceResponse extends $MetadataBearer {
 
 export namespace TagResourceResponse {
   export function isa(o: any): o is TagResourceResponse {
-    return _smithy.isa(o, "TagResourceResponse");
+    return __isa(o, "TagResourceResponse");
   }
 }
 
@@ -5374,7 +5373,7 @@ export interface UntagResourceRequest {
 
 export namespace UntagResourceRequest {
   export function isa(o: any): o is UntagResourceRequest {
-    return _smithy.isa(o, "UntagResourceRequest");
+    return __isa(o, "UntagResourceRequest");
   }
 }
 
@@ -5384,7 +5383,7 @@ export interface UntagResourceResponse extends $MetadataBearer {
 
 export namespace UntagResourceResponse {
   export function isa(o: any): o is UntagResourceResponse {
-    return _smithy.isa(o, "UntagResourceResponse");
+    return __isa(o, "UntagResourceResponse");
   }
 }
 
@@ -5408,7 +5407,7 @@ export interface UpdateAddressBookRequest {
 
 export namespace UpdateAddressBookRequest {
   export function isa(o: any): o is UpdateAddressBookRequest {
-    return _smithy.isa(o, "UpdateAddressBookRequest");
+    return __isa(o, "UpdateAddressBookRequest");
   }
 }
 
@@ -5418,7 +5417,7 @@ export interface UpdateAddressBookResponse extends $MetadataBearer {
 
 export namespace UpdateAddressBookResponse {
   export function isa(o: any): o is UpdateAddressBookResponse {
-    return _smithy.isa(o, "UpdateAddressBookResponse");
+    return __isa(o, "UpdateAddressBookResponse");
   }
 }
 
@@ -5458,7 +5457,7 @@ export interface UpdateBusinessReportScheduleRequest {
 
 export namespace UpdateBusinessReportScheduleRequest {
   export function isa(o: any): o is UpdateBusinessReportScheduleRequest {
-    return _smithy.isa(o, "UpdateBusinessReportScheduleRequest");
+    return __isa(o, "UpdateBusinessReportScheduleRequest");
   }
 }
 
@@ -5468,7 +5467,7 @@ export interface UpdateBusinessReportScheduleResponse extends $MetadataBearer {
 
 export namespace UpdateBusinessReportScheduleResponse {
   export function isa(o: any): o is UpdateBusinessReportScheduleResponse {
-    return _smithy.isa(o, "UpdateBusinessReportScheduleResponse");
+    return __isa(o, "UpdateBusinessReportScheduleResponse");
   }
 }
 
@@ -5502,7 +5501,7 @@ export interface UpdateConferenceProviderRequest {
 
 export namespace UpdateConferenceProviderRequest {
   export function isa(o: any): o is UpdateConferenceProviderRequest {
-    return _smithy.isa(o, "UpdateConferenceProviderRequest");
+    return __isa(o, "UpdateConferenceProviderRequest");
   }
 }
 
@@ -5512,7 +5511,7 @@ export interface UpdateConferenceProviderResponse extends $MetadataBearer {
 
 export namespace UpdateConferenceProviderResponse {
   export function isa(o: any): o is UpdateConferenceProviderResponse {
-    return _smithy.isa(o, "UpdateConferenceProviderResponse");
+    return __isa(o, "UpdateConferenceProviderResponse");
   }
 }
 
@@ -5558,7 +5557,7 @@ export interface UpdateContactRequest {
 
 export namespace UpdateContactRequest {
   export function isa(o: any): o is UpdateContactRequest {
-    return _smithy.isa(o, "UpdateContactRequest");
+    return __isa(o, "UpdateContactRequest");
   }
 }
 
@@ -5568,7 +5567,7 @@ export interface UpdateContactResponse extends $MetadataBearer {
 
 export namespace UpdateContactResponse {
   export function isa(o: any): o is UpdateContactResponse {
-    return _smithy.isa(o, "UpdateContactResponse");
+    return __isa(o, "UpdateContactResponse");
   }
 }
 
@@ -5587,7 +5586,7 @@ export interface UpdateDeviceRequest {
 
 export namespace UpdateDeviceRequest {
   export function isa(o: any): o is UpdateDeviceRequest {
-    return _smithy.isa(o, "UpdateDeviceRequest");
+    return __isa(o, "UpdateDeviceRequest");
   }
 }
 
@@ -5597,7 +5596,7 @@ export interface UpdateDeviceResponse extends $MetadataBearer {
 
 export namespace UpdateDeviceResponse {
   export function isa(o: any): o is UpdateDeviceResponse {
-    return _smithy.isa(o, "UpdateDeviceResponse");
+    return __isa(o, "UpdateDeviceResponse");
   }
 }
 
@@ -5627,7 +5626,7 @@ export interface UpdateEndOfMeetingReminder {
 
 export namespace UpdateEndOfMeetingReminder {
   export function isa(o: any): o is UpdateEndOfMeetingReminder {
-    return _smithy.isa(o, "UpdateEndOfMeetingReminder");
+    return __isa(o, "UpdateEndOfMeetingReminder");
   }
 }
 
@@ -5651,7 +5650,7 @@ export interface UpdateGatewayGroupRequest {
 
 export namespace UpdateGatewayGroupRequest {
   export function isa(o: any): o is UpdateGatewayGroupRequest {
-    return _smithy.isa(o, "UpdateGatewayGroupRequest");
+    return __isa(o, "UpdateGatewayGroupRequest");
   }
 }
 
@@ -5661,7 +5660,7 @@ export interface UpdateGatewayGroupResponse extends $MetadataBearer {
 
 export namespace UpdateGatewayGroupResponse {
   export function isa(o: any): o is UpdateGatewayGroupResponse {
-    return _smithy.isa(o, "UpdateGatewayGroupResponse");
+    return __isa(o, "UpdateGatewayGroupResponse");
   }
 }
 
@@ -5691,7 +5690,7 @@ export interface UpdateGatewayRequest {
 
 export namespace UpdateGatewayRequest {
   export function isa(o: any): o is UpdateGatewayRequest {
-    return _smithy.isa(o, "UpdateGatewayRequest");
+    return __isa(o, "UpdateGatewayRequest");
   }
 }
 
@@ -5701,7 +5700,7 @@ export interface UpdateGatewayResponse extends $MetadataBearer {
 
 export namespace UpdateGatewayResponse {
   export function isa(o: any): o is UpdateGatewayResponse {
-    return _smithy.isa(o, "UpdateGatewayResponse");
+    return __isa(o, "UpdateGatewayResponse");
   }
 }
 
@@ -5726,7 +5725,7 @@ export interface UpdateInstantBooking {
 
 export namespace UpdateInstantBooking {
   export function isa(o: any): o is UpdateInstantBooking {
-    return _smithy.isa(o, "UpdateInstantBooking");
+    return __isa(o, "UpdateInstantBooking");
   }
 }
 
@@ -5760,7 +5759,7 @@ export interface UpdateMeetingRoomConfiguration {
 
 export namespace UpdateMeetingRoomConfiguration {
   export function isa(o: any): o is UpdateMeetingRoomConfiguration {
-    return _smithy.isa(o, "UpdateMeetingRoomConfiguration");
+    return __isa(o, "UpdateMeetingRoomConfiguration");
   }
 }
 
@@ -5808,7 +5807,7 @@ export interface UpdateNetworkProfileRequest {
 
 export namespace UpdateNetworkProfileRequest {
   export function isa(o: any): o is UpdateNetworkProfileRequest {
-    return _smithy.isa(o, "UpdateNetworkProfileRequest");
+    return __isa(o, "UpdateNetworkProfileRequest");
   }
 }
 
@@ -5818,7 +5817,7 @@ export interface UpdateNetworkProfileResponse extends $MetadataBearer {
 
 export namespace UpdateNetworkProfileResponse {
   export function isa(o: any): o is UpdateNetworkProfileResponse {
-    return _smithy.isa(o, "UpdateNetworkProfileResponse");
+    return __isa(o, "UpdateNetworkProfileResponse");
   }
 }
 
@@ -5893,7 +5892,7 @@ export interface UpdateProfileRequest {
 
 export namespace UpdateProfileRequest {
   export function isa(o: any): o is UpdateProfileRequest {
-    return _smithy.isa(o, "UpdateProfileRequest");
+    return __isa(o, "UpdateProfileRequest");
   }
 }
 
@@ -5903,7 +5902,7 @@ export interface UpdateProfileResponse extends $MetadataBearer {
 
 export namespace UpdateProfileResponse {
   export function isa(o: any): o is UpdateProfileResponse {
-    return _smithy.isa(o, "UpdateProfileResponse");
+    return __isa(o, "UpdateProfileResponse");
   }
 }
 
@@ -5925,7 +5924,7 @@ export interface UpdateRequireCheckIn {
 
 export namespace UpdateRequireCheckIn {
   export function isa(o: any): o is UpdateRequireCheckIn {
-    return _smithy.isa(o, "UpdateRequireCheckIn");
+    return __isa(o, "UpdateRequireCheckIn");
   }
 }
 
@@ -5959,7 +5958,7 @@ export interface UpdateRoomRequest {
 
 export namespace UpdateRoomRequest {
   export function isa(o: any): o is UpdateRoomRequest {
-    return _smithy.isa(o, "UpdateRoomRequest");
+    return __isa(o, "UpdateRoomRequest");
   }
 }
 
@@ -5969,7 +5968,7 @@ export interface UpdateRoomResponse extends $MetadataBearer {
 
 export namespace UpdateRoomResponse {
   export function isa(o: any): o is UpdateRoomResponse {
-    return _smithy.isa(o, "UpdateRoomResponse");
+    return __isa(o, "UpdateRoomResponse");
   }
 }
 
@@ -5993,7 +5992,7 @@ export interface UpdateSkillGroupRequest {
 
 export namespace UpdateSkillGroupRequest {
   export function isa(o: any): o is UpdateSkillGroupRequest {
-    return _smithy.isa(o, "UpdateSkillGroupRequest");
+    return __isa(o, "UpdateSkillGroupRequest");
   }
 }
 
@@ -6003,7 +6002,7 @@ export interface UpdateSkillGroupResponse extends $MetadataBearer {
 
 export namespace UpdateSkillGroupResponse {
   export function isa(o: any): o is UpdateSkillGroupResponse {
-    return _smithy.isa(o, "UpdateSkillGroupResponse");
+    return __isa(o, "UpdateSkillGroupResponse");
   }
 }
 
@@ -6045,7 +6044,7 @@ export interface UserData {
 
 export namespace UserData {
   export function isa(o: any): o is UserData {
-    return _smithy.isa(o, "UserData");
+    return __isa(o, "UserData");
   }
 }
 

--- a/clients/client-amplify/models/index.ts
+++ b/clients/client-amplify/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -158,7 +161,7 @@ export interface App {
 
 export namespace App {
   export function isa(o: any): o is App {
-    return _smithy.isa(o, "App");
+    return __isa(o, "App");
   }
 }
 
@@ -186,7 +189,7 @@ export interface Artifact {
 
 export namespace Artifact {
   export function isa(o: any): o is Artifact {
-    return _smithy.isa(o, "Artifact");
+    return __isa(o, "Artifact");
   }
 }
 
@@ -263,7 +266,7 @@ export interface AutoBranchCreationConfig {
 
 export namespace AutoBranchCreationConfig {
   export function isa(o: any): o is AutoBranchCreationConfig {
-    return _smithy.isa(o, "AutoBranchCreationConfig");
+    return __isa(o, "AutoBranchCreationConfig");
   }
 }
 
@@ -319,7 +322,7 @@ export interface BackendEnvironment {
 
 export namespace BackendEnvironment {
   export function isa(o: any): o is BackendEnvironment {
-    return _smithy.isa(o, "BackendEnvironment");
+    return __isa(o, "BackendEnvironment");
   }
 }
 
@@ -329,7 +332,7 @@ export namespace BackendEnvironment {
  *         </p>
  */
 export interface BadRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "BadRequestException";
   $fault: "client";
@@ -338,7 +341,7 @@ export interface BadRequestException
 
 export namespace BadRequestException {
   export function isa(o: any): o is BadRequestException {
-    return _smithy.isa(o, "BadRequestException");
+    return __isa(o, "BadRequestException");
   }
 }
 
@@ -534,7 +537,7 @@ export interface Branch {
 
 export namespace Branch {
   export function isa(o: any): o is Branch {
-    return _smithy.isa(o, "Branch");
+    return __isa(o, "Branch");
   }
 }
 
@@ -669,7 +672,7 @@ export interface CreateAppRequest {
 
 export namespace CreateAppRequest {
   export function isa(o: any): o is CreateAppRequest {
-    return _smithy.isa(o, "CreateAppRequest");
+    return __isa(o, "CreateAppRequest");
   }
 }
 
@@ -685,7 +688,7 @@ export interface CreateAppResult extends $MetadataBearer {
 
 export namespace CreateAppResult {
   export function isa(o: any): o is CreateAppResult {
-    return _smithy.isa(o, "CreateAppResult");
+    return __isa(o, "CreateAppResult");
   }
 }
 
@@ -727,7 +730,7 @@ export interface CreateBackendEnvironmentRequest {
 
 export namespace CreateBackendEnvironmentRequest {
   export function isa(o: any): o is CreateBackendEnvironmentRequest {
-    return _smithy.isa(o, "CreateBackendEnvironmentRequest");
+    return __isa(o, "CreateBackendEnvironmentRequest");
   }
 }
 
@@ -748,7 +751,7 @@ export interface CreateBackendEnvironmentResult extends $MetadataBearer {
 
 export namespace CreateBackendEnvironmentResult {
   export function isa(o: any): o is CreateBackendEnvironmentResult {
-    return _smithy.isa(o, "CreateBackendEnvironmentResult");
+    return __isa(o, "CreateBackendEnvironmentResult");
   }
 }
 
@@ -881,7 +884,7 @@ export interface CreateBranchRequest {
 
 export namespace CreateBranchRequest {
   export function isa(o: any): o is CreateBranchRequest {
-    return _smithy.isa(o, "CreateBranchRequest");
+    return __isa(o, "CreateBranchRequest");
   }
 }
 
@@ -902,7 +905,7 @@ export interface CreateBranchResult extends $MetadataBearer {
 
 export namespace CreateBranchResult {
   export function isa(o: any): o is CreateBranchResult {
-    return _smithy.isa(o, "CreateBranchResult");
+    return __isa(o, "CreateBranchResult");
   }
 }
 
@@ -939,7 +942,7 @@ export interface CreateDeploymentRequest {
 
 export namespace CreateDeploymentRequest {
   export function isa(o: any): o is CreateDeploymentRequest {
-    return _smithy.isa(o, "CreateDeploymentRequest");
+    return __isa(o, "CreateDeploymentRequest");
   }
 }
 
@@ -975,7 +978,7 @@ export interface CreateDeploymentResult extends $MetadataBearer {
 
 export namespace CreateDeploymentResult {
   export function isa(o: any): o is CreateDeploymentResult {
-    return _smithy.isa(o, "CreateDeploymentResult");
+    return __isa(o, "CreateDeploymentResult");
   }
 }
 
@@ -1017,7 +1020,7 @@ export interface CreateDomainAssociationRequest {
 
 export namespace CreateDomainAssociationRequest {
   export function isa(o: any): o is CreateDomainAssociationRequest {
-    return _smithy.isa(o, "CreateDomainAssociationRequest");
+    return __isa(o, "CreateDomainAssociationRequest");
   }
 }
 
@@ -1038,7 +1041,7 @@ export interface CreateDomainAssociationResult extends $MetadataBearer {
 
 export namespace CreateDomainAssociationResult {
   export function isa(o: any): o is CreateDomainAssociationResult {
-    return _smithy.isa(o, "CreateDomainAssociationResult");
+    return __isa(o, "CreateDomainAssociationResult");
   }
 }
 
@@ -1073,7 +1076,7 @@ export interface CreateWebhookRequest {
 
 export namespace CreateWebhookRequest {
   export function isa(o: any): o is CreateWebhookRequest {
-    return _smithy.isa(o, "CreateWebhookRequest");
+    return __isa(o, "CreateWebhookRequest");
   }
 }
 
@@ -1094,7 +1097,7 @@ export interface CreateWebhookResult extends $MetadataBearer {
 
 export namespace CreateWebhookResult {
   export function isa(o: any): o is CreateWebhookResult {
-    return _smithy.isa(o, "CreateWebhookResult");
+    return __isa(o, "CreateWebhookResult");
   }
 }
 
@@ -1136,7 +1139,7 @@ export interface CustomRule {
 
 export namespace CustomRule {
   export function isa(o: any): o is CustomRule {
-    return _smithy.isa(o, "CustomRule");
+    return __isa(o, "CustomRule");
   }
 }
 
@@ -1157,7 +1160,7 @@ export interface DeleteAppRequest {
 
 export namespace DeleteAppRequest {
   export function isa(o: any): o is DeleteAppRequest {
-    return _smithy.isa(o, "DeleteAppRequest");
+    return __isa(o, "DeleteAppRequest");
   }
 }
 
@@ -1178,7 +1181,7 @@ export interface DeleteAppResult extends $MetadataBearer {
 
 export namespace DeleteAppResult {
   export function isa(o: any): o is DeleteAppResult {
-    return _smithy.isa(o, "DeleteAppResult");
+    return __isa(o, "DeleteAppResult");
   }
 }
 
@@ -1206,7 +1209,7 @@ export interface DeleteBackendEnvironmentRequest {
 
 export namespace DeleteBackendEnvironmentRequest {
   export function isa(o: any): o is DeleteBackendEnvironmentRequest {
-    return _smithy.isa(o, "DeleteBackendEnvironmentRequest");
+    return __isa(o, "DeleteBackendEnvironmentRequest");
   }
 }
 
@@ -1227,7 +1230,7 @@ export interface DeleteBackendEnvironmentResult extends $MetadataBearer {
 
 export namespace DeleteBackendEnvironmentResult {
   export function isa(o: any): o is DeleteBackendEnvironmentResult {
-    return _smithy.isa(o, "DeleteBackendEnvironmentResult");
+    return __isa(o, "DeleteBackendEnvironmentResult");
   }
 }
 
@@ -1255,7 +1258,7 @@ export interface DeleteBranchRequest {
 
 export namespace DeleteBranchRequest {
   export function isa(o: any): o is DeleteBranchRequest {
-    return _smithy.isa(o, "DeleteBranchRequest");
+    return __isa(o, "DeleteBranchRequest");
   }
 }
 
@@ -1276,7 +1279,7 @@ export interface DeleteBranchResult extends $MetadataBearer {
 
 export namespace DeleteBranchResult {
   export function isa(o: any): o is DeleteBranchResult {
-    return _smithy.isa(o, "DeleteBranchResult");
+    return __isa(o, "DeleteBranchResult");
   }
 }
 
@@ -1304,7 +1307,7 @@ export interface DeleteDomainAssociationRequest {
 
 export namespace DeleteDomainAssociationRequest {
   export function isa(o: any): o is DeleteDomainAssociationRequest {
-    return _smithy.isa(o, "DeleteDomainAssociationRequest");
+    return __isa(o, "DeleteDomainAssociationRequest");
   }
 }
 
@@ -1320,7 +1323,7 @@ export interface DeleteDomainAssociationResult extends $MetadataBearer {
 
 export namespace DeleteDomainAssociationResult {
   export function isa(o: any): o is DeleteDomainAssociationResult {
-    return _smithy.isa(o, "DeleteDomainAssociationResult");
+    return __isa(o, "DeleteDomainAssociationResult");
   }
 }
 
@@ -1355,7 +1358,7 @@ export interface DeleteJobRequest {
 
 export namespace DeleteJobRequest {
   export function isa(o: any): o is DeleteJobRequest {
-    return _smithy.isa(o, "DeleteJobRequest");
+    return __isa(o, "DeleteJobRequest");
   }
 }
 
@@ -1376,7 +1379,7 @@ export interface DeleteJobResult extends $MetadataBearer {
 
 export namespace DeleteJobResult {
   export function isa(o: any): o is DeleteJobResult {
-    return _smithy.isa(o, "DeleteJobResult");
+    return __isa(o, "DeleteJobResult");
   }
 }
 
@@ -1397,7 +1400,7 @@ export interface DeleteWebhookRequest {
 
 export namespace DeleteWebhookRequest {
   export function isa(o: any): o is DeleteWebhookRequest {
-    return _smithy.isa(o, "DeleteWebhookRequest");
+    return __isa(o, "DeleteWebhookRequest");
   }
 }
 
@@ -1418,7 +1421,7 @@ export interface DeleteWebhookResult extends $MetadataBearer {
 
 export namespace DeleteWebhookResult {
   export function isa(o: any): o is DeleteWebhookResult {
-    return _smithy.isa(o, "DeleteWebhookResult");
+    return __isa(o, "DeleteWebhookResult");
   }
 }
 
@@ -1428,7 +1431,7 @@ export namespace DeleteWebhookResult {
  *         </p>
  */
 export interface DependentServiceFailureException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DependentServiceFailureException";
   $fault: "server";
@@ -1437,7 +1440,7 @@ export interface DependentServiceFailureException
 
 export namespace DependentServiceFailureException {
   export function isa(o: any): o is DependentServiceFailureException {
-    return _smithy.isa(o, "DependentServiceFailureException");
+    return __isa(o, "DependentServiceFailureException");
   }
 }
 
@@ -1500,7 +1503,7 @@ export interface DomainAssociation {
 
 export namespace DomainAssociation {
   export function isa(o: any): o is DomainAssociation {
-    return _smithy.isa(o, "DomainAssociation");
+    return __isa(o, "DomainAssociation");
   }
 }
 
@@ -1553,7 +1556,7 @@ export interface GenerateAccessLogsRequest {
 
 export namespace GenerateAccessLogsRequest {
   export function isa(o: any): o is GenerateAccessLogsRequest {
-    return _smithy.isa(o, "GenerateAccessLogsRequest");
+    return __isa(o, "GenerateAccessLogsRequest");
   }
 }
 
@@ -1574,7 +1577,7 @@ export interface GenerateAccessLogsResult extends $MetadataBearer {
 
 export namespace GenerateAccessLogsResult {
   export function isa(o: any): o is GenerateAccessLogsResult {
-    return _smithy.isa(o, "GenerateAccessLogsResult");
+    return __isa(o, "GenerateAccessLogsResult");
   }
 }
 
@@ -1595,7 +1598,7 @@ export interface GetAppRequest {
 
 export namespace GetAppRequest {
   export function isa(o: any): o is GetAppRequest {
-    return _smithy.isa(o, "GetAppRequest");
+    return __isa(o, "GetAppRequest");
   }
 }
 
@@ -1611,7 +1614,7 @@ export interface GetAppResult extends $MetadataBearer {
 
 export namespace GetAppResult {
   export function isa(o: any): o is GetAppResult {
-    return _smithy.isa(o, "GetAppResult");
+    return __isa(o, "GetAppResult");
   }
 }
 
@@ -1632,7 +1635,7 @@ export interface GetArtifactUrlRequest {
 
 export namespace GetArtifactUrlRequest {
   export function isa(o: any): o is GetArtifactUrlRequest {
-    return _smithy.isa(o, "GetArtifactUrlRequest");
+    return __isa(o, "GetArtifactUrlRequest");
   }
 }
 
@@ -1660,7 +1663,7 @@ export interface GetArtifactUrlResult extends $MetadataBearer {
 
 export namespace GetArtifactUrlResult {
   export function isa(o: any): o is GetArtifactUrlResult {
-    return _smithy.isa(o, "GetArtifactUrlResult");
+    return __isa(o, "GetArtifactUrlResult");
   }
 }
 
@@ -1688,7 +1691,7 @@ export interface GetBackendEnvironmentRequest {
 
 export namespace GetBackendEnvironmentRequest {
   export function isa(o: any): o is GetBackendEnvironmentRequest {
-    return _smithy.isa(o, "GetBackendEnvironmentRequest");
+    return __isa(o, "GetBackendEnvironmentRequest");
   }
 }
 
@@ -1709,7 +1712,7 @@ export interface GetBackendEnvironmentResult extends $MetadataBearer {
 
 export namespace GetBackendEnvironmentResult {
   export function isa(o: any): o is GetBackendEnvironmentResult {
-    return _smithy.isa(o, "GetBackendEnvironmentResult");
+    return __isa(o, "GetBackendEnvironmentResult");
   }
 }
 
@@ -1737,7 +1740,7 @@ export interface GetBranchRequest {
 
 export namespace GetBranchRequest {
   export function isa(o: any): o is GetBranchRequest {
-    return _smithy.isa(o, "GetBranchRequest");
+    return __isa(o, "GetBranchRequest");
   }
 }
 
@@ -1753,7 +1756,7 @@ export interface GetBranchResult extends $MetadataBearer {
 
 export namespace GetBranchResult {
   export function isa(o: any): o is GetBranchResult {
-    return _smithy.isa(o, "GetBranchResult");
+    return __isa(o, "GetBranchResult");
   }
 }
 
@@ -1781,7 +1784,7 @@ export interface GetDomainAssociationRequest {
 
 export namespace GetDomainAssociationRequest {
   export function isa(o: any): o is GetDomainAssociationRequest {
-    return _smithy.isa(o, "GetDomainAssociationRequest");
+    return __isa(o, "GetDomainAssociationRequest");
   }
 }
 
@@ -1802,7 +1805,7 @@ export interface GetDomainAssociationResult extends $MetadataBearer {
 
 export namespace GetDomainAssociationResult {
   export function isa(o: any): o is GetDomainAssociationResult {
-    return _smithy.isa(o, "GetDomainAssociationResult");
+    return __isa(o, "GetDomainAssociationResult");
   }
 }
 
@@ -1837,7 +1840,7 @@ export interface GetJobRequest {
 
 export namespace GetJobRequest {
   export function isa(o: any): o is GetJobRequest {
-    return _smithy.isa(o, "GetJobRequest");
+    return __isa(o, "GetJobRequest");
   }
 }
 
@@ -1853,7 +1856,7 @@ export interface GetJobResult extends $MetadataBearer {
 
 export namespace GetJobResult {
   export function isa(o: any): o is GetJobResult {
-    return _smithy.isa(o, "GetJobResult");
+    return __isa(o, "GetJobResult");
   }
 }
 
@@ -1874,7 +1877,7 @@ export interface GetWebhookRequest {
 
 export namespace GetWebhookRequest {
   export function isa(o: any): o is GetWebhookRequest {
-    return _smithy.isa(o, "GetWebhookRequest");
+    return __isa(o, "GetWebhookRequest");
   }
 }
 
@@ -1895,7 +1898,7 @@ export interface GetWebhookResult extends $MetadataBearer {
 
 export namespace GetWebhookResult {
   export function isa(o: any): o is GetWebhookResult {
-    return _smithy.isa(o, "GetWebhookResult");
+    return __isa(o, "GetWebhookResult");
   }
 }
 
@@ -1905,7 +1908,7 @@ export namespace GetWebhookResult {
  *         </p>
  */
 export interface InternalFailureException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalFailureException";
   $fault: "server";
@@ -1914,7 +1917,7 @@ export interface InternalFailureException
 
 export namespace InternalFailureException {
   export function isa(o: any): o is InternalFailureException {
-    return _smithy.isa(o, "InternalFailureException");
+    return __isa(o, "InternalFailureException");
   }
 }
 
@@ -1942,7 +1945,7 @@ export interface Job {
 
 export namespace Job {
   export function isa(o: any): o is Job {
-    return _smithy.isa(o, "Job");
+    return __isa(o, "Job");
   }
 }
 
@@ -2032,7 +2035,7 @@ export interface JobSummary {
 
 export namespace JobSummary {
   export function isa(o: any): o is JobSummary {
-    return _smithy.isa(o, "JobSummary");
+    return __isa(o, "JobSummary");
   }
 }
 
@@ -2049,7 +2052,7 @@ export enum JobType {
  *         </p>
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -2058,7 +2061,7 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
@@ -2087,7 +2090,7 @@ export interface ListAppsRequest {
 
 export namespace ListAppsRequest {
   export function isa(o: any): o is ListAppsRequest {
-    return _smithy.isa(o, "ListAppsRequest");
+    return __isa(o, "ListAppsRequest");
   }
 }
 
@@ -2117,7 +2120,7 @@ export interface ListAppsResult extends $MetadataBearer {
 
 export namespace ListAppsResult {
   export function isa(o: any): o is ListAppsResult {
-    return _smithy.isa(o, "ListAppsResult");
+    return __isa(o, "ListAppsResult");
   }
 }
 
@@ -2168,7 +2171,7 @@ export interface ListArtifactsRequest {
 
 export namespace ListArtifactsRequest {
   export function isa(o: any): o is ListArtifactsRequest {
-    return _smithy.isa(o, "ListArtifactsRequest");
+    return __isa(o, "ListArtifactsRequest");
   }
 }
 
@@ -2197,7 +2200,7 @@ export interface ListArtifactsResult extends $MetadataBearer {
 
 export namespace ListArtifactsResult {
   export function isa(o: any): o is ListArtifactsResult {
-    return _smithy.isa(o, "ListArtifactsResult");
+    return __isa(o, "ListArtifactsResult");
   }
 }
 
@@ -2241,7 +2244,7 @@ export interface ListBackendEnvironmentsRequest {
 
 export namespace ListBackendEnvironmentsRequest {
   export function isa(o: any): o is ListBackendEnvironmentsRequest {
-    return _smithy.isa(o, "ListBackendEnvironmentsRequest");
+    return __isa(o, "ListBackendEnvironmentsRequest");
   }
 }
 
@@ -2270,7 +2273,7 @@ export interface ListBackendEnvironmentsResult extends $MetadataBearer {
 
 export namespace ListBackendEnvironmentsResult {
   export function isa(o: any): o is ListBackendEnvironmentsResult {
-    return _smithy.isa(o, "ListBackendEnvironmentsResult");
+    return __isa(o, "ListBackendEnvironmentsResult");
   }
 }
 
@@ -2307,7 +2310,7 @@ export interface ListBranchesRequest {
 
 export namespace ListBranchesRequest {
   export function isa(o: any): o is ListBranchesRequest {
-    return _smithy.isa(o, "ListBranchesRequest");
+    return __isa(o, "ListBranchesRequest");
   }
 }
 
@@ -2336,7 +2339,7 @@ export interface ListBranchesResult extends $MetadataBearer {
 
 export namespace ListBranchesResult {
   export function isa(o: any): o is ListBranchesResult {
-    return _smithy.isa(o, "ListBranchesResult");
+    return __isa(o, "ListBranchesResult");
   }
 }
 
@@ -2373,7 +2376,7 @@ export interface ListDomainAssociationsRequest {
 
 export namespace ListDomainAssociationsRequest {
   export function isa(o: any): o is ListDomainAssociationsRequest {
-    return _smithy.isa(o, "ListDomainAssociationsRequest");
+    return __isa(o, "ListDomainAssociationsRequest");
   }
 }
 
@@ -2402,7 +2405,7 @@ export interface ListDomainAssociationsResult extends $MetadataBearer {
 
 export namespace ListDomainAssociationsResult {
   export function isa(o: any): o is ListDomainAssociationsResult {
-    return _smithy.isa(o, "ListDomainAssociationsResult");
+    return __isa(o, "ListDomainAssociationsResult");
   }
 }
 
@@ -2446,7 +2449,7 @@ export interface ListJobsRequest {
 
 export namespace ListJobsRequest {
   export function isa(o: any): o is ListJobsRequest {
-    return _smithy.isa(o, "ListJobsRequest");
+    return __isa(o, "ListJobsRequest");
   }
 }
 
@@ -2475,7 +2478,7 @@ export interface ListJobsResult extends $MetadataBearer {
 
 export namespace ListJobsResult {
   export function isa(o: any): o is ListJobsResult {
-    return _smithy.isa(o, "ListJobsResult");
+    return __isa(o, "ListJobsResult");
   }
 }
 
@@ -2496,7 +2499,7 @@ export interface ListTagsForResourceRequest {
 
 export namespace ListTagsForResourceRequest {
   export function isa(o: any): o is ListTagsForResourceRequest {
-    return _smithy.isa(o, "ListTagsForResourceRequest");
+    return __isa(o, "ListTagsForResourceRequest");
   }
 }
 
@@ -2517,7 +2520,7 @@ export interface ListTagsForResourceResponse extends $MetadataBearer {
 
 export namespace ListTagsForResourceResponse {
   export function isa(o: any): o is ListTagsForResourceResponse {
-    return _smithy.isa(o, "ListTagsForResourceResponse");
+    return __isa(o, "ListTagsForResourceResponse");
   }
 }
 
@@ -2554,7 +2557,7 @@ export interface ListWebhooksRequest {
 
 export namespace ListWebhooksRequest {
   export function isa(o: any): o is ListWebhooksRequest {
-    return _smithy.isa(o, "ListWebhooksRequest");
+    return __isa(o, "ListWebhooksRequest");
   }
 }
 
@@ -2583,7 +2586,7 @@ export interface ListWebhooksResult extends $MetadataBearer {
 
 export namespace ListWebhooksResult {
   export function isa(o: any): o is ListWebhooksResult {
-    return _smithy.isa(o, "ListWebhooksResult");
+    return __isa(o, "ListWebhooksResult");
   }
 }
 
@@ -2592,9 +2595,7 @@ export namespace ListWebhooksResult {
  *             Exception thrown when an entity has not been found during an operation.
  *         </p>
  */
-export interface NotFoundException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface NotFoundException extends __SmithyException, $MetadataBearer {
   name: "NotFoundException";
   $fault: "client";
   message?: string;
@@ -2602,7 +2603,7 @@ export interface NotFoundException
 
 export namespace NotFoundException {
   export function isa(o: any): o is NotFoundException {
-    return _smithy.isa(o, "NotFoundException");
+    return __isa(o, "NotFoundException");
   }
 }
 
@@ -2648,7 +2649,7 @@ export interface ProductionBranch {
 
 export namespace ProductionBranch {
   export function isa(o: any): o is ProductionBranch {
-    return _smithy.isa(o, "ProductionBranch");
+    return __isa(o, "ProductionBranch");
   }
 }
 
@@ -2658,7 +2659,7 @@ export namespace ProductionBranch {
  *         </p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -2668,7 +2669,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -2719,7 +2720,7 @@ export interface StartDeploymentRequest {
 
 export namespace StartDeploymentRequest {
   export function isa(o: any): o is StartDeploymentRequest {
-    return _smithy.isa(o, "StartDeploymentRequest");
+    return __isa(o, "StartDeploymentRequest");
   }
 }
 
@@ -2740,7 +2741,7 @@ export interface StartDeploymentResult extends $MetadataBearer {
 
 export namespace StartDeploymentResult {
   export function isa(o: any): o is StartDeploymentResult {
-    return _smithy.isa(o, "StartDeploymentResult");
+    return __isa(o, "StartDeploymentResult");
   }
 }
 
@@ -2812,7 +2813,7 @@ export interface StartJobRequest {
 
 export namespace StartJobRequest {
   export function isa(o: any): o is StartJobRequest {
-    return _smithy.isa(o, "StartJobRequest");
+    return __isa(o, "StartJobRequest");
   }
 }
 
@@ -2833,7 +2834,7 @@ export interface StartJobResult extends $MetadataBearer {
 
 export namespace StartJobResult {
   export function isa(o: any): o is StartJobResult {
-    return _smithy.isa(o, "StartJobResult");
+    return __isa(o, "StartJobResult");
   }
 }
 
@@ -2924,7 +2925,7 @@ export interface Step {
 
 export namespace Step {
   export function isa(o: any): o is Step {
-    return _smithy.isa(o, "Step");
+    return __isa(o, "Step");
   }
 }
 
@@ -2959,7 +2960,7 @@ export interface StopJobRequest {
 
 export namespace StopJobRequest {
   export function isa(o: any): o is StopJobRequest {
-    return _smithy.isa(o, "StopJobRequest");
+    return __isa(o, "StopJobRequest");
   }
 }
 
@@ -2980,7 +2981,7 @@ export interface StopJobResult extends $MetadataBearer {
 
 export namespace StopJobResult {
   export function isa(o: any): o is StopJobResult {
-    return _smithy.isa(o, "StopJobResult");
+    return __isa(o, "StopJobResult");
   }
 }
 
@@ -3015,7 +3016,7 @@ export interface SubDomain {
 
 export namespace SubDomain {
   export function isa(o: any): o is SubDomain {
-    return _smithy.isa(o, "SubDomain");
+    return __isa(o, "SubDomain");
   }
 }
 
@@ -3043,7 +3044,7 @@ export interface SubDomainSetting {
 
 export namespace SubDomainSetting {
   export function isa(o: any): o is SubDomainSetting {
-    return _smithy.isa(o, "SubDomainSetting");
+    return __isa(o, "SubDomainSetting");
   }
 }
 
@@ -3071,7 +3072,7 @@ export interface TagResourceRequest {
 
 export namespace TagResourceRequest {
   export function isa(o: any): o is TagResourceRequest {
-    return _smithy.isa(o, "TagResourceRequest");
+    return __isa(o, "TagResourceRequest");
   }
 }
 
@@ -3086,7 +3087,7 @@ export interface TagResourceResponse extends $MetadataBearer {
 
 export namespace TagResourceResponse {
   export function isa(o: any): o is TagResourceResponse {
-    return _smithy.isa(o, "TagResourceResponse");
+    return __isa(o, "TagResourceResponse");
   }
 }
 
@@ -3096,7 +3097,7 @@ export namespace TagResourceResponse {
  *         </p>
  */
 export interface UnauthorizedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UnauthorizedException";
   $fault: "client";
@@ -3105,7 +3106,7 @@ export interface UnauthorizedException
 
 export namespace UnauthorizedException {
   export function isa(o: any): o is UnauthorizedException {
-    return _smithy.isa(o, "UnauthorizedException");
+    return __isa(o, "UnauthorizedException");
   }
 }
 
@@ -3133,7 +3134,7 @@ export interface UntagResourceRequest {
 
 export namespace UntagResourceRequest {
   export function isa(o: any): o is UntagResourceRequest {
-    return _smithy.isa(o, "UntagResourceRequest");
+    return __isa(o, "UntagResourceRequest");
   }
 }
 
@@ -3148,7 +3149,7 @@ export interface UntagResourceResponse extends $MetadataBearer {
 
 export namespace UntagResourceResponse {
   export function isa(o: any): o is UntagResourceResponse {
-    return _smithy.isa(o, "UntagResourceResponse");
+    return __isa(o, "UntagResourceResponse");
   }
 }
 
@@ -3283,7 +3284,7 @@ export interface UpdateAppRequest {
 
 export namespace UpdateAppRequest {
   export function isa(o: any): o is UpdateAppRequest {
-    return _smithy.isa(o, "UpdateAppRequest");
+    return __isa(o, "UpdateAppRequest");
   }
 }
 
@@ -3304,7 +3305,7 @@ export interface UpdateAppResult extends $MetadataBearer {
 
 export namespace UpdateAppResult {
   export function isa(o: any): o is UpdateAppResult {
-    return _smithy.isa(o, "UpdateAppResult");
+    return __isa(o, "UpdateAppResult");
   }
 }
 
@@ -3430,7 +3431,7 @@ export interface UpdateBranchRequest {
 
 export namespace UpdateBranchRequest {
   export function isa(o: any): o is UpdateBranchRequest {
-    return _smithy.isa(o, "UpdateBranchRequest");
+    return __isa(o, "UpdateBranchRequest");
   }
 }
 
@@ -3451,7 +3452,7 @@ export interface UpdateBranchResult extends $MetadataBearer {
 
 export namespace UpdateBranchResult {
   export function isa(o: any): o is UpdateBranchResult {
-    return _smithy.isa(o, "UpdateBranchResult");
+    return __isa(o, "UpdateBranchResult");
   }
 }
 
@@ -3493,7 +3494,7 @@ export interface UpdateDomainAssociationRequest {
 
 export namespace UpdateDomainAssociationRequest {
   export function isa(o: any): o is UpdateDomainAssociationRequest {
-    return _smithy.isa(o, "UpdateDomainAssociationRequest");
+    return __isa(o, "UpdateDomainAssociationRequest");
   }
 }
 
@@ -3514,7 +3515,7 @@ export interface UpdateDomainAssociationResult extends $MetadataBearer {
 
 export namespace UpdateDomainAssociationResult {
   export function isa(o: any): o is UpdateDomainAssociationResult {
-    return _smithy.isa(o, "UpdateDomainAssociationResult");
+    return __isa(o, "UpdateDomainAssociationResult");
   }
 }
 
@@ -3549,7 +3550,7 @@ export interface UpdateWebhookRequest {
 
 export namespace UpdateWebhookRequest {
   export function isa(o: any): o is UpdateWebhookRequest {
-    return _smithy.isa(o, "UpdateWebhookRequest");
+    return __isa(o, "UpdateWebhookRequest");
   }
 }
 
@@ -3570,7 +3571,7 @@ export interface UpdateWebhookResult extends $MetadataBearer {
 
 export namespace UpdateWebhookResult {
   export function isa(o: any): o is UpdateWebhookResult {
-    return _smithy.isa(o, "UpdateWebhookResult");
+    return __isa(o, "UpdateWebhookResult");
   }
 }
 
@@ -3633,6 +3634,6 @@ export interface Webhook {
 
 export namespace Webhook {
   export function isa(o: any): o is Webhook {
-    return _smithy.isa(o, "Webhook");
+    return __isa(o, "Webhook");
   }
 }

--- a/clients/client-amplify/protocols/Aws_restJson1_1.ts
+++ b/clients/client-amplify/protocols/Aws_restJson1_1.ts
@@ -173,7 +173,10 @@ import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  extendedEncodeURIComponent as __extendedEncodeURIComponent
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -278,13 +281,13 @@ export async function serializeAws_restJson1_1CreateBackendEnvironmentCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/apps/{appId}/backendenvironments";
   if (input.appId !== undefined) {
-    const labelValue: string = input.appId.toString();
+    const labelValue: string = input.appId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: appId.");
     }
     resolvedPath = resolvedPath.replace(
       "{appId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: appId.");
@@ -319,13 +322,13 @@ export async function serializeAws_restJson1_1CreateBranchCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/apps/{appId}/branches";
   if (input.appId !== undefined) {
-    const labelValue: string = input.appId.toString();
+    const labelValue: string = input.appId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: appId.");
     }
     resolvedPath = resolvedPath.replace(
       "{appId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: appId.");
@@ -404,25 +407,25 @@ export async function serializeAws_restJson1_1CreateDeploymentCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/apps/{appId}/branches/{branchName}/deployments";
   if (input.appId !== undefined) {
-    const labelValue: string = input.appId.toString();
+    const labelValue: string = input.appId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: appId.");
     }
     resolvedPath = resolvedPath.replace(
       "{appId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: appId.");
   }
   if (input.branchName !== undefined) {
-    const labelValue: string = input.branchName.toString();
+    const labelValue: string = input.branchName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: branchName.");
     }
     resolvedPath = resolvedPath.replace(
       "{branchName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: branchName.");
@@ -454,13 +457,13 @@ export async function serializeAws_restJson1_1CreateDomainAssociationCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/apps/{appId}/domains";
   if (input.appId !== undefined) {
-    const labelValue: string = input.appId.toString();
+    const labelValue: string = input.appId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: appId.");
     }
     resolvedPath = resolvedPath.replace(
       "{appId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: appId.");
@@ -498,13 +501,13 @@ export async function serializeAws_restJson1_1CreateWebhookCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/apps/{appId}/webhooks";
   if (input.appId !== undefined) {
-    const labelValue: string = input.appId.toString();
+    const labelValue: string = input.appId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: appId.");
     }
     resolvedPath = resolvedPath.replace(
       "{appId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: appId.");
@@ -536,13 +539,13 @@ export async function serializeAws_restJson1_1DeleteAppCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/apps/{appId}";
   if (input.appId !== undefined) {
-    const labelValue: string = input.appId.toString();
+    const labelValue: string = input.appId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: appId.");
     }
     resolvedPath = resolvedPath.replace(
       "{appId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: appId.");
@@ -564,19 +567,19 @@ export async function serializeAws_restJson1_1DeleteBackendEnvironmentCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/apps/{appId}/backendenvironments/{environmentName}";
   if (input.appId !== undefined) {
-    const labelValue: string = input.appId.toString();
+    const labelValue: string = input.appId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: appId.");
     }
     resolvedPath = resolvedPath.replace(
       "{appId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: appId.");
   }
   if (input.environmentName !== undefined) {
-    const labelValue: string = input.environmentName.toString();
+    const labelValue: string = input.environmentName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: environmentName."
@@ -584,7 +587,7 @@ export async function serializeAws_restJson1_1DeleteBackendEnvironmentCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{environmentName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: environmentName.");
@@ -606,25 +609,25 @@ export async function serializeAws_restJson1_1DeleteBranchCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/apps/{appId}/branches/{branchName}";
   if (input.appId !== undefined) {
-    const labelValue: string = input.appId.toString();
+    const labelValue: string = input.appId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: appId.");
     }
     resolvedPath = resolvedPath.replace(
       "{appId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: appId.");
   }
   if (input.branchName !== undefined) {
-    const labelValue: string = input.branchName.toString();
+    const labelValue: string = input.branchName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: branchName.");
     }
     resolvedPath = resolvedPath.replace(
       "{branchName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: branchName.");
@@ -646,25 +649,25 @@ export async function serializeAws_restJson1_1DeleteDomainAssociationCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/apps/{appId}/domains/{domainName}";
   if (input.appId !== undefined) {
-    const labelValue: string = input.appId.toString();
+    const labelValue: string = input.appId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: appId.");
     }
     resolvedPath = resolvedPath.replace(
       "{appId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: appId.");
   }
   if (input.domainName !== undefined) {
-    const labelValue: string = input.domainName.toString();
+    const labelValue: string = input.domainName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: domainName.");
     }
     resolvedPath = resolvedPath.replace(
       "{domainName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: domainName.");
@@ -686,37 +689,37 @@ export async function serializeAws_restJson1_1DeleteJobCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/apps/{appId}/branches/{branchName}/jobs/{jobId}";
   if (input.appId !== undefined) {
-    const labelValue: string = input.appId.toString();
+    const labelValue: string = input.appId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: appId.");
     }
     resolvedPath = resolvedPath.replace(
       "{appId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: appId.");
   }
   if (input.branchName !== undefined) {
-    const labelValue: string = input.branchName.toString();
+    const labelValue: string = input.branchName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: branchName.");
     }
     resolvedPath = resolvedPath.replace(
       "{branchName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: branchName.");
   }
   if (input.jobId !== undefined) {
-    const labelValue: string = input.jobId.toString();
+    const labelValue: string = input.jobId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: jobId.");
     }
     resolvedPath = resolvedPath.replace(
       "{jobId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: jobId.");
@@ -738,13 +741,13 @@ export async function serializeAws_restJson1_1DeleteWebhookCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/webhooks/{webhookId}";
   if (input.webhookId !== undefined) {
-    const labelValue: string = input.webhookId.toString();
+    const labelValue: string = input.webhookId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: webhookId.");
     }
     resolvedPath = resolvedPath.replace(
       "{webhookId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: webhookId.");
@@ -766,13 +769,13 @@ export async function serializeAws_restJson1_1GenerateAccessLogsCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/apps/{appId}/accesslogs";
   if (input.appId !== undefined) {
-    const labelValue: string = input.appId.toString();
+    const labelValue: string = input.appId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: appId.");
     }
     resolvedPath = resolvedPath.replace(
       "{appId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: appId.");
@@ -807,13 +810,13 @@ export async function serializeAws_restJson1_1GetAppCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/apps/{appId}";
   if (input.appId !== undefined) {
-    const labelValue: string = input.appId.toString();
+    const labelValue: string = input.appId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: appId.");
     }
     resolvedPath = resolvedPath.replace(
       "{appId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: appId.");
@@ -835,13 +838,13 @@ export async function serializeAws_restJson1_1GetArtifactUrlCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/artifacts/{artifactId}";
   if (input.artifactId !== undefined) {
-    const labelValue: string = input.artifactId.toString();
+    const labelValue: string = input.artifactId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: artifactId.");
     }
     resolvedPath = resolvedPath.replace(
       "{artifactId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: artifactId.");
@@ -863,19 +866,19 @@ export async function serializeAws_restJson1_1GetBackendEnvironmentCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/apps/{appId}/backendenvironments/{environmentName}";
   if (input.appId !== undefined) {
-    const labelValue: string = input.appId.toString();
+    const labelValue: string = input.appId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: appId.");
     }
     resolvedPath = resolvedPath.replace(
       "{appId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: appId.");
   }
   if (input.environmentName !== undefined) {
-    const labelValue: string = input.environmentName.toString();
+    const labelValue: string = input.environmentName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: environmentName."
@@ -883,7 +886,7 @@ export async function serializeAws_restJson1_1GetBackendEnvironmentCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{environmentName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: environmentName.");
@@ -905,25 +908,25 @@ export async function serializeAws_restJson1_1GetBranchCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/apps/{appId}/branches/{branchName}";
   if (input.appId !== undefined) {
-    const labelValue: string = input.appId.toString();
+    const labelValue: string = input.appId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: appId.");
     }
     resolvedPath = resolvedPath.replace(
       "{appId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: appId.");
   }
   if (input.branchName !== undefined) {
-    const labelValue: string = input.branchName.toString();
+    const labelValue: string = input.branchName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: branchName.");
     }
     resolvedPath = resolvedPath.replace(
       "{branchName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: branchName.");
@@ -945,25 +948,25 @@ export async function serializeAws_restJson1_1GetDomainAssociationCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/apps/{appId}/domains/{domainName}";
   if (input.appId !== undefined) {
-    const labelValue: string = input.appId.toString();
+    const labelValue: string = input.appId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: appId.");
     }
     resolvedPath = resolvedPath.replace(
       "{appId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: appId.");
   }
   if (input.domainName !== undefined) {
-    const labelValue: string = input.domainName.toString();
+    const labelValue: string = input.domainName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: domainName.");
     }
     resolvedPath = resolvedPath.replace(
       "{domainName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: domainName.");
@@ -985,37 +988,37 @@ export async function serializeAws_restJson1_1GetJobCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/apps/{appId}/branches/{branchName}/jobs/{jobId}";
   if (input.appId !== undefined) {
-    const labelValue: string = input.appId.toString();
+    const labelValue: string = input.appId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: appId.");
     }
     resolvedPath = resolvedPath.replace(
       "{appId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: appId.");
   }
   if (input.branchName !== undefined) {
-    const labelValue: string = input.branchName.toString();
+    const labelValue: string = input.branchName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: branchName.");
     }
     resolvedPath = resolvedPath.replace(
       "{branchName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: branchName.");
   }
   if (input.jobId !== undefined) {
-    const labelValue: string = input.jobId.toString();
+    const labelValue: string = input.jobId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: jobId.");
     }
     resolvedPath = resolvedPath.replace(
       "{jobId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: jobId.");
@@ -1037,13 +1040,13 @@ export async function serializeAws_restJson1_1GetWebhookCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/webhooks/{webhookId}";
   if (input.webhookId !== undefined) {
-    const labelValue: string = input.webhookId.toString();
+    const labelValue: string = input.webhookId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: webhookId.");
     }
     resolvedPath = resolvedPath.replace(
       "{webhookId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: webhookId.");
@@ -1066,10 +1069,14 @@ export async function serializeAws_restJson1_1ListAppsCommand(
   let resolvedPath = "/apps";
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1090,47 +1097,51 @@ export async function serializeAws_restJson1_1ListArtifactsCommand(
   let resolvedPath =
     "/apps/{appId}/branches/{branchName}/jobs/{jobId}/artifacts";
   if (input.appId !== undefined) {
-    const labelValue: string = input.appId.toString();
+    const labelValue: string = input.appId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: appId.");
     }
     resolvedPath = resolvedPath.replace(
       "{appId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: appId.");
   }
   if (input.branchName !== undefined) {
-    const labelValue: string = input.branchName.toString();
+    const labelValue: string = input.branchName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: branchName.");
     }
     resolvedPath = resolvedPath.replace(
       "{branchName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: branchName.");
   }
   if (input.jobId !== undefined) {
-    const labelValue: string = input.jobId.toString();
+    const labelValue: string = input.jobId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: jobId.");
     }
     resolvedPath = resolvedPath.replace(
       "{jobId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: jobId.");
   }
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1150,23 +1161,27 @@ export async function serializeAws_restJson1_1ListBackendEnvironmentsCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/apps/{appId}/backendenvironments";
   if (input.appId !== undefined) {
-    const labelValue: string = input.appId.toString();
+    const labelValue: string = input.appId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: appId.");
     }
     resolvedPath = resolvedPath.replace(
       "{appId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: appId.");
   }
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   let body: any;
   const bodyParams: any = {};
@@ -1193,23 +1208,27 @@ export async function serializeAws_restJson1_1ListBranchesCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/apps/{appId}/branches";
   if (input.appId !== undefined) {
-    const labelValue: string = input.appId.toString();
+    const labelValue: string = input.appId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: appId.");
     }
     resolvedPath = resolvedPath.replace(
       "{appId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: appId.");
   }
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1229,23 +1248,27 @@ export async function serializeAws_restJson1_1ListDomainAssociationsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/apps/{appId}/domains";
   if (input.appId !== undefined) {
-    const labelValue: string = input.appId.toString();
+    const labelValue: string = input.appId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: appId.");
     }
     resolvedPath = resolvedPath.replace(
       "{appId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: appId.");
   }
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1265,35 +1288,39 @@ export async function serializeAws_restJson1_1ListJobsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/apps/{appId}/branches/{branchName}/jobs";
   if (input.appId !== undefined) {
-    const labelValue: string = input.appId.toString();
+    const labelValue: string = input.appId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: appId.");
     }
     resolvedPath = resolvedPath.replace(
       "{appId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: appId.");
   }
   if (input.branchName !== undefined) {
-    const labelValue: string = input.branchName.toString();
+    const labelValue: string = input.branchName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: branchName.");
     }
     resolvedPath = resolvedPath.replace(
       "{branchName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: branchName.");
   }
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1313,7 +1340,7 @@ export async function serializeAws_restJson1_1ListTagsForResourceCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/tags/{resourceArn}";
   if (input.resourceArn !== undefined) {
-    const labelValue: string = input.resourceArn.toString();
+    const labelValue: string = input.resourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: resourceArn."
@@ -1321,7 +1348,7 @@ export async function serializeAws_restJson1_1ListTagsForResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{resourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: resourceArn.");
@@ -1343,23 +1370,27 @@ export async function serializeAws_restJson1_1ListWebhooksCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/apps/{appId}/webhooks";
   if (input.appId !== undefined) {
-    const labelValue: string = input.appId.toString();
+    const labelValue: string = input.appId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: appId.");
     }
     resolvedPath = resolvedPath.replace(
       "{appId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: appId.");
   }
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1379,25 +1410,25 @@ export async function serializeAws_restJson1_1StartDeploymentCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/apps/{appId}/branches/{branchName}/deployments/start";
   if (input.appId !== undefined) {
-    const labelValue: string = input.appId.toString();
+    const labelValue: string = input.appId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: appId.");
     }
     resolvedPath = resolvedPath.replace(
       "{appId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: appId.");
   }
   if (input.branchName !== undefined) {
-    const labelValue: string = input.branchName.toString();
+    const labelValue: string = input.branchName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: branchName.");
     }
     resolvedPath = resolvedPath.replace(
       "{branchName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: branchName.");
@@ -1429,25 +1460,25 @@ export async function serializeAws_restJson1_1StartJobCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/apps/{appId}/branches/{branchName}/jobs";
   if (input.appId !== undefined) {
-    const labelValue: string = input.appId.toString();
+    const labelValue: string = input.appId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: appId.");
     }
     resolvedPath = resolvedPath.replace(
       "{appId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: appId.");
   }
   if (input.branchName !== undefined) {
-    const labelValue: string = input.branchName.toString();
+    const labelValue: string = input.branchName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: branchName.");
     }
     resolvedPath = resolvedPath.replace(
       "{branchName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: branchName.");
@@ -1491,37 +1522,37 @@ export async function serializeAws_restJson1_1StopJobCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/apps/{appId}/branches/{branchName}/jobs/{jobId}/stop";
   if (input.appId !== undefined) {
-    const labelValue: string = input.appId.toString();
+    const labelValue: string = input.appId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: appId.");
     }
     resolvedPath = resolvedPath.replace(
       "{appId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: appId.");
   }
   if (input.branchName !== undefined) {
-    const labelValue: string = input.branchName.toString();
+    const labelValue: string = input.branchName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: branchName.");
     }
     resolvedPath = resolvedPath.replace(
       "{branchName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: branchName.");
   }
   if (input.jobId !== undefined) {
-    const labelValue: string = input.jobId.toString();
+    const labelValue: string = input.jobId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: jobId.");
     }
     resolvedPath = resolvedPath.replace(
       "{jobId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: jobId.");
@@ -1543,7 +1574,7 @@ export async function serializeAws_restJson1_1TagResourceCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/tags/{resourceArn}";
   if (input.resourceArn !== undefined) {
-    const labelValue: string = input.resourceArn.toString();
+    const labelValue: string = input.resourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: resourceArn."
@@ -1551,7 +1582,7 @@ export async function serializeAws_restJson1_1TagResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{resourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: resourceArn.");
@@ -1580,7 +1611,7 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/tags/{resourceArn}";
   if (input.resourceArn !== undefined) {
-    const labelValue: string = input.resourceArn.toString();
+    const labelValue: string = input.resourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: resourceArn."
@@ -1588,14 +1619,16 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{resourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: resourceArn.");
   }
   const query: any = {};
   if (input.tagKeys !== undefined) {
-    query["tagKeys"] = input.tagKeys;
+    query[__extendedEncodeURIComponent("tagKeys")] = input.tagKeys.map(entry =>
+      __extendedEncodeURIComponent(entry)
+    );
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1615,13 +1648,13 @@ export async function serializeAws_restJson1_1UpdateAppCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/apps/{appId}";
   if (input.appId !== undefined) {
-    const labelValue: string = input.appId.toString();
+    const labelValue: string = input.appId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: appId.");
     }
     resolvedPath = resolvedPath.replace(
       "{appId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: appId.");
@@ -1713,25 +1746,25 @@ export async function serializeAws_restJson1_1UpdateBranchCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/apps/{appId}/branches/{branchName}";
   if (input.appId !== undefined) {
-    const labelValue: string = input.appId.toString();
+    const labelValue: string = input.appId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: appId.");
     }
     resolvedPath = resolvedPath.replace(
       "{appId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: appId.");
   }
   if (input.branchName !== undefined) {
-    const labelValue: string = input.branchName.toString();
+    const labelValue: string = input.branchName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: branchName.");
     }
     resolvedPath = resolvedPath.replace(
       "{branchName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: branchName.");
@@ -1804,25 +1837,25 @@ export async function serializeAws_restJson1_1UpdateDomainAssociationCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/apps/{appId}/domains/{domainName}";
   if (input.appId !== undefined) {
-    const labelValue: string = input.appId.toString();
+    const labelValue: string = input.appId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: appId.");
     }
     resolvedPath = resolvedPath.replace(
       "{appId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: appId.");
   }
   if (input.domainName !== undefined) {
-    const labelValue: string = input.domainName.toString();
+    const labelValue: string = input.domainName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: domainName.");
     }
     resolvedPath = resolvedPath.replace(
       "{domainName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: domainName.");
@@ -1857,13 +1890,13 @@ export async function serializeAws_restJson1_1UpdateWebhookCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/webhooks/{webhookId}";
   if (input.webhookId !== undefined) {
-    const labelValue: string = input.webhookId.toString();
+    const labelValue: string = input.webhookId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: webhookId.");
     }
     resolvedPath = resolvedPath.replace(
       "{webhookId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: webhookId.");
@@ -4442,6 +4475,7 @@ export async function deserializeAws_restJson1_1TagResourceCommand(
     $metadata: deserializeMetadata(output),
     __type: "TagResourceResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -4504,6 +4538,7 @@ export async function deserializeAws_restJson1_1UntagResourceCommand(
     $metadata: deserializeMetadata(output),
     __type: "UntagResourceResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 

--- a/clients/client-api-gateway/models/index.ts
+++ b/clients/client-api-gateway/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -19,7 +22,7 @@ export interface AccessLogSettings {
 
 export namespace AccessLogSettings {
   export function isa(o: any): o is AccessLogSettings {
-    return _smithy.isa(o, "AccessLogSettings");
+    return __isa(o, "AccessLogSettings");
   }
 }
 
@@ -99,7 +102,7 @@ export interface Account extends $MetadataBearer {
 
 export namespace Account {
   export function isa(o: any): o is Account {
-    return _smithy.isa(o, "Account");
+    return __isa(o, "Account");
   }
 }
 
@@ -164,7 +167,7 @@ export interface ApiKey extends $MetadataBearer {
 
 export namespace ApiKey {
   export function isa(o: any): o is ApiKey {
-    return _smithy.isa(o, "ApiKey");
+    return __isa(o, "ApiKey");
   }
 }
 
@@ -186,7 +189,7 @@ export interface ApiKeyIds extends $MetadataBearer {
 
 export namespace ApiKeyIds {
   export function isa(o: any): o is ApiKeyIds {
-    return _smithy.isa(o, "ApiKeyIds");
+    return __isa(o, "ApiKeyIds");
   }
 }
 
@@ -221,7 +224,7 @@ export interface ApiKeys extends $MetadataBearer {
 
 export namespace ApiKeys {
   export function isa(o: any): o is ApiKeys {
-    return _smithy.isa(o, "ApiKeys");
+    return __isa(o, "ApiKeys");
   }
 }
 
@@ -252,7 +255,7 @@ export interface ApiStage {
 
 export namespace ApiStage {
   export function isa(o: any): o is ApiStage {
-    return _smithy.isa(o, "ApiStage");
+    return __isa(o, "ApiStage");
   }
 }
 
@@ -318,7 +321,7 @@ export interface Authorizer extends $MetadataBearer {
 
 export namespace Authorizer {
   export function isa(o: any): o is Authorizer {
-    return _smithy.isa(o, "Authorizer");
+    return __isa(o, "Authorizer");
   }
 }
 
@@ -350,7 +353,7 @@ export interface Authorizers extends $MetadataBearer {
 
 export namespace Authorizers {
   export function isa(o: any): o is Authorizers {
-    return _smithy.isa(o, "Authorizers");
+    return __isa(o, "Authorizers");
   }
 }
 
@@ -381,7 +384,7 @@ export interface BasePathMapping extends $MetadataBearer {
 
 export namespace BasePathMapping {
   export function isa(o: any): o is BasePathMapping {
-    return _smithy.isa(o, "BasePathMapping");
+    return __isa(o, "BasePathMapping");
   }
 }
 
@@ -406,7 +409,7 @@ export interface BasePathMappings extends $MetadataBearer {
 
 export namespace BasePathMappings {
   export function isa(o: any): o is BasePathMappings {
-    return _smithy.isa(o, "BasePathMappings");
+    return __isa(o, "BasePathMappings");
   }
 }
 
@@ -457,7 +460,7 @@ export interface CanarySettings {
 
 export namespace CanarySettings {
   export function isa(o: any): o is CanarySettings {
-    return _smithy.isa(o, "CanarySettings");
+    return __isa(o, "CanarySettings");
   }
 }
 
@@ -503,7 +506,7 @@ export interface ClientCertificate extends $MetadataBearer {
 
 export namespace ClientCertificate {
   export function isa(o: any): o is ClientCertificate {
-    return _smithy.isa(o, "ClientCertificate");
+    return __isa(o, "ClientCertificate");
   }
 }
 
@@ -528,7 +531,7 @@ export interface ClientCertificates extends $MetadataBearer {
 
 export namespace ClientCertificates {
   export function isa(o: any): o is ClientCertificates {
-    return _smithy.isa(o, "ClientCertificates");
+    return __isa(o, "ClientCertificates");
   }
 }
 
@@ -593,7 +596,7 @@ export interface CreateApiKeyRequest {
 
 export namespace CreateApiKeyRequest {
   export function isa(o: any): o is CreateApiKeyRequest {
-    return _smithy.isa(o, "CreateApiKeyRequest");
+    return __isa(o, "CreateApiKeyRequest");
   }
 }
 
@@ -658,7 +661,7 @@ export interface CreateAuthorizerRequest {
 
 export namespace CreateAuthorizerRequest {
   export function isa(o: any): o is CreateAuthorizerRequest {
-    return _smithy.isa(o, "CreateAuthorizerRequest");
+    return __isa(o, "CreateAuthorizerRequest");
   }
 }
 
@@ -695,7 +698,7 @@ export interface CreateBasePathMappingRequest {
 
 export namespace CreateBasePathMappingRequest {
   export function isa(o: any): o is CreateBasePathMappingRequest {
-    return _smithy.isa(o, "CreateBasePathMappingRequest");
+    return __isa(o, "CreateBasePathMappingRequest");
   }
 }
 
@@ -758,7 +761,7 @@ export interface CreateDeploymentRequest {
 
 export namespace CreateDeploymentRequest {
   export function isa(o: any): o is CreateDeploymentRequest {
-    return _smithy.isa(o, "CreateDeploymentRequest");
+    return __isa(o, "CreateDeploymentRequest");
   }
 }
 
@@ -790,7 +793,7 @@ export interface CreateDocumentationPartRequest {
 
 export namespace CreateDocumentationPartRequest {
   export function isa(o: any): o is CreateDocumentationPartRequest {
-    return _smithy.isa(o, "CreateDocumentationPartRequest");
+    return __isa(o, "CreateDocumentationPartRequest");
   }
 }
 
@@ -827,7 +830,7 @@ export interface CreateDocumentationVersionRequest {
 
 export namespace CreateDocumentationVersionRequest {
   export function isa(o: any): o is CreateDocumentationVersionRequest {
-    return _smithy.isa(o, "CreateDocumentationVersionRequest");
+    return __isa(o, "CreateDocumentationVersionRequest");
   }
 }
 
@@ -899,7 +902,7 @@ export interface CreateDomainNameRequest {
 
 export namespace CreateDomainNameRequest {
   export function isa(o: any): o is CreateDomainNameRequest {
-    return _smithy.isa(o, "CreateDomainNameRequest");
+    return __isa(o, "CreateDomainNameRequest");
   }
 }
 
@@ -940,7 +943,7 @@ export interface CreateModelRequest {
 
 export namespace CreateModelRequest {
   export function isa(o: any): o is CreateModelRequest {
-    return _smithy.isa(o, "CreateModelRequest");
+    return __isa(o, "CreateModelRequest");
   }
 }
 
@@ -975,7 +978,7 @@ export interface CreateRequestValidatorRequest {
 
 export namespace CreateRequestValidatorRequest {
   export function isa(o: any): o is CreateRequestValidatorRequest {
-    return _smithy.isa(o, "CreateRequestValidatorRequest");
+    return __isa(o, "CreateRequestValidatorRequest");
   }
 }
 
@@ -1007,7 +1010,7 @@ export interface CreateResourceRequest {
 
 export namespace CreateResourceRequest {
   export function isa(o: any): o is CreateResourceRequest {
-    return _smithy.isa(o, "CreateResourceRequest");
+    return __isa(o, "CreateResourceRequest");
   }
 }
 
@@ -1072,7 +1075,7 @@ export interface CreateRestApiRequest {
 
 export namespace CreateRestApiRequest {
   export function isa(o: any): o is CreateRestApiRequest {
-    return _smithy.isa(o, "CreateRestApiRequest");
+    return __isa(o, "CreateRestApiRequest");
   }
 }
 
@@ -1145,7 +1148,7 @@ export interface CreateStageRequest {
 
 export namespace CreateStageRequest {
   export function isa(o: any): o is CreateStageRequest {
-    return _smithy.isa(o, "CreateStageRequest");
+    return __isa(o, "CreateStageRequest");
   }
 }
 
@@ -1176,7 +1179,7 @@ export interface CreateUsagePlanKeyRequest {
 
 export namespace CreateUsagePlanKeyRequest {
   export function isa(o: any): o is CreateUsagePlanKeyRequest {
-    return _smithy.isa(o, "CreateUsagePlanKeyRequest");
+    return __isa(o, "CreateUsagePlanKeyRequest");
   }
 }
 
@@ -1222,7 +1225,7 @@ export interface CreateUsagePlanRequest {
 
 export namespace CreateUsagePlanRequest {
   export function isa(o: any): o is CreateUsagePlanRequest {
-    return _smithy.isa(o, "CreateUsagePlanRequest");
+    return __isa(o, "CreateUsagePlanRequest");
   }
 }
 
@@ -1258,7 +1261,7 @@ export interface CreateVpcLinkRequest {
 
 export namespace CreateVpcLinkRequest {
   export function isa(o: any): o is CreateVpcLinkRequest {
-    return _smithy.isa(o, "CreateVpcLinkRequest");
+    return __isa(o, "CreateVpcLinkRequest");
   }
 }
 
@@ -1280,7 +1283,7 @@ export interface DeleteApiKeyRequest {
 
 export namespace DeleteApiKeyRequest {
   export function isa(o: any): o is DeleteApiKeyRequest {
-    return _smithy.isa(o, "DeleteApiKeyRequest");
+    return __isa(o, "DeleteApiKeyRequest");
   }
 }
 
@@ -1307,7 +1310,7 @@ export interface DeleteAuthorizerRequest {
 
 export namespace DeleteAuthorizerRequest {
   export function isa(o: any): o is DeleteAuthorizerRequest {
-    return _smithy.isa(o, "DeleteAuthorizerRequest");
+    return __isa(o, "DeleteAuthorizerRequest");
   }
 }
 
@@ -1335,7 +1338,7 @@ export interface DeleteBasePathMappingRequest {
 
 export namespace DeleteBasePathMappingRequest {
   export function isa(o: any): o is DeleteBasePathMappingRequest {
-    return _smithy.isa(o, "DeleteBasePathMappingRequest");
+    return __isa(o, "DeleteBasePathMappingRequest");
   }
 }
 
@@ -1357,7 +1360,7 @@ export interface DeleteClientCertificateRequest {
 
 export namespace DeleteClientCertificateRequest {
   export function isa(o: any): o is DeleteClientCertificateRequest {
-    return _smithy.isa(o, "DeleteClientCertificateRequest");
+    return __isa(o, "DeleteClientCertificateRequest");
   }
 }
 
@@ -1384,7 +1387,7 @@ export interface DeleteDeploymentRequest {
 
 export namespace DeleteDeploymentRequest {
   export function isa(o: any): o is DeleteDeploymentRequest {
-    return _smithy.isa(o, "DeleteDeploymentRequest");
+    return __isa(o, "DeleteDeploymentRequest");
   }
 }
 
@@ -1411,7 +1414,7 @@ export interface DeleteDocumentationPartRequest {
 
 export namespace DeleteDocumentationPartRequest {
   export function isa(o: any): o is DeleteDocumentationPartRequest {
-    return _smithy.isa(o, "DeleteDocumentationPartRequest");
+    return __isa(o, "DeleteDocumentationPartRequest");
   }
 }
 
@@ -1438,7 +1441,7 @@ export interface DeleteDocumentationVersionRequest {
 
 export namespace DeleteDocumentationVersionRequest {
   export function isa(o: any): o is DeleteDocumentationVersionRequest {
-    return _smithy.isa(o, "DeleteDocumentationVersionRequest");
+    return __isa(o, "DeleteDocumentationVersionRequest");
   }
 }
 
@@ -1460,7 +1463,7 @@ export interface DeleteDomainNameRequest {
 
 export namespace DeleteDomainNameRequest {
   export function isa(o: any): o is DeleteDomainNameRequest {
-    return _smithy.isa(o, "DeleteDomainNameRequest");
+    return __isa(o, "DeleteDomainNameRequest");
   }
 }
 
@@ -1487,7 +1490,7 @@ export interface DeleteGatewayResponseRequest {
 
 export namespace DeleteGatewayResponseRequest {
   export function isa(o: any): o is DeleteGatewayResponseRequest {
-    return _smithy.isa(o, "DeleteGatewayResponseRequest");
+    return __isa(o, "DeleteGatewayResponseRequest");
   }
 }
 
@@ -1519,7 +1522,7 @@ export interface DeleteIntegrationRequest {
 
 export namespace DeleteIntegrationRequest {
   export function isa(o: any): o is DeleteIntegrationRequest {
-    return _smithy.isa(o, "DeleteIntegrationRequest");
+    return __isa(o, "DeleteIntegrationRequest");
   }
 }
 
@@ -1556,7 +1559,7 @@ export interface DeleteIntegrationResponseRequest {
 
 export namespace DeleteIntegrationResponseRequest {
   export function isa(o: any): o is DeleteIntegrationResponseRequest {
-    return _smithy.isa(o, "DeleteIntegrationResponseRequest");
+    return __isa(o, "DeleteIntegrationResponseRequest");
   }
 }
 
@@ -1588,7 +1591,7 @@ export interface DeleteMethodRequest {
 
 export namespace DeleteMethodRequest {
   export function isa(o: any): o is DeleteMethodRequest {
-    return _smithy.isa(o, "DeleteMethodRequest");
+    return __isa(o, "DeleteMethodRequest");
   }
 }
 
@@ -1625,7 +1628,7 @@ export interface DeleteMethodResponseRequest {
 
 export namespace DeleteMethodResponseRequest {
   export function isa(o: any): o is DeleteMethodResponseRequest {
-    return _smithy.isa(o, "DeleteMethodResponseRequest");
+    return __isa(o, "DeleteMethodResponseRequest");
   }
 }
 
@@ -1652,7 +1655,7 @@ export interface DeleteModelRequest {
 
 export namespace DeleteModelRequest {
   export function isa(o: any): o is DeleteModelRequest {
-    return _smithy.isa(o, "DeleteModelRequest");
+    return __isa(o, "DeleteModelRequest");
   }
 }
 
@@ -1679,7 +1682,7 @@ export interface DeleteRequestValidatorRequest {
 
 export namespace DeleteRequestValidatorRequest {
   export function isa(o: any): o is DeleteRequestValidatorRequest {
-    return _smithy.isa(o, "DeleteRequestValidatorRequest");
+    return __isa(o, "DeleteRequestValidatorRequest");
   }
 }
 
@@ -1706,7 +1709,7 @@ export interface DeleteResourceRequest {
 
 export namespace DeleteResourceRequest {
   export function isa(o: any): o is DeleteResourceRequest {
-    return _smithy.isa(o, "DeleteResourceRequest");
+    return __isa(o, "DeleteResourceRequest");
   }
 }
 
@@ -1728,7 +1731,7 @@ export interface DeleteRestApiRequest {
 
 export namespace DeleteRestApiRequest {
   export function isa(o: any): o is DeleteRestApiRequest {
-    return _smithy.isa(o, "DeleteRestApiRequest");
+    return __isa(o, "DeleteRestApiRequest");
   }
 }
 
@@ -1755,7 +1758,7 @@ export interface DeleteStageRequest {
 
 export namespace DeleteStageRequest {
   export function isa(o: any): o is DeleteStageRequest {
-    return _smithy.isa(o, "DeleteStageRequest");
+    return __isa(o, "DeleteStageRequest");
   }
 }
 
@@ -1781,7 +1784,7 @@ export interface DeleteUsagePlanKeyRequest {
 
 export namespace DeleteUsagePlanKeyRequest {
   export function isa(o: any): o is DeleteUsagePlanKeyRequest {
-    return _smithy.isa(o, "DeleteUsagePlanKeyRequest");
+    return __isa(o, "DeleteUsagePlanKeyRequest");
   }
 }
 
@@ -1802,7 +1805,7 @@ export interface DeleteUsagePlanRequest {
 
 export namespace DeleteUsagePlanRequest {
   export function isa(o: any): o is DeleteUsagePlanRequest {
-    return _smithy.isa(o, "DeleteUsagePlanRequest");
+    return __isa(o, "DeleteUsagePlanRequest");
   }
 }
 
@@ -1823,7 +1826,7 @@ export interface DeleteVpcLinkRequest {
 
 export namespace DeleteVpcLinkRequest {
   export function isa(o: any): o is DeleteVpcLinkRequest {
-    return _smithy.isa(o, "DeleteVpcLinkRequest");
+    return __isa(o, "DeleteVpcLinkRequest");
   }
 }
 
@@ -1861,7 +1864,7 @@ export interface Deployment extends $MetadataBearer {
 
 export namespace Deployment {
   export function isa(o: any): o is Deployment {
-    return _smithy.isa(o, "Deployment");
+    return __isa(o, "Deployment");
   }
 }
 
@@ -1888,7 +1891,7 @@ export interface DeploymentCanarySettings {
 
 export namespace DeploymentCanarySettings {
   export function isa(o: any): o is DeploymentCanarySettings {
-    return _smithy.isa(o, "DeploymentCanarySettings");
+    return __isa(o, "DeploymentCanarySettings");
   }
 }
 
@@ -1917,7 +1920,7 @@ export interface Deployments extends $MetadataBearer {
 
 export namespace Deployments {
   export function isa(o: any): o is Deployments {
-    return _smithy.isa(o, "Deployments");
+    return __isa(o, "Deployments");
   }
 }
 
@@ -1950,7 +1953,7 @@ export interface DocumentationPart extends $MetadataBearer {
 
 export namespace DocumentationPart {
   export function isa(o: any): o is DocumentationPart {
-    return _smithy.isa(o, "DocumentationPart");
+    return __isa(o, "DocumentationPart");
   }
 }
 
@@ -1976,7 +1979,7 @@ export interface DocumentationPartIds extends $MetadataBearer {
 
 export namespace DocumentationPartIds {
   export function isa(o: any): o is DocumentationPartIds {
-    return _smithy.isa(o, "DocumentationPartIds");
+    return __isa(o, "DocumentationPartIds");
   }
 }
 
@@ -2013,7 +2016,7 @@ export interface DocumentationPartLocation {
 
 export namespace DocumentationPartLocation {
   export function isa(o: any): o is DocumentationPartLocation {
-    return _smithy.isa(o, "DocumentationPartLocation");
+    return __isa(o, "DocumentationPartLocation");
   }
 }
 
@@ -2054,7 +2057,7 @@ export interface DocumentationParts extends $MetadataBearer {
 
 export namespace DocumentationParts {
   export function isa(o: any): o is DocumentationParts {
-    return _smithy.isa(o, "DocumentationParts");
+    return __isa(o, "DocumentationParts");
   }
 }
 
@@ -2085,7 +2088,7 @@ export interface DocumentationVersion extends $MetadataBearer {
 
 export namespace DocumentationVersion {
   export function isa(o: any): o is DocumentationVersion {
-    return _smithy.isa(o, "DocumentationVersion");
+    return __isa(o, "DocumentationVersion");
   }
 }
 
@@ -2111,7 +2114,7 @@ export interface DocumentationVersions extends $MetadataBearer {
 
 export namespace DocumentationVersions {
   export function isa(o: any): o is DocumentationVersions {
-    return _smithy.isa(o, "DocumentationVersions");
+    return __isa(o, "DocumentationVersions");
   }
 }
 
@@ -2205,7 +2208,7 @@ export interface DomainName extends $MetadataBearer {
 
 export namespace DomainName {
   export function isa(o: any): o is DomainName {
-    return _smithy.isa(o, "DomainName");
+    return __isa(o, "DomainName");
   }
 }
 
@@ -2236,7 +2239,7 @@ export interface DomainNames extends $MetadataBearer {
 
 export namespace DomainNames {
   export function isa(o: any): o is DomainNames {
-    return _smithy.isa(o, "DomainNames");
+    return __isa(o, "DomainNames");
   }
 }
 
@@ -2258,7 +2261,7 @@ export interface EndpointConfiguration {
 
 export namespace EndpointConfiguration {
   export function isa(o: any): o is EndpointConfiguration {
-    return _smithy.isa(o, "EndpointConfiguration");
+    return __isa(o, "EndpointConfiguration");
   }
 }
 
@@ -2287,7 +2290,7 @@ export interface ExportResponse extends $MetadataBearer {
 
 export namespace ExportResponse {
   export function isa(o: any): o is ExportResponse {
-    return _smithy.isa(o, "ExportResponse");
+    return __isa(o, "ExportResponse");
   }
 }
 
@@ -2314,7 +2317,7 @@ export interface FlushStageAuthorizersCacheRequest {
 
 export namespace FlushStageAuthorizersCacheRequest {
   export function isa(o: any): o is FlushStageAuthorizersCacheRequest {
-    return _smithy.isa(o, "FlushStageAuthorizersCacheRequest");
+    return __isa(o, "FlushStageAuthorizersCacheRequest");
   }
 }
 
@@ -2341,7 +2344,7 @@ export interface FlushStageCacheRequest {
 
 export namespace FlushStageCacheRequest {
   export function isa(o: any): o is FlushStageCacheRequest {
-    return _smithy.isa(o, "FlushStageCacheRequest");
+    return __isa(o, "FlushStageCacheRequest");
   }
 }
 
@@ -2437,7 +2440,7 @@ export interface GatewayResponse extends $MetadataBearer {
 
 export namespace GatewayResponse {
   export function isa(o: any): o is GatewayResponse {
-    return _smithy.isa(o, "GatewayResponse");
+    return __isa(o, "GatewayResponse");
   }
 }
 
@@ -3010,7 +3013,7 @@ export interface GatewayResponses extends $MetadataBearer {
 
 export namespace GatewayResponses {
   export function isa(o: any): o is GatewayResponses {
-    return _smithy.isa(o, "GatewayResponses");
+    return __isa(o, "GatewayResponses");
   }
 }
 
@@ -3037,7 +3040,7 @@ export interface GenerateClientCertificateRequest {
 
 export namespace GenerateClientCertificateRequest {
   export function isa(o: any): o is GenerateClientCertificateRequest {
-    return _smithy.isa(o, "GenerateClientCertificateRequest");
+    return __isa(o, "GenerateClientCertificateRequest");
   }
 }
 
@@ -3054,7 +3057,7 @@ export interface GetAccountRequest {
 
 export namespace GetAccountRequest {
   export function isa(o: any): o is GetAccountRequest {
-    return _smithy.isa(o, "GetAccountRequest");
+    return __isa(o, "GetAccountRequest");
   }
 }
 
@@ -3081,7 +3084,7 @@ export interface GetApiKeyRequest {
 
 export namespace GetApiKeyRequest {
   export function isa(o: any): o is GetApiKeyRequest {
-    return _smithy.isa(o, "GetApiKeyRequest");
+    return __isa(o, "GetApiKeyRequest");
   }
 }
 
@@ -3123,7 +3126,7 @@ export interface GetApiKeysRequest {
 
 export namespace GetApiKeysRequest {
   export function isa(o: any): o is GetApiKeysRequest {
-    return _smithy.isa(o, "GetApiKeysRequest");
+    return __isa(o, "GetApiKeysRequest");
   }
 }
 
@@ -3150,7 +3153,7 @@ export interface GetAuthorizerRequest {
 
 export namespace GetAuthorizerRequest {
   export function isa(o: any): o is GetAuthorizerRequest {
-    return _smithy.isa(o, "GetAuthorizerRequest");
+    return __isa(o, "GetAuthorizerRequest");
   }
 }
 
@@ -3182,7 +3185,7 @@ export interface GetAuthorizersRequest {
 
 export namespace GetAuthorizersRequest {
   export function isa(o: any): o is GetAuthorizersRequest {
-    return _smithy.isa(o, "GetAuthorizersRequest");
+    return __isa(o, "GetAuthorizersRequest");
   }
 }
 
@@ -3209,7 +3212,7 @@ export interface GetBasePathMappingRequest {
 
 export namespace GetBasePathMappingRequest {
   export function isa(o: any): o is GetBasePathMappingRequest {
-    return _smithy.isa(o, "GetBasePathMappingRequest");
+    return __isa(o, "GetBasePathMappingRequest");
   }
 }
 
@@ -3241,7 +3244,7 @@ export interface GetBasePathMappingsRequest {
 
 export namespace GetBasePathMappingsRequest {
   export function isa(o: any): o is GetBasePathMappingsRequest {
-    return _smithy.isa(o, "GetBasePathMappingsRequest");
+    return __isa(o, "GetBasePathMappingsRequest");
   }
 }
 
@@ -3263,7 +3266,7 @@ export interface GetClientCertificateRequest {
 
 export namespace GetClientCertificateRequest {
   export function isa(o: any): o is GetClientCertificateRequest {
-    return _smithy.isa(o, "GetClientCertificateRequest");
+    return __isa(o, "GetClientCertificateRequest");
   }
 }
 
@@ -3290,7 +3293,7 @@ export interface GetClientCertificatesRequest {
 
 export namespace GetClientCertificatesRequest {
   export function isa(o: any): o is GetClientCertificatesRequest {
-    return _smithy.isa(o, "GetClientCertificatesRequest");
+    return __isa(o, "GetClientCertificatesRequest");
   }
 }
 
@@ -3322,7 +3325,7 @@ export interface GetDeploymentRequest {
 
 export namespace GetDeploymentRequest {
   export function isa(o: any): o is GetDeploymentRequest {
-    return _smithy.isa(o, "GetDeploymentRequest");
+    return __isa(o, "GetDeploymentRequest");
   }
 }
 
@@ -3354,7 +3357,7 @@ export interface GetDeploymentsRequest {
 
 export namespace GetDeploymentsRequest {
   export function isa(o: any): o is GetDeploymentsRequest {
-    return _smithy.isa(o, "GetDeploymentsRequest");
+    return __isa(o, "GetDeploymentsRequest");
   }
 }
 
@@ -3381,7 +3384,7 @@ export interface GetDocumentationPartRequest {
 
 export namespace GetDocumentationPartRequest {
   export function isa(o: any): o is GetDocumentationPartRequest {
-    return _smithy.isa(o, "GetDocumentationPartRequest");
+    return __isa(o, "GetDocumentationPartRequest");
   }
 }
 
@@ -3432,7 +3435,7 @@ export interface GetDocumentationPartsRequest {
 
 export namespace GetDocumentationPartsRequest {
   export function isa(o: any): o is GetDocumentationPartsRequest {
-    return _smithy.isa(o, "GetDocumentationPartsRequest");
+    return __isa(o, "GetDocumentationPartsRequest");
   }
 }
 
@@ -3459,7 +3462,7 @@ export interface GetDocumentationVersionRequest {
 
 export namespace GetDocumentationVersionRequest {
   export function isa(o: any): o is GetDocumentationVersionRequest {
-    return _smithy.isa(o, "GetDocumentationVersionRequest");
+    return __isa(o, "GetDocumentationVersionRequest");
   }
 }
 
@@ -3491,7 +3494,7 @@ export interface GetDocumentationVersionsRequest {
 
 export namespace GetDocumentationVersionsRequest {
   export function isa(o: any): o is GetDocumentationVersionsRequest {
-    return _smithy.isa(o, "GetDocumentationVersionsRequest");
+    return __isa(o, "GetDocumentationVersionsRequest");
   }
 }
 
@@ -3513,7 +3516,7 @@ export interface GetDomainNameRequest {
 
 export namespace GetDomainNameRequest {
   export function isa(o: any): o is GetDomainNameRequest {
-    return _smithy.isa(o, "GetDomainNameRequest");
+    return __isa(o, "GetDomainNameRequest");
   }
 }
 
@@ -3540,7 +3543,7 @@ export interface GetDomainNamesRequest {
 
 export namespace GetDomainNamesRequest {
   export function isa(o: any): o is GetDomainNamesRequest {
-    return _smithy.isa(o, "GetDomainNamesRequest");
+    return __isa(o, "GetDomainNamesRequest");
   }
 }
 
@@ -3577,7 +3580,7 @@ export interface GetExportRequest {
 
 export namespace GetExportRequest {
   export function isa(o: any): o is GetExportRequest {
-    return _smithy.isa(o, "GetExportRequest");
+    return __isa(o, "GetExportRequest");
   }
 }
 
@@ -3604,7 +3607,7 @@ export interface GetGatewayResponseRequest {
 
 export namespace GetGatewayResponseRequest {
   export function isa(o: any): o is GetGatewayResponseRequest {
-    return _smithy.isa(o, "GetGatewayResponseRequest");
+    return __isa(o, "GetGatewayResponseRequest");
   }
 }
 
@@ -3636,7 +3639,7 @@ export interface GetGatewayResponsesRequest {
 
 export namespace GetGatewayResponsesRequest {
   export function isa(o: any): o is GetGatewayResponsesRequest {
-    return _smithy.isa(o, "GetGatewayResponsesRequest");
+    return __isa(o, "GetGatewayResponsesRequest");
   }
 }
 
@@ -3668,7 +3671,7 @@ export interface GetIntegrationRequest {
 
 export namespace GetIntegrationRequest {
   export function isa(o: any): o is GetIntegrationRequest {
-    return _smithy.isa(o, "GetIntegrationRequest");
+    return __isa(o, "GetIntegrationRequest");
   }
 }
 
@@ -3705,7 +3708,7 @@ export interface GetIntegrationResponseRequest {
 
 export namespace GetIntegrationResponseRequest {
   export function isa(o: any): o is GetIntegrationResponseRequest {
-    return _smithy.isa(o, "GetIntegrationResponseRequest");
+    return __isa(o, "GetIntegrationResponseRequest");
   }
 }
 
@@ -3737,7 +3740,7 @@ export interface GetMethodRequest {
 
 export namespace GetMethodRequest {
   export function isa(o: any): o is GetMethodRequest {
-    return _smithy.isa(o, "GetMethodRequest");
+    return __isa(o, "GetMethodRequest");
   }
 }
 
@@ -3774,7 +3777,7 @@ export interface GetMethodResponseRequest {
 
 export namespace GetMethodResponseRequest {
   export function isa(o: any): o is GetMethodResponseRequest {
-    return _smithy.isa(o, "GetMethodResponseRequest");
+    return __isa(o, "GetMethodResponseRequest");
   }
 }
 
@@ -3806,7 +3809,7 @@ export interface GetModelRequest {
 
 export namespace GetModelRequest {
   export function isa(o: any): o is GetModelRequest {
-    return _smithy.isa(o, "GetModelRequest");
+    return __isa(o, "GetModelRequest");
   }
 }
 
@@ -3833,7 +3836,7 @@ export interface GetModelTemplateRequest {
 
 export namespace GetModelTemplateRequest {
   export function isa(o: any): o is GetModelTemplateRequest {
-    return _smithy.isa(o, "GetModelTemplateRequest");
+    return __isa(o, "GetModelTemplateRequest");
   }
 }
 
@@ -3865,7 +3868,7 @@ export interface GetModelsRequest {
 
 export namespace GetModelsRequest {
   export function isa(o: any): o is GetModelsRequest {
-    return _smithy.isa(o, "GetModelsRequest");
+    return __isa(o, "GetModelsRequest");
   }
 }
 
@@ -3892,7 +3895,7 @@ export interface GetRequestValidatorRequest {
 
 export namespace GetRequestValidatorRequest {
   export function isa(o: any): o is GetRequestValidatorRequest {
-    return _smithy.isa(o, "GetRequestValidatorRequest");
+    return __isa(o, "GetRequestValidatorRequest");
   }
 }
 
@@ -3924,7 +3927,7 @@ export interface GetRequestValidatorsRequest {
 
 export namespace GetRequestValidatorsRequest {
   export function isa(o: any): o is GetRequestValidatorsRequest {
-    return _smithy.isa(o, "GetRequestValidatorsRequest");
+    return __isa(o, "GetRequestValidatorsRequest");
   }
 }
 
@@ -3956,7 +3959,7 @@ export interface GetResourceRequest {
 
 export namespace GetResourceRequest {
   export function isa(o: any): o is GetResourceRequest {
-    return _smithy.isa(o, "GetResourceRequest");
+    return __isa(o, "GetResourceRequest");
   }
 }
 
@@ -3993,7 +3996,7 @@ export interface GetResourcesRequest {
 
 export namespace GetResourcesRequest {
   export function isa(o: any): o is GetResourcesRequest {
-    return _smithy.isa(o, "GetResourcesRequest");
+    return __isa(o, "GetResourcesRequest");
   }
 }
 
@@ -4015,7 +4018,7 @@ export interface GetRestApiRequest {
 
 export namespace GetRestApiRequest {
   export function isa(o: any): o is GetRestApiRequest {
-    return _smithy.isa(o, "GetRestApiRequest");
+    return __isa(o, "GetRestApiRequest");
   }
 }
 
@@ -4042,7 +4045,7 @@ export interface GetRestApisRequest {
 
 export namespace GetRestApisRequest {
   export function isa(o: any): o is GetRestApisRequest {
-    return _smithy.isa(o, "GetRestApisRequest");
+    return __isa(o, "GetRestApisRequest");
   }
 }
 
@@ -4074,7 +4077,7 @@ export interface GetSdkRequest {
 
 export namespace GetSdkRequest {
   export function isa(o: any): o is GetSdkRequest {
-    return _smithy.isa(o, "GetSdkRequest");
+    return __isa(o, "GetSdkRequest");
   }
 }
 
@@ -4096,7 +4099,7 @@ export interface GetSdkTypeRequest {
 
 export namespace GetSdkTypeRequest {
   export function isa(o: any): o is GetSdkTypeRequest {
-    return _smithy.isa(o, "GetSdkTypeRequest");
+    return __isa(o, "GetSdkTypeRequest");
   }
 }
 
@@ -4123,7 +4126,7 @@ export interface GetSdkTypesRequest {
 
 export namespace GetSdkTypesRequest {
   export function isa(o: any): o is GetSdkTypesRequest {
-    return _smithy.isa(o, "GetSdkTypesRequest");
+    return __isa(o, "GetSdkTypesRequest");
   }
 }
 
@@ -4150,7 +4153,7 @@ export interface GetStageRequest {
 
 export namespace GetStageRequest {
   export function isa(o: any): o is GetStageRequest {
-    return _smithy.isa(o, "GetStageRequest");
+    return __isa(o, "GetStageRequest");
   }
 }
 
@@ -4177,7 +4180,7 @@ export interface GetStagesRequest {
 
 export namespace GetStagesRequest {
   export function isa(o: any): o is GetStagesRequest {
-    return _smithy.isa(o, "GetStagesRequest");
+    return __isa(o, "GetStagesRequest");
   }
 }
 
@@ -4209,7 +4212,7 @@ export interface GetTagsRequest {
 
 export namespace GetTagsRequest {
   export function isa(o: any): o is GetTagsRequest {
-    return _smithy.isa(o, "GetTagsRequest");
+    return __isa(o, "GetTagsRequest");
   }
 }
 
@@ -4235,7 +4238,7 @@ export interface GetUsagePlanKeyRequest {
 
 export namespace GetUsagePlanKeyRequest {
   export function isa(o: any): o is GetUsagePlanKeyRequest {
-    return _smithy.isa(o, "GetUsagePlanKeyRequest");
+    return __isa(o, "GetUsagePlanKeyRequest");
   }
 }
 
@@ -4271,7 +4274,7 @@ export interface GetUsagePlanKeysRequest {
 
 export namespace GetUsagePlanKeysRequest {
   export function isa(o: any): o is GetUsagePlanKeysRequest {
-    return _smithy.isa(o, "GetUsagePlanKeysRequest");
+    return __isa(o, "GetUsagePlanKeysRequest");
   }
 }
 
@@ -4292,7 +4295,7 @@ export interface GetUsagePlanRequest {
 
 export namespace GetUsagePlanRequest {
   export function isa(o: any): o is GetUsagePlanRequest {
-    return _smithy.isa(o, "GetUsagePlanRequest");
+    return __isa(o, "GetUsagePlanRequest");
   }
 }
 
@@ -4324,7 +4327,7 @@ export interface GetUsagePlansRequest {
 
 export namespace GetUsagePlansRequest {
   export function isa(o: any): o is GetUsagePlansRequest {
-    return _smithy.isa(o, "GetUsagePlansRequest");
+    return __isa(o, "GetUsagePlansRequest");
   }
 }
 
@@ -4370,7 +4373,7 @@ export interface GetUsageRequest {
 
 export namespace GetUsageRequest {
   export function isa(o: any): o is GetUsageRequest {
-    return _smithy.isa(o, "GetUsageRequest");
+    return __isa(o, "GetUsageRequest");
   }
 }
 
@@ -4391,7 +4394,7 @@ export interface GetVpcLinkRequest {
 
 export namespace GetVpcLinkRequest {
   export function isa(o: any): o is GetVpcLinkRequest {
-    return _smithy.isa(o, "GetVpcLinkRequest");
+    return __isa(o, "GetVpcLinkRequest");
   }
 }
 
@@ -4418,7 +4421,7 @@ export interface GetVpcLinksRequest {
 
 export namespace GetVpcLinksRequest {
   export function isa(o: any): o is GetVpcLinksRequest {
-    return _smithy.isa(o, "GetVpcLinksRequest");
+    return __isa(o, "GetVpcLinksRequest");
   }
 }
 
@@ -4445,7 +4448,7 @@ export interface ImportApiKeysRequest {
 
 export namespace ImportApiKeysRequest {
   export function isa(o: any): o is ImportApiKeysRequest {
-    return _smithy.isa(o, "ImportApiKeysRequest");
+    return __isa(o, "ImportApiKeysRequest");
   }
 }
 
@@ -4477,7 +4480,7 @@ export interface ImportDocumentationPartsRequest {
 
 export namespace ImportDocumentationPartsRequest {
   export function isa(o: any): o is ImportDocumentationPartsRequest {
-    return _smithy.isa(o, "ImportDocumentationPartsRequest");
+    return __isa(o, "ImportDocumentationPartsRequest");
   }
 }
 
@@ -4512,7 +4515,7 @@ export interface ImportRestApiRequest {
 
 export namespace ImportRestApiRequest {
   export function isa(o: any): o is ImportRestApiRequest {
-    return _smithy.isa(o, "ImportRestApiRequest");
+    return __isa(o, "ImportRestApiRequest");
   }
 }
 
@@ -4683,7 +4686,7 @@ export interface Integration extends $MetadataBearer {
 
 export namespace Integration {
   export function isa(o: any): o is Integration {
-    return _smithy.isa(o, "Integration");
+    return __isa(o, "Integration");
   }
 }
 
@@ -4729,7 +4732,7 @@ export interface IntegrationResponse extends $MetadataBearer {
 
 export namespace IntegrationResponse {
   export function isa(o: any): o is IntegrationResponse {
-    return _smithy.isa(o, "IntegrationResponse");
+    return __isa(o, "IntegrationResponse");
   }
 }
 
@@ -5107,7 +5110,7 @@ export interface Method extends $MetadataBearer {
 
 export namespace Method {
   export function isa(o: any): o is Method {
-    return _smithy.isa(o, "Method");
+    return __isa(o, "Method");
   }
 }
 
@@ -5178,7 +5181,7 @@ export interface MethodResponse extends $MetadataBearer {
 
 export namespace MethodResponse {
   export function isa(o: any): o is MethodResponse {
-    return _smithy.isa(o, "MethodResponse");
+    return __isa(o, "MethodResponse");
   }
 }
 
@@ -5242,7 +5245,7 @@ export interface MethodSetting {
 
 export namespace MethodSetting {
   export function isa(o: any): o is MethodSetting {
-    return _smithy.isa(o, "MethodSetting");
+    return __isa(o, "MethodSetting");
   }
 }
 
@@ -5264,7 +5267,7 @@ export interface MethodSnapshot {
 
 export namespace MethodSnapshot {
   export function isa(o: any): o is MethodSnapshot {
-    return _smithy.isa(o, "MethodSnapshot");
+    return __isa(o, "MethodSnapshot");
   }
 }
 
@@ -5308,7 +5311,7 @@ export interface Model extends $MetadataBearer {
 
 export namespace Model {
   export function isa(o: any): o is Model {
-    return _smithy.isa(o, "Model");
+    return __isa(o, "Model");
   }
 }
 
@@ -5333,7 +5336,7 @@ export interface Models extends $MetadataBearer {
 
 export namespace Models {
   export function isa(o: any): o is Models {
-    return _smithy.isa(o, "Models");
+    return __isa(o, "Models");
   }
 }
 
@@ -5375,7 +5378,7 @@ export interface PutGatewayResponseRequest {
 
 export namespace PutGatewayResponseRequest {
   export function isa(o: any): o is PutGatewayResponseRequest {
-    return _smithy.isa(o, "PutGatewayResponseRequest");
+    return __isa(o, "PutGatewayResponseRequest");
   }
 }
 
@@ -5487,7 +5490,7 @@ export interface PutIntegrationRequest {
 
 export namespace PutIntegrationRequest {
   export function isa(o: any): o is PutIntegrationRequest {
-    return _smithy.isa(o, "PutIntegrationRequest");
+    return __isa(o, "PutIntegrationRequest");
   }
 }
 
@@ -5550,7 +5553,7 @@ export interface PutIntegrationResponseRequest {
 
 export namespace PutIntegrationResponseRequest {
   export function isa(o: any): o is PutIntegrationResponseRequest {
-    return _smithy.isa(o, "PutIntegrationResponseRequest");
+    return __isa(o, "PutIntegrationResponseRequest");
   }
 }
 
@@ -5622,7 +5625,7 @@ export interface PutMethodRequest {
 
 export namespace PutMethodRequest {
   export function isa(o: any): o is PutMethodRequest {
-    return _smithy.isa(o, "PutMethodRequest");
+    return __isa(o, "PutMethodRequest");
   }
 }
 
@@ -5669,7 +5672,7 @@ export interface PutMethodResponseRequest {
 
 export namespace PutMethodResponseRequest {
   export function isa(o: any): o is PutMethodResponseRequest {
-    return _smithy.isa(o, "PutMethodResponseRequest");
+    return __isa(o, "PutMethodResponseRequest");
   }
 }
 
@@ -5713,7 +5716,7 @@ export interface PutRestApiRequest {
 
 export namespace PutRestApiRequest {
   export function isa(o: any): o is PutRestApiRequest {
-    return _smithy.isa(o, "PutRestApiRequest");
+    return __isa(o, "PutRestApiRequest");
   }
 }
 
@@ -5746,7 +5749,7 @@ export interface QuotaSettings {
 
 export namespace QuotaSettings {
   export function isa(o: any): o is QuotaSettings {
-    return _smithy.isa(o, "QuotaSettings");
+    return __isa(o, "QuotaSettings");
   }
 }
 
@@ -5782,7 +5785,7 @@ export interface RequestValidator extends $MetadataBearer {
 
 export namespace RequestValidator {
   export function isa(o: any): o is RequestValidator {
-    return _smithy.isa(o, "RequestValidator");
+    return __isa(o, "RequestValidator");
   }
 }
 
@@ -5808,7 +5811,7 @@ export interface RequestValidators extends $MetadataBearer {
 
 export namespace RequestValidators {
   export function isa(o: any): o is RequestValidators {
-    return _smithy.isa(o, "RequestValidators");
+    return __isa(o, "RequestValidators");
   }
 }
 
@@ -6000,7 +6003,7 @@ export interface Resource extends $MetadataBearer {
 
 export namespace Resource {
   export function isa(o: any): o is Resource {
-    return _smithy.isa(o, "Resource");
+    return __isa(o, "Resource");
   }
 }
 
@@ -6025,7 +6028,7 @@ export interface Resources extends $MetadataBearer {
 
 export namespace Resources {
   export function isa(o: any): o is Resources {
-    return _smithy.isa(o, "Resources");
+    return __isa(o, "Resources");
   }
 }
 
@@ -6100,7 +6103,7 @@ export interface RestApi extends $MetadataBearer {
 
 export namespace RestApi {
   export function isa(o: any): o is RestApi {
-    return _smithy.isa(o, "RestApi");
+    return __isa(o, "RestApi");
   }
 }
 
@@ -6125,7 +6128,7 @@ export interface RestApis extends $MetadataBearer {
 
 export namespace RestApis {
   export function isa(o: any): o is RestApis {
-    return _smithy.isa(o, "RestApis");
+    return __isa(o, "RestApis");
   }
 }
 
@@ -6162,7 +6165,7 @@ export interface SdkConfigurationProperty {
 
 export namespace SdkConfigurationProperty {
   export function isa(o: any): o is SdkConfigurationProperty {
-    return _smithy.isa(o, "SdkConfigurationProperty");
+    return __isa(o, "SdkConfigurationProperty");
   }
 }
 
@@ -6189,7 +6192,7 @@ export interface SdkResponse extends $MetadataBearer {
 
 export namespace SdkResponse {
   export function isa(o: any): o is SdkResponse {
-    return _smithy.isa(o, "SdkResponse");
+    return __isa(o, "SdkResponse");
   }
 }
 
@@ -6221,7 +6224,7 @@ export interface SdkType extends $MetadataBearer {
 
 export namespace SdkType {
   export function isa(o: any): o is SdkType {
-    return _smithy.isa(o, "SdkType");
+    return __isa(o, "SdkType");
   }
 }
 
@@ -6238,7 +6241,7 @@ export interface SdkTypes extends $MetadataBearer {
 
 export namespace SdkTypes {
   export function isa(o: any): o is SdkTypes {
-    return _smithy.isa(o, "SdkTypes");
+    return __isa(o, "SdkTypes");
   }
 }
 
@@ -6341,7 +6344,7 @@ export interface Stage extends $MetadataBearer {
 
 export namespace Stage {
   export function isa(o: any): o is Stage {
-    return _smithy.isa(o, "Stage");
+    return __isa(o, "Stage");
   }
 }
 
@@ -6363,7 +6366,7 @@ export interface StageKey {
 
 export namespace StageKey {
   export function isa(o: any): o is StageKey {
-    return _smithy.isa(o, "StageKey");
+    return __isa(o, "StageKey");
   }
 }
 
@@ -6381,7 +6384,7 @@ export interface Stages extends $MetadataBearer {
 
 export namespace Stages {
   export function isa(o: any): o is Stages {
-    return _smithy.isa(o, "Stages");
+    return __isa(o, "Stages");
   }
 }
 
@@ -6408,7 +6411,7 @@ export interface TagResourceRequest {
 
 export namespace TagResourceRequest {
   export function isa(o: any): o is TagResourceRequest {
-    return _smithy.isa(o, "TagResourceRequest");
+    return __isa(o, "TagResourceRequest");
   }
 }
 
@@ -6425,7 +6428,7 @@ export interface Tags extends $MetadataBearer {
 
 export namespace Tags {
   export function isa(o: any): o is Tags {
-    return _smithy.isa(o, "Tags");
+    return __isa(o, "Tags");
   }
 }
 
@@ -6445,7 +6448,7 @@ export interface Template extends $MetadataBearer {
 
 export namespace Template {
   export function isa(o: any): o is Template {
-    return _smithy.isa(o, "Template");
+    return __isa(o, "Template");
   }
 }
 
@@ -6497,7 +6500,7 @@ export interface TestInvokeAuthorizerRequest {
 
 export namespace TestInvokeAuthorizerRequest {
   export function isa(o: any): o is TestInvokeAuthorizerRequest {
-    return _smithy.isa(o, "TestInvokeAuthorizerRequest");
+    return __isa(o, "TestInvokeAuthorizerRequest");
   }
 }
 
@@ -6540,7 +6543,7 @@ export interface TestInvokeAuthorizerResponse extends $MetadataBearer {
 
 export namespace TestInvokeAuthorizerResponse {
   export function isa(o: any): o is TestInvokeAuthorizerResponse {
-    return _smithy.isa(o, "TestInvokeAuthorizerResponse");
+    return __isa(o, "TestInvokeAuthorizerResponse");
   }
 }
 
@@ -6597,7 +6600,7 @@ export interface TestInvokeMethodRequest {
 
 export namespace TestInvokeMethodRequest {
   export function isa(o: any): o is TestInvokeMethodRequest {
-    return _smithy.isa(o, "TestInvokeMethodRequest");
+    return __isa(o, "TestInvokeMethodRequest");
   }
 }
 
@@ -6642,7 +6645,7 @@ export interface TestInvokeMethodResponse extends $MetadataBearer {
 
 export namespace TestInvokeMethodResponse {
   export function isa(o: any): o is TestInvokeMethodResponse {
-    return _smithy.isa(o, "TestInvokeMethodResponse");
+    return __isa(o, "TestInvokeMethodResponse");
   }
 }
 
@@ -6664,7 +6667,7 @@ export interface ThrottleSettings {
 
 export namespace ThrottleSettings {
   export function isa(o: any): o is ThrottleSettings {
-    return _smithy.isa(o, "ThrottleSettings");
+    return __isa(o, "ThrottleSettings");
   }
 }
 
@@ -6697,7 +6700,7 @@ export interface UntagResourceRequest {
 
 export namespace UntagResourceRequest {
   export function isa(o: any): o is UntagResourceRequest {
-    return _smithy.isa(o, "UntagResourceRequest");
+    return __isa(o, "UntagResourceRequest");
   }
 }
 
@@ -6719,7 +6722,7 @@ export interface UpdateAccountRequest {
 
 export namespace UpdateAccountRequest {
   export function isa(o: any): o is UpdateAccountRequest {
-    return _smithy.isa(o, "UpdateAccountRequest");
+    return __isa(o, "UpdateAccountRequest");
   }
 }
 
@@ -6746,7 +6749,7 @@ export interface UpdateApiKeyRequest {
 
 export namespace UpdateApiKeyRequest {
   export function isa(o: any): o is UpdateApiKeyRequest {
-    return _smithy.isa(o, "UpdateApiKeyRequest");
+    return __isa(o, "UpdateApiKeyRequest");
   }
 }
 
@@ -6778,7 +6781,7 @@ export interface UpdateAuthorizerRequest {
 
 export namespace UpdateAuthorizerRequest {
   export function isa(o: any): o is UpdateAuthorizerRequest {
-    return _smithy.isa(o, "UpdateAuthorizerRequest");
+    return __isa(o, "UpdateAuthorizerRequest");
   }
 }
 
@@ -6811,7 +6814,7 @@ export interface UpdateBasePathMappingRequest {
 
 export namespace UpdateBasePathMappingRequest {
   export function isa(o: any): o is UpdateBasePathMappingRequest {
-    return _smithy.isa(o, "UpdateBasePathMappingRequest");
+    return __isa(o, "UpdateBasePathMappingRequest");
   }
 }
 
@@ -6838,7 +6841,7 @@ export interface UpdateClientCertificateRequest {
 
 export namespace UpdateClientCertificateRequest {
   export function isa(o: any): o is UpdateClientCertificateRequest {
-    return _smithy.isa(o, "UpdateClientCertificateRequest");
+    return __isa(o, "UpdateClientCertificateRequest");
   }
 }
 
@@ -6870,7 +6873,7 @@ export interface UpdateDeploymentRequest {
 
 export namespace UpdateDeploymentRequest {
   export function isa(o: any): o is UpdateDeploymentRequest {
-    return _smithy.isa(o, "UpdateDeploymentRequest");
+    return __isa(o, "UpdateDeploymentRequest");
   }
 }
 
@@ -6902,7 +6905,7 @@ export interface UpdateDocumentationPartRequest {
 
 export namespace UpdateDocumentationPartRequest {
   export function isa(o: any): o is UpdateDocumentationPartRequest {
-    return _smithy.isa(o, "UpdateDocumentationPartRequest");
+    return __isa(o, "UpdateDocumentationPartRequest");
   }
 }
 
@@ -6934,7 +6937,7 @@ export interface UpdateDocumentationVersionRequest {
 
 export namespace UpdateDocumentationVersionRequest {
   export function isa(o: any): o is UpdateDocumentationVersionRequest {
-    return _smithy.isa(o, "UpdateDocumentationVersionRequest");
+    return __isa(o, "UpdateDocumentationVersionRequest");
   }
 }
 
@@ -6961,7 +6964,7 @@ export interface UpdateDomainNameRequest {
 
 export namespace UpdateDomainNameRequest {
   export function isa(o: any): o is UpdateDomainNameRequest {
-    return _smithy.isa(o, "UpdateDomainNameRequest");
+    return __isa(o, "UpdateDomainNameRequest");
   }
 }
 
@@ -6993,7 +6996,7 @@ export interface UpdateGatewayResponseRequest {
 
 export namespace UpdateGatewayResponseRequest {
   export function isa(o: any): o is UpdateGatewayResponseRequest {
-    return _smithy.isa(o, "UpdateGatewayResponseRequest");
+    return __isa(o, "UpdateGatewayResponseRequest");
   }
 }
 
@@ -7030,7 +7033,7 @@ export interface UpdateIntegrationRequest {
 
 export namespace UpdateIntegrationRequest {
   export function isa(o: any): o is UpdateIntegrationRequest {
-    return _smithy.isa(o, "UpdateIntegrationRequest");
+    return __isa(o, "UpdateIntegrationRequest");
   }
 }
 
@@ -7072,7 +7075,7 @@ export interface UpdateIntegrationResponseRequest {
 
 export namespace UpdateIntegrationResponseRequest {
   export function isa(o: any): o is UpdateIntegrationResponseRequest {
-    return _smithy.isa(o, "UpdateIntegrationResponseRequest");
+    return __isa(o, "UpdateIntegrationResponseRequest");
   }
 }
 
@@ -7109,7 +7112,7 @@ export interface UpdateMethodRequest {
 
 export namespace UpdateMethodRequest {
   export function isa(o: any): o is UpdateMethodRequest {
-    return _smithy.isa(o, "UpdateMethodRequest");
+    return __isa(o, "UpdateMethodRequest");
   }
 }
 
@@ -7151,7 +7154,7 @@ export interface UpdateMethodResponseRequest {
 
 export namespace UpdateMethodResponseRequest {
   export function isa(o: any): o is UpdateMethodResponseRequest {
-    return _smithy.isa(o, "UpdateMethodResponseRequest");
+    return __isa(o, "UpdateMethodResponseRequest");
   }
 }
 
@@ -7183,7 +7186,7 @@ export interface UpdateModelRequest {
 
 export namespace UpdateModelRequest {
   export function isa(o: any): o is UpdateModelRequest {
-    return _smithy.isa(o, "UpdateModelRequest");
+    return __isa(o, "UpdateModelRequest");
   }
 }
 
@@ -7215,7 +7218,7 @@ export interface UpdateRequestValidatorRequest {
 
 export namespace UpdateRequestValidatorRequest {
   export function isa(o: any): o is UpdateRequestValidatorRequest {
-    return _smithy.isa(o, "UpdateRequestValidatorRequest");
+    return __isa(o, "UpdateRequestValidatorRequest");
   }
 }
 
@@ -7247,7 +7250,7 @@ export interface UpdateResourceRequest {
 
 export namespace UpdateResourceRequest {
   export function isa(o: any): o is UpdateResourceRequest {
-    return _smithy.isa(o, "UpdateResourceRequest");
+    return __isa(o, "UpdateResourceRequest");
   }
 }
 
@@ -7274,7 +7277,7 @@ export interface UpdateRestApiRequest {
 
 export namespace UpdateRestApiRequest {
   export function isa(o: any): o is UpdateRestApiRequest {
-    return _smithy.isa(o, "UpdateRestApiRequest");
+    return __isa(o, "UpdateRestApiRequest");
   }
 }
 
@@ -7306,7 +7309,7 @@ export interface UpdateStageRequest {
 
 export namespace UpdateStageRequest {
   export function isa(o: any): o is UpdateStageRequest {
-    return _smithy.isa(o, "UpdateStageRequest");
+    return __isa(o, "UpdateStageRequest");
   }
 }
 
@@ -7332,7 +7335,7 @@ export interface UpdateUsagePlanRequest {
 
 export namespace UpdateUsagePlanRequest {
   export function isa(o: any): o is UpdateUsagePlanRequest {
-    return _smithy.isa(o, "UpdateUsagePlanRequest");
+    return __isa(o, "UpdateUsagePlanRequest");
   }
 }
 
@@ -7363,7 +7366,7 @@ export interface UpdateUsageRequest {
 
 export namespace UpdateUsageRequest {
   export function isa(o: any): o is UpdateUsageRequest {
-    return _smithy.isa(o, "UpdateUsageRequest");
+    return __isa(o, "UpdateUsageRequest");
   }
 }
 
@@ -7389,7 +7392,7 @@ export interface UpdateVpcLinkRequest {
 
 export namespace UpdateVpcLinkRequest {
   export function isa(o: any): o is UpdateVpcLinkRequest {
-    return _smithy.isa(o, "UpdateVpcLinkRequest");
+    return __isa(o, "UpdateVpcLinkRequest");
   }
 }
 
@@ -7431,7 +7434,7 @@ export interface Usage extends $MetadataBearer {
 
 export namespace Usage {
   export function isa(o: any): o is Usage {
-    return _smithy.isa(o, "Usage");
+    return __isa(o, "Usage");
   }
 }
 
@@ -7489,7 +7492,7 @@ export interface UsagePlan extends $MetadataBearer {
 
 export namespace UsagePlan {
   export function isa(o: any): o is UsagePlan {
-    return _smithy.isa(o, "UsagePlan");
+    return __isa(o, "UsagePlan");
   }
 }
 
@@ -7527,7 +7530,7 @@ export interface UsagePlanKey extends $MetadataBearer {
 
 export namespace UsagePlanKey {
   export function isa(o: any): o is UsagePlanKey {
-    return _smithy.isa(o, "UsagePlanKey");
+    return __isa(o, "UsagePlanKey");
   }
 }
 
@@ -7552,7 +7555,7 @@ export interface UsagePlanKeys extends $MetadataBearer {
 
 export namespace UsagePlanKeys {
   export function isa(o: any): o is UsagePlanKeys {
-    return _smithy.isa(o, "UsagePlanKeys");
+    return __isa(o, "UsagePlanKeys");
   }
 }
 
@@ -7577,7 +7580,7 @@ export interface UsagePlans extends $MetadataBearer {
 
 export namespace UsagePlans {
   export function isa(o: any): o is UsagePlans {
-    return _smithy.isa(o, "UsagePlans");
+    return __isa(o, "UsagePlans");
   }
 }
 
@@ -7629,7 +7632,7 @@ export interface VpcLink extends $MetadataBearer {
 
 export namespace VpcLink {
   export function isa(o: any): o is VpcLink {
-    return _smithy.isa(o, "VpcLink");
+    return __isa(o, "VpcLink");
   }
 }
 
@@ -7664,7 +7667,7 @@ export interface VpcLinks extends $MetadataBearer {
 
 export namespace VpcLinks {
   export function isa(o: any): o is VpcLinks {
-    return _smithy.isa(o, "VpcLinks");
+    return __isa(o, "VpcLinks");
   }
 }
 
@@ -7699,7 +7702,7 @@ export interface PatchOperation {
 
 export namespace PatchOperation {
   export function isa(o: any): o is PatchOperation {
-    return _smithy.isa(o, "PatchOperation");
+    return __isa(o, "PatchOperation");
   }
 }
 
@@ -7707,7 +7710,7 @@ export namespace PatchOperation {
  * <p>The submitted request is not valid, for example, the input is incomplete or incorrect. See the accompanying error message for details.</p>
  */
 export interface BadRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "BadRequestException";
   $fault: "client";
@@ -7716,16 +7719,14 @@ export interface BadRequestException
 
 export namespace BadRequestException {
   export function isa(o: any): o is BadRequestException {
-    return _smithy.isa(o, "BadRequestException");
+    return __isa(o, "BadRequestException");
   }
 }
 
 /**
  * <p>The request configuration has conflicts. For details, see the accompanying error message.</p>
  */
-export interface ConflictException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface ConflictException extends __SmithyException, $MetadataBearer {
   name: "ConflictException";
   $fault: "client";
   message?: string;
@@ -7733,7 +7734,7 @@ export interface ConflictException
 
 export namespace ConflictException {
   export function isa(o: any): o is ConflictException {
-    return _smithy.isa(o, "ConflictException");
+    return __isa(o, "ConflictException");
   }
 }
 
@@ -7741,7 +7742,7 @@ export namespace ConflictException {
  * <p>The request exceeded the rate limit. Retry after the specified time period.</p>
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -7751,16 +7752,14 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
 /**
  * <p>The requested resource is not found. Make sure that the request URI is correct.</p>
  */
-export interface NotFoundException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface NotFoundException extends __SmithyException, $MetadataBearer {
   name: "NotFoundException";
   $fault: "client";
   message?: string;
@@ -7768,7 +7767,7 @@ export interface NotFoundException
 
 export namespace NotFoundException {
   export function isa(o: any): o is NotFoundException {
-    return _smithy.isa(o, "NotFoundException");
+    return __isa(o, "NotFoundException");
   }
 }
 
@@ -7776,7 +7775,7 @@ export namespace NotFoundException {
  * <p>The requested service is not available. For details see the accompanying error message. Retry after the specified time period.</p>
  */
 export interface ServiceUnavailableException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ServiceUnavailableException";
   $fault: "server";
@@ -7786,7 +7785,7 @@ export interface ServiceUnavailableException
 
 export namespace ServiceUnavailableException {
   export function isa(o: any): o is ServiceUnavailableException {
-    return _smithy.isa(o, "ServiceUnavailableException");
+    return __isa(o, "ServiceUnavailableException");
   }
 }
 
@@ -7794,7 +7793,7 @@ export namespace ServiceUnavailableException {
  * <p>The request has reached its throttling limit. Retry after the specified time period.</p>
  */
 export interface TooManyRequestsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyRequestsException";
   $fault: "client";
@@ -7804,7 +7803,7 @@ export interface TooManyRequestsException
 
 export namespace TooManyRequestsException {
   export function isa(o: any): o is TooManyRequestsException {
-    return _smithy.isa(o, "TooManyRequestsException");
+    return __isa(o, "TooManyRequestsException");
   }
 }
 
@@ -7812,7 +7811,7 @@ export namespace TooManyRequestsException {
  * <p>The request is denied because the caller has insufficient permissions.</p>
  */
 export interface UnauthorizedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UnauthorizedException";
   $fault: "client";
@@ -7821,6 +7820,6 @@ export interface UnauthorizedException
 
 export namespace UnauthorizedException {
   export function isa(o: any): o is UnauthorizedException {
-    return _smithy.isa(o, "UnauthorizedException");
+    return __isa(o, "UnauthorizedException");
   }
 }

--- a/clients/client-api-gateway/protocols/Aws_restJson1_1.ts
+++ b/clients/client-api-gateway/protocols/Aws_restJson1_1.ts
@@ -527,7 +527,10 @@ import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  extendedEncodeURIComponent as __extendedEncodeURIComponent
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -605,13 +608,13 @@ export async function serializeAws_restJson1_1CreateAuthorizerCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/restapis/{restApiId}/authorizers";
   if (input.restApiId !== undefined) {
-    const labelValue: string = input.restApiId.toString();
+    const labelValue: string = input.restApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: restApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{restApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: restApiId.");
@@ -681,13 +684,13 @@ export async function serializeAws_restJson1_1CreateBasePathMappingCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/domainnames/{domainName}/basepathmappings";
   if (input.domainName !== undefined) {
-    const labelValue: string = input.domainName.toString();
+    const labelValue: string = input.domainName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: domainName.");
     }
     resolvedPath = resolvedPath.replace(
       "{domainName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: domainName.");
@@ -737,13 +740,13 @@ export async function serializeAws_restJson1_1CreateDeploymentCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/restapis/{restApiId}/deployments";
   if (input.restApiId !== undefined) {
-    const labelValue: string = input.restApiId.toString();
+    const labelValue: string = input.restApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: restApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{restApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: restApiId.");
@@ -816,13 +819,13 @@ export async function serializeAws_restJson1_1CreateDocumentationPartCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/restapis/{restApiId}/documentation/parts";
   if (input.restApiId !== undefined) {
-    const labelValue: string = input.restApiId.toString();
+    const labelValue: string = input.restApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: restApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{restApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: restApiId.");
@@ -872,13 +875,13 @@ export async function serializeAws_restJson1_1CreateDocumentationVersionCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/restapis/{restApiId}/documentation/versions";
   if (input.restApiId !== undefined) {
-    const labelValue: string = input.restApiId.toString();
+    const labelValue: string = input.restApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: restApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{restApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: restApiId.");
@@ -1004,13 +1007,13 @@ export async function serializeAws_restJson1_1CreateModelCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/restapis/{restApiId}/models";
   if (input.restApiId !== undefined) {
-    const labelValue: string = input.restApiId.toString();
+    const labelValue: string = input.restApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: restApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{restApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: restApiId.");
@@ -1060,13 +1063,13 @@ export async function serializeAws_restJson1_1CreateRequestValidatorCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/restapis/{restApiId}/requestvalidators";
   if (input.restApiId !== undefined) {
-    const labelValue: string = input.restApiId.toString();
+    const labelValue: string = input.restApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: restApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{restApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: restApiId.");
@@ -1113,25 +1116,25 @@ export async function serializeAws_restJson1_1CreateResourceCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/restapis/{restApiId}/resources/{parentId}";
   if (input.parentId !== undefined) {
-    const labelValue: string = input.parentId.toString();
+    const labelValue: string = input.parentId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: parentId.");
     }
     resolvedPath = resolvedPath.replace(
       "{parentId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: parentId.");
   }
   if (input.restApiId !== undefined) {
-    const labelValue: string = input.restApiId.toString();
+    const labelValue: string = input.restApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: restApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{restApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: restApiId.");
@@ -1248,13 +1251,13 @@ export async function serializeAws_restJson1_1CreateStageCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/restapis/{restApiId}/stages";
   if (input.restApiId !== undefined) {
-    const labelValue: string = input.restApiId.toString();
+    const labelValue: string = input.restApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: restApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{restApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: restApiId.");
@@ -1396,7 +1399,7 @@ export async function serializeAws_restJson1_1CreateUsagePlanKeyCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/usageplans/{usagePlanId}/keys";
   if (input.usagePlanId !== undefined) {
-    const labelValue: string = input.usagePlanId.toString();
+    const labelValue: string = input.usagePlanId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: usagePlanId."
@@ -1404,7 +1407,7 @@ export async function serializeAws_restJson1_1CreateUsagePlanKeyCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{usagePlanId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: usagePlanId.");
@@ -1501,13 +1504,13 @@ export async function serializeAws_restJson1_1DeleteApiKeyCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/apikeys/{apiKey}";
   if (input.apiKey !== undefined) {
-    const labelValue: string = input.apiKey.toString();
+    const labelValue: string = input.apiKey;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: apiKey.");
     }
     resolvedPath = resolvedPath.replace(
       "{apiKey}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: apiKey.");
@@ -1548,7 +1551,7 @@ export async function serializeAws_restJson1_1DeleteAuthorizerCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/restapis/{restApiId}/authorizers/{authorizerId}";
   if (input.authorizerId !== undefined) {
-    const labelValue: string = input.authorizerId.toString();
+    const labelValue: string = input.authorizerId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: authorizerId."
@@ -1556,19 +1559,19 @@ export async function serializeAws_restJson1_1DeleteAuthorizerCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{authorizerId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: authorizerId.");
   }
   if (input.restApiId !== undefined) {
-    const labelValue: string = input.restApiId.toString();
+    const labelValue: string = input.restApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: restApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{restApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: restApiId.");
@@ -1609,25 +1612,25 @@ export async function serializeAws_restJson1_1DeleteBasePathMappingCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/domainnames/{domainName}/basepathmappings/{basePath}";
   if (input.basePath !== undefined) {
-    const labelValue: string = input.basePath.toString();
+    const labelValue: string = input.basePath;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: basePath.");
     }
     resolvedPath = resolvedPath.replace(
       "{basePath}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: basePath.");
   }
   if (input.domainName !== undefined) {
-    const labelValue: string = input.domainName.toString();
+    const labelValue: string = input.domainName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: domainName.");
     }
     resolvedPath = resolvedPath.replace(
       "{domainName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: domainName.");
@@ -1668,7 +1671,7 @@ export async function serializeAws_restJson1_1DeleteClientCertificateCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/clientcertificates/{clientCertificateId}";
   if (input.clientCertificateId !== undefined) {
-    const labelValue: string = input.clientCertificateId.toString();
+    const labelValue: string = input.clientCertificateId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: clientCertificateId."
@@ -1676,7 +1679,7 @@ export async function serializeAws_restJson1_1DeleteClientCertificateCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{clientCertificateId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -1719,7 +1722,7 @@ export async function serializeAws_restJson1_1DeleteDeploymentCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/restapis/{restApiId}/deployments/{deploymentId}";
   if (input.deploymentId !== undefined) {
-    const labelValue: string = input.deploymentId.toString();
+    const labelValue: string = input.deploymentId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: deploymentId."
@@ -1727,19 +1730,19 @@ export async function serializeAws_restJson1_1DeleteDeploymentCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{deploymentId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: deploymentId.");
   }
   if (input.restApiId !== undefined) {
-    const labelValue: string = input.restApiId.toString();
+    const labelValue: string = input.restApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: restApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{restApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: restApiId.");
@@ -1781,7 +1784,7 @@ export async function serializeAws_restJson1_1DeleteDocumentationPartCommand(
   let resolvedPath =
     "/restapis/{restApiId}/documentation/parts/{documentationPartId}";
   if (input.documentationPartId !== undefined) {
-    const labelValue: string = input.documentationPartId.toString();
+    const labelValue: string = input.documentationPartId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: documentationPartId."
@@ -1789,7 +1792,7 @@ export async function serializeAws_restJson1_1DeleteDocumentationPartCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{documentationPartId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -1797,13 +1800,13 @@ export async function serializeAws_restJson1_1DeleteDocumentationPartCommand(
     );
   }
   if (input.restApiId !== undefined) {
-    const labelValue: string = input.restApiId.toString();
+    const labelValue: string = input.restApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: restApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{restApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: restApiId.");
@@ -1845,7 +1848,7 @@ export async function serializeAws_restJson1_1DeleteDocumentationVersionCommand(
   let resolvedPath =
     "/restapis/{restApiId}/documentation/versions/{documentationVersion}";
   if (input.documentationVersion !== undefined) {
-    const labelValue: string = input.documentationVersion.toString();
+    const labelValue: string = input.documentationVersion;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: documentationVersion."
@@ -1853,7 +1856,7 @@ export async function serializeAws_restJson1_1DeleteDocumentationVersionCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{documentationVersion}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -1861,13 +1864,13 @@ export async function serializeAws_restJson1_1DeleteDocumentationVersionCommand(
     );
   }
   if (input.restApiId !== undefined) {
-    const labelValue: string = input.restApiId.toString();
+    const labelValue: string = input.restApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: restApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{restApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: restApiId.");
@@ -1908,13 +1911,13 @@ export async function serializeAws_restJson1_1DeleteDomainNameCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/domainnames/{domainName}";
   if (input.domainName !== undefined) {
-    const labelValue: string = input.domainName.toString();
+    const labelValue: string = input.domainName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: domainName.");
     }
     resolvedPath = resolvedPath.replace(
       "{domainName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: domainName.");
@@ -1955,7 +1958,7 @@ export async function serializeAws_restJson1_1DeleteGatewayResponseCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/restapis/{restApiId}/gatewayresponses/{responseType}";
   if (input.responseType !== undefined) {
-    const labelValue: string = input.responseType.toString();
+    const labelValue: string = input.responseType;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: responseType."
@@ -1963,19 +1966,19 @@ export async function serializeAws_restJson1_1DeleteGatewayResponseCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{responseType}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: responseType.");
   }
   if (input.restApiId !== undefined) {
-    const labelValue: string = input.restApiId.toString();
+    const labelValue: string = input.restApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: restApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{restApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: restApiId.");
@@ -2017,37 +2020,37 @@ export async function serializeAws_restJson1_1DeleteIntegrationCommand(
   let resolvedPath =
     "/restapis/{restApiId}/resources/{resourceId}/methods/{httpMethod}/integration";
   if (input.httpMethod !== undefined) {
-    const labelValue: string = input.httpMethod.toString();
+    const labelValue: string = input.httpMethod;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: httpMethod.");
     }
     resolvedPath = resolvedPath.replace(
       "{httpMethod}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: httpMethod.");
   }
   if (input.resourceId !== undefined) {
-    const labelValue: string = input.resourceId.toString();
+    const labelValue: string = input.resourceId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: resourceId.");
     }
     resolvedPath = resolvedPath.replace(
       "{resourceId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: resourceId.");
   }
   if (input.restApiId !== undefined) {
-    const labelValue: string = input.restApiId.toString();
+    const labelValue: string = input.restApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: restApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{restApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: restApiId.");
@@ -2089,49 +2092,49 @@ export async function serializeAws_restJson1_1DeleteIntegrationResponseCommand(
   let resolvedPath =
     "/restapis/{restApiId}/resources/{resourceId}/methods/{httpMethod}/integration/responses/{statusCode}";
   if (input.httpMethod !== undefined) {
-    const labelValue: string = input.httpMethod.toString();
+    const labelValue: string = input.httpMethod;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: httpMethod.");
     }
     resolvedPath = resolvedPath.replace(
       "{httpMethod}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: httpMethod.");
   }
   if (input.resourceId !== undefined) {
-    const labelValue: string = input.resourceId.toString();
+    const labelValue: string = input.resourceId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: resourceId.");
     }
     resolvedPath = resolvedPath.replace(
       "{resourceId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: resourceId.");
   }
   if (input.restApiId !== undefined) {
-    const labelValue: string = input.restApiId.toString();
+    const labelValue: string = input.restApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: restApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{restApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: restApiId.");
   }
   if (input.statusCode !== undefined) {
-    const labelValue: string = input.statusCode.toString();
+    const labelValue: string = input.statusCode;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: statusCode.");
     }
     resolvedPath = resolvedPath.replace(
       "{statusCode}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: statusCode.");
@@ -2173,37 +2176,37 @@ export async function serializeAws_restJson1_1DeleteMethodCommand(
   let resolvedPath =
     "/restapis/{restApiId}/resources/{resourceId}/methods/{httpMethod}";
   if (input.httpMethod !== undefined) {
-    const labelValue: string = input.httpMethod.toString();
+    const labelValue: string = input.httpMethod;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: httpMethod.");
     }
     resolvedPath = resolvedPath.replace(
       "{httpMethod}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: httpMethod.");
   }
   if (input.resourceId !== undefined) {
-    const labelValue: string = input.resourceId.toString();
+    const labelValue: string = input.resourceId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: resourceId.");
     }
     resolvedPath = resolvedPath.replace(
       "{resourceId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: resourceId.");
   }
   if (input.restApiId !== undefined) {
-    const labelValue: string = input.restApiId.toString();
+    const labelValue: string = input.restApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: restApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{restApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: restApiId.");
@@ -2245,49 +2248,49 @@ export async function serializeAws_restJson1_1DeleteMethodResponseCommand(
   let resolvedPath =
     "/restapis/{restApiId}/resources/{resourceId}/methods/{httpMethod}/responses/{statusCode}";
   if (input.httpMethod !== undefined) {
-    const labelValue: string = input.httpMethod.toString();
+    const labelValue: string = input.httpMethod;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: httpMethod.");
     }
     resolvedPath = resolvedPath.replace(
       "{httpMethod}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: httpMethod.");
   }
   if (input.resourceId !== undefined) {
-    const labelValue: string = input.resourceId.toString();
+    const labelValue: string = input.resourceId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: resourceId.");
     }
     resolvedPath = resolvedPath.replace(
       "{resourceId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: resourceId.");
   }
   if (input.restApiId !== undefined) {
-    const labelValue: string = input.restApiId.toString();
+    const labelValue: string = input.restApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: restApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{restApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: restApiId.");
   }
   if (input.statusCode !== undefined) {
-    const labelValue: string = input.statusCode.toString();
+    const labelValue: string = input.statusCode;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: statusCode.");
     }
     resolvedPath = resolvedPath.replace(
       "{statusCode}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: statusCode.");
@@ -2328,25 +2331,25 @@ export async function serializeAws_restJson1_1DeleteModelCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/restapis/{restApiId}/models/{modelName}";
   if (input.modelName !== undefined) {
-    const labelValue: string = input.modelName.toString();
+    const labelValue: string = input.modelName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: modelName.");
     }
     resolvedPath = resolvedPath.replace(
       "{modelName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: modelName.");
   }
   if (input.restApiId !== undefined) {
-    const labelValue: string = input.restApiId.toString();
+    const labelValue: string = input.restApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: restApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{restApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: restApiId.");
@@ -2388,7 +2391,7 @@ export async function serializeAws_restJson1_1DeleteRequestValidatorCommand(
   let resolvedPath =
     "/restapis/{restApiId}/requestvalidators/{requestValidatorId}";
   if (input.requestValidatorId !== undefined) {
-    const labelValue: string = input.requestValidatorId.toString();
+    const labelValue: string = input.requestValidatorId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: requestValidatorId."
@@ -2396,7 +2399,7 @@ export async function serializeAws_restJson1_1DeleteRequestValidatorCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{requestValidatorId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -2404,13 +2407,13 @@ export async function serializeAws_restJson1_1DeleteRequestValidatorCommand(
     );
   }
   if (input.restApiId !== undefined) {
-    const labelValue: string = input.restApiId.toString();
+    const labelValue: string = input.restApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: restApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{restApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: restApiId.");
@@ -2451,25 +2454,25 @@ export async function serializeAws_restJson1_1DeleteResourceCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/restapis/{restApiId}/resources/{resourceId}";
   if (input.resourceId !== undefined) {
-    const labelValue: string = input.resourceId.toString();
+    const labelValue: string = input.resourceId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: resourceId.");
     }
     resolvedPath = resolvedPath.replace(
       "{resourceId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: resourceId.");
   }
   if (input.restApiId !== undefined) {
-    const labelValue: string = input.restApiId.toString();
+    const labelValue: string = input.restApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: restApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{restApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: restApiId.");
@@ -2510,13 +2513,13 @@ export async function serializeAws_restJson1_1DeleteRestApiCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/restapis/{restApiId}";
   if (input.restApiId !== undefined) {
-    const labelValue: string = input.restApiId.toString();
+    const labelValue: string = input.restApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: restApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{restApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: restApiId.");
@@ -2557,25 +2560,25 @@ export async function serializeAws_restJson1_1DeleteStageCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/restapis/{restApiId}/stages/{stageName}";
   if (input.restApiId !== undefined) {
-    const labelValue: string = input.restApiId.toString();
+    const labelValue: string = input.restApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: restApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{restApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: restApiId.");
   }
   if (input.stageName !== undefined) {
-    const labelValue: string = input.stageName.toString();
+    const labelValue: string = input.stageName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: stageName.");
     }
     resolvedPath = resolvedPath.replace(
       "{stageName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: stageName.");
@@ -2616,7 +2619,7 @@ export async function serializeAws_restJson1_1DeleteUsagePlanCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/usageplans/{usagePlanId}";
   if (input.usagePlanId !== undefined) {
-    const labelValue: string = input.usagePlanId.toString();
+    const labelValue: string = input.usagePlanId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: usagePlanId."
@@ -2624,7 +2627,7 @@ export async function serializeAws_restJson1_1DeleteUsagePlanCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{usagePlanId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: usagePlanId.");
@@ -2665,19 +2668,19 @@ export async function serializeAws_restJson1_1DeleteUsagePlanKeyCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/usageplans/{usagePlanId}/keys/{keyId}";
   if (input.keyId !== undefined) {
-    const labelValue: string = input.keyId.toString();
+    const labelValue: string = input.keyId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: keyId.");
     }
     resolvedPath = resolvedPath.replace(
       "{keyId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: keyId.");
   }
   if (input.usagePlanId !== undefined) {
-    const labelValue: string = input.usagePlanId.toString();
+    const labelValue: string = input.usagePlanId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: usagePlanId."
@@ -2685,7 +2688,7 @@ export async function serializeAws_restJson1_1DeleteUsagePlanKeyCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{usagePlanId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: usagePlanId.");
@@ -2726,13 +2729,13 @@ export async function serializeAws_restJson1_1DeleteVpcLinkCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/vpclinks/{vpcLinkId}";
   if (input.vpcLinkId !== undefined) {
-    const labelValue: string = input.vpcLinkId.toString();
+    const labelValue: string = input.vpcLinkId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: vpcLinkId.");
     }
     resolvedPath = resolvedPath.replace(
       "{vpcLinkId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: vpcLinkId.");
@@ -2774,25 +2777,25 @@ export async function serializeAws_restJson1_1FlushStageAuthorizersCacheCommand(
   let resolvedPath =
     "/restapis/{restApiId}/stages/{stageName}/cache/authorizers";
   if (input.restApiId !== undefined) {
-    const labelValue: string = input.restApiId.toString();
+    const labelValue: string = input.restApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: restApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{restApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: restApiId.");
   }
   if (input.stageName !== undefined) {
-    const labelValue: string = input.stageName.toString();
+    const labelValue: string = input.stageName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: stageName.");
     }
     resolvedPath = resolvedPath.replace(
       "{stageName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: stageName.");
@@ -2833,25 +2836,25 @@ export async function serializeAws_restJson1_1FlushStageCacheCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/restapis/{restApiId}/stages/{stageName}/cache/data";
   if (input.restApiId !== undefined) {
-    const labelValue: string = input.restApiId.toString();
+    const labelValue: string = input.restApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: restApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{restApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: restApiId.");
   }
   if (input.stageName !== undefined) {
-    const labelValue: string = input.stageName.toString();
+    const labelValue: string = input.stageName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: stageName.");
     }
     resolvedPath = resolvedPath.replace(
       "{stageName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: stageName.");
@@ -2971,20 +2974,22 @@ export async function serializeAws_restJson1_1GetApiKeyCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/apikeys/{apiKey}";
   if (input.apiKey !== undefined) {
-    const labelValue: string = input.apiKey.toString();
+    const labelValue: string = input.apiKey;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: apiKey.");
     }
     resolvedPath = resolvedPath.replace(
       "{apiKey}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: apiKey.");
   }
   const query: any = {};
   if (input.includeValue !== undefined) {
-    query["includeValue"] = input.includeValue.toString();
+    query[
+      __extendedEncodeURIComponent("includeValue")
+    ] = __extendedEncodeURIComponent(input.includeValue.toString());
   }
   let body: any;
   const bodyParams: any = {};
@@ -3024,19 +3029,29 @@ export async function serializeAws_restJson1_1GetApiKeysCommand(
   let resolvedPath = "/apikeys";
   const query: any = {};
   if (input.customerId !== undefined) {
-    query["customerId"] = input.customerId.toString();
+    query[
+      __extendedEncodeURIComponent("customerId")
+    ] = __extendedEncodeURIComponent(input.customerId);
   }
   if (input.includeValues !== undefined) {
-    query["includeValues"] = input.includeValues.toString();
+    query[
+      __extendedEncodeURIComponent("includeValues")
+    ] = __extendedEncodeURIComponent(input.includeValues.toString());
   }
   if (input.limit !== undefined) {
-    query["limit"] = input.limit.toString();
+    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
+      input.limit.toString()
+    );
   }
   if (input.nameQuery !== undefined) {
-    query["name"] = input.nameQuery.toString();
+    query[__extendedEncodeURIComponent("name")] = __extendedEncodeURIComponent(
+      input.nameQuery
+    );
   }
   if (input.position !== undefined) {
-    query["position"] = input.position.toString();
+    query[
+      __extendedEncodeURIComponent("position")
+    ] = __extendedEncodeURIComponent(input.position);
   }
   let body: any;
   const bodyParams: any = {};
@@ -3075,7 +3090,7 @@ export async function serializeAws_restJson1_1GetAuthorizerCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/restapis/{restApiId}/authorizers/{authorizerId}";
   if (input.authorizerId !== undefined) {
-    const labelValue: string = input.authorizerId.toString();
+    const labelValue: string = input.authorizerId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: authorizerId."
@@ -3083,19 +3098,19 @@ export async function serializeAws_restJson1_1GetAuthorizerCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{authorizerId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: authorizerId.");
   }
   if (input.restApiId !== undefined) {
-    const labelValue: string = input.restApiId.toString();
+    const labelValue: string = input.restApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: restApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{restApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: restApiId.");
@@ -3136,23 +3151,27 @@ export async function serializeAws_restJson1_1GetAuthorizersCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/restapis/{restApiId}/authorizers";
   if (input.restApiId !== undefined) {
-    const labelValue: string = input.restApiId.toString();
+    const labelValue: string = input.restApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: restApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{restApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: restApiId.");
   }
   const query: any = {};
   if (input.limit !== undefined) {
-    query["limit"] = input.limit.toString();
+    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
+      input.limit.toString()
+    );
   }
   if (input.position !== undefined) {
-    query["position"] = input.position.toString();
+    query[
+      __extendedEncodeURIComponent("position")
+    ] = __extendedEncodeURIComponent(input.position);
   }
   let body: any;
   const bodyParams: any = {};
@@ -3191,25 +3210,25 @@ export async function serializeAws_restJson1_1GetBasePathMappingCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/domainnames/{domainName}/basepathmappings/{basePath}";
   if (input.basePath !== undefined) {
-    const labelValue: string = input.basePath.toString();
+    const labelValue: string = input.basePath;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: basePath.");
     }
     resolvedPath = resolvedPath.replace(
       "{basePath}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: basePath.");
   }
   if (input.domainName !== undefined) {
-    const labelValue: string = input.domainName.toString();
+    const labelValue: string = input.domainName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: domainName.");
     }
     resolvedPath = resolvedPath.replace(
       "{domainName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: domainName.");
@@ -3250,23 +3269,27 @@ export async function serializeAws_restJson1_1GetBasePathMappingsCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/domainnames/{domainName}/basepathmappings";
   if (input.domainName !== undefined) {
-    const labelValue: string = input.domainName.toString();
+    const labelValue: string = input.domainName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: domainName.");
     }
     resolvedPath = resolvedPath.replace(
       "{domainName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: domainName.");
   }
   const query: any = {};
   if (input.limit !== undefined) {
-    query["limit"] = input.limit.toString();
+    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
+      input.limit.toString()
+    );
   }
   if (input.position !== undefined) {
-    query["position"] = input.position.toString();
+    query[
+      __extendedEncodeURIComponent("position")
+    ] = __extendedEncodeURIComponent(input.position);
   }
   let body: any;
   const bodyParams: any = {};
@@ -3305,7 +3328,7 @@ export async function serializeAws_restJson1_1GetClientCertificateCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/clientcertificates/{clientCertificateId}";
   if (input.clientCertificateId !== undefined) {
-    const labelValue: string = input.clientCertificateId.toString();
+    const labelValue: string = input.clientCertificateId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: clientCertificateId."
@@ -3313,7 +3336,7 @@ export async function serializeAws_restJson1_1GetClientCertificateCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{clientCertificateId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -3357,10 +3380,14 @@ export async function serializeAws_restJson1_1GetClientCertificatesCommand(
   let resolvedPath = "/clientcertificates";
   const query: any = {};
   if (input.limit !== undefined) {
-    query["limit"] = input.limit.toString();
+    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
+      input.limit.toString()
+    );
   }
   if (input.position !== undefined) {
-    query["position"] = input.position.toString();
+    query[
+      __extendedEncodeURIComponent("position")
+    ] = __extendedEncodeURIComponent(input.position);
   }
   let body: any;
   const bodyParams: any = {};
@@ -3399,7 +3426,7 @@ export async function serializeAws_restJson1_1GetDeploymentCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/restapis/{restApiId}/deployments/{deploymentId}";
   if (input.deploymentId !== undefined) {
-    const labelValue: string = input.deploymentId.toString();
+    const labelValue: string = input.deploymentId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: deploymentId."
@@ -3407,26 +3434,28 @@ export async function serializeAws_restJson1_1GetDeploymentCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{deploymentId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: deploymentId.");
   }
   if (input.restApiId !== undefined) {
-    const labelValue: string = input.restApiId.toString();
+    const labelValue: string = input.restApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: restApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{restApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: restApiId.");
   }
   const query: any = {};
   if (input.embed !== undefined) {
-    query["embed"] = input.embed;
+    query[__extendedEncodeURIComponent("embed")] = input.embed.map(entry =>
+      __extendedEncodeURIComponent(entry)
+    );
   }
   let body: any;
   const bodyParams: any = {};
@@ -3465,23 +3494,27 @@ export async function serializeAws_restJson1_1GetDeploymentsCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/restapis/{restApiId}/deployments";
   if (input.restApiId !== undefined) {
-    const labelValue: string = input.restApiId.toString();
+    const labelValue: string = input.restApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: restApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{restApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: restApiId.");
   }
   const query: any = {};
   if (input.limit !== undefined) {
-    query["limit"] = input.limit.toString();
+    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
+      input.limit.toString()
+    );
   }
   if (input.position !== undefined) {
-    query["position"] = input.position.toString();
+    query[
+      __extendedEncodeURIComponent("position")
+    ] = __extendedEncodeURIComponent(input.position);
   }
   let body: any;
   const bodyParams: any = {};
@@ -3521,7 +3554,7 @@ export async function serializeAws_restJson1_1GetDocumentationPartCommand(
   let resolvedPath =
     "/restapis/{restApiId}/documentation/parts/{documentationPartId}";
   if (input.documentationPartId !== undefined) {
-    const labelValue: string = input.documentationPartId.toString();
+    const labelValue: string = input.documentationPartId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: documentationPartId."
@@ -3529,7 +3562,7 @@ export async function serializeAws_restJson1_1GetDocumentationPartCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{documentationPartId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -3537,13 +3570,13 @@ export async function serializeAws_restJson1_1GetDocumentationPartCommand(
     );
   }
   if (input.restApiId !== undefined) {
-    const labelValue: string = input.restApiId.toString();
+    const labelValue: string = input.restApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: restApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{restApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: restApiId.");
@@ -3584,35 +3617,47 @@ export async function serializeAws_restJson1_1GetDocumentationPartsCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/restapis/{restApiId}/documentation/parts";
   if (input.restApiId !== undefined) {
-    const labelValue: string = input.restApiId.toString();
+    const labelValue: string = input.restApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: restApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{restApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: restApiId.");
   }
   const query: any = {};
   if (input.limit !== undefined) {
-    query["limit"] = input.limit.toString();
+    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
+      input.limit.toString()
+    );
   }
   if (input.locationStatus !== undefined) {
-    query["locationStatus"] = input.locationStatus.toString();
+    query[
+      __extendedEncodeURIComponent("locationStatus")
+    ] = __extendedEncodeURIComponent(input.locationStatus);
   }
   if (input.nameQuery !== undefined) {
-    query["name"] = input.nameQuery.toString();
+    query[__extendedEncodeURIComponent("name")] = __extendedEncodeURIComponent(
+      input.nameQuery
+    );
   }
   if (input.path !== undefined) {
-    query["path"] = input.path.toString();
+    query[__extendedEncodeURIComponent("path")] = __extendedEncodeURIComponent(
+      input.path
+    );
   }
   if (input.position !== undefined) {
-    query["position"] = input.position.toString();
+    query[
+      __extendedEncodeURIComponent("position")
+    ] = __extendedEncodeURIComponent(input.position);
   }
   if (input.type !== undefined) {
-    query["type"] = input.type.toString();
+    query[__extendedEncodeURIComponent("type")] = __extendedEncodeURIComponent(
+      input.type
+    );
   }
   let body: any;
   const bodyParams: any = {};
@@ -3652,7 +3697,7 @@ export async function serializeAws_restJson1_1GetDocumentationVersionCommand(
   let resolvedPath =
     "/restapis/{restApiId}/documentation/versions/{documentationVersion}";
   if (input.documentationVersion !== undefined) {
-    const labelValue: string = input.documentationVersion.toString();
+    const labelValue: string = input.documentationVersion;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: documentationVersion."
@@ -3660,7 +3705,7 @@ export async function serializeAws_restJson1_1GetDocumentationVersionCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{documentationVersion}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -3668,13 +3713,13 @@ export async function serializeAws_restJson1_1GetDocumentationVersionCommand(
     );
   }
   if (input.restApiId !== undefined) {
-    const labelValue: string = input.restApiId.toString();
+    const labelValue: string = input.restApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: restApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{restApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: restApiId.");
@@ -3715,23 +3760,27 @@ export async function serializeAws_restJson1_1GetDocumentationVersionsCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/restapis/{restApiId}/documentation/versions";
   if (input.restApiId !== undefined) {
-    const labelValue: string = input.restApiId.toString();
+    const labelValue: string = input.restApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: restApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{restApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: restApiId.");
   }
   const query: any = {};
   if (input.limit !== undefined) {
-    query["limit"] = input.limit.toString();
+    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
+      input.limit.toString()
+    );
   }
   if (input.position !== undefined) {
-    query["position"] = input.position.toString();
+    query[
+      __extendedEncodeURIComponent("position")
+    ] = __extendedEncodeURIComponent(input.position);
   }
   let body: any;
   const bodyParams: any = {};
@@ -3770,13 +3819,13 @@ export async function serializeAws_restJson1_1GetDomainNameCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/domainnames/{domainName}";
   if (input.domainName !== undefined) {
-    const labelValue: string = input.domainName.toString();
+    const labelValue: string = input.domainName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: domainName.");
     }
     resolvedPath = resolvedPath.replace(
       "{domainName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: domainName.");
@@ -3818,10 +3867,14 @@ export async function serializeAws_restJson1_1GetDomainNamesCommand(
   let resolvedPath = "/domainnames";
   const query: any = {};
   if (input.limit !== undefined) {
-    query["limit"] = input.limit.toString();
+    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
+      input.limit.toString()
+    );
   }
   if (input.position !== undefined) {
-    query["position"] = input.position.toString();
+    query[
+      __extendedEncodeURIComponent("position")
+    ] = __extendedEncodeURIComponent(input.position);
   }
   let body: any;
   const bodyParams: any = {};
@@ -3859,42 +3912,42 @@ export async function serializeAws_restJson1_1GetExportCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.accepts !== undefined) {
-    headers["Accept"] = input.accepts.toString();
+    headers["Accept"] = input.accepts;
   }
   let resolvedPath =
     "/restapis/{restApiId}/stages/{stageName}/exports/{exportType}";
   if (input.exportType !== undefined) {
-    const labelValue: string = input.exportType.toString();
+    const labelValue: string = input.exportType;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: exportType.");
     }
     resolvedPath = resolvedPath.replace(
       "{exportType}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: exportType.");
   }
   if (input.restApiId !== undefined) {
-    const labelValue: string = input.restApiId.toString();
+    const labelValue: string = input.restApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: restApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{restApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: restApiId.");
   }
   if (input.stageName !== undefined) {
-    const labelValue: string = input.stageName.toString();
+    const labelValue: string = input.stageName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: stageName.");
     }
     resolvedPath = resolvedPath.replace(
       "{stageName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: stageName.");
@@ -3926,7 +3979,7 @@ export async function serializeAws_restJson1_1GetGatewayResponseCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/restapis/{restApiId}/gatewayresponses/{responseType}";
   if (input.responseType !== undefined) {
-    const labelValue: string = input.responseType.toString();
+    const labelValue: string = input.responseType;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: responseType."
@@ -3934,19 +3987,19 @@ export async function serializeAws_restJson1_1GetGatewayResponseCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{responseType}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: responseType.");
   }
   if (input.restApiId !== undefined) {
-    const labelValue: string = input.restApiId.toString();
+    const labelValue: string = input.restApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: restApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{restApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: restApiId.");
@@ -3987,23 +4040,27 @@ export async function serializeAws_restJson1_1GetGatewayResponsesCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/restapis/{restApiId}/gatewayresponses";
   if (input.restApiId !== undefined) {
-    const labelValue: string = input.restApiId.toString();
+    const labelValue: string = input.restApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: restApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{restApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: restApiId.");
   }
   const query: any = {};
   if (input.limit !== undefined) {
-    query["limit"] = input.limit.toString();
+    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
+      input.limit.toString()
+    );
   }
   if (input.position !== undefined) {
-    query["position"] = input.position.toString();
+    query[
+      __extendedEncodeURIComponent("position")
+    ] = __extendedEncodeURIComponent(input.position);
   }
   let body: any;
   const bodyParams: any = {};
@@ -4043,37 +4100,37 @@ export async function serializeAws_restJson1_1GetIntegrationCommand(
   let resolvedPath =
     "/restapis/{restApiId}/resources/{resourceId}/methods/{httpMethod}/integration";
   if (input.httpMethod !== undefined) {
-    const labelValue: string = input.httpMethod.toString();
+    const labelValue: string = input.httpMethod;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: httpMethod.");
     }
     resolvedPath = resolvedPath.replace(
       "{httpMethod}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: httpMethod.");
   }
   if (input.resourceId !== undefined) {
-    const labelValue: string = input.resourceId.toString();
+    const labelValue: string = input.resourceId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: resourceId.");
     }
     resolvedPath = resolvedPath.replace(
       "{resourceId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: resourceId.");
   }
   if (input.restApiId !== undefined) {
-    const labelValue: string = input.restApiId.toString();
+    const labelValue: string = input.restApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: restApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{restApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: restApiId.");
@@ -4115,49 +4172,49 @@ export async function serializeAws_restJson1_1GetIntegrationResponseCommand(
   let resolvedPath =
     "/restapis/{restApiId}/resources/{resourceId}/methods/{httpMethod}/integration/responses/{statusCode}";
   if (input.httpMethod !== undefined) {
-    const labelValue: string = input.httpMethod.toString();
+    const labelValue: string = input.httpMethod;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: httpMethod.");
     }
     resolvedPath = resolvedPath.replace(
       "{httpMethod}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: httpMethod.");
   }
   if (input.resourceId !== undefined) {
-    const labelValue: string = input.resourceId.toString();
+    const labelValue: string = input.resourceId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: resourceId.");
     }
     resolvedPath = resolvedPath.replace(
       "{resourceId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: resourceId.");
   }
   if (input.restApiId !== undefined) {
-    const labelValue: string = input.restApiId.toString();
+    const labelValue: string = input.restApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: restApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{restApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: restApiId.");
   }
   if (input.statusCode !== undefined) {
-    const labelValue: string = input.statusCode.toString();
+    const labelValue: string = input.statusCode;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: statusCode.");
     }
     resolvedPath = resolvedPath.replace(
       "{statusCode}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: statusCode.");
@@ -4199,37 +4256,37 @@ export async function serializeAws_restJson1_1GetMethodCommand(
   let resolvedPath =
     "/restapis/{restApiId}/resources/{resourceId}/methods/{httpMethod}";
   if (input.httpMethod !== undefined) {
-    const labelValue: string = input.httpMethod.toString();
+    const labelValue: string = input.httpMethod;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: httpMethod.");
     }
     resolvedPath = resolvedPath.replace(
       "{httpMethod}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: httpMethod.");
   }
   if (input.resourceId !== undefined) {
-    const labelValue: string = input.resourceId.toString();
+    const labelValue: string = input.resourceId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: resourceId.");
     }
     resolvedPath = resolvedPath.replace(
       "{resourceId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: resourceId.");
   }
   if (input.restApiId !== undefined) {
-    const labelValue: string = input.restApiId.toString();
+    const labelValue: string = input.restApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: restApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{restApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: restApiId.");
@@ -4271,49 +4328,49 @@ export async function serializeAws_restJson1_1GetMethodResponseCommand(
   let resolvedPath =
     "/restapis/{restApiId}/resources/{resourceId}/methods/{httpMethod}/responses/{statusCode}";
   if (input.httpMethod !== undefined) {
-    const labelValue: string = input.httpMethod.toString();
+    const labelValue: string = input.httpMethod;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: httpMethod.");
     }
     resolvedPath = resolvedPath.replace(
       "{httpMethod}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: httpMethod.");
   }
   if (input.resourceId !== undefined) {
-    const labelValue: string = input.resourceId.toString();
+    const labelValue: string = input.resourceId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: resourceId.");
     }
     resolvedPath = resolvedPath.replace(
       "{resourceId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: resourceId.");
   }
   if (input.restApiId !== undefined) {
-    const labelValue: string = input.restApiId.toString();
+    const labelValue: string = input.restApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: restApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{restApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: restApiId.");
   }
   if (input.statusCode !== undefined) {
-    const labelValue: string = input.statusCode.toString();
+    const labelValue: string = input.statusCode;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: statusCode.");
     }
     resolvedPath = resolvedPath.replace(
       "{statusCode}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: statusCode.");
@@ -4354,32 +4411,34 @@ export async function serializeAws_restJson1_1GetModelCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/restapis/{restApiId}/models/{modelName}";
   if (input.modelName !== undefined) {
-    const labelValue: string = input.modelName.toString();
+    const labelValue: string = input.modelName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: modelName.");
     }
     resolvedPath = resolvedPath.replace(
       "{modelName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: modelName.");
   }
   if (input.restApiId !== undefined) {
-    const labelValue: string = input.restApiId.toString();
+    const labelValue: string = input.restApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: restApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{restApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: restApiId.");
   }
   const query: any = {};
   if (input.flatten !== undefined) {
-    query["flatten"] = input.flatten.toString();
+    query[
+      __extendedEncodeURIComponent("flatten")
+    ] = __extendedEncodeURIComponent(input.flatten.toString());
   }
   let body: any;
   const bodyParams: any = {};
@@ -4419,25 +4478,25 @@ export async function serializeAws_restJson1_1GetModelTemplateCommand(
   let resolvedPath =
     "/restapis/{restApiId}/models/{modelName}/default_template";
   if (input.modelName !== undefined) {
-    const labelValue: string = input.modelName.toString();
+    const labelValue: string = input.modelName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: modelName.");
     }
     resolvedPath = resolvedPath.replace(
       "{modelName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: modelName.");
   }
   if (input.restApiId !== undefined) {
-    const labelValue: string = input.restApiId.toString();
+    const labelValue: string = input.restApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: restApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{restApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: restApiId.");
@@ -4478,23 +4537,27 @@ export async function serializeAws_restJson1_1GetModelsCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/restapis/{restApiId}/models";
   if (input.restApiId !== undefined) {
-    const labelValue: string = input.restApiId.toString();
+    const labelValue: string = input.restApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: restApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{restApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: restApiId.");
   }
   const query: any = {};
   if (input.limit !== undefined) {
-    query["limit"] = input.limit.toString();
+    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
+      input.limit.toString()
+    );
   }
   if (input.position !== undefined) {
-    query["position"] = input.position.toString();
+    query[
+      __extendedEncodeURIComponent("position")
+    ] = __extendedEncodeURIComponent(input.position);
   }
   let body: any;
   const bodyParams: any = {};
@@ -4534,7 +4597,7 @@ export async function serializeAws_restJson1_1GetRequestValidatorCommand(
   let resolvedPath =
     "/restapis/{restApiId}/requestvalidators/{requestValidatorId}";
   if (input.requestValidatorId !== undefined) {
-    const labelValue: string = input.requestValidatorId.toString();
+    const labelValue: string = input.requestValidatorId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: requestValidatorId."
@@ -4542,7 +4605,7 @@ export async function serializeAws_restJson1_1GetRequestValidatorCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{requestValidatorId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -4550,13 +4613,13 @@ export async function serializeAws_restJson1_1GetRequestValidatorCommand(
     );
   }
   if (input.restApiId !== undefined) {
-    const labelValue: string = input.restApiId.toString();
+    const labelValue: string = input.restApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: restApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{restApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: restApiId.");
@@ -4597,23 +4660,27 @@ export async function serializeAws_restJson1_1GetRequestValidatorsCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/restapis/{restApiId}/requestvalidators";
   if (input.restApiId !== undefined) {
-    const labelValue: string = input.restApiId.toString();
+    const labelValue: string = input.restApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: restApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{restApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: restApiId.");
   }
   const query: any = {};
   if (input.limit !== undefined) {
-    query["limit"] = input.limit.toString();
+    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
+      input.limit.toString()
+    );
   }
   if (input.position !== undefined) {
-    query["position"] = input.position.toString();
+    query[
+      __extendedEncodeURIComponent("position")
+    ] = __extendedEncodeURIComponent(input.position);
   }
   let body: any;
   const bodyParams: any = {};
@@ -4652,32 +4719,34 @@ export async function serializeAws_restJson1_1GetResourceCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/restapis/{restApiId}/resources/{resourceId}";
   if (input.resourceId !== undefined) {
-    const labelValue: string = input.resourceId.toString();
+    const labelValue: string = input.resourceId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: resourceId.");
     }
     resolvedPath = resolvedPath.replace(
       "{resourceId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: resourceId.");
   }
   if (input.restApiId !== undefined) {
-    const labelValue: string = input.restApiId.toString();
+    const labelValue: string = input.restApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: restApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{restApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: restApiId.");
   }
   const query: any = {};
   if (input.embed !== undefined) {
-    query["embed"] = input.embed;
+    query[__extendedEncodeURIComponent("embed")] = input.embed.map(entry =>
+      __extendedEncodeURIComponent(entry)
+    );
   }
   let body: any;
   const bodyParams: any = {};
@@ -4716,26 +4785,32 @@ export async function serializeAws_restJson1_1GetResourcesCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/restapis/{restApiId}/resources";
   if (input.restApiId !== undefined) {
-    const labelValue: string = input.restApiId.toString();
+    const labelValue: string = input.restApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: restApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{restApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: restApiId.");
   }
   const query: any = {};
   if (input.embed !== undefined) {
-    query["embed"] = input.embed;
+    query[__extendedEncodeURIComponent("embed")] = input.embed.map(entry =>
+      __extendedEncodeURIComponent(entry)
+    );
   }
   if (input.limit !== undefined) {
-    query["limit"] = input.limit.toString();
+    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
+      input.limit.toString()
+    );
   }
   if (input.position !== undefined) {
-    query["position"] = input.position.toString();
+    query[
+      __extendedEncodeURIComponent("position")
+    ] = __extendedEncodeURIComponent(input.position);
   }
   let body: any;
   const bodyParams: any = {};
@@ -4774,13 +4849,13 @@ export async function serializeAws_restJson1_1GetRestApiCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/restapis/{restApiId}";
   if (input.restApiId !== undefined) {
-    const labelValue: string = input.restApiId.toString();
+    const labelValue: string = input.restApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: restApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{restApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: restApiId.");
@@ -4822,10 +4897,14 @@ export async function serializeAws_restJson1_1GetRestApisCommand(
   let resolvedPath = "/restapis";
   const query: any = {};
   if (input.limit !== undefined) {
-    query["limit"] = input.limit.toString();
+    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
+      input.limit.toString()
+    );
   }
   if (input.position !== undefined) {
-    query["position"] = input.position.toString();
+    query[
+      __extendedEncodeURIComponent("position")
+    ] = __extendedEncodeURIComponent(input.position);
   }
   let body: any;
   const bodyParams: any = {};
@@ -4864,37 +4943,37 @@ export async function serializeAws_restJson1_1GetSdkCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/restapis/{restApiId}/stages/{stageName}/sdks/{sdkType}";
   if (input.restApiId !== undefined) {
-    const labelValue: string = input.restApiId.toString();
+    const labelValue: string = input.restApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: restApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{restApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: restApiId.");
   }
   if (input.sdkType !== undefined) {
-    const labelValue: string = input.sdkType.toString();
+    const labelValue: string = input.sdkType;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: sdkType.");
     }
     resolvedPath = resolvedPath.replace(
       "{sdkType}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: sdkType.");
   }
   if (input.stageName !== undefined) {
-    const labelValue: string = input.stageName.toString();
+    const labelValue: string = input.stageName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: stageName.");
     }
     resolvedPath = resolvedPath.replace(
       "{stageName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: stageName.");
@@ -4926,11 +5005,14 @@ export async function serializeAws_restJson1_1GetSdkTypeCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/sdktypes/{id}";
   if (input.id !== undefined) {
-    const labelValue: string = input.id.toString();
+    const labelValue: string = input.id;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: id.");
     }
-    resolvedPath = resolvedPath.replace("{id}", encodeURIComponent(labelValue));
+    resolvedPath = resolvedPath.replace(
+      "{id}",
+      __extendedEncodeURIComponent(labelValue)
+    );
   } else {
     throw new Error("No value provided for input HTTP label: id.");
   }
@@ -4971,10 +5053,14 @@ export async function serializeAws_restJson1_1GetSdkTypesCommand(
   let resolvedPath = "/sdktypes";
   const query: any = {};
   if (input.limit !== undefined) {
-    query["limit"] = input.limit.toString();
+    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
+      input.limit.toString()
+    );
   }
   if (input.position !== undefined) {
-    query["position"] = input.position.toString();
+    query[
+      __extendedEncodeURIComponent("position")
+    ] = __extendedEncodeURIComponent(input.position);
   }
   let body: any;
   const bodyParams: any = {};
@@ -5013,25 +5099,25 @@ export async function serializeAws_restJson1_1GetStageCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/restapis/{restApiId}/stages/{stageName}";
   if (input.restApiId !== undefined) {
-    const labelValue: string = input.restApiId.toString();
+    const labelValue: string = input.restApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: restApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{restApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: restApiId.");
   }
   if (input.stageName !== undefined) {
-    const labelValue: string = input.stageName.toString();
+    const labelValue: string = input.stageName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: stageName.");
     }
     resolvedPath = resolvedPath.replace(
       "{stageName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: stageName.");
@@ -5072,20 +5158,22 @@ export async function serializeAws_restJson1_1GetStagesCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/restapis/{restApiId}/stages";
   if (input.restApiId !== undefined) {
-    const labelValue: string = input.restApiId.toString();
+    const labelValue: string = input.restApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: restApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{restApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: restApiId.");
   }
   const query: any = {};
   if (input.deploymentId !== undefined) {
-    query["deploymentId"] = input.deploymentId.toString();
+    query[
+      __extendedEncodeURIComponent("deploymentId")
+    ] = __extendedEncodeURIComponent(input.deploymentId);
   }
   let body: any;
   const bodyParams: any = {};
@@ -5124,7 +5212,7 @@ export async function serializeAws_restJson1_1GetTagsCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/tags/{resourceArn}";
   if (input.resourceArn !== undefined) {
-    const labelValue: string = input.resourceArn.toString();
+    const labelValue: string = input.resourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: resourceArn."
@@ -5132,17 +5220,21 @@ export async function serializeAws_restJson1_1GetTagsCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{resourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: resourceArn.");
   }
   const query: any = {};
   if (input.limit !== undefined) {
-    query["limit"] = input.limit.toString();
+    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
+      input.limit.toString()
+    );
   }
   if (input.position !== undefined) {
-    query["position"] = input.position.toString();
+    query[
+      __extendedEncodeURIComponent("position")
+    ] = __extendedEncodeURIComponent(input.position);
   }
   let body: any;
   const bodyParams: any = {};
@@ -5181,7 +5273,7 @@ export async function serializeAws_restJson1_1GetUsageCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/usageplans/{usagePlanId}/usage";
   if (input.usagePlanId !== undefined) {
-    const labelValue: string = input.usagePlanId.toString();
+    const labelValue: string = input.usagePlanId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: usagePlanId."
@@ -5189,26 +5281,36 @@ export async function serializeAws_restJson1_1GetUsageCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{usagePlanId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: usagePlanId.");
   }
   const query: any = {};
   if (input.endDate !== undefined) {
-    query["endDate"] = input.endDate.toString();
+    query[
+      __extendedEncodeURIComponent("endDate")
+    ] = __extendedEncodeURIComponent(input.endDate);
   }
   if (input.keyId !== undefined) {
-    query["keyId"] = input.keyId.toString();
+    query[__extendedEncodeURIComponent("keyId")] = __extendedEncodeURIComponent(
+      input.keyId
+    );
   }
   if (input.limit !== undefined) {
-    query["limit"] = input.limit.toString();
+    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
+      input.limit.toString()
+    );
   }
   if (input.position !== undefined) {
-    query["position"] = input.position.toString();
+    query[
+      __extendedEncodeURIComponent("position")
+    ] = __extendedEncodeURIComponent(input.position);
   }
   if (input.startDate !== undefined) {
-    query["startDate"] = input.startDate.toString();
+    query[
+      __extendedEncodeURIComponent("startDate")
+    ] = __extendedEncodeURIComponent(input.startDate);
   }
   let body: any;
   const bodyParams: any = {};
@@ -5247,7 +5349,7 @@ export async function serializeAws_restJson1_1GetUsagePlanCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/usageplans/{usagePlanId}";
   if (input.usagePlanId !== undefined) {
-    const labelValue: string = input.usagePlanId.toString();
+    const labelValue: string = input.usagePlanId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: usagePlanId."
@@ -5255,7 +5357,7 @@ export async function serializeAws_restJson1_1GetUsagePlanCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{usagePlanId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: usagePlanId.");
@@ -5296,19 +5398,19 @@ export async function serializeAws_restJson1_1GetUsagePlanKeyCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/usageplans/{usagePlanId}/keys/{keyId}";
   if (input.keyId !== undefined) {
-    const labelValue: string = input.keyId.toString();
+    const labelValue: string = input.keyId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: keyId.");
     }
     resolvedPath = resolvedPath.replace(
       "{keyId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: keyId.");
   }
   if (input.usagePlanId !== undefined) {
-    const labelValue: string = input.usagePlanId.toString();
+    const labelValue: string = input.usagePlanId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: usagePlanId."
@@ -5316,7 +5418,7 @@ export async function serializeAws_restJson1_1GetUsagePlanKeyCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{usagePlanId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: usagePlanId.");
@@ -5357,7 +5459,7 @@ export async function serializeAws_restJson1_1GetUsagePlanKeysCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/usageplans/{usagePlanId}/keys";
   if (input.usagePlanId !== undefined) {
-    const labelValue: string = input.usagePlanId.toString();
+    const labelValue: string = input.usagePlanId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: usagePlanId."
@@ -5365,20 +5467,26 @@ export async function serializeAws_restJson1_1GetUsagePlanKeysCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{usagePlanId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: usagePlanId.");
   }
   const query: any = {};
   if (input.limit !== undefined) {
-    query["limit"] = input.limit.toString();
+    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
+      input.limit.toString()
+    );
   }
   if (input.nameQuery !== undefined) {
-    query["name"] = input.nameQuery.toString();
+    query[__extendedEncodeURIComponent("name")] = __extendedEncodeURIComponent(
+      input.nameQuery
+    );
   }
   if (input.position !== undefined) {
-    query["position"] = input.position.toString();
+    query[
+      __extendedEncodeURIComponent("position")
+    ] = __extendedEncodeURIComponent(input.position);
   }
   let body: any;
   const bodyParams: any = {};
@@ -5418,13 +5526,19 @@ export async function serializeAws_restJson1_1GetUsagePlansCommand(
   let resolvedPath = "/usageplans";
   const query: any = {};
   if (input.keyId !== undefined) {
-    query["keyId"] = input.keyId.toString();
+    query[__extendedEncodeURIComponent("keyId")] = __extendedEncodeURIComponent(
+      input.keyId
+    );
   }
   if (input.limit !== undefined) {
-    query["limit"] = input.limit.toString();
+    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
+      input.limit.toString()
+    );
   }
   if (input.position !== undefined) {
-    query["position"] = input.position.toString();
+    query[
+      __extendedEncodeURIComponent("position")
+    ] = __extendedEncodeURIComponent(input.position);
   }
   let body: any;
   const bodyParams: any = {};
@@ -5463,13 +5577,13 @@ export async function serializeAws_restJson1_1GetVpcLinkCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/vpclinks/{vpcLinkId}";
   if (input.vpcLinkId !== undefined) {
-    const labelValue: string = input.vpcLinkId.toString();
+    const labelValue: string = input.vpcLinkId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: vpcLinkId.");
     }
     resolvedPath = resolvedPath.replace(
       "{vpcLinkId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: vpcLinkId.");
@@ -5511,10 +5625,14 @@ export async function serializeAws_restJson1_1GetVpcLinksCommand(
   let resolvedPath = "/vpclinks";
   const query: any = {};
   if (input.limit !== undefined) {
-    query["limit"] = input.limit.toString();
+    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
+      input.limit.toString()
+    );
   }
   if (input.position !== undefined) {
-    query["position"] = input.position.toString();
+    query[
+      __extendedEncodeURIComponent("position")
+    ] = __extendedEncodeURIComponent(input.position);
   }
   let body: any;
   const bodyParams: any = {};
@@ -5556,10 +5674,14 @@ export async function serializeAws_restJson1_1ImportApiKeysCommand(
     mode: "import"
   };
   if (input.failOnWarnings !== undefined) {
-    query["failonwarnings"] = input.failOnWarnings.toString();
+    query[
+      __extendedEncodeURIComponent("failonwarnings")
+    ] = __extendedEncodeURIComponent(input.failOnWarnings.toString());
   }
   if (input.format !== undefined) {
-    query["format"] = input.format.toString();
+    query[
+      __extendedEncodeURIComponent("format")
+    ] = __extendedEncodeURIComponent(input.format);
   }
   let body: any;
   const bodyParams: any = {};
@@ -5598,23 +5720,27 @@ export async function serializeAws_restJson1_1ImportDocumentationPartsCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/restapis/{restApiId}/documentation/parts";
   if (input.restApiId !== undefined) {
-    const labelValue: string = input.restApiId.toString();
+    const labelValue: string = input.restApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: restApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{restApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: restApiId.");
   }
   const query: any = {};
   if (input.failOnWarnings !== undefined) {
-    query["failonwarnings"] = input.failOnWarnings.toString();
+    query[
+      __extendedEncodeURIComponent("failonwarnings")
+    ] = __extendedEncodeURIComponent(input.failOnWarnings.toString());
   }
   if (input.mode !== undefined) {
-    query["mode"] = input.mode.toString();
+    query[__extendedEncodeURIComponent("mode")] = __extendedEncodeURIComponent(
+      input.mode
+    );
   }
   let body: any;
   const bodyParams: any = {};
@@ -5656,7 +5782,9 @@ export async function serializeAws_restJson1_1ImportRestApiCommand(
     mode: "import"
   };
   if (input.failOnWarnings !== undefined) {
-    query["failonwarnings"] = input.failOnWarnings.toString();
+    query[
+      __extendedEncodeURIComponent("failonwarnings")
+    ] = __extendedEncodeURIComponent(input.failOnWarnings.toString());
   }
   let body: any;
   const bodyParams: any = {};
@@ -5701,7 +5829,7 @@ export async function serializeAws_restJson1_1PutGatewayResponseCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/restapis/{restApiId}/gatewayresponses/{responseType}";
   if (input.responseType !== undefined) {
-    const labelValue: string = input.responseType.toString();
+    const labelValue: string = input.responseType;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: responseType."
@@ -5709,19 +5837,19 @@ export async function serializeAws_restJson1_1PutGatewayResponseCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{responseType}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: responseType.");
   }
   if (input.restApiId !== undefined) {
-    const labelValue: string = input.restApiId.toString();
+    const labelValue: string = input.restApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: restApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{restApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: restApiId.");
@@ -5782,37 +5910,37 @@ export async function serializeAws_restJson1_1PutIntegrationCommand(
   let resolvedPath =
     "/restapis/{restApiId}/resources/{resourceId}/methods/{httpMethod}/integration";
   if (input.httpMethod !== undefined) {
-    const labelValue: string = input.httpMethod.toString();
+    const labelValue: string = input.httpMethod;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: httpMethod.");
     }
     resolvedPath = resolvedPath.replace(
       "{httpMethod}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: httpMethod.");
   }
   if (input.resourceId !== undefined) {
-    const labelValue: string = input.resourceId.toString();
+    const labelValue: string = input.resourceId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: resourceId.");
     }
     resolvedPath = resolvedPath.replace(
       "{resourceId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: resourceId.");
   }
   if (input.restApiId !== undefined) {
-    const labelValue: string = input.restApiId.toString();
+    const labelValue: string = input.restApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: restApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{restApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: restApiId.");
@@ -5906,49 +6034,49 @@ export async function serializeAws_restJson1_1PutIntegrationResponseCommand(
   let resolvedPath =
     "/restapis/{restApiId}/resources/{resourceId}/methods/{httpMethod}/integration/responses/{statusCode}";
   if (input.httpMethod !== undefined) {
-    const labelValue: string = input.httpMethod.toString();
+    const labelValue: string = input.httpMethod;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: httpMethod.");
     }
     resolvedPath = resolvedPath.replace(
       "{httpMethod}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: httpMethod.");
   }
   if (input.resourceId !== undefined) {
-    const labelValue: string = input.resourceId.toString();
+    const labelValue: string = input.resourceId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: resourceId.");
     }
     resolvedPath = resolvedPath.replace(
       "{resourceId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: resourceId.");
   }
   if (input.restApiId !== undefined) {
-    const labelValue: string = input.restApiId.toString();
+    const labelValue: string = input.restApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: restApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{restApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: restApiId.");
   }
   if (input.statusCode !== undefined) {
-    const labelValue: string = input.statusCode.toString();
+    const labelValue: string = input.statusCode;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: statusCode.");
     }
     resolvedPath = resolvedPath.replace(
       "{statusCode}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: statusCode.");
@@ -6012,37 +6140,37 @@ export async function serializeAws_restJson1_1PutMethodCommand(
   let resolvedPath =
     "/restapis/{restApiId}/resources/{resourceId}/methods/{httpMethod}";
   if (input.httpMethod !== undefined) {
-    const labelValue: string = input.httpMethod.toString();
+    const labelValue: string = input.httpMethod;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: httpMethod.");
     }
     resolvedPath = resolvedPath.replace(
       "{httpMethod}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: httpMethod.");
   }
   if (input.resourceId !== undefined) {
-    const labelValue: string = input.resourceId.toString();
+    const labelValue: string = input.resourceId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: resourceId.");
     }
     resolvedPath = resolvedPath.replace(
       "{resourceId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: resourceId.");
   }
   if (input.restApiId !== undefined) {
-    const labelValue: string = input.restApiId.toString();
+    const labelValue: string = input.restApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: restApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{restApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: restApiId.");
@@ -6119,49 +6247,49 @@ export async function serializeAws_restJson1_1PutMethodResponseCommand(
   let resolvedPath =
     "/restapis/{restApiId}/resources/{resourceId}/methods/{httpMethod}/responses/{statusCode}";
   if (input.httpMethod !== undefined) {
-    const labelValue: string = input.httpMethod.toString();
+    const labelValue: string = input.httpMethod;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: httpMethod.");
     }
     resolvedPath = resolvedPath.replace(
       "{httpMethod}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: httpMethod.");
   }
   if (input.resourceId !== undefined) {
-    const labelValue: string = input.resourceId.toString();
+    const labelValue: string = input.resourceId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: resourceId.");
     }
     resolvedPath = resolvedPath.replace(
       "{resourceId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: resourceId.");
   }
   if (input.restApiId !== undefined) {
-    const labelValue: string = input.restApiId.toString();
+    const labelValue: string = input.restApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: restApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{restApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: restApiId.");
   }
   if (input.statusCode !== undefined) {
-    const labelValue: string = input.statusCode.toString();
+    const labelValue: string = input.statusCode;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: statusCode.");
     }
     resolvedPath = resolvedPath.replace(
       "{statusCode}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: statusCode.");
@@ -6216,23 +6344,27 @@ export async function serializeAws_restJson1_1PutRestApiCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/restapis/{restApiId}";
   if (input.restApiId !== undefined) {
-    const labelValue: string = input.restApiId.toString();
+    const labelValue: string = input.restApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: restApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{restApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: restApiId.");
   }
   const query: any = {};
   if (input.failOnWarnings !== undefined) {
-    query["failonwarnings"] = input.failOnWarnings.toString();
+    query[
+      __extendedEncodeURIComponent("failonwarnings")
+    ] = __extendedEncodeURIComponent(input.failOnWarnings.toString());
   }
   if (input.mode !== undefined) {
-    query["mode"] = input.mode.toString();
+    query[__extendedEncodeURIComponent("mode")] = __extendedEncodeURIComponent(
+      input.mode
+    );
   }
   let body: any;
   const bodyParams: any = {};
@@ -6277,7 +6409,7 @@ export async function serializeAws_restJson1_1TagResourceCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/tags/{resourceArn}";
   if (input.resourceArn !== undefined) {
-    const labelValue: string = input.resourceArn.toString();
+    const labelValue: string = input.resourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: resourceArn."
@@ -6285,7 +6417,7 @@ export async function serializeAws_restJson1_1TagResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{resourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: resourceArn.");
@@ -6332,7 +6464,7 @@ export async function serializeAws_restJson1_1TestInvokeAuthorizerCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/restapis/{restApiId}/authorizers/{authorizerId}";
   if (input.authorizerId !== undefined) {
-    const labelValue: string = input.authorizerId.toString();
+    const labelValue: string = input.authorizerId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: authorizerId."
@@ -6340,19 +6472,19 @@ export async function serializeAws_restJson1_1TestInvokeAuthorizerCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{authorizerId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: authorizerId.");
   }
   if (input.restApiId !== undefined) {
-    const labelValue: string = input.restApiId.toString();
+    const labelValue: string = input.restApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: restApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{restApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: restApiId.");
@@ -6411,37 +6543,37 @@ export async function serializeAws_restJson1_1TestInvokeMethodCommand(
   let resolvedPath =
     "/restapis/{restApiId}/resources/{resourceId}/methods/{httpMethod}";
   if (input.httpMethod !== undefined) {
-    const labelValue: string = input.httpMethod.toString();
+    const labelValue: string = input.httpMethod;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: httpMethod.");
     }
     resolvedPath = resolvedPath.replace(
       "{httpMethod}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: httpMethod.");
   }
   if (input.resourceId !== undefined) {
-    const labelValue: string = input.resourceId.toString();
+    const labelValue: string = input.resourceId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: resourceId.");
     }
     resolvedPath = resolvedPath.replace(
       "{resourceId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: resourceId.");
   }
   if (input.restApiId !== undefined) {
-    const labelValue: string = input.restApiId.toString();
+    const labelValue: string = input.restApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: restApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{restApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: restApiId.");
@@ -6494,7 +6626,7 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/tags/{resourceArn}";
   if (input.resourceArn !== undefined) {
-    const labelValue: string = input.resourceArn.toString();
+    const labelValue: string = input.resourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: resourceArn."
@@ -6502,14 +6634,16 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{resourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: resourceArn.");
   }
   const query: any = {};
   if (input.tagKeys !== undefined) {
-    query["tagKeys"] = input.tagKeys;
+    query[__extendedEncodeURIComponent("tagKeys")] = input.tagKeys.map(entry =>
+      __extendedEncodeURIComponent(entry)
+    );
   }
   let body: any;
   const bodyParams: any = {};
@@ -6591,13 +6725,13 @@ export async function serializeAws_restJson1_1UpdateApiKeyCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/apikeys/{apiKey}";
   if (input.apiKey !== undefined) {
-    const labelValue: string = input.apiKey.toString();
+    const labelValue: string = input.apiKey;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: apiKey.");
     }
     resolvedPath = resolvedPath.replace(
       "{apiKey}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: apiKey.");
@@ -6646,7 +6780,7 @@ export async function serializeAws_restJson1_1UpdateAuthorizerCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/restapis/{restApiId}/authorizers/{authorizerId}";
   if (input.authorizerId !== undefined) {
-    const labelValue: string = input.authorizerId.toString();
+    const labelValue: string = input.authorizerId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: authorizerId."
@@ -6654,19 +6788,19 @@ export async function serializeAws_restJson1_1UpdateAuthorizerCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{authorizerId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: authorizerId.");
   }
   if (input.restApiId !== undefined) {
-    const labelValue: string = input.restApiId.toString();
+    const labelValue: string = input.restApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: restApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{restApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: restApiId.");
@@ -6715,25 +6849,25 @@ export async function serializeAws_restJson1_1UpdateBasePathMappingCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/domainnames/{domainName}/basepathmappings/{basePath}";
   if (input.basePath !== undefined) {
-    const labelValue: string = input.basePath.toString();
+    const labelValue: string = input.basePath;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: basePath.");
     }
     resolvedPath = resolvedPath.replace(
       "{basePath}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: basePath.");
   }
   if (input.domainName !== undefined) {
-    const labelValue: string = input.domainName.toString();
+    const labelValue: string = input.domainName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: domainName.");
     }
     resolvedPath = resolvedPath.replace(
       "{domainName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: domainName.");
@@ -6782,7 +6916,7 @@ export async function serializeAws_restJson1_1UpdateClientCertificateCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/clientcertificates/{clientCertificateId}";
   if (input.clientCertificateId !== undefined) {
-    const labelValue: string = input.clientCertificateId.toString();
+    const labelValue: string = input.clientCertificateId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: clientCertificateId."
@@ -6790,7 +6924,7 @@ export async function serializeAws_restJson1_1UpdateClientCertificateCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{clientCertificateId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -6841,7 +6975,7 @@ export async function serializeAws_restJson1_1UpdateDeploymentCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/restapis/{restApiId}/deployments/{deploymentId}";
   if (input.deploymentId !== undefined) {
-    const labelValue: string = input.deploymentId.toString();
+    const labelValue: string = input.deploymentId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: deploymentId."
@@ -6849,19 +6983,19 @@ export async function serializeAws_restJson1_1UpdateDeploymentCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{deploymentId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: deploymentId.");
   }
   if (input.restApiId !== undefined) {
-    const labelValue: string = input.restApiId.toString();
+    const labelValue: string = input.restApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: restApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{restApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: restApiId.");
@@ -6911,7 +7045,7 @@ export async function serializeAws_restJson1_1UpdateDocumentationPartCommand(
   let resolvedPath =
     "/restapis/{restApiId}/documentation/parts/{documentationPartId}";
   if (input.documentationPartId !== undefined) {
-    const labelValue: string = input.documentationPartId.toString();
+    const labelValue: string = input.documentationPartId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: documentationPartId."
@@ -6919,7 +7053,7 @@ export async function serializeAws_restJson1_1UpdateDocumentationPartCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{documentationPartId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -6927,13 +7061,13 @@ export async function serializeAws_restJson1_1UpdateDocumentationPartCommand(
     );
   }
   if (input.restApiId !== undefined) {
-    const labelValue: string = input.restApiId.toString();
+    const labelValue: string = input.restApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: restApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{restApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: restApiId.");
@@ -6983,7 +7117,7 @@ export async function serializeAws_restJson1_1UpdateDocumentationVersionCommand(
   let resolvedPath =
     "/restapis/{restApiId}/documentation/versions/{documentationVersion}";
   if (input.documentationVersion !== undefined) {
-    const labelValue: string = input.documentationVersion.toString();
+    const labelValue: string = input.documentationVersion;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: documentationVersion."
@@ -6991,7 +7125,7 @@ export async function serializeAws_restJson1_1UpdateDocumentationVersionCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{documentationVersion}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -6999,13 +7133,13 @@ export async function serializeAws_restJson1_1UpdateDocumentationVersionCommand(
     );
   }
   if (input.restApiId !== undefined) {
-    const labelValue: string = input.restApiId.toString();
+    const labelValue: string = input.restApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: restApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{restApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: restApiId.");
@@ -7054,13 +7188,13 @@ export async function serializeAws_restJson1_1UpdateDomainNameCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/domainnames/{domainName}";
   if (input.domainName !== undefined) {
-    const labelValue: string = input.domainName.toString();
+    const labelValue: string = input.domainName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: domainName.");
     }
     resolvedPath = resolvedPath.replace(
       "{domainName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: domainName.");
@@ -7109,7 +7243,7 @@ export async function serializeAws_restJson1_1UpdateGatewayResponseCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/restapis/{restApiId}/gatewayresponses/{responseType}";
   if (input.responseType !== undefined) {
-    const labelValue: string = input.responseType.toString();
+    const labelValue: string = input.responseType;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: responseType."
@@ -7117,19 +7251,19 @@ export async function serializeAws_restJson1_1UpdateGatewayResponseCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{responseType}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: responseType.");
   }
   if (input.restApiId !== undefined) {
-    const labelValue: string = input.restApiId.toString();
+    const labelValue: string = input.restApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: restApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{restApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: restApiId.");
@@ -7179,37 +7313,37 @@ export async function serializeAws_restJson1_1UpdateIntegrationCommand(
   let resolvedPath =
     "/restapis/{restApiId}/resources/{resourceId}/methods/{httpMethod}/integration";
   if (input.httpMethod !== undefined) {
-    const labelValue: string = input.httpMethod.toString();
+    const labelValue: string = input.httpMethod;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: httpMethod.");
     }
     resolvedPath = resolvedPath.replace(
       "{httpMethod}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: httpMethod.");
   }
   if (input.resourceId !== undefined) {
-    const labelValue: string = input.resourceId.toString();
+    const labelValue: string = input.resourceId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: resourceId.");
     }
     resolvedPath = resolvedPath.replace(
       "{resourceId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: resourceId.");
   }
   if (input.restApiId !== undefined) {
-    const labelValue: string = input.restApiId.toString();
+    const labelValue: string = input.restApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: restApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{restApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: restApiId.");
@@ -7259,49 +7393,49 @@ export async function serializeAws_restJson1_1UpdateIntegrationResponseCommand(
   let resolvedPath =
     "/restapis/{restApiId}/resources/{resourceId}/methods/{httpMethod}/integration/responses/{statusCode}";
   if (input.httpMethod !== undefined) {
-    const labelValue: string = input.httpMethod.toString();
+    const labelValue: string = input.httpMethod;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: httpMethod.");
     }
     resolvedPath = resolvedPath.replace(
       "{httpMethod}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: httpMethod.");
   }
   if (input.resourceId !== undefined) {
-    const labelValue: string = input.resourceId.toString();
+    const labelValue: string = input.resourceId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: resourceId.");
     }
     resolvedPath = resolvedPath.replace(
       "{resourceId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: resourceId.");
   }
   if (input.restApiId !== undefined) {
-    const labelValue: string = input.restApiId.toString();
+    const labelValue: string = input.restApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: restApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{restApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: restApiId.");
   }
   if (input.statusCode !== undefined) {
-    const labelValue: string = input.statusCode.toString();
+    const labelValue: string = input.statusCode;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: statusCode.");
     }
     resolvedPath = resolvedPath.replace(
       "{statusCode}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: statusCode.");
@@ -7351,37 +7485,37 @@ export async function serializeAws_restJson1_1UpdateMethodCommand(
   let resolvedPath =
     "/restapis/{restApiId}/resources/{resourceId}/methods/{httpMethod}";
   if (input.httpMethod !== undefined) {
-    const labelValue: string = input.httpMethod.toString();
+    const labelValue: string = input.httpMethod;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: httpMethod.");
     }
     resolvedPath = resolvedPath.replace(
       "{httpMethod}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: httpMethod.");
   }
   if (input.resourceId !== undefined) {
-    const labelValue: string = input.resourceId.toString();
+    const labelValue: string = input.resourceId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: resourceId.");
     }
     resolvedPath = resolvedPath.replace(
       "{resourceId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: resourceId.");
   }
   if (input.restApiId !== undefined) {
-    const labelValue: string = input.restApiId.toString();
+    const labelValue: string = input.restApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: restApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{restApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: restApiId.");
@@ -7431,49 +7565,49 @@ export async function serializeAws_restJson1_1UpdateMethodResponseCommand(
   let resolvedPath =
     "/restapis/{restApiId}/resources/{resourceId}/methods/{httpMethod}/responses/{statusCode}";
   if (input.httpMethod !== undefined) {
-    const labelValue: string = input.httpMethod.toString();
+    const labelValue: string = input.httpMethod;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: httpMethod.");
     }
     resolvedPath = resolvedPath.replace(
       "{httpMethod}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: httpMethod.");
   }
   if (input.resourceId !== undefined) {
-    const labelValue: string = input.resourceId.toString();
+    const labelValue: string = input.resourceId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: resourceId.");
     }
     resolvedPath = resolvedPath.replace(
       "{resourceId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: resourceId.");
   }
   if (input.restApiId !== undefined) {
-    const labelValue: string = input.restApiId.toString();
+    const labelValue: string = input.restApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: restApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{restApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: restApiId.");
   }
   if (input.statusCode !== undefined) {
-    const labelValue: string = input.statusCode.toString();
+    const labelValue: string = input.statusCode;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: statusCode.");
     }
     resolvedPath = resolvedPath.replace(
       "{statusCode}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: statusCode.");
@@ -7522,25 +7656,25 @@ export async function serializeAws_restJson1_1UpdateModelCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/restapis/{restApiId}/models/{modelName}";
   if (input.modelName !== undefined) {
-    const labelValue: string = input.modelName.toString();
+    const labelValue: string = input.modelName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: modelName.");
     }
     resolvedPath = resolvedPath.replace(
       "{modelName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: modelName.");
   }
   if (input.restApiId !== undefined) {
-    const labelValue: string = input.restApiId.toString();
+    const labelValue: string = input.restApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: restApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{restApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: restApiId.");
@@ -7590,7 +7724,7 @@ export async function serializeAws_restJson1_1UpdateRequestValidatorCommand(
   let resolvedPath =
     "/restapis/{restApiId}/requestvalidators/{requestValidatorId}";
   if (input.requestValidatorId !== undefined) {
-    const labelValue: string = input.requestValidatorId.toString();
+    const labelValue: string = input.requestValidatorId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: requestValidatorId."
@@ -7598,7 +7732,7 @@ export async function serializeAws_restJson1_1UpdateRequestValidatorCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{requestValidatorId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -7606,13 +7740,13 @@ export async function serializeAws_restJson1_1UpdateRequestValidatorCommand(
     );
   }
   if (input.restApiId !== undefined) {
-    const labelValue: string = input.restApiId.toString();
+    const labelValue: string = input.restApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: restApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{restApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: restApiId.");
@@ -7661,25 +7795,25 @@ export async function serializeAws_restJson1_1UpdateResourceCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/restapis/{restApiId}/resources/{resourceId}";
   if (input.resourceId !== undefined) {
-    const labelValue: string = input.resourceId.toString();
+    const labelValue: string = input.resourceId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: resourceId.");
     }
     resolvedPath = resolvedPath.replace(
       "{resourceId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: resourceId.");
   }
   if (input.restApiId !== undefined) {
-    const labelValue: string = input.restApiId.toString();
+    const labelValue: string = input.restApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: restApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{restApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: restApiId.");
@@ -7728,13 +7862,13 @@ export async function serializeAws_restJson1_1UpdateRestApiCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/restapis/{restApiId}";
   if (input.restApiId !== undefined) {
-    const labelValue: string = input.restApiId.toString();
+    const labelValue: string = input.restApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: restApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{restApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: restApiId.");
@@ -7783,25 +7917,25 @@ export async function serializeAws_restJson1_1UpdateStageCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/restapis/{restApiId}/stages/{stageName}";
   if (input.restApiId !== undefined) {
-    const labelValue: string = input.restApiId.toString();
+    const labelValue: string = input.restApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: restApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{restApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: restApiId.");
   }
   if (input.stageName !== undefined) {
-    const labelValue: string = input.stageName.toString();
+    const labelValue: string = input.stageName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: stageName.");
     }
     resolvedPath = resolvedPath.replace(
       "{stageName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: stageName.");
@@ -7850,19 +7984,19 @@ export async function serializeAws_restJson1_1UpdateUsageCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/usageplans/{usagePlanId}/keys/{keyId}/usage";
   if (input.keyId !== undefined) {
-    const labelValue: string = input.keyId.toString();
+    const labelValue: string = input.keyId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: keyId.");
     }
     resolvedPath = resolvedPath.replace(
       "{keyId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: keyId.");
   }
   if (input.usagePlanId !== undefined) {
-    const labelValue: string = input.usagePlanId.toString();
+    const labelValue: string = input.usagePlanId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: usagePlanId."
@@ -7870,7 +8004,7 @@ export async function serializeAws_restJson1_1UpdateUsageCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{usagePlanId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: usagePlanId.");
@@ -7919,7 +8053,7 @@ export async function serializeAws_restJson1_1UpdateUsagePlanCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/usageplans/{usagePlanId}";
   if (input.usagePlanId !== undefined) {
-    const labelValue: string = input.usagePlanId.toString();
+    const labelValue: string = input.usagePlanId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: usagePlanId."
@@ -7927,7 +8061,7 @@ export async function serializeAws_restJson1_1UpdateUsagePlanCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{usagePlanId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: usagePlanId.");
@@ -7976,13 +8110,13 @@ export async function serializeAws_restJson1_1UpdateVpcLinkCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/vpclinks/{vpcLinkId}";
   if (input.vpcLinkId !== undefined) {
-    const labelValue: string = input.vpcLinkId.toString();
+    const labelValue: string = input.vpcLinkId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: vpcLinkId.");
     }
     resolvedPath = resolvedPath.replace(
       "{vpcLinkId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: vpcLinkId.");
@@ -9828,6 +9962,7 @@ export async function deserializeAws_restJson1_1DeleteApiKeyCommand(
   const contents: DeleteApiKeyCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -9892,6 +10027,7 @@ export async function deserializeAws_restJson1_1DeleteAuthorizerCommand(
   const contents: DeleteAuthorizerCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -9970,6 +10106,7 @@ export async function deserializeAws_restJson1_1DeleteBasePathMappingCommand(
   const contents: DeleteBasePathMappingCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -10048,6 +10185,7 @@ export async function deserializeAws_restJson1_1DeleteClientCertificateCommand(
   const contents: DeleteClientCertificateCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -10119,6 +10257,7 @@ export async function deserializeAws_restJson1_1DeleteDeploymentCommand(
   const contents: DeleteDeploymentCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -10190,6 +10329,7 @@ export async function deserializeAws_restJson1_1DeleteDocumentationPartCommand(
   const contents: DeleteDocumentationPartCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -10268,6 +10408,7 @@ export async function deserializeAws_restJson1_1DeleteDocumentationVersionComman
   const contents: DeleteDocumentationVersionCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -10346,6 +10487,7 @@ export async function deserializeAws_restJson1_1DeleteDomainNameCommand(
   const contents: DeleteDomainNameCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -10417,6 +10559,7 @@ export async function deserializeAws_restJson1_1DeleteGatewayResponseCommand(
   const contents: DeleteGatewayResponseCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -10495,6 +10638,7 @@ export async function deserializeAws_restJson1_1DeleteIntegrationCommand(
   const contents: DeleteIntegrationCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -10566,6 +10710,7 @@ export async function deserializeAws_restJson1_1DeleteIntegrationResponseCommand
   const contents: DeleteIntegrationResponseCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -10641,6 +10786,7 @@ export async function deserializeAws_restJson1_1DeleteMethodCommand(
   const contents: DeleteMethodCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -10712,6 +10858,7 @@ export async function deserializeAws_restJson1_1DeleteMethodResponseCommand(
   const contents: DeleteMethodResponseCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -10787,6 +10934,7 @@ export async function deserializeAws_restJson1_1DeleteModelCommand(
   const contents: DeleteModelCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -10865,6 +11013,7 @@ export async function deserializeAws_restJson1_1DeleteRequestValidatorCommand(
   const contents: DeleteRequestValidatorCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -10943,6 +11092,7 @@ export async function deserializeAws_restJson1_1DeleteResourceCommand(
   const contents: DeleteResourceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -11018,6 +11168,7 @@ export async function deserializeAws_restJson1_1DeleteRestApiCommand(
   const contents: DeleteRestApiCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -11086,6 +11237,7 @@ export async function deserializeAws_restJson1_1DeleteStageCommand(
   const contents: DeleteStageCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -11157,6 +11309,7 @@ export async function deserializeAws_restJson1_1DeleteUsagePlanCommand(
   const contents: DeleteUsagePlanCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -11228,6 +11381,7 @@ export async function deserializeAws_restJson1_1DeleteUsagePlanKeyCommand(
   const contents: DeleteUsagePlanKeyCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -11303,6 +11457,7 @@ export async function deserializeAws_restJson1_1DeleteVpcLinkCommand(
   const contents: DeleteVpcLinkCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -11374,6 +11529,7 @@ export async function deserializeAws_restJson1_1FlushStageAuthorizersCacheComman
   const contents: FlushStageAuthorizersCacheCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -11445,6 +11601,7 @@ export async function deserializeAws_restJson1_1FlushStageCacheCommand(
   const contents: FlushStageCacheCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -16960,6 +17117,7 @@ export async function deserializeAws_restJson1_1TagResourceCommand(
   const contents: TagResourceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -17252,6 +17410,7 @@ export async function deserializeAws_restJson1_1UntagResourceCommand(
   const contents: UntagResourceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 

--- a/clients/client-apigatewaymanagementapi/models/index.ts
+++ b/clients/client-apigatewaymanagementapi/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export interface DeleteConnectionRequest {
@@ -8,23 +11,21 @@ export interface DeleteConnectionRequest {
 
 export namespace DeleteConnectionRequest {
   export function isa(o: any): o is DeleteConnectionRequest {
-    return _smithy.isa(o, "DeleteConnectionRequest");
+    return __isa(o, "DeleteConnectionRequest");
   }
 }
 
 /**
  * <p>The caller is not authorized to invoke this operation.</p>
  */
-export interface ForbiddenException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface ForbiddenException extends __SmithyException, $MetadataBearer {
   name: "ForbiddenException";
   $fault: "client";
 }
 
 export namespace ForbiddenException {
   export function isa(o: any): o is ForbiddenException {
-    return _smithy.isa(o, "ForbiddenException");
+    return __isa(o, "ForbiddenException");
   }
 }
 
@@ -35,7 +36,7 @@ export interface GetConnectionRequest {
 
 export namespace GetConnectionRequest {
   export function isa(o: any): o is GetConnectionRequest {
-    return _smithy.isa(o, "GetConnectionRequest");
+    return __isa(o, "GetConnectionRequest");
   }
 }
 
@@ -55,23 +56,21 @@ export interface GetConnectionResponse extends $MetadataBearer {
 
 export namespace GetConnectionResponse {
   export function isa(o: any): o is GetConnectionResponse {
-    return _smithy.isa(o, "GetConnectionResponse");
+    return __isa(o, "GetConnectionResponse");
   }
 }
 
 /**
  * <p>The connection with the provided id no longer exists.</p>
  */
-export interface GoneException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface GoneException extends __SmithyException, $MetadataBearer {
   name: "GoneException";
   $fault: "client";
 }
 
 export namespace GoneException {
   export function isa(o: any): o is GoneException {
-    return _smithy.isa(o, "GoneException");
+    return __isa(o, "GoneException");
   }
 }
 
@@ -90,7 +89,7 @@ export interface Identity {
 
 export namespace Identity {
   export function isa(o: any): o is Identity {
-    return _smithy.isa(o, "Identity");
+    return __isa(o, "Identity");
   }
 }
 
@@ -98,7 +97,7 @@ export namespace Identity {
  * <p>The client is sending more than the allowed number of requests per unit of time or the WebSocket client side buffer is full.</p>
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -106,7 +105,7 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
@@ -114,7 +113,7 @@ export namespace LimitExceededException {
  * <p>The data has exceeded the maximum size allowed.</p>
  */
 export interface PayloadTooLargeException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "PayloadTooLargeException";
   $fault: "client";
@@ -123,7 +122,7 @@ export interface PayloadTooLargeException
 
 export namespace PayloadTooLargeException {
   export function isa(o: any): o is PayloadTooLargeException {
-    return _smithy.isa(o, "PayloadTooLargeException");
+    return __isa(o, "PayloadTooLargeException");
   }
 }
 
@@ -142,6 +141,6 @@ export interface PostToConnectionRequest {
 
 export namespace PostToConnectionRequest {
   export function isa(o: any): o is PostToConnectionRequest {
-    return _smithy.isa(o, "PostToConnectionRequest");
+    return __isa(o, "PostToConnectionRequest");
   }
 }

--- a/clients/client-apigatewaymanagementapi/protocols/Aws_restJson1_1.ts
+++ b/clients/client-apigatewaymanagementapi/protocols/Aws_restJson1_1.ts
@@ -21,7 +21,10 @@ import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  extendedEncodeURIComponent as __extendedEncodeURIComponent
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -37,7 +40,7 @@ export async function serializeAws_restJson1_1DeleteConnectionCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/@connections/{ConnectionId}";
   if (input.ConnectionId !== undefined) {
-    const labelValue: string = input.ConnectionId.toString();
+    const labelValue: string = input.ConnectionId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ConnectionId."
@@ -45,7 +48,7 @@ export async function serializeAws_restJson1_1DeleteConnectionCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ConnectionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ConnectionId.");
@@ -67,7 +70,7 @@ export async function serializeAws_restJson1_1GetConnectionCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/@connections/{ConnectionId}";
   if (input.ConnectionId !== undefined) {
-    const labelValue: string = input.ConnectionId.toString();
+    const labelValue: string = input.ConnectionId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ConnectionId."
@@ -75,7 +78,7 @@ export async function serializeAws_restJson1_1GetConnectionCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ConnectionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ConnectionId.");
@@ -97,7 +100,7 @@ export async function serializeAws_restJson1_1PostToConnectionCommand(
   headers["Content-Type"] = "application/octet-stream";
   let resolvedPath = "/@connections/{ConnectionId}";
   if (input.ConnectionId !== undefined) {
-    const labelValue: string = input.ConnectionId.toString();
+    const labelValue: string = input.ConnectionId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ConnectionId."
@@ -105,7 +108,7 @@ export async function serializeAws_restJson1_1PostToConnectionCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ConnectionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ConnectionId.");
@@ -137,6 +140,7 @@ export async function deserializeAws_restJson1_1DeleteConnectionCommand(
   const contents: DeleteConnectionCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -279,6 +283,7 @@ export async function deserializeAws_restJson1_1PostToConnectionCommand(
   const contents: PostToConnectionCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -346,6 +351,7 @@ const deserializeAws_restJson1_1ForbiddenExceptionResponse = async (
     $fault: "client",
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return contents;
 };
 
@@ -358,6 +364,7 @@ const deserializeAws_restJson1_1GoneExceptionResponse = async (
     $fault: "client",
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return contents;
 };
 
@@ -370,6 +377,7 @@ const deserializeAws_restJson1_1LimitExceededExceptionResponse = async (
     $fault: "client",
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return contents;
 };
 

--- a/clients/client-apigatewayv2/models/index.ts
+++ b/clients/client-apigatewayv2/models/index.ts
@@ -1,8 +1,11 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export interface AccessDeniedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AccessDeniedException";
   $fault: "client";
@@ -11,7 +14,7 @@ export interface AccessDeniedException
 
 export namespace AccessDeniedException {
   export function isa(o: any): o is AccessDeniedException {
-    return _smithy.isa(o, "AccessDeniedException");
+    return __isa(o, "AccessDeniedException");
   }
 }
 
@@ -33,7 +36,7 @@ export interface AccessLogSettings {
 
 export namespace AccessLogSettings {
   export function isa(o: any): o is AccessLogSettings {
-    return _smithy.isa(o, "AccessLogSettings");
+    return __isa(o, "AccessLogSettings");
   }
 }
 
@@ -115,7 +118,7 @@ export interface Api {
 
 export namespace Api {
   export function isa(o: any): o is Api {
-    return _smithy.isa(o, "Api");
+    return __isa(o, "Api");
   }
 }
 
@@ -147,7 +150,7 @@ export interface ApiMapping {
 
 export namespace ApiMapping {
   export function isa(o: any): o is ApiMapping {
-    return _smithy.isa(o, "ApiMapping");
+    return __isa(o, "ApiMapping");
   }
 }
 
@@ -212,7 +215,7 @@ export interface Authorizer {
 
 export namespace Authorizer {
   export function isa(o: any): o is Authorizer {
-    return _smithy.isa(o, "Authorizer");
+    return __isa(o, "Authorizer");
   }
 }
 
@@ -225,7 +228,7 @@ export enum AuthorizerType {
  * <p>The request is not valid, for example, the input is incomplete or incorrect. See the accompanying error message for details.</p>
  */
 export interface BadRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "BadRequestException";
   $fault: "client";
@@ -237,16 +240,14 @@ export interface BadRequestException
 
 export namespace BadRequestException {
   export function isa(o: any): o is BadRequestException {
-    return _smithy.isa(o, "BadRequestException");
+    return __isa(o, "BadRequestException");
   }
 }
 
 /**
  * <p>The requested operation would cause a conflict with the current state of a service resource associated with the request. Resolve the conflict before retrying this request. See the accompanying error message for details.</p>
  */
-export interface ConflictException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface ConflictException extends __SmithyException, $MetadataBearer {
   name: "ConflictException";
   $fault: "client";
   /**
@@ -257,7 +258,7 @@ export interface ConflictException
 
 export namespace ConflictException {
   export function isa(o: any): o is ConflictException {
-    return _smithy.isa(o, "ConflictException");
+    return __isa(o, "ConflictException");
   }
 }
 
@@ -309,7 +310,7 @@ export interface Cors {
 
 export namespace Cors {
   export function isa(o: any): o is Cors {
-    return _smithy.isa(o, "Cors");
+    return __isa(o, "Cors");
   }
 }
 
@@ -341,7 +342,7 @@ export interface CreateApiMappingRequest {
 
 export namespace CreateApiMappingRequest {
   export function isa(o: any): o is CreateApiMappingRequest {
-    return _smithy.isa(o, "CreateApiMappingRequest");
+    return __isa(o, "CreateApiMappingRequest");
   }
 }
 
@@ -370,7 +371,7 @@ export interface CreateApiMappingResponse extends $MetadataBearer {
 
 export namespace CreateApiMappingResponse {
   export function isa(o: any): o is CreateApiMappingResponse {
-    return _smithy.isa(o, "CreateApiMappingResponse");
+    return __isa(o, "CreateApiMappingResponse");
   }
 }
 
@@ -442,7 +443,7 @@ export interface CreateApiRequest {
 
 export namespace CreateApiRequest {
   export function isa(o: any): o is CreateApiRequest {
-    return _smithy.isa(o, "CreateApiRequest");
+    return __isa(o, "CreateApiRequest");
   }
 }
 
@@ -521,7 +522,7 @@ export interface CreateApiResponse extends $MetadataBearer {
 
 export namespace CreateApiResponse {
   export function isa(o: any): o is CreateApiResponse {
-    return _smithy.isa(o, "CreateApiResponse");
+    return __isa(o, "CreateApiResponse");
   }
 }
 
@@ -579,7 +580,7 @@ export interface CreateAuthorizerRequest {
 
 export namespace CreateAuthorizerRequest {
   export function isa(o: any): o is CreateAuthorizerRequest {
-    return _smithy.isa(o, "CreateAuthorizerRequest");
+    return __isa(o, "CreateAuthorizerRequest");
   }
 }
 
@@ -634,7 +635,7 @@ export interface CreateAuthorizerResponse extends $MetadataBearer {
 
 export namespace CreateAuthorizerResponse {
   export function isa(o: any): o is CreateAuthorizerResponse {
-    return _smithy.isa(o, "CreateAuthorizerResponse");
+    return __isa(o, "CreateAuthorizerResponse");
   }
 }
 
@@ -661,7 +662,7 @@ export interface CreateDeploymentRequest {
 
 export namespace CreateDeploymentRequest {
   export function isa(o: any): o is CreateDeploymentRequest {
-    return _smithy.isa(o, "CreateDeploymentRequest");
+    return __isa(o, "CreateDeploymentRequest");
   }
 }
 
@@ -700,7 +701,7 @@ export interface CreateDeploymentResponse extends $MetadataBearer {
 
 export namespace CreateDeploymentResponse {
   export function isa(o: any): o is CreateDeploymentResponse {
-    return _smithy.isa(o, "CreateDeploymentResponse");
+    return __isa(o, "CreateDeploymentResponse");
   }
 }
 
@@ -727,7 +728,7 @@ export interface CreateDomainNameRequest {
 
 export namespace CreateDomainNameRequest {
   export function isa(o: any): o is CreateDomainNameRequest {
-    return _smithy.isa(o, "CreateDomainNameRequest");
+    return __isa(o, "CreateDomainNameRequest");
   }
 }
 
@@ -756,7 +757,7 @@ export interface CreateDomainNameResponse extends $MetadataBearer {
 
 export namespace CreateDomainNameResponse {
   export function isa(o: any): o is CreateDomainNameResponse {
-    return _smithy.isa(o, "CreateDomainNameResponse");
+    return __isa(o, "CreateDomainNameResponse");
   }
 }
 
@@ -848,7 +849,7 @@ export interface CreateIntegrationRequest {
 
 export namespace CreateIntegrationRequest {
   export function isa(o: any): o is CreateIntegrationRequest {
-    return _smithy.isa(o, "CreateIntegrationRequest");
+    return __isa(o, "CreateIntegrationRequest");
   }
 }
 
@@ -895,7 +896,7 @@ export interface CreateIntegrationResponseRequest {
 
 export namespace CreateIntegrationResponseRequest {
   export function isa(o: any): o is CreateIntegrationResponseRequest {
-    return _smithy.isa(o, "CreateIntegrationResponseRequest");
+    return __isa(o, "CreateIntegrationResponseRequest");
   }
 }
 
@@ -934,7 +935,7 @@ export interface CreateIntegrationResponseResponse extends $MetadataBearer {
 
 export namespace CreateIntegrationResponseResponse {
   export function isa(o: any): o is CreateIntegrationResponseResponse {
-    return _smithy.isa(o, "CreateIntegrationResponseResponse");
+    return __isa(o, "CreateIntegrationResponseResponse");
   }
 }
 
@@ -1033,7 +1034,7 @@ export interface CreateIntegrationResult extends $MetadataBearer {
 
 export namespace CreateIntegrationResult {
   export function isa(o: any): o is CreateIntegrationResult {
-    return _smithy.isa(o, "CreateIntegrationResult");
+    return __isa(o, "CreateIntegrationResult");
   }
 }
 
@@ -1070,7 +1071,7 @@ export interface CreateModelRequest {
 
 export namespace CreateModelRequest {
   export function isa(o: any): o is CreateModelRequest {
-    return _smithy.isa(o, "CreateModelRequest");
+    return __isa(o, "CreateModelRequest");
   }
 }
 
@@ -1104,7 +1105,7 @@ export interface CreateModelResponse extends $MetadataBearer {
 
 export namespace CreateModelResponse {
   export function isa(o: any): o is CreateModelResponse {
-    return _smithy.isa(o, "CreateModelResponse");
+    return __isa(o, "CreateModelResponse");
   }
 }
 
@@ -1176,7 +1177,7 @@ export interface CreateRouteRequest {
 
 export namespace CreateRouteRequest {
   export function isa(o: any): o is CreateRouteRequest {
-    return _smithy.isa(o, "CreateRouteRequest");
+    return __isa(o, "CreateRouteRequest");
   }
 }
 
@@ -1218,7 +1219,7 @@ export interface CreateRouteResponseRequest {
 
 export namespace CreateRouteResponseRequest {
   export function isa(o: any): o is CreateRouteResponseRequest {
-    return _smithy.isa(o, "CreateRouteResponseRequest");
+    return __isa(o, "CreateRouteResponseRequest");
   }
 }
 
@@ -1252,7 +1253,7 @@ export interface CreateRouteResponseResponse extends $MetadataBearer {
 
 export namespace CreateRouteResponseResponse {
   export function isa(o: any): o is CreateRouteResponseResponse {
-    return _smithy.isa(o, "CreateRouteResponseResponse");
+    return __isa(o, "CreateRouteResponseResponse");
   }
 }
 
@@ -1326,7 +1327,7 @@ export interface CreateRouteResult extends $MetadataBearer {
 
 export namespace CreateRouteResult {
   export function isa(o: any): o is CreateRouteResult {
-    return _smithy.isa(o, "CreateRouteResult");
+    return __isa(o, "CreateRouteResult");
   }
 }
 
@@ -1393,7 +1394,7 @@ export interface CreateStageRequest {
 
 export namespace CreateStageRequest {
   export function isa(o: any): o is CreateStageRequest {
-    return _smithy.isa(o, "CreateStageRequest");
+    return __isa(o, "CreateStageRequest");
   }
 }
 
@@ -1472,7 +1473,7 @@ export interface CreateStageResponse extends $MetadataBearer {
 
 export namespace CreateStageResponse {
   export function isa(o: any): o is CreateStageResponse {
-    return _smithy.isa(o, "CreateStageResponse");
+    return __isa(o, "CreateStageResponse");
   }
 }
 
@@ -1491,7 +1492,7 @@ export interface DeleteApiMappingRequest {
 
 export namespace DeleteApiMappingRequest {
   export function isa(o: any): o is DeleteApiMappingRequest {
-    return _smithy.isa(o, "DeleteApiMappingRequest");
+    return __isa(o, "DeleteApiMappingRequest");
   }
 }
 
@@ -1505,7 +1506,7 @@ export interface DeleteApiRequest {
 
 export namespace DeleteApiRequest {
   export function isa(o: any): o is DeleteApiRequest {
-    return _smithy.isa(o, "DeleteApiRequest");
+    return __isa(o, "DeleteApiRequest");
   }
 }
 
@@ -1524,7 +1525,7 @@ export interface DeleteAuthorizerRequest {
 
 export namespace DeleteAuthorizerRequest {
   export function isa(o: any): o is DeleteAuthorizerRequest {
-    return _smithy.isa(o, "DeleteAuthorizerRequest");
+    return __isa(o, "DeleteAuthorizerRequest");
   }
 }
 
@@ -1538,7 +1539,7 @@ export interface DeleteCorsConfigurationRequest {
 
 export namespace DeleteCorsConfigurationRequest {
   export function isa(o: any): o is DeleteCorsConfigurationRequest {
-    return _smithy.isa(o, "DeleteCorsConfigurationRequest");
+    return __isa(o, "DeleteCorsConfigurationRequest");
   }
 }
 
@@ -1557,7 +1558,7 @@ export interface DeleteDeploymentRequest {
 
 export namespace DeleteDeploymentRequest {
   export function isa(o: any): o is DeleteDeploymentRequest {
-    return _smithy.isa(o, "DeleteDeploymentRequest");
+    return __isa(o, "DeleteDeploymentRequest");
   }
 }
 
@@ -1571,7 +1572,7 @@ export interface DeleteDomainNameRequest {
 
 export namespace DeleteDomainNameRequest {
   export function isa(o: any): o is DeleteDomainNameRequest {
-    return _smithy.isa(o, "DeleteDomainNameRequest");
+    return __isa(o, "DeleteDomainNameRequest");
   }
 }
 
@@ -1590,7 +1591,7 @@ export interface DeleteIntegrationRequest {
 
 export namespace DeleteIntegrationRequest {
   export function isa(o: any): o is DeleteIntegrationRequest {
-    return _smithy.isa(o, "DeleteIntegrationRequest");
+    return __isa(o, "DeleteIntegrationRequest");
   }
 }
 
@@ -1614,7 +1615,7 @@ export interface DeleteIntegrationResponseRequest {
 
 export namespace DeleteIntegrationResponseRequest {
   export function isa(o: any): o is DeleteIntegrationResponseRequest {
-    return _smithy.isa(o, "DeleteIntegrationResponseRequest");
+    return __isa(o, "DeleteIntegrationResponseRequest");
   }
 }
 
@@ -1633,7 +1634,7 @@ export interface DeleteModelRequest {
 
 export namespace DeleteModelRequest {
   export function isa(o: any): o is DeleteModelRequest {
-    return _smithy.isa(o, "DeleteModelRequest");
+    return __isa(o, "DeleteModelRequest");
   }
 }
 
@@ -1652,7 +1653,7 @@ export interface DeleteRouteRequest {
 
 export namespace DeleteRouteRequest {
   export function isa(o: any): o is DeleteRouteRequest {
-    return _smithy.isa(o, "DeleteRouteRequest");
+    return __isa(o, "DeleteRouteRequest");
   }
 }
 
@@ -1676,7 +1677,7 @@ export interface DeleteRouteResponseRequest {
 
 export namespace DeleteRouteResponseRequest {
   export function isa(o: any): o is DeleteRouteResponseRequest {
-    return _smithy.isa(o, "DeleteRouteResponseRequest");
+    return __isa(o, "DeleteRouteResponseRequest");
   }
 }
 
@@ -1700,7 +1701,7 @@ export interface DeleteRouteSettingsRequest {
 
 export namespace DeleteRouteSettingsRequest {
   export function isa(o: any): o is DeleteRouteSettingsRequest {
-    return _smithy.isa(o, "DeleteRouteSettingsRequest");
+    return __isa(o, "DeleteRouteSettingsRequest");
   }
 }
 
@@ -1719,7 +1720,7 @@ export interface DeleteStageRequest {
 
 export namespace DeleteStageRequest {
   export function isa(o: any): o is DeleteStageRequest {
-    return _smithy.isa(o, "DeleteStageRequest");
+    return __isa(o, "DeleteStageRequest");
   }
 }
 
@@ -1761,7 +1762,7 @@ export interface Deployment {
 
 export namespace Deployment {
   export function isa(o: any): o is Deployment {
-    return _smithy.isa(o, "Deployment");
+    return __isa(o, "Deployment");
   }
 }
 
@@ -1799,7 +1800,7 @@ export interface DomainName {
 
 export namespace DomainName {
   export function isa(o: any): o is DomainName {
-    return _smithy.isa(o, "DomainName");
+    return __isa(o, "DomainName");
   }
 }
 
@@ -1856,7 +1857,7 @@ export interface DomainNameConfiguration {
 
 export namespace DomainNameConfiguration {
   export function isa(o: any): o is DomainNameConfiguration {
-    return _smithy.isa(o, "DomainNameConfiguration");
+    return __isa(o, "DomainNameConfiguration");
   }
 }
 
@@ -1885,7 +1886,7 @@ export interface GetApiMappingRequest {
 
 export namespace GetApiMappingRequest {
   export function isa(o: any): o is GetApiMappingRequest {
-    return _smithy.isa(o, "GetApiMappingRequest");
+    return __isa(o, "GetApiMappingRequest");
   }
 }
 
@@ -1914,7 +1915,7 @@ export interface GetApiMappingResponse extends $MetadataBearer {
 
 export namespace GetApiMappingResponse {
   export function isa(o: any): o is GetApiMappingResponse {
-    return _smithy.isa(o, "GetApiMappingResponse");
+    return __isa(o, "GetApiMappingResponse");
   }
 }
 
@@ -1938,7 +1939,7 @@ export interface GetApiMappingsRequest {
 
 export namespace GetApiMappingsRequest {
   export function isa(o: any): o is GetApiMappingsRequest {
-    return _smithy.isa(o, "GetApiMappingsRequest");
+    return __isa(o, "GetApiMappingsRequest");
   }
 }
 
@@ -1957,7 +1958,7 @@ export interface GetApiMappingsResponse extends $MetadataBearer {
 
 export namespace GetApiMappingsResponse {
   export function isa(o: any): o is GetApiMappingsResponse {
-    return _smithy.isa(o, "GetApiMappingsResponse");
+    return __isa(o, "GetApiMappingsResponse");
   }
 }
 
@@ -1971,7 +1972,7 @@ export interface GetApiRequest {
 
 export namespace GetApiRequest {
   export function isa(o: any): o is GetApiRequest {
-    return _smithy.isa(o, "GetApiRequest");
+    return __isa(o, "GetApiRequest");
   }
 }
 
@@ -2050,7 +2051,7 @@ export interface GetApiResponse extends $MetadataBearer {
 
 export namespace GetApiResponse {
   export function isa(o: any): o is GetApiResponse {
-    return _smithy.isa(o, "GetApiResponse");
+    return __isa(o, "GetApiResponse");
   }
 }
 
@@ -2069,7 +2070,7 @@ export interface GetApisRequest {
 
 export namespace GetApisRequest {
   export function isa(o: any): o is GetApisRequest {
-    return _smithy.isa(o, "GetApisRequest");
+    return __isa(o, "GetApisRequest");
   }
 }
 
@@ -2088,7 +2089,7 @@ export interface GetApisResponse extends $MetadataBearer {
 
 export namespace GetApisResponse {
   export function isa(o: any): o is GetApisResponse {
-    return _smithy.isa(o, "GetApisResponse");
+    return __isa(o, "GetApisResponse");
   }
 }
 
@@ -2107,7 +2108,7 @@ export interface GetAuthorizerRequest {
 
 export namespace GetAuthorizerRequest {
   export function isa(o: any): o is GetAuthorizerRequest {
-    return _smithy.isa(o, "GetAuthorizerRequest");
+    return __isa(o, "GetAuthorizerRequest");
   }
 }
 
@@ -2162,7 +2163,7 @@ export interface GetAuthorizerResponse extends $MetadataBearer {
 
 export namespace GetAuthorizerResponse {
   export function isa(o: any): o is GetAuthorizerResponse {
-    return _smithy.isa(o, "GetAuthorizerResponse");
+    return __isa(o, "GetAuthorizerResponse");
   }
 }
 
@@ -2186,7 +2187,7 @@ export interface GetAuthorizersRequest {
 
 export namespace GetAuthorizersRequest {
   export function isa(o: any): o is GetAuthorizersRequest {
-    return _smithy.isa(o, "GetAuthorizersRequest");
+    return __isa(o, "GetAuthorizersRequest");
   }
 }
 
@@ -2205,7 +2206,7 @@ export interface GetAuthorizersResponse extends $MetadataBearer {
 
 export namespace GetAuthorizersResponse {
   export function isa(o: any): o is GetAuthorizersResponse {
-    return _smithy.isa(o, "GetAuthorizersResponse");
+    return __isa(o, "GetAuthorizersResponse");
   }
 }
 
@@ -2224,7 +2225,7 @@ export interface GetDeploymentRequest {
 
 export namespace GetDeploymentRequest {
   export function isa(o: any): o is GetDeploymentRequest {
-    return _smithy.isa(o, "GetDeploymentRequest");
+    return __isa(o, "GetDeploymentRequest");
   }
 }
 
@@ -2263,7 +2264,7 @@ export interface GetDeploymentResponse extends $MetadataBearer {
 
 export namespace GetDeploymentResponse {
   export function isa(o: any): o is GetDeploymentResponse {
-    return _smithy.isa(o, "GetDeploymentResponse");
+    return __isa(o, "GetDeploymentResponse");
   }
 }
 
@@ -2287,7 +2288,7 @@ export interface GetDeploymentsRequest {
 
 export namespace GetDeploymentsRequest {
   export function isa(o: any): o is GetDeploymentsRequest {
-    return _smithy.isa(o, "GetDeploymentsRequest");
+    return __isa(o, "GetDeploymentsRequest");
   }
 }
 
@@ -2306,7 +2307,7 @@ export interface GetDeploymentsResponse extends $MetadataBearer {
 
 export namespace GetDeploymentsResponse {
   export function isa(o: any): o is GetDeploymentsResponse {
-    return _smithy.isa(o, "GetDeploymentsResponse");
+    return __isa(o, "GetDeploymentsResponse");
   }
 }
 
@@ -2320,7 +2321,7 @@ export interface GetDomainNameRequest {
 
 export namespace GetDomainNameRequest {
   export function isa(o: any): o is GetDomainNameRequest {
-    return _smithy.isa(o, "GetDomainNameRequest");
+    return __isa(o, "GetDomainNameRequest");
   }
 }
 
@@ -2349,7 +2350,7 @@ export interface GetDomainNameResponse extends $MetadataBearer {
 
 export namespace GetDomainNameResponse {
   export function isa(o: any): o is GetDomainNameResponse {
-    return _smithy.isa(o, "GetDomainNameResponse");
+    return __isa(o, "GetDomainNameResponse");
   }
 }
 
@@ -2368,7 +2369,7 @@ export interface GetDomainNamesRequest {
 
 export namespace GetDomainNamesRequest {
   export function isa(o: any): o is GetDomainNamesRequest {
-    return _smithy.isa(o, "GetDomainNamesRequest");
+    return __isa(o, "GetDomainNamesRequest");
   }
 }
 
@@ -2387,7 +2388,7 @@ export interface GetDomainNamesResponse extends $MetadataBearer {
 
 export namespace GetDomainNamesResponse {
   export function isa(o: any): o is GetDomainNamesResponse {
-    return _smithy.isa(o, "GetDomainNamesResponse");
+    return __isa(o, "GetDomainNamesResponse");
   }
 }
 
@@ -2406,7 +2407,7 @@ export interface GetIntegrationRequest {
 
 export namespace GetIntegrationRequest {
   export function isa(o: any): o is GetIntegrationRequest {
-    return _smithy.isa(o, "GetIntegrationRequest");
+    return __isa(o, "GetIntegrationRequest");
   }
 }
 
@@ -2430,7 +2431,7 @@ export interface GetIntegrationResponseRequest {
 
 export namespace GetIntegrationResponseRequest {
   export function isa(o: any): o is GetIntegrationResponseRequest {
-    return _smithy.isa(o, "GetIntegrationResponseRequest");
+    return __isa(o, "GetIntegrationResponseRequest");
   }
 }
 
@@ -2469,7 +2470,7 @@ export interface GetIntegrationResponseResponse extends $MetadataBearer {
 
 export namespace GetIntegrationResponseResponse {
   export function isa(o: any): o is GetIntegrationResponseResponse {
-    return _smithy.isa(o, "GetIntegrationResponseResponse");
+    return __isa(o, "GetIntegrationResponseResponse");
   }
 }
 
@@ -2498,7 +2499,7 @@ export interface GetIntegrationResponsesRequest {
 
 export namespace GetIntegrationResponsesRequest {
   export function isa(o: any): o is GetIntegrationResponsesRequest {
-    return _smithy.isa(o, "GetIntegrationResponsesRequest");
+    return __isa(o, "GetIntegrationResponsesRequest");
   }
 }
 
@@ -2517,7 +2518,7 @@ export interface GetIntegrationResponsesResponse extends $MetadataBearer {
 
 export namespace GetIntegrationResponsesResponse {
   export function isa(o: any): o is GetIntegrationResponsesResponse {
-    return _smithy.isa(o, "GetIntegrationResponsesResponse");
+    return __isa(o, "GetIntegrationResponsesResponse");
   }
 }
 
@@ -2616,7 +2617,7 @@ export interface GetIntegrationResult extends $MetadataBearer {
 
 export namespace GetIntegrationResult {
   export function isa(o: any): o is GetIntegrationResult {
-    return _smithy.isa(o, "GetIntegrationResult");
+    return __isa(o, "GetIntegrationResult");
   }
 }
 
@@ -2640,7 +2641,7 @@ export interface GetIntegrationsRequest {
 
 export namespace GetIntegrationsRequest {
   export function isa(o: any): o is GetIntegrationsRequest {
-    return _smithy.isa(o, "GetIntegrationsRequest");
+    return __isa(o, "GetIntegrationsRequest");
   }
 }
 
@@ -2659,7 +2660,7 @@ export interface GetIntegrationsResponse extends $MetadataBearer {
 
 export namespace GetIntegrationsResponse {
   export function isa(o: any): o is GetIntegrationsResponse {
-    return _smithy.isa(o, "GetIntegrationsResponse");
+    return __isa(o, "GetIntegrationsResponse");
   }
 }
 
@@ -2678,7 +2679,7 @@ export interface GetModelRequest {
 
 export namespace GetModelRequest {
   export function isa(o: any): o is GetModelRequest {
-    return _smithy.isa(o, "GetModelRequest");
+    return __isa(o, "GetModelRequest");
   }
 }
 
@@ -2712,7 +2713,7 @@ export interface GetModelResponse extends $MetadataBearer {
 
 export namespace GetModelResponse {
   export function isa(o: any): o is GetModelResponse {
-    return _smithy.isa(o, "GetModelResponse");
+    return __isa(o, "GetModelResponse");
   }
 }
 
@@ -2731,7 +2732,7 @@ export interface GetModelTemplateRequest {
 
 export namespace GetModelTemplateRequest {
   export function isa(o: any): o is GetModelTemplateRequest {
-    return _smithy.isa(o, "GetModelTemplateRequest");
+    return __isa(o, "GetModelTemplateRequest");
   }
 }
 
@@ -2745,7 +2746,7 @@ export interface GetModelTemplateResponse extends $MetadataBearer {
 
 export namespace GetModelTemplateResponse {
   export function isa(o: any): o is GetModelTemplateResponse {
-    return _smithy.isa(o, "GetModelTemplateResponse");
+    return __isa(o, "GetModelTemplateResponse");
   }
 }
 
@@ -2769,7 +2770,7 @@ export interface GetModelsRequest {
 
 export namespace GetModelsRequest {
   export function isa(o: any): o is GetModelsRequest {
-    return _smithy.isa(o, "GetModelsRequest");
+    return __isa(o, "GetModelsRequest");
   }
 }
 
@@ -2788,7 +2789,7 @@ export interface GetModelsResponse extends $MetadataBearer {
 
 export namespace GetModelsResponse {
   export function isa(o: any): o is GetModelsResponse {
-    return _smithy.isa(o, "GetModelsResponse");
+    return __isa(o, "GetModelsResponse");
   }
 }
 
@@ -2807,7 +2808,7 @@ export interface GetRouteRequest {
 
 export namespace GetRouteRequest {
   export function isa(o: any): o is GetRouteRequest {
-    return _smithy.isa(o, "GetRouteRequest");
+    return __isa(o, "GetRouteRequest");
   }
 }
 
@@ -2831,7 +2832,7 @@ export interface GetRouteResponseRequest {
 
 export namespace GetRouteResponseRequest {
   export function isa(o: any): o is GetRouteResponseRequest {
-    return _smithy.isa(o, "GetRouteResponseRequest");
+    return __isa(o, "GetRouteResponseRequest");
   }
 }
 
@@ -2865,7 +2866,7 @@ export interface GetRouteResponseResponse extends $MetadataBearer {
 
 export namespace GetRouteResponseResponse {
   export function isa(o: any): o is GetRouteResponseResponse {
-    return _smithy.isa(o, "GetRouteResponseResponse");
+    return __isa(o, "GetRouteResponseResponse");
   }
 }
 
@@ -2894,7 +2895,7 @@ export interface GetRouteResponsesRequest {
 
 export namespace GetRouteResponsesRequest {
   export function isa(o: any): o is GetRouteResponsesRequest {
-    return _smithy.isa(o, "GetRouteResponsesRequest");
+    return __isa(o, "GetRouteResponsesRequest");
   }
 }
 
@@ -2913,7 +2914,7 @@ export interface GetRouteResponsesResponse extends $MetadataBearer {
 
 export namespace GetRouteResponsesResponse {
   export function isa(o: any): o is GetRouteResponsesResponse {
-    return _smithy.isa(o, "GetRouteResponsesResponse");
+    return __isa(o, "GetRouteResponsesResponse");
   }
 }
 
@@ -2987,7 +2988,7 @@ export interface GetRouteResult extends $MetadataBearer {
 
 export namespace GetRouteResult {
   export function isa(o: any): o is GetRouteResult {
-    return _smithy.isa(o, "GetRouteResult");
+    return __isa(o, "GetRouteResult");
   }
 }
 
@@ -3011,7 +3012,7 @@ export interface GetRoutesRequest {
 
 export namespace GetRoutesRequest {
   export function isa(o: any): o is GetRoutesRequest {
-    return _smithy.isa(o, "GetRoutesRequest");
+    return __isa(o, "GetRoutesRequest");
   }
 }
 
@@ -3030,7 +3031,7 @@ export interface GetRoutesResponse extends $MetadataBearer {
 
 export namespace GetRoutesResponse {
   export function isa(o: any): o is GetRoutesResponse {
-    return _smithy.isa(o, "GetRoutesResponse");
+    return __isa(o, "GetRoutesResponse");
   }
 }
 
@@ -3049,7 +3050,7 @@ export interface GetStageRequest {
 
 export namespace GetStageRequest {
   export function isa(o: any): o is GetStageRequest {
-    return _smithy.isa(o, "GetStageRequest");
+    return __isa(o, "GetStageRequest");
   }
 }
 
@@ -3128,7 +3129,7 @@ export interface GetStageResponse extends $MetadataBearer {
 
 export namespace GetStageResponse {
   export function isa(o: any): o is GetStageResponse {
-    return _smithy.isa(o, "GetStageResponse");
+    return __isa(o, "GetStageResponse");
   }
 }
 
@@ -3152,7 +3153,7 @@ export interface GetStagesRequest {
 
 export namespace GetStagesRequest {
   export function isa(o: any): o is GetStagesRequest {
-    return _smithy.isa(o, "GetStagesRequest");
+    return __isa(o, "GetStagesRequest");
   }
 }
 
@@ -3171,7 +3172,7 @@ export interface GetStagesResponse extends $MetadataBearer {
 
 export namespace GetStagesResponse {
   export function isa(o: any): o is GetStagesResponse {
-    return _smithy.isa(o, "GetStagesResponse");
+    return __isa(o, "GetStagesResponse");
   }
 }
 
@@ -3185,7 +3186,7 @@ export interface GetTagsRequest {
 
 export namespace GetTagsRequest {
   export function isa(o: any): o is GetTagsRequest {
-    return _smithy.isa(o, "GetTagsRequest");
+    return __isa(o, "GetTagsRequest");
   }
 }
 
@@ -3199,7 +3200,7 @@ export interface GetTagsResponse extends $MetadataBearer {
 
 export namespace GetTagsResponse {
   export function isa(o: any): o is GetTagsResponse {
-    return _smithy.isa(o, "GetTagsResponse");
+    return __isa(o, "GetTagsResponse");
   }
 }
 
@@ -3226,7 +3227,7 @@ export interface ImportApiRequest {
 
 export namespace ImportApiRequest {
   export function isa(o: any): o is ImportApiRequest {
-    return _smithy.isa(o, "ImportApiRequest");
+    return __isa(o, "ImportApiRequest");
   }
 }
 
@@ -3305,7 +3306,7 @@ export interface ImportApiResponse extends $MetadataBearer {
 
 export namespace ImportApiResponse {
   export function isa(o: any): o is ImportApiResponse {
-    return _smithy.isa(o, "ImportApiResponse");
+    return __isa(o, "ImportApiResponse");
   }
 }
 
@@ -3407,7 +3408,7 @@ export interface Integration {
 
 export namespace Integration {
   export function isa(o: any): o is Integration {
-    return _smithy.isa(o, "Integration");
+    return __isa(o, "Integration");
   }
 }
 
@@ -3449,7 +3450,7 @@ export interface IntegrationResponse {
 
 export namespace IntegrationResponse {
   export function isa(o: any): o is IntegrationResponse {
-    return _smithy.isa(o, "IntegrationResponse");
+    return __isa(o, "IntegrationResponse");
   }
 }
 
@@ -3480,7 +3481,7 @@ export interface JWTConfiguration {
 
 export namespace JWTConfiguration {
   export function isa(o: any): o is JWTConfiguration {
-    return _smithy.isa(o, "JWTConfiguration");
+    return __isa(o, "JWTConfiguration");
   }
 }
 
@@ -3523,16 +3524,14 @@ export interface Model {
 
 export namespace Model {
   export function isa(o: any): o is Model {
-    return _smithy.isa(o, "Model");
+    return __isa(o, "Model");
   }
 }
 
 /**
  * <p>The resource specified in the request was not found. See the message field for more information.</p>
  */
-export interface NotFoundException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface NotFoundException extends __SmithyException, $MetadataBearer {
   name: "NotFoundException";
   $fault: "client";
   /**
@@ -3548,7 +3547,7 @@ export interface NotFoundException
 
 export namespace NotFoundException {
   export function isa(o: any): o is NotFoundException {
-    return _smithy.isa(o, "NotFoundException");
+    return __isa(o, "NotFoundException");
   }
 }
 
@@ -3565,7 +3564,7 @@ export interface ParameterConstraints {
 
 export namespace ParameterConstraints {
   export function isa(o: any): o is ParameterConstraints {
-    return _smithy.isa(o, "ParameterConstraints");
+    return __isa(o, "ParameterConstraints");
   }
 }
 
@@ -3608,7 +3607,7 @@ export interface ReimportApiRequest {
 
 export namespace ReimportApiRequest {
   export function isa(o: any): o is ReimportApiRequest {
-    return _smithy.isa(o, "ReimportApiRequest");
+    return __isa(o, "ReimportApiRequest");
   }
 }
 
@@ -3687,7 +3686,7 @@ export interface ReimportApiResponse extends $MetadataBearer {
 
 export namespace ReimportApiResponse {
   export function isa(o: any): o is ReimportApiResponse {
-    return _smithy.isa(o, "ReimportApiResponse");
+    return __isa(o, "ReimportApiResponse");
   }
 }
 
@@ -3764,7 +3763,7 @@ export interface Route {
 
 export namespace Route {
   export function isa(o: any): o is Route {
-    return _smithy.isa(o, "Route");
+    return __isa(o, "Route");
   }
 }
 
@@ -3801,7 +3800,7 @@ export interface RouteResponse {
 
 export namespace RouteResponse {
   export function isa(o: any): o is RouteResponse {
-    return _smithy.isa(o, "RouteResponse");
+    return __isa(o, "RouteResponse");
   }
 }
 
@@ -3838,7 +3837,7 @@ export interface RouteSettings {
 
 export namespace RouteSettings {
   export function isa(o: any): o is RouteSettings {
-    return _smithy.isa(o, "RouteSettings");
+    return __isa(o, "RouteSettings");
   }
 }
 
@@ -3925,7 +3924,7 @@ export interface Stage {
 
 export namespace Stage {
   export function isa(o: any): o is Stage {
-    return _smithy.isa(o, "Stage");
+    return __isa(o, "Stage");
   }
 }
 
@@ -3947,7 +3946,7 @@ export interface TagResourceRequest {
 
 export namespace TagResourceRequest {
   export function isa(o: any): o is TagResourceRequest {
-    return _smithy.isa(o, "TagResourceRequest");
+    return __isa(o, "TagResourceRequest");
   }
 }
 
@@ -3957,7 +3956,7 @@ export interface TagResourceResponse extends $MetadataBearer {
 
 export namespace TagResourceResponse {
   export function isa(o: any): o is TagResourceResponse {
-    return _smithy.isa(o, "TagResourceResponse");
+    return __isa(o, "TagResourceResponse");
   }
 }
 
@@ -3965,7 +3964,7 @@ export namespace TagResourceResponse {
  * <p>A limit has been exceeded. See the accompanying error message for details.</p>
  */
 export interface TooManyRequestsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyRequestsException";
   $fault: "client";
@@ -3982,7 +3981,7 @@ export interface TooManyRequestsException
 
 export namespace TooManyRequestsException {
   export function isa(o: any): o is TooManyRequestsException {
-    return _smithy.isa(o, "TooManyRequestsException");
+    return __isa(o, "TooManyRequestsException");
   }
 }
 
@@ -4001,7 +4000,7 @@ export interface UntagResourceRequest {
 
 export namespace UntagResourceRequest {
   export function isa(o: any): o is UntagResourceRequest {
-    return _smithy.isa(o, "UntagResourceRequest");
+    return __isa(o, "UntagResourceRequest");
   }
 }
 
@@ -4038,7 +4037,7 @@ export interface UpdateApiMappingRequest {
 
 export namespace UpdateApiMappingRequest {
   export function isa(o: any): o is UpdateApiMappingRequest {
-    return _smithy.isa(o, "UpdateApiMappingRequest");
+    return __isa(o, "UpdateApiMappingRequest");
   }
 }
 
@@ -4067,7 +4066,7 @@ export interface UpdateApiMappingResponse extends $MetadataBearer {
 
 export namespace UpdateApiMappingResponse {
   export function isa(o: any): o is UpdateApiMappingResponse {
-    return _smithy.isa(o, "UpdateApiMappingResponse");
+    return __isa(o, "UpdateApiMappingResponse");
   }
 }
 
@@ -4134,7 +4133,7 @@ export interface UpdateApiRequest {
 
 export namespace UpdateApiRequest {
   export function isa(o: any): o is UpdateApiRequest {
-    return _smithy.isa(o, "UpdateApiRequest");
+    return __isa(o, "UpdateApiRequest");
   }
 }
 
@@ -4213,7 +4212,7 @@ export interface UpdateApiResponse extends $MetadataBearer {
 
 export namespace UpdateApiResponse {
   export function isa(o: any): o is UpdateApiResponse {
-    return _smithy.isa(o, "UpdateApiResponse");
+    return __isa(o, "UpdateApiResponse");
   }
 }
 
@@ -4276,7 +4275,7 @@ export interface UpdateAuthorizerRequest {
 
 export namespace UpdateAuthorizerRequest {
   export function isa(o: any): o is UpdateAuthorizerRequest {
-    return _smithy.isa(o, "UpdateAuthorizerRequest");
+    return __isa(o, "UpdateAuthorizerRequest");
   }
 }
 
@@ -4331,7 +4330,7 @@ export interface UpdateAuthorizerResponse extends $MetadataBearer {
 
 export namespace UpdateAuthorizerResponse {
   export function isa(o: any): o is UpdateAuthorizerResponse {
-    return _smithy.isa(o, "UpdateAuthorizerResponse");
+    return __isa(o, "UpdateAuthorizerResponse");
   }
 }
 
@@ -4358,7 +4357,7 @@ export interface UpdateDeploymentRequest {
 
 export namespace UpdateDeploymentRequest {
   export function isa(o: any): o is UpdateDeploymentRequest {
-    return _smithy.isa(o, "UpdateDeploymentRequest");
+    return __isa(o, "UpdateDeploymentRequest");
   }
 }
 
@@ -4397,7 +4396,7 @@ export interface UpdateDeploymentResponse extends $MetadataBearer {
 
 export namespace UpdateDeploymentResponse {
   export function isa(o: any): o is UpdateDeploymentResponse {
-    return _smithy.isa(o, "UpdateDeploymentResponse");
+    return __isa(o, "UpdateDeploymentResponse");
   }
 }
 
@@ -4419,7 +4418,7 @@ export interface UpdateDomainNameRequest {
 
 export namespace UpdateDomainNameRequest {
   export function isa(o: any): o is UpdateDomainNameRequest {
-    return _smithy.isa(o, "UpdateDomainNameRequest");
+    return __isa(o, "UpdateDomainNameRequest");
   }
 }
 
@@ -4448,7 +4447,7 @@ export interface UpdateDomainNameResponse extends $MetadataBearer {
 
 export namespace UpdateDomainNameResponse {
   export function isa(o: any): o is UpdateDomainNameResponse {
-    return _smithy.isa(o, "UpdateDomainNameResponse");
+    return __isa(o, "UpdateDomainNameResponse");
   }
 }
 
@@ -4545,7 +4544,7 @@ export interface UpdateIntegrationRequest {
 
 export namespace UpdateIntegrationRequest {
   export function isa(o: any): o is UpdateIntegrationRequest {
-    return _smithy.isa(o, "UpdateIntegrationRequest");
+    return __isa(o, "UpdateIntegrationRequest");
   }
 }
 
@@ -4604,7 +4603,7 @@ export interface UpdateIntegrationResponseRequest {
 
 export namespace UpdateIntegrationResponseRequest {
   export function isa(o: any): o is UpdateIntegrationResponseRequest {
-    return _smithy.isa(o, "UpdateIntegrationResponseRequest");
+    return __isa(o, "UpdateIntegrationResponseRequest");
   }
 }
 
@@ -4643,7 +4642,7 @@ export interface UpdateIntegrationResponseResponse extends $MetadataBearer {
 
 export namespace UpdateIntegrationResponseResponse {
   export function isa(o: any): o is UpdateIntegrationResponseResponse {
-    return _smithy.isa(o, "UpdateIntegrationResponseResponse");
+    return __isa(o, "UpdateIntegrationResponseResponse");
   }
 }
 
@@ -4742,7 +4741,7 @@ export interface UpdateIntegrationResult extends $MetadataBearer {
 
 export namespace UpdateIntegrationResult {
   export function isa(o: any): o is UpdateIntegrationResult {
-    return _smithy.isa(o, "UpdateIntegrationResult");
+    return __isa(o, "UpdateIntegrationResult");
   }
 }
 
@@ -4784,7 +4783,7 @@ export interface UpdateModelRequest {
 
 export namespace UpdateModelRequest {
   export function isa(o: any): o is UpdateModelRequest {
-    return _smithy.isa(o, "UpdateModelRequest");
+    return __isa(o, "UpdateModelRequest");
   }
 }
 
@@ -4818,7 +4817,7 @@ export interface UpdateModelResponse extends $MetadataBearer {
 
 export namespace UpdateModelResponse {
   export function isa(o: any): o is UpdateModelResponse {
-    return _smithy.isa(o, "UpdateModelResponse");
+    return __isa(o, "UpdateModelResponse");
   }
 }
 
@@ -4895,7 +4894,7 @@ export interface UpdateRouteRequest {
 
 export namespace UpdateRouteRequest {
   export function isa(o: any): o is UpdateRouteRequest {
-    return _smithy.isa(o, "UpdateRouteRequest");
+    return __isa(o, "UpdateRouteRequest");
   }
 }
 
@@ -4942,7 +4941,7 @@ export interface UpdateRouteResponseRequest {
 
 export namespace UpdateRouteResponseRequest {
   export function isa(o: any): o is UpdateRouteResponseRequest {
-    return _smithy.isa(o, "UpdateRouteResponseRequest");
+    return __isa(o, "UpdateRouteResponseRequest");
   }
 }
 
@@ -4976,7 +4975,7 @@ export interface UpdateRouteResponseResponse extends $MetadataBearer {
 
 export namespace UpdateRouteResponseResponse {
   export function isa(o: any): o is UpdateRouteResponseResponse {
-    return _smithy.isa(o, "UpdateRouteResponseResponse");
+    return __isa(o, "UpdateRouteResponseResponse");
   }
 }
 
@@ -5050,7 +5049,7 @@ export interface UpdateRouteResult extends $MetadataBearer {
 
 export namespace UpdateRouteResult {
   export function isa(o: any): o is UpdateRouteResult {
-    return _smithy.isa(o, "UpdateRouteResult");
+    return __isa(o, "UpdateRouteResult");
   }
 }
 
@@ -5112,7 +5111,7 @@ export interface UpdateStageRequest {
 
 export namespace UpdateStageRequest {
   export function isa(o: any): o is UpdateStageRequest {
-    return _smithy.isa(o, "UpdateStageRequest");
+    return __isa(o, "UpdateStageRequest");
   }
 }
 
@@ -5191,6 +5190,6 @@ export interface UpdateStageResponse extends $MetadataBearer {
 
 export namespace UpdateStageResponse {
   export function isa(o: any): o is UpdateStageResponse {
-    return _smithy.isa(o, "UpdateStageResponse");
+    return __isa(o, "UpdateStageResponse");
   }
 }

--- a/clients/client-apigatewayv2/protocols/Aws_restJson1_1.ts
+++ b/clients/client-apigatewayv2/protocols/Aws_restJson1_1.ts
@@ -278,7 +278,10 @@ import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  extendedEncodeURIComponent as __extendedEncodeURIComponent
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -353,13 +356,13 @@ export async function serializeAws_restJson1_1CreateApiMappingCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v2/domainnames/{DomainName}/apimappings";
   if (input.DomainName !== undefined) {
-    const labelValue: string = input.DomainName.toString();
+    const labelValue: string = input.DomainName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DomainName.");
     }
     resolvedPath = resolvedPath.replace(
       "{DomainName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DomainName.");
@@ -394,13 +397,13 @@ export async function serializeAws_restJson1_1CreateAuthorizerCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v2/apis/{ApiId}/authorizers";
   if (input.ApiId !== undefined) {
-    const labelValue: string = input.ApiId.toString();
+    const labelValue: string = input.ApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{ApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApiId.");
@@ -458,13 +461,13 @@ export async function serializeAws_restJson1_1CreateDeploymentCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v2/apis/{ApiId}/deployments";
   if (input.ApiId !== undefined) {
-    const labelValue: string = input.ApiId.toString();
+    const labelValue: string = input.ApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{ApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApiId.");
@@ -530,13 +533,13 @@ export async function serializeAws_restJson1_1CreateIntegrationCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v2/apis/{ApiId}/integrations";
   if (input.ApiId !== undefined) {
-    const labelValue: string = input.ApiId.toString();
+    const labelValue: string = input.ApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{ApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApiId.");
@@ -614,19 +617,19 @@ export async function serializeAws_restJson1_1CreateIntegrationResponseCommand(
   let resolvedPath =
     "/v2/apis/{ApiId}/integrations/{IntegrationId}/integrationresponses";
   if (input.ApiId !== undefined) {
-    const labelValue: string = input.ApiId.toString();
+    const labelValue: string = input.ApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{ApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApiId.");
   }
   if (input.IntegrationId !== undefined) {
-    const labelValue: string = input.IntegrationId.toString();
+    const labelValue: string = input.IntegrationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: IntegrationId."
@@ -634,7 +637,7 @@ export async function serializeAws_restJson1_1CreateIntegrationResponseCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{IntegrationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: IntegrationId.");
@@ -684,13 +687,13 @@ export async function serializeAws_restJson1_1CreateModelCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v2/apis/{ApiId}/models";
   if (input.ApiId !== undefined) {
-    const labelValue: string = input.ApiId.toString();
+    const labelValue: string = input.ApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{ApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApiId.");
@@ -728,13 +731,13 @@ export async function serializeAws_restJson1_1CreateRouteCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v2/apis/{ApiId}/routes";
   if (input.ApiId !== undefined) {
-    const labelValue: string = input.ApiId.toString();
+    const labelValue: string = input.ApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{ApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApiId.");
@@ -805,25 +808,25 @@ export async function serializeAws_restJson1_1CreateRouteResponseCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v2/apis/{ApiId}/routes/{RouteId}/routeresponses";
   if (input.ApiId !== undefined) {
-    const labelValue: string = input.ApiId.toString();
+    const labelValue: string = input.ApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{ApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApiId.");
   }
   if (input.RouteId !== undefined) {
-    const labelValue: string = input.RouteId.toString();
+    const labelValue: string = input.RouteId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: RouteId.");
     }
     resolvedPath = resolvedPath.replace(
       "{RouteId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: RouteId.");
@@ -867,13 +870,13 @@ export async function serializeAws_restJson1_1CreateStageCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v2/apis/{ApiId}/stages";
   if (input.ApiId !== undefined) {
-    const labelValue: string = input.ApiId.toString();
+    const labelValue: string = input.ApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{ApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApiId.");
@@ -941,13 +944,13 @@ export async function serializeAws_restJson1_1DeleteApiCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v2/apis/{ApiId}";
   if (input.ApiId !== undefined) {
-    const labelValue: string = input.ApiId.toString();
+    const labelValue: string = input.ApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{ApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApiId.");
@@ -969,7 +972,7 @@ export async function serializeAws_restJson1_1DeleteApiMappingCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v2/domainnames/{DomainName}/apimappings/{ApiMappingId}";
   if (input.ApiMappingId !== undefined) {
-    const labelValue: string = input.ApiMappingId.toString();
+    const labelValue: string = input.ApiMappingId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApiMappingId."
@@ -977,19 +980,19 @@ export async function serializeAws_restJson1_1DeleteApiMappingCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApiMappingId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApiMappingId.");
   }
   if (input.DomainName !== undefined) {
-    const labelValue: string = input.DomainName.toString();
+    const labelValue: string = input.DomainName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DomainName.");
     }
     resolvedPath = resolvedPath.replace(
       "{DomainName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DomainName.");
@@ -1011,19 +1014,19 @@ export async function serializeAws_restJson1_1DeleteAuthorizerCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v2/apis/{ApiId}/authorizers/{AuthorizerId}";
   if (input.ApiId !== undefined) {
-    const labelValue: string = input.ApiId.toString();
+    const labelValue: string = input.ApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{ApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApiId.");
   }
   if (input.AuthorizerId !== undefined) {
-    const labelValue: string = input.AuthorizerId.toString();
+    const labelValue: string = input.AuthorizerId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: AuthorizerId."
@@ -1031,7 +1034,7 @@ export async function serializeAws_restJson1_1DeleteAuthorizerCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{AuthorizerId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AuthorizerId.");
@@ -1053,13 +1056,13 @@ export async function serializeAws_restJson1_1DeleteCorsConfigurationCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v2/apis/{ApiId}/cors";
   if (input.ApiId !== undefined) {
-    const labelValue: string = input.ApiId.toString();
+    const labelValue: string = input.ApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{ApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApiId.");
@@ -1081,19 +1084,19 @@ export async function serializeAws_restJson1_1DeleteDeploymentCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v2/apis/{ApiId}/deployments/{DeploymentId}";
   if (input.ApiId !== undefined) {
-    const labelValue: string = input.ApiId.toString();
+    const labelValue: string = input.ApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{ApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApiId.");
   }
   if (input.DeploymentId !== undefined) {
-    const labelValue: string = input.DeploymentId.toString();
+    const labelValue: string = input.DeploymentId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: DeploymentId."
@@ -1101,7 +1104,7 @@ export async function serializeAws_restJson1_1DeleteDeploymentCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{DeploymentId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DeploymentId.");
@@ -1123,13 +1126,13 @@ export async function serializeAws_restJson1_1DeleteDomainNameCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v2/domainnames/{DomainName}";
   if (input.DomainName !== undefined) {
-    const labelValue: string = input.DomainName.toString();
+    const labelValue: string = input.DomainName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DomainName.");
     }
     resolvedPath = resolvedPath.replace(
       "{DomainName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DomainName.");
@@ -1151,19 +1154,19 @@ export async function serializeAws_restJson1_1DeleteIntegrationCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v2/apis/{ApiId}/integrations/{IntegrationId}";
   if (input.ApiId !== undefined) {
-    const labelValue: string = input.ApiId.toString();
+    const labelValue: string = input.ApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{ApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApiId.");
   }
   if (input.IntegrationId !== undefined) {
-    const labelValue: string = input.IntegrationId.toString();
+    const labelValue: string = input.IntegrationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: IntegrationId."
@@ -1171,7 +1174,7 @@ export async function serializeAws_restJson1_1DeleteIntegrationCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{IntegrationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: IntegrationId.");
@@ -1194,19 +1197,19 @@ export async function serializeAws_restJson1_1DeleteIntegrationResponseCommand(
   let resolvedPath =
     "/v2/apis/{ApiId}/integrations/{IntegrationId}/integrationresponses/{IntegrationResponseId}";
   if (input.ApiId !== undefined) {
-    const labelValue: string = input.ApiId.toString();
+    const labelValue: string = input.ApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{ApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApiId.");
   }
   if (input.IntegrationId !== undefined) {
-    const labelValue: string = input.IntegrationId.toString();
+    const labelValue: string = input.IntegrationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: IntegrationId."
@@ -1214,13 +1217,13 @@ export async function serializeAws_restJson1_1DeleteIntegrationResponseCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{IntegrationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: IntegrationId.");
   }
   if (input.IntegrationResponseId !== undefined) {
-    const labelValue: string = input.IntegrationResponseId.toString();
+    const labelValue: string = input.IntegrationResponseId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: IntegrationResponseId."
@@ -1228,7 +1231,7 @@ export async function serializeAws_restJson1_1DeleteIntegrationResponseCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{IntegrationResponseId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -1252,25 +1255,25 @@ export async function serializeAws_restJson1_1DeleteModelCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v2/apis/{ApiId}/models/{ModelId}";
   if (input.ApiId !== undefined) {
-    const labelValue: string = input.ApiId.toString();
+    const labelValue: string = input.ApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{ApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApiId.");
   }
   if (input.ModelId !== undefined) {
-    const labelValue: string = input.ModelId.toString();
+    const labelValue: string = input.ModelId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ModelId.");
     }
     resolvedPath = resolvedPath.replace(
       "{ModelId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ModelId.");
@@ -1292,25 +1295,25 @@ export async function serializeAws_restJson1_1DeleteRouteCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v2/apis/{ApiId}/routes/{RouteId}";
   if (input.ApiId !== undefined) {
-    const labelValue: string = input.ApiId.toString();
+    const labelValue: string = input.ApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{ApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApiId.");
   }
   if (input.RouteId !== undefined) {
-    const labelValue: string = input.RouteId.toString();
+    const labelValue: string = input.RouteId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: RouteId.");
     }
     resolvedPath = resolvedPath.replace(
       "{RouteId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: RouteId.");
@@ -1333,31 +1336,31 @@ export async function serializeAws_restJson1_1DeleteRouteResponseCommand(
   let resolvedPath =
     "/v2/apis/{ApiId}/routes/{RouteId}/routeresponses/{RouteResponseId}";
   if (input.ApiId !== undefined) {
-    const labelValue: string = input.ApiId.toString();
+    const labelValue: string = input.ApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{ApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApiId.");
   }
   if (input.RouteId !== undefined) {
-    const labelValue: string = input.RouteId.toString();
+    const labelValue: string = input.RouteId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: RouteId.");
     }
     resolvedPath = resolvedPath.replace(
       "{RouteId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: RouteId.");
   }
   if (input.RouteResponseId !== undefined) {
-    const labelValue: string = input.RouteResponseId.toString();
+    const labelValue: string = input.RouteResponseId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: RouteResponseId."
@@ -1365,7 +1368,7 @@ export async function serializeAws_restJson1_1DeleteRouteResponseCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{RouteResponseId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: RouteResponseId.");
@@ -1388,37 +1391,37 @@ export async function serializeAws_restJson1_1DeleteRouteSettingsCommand(
   let resolvedPath =
     "/v2/apis/{ApiId}/stages/{StageName}/routesettings/{RouteKey}";
   if (input.ApiId !== undefined) {
-    const labelValue: string = input.ApiId.toString();
+    const labelValue: string = input.ApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{ApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApiId.");
   }
   if (input.RouteKey !== undefined) {
-    const labelValue: string = input.RouteKey.toString();
+    const labelValue: string = input.RouteKey;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: RouteKey.");
     }
     resolvedPath = resolvedPath.replace(
       "{RouteKey}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: RouteKey.");
   }
   if (input.StageName !== undefined) {
-    const labelValue: string = input.StageName.toString();
+    const labelValue: string = input.StageName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: StageName.");
     }
     resolvedPath = resolvedPath.replace(
       "{StageName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: StageName.");
@@ -1440,25 +1443,25 @@ export async function serializeAws_restJson1_1DeleteStageCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v2/apis/{ApiId}/stages/{StageName}";
   if (input.ApiId !== undefined) {
-    const labelValue: string = input.ApiId.toString();
+    const labelValue: string = input.ApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{ApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApiId.");
   }
   if (input.StageName !== undefined) {
-    const labelValue: string = input.StageName.toString();
+    const labelValue: string = input.StageName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: StageName.");
     }
     resolvedPath = resolvedPath.replace(
       "{StageName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: StageName.");
@@ -1480,13 +1483,13 @@ export async function serializeAws_restJson1_1GetApiCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v2/apis/{ApiId}";
   if (input.ApiId !== undefined) {
-    const labelValue: string = input.ApiId.toString();
+    const labelValue: string = input.ApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{ApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApiId.");
@@ -1508,7 +1511,7 @@ export async function serializeAws_restJson1_1GetApiMappingCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v2/domainnames/{DomainName}/apimappings/{ApiMappingId}";
   if (input.ApiMappingId !== undefined) {
-    const labelValue: string = input.ApiMappingId.toString();
+    const labelValue: string = input.ApiMappingId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApiMappingId."
@@ -1516,19 +1519,19 @@ export async function serializeAws_restJson1_1GetApiMappingCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApiMappingId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApiMappingId.");
   }
   if (input.DomainName !== undefined) {
-    const labelValue: string = input.DomainName.toString();
+    const labelValue: string = input.DomainName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DomainName.");
     }
     resolvedPath = resolvedPath.replace(
       "{DomainName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DomainName.");
@@ -1550,23 +1553,27 @@ export async function serializeAws_restJson1_1GetApiMappingsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v2/domainnames/{DomainName}/apimappings";
   if (input.DomainName !== undefined) {
-    const labelValue: string = input.DomainName.toString();
+    const labelValue: string = input.DomainName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DomainName.");
     }
     resolvedPath = resolvedPath.replace(
       "{DomainName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DomainName.");
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults);
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1587,10 +1594,14 @@ export async function serializeAws_restJson1_1GetApisCommand(
   let resolvedPath = "/v2/apis";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults);
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1610,19 +1621,19 @@ export async function serializeAws_restJson1_1GetAuthorizerCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v2/apis/{ApiId}/authorizers/{AuthorizerId}";
   if (input.ApiId !== undefined) {
-    const labelValue: string = input.ApiId.toString();
+    const labelValue: string = input.ApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{ApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApiId.");
   }
   if (input.AuthorizerId !== undefined) {
-    const labelValue: string = input.AuthorizerId.toString();
+    const labelValue: string = input.AuthorizerId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: AuthorizerId."
@@ -1630,7 +1641,7 @@ export async function serializeAws_restJson1_1GetAuthorizerCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{AuthorizerId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AuthorizerId.");
@@ -1652,23 +1663,27 @@ export async function serializeAws_restJson1_1GetAuthorizersCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v2/apis/{ApiId}/authorizers";
   if (input.ApiId !== undefined) {
-    const labelValue: string = input.ApiId.toString();
+    const labelValue: string = input.ApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{ApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApiId.");
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults);
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1688,19 +1703,19 @@ export async function serializeAws_restJson1_1GetDeploymentCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v2/apis/{ApiId}/deployments/{DeploymentId}";
   if (input.ApiId !== undefined) {
-    const labelValue: string = input.ApiId.toString();
+    const labelValue: string = input.ApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{ApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApiId.");
   }
   if (input.DeploymentId !== undefined) {
-    const labelValue: string = input.DeploymentId.toString();
+    const labelValue: string = input.DeploymentId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: DeploymentId."
@@ -1708,7 +1723,7 @@ export async function serializeAws_restJson1_1GetDeploymentCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{DeploymentId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DeploymentId.");
@@ -1730,23 +1745,27 @@ export async function serializeAws_restJson1_1GetDeploymentsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v2/apis/{ApiId}/deployments";
   if (input.ApiId !== undefined) {
-    const labelValue: string = input.ApiId.toString();
+    const labelValue: string = input.ApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{ApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApiId.");
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults);
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1766,13 +1785,13 @@ export async function serializeAws_restJson1_1GetDomainNameCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v2/domainnames/{DomainName}";
   if (input.DomainName !== undefined) {
-    const labelValue: string = input.DomainName.toString();
+    const labelValue: string = input.DomainName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DomainName.");
     }
     resolvedPath = resolvedPath.replace(
       "{DomainName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DomainName.");
@@ -1795,10 +1814,14 @@ export async function serializeAws_restJson1_1GetDomainNamesCommand(
   let resolvedPath = "/v2/domainnames";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults);
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1818,19 +1841,19 @@ export async function serializeAws_restJson1_1GetIntegrationCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v2/apis/{ApiId}/integrations/{IntegrationId}";
   if (input.ApiId !== undefined) {
-    const labelValue: string = input.ApiId.toString();
+    const labelValue: string = input.ApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{ApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApiId.");
   }
   if (input.IntegrationId !== undefined) {
-    const labelValue: string = input.IntegrationId.toString();
+    const labelValue: string = input.IntegrationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: IntegrationId."
@@ -1838,7 +1861,7 @@ export async function serializeAws_restJson1_1GetIntegrationCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{IntegrationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: IntegrationId.");
@@ -1861,19 +1884,19 @@ export async function serializeAws_restJson1_1GetIntegrationResponseCommand(
   let resolvedPath =
     "/v2/apis/{ApiId}/integrations/{IntegrationId}/integrationresponses/{IntegrationResponseId}";
   if (input.ApiId !== undefined) {
-    const labelValue: string = input.ApiId.toString();
+    const labelValue: string = input.ApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{ApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApiId.");
   }
   if (input.IntegrationId !== undefined) {
-    const labelValue: string = input.IntegrationId.toString();
+    const labelValue: string = input.IntegrationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: IntegrationId."
@@ -1881,13 +1904,13 @@ export async function serializeAws_restJson1_1GetIntegrationResponseCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{IntegrationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: IntegrationId.");
   }
   if (input.IntegrationResponseId !== undefined) {
-    const labelValue: string = input.IntegrationResponseId.toString();
+    const labelValue: string = input.IntegrationResponseId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: IntegrationResponseId."
@@ -1895,7 +1918,7 @@ export async function serializeAws_restJson1_1GetIntegrationResponseCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{IntegrationResponseId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -1920,19 +1943,19 @@ export async function serializeAws_restJson1_1GetIntegrationResponsesCommand(
   let resolvedPath =
     "/v2/apis/{ApiId}/integrations/{IntegrationId}/integrationresponses";
   if (input.ApiId !== undefined) {
-    const labelValue: string = input.ApiId.toString();
+    const labelValue: string = input.ApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{ApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApiId.");
   }
   if (input.IntegrationId !== undefined) {
-    const labelValue: string = input.IntegrationId.toString();
+    const labelValue: string = input.IntegrationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: IntegrationId."
@@ -1940,17 +1963,21 @@ export async function serializeAws_restJson1_1GetIntegrationResponsesCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{IntegrationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: IntegrationId.");
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults);
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1970,23 +1997,27 @@ export async function serializeAws_restJson1_1GetIntegrationsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v2/apis/{ApiId}/integrations";
   if (input.ApiId !== undefined) {
-    const labelValue: string = input.ApiId.toString();
+    const labelValue: string = input.ApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{ApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApiId.");
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults);
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2006,25 +2037,25 @@ export async function serializeAws_restJson1_1GetModelCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v2/apis/{ApiId}/models/{ModelId}";
   if (input.ApiId !== undefined) {
-    const labelValue: string = input.ApiId.toString();
+    const labelValue: string = input.ApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{ApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApiId.");
   }
   if (input.ModelId !== undefined) {
-    const labelValue: string = input.ModelId.toString();
+    const labelValue: string = input.ModelId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ModelId.");
     }
     resolvedPath = resolvedPath.replace(
       "{ModelId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ModelId.");
@@ -2046,25 +2077,25 @@ export async function serializeAws_restJson1_1GetModelTemplateCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v2/apis/{ApiId}/models/{ModelId}/template";
   if (input.ApiId !== undefined) {
-    const labelValue: string = input.ApiId.toString();
+    const labelValue: string = input.ApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{ApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApiId.");
   }
   if (input.ModelId !== undefined) {
-    const labelValue: string = input.ModelId.toString();
+    const labelValue: string = input.ModelId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ModelId.");
     }
     resolvedPath = resolvedPath.replace(
       "{ModelId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ModelId.");
@@ -2086,23 +2117,27 @@ export async function serializeAws_restJson1_1GetModelsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v2/apis/{ApiId}/models";
   if (input.ApiId !== undefined) {
-    const labelValue: string = input.ApiId.toString();
+    const labelValue: string = input.ApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{ApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApiId.");
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults);
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2122,25 +2157,25 @@ export async function serializeAws_restJson1_1GetRouteCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v2/apis/{ApiId}/routes/{RouteId}";
   if (input.ApiId !== undefined) {
-    const labelValue: string = input.ApiId.toString();
+    const labelValue: string = input.ApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{ApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApiId.");
   }
   if (input.RouteId !== undefined) {
-    const labelValue: string = input.RouteId.toString();
+    const labelValue: string = input.RouteId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: RouteId.");
     }
     resolvedPath = resolvedPath.replace(
       "{RouteId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: RouteId.");
@@ -2163,31 +2198,31 @@ export async function serializeAws_restJson1_1GetRouteResponseCommand(
   let resolvedPath =
     "/v2/apis/{ApiId}/routes/{RouteId}/routeresponses/{RouteResponseId}";
   if (input.ApiId !== undefined) {
-    const labelValue: string = input.ApiId.toString();
+    const labelValue: string = input.ApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{ApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApiId.");
   }
   if (input.RouteId !== undefined) {
-    const labelValue: string = input.RouteId.toString();
+    const labelValue: string = input.RouteId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: RouteId.");
     }
     resolvedPath = resolvedPath.replace(
       "{RouteId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: RouteId.");
   }
   if (input.RouteResponseId !== undefined) {
-    const labelValue: string = input.RouteResponseId.toString();
+    const labelValue: string = input.RouteResponseId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: RouteResponseId."
@@ -2195,7 +2230,7 @@ export async function serializeAws_restJson1_1GetRouteResponseCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{RouteResponseId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: RouteResponseId.");
@@ -2217,35 +2252,39 @@ export async function serializeAws_restJson1_1GetRouteResponsesCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v2/apis/{ApiId}/routes/{RouteId}/routeresponses";
   if (input.ApiId !== undefined) {
-    const labelValue: string = input.ApiId.toString();
+    const labelValue: string = input.ApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{ApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApiId.");
   }
   if (input.RouteId !== undefined) {
-    const labelValue: string = input.RouteId.toString();
+    const labelValue: string = input.RouteId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: RouteId.");
     }
     resolvedPath = resolvedPath.replace(
       "{RouteId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: RouteId.");
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults);
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2265,23 +2304,27 @@ export async function serializeAws_restJson1_1GetRoutesCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v2/apis/{ApiId}/routes";
   if (input.ApiId !== undefined) {
-    const labelValue: string = input.ApiId.toString();
+    const labelValue: string = input.ApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{ApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApiId.");
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults);
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2301,25 +2344,25 @@ export async function serializeAws_restJson1_1GetStageCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v2/apis/{ApiId}/stages/{StageName}";
   if (input.ApiId !== undefined) {
-    const labelValue: string = input.ApiId.toString();
+    const labelValue: string = input.ApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{ApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApiId.");
   }
   if (input.StageName !== undefined) {
-    const labelValue: string = input.StageName.toString();
+    const labelValue: string = input.StageName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: StageName.");
     }
     resolvedPath = resolvedPath.replace(
       "{StageName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: StageName.");
@@ -2341,23 +2384,27 @@ export async function serializeAws_restJson1_1GetStagesCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v2/apis/{ApiId}/stages";
   if (input.ApiId !== undefined) {
-    const labelValue: string = input.ApiId.toString();
+    const labelValue: string = input.ApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{ApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApiId.");
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults);
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2377,7 +2424,7 @@ export async function serializeAws_restJson1_1GetTagsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v2/tags/{ResourceArn}";
   if (input.ResourceArn !== undefined) {
-    const labelValue: string = input.ResourceArn.toString();
+    const labelValue: string = input.ResourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ResourceArn."
@@ -2385,7 +2432,7 @@ export async function serializeAws_restJson1_1GetTagsCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ResourceArn.");
@@ -2408,10 +2455,14 @@ export async function serializeAws_restJson1_1ImportApiCommand(
   let resolvedPath = "/v2/apis";
   const query: any = {};
   if (input.Basepath !== undefined) {
-    query["basepath"] = input.Basepath.toString();
+    query[
+      __extendedEncodeURIComponent("basepath")
+    ] = __extendedEncodeURIComponent(input.Basepath);
   }
   if (input.FailOnWarnings !== undefined) {
-    query["failOnWarnings"] = input.FailOnWarnings.toString();
+    query[
+      __extendedEncodeURIComponent("failOnWarnings")
+    ] = __extendedEncodeURIComponent(input.FailOnWarnings.toString());
   }
   let body: any;
   const bodyParams: any = {};
@@ -2438,23 +2489,27 @@ export async function serializeAws_restJson1_1ReimportApiCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v2/apis/{ApiId}";
   if (input.ApiId !== undefined) {
-    const labelValue: string = input.ApiId.toString();
+    const labelValue: string = input.ApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{ApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApiId.");
   }
   const query: any = {};
   if (input.Basepath !== undefined) {
-    query["basepath"] = input.Basepath.toString();
+    query[
+      __extendedEncodeURIComponent("basepath")
+    ] = __extendedEncodeURIComponent(input.Basepath);
   }
   if (input.FailOnWarnings !== undefined) {
-    query["failOnWarnings"] = input.FailOnWarnings.toString();
+    query[
+      __extendedEncodeURIComponent("failOnWarnings")
+    ] = __extendedEncodeURIComponent(input.FailOnWarnings.toString());
   }
   let body: any;
   const bodyParams: any = {};
@@ -2481,7 +2536,7 @@ export async function serializeAws_restJson1_1TagResourceCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v2/tags/{ResourceArn}";
   if (input.ResourceArn !== undefined) {
-    const labelValue: string = input.ResourceArn.toString();
+    const labelValue: string = input.ResourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ResourceArn."
@@ -2489,7 +2544,7 @@ export async function serializeAws_restJson1_1TagResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ResourceArn.");
@@ -2518,7 +2573,7 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v2/tags/{ResourceArn}";
   if (input.ResourceArn !== undefined) {
-    const labelValue: string = input.ResourceArn.toString();
+    const labelValue: string = input.ResourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ResourceArn."
@@ -2526,14 +2581,16 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ResourceArn.");
   }
   const query: any = {};
   if (input.TagKeys !== undefined) {
-    query["tagKeys"] = input.TagKeys;
+    query[__extendedEncodeURIComponent("tagKeys")] = input.TagKeys.map(entry =>
+      __extendedEncodeURIComponent(entry)
+    );
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2553,13 +2610,13 @@ export async function serializeAws_restJson1_1UpdateApiCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v2/apis/{ApiId}";
   if (input.ApiId !== undefined) {
-    const labelValue: string = input.ApiId.toString();
+    const labelValue: string = input.ApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{ApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApiId.");
@@ -2618,7 +2675,7 @@ export async function serializeAws_restJson1_1UpdateApiMappingCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v2/domainnames/{DomainName}/apimappings/{ApiMappingId}";
   if (input.ApiMappingId !== undefined) {
-    const labelValue: string = input.ApiMappingId.toString();
+    const labelValue: string = input.ApiMappingId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApiMappingId."
@@ -2626,19 +2683,19 @@ export async function serializeAws_restJson1_1UpdateApiMappingCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApiMappingId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApiMappingId.");
   }
   if (input.DomainName !== undefined) {
-    const labelValue: string = input.DomainName.toString();
+    const labelValue: string = input.DomainName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DomainName.");
     }
     resolvedPath = resolvedPath.replace(
       "{DomainName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DomainName.");
@@ -2673,19 +2730,19 @@ export async function serializeAws_restJson1_1UpdateAuthorizerCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v2/apis/{ApiId}/authorizers/{AuthorizerId}";
   if (input.ApiId !== undefined) {
-    const labelValue: string = input.ApiId.toString();
+    const labelValue: string = input.ApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{ApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApiId.");
   }
   if (input.AuthorizerId !== undefined) {
-    const labelValue: string = input.AuthorizerId.toString();
+    const labelValue: string = input.AuthorizerId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: AuthorizerId."
@@ -2693,7 +2750,7 @@ export async function serializeAws_restJson1_1UpdateAuthorizerCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{AuthorizerId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AuthorizerId.");
@@ -2751,19 +2808,19 @@ export async function serializeAws_restJson1_1UpdateDeploymentCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v2/apis/{ApiId}/deployments/{DeploymentId}";
   if (input.ApiId !== undefined) {
-    const labelValue: string = input.ApiId.toString();
+    const labelValue: string = input.ApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{ApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApiId.");
   }
   if (input.DeploymentId !== undefined) {
-    const labelValue: string = input.DeploymentId.toString();
+    const labelValue: string = input.DeploymentId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: DeploymentId."
@@ -2771,7 +2828,7 @@ export async function serializeAws_restJson1_1UpdateDeploymentCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{DeploymentId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DeploymentId.");
@@ -2800,13 +2857,13 @@ export async function serializeAws_restJson1_1UpdateDomainNameCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v2/domainnames/{DomainName}";
   if (input.DomainName !== undefined) {
-    const labelValue: string = input.DomainName.toString();
+    const labelValue: string = input.DomainName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DomainName.");
     }
     resolvedPath = resolvedPath.replace(
       "{DomainName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DomainName.");
@@ -2840,19 +2897,19 @@ export async function serializeAws_restJson1_1UpdateIntegrationCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v2/apis/{ApiId}/integrations/{IntegrationId}";
   if (input.ApiId !== undefined) {
-    const labelValue: string = input.ApiId.toString();
+    const labelValue: string = input.ApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{ApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApiId.");
   }
   if (input.IntegrationId !== undefined) {
-    const labelValue: string = input.IntegrationId.toString();
+    const labelValue: string = input.IntegrationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: IntegrationId."
@@ -2860,7 +2917,7 @@ export async function serializeAws_restJson1_1UpdateIntegrationCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{IntegrationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: IntegrationId.");
@@ -2938,19 +2995,19 @@ export async function serializeAws_restJson1_1UpdateIntegrationResponseCommand(
   let resolvedPath =
     "/v2/apis/{ApiId}/integrations/{IntegrationId}/integrationresponses/{IntegrationResponseId}";
   if (input.ApiId !== undefined) {
-    const labelValue: string = input.ApiId.toString();
+    const labelValue: string = input.ApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{ApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApiId.");
   }
   if (input.IntegrationId !== undefined) {
-    const labelValue: string = input.IntegrationId.toString();
+    const labelValue: string = input.IntegrationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: IntegrationId."
@@ -2958,13 +3015,13 @@ export async function serializeAws_restJson1_1UpdateIntegrationResponseCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{IntegrationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: IntegrationId.");
   }
   if (input.IntegrationResponseId !== undefined) {
-    const labelValue: string = input.IntegrationResponseId.toString();
+    const labelValue: string = input.IntegrationResponseId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: IntegrationResponseId."
@@ -2972,7 +3029,7 @@ export async function serializeAws_restJson1_1UpdateIntegrationResponseCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{IntegrationResponseId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -3024,25 +3081,25 @@ export async function serializeAws_restJson1_1UpdateModelCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v2/apis/{ApiId}/models/{ModelId}";
   if (input.ApiId !== undefined) {
-    const labelValue: string = input.ApiId.toString();
+    const labelValue: string = input.ApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{ApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApiId.");
   }
   if (input.ModelId !== undefined) {
-    const labelValue: string = input.ModelId.toString();
+    const labelValue: string = input.ModelId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ModelId.");
     }
     resolvedPath = resolvedPath.replace(
       "{ModelId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ModelId.");
@@ -3080,25 +3137,25 @@ export async function serializeAws_restJson1_1UpdateRouteCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v2/apis/{ApiId}/routes/{RouteId}";
   if (input.ApiId !== undefined) {
-    const labelValue: string = input.ApiId.toString();
+    const labelValue: string = input.ApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{ApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApiId.");
   }
   if (input.RouteId !== undefined) {
-    const labelValue: string = input.RouteId.toString();
+    const labelValue: string = input.RouteId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: RouteId.");
     }
     resolvedPath = resolvedPath.replace(
       "{RouteId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: RouteId.");
@@ -3170,31 +3227,31 @@ export async function serializeAws_restJson1_1UpdateRouteResponseCommand(
   let resolvedPath =
     "/v2/apis/{ApiId}/routes/{RouteId}/routeresponses/{RouteResponseId}";
   if (input.ApiId !== undefined) {
-    const labelValue: string = input.ApiId.toString();
+    const labelValue: string = input.ApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{ApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApiId.");
   }
   if (input.RouteId !== undefined) {
-    const labelValue: string = input.RouteId.toString();
+    const labelValue: string = input.RouteId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: RouteId.");
     }
     resolvedPath = resolvedPath.replace(
       "{RouteId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: RouteId.");
   }
   if (input.RouteResponseId !== undefined) {
-    const labelValue: string = input.RouteResponseId.toString();
+    const labelValue: string = input.RouteResponseId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: RouteResponseId."
@@ -3202,7 +3259,7 @@ export async function serializeAws_restJson1_1UpdateRouteResponseCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{RouteResponseId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: RouteResponseId.");
@@ -3246,25 +3303,25 @@ export async function serializeAws_restJson1_1UpdateStageCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v2/apis/{ApiId}/stages/{StageName}";
   if (input.ApiId !== undefined) {
-    const labelValue: string = input.ApiId.toString();
+    const labelValue: string = input.ApiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ApiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{ApiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApiId.");
   }
   if (input.StageName !== undefined) {
-    const labelValue: string = input.StageName.toString();
+    const labelValue: string = input.StageName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: StageName.");
     }
     resolvedPath = resolvedPath.replace(
       "{StageName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: StageName.");
@@ -4654,6 +4711,7 @@ export async function deserializeAws_restJson1_1DeleteApiCommand(
   const contents: DeleteApiCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -4711,6 +4769,7 @@ export async function deserializeAws_restJson1_1DeleteApiMappingCommand(
   const contents: DeleteApiMappingCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -4775,6 +4834,7 @@ export async function deserializeAws_restJson1_1DeleteAuthorizerCommand(
   const contents: DeleteAuthorizerCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -4832,6 +4892,7 @@ export async function deserializeAws_restJson1_1DeleteCorsConfigurationCommand(
   const contents: DeleteCorsConfigurationCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -4889,6 +4950,7 @@ export async function deserializeAws_restJson1_1DeleteDeploymentCommand(
   const contents: DeleteDeploymentCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -4946,6 +5008,7 @@ export async function deserializeAws_restJson1_1DeleteDomainNameCommand(
   const contents: DeleteDomainNameCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -5003,6 +5066,7 @@ export async function deserializeAws_restJson1_1DeleteIntegrationCommand(
   const contents: DeleteIntegrationCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -5060,6 +5124,7 @@ export async function deserializeAws_restJson1_1DeleteIntegrationResponseCommand
   const contents: DeleteIntegrationResponseCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -5114,6 +5179,7 @@ export async function deserializeAws_restJson1_1DeleteModelCommand(
   const contents: DeleteModelCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -5168,6 +5234,7 @@ export async function deserializeAws_restJson1_1DeleteRouteCommand(
   const contents: DeleteRouteCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -5225,6 +5292,7 @@ export async function deserializeAws_restJson1_1DeleteRouteResponseCommand(
   const contents: DeleteRouteResponseCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -5282,6 +5350,7 @@ export async function deserializeAws_restJson1_1DeleteRouteSettingsCommand(
   const contents: DeleteRouteSettingsCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -5336,6 +5405,7 @@ export async function deserializeAws_restJson1_1DeleteStageCommand(
   const contents: DeleteStageCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -7808,6 +7878,7 @@ export async function deserializeAws_restJson1_1TagResourceCommand(
     $metadata: deserializeMetadata(output),
     __type: "TagResourceResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -7876,6 +7947,7 @@ export async function deserializeAws_restJson1_1UntagResourceCommand(
   const contents: UntagResourceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 

--- a/clients/client-app-mesh/models/index.ts
+++ b/clients/client-app-mesh/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -52,7 +55,7 @@ export interface AwsCloudMapInstanceAttribute {
 
 export namespace AwsCloudMapInstanceAttribute {
   export function isa(o: any): o is AwsCloudMapInstanceAttribute {
-    return _smithy.isa(o, "AwsCloudMapInstanceAttribute");
+    return __isa(o, "AwsCloudMapInstanceAttribute");
   }
 }
 
@@ -82,7 +85,7 @@ export interface AwsCloudMapServiceDiscovery {
 
 export namespace AwsCloudMapServiceDiscovery {
   export function isa(o: any): o is AwsCloudMapServiceDiscovery {
-    return _smithy.isa(o, "AwsCloudMapServiceDiscovery");
+    return __isa(o, "AwsCloudMapServiceDiscovery");
   }
 }
 
@@ -122,7 +125,7 @@ export namespace Backend {
  * <p>The request syntax was malformed. Check your request syntax and try again.</p>
  */
 export interface BadRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "BadRequestException";
   $fault: "client";
@@ -131,7 +134,7 @@ export interface BadRequestException
 
 export namespace BadRequestException {
   export function isa(o: any): o is BadRequestException {
-    return _smithy.isa(o, "BadRequestException");
+    return __isa(o, "BadRequestException");
   }
 }
 
@@ -139,9 +142,7 @@ export namespace BadRequestException {
  * <p>The request contains a client token that was used for a previous update resource call
  *          with different specifications. Try the request again with a new client token.</p>
  */
-export interface ConflictException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface ConflictException extends __SmithyException, $MetadataBearer {
   name: "ConflictException";
   $fault: "client";
   message?: string;
@@ -149,7 +150,7 @@ export interface ConflictException
 
 export namespace ConflictException {
   export function isa(o: any): o is ConflictException {
-    return _smithy.isa(o, "ConflictException");
+    return __isa(o, "ConflictException");
   }
 }
 
@@ -185,7 +186,7 @@ export interface CreateMeshInput {
 
 export namespace CreateMeshInput {
   export function isa(o: any): o is CreateMeshInput {
-    return _smithy.isa(o, "CreateMeshInput");
+    return __isa(o, "CreateMeshInput");
   }
 }
 
@@ -202,7 +203,7 @@ export interface CreateMeshOutput extends $MetadataBearer {
 
 export namespace CreateMeshOutput {
   export function isa(o: any): o is CreateMeshOutput {
-    return _smithy.isa(o, "CreateMeshOutput");
+    return __isa(o, "CreateMeshOutput");
   }
 }
 
@@ -248,7 +249,7 @@ export interface CreateRouteInput {
 
 export namespace CreateRouteInput {
   export function isa(o: any): o is CreateRouteInput {
-    return _smithy.isa(o, "CreateRouteInput");
+    return __isa(o, "CreateRouteInput");
   }
 }
 
@@ -265,7 +266,7 @@ export interface CreateRouteOutput extends $MetadataBearer {
 
 export namespace CreateRouteOutput {
   export function isa(o: any): o is CreateRouteOutput {
-    return _smithy.isa(o, "CreateRouteOutput");
+    return __isa(o, "CreateRouteOutput");
   }
 }
 
@@ -306,7 +307,7 @@ export interface CreateVirtualNodeInput {
 
 export namespace CreateVirtualNodeInput {
   export function isa(o: any): o is CreateVirtualNodeInput {
-    return _smithy.isa(o, "CreateVirtualNodeInput");
+    return __isa(o, "CreateVirtualNodeInput");
   }
 }
 
@@ -323,7 +324,7 @@ export interface CreateVirtualNodeOutput extends $MetadataBearer {
 
 export namespace CreateVirtualNodeOutput {
   export function isa(o: any): o is CreateVirtualNodeOutput {
-    return _smithy.isa(o, "CreateVirtualNodeOutput");
+    return __isa(o, "CreateVirtualNodeOutput");
   }
 }
 
@@ -364,7 +365,7 @@ export interface CreateVirtualRouterInput {
 
 export namespace CreateVirtualRouterInput {
   export function isa(o: any): o is CreateVirtualRouterInput {
-    return _smithy.isa(o, "CreateVirtualRouterInput");
+    return __isa(o, "CreateVirtualRouterInput");
   }
 }
 
@@ -381,7 +382,7 @@ export interface CreateVirtualRouterOutput extends $MetadataBearer {
 
 export namespace CreateVirtualRouterOutput {
   export function isa(o: any): o is CreateVirtualRouterOutput {
-    return _smithy.isa(o, "CreateVirtualRouterOutput");
+    return __isa(o, "CreateVirtualRouterOutput");
   }
 }
 
@@ -422,7 +423,7 @@ export interface CreateVirtualServiceInput {
 
 export namespace CreateVirtualServiceInput {
   export function isa(o: any): o is CreateVirtualServiceInput {
-    return _smithy.isa(o, "CreateVirtualServiceInput");
+    return __isa(o, "CreateVirtualServiceInput");
   }
 }
 
@@ -439,7 +440,7 @@ export interface CreateVirtualServiceOutput extends $MetadataBearer {
 
 export namespace CreateVirtualServiceOutput {
   export function isa(o: any): o is CreateVirtualServiceOutput {
-    return _smithy.isa(o, "CreateVirtualServiceOutput");
+    return __isa(o, "CreateVirtualServiceOutput");
   }
 }
 
@@ -456,7 +457,7 @@ export interface DeleteMeshInput {
 
 export namespace DeleteMeshInput {
   export function isa(o: any): o is DeleteMeshInput {
-    return _smithy.isa(o, "DeleteMeshInput");
+    return __isa(o, "DeleteMeshInput");
   }
 }
 
@@ -473,7 +474,7 @@ export interface DeleteMeshOutput extends $MetadataBearer {
 
 export namespace DeleteMeshOutput {
   export function isa(o: any): o is DeleteMeshOutput {
-    return _smithy.isa(o, "DeleteMeshOutput");
+    return __isa(o, "DeleteMeshOutput");
   }
 }
 
@@ -500,7 +501,7 @@ export interface DeleteRouteInput {
 
 export namespace DeleteRouteInput {
   export function isa(o: any): o is DeleteRouteInput {
-    return _smithy.isa(o, "DeleteRouteInput");
+    return __isa(o, "DeleteRouteInput");
   }
 }
 
@@ -517,7 +518,7 @@ export interface DeleteRouteOutput extends $MetadataBearer {
 
 export namespace DeleteRouteOutput {
   export function isa(o: any): o is DeleteRouteOutput {
-    return _smithy.isa(o, "DeleteRouteOutput");
+    return __isa(o, "DeleteRouteOutput");
   }
 }
 
@@ -539,7 +540,7 @@ export interface DeleteVirtualNodeInput {
 
 export namespace DeleteVirtualNodeInput {
   export function isa(o: any): o is DeleteVirtualNodeInput {
-    return _smithy.isa(o, "DeleteVirtualNodeInput");
+    return __isa(o, "DeleteVirtualNodeInput");
   }
 }
 
@@ -556,7 +557,7 @@ export interface DeleteVirtualNodeOutput extends $MetadataBearer {
 
 export namespace DeleteVirtualNodeOutput {
   export function isa(o: any): o is DeleteVirtualNodeOutput {
-    return _smithy.isa(o, "DeleteVirtualNodeOutput");
+    return __isa(o, "DeleteVirtualNodeOutput");
   }
 }
 
@@ -578,7 +579,7 @@ export interface DeleteVirtualRouterInput {
 
 export namespace DeleteVirtualRouterInput {
   export function isa(o: any): o is DeleteVirtualRouterInput {
-    return _smithy.isa(o, "DeleteVirtualRouterInput");
+    return __isa(o, "DeleteVirtualRouterInput");
   }
 }
 
@@ -595,7 +596,7 @@ export interface DeleteVirtualRouterOutput extends $MetadataBearer {
 
 export namespace DeleteVirtualRouterOutput {
   export function isa(o: any): o is DeleteVirtualRouterOutput {
-    return _smithy.isa(o, "DeleteVirtualRouterOutput");
+    return __isa(o, "DeleteVirtualRouterOutput");
   }
 }
 
@@ -617,7 +618,7 @@ export interface DeleteVirtualServiceInput {
 
 export namespace DeleteVirtualServiceInput {
   export function isa(o: any): o is DeleteVirtualServiceInput {
-    return _smithy.isa(o, "DeleteVirtualServiceInput");
+    return __isa(o, "DeleteVirtualServiceInput");
   }
 }
 
@@ -634,7 +635,7 @@ export interface DeleteVirtualServiceOutput extends $MetadataBearer {
 
 export namespace DeleteVirtualServiceOutput {
   export function isa(o: any): o is DeleteVirtualServiceOutput {
-    return _smithy.isa(o, "DeleteVirtualServiceOutput");
+    return __isa(o, "DeleteVirtualServiceOutput");
   }
 }
 
@@ -651,7 +652,7 @@ export interface DescribeMeshInput {
 
 export namespace DescribeMeshInput {
   export function isa(o: any): o is DescribeMeshInput {
-    return _smithy.isa(o, "DescribeMeshInput");
+    return __isa(o, "DescribeMeshInput");
   }
 }
 
@@ -668,7 +669,7 @@ export interface DescribeMeshOutput extends $MetadataBearer {
 
 export namespace DescribeMeshOutput {
   export function isa(o: any): o is DescribeMeshOutput {
-    return _smithy.isa(o, "DescribeMeshOutput");
+    return __isa(o, "DescribeMeshOutput");
   }
 }
 
@@ -695,7 +696,7 @@ export interface DescribeRouteInput {
 
 export namespace DescribeRouteInput {
   export function isa(o: any): o is DescribeRouteInput {
-    return _smithy.isa(o, "DescribeRouteInput");
+    return __isa(o, "DescribeRouteInput");
   }
 }
 
@@ -712,7 +713,7 @@ export interface DescribeRouteOutput extends $MetadataBearer {
 
 export namespace DescribeRouteOutput {
   export function isa(o: any): o is DescribeRouteOutput {
-    return _smithy.isa(o, "DescribeRouteOutput");
+    return __isa(o, "DescribeRouteOutput");
   }
 }
 
@@ -734,7 +735,7 @@ export interface DescribeVirtualNodeInput {
 
 export namespace DescribeVirtualNodeInput {
   export function isa(o: any): o is DescribeVirtualNodeInput {
-    return _smithy.isa(o, "DescribeVirtualNodeInput");
+    return __isa(o, "DescribeVirtualNodeInput");
   }
 }
 
@@ -751,7 +752,7 @@ export interface DescribeVirtualNodeOutput extends $MetadataBearer {
 
 export namespace DescribeVirtualNodeOutput {
   export function isa(o: any): o is DescribeVirtualNodeOutput {
-    return _smithy.isa(o, "DescribeVirtualNodeOutput");
+    return __isa(o, "DescribeVirtualNodeOutput");
   }
 }
 
@@ -773,7 +774,7 @@ export interface DescribeVirtualRouterInput {
 
 export namespace DescribeVirtualRouterInput {
   export function isa(o: any): o is DescribeVirtualRouterInput {
-    return _smithy.isa(o, "DescribeVirtualRouterInput");
+    return __isa(o, "DescribeVirtualRouterInput");
   }
 }
 
@@ -790,7 +791,7 @@ export interface DescribeVirtualRouterOutput extends $MetadataBearer {
 
 export namespace DescribeVirtualRouterOutput {
   export function isa(o: any): o is DescribeVirtualRouterOutput {
-    return _smithy.isa(o, "DescribeVirtualRouterOutput");
+    return __isa(o, "DescribeVirtualRouterOutput");
   }
 }
 
@@ -812,7 +813,7 @@ export interface DescribeVirtualServiceInput {
 
 export namespace DescribeVirtualServiceInput {
   export function isa(o: any): o is DescribeVirtualServiceInput {
-    return _smithy.isa(o, "DescribeVirtualServiceInput");
+    return __isa(o, "DescribeVirtualServiceInput");
   }
 }
 
@@ -829,7 +830,7 @@ export interface DescribeVirtualServiceOutput extends $MetadataBearer {
 
 export namespace DescribeVirtualServiceOutput {
   export function isa(o: any): o is DescribeVirtualServiceOutput {
-    return _smithy.isa(o, "DescribeVirtualServiceOutput");
+    return __isa(o, "DescribeVirtualServiceOutput");
   }
 }
 
@@ -847,7 +848,7 @@ export interface DnsServiceDiscovery {
 
 export namespace DnsServiceDiscovery {
   export function isa(o: any): o is DnsServiceDiscovery {
-    return _smithy.isa(o, "DnsServiceDiscovery");
+    return __isa(o, "DnsServiceDiscovery");
   }
 }
 
@@ -869,7 +870,7 @@ export interface Duration {
 
 export namespace Duration {
   export function isa(o: any): o is Duration {
-    return _smithy.isa(o, "Duration");
+    return __isa(o, "Duration");
   }
 }
 
@@ -895,7 +896,7 @@ export interface EgressFilter {
 
 export namespace EgressFilter {
   export function isa(o: any): o is EgressFilter {
-    return _smithy.isa(o, "EgressFilter");
+    return __isa(o, "EgressFilter");
   }
 }
 
@@ -925,16 +926,14 @@ export interface FileAccessLog {
 
 export namespace FileAccessLog {
   export function isa(o: any): o is FileAccessLog {
-    return _smithy.isa(o, "FileAccessLog");
+    return __isa(o, "FileAccessLog");
   }
 }
 
 /**
  * <p>You don't have permissions to perform this action.</p>
  */
-export interface ForbiddenException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface ForbiddenException extends __SmithyException, $MetadataBearer {
   name: "ForbiddenException";
   $fault: "client";
   message?: string;
@@ -942,7 +941,7 @@ export interface ForbiddenException
 
 export namespace ForbiddenException {
   export function isa(o: any): o is ForbiddenException {
-    return _smithy.isa(o, "ForbiddenException");
+    return __isa(o, "ForbiddenException");
   }
 }
 
@@ -1000,7 +999,7 @@ export interface GrpcRetryPolicy {
 
 export namespace GrpcRetryPolicy {
   export function isa(o: any): o is GrpcRetryPolicy {
-    return _smithy.isa(o, "GrpcRetryPolicy");
+    return __isa(o, "GrpcRetryPolicy");
   }
 }
 
@@ -1035,7 +1034,7 @@ export interface GrpcRoute {
 
 export namespace GrpcRoute {
   export function isa(o: any): o is GrpcRoute {
-    return _smithy.isa(o, "GrpcRoute");
+    return __isa(o, "GrpcRoute");
   }
 }
 
@@ -1052,7 +1051,7 @@ export interface GrpcRouteAction {
 
 export namespace GrpcRouteAction {
   export function isa(o: any): o is GrpcRouteAction {
-    return _smithy.isa(o, "GrpcRouteAction");
+    return __isa(o, "GrpcRouteAction");
   }
 }
 
@@ -1079,7 +1078,7 @@ export interface GrpcRouteMatch {
 
 export namespace GrpcRouteMatch {
   export function isa(o: any): o is GrpcRouteMatch {
-    return _smithy.isa(o, "GrpcRouteMatch");
+    return __isa(o, "GrpcRouteMatch");
   }
 }
 
@@ -1106,7 +1105,7 @@ export interface GrpcRouteMetadata {
 
 export namespace GrpcRouteMetadata {
   export function isa(o: any): o is GrpcRouteMetadata {
-    return _smithy.isa(o, "GrpcRouteMetadata");
+    return __isa(o, "GrpcRouteMetadata");
   }
 }
 
@@ -1354,7 +1353,7 @@ export interface HealthCheckPolicy {
 
 export namespace HealthCheckPolicy {
   export function isa(o: any): o is HealthCheckPolicy {
-    return _smithy.isa(o, "HealthCheckPolicy");
+    return __isa(o, "HealthCheckPolicy");
   }
 }
 
@@ -1419,7 +1418,7 @@ export interface HttpRetryPolicy {
 
 export namespace HttpRetryPolicy {
   export function isa(o: any): o is HttpRetryPolicy {
-    return _smithy.isa(o, "HttpRetryPolicy");
+    return __isa(o, "HttpRetryPolicy");
   }
 }
 
@@ -1446,7 +1445,7 @@ export interface HttpRoute {
 
 export namespace HttpRoute {
   export function isa(o: any): o is HttpRoute {
-    return _smithy.isa(o, "HttpRoute");
+    return __isa(o, "HttpRoute");
   }
 }
 
@@ -1463,7 +1462,7 @@ export interface HttpRouteAction {
 
 export namespace HttpRouteAction {
   export function isa(o: any): o is HttpRouteAction {
-    return _smithy.isa(o, "HttpRouteAction");
+    return __isa(o, "HttpRouteAction");
   }
 }
 
@@ -1490,7 +1489,7 @@ export interface HttpRouteHeader {
 
 export namespace HttpRouteHeader {
   export function isa(o: any): o is HttpRouteHeader {
-    return _smithy.isa(o, "HttpRouteHeader");
+    return __isa(o, "HttpRouteHeader");
   }
 }
 
@@ -1528,7 +1527,7 @@ export interface HttpRouteMatch {
 
 export namespace HttpRouteMatch {
   export function isa(o: any): o is HttpRouteMatch {
-    return _smithy.isa(o, "HttpRouteMatch");
+    return __isa(o, "HttpRouteMatch");
   }
 }
 
@@ -1542,7 +1541,7 @@ export enum HttpScheme {
  *          failure.</p>
  */
 export interface InternalServerErrorException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalServerErrorException";
   $fault: "server";
@@ -1551,7 +1550,7 @@ export interface InternalServerErrorException
 
 export namespace InternalServerErrorException {
   export function isa(o: any): o is InternalServerErrorException {
-    return _smithy.isa(o, "InternalServerErrorException");
+    return __isa(o, "InternalServerErrorException");
   }
 }
 
@@ -1560,7 +1559,7 @@ export namespace InternalServerErrorException {
  *             Limits</a> in the <i>AWS App Mesh User Guide</i>.</p>
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -1569,7 +1568,7 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
@@ -1605,7 +1604,7 @@ export interface ListMeshesInput {
 
 export namespace ListMeshesInput {
   export function isa(o: any): o is ListMeshesInput {
-    return _smithy.isa(o, "ListMeshesInput");
+    return __isa(o, "ListMeshesInput");
   }
 }
 
@@ -1630,7 +1629,7 @@ export interface ListMeshesOutput extends $MetadataBearer {
 
 export namespace ListMeshesOutput {
   export function isa(o: any): o is ListMeshesOutput {
-    return _smithy.isa(o, "ListMeshesOutput");
+    return __isa(o, "ListMeshesOutput");
   }
 }
 
@@ -1672,7 +1671,7 @@ export interface ListRoutesInput {
 
 export namespace ListRoutesInput {
   export function isa(o: any): o is ListRoutesInput {
-    return _smithy.isa(o, "ListRoutesInput");
+    return __isa(o, "ListRoutesInput");
   }
 }
 
@@ -1697,7 +1696,7 @@ export interface ListRoutesOutput extends $MetadataBearer {
 
 export namespace ListRoutesOutput {
   export function isa(o: any): o is ListRoutesOutput {
-    return _smithy.isa(o, "ListRoutesOutput");
+    return __isa(o, "ListRoutesOutput");
   }
 }
 
@@ -1734,7 +1733,7 @@ export interface ListTagsForResourceInput {
 
 export namespace ListTagsForResourceInput {
   export function isa(o: any): o is ListTagsForResourceInput {
-    return _smithy.isa(o, "ListTagsForResourceInput");
+    return __isa(o, "ListTagsForResourceInput");
   }
 }
 
@@ -1759,7 +1758,7 @@ export interface ListTagsForResourceOutput extends $MetadataBearer {
 
 export namespace ListTagsForResourceOutput {
   export function isa(o: any): o is ListTagsForResourceOutput {
-    return _smithy.isa(o, "ListTagsForResourceOutput");
+    return __isa(o, "ListTagsForResourceOutput");
   }
 }
 
@@ -1796,7 +1795,7 @@ export interface ListVirtualNodesInput {
 
 export namespace ListVirtualNodesInput {
   export function isa(o: any): o is ListVirtualNodesInput {
-    return _smithy.isa(o, "ListVirtualNodesInput");
+    return __isa(o, "ListVirtualNodesInput");
   }
 }
 
@@ -1821,7 +1820,7 @@ export interface ListVirtualNodesOutput extends $MetadataBearer {
 
 export namespace ListVirtualNodesOutput {
   export function isa(o: any): o is ListVirtualNodesOutput {
-    return _smithy.isa(o, "ListVirtualNodesOutput");
+    return __isa(o, "ListVirtualNodesOutput");
   }
 }
 
@@ -1858,7 +1857,7 @@ export interface ListVirtualRoutersInput {
 
 export namespace ListVirtualRoutersInput {
   export function isa(o: any): o is ListVirtualRoutersInput {
-    return _smithy.isa(o, "ListVirtualRoutersInput");
+    return __isa(o, "ListVirtualRoutersInput");
   }
 }
 
@@ -1883,7 +1882,7 @@ export interface ListVirtualRoutersOutput extends $MetadataBearer {
 
 export namespace ListVirtualRoutersOutput {
   export function isa(o: any): o is ListVirtualRoutersOutput {
-    return _smithy.isa(o, "ListVirtualRoutersOutput");
+    return __isa(o, "ListVirtualRoutersOutput");
   }
 }
 
@@ -1920,7 +1919,7 @@ export interface ListVirtualServicesInput {
 
 export namespace ListVirtualServicesInput {
   export function isa(o: any): o is ListVirtualServicesInput {
-    return _smithy.isa(o, "ListVirtualServicesInput");
+    return __isa(o, "ListVirtualServicesInput");
   }
 }
 
@@ -1945,7 +1944,7 @@ export interface ListVirtualServicesOutput extends $MetadataBearer {
 
 export namespace ListVirtualServicesOutput {
   export function isa(o: any): o is ListVirtualServicesOutput {
-    return _smithy.isa(o, "ListVirtualServicesOutput");
+    return __isa(o, "ListVirtualServicesOutput");
   }
 }
 
@@ -1967,7 +1966,7 @@ export interface Listener {
 
 export namespace Listener {
   export function isa(o: any): o is Listener {
-    return _smithy.isa(o, "Listener");
+    return __isa(o, "Listener");
   }
 }
 
@@ -1984,7 +1983,7 @@ export interface Logging {
 
 export namespace Logging {
   export function isa(o: any): o is Logging {
-    return _smithy.isa(o, "Logging");
+    return __isa(o, "Logging");
   }
 }
 
@@ -2006,7 +2005,7 @@ export interface MatchRange {
 
 export namespace MatchRange {
   export function isa(o: any): o is MatchRange {
-    return _smithy.isa(o, "MatchRange");
+    return __isa(o, "MatchRange");
   }
 }
 
@@ -2038,7 +2037,7 @@ export interface MeshData {
 
 export namespace MeshData {
   export function isa(o: any): o is MeshData {
-    return _smithy.isa(o, "MeshData");
+    return __isa(o, "MeshData");
   }
 }
 
@@ -2060,7 +2059,7 @@ export interface MeshRef {
 
 export namespace MeshRef {
   export function isa(o: any): o is MeshRef {
-    return _smithy.isa(o, "MeshRef");
+    return __isa(o, "MeshRef");
   }
 }
 
@@ -2077,7 +2076,7 @@ export interface MeshSpec {
 
 export namespace MeshSpec {
   export function isa(o: any): o is MeshSpec {
-    return _smithy.isa(o, "MeshSpec");
+    return __isa(o, "MeshSpec");
   }
 }
 
@@ -2094,7 +2093,7 @@ export interface MeshStatus {
 
 export namespace MeshStatus {
   export function isa(o: any): o is MeshStatus {
-    return _smithy.isa(o, "MeshStatus");
+    return __isa(o, "MeshStatus");
   }
 }
 
@@ -2107,9 +2106,7 @@ export enum MeshStatusCode {
 /**
  * <p>The specified resource doesn't exist. Check your request syntax and try again.</p>
  */
-export interface NotFoundException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface NotFoundException extends __SmithyException, $MetadataBearer {
   name: "NotFoundException";
   $fault: "client";
   message?: string;
@@ -2117,7 +2114,7 @@ export interface NotFoundException
 
 export namespace NotFoundException {
   export function isa(o: any): o is NotFoundException {
-    return _smithy.isa(o, "NotFoundException");
+    return __isa(o, "NotFoundException");
   }
 }
 
@@ -2139,7 +2136,7 @@ export interface PortMapping {
 
 export namespace PortMapping {
   export function isa(o: any): o is PortMapping {
-    return _smithy.isa(o, "PortMapping");
+    return __isa(o, "PortMapping");
   }
 }
 
@@ -2155,7 +2152,7 @@ export enum PortProtocol {
  *          resource.</p>
  */
 export interface ResourceInUseException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceInUseException";
   $fault: "client";
@@ -2164,7 +2161,7 @@ export interface ResourceInUseException
 
 export namespace ResourceInUseException {
   export function isa(o: any): o is ResourceInUseException {
-    return _smithy.isa(o, "ResourceInUseException");
+    return __isa(o, "ResourceInUseException");
   }
 }
 
@@ -2202,7 +2199,7 @@ export interface ResourceMetadata {
 
 export namespace ResourceMetadata {
   export function isa(o: any): o is ResourceMetadata {
-    return _smithy.isa(o, "ResourceMetadata");
+    return __isa(o, "ResourceMetadata");
   }
 }
 
@@ -2244,7 +2241,7 @@ export interface RouteData {
 
 export namespace RouteData {
   export function isa(o: any): o is RouteData {
-    return _smithy.isa(o, "RouteData");
+    return __isa(o, "RouteData");
   }
 }
 
@@ -2276,7 +2273,7 @@ export interface RouteRef {
 
 export namespace RouteRef {
   export function isa(o: any): o is RouteRef {
-    return _smithy.isa(o, "RouteRef");
+    return __isa(o, "RouteRef");
   }
 }
 
@@ -2314,7 +2311,7 @@ export interface RouteSpec {
 
 export namespace RouteSpec {
   export function isa(o: any): o is RouteSpec {
-    return _smithy.isa(o, "RouteSpec");
+    return __isa(o, "RouteSpec");
   }
 }
 
@@ -2331,7 +2328,7 @@ export interface RouteStatus {
 
 export namespace RouteStatus {
   export function isa(o: any): o is RouteStatus {
-    return _smithy.isa(o, "RouteStatus");
+    return __isa(o, "RouteStatus");
   }
 }
 
@@ -2391,7 +2388,7 @@ export namespace ServiceDiscovery {
  * <p>The request has failed due to a temporary failure of the service.</p>
  */
 export interface ServiceUnavailableException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ServiceUnavailableException";
   $fault: "server";
@@ -2400,7 +2397,7 @@ export interface ServiceUnavailableException
 
 export namespace ServiceUnavailableException {
   export function isa(o: any): o is ServiceUnavailableException {
-    return _smithy.isa(o, "ServiceUnavailableException");
+    return __isa(o, "ServiceUnavailableException");
   }
 }
 
@@ -2427,7 +2424,7 @@ export interface TagRef {
 
 export namespace TagRef {
   export function isa(o: any): o is TagRef {
-    return _smithy.isa(o, "TagRef");
+    return __isa(o, "TagRef");
   }
 }
 
@@ -2451,7 +2448,7 @@ export interface TagResourceInput {
 
 export namespace TagResourceInput {
   export function isa(o: any): o is TagResourceInput {
-    return _smithy.isa(o, "TagResourceInput");
+    return __isa(o, "TagResourceInput");
   }
 }
 
@@ -2464,7 +2461,7 @@ export interface TagResourceOutput extends $MetadataBearer {
 
 export namespace TagResourceOutput {
   export function isa(o: any): o is TagResourceOutput {
-    return _smithy.isa(o, "TagResourceOutput");
+    return __isa(o, "TagResourceOutput");
   }
 }
 
@@ -2485,7 +2482,7 @@ export interface TcpRoute {
 
 export namespace TcpRoute {
   export function isa(o: any): o is TcpRoute {
-    return _smithy.isa(o, "TcpRoute");
+    return __isa(o, "TcpRoute");
   }
 }
 
@@ -2502,7 +2499,7 @@ export interface TcpRouteAction {
 
 export namespace TcpRouteAction {
   export function isa(o: any): o is TcpRouteAction {
-    return _smithy.isa(o, "TcpRouteAction");
+    return __isa(o, "TcpRouteAction");
   }
 }
 
@@ -2512,7 +2509,7 @@ export namespace TcpRouteAction {
  *          requests.</p>
  */
 export interface TooManyRequestsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyRequestsException";
   $fault: "client";
@@ -2521,7 +2518,7 @@ export interface TooManyRequestsException
 
 export namespace TooManyRequestsException {
   export function isa(o: any): o is TooManyRequestsException {
-    return _smithy.isa(o, "TooManyRequestsException");
+    return __isa(o, "TooManyRequestsException");
   }
 }
 
@@ -2531,7 +2528,7 @@ export namespace TooManyRequestsException {
  *          of the tags in this request were applied.</p>
  */
 export interface TooManyTagsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyTagsException";
   $fault: "client";
@@ -2540,7 +2537,7 @@ export interface TooManyTagsException
 
 export namespace TooManyTagsException {
   export function isa(o: any): o is TooManyTagsException {
-    return _smithy.isa(o, "TooManyTagsException");
+    return __isa(o, "TooManyTagsException");
   }
 }
 
@@ -2562,7 +2559,7 @@ export interface UntagResourceInput {
 
 export namespace UntagResourceInput {
   export function isa(o: any): o is UntagResourceInput {
-    return _smithy.isa(o, "UntagResourceInput");
+    return __isa(o, "UntagResourceInput");
   }
 }
 
@@ -2575,7 +2572,7 @@ export interface UntagResourceOutput extends $MetadataBearer {
 
 export namespace UntagResourceOutput {
   export function isa(o: any): o is UntagResourceOutput {
-    return _smithy.isa(o, "UntagResourceOutput");
+    return __isa(o, "UntagResourceOutput");
   }
 }
 
@@ -2603,7 +2600,7 @@ export interface UpdateMeshInput {
 
 export namespace UpdateMeshInput {
   export function isa(o: any): o is UpdateMeshInput {
-    return _smithy.isa(o, "UpdateMeshInput");
+    return __isa(o, "UpdateMeshInput");
   }
 }
 
@@ -2620,7 +2617,7 @@ export interface UpdateMeshOutput extends $MetadataBearer {
 
 export namespace UpdateMeshOutput {
   export function isa(o: any): o is UpdateMeshOutput {
-    return _smithy.isa(o, "UpdateMeshOutput");
+    return __isa(o, "UpdateMeshOutput");
   }
 }
 
@@ -2658,7 +2655,7 @@ export interface UpdateRouteInput {
 
 export namespace UpdateRouteInput {
   export function isa(o: any): o is UpdateRouteInput {
-    return _smithy.isa(o, "UpdateRouteInput");
+    return __isa(o, "UpdateRouteInput");
   }
 }
 
@@ -2675,7 +2672,7 @@ export interface UpdateRouteOutput extends $MetadataBearer {
 
 export namespace UpdateRouteOutput {
   export function isa(o: any): o is UpdateRouteOutput {
-    return _smithy.isa(o, "UpdateRouteOutput");
+    return __isa(o, "UpdateRouteOutput");
   }
 }
 
@@ -2708,7 +2705,7 @@ export interface UpdateVirtualNodeInput {
 
 export namespace UpdateVirtualNodeInput {
   export function isa(o: any): o is UpdateVirtualNodeInput {
-    return _smithy.isa(o, "UpdateVirtualNodeInput");
+    return __isa(o, "UpdateVirtualNodeInput");
   }
 }
 
@@ -2725,7 +2722,7 @@ export interface UpdateVirtualNodeOutput extends $MetadataBearer {
 
 export namespace UpdateVirtualNodeOutput {
   export function isa(o: any): o is UpdateVirtualNodeOutput {
-    return _smithy.isa(o, "UpdateVirtualNodeOutput");
+    return __isa(o, "UpdateVirtualNodeOutput");
   }
 }
 
@@ -2758,7 +2755,7 @@ export interface UpdateVirtualRouterInput {
 
 export namespace UpdateVirtualRouterInput {
   export function isa(o: any): o is UpdateVirtualRouterInput {
-    return _smithy.isa(o, "UpdateVirtualRouterInput");
+    return __isa(o, "UpdateVirtualRouterInput");
   }
 }
 
@@ -2775,7 +2772,7 @@ export interface UpdateVirtualRouterOutput extends $MetadataBearer {
 
 export namespace UpdateVirtualRouterOutput {
   export function isa(o: any): o is UpdateVirtualRouterOutput {
-    return _smithy.isa(o, "UpdateVirtualRouterOutput");
+    return __isa(o, "UpdateVirtualRouterOutput");
   }
 }
 
@@ -2809,7 +2806,7 @@ export interface UpdateVirtualServiceInput {
 
 export namespace UpdateVirtualServiceInput {
   export function isa(o: any): o is UpdateVirtualServiceInput {
-    return _smithy.isa(o, "UpdateVirtualServiceInput");
+    return __isa(o, "UpdateVirtualServiceInput");
   }
 }
 
@@ -2826,7 +2823,7 @@ export interface UpdateVirtualServiceOutput extends $MetadataBearer {
 
 export namespace UpdateVirtualServiceOutput {
   export function isa(o: any): o is UpdateVirtualServiceOutput {
-    return _smithy.isa(o, "UpdateVirtualServiceOutput");
+    return __isa(o, "UpdateVirtualServiceOutput");
   }
 }
 
@@ -2863,7 +2860,7 @@ export interface VirtualNodeData {
 
 export namespace VirtualNodeData {
   export function isa(o: any): o is VirtualNodeData {
-    return _smithy.isa(o, "VirtualNodeData");
+    return __isa(o, "VirtualNodeData");
   }
 }
 
@@ -2890,7 +2887,7 @@ export interface VirtualNodeRef {
 
 export namespace VirtualNodeRef {
   export function isa(o: any): o is VirtualNodeRef {
-    return _smithy.isa(o, "VirtualNodeRef");
+    return __isa(o, "VirtualNodeRef");
   }
 }
 
@@ -2907,7 +2904,7 @@ export interface VirtualNodeServiceProvider {
 
 export namespace VirtualNodeServiceProvider {
   export function isa(o: any): o is VirtualNodeServiceProvider {
-    return _smithy.isa(o, "VirtualNodeServiceProvider");
+    return __isa(o, "VirtualNodeServiceProvider");
   }
 }
 
@@ -2941,7 +2938,7 @@ export interface VirtualNodeSpec {
 
 export namespace VirtualNodeSpec {
   export function isa(o: any): o is VirtualNodeSpec {
-    return _smithy.isa(o, "VirtualNodeSpec");
+    return __isa(o, "VirtualNodeSpec");
   }
 }
 
@@ -2958,7 +2955,7 @@ export interface VirtualNodeStatus {
 
 export namespace VirtualNodeStatus {
   export function isa(o: any): o is VirtualNodeStatus {
-    return _smithy.isa(o, "VirtualNodeStatus");
+    return __isa(o, "VirtualNodeStatus");
   }
 }
 
@@ -3001,7 +2998,7 @@ export interface VirtualRouterData {
 
 export namespace VirtualRouterData {
   export function isa(o: any): o is VirtualRouterData {
-    return _smithy.isa(o, "VirtualRouterData");
+    return __isa(o, "VirtualRouterData");
   }
 }
 
@@ -3018,7 +3015,7 @@ export interface VirtualRouterListener {
 
 export namespace VirtualRouterListener {
   export function isa(o: any): o is VirtualRouterListener {
-    return _smithy.isa(o, "VirtualRouterListener");
+    return __isa(o, "VirtualRouterListener");
   }
 }
 
@@ -3045,7 +3042,7 @@ export interface VirtualRouterRef {
 
 export namespace VirtualRouterRef {
   export function isa(o: any): o is VirtualRouterRef {
-    return _smithy.isa(o, "VirtualRouterRef");
+    return __isa(o, "VirtualRouterRef");
   }
 }
 
@@ -3062,7 +3059,7 @@ export interface VirtualRouterServiceProvider {
 
 export namespace VirtualRouterServiceProvider {
   export function isa(o: any): o is VirtualRouterServiceProvider {
-    return _smithy.isa(o, "VirtualRouterServiceProvider");
+    return __isa(o, "VirtualRouterServiceProvider");
   }
 }
 
@@ -3080,7 +3077,7 @@ export interface VirtualRouterSpec {
 
 export namespace VirtualRouterSpec {
   export function isa(o: any): o is VirtualRouterSpec {
-    return _smithy.isa(o, "VirtualRouterSpec");
+    return __isa(o, "VirtualRouterSpec");
   }
 }
 
@@ -3097,7 +3094,7 @@ export interface VirtualRouterStatus {
 
 export namespace VirtualRouterStatus {
   export function isa(o: any): o is VirtualRouterStatus {
-    return _smithy.isa(o, "VirtualRouterStatus");
+    return __isa(o, "VirtualRouterStatus");
   }
 }
 
@@ -3120,7 +3117,7 @@ export interface VirtualServiceBackend {
 
 export namespace VirtualServiceBackend {
   export function isa(o: any): o is VirtualServiceBackend {
-    return _smithy.isa(o, "VirtualServiceBackend");
+    return __isa(o, "VirtualServiceBackend");
   }
 }
 
@@ -3157,7 +3154,7 @@ export interface VirtualServiceData {
 
 export namespace VirtualServiceData {
   export function isa(o: any): o is VirtualServiceData {
-    return _smithy.isa(o, "VirtualServiceData");
+    return __isa(o, "VirtualServiceData");
   }
 }
 
@@ -3234,7 +3231,7 @@ export interface VirtualServiceRef {
 
 export namespace VirtualServiceRef {
   export function isa(o: any): o is VirtualServiceRef {
-    return _smithy.isa(o, "VirtualServiceRef");
+    return __isa(o, "VirtualServiceRef");
   }
 }
 
@@ -3252,7 +3249,7 @@ export interface VirtualServiceSpec {
 
 export namespace VirtualServiceSpec {
   export function isa(o: any): o is VirtualServiceSpec {
-    return _smithy.isa(o, "VirtualServiceSpec");
+    return __isa(o, "VirtualServiceSpec");
   }
 }
 
@@ -3269,7 +3266,7 @@ export interface VirtualServiceStatus {
 
 export namespace VirtualServiceStatus {
   export function isa(o: any): o is VirtualServiceStatus {
-    return _smithy.isa(o, "VirtualServiceStatus");
+    return __isa(o, "VirtualServiceStatus");
   }
 }
 
@@ -3300,6 +3297,6 @@ export interface WeightedTarget {
 
 export namespace WeightedTarget {
   export function isa(o: any): o is WeightedTarget {
-    return _smithy.isa(o, "WeightedTarget");
+    return __isa(o, "WeightedTarget");
   }
 }

--- a/clients/client-app-mesh/protocols/Aws_restJson1_1.ts
+++ b/clients/client-app-mesh/protocols/Aws_restJson1_1.ts
@@ -184,7 +184,10 @@ import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  extendedEncodeURIComponent as __extendedEncodeURIComponent
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -237,19 +240,19 @@ export async function serializeAws_restJson1_1CreateRouteCommand(
   let resolvedPath =
     "/v20190125/meshes/{meshName}/virtualRouter/{virtualRouterName}/routes";
   if (input.meshName !== undefined) {
-    const labelValue: string = input.meshName.toString();
+    const labelValue: string = input.meshName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: meshName.");
     }
     resolvedPath = resolvedPath.replace(
       "{meshName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: meshName.");
   }
   if (input.virtualRouterName !== undefined) {
-    const labelValue: string = input.virtualRouterName.toString();
+    const labelValue: string = input.virtualRouterName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: virtualRouterName."
@@ -257,7 +260,7 @@ export async function serializeAws_restJson1_1CreateRouteCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{virtualRouterName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -300,13 +303,13 @@ export async function serializeAws_restJson1_1CreateVirtualNodeCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v20190125/meshes/{meshName}/virtualNodes";
   if (input.meshName !== undefined) {
-    const labelValue: string = input.meshName.toString();
+    const labelValue: string = input.meshName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: meshName.");
     }
     resolvedPath = resolvedPath.replace(
       "{meshName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: meshName.");
@@ -350,13 +353,13 @@ export async function serializeAws_restJson1_1CreateVirtualRouterCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v20190125/meshes/{meshName}/virtualRouters";
   if (input.meshName !== undefined) {
-    const labelValue: string = input.meshName.toString();
+    const labelValue: string = input.meshName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: meshName.");
     }
     resolvedPath = resolvedPath.replace(
       "{meshName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: meshName.");
@@ -400,13 +403,13 @@ export async function serializeAws_restJson1_1CreateVirtualServiceCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v20190125/meshes/{meshName}/virtualServices";
   if (input.meshName !== undefined) {
-    const labelValue: string = input.meshName.toString();
+    const labelValue: string = input.meshName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: meshName.");
     }
     resolvedPath = resolvedPath.replace(
       "{meshName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: meshName.");
@@ -450,13 +453,13 @@ export async function serializeAws_restJson1_1DeleteMeshCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v20190125/meshes/{meshName}";
   if (input.meshName !== undefined) {
-    const labelValue: string = input.meshName.toString();
+    const labelValue: string = input.meshName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: meshName.");
     }
     resolvedPath = resolvedPath.replace(
       "{meshName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: meshName.");
@@ -479,31 +482,31 @@ export async function serializeAws_restJson1_1DeleteRouteCommand(
   let resolvedPath =
     "/v20190125/meshes/{meshName}/virtualRouter/{virtualRouterName}/routes/{routeName}";
   if (input.meshName !== undefined) {
-    const labelValue: string = input.meshName.toString();
+    const labelValue: string = input.meshName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: meshName.");
     }
     resolvedPath = resolvedPath.replace(
       "{meshName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: meshName.");
   }
   if (input.routeName !== undefined) {
-    const labelValue: string = input.routeName.toString();
+    const labelValue: string = input.routeName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: routeName.");
     }
     resolvedPath = resolvedPath.replace(
       "{routeName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: routeName.");
   }
   if (input.virtualRouterName !== undefined) {
-    const labelValue: string = input.virtualRouterName.toString();
+    const labelValue: string = input.virtualRouterName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: virtualRouterName."
@@ -511,7 +514,7 @@ export async function serializeAws_restJson1_1DeleteRouteCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{virtualRouterName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -536,19 +539,19 @@ export async function serializeAws_restJson1_1DeleteVirtualNodeCommand(
   let resolvedPath =
     "/v20190125/meshes/{meshName}/virtualNodes/{virtualNodeName}";
   if (input.meshName !== undefined) {
-    const labelValue: string = input.meshName.toString();
+    const labelValue: string = input.meshName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: meshName.");
     }
     resolvedPath = resolvedPath.replace(
       "{meshName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: meshName.");
   }
   if (input.virtualNodeName !== undefined) {
-    const labelValue: string = input.virtualNodeName.toString();
+    const labelValue: string = input.virtualNodeName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: virtualNodeName."
@@ -556,7 +559,7 @@ export async function serializeAws_restJson1_1DeleteVirtualNodeCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{virtualNodeName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: virtualNodeName.");
@@ -579,19 +582,19 @@ export async function serializeAws_restJson1_1DeleteVirtualRouterCommand(
   let resolvedPath =
     "/v20190125/meshes/{meshName}/virtualRouters/{virtualRouterName}";
   if (input.meshName !== undefined) {
-    const labelValue: string = input.meshName.toString();
+    const labelValue: string = input.meshName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: meshName.");
     }
     resolvedPath = resolvedPath.replace(
       "{meshName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: meshName.");
   }
   if (input.virtualRouterName !== undefined) {
-    const labelValue: string = input.virtualRouterName.toString();
+    const labelValue: string = input.virtualRouterName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: virtualRouterName."
@@ -599,7 +602,7 @@ export async function serializeAws_restJson1_1DeleteVirtualRouterCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{virtualRouterName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -624,19 +627,19 @@ export async function serializeAws_restJson1_1DeleteVirtualServiceCommand(
   let resolvedPath =
     "/v20190125/meshes/{meshName}/virtualServices/{virtualServiceName}";
   if (input.meshName !== undefined) {
-    const labelValue: string = input.meshName.toString();
+    const labelValue: string = input.meshName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: meshName.");
     }
     resolvedPath = resolvedPath.replace(
       "{meshName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: meshName.");
   }
   if (input.virtualServiceName !== undefined) {
-    const labelValue: string = input.virtualServiceName.toString();
+    const labelValue: string = input.virtualServiceName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: virtualServiceName."
@@ -644,7 +647,7 @@ export async function serializeAws_restJson1_1DeleteVirtualServiceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{virtualServiceName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -668,13 +671,13 @@ export async function serializeAws_restJson1_1DescribeMeshCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v20190125/meshes/{meshName}";
   if (input.meshName !== undefined) {
-    const labelValue: string = input.meshName.toString();
+    const labelValue: string = input.meshName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: meshName.");
     }
     resolvedPath = resolvedPath.replace(
       "{meshName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: meshName.");
@@ -697,31 +700,31 @@ export async function serializeAws_restJson1_1DescribeRouteCommand(
   let resolvedPath =
     "/v20190125/meshes/{meshName}/virtualRouter/{virtualRouterName}/routes/{routeName}";
   if (input.meshName !== undefined) {
-    const labelValue: string = input.meshName.toString();
+    const labelValue: string = input.meshName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: meshName.");
     }
     resolvedPath = resolvedPath.replace(
       "{meshName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: meshName.");
   }
   if (input.routeName !== undefined) {
-    const labelValue: string = input.routeName.toString();
+    const labelValue: string = input.routeName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: routeName.");
     }
     resolvedPath = resolvedPath.replace(
       "{routeName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: routeName.");
   }
   if (input.virtualRouterName !== undefined) {
-    const labelValue: string = input.virtualRouterName.toString();
+    const labelValue: string = input.virtualRouterName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: virtualRouterName."
@@ -729,7 +732,7 @@ export async function serializeAws_restJson1_1DescribeRouteCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{virtualRouterName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -754,19 +757,19 @@ export async function serializeAws_restJson1_1DescribeVirtualNodeCommand(
   let resolvedPath =
     "/v20190125/meshes/{meshName}/virtualNodes/{virtualNodeName}";
   if (input.meshName !== undefined) {
-    const labelValue: string = input.meshName.toString();
+    const labelValue: string = input.meshName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: meshName.");
     }
     resolvedPath = resolvedPath.replace(
       "{meshName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: meshName.");
   }
   if (input.virtualNodeName !== undefined) {
-    const labelValue: string = input.virtualNodeName.toString();
+    const labelValue: string = input.virtualNodeName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: virtualNodeName."
@@ -774,7 +777,7 @@ export async function serializeAws_restJson1_1DescribeVirtualNodeCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{virtualNodeName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: virtualNodeName.");
@@ -797,19 +800,19 @@ export async function serializeAws_restJson1_1DescribeVirtualRouterCommand(
   let resolvedPath =
     "/v20190125/meshes/{meshName}/virtualRouters/{virtualRouterName}";
   if (input.meshName !== undefined) {
-    const labelValue: string = input.meshName.toString();
+    const labelValue: string = input.meshName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: meshName.");
     }
     resolvedPath = resolvedPath.replace(
       "{meshName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: meshName.");
   }
   if (input.virtualRouterName !== undefined) {
-    const labelValue: string = input.virtualRouterName.toString();
+    const labelValue: string = input.virtualRouterName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: virtualRouterName."
@@ -817,7 +820,7 @@ export async function serializeAws_restJson1_1DescribeVirtualRouterCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{virtualRouterName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -842,19 +845,19 @@ export async function serializeAws_restJson1_1DescribeVirtualServiceCommand(
   let resolvedPath =
     "/v20190125/meshes/{meshName}/virtualServices/{virtualServiceName}";
   if (input.meshName !== undefined) {
-    const labelValue: string = input.meshName.toString();
+    const labelValue: string = input.meshName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: meshName.");
     }
     resolvedPath = resolvedPath.replace(
       "{meshName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: meshName.");
   }
   if (input.virtualServiceName !== undefined) {
-    const labelValue: string = input.virtualServiceName.toString();
+    const labelValue: string = input.virtualServiceName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: virtualServiceName."
@@ -862,7 +865,7 @@ export async function serializeAws_restJson1_1DescribeVirtualServiceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{virtualServiceName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -887,10 +890,14 @@ export async function serializeAws_restJson1_1ListMeshesCommand(
   let resolvedPath = "/v20190125/meshes";
   const query: any = {};
   if (input.limit !== undefined) {
-    query["limit"] = input.limit.toString();
+    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
+      input.limit.toString()
+    );
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -911,19 +918,19 @@ export async function serializeAws_restJson1_1ListRoutesCommand(
   let resolvedPath =
     "/v20190125/meshes/{meshName}/virtualRouter/{virtualRouterName}/routes";
   if (input.meshName !== undefined) {
-    const labelValue: string = input.meshName.toString();
+    const labelValue: string = input.meshName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: meshName.");
     }
     resolvedPath = resolvedPath.replace(
       "{meshName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: meshName.");
   }
   if (input.virtualRouterName !== undefined) {
-    const labelValue: string = input.virtualRouterName.toString();
+    const labelValue: string = input.virtualRouterName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: virtualRouterName."
@@ -931,7 +938,7 @@ export async function serializeAws_restJson1_1ListRoutesCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{virtualRouterName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -940,10 +947,14 @@ export async function serializeAws_restJson1_1ListRoutesCommand(
   }
   const query: any = {};
   if (input.limit !== undefined) {
-    query["limit"] = input.limit.toString();
+    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
+      input.limit.toString()
+    );
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -964,13 +975,19 @@ export async function serializeAws_restJson1_1ListTagsForResourceCommand(
   let resolvedPath = "/v20190125/tags";
   const query: any = {};
   if (input.limit !== undefined) {
-    query["limit"] = input.limit.toString();
+    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
+      input.limit.toString()
+    );
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   if (input.resourceArn !== undefined) {
-    query["resourceArn"] = input.resourceArn.toString();
+    query[
+      __extendedEncodeURIComponent("resourceArn")
+    ] = __extendedEncodeURIComponent(input.resourceArn);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -990,23 +1007,27 @@ export async function serializeAws_restJson1_1ListVirtualNodesCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v20190125/meshes/{meshName}/virtualNodes";
   if (input.meshName !== undefined) {
-    const labelValue: string = input.meshName.toString();
+    const labelValue: string = input.meshName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: meshName.");
     }
     resolvedPath = resolvedPath.replace(
       "{meshName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: meshName.");
   }
   const query: any = {};
   if (input.limit !== undefined) {
-    query["limit"] = input.limit.toString();
+    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
+      input.limit.toString()
+    );
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1026,23 +1047,27 @@ export async function serializeAws_restJson1_1ListVirtualRoutersCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v20190125/meshes/{meshName}/virtualRouters";
   if (input.meshName !== undefined) {
-    const labelValue: string = input.meshName.toString();
+    const labelValue: string = input.meshName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: meshName.");
     }
     resolvedPath = resolvedPath.replace(
       "{meshName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: meshName.");
   }
   const query: any = {};
   if (input.limit !== undefined) {
-    query["limit"] = input.limit.toString();
+    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
+      input.limit.toString()
+    );
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1062,23 +1087,27 @@ export async function serializeAws_restJson1_1ListVirtualServicesCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v20190125/meshes/{meshName}/virtualServices";
   if (input.meshName !== undefined) {
-    const labelValue: string = input.meshName.toString();
+    const labelValue: string = input.meshName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: meshName.");
     }
     resolvedPath = resolvedPath.replace(
       "{meshName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: meshName.");
   }
   const query: any = {};
   if (input.limit !== undefined) {
-    query["limit"] = input.limit.toString();
+    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
+      input.limit.toString()
+    );
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1099,7 +1128,9 @@ export async function serializeAws_restJson1_1TagResourceCommand(
   let resolvedPath = "/v20190125/tag";
   const query: any = {};
   if (input.resourceArn !== undefined) {
-    query["resourceArn"] = input.resourceArn.toString();
+    query[
+      __extendedEncodeURIComponent("resourceArn")
+    ] = __extendedEncodeURIComponent(input.resourceArn);
   }
   let body: any;
   const bodyParams: any = {};
@@ -1127,7 +1158,9 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
   let resolvedPath = "/v20190125/untag";
   const query: any = {};
   if (input.resourceArn !== undefined) {
-    query["resourceArn"] = input.resourceArn.toString();
+    query[
+      __extendedEncodeURIComponent("resourceArn")
+    ] = __extendedEncodeURIComponent(input.resourceArn);
   }
   let body: any;
   const bodyParams: any = {};
@@ -1157,13 +1190,13 @@ export async function serializeAws_restJson1_1UpdateMeshCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v20190125/meshes/{meshName}";
   if (input.meshName !== undefined) {
-    const labelValue: string = input.meshName.toString();
+    const labelValue: string = input.meshName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: meshName.");
     }
     resolvedPath = resolvedPath.replace(
       "{meshName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: meshName.");
@@ -1199,31 +1232,31 @@ export async function serializeAws_restJson1_1UpdateRouteCommand(
   let resolvedPath =
     "/v20190125/meshes/{meshName}/virtualRouter/{virtualRouterName}/routes/{routeName}";
   if (input.meshName !== undefined) {
-    const labelValue: string = input.meshName.toString();
+    const labelValue: string = input.meshName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: meshName.");
     }
     resolvedPath = resolvedPath.replace(
       "{meshName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: meshName.");
   }
   if (input.routeName !== undefined) {
-    const labelValue: string = input.routeName.toString();
+    const labelValue: string = input.routeName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: routeName.");
     }
     resolvedPath = resolvedPath.replace(
       "{routeName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: routeName.");
   }
   if (input.virtualRouterName !== undefined) {
-    const labelValue: string = input.virtualRouterName.toString();
+    const labelValue: string = input.virtualRouterName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: virtualRouterName."
@@ -1231,7 +1264,7 @@ export async function serializeAws_restJson1_1UpdateRouteCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{virtualRouterName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -1269,19 +1302,19 @@ export async function serializeAws_restJson1_1UpdateVirtualNodeCommand(
   let resolvedPath =
     "/v20190125/meshes/{meshName}/virtualNodes/{virtualNodeName}";
   if (input.meshName !== undefined) {
-    const labelValue: string = input.meshName.toString();
+    const labelValue: string = input.meshName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: meshName.");
     }
     resolvedPath = resolvedPath.replace(
       "{meshName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: meshName.");
   }
   if (input.virtualNodeName !== undefined) {
-    const labelValue: string = input.virtualNodeName.toString();
+    const labelValue: string = input.virtualNodeName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: virtualNodeName."
@@ -1289,7 +1322,7 @@ export async function serializeAws_restJson1_1UpdateVirtualNodeCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{virtualNodeName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: virtualNodeName.");
@@ -1328,19 +1361,19 @@ export async function serializeAws_restJson1_1UpdateVirtualRouterCommand(
   let resolvedPath =
     "/v20190125/meshes/{meshName}/virtualRouters/{virtualRouterName}";
   if (input.meshName !== undefined) {
-    const labelValue: string = input.meshName.toString();
+    const labelValue: string = input.meshName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: meshName.");
     }
     resolvedPath = resolvedPath.replace(
       "{meshName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: meshName.");
   }
   if (input.virtualRouterName !== undefined) {
-    const labelValue: string = input.virtualRouterName.toString();
+    const labelValue: string = input.virtualRouterName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: virtualRouterName."
@@ -1348,7 +1381,7 @@ export async function serializeAws_restJson1_1UpdateVirtualRouterCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{virtualRouterName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -1389,19 +1422,19 @@ export async function serializeAws_restJson1_1UpdateVirtualServiceCommand(
   let resolvedPath =
     "/v20190125/meshes/{meshName}/virtualServices/{virtualServiceName}";
   if (input.meshName !== undefined) {
-    const labelValue: string = input.meshName.toString();
+    const labelValue: string = input.meshName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: meshName.");
     }
     resolvedPath = resolvedPath.replace(
       "{meshName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: meshName.");
   }
   if (input.virtualServiceName !== undefined) {
-    const labelValue: string = input.virtualServiceName.toString();
+    const labelValue: string = input.virtualServiceName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: virtualServiceName."
@@ -1409,7 +1442,7 @@ export async function serializeAws_restJson1_1UpdateVirtualServiceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{virtualServiceName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -3467,6 +3500,7 @@ export async function deserializeAws_restJson1_1TagResourceCommand(
     $metadata: deserializeMetadata(output),
     __type: "TagResourceOutput"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -3557,6 +3591,7 @@ export async function deserializeAws_restJson1_1UntagResourceCommand(
     $metadata: deserializeMetadata(output),
     __type: "UntagResourceOutput"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 

--- a/clients/client-appconfig/models/index.ts
+++ b/clients/client-appconfig/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export interface Application extends $MetadataBearer {
@@ -21,7 +24,7 @@ export interface Application extends $MetadataBearer {
 
 export namespace Application {
   export function isa(o: any): o is Application {
-    return _smithy.isa(o, "Application");
+    return __isa(o, "Application");
   }
 }
 
@@ -41,7 +44,7 @@ export interface Applications extends $MetadataBearer {
 
 export namespace Applications {
   export function isa(o: any): o is Applications {
-    return _smithy.isa(o, "Applications");
+    return __isa(o, "Applications");
   }
 }
 
@@ -49,7 +52,7 @@ export namespace Applications {
  * <p>The input fails to satisfy the constraints specified by an AWS service.</p>
  */
 export interface BadRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "BadRequestException";
   $fault: "client";
@@ -58,7 +61,7 @@ export interface BadRequestException
 
 export namespace BadRequestException {
   export function isa(o: any): o is BadRequestException {
-    return _smithy.isa(o, "BadRequestException");
+    return __isa(o, "BadRequestException");
   }
 }
 
@@ -83,7 +86,7 @@ export interface Configuration extends $MetadataBearer {
 
 export namespace Configuration {
   export function isa(o: any): o is Configuration {
-    return _smithy.isa(o, "Configuration");
+    return __isa(o, "Configuration");
   }
 }
 
@@ -128,7 +131,7 @@ export interface ConfigurationProfile extends $MetadataBearer {
 
 export namespace ConfigurationProfile {
   export function isa(o: any): o is ConfigurationProfile {
-    return _smithy.isa(o, "ConfigurationProfile");
+    return __isa(o, "ConfigurationProfile");
   }
 }
 
@@ -165,7 +168,7 @@ export interface ConfigurationProfileSummary {
 
 export namespace ConfigurationProfileSummary {
   export function isa(o: any): o is ConfigurationProfileSummary {
-    return _smithy.isa(o, "ConfigurationProfileSummary");
+    return __isa(o, "ConfigurationProfileSummary");
   }
 }
 
@@ -185,7 +188,7 @@ export interface ConfigurationProfiles extends $MetadataBearer {
 
 export namespace ConfigurationProfiles {
   export function isa(o: any): o is ConfigurationProfiles {
-    return _smithy.isa(o, "ConfigurationProfiles");
+    return __isa(o, "ConfigurationProfiles");
   }
 }
 
@@ -193,9 +196,7 @@ export namespace ConfigurationProfiles {
  * <p>The request could not be processed because of conflict in the current state of the
  *          resource.</p>
  */
-export interface ConflictException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface ConflictException extends __SmithyException, $MetadataBearer {
   name: "ConflictException";
   $fault: "client";
   Message?: string;
@@ -203,7 +204,7 @@ export interface ConflictException
 
 export namespace ConflictException {
   export function isa(o: any): o is ConflictException {
-    return _smithy.isa(o, "ConflictException");
+    return __isa(o, "ConflictException");
   }
 }
 
@@ -229,7 +230,7 @@ export interface CreateApplicationRequest {
 
 export namespace CreateApplicationRequest {
   export function isa(o: any): o is CreateApplicationRequest {
-    return _smithy.isa(o, "CreateApplicationRequest");
+    return __isa(o, "CreateApplicationRequest");
   }
 }
 
@@ -276,7 +277,7 @@ export interface CreateConfigurationProfileRequest {
 
 export namespace CreateConfigurationProfileRequest {
   export function isa(o: any): o is CreateConfigurationProfileRequest {
-    return _smithy.isa(o, "CreateConfigurationProfileRequest");
+    return __isa(o, "CreateConfigurationProfileRequest");
   }
 }
 
@@ -329,7 +330,7 @@ export interface CreateDeploymentStrategyRequest {
 
 export namespace CreateDeploymentStrategyRequest {
   export function isa(o: any): o is CreateDeploymentStrategyRequest {
-    return _smithy.isa(o, "CreateDeploymentStrategyRequest");
+    return __isa(o, "CreateDeploymentStrategyRequest");
   }
 }
 
@@ -365,7 +366,7 @@ export interface CreateEnvironmentRequest {
 
 export namespace CreateEnvironmentRequest {
   export function isa(o: any): o is CreateEnvironmentRequest {
-    return _smithy.isa(o, "CreateEnvironmentRequest");
+    return __isa(o, "CreateEnvironmentRequest");
   }
 }
 
@@ -379,7 +380,7 @@ export interface DeleteApplicationRequest {
 
 export namespace DeleteApplicationRequest {
   export function isa(o: any): o is DeleteApplicationRequest {
-    return _smithy.isa(o, "DeleteApplicationRequest");
+    return __isa(o, "DeleteApplicationRequest");
   }
 }
 
@@ -398,7 +399,7 @@ export interface DeleteConfigurationProfileRequest {
 
 export namespace DeleteConfigurationProfileRequest {
   export function isa(o: any): o is DeleteConfigurationProfileRequest {
-    return _smithy.isa(o, "DeleteConfigurationProfileRequest");
+    return __isa(o, "DeleteConfigurationProfileRequest");
   }
 }
 
@@ -412,7 +413,7 @@ export interface DeleteDeploymentStrategyRequest {
 
 export namespace DeleteDeploymentStrategyRequest {
   export function isa(o: any): o is DeleteDeploymentStrategyRequest {
-    return _smithy.isa(o, "DeleteDeploymentStrategyRequest");
+    return __isa(o, "DeleteDeploymentStrategyRequest");
   }
 }
 
@@ -431,7 +432,7 @@ export interface DeleteEnvironmentRequest {
 
 export namespace DeleteEnvironmentRequest {
   export function isa(o: any): o is DeleteEnvironmentRequest {
-    return _smithy.isa(o, "DeleteEnvironmentRequest");
+    return __isa(o, "DeleteEnvironmentRequest");
   }
 }
 
@@ -527,7 +528,7 @@ export interface Deployment extends $MetadataBearer {
 
 export namespace Deployment {
   export function isa(o: any): o is Deployment {
-    return _smithy.isa(o, "Deployment");
+    return __isa(o, "Deployment");
   }
 }
 
@@ -556,7 +557,7 @@ export interface DeploymentStrategies extends $MetadataBearer {
 
 export namespace DeploymentStrategies {
   export function isa(o: any): o is DeploymentStrategies {
-    return _smithy.isa(o, "DeploymentStrategies");
+    return __isa(o, "DeploymentStrategies");
   }
 }
 
@@ -607,7 +608,7 @@ export interface DeploymentStrategy extends $MetadataBearer {
 
 export namespace DeploymentStrategy {
   export function isa(o: any): o is DeploymentStrategy {
-    return _smithy.isa(o, "DeploymentStrategy");
+    return __isa(o, "DeploymentStrategy");
   }
 }
 
@@ -676,7 +677,7 @@ export interface DeploymentSummary {
 
 export namespace DeploymentSummary {
   export function isa(o: any): o is DeploymentSummary {
-    return _smithy.isa(o, "DeploymentSummary");
+    return __isa(o, "DeploymentSummary");
   }
 }
 
@@ -696,7 +697,7 @@ export interface Deployments extends $MetadataBearer {
 
 export namespace Deployments {
   export function isa(o: any): o is Deployments {
-    return _smithy.isa(o, "Deployments");
+    return __isa(o, "Deployments");
   }
 }
 
@@ -738,7 +739,7 @@ export interface Environment extends $MetadataBearer {
 
 export namespace Environment {
   export function isa(o: any): o is Environment {
-    return _smithy.isa(o, "Environment");
+    return __isa(o, "Environment");
   }
 }
 
@@ -765,7 +766,7 @@ export interface Environments extends $MetadataBearer {
 
 export namespace Environments {
   export function isa(o: any): o is Environments {
-    return _smithy.isa(o, "Environments");
+    return __isa(o, "Environments");
   }
 }
 
@@ -779,7 +780,7 @@ export interface GetApplicationRequest {
 
 export namespace GetApplicationRequest {
   export function isa(o: any): o is GetApplicationRequest {
-    return _smithy.isa(o, "GetApplicationRequest");
+    return __isa(o, "GetApplicationRequest");
   }
 }
 
@@ -799,7 +800,7 @@ export interface GetConfigurationProfileRequest {
 
 export namespace GetConfigurationProfileRequest {
   export function isa(o: any): o is GetConfigurationProfileRequest {
-    return _smithy.isa(o, "GetConfigurationProfileRequest");
+    return __isa(o, "GetConfigurationProfileRequest");
   }
 }
 
@@ -834,7 +835,7 @@ export interface GetConfigurationRequest {
 
 export namespace GetConfigurationRequest {
   export function isa(o: any): o is GetConfigurationRequest {
-    return _smithy.isa(o, "GetConfigurationRequest");
+    return __isa(o, "GetConfigurationRequest");
   }
 }
 
@@ -858,7 +859,7 @@ export interface GetDeploymentRequest {
 
 export namespace GetDeploymentRequest {
   export function isa(o: any): o is GetDeploymentRequest {
-    return _smithy.isa(o, "GetDeploymentRequest");
+    return __isa(o, "GetDeploymentRequest");
   }
 }
 
@@ -872,7 +873,7 @@ export interface GetDeploymentStrategyRequest {
 
 export namespace GetDeploymentStrategyRequest {
   export function isa(o: any): o is GetDeploymentStrategyRequest {
-    return _smithy.isa(o, "GetDeploymentStrategyRequest");
+    return __isa(o, "GetDeploymentStrategyRequest");
   }
 }
 
@@ -891,7 +892,7 @@ export interface GetEnvironmentRequest {
 
 export namespace GetEnvironmentRequest {
   export function isa(o: any): o is GetEnvironmentRequest {
-    return _smithy.isa(o, "GetEnvironmentRequest");
+    return __isa(o, "GetEnvironmentRequest");
   }
 }
 
@@ -903,7 +904,7 @@ export enum GrowthType {
  * <p>There was an internal failure in the AppConfig service.</p>
  */
 export interface InternalServerException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalServerException";
   $fault: "server";
@@ -912,7 +913,7 @@ export interface InternalServerException
 
 export namespace InternalServerException {
   export function isa(o: any): o is InternalServerException {
-    return _smithy.isa(o, "InternalServerException");
+    return __isa(o, "InternalServerException");
   }
 }
 
@@ -932,7 +933,7 @@ export interface ListApplicationsRequest {
 
 export namespace ListApplicationsRequest {
   export function isa(o: any): o is ListApplicationsRequest {
-    return _smithy.isa(o, "ListApplicationsRequest");
+    return __isa(o, "ListApplicationsRequest");
   }
 }
 
@@ -957,7 +958,7 @@ export interface ListConfigurationProfilesRequest {
 
 export namespace ListConfigurationProfilesRequest {
   export function isa(o: any): o is ListConfigurationProfilesRequest {
-    return _smithy.isa(o, "ListConfigurationProfilesRequest");
+    return __isa(o, "ListConfigurationProfilesRequest");
   }
 }
 
@@ -977,7 +978,7 @@ export interface ListDeploymentStrategiesRequest {
 
 export namespace ListDeploymentStrategiesRequest {
   export function isa(o: any): o is ListDeploymentStrategiesRequest {
-    return _smithy.isa(o, "ListDeploymentStrategiesRequest");
+    return __isa(o, "ListDeploymentStrategiesRequest");
   }
 }
 
@@ -1007,7 +1008,7 @@ export interface ListDeploymentsRequest {
 
 export namespace ListDeploymentsRequest {
   export function isa(o: any): o is ListDeploymentsRequest {
-    return _smithy.isa(o, "ListDeploymentsRequest");
+    return __isa(o, "ListDeploymentsRequest");
   }
 }
 
@@ -1032,7 +1033,7 @@ export interface ListEnvironmentsRequest {
 
 export namespace ListEnvironmentsRequest {
   export function isa(o: any): o is ListEnvironmentsRequest {
-    return _smithy.isa(o, "ListEnvironmentsRequest");
+    return __isa(o, "ListEnvironmentsRequest");
   }
 }
 
@@ -1046,7 +1047,7 @@ export interface ListTagsForResourceRequest {
 
 export namespace ListTagsForResourceRequest {
   export function isa(o: any): o is ListTagsForResourceRequest {
-    return _smithy.isa(o, "ListTagsForResourceRequest");
+    return __isa(o, "ListTagsForResourceRequest");
   }
 }
 
@@ -1068,7 +1069,7 @@ export interface Monitor {
 
 export namespace Monitor {
   export function isa(o: any): o is Monitor {
-    return _smithy.isa(o, "Monitor");
+    return __isa(o, "Monitor");
   }
 }
 
@@ -1081,7 +1082,7 @@ export enum ReplicateTo {
  * <p>The requested resource could not be found.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -1091,7 +1092,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -1107,7 +1108,7 @@ export interface ResourceTags extends $MetadataBearer {
 
 export namespace ResourceTags {
   export function isa(o: any): o is ResourceTags {
-    return _smithy.isa(o, "ResourceTags");
+    return __isa(o, "ResourceTags");
   }
 }
 
@@ -1153,7 +1154,7 @@ export interface StartDeploymentRequest {
 
 export namespace StartDeploymentRequest {
   export function isa(o: any): o is StartDeploymentRequest {
-    return _smithy.isa(o, "StartDeploymentRequest");
+    return __isa(o, "StartDeploymentRequest");
   }
 }
 
@@ -1177,7 +1178,7 @@ export interface StopDeploymentRequest {
 
 export namespace StopDeploymentRequest {
   export function isa(o: any): o is StopDeploymentRequest {
-    return _smithy.isa(o, "StopDeploymentRequest");
+    return __isa(o, "StopDeploymentRequest");
   }
 }
 
@@ -1198,7 +1199,7 @@ export interface TagResourceRequest {
 
 export namespace TagResourceRequest {
   export function isa(o: any): o is TagResourceRequest {
-    return _smithy.isa(o, "TagResourceRequest");
+    return __isa(o, "TagResourceRequest");
   }
 }
 
@@ -1217,7 +1218,7 @@ export interface UntagResourceRequest {
 
 export namespace UntagResourceRequest {
   export function isa(o: any): o is UntagResourceRequest {
-    return _smithy.isa(o, "UntagResourceRequest");
+    return __isa(o, "UntagResourceRequest");
   }
 }
 
@@ -1241,7 +1242,7 @@ export interface UpdateApplicationRequest {
 
 export namespace UpdateApplicationRequest {
   export function isa(o: any): o is UpdateApplicationRequest {
-    return _smithy.isa(o, "UpdateApplicationRequest");
+    return __isa(o, "UpdateApplicationRequest");
   }
 }
 
@@ -1281,7 +1282,7 @@ export interface UpdateConfigurationProfileRequest {
 
 export namespace UpdateConfigurationProfileRequest {
   export function isa(o: any): o is UpdateConfigurationProfileRequest {
-    return _smithy.isa(o, "UpdateConfigurationProfileRequest");
+    return __isa(o, "UpdateConfigurationProfileRequest");
   }
 }
 
@@ -1322,7 +1323,7 @@ export interface UpdateDeploymentStrategyRequest {
 
 export namespace UpdateDeploymentStrategyRequest {
   export function isa(o: any): o is UpdateDeploymentStrategyRequest {
-    return _smithy.isa(o, "UpdateDeploymentStrategyRequest");
+    return __isa(o, "UpdateDeploymentStrategyRequest");
   }
 }
 
@@ -1356,7 +1357,7 @@ export interface UpdateEnvironmentRequest {
 
 export namespace UpdateEnvironmentRequest {
   export function isa(o: any): o is UpdateEnvironmentRequest {
-    return _smithy.isa(o, "UpdateEnvironmentRequest");
+    return __isa(o, "UpdateEnvironmentRequest");
   }
 }
 
@@ -1380,7 +1381,7 @@ export interface ValidateConfigurationRequest {
 
 export namespace ValidateConfigurationRequest {
   export function isa(o: any): o is ValidateConfigurationRequest {
-    return _smithy.isa(o, "ValidateConfigurationRequest");
+    return __isa(o, "ValidateConfigurationRequest");
   }
 }
 
@@ -1407,7 +1408,7 @@ export interface Validator {
 
 export namespace Validator {
   export function isa(o: any): o is Validator {
-    return _smithy.isa(o, "Validator");
+    return __isa(o, "Validator");
   }
 }
 

--- a/clients/client-appconfig/protocols/Aws_restJson1_1.ts
+++ b/clients/client-appconfig/protocols/Aws_restJson1_1.ts
@@ -132,7 +132,10 @@ import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  extendedEncodeURIComponent as __extendedEncodeURIComponent
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -177,7 +180,7 @@ export async function serializeAws_restJson1_1CreateConfigurationProfileCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/applications/{ApplicationId}/configurationprofiles";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -185,7 +188,7 @@ export async function serializeAws_restJson1_1CreateConfigurationProfileCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
@@ -277,7 +280,7 @@ export async function serializeAws_restJson1_1CreateEnvironmentCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/applications/{ApplicationId}/environments";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -285,7 +288,7 @@ export async function serializeAws_restJson1_1CreateEnvironmentCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
@@ -326,7 +329,7 @@ export async function serializeAws_restJson1_1DeleteApplicationCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/applications/{ApplicationId}";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -334,7 +337,7 @@ export async function serializeAws_restJson1_1DeleteApplicationCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
@@ -357,7 +360,7 @@ export async function serializeAws_restJson1_1DeleteConfigurationProfileCommand(
   let resolvedPath =
     "/applications/{ApplicationId}/configurationprofiles/{ConfigurationProfileId}";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -365,13 +368,13 @@ export async function serializeAws_restJson1_1DeleteConfigurationProfileCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
   }
   if (input.ConfigurationProfileId !== undefined) {
-    const labelValue: string = input.ConfigurationProfileId.toString();
+    const labelValue: string = input.ConfigurationProfileId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ConfigurationProfileId."
@@ -379,7 +382,7 @@ export async function serializeAws_restJson1_1DeleteConfigurationProfileCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ConfigurationProfileId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -403,7 +406,7 @@ export async function serializeAws_restJson1_1DeleteDeploymentStrategyCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/deployementstrategies/{DeploymentStrategyId}";
   if (input.DeploymentStrategyId !== undefined) {
-    const labelValue: string = input.DeploymentStrategyId.toString();
+    const labelValue: string = input.DeploymentStrategyId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: DeploymentStrategyId."
@@ -411,7 +414,7 @@ export async function serializeAws_restJson1_1DeleteDeploymentStrategyCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{DeploymentStrategyId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -436,7 +439,7 @@ export async function serializeAws_restJson1_1DeleteEnvironmentCommand(
   let resolvedPath =
     "/applications/{ApplicationId}/environments/{EnvironmentId}";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -444,13 +447,13 @@ export async function serializeAws_restJson1_1DeleteEnvironmentCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
   }
   if (input.EnvironmentId !== undefined) {
-    const labelValue: string = input.EnvironmentId.toString();
+    const labelValue: string = input.EnvironmentId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: EnvironmentId."
@@ -458,7 +461,7 @@ export async function serializeAws_restJson1_1DeleteEnvironmentCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{EnvironmentId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: EnvironmentId.");
@@ -480,7 +483,7 @@ export async function serializeAws_restJson1_1GetApplicationCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/applications/{ApplicationId}";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -488,7 +491,7 @@ export async function serializeAws_restJson1_1GetApplicationCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
@@ -511,7 +514,7 @@ export async function serializeAws_restJson1_1GetConfigurationCommand(
   let resolvedPath =
     "/applications/{Application}/environments/{Environment}/configurations/{Configuration}";
   if (input.Application !== undefined) {
-    const labelValue: string = input.Application.toString();
+    const labelValue: string = input.Application;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: Application."
@@ -519,13 +522,13 @@ export async function serializeAws_restJson1_1GetConfigurationCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{Application}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Application.");
   }
   if (input.Configuration !== undefined) {
-    const labelValue: string = input.Configuration.toString();
+    const labelValue: string = input.Configuration;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: Configuration."
@@ -533,13 +536,13 @@ export async function serializeAws_restJson1_1GetConfigurationCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{Configuration}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Configuration.");
   }
   if (input.Environment !== undefined) {
-    const labelValue: string = input.Environment.toString();
+    const labelValue: string = input.Environment;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: Environment."
@@ -547,7 +550,7 @@ export async function serializeAws_restJson1_1GetConfigurationCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{Environment}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Environment.");
@@ -555,11 +558,13 @@ export async function serializeAws_restJson1_1GetConfigurationCommand(
   const query: any = {};
   if (input.ClientConfigurationVersion !== undefined) {
     query[
-      "client_configuration_version"
-    ] = input.ClientConfigurationVersion.toString();
+      __extendedEncodeURIComponent("client_configuration_version")
+    ] = __extendedEncodeURIComponent(input.ClientConfigurationVersion);
   }
   if (input.ClientId !== undefined) {
-    query["client_id"] = input.ClientId.toString();
+    query[
+      __extendedEncodeURIComponent("client_id")
+    ] = __extendedEncodeURIComponent(input.ClientId);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -580,7 +585,7 @@ export async function serializeAws_restJson1_1GetConfigurationProfileCommand(
   let resolvedPath =
     "/applications/{ApplicationId}/configurationprofiles/{ConfigurationProfileId}";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -588,13 +593,13 @@ export async function serializeAws_restJson1_1GetConfigurationProfileCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
   }
   if (input.ConfigurationProfileId !== undefined) {
-    const labelValue: string = input.ConfigurationProfileId.toString();
+    const labelValue: string = input.ConfigurationProfileId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ConfigurationProfileId."
@@ -602,7 +607,7 @@ export async function serializeAws_restJson1_1GetConfigurationProfileCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ConfigurationProfileId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -627,7 +632,7 @@ export async function serializeAws_restJson1_1GetDeploymentCommand(
   let resolvedPath =
     "/applications/{ApplicationId}/environments/{EnvironmentId}/deployments/{DeploymentNumber}";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -635,7 +640,7 @@ export async function serializeAws_restJson1_1GetDeploymentCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
@@ -649,7 +654,7 @@ export async function serializeAws_restJson1_1GetDeploymentCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{DeploymentNumber}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -657,7 +662,7 @@ export async function serializeAws_restJson1_1GetDeploymentCommand(
     );
   }
   if (input.EnvironmentId !== undefined) {
-    const labelValue: string = input.EnvironmentId.toString();
+    const labelValue: string = input.EnvironmentId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: EnvironmentId."
@@ -665,7 +670,7 @@ export async function serializeAws_restJson1_1GetDeploymentCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{EnvironmentId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: EnvironmentId.");
@@ -687,7 +692,7 @@ export async function serializeAws_restJson1_1GetDeploymentStrategyCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/deploymentstrategies/{DeploymentStrategyId}";
   if (input.DeploymentStrategyId !== undefined) {
-    const labelValue: string = input.DeploymentStrategyId.toString();
+    const labelValue: string = input.DeploymentStrategyId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: DeploymentStrategyId."
@@ -695,7 +700,7 @@ export async function serializeAws_restJson1_1GetDeploymentStrategyCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{DeploymentStrategyId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -720,7 +725,7 @@ export async function serializeAws_restJson1_1GetEnvironmentCommand(
   let resolvedPath =
     "/applications/{ApplicationId}/environments/{EnvironmentId}";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -728,13 +733,13 @@ export async function serializeAws_restJson1_1GetEnvironmentCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
   }
   if (input.EnvironmentId !== undefined) {
-    const labelValue: string = input.EnvironmentId.toString();
+    const labelValue: string = input.EnvironmentId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: EnvironmentId."
@@ -742,7 +747,7 @@ export async function serializeAws_restJson1_1GetEnvironmentCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{EnvironmentId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: EnvironmentId.");
@@ -765,10 +770,14 @@ export async function serializeAws_restJson1_1ListApplicationsCommand(
   let resolvedPath = "/applications";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["max_results"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("max_results")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["next_token"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("next_token")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -788,7 +797,7 @@ export async function serializeAws_restJson1_1ListConfigurationProfilesCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/applications/{ApplicationId}/configurationprofiles";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -796,17 +805,21 @@ export async function serializeAws_restJson1_1ListConfigurationProfilesCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["max_results"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("max_results")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["next_token"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("next_token")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -827,10 +840,14 @@ export async function serializeAws_restJson1_1ListDeploymentStrategiesCommand(
   let resolvedPath = "/deploymentstrategies";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["max_results"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("max_results")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["next_token"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("next_token")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -851,7 +868,7 @@ export async function serializeAws_restJson1_1ListDeploymentsCommand(
   let resolvedPath =
     "/applications/{ApplicationId}/environments/{EnvironmentId}/deployments";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -859,13 +876,13 @@ export async function serializeAws_restJson1_1ListDeploymentsCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
   }
   if (input.EnvironmentId !== undefined) {
-    const labelValue: string = input.EnvironmentId.toString();
+    const labelValue: string = input.EnvironmentId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: EnvironmentId."
@@ -873,17 +890,21 @@ export async function serializeAws_restJson1_1ListDeploymentsCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{EnvironmentId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: EnvironmentId.");
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["max_results"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("max_results")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["next_token"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("next_token")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -903,7 +924,7 @@ export async function serializeAws_restJson1_1ListEnvironmentsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/applications/{ApplicationId}/environments";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -911,17 +932,21 @@ export async function serializeAws_restJson1_1ListEnvironmentsCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["max_results"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("max_results")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["next_token"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("next_token")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -941,7 +966,7 @@ export async function serializeAws_restJson1_1ListTagsForResourceCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/tags/{ResourceArn}";
   if (input.ResourceArn !== undefined) {
-    const labelValue: string = input.ResourceArn.toString();
+    const labelValue: string = input.ResourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ResourceArn."
@@ -949,7 +974,7 @@ export async function serializeAws_restJson1_1ListTagsForResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ResourceArn.");
@@ -972,7 +997,7 @@ export async function serializeAws_restJson1_1StartDeploymentCommand(
   let resolvedPath =
     "/applications/{ApplicationId}/environments/{EnvironmentId}/deployments";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -980,13 +1005,13 @@ export async function serializeAws_restJson1_1StartDeploymentCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
   }
   if (input.EnvironmentId !== undefined) {
-    const labelValue: string = input.EnvironmentId.toString();
+    const labelValue: string = input.EnvironmentId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: EnvironmentId."
@@ -994,7 +1019,7 @@ export async function serializeAws_restJson1_1StartDeploymentCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{EnvironmentId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: EnvironmentId.");
@@ -1036,7 +1061,7 @@ export async function serializeAws_restJson1_1StopDeploymentCommand(
   let resolvedPath =
     "/applications/{ApplicationId}/environments/{EnvironmentId}/deployments/{DeploymentNumber}";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -1044,7 +1069,7 @@ export async function serializeAws_restJson1_1StopDeploymentCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
@@ -1058,7 +1083,7 @@ export async function serializeAws_restJson1_1StopDeploymentCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{DeploymentNumber}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -1066,7 +1091,7 @@ export async function serializeAws_restJson1_1StopDeploymentCommand(
     );
   }
   if (input.EnvironmentId !== undefined) {
-    const labelValue: string = input.EnvironmentId.toString();
+    const labelValue: string = input.EnvironmentId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: EnvironmentId."
@@ -1074,7 +1099,7 @@ export async function serializeAws_restJson1_1StopDeploymentCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{EnvironmentId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: EnvironmentId.");
@@ -1096,7 +1121,7 @@ export async function serializeAws_restJson1_1TagResourceCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/tags/{ResourceArn}";
   if (input.ResourceArn !== undefined) {
-    const labelValue: string = input.ResourceArn.toString();
+    const labelValue: string = input.ResourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ResourceArn."
@@ -1104,7 +1129,7 @@ export async function serializeAws_restJson1_1TagResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ResourceArn.");
@@ -1133,7 +1158,7 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/tags/{ResourceArn}";
   if (input.ResourceArn !== undefined) {
-    const labelValue: string = input.ResourceArn.toString();
+    const labelValue: string = input.ResourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ResourceArn."
@@ -1141,14 +1166,16 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ResourceArn.");
   }
   const query: any = {};
   if (input.TagKeys !== undefined) {
-    query["tagKeys"] = input.TagKeys;
+    query[__extendedEncodeURIComponent("tagKeys")] = input.TagKeys.map(entry =>
+      __extendedEncodeURIComponent(entry)
+    );
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1168,7 +1195,7 @@ export async function serializeAws_restJson1_1UpdateApplicationCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/applications/{ApplicationId}";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -1176,7 +1203,7 @@ export async function serializeAws_restJson1_1UpdateApplicationCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
@@ -1209,7 +1236,7 @@ export async function serializeAws_restJson1_1UpdateConfigurationProfileCommand(
   let resolvedPath =
     "/applications/{ApplicationId}/configurationprofiles/{ConfigurationProfileId}";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -1217,13 +1244,13 @@ export async function serializeAws_restJson1_1UpdateConfigurationProfileCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
   }
   if (input.ConfigurationProfileId !== undefined) {
-    const labelValue: string = input.ConfigurationProfileId.toString();
+    const labelValue: string = input.ConfigurationProfileId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ConfigurationProfileId."
@@ -1231,7 +1258,7 @@ export async function serializeAws_restJson1_1UpdateConfigurationProfileCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ConfigurationProfileId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -1274,7 +1301,7 @@ export async function serializeAws_restJson1_1UpdateDeploymentStrategyCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/deploymentstrategies/{DeploymentStrategyId}";
   if (input.DeploymentStrategyId !== undefined) {
-    const labelValue: string = input.DeploymentStrategyId.toString();
+    const labelValue: string = input.DeploymentStrategyId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: DeploymentStrategyId."
@@ -1282,7 +1309,7 @@ export async function serializeAws_restJson1_1UpdateDeploymentStrategyCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{DeploymentStrategyId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -1327,7 +1354,7 @@ export async function serializeAws_restJson1_1UpdateEnvironmentCommand(
   let resolvedPath =
     "/applications/{ApplicationId}/environments/{EnvironmentId}";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -1335,13 +1362,13 @@ export async function serializeAws_restJson1_1UpdateEnvironmentCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
   }
   if (input.EnvironmentId !== undefined) {
-    const labelValue: string = input.EnvironmentId.toString();
+    const labelValue: string = input.EnvironmentId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: EnvironmentId."
@@ -1349,7 +1376,7 @@ export async function serializeAws_restJson1_1UpdateEnvironmentCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{EnvironmentId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: EnvironmentId.");
@@ -1388,7 +1415,7 @@ export async function serializeAws_restJson1_1ValidateConfigurationCommand(
   let resolvedPath =
     "/applications/{ApplicationId}/configurationprofiles/{ConfigurationProfileId}/validators";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -1396,13 +1423,13 @@ export async function serializeAws_restJson1_1ValidateConfigurationCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
   }
   if (input.ConfigurationProfileId !== undefined) {
-    const labelValue: string = input.ConfigurationProfileId.toString();
+    const labelValue: string = input.ConfigurationProfileId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ConfigurationProfileId."
@@ -1410,7 +1437,7 @@ export async function serializeAws_restJson1_1ValidateConfigurationCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ConfigurationProfileId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -1419,7 +1446,9 @@ export async function serializeAws_restJson1_1ValidateConfigurationCommand(
   }
   const query: any = {};
   if (input.ConfigurationVersion !== undefined) {
-    query["configuration_version"] = input.ConfigurationVersion.toString();
+    query[
+      __extendedEncodeURIComponent("configuration_version")
+    ] = __extendedEncodeURIComponent(input.ConfigurationVersion);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1802,6 +1831,7 @@ export async function deserializeAws_restJson1_1DeleteApplicationCommand(
   const contents: DeleteApplicationCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -1866,6 +1896,7 @@ export async function deserializeAws_restJson1_1DeleteConfigurationProfileComman
   const contents: DeleteConfigurationProfileCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -1937,6 +1968,7 @@ export async function deserializeAws_restJson1_1DeleteDeploymentStrategyCommand(
   const contents: DeleteDeploymentStrategyCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2001,6 +2033,7 @@ export async function deserializeAws_restJson1_1DeleteEnvironmentCommand(
   const contents: DeleteEnvironmentCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -3427,6 +3460,7 @@ export async function deserializeAws_restJson1_1TagResourceCommand(
   const contents: TagResourceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -3488,6 +3522,7 @@ export async function deserializeAws_restJson1_1UntagResourceCommand(
   const contents: UntagResourceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -3924,6 +3959,7 @@ export async function deserializeAws_restJson1_1ValidateConfigurationCommand(
   const contents: ValidateConfigurationCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 

--- a/clients/client-application-auto-scaling/models/index.ts
+++ b/clients/client-application-auto-scaling/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export enum AdjustmentType {
@@ -25,7 +28,7 @@ export interface Alarm {
 
 export namespace Alarm {
   export function isa(o: any): o is Alarm {
-    return _smithy.isa(o, "Alarm");
+    return __isa(o, "Alarm");
   }
 }
 
@@ -34,7 +37,7 @@ export namespace Alarm {
  *          Application Auto Scaling resource that already has a pending update.</p>
  */
 export interface ConcurrentUpdateException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ConcurrentUpdateException";
   $fault: "server";
@@ -43,7 +46,7 @@ export interface ConcurrentUpdateException
 
 export namespace ConcurrentUpdateException {
   export function isa(o: any): o is ConcurrentUpdateException {
-    return _smithy.isa(o, "ConcurrentUpdateException");
+    return __isa(o, "ConcurrentUpdateException");
   }
 }
 
@@ -99,7 +102,7 @@ export interface CustomizedMetricSpecification {
 
 export namespace CustomizedMetricSpecification {
   export function isa(o: any): o is CustomizedMetricSpecification {
-    return _smithy.isa(o, "CustomizedMetricSpecification");
+    return __isa(o, "CustomizedMetricSpecification");
   }
 }
 
@@ -231,7 +234,7 @@ export interface DeleteScalingPolicyRequest {
 
 export namespace DeleteScalingPolicyRequest {
   export function isa(o: any): o is DeleteScalingPolicyRequest {
-    return _smithy.isa(o, "DeleteScalingPolicyRequest");
+    return __isa(o, "DeleteScalingPolicyRequest");
   }
 }
 
@@ -241,7 +244,7 @@ export interface DeleteScalingPolicyResponse extends $MetadataBearer {
 
 export namespace DeleteScalingPolicyResponse {
   export function isa(o: any): o is DeleteScalingPolicyResponse {
-    return _smithy.isa(o, "DeleteScalingPolicyResponse");
+    return __isa(o, "DeleteScalingPolicyResponse");
   }
 }
 
@@ -373,7 +376,7 @@ export interface DeleteScheduledActionRequest {
 
 export namespace DeleteScheduledActionRequest {
   export function isa(o: any): o is DeleteScheduledActionRequest {
-    return _smithy.isa(o, "DeleteScheduledActionRequest");
+    return __isa(o, "DeleteScheduledActionRequest");
   }
 }
 
@@ -383,7 +386,7 @@ export interface DeleteScheduledActionResponse extends $MetadataBearer {
 
 export namespace DeleteScheduledActionResponse {
   export function isa(o: any): o is DeleteScheduledActionResponse {
-    return _smithy.isa(o, "DeleteScheduledActionResponse");
+    return __isa(o, "DeleteScheduledActionResponse");
   }
 }
 
@@ -511,7 +514,7 @@ export interface DeregisterScalableTargetRequest {
 
 export namespace DeregisterScalableTargetRequest {
   export function isa(o: any): o is DeregisterScalableTargetRequest {
-    return _smithy.isa(o, "DeregisterScalableTargetRequest");
+    return __isa(o, "DeregisterScalableTargetRequest");
   }
 }
 
@@ -521,7 +524,7 @@ export interface DeregisterScalableTargetResponse extends $MetadataBearer {
 
 export namespace DeregisterScalableTargetResponse {
   export function isa(o: any): o is DeregisterScalableTargetResponse {
-    return _smithy.isa(o, "DeregisterScalableTargetResponse");
+    return __isa(o, "DeregisterScalableTargetResponse");
   }
 }
 
@@ -665,7 +668,7 @@ export interface DescribeScalableTargetsRequest {
 
 export namespace DescribeScalableTargetsRequest {
   export function isa(o: any): o is DescribeScalableTargetsRequest {
-    return _smithy.isa(o, "DescribeScalableTargetsRequest");
+    return __isa(o, "DescribeScalableTargetsRequest");
   }
 }
 
@@ -685,7 +688,7 @@ export interface DescribeScalableTargetsResponse extends $MetadataBearer {
 
 export namespace DescribeScalableTargetsResponse {
   export function isa(o: any): o is DescribeScalableTargetsResponse {
-    return _smithy.isa(o, "DescribeScalableTargetsResponse");
+    return __isa(o, "DescribeScalableTargetsResponse");
   }
 }
 
@@ -829,7 +832,7 @@ export interface DescribeScalingActivitiesRequest {
 
 export namespace DescribeScalingActivitiesRequest {
   export function isa(o: any): o is DescribeScalingActivitiesRequest {
-    return _smithy.isa(o, "DescribeScalingActivitiesRequest");
+    return __isa(o, "DescribeScalingActivitiesRequest");
   }
 }
 
@@ -849,7 +852,7 @@ export interface DescribeScalingActivitiesResponse extends $MetadataBearer {
 
 export namespace DescribeScalingActivitiesResponse {
   export function isa(o: any): o is DescribeScalingActivitiesResponse {
-    return _smithy.isa(o, "DescribeScalingActivitiesResponse");
+    return __isa(o, "DescribeScalingActivitiesResponse");
   }
 }
 
@@ -998,7 +1001,7 @@ export interface DescribeScalingPoliciesRequest {
 
 export namespace DescribeScalingPoliciesRequest {
   export function isa(o: any): o is DescribeScalingPoliciesRequest {
-    return _smithy.isa(o, "DescribeScalingPoliciesRequest");
+    return __isa(o, "DescribeScalingPoliciesRequest");
   }
 }
 
@@ -1018,7 +1021,7 @@ export interface DescribeScalingPoliciesResponse extends $MetadataBearer {
 
 export namespace DescribeScalingPoliciesResponse {
   export function isa(o: any): o is DescribeScalingPoliciesResponse {
-    return _smithy.isa(o, "DescribeScalingPoliciesResponse");
+    return __isa(o, "DescribeScalingPoliciesResponse");
   }
 }
 
@@ -1167,7 +1170,7 @@ export interface DescribeScheduledActionsRequest {
 
 export namespace DescribeScheduledActionsRequest {
   export function isa(o: any): o is DescribeScheduledActionsRequest {
-    return _smithy.isa(o, "DescribeScheduledActionsRequest");
+    return __isa(o, "DescribeScheduledActionsRequest");
   }
 }
 
@@ -1187,7 +1190,7 @@ export interface DescribeScheduledActionsResponse extends $MetadataBearer {
 
 export namespace DescribeScheduledActionsResponse {
   export function isa(o: any): o is DescribeScheduledActionsResponse {
-    return _smithy.isa(o, "DescribeScheduledActionsResponse");
+    return __isa(o, "DescribeScheduledActionsResponse");
   }
 }
 
@@ -1198,7 +1201,7 @@ export namespace DescribeScheduledActionsResponse {
  *          call the CloudWatch <a href="https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_DescribeAlarms.html">DescribeAlarms</a> on your behalf.</p>
  */
 export interface FailedResourceAccessException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "FailedResourceAccessException";
   $fault: "client";
@@ -1207,7 +1210,7 @@ export interface FailedResourceAccessException
 
 export namespace FailedResourceAccessException {
   export function isa(o: any): o is FailedResourceAccessException {
-    return _smithy.isa(o, "FailedResourceAccessException");
+    return __isa(o, "FailedResourceAccessException");
   }
 }
 
@@ -1215,7 +1218,7 @@ export namespace FailedResourceAccessException {
  * <p>The service encountered an internal error.</p>
  */
 export interface InternalServiceException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalServiceException";
   $fault: "server";
@@ -1224,7 +1227,7 @@ export interface InternalServiceException
 
 export namespace InternalServiceException {
   export function isa(o: any): o is InternalServiceException {
-    return _smithy.isa(o, "InternalServiceException");
+    return __isa(o, "InternalServiceException");
   }
 }
 
@@ -1232,7 +1235,7 @@ export namespace InternalServiceException {
  * <p>The next token supplied was invalid.</p>
  */
 export interface InvalidNextTokenException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidNextTokenException";
   $fault: "client";
@@ -1241,7 +1244,7 @@ export interface InvalidNextTokenException
 
 export namespace InvalidNextTokenException {
   export function isa(o: any): o is InvalidNextTokenException {
-    return _smithy.isa(o, "InvalidNextTokenException");
+    return __isa(o, "InvalidNextTokenException");
   }
 }
 
@@ -1249,7 +1252,7 @@ export namespace InvalidNextTokenException {
  * <p>A per-account resource limit is exceeded. For more information, see <a href="https://docs.aws.amazon.com/ApplicationAutoScaling/latest/userguide/application-auto-scaling-limits.html">Application Auto Scaling Limits</a>.</p>
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -1258,7 +1261,7 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
@@ -1286,7 +1289,7 @@ export interface MetricDimension {
 
 export namespace MetricDimension {
   export function isa(o: any): o is MetricDimension {
-    return _smithy.isa(o, "MetricDimension");
+    return __isa(o, "MetricDimension");
   }
 }
 
@@ -1323,7 +1326,7 @@ export enum MetricType {
  *          found.</p>
  */
 export interface ObjectNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ObjectNotFoundException";
   $fault: "client";
@@ -1332,7 +1335,7 @@ export interface ObjectNotFoundException
 
 export namespace ObjectNotFoundException {
   export function isa(o: any): o is ObjectNotFoundException {
-    return _smithy.isa(o, "ObjectNotFoundException");
+    return __isa(o, "ObjectNotFoundException");
   }
 }
 
@@ -1377,7 +1380,7 @@ export interface PredefinedMetricSpecification {
 
 export namespace PredefinedMetricSpecification {
   export function isa(o: any): o is PredefinedMetricSpecification {
-    return _smithy.isa(o, "PredefinedMetricSpecification");
+    return __isa(o, "PredefinedMetricSpecification");
   }
 }
 
@@ -1535,7 +1538,7 @@ export interface PutScalingPolicyRequest {
 
 export namespace PutScalingPolicyRequest {
   export function isa(o: any): o is PutScalingPolicyRequest {
-    return _smithy.isa(o, "PutScalingPolicyRequest");
+    return __isa(o, "PutScalingPolicyRequest");
   }
 }
 
@@ -1554,7 +1557,7 @@ export interface PutScalingPolicyResponse extends $MetadataBearer {
 
 export namespace PutScalingPolicyResponse {
   export function isa(o: any): o is PutScalingPolicyResponse {
-    return _smithy.isa(o, "PutScalingPolicyResponse");
+    return __isa(o, "PutScalingPolicyResponse");
   }
 }
 
@@ -1725,7 +1728,7 @@ export interface PutScheduledActionRequest {
 
 export namespace PutScheduledActionRequest {
   export function isa(o: any): o is PutScheduledActionRequest {
-    return _smithy.isa(o, "PutScheduledActionRequest");
+    return __isa(o, "PutScheduledActionRequest");
   }
 }
 
@@ -1735,7 +1738,7 @@ export interface PutScheduledActionResponse extends $MetadataBearer {
 
 export namespace PutScheduledActionResponse {
   export function isa(o: any): o is PutScheduledActionResponse {
-    return _smithy.isa(o, "PutScheduledActionResponse");
+    return __isa(o, "PutScheduledActionResponse");
   }
 }
 
@@ -1912,7 +1915,7 @@ export interface RegisterScalableTargetRequest {
 
 export namespace RegisterScalableTargetRequest {
   export function isa(o: any): o is RegisterScalableTargetRequest {
-    return _smithy.isa(o, "RegisterScalableTargetRequest");
+    return __isa(o, "RegisterScalableTargetRequest");
   }
 }
 
@@ -1922,7 +1925,7 @@ export interface RegisterScalableTargetResponse extends $MetadataBearer {
 
 export namespace RegisterScalableTargetResponse {
   export function isa(o: any): o is RegisterScalableTargetResponse {
-    return _smithy.isa(o, "RegisterScalableTargetResponse");
+    return __isa(o, "RegisterScalableTargetResponse");
   }
 }
 
@@ -2096,7 +2099,7 @@ export interface ScalableTarget {
 
 export namespace ScalableTarget {
   export function isa(o: any): o is ScalableTarget {
-    return _smithy.isa(o, "ScalableTarget");
+    return __isa(o, "ScalableTarget");
   }
 }
 
@@ -2118,7 +2121,7 @@ export interface ScalableTargetAction {
 
 export namespace ScalableTargetAction {
   export function isa(o: any): o is ScalableTargetAction {
-    return _smithy.isa(o, "ScalableTargetAction");
+    return __isa(o, "ScalableTargetAction");
   }
 }
 
@@ -2288,7 +2291,7 @@ export interface ScalingActivity {
 
 export namespace ScalingActivity {
   export function isa(o: any): o is ScalingActivity {
-    return _smithy.isa(o, "ScalingActivity");
+    return __isa(o, "ScalingActivity");
   }
 }
 
@@ -2462,7 +2465,7 @@ export interface ScalingPolicy {
 
 export namespace ScalingPolicy {
   export function isa(o: any): o is ScalingPolicy {
-    return _smithy.isa(o, "ScalingPolicy");
+    return __isa(o, "ScalingPolicy");
   }
 }
 
@@ -2646,7 +2649,7 @@ export interface ScheduledAction {
 
 export namespace ScheduledAction {
   export function isa(o: any): o is ScheduledAction {
-    return _smithy.isa(o, "ScheduledAction");
+    return __isa(o, "ScheduledAction");
   }
 }
 
@@ -2730,7 +2733,7 @@ export interface StepAdjustment {
 
 export namespace StepAdjustment {
   export function isa(o: any): o is StepAdjustment {
-    return _smithy.isa(o, "StepAdjustment");
+    return __isa(o, "StepAdjustment");
   }
 }
 
@@ -2793,7 +2796,7 @@ export interface StepScalingPolicyConfiguration {
 
 export namespace StepScalingPolicyConfiguration {
   export function isa(o: any): o is StepScalingPolicyConfiguration {
-    return _smithy.isa(o, "StepScalingPolicyConfiguration");
+    return __isa(o, "StepScalingPolicyConfiguration");
   }
 }
 
@@ -2827,7 +2830,7 @@ export interface SuspendedState {
 
 export namespace SuspendedState {
   export function isa(o: any): o is SuspendedState {
-    return _smithy.isa(o, "SuspendedState");
+    return __isa(o, "SuspendedState");
   }
 }
 
@@ -2886,7 +2889,7 @@ export interface TargetTrackingScalingPolicyConfiguration {
 
 export namespace TargetTrackingScalingPolicyConfiguration {
   export function isa(o: any): o is TargetTrackingScalingPolicyConfiguration {
-    return _smithy.isa(o, "TargetTrackingScalingPolicyConfiguration");
+    return __isa(o, "TargetTrackingScalingPolicyConfiguration");
   }
 }
 
@@ -2895,7 +2898,7 @@ export namespace TargetTrackingScalingPolicyConfiguration {
  *          API request.</p>
  */
 export interface ValidationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ValidationException";
   $fault: "client";
@@ -2904,6 +2907,6 @@ export interface ValidationException
 
 export namespace ValidationException {
   export function isa(o: any): o is ValidationException {
-    return _smithy.isa(o, "ValidationException");
+    return __isa(o, "ValidationException");
   }
 }

--- a/clients/client-application-discovery-service/models/index.ts
+++ b/clients/client-application-discovery-service/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -29,7 +32,7 @@ export interface AgentConfigurationStatus {
 
 export namespace AgentConfigurationStatus {
   export function isa(o: any): o is AgentConfigurationStatus {
-    return _smithy.isa(o, "AgentConfigurationStatus");
+    return __isa(o, "AgentConfigurationStatus");
   }
 }
 
@@ -95,7 +98,7 @@ export interface AgentInfo {
 
 export namespace AgentInfo {
   export function isa(o: any): o is AgentInfo {
-    return _smithy.isa(o, "AgentInfo");
+    return __isa(o, "AgentInfo");
   }
 }
 
@@ -117,7 +120,7 @@ export interface AgentNetworkInfo {
 
 export namespace AgentNetworkInfo {
   export function isa(o: any): o is AgentNetworkInfo {
-    return _smithy.isa(o, "AgentNetworkInfo");
+    return __isa(o, "AgentNetworkInfo");
   }
 }
 
@@ -147,7 +150,7 @@ export namespace AssociateConfigurationItemsToApplicationRequest {
   export function isa(
     o: any
   ): o is AssociateConfigurationItemsToApplicationRequest {
-    return _smithy.isa(o, "AssociateConfigurationItemsToApplicationRequest");
+    return __isa(o, "AssociateConfigurationItemsToApplicationRequest");
   }
 }
 
@@ -160,7 +163,7 @@ export namespace AssociateConfigurationItemsToApplicationResponse {
   export function isa(
     o: any
   ): o is AssociateConfigurationItemsToApplicationResponse {
-    return _smithy.isa(o, "AssociateConfigurationItemsToApplicationResponse");
+    return __isa(o, "AssociateConfigurationItemsToApplicationResponse");
   }
 }
 
@@ -169,7 +172,7 @@ export namespace AssociateConfigurationItemsToApplicationResponse {
  *       policy associated with this account.</p>
  */
 export interface AuthorizationErrorException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AuthorizationErrorException";
   $fault: "client";
@@ -178,7 +181,7 @@ export interface AuthorizationErrorException
 
 export namespace AuthorizationErrorException {
   export function isa(o: any): o is AuthorizationErrorException {
-    return _smithy.isa(o, "AuthorizationErrorException");
+    return __isa(o, "AuthorizationErrorException");
   }
 }
 
@@ -206,7 +209,7 @@ export interface BatchDeleteImportDataError {
 
 export namespace BatchDeleteImportDataError {
   export function isa(o: any): o is BatchDeleteImportDataError {
-    return _smithy.isa(o, "BatchDeleteImportDataError");
+    return __isa(o, "BatchDeleteImportDataError");
   }
 }
 
@@ -226,7 +229,7 @@ export interface BatchDeleteImportDataRequest {
 
 export namespace BatchDeleteImportDataRequest {
   export function isa(o: any): o is BatchDeleteImportDataRequest {
-    return _smithy.isa(o, "BatchDeleteImportDataRequest");
+    return __isa(o, "BatchDeleteImportDataRequest");
   }
 }
 
@@ -241,7 +244,7 @@ export interface BatchDeleteImportDataResponse extends $MetadataBearer {
 
 export namespace BatchDeleteImportDataResponse {
   export function isa(o: any): o is BatchDeleteImportDataResponse {
-    return _smithy.isa(o, "BatchDeleteImportDataResponse");
+    return __isa(o, "BatchDeleteImportDataResponse");
   }
 }
 
@@ -290,7 +293,7 @@ export interface ConfigurationTag {
 
 export namespace ConfigurationTag {
   export function isa(o: any): o is ConfigurationTag {
-    return _smithy.isa(o, "ConfigurationTag");
+    return __isa(o, "ConfigurationTag");
   }
 }
 
@@ -298,7 +301,7 @@ export namespace ConfigurationTag {
  * <p></p>
  */
 export interface ConflictErrorException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ConflictErrorException";
   $fault: "client";
@@ -307,7 +310,7 @@ export interface ConflictErrorException
 
 export namespace ConflictErrorException {
   export function isa(o: any): o is ConflictErrorException {
-    return _smithy.isa(o, "ConflictErrorException");
+    return __isa(o, "ConflictErrorException");
   }
 }
 
@@ -436,7 +439,7 @@ export interface ContinuousExportDescription {
 
 export namespace ContinuousExportDescription {
   export function isa(o: any): o is ContinuousExportDescription {
-    return _smithy.isa(o, "ContinuousExportDescription");
+    return __isa(o, "ContinuousExportDescription");
   }
 }
 
@@ -465,7 +468,7 @@ export interface CreateApplicationRequest {
 
 export namespace CreateApplicationRequest {
   export function isa(o: any): o is CreateApplicationRequest {
-    return _smithy.isa(o, "CreateApplicationRequest");
+    return __isa(o, "CreateApplicationRequest");
   }
 }
 
@@ -479,7 +482,7 @@ export interface CreateApplicationResponse extends $MetadataBearer {
 
 export namespace CreateApplicationResponse {
   export function isa(o: any): o is CreateApplicationResponse {
-    return _smithy.isa(o, "CreateApplicationResponse");
+    return __isa(o, "CreateApplicationResponse");
   }
 }
 
@@ -503,7 +506,7 @@ export interface CreateTagsRequest {
 
 export namespace CreateTagsRequest {
   export function isa(o: any): o is CreateTagsRequest {
-    return _smithy.isa(o, "CreateTagsRequest");
+    return __isa(o, "CreateTagsRequest");
   }
 }
 
@@ -513,7 +516,7 @@ export interface CreateTagsResponse extends $MetadataBearer {
 
 export namespace CreateTagsResponse {
   export function isa(o: any): o is CreateTagsResponse {
-    return _smithy.isa(o, "CreateTagsResponse");
+    return __isa(o, "CreateTagsResponse");
   }
 }
 
@@ -560,7 +563,7 @@ export interface CustomerAgentInfo {
 
 export namespace CustomerAgentInfo {
   export function isa(o: any): o is CustomerAgentInfo {
-    return _smithy.isa(o, "CustomerAgentInfo");
+    return __isa(o, "CustomerAgentInfo");
   }
 }
 
@@ -607,7 +610,7 @@ export interface CustomerConnectorInfo {
 
 export namespace CustomerConnectorInfo {
   export function isa(o: any): o is CustomerConnectorInfo {
-    return _smithy.isa(o, "CustomerConnectorInfo");
+    return __isa(o, "CustomerConnectorInfo");
   }
 }
 
@@ -625,7 +628,7 @@ export interface DeleteApplicationsRequest {
 
 export namespace DeleteApplicationsRequest {
   export function isa(o: any): o is DeleteApplicationsRequest {
-    return _smithy.isa(o, "DeleteApplicationsRequest");
+    return __isa(o, "DeleteApplicationsRequest");
   }
 }
 
@@ -635,7 +638,7 @@ export interface DeleteApplicationsResponse extends $MetadataBearer {
 
 export namespace DeleteApplicationsResponse {
   export function isa(o: any): o is DeleteApplicationsResponse {
-    return _smithy.isa(o, "DeleteApplicationsResponse");
+    return __isa(o, "DeleteApplicationsResponse");
   }
 }
 
@@ -659,7 +662,7 @@ export interface DeleteTagsRequest {
 
 export namespace DeleteTagsRequest {
   export function isa(o: any): o is DeleteTagsRequest {
-    return _smithy.isa(o, "DeleteTagsRequest");
+    return __isa(o, "DeleteTagsRequest");
   }
 }
 
@@ -669,7 +672,7 @@ export interface DeleteTagsResponse extends $MetadataBearer {
 
 export namespace DeleteTagsResponse {
   export function isa(o: any): o is DeleteTagsResponse {
-    return _smithy.isa(o, "DeleteTagsResponse");
+    return __isa(o, "DeleteTagsResponse");
   }
 }
 
@@ -708,7 +711,7 @@ export interface DescribeAgentsRequest {
 
 export namespace DescribeAgentsRequest {
   export function isa(o: any): o is DescribeAgentsRequest {
-    return _smithy.isa(o, "DescribeAgentsRequest");
+    return __isa(o, "DescribeAgentsRequest");
   }
 }
 
@@ -733,7 +736,7 @@ export interface DescribeAgentsResponse extends $MetadataBearer {
 
 export namespace DescribeAgentsResponse {
   export function isa(o: any): o is DescribeAgentsResponse {
-    return _smithy.isa(o, "DescribeAgentsResponse");
+    return __isa(o, "DescribeAgentsResponse");
   }
 }
 
@@ -747,7 +750,7 @@ export interface DescribeConfigurationsRequest {
 
 export namespace DescribeConfigurationsRequest {
   export function isa(o: any): o is DescribeConfigurationsRequest {
-    return _smithy.isa(o, "DescribeConfigurationsRequest");
+    return __isa(o, "DescribeConfigurationsRequest");
   }
 }
 
@@ -761,7 +764,7 @@ export interface DescribeConfigurationsResponse extends $MetadataBearer {
 
 export namespace DescribeConfigurationsResponse {
   export function isa(o: any): o is DescribeConfigurationsResponse {
-    return _smithy.isa(o, "DescribeConfigurationsResponse");
+    return __isa(o, "DescribeConfigurationsResponse");
   }
 }
 
@@ -786,7 +789,7 @@ export interface DescribeContinuousExportsRequest {
 
 export namespace DescribeContinuousExportsRequest {
   export function isa(o: any): o is DescribeContinuousExportsRequest {
-    return _smithy.isa(o, "DescribeContinuousExportsRequest");
+    return __isa(o, "DescribeContinuousExportsRequest");
   }
 }
 
@@ -805,7 +808,7 @@ export interface DescribeContinuousExportsResponse extends $MetadataBearer {
 
 export namespace DescribeContinuousExportsResponse {
   export function isa(o: any): o is DescribeContinuousExportsResponse {
-    return _smithy.isa(o, "DescribeContinuousExportsResponse");
+    return __isa(o, "DescribeContinuousExportsResponse");
   }
 }
 
@@ -830,7 +833,7 @@ export interface DescribeExportConfigurationsRequest {
 
 export namespace DescribeExportConfigurationsRequest {
   export function isa(o: any): o is DescribeExportConfigurationsRequest {
-    return _smithy.isa(o, "DescribeExportConfigurationsRequest");
+    return __isa(o, "DescribeExportConfigurationsRequest");
   }
 }
 
@@ -849,7 +852,7 @@ export interface DescribeExportConfigurationsResponse extends $MetadataBearer {
 
 export namespace DescribeExportConfigurationsResponse {
   export function isa(o: any): o is DescribeExportConfigurationsResponse {
-    return _smithy.isa(o, "DescribeExportConfigurationsResponse");
+    return __isa(o, "DescribeExportConfigurationsResponse");
   }
 }
 
@@ -892,7 +895,7 @@ export interface DescribeExportTasksRequest {
 
 export namespace DescribeExportTasksRequest {
   export function isa(o: any): o is DescribeExportTasksRequest {
-    return _smithy.isa(o, "DescribeExportTasksRequest");
+    return __isa(o, "DescribeExportTasksRequest");
   }
 }
 
@@ -917,7 +920,7 @@ export interface DescribeExportTasksResponse extends $MetadataBearer {
 
 export namespace DescribeExportTasksResponse {
   export function isa(o: any): o is DescribeExportTasksResponse {
-    return _smithy.isa(o, "DescribeExportTasksResponse");
+    return __isa(o, "DescribeExportTasksResponse");
   }
 }
 
@@ -943,7 +946,7 @@ export interface DescribeImportTasksRequest {
 
 export namespace DescribeImportTasksRequest {
   export function isa(o: any): o is DescribeImportTasksRequest {
-    return _smithy.isa(o, "DescribeImportTasksRequest");
+    return __isa(o, "DescribeImportTasksRequest");
   }
 }
 
@@ -963,7 +966,7 @@ export interface DescribeImportTasksResponse extends $MetadataBearer {
 
 export namespace DescribeImportTasksResponse {
   export function isa(o: any): o is DescribeImportTasksResponse {
-    return _smithy.isa(o, "DescribeImportTasksResponse");
+    return __isa(o, "DescribeImportTasksResponse");
   }
 }
 
@@ -990,7 +993,7 @@ export interface DescribeTagsRequest {
 
 export namespace DescribeTagsRequest {
   export function isa(o: any): o is DescribeTagsRequest {
-    return _smithy.isa(o, "DescribeTagsRequest");
+    return __isa(o, "DescribeTagsRequest");
   }
 }
 
@@ -1010,7 +1013,7 @@ export interface DescribeTagsResponse extends $MetadataBearer {
 
 export namespace DescribeTagsResponse {
   export function isa(o: any): o is DescribeTagsResponse {
-    return _smithy.isa(o, "DescribeTagsResponse");
+    return __isa(o, "DescribeTagsResponse");
   }
 }
 
@@ -1031,10 +1034,7 @@ export namespace DisassociateConfigurationItemsFromApplicationRequest {
   export function isa(
     o: any
   ): o is DisassociateConfigurationItemsFromApplicationRequest {
-    return _smithy.isa(
-      o,
-      "DisassociateConfigurationItemsFromApplicationRequest"
-    );
+    return __isa(o, "DisassociateConfigurationItemsFromApplicationRequest");
   }
 }
 
@@ -1047,10 +1047,7 @@ export namespace DisassociateConfigurationItemsFromApplicationResponse {
   export function isa(
     o: any
   ): o is DisassociateConfigurationItemsFromApplicationResponse {
-    return _smithy.isa(
-      o,
-      "DisassociateConfigurationItemsFromApplicationResponse"
-    );
+    return __isa(o, "DisassociateConfigurationItemsFromApplicationResponse");
   }
 }
 
@@ -1064,7 +1061,7 @@ export interface ExportConfigurationsResponse extends $MetadataBearer {
 
 export namespace ExportConfigurationsResponse {
   export function isa(o: any): o is ExportConfigurationsResponse {
-    return _smithy.isa(o, "ExportConfigurationsResponse");
+    return __isa(o, "ExportConfigurationsResponse");
   }
 }
 
@@ -1101,7 +1098,7 @@ export interface ExportFilter {
 
 export namespace ExportFilter {
   export function isa(o: any): o is ExportFilter {
-    return _smithy.isa(o, "ExportFilter");
+    return __isa(o, "ExportFilter");
   }
 }
 
@@ -1162,7 +1159,7 @@ export interface ExportInfo {
 
 export namespace ExportInfo {
   export function isa(o: any): o is ExportInfo {
-    return _smithy.isa(o, "ExportInfo");
+    return __isa(o, "ExportInfo");
   }
 }
 
@@ -1205,7 +1202,7 @@ export interface Filter {
 
 export namespace Filter {
   export function isa(o: any): o is Filter {
-    return _smithy.isa(o, "Filter");
+    return __isa(o, "Filter");
   }
 }
 
@@ -1215,7 +1212,7 @@ export interface GetDiscoverySummaryRequest {
 
 export namespace GetDiscoverySummaryRequest {
   export function isa(o: any): o is GetDiscoverySummaryRequest {
-    return _smithy.isa(o, "GetDiscoverySummaryRequest");
+    return __isa(o, "GetDiscoverySummaryRequest");
   }
 }
 
@@ -1254,7 +1251,7 @@ export interface GetDiscoverySummaryResponse extends $MetadataBearer {
 
 export namespace GetDiscoverySummaryResponse {
   export function isa(o: any): o is GetDiscoverySummaryResponse {
-    return _smithy.isa(o, "GetDiscoverySummaryResponse");
+    return __isa(o, "GetDiscoverySummaryResponse");
   }
 }
 
@@ -1262,7 +1259,7 @@ export namespace GetDiscoverySummaryResponse {
  * <p>The home region is not set. Set the home region to continue.</p>
  */
 export interface HomeRegionNotSetException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "HomeRegionNotSetException";
   $fault: "client";
@@ -1271,7 +1268,7 @@ export interface HomeRegionNotSetException
 
 export namespace HomeRegionNotSetException {
   export function isa(o: any): o is HomeRegionNotSetException {
-    return _smithy.isa(o, "HomeRegionNotSetException");
+    return __isa(o, "HomeRegionNotSetException");
   }
 }
 
@@ -1388,7 +1385,7 @@ export interface ImportTask {
 
 export namespace ImportTask {
   export function isa(o: any): o is ImportTask {
-    return _smithy.isa(o, "ImportTask");
+    return __isa(o, "ImportTask");
   }
 }
 
@@ -1416,7 +1413,7 @@ export interface ImportTaskFilter {
 
 export namespace ImportTaskFilter {
   export function isa(o: any): o is ImportTaskFilter {
-    return _smithy.isa(o, "ImportTaskFilter");
+    return __isa(o, "ImportTaskFilter");
   }
 }
 
@@ -1430,7 +1427,7 @@ export enum ImportTaskFilterName {
  * <p>One or more parameters are not valid. Verify the parameters and try again.</p>
  */
 export interface InvalidParameterException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidParameterException";
   $fault: "client";
@@ -1439,7 +1436,7 @@ export interface InvalidParameterException
 
 export namespace InvalidParameterException {
   export function isa(o: any): o is InvalidParameterException {
-    return _smithy.isa(o, "InvalidParameterException");
+    return __isa(o, "InvalidParameterException");
   }
 }
 
@@ -1448,7 +1445,7 @@ export namespace InvalidParameterException {
  *       parameter values and try again.</p>
  */
 export interface InvalidParameterValueException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidParameterValueException";
   $fault: "client";
@@ -1457,7 +1454,7 @@ export interface InvalidParameterValueException
 
 export namespace InvalidParameterValueException {
   export function isa(o: any): o is InvalidParameterValueException {
-    return _smithy.isa(o, "InvalidParameterValueException");
+    return __isa(o, "InvalidParameterValueException");
   }
 }
 
@@ -1503,7 +1500,7 @@ export interface ListConfigurationsRequest {
 
 export namespace ListConfigurationsRequest {
   export function isa(o: any): o is ListConfigurationsRequest {
-    return _smithy.isa(o, "ListConfigurationsRequest");
+    return __isa(o, "ListConfigurationsRequest");
   }
 }
 
@@ -1527,7 +1524,7 @@ export interface ListConfigurationsResponse extends $MetadataBearer {
 
 export namespace ListConfigurationsResponse {
   export function isa(o: any): o is ListConfigurationsResponse {
-    return _smithy.isa(o, "ListConfigurationsResponse");
+    return __isa(o, "ListConfigurationsResponse");
   }
 }
 
@@ -1565,7 +1562,7 @@ export interface ListServerNeighborsRequest {
 
 export namespace ListServerNeighborsRequest {
   export function isa(o: any): o is ListServerNeighborsRequest {
-    return _smithy.isa(o, "ListServerNeighborsRequest");
+    return __isa(o, "ListServerNeighborsRequest");
   }
 }
 
@@ -1593,7 +1590,7 @@ export interface ListServerNeighborsResponse extends $MetadataBearer {
 
 export namespace ListServerNeighborsResponse {
   export function isa(o: any): o is ListServerNeighborsResponse {
-    return _smithy.isa(o, "ListServerNeighborsResponse");
+    return __isa(o, "ListServerNeighborsResponse");
   }
 }
 
@@ -1630,7 +1627,7 @@ export interface NeighborConnectionDetail {
 
 export namespace NeighborConnectionDetail {
   export function isa(o: any): o is NeighborConnectionDetail {
-    return _smithy.isa(o, "NeighborConnectionDetail");
+    return __isa(o, "NeighborConnectionDetail");
   }
 }
 
@@ -1638,7 +1635,7 @@ export namespace NeighborConnectionDetail {
  * <p>This operation is not permitted.</p>
  */
 export interface OperationNotPermittedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "OperationNotPermittedException";
   $fault: "client";
@@ -1647,7 +1644,7 @@ export interface OperationNotPermittedException
 
 export namespace OperationNotPermittedException {
   export function isa(o: any): o is OperationNotPermittedException {
-    return _smithy.isa(o, "OperationNotPermittedException");
+    return __isa(o, "OperationNotPermittedException");
   }
 }
 
@@ -1669,7 +1666,7 @@ export interface OrderByElement {
 
 export namespace OrderByElement {
   export function isa(o: any): o is OrderByElement {
-    return _smithy.isa(o, "OrderByElement");
+    return __isa(o, "OrderByElement");
   }
 }
 
@@ -1681,7 +1678,7 @@ export namespace OrderByElement {
  *       try again.</p>
  */
 export interface ResourceInUseException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceInUseException";
   $fault: "client";
@@ -1690,7 +1687,7 @@ export interface ResourceInUseException
 
 export namespace ResourceInUseException {
   export function isa(o: any): o is ResourceInUseException {
-    return _smithy.isa(o, "ResourceInUseException");
+    return __isa(o, "ResourceInUseException");
   }
 }
 
@@ -1699,7 +1696,7 @@ export namespace ResourceInUseException {
  *       again.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -1708,7 +1705,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -1716,7 +1713,7 @@ export namespace ResourceNotFoundException {
  * <p>The server experienced an internal error. Try again.</p>
  */
 export interface ServerInternalErrorException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ServerInternalErrorException";
   $fault: "server";
@@ -1725,7 +1722,7 @@ export interface ServerInternalErrorException
 
 export namespace ServerInternalErrorException {
   export function isa(o: any): o is ServerInternalErrorException {
-    return _smithy.isa(o, "ServerInternalErrorException");
+    return __isa(o, "ServerInternalErrorException");
   }
 }
 
@@ -1735,7 +1732,7 @@ export interface StartContinuousExportRequest {
 
 export namespace StartContinuousExportRequest {
   export function isa(o: any): o is StartContinuousExportRequest {
-    return _smithy.isa(o, "StartContinuousExportRequest");
+    return __isa(o, "StartContinuousExportRequest");
   }
 }
 
@@ -1777,7 +1774,7 @@ export interface StartContinuousExportResponse extends $MetadataBearer {
 
 export namespace StartContinuousExportResponse {
   export function isa(o: any): o is StartContinuousExportResponse {
-    return _smithy.isa(o, "StartContinuousExportResponse");
+    return __isa(o, "StartContinuousExportResponse");
   }
 }
 
@@ -1797,7 +1794,7 @@ export interface StartDataCollectionByAgentIdsRequest {
 
 export namespace StartDataCollectionByAgentIdsRequest {
   export function isa(o: any): o is StartDataCollectionByAgentIdsRequest {
-    return _smithy.isa(o, "StartDataCollectionByAgentIdsRequest");
+    return __isa(o, "StartDataCollectionByAgentIdsRequest");
   }
 }
 
@@ -1813,7 +1810,7 @@ export interface StartDataCollectionByAgentIdsResponse extends $MetadataBearer {
 
 export namespace StartDataCollectionByAgentIdsResponse {
   export function isa(o: any): o is StartDataCollectionByAgentIdsResponse {
-    return _smithy.isa(o, "StartDataCollectionByAgentIdsResponse");
+    return __isa(o, "StartDataCollectionByAgentIdsResponse");
   }
 }
 
@@ -1856,7 +1853,7 @@ export interface StartExportTaskRequest {
 
 export namespace StartExportTaskRequest {
   export function isa(o: any): o is StartExportTaskRequest {
-    return _smithy.isa(o, "StartExportTaskRequest");
+    return __isa(o, "StartExportTaskRequest");
   }
 }
 
@@ -1870,7 +1867,7 @@ export interface StartExportTaskResponse extends $MetadataBearer {
 
 export namespace StartExportTaskResponse {
   export function isa(o: any): o is StartExportTaskResponse {
-    return _smithy.isa(o, "StartExportTaskResponse");
+    return __isa(o, "StartExportTaskResponse");
   }
 }
 
@@ -1908,7 +1905,7 @@ export interface StartImportTaskRequest {
 
 export namespace StartImportTaskRequest {
   export function isa(o: any): o is StartImportTaskRequest {
-    return _smithy.isa(o, "StartImportTaskRequest");
+    return __isa(o, "StartImportTaskRequest");
   }
 }
 
@@ -1923,7 +1920,7 @@ export interface StartImportTaskResponse extends $MetadataBearer {
 
 export namespace StartImportTaskResponse {
   export function isa(o: any): o is StartImportTaskResponse {
-    return _smithy.isa(o, "StartImportTaskResponse");
+    return __isa(o, "StartImportTaskResponse");
   }
 }
 
@@ -1937,7 +1934,7 @@ export interface StopContinuousExportRequest {
 
 export namespace StopContinuousExportRequest {
   export function isa(o: any): o is StopContinuousExportRequest {
-    return _smithy.isa(o, "StopContinuousExportRequest");
+    return __isa(o, "StopContinuousExportRequest");
   }
 }
 
@@ -1957,7 +1954,7 @@ export interface StopContinuousExportResponse extends $MetadataBearer {
 
 export namespace StopContinuousExportResponse {
   export function isa(o: any): o is StopContinuousExportResponse {
-    return _smithy.isa(o, "StopContinuousExportResponse");
+    return __isa(o, "StopContinuousExportResponse");
   }
 }
 
@@ -1971,7 +1968,7 @@ export interface StopDataCollectionByAgentIdsRequest {
 
 export namespace StopDataCollectionByAgentIdsRequest {
   export function isa(o: any): o is StopDataCollectionByAgentIdsRequest {
-    return _smithy.isa(o, "StopDataCollectionByAgentIdsRequest");
+    return __isa(o, "StopDataCollectionByAgentIdsRequest");
   }
 }
 
@@ -1987,7 +1984,7 @@ export interface StopDataCollectionByAgentIdsResponse extends $MetadataBearer {
 
 export namespace StopDataCollectionByAgentIdsResponse {
   export function isa(o: any): o is StopDataCollectionByAgentIdsResponse {
-    return _smithy.isa(o, "StopDataCollectionByAgentIdsResponse");
+    return __isa(o, "StopDataCollectionByAgentIdsResponse");
   }
 }
 
@@ -2009,7 +2006,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -2032,7 +2029,7 @@ export interface TagFilter {
 
 export namespace TagFilter {
   export function isa(o: any): o is TagFilter {
-    return _smithy.isa(o, "TagFilter");
+    return __isa(o, "TagFilter");
   }
 }
 
@@ -2056,7 +2053,7 @@ export interface UpdateApplicationRequest {
 
 export namespace UpdateApplicationRequest {
   export function isa(o: any): o is UpdateApplicationRequest {
-    return _smithy.isa(o, "UpdateApplicationRequest");
+    return __isa(o, "UpdateApplicationRequest");
   }
 }
 
@@ -2066,7 +2063,7 @@ export interface UpdateApplicationResponse extends $MetadataBearer {
 
 export namespace UpdateApplicationResponse {
   export function isa(o: any): o is UpdateApplicationResponse {
-    return _smithy.isa(o, "UpdateApplicationResponse");
+    return __isa(o, "UpdateApplicationResponse");
   }
 }
 

--- a/clients/client-application-insights/models/index.ts
+++ b/clients/client-application-insights/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -30,7 +33,7 @@ export interface ApplicationComponent {
 
 export namespace ApplicationComponent {
   export function isa(o: any): o is ApplicationComponent {
-    return _smithy.isa(o, "ApplicationComponent");
+    return __isa(o, "ApplicationComponent");
   }
 }
 
@@ -82,7 +85,7 @@ export interface ApplicationInfo {
 
 export namespace ApplicationInfo {
   export function isa(o: any): o is ApplicationInfo {
-    return _smithy.isa(o, "ApplicationInfo");
+    return __isa(o, "ApplicationInfo");
   }
 }
 
@@ -90,7 +93,7 @@ export namespace ApplicationInfo {
  * <p>The request is not understood by the server.</p>
  */
 export interface BadRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "BadRequestException";
   $fault: "client";
@@ -99,7 +102,7 @@ export interface BadRequestException
 
 export namespace BadRequestException {
   export function isa(o: any): o is BadRequestException {
-    return _smithy.isa(o, "BadRequestException");
+    return __isa(o, "BadRequestException");
   }
 }
 
@@ -155,7 +158,7 @@ export interface ConfigurationEvent {
 
 export namespace ConfigurationEvent {
   export function isa(o: any): o is ConfigurationEvent {
-    return _smithy.isa(o, "ConfigurationEvent");
+    return __isa(o, "ConfigurationEvent");
   }
 }
 
@@ -199,7 +202,7 @@ export interface CreateApplicationRequest {
 
 export namespace CreateApplicationRequest {
   export function isa(o: any): o is CreateApplicationRequest {
-    return _smithy.isa(o, "CreateApplicationRequest");
+    return __isa(o, "CreateApplicationRequest");
   }
 }
 
@@ -213,7 +216,7 @@ export interface CreateApplicationResponse extends $MetadataBearer {
 
 export namespace CreateApplicationResponse {
   export function isa(o: any): o is CreateApplicationResponse {
-    return _smithy.isa(o, "CreateApplicationResponse");
+    return __isa(o, "CreateApplicationResponse");
   }
 }
 
@@ -237,7 +240,7 @@ export interface CreateComponentRequest {
 
 export namespace CreateComponentRequest {
   export function isa(o: any): o is CreateComponentRequest {
-    return _smithy.isa(o, "CreateComponentRequest");
+    return __isa(o, "CreateComponentRequest");
   }
 }
 
@@ -247,7 +250,7 @@ export interface CreateComponentResponse extends $MetadataBearer {
 
 export namespace CreateComponentResponse {
   export function isa(o: any): o is CreateComponentResponse {
-    return _smithy.isa(o, "CreateComponentResponse");
+    return __isa(o, "CreateComponentResponse");
   }
 }
 
@@ -281,7 +284,7 @@ export interface CreateLogPatternRequest {
 
 export namespace CreateLogPatternRequest {
   export function isa(o: any): o is CreateLogPatternRequest {
-    return _smithy.isa(o, "CreateLogPatternRequest");
+    return __isa(o, "CreateLogPatternRequest");
   }
 }
 
@@ -300,7 +303,7 @@ export interface CreateLogPatternResponse extends $MetadataBearer {
 
 export namespace CreateLogPatternResponse {
   export function isa(o: any): o is CreateLogPatternResponse {
-    return _smithy.isa(o, "CreateLogPatternResponse");
+    return __isa(o, "CreateLogPatternResponse");
   }
 }
 
@@ -314,7 +317,7 @@ export interface DeleteApplicationRequest {
 
 export namespace DeleteApplicationRequest {
   export function isa(o: any): o is DeleteApplicationRequest {
-    return _smithy.isa(o, "DeleteApplicationRequest");
+    return __isa(o, "DeleteApplicationRequest");
   }
 }
 
@@ -324,7 +327,7 @@ export interface DeleteApplicationResponse extends $MetadataBearer {
 
 export namespace DeleteApplicationResponse {
   export function isa(o: any): o is DeleteApplicationResponse {
-    return _smithy.isa(o, "DeleteApplicationResponse");
+    return __isa(o, "DeleteApplicationResponse");
   }
 }
 
@@ -343,7 +346,7 @@ export interface DeleteComponentRequest {
 
 export namespace DeleteComponentRequest {
   export function isa(o: any): o is DeleteComponentRequest {
-    return _smithy.isa(o, "DeleteComponentRequest");
+    return __isa(o, "DeleteComponentRequest");
   }
 }
 
@@ -353,7 +356,7 @@ export interface DeleteComponentResponse extends $MetadataBearer {
 
 export namespace DeleteComponentResponse {
   export function isa(o: any): o is DeleteComponentResponse {
-    return _smithy.isa(o, "DeleteComponentResponse");
+    return __isa(o, "DeleteComponentResponse");
   }
 }
 
@@ -377,7 +380,7 @@ export interface DeleteLogPatternRequest {
 
 export namespace DeleteLogPatternRequest {
   export function isa(o: any): o is DeleteLogPatternRequest {
-    return _smithy.isa(o, "DeleteLogPatternRequest");
+    return __isa(o, "DeleteLogPatternRequest");
   }
 }
 
@@ -387,7 +390,7 @@ export interface DeleteLogPatternResponse extends $MetadataBearer {
 
 export namespace DeleteLogPatternResponse {
   export function isa(o: any): o is DeleteLogPatternResponse {
-    return _smithy.isa(o, "DeleteLogPatternResponse");
+    return __isa(o, "DeleteLogPatternResponse");
   }
 }
 
@@ -401,7 +404,7 @@ export interface DescribeApplicationRequest {
 
 export namespace DescribeApplicationRequest {
   export function isa(o: any): o is DescribeApplicationRequest {
-    return _smithy.isa(o, "DescribeApplicationRequest");
+    return __isa(o, "DescribeApplicationRequest");
   }
 }
 
@@ -415,7 +418,7 @@ export interface DescribeApplicationResponse extends $MetadataBearer {
 
 export namespace DescribeApplicationResponse {
   export function isa(o: any): o is DescribeApplicationResponse {
-    return _smithy.isa(o, "DescribeApplicationResponse");
+    return __isa(o, "DescribeApplicationResponse");
   }
 }
 
@@ -443,10 +446,7 @@ export namespace DescribeComponentConfigurationRecommendationRequest {
   export function isa(
     o: any
   ): o is DescribeComponentConfigurationRecommendationRequest {
-    return _smithy.isa(
-      o,
-      "DescribeComponentConfigurationRecommendationRequest"
-    );
+    return __isa(o, "DescribeComponentConfigurationRecommendationRequest");
   }
 }
 
@@ -463,10 +463,7 @@ export namespace DescribeComponentConfigurationRecommendationResponse {
   export function isa(
     o: any
   ): o is DescribeComponentConfigurationRecommendationResponse {
-    return _smithy.isa(
-      o,
-      "DescribeComponentConfigurationRecommendationResponse"
-    );
+    return __isa(o, "DescribeComponentConfigurationRecommendationResponse");
   }
 }
 
@@ -485,7 +482,7 @@ export interface DescribeComponentConfigurationRequest {
 
 export namespace DescribeComponentConfigurationRequest {
   export function isa(o: any): o is DescribeComponentConfigurationRequest {
-    return _smithy.isa(o, "DescribeComponentConfigurationRequest");
+    return __isa(o, "DescribeComponentConfigurationRequest");
   }
 }
 
@@ -513,7 +510,7 @@ export interface DescribeComponentConfigurationResponse
 
 export namespace DescribeComponentConfigurationResponse {
   export function isa(o: any): o is DescribeComponentConfigurationResponse {
-    return _smithy.isa(o, "DescribeComponentConfigurationResponse");
+    return __isa(o, "DescribeComponentConfigurationResponse");
   }
 }
 
@@ -532,7 +529,7 @@ export interface DescribeComponentRequest {
 
 export namespace DescribeComponentRequest {
   export function isa(o: any): o is DescribeComponentRequest {
-    return _smithy.isa(o, "DescribeComponentRequest");
+    return __isa(o, "DescribeComponentRequest");
   }
 }
 
@@ -552,7 +549,7 @@ export interface DescribeComponentResponse extends $MetadataBearer {
 
 export namespace DescribeComponentResponse {
   export function isa(o: any): o is DescribeComponentResponse {
-    return _smithy.isa(o, "DescribeComponentResponse");
+    return __isa(o, "DescribeComponentResponse");
   }
 }
 
@@ -576,7 +573,7 @@ export interface DescribeLogPatternRequest {
 
 export namespace DescribeLogPatternRequest {
   export function isa(o: any): o is DescribeLogPatternRequest {
-    return _smithy.isa(o, "DescribeLogPatternRequest");
+    return __isa(o, "DescribeLogPatternRequest");
   }
 }
 
@@ -595,7 +592,7 @@ export interface DescribeLogPatternResponse extends $MetadataBearer {
 
 export namespace DescribeLogPatternResponse {
   export function isa(o: any): o is DescribeLogPatternResponse {
-    return _smithy.isa(o, "DescribeLogPatternResponse");
+    return __isa(o, "DescribeLogPatternResponse");
   }
 }
 
@@ -609,7 +606,7 @@ export interface DescribeObservationRequest {
 
 export namespace DescribeObservationRequest {
   export function isa(o: any): o is DescribeObservationRequest {
-    return _smithy.isa(o, "DescribeObservationRequest");
+    return __isa(o, "DescribeObservationRequest");
   }
 }
 
@@ -623,7 +620,7 @@ export interface DescribeObservationResponse extends $MetadataBearer {
 
 export namespace DescribeObservationResponse {
   export function isa(o: any): o is DescribeObservationResponse {
-    return _smithy.isa(o, "DescribeObservationResponse");
+    return __isa(o, "DescribeObservationResponse");
   }
 }
 
@@ -637,7 +634,7 @@ export interface DescribeProblemObservationsRequest {
 
 export namespace DescribeProblemObservationsRequest {
   export function isa(o: any): o is DescribeProblemObservationsRequest {
-    return _smithy.isa(o, "DescribeProblemObservationsRequest");
+    return __isa(o, "DescribeProblemObservationsRequest");
   }
 }
 
@@ -651,7 +648,7 @@ export interface DescribeProblemObservationsResponse extends $MetadataBearer {
 
 export namespace DescribeProblemObservationsResponse {
   export function isa(o: any): o is DescribeProblemObservationsResponse {
-    return _smithy.isa(o, "DescribeProblemObservationsResponse");
+    return __isa(o, "DescribeProblemObservationsResponse");
   }
 }
 
@@ -665,7 +662,7 @@ export interface DescribeProblemRequest {
 
 export namespace DescribeProblemRequest {
   export function isa(o: any): o is DescribeProblemRequest {
-    return _smithy.isa(o, "DescribeProblemRequest");
+    return __isa(o, "DescribeProblemRequest");
   }
 }
 
@@ -679,7 +676,7 @@ export interface DescribeProblemResponse extends $MetadataBearer {
 
 export namespace DescribeProblemResponse {
   export function isa(o: any): o is DescribeProblemResponse {
-    return _smithy.isa(o, "DescribeProblemResponse");
+    return __isa(o, "DescribeProblemResponse");
   }
 }
 
@@ -691,7 +688,7 @@ export type FeedbackValue = "NOT_SPECIFIED" | "NOT_USEFUL" | "USEFUL";
  * <p>The server encountered an internal error and is unable to complete the request.</p>
  */
 export interface InternalServerException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalServerException";
   $fault: "server";
@@ -700,7 +697,7 @@ export interface InternalServerException
 
 export namespace InternalServerException {
   export function isa(o: any): o is InternalServerException {
-    return _smithy.isa(o, "InternalServerException");
+    return __isa(o, "InternalServerException");
   }
 }
 
@@ -720,7 +717,7 @@ export interface ListApplicationsRequest {
 
 export namespace ListApplicationsRequest {
   export function isa(o: any): o is ListApplicationsRequest {
-    return _smithy.isa(o, "ListApplicationsRequest");
+    return __isa(o, "ListApplicationsRequest");
   }
 }
 
@@ -740,7 +737,7 @@ export interface ListApplicationsResponse extends $MetadataBearer {
 
 export namespace ListApplicationsResponse {
   export function isa(o: any): o is ListApplicationsResponse {
-    return _smithy.isa(o, "ListApplicationsResponse");
+    return __isa(o, "ListApplicationsResponse");
   }
 }
 
@@ -765,7 +762,7 @@ export interface ListComponentsRequest {
 
 export namespace ListComponentsRequest {
   export function isa(o: any): o is ListComponentsRequest {
-    return _smithy.isa(o, "ListComponentsRequest");
+    return __isa(o, "ListComponentsRequest");
   }
 }
 
@@ -784,7 +781,7 @@ export interface ListComponentsResponse extends $MetadataBearer {
 
 export namespace ListComponentsResponse {
   export function isa(o: any): o is ListComponentsResponse {
-    return _smithy.isa(o, "ListComponentsResponse");
+    return __isa(o, "ListComponentsResponse");
   }
 }
 
@@ -832,7 +829,7 @@ export interface ListConfigurationHistoryRequest {
 
 export namespace ListConfigurationHistoryRequest {
   export function isa(o: any): o is ListConfigurationHistoryRequest {
-    return _smithy.isa(o, "ListConfigurationHistoryRequest");
+    return __isa(o, "ListConfigurationHistoryRequest");
   }
 }
 
@@ -855,7 +852,7 @@ export interface ListConfigurationHistoryResponse extends $MetadataBearer {
 
 export namespace ListConfigurationHistoryResponse {
   export function isa(o: any): o is ListConfigurationHistoryResponse {
-    return _smithy.isa(o, "ListConfigurationHistoryResponse");
+    return __isa(o, "ListConfigurationHistoryResponse");
   }
 }
 
@@ -880,7 +877,7 @@ export interface ListLogPatternSetsRequest {
 
 export namespace ListLogPatternSetsRequest {
   export function isa(o: any): o is ListLogPatternSetsRequest {
-    return _smithy.isa(o, "ListLogPatternSetsRequest");
+    return __isa(o, "ListLogPatternSetsRequest");
   }
 }
 
@@ -905,7 +902,7 @@ export interface ListLogPatternSetsResponse extends $MetadataBearer {
 
 export namespace ListLogPatternSetsResponse {
   export function isa(o: any): o is ListLogPatternSetsResponse {
-    return _smithy.isa(o, "ListLogPatternSetsResponse");
+    return __isa(o, "ListLogPatternSetsResponse");
   }
 }
 
@@ -935,7 +932,7 @@ export interface ListLogPatternsRequest {
 
 export namespace ListLogPatternsRequest {
   export function isa(o: any): o is ListLogPatternsRequest {
-    return _smithy.isa(o, "ListLogPatternsRequest");
+    return __isa(o, "ListLogPatternsRequest");
   }
 }
 
@@ -960,7 +957,7 @@ export interface ListLogPatternsResponse extends $MetadataBearer {
 
 export namespace ListLogPatternsResponse {
   export function isa(o: any): o is ListLogPatternsResponse {
-    return _smithy.isa(o, "ListLogPatternsResponse");
+    return __isa(o, "ListLogPatternsResponse");
   }
 }
 
@@ -997,7 +994,7 @@ export interface ListProblemsRequest {
 
 export namespace ListProblemsRequest {
   export function isa(o: any): o is ListProblemsRequest {
-    return _smithy.isa(o, "ListProblemsRequest");
+    return __isa(o, "ListProblemsRequest");
   }
 }
 
@@ -1017,7 +1014,7 @@ export interface ListProblemsResponse extends $MetadataBearer {
 
 export namespace ListProblemsResponse {
   export function isa(o: any): o is ListProblemsResponse {
-    return _smithy.isa(o, "ListProblemsResponse");
+    return __isa(o, "ListProblemsResponse");
   }
 }
 
@@ -1032,7 +1029,7 @@ export interface ListTagsForResourceRequest {
 
 export namespace ListTagsForResourceRequest {
   export function isa(o: any): o is ListTagsForResourceRequest {
-    return _smithy.isa(o, "ListTagsForResourceRequest");
+    return __isa(o, "ListTagsForResourceRequest");
   }
 }
 
@@ -1048,7 +1045,7 @@ export interface ListTagsForResourceResponse extends $MetadataBearer {
 
 export namespace ListTagsForResourceResponse {
   export function isa(o: any): o is ListTagsForResourceResponse {
-    return _smithy.isa(o, "ListTagsForResourceResponse");
+    return __isa(o, "ListTagsForResourceResponse");
   }
 }
 
@@ -1085,7 +1082,7 @@ export interface LogPattern {
 
 export namespace LogPattern {
   export function isa(o: any): o is LogPattern {
-    return _smithy.isa(o, "LogPattern");
+    return __isa(o, "LogPattern");
   }
 }
 
@@ -1162,7 +1159,7 @@ export interface Observation {
 
 export namespace Observation {
   export function isa(o: any): o is Observation {
-    return _smithy.isa(o, "Observation");
+    return __isa(o, "Observation");
   }
 }
 
@@ -1224,7 +1221,7 @@ export interface Problem {
 
 export namespace Problem {
   export function isa(o: any): o is Problem {
-    return _smithy.isa(o, "Problem");
+    return __isa(o, "Problem");
   }
 }
 
@@ -1241,7 +1238,7 @@ export interface RelatedObservations {
 
 export namespace RelatedObservations {
   export function isa(o: any): o is RelatedObservations {
-    return _smithy.isa(o, "RelatedObservations");
+    return __isa(o, "RelatedObservations");
   }
 }
 
@@ -1249,7 +1246,7 @@ export namespace RelatedObservations {
  * <p>The resource is already created or in use.</p>
  */
 export interface ResourceInUseException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceInUseException";
   $fault: "client";
@@ -1258,7 +1255,7 @@ export interface ResourceInUseException
 
 export namespace ResourceInUseException {
   export function isa(o: any): o is ResourceInUseException {
-    return _smithy.isa(o, "ResourceInUseException");
+    return __isa(o, "ResourceInUseException");
   }
 }
 
@@ -1266,7 +1263,7 @@ export namespace ResourceInUseException {
  * <p>The resource does not exist in the customer account.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -1275,7 +1272,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -1328,7 +1325,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -1350,7 +1347,7 @@ export interface TagResourceRequest {
 
 export namespace TagResourceRequest {
   export function isa(o: any): o is TagResourceRequest {
-    return _smithy.isa(o, "TagResourceRequest");
+    return __isa(o, "TagResourceRequest");
   }
 }
 
@@ -1360,7 +1357,7 @@ export interface TagResourceResponse extends $MetadataBearer {
 
 export namespace TagResourceResponse {
   export function isa(o: any): o is TagResourceResponse {
-    return _smithy.isa(o, "TagResourceResponse");
+    return __isa(o, "TagResourceResponse");
   }
 }
 
@@ -1368,7 +1365,7 @@ export namespace TagResourceResponse {
  * <p>Tags are already registered for the specified application ARN.</p>
  */
 export interface TagsAlreadyExistException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TagsAlreadyExistException";
   $fault: "client";
@@ -1377,7 +1374,7 @@ export interface TagsAlreadyExistException
 
 export namespace TagsAlreadyExistException {
   export function isa(o: any): o is TagsAlreadyExistException {
-    return _smithy.isa(o, "TagsAlreadyExistException");
+    return __isa(o, "TagsAlreadyExistException");
   }
 }
 
@@ -1393,7 +1390,7 @@ export type Tier =
  *          the number of total tags you are trying to attach to the specified resource exceeds the limit.</p>
  */
 export interface TooManyTagsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyTagsException";
   $fault: "client";
@@ -1406,7 +1403,7 @@ export interface TooManyTagsException
 
 export namespace TooManyTagsException {
   export function isa(o: any): o is TooManyTagsException {
-    return _smithy.isa(o, "TooManyTagsException");
+    return __isa(o, "TooManyTagsException");
   }
 }
 
@@ -1429,7 +1426,7 @@ export interface UntagResourceRequest {
 
 export namespace UntagResourceRequest {
   export function isa(o: any): o is UntagResourceRequest {
-    return _smithy.isa(o, "UntagResourceRequest");
+    return __isa(o, "UntagResourceRequest");
   }
 }
 
@@ -1439,7 +1436,7 @@ export interface UntagResourceResponse extends $MetadataBearer {
 
 export namespace UntagResourceResponse {
   export function isa(o: any): o is UntagResourceResponse {
-    return _smithy.isa(o, "UntagResourceResponse");
+    return __isa(o, "UntagResourceResponse");
   }
 }
 
@@ -1473,7 +1470,7 @@ export interface UpdateApplicationRequest {
 
 export namespace UpdateApplicationRequest {
   export function isa(o: any): o is UpdateApplicationRequest {
-    return _smithy.isa(o, "UpdateApplicationRequest");
+    return __isa(o, "UpdateApplicationRequest");
   }
 }
 
@@ -1487,7 +1484,7 @@ export interface UpdateApplicationResponse extends $MetadataBearer {
 
 export namespace UpdateApplicationResponse {
   export function isa(o: any): o is UpdateApplicationResponse {
-    return _smithy.isa(o, "UpdateApplicationResponse");
+    return __isa(o, "UpdateApplicationResponse");
   }
 }
 
@@ -1525,7 +1522,7 @@ export interface UpdateComponentConfigurationRequest {
 
 export namespace UpdateComponentConfigurationRequest {
   export function isa(o: any): o is UpdateComponentConfigurationRequest {
-    return _smithy.isa(o, "UpdateComponentConfigurationRequest");
+    return __isa(o, "UpdateComponentConfigurationRequest");
   }
 }
 
@@ -1535,7 +1532,7 @@ export interface UpdateComponentConfigurationResponse extends $MetadataBearer {
 
 export namespace UpdateComponentConfigurationResponse {
   export function isa(o: any): o is UpdateComponentConfigurationResponse {
-    return _smithy.isa(o, "UpdateComponentConfigurationResponse");
+    return __isa(o, "UpdateComponentConfigurationResponse");
   }
 }
 
@@ -1564,7 +1561,7 @@ export interface UpdateComponentRequest {
 
 export namespace UpdateComponentRequest {
   export function isa(o: any): o is UpdateComponentRequest {
-    return _smithy.isa(o, "UpdateComponentRequest");
+    return __isa(o, "UpdateComponentRequest");
   }
 }
 
@@ -1574,7 +1571,7 @@ export interface UpdateComponentResponse extends $MetadataBearer {
 
 export namespace UpdateComponentResponse {
   export function isa(o: any): o is UpdateComponentResponse {
-    return _smithy.isa(o, "UpdateComponentResponse");
+    return __isa(o, "UpdateComponentResponse");
   }
 }
 
@@ -1608,7 +1605,7 @@ export interface UpdateLogPatternRequest {
 
 export namespace UpdateLogPatternRequest {
   export function isa(o: any): o is UpdateLogPatternRequest {
-    return _smithy.isa(o, "UpdateLogPatternRequest");
+    return __isa(o, "UpdateLogPatternRequest");
   }
 }
 
@@ -1627,7 +1624,7 @@ export interface UpdateLogPatternResponse extends $MetadataBearer {
 
 export namespace UpdateLogPatternResponse {
   export function isa(o: any): o is UpdateLogPatternResponse {
-    return _smithy.isa(o, "UpdateLogPatternResponse");
+    return __isa(o, "UpdateLogPatternResponse");
   }
 }
 
@@ -1635,7 +1632,7 @@ export namespace UpdateLogPatternResponse {
  * <p>The parameter is not valid.</p>
  */
 export interface ValidationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ValidationException";
   $fault: "client";
@@ -1644,6 +1641,6 @@ export interface ValidationException
 
 export namespace ValidationException {
   export function isa(o: any): o is ValidationException {
-    return _smithy.isa(o, "ValidationException");
+    return __isa(o, "ValidationException");
   }
 }

--- a/clients/client-appstream/models/index.ts
+++ b/clients/client-appstream/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -19,7 +22,7 @@ export interface AccessEndpoint {
 
 export namespace AccessEndpoint {
   export function isa(o: any): o is AccessEndpoint {
-    return _smithy.isa(o, "AccessEndpoint");
+    return __isa(o, "AccessEndpoint");
   }
 }
 
@@ -78,7 +81,7 @@ export interface Application {
 
 export namespace Application {
   export function isa(o: any): o is Application {
-    return _smithy.isa(o, "Application");
+    return __isa(o, "Application");
   }
 }
 
@@ -100,7 +103,7 @@ export interface ApplicationSettings {
 
 export namespace ApplicationSettings {
   export function isa(o: any): o is ApplicationSettings {
-    return _smithy.isa(o, "ApplicationSettings");
+    return __isa(o, "ApplicationSettings");
   }
 }
 
@@ -128,7 +131,7 @@ export interface ApplicationSettingsResponse {
 
 export namespace ApplicationSettingsResponse {
   export function isa(o: any): o is ApplicationSettingsResponse {
-    return _smithy.isa(o, "ApplicationSettingsResponse");
+    return __isa(o, "ApplicationSettingsResponse");
   }
 }
 
@@ -147,7 +150,7 @@ export interface AssociateFleetRequest {
 
 export namespace AssociateFleetRequest {
   export function isa(o: any): o is AssociateFleetRequest {
-    return _smithy.isa(o, "AssociateFleetRequest");
+    return __isa(o, "AssociateFleetRequest");
   }
 }
 
@@ -157,7 +160,7 @@ export interface AssociateFleetResult extends $MetadataBearer {
 
 export namespace AssociateFleetResult {
   export function isa(o: any): o is AssociateFleetResult {
-    return _smithy.isa(o, "AssociateFleetResult");
+    return __isa(o, "AssociateFleetResult");
   }
 }
 
@@ -177,7 +180,7 @@ export interface BatchAssociateUserStackRequest {
 
 export namespace BatchAssociateUserStackRequest {
   export function isa(o: any): o is BatchAssociateUserStackRequest {
-    return _smithy.isa(o, "BatchAssociateUserStackRequest");
+    return __isa(o, "BatchAssociateUserStackRequest");
   }
 }
 
@@ -191,7 +194,7 @@ export interface BatchAssociateUserStackResult extends $MetadataBearer {
 
 export namespace BatchAssociateUserStackResult {
   export function isa(o: any): o is BatchAssociateUserStackResult {
-    return _smithy.isa(o, "BatchAssociateUserStackResult");
+    return __isa(o, "BatchAssociateUserStackResult");
   }
 }
 
@@ -205,7 +208,7 @@ export interface BatchDisassociateUserStackRequest {
 
 export namespace BatchDisassociateUserStackRequest {
   export function isa(o: any): o is BatchDisassociateUserStackRequest {
-    return _smithy.isa(o, "BatchDisassociateUserStackRequest");
+    return __isa(o, "BatchDisassociateUserStackRequest");
   }
 }
 
@@ -219,7 +222,7 @@ export interface BatchDisassociateUserStackResult extends $MetadataBearer {
 
 export namespace BatchDisassociateUserStackResult {
   export function isa(o: any): o is BatchDisassociateUserStackResult {
-    return _smithy.isa(o, "BatchDisassociateUserStackResult");
+    return __isa(o, "BatchDisassociateUserStackResult");
   }
 }
 
@@ -236,7 +239,7 @@ export interface ComputeCapacity {
 
 export namespace ComputeCapacity {
   export function isa(o: any): o is ComputeCapacity {
-    return _smithy.isa(o, "ComputeCapacity");
+    return __isa(o, "ComputeCapacity");
   }
 }
 
@@ -269,7 +272,7 @@ export interface ComputeCapacityStatus {
 
 export namespace ComputeCapacityStatus {
   export function isa(o: any): o is ComputeCapacityStatus {
-    return _smithy.isa(o, "ComputeCapacityStatus");
+    return __isa(o, "ComputeCapacityStatus");
   }
 }
 
@@ -277,7 +280,7 @@ export namespace ComputeCapacityStatus {
  * <p>An API error occurred. Wait a few minutes and try again.</p>
  */
 export interface ConcurrentModificationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ConcurrentModificationException";
   $fault: "client";
@@ -289,7 +292,7 @@ export interface ConcurrentModificationException
 
 export namespace ConcurrentModificationException {
   export function isa(o: any): o is ConcurrentModificationException {
-    return _smithy.isa(o, "ConcurrentModificationException");
+    return __isa(o, "ConcurrentModificationException");
   }
 }
 
@@ -318,7 +321,7 @@ export interface CopyImageRequest {
 
 export namespace CopyImageRequest {
   export function isa(o: any): o is CopyImageRequest {
-    return _smithy.isa(o, "CopyImageRequest");
+    return __isa(o, "CopyImageRequest");
   }
 }
 
@@ -332,7 +335,7 @@ export interface CopyImageResponse extends $MetadataBearer {
 
 export namespace CopyImageResponse {
   export function isa(o: any): o is CopyImageResponse {
-    return _smithy.isa(o, "CopyImageResponse");
+    return __isa(o, "CopyImageResponse");
   }
 }
 
@@ -356,7 +359,7 @@ export interface CreateDirectoryConfigRequest {
 
 export namespace CreateDirectoryConfigRequest {
   export function isa(o: any): o is CreateDirectoryConfigRequest {
-    return _smithy.isa(o, "CreateDirectoryConfigRequest");
+    return __isa(o, "CreateDirectoryConfigRequest");
   }
 }
 
@@ -370,7 +373,7 @@ export interface CreateDirectoryConfigResult extends $MetadataBearer {
 
 export namespace CreateDirectoryConfigResult {
   export function isa(o: any): o is CreateDirectoryConfigResult {
-    return _smithy.isa(o, "CreateDirectoryConfigResult");
+    return __isa(o, "CreateDirectoryConfigResult");
   }
 }
 
@@ -558,7 +561,7 @@ export interface CreateFleetRequest {
 
 export namespace CreateFleetRequest {
   export function isa(o: any): o is CreateFleetRequest {
-    return _smithy.isa(o, "CreateFleetRequest");
+    return __isa(o, "CreateFleetRequest");
   }
 }
 
@@ -572,7 +575,7 @@ export interface CreateFleetResult extends $MetadataBearer {
 
 export namespace CreateFleetResult {
   export function isa(o: any): o is CreateFleetResult {
-    return _smithy.isa(o, "CreateFleetResult");
+    return __isa(o, "CreateFleetResult");
   }
 }
 
@@ -717,7 +720,7 @@ export interface CreateImageBuilderRequest {
 
 export namespace CreateImageBuilderRequest {
   export function isa(o: any): o is CreateImageBuilderRequest {
-    return _smithy.isa(o, "CreateImageBuilderRequest");
+    return __isa(o, "CreateImageBuilderRequest");
   }
 }
 
@@ -731,7 +734,7 @@ export interface CreateImageBuilderResult extends $MetadataBearer {
 
 export namespace CreateImageBuilderResult {
   export function isa(o: any): o is CreateImageBuilderResult {
-    return _smithy.isa(o, "CreateImageBuilderResult");
+    return __isa(o, "CreateImageBuilderResult");
   }
 }
 
@@ -751,7 +754,7 @@ export interface CreateImageBuilderStreamingURLRequest {
 
 export namespace CreateImageBuilderStreamingURLRequest {
   export function isa(o: any): o is CreateImageBuilderStreamingURLRequest {
-    return _smithy.isa(o, "CreateImageBuilderStreamingURLRequest");
+    return __isa(o, "CreateImageBuilderStreamingURLRequest");
   }
 }
 
@@ -770,7 +773,7 @@ export interface CreateImageBuilderStreamingURLResult extends $MetadataBearer {
 
 export namespace CreateImageBuilderStreamingURLResult {
   export function isa(o: any): o is CreateImageBuilderStreamingURLResult {
-    return _smithy.isa(o, "CreateImageBuilderStreamingURLResult");
+    return __isa(o, "CreateImageBuilderStreamingURLResult");
   }
 }
 
@@ -841,7 +844,7 @@ export interface CreateStackRequest {
 
 export namespace CreateStackRequest {
   export function isa(o: any): o is CreateStackRequest {
-    return _smithy.isa(o, "CreateStackRequest");
+    return __isa(o, "CreateStackRequest");
   }
 }
 
@@ -855,7 +858,7 @@ export interface CreateStackResult extends $MetadataBearer {
 
 export namespace CreateStackResult {
   export function isa(o: any): o is CreateStackResult {
-    return _smithy.isa(o, "CreateStackResult");
+    return __isa(o, "CreateStackResult");
   }
 }
 
@@ -896,7 +899,7 @@ export interface CreateStreamingURLRequest {
 
 export namespace CreateStreamingURLRequest {
   export function isa(o: any): o is CreateStreamingURLRequest {
-    return _smithy.isa(o, "CreateStreamingURLRequest");
+    return __isa(o, "CreateStreamingURLRequest");
   }
 }
 
@@ -915,7 +918,7 @@ export interface CreateStreamingURLResult extends $MetadataBearer {
 
 export namespace CreateStreamingURLResult {
   export function isa(o: any): o is CreateStreamingURLResult {
-    return _smithy.isa(o, "CreateStreamingURLResult");
+    return __isa(o, "CreateStreamingURLResult");
   }
 }
 
@@ -925,7 +928,7 @@ export interface CreateUsageReportSubscriptionRequest {
 
 export namespace CreateUsageReportSubscriptionRequest {
   export function isa(o: any): o is CreateUsageReportSubscriptionRequest {
-    return _smithy.isa(o, "CreateUsageReportSubscriptionRequest");
+    return __isa(o, "CreateUsageReportSubscriptionRequest");
   }
 }
 
@@ -950,7 +953,7 @@ export interface CreateUsageReportSubscriptionResult extends $MetadataBearer {
 
 export namespace CreateUsageReportSubscriptionResult {
   export function isa(o: any): o is CreateUsageReportSubscriptionResult {
-    return _smithy.isa(o, "CreateUsageReportSubscriptionResult");
+    return __isa(o, "CreateUsageReportSubscriptionResult");
   }
 }
 
@@ -992,7 +995,7 @@ export interface CreateUserRequest {
 
 export namespace CreateUserRequest {
   export function isa(o: any): o is CreateUserRequest {
-    return _smithy.isa(o, "CreateUserRequest");
+    return __isa(o, "CreateUserRequest");
   }
 }
 
@@ -1002,7 +1005,7 @@ export interface CreateUserResult extends $MetadataBearer {
 
 export namespace CreateUserResult {
   export function isa(o: any): o is CreateUserResult {
-    return _smithy.isa(o, "CreateUserResult");
+    return __isa(o, "CreateUserResult");
   }
 }
 
@@ -1016,7 +1019,7 @@ export interface DeleteDirectoryConfigRequest {
 
 export namespace DeleteDirectoryConfigRequest {
   export function isa(o: any): o is DeleteDirectoryConfigRequest {
-    return _smithy.isa(o, "DeleteDirectoryConfigRequest");
+    return __isa(o, "DeleteDirectoryConfigRequest");
   }
 }
 
@@ -1026,7 +1029,7 @@ export interface DeleteDirectoryConfigResult extends $MetadataBearer {
 
 export namespace DeleteDirectoryConfigResult {
   export function isa(o: any): o is DeleteDirectoryConfigResult {
-    return _smithy.isa(o, "DeleteDirectoryConfigResult");
+    return __isa(o, "DeleteDirectoryConfigResult");
   }
 }
 
@@ -1040,7 +1043,7 @@ export interface DeleteFleetRequest {
 
 export namespace DeleteFleetRequest {
   export function isa(o: any): o is DeleteFleetRequest {
-    return _smithy.isa(o, "DeleteFleetRequest");
+    return __isa(o, "DeleteFleetRequest");
   }
 }
 
@@ -1050,7 +1053,7 @@ export interface DeleteFleetResult extends $MetadataBearer {
 
 export namespace DeleteFleetResult {
   export function isa(o: any): o is DeleteFleetResult {
-    return _smithy.isa(o, "DeleteFleetResult");
+    return __isa(o, "DeleteFleetResult");
   }
 }
 
@@ -1064,7 +1067,7 @@ export interface DeleteImageBuilderRequest {
 
 export namespace DeleteImageBuilderRequest {
   export function isa(o: any): o is DeleteImageBuilderRequest {
-    return _smithy.isa(o, "DeleteImageBuilderRequest");
+    return __isa(o, "DeleteImageBuilderRequest");
   }
 }
 
@@ -1078,7 +1081,7 @@ export interface DeleteImageBuilderResult extends $MetadataBearer {
 
 export namespace DeleteImageBuilderResult {
   export function isa(o: any): o is DeleteImageBuilderResult {
-    return _smithy.isa(o, "DeleteImageBuilderResult");
+    return __isa(o, "DeleteImageBuilderResult");
   }
 }
 
@@ -1097,7 +1100,7 @@ export interface DeleteImagePermissionsRequest {
 
 export namespace DeleteImagePermissionsRequest {
   export function isa(o: any): o is DeleteImagePermissionsRequest {
-    return _smithy.isa(o, "DeleteImagePermissionsRequest");
+    return __isa(o, "DeleteImagePermissionsRequest");
   }
 }
 
@@ -1107,7 +1110,7 @@ export interface DeleteImagePermissionsResult extends $MetadataBearer {
 
 export namespace DeleteImagePermissionsResult {
   export function isa(o: any): o is DeleteImagePermissionsResult {
-    return _smithy.isa(o, "DeleteImagePermissionsResult");
+    return __isa(o, "DeleteImagePermissionsResult");
   }
 }
 
@@ -1121,7 +1124,7 @@ export interface DeleteImageRequest {
 
 export namespace DeleteImageRequest {
   export function isa(o: any): o is DeleteImageRequest {
-    return _smithy.isa(o, "DeleteImageRequest");
+    return __isa(o, "DeleteImageRequest");
   }
 }
 
@@ -1135,7 +1138,7 @@ export interface DeleteImageResult extends $MetadataBearer {
 
 export namespace DeleteImageResult {
   export function isa(o: any): o is DeleteImageResult {
-    return _smithy.isa(o, "DeleteImageResult");
+    return __isa(o, "DeleteImageResult");
   }
 }
 
@@ -1149,7 +1152,7 @@ export interface DeleteStackRequest {
 
 export namespace DeleteStackRequest {
   export function isa(o: any): o is DeleteStackRequest {
-    return _smithy.isa(o, "DeleteStackRequest");
+    return __isa(o, "DeleteStackRequest");
   }
 }
 
@@ -1159,7 +1162,7 @@ export interface DeleteStackResult extends $MetadataBearer {
 
 export namespace DeleteStackResult {
   export function isa(o: any): o is DeleteStackResult {
-    return _smithy.isa(o, "DeleteStackResult");
+    return __isa(o, "DeleteStackResult");
   }
 }
 
@@ -1169,7 +1172,7 @@ export interface DeleteUsageReportSubscriptionRequest {
 
 export namespace DeleteUsageReportSubscriptionRequest {
   export function isa(o: any): o is DeleteUsageReportSubscriptionRequest {
-    return _smithy.isa(o, "DeleteUsageReportSubscriptionRequest");
+    return __isa(o, "DeleteUsageReportSubscriptionRequest");
   }
 }
 
@@ -1179,7 +1182,7 @@ export interface DeleteUsageReportSubscriptionResult extends $MetadataBearer {
 
 export namespace DeleteUsageReportSubscriptionResult {
   export function isa(o: any): o is DeleteUsageReportSubscriptionResult {
-    return _smithy.isa(o, "DeleteUsageReportSubscriptionResult");
+    return __isa(o, "DeleteUsageReportSubscriptionResult");
   }
 }
 
@@ -1202,7 +1205,7 @@ export interface DeleteUserRequest {
 
 export namespace DeleteUserRequest {
   export function isa(o: any): o is DeleteUserRequest {
-    return _smithy.isa(o, "DeleteUserRequest");
+    return __isa(o, "DeleteUserRequest");
   }
 }
 
@@ -1212,7 +1215,7 @@ export interface DeleteUserResult extends $MetadataBearer {
 
 export namespace DeleteUserResult {
   export function isa(o: any): o is DeleteUserResult {
-    return _smithy.isa(o, "DeleteUserResult");
+    return __isa(o, "DeleteUserResult");
   }
 }
 
@@ -1236,7 +1239,7 @@ export interface DescribeDirectoryConfigsRequest {
 
 export namespace DescribeDirectoryConfigsRequest {
   export function isa(o: any): o is DescribeDirectoryConfigsRequest {
-    return _smithy.isa(o, "DescribeDirectoryConfigsRequest");
+    return __isa(o, "DescribeDirectoryConfigsRequest");
   }
 }
 
@@ -1255,7 +1258,7 @@ export interface DescribeDirectoryConfigsResult extends $MetadataBearer {
 
 export namespace DescribeDirectoryConfigsResult {
   export function isa(o: any): o is DescribeDirectoryConfigsResult {
-    return _smithy.isa(o, "DescribeDirectoryConfigsResult");
+    return __isa(o, "DescribeDirectoryConfigsResult");
   }
 }
 
@@ -1274,7 +1277,7 @@ export interface DescribeFleetsRequest {
 
 export namespace DescribeFleetsRequest {
   export function isa(o: any): o is DescribeFleetsRequest {
-    return _smithy.isa(o, "DescribeFleetsRequest");
+    return __isa(o, "DescribeFleetsRequest");
   }
 }
 
@@ -1293,7 +1296,7 @@ export interface DescribeFleetsResult extends $MetadataBearer {
 
 export namespace DescribeFleetsResult {
   export function isa(o: any): o is DescribeFleetsResult {
-    return _smithy.isa(o, "DescribeFleetsResult");
+    return __isa(o, "DescribeFleetsResult");
   }
 }
 
@@ -1317,7 +1320,7 @@ export interface DescribeImageBuildersRequest {
 
 export namespace DescribeImageBuildersRequest {
   export function isa(o: any): o is DescribeImageBuildersRequest {
-    return _smithy.isa(o, "DescribeImageBuildersRequest");
+    return __isa(o, "DescribeImageBuildersRequest");
   }
 }
 
@@ -1336,7 +1339,7 @@ export interface DescribeImageBuildersResult extends $MetadataBearer {
 
 export namespace DescribeImageBuildersResult {
   export function isa(o: any): o is DescribeImageBuildersResult {
-    return _smithy.isa(o, "DescribeImageBuildersResult");
+    return __isa(o, "DescribeImageBuildersResult");
   }
 }
 
@@ -1365,7 +1368,7 @@ export interface DescribeImagePermissionsRequest {
 
 export namespace DescribeImagePermissionsRequest {
   export function isa(o: any): o is DescribeImagePermissionsRequest {
-    return _smithy.isa(o, "DescribeImagePermissionsRequest");
+    return __isa(o, "DescribeImagePermissionsRequest");
   }
 }
 
@@ -1389,7 +1392,7 @@ export interface DescribeImagePermissionsResult extends $MetadataBearer {
 
 export namespace DescribeImagePermissionsResult {
   export function isa(o: any): o is DescribeImagePermissionsResult {
-    return _smithy.isa(o, "DescribeImagePermissionsResult");
+    return __isa(o, "DescribeImagePermissionsResult");
   }
 }
 
@@ -1423,7 +1426,7 @@ export interface DescribeImagesRequest {
 
 export namespace DescribeImagesRequest {
   export function isa(o: any): o is DescribeImagesRequest {
-    return _smithy.isa(o, "DescribeImagesRequest");
+    return __isa(o, "DescribeImagesRequest");
   }
 }
 
@@ -1442,7 +1445,7 @@ export interface DescribeImagesResult extends $MetadataBearer {
 
 export namespace DescribeImagesResult {
   export function isa(o: any): o is DescribeImagesResult {
-    return _smithy.isa(o, "DescribeImagesResult");
+    return __isa(o, "DescribeImagesResult");
   }
 }
 
@@ -1483,7 +1486,7 @@ export interface DescribeSessionsRequest {
 
 export namespace DescribeSessionsRequest {
   export function isa(o: any): o is DescribeSessionsRequest {
-    return _smithy.isa(o, "DescribeSessionsRequest");
+    return __isa(o, "DescribeSessionsRequest");
   }
 }
 
@@ -1502,7 +1505,7 @@ export interface DescribeSessionsResult extends $MetadataBearer {
 
 export namespace DescribeSessionsResult {
   export function isa(o: any): o is DescribeSessionsResult {
-    return _smithy.isa(o, "DescribeSessionsResult");
+    return __isa(o, "DescribeSessionsResult");
   }
 }
 
@@ -1521,7 +1524,7 @@ export interface DescribeStacksRequest {
 
 export namespace DescribeStacksRequest {
   export function isa(o: any): o is DescribeStacksRequest {
-    return _smithy.isa(o, "DescribeStacksRequest");
+    return __isa(o, "DescribeStacksRequest");
   }
 }
 
@@ -1540,7 +1543,7 @@ export interface DescribeStacksResult extends $MetadataBearer {
 
 export namespace DescribeStacksResult {
   export function isa(o: any): o is DescribeStacksResult {
-    return _smithy.isa(o, "DescribeStacksResult");
+    return __isa(o, "DescribeStacksResult");
   }
 }
 
@@ -1559,7 +1562,7 @@ export interface DescribeUsageReportSubscriptionsRequest {
 
 export namespace DescribeUsageReportSubscriptionsRequest {
   export function isa(o: any): o is DescribeUsageReportSubscriptionsRequest {
-    return _smithy.isa(o, "DescribeUsageReportSubscriptionsRequest");
+    return __isa(o, "DescribeUsageReportSubscriptionsRequest");
   }
 }
 
@@ -1579,7 +1582,7 @@ export interface DescribeUsageReportSubscriptionsResult
 
 export namespace DescribeUsageReportSubscriptionsResult {
   export function isa(o: any): o is DescribeUsageReportSubscriptionsResult {
-    return _smithy.isa(o, "DescribeUsageReportSubscriptionsResult");
+    return __isa(o, "DescribeUsageReportSubscriptionsResult");
   }
 }
 
@@ -1617,7 +1620,7 @@ export interface DescribeUserStackAssociationsRequest {
 
 export namespace DescribeUserStackAssociationsRequest {
   export function isa(o: any): o is DescribeUserStackAssociationsRequest {
-    return _smithy.isa(o, "DescribeUserStackAssociationsRequest");
+    return __isa(o, "DescribeUserStackAssociationsRequest");
   }
 }
 
@@ -1636,7 +1639,7 @@ export interface DescribeUserStackAssociationsResult extends $MetadataBearer {
 
 export namespace DescribeUserStackAssociationsResult {
   export function isa(o: any): o is DescribeUserStackAssociationsResult {
-    return _smithy.isa(o, "DescribeUserStackAssociationsResult");
+    return __isa(o, "DescribeUserStackAssociationsResult");
   }
 }
 
@@ -1660,7 +1663,7 @@ export interface DescribeUsersRequest {
 
 export namespace DescribeUsersRequest {
   export function isa(o: any): o is DescribeUsersRequest {
-    return _smithy.isa(o, "DescribeUsersRequest");
+    return __isa(o, "DescribeUsersRequest");
   }
 }
 
@@ -1679,7 +1682,7 @@ export interface DescribeUsersResult extends $MetadataBearer {
 
 export namespace DescribeUsersResult {
   export function isa(o: any): o is DescribeUsersResult {
-    return _smithy.isa(o, "DescribeUsersResult");
+    return __isa(o, "DescribeUsersResult");
   }
 }
 
@@ -1711,7 +1714,7 @@ export interface DirectoryConfig {
 
 export namespace DirectoryConfig {
   export function isa(o: any): o is DirectoryConfig {
-    return _smithy.isa(o, "DirectoryConfig");
+    return __isa(o, "DirectoryConfig");
   }
 }
 
@@ -1734,7 +1737,7 @@ export interface DisableUserRequest {
 
 export namespace DisableUserRequest {
   export function isa(o: any): o is DisableUserRequest {
-    return _smithy.isa(o, "DisableUserRequest");
+    return __isa(o, "DisableUserRequest");
   }
 }
 
@@ -1744,7 +1747,7 @@ export interface DisableUserResult extends $MetadataBearer {
 
 export namespace DisableUserResult {
   export function isa(o: any): o is DisableUserResult {
-    return _smithy.isa(o, "DisableUserResult");
+    return __isa(o, "DisableUserResult");
   }
 }
 
@@ -1763,7 +1766,7 @@ export interface DisassociateFleetRequest {
 
 export namespace DisassociateFleetRequest {
   export function isa(o: any): o is DisassociateFleetRequest {
-    return _smithy.isa(o, "DisassociateFleetRequest");
+    return __isa(o, "DisassociateFleetRequest");
   }
 }
 
@@ -1773,7 +1776,7 @@ export interface DisassociateFleetResult extends $MetadataBearer {
 
 export namespace DisassociateFleetResult {
   export function isa(o: any): o is DisassociateFleetResult {
-    return _smithy.isa(o, "DisassociateFleetResult");
+    return __isa(o, "DisassociateFleetResult");
   }
 }
 
@@ -1795,7 +1798,7 @@ export interface DomainJoinInfo {
 
 export namespace DomainJoinInfo {
   export function isa(o: any): o is DomainJoinInfo {
-    return _smithy.isa(o, "DomainJoinInfo");
+    return __isa(o, "DomainJoinInfo");
   }
 }
 
@@ -1818,7 +1821,7 @@ export interface EnableUserRequest {
 
 export namespace EnableUserRequest {
   export function isa(o: any): o is EnableUserRequest {
-    return _smithy.isa(o, "EnableUserRequest");
+    return __isa(o, "EnableUserRequest");
   }
 }
 
@@ -1828,7 +1831,7 @@ export interface EnableUserResult extends $MetadataBearer {
 
 export namespace EnableUserResult {
   export function isa(o: any): o is EnableUserResult {
-    return _smithy.isa(o, "EnableUserResult");
+    return __isa(o, "EnableUserResult");
   }
 }
 
@@ -1842,7 +1845,7 @@ export interface ExpireSessionRequest {
 
 export namespace ExpireSessionRequest {
   export function isa(o: any): o is ExpireSessionRequest {
-    return _smithy.isa(o, "ExpireSessionRequest");
+    return __isa(o, "ExpireSessionRequest");
   }
 }
 
@@ -1852,7 +1855,7 @@ export interface ExpireSessionResult extends $MetadataBearer {
 
 export namespace ExpireSessionResult {
   export function isa(o: any): o is ExpireSessionResult {
-    return _smithy.isa(o, "ExpireSessionResult");
+    return __isa(o, "ExpireSessionResult");
   }
 }
 
@@ -2052,7 +2055,7 @@ export interface Fleet {
 
 export namespace Fleet {
   export function isa(o: any): o is Fleet {
-    return _smithy.isa(o, "Fleet");
+    return __isa(o, "Fleet");
   }
 }
 
@@ -2081,7 +2084,7 @@ export interface FleetError {
 
 export namespace FleetError {
   export function isa(o: any): o is FleetError {
-    return _smithy.isa(o, "FleetError");
+    return __isa(o, "FleetError");
   }
 }
 
@@ -2218,7 +2221,7 @@ export interface Image {
 
 export namespace Image {
   export function isa(o: any): o is Image {
-    return _smithy.isa(o, "Image");
+    return __isa(o, "Image");
   }
 }
 
@@ -2384,7 +2387,7 @@ export interface ImageBuilder {
 
 export namespace ImageBuilder {
   export function isa(o: any): o is ImageBuilder {
-    return _smithy.isa(o, "ImageBuilder");
+    return __isa(o, "ImageBuilder");
   }
 }
 
@@ -2418,7 +2421,7 @@ export interface ImageBuilderStateChangeReason {
 
 export namespace ImageBuilderStateChangeReason {
   export function isa(o: any): o is ImageBuilderStateChangeReason {
-    return _smithy.isa(o, "ImageBuilderStateChangeReason");
+    return __isa(o, "ImageBuilderStateChangeReason");
   }
 }
 
@@ -2445,7 +2448,7 @@ export interface ImagePermissions {
 
 export namespace ImagePermissions {
   export function isa(o: any): o is ImagePermissions {
-    return _smithy.isa(o, "ImagePermissions");
+    return __isa(o, "ImagePermissions");
   }
 }
 
@@ -2475,7 +2478,7 @@ export interface ImageStateChangeReason {
 
 export namespace ImageStateChangeReason {
   export function isa(o: any): o is ImageStateChangeReason {
-    return _smithy.isa(o, "ImageStateChangeReason");
+    return __isa(o, "ImageStateChangeReason");
   }
 }
 
@@ -2489,7 +2492,7 @@ export enum ImageStateChangeReasonCode {
  * <p>The image does not support storage connectors.</p>
  */
 export interface IncompatibleImageException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "IncompatibleImageException";
   $fault: "client";
@@ -2501,7 +2504,7 @@ export interface IncompatibleImageException
 
 export namespace IncompatibleImageException {
   export function isa(o: any): o is IncompatibleImageException {
-    return _smithy.isa(o, "IncompatibleImageException");
+    return __isa(o, "IncompatibleImageException");
   }
 }
 
@@ -2509,7 +2512,7 @@ export namespace IncompatibleImageException {
  * <p>The resource cannot be created because your AWS account is suspended. For assistance, contact AWS Support. </p>
  */
 export interface InvalidAccountStatusException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidAccountStatusException";
   $fault: "client";
@@ -2521,7 +2524,7 @@ export interface InvalidAccountStatusException
 
 export namespace InvalidAccountStatusException {
   export function isa(o: any): o is InvalidAccountStatusException {
-    return _smithy.isa(o, "InvalidAccountStatusException");
+    return __isa(o, "InvalidAccountStatusException");
   }
 }
 
@@ -2529,7 +2532,7 @@ export namespace InvalidAccountStatusException {
  * <p>Indicates an incorrect combination of parameters, or a missing parameter.</p>
  */
 export interface InvalidParameterCombinationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidParameterCombinationException";
   $fault: "client";
@@ -2541,7 +2544,7 @@ export interface InvalidParameterCombinationException
 
 export namespace InvalidParameterCombinationException {
   export function isa(o: any): o is InvalidParameterCombinationException {
-    return _smithy.isa(o, "InvalidParameterCombinationException");
+    return __isa(o, "InvalidParameterCombinationException");
   }
 }
 
@@ -2549,7 +2552,7 @@ export namespace InvalidParameterCombinationException {
  * <p>The specified role is invalid.</p>
  */
 export interface InvalidRoleException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidRoleException";
   $fault: "client";
@@ -2561,7 +2564,7 @@ export interface InvalidRoleException
 
 export namespace InvalidRoleException {
   export function isa(o: any): o is InvalidRoleException {
-    return _smithy.isa(o, "InvalidRoleException");
+    return __isa(o, "InvalidRoleException");
   }
 }
 
@@ -2583,7 +2586,7 @@ export interface LastReportGenerationExecutionError {
 
 export namespace LastReportGenerationExecutionError {
   export function isa(o: any): o is LastReportGenerationExecutionError {
-    return _smithy.isa(o, "LastReportGenerationExecutionError");
+    return __isa(o, "LastReportGenerationExecutionError");
   }
 }
 
@@ -2591,7 +2594,7 @@ export namespace LastReportGenerationExecutionError {
  * <p>The requested limit exceeds the permitted limit for an account.</p>
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -2603,7 +2606,7 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
@@ -2622,7 +2625,7 @@ export interface ListAssociatedFleetsRequest {
 
 export namespace ListAssociatedFleetsRequest {
   export function isa(o: any): o is ListAssociatedFleetsRequest {
-    return _smithy.isa(o, "ListAssociatedFleetsRequest");
+    return __isa(o, "ListAssociatedFleetsRequest");
   }
 }
 
@@ -2641,7 +2644,7 @@ export interface ListAssociatedFleetsResult extends $MetadataBearer {
 
 export namespace ListAssociatedFleetsResult {
   export function isa(o: any): o is ListAssociatedFleetsResult {
-    return _smithy.isa(o, "ListAssociatedFleetsResult");
+    return __isa(o, "ListAssociatedFleetsResult");
   }
 }
 
@@ -2660,7 +2663,7 @@ export interface ListAssociatedStacksRequest {
 
 export namespace ListAssociatedStacksRequest {
   export function isa(o: any): o is ListAssociatedStacksRequest {
-    return _smithy.isa(o, "ListAssociatedStacksRequest");
+    return __isa(o, "ListAssociatedStacksRequest");
   }
 }
 
@@ -2679,7 +2682,7 @@ export interface ListAssociatedStacksResult extends $MetadataBearer {
 
 export namespace ListAssociatedStacksResult {
   export function isa(o: any): o is ListAssociatedStacksResult {
-    return _smithy.isa(o, "ListAssociatedStacksResult");
+    return __isa(o, "ListAssociatedStacksResult");
   }
 }
 
@@ -2693,7 +2696,7 @@ export interface ListTagsForResourceRequest {
 
 export namespace ListTagsForResourceRequest {
   export function isa(o: any): o is ListTagsForResourceRequest {
-    return _smithy.isa(o, "ListTagsForResourceRequest");
+    return __isa(o, "ListTagsForResourceRequest");
   }
 }
 
@@ -2707,7 +2710,7 @@ export interface ListTagsForResourceResponse extends $MetadataBearer {
 
 export namespace ListTagsForResourceResponse {
   export function isa(o: any): o is ListTagsForResourceResponse {
-    return _smithy.isa(o, "ListTagsForResourceResponse");
+    return __isa(o, "ListTagsForResourceResponse");
   }
 }
 
@@ -2734,7 +2737,7 @@ export interface NetworkAccessConfiguration {
 
 export namespace NetworkAccessConfiguration {
   export function isa(o: any): o is NetworkAccessConfiguration {
-    return _smithy.isa(o, "NetworkAccessConfiguration");
+    return __isa(o, "NetworkAccessConfiguration");
   }
 }
 
@@ -2742,7 +2745,7 @@ export namespace NetworkAccessConfiguration {
  * <p>The attempted operation is not permitted.</p>
  */
 export interface OperationNotPermittedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "OperationNotPermittedException";
   $fault: "client";
@@ -2754,7 +2757,7 @@ export interface OperationNotPermittedException
 
 export namespace OperationNotPermittedException {
   export function isa(o: any): o is OperationNotPermittedException {
-    return _smithy.isa(o, "OperationNotPermittedException");
+    return __isa(o, "OperationNotPermittedException");
   }
 }
 
@@ -2772,7 +2775,7 @@ export type PlatformType =
  * <p>The specified resource already exists.</p>
  */
 export interface ResourceAlreadyExistsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceAlreadyExistsException";
   $fault: "client";
@@ -2784,7 +2787,7 @@ export interface ResourceAlreadyExistsException
 
 export namespace ResourceAlreadyExistsException {
   export function isa(o: any): o is ResourceAlreadyExistsException {
-    return _smithy.isa(o, "ResourceAlreadyExistsException");
+    return __isa(o, "ResourceAlreadyExistsException");
   }
 }
 
@@ -2811,7 +2814,7 @@ export interface ResourceError {
 
 export namespace ResourceError {
   export function isa(o: any): o is ResourceError {
-    return _smithy.isa(o, "ResourceError");
+    return __isa(o, "ResourceError");
   }
 }
 
@@ -2819,7 +2822,7 @@ export namespace ResourceError {
  * <p>The specified resource is in use.</p>
  */
 export interface ResourceInUseException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceInUseException";
   $fault: "client";
@@ -2831,7 +2834,7 @@ export interface ResourceInUseException
 
 export namespace ResourceInUseException {
   export function isa(o: any): o is ResourceInUseException {
-    return _smithy.isa(o, "ResourceInUseException");
+    return __isa(o, "ResourceInUseException");
   }
 }
 
@@ -2839,7 +2842,7 @@ export namespace ResourceInUseException {
  * <p>The specified resource exists and is not in use, but isn't available.</p>
  */
 export interface ResourceNotAvailableException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotAvailableException";
   $fault: "client";
@@ -2851,7 +2854,7 @@ export interface ResourceNotAvailableException
 
 export namespace ResourceNotAvailableException {
   export function isa(o: any): o is ResourceNotAvailableException {
-    return _smithy.isa(o, "ResourceNotAvailableException");
+    return __isa(o, "ResourceNotAvailableException");
   }
 }
 
@@ -2859,7 +2862,7 @@ export namespace ResourceNotAvailableException {
  * <p>The specified resource was not found.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -2871,7 +2874,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -2895,7 +2898,7 @@ export interface ServiceAccountCredentials {
 
 export namespace ServiceAccountCredentials {
   export function isa(o: any): o is ServiceAccountCredentials {
-    return _smithy.isa(o, "ServiceAccountCredentials");
+    return __isa(o, "ServiceAccountCredentials");
   }
 }
 
@@ -2958,7 +2961,7 @@ export interface Session {
 
 export namespace Session {
   export function isa(o: any): o is Session {
-    return _smithy.isa(o, "Session");
+    return __isa(o, "Session");
   }
 }
 
@@ -2991,7 +2994,7 @@ export interface SharedImagePermissions {
 
 export namespace SharedImagePermissions {
   export function isa(o: any): o is SharedImagePermissions {
-    return _smithy.isa(o, "SharedImagePermissions");
+    return __isa(o, "SharedImagePermissions");
   }
 }
 
@@ -3068,7 +3071,7 @@ export interface Stack {
 
 export namespace Stack {
   export function isa(o: any): o is Stack {
-    return _smithy.isa(o, "Stack");
+    return __isa(o, "Stack");
   }
 }
 
@@ -3104,7 +3107,7 @@ export interface StackError {
 
 export namespace StackError {
   export function isa(o: any): o is StackError {
-    return _smithy.isa(o, "StackError");
+    return __isa(o, "StackError");
   }
 }
 
@@ -3123,7 +3126,7 @@ export interface StartFleetRequest {
 
 export namespace StartFleetRequest {
   export function isa(o: any): o is StartFleetRequest {
-    return _smithy.isa(o, "StartFleetRequest");
+    return __isa(o, "StartFleetRequest");
   }
 }
 
@@ -3133,7 +3136,7 @@ export interface StartFleetResult extends $MetadataBearer {
 
 export namespace StartFleetResult {
   export function isa(o: any): o is StartFleetResult {
-    return _smithy.isa(o, "StartFleetResult");
+    return __isa(o, "StartFleetResult");
   }
 }
 
@@ -3152,7 +3155,7 @@ export interface StartImageBuilderRequest {
 
 export namespace StartImageBuilderRequest {
   export function isa(o: any): o is StartImageBuilderRequest {
-    return _smithy.isa(o, "StartImageBuilderRequest");
+    return __isa(o, "StartImageBuilderRequest");
   }
 }
 
@@ -3166,7 +3169,7 @@ export interface StartImageBuilderResult extends $MetadataBearer {
 
 export namespace StartImageBuilderResult {
   export function isa(o: any): o is StartImageBuilderResult {
-    return _smithy.isa(o, "StartImageBuilderResult");
+    return __isa(o, "StartImageBuilderResult");
   }
 }
 
@@ -3180,7 +3183,7 @@ export interface StopFleetRequest {
 
 export namespace StopFleetRequest {
   export function isa(o: any): o is StopFleetRequest {
-    return _smithy.isa(o, "StopFleetRequest");
+    return __isa(o, "StopFleetRequest");
   }
 }
 
@@ -3190,7 +3193,7 @@ export interface StopFleetResult extends $MetadataBearer {
 
 export namespace StopFleetResult {
   export function isa(o: any): o is StopFleetResult {
-    return _smithy.isa(o, "StopFleetResult");
+    return __isa(o, "StopFleetResult");
   }
 }
 
@@ -3204,7 +3207,7 @@ export interface StopImageBuilderRequest {
 
 export namespace StopImageBuilderRequest {
   export function isa(o: any): o is StopImageBuilderRequest {
-    return _smithy.isa(o, "StopImageBuilderRequest");
+    return __isa(o, "StopImageBuilderRequest");
   }
 }
 
@@ -3218,7 +3221,7 @@ export interface StopImageBuilderResult extends $MetadataBearer {
 
 export namespace StopImageBuilderResult {
   export function isa(o: any): o is StopImageBuilderResult {
-    return _smithy.isa(o, "StopImageBuilderResult");
+    return __isa(o, "StopImageBuilderResult");
   }
 }
 
@@ -3245,7 +3248,7 @@ export interface StorageConnector {
 
 export namespace StorageConnector {
   export function isa(o: any): o is StorageConnector {
-    return _smithy.isa(o, "StorageConnector");
+    return __isa(o, "StorageConnector");
   }
 }
 
@@ -3275,7 +3278,7 @@ export interface TagResourceRequest {
 
 export namespace TagResourceRequest {
   export function isa(o: any): o is TagResourceRequest {
-    return _smithy.isa(o, "TagResourceRequest");
+    return __isa(o, "TagResourceRequest");
   }
 }
 
@@ -3285,7 +3288,7 @@ export interface TagResourceResponse extends $MetadataBearer {
 
 export namespace TagResourceResponse {
   export function isa(o: any): o is TagResourceResponse {
-    return _smithy.isa(o, "TagResourceResponse");
+    return __isa(o, "TagResourceResponse");
   }
 }
 
@@ -3304,7 +3307,7 @@ export interface UntagResourceRequest {
 
 export namespace UntagResourceRequest {
   export function isa(o: any): o is UntagResourceRequest {
-    return _smithy.isa(o, "UntagResourceRequest");
+    return __isa(o, "UntagResourceRequest");
   }
 }
 
@@ -3314,7 +3317,7 @@ export interface UntagResourceResponse extends $MetadataBearer {
 
 export namespace UntagResourceResponse {
   export function isa(o: any): o is UntagResourceResponse {
-    return _smithy.isa(o, "UntagResourceResponse");
+    return __isa(o, "UntagResourceResponse");
   }
 }
 
@@ -3338,7 +3341,7 @@ export interface UpdateDirectoryConfigRequest {
 
 export namespace UpdateDirectoryConfigRequest {
   export function isa(o: any): o is UpdateDirectoryConfigRequest {
-    return _smithy.isa(o, "UpdateDirectoryConfigRequest");
+    return __isa(o, "UpdateDirectoryConfigRequest");
   }
 }
 
@@ -3352,7 +3355,7 @@ export interface UpdateDirectoryConfigResult extends $MetadataBearer {
 
 export namespace UpdateDirectoryConfigResult {
   export function isa(o: any): o is UpdateDirectoryConfigResult {
-    return _smithy.isa(o, "UpdateDirectoryConfigResult");
+    return __isa(o, "UpdateDirectoryConfigResult");
   }
 }
 
@@ -3521,7 +3524,7 @@ export interface UpdateFleetRequest {
 
 export namespace UpdateFleetRequest {
   export function isa(o: any): o is UpdateFleetRequest {
-    return _smithy.isa(o, "UpdateFleetRequest");
+    return __isa(o, "UpdateFleetRequest");
   }
 }
 
@@ -3535,7 +3538,7 @@ export interface UpdateFleetResult extends $MetadataBearer {
 
 export namespace UpdateFleetResult {
   export function isa(o: any): o is UpdateFleetResult {
-    return _smithy.isa(o, "UpdateFleetResult");
+    return __isa(o, "UpdateFleetResult");
   }
 }
 
@@ -3559,7 +3562,7 @@ export interface UpdateImagePermissionsRequest {
 
 export namespace UpdateImagePermissionsRequest {
   export function isa(o: any): o is UpdateImagePermissionsRequest {
-    return _smithy.isa(o, "UpdateImagePermissionsRequest");
+    return __isa(o, "UpdateImagePermissionsRequest");
   }
 }
 
@@ -3569,7 +3572,7 @@ export interface UpdateImagePermissionsResult extends $MetadataBearer {
 
 export namespace UpdateImagePermissionsResult {
   export function isa(o: any): o is UpdateImagePermissionsResult {
-    return _smithy.isa(o, "UpdateImagePermissionsResult");
+    return __isa(o, "UpdateImagePermissionsResult");
   }
 }
 
@@ -3638,7 +3641,7 @@ export interface UpdateStackRequest {
 
 export namespace UpdateStackRequest {
   export function isa(o: any): o is UpdateStackRequest {
-    return _smithy.isa(o, "UpdateStackRequest");
+    return __isa(o, "UpdateStackRequest");
   }
 }
 
@@ -3652,7 +3655,7 @@ export interface UpdateStackResult extends $MetadataBearer {
 
 export namespace UpdateStackResult {
   export function isa(o: any): o is UpdateStackResult {
-    return _smithy.isa(o, "UpdateStackResult");
+    return __isa(o, "UpdateStackResult");
   }
 }
 
@@ -3700,7 +3703,7 @@ export interface UsageReportSubscription {
 
 export namespace UsageReportSubscription {
   export function isa(o: any): o is UsageReportSubscription {
-    return _smithy.isa(o, "UsageReportSubscription");
+    return __isa(o, "UsageReportSubscription");
   }
 }
 
@@ -3773,7 +3776,7 @@ export interface User {
 
 export namespace User {
   export function isa(o: any): o is User {
-    return _smithy.isa(o, "User");
+    return __isa(o, "User");
   }
 }
 
@@ -3795,7 +3798,7 @@ export interface UserSetting {
 
 export namespace UserSetting {
   export function isa(o: any): o is UserSetting {
-    return _smithy.isa(o, "UserSetting");
+    return __isa(o, "UserSetting");
   }
 }
 
@@ -3831,7 +3834,7 @@ export interface UserStackAssociation {
 
 export namespace UserStackAssociation {
   export function isa(o: any): o is UserStackAssociation {
-    return _smithy.isa(o, "UserStackAssociation");
+    return __isa(o, "UserStackAssociation");
   }
 }
 
@@ -3858,7 +3861,7 @@ export interface UserStackAssociationError {
 
 export namespace UserStackAssociationError {
   export function isa(o: any): o is UserStackAssociationError {
-    return _smithy.isa(o, "UserStackAssociationError");
+    return __isa(o, "UserStackAssociationError");
   }
 }
 
@@ -3892,6 +3895,6 @@ export interface VpcConfig {
 
 export namespace VpcConfig {
   export function isa(o: any): o is VpcConfig {
-    return _smithy.isa(o, "VpcConfig");
+    return __isa(o, "VpcConfig");
   }
 }

--- a/clients/client-appsync/models/index.ts
+++ b/clients/client-appsync/models/index.ts
@@ -1,11 +1,14 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
  * <p>You do not have access to perform this operation on this resource.</p>
  */
 export interface AccessDeniedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AccessDeniedException";
   $fault: "client";
@@ -14,7 +17,7 @@ export interface AccessDeniedException
 
 export namespace AccessDeniedException {
   export function isa(o: any): o is AccessDeniedException {
-    return _smithy.isa(o, "AccessDeniedException");
+    return __isa(o, "AccessDeniedException");
   }
 }
 
@@ -41,7 +44,7 @@ export interface AdditionalAuthenticationProvider {
 
 export namespace AdditionalAuthenticationProvider {
   export function isa(o: any): o is AdditionalAuthenticationProvider {
-    return _smithy.isa(o, "AdditionalAuthenticationProvider");
+    return __isa(o, "AdditionalAuthenticationProvider");
   }
 }
 
@@ -143,7 +146,7 @@ export interface ApiCache {
 
 export namespace ApiCache {
   export function isa(o: any): o is ApiCache {
-    return _smithy.isa(o, "ApiCache");
+    return __isa(o, "ApiCache");
   }
 }
 
@@ -253,7 +256,7 @@ export interface ApiKey {
 
 export namespace ApiKey {
   export function isa(o: any): o is ApiKey {
-    return _smithy.isa(o, "ApiKey");
+    return __isa(o, "ApiKey");
   }
 }
 
@@ -261,7 +264,7 @@ export namespace ApiKey {
  * <p>The API key exceeded a limit. Try your request again.</p>
  */
 export interface ApiKeyLimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ApiKeyLimitExceededException";
   $fault: "client";
@@ -270,7 +273,7 @@ export interface ApiKeyLimitExceededException
 
 export namespace ApiKeyLimitExceededException {
   export function isa(o: any): o is ApiKeyLimitExceededException {
-    return _smithy.isa(o, "ApiKeyLimitExceededException");
+    return __isa(o, "ApiKeyLimitExceededException");
   }
 }
 
@@ -279,7 +282,7 @@ export namespace ApiKeyLimitExceededException {
  *             <code>CreateApiKey</code>) or from update (for <code>UpdateApiKey</code>).</p>
  */
 export interface ApiKeyValidityOutOfBoundsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ApiKeyValidityOutOfBoundsException";
   $fault: "client";
@@ -288,7 +291,7 @@ export interface ApiKeyValidityOutOfBoundsException
 
 export namespace ApiKeyValidityOutOfBoundsException {
   export function isa(o: any): o is ApiKeyValidityOutOfBoundsException {
-    return _smithy.isa(o, "ApiKeyValidityOutOfBoundsException");
+    return __isa(o, "ApiKeyValidityOutOfBoundsException");
   }
 }
 
@@ -296,7 +299,7 @@ export namespace ApiKeyValidityOutOfBoundsException {
  * <p>The GraphQL API exceeded a limit. Try your request again.</p>
  */
 export interface ApiLimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ApiLimitExceededException";
   $fault: "client";
@@ -305,7 +308,7 @@ export interface ApiLimitExceededException
 
 export namespace ApiLimitExceededException {
   export function isa(o: any): o is ApiLimitExceededException {
-    return _smithy.isa(o, "ApiLimitExceededException");
+    return __isa(o, "ApiLimitExceededException");
   }
 }
 
@@ -341,7 +344,7 @@ export interface AuthorizationConfig {
 
 export namespace AuthorizationConfig {
   export function isa(o: any): o is AuthorizationConfig {
-    return _smithy.isa(o, "AuthorizationConfig");
+    return __isa(o, "AuthorizationConfig");
   }
 }
 
@@ -367,7 +370,7 @@ export interface AwsIamConfig {
 
 export namespace AwsIamConfig {
   export function isa(o: any): o is AwsIamConfig {
-    return _smithy.isa(o, "AwsIamConfig");
+    return __isa(o, "AwsIamConfig");
   }
 }
 
@@ -376,7 +379,7 @@ export namespace AwsIamConfig {
  *          missing. Check the field values, and then try again. </p>
  */
 export interface BadRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "BadRequestException";
   $fault: "client";
@@ -385,7 +388,7 @@ export interface BadRequestException
 
 export namespace BadRequestException {
   export function isa(o: any): o is BadRequestException {
-    return _smithy.isa(o, "BadRequestException");
+    return __isa(o, "BadRequestException");
   }
 }
 
@@ -409,7 +412,7 @@ export interface CachingConfig {
 
 export namespace CachingConfig {
   export function isa(o: any): o is CachingConfig {
-    return _smithy.isa(o, "CachingConfig");
+    return __isa(o, "CachingConfig");
   }
 }
 
@@ -437,7 +440,7 @@ export interface CognitoUserPoolConfig {
 
 export namespace CognitoUserPoolConfig {
   export function isa(o: any): o is CognitoUserPoolConfig {
-    return _smithy.isa(o, "CognitoUserPoolConfig");
+    return __isa(o, "CognitoUserPoolConfig");
   }
 }
 
@@ -446,7 +449,7 @@ export namespace CognitoUserPoolConfig {
  *          your change. </p>
  */
 export interface ConcurrentModificationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ConcurrentModificationException";
   $fault: "client";
@@ -455,7 +458,7 @@ export interface ConcurrentModificationException
 
 export namespace ConcurrentModificationException {
   export function isa(o: any): o is ConcurrentModificationException {
-    return _smithy.isa(o, "ConcurrentModificationException");
+    return __isa(o, "ConcurrentModificationException");
   }
 }
 
@@ -550,7 +553,7 @@ export interface CreateApiCacheRequest {
 
 export namespace CreateApiCacheRequest {
   export function isa(o: any): o is CreateApiCacheRequest {
-    return _smithy.isa(o, "CreateApiCacheRequest");
+    return __isa(o, "CreateApiCacheRequest");
   }
 }
 
@@ -567,7 +570,7 @@ export interface CreateApiCacheResponse extends $MetadataBearer {
 
 export namespace CreateApiCacheResponse {
   export function isa(o: any): o is CreateApiCacheResponse {
-    return _smithy.isa(o, "CreateApiCacheResponse");
+    return __isa(o, "CreateApiCacheResponse");
   }
 }
 
@@ -593,7 +596,7 @@ export interface CreateApiKeyRequest {
 
 export namespace CreateApiKeyRequest {
   export function isa(o: any): o is CreateApiKeyRequest {
-    return _smithy.isa(o, "CreateApiKeyRequest");
+    return __isa(o, "CreateApiKeyRequest");
   }
 }
 
@@ -607,7 +610,7 @@ export interface CreateApiKeyResponse extends $MetadataBearer {
 
 export namespace CreateApiKeyResponse {
   export function isa(o: any): o is CreateApiKeyResponse {
-    return _smithy.isa(o, "CreateApiKeyResponse");
+    return __isa(o, "CreateApiKeyResponse");
   }
 }
 
@@ -667,7 +670,7 @@ export interface CreateDataSourceRequest {
 
 export namespace CreateDataSourceRequest {
   export function isa(o: any): o is CreateDataSourceRequest {
-    return _smithy.isa(o, "CreateDataSourceRequest");
+    return __isa(o, "CreateDataSourceRequest");
   }
 }
 
@@ -681,7 +684,7 @@ export interface CreateDataSourceResponse extends $MetadataBearer {
 
 export namespace CreateDataSourceResponse {
   export function isa(o: any): o is CreateDataSourceResponse {
-    return _smithy.isa(o, "CreateDataSourceResponse");
+    return __isa(o, "CreateDataSourceResponse");
   }
 }
 
@@ -726,7 +729,7 @@ export interface CreateFunctionRequest {
 
 export namespace CreateFunctionRequest {
   export function isa(o: any): o is CreateFunctionRequest {
-    return _smithy.isa(o, "CreateFunctionRequest");
+    return __isa(o, "CreateFunctionRequest");
   }
 }
 
@@ -740,7 +743,7 @@ export interface CreateFunctionResponse extends $MetadataBearer {
 
 export namespace CreateFunctionResponse {
   export function isa(o: any): o is CreateFunctionResponse {
-    return _smithy.isa(o, "CreateFunctionResponse");
+    return __isa(o, "CreateFunctionResponse");
   }
 }
 
@@ -784,7 +787,7 @@ export interface CreateGraphqlApiRequest {
 
 export namespace CreateGraphqlApiRequest {
   export function isa(o: any): o is CreateGraphqlApiRequest {
-    return _smithy.isa(o, "CreateGraphqlApiRequest");
+    return __isa(o, "CreateGraphqlApiRequest");
   }
 }
 
@@ -798,7 +801,7 @@ export interface CreateGraphqlApiResponse extends $MetadataBearer {
 
 export namespace CreateGraphqlApiResponse {
   export function isa(o: any): o is CreateGraphqlApiResponse {
-    return _smithy.isa(o, "CreateGraphqlApiResponse");
+    return __isa(o, "CreateGraphqlApiResponse");
   }
 }
 
@@ -874,7 +877,7 @@ export interface CreateResolverRequest {
 
 export namespace CreateResolverRequest {
   export function isa(o: any): o is CreateResolverRequest {
-    return _smithy.isa(o, "CreateResolverRequest");
+    return __isa(o, "CreateResolverRequest");
   }
 }
 
@@ -888,7 +891,7 @@ export interface CreateResolverResponse extends $MetadataBearer {
 
 export namespace CreateResolverResponse {
   export function isa(o: any): o is CreateResolverResponse {
-    return _smithy.isa(o, "CreateResolverResponse");
+    return __isa(o, "CreateResolverResponse");
   }
 }
 
@@ -914,7 +917,7 @@ export interface CreateTypeRequest {
 
 export namespace CreateTypeRequest {
   export function isa(o: any): o is CreateTypeRequest {
-    return _smithy.isa(o, "CreateTypeRequest");
+    return __isa(o, "CreateTypeRequest");
   }
 }
 
@@ -928,7 +931,7 @@ export interface CreateTypeResponse extends $MetadataBearer {
 
 export namespace CreateTypeResponse {
   export function isa(o: any): o is CreateTypeResponse {
-    return _smithy.isa(o, "CreateTypeResponse");
+    return __isa(o, "CreateTypeResponse");
   }
 }
 
@@ -1024,7 +1027,7 @@ export interface DataSource {
 
 export namespace DataSource {
   export function isa(o: any): o is DataSource {
-    return _smithy.isa(o, "DataSource");
+    return __isa(o, "DataSource");
   }
 }
 
@@ -1055,7 +1058,7 @@ export interface DeleteApiCacheRequest {
 
 export namespace DeleteApiCacheRequest {
   export function isa(o: any): o is DeleteApiCacheRequest {
-    return _smithy.isa(o, "DeleteApiCacheRequest");
+    return __isa(o, "DeleteApiCacheRequest");
   }
 }
 
@@ -1068,7 +1071,7 @@ export interface DeleteApiCacheResponse extends $MetadataBearer {
 
 export namespace DeleteApiCacheResponse {
   export function isa(o: any): o is DeleteApiCacheResponse {
-    return _smithy.isa(o, "DeleteApiCacheResponse");
+    return __isa(o, "DeleteApiCacheResponse");
   }
 }
 
@@ -1087,7 +1090,7 @@ export interface DeleteApiKeyRequest {
 
 export namespace DeleteApiKeyRequest {
   export function isa(o: any): o is DeleteApiKeyRequest {
-    return _smithy.isa(o, "DeleteApiKeyRequest");
+    return __isa(o, "DeleteApiKeyRequest");
   }
 }
 
@@ -1097,7 +1100,7 @@ export interface DeleteApiKeyResponse extends $MetadataBearer {
 
 export namespace DeleteApiKeyResponse {
   export function isa(o: any): o is DeleteApiKeyResponse {
-    return _smithy.isa(o, "DeleteApiKeyResponse");
+    return __isa(o, "DeleteApiKeyResponse");
   }
 }
 
@@ -1116,7 +1119,7 @@ export interface DeleteDataSourceRequest {
 
 export namespace DeleteDataSourceRequest {
   export function isa(o: any): o is DeleteDataSourceRequest {
-    return _smithy.isa(o, "DeleteDataSourceRequest");
+    return __isa(o, "DeleteDataSourceRequest");
   }
 }
 
@@ -1126,7 +1129,7 @@ export interface DeleteDataSourceResponse extends $MetadataBearer {
 
 export namespace DeleteDataSourceResponse {
   export function isa(o: any): o is DeleteDataSourceResponse {
-    return _smithy.isa(o, "DeleteDataSourceResponse");
+    return __isa(o, "DeleteDataSourceResponse");
   }
 }
 
@@ -1145,7 +1148,7 @@ export interface DeleteFunctionRequest {
 
 export namespace DeleteFunctionRequest {
   export function isa(o: any): o is DeleteFunctionRequest {
-    return _smithy.isa(o, "DeleteFunctionRequest");
+    return __isa(o, "DeleteFunctionRequest");
   }
 }
 
@@ -1155,7 +1158,7 @@ export interface DeleteFunctionResponse extends $MetadataBearer {
 
 export namespace DeleteFunctionResponse {
   export function isa(o: any): o is DeleteFunctionResponse {
-    return _smithy.isa(o, "DeleteFunctionResponse");
+    return __isa(o, "DeleteFunctionResponse");
   }
 }
 
@@ -1169,7 +1172,7 @@ export interface DeleteGraphqlApiRequest {
 
 export namespace DeleteGraphqlApiRequest {
   export function isa(o: any): o is DeleteGraphqlApiRequest {
-    return _smithy.isa(o, "DeleteGraphqlApiRequest");
+    return __isa(o, "DeleteGraphqlApiRequest");
   }
 }
 
@@ -1179,7 +1182,7 @@ export interface DeleteGraphqlApiResponse extends $MetadataBearer {
 
 export namespace DeleteGraphqlApiResponse {
   export function isa(o: any): o is DeleteGraphqlApiResponse {
-    return _smithy.isa(o, "DeleteGraphqlApiResponse");
+    return __isa(o, "DeleteGraphqlApiResponse");
   }
 }
 
@@ -1203,7 +1206,7 @@ export interface DeleteResolverRequest {
 
 export namespace DeleteResolverRequest {
   export function isa(o: any): o is DeleteResolverRequest {
-    return _smithy.isa(o, "DeleteResolverRequest");
+    return __isa(o, "DeleteResolverRequest");
   }
 }
 
@@ -1213,7 +1216,7 @@ export interface DeleteResolverResponse extends $MetadataBearer {
 
 export namespace DeleteResolverResponse {
   export function isa(o: any): o is DeleteResolverResponse {
-    return _smithy.isa(o, "DeleteResolverResponse");
+    return __isa(o, "DeleteResolverResponse");
   }
 }
 
@@ -1232,7 +1235,7 @@ export interface DeleteTypeRequest {
 
 export namespace DeleteTypeRequest {
   export function isa(o: any): o is DeleteTypeRequest {
-    return _smithy.isa(o, "DeleteTypeRequest");
+    return __isa(o, "DeleteTypeRequest");
   }
 }
 
@@ -1242,7 +1245,7 @@ export interface DeleteTypeResponse extends $MetadataBearer {
 
 export namespace DeleteTypeResponse {
   export function isa(o: any): o is DeleteTypeResponse {
-    return _smithy.isa(o, "DeleteTypeResponse");
+    return __isa(o, "DeleteTypeResponse");
   }
 }
 
@@ -1269,7 +1272,7 @@ export interface DeltaSyncConfig {
 
 export namespace DeltaSyncConfig {
   export function isa(o: any): o is DeltaSyncConfig {
-    return _smithy.isa(o, "DeltaSyncConfig");
+    return __isa(o, "DeltaSyncConfig");
   }
 }
 
@@ -1306,7 +1309,7 @@ export interface DynamodbDataSourceConfig {
 
 export namespace DynamodbDataSourceConfig {
   export function isa(o: any): o is DynamodbDataSourceConfig {
-    return _smithy.isa(o, "DynamodbDataSourceConfig");
+    return __isa(o, "DynamodbDataSourceConfig");
   }
 }
 
@@ -1328,7 +1331,7 @@ export interface ElasticsearchDataSourceConfig {
 
 export namespace ElasticsearchDataSourceConfig {
   export function isa(o: any): o is ElasticsearchDataSourceConfig {
-    return _smithy.isa(o, "ElasticsearchDataSourceConfig");
+    return __isa(o, "ElasticsearchDataSourceConfig");
   }
 }
 
@@ -1351,7 +1354,7 @@ export interface FlushApiCacheRequest {
 
 export namespace FlushApiCacheRequest {
   export function isa(o: any): o is FlushApiCacheRequest {
-    return _smithy.isa(o, "FlushApiCacheRequest");
+    return __isa(o, "FlushApiCacheRequest");
   }
 }
 
@@ -1364,7 +1367,7 @@ export interface FlushApiCacheResponse extends $MetadataBearer {
 
 export namespace FlushApiCacheResponse {
   export function isa(o: any): o is FlushApiCacheResponse {
-    return _smithy.isa(o, "FlushApiCacheResponse");
+    return __isa(o, "FlushApiCacheResponse");
   }
 }
 
@@ -1416,7 +1419,7 @@ export interface FunctionConfiguration {
 
 export namespace FunctionConfiguration {
   export function isa(o: any): o is FunctionConfiguration {
-    return _smithy.isa(o, "FunctionConfiguration");
+    return __isa(o, "FunctionConfiguration");
   }
 }
 
@@ -1433,7 +1436,7 @@ export interface GetApiCacheRequest {
 
 export namespace GetApiCacheRequest {
   export function isa(o: any): o is GetApiCacheRequest {
-    return _smithy.isa(o, "GetApiCacheRequest");
+    return __isa(o, "GetApiCacheRequest");
   }
 }
 
@@ -1447,7 +1450,7 @@ export interface GetApiCacheResponse extends $MetadataBearer {
 
 export namespace GetApiCacheResponse {
   export function isa(o: any): o is GetApiCacheResponse {
-    return _smithy.isa(o, "GetApiCacheResponse");
+    return __isa(o, "GetApiCacheResponse");
   }
 }
 
@@ -1466,7 +1469,7 @@ export interface GetDataSourceRequest {
 
 export namespace GetDataSourceRequest {
   export function isa(o: any): o is GetDataSourceRequest {
-    return _smithy.isa(o, "GetDataSourceRequest");
+    return __isa(o, "GetDataSourceRequest");
   }
 }
 
@@ -1480,7 +1483,7 @@ export interface GetDataSourceResponse extends $MetadataBearer {
 
 export namespace GetDataSourceResponse {
   export function isa(o: any): o is GetDataSourceResponse {
-    return _smithy.isa(o, "GetDataSourceResponse");
+    return __isa(o, "GetDataSourceResponse");
   }
 }
 
@@ -1499,7 +1502,7 @@ export interface GetFunctionRequest {
 
 export namespace GetFunctionRequest {
   export function isa(o: any): o is GetFunctionRequest {
-    return _smithy.isa(o, "GetFunctionRequest");
+    return __isa(o, "GetFunctionRequest");
   }
 }
 
@@ -1513,7 +1516,7 @@ export interface GetFunctionResponse extends $MetadataBearer {
 
 export namespace GetFunctionResponse {
   export function isa(o: any): o is GetFunctionResponse {
-    return _smithy.isa(o, "GetFunctionResponse");
+    return __isa(o, "GetFunctionResponse");
   }
 }
 
@@ -1527,7 +1530,7 @@ export interface GetGraphqlApiRequest {
 
 export namespace GetGraphqlApiRequest {
   export function isa(o: any): o is GetGraphqlApiRequest {
-    return _smithy.isa(o, "GetGraphqlApiRequest");
+    return __isa(o, "GetGraphqlApiRequest");
   }
 }
 
@@ -1541,7 +1544,7 @@ export interface GetGraphqlApiResponse extends $MetadataBearer {
 
 export namespace GetGraphqlApiResponse {
   export function isa(o: any): o is GetGraphqlApiResponse {
-    return _smithy.isa(o, "GetGraphqlApiResponse");
+    return __isa(o, "GetGraphqlApiResponse");
   }
 }
 
@@ -1565,7 +1568,7 @@ export interface GetIntrospectionSchemaRequest {
 
 export namespace GetIntrospectionSchemaRequest {
   export function isa(o: any): o is GetIntrospectionSchemaRequest {
-    return _smithy.isa(o, "GetIntrospectionSchemaRequest");
+    return __isa(o, "GetIntrospectionSchemaRequest");
   }
 }
 
@@ -1581,7 +1584,7 @@ export interface GetIntrospectionSchemaResponse extends $MetadataBearer {
 
 export namespace GetIntrospectionSchemaResponse {
   export function isa(o: any): o is GetIntrospectionSchemaResponse {
-    return _smithy.isa(o, "GetIntrospectionSchemaResponse");
+    return __isa(o, "GetIntrospectionSchemaResponse");
   }
 }
 
@@ -1605,7 +1608,7 @@ export interface GetResolverRequest {
 
 export namespace GetResolverRequest {
   export function isa(o: any): o is GetResolverRequest {
-    return _smithy.isa(o, "GetResolverRequest");
+    return __isa(o, "GetResolverRequest");
   }
 }
 
@@ -1619,7 +1622,7 @@ export interface GetResolverResponse extends $MetadataBearer {
 
 export namespace GetResolverResponse {
   export function isa(o: any): o is GetResolverResponse {
-    return _smithy.isa(o, "GetResolverResponse");
+    return __isa(o, "GetResolverResponse");
   }
 }
 
@@ -1633,7 +1636,7 @@ export interface GetSchemaCreationStatusRequest {
 
 export namespace GetSchemaCreationStatusRequest {
   export function isa(o: any): o is GetSchemaCreationStatusRequest {
-    return _smithy.isa(o, "GetSchemaCreationStatusRequest");
+    return __isa(o, "GetSchemaCreationStatusRequest");
   }
 }
 
@@ -1653,7 +1656,7 @@ export interface GetSchemaCreationStatusResponse extends $MetadataBearer {
 
 export namespace GetSchemaCreationStatusResponse {
   export function isa(o: any): o is GetSchemaCreationStatusResponse {
-    return _smithy.isa(o, "GetSchemaCreationStatusResponse");
+    return __isa(o, "GetSchemaCreationStatusResponse");
   }
 }
 
@@ -1677,7 +1680,7 @@ export interface GetTypeRequest {
 
 export namespace GetTypeRequest {
   export function isa(o: any): o is GetTypeRequest {
-    return _smithy.isa(o, "GetTypeRequest");
+    return __isa(o, "GetTypeRequest");
   }
 }
 
@@ -1691,7 +1694,7 @@ export interface GetTypeResponse extends $MetadataBearer {
 
 export namespace GetTypeResponse {
   export function isa(o: any): o is GetTypeResponse {
-    return _smithy.isa(o, "GetTypeResponse");
+    return __isa(o, "GetTypeResponse");
   }
 }
 
@@ -1699,7 +1702,7 @@ export namespace GetTypeResponse {
  * <p>The GraphQL schema is not valid.</p>
  */
 export interface GraphQLSchemaException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "GraphQLSchemaException";
   $fault: "client";
@@ -1708,7 +1711,7 @@ export interface GraphQLSchemaException
 
 export namespace GraphQLSchemaException {
   export function isa(o: any): o is GraphQLSchemaException {
-    return _smithy.isa(o, "GraphQLSchemaException");
+    return __isa(o, "GraphQLSchemaException");
   }
 }
 
@@ -1770,7 +1773,7 @@ export interface GraphqlApi {
 
 export namespace GraphqlApi {
   export function isa(o: any): o is GraphqlApi {
-    return _smithy.isa(o, "GraphqlApi");
+    return __isa(o, "GraphqlApi");
   }
 }
 
@@ -1792,7 +1795,7 @@ export interface HttpDataSourceConfig {
 
 export namespace HttpDataSourceConfig {
   export function isa(o: any): o is HttpDataSourceConfig {
-    return _smithy.isa(o, "HttpDataSourceConfig");
+    return __isa(o, "HttpDataSourceConfig");
   }
 }
 
@@ -1800,7 +1803,7 @@ export namespace HttpDataSourceConfig {
  * <p>An internal AWS AppSync error occurred. Try your request again.</p>
  */
 export interface InternalFailureException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalFailureException";
   $fault: "server";
@@ -1809,7 +1812,7 @@ export interface InternalFailureException
 
 export namespace InternalFailureException {
   export function isa(o: any): o is InternalFailureException {
-    return _smithy.isa(o, "InternalFailureException");
+    return __isa(o, "InternalFailureException");
   }
 }
 
@@ -1823,7 +1826,7 @@ export interface LambdaConflictHandlerConfig {
 
 export namespace LambdaConflictHandlerConfig {
   export function isa(o: any): o is LambdaConflictHandlerConfig {
-    return _smithy.isa(o, "LambdaConflictHandlerConfig");
+    return __isa(o, "LambdaConflictHandlerConfig");
   }
 }
 
@@ -1840,7 +1843,7 @@ export interface LambdaDataSourceConfig {
 
 export namespace LambdaDataSourceConfig {
   export function isa(o: any): o is LambdaDataSourceConfig {
-    return _smithy.isa(o, "LambdaDataSourceConfig");
+    return __isa(o, "LambdaDataSourceConfig");
   }
 }
 
@@ -1848,7 +1851,7 @@ export namespace LambdaDataSourceConfig {
  * <p>The request exceeded a limit. Try your request again.</p>
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -1857,7 +1860,7 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
@@ -1882,7 +1885,7 @@ export interface ListApiKeysRequest {
 
 export namespace ListApiKeysRequest {
   export function isa(o: any): o is ListApiKeysRequest {
-    return _smithy.isa(o, "ListApiKeysRequest");
+    return __isa(o, "ListApiKeysRequest");
   }
 }
 
@@ -1902,7 +1905,7 @@ export interface ListApiKeysResponse extends $MetadataBearer {
 
 export namespace ListApiKeysResponse {
   export function isa(o: any): o is ListApiKeysResponse {
-    return _smithy.isa(o, "ListApiKeysResponse");
+    return __isa(o, "ListApiKeysResponse");
   }
 }
 
@@ -1927,7 +1930,7 @@ export interface ListDataSourcesRequest {
 
 export namespace ListDataSourcesRequest {
   export function isa(o: any): o is ListDataSourcesRequest {
-    return _smithy.isa(o, "ListDataSourcesRequest");
+    return __isa(o, "ListDataSourcesRequest");
   }
 }
 
@@ -1947,7 +1950,7 @@ export interface ListDataSourcesResponse extends $MetadataBearer {
 
 export namespace ListDataSourcesResponse {
   export function isa(o: any): o is ListDataSourcesResponse {
-    return _smithy.isa(o, "ListDataSourcesResponse");
+    return __isa(o, "ListDataSourcesResponse");
   }
 }
 
@@ -1972,7 +1975,7 @@ export interface ListFunctionsRequest {
 
 export namespace ListFunctionsRequest {
   export function isa(o: any): o is ListFunctionsRequest {
-    return _smithy.isa(o, "ListFunctionsRequest");
+    return __isa(o, "ListFunctionsRequest");
   }
 }
 
@@ -1992,7 +1995,7 @@ export interface ListFunctionsResponse extends $MetadataBearer {
 
 export namespace ListFunctionsResponse {
   export function isa(o: any): o is ListFunctionsResponse {
-    return _smithy.isa(o, "ListFunctionsResponse");
+    return __isa(o, "ListFunctionsResponse");
   }
 }
 
@@ -2012,7 +2015,7 @@ export interface ListGraphqlApisRequest {
 
 export namespace ListGraphqlApisRequest {
   export function isa(o: any): o is ListGraphqlApisRequest {
-    return _smithy.isa(o, "ListGraphqlApisRequest");
+    return __isa(o, "ListGraphqlApisRequest");
   }
 }
 
@@ -2032,7 +2035,7 @@ export interface ListGraphqlApisResponse extends $MetadataBearer {
 
 export namespace ListGraphqlApisResponse {
   export function isa(o: any): o is ListGraphqlApisResponse {
-    return _smithy.isa(o, "ListGraphqlApisResponse");
+    return __isa(o, "ListGraphqlApisResponse");
   }
 }
 
@@ -2061,7 +2064,7 @@ export interface ListResolversByFunctionRequest {
 
 export namespace ListResolversByFunctionRequest {
   export function isa(o: any): o is ListResolversByFunctionRequest {
-    return _smithy.isa(o, "ListResolversByFunctionRequest");
+    return __isa(o, "ListResolversByFunctionRequest");
   }
 }
 
@@ -2080,7 +2083,7 @@ export interface ListResolversByFunctionResponse extends $MetadataBearer {
 
 export namespace ListResolversByFunctionResponse {
   export function isa(o: any): o is ListResolversByFunctionResponse {
-    return _smithy.isa(o, "ListResolversByFunctionResponse");
+    return __isa(o, "ListResolversByFunctionResponse");
   }
 }
 
@@ -2110,7 +2113,7 @@ export interface ListResolversRequest {
 
 export namespace ListResolversRequest {
   export function isa(o: any): o is ListResolversRequest {
-    return _smithy.isa(o, "ListResolversRequest");
+    return __isa(o, "ListResolversRequest");
   }
 }
 
@@ -2130,7 +2133,7 @@ export interface ListResolversResponse extends $MetadataBearer {
 
 export namespace ListResolversResponse {
   export function isa(o: any): o is ListResolversResponse {
-    return _smithy.isa(o, "ListResolversResponse");
+    return __isa(o, "ListResolversResponse");
   }
 }
 
@@ -2144,7 +2147,7 @@ export interface ListTagsForResourceRequest {
 
 export namespace ListTagsForResourceRequest {
   export function isa(o: any): o is ListTagsForResourceRequest {
-    return _smithy.isa(o, "ListTagsForResourceRequest");
+    return __isa(o, "ListTagsForResourceRequest");
   }
 }
 
@@ -2158,7 +2161,7 @@ export interface ListTagsForResourceResponse extends $MetadataBearer {
 
 export namespace ListTagsForResourceResponse {
   export function isa(o: any): o is ListTagsForResourceResponse {
-    return _smithy.isa(o, "ListTagsForResourceResponse");
+    return __isa(o, "ListTagsForResourceResponse");
   }
 }
 
@@ -2188,7 +2191,7 @@ export interface ListTypesRequest {
 
 export namespace ListTypesRequest {
   export function isa(o: any): o is ListTypesRequest {
-    return _smithy.isa(o, "ListTypesRequest");
+    return __isa(o, "ListTypesRequest");
   }
 }
 
@@ -2208,7 +2211,7 @@ export interface ListTypesResponse extends $MetadataBearer {
 
 export namespace ListTypesResponse {
   export function isa(o: any): o is ListTypesResponse {
-    return _smithy.isa(o, "ListTypesResponse");
+    return __isa(o, "ListTypesResponse");
   }
 }
 
@@ -2268,7 +2271,7 @@ export interface LogConfig {
 
 export namespace LogConfig {
   export function isa(o: any): o is LogConfig {
-    return _smithy.isa(o, "LogConfig");
+    return __isa(o, "LogConfig");
   }
 }
 
@@ -2276,9 +2279,7 @@ export namespace LogConfig {
  * <p>The resource specified in the request was not found. Check the resource, and then try
  *          again.</p>
  */
-export interface NotFoundException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface NotFoundException extends __SmithyException, $MetadataBearer {
   name: "NotFoundException";
   $fault: "client";
   message?: string;
@@ -2286,7 +2287,7 @@ export interface NotFoundException
 
 export namespace NotFoundException {
   export function isa(o: any): o is NotFoundException {
-    return _smithy.isa(o, "NotFoundException");
+    return __isa(o, "NotFoundException");
   }
 }
 
@@ -2321,7 +2322,7 @@ export interface OpenIDConnectConfig {
 
 export namespace OpenIDConnectConfig {
   export function isa(o: any): o is OpenIDConnectConfig {
-    return _smithy.isa(o, "OpenIDConnectConfig");
+    return __isa(o, "OpenIDConnectConfig");
   }
 }
 
@@ -2343,7 +2344,7 @@ export interface PipelineConfig {
 
 export namespace PipelineConfig {
   export function isa(o: any): o is PipelineConfig {
-    return _smithy.isa(o, "PipelineConfig");
+    return __isa(o, "PipelineConfig");
   }
 }
 
@@ -2380,7 +2381,7 @@ export interface RdsHttpEndpointConfig {
 
 export namespace RdsHttpEndpointConfig {
   export function isa(o: any): o is RdsHttpEndpointConfig {
-    return _smithy.isa(o, "RdsHttpEndpointConfig");
+    return __isa(o, "RdsHttpEndpointConfig");
   }
 }
 
@@ -2409,7 +2410,7 @@ export interface RelationalDatabaseDataSourceConfig {
 
 export namespace RelationalDatabaseDataSourceConfig {
   export function isa(o: any): o is RelationalDatabaseDataSourceConfig {
-    return _smithy.isa(o, "RelationalDatabaseDataSourceConfig");
+    return __isa(o, "RelationalDatabaseDataSourceConfig");
   }
 }
 
@@ -2489,7 +2490,7 @@ export interface Resolver {
 
 export namespace Resolver {
   export function isa(o: any): o is Resolver {
-    return _smithy.isa(o, "Resolver");
+    return __isa(o, "Resolver");
   }
 }
 
@@ -2522,7 +2523,7 @@ export interface StartSchemaCreationRequest {
 
 export namespace StartSchemaCreationRequest {
   export function isa(o: any): o is StartSchemaCreationRequest {
-    return _smithy.isa(o, "StartSchemaCreationRequest");
+    return __isa(o, "StartSchemaCreationRequest");
   }
 }
 
@@ -2537,7 +2538,7 @@ export interface StartSchemaCreationResponse extends $MetadataBearer {
 
 export namespace StartSchemaCreationResponse {
   export function isa(o: any): o is StartSchemaCreationResponse {
-    return _smithy.isa(o, "StartSchemaCreationResponse");
+    return __isa(o, "StartSchemaCreationResponse");
   }
 }
 
@@ -2589,7 +2590,7 @@ export interface SyncConfig {
 
 export namespace SyncConfig {
   export function isa(o: any): o is SyncConfig {
-    return _smithy.isa(o, "SyncConfig");
+    return __isa(o, "SyncConfig");
   }
 }
 
@@ -2608,7 +2609,7 @@ export interface TagResourceRequest {
 
 export namespace TagResourceRequest {
   export function isa(o: any): o is TagResourceRequest {
-    return _smithy.isa(o, "TagResourceRequest");
+    return __isa(o, "TagResourceRequest");
   }
 }
 
@@ -2618,7 +2619,7 @@ export interface TagResourceResponse extends $MetadataBearer {
 
 export namespace TagResourceResponse {
   export function isa(o: any): o is TagResourceResponse {
-    return _smithy.isa(o, "TagResourceResponse");
+    return __isa(o, "TagResourceResponse");
   }
 }
 
@@ -2655,7 +2656,7 @@ export interface Type {
 
 export namespace Type {
   export function isa(o: any): o is Type {
-    return _smithy.isa(o, "Type");
+    return __isa(o, "Type");
   }
 }
 
@@ -2668,7 +2669,7 @@ export enum TypeDefinitionFormat {
  * <p>You are not authorized to perform this operation.</p>
  */
 export interface UnauthorizedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UnauthorizedException";
   $fault: "client";
@@ -2677,7 +2678,7 @@ export interface UnauthorizedException
 
 export namespace UnauthorizedException {
   export function isa(o: any): o is UnauthorizedException {
-    return _smithy.isa(o, "UnauthorizedException");
+    return __isa(o, "UnauthorizedException");
   }
 }
 
@@ -2696,7 +2697,7 @@ export interface UntagResourceRequest {
 
 export namespace UntagResourceRequest {
   export function isa(o: any): o is UntagResourceRequest {
-    return _smithy.isa(o, "UntagResourceRequest");
+    return __isa(o, "UntagResourceRequest");
   }
 }
 
@@ -2706,7 +2707,7 @@ export interface UntagResourceResponse extends $MetadataBearer {
 
 export namespace UntagResourceResponse {
   export function isa(o: any): o is UntagResourceResponse {
-    return _smithy.isa(o, "UntagResourceResponse");
+    return __isa(o, "UntagResourceResponse");
   }
 }
 
@@ -2779,7 +2780,7 @@ export interface UpdateApiCacheRequest {
 
 export namespace UpdateApiCacheRequest {
   export function isa(o: any): o is UpdateApiCacheRequest {
-    return _smithy.isa(o, "UpdateApiCacheRequest");
+    return __isa(o, "UpdateApiCacheRequest");
   }
 }
 
@@ -2796,7 +2797,7 @@ export interface UpdateApiCacheResponse extends $MetadataBearer {
 
 export namespace UpdateApiCacheResponse {
   export function isa(o: any): o is UpdateApiCacheResponse {
-    return _smithy.isa(o, "UpdateApiCacheResponse");
+    return __isa(o, "UpdateApiCacheResponse");
   }
 }
 
@@ -2826,7 +2827,7 @@ export interface UpdateApiKeyRequest {
 
 export namespace UpdateApiKeyRequest {
   export function isa(o: any): o is UpdateApiKeyRequest {
-    return _smithy.isa(o, "UpdateApiKeyRequest");
+    return __isa(o, "UpdateApiKeyRequest");
   }
 }
 
@@ -2840,7 +2841,7 @@ export interface UpdateApiKeyResponse extends $MetadataBearer {
 
 export namespace UpdateApiKeyResponse {
   export function isa(o: any): o is UpdateApiKeyResponse {
-    return _smithy.isa(o, "UpdateApiKeyResponse");
+    return __isa(o, "UpdateApiKeyResponse");
   }
 }
 
@@ -2899,7 +2900,7 @@ export interface UpdateDataSourceRequest {
 
 export namespace UpdateDataSourceRequest {
   export function isa(o: any): o is UpdateDataSourceRequest {
-    return _smithy.isa(o, "UpdateDataSourceRequest");
+    return __isa(o, "UpdateDataSourceRequest");
   }
 }
 
@@ -2913,7 +2914,7 @@ export interface UpdateDataSourceResponse extends $MetadataBearer {
 
 export namespace UpdateDataSourceResponse {
   export function isa(o: any): o is UpdateDataSourceResponse {
-    return _smithy.isa(o, "UpdateDataSourceResponse");
+    return __isa(o, "UpdateDataSourceResponse");
   }
 }
 
@@ -2963,7 +2964,7 @@ export interface UpdateFunctionRequest {
 
 export namespace UpdateFunctionRequest {
   export function isa(o: any): o is UpdateFunctionRequest {
-    return _smithy.isa(o, "UpdateFunctionRequest");
+    return __isa(o, "UpdateFunctionRequest");
   }
 }
 
@@ -2977,7 +2978,7 @@ export interface UpdateFunctionResponse extends $MetadataBearer {
 
 export namespace UpdateFunctionResponse {
   export function isa(o: any): o is UpdateFunctionResponse {
-    return _smithy.isa(o, "UpdateFunctionResponse");
+    return __isa(o, "UpdateFunctionResponse");
   }
 }
 
@@ -3024,7 +3025,7 @@ export interface UpdateGraphqlApiRequest {
 
 export namespace UpdateGraphqlApiRequest {
   export function isa(o: any): o is UpdateGraphqlApiRequest {
-    return _smithy.isa(o, "UpdateGraphqlApiRequest");
+    return __isa(o, "UpdateGraphqlApiRequest");
   }
 }
 
@@ -3038,7 +3039,7 @@ export interface UpdateGraphqlApiResponse extends $MetadataBearer {
 
 export namespace UpdateGraphqlApiResponse {
   export function isa(o: any): o is UpdateGraphqlApiResponse {
-    return _smithy.isa(o, "UpdateGraphqlApiResponse");
+    return __isa(o, "UpdateGraphqlApiResponse");
   }
 }
 
@@ -3111,7 +3112,7 @@ export interface UpdateResolverRequest {
 
 export namespace UpdateResolverRequest {
   export function isa(o: any): o is UpdateResolverRequest {
-    return _smithy.isa(o, "UpdateResolverRequest");
+    return __isa(o, "UpdateResolverRequest");
   }
 }
 
@@ -3125,7 +3126,7 @@ export interface UpdateResolverResponse extends $MetadataBearer {
 
 export namespace UpdateResolverResponse {
   export function isa(o: any): o is UpdateResolverResponse {
-    return _smithy.isa(o, "UpdateResolverResponse");
+    return __isa(o, "UpdateResolverResponse");
   }
 }
 
@@ -3154,7 +3155,7 @@ export interface UpdateTypeRequest {
 
 export namespace UpdateTypeRequest {
   export function isa(o: any): o is UpdateTypeRequest {
-    return _smithy.isa(o, "UpdateTypeRequest");
+    return __isa(o, "UpdateTypeRequest");
   }
 }
 
@@ -3168,7 +3169,7 @@ export interface UpdateTypeResponse extends $MetadataBearer {
 
 export namespace UpdateTypeResponse {
   export function isa(o: any): o is UpdateTypeResponse {
-    return _smithy.isa(o, "UpdateTypeResponse");
+    return __isa(o, "UpdateTypeResponse");
   }
 }
 
@@ -3203,6 +3204,6 @@ export interface UserPoolConfig {
 
 export namespace UserPoolConfig {
   export function isa(o: any): o is UserPoolConfig {
-    return _smithy.isa(o, "UserPoolConfig");
+    return __isa(o, "UserPoolConfig");
   }
 }

--- a/clients/client-appsync/protocols/Aws_restJson1_1.ts
+++ b/clients/client-appsync/protocols/Aws_restJson1_1.ts
@@ -204,7 +204,10 @@ import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  extendedEncodeURIComponent as __extendedEncodeURIComponent
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -220,13 +223,13 @@ export async function serializeAws_restJson1_1CreateApiCacheCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/apis/{apiId}/ApiCaches";
   if (input.apiId !== undefined) {
-    const labelValue: string = input.apiId.toString();
+    const labelValue: string = input.apiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: apiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{apiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: apiId.");
@@ -267,13 +270,13 @@ export async function serializeAws_restJson1_1CreateApiKeyCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/apis/{apiId}/apikeys";
   if (input.apiId !== undefined) {
-    const labelValue: string = input.apiId.toString();
+    const labelValue: string = input.apiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: apiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{apiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: apiId.");
@@ -305,13 +308,13 @@ export async function serializeAws_restJson1_1CreateDataSourceCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/apis/{apiId}/datasources";
   if (input.apiId !== undefined) {
-    const labelValue: string = input.apiId.toString();
+    const labelValue: string = input.apiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: apiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{apiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: apiId.");
@@ -385,13 +388,13 @@ export async function serializeAws_restJson1_1CreateFunctionCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/apis/{apiId}/functions";
   if (input.apiId !== undefined) {
-    const labelValue: string = input.apiId.toString();
+    const labelValue: string = input.apiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: apiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{apiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: apiId.");
@@ -492,25 +495,25 @@ export async function serializeAws_restJson1_1CreateResolverCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/apis/{apiId}/types/{typeName}/resolvers";
   if (input.apiId !== undefined) {
-    const labelValue: string = input.apiId.toString();
+    const labelValue: string = input.apiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: apiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{apiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: apiId.");
   }
   if (input.typeName !== undefined) {
-    const labelValue: string = input.typeName.toString();
+    const labelValue: string = input.typeName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: typeName.");
     }
     resolvedPath = resolvedPath.replace(
       "{typeName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: typeName.");
@@ -569,13 +572,13 @@ export async function serializeAws_restJson1_1CreateTypeCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/apis/{apiId}/types";
   if (input.apiId !== undefined) {
-    const labelValue: string = input.apiId.toString();
+    const labelValue: string = input.apiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: apiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{apiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: apiId.");
@@ -607,13 +610,13 @@ export async function serializeAws_restJson1_1DeleteApiCacheCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/apis/{apiId}/ApiCaches";
   if (input.apiId !== undefined) {
-    const labelValue: string = input.apiId.toString();
+    const labelValue: string = input.apiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: apiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{apiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: apiId.");
@@ -635,23 +638,26 @@ export async function serializeAws_restJson1_1DeleteApiKeyCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/apis/{apiId}/apikeys/{id}";
   if (input.apiId !== undefined) {
-    const labelValue: string = input.apiId.toString();
+    const labelValue: string = input.apiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: apiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{apiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: apiId.");
   }
   if (input.id !== undefined) {
-    const labelValue: string = input.id.toString();
+    const labelValue: string = input.id;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: id.");
     }
-    resolvedPath = resolvedPath.replace("{id}", encodeURIComponent(labelValue));
+    resolvedPath = resolvedPath.replace(
+      "{id}",
+      __extendedEncodeURIComponent(labelValue)
+    );
   } else {
     throw new Error("No value provided for input HTTP label: id.");
   }
@@ -672,25 +678,25 @@ export async function serializeAws_restJson1_1DeleteDataSourceCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/apis/{apiId}/datasources/{name}";
   if (input.apiId !== undefined) {
-    const labelValue: string = input.apiId.toString();
+    const labelValue: string = input.apiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: apiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{apiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: apiId.");
   }
   if (input.name !== undefined) {
-    const labelValue: string = input.name.toString();
+    const labelValue: string = input.name;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: name.");
     }
     resolvedPath = resolvedPath.replace(
       "{name}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: name.");
@@ -712,25 +718,25 @@ export async function serializeAws_restJson1_1DeleteFunctionCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/apis/{apiId}/functions/{functionId}";
   if (input.apiId !== undefined) {
-    const labelValue: string = input.apiId.toString();
+    const labelValue: string = input.apiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: apiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{apiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: apiId.");
   }
   if (input.functionId !== undefined) {
-    const labelValue: string = input.functionId.toString();
+    const labelValue: string = input.functionId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: functionId.");
     }
     resolvedPath = resolvedPath.replace(
       "{functionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: functionId.");
@@ -752,13 +758,13 @@ export async function serializeAws_restJson1_1DeleteGraphqlApiCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/apis/{apiId}";
   if (input.apiId !== undefined) {
-    const labelValue: string = input.apiId.toString();
+    const labelValue: string = input.apiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: apiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{apiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: apiId.");
@@ -780,37 +786,37 @@ export async function serializeAws_restJson1_1DeleteResolverCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/apis/{apiId}/types/{typeName}/resolvers/{fieldName}";
   if (input.apiId !== undefined) {
-    const labelValue: string = input.apiId.toString();
+    const labelValue: string = input.apiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: apiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{apiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: apiId.");
   }
   if (input.fieldName !== undefined) {
-    const labelValue: string = input.fieldName.toString();
+    const labelValue: string = input.fieldName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: fieldName.");
     }
     resolvedPath = resolvedPath.replace(
       "{fieldName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: fieldName.");
   }
   if (input.typeName !== undefined) {
-    const labelValue: string = input.typeName.toString();
+    const labelValue: string = input.typeName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: typeName.");
     }
     resolvedPath = resolvedPath.replace(
       "{typeName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: typeName.");
@@ -832,25 +838,25 @@ export async function serializeAws_restJson1_1DeleteTypeCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/apis/{apiId}/types/{typeName}";
   if (input.apiId !== undefined) {
-    const labelValue: string = input.apiId.toString();
+    const labelValue: string = input.apiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: apiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{apiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: apiId.");
   }
   if (input.typeName !== undefined) {
-    const labelValue: string = input.typeName.toString();
+    const labelValue: string = input.typeName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: typeName.");
     }
     resolvedPath = resolvedPath.replace(
       "{typeName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: typeName.");
@@ -872,13 +878,13 @@ export async function serializeAws_restJson1_1FlushApiCacheCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/apis/{apiId}/FlushCache";
   if (input.apiId !== undefined) {
-    const labelValue: string = input.apiId.toString();
+    const labelValue: string = input.apiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: apiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{apiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: apiId.");
@@ -900,13 +906,13 @@ export async function serializeAws_restJson1_1GetApiCacheCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/apis/{apiId}/ApiCaches";
   if (input.apiId !== undefined) {
-    const labelValue: string = input.apiId.toString();
+    const labelValue: string = input.apiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: apiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{apiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: apiId.");
@@ -928,25 +934,25 @@ export async function serializeAws_restJson1_1GetDataSourceCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/apis/{apiId}/datasources/{name}";
   if (input.apiId !== undefined) {
-    const labelValue: string = input.apiId.toString();
+    const labelValue: string = input.apiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: apiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{apiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: apiId.");
   }
   if (input.name !== undefined) {
-    const labelValue: string = input.name.toString();
+    const labelValue: string = input.name;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: name.");
     }
     resolvedPath = resolvedPath.replace(
       "{name}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: name.");
@@ -968,25 +974,25 @@ export async function serializeAws_restJson1_1GetFunctionCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/apis/{apiId}/functions/{functionId}";
   if (input.apiId !== undefined) {
-    const labelValue: string = input.apiId.toString();
+    const labelValue: string = input.apiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: apiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{apiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: apiId.");
   }
   if (input.functionId !== undefined) {
-    const labelValue: string = input.functionId.toString();
+    const labelValue: string = input.functionId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: functionId.");
     }
     resolvedPath = resolvedPath.replace(
       "{functionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: functionId.");
@@ -1008,13 +1014,13 @@ export async function serializeAws_restJson1_1GetGraphqlApiCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/apis/{apiId}";
   if (input.apiId !== undefined) {
-    const labelValue: string = input.apiId.toString();
+    const labelValue: string = input.apiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: apiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{apiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: apiId.");
@@ -1036,23 +1042,27 @@ export async function serializeAws_restJson1_1GetIntrospectionSchemaCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/apis/{apiId}/schema";
   if (input.apiId !== undefined) {
-    const labelValue: string = input.apiId.toString();
+    const labelValue: string = input.apiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: apiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{apiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: apiId.");
   }
   const query: any = {};
   if (input.format !== undefined) {
-    query["format"] = input.format.toString();
+    query[
+      __extendedEncodeURIComponent("format")
+    ] = __extendedEncodeURIComponent(input.format);
   }
   if (input.includeDirectives !== undefined) {
-    query["includeDirectives"] = input.includeDirectives.toString();
+    query[
+      __extendedEncodeURIComponent("includeDirectives")
+    ] = __extendedEncodeURIComponent(input.includeDirectives.toString());
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1072,37 +1082,37 @@ export async function serializeAws_restJson1_1GetResolverCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/apis/{apiId}/types/{typeName}/resolvers/{fieldName}";
   if (input.apiId !== undefined) {
-    const labelValue: string = input.apiId.toString();
+    const labelValue: string = input.apiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: apiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{apiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: apiId.");
   }
   if (input.fieldName !== undefined) {
-    const labelValue: string = input.fieldName.toString();
+    const labelValue: string = input.fieldName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: fieldName.");
     }
     resolvedPath = resolvedPath.replace(
       "{fieldName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: fieldName.");
   }
   if (input.typeName !== undefined) {
-    const labelValue: string = input.typeName.toString();
+    const labelValue: string = input.typeName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: typeName.");
     }
     resolvedPath = resolvedPath.replace(
       "{typeName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: typeName.");
@@ -1124,13 +1134,13 @@ export async function serializeAws_restJson1_1GetSchemaCreationStatusCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/apis/{apiId}/schemacreation";
   if (input.apiId !== undefined) {
-    const labelValue: string = input.apiId.toString();
+    const labelValue: string = input.apiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: apiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{apiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: apiId.");
@@ -1152,32 +1162,34 @@ export async function serializeAws_restJson1_1GetTypeCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/apis/{apiId}/types/{typeName}";
   if (input.apiId !== undefined) {
-    const labelValue: string = input.apiId.toString();
+    const labelValue: string = input.apiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: apiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{apiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: apiId.");
   }
   if (input.typeName !== undefined) {
-    const labelValue: string = input.typeName.toString();
+    const labelValue: string = input.typeName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: typeName.");
     }
     resolvedPath = resolvedPath.replace(
       "{typeName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: typeName.");
   }
   const query: any = {};
   if (input.format !== undefined) {
-    query["format"] = input.format.toString();
+    query[
+      __extendedEncodeURIComponent("format")
+    ] = __extendedEncodeURIComponent(input.format);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1197,23 +1209,27 @@ export async function serializeAws_restJson1_1ListApiKeysCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/apis/{apiId}/apikeys";
   if (input.apiId !== undefined) {
-    const labelValue: string = input.apiId.toString();
+    const labelValue: string = input.apiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: apiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{apiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: apiId.");
   }
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1233,23 +1249,27 @@ export async function serializeAws_restJson1_1ListDataSourcesCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/apis/{apiId}/datasources";
   if (input.apiId !== undefined) {
-    const labelValue: string = input.apiId.toString();
+    const labelValue: string = input.apiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: apiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{apiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: apiId.");
   }
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1269,23 +1289,27 @@ export async function serializeAws_restJson1_1ListFunctionsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/apis/{apiId}/functions";
   if (input.apiId !== undefined) {
-    const labelValue: string = input.apiId.toString();
+    const labelValue: string = input.apiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: apiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{apiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: apiId.");
   }
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1306,10 +1330,14 @@ export async function serializeAws_restJson1_1ListGraphqlApisCommand(
   let resolvedPath = "/apis";
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1329,35 +1357,39 @@ export async function serializeAws_restJson1_1ListResolversCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/apis/{apiId}/types/{typeName}/resolvers";
   if (input.apiId !== undefined) {
-    const labelValue: string = input.apiId.toString();
+    const labelValue: string = input.apiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: apiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{apiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: apiId.");
   }
   if (input.typeName !== undefined) {
-    const labelValue: string = input.typeName.toString();
+    const labelValue: string = input.typeName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: typeName.");
     }
     resolvedPath = resolvedPath.replace(
       "{typeName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: typeName.");
   }
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1377,35 +1409,39 @@ export async function serializeAws_restJson1_1ListResolversByFunctionCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/apis/{apiId}/functions/{functionId}/resolvers";
   if (input.apiId !== undefined) {
-    const labelValue: string = input.apiId.toString();
+    const labelValue: string = input.apiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: apiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{apiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: apiId.");
   }
   if (input.functionId !== undefined) {
-    const labelValue: string = input.functionId.toString();
+    const labelValue: string = input.functionId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: functionId.");
     }
     resolvedPath = resolvedPath.replace(
       "{functionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: functionId.");
   }
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1425,7 +1461,7 @@ export async function serializeAws_restJson1_1ListTagsForResourceCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/tags/{resourceArn}";
   if (input.resourceArn !== undefined) {
-    const labelValue: string = input.resourceArn.toString();
+    const labelValue: string = input.resourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: resourceArn."
@@ -1433,7 +1469,7 @@ export async function serializeAws_restJson1_1ListTagsForResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{resourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: resourceArn.");
@@ -1455,26 +1491,32 @@ export async function serializeAws_restJson1_1ListTypesCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/apis/{apiId}/types";
   if (input.apiId !== undefined) {
-    const labelValue: string = input.apiId.toString();
+    const labelValue: string = input.apiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: apiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{apiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: apiId.");
   }
   const query: any = {};
   if (input.format !== undefined) {
-    query["format"] = input.format.toString();
+    query[
+      __extendedEncodeURIComponent("format")
+    ] = __extendedEncodeURIComponent(input.format);
   }
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1494,13 +1536,13 @@ export async function serializeAws_restJson1_1StartSchemaCreationCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/apis/{apiId}/schemacreation";
   if (input.apiId !== undefined) {
-    const labelValue: string = input.apiId.toString();
+    const labelValue: string = input.apiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: apiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{apiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: apiId.");
@@ -1529,7 +1571,7 @@ export async function serializeAws_restJson1_1TagResourceCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/tags/{resourceArn}";
   if (input.resourceArn !== undefined) {
-    const labelValue: string = input.resourceArn.toString();
+    const labelValue: string = input.resourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: resourceArn."
@@ -1537,7 +1579,7 @@ export async function serializeAws_restJson1_1TagResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{resourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: resourceArn.");
@@ -1566,7 +1608,7 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/tags/{resourceArn}";
   if (input.resourceArn !== undefined) {
-    const labelValue: string = input.resourceArn.toString();
+    const labelValue: string = input.resourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: resourceArn."
@@ -1574,14 +1616,16 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{resourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: resourceArn.");
   }
   const query: any = {};
   if (input.tagKeys !== undefined) {
-    query["tagKeys"] = input.tagKeys;
+    query[__extendedEncodeURIComponent("tagKeys")] = input.tagKeys.map(entry =>
+      __extendedEncodeURIComponent(entry)
+    );
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1601,13 +1645,13 @@ export async function serializeAws_restJson1_1UpdateApiCacheCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/apis/{apiId}/ApiCaches/update";
   if (input.apiId !== undefined) {
-    const labelValue: string = input.apiId.toString();
+    const labelValue: string = input.apiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: apiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{apiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: apiId.");
@@ -1642,23 +1686,26 @@ export async function serializeAws_restJson1_1UpdateApiKeyCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/apis/{apiId}/apikeys/{id}";
   if (input.apiId !== undefined) {
-    const labelValue: string = input.apiId.toString();
+    const labelValue: string = input.apiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: apiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{apiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: apiId.");
   }
   if (input.id !== undefined) {
-    const labelValue: string = input.id.toString();
+    const labelValue: string = input.id;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: id.");
     }
-    resolvedPath = resolvedPath.replace("{id}", encodeURIComponent(labelValue));
+    resolvedPath = resolvedPath.replace(
+      "{id}",
+      __extendedEncodeURIComponent(labelValue)
+    );
   } else {
     throw new Error("No value provided for input HTTP label: id.");
   }
@@ -1689,25 +1736,25 @@ export async function serializeAws_restJson1_1UpdateDataSourceCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/apis/{apiId}/datasources/{name}";
   if (input.apiId !== undefined) {
-    const labelValue: string = input.apiId.toString();
+    const labelValue: string = input.apiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: apiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{apiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: apiId.");
   }
   if (input.name !== undefined) {
-    const labelValue: string = input.name.toString();
+    const labelValue: string = input.name;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: name.");
     }
     resolvedPath = resolvedPath.replace(
       "{name}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: name.");
@@ -1778,25 +1825,25 @@ export async function serializeAws_restJson1_1UpdateFunctionCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/apis/{apiId}/functions/{functionId}";
   if (input.apiId !== undefined) {
-    const labelValue: string = input.apiId.toString();
+    const labelValue: string = input.apiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: apiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{apiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: apiId.");
   }
   if (input.functionId !== undefined) {
-    const labelValue: string = input.functionId.toString();
+    const labelValue: string = input.functionId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: functionId.");
     }
     resolvedPath = resolvedPath.replace(
       "{functionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: functionId.");
@@ -1840,13 +1887,13 @@ export async function serializeAws_restJson1_1UpdateGraphqlApiCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/apis/{apiId}";
   if (input.apiId !== undefined) {
-    const labelValue: string = input.apiId.toString();
+    const labelValue: string = input.apiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: apiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{apiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: apiId.");
@@ -1906,37 +1953,37 @@ export async function serializeAws_restJson1_1UpdateResolverCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/apis/{apiId}/types/{typeName}/resolvers/{fieldName}";
   if (input.apiId !== undefined) {
-    const labelValue: string = input.apiId.toString();
+    const labelValue: string = input.apiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: apiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{apiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: apiId.");
   }
   if (input.fieldName !== undefined) {
-    const labelValue: string = input.fieldName.toString();
+    const labelValue: string = input.fieldName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: fieldName.");
     }
     resolvedPath = resolvedPath.replace(
       "{fieldName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: fieldName.");
   }
   if (input.typeName !== undefined) {
-    const labelValue: string = input.typeName.toString();
+    const labelValue: string = input.typeName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: typeName.");
     }
     resolvedPath = resolvedPath.replace(
       "{typeName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: typeName.");
@@ -1992,25 +2039,25 @@ export async function serializeAws_restJson1_1UpdateTypeCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/apis/{apiId}/types/{typeName}";
   if (input.apiId !== undefined) {
-    const labelValue: string = input.apiId.toString();
+    const labelValue: string = input.apiId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: apiId.");
     }
     resolvedPath = resolvedPath.replace(
       "{apiId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: apiId.");
   }
   if (input.typeName !== undefined) {
-    const labelValue: string = input.typeName.toString();
+    const labelValue: string = input.typeName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: typeName.");
     }
     resolvedPath = resolvedPath.replace(
       "{typeName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: typeName.");
@@ -2655,6 +2702,7 @@ export async function deserializeAws_restJson1_1DeleteApiCacheCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeleteApiCacheResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2731,6 +2779,7 @@ export async function deserializeAws_restJson1_1DeleteApiKeyCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeleteApiKeyResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2803,6 +2852,7 @@ export async function deserializeAws_restJson1_1DeleteDataSourceCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeleteDataSourceResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2882,6 +2932,7 @@ export async function deserializeAws_restJson1_1DeleteFunctionCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeleteFunctionResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2954,6 +3005,7 @@ export async function deserializeAws_restJson1_1DeleteGraphqlApiCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeleteGraphqlApiResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -3040,6 +3092,7 @@ export async function deserializeAws_restJson1_1DeleteResolverCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeleteResolverResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -3109,6 +3162,7 @@ export async function deserializeAws_restJson1_1DeleteTypeCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeleteTypeResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -3185,6 +3239,7 @@ export async function deserializeAws_restJson1_1FlushApiCacheCommand(
     $metadata: deserializeMetadata(output),
     __type: "FlushApiCacheResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -4638,6 +4693,7 @@ export async function deserializeAws_restJson1_1TagResourceCommand(
     $metadata: deserializeMetadata(output),
     __type: "TagResourceResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -4721,6 +4777,7 @@ export async function deserializeAws_restJson1_1UntagResourceCommand(
     $metadata: deserializeMetadata(output),
     __type: "UntagResourceResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 

--- a/clients/client-athena/models/index.ts
+++ b/clients/client-athena/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export interface BatchGetNamedQueryInput {
@@ -11,7 +14,7 @@ export interface BatchGetNamedQueryInput {
 
 export namespace BatchGetNamedQueryInput {
   export function isa(o: any): o is BatchGetNamedQueryInput {
-    return _smithy.isa(o, "BatchGetNamedQueryInput");
+    return __isa(o, "BatchGetNamedQueryInput");
   }
 }
 
@@ -30,7 +33,7 @@ export interface BatchGetNamedQueryOutput extends $MetadataBearer {
 
 export namespace BatchGetNamedQueryOutput {
   export function isa(o: any): o is BatchGetNamedQueryOutput {
-    return _smithy.isa(o, "BatchGetNamedQueryOutput");
+    return __isa(o, "BatchGetNamedQueryOutput");
   }
 }
 
@@ -44,7 +47,7 @@ export interface BatchGetQueryExecutionInput {
 
 export namespace BatchGetQueryExecutionInput {
   export function isa(o: any): o is BatchGetQueryExecutionInput {
-    return _smithy.isa(o, "BatchGetQueryExecutionInput");
+    return __isa(o, "BatchGetQueryExecutionInput");
   }
 }
 
@@ -63,7 +66,7 @@ export interface BatchGetQueryExecutionOutput extends $MetadataBearer {
 
 export namespace BatchGetQueryExecutionOutput {
   export function isa(o: any): o is BatchGetQueryExecutionOutput {
-    return _smithy.isa(o, "BatchGetQueryExecutionOutput");
+    return __isa(o, "BatchGetQueryExecutionOutput");
   }
 }
 
@@ -125,7 +128,7 @@ export interface ColumnInfo {
 
 export namespace ColumnInfo {
   export function isa(o: any): o is ColumnInfo {
-    return _smithy.isa(o, "ColumnInfo");
+    return __isa(o, "ColumnInfo");
   }
 }
 
@@ -173,7 +176,7 @@ export interface CreateNamedQueryInput {
 
 export namespace CreateNamedQueryInput {
   export function isa(o: any): o is CreateNamedQueryInput {
-    return _smithy.isa(o, "CreateNamedQueryInput");
+    return __isa(o, "CreateNamedQueryInput");
   }
 }
 
@@ -187,7 +190,7 @@ export interface CreateNamedQueryOutput extends $MetadataBearer {
 
 export namespace CreateNamedQueryOutput {
   export function isa(o: any): o is CreateNamedQueryOutput {
-    return _smithy.isa(o, "CreateNamedQueryOutput");
+    return __isa(o, "CreateNamedQueryOutput");
   }
 }
 
@@ -221,7 +224,7 @@ export interface CreateWorkGroupInput {
 
 export namespace CreateWorkGroupInput {
   export function isa(o: any): o is CreateWorkGroupInput {
-    return _smithy.isa(o, "CreateWorkGroupInput");
+    return __isa(o, "CreateWorkGroupInput");
   }
 }
 
@@ -231,7 +234,7 @@ export interface CreateWorkGroupOutput extends $MetadataBearer {
 
 export namespace CreateWorkGroupOutput {
   export function isa(o: any): o is CreateWorkGroupOutput {
-    return _smithy.isa(o, "CreateWorkGroupOutput");
+    return __isa(o, "CreateWorkGroupOutput");
   }
 }
 
@@ -248,7 +251,7 @@ export interface Datum {
 
 export namespace Datum {
   export function isa(o: any): o is Datum {
-    return _smithy.isa(o, "Datum");
+    return __isa(o, "Datum");
   }
 }
 
@@ -262,7 +265,7 @@ export interface DeleteNamedQueryInput {
 
 export namespace DeleteNamedQueryInput {
   export function isa(o: any): o is DeleteNamedQueryInput {
-    return _smithy.isa(o, "DeleteNamedQueryInput");
+    return __isa(o, "DeleteNamedQueryInput");
   }
 }
 
@@ -272,7 +275,7 @@ export interface DeleteNamedQueryOutput extends $MetadataBearer {
 
 export namespace DeleteNamedQueryOutput {
   export function isa(o: any): o is DeleteNamedQueryOutput {
-    return _smithy.isa(o, "DeleteNamedQueryOutput");
+    return __isa(o, "DeleteNamedQueryOutput");
   }
 }
 
@@ -291,7 +294,7 @@ export interface DeleteWorkGroupInput {
 
 export namespace DeleteWorkGroupInput {
   export function isa(o: any): o is DeleteWorkGroupInput {
-    return _smithy.isa(o, "DeleteWorkGroupInput");
+    return __isa(o, "DeleteWorkGroupInput");
   }
 }
 
@@ -301,7 +304,7 @@ export interface DeleteWorkGroupOutput extends $MetadataBearer {
 
 export namespace DeleteWorkGroupOutput {
   export function isa(o: any): o is DeleteWorkGroupOutput {
-    return _smithy.isa(o, "DeleteWorkGroupOutput");
+    return __isa(o, "DeleteWorkGroupOutput");
   }
 }
 
@@ -331,7 +334,7 @@ export interface EncryptionConfiguration {
 
 export namespace EncryptionConfiguration {
   export function isa(o: any): o is EncryptionConfiguration {
-    return _smithy.isa(o, "EncryptionConfiguration");
+    return __isa(o, "EncryptionConfiguration");
   }
 }
 
@@ -351,7 +354,7 @@ export interface GetNamedQueryInput {
 
 export namespace GetNamedQueryInput {
   export function isa(o: any): o is GetNamedQueryInput {
-    return _smithy.isa(o, "GetNamedQueryInput");
+    return __isa(o, "GetNamedQueryInput");
   }
 }
 
@@ -365,7 +368,7 @@ export interface GetNamedQueryOutput extends $MetadataBearer {
 
 export namespace GetNamedQueryOutput {
   export function isa(o: any): o is GetNamedQueryOutput {
-    return _smithy.isa(o, "GetNamedQueryOutput");
+    return __isa(o, "GetNamedQueryOutput");
   }
 }
 
@@ -379,7 +382,7 @@ export interface GetQueryExecutionInput {
 
 export namespace GetQueryExecutionInput {
   export function isa(o: any): o is GetQueryExecutionInput {
-    return _smithy.isa(o, "GetQueryExecutionInput");
+    return __isa(o, "GetQueryExecutionInput");
   }
 }
 
@@ -393,7 +396,7 @@ export interface GetQueryExecutionOutput extends $MetadataBearer {
 
 export namespace GetQueryExecutionOutput {
   export function isa(o: any): o is GetQueryExecutionOutput {
-    return _smithy.isa(o, "GetQueryExecutionOutput");
+    return __isa(o, "GetQueryExecutionOutput");
   }
 }
 
@@ -417,7 +420,7 @@ export interface GetQueryResultsInput {
 
 export namespace GetQueryResultsInput {
   export function isa(o: any): o is GetQueryResultsInput {
-    return _smithy.isa(o, "GetQueryResultsInput");
+    return __isa(o, "GetQueryResultsInput");
   }
 }
 
@@ -442,7 +445,7 @@ export interface GetQueryResultsOutput extends $MetadataBearer {
 
 export namespace GetQueryResultsOutput {
   export function isa(o: any): o is GetQueryResultsOutput {
-    return _smithy.isa(o, "GetQueryResultsOutput");
+    return __isa(o, "GetQueryResultsOutput");
   }
 }
 
@@ -456,7 +459,7 @@ export interface GetWorkGroupInput {
 
 export namespace GetWorkGroupInput {
   export function isa(o: any): o is GetWorkGroupInput {
-    return _smithy.isa(o, "GetWorkGroupInput");
+    return __isa(o, "GetWorkGroupInput");
   }
 }
 
@@ -470,7 +473,7 @@ export interface GetWorkGroupOutput extends $MetadataBearer {
 
 export namespace GetWorkGroupOutput {
   export function isa(o: any): o is GetWorkGroupOutput {
-    return _smithy.isa(o, "GetWorkGroupOutput");
+    return __isa(o, "GetWorkGroupOutput");
   }
 }
 
@@ -478,7 +481,7 @@ export namespace GetWorkGroupOutput {
  * <p>Indicates a platform issue, which may be due to a transient condition or outage.</p>
  */
 export interface InternalServerException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalServerException";
   $fault: "server";
@@ -487,7 +490,7 @@ export interface InternalServerException
 
 export namespace InternalServerException {
   export function isa(o: any): o is InternalServerException {
-    return _smithy.isa(o, "InternalServerException");
+    return __isa(o, "InternalServerException");
   }
 }
 
@@ -495,7 +498,7 @@ export namespace InternalServerException {
  * <p>Indicates that something is wrong with the input to the request. For example, a required parameter may be missing or out of range.</p>
  */
 export interface InvalidRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidRequestException";
   $fault: "client";
@@ -509,7 +512,7 @@ export interface InvalidRequestException
 
 export namespace InvalidRequestException {
   export function isa(o: any): o is InvalidRequestException {
-    return _smithy.isa(o, "InvalidRequestException");
+    return __isa(o, "InvalidRequestException");
   }
 }
 
@@ -533,7 +536,7 @@ export interface ListNamedQueriesInput {
 
 export namespace ListNamedQueriesInput {
   export function isa(o: any): o is ListNamedQueriesInput {
-    return _smithy.isa(o, "ListNamedQueriesInput");
+    return __isa(o, "ListNamedQueriesInput");
   }
 }
 
@@ -552,7 +555,7 @@ export interface ListNamedQueriesOutput extends $MetadataBearer {
 
 export namespace ListNamedQueriesOutput {
   export function isa(o: any): o is ListNamedQueriesOutput {
-    return _smithy.isa(o, "ListNamedQueriesOutput");
+    return __isa(o, "ListNamedQueriesOutput");
   }
 }
 
@@ -576,7 +579,7 @@ export interface ListQueryExecutionsInput {
 
 export namespace ListQueryExecutionsInput {
   export function isa(o: any): o is ListQueryExecutionsInput {
-    return _smithy.isa(o, "ListQueryExecutionsInput");
+    return __isa(o, "ListQueryExecutionsInput");
   }
 }
 
@@ -595,7 +598,7 @@ export interface ListQueryExecutionsOutput extends $MetadataBearer {
 
 export namespace ListQueryExecutionsOutput {
   export function isa(o: any): o is ListQueryExecutionsOutput {
-    return _smithy.isa(o, "ListQueryExecutionsOutput");
+    return __isa(o, "ListQueryExecutionsOutput");
   }
 }
 
@@ -619,7 +622,7 @@ export interface ListTagsForResourceInput {
 
 export namespace ListTagsForResourceInput {
   export function isa(o: any): o is ListTagsForResourceInput {
-    return _smithy.isa(o, "ListTagsForResourceInput");
+    return __isa(o, "ListTagsForResourceInput");
   }
 }
 
@@ -638,7 +641,7 @@ export interface ListTagsForResourceOutput extends $MetadataBearer {
 
 export namespace ListTagsForResourceOutput {
   export function isa(o: any): o is ListTagsForResourceOutput {
-    return _smithy.isa(o, "ListTagsForResourceOutput");
+    return __isa(o, "ListTagsForResourceOutput");
   }
 }
 
@@ -657,7 +660,7 @@ export interface ListWorkGroupsInput {
 
 export namespace ListWorkGroupsInput {
   export function isa(o: any): o is ListWorkGroupsInput {
-    return _smithy.isa(o, "ListWorkGroupsInput");
+    return __isa(o, "ListWorkGroupsInput");
   }
 }
 
@@ -676,7 +679,7 @@ export interface ListWorkGroupsOutput extends $MetadataBearer {
 
 export namespace ListWorkGroupsOutput {
   export function isa(o: any): o is ListWorkGroupsOutput {
-    return _smithy.isa(o, "ListWorkGroupsOutput");
+    return __isa(o, "ListWorkGroupsOutput");
   }
 }
 
@@ -718,7 +721,7 @@ export interface NamedQuery {
 
 export namespace NamedQuery {
   export function isa(o: any): o is NamedQuery {
-    return _smithy.isa(o, "NamedQuery");
+    return __isa(o, "NamedQuery");
   }
 }
 
@@ -779,7 +782,7 @@ export interface QueryExecution {
 
 export namespace QueryExecution {
   export function isa(o: any): o is QueryExecution {
-    return _smithy.isa(o, "QueryExecution");
+    return __isa(o, "QueryExecution");
   }
 }
 
@@ -796,7 +799,7 @@ export interface QueryExecutionContext {
 
 export namespace QueryExecutionContext {
   export function isa(o: any): o is QueryExecutionContext {
-    return _smithy.isa(o, "QueryExecutionContext");
+    return __isa(o, "QueryExecutionContext");
   }
 }
 
@@ -852,7 +855,7 @@ export interface QueryExecutionStatistics {
 
 export namespace QueryExecutionStatistics {
   export function isa(o: any): o is QueryExecutionStatistics {
-    return _smithy.isa(o, "QueryExecutionStatistics");
+    return __isa(o, "QueryExecutionStatistics");
   }
 }
 
@@ -889,7 +892,7 @@ export interface QueryExecutionStatus {
 
 export namespace QueryExecutionStatus {
   export function isa(o: any): o is QueryExecutionStatus {
-    return _smithy.isa(o, "QueryExecutionStatus");
+    return __isa(o, "QueryExecutionStatus");
   }
 }
 
@@ -897,7 +900,7 @@ export namespace QueryExecutionStatus {
  * <p>A resource, such as a workgroup, was not found.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -907,7 +910,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -943,7 +946,7 @@ export interface ResultConfiguration {
 
 export namespace ResultConfiguration {
   export function isa(o: any): o is ResultConfiguration {
-    return _smithy.isa(o, "ResultConfiguration");
+    return __isa(o, "ResultConfiguration");
   }
 }
 
@@ -984,7 +987,7 @@ export interface ResultConfigurationUpdates {
 
 export namespace ResultConfigurationUpdates {
   export function isa(o: any): o is ResultConfigurationUpdates {
-    return _smithy.isa(o, "ResultConfigurationUpdates");
+    return __isa(o, "ResultConfigurationUpdates");
   }
 }
 
@@ -1006,7 +1009,7 @@ export interface ResultSet {
 
 export namespace ResultSet {
   export function isa(o: any): o is ResultSet {
-    return _smithy.isa(o, "ResultSet");
+    return __isa(o, "ResultSet");
   }
 }
 
@@ -1024,7 +1027,7 @@ export interface ResultSetMetadata {
 
 export namespace ResultSetMetadata {
   export function isa(o: any): o is ResultSetMetadata {
-    return _smithy.isa(o, "ResultSetMetadata");
+    return __isa(o, "ResultSetMetadata");
   }
 }
 
@@ -1041,7 +1044,7 @@ export interface Row {
 
 export namespace Row {
   export function isa(o: any): o is Row {
-    return _smithy.isa(o, "Row");
+    return __isa(o, "Row");
   }
 }
 
@@ -1080,7 +1083,7 @@ export interface StartQueryExecutionInput {
 
 export namespace StartQueryExecutionInput {
   export function isa(o: any): o is StartQueryExecutionInput {
-    return _smithy.isa(o, "StartQueryExecutionInput");
+    return __isa(o, "StartQueryExecutionInput");
   }
 }
 
@@ -1094,7 +1097,7 @@ export interface StartQueryExecutionOutput extends $MetadataBearer {
 
 export namespace StartQueryExecutionOutput {
   export function isa(o: any): o is StartQueryExecutionOutput {
-    return _smithy.isa(o, "StartQueryExecutionOutput");
+    return __isa(o, "StartQueryExecutionOutput");
   }
 }
 
@@ -1114,7 +1117,7 @@ export interface StopQueryExecutionInput {
 
 export namespace StopQueryExecutionInput {
   export function isa(o: any): o is StopQueryExecutionInput {
-    return _smithy.isa(o, "StopQueryExecutionInput");
+    return __isa(o, "StopQueryExecutionInput");
   }
 }
 
@@ -1124,7 +1127,7 @@ export interface StopQueryExecutionOutput extends $MetadataBearer {
 
 export namespace StopQueryExecutionOutput {
   export function isa(o: any): o is StopQueryExecutionOutput {
-    return _smithy.isa(o, "StopQueryExecutionOutput");
+    return __isa(o, "StopQueryExecutionOutput");
   }
 }
 
@@ -1153,7 +1156,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -1172,7 +1175,7 @@ export interface TagResourceInput {
 
 export namespace TagResourceInput {
   export function isa(o: any): o is TagResourceInput {
-    return _smithy.isa(o, "TagResourceInput");
+    return __isa(o, "TagResourceInput");
   }
 }
 
@@ -1182,7 +1185,7 @@ export interface TagResourceOutput extends $MetadataBearer {
 
 export namespace TagResourceOutput {
   export function isa(o: any): o is TagResourceOutput {
-    return _smithy.isa(o, "TagResourceOutput");
+    return __isa(o, "TagResourceOutput");
   }
 }
 
@@ -1194,7 +1197,7 @@ export enum ThrottleReason {
  * <p>Indicates that the request was throttled.</p>
  */
 export interface TooManyRequestsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyRequestsException";
   $fault: "client";
@@ -1207,7 +1210,7 @@ export interface TooManyRequestsException
 
 export namespace TooManyRequestsException {
   export function isa(o: any): o is TooManyRequestsException {
-    return _smithy.isa(o, "TooManyRequestsException");
+    return __isa(o, "TooManyRequestsException");
   }
 }
 
@@ -1234,7 +1237,7 @@ export interface UnprocessedNamedQueryId {
 
 export namespace UnprocessedNamedQueryId {
   export function isa(o: any): o is UnprocessedNamedQueryId {
-    return _smithy.isa(o, "UnprocessedNamedQueryId");
+    return __isa(o, "UnprocessedNamedQueryId");
   }
 }
 
@@ -1261,7 +1264,7 @@ export interface UnprocessedQueryExecutionId {
 
 export namespace UnprocessedQueryExecutionId {
   export function isa(o: any): o is UnprocessedQueryExecutionId {
-    return _smithy.isa(o, "UnprocessedQueryExecutionId");
+    return __isa(o, "UnprocessedQueryExecutionId");
   }
 }
 
@@ -1280,7 +1283,7 @@ export interface UntagResourceInput {
 
 export namespace UntagResourceInput {
   export function isa(o: any): o is UntagResourceInput {
-    return _smithy.isa(o, "UntagResourceInput");
+    return __isa(o, "UntagResourceInput");
   }
 }
 
@@ -1290,7 +1293,7 @@ export interface UntagResourceOutput extends $MetadataBearer {
 
 export namespace UntagResourceOutput {
   export function isa(o: any): o is UntagResourceOutput {
-    return _smithy.isa(o, "UntagResourceOutput");
+    return __isa(o, "UntagResourceOutput");
   }
 }
 
@@ -1319,7 +1322,7 @@ export interface UpdateWorkGroupInput {
 
 export namespace UpdateWorkGroupInput {
   export function isa(o: any): o is UpdateWorkGroupInput {
-    return _smithy.isa(o, "UpdateWorkGroupInput");
+    return __isa(o, "UpdateWorkGroupInput");
   }
 }
 
@@ -1329,7 +1332,7 @@ export interface UpdateWorkGroupOutput extends $MetadataBearer {
 
 export namespace UpdateWorkGroupOutput {
   export function isa(o: any): o is UpdateWorkGroupOutput {
-    return _smithy.isa(o, "UpdateWorkGroupOutput");
+    return __isa(o, "UpdateWorkGroupOutput");
   }
 }
 
@@ -1377,7 +1380,7 @@ export interface WorkGroup {
 
 export namespace WorkGroup {
   export function isa(o: any): o is WorkGroup {
-    return _smithy.isa(o, "WorkGroup");
+    return __isa(o, "WorkGroup");
   }
 }
 
@@ -1425,7 +1428,7 @@ export interface WorkGroupConfiguration {
 
 export namespace WorkGroupConfiguration {
   export function isa(o: any): o is WorkGroupConfiguration {
-    return _smithy.isa(o, "WorkGroupConfiguration");
+    return __isa(o, "WorkGroupConfiguration");
   }
 }
 
@@ -1474,7 +1477,7 @@ export interface WorkGroupConfigurationUpdates {
 
 export namespace WorkGroupConfigurationUpdates {
   export function isa(o: any): o is WorkGroupConfigurationUpdates {
-    return _smithy.isa(o, "WorkGroupConfigurationUpdates");
+    return __isa(o, "WorkGroupConfigurationUpdates");
   }
 }
 
@@ -1512,6 +1515,6 @@ export interface WorkGroupSummary {
 
 export namespace WorkGroupSummary {
   export function isa(o: any): o is WorkGroupSummary {
-    return _smithy.isa(o, "WorkGroupSummary");
+    return __isa(o, "WorkGroupSummary");
   }
 }

--- a/clients/client-auto-scaling-plans/models/index.ts
+++ b/clients/client-auto-scaling-plans/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -19,7 +22,7 @@ export interface ApplicationSource {
 
 export namespace ApplicationSource {
   export function isa(o: any): o is ApplicationSource {
-    return _smithy.isa(o, "ApplicationSource");
+    return __isa(o, "ApplicationSource");
   }
 }
 
@@ -28,7 +31,7 @@ export namespace ApplicationSource {
  *          scaling plan that already has a pending update.</p>
  */
 export interface ConcurrentUpdateException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ConcurrentUpdateException";
   $fault: "server";
@@ -37,7 +40,7 @@ export interface ConcurrentUpdateException
 
 export namespace ConcurrentUpdateException {
   export function isa(o: any): o is ConcurrentUpdateException {
-    return _smithy.isa(o, "ConcurrentUpdateException");
+    return __isa(o, "ConcurrentUpdateException");
   }
 }
 
@@ -63,7 +66,7 @@ export interface CreateScalingPlanRequest {
 
 export namespace CreateScalingPlanRequest {
   export function isa(o: any): o is CreateScalingPlanRequest {
-    return _smithy.isa(o, "CreateScalingPlanRequest");
+    return __isa(o, "CreateScalingPlanRequest");
   }
 }
 
@@ -78,7 +81,7 @@ export interface CreateScalingPlanResponse extends $MetadataBearer {
 
 export namespace CreateScalingPlanResponse {
   export function isa(o: any): o is CreateScalingPlanResponse {
-    return _smithy.isa(o, "CreateScalingPlanResponse");
+    return __isa(o, "CreateScalingPlanResponse");
   }
 }
 
@@ -134,7 +137,7 @@ export interface CustomizedLoadMetricSpecification {
 
 export namespace CustomizedLoadMetricSpecification {
   export function isa(o: any): o is CustomizedLoadMetricSpecification {
-    return _smithy.isa(o, "CustomizedLoadMetricSpecification");
+    return __isa(o, "CustomizedLoadMetricSpecification");
   }
 }
 
@@ -190,7 +193,7 @@ export interface CustomizedScalingMetricSpecification {
 
 export namespace CustomizedScalingMetricSpecification {
   export function isa(o: any): o is CustomizedScalingMetricSpecification {
-    return _smithy.isa(o, "CustomizedScalingMetricSpecification");
+    return __isa(o, "CustomizedScalingMetricSpecification");
   }
 }
 
@@ -212,7 +215,7 @@ export interface Datapoint {
 
 export namespace Datapoint {
   export function isa(o: any): o is Datapoint {
-    return _smithy.isa(o, "Datapoint");
+    return __isa(o, "Datapoint");
   }
 }
 
@@ -231,7 +234,7 @@ export interface DeleteScalingPlanRequest {
 
 export namespace DeleteScalingPlanRequest {
   export function isa(o: any): o is DeleteScalingPlanRequest {
-    return _smithy.isa(o, "DeleteScalingPlanRequest");
+    return __isa(o, "DeleteScalingPlanRequest");
   }
 }
 
@@ -241,7 +244,7 @@ export interface DeleteScalingPlanResponse extends $MetadataBearer {
 
 export namespace DeleteScalingPlanResponse {
   export function isa(o: any): o is DeleteScalingPlanResponse {
-    return _smithy.isa(o, "DeleteScalingPlanResponse");
+    return __isa(o, "DeleteScalingPlanResponse");
   }
 }
 
@@ -271,7 +274,7 @@ export interface DescribeScalingPlanResourcesRequest {
 
 export namespace DescribeScalingPlanResourcesRequest {
   export function isa(o: any): o is DescribeScalingPlanResourcesRequest {
-    return _smithy.isa(o, "DescribeScalingPlanResourcesRequest");
+    return __isa(o, "DescribeScalingPlanResourcesRequest");
   }
 }
 
@@ -291,7 +294,7 @@ export interface DescribeScalingPlanResourcesResponse extends $MetadataBearer {
 
 export namespace DescribeScalingPlanResourcesResponse {
   export function isa(o: any): o is DescribeScalingPlanResourcesResponse {
-    return _smithy.isa(o, "DescribeScalingPlanResourcesResponse");
+    return __isa(o, "DescribeScalingPlanResourcesResponse");
   }
 }
 
@@ -329,7 +332,7 @@ export interface DescribeScalingPlansRequest {
 
 export namespace DescribeScalingPlansRequest {
   export function isa(o: any): o is DescribeScalingPlansRequest {
-    return _smithy.isa(o, "DescribeScalingPlansRequest");
+    return __isa(o, "DescribeScalingPlansRequest");
   }
 }
 
@@ -349,7 +352,7 @@ export interface DescribeScalingPlansResponse extends $MetadataBearer {
 
 export namespace DescribeScalingPlansResponse {
   export function isa(o: any): o is DescribeScalingPlansResponse {
-    return _smithy.isa(o, "DescribeScalingPlansResponse");
+    return __isa(o, "DescribeScalingPlansResponse");
   }
 }
 
@@ -459,7 +462,7 @@ export interface GetScalingPlanResourceForecastDataRequest {
 
 export namespace GetScalingPlanResourceForecastDataRequest {
   export function isa(o: any): o is GetScalingPlanResourceForecastDataRequest {
-    return _smithy.isa(o, "GetScalingPlanResourceForecastDataRequest");
+    return __isa(o, "GetScalingPlanResourceForecastDataRequest");
   }
 }
 
@@ -474,7 +477,7 @@ export interface GetScalingPlanResourceForecastDataResponse
 
 export namespace GetScalingPlanResourceForecastDataResponse {
   export function isa(o: any): o is GetScalingPlanResourceForecastDataResponse {
-    return _smithy.isa(o, "GetScalingPlanResourceForecastDataResponse");
+    return __isa(o, "GetScalingPlanResourceForecastDataResponse");
   }
 }
 
@@ -482,7 +485,7 @@ export namespace GetScalingPlanResourceForecastDataResponse {
  * <p>The service encountered an internal error.</p>
  */
 export interface InternalServiceException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalServiceException";
   $fault: "server";
@@ -491,7 +494,7 @@ export interface InternalServiceException
 
 export namespace InternalServiceException {
   export function isa(o: any): o is InternalServiceException {
-    return _smithy.isa(o, "InternalServiceException");
+    return __isa(o, "InternalServiceException");
   }
 }
 
@@ -499,7 +502,7 @@ export namespace InternalServiceException {
  * <p>The token provided is not valid.</p>
  */
 export interface InvalidNextTokenException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidNextTokenException";
   $fault: "client";
@@ -508,7 +511,7 @@ export interface InvalidNextTokenException
 
 export namespace InvalidNextTokenException {
   export function isa(o: any): o is InvalidNextTokenException {
-    return _smithy.isa(o, "InvalidNextTokenException");
+    return __isa(o, "InvalidNextTokenException");
   }
 }
 
@@ -517,7 +520,7 @@ export namespace InvalidNextTokenException {
  *          limit is exceeded.</p>
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -526,7 +529,7 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
@@ -555,7 +558,7 @@ export interface MetricDimension {
 
 export namespace MetricDimension {
   export function isa(o: any): o is MetricDimension {
-    return _smithy.isa(o, "MetricDimension");
+    return __isa(o, "MetricDimension");
   }
 }
 
@@ -571,7 +574,7 @@ export enum MetricStatistic {
  * <p>The specified object could not be found.</p>
  */
 export interface ObjectNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ObjectNotFoundException";
   $fault: "client";
@@ -580,7 +583,7 @@ export interface ObjectNotFoundException
 
 export namespace ObjectNotFoundException {
   export function isa(o: any): o is ObjectNotFoundException {
-    return _smithy.isa(o, "ObjectNotFoundException");
+    return __isa(o, "ObjectNotFoundException");
   }
 }
 
@@ -621,7 +624,7 @@ export interface PredefinedLoadMetricSpecification {
 
 export namespace PredefinedLoadMetricSpecification {
   export function isa(o: any): o is PredefinedLoadMetricSpecification {
-    return _smithy.isa(o, "PredefinedLoadMetricSpecification");
+    return __isa(o, "PredefinedLoadMetricSpecification");
   }
 }
 
@@ -661,7 +664,7 @@ export interface PredefinedScalingMetricSpecification {
 
 export namespace PredefinedScalingMetricSpecification {
   export function isa(o: any): o is PredefinedScalingMetricSpecification {
-    return _smithy.isa(o, "PredefinedScalingMetricSpecification");
+    return __isa(o, "PredefinedScalingMetricSpecification");
   }
 }
 
@@ -908,7 +911,7 @@ export interface ScalingInstruction {
 
 export namespace ScalingInstruction {
   export function isa(o: any): o is ScalingInstruction {
-    return _smithy.isa(o, "ScalingInstruction");
+    return __isa(o, "ScalingInstruction");
   }
 }
 
@@ -1011,7 +1014,7 @@ export interface ScalingPlan {
 
 export namespace ScalingPlan {
   export function isa(o: any): o is ScalingPlan {
-    return _smithy.isa(o, "ScalingPlan");
+    return __isa(o, "ScalingPlan");
   }
 }
 
@@ -1142,7 +1145,7 @@ export interface ScalingPlanResource {
 
 export namespace ScalingPlanResource {
   export function isa(o: any): o is ScalingPlanResource {
-    return _smithy.isa(o, "ScalingPlanResource");
+    return __isa(o, "ScalingPlanResource");
   }
 }
 
@@ -1181,7 +1184,7 @@ export interface ScalingPolicy {
 
 export namespace ScalingPolicy {
   export function isa(o: any): o is ScalingPolicy {
-    return _smithy.isa(o, "ScalingPolicy");
+    return __isa(o, "ScalingPolicy");
   }
 }
 
@@ -1222,7 +1225,7 @@ export interface TagFilter {
 
 export namespace TagFilter {
   export function isa(o: any): o is TagFilter {
-    return _smithy.isa(o, "TagFilter");
+    return __isa(o, "TagFilter");
   }
 }
 
@@ -1289,7 +1292,7 @@ export interface TargetTrackingConfiguration {
 
 export namespace TargetTrackingConfiguration {
   export function isa(o: any): o is TargetTrackingConfiguration {
-    return _smithy.isa(o, "TargetTrackingConfiguration");
+    return __isa(o, "TargetTrackingConfiguration");
   }
 }
 
@@ -1318,7 +1321,7 @@ export interface UpdateScalingPlanRequest {
 
 export namespace UpdateScalingPlanRequest {
   export function isa(o: any): o is UpdateScalingPlanRequest {
-    return _smithy.isa(o, "UpdateScalingPlanRequest");
+    return __isa(o, "UpdateScalingPlanRequest");
   }
 }
 
@@ -1328,7 +1331,7 @@ export interface UpdateScalingPlanResponse extends $MetadataBearer {
 
 export namespace UpdateScalingPlanResponse {
   export function isa(o: any): o is UpdateScalingPlanResponse {
-    return _smithy.isa(o, "UpdateScalingPlanResponse");
+    return __isa(o, "UpdateScalingPlanResponse");
   }
 }
 
@@ -1336,7 +1339,7 @@ export namespace UpdateScalingPlanResponse {
  * <p>An exception was thrown for a validation issue. Review the parameters provided.</p>
  */
 export interface ValidationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ValidationException";
   $fault: "client";
@@ -1345,6 +1348,6 @@ export interface ValidationException
 
 export namespace ValidationException {
   export function isa(o: any): o is ValidationException {
-    return _smithy.isa(o, "ValidationException");
+    return __isa(o, "ValidationException");
   }
 }

--- a/clients/client-auto-scaling/models/index.ts
+++ b/clients/client-auto-scaling/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export interface ActivitiesType extends $MetadataBearer {
@@ -20,7 +23,7 @@ export interface ActivitiesType extends $MetadataBearer {
 
 export namespace ActivitiesType {
   export function isa(o: any): o is ActivitiesType {
-    return _smithy.isa(o, "ActivitiesType");
+    return __isa(o, "ActivitiesType");
   }
 }
 
@@ -83,7 +86,7 @@ export interface Activity {
 
 export namespace Activity {
   export function isa(o: any): o is Activity {
-    return _smithy.isa(o, "Activity");
+    return __isa(o, "Activity");
   }
 }
 
@@ -97,7 +100,7 @@ export interface ActivityType extends $MetadataBearer {
 
 export namespace ActivityType {
   export function isa(o: any): o is ActivityType {
-    return _smithy.isa(o, "ActivityType");
+    return __isa(o, "ActivityType");
   }
 }
 
@@ -115,7 +118,7 @@ export interface AdjustmentType {
 
 export namespace AdjustmentType {
   export function isa(o: any): o is AdjustmentType {
-    return _smithy.isa(o, "AdjustmentType");
+    return __isa(o, "AdjustmentType");
   }
 }
 
@@ -137,16 +140,14 @@ export interface Alarm {
 
 export namespace Alarm {
   export function isa(o: any): o is Alarm {
-    return _smithy.isa(o, "Alarm");
+    return __isa(o, "Alarm");
   }
 }
 
 /**
  * <p>You already have an Auto Scaling group or launch configuration with this name.</p>
  */
-export interface AlreadyExistsFault
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface AlreadyExistsFault extends __SmithyException, $MetadataBearer {
   name: "AlreadyExistsFault";
   $fault: "client";
   /**
@@ -157,7 +158,7 @@ export interface AlreadyExistsFault
 
 export namespace AlreadyExistsFault {
   export function isa(o: any): o is AlreadyExistsFault {
-    return _smithy.isa(o, "AlreadyExistsFault");
+    return __isa(o, "AlreadyExistsFault");
   }
 }
 
@@ -176,7 +177,7 @@ export interface AttachInstancesQuery {
 
 export namespace AttachInstancesQuery {
   export function isa(o: any): o is AttachInstancesQuery {
-    return _smithy.isa(o, "AttachInstancesQuery");
+    return __isa(o, "AttachInstancesQuery");
   }
 }
 
@@ -187,7 +188,7 @@ export interface AttachLoadBalancerTargetGroupsResultType
 
 export namespace AttachLoadBalancerTargetGroupsResultType {
   export function isa(o: any): o is AttachLoadBalancerTargetGroupsResultType {
-    return _smithy.isa(o, "AttachLoadBalancerTargetGroupsResultType");
+    return __isa(o, "AttachLoadBalancerTargetGroupsResultType");
   }
 }
 
@@ -207,7 +208,7 @@ export interface AttachLoadBalancerTargetGroupsType {
 
 export namespace AttachLoadBalancerTargetGroupsType {
   export function isa(o: any): o is AttachLoadBalancerTargetGroupsType {
-    return _smithy.isa(o, "AttachLoadBalancerTargetGroupsType");
+    return __isa(o, "AttachLoadBalancerTargetGroupsType");
   }
 }
 
@@ -217,7 +218,7 @@ export interface AttachLoadBalancersResultType extends $MetadataBearer {
 
 export namespace AttachLoadBalancersResultType {
   export function isa(o: any): o is AttachLoadBalancersResultType {
-    return _smithy.isa(o, "AttachLoadBalancersResultType");
+    return __isa(o, "AttachLoadBalancersResultType");
   }
 }
 
@@ -236,7 +237,7 @@ export interface AttachLoadBalancersType {
 
 export namespace AttachLoadBalancersType {
   export function isa(o: any): o is AttachLoadBalancersType {
-    return _smithy.isa(o, "AttachLoadBalancersType");
+    return __isa(o, "AttachLoadBalancersType");
   }
 }
 
@@ -387,7 +388,7 @@ export interface AutoScalingGroup {
 
 export namespace AutoScalingGroup {
   export function isa(o: any): o is AutoScalingGroup {
-    return _smithy.isa(o, "AutoScalingGroup");
+    return __isa(o, "AutoScalingGroup");
   }
 }
 
@@ -416,7 +417,7 @@ export interface AutoScalingGroupNamesType {
 
 export namespace AutoScalingGroupNamesType {
   export function isa(o: any): o is AutoScalingGroupNamesType {
-    return _smithy.isa(o, "AutoScalingGroupNamesType");
+    return __isa(o, "AutoScalingGroupNamesType");
   }
 }
 
@@ -438,7 +439,7 @@ export interface AutoScalingGroupsType extends $MetadataBearer {
 
 export namespace AutoScalingGroupsType {
   export function isa(o: any): o is AutoScalingGroupsType {
-    return _smithy.isa(o, "AutoScalingGroupsType");
+    return __isa(o, "AutoScalingGroupsType");
   }
 }
 
@@ -505,7 +506,7 @@ export interface AutoScalingInstanceDetails {
 
 export namespace AutoScalingInstanceDetails {
   export function isa(o: any): o is AutoScalingInstanceDetails {
-    return _smithy.isa(o, "AutoScalingInstanceDetails");
+    return __isa(o, "AutoScalingInstanceDetails");
   }
 }
 
@@ -527,7 +528,7 @@ export interface AutoScalingInstancesType extends $MetadataBearer {
 
 export namespace AutoScalingInstancesType {
   export function isa(o: any): o is AutoScalingInstancesType {
-    return _smithy.isa(o, "AutoScalingInstancesType");
+    return __isa(o, "AutoScalingInstancesType");
   }
 }
 
@@ -542,7 +543,7 @@ export interface BatchDeleteScheduledActionAnswer extends $MetadataBearer {
 
 export namespace BatchDeleteScheduledActionAnswer {
   export function isa(o: any): o is BatchDeleteScheduledActionAnswer {
-    return _smithy.isa(o, "BatchDeleteScheduledActionAnswer");
+    return __isa(o, "BatchDeleteScheduledActionAnswer");
   }
 }
 
@@ -562,7 +563,7 @@ export interface BatchDeleteScheduledActionType {
 
 export namespace BatchDeleteScheduledActionType {
   export function isa(o: any): o is BatchDeleteScheduledActionType {
-    return _smithy.isa(o, "BatchDeleteScheduledActionType");
+    return __isa(o, "BatchDeleteScheduledActionType");
   }
 }
 
@@ -580,7 +581,7 @@ export interface BatchPutScheduledUpdateGroupActionAnswer
 
 export namespace BatchPutScheduledUpdateGroupActionAnswer {
   export function isa(o: any): o is BatchPutScheduledUpdateGroupActionAnswer {
-    return _smithy.isa(o, "BatchPutScheduledUpdateGroupActionAnswer");
+    return __isa(o, "BatchPutScheduledUpdateGroupActionAnswer");
   }
 }
 
@@ -601,7 +602,7 @@ export interface BatchPutScheduledUpdateGroupActionType {
 
 export namespace BatchPutScheduledUpdateGroupActionType {
   export function isa(o: any): o is BatchPutScheduledUpdateGroupActionType {
-    return _smithy.isa(o, "BatchPutScheduledUpdateGroupActionType");
+    return __isa(o, "BatchPutScheduledUpdateGroupActionType");
   }
 }
 
@@ -638,7 +639,7 @@ export interface BlockDeviceMapping {
 
 export namespace BlockDeviceMapping {
   export function isa(o: any): o is BlockDeviceMapping {
-    return _smithy.isa(o, "BlockDeviceMapping");
+    return __isa(o, "BlockDeviceMapping");
   }
 }
 
@@ -648,7 +649,7 @@ export interface CompleteLifecycleActionAnswer extends $MetadataBearer {
 
 export namespace CompleteLifecycleActionAnswer {
   export function isa(o: any): o is CompleteLifecycleActionAnswer {
-    return _smithy.isa(o, "CompleteLifecycleActionAnswer");
+    return __isa(o, "CompleteLifecycleActionAnswer");
   }
 }
 
@@ -685,7 +686,7 @@ export interface CompleteLifecycleActionType {
 
 export namespace CompleteLifecycleActionType {
   export function isa(o: any): o is CompleteLifecycleActionType {
-    return _smithy.isa(o, "CompleteLifecycleActionType");
+    return __isa(o, "CompleteLifecycleActionType");
   }
 }
 
@@ -888,7 +889,7 @@ export interface CreateAutoScalingGroupType {
 
 export namespace CreateAutoScalingGroupType {
   export function isa(o: any): o is CreateAutoScalingGroupType {
-    return _smithy.isa(o, "CreateAutoScalingGroupType");
+    return __isa(o, "CreateAutoScalingGroupType");
   }
 }
 
@@ -1080,7 +1081,7 @@ export interface CreateLaunchConfigurationType {
 
 export namespace CreateLaunchConfigurationType {
   export function isa(o: any): o is CreateLaunchConfigurationType {
-    return _smithy.isa(o, "CreateLaunchConfigurationType");
+    return __isa(o, "CreateLaunchConfigurationType");
   }
 }
 
@@ -1094,7 +1095,7 @@ export interface CreateOrUpdateTagsType {
 
 export namespace CreateOrUpdateTagsType {
   export function isa(o: any): o is CreateOrUpdateTagsType {
-    return _smithy.isa(o, "CreateOrUpdateTagsType");
+    return __isa(o, "CreateOrUpdateTagsType");
   }
 }
 
@@ -1152,7 +1153,7 @@ export interface CustomizedMetricSpecification {
 
 export namespace CustomizedMetricSpecification {
   export function isa(o: any): o is CustomizedMetricSpecification {
-    return _smithy.isa(o, "CustomizedMetricSpecification");
+    return __isa(o, "CustomizedMetricSpecification");
   }
 }
 
@@ -1173,7 +1174,7 @@ export interface DeleteAutoScalingGroupType {
 
 export namespace DeleteAutoScalingGroupType {
   export function isa(o: any): o is DeleteAutoScalingGroupType {
-    return _smithy.isa(o, "DeleteAutoScalingGroupType");
+    return __isa(o, "DeleteAutoScalingGroupType");
   }
 }
 
@@ -1183,7 +1184,7 @@ export interface DeleteLifecycleHookAnswer extends $MetadataBearer {
 
 export namespace DeleteLifecycleHookAnswer {
   export function isa(o: any): o is DeleteLifecycleHookAnswer {
-    return _smithy.isa(o, "DeleteLifecycleHookAnswer");
+    return __isa(o, "DeleteLifecycleHookAnswer");
   }
 }
 
@@ -1202,7 +1203,7 @@ export interface DeleteLifecycleHookType {
 
 export namespace DeleteLifecycleHookType {
   export function isa(o: any): o is DeleteLifecycleHookType {
-    return _smithy.isa(o, "DeleteLifecycleHookType");
+    return __isa(o, "DeleteLifecycleHookType");
   }
 }
 
@@ -1222,7 +1223,7 @@ export interface DeleteNotificationConfigurationType {
 
 export namespace DeleteNotificationConfigurationType {
   export function isa(o: any): o is DeleteNotificationConfigurationType {
-    return _smithy.isa(o, "DeleteNotificationConfigurationType");
+    return __isa(o, "DeleteNotificationConfigurationType");
   }
 }
 
@@ -1241,7 +1242,7 @@ export interface DeletePolicyType {
 
 export namespace DeletePolicyType {
   export function isa(o: any): o is DeletePolicyType {
-    return _smithy.isa(o, "DeletePolicyType");
+    return __isa(o, "DeletePolicyType");
   }
 }
 
@@ -1260,7 +1261,7 @@ export interface DeleteScheduledActionType {
 
 export namespace DeleteScheduledActionType {
   export function isa(o: any): o is DeleteScheduledActionType {
-    return _smithy.isa(o, "DeleteScheduledActionType");
+    return __isa(o, "DeleteScheduledActionType");
   }
 }
 
@@ -1274,7 +1275,7 @@ export interface DeleteTagsType {
 
 export namespace DeleteTagsType {
   export function isa(o: any): o is DeleteTagsType {
-    return _smithy.isa(o, "DeleteTagsType");
+    return __isa(o, "DeleteTagsType");
   }
 }
 
@@ -1305,7 +1306,7 @@ export interface DescribeAccountLimitsAnswer extends $MetadataBearer {
 
 export namespace DescribeAccountLimitsAnswer {
   export function isa(o: any): o is DescribeAccountLimitsAnswer {
-    return _smithy.isa(o, "DescribeAccountLimitsAnswer");
+    return __isa(o, "DescribeAccountLimitsAnswer");
   }
 }
 
@@ -1319,7 +1320,7 @@ export interface DescribeAdjustmentTypesAnswer extends $MetadataBearer {
 
 export namespace DescribeAdjustmentTypesAnswer {
   export function isa(o: any): o is DescribeAdjustmentTypesAnswer {
-    return _smithy.isa(o, "DescribeAdjustmentTypesAnswer");
+    return __isa(o, "DescribeAdjustmentTypesAnswer");
   }
 }
 
@@ -1347,7 +1348,7 @@ export interface DescribeAutoScalingInstancesType {
 
 export namespace DescribeAutoScalingInstancesType {
   export function isa(o: any): o is DescribeAutoScalingInstancesType {
-    return _smithy.isa(o, "DescribeAutoScalingInstancesType");
+    return __isa(o, "DescribeAutoScalingInstancesType");
   }
 }
 
@@ -1362,7 +1363,7 @@ export interface DescribeAutoScalingNotificationTypesAnswer
 
 export namespace DescribeAutoScalingNotificationTypesAnswer {
   export function isa(o: any): o is DescribeAutoScalingNotificationTypesAnswer {
-    return _smithy.isa(o, "DescribeAutoScalingNotificationTypesAnswer");
+    return __isa(o, "DescribeAutoScalingNotificationTypesAnswer");
   }
 }
 
@@ -1376,7 +1377,7 @@ export interface DescribeLifecycleHookTypesAnswer extends $MetadataBearer {
 
 export namespace DescribeLifecycleHookTypesAnswer {
   export function isa(o: any): o is DescribeLifecycleHookTypesAnswer {
-    return _smithy.isa(o, "DescribeLifecycleHookTypesAnswer");
+    return __isa(o, "DescribeLifecycleHookTypesAnswer");
   }
 }
 
@@ -1390,7 +1391,7 @@ export interface DescribeLifecycleHooksAnswer extends $MetadataBearer {
 
 export namespace DescribeLifecycleHooksAnswer {
   export function isa(o: any): o is DescribeLifecycleHooksAnswer {
-    return _smithy.isa(o, "DescribeLifecycleHooksAnswer");
+    return __isa(o, "DescribeLifecycleHooksAnswer");
   }
 }
 
@@ -1410,7 +1411,7 @@ export interface DescribeLifecycleHooksType {
 
 export namespace DescribeLifecycleHooksType {
   export function isa(o: any): o is DescribeLifecycleHooksType {
-    return _smithy.isa(o, "DescribeLifecycleHooksType");
+    return __isa(o, "DescribeLifecycleHooksType");
   }
 }
 
@@ -1436,7 +1437,7 @@ export interface DescribeLoadBalancerTargetGroupsRequest {
 
 export namespace DescribeLoadBalancerTargetGroupsRequest {
   export function isa(o: any): o is DescribeLoadBalancerTargetGroupsRequest {
-    return _smithy.isa(o, "DescribeLoadBalancerTargetGroupsRequest");
+    return __isa(o, "DescribeLoadBalancerTargetGroupsRequest");
   }
 }
 
@@ -1459,7 +1460,7 @@ export interface DescribeLoadBalancerTargetGroupsResponse
 
 export namespace DescribeLoadBalancerTargetGroupsResponse {
   export function isa(o: any): o is DescribeLoadBalancerTargetGroupsResponse {
-    return _smithy.isa(o, "DescribeLoadBalancerTargetGroupsResponse");
+    return __isa(o, "DescribeLoadBalancerTargetGroupsResponse");
   }
 }
 
@@ -1485,7 +1486,7 @@ export interface DescribeLoadBalancersRequest {
 
 export namespace DescribeLoadBalancersRequest {
   export function isa(o: any): o is DescribeLoadBalancersRequest {
-    return _smithy.isa(o, "DescribeLoadBalancersRequest");
+    return __isa(o, "DescribeLoadBalancersRequest");
   }
 }
 
@@ -1507,7 +1508,7 @@ export interface DescribeLoadBalancersResponse extends $MetadataBearer {
 
 export namespace DescribeLoadBalancersResponse {
   export function isa(o: any): o is DescribeLoadBalancersResponse {
-    return _smithy.isa(o, "DescribeLoadBalancersResponse");
+    return __isa(o, "DescribeLoadBalancersResponse");
   }
 }
 
@@ -1526,7 +1527,7 @@ export interface DescribeMetricCollectionTypesAnswer extends $MetadataBearer {
 
 export namespace DescribeMetricCollectionTypesAnswer {
   export function isa(o: any): o is DescribeMetricCollectionTypesAnswer {
-    return _smithy.isa(o, "DescribeMetricCollectionTypesAnswer");
+    return __isa(o, "DescribeMetricCollectionTypesAnswer");
   }
 }
 
@@ -1549,7 +1550,7 @@ export interface DescribeNotificationConfigurationsAnswer
 
 export namespace DescribeNotificationConfigurationsAnswer {
   export function isa(o: any): o is DescribeNotificationConfigurationsAnswer {
-    return _smithy.isa(o, "DescribeNotificationConfigurationsAnswer");
+    return __isa(o, "DescribeNotificationConfigurationsAnswer");
   }
 }
 
@@ -1575,7 +1576,7 @@ export interface DescribeNotificationConfigurationsType {
 
 export namespace DescribeNotificationConfigurationsType {
   export function isa(o: any): o is DescribeNotificationConfigurationsType {
-    return _smithy.isa(o, "DescribeNotificationConfigurationsType");
+    return __isa(o, "DescribeNotificationConfigurationsType");
   }
 }
 
@@ -1615,7 +1616,7 @@ export interface DescribePoliciesType {
 
 export namespace DescribePoliciesType {
   export function isa(o: any): o is DescribePoliciesType {
-    return _smithy.isa(o, "DescribePoliciesType");
+    return __isa(o, "DescribePoliciesType");
   }
 }
 
@@ -1649,7 +1650,7 @@ export interface DescribeScalingActivitiesType {
 
 export namespace DescribeScalingActivitiesType {
   export function isa(o: any): o is DescribeScalingActivitiesType {
-    return _smithy.isa(o, "DescribeScalingActivitiesType");
+    return __isa(o, "DescribeScalingActivitiesType");
   }
 }
 
@@ -1694,7 +1695,7 @@ export interface DescribeScheduledActionsType {
 
 export namespace DescribeScheduledActionsType {
   export function isa(o: any): o is DescribeScheduledActionsType {
-    return _smithy.isa(o, "DescribeScheduledActionsType");
+    return __isa(o, "DescribeScheduledActionsType");
   }
 }
 
@@ -1721,7 +1722,7 @@ export interface DescribeTagsType {
 
 export namespace DescribeTagsType {
   export function isa(o: any): o is DescribeTagsType {
-    return _smithy.isa(o, "DescribeTagsType");
+    return __isa(o, "DescribeTagsType");
   }
 }
 
@@ -1738,7 +1739,7 @@ export interface DescribeTerminationPolicyTypesAnswer extends $MetadataBearer {
 
 export namespace DescribeTerminationPolicyTypesAnswer {
   export function isa(o: any): o is DescribeTerminationPolicyTypesAnswer {
-    return _smithy.isa(o, "DescribeTerminationPolicyTypesAnswer");
+    return __isa(o, "DescribeTerminationPolicyTypesAnswer");
   }
 }
 
@@ -1752,7 +1753,7 @@ export interface DetachInstancesAnswer extends $MetadataBearer {
 
 export namespace DetachInstancesAnswer {
   export function isa(o: any): o is DetachInstancesAnswer {
-    return _smithy.isa(o, "DetachInstancesAnswer");
+    return __isa(o, "DetachInstancesAnswer");
   }
 }
 
@@ -1777,7 +1778,7 @@ export interface DetachInstancesQuery {
 
 export namespace DetachInstancesQuery {
   export function isa(o: any): o is DetachInstancesQuery {
-    return _smithy.isa(o, "DetachInstancesQuery");
+    return __isa(o, "DetachInstancesQuery");
   }
 }
 
@@ -1788,7 +1789,7 @@ export interface DetachLoadBalancerTargetGroupsResultType
 
 export namespace DetachLoadBalancerTargetGroupsResultType {
   export function isa(o: any): o is DetachLoadBalancerTargetGroupsResultType {
-    return _smithy.isa(o, "DetachLoadBalancerTargetGroupsResultType");
+    return __isa(o, "DetachLoadBalancerTargetGroupsResultType");
   }
 }
 
@@ -1808,7 +1809,7 @@ export interface DetachLoadBalancerTargetGroupsType {
 
 export namespace DetachLoadBalancerTargetGroupsType {
   export function isa(o: any): o is DetachLoadBalancerTargetGroupsType {
-    return _smithy.isa(o, "DetachLoadBalancerTargetGroupsType");
+    return __isa(o, "DetachLoadBalancerTargetGroupsType");
   }
 }
 
@@ -1818,7 +1819,7 @@ export interface DetachLoadBalancersResultType extends $MetadataBearer {
 
 export namespace DetachLoadBalancersResultType {
   export function isa(o: any): o is DetachLoadBalancersResultType {
-    return _smithy.isa(o, "DetachLoadBalancersResultType");
+    return __isa(o, "DetachLoadBalancersResultType");
   }
 }
 
@@ -1837,7 +1838,7 @@ export interface DetachLoadBalancersType {
 
 export namespace DetachLoadBalancersType {
   export function isa(o: any): o is DetachLoadBalancersType {
-    return _smithy.isa(o, "DetachLoadBalancersType");
+    return __isa(o, "DetachLoadBalancersType");
   }
 }
 
@@ -1899,7 +1900,7 @@ export interface DisableMetricsCollectionQuery {
 
 export namespace DisableMetricsCollectionQuery {
   export function isa(o: any): o is DisableMetricsCollectionQuery {
-    return _smithy.isa(o, "DisableMetricsCollectionQuery");
+    return __isa(o, "DisableMetricsCollectionQuery");
   }
 }
 
@@ -1988,7 +1989,7 @@ export interface Ebs {
 
 export namespace Ebs {
   export function isa(o: any): o is Ebs {
-    return _smithy.isa(o, "Ebs");
+    return __isa(o, "Ebs");
   }
 }
 
@@ -2056,7 +2057,7 @@ export interface EnableMetricsCollectionQuery {
 
 export namespace EnableMetricsCollectionQuery {
   export function isa(o: any): o is EnableMetricsCollectionQuery {
-    return _smithy.isa(o, "EnableMetricsCollectionQuery");
+    return __isa(o, "EnableMetricsCollectionQuery");
   }
 }
 
@@ -2120,7 +2121,7 @@ export interface EnabledMetric {
 
 export namespace EnabledMetric {
   export function isa(o: any): o is EnabledMetric {
-    return _smithy.isa(o, "EnabledMetric");
+    return __isa(o, "EnabledMetric");
   }
 }
 
@@ -2134,7 +2135,7 @@ export interface EnterStandbyAnswer extends $MetadataBearer {
 
 export namespace EnterStandbyAnswer {
   export function isa(o: any): o is EnterStandbyAnswer {
-    return _smithy.isa(o, "EnterStandbyAnswer");
+    return __isa(o, "EnterStandbyAnswer");
   }
 }
 
@@ -2159,7 +2160,7 @@ export interface EnterStandbyQuery {
 
 export namespace EnterStandbyQuery {
   export function isa(o: any): o is EnterStandbyQuery {
-    return _smithy.isa(o, "EnterStandbyQuery");
+    return __isa(o, "EnterStandbyQuery");
   }
 }
 
@@ -2208,7 +2209,7 @@ export interface ExecutePolicyType {
 
 export namespace ExecutePolicyType {
   export function isa(o: any): o is ExecutePolicyType {
-    return _smithy.isa(o, "ExecutePolicyType");
+    return __isa(o, "ExecutePolicyType");
   }
 }
 
@@ -2222,7 +2223,7 @@ export interface ExitStandbyAnswer extends $MetadataBearer {
 
 export namespace ExitStandbyAnswer {
   export function isa(o: any): o is ExitStandbyAnswer {
-    return _smithy.isa(o, "ExitStandbyAnswer");
+    return __isa(o, "ExitStandbyAnswer");
   }
 }
 
@@ -2241,7 +2242,7 @@ export interface ExitStandbyQuery {
 
 export namespace ExitStandbyQuery {
   export function isa(o: any): o is ExitStandbyQuery {
-    return _smithy.isa(o, "ExitStandbyQuery");
+    return __isa(o, "ExitStandbyQuery");
   }
 }
 
@@ -2268,7 +2269,7 @@ export interface FailedScheduledUpdateGroupActionRequest {
 
 export namespace FailedScheduledUpdateGroupActionRequest {
   export function isa(o: any): o is FailedScheduledUpdateGroupActionRequest {
-    return _smithy.isa(o, "FailedScheduledUpdateGroupActionRequest");
+    return __isa(o, "FailedScheduledUpdateGroupActionRequest");
   }
 }
 
@@ -2292,7 +2293,7 @@ export interface Filter {
 
 export namespace Filter {
   export function isa(o: any): o is Filter {
-    return _smithy.isa(o, "Filter");
+    return __isa(o, "Filter");
   }
 }
 
@@ -2354,7 +2355,7 @@ export interface Instance {
 
 export namespace Instance {
   export function isa(o: any): o is Instance {
-    return _smithy.isa(o, "Instance");
+    return __isa(o, "Instance");
   }
 }
 
@@ -2372,7 +2373,7 @@ export interface InstanceMonitoring {
 
 export namespace InstanceMonitoring {
   export function isa(o: any): o is InstanceMonitoring {
-    return _smithy.isa(o, "InstanceMonitoring");
+    return __isa(o, "InstanceMonitoring");
   }
 }
 
@@ -2468,16 +2469,14 @@ export interface InstancesDistribution {
 
 export namespace InstancesDistribution {
   export function isa(o: any): o is InstancesDistribution {
-    return _smithy.isa(o, "InstancesDistribution");
+    return __isa(o, "InstancesDistribution");
   }
 }
 
 /**
  * <p>The <code>NextToken</code> value is not valid.</p>
  */
-export interface InvalidNextToken
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface InvalidNextToken extends __SmithyException, $MetadataBearer {
   name: "InvalidNextToken";
   $fault: "client";
   /**
@@ -2488,7 +2487,7 @@ export interface InvalidNextToken
 
 export namespace InvalidNextToken {
   export function isa(o: any): o is InvalidNextToken {
-    return _smithy.isa(o, "InvalidNextToken");
+    return __isa(o, "InvalidNextToken");
   }
 }
 
@@ -2641,7 +2640,7 @@ export interface LaunchConfiguration {
 
 export namespace LaunchConfiguration {
   export function isa(o: any): o is LaunchConfiguration {
-    return _smithy.isa(o, "LaunchConfiguration");
+    return __isa(o, "LaunchConfiguration");
   }
 }
 
@@ -2655,7 +2654,7 @@ export interface LaunchConfigurationNameType {
 
 export namespace LaunchConfigurationNameType {
   export function isa(o: any): o is LaunchConfigurationNameType {
-    return _smithy.isa(o, "LaunchConfigurationNameType");
+    return __isa(o, "LaunchConfigurationNameType");
   }
 }
 
@@ -2682,7 +2681,7 @@ export interface LaunchConfigurationNamesType {
 
 export namespace LaunchConfigurationNamesType {
   export function isa(o: any): o is LaunchConfigurationNamesType {
-    return _smithy.isa(o, "LaunchConfigurationNamesType");
+    return __isa(o, "LaunchConfigurationNamesType");
   }
 }
 
@@ -2704,7 +2703,7 @@ export interface LaunchConfigurationsType extends $MetadataBearer {
 
 export namespace LaunchConfigurationsType {
   export function isa(o: any): o is LaunchConfigurationsType {
-    return _smithy.isa(o, "LaunchConfigurationsType");
+    return __isa(o, "LaunchConfigurationsType");
   }
 }
 
@@ -2736,7 +2735,7 @@ export interface LaunchTemplate {
 
 export namespace LaunchTemplate {
   export function isa(o: any): o is LaunchTemplate {
-    return _smithy.isa(o, "LaunchTemplate");
+    return __isa(o, "LaunchTemplate");
   }
 }
 
@@ -2767,7 +2766,7 @@ export interface LaunchTemplateOverrides {
 
 export namespace LaunchTemplateOverrides {
   export function isa(o: any): o is LaunchTemplateOverrides {
-    return _smithy.isa(o, "LaunchTemplateOverrides");
+    return __isa(o, "LaunchTemplateOverrides");
   }
 }
 
@@ -2803,7 +2802,7 @@ export interface LaunchTemplateSpecification {
 
 export namespace LaunchTemplateSpecification {
   export function isa(o: any): o is LaunchTemplateSpecification {
-    return _smithy.isa(o, "LaunchTemplateSpecification");
+    return __isa(o, "LaunchTemplateSpecification");
   }
 }
 
@@ -2881,7 +2880,7 @@ export interface LifecycleHook {
 
 export namespace LifecycleHook {
   export function isa(o: any): o is LifecycleHook {
-    return _smithy.isa(o, "LifecycleHook");
+    return __isa(o, "LifecycleHook");
   }
 }
 
@@ -2983,7 +2982,7 @@ export interface LifecycleHookSpecification {
 
 export namespace LifecycleHookSpecification {
   export function isa(o: any): o is LifecycleHookSpecification {
-    return _smithy.isa(o, "LifecycleHookSpecification");
+    return __isa(o, "LifecycleHookSpecification");
   }
 }
 
@@ -3007,9 +3006,7 @@ export enum LifecycleState {
  * <p>You have already reached a limit for your Amazon EC2 Auto Scaling resources (for example, Auto Scaling
  *             groups, launch configurations, or lifecycle hooks). For more information, see <a>DescribeAccountLimits</a>.</p>
  */
-export interface LimitExceededFault
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface LimitExceededFault extends __SmithyException, $MetadataBearer {
   name: "LimitExceededFault";
   $fault: "client";
   /**
@@ -3020,7 +3017,7 @@ export interface LimitExceededFault
 
 export namespace LimitExceededFault {
   export function isa(o: any): o is LimitExceededFault {
-    return _smithy.isa(o, "LimitExceededFault");
+    return __isa(o, "LimitExceededFault");
   }
 }
 
@@ -3080,7 +3077,7 @@ export interface LoadBalancerState {
 
 export namespace LoadBalancerState {
   export function isa(o: any): o is LoadBalancerState {
-    return _smithy.isa(o, "LoadBalancerState");
+    return __isa(o, "LoadBalancerState");
   }
 }
 
@@ -3136,7 +3133,7 @@ export interface LoadBalancerTargetGroupState {
 
 export namespace LoadBalancerTargetGroupState {
   export function isa(o: any): o is LoadBalancerTargetGroupState {
-    return _smithy.isa(o, "LoadBalancerTargetGroupState");
+    return __isa(o, "LoadBalancerTargetGroupState");
   }
 }
 
@@ -3195,7 +3192,7 @@ export interface MetricCollectionType {
 
 export namespace MetricCollectionType {
   export function isa(o: any): o is MetricCollectionType {
-    return _smithy.isa(o, "MetricCollectionType");
+    return __isa(o, "MetricCollectionType");
   }
 }
 
@@ -3217,7 +3214,7 @@ export interface MetricDimension {
 
 export namespace MetricDimension {
   export function isa(o: any): o is MetricDimension {
-    return _smithy.isa(o, "MetricDimension");
+    return __isa(o, "MetricDimension");
   }
 }
 
@@ -3234,7 +3231,7 @@ export interface MetricGranularityType {
 
 export namespace MetricGranularityType {
   export function isa(o: any): o is MetricGranularityType {
-    return _smithy.isa(o, "MetricGranularityType");
+    return __isa(o, "MetricGranularityType");
   }
 }
 
@@ -3282,7 +3279,7 @@ export interface MixedInstancesPolicy {
 
 export namespace MixedInstancesPolicy {
   export function isa(o: any): o is MixedInstancesPolicy {
-    return _smithy.isa(o, "MixedInstancesPolicy");
+    return __isa(o, "MixedInstancesPolicy");
   }
 }
 
@@ -3337,7 +3334,7 @@ export interface NotificationConfiguration {
 
 export namespace NotificationConfiguration {
   export function isa(o: any): o is NotificationConfiguration {
-    return _smithy.isa(o, "NotificationConfiguration");
+    return __isa(o, "NotificationConfiguration");
   }
 }
 
@@ -3359,7 +3356,7 @@ export interface PoliciesType extends $MetadataBearer {
 
 export namespace PoliciesType {
   export function isa(o: any): o is PoliciesType {
-    return _smithy.isa(o, "PoliciesType");
+    return __isa(o, "PoliciesType");
   }
 }
 
@@ -3381,7 +3378,7 @@ export interface PolicyARNType extends $MetadataBearer {
 
 export namespace PolicyARNType {
   export function isa(o: any): o is PolicyARNType {
-    return _smithy.isa(o, "PolicyARNType");
+    return __isa(o, "PolicyARNType");
   }
 }
 
@@ -3443,7 +3440,7 @@ export interface PredefinedMetricSpecification {
 
 export namespace PredefinedMetricSpecification {
   export function isa(o: any): o is PredefinedMetricSpecification {
-    return _smithy.isa(o, "PredefinedMetricSpecification");
+    return __isa(o, "PredefinedMetricSpecification");
   }
 }
 
@@ -3503,7 +3500,7 @@ export interface ProcessType {
 
 export namespace ProcessType {
   export function isa(o: any): o is ProcessType {
-    return _smithy.isa(o, "ProcessType");
+    return __isa(o, "ProcessType");
   }
 }
 
@@ -3517,7 +3514,7 @@ export interface ProcessesType extends $MetadataBearer {
 
 export namespace ProcessesType {
   export function isa(o: any): o is ProcessesType {
-    return _smithy.isa(o, "ProcessesType");
+    return __isa(o, "ProcessesType");
   }
 }
 
@@ -3527,7 +3524,7 @@ export interface PutLifecycleHookAnswer extends $MetadataBearer {
 
 export namespace PutLifecycleHookAnswer {
   export function isa(o: any): o is PutLifecycleHookAnswer {
-    return _smithy.isa(o, "PutLifecycleHookAnswer");
+    return __isa(o, "PutLifecycleHookAnswer");
   }
 }
 
@@ -3607,7 +3604,7 @@ export interface PutLifecycleHookType {
 
 export namespace PutLifecycleHookType {
   export function isa(o: any): o is PutLifecycleHookType {
-    return _smithy.isa(o, "PutLifecycleHookType");
+    return __isa(o, "PutLifecycleHookType");
   }
 }
 
@@ -3633,7 +3630,7 @@ export interface PutNotificationConfigurationType {
 
 export namespace PutNotificationConfigurationType {
   export function isa(o: any): o is PutNotificationConfigurationType {
-    return _smithy.isa(o, "PutNotificationConfigurationType");
+    return __isa(o, "PutNotificationConfigurationType");
   }
 }
 
@@ -3747,7 +3744,7 @@ export interface PutScalingPolicyType {
 
 export namespace PutScalingPolicyType {
   export function isa(o: any): o is PutScalingPolicyType {
-    return _smithy.isa(o, "PutScalingPolicyType");
+    return __isa(o, "PutScalingPolicyType");
   }
 }
 
@@ -3814,7 +3811,7 @@ export interface PutScheduledUpdateGroupActionType {
 
 export namespace PutScheduledUpdateGroupActionType {
   export function isa(o: any): o is PutScheduledUpdateGroupActionType {
-    return _smithy.isa(o, "PutScheduledUpdateGroupActionType");
+    return __isa(o, "PutScheduledUpdateGroupActionType");
   }
 }
 
@@ -3824,7 +3821,7 @@ export interface RecordLifecycleActionHeartbeatAnswer extends $MetadataBearer {
 
 export namespace RecordLifecycleActionHeartbeatAnswer {
   export function isa(o: any): o is RecordLifecycleActionHeartbeatAnswer {
-    return _smithy.isa(o, "RecordLifecycleActionHeartbeatAnswer");
+    return __isa(o, "RecordLifecycleActionHeartbeatAnswer");
   }
 }
 
@@ -3855,7 +3852,7 @@ export interface RecordLifecycleActionHeartbeatType {
 
 export namespace RecordLifecycleActionHeartbeatType {
   export function isa(o: any): o is RecordLifecycleActionHeartbeatType {
-    return _smithy.isa(o, "RecordLifecycleActionHeartbeatType");
+    return __isa(o, "RecordLifecycleActionHeartbeatType");
   }
 }
 
@@ -3864,7 +3861,7 @@ export namespace RecordLifecycleActionHeartbeatType {
  *             instance, or load balancer).</p>
  */
 export interface ResourceContentionFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceContentionFault";
   $fault: "server";
@@ -3876,16 +3873,14 @@ export interface ResourceContentionFault
 
 export namespace ResourceContentionFault {
   export function isa(o: any): o is ResourceContentionFault {
-    return _smithy.isa(o, "ResourceContentionFault");
+    return __isa(o, "ResourceContentionFault");
   }
 }
 
 /**
  * <p>The operation can't be performed because the resource is in use.</p>
  */
-export interface ResourceInUseFault
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface ResourceInUseFault extends __SmithyException, $MetadataBearer {
   name: "ResourceInUseFault";
   $fault: "client";
   /**
@@ -3896,7 +3891,7 @@ export interface ResourceInUseFault
 
 export namespace ResourceInUseFault {
   export function isa(o: any): o is ResourceInUseFault {
-    return _smithy.isa(o, "ResourceInUseFault");
+    return __isa(o, "ResourceInUseFault");
   }
 }
 
@@ -3905,7 +3900,7 @@ export namespace ResourceInUseFault {
  *             progress.</p>
  */
 export interface ScalingActivityInProgressFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ScalingActivityInProgressFault";
   $fault: "client";
@@ -3917,7 +3912,7 @@ export interface ScalingActivityInProgressFault
 
 export namespace ScalingActivityInProgressFault {
   export function isa(o: any): o is ScalingActivityInProgressFault {
-    return _smithy.isa(o, "ScalingActivityInProgressFault");
+    return __isa(o, "ScalingActivityInProgressFault");
   }
 }
 
@@ -4027,7 +4022,7 @@ export interface ScalingPolicy {
 
 export namespace ScalingPolicy {
   export function isa(o: any): o is ScalingPolicy {
-    return _smithy.isa(o, "ScalingPolicy");
+    return __isa(o, "ScalingPolicy");
   }
 }
 
@@ -4089,7 +4084,7 @@ export interface ScalingProcessQuery {
 
 export namespace ScalingProcessQuery {
   export function isa(o: any): o is ScalingProcessQuery {
-    return _smithy.isa(o, "ScalingProcessQuery");
+    return __isa(o, "ScalingProcessQuery");
   }
 }
 
@@ -4111,7 +4106,7 @@ export interface ScheduledActionsType extends $MetadataBearer {
 
 export namespace ScheduledActionsType {
   export function isa(o: any): o is ScheduledActionsType {
-    return _smithy.isa(o, "ScheduledActionsType");
+    return __isa(o, "ScheduledActionsType");
   }
 }
 
@@ -4180,7 +4175,7 @@ export interface ScheduledUpdateGroupAction {
 
 export namespace ScheduledUpdateGroupAction {
   export function isa(o: any): o is ScheduledUpdateGroupAction {
-    return _smithy.isa(o, "ScheduledUpdateGroupAction");
+    return __isa(o, "ScheduledUpdateGroupAction");
   }
 }
 
@@ -4243,7 +4238,7 @@ export interface ScheduledUpdateGroupActionRequest {
 
 export namespace ScheduledUpdateGroupActionRequest {
   export function isa(o: any): o is ScheduledUpdateGroupActionRequest {
-    return _smithy.isa(o, "ScheduledUpdateGroupActionRequest");
+    return __isa(o, "ScheduledUpdateGroupActionRequest");
   }
 }
 
@@ -4251,7 +4246,7 @@ export namespace ScheduledUpdateGroupActionRequest {
  * <p>The service-linked role is not yet ready for use.</p>
  */
 export interface ServiceLinkedRoleFailure
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ServiceLinkedRoleFailure";
   $fault: "server";
@@ -4260,7 +4255,7 @@ export interface ServiceLinkedRoleFailure
 
 export namespace ServiceLinkedRoleFailure {
   export function isa(o: any): o is ServiceLinkedRoleFailure {
-    return _smithy.isa(o, "ServiceLinkedRoleFailure");
+    return __isa(o, "ServiceLinkedRoleFailure");
   }
 }
 
@@ -4286,7 +4281,7 @@ export interface SetDesiredCapacityType {
 
 export namespace SetDesiredCapacityType {
   export function isa(o: any): o is SetDesiredCapacityType {
-    return _smithy.isa(o, "SetDesiredCapacityType");
+    return __isa(o, "SetDesiredCapacityType");
   }
 }
 
@@ -4316,7 +4311,7 @@ export interface SetInstanceHealthQuery {
 
 export namespace SetInstanceHealthQuery {
   export function isa(o: any): o is SetInstanceHealthQuery {
-    return _smithy.isa(o, "SetInstanceHealthQuery");
+    return __isa(o, "SetInstanceHealthQuery");
   }
 }
 
@@ -4326,7 +4321,7 @@ export interface SetInstanceProtectionAnswer extends $MetadataBearer {
 
 export namespace SetInstanceProtectionAnswer {
   export function isa(o: any): o is SetInstanceProtectionAnswer {
-    return _smithy.isa(o, "SetInstanceProtectionAnswer");
+    return __isa(o, "SetInstanceProtectionAnswer");
   }
 }
 
@@ -4351,7 +4346,7 @@ export interface SetInstanceProtectionQuery {
 
 export namespace SetInstanceProtectionQuery {
   export function isa(o: any): o is SetInstanceProtectionQuery {
-    return _smithy.isa(o, "SetInstanceProtectionQuery");
+    return __isa(o, "SetInstanceProtectionQuery");
   }
 }
 
@@ -4422,7 +4417,7 @@ export interface StepAdjustment {
 
 export namespace StepAdjustment {
   export function isa(o: any): o is StepAdjustment {
-    return _smithy.isa(o, "StepAdjustment");
+    return __isa(o, "StepAdjustment");
   }
 }
 
@@ -4445,7 +4440,7 @@ export interface SuspendedProcess {
 
 export namespace SuspendedProcess {
   export function isa(o: any): o is SuspendedProcess {
-    return _smithy.isa(o, "SuspendedProcess");
+    return __isa(o, "SuspendedProcess");
   }
 }
 
@@ -4484,7 +4479,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -4523,7 +4518,7 @@ export interface TagDescription {
 
 export namespace TagDescription {
   export function isa(o: any): o is TagDescription {
-    return _smithy.isa(o, "TagDescription");
+    return __isa(o, "TagDescription");
   }
 }
 
@@ -4545,7 +4540,7 @@ export interface TagsType extends $MetadataBearer {
 
 export namespace TagsType {
   export function isa(o: any): o is TagsType {
-    return _smithy.isa(o, "TagsType");
+    return __isa(o, "TagsType");
   }
 }
 
@@ -4582,7 +4577,7 @@ export interface TargetTrackingConfiguration {
 
 export namespace TargetTrackingConfiguration {
   export function isa(o: any): o is TargetTrackingConfiguration {
-    return _smithy.isa(o, "TargetTrackingConfiguration");
+    return __isa(o, "TargetTrackingConfiguration");
   }
 }
 
@@ -4602,7 +4597,7 @@ export interface TerminateInstanceInAutoScalingGroupType {
 
 export namespace TerminateInstanceInAutoScalingGroupType {
   export function isa(o: any): o is TerminateInstanceInAutoScalingGroupType {
-    return _smithy.isa(o, "TerminateInstanceInAutoScalingGroupType");
+    return __isa(o, "TerminateInstanceInAutoScalingGroupType");
   }
 }
 
@@ -4744,6 +4739,6 @@ export interface UpdateAutoScalingGroupType {
 
 export namespace UpdateAutoScalingGroupType {
   export function isa(o: any): o is UpdateAutoScalingGroupType {
-    return _smithy.isa(o, "UpdateAutoScalingGroupType");
+    return __isa(o, "UpdateAutoScalingGroupType");
   }
 }

--- a/clients/client-auto-scaling/protocols/Aws_query.ts
+++ b/clients/client-auto-scaling/protocols/Aws_query.ts
@@ -1264,6 +1264,7 @@ export async function deserializeAws_queryAttachInstancesCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_queryAttachInstancesCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: AttachInstancesCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1654,6 +1655,7 @@ export async function deserializeAws_queryCreateAutoScalingGroupCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: CreateAutoScalingGroupCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1728,6 +1730,7 @@ export async function deserializeAws_queryCreateLaunchConfigurationCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: CreateLaunchConfigurationCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1792,6 +1795,7 @@ export async function deserializeAws_queryCreateOrUpdateTagsCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_queryCreateOrUpdateTagsCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: CreateOrUpdateTagsCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1866,6 +1870,7 @@ export async function deserializeAws_queryDeleteAutoScalingGroupCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteAutoScalingGroupCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1933,6 +1938,7 @@ export async function deserializeAws_queryDeleteLaunchConfigurationCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteLaunchConfigurationCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2051,6 +2057,7 @@ export async function deserializeAws_queryDeleteNotificationConfigurationCommand
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteNotificationConfigurationCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2101,6 +2108,7 @@ export async function deserializeAws_queryDeletePolicyCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_queryDeletePolicyCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeletePolicyCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2161,6 +2169,7 @@ export async function deserializeAws_queryDeleteScheduledActionCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteScheduledActionCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2211,6 +2220,7 @@ export async function deserializeAws_queryDeleteTagsCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_queryDeleteTagsCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteTagsCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -3600,6 +3610,7 @@ export async function deserializeAws_queryDisableMetricsCollectionCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DisableMetricsCollectionCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -3653,6 +3664,7 @@ export async function deserializeAws_queryEnableMetricsCollectionCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: EnableMetricsCollectionCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -3761,6 +3773,7 @@ export async function deserializeAws_queryExecutePolicyCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_queryExecutePolicyCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: ExecutePolicyCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -3944,6 +3957,7 @@ export async function deserializeAws_queryPutNotificationConfigurationCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: PutNotificationConfigurationCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -4083,6 +4097,7 @@ export async function deserializeAws_queryPutScheduledUpdateGroupActionCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: PutScheduledUpdateGroupActionCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -4208,6 +4223,7 @@ export async function deserializeAws_queryResumeProcessesCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_queryResumeProcessesCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: ResumeProcessesCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -4265,6 +4281,7 @@ export async function deserializeAws_querySetDesiredCapacityCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_querySetDesiredCapacityCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: SetDesiredCapacityCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -4322,6 +4339,7 @@ export async function deserializeAws_querySetInstanceHealthCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_querySetInstanceHealthCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: SetInstanceHealthCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -4440,6 +4458,7 @@ export async function deserializeAws_querySuspendProcessesCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_querySuspendProcessesCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: SuspendProcessesCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -4568,6 +4587,7 @@ export async function deserializeAws_queryUpdateAutoScalingGroupCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: UpdateAutoScalingGroupCommandOutput = {
     $metadata: deserializeMetadata(output)
   };

--- a/clients/client-backup/models/index.ts
+++ b/clients/client-backup/models/index.ts
@@ -1,11 +1,14 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
  * <p>The required resource already exists.</p>
  */
 export interface AlreadyExistsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AlreadyExistsException";
   $fault: "client";
@@ -34,7 +37,7 @@ export interface AlreadyExistsException
 
 export namespace AlreadyExistsException {
   export function isa(o: any): o is AlreadyExistsException {
-    return _smithy.isa(o, "AlreadyExistsException");
+    return __isa(o, "AlreadyExistsException");
   }
 }
 
@@ -155,7 +158,7 @@ export interface BackupJob {
 
 export namespace BackupJob {
   export function isa(o: any): o is BackupJob {
-    return _smithy.isa(o, "BackupJob");
+    return __isa(o, "BackupJob");
   }
 }
 
@@ -191,7 +194,7 @@ export interface BackupPlan {
 
 export namespace BackupPlan {
   export function isa(o: any): o is BackupPlan {
-    return _smithy.isa(o, "BackupPlan");
+    return __isa(o, "BackupPlan");
   }
 }
 
@@ -216,7 +219,7 @@ export interface BackupPlanInput {
 
 export namespace BackupPlanInput {
   export function isa(o: any): o is BackupPlanInput {
-    return _smithy.isa(o, "BackupPlanInput");
+    return __isa(o, "BackupPlanInput");
   }
 }
 
@@ -238,7 +241,7 @@ export interface BackupPlanTemplatesListMember {
 
 export namespace BackupPlanTemplatesListMember {
   export function isa(o: any): o is BackupPlanTemplatesListMember {
-    return _smithy.isa(o, "BackupPlanTemplatesListMember");
+    return __isa(o, "BackupPlanTemplatesListMember");
   }
 }
 
@@ -302,7 +305,7 @@ export interface BackupPlansListMember {
 
 export namespace BackupPlansListMember {
   export function isa(o: any): o is BackupPlansListMember {
-    return _smithy.isa(o, "BackupPlansListMember");
+    return __isa(o, "BackupPlansListMember");
   }
 }
 
@@ -371,7 +374,7 @@ export interface BackupRule {
 
 export namespace BackupRule {
   export function isa(o: any): o is BackupRule {
-    return _smithy.isa(o, "BackupRule");
+    return __isa(o, "BackupRule");
   }
 }
 
@@ -433,7 +436,7 @@ export interface BackupRuleInput {
 
 export namespace BackupRuleInput {
   export function isa(o: any): o is BackupRuleInput {
-    return _smithy.isa(o, "BackupRuleInput");
+    return __isa(o, "BackupRuleInput");
   }
 }
 
@@ -469,7 +472,7 @@ export interface BackupSelection {
 
 export namespace BackupSelection {
   export function isa(o: any): o is BackupSelection {
-    return _smithy.isa(o, "BackupSelection");
+    return __isa(o, "BackupSelection");
   }
 }
 
@@ -516,7 +519,7 @@ export interface BackupSelectionsListMember {
 
 export namespace BackupSelectionsListMember {
   export function isa(o: any): o is BackupSelectionsListMember {
-    return _smithy.isa(o, "BackupSelectionsListMember");
+    return __isa(o, "BackupSelectionsListMember");
   }
 }
 
@@ -584,7 +587,7 @@ export interface BackupVaultListMember {
 
 export namespace BackupVaultListMember {
   export function isa(o: any): o is BackupVaultListMember {
-    return _smithy.isa(o, "BackupVaultListMember");
+    return __isa(o, "BackupVaultListMember");
   }
 }
 
@@ -614,7 +617,7 @@ export interface CalculatedLifecycle {
 
 export namespace CalculatedLifecycle {
   export function isa(o: any): o is CalculatedLifecycle {
-    return _smithy.isa(o, "CalculatedLifecycle");
+    return __isa(o, "CalculatedLifecycle");
   }
 }
 
@@ -646,7 +649,7 @@ export interface Condition {
 
 export namespace Condition {
   export function isa(o: any): o is Condition {
-    return _smithy.isa(o, "Condition");
+    return __isa(o, "Condition");
   }
 }
 
@@ -677,7 +680,7 @@ export interface CopyAction {
 
 export namespace CopyAction {
   export function isa(o: any): o is CopyAction {
-    return _smithy.isa(o, "CopyAction");
+    return __isa(o, "CopyAction");
   }
 }
 
@@ -760,7 +763,7 @@ export interface CopyJob {
 
 export namespace CopyJob {
   export function isa(o: any): o is CopyJob {
-    return _smithy.isa(o, "CopyJob");
+    return __isa(o, "CopyJob");
   }
 }
 
@@ -796,7 +799,7 @@ export interface CreateBackupPlanInput {
 
 export namespace CreateBackupPlanInput {
   export function isa(o: any): o is CreateBackupPlanInput {
-    return _smithy.isa(o, "CreateBackupPlanInput");
+    return __isa(o, "CreateBackupPlanInput");
   }
 }
 
@@ -830,7 +833,7 @@ export interface CreateBackupPlanOutput extends $MetadataBearer {
 
 export namespace CreateBackupPlanOutput {
   export function isa(o: any): o is CreateBackupPlanOutput {
-    return _smithy.isa(o, "CreateBackupPlanOutput");
+    return __isa(o, "CreateBackupPlanOutput");
   }
 }
 
@@ -856,7 +859,7 @@ export interface CreateBackupSelectionInput {
 
 export namespace CreateBackupSelectionInput {
   export function isa(o: any): o is CreateBackupSelectionInput {
-    return _smithy.isa(o, "CreateBackupSelectionInput");
+    return __isa(o, "CreateBackupSelectionInput");
   }
 }
 
@@ -884,7 +887,7 @@ export interface CreateBackupSelectionOutput extends $MetadataBearer {
 
 export namespace CreateBackupSelectionOutput {
   export function isa(o: any): o is CreateBackupSelectionOutput {
-    return _smithy.isa(o, "CreateBackupSelectionOutput");
+    return __isa(o, "CreateBackupSelectionOutput");
   }
 }
 
@@ -918,7 +921,7 @@ export interface CreateBackupVaultInput {
 
 export namespace CreateBackupVaultInput {
   export function isa(o: any): o is CreateBackupVaultInput {
-    return _smithy.isa(o, "CreateBackupVaultInput");
+    return __isa(o, "CreateBackupVaultInput");
   }
 }
 
@@ -948,7 +951,7 @@ export interface CreateBackupVaultOutput extends $MetadataBearer {
 
 export namespace CreateBackupVaultOutput {
   export function isa(o: any): o is CreateBackupVaultOutput {
-    return _smithy.isa(o, "CreateBackupVaultOutput");
+    return __isa(o, "CreateBackupVaultOutput");
   }
 }
 
@@ -962,7 +965,7 @@ export interface DeleteBackupPlanInput {
 
 export namespace DeleteBackupPlanInput {
   export function isa(o: any): o is DeleteBackupPlanInput {
-    return _smithy.isa(o, "DeleteBackupPlanInput");
+    return __isa(o, "DeleteBackupPlanInput");
   }
 }
 
@@ -996,7 +999,7 @@ export interface DeleteBackupPlanOutput extends $MetadataBearer {
 
 export namespace DeleteBackupPlanOutput {
   export function isa(o: any): o is DeleteBackupPlanOutput {
-    return _smithy.isa(o, "DeleteBackupPlanOutput");
+    return __isa(o, "DeleteBackupPlanOutput");
   }
 }
 
@@ -1016,7 +1019,7 @@ export interface DeleteBackupSelectionInput {
 
 export namespace DeleteBackupSelectionInput {
   export function isa(o: any): o is DeleteBackupSelectionInput {
-    return _smithy.isa(o, "DeleteBackupSelectionInput");
+    return __isa(o, "DeleteBackupSelectionInput");
   }
 }
 
@@ -1032,7 +1035,7 @@ export interface DeleteBackupVaultAccessPolicyInput {
 
 export namespace DeleteBackupVaultAccessPolicyInput {
   export function isa(o: any): o is DeleteBackupVaultAccessPolicyInput {
-    return _smithy.isa(o, "DeleteBackupVaultAccessPolicyInput");
+    return __isa(o, "DeleteBackupVaultAccessPolicyInput");
   }
 }
 
@@ -1048,7 +1051,7 @@ export interface DeleteBackupVaultInput {
 
 export namespace DeleteBackupVaultInput {
   export function isa(o: any): o is DeleteBackupVaultInput {
-    return _smithy.isa(o, "DeleteBackupVaultInput");
+    return __isa(o, "DeleteBackupVaultInput");
   }
 }
 
@@ -1064,7 +1067,7 @@ export interface DeleteBackupVaultNotificationsInput {
 
 export namespace DeleteBackupVaultNotificationsInput {
   export function isa(o: any): o is DeleteBackupVaultNotificationsInput {
-    return _smithy.isa(o, "DeleteBackupVaultNotificationsInput");
+    return __isa(o, "DeleteBackupVaultNotificationsInput");
   }
 }
 
@@ -1086,7 +1089,7 @@ export interface DeleteRecoveryPointInput {
 
 export namespace DeleteRecoveryPointInput {
   export function isa(o: any): o is DeleteRecoveryPointInput {
-    return _smithy.isa(o, "DeleteRecoveryPointInput");
+    return __isa(o, "DeleteRecoveryPointInput");
   }
 }
 
@@ -1095,7 +1098,7 @@ export namespace DeleteRecoveryPointInput {
  *          action cannot be completed.</p>
  */
 export interface DependencyFailureException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DependencyFailureException";
   $fault: "server";
@@ -1114,7 +1117,7 @@ export interface DependencyFailureException
 
 export namespace DependencyFailureException {
   export function isa(o: any): o is DependencyFailureException {
-    return _smithy.isa(o, "DependencyFailureException");
+    return __isa(o, "DependencyFailureException");
   }
 }
 
@@ -1128,7 +1131,7 @@ export interface DescribeBackupJobInput {
 
 export namespace DescribeBackupJobInput {
   export function isa(o: any): o is DescribeBackupJobInput {
-    return _smithy.isa(o, "DescribeBackupJobInput");
+    return __isa(o, "DescribeBackupJobInput");
   }
 }
 
@@ -1247,7 +1250,7 @@ export interface DescribeBackupJobOutput extends $MetadataBearer {
 
 export namespace DescribeBackupJobOutput {
   export function isa(o: any): o is DescribeBackupJobOutput {
-    return _smithy.isa(o, "DescribeBackupJobOutput");
+    return __isa(o, "DescribeBackupJobOutput");
   }
 }
 
@@ -1263,7 +1266,7 @@ export interface DescribeBackupVaultInput {
 
 export namespace DescribeBackupVaultInput {
   export function isa(o: any): o is DescribeBackupVaultInput {
-    return _smithy.isa(o, "DescribeBackupVaultInput");
+    return __isa(o, "DescribeBackupVaultInput");
   }
 }
 
@@ -1310,7 +1313,7 @@ export interface DescribeBackupVaultOutput extends $MetadataBearer {
 
 export namespace DescribeBackupVaultOutput {
   export function isa(o: any): o is DescribeBackupVaultOutput {
-    return _smithy.isa(o, "DescribeBackupVaultOutput");
+    return __isa(o, "DescribeBackupVaultOutput");
   }
 }
 
@@ -1324,7 +1327,7 @@ export interface DescribeCopyJobInput {
 
 export namespace DescribeCopyJobInput {
   export function isa(o: any): o is DescribeCopyJobInput {
-    return _smithy.isa(o, "DescribeCopyJobInput");
+    return __isa(o, "DescribeCopyJobInput");
   }
 }
 
@@ -1338,7 +1341,7 @@ export interface DescribeCopyJobOutput extends $MetadataBearer {
 
 export namespace DescribeCopyJobOutput {
   export function isa(o: any): o is DescribeCopyJobOutput {
-    return _smithy.isa(o, "DescribeCopyJobOutput");
+    return __isa(o, "DescribeCopyJobOutput");
   }
 }
 
@@ -1353,7 +1356,7 @@ export interface DescribeProtectedResourceInput {
 
 export namespace DescribeProtectedResourceInput {
   export function isa(o: any): o is DescribeProtectedResourceInput {
-    return _smithy.isa(o, "DescribeProtectedResourceInput");
+    return __isa(o, "DescribeProtectedResourceInput");
   }
 }
 
@@ -1382,7 +1385,7 @@ export interface DescribeProtectedResourceOutput extends $MetadataBearer {
 
 export namespace DescribeProtectedResourceOutput {
   export function isa(o: any): o is DescribeProtectedResourceOutput {
-    return _smithy.isa(o, "DescribeProtectedResourceOutput");
+    return __isa(o, "DescribeProtectedResourceOutput");
   }
 }
 
@@ -1404,7 +1407,7 @@ export interface DescribeRecoveryPointInput {
 
 export namespace DescribeRecoveryPointInput {
   export function isa(o: any): o is DescribeRecoveryPointInput {
-    return _smithy.isa(o, "DescribeRecoveryPointInput");
+    return __isa(o, "DescribeRecoveryPointInput");
   }
 }
 
@@ -1531,7 +1534,7 @@ export interface DescribeRecoveryPointOutput extends $MetadataBearer {
 
 export namespace DescribeRecoveryPointOutput {
   export function isa(o: any): o is DescribeRecoveryPointOutput {
-    return _smithy.isa(o, "DescribeRecoveryPointOutput");
+    return __isa(o, "DescribeRecoveryPointOutput");
   }
 }
 
@@ -1545,7 +1548,7 @@ export interface DescribeRestoreJobInput {
 
 export namespace DescribeRestoreJobInput {
   export function isa(o: any): o is DescribeRestoreJobInput {
-    return _smithy.isa(o, "DescribeRestoreJobInput");
+    return __isa(o, "DescribeRestoreJobInput");
   }
 }
 
@@ -1622,7 +1625,7 @@ export interface DescribeRestoreJobOutput extends $MetadataBearer {
 
 export namespace DescribeRestoreJobOutput {
   export function isa(o: any): o is DescribeRestoreJobOutput {
-    return _smithy.isa(o, "DescribeRestoreJobOutput");
+    return __isa(o, "DescribeRestoreJobOutput");
   }
 }
 
@@ -1636,7 +1639,7 @@ export interface ExportBackupPlanTemplateInput {
 
 export namespace ExportBackupPlanTemplateInput {
   export function isa(o: any): o is ExportBackupPlanTemplateInput {
-    return _smithy.isa(o, "ExportBackupPlanTemplateInput");
+    return __isa(o, "ExportBackupPlanTemplateInput");
   }
 }
 
@@ -1655,7 +1658,7 @@ export interface ExportBackupPlanTemplateOutput extends $MetadataBearer {
 
 export namespace ExportBackupPlanTemplateOutput {
   export function isa(o: any): o is ExportBackupPlanTemplateOutput {
-    return _smithy.isa(o, "ExportBackupPlanTemplateOutput");
+    return __isa(o, "ExportBackupPlanTemplateOutput");
   }
 }
 
@@ -1669,7 +1672,7 @@ export interface GetBackupPlanFromJSONInput {
 
 export namespace GetBackupPlanFromJSONInput {
   export function isa(o: any): o is GetBackupPlanFromJSONInput {
-    return _smithy.isa(o, "GetBackupPlanFromJSONInput");
+    return __isa(o, "GetBackupPlanFromJSONInput");
   }
 }
 
@@ -1684,7 +1687,7 @@ export interface GetBackupPlanFromJSONOutput extends $MetadataBearer {
 
 export namespace GetBackupPlanFromJSONOutput {
   export function isa(o: any): o is GetBackupPlanFromJSONOutput {
-    return _smithy.isa(o, "GetBackupPlanFromJSONOutput");
+    return __isa(o, "GetBackupPlanFromJSONOutput");
   }
 }
 
@@ -1698,7 +1701,7 @@ export interface GetBackupPlanFromTemplateInput {
 
 export namespace GetBackupPlanFromTemplateInput {
   export function isa(o: any): o is GetBackupPlanFromTemplateInput {
-    return _smithy.isa(o, "GetBackupPlanFromTemplateInput");
+    return __isa(o, "GetBackupPlanFromTemplateInput");
   }
 }
 
@@ -1713,7 +1716,7 @@ export interface GetBackupPlanFromTemplateOutput extends $MetadataBearer {
 
 export namespace GetBackupPlanFromTemplateOutput {
   export function isa(o: any): o is GetBackupPlanFromTemplateOutput {
-    return _smithy.isa(o, "GetBackupPlanFromTemplateOutput");
+    return __isa(o, "GetBackupPlanFromTemplateOutput");
   }
 }
 
@@ -1733,7 +1736,7 @@ export interface GetBackupPlanInput {
 
 export namespace GetBackupPlanInput {
   export function isa(o: any): o is GetBackupPlanInput {
-    return _smithy.isa(o, "GetBackupPlanInput");
+    return __isa(o, "GetBackupPlanInput");
   }
 }
 
@@ -1795,7 +1798,7 @@ export interface GetBackupPlanOutput extends $MetadataBearer {
 
 export namespace GetBackupPlanOutput {
   export function isa(o: any): o is GetBackupPlanOutput {
-    return _smithy.isa(o, "GetBackupPlanOutput");
+    return __isa(o, "GetBackupPlanOutput");
   }
 }
 
@@ -1815,7 +1818,7 @@ export interface GetBackupSelectionInput {
 
 export namespace GetBackupSelectionInput {
   export function isa(o: any): o is GetBackupSelectionInput {
-    return _smithy.isa(o, "GetBackupSelectionInput");
+    return __isa(o, "GetBackupSelectionInput");
   }
 }
 
@@ -1854,7 +1857,7 @@ export interface GetBackupSelectionOutput extends $MetadataBearer {
 
 export namespace GetBackupSelectionOutput {
   export function isa(o: any): o is GetBackupSelectionOutput {
-    return _smithy.isa(o, "GetBackupSelectionOutput");
+    return __isa(o, "GetBackupSelectionOutput");
   }
 }
 
@@ -1870,7 +1873,7 @@ export interface GetBackupVaultAccessPolicyInput {
 
 export namespace GetBackupVaultAccessPolicyInput {
   export function isa(o: any): o is GetBackupVaultAccessPolicyInput {
-    return _smithy.isa(o, "GetBackupVaultAccessPolicyInput");
+    return __isa(o, "GetBackupVaultAccessPolicyInput");
   }
 }
 
@@ -1897,7 +1900,7 @@ export interface GetBackupVaultAccessPolicyOutput extends $MetadataBearer {
 
 export namespace GetBackupVaultAccessPolicyOutput {
   export function isa(o: any): o is GetBackupVaultAccessPolicyOutput {
-    return _smithy.isa(o, "GetBackupVaultAccessPolicyOutput");
+    return __isa(o, "GetBackupVaultAccessPolicyOutput");
   }
 }
 
@@ -1913,7 +1916,7 @@ export interface GetBackupVaultNotificationsInput {
 
 export namespace GetBackupVaultNotificationsInput {
   export function isa(o: any): o is GetBackupVaultNotificationsInput {
-    return _smithy.isa(o, "GetBackupVaultNotificationsInput");
+    return __isa(o, "GetBackupVaultNotificationsInput");
   }
 }
 
@@ -1947,7 +1950,7 @@ export interface GetBackupVaultNotificationsOutput extends $MetadataBearer {
 
 export namespace GetBackupVaultNotificationsOutput {
   export function isa(o: any): o is GetBackupVaultNotificationsOutput {
-    return _smithy.isa(o, "GetBackupVaultNotificationsOutput");
+    return __isa(o, "GetBackupVaultNotificationsOutput");
   }
 }
 
@@ -1969,7 +1972,7 @@ export interface GetRecoveryPointRestoreMetadataInput {
 
 export namespace GetRecoveryPointRestoreMetadataInput {
   export function isa(o: any): o is GetRecoveryPointRestoreMetadataInput {
-    return _smithy.isa(o, "GetRecoveryPointRestoreMetadataInput");
+    return __isa(o, "GetRecoveryPointRestoreMetadataInput");
   }
 }
 
@@ -1997,7 +2000,7 @@ export interface GetRecoveryPointRestoreMetadataOutput extends $MetadataBearer {
 
 export namespace GetRecoveryPointRestoreMetadataOutput {
   export function isa(o: any): o is GetRecoveryPointRestoreMetadataOutput {
-    return _smithy.isa(o, "GetRecoveryPointRestoreMetadataOutput");
+    return __isa(o, "GetRecoveryPointRestoreMetadataOutput");
   }
 }
 
@@ -2033,7 +2036,7 @@ export interface GetSupportedResourceTypesOutput extends $MetadataBearer {
 
 export namespace GetSupportedResourceTypesOutput {
   export function isa(o: any): o is GetSupportedResourceTypesOutput {
-    return _smithy.isa(o, "GetSupportedResourceTypesOutput");
+    return __isa(o, "GetSupportedResourceTypesOutput");
   }
 }
 
@@ -2042,7 +2045,7 @@ export namespace GetSupportedResourceTypesOutput {
  *          out of range.</p>
  */
 export interface InvalidParameterValueException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidParameterValueException";
   $fault: "client";
@@ -2061,7 +2064,7 @@ export interface InvalidParameterValueException
 
 export namespace InvalidParameterValueException {
   export function isa(o: any): o is InvalidParameterValueException {
-    return _smithy.isa(o, "InvalidParameterValueException");
+    return __isa(o, "InvalidParameterValueException");
   }
 }
 
@@ -2070,7 +2073,7 @@ export namespace InvalidParameterValueException {
  *          parameter is of the wrong type.</p>
  */
 export interface InvalidRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidRequestException";
   $fault: "client";
@@ -2089,7 +2092,7 @@ export interface InvalidRequestException
 
 export namespace InvalidRequestException {
   export function isa(o: any): o is InvalidRequestException {
-    return _smithy.isa(o, "InvalidRequestException");
+    return __isa(o, "InvalidRequestException");
   }
 }
 
@@ -2118,7 +2121,7 @@ export interface Lifecycle {
 
 export namespace Lifecycle {
   export function isa(o: any): o is Lifecycle {
-    return _smithy.isa(o, "Lifecycle");
+    return __isa(o, "Lifecycle");
   }
 }
 
@@ -2127,7 +2130,7 @@ export namespace Lifecycle {
  *          in a request.</p>
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -2146,7 +2149,7 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
@@ -2224,7 +2227,7 @@ export interface ListBackupJobsInput {
 
 export namespace ListBackupJobsInput {
   export function isa(o: any): o is ListBackupJobsInput {
-    return _smithy.isa(o, "ListBackupJobsInput");
+    return __isa(o, "ListBackupJobsInput");
   }
 }
 
@@ -2247,7 +2250,7 @@ export interface ListBackupJobsOutput extends $MetadataBearer {
 
 export namespace ListBackupJobsOutput {
   export function isa(o: any): o is ListBackupJobsOutput {
-    return _smithy.isa(o, "ListBackupJobsOutput");
+    return __isa(o, "ListBackupJobsOutput");
   }
 }
 
@@ -2269,7 +2272,7 @@ export interface ListBackupPlanTemplatesInput {
 
 export namespace ListBackupPlanTemplatesInput {
   export function isa(o: any): o is ListBackupPlanTemplatesInput {
-    return _smithy.isa(o, "ListBackupPlanTemplatesInput");
+    return __isa(o, "ListBackupPlanTemplatesInput");
   }
 }
 
@@ -2291,7 +2294,7 @@ export interface ListBackupPlanTemplatesOutput extends $MetadataBearer {
 
 export namespace ListBackupPlanTemplatesOutput {
   export function isa(o: any): o is ListBackupPlanTemplatesOutput {
-    return _smithy.isa(o, "ListBackupPlanTemplatesOutput");
+    return __isa(o, "ListBackupPlanTemplatesOutput");
   }
 }
 
@@ -2318,7 +2321,7 @@ export interface ListBackupPlanVersionsInput {
 
 export namespace ListBackupPlanVersionsInput {
   export function isa(o: any): o is ListBackupPlanVersionsInput {
-    return _smithy.isa(o, "ListBackupPlanVersionsInput");
+    return __isa(o, "ListBackupPlanVersionsInput");
   }
 }
 
@@ -2340,7 +2343,7 @@ export interface ListBackupPlanVersionsOutput extends $MetadataBearer {
 
 export namespace ListBackupPlanVersionsOutput {
   export function isa(o: any): o is ListBackupPlanVersionsOutput {
-    return _smithy.isa(o, "ListBackupPlanVersionsOutput");
+    return __isa(o, "ListBackupPlanVersionsOutput");
   }
 }
 
@@ -2368,7 +2371,7 @@ export interface ListBackupPlansInput {
 
 export namespace ListBackupPlansInput {
   export function isa(o: any): o is ListBackupPlansInput {
-    return _smithy.isa(o, "ListBackupPlansInput");
+    return __isa(o, "ListBackupPlansInput");
   }
 }
 
@@ -2391,7 +2394,7 @@ export interface ListBackupPlansOutput extends $MetadataBearer {
 
 export namespace ListBackupPlansOutput {
   export function isa(o: any): o is ListBackupPlansOutput {
-    return _smithy.isa(o, "ListBackupPlansOutput");
+    return __isa(o, "ListBackupPlansOutput");
   }
 }
 
@@ -2418,7 +2421,7 @@ export interface ListBackupSelectionsInput {
 
 export namespace ListBackupSelectionsInput {
   export function isa(o: any): o is ListBackupSelectionsInput {
-    return _smithy.isa(o, "ListBackupSelectionsInput");
+    return __isa(o, "ListBackupSelectionsInput");
   }
 }
 
@@ -2441,7 +2444,7 @@ export interface ListBackupSelectionsOutput extends $MetadataBearer {
 
 export namespace ListBackupSelectionsOutput {
   export function isa(o: any): o is ListBackupSelectionsOutput {
-    return _smithy.isa(o, "ListBackupSelectionsOutput");
+    return __isa(o, "ListBackupSelectionsOutput");
   }
 }
 
@@ -2463,7 +2466,7 @@ export interface ListBackupVaultsInput {
 
 export namespace ListBackupVaultsInput {
   export function isa(o: any): o is ListBackupVaultsInput {
-    return _smithy.isa(o, "ListBackupVaultsInput");
+    return __isa(o, "ListBackupVaultsInput");
   }
 }
 
@@ -2487,7 +2490,7 @@ export interface ListBackupVaultsOutput extends $MetadataBearer {
 
 export namespace ListBackupVaultsOutput {
   export function isa(o: any): o is ListBackupVaultsOutput {
-    return _smithy.isa(o, "ListBackupVaultsOutput");
+    return __isa(o, "ListBackupVaultsOutput");
   }
 }
 
@@ -2560,7 +2563,7 @@ export interface ListCopyJobsInput {
 
 export namespace ListCopyJobsInput {
   export function isa(o: any): o is ListCopyJobsInput {
-    return _smithy.isa(o, "ListCopyJobsInput");
+    return __isa(o, "ListCopyJobsInput");
   }
 }
 
@@ -2580,7 +2583,7 @@ export interface ListCopyJobsOutput extends $MetadataBearer {
 
 export namespace ListCopyJobsOutput {
   export function isa(o: any): o is ListCopyJobsOutput {
-    return _smithy.isa(o, "ListCopyJobsOutput");
+    return __isa(o, "ListCopyJobsOutput");
   }
 }
 
@@ -2602,7 +2605,7 @@ export interface ListProtectedResourcesInput {
 
 export namespace ListProtectedResourcesInput {
   export function isa(o: any): o is ListProtectedResourcesInput {
-    return _smithy.isa(o, "ListProtectedResourcesInput");
+    return __isa(o, "ListProtectedResourcesInput");
   }
 }
 
@@ -2626,7 +2629,7 @@ export interface ListProtectedResourcesOutput extends $MetadataBearer {
 
 export namespace ListProtectedResourcesOutput {
   export function isa(o: any): o is ListProtectedResourcesOutput {
-    return _smithy.isa(o, "ListProtectedResourcesOutput");
+    return __isa(o, "ListProtectedResourcesOutput");
   }
 }
 
@@ -2681,7 +2684,7 @@ export interface ListRecoveryPointsByBackupVaultInput {
 
 export namespace ListRecoveryPointsByBackupVaultInput {
   export function isa(o: any): o is ListRecoveryPointsByBackupVaultInput {
-    return _smithy.isa(o, "ListRecoveryPointsByBackupVaultInput");
+    return __isa(o, "ListRecoveryPointsByBackupVaultInput");
   }
 }
 
@@ -2704,7 +2707,7 @@ export interface ListRecoveryPointsByBackupVaultOutput extends $MetadataBearer {
 
 export namespace ListRecoveryPointsByBackupVaultOutput {
   export function isa(o: any): o is ListRecoveryPointsByBackupVaultOutput {
-    return _smithy.isa(o, "ListRecoveryPointsByBackupVaultOutput");
+    return __isa(o, "ListRecoveryPointsByBackupVaultOutput");
   }
 }
 
@@ -2732,7 +2735,7 @@ export interface ListRecoveryPointsByResourceInput {
 
 export namespace ListRecoveryPointsByResourceInput {
   export function isa(o: any): o is ListRecoveryPointsByResourceInput {
-    return _smithy.isa(o, "ListRecoveryPointsByResourceInput");
+    return __isa(o, "ListRecoveryPointsByResourceInput");
   }
 }
 
@@ -2755,7 +2758,7 @@ export interface ListRecoveryPointsByResourceOutput extends $MetadataBearer {
 
 export namespace ListRecoveryPointsByResourceOutput {
   export function isa(o: any): o is ListRecoveryPointsByResourceOutput {
-    return _smithy.isa(o, "ListRecoveryPointsByResourceOutput");
+    return __isa(o, "ListRecoveryPointsByResourceOutput");
   }
 }
 
@@ -2777,7 +2780,7 @@ export interface ListRestoreJobsInput {
 
 export namespace ListRestoreJobsInput {
   export function isa(o: any): o is ListRestoreJobsInput {
-    return _smithy.isa(o, "ListRestoreJobsInput");
+    return __isa(o, "ListRestoreJobsInput");
   }
 }
 
@@ -2800,7 +2803,7 @@ export interface ListRestoreJobsOutput extends $MetadataBearer {
 
 export namespace ListRestoreJobsOutput {
   export function isa(o: any): o is ListRestoreJobsOutput {
-    return _smithy.isa(o, "ListRestoreJobsOutput");
+    return __isa(o, "ListRestoreJobsOutput");
   }
 }
 
@@ -2829,7 +2832,7 @@ export interface ListTagsInput {
 
 export namespace ListTagsInput {
   export function isa(o: any): o is ListTagsInput {
-    return _smithy.isa(o, "ListTagsInput");
+    return __isa(o, "ListTagsInput");
   }
 }
 
@@ -2852,7 +2855,7 @@ export interface ListTagsOutput extends $MetadataBearer {
 
 export namespace ListTagsOutput {
   export function isa(o: any): o is ListTagsOutput {
-    return _smithy.isa(o, "ListTagsOutput");
+    return __isa(o, "ListTagsOutput");
   }
 }
 
@@ -2860,7 +2863,7 @@ export namespace ListTagsOutput {
  * <p>Indicates that a required parameter is missing.</p>
  */
 export interface MissingParameterValueException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "MissingParameterValueException";
   $fault: "client";
@@ -2879,7 +2882,7 @@ export interface MissingParameterValueException
 
 export namespace MissingParameterValueException {
   export function isa(o: any): o is MissingParameterValueException {
-    return _smithy.isa(o, "MissingParameterValueException");
+    return __isa(o, "MissingParameterValueException");
   }
 }
 
@@ -2911,7 +2914,7 @@ export interface ProtectedResource {
 
 export namespace ProtectedResource {
   export function isa(o: any): o is ProtectedResource {
-    return _smithy.isa(o, "ProtectedResource");
+    return __isa(o, "ProtectedResource");
   }
 }
 
@@ -2932,7 +2935,7 @@ export interface PutBackupVaultAccessPolicyInput {
 
 export namespace PutBackupVaultAccessPolicyInput {
   export function isa(o: any): o is PutBackupVaultAccessPolicyInput {
-    return _smithy.isa(o, "PutBackupVaultAccessPolicyInput");
+    return __isa(o, "PutBackupVaultAccessPolicyInput");
   }
 }
 
@@ -2960,7 +2963,7 @@ export interface PutBackupVaultNotificationsInput {
 
 export namespace PutBackupVaultNotificationsInput {
   export function isa(o: any): o is PutBackupVaultNotificationsInput {
-    return _smithy.isa(o, "PutBackupVaultNotificationsInput");
+    return __isa(o, "PutBackupVaultNotificationsInput");
   }
 }
 
@@ -3080,7 +3083,7 @@ export interface RecoveryPointByBackupVault {
 
 export namespace RecoveryPointByBackupVault {
   export function isa(o: any): o is RecoveryPointByBackupVault {
-    return _smithy.isa(o, "RecoveryPointByBackupVault");
+    return __isa(o, "RecoveryPointByBackupVault");
   }
 }
 
@@ -3129,7 +3132,7 @@ export interface RecoveryPointByResource {
 
 export namespace RecoveryPointByResource {
   export function isa(o: any): o is RecoveryPointByResource {
-    return _smithy.isa(o, "RecoveryPointByResource");
+    return __isa(o, "RecoveryPointByResource");
   }
 }
 
@@ -3165,7 +3168,7 @@ export interface RecoveryPointCreator {
 
 export namespace RecoveryPointCreator {
   export function isa(o: any): o is RecoveryPointCreator {
-    return _smithy.isa(o, "RecoveryPointCreator");
+    return __isa(o, "RecoveryPointCreator");
   }
 }
 
@@ -3180,7 +3183,7 @@ export enum RecoveryPointStatus {
  * <p>A resource that is required for the action doesn't exist.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -3199,7 +3202,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -3286,7 +3289,7 @@ export interface RestoreJobsListMember {
 
 export namespace RestoreJobsListMember {
   export function isa(o: any): o is RestoreJobsListMember {
-    return _smithy.isa(o, "RestoreJobsListMember");
+    return __isa(o, "RestoreJobsListMember");
   }
 }
 
@@ -3294,7 +3297,7 @@ export namespace RestoreJobsListMember {
  * <p>The request failed due to a temporary failure of the server.</p>
  */
 export interface ServiceUnavailableException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ServiceUnavailableException";
   $fault: "server";
@@ -3313,7 +3316,7 @@ export interface ServiceUnavailableException
 
 export namespace ServiceUnavailableException {
   export function isa(o: any): o is ServiceUnavailableException {
-    return _smithy.isa(o, "ServiceUnavailableException");
+    return __isa(o, "ServiceUnavailableException");
   }
 }
 
@@ -3375,7 +3378,7 @@ export interface StartBackupJobInput {
 
 export namespace StartBackupJobInput {
   export function isa(o: any): o is StartBackupJobInput {
-    return _smithy.isa(o, "StartBackupJobInput");
+    return __isa(o, "StartBackupJobInput");
   }
 }
 
@@ -3403,7 +3406,7 @@ export interface StartBackupJobOutput extends $MetadataBearer {
 
 export namespace StartBackupJobOutput {
   export function isa(o: any): o is StartBackupJobOutput {
-    return _smithy.isa(o, "StartBackupJobOutput");
+    return __isa(o, "StartBackupJobOutput");
   }
 }
 
@@ -3449,7 +3452,7 @@ export interface StartCopyJobInput {
 
 export namespace StartCopyJobInput {
   export function isa(o: any): o is StartCopyJobInput {
-    return _smithy.isa(o, "StartCopyJobInput");
+    return __isa(o, "StartCopyJobInput");
   }
 }
 
@@ -3468,7 +3471,7 @@ export interface StartCopyJobOutput extends $MetadataBearer {
 
 export namespace StartCopyJobOutput {
   export function isa(o: any): o is StartCopyJobOutput {
-    return _smithy.isa(o, "StartCopyJobOutput");
+    return __isa(o, "StartCopyJobOutput");
   }
 }
 
@@ -3567,7 +3570,7 @@ export interface StartRestoreJobInput {
 
 export namespace StartRestoreJobInput {
   export function isa(o: any): o is StartRestoreJobInput {
-    return _smithy.isa(o, "StartRestoreJobInput");
+    return __isa(o, "StartRestoreJobInput");
   }
 }
 
@@ -3581,7 +3584,7 @@ export interface StartRestoreJobOutput extends $MetadataBearer {
 
 export namespace StartRestoreJobOutput {
   export function isa(o: any): o is StartRestoreJobOutput {
-    return _smithy.isa(o, "StartRestoreJobOutput");
+    return __isa(o, "StartRestoreJobOutput");
   }
 }
 
@@ -3595,7 +3598,7 @@ export interface StopBackupJobInput {
 
 export namespace StopBackupJobInput {
   export function isa(o: any): o is StopBackupJobInput {
-    return _smithy.isa(o, "StopBackupJobInput");
+    return __isa(o, "StopBackupJobInput");
   }
 }
 
@@ -3622,7 +3625,7 @@ export interface TagResourceInput {
 
 export namespace TagResourceInput {
   export function isa(o: any): o is TagResourceInput {
-    return _smithy.isa(o, "TagResourceInput");
+    return __isa(o, "TagResourceInput");
   }
 }
 
@@ -3642,7 +3645,7 @@ export interface UntagResourceInput {
 
 export namespace UntagResourceInput {
   export function isa(o: any): o is UntagResourceInput {
-    return _smithy.isa(o, "UntagResourceInput");
+    return __isa(o, "UntagResourceInput");
   }
 }
 
@@ -3662,7 +3665,7 @@ export interface UpdateBackupPlanInput {
 
 export namespace UpdateBackupPlanInput {
   export function isa(o: any): o is UpdateBackupPlanInput {
-    return _smithy.isa(o, "UpdateBackupPlanInput");
+    return __isa(o, "UpdateBackupPlanInput");
   }
 }
 
@@ -3696,7 +3699,7 @@ export interface UpdateBackupPlanOutput extends $MetadataBearer {
 
 export namespace UpdateBackupPlanOutput {
   export function isa(o: any): o is UpdateBackupPlanOutput {
-    return _smithy.isa(o, "UpdateBackupPlanOutput");
+    return __isa(o, "UpdateBackupPlanOutput");
   }
 }
 
@@ -3729,7 +3732,7 @@ export interface UpdateRecoveryPointLifecycleInput {
 
 export namespace UpdateRecoveryPointLifecycleInput {
   export function isa(o: any): o is UpdateRecoveryPointLifecycleInput {
-    return _smithy.isa(o, "UpdateRecoveryPointLifecycleInput");
+    return __isa(o, "UpdateRecoveryPointLifecycleInput");
   }
 }
 
@@ -3767,6 +3770,6 @@ export interface UpdateRecoveryPointLifecycleOutput extends $MetadataBearer {
 
 export namespace UpdateRecoveryPointLifecycleOutput {
   export function isa(o: any): o is UpdateRecoveryPointLifecycleOutput {
-    return _smithy.isa(o, "UpdateRecoveryPointLifecycleOutput");
+    return __isa(o, "UpdateRecoveryPointLifecycleOutput");
   }
 }

--- a/clients/client-backup/protocols/Aws_restJson1_1.ts
+++ b/clients/client-backup/protocols/Aws_restJson1_1.ts
@@ -217,7 +217,10 @@ import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  extendedEncodeURIComponent as __extendedEncodeURIComponent
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -268,7 +271,7 @@ export async function serializeAws_restJson1_1CreateBackupSelectionCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/backup/plans/{BackupPlanId}/selections";
   if (input.BackupPlanId !== undefined) {
-    const labelValue: string = input.BackupPlanId.toString();
+    const labelValue: string = input.BackupPlanId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: BackupPlanId."
@@ -276,7 +279,7 @@ export async function serializeAws_restJson1_1CreateBackupSelectionCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{BackupPlanId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: BackupPlanId.");
@@ -311,7 +314,7 @@ export async function serializeAws_restJson1_1CreateBackupVaultCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/backup-vaults/{BackupVaultName}";
   if (input.BackupVaultName !== undefined) {
-    const labelValue: string = input.BackupVaultName.toString();
+    const labelValue: string = input.BackupVaultName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: BackupVaultName."
@@ -319,7 +322,7 @@ export async function serializeAws_restJson1_1CreateBackupVaultCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{BackupVaultName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: BackupVaultName.");
@@ -357,7 +360,7 @@ export async function serializeAws_restJson1_1DeleteBackupPlanCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/backup/plans/{BackupPlanId}";
   if (input.BackupPlanId !== undefined) {
-    const labelValue: string = input.BackupPlanId.toString();
+    const labelValue: string = input.BackupPlanId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: BackupPlanId."
@@ -365,7 +368,7 @@ export async function serializeAws_restJson1_1DeleteBackupPlanCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{BackupPlanId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: BackupPlanId.");
@@ -387,7 +390,7 @@ export async function serializeAws_restJson1_1DeleteBackupSelectionCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/backup/plans/{BackupPlanId}/selections/{SelectionId}";
   if (input.BackupPlanId !== undefined) {
-    const labelValue: string = input.BackupPlanId.toString();
+    const labelValue: string = input.BackupPlanId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: BackupPlanId."
@@ -395,13 +398,13 @@ export async function serializeAws_restJson1_1DeleteBackupSelectionCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{BackupPlanId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: BackupPlanId.");
   }
   if (input.SelectionId !== undefined) {
-    const labelValue: string = input.SelectionId.toString();
+    const labelValue: string = input.SelectionId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: SelectionId."
@@ -409,7 +412,7 @@ export async function serializeAws_restJson1_1DeleteBackupSelectionCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{SelectionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: SelectionId.");
@@ -431,7 +434,7 @@ export async function serializeAws_restJson1_1DeleteBackupVaultCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/backup-vaults/{BackupVaultName}";
   if (input.BackupVaultName !== undefined) {
-    const labelValue: string = input.BackupVaultName.toString();
+    const labelValue: string = input.BackupVaultName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: BackupVaultName."
@@ -439,7 +442,7 @@ export async function serializeAws_restJson1_1DeleteBackupVaultCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{BackupVaultName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: BackupVaultName.");
@@ -461,7 +464,7 @@ export async function serializeAws_restJson1_1DeleteBackupVaultAccessPolicyComma
   headers["Content-Type"] = "";
   let resolvedPath = "/backup-vaults/{BackupVaultName}/access-policy";
   if (input.BackupVaultName !== undefined) {
-    const labelValue: string = input.BackupVaultName.toString();
+    const labelValue: string = input.BackupVaultName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: BackupVaultName."
@@ -469,7 +472,7 @@ export async function serializeAws_restJson1_1DeleteBackupVaultAccessPolicyComma
     }
     resolvedPath = resolvedPath.replace(
       "{BackupVaultName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: BackupVaultName.");
@@ -492,7 +495,7 @@ export async function serializeAws_restJson1_1DeleteBackupVaultNotificationsComm
   let resolvedPath =
     "/backup-vaults/{BackupVaultName}/notification-configuration";
   if (input.BackupVaultName !== undefined) {
-    const labelValue: string = input.BackupVaultName.toString();
+    const labelValue: string = input.BackupVaultName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: BackupVaultName."
@@ -500,7 +503,7 @@ export async function serializeAws_restJson1_1DeleteBackupVaultNotificationsComm
     }
     resolvedPath = resolvedPath.replace(
       "{BackupVaultName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: BackupVaultName.");
@@ -523,7 +526,7 @@ export async function serializeAws_restJson1_1DeleteRecoveryPointCommand(
   let resolvedPath =
     "/backup-vaults/{BackupVaultName}/recovery-points/{RecoveryPointArn}";
   if (input.BackupVaultName !== undefined) {
-    const labelValue: string = input.BackupVaultName.toString();
+    const labelValue: string = input.BackupVaultName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: BackupVaultName."
@@ -531,13 +534,13 @@ export async function serializeAws_restJson1_1DeleteRecoveryPointCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{BackupVaultName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: BackupVaultName.");
   }
   if (input.RecoveryPointArn !== undefined) {
-    const labelValue: string = input.RecoveryPointArn.toString();
+    const labelValue: string = input.RecoveryPointArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: RecoveryPointArn."
@@ -545,7 +548,7 @@ export async function serializeAws_restJson1_1DeleteRecoveryPointCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{RecoveryPointArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -569,7 +572,7 @@ export async function serializeAws_restJson1_1DescribeBackupJobCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/backup-jobs/{BackupJobId}";
   if (input.BackupJobId !== undefined) {
-    const labelValue: string = input.BackupJobId.toString();
+    const labelValue: string = input.BackupJobId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: BackupJobId."
@@ -577,7 +580,7 @@ export async function serializeAws_restJson1_1DescribeBackupJobCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{BackupJobId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: BackupJobId.");
@@ -599,7 +602,7 @@ export async function serializeAws_restJson1_1DescribeBackupVaultCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/backup-vaults/{BackupVaultName}";
   if (input.BackupVaultName !== undefined) {
-    const labelValue: string = input.BackupVaultName.toString();
+    const labelValue: string = input.BackupVaultName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: BackupVaultName."
@@ -607,7 +610,7 @@ export async function serializeAws_restJson1_1DescribeBackupVaultCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{BackupVaultName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: BackupVaultName.");
@@ -629,13 +632,13 @@ export async function serializeAws_restJson1_1DescribeCopyJobCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/copy-jobs/{CopyJobId}";
   if (input.CopyJobId !== undefined) {
-    const labelValue: string = input.CopyJobId.toString();
+    const labelValue: string = input.CopyJobId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: CopyJobId.");
     }
     resolvedPath = resolvedPath.replace(
       "{CopyJobId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: CopyJobId.");
@@ -657,7 +660,7 @@ export async function serializeAws_restJson1_1DescribeProtectedResourceCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/resources/{ResourceArn}";
   if (input.ResourceArn !== undefined) {
-    const labelValue: string = input.ResourceArn.toString();
+    const labelValue: string = input.ResourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ResourceArn."
@@ -665,7 +668,7 @@ export async function serializeAws_restJson1_1DescribeProtectedResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ResourceArn.");
@@ -688,7 +691,7 @@ export async function serializeAws_restJson1_1DescribeRecoveryPointCommand(
   let resolvedPath =
     "/backup-vaults/{BackupVaultName}/recovery-points/{RecoveryPointArn}";
   if (input.BackupVaultName !== undefined) {
-    const labelValue: string = input.BackupVaultName.toString();
+    const labelValue: string = input.BackupVaultName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: BackupVaultName."
@@ -696,13 +699,13 @@ export async function serializeAws_restJson1_1DescribeRecoveryPointCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{BackupVaultName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: BackupVaultName.");
   }
   if (input.RecoveryPointArn !== undefined) {
-    const labelValue: string = input.RecoveryPointArn.toString();
+    const labelValue: string = input.RecoveryPointArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: RecoveryPointArn."
@@ -710,7 +713,7 @@ export async function serializeAws_restJson1_1DescribeRecoveryPointCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{RecoveryPointArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -734,7 +737,7 @@ export async function serializeAws_restJson1_1DescribeRestoreJobCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/restore-jobs/{RestoreJobId}";
   if (input.RestoreJobId !== undefined) {
-    const labelValue: string = input.RestoreJobId.toString();
+    const labelValue: string = input.RestoreJobId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: RestoreJobId."
@@ -742,7 +745,7 @@ export async function serializeAws_restJson1_1DescribeRestoreJobCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{RestoreJobId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: RestoreJobId.");
@@ -764,7 +767,7 @@ export async function serializeAws_restJson1_1ExportBackupPlanTemplateCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/backup/plans/{BackupPlanId}/toTemplate";
   if (input.BackupPlanId !== undefined) {
-    const labelValue: string = input.BackupPlanId.toString();
+    const labelValue: string = input.BackupPlanId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: BackupPlanId."
@@ -772,7 +775,7 @@ export async function serializeAws_restJson1_1ExportBackupPlanTemplateCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{BackupPlanId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: BackupPlanId.");
@@ -794,7 +797,7 @@ export async function serializeAws_restJson1_1GetBackupPlanCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/backup/plans/{BackupPlanId}";
   if (input.BackupPlanId !== undefined) {
-    const labelValue: string = input.BackupPlanId.toString();
+    const labelValue: string = input.BackupPlanId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: BackupPlanId."
@@ -802,14 +805,16 @@ export async function serializeAws_restJson1_1GetBackupPlanCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{BackupPlanId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: BackupPlanId.");
   }
   const query: any = {};
   if (input.VersionId !== undefined) {
-    query["versionId"] = input.VersionId.toString();
+    query[
+      __extendedEncodeURIComponent("versionId")
+    ] = __extendedEncodeURIComponent(input.VersionId);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -852,7 +857,7 @@ export async function serializeAws_restJson1_1GetBackupPlanFromTemplateCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/backup/template/plans/{BackupPlanTemplateId}/toPlan";
   if (input.BackupPlanTemplateId !== undefined) {
-    const labelValue: string = input.BackupPlanTemplateId.toString();
+    const labelValue: string = input.BackupPlanTemplateId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: BackupPlanTemplateId."
@@ -860,7 +865,7 @@ export async function serializeAws_restJson1_1GetBackupPlanFromTemplateCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{BackupPlanTemplateId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -884,7 +889,7 @@ export async function serializeAws_restJson1_1GetBackupSelectionCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/backup/plans/{BackupPlanId}/selections/{SelectionId}";
   if (input.BackupPlanId !== undefined) {
-    const labelValue: string = input.BackupPlanId.toString();
+    const labelValue: string = input.BackupPlanId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: BackupPlanId."
@@ -892,13 +897,13 @@ export async function serializeAws_restJson1_1GetBackupSelectionCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{BackupPlanId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: BackupPlanId.");
   }
   if (input.SelectionId !== undefined) {
-    const labelValue: string = input.SelectionId.toString();
+    const labelValue: string = input.SelectionId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: SelectionId."
@@ -906,7 +911,7 @@ export async function serializeAws_restJson1_1GetBackupSelectionCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{SelectionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: SelectionId.");
@@ -928,7 +933,7 @@ export async function serializeAws_restJson1_1GetBackupVaultAccessPolicyCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/backup-vaults/{BackupVaultName}/access-policy";
   if (input.BackupVaultName !== undefined) {
-    const labelValue: string = input.BackupVaultName.toString();
+    const labelValue: string = input.BackupVaultName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: BackupVaultName."
@@ -936,7 +941,7 @@ export async function serializeAws_restJson1_1GetBackupVaultAccessPolicyCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{BackupVaultName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: BackupVaultName.");
@@ -959,7 +964,7 @@ export async function serializeAws_restJson1_1GetBackupVaultNotificationsCommand
   let resolvedPath =
     "/backup-vaults/{BackupVaultName}/notification-configuration";
   if (input.BackupVaultName !== undefined) {
-    const labelValue: string = input.BackupVaultName.toString();
+    const labelValue: string = input.BackupVaultName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: BackupVaultName."
@@ -967,7 +972,7 @@ export async function serializeAws_restJson1_1GetBackupVaultNotificationsCommand
     }
     resolvedPath = resolvedPath.replace(
       "{BackupVaultName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: BackupVaultName.");
@@ -990,7 +995,7 @@ export async function serializeAws_restJson1_1GetRecoveryPointRestoreMetadataCom
   let resolvedPath =
     "/backup-vaults/{BackupVaultName}/recovery-points/{RecoveryPointArn}/restore-metadata";
   if (input.BackupVaultName !== undefined) {
-    const labelValue: string = input.BackupVaultName.toString();
+    const labelValue: string = input.BackupVaultName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: BackupVaultName."
@@ -998,13 +1003,13 @@ export async function serializeAws_restJson1_1GetRecoveryPointRestoreMetadataCom
     }
     resolvedPath = resolvedPath.replace(
       "{BackupVaultName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: BackupVaultName.");
   }
   if (input.RecoveryPointArn !== undefined) {
-    const labelValue: string = input.RecoveryPointArn.toString();
+    const labelValue: string = input.RecoveryPointArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: RecoveryPointArn."
@@ -1012,7 +1017,7 @@ export async function serializeAws_restJson1_1GetRecoveryPointRestoreMetadataCom
     }
     resolvedPath = resolvedPath.replace(
       "{RecoveryPointArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -1053,28 +1058,44 @@ export async function serializeAws_restJson1_1ListBackupJobsCommand(
   let resolvedPath = "/backup-jobs";
   const query: any = {};
   if (input.ByBackupVaultName !== undefined) {
-    query["backupVaultName"] = input.ByBackupVaultName.toString();
+    query[
+      __extendedEncodeURIComponent("backupVaultName")
+    ] = __extendedEncodeURIComponent(input.ByBackupVaultName);
   }
   if (input.ByCreatedAfter !== undefined) {
-    query["createdAfter"] = input.ByCreatedAfter.toISOString();
+    query[
+      __extendedEncodeURIComponent("createdAfter")
+    ] = __extendedEncodeURIComponent(input.ByCreatedAfter.toISOString());
   }
   if (input.ByCreatedBefore !== undefined) {
-    query["createdBefore"] = input.ByCreatedBefore.toISOString();
+    query[
+      __extendedEncodeURIComponent("createdBefore")
+    ] = __extendedEncodeURIComponent(input.ByCreatedBefore.toISOString());
   }
   if (input.ByResourceArn !== undefined) {
-    query["resourceArn"] = input.ByResourceArn.toString();
+    query[
+      __extendedEncodeURIComponent("resourceArn")
+    ] = __extendedEncodeURIComponent(input.ByResourceArn);
   }
   if (input.ByResourceType !== undefined) {
-    query["resourceType"] = input.ByResourceType.toString();
+    query[
+      __extendedEncodeURIComponent("resourceType")
+    ] = __extendedEncodeURIComponent(input.ByResourceType);
   }
   if (input.ByState !== undefined) {
-    query["state"] = input.ByState.toString();
+    query[__extendedEncodeURIComponent("state")] = __extendedEncodeURIComponent(
+      input.ByState
+    );
   }
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1095,10 +1116,14 @@ export async function serializeAws_restJson1_1ListBackupPlanTemplatesCommand(
   let resolvedPath = "/backup/template/plans";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1118,7 +1143,7 @@ export async function serializeAws_restJson1_1ListBackupPlanVersionsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/backup/plans/{BackupPlanId}/versions";
   if (input.BackupPlanId !== undefined) {
-    const labelValue: string = input.BackupPlanId.toString();
+    const labelValue: string = input.BackupPlanId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: BackupPlanId."
@@ -1126,17 +1151,21 @@ export async function serializeAws_restJson1_1ListBackupPlanVersionsCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{BackupPlanId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: BackupPlanId.");
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1157,13 +1186,19 @@ export async function serializeAws_restJson1_1ListBackupPlansCommand(
   let resolvedPath = "/backup/plans";
   const query: any = {};
   if (input.IncludeDeleted !== undefined) {
-    query["includeDeleted"] = input.IncludeDeleted.toString();
+    query[
+      __extendedEncodeURIComponent("includeDeleted")
+    ] = __extendedEncodeURIComponent(input.IncludeDeleted.toString());
   }
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1183,7 +1218,7 @@ export async function serializeAws_restJson1_1ListBackupSelectionsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/backup/plans/{BackupPlanId}/selections";
   if (input.BackupPlanId !== undefined) {
-    const labelValue: string = input.BackupPlanId.toString();
+    const labelValue: string = input.BackupPlanId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: BackupPlanId."
@@ -1191,17 +1226,21 @@ export async function serializeAws_restJson1_1ListBackupSelectionsCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{BackupPlanId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: BackupPlanId.");
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1222,10 +1261,14 @@ export async function serializeAws_restJson1_1ListBackupVaultsCommand(
   let resolvedPath = "/backup-vaults";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1246,28 +1289,44 @@ export async function serializeAws_restJson1_1ListCopyJobsCommand(
   let resolvedPath = "/copy-jobs";
   const query: any = {};
   if (input.ByCreatedAfter !== undefined) {
-    query["createdAfter"] = input.ByCreatedAfter.toISOString();
+    query[
+      __extendedEncodeURIComponent("createdAfter")
+    ] = __extendedEncodeURIComponent(input.ByCreatedAfter.toISOString());
   }
   if (input.ByCreatedBefore !== undefined) {
-    query["createdBefore"] = input.ByCreatedBefore.toISOString();
+    query[
+      __extendedEncodeURIComponent("createdBefore")
+    ] = __extendedEncodeURIComponent(input.ByCreatedBefore.toISOString());
   }
   if (input.ByDestinationVaultArn !== undefined) {
-    query["destinationVaultArn"] = input.ByDestinationVaultArn.toString();
+    query[
+      __extendedEncodeURIComponent("destinationVaultArn")
+    ] = __extendedEncodeURIComponent(input.ByDestinationVaultArn);
   }
   if (input.ByResourceArn !== undefined) {
-    query["resourceArn"] = input.ByResourceArn.toString();
+    query[
+      __extendedEncodeURIComponent("resourceArn")
+    ] = __extendedEncodeURIComponent(input.ByResourceArn);
   }
   if (input.ByResourceType !== undefined) {
-    query["resourceType"] = input.ByResourceType.toString();
+    query[
+      __extendedEncodeURIComponent("resourceType")
+    ] = __extendedEncodeURIComponent(input.ByResourceType);
   }
   if (input.ByState !== undefined) {
-    query["state"] = input.ByState.toString();
+    query[__extendedEncodeURIComponent("state")] = __extendedEncodeURIComponent(
+      input.ByState
+    );
   }
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1288,10 +1347,14 @@ export async function serializeAws_restJson1_1ListProtectedResourcesCommand(
   let resolvedPath = "/resources";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1311,7 +1374,7 @@ export async function serializeAws_restJson1_1ListRecoveryPointsByBackupVaultCom
   headers["Content-Type"] = "";
   let resolvedPath = "/backup-vaults/{BackupVaultName}/recovery-points";
   if (input.BackupVaultName !== undefined) {
-    const labelValue: string = input.BackupVaultName.toString();
+    const labelValue: string = input.BackupVaultName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: BackupVaultName."
@@ -1319,32 +1382,46 @@ export async function serializeAws_restJson1_1ListRecoveryPointsByBackupVaultCom
     }
     resolvedPath = resolvedPath.replace(
       "{BackupVaultName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: BackupVaultName.");
   }
   const query: any = {};
   if (input.ByBackupPlanId !== undefined) {
-    query["backupPlanId"] = input.ByBackupPlanId.toString();
+    query[
+      __extendedEncodeURIComponent("backupPlanId")
+    ] = __extendedEncodeURIComponent(input.ByBackupPlanId);
   }
   if (input.ByCreatedAfter !== undefined) {
-    query["createdAfter"] = input.ByCreatedAfter.toISOString();
+    query[
+      __extendedEncodeURIComponent("createdAfter")
+    ] = __extendedEncodeURIComponent(input.ByCreatedAfter.toISOString());
   }
   if (input.ByCreatedBefore !== undefined) {
-    query["createdBefore"] = input.ByCreatedBefore.toISOString();
+    query[
+      __extendedEncodeURIComponent("createdBefore")
+    ] = __extendedEncodeURIComponent(input.ByCreatedBefore.toISOString());
   }
   if (input.ByResourceArn !== undefined) {
-    query["resourceArn"] = input.ByResourceArn.toString();
+    query[
+      __extendedEncodeURIComponent("resourceArn")
+    ] = __extendedEncodeURIComponent(input.ByResourceArn);
   }
   if (input.ByResourceType !== undefined) {
-    query["resourceType"] = input.ByResourceType.toString();
+    query[
+      __extendedEncodeURIComponent("resourceType")
+    ] = __extendedEncodeURIComponent(input.ByResourceType);
   }
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1364,7 +1441,7 @@ export async function serializeAws_restJson1_1ListRecoveryPointsByResourceComman
   headers["Content-Type"] = "";
   let resolvedPath = "/resources/{ResourceArn}/recovery-points";
   if (input.ResourceArn !== undefined) {
-    const labelValue: string = input.ResourceArn.toString();
+    const labelValue: string = input.ResourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ResourceArn."
@@ -1372,17 +1449,21 @@ export async function serializeAws_restJson1_1ListRecoveryPointsByResourceComman
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ResourceArn.");
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1403,10 +1484,14 @@ export async function serializeAws_restJson1_1ListRestoreJobsCommand(
   let resolvedPath = "/restore-jobs";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1426,7 +1511,7 @@ export async function serializeAws_restJson1_1ListTagsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/tags/{ResourceArn}";
   if (input.ResourceArn !== undefined) {
-    const labelValue: string = input.ResourceArn.toString();
+    const labelValue: string = input.ResourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ResourceArn."
@@ -1434,17 +1519,21 @@ export async function serializeAws_restJson1_1ListTagsCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ResourceArn.");
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1464,7 +1553,7 @@ export async function serializeAws_restJson1_1PutBackupVaultAccessPolicyCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/backup-vaults/{BackupVaultName}/access-policy";
   if (input.BackupVaultName !== undefined) {
-    const labelValue: string = input.BackupVaultName.toString();
+    const labelValue: string = input.BackupVaultName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: BackupVaultName."
@@ -1472,7 +1561,7 @@ export async function serializeAws_restJson1_1PutBackupVaultAccessPolicyCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{BackupVaultName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: BackupVaultName.");
@@ -1502,7 +1591,7 @@ export async function serializeAws_restJson1_1PutBackupVaultNotificationsCommand
   let resolvedPath =
     "/backup-vaults/{BackupVaultName}/notification-configuration";
   if (input.BackupVaultName !== undefined) {
-    const labelValue: string = input.BackupVaultName.toString();
+    const labelValue: string = input.BackupVaultName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: BackupVaultName."
@@ -1510,7 +1599,7 @@ export async function serializeAws_restJson1_1PutBackupVaultNotificationsCommand
     }
     resolvedPath = resolvedPath.replace(
       "{BackupVaultName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: BackupVaultName.");
@@ -1674,7 +1763,7 @@ export async function serializeAws_restJson1_1StopBackupJobCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/backup-jobs/{BackupJobId}";
   if (input.BackupJobId !== undefined) {
-    const labelValue: string = input.BackupJobId.toString();
+    const labelValue: string = input.BackupJobId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: BackupJobId."
@@ -1682,7 +1771,7 @@ export async function serializeAws_restJson1_1StopBackupJobCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{BackupJobId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: BackupJobId.");
@@ -1704,7 +1793,7 @@ export async function serializeAws_restJson1_1TagResourceCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/tags/{ResourceArn}";
   if (input.ResourceArn !== undefined) {
-    const labelValue: string = input.ResourceArn.toString();
+    const labelValue: string = input.ResourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ResourceArn."
@@ -1712,7 +1801,7 @@ export async function serializeAws_restJson1_1TagResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ResourceArn.");
@@ -1741,7 +1830,7 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/untag/{ResourceArn}";
   if (input.ResourceArn !== undefined) {
-    const labelValue: string = input.ResourceArn.toString();
+    const labelValue: string = input.ResourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ResourceArn."
@@ -1749,7 +1838,7 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ResourceArn.");
@@ -1781,7 +1870,7 @@ export async function serializeAws_restJson1_1UpdateBackupPlanCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/backup/plans/{BackupPlanId}";
   if (input.BackupPlanId !== undefined) {
-    const labelValue: string = input.BackupPlanId.toString();
+    const labelValue: string = input.BackupPlanId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: BackupPlanId."
@@ -1789,7 +1878,7 @@ export async function serializeAws_restJson1_1UpdateBackupPlanCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{BackupPlanId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: BackupPlanId.");
@@ -1822,7 +1911,7 @@ export async function serializeAws_restJson1_1UpdateRecoveryPointLifecycleComman
   let resolvedPath =
     "/backup-vaults/{BackupVaultName}/recovery-points/{RecoveryPointArn}";
   if (input.BackupVaultName !== undefined) {
-    const labelValue: string = input.BackupVaultName.toString();
+    const labelValue: string = input.BackupVaultName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: BackupVaultName."
@@ -1830,13 +1919,13 @@ export async function serializeAws_restJson1_1UpdateRecoveryPointLifecycleComman
     }
     resolvedPath = resolvedPath.replace(
       "{BackupVaultName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: BackupVaultName.");
   }
   if (input.RecoveryPointArn !== undefined) {
-    const labelValue: string = input.RecoveryPointArn.toString();
+    const labelValue: string = input.RecoveryPointArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: RecoveryPointArn."
@@ -1844,7 +1933,7 @@ export async function serializeAws_restJson1_1UpdateRecoveryPointLifecycleComman
     }
     resolvedPath = resolvedPath.replace(
       "{RecoveryPointArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -2259,6 +2348,7 @@ export async function deserializeAws_restJson1_1DeleteBackupSelectionCommand(
   const contents: DeleteBackupSelectionCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2330,6 +2420,7 @@ export async function deserializeAws_restJson1_1DeleteBackupVaultCommand(
   const contents: DeleteBackupVaultCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2408,6 +2499,7 @@ export async function deserializeAws_restJson1_1DeleteBackupVaultAccessPolicyCom
   const contents: DeleteBackupVaultAccessPolicyCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2479,6 +2571,7 @@ export async function deserializeAws_restJson1_1DeleteBackupVaultNotificationsCo
   const contents: DeleteBackupVaultNotificationsCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2550,6 +2643,7 @@ export async function deserializeAws_restJson1_1DeleteRecoveryPointCommand(
   const contents: DeleteRecoveryPointCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -5081,6 +5175,7 @@ export async function deserializeAws_restJson1_1PutBackupVaultAccessPolicyComman
   const contents: PutBackupVaultAccessPolicyCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -5152,6 +5247,7 @@ export async function deserializeAws_restJson1_1PutBackupVaultNotificationsComma
   const contents: PutBackupVaultNotificationsCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -5474,6 +5570,7 @@ export async function deserializeAws_restJson1_1StopBackupJobCommand(
   const contents: StopBackupJobCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -5549,6 +5646,7 @@ export async function deserializeAws_restJson1_1TagResourceCommand(
   const contents: TagResourceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -5624,6 +5722,7 @@ export async function deserializeAws_restJson1_1UntagResourceCommand(
   const contents: UntagResourceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 

--- a/clients/client-batch/models/index.ts
+++ b/clients/client-batch/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export enum ArrayJobDependency {
@@ -19,7 +22,7 @@ export interface ArrayProperties {
 
 export namespace ArrayProperties {
   export function isa(o: any): o is ArrayProperties {
-    return _smithy.isa(o, "ArrayProperties");
+    return __isa(o, "ArrayProperties");
   }
 }
 
@@ -48,7 +51,7 @@ export interface ArrayPropertiesDetail {
 
 export namespace ArrayPropertiesDetail {
   export function isa(o: any): o is ArrayPropertiesDetail {
-    return _smithy.isa(o, "ArrayPropertiesDetail");
+    return __isa(o, "ArrayPropertiesDetail");
   }
 }
 
@@ -71,7 +74,7 @@ export interface ArrayPropertiesSummary {
 
 export namespace ArrayPropertiesSummary {
   export function isa(o: any): o is ArrayPropertiesSummary {
-    return _smithy.isa(o, "ArrayPropertiesSummary");
+    return __isa(o, "ArrayPropertiesSummary");
   }
 }
 
@@ -117,7 +120,7 @@ export interface AttemptContainerDetail {
 
 export namespace AttemptContainerDetail {
   export function isa(o: any): o is AttemptContainerDetail {
-    return _smithy.isa(o, "AttemptContainerDetail");
+    return __isa(o, "AttemptContainerDetail");
   }
 }
 
@@ -152,7 +155,7 @@ export interface AttemptDetail {
 
 export namespace AttemptDetail {
   export function isa(o: any): o is AttemptDetail {
-    return _smithy.isa(o, "AttemptDetail");
+    return __isa(o, "AttemptDetail");
   }
 }
 
@@ -203,7 +206,7 @@ export interface CancelJobRequest {
 
 export namespace CancelJobRequest {
   export function isa(o: any): o is CancelJobRequest {
-    return _smithy.isa(o, "CancelJobRequest");
+    return __isa(o, "CancelJobRequest");
   }
 }
 
@@ -213,7 +216,7 @@ export interface CancelJobResponse extends $MetadataBearer {
 
 export namespace CancelJobResponse {
   export function isa(o: any): o is CancelJobResponse {
-    return _smithy.isa(o, "CancelJobResponse");
+    return __isa(o, "CancelJobResponse");
   }
 }
 
@@ -221,9 +224,7 @@ export namespace CancelJobResponse {
  * <p>These errors are usually caused by a client action, such as using an action or resource on behalf of a user that
  *    doesn't have permissions to use the action or resource, or specifying an identifier that is not valid.</p>
  */
-export interface ClientException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface ClientException extends __SmithyException, $MetadataBearer {
   name: "ClientException";
   $fault: "client";
   message?: string;
@@ -231,7 +232,7 @@ export interface ClientException
 
 export namespace ClientException {
   export function isa(o: any): o is ClientException {
-    return _smithy.isa(o, "ClientException");
+    return __isa(o, "ClientException");
   }
 }
 
@@ -297,7 +298,7 @@ export interface ComputeEnvironmentDetail {
 
 export namespace ComputeEnvironmentDetail {
   export function isa(o: any): o is ComputeEnvironmentDetail {
-    return _smithy.isa(o, "ComputeEnvironmentDetail");
+    return __isa(o, "ComputeEnvironmentDetail");
   }
 }
 
@@ -321,7 +322,7 @@ export interface ComputeEnvironmentOrder {
 
 export namespace ComputeEnvironmentOrder {
   export function isa(o: any): o is ComputeEnvironmentOrder {
-    return _smithy.isa(o, "ComputeEnvironmentOrder");
+    return __isa(o, "ComputeEnvironmentOrder");
   }
 }
 
@@ -457,7 +458,7 @@ export interface ComputeResource {
 
 export namespace ComputeResource {
   export function isa(o: any): o is ComputeResource {
-    return _smithy.isa(o, "ComputeResource");
+    return __isa(o, "ComputeResource");
   }
 }
 
@@ -484,7 +485,7 @@ export interface ComputeResourceUpdate {
 
 export namespace ComputeResourceUpdate {
   export function isa(o: any): o is ComputeResourceUpdate {
-    return _smithy.isa(o, "ComputeResourceUpdate");
+    return __isa(o, "ComputeResourceUpdate");
   }
 }
 
@@ -610,7 +611,7 @@ export interface ContainerDetail {
 
 export namespace ContainerDetail {
   export function isa(o: any): o is ContainerDetail {
-    return _smithy.isa(o, "ContainerDetail");
+    return __isa(o, "ContainerDetail");
   }
 }
 
@@ -662,7 +663,7 @@ export interface ContainerOverrides {
 
 export namespace ContainerOverrides {
   export function isa(o: any): o is ContainerOverrides {
-    return _smithy.isa(o, "ContainerOverrides");
+    return __isa(o, "ContainerOverrides");
   }
 }
 
@@ -804,7 +805,7 @@ export interface ContainerProperties {
 
 export namespace ContainerProperties {
   export function isa(o: any): o is ContainerProperties {
-    return _smithy.isa(o, "ContainerProperties");
+    return __isa(o, "ContainerProperties");
   }
 }
 
@@ -827,7 +828,7 @@ export interface ContainerSummary {
 
 export namespace ContainerSummary {
   export function isa(o: any): o is ContainerSummary {
-    return _smithy.isa(o, "ContainerSummary");
+    return __isa(o, "ContainerSummary");
   }
 }
 
@@ -874,7 +875,7 @@ export interface CreateComputeEnvironmentRequest {
 
 export namespace CreateComputeEnvironmentRequest {
   export function isa(o: any): o is CreateComputeEnvironmentRequest {
-    return _smithy.isa(o, "CreateComputeEnvironmentRequest");
+    return __isa(o, "CreateComputeEnvironmentRequest");
   }
 }
 
@@ -893,7 +894,7 @@ export interface CreateComputeEnvironmentResponse extends $MetadataBearer {
 
 export namespace CreateComputeEnvironmentResponse {
   export function isa(o: any): o is CreateComputeEnvironmentResponse {
-    return _smithy.isa(o, "CreateComputeEnvironmentResponse");
+    return __isa(o, "CreateComputeEnvironmentResponse");
   }
 }
 
@@ -928,7 +929,7 @@ export interface CreateJobQueueRequest {
 
 export namespace CreateJobQueueRequest {
   export function isa(o: any): o is CreateJobQueueRequest {
-    return _smithy.isa(o, "CreateJobQueueRequest");
+    return __isa(o, "CreateJobQueueRequest");
   }
 }
 
@@ -947,7 +948,7 @@ export interface CreateJobQueueResponse extends $MetadataBearer {
 
 export namespace CreateJobQueueResponse {
   export function isa(o: any): o is CreateJobQueueResponse {
-    return _smithy.isa(o, "CreateJobQueueResponse");
+    return __isa(o, "CreateJobQueueResponse");
   }
 }
 
@@ -961,7 +962,7 @@ export interface DeleteComputeEnvironmentRequest {
 
 export namespace DeleteComputeEnvironmentRequest {
   export function isa(o: any): o is DeleteComputeEnvironmentRequest {
-    return _smithy.isa(o, "DeleteComputeEnvironmentRequest");
+    return __isa(o, "DeleteComputeEnvironmentRequest");
   }
 }
 
@@ -971,7 +972,7 @@ export interface DeleteComputeEnvironmentResponse extends $MetadataBearer {
 
 export namespace DeleteComputeEnvironmentResponse {
   export function isa(o: any): o is DeleteComputeEnvironmentResponse {
-    return _smithy.isa(o, "DeleteComputeEnvironmentResponse");
+    return __isa(o, "DeleteComputeEnvironmentResponse");
   }
 }
 
@@ -985,7 +986,7 @@ export interface DeleteJobQueueRequest {
 
 export namespace DeleteJobQueueRequest {
   export function isa(o: any): o is DeleteJobQueueRequest {
-    return _smithy.isa(o, "DeleteJobQueueRequest");
+    return __isa(o, "DeleteJobQueueRequest");
   }
 }
 
@@ -995,7 +996,7 @@ export interface DeleteJobQueueResponse extends $MetadataBearer {
 
 export namespace DeleteJobQueueResponse {
   export function isa(o: any): o is DeleteJobQueueResponse {
-    return _smithy.isa(o, "DeleteJobQueueResponse");
+    return __isa(o, "DeleteJobQueueResponse");
   }
 }
 
@@ -1009,7 +1010,7 @@ export interface DeregisterJobDefinitionRequest {
 
 export namespace DeregisterJobDefinitionRequest {
   export function isa(o: any): o is DeregisterJobDefinitionRequest {
-    return _smithy.isa(o, "DeregisterJobDefinitionRequest");
+    return __isa(o, "DeregisterJobDefinitionRequest");
   }
 }
 
@@ -1019,7 +1020,7 @@ export interface DeregisterJobDefinitionResponse extends $MetadataBearer {
 
 export namespace DeregisterJobDefinitionResponse {
   export function isa(o: any): o is DeregisterJobDefinitionResponse {
-    return _smithy.isa(o, "DeregisterJobDefinitionResponse");
+    return __isa(o, "DeregisterJobDefinitionResponse");
   }
 }
 
@@ -1055,7 +1056,7 @@ export interface DescribeComputeEnvironmentsRequest {
 
 export namespace DescribeComputeEnvironmentsRequest {
   export function isa(o: any): o is DescribeComputeEnvironmentsRequest {
-    return _smithy.isa(o, "DescribeComputeEnvironmentsRequest");
+    return __isa(o, "DescribeComputeEnvironmentsRequest");
   }
 }
 
@@ -1077,7 +1078,7 @@ export interface DescribeComputeEnvironmentsResponse extends $MetadataBearer {
 
 export namespace DescribeComputeEnvironmentsResponse {
   export function isa(o: any): o is DescribeComputeEnvironmentsResponse {
-    return _smithy.isa(o, "DescribeComputeEnvironmentsResponse");
+    return __isa(o, "DescribeComputeEnvironmentsResponse");
   }
 }
 
@@ -1123,7 +1124,7 @@ export interface DescribeJobDefinitionsRequest {
 
 export namespace DescribeJobDefinitionsRequest {
   export function isa(o: any): o is DescribeJobDefinitionsRequest {
-    return _smithy.isa(o, "DescribeJobDefinitionsRequest");
+    return __isa(o, "DescribeJobDefinitionsRequest");
   }
 }
 
@@ -1144,7 +1145,7 @@ export interface DescribeJobDefinitionsResponse extends $MetadataBearer {
 
 export namespace DescribeJobDefinitionsResponse {
   export function isa(o: any): o is DescribeJobDefinitionsResponse {
-    return _smithy.isa(o, "DescribeJobDefinitionsResponse");
+    return __isa(o, "DescribeJobDefinitionsResponse");
   }
 }
 
@@ -1179,7 +1180,7 @@ export interface DescribeJobQueuesRequest {
 
 export namespace DescribeJobQueuesRequest {
   export function isa(o: any): o is DescribeJobQueuesRequest {
-    return _smithy.isa(o, "DescribeJobQueuesRequest");
+    return __isa(o, "DescribeJobQueuesRequest");
   }
 }
 
@@ -1200,7 +1201,7 @@ export interface DescribeJobQueuesResponse extends $MetadataBearer {
 
 export namespace DescribeJobQueuesResponse {
   export function isa(o: any): o is DescribeJobQueuesResponse {
-    return _smithy.isa(o, "DescribeJobQueuesResponse");
+    return __isa(o, "DescribeJobQueuesResponse");
   }
 }
 
@@ -1214,7 +1215,7 @@ export interface DescribeJobsRequest {
 
 export namespace DescribeJobsRequest {
   export function isa(o: any): o is DescribeJobsRequest {
-    return _smithy.isa(o, "DescribeJobsRequest");
+    return __isa(o, "DescribeJobsRequest");
   }
 }
 
@@ -1228,7 +1229,7 @@ export interface DescribeJobsResponse extends $MetadataBearer {
 
 export namespace DescribeJobsResponse {
   export function isa(o: any): o is DescribeJobsResponse {
-    return _smithy.isa(o, "DescribeJobsResponse");
+    return __isa(o, "DescribeJobsResponse");
   }
 }
 
@@ -1257,7 +1258,7 @@ export interface Device {
 
 export namespace Device {
   export function isa(o: any): o is Device {
-    return _smithy.isa(o, "Device");
+    return __isa(o, "Device");
   }
 }
 
@@ -1286,7 +1287,7 @@ export interface Host {
 
 export namespace Host {
   export function isa(o: any): o is Host {
-    return _smithy.isa(o, "Host");
+    return __isa(o, "Host");
   }
 }
 
@@ -1366,7 +1367,7 @@ export interface JobDefinition {
 
 export namespace JobDefinition {
   export function isa(o: any): o is JobDefinition {
-    return _smithy.isa(o, "JobDefinition");
+    return __isa(o, "JobDefinition");
   }
 }
 
@@ -1393,7 +1394,7 @@ export interface JobDependency {
 
 export namespace JobDependency {
   export function isa(o: any): o is JobDependency {
-    return _smithy.isa(o, "JobDependency");
+    return __isa(o, "JobDependency");
   }
 }
 
@@ -1505,7 +1506,7 @@ export interface JobDetail {
 
 export namespace JobDetail {
   export function isa(o: any): o is JobDetail {
-    return _smithy.isa(o, "JobDetail");
+    return __isa(o, "JobDetail");
   }
 }
 
@@ -1553,7 +1554,7 @@ export interface JobQueueDetail {
 
 export namespace JobQueueDetail {
   export function isa(o: any): o is JobQueueDetail {
-    return _smithy.isa(o, "JobQueueDetail");
+    return __isa(o, "JobQueueDetail");
   }
 }
 
@@ -1629,7 +1630,7 @@ export interface JobSummary {
 
 export namespace JobSummary {
   export function isa(o: any): o is JobSummary {
-    return _smithy.isa(o, "JobSummary");
+    return __isa(o, "JobSummary");
   }
 }
 
@@ -1647,7 +1648,7 @@ export interface JobTimeout {
 
 export namespace JobTimeout {
   export function isa(o: any): o is JobTimeout {
-    return _smithy.isa(o, "JobTimeout");
+    return __isa(o, "JobTimeout");
   }
 }
 
@@ -1670,7 +1671,7 @@ export interface KeyValuePair {
 
 export namespace KeyValuePair {
   export function isa(o: any): o is KeyValuePair {
-    return _smithy.isa(o, "KeyValuePair");
+    return __isa(o, "KeyValuePair");
   }
 }
 
@@ -1699,7 +1700,7 @@ export interface LaunchTemplateSpecification {
 
 export namespace LaunchTemplateSpecification {
   export function isa(o: any): o is LaunchTemplateSpecification {
-    return _smithy.isa(o, "LaunchTemplateSpecification");
+    return __isa(o, "LaunchTemplateSpecification");
   }
 }
 
@@ -1717,7 +1718,7 @@ export interface LinuxParameters {
 
 export namespace LinuxParameters {
   export function isa(o: any): o is LinuxParameters {
-    return _smithy.isa(o, "LinuxParameters");
+    return __isa(o, "LinuxParameters");
   }
 }
 
@@ -1770,7 +1771,7 @@ export interface ListJobsRequest {
 
 export namespace ListJobsRequest {
   export function isa(o: any): o is ListJobsRequest {
-    return _smithy.isa(o, "ListJobsRequest");
+    return __isa(o, "ListJobsRequest");
   }
 }
 
@@ -1791,7 +1792,7 @@ export interface ListJobsResponse extends $MetadataBearer {
 
 export namespace ListJobsResponse {
   export function isa(o: any): o is ListJobsResponse {
-    return _smithy.isa(o, "ListJobsResponse");
+    return __isa(o, "ListJobsResponse");
   }
 }
 
@@ -1821,7 +1822,7 @@ export interface MountPoint {
 
 export namespace MountPoint {
   export function isa(o: any): o is MountPoint {
-    return _smithy.isa(o, "MountPoint");
+    return __isa(o, "MountPoint");
   }
 }
 
@@ -1848,7 +1849,7 @@ export interface NetworkInterface {
 
 export namespace NetworkInterface {
   export function isa(o: any): o is NetworkInterface {
-    return _smithy.isa(o, "NetworkInterface");
+    return __isa(o, "NetworkInterface");
   }
 }
 
@@ -1871,7 +1872,7 @@ export interface NodeDetails {
 
 export namespace NodeDetails {
   export function isa(o: any): o is NodeDetails {
-    return _smithy.isa(o, "NodeDetails");
+    return __isa(o, "NodeDetails");
   }
 }
 
@@ -1909,7 +1910,7 @@ export interface NodeOverrides {
 
 export namespace NodeOverrides {
   export function isa(o: any): o is NodeOverrides {
-    return _smithy.isa(o, "NodeOverrides");
+    return __isa(o, "NodeOverrides");
   }
 }
 
@@ -1937,7 +1938,7 @@ export interface NodeProperties {
 
 export namespace NodeProperties {
   export function isa(o: any): o is NodeProperties {
-    return _smithy.isa(o, "NodeProperties");
+    return __isa(o, "NodeProperties");
   }
 }
 
@@ -1965,7 +1966,7 @@ export interface NodePropertiesSummary {
 
 export namespace NodePropertiesSummary {
   export function isa(o: any): o is NodePropertiesSummary {
-    return _smithy.isa(o, "NodePropertiesSummary");
+    return __isa(o, "NodePropertiesSummary");
   }
 }
 
@@ -1991,7 +1992,7 @@ export interface NodePropertyOverride {
 
 export namespace NodePropertyOverride {
   export function isa(o: any): o is NodePropertyOverride {
-    return _smithy.isa(o, "NodePropertyOverride");
+    return __isa(o, "NodePropertyOverride");
   }
 }
 
@@ -2017,7 +2018,7 @@ export interface NodeRangeProperty {
 
 export namespace NodeRangeProperty {
   export function isa(o: any): o is NodeRangeProperty {
-    return _smithy.isa(o, "NodeRangeProperty");
+    return __isa(o, "NodeRangeProperty");
   }
 }
 
@@ -2076,7 +2077,7 @@ export interface RegisterJobDefinitionRequest {
 
 export namespace RegisterJobDefinitionRequest {
   export function isa(o: any): o is RegisterJobDefinitionRequest {
-    return _smithy.isa(o, "RegisterJobDefinitionRequest");
+    return __isa(o, "RegisterJobDefinitionRequest");
   }
 }
 
@@ -2100,7 +2101,7 @@ export interface RegisterJobDefinitionResponse extends $MetadataBearer {
 
 export namespace RegisterJobDefinitionResponse {
   export function isa(o: any): o is RegisterJobDefinitionResponse {
-    return _smithy.isa(o, "RegisterJobDefinitionResponse");
+    return __isa(o, "RegisterJobDefinitionResponse");
   }
 }
 
@@ -2125,7 +2126,7 @@ export interface ResourceRequirement {
 
 export namespace ResourceRequirement {
   export function isa(o: any): o is ResourceRequirement {
-    return _smithy.isa(o, "ResourceRequirement");
+    return __isa(o, "ResourceRequirement");
   }
 }
 
@@ -2148,16 +2149,14 @@ export interface RetryStrategy {
 
 export namespace RetryStrategy {
   export function isa(o: any): o is RetryStrategy {
-    return _smithy.isa(o, "RetryStrategy");
+    return __isa(o, "RetryStrategy");
   }
 }
 
 /**
  * <p>These errors are usually caused by a server issue.</p>
  */
-export interface ServerException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface ServerException extends __SmithyException, $MetadataBearer {
   name: "ServerException";
   $fault: "server";
   message?: string;
@@ -2165,7 +2164,7 @@ export interface ServerException
 
 export namespace ServerException {
   export function isa(o: any): o is ServerException {
-    return _smithy.isa(o, "ServerException");
+    return __isa(o, "ServerException");
   }
 }
 
@@ -2247,7 +2246,7 @@ export interface SubmitJobRequest {
 
 export namespace SubmitJobRequest {
   export function isa(o: any): o is SubmitJobRequest {
-    return _smithy.isa(o, "SubmitJobRequest");
+    return __isa(o, "SubmitJobRequest");
   }
 }
 
@@ -2266,7 +2265,7 @@ export interface SubmitJobResponse extends $MetadataBearer {
 
 export namespace SubmitJobResponse {
   export function isa(o: any): o is SubmitJobResponse {
-    return _smithy.isa(o, "SubmitJobResponse");
+    return __isa(o, "SubmitJobResponse");
   }
 }
 
@@ -2287,7 +2286,7 @@ export interface TerminateJobRequest {
 
 export namespace TerminateJobRequest {
   export function isa(o: any): o is TerminateJobRequest {
-    return _smithy.isa(o, "TerminateJobRequest");
+    return __isa(o, "TerminateJobRequest");
   }
 }
 
@@ -2297,7 +2296,7 @@ export interface TerminateJobResponse extends $MetadataBearer {
 
 export namespace TerminateJobResponse {
   export function isa(o: any): o is TerminateJobResponse {
-    return _smithy.isa(o, "TerminateJobResponse");
+    return __isa(o, "TerminateJobResponse");
   }
 }
 
@@ -2324,7 +2323,7 @@ export interface Ulimit {
 
 export namespace Ulimit {
   export function isa(o: any): o is Ulimit {
-    return _smithy.isa(o, "Ulimit");
+    return __isa(o, "Ulimit");
   }
 }
 
@@ -2364,7 +2363,7 @@ export interface UpdateComputeEnvironmentRequest {
 
 export namespace UpdateComputeEnvironmentRequest {
   export function isa(o: any): o is UpdateComputeEnvironmentRequest {
-    return _smithy.isa(o, "UpdateComputeEnvironmentRequest");
+    return __isa(o, "UpdateComputeEnvironmentRequest");
   }
 }
 
@@ -2383,7 +2382,7 @@ export interface UpdateComputeEnvironmentResponse extends $MetadataBearer {
 
 export namespace UpdateComputeEnvironmentResponse {
   export function isa(o: any): o is UpdateComputeEnvironmentResponse {
-    return _smithy.isa(o, "UpdateComputeEnvironmentResponse");
+    return __isa(o, "UpdateComputeEnvironmentResponse");
   }
 }
 
@@ -2417,7 +2416,7 @@ export interface UpdateJobQueueRequest {
 
 export namespace UpdateJobQueueRequest {
   export function isa(o: any): o is UpdateJobQueueRequest {
-    return _smithy.isa(o, "UpdateJobQueueRequest");
+    return __isa(o, "UpdateJobQueueRequest");
   }
 }
 
@@ -2436,7 +2435,7 @@ export interface UpdateJobQueueResponse extends $MetadataBearer {
 
 export namespace UpdateJobQueueResponse {
   export function isa(o: any): o is UpdateJobQueueResponse {
-    return _smithy.isa(o, "UpdateJobQueueResponse");
+    return __isa(o, "UpdateJobQueueResponse");
   }
 }
 
@@ -2462,6 +2461,6 @@ export interface Volume {
 
 export namespace Volume {
   export function isa(o: any): o is Volume {
-    return _smithy.isa(o, "Volume");
+    return __isa(o, "Volume");
   }
 }

--- a/clients/client-batch/protocols/Aws_restJson1_1.ts
+++ b/clients/client-batch/protocols/Aws_restJson1_1.ts
@@ -693,6 +693,7 @@ export async function deserializeAws_restJson1_1CancelJobCommand(
     $metadata: deserializeMetadata(output),
     __type: "CancelJobResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -891,6 +892,7 @@ export async function deserializeAws_restJson1_1DeleteComputeEnvironmentCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeleteComputeEnvironmentResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -949,6 +951,7 @@ export async function deserializeAws_restJson1_1DeleteJobQueueCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeleteJobQueueResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -1007,6 +1010,7 @@ export async function deserializeAws_restJson1_1DeregisterJobDefinitionCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeregisterJobDefinitionResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -1537,6 +1541,7 @@ export async function deserializeAws_restJson1_1TerminateJobCommand(
     $metadata: deserializeMetadata(output),
     __type: "TerminateJobResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 

--- a/clients/client-budgets/models/index.ts
+++ b/clients/client-budgets/models/index.ts
@@ -1,11 +1,14 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
  * <p>You are not authorized to use this operation with the given parameters.</p>
  */
 export interface AccessDeniedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AccessDeniedException";
   $fault: "client";
@@ -17,7 +20,7 @@ export interface AccessDeniedException
 
 export namespace AccessDeniedException {
   export function isa(o: any): o is AccessDeniedException {
-    return _smithy.isa(o, "AccessDeniedException");
+    return __isa(o, "AccessDeniedException");
   }
 }
 
@@ -117,7 +120,7 @@ export interface Budget {
 
 export namespace Budget {
   export function isa(o: any): o is Budget {
-    return _smithy.isa(o, "Budget");
+    return __isa(o, "Budget");
   }
 }
 
@@ -161,7 +164,7 @@ export interface BudgetPerformanceHistory {
 
 export namespace BudgetPerformanceHistory {
   export function isa(o: any): o is BudgetPerformanceHistory {
-    return _smithy.isa(o, "BudgetPerformanceHistory");
+    return __isa(o, "BudgetPerformanceHistory");
   }
 }
 
@@ -197,7 +200,7 @@ export interface BudgetedAndActualAmounts {
 
 export namespace BudgetedAndActualAmounts {
   export function isa(o: any): o is BudgetedAndActualAmounts {
-    return _smithy.isa(o, "BudgetedAndActualAmounts");
+    return __isa(o, "BudgetedAndActualAmounts");
   }
 }
 
@@ -220,7 +223,7 @@ export interface CalculatedSpend {
 
 export namespace CalculatedSpend {
   export function isa(o: any): o is CalculatedSpend {
-    return _smithy.isa(o, "CalculatedSpend");
+    return __isa(o, "CalculatedSpend");
   }
 }
 
@@ -306,7 +309,7 @@ export interface CostTypes {
 
 export namespace CostTypes {
   export function isa(o: any): o is CostTypes {
-    return _smithy.isa(o, "CostTypes");
+    return __isa(o, "CostTypes");
   }
 }
 
@@ -333,7 +336,7 @@ export interface CreateBudgetRequest {
 
 export namespace CreateBudgetRequest {
   export function isa(o: any): o is CreateBudgetRequest {
-    return _smithy.isa(o, "CreateBudgetRequest");
+    return __isa(o, "CreateBudgetRequest");
   }
 }
 
@@ -346,7 +349,7 @@ export interface CreateBudgetResponse extends $MetadataBearer {
 
 export namespace CreateBudgetResponse {
   export function isa(o: any): o is CreateBudgetResponse {
-    return _smithy.isa(o, "CreateBudgetResponse");
+    return __isa(o, "CreateBudgetResponse");
   }
 }
 
@@ -378,7 +381,7 @@ export interface CreateNotificationRequest {
 
 export namespace CreateNotificationRequest {
   export function isa(o: any): o is CreateNotificationRequest {
-    return _smithy.isa(o, "CreateNotificationRequest");
+    return __isa(o, "CreateNotificationRequest");
   }
 }
 
@@ -391,7 +394,7 @@ export interface CreateNotificationResponse extends $MetadataBearer {
 
 export namespace CreateNotificationResponse {
   export function isa(o: any): o is CreateNotificationResponse {
-    return _smithy.isa(o, "CreateNotificationResponse");
+    return __isa(o, "CreateNotificationResponse");
   }
 }
 
@@ -423,7 +426,7 @@ export interface CreateSubscriberRequest {
 
 export namespace CreateSubscriberRequest {
   export function isa(o: any): o is CreateSubscriberRequest {
-    return _smithy.isa(o, "CreateSubscriberRequest");
+    return __isa(o, "CreateSubscriberRequest");
   }
 }
 
@@ -436,7 +439,7 @@ export interface CreateSubscriberResponse extends $MetadataBearer {
 
 export namespace CreateSubscriberResponse {
   export function isa(o: any): o is CreateSubscriberResponse {
-    return _smithy.isa(o, "CreateSubscriberResponse");
+    return __isa(o, "CreateSubscriberResponse");
   }
 }
 
@@ -444,7 +447,7 @@ export namespace CreateSubscriberResponse {
  * <p>You've exceeded the notification or subscriber limit.</p>
  */
 export interface CreationLimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CreationLimitExceededException";
   $fault: "client";
@@ -456,7 +459,7 @@ export interface CreationLimitExceededException
 
 export namespace CreationLimitExceededException {
   export function isa(o: any): o is CreationLimitExceededException {
-    return _smithy.isa(o, "CreationLimitExceededException");
+    return __isa(o, "CreationLimitExceededException");
   }
 }
 
@@ -478,7 +481,7 @@ export interface DeleteBudgetRequest {
 
 export namespace DeleteBudgetRequest {
   export function isa(o: any): o is DeleteBudgetRequest {
-    return _smithy.isa(o, "DeleteBudgetRequest");
+    return __isa(o, "DeleteBudgetRequest");
   }
 }
 
@@ -491,7 +494,7 @@ export interface DeleteBudgetResponse extends $MetadataBearer {
 
 export namespace DeleteBudgetResponse {
   export function isa(o: any): o is DeleteBudgetResponse {
-    return _smithy.isa(o, "DeleteBudgetResponse");
+    return __isa(o, "DeleteBudgetResponse");
   }
 }
 
@@ -518,7 +521,7 @@ export interface DeleteNotificationRequest {
 
 export namespace DeleteNotificationRequest {
   export function isa(o: any): o is DeleteNotificationRequest {
-    return _smithy.isa(o, "DeleteNotificationRequest");
+    return __isa(o, "DeleteNotificationRequest");
   }
 }
 
@@ -531,7 +534,7 @@ export interface DeleteNotificationResponse extends $MetadataBearer {
 
 export namespace DeleteNotificationResponse {
   export function isa(o: any): o is DeleteNotificationResponse {
-    return _smithy.isa(o, "DeleteNotificationResponse");
+    return __isa(o, "DeleteNotificationResponse");
   }
 }
 
@@ -563,7 +566,7 @@ export interface DeleteSubscriberRequest {
 
 export namespace DeleteSubscriberRequest {
   export function isa(o: any): o is DeleteSubscriberRequest {
-    return _smithy.isa(o, "DeleteSubscriberRequest");
+    return __isa(o, "DeleteSubscriberRequest");
   }
 }
 
@@ -576,7 +579,7 @@ export interface DeleteSubscriberResponse extends $MetadataBearer {
 
 export namespace DeleteSubscriberResponse {
   export function isa(o: any): o is DeleteSubscriberResponse {
-    return _smithy.isa(o, "DeleteSubscriberResponse");
+    return __isa(o, "DeleteSubscriberResponse");
   }
 }
 
@@ -610,7 +613,7 @@ export interface DescribeBudgetPerformanceHistoryRequest {
 
 export namespace DescribeBudgetPerformanceHistoryRequest {
   export function isa(o: any): o is DescribeBudgetPerformanceHistoryRequest {
-    return _smithy.isa(o, "DescribeBudgetPerformanceHistoryRequest");
+    return __isa(o, "DescribeBudgetPerformanceHistoryRequest");
   }
 }
 
@@ -631,7 +634,7 @@ export interface DescribeBudgetPerformanceHistoryResponse
 
 export namespace DescribeBudgetPerformanceHistoryResponse {
   export function isa(o: any): o is DescribeBudgetPerformanceHistoryResponse {
-    return _smithy.isa(o, "DescribeBudgetPerformanceHistoryResponse");
+    return __isa(o, "DescribeBudgetPerformanceHistoryResponse");
   }
 }
 
@@ -653,7 +656,7 @@ export interface DescribeBudgetRequest {
 
 export namespace DescribeBudgetRequest {
   export function isa(o: any): o is DescribeBudgetRequest {
-    return _smithy.isa(o, "DescribeBudgetRequest");
+    return __isa(o, "DescribeBudgetRequest");
   }
 }
 
@@ -670,7 +673,7 @@ export interface DescribeBudgetResponse extends $MetadataBearer {
 
 export namespace DescribeBudgetResponse {
   export function isa(o: any): o is DescribeBudgetResponse {
-    return _smithy.isa(o, "DescribeBudgetResponse");
+    return __isa(o, "DescribeBudgetResponse");
   }
 }
 
@@ -697,7 +700,7 @@ export interface DescribeBudgetsRequest {
 
 export namespace DescribeBudgetsRequest {
   export function isa(o: any): o is DescribeBudgetsRequest {
-    return _smithy.isa(o, "DescribeBudgetsRequest");
+    return __isa(o, "DescribeBudgetsRequest");
   }
 }
 
@@ -719,7 +722,7 @@ export interface DescribeBudgetsResponse extends $MetadataBearer {
 
 export namespace DescribeBudgetsResponse {
   export function isa(o: any): o is DescribeBudgetsResponse {
-    return _smithy.isa(o, "DescribeBudgetsResponse");
+    return __isa(o, "DescribeBudgetsResponse");
   }
 }
 
@@ -751,7 +754,7 @@ export interface DescribeNotificationsForBudgetRequest {
 
 export namespace DescribeNotificationsForBudgetRequest {
   export function isa(o: any): o is DescribeNotificationsForBudgetRequest {
-    return _smithy.isa(o, "DescribeNotificationsForBudgetRequest");
+    return __isa(o, "DescribeNotificationsForBudgetRequest");
   }
 }
 
@@ -774,7 +777,7 @@ export interface DescribeNotificationsForBudgetResponse
 
 export namespace DescribeNotificationsForBudgetResponse {
   export function isa(o: any): o is DescribeNotificationsForBudgetResponse {
-    return _smithy.isa(o, "DescribeNotificationsForBudgetResponse");
+    return __isa(o, "DescribeNotificationsForBudgetResponse");
   }
 }
 
@@ -811,7 +814,7 @@ export interface DescribeSubscribersForNotificationRequest {
 
 export namespace DescribeSubscribersForNotificationRequest {
   export function isa(o: any): o is DescribeSubscribersForNotificationRequest {
-    return _smithy.isa(o, "DescribeSubscribersForNotificationRequest");
+    return __isa(o, "DescribeSubscribersForNotificationRequest");
   }
 }
 
@@ -834,7 +837,7 @@ export interface DescribeSubscribersForNotificationResponse
 
 export namespace DescribeSubscribersForNotificationResponse {
   export function isa(o: any): o is DescribeSubscribersForNotificationResponse {
-    return _smithy.isa(o, "DescribeSubscribersForNotificationResponse");
+    return __isa(o, "DescribeSubscribersForNotificationResponse");
   }
 }
 
@@ -842,7 +845,7 @@ export namespace DescribeSubscribersForNotificationResponse {
  * <p>The budget name already exists. Budget names must be unique within an account.</p>
  */
 export interface DuplicateRecordException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DuplicateRecordException";
   $fault: "client";
@@ -854,7 +857,7 @@ export interface DuplicateRecordException
 
 export namespace DuplicateRecordException {
   export function isa(o: any): o is DuplicateRecordException {
-    return _smithy.isa(o, "DuplicateRecordException");
+    return __isa(o, "DuplicateRecordException");
   }
 }
 
@@ -862,7 +865,7 @@ export namespace DuplicateRecordException {
  * <p>The pagination token expired.</p>
  */
 export interface ExpiredNextTokenException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ExpiredNextTokenException";
   $fault: "client";
@@ -874,7 +877,7 @@ export interface ExpiredNextTokenException
 
 export namespace ExpiredNextTokenException {
   export function isa(o: any): o is ExpiredNextTokenException {
-    return _smithy.isa(o, "ExpiredNextTokenException");
+    return __isa(o, "ExpiredNextTokenException");
   }
 }
 
@@ -882,7 +885,7 @@ export namespace ExpiredNextTokenException {
  * <p>An error on the server occurred during the processing of your request. Try again later.</p>
  */
 export interface InternalErrorException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalErrorException";
   $fault: "server";
@@ -894,7 +897,7 @@ export interface InternalErrorException
 
 export namespace InternalErrorException {
   export function isa(o: any): o is InternalErrorException {
-    return _smithy.isa(o, "InternalErrorException");
+    return __isa(o, "InternalErrorException");
   }
 }
 
@@ -902,7 +905,7 @@ export namespace InternalErrorException {
  * <p>The pagination token is invalid.</p>
  */
 export interface InvalidNextTokenException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidNextTokenException";
   $fault: "client";
@@ -914,7 +917,7 @@ export interface InvalidNextTokenException
 
 export namespace InvalidNextTokenException {
   export function isa(o: any): o is InvalidNextTokenException {
-    return _smithy.isa(o, "InvalidNextTokenException");
+    return __isa(o, "InvalidNextTokenException");
   }
 }
 
@@ -922,7 +925,7 @@ export namespace InvalidNextTokenException {
  * <p>An error on the client occurred. Typically, the cause is an invalid input value.</p>
  */
 export interface InvalidParameterException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidParameterException";
   $fault: "client";
@@ -934,16 +937,14 @@ export interface InvalidParameterException
 
 export namespace InvalidParameterException {
   export function isa(o: any): o is InvalidParameterException {
-    return _smithy.isa(o, "InvalidParameterException");
+    return __isa(o, "InvalidParameterException");
   }
 }
 
 /**
  * <p>We can’t locate the resource that you specified.</p>
  */
-export interface NotFoundException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface NotFoundException extends __SmithyException, $MetadataBearer {
   name: "NotFoundException";
   $fault: "client";
   /**
@@ -954,7 +955,7 @@ export interface NotFoundException
 
 export namespace NotFoundException {
   export function isa(o: any): o is NotFoundException {
-    return _smithy.isa(o, "NotFoundException");
+    return __isa(o, "NotFoundException");
   }
 }
 
@@ -1011,7 +1012,7 @@ export interface Notification {
 
 export namespace Notification {
   export function isa(o: any): o is Notification {
-    return _smithy.isa(o, "Notification");
+    return __isa(o, "Notification");
   }
 }
 
@@ -1043,7 +1044,7 @@ export interface NotificationWithSubscribers {
 
 export namespace NotificationWithSubscribers {
   export function isa(o: any): o is NotificationWithSubscribers {
-    return _smithy.isa(o, "NotificationWithSubscribers");
+    return __isa(o, "NotificationWithSubscribers");
   }
 }
 
@@ -1076,7 +1077,7 @@ export interface Spend {
 
 export namespace Spend {
   export function isa(o: any): o is Spend {
-    return _smithy.isa(o, "Spend");
+    return __isa(o, "Spend");
   }
 }
 
@@ -1110,7 +1111,7 @@ export interface Subscriber {
 
 export namespace Subscriber {
   export function isa(o: any): o is Subscriber {
-    return _smithy.isa(o, "Subscriber");
+    return __isa(o, "Subscriber");
   }
 }
 
@@ -1144,7 +1145,7 @@ export interface TimePeriod {
 
 export namespace TimePeriod {
   export function isa(o: any): o is TimePeriod {
-    return _smithy.isa(o, "TimePeriod");
+    return __isa(o, "TimePeriod");
   }
 }
 
@@ -1173,7 +1174,7 @@ export interface UpdateBudgetRequest {
 
 export namespace UpdateBudgetRequest {
   export function isa(o: any): o is UpdateBudgetRequest {
-    return _smithy.isa(o, "UpdateBudgetRequest");
+    return __isa(o, "UpdateBudgetRequest");
   }
 }
 
@@ -1186,7 +1187,7 @@ export interface UpdateBudgetResponse extends $MetadataBearer {
 
 export namespace UpdateBudgetResponse {
   export function isa(o: any): o is UpdateBudgetResponse {
-    return _smithy.isa(o, "UpdateBudgetResponse");
+    return __isa(o, "UpdateBudgetResponse");
   }
 }
 
@@ -1218,7 +1219,7 @@ export interface UpdateNotificationRequest {
 
 export namespace UpdateNotificationRequest {
   export function isa(o: any): o is UpdateNotificationRequest {
-    return _smithy.isa(o, "UpdateNotificationRequest");
+    return __isa(o, "UpdateNotificationRequest");
   }
 }
 
@@ -1231,7 +1232,7 @@ export interface UpdateNotificationResponse extends $MetadataBearer {
 
 export namespace UpdateNotificationResponse {
   export function isa(o: any): o is UpdateNotificationResponse {
-    return _smithy.isa(o, "UpdateNotificationResponse");
+    return __isa(o, "UpdateNotificationResponse");
   }
 }
 
@@ -1268,7 +1269,7 @@ export interface UpdateSubscriberRequest {
 
 export namespace UpdateSubscriberRequest {
   export function isa(o: any): o is UpdateSubscriberRequest {
-    return _smithy.isa(o, "UpdateSubscriberRequest");
+    return __isa(o, "UpdateSubscriberRequest");
   }
 }
 
@@ -1281,6 +1282,6 @@ export interface UpdateSubscriberResponse extends $MetadataBearer {
 
 export namespace UpdateSubscriberResponse {
   export function isa(o: any): o is UpdateSubscriberResponse {
-    return _smithy.isa(o, "UpdateSubscriberResponse");
+    return __isa(o, "UpdateSubscriberResponse");
   }
 }

--- a/clients/client-chime/models/index.ts
+++ b/clients/client-chime/models/index.ts
@@ -1,11 +1,14 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
  * <p>You don't have permissions to perform the requested operation.</p>
  */
 export interface AccessDeniedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AccessDeniedException";
   $fault: "client";
@@ -15,7 +18,7 @@ export interface AccessDeniedException
 
 export namespace AccessDeniedException {
   export function isa(o: any): o is AccessDeniedException {
-    return _smithy.isa(o, "AccessDeniedException");
+    return __isa(o, "AccessDeniedException");
   }
 }
 
@@ -70,7 +73,7 @@ export interface Account {
 
 export namespace Account {
   export function isa(o: any): o is Account {
-    return _smithy.isa(o, "Account");
+    return __isa(o, "Account");
   }
 }
 
@@ -96,7 +99,7 @@ export interface AccountSettings {
 
 export namespace AccountSettings {
   export function isa(o: any): o is AccountSettings {
-    return _smithy.isa(o, "AccountSettings");
+    return __isa(o, "AccountSettings");
   }
 }
 
@@ -125,7 +128,7 @@ export interface AlexaForBusinessMetadata {
 
 export namespace AlexaForBusinessMetadata {
   export function isa(o: any): o is AlexaForBusinessMetadata {
-    return _smithy.isa(o, "AlexaForBusinessMetadata");
+    return __isa(o, "AlexaForBusinessMetadata");
   }
 }
 
@@ -149,7 +152,7 @@ export interface AssociatePhoneNumberWithUserRequest {
 
 export namespace AssociatePhoneNumberWithUserRequest {
   export function isa(o: any): o is AssociatePhoneNumberWithUserRequest {
-    return _smithy.isa(o, "AssociatePhoneNumberWithUserRequest");
+    return __isa(o, "AssociatePhoneNumberWithUserRequest");
   }
 }
 
@@ -159,7 +162,7 @@ export interface AssociatePhoneNumberWithUserResponse extends $MetadataBearer {
 
 export namespace AssociatePhoneNumberWithUserResponse {
   export function isa(o: any): o is AssociatePhoneNumberWithUserResponse {
-    return _smithy.isa(o, "AssociatePhoneNumberWithUserResponse");
+    return __isa(o, "AssociatePhoneNumberWithUserResponse");
   }
 }
 
@@ -185,10 +188,7 @@ export namespace AssociatePhoneNumbersWithVoiceConnectorGroupRequest {
   export function isa(
     o: any
   ): o is AssociatePhoneNumbersWithVoiceConnectorGroupRequest {
-    return _smithy.isa(
-      o,
-      "AssociatePhoneNumbersWithVoiceConnectorGroupRequest"
-    );
+    return __isa(o, "AssociatePhoneNumbersWithVoiceConnectorGroupRequest");
   }
 }
 
@@ -205,10 +205,7 @@ export namespace AssociatePhoneNumbersWithVoiceConnectorGroupResponse {
   export function isa(
     o: any
   ): o is AssociatePhoneNumbersWithVoiceConnectorGroupResponse {
-    return _smithy.isa(
-      o,
-      "AssociatePhoneNumbersWithVoiceConnectorGroupResponse"
-    );
+    return __isa(o, "AssociatePhoneNumbersWithVoiceConnectorGroupResponse");
   }
 }
 
@@ -234,7 +231,7 @@ export namespace AssociatePhoneNumbersWithVoiceConnectorRequest {
   export function isa(
     o: any
   ): o is AssociatePhoneNumbersWithVoiceConnectorRequest {
-    return _smithy.isa(o, "AssociatePhoneNumbersWithVoiceConnectorRequest");
+    return __isa(o, "AssociatePhoneNumbersWithVoiceConnectorRequest");
   }
 }
 
@@ -251,7 +248,7 @@ export namespace AssociatePhoneNumbersWithVoiceConnectorResponse {
   export function isa(
     o: any
   ): o is AssociatePhoneNumbersWithVoiceConnectorResponse {
-    return _smithy.isa(o, "AssociatePhoneNumbersWithVoiceConnectorResponse");
+    return __isa(o, "AssociatePhoneNumbersWithVoiceConnectorResponse");
   }
 }
 
@@ -272,7 +269,7 @@ export namespace AssociateSigninDelegateGroupsWithAccountRequest {
   export function isa(
     o: any
   ): o is AssociateSigninDelegateGroupsWithAccountRequest {
-    return _smithy.isa(o, "AssociateSigninDelegateGroupsWithAccountRequest");
+    return __isa(o, "AssociateSigninDelegateGroupsWithAccountRequest");
   }
 }
 
@@ -285,7 +282,7 @@ export namespace AssociateSigninDelegateGroupsWithAccountResponse {
   export function isa(
     o: any
   ): o is AssociateSigninDelegateGroupsWithAccountResponse {
-    return _smithy.isa(o, "AssociateSigninDelegateGroupsWithAccountResponse");
+    return __isa(o, "AssociateSigninDelegateGroupsWithAccountResponse");
   }
 }
 
@@ -315,7 +312,7 @@ export interface Attendee {
 
 export namespace Attendee {
   export function isa(o: any): o is Attendee {
-    return _smithy.isa(o, "Attendee");
+    return __isa(o, "Attendee");
   }
 }
 
@@ -323,7 +320,7 @@ export namespace Attendee {
  * <p>The input parameters don't match the service's restrictions.</p>
  */
 export interface BadRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "BadRequestException";
   $fault: "client";
@@ -333,7 +330,7 @@ export interface BadRequestException
 
 export namespace BadRequestException {
   export function isa(o: any): o is BadRequestException {
-    return _smithy.isa(o, "BadRequestException");
+    return __isa(o, "BadRequestException");
   }
 }
 
@@ -352,7 +349,7 @@ export interface BatchCreateAttendeeRequest {
 
 export namespace BatchCreateAttendeeRequest {
   export function isa(o: any): o is BatchCreateAttendeeRequest {
-    return _smithy.isa(o, "BatchCreateAttendeeRequest");
+    return __isa(o, "BatchCreateAttendeeRequest");
   }
 }
 
@@ -371,7 +368,7 @@ export interface BatchCreateAttendeeResponse extends $MetadataBearer {
 
 export namespace BatchCreateAttendeeResponse {
   export function isa(o: any): o is BatchCreateAttendeeResponse {
-    return _smithy.isa(o, "BatchCreateAttendeeResponse");
+    return __isa(o, "BatchCreateAttendeeResponse");
   }
 }
 
@@ -395,7 +392,7 @@ export interface BatchCreateRoomMembershipRequest {
 
 export namespace BatchCreateRoomMembershipRequest {
   export function isa(o: any): o is BatchCreateRoomMembershipRequest {
-    return _smithy.isa(o, "BatchCreateRoomMembershipRequest");
+    return __isa(o, "BatchCreateRoomMembershipRequest");
   }
 }
 
@@ -409,7 +406,7 @@ export interface BatchCreateRoomMembershipResponse extends $MetadataBearer {
 
 export namespace BatchCreateRoomMembershipResponse {
   export function isa(o: any): o is BatchCreateRoomMembershipResponse {
-    return _smithy.isa(o, "BatchCreateRoomMembershipResponse");
+    return __isa(o, "BatchCreateRoomMembershipResponse");
   }
 }
 
@@ -423,7 +420,7 @@ export interface BatchDeletePhoneNumberRequest {
 
 export namespace BatchDeletePhoneNumberRequest {
   export function isa(o: any): o is BatchDeletePhoneNumberRequest {
-    return _smithy.isa(o, "BatchDeletePhoneNumberRequest");
+    return __isa(o, "BatchDeletePhoneNumberRequest");
   }
 }
 
@@ -437,7 +434,7 @@ export interface BatchDeletePhoneNumberResponse extends $MetadataBearer {
 
 export namespace BatchDeletePhoneNumberResponse {
   export function isa(o: any): o is BatchDeletePhoneNumberResponse {
-    return _smithy.isa(o, "BatchDeletePhoneNumberResponse");
+    return __isa(o, "BatchDeletePhoneNumberResponse");
   }
 }
 
@@ -456,7 +453,7 @@ export interface BatchSuspendUserRequest {
 
 export namespace BatchSuspendUserRequest {
   export function isa(o: any): o is BatchSuspendUserRequest {
-    return _smithy.isa(o, "BatchSuspendUserRequest");
+    return __isa(o, "BatchSuspendUserRequest");
   }
 }
 
@@ -472,7 +469,7 @@ export interface BatchSuspendUserResponse extends $MetadataBearer {
 
 export namespace BatchSuspendUserResponse {
   export function isa(o: any): o is BatchSuspendUserResponse {
-    return _smithy.isa(o, "BatchSuspendUserResponse");
+    return __isa(o, "BatchSuspendUserResponse");
   }
 }
 
@@ -491,7 +488,7 @@ export interface BatchUnsuspendUserRequest {
 
 export namespace BatchUnsuspendUserRequest {
   export function isa(o: any): o is BatchUnsuspendUserRequest {
-    return _smithy.isa(o, "BatchUnsuspendUserRequest");
+    return __isa(o, "BatchUnsuspendUserRequest");
   }
 }
 
@@ -507,7 +504,7 @@ export interface BatchUnsuspendUserResponse extends $MetadataBearer {
 
 export namespace BatchUnsuspendUserResponse {
   export function isa(o: any): o is BatchUnsuspendUserResponse {
-    return _smithy.isa(o, "BatchUnsuspendUserResponse");
+    return __isa(o, "BatchUnsuspendUserResponse");
   }
 }
 
@@ -523,7 +520,7 @@ export interface BatchUpdatePhoneNumberRequest {
 
 export namespace BatchUpdatePhoneNumberRequest {
   export function isa(o: any): o is BatchUpdatePhoneNumberRequest {
-    return _smithy.isa(o, "BatchUpdatePhoneNumberRequest");
+    return __isa(o, "BatchUpdatePhoneNumberRequest");
   }
 }
 
@@ -537,7 +534,7 @@ export interface BatchUpdatePhoneNumberResponse extends $MetadataBearer {
 
 export namespace BatchUpdatePhoneNumberResponse {
   export function isa(o: any): o is BatchUpdatePhoneNumberResponse {
-    return _smithy.isa(o, "BatchUpdatePhoneNumberResponse");
+    return __isa(o, "BatchUpdatePhoneNumberResponse");
   }
 }
 
@@ -556,7 +553,7 @@ export interface BatchUpdateUserRequest {
 
 export namespace BatchUpdateUserRequest {
   export function isa(o: any): o is BatchUpdateUserRequest {
-    return _smithy.isa(o, "BatchUpdateUserRequest");
+    return __isa(o, "BatchUpdateUserRequest");
   }
 }
 
@@ -572,7 +569,7 @@ export interface BatchUpdateUserResponse extends $MetadataBearer {
 
 export namespace BatchUpdateUserResponse {
   export function isa(o: any): o is BatchUpdateUserResponse {
-    return _smithy.isa(o, "BatchUpdateUserResponse");
+    return __isa(o, "BatchUpdateUserResponse");
   }
 }
 
@@ -629,7 +626,7 @@ export interface Bot {
 
 export namespace Bot {
   export function isa(o: any): o is Bot {
-    return _smithy.isa(o, "Bot");
+    return __isa(o, "Bot");
   }
 }
 
@@ -651,7 +648,7 @@ export interface BusinessCallingSettings {
 
 export namespace BusinessCallingSettings {
   export function isa(o: any): o is BusinessCallingSettings {
-    return _smithy.isa(o, "BusinessCallingSettings");
+    return __isa(o, "BusinessCallingSettings");
   }
 }
 
@@ -666,9 +663,7 @@ export enum CallingNameStatus {
  * <p>The request could not be processed because of conflict in the current state of the
  *        resource.</p>
  */
-export interface ConflictException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface ConflictException extends __SmithyException, $MetadataBearer {
   name: "ConflictException";
   $fault: "client";
   Code?: ErrorCode | string;
@@ -677,7 +672,7 @@ export interface ConflictException
 
 export namespace ConflictException {
   export function isa(o: any): o is ConflictException {
-    return _smithy.isa(o, "ConflictException");
+    return __isa(o, "ConflictException");
   }
 }
 
@@ -691,7 +686,7 @@ export interface CreateAccountRequest {
 
 export namespace CreateAccountRequest {
   export function isa(o: any): o is CreateAccountRequest {
-    return _smithy.isa(o, "CreateAccountRequest");
+    return __isa(o, "CreateAccountRequest");
   }
 }
 
@@ -705,7 +700,7 @@ export interface CreateAccountResponse extends $MetadataBearer {
 
 export namespace CreateAccountResponse {
   export function isa(o: any): o is CreateAccountResponse {
-    return _smithy.isa(o, "CreateAccountResponse");
+    return __isa(o, "CreateAccountResponse");
   }
 }
 
@@ -732,7 +727,7 @@ export interface CreateAttendeeError {
 
 export namespace CreateAttendeeError {
   export function isa(o: any): o is CreateAttendeeError {
-    return _smithy.isa(o, "CreateAttendeeError");
+    return __isa(o, "CreateAttendeeError");
   }
 }
 
@@ -751,7 +746,7 @@ export interface CreateAttendeeRequest {
 
 export namespace CreateAttendeeRequest {
   export function isa(o: any): o is CreateAttendeeRequest {
-    return _smithy.isa(o, "CreateAttendeeRequest");
+    return __isa(o, "CreateAttendeeRequest");
   }
 }
 
@@ -768,7 +763,7 @@ export interface CreateAttendeeRequestItem {
 
 export namespace CreateAttendeeRequestItem {
   export function isa(o: any): o is CreateAttendeeRequestItem {
-    return _smithy.isa(o, "CreateAttendeeRequestItem");
+    return __isa(o, "CreateAttendeeRequestItem");
   }
 }
 
@@ -782,7 +777,7 @@ export interface CreateAttendeeResponse extends $MetadataBearer {
 
 export namespace CreateAttendeeResponse {
   export function isa(o: any): o is CreateAttendeeResponse {
-    return _smithy.isa(o, "CreateAttendeeResponse");
+    return __isa(o, "CreateAttendeeResponse");
   }
 }
 
@@ -806,7 +801,7 @@ export interface CreateBotRequest {
 
 export namespace CreateBotRequest {
   export function isa(o: any): o is CreateBotRequest {
-    return _smithy.isa(o, "CreateBotRequest");
+    return __isa(o, "CreateBotRequest");
   }
 }
 
@@ -820,7 +815,7 @@ export interface CreateBotResponse extends $MetadataBearer {
 
 export namespace CreateBotResponse {
   export function isa(o: any): o is CreateBotResponse {
-    return _smithy.isa(o, "CreateBotResponse");
+    return __isa(o, "CreateBotResponse");
   }
 }
 
@@ -849,7 +844,7 @@ export interface CreateMeetingRequest {
 
 export namespace CreateMeetingRequest {
   export function isa(o: any): o is CreateMeetingRequest {
-    return _smithy.isa(o, "CreateMeetingRequest");
+    return __isa(o, "CreateMeetingRequest");
   }
 }
 
@@ -863,7 +858,7 @@ export interface CreateMeetingResponse extends $MetadataBearer {
 
 export namespace CreateMeetingResponse {
   export function isa(o: any): o is CreateMeetingResponse {
-    return _smithy.isa(o, "CreateMeetingResponse");
+    return __isa(o, "CreateMeetingResponse");
   }
 }
 
@@ -882,7 +877,7 @@ export interface CreatePhoneNumberOrderRequest {
 
 export namespace CreatePhoneNumberOrderRequest {
   export function isa(o: any): o is CreatePhoneNumberOrderRequest {
-    return _smithy.isa(o, "CreatePhoneNumberOrderRequest");
+    return __isa(o, "CreatePhoneNumberOrderRequest");
   }
 }
 
@@ -896,7 +891,7 @@ export interface CreatePhoneNumberOrderResponse extends $MetadataBearer {
 
 export namespace CreatePhoneNumberOrderResponse {
   export function isa(o: any): o is CreatePhoneNumberOrderResponse {
-    return _smithy.isa(o, "CreatePhoneNumberOrderResponse");
+    return __isa(o, "CreatePhoneNumberOrderResponse");
   }
 }
 
@@ -925,7 +920,7 @@ export interface CreateRoomMembershipRequest {
 
 export namespace CreateRoomMembershipRequest {
   export function isa(o: any): o is CreateRoomMembershipRequest {
-    return _smithy.isa(o, "CreateRoomMembershipRequest");
+    return __isa(o, "CreateRoomMembershipRequest");
   }
 }
 
@@ -939,7 +934,7 @@ export interface CreateRoomMembershipResponse extends $MetadataBearer {
 
 export namespace CreateRoomMembershipResponse {
   export function isa(o: any): o is CreateRoomMembershipResponse {
-    return _smithy.isa(o, "CreateRoomMembershipResponse");
+    return __isa(o, "CreateRoomMembershipResponse");
   }
 }
 
@@ -963,7 +958,7 @@ export interface CreateRoomRequest {
 
 export namespace CreateRoomRequest {
   export function isa(o: any): o is CreateRoomRequest {
-    return _smithy.isa(o, "CreateRoomRequest");
+    return __isa(o, "CreateRoomRequest");
   }
 }
 
@@ -977,7 +972,7 @@ export interface CreateRoomResponse extends $MetadataBearer {
 
 export namespace CreateRoomResponse {
   export function isa(o: any): o is CreateRoomResponse {
-    return _smithy.isa(o, "CreateRoomResponse");
+    return __isa(o, "CreateRoomResponse");
   }
 }
 
@@ -1006,7 +1001,7 @@ export interface CreateUserRequest {
 
 export namespace CreateUserRequest {
   export function isa(o: any): o is CreateUserRequest {
-    return _smithy.isa(o, "CreateUserRequest");
+    return __isa(o, "CreateUserRequest");
   }
 }
 
@@ -1020,7 +1015,7 @@ export interface CreateUserResponse extends $MetadataBearer {
 
 export namespace CreateUserResponse {
   export function isa(o: any): o is CreateUserResponse {
-    return _smithy.isa(o, "CreateUserResponse");
+    return __isa(o, "CreateUserResponse");
   }
 }
 
@@ -1039,7 +1034,7 @@ export interface CreateVoiceConnectorGroupRequest {
 
 export namespace CreateVoiceConnectorGroupRequest {
   export function isa(o: any): o is CreateVoiceConnectorGroupRequest {
-    return _smithy.isa(o, "CreateVoiceConnectorGroupRequest");
+    return __isa(o, "CreateVoiceConnectorGroupRequest");
   }
 }
 
@@ -1053,7 +1048,7 @@ export interface CreateVoiceConnectorGroupResponse extends $MetadataBearer {
 
 export namespace CreateVoiceConnectorGroupResponse {
   export function isa(o: any): o is CreateVoiceConnectorGroupResponse {
-    return _smithy.isa(o, "CreateVoiceConnectorGroupResponse");
+    return __isa(o, "CreateVoiceConnectorGroupResponse");
   }
 }
 
@@ -1077,7 +1072,7 @@ export interface CreateVoiceConnectorRequest {
 
 export namespace CreateVoiceConnectorRequest {
   export function isa(o: any): o is CreateVoiceConnectorRequest {
-    return _smithy.isa(o, "CreateVoiceConnectorRequest");
+    return __isa(o, "CreateVoiceConnectorRequest");
   }
 }
 
@@ -1091,7 +1086,7 @@ export interface CreateVoiceConnectorResponse extends $MetadataBearer {
 
 export namespace CreateVoiceConnectorResponse {
   export function isa(o: any): o is CreateVoiceConnectorResponse {
-    return _smithy.isa(o, "CreateVoiceConnectorResponse");
+    return __isa(o, "CreateVoiceConnectorResponse");
   }
 }
 
@@ -1114,7 +1109,7 @@ export interface Credential {
 
 export namespace Credential {
   export function isa(o: any): o is Credential {
-    return _smithy.isa(o, "Credential");
+    return __isa(o, "Credential");
   }
 }
 
@@ -1128,7 +1123,7 @@ export interface DeleteAccountRequest {
 
 export namespace DeleteAccountRequest {
   export function isa(o: any): o is DeleteAccountRequest {
-    return _smithy.isa(o, "DeleteAccountRequest");
+    return __isa(o, "DeleteAccountRequest");
   }
 }
 
@@ -1138,7 +1133,7 @@ export interface DeleteAccountResponse extends $MetadataBearer {
 
 export namespace DeleteAccountResponse {
   export function isa(o: any): o is DeleteAccountResponse {
-    return _smithy.isa(o, "DeleteAccountResponse");
+    return __isa(o, "DeleteAccountResponse");
   }
 }
 
@@ -1157,7 +1152,7 @@ export interface DeleteAttendeeRequest {
 
 export namespace DeleteAttendeeRequest {
   export function isa(o: any): o is DeleteAttendeeRequest {
-    return _smithy.isa(o, "DeleteAttendeeRequest");
+    return __isa(o, "DeleteAttendeeRequest");
   }
 }
 
@@ -1176,7 +1171,7 @@ export interface DeleteEventsConfigurationRequest {
 
 export namespace DeleteEventsConfigurationRequest {
   export function isa(o: any): o is DeleteEventsConfigurationRequest {
-    return _smithy.isa(o, "DeleteEventsConfigurationRequest");
+    return __isa(o, "DeleteEventsConfigurationRequest");
   }
 }
 
@@ -1190,7 +1185,7 @@ export interface DeleteMeetingRequest {
 
 export namespace DeleteMeetingRequest {
   export function isa(o: any): o is DeleteMeetingRequest {
-    return _smithy.isa(o, "DeleteMeetingRequest");
+    return __isa(o, "DeleteMeetingRequest");
   }
 }
 
@@ -1204,7 +1199,7 @@ export interface DeletePhoneNumberRequest {
 
 export namespace DeletePhoneNumberRequest {
   export function isa(o: any): o is DeletePhoneNumberRequest {
-    return _smithy.isa(o, "DeletePhoneNumberRequest");
+    return __isa(o, "DeletePhoneNumberRequest");
   }
 }
 
@@ -1228,7 +1223,7 @@ export interface DeleteRoomMembershipRequest {
 
 export namespace DeleteRoomMembershipRequest {
   export function isa(o: any): o is DeleteRoomMembershipRequest {
-    return _smithy.isa(o, "DeleteRoomMembershipRequest");
+    return __isa(o, "DeleteRoomMembershipRequest");
   }
 }
 
@@ -1247,7 +1242,7 @@ export interface DeleteRoomRequest {
 
 export namespace DeleteRoomRequest {
   export function isa(o: any): o is DeleteRoomRequest {
-    return _smithy.isa(o, "DeleteRoomRequest");
+    return __isa(o, "DeleteRoomRequest");
   }
 }
 
@@ -1261,7 +1256,7 @@ export interface DeleteVoiceConnectorGroupRequest {
 
 export namespace DeleteVoiceConnectorGroupRequest {
   export function isa(o: any): o is DeleteVoiceConnectorGroupRequest {
-    return _smithy.isa(o, "DeleteVoiceConnectorGroupRequest");
+    return __isa(o, "DeleteVoiceConnectorGroupRequest");
   }
 }
 
@@ -1275,7 +1270,7 @@ export interface DeleteVoiceConnectorOriginationRequest {
 
 export namespace DeleteVoiceConnectorOriginationRequest {
   export function isa(o: any): o is DeleteVoiceConnectorOriginationRequest {
-    return _smithy.isa(o, "DeleteVoiceConnectorOriginationRequest");
+    return __isa(o, "DeleteVoiceConnectorOriginationRequest");
   }
 }
 
@@ -1289,7 +1284,7 @@ export interface DeleteVoiceConnectorRequest {
 
 export namespace DeleteVoiceConnectorRequest {
   export function isa(o: any): o is DeleteVoiceConnectorRequest {
-    return _smithy.isa(o, "DeleteVoiceConnectorRequest");
+    return __isa(o, "DeleteVoiceConnectorRequest");
   }
 }
 
@@ -1305,7 +1300,7 @@ export namespace DeleteVoiceConnectorStreamingConfigurationRequest {
   export function isa(
     o: any
   ): o is DeleteVoiceConnectorStreamingConfigurationRequest {
-    return _smithy.isa(o, "DeleteVoiceConnectorStreamingConfigurationRequest");
+    return __isa(o, "DeleteVoiceConnectorStreamingConfigurationRequest");
   }
 }
 
@@ -1326,7 +1321,7 @@ export namespace DeleteVoiceConnectorTerminationCredentialsRequest {
   export function isa(
     o: any
   ): o is DeleteVoiceConnectorTerminationCredentialsRequest {
-    return _smithy.isa(o, "DeleteVoiceConnectorTerminationCredentialsRequest");
+    return __isa(o, "DeleteVoiceConnectorTerminationCredentialsRequest");
   }
 }
 
@@ -1340,7 +1335,7 @@ export interface DeleteVoiceConnectorTerminationRequest {
 
 export namespace DeleteVoiceConnectorTerminationRequest {
   export function isa(o: any): o is DeleteVoiceConnectorTerminationRequest {
-    return _smithy.isa(o, "DeleteVoiceConnectorTerminationRequest");
+    return __isa(o, "DeleteVoiceConnectorTerminationRequest");
   }
 }
 
@@ -1359,7 +1354,7 @@ export interface DisassociatePhoneNumberFromUserRequest {
 
 export namespace DisassociatePhoneNumberFromUserRequest {
   export function isa(o: any): o is DisassociatePhoneNumberFromUserRequest {
-    return _smithy.isa(o, "DisassociatePhoneNumberFromUserRequest");
+    return __isa(o, "DisassociatePhoneNumberFromUserRequest");
   }
 }
 
@@ -1370,7 +1365,7 @@ export interface DisassociatePhoneNumberFromUserResponse
 
 export namespace DisassociatePhoneNumberFromUserResponse {
   export function isa(o: any): o is DisassociatePhoneNumberFromUserResponse {
-    return _smithy.isa(o, "DisassociatePhoneNumberFromUserResponse");
+    return __isa(o, "DisassociatePhoneNumberFromUserResponse");
   }
 }
 
@@ -1391,10 +1386,7 @@ export namespace DisassociatePhoneNumbersFromVoiceConnectorGroupRequest {
   export function isa(
     o: any
   ): o is DisassociatePhoneNumbersFromVoiceConnectorGroupRequest {
-    return _smithy.isa(
-      o,
-      "DisassociatePhoneNumbersFromVoiceConnectorGroupRequest"
-    );
+    return __isa(o, "DisassociatePhoneNumbersFromVoiceConnectorGroupRequest");
   }
 }
 
@@ -1411,10 +1403,7 @@ export namespace DisassociatePhoneNumbersFromVoiceConnectorGroupResponse {
   export function isa(
     o: any
   ): o is DisassociatePhoneNumbersFromVoiceConnectorGroupResponse {
-    return _smithy.isa(
-      o,
-      "DisassociatePhoneNumbersFromVoiceConnectorGroupResponse"
-    );
+    return __isa(o, "DisassociatePhoneNumbersFromVoiceConnectorGroupResponse");
   }
 }
 
@@ -1435,7 +1424,7 @@ export namespace DisassociatePhoneNumbersFromVoiceConnectorRequest {
   export function isa(
     o: any
   ): o is DisassociatePhoneNumbersFromVoiceConnectorRequest {
-    return _smithy.isa(o, "DisassociatePhoneNumbersFromVoiceConnectorRequest");
+    return __isa(o, "DisassociatePhoneNumbersFromVoiceConnectorRequest");
   }
 }
 
@@ -1452,7 +1441,7 @@ export namespace DisassociatePhoneNumbersFromVoiceConnectorResponse {
   export function isa(
     o: any
   ): o is DisassociatePhoneNumbersFromVoiceConnectorResponse {
-    return _smithy.isa(o, "DisassociatePhoneNumbersFromVoiceConnectorResponse");
+    return __isa(o, "DisassociatePhoneNumbersFromVoiceConnectorResponse");
   }
 }
 
@@ -1473,7 +1462,7 @@ export namespace DisassociateSigninDelegateGroupsFromAccountRequest {
   export function isa(
     o: any
   ): o is DisassociateSigninDelegateGroupsFromAccountRequest {
-    return _smithy.isa(o, "DisassociateSigninDelegateGroupsFromAccountRequest");
+    return __isa(o, "DisassociateSigninDelegateGroupsFromAccountRequest");
   }
 }
 
@@ -1486,10 +1475,7 @@ export namespace DisassociateSigninDelegateGroupsFromAccountResponse {
   export function isa(
     o: any
   ): o is DisassociateSigninDelegateGroupsFromAccountResponse {
-    return _smithy.isa(
-      o,
-      "DisassociateSigninDelegateGroupsFromAccountResponse"
-    );
+    return __isa(o, "DisassociateSigninDelegateGroupsFromAccountResponse");
   }
 }
 
@@ -1539,7 +1525,7 @@ export interface EventsConfiguration {
 
 export namespace EventsConfiguration {
   export function isa(o: any): o is EventsConfiguration {
-    return _smithy.isa(o, "EventsConfiguration");
+    return __isa(o, "EventsConfiguration");
   }
 }
 
@@ -1547,9 +1533,7 @@ export namespace EventsConfiguration {
  * <p>The client is permanently forbidden from making the request. For example, when a user
  *         tries to create an account from an unsupported Region.</p>
  */
-export interface ForbiddenException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface ForbiddenException extends __SmithyException, $MetadataBearer {
   name: "ForbiddenException";
   $fault: "client";
   Code?: ErrorCode | string;
@@ -1558,7 +1542,7 @@ export interface ForbiddenException
 
 export namespace ForbiddenException {
   export function isa(o: any): o is ForbiddenException {
-    return _smithy.isa(o, "ForbiddenException");
+    return __isa(o, "ForbiddenException");
   }
 }
 
@@ -1572,7 +1556,7 @@ export interface GetAccountRequest {
 
 export namespace GetAccountRequest {
   export function isa(o: any): o is GetAccountRequest {
-    return _smithy.isa(o, "GetAccountRequest");
+    return __isa(o, "GetAccountRequest");
   }
 }
 
@@ -1586,7 +1570,7 @@ export interface GetAccountResponse extends $MetadataBearer {
 
 export namespace GetAccountResponse {
   export function isa(o: any): o is GetAccountResponse {
-    return _smithy.isa(o, "GetAccountResponse");
+    return __isa(o, "GetAccountResponse");
   }
 }
 
@@ -1600,7 +1584,7 @@ export interface GetAccountSettingsRequest {
 
 export namespace GetAccountSettingsRequest {
   export function isa(o: any): o is GetAccountSettingsRequest {
-    return _smithy.isa(o, "GetAccountSettingsRequest");
+    return __isa(o, "GetAccountSettingsRequest");
   }
 }
 
@@ -1614,7 +1598,7 @@ export interface GetAccountSettingsResponse extends $MetadataBearer {
 
 export namespace GetAccountSettingsResponse {
   export function isa(o: any): o is GetAccountSettingsResponse {
-    return _smithy.isa(o, "GetAccountSettingsResponse");
+    return __isa(o, "GetAccountSettingsResponse");
   }
 }
 
@@ -1633,7 +1617,7 @@ export interface GetAttendeeRequest {
 
 export namespace GetAttendeeRequest {
   export function isa(o: any): o is GetAttendeeRequest {
-    return _smithy.isa(o, "GetAttendeeRequest");
+    return __isa(o, "GetAttendeeRequest");
   }
 }
 
@@ -1647,7 +1631,7 @@ export interface GetAttendeeResponse extends $MetadataBearer {
 
 export namespace GetAttendeeResponse {
   export function isa(o: any): o is GetAttendeeResponse {
-    return _smithy.isa(o, "GetAttendeeResponse");
+    return __isa(o, "GetAttendeeResponse");
   }
 }
 
@@ -1666,7 +1650,7 @@ export interface GetBotRequest {
 
 export namespace GetBotRequest {
   export function isa(o: any): o is GetBotRequest {
-    return _smithy.isa(o, "GetBotRequest");
+    return __isa(o, "GetBotRequest");
   }
 }
 
@@ -1680,7 +1664,7 @@ export interface GetBotResponse extends $MetadataBearer {
 
 export namespace GetBotResponse {
   export function isa(o: any): o is GetBotResponse {
-    return _smithy.isa(o, "GetBotResponse");
+    return __isa(o, "GetBotResponse");
   }
 }
 
@@ -1699,7 +1683,7 @@ export interface GetEventsConfigurationRequest {
 
 export namespace GetEventsConfigurationRequest {
   export function isa(o: any): o is GetEventsConfigurationRequest {
-    return _smithy.isa(o, "GetEventsConfigurationRequest");
+    return __isa(o, "GetEventsConfigurationRequest");
   }
 }
 
@@ -1713,7 +1697,7 @@ export interface GetEventsConfigurationResponse extends $MetadataBearer {
 
 export namespace GetEventsConfigurationResponse {
   export function isa(o: any): o is GetEventsConfigurationResponse {
-    return _smithy.isa(o, "GetEventsConfigurationResponse");
+    return __isa(o, "GetEventsConfigurationResponse");
   }
 }
 
@@ -1732,7 +1716,7 @@ export interface GetGlobalSettingsResponse extends $MetadataBearer {
 
 export namespace GetGlobalSettingsResponse {
   export function isa(o: any): o is GetGlobalSettingsResponse {
-    return _smithy.isa(o, "GetGlobalSettingsResponse");
+    return __isa(o, "GetGlobalSettingsResponse");
   }
 }
 
@@ -1746,7 +1730,7 @@ export interface GetMeetingRequest {
 
 export namespace GetMeetingRequest {
   export function isa(o: any): o is GetMeetingRequest {
-    return _smithy.isa(o, "GetMeetingRequest");
+    return __isa(o, "GetMeetingRequest");
   }
 }
 
@@ -1760,7 +1744,7 @@ export interface GetMeetingResponse extends $MetadataBearer {
 
 export namespace GetMeetingResponse {
   export function isa(o: any): o is GetMeetingResponse {
-    return _smithy.isa(o, "GetMeetingResponse");
+    return __isa(o, "GetMeetingResponse");
   }
 }
 
@@ -1774,7 +1758,7 @@ export interface GetPhoneNumberOrderRequest {
 
 export namespace GetPhoneNumberOrderRequest {
   export function isa(o: any): o is GetPhoneNumberOrderRequest {
-    return _smithy.isa(o, "GetPhoneNumberOrderRequest");
+    return __isa(o, "GetPhoneNumberOrderRequest");
   }
 }
 
@@ -1788,7 +1772,7 @@ export interface GetPhoneNumberOrderResponse extends $MetadataBearer {
 
 export namespace GetPhoneNumberOrderResponse {
   export function isa(o: any): o is GetPhoneNumberOrderResponse {
-    return _smithy.isa(o, "GetPhoneNumberOrderResponse");
+    return __isa(o, "GetPhoneNumberOrderResponse");
   }
 }
 
@@ -1802,7 +1786,7 @@ export interface GetPhoneNumberRequest {
 
 export namespace GetPhoneNumberRequest {
   export function isa(o: any): o is GetPhoneNumberRequest {
-    return _smithy.isa(o, "GetPhoneNumberRequest");
+    return __isa(o, "GetPhoneNumberRequest");
   }
 }
 
@@ -1816,7 +1800,7 @@ export interface GetPhoneNumberResponse extends $MetadataBearer {
 
 export namespace GetPhoneNumberResponse {
   export function isa(o: any): o is GetPhoneNumberResponse {
-    return _smithy.isa(o, "GetPhoneNumberResponse");
+    return __isa(o, "GetPhoneNumberResponse");
   }
 }
 
@@ -1835,7 +1819,7 @@ export interface GetPhoneNumberSettingsResponse extends $MetadataBearer {
 
 export namespace GetPhoneNumberSettingsResponse {
   export function isa(o: any): o is GetPhoneNumberSettingsResponse {
-    return _smithy.isa(o, "GetPhoneNumberSettingsResponse");
+    return __isa(o, "GetPhoneNumberSettingsResponse");
   }
 }
 
@@ -1854,7 +1838,7 @@ export interface GetRoomRequest {
 
 export namespace GetRoomRequest {
   export function isa(o: any): o is GetRoomRequest {
-    return _smithy.isa(o, "GetRoomRequest");
+    return __isa(o, "GetRoomRequest");
   }
 }
 
@@ -1868,7 +1852,7 @@ export interface GetRoomResponse extends $MetadataBearer {
 
 export namespace GetRoomResponse {
   export function isa(o: any): o is GetRoomResponse {
-    return _smithy.isa(o, "GetRoomResponse");
+    return __isa(o, "GetRoomResponse");
   }
 }
 
@@ -1887,7 +1871,7 @@ export interface GetUserRequest {
 
 export namespace GetUserRequest {
   export function isa(o: any): o is GetUserRequest {
-    return _smithy.isa(o, "GetUserRequest");
+    return __isa(o, "GetUserRequest");
   }
 }
 
@@ -1901,7 +1885,7 @@ export interface GetUserResponse extends $MetadataBearer {
 
 export namespace GetUserResponse {
   export function isa(o: any): o is GetUserResponse {
-    return _smithy.isa(o, "GetUserResponse");
+    return __isa(o, "GetUserResponse");
   }
 }
 
@@ -1920,7 +1904,7 @@ export interface GetUserSettingsRequest {
 
 export namespace GetUserSettingsRequest {
   export function isa(o: any): o is GetUserSettingsRequest {
-    return _smithy.isa(o, "GetUserSettingsRequest");
+    return __isa(o, "GetUserSettingsRequest");
   }
 }
 
@@ -1934,7 +1918,7 @@ export interface GetUserSettingsResponse extends $MetadataBearer {
 
 export namespace GetUserSettingsResponse {
   export function isa(o: any): o is GetUserSettingsResponse {
-    return _smithy.isa(o, "GetUserSettingsResponse");
+    return __isa(o, "GetUserSettingsResponse");
   }
 }
 
@@ -1948,7 +1932,7 @@ export interface GetVoiceConnectorGroupRequest {
 
 export namespace GetVoiceConnectorGroupRequest {
   export function isa(o: any): o is GetVoiceConnectorGroupRequest {
-    return _smithy.isa(o, "GetVoiceConnectorGroupRequest");
+    return __isa(o, "GetVoiceConnectorGroupRequest");
   }
 }
 
@@ -1962,7 +1946,7 @@ export interface GetVoiceConnectorGroupResponse extends $MetadataBearer {
 
 export namespace GetVoiceConnectorGroupResponse {
   export function isa(o: any): o is GetVoiceConnectorGroupResponse {
-    return _smithy.isa(o, "GetVoiceConnectorGroupResponse");
+    return __isa(o, "GetVoiceConnectorGroupResponse");
   }
 }
 
@@ -1978,7 +1962,7 @@ export namespace GetVoiceConnectorLoggingConfigurationRequest {
   export function isa(
     o: any
   ): o is GetVoiceConnectorLoggingConfigurationRequest {
-    return _smithy.isa(o, "GetVoiceConnectorLoggingConfigurationRequest");
+    return __isa(o, "GetVoiceConnectorLoggingConfigurationRequest");
   }
 }
 
@@ -1995,7 +1979,7 @@ export namespace GetVoiceConnectorLoggingConfigurationResponse {
   export function isa(
     o: any
   ): o is GetVoiceConnectorLoggingConfigurationResponse {
-    return _smithy.isa(o, "GetVoiceConnectorLoggingConfigurationResponse");
+    return __isa(o, "GetVoiceConnectorLoggingConfigurationResponse");
   }
 }
 
@@ -2009,7 +1993,7 @@ export interface GetVoiceConnectorOriginationRequest {
 
 export namespace GetVoiceConnectorOriginationRequest {
   export function isa(o: any): o is GetVoiceConnectorOriginationRequest {
-    return _smithy.isa(o, "GetVoiceConnectorOriginationRequest");
+    return __isa(o, "GetVoiceConnectorOriginationRequest");
   }
 }
 
@@ -2023,7 +2007,7 @@ export interface GetVoiceConnectorOriginationResponse extends $MetadataBearer {
 
 export namespace GetVoiceConnectorOriginationResponse {
   export function isa(o: any): o is GetVoiceConnectorOriginationResponse {
-    return _smithy.isa(o, "GetVoiceConnectorOriginationResponse");
+    return __isa(o, "GetVoiceConnectorOriginationResponse");
   }
 }
 
@@ -2037,7 +2021,7 @@ export interface GetVoiceConnectorRequest {
 
 export namespace GetVoiceConnectorRequest {
   export function isa(o: any): o is GetVoiceConnectorRequest {
-    return _smithy.isa(o, "GetVoiceConnectorRequest");
+    return __isa(o, "GetVoiceConnectorRequest");
   }
 }
 
@@ -2051,7 +2035,7 @@ export interface GetVoiceConnectorResponse extends $MetadataBearer {
 
 export namespace GetVoiceConnectorResponse {
   export function isa(o: any): o is GetVoiceConnectorResponse {
-    return _smithy.isa(o, "GetVoiceConnectorResponse");
+    return __isa(o, "GetVoiceConnectorResponse");
   }
 }
 
@@ -2067,7 +2051,7 @@ export namespace GetVoiceConnectorStreamingConfigurationRequest {
   export function isa(
     o: any
   ): o is GetVoiceConnectorStreamingConfigurationRequest {
-    return _smithy.isa(o, "GetVoiceConnectorStreamingConfigurationRequest");
+    return __isa(o, "GetVoiceConnectorStreamingConfigurationRequest");
   }
 }
 
@@ -2084,7 +2068,7 @@ export namespace GetVoiceConnectorStreamingConfigurationResponse {
   export function isa(
     o: any
   ): o is GetVoiceConnectorStreamingConfigurationResponse {
-    return _smithy.isa(o, "GetVoiceConnectorStreamingConfigurationResponse");
+    return __isa(o, "GetVoiceConnectorStreamingConfigurationResponse");
   }
 }
 
@@ -2098,7 +2082,7 @@ export interface GetVoiceConnectorTerminationHealthRequest {
 
 export namespace GetVoiceConnectorTerminationHealthRequest {
   export function isa(o: any): o is GetVoiceConnectorTerminationHealthRequest {
-    return _smithy.isa(o, "GetVoiceConnectorTerminationHealthRequest");
+    return __isa(o, "GetVoiceConnectorTerminationHealthRequest");
   }
 }
 
@@ -2113,7 +2097,7 @@ export interface GetVoiceConnectorTerminationHealthResponse
 
 export namespace GetVoiceConnectorTerminationHealthResponse {
   export function isa(o: any): o is GetVoiceConnectorTerminationHealthResponse {
-    return _smithy.isa(o, "GetVoiceConnectorTerminationHealthResponse");
+    return __isa(o, "GetVoiceConnectorTerminationHealthResponse");
   }
 }
 
@@ -2127,7 +2111,7 @@ export interface GetVoiceConnectorTerminationRequest {
 
 export namespace GetVoiceConnectorTerminationRequest {
   export function isa(o: any): o is GetVoiceConnectorTerminationRequest {
-    return _smithy.isa(o, "GetVoiceConnectorTerminationRequest");
+    return __isa(o, "GetVoiceConnectorTerminationRequest");
   }
 }
 
@@ -2141,7 +2125,7 @@ export interface GetVoiceConnectorTerminationResponse extends $MetadataBearer {
 
 export namespace GetVoiceConnectorTerminationResponse {
   export function isa(o: any): o is GetVoiceConnectorTerminationResponse {
-    return _smithy.isa(o, "GetVoiceConnectorTerminationResponse");
+    return __isa(o, "GetVoiceConnectorTerminationResponse");
   }
 }
 
@@ -2174,7 +2158,7 @@ export interface Invite {
 
 export namespace Invite {
   export function isa(o: any): o is Invite {
-    return _smithy.isa(o, "Invite");
+    return __isa(o, "Invite");
   }
 }
 
@@ -2204,7 +2188,7 @@ export interface InviteUsersRequest {
 
 export namespace InviteUsersRequest {
   export function isa(o: any): o is InviteUsersRequest {
-    return _smithy.isa(o, "InviteUsersRequest");
+    return __isa(o, "InviteUsersRequest");
   }
 }
 
@@ -2218,7 +2202,7 @@ export interface InviteUsersResponse extends $MetadataBearer {
 
 export namespace InviteUsersResponse {
   export function isa(o: any): o is InviteUsersResponse {
-    return _smithy.isa(o, "InviteUsersResponse");
+    return __isa(o, "InviteUsersResponse");
   }
 }
 
@@ -2254,7 +2238,7 @@ export interface ListAccountsRequest {
 
 export namespace ListAccountsRequest {
   export function isa(o: any): o is ListAccountsRequest {
-    return _smithy.isa(o, "ListAccountsRequest");
+    return __isa(o, "ListAccountsRequest");
   }
 }
 
@@ -2273,7 +2257,7 @@ export interface ListAccountsResponse extends $MetadataBearer {
 
 export namespace ListAccountsResponse {
   export function isa(o: any): o is ListAccountsResponse {
-    return _smithy.isa(o, "ListAccountsResponse");
+    return __isa(o, "ListAccountsResponse");
   }
 }
 
@@ -2297,7 +2281,7 @@ export interface ListAttendeesRequest {
 
 export namespace ListAttendeesRequest {
   export function isa(o: any): o is ListAttendeesRequest {
-    return _smithy.isa(o, "ListAttendeesRequest");
+    return __isa(o, "ListAttendeesRequest");
   }
 }
 
@@ -2316,7 +2300,7 @@ export interface ListAttendeesResponse extends $MetadataBearer {
 
 export namespace ListAttendeesResponse {
   export function isa(o: any): o is ListAttendeesResponse {
-    return _smithy.isa(o, "ListAttendeesResponse");
+    return __isa(o, "ListAttendeesResponse");
   }
 }
 
@@ -2340,7 +2324,7 @@ export interface ListBotsRequest {
 
 export namespace ListBotsRequest {
   export function isa(o: any): o is ListBotsRequest {
-    return _smithy.isa(o, "ListBotsRequest");
+    return __isa(o, "ListBotsRequest");
   }
 }
 
@@ -2359,7 +2343,7 @@ export interface ListBotsResponse extends $MetadataBearer {
 
 export namespace ListBotsResponse {
   export function isa(o: any): o is ListBotsResponse {
-    return _smithy.isa(o, "ListBotsResponse");
+    return __isa(o, "ListBotsResponse");
   }
 }
 
@@ -2378,7 +2362,7 @@ export interface ListMeetingsRequest {
 
 export namespace ListMeetingsRequest {
   export function isa(o: any): o is ListMeetingsRequest {
-    return _smithy.isa(o, "ListMeetingsRequest");
+    return __isa(o, "ListMeetingsRequest");
   }
 }
 
@@ -2397,7 +2381,7 @@ export interface ListMeetingsResponse extends $MetadataBearer {
 
 export namespace ListMeetingsResponse {
   export function isa(o: any): o is ListMeetingsResponse {
-    return _smithy.isa(o, "ListMeetingsResponse");
+    return __isa(o, "ListMeetingsResponse");
   }
 }
 
@@ -2416,7 +2400,7 @@ export interface ListPhoneNumberOrdersRequest {
 
 export namespace ListPhoneNumberOrdersRequest {
   export function isa(o: any): o is ListPhoneNumberOrdersRequest {
-    return _smithy.isa(o, "ListPhoneNumberOrdersRequest");
+    return __isa(o, "ListPhoneNumberOrdersRequest");
   }
 }
 
@@ -2435,7 +2419,7 @@ export interface ListPhoneNumberOrdersResponse extends $MetadataBearer {
 
 export namespace ListPhoneNumberOrdersResponse {
   export function isa(o: any): o is ListPhoneNumberOrdersResponse {
-    return _smithy.isa(o, "ListPhoneNumberOrdersResponse");
+    return __isa(o, "ListPhoneNumberOrdersResponse");
   }
 }
 
@@ -2474,7 +2458,7 @@ export interface ListPhoneNumbersRequest {
 
 export namespace ListPhoneNumbersRequest {
   export function isa(o: any): o is ListPhoneNumbersRequest {
-    return _smithy.isa(o, "ListPhoneNumbersRequest");
+    return __isa(o, "ListPhoneNumbersRequest");
   }
 }
 
@@ -2493,7 +2477,7 @@ export interface ListPhoneNumbersResponse extends $MetadataBearer {
 
 export namespace ListPhoneNumbersResponse {
   export function isa(o: any): o is ListPhoneNumbersResponse {
-    return _smithy.isa(o, "ListPhoneNumbersResponse");
+    return __isa(o, "ListPhoneNumbersResponse");
   }
 }
 
@@ -2522,7 +2506,7 @@ export interface ListRoomMembershipsRequest {
 
 export namespace ListRoomMembershipsRequest {
   export function isa(o: any): o is ListRoomMembershipsRequest {
-    return _smithy.isa(o, "ListRoomMembershipsRequest");
+    return __isa(o, "ListRoomMembershipsRequest");
   }
 }
 
@@ -2541,7 +2525,7 @@ export interface ListRoomMembershipsResponse extends $MetadataBearer {
 
 export namespace ListRoomMembershipsResponse {
   export function isa(o: any): o is ListRoomMembershipsResponse {
-    return _smithy.isa(o, "ListRoomMembershipsResponse");
+    return __isa(o, "ListRoomMembershipsResponse");
   }
 }
 
@@ -2570,7 +2554,7 @@ export interface ListRoomsRequest {
 
 export namespace ListRoomsRequest {
   export function isa(o: any): o is ListRoomsRequest {
-    return _smithy.isa(o, "ListRoomsRequest");
+    return __isa(o, "ListRoomsRequest");
   }
 }
 
@@ -2589,7 +2573,7 @@ export interface ListRoomsResponse extends $MetadataBearer {
 
 export namespace ListRoomsResponse {
   export function isa(o: any): o is ListRoomsResponse {
-    return _smithy.isa(o, "ListRoomsResponse");
+    return __isa(o, "ListRoomsResponse");
   }
 }
 
@@ -2623,7 +2607,7 @@ export interface ListUsersRequest {
 
 export namespace ListUsersRequest {
   export function isa(o: any): o is ListUsersRequest {
-    return _smithy.isa(o, "ListUsersRequest");
+    return __isa(o, "ListUsersRequest");
   }
 }
 
@@ -2642,7 +2626,7 @@ export interface ListUsersResponse extends $MetadataBearer {
 
 export namespace ListUsersResponse {
   export function isa(o: any): o is ListUsersResponse {
-    return _smithy.isa(o, "ListUsersResponse");
+    return __isa(o, "ListUsersResponse");
   }
 }
 
@@ -2661,7 +2645,7 @@ export interface ListVoiceConnectorGroupsRequest {
 
 export namespace ListVoiceConnectorGroupsRequest {
   export function isa(o: any): o is ListVoiceConnectorGroupsRequest {
-    return _smithy.isa(o, "ListVoiceConnectorGroupsRequest");
+    return __isa(o, "ListVoiceConnectorGroupsRequest");
   }
 }
 
@@ -2680,7 +2664,7 @@ export interface ListVoiceConnectorGroupsResponse extends $MetadataBearer {
 
 export namespace ListVoiceConnectorGroupsResponse {
   export function isa(o: any): o is ListVoiceConnectorGroupsResponse {
-    return _smithy.isa(o, "ListVoiceConnectorGroupsResponse");
+    return __isa(o, "ListVoiceConnectorGroupsResponse");
   }
 }
 
@@ -2696,7 +2680,7 @@ export namespace ListVoiceConnectorTerminationCredentialsRequest {
   export function isa(
     o: any
   ): o is ListVoiceConnectorTerminationCredentialsRequest {
-    return _smithy.isa(o, "ListVoiceConnectorTerminationCredentialsRequest");
+    return __isa(o, "ListVoiceConnectorTerminationCredentialsRequest");
   }
 }
 
@@ -2713,7 +2697,7 @@ export namespace ListVoiceConnectorTerminationCredentialsResponse {
   export function isa(
     o: any
   ): o is ListVoiceConnectorTerminationCredentialsResponse {
-    return _smithy.isa(o, "ListVoiceConnectorTerminationCredentialsResponse");
+    return __isa(o, "ListVoiceConnectorTerminationCredentialsResponse");
   }
 }
 
@@ -2732,7 +2716,7 @@ export interface ListVoiceConnectorsRequest {
 
 export namespace ListVoiceConnectorsRequest {
   export function isa(o: any): o is ListVoiceConnectorsRequest {
-    return _smithy.isa(o, "ListVoiceConnectorsRequest");
+    return __isa(o, "ListVoiceConnectorsRequest");
   }
 }
 
@@ -2751,7 +2735,7 @@ export interface ListVoiceConnectorsResponse extends $MetadataBearer {
 
 export namespace ListVoiceConnectorsResponse {
   export function isa(o: any): o is ListVoiceConnectorsResponse {
-    return _smithy.isa(o, "ListVoiceConnectorsResponse");
+    return __isa(o, "ListVoiceConnectorsResponse");
   }
 }
 
@@ -2768,7 +2752,7 @@ export interface LoggingConfiguration {
 
 export namespace LoggingConfiguration {
   export function isa(o: any): o is LoggingConfiguration {
-    return _smithy.isa(o, "LoggingConfiguration");
+    return __isa(o, "LoggingConfiguration");
   }
 }
 
@@ -2787,7 +2771,7 @@ export interface LogoutUserRequest {
 
 export namespace LogoutUserRequest {
   export function isa(o: any): o is LogoutUserRequest {
-    return _smithy.isa(o, "LogoutUserRequest");
+    return __isa(o, "LogoutUserRequest");
   }
 }
 
@@ -2797,7 +2781,7 @@ export interface LogoutUserResponse extends $MetadataBearer {
 
 export namespace LogoutUserResponse {
   export function isa(o: any): o is LogoutUserResponse {
-    return _smithy.isa(o, "LogoutUserResponse");
+    return __isa(o, "LogoutUserResponse");
   }
 }
 
@@ -2839,7 +2823,7 @@ export interface MediaPlacement {
 
 export namespace MediaPlacement {
   export function isa(o: any): o is MediaPlacement {
-    return _smithy.isa(o, "MediaPlacement");
+    return __isa(o, "MediaPlacement");
   }
 }
 
@@ -2866,7 +2850,7 @@ export interface Meeting {
 
 export namespace Meeting {
   export function isa(o: any): o is Meeting {
-    return _smithy.isa(o, "Meeting");
+    return __isa(o, "Meeting");
   }
 }
 
@@ -2888,7 +2872,7 @@ export interface MeetingNotificationConfiguration {
 
 export namespace MeetingNotificationConfiguration {
   export function isa(o: any): o is MeetingNotificationConfiguration {
-    return _smithy.isa(o, "MeetingNotificationConfiguration");
+    return __isa(o, "MeetingNotificationConfiguration");
   }
 }
 
@@ -2925,7 +2909,7 @@ export interface Member {
 
 export namespace Member {
   export function isa(o: any): o is Member {
-    return _smithy.isa(o, "Member");
+    return __isa(o, "Member");
   }
 }
 
@@ -2952,7 +2936,7 @@ export interface MemberError {
 
 export namespace MemberError {
   export function isa(o: any): o is MemberError {
-    return _smithy.isa(o, "MemberError");
+    return __isa(o, "MemberError");
   }
 }
 
@@ -2980,16 +2964,14 @@ export interface MembershipItem {
 
 export namespace MembershipItem {
   export function isa(o: any): o is MembershipItem {
-    return _smithy.isa(o, "MembershipItem");
+    return __isa(o, "MembershipItem");
   }
 }
 
 /**
  * <p>One or more of the resources in the request does not exist in the system.</p>
  */
-export interface NotFoundException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface NotFoundException extends __SmithyException, $MetadataBearer {
   name: "NotFoundException";
   $fault: "client";
   Code?: ErrorCode | string;
@@ -2998,7 +2980,7 @@ export interface NotFoundException
 
 export namespace NotFoundException {
   export function isa(o: any): o is NotFoundException {
-    return _smithy.isa(o, "NotFoundException");
+    return __isa(o, "NotFoundException");
   }
 }
 
@@ -3020,7 +3002,7 @@ export interface OrderedPhoneNumber {
 
 export namespace OrderedPhoneNumber {
   export function isa(o: any): o is OrderedPhoneNumber {
-    return _smithy.isa(o, "OrderedPhoneNumber");
+    return __isa(o, "OrderedPhoneNumber");
   }
 }
 
@@ -3051,7 +3033,7 @@ export interface Origination {
 
 export namespace Origination {
   export function isa(o: any): o is Origination {
-    return _smithy.isa(o, "Origination");
+    return __isa(o, "Origination");
   }
 }
 
@@ -3092,7 +3074,7 @@ export interface OriginationRoute {
 
 export namespace OriginationRoute {
   export function isa(o: any): o is OriginationRoute {
-    return _smithy.isa(o, "OriginationRoute");
+    return __isa(o, "OriginationRoute");
   }
 }
 
@@ -3170,7 +3152,7 @@ export interface PhoneNumber {
 
 export namespace PhoneNumber {
   export function isa(o: any): o is PhoneNumber {
-    return _smithy.isa(o, "PhoneNumber");
+    return __isa(o, "PhoneNumber");
   }
 }
 
@@ -3199,7 +3181,7 @@ export interface PhoneNumberAssociation {
 
 export namespace PhoneNumberAssociation {
   export function isa(o: any): o is PhoneNumberAssociation {
-    return _smithy.isa(o, "PhoneNumberAssociation");
+    return __isa(o, "PhoneNumberAssociation");
   }
 }
 
@@ -3249,7 +3231,7 @@ export interface PhoneNumberCapabilities {
 
 export namespace PhoneNumberCapabilities {
   export function isa(o: any): o is PhoneNumberCapabilities {
-    return _smithy.isa(o, "PhoneNumberCapabilities");
+    return __isa(o, "PhoneNumberCapabilities");
   }
 }
 
@@ -3277,7 +3259,7 @@ export interface PhoneNumberError {
 
 export namespace PhoneNumberError {
   export function isa(o: any): o is PhoneNumberError {
-    return _smithy.isa(o, "PhoneNumberError");
+    return __isa(o, "PhoneNumberError");
   }
 }
 
@@ -3320,7 +3302,7 @@ export interface PhoneNumberOrder {
 
 export namespace PhoneNumberOrder {
   export function isa(o: any): o is PhoneNumberOrder {
-    return _smithy.isa(o, "PhoneNumberOrder");
+    return __isa(o, "PhoneNumberOrder");
   }
 }
 
@@ -3377,7 +3359,7 @@ export interface PutEventsConfigurationRequest {
 
 export namespace PutEventsConfigurationRequest {
   export function isa(o: any): o is PutEventsConfigurationRequest {
-    return _smithy.isa(o, "PutEventsConfigurationRequest");
+    return __isa(o, "PutEventsConfigurationRequest");
   }
 }
 
@@ -3391,7 +3373,7 @@ export interface PutEventsConfigurationResponse extends $MetadataBearer {
 
 export namespace PutEventsConfigurationResponse {
   export function isa(o: any): o is PutEventsConfigurationResponse {
-    return _smithy.isa(o, "PutEventsConfigurationResponse");
+    return __isa(o, "PutEventsConfigurationResponse");
   }
 }
 
@@ -3412,7 +3394,7 @@ export namespace PutVoiceConnectorLoggingConfigurationRequest {
   export function isa(
     o: any
   ): o is PutVoiceConnectorLoggingConfigurationRequest {
-    return _smithy.isa(o, "PutVoiceConnectorLoggingConfigurationRequest");
+    return __isa(o, "PutVoiceConnectorLoggingConfigurationRequest");
   }
 }
 
@@ -3429,7 +3411,7 @@ export namespace PutVoiceConnectorLoggingConfigurationResponse {
   export function isa(
     o: any
   ): o is PutVoiceConnectorLoggingConfigurationResponse {
-    return _smithy.isa(o, "PutVoiceConnectorLoggingConfigurationResponse");
+    return __isa(o, "PutVoiceConnectorLoggingConfigurationResponse");
   }
 }
 
@@ -3448,7 +3430,7 @@ export interface PutVoiceConnectorOriginationRequest {
 
 export namespace PutVoiceConnectorOriginationRequest {
   export function isa(o: any): o is PutVoiceConnectorOriginationRequest {
-    return _smithy.isa(o, "PutVoiceConnectorOriginationRequest");
+    return __isa(o, "PutVoiceConnectorOriginationRequest");
   }
 }
 
@@ -3462,7 +3444,7 @@ export interface PutVoiceConnectorOriginationResponse extends $MetadataBearer {
 
 export namespace PutVoiceConnectorOriginationResponse {
   export function isa(o: any): o is PutVoiceConnectorOriginationResponse {
-    return _smithy.isa(o, "PutVoiceConnectorOriginationResponse");
+    return __isa(o, "PutVoiceConnectorOriginationResponse");
   }
 }
 
@@ -3483,7 +3465,7 @@ export namespace PutVoiceConnectorStreamingConfigurationRequest {
   export function isa(
     o: any
   ): o is PutVoiceConnectorStreamingConfigurationRequest {
-    return _smithy.isa(o, "PutVoiceConnectorStreamingConfigurationRequest");
+    return __isa(o, "PutVoiceConnectorStreamingConfigurationRequest");
   }
 }
 
@@ -3500,7 +3482,7 @@ export namespace PutVoiceConnectorStreamingConfigurationResponse {
   export function isa(
     o: any
   ): o is PutVoiceConnectorStreamingConfigurationResponse {
-    return _smithy.isa(o, "PutVoiceConnectorStreamingConfigurationResponse");
+    return __isa(o, "PutVoiceConnectorStreamingConfigurationResponse");
   }
 }
 
@@ -3521,7 +3503,7 @@ export namespace PutVoiceConnectorTerminationCredentialsRequest {
   export function isa(
     o: any
   ): o is PutVoiceConnectorTerminationCredentialsRequest {
-    return _smithy.isa(o, "PutVoiceConnectorTerminationCredentialsRequest");
+    return __isa(o, "PutVoiceConnectorTerminationCredentialsRequest");
   }
 }
 
@@ -3540,7 +3522,7 @@ export interface PutVoiceConnectorTerminationRequest {
 
 export namespace PutVoiceConnectorTerminationRequest {
   export function isa(o: any): o is PutVoiceConnectorTerminationRequest {
-    return _smithy.isa(o, "PutVoiceConnectorTerminationRequest");
+    return __isa(o, "PutVoiceConnectorTerminationRequest");
   }
 }
 
@@ -3554,7 +3536,7 @@ export interface PutVoiceConnectorTerminationResponse extends $MetadataBearer {
 
 export namespace PutVoiceConnectorTerminationResponse {
   export function isa(o: any): o is PutVoiceConnectorTerminationResponse {
-    return _smithy.isa(o, "PutVoiceConnectorTerminationResponse");
+    return __isa(o, "PutVoiceConnectorTerminationResponse");
   }
 }
 
@@ -3573,7 +3555,7 @@ export interface RegenerateSecurityTokenRequest {
 
 export namespace RegenerateSecurityTokenRequest {
   export function isa(o: any): o is RegenerateSecurityTokenRequest {
-    return _smithy.isa(o, "RegenerateSecurityTokenRequest");
+    return __isa(o, "RegenerateSecurityTokenRequest");
   }
 }
 
@@ -3587,7 +3569,7 @@ export interface RegenerateSecurityTokenResponse extends $MetadataBearer {
 
 export namespace RegenerateSecurityTokenResponse {
   export function isa(o: any): o is RegenerateSecurityTokenResponse {
-    return _smithy.isa(o, "RegenerateSecurityTokenResponse");
+    return __isa(o, "RegenerateSecurityTokenResponse");
   }
 }
 
@@ -3612,7 +3594,7 @@ export interface ResetPersonalPINRequest {
 
 export namespace ResetPersonalPINRequest {
   export function isa(o: any): o is ResetPersonalPINRequest {
-    return _smithy.isa(o, "ResetPersonalPINRequest");
+    return __isa(o, "ResetPersonalPINRequest");
   }
 }
 
@@ -3626,7 +3608,7 @@ export interface ResetPersonalPINResponse extends $MetadataBearer {
 
 export namespace ResetPersonalPINResponse {
   export function isa(o: any): o is ResetPersonalPINResponse {
-    return _smithy.isa(o, "ResetPersonalPINResponse");
+    return __isa(o, "ResetPersonalPINResponse");
   }
 }
 
@@ -3634,7 +3616,7 @@ export namespace ResetPersonalPINResponse {
  * <p>The request exceeds the resource limit.</p>
  */
 export interface ResourceLimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceLimitExceededException";
   $fault: "client";
@@ -3644,7 +3626,7 @@ export interface ResourceLimitExceededException
 
 export namespace ResourceLimitExceededException {
   export function isa(o: any): o is ResourceLimitExceededException {
-    return _smithy.isa(o, "ResourceLimitExceededException");
+    return __isa(o, "ResourceLimitExceededException");
   }
 }
 
@@ -3658,7 +3640,7 @@ export interface RestorePhoneNumberRequest {
 
 export namespace RestorePhoneNumberRequest {
   export function isa(o: any): o is RestorePhoneNumberRequest {
-    return _smithy.isa(o, "RestorePhoneNumberRequest");
+    return __isa(o, "RestorePhoneNumberRequest");
   }
 }
 
@@ -3672,7 +3654,7 @@ export interface RestorePhoneNumberResponse extends $MetadataBearer {
 
 export namespace RestorePhoneNumberResponse {
   export function isa(o: any): o is RestorePhoneNumberResponse {
-    return _smithy.isa(o, "RestorePhoneNumberResponse");
+    return __isa(o, "RestorePhoneNumberResponse");
   }
 }
 
@@ -3714,7 +3696,7 @@ export interface Room {
 
 export namespace Room {
   export function isa(o: any): o is Room {
-    return _smithy.isa(o, "Room");
+    return __isa(o, "Room");
   }
 }
 
@@ -3751,7 +3733,7 @@ export interface RoomMembership {
 
 export namespace RoomMembership {
   export function isa(o: any): o is RoomMembership {
-    return _smithy.isa(o, "RoomMembership");
+    return __isa(o, "RoomMembership");
   }
 }
 
@@ -3800,7 +3782,7 @@ export interface SearchAvailablePhoneNumbersRequest {
 
 export namespace SearchAvailablePhoneNumbersRequest {
   export function isa(o: any): o is SearchAvailablePhoneNumbersRequest {
-    return _smithy.isa(o, "SearchAvailablePhoneNumbersRequest");
+    return __isa(o, "SearchAvailablePhoneNumbersRequest");
   }
 }
 
@@ -3814,7 +3796,7 @@ export interface SearchAvailablePhoneNumbersResponse extends $MetadataBearer {
 
 export namespace SearchAvailablePhoneNumbersResponse {
   export function isa(o: any): o is SearchAvailablePhoneNumbersResponse {
-    return _smithy.isa(o, "SearchAvailablePhoneNumbersResponse");
+    return __isa(o, "SearchAvailablePhoneNumbersResponse");
   }
 }
 
@@ -3822,7 +3804,7 @@ export namespace SearchAvailablePhoneNumbersResponse {
  * <p>The service encountered an unexpected error.</p>
  */
 export interface ServiceFailureException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ServiceFailureException";
   $fault: "server";
@@ -3832,7 +3814,7 @@ export interface ServiceFailureException
 
 export namespace ServiceFailureException {
   export function isa(o: any): o is ServiceFailureException {
-    return _smithy.isa(o, "ServiceFailureException");
+    return __isa(o, "ServiceFailureException");
   }
 }
 
@@ -3840,7 +3822,7 @@ export namespace ServiceFailureException {
  * <p>The service is currently unavailable.</p>
  */
 export interface ServiceUnavailableException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ServiceUnavailableException";
   $fault: "server";
@@ -3850,7 +3832,7 @@ export interface ServiceUnavailableException
 
 export namespace ServiceUnavailableException {
   export function isa(o: any): o is ServiceUnavailableException {
-    return _smithy.isa(o, "ServiceUnavailableException");
+    return __isa(o, "ServiceUnavailableException");
   }
 }
 
@@ -3867,7 +3849,7 @@ export interface SigninDelegateGroup {
 
 export namespace SigninDelegateGroup {
   export function isa(o: any): o is SigninDelegateGroup {
-    return _smithy.isa(o, "SigninDelegateGroup");
+    return __isa(o, "SigninDelegateGroup");
   }
 }
 
@@ -3889,7 +3871,7 @@ export interface StreamingConfiguration {
 
 export namespace StreamingConfiguration {
   export function isa(o: any): o is StreamingConfiguration {
-    return _smithy.isa(o, "StreamingConfiguration");
+    return __isa(o, "StreamingConfiguration");
   }
 }
 
@@ -3917,7 +3899,7 @@ export interface TelephonySettings {
 
 export namespace TelephonySettings {
   export function isa(o: any): o is TelephonySettings {
-    return _smithy.isa(o, "TelephonySettings");
+    return __isa(o, "TelephonySettings");
   }
 }
 
@@ -3956,7 +3938,7 @@ export interface Termination {
 
 export namespace Termination {
   export function isa(o: any): o is Termination {
-    return _smithy.isa(o, "Termination");
+    return __isa(o, "Termination");
   }
 }
 
@@ -3979,7 +3961,7 @@ export interface TerminationHealth {
 
 export namespace TerminationHealth {
   export function isa(o: any): o is TerminationHealth {
-    return _smithy.isa(o, "TerminationHealth");
+    return __isa(o, "TerminationHealth");
   }
 }
 
@@ -3987,7 +3969,7 @@ export namespace TerminationHealth {
  * <p>The client exceeded its request rate limit.</p>
  */
 export interface ThrottledClientException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ThrottledClientException";
   $fault: "client";
@@ -3997,7 +3979,7 @@ export interface ThrottledClientException
 
 export namespace ThrottledClientException {
   export function isa(o: any): o is ThrottledClientException {
-    return _smithy.isa(o, "ThrottledClientException");
+    return __isa(o, "ThrottledClientException");
   }
 }
 
@@ -4005,7 +3987,7 @@ export namespace ThrottledClientException {
  * <p>The client is not currently authorized to make the request.</p>
  */
 export interface UnauthorizedClientException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UnauthorizedClientException";
   $fault: "client";
@@ -4015,7 +3997,7 @@ export interface UnauthorizedClientException
 
 export namespace UnauthorizedClientException {
   export function isa(o: any): o is UnauthorizedClientException {
-    return _smithy.isa(o, "UnauthorizedClientException");
+    return __isa(o, "UnauthorizedClientException");
   }
 }
 
@@ -4023,7 +4005,7 @@ export namespace UnauthorizedClientException {
  * <p>The request was well-formed but was unable to be followed due to semantic errors.</p>
  */
 export interface UnprocessableEntityException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UnprocessableEntityException";
   $fault: "client";
@@ -4033,7 +4015,7 @@ export interface UnprocessableEntityException
 
 export namespace UnprocessableEntityException {
   export function isa(o: any): o is UnprocessableEntityException {
-    return _smithy.isa(o, "UnprocessableEntityException");
+    return __isa(o, "UnprocessableEntityException");
   }
 }
 
@@ -4052,7 +4034,7 @@ export interface UpdateAccountRequest {
 
 export namespace UpdateAccountRequest {
   export function isa(o: any): o is UpdateAccountRequest {
-    return _smithy.isa(o, "UpdateAccountRequest");
+    return __isa(o, "UpdateAccountRequest");
   }
 }
 
@@ -4066,7 +4048,7 @@ export interface UpdateAccountResponse extends $MetadataBearer {
 
 export namespace UpdateAccountResponse {
   export function isa(o: any): o is UpdateAccountResponse {
-    return _smithy.isa(o, "UpdateAccountResponse");
+    return __isa(o, "UpdateAccountResponse");
   }
 }
 
@@ -4085,7 +4067,7 @@ export interface UpdateAccountSettingsRequest {
 
 export namespace UpdateAccountSettingsRequest {
   export function isa(o: any): o is UpdateAccountSettingsRequest {
-    return _smithy.isa(o, "UpdateAccountSettingsRequest");
+    return __isa(o, "UpdateAccountSettingsRequest");
   }
 }
 
@@ -4095,7 +4077,7 @@ export interface UpdateAccountSettingsResponse extends $MetadataBearer {
 
 export namespace UpdateAccountSettingsResponse {
   export function isa(o: any): o is UpdateAccountSettingsResponse {
-    return _smithy.isa(o, "UpdateAccountSettingsResponse");
+    return __isa(o, "UpdateAccountSettingsResponse");
   }
 }
 
@@ -4119,7 +4101,7 @@ export interface UpdateBotRequest {
 
 export namespace UpdateBotRequest {
   export function isa(o: any): o is UpdateBotRequest {
-    return _smithy.isa(o, "UpdateBotRequest");
+    return __isa(o, "UpdateBotRequest");
   }
 }
 
@@ -4133,7 +4115,7 @@ export interface UpdateBotResponse extends $MetadataBearer {
 
 export namespace UpdateBotResponse {
   export function isa(o: any): o is UpdateBotResponse {
-    return _smithy.isa(o, "UpdateBotResponse");
+    return __isa(o, "UpdateBotResponse");
   }
 }
 
@@ -4152,7 +4134,7 @@ export interface UpdateGlobalSettingsRequest {
 
 export namespace UpdateGlobalSettingsRequest {
   export function isa(o: any): o is UpdateGlobalSettingsRequest {
-    return _smithy.isa(o, "UpdateGlobalSettingsRequest");
+    return __isa(o, "UpdateGlobalSettingsRequest");
   }
 }
 
@@ -4176,7 +4158,7 @@ export interface UpdatePhoneNumberRequest {
 
 export namespace UpdatePhoneNumberRequest {
   export function isa(o: any): o is UpdatePhoneNumberRequest {
-    return _smithy.isa(o, "UpdatePhoneNumberRequest");
+    return __isa(o, "UpdatePhoneNumberRequest");
   }
 }
 
@@ -4203,7 +4185,7 @@ export interface UpdatePhoneNumberRequestItem {
 
 export namespace UpdatePhoneNumberRequestItem {
   export function isa(o: any): o is UpdatePhoneNumberRequestItem {
-    return _smithy.isa(o, "UpdatePhoneNumberRequestItem");
+    return __isa(o, "UpdatePhoneNumberRequestItem");
   }
 }
 
@@ -4217,7 +4199,7 @@ export interface UpdatePhoneNumberResponse extends $MetadataBearer {
 
 export namespace UpdatePhoneNumberResponse {
   export function isa(o: any): o is UpdatePhoneNumberResponse {
-    return _smithy.isa(o, "UpdatePhoneNumberResponse");
+    return __isa(o, "UpdatePhoneNumberResponse");
   }
 }
 
@@ -4231,7 +4213,7 @@ export interface UpdatePhoneNumberSettingsRequest {
 
 export namespace UpdatePhoneNumberSettingsRequest {
   export function isa(o: any): o is UpdatePhoneNumberSettingsRequest {
-    return _smithy.isa(o, "UpdatePhoneNumberSettingsRequest");
+    return __isa(o, "UpdatePhoneNumberSettingsRequest");
   }
 }
 
@@ -4260,7 +4242,7 @@ export interface UpdateRoomMembershipRequest {
 
 export namespace UpdateRoomMembershipRequest {
   export function isa(o: any): o is UpdateRoomMembershipRequest {
-    return _smithy.isa(o, "UpdateRoomMembershipRequest");
+    return __isa(o, "UpdateRoomMembershipRequest");
   }
 }
 
@@ -4274,7 +4256,7 @@ export interface UpdateRoomMembershipResponse extends $MetadataBearer {
 
 export namespace UpdateRoomMembershipResponse {
   export function isa(o: any): o is UpdateRoomMembershipResponse {
-    return _smithy.isa(o, "UpdateRoomMembershipResponse");
+    return __isa(o, "UpdateRoomMembershipResponse");
   }
 }
 
@@ -4298,7 +4280,7 @@ export interface UpdateRoomRequest {
 
 export namespace UpdateRoomRequest {
   export function isa(o: any): o is UpdateRoomRequest {
-    return _smithy.isa(o, "UpdateRoomRequest");
+    return __isa(o, "UpdateRoomRequest");
   }
 }
 
@@ -4312,7 +4294,7 @@ export interface UpdateRoomResponse extends $MetadataBearer {
 
 export namespace UpdateRoomResponse {
   export function isa(o: any): o is UpdateRoomResponse {
-    return _smithy.isa(o, "UpdateRoomResponse");
+    return __isa(o, "UpdateRoomResponse");
   }
 }
 
@@ -4347,7 +4329,7 @@ export interface UpdateUserRequest {
 
 export namespace UpdateUserRequest {
   export function isa(o: any): o is UpdateUserRequest {
-    return _smithy.isa(o, "UpdateUserRequest");
+    return __isa(o, "UpdateUserRequest");
   }
 }
 
@@ -4379,7 +4361,7 @@ export interface UpdateUserRequestItem {
 
 export namespace UpdateUserRequestItem {
   export function isa(o: any): o is UpdateUserRequestItem {
-    return _smithy.isa(o, "UpdateUserRequestItem");
+    return __isa(o, "UpdateUserRequestItem");
   }
 }
 
@@ -4393,7 +4375,7 @@ export interface UpdateUserResponse extends $MetadataBearer {
 
 export namespace UpdateUserResponse {
   export function isa(o: any): o is UpdateUserResponse {
-    return _smithy.isa(o, "UpdateUserResponse");
+    return __isa(o, "UpdateUserResponse");
   }
 }
 
@@ -4417,7 +4399,7 @@ export interface UpdateUserSettingsRequest {
 
 export namespace UpdateUserSettingsRequest {
   export function isa(o: any): o is UpdateUserSettingsRequest {
-    return _smithy.isa(o, "UpdateUserSettingsRequest");
+    return __isa(o, "UpdateUserSettingsRequest");
   }
 }
 
@@ -4441,7 +4423,7 @@ export interface UpdateVoiceConnectorGroupRequest {
 
 export namespace UpdateVoiceConnectorGroupRequest {
   export function isa(o: any): o is UpdateVoiceConnectorGroupRequest {
-    return _smithy.isa(o, "UpdateVoiceConnectorGroupRequest");
+    return __isa(o, "UpdateVoiceConnectorGroupRequest");
   }
 }
 
@@ -4455,7 +4437,7 @@ export interface UpdateVoiceConnectorGroupResponse extends $MetadataBearer {
 
 export namespace UpdateVoiceConnectorGroupResponse {
   export function isa(o: any): o is UpdateVoiceConnectorGroupResponse {
-    return _smithy.isa(o, "UpdateVoiceConnectorGroupResponse");
+    return __isa(o, "UpdateVoiceConnectorGroupResponse");
   }
 }
 
@@ -4479,7 +4461,7 @@ export interface UpdateVoiceConnectorRequest {
 
 export namespace UpdateVoiceConnectorRequest {
   export function isa(o: any): o is UpdateVoiceConnectorRequest {
-    return _smithy.isa(o, "UpdateVoiceConnectorRequest");
+    return __isa(o, "UpdateVoiceConnectorRequest");
   }
 }
 
@@ -4493,7 +4475,7 @@ export interface UpdateVoiceConnectorResponse extends $MetadataBearer {
 
 export namespace UpdateVoiceConnectorResponse {
   export function isa(o: any): o is UpdateVoiceConnectorResponse {
-    return _smithy.isa(o, "UpdateVoiceConnectorResponse");
+    return __isa(o, "UpdateVoiceConnectorResponse");
   }
 }
 
@@ -4571,7 +4553,7 @@ export interface User {
 
 export namespace User {
   export function isa(o: any): o is User {
-    return _smithy.isa(o, "User");
+    return __isa(o, "User");
   }
 }
 
@@ -4599,7 +4581,7 @@ export interface UserError {
 
 export namespace UserError {
   export function isa(o: any): o is UserError {
-    return _smithy.isa(o, "UserError");
+    return __isa(o, "UserError");
   }
 }
 
@@ -4617,7 +4599,7 @@ export interface UserSettings {
 
 export namespace UserSettings {
   export function isa(o: any): o is UserSettings {
-    return _smithy.isa(o, "UserSettings");
+    return __isa(o, "UserSettings");
   }
 }
 
@@ -4670,7 +4652,7 @@ export interface VoiceConnector {
 
 export namespace VoiceConnector {
   export function isa(o: any): o is VoiceConnector {
-    return _smithy.isa(o, "VoiceConnector");
+    return __isa(o, "VoiceConnector");
   }
 }
 
@@ -4715,7 +4697,7 @@ export interface VoiceConnectorGroup {
 
 export namespace VoiceConnectorGroup {
   export function isa(o: any): o is VoiceConnectorGroup {
-    return _smithy.isa(o, "VoiceConnectorGroup");
+    return __isa(o, "VoiceConnectorGroup");
   }
 }
 
@@ -4737,7 +4719,7 @@ export interface VoiceConnectorItem {
 
 export namespace VoiceConnectorItem {
   export function isa(o: any): o is VoiceConnectorItem {
-    return _smithy.isa(o, "VoiceConnectorItem");
+    return __isa(o, "VoiceConnectorItem");
   }
 }
 
@@ -4755,6 +4737,6 @@ export interface VoiceConnectorSettings {
 
 export namespace VoiceConnectorSettings {
   export function isa(o: any): o is VoiceConnectorSettings {
-    return _smithy.isa(o, "VoiceConnectorSettings");
+    return __isa(o, "VoiceConnectorSettings");
   }
 }

--- a/clients/client-chime/protocols/Aws_restJson1_1.ts
+++ b/clients/client-chime/protocols/Aws_restJson1_1.ts
@@ -434,7 +434,10 @@ import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  extendedEncodeURIComponent as __extendedEncodeURIComponent
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -451,25 +454,25 @@ export async function serializeAws_restJson1_1AssociatePhoneNumberWithUserComman
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/accounts/{AccountId}/users/{UserId}";
   if (input.AccountId !== undefined) {
-    const labelValue: string = input.AccountId.toString();
+    const labelValue: string = input.AccountId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: AccountId.");
     }
     resolvedPath = resolvedPath.replace(
       "{AccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AccountId.");
   }
   if (input.UserId !== undefined) {
-    const labelValue: string = input.UserId.toString();
+    const labelValue: string = input.UserId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: UserId.");
     }
     resolvedPath = resolvedPath.replace(
       "{UserId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: UserId.");
@@ -502,7 +505,7 @@ export async function serializeAws_restJson1_1AssociatePhoneNumbersWithVoiceConn
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/voice-connectors/{VoiceConnectorId}";
   if (input.VoiceConnectorId !== undefined) {
-    const labelValue: string = input.VoiceConnectorId.toString();
+    const labelValue: string = input.VoiceConnectorId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: VoiceConnectorId."
@@ -510,7 +513,7 @@ export async function serializeAws_restJson1_1AssociatePhoneNumbersWithVoiceConn
     }
     resolvedPath = resolvedPath.replace(
       "{VoiceConnectorId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -553,7 +556,7 @@ export async function serializeAws_restJson1_1AssociatePhoneNumbersWithVoiceConn
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/voice-connector-groups/{VoiceConnectorGroupId}";
   if (input.VoiceConnectorGroupId !== undefined) {
-    const labelValue: string = input.VoiceConnectorGroupId.toString();
+    const labelValue: string = input.VoiceConnectorGroupId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: VoiceConnectorGroupId."
@@ -561,7 +564,7 @@ export async function serializeAws_restJson1_1AssociatePhoneNumbersWithVoiceConn
     }
     resolvedPath = resolvedPath.replace(
       "{VoiceConnectorGroupId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -604,13 +607,13 @@ export async function serializeAws_restJson1_1AssociateSigninDelegateGroupsWithA
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/accounts/{AccountId}";
   if (input.AccountId !== undefined) {
-    const labelValue: string = input.AccountId.toString();
+    const labelValue: string = input.AccountId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: AccountId.");
     }
     resolvedPath = resolvedPath.replace(
       "{AccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AccountId.");
@@ -648,13 +651,13 @@ export async function serializeAws_restJson1_1BatchCreateAttendeeCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/meetings/{MeetingId}/attendees";
   if (input.MeetingId !== undefined) {
-    const labelValue: string = input.MeetingId.toString();
+    const labelValue: string = input.MeetingId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: MeetingId.");
     }
     resolvedPath = resolvedPath.replace(
       "{MeetingId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: MeetingId.");
@@ -692,25 +695,25 @@ export async function serializeAws_restJson1_1BatchCreateRoomMembershipCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/accounts/{AccountId}/rooms/{RoomId}/memberships";
   if (input.AccountId !== undefined) {
-    const labelValue: string = input.AccountId.toString();
+    const labelValue: string = input.AccountId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: AccountId.");
     }
     resolvedPath = resolvedPath.replace(
       "{AccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AccountId.");
   }
   if (input.RoomId !== undefined) {
-    const labelValue: string = input.RoomId.toString();
+    const labelValue: string = input.RoomId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: RoomId.");
     }
     resolvedPath = resolvedPath.replace(
       "{RoomId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: RoomId.");
@@ -778,13 +781,13 @@ export async function serializeAws_restJson1_1BatchSuspendUserCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/accounts/{AccountId}/users";
   if (input.AccountId !== undefined) {
-    const labelValue: string = input.AccountId.toString();
+    const labelValue: string = input.AccountId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: AccountId.");
     }
     resolvedPath = resolvedPath.replace(
       "{AccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AccountId.");
@@ -820,13 +823,13 @@ export async function serializeAws_restJson1_1BatchUnsuspendUserCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/accounts/{AccountId}/users";
   if (input.AccountId !== undefined) {
-    const labelValue: string = input.AccountId.toString();
+    const labelValue: string = input.AccountId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: AccountId.");
     }
     resolvedPath = resolvedPath.replace(
       "{AccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AccountId.");
@@ -894,13 +897,13 @@ export async function serializeAws_restJson1_1BatchUpdateUserCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/accounts/{AccountId}/users";
   if (input.AccountId !== undefined) {
-    const labelValue: string = input.AccountId.toString();
+    const labelValue: string = input.AccountId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: AccountId.");
     }
     resolvedPath = resolvedPath.replace(
       "{AccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AccountId.");
@@ -957,13 +960,13 @@ export async function serializeAws_restJson1_1CreateAttendeeCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/meetings/{MeetingId}/attendees";
   if (input.MeetingId !== undefined) {
-    const labelValue: string = input.MeetingId.toString();
+    const labelValue: string = input.MeetingId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: MeetingId.");
     }
     resolvedPath = resolvedPath.replace(
       "{MeetingId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: MeetingId.");
@@ -992,13 +995,13 @@ export async function serializeAws_restJson1_1CreateBotCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/accounts/{AccountId}/bots";
   if (input.AccountId !== undefined) {
-    const labelValue: string = input.AccountId.toString();
+    const labelValue: string = input.AccountId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: AccountId.");
     }
     resolvedPath = resolvedPath.replace(
       "{AccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AccountId.");
@@ -1101,13 +1104,13 @@ export async function serializeAws_restJson1_1CreateRoomCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/accounts/{AccountId}/rooms";
   if (input.AccountId !== undefined) {
-    const labelValue: string = input.AccountId.toString();
+    const labelValue: string = input.AccountId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: AccountId.");
     }
     resolvedPath = resolvedPath.replace(
       "{AccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AccountId.");
@@ -1142,25 +1145,25 @@ export async function serializeAws_restJson1_1CreateRoomMembershipCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/accounts/{AccountId}/rooms/{RoomId}/memberships";
   if (input.AccountId !== undefined) {
-    const labelValue: string = input.AccountId.toString();
+    const labelValue: string = input.AccountId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: AccountId.");
     }
     resolvedPath = resolvedPath.replace(
       "{AccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AccountId.");
   }
   if (input.RoomId !== undefined) {
-    const labelValue: string = input.RoomId.toString();
+    const labelValue: string = input.RoomId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: RoomId.");
     }
     resolvedPath = resolvedPath.replace(
       "{RoomId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: RoomId.");
@@ -1192,13 +1195,13 @@ export async function serializeAws_restJson1_1CreateUserCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/accounts/{AccountId}/users";
   if (input.AccountId !== undefined) {
-    const labelValue: string = input.AccountId.toString();
+    const labelValue: string = input.AccountId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: AccountId.");
     }
     resolvedPath = resolvedPath.replace(
       "{AccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AccountId.");
@@ -1297,13 +1300,13 @@ export async function serializeAws_restJson1_1DeleteAccountCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/accounts/{AccountId}";
   if (input.AccountId !== undefined) {
-    const labelValue: string = input.AccountId.toString();
+    const labelValue: string = input.AccountId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: AccountId.");
     }
     resolvedPath = resolvedPath.replace(
       "{AccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AccountId.");
@@ -1325,25 +1328,25 @@ export async function serializeAws_restJson1_1DeleteAttendeeCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/meetings/{MeetingId}/attendees/{AttendeeId}";
   if (input.AttendeeId !== undefined) {
-    const labelValue: string = input.AttendeeId.toString();
+    const labelValue: string = input.AttendeeId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: AttendeeId.");
     }
     resolvedPath = resolvedPath.replace(
       "{AttendeeId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AttendeeId.");
   }
   if (input.MeetingId !== undefined) {
-    const labelValue: string = input.MeetingId.toString();
+    const labelValue: string = input.MeetingId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: MeetingId.");
     }
     resolvedPath = resolvedPath.replace(
       "{MeetingId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: MeetingId.");
@@ -1365,25 +1368,25 @@ export async function serializeAws_restJson1_1DeleteEventsConfigurationCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/accounts/{AccountId}/bots/{BotId}/events-configuration";
   if (input.AccountId !== undefined) {
-    const labelValue: string = input.AccountId.toString();
+    const labelValue: string = input.AccountId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: AccountId.");
     }
     resolvedPath = resolvedPath.replace(
       "{AccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AccountId.");
   }
   if (input.BotId !== undefined) {
-    const labelValue: string = input.BotId.toString();
+    const labelValue: string = input.BotId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: BotId.");
     }
     resolvedPath = resolvedPath.replace(
       "{BotId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: BotId.");
@@ -1405,13 +1408,13 @@ export async function serializeAws_restJson1_1DeleteMeetingCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/meetings/{MeetingId}";
   if (input.MeetingId !== undefined) {
-    const labelValue: string = input.MeetingId.toString();
+    const labelValue: string = input.MeetingId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: MeetingId.");
     }
     resolvedPath = resolvedPath.replace(
       "{MeetingId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: MeetingId.");
@@ -1433,7 +1436,7 @@ export async function serializeAws_restJson1_1DeletePhoneNumberCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/phone-numbers/{PhoneNumberId}";
   if (input.PhoneNumberId !== undefined) {
-    const labelValue: string = input.PhoneNumberId.toString();
+    const labelValue: string = input.PhoneNumberId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: PhoneNumberId."
@@ -1441,7 +1444,7 @@ export async function serializeAws_restJson1_1DeletePhoneNumberCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{PhoneNumberId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: PhoneNumberId.");
@@ -1463,25 +1466,25 @@ export async function serializeAws_restJson1_1DeleteRoomCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/accounts/{AccountId}/rooms/{RoomId}";
   if (input.AccountId !== undefined) {
-    const labelValue: string = input.AccountId.toString();
+    const labelValue: string = input.AccountId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: AccountId.");
     }
     resolvedPath = resolvedPath.replace(
       "{AccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AccountId.");
   }
   if (input.RoomId !== undefined) {
-    const labelValue: string = input.RoomId.toString();
+    const labelValue: string = input.RoomId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: RoomId.");
     }
     resolvedPath = resolvedPath.replace(
       "{RoomId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: RoomId.");
@@ -1504,37 +1507,37 @@ export async function serializeAws_restJson1_1DeleteRoomMembershipCommand(
   let resolvedPath =
     "/accounts/{AccountId}/rooms/{RoomId}/memberships/{MemberId}";
   if (input.AccountId !== undefined) {
-    const labelValue: string = input.AccountId.toString();
+    const labelValue: string = input.AccountId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: AccountId.");
     }
     resolvedPath = resolvedPath.replace(
       "{AccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AccountId.");
   }
   if (input.MemberId !== undefined) {
-    const labelValue: string = input.MemberId.toString();
+    const labelValue: string = input.MemberId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: MemberId.");
     }
     resolvedPath = resolvedPath.replace(
       "{MemberId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: MemberId.");
   }
   if (input.RoomId !== undefined) {
-    const labelValue: string = input.RoomId.toString();
+    const labelValue: string = input.RoomId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: RoomId.");
     }
     resolvedPath = resolvedPath.replace(
       "{RoomId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: RoomId.");
@@ -1556,7 +1559,7 @@ export async function serializeAws_restJson1_1DeleteVoiceConnectorCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/voice-connectors/{VoiceConnectorId}";
   if (input.VoiceConnectorId !== undefined) {
-    const labelValue: string = input.VoiceConnectorId.toString();
+    const labelValue: string = input.VoiceConnectorId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: VoiceConnectorId."
@@ -1564,7 +1567,7 @@ export async function serializeAws_restJson1_1DeleteVoiceConnectorCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{VoiceConnectorId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -1588,7 +1591,7 @@ export async function serializeAws_restJson1_1DeleteVoiceConnectorGroupCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/voice-connector-groups/{VoiceConnectorGroupId}";
   if (input.VoiceConnectorGroupId !== undefined) {
-    const labelValue: string = input.VoiceConnectorGroupId.toString();
+    const labelValue: string = input.VoiceConnectorGroupId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: VoiceConnectorGroupId."
@@ -1596,7 +1599,7 @@ export async function serializeAws_restJson1_1DeleteVoiceConnectorGroupCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{VoiceConnectorGroupId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -1620,7 +1623,7 @@ export async function serializeAws_restJson1_1DeleteVoiceConnectorOriginationCom
   headers["Content-Type"] = "";
   let resolvedPath = "/voice-connectors/{VoiceConnectorId}/origination";
   if (input.VoiceConnectorId !== undefined) {
-    const labelValue: string = input.VoiceConnectorId.toString();
+    const labelValue: string = input.VoiceConnectorId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: VoiceConnectorId."
@@ -1628,7 +1631,7 @@ export async function serializeAws_restJson1_1DeleteVoiceConnectorOriginationCom
     }
     resolvedPath = resolvedPath.replace(
       "{VoiceConnectorId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -1653,7 +1656,7 @@ export async function serializeAws_restJson1_1DeleteVoiceConnectorStreamingConfi
   let resolvedPath =
     "/voice-connectors/{VoiceConnectorId}/streaming-configuration";
   if (input.VoiceConnectorId !== undefined) {
-    const labelValue: string = input.VoiceConnectorId.toString();
+    const labelValue: string = input.VoiceConnectorId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: VoiceConnectorId."
@@ -1661,7 +1664,7 @@ export async function serializeAws_restJson1_1DeleteVoiceConnectorStreamingConfi
     }
     resolvedPath = resolvedPath.replace(
       "{VoiceConnectorId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -1685,7 +1688,7 @@ export async function serializeAws_restJson1_1DeleteVoiceConnectorTerminationCom
   headers["Content-Type"] = "";
   let resolvedPath = "/voice-connectors/{VoiceConnectorId}/termination";
   if (input.VoiceConnectorId !== undefined) {
-    const labelValue: string = input.VoiceConnectorId.toString();
+    const labelValue: string = input.VoiceConnectorId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: VoiceConnectorId."
@@ -1693,7 +1696,7 @@ export async function serializeAws_restJson1_1DeleteVoiceConnectorTerminationCom
     }
     resolvedPath = resolvedPath.replace(
       "{VoiceConnectorId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -1718,7 +1721,7 @@ export async function serializeAws_restJson1_1DeleteVoiceConnectorTerminationCre
   let resolvedPath =
     "/voice-connectors/{VoiceConnectorId}/termination/credentials";
   if (input.VoiceConnectorId !== undefined) {
-    const labelValue: string = input.VoiceConnectorId.toString();
+    const labelValue: string = input.VoiceConnectorId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: VoiceConnectorId."
@@ -1726,7 +1729,7 @@ export async function serializeAws_restJson1_1DeleteVoiceConnectorTerminationCre
     }
     resolvedPath = resolvedPath.replace(
       "{VoiceConnectorId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -1764,25 +1767,25 @@ export async function serializeAws_restJson1_1DisassociatePhoneNumberFromUserCom
   headers["Content-Type"] = "";
   let resolvedPath = "/accounts/{AccountId}/users/{UserId}";
   if (input.AccountId !== undefined) {
-    const labelValue: string = input.AccountId.toString();
+    const labelValue: string = input.AccountId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: AccountId.");
     }
     resolvedPath = resolvedPath.replace(
       "{AccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AccountId.");
   }
   if (input.UserId !== undefined) {
-    const labelValue: string = input.UserId.toString();
+    const labelValue: string = input.UserId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: UserId.");
     }
     resolvedPath = resolvedPath.replace(
       "{UserId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: UserId.");
@@ -1808,7 +1811,7 @@ export async function serializeAws_restJson1_1DisassociatePhoneNumbersFromVoiceC
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/voice-connectors/{VoiceConnectorId}";
   if (input.VoiceConnectorId !== undefined) {
-    const labelValue: string = input.VoiceConnectorId.toString();
+    const labelValue: string = input.VoiceConnectorId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: VoiceConnectorId."
@@ -1816,7 +1819,7 @@ export async function serializeAws_restJson1_1DisassociatePhoneNumbersFromVoiceC
     }
     resolvedPath = resolvedPath.replace(
       "{VoiceConnectorId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -1856,7 +1859,7 @@ export async function serializeAws_restJson1_1DisassociatePhoneNumbersFromVoiceC
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/voice-connector-groups/{VoiceConnectorGroupId}";
   if (input.VoiceConnectorGroupId !== undefined) {
-    const labelValue: string = input.VoiceConnectorGroupId.toString();
+    const labelValue: string = input.VoiceConnectorGroupId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: VoiceConnectorGroupId."
@@ -1864,7 +1867,7 @@ export async function serializeAws_restJson1_1DisassociatePhoneNumbersFromVoiceC
     }
     resolvedPath = resolvedPath.replace(
       "{VoiceConnectorGroupId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -1904,13 +1907,13 @@ export async function serializeAws_restJson1_1DisassociateSigninDelegateGroupsFr
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/accounts/{AccountId}";
   if (input.AccountId !== undefined) {
-    const labelValue: string = input.AccountId.toString();
+    const labelValue: string = input.AccountId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: AccountId.");
     }
     resolvedPath = resolvedPath.replace(
       "{AccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AccountId.");
@@ -1946,13 +1949,13 @@ export async function serializeAws_restJson1_1GetAccountCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/accounts/{AccountId}";
   if (input.AccountId !== undefined) {
-    const labelValue: string = input.AccountId.toString();
+    const labelValue: string = input.AccountId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: AccountId.");
     }
     resolvedPath = resolvedPath.replace(
       "{AccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AccountId.");
@@ -1974,13 +1977,13 @@ export async function serializeAws_restJson1_1GetAccountSettingsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/accounts/{AccountId}/settings";
   if (input.AccountId !== undefined) {
-    const labelValue: string = input.AccountId.toString();
+    const labelValue: string = input.AccountId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: AccountId.");
     }
     resolvedPath = resolvedPath.replace(
       "{AccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AccountId.");
@@ -2002,25 +2005,25 @@ export async function serializeAws_restJson1_1GetAttendeeCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/meetings/{MeetingId}/attendees/{AttendeeId}";
   if (input.AttendeeId !== undefined) {
-    const labelValue: string = input.AttendeeId.toString();
+    const labelValue: string = input.AttendeeId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: AttendeeId.");
     }
     resolvedPath = resolvedPath.replace(
       "{AttendeeId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AttendeeId.");
   }
   if (input.MeetingId !== undefined) {
-    const labelValue: string = input.MeetingId.toString();
+    const labelValue: string = input.MeetingId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: MeetingId.");
     }
     resolvedPath = resolvedPath.replace(
       "{MeetingId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: MeetingId.");
@@ -2042,25 +2045,25 @@ export async function serializeAws_restJson1_1GetBotCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/accounts/{AccountId}/bots/{BotId}";
   if (input.AccountId !== undefined) {
-    const labelValue: string = input.AccountId.toString();
+    const labelValue: string = input.AccountId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: AccountId.");
     }
     resolvedPath = resolvedPath.replace(
       "{AccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AccountId.");
   }
   if (input.BotId !== undefined) {
-    const labelValue: string = input.BotId.toString();
+    const labelValue: string = input.BotId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: BotId.");
     }
     resolvedPath = resolvedPath.replace(
       "{BotId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: BotId.");
@@ -2082,25 +2085,25 @@ export async function serializeAws_restJson1_1GetEventsConfigurationCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/accounts/{AccountId}/bots/{BotId}/events-configuration";
   if (input.AccountId !== undefined) {
-    const labelValue: string = input.AccountId.toString();
+    const labelValue: string = input.AccountId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: AccountId.");
     }
     resolvedPath = resolvedPath.replace(
       "{AccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AccountId.");
   }
   if (input.BotId !== undefined) {
-    const labelValue: string = input.BotId.toString();
+    const labelValue: string = input.BotId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: BotId.");
     }
     resolvedPath = resolvedPath.replace(
       "{BotId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: BotId.");
@@ -2138,13 +2141,13 @@ export async function serializeAws_restJson1_1GetMeetingCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/meetings/{MeetingId}";
   if (input.MeetingId !== undefined) {
-    const labelValue: string = input.MeetingId.toString();
+    const labelValue: string = input.MeetingId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: MeetingId.");
     }
     resolvedPath = resolvedPath.replace(
       "{MeetingId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: MeetingId.");
@@ -2166,7 +2169,7 @@ export async function serializeAws_restJson1_1GetPhoneNumberCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/phone-numbers/{PhoneNumberId}";
   if (input.PhoneNumberId !== undefined) {
-    const labelValue: string = input.PhoneNumberId.toString();
+    const labelValue: string = input.PhoneNumberId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: PhoneNumberId."
@@ -2174,7 +2177,7 @@ export async function serializeAws_restJson1_1GetPhoneNumberCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{PhoneNumberId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: PhoneNumberId.");
@@ -2196,7 +2199,7 @@ export async function serializeAws_restJson1_1GetPhoneNumberOrderCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/phone-number-orders/{PhoneNumberOrderId}";
   if (input.PhoneNumberOrderId !== undefined) {
-    const labelValue: string = input.PhoneNumberOrderId.toString();
+    const labelValue: string = input.PhoneNumberOrderId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: PhoneNumberOrderId."
@@ -2204,7 +2207,7 @@ export async function serializeAws_restJson1_1GetPhoneNumberOrderCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{PhoneNumberOrderId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -2244,25 +2247,25 @@ export async function serializeAws_restJson1_1GetRoomCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/accounts/{AccountId}/rooms/{RoomId}";
   if (input.AccountId !== undefined) {
-    const labelValue: string = input.AccountId.toString();
+    const labelValue: string = input.AccountId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: AccountId.");
     }
     resolvedPath = resolvedPath.replace(
       "{AccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AccountId.");
   }
   if (input.RoomId !== undefined) {
-    const labelValue: string = input.RoomId.toString();
+    const labelValue: string = input.RoomId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: RoomId.");
     }
     resolvedPath = resolvedPath.replace(
       "{RoomId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: RoomId.");
@@ -2284,25 +2287,25 @@ export async function serializeAws_restJson1_1GetUserCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/accounts/{AccountId}/users/{UserId}";
   if (input.AccountId !== undefined) {
-    const labelValue: string = input.AccountId.toString();
+    const labelValue: string = input.AccountId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: AccountId.");
     }
     resolvedPath = resolvedPath.replace(
       "{AccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AccountId.");
   }
   if (input.UserId !== undefined) {
-    const labelValue: string = input.UserId.toString();
+    const labelValue: string = input.UserId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: UserId.");
     }
     resolvedPath = resolvedPath.replace(
       "{UserId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: UserId.");
@@ -2324,25 +2327,25 @@ export async function serializeAws_restJson1_1GetUserSettingsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/accounts/{AccountId}/users/{UserId}/settings";
   if (input.AccountId !== undefined) {
-    const labelValue: string = input.AccountId.toString();
+    const labelValue: string = input.AccountId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: AccountId.");
     }
     resolvedPath = resolvedPath.replace(
       "{AccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AccountId.");
   }
   if (input.UserId !== undefined) {
-    const labelValue: string = input.UserId.toString();
+    const labelValue: string = input.UserId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: UserId.");
     }
     resolvedPath = resolvedPath.replace(
       "{UserId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: UserId.");
@@ -2364,7 +2367,7 @@ export async function serializeAws_restJson1_1GetVoiceConnectorCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/voice-connectors/{VoiceConnectorId}";
   if (input.VoiceConnectorId !== undefined) {
-    const labelValue: string = input.VoiceConnectorId.toString();
+    const labelValue: string = input.VoiceConnectorId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: VoiceConnectorId."
@@ -2372,7 +2375,7 @@ export async function serializeAws_restJson1_1GetVoiceConnectorCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{VoiceConnectorId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -2396,7 +2399,7 @@ export async function serializeAws_restJson1_1GetVoiceConnectorGroupCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/voice-connector-groups/{VoiceConnectorGroupId}";
   if (input.VoiceConnectorGroupId !== undefined) {
-    const labelValue: string = input.VoiceConnectorGroupId.toString();
+    const labelValue: string = input.VoiceConnectorGroupId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: VoiceConnectorGroupId."
@@ -2404,7 +2407,7 @@ export async function serializeAws_restJson1_1GetVoiceConnectorGroupCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{VoiceConnectorGroupId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -2429,7 +2432,7 @@ export async function serializeAws_restJson1_1GetVoiceConnectorLoggingConfigurat
   let resolvedPath =
     "/voice-connectors/{VoiceConnectorId}/logging-configuration";
   if (input.VoiceConnectorId !== undefined) {
-    const labelValue: string = input.VoiceConnectorId.toString();
+    const labelValue: string = input.VoiceConnectorId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: VoiceConnectorId."
@@ -2437,7 +2440,7 @@ export async function serializeAws_restJson1_1GetVoiceConnectorLoggingConfigurat
     }
     resolvedPath = resolvedPath.replace(
       "{VoiceConnectorId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -2461,7 +2464,7 @@ export async function serializeAws_restJson1_1GetVoiceConnectorOriginationComman
   headers["Content-Type"] = "";
   let resolvedPath = "/voice-connectors/{VoiceConnectorId}/origination";
   if (input.VoiceConnectorId !== undefined) {
-    const labelValue: string = input.VoiceConnectorId.toString();
+    const labelValue: string = input.VoiceConnectorId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: VoiceConnectorId."
@@ -2469,7 +2472,7 @@ export async function serializeAws_restJson1_1GetVoiceConnectorOriginationComman
     }
     resolvedPath = resolvedPath.replace(
       "{VoiceConnectorId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -2494,7 +2497,7 @@ export async function serializeAws_restJson1_1GetVoiceConnectorStreamingConfigur
   let resolvedPath =
     "/voice-connectors/{VoiceConnectorId}/streaming-configuration";
   if (input.VoiceConnectorId !== undefined) {
-    const labelValue: string = input.VoiceConnectorId.toString();
+    const labelValue: string = input.VoiceConnectorId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: VoiceConnectorId."
@@ -2502,7 +2505,7 @@ export async function serializeAws_restJson1_1GetVoiceConnectorStreamingConfigur
     }
     resolvedPath = resolvedPath.replace(
       "{VoiceConnectorId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -2526,7 +2529,7 @@ export async function serializeAws_restJson1_1GetVoiceConnectorTerminationComman
   headers["Content-Type"] = "";
   let resolvedPath = "/voice-connectors/{VoiceConnectorId}/termination";
   if (input.VoiceConnectorId !== undefined) {
-    const labelValue: string = input.VoiceConnectorId.toString();
+    const labelValue: string = input.VoiceConnectorId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: VoiceConnectorId."
@@ -2534,7 +2537,7 @@ export async function serializeAws_restJson1_1GetVoiceConnectorTerminationComman
     }
     resolvedPath = resolvedPath.replace(
       "{VoiceConnectorId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -2558,7 +2561,7 @@ export async function serializeAws_restJson1_1GetVoiceConnectorTerminationHealth
   headers["Content-Type"] = "";
   let resolvedPath = "/voice-connectors/{VoiceConnectorId}/termination/health";
   if (input.VoiceConnectorId !== undefined) {
-    const labelValue: string = input.VoiceConnectorId.toString();
+    const labelValue: string = input.VoiceConnectorId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: VoiceConnectorId."
@@ -2566,7 +2569,7 @@ export async function serializeAws_restJson1_1GetVoiceConnectorTerminationHealth
     }
     resolvedPath = resolvedPath.replace(
       "{VoiceConnectorId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -2590,13 +2593,13 @@ export async function serializeAws_restJson1_1InviteUsersCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/accounts/{AccountId}/users";
   if (input.AccountId !== undefined) {
-    const labelValue: string = input.AccountId.toString();
+    const labelValue: string = input.AccountId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: AccountId.");
     }
     resolvedPath = resolvedPath.replace(
       "{AccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AccountId.");
@@ -2636,16 +2639,24 @@ export async function serializeAws_restJson1_1ListAccountsCommand(
   let resolvedPath = "/accounts";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["max-results"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("max-results")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.Name !== undefined) {
-    query["name"] = input.Name.toString();
+    query[__extendedEncodeURIComponent("name")] = __extendedEncodeURIComponent(
+      input.Name
+    );
   }
   if (input.NextToken !== undefined) {
-    query["next-token"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("next-token")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   if (input.UserEmail !== undefined) {
-    query["user-email"] = input.UserEmail.toString();
+    query[
+      __extendedEncodeURIComponent("user-email")
+    ] = __extendedEncodeURIComponent(input.UserEmail);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2665,23 +2676,27 @@ export async function serializeAws_restJson1_1ListAttendeesCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/meetings/{MeetingId}/attendees";
   if (input.MeetingId !== undefined) {
-    const labelValue: string = input.MeetingId.toString();
+    const labelValue: string = input.MeetingId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: MeetingId.");
     }
     resolvedPath = resolvedPath.replace(
       "{MeetingId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: MeetingId.");
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["max-results"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("max-results")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["next-token"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("next-token")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2701,23 +2716,27 @@ export async function serializeAws_restJson1_1ListBotsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/accounts/{AccountId}/bots";
   if (input.AccountId !== undefined) {
-    const labelValue: string = input.AccountId.toString();
+    const labelValue: string = input.AccountId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: AccountId.");
     }
     resolvedPath = resolvedPath.replace(
       "{AccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AccountId.");
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["max-results"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("max-results")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["next-token"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("next-token")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2738,10 +2757,14 @@ export async function serializeAws_restJson1_1ListMeetingsCommand(
   let resolvedPath = "/meetings";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["max-results"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("max-results")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["next-token"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("next-token")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2762,10 +2785,14 @@ export async function serializeAws_restJson1_1ListPhoneNumberOrdersCommand(
   let resolvedPath = "/phone-number-orders";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["max-results"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("max-results")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["next-token"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("next-token")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2786,22 +2813,34 @@ export async function serializeAws_restJson1_1ListPhoneNumbersCommand(
   let resolvedPath = "/phone-numbers";
   const query: any = {};
   if (input.FilterName !== undefined) {
-    query["filter-name"] = input.FilterName.toString();
+    query[
+      __extendedEncodeURIComponent("filter-name")
+    ] = __extendedEncodeURIComponent(input.FilterName);
   }
   if (input.FilterValue !== undefined) {
-    query["filter-value"] = input.FilterValue.toString();
+    query[
+      __extendedEncodeURIComponent("filter-value")
+    ] = __extendedEncodeURIComponent(input.FilterValue);
   }
   if (input.MaxResults !== undefined) {
-    query["max-results"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("max-results")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["next-token"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("next-token")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   if (input.ProductType !== undefined) {
-    query["product-type"] = input.ProductType.toString();
+    query[
+      __extendedEncodeURIComponent("product-type")
+    ] = __extendedEncodeURIComponent(input.ProductType);
   }
   if (input.Status !== undefined) {
-    query["status"] = input.Status.toString();
+    query[
+      __extendedEncodeURIComponent("status")
+    ] = __extendedEncodeURIComponent(input.Status);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2821,35 +2860,39 @@ export async function serializeAws_restJson1_1ListRoomMembershipsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/accounts/{AccountId}/rooms/{RoomId}/memberships";
   if (input.AccountId !== undefined) {
-    const labelValue: string = input.AccountId.toString();
+    const labelValue: string = input.AccountId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: AccountId.");
     }
     resolvedPath = resolvedPath.replace(
       "{AccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AccountId.");
   }
   if (input.RoomId !== undefined) {
-    const labelValue: string = input.RoomId.toString();
+    const labelValue: string = input.RoomId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: RoomId.");
     }
     resolvedPath = resolvedPath.replace(
       "{RoomId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: RoomId.");
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["max-results"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("max-results")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["next-token"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("next-token")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2869,26 +2912,32 @@ export async function serializeAws_restJson1_1ListRoomsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/accounts/{AccountId}/rooms";
   if (input.AccountId !== undefined) {
-    const labelValue: string = input.AccountId.toString();
+    const labelValue: string = input.AccountId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: AccountId.");
     }
     resolvedPath = resolvedPath.replace(
       "{AccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AccountId.");
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["max-results"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("max-results")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.MemberId !== undefined) {
-    query["member-id"] = input.MemberId.toString();
+    query[
+      __extendedEncodeURIComponent("member-id")
+    ] = __extendedEncodeURIComponent(input.MemberId);
   }
   if (input.NextToken !== undefined) {
-    query["next-token"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("next-token")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2908,29 +2957,37 @@ export async function serializeAws_restJson1_1ListUsersCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/accounts/{AccountId}/users";
   if (input.AccountId !== undefined) {
-    const labelValue: string = input.AccountId.toString();
+    const labelValue: string = input.AccountId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: AccountId.");
     }
     resolvedPath = resolvedPath.replace(
       "{AccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AccountId.");
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["max-results"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("max-results")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["next-token"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("next-token")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   if (input.UserEmail !== undefined) {
-    query["user-email"] = input.UserEmail.toString();
+    query[
+      __extendedEncodeURIComponent("user-email")
+    ] = __extendedEncodeURIComponent(input.UserEmail);
   }
   if (input.UserType !== undefined) {
-    query["user-type"] = input.UserType.toString();
+    query[
+      __extendedEncodeURIComponent("user-type")
+    ] = __extendedEncodeURIComponent(input.UserType);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2951,10 +3008,14 @@ export async function serializeAws_restJson1_1ListVoiceConnectorGroupsCommand(
   let resolvedPath = "/voice-connector-groups";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["max-results"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("max-results")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["next-token"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("next-token")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2975,7 +3036,7 @@ export async function serializeAws_restJson1_1ListVoiceConnectorTerminationCrede
   let resolvedPath =
     "/voice-connectors/{VoiceConnectorId}/termination/credentials";
   if (input.VoiceConnectorId !== undefined) {
-    const labelValue: string = input.VoiceConnectorId.toString();
+    const labelValue: string = input.VoiceConnectorId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: VoiceConnectorId."
@@ -2983,7 +3044,7 @@ export async function serializeAws_restJson1_1ListVoiceConnectorTerminationCrede
     }
     resolvedPath = resolvedPath.replace(
       "{VoiceConnectorId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -3008,10 +3069,14 @@ export async function serializeAws_restJson1_1ListVoiceConnectorsCommand(
   let resolvedPath = "/voice-connectors";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["max-results"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("max-results")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["next-token"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("next-token")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -3031,25 +3096,25 @@ export async function serializeAws_restJson1_1LogoutUserCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/accounts/{AccountId}/users/{UserId}";
   if (input.AccountId !== undefined) {
-    const labelValue: string = input.AccountId.toString();
+    const labelValue: string = input.AccountId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: AccountId.");
     }
     resolvedPath = resolvedPath.replace(
       "{AccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AccountId.");
   }
   if (input.UserId !== undefined) {
-    const labelValue: string = input.UserId.toString();
+    const labelValue: string = input.UserId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: UserId.");
     }
     resolvedPath = resolvedPath.replace(
       "{UserId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: UserId.");
@@ -3075,25 +3140,25 @@ export async function serializeAws_restJson1_1PutEventsConfigurationCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/accounts/{AccountId}/bots/{BotId}/events-configuration";
   if (input.AccountId !== undefined) {
-    const labelValue: string = input.AccountId.toString();
+    const labelValue: string = input.AccountId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: AccountId.");
     }
     resolvedPath = resolvedPath.replace(
       "{AccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AccountId.");
   }
   if (input.BotId !== undefined) {
-    const labelValue: string = input.BotId.toString();
+    const labelValue: string = input.BotId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: BotId.");
     }
     resolvedPath = resolvedPath.replace(
       "{BotId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: BotId.");
@@ -3127,7 +3192,7 @@ export async function serializeAws_restJson1_1PutVoiceConnectorLoggingConfigurat
   let resolvedPath =
     "/voice-connectors/{VoiceConnectorId}/logging-configuration";
   if (input.VoiceConnectorId !== undefined) {
-    const labelValue: string = input.VoiceConnectorId.toString();
+    const labelValue: string = input.VoiceConnectorId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: VoiceConnectorId."
@@ -3135,7 +3200,7 @@ export async function serializeAws_restJson1_1PutVoiceConnectorLoggingConfigurat
     }
     resolvedPath = resolvedPath.replace(
       "{VoiceConnectorId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -3171,7 +3236,7 @@ export async function serializeAws_restJson1_1PutVoiceConnectorOriginationComman
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/voice-connectors/{VoiceConnectorId}/origination";
   if (input.VoiceConnectorId !== undefined) {
-    const labelValue: string = input.VoiceConnectorId.toString();
+    const labelValue: string = input.VoiceConnectorId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: VoiceConnectorId."
@@ -3179,7 +3244,7 @@ export async function serializeAws_restJson1_1PutVoiceConnectorOriginationComman
     }
     resolvedPath = resolvedPath.replace(
       "{VoiceConnectorId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -3214,7 +3279,7 @@ export async function serializeAws_restJson1_1PutVoiceConnectorStreamingConfigur
   let resolvedPath =
     "/voice-connectors/{VoiceConnectorId}/streaming-configuration";
   if (input.VoiceConnectorId !== undefined) {
-    const labelValue: string = input.VoiceConnectorId.toString();
+    const labelValue: string = input.VoiceConnectorId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: VoiceConnectorId."
@@ -3222,7 +3287,7 @@ export async function serializeAws_restJson1_1PutVoiceConnectorStreamingConfigur
     }
     resolvedPath = resolvedPath.replace(
       "{VoiceConnectorId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -3258,7 +3323,7 @@ export async function serializeAws_restJson1_1PutVoiceConnectorTerminationComman
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/voice-connectors/{VoiceConnectorId}/termination";
   if (input.VoiceConnectorId !== undefined) {
-    const labelValue: string = input.VoiceConnectorId.toString();
+    const labelValue: string = input.VoiceConnectorId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: VoiceConnectorId."
@@ -3266,7 +3331,7 @@ export async function serializeAws_restJson1_1PutVoiceConnectorTerminationComman
     }
     resolvedPath = resolvedPath.replace(
       "{VoiceConnectorId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -3301,7 +3366,7 @@ export async function serializeAws_restJson1_1PutVoiceConnectorTerminationCreden
   let resolvedPath =
     "/voice-connectors/{VoiceConnectorId}/termination/credentials";
   if (input.VoiceConnectorId !== undefined) {
-    const labelValue: string = input.VoiceConnectorId.toString();
+    const labelValue: string = input.VoiceConnectorId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: VoiceConnectorId."
@@ -3309,7 +3374,7 @@ export async function serializeAws_restJson1_1PutVoiceConnectorTerminationCreden
     }
     resolvedPath = resolvedPath.replace(
       "{VoiceConnectorId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -3347,25 +3412,25 @@ export async function serializeAws_restJson1_1RegenerateSecurityTokenCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/accounts/{AccountId}/bots/{BotId}";
   if (input.AccountId !== undefined) {
-    const labelValue: string = input.AccountId.toString();
+    const labelValue: string = input.AccountId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: AccountId.");
     }
     resolvedPath = resolvedPath.replace(
       "{AccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AccountId.");
   }
   if (input.BotId !== undefined) {
-    const labelValue: string = input.BotId.toString();
+    const labelValue: string = input.BotId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: BotId.");
     }
     resolvedPath = resolvedPath.replace(
       "{BotId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: BotId.");
@@ -3391,25 +3456,25 @@ export async function serializeAws_restJson1_1ResetPersonalPINCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/accounts/{AccountId}/users/{UserId}";
   if (input.AccountId !== undefined) {
-    const labelValue: string = input.AccountId.toString();
+    const labelValue: string = input.AccountId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: AccountId.");
     }
     resolvedPath = resolvedPath.replace(
       "{AccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AccountId.");
   }
   if (input.UserId !== undefined) {
-    const labelValue: string = input.UserId.toString();
+    const labelValue: string = input.UserId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: UserId.");
     }
     resolvedPath = resolvedPath.replace(
       "{UserId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: UserId.");
@@ -3435,7 +3500,7 @@ export async function serializeAws_restJson1_1RestorePhoneNumberCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/phone-numbers/{PhoneNumberId}";
   if (input.PhoneNumberId !== undefined) {
-    const labelValue: string = input.PhoneNumberId.toString();
+    const labelValue: string = input.PhoneNumberId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: PhoneNumberId."
@@ -3443,7 +3508,7 @@ export async function serializeAws_restJson1_1RestorePhoneNumberCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{PhoneNumberId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: PhoneNumberId.");
@@ -3472,25 +3537,39 @@ export async function serializeAws_restJson1_1SearchAvailablePhoneNumbersCommand
     type: "phone-numbers"
   };
   if (input.AreaCode !== undefined) {
-    query["area-code"] = input.AreaCode.toString();
+    query[
+      __extendedEncodeURIComponent("area-code")
+    ] = __extendedEncodeURIComponent(input.AreaCode);
   }
   if (input.City !== undefined) {
-    query["city"] = input.City.toString();
+    query[__extendedEncodeURIComponent("city")] = __extendedEncodeURIComponent(
+      input.City
+    );
   }
   if (input.Country !== undefined) {
-    query["country"] = input.Country.toString();
+    query[
+      __extendedEncodeURIComponent("country")
+    ] = __extendedEncodeURIComponent(input.Country);
   }
   if (input.MaxResults !== undefined) {
-    query["max-results"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("max-results")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["next-token"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("next-token")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   if (input.State !== undefined) {
-    query["state"] = input.State.toString();
+    query[__extendedEncodeURIComponent("state")] = __extendedEncodeURIComponent(
+      input.State
+    );
   }
   if (input.TollFreePrefix !== undefined) {
-    query["toll-free-prefix"] = input.TollFreePrefix.toString();
+    query[
+      __extendedEncodeURIComponent("toll-free-prefix")
+    ] = __extendedEncodeURIComponent(input.TollFreePrefix);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -3510,13 +3589,13 @@ export async function serializeAws_restJson1_1UpdateAccountCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/accounts/{AccountId}";
   if (input.AccountId !== undefined) {
-    const labelValue: string = input.AccountId.toString();
+    const labelValue: string = input.AccountId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: AccountId.");
     }
     resolvedPath = resolvedPath.replace(
       "{AccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AccountId.");
@@ -3545,13 +3624,13 @@ export async function serializeAws_restJson1_1UpdateAccountSettingsCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/accounts/{AccountId}/settings";
   if (input.AccountId !== undefined) {
-    const labelValue: string = input.AccountId.toString();
+    const labelValue: string = input.AccountId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: AccountId.");
     }
     resolvedPath = resolvedPath.replace(
       "{AccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AccountId.");
@@ -3583,25 +3662,25 @@ export async function serializeAws_restJson1_1UpdateBotCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/accounts/{AccountId}/bots/{BotId}";
   if (input.AccountId !== undefined) {
-    const labelValue: string = input.AccountId.toString();
+    const labelValue: string = input.AccountId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: AccountId.");
     }
     resolvedPath = resolvedPath.replace(
       "{AccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AccountId.");
   }
   if (input.BotId !== undefined) {
-    const labelValue: string = input.BotId.toString();
+    const labelValue: string = input.BotId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: BotId.");
     }
     resolvedPath = resolvedPath.replace(
       "{BotId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: BotId.");
@@ -3666,7 +3745,7 @@ export async function serializeAws_restJson1_1UpdatePhoneNumberCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/phone-numbers/{PhoneNumberId}";
   if (input.PhoneNumberId !== undefined) {
-    const labelValue: string = input.PhoneNumberId.toString();
+    const labelValue: string = input.PhoneNumberId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: PhoneNumberId."
@@ -3674,7 +3753,7 @@ export async function serializeAws_restJson1_1UpdatePhoneNumberCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{PhoneNumberId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: PhoneNumberId.");
@@ -3729,25 +3808,25 @@ export async function serializeAws_restJson1_1UpdateRoomCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/accounts/{AccountId}/rooms/{RoomId}";
   if (input.AccountId !== undefined) {
-    const labelValue: string = input.AccountId.toString();
+    const labelValue: string = input.AccountId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: AccountId.");
     }
     resolvedPath = resolvedPath.replace(
       "{AccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AccountId.");
   }
   if (input.RoomId !== undefined) {
-    const labelValue: string = input.RoomId.toString();
+    const labelValue: string = input.RoomId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: RoomId.");
     }
     resolvedPath = resolvedPath.replace(
       "{RoomId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: RoomId.");
@@ -3777,37 +3856,37 @@ export async function serializeAws_restJson1_1UpdateRoomMembershipCommand(
   let resolvedPath =
     "/accounts/{AccountId}/rooms/{RoomId}/memberships/{MemberId}";
   if (input.AccountId !== undefined) {
-    const labelValue: string = input.AccountId.toString();
+    const labelValue: string = input.AccountId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: AccountId.");
     }
     resolvedPath = resolvedPath.replace(
       "{AccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AccountId.");
   }
   if (input.MemberId !== undefined) {
-    const labelValue: string = input.MemberId.toString();
+    const labelValue: string = input.MemberId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: MemberId.");
     }
     resolvedPath = resolvedPath.replace(
       "{MemberId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: MemberId.");
   }
   if (input.RoomId !== undefined) {
-    const labelValue: string = input.RoomId.toString();
+    const labelValue: string = input.RoomId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: RoomId.");
     }
     resolvedPath = resolvedPath.replace(
       "{RoomId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: RoomId.");
@@ -3836,25 +3915,25 @@ export async function serializeAws_restJson1_1UpdateUserCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/accounts/{AccountId}/users/{UserId}";
   if (input.AccountId !== undefined) {
-    const labelValue: string = input.AccountId.toString();
+    const labelValue: string = input.AccountId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: AccountId.");
     }
     resolvedPath = resolvedPath.replace(
       "{AccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AccountId.");
   }
   if (input.UserId !== undefined) {
-    const labelValue: string = input.UserId.toString();
+    const labelValue: string = input.UserId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: UserId.");
     }
     resolvedPath = resolvedPath.replace(
       "{UserId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: UserId.");
@@ -3894,25 +3973,25 @@ export async function serializeAws_restJson1_1UpdateUserSettingsCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/accounts/{AccountId}/users/{UserId}/settings";
   if (input.AccountId !== undefined) {
-    const labelValue: string = input.AccountId.toString();
+    const labelValue: string = input.AccountId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: AccountId.");
     }
     resolvedPath = resolvedPath.replace(
       "{AccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AccountId.");
   }
   if (input.UserId !== undefined) {
-    const labelValue: string = input.UserId.toString();
+    const labelValue: string = input.UserId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: UserId.");
     }
     resolvedPath = resolvedPath.replace(
       "{UserId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: UserId.");
@@ -3944,7 +4023,7 @@ export async function serializeAws_restJson1_1UpdateVoiceConnectorCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/voice-connectors/{VoiceConnectorId}";
   if (input.VoiceConnectorId !== undefined) {
-    const labelValue: string = input.VoiceConnectorId.toString();
+    const labelValue: string = input.VoiceConnectorId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: VoiceConnectorId."
@@ -3952,7 +4031,7 @@ export async function serializeAws_restJson1_1UpdateVoiceConnectorCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{VoiceConnectorId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -3986,7 +4065,7 @@ export async function serializeAws_restJson1_1UpdateVoiceConnectorGroupCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/voice-connector-groups/{VoiceConnectorGroupId}";
   if (input.VoiceConnectorGroupId !== undefined) {
-    const labelValue: string = input.VoiceConnectorGroupId.toString();
+    const labelValue: string = input.VoiceConnectorGroupId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: VoiceConnectorGroupId."
@@ -3994,7 +4073,7 @@ export async function serializeAws_restJson1_1UpdateVoiceConnectorGroupCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{VoiceConnectorGroupId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -4039,6 +4118,7 @@ export async function deserializeAws_restJson1_1AssociatePhoneNumberWithUserComm
     $metadata: deserializeMetadata(output),
     __type: "AssociatePhoneNumberWithUserResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -4355,6 +4435,7 @@ export async function deserializeAws_restJson1_1AssociateSigninDelegateGroupsWit
     $metadata: deserializeMetadata(output),
     __type: "AssociateSigninDelegateGroupsWithAccountResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -6212,6 +6293,7 @@ export async function deserializeAws_restJson1_1DeleteAccountCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeleteAccountResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -6311,6 +6393,7 @@ export async function deserializeAws_restJson1_1DeleteAttendeeCommand(
   const contents: DeleteAttendeeCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -6403,6 +6486,7 @@ export async function deserializeAws_restJson1_1DeleteEventsConfigurationCommand
   const contents: DeleteEventsConfigurationCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -6485,6 +6569,7 @@ export async function deserializeAws_restJson1_1DeleteMeetingCommand(
   const contents: DeleteMeetingCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -6577,6 +6662,7 @@ export async function deserializeAws_restJson1_1DeletePhoneNumberCommand(
   const contents: DeletePhoneNumberCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -6666,6 +6752,7 @@ export async function deserializeAws_restJson1_1DeleteRoomCommand(
   const contents: DeleteRoomCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -6758,6 +6845,7 @@ export async function deserializeAws_restJson1_1DeleteRoomMembershipCommand(
   const contents: DeleteRoomMembershipCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -6850,6 +6938,7 @@ export async function deserializeAws_restJson1_1DeleteVoiceConnectorCommand(
   const contents: DeleteVoiceConnectorCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -6949,6 +7038,7 @@ export async function deserializeAws_restJson1_1DeleteVoiceConnectorGroupCommand
   const contents: DeleteVoiceConnectorGroupCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -7048,6 +7138,7 @@ export async function deserializeAws_restJson1_1DeleteVoiceConnectorOriginationC
   const contents: DeleteVoiceConnectorOriginationCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -7140,6 +7231,7 @@ export async function deserializeAws_restJson1_1DeleteVoiceConnectorStreamingCon
   const contents: DeleteVoiceConnectorStreamingConfigurationCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -7232,6 +7324,7 @@ export async function deserializeAws_restJson1_1DeleteVoiceConnectorTerminationC
   const contents: DeleteVoiceConnectorTerminationCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -7324,6 +7417,7 @@ export async function deserializeAws_restJson1_1DeleteVoiceConnectorTerminationC
   const contents: DeleteVoiceConnectorTerminationCredentialsCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -7417,6 +7511,7 @@ export async function deserializeAws_restJson1_1DisassociatePhoneNumberFromUserC
     $metadata: deserializeMetadata(output),
     __type: "DisassociatePhoneNumberFromUserResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -7712,6 +7807,7 @@ export async function deserializeAws_restJson1_1DisassociateSigninDelegateGroups
     $metadata: deserializeMetadata(output),
     __type: "DisassociateSigninDelegateGroupsFromAccountResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -11095,6 +11191,7 @@ export async function deserializeAws_restJson1_1LogoutUserCommand(
     $metadata: deserializeMetadata(output),
     __type: "LogoutUserResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -11708,6 +11805,7 @@ export async function deserializeAws_restJson1_1PutVoiceConnectorTerminationCred
   const contents: PutVoiceConnectorTerminationCredentialsCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -12301,6 +12399,7 @@ export async function deserializeAws_restJson1_1UpdateAccountSettingsCommand(
     $metadata: deserializeMetadata(output),
     __type: "UpdateAccountSettingsResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -12495,6 +12594,7 @@ export async function deserializeAws_restJson1_1UpdateGlobalSettingsCommand(
   const contents: UpdateGlobalSettingsCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -12681,6 +12781,7 @@ export async function deserializeAws_restJson1_1UpdatePhoneNumberSettingsCommand
   const contents: UpdatePhoneNumberSettingsCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -13057,6 +13158,7 @@ export async function deserializeAws_restJson1_1UpdateUserSettingsCommand(
   const contents: UpdateUserSettingsCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 

--- a/clients/client-cloud9/models/index.ts
+++ b/clients/client-cloud9/models/index.ts
@@ -1,11 +1,14 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
  * <p>The target request is invalid.</p>
  */
 export interface BadRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "BadRequestException";
   $fault: "client";
@@ -16,16 +19,14 @@ export interface BadRequestException
 
 export namespace BadRequestException {
   export function isa(o: any): o is BadRequestException {
-    return _smithy.isa(o, "BadRequestException");
+    return __isa(o, "BadRequestException");
   }
 }
 
 /**
  * <p>A conflict occurred.</p>
  */
-export interface ConflictException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface ConflictException extends __SmithyException, $MetadataBearer {
   name: "ConflictException";
   $fault: "client";
   className?: string;
@@ -35,7 +36,7 @@ export interface ConflictException
 
 export namespace ConflictException {
   export function isa(o: any): o is ConflictException {
-    return _smithy.isa(o, "ConflictException");
+    return __isa(o, "ConflictException");
   }
 }
 
@@ -81,7 +82,7 @@ export interface CreateEnvironmentEC2Request {
 
 export namespace CreateEnvironmentEC2Request {
   export function isa(o: any): o is CreateEnvironmentEC2Request {
-    return _smithy.isa(o, "CreateEnvironmentEC2Request");
+    return __isa(o, "CreateEnvironmentEC2Request");
   }
 }
 
@@ -95,7 +96,7 @@ export interface CreateEnvironmentEC2Result extends $MetadataBearer {
 
 export namespace CreateEnvironmentEC2Result {
   export function isa(o: any): o is CreateEnvironmentEC2Result {
-    return _smithy.isa(o, "CreateEnvironmentEC2Result");
+    return __isa(o, "CreateEnvironmentEC2Result");
   }
 }
 
@@ -129,7 +130,7 @@ export interface CreateEnvironmentMembershipRequest {
 
 export namespace CreateEnvironmentMembershipRequest {
   export function isa(o: any): o is CreateEnvironmentMembershipRequest {
-    return _smithy.isa(o, "CreateEnvironmentMembershipRequest");
+    return __isa(o, "CreateEnvironmentMembershipRequest");
   }
 }
 
@@ -143,7 +144,7 @@ export interface CreateEnvironmentMembershipResult extends $MetadataBearer {
 
 export namespace CreateEnvironmentMembershipResult {
   export function isa(o: any): o is CreateEnvironmentMembershipResult {
-    return _smithy.isa(o, "CreateEnvironmentMembershipResult");
+    return __isa(o, "CreateEnvironmentMembershipResult");
   }
 }
 
@@ -162,7 +163,7 @@ export interface DeleteEnvironmentMembershipRequest {
 
 export namespace DeleteEnvironmentMembershipRequest {
   export function isa(o: any): o is DeleteEnvironmentMembershipRequest {
-    return _smithy.isa(o, "DeleteEnvironmentMembershipRequest");
+    return __isa(o, "DeleteEnvironmentMembershipRequest");
   }
 }
 
@@ -172,7 +173,7 @@ export interface DeleteEnvironmentMembershipResult extends $MetadataBearer {
 
 export namespace DeleteEnvironmentMembershipResult {
   export function isa(o: any): o is DeleteEnvironmentMembershipResult {
-    return _smithy.isa(o, "DeleteEnvironmentMembershipResult");
+    return __isa(o, "DeleteEnvironmentMembershipResult");
   }
 }
 
@@ -186,7 +187,7 @@ export interface DeleteEnvironmentRequest {
 
 export namespace DeleteEnvironmentRequest {
   export function isa(o: any): o is DeleteEnvironmentRequest {
-    return _smithy.isa(o, "DeleteEnvironmentRequest");
+    return __isa(o, "DeleteEnvironmentRequest");
   }
 }
 
@@ -196,7 +197,7 @@ export interface DeleteEnvironmentResult extends $MetadataBearer {
 
 export namespace DeleteEnvironmentResult {
   export function isa(o: any): o is DeleteEnvironmentResult {
-    return _smithy.isa(o, "DeleteEnvironmentResult");
+    return __isa(o, "DeleteEnvironmentResult");
   }
 }
 
@@ -245,7 +246,7 @@ export interface DescribeEnvironmentMembershipsRequest {
 
 export namespace DescribeEnvironmentMembershipsRequest {
   export function isa(o: any): o is DescribeEnvironmentMembershipsRequest {
-    return _smithy.isa(o, "DescribeEnvironmentMembershipsRequest");
+    return __isa(o, "DescribeEnvironmentMembershipsRequest");
   }
 }
 
@@ -264,7 +265,7 @@ export interface DescribeEnvironmentMembershipsResult extends $MetadataBearer {
 
 export namespace DescribeEnvironmentMembershipsResult {
   export function isa(o: any): o is DescribeEnvironmentMembershipsResult {
-    return _smithy.isa(o, "DescribeEnvironmentMembershipsResult");
+    return __isa(o, "DescribeEnvironmentMembershipsResult");
   }
 }
 
@@ -278,7 +279,7 @@ export interface DescribeEnvironmentStatusRequest {
 
 export namespace DescribeEnvironmentStatusRequest {
   export function isa(o: any): o is DescribeEnvironmentStatusRequest {
-    return _smithy.isa(o, "DescribeEnvironmentStatusRequest");
+    return __isa(o, "DescribeEnvironmentStatusRequest");
   }
 }
 
@@ -327,7 +328,7 @@ export interface DescribeEnvironmentStatusResult extends $MetadataBearer {
 
 export namespace DescribeEnvironmentStatusResult {
   export function isa(o: any): o is DescribeEnvironmentStatusResult {
-    return _smithy.isa(o, "DescribeEnvironmentStatusResult");
+    return __isa(o, "DescribeEnvironmentStatusResult");
   }
 }
 
@@ -341,7 +342,7 @@ export interface DescribeEnvironmentsRequest {
 
 export namespace DescribeEnvironmentsRequest {
   export function isa(o: any): o is DescribeEnvironmentsRequest {
-    return _smithy.isa(o, "DescribeEnvironmentsRequest");
+    return __isa(o, "DescribeEnvironmentsRequest");
   }
 }
 
@@ -355,7 +356,7 @@ export interface DescribeEnvironmentsResult extends $MetadataBearer {
 
 export namespace DescribeEnvironmentsResult {
   export function isa(o: any): o is DescribeEnvironmentsResult {
-    return _smithy.isa(o, "DescribeEnvironmentsResult");
+    return __isa(o, "DescribeEnvironmentsResult");
   }
 }
 
@@ -412,7 +413,7 @@ export interface Environment {
 
 export namespace Environment {
   export function isa(o: any): o is Environment {
-    return _smithy.isa(o, "Environment");
+    return __isa(o, "Environment");
   }
 }
 
@@ -461,7 +462,7 @@ export interface EnvironmentLifecycle {
 
 export namespace EnvironmentLifecycle {
   export function isa(o: any): o is EnvironmentLifecycle {
-    return _smithy.isa(o, "EnvironmentLifecycle");
+    return __isa(o, "EnvironmentLifecycle");
   }
 }
 
@@ -520,7 +521,7 @@ export interface EnvironmentMember {
 
 export namespace EnvironmentMember {
   export function isa(o: any): o is EnvironmentMember {
-    return _smithy.isa(o, "EnvironmentMember");
+    return __isa(o, "EnvironmentMember");
   }
 }
 
@@ -542,9 +543,7 @@ export enum EnvironmentType {
 /**
  * <p>An access permissions issue occurred.</p>
  */
-export interface ForbiddenException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface ForbiddenException extends __SmithyException, $MetadataBearer {
   name: "ForbiddenException";
   $fault: "client";
   className?: string;
@@ -554,7 +553,7 @@ export interface ForbiddenException
 
 export namespace ForbiddenException {
   export function isa(o: any): o is ForbiddenException {
-    return _smithy.isa(o, "ForbiddenException");
+    return __isa(o, "ForbiddenException");
   }
 }
 
@@ -562,7 +561,7 @@ export namespace ForbiddenException {
  * <p>An internal server error occurred.</p>
  */
 export interface InternalServerErrorException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalServerErrorException";
   $fault: "server";
@@ -573,7 +572,7 @@ export interface InternalServerErrorException
 
 export namespace InternalServerErrorException {
   export function isa(o: any): o is InternalServerErrorException {
-    return _smithy.isa(o, "InternalServerErrorException");
+    return __isa(o, "InternalServerErrorException");
   }
 }
 
@@ -581,7 +580,7 @@ export namespace InternalServerErrorException {
  * <p>A service limit was exceeded.</p>
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -592,7 +591,7 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
@@ -611,7 +610,7 @@ export interface ListEnvironmentsRequest {
 
 export namespace ListEnvironmentsRequest {
   export function isa(o: any): o is ListEnvironmentsRequest {
-    return _smithy.isa(o, "ListEnvironmentsRequest");
+    return __isa(o, "ListEnvironmentsRequest");
   }
 }
 
@@ -630,7 +629,7 @@ export interface ListEnvironmentsResult extends $MetadataBearer {
 
 export namespace ListEnvironmentsResult {
   export function isa(o: any): o is ListEnvironmentsResult {
-    return _smithy.isa(o, "ListEnvironmentsResult");
+    return __isa(o, "ListEnvironmentsResult");
   }
 }
 
@@ -642,9 +641,7 @@ export enum MemberPermissions {
 /**
  * <p>The target resource cannot be found.</p>
  */
-export interface NotFoundException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface NotFoundException extends __SmithyException, $MetadataBearer {
   name: "NotFoundException";
   $fault: "client";
   className?: string;
@@ -654,7 +651,7 @@ export interface NotFoundException
 
 export namespace NotFoundException {
   export function isa(o: any): o is NotFoundException {
-    return _smithy.isa(o, "NotFoundException");
+    return __isa(o, "NotFoundException");
   }
 }
 
@@ -668,7 +665,7 @@ export enum Permissions {
  * <p>Too many service requests were made over the given time period.</p>
  */
 export interface TooManyRequestsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyRequestsException";
   $fault: "client";
@@ -679,7 +676,7 @@ export interface TooManyRequestsException
 
 export namespace TooManyRequestsException {
   export function isa(o: any): o is TooManyRequestsException {
-    return _smithy.isa(o, "TooManyRequestsException");
+    return __isa(o, "TooManyRequestsException");
   }
 }
 
@@ -713,7 +710,7 @@ export interface UpdateEnvironmentMembershipRequest {
 
 export namespace UpdateEnvironmentMembershipRequest {
   export function isa(o: any): o is UpdateEnvironmentMembershipRequest {
-    return _smithy.isa(o, "UpdateEnvironmentMembershipRequest");
+    return __isa(o, "UpdateEnvironmentMembershipRequest");
   }
 }
 
@@ -727,7 +724,7 @@ export interface UpdateEnvironmentMembershipResult extends $MetadataBearer {
 
 export namespace UpdateEnvironmentMembershipResult {
   export function isa(o: any): o is UpdateEnvironmentMembershipResult {
-    return _smithy.isa(o, "UpdateEnvironmentMembershipResult");
+    return __isa(o, "UpdateEnvironmentMembershipResult");
   }
 }
 
@@ -751,7 +748,7 @@ export interface UpdateEnvironmentRequest {
 
 export namespace UpdateEnvironmentRequest {
   export function isa(o: any): o is UpdateEnvironmentRequest {
-    return _smithy.isa(o, "UpdateEnvironmentRequest");
+    return __isa(o, "UpdateEnvironmentRequest");
   }
 }
 
@@ -761,6 +758,6 @@ export interface UpdateEnvironmentResult extends $MetadataBearer {
 
 export namespace UpdateEnvironmentResult {
   export function isa(o: any): o is UpdateEnvironmentResult {
-    return _smithy.isa(o, "UpdateEnvironmentResult");
+    return __isa(o, "UpdateEnvironmentResult");
   }
 }

--- a/clients/client-clouddirectory/models/index.ts
+++ b/clients/client-clouddirectory/models/index.ts
@@ -1,11 +1,14 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
  * <p>Access denied. Check your permissions.</p>
  */
 export interface AccessDeniedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AccessDeniedException";
   $fault: "client";
@@ -14,7 +17,7 @@ export interface AccessDeniedException
 
 export namespace AccessDeniedException {
   export function isa(o: any): o is AccessDeniedException {
-    return _smithy.isa(o, "AccessDeniedException");
+    return __isa(o, "AccessDeniedException");
   }
 }
 
@@ -44,7 +47,7 @@ export interface AddFacetToObjectRequest {
 
 export namespace AddFacetToObjectRequest {
   export function isa(o: any): o is AddFacetToObjectRequest {
-    return _smithy.isa(o, "AddFacetToObjectRequest");
+    return __isa(o, "AddFacetToObjectRequest");
   }
 }
 
@@ -54,7 +57,7 @@ export interface AddFacetToObjectResponse extends $MetadataBearer {
 
 export namespace AddFacetToObjectResponse {
   export function isa(o: any): o is AddFacetToObjectResponse {
-    return _smithy.isa(o, "AddFacetToObjectResponse");
+    return __isa(o, "AddFacetToObjectResponse");
   }
 }
 
@@ -75,7 +78,7 @@ export interface ApplySchemaRequest {
 
 export namespace ApplySchemaRequest {
   export function isa(o: any): o is ApplySchemaRequest {
-    return _smithy.isa(o, "ApplySchemaRequest");
+    return __isa(o, "ApplySchemaRequest");
   }
 }
 
@@ -96,7 +99,7 @@ export interface ApplySchemaResponse extends $MetadataBearer {
 
 export namespace ApplySchemaResponse {
   export function isa(o: any): o is ApplySchemaResponse {
-    return _smithy.isa(o, "ApplySchemaResponse");
+    return __isa(o, "ApplySchemaResponse");
   }
 }
 
@@ -126,7 +129,7 @@ export interface AttachObjectRequest {
 
 export namespace AttachObjectRequest {
   export function isa(o: any): o is AttachObjectRequest {
-    return _smithy.isa(o, "AttachObjectRequest");
+    return __isa(o, "AttachObjectRequest");
   }
 }
 
@@ -141,7 +144,7 @@ export interface AttachObjectResponse extends $MetadataBearer {
 
 export namespace AttachObjectResponse {
   export function isa(o: any): o is AttachObjectResponse {
-    return _smithy.isa(o, "AttachObjectResponse");
+    return __isa(o, "AttachObjectResponse");
   }
 }
 
@@ -167,7 +170,7 @@ export interface AttachPolicyRequest {
 
 export namespace AttachPolicyRequest {
   export function isa(o: any): o is AttachPolicyRequest {
-    return _smithy.isa(o, "AttachPolicyRequest");
+    return __isa(o, "AttachPolicyRequest");
   }
 }
 
@@ -177,7 +180,7 @@ export interface AttachPolicyResponse extends $MetadataBearer {
 
 export namespace AttachPolicyResponse {
   export function isa(o: any): o is AttachPolicyResponse {
-    return _smithy.isa(o, "AttachPolicyResponse");
+    return __isa(o, "AttachPolicyResponse");
   }
 }
 
@@ -202,7 +205,7 @@ export interface AttachToIndexRequest {
 
 export namespace AttachToIndexRequest {
   export function isa(o: any): o is AttachToIndexRequest {
-    return _smithy.isa(o, "AttachToIndexRequest");
+    return __isa(o, "AttachToIndexRequest");
   }
 }
 
@@ -216,7 +219,7 @@ export interface AttachToIndexResponse extends $MetadataBearer {
 
 export namespace AttachToIndexResponse {
   export function isa(o: any): o is AttachToIndexResponse {
-    return _smithy.isa(o, "AttachToIndexResponse");
+    return __isa(o, "AttachToIndexResponse");
   }
 }
 
@@ -251,7 +254,7 @@ export interface AttachTypedLinkRequest {
 
 export namespace AttachTypedLinkRequest {
   export function isa(o: any): o is AttachTypedLinkRequest {
-    return _smithy.isa(o, "AttachTypedLinkRequest");
+    return __isa(o, "AttachTypedLinkRequest");
   }
 }
 
@@ -265,7 +268,7 @@ export interface AttachTypedLinkResponse extends $MetadataBearer {
 
 export namespace AttachTypedLinkResponse {
   export function isa(o: any): o is AttachTypedLinkResponse {
-    return _smithy.isa(o, "AttachTypedLinkResponse");
+    return __isa(o, "AttachTypedLinkResponse");
   }
 }
 
@@ -293,7 +296,7 @@ export interface AttributeKey {
 
 export namespace AttributeKey {
   export function isa(o: any): o is AttributeKey {
-    return _smithy.isa(o, "AttributeKey");
+    return __isa(o, "AttributeKey");
   }
 }
 
@@ -315,7 +318,7 @@ export interface AttributeKeyAndValue {
 
 export namespace AttributeKeyAndValue {
   export function isa(o: any): o is AttributeKeyAndValue {
-    return _smithy.isa(o, "AttributeKeyAndValue");
+    return __isa(o, "AttributeKeyAndValue");
   }
 }
 
@@ -337,7 +340,7 @@ export interface AttributeNameAndValue {
 
 export namespace AttributeNameAndValue {
   export function isa(o: any): o is AttributeNameAndValue {
-    return _smithy.isa(o, "AttributeNameAndValue");
+    return __isa(o, "AttributeNameAndValue");
   }
 }
 
@@ -364,7 +367,7 @@ export interface BatchAddFacetToObject {
 
 export namespace BatchAddFacetToObject {
   export function isa(o: any): o is BatchAddFacetToObject {
-    return _smithy.isa(o, "BatchAddFacetToObject");
+    return __isa(o, "BatchAddFacetToObject");
   }
 }
 
@@ -377,7 +380,7 @@ export interface BatchAddFacetToObjectResponse {
 
 export namespace BatchAddFacetToObjectResponse {
   export function isa(o: any): o is BatchAddFacetToObjectResponse {
-    return _smithy.isa(o, "BatchAddFacetToObjectResponse");
+    return __isa(o, "BatchAddFacetToObjectResponse");
   }
 }
 
@@ -404,7 +407,7 @@ export interface BatchAttachObject {
 
 export namespace BatchAttachObject {
   export function isa(o: any): o is BatchAttachObject {
-    return _smithy.isa(o, "BatchAttachObject");
+    return __isa(o, "BatchAttachObject");
   }
 }
 
@@ -421,7 +424,7 @@ export interface BatchAttachObjectResponse {
 
 export namespace BatchAttachObjectResponse {
   export function isa(o: any): o is BatchAttachObjectResponse {
-    return _smithy.isa(o, "BatchAttachObjectResponse");
+    return __isa(o, "BatchAttachObjectResponse");
   }
 }
 
@@ -444,7 +447,7 @@ export interface BatchAttachPolicy {
 
 export namespace BatchAttachPolicy {
   export function isa(o: any): o is BatchAttachPolicy {
-    return _smithy.isa(o, "BatchAttachPolicy");
+    return __isa(o, "BatchAttachPolicy");
   }
 }
 
@@ -458,7 +461,7 @@ export interface BatchAttachPolicyResponse {
 
 export namespace BatchAttachPolicyResponse {
   export function isa(o: any): o is BatchAttachPolicyResponse {
-    return _smithy.isa(o, "BatchAttachPolicyResponse");
+    return __isa(o, "BatchAttachPolicyResponse");
   }
 }
 
@@ -480,7 +483,7 @@ export interface BatchAttachToIndex {
 
 export namespace BatchAttachToIndex {
   export function isa(o: any): o is BatchAttachToIndex {
-    return _smithy.isa(o, "BatchAttachToIndex");
+    return __isa(o, "BatchAttachToIndex");
   }
 }
 
@@ -497,7 +500,7 @@ export interface BatchAttachToIndexResponse {
 
 export namespace BatchAttachToIndexResponse {
   export function isa(o: any): o is BatchAttachToIndexResponse {
-    return _smithy.isa(o, "BatchAttachToIndexResponse");
+    return __isa(o, "BatchAttachToIndexResponse");
   }
 }
 
@@ -529,7 +532,7 @@ export interface BatchAttachTypedLink {
 
 export namespace BatchAttachTypedLink {
   export function isa(o: any): o is BatchAttachTypedLink {
-    return _smithy.isa(o, "BatchAttachTypedLink");
+    return __isa(o, "BatchAttachTypedLink");
   }
 }
 
@@ -546,7 +549,7 @@ export interface BatchAttachTypedLinkResponse {
 
 export namespace BatchAttachTypedLinkResponse {
   export function isa(o: any): o is BatchAttachTypedLinkResponse {
-    return _smithy.isa(o, "BatchAttachTypedLinkResponse");
+    return __isa(o, "BatchAttachTypedLinkResponse");
   }
 }
 
@@ -585,7 +588,7 @@ export interface BatchCreateIndex {
 
 export namespace BatchCreateIndex {
   export function isa(o: any): o is BatchCreateIndex {
-    return _smithy.isa(o, "BatchCreateIndex");
+    return __isa(o, "BatchCreateIndex");
   }
 }
 
@@ -602,7 +605,7 @@ export interface BatchCreateIndexResponse {
 
 export namespace BatchCreateIndexResponse {
   export function isa(o: any): o is BatchCreateIndexResponse {
-    return _smithy.isa(o, "BatchCreateIndexResponse");
+    return __isa(o, "BatchCreateIndexResponse");
   }
 }
 
@@ -641,7 +644,7 @@ export interface BatchCreateObject {
 
 export namespace BatchCreateObject {
   export function isa(o: any): o is BatchCreateObject {
-    return _smithy.isa(o, "BatchCreateObject");
+    return __isa(o, "BatchCreateObject");
   }
 }
 
@@ -658,7 +661,7 @@ export interface BatchCreateObjectResponse {
 
 export namespace BatchCreateObjectResponse {
   export function isa(o: any): o is BatchCreateObjectResponse {
-    return _smithy.isa(o, "BatchCreateObjectResponse");
+    return __isa(o, "BatchCreateObjectResponse");
   }
 }
 
@@ -675,7 +678,7 @@ export interface BatchDeleteObject {
 
 export namespace BatchDeleteObject {
   export function isa(o: any): o is BatchDeleteObject {
-    return _smithy.isa(o, "BatchDeleteObject");
+    return __isa(o, "BatchDeleteObject");
   }
 }
 
@@ -688,7 +691,7 @@ export interface BatchDeleteObjectResponse {
 
 export namespace BatchDeleteObjectResponse {
   export function isa(o: any): o is BatchDeleteObjectResponse {
-    return _smithy.isa(o, "BatchDeleteObjectResponse");
+    return __isa(o, "BatchDeleteObjectResponse");
   }
 }
 
@@ -710,7 +713,7 @@ export interface BatchDetachFromIndex {
 
 export namespace BatchDetachFromIndex {
   export function isa(o: any): o is BatchDetachFromIndex {
-    return _smithy.isa(o, "BatchDetachFromIndex");
+    return __isa(o, "BatchDetachFromIndex");
   }
 }
 
@@ -727,7 +730,7 @@ export interface BatchDetachFromIndexResponse {
 
 export namespace BatchDetachFromIndexResponse {
   export function isa(o: any): o is BatchDetachFromIndexResponse {
-    return _smithy.isa(o, "BatchDetachFromIndexResponse");
+    return __isa(o, "BatchDetachFromIndexResponse");
   }
 }
 
@@ -755,7 +758,7 @@ export interface BatchDetachObject {
 
 export namespace BatchDetachObject {
   export function isa(o: any): o is BatchDetachObject {
-    return _smithy.isa(o, "BatchDetachObject");
+    return __isa(o, "BatchDetachObject");
   }
 }
 
@@ -772,7 +775,7 @@ export interface BatchDetachObjectResponse {
 
 export namespace BatchDetachObjectResponse {
   export function isa(o: any): o is BatchDetachObjectResponse {
-    return _smithy.isa(o, "BatchDetachObjectResponse");
+    return __isa(o, "BatchDetachObjectResponse");
   }
 }
 
@@ -794,7 +797,7 @@ export interface BatchDetachPolicy {
 
 export namespace BatchDetachPolicy {
   export function isa(o: any): o is BatchDetachPolicy {
-    return _smithy.isa(o, "BatchDetachPolicy");
+    return __isa(o, "BatchDetachPolicy");
   }
 }
 
@@ -807,7 +810,7 @@ export interface BatchDetachPolicyResponse {
 
 export namespace BatchDetachPolicyResponse {
   export function isa(o: any): o is BatchDetachPolicyResponse {
-    return _smithy.isa(o, "BatchDetachPolicyResponse");
+    return __isa(o, "BatchDetachPolicyResponse");
   }
 }
 
@@ -824,7 +827,7 @@ export interface BatchDetachTypedLink {
 
 export namespace BatchDetachTypedLink {
   export function isa(o: any): o is BatchDetachTypedLink {
-    return _smithy.isa(o, "BatchDetachTypedLink");
+    return __isa(o, "BatchDetachTypedLink");
   }
 }
 
@@ -837,7 +840,7 @@ export interface BatchDetachTypedLinkResponse {
 
 export namespace BatchDetachTypedLinkResponse {
   export function isa(o: any): o is BatchDetachTypedLinkResponse {
-    return _smithy.isa(o, "BatchDetachTypedLinkResponse");
+    return __isa(o, "BatchDetachTypedLinkResponse");
   }
 }
 
@@ -859,7 +862,7 @@ export interface BatchGetLinkAttributes {
 
 export namespace BatchGetLinkAttributes {
   export function isa(o: any): o is BatchGetLinkAttributes {
-    return _smithy.isa(o, "BatchGetLinkAttributes");
+    return __isa(o, "BatchGetLinkAttributes");
   }
 }
 
@@ -876,7 +879,7 @@ export interface BatchGetLinkAttributesResponse {
 
 export namespace BatchGetLinkAttributesResponse {
   export function isa(o: any): o is BatchGetLinkAttributesResponse {
-    return _smithy.isa(o, "BatchGetLinkAttributesResponse");
+    return __isa(o, "BatchGetLinkAttributesResponse");
   }
 }
 
@@ -903,7 +906,7 @@ export interface BatchGetObjectAttributes {
 
 export namespace BatchGetObjectAttributes {
   export function isa(o: any): o is BatchGetObjectAttributes {
-    return _smithy.isa(o, "BatchGetObjectAttributes");
+    return __isa(o, "BatchGetObjectAttributes");
   }
 }
 
@@ -920,7 +923,7 @@ export interface BatchGetObjectAttributesResponse {
 
 export namespace BatchGetObjectAttributesResponse {
   export function isa(o: any): o is BatchGetObjectAttributesResponse {
-    return _smithy.isa(o, "BatchGetObjectAttributesResponse");
+    return __isa(o, "BatchGetObjectAttributesResponse");
   }
 }
 
@@ -937,7 +940,7 @@ export interface BatchGetObjectInformation {
 
 export namespace BatchGetObjectInformation {
   export function isa(o: any): o is BatchGetObjectInformation {
-    return _smithy.isa(o, "BatchGetObjectInformation");
+    return __isa(o, "BatchGetObjectInformation");
   }
 }
 
@@ -959,7 +962,7 @@ export interface BatchGetObjectInformationResponse {
 
 export namespace BatchGetObjectInformationResponse {
   export function isa(o: any): o is BatchGetObjectInformationResponse {
-    return _smithy.isa(o, "BatchGetObjectInformationResponse");
+    return __isa(o, "BatchGetObjectInformationResponse");
   }
 }
 
@@ -986,7 +989,7 @@ export interface BatchListAttachedIndices {
 
 export namespace BatchListAttachedIndices {
   export function isa(o: any): o is BatchListAttachedIndices {
-    return _smithy.isa(o, "BatchListAttachedIndices");
+    return __isa(o, "BatchListAttachedIndices");
   }
 }
 
@@ -1008,7 +1011,7 @@ export interface BatchListAttachedIndicesResponse {
 
 export namespace BatchListAttachedIndicesResponse {
   export function isa(o: any): o is BatchListAttachedIndicesResponse {
-    return _smithy.isa(o, "BatchListAttachedIndicesResponse");
+    return __isa(o, "BatchListAttachedIndicesResponse");
   }
 }
 
@@ -1048,7 +1051,7 @@ export interface BatchListIncomingTypedLinks {
 
 export namespace BatchListIncomingTypedLinks {
   export function isa(o: any): o is BatchListIncomingTypedLinks {
-    return _smithy.isa(o, "BatchListIncomingTypedLinks");
+    return __isa(o, "BatchListIncomingTypedLinks");
   }
 }
 
@@ -1070,7 +1073,7 @@ export interface BatchListIncomingTypedLinksResponse {
 
 export namespace BatchListIncomingTypedLinksResponse {
   export function isa(o: any): o is BatchListIncomingTypedLinksResponse {
-    return _smithy.isa(o, "BatchListIncomingTypedLinksResponse");
+    return __isa(o, "BatchListIncomingTypedLinksResponse");
   }
 }
 
@@ -1102,7 +1105,7 @@ export interface BatchListIndex {
 
 export namespace BatchListIndex {
   export function isa(o: any): o is BatchListIndex {
-    return _smithy.isa(o, "BatchListIndex");
+    return __isa(o, "BatchListIndex");
   }
 }
 
@@ -1124,7 +1127,7 @@ export interface BatchListIndexResponse {
 
 export namespace BatchListIndexResponse {
   export function isa(o: any): o is BatchListIndexResponse {
-    return _smithy.isa(o, "BatchListIndexResponse");
+    return __isa(o, "BatchListIndexResponse");
   }
 }
 
@@ -1158,7 +1161,7 @@ export interface BatchListObjectAttributes {
 
 export namespace BatchListObjectAttributes {
   export function isa(o: any): o is BatchListObjectAttributes {
-    return _smithy.isa(o, "BatchListObjectAttributes");
+    return __isa(o, "BatchListObjectAttributes");
   }
 }
 
@@ -1181,7 +1184,7 @@ export interface BatchListObjectAttributesResponse {
 
 export namespace BatchListObjectAttributesResponse {
   export function isa(o: any): o is BatchListObjectAttributesResponse {
-    return _smithy.isa(o, "BatchListObjectAttributesResponse");
+    return __isa(o, "BatchListObjectAttributesResponse");
   }
 }
 
@@ -1209,7 +1212,7 @@ export interface BatchListObjectChildren {
 
 export namespace BatchListObjectChildren {
   export function isa(o: any): o is BatchListObjectChildren {
-    return _smithy.isa(o, "BatchListObjectChildren");
+    return __isa(o, "BatchListObjectChildren");
   }
 }
 
@@ -1232,7 +1235,7 @@ export interface BatchListObjectChildrenResponse {
 
 export namespace BatchListObjectChildrenResponse {
   export function isa(o: any): o is BatchListObjectChildrenResponse {
-    return _smithy.isa(o, "BatchListObjectChildrenResponse");
+    return __isa(o, "BatchListObjectChildrenResponse");
   }
 }
 
@@ -1259,7 +1262,7 @@ export interface BatchListObjectParentPaths {
 
 export namespace BatchListObjectParentPaths {
   export function isa(o: any): o is BatchListObjectParentPaths {
-    return _smithy.isa(o, "BatchListObjectParentPaths");
+    return __isa(o, "BatchListObjectParentPaths");
   }
 }
 
@@ -1282,7 +1285,7 @@ export interface BatchListObjectParentPathsResponse {
 
 export namespace BatchListObjectParentPathsResponse {
   export function isa(o: any): o is BatchListObjectParentPathsResponse {
-    return _smithy.isa(o, "BatchListObjectParentPathsResponse");
+    return __isa(o, "BatchListObjectParentPathsResponse");
   }
 }
 
@@ -1298,7 +1301,7 @@ export interface BatchListObjectParents {
 
 export namespace BatchListObjectParents {
   export function isa(o: any): o is BatchListObjectParents {
-    return _smithy.isa(o, "BatchListObjectParents");
+    return __isa(o, "BatchListObjectParents");
   }
 }
 
@@ -1310,7 +1313,7 @@ export interface BatchListObjectParentsResponse {
 
 export namespace BatchListObjectParentsResponse {
   export function isa(o: any): o is BatchListObjectParentsResponse {
-    return _smithy.isa(o, "BatchListObjectParentsResponse");
+    return __isa(o, "BatchListObjectParentsResponse");
   }
 }
 
@@ -1337,7 +1340,7 @@ export interface BatchListObjectPolicies {
 
 export namespace BatchListObjectPolicies {
   export function isa(o: any): o is BatchListObjectPolicies {
-    return _smithy.isa(o, "BatchListObjectPolicies");
+    return __isa(o, "BatchListObjectPolicies");
   }
 }
 
@@ -1360,7 +1363,7 @@ export interface BatchListObjectPoliciesResponse {
 
 export namespace BatchListObjectPoliciesResponse {
   export function isa(o: any): o is BatchListObjectPoliciesResponse {
-    return _smithy.isa(o, "BatchListObjectPoliciesResponse");
+    return __isa(o, "BatchListObjectPoliciesResponse");
   }
 }
 
@@ -1400,7 +1403,7 @@ export interface BatchListOutgoingTypedLinks {
 
 export namespace BatchListOutgoingTypedLinks {
   export function isa(o: any): o is BatchListOutgoingTypedLinks {
-    return _smithy.isa(o, "BatchListOutgoingTypedLinks");
+    return __isa(o, "BatchListOutgoingTypedLinks");
   }
 }
 
@@ -1422,7 +1425,7 @@ export interface BatchListOutgoingTypedLinksResponse {
 
 export namespace BatchListOutgoingTypedLinksResponse {
   export function isa(o: any): o is BatchListOutgoingTypedLinksResponse {
-    return _smithy.isa(o, "BatchListOutgoingTypedLinksResponse");
+    return __isa(o, "BatchListOutgoingTypedLinksResponse");
   }
 }
 
@@ -1449,7 +1452,7 @@ export interface BatchListPolicyAttachments {
 
 export namespace BatchListPolicyAttachments {
   export function isa(o: any): o is BatchListPolicyAttachments {
-    return _smithy.isa(o, "BatchListPolicyAttachments");
+    return __isa(o, "BatchListPolicyAttachments");
   }
 }
 
@@ -1471,7 +1474,7 @@ export interface BatchListPolicyAttachmentsResponse {
 
 export namespace BatchListPolicyAttachmentsResponse {
   export function isa(o: any): o is BatchListPolicyAttachmentsResponse {
-    return _smithy.isa(o, "BatchListPolicyAttachmentsResponse");
+    return __isa(o, "BatchListPolicyAttachmentsResponse");
   }
 }
 
@@ -1498,7 +1501,7 @@ export interface BatchLookupPolicy {
 
 export namespace BatchLookupPolicy {
   export function isa(o: any): o is BatchLookupPolicy {
-    return _smithy.isa(o, "BatchLookupPolicy");
+    return __isa(o, "BatchLookupPolicy");
   }
 }
 
@@ -1522,7 +1525,7 @@ export interface BatchLookupPolicyResponse {
 
 export namespace BatchLookupPolicyResponse {
   export function isa(o: any): o is BatchLookupPolicyResponse {
-    return _smithy.isa(o, "BatchLookupPolicyResponse");
+    return __isa(o, "BatchLookupPolicyResponse");
   }
 }
 
@@ -1545,7 +1548,7 @@ export interface BatchReadException {
 
 export namespace BatchReadException {
   export function isa(o: any): o is BatchReadException {
-    return _smithy.isa(o, "BatchReadException");
+    return __isa(o, "BatchReadException");
   }
 }
 
@@ -1650,7 +1653,7 @@ export interface BatchReadOperation {
 
 export namespace BatchReadOperation {
   export function isa(o: any): o is BatchReadOperation {
-    return _smithy.isa(o, "BatchReadOperation");
+    return __isa(o, "BatchReadOperation");
   }
 }
 
@@ -1672,7 +1675,7 @@ export interface BatchReadOperationResponse {
 
 export namespace BatchReadOperationResponse {
   export function isa(o: any): o is BatchReadOperationResponse {
-    return _smithy.isa(o, "BatchReadOperationResponse");
+    return __isa(o, "BatchReadOperationResponse");
   }
 }
 
@@ -1698,7 +1701,7 @@ export interface BatchReadRequest {
 
 export namespace BatchReadRequest {
   export function isa(o: any): o is BatchReadRequest {
-    return _smithy.isa(o, "BatchReadRequest");
+    return __isa(o, "BatchReadRequest");
   }
 }
 
@@ -1712,7 +1715,7 @@ export interface BatchReadResponse extends $MetadataBearer {
 
 export namespace BatchReadResponse {
   export function isa(o: any): o is BatchReadResponse {
-    return _smithy.isa(o, "BatchReadResponse");
+    return __isa(o, "BatchReadResponse");
   }
 }
 
@@ -1801,7 +1804,7 @@ export interface BatchReadSuccessfulResponse {
 
 export namespace BatchReadSuccessfulResponse {
   export function isa(o: any): o is BatchReadSuccessfulResponse {
-    return _smithy.isa(o, "BatchReadSuccessfulResponse");
+    return __isa(o, "BatchReadSuccessfulResponse");
   }
 }
 
@@ -1823,7 +1826,7 @@ export interface BatchRemoveFacetFromObject {
 
 export namespace BatchRemoveFacetFromObject {
   export function isa(o: any): o is BatchRemoveFacetFromObject {
-    return _smithy.isa(o, "BatchRemoveFacetFromObject");
+    return __isa(o, "BatchRemoveFacetFromObject");
   }
 }
 
@@ -1836,7 +1839,7 @@ export interface BatchRemoveFacetFromObjectResponse {
 
 export namespace BatchRemoveFacetFromObjectResponse {
   export function isa(o: any): o is BatchRemoveFacetFromObjectResponse {
-    return _smithy.isa(o, "BatchRemoveFacetFromObjectResponse");
+    return __isa(o, "BatchRemoveFacetFromObjectResponse");
   }
 }
 
@@ -1858,7 +1861,7 @@ export interface BatchUpdateLinkAttributes {
 
 export namespace BatchUpdateLinkAttributes {
   export function isa(o: any): o is BatchUpdateLinkAttributes {
-    return _smithy.isa(o, "BatchUpdateLinkAttributes");
+    return __isa(o, "BatchUpdateLinkAttributes");
   }
 }
 
@@ -1871,7 +1874,7 @@ export interface BatchUpdateLinkAttributesResponse {
 
 export namespace BatchUpdateLinkAttributesResponse {
   export function isa(o: any): o is BatchUpdateLinkAttributesResponse {
-    return _smithy.isa(o, "BatchUpdateLinkAttributesResponse");
+    return __isa(o, "BatchUpdateLinkAttributesResponse");
   }
 }
 
@@ -1893,7 +1896,7 @@ export interface BatchUpdateObjectAttributes {
 
 export namespace BatchUpdateObjectAttributes {
   export function isa(o: any): o is BatchUpdateObjectAttributes {
-    return _smithy.isa(o, "BatchUpdateObjectAttributes");
+    return __isa(o, "BatchUpdateObjectAttributes");
   }
 }
 
@@ -1910,7 +1913,7 @@ export interface BatchUpdateObjectAttributesResponse {
 
 export namespace BatchUpdateObjectAttributesResponse {
   export function isa(o: any): o is BatchUpdateObjectAttributesResponse {
-    return _smithy.isa(o, "BatchUpdateObjectAttributesResponse");
+    return __isa(o, "BatchUpdateObjectAttributesResponse");
   }
 }
 
@@ -1918,7 +1921,7 @@ export namespace BatchUpdateObjectAttributesResponse {
  * <p>A <code>BatchWrite</code> exception has occurred.</p>
  */
 export interface BatchWriteException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "BatchWriteException";
   $fault: "client";
@@ -1929,7 +1932,7 @@ export interface BatchWriteException
 
 export namespace BatchWriteException {
   export function isa(o: any): o is BatchWriteException {
-    return _smithy.isa(o, "BatchWriteException");
+    return __isa(o, "BatchWriteException");
   }
 }
 
@@ -2038,7 +2041,7 @@ export interface BatchWriteOperation {
 
 export namespace BatchWriteOperation {
   export function isa(o: any): o is BatchWriteOperation {
-    return _smithy.isa(o, "BatchWriteOperation");
+    return __isa(o, "BatchWriteOperation");
   }
 }
 
@@ -2126,7 +2129,7 @@ export interface BatchWriteOperationResponse {
 
 export namespace BatchWriteOperationResponse {
   export function isa(o: any): o is BatchWriteOperationResponse {
-    return _smithy.isa(o, "BatchWriteOperationResponse");
+    return __isa(o, "BatchWriteOperationResponse");
   }
 }
 
@@ -2146,7 +2149,7 @@ export interface BatchWriteRequest {
 
 export namespace BatchWriteRequest {
   export function isa(o: any): o is BatchWriteRequest {
-    return _smithy.isa(o, "BatchWriteRequest");
+    return __isa(o, "BatchWriteRequest");
   }
 }
 
@@ -2160,7 +2163,7 @@ export interface BatchWriteResponse extends $MetadataBearer {
 
 export namespace BatchWriteResponse {
   export function isa(o: any): o is BatchWriteResponse {
-    return _smithy.isa(o, "BatchWriteResponse");
+    return __isa(o, "BatchWriteResponse");
   }
 }
 
@@ -2168,7 +2171,7 @@ export namespace BatchWriteResponse {
  * <p>Cannot list the parents of a <a>Directory</a> root.</p>
  */
 export interface CannotListParentOfRootException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CannotListParentOfRootException";
   $fault: "client";
@@ -2177,7 +2180,7 @@ export interface CannotListParentOfRootException
 
 export namespace CannotListParentOfRootException {
   export function isa(o: any): o is CannotListParentOfRootException {
-    return _smithy.isa(o, "CannotListParentOfRootException");
+    return __isa(o, "CannotListParentOfRootException");
   }
 }
 
@@ -2203,7 +2206,7 @@ export interface CreateDirectoryRequest {
 
 export namespace CreateDirectoryRequest {
   export function isa(o: any): o is CreateDirectoryRequest {
-    return _smithy.isa(o, "CreateDirectoryRequest");
+    return __isa(o, "CreateDirectoryRequest");
   }
 }
 
@@ -2235,7 +2238,7 @@ export interface CreateDirectoryResponse extends $MetadataBearer {
 
 export namespace CreateDirectoryResponse {
   export function isa(o: any): o is CreateDirectoryResponse {
-    return _smithy.isa(o, "CreateDirectoryResponse");
+    return __isa(o, "CreateDirectoryResponse");
   }
 }
 
@@ -2292,7 +2295,7 @@ export interface CreateFacetRequest {
 
 export namespace CreateFacetRequest {
   export function isa(o: any): o is CreateFacetRequest {
-    return _smithy.isa(o, "CreateFacetRequest");
+    return __isa(o, "CreateFacetRequest");
   }
 }
 
@@ -2302,7 +2305,7 @@ export interface CreateFacetResponse extends $MetadataBearer {
 
 export namespace CreateFacetResponse {
   export function isa(o: any): o is CreateFacetResponse {
-    return _smithy.isa(o, "CreateFacetResponse");
+    return __isa(o, "CreateFacetResponse");
   }
 }
 
@@ -2338,7 +2341,7 @@ export interface CreateIndexRequest {
 
 export namespace CreateIndexRequest {
   export function isa(o: any): o is CreateIndexRequest {
-    return _smithy.isa(o, "CreateIndexRequest");
+    return __isa(o, "CreateIndexRequest");
   }
 }
 
@@ -2352,7 +2355,7 @@ export interface CreateIndexResponse extends $MetadataBearer {
 
 export namespace CreateIndexResponse {
   export function isa(o: any): o is CreateIndexResponse {
-    return _smithy.isa(o, "CreateIndexResponse");
+    return __isa(o, "CreateIndexResponse");
   }
 }
 
@@ -2388,7 +2391,7 @@ export interface CreateObjectRequest {
 
 export namespace CreateObjectRequest {
   export function isa(o: any): o is CreateObjectRequest {
-    return _smithy.isa(o, "CreateObjectRequest");
+    return __isa(o, "CreateObjectRequest");
   }
 }
 
@@ -2402,7 +2405,7 @@ export interface CreateObjectResponse extends $MetadataBearer {
 
 export namespace CreateObjectResponse {
   export function isa(o: any): o is CreateObjectResponse {
-    return _smithy.isa(o, "CreateObjectResponse");
+    return __isa(o, "CreateObjectResponse");
   }
 }
 
@@ -2417,7 +2420,7 @@ export interface CreateSchemaRequest {
 
 export namespace CreateSchemaRequest {
   export function isa(o: any): o is CreateSchemaRequest {
-    return _smithy.isa(o, "CreateSchemaRequest");
+    return __isa(o, "CreateSchemaRequest");
   }
 }
 
@@ -2432,7 +2435,7 @@ export interface CreateSchemaResponse extends $MetadataBearer {
 
 export namespace CreateSchemaResponse {
   export function isa(o: any): o is CreateSchemaResponse {
-    return _smithy.isa(o, "CreateSchemaResponse");
+    return __isa(o, "CreateSchemaResponse");
   }
 }
 
@@ -2454,7 +2457,7 @@ export interface CreateTypedLinkFacetRequest {
 
 export namespace CreateTypedLinkFacetRequest {
   export function isa(o: any): o is CreateTypedLinkFacetRequest {
-    return _smithy.isa(o, "CreateTypedLinkFacetRequest");
+    return __isa(o, "CreateTypedLinkFacetRequest");
   }
 }
 
@@ -2464,7 +2467,7 @@ export interface CreateTypedLinkFacetResponse extends $MetadataBearer {
 
 export namespace CreateTypedLinkFacetResponse {
   export function isa(o: any): o is CreateTypedLinkFacetResponse {
-    return _smithy.isa(o, "CreateTypedLinkFacetResponse");
+    return __isa(o, "CreateTypedLinkFacetResponse");
   }
 }
 
@@ -2478,7 +2481,7 @@ export interface DeleteDirectoryRequest {
 
 export namespace DeleteDirectoryRequest {
   export function isa(o: any): o is DeleteDirectoryRequest {
-    return _smithy.isa(o, "DeleteDirectoryRequest");
+    return __isa(o, "DeleteDirectoryRequest");
   }
 }
 
@@ -2492,7 +2495,7 @@ export interface DeleteDirectoryResponse extends $MetadataBearer {
 
 export namespace DeleteDirectoryResponse {
   export function isa(o: any): o is DeleteDirectoryResponse {
-    return _smithy.isa(o, "DeleteDirectoryResponse");
+    return __isa(o, "DeleteDirectoryResponse");
   }
 }
 
@@ -2512,7 +2515,7 @@ export interface DeleteFacetRequest {
 
 export namespace DeleteFacetRequest {
   export function isa(o: any): o is DeleteFacetRequest {
-    return _smithy.isa(o, "DeleteFacetRequest");
+    return __isa(o, "DeleteFacetRequest");
   }
 }
 
@@ -2522,7 +2525,7 @@ export interface DeleteFacetResponse extends $MetadataBearer {
 
 export namespace DeleteFacetResponse {
   export function isa(o: any): o is DeleteFacetResponse {
-    return _smithy.isa(o, "DeleteFacetResponse");
+    return __isa(o, "DeleteFacetResponse");
   }
 }
 
@@ -2542,7 +2545,7 @@ export interface DeleteObjectRequest {
 
 export namespace DeleteObjectRequest {
   export function isa(o: any): o is DeleteObjectRequest {
-    return _smithy.isa(o, "DeleteObjectRequest");
+    return __isa(o, "DeleteObjectRequest");
   }
 }
 
@@ -2552,7 +2555,7 @@ export interface DeleteObjectResponse extends $MetadataBearer {
 
 export namespace DeleteObjectResponse {
   export function isa(o: any): o is DeleteObjectResponse {
-    return _smithy.isa(o, "DeleteObjectResponse");
+    return __isa(o, "DeleteObjectResponse");
   }
 }
 
@@ -2567,7 +2570,7 @@ export interface DeleteSchemaRequest {
 
 export namespace DeleteSchemaRequest {
   export function isa(o: any): o is DeleteSchemaRequest {
-    return _smithy.isa(o, "DeleteSchemaRequest");
+    return __isa(o, "DeleteSchemaRequest");
   }
 }
 
@@ -2582,7 +2585,7 @@ export interface DeleteSchemaResponse extends $MetadataBearer {
 
 export namespace DeleteSchemaResponse {
   export function isa(o: any): o is DeleteSchemaResponse {
-    return _smithy.isa(o, "DeleteSchemaResponse");
+    return __isa(o, "DeleteSchemaResponse");
   }
 }
 
@@ -2602,7 +2605,7 @@ export interface DeleteTypedLinkFacetRequest {
 
 export namespace DeleteTypedLinkFacetRequest {
   export function isa(o: any): o is DeleteTypedLinkFacetRequest {
-    return _smithy.isa(o, "DeleteTypedLinkFacetRequest");
+    return __isa(o, "DeleteTypedLinkFacetRequest");
   }
 }
 
@@ -2612,7 +2615,7 @@ export interface DeleteTypedLinkFacetResponse extends $MetadataBearer {
 
 export namespace DeleteTypedLinkFacetResponse {
   export function isa(o: any): o is DeleteTypedLinkFacetResponse {
-    return _smithy.isa(o, "DeleteTypedLinkFacetResponse");
+    return __isa(o, "DeleteTypedLinkFacetResponse");
   }
 }
 
@@ -2637,7 +2640,7 @@ export interface DetachFromIndexRequest {
 
 export namespace DetachFromIndexRequest {
   export function isa(o: any): o is DetachFromIndexRequest {
-    return _smithy.isa(o, "DetachFromIndexRequest");
+    return __isa(o, "DetachFromIndexRequest");
   }
 }
 
@@ -2651,7 +2654,7 @@ export interface DetachFromIndexResponse extends $MetadataBearer {
 
 export namespace DetachFromIndexResponse {
   export function isa(o: any): o is DetachFromIndexResponse {
-    return _smithy.isa(o, "DetachFromIndexResponse");
+    return __isa(o, "DetachFromIndexResponse");
   }
 }
 
@@ -2677,7 +2680,7 @@ export interface DetachObjectRequest {
 
 export namespace DetachObjectRequest {
   export function isa(o: any): o is DetachObjectRequest {
-    return _smithy.isa(o, "DetachObjectRequest");
+    return __isa(o, "DetachObjectRequest");
   }
 }
 
@@ -2691,7 +2694,7 @@ export interface DetachObjectResponse extends $MetadataBearer {
 
 export namespace DetachObjectResponse {
   export function isa(o: any): o is DetachObjectResponse {
-    return _smithy.isa(o, "DetachObjectResponse");
+    return __isa(o, "DetachObjectResponse");
   }
 }
 
@@ -2716,7 +2719,7 @@ export interface DetachPolicyRequest {
 
 export namespace DetachPolicyRequest {
   export function isa(o: any): o is DetachPolicyRequest {
-    return _smithy.isa(o, "DetachPolicyRequest");
+    return __isa(o, "DetachPolicyRequest");
   }
 }
 
@@ -2726,7 +2729,7 @@ export interface DetachPolicyResponse extends $MetadataBearer {
 
 export namespace DetachPolicyResponse {
   export function isa(o: any): o is DetachPolicyResponse {
-    return _smithy.isa(o, "DetachPolicyResponse");
+    return __isa(o, "DetachPolicyResponse");
   }
 }
 
@@ -2746,7 +2749,7 @@ export interface DetachTypedLinkRequest {
 
 export namespace DetachTypedLinkRequest {
   export function isa(o: any): o is DetachTypedLinkRequest {
-    return _smithy.isa(o, "DetachTypedLinkRequest");
+    return __isa(o, "DetachTypedLinkRequest");
   }
 }
 
@@ -2779,7 +2782,7 @@ export interface Directory {
 
 export namespace Directory {
   export function isa(o: any): o is Directory {
-    return _smithy.isa(o, "Directory");
+    return __isa(o, "Directory");
   }
 }
 
@@ -2788,7 +2791,7 @@ export namespace Directory {
  *       conflict. Choose a different name and try again.</p>
  */
 export interface DirectoryAlreadyExistsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DirectoryAlreadyExistsException";
   $fault: "client";
@@ -2797,7 +2800,7 @@ export interface DirectoryAlreadyExistsException
 
 export namespace DirectoryAlreadyExistsException {
   export function isa(o: any): o is DirectoryAlreadyExistsException {
-    return _smithy.isa(o, "DirectoryAlreadyExistsException");
+    return __isa(o, "DirectoryAlreadyExistsException");
   }
 }
 
@@ -2806,7 +2809,7 @@ export namespace DirectoryAlreadyExistsException {
  *       requested resource will eventually cease to exist.</p>
  */
 export interface DirectoryDeletedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DirectoryDeletedException";
   $fault: "client";
@@ -2815,7 +2818,7 @@ export interface DirectoryDeletedException
 
 export namespace DirectoryDeletedException {
   export function isa(o: any): o is DirectoryDeletedException {
-    return _smithy.isa(o, "DirectoryDeletedException");
+    return __isa(o, "DirectoryDeletedException");
   }
 }
 
@@ -2823,7 +2826,7 @@ export namespace DirectoryDeletedException {
  * <p>An operation can only operate on a disabled directory.</p>
  */
 export interface DirectoryNotDisabledException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DirectoryNotDisabledException";
   $fault: "client";
@@ -2832,7 +2835,7 @@ export interface DirectoryNotDisabledException
 
 export namespace DirectoryNotDisabledException {
   export function isa(o: any): o is DirectoryNotDisabledException {
-    return _smithy.isa(o, "DirectoryNotDisabledException");
+    return __isa(o, "DirectoryNotDisabledException");
   }
 }
 
@@ -2840,7 +2843,7 @@ export namespace DirectoryNotDisabledException {
  * <p>Operations are only permitted on enabled directories.</p>
  */
 export interface DirectoryNotEnabledException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DirectoryNotEnabledException";
   $fault: "client";
@@ -2849,7 +2852,7 @@ export interface DirectoryNotEnabledException
 
 export namespace DirectoryNotEnabledException {
   export function isa(o: any): o is DirectoryNotEnabledException {
-    return _smithy.isa(o, "DirectoryNotEnabledException");
+    return __isa(o, "DirectoryNotEnabledException");
   }
 }
 
@@ -2869,7 +2872,7 @@ export interface DisableDirectoryRequest {
 
 export namespace DisableDirectoryRequest {
   export function isa(o: any): o is DisableDirectoryRequest {
-    return _smithy.isa(o, "DisableDirectoryRequest");
+    return __isa(o, "DisableDirectoryRequest");
   }
 }
 
@@ -2883,7 +2886,7 @@ export interface DisableDirectoryResponse extends $MetadataBearer {
 
 export namespace DisableDirectoryResponse {
   export function isa(o: any): o is DisableDirectoryResponse {
-    return _smithy.isa(o, "DisableDirectoryResponse");
+    return __isa(o, "DisableDirectoryResponse");
   }
 }
 
@@ -2897,7 +2900,7 @@ export interface EnableDirectoryRequest {
 
 export namespace EnableDirectoryRequest {
   export function isa(o: any): o is EnableDirectoryRequest {
-    return _smithy.isa(o, "EnableDirectoryRequest");
+    return __isa(o, "EnableDirectoryRequest");
   }
 }
 
@@ -2911,7 +2914,7 @@ export interface EnableDirectoryResponse extends $MetadataBearer {
 
 export namespace EnableDirectoryResponse {
   export function isa(o: any): o is EnableDirectoryResponse {
-    return _smithy.isa(o, "EnableDirectoryResponse");
+    return __isa(o, "EnableDirectoryResponse");
   }
 }
 
@@ -2940,7 +2943,7 @@ export interface Facet {
 
 export namespace Facet {
   export function isa(o: any): o is Facet {
-    return _smithy.isa(o, "Facet");
+    return __isa(o, "Facet");
   }
 }
 
@@ -2948,7 +2951,7 @@ export namespace Facet {
  * <p>A facet with the same name already exists.</p>
  */
 export interface FacetAlreadyExistsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "FacetAlreadyExistsException";
   $fault: "client";
@@ -2957,7 +2960,7 @@ export interface FacetAlreadyExistsException
 
 export namespace FacetAlreadyExistsException {
   export function isa(o: any): o is FacetAlreadyExistsException {
-    return _smithy.isa(o, "FacetAlreadyExistsException");
+    return __isa(o, "FacetAlreadyExistsException");
   }
 }
 
@@ -2990,7 +2993,7 @@ export interface FacetAttribute {
 
 export namespace FacetAttribute {
   export function isa(o: any): o is FacetAttribute {
-    return _smithy.isa(o, "FacetAttribute");
+    return __isa(o, "FacetAttribute");
   }
 }
 
@@ -3022,7 +3025,7 @@ export interface FacetAttributeDefinition {
 
 export namespace FacetAttributeDefinition {
   export function isa(o: any): o is FacetAttributeDefinition {
-    return _smithy.isa(o, "FacetAttributeDefinition");
+    return __isa(o, "FacetAttributeDefinition");
   }
 }
 
@@ -3045,7 +3048,7 @@ export interface FacetAttributeReference {
 
 export namespace FacetAttributeReference {
   export function isa(o: any): o is FacetAttributeReference {
-    return _smithy.isa(o, "FacetAttributeReference");
+    return __isa(o, "FacetAttributeReference");
   }
 }
 
@@ -3076,7 +3079,7 @@ export interface FacetAttributeUpdate {
 
 export namespace FacetAttributeUpdate {
   export function isa(o: any): o is FacetAttributeUpdate {
-    return _smithy.isa(o, "FacetAttributeUpdate");
+    return __isa(o, "FacetAttributeUpdate");
   }
 }
 
@@ -3085,7 +3088,7 @@ export namespace FacetAttributeUpdate {
  *       attribute reference in a different facet.</p>
  */
 export interface FacetInUseException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "FacetInUseException";
   $fault: "client";
@@ -3094,7 +3097,7 @@ export interface FacetInUseException
 
 export namespace FacetInUseException {
   export function isa(o: any): o is FacetInUseException {
-    return _smithy.isa(o, "FacetInUseException");
+    return __isa(o, "FacetInUseException");
   }
 }
 
@@ -3102,7 +3105,7 @@ export namespace FacetInUseException {
  * <p>The specified <a>Facet</a> could not be found.</p>
  */
 export interface FacetNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "FacetNotFoundException";
   $fault: "client";
@@ -3111,7 +3114,7 @@ export interface FacetNotFoundException
 
 export namespace FacetNotFoundException {
   export function isa(o: any): o is FacetNotFoundException {
-    return _smithy.isa(o, "FacetNotFoundException");
+    return __isa(o, "FacetNotFoundException");
   }
 }
 
@@ -3125,7 +3128,7 @@ export enum FacetStyle {
  *       validated with the schema.</p>
  */
 export interface FacetValidationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "FacetValidationException";
   $fault: "client";
@@ -3134,7 +3137,7 @@ export interface FacetValidationException
 
 export namespace FacetValidationException {
   export function isa(o: any): o is FacetValidationException {
-    return _smithy.isa(o, "FacetValidationException");
+    return __isa(o, "FacetValidationException");
   }
 }
 
@@ -3148,7 +3151,7 @@ export interface GetAppliedSchemaVersionRequest {
 
 export namespace GetAppliedSchemaVersionRequest {
   export function isa(o: any): o is GetAppliedSchemaVersionRequest {
-    return _smithy.isa(o, "GetAppliedSchemaVersionRequest");
+    return __isa(o, "GetAppliedSchemaVersionRequest");
   }
 }
 
@@ -3162,7 +3165,7 @@ export interface GetAppliedSchemaVersionResponse extends $MetadataBearer {
 
 export namespace GetAppliedSchemaVersionResponse {
   export function isa(o: any): o is GetAppliedSchemaVersionResponse {
-    return _smithy.isa(o, "GetAppliedSchemaVersionResponse");
+    return __isa(o, "GetAppliedSchemaVersionResponse");
   }
 }
 
@@ -3176,7 +3179,7 @@ export interface GetDirectoryRequest {
 
 export namespace GetDirectoryRequest {
   export function isa(o: any): o is GetDirectoryRequest {
-    return _smithy.isa(o, "GetDirectoryRequest");
+    return __isa(o, "GetDirectoryRequest");
   }
 }
 
@@ -3190,7 +3193,7 @@ export interface GetDirectoryResponse extends $MetadataBearer {
 
 export namespace GetDirectoryResponse {
   export function isa(o: any): o is GetDirectoryResponse {
-    return _smithy.isa(o, "GetDirectoryResponse");
+    return __isa(o, "GetDirectoryResponse");
   }
 }
 
@@ -3210,7 +3213,7 @@ export interface GetFacetRequest {
 
 export namespace GetFacetRequest {
   export function isa(o: any): o is GetFacetRequest {
-    return _smithy.isa(o, "GetFacetRequest");
+    return __isa(o, "GetFacetRequest");
   }
 }
 
@@ -3224,7 +3227,7 @@ export interface GetFacetResponse extends $MetadataBearer {
 
 export namespace GetFacetResponse {
   export function isa(o: any): o is GetFacetResponse {
-    return _smithy.isa(o, "GetFacetResponse");
+    return __isa(o, "GetFacetResponse");
   }
 }
 
@@ -3253,7 +3256,7 @@ export interface GetLinkAttributesRequest {
 
 export namespace GetLinkAttributesRequest {
   export function isa(o: any): o is GetLinkAttributesRequest {
-    return _smithy.isa(o, "GetLinkAttributesRequest");
+    return __isa(o, "GetLinkAttributesRequest");
   }
 }
 
@@ -3267,7 +3270,7 @@ export interface GetLinkAttributesResponse extends $MetadataBearer {
 
 export namespace GetLinkAttributesResponse {
   export function isa(o: any): o is GetLinkAttributesResponse {
-    return _smithy.isa(o, "GetLinkAttributesResponse");
+    return __isa(o, "GetLinkAttributesResponse");
   }
 }
 
@@ -3301,7 +3304,7 @@ export interface GetObjectAttributesRequest {
 
 export namespace GetObjectAttributesRequest {
   export function isa(o: any): o is GetObjectAttributesRequest {
-    return _smithy.isa(o, "GetObjectAttributesRequest");
+    return __isa(o, "GetObjectAttributesRequest");
   }
 }
 
@@ -3315,7 +3318,7 @@ export interface GetObjectAttributesResponse extends $MetadataBearer {
 
 export namespace GetObjectAttributesResponse {
   export function isa(o: any): o is GetObjectAttributesResponse {
-    return _smithy.isa(o, "GetObjectAttributesResponse");
+    return __isa(o, "GetObjectAttributesResponse");
   }
 }
 
@@ -3339,7 +3342,7 @@ export interface GetObjectInformationRequest {
 
 export namespace GetObjectInformationRequest {
   export function isa(o: any): o is GetObjectInformationRequest {
-    return _smithy.isa(o, "GetObjectInformationRequest");
+    return __isa(o, "GetObjectInformationRequest");
   }
 }
 
@@ -3358,7 +3361,7 @@ export interface GetObjectInformationResponse extends $MetadataBearer {
 
 export namespace GetObjectInformationResponse {
   export function isa(o: any): o is GetObjectInformationResponse {
-    return _smithy.isa(o, "GetObjectInformationResponse");
+    return __isa(o, "GetObjectInformationResponse");
   }
 }
 
@@ -3372,7 +3375,7 @@ export interface GetSchemaAsJsonRequest {
 
 export namespace GetSchemaAsJsonRequest {
   export function isa(o: any): o is GetSchemaAsJsonRequest {
-    return _smithy.isa(o, "GetSchemaAsJsonRequest");
+    return __isa(o, "GetSchemaAsJsonRequest");
   }
 }
 
@@ -3391,7 +3394,7 @@ export interface GetSchemaAsJsonResponse extends $MetadataBearer {
 
 export namespace GetSchemaAsJsonResponse {
   export function isa(o: any): o is GetSchemaAsJsonResponse {
-    return _smithy.isa(o, "GetSchemaAsJsonResponse");
+    return __isa(o, "GetSchemaAsJsonResponse");
   }
 }
 
@@ -3411,7 +3414,7 @@ export interface GetTypedLinkFacetInformationRequest {
 
 export namespace GetTypedLinkFacetInformationRequest {
   export function isa(o: any): o is GetTypedLinkFacetInformationRequest {
-    return _smithy.isa(o, "GetTypedLinkFacetInformationRequest");
+    return __isa(o, "GetTypedLinkFacetInformationRequest");
   }
 }
 
@@ -3430,7 +3433,7 @@ export interface GetTypedLinkFacetInformationResponse extends $MetadataBearer {
 
 export namespace GetTypedLinkFacetInformationResponse {
   export function isa(o: any): o is GetTypedLinkFacetInformationResponse {
-    return _smithy.isa(o, "GetTypedLinkFacetInformationResponse");
+    return __isa(o, "GetTypedLinkFacetInformationResponse");
   }
 }
 
@@ -3438,7 +3441,7 @@ export namespace GetTypedLinkFacetInformationResponse {
  * <p>Indicates a failure occurred while performing a check for backward compatibility between the specified schema and the schema that is currently applied to the directory.</p>
  */
 export interface IncompatibleSchemaException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "IncompatibleSchemaException";
   $fault: "client";
@@ -3447,7 +3450,7 @@ export interface IncompatibleSchemaException
 
 export namespace IncompatibleSchemaException {
   export function isa(o: any): o is IncompatibleSchemaException {
-    return _smithy.isa(o, "IncompatibleSchemaException");
+    return __isa(o, "IncompatibleSchemaException");
   }
 }
 
@@ -3469,7 +3472,7 @@ export interface IndexAttachment {
 
 export namespace IndexAttachment {
   export function isa(o: any): o is IndexAttachment {
-    return _smithy.isa(o, "IndexAttachment");
+    return __isa(o, "IndexAttachment");
   }
 }
 
@@ -3477,7 +3480,7 @@ export namespace IndexAttachment {
  * <p>An object has been attempted to be attached to an object that does not have the appropriate attribute value.</p>
  */
 export interface IndexedAttributeMissingException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "IndexedAttributeMissingException";
   $fault: "client";
@@ -3486,7 +3489,7 @@ export interface IndexedAttributeMissingException
 
 export namespace IndexedAttributeMissingException {
   export function isa(o: any): o is IndexedAttributeMissingException {
-    return _smithy.isa(o, "IndexedAttributeMissingException");
+    return __isa(o, "IndexedAttributeMissingException");
   }
 }
 
@@ -3494,7 +3497,7 @@ export namespace IndexedAttributeMissingException {
  * <p>Indicates a problem that must be resolved by Amazon Web Services. This might be a transient error in which case you can retry your request until it succeeds. Otherwise, go to the <a href="http://status.aws.amazon.com/">AWS Service Health Dashboard</a> site to see if there are any operational issues with the service.</p>
  */
 export interface InternalServiceException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalServiceException";
   $fault: "server";
@@ -3503,7 +3506,7 @@ export interface InternalServiceException
 
 export namespace InternalServiceException {
   export function isa(o: any): o is InternalServiceException {
-    return _smithy.isa(o, "InternalServiceException");
+    return __isa(o, "InternalServiceException");
   }
 }
 
@@ -3511,7 +3514,7 @@ export namespace InternalServiceException {
  * <p>Indicates that the provided ARN value is not valid.</p>
  */
 export interface InvalidArnException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidArnException";
   $fault: "client";
@@ -3520,7 +3523,7 @@ export interface InvalidArnException
 
 export namespace InvalidArnException {
   export function isa(o: any): o is InvalidArnException {
-    return _smithy.isa(o, "InvalidArnException");
+    return __isa(o, "InvalidArnException");
   }
 }
 
@@ -3529,7 +3532,7 @@ export namespace InvalidArnException {
  *       with a link type that is not applicable to the nodes or attempting to apply a schema to a directory a second time.</p>
  */
 export interface InvalidAttachmentException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidAttachmentException";
   $fault: "client";
@@ -3538,7 +3541,7 @@ export interface InvalidAttachmentException
 
 export namespace InvalidAttachmentException {
   export function isa(o: any): o is InvalidAttachmentException {
-    return _smithy.isa(o, "InvalidAttachmentException");
+    return __isa(o, "InvalidAttachmentException");
   }
 }
 
@@ -3547,7 +3550,7 @@ export namespace InvalidAttachmentException {
  *       exception.</p>
  */
 export interface InvalidFacetUpdateException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidFacetUpdateException";
   $fault: "client";
@@ -3556,7 +3559,7 @@ export interface InvalidFacetUpdateException
 
 export namespace InvalidFacetUpdateException {
   export function isa(o: any): o is InvalidFacetUpdateException {
-    return _smithy.isa(o, "InvalidFacetUpdateException");
+    return __isa(o, "InvalidFacetUpdateException");
   }
 }
 
@@ -3564,7 +3567,7 @@ export namespace InvalidFacetUpdateException {
  * <p>Indicates that the <code>NextToken</code> value is not valid.</p>
  */
 export interface InvalidNextTokenException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidNextTokenException";
   $fault: "client";
@@ -3573,7 +3576,7 @@ export interface InvalidNextTokenException
 
 export namespace InvalidNextTokenException {
   export function isa(o: any): o is InvalidNextTokenException {
-    return _smithy.isa(o, "InvalidNextTokenException");
+    return __isa(o, "InvalidNextTokenException");
   }
 }
 
@@ -3581,7 +3584,7 @@ export namespace InvalidNextTokenException {
  * <p>Occurs when any of the rule parameter keys or values are invalid.</p>
  */
 export interface InvalidRuleException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidRuleException";
   $fault: "client";
@@ -3590,7 +3593,7 @@ export interface InvalidRuleException
 
 export namespace InvalidRuleException {
   export function isa(o: any): o is InvalidRuleException {
-    return _smithy.isa(o, "InvalidRuleException");
+    return __isa(o, "InvalidRuleException");
   }
 }
 
@@ -3598,7 +3601,7 @@ export namespace InvalidRuleException {
  * <p>Indicates that the provided <code>SchemaDoc</code> value is not valid.</p>
  */
 export interface InvalidSchemaDocException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidSchemaDocException";
   $fault: "client";
@@ -3607,7 +3610,7 @@ export interface InvalidSchemaDocException
 
 export namespace InvalidSchemaDocException {
   export function isa(o: any): o is InvalidSchemaDocException {
-    return _smithy.isa(o, "InvalidSchemaDocException");
+    return __isa(o, "InvalidSchemaDocException");
   }
 }
 
@@ -3615,7 +3618,7 @@ export namespace InvalidSchemaDocException {
  * <p>Can occur for multiple reasons such as when you tag a resource that doesn’t exist or if you specify a higher number of tags for a resource than the allowed limit. Allowed limit is 50 tags per resource.</p>
  */
 export interface InvalidTaggingRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidTaggingRequestException";
   $fault: "client";
@@ -3624,7 +3627,7 @@ export interface InvalidTaggingRequestException
 
 export namespace InvalidTaggingRequestException {
   export function isa(o: any): o is InvalidTaggingRequestException {
-    return _smithy.isa(o, "InvalidTaggingRequestException");
+    return __isa(o, "InvalidTaggingRequestException");
   }
 }
 
@@ -3632,7 +3635,7 @@ export namespace InvalidTaggingRequestException {
  * <p>Indicates that limits are exceeded. See <a href="https://docs.aws.amazon.com/clouddirectory/latest/developerguide/limits.html">Limits</a> for more information.</p>
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -3641,7 +3644,7 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
@@ -3663,7 +3666,7 @@ export interface LinkAttributeAction {
 
 export namespace LinkAttributeAction {
   export function isa(o: any): o is LinkAttributeAction {
-    return _smithy.isa(o, "LinkAttributeAction");
+    return __isa(o, "LinkAttributeAction");
   }
 }
 
@@ -3685,7 +3688,7 @@ export interface LinkAttributeUpdate {
 
 export namespace LinkAttributeUpdate {
   export function isa(o: any): o is LinkAttributeUpdate {
-    return _smithy.isa(o, "LinkAttributeUpdate");
+    return __isa(o, "LinkAttributeUpdate");
   }
 }
 
@@ -3694,7 +3697,7 @@ export namespace LinkAttributeUpdate {
  *       name and then try again.</p>
  */
 export interface LinkNameAlreadyInUseException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LinkNameAlreadyInUseException";
   $fault: "client";
@@ -3703,7 +3706,7 @@ export interface LinkNameAlreadyInUseException
 
 export namespace LinkNameAlreadyInUseException {
   export function isa(o: any): o is LinkNameAlreadyInUseException {
-    return _smithy.isa(o, "LinkNameAlreadyInUseException");
+    return __isa(o, "LinkNameAlreadyInUseException");
   }
 }
 
@@ -3732,7 +3735,7 @@ export interface ListAppliedSchemaArnsRequest {
 
 export namespace ListAppliedSchemaArnsRequest {
   export function isa(o: any): o is ListAppliedSchemaArnsRequest {
-    return _smithy.isa(o, "ListAppliedSchemaArnsRequest");
+    return __isa(o, "ListAppliedSchemaArnsRequest");
   }
 }
 
@@ -3751,7 +3754,7 @@ export interface ListAppliedSchemaArnsResponse extends $MetadataBearer {
 
 export namespace ListAppliedSchemaArnsResponse {
   export function isa(o: any): o is ListAppliedSchemaArnsResponse {
-    return _smithy.isa(o, "ListAppliedSchemaArnsResponse");
+    return __isa(o, "ListAppliedSchemaArnsResponse");
   }
 }
 
@@ -3785,7 +3788,7 @@ export interface ListAttachedIndicesRequest {
 
 export namespace ListAttachedIndicesRequest {
   export function isa(o: any): o is ListAttachedIndicesRequest {
-    return _smithy.isa(o, "ListAttachedIndicesRequest");
+    return __isa(o, "ListAttachedIndicesRequest");
   }
 }
 
@@ -3804,7 +3807,7 @@ export interface ListAttachedIndicesResponse extends $MetadataBearer {
 
 export namespace ListAttachedIndicesResponse {
   export function isa(o: any): o is ListAttachedIndicesResponse {
-    return _smithy.isa(o, "ListAttachedIndicesResponse");
+    return __isa(o, "ListAttachedIndicesResponse");
   }
 }
 
@@ -3823,7 +3826,7 @@ export interface ListDevelopmentSchemaArnsRequest {
 
 export namespace ListDevelopmentSchemaArnsRequest {
   export function isa(o: any): o is ListDevelopmentSchemaArnsRequest {
-    return _smithy.isa(o, "ListDevelopmentSchemaArnsRequest");
+    return __isa(o, "ListDevelopmentSchemaArnsRequest");
   }
 }
 
@@ -3842,7 +3845,7 @@ export interface ListDevelopmentSchemaArnsResponse extends $MetadataBearer {
 
 export namespace ListDevelopmentSchemaArnsResponse {
   export function isa(o: any): o is ListDevelopmentSchemaArnsResponse {
-    return _smithy.isa(o, "ListDevelopmentSchemaArnsResponse");
+    return __isa(o, "ListDevelopmentSchemaArnsResponse");
   }
 }
 
@@ -3867,7 +3870,7 @@ export interface ListDirectoriesRequest {
 
 export namespace ListDirectoriesRequest {
   export function isa(o: any): o is ListDirectoriesRequest {
-    return _smithy.isa(o, "ListDirectoriesRequest");
+    return __isa(o, "ListDirectoriesRequest");
   }
 }
 
@@ -3887,7 +3890,7 @@ export interface ListDirectoriesResponse extends $MetadataBearer {
 
 export namespace ListDirectoriesResponse {
   export function isa(o: any): o is ListDirectoriesResponse {
-    return _smithy.isa(o, "ListDirectoriesResponse");
+    return __isa(o, "ListDirectoriesResponse");
   }
 }
 
@@ -3916,7 +3919,7 @@ export interface ListFacetAttributesRequest {
 
 export namespace ListFacetAttributesRequest {
   export function isa(o: any): o is ListFacetAttributesRequest {
-    return _smithy.isa(o, "ListFacetAttributesRequest");
+    return __isa(o, "ListFacetAttributesRequest");
   }
 }
 
@@ -3935,7 +3938,7 @@ export interface ListFacetAttributesResponse extends $MetadataBearer {
 
 export namespace ListFacetAttributesResponse {
   export function isa(o: any): o is ListFacetAttributesResponse {
-    return _smithy.isa(o, "ListFacetAttributesResponse");
+    return __isa(o, "ListFacetAttributesResponse");
   }
 }
 
@@ -3959,7 +3962,7 @@ export interface ListFacetNamesRequest {
 
 export namespace ListFacetNamesRequest {
   export function isa(o: any): o is ListFacetNamesRequest {
-    return _smithy.isa(o, "ListFacetNamesRequest");
+    return __isa(o, "ListFacetNamesRequest");
   }
 }
 
@@ -3978,7 +3981,7 @@ export interface ListFacetNamesResponse extends $MetadataBearer {
 
 export namespace ListFacetNamesResponse {
   export function isa(o: any): o is ListFacetNamesResponse {
-    return _smithy.isa(o, "ListFacetNamesResponse");
+    return __isa(o, "ListFacetNamesResponse");
   }
 }
 
@@ -4026,7 +4029,7 @@ export interface ListIncomingTypedLinksRequest {
 
 export namespace ListIncomingTypedLinksRequest {
   export function isa(o: any): o is ListIncomingTypedLinksRequest {
-    return _smithy.isa(o, "ListIncomingTypedLinksRequest");
+    return __isa(o, "ListIncomingTypedLinksRequest");
   }
 }
 
@@ -4045,7 +4048,7 @@ export interface ListIncomingTypedLinksResponse extends $MetadataBearer {
 
 export namespace ListIncomingTypedLinksResponse {
   export function isa(o: any): o is ListIncomingTypedLinksResponse {
-    return _smithy.isa(o, "ListIncomingTypedLinksResponse");
+    return __isa(o, "ListIncomingTypedLinksResponse");
   }
 }
 
@@ -4084,7 +4087,7 @@ export interface ListIndexRequest {
 
 export namespace ListIndexRequest {
   export function isa(o: any): o is ListIndexRequest {
-    return _smithy.isa(o, "ListIndexRequest");
+    return __isa(o, "ListIndexRequest");
   }
 }
 
@@ -4103,7 +4106,7 @@ export interface ListIndexResponse extends $MetadataBearer {
 
 export namespace ListIndexResponse {
   export function isa(o: any): o is ListIndexResponse {
-    return _smithy.isa(o, "ListIndexResponse");
+    return __isa(o, "ListIndexResponse");
   }
 }
 
@@ -4127,7 +4130,7 @@ export interface ListManagedSchemaArnsRequest {
 
 export namespace ListManagedSchemaArnsRequest {
   export function isa(o: any): o is ListManagedSchemaArnsRequest {
-    return _smithy.isa(o, "ListManagedSchemaArnsRequest");
+    return __isa(o, "ListManagedSchemaArnsRequest");
   }
 }
 
@@ -4146,7 +4149,7 @@ export interface ListManagedSchemaArnsResponse extends $MetadataBearer {
 
 export namespace ListManagedSchemaArnsResponse {
   export function isa(o: any): o is ListManagedSchemaArnsResponse {
-    return _smithy.isa(o, "ListManagedSchemaArnsResponse");
+    return __isa(o, "ListManagedSchemaArnsResponse");
   }
 }
 
@@ -4189,7 +4192,7 @@ export interface ListObjectAttributesRequest {
 
 export namespace ListObjectAttributesRequest {
   export function isa(o: any): o is ListObjectAttributesRequest {
-    return _smithy.isa(o, "ListObjectAttributesRequest");
+    return __isa(o, "ListObjectAttributesRequest");
   }
 }
 
@@ -4209,7 +4212,7 @@ export interface ListObjectAttributesResponse extends $MetadataBearer {
 
 export namespace ListObjectAttributesResponse {
   export function isa(o: any): o is ListObjectAttributesResponse {
-    return _smithy.isa(o, "ListObjectAttributesResponse");
+    return __isa(o, "ListObjectAttributesResponse");
   }
 }
 
@@ -4247,7 +4250,7 @@ export interface ListObjectChildrenRequest {
 
 export namespace ListObjectChildrenRequest {
   export function isa(o: any): o is ListObjectChildrenRequest {
-    return _smithy.isa(o, "ListObjectChildrenRequest");
+    return __isa(o, "ListObjectChildrenRequest");
   }
 }
 
@@ -4267,7 +4270,7 @@ export interface ListObjectChildrenResponse extends $MetadataBearer {
 
 export namespace ListObjectChildrenResponse {
   export function isa(o: any): o is ListObjectChildrenResponse {
-    return _smithy.isa(o, "ListObjectChildrenResponse");
+    return __isa(o, "ListObjectChildrenResponse");
   }
 }
 
@@ -4297,7 +4300,7 @@ export interface ListObjectParentPathsRequest {
 
 export namespace ListObjectParentPathsRequest {
   export function isa(o: any): o is ListObjectParentPathsRequest {
-    return _smithy.isa(o, "ListObjectParentPathsRequest");
+    return __isa(o, "ListObjectParentPathsRequest");
   }
 }
 
@@ -4317,7 +4320,7 @@ export interface ListObjectParentPathsResponse extends $MetadataBearer {
 
 export namespace ListObjectParentPathsResponse {
   export function isa(o: any): o is ListObjectParentPathsResponse {
-    return _smithy.isa(o, "ListObjectParentPathsResponse");
+    return __isa(o, "ListObjectParentPathsResponse");
   }
 }
 
@@ -4360,7 +4363,7 @@ export interface ListObjectParentsRequest {
 
 export namespace ListObjectParentsRequest {
   export function isa(o: any): o is ListObjectParentsRequest {
-    return _smithy.isa(o, "ListObjectParentsRequest");
+    return __isa(o, "ListObjectParentsRequest");
   }
 }
 
@@ -4385,7 +4388,7 @@ export interface ListObjectParentsResponse extends $MetadataBearer {
 
 export namespace ListObjectParentsResponse {
   export function isa(o: any): o is ListObjectParentsResponse {
-    return _smithy.isa(o, "ListObjectParentsResponse");
+    return __isa(o, "ListObjectParentsResponse");
   }
 }
 
@@ -4422,7 +4425,7 @@ export interface ListObjectPoliciesRequest {
 
 export namespace ListObjectPoliciesRequest {
   export function isa(o: any): o is ListObjectPoliciesRequest {
-    return _smithy.isa(o, "ListObjectPoliciesRequest");
+    return __isa(o, "ListObjectPoliciesRequest");
   }
 }
 
@@ -4442,7 +4445,7 @@ export interface ListObjectPoliciesResponse extends $MetadataBearer {
 
 export namespace ListObjectPoliciesResponse {
   export function isa(o: any): o is ListObjectPoliciesResponse {
-    return _smithy.isa(o, "ListObjectPoliciesResponse");
+    return __isa(o, "ListObjectPoliciesResponse");
   }
 }
 
@@ -4490,7 +4493,7 @@ export interface ListOutgoingTypedLinksRequest {
 
 export namespace ListOutgoingTypedLinksRequest {
   export function isa(o: any): o is ListOutgoingTypedLinksRequest {
-    return _smithy.isa(o, "ListOutgoingTypedLinksRequest");
+    return __isa(o, "ListOutgoingTypedLinksRequest");
   }
 }
 
@@ -4509,7 +4512,7 @@ export interface ListOutgoingTypedLinksResponse extends $MetadataBearer {
 
 export namespace ListOutgoingTypedLinksResponse {
   export function isa(o: any): o is ListOutgoingTypedLinksResponse {
-    return _smithy.isa(o, "ListOutgoingTypedLinksResponse");
+    return __isa(o, "ListOutgoingTypedLinksResponse");
   }
 }
 
@@ -4546,7 +4549,7 @@ export interface ListPolicyAttachmentsRequest {
 
 export namespace ListPolicyAttachmentsRequest {
   export function isa(o: any): o is ListPolicyAttachmentsRequest {
-    return _smithy.isa(o, "ListPolicyAttachmentsRequest");
+    return __isa(o, "ListPolicyAttachmentsRequest");
   }
 }
 
@@ -4565,7 +4568,7 @@ export interface ListPolicyAttachmentsResponse extends $MetadataBearer {
 
 export namespace ListPolicyAttachmentsResponse {
   export function isa(o: any): o is ListPolicyAttachmentsResponse {
-    return _smithy.isa(o, "ListPolicyAttachmentsResponse");
+    return __isa(o, "ListPolicyAttachmentsResponse");
   }
 }
 
@@ -4589,7 +4592,7 @@ export interface ListPublishedSchemaArnsRequest {
 
 export namespace ListPublishedSchemaArnsRequest {
   export function isa(o: any): o is ListPublishedSchemaArnsRequest {
-    return _smithy.isa(o, "ListPublishedSchemaArnsRequest");
+    return __isa(o, "ListPublishedSchemaArnsRequest");
   }
 }
 
@@ -4608,7 +4611,7 @@ export interface ListPublishedSchemaArnsResponse extends $MetadataBearer {
 
 export namespace ListPublishedSchemaArnsResponse {
   export function isa(o: any): o is ListPublishedSchemaArnsResponse {
-    return _smithy.isa(o, "ListPublishedSchemaArnsResponse");
+    return __isa(o, "ListPublishedSchemaArnsResponse");
   }
 }
 
@@ -4635,7 +4638,7 @@ export interface ListTagsForResourceRequest {
 
 export namespace ListTagsForResourceRequest {
   export function isa(o: any): o is ListTagsForResourceRequest {
-    return _smithy.isa(o, "ListTagsForResourceRequest");
+    return __isa(o, "ListTagsForResourceRequest");
   }
 }
 
@@ -4654,7 +4657,7 @@ export interface ListTagsForResourceResponse extends $MetadataBearer {
 
 export namespace ListTagsForResourceResponse {
   export function isa(o: any): o is ListTagsForResourceResponse {
-    return _smithy.isa(o, "ListTagsForResourceResponse");
+    return __isa(o, "ListTagsForResourceResponse");
   }
 }
 
@@ -4684,7 +4687,7 @@ export interface ListTypedLinkFacetAttributesRequest {
 
 export namespace ListTypedLinkFacetAttributesRequest {
   export function isa(o: any): o is ListTypedLinkFacetAttributesRequest {
-    return _smithy.isa(o, "ListTypedLinkFacetAttributesRequest");
+    return __isa(o, "ListTypedLinkFacetAttributesRequest");
   }
 }
 
@@ -4703,7 +4706,7 @@ export interface ListTypedLinkFacetAttributesResponse extends $MetadataBearer {
 
 export namespace ListTypedLinkFacetAttributesResponse {
   export function isa(o: any): o is ListTypedLinkFacetAttributesResponse {
-    return _smithy.isa(o, "ListTypedLinkFacetAttributesResponse");
+    return __isa(o, "ListTypedLinkFacetAttributesResponse");
   }
 }
 
@@ -4728,7 +4731,7 @@ export interface ListTypedLinkFacetNamesRequest {
 
 export namespace ListTypedLinkFacetNamesRequest {
   export function isa(o: any): o is ListTypedLinkFacetNamesRequest {
-    return _smithy.isa(o, "ListTypedLinkFacetNamesRequest");
+    return __isa(o, "ListTypedLinkFacetNamesRequest");
   }
 }
 
@@ -4747,7 +4750,7 @@ export interface ListTypedLinkFacetNamesResponse extends $MetadataBearer {
 
 export namespace ListTypedLinkFacetNamesResponse {
   export function isa(o: any): o is ListTypedLinkFacetNamesResponse {
-    return _smithy.isa(o, "ListTypedLinkFacetNamesResponse");
+    return __isa(o, "ListTypedLinkFacetNamesResponse");
   }
 }
 
@@ -4778,7 +4781,7 @@ export interface LookupPolicyRequest {
 
 export namespace LookupPolicyRequest {
   export function isa(o: any): o is LookupPolicyRequest {
-    return _smithy.isa(o, "LookupPolicyRequest");
+    return __isa(o, "LookupPolicyRequest");
   }
 }
 
@@ -4799,16 +4802,14 @@ export interface LookupPolicyResponse extends $MetadataBearer {
 
 export namespace LookupPolicyResponse {
   export function isa(o: any): o is LookupPolicyResponse {
-    return _smithy.isa(o, "LookupPolicyResponse");
+    return __isa(o, "LookupPolicyResponse");
   }
 }
 
 /**
  * <p>Indicates that the requested operation can only operate on index objects.</p>
  */
-export interface NotIndexException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface NotIndexException extends __SmithyException, $MetadataBearer {
   name: "NotIndexException";
   $fault: "client";
   Message?: string;
@@ -4816,7 +4817,7 @@ export interface NotIndexException
 
 export namespace NotIndexException {
   export function isa(o: any): o is NotIndexException {
-    return _smithy.isa(o, "NotIndexException");
+    return __isa(o, "NotIndexException");
   }
 }
 
@@ -4824,9 +4825,7 @@ export namespace NotIndexException {
  * <p>Occurs when any invalid operations are performed on an object that is not a node, such
  *       as calling <code>ListObjectChildren</code> for a leaf node object.</p>
  */
-export interface NotNodeException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface NotNodeException extends __SmithyException, $MetadataBearer {
   name: "NotNodeException";
   $fault: "client";
   Message?: string;
@@ -4834,16 +4833,14 @@ export interface NotNodeException
 
 export namespace NotNodeException {
   export function isa(o: any): o is NotNodeException {
-    return _smithy.isa(o, "NotNodeException");
+    return __isa(o, "NotNodeException");
   }
 }
 
 /**
  * <p>Indicates that the requested operation can only operate on policy objects.</p>
  */
-export interface NotPolicyException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface NotPolicyException extends __SmithyException, $MetadataBearer {
   name: "NotPolicyException";
   $fault: "client";
   Message?: string;
@@ -4851,7 +4848,7 @@ export interface NotPolicyException
 
 export namespace NotPolicyException {
   export function isa(o: any): o is NotPolicyException {
-    return _smithy.isa(o, "NotPolicyException");
+    return __isa(o, "NotPolicyException");
   }
 }
 
@@ -4859,7 +4856,7 @@ export namespace NotPolicyException {
  * <p>Indicates that the object is not attached to the index.</p>
  */
 export interface ObjectAlreadyDetachedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ObjectAlreadyDetachedException";
   $fault: "client";
@@ -4868,7 +4865,7 @@ export interface ObjectAlreadyDetachedException
 
 export namespace ObjectAlreadyDetachedException {
   export function isa(o: any): o is ObjectAlreadyDetachedException {
-    return _smithy.isa(o, "ObjectAlreadyDetachedException");
+    return __isa(o, "ObjectAlreadyDetachedException");
   }
 }
 
@@ -4890,7 +4887,7 @@ export interface ObjectAttributeAction {
 
 export namespace ObjectAttributeAction {
   export function isa(o: any): o is ObjectAttributeAction {
-    return _smithy.isa(o, "ObjectAttributeAction");
+    return __isa(o, "ObjectAttributeAction");
   }
 }
 
@@ -4912,7 +4909,7 @@ export interface ObjectAttributeRange {
 
 export namespace ObjectAttributeRange {
   export function isa(o: any): o is ObjectAttributeRange {
-    return _smithy.isa(o, "ObjectAttributeRange");
+    return __isa(o, "ObjectAttributeRange");
   }
 }
 
@@ -4934,7 +4931,7 @@ export interface ObjectAttributeUpdate {
 
 export namespace ObjectAttributeUpdate {
   export function isa(o: any): o is ObjectAttributeUpdate {
-    return _smithy.isa(o, "ObjectAttributeUpdate");
+    return __isa(o, "ObjectAttributeUpdate");
   }
 }
 
@@ -4956,7 +4953,7 @@ export interface ObjectIdentifierAndLinkNameTuple {
 
 export namespace ObjectIdentifierAndLinkNameTuple {
   export function isa(o: any): o is ObjectIdentifierAndLinkNameTuple {
-    return _smithy.isa(o, "ObjectIdentifierAndLinkNameTuple");
+    return __isa(o, "ObjectIdentifierAndLinkNameTuple");
   }
 }
 
@@ -4965,7 +4962,7 @@ export namespace ObjectIdentifierAndLinkNameTuple {
  *       been detached from the tree.</p>
  */
 export interface ObjectNotDetachedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ObjectNotDetachedException";
   $fault: "client";
@@ -4974,7 +4971,7 @@ export interface ObjectNotDetachedException
 
 export namespace ObjectNotDetachedException {
   export function isa(o: any): o is ObjectNotDetachedException {
-    return _smithy.isa(o, "ObjectNotDetachedException");
+    return __isa(o, "ObjectNotDetachedException");
   }
 }
 
@@ -5005,7 +5002,7 @@ export interface ObjectReference {
 
 export namespace ObjectReference {
   export function isa(o: any): o is ObjectReference {
-    return _smithy.isa(o, "ObjectReference");
+    return __isa(o, "ObjectReference");
   }
 }
 
@@ -5036,7 +5033,7 @@ export interface PathToObjectIdentifiers {
 
 export namespace PathToObjectIdentifiers {
   export function isa(o: any): o is PathToObjectIdentifiers {
-    return _smithy.isa(o, "PathToObjectIdentifiers");
+    return __isa(o, "PathToObjectIdentifiers");
   }
 }
 
@@ -5066,7 +5063,7 @@ export interface PolicyAttachment {
 
 export namespace PolicyAttachment {
   export function isa(o: any): o is PolicyAttachment {
-    return _smithy.isa(o, "PolicyAttachment");
+    return __isa(o, "PolicyAttachment");
   }
 }
 
@@ -5090,7 +5087,7 @@ export interface PolicyToPath {
 
 export namespace PolicyToPath {
   export function isa(o: any): o is PolicyToPath {
-    return _smithy.isa(o, "PolicyToPath");
+    return __isa(o, "PolicyToPath");
   }
 }
 
@@ -5121,7 +5118,7 @@ export interface PublishSchemaRequest {
 
 export namespace PublishSchemaRequest {
   export function isa(o: any): o is PublishSchemaRequest {
-    return _smithy.isa(o, "PublishSchemaRequest");
+    return __isa(o, "PublishSchemaRequest");
   }
 }
 
@@ -5135,7 +5132,7 @@ export interface PublishSchemaResponse extends $MetadataBearer {
 
 export namespace PublishSchemaResponse {
   export function isa(o: any): o is PublishSchemaResponse {
-    return _smithy.isa(o, "PublishSchemaResponse");
+    return __isa(o, "PublishSchemaResponse");
   }
 }
 
@@ -5154,7 +5151,7 @@ export interface PutSchemaFromJsonRequest {
 
 export namespace PutSchemaFromJsonRequest {
   export function isa(o: any): o is PutSchemaFromJsonRequest {
-    return _smithy.isa(o, "PutSchemaFromJsonRequest");
+    return __isa(o, "PutSchemaFromJsonRequest");
   }
 }
 
@@ -5168,7 +5165,7 @@ export interface PutSchemaFromJsonResponse extends $MetadataBearer {
 
 export namespace PutSchemaFromJsonResponse {
   export function isa(o: any): o is PutSchemaFromJsonResponse {
-    return _smithy.isa(o, "PutSchemaFromJsonResponse");
+    return __isa(o, "PutSchemaFromJsonResponse");
   }
 }
 
@@ -5200,7 +5197,7 @@ export interface RemoveFacetFromObjectRequest {
 
 export namespace RemoveFacetFromObjectRequest {
   export function isa(o: any): o is RemoveFacetFromObjectRequest {
-    return _smithy.isa(o, "RemoveFacetFromObjectRequest");
+    return __isa(o, "RemoveFacetFromObjectRequest");
   }
 }
 
@@ -5210,7 +5207,7 @@ export interface RemoveFacetFromObjectResponse extends $MetadataBearer {
 
 export namespace RemoveFacetFromObjectResponse {
   export function isa(o: any): o is RemoveFacetFromObjectResponse {
-    return _smithy.isa(o, "RemoveFacetFromObjectResponse");
+    return __isa(o, "RemoveFacetFromObjectResponse");
   }
 }
 
@@ -5223,7 +5220,7 @@ export enum RequiredAttributeBehavior {
  * <p>The specified resource could not be found.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -5232,7 +5229,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -5240,7 +5237,7 @@ export namespace ResourceNotFoundException {
  * <p>Occurs when a conflict with a previous successful write is detected. For example, if a write operation occurs on an object and then an attempt is made to read the object using “SERIALIZABLE” consistency, this exception may result. This generally occurs when the previous write did not have time to propagate to the host serving the current request. A retry (with appropriate backoff logic) is the recommended response to this exception.</p>
  */
 export interface RetryableConflictException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "RetryableConflictException";
   $fault: "client";
@@ -5249,7 +5246,7 @@ export interface RetryableConflictException
 
 export namespace RetryableConflictException {
   export function isa(o: any): o is RetryableConflictException {
-    return _smithy.isa(o, "RetryableConflictException");
+    return __isa(o, "RetryableConflictException");
   }
 }
 
@@ -5272,7 +5269,7 @@ export interface Rule {
 
 export namespace Rule {
   export function isa(o: any): o is Rule {
-    return _smithy.isa(o, "Rule");
+    return __isa(o, "Rule");
   }
 }
 
@@ -5288,7 +5285,7 @@ export enum RuleType {
  *       different name and then try again.</p>
  */
 export interface SchemaAlreadyExistsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "SchemaAlreadyExistsException";
   $fault: "client";
@@ -5297,7 +5294,7 @@ export interface SchemaAlreadyExistsException
 
 export namespace SchemaAlreadyExistsException {
   export function isa(o: any): o is SchemaAlreadyExistsException {
-    return _smithy.isa(o, "SchemaAlreadyExistsException");
+    return __isa(o, "SchemaAlreadyExistsException");
   }
 }
 
@@ -5305,7 +5302,7 @@ export namespace SchemaAlreadyExistsException {
  * <p>Indicates that a schema is already published.</p>
  */
 export interface SchemaAlreadyPublishedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "SchemaAlreadyPublishedException";
   $fault: "client";
@@ -5314,7 +5311,7 @@ export interface SchemaAlreadyPublishedException
 
 export namespace SchemaAlreadyPublishedException {
   export function isa(o: any): o is SchemaAlreadyPublishedException {
-    return _smithy.isa(o, "SchemaAlreadyPublishedException");
+    return __isa(o, "SchemaAlreadyPublishedException");
   }
 }
 
@@ -5336,7 +5333,7 @@ export interface SchemaFacet {
 
 export namespace SchemaFacet {
   export function isa(o: any): o is SchemaFacet {
-    return _smithy.isa(o, "SchemaFacet");
+    return __isa(o, "SchemaFacet");
   }
 }
 
@@ -5345,7 +5342,7 @@ export namespace SchemaFacet {
  *       try the operation again.</p>
  */
 export interface StillContainsLinksException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "StillContainsLinksException";
   $fault: "client";
@@ -5354,7 +5351,7 @@ export interface StillContainsLinksException
 
 export namespace StillContainsLinksException {
   export function isa(o: any): o is StillContainsLinksException {
-    return _smithy.isa(o, "StillContainsLinksException");
+    return __isa(o, "StillContainsLinksException");
   }
 }
 
@@ -5376,7 +5373,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -5396,7 +5393,7 @@ export interface TagResourceRequest {
 
 export namespace TagResourceRequest {
   export function isa(o: any): o is TagResourceRequest {
-    return _smithy.isa(o, "TagResourceRequest");
+    return __isa(o, "TagResourceRequest");
   }
 }
 
@@ -5406,7 +5403,7 @@ export interface TagResourceResponse extends $MetadataBearer {
 
 export namespace TagResourceResponse {
   export function isa(o: any): o is TagResourceResponse {
-    return _smithy.isa(o, "TagResourceResponse");
+    return __isa(o, "TagResourceResponse");
   }
 }
 
@@ -5445,7 +5442,7 @@ export interface TypedAttributeValue {
 
 export namespace TypedAttributeValue {
   export function isa(o: any): o is TypedAttributeValue {
-    return _smithy.isa(o, "TypedAttributeValue");
+    return __isa(o, "TypedAttributeValue");
   }
 }
 
@@ -5477,7 +5474,7 @@ export interface TypedAttributeValueRange {
 
 export namespace TypedAttributeValueRange {
   export function isa(o: any): o is TypedAttributeValueRange {
-    return _smithy.isa(o, "TypedAttributeValueRange");
+    return __isa(o, "TypedAttributeValueRange");
   }
 }
 
@@ -5519,7 +5516,7 @@ export interface TypedLinkAttributeDefinition {
 
 export namespace TypedLinkAttributeDefinition {
   export function isa(o: any): o is TypedLinkAttributeDefinition {
-    return _smithy.isa(o, "TypedLinkAttributeDefinition");
+    return __isa(o, "TypedLinkAttributeDefinition");
   }
 }
 
@@ -5541,7 +5538,7 @@ export interface TypedLinkAttributeRange {
 
 export namespace TypedLinkAttributeRange {
   export function isa(o: any): o is TypedLinkAttributeRange {
-    return _smithy.isa(o, "TypedLinkAttributeRange");
+    return __isa(o, "TypedLinkAttributeRange");
   }
 }
 
@@ -5569,7 +5566,7 @@ export interface TypedLinkFacet {
 
 export namespace TypedLinkFacet {
   export function isa(o: any): o is TypedLinkFacet {
-    return _smithy.isa(o, "TypedLinkFacet");
+    return __isa(o, "TypedLinkFacet");
   }
 }
 
@@ -5591,7 +5588,7 @@ export interface TypedLinkFacetAttributeUpdate {
 
 export namespace TypedLinkFacetAttributeUpdate {
   export function isa(o: any): o is TypedLinkFacetAttributeUpdate {
-    return _smithy.isa(o, "TypedLinkFacetAttributeUpdate");
+    return __isa(o, "TypedLinkFacetAttributeUpdate");
   }
 }
 
@@ -5615,7 +5612,7 @@ export interface TypedLinkSchemaAndFacetName {
 
 export namespace TypedLinkSchemaAndFacetName {
   export function isa(o: any): o is TypedLinkSchemaAndFacetName {
-    return _smithy.isa(o, "TypedLinkSchemaAndFacetName");
+    return __isa(o, "TypedLinkSchemaAndFacetName");
   }
 }
 
@@ -5651,7 +5648,7 @@ export interface TypedLinkSpecifier {
 
 export namespace TypedLinkSpecifier {
   export function isa(o: any): o is TypedLinkSpecifier {
-    return _smithy.isa(o, "TypedLinkSpecifier");
+    return __isa(o, "TypedLinkSpecifier");
   }
 }
 
@@ -5659,7 +5656,7 @@ export namespace TypedLinkSpecifier {
  * <p>Indicates that the requested index type is not supported.</p>
  */
 export interface UnsupportedIndexTypeException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UnsupportedIndexTypeException";
   $fault: "client";
@@ -5668,7 +5665,7 @@ export interface UnsupportedIndexTypeException
 
 export namespace UnsupportedIndexTypeException {
   export function isa(o: any): o is UnsupportedIndexTypeException {
-    return _smithy.isa(o, "UnsupportedIndexTypeException");
+    return __isa(o, "UnsupportedIndexTypeException");
   }
 }
 
@@ -5688,7 +5685,7 @@ export interface UntagResourceRequest {
 
 export namespace UntagResourceRequest {
   export function isa(o: any): o is UntagResourceRequest {
-    return _smithy.isa(o, "UntagResourceRequest");
+    return __isa(o, "UntagResourceRequest");
   }
 }
 
@@ -5698,7 +5695,7 @@ export interface UntagResourceResponse extends $MetadataBearer {
 
 export namespace UntagResourceResponse {
   export function isa(o: any): o is UntagResourceResponse {
-    return _smithy.isa(o, "UntagResourceResponse");
+    return __isa(o, "UntagResourceResponse");
   }
 }
 
@@ -5735,7 +5732,7 @@ export interface UpdateFacetRequest {
 
 export namespace UpdateFacetRequest {
   export function isa(o: any): o is UpdateFacetRequest {
-    return _smithy.isa(o, "UpdateFacetRequest");
+    return __isa(o, "UpdateFacetRequest");
   }
 }
 
@@ -5745,7 +5742,7 @@ export interface UpdateFacetResponse extends $MetadataBearer {
 
 export namespace UpdateFacetResponse {
   export function isa(o: any): o is UpdateFacetResponse {
-    return _smithy.isa(o, "UpdateFacetResponse");
+    return __isa(o, "UpdateFacetResponse");
   }
 }
 
@@ -5769,7 +5766,7 @@ export interface UpdateLinkAttributesRequest {
 
 export namespace UpdateLinkAttributesRequest {
   export function isa(o: any): o is UpdateLinkAttributesRequest {
-    return _smithy.isa(o, "UpdateLinkAttributesRequest");
+    return __isa(o, "UpdateLinkAttributesRequest");
   }
 }
 
@@ -5779,7 +5776,7 @@ export interface UpdateLinkAttributesResponse extends $MetadataBearer {
 
 export namespace UpdateLinkAttributesResponse {
   export function isa(o: any): o is UpdateLinkAttributesResponse {
-    return _smithy.isa(o, "UpdateLinkAttributesResponse");
+    return __isa(o, "UpdateLinkAttributesResponse");
   }
 }
 
@@ -5804,7 +5801,7 @@ export interface UpdateObjectAttributesRequest {
 
 export namespace UpdateObjectAttributesRequest {
   export function isa(o: any): o is UpdateObjectAttributesRequest {
-    return _smithy.isa(o, "UpdateObjectAttributesRequest");
+    return __isa(o, "UpdateObjectAttributesRequest");
   }
 }
 
@@ -5818,7 +5815,7 @@ export interface UpdateObjectAttributesResponse extends $MetadataBearer {
 
 export namespace UpdateObjectAttributesResponse {
   export function isa(o: any): o is UpdateObjectAttributesResponse {
-    return _smithy.isa(o, "UpdateObjectAttributesResponse");
+    return __isa(o, "UpdateObjectAttributesResponse");
   }
 }
 
@@ -5838,7 +5835,7 @@ export interface UpdateSchemaRequest {
 
 export namespace UpdateSchemaRequest {
   export function isa(o: any): o is UpdateSchemaRequest {
-    return _smithy.isa(o, "UpdateSchemaRequest");
+    return __isa(o, "UpdateSchemaRequest");
   }
 }
 
@@ -5852,7 +5849,7 @@ export interface UpdateSchemaResponse extends $MetadataBearer {
 
 export namespace UpdateSchemaResponse {
   export function isa(o: any): o is UpdateSchemaResponse {
-    return _smithy.isa(o, "UpdateSchemaResponse");
+    return __isa(o, "UpdateSchemaResponse");
   }
 }
 
@@ -5887,7 +5884,7 @@ export interface UpdateTypedLinkFacetRequest {
 
 export namespace UpdateTypedLinkFacetRequest {
   export function isa(o: any): o is UpdateTypedLinkFacetRequest {
-    return _smithy.isa(o, "UpdateTypedLinkFacetRequest");
+    return __isa(o, "UpdateTypedLinkFacetRequest");
   }
 }
 
@@ -5897,7 +5894,7 @@ export interface UpdateTypedLinkFacetResponse extends $MetadataBearer {
 
 export namespace UpdateTypedLinkFacetResponse {
   export function isa(o: any): o is UpdateTypedLinkFacetResponse {
-    return _smithy.isa(o, "UpdateTypedLinkFacetResponse");
+    return __isa(o, "UpdateTypedLinkFacetResponse");
   }
 }
 
@@ -5921,7 +5918,7 @@ export interface UpgradeAppliedSchemaRequest {
 
 export namespace UpgradeAppliedSchemaRequest {
   export function isa(o: any): o is UpgradeAppliedSchemaRequest {
-    return _smithy.isa(o, "UpgradeAppliedSchemaRequest");
+    return __isa(o, "UpgradeAppliedSchemaRequest");
   }
 }
 
@@ -5940,7 +5937,7 @@ export interface UpgradeAppliedSchemaResponse extends $MetadataBearer {
 
 export namespace UpgradeAppliedSchemaResponse {
   export function isa(o: any): o is UpgradeAppliedSchemaResponse {
-    return _smithy.isa(o, "UpgradeAppliedSchemaResponse");
+    return __isa(o, "UpgradeAppliedSchemaResponse");
   }
 }
 
@@ -5969,7 +5966,7 @@ export interface UpgradePublishedSchemaRequest {
 
 export namespace UpgradePublishedSchemaRequest {
   export function isa(o: any): o is UpgradePublishedSchemaRequest {
-    return _smithy.isa(o, "UpgradePublishedSchemaRequest");
+    return __isa(o, "UpgradePublishedSchemaRequest");
   }
 }
 
@@ -5983,7 +5980,7 @@ export interface UpgradePublishedSchemaResponse extends $MetadataBearer {
 
 export namespace UpgradePublishedSchemaResponse {
   export function isa(o: any): o is UpgradePublishedSchemaResponse {
-    return _smithy.isa(o, "UpgradePublishedSchemaResponse");
+    return __isa(o, "UpgradePublishedSchemaResponse");
   }
 }
 
@@ -5992,7 +5989,7 @@ export namespace UpgradePublishedSchemaResponse {
  *       message.</p>
  */
 export interface ValidationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ValidationException";
   $fault: "client";
@@ -6001,6 +5998,6 @@ export interface ValidationException
 
 export namespace ValidationException {
   export function isa(o: any): o is ValidationException {
-    return _smithy.isa(o, "ValidationException");
+    return __isa(o, "ValidationException");
   }
 }

--- a/clients/client-clouddirectory/protocols/Aws_restJson1_1.ts
+++ b/clients/client-clouddirectory/protocols/Aws_restJson1_1.ts
@@ -413,7 +413,7 @@ export async function serializeAws_restJson1_1AddFacetToObjectCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.DirectoryArn !== undefined) {
-    headers["x-amz-data-partition"] = input.DirectoryArn.toString();
+    headers["x-amz-data-partition"] = input.DirectoryArn;
   }
   let resolvedPath = "/amazonclouddirectory/2017-01-11/object/facets";
   let body: any;
@@ -456,7 +456,7 @@ export async function serializeAws_restJson1_1ApplySchemaCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.DirectoryArn !== undefined) {
-    headers["x-amz-data-partition"] = input.DirectoryArn.toString();
+    headers["x-amz-data-partition"] = input.DirectoryArn;
   }
   let resolvedPath = "/amazonclouddirectory/2017-01-11/schema/apply";
   let body: any;
@@ -482,7 +482,7 @@ export async function serializeAws_restJson1_1AttachObjectCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.DirectoryArn !== undefined) {
-    headers["x-amz-data-partition"] = input.DirectoryArn.toString();
+    headers["x-amz-data-partition"] = input.DirectoryArn;
   }
   let resolvedPath = "/amazonclouddirectory/2017-01-11/object/attach";
   let body: any;
@@ -520,7 +520,7 @@ export async function serializeAws_restJson1_1AttachPolicyCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.DirectoryArn !== undefined) {
-    headers["x-amz-data-partition"] = input.DirectoryArn.toString();
+    headers["x-amz-data-partition"] = input.DirectoryArn;
   }
   let resolvedPath = "/amazonclouddirectory/2017-01-11/policy/attach";
   let body: any;
@@ -555,7 +555,7 @@ export async function serializeAws_restJson1_1AttachToIndexCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.DirectoryArn !== undefined) {
-    headers["x-amz-data-partition"] = input.DirectoryArn.toString();
+    headers["x-amz-data-partition"] = input.DirectoryArn;
   }
   let resolvedPath = "/amazonclouddirectory/2017-01-11/index/attach";
   let body: any;
@@ -590,7 +590,7 @@ export async function serializeAws_restJson1_1AttachTypedLinkCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.DirectoryArn !== undefined) {
-    headers["x-amz-data-partition"] = input.DirectoryArn.toString();
+    headers["x-amz-data-partition"] = input.DirectoryArn;
   }
   let resolvedPath = "/amazonclouddirectory/2017-01-11/typedlink/attach";
   let body: any;
@@ -645,10 +645,10 @@ export async function serializeAws_restJson1_1BatchReadCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.ConsistencyLevel !== undefined) {
-    headers["x-amz-consistency-level"] = input.ConsistencyLevel.toString();
+    headers["x-amz-consistency-level"] = input.ConsistencyLevel;
   }
   if (input.DirectoryArn !== undefined) {
-    headers["x-amz-data-partition"] = input.DirectoryArn.toString();
+    headers["x-amz-data-partition"] = input.DirectoryArn;
   }
   let resolvedPath = "/amazonclouddirectory/2017-01-11/batchread";
   let body: any;
@@ -677,7 +677,7 @@ export async function serializeAws_restJson1_1BatchWriteCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.DirectoryArn !== undefined) {
-    headers["x-amz-data-partition"] = input.DirectoryArn.toString();
+    headers["x-amz-data-partition"] = input.DirectoryArn;
   }
   let resolvedPath = "/amazonclouddirectory/2017-01-11/batchwrite";
   let body: any;
@@ -706,7 +706,7 @@ export async function serializeAws_restJson1_1CreateDirectoryCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.SchemaArn !== undefined) {
-    headers["x-amz-data-partition"] = input.SchemaArn.toString();
+    headers["x-amz-data-partition"] = input.SchemaArn;
   }
   let resolvedPath = "/amazonclouddirectory/2017-01-11/directory/create";
   let body: any;
@@ -732,7 +732,7 @@ export async function serializeAws_restJson1_1CreateFacetCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.SchemaArn !== undefined) {
-    headers["x-amz-data-partition"] = input.SchemaArn.toString();
+    headers["x-amz-data-partition"] = input.SchemaArn;
   }
   let resolvedPath = "/amazonclouddirectory/2017-01-11/facet/create";
   let body: any;
@@ -770,7 +770,7 @@ export async function serializeAws_restJson1_1CreateIndexCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.DirectoryArn !== undefined) {
-    headers["x-amz-data-partition"] = input.DirectoryArn.toString();
+    headers["x-amz-data-partition"] = input.DirectoryArn;
   }
   let resolvedPath = "/amazonclouddirectory/2017-01-11/index";
   let body: any;
@@ -813,7 +813,7 @@ export async function serializeAws_restJson1_1CreateObjectCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.DirectoryArn !== undefined) {
-    headers["x-amz-data-partition"] = input.DirectoryArn.toString();
+    headers["x-amz-data-partition"] = input.DirectoryArn;
   }
   let resolvedPath = "/amazonclouddirectory/2017-01-11/object";
   let body: any;
@@ -882,7 +882,7 @@ export async function serializeAws_restJson1_1CreateTypedLinkFacetCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.SchemaArn !== undefined) {
-    headers["x-amz-data-partition"] = input.SchemaArn.toString();
+    headers["x-amz-data-partition"] = input.SchemaArn;
   }
   let resolvedPath = "/amazonclouddirectory/2017-01-11/typedlink/facet/create";
   let body: any;
@@ -911,7 +911,7 @@ export async function serializeAws_restJson1_1DeleteDirectoryCommand(
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.DirectoryArn !== undefined) {
-    headers["x-amz-data-partition"] = input.DirectoryArn.toString();
+    headers["x-amz-data-partition"] = input.DirectoryArn;
   }
   let resolvedPath = "/amazonclouddirectory/2017-01-11/directory";
   return new __HttpRequest({
@@ -930,7 +930,7 @@ export async function serializeAws_restJson1_1DeleteFacetCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.SchemaArn !== undefined) {
-    headers["x-amz-data-partition"] = input.SchemaArn.toString();
+    headers["x-amz-data-partition"] = input.SchemaArn;
   }
   let resolvedPath = "/amazonclouddirectory/2017-01-11/facet/delete";
   let body: any;
@@ -956,7 +956,7 @@ export async function serializeAws_restJson1_1DeleteObjectCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.DirectoryArn !== undefined) {
-    headers["x-amz-data-partition"] = input.DirectoryArn.toString();
+    headers["x-amz-data-partition"] = input.DirectoryArn;
   }
   let resolvedPath = "/amazonclouddirectory/2017-01-11/object/delete";
   let body: any;
@@ -985,7 +985,7 @@ export async function serializeAws_restJson1_1DeleteSchemaCommand(
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.SchemaArn !== undefined) {
-    headers["x-amz-data-partition"] = input.SchemaArn.toString();
+    headers["x-amz-data-partition"] = input.SchemaArn;
   }
   let resolvedPath = "/amazonclouddirectory/2017-01-11/schema";
   return new __HttpRequest({
@@ -1004,7 +1004,7 @@ export async function serializeAws_restJson1_1DeleteTypedLinkFacetCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.SchemaArn !== undefined) {
-    headers["x-amz-data-partition"] = input.SchemaArn.toString();
+    headers["x-amz-data-partition"] = input.SchemaArn;
   }
   let resolvedPath = "/amazonclouddirectory/2017-01-11/typedlink/facet/delete";
   let body: any;
@@ -1030,7 +1030,7 @@ export async function serializeAws_restJson1_1DetachFromIndexCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.DirectoryArn !== undefined) {
-    headers["x-amz-data-partition"] = input.DirectoryArn.toString();
+    headers["x-amz-data-partition"] = input.DirectoryArn;
   }
   let resolvedPath = "/amazonclouddirectory/2017-01-11/index/detach";
   let body: any;
@@ -1065,7 +1065,7 @@ export async function serializeAws_restJson1_1DetachObjectCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.DirectoryArn !== undefined) {
-    headers["x-amz-data-partition"] = input.DirectoryArn.toString();
+    headers["x-amz-data-partition"] = input.DirectoryArn;
   }
   let resolvedPath = "/amazonclouddirectory/2017-01-11/object/detach";
   let body: any;
@@ -1097,7 +1097,7 @@ export async function serializeAws_restJson1_1DetachPolicyCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.DirectoryArn !== undefined) {
-    headers["x-amz-data-partition"] = input.DirectoryArn.toString();
+    headers["x-amz-data-partition"] = input.DirectoryArn;
   }
   let resolvedPath = "/amazonclouddirectory/2017-01-11/policy/detach";
   let body: any;
@@ -1132,7 +1132,7 @@ export async function serializeAws_restJson1_1DetachTypedLinkCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.DirectoryArn !== undefined) {
-    headers["x-amz-data-partition"] = input.DirectoryArn.toString();
+    headers["x-amz-data-partition"] = input.DirectoryArn;
   }
   let resolvedPath = "/amazonclouddirectory/2017-01-11/typedlink/detach";
   let body: any;
@@ -1163,7 +1163,7 @@ export async function serializeAws_restJson1_1DisableDirectoryCommand(
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.DirectoryArn !== undefined) {
-    headers["x-amz-data-partition"] = input.DirectoryArn.toString();
+    headers["x-amz-data-partition"] = input.DirectoryArn;
   }
   let resolvedPath = "/amazonclouddirectory/2017-01-11/directory/disable";
   return new __HttpRequest({
@@ -1182,7 +1182,7 @@ export async function serializeAws_restJson1_1EnableDirectoryCommand(
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.DirectoryArn !== undefined) {
-    headers["x-amz-data-partition"] = input.DirectoryArn.toString();
+    headers["x-amz-data-partition"] = input.DirectoryArn;
   }
   let resolvedPath = "/amazonclouddirectory/2017-01-11/directory/enable";
   return new __HttpRequest({
@@ -1224,7 +1224,7 @@ export async function serializeAws_restJson1_1GetDirectoryCommand(
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.DirectoryArn !== undefined) {
-    headers["x-amz-data-partition"] = input.DirectoryArn.toString();
+    headers["x-amz-data-partition"] = input.DirectoryArn;
   }
   let resolvedPath = "/amazonclouddirectory/2017-01-11/directory/get";
   return new __HttpRequest({
@@ -1243,7 +1243,7 @@ export async function serializeAws_restJson1_1GetFacetCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.SchemaArn !== undefined) {
-    headers["x-amz-data-partition"] = input.SchemaArn.toString();
+    headers["x-amz-data-partition"] = input.SchemaArn;
   }
   let resolvedPath = "/amazonclouddirectory/2017-01-11/facet";
   let body: any;
@@ -1269,7 +1269,7 @@ export async function serializeAws_restJson1_1GetLinkAttributesCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.DirectoryArn !== undefined) {
-    headers["x-amz-data-partition"] = input.DirectoryArn.toString();
+    headers["x-amz-data-partition"] = input.DirectoryArn;
   }
   let resolvedPath =
     "/amazonclouddirectory/2017-01-11/typedlink/attributes/get";
@@ -1310,10 +1310,10 @@ export async function serializeAws_restJson1_1GetObjectAttributesCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.ConsistencyLevel !== undefined) {
-    headers["x-amz-consistency-level"] = input.ConsistencyLevel.toString();
+    headers["x-amz-consistency-level"] = input.ConsistencyLevel;
   }
   if (input.DirectoryArn !== undefined) {
-    headers["x-amz-data-partition"] = input.DirectoryArn.toString();
+    headers["x-amz-data-partition"] = input.DirectoryArn;
   }
   let resolvedPath = "/amazonclouddirectory/2017-01-11/object/attributes/get";
   let body: any;
@@ -1354,10 +1354,10 @@ export async function serializeAws_restJson1_1GetObjectInformationCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.ConsistencyLevel !== undefined) {
-    headers["x-amz-consistency-level"] = input.ConsistencyLevel.toString();
+    headers["x-amz-consistency-level"] = input.ConsistencyLevel;
   }
   if (input.DirectoryArn !== undefined) {
-    headers["x-amz-data-partition"] = input.DirectoryArn.toString();
+    headers["x-amz-data-partition"] = input.DirectoryArn;
   }
   let resolvedPath = "/amazonclouddirectory/2017-01-11/object/information";
   let body: any;
@@ -1386,7 +1386,7 @@ export async function serializeAws_restJson1_1GetSchemaAsJsonCommand(
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.SchemaArn !== undefined) {
-    headers["x-amz-data-partition"] = input.SchemaArn.toString();
+    headers["x-amz-data-partition"] = input.SchemaArn;
   }
   let resolvedPath = "/amazonclouddirectory/2017-01-11/schema/json";
   return new __HttpRequest({
@@ -1405,7 +1405,7 @@ export async function serializeAws_restJson1_1GetTypedLinkFacetInformationComman
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.SchemaArn !== undefined) {
-    headers["x-amz-data-partition"] = input.SchemaArn.toString();
+    headers["x-amz-data-partition"] = input.SchemaArn;
   }
   let resolvedPath = "/amazonclouddirectory/2017-01-11/typedlink/facet/get";
   let body: any;
@@ -1463,10 +1463,10 @@ export async function serializeAws_restJson1_1ListAttachedIndicesCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.ConsistencyLevel !== undefined) {
-    headers["x-amz-consistency-level"] = input.ConsistencyLevel.toString();
+    headers["x-amz-consistency-level"] = input.ConsistencyLevel;
   }
   if (input.DirectoryArn !== undefined) {
-    headers["x-amz-data-partition"] = input.DirectoryArn.toString();
+    headers["x-amz-data-partition"] = input.DirectoryArn;
   }
   let resolvedPath = "/amazonclouddirectory/2017-01-11/object/indices";
   let body: any;
@@ -1556,7 +1556,7 @@ export async function serializeAws_restJson1_1ListFacetAttributesCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.SchemaArn !== undefined) {
-    headers["x-amz-data-partition"] = input.SchemaArn.toString();
+    headers["x-amz-data-partition"] = input.SchemaArn;
   }
   let resolvedPath = "/amazonclouddirectory/2017-01-11/facet/attributes";
   let body: any;
@@ -1588,7 +1588,7 @@ export async function serializeAws_restJson1_1ListFacetNamesCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.SchemaArn !== undefined) {
-    headers["x-amz-data-partition"] = input.SchemaArn.toString();
+    headers["x-amz-data-partition"] = input.SchemaArn;
   }
   let resolvedPath = "/amazonclouddirectory/2017-01-11/facet/list";
   let body: any;
@@ -1617,7 +1617,7 @@ export async function serializeAws_restJson1_1ListIncomingTypedLinksCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.DirectoryArn !== undefined) {
-    headers["x-amz-data-partition"] = input.DirectoryArn.toString();
+    headers["x-amz-data-partition"] = input.DirectoryArn;
   }
   let resolvedPath = "/amazonclouddirectory/2017-01-11/typedlink/incoming";
   let body: any;
@@ -1671,10 +1671,10 @@ export async function serializeAws_restJson1_1ListIndexCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.ConsistencyLevel !== undefined) {
-    headers["x-amz-consistency-level"] = input.ConsistencyLevel.toString();
+    headers["x-amz-consistency-level"] = input.ConsistencyLevel;
   }
   if (input.DirectoryArn !== undefined) {
-    headers["x-amz-data-partition"] = input.DirectoryArn.toString();
+    headers["x-amz-data-partition"] = input.DirectoryArn;
   }
   let resolvedPath = "/amazonclouddirectory/2017-01-11/index/targets";
   let body: any;
@@ -1746,10 +1746,10 @@ export async function serializeAws_restJson1_1ListObjectAttributesCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.ConsistencyLevel !== undefined) {
-    headers["x-amz-consistency-level"] = input.ConsistencyLevel.toString();
+    headers["x-amz-consistency-level"] = input.ConsistencyLevel;
   }
   if (input.DirectoryArn !== undefined) {
-    headers["x-amz-data-partition"] = input.DirectoryArn.toString();
+    headers["x-amz-data-partition"] = input.DirectoryArn;
   }
   let resolvedPath = "/amazonclouddirectory/2017-01-11/object/attributes";
   let body: any;
@@ -1790,10 +1790,10 @@ export async function serializeAws_restJson1_1ListObjectChildrenCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.ConsistencyLevel !== undefined) {
-    headers["x-amz-consistency-level"] = input.ConsistencyLevel.toString();
+    headers["x-amz-consistency-level"] = input.ConsistencyLevel;
   }
   if (input.DirectoryArn !== undefined) {
-    headers["x-amz-data-partition"] = input.DirectoryArn.toString();
+    headers["x-amz-data-partition"] = input.DirectoryArn;
   }
   let resolvedPath = "/amazonclouddirectory/2017-01-11/object/children";
   let body: any;
@@ -1828,7 +1828,7 @@ export async function serializeAws_restJson1_1ListObjectParentPathsCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.DirectoryArn !== undefined) {
-    headers["x-amz-data-partition"] = input.DirectoryArn.toString();
+    headers["x-amz-data-partition"] = input.DirectoryArn;
   }
   let resolvedPath = "/amazonclouddirectory/2017-01-11/object/parentpaths";
   let body: any;
@@ -1863,10 +1863,10 @@ export async function serializeAws_restJson1_1ListObjectParentsCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.ConsistencyLevel !== undefined) {
-    headers["x-amz-consistency-level"] = input.ConsistencyLevel.toString();
+    headers["x-amz-consistency-level"] = input.ConsistencyLevel;
   }
   if (input.DirectoryArn !== undefined) {
-    headers["x-amz-data-partition"] = input.DirectoryArn.toString();
+    headers["x-amz-data-partition"] = input.DirectoryArn;
   }
   let resolvedPath = "/amazonclouddirectory/2017-01-11/object/parent";
   let body: any;
@@ -1905,10 +1905,10 @@ export async function serializeAws_restJson1_1ListObjectPoliciesCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.ConsistencyLevel !== undefined) {
-    headers["x-amz-consistency-level"] = input.ConsistencyLevel.toString();
+    headers["x-amz-consistency-level"] = input.ConsistencyLevel;
   }
   if (input.DirectoryArn !== undefined) {
-    headers["x-amz-data-partition"] = input.DirectoryArn.toString();
+    headers["x-amz-data-partition"] = input.DirectoryArn;
   }
   let resolvedPath = "/amazonclouddirectory/2017-01-11/object/policy";
   let body: any;
@@ -1943,7 +1943,7 @@ export async function serializeAws_restJson1_1ListOutgoingTypedLinksCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.DirectoryArn !== undefined) {
-    headers["x-amz-data-partition"] = input.DirectoryArn.toString();
+    headers["x-amz-data-partition"] = input.DirectoryArn;
   }
   let resolvedPath = "/amazonclouddirectory/2017-01-11/typedlink/outgoing";
   let body: any;
@@ -1997,10 +1997,10 @@ export async function serializeAws_restJson1_1ListPolicyAttachmentsCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.ConsistencyLevel !== undefined) {
-    headers["x-amz-consistency-level"] = input.ConsistencyLevel.toString();
+    headers["x-amz-consistency-level"] = input.ConsistencyLevel;
   }
   if (input.DirectoryArn !== undefined) {
-    headers["x-amz-data-partition"] = input.DirectoryArn.toString();
+    headers["x-amz-data-partition"] = input.DirectoryArn;
   }
   let resolvedPath = "/amazonclouddirectory/2017-01-11/policy/attachment";
   let body: any;
@@ -2093,7 +2093,7 @@ export async function serializeAws_restJson1_1ListTypedLinkFacetAttributesComman
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.SchemaArn !== undefined) {
-    headers["x-amz-data-partition"] = input.SchemaArn.toString();
+    headers["x-amz-data-partition"] = input.SchemaArn;
   }
   let resolvedPath =
     "/amazonclouddirectory/2017-01-11/typedlink/facet/attributes";
@@ -2126,7 +2126,7 @@ export async function serializeAws_restJson1_1ListTypedLinkFacetNamesCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.SchemaArn !== undefined) {
-    headers["x-amz-data-partition"] = input.SchemaArn.toString();
+    headers["x-amz-data-partition"] = input.SchemaArn;
   }
   let resolvedPath = "/amazonclouddirectory/2017-01-11/typedlink/facet/list";
   let body: any;
@@ -2155,7 +2155,7 @@ export async function serializeAws_restJson1_1LookupPolicyCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.DirectoryArn !== undefined) {
-    headers["x-amz-data-partition"] = input.DirectoryArn.toString();
+    headers["x-amz-data-partition"] = input.DirectoryArn;
   }
   let resolvedPath = "/amazonclouddirectory/2017-01-11/policy/lookup";
   let body: any;
@@ -2190,7 +2190,7 @@ export async function serializeAws_restJson1_1PublishSchemaCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.DevelopmentSchemaArn !== undefined) {
-    headers["x-amz-data-partition"] = input.DevelopmentSchemaArn.toString();
+    headers["x-amz-data-partition"] = input.DevelopmentSchemaArn;
   }
   let resolvedPath = "/amazonclouddirectory/2017-01-11/schema/publish";
   let body: any;
@@ -2222,7 +2222,7 @@ export async function serializeAws_restJson1_1PutSchemaFromJsonCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.SchemaArn !== undefined) {
-    headers["x-amz-data-partition"] = input.SchemaArn.toString();
+    headers["x-amz-data-partition"] = input.SchemaArn;
   }
   let resolvedPath = "/amazonclouddirectory/2017-01-11/schema/json";
   let body: any;
@@ -2248,7 +2248,7 @@ export async function serializeAws_restJson1_1RemoveFacetFromObjectCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.DirectoryArn !== undefined) {
-    headers["x-amz-data-partition"] = input.DirectoryArn.toString();
+    headers["x-amz-data-partition"] = input.DirectoryArn;
   }
   let resolvedPath = "/amazonclouddirectory/2017-01-11/object/facets/delete";
   let body: any;
@@ -2338,7 +2338,7 @@ export async function serializeAws_restJson1_1UpdateFacetCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.SchemaArn !== undefined) {
-    headers["x-amz-data-partition"] = input.SchemaArn.toString();
+    headers["x-amz-data-partition"] = input.SchemaArn;
   }
   let resolvedPath = "/amazonclouddirectory/2017-01-11/facet";
   let body: any;
@@ -2375,7 +2375,7 @@ export async function serializeAws_restJson1_1UpdateLinkAttributesCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.DirectoryArn !== undefined) {
-    headers["x-amz-data-partition"] = input.DirectoryArn.toString();
+    headers["x-amz-data-partition"] = input.DirectoryArn;
   }
   let resolvedPath =
     "/amazonclouddirectory/2017-01-11/typedlink/attributes/update";
@@ -2415,7 +2415,7 @@ export async function serializeAws_restJson1_1UpdateObjectAttributesCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.DirectoryArn !== undefined) {
-    headers["x-amz-data-partition"] = input.DirectoryArn.toString();
+    headers["x-amz-data-partition"] = input.DirectoryArn;
   }
   let resolvedPath = "/amazonclouddirectory/2017-01-11/object/update";
   let body: any;
@@ -2452,7 +2452,7 @@ export async function serializeAws_restJson1_1UpdateSchemaCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.SchemaArn !== undefined) {
-    headers["x-amz-data-partition"] = input.SchemaArn.toString();
+    headers["x-amz-data-partition"] = input.SchemaArn;
   }
   let resolvedPath = "/amazonclouddirectory/2017-01-11/schema/update";
   let body: any;
@@ -2478,7 +2478,7 @@ export async function serializeAws_restJson1_1UpdateTypedLinkFacetCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.SchemaArn !== undefined) {
-    headers["x-amz-data-partition"] = input.SchemaArn.toString();
+    headers["x-amz-data-partition"] = input.SchemaArn;
   }
   let resolvedPath = "/amazonclouddirectory/2017-01-11/typedlink/facet";
   let body: any;
@@ -2588,6 +2588,7 @@ export async function deserializeAws_restJson1_1AddFacetToObjectCommand(
     $metadata: deserializeMetadata(output),
     __type: "AddFacetToObjectResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2931,6 +2932,7 @@ export async function deserializeAws_restJson1_1AttachPolicyCommand(
     $metadata: deserializeMetadata(output),
     __type: "AttachPolicyResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -3613,6 +3615,7 @@ export async function deserializeAws_restJson1_1CreateFacetCommand(
     $metadata: deserializeMetadata(output),
     __type: "CreateFacetResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -4068,6 +4071,7 @@ export async function deserializeAws_restJson1_1CreateTypedLinkFacetCommand(
     $metadata: deserializeMetadata(output),
     __type: "CreateTypedLinkFacetResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -4291,6 +4295,7 @@ export async function deserializeAws_restJson1_1DeleteFacetCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeleteFacetResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -4395,6 +4400,7 @@ export async function deserializeAws_restJson1_1DeleteObjectCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeleteObjectResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -4604,6 +4610,7 @@ export async function deserializeAws_restJson1_1DeleteTypedLinkFacetCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeleteTypedLinkFacetResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -4935,6 +4942,7 @@ export async function deserializeAws_restJson1_1DetachPolicyCommand(
     $metadata: deserializeMetadata(output),
     __type: "DetachPolicyResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -5041,6 +5049,7 @@ export async function deserializeAws_restJson1_1DetachTypedLinkCommand(
   const contents: DetachTypedLinkCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -8896,6 +8905,7 @@ export async function deserializeAws_restJson1_1RemoveFacetFromObjectCommand(
     $metadata: deserializeMetadata(output),
     __type: "RemoveFacetFromObjectResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -9000,6 +9010,7 @@ export async function deserializeAws_restJson1_1TagResourceCommand(
     $metadata: deserializeMetadata(output),
     __type: "TagResourceResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -9097,6 +9108,7 @@ export async function deserializeAws_restJson1_1UntagResourceCommand(
     $metadata: deserializeMetadata(output),
     __type: "UntagResourceResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -9194,6 +9206,7 @@ export async function deserializeAws_restJson1_1UpdateFacetCommand(
     $metadata: deserializeMetadata(output),
     __type: "UpdateFacetResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -9315,6 +9328,7 @@ export async function deserializeAws_restJson1_1UpdateLinkAttributesCommand(
     $metadata: deserializeMetadata(output),
     __type: "UpdateLinkAttributesResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -9636,6 +9650,7 @@ export async function deserializeAws_restJson1_1UpdateTypedLinkFacetCommand(
     $metadata: deserializeMetadata(output),
     __type: "UpdateTypedLinkFacetResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 

--- a/clients/client-cloudformation/models/index.ts
+++ b/clients/client-cloudformation/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -37,7 +40,7 @@ export interface AccountLimit {
 
 export namespace AccountLimit {
   export function isa(o: any): o is AccountLimit {
-    return _smithy.isa(o, "AccountLimit");
+    return __isa(o, "AccountLimit");
   }
 }
 
@@ -45,7 +48,7 @@ export namespace AccountLimit {
  * <p>The resource with the name requested already exists.</p>
  */
 export interface AlreadyExistsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AlreadyExistsException";
   $fault: "client";
@@ -54,7 +57,7 @@ export interface AlreadyExistsException
 
 export namespace AlreadyExistsException {
   export function isa(o: any): o is AlreadyExistsException {
-    return _smithy.isa(o, "AlreadyExistsException");
+    return __isa(o, "AlreadyExistsException");
   }
 }
 
@@ -62,7 +65,7 @@ export namespace AlreadyExistsException {
  * <p>An error occurred during a CloudFormation registry operation.</p>
  */
 export interface CFNRegistryException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CFNRegistryException";
   $fault: "client";
@@ -71,7 +74,7 @@ export interface CFNRegistryException
 
 export namespace CFNRegistryException {
   export function isa(o: any): o is CFNRegistryException {
-    return _smithy.isa(o, "CFNRegistryException");
+    return __isa(o, "CFNRegistryException");
   }
 }
 
@@ -97,7 +100,7 @@ export interface CancelUpdateStackInput {
 
 export namespace CancelUpdateStackInput {
   export function isa(o: any): o is CancelUpdateStackInput {
-    return _smithy.isa(o, "CancelUpdateStackInput");
+    return __isa(o, "CancelUpdateStackInput");
   }
 }
 
@@ -128,7 +131,7 @@ export interface Change {
 
 export namespace Change {
   export function isa(o: any): o is Change {
-    return _smithy.isa(o, "Change");
+    return __isa(o, "Change");
   }
 }
 
@@ -144,7 +147,7 @@ export enum ChangeAction {
  *          stack, use the <code>ListChangeSets</code> action.</p>
  */
 export interface ChangeSetNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ChangeSetNotFoundException";
   $fault: "client";
@@ -153,7 +156,7 @@ export interface ChangeSetNotFoundException
 
 export namespace ChangeSetNotFoundException {
   export function isa(o: any): o is ChangeSetNotFoundException {
-    return _smithy.isa(o, "ChangeSetNotFoundException");
+    return __isa(o, "ChangeSetNotFoundException");
   }
 }
 
@@ -225,7 +228,7 @@ export interface ChangeSetSummary {
 
 export namespace ChangeSetSummary {
   export function isa(o: any): o is ChangeSetSummary {
-    return _smithy.isa(o, "ChangeSetSummary");
+    return __isa(o, "ChangeSetSummary");
   }
 }
 
@@ -322,7 +325,7 @@ export interface ContinueUpdateRollbackInput {
 
 export namespace ContinueUpdateRollbackInput {
   export function isa(o: any): o is ContinueUpdateRollbackInput {
-    return _smithy.isa(o, "ContinueUpdateRollbackInput");
+    return __isa(o, "ContinueUpdateRollbackInput");
   }
 }
 
@@ -335,7 +338,7 @@ export interface ContinueUpdateRollbackOutput extends $MetadataBearer {
 
 export namespace ContinueUpdateRollbackOutput {
   export function isa(o: any): o is ContinueUpdateRollbackOutput {
-    return _smithy.isa(o, "ContinueUpdateRollbackOutput");
+    return __isa(o, "ContinueUpdateRollbackOutput");
   }
 }
 
@@ -579,7 +582,7 @@ export interface CreateChangeSetInput {
 
 export namespace CreateChangeSetInput {
   export function isa(o: any): o is CreateChangeSetInput {
-    return _smithy.isa(o, "CreateChangeSetInput");
+    return __isa(o, "CreateChangeSetInput");
   }
 }
 
@@ -601,7 +604,7 @@ export interface CreateChangeSetOutput extends $MetadataBearer {
 
 export namespace CreateChangeSetOutput {
   export function isa(o: any): o is CreateChangeSetOutput {
-    return _smithy.isa(o, "CreateChangeSetOutput");
+    return __isa(o, "CreateChangeSetOutput");
   }
 }
 
@@ -879,7 +882,7 @@ export interface CreateStackInput {
 
 export namespace CreateStackInput {
   export function isa(o: any): o is CreateStackInput {
-    return _smithy.isa(o, "CreateStackInput");
+    return __isa(o, "CreateStackInput");
   }
 }
 
@@ -896,7 +899,7 @@ export interface CreateStackOutput extends $MetadataBearer {
 
 export namespace CreateStackOutput {
   export function isa(o: any): o is CreateStackOutput {
-    return _smithy.isa(o, "CreateStackOutput");
+    return __isa(o, "CreateStackOutput");
   }
 }
 
@@ -920,7 +923,7 @@ export interface DeleteChangeSetInput {
 
 export namespace DeleteChangeSetInput {
   export function isa(o: any): o is DeleteChangeSetInput {
-    return _smithy.isa(o, "DeleteChangeSetInput");
+    return __isa(o, "DeleteChangeSetInput");
   }
 }
 
@@ -933,7 +936,7 @@ export interface DeleteChangeSetOutput extends $MetadataBearer {
 
 export namespace DeleteChangeSetOutput {
   export function isa(o: any): o is DeleteChangeSetOutput {
-    return _smithy.isa(o, "DeleteChangeSetOutput");
+    return __isa(o, "DeleteChangeSetOutput");
   }
 }
 
@@ -988,7 +991,7 @@ export interface DeleteStackInput {
 
 export namespace DeleteStackInput {
   export function isa(o: any): o is DeleteStackInput {
-    return _smithy.isa(o, "DeleteStackInput");
+    return __isa(o, "DeleteStackInput");
   }
 }
 
@@ -1022,7 +1025,7 @@ export interface DeregisterTypeInput {
 
 export namespace DeregisterTypeInput {
   export function isa(o: any): o is DeregisterTypeInput {
-    return _smithy.isa(o, "DeregisterTypeInput");
+    return __isa(o, "DeregisterTypeInput");
   }
 }
 
@@ -1032,7 +1035,7 @@ export interface DeregisterTypeOutput extends $MetadataBearer {
 
 export namespace DeregisterTypeOutput {
   export function isa(o: any): o is DeregisterTypeOutput {
-    return _smithy.isa(o, "DeregisterTypeOutput");
+    return __isa(o, "DeregisterTypeOutput");
   }
 }
 
@@ -1049,7 +1052,7 @@ export interface DescribeAccountLimitsInput {
 
 export namespace DescribeAccountLimitsInput {
   export function isa(o: any): o is DescribeAccountLimitsInput {
-    return _smithy.isa(o, "DescribeAccountLimitsInput");
+    return __isa(o, "DescribeAccountLimitsInput");
   }
 }
 
@@ -1073,7 +1076,7 @@ export interface DescribeAccountLimitsOutput extends $MetadataBearer {
 
 export namespace DescribeAccountLimitsOutput {
   export function isa(o: any): o is DescribeAccountLimitsOutput {
-    return _smithy.isa(o, "DescribeAccountLimitsOutput");
+    return __isa(o, "DescribeAccountLimitsOutput");
   }
 }
 
@@ -1103,7 +1106,7 @@ export interface DescribeChangeSetInput {
 
 export namespace DescribeChangeSetInput {
   export function isa(o: any): o is DescribeChangeSetInput {
-    return _smithy.isa(o, "DescribeChangeSetInput");
+    return __isa(o, "DescribeChangeSetInput");
   }
 }
 
@@ -1208,7 +1211,7 @@ export interface DescribeChangeSetOutput extends $MetadataBearer {
 
 export namespace DescribeChangeSetOutput {
   export function isa(o: any): o is DescribeChangeSetOutput {
-    return _smithy.isa(o, "DescribeChangeSetOutput");
+    return __isa(o, "DescribeChangeSetOutput");
   }
 }
 
@@ -1225,7 +1228,7 @@ export interface DescribeStackDriftDetectionStatusInput {
 
 export namespace DescribeStackDriftDetectionStatusInput {
   export function isa(o: any): o is DescribeStackDriftDetectionStatusInput {
-    return _smithy.isa(o, "DescribeStackDriftDetectionStatusInput");
+    return __isa(o, "DescribeStackDriftDetectionStatusInput");
   }
 }
 
@@ -1319,7 +1322,7 @@ export interface DescribeStackDriftDetectionStatusOutput
 
 export namespace DescribeStackDriftDetectionStatusOutput {
   export function isa(o: any): o is DescribeStackDriftDetectionStatusOutput {
-    return _smithy.isa(o, "DescribeStackDriftDetectionStatusOutput");
+    return __isa(o, "DescribeStackDriftDetectionStatusOutput");
   }
 }
 
@@ -1352,7 +1355,7 @@ export interface DescribeStackEventsInput {
 
 export namespace DescribeStackEventsInput {
   export function isa(o: any): o is DescribeStackEventsInput {
-    return _smithy.isa(o, "DescribeStackEventsInput");
+    return __isa(o, "DescribeStackEventsInput");
   }
 }
 
@@ -1375,7 +1378,7 @@ export interface DescribeStackEventsOutput extends $MetadataBearer {
 
 export namespace DescribeStackEventsOutput {
   export function isa(o: any): o is DescribeStackEventsOutput {
-    return _smithy.isa(o, "DescribeStackEventsOutput");
+    return __isa(o, "DescribeStackEventsOutput");
   }
 }
 
@@ -1429,7 +1432,7 @@ export interface DescribeStackResourceDriftsInput {
 
 export namespace DescribeStackResourceDriftsInput {
   export function isa(o: any): o is DescribeStackResourceDriftsInput {
-    return _smithy.isa(o, "DescribeStackResourceDriftsInput");
+    return __isa(o, "DescribeStackResourceDriftsInput");
   }
 }
 
@@ -1459,7 +1462,7 @@ export interface DescribeStackResourceDriftsOutput extends $MetadataBearer {
 
 export namespace DescribeStackResourceDriftsOutput {
   export function isa(o: any): o is DescribeStackResourceDriftsOutput {
-    return _smithy.isa(o, "DescribeStackResourceDriftsOutput");
+    return __isa(o, "DescribeStackResourceDriftsOutput");
   }
 }
 
@@ -1493,7 +1496,7 @@ export interface DescribeStackResourceInput {
 
 export namespace DescribeStackResourceInput {
   export function isa(o: any): o is DescribeStackResourceInput {
-    return _smithy.isa(o, "DescribeStackResourceInput");
+    return __isa(o, "DescribeStackResourceInput");
   }
 }
 
@@ -1511,7 +1514,7 @@ export interface DescribeStackResourceOutput extends $MetadataBearer {
 
 export namespace DescribeStackResourceOutput {
   export function isa(o: any): o is DescribeStackResourceOutput {
-    return _smithy.isa(o, "DescribeStackResourceOutput");
+    return __isa(o, "DescribeStackResourceOutput");
   }
 }
 
@@ -1560,7 +1563,7 @@ export interface DescribeStackResourcesInput {
 
 export namespace DescribeStackResourcesInput {
   export function isa(o: any): o is DescribeStackResourcesInput {
-    return _smithy.isa(o, "DescribeStackResourcesInput");
+    return __isa(o, "DescribeStackResourcesInput");
   }
 }
 
@@ -1577,7 +1580,7 @@ export interface DescribeStackResourcesOutput extends $MetadataBearer {
 
 export namespace DescribeStackResourcesOutput {
   export function isa(o: any): o is DescribeStackResourcesOutput {
-    return _smithy.isa(o, "DescribeStackResourcesOutput");
+    return __isa(o, "DescribeStackResourcesOutput");
   }
 }
 
@@ -1610,7 +1613,7 @@ export interface DescribeStacksInput {
 
 export namespace DescribeStacksInput {
   export function isa(o: any): o is DescribeStacksInput {
-    return _smithy.isa(o, "DescribeStacksInput");
+    return __isa(o, "DescribeStacksInput");
   }
 }
 
@@ -1633,7 +1636,7 @@ export interface DescribeStacksOutput extends $MetadataBearer {
 
 export namespace DescribeStacksOutput {
   export function isa(o: any): o is DescribeStacksOutput {
-    return _smithy.isa(o, "DescribeStacksOutput");
+    return __isa(o, "DescribeStacksOutput");
   }
 }
 
@@ -1666,7 +1669,7 @@ export interface DescribeTypeInput {
 
 export namespace DescribeTypeInput {
   export function isa(o: any): o is DescribeTypeInput {
-    return _smithy.isa(o, "DescribeTypeInput");
+    return __isa(o, "DescribeTypeInput");
   }
 }
 
@@ -1810,7 +1813,7 @@ export interface DescribeTypeOutput extends $MetadataBearer {
 
 export namespace DescribeTypeOutput {
   export function isa(o: any): o is DescribeTypeOutput {
-    return _smithy.isa(o, "DescribeTypeOutput");
+    return __isa(o, "DescribeTypeOutput");
   }
 }
 
@@ -1827,7 +1830,7 @@ export interface DescribeTypeRegistrationInput {
 
 export namespace DescribeTypeRegistrationInput {
   export function isa(o: any): o is DescribeTypeRegistrationInput {
-    return _smithy.isa(o, "DescribeTypeRegistrationInput");
+    return __isa(o, "DescribeTypeRegistrationInput");
   }
 }
 
@@ -1858,7 +1861,7 @@ export interface DescribeTypeRegistrationOutput extends $MetadataBearer {
 
 export namespace DescribeTypeRegistrationOutput {
   export function isa(o: any): o is DescribeTypeRegistrationOutput {
-    return _smithy.isa(o, "DescribeTypeRegistrationOutput");
+    return __isa(o, "DescribeTypeRegistrationOutput");
   }
 }
 
@@ -1877,7 +1880,7 @@ export interface DetectStackDriftInput {
 
 export namespace DetectStackDriftInput {
   export function isa(o: any): o is DetectStackDriftInput {
-    return _smithy.isa(o, "DetectStackDriftInput");
+    return __isa(o, "DetectStackDriftInput");
   }
 }
 
@@ -1894,7 +1897,7 @@ export interface DetectStackDriftOutput extends $MetadataBearer {
 
 export namespace DetectStackDriftOutput {
   export function isa(o: any): o is DetectStackDriftOutput {
-    return _smithy.isa(o, "DetectStackDriftOutput");
+    return __isa(o, "DetectStackDriftOutput");
   }
 }
 
@@ -1913,7 +1916,7 @@ export interface DetectStackResourceDriftInput {
 
 export namespace DetectStackResourceDriftInput {
   export function isa(o: any): o is DetectStackResourceDriftInput {
-    return _smithy.isa(o, "DetectStackResourceDriftInput");
+    return __isa(o, "DetectStackResourceDriftInput");
   }
 }
 
@@ -1929,7 +1932,7 @@ export interface DetectStackResourceDriftOutput extends $MetadataBearer {
 
 export namespace DetectStackResourceDriftOutput {
   export function isa(o: any): o is DetectStackResourceDriftOutput {
-    return _smithy.isa(o, "DetectStackResourceDriftOutput");
+    return __isa(o, "DetectStackResourceDriftOutput");
   }
 }
 
@@ -1970,7 +1973,7 @@ export interface EstimateTemplateCostInput {
 
 export namespace EstimateTemplateCostInput {
   export function isa(o: any): o is EstimateTemplateCostInput {
-    return _smithy.isa(o, "EstimateTemplateCostInput");
+    return __isa(o, "EstimateTemplateCostInput");
   }
 }
 
@@ -1988,7 +1991,7 @@ export interface EstimateTemplateCostOutput extends $MetadataBearer {
 
 export namespace EstimateTemplateCostOutput {
   export function isa(o: any): o is EstimateTemplateCostOutput {
-    return _smithy.isa(o, "EstimateTemplateCostOutput");
+    return __isa(o, "EstimateTemplateCostOutput");
   }
 }
 
@@ -2026,7 +2029,7 @@ export interface ExecuteChangeSetInput {
 
 export namespace ExecuteChangeSetInput {
   export function isa(o: any): o is ExecuteChangeSetInput {
-    return _smithy.isa(o, "ExecuteChangeSetInput");
+    return __isa(o, "ExecuteChangeSetInput");
   }
 }
 
@@ -2039,7 +2042,7 @@ export interface ExecuteChangeSetOutput extends $MetadataBearer {
 
 export namespace ExecuteChangeSetOutput {
   export function isa(o: any): o is ExecuteChangeSetOutput {
-    return _smithy.isa(o, "ExecuteChangeSetOutput");
+    return __isa(o, "ExecuteChangeSetOutput");
   }
 }
 
@@ -2081,7 +2084,7 @@ export interface Export {
 
 export namespace Export {
   export function isa(o: any): o is Export {
-    return _smithy.isa(o, "Export");
+    return __isa(o, "Export");
   }
 }
 
@@ -2099,7 +2102,7 @@ export interface GetStackPolicyInput {
 
 export namespace GetStackPolicyInput {
   export function isa(o: any): o is GetStackPolicyInput {
-    return _smithy.isa(o, "GetStackPolicyInput");
+    return __isa(o, "GetStackPolicyInput");
   }
 }
 
@@ -2117,7 +2120,7 @@ export interface GetStackPolicyOutput extends $MetadataBearer {
 
 export namespace GetStackPolicyOutput {
   export function isa(o: any): o is GetStackPolicyOutput {
-    return _smithy.isa(o, "GetStackPolicyOutput");
+    return __isa(o, "GetStackPolicyOutput");
   }
 }
 
@@ -2163,7 +2166,7 @@ export interface GetTemplateInput {
 
 export namespace GetTemplateInput {
   export function isa(o: any): o is GetTemplateInput {
-    return _smithy.isa(o, "GetTemplateInput");
+    return __isa(o, "GetTemplateInput");
   }
 }
 
@@ -2191,7 +2194,7 @@ export interface GetTemplateOutput extends $MetadataBearer {
 
 export namespace GetTemplateOutput {
   export function isa(o: any): o is GetTemplateOutput {
-    return _smithy.isa(o, "GetTemplateOutput");
+    return __isa(o, "GetTemplateOutput");
   }
 }
 
@@ -2241,7 +2244,7 @@ export interface GetTemplateSummaryInput {
 
 export namespace GetTemplateSummaryInput {
   export function isa(o: any): o is GetTemplateSummaryInput {
-    return _smithy.isa(o, "GetTemplateSummaryInput");
+    return __isa(o, "GetTemplateSummaryInput");
   }
 }
 
@@ -2312,7 +2315,7 @@ export interface GetTemplateSummaryOutput extends $MetadataBearer {
 
 export namespace GetTemplateSummaryOutput {
   export function isa(o: any): o is GetTemplateSummaryOutput {
-    return _smithy.isa(o, "GetTemplateSummaryOutput");
+    return __isa(o, "GetTemplateSummaryOutput");
   }
 }
 
@@ -2338,7 +2341,7 @@ export enum HandlerErrorCode {
  *          Capabilities parameter.</p>
  */
 export interface InsufficientCapabilitiesException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InsufficientCapabilitiesException";
   $fault: "client";
@@ -2347,7 +2350,7 @@ export interface InsufficientCapabilitiesException
 
 export namespace InsufficientCapabilitiesException {
   export function isa(o: any): o is InsufficientCapabilitiesException {
-    return _smithy.isa(o, "InsufficientCapabilitiesException");
+    return __isa(o, "InsufficientCapabilitiesException");
   }
 }
 
@@ -2357,7 +2360,7 @@ export namespace InsufficientCapabilitiesException {
  *             <code>UPDATE_IN_PROGRESS</code>.</p>
  */
 export interface InvalidChangeSetStatusException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidChangeSetStatusException";
   $fault: "client";
@@ -2366,7 +2369,7 @@ export interface InvalidChangeSetStatusException
 
 export namespace InvalidChangeSetStatusException {
   export function isa(o: any): o is InvalidChangeSetStatusException {
-    return _smithy.isa(o, "InvalidChangeSetStatusException");
+    return __isa(o, "InvalidChangeSetStatusException");
   }
 }
 
@@ -2374,7 +2377,7 @@ export namespace InvalidChangeSetStatusException {
  * <p>Error reserved for use by the <a href="https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/what-is-cloudformation-cli.html">CloudFormation CLI</a>. CloudFormation does not return this error to users.</p>
  */
 export interface InvalidStateTransitionException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidStateTransitionException";
   $fault: "client";
@@ -2383,7 +2386,7 @@ export interface InvalidStateTransitionException
 
 export namespace InvalidStateTransitionException {
   export function isa(o: any): o is InvalidStateTransitionException {
-    return _smithy.isa(o, "InvalidStateTransitionException");
+    return __isa(o, "InvalidStateTransitionException");
   }
 }
 
@@ -2393,7 +2396,7 @@ export namespace InvalidStateTransitionException {
  *          the <i>AWS CloudFormation User Guide</i>.</p>
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -2402,7 +2405,7 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
@@ -2426,7 +2429,7 @@ export interface ListChangeSetsInput {
 
 export namespace ListChangeSetsInput {
   export function isa(o: any): o is ListChangeSetsInput {
-    return _smithy.isa(o, "ListChangeSetsInput");
+    return __isa(o, "ListChangeSetsInput");
   }
 }
 
@@ -2450,7 +2453,7 @@ export interface ListChangeSetsOutput extends $MetadataBearer {
 
 export namespace ListChangeSetsOutput {
   export function isa(o: any): o is ListChangeSetsOutput {
-    return _smithy.isa(o, "ListChangeSetsOutput");
+    return __isa(o, "ListChangeSetsOutput");
   }
 }
 
@@ -2465,7 +2468,7 @@ export interface ListExportsInput {
 
 export namespace ListExportsInput {
   export function isa(o: any): o is ListExportsInput {
-    return _smithy.isa(o, "ListExportsInput");
+    return __isa(o, "ListExportsInput");
   }
 }
 
@@ -2485,7 +2488,7 @@ export interface ListExportsOutput extends $MetadataBearer {
 
 export namespace ListExportsOutput {
   export function isa(o: any): o is ListExportsOutput {
-    return _smithy.isa(o, "ListExportsOutput");
+    return __isa(o, "ListExportsOutput");
   }
 }
 
@@ -2507,7 +2510,7 @@ export interface ListImportsInput {
 
 export namespace ListImportsInput {
   export function isa(o: any): o is ListImportsInput {
-    return _smithy.isa(o, "ListImportsInput");
+    return __isa(o, "ListImportsInput");
   }
 }
 
@@ -2528,7 +2531,7 @@ export interface ListImportsOutput extends $MetadataBearer {
 
 export namespace ListImportsOutput {
   export function isa(o: any): o is ListImportsOutput {
-    return _smithy.isa(o, "ListImportsOutput");
+    return __isa(o, "ListImportsOutput");
   }
 }
 
@@ -2562,7 +2565,7 @@ export interface ListStackResourcesInput {
 
 export namespace ListStackResourcesInput {
   export function isa(o: any): o is ListStackResourcesInput {
-    return _smithy.isa(o, "ListStackResourcesInput");
+    return __isa(o, "ListStackResourcesInput");
   }
 }
 
@@ -2585,7 +2588,7 @@ export interface ListStackResourcesOutput extends $MetadataBearer {
 
 export namespace ListStackResourcesOutput {
   export function isa(o: any): o is ListStackResourcesOutput {
-    return _smithy.isa(o, "ListStackResourcesOutput");
+    return __isa(o, "ListStackResourcesOutput");
   }
 }
 
@@ -2609,7 +2612,7 @@ export interface ListStacksInput {
 
 export namespace ListStacksInput {
   export function isa(o: any): o is ListStacksInput {
-    return _smithy.isa(o, "ListStacksInput");
+    return __isa(o, "ListStacksInput");
   }
 }
 
@@ -2633,7 +2636,7 @@ export interface ListStacksOutput extends $MetadataBearer {
 
 export namespace ListStacksOutput {
   export function isa(o: any): o is ListStacksOutput {
-    return _smithy.isa(o, "ListStacksOutput");
+    return __isa(o, "ListStacksOutput");
   }
 }
 
@@ -2675,7 +2678,7 @@ export interface ListTypeRegistrationsInput {
 
 export namespace ListTypeRegistrationsInput {
   export function isa(o: any): o is ListTypeRegistrationsInput {
-    return _smithy.isa(o, "ListTypeRegistrationsInput");
+    return __isa(o, "ListTypeRegistrationsInput");
   }
 }
 
@@ -2697,7 +2700,7 @@ export interface ListTypeRegistrationsOutput extends $MetadataBearer {
 
 export namespace ListTypeRegistrationsOutput {
   export function isa(o: any): o is ListTypeRegistrationsOutput {
-    return _smithy.isa(o, "ListTypeRegistrationsOutput");
+    return __isa(o, "ListTypeRegistrationsOutput");
   }
 }
 
@@ -2750,7 +2753,7 @@ export interface ListTypeVersionsInput {
 
 export namespace ListTypeVersionsInput {
   export function isa(o: any): o is ListTypeVersionsInput {
-    return _smithy.isa(o, "ListTypeVersionsInput");
+    return __isa(o, "ListTypeVersionsInput");
   }
 }
 
@@ -2769,7 +2772,7 @@ export interface ListTypeVersionsOutput extends $MetadataBearer {
 
 export namespace ListTypeVersionsOutput {
   export function isa(o: any): o is ListTypeVersionsOutput {
-    return _smithy.isa(o, "ListTypeVersionsOutput");
+    return __isa(o, "ListTypeVersionsOutput");
   }
 }
 
@@ -2840,7 +2843,7 @@ export interface ListTypesInput {
 
 export namespace ListTypesInput {
   export function isa(o: any): o is ListTypesInput {
-    return _smithy.isa(o, "ListTypesInput");
+    return __isa(o, "ListTypesInput");
   }
 }
 
@@ -2859,7 +2862,7 @@ export interface ListTypesOutput extends $MetadataBearer {
 
 export namespace ListTypesOutput {
   export function isa(o: any): o is ListTypesOutput {
-    return _smithy.isa(o, "ListTypesOutput");
+    return __isa(o, "ListTypesOutput");
   }
 }
 
@@ -2881,7 +2884,7 @@ export interface LoggingConfig {
 
 export namespace LoggingConfig {
   export function isa(o: any): o is LoggingConfig {
-    return _smithy.isa(o, "LoggingConfig");
+    return __isa(o, "LoggingConfig");
   }
 }
 
@@ -2902,7 +2905,7 @@ export enum OperationStatus {
  * <p>Error reserved for use by the <a href="https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/what-is-cloudformation-cli.html">CloudFormation CLI</a>. CloudFormation does not return this error to users.</p>
  */
 export interface OperationStatusCheckFailedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "OperationStatusCheckFailedException";
   $fault: "client";
@@ -2911,7 +2914,7 @@ export interface OperationStatusCheckFailedException
 
 export namespace OperationStatusCheckFailedException {
   export function isa(o: any): o is OperationStatusCheckFailedException {
-    return _smithy.isa(o, "OperationStatusCheckFailedException");
+    return __isa(o, "OperationStatusCheckFailedException");
   }
 }
 
@@ -2943,7 +2946,7 @@ export interface Output {
 
 export namespace Output {
   export function isa(o: any): o is Output {
-    return _smithy.isa(o, "Output");
+    return __isa(o, "Output");
   }
 }
 
@@ -2981,7 +2984,7 @@ export interface Parameter {
 
 export namespace Parameter {
   export function isa(o: any): o is Parameter {
-    return _smithy.isa(o, "Parameter");
+    return __isa(o, "Parameter");
   }
 }
 
@@ -3000,7 +3003,7 @@ export interface ParameterConstraints {
 
 export namespace ParameterConstraints {
   export function isa(o: any): o is ParameterConstraints {
-    return _smithy.isa(o, "ParameterConstraints");
+    return __isa(o, "ParameterConstraints");
   }
 }
 
@@ -3043,7 +3046,7 @@ export interface ParameterDeclaration {
 
 export namespace ParameterDeclaration {
   export function isa(o: any): o is ParameterDeclaration {
-    return _smithy.isa(o, "ParameterDeclaration");
+    return __isa(o, "ParameterDeclaration");
   }
 }
 
@@ -3068,7 +3071,7 @@ export interface PhysicalResourceIdContextKeyValuePair {
 
 export namespace PhysicalResourceIdContextKeyValuePair {
   export function isa(o: any): o is PhysicalResourceIdContextKeyValuePair {
-    return _smithy.isa(o, "PhysicalResourceIdContextKeyValuePair");
+    return __isa(o, "PhysicalResourceIdContextKeyValuePair");
   }
 }
 
@@ -3123,7 +3126,7 @@ export interface PropertyDifference {
 
 export namespace PropertyDifference {
   export function isa(o: any): o is PropertyDifference {
-    return _smithy.isa(o, "PropertyDifference");
+    return __isa(o, "PropertyDifference");
   }
 }
 
@@ -3172,7 +3175,7 @@ export interface RecordHandlerProgressInput {
 
 export namespace RecordHandlerProgressInput {
   export function isa(o: any): o is RecordHandlerProgressInput {
-    return _smithy.isa(o, "RecordHandlerProgressInput");
+    return __isa(o, "RecordHandlerProgressInput");
   }
 }
 
@@ -3182,7 +3185,7 @@ export interface RecordHandlerProgressOutput extends $MetadataBearer {
 
 export namespace RecordHandlerProgressOutput {
   export function isa(o: any): o is RecordHandlerProgressOutput {
-    return _smithy.isa(o, "RecordHandlerProgressOutput");
+    return __isa(o, "RecordHandlerProgressOutput");
   }
 }
 
@@ -3266,7 +3269,7 @@ export interface RegisterTypeInput {
 
 export namespace RegisterTypeInput {
   export function isa(o: any): o is RegisterTypeInput {
-    return _smithy.isa(o, "RegisterTypeInput");
+    return __isa(o, "RegisterTypeInput");
   }
 }
 
@@ -3283,7 +3286,7 @@ export interface RegisterTypeOutput extends $MetadataBearer {
 
 export namespace RegisterTypeOutput {
   export function isa(o: any): o is RegisterTypeOutput {
-    return _smithy.isa(o, "RegisterTypeOutput");
+    return __isa(o, "RegisterTypeOutput");
   }
 }
 
@@ -3376,7 +3379,7 @@ export interface ResourceChange {
 
 export namespace ResourceChange {
   export function isa(o: any): o is ResourceChange {
-    return _smithy.isa(o, "ResourceChange");
+    return __isa(o, "ResourceChange");
   }
 }
 
@@ -3465,7 +3468,7 @@ export interface ResourceChangeDetail {
 
 export namespace ResourceChangeDetail {
   export function isa(o: any): o is ResourceChangeDetail {
-    return _smithy.isa(o, "ResourceChangeDetail");
+    return __isa(o, "ResourceChangeDetail");
   }
 }
 
@@ -3498,7 +3501,7 @@ export interface ResourceIdentifierSummary {
 
 export namespace ResourceIdentifierSummary {
   export function isa(o: any): o is ResourceIdentifierSummary {
-    return _smithy.isa(o, "ResourceIdentifierSummary");
+    return __isa(o, "ResourceIdentifierSummary");
   }
 }
 
@@ -3557,7 +3560,7 @@ export interface ResourceTargetDefinition {
 
 export namespace ResourceTargetDefinition {
   export function isa(o: any): o is ResourceTargetDefinition {
-    return _smithy.isa(o, "ResourceTargetDefinition");
+    return __isa(o, "ResourceTargetDefinition");
   }
 }
 
@@ -3587,7 +3590,7 @@ export interface ResourceToImport {
 
 export namespace ResourceToImport {
   export function isa(o: any): o is ResourceToImport {
-    return _smithy.isa(o, "ResourceToImport");
+    return __isa(o, "ResourceToImport");
   }
 }
 
@@ -3648,7 +3651,7 @@ export interface RollbackConfiguration {
 
 export namespace RollbackConfiguration {
   export function isa(o: any): o is RollbackConfiguration {
-    return _smithy.isa(o, "RollbackConfiguration");
+    return __isa(o, "RollbackConfiguration");
   }
 }
 
@@ -3675,7 +3678,7 @@ export interface RollbackTrigger {
 
 export namespace RollbackTrigger {
   export function isa(o: any): o is RollbackTrigger {
-    return _smithy.isa(o, "RollbackTrigger");
+    return __isa(o, "RollbackTrigger");
   }
 }
 
@@ -3708,7 +3711,7 @@ export interface SetStackPolicyInput {
 
 export namespace SetStackPolicyInput {
   export function isa(o: any): o is SetStackPolicyInput {
-    return _smithy.isa(o, "SetStackPolicyInput");
+    return __isa(o, "SetStackPolicyInput");
   }
 }
 
@@ -3739,7 +3742,7 @@ export interface SetTypeDefaultVersionInput {
 
 export namespace SetTypeDefaultVersionInput {
   export function isa(o: any): o is SetTypeDefaultVersionInput {
-    return _smithy.isa(o, "SetTypeDefaultVersionInput");
+    return __isa(o, "SetTypeDefaultVersionInput");
   }
 }
 
@@ -3749,7 +3752,7 @@ export interface SetTypeDefaultVersionOutput extends $MetadataBearer {
 
 export namespace SetTypeDefaultVersionOutput {
   export function isa(o: any): o is SetTypeDefaultVersionOutput {
-    return _smithy.isa(o, "SetTypeDefaultVersionOutput");
+    return __isa(o, "SetTypeDefaultVersionOutput");
   }
 }
 
@@ -3787,7 +3790,7 @@ export interface SignalResourceInput {
 
 export namespace SignalResourceInput {
   export function isa(o: any): o is SignalResourceInput {
-    return _smithy.isa(o, "SignalResourceInput");
+    return __isa(o, "SignalResourceInput");
   }
 }
 
@@ -3937,7 +3940,7 @@ export interface Stack {
 
 export namespace Stack {
   export function isa(o: any): o is Stack {
-    return _smithy.isa(o, "Stack");
+    return __isa(o, "Stack");
   }
 }
 
@@ -3992,7 +3995,7 @@ export interface StackDriftInformation {
 
 export namespace StackDriftInformation {
   export function isa(o: any): o is StackDriftInformation {
-    return _smithy.isa(o, "StackDriftInformation");
+    return __isa(o, "StackDriftInformation");
   }
 }
 
@@ -4041,7 +4044,7 @@ export interface StackDriftInformationSummary {
 
 export namespace StackDriftInformationSummary {
   export function isa(o: any): o is StackDriftInformationSummary {
-    return _smithy.isa(o, "StackDriftInformationSummary");
+    return __isa(o, "StackDriftInformationSummary");
   }
 }
 
@@ -4128,7 +4131,7 @@ export interface StackEvent {
 
 export namespace StackEvent {
   export function isa(o: any): o is StackEvent {
-    return _smithy.isa(o, "StackEvent");
+    return __isa(o, "StackEvent");
   }
 }
 
@@ -4195,7 +4198,7 @@ export interface StackResource {
 
 export namespace StackResource {
   export function isa(o: any): o is StackResource {
-    return _smithy.isa(o, "StackResource");
+    return __isa(o, "StackResource");
   }
 }
 
@@ -4269,7 +4272,7 @@ export interface StackResourceDetail {
 
 export namespace StackResourceDetail {
   export function isa(o: any): o is StackResourceDetail {
-    return _smithy.isa(o, "StackResourceDetail");
+    return __isa(o, "StackResourceDetail");
   }
 }
 
@@ -4377,7 +4380,7 @@ export interface StackResourceDrift {
 
 export namespace StackResourceDrift {
   export function isa(o: any): o is StackResourceDrift {
-    return _smithy.isa(o, "StackResourceDrift");
+    return __isa(o, "StackResourceDrift");
   }
 }
 
@@ -4426,7 +4429,7 @@ export interface StackResourceDriftInformation {
 
 export namespace StackResourceDriftInformation {
   export function isa(o: any): o is StackResourceDriftInformation {
-    return _smithy.isa(o, "StackResourceDriftInformation");
+    return __isa(o, "StackResourceDriftInformation");
   }
 }
 
@@ -4477,7 +4480,7 @@ export interface StackResourceDriftInformationSummary {
 
 export namespace StackResourceDriftInformationSummary {
   export function isa(o: any): o is StackResourceDriftInformationSummary {
-    return _smithy.isa(o, "StackResourceDriftInformationSummary");
+    return __isa(o, "StackResourceDriftInformationSummary");
   }
 }
 
@@ -4536,7 +4539,7 @@ export interface StackResourceSummary {
 
 export namespace StackResourceSummary {
   export function isa(o: any): o is StackResourceSummary {
-    return _smithy.isa(o, "StackResourceSummary");
+    return __isa(o, "StackResourceSummary");
   }
 }
 
@@ -4544,7 +4547,7 @@ export namespace StackResourceSummary {
  * <p>The specified stack set doesn't exist.</p>
  */
 export interface StackSetNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "StackSetNotFoundException";
   $fault: "client";
@@ -4553,7 +4556,7 @@ export interface StackSetNotFoundException
 
 export namespace StackSetNotFoundException {
   export function isa(o: any): o is StackSetNotFoundException {
-    return _smithy.isa(o, "StackSetNotFoundException");
+    return __isa(o, "StackSetNotFoundException");
   }
 }
 
@@ -4656,7 +4659,7 @@ export interface StackSummary {
 
 export namespace StackSummary {
   export function isa(o: any): o is StackSummary {
-    return _smithy.isa(o, "StackSummary");
+    return __isa(o, "StackSummary");
   }
 }
 
@@ -4684,7 +4687,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -4717,7 +4720,7 @@ export interface TemplateParameter {
 
 export namespace TemplateParameter {
   export function isa(o: any): o is TemplateParameter {
-    return _smithy.isa(o, "TemplateParameter");
+    return __isa(o, "TemplateParameter");
   }
 }
 
@@ -4730,7 +4733,7 @@ export enum TemplateStage {
  * <p>A client request token already exists.</p>
  */
 export interface TokenAlreadyExistsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TokenAlreadyExistsException";
   $fault: "client";
@@ -4739,7 +4742,7 @@ export interface TokenAlreadyExistsException
 
 export namespace TokenAlreadyExistsException {
   export function isa(o: any): o is TokenAlreadyExistsException {
-    return _smithy.isa(o, "TokenAlreadyExistsException");
+    return __isa(o, "TokenAlreadyExistsException");
   }
 }
 
@@ -4747,7 +4750,7 @@ export namespace TokenAlreadyExistsException {
  * <p>The specified type does not exist in the CloudFormation registry.</p>
  */
 export interface TypeNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TypeNotFoundException";
   $fault: "client";
@@ -4756,7 +4759,7 @@ export interface TypeNotFoundException
 
 export namespace TypeNotFoundException {
   export function isa(o: any): o is TypeNotFoundException {
-    return _smithy.isa(o, "TypeNotFoundException");
+    return __isa(o, "TypeNotFoundException");
   }
 }
 
@@ -4801,7 +4804,7 @@ export interface TypeSummary {
 
 export namespace TypeSummary {
   export function isa(o: any): o is TypeSummary {
-    return _smithy.isa(o, "TypeSummary");
+    return __isa(o, "TypeSummary");
   }
 }
 
@@ -4843,7 +4846,7 @@ export interface TypeVersionSummary {
 
 export namespace TypeVersionSummary {
   export function isa(o: any): o is TypeVersionSummary {
-    return _smithy.isa(o, "TypeVersionSummary");
+    return __isa(o, "TypeVersionSummary");
   }
 }
 
@@ -5110,7 +5113,7 @@ export interface UpdateStackInput {
 
 export namespace UpdateStackInput {
   export function isa(o: any): o is UpdateStackInput {
-    return _smithy.isa(o, "UpdateStackInput");
+    return __isa(o, "UpdateStackInput");
   }
 }
 
@@ -5127,7 +5130,7 @@ export interface UpdateStackOutput extends $MetadataBearer {
 
 export namespace UpdateStackOutput {
   export function isa(o: any): o is UpdateStackOutput {
-    return _smithy.isa(o, "UpdateStackOutput");
+    return __isa(o, "UpdateStackOutput");
   }
 }
 
@@ -5147,7 +5150,7 @@ export interface UpdateTerminationProtectionInput {
 
 export namespace UpdateTerminationProtectionInput {
   export function isa(o: any): o is UpdateTerminationProtectionInput {
-    return _smithy.isa(o, "UpdateTerminationProtectionInput");
+    return __isa(o, "UpdateTerminationProtectionInput");
   }
 }
 
@@ -5161,7 +5164,7 @@ export interface UpdateTerminationProtectionOutput extends $MetadataBearer {
 
 export namespace UpdateTerminationProtectionOutput {
   export function isa(o: any): o is UpdateTerminationProtectionOutput {
-    return _smithy.isa(o, "UpdateTerminationProtectionOutput");
+    return __isa(o, "UpdateTerminationProtectionOutput");
   }
 }
 
@@ -5192,7 +5195,7 @@ export interface ValidateTemplateInput {
 
 export namespace ValidateTemplateInput {
   export function isa(o: any): o is ValidateTemplateInput {
-    return _smithy.isa(o, "ValidateTemplateInput");
+    return __isa(o, "ValidateTemplateInput");
   }
 }
 
@@ -5234,7 +5237,7 @@ export interface ValidateTemplateOutput extends $MetadataBearer {
 
 export namespace ValidateTemplateOutput {
   export function isa(o: any): o is ValidateTemplateOutput {
-    return _smithy.isa(o, "ValidateTemplateOutput");
+    return __isa(o, "ValidateTemplateOutput");
   }
 }
 
@@ -5310,7 +5313,7 @@ export interface AccountGateResult {
 
 export namespace AccountGateResult {
   export function isa(o: any): o is AccountGateResult {
-    return _smithy.isa(o, "AccountGateResult");
+    return __isa(o, "AccountGateResult");
   }
 }
 
@@ -5397,7 +5400,7 @@ export interface CreateStackInstancesInput {
 
 export namespace CreateStackInstancesInput {
   export function isa(o: any): o is CreateStackInstancesInput {
-    return _smithy.isa(o, "CreateStackInstancesInput");
+    return __isa(o, "CreateStackInstancesInput");
   }
 }
 
@@ -5411,7 +5414,7 @@ export interface CreateStackInstancesOutput extends $MetadataBearer {
 
 export namespace CreateStackInstancesOutput {
   export function isa(o: any): o is CreateStackInstancesOutput {
-    return _smithy.isa(o, "CreateStackInstancesOutput");
+    return __isa(o, "CreateStackInstancesOutput");
   }
 }
 
@@ -5601,7 +5604,7 @@ export interface CreateStackSetInput {
 
 export namespace CreateStackSetInput {
   export function isa(o: any): o is CreateStackSetInput {
-    return _smithy.isa(o, "CreateStackSetInput");
+    return __isa(o, "CreateStackSetInput");
   }
 }
 
@@ -5615,7 +5618,7 @@ export interface CreateStackSetOutput extends $MetadataBearer {
 
 export namespace CreateStackSetOutput {
   export function isa(o: any): o is CreateStackSetOutput {
-    return _smithy.isa(o, "CreateStackSetOutput");
+    return __isa(o, "CreateStackSetOutput");
   }
 }
 
@@ -5623,7 +5626,7 @@ export namespace CreateStackSetOutput {
  * <p>The specified resource exists, but has been changed.</p>
  */
 export interface CreatedButModifiedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CreatedButModifiedException";
   $fault: "client";
@@ -5632,7 +5635,7 @@ export interface CreatedButModifiedException
 
 export namespace CreatedButModifiedException {
   export function isa(o: any): o is CreatedButModifiedException {
-    return _smithy.isa(o, "CreatedButModifiedException");
+    return __isa(o, "CreatedButModifiedException");
   }
 }
 
@@ -5682,7 +5685,7 @@ export interface DeleteStackInstancesInput {
 
 export namespace DeleteStackInstancesInput {
   export function isa(o: any): o is DeleteStackInstancesInput {
-    return _smithy.isa(o, "DeleteStackInstancesInput");
+    return __isa(o, "DeleteStackInstancesInput");
   }
 }
 
@@ -5696,7 +5699,7 @@ export interface DeleteStackInstancesOutput extends $MetadataBearer {
 
 export namespace DeleteStackInstancesOutput {
   export function isa(o: any): o is DeleteStackInstancesOutput {
-    return _smithy.isa(o, "DeleteStackInstancesOutput");
+    return __isa(o, "DeleteStackInstancesOutput");
   }
 }
 
@@ -5711,7 +5714,7 @@ export interface DeleteStackSetInput {
 
 export namespace DeleteStackSetInput {
   export function isa(o: any): o is DeleteStackSetInput {
-    return _smithy.isa(o, "DeleteStackSetInput");
+    return __isa(o, "DeleteStackSetInput");
   }
 }
 
@@ -5721,7 +5724,7 @@ export interface DeleteStackSetOutput extends $MetadataBearer {
 
 export namespace DeleteStackSetOutput {
   export function isa(o: any): o is DeleteStackSetOutput {
-    return _smithy.isa(o, "DeleteStackSetOutput");
+    return __isa(o, "DeleteStackSetOutput");
   }
 }
 
@@ -5746,7 +5749,7 @@ export interface DescribeStackInstanceInput {
 
 export namespace DescribeStackInstanceInput {
   export function isa(o: any): o is DescribeStackInstanceInput {
-    return _smithy.isa(o, "DescribeStackInstanceInput");
+    return __isa(o, "DescribeStackInstanceInput");
   }
 }
 
@@ -5760,7 +5763,7 @@ export interface DescribeStackInstanceOutput extends $MetadataBearer {
 
 export namespace DescribeStackInstanceOutput {
   export function isa(o: any): o is DescribeStackInstanceOutput {
-    return _smithy.isa(o, "DescribeStackInstanceOutput");
+    return __isa(o, "DescribeStackInstanceOutput");
   }
 }
 
@@ -5774,7 +5777,7 @@ export interface DescribeStackSetInput {
 
 export namespace DescribeStackSetInput {
   export function isa(o: any): o is DescribeStackSetInput {
-    return _smithy.isa(o, "DescribeStackSetInput");
+    return __isa(o, "DescribeStackSetInput");
   }
 }
 
@@ -5793,7 +5796,7 @@ export interface DescribeStackSetOperationInput {
 
 export namespace DescribeStackSetOperationInput {
   export function isa(o: any): o is DescribeStackSetOperationInput {
-    return _smithy.isa(o, "DescribeStackSetOperationInput");
+    return __isa(o, "DescribeStackSetOperationInput");
   }
 }
 
@@ -5807,7 +5810,7 @@ export interface DescribeStackSetOperationOutput extends $MetadataBearer {
 
 export namespace DescribeStackSetOperationOutput {
   export function isa(o: any): o is DescribeStackSetOperationOutput {
-    return _smithy.isa(o, "DescribeStackSetOperationOutput");
+    return __isa(o, "DescribeStackSetOperationOutput");
   }
 }
 
@@ -5821,7 +5824,7 @@ export interface DescribeStackSetOutput extends $MetadataBearer {
 
 export namespace DescribeStackSetOutput {
   export function isa(o: any): o is DescribeStackSetOutput {
-    return _smithy.isa(o, "DescribeStackSetOutput");
+    return __isa(o, "DescribeStackSetOutput");
   }
 }
 
@@ -5849,7 +5852,7 @@ export interface DetectStackSetDriftInput {
 
 export namespace DetectStackSetDriftInput {
   export function isa(o: any): o is DetectStackSetDriftInput {
-    return _smithy.isa(o, "DetectStackSetDriftInput");
+    return __isa(o, "DetectStackSetDriftInput");
   }
 }
 
@@ -5866,7 +5869,7 @@ export interface DetectStackSetDriftOutput extends $MetadataBearer {
 
 export namespace DetectStackSetDriftOutput {
   export function isa(o: any): o is DetectStackSetDriftOutput {
-    return _smithy.isa(o, "DetectStackSetDriftOutput");
+    return __isa(o, "DetectStackSetDriftOutput");
   }
 }
 
@@ -5874,7 +5877,7 @@ export namespace DetectStackSetDriftOutput {
  * <p>The specified operation isn't valid.</p>
  */
 export interface InvalidOperationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidOperationException";
   $fault: "client";
@@ -5883,7 +5886,7 @@ export interface InvalidOperationException
 
 export namespace InvalidOperationException {
   export function isa(o: any): o is InvalidOperationException {
-    return _smithy.isa(o, "InvalidOperationException");
+    return __isa(o, "InvalidOperationException");
   }
 }
 
@@ -5925,7 +5928,7 @@ export interface ListStackInstancesInput {
 
 export namespace ListStackInstancesInput {
   export function isa(o: any): o is ListStackInstancesInput {
-    return _smithy.isa(o, "ListStackInstancesInput");
+    return __isa(o, "ListStackInstancesInput");
   }
 }
 
@@ -5949,7 +5952,7 @@ export interface ListStackInstancesOutput extends $MetadataBearer {
 
 export namespace ListStackInstancesOutput {
   export function isa(o: any): o is ListStackInstancesOutput {
-    return _smithy.isa(o, "ListStackInstancesOutput");
+    return __isa(o, "ListStackInstancesOutput");
   }
 }
 
@@ -5987,7 +5990,7 @@ export interface ListStackSetOperationResultsInput {
 
 export namespace ListStackSetOperationResultsInput {
   export function isa(o: any): o is ListStackSetOperationResultsInput {
-    return _smithy.isa(o, "ListStackSetOperationResultsInput");
+    return __isa(o, "ListStackSetOperationResultsInput");
   }
 }
 
@@ -6011,7 +6014,7 @@ export interface ListStackSetOperationResultsOutput extends $MetadataBearer {
 
 export namespace ListStackSetOperationResultsOutput {
   export function isa(o: any): o is ListStackSetOperationResultsOutput {
-    return _smithy.isa(o, "ListStackSetOperationResultsOutput");
+    return __isa(o, "ListStackSetOperationResultsOutput");
   }
 }
 
@@ -6044,7 +6047,7 @@ export interface ListStackSetOperationsInput {
 
 export namespace ListStackSetOperationsInput {
   export function isa(o: any): o is ListStackSetOperationsInput {
-    return _smithy.isa(o, "ListStackSetOperationsInput");
+    return __isa(o, "ListStackSetOperationsInput");
   }
 }
 
@@ -6067,7 +6070,7 @@ export interface ListStackSetOperationsOutput extends $MetadataBearer {
 
 export namespace ListStackSetOperationsOutput {
   export function isa(o: any): o is ListStackSetOperationsOutput {
-    return _smithy.isa(o, "ListStackSetOperationsOutput");
+    return __isa(o, "ListStackSetOperationsOutput");
   }
 }
 
@@ -6100,7 +6103,7 @@ export interface ListStackSetsInput {
 
 export namespace ListStackSetsInput {
   export function isa(o: any): o is ListStackSetsInput {
-    return _smithy.isa(o, "ListStackSetsInput");
+    return __isa(o, "ListStackSetsInput");
   }
 }
 
@@ -6124,7 +6127,7 @@ export interface ListStackSetsOutput extends $MetadataBearer {
 
 export namespace ListStackSetsOutput {
   export function isa(o: any): o is ListStackSetsOutput {
-    return _smithy.isa(o, "ListStackSetsOutput");
+    return __isa(o, "ListStackSetsOutput");
   }
 }
 
@@ -6132,7 +6135,7 @@ export namespace ListStackSetsOutput {
  * <p>The specified name is already in use.</p>
  */
 export interface NameAlreadyExistsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "NameAlreadyExistsException";
   $fault: "client";
@@ -6141,7 +6144,7 @@ export interface NameAlreadyExistsException
 
 export namespace NameAlreadyExistsException {
   export function isa(o: any): o is NameAlreadyExistsException {
-    return _smithy.isa(o, "NameAlreadyExistsException");
+    return __isa(o, "NameAlreadyExistsException");
   }
 }
 
@@ -6149,7 +6152,7 @@ export namespace NameAlreadyExistsException {
  * <p>The specified operation ID already exists.</p>
  */
 export interface OperationIdAlreadyExistsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "OperationIdAlreadyExistsException";
   $fault: "client";
@@ -6158,7 +6161,7 @@ export interface OperationIdAlreadyExistsException
 
 export namespace OperationIdAlreadyExistsException {
   export function isa(o: any): o is OperationIdAlreadyExistsException {
-    return _smithy.isa(o, "OperationIdAlreadyExistsException");
+    return __isa(o, "OperationIdAlreadyExistsException");
   }
 }
 
@@ -6167,7 +6170,7 @@ export namespace OperationIdAlreadyExistsException {
  *          be performed for a stack set at a given time.</p>
  */
 export interface OperationInProgressException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "OperationInProgressException";
   $fault: "client";
@@ -6176,7 +6179,7 @@ export interface OperationInProgressException
 
 export namespace OperationInProgressException {
   export function isa(o: any): o is OperationInProgressException {
-    return _smithy.isa(o, "OperationInProgressException");
+    return __isa(o, "OperationInProgressException");
   }
 }
 
@@ -6184,7 +6187,7 @@ export namespace OperationInProgressException {
  * <p>The specified ID refers to an operation that doesn't exist.</p>
  */
 export interface OperationNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "OperationNotFoundException";
   $fault: "client";
@@ -6193,7 +6196,7 @@ export interface OperationNotFoundException
 
 export namespace OperationNotFoundException {
   export function isa(o: any): o is OperationNotFoundException {
-    return _smithy.isa(o, "OperationNotFoundException");
+    return __isa(o, "OperationNotFoundException");
   }
 }
 
@@ -6317,7 +6320,7 @@ export interface StackInstance {
 
 export namespace StackInstance {
   export function isa(o: any): o is StackInstance {
-    return _smithy.isa(o, "StackInstance");
+    return __isa(o, "StackInstance");
   }
 }
 
@@ -6325,7 +6328,7 @@ export namespace StackInstance {
  * <p>The specified stack instance doesn't exist.</p>
  */
 export interface StackInstanceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "StackInstanceNotFoundException";
   $fault: "client";
@@ -6334,7 +6337,7 @@ export interface StackInstanceNotFoundException
 
 export namespace StackInstanceNotFoundException {
   export function isa(o: any): o is StackInstanceNotFoundException {
-    return _smithy.isa(o, "StackInstanceNotFoundException");
+    return __isa(o, "StackInstanceNotFoundException");
   }
 }
 
@@ -6449,7 +6452,7 @@ export interface StackInstanceSummary {
 
 export namespace StackInstanceSummary {
   export function isa(o: any): o is StackInstanceSummary {
-    return _smithy.isa(o, "StackInstanceSummary");
+    return __isa(o, "StackInstanceSummary");
   }
 }
 
@@ -6541,7 +6544,7 @@ export interface StackSet {
 
 export namespace StackSet {
   export function isa(o: any): o is StackSet {
-    return _smithy.isa(o, "StackSet");
+    return __isa(o, "StackSet");
   }
 }
 
@@ -6668,7 +6671,7 @@ export interface StackSetDriftDetectionDetails {
 
 export namespace StackSetDriftDetectionDetails {
   export function isa(o: any): o is StackSetDriftDetectionDetails {
-    return _smithy.isa(o, "StackSetDriftDetectionDetails");
+    return __isa(o, "StackSetDriftDetectionDetails");
   }
 }
 
@@ -6692,7 +6695,7 @@ export enum StackSetDriftStatus {
  *          set.</p>
  */
 export interface StackSetNotEmptyException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "StackSetNotEmptyException";
   $fault: "client";
@@ -6701,7 +6704,7 @@ export interface StackSetNotEmptyException
 
 export namespace StackSetNotEmptyException {
   export function isa(o: any): o is StackSetNotEmptyException {
-    return _smithy.isa(o, "StackSetNotEmptyException");
+    return __isa(o, "StackSetNotEmptyException");
   }
 }
 
@@ -6826,7 +6829,7 @@ export interface StackSetOperation {
 
 export namespace StackSetOperation {
   export function isa(o: any): o is StackSetOperation {
-    return _smithy.isa(o, "StackSetOperation");
+    return __isa(o, "StackSetOperation");
   }
 }
 
@@ -6900,7 +6903,7 @@ export interface StackSetOperationPreferences {
 
 export namespace StackSetOperationPreferences {
   export function isa(o: any): o is StackSetOperationPreferences {
-    return _smithy.isa(o, "StackSetOperationPreferences");
+    return __isa(o, "StackSetOperationPreferences");
   }
 }
 
@@ -6977,7 +6980,7 @@ export interface StackSetOperationResultSummary {
 
 export namespace StackSetOperationResultSummary {
   export function isa(o: any): o is StackSetOperationResultSummary {
-    return _smithy.isa(o, "StackSetOperationResultSummary");
+    return __isa(o, "StackSetOperationResultSummary");
   }
 }
 
@@ -7063,7 +7066,7 @@ export interface StackSetOperationSummary {
 
 export namespace StackSetOperationSummary {
   export function isa(o: any): o is StackSetOperationSummary {
-    return _smithy.isa(o, "StackSetOperationSummary");
+    return __isa(o, "StackSetOperationSummary");
   }
 }
 
@@ -7136,7 +7139,7 @@ export interface StackSetSummary {
 
 export namespace StackSetSummary {
   export function isa(o: any): o is StackSetSummary {
-    return _smithy.isa(o, "StackSetSummary");
+    return __isa(o, "StackSetSummary");
   }
 }
 
@@ -7145,7 +7148,7 @@ export namespace StackSetSummary {
  *          was performed. </p>
  */
 export interface StaleRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "StaleRequestException";
   $fault: "client";
@@ -7154,7 +7157,7 @@ export interface StaleRequestException
 
 export namespace StaleRequestException {
   export function isa(o: any): o is StaleRequestException {
-    return _smithy.isa(o, "StaleRequestException");
+    return __isa(o, "StaleRequestException");
   }
 }
 
@@ -7174,7 +7177,7 @@ export interface StopStackSetOperationInput {
 
 export namespace StopStackSetOperationInput {
   export function isa(o: any): o is StopStackSetOperationInput {
-    return _smithy.isa(o, "StopStackSetOperationInput");
+    return __isa(o, "StopStackSetOperationInput");
   }
 }
 
@@ -7184,7 +7187,7 @@ export interface StopStackSetOperationOutput extends $MetadataBearer {
 
 export namespace StopStackSetOperationOutput {
   export function isa(o: any): o is StopStackSetOperationOutput {
-    return _smithy.isa(o, "StopStackSetOperationOutput");
+    return __isa(o, "StopStackSetOperationOutput");
   }
 }
 
@@ -7275,7 +7278,7 @@ export interface UpdateStackInstancesInput {
 
 export namespace UpdateStackInstancesInput {
   export function isa(o: any): o is UpdateStackInstancesInput {
-    return _smithy.isa(o, "UpdateStackInstancesInput");
+    return __isa(o, "UpdateStackInstancesInput");
   }
 }
 
@@ -7289,7 +7292,7 @@ export interface UpdateStackInstancesOutput extends $MetadataBearer {
 
 export namespace UpdateStackInstancesOutput {
   export function isa(o: any): o is UpdateStackInstancesOutput {
-    return _smithy.isa(o, "UpdateStackInstancesOutput");
+    return __isa(o, "UpdateStackInstancesOutput");
   }
 }
 
@@ -7551,7 +7554,7 @@ export interface UpdateStackSetInput {
 
 export namespace UpdateStackSetInput {
   export function isa(o: any): o is UpdateStackSetInput {
-    return _smithy.isa(o, "UpdateStackSetInput");
+    return __isa(o, "UpdateStackSetInput");
   }
 }
 
@@ -7565,6 +7568,6 @@ export interface UpdateStackSetOutput extends $MetadataBearer {
 
 export namespace UpdateStackSetOutput {
   export function isa(o: any): o is UpdateStackSetOutput {
-    return _smithy.isa(o, "UpdateStackSetOutput");
+    return __isa(o, "UpdateStackSetOutput");
   }
 }

--- a/clients/client-cloudformation/protocols/Aws_query.ts
+++ b/clients/client-cloudformation/protocols/Aws_query.ts
@@ -1320,6 +1320,7 @@ export async function deserializeAws_queryCancelUpdateStackCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_queryCancelUpdateStackCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: CancelUpdateStackCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1640,6 +1641,7 @@ export async function deserializeAws_queryDeleteStackCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_queryDeleteStackCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteStackCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -3271,6 +3273,7 @@ export async function deserializeAws_querySetStackPolicyCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_querySetStackPolicyCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: SetStackPolicyCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -3382,6 +3385,7 @@ export async function deserializeAws_querySignalResourceCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_querySignalResourceCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: SignalResourceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };

--- a/clients/client-cloudfront/models/index.ts
+++ b/clients/client-cloudfront/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -36,7 +39,7 @@ export interface ActiveTrustedSigners {
 
 export namespace ActiveTrustedSigners {
   export function isa(o: any): o is ActiveTrustedSigners {
-    return _smithy.isa(o, "ActiveTrustedSigners");
+    return __isa(o, "ActiveTrustedSigners");
   }
 }
 
@@ -84,7 +87,7 @@ export interface AliasICPRecordal {
 
 export namespace AliasICPRecordal {
   export function isa(o: any): o is AliasICPRecordal {
-    return _smithy.isa(o, "AliasICPRecordal");
+    return __isa(o, "AliasICPRecordal");
   }
 }
 
@@ -109,7 +112,7 @@ export interface Aliases {
 
 export namespace Aliases {
   export function isa(o: any): o is Aliases {
-    return _smithy.isa(o, "Aliases");
+    return __isa(o, "Aliases");
   }
 }
 
@@ -171,7 +174,7 @@ export interface AllowedMethods {
 
 export namespace AllowedMethods {
   export function isa(o: any): o is AllowedMethods {
-    return _smithy.isa(o, "AllowedMethods");
+    return __isa(o, "AllowedMethods");
   }
 }
 
@@ -370,7 +373,7 @@ export interface CacheBehavior {
 
 export namespace CacheBehavior {
   export function isa(o: any): o is CacheBehavior {
-    return _smithy.isa(o, "CacheBehavior");
+    return __isa(o, "CacheBehavior");
   }
 }
 
@@ -394,7 +397,7 @@ export interface CacheBehaviors {
 
 export namespace CacheBehaviors {
   export function isa(o: any): o is CacheBehaviors {
-    return _smithy.isa(o, "CacheBehaviors");
+    return __isa(o, "CacheBehaviors");
   }
 }
 
@@ -433,7 +436,7 @@ export interface CachedMethods {
 
 export namespace CachedMethods {
   export function isa(o: any): o is CachedMethods {
-    return _smithy.isa(o, "CachedMethods");
+    return __isa(o, "CachedMethods");
   }
 }
 
@@ -464,7 +467,7 @@ export interface CloudFrontOriginAccessIdentity {
 
 export namespace CloudFrontOriginAccessIdentity {
   export function isa(o: any): o is CloudFrontOriginAccessIdentity {
-    return _smithy.isa(o, "CloudFrontOriginAccessIdentity");
+    return __isa(o, "CloudFrontOriginAccessIdentity");
   }
 }
 
@@ -499,7 +502,7 @@ export interface CloudFrontOriginAccessIdentityConfig {
 
 export namespace CloudFrontOriginAccessIdentityConfig {
   export function isa(o: any): o is CloudFrontOriginAccessIdentityConfig {
-    return _smithy.isa(o, "CloudFrontOriginAccessIdentityConfig");
+    return __isa(o, "CloudFrontOriginAccessIdentityConfig");
   }
 }
 
@@ -559,7 +562,7 @@ export interface CloudFrontOriginAccessIdentityList {
 
 export namespace CloudFrontOriginAccessIdentityList {
   export function isa(o: any): o is CloudFrontOriginAccessIdentityList {
-    return _smithy.isa(o, "CloudFrontOriginAccessIdentityList");
+    return __isa(o, "CloudFrontOriginAccessIdentityList");
   }
 }
 
@@ -589,7 +592,7 @@ export interface CloudFrontOriginAccessIdentitySummary {
 
 export namespace CloudFrontOriginAccessIdentitySummary {
   export function isa(o: any): o is CloudFrontOriginAccessIdentitySummary {
-    return _smithy.isa(o, "CloudFrontOriginAccessIdentitySummary");
+    return __isa(o, "CloudFrontOriginAccessIdentitySummary");
   }
 }
 
@@ -616,7 +619,7 @@ export interface ContentTypeProfile {
 
 export namespace ContentTypeProfile {
   export function isa(o: any): o is ContentTypeProfile {
-    return _smithy.isa(o, "ContentTypeProfile");
+    return __isa(o, "ContentTypeProfile");
   }
 }
 
@@ -641,7 +644,7 @@ export interface ContentTypeProfileConfig {
 
 export namespace ContentTypeProfileConfig {
   export function isa(o: any): o is ContentTypeProfileConfig {
-    return _smithy.isa(o, "ContentTypeProfileConfig");
+    return __isa(o, "ContentTypeProfileConfig");
   }
 }
 
@@ -663,7 +666,7 @@ export interface ContentTypeProfiles {
 
 export namespace ContentTypeProfiles {
   export function isa(o: any): o is ContentTypeProfiles {
-    return _smithy.isa(o, "ContentTypeProfiles");
+    return __isa(o, "ContentTypeProfiles");
   }
 }
 
@@ -690,7 +693,7 @@ export interface CookieNames {
 
 export namespace CookieNames {
   export function isa(o: any): o is CookieNames {
-    return _smithy.isa(o, "CookieNames");
+    return __isa(o, "CookieNames");
   }
 }
 
@@ -728,7 +731,7 @@ export interface CookiePreference {
 
 export namespace CookiePreference {
   export function isa(o: any): o is CookiePreference {
-    return _smithy.isa(o, "CookiePreference");
+    return __isa(o, "CookiePreference");
   }
 }
 
@@ -753,7 +756,7 @@ export namespace CreateCloudFrontOriginAccessIdentityRequest {
   export function isa(
     o: any
   ): o is CreateCloudFrontOriginAccessIdentityRequest {
-    return _smithy.isa(o, "CreateCloudFrontOriginAccessIdentityRequest");
+    return __isa(o, "CreateCloudFrontOriginAccessIdentityRequest");
   }
 }
 
@@ -782,7 +785,7 @@ export interface CreateCloudFrontOriginAccessIdentityResult
 
 export namespace CreateCloudFrontOriginAccessIdentityResult {
   export function isa(o: any): o is CreateCloudFrontOriginAccessIdentityResult {
-    return _smithy.isa(o, "CreateCloudFrontOriginAccessIdentityResult");
+    return __isa(o, "CreateCloudFrontOriginAccessIdentityResult");
   }
 }
 
@@ -799,7 +802,7 @@ export interface CreateDistributionRequest {
 
 export namespace CreateDistributionRequest {
   export function isa(o: any): o is CreateDistributionRequest {
-    return _smithy.isa(o, "CreateDistributionRequest");
+    return __isa(o, "CreateDistributionRequest");
   }
 }
 
@@ -827,7 +830,7 @@ export interface CreateDistributionResult extends $MetadataBearer {
 
 export namespace CreateDistributionResult {
   export function isa(o: any): o is CreateDistributionResult {
-    return _smithy.isa(o, "CreateDistributionResult");
+    return __isa(o, "CreateDistributionResult");
   }
 }
 
@@ -844,7 +847,7 @@ export interface CreateDistributionWithTagsRequest {
 
 export namespace CreateDistributionWithTagsRequest {
   export function isa(o: any): o is CreateDistributionWithTagsRequest {
-    return _smithy.isa(o, "CreateDistributionWithTagsRequest");
+    return __isa(o, "CreateDistributionWithTagsRequest");
   }
 }
 
@@ -873,7 +876,7 @@ export interface CreateDistributionWithTagsResult extends $MetadataBearer {
 
 export namespace CreateDistributionWithTagsResult {
   export function isa(o: any): o is CreateDistributionWithTagsResult {
-    return _smithy.isa(o, "CreateDistributionWithTagsResult");
+    return __isa(o, "CreateDistributionWithTagsResult");
   }
 }
 
@@ -887,7 +890,7 @@ export interface CreateFieldLevelEncryptionConfigRequest {
 
 export namespace CreateFieldLevelEncryptionConfigRequest {
   export function isa(o: any): o is CreateFieldLevelEncryptionConfigRequest {
-    return _smithy.isa(o, "CreateFieldLevelEncryptionConfigRequest");
+    return __isa(o, "CreateFieldLevelEncryptionConfigRequest");
   }
 }
 
@@ -913,7 +916,7 @@ export interface CreateFieldLevelEncryptionConfigResult
 
 export namespace CreateFieldLevelEncryptionConfigResult {
   export function isa(o: any): o is CreateFieldLevelEncryptionConfigResult {
-    return _smithy.isa(o, "CreateFieldLevelEncryptionConfigResult");
+    return __isa(o, "CreateFieldLevelEncryptionConfigResult");
   }
 }
 
@@ -929,7 +932,7 @@ export interface CreateFieldLevelEncryptionProfileRequest {
 
 export namespace CreateFieldLevelEncryptionProfileRequest {
   export function isa(o: any): o is CreateFieldLevelEncryptionProfileRequest {
-    return _smithy.isa(o, "CreateFieldLevelEncryptionProfileRequest");
+    return __isa(o, "CreateFieldLevelEncryptionProfileRequest");
   }
 }
 
@@ -955,7 +958,7 @@ export interface CreateFieldLevelEncryptionProfileResult
 
 export namespace CreateFieldLevelEncryptionProfileResult {
   export function isa(o: any): o is CreateFieldLevelEncryptionProfileResult {
-    return _smithy.isa(o, "CreateFieldLevelEncryptionProfileResult");
+    return __isa(o, "CreateFieldLevelEncryptionProfileResult");
   }
 }
 
@@ -977,7 +980,7 @@ export interface CreateInvalidationRequest {
 
 export namespace CreateInvalidationRequest {
   export function isa(o: any): o is CreateInvalidationRequest {
-    return _smithy.isa(o, "CreateInvalidationRequest");
+    return __isa(o, "CreateInvalidationRequest");
   }
 }
 
@@ -1000,7 +1003,7 @@ export interface CreateInvalidationResult extends $MetadataBearer {
 
 export namespace CreateInvalidationResult {
   export function isa(o: any): o is CreateInvalidationResult {
-    return _smithy.isa(o, "CreateInvalidationResult");
+    return __isa(o, "CreateInvalidationResult");
   }
 }
 
@@ -1014,7 +1017,7 @@ export interface CreatePublicKeyRequest {
 
 export namespace CreatePublicKeyRequest {
   export function isa(o: any): o is CreatePublicKeyRequest {
-    return _smithy.isa(o, "CreatePublicKeyRequest");
+    return __isa(o, "CreatePublicKeyRequest");
   }
 }
 
@@ -1039,7 +1042,7 @@ export interface CreatePublicKeyResult extends $MetadataBearer {
 
 export namespace CreatePublicKeyResult {
   export function isa(o: any): o is CreatePublicKeyResult {
-    return _smithy.isa(o, "CreatePublicKeyResult");
+    return __isa(o, "CreatePublicKeyResult");
   }
 }
 
@@ -1056,7 +1059,7 @@ export interface CreateStreamingDistributionRequest {
 
 export namespace CreateStreamingDistributionRequest {
   export function isa(o: any): o is CreateStreamingDistributionRequest {
-    return _smithy.isa(o, "CreateStreamingDistributionRequest");
+    return __isa(o, "CreateStreamingDistributionRequest");
   }
 }
 
@@ -1085,7 +1088,7 @@ export interface CreateStreamingDistributionResult extends $MetadataBearer {
 
 export namespace CreateStreamingDistributionResult {
   export function isa(o: any): o is CreateStreamingDistributionResult {
-    return _smithy.isa(o, "CreateStreamingDistributionResult");
+    return __isa(o, "CreateStreamingDistributionResult");
   }
 }
 
@@ -1104,7 +1107,7 @@ export interface CreateStreamingDistributionWithTagsRequest {
 
 export namespace CreateStreamingDistributionWithTagsRequest {
   export function isa(o: any): o is CreateStreamingDistributionWithTagsRequest {
-    return _smithy.isa(o, "CreateStreamingDistributionWithTagsRequest");
+    return __isa(o, "CreateStreamingDistributionWithTagsRequest");
   }
 }
 
@@ -1134,7 +1137,7 @@ export interface CreateStreamingDistributionWithTagsResult
 
 export namespace CreateStreamingDistributionWithTagsResult {
   export function isa(o: any): o is CreateStreamingDistributionWithTagsResult {
-    return _smithy.isa(o, "CreateStreamingDistributionWithTagsResult");
+    return __isa(o, "CreateStreamingDistributionWithTagsResult");
   }
 }
 
@@ -1225,7 +1228,7 @@ export interface CustomErrorResponse {
 
 export namespace CustomErrorResponse {
   export function isa(o: any): o is CustomErrorResponse {
-    return _smithy.isa(o, "CustomErrorResponse");
+    return __isa(o, "CustomErrorResponse");
   }
 }
 
@@ -1262,7 +1265,7 @@ export interface CustomErrorResponses {
 
 export namespace CustomErrorResponses {
   export function isa(o: any): o is CustomErrorResponses {
-    return _smithy.isa(o, "CustomErrorResponses");
+    return __isa(o, "CustomErrorResponses");
   }
 }
 
@@ -1287,7 +1290,7 @@ export interface CustomHeaders {
 
 export namespace CustomHeaders {
   export function isa(o: any): o is CustomHeaders {
-    return _smithy.isa(o, "CustomHeaders");
+    return __isa(o, "CustomHeaders");
   }
 }
 
@@ -1335,7 +1338,7 @@ export interface CustomOriginConfig {
 
 export namespace CustomOriginConfig {
   export function isa(o: any): o is CustomOriginConfig {
-    return _smithy.isa(o, "CustomOriginConfig");
+    return __isa(o, "CustomOriginConfig");
   }
 }
 
@@ -1500,7 +1503,7 @@ export interface DefaultCacheBehavior {
 
 export namespace DefaultCacheBehavior {
   export function isa(o: any): o is DefaultCacheBehavior {
-    return _smithy.isa(o, "DefaultCacheBehavior");
+    return __isa(o, "DefaultCacheBehavior");
   }
 }
 
@@ -1525,7 +1528,7 @@ export namespace DeleteCloudFrontOriginAccessIdentityRequest {
   export function isa(
     o: any
   ): o is DeleteCloudFrontOriginAccessIdentityRequest {
-    return _smithy.isa(o, "DeleteCloudFrontOriginAccessIdentityRequest");
+    return __isa(o, "DeleteCloudFrontOriginAccessIdentityRequest");
   }
 }
 
@@ -1594,7 +1597,7 @@ export interface DeleteDistributionRequest {
 
 export namespace DeleteDistributionRequest {
   export function isa(o: any): o is DeleteDistributionRequest {
-    return _smithy.isa(o, "DeleteDistributionRequest");
+    return __isa(o, "DeleteDistributionRequest");
   }
 }
 
@@ -1614,7 +1617,7 @@ export interface DeleteFieldLevelEncryptionConfigRequest {
 
 export namespace DeleteFieldLevelEncryptionConfigRequest {
   export function isa(o: any): o is DeleteFieldLevelEncryptionConfigRequest {
-    return _smithy.isa(o, "DeleteFieldLevelEncryptionConfigRequest");
+    return __isa(o, "DeleteFieldLevelEncryptionConfigRequest");
   }
 }
 
@@ -1634,7 +1637,7 @@ export interface DeleteFieldLevelEncryptionProfileRequest {
 
 export namespace DeleteFieldLevelEncryptionProfileRequest {
   export function isa(o: any): o is DeleteFieldLevelEncryptionProfileRequest {
-    return _smithy.isa(o, "DeleteFieldLevelEncryptionProfileRequest");
+    return __isa(o, "DeleteFieldLevelEncryptionProfileRequest");
   }
 }
 
@@ -1654,7 +1657,7 @@ export interface DeletePublicKeyRequest {
 
 export namespace DeletePublicKeyRequest {
   export function isa(o: any): o is DeletePublicKeyRequest {
-    return _smithy.isa(o, "DeletePublicKeyRequest");
+    return __isa(o, "DeletePublicKeyRequest");
   }
 }
 
@@ -1677,7 +1680,7 @@ export interface DeleteStreamingDistributionRequest {
 
 export namespace DeleteStreamingDistributionRequest {
   export function isa(o: any): o is DeleteStreamingDistributionRequest {
-    return _smithy.isa(o, "DeleteStreamingDistributionRequest");
+    return __isa(o, "DeleteStreamingDistributionRequest");
   }
 }
 
@@ -1752,7 +1755,7 @@ export interface Distribution {
 
 export namespace Distribution {
   export function isa(o: any): o is Distribution {
-    return _smithy.isa(o, "Distribution");
+    return __isa(o, "Distribution");
   }
 }
 
@@ -1958,7 +1961,7 @@ export interface DistributionConfig {
 
 export namespace DistributionConfig {
   export function isa(o: any): o is DistributionConfig {
-    return _smithy.isa(o, "DistributionConfig");
+    return __isa(o, "DistributionConfig");
   }
 }
 
@@ -1981,7 +1984,7 @@ export interface DistributionConfigWithTags {
 
 export namespace DistributionConfigWithTags {
   export function isa(o: any): o is DistributionConfigWithTags {
-    return _smithy.isa(o, "DistributionConfigWithTags");
+    return __isa(o, "DistributionConfigWithTags");
   }
 }
 
@@ -2028,7 +2031,7 @@ export interface DistributionList {
 
 export namespace DistributionList {
   export function isa(o: any): o is DistributionList {
-    return _smithy.isa(o, "DistributionList");
+    return __isa(o, "DistributionList");
   }
 }
 
@@ -2162,7 +2165,7 @@ export interface DistributionSummary {
 
 export namespace DistributionSummary {
   export function isa(o: any): o is DistributionSummary {
-    return _smithy.isa(o, "DistributionSummary");
+    return __isa(o, "DistributionSummary");
   }
 }
 
@@ -2184,7 +2187,7 @@ export interface EncryptionEntities {
 
 export namespace EncryptionEntities {
   export function isa(o: any): o is EncryptionEntities {
-    return _smithy.isa(o, "EncryptionEntities");
+    return __isa(o, "EncryptionEntities");
   }
 }
 
@@ -2215,7 +2218,7 @@ export interface EncryptionEntity {
 
 export namespace EncryptionEntity {
   export function isa(o: any): o is EncryptionEntity {
-    return _smithy.isa(o, "EncryptionEntity");
+    return __isa(o, "EncryptionEntity");
   }
 }
 
@@ -2249,7 +2252,7 @@ export interface FieldLevelEncryption {
 
 export namespace FieldLevelEncryption {
   export function isa(o: any): o is FieldLevelEncryption {
-    return _smithy.isa(o, "FieldLevelEncryption");
+    return __isa(o, "FieldLevelEncryption");
   }
 }
 
@@ -2283,7 +2286,7 @@ export interface FieldLevelEncryptionConfig {
 
 export namespace FieldLevelEncryptionConfig {
   export function isa(o: any): o is FieldLevelEncryptionConfig {
-    return _smithy.isa(o, "FieldLevelEncryptionConfig");
+    return __isa(o, "FieldLevelEncryptionConfig");
   }
 }
 
@@ -2317,7 +2320,7 @@ export interface FieldLevelEncryptionList {
 
 export namespace FieldLevelEncryptionList {
   export function isa(o: any): o is FieldLevelEncryptionList {
-    return _smithy.isa(o, "FieldLevelEncryptionList");
+    return __isa(o, "FieldLevelEncryptionList");
   }
 }
 
@@ -2347,7 +2350,7 @@ export interface FieldLevelEncryptionProfile {
 
 export namespace FieldLevelEncryptionProfile {
   export function isa(o: any): o is FieldLevelEncryptionProfile {
-    return _smithy.isa(o, "FieldLevelEncryptionProfile");
+    return __isa(o, "FieldLevelEncryptionProfile");
   }
 }
 
@@ -2380,7 +2383,7 @@ export interface FieldLevelEncryptionProfileConfig {
 
 export namespace FieldLevelEncryptionProfileConfig {
   export function isa(o: any): o is FieldLevelEncryptionProfileConfig {
-    return _smithy.isa(o, "FieldLevelEncryptionProfileConfig");
+    return __isa(o, "FieldLevelEncryptionProfileConfig");
   }
 }
 
@@ -2414,7 +2417,7 @@ export interface FieldLevelEncryptionProfileList {
 
 export namespace FieldLevelEncryptionProfileList {
   export function isa(o: any): o is FieldLevelEncryptionProfileList {
-    return _smithy.isa(o, "FieldLevelEncryptionProfileList");
+    return __isa(o, "FieldLevelEncryptionProfileList");
   }
 }
 
@@ -2452,7 +2455,7 @@ export interface FieldLevelEncryptionProfileSummary {
 
 export namespace FieldLevelEncryptionProfileSummary {
   export function isa(o: any): o is FieldLevelEncryptionProfileSummary {
-    return _smithy.isa(o, "FieldLevelEncryptionProfileSummary");
+    return __isa(o, "FieldLevelEncryptionProfileSummary");
   }
 }
 
@@ -2493,7 +2496,7 @@ export interface FieldLevelEncryptionSummary {
 
 export namespace FieldLevelEncryptionSummary {
   export function isa(o: any): o is FieldLevelEncryptionSummary {
-    return _smithy.isa(o, "FieldLevelEncryptionSummary");
+    return __isa(o, "FieldLevelEncryptionSummary");
   }
 }
 
@@ -2515,7 +2518,7 @@ export interface FieldPatterns {
 
 export namespace FieldPatterns {
   export function isa(o: any): o is FieldPatterns {
-    return _smithy.isa(o, "FieldPatterns");
+    return __isa(o, "FieldPatterns");
   }
 }
 
@@ -2572,7 +2575,7 @@ export interface ForwardedValues {
 
 export namespace ForwardedValues {
   export function isa(o: any): o is ForwardedValues {
-    return _smithy.isa(o, "ForwardedValues");
+    return __isa(o, "ForwardedValues");
   }
 }
 
@@ -2630,7 +2633,7 @@ export interface GeoRestriction {
 
 export namespace GeoRestriction {
   export function isa(o: any): o is GeoRestriction {
-    return _smithy.isa(o, "GeoRestriction");
+    return __isa(o, "GeoRestriction");
   }
 }
 
@@ -2652,7 +2655,7 @@ export namespace GetCloudFrontOriginAccessIdentityConfigRequest {
   export function isa(
     o: any
   ): o is GetCloudFrontOriginAccessIdentityConfigRequest {
-    return _smithy.isa(o, "GetCloudFrontOriginAccessIdentityConfigRequest");
+    return __isa(o, "GetCloudFrontOriginAccessIdentityConfigRequest");
   }
 }
 
@@ -2678,7 +2681,7 @@ export namespace GetCloudFrontOriginAccessIdentityConfigResult {
   export function isa(
     o: any
   ): o is GetCloudFrontOriginAccessIdentityConfigResult {
-    return _smithy.isa(o, "GetCloudFrontOriginAccessIdentityConfigResult");
+    return __isa(o, "GetCloudFrontOriginAccessIdentityConfigResult");
   }
 }
 
@@ -2695,7 +2698,7 @@ export interface GetCloudFrontOriginAccessIdentityRequest {
 
 export namespace GetCloudFrontOriginAccessIdentityRequest {
   export function isa(o: any): o is GetCloudFrontOriginAccessIdentityRequest {
-    return _smithy.isa(o, "GetCloudFrontOriginAccessIdentityRequest");
+    return __isa(o, "GetCloudFrontOriginAccessIdentityRequest");
   }
 }
 
@@ -2719,7 +2722,7 @@ export interface GetCloudFrontOriginAccessIdentityResult
 
 export namespace GetCloudFrontOriginAccessIdentityResult {
   export function isa(o: any): o is GetCloudFrontOriginAccessIdentityResult {
-    return _smithy.isa(o, "GetCloudFrontOriginAccessIdentityResult");
+    return __isa(o, "GetCloudFrontOriginAccessIdentityResult");
   }
 }
 
@@ -2736,7 +2739,7 @@ export interface GetDistributionConfigRequest {
 
 export namespace GetDistributionConfigRequest {
   export function isa(o: any): o is GetDistributionConfigRequest {
-    return _smithy.isa(o, "GetDistributionConfigRequest");
+    return __isa(o, "GetDistributionConfigRequest");
   }
 }
 
@@ -2759,7 +2762,7 @@ export interface GetDistributionConfigResult extends $MetadataBearer {
 
 export namespace GetDistributionConfigResult {
   export function isa(o: any): o is GetDistributionConfigResult {
-    return _smithy.isa(o, "GetDistributionConfigResult");
+    return __isa(o, "GetDistributionConfigResult");
   }
 }
 
@@ -2776,7 +2779,7 @@ export interface GetDistributionRequest {
 
 export namespace GetDistributionRequest {
   export function isa(o: any): o is GetDistributionRequest {
-    return _smithy.isa(o, "GetDistributionRequest");
+    return __isa(o, "GetDistributionRequest");
   }
 }
 
@@ -2799,7 +2802,7 @@ export interface GetDistributionResult extends $MetadataBearer {
 
 export namespace GetDistributionResult {
   export function isa(o: any): o is GetDistributionResult {
-    return _smithy.isa(o, "GetDistributionResult");
+    return __isa(o, "GetDistributionResult");
   }
 }
 
@@ -2813,7 +2816,7 @@ export interface GetFieldLevelEncryptionConfigRequest {
 
 export namespace GetFieldLevelEncryptionConfigRequest {
   export function isa(o: any): o is GetFieldLevelEncryptionConfigRequest {
-    return _smithy.isa(o, "GetFieldLevelEncryptionConfigRequest");
+    return __isa(o, "GetFieldLevelEncryptionConfigRequest");
   }
 }
 
@@ -2832,7 +2835,7 @@ export interface GetFieldLevelEncryptionConfigResult extends $MetadataBearer {
 
 export namespace GetFieldLevelEncryptionConfigResult {
   export function isa(o: any): o is GetFieldLevelEncryptionConfigResult {
-    return _smithy.isa(o, "GetFieldLevelEncryptionConfigResult");
+    return __isa(o, "GetFieldLevelEncryptionConfigResult");
   }
 }
 
@@ -2848,7 +2851,7 @@ export namespace GetFieldLevelEncryptionProfileConfigRequest {
   export function isa(
     o: any
   ): o is GetFieldLevelEncryptionProfileConfigRequest {
-    return _smithy.isa(o, "GetFieldLevelEncryptionProfileConfigRequest");
+    return __isa(o, "GetFieldLevelEncryptionProfileConfigRequest");
   }
 }
 
@@ -2868,7 +2871,7 @@ export interface GetFieldLevelEncryptionProfileConfigResult
 
 export namespace GetFieldLevelEncryptionProfileConfigResult {
   export function isa(o: any): o is GetFieldLevelEncryptionProfileConfigResult {
-    return _smithy.isa(o, "GetFieldLevelEncryptionProfileConfigResult");
+    return __isa(o, "GetFieldLevelEncryptionProfileConfigResult");
   }
 }
 
@@ -2882,7 +2885,7 @@ export interface GetFieldLevelEncryptionProfileRequest {
 
 export namespace GetFieldLevelEncryptionProfileRequest {
   export function isa(o: any): o is GetFieldLevelEncryptionProfileRequest {
-    return _smithy.isa(o, "GetFieldLevelEncryptionProfileRequest");
+    return __isa(o, "GetFieldLevelEncryptionProfileRequest");
   }
 }
 
@@ -2901,7 +2904,7 @@ export interface GetFieldLevelEncryptionProfileResult extends $MetadataBearer {
 
 export namespace GetFieldLevelEncryptionProfileResult {
   export function isa(o: any): o is GetFieldLevelEncryptionProfileResult {
-    return _smithy.isa(o, "GetFieldLevelEncryptionProfileResult");
+    return __isa(o, "GetFieldLevelEncryptionProfileResult");
   }
 }
 
@@ -2915,7 +2918,7 @@ export interface GetFieldLevelEncryptionRequest {
 
 export namespace GetFieldLevelEncryptionRequest {
   export function isa(o: any): o is GetFieldLevelEncryptionRequest {
-    return _smithy.isa(o, "GetFieldLevelEncryptionRequest");
+    return __isa(o, "GetFieldLevelEncryptionRequest");
   }
 }
 
@@ -2934,7 +2937,7 @@ export interface GetFieldLevelEncryptionResult extends $MetadataBearer {
 
 export namespace GetFieldLevelEncryptionResult {
   export function isa(o: any): o is GetFieldLevelEncryptionResult {
-    return _smithy.isa(o, "GetFieldLevelEncryptionResult");
+    return __isa(o, "GetFieldLevelEncryptionResult");
   }
 }
 
@@ -2957,7 +2960,7 @@ export interface GetInvalidationRequest {
 
 export namespace GetInvalidationRequest {
   export function isa(o: any): o is GetInvalidationRequest {
-    return _smithy.isa(o, "GetInvalidationRequest");
+    return __isa(o, "GetInvalidationRequest");
   }
 }
 
@@ -2974,7 +2977,7 @@ export interface GetInvalidationResult extends $MetadataBearer {
 
 export namespace GetInvalidationResult {
   export function isa(o: any): o is GetInvalidationResult {
-    return _smithy.isa(o, "GetInvalidationResult");
+    return __isa(o, "GetInvalidationResult");
   }
 }
 
@@ -2988,7 +2991,7 @@ export interface GetPublicKeyConfigRequest {
 
 export namespace GetPublicKeyConfigRequest {
   export function isa(o: any): o is GetPublicKeyConfigRequest {
-    return _smithy.isa(o, "GetPublicKeyConfigRequest");
+    return __isa(o, "GetPublicKeyConfigRequest");
   }
 }
 
@@ -3007,7 +3010,7 @@ export interface GetPublicKeyConfigResult extends $MetadataBearer {
 
 export namespace GetPublicKeyConfigResult {
   export function isa(o: any): o is GetPublicKeyConfigResult {
-    return _smithy.isa(o, "GetPublicKeyConfigResult");
+    return __isa(o, "GetPublicKeyConfigResult");
   }
 }
 
@@ -3021,7 +3024,7 @@ export interface GetPublicKeyRequest {
 
 export namespace GetPublicKeyRequest {
   export function isa(o: any): o is GetPublicKeyRequest {
-    return _smithy.isa(o, "GetPublicKeyRequest");
+    return __isa(o, "GetPublicKeyRequest");
   }
 }
 
@@ -3040,7 +3043,7 @@ export interface GetPublicKeyResult extends $MetadataBearer {
 
 export namespace GetPublicKeyResult {
   export function isa(o: any): o is GetPublicKeyResult {
-    return _smithy.isa(o, "GetPublicKeyResult");
+    return __isa(o, "GetPublicKeyResult");
   }
 }
 
@@ -3057,7 +3060,7 @@ export interface GetStreamingDistributionConfigRequest {
 
 export namespace GetStreamingDistributionConfigRequest {
   export function isa(o: any): o is GetStreamingDistributionConfigRequest {
-    return _smithy.isa(o, "GetStreamingDistributionConfigRequest");
+    return __isa(o, "GetStreamingDistributionConfigRequest");
   }
 }
 
@@ -3080,7 +3083,7 @@ export interface GetStreamingDistributionConfigResult extends $MetadataBearer {
 
 export namespace GetStreamingDistributionConfigResult {
   export function isa(o: any): o is GetStreamingDistributionConfigResult {
-    return _smithy.isa(o, "GetStreamingDistributionConfigResult");
+    return __isa(o, "GetStreamingDistributionConfigResult");
   }
 }
 
@@ -3097,7 +3100,7 @@ export interface GetStreamingDistributionRequest {
 
 export namespace GetStreamingDistributionRequest {
   export function isa(o: any): o is GetStreamingDistributionRequest {
-    return _smithy.isa(o, "GetStreamingDistributionRequest");
+    return __isa(o, "GetStreamingDistributionRequest");
   }
 }
 
@@ -3120,7 +3123,7 @@ export interface GetStreamingDistributionResult extends $MetadataBearer {
 
 export namespace GetStreamingDistributionResult {
   export function isa(o: any): o is GetStreamingDistributionResult {
-    return _smithy.isa(o, "GetStreamingDistributionResult");
+    return __isa(o, "GetStreamingDistributionResult");
   }
 }
 
@@ -3188,7 +3191,7 @@ export interface Headers {
 
 export namespace Headers {
   export function isa(o: any): o is Headers {
-    return _smithy.isa(o, "Headers");
+    return __isa(o, "Headers");
   }
 }
 
@@ -3226,7 +3229,7 @@ export interface Invalidation {
 
 export namespace Invalidation {
   export function isa(o: any): o is Invalidation {
-    return _smithy.isa(o, "Invalidation");
+    return __isa(o, "Invalidation");
   }
 }
 
@@ -3262,7 +3265,7 @@ export interface InvalidationBatch {
 
 export namespace InvalidationBatch {
   export function isa(o: any): o is InvalidationBatch {
-    return _smithy.isa(o, "InvalidationBatch");
+    return __isa(o, "InvalidationBatch");
   }
 }
 
@@ -3313,7 +3316,7 @@ export interface InvalidationList {
 
 export namespace InvalidationList {
   export function isa(o: any): o is InvalidationList {
-    return _smithy.isa(o, "InvalidationList");
+    return __isa(o, "InvalidationList");
   }
 }
 
@@ -3340,7 +3343,7 @@ export interface InvalidationSummary {
 
 export namespace InvalidationSummary {
   export function isa(o: any): o is InvalidationSummary {
-    return _smithy.isa(o, "InvalidationSummary");
+    return __isa(o, "InvalidationSummary");
   }
 }
 
@@ -3370,7 +3373,7 @@ export interface KeyPairIds {
 
 export namespace KeyPairIds {
   export function isa(o: any): o is KeyPairIds {
-    return _smithy.isa(o, "KeyPairIds");
+    return __isa(o, "KeyPairIds");
   }
 }
 
@@ -3423,7 +3426,7 @@ export interface LambdaFunctionAssociation {
 
 export namespace LambdaFunctionAssociation {
   export function isa(o: any): o is LambdaFunctionAssociation {
-    return _smithy.isa(o, "LambdaFunctionAssociation");
+    return __isa(o, "LambdaFunctionAssociation");
   }
 }
 
@@ -3459,7 +3462,7 @@ export interface LambdaFunctionAssociations {
 
 export namespace LambdaFunctionAssociations {
   export function isa(o: any): o is LambdaFunctionAssociations {
-    return _smithy.isa(o, "LambdaFunctionAssociations");
+    return __isa(o, "LambdaFunctionAssociations");
   }
 }
 
@@ -3488,7 +3491,7 @@ export namespace ListCloudFrontOriginAccessIdentitiesRequest {
   export function isa(
     o: any
   ): o is ListCloudFrontOriginAccessIdentitiesRequest {
-    return _smithy.isa(o, "ListCloudFrontOriginAccessIdentitiesRequest");
+    return __isa(o, "ListCloudFrontOriginAccessIdentitiesRequest");
   }
 }
 
@@ -3506,7 +3509,7 @@ export interface ListCloudFrontOriginAccessIdentitiesResult
 
 export namespace ListCloudFrontOriginAccessIdentitiesResult {
   export function isa(o: any): o is ListCloudFrontOriginAccessIdentitiesResult {
-    return _smithy.isa(o, "ListCloudFrontOriginAccessIdentitiesResult");
+    return __isa(o, "ListCloudFrontOriginAccessIdentitiesResult");
   }
 }
 
@@ -3541,7 +3544,7 @@ export interface ListDistributionsByWebACLIdRequest {
 
 export namespace ListDistributionsByWebACLIdRequest {
   export function isa(o: any): o is ListDistributionsByWebACLIdRequest {
-    return _smithy.isa(o, "ListDistributionsByWebACLIdRequest");
+    return __isa(o, "ListDistributionsByWebACLIdRequest");
   }
 }
 
@@ -3559,7 +3562,7 @@ export interface ListDistributionsByWebACLIdResult extends $MetadataBearer {
 
 export namespace ListDistributionsByWebACLIdResult {
   export function isa(o: any): o is ListDistributionsByWebACLIdResult {
-    return _smithy.isa(o, "ListDistributionsByWebACLIdResult");
+    return __isa(o, "ListDistributionsByWebACLIdResult");
   }
 }
 
@@ -3585,7 +3588,7 @@ export interface ListDistributionsRequest {
 
 export namespace ListDistributionsRequest {
   export function isa(o: any): o is ListDistributionsRequest {
-    return _smithy.isa(o, "ListDistributionsRequest");
+    return __isa(o, "ListDistributionsRequest");
   }
 }
 
@@ -3602,7 +3605,7 @@ export interface ListDistributionsResult extends $MetadataBearer {
 
 export namespace ListDistributionsResult {
   export function isa(o: any): o is ListDistributionsResult {
-    return _smithy.isa(o, "ListDistributionsResult");
+    return __isa(o, "ListDistributionsResult");
   }
 }
 
@@ -3623,7 +3626,7 @@ export interface ListFieldLevelEncryptionConfigsRequest {
 
 export namespace ListFieldLevelEncryptionConfigsRequest {
   export function isa(o: any): o is ListFieldLevelEncryptionConfigsRequest {
-    return _smithy.isa(o, "ListFieldLevelEncryptionConfigsRequest");
+    return __isa(o, "ListFieldLevelEncryptionConfigsRequest");
   }
 }
 
@@ -3637,7 +3640,7 @@ export interface ListFieldLevelEncryptionConfigsResult extends $MetadataBearer {
 
 export namespace ListFieldLevelEncryptionConfigsResult {
   export function isa(o: any): o is ListFieldLevelEncryptionConfigsResult {
-    return _smithy.isa(o, "ListFieldLevelEncryptionConfigsResult");
+    return __isa(o, "ListFieldLevelEncryptionConfigsResult");
   }
 }
 
@@ -3658,7 +3661,7 @@ export interface ListFieldLevelEncryptionProfilesRequest {
 
 export namespace ListFieldLevelEncryptionProfilesRequest {
   export function isa(o: any): o is ListFieldLevelEncryptionProfilesRequest {
-    return _smithy.isa(o, "ListFieldLevelEncryptionProfilesRequest");
+    return __isa(o, "ListFieldLevelEncryptionProfilesRequest");
   }
 }
 
@@ -3673,7 +3676,7 @@ export interface ListFieldLevelEncryptionProfilesResult
 
 export namespace ListFieldLevelEncryptionProfilesResult {
   export function isa(o: any): o is ListFieldLevelEncryptionProfilesResult {
-    return _smithy.isa(o, "ListFieldLevelEncryptionProfilesResult");
+    return __isa(o, "ListFieldLevelEncryptionProfilesResult");
   }
 }
 
@@ -3706,7 +3709,7 @@ export interface ListInvalidationsRequest {
 
 export namespace ListInvalidationsRequest {
   export function isa(o: any): o is ListInvalidationsRequest {
-    return _smithy.isa(o, "ListInvalidationsRequest");
+    return __isa(o, "ListInvalidationsRequest");
   }
 }
 
@@ -3723,7 +3726,7 @@ export interface ListInvalidationsResult extends $MetadataBearer {
 
 export namespace ListInvalidationsResult {
   export function isa(o: any): o is ListInvalidationsResult {
-    return _smithy.isa(o, "ListInvalidationsResult");
+    return __isa(o, "ListInvalidationsResult");
   }
 }
 
@@ -3744,7 +3747,7 @@ export interface ListPublicKeysRequest {
 
 export namespace ListPublicKeysRequest {
   export function isa(o: any): o is ListPublicKeysRequest {
-    return _smithy.isa(o, "ListPublicKeysRequest");
+    return __isa(o, "ListPublicKeysRequest");
   }
 }
 
@@ -3758,7 +3761,7 @@ export interface ListPublicKeysResult extends $MetadataBearer {
 
 export namespace ListPublicKeysResult {
   export function isa(o: any): o is ListPublicKeysResult {
-    return _smithy.isa(o, "ListPublicKeysResult");
+    return __isa(o, "ListPublicKeysResult");
   }
 }
 
@@ -3780,7 +3783,7 @@ export interface ListStreamingDistributionsRequest {
 
 export namespace ListStreamingDistributionsRequest {
   export function isa(o: any): o is ListStreamingDistributionsRequest {
-    return _smithy.isa(o, "ListStreamingDistributionsRequest");
+    return __isa(o, "ListStreamingDistributionsRequest");
   }
 }
 
@@ -3797,7 +3800,7 @@ export interface ListStreamingDistributionsResult extends $MetadataBearer {
 
 export namespace ListStreamingDistributionsResult {
   export function isa(o: any): o is ListStreamingDistributionsResult {
-    return _smithy.isa(o, "ListStreamingDistributionsResult");
+    return __isa(o, "ListStreamingDistributionsResult");
   }
 }
 
@@ -3814,7 +3817,7 @@ export interface ListTagsForResourceRequest {
 
 export namespace ListTagsForResourceRequest {
   export function isa(o: any): o is ListTagsForResourceRequest {
-    return _smithy.isa(o, "ListTagsForResourceRequest");
+    return __isa(o, "ListTagsForResourceRequest");
   }
 }
 
@@ -3831,7 +3834,7 @@ export interface ListTagsForResourceResult extends $MetadataBearer {
 
 export namespace ListTagsForResourceResult {
   export function isa(o: any): o is ListTagsForResourceResult {
-    return _smithy.isa(o, "ListTagsForResourceResult");
+    return __isa(o, "ListTagsForResourceResult");
   }
 }
 
@@ -3878,7 +3881,7 @@ export interface LoggingConfig {
 
 export namespace LoggingConfig {
   export function isa(o: any): o is LoggingConfig {
-    return _smithy.isa(o, "LoggingConfig");
+    return __isa(o, "LoggingConfig");
   }
 }
 
@@ -4017,7 +4020,7 @@ export interface Origin {
 
 export namespace Origin {
   export function isa(o: any): o is Origin {
-    return _smithy.isa(o, "Origin");
+    return __isa(o, "Origin");
   }
 }
 
@@ -4044,7 +4047,7 @@ export interface OriginCustomHeader {
 
 export namespace OriginCustomHeader {
   export function isa(o: any): o is OriginCustomHeader {
-    return _smithy.isa(o, "OriginCustomHeader");
+    return __isa(o, "OriginCustomHeader");
   }
 }
 
@@ -4074,7 +4077,7 @@ export interface OriginGroup {
 
 export namespace OriginGroup {
   export function isa(o: any): o is OriginGroup {
-    return _smithy.isa(o, "OriginGroup");
+    return __isa(o, "OriginGroup");
   }
 }
 
@@ -4093,7 +4096,7 @@ export interface OriginGroupFailoverCriteria {
 
 export namespace OriginGroupFailoverCriteria {
   export function isa(o: any): o is OriginGroupFailoverCriteria {
-    return _smithy.isa(o, "OriginGroupFailoverCriteria");
+    return __isa(o, "OriginGroupFailoverCriteria");
   }
 }
 
@@ -4110,7 +4113,7 @@ export interface OriginGroupMember {
 
 export namespace OriginGroupMember {
   export function isa(o: any): o is OriginGroupMember {
-    return _smithy.isa(o, "OriginGroupMember");
+    return __isa(o, "OriginGroupMember");
   }
 }
 
@@ -4132,7 +4135,7 @@ export interface OriginGroupMembers {
 
 export namespace OriginGroupMembers {
   export function isa(o: any): o is OriginGroupMembers {
-    return _smithy.isa(o, "OriginGroupMembers");
+    return __isa(o, "OriginGroupMembers");
   }
 }
 
@@ -4154,7 +4157,7 @@ export interface OriginGroups {
 
 export namespace OriginGroups {
   export function isa(o: any): o is OriginGroups {
-    return _smithy.isa(o, "OriginGroups");
+    return __isa(o, "OriginGroups");
   }
 }
 
@@ -4180,7 +4183,7 @@ export interface OriginSslProtocols {
 
 export namespace OriginSslProtocols {
   export function isa(o: any): o is OriginSslProtocols {
-    return _smithy.isa(o, "OriginSslProtocols");
+    return __isa(o, "OriginSslProtocols");
   }
 }
 
@@ -4203,7 +4206,7 @@ export interface Origins {
 
 export namespace Origins {
   export function isa(o: any): o is Origins {
-    return _smithy.isa(o, "Origins");
+    return __isa(o, "Origins");
   }
 }
 
@@ -4227,7 +4230,7 @@ export interface Paths {
 
 export namespace Paths {
   export function isa(o: any): o is Paths {
-    return _smithy.isa(o, "Paths");
+    return __isa(o, "Paths");
   }
 }
 
@@ -4256,7 +4259,7 @@ export interface PublicKey {
 
 export namespace PublicKey {
   export function isa(o: any): o is PublicKey {
-    return _smithy.isa(o, "PublicKey");
+    return __isa(o, "PublicKey");
   }
 }
 
@@ -4288,7 +4291,7 @@ export interface PublicKeyConfig {
 
 export namespace PublicKeyConfig {
   export function isa(o: any): o is PublicKeyConfig {
-    return _smithy.isa(o, "PublicKeyConfig");
+    return __isa(o, "PublicKeyConfig");
   }
 }
 
@@ -4323,7 +4326,7 @@ export interface PublicKeyList {
 
 export namespace PublicKeyList {
   export function isa(o: any): o is PublicKeyList {
-    return _smithy.isa(o, "PublicKeyList");
+    return __isa(o, "PublicKeyList");
   }
 }
 
@@ -4371,7 +4374,7 @@ export interface PublicKeySummary {
 
 export namespace PublicKeySummary {
   export function isa(o: any): o is PublicKeySummary {
-    return _smithy.isa(o, "PublicKeySummary");
+    return __isa(o, "PublicKeySummary");
   }
 }
 
@@ -4393,7 +4396,7 @@ export interface QueryArgProfile {
 
 export namespace QueryArgProfile {
   export function isa(o: any): o is QueryArgProfile {
-    return _smithy.isa(o, "QueryArgProfile");
+    return __isa(o, "QueryArgProfile");
   }
 }
 
@@ -4416,7 +4419,7 @@ export interface QueryArgProfileConfig {
 
 export namespace QueryArgProfileConfig {
   export function isa(o: any): o is QueryArgProfileConfig {
-    return _smithy.isa(o, "QueryArgProfileConfig");
+    return __isa(o, "QueryArgProfileConfig");
   }
 }
 
@@ -4438,7 +4441,7 @@ export interface QueryArgProfiles {
 
 export namespace QueryArgProfiles {
   export function isa(o: any): o is QueryArgProfiles {
-    return _smithy.isa(o, "QueryArgProfiles");
+    return __isa(o, "QueryArgProfiles");
   }
 }
 
@@ -4465,7 +4468,7 @@ export interface QueryStringCacheKeys {
 
 export namespace QueryStringCacheKeys {
   export function isa(o: any): o is QueryStringCacheKeys {
-    return _smithy.isa(o, "QueryStringCacheKeys");
+    return __isa(o, "QueryStringCacheKeys");
   }
 }
 
@@ -4484,7 +4487,7 @@ export interface Restrictions {
 
 export namespace Restrictions {
   export function isa(o: any): o is Restrictions {
-    return _smithy.isa(o, "Restrictions");
+    return __isa(o, "Restrictions");
   }
 }
 
@@ -4519,7 +4522,7 @@ export interface S3Origin {
 
 export namespace S3Origin {
   export function isa(o: any): o is S3Origin {
-    return _smithy.isa(o, "S3Origin");
+    return __isa(o, "S3Origin");
   }
 }
 
@@ -4555,7 +4558,7 @@ export interface S3OriginConfig {
 
 export namespace S3OriginConfig {
   export function isa(o: any): o is S3OriginConfig {
-    return _smithy.isa(o, "S3OriginConfig");
+    return __isa(o, "S3OriginConfig");
   }
 }
 
@@ -4591,7 +4594,7 @@ export interface Signer {
 
 export namespace Signer {
   export function isa(o: any): o is Signer {
-    return _smithy.isa(o, "Signer");
+    return __isa(o, "Signer");
   }
 }
 
@@ -4616,7 +4619,7 @@ export interface StatusCodes {
 
 export namespace StatusCodes {
   export function isa(o: any): o is StatusCodes {
-    return _smithy.isa(o, "StatusCodes");
+    return __isa(o, "StatusCodes");
   }
 }
 
@@ -4677,7 +4680,7 @@ export interface StreamingDistribution {
 
 export namespace StreamingDistribution {
   export function isa(o: any): o is StreamingDistribution {
-    return _smithy.isa(o, "StreamingDistribution");
+    return __isa(o, "StreamingDistribution");
   }
 }
 
@@ -4743,7 +4746,7 @@ export interface StreamingDistributionConfig {
 
 export namespace StreamingDistributionConfig {
   export function isa(o: any): o is StreamingDistributionConfig {
-    return _smithy.isa(o, "StreamingDistributionConfig");
+    return __isa(o, "StreamingDistributionConfig");
   }
 }
 
@@ -4766,7 +4769,7 @@ export interface StreamingDistributionConfigWithTags {
 
 export namespace StreamingDistributionConfigWithTags {
   export function isa(o: any): o is StreamingDistributionConfigWithTags {
-    return _smithy.isa(o, "StreamingDistributionConfigWithTags");
+    return __isa(o, "StreamingDistributionConfigWithTags");
   }
 }
 
@@ -4814,7 +4817,7 @@ export interface StreamingDistributionList {
 
 export namespace StreamingDistributionList {
   export function isa(o: any): o is StreamingDistributionList {
-    return _smithy.isa(o, "StreamingDistributionList");
+    return __isa(o, "StreamingDistributionList");
   }
 }
 
@@ -4900,7 +4903,7 @@ export interface StreamingDistributionSummary {
 
 export namespace StreamingDistributionSummary {
   export function isa(o: any): o is StreamingDistributionSummary {
-    return _smithy.isa(o, "StreamingDistributionSummary");
+    return __isa(o, "StreamingDistributionSummary");
   }
 }
 
@@ -4935,7 +4938,7 @@ export interface StreamingLoggingConfig {
 
 export namespace StreamingLoggingConfig {
   export function isa(o: any): o is StreamingLoggingConfig {
-    return _smithy.isa(o, "StreamingLoggingConfig");
+    return __isa(o, "StreamingLoggingConfig");
   }
 }
 
@@ -4963,7 +4966,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -4980,7 +4983,7 @@ export interface TagKeys {
 
 export namespace TagKeys {
   export function isa(o: any): o is TagKeys {
-    return _smithy.isa(o, "TagKeys");
+    return __isa(o, "TagKeys");
   }
 }
 
@@ -5002,7 +5005,7 @@ export interface TagResourceRequest {
 
 export namespace TagResourceRequest {
   export function isa(o: any): o is TagResourceRequest {
-    return _smithy.isa(o, "TagResourceRequest");
+    return __isa(o, "TagResourceRequest");
   }
 }
 
@@ -5019,7 +5022,7 @@ export interface Tags {
 
 export namespace Tags {
   export function isa(o: any): o is Tags {
-    return _smithy.isa(o, "Tags");
+    return __isa(o, "Tags");
   }
 }
 
@@ -5065,7 +5068,7 @@ export interface TrustedSigners {
 
 export namespace TrustedSigners {
   export function isa(o: any): o is TrustedSigners {
-    return _smithy.isa(o, "TrustedSigners");
+    return __isa(o, "TrustedSigners");
   }
 }
 
@@ -5087,7 +5090,7 @@ export interface UntagResourceRequest {
 
 export namespace UntagResourceRequest {
   export function isa(o: any): o is UntagResourceRequest {
-    return _smithy.isa(o, "UntagResourceRequest");
+    return __isa(o, "UntagResourceRequest");
   }
 }
 
@@ -5119,7 +5122,7 @@ export namespace UpdateCloudFrontOriginAccessIdentityRequest {
   export function isa(
     o: any
   ): o is UpdateCloudFrontOriginAccessIdentityRequest {
-    return _smithy.isa(o, "UpdateCloudFrontOriginAccessIdentityRequest");
+    return __isa(o, "UpdateCloudFrontOriginAccessIdentityRequest");
   }
 }
 
@@ -5143,7 +5146,7 @@ export interface UpdateCloudFrontOriginAccessIdentityResult
 
 export namespace UpdateCloudFrontOriginAccessIdentityResult {
   export function isa(o: any): o is UpdateCloudFrontOriginAccessIdentityResult {
-    return _smithy.isa(o, "UpdateCloudFrontOriginAccessIdentityResult");
+    return __isa(o, "UpdateCloudFrontOriginAccessIdentityResult");
   }
 }
 
@@ -5171,7 +5174,7 @@ export interface UpdateDistributionRequest {
 
 export namespace UpdateDistributionRequest {
   export function isa(o: any): o is UpdateDistributionRequest {
-    return _smithy.isa(o, "UpdateDistributionRequest");
+    return __isa(o, "UpdateDistributionRequest");
   }
 }
 
@@ -5194,7 +5197,7 @@ export interface UpdateDistributionResult extends $MetadataBearer {
 
 export namespace UpdateDistributionResult {
   export function isa(o: any): o is UpdateDistributionResult {
-    return _smithy.isa(o, "UpdateDistributionResult");
+    return __isa(o, "UpdateDistributionResult");
   }
 }
 
@@ -5219,7 +5222,7 @@ export interface UpdateFieldLevelEncryptionConfigRequest {
 
 export namespace UpdateFieldLevelEncryptionConfigRequest {
   export function isa(o: any): o is UpdateFieldLevelEncryptionConfigRequest {
-    return _smithy.isa(o, "UpdateFieldLevelEncryptionConfigRequest");
+    return __isa(o, "UpdateFieldLevelEncryptionConfigRequest");
   }
 }
 
@@ -5240,7 +5243,7 @@ export interface UpdateFieldLevelEncryptionConfigResult
 
 export namespace UpdateFieldLevelEncryptionConfigResult {
   export function isa(o: any): o is UpdateFieldLevelEncryptionConfigResult {
-    return _smithy.isa(o, "UpdateFieldLevelEncryptionConfigResult");
+    return __isa(o, "UpdateFieldLevelEncryptionConfigResult");
   }
 }
 
@@ -5267,7 +5270,7 @@ export interface UpdateFieldLevelEncryptionProfileRequest {
 
 export namespace UpdateFieldLevelEncryptionProfileRequest {
   export function isa(o: any): o is UpdateFieldLevelEncryptionProfileRequest {
-    return _smithy.isa(o, "UpdateFieldLevelEncryptionProfileRequest");
+    return __isa(o, "UpdateFieldLevelEncryptionProfileRequest");
   }
 }
 
@@ -5287,7 +5290,7 @@ export interface UpdateFieldLevelEncryptionProfileResult
 
 export namespace UpdateFieldLevelEncryptionProfileResult {
   export function isa(o: any): o is UpdateFieldLevelEncryptionProfileResult {
-    return _smithy.isa(o, "UpdateFieldLevelEncryptionProfileResult");
+    return __isa(o, "UpdateFieldLevelEncryptionProfileResult");
   }
 }
 
@@ -5312,7 +5315,7 @@ export interface UpdatePublicKeyRequest {
 
 export namespace UpdatePublicKeyRequest {
   export function isa(o: any): o is UpdatePublicKeyRequest {
-    return _smithy.isa(o, "UpdatePublicKeyRequest");
+    return __isa(o, "UpdatePublicKeyRequest");
   }
 }
 
@@ -5331,7 +5334,7 @@ export interface UpdatePublicKeyResult extends $MetadataBearer {
 
 export namespace UpdatePublicKeyResult {
   export function isa(o: any): o is UpdatePublicKeyResult {
-    return _smithy.isa(o, "UpdatePublicKeyResult");
+    return __isa(o, "UpdatePublicKeyResult");
   }
 }
 
@@ -5359,7 +5362,7 @@ export interface UpdateStreamingDistributionRequest {
 
 export namespace UpdateStreamingDistributionRequest {
   export function isa(o: any): o is UpdateStreamingDistributionRequest {
-    return _smithy.isa(o, "UpdateStreamingDistributionRequest");
+    return __isa(o, "UpdateStreamingDistributionRequest");
   }
 }
 
@@ -5382,7 +5385,7 @@ export interface UpdateStreamingDistributionResult extends $MetadataBearer {
 
 export namespace UpdateStreamingDistributionResult {
   export function isa(o: any): o is UpdateStreamingDistributionResult {
-    return _smithy.isa(o, "UpdateStreamingDistributionResult");
+    return __isa(o, "UpdateStreamingDistributionResult");
   }
 }
 
@@ -5575,7 +5578,7 @@ export interface ViewerCertificate {
 
 export namespace ViewerCertificate {
   export function isa(o: any): o is ViewerCertificate {
-    return _smithy.isa(o, "ViewerCertificate");
+    return __isa(o, "ViewerCertificate");
   }
 }
 
@@ -5587,7 +5590,7 @@ export type ViewerProtocolPolicy =
 /**
  * <p>Access denied.</p>
  */
-export interface AccessDenied extends _smithy.SmithyException, $MetadataBearer {
+export interface AccessDenied extends __SmithyException, $MetadataBearer {
   name: "AccessDenied";
   $fault: "client";
   Message?: string;
@@ -5595,16 +5598,14 @@ export interface AccessDenied extends _smithy.SmithyException, $MetadataBearer {
 
 export namespace AccessDenied {
   export function isa(o: any): o is AccessDenied {
-    return _smithy.isa(o, "AccessDenied");
+    return __isa(o, "AccessDenied");
   }
 }
 
 /**
  * <p>Invalidation batch specified is too large.</p>
  */
-export interface BatchTooLarge
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface BatchTooLarge extends __SmithyException, $MetadataBearer {
   name: "BatchTooLarge";
   $fault: "client";
   Message?: string;
@@ -5612,16 +5613,14 @@ export interface BatchTooLarge
 
 export namespace BatchTooLarge {
   export function isa(o: any): o is BatchTooLarge {
-    return _smithy.isa(o, "BatchTooLarge");
+    return __isa(o, "BatchTooLarge");
   }
 }
 
 /**
  * <p>The CNAME specified is already defined for CloudFront.</p>
  */
-export interface CNAMEAlreadyExists
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface CNAMEAlreadyExists extends __SmithyException, $MetadataBearer {
   name: "CNAMEAlreadyExists";
   $fault: "client";
   Message?: string;
@@ -5629,7 +5628,7 @@ export interface CNAMEAlreadyExists
 
 export namespace CNAMEAlreadyExists {
   export function isa(o: any): o is CNAMEAlreadyExists {
-    return _smithy.isa(o, "CNAMEAlreadyExists");
+    return __isa(o, "CNAMEAlreadyExists");
   }
 }
 
@@ -5637,7 +5636,7 @@ export namespace CNAMEAlreadyExists {
  * <p>You can't change the value of a public key.</p>
  */
 export interface CannotChangeImmutablePublicKeyFields
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CannotChangeImmutablePublicKeyFields";
   $fault: "client";
@@ -5646,7 +5645,7 @@ export interface CannotChangeImmutablePublicKeyFields
 
 export namespace CannotChangeImmutablePublicKeyFields {
   export function isa(o: any): o is CannotChangeImmutablePublicKeyFields {
-    return _smithy.isa(o, "CannotChangeImmutablePublicKeyFields");
+    return __isa(o, "CannotChangeImmutablePublicKeyFields");
   }
 }
 
@@ -5656,7 +5655,7 @@ export namespace CannotChangeImmutablePublicKeyFields {
  * 			<code>CloudFrontOriginAccessIdentityAlreadyExists</code> error. </p>
  */
 export interface CloudFrontOriginAccessIdentityAlreadyExists
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CloudFrontOriginAccessIdentityAlreadyExists";
   $fault: "client";
@@ -5667,7 +5666,7 @@ export namespace CloudFrontOriginAccessIdentityAlreadyExists {
   export function isa(
     o: any
   ): o is CloudFrontOriginAccessIdentityAlreadyExists {
-    return _smithy.isa(o, "CloudFrontOriginAccessIdentityAlreadyExists");
+    return __isa(o, "CloudFrontOriginAccessIdentityAlreadyExists");
   }
 }
 
@@ -5675,7 +5674,7 @@ export namespace CloudFrontOriginAccessIdentityAlreadyExists {
  * <p>The Origin Access Identity specified is already in use.</p>
  */
 export interface CloudFrontOriginAccessIdentityInUse
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CloudFrontOriginAccessIdentityInUse";
   $fault: "client";
@@ -5684,7 +5683,7 @@ export interface CloudFrontOriginAccessIdentityInUse
 
 export namespace CloudFrontOriginAccessIdentityInUse {
   export function isa(o: any): o is CloudFrontOriginAccessIdentityInUse {
-    return _smithy.isa(o, "CloudFrontOriginAccessIdentityInUse");
+    return __isa(o, "CloudFrontOriginAccessIdentityInUse");
   }
 }
 
@@ -5692,7 +5691,7 @@ export namespace CloudFrontOriginAccessIdentityInUse {
  * <p>The caller reference you attempted to create the distribution with is associated with another distribution.</p>
  */
 export interface DistributionAlreadyExists
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DistributionAlreadyExists";
   $fault: "client";
@@ -5701,7 +5700,7 @@ export interface DistributionAlreadyExists
 
 export namespace DistributionAlreadyExists {
   export function isa(o: any): o is DistributionAlreadyExists {
-    return _smithy.isa(o, "DistributionAlreadyExists");
+    return __isa(o, "DistributionAlreadyExists");
   }
 }
 
@@ -5710,7 +5709,7 @@ export namespace DistributionAlreadyExists {
  * 			the distribution before you can delete it.</p>
  */
 export interface DistributionNotDisabled
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DistributionNotDisabled";
   $fault: "client";
@@ -5719,7 +5718,7 @@ export interface DistributionNotDisabled
 
 export namespace DistributionNotDisabled {
   export function isa(o: any): o is DistributionNotDisabled {
-    return _smithy.isa(o, "DistributionNotDisabled");
+    return __isa(o, "DistributionNotDisabled");
   }
 }
 
@@ -5727,7 +5726,7 @@ export namespace DistributionNotDisabled {
  * <p>The specified configuration for field-level encryption already exists.</p>
  */
 export interface FieldLevelEncryptionConfigAlreadyExists
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "FieldLevelEncryptionConfigAlreadyExists";
   $fault: "client";
@@ -5736,7 +5735,7 @@ export interface FieldLevelEncryptionConfigAlreadyExists
 
 export namespace FieldLevelEncryptionConfigAlreadyExists {
   export function isa(o: any): o is FieldLevelEncryptionConfigAlreadyExists {
-    return _smithy.isa(o, "FieldLevelEncryptionConfigAlreadyExists");
+    return __isa(o, "FieldLevelEncryptionConfigAlreadyExists");
   }
 }
 
@@ -5744,7 +5743,7 @@ export namespace FieldLevelEncryptionConfigAlreadyExists {
  * <p>The specified configuration for field-level encryption is in use.</p>
  */
 export interface FieldLevelEncryptionConfigInUse
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "FieldLevelEncryptionConfigInUse";
   $fault: "client";
@@ -5753,7 +5752,7 @@ export interface FieldLevelEncryptionConfigInUse
 
 export namespace FieldLevelEncryptionConfigInUse {
   export function isa(o: any): o is FieldLevelEncryptionConfigInUse {
-    return _smithy.isa(o, "FieldLevelEncryptionConfigInUse");
+    return __isa(o, "FieldLevelEncryptionConfigInUse");
   }
 }
 
@@ -5761,7 +5760,7 @@ export namespace FieldLevelEncryptionConfigInUse {
  * <p>The specified profile for field-level encryption already exists.</p>
  */
 export interface FieldLevelEncryptionProfileAlreadyExists
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "FieldLevelEncryptionProfileAlreadyExists";
   $fault: "client";
@@ -5770,7 +5769,7 @@ export interface FieldLevelEncryptionProfileAlreadyExists
 
 export namespace FieldLevelEncryptionProfileAlreadyExists {
   export function isa(o: any): o is FieldLevelEncryptionProfileAlreadyExists {
-    return _smithy.isa(o, "FieldLevelEncryptionProfileAlreadyExists");
+    return __isa(o, "FieldLevelEncryptionProfileAlreadyExists");
   }
 }
 
@@ -5778,7 +5777,7 @@ export namespace FieldLevelEncryptionProfileAlreadyExists {
  * <p>The specified profile for field-level encryption is in use.</p>
  */
 export interface FieldLevelEncryptionProfileInUse
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "FieldLevelEncryptionProfileInUse";
   $fault: "client";
@@ -5787,7 +5786,7 @@ export interface FieldLevelEncryptionProfileInUse
 
 export namespace FieldLevelEncryptionProfileInUse {
   export function isa(o: any): o is FieldLevelEncryptionProfileInUse {
-    return _smithy.isa(o, "FieldLevelEncryptionProfileInUse");
+    return __isa(o, "FieldLevelEncryptionProfileInUse");
   }
 }
 
@@ -5795,7 +5794,7 @@ export namespace FieldLevelEncryptionProfileInUse {
  * <p>The maximum size of a profile for field-level encryption was exceeded.</p>
  */
 export interface FieldLevelEncryptionProfileSizeExceeded
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "FieldLevelEncryptionProfileSizeExceeded";
   $fault: "client";
@@ -5804,7 +5803,7 @@ export interface FieldLevelEncryptionProfileSizeExceeded
 
 export namespace FieldLevelEncryptionProfileSizeExceeded {
   export function isa(o: any): o is FieldLevelEncryptionProfileSizeExceeded {
-    return _smithy.isa(o, "FieldLevelEncryptionProfileSizeExceeded");
+    return __isa(o, "FieldLevelEncryptionProfileSizeExceeded");
   }
 }
 
@@ -5812,7 +5811,7 @@ export namespace FieldLevelEncryptionProfileSizeExceeded {
  * <p>The specified configuration for field-level encryption can't be associated with the specified cache behavior.</p>
  */
 export interface IllegalFieldLevelEncryptionConfigAssociationWithCacheBehavior
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "IllegalFieldLevelEncryptionConfigAssociationWithCacheBehavior";
   $fault: "client";
@@ -5823,7 +5822,7 @@ export namespace IllegalFieldLevelEncryptionConfigAssociationWithCacheBehavior {
   export function isa(
     o: any
   ): o is IllegalFieldLevelEncryptionConfigAssociationWithCacheBehavior {
-    return _smithy.isa(
+    return __isa(
       o,
       "IllegalFieldLevelEncryptionConfigAssociationWithCacheBehavior"
     );
@@ -5833,9 +5832,7 @@ export namespace IllegalFieldLevelEncryptionConfigAssociationWithCacheBehavior {
 /**
  * <p>Origin and <code>CallerReference</code> cannot be updated. </p>
  */
-export interface IllegalUpdate
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface IllegalUpdate extends __SmithyException, $MetadataBearer {
   name: "IllegalUpdate";
   $fault: "client";
   Message?: string;
@@ -5843,7 +5840,7 @@ export interface IllegalUpdate
 
 export namespace IllegalUpdate {
   export function isa(o: any): o is IllegalUpdate {
-    return _smithy.isa(o, "IllegalUpdate");
+    return __isa(o, "IllegalUpdate");
   }
 }
 
@@ -5851,7 +5848,7 @@ export namespace IllegalUpdate {
  * <p>The value of <code>Quantity</code> and the size of <code>Items</code> don't match.</p>
  */
 export interface InconsistentQuantities
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InconsistentQuantities";
   $fault: "client";
@@ -5860,16 +5857,14 @@ export interface InconsistentQuantities
 
 export namespace InconsistentQuantities {
   export function isa(o: any): o is InconsistentQuantities {
-    return _smithy.isa(o, "InconsistentQuantities");
+    return __isa(o, "InconsistentQuantities");
   }
 }
 
 /**
  * <p>The argument is invalid.</p>
  */
-export interface InvalidArgument
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface InvalidArgument extends __SmithyException, $MetadataBearer {
   name: "InvalidArgument";
   $fault: "client";
   Message?: string;
@@ -5877,7 +5872,7 @@ export interface InvalidArgument
 
 export namespace InvalidArgument {
   export function isa(o: any): o is InvalidArgument {
-    return _smithy.isa(o, "InvalidArgument");
+    return __isa(o, "InvalidArgument");
   }
 }
 
@@ -5885,7 +5880,7 @@ export namespace InvalidArgument {
  * <p>The default root object file name is too big or contains an invalid character.</p>
  */
 export interface InvalidDefaultRootObject
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidDefaultRootObject";
   $fault: "client";
@@ -5894,16 +5889,14 @@ export interface InvalidDefaultRootObject
 
 export namespace InvalidDefaultRootObject {
   export function isa(o: any): o is InvalidDefaultRootObject {
-    return _smithy.isa(o, "InvalidDefaultRootObject");
+    return __isa(o, "InvalidDefaultRootObject");
   }
 }
 
 /**
  * <p>An invalid error code was specified.</p>
  */
-export interface InvalidErrorCode
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface InvalidErrorCode extends __SmithyException, $MetadataBearer {
   name: "InvalidErrorCode";
   $fault: "client";
   Message?: string;
@@ -5911,7 +5904,7 @@ export interface InvalidErrorCode
 
 export namespace InvalidErrorCode {
   export function isa(o: any): o is InvalidErrorCode {
-    return _smithy.isa(o, "InvalidErrorCode");
+    return __isa(o, "InvalidErrorCode");
   }
 }
 
@@ -5920,7 +5913,7 @@ export namespace InvalidErrorCode {
  * 			list of cookie names. Either list of cookie names has been specified when not allowed or list of cookie names is missing when expected.</p>
  */
 export interface InvalidForwardCookies
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidForwardCookies";
   $fault: "client";
@@ -5929,7 +5922,7 @@ export interface InvalidForwardCookies
 
 export namespace InvalidForwardCookies {
   export function isa(o: any): o is InvalidForwardCookies {
-    return _smithy.isa(o, "InvalidForwardCookies");
+    return __isa(o, "InvalidForwardCookies");
   }
 }
 
@@ -5937,7 +5930,7 @@ export namespace InvalidForwardCookies {
  * <p>The specified geo restriction parameter is not valid.</p>
  */
 export interface InvalidGeoRestrictionParameter
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidGeoRestrictionParameter";
   $fault: "client";
@@ -5946,7 +5939,7 @@ export interface InvalidGeoRestrictionParameter
 
 export namespace InvalidGeoRestrictionParameter {
   export function isa(o: any): o is InvalidGeoRestrictionParameter {
-    return _smithy.isa(o, "InvalidGeoRestrictionParameter");
+    return __isa(o, "InvalidGeoRestrictionParameter");
   }
 }
 
@@ -5954,7 +5947,7 @@ export namespace InvalidGeoRestrictionParameter {
  * <p>The headers specified are not valid for an Amazon S3 origin.</p>
  */
 export interface InvalidHeadersForS3Origin
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidHeadersForS3Origin";
   $fault: "client";
@@ -5963,7 +5956,7 @@ export interface InvalidHeadersForS3Origin
 
 export namespace InvalidHeadersForS3Origin {
   export function isa(o: any): o is InvalidHeadersForS3Origin {
-    return _smithy.isa(o, "InvalidHeadersForS3Origin");
+    return __isa(o, "InvalidHeadersForS3Origin");
   }
 }
 
@@ -5971,7 +5964,7 @@ export namespace InvalidHeadersForS3Origin {
  * <p>The <code>If-Match</code> version is missing or not valid for the distribution.</p>
  */
 export interface InvalidIfMatchVersion
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidIfMatchVersion";
   $fault: "client";
@@ -5980,7 +5973,7 @@ export interface InvalidIfMatchVersion
 
 export namespace InvalidIfMatchVersion {
   export function isa(o: any): o is InvalidIfMatchVersion {
-    return _smithy.isa(o, "InvalidIfMatchVersion");
+    return __isa(o, "InvalidIfMatchVersion");
   }
 }
 
@@ -5988,7 +5981,7 @@ export namespace InvalidIfMatchVersion {
  * <p>The specified Lambda function association is invalid.</p>
  */
 export interface InvalidLambdaFunctionAssociation
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidLambdaFunctionAssociation";
   $fault: "client";
@@ -5997,7 +5990,7 @@ export interface InvalidLambdaFunctionAssociation
 
 export namespace InvalidLambdaFunctionAssociation {
   export function isa(o: any): o is InvalidLambdaFunctionAssociation {
-    return _smithy.isa(o, "InvalidLambdaFunctionAssociation");
+    return __isa(o, "InvalidLambdaFunctionAssociation");
   }
 }
 
@@ -6005,7 +5998,7 @@ export namespace InvalidLambdaFunctionAssociation {
  * <p>The location code specified is not valid.</p>
  */
 export interface InvalidLocationCode
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidLocationCode";
   $fault: "client";
@@ -6014,7 +6007,7 @@ export interface InvalidLocationCode
 
 export namespace InvalidLocationCode {
   export function isa(o: any): o is InvalidLocationCode {
-    return _smithy.isa(o, "InvalidLocationCode");
+    return __isa(o, "InvalidLocationCode");
   }
 }
 
@@ -6022,7 +6015,7 @@ export namespace InvalidLocationCode {
  * <p>The minimum protocol version specified is not valid.</p>
  */
 export interface InvalidMinimumProtocolVersion
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidMinimumProtocolVersion";
   $fault: "client";
@@ -6031,16 +6024,14 @@ export interface InvalidMinimumProtocolVersion
 
 export namespace InvalidMinimumProtocolVersion {
   export function isa(o: any): o is InvalidMinimumProtocolVersion {
-    return _smithy.isa(o, "InvalidMinimumProtocolVersion");
+    return __isa(o, "InvalidMinimumProtocolVersion");
   }
 }
 
 /**
  * <p>The Amazon S3 origin server specified does not refer to a valid Amazon S3 bucket.</p>
  */
-export interface InvalidOrigin
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface InvalidOrigin extends __SmithyException, $MetadataBearer {
   name: "InvalidOrigin";
   $fault: "client";
   Message?: string;
@@ -6048,7 +6039,7 @@ export interface InvalidOrigin
 
 export namespace InvalidOrigin {
   export function isa(o: any): o is InvalidOrigin {
-    return _smithy.isa(o, "InvalidOrigin");
+    return __isa(o, "InvalidOrigin");
   }
 }
 
@@ -6056,7 +6047,7 @@ export namespace InvalidOrigin {
  * <p>The origin access identity is not valid or doesn't exist.</p>
  */
 export interface InvalidOriginAccessIdentity
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidOriginAccessIdentity";
   $fault: "client";
@@ -6065,7 +6056,7 @@ export interface InvalidOriginAccessIdentity
 
 export namespace InvalidOriginAccessIdentity {
   export function isa(o: any): o is InvalidOriginAccessIdentity {
-    return _smithy.isa(o, "InvalidOriginAccessIdentity");
+    return __isa(o, "InvalidOriginAccessIdentity");
   }
 }
 
@@ -6073,7 +6064,7 @@ export namespace InvalidOriginAccessIdentity {
  * <p>The keep alive timeout specified for the origin is not valid.</p>
  */
 export interface InvalidOriginKeepaliveTimeout
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidOriginKeepaliveTimeout";
   $fault: "client";
@@ -6082,7 +6073,7 @@ export interface InvalidOriginKeepaliveTimeout
 
 export namespace InvalidOriginKeepaliveTimeout {
   export function isa(o: any): o is InvalidOriginKeepaliveTimeout {
-    return _smithy.isa(o, "InvalidOriginKeepaliveTimeout");
+    return __isa(o, "InvalidOriginKeepaliveTimeout");
   }
 }
 
@@ -6090,7 +6081,7 @@ export namespace InvalidOriginKeepaliveTimeout {
  * <p>The read timeout specified for the origin is not valid.</p>
  */
 export interface InvalidOriginReadTimeout
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidOriginReadTimeout";
   $fault: "client";
@@ -6099,7 +6090,7 @@ export interface InvalidOriginReadTimeout
 
 export namespace InvalidOriginReadTimeout {
   export function isa(o: any): o is InvalidOriginReadTimeout {
-    return _smithy.isa(o, "InvalidOriginReadTimeout");
+    return __isa(o, "InvalidOriginReadTimeout");
   }
 }
 
@@ -6108,7 +6099,7 @@ export namespace InvalidOriginReadTimeout {
  * 			Server Name Indication (SNI).</p>
  */
 export interface InvalidProtocolSettings
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidProtocolSettings";
   $fault: "client";
@@ -6117,7 +6108,7 @@ export interface InvalidProtocolSettings
 
 export namespace InvalidProtocolSettings {
   export function isa(o: any): o is InvalidProtocolSettings {
-    return _smithy.isa(o, "InvalidProtocolSettings");
+    return __isa(o, "InvalidProtocolSettings");
   }
 }
 
@@ -6125,7 +6116,7 @@ export namespace InvalidProtocolSettings {
  * <p>Query string parameters specified in the response body are not valid.</p>
  */
 export interface InvalidQueryStringParameters
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidQueryStringParameters";
   $fault: "client";
@@ -6134,7 +6125,7 @@ export interface InvalidQueryStringParameters
 
 export namespace InvalidQueryStringParameters {
   export function isa(o: any): o is InvalidQueryStringParameters {
-    return _smithy.isa(o, "InvalidQueryStringParameters");
+    return __isa(o, "InvalidQueryStringParameters");
   }
 }
 
@@ -6142,7 +6133,7 @@ export namespace InvalidQueryStringParameters {
  * <p>The relative path is too big, is not URL-encoded, or does not begin with a slash (/).</p>
  */
 export interface InvalidRelativePath
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidRelativePath";
   $fault: "client";
@@ -6151,7 +6142,7 @@ export interface InvalidRelativePath
 
 export namespace InvalidRelativePath {
   export function isa(o: any): o is InvalidRelativePath {
-    return _smithy.isa(o, "InvalidRelativePath");
+    return __isa(o, "InvalidRelativePath");
   }
 }
 
@@ -6160,7 +6151,7 @@ export namespace InvalidRelativePath {
  * 			<code>RequiredProtocols</code> element from your distribution configuration.</p>
  */
 export interface InvalidRequiredProtocol
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidRequiredProtocol";
   $fault: "client";
@@ -6169,7 +6160,7 @@ export interface InvalidRequiredProtocol
 
 export namespace InvalidRequiredProtocol {
   export function isa(o: any): o is InvalidRequiredProtocol {
-    return _smithy.isa(o, "InvalidRequiredProtocol");
+    return __isa(o, "InvalidRequiredProtocol");
   }
 }
 
@@ -6177,7 +6168,7 @@ export namespace InvalidRequiredProtocol {
  * <p>A response code specified in the response body is not valid.</p>
  */
 export interface InvalidResponseCode
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidResponseCode";
   $fault: "client";
@@ -6186,16 +6177,14 @@ export interface InvalidResponseCode
 
 export namespace InvalidResponseCode {
   export function isa(o: any): o is InvalidResponseCode {
-    return _smithy.isa(o, "InvalidResponseCode");
+    return __isa(o, "InvalidResponseCode");
   }
 }
 
 /**
  * <p>TTL order specified in the response body is not valid.</p>
  */
-export interface InvalidTTLOrder
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface InvalidTTLOrder extends __SmithyException, $MetadataBearer {
   name: "InvalidTTLOrder";
   $fault: "client";
   Message?: string;
@@ -6203,16 +6192,14 @@ export interface InvalidTTLOrder
 
 export namespace InvalidTTLOrder {
   export function isa(o: any): o is InvalidTTLOrder {
-    return _smithy.isa(o, "InvalidTTLOrder");
+    return __isa(o, "InvalidTTLOrder");
   }
 }
 
 /**
  * <p>Tagging specified in the response body is not valid.</p>
  */
-export interface InvalidTagging
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface InvalidTagging extends __SmithyException, $MetadataBearer {
   name: "InvalidTagging";
   $fault: "client";
   Message?: string;
@@ -6220,7 +6207,7 @@ export interface InvalidTagging
 
 export namespace InvalidTagging {
   export function isa(o: any): o is InvalidTagging {
-    return _smithy.isa(o, "InvalidTagging");
+    return __isa(o, "InvalidTagging");
   }
 }
 
@@ -6228,7 +6215,7 @@ export namespace InvalidTagging {
  * <p>A viewer certificate specified in the response body is not valid.</p>
  */
 export interface InvalidViewerCertificate
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidViewerCertificate";
   $fault: "client";
@@ -6237,7 +6224,7 @@ export interface InvalidViewerCertificate
 
 export namespace InvalidViewerCertificate {
   export function isa(o: any): o is InvalidViewerCertificate {
-    return _smithy.isa(o, "InvalidViewerCertificate");
+    return __isa(o, "InvalidViewerCertificate");
   }
 }
 
@@ -6248,9 +6235,7 @@ export namespace InvalidViewerCertificate {
  * 			To specify a web ACL created using AWS WAF Classic, use the ACL ID, for example
  * 			<code>473e64fd-f30b-4765-81a0-62ad96dd167a</code>.</p>
  */
-export interface InvalidWebACLId
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface InvalidWebACLId extends __SmithyException, $MetadataBearer {
   name: "InvalidWebACLId";
   $fault: "client";
   Message?: string;
@@ -6258,14 +6243,14 @@ export interface InvalidWebACLId
 
 export namespace InvalidWebACLId {
   export function isa(o: any): o is InvalidWebACLId {
-    return _smithy.isa(o, "InvalidWebACLId");
+    return __isa(o, "InvalidWebACLId");
   }
 }
 
 /**
  * <p>This operation requires a body. Ensure that the body is present and the <code>Content-Type</code> header is set.</p>
  */
-export interface MissingBody extends _smithy.SmithyException, $MetadataBearer {
+export interface MissingBody extends __SmithyException, $MetadataBearer {
   name: "MissingBody";
   $fault: "client";
   Message?: string;
@@ -6273,7 +6258,7 @@ export interface MissingBody extends _smithy.SmithyException, $MetadataBearer {
 
 export namespace MissingBody {
   export function isa(o: any): o is MissingBody {
-    return _smithy.isa(o, "MissingBody");
+    return __isa(o, "MissingBody");
   }
 }
 
@@ -6281,7 +6266,7 @@ export namespace MissingBody {
  * <p>The specified origin access identity does not exist.</p>
  */
 export interface NoSuchCloudFrontOriginAccessIdentity
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "NoSuchCloudFrontOriginAccessIdentity";
   $fault: "client";
@@ -6290,16 +6275,14 @@ export interface NoSuchCloudFrontOriginAccessIdentity
 
 export namespace NoSuchCloudFrontOriginAccessIdentity {
   export function isa(o: any): o is NoSuchCloudFrontOriginAccessIdentity {
-    return _smithy.isa(o, "NoSuchCloudFrontOriginAccessIdentity");
+    return __isa(o, "NoSuchCloudFrontOriginAccessIdentity");
   }
 }
 
 /**
  * <p>The specified distribution does not exist.</p>
  */
-export interface NoSuchDistribution
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface NoSuchDistribution extends __SmithyException, $MetadataBearer {
   name: "NoSuchDistribution";
   $fault: "client";
   Message?: string;
@@ -6307,7 +6290,7 @@ export interface NoSuchDistribution
 
 export namespace NoSuchDistribution {
   export function isa(o: any): o is NoSuchDistribution {
-    return _smithy.isa(o, "NoSuchDistribution");
+    return __isa(o, "NoSuchDistribution");
   }
 }
 
@@ -6315,7 +6298,7 @@ export namespace NoSuchDistribution {
  * <p>The specified configuration for field-level encryption doesn't exist.</p>
  */
 export interface NoSuchFieldLevelEncryptionConfig
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "NoSuchFieldLevelEncryptionConfig";
   $fault: "client";
@@ -6324,7 +6307,7 @@ export interface NoSuchFieldLevelEncryptionConfig
 
 export namespace NoSuchFieldLevelEncryptionConfig {
   export function isa(o: any): o is NoSuchFieldLevelEncryptionConfig {
-    return _smithy.isa(o, "NoSuchFieldLevelEncryptionConfig");
+    return __isa(o, "NoSuchFieldLevelEncryptionConfig");
   }
 }
 
@@ -6332,7 +6315,7 @@ export namespace NoSuchFieldLevelEncryptionConfig {
  * <p>The specified profile for field-level encryption doesn't exist.</p>
  */
 export interface NoSuchFieldLevelEncryptionProfile
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "NoSuchFieldLevelEncryptionProfile";
   $fault: "client";
@@ -6341,16 +6324,14 @@ export interface NoSuchFieldLevelEncryptionProfile
 
 export namespace NoSuchFieldLevelEncryptionProfile {
   export function isa(o: any): o is NoSuchFieldLevelEncryptionProfile {
-    return _smithy.isa(o, "NoSuchFieldLevelEncryptionProfile");
+    return __isa(o, "NoSuchFieldLevelEncryptionProfile");
   }
 }
 
 /**
  * <p>The specified invalidation does not exist.</p>
  */
-export interface NoSuchInvalidation
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface NoSuchInvalidation extends __SmithyException, $MetadataBearer {
   name: "NoSuchInvalidation";
   $fault: "client";
   Message?: string;
@@ -6358,14 +6339,14 @@ export interface NoSuchInvalidation
 
 export namespace NoSuchInvalidation {
   export function isa(o: any): o is NoSuchInvalidation {
-    return _smithy.isa(o, "NoSuchInvalidation");
+    return __isa(o, "NoSuchInvalidation");
   }
 }
 
 /**
  * <p>No origin exists with the specified <code>Origin Id</code>. </p>
  */
-export interface NoSuchOrigin extends _smithy.SmithyException, $MetadataBearer {
+export interface NoSuchOrigin extends __SmithyException, $MetadataBearer {
   name: "NoSuchOrigin";
   $fault: "client";
   Message?: string;
@@ -6373,16 +6354,14 @@ export interface NoSuchOrigin extends _smithy.SmithyException, $MetadataBearer {
 
 export namespace NoSuchOrigin {
   export function isa(o: any): o is NoSuchOrigin {
-    return _smithy.isa(o, "NoSuchOrigin");
+    return __isa(o, "NoSuchOrigin");
   }
 }
 
 /**
  * <p>The specified public key doesn't exist.</p>
  */
-export interface NoSuchPublicKey
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface NoSuchPublicKey extends __SmithyException, $MetadataBearer {
   name: "NoSuchPublicKey";
   $fault: "client";
   Message?: string;
@@ -6390,16 +6369,14 @@ export interface NoSuchPublicKey
 
 export namespace NoSuchPublicKey {
   export function isa(o: any): o is NoSuchPublicKey {
-    return _smithy.isa(o, "NoSuchPublicKey");
+    return __isa(o, "NoSuchPublicKey");
   }
 }
 
 /**
  * <p>A resource that was specified is not valid.</p>
  */
-export interface NoSuchResource
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface NoSuchResource extends __SmithyException, $MetadataBearer {
   name: "NoSuchResource";
   $fault: "client";
   Message?: string;
@@ -6407,7 +6384,7 @@ export interface NoSuchResource
 
 export namespace NoSuchResource {
   export function isa(o: any): o is NoSuchResource {
-    return _smithy.isa(o, "NoSuchResource");
+    return __isa(o, "NoSuchResource");
   }
 }
 
@@ -6415,7 +6392,7 @@ export namespace NoSuchResource {
  * <p>The specified streaming distribution does not exist.</p>
  */
 export interface NoSuchStreamingDistribution
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "NoSuchStreamingDistribution";
   $fault: "client";
@@ -6424,16 +6401,14 @@ export interface NoSuchStreamingDistribution
 
 export namespace NoSuchStreamingDistribution {
   export function isa(o: any): o is NoSuchStreamingDistribution {
-    return _smithy.isa(o, "NoSuchStreamingDistribution");
+    return __isa(o, "NoSuchStreamingDistribution");
   }
 }
 
 /**
  * <p>The precondition given in one or more of the request-header fields evaluated to <code>false</code>. </p>
  */
-export interface PreconditionFailed
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface PreconditionFailed extends __SmithyException, $MetadataBearer {
   name: "PreconditionFailed";
   $fault: "client";
   Message?: string;
@@ -6441,7 +6416,7 @@ export interface PreconditionFailed
 
 export namespace PreconditionFailed {
   export function isa(o: any): o is PreconditionFailed {
-    return _smithy.isa(o, "PreconditionFailed");
+    return __isa(o, "PreconditionFailed");
   }
 }
 
@@ -6449,7 +6424,7 @@ export namespace PreconditionFailed {
  * <p>The specified public key already exists.</p>
  */
 export interface PublicKeyAlreadyExists
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "PublicKeyAlreadyExists";
   $fault: "client";
@@ -6458,16 +6433,14 @@ export interface PublicKeyAlreadyExists
 
 export namespace PublicKeyAlreadyExists {
   export function isa(o: any): o is PublicKeyAlreadyExists {
-    return _smithy.isa(o, "PublicKeyAlreadyExists");
+    return __isa(o, "PublicKeyAlreadyExists");
   }
 }
 
 /**
  * <p>The specified public key is in use. </p>
  */
-export interface PublicKeyInUse
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface PublicKeyInUse extends __SmithyException, $MetadataBearer {
   name: "PublicKeyInUse";
   $fault: "client";
   Message?: string;
@@ -6475,7 +6448,7 @@ export interface PublicKeyInUse
 
 export namespace PublicKeyInUse {
   export function isa(o: any): o is PublicKeyInUse {
-    return _smithy.isa(o, "PublicKeyInUse");
+    return __isa(o, "PublicKeyInUse");
   }
 }
 
@@ -6483,7 +6456,7 @@ export namespace PublicKeyInUse {
  * <p>No profile specified for the field-level encryption query argument.</p>
  */
 export interface QueryArgProfileEmpty
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "QueryArgProfileEmpty";
   $fault: "client";
@@ -6492,7 +6465,7 @@ export interface QueryArgProfileEmpty
 
 export namespace QueryArgProfileEmpty {
   export function isa(o: any): o is QueryArgProfileEmpty {
-    return _smithy.isa(o, "QueryArgProfileEmpty");
+    return __isa(o, "QueryArgProfileEmpty");
   }
 }
 
@@ -6501,7 +6474,7 @@ export namespace QueryArgProfileEmpty {
  * 			is associated with another distribution</p>
  */
 export interface StreamingDistributionAlreadyExists
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "StreamingDistributionAlreadyExists";
   $fault: "client";
@@ -6510,7 +6483,7 @@ export interface StreamingDistributionAlreadyExists
 
 export namespace StreamingDistributionAlreadyExists {
   export function isa(o: any): o is StreamingDistributionAlreadyExists {
-    return _smithy.isa(o, "StreamingDistributionAlreadyExists");
+    return __isa(o, "StreamingDistributionAlreadyExists");
   }
 }
 
@@ -6519,7 +6492,7 @@ export namespace StreamingDistributionAlreadyExists {
  * 			the distribution before you can delete it.</p>
  */
 export interface StreamingDistributionNotDisabled
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "StreamingDistributionNotDisabled";
   $fault: "client";
@@ -6528,7 +6501,7 @@ export interface StreamingDistributionNotDisabled
 
 export namespace StreamingDistributionNotDisabled {
   export function isa(o: any): o is StreamingDistributionNotDisabled {
-    return _smithy.isa(o, "StreamingDistributionNotDisabled");
+    return __isa(o, "StreamingDistributionNotDisabled");
   }
 }
 
@@ -6536,7 +6509,7 @@ export namespace StreamingDistributionNotDisabled {
  * <p>You cannot create more cache behaviors for the distribution.</p>
  */
 export interface TooManyCacheBehaviors
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyCacheBehaviors";
   $fault: "client";
@@ -6545,7 +6518,7 @@ export interface TooManyCacheBehaviors
 
 export namespace TooManyCacheBehaviors {
   export function isa(o: any): o is TooManyCacheBehaviors {
-    return _smithy.isa(o, "TooManyCacheBehaviors");
+    return __isa(o, "TooManyCacheBehaviors");
   }
 }
 
@@ -6553,7 +6526,7 @@ export namespace TooManyCacheBehaviors {
  * <p>You cannot create anymore custom SSL/TLS certificates.</p>
  */
 export interface TooManyCertificates
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyCertificates";
   $fault: "client";
@@ -6562,7 +6535,7 @@ export interface TooManyCertificates
 
 export namespace TooManyCertificates {
   export function isa(o: any): o is TooManyCertificates {
-    return _smithy.isa(o, "TooManyCertificates");
+    return __isa(o, "TooManyCertificates");
   }
 }
 
@@ -6570,7 +6543,7 @@ export namespace TooManyCertificates {
  * <p>Processing your request would cause you to exceed the maximum number of origin access identities allowed.</p>
  */
 export interface TooManyCloudFrontOriginAccessIdentities
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyCloudFrontOriginAccessIdentities";
   $fault: "client";
@@ -6579,7 +6552,7 @@ export interface TooManyCloudFrontOriginAccessIdentities
 
 export namespace TooManyCloudFrontOriginAccessIdentities {
   export function isa(o: any): o is TooManyCloudFrontOriginAccessIdentities {
-    return _smithy.isa(o, "TooManyCloudFrontOriginAccessIdentities");
+    return __isa(o, "TooManyCloudFrontOriginAccessIdentities");
   }
 }
 
@@ -6587,7 +6560,7 @@ export namespace TooManyCloudFrontOriginAccessIdentities {
  * <p>Your request contains more cookie names in the whitelist than are allowed per cache behavior.</p>
  */
 export interface TooManyCookieNamesInWhiteList
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyCookieNamesInWhiteList";
   $fault: "client";
@@ -6596,7 +6569,7 @@ export interface TooManyCookieNamesInWhiteList
 
 export namespace TooManyCookieNamesInWhiteList {
   export function isa(o: any): o is TooManyCookieNamesInWhiteList {
-    return _smithy.isa(o, "TooManyCookieNamesInWhiteList");
+    return __isa(o, "TooManyCookieNamesInWhiteList");
   }
 }
 
@@ -6604,7 +6577,7 @@ export namespace TooManyCookieNamesInWhiteList {
  * <p>Your request contains more CNAMEs than are allowed per distribution.</p>
  */
 export interface TooManyDistributionCNAMEs
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyDistributionCNAMEs";
   $fault: "client";
@@ -6613,7 +6586,7 @@ export interface TooManyDistributionCNAMEs
 
 export namespace TooManyDistributionCNAMEs {
   export function isa(o: any): o is TooManyDistributionCNAMEs {
-    return _smithy.isa(o, "TooManyDistributionCNAMEs");
+    return __isa(o, "TooManyDistributionCNAMEs");
   }
 }
 
@@ -6621,7 +6594,7 @@ export namespace TooManyDistributionCNAMEs {
  * <p>Processing your request would cause you to exceed the maximum number of distributions allowed.</p>
  */
 export interface TooManyDistributions
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyDistributions";
   $fault: "client";
@@ -6630,7 +6603,7 @@ export interface TooManyDistributions
 
 export namespace TooManyDistributions {
   export function isa(o: any): o is TooManyDistributions {
-    return _smithy.isa(o, "TooManyDistributions");
+    return __isa(o, "TooManyDistributions");
   }
 }
 
@@ -6638,7 +6611,7 @@ export namespace TooManyDistributions {
  * <p>The maximum number of distributions have been associated with the specified configuration for field-level encryption.</p>
  */
 export interface TooManyDistributionsAssociatedToFieldLevelEncryptionConfig
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyDistributionsAssociatedToFieldLevelEncryptionConfig";
   $fault: "client";
@@ -6649,7 +6622,7 @@ export namespace TooManyDistributionsAssociatedToFieldLevelEncryptionConfig {
   export function isa(
     o: any
   ): o is TooManyDistributionsAssociatedToFieldLevelEncryptionConfig {
-    return _smithy.isa(
+    return __isa(
       o,
       "TooManyDistributionsAssociatedToFieldLevelEncryptionConfig"
     );
@@ -6661,7 +6634,7 @@ export namespace TooManyDistributionsAssociatedToFieldLevelEncryptionConfig {
  * 			to be exceeded.</p>
  */
 export interface TooManyDistributionsWithLambdaAssociations
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyDistributionsWithLambdaAssociations";
   $fault: "client";
@@ -6670,7 +6643,7 @@ export interface TooManyDistributionsWithLambdaAssociations
 
 export namespace TooManyDistributionsWithLambdaAssociations {
   export function isa(o: any): o is TooManyDistributionsWithLambdaAssociations {
-    return _smithy.isa(o, "TooManyDistributionsWithLambdaAssociations");
+    return __isa(o, "TooManyDistributionsWithLambdaAssociations");
   }
 }
 
@@ -6678,7 +6651,7 @@ export namespace TooManyDistributionsWithLambdaAssociations {
  * <p>The maximum number of configurations for field-level encryption have been created.</p>
  */
 export interface TooManyFieldLevelEncryptionConfigs
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyFieldLevelEncryptionConfigs";
   $fault: "client";
@@ -6687,7 +6660,7 @@ export interface TooManyFieldLevelEncryptionConfigs
 
 export namespace TooManyFieldLevelEncryptionConfigs {
   export function isa(o: any): o is TooManyFieldLevelEncryptionConfigs {
-    return _smithy.isa(o, "TooManyFieldLevelEncryptionConfigs");
+    return __isa(o, "TooManyFieldLevelEncryptionConfigs");
   }
 }
 
@@ -6695,7 +6668,7 @@ export namespace TooManyFieldLevelEncryptionConfigs {
  * <p>The maximum number of content type profiles for field-level encryption have been created.</p>
  */
 export interface TooManyFieldLevelEncryptionContentTypeProfiles
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyFieldLevelEncryptionContentTypeProfiles";
   $fault: "client";
@@ -6706,7 +6679,7 @@ export namespace TooManyFieldLevelEncryptionContentTypeProfiles {
   export function isa(
     o: any
   ): o is TooManyFieldLevelEncryptionContentTypeProfiles {
-    return _smithy.isa(o, "TooManyFieldLevelEncryptionContentTypeProfiles");
+    return __isa(o, "TooManyFieldLevelEncryptionContentTypeProfiles");
   }
 }
 
@@ -6714,7 +6687,7 @@ export namespace TooManyFieldLevelEncryptionContentTypeProfiles {
  * <p>The maximum number of encryption entities for field-level encryption have been created.</p>
  */
 export interface TooManyFieldLevelEncryptionEncryptionEntities
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyFieldLevelEncryptionEncryptionEntities";
   $fault: "client";
@@ -6725,7 +6698,7 @@ export namespace TooManyFieldLevelEncryptionEncryptionEntities {
   export function isa(
     o: any
   ): o is TooManyFieldLevelEncryptionEncryptionEntities {
-    return _smithy.isa(o, "TooManyFieldLevelEncryptionEncryptionEntities");
+    return __isa(o, "TooManyFieldLevelEncryptionEncryptionEntities");
   }
 }
 
@@ -6733,7 +6706,7 @@ export namespace TooManyFieldLevelEncryptionEncryptionEntities {
  * <p>The maximum number of field patterns for field-level encryption have been created.</p>
  */
 export interface TooManyFieldLevelEncryptionFieldPatterns
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyFieldLevelEncryptionFieldPatterns";
   $fault: "client";
@@ -6742,7 +6715,7 @@ export interface TooManyFieldLevelEncryptionFieldPatterns
 
 export namespace TooManyFieldLevelEncryptionFieldPatterns {
   export function isa(o: any): o is TooManyFieldLevelEncryptionFieldPatterns {
-    return _smithy.isa(o, "TooManyFieldLevelEncryptionFieldPatterns");
+    return __isa(o, "TooManyFieldLevelEncryptionFieldPatterns");
   }
 }
 
@@ -6750,7 +6723,7 @@ export namespace TooManyFieldLevelEncryptionFieldPatterns {
  * <p>The maximum number of profiles for field-level encryption have been created.</p>
  */
 export interface TooManyFieldLevelEncryptionProfiles
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyFieldLevelEncryptionProfiles";
   $fault: "client";
@@ -6759,7 +6732,7 @@ export interface TooManyFieldLevelEncryptionProfiles
 
 export namespace TooManyFieldLevelEncryptionProfiles {
   export function isa(o: any): o is TooManyFieldLevelEncryptionProfiles {
-    return _smithy.isa(o, "TooManyFieldLevelEncryptionProfiles");
+    return __isa(o, "TooManyFieldLevelEncryptionProfiles");
   }
 }
 
@@ -6767,7 +6740,7 @@ export namespace TooManyFieldLevelEncryptionProfiles {
  * <p>The maximum number of query arg profiles for field-level encryption have been created.</p>
  */
 export interface TooManyFieldLevelEncryptionQueryArgProfiles
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyFieldLevelEncryptionQueryArgProfiles";
   $fault: "client";
@@ -6778,7 +6751,7 @@ export namespace TooManyFieldLevelEncryptionQueryArgProfiles {
   export function isa(
     o: any
   ): o is TooManyFieldLevelEncryptionQueryArgProfiles {
-    return _smithy.isa(o, "TooManyFieldLevelEncryptionQueryArgProfiles");
+    return __isa(o, "TooManyFieldLevelEncryptionQueryArgProfiles");
   }
 }
 
@@ -6786,7 +6759,7 @@ export namespace TooManyFieldLevelEncryptionQueryArgProfiles {
  * <p>Your request contains too many headers in forwarded values.</p>
  */
 export interface TooManyHeadersInForwardedValues
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyHeadersInForwardedValues";
   $fault: "client";
@@ -6795,7 +6768,7 @@ export interface TooManyHeadersInForwardedValues
 
 export namespace TooManyHeadersInForwardedValues {
   export function isa(o: any): o is TooManyHeadersInForwardedValues {
-    return _smithy.isa(o, "TooManyHeadersInForwardedValues");
+    return __isa(o, "TooManyHeadersInForwardedValues");
   }
 }
 
@@ -6803,7 +6776,7 @@ export namespace TooManyHeadersInForwardedValues {
  * <p>You have exceeded the maximum number of allowable InProgress invalidation batch requests, or invalidation objects.</p>
  */
 export interface TooManyInvalidationsInProgress
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyInvalidationsInProgress";
   $fault: "client";
@@ -6812,7 +6785,7 @@ export interface TooManyInvalidationsInProgress
 
 export namespace TooManyInvalidationsInProgress {
   export function isa(o: any): o is TooManyInvalidationsInProgress {
-    return _smithy.isa(o, "TooManyInvalidationsInProgress");
+    return __isa(o, "TooManyInvalidationsInProgress");
   }
 }
 
@@ -6820,7 +6793,7 @@ export namespace TooManyInvalidationsInProgress {
  * <p>Your request contains more Lambda function associations than are allowed per distribution.</p>
  */
 export interface TooManyLambdaFunctionAssociations
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyLambdaFunctionAssociations";
   $fault: "client";
@@ -6829,7 +6802,7 @@ export interface TooManyLambdaFunctionAssociations
 
 export namespace TooManyLambdaFunctionAssociations {
   export function isa(o: any): o is TooManyLambdaFunctionAssociations {
-    return _smithy.isa(o, "TooManyLambdaFunctionAssociations");
+    return __isa(o, "TooManyLambdaFunctionAssociations");
   }
 }
 
@@ -6837,7 +6810,7 @@ export namespace TooManyLambdaFunctionAssociations {
  * <p>Your request contains too many origin custom headers.</p>
  */
 export interface TooManyOriginCustomHeaders
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyOriginCustomHeaders";
   $fault: "client";
@@ -6846,7 +6819,7 @@ export interface TooManyOriginCustomHeaders
 
 export namespace TooManyOriginCustomHeaders {
   export function isa(o: any): o is TooManyOriginCustomHeaders {
-    return _smithy.isa(o, "TooManyOriginCustomHeaders");
+    return __isa(o, "TooManyOriginCustomHeaders");
   }
 }
 
@@ -6854,7 +6827,7 @@ export namespace TooManyOriginCustomHeaders {
  * <p>Processing your request would cause you to exceed the maximum number of origin groups allowed.</p>
  */
 export interface TooManyOriginGroupsPerDistribution
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyOriginGroupsPerDistribution";
   $fault: "client";
@@ -6863,16 +6836,14 @@ export interface TooManyOriginGroupsPerDistribution
 
 export namespace TooManyOriginGroupsPerDistribution {
   export function isa(o: any): o is TooManyOriginGroupsPerDistribution {
-    return _smithy.isa(o, "TooManyOriginGroupsPerDistribution");
+    return __isa(o, "TooManyOriginGroupsPerDistribution");
   }
 }
 
 /**
  * <p>You cannot create more origins for the distribution.</p>
  */
-export interface TooManyOrigins
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface TooManyOrigins extends __SmithyException, $MetadataBearer {
   name: "TooManyOrigins";
   $fault: "client";
   Message?: string;
@@ -6880,16 +6851,14 @@ export interface TooManyOrigins
 
 export namespace TooManyOrigins {
   export function isa(o: any): o is TooManyOrigins {
-    return _smithy.isa(o, "TooManyOrigins");
+    return __isa(o, "TooManyOrigins");
   }
 }
 
 /**
  * <p>The maximum number of public keys for field-level encryption have been created. To create a new public key, delete one of the existing keys.</p>
  */
-export interface TooManyPublicKeys
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface TooManyPublicKeys extends __SmithyException, $MetadataBearer {
   name: "TooManyPublicKeys";
   $fault: "client";
   Message?: string;
@@ -6897,7 +6866,7 @@ export interface TooManyPublicKeys
 
 export namespace TooManyPublicKeys {
   export function isa(o: any): o is TooManyPublicKeys {
-    return _smithy.isa(o, "TooManyPublicKeys");
+    return __isa(o, "TooManyPublicKeys");
   }
 }
 
@@ -6905,7 +6874,7 @@ export namespace TooManyPublicKeys {
  * <p>Your request contains too many query string parameters.</p>
  */
 export interface TooManyQueryStringParameters
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyQueryStringParameters";
   $fault: "client";
@@ -6914,7 +6883,7 @@ export interface TooManyQueryStringParameters
 
 export namespace TooManyQueryStringParameters {
   export function isa(o: any): o is TooManyQueryStringParameters {
-    return _smithy.isa(o, "TooManyQueryStringParameters");
+    return __isa(o, "TooManyQueryStringParameters");
   }
 }
 
@@ -6922,7 +6891,7 @@ export namespace TooManyQueryStringParameters {
  * <p>Your request contains more CNAMEs than are allowed per distribution.</p>
  */
 export interface TooManyStreamingDistributionCNAMEs
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyStreamingDistributionCNAMEs";
   $fault: "client";
@@ -6931,7 +6900,7 @@ export interface TooManyStreamingDistributionCNAMEs
 
 export namespace TooManyStreamingDistributionCNAMEs {
   export function isa(o: any): o is TooManyStreamingDistributionCNAMEs {
-    return _smithy.isa(o, "TooManyStreamingDistributionCNAMEs");
+    return __isa(o, "TooManyStreamingDistributionCNAMEs");
   }
 }
 
@@ -6939,7 +6908,7 @@ export namespace TooManyStreamingDistributionCNAMEs {
  * <p>Processing your request would cause you to exceed the maximum number of streaming distributions allowed.</p>
  */
 export interface TooManyStreamingDistributions
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyStreamingDistributions";
   $fault: "client";
@@ -6948,7 +6917,7 @@ export interface TooManyStreamingDistributions
 
 export namespace TooManyStreamingDistributions {
   export function isa(o: any): o is TooManyStreamingDistributions {
-    return _smithy.isa(o, "TooManyStreamingDistributions");
+    return __isa(o, "TooManyStreamingDistributions");
   }
 }
 
@@ -6956,7 +6925,7 @@ export namespace TooManyStreamingDistributions {
  * <p>Your request contains more trusted signers than are allowed per distribution.</p>
  */
 export interface TooManyTrustedSigners
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyTrustedSigners";
   $fault: "client";
@@ -6965,7 +6934,7 @@ export interface TooManyTrustedSigners
 
 export namespace TooManyTrustedSigners {
   export function isa(o: any): o is TooManyTrustedSigners {
-    return _smithy.isa(o, "TooManyTrustedSigners");
+    return __isa(o, "TooManyTrustedSigners");
   }
 }
 
@@ -6973,7 +6942,7 @@ export namespace TooManyTrustedSigners {
  * <p>One or more of your trusted signers don't exist.</p>
  */
 export interface TrustedSignerDoesNotExist
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TrustedSignerDoesNotExist";
   $fault: "client";
@@ -6982,6 +6951,6 @@ export interface TrustedSignerDoesNotExist
 
 export namespace TrustedSignerDoesNotExist {
   export function isa(o: any): o is TrustedSignerDoesNotExist {
-    return _smithy.isa(o, "TrustedSignerDoesNotExist");
+    return __isa(o, "TrustedSignerDoesNotExist");
   }
 }

--- a/clients/client-cloudfront/protocols/Aws_restXml.ts
+++ b/clients/client-cloudfront/protocols/Aws_restXml.ts
@@ -349,7 +349,10 @@ import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  extendedEncodeURIComponent as __extendedEncodeURIComponent
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -529,7 +532,7 @@ export async function serializeAws_restXmlCreateInvalidationCommand(
   headers["Content-Type"] = "application/xml";
   let resolvedPath = "/2019-03-26/distribution/{DistributionId}/invalidation";
   if (input.DistributionId !== undefined) {
-    const labelValue: string = input.DistributionId.toString();
+    const labelValue: string = input.DistributionId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: DistributionId."
@@ -537,7 +540,7 @@ export async function serializeAws_restXmlCreateInvalidationCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{DistributionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DistributionId.");
@@ -670,15 +673,18 @@ export async function serializeAws_restXmlDeleteCloudFrontOriginAccessIdentityCo
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.IfMatch !== undefined) {
-    headers["If-Match"] = input.IfMatch.toString();
+    headers["If-Match"] = input.IfMatch;
   }
   let resolvedPath = "/2019-03-26/origin-access-identity/cloudfront/{Id}";
   if (input.Id !== undefined) {
-    const labelValue: string = input.Id.toString();
+    const labelValue: string = input.Id;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Id.");
     }
-    resolvedPath = resolvedPath.replace("{Id}", encodeURIComponent(labelValue));
+    resolvedPath = resolvedPath.replace(
+      "{Id}",
+      __extendedEncodeURIComponent(labelValue)
+    );
   } else {
     throw new Error("No value provided for input HTTP label: Id.");
   }
@@ -698,15 +704,18 @@ export async function serializeAws_restXmlDeleteDistributionCommand(
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.IfMatch !== undefined) {
-    headers["If-Match"] = input.IfMatch.toString();
+    headers["If-Match"] = input.IfMatch;
   }
   let resolvedPath = "/2019-03-26/distribution/{Id}";
   if (input.Id !== undefined) {
-    const labelValue: string = input.Id.toString();
+    const labelValue: string = input.Id;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Id.");
     }
-    resolvedPath = resolvedPath.replace("{Id}", encodeURIComponent(labelValue));
+    resolvedPath = resolvedPath.replace(
+      "{Id}",
+      __extendedEncodeURIComponent(labelValue)
+    );
   } else {
     throw new Error("No value provided for input HTTP label: Id.");
   }
@@ -726,15 +735,18 @@ export async function serializeAws_restXmlDeleteFieldLevelEncryptionConfigComman
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.IfMatch !== undefined) {
-    headers["If-Match"] = input.IfMatch.toString();
+    headers["If-Match"] = input.IfMatch;
   }
   let resolvedPath = "/2019-03-26/field-level-encryption/{Id}";
   if (input.Id !== undefined) {
-    const labelValue: string = input.Id.toString();
+    const labelValue: string = input.Id;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Id.");
     }
-    resolvedPath = resolvedPath.replace("{Id}", encodeURIComponent(labelValue));
+    resolvedPath = resolvedPath.replace(
+      "{Id}",
+      __extendedEncodeURIComponent(labelValue)
+    );
   } else {
     throw new Error("No value provided for input HTTP label: Id.");
   }
@@ -754,15 +766,18 @@ export async function serializeAws_restXmlDeleteFieldLevelEncryptionProfileComma
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.IfMatch !== undefined) {
-    headers["If-Match"] = input.IfMatch.toString();
+    headers["If-Match"] = input.IfMatch;
   }
   let resolvedPath = "/2019-03-26/field-level-encryption-profile/{Id}";
   if (input.Id !== undefined) {
-    const labelValue: string = input.Id.toString();
+    const labelValue: string = input.Id;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Id.");
     }
-    resolvedPath = resolvedPath.replace("{Id}", encodeURIComponent(labelValue));
+    resolvedPath = resolvedPath.replace(
+      "{Id}",
+      __extendedEncodeURIComponent(labelValue)
+    );
   } else {
     throw new Error("No value provided for input HTTP label: Id.");
   }
@@ -782,15 +797,18 @@ export async function serializeAws_restXmlDeletePublicKeyCommand(
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.IfMatch !== undefined) {
-    headers["If-Match"] = input.IfMatch.toString();
+    headers["If-Match"] = input.IfMatch;
   }
   let resolvedPath = "/2019-03-26/public-key/{Id}";
   if (input.Id !== undefined) {
-    const labelValue: string = input.Id.toString();
+    const labelValue: string = input.Id;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Id.");
     }
-    resolvedPath = resolvedPath.replace("{Id}", encodeURIComponent(labelValue));
+    resolvedPath = resolvedPath.replace(
+      "{Id}",
+      __extendedEncodeURIComponent(labelValue)
+    );
   } else {
     throw new Error("No value provided for input HTTP label: Id.");
   }
@@ -810,15 +828,18 @@ export async function serializeAws_restXmlDeleteStreamingDistributionCommand(
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.IfMatch !== undefined) {
-    headers["If-Match"] = input.IfMatch.toString();
+    headers["If-Match"] = input.IfMatch;
   }
   let resolvedPath = "/2019-03-26/streaming-distribution/{Id}";
   if (input.Id !== undefined) {
-    const labelValue: string = input.Id.toString();
+    const labelValue: string = input.Id;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Id.");
     }
-    resolvedPath = resolvedPath.replace("{Id}", encodeURIComponent(labelValue));
+    resolvedPath = resolvedPath.replace(
+      "{Id}",
+      __extendedEncodeURIComponent(labelValue)
+    );
   } else {
     throw new Error("No value provided for input HTTP label: Id.");
   }
@@ -839,11 +860,14 @@ export async function serializeAws_restXmlGetCloudFrontOriginAccessIdentityComma
   headers["Content-Type"] = "";
   let resolvedPath = "/2019-03-26/origin-access-identity/cloudfront/{Id}";
   if (input.Id !== undefined) {
-    const labelValue: string = input.Id.toString();
+    const labelValue: string = input.Id;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Id.");
     }
-    resolvedPath = resolvedPath.replace("{Id}", encodeURIComponent(labelValue));
+    resolvedPath = resolvedPath.replace(
+      "{Id}",
+      __extendedEncodeURIComponent(labelValue)
+    );
   } else {
     throw new Error("No value provided for input HTTP label: Id.");
   }
@@ -865,11 +889,14 @@ export async function serializeAws_restXmlGetCloudFrontOriginAccessIdentityConfi
   let resolvedPath =
     "/2019-03-26/origin-access-identity/cloudfront/{Id}/config";
   if (input.Id !== undefined) {
-    const labelValue: string = input.Id.toString();
+    const labelValue: string = input.Id;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Id.");
     }
-    resolvedPath = resolvedPath.replace("{Id}", encodeURIComponent(labelValue));
+    resolvedPath = resolvedPath.replace(
+      "{Id}",
+      __extendedEncodeURIComponent(labelValue)
+    );
   } else {
     throw new Error("No value provided for input HTTP label: Id.");
   }
@@ -890,11 +917,14 @@ export async function serializeAws_restXmlGetDistributionCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/2019-03-26/distribution/{Id}";
   if (input.Id !== undefined) {
-    const labelValue: string = input.Id.toString();
+    const labelValue: string = input.Id;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Id.");
     }
-    resolvedPath = resolvedPath.replace("{Id}", encodeURIComponent(labelValue));
+    resolvedPath = resolvedPath.replace(
+      "{Id}",
+      __extendedEncodeURIComponent(labelValue)
+    );
   } else {
     throw new Error("No value provided for input HTTP label: Id.");
   }
@@ -915,11 +945,14 @@ export async function serializeAws_restXmlGetDistributionConfigCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/2019-03-26/distribution/{Id}/config";
   if (input.Id !== undefined) {
-    const labelValue: string = input.Id.toString();
+    const labelValue: string = input.Id;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Id.");
     }
-    resolvedPath = resolvedPath.replace("{Id}", encodeURIComponent(labelValue));
+    resolvedPath = resolvedPath.replace(
+      "{Id}",
+      __extendedEncodeURIComponent(labelValue)
+    );
   } else {
     throw new Error("No value provided for input HTTP label: Id.");
   }
@@ -940,11 +973,14 @@ export async function serializeAws_restXmlGetFieldLevelEncryptionCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/2019-03-26/field-level-encryption/{Id}";
   if (input.Id !== undefined) {
-    const labelValue: string = input.Id.toString();
+    const labelValue: string = input.Id;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Id.");
     }
-    resolvedPath = resolvedPath.replace("{Id}", encodeURIComponent(labelValue));
+    resolvedPath = resolvedPath.replace(
+      "{Id}",
+      __extendedEncodeURIComponent(labelValue)
+    );
   } else {
     throw new Error("No value provided for input HTTP label: Id.");
   }
@@ -965,11 +1001,14 @@ export async function serializeAws_restXmlGetFieldLevelEncryptionConfigCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/2019-03-26/field-level-encryption/{Id}/config";
   if (input.Id !== undefined) {
-    const labelValue: string = input.Id.toString();
+    const labelValue: string = input.Id;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Id.");
     }
-    resolvedPath = resolvedPath.replace("{Id}", encodeURIComponent(labelValue));
+    resolvedPath = resolvedPath.replace(
+      "{Id}",
+      __extendedEncodeURIComponent(labelValue)
+    );
   } else {
     throw new Error("No value provided for input HTTP label: Id.");
   }
@@ -990,11 +1029,14 @@ export async function serializeAws_restXmlGetFieldLevelEncryptionProfileCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/2019-03-26/field-level-encryption-profile/{Id}";
   if (input.Id !== undefined) {
-    const labelValue: string = input.Id.toString();
+    const labelValue: string = input.Id;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Id.");
     }
-    resolvedPath = resolvedPath.replace("{Id}", encodeURIComponent(labelValue));
+    resolvedPath = resolvedPath.replace(
+      "{Id}",
+      __extendedEncodeURIComponent(labelValue)
+    );
   } else {
     throw new Error("No value provided for input HTTP label: Id.");
   }
@@ -1015,11 +1057,14 @@ export async function serializeAws_restXmlGetFieldLevelEncryptionProfileConfigCo
   headers["Content-Type"] = "";
   let resolvedPath = "/2019-03-26/field-level-encryption-profile/{Id}/config";
   if (input.Id !== undefined) {
-    const labelValue: string = input.Id.toString();
+    const labelValue: string = input.Id;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Id.");
     }
-    resolvedPath = resolvedPath.replace("{Id}", encodeURIComponent(labelValue));
+    resolvedPath = resolvedPath.replace(
+      "{Id}",
+      __extendedEncodeURIComponent(labelValue)
+    );
   } else {
     throw new Error("No value provided for input HTTP label: Id.");
   }
@@ -1041,7 +1086,7 @@ export async function serializeAws_restXmlGetInvalidationCommand(
   let resolvedPath =
     "/2019-03-26/distribution/{DistributionId}/invalidation/{Id}";
   if (input.DistributionId !== undefined) {
-    const labelValue: string = input.DistributionId.toString();
+    const labelValue: string = input.DistributionId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: DistributionId."
@@ -1049,17 +1094,20 @@ export async function serializeAws_restXmlGetInvalidationCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{DistributionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DistributionId.");
   }
   if (input.Id !== undefined) {
-    const labelValue: string = input.Id.toString();
+    const labelValue: string = input.Id;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Id.");
     }
-    resolvedPath = resolvedPath.replace("{Id}", encodeURIComponent(labelValue));
+    resolvedPath = resolvedPath.replace(
+      "{Id}",
+      __extendedEncodeURIComponent(labelValue)
+    );
   } else {
     throw new Error("No value provided for input HTTP label: Id.");
   }
@@ -1080,11 +1128,14 @@ export async function serializeAws_restXmlGetPublicKeyCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/2019-03-26/public-key/{Id}";
   if (input.Id !== undefined) {
-    const labelValue: string = input.Id.toString();
+    const labelValue: string = input.Id;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Id.");
     }
-    resolvedPath = resolvedPath.replace("{Id}", encodeURIComponent(labelValue));
+    resolvedPath = resolvedPath.replace(
+      "{Id}",
+      __extendedEncodeURIComponent(labelValue)
+    );
   } else {
     throw new Error("No value provided for input HTTP label: Id.");
   }
@@ -1105,11 +1156,14 @@ export async function serializeAws_restXmlGetPublicKeyConfigCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/2019-03-26/public-key/{Id}/config";
   if (input.Id !== undefined) {
-    const labelValue: string = input.Id.toString();
+    const labelValue: string = input.Id;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Id.");
     }
-    resolvedPath = resolvedPath.replace("{Id}", encodeURIComponent(labelValue));
+    resolvedPath = resolvedPath.replace(
+      "{Id}",
+      __extendedEncodeURIComponent(labelValue)
+    );
   } else {
     throw new Error("No value provided for input HTTP label: Id.");
   }
@@ -1130,11 +1184,14 @@ export async function serializeAws_restXmlGetStreamingDistributionCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/2019-03-26/streaming-distribution/{Id}";
   if (input.Id !== undefined) {
-    const labelValue: string = input.Id.toString();
+    const labelValue: string = input.Id;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Id.");
     }
-    resolvedPath = resolvedPath.replace("{Id}", encodeURIComponent(labelValue));
+    resolvedPath = resolvedPath.replace(
+      "{Id}",
+      __extendedEncodeURIComponent(labelValue)
+    );
   } else {
     throw new Error("No value provided for input HTTP label: Id.");
   }
@@ -1155,11 +1212,14 @@ export async function serializeAws_restXmlGetStreamingDistributionConfigCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/2019-03-26/streaming-distribution/{Id}/config";
   if (input.Id !== undefined) {
-    const labelValue: string = input.Id.toString();
+    const labelValue: string = input.Id;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Id.");
     }
-    resolvedPath = resolvedPath.replace("{Id}", encodeURIComponent(labelValue));
+    resolvedPath = resolvedPath.replace(
+      "{Id}",
+      __extendedEncodeURIComponent(labelValue)
+    );
   } else {
     throw new Error("No value provided for input HTTP label: Id.");
   }
@@ -1181,10 +1241,14 @@ export async function serializeAws_restXmlListCloudFrontOriginAccessIdentitiesCo
   let resolvedPath = "/2019-03-26/origin-access-identity/cloudfront";
   const query: any = {};
   if (input.Marker !== undefined) {
-    query["Marker"] = input.Marker.toString();
+    query[
+      __extendedEncodeURIComponent("Marker")
+    ] = __extendedEncodeURIComponent(input.Marker);
   }
   if (input.MaxItems !== undefined) {
-    query["MaxItems"] = input.MaxItems.toString();
+    query[
+      __extendedEncodeURIComponent("MaxItems")
+    ] = __extendedEncodeURIComponent(input.MaxItems);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1205,10 +1269,14 @@ export async function serializeAws_restXmlListDistributionsCommand(
   let resolvedPath = "/2019-03-26/distribution";
   const query: any = {};
   if (input.Marker !== undefined) {
-    query["Marker"] = input.Marker.toString();
+    query[
+      __extendedEncodeURIComponent("Marker")
+    ] = __extendedEncodeURIComponent(input.Marker);
   }
   if (input.MaxItems !== undefined) {
-    query["MaxItems"] = input.MaxItems.toString();
+    query[
+      __extendedEncodeURIComponent("MaxItems")
+    ] = __extendedEncodeURIComponent(input.MaxItems);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1228,23 +1296,27 @@ export async function serializeAws_restXmlListDistributionsByWebACLIdCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/2019-03-26/distributionsByWebACLId/{WebACLId}";
   if (input.WebACLId !== undefined) {
-    const labelValue: string = input.WebACLId.toString();
+    const labelValue: string = input.WebACLId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: WebACLId.");
     }
     resolvedPath = resolvedPath.replace(
       "{WebACLId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: WebACLId.");
   }
   const query: any = {};
   if (input.Marker !== undefined) {
-    query["Marker"] = input.Marker.toString();
+    query[
+      __extendedEncodeURIComponent("Marker")
+    ] = __extendedEncodeURIComponent(input.Marker);
   }
   if (input.MaxItems !== undefined) {
-    query["MaxItems"] = input.MaxItems.toString();
+    query[
+      __extendedEncodeURIComponent("MaxItems")
+    ] = __extendedEncodeURIComponent(input.MaxItems);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1265,10 +1337,14 @@ export async function serializeAws_restXmlListFieldLevelEncryptionConfigsCommand
   let resolvedPath = "/2019-03-26/field-level-encryption";
   const query: any = {};
   if (input.Marker !== undefined) {
-    query["Marker"] = input.Marker.toString();
+    query[
+      __extendedEncodeURIComponent("Marker")
+    ] = __extendedEncodeURIComponent(input.Marker);
   }
   if (input.MaxItems !== undefined) {
-    query["MaxItems"] = input.MaxItems.toString();
+    query[
+      __extendedEncodeURIComponent("MaxItems")
+    ] = __extendedEncodeURIComponent(input.MaxItems);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1289,10 +1365,14 @@ export async function serializeAws_restXmlListFieldLevelEncryptionProfilesComman
   let resolvedPath = "/2019-03-26/field-level-encryption-profile";
   const query: any = {};
   if (input.Marker !== undefined) {
-    query["Marker"] = input.Marker.toString();
+    query[
+      __extendedEncodeURIComponent("Marker")
+    ] = __extendedEncodeURIComponent(input.Marker);
   }
   if (input.MaxItems !== undefined) {
-    query["MaxItems"] = input.MaxItems.toString();
+    query[
+      __extendedEncodeURIComponent("MaxItems")
+    ] = __extendedEncodeURIComponent(input.MaxItems);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1312,7 +1392,7 @@ export async function serializeAws_restXmlListInvalidationsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/2019-03-26/distribution/{DistributionId}/invalidation";
   if (input.DistributionId !== undefined) {
-    const labelValue: string = input.DistributionId.toString();
+    const labelValue: string = input.DistributionId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: DistributionId."
@@ -1320,17 +1400,21 @@ export async function serializeAws_restXmlListInvalidationsCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{DistributionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DistributionId.");
   }
   const query: any = {};
   if (input.Marker !== undefined) {
-    query["Marker"] = input.Marker.toString();
+    query[
+      __extendedEncodeURIComponent("Marker")
+    ] = __extendedEncodeURIComponent(input.Marker);
   }
   if (input.MaxItems !== undefined) {
-    query["MaxItems"] = input.MaxItems.toString();
+    query[
+      __extendedEncodeURIComponent("MaxItems")
+    ] = __extendedEncodeURIComponent(input.MaxItems);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1351,10 +1435,14 @@ export async function serializeAws_restXmlListPublicKeysCommand(
   let resolvedPath = "/2019-03-26/public-key";
   const query: any = {};
   if (input.Marker !== undefined) {
-    query["Marker"] = input.Marker.toString();
+    query[
+      __extendedEncodeURIComponent("Marker")
+    ] = __extendedEncodeURIComponent(input.Marker);
   }
   if (input.MaxItems !== undefined) {
-    query["MaxItems"] = input.MaxItems.toString();
+    query[
+      __extendedEncodeURIComponent("MaxItems")
+    ] = __extendedEncodeURIComponent(input.MaxItems);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1375,10 +1463,14 @@ export async function serializeAws_restXmlListStreamingDistributionsCommand(
   let resolvedPath = "/2019-03-26/streaming-distribution";
   const query: any = {};
   if (input.Marker !== undefined) {
-    query["Marker"] = input.Marker.toString();
+    query[
+      __extendedEncodeURIComponent("Marker")
+    ] = __extendedEncodeURIComponent(input.Marker);
   }
   if (input.MaxItems !== undefined) {
-    query["MaxItems"] = input.MaxItems.toString();
+    query[
+      __extendedEncodeURIComponent("MaxItems")
+    ] = __extendedEncodeURIComponent(input.MaxItems);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1399,7 +1491,9 @@ export async function serializeAws_restXmlListTagsForResourceCommand(
   let resolvedPath = "/2019-03-26/tagging";
   const query: any = {};
   if (input.Resource !== undefined) {
-    query["Resource"] = input.Resource.toString();
+    query[
+      __extendedEncodeURIComponent("Resource")
+    ] = __extendedEncodeURIComponent(input.Resource);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1422,7 +1516,9 @@ export async function serializeAws_restXmlTagResourceCommand(
     Operation: "Tag"
   };
   if (input.Resource !== undefined) {
-    query["Resource"] = input.Resource.toString();
+    query[
+      __extendedEncodeURIComponent("Resource")
+    ] = __extendedEncodeURIComponent(input.Resource);
   }
   let body: any;
   let contents: any;
@@ -1457,7 +1553,9 @@ export async function serializeAws_restXmlUntagResourceCommand(
     Operation: "Untag"
   };
   if (input.Resource !== undefined) {
-    query["Resource"] = input.Resource.toString();
+    query[
+      __extendedEncodeURIComponent("Resource")
+    ] = __extendedEncodeURIComponent(input.Resource);
   }
   let body: any;
   let contents: any;
@@ -1488,16 +1586,19 @@ export async function serializeAws_restXmlUpdateCloudFrontOriginAccessIdentityCo
   const headers: any = {};
   headers["Content-Type"] = "application/xml";
   if (input.IfMatch !== undefined) {
-    headers["If-Match"] = input.IfMatch.toString();
+    headers["If-Match"] = input.IfMatch;
   }
   let resolvedPath =
     "/2019-03-26/origin-access-identity/cloudfront/{Id}/config";
   if (input.Id !== undefined) {
-    const labelValue: string = input.Id.toString();
+    const labelValue: string = input.Id;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Id.");
     }
-    resolvedPath = resolvedPath.replace("{Id}", encodeURIComponent(labelValue));
+    resolvedPath = resolvedPath.replace(
+      "{Id}",
+      __extendedEncodeURIComponent(labelValue)
+    );
   } else {
     throw new Error("No value provided for input HTTP label: Id.");
   }
@@ -1532,15 +1633,18 @@ export async function serializeAws_restXmlUpdateDistributionCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/xml";
   if (input.IfMatch !== undefined) {
-    headers["If-Match"] = input.IfMatch.toString();
+    headers["If-Match"] = input.IfMatch;
   }
   let resolvedPath = "/2019-03-26/distribution/{Id}/config";
   if (input.Id !== undefined) {
-    const labelValue: string = input.Id.toString();
+    const labelValue: string = input.Id;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Id.");
     }
-    resolvedPath = resolvedPath.replace("{Id}", encodeURIComponent(labelValue));
+    resolvedPath = resolvedPath.replace(
+      "{Id}",
+      __extendedEncodeURIComponent(labelValue)
+    );
   } else {
     throw new Error("No value provided for input HTTP label: Id.");
   }
@@ -1575,15 +1679,18 @@ export async function serializeAws_restXmlUpdateFieldLevelEncryptionConfigComman
   const headers: any = {};
   headers["Content-Type"] = "application/xml";
   if (input.IfMatch !== undefined) {
-    headers["If-Match"] = input.IfMatch.toString();
+    headers["If-Match"] = input.IfMatch;
   }
   let resolvedPath = "/2019-03-26/field-level-encryption/{Id}/config";
   if (input.Id !== undefined) {
-    const labelValue: string = input.Id.toString();
+    const labelValue: string = input.Id;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Id.");
     }
-    resolvedPath = resolvedPath.replace("{Id}", encodeURIComponent(labelValue));
+    resolvedPath = resolvedPath.replace(
+      "{Id}",
+      __extendedEncodeURIComponent(labelValue)
+    );
   } else {
     throw new Error("No value provided for input HTTP label: Id.");
   }
@@ -1618,15 +1725,18 @@ export async function serializeAws_restXmlUpdateFieldLevelEncryptionProfileComma
   const headers: any = {};
   headers["Content-Type"] = "application/xml";
   if (input.IfMatch !== undefined) {
-    headers["If-Match"] = input.IfMatch.toString();
+    headers["If-Match"] = input.IfMatch;
   }
   let resolvedPath = "/2019-03-26/field-level-encryption-profile/{Id}/config";
   if (input.Id !== undefined) {
-    const labelValue: string = input.Id.toString();
+    const labelValue: string = input.Id;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Id.");
     }
-    resolvedPath = resolvedPath.replace("{Id}", encodeURIComponent(labelValue));
+    resolvedPath = resolvedPath.replace(
+      "{Id}",
+      __extendedEncodeURIComponent(labelValue)
+    );
   } else {
     throw new Error("No value provided for input HTTP label: Id.");
   }
@@ -1661,15 +1771,18 @@ export async function serializeAws_restXmlUpdatePublicKeyCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/xml";
   if (input.IfMatch !== undefined) {
-    headers["If-Match"] = input.IfMatch.toString();
+    headers["If-Match"] = input.IfMatch;
   }
   let resolvedPath = "/2019-03-26/public-key/{Id}/config";
   if (input.Id !== undefined) {
-    const labelValue: string = input.Id.toString();
+    const labelValue: string = input.Id;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Id.");
     }
-    resolvedPath = resolvedPath.replace("{Id}", encodeURIComponent(labelValue));
+    resolvedPath = resolvedPath.replace(
+      "{Id}",
+      __extendedEncodeURIComponent(labelValue)
+    );
   } else {
     throw new Error("No value provided for input HTTP label: Id.");
   }
@@ -1704,15 +1817,18 @@ export async function serializeAws_restXmlUpdateStreamingDistributionCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/xml";
   if (input.IfMatch !== undefined) {
-    headers["If-Match"] = input.IfMatch.toString();
+    headers["If-Match"] = input.IfMatch;
   }
   let resolvedPath = "/2019-03-26/streaming-distribution/{Id}/config";
   if (input.Id !== undefined) {
-    const labelValue: string = input.Id.toString();
+    const labelValue: string = input.Id;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Id.");
     }
-    resolvedPath = resolvedPath.replace("{Id}", encodeURIComponent(labelValue));
+    resolvedPath = resolvedPath.replace(
+      "{Id}",
+      __extendedEncodeURIComponent(labelValue)
+    );
   } else {
     throw new Error("No value provided for input HTTP label: Id.");
   }
@@ -3298,6 +3414,7 @@ export async function deserializeAws_restXmlDeleteCloudFrontOriginAccessIdentity
   const contents: DeleteCloudFrontOriginAccessIdentityCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -3379,6 +3496,7 @@ export async function deserializeAws_restXmlDeleteDistributionCommand(
   const contents: DeleteDistributionCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -3460,6 +3578,7 @@ export async function deserializeAws_restXmlDeleteFieldLevelEncryptionConfigComm
   const contents: DeleteFieldLevelEncryptionConfigCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -3541,6 +3660,7 @@ export async function deserializeAws_restXmlDeleteFieldLevelEncryptionProfileCom
   const contents: DeleteFieldLevelEncryptionProfileCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -3619,6 +3739,7 @@ export async function deserializeAws_restXmlDeletePublicKeyCommand(
   const contents: DeletePublicKeyCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -3700,6 +3821,7 @@ export async function deserializeAws_restXmlDeleteStreamingDistributionCommand(
   const contents: DeleteStreamingDistributionCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -5253,6 +5375,7 @@ export async function deserializeAws_restXmlTagResourceCommand(
   const contents: TagResourceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -5324,6 +5447,7 @@ export async function deserializeAws_restXmlUntagResourceCommand(
   const contents: UntagResourceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 

--- a/clients/client-cloudhsm-v2/models/index.ts
+++ b/clients/client-cloudhsm-v2/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -62,7 +65,7 @@ export interface Backup {
 
 export namespace Backup {
   export function isa(o: any): o is Backup {
-    return _smithy.isa(o, "Backup");
+    return __isa(o, "Backup");
   }
 }
 
@@ -112,7 +115,7 @@ export interface Certificates {
 
 export namespace Certificates {
   export function isa(o: any): o is Certificates {
-    return _smithy.isa(o, "Certificates");
+    return __isa(o, "Certificates");
   }
 }
 
@@ -192,7 +195,7 @@ export interface Cluster {
 
 export namespace Cluster {
   export function isa(o: any): o is Cluster {
-    return _smithy.isa(o, "Cluster");
+    return __isa(o, "Cluster");
   }
 }
 
@@ -225,7 +228,7 @@ export interface CopyBackupToRegionRequest {
 
 export namespace CopyBackupToRegionRequest {
   export function isa(o: any): o is CopyBackupToRegionRequest {
-    return _smithy.isa(o, "CopyBackupToRegionRequest");
+    return __isa(o, "CopyBackupToRegionRequest");
   }
 }
 
@@ -244,7 +247,7 @@ export interface CopyBackupToRegionResponse extends $MetadataBearer {
 
 export namespace CopyBackupToRegionResponse {
   export function isa(o: any): o is CopyBackupToRegionResponse {
-    return _smithy.isa(o, "CopyBackupToRegionResponse");
+    return __isa(o, "CopyBackupToRegionResponse");
   }
 }
 
@@ -282,7 +285,7 @@ export interface CreateClusterRequest {
 
 export namespace CreateClusterRequest {
   export function isa(o: any): o is CreateClusterRequest {
-    return _smithy.isa(o, "CreateClusterRequest");
+    return __isa(o, "CreateClusterRequest");
   }
 }
 
@@ -296,7 +299,7 @@ export interface CreateClusterResponse extends $MetadataBearer {
 
 export namespace CreateClusterResponse {
   export function isa(o: any): o is CreateClusterResponse {
-    return _smithy.isa(o, "CreateClusterResponse");
+    return __isa(o, "CreateClusterResponse");
   }
 }
 
@@ -323,7 +326,7 @@ export interface CreateHsmRequest {
 
 export namespace CreateHsmRequest {
   export function isa(o: any): o is CreateHsmRequest {
-    return _smithy.isa(o, "CreateHsmRequest");
+    return __isa(o, "CreateHsmRequest");
   }
 }
 
@@ -337,7 +340,7 @@ export interface CreateHsmResponse extends $MetadataBearer {
 
 export namespace CreateHsmResponse {
   export function isa(o: any): o is CreateHsmResponse {
-    return _smithy.isa(o, "CreateHsmResponse");
+    return __isa(o, "CreateHsmResponse");
   }
 }
 
@@ -351,7 +354,7 @@ export interface DeleteBackupRequest {
 
 export namespace DeleteBackupRequest {
   export function isa(o: any): o is DeleteBackupRequest {
-    return _smithy.isa(o, "DeleteBackupRequest");
+    return __isa(o, "DeleteBackupRequest");
   }
 }
 
@@ -365,7 +368,7 @@ export interface DeleteBackupResponse extends $MetadataBearer {
 
 export namespace DeleteBackupResponse {
   export function isa(o: any): o is DeleteBackupResponse {
-    return _smithy.isa(o, "DeleteBackupResponse");
+    return __isa(o, "DeleteBackupResponse");
   }
 }
 
@@ -380,7 +383,7 @@ export interface DeleteClusterRequest {
 
 export namespace DeleteClusterRequest {
   export function isa(o: any): o is DeleteClusterRequest {
-    return _smithy.isa(o, "DeleteClusterRequest");
+    return __isa(o, "DeleteClusterRequest");
   }
 }
 
@@ -394,7 +397,7 @@ export interface DeleteClusterResponse extends $MetadataBearer {
 
 export namespace DeleteClusterResponse {
   export function isa(o: any): o is DeleteClusterResponse {
-    return _smithy.isa(o, "DeleteClusterResponse");
+    return __isa(o, "DeleteClusterResponse");
   }
 }
 
@@ -426,7 +429,7 @@ export interface DeleteHsmRequest {
 
 export namespace DeleteHsmRequest {
   export function isa(o: any): o is DeleteHsmRequest {
-    return _smithy.isa(o, "DeleteHsmRequest");
+    return __isa(o, "DeleteHsmRequest");
   }
 }
 
@@ -440,7 +443,7 @@ export interface DeleteHsmResponse extends $MetadataBearer {
 
 export namespace DeleteHsmResponse {
   export function isa(o: any): o is DeleteHsmResponse {
-    return _smithy.isa(o, "DeleteHsmResponse");
+    return __isa(o, "DeleteHsmResponse");
   }
 }
 
@@ -480,7 +483,7 @@ export interface DescribeBackupsRequest {
 
 export namespace DescribeBackupsRequest {
   export function isa(o: any): o is DescribeBackupsRequest {
-    return _smithy.isa(o, "DescribeBackupsRequest");
+    return __isa(o, "DescribeBackupsRequest");
   }
 }
 
@@ -501,7 +504,7 @@ export interface DescribeBackupsResponse extends $MetadataBearer {
 
 export namespace DescribeBackupsResponse {
   export function isa(o: any): o is DescribeBackupsResponse {
-    return _smithy.isa(o, "DescribeBackupsResponse");
+    return __isa(o, "DescribeBackupsResponse");
   }
 }
 
@@ -533,7 +536,7 @@ export interface DescribeClustersRequest {
 
 export namespace DescribeClustersRequest {
   export function isa(o: any): o is DescribeClustersRequest {
-    return _smithy.isa(o, "DescribeClustersRequest");
+    return __isa(o, "DescribeClustersRequest");
   }
 }
 
@@ -554,7 +557,7 @@ export interface DescribeClustersResponse extends $MetadataBearer {
 
 export namespace DescribeClustersResponse {
   export function isa(o: any): o is DescribeClustersResponse {
-    return _smithy.isa(o, "DescribeClustersResponse");
+    return __isa(o, "DescribeClustersResponse");
   }
 }
 
@@ -586,7 +589,7 @@ export interface DestinationBackup {
 
 export namespace DestinationBackup {
   export function isa(o: any): o is DestinationBackup {
-    return _smithy.isa(o, "DestinationBackup");
+    return __isa(o, "DestinationBackup");
   }
 }
 
@@ -639,7 +642,7 @@ export interface Hsm {
 
 export namespace Hsm {
   export function isa(o: any): o is Hsm {
-    return _smithy.isa(o, "Hsm");
+    return __isa(o, "Hsm");
   }
 }
 
@@ -676,7 +679,7 @@ export interface InitializeClusterRequest {
 
 export namespace InitializeClusterRequest {
   export function isa(o: any): o is InitializeClusterRequest {
-    return _smithy.isa(o, "InitializeClusterRequest");
+    return __isa(o, "InitializeClusterRequest");
   }
 }
 
@@ -695,7 +698,7 @@ export interface InitializeClusterResponse extends $MetadataBearer {
 
 export namespace InitializeClusterResponse {
   export function isa(o: any): o is InitializeClusterResponse {
-    return _smithy.isa(o, "InitializeClusterResponse");
+    return __isa(o, "InitializeClusterResponse");
   }
 }
 
@@ -722,7 +725,7 @@ export interface ListTagsRequest {
 
 export namespace ListTagsRequest {
   export function isa(o: any): o is ListTagsRequest {
-    return _smithy.isa(o, "ListTagsRequest");
+    return __isa(o, "ListTagsRequest");
   }
 }
 
@@ -742,7 +745,7 @@ export interface ListTagsResponse extends $MetadataBearer {
 
 export namespace ListTagsResponse {
   export function isa(o: any): o is ListTagsResponse {
-    return _smithy.isa(o, "ListTagsResponse");
+    return __isa(o, "ListTagsResponse");
   }
 }
 
@@ -756,7 +759,7 @@ export interface RestoreBackupRequest {
 
 export namespace RestoreBackupRequest {
   export function isa(o: any): o is RestoreBackupRequest {
-    return _smithy.isa(o, "RestoreBackupRequest");
+    return __isa(o, "RestoreBackupRequest");
   }
 }
 
@@ -770,7 +773,7 @@ export interface RestoreBackupResponse extends $MetadataBearer {
 
 export namespace RestoreBackupResponse {
   export function isa(o: any): o is RestoreBackupResponse {
-    return _smithy.isa(o, "RestoreBackupResponse");
+    return __isa(o, "RestoreBackupResponse");
   }
 }
 
@@ -792,7 +795,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -812,7 +815,7 @@ export interface TagResourceRequest {
 
 export namespace TagResourceRequest {
   export function isa(o: any): o is TagResourceRequest {
-    return _smithy.isa(o, "TagResourceRequest");
+    return __isa(o, "TagResourceRequest");
   }
 }
 
@@ -822,7 +825,7 @@ export interface TagResourceResponse extends $MetadataBearer {
 
 export namespace TagResourceResponse {
   export function isa(o: any): o is TagResourceResponse {
-    return _smithy.isa(o, "TagResourceResponse");
+    return __isa(o, "TagResourceResponse");
   }
 }
 
@@ -843,7 +846,7 @@ export interface UntagResourceRequest {
 
 export namespace UntagResourceRequest {
   export function isa(o: any): o is UntagResourceRequest {
-    return _smithy.isa(o, "UntagResourceRequest");
+    return __isa(o, "UntagResourceRequest");
   }
 }
 
@@ -853,7 +856,7 @@ export interface UntagResourceResponse extends $MetadataBearer {
 
 export namespace UntagResourceResponse {
   export function isa(o: any): o is UntagResourceResponse {
-    return _smithy.isa(o, "UntagResourceResponse");
+    return __isa(o, "UntagResourceResponse");
   }
 }
 
@@ -862,7 +865,7 @@ export namespace UntagResourceResponse {
  *       requested operation.</p>
  */
 export interface CloudHsmAccessDeniedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CloudHsmAccessDeniedException";
   $fault: "client";
@@ -871,7 +874,7 @@ export interface CloudHsmAccessDeniedException
 
 export namespace CloudHsmAccessDeniedException {
   export function isa(o: any): o is CloudHsmAccessDeniedException {
-    return _smithy.isa(o, "CloudHsmAccessDeniedException");
+    return __isa(o, "CloudHsmAccessDeniedException");
   }
 }
 
@@ -880,7 +883,7 @@ export namespace CloudHsmAccessDeniedException {
  *       be retried.</p>
  */
 export interface CloudHsmInternalFailureException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CloudHsmInternalFailureException";
   $fault: "server";
@@ -889,7 +892,7 @@ export interface CloudHsmInternalFailureException
 
 export namespace CloudHsmInternalFailureException {
   export function isa(o: any): o is CloudHsmInternalFailureException {
-    return _smithy.isa(o, "CloudHsmInternalFailureException");
+    return __isa(o, "CloudHsmInternalFailureException");
   }
 }
 
@@ -897,7 +900,7 @@ export namespace CloudHsmInternalFailureException {
  * <p>The request was rejected because it is not a valid request.</p>
  */
 export interface CloudHsmInvalidRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CloudHsmInvalidRequestException";
   $fault: "client";
@@ -906,7 +909,7 @@ export interface CloudHsmInvalidRequestException
 
 export namespace CloudHsmInvalidRequestException {
   export function isa(o: any): o is CloudHsmInvalidRequestException {
-    return _smithy.isa(o, "CloudHsmInvalidRequestException");
+    return __isa(o, "CloudHsmInvalidRequestException");
   }
 }
 
@@ -915,7 +918,7 @@ export namespace CloudHsmInvalidRequestException {
  *       found.</p>
  */
 export interface CloudHsmResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CloudHsmResourceNotFoundException";
   $fault: "client";
@@ -924,7 +927,7 @@ export interface CloudHsmResourceNotFoundException
 
 export namespace CloudHsmResourceNotFoundException {
   export function isa(o: any): o is CloudHsmResourceNotFoundException {
-    return _smithy.isa(o, "CloudHsmResourceNotFoundException");
+    return __isa(o, "CloudHsmResourceNotFoundException");
   }
 }
 
@@ -932,7 +935,7 @@ export namespace CloudHsmResourceNotFoundException {
  * <p>The request was rejected because an error occurred.</p>
  */
 export interface CloudHsmServiceException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CloudHsmServiceException";
   $fault: "client";
@@ -941,12 +944,12 @@ export interface CloudHsmServiceException
 
 export namespace CloudHsmServiceException {
   export function isa(o: any): o is CloudHsmServiceException {
-    return _smithy.isa(o, "CloudHsmServiceException");
+    return __isa(o, "CloudHsmServiceException");
   }
 }
 
 export interface CloudHsmTagException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CloudHsmTagException";
   $fault: "client";
@@ -955,6 +958,6 @@ export interface CloudHsmTagException
 
 export namespace CloudHsmTagException {
   export function isa(o: any): o is CloudHsmTagException {
-    return _smithy.isa(o, "CloudHsmTagException");
+    return __isa(o, "CloudHsmTagException");
   }
 }

--- a/clients/client-cloudhsm/models/index.ts
+++ b/clients/client-cloudhsm/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export interface AddTagsToResourceRequest {
@@ -16,7 +19,7 @@ export interface AddTagsToResourceRequest {
 
 export namespace AddTagsToResourceRequest {
   export function isa(o: any): o is AddTagsToResourceRequest {
-    return _smithy.isa(o, "AddTagsToResourceRequest");
+    return __isa(o, "AddTagsToResourceRequest");
   }
 }
 
@@ -30,7 +33,7 @@ export interface AddTagsToResourceResponse extends $MetadataBearer {
 
 export namespace AddTagsToResourceResponse {
   export function isa(o: any): o is AddTagsToResourceResponse {
-    return _smithy.isa(o, "AddTagsToResourceResponse");
+    return __isa(o, "AddTagsToResourceResponse");
   }
 }
 
@@ -43,7 +46,7 @@ export enum ClientVersion {
  * <p>Indicates that an internal error occurred.</p>
  */
 export interface CloudHsmInternalException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CloudHsmInternalException";
   $fault: "server";
@@ -60,7 +63,7 @@ export interface CloudHsmInternalException
 
 export namespace CloudHsmInternalException {
   export function isa(o: any): o is CloudHsmInternalException {
-    return _smithy.isa(o, "CloudHsmInternalException");
+    return __isa(o, "CloudHsmInternalException");
   }
 }
 
@@ -74,7 +77,7 @@ export enum CloudHsmObjectState {
  * <p>Indicates that an exception occurred in the AWS CloudHSM service.</p>
  */
 export interface CloudHsmServiceException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CloudHsmServiceException";
   $fault: "client";
@@ -91,7 +94,7 @@ export interface CloudHsmServiceException
 
 export namespace CloudHsmServiceException {
   export function isa(o: any): o is CloudHsmServiceException {
-    return _smithy.isa(o, "CloudHsmServiceException");
+    return __isa(o, "CloudHsmServiceException");
   }
 }
 
@@ -108,7 +111,7 @@ export interface CreateHapgRequest {
 
 export namespace CreateHapgRequest {
   export function isa(o: any): o is CreateHapgRequest {
-    return _smithy.isa(o, "CreateHapgRequest");
+    return __isa(o, "CreateHapgRequest");
   }
 }
 
@@ -125,7 +128,7 @@ export interface CreateHapgResponse extends $MetadataBearer {
 
 export namespace CreateHapgResponse {
   export function isa(o: any): o is CreateHapgResponse {
-    return _smithy.isa(o, "CreateHapgResponse");
+    return __isa(o, "CreateHapgResponse");
   }
 }
 
@@ -194,7 +197,7 @@ export interface CreateHsmRequest {
 
 export namespace CreateHsmRequest {
   export function isa(o: any): o is CreateHsmRequest {
-    return _smithy.isa(o, "CreateHsmRequest");
+    return __isa(o, "CreateHsmRequest");
   }
 }
 
@@ -211,7 +214,7 @@ export interface CreateHsmResponse extends $MetadataBearer {
 
 export namespace CreateHsmResponse {
   export function isa(o: any): o is CreateHsmResponse {
-    return _smithy.isa(o, "CreateHsmResponse");
+    return __isa(o, "CreateHsmResponse");
   }
 }
 
@@ -234,7 +237,7 @@ export interface CreateLunaClientRequest {
 
 export namespace CreateLunaClientRequest {
   export function isa(o: any): o is CreateLunaClientRequest {
-    return _smithy.isa(o, "CreateLunaClientRequest");
+    return __isa(o, "CreateLunaClientRequest");
   }
 }
 
@@ -251,7 +254,7 @@ export interface CreateLunaClientResponse extends $MetadataBearer {
 
 export namespace CreateLunaClientResponse {
   export function isa(o: any): o is CreateLunaClientResponse {
-    return _smithy.isa(o, "CreateLunaClientResponse");
+    return __isa(o, "CreateLunaClientResponse");
   }
 }
 
@@ -268,7 +271,7 @@ export interface DeleteHapgRequest {
 
 export namespace DeleteHapgRequest {
   export function isa(o: any): o is DeleteHapgRequest {
-    return _smithy.isa(o, "DeleteHapgRequest");
+    return __isa(o, "DeleteHapgRequest");
   }
 }
 
@@ -285,7 +288,7 @@ export interface DeleteHapgResponse extends $MetadataBearer {
 
 export namespace DeleteHapgResponse {
   export function isa(o: any): o is DeleteHapgResponse {
-    return _smithy.isa(o, "DeleteHapgResponse");
+    return __isa(o, "DeleteHapgResponse");
   }
 }
 
@@ -302,7 +305,7 @@ export interface DeleteHsmRequest {
 
 export namespace DeleteHsmRequest {
   export function isa(o: any): o is DeleteHsmRequest {
-    return _smithy.isa(o, "DeleteHsmRequest");
+    return __isa(o, "DeleteHsmRequest");
   }
 }
 
@@ -319,7 +322,7 @@ export interface DeleteHsmResponse extends $MetadataBearer {
 
 export namespace DeleteHsmResponse {
   export function isa(o: any): o is DeleteHsmResponse {
-    return _smithy.isa(o, "DeleteHsmResponse");
+    return __isa(o, "DeleteHsmResponse");
   }
 }
 
@@ -333,7 +336,7 @@ export interface DeleteLunaClientRequest {
 
 export namespace DeleteLunaClientRequest {
   export function isa(o: any): o is DeleteLunaClientRequest {
-    return _smithy.isa(o, "DeleteLunaClientRequest");
+    return __isa(o, "DeleteLunaClientRequest");
   }
 }
 
@@ -347,7 +350,7 @@ export interface DeleteLunaClientResponse extends $MetadataBearer {
 
 export namespace DeleteLunaClientResponse {
   export function isa(o: any): o is DeleteLunaClientResponse {
-    return _smithy.isa(o, "DeleteLunaClientResponse");
+    return __isa(o, "DeleteLunaClientResponse");
   }
 }
 
@@ -364,7 +367,7 @@ export interface DescribeHapgRequest {
 
 export namespace DescribeHapgRequest {
   export function isa(o: any): o is DescribeHapgRequest {
-    return _smithy.isa(o, "DescribeHapgRequest");
+    return __isa(o, "DescribeHapgRequest");
   }
 }
 
@@ -422,7 +425,7 @@ export interface DescribeHapgResponse extends $MetadataBearer {
 
 export namespace DescribeHapgResponse {
   export function isa(o: any): o is DescribeHapgResponse {
-    return _smithy.isa(o, "DescribeHapgResponse");
+    return __isa(o, "DescribeHapgResponse");
   }
 }
 
@@ -446,7 +449,7 @@ export interface DescribeHsmRequest {
 
 export namespace DescribeHsmRequest {
   export function isa(o: any): o is DescribeHsmRequest {
-    return _smithy.isa(o, "DescribeHsmRequest");
+    return __isa(o, "DescribeHsmRequest");
   }
 }
 
@@ -575,7 +578,7 @@ export interface DescribeHsmResponse extends $MetadataBearer {
 
 export namespace DescribeHsmResponse {
   export function isa(o: any): o is DescribeHsmResponse {
-    return _smithy.isa(o, "DescribeHsmResponse");
+    return __isa(o, "DescribeHsmResponse");
   }
 }
 
@@ -594,7 +597,7 @@ export interface DescribeLunaClientRequest {
 
 export namespace DescribeLunaClientRequest {
   export function isa(o: any): o is DescribeLunaClientRequest {
-    return _smithy.isa(o, "DescribeLunaClientRequest");
+    return __isa(o, "DescribeLunaClientRequest");
   }
 }
 
@@ -628,7 +631,7 @@ export interface DescribeLunaClientResponse extends $MetadataBearer {
 
 export namespace DescribeLunaClientResponse {
   export function isa(o: any): o is DescribeLunaClientResponse {
-    return _smithy.isa(o, "DescribeLunaClientResponse");
+    return __isa(o, "DescribeLunaClientResponse");
   }
 }
 
@@ -653,7 +656,7 @@ export interface GetConfigRequest {
 
 export namespace GetConfigRequest {
   export function isa(o: any): o is GetConfigRequest {
-    return _smithy.isa(o, "GetConfigRequest");
+    return __isa(o, "GetConfigRequest");
   }
 }
 
@@ -677,7 +680,7 @@ export interface GetConfigResponse extends $MetadataBearer {
 
 export namespace GetConfigResponse {
   export function isa(o: any): o is GetConfigResponse {
-    return _smithy.isa(o, "GetConfigResponse");
+    return __isa(o, "GetConfigResponse");
   }
 }
 
@@ -695,7 +698,7 @@ export enum HsmStatus {
  * <p>Indicates that one or more of the request parameters are not valid.</p>
  */
 export interface InvalidRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidRequestException";
   $fault: "client";
@@ -712,7 +715,7 @@ export interface InvalidRequestException
 
 export namespace InvalidRequestException {
   export function isa(o: any): o is InvalidRequestException {
-    return _smithy.isa(o, "InvalidRequestException");
+    return __isa(o, "InvalidRequestException");
   }
 }
 
@@ -725,7 +728,7 @@ export interface ListAvailableZonesRequest {
 
 export namespace ListAvailableZonesRequest {
   export function isa(o: any): o is ListAvailableZonesRequest {
-    return _smithy.isa(o, "ListAvailableZonesRequest");
+    return __isa(o, "ListAvailableZonesRequest");
   }
 }
 
@@ -739,7 +742,7 @@ export interface ListAvailableZonesResponse extends $MetadataBearer {
 
 export namespace ListAvailableZonesResponse {
   export function isa(o: any): o is ListAvailableZonesResponse {
-    return _smithy.isa(o, "ListAvailableZonesResponse");
+    return __isa(o, "ListAvailableZonesResponse");
   }
 }
 
@@ -754,7 +757,7 @@ export interface ListHapgsRequest {
 
 export namespace ListHapgsRequest {
   export function isa(o: any): o is ListHapgsRequest {
-    return _smithy.isa(o, "ListHapgsRequest");
+    return __isa(o, "ListHapgsRequest");
   }
 }
 
@@ -774,7 +777,7 @@ export interface ListHapgsResponse extends $MetadataBearer {
 
 export namespace ListHapgsResponse {
   export function isa(o: any): o is ListHapgsResponse {
-    return _smithy.isa(o, "ListHapgsResponse");
+    return __isa(o, "ListHapgsResponse");
   }
 }
 
@@ -789,7 +792,7 @@ export interface ListHsmsRequest {
 
 export namespace ListHsmsRequest {
   export function isa(o: any): o is ListHsmsRequest {
-    return _smithy.isa(o, "ListHsmsRequest");
+    return __isa(o, "ListHsmsRequest");
   }
 }
 
@@ -812,7 +815,7 @@ export interface ListHsmsResponse extends $MetadataBearer {
 
 export namespace ListHsmsResponse {
   export function isa(o: any): o is ListHsmsResponse {
-    return _smithy.isa(o, "ListHsmsResponse");
+    return __isa(o, "ListHsmsResponse");
   }
 }
 
@@ -827,7 +830,7 @@ export interface ListLunaClientsRequest {
 
 export namespace ListLunaClientsRequest {
   export function isa(o: any): o is ListLunaClientsRequest {
-    return _smithy.isa(o, "ListLunaClientsRequest");
+    return __isa(o, "ListLunaClientsRequest");
   }
 }
 
@@ -847,7 +850,7 @@ export interface ListLunaClientsResponse extends $MetadataBearer {
 
 export namespace ListLunaClientsResponse {
   export function isa(o: any): o is ListLunaClientsResponse {
-    return _smithy.isa(o, "ListLunaClientsResponse");
+    return __isa(o, "ListLunaClientsResponse");
   }
 }
 
@@ -861,7 +864,7 @@ export interface ListTagsForResourceRequest {
 
 export namespace ListTagsForResourceRequest {
   export function isa(o: any): o is ListTagsForResourceRequest {
-    return _smithy.isa(o, "ListTagsForResourceRequest");
+    return __isa(o, "ListTagsForResourceRequest");
   }
 }
 
@@ -875,7 +878,7 @@ export interface ListTagsForResourceResponse extends $MetadataBearer {
 
 export namespace ListTagsForResourceResponse {
   export function isa(o: any): o is ListTagsForResourceResponse {
-    return _smithy.isa(o, "ListTagsForResourceResponse");
+    return __isa(o, "ListTagsForResourceResponse");
   }
 }
 
@@ -900,7 +903,7 @@ export interface ModifyHapgRequest {
 
 export namespace ModifyHapgRequest {
   export function isa(o: any): o is ModifyHapgRequest {
-    return _smithy.isa(o, "ModifyHapgRequest");
+    return __isa(o, "ModifyHapgRequest");
   }
 }
 
@@ -914,7 +917,7 @@ export interface ModifyHapgResponse extends $MetadataBearer {
 
 export namespace ModifyHapgResponse {
   export function isa(o: any): o is ModifyHapgResponse {
-    return _smithy.isa(o, "ModifyHapgResponse");
+    return __isa(o, "ModifyHapgResponse");
   }
 }
 
@@ -961,7 +964,7 @@ export interface ModifyHsmRequest {
 
 export namespace ModifyHsmRequest {
   export function isa(o: any): o is ModifyHsmRequest {
-    return _smithy.isa(o, "ModifyHsmRequest");
+    return __isa(o, "ModifyHsmRequest");
   }
 }
 
@@ -978,7 +981,7 @@ export interface ModifyHsmResponse extends $MetadataBearer {
 
 export namespace ModifyHsmResponse {
   export function isa(o: any): o is ModifyHsmResponse {
-    return _smithy.isa(o, "ModifyHsmResponse");
+    return __isa(o, "ModifyHsmResponse");
   }
 }
 
@@ -997,7 +1000,7 @@ export interface ModifyLunaClientRequest {
 
 export namespace ModifyLunaClientRequest {
   export function isa(o: any): o is ModifyLunaClientRequest {
-    return _smithy.isa(o, "ModifyLunaClientRequest");
+    return __isa(o, "ModifyLunaClientRequest");
   }
 }
 
@@ -1011,7 +1014,7 @@ export interface ModifyLunaClientResponse extends $MetadataBearer {
 
 export namespace ModifyLunaClientResponse {
   export function isa(o: any): o is ModifyLunaClientResponse {
-    return _smithy.isa(o, "ModifyLunaClientResponse");
+    return __isa(o, "ModifyLunaClientResponse");
   }
 }
 
@@ -1032,7 +1035,7 @@ export interface RemoveTagsFromResourceRequest {
 
 export namespace RemoveTagsFromResourceRequest {
   export function isa(o: any): o is RemoveTagsFromResourceRequest {
-    return _smithy.isa(o, "RemoveTagsFromResourceRequest");
+    return __isa(o, "RemoveTagsFromResourceRequest");
   }
 }
 
@@ -1046,7 +1049,7 @@ export interface RemoveTagsFromResourceResponse extends $MetadataBearer {
 
 export namespace RemoveTagsFromResourceResponse {
   export function isa(o: any): o is RemoveTagsFromResourceResponse {
-    return _smithy.isa(o, "RemoveTagsFromResourceResponse");
+    return __isa(o, "RemoveTagsFromResourceResponse");
   }
 }
 
@@ -1073,6 +1076,6 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }

--- a/clients/client-cloudsearch-domain/models/index.ts
+++ b/clients/client-cloudsearch-domain/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -19,7 +22,7 @@ export interface Bucket {
 
 export namespace Bucket {
   export function isa(o: any): o is Bucket {
-    return _smithy.isa(o, "Bucket");
+    return __isa(o, "Bucket");
   }
 }
 
@@ -36,7 +39,7 @@ export interface BucketInfo {
 
 export namespace BucketInfo {
   export function isa(o: any): o is BucketInfo {
-    return _smithy.isa(o, "BucketInfo");
+    return __isa(o, "BucketInfo");
   }
 }
 
@@ -46,7 +49,7 @@ export type ContentType = "application/json" | "application/xml";
  * <p>Information about any problems encountered while processing an upload request.</p>
  */
 export interface DocumentServiceException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DocumentServiceException";
   $fault: "client";
@@ -63,7 +66,7 @@ export interface DocumentServiceException
 
 export namespace DocumentServiceException {
   export function isa(o: any): o is DocumentServiceException {
-    return _smithy.isa(o, "DocumentServiceException");
+    return __isa(o, "DocumentServiceException");
   }
 }
 
@@ -80,7 +83,7 @@ export interface DocumentServiceWarning {
 
 export namespace DocumentServiceWarning {
   export function isa(o: any): o is DocumentServiceWarning {
-    return _smithy.isa(o, "DocumentServiceWarning");
+    return __isa(o, "DocumentServiceWarning");
   }
 }
 
@@ -135,7 +138,7 @@ export interface FieldStats {
 
 export namespace FieldStats {
   export function isa(o: any): o is FieldStats {
-    return _smithy.isa(o, "FieldStats");
+    return __isa(o, "FieldStats");
   }
 }
 
@@ -167,7 +170,7 @@ export interface Hit {
 
 export namespace Hit {
   export function isa(o: any): o is Hit {
-    return _smithy.isa(o, "Hit");
+    return __isa(o, "Hit");
   }
 }
 
@@ -199,7 +202,7 @@ export interface Hits {
 
 export namespace Hits {
   export function isa(o: any): o is Hits {
-    return _smithy.isa(o, "Hits");
+    return __isa(o, "Hits");
   }
 }
 
@@ -208,9 +211,7 @@ export type QueryParser = "dismax" | "lucene" | "simple" | "structured";
 /**
  * <p>Information about any problems encountered while processing a search request.</p>
  */
-export interface SearchException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface SearchException extends __SmithyException, $MetadataBearer {
   name: "SearchException";
   $fault: "client";
   /**
@@ -221,7 +222,7 @@ export interface SearchException
 
 export namespace SearchException {
   export function isa(o: any): o is SearchException {
-    return _smithy.isa(o, "SearchException");
+    return __isa(o, "SearchException");
   }
 }
 
@@ -513,7 +514,7 @@ export interface SearchRequest {
 
 export namespace SearchRequest {
   export function isa(o: any): o is SearchRequest {
-    return _smithy.isa(o, "SearchRequest");
+    return __isa(o, "SearchRequest");
   }
 }
 
@@ -545,7 +546,7 @@ export interface SearchResponse extends $MetadataBearer {
 
 export namespace SearchResponse {
   export function isa(o: any): o is SearchResponse {
-    return _smithy.isa(o, "SearchResponse");
+    return __isa(o, "SearchResponse");
   }
 }
 
@@ -567,7 +568,7 @@ export interface SearchStatus {
 
 export namespace SearchStatus {
   export function isa(o: any): o is SearchStatus {
-    return _smithy.isa(o, "SearchStatus");
+    return __isa(o, "SearchStatus");
   }
 }
 
@@ -594,7 +595,7 @@ export interface SuggestModel {
 
 export namespace SuggestModel {
   export function isa(o: any): o is SuggestModel {
-    return _smithy.isa(o, "SuggestModel");
+    return __isa(o, "SuggestModel");
   }
 }
 
@@ -621,7 +622,7 @@ export interface SuggestRequest {
 
 export namespace SuggestRequest {
   export function isa(o: any): o is SuggestRequest {
-    return _smithy.isa(o, "SuggestRequest");
+    return __isa(o, "SuggestRequest");
   }
 }
 
@@ -643,7 +644,7 @@ export interface SuggestResponse extends $MetadataBearer {
 
 export namespace SuggestResponse {
   export function isa(o: any): o is SuggestResponse {
-    return _smithy.isa(o, "SuggestResponse");
+    return __isa(o, "SuggestResponse");
   }
 }
 
@@ -665,7 +666,7 @@ export interface SuggestStatus {
 
 export namespace SuggestStatus {
   export function isa(o: any): o is SuggestStatus {
-    return _smithy.isa(o, "SuggestStatus");
+    return __isa(o, "SuggestStatus");
   }
 }
 
@@ -692,7 +693,7 @@ export interface SuggestionMatch {
 
 export namespace SuggestionMatch {
   export function isa(o: any): o is SuggestionMatch {
-    return _smithy.isa(o, "SuggestionMatch");
+    return __isa(o, "SuggestionMatch");
   }
 }
 
@@ -718,7 +719,7 @@ export interface UploadDocumentsRequest {
 
 export namespace UploadDocumentsRequest {
   export function isa(o: any): o is UploadDocumentsRequest {
-    return _smithy.isa(o, "UploadDocumentsRequest");
+    return __isa(o, "UploadDocumentsRequest");
   }
 }
 
@@ -750,6 +751,6 @@ export interface UploadDocumentsResponse extends $MetadataBearer {
 
 export namespace UploadDocumentsResponse {
   export function isa(o: any): o is UploadDocumentsResponse {
-    return _smithy.isa(o, "UploadDocumentsResponse");
+    return __isa(o, "UploadDocumentsResponse");
   }
 }

--- a/clients/client-cloudsearch-domain/protocols/Aws_restJson1_1.ts
+++ b/clients/client-cloudsearch-domain/protocols/Aws_restJson1_1.ts
@@ -28,7 +28,10 @@ import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  extendedEncodeURIComponent as __extendedEncodeURIComponent
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -48,46 +51,74 @@ export async function serializeAws_restJson1_1SearchCommand(
     pretty: "true"
   };
   if (input.cursor !== undefined) {
-    query["cursor"] = input.cursor.toString();
+    query[
+      __extendedEncodeURIComponent("cursor")
+    ] = __extendedEncodeURIComponent(input.cursor);
   }
   if (input.expr !== undefined) {
-    query["expr"] = input.expr.toString();
+    query[__extendedEncodeURIComponent("expr")] = __extendedEncodeURIComponent(
+      input.expr
+    );
   }
   if (input.facet !== undefined) {
-    query["facet"] = input.facet.toString();
+    query[__extendedEncodeURIComponent("facet")] = __extendedEncodeURIComponent(
+      input.facet
+    );
   }
   if (input.filterQuery !== undefined) {
-    query["fq"] = input.filterQuery.toString();
+    query[__extendedEncodeURIComponent("fq")] = __extendedEncodeURIComponent(
+      input.filterQuery
+    );
   }
   if (input.highlight !== undefined) {
-    query["highlight"] = input.highlight.toString();
+    query[
+      __extendedEncodeURIComponent("highlight")
+    ] = __extendedEncodeURIComponent(input.highlight);
   }
   if (input.partial !== undefined) {
-    query["partial"] = input.partial.toString();
+    query[
+      __extendedEncodeURIComponent("partial")
+    ] = __extendedEncodeURIComponent(input.partial.toString());
   }
   if (input.query !== undefined) {
-    query["q"] = input.query.toString();
+    query[__extendedEncodeURIComponent("q")] = __extendedEncodeURIComponent(
+      input.query
+    );
   }
   if (input.queryOptions !== undefined) {
-    query["q.options"] = input.queryOptions.toString();
+    query[
+      __extendedEncodeURIComponent("q.options")
+    ] = __extendedEncodeURIComponent(input.queryOptions);
   }
   if (input.queryParser !== undefined) {
-    query["q.parser"] = input.queryParser.toString();
+    query[
+      __extendedEncodeURIComponent("q.parser")
+    ] = __extendedEncodeURIComponent(input.queryParser);
   }
   if (input.return !== undefined) {
-    query["return"] = input.return.toString();
+    query[
+      __extendedEncodeURIComponent("return")
+    ] = __extendedEncodeURIComponent(input.return);
   }
   if (input.size !== undefined) {
-    query["size"] = input.size.toString();
+    query[__extendedEncodeURIComponent("size")] = __extendedEncodeURIComponent(
+      input.size.toString()
+    );
   }
   if (input.sort !== undefined) {
-    query["sort"] = input.sort.toString();
+    query[__extendedEncodeURIComponent("sort")] = __extendedEncodeURIComponent(
+      input.sort
+    );
   }
   if (input.start !== undefined) {
-    query["start"] = input.start.toString();
+    query[__extendedEncodeURIComponent("start")] = __extendedEncodeURIComponent(
+      input.start.toString()
+    );
   }
   if (input.stats !== undefined) {
-    query["stats"] = input.stats.toString();
+    query[__extendedEncodeURIComponent("stats")] = __extendedEncodeURIComponent(
+      input.stats
+    );
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -111,13 +142,19 @@ export async function serializeAws_restJson1_1SuggestCommand(
     pretty: "true"
   };
   if (input.query !== undefined) {
-    query["q"] = input.query.toString();
+    query[__extendedEncodeURIComponent("q")] = __extendedEncodeURIComponent(
+      input.query
+    );
   }
   if (input.size !== undefined) {
-    query["size"] = input.size.toString();
+    query[__extendedEncodeURIComponent("size")] = __extendedEncodeURIComponent(
+      input.size.toString()
+    );
   }
   if (input.suggester !== undefined) {
-    query["suggester"] = input.suggester.toString();
+    query[
+      __extendedEncodeURIComponent("suggester")
+    ] = __extendedEncodeURIComponent(input.suggester);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -136,7 +173,7 @@ export async function serializeAws_restJson1_1UploadDocumentsCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/octet-stream";
   if (input.contentType !== undefined) {
-    headers["Content-Type"] = input.contentType.toString();
+    headers["Content-Type"] = input.contentType;
   }
   let resolvedPath = "/2013-01-01/documents/batch";
   const query: any = {

--- a/clients/client-cloudsearch/models/index.ts
+++ b/clients/client-cloudsearch/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -19,7 +22,7 @@ export interface AccessPoliciesStatus {
 
 export namespace AccessPoliciesStatus {
   export function isa(o: any): o is AccessPoliciesStatus {
-    return _smithy.isa(o, "AccessPoliciesStatus");
+    return __isa(o, "AccessPoliciesStatus");
   }
 }
 
@@ -58,7 +61,7 @@ export interface AnalysisOptions {
 
 export namespace AnalysisOptions {
   export function isa(o: any): o is AnalysisOptions {
-    return _smithy.isa(o, "AnalysisOptions");
+    return __isa(o, "AnalysisOptions");
   }
 }
 
@@ -86,7 +89,7 @@ export interface AnalysisScheme {
 
 export namespace AnalysisScheme {
   export function isa(o: any): o is AnalysisScheme {
-    return _smithy.isa(o, "AnalysisScheme");
+    return __isa(o, "AnalysisScheme");
   }
 }
 
@@ -145,7 +148,7 @@ export interface AnalysisSchemeStatus {
 
 export namespace AnalysisSchemeStatus {
   export function isa(o: any): o is AnalysisSchemeStatus {
-    return _smithy.isa(o, "AnalysisSchemeStatus");
+    return __isa(o, "AnalysisSchemeStatus");
   }
 }
 
@@ -167,16 +170,14 @@ export interface AvailabilityOptionsStatus {
 
 export namespace AvailabilityOptionsStatus {
   export function isa(o: any): o is AvailabilityOptionsStatus {
-    return _smithy.isa(o, "AvailabilityOptionsStatus");
+    return __isa(o, "AvailabilityOptionsStatus");
   }
 }
 
 /**
  * <p>An error occurred while processing the request.</p>
  */
-export interface BaseException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface BaseException extends __SmithyException, $MetadataBearer {
   name: "BaseException";
   $fault: "client";
   /**
@@ -192,7 +193,7 @@ export interface BaseException
 
 export namespace BaseException {
   export function isa(o: any): o is BaseException {
-    return _smithy.isa(o, "BaseException");
+    return __isa(o, "BaseException");
   }
 }
 
@@ -209,7 +210,7 @@ export interface BuildSuggestersRequest {
 
 export namespace BuildSuggestersRequest {
   export function isa(o: any): o is BuildSuggestersRequest {
-    return _smithy.isa(o, "BuildSuggestersRequest");
+    return __isa(o, "BuildSuggestersRequest");
   }
 }
 
@@ -226,7 +227,7 @@ export interface BuildSuggestersResponse extends $MetadataBearer {
 
 export namespace BuildSuggestersResponse {
   export function isa(o: any): o is BuildSuggestersResponse {
-    return _smithy.isa(o, "BuildSuggestersResponse");
+    return __isa(o, "BuildSuggestersResponse");
   }
 }
 
@@ -243,7 +244,7 @@ export interface CreateDomainRequest {
 
 export namespace CreateDomainRequest {
   export function isa(o: any): o is CreateDomainRequest {
-    return _smithy.isa(o, "CreateDomainRequest");
+    return __isa(o, "CreateDomainRequest");
   }
 }
 
@@ -260,7 +261,7 @@ export interface CreateDomainResponse extends $MetadataBearer {
 
 export namespace CreateDomainResponse {
   export function isa(o: any): o is CreateDomainResponse {
-    return _smithy.isa(o, "CreateDomainResponse");
+    return __isa(o, "CreateDomainResponse");
   }
 }
 
@@ -297,7 +298,7 @@ export interface DateArrayOptions {
 
 export namespace DateArrayOptions {
   export function isa(o: any): o is DateArrayOptions {
-    return _smithy.isa(o, "DateArrayOptions");
+    return __isa(o, "DateArrayOptions");
   }
 }
 
@@ -352,7 +353,7 @@ export interface DateOptions {
 
 export namespace DateOptions {
   export function isa(o: any): o is DateOptions {
-    return _smithy.isa(o, "DateOptions");
+    return __isa(o, "DateOptions");
   }
 }
 
@@ -374,7 +375,7 @@ export interface DefineAnalysisSchemeRequest {
 
 export namespace DefineAnalysisSchemeRequest {
   export function isa(o: any): o is DefineAnalysisSchemeRequest {
-    return _smithy.isa(o, "DefineAnalysisSchemeRequest");
+    return __isa(o, "DefineAnalysisSchemeRequest");
   }
 }
 
@@ -391,7 +392,7 @@ export interface DefineAnalysisSchemeResponse extends $MetadataBearer {
 
 export namespace DefineAnalysisSchemeResponse {
   export function isa(o: any): o is DefineAnalysisSchemeResponse {
-    return _smithy.isa(o, "DefineAnalysisSchemeResponse");
+    return __isa(o, "DefineAnalysisSchemeResponse");
   }
 }
 
@@ -413,7 +414,7 @@ export interface DefineExpressionRequest {
 
 export namespace DefineExpressionRequest {
   export function isa(o: any): o is DefineExpressionRequest {
-    return _smithy.isa(o, "DefineExpressionRequest");
+    return __isa(o, "DefineExpressionRequest");
   }
 }
 
@@ -430,7 +431,7 @@ export interface DefineExpressionResponse extends $MetadataBearer {
 
 export namespace DefineExpressionResponse {
   export function isa(o: any): o is DefineExpressionResponse {
-    return _smithy.isa(o, "DefineExpressionResponse");
+    return __isa(o, "DefineExpressionResponse");
   }
 }
 
@@ -452,7 +453,7 @@ export interface DefineIndexFieldRequest {
 
 export namespace DefineIndexFieldRequest {
   export function isa(o: any): o is DefineIndexFieldRequest {
-    return _smithy.isa(o, "DefineIndexFieldRequest");
+    return __isa(o, "DefineIndexFieldRequest");
   }
 }
 
@@ -469,7 +470,7 @@ export interface DefineIndexFieldResponse extends $MetadataBearer {
 
 export namespace DefineIndexFieldResponse {
   export function isa(o: any): o is DefineIndexFieldResponse {
-    return _smithy.isa(o, "DefineIndexFieldResponse");
+    return __isa(o, "DefineIndexFieldResponse");
   }
 }
 
@@ -491,7 +492,7 @@ export interface DefineSuggesterRequest {
 
 export namespace DefineSuggesterRequest {
   export function isa(o: any): o is DefineSuggesterRequest {
-    return _smithy.isa(o, "DefineSuggesterRequest");
+    return __isa(o, "DefineSuggesterRequest");
   }
 }
 
@@ -508,7 +509,7 @@ export interface DefineSuggesterResponse extends $MetadataBearer {
 
 export namespace DefineSuggesterResponse {
   export function isa(o: any): o is DefineSuggesterResponse {
-    return _smithy.isa(o, "DefineSuggesterResponse");
+    return __isa(o, "DefineSuggesterResponse");
   }
 }
 
@@ -530,7 +531,7 @@ export interface DeleteAnalysisSchemeRequest {
 
 export namespace DeleteAnalysisSchemeRequest {
   export function isa(o: any): o is DeleteAnalysisSchemeRequest {
-    return _smithy.isa(o, "DeleteAnalysisSchemeRequest");
+    return __isa(o, "DeleteAnalysisSchemeRequest");
   }
 }
 
@@ -547,7 +548,7 @@ export interface DeleteAnalysisSchemeResponse extends $MetadataBearer {
 
 export namespace DeleteAnalysisSchemeResponse {
   export function isa(o: any): o is DeleteAnalysisSchemeResponse {
-    return _smithy.isa(o, "DeleteAnalysisSchemeResponse");
+    return __isa(o, "DeleteAnalysisSchemeResponse");
   }
 }
 
@@ -564,7 +565,7 @@ export interface DeleteDomainRequest {
 
 export namespace DeleteDomainRequest {
   export function isa(o: any): o is DeleteDomainRequest {
-    return _smithy.isa(o, "DeleteDomainRequest");
+    return __isa(o, "DeleteDomainRequest");
   }
 }
 
@@ -581,7 +582,7 @@ export interface DeleteDomainResponse extends $MetadataBearer {
 
 export namespace DeleteDomainResponse {
   export function isa(o: any): o is DeleteDomainResponse {
-    return _smithy.isa(o, "DeleteDomainResponse");
+    return __isa(o, "DeleteDomainResponse");
   }
 }
 
@@ -603,7 +604,7 @@ export interface DeleteExpressionRequest {
 
 export namespace DeleteExpressionRequest {
   export function isa(o: any): o is DeleteExpressionRequest {
-    return _smithy.isa(o, "DeleteExpressionRequest");
+    return __isa(o, "DeleteExpressionRequest");
   }
 }
 
@@ -620,7 +621,7 @@ export interface DeleteExpressionResponse extends $MetadataBearer {
 
 export namespace DeleteExpressionResponse {
   export function isa(o: any): o is DeleteExpressionResponse {
-    return _smithy.isa(o, "DeleteExpressionResponse");
+    return __isa(o, "DeleteExpressionResponse");
   }
 }
 
@@ -642,7 +643,7 @@ export interface DeleteIndexFieldRequest {
 
 export namespace DeleteIndexFieldRequest {
   export function isa(o: any): o is DeleteIndexFieldRequest {
-    return _smithy.isa(o, "DeleteIndexFieldRequest");
+    return __isa(o, "DeleteIndexFieldRequest");
   }
 }
 
@@ -659,7 +660,7 @@ export interface DeleteIndexFieldResponse extends $MetadataBearer {
 
 export namespace DeleteIndexFieldResponse {
   export function isa(o: any): o is DeleteIndexFieldResponse {
-    return _smithy.isa(o, "DeleteIndexFieldResponse");
+    return __isa(o, "DeleteIndexFieldResponse");
   }
 }
 
@@ -681,7 +682,7 @@ export interface DeleteSuggesterRequest {
 
 export namespace DeleteSuggesterRequest {
   export function isa(o: any): o is DeleteSuggesterRequest {
-    return _smithy.isa(o, "DeleteSuggesterRequest");
+    return __isa(o, "DeleteSuggesterRequest");
   }
 }
 
@@ -698,7 +699,7 @@ export interface DeleteSuggesterResponse extends $MetadataBearer {
 
 export namespace DeleteSuggesterResponse {
   export function isa(o: any): o is DeleteSuggesterResponse {
-    return _smithy.isa(o, "DeleteSuggesterResponse");
+    return __isa(o, "DeleteSuggesterResponse");
   }
 }
 
@@ -725,7 +726,7 @@ export interface DescribeAnalysisSchemesRequest {
 
 export namespace DescribeAnalysisSchemesRequest {
   export function isa(o: any): o is DescribeAnalysisSchemesRequest {
-    return _smithy.isa(o, "DescribeAnalysisSchemesRequest");
+    return __isa(o, "DescribeAnalysisSchemesRequest");
   }
 }
 
@@ -742,7 +743,7 @@ export interface DescribeAnalysisSchemesResponse extends $MetadataBearer {
 
 export namespace DescribeAnalysisSchemesResponse {
   export function isa(o: any): o is DescribeAnalysisSchemesResponse {
-    return _smithy.isa(o, "DescribeAnalysisSchemesResponse");
+    return __isa(o, "DescribeAnalysisSchemesResponse");
   }
 }
 
@@ -764,7 +765,7 @@ export interface DescribeAvailabilityOptionsRequest {
 
 export namespace DescribeAvailabilityOptionsRequest {
   export function isa(o: any): o is DescribeAvailabilityOptionsRequest {
-    return _smithy.isa(o, "DescribeAvailabilityOptionsRequest");
+    return __isa(o, "DescribeAvailabilityOptionsRequest");
   }
 }
 
@@ -781,7 +782,7 @@ export interface DescribeAvailabilityOptionsResponse extends $MetadataBearer {
 
 export namespace DescribeAvailabilityOptionsResponse {
   export function isa(o: any): o is DescribeAvailabilityOptionsResponse {
-    return _smithy.isa(o, "DescribeAvailabilityOptionsResponse");
+    return __isa(o, "DescribeAvailabilityOptionsResponse");
   }
 }
 
@@ -803,7 +804,7 @@ export interface DescribeDomainEndpointOptionsRequest {
 
 export namespace DescribeDomainEndpointOptionsRequest {
   export function isa(o: any): o is DescribeDomainEndpointOptionsRequest {
-    return _smithy.isa(o, "DescribeDomainEndpointOptionsRequest");
+    return __isa(o, "DescribeDomainEndpointOptionsRequest");
   }
 }
 
@@ -820,7 +821,7 @@ export interface DescribeDomainEndpointOptionsResponse extends $MetadataBearer {
 
 export namespace DescribeDomainEndpointOptionsResponse {
   export function isa(o: any): o is DescribeDomainEndpointOptionsResponse {
-    return _smithy.isa(o, "DescribeDomainEndpointOptionsResponse");
+    return __isa(o, "DescribeDomainEndpointOptionsResponse");
   }
 }
 
@@ -837,7 +838,7 @@ export interface DescribeDomainsRequest {
 
 export namespace DescribeDomainsRequest {
   export function isa(o: any): o is DescribeDomainsRequest {
-    return _smithy.isa(o, "DescribeDomainsRequest");
+    return __isa(o, "DescribeDomainsRequest");
   }
 }
 
@@ -854,7 +855,7 @@ export interface DescribeDomainsResponse extends $MetadataBearer {
 
 export namespace DescribeDomainsResponse {
   export function isa(o: any): o is DescribeDomainsResponse {
-    return _smithy.isa(o, "DescribeDomainsResponse");
+    return __isa(o, "DescribeDomainsResponse");
   }
 }
 
@@ -882,7 +883,7 @@ export interface DescribeExpressionsRequest {
 
 export namespace DescribeExpressionsRequest {
   export function isa(o: any): o is DescribeExpressionsRequest {
-    return _smithy.isa(o, "DescribeExpressionsRequest");
+    return __isa(o, "DescribeExpressionsRequest");
   }
 }
 
@@ -899,7 +900,7 @@ export interface DescribeExpressionsResponse extends $MetadataBearer {
 
 export namespace DescribeExpressionsResponse {
   export function isa(o: any): o is DescribeExpressionsResponse {
-    return _smithy.isa(o, "DescribeExpressionsResponse");
+    return __isa(o, "DescribeExpressionsResponse");
   }
 }
 
@@ -926,7 +927,7 @@ export interface DescribeIndexFieldsRequest {
 
 export namespace DescribeIndexFieldsRequest {
   export function isa(o: any): o is DescribeIndexFieldsRequest {
-    return _smithy.isa(o, "DescribeIndexFieldsRequest");
+    return __isa(o, "DescribeIndexFieldsRequest");
   }
 }
 
@@ -943,7 +944,7 @@ export interface DescribeIndexFieldsResponse extends $MetadataBearer {
 
 export namespace DescribeIndexFieldsResponse {
   export function isa(o: any): o is DescribeIndexFieldsResponse {
-    return _smithy.isa(o, "DescribeIndexFieldsResponse");
+    return __isa(o, "DescribeIndexFieldsResponse");
   }
 }
 
@@ -960,7 +961,7 @@ export interface DescribeScalingParametersRequest {
 
 export namespace DescribeScalingParametersRequest {
   export function isa(o: any): o is DescribeScalingParametersRequest {
-    return _smithy.isa(o, "DescribeScalingParametersRequest");
+    return __isa(o, "DescribeScalingParametersRequest");
   }
 }
 
@@ -977,7 +978,7 @@ export interface DescribeScalingParametersResponse extends $MetadataBearer {
 
 export namespace DescribeScalingParametersResponse {
   export function isa(o: any): o is DescribeScalingParametersResponse {
-    return _smithy.isa(o, "DescribeScalingParametersResponse");
+    return __isa(o, "DescribeScalingParametersResponse");
   }
 }
 
@@ -999,7 +1000,7 @@ export interface DescribeServiceAccessPoliciesRequest {
 
 export namespace DescribeServiceAccessPoliciesRequest {
   export function isa(o: any): o is DescribeServiceAccessPoliciesRequest {
-    return _smithy.isa(o, "DescribeServiceAccessPoliciesRequest");
+    return __isa(o, "DescribeServiceAccessPoliciesRequest");
   }
 }
 
@@ -1016,7 +1017,7 @@ export interface DescribeServiceAccessPoliciesResponse extends $MetadataBearer {
 
 export namespace DescribeServiceAccessPoliciesResponse {
   export function isa(o: any): o is DescribeServiceAccessPoliciesResponse {
-    return _smithy.isa(o, "DescribeServiceAccessPoliciesResponse");
+    return __isa(o, "DescribeServiceAccessPoliciesResponse");
   }
 }
 
@@ -1043,7 +1044,7 @@ export interface DescribeSuggestersRequest {
 
 export namespace DescribeSuggestersRequest {
   export function isa(o: any): o is DescribeSuggestersRequest {
-    return _smithy.isa(o, "DescribeSuggestersRequest");
+    return __isa(o, "DescribeSuggestersRequest");
   }
 }
 
@@ -1060,7 +1061,7 @@ export interface DescribeSuggestersResponse extends $MetadataBearer {
 
 export namespace DescribeSuggestersResponse {
   export function isa(o: any): o is DescribeSuggestersResponse {
-    return _smithy.isa(o, "DescribeSuggestersResponse");
+    return __isa(o, "DescribeSuggestersResponse");
   }
 }
 
@@ -1068,7 +1069,7 @@ export namespace DescribeSuggestersResponse {
  * <p>The request was rejected because it attempted an operation which is not enabled.</p>
  */
 export interface DisabledOperationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DisabledOperationException";
   $fault: "client";
@@ -1085,7 +1086,7 @@ export interface DisabledOperationException
 
 export namespace DisabledOperationException {
   export function isa(o: any): o is DisabledOperationException {
-    return _smithy.isa(o, "DisabledOperationException");
+    return __isa(o, "DisabledOperationException");
   }
 }
 
@@ -1118,7 +1119,7 @@ export interface DocumentSuggesterOptions {
 
 export namespace DocumentSuggesterOptions {
   export function isa(o: any): o is DocumentSuggesterOptions {
-    return _smithy.isa(o, "DocumentSuggesterOptions");
+    return __isa(o, "DocumentSuggesterOptions");
   }
 }
 
@@ -1140,7 +1141,7 @@ export interface DomainEndpointOptions {
 
 export namespace DomainEndpointOptions {
   export function isa(o: any): o is DomainEndpointOptions {
-    return _smithy.isa(o, "DomainEndpointOptions");
+    return __isa(o, "DomainEndpointOptions");
   }
 }
 
@@ -1162,7 +1163,7 @@ export interface DomainEndpointOptionsStatus {
 
 export namespace DomainEndpointOptionsStatus {
   export function isa(o: any): o is DomainEndpointOptionsStatus {
-    return _smithy.isa(o, "DomainEndpointOptionsStatus");
+    return __isa(o, "DomainEndpointOptionsStatus");
   }
 }
 
@@ -1235,7 +1236,7 @@ export interface DomainStatus {
 
 export namespace DomainStatus {
   export function isa(o: any): o is DomainStatus {
-    return _smithy.isa(o, "DomainStatus");
+    return __isa(o, "DomainStatus");
   }
 }
 
@@ -1272,7 +1273,7 @@ export interface DoubleArrayOptions {
 
 export namespace DoubleArrayOptions {
   export function isa(o: any): o is DoubleArrayOptions {
-    return _smithy.isa(o, "DoubleArrayOptions");
+    return __isa(o, "DoubleArrayOptions");
   }
 }
 
@@ -1314,7 +1315,7 @@ export interface DoubleOptions {
 
 export namespace DoubleOptions {
   export function isa(o: any): o is DoubleOptions {
-    return _smithy.isa(o, "DoubleOptions");
+    return __isa(o, "DoubleOptions");
   }
 }
 
@@ -1337,7 +1338,7 @@ export interface Expression {
 
 export namespace Expression {
   export function isa(o: any): o is Expression {
-    return _smithy.isa(o, "Expression");
+    return __isa(o, "Expression");
   }
 }
 
@@ -1359,7 +1360,7 @@ export interface ExpressionStatus {
 
 export namespace ExpressionStatus {
   export function isa(o: any): o is ExpressionStatus {
-    return _smithy.isa(o, "ExpressionStatus");
+    return __isa(o, "ExpressionStatus");
   }
 }
 
@@ -1376,7 +1377,7 @@ export interface IndexDocumentsRequest {
 
 export namespace IndexDocumentsRequest {
   export function isa(o: any): o is IndexDocumentsRequest {
-    return _smithy.isa(o, "IndexDocumentsRequest");
+    return __isa(o, "IndexDocumentsRequest");
   }
 }
 
@@ -1393,7 +1394,7 @@ export interface IndexDocumentsResponse extends $MetadataBearer {
 
 export namespace IndexDocumentsResponse {
   export function isa(o: any): o is IndexDocumentsResponse {
-    return _smithy.isa(o, "IndexDocumentsResponse");
+    return __isa(o, "IndexDocumentsResponse");
   }
 }
 
@@ -1483,7 +1484,7 @@ export interface IndexField {
 
 export namespace IndexField {
   export function isa(o: any): o is IndexField {
-    return _smithy.isa(o, "IndexField");
+    return __isa(o, "IndexField");
   }
 }
 
@@ -1505,7 +1506,7 @@ export interface IndexFieldStatus {
 
 export namespace IndexFieldStatus {
   export function isa(o: any): o is IndexFieldStatus {
-    return _smithy.isa(o, "IndexFieldStatus");
+    return __isa(o, "IndexFieldStatus");
   }
 }
 
@@ -1555,7 +1556,7 @@ export interface IntArrayOptions {
 
 export namespace IntArrayOptions {
   export function isa(o: any): o is IntArrayOptions {
-    return _smithy.isa(o, "IntArrayOptions");
+    return __isa(o, "IntArrayOptions");
   }
 }
 
@@ -1597,7 +1598,7 @@ export interface IntOptions {
 
 export namespace IntOptions {
   export function isa(o: any): o is IntOptions {
-    return _smithy.isa(o, "IntOptions");
+    return __isa(o, "IntOptions");
   }
 }
 
@@ -1605,9 +1606,7 @@ export namespace IntOptions {
  * <p>An internal error occurred while processing the request. If this problem persists,
  *       report an issue from the <a href="http://status.aws.amazon.com/" target="_blank">Service Health Dashboard</a>.</p>
  */
-export interface InternalException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface InternalException extends __SmithyException, $MetadataBearer {
   name: "InternalException";
   $fault: "server";
   /**
@@ -1623,7 +1622,7 @@ export interface InternalException
 
 export namespace InternalException {
   export function isa(o: any): o is InternalException {
-    return _smithy.isa(o, "InternalException");
+    return __isa(o, "InternalException");
   }
 }
 
@@ -1631,7 +1630,7 @@ export namespace InternalException {
  * <p>The request was rejected because it specified an invalid type definition.</p>
  */
 export interface InvalidTypeException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidTypeException";
   $fault: "client";
@@ -1648,7 +1647,7 @@ export interface InvalidTypeException
 
 export namespace InvalidTypeException {
   export function isa(o: any): o is InvalidTypeException {
-    return _smithy.isa(o, "InvalidTypeException");
+    return __isa(o, "InvalidTypeException");
   }
 }
 
@@ -1703,7 +1702,7 @@ export interface LatLonOptions {
 
 export namespace LatLonOptions {
   export function isa(o: any): o is LatLonOptions {
-    return _smithy.isa(o, "LatLonOptions");
+    return __isa(o, "LatLonOptions");
   }
 }
 
@@ -1711,7 +1710,7 @@ export namespace LatLonOptions {
  * <p>The request was rejected because a resource limit has already been met.</p>
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -1728,7 +1727,7 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
@@ -1740,7 +1739,7 @@ export interface Limits {
 
 export namespace Limits {
   export function isa(o: any): o is Limits {
-    return _smithy.isa(o, "Limits");
+    return __isa(o, "Limits");
   }
 }
 
@@ -1757,7 +1756,7 @@ export interface ListDomainNamesResponse extends $MetadataBearer {
 
 export namespace ListDomainNamesResponse {
   export function isa(o: any): o is ListDomainNamesResponse {
-    return _smithy.isa(o, "ListDomainNamesResponse");
+    return __isa(o, "ListDomainNamesResponse");
   }
 }
 
@@ -1794,7 +1793,7 @@ export interface LiteralArrayOptions {
 
 export namespace LiteralArrayOptions {
   export function isa(o: any): o is LiteralArrayOptions {
-    return _smithy.isa(o, "LiteralArrayOptions");
+    return __isa(o, "LiteralArrayOptions");
   }
 }
 
@@ -1849,7 +1848,7 @@ export interface LiteralOptions {
 
 export namespace LiteralOptions {
   export function isa(o: any): o is LiteralOptions {
-    return _smithy.isa(o, "LiteralOptions");
+    return __isa(o, "LiteralOptions");
   }
 }
 
@@ -1897,7 +1896,7 @@ export interface OptionStatus {
 
 export namespace OptionStatus {
   export function isa(o: any): o is OptionStatus {
-    return _smithy.isa(o, "OptionStatus");
+    return __isa(o, "OptionStatus");
   }
 }
 
@@ -1915,7 +1914,7 @@ export type PartitionInstanceType =
  * <p>The request was rejected because it attempted to reference a resource that does not exist.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -1932,7 +1931,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -1960,7 +1959,7 @@ export interface ScalingParameters {
 
 export namespace ScalingParameters {
   export function isa(o: any): o is ScalingParameters {
-    return _smithy.isa(o, "ScalingParameters");
+    return __isa(o, "ScalingParameters");
   }
 }
 
@@ -1982,7 +1981,7 @@ export interface ScalingParametersStatus {
 
 export namespace ScalingParametersStatus {
   export function isa(o: any): o is ScalingParametersStatus {
-    return _smithy.isa(o, "ScalingParametersStatus");
+    return __isa(o, "ScalingParametersStatus");
   }
 }
 
@@ -1999,7 +1998,7 @@ export interface ServiceEndpoint {
 
 export namespace ServiceEndpoint {
   export function isa(o: any): o is ServiceEndpoint {
-    return _smithy.isa(o, "ServiceEndpoint");
+    return __isa(o, "ServiceEndpoint");
   }
 }
 
@@ -2022,7 +2021,7 @@ export interface Suggester {
 
 export namespace Suggester {
   export function isa(o: any): o is Suggester {
-    return _smithy.isa(o, "Suggester");
+    return __isa(o, "Suggester");
   }
 }
 
@@ -2046,7 +2045,7 @@ export interface SuggesterStatus {
 
 export namespace SuggesterStatus {
   export function isa(o: any): o is SuggesterStatus {
-    return _smithy.isa(o, "SuggesterStatus");
+    return __isa(o, "SuggesterStatus");
   }
 }
 
@@ -2088,7 +2087,7 @@ export interface TextArrayOptions {
 
 export namespace TextArrayOptions {
   export function isa(o: any): o is TextArrayOptions {
-    return _smithy.isa(o, "TextArrayOptions");
+    return __isa(o, "TextArrayOptions");
   }
 }
 
@@ -2143,7 +2142,7 @@ export interface TextOptions {
 
 export namespace TextOptions {
   export function isa(o: any): o is TextOptions {
-    return _smithy.isa(o, "TextOptions");
+    return __isa(o, "TextOptions");
   }
 }
 
@@ -2165,7 +2164,7 @@ export interface UpdateAvailabilityOptionsRequest {
 
 export namespace UpdateAvailabilityOptionsRequest {
   export function isa(o: any): o is UpdateAvailabilityOptionsRequest {
-    return _smithy.isa(o, "UpdateAvailabilityOptionsRequest");
+    return __isa(o, "UpdateAvailabilityOptionsRequest");
   }
 }
 
@@ -2182,7 +2181,7 @@ export interface UpdateAvailabilityOptionsResponse extends $MetadataBearer {
 
 export namespace UpdateAvailabilityOptionsResponse {
   export function isa(o: any): o is UpdateAvailabilityOptionsResponse {
-    return _smithy.isa(o, "UpdateAvailabilityOptionsResponse");
+    return __isa(o, "UpdateAvailabilityOptionsResponse");
   }
 }
 
@@ -2204,7 +2203,7 @@ export interface UpdateDomainEndpointOptionsRequest {
 
 export namespace UpdateDomainEndpointOptionsRequest {
   export function isa(o: any): o is UpdateDomainEndpointOptionsRequest {
-    return _smithy.isa(o, "UpdateDomainEndpointOptionsRequest");
+    return __isa(o, "UpdateDomainEndpointOptionsRequest");
   }
 }
 
@@ -2221,7 +2220,7 @@ export interface UpdateDomainEndpointOptionsResponse extends $MetadataBearer {
 
 export namespace UpdateDomainEndpointOptionsResponse {
   export function isa(o: any): o is UpdateDomainEndpointOptionsResponse {
-    return _smithy.isa(o, "UpdateDomainEndpointOptionsResponse");
+    return __isa(o, "UpdateDomainEndpointOptionsResponse");
   }
 }
 
@@ -2243,7 +2242,7 @@ export interface UpdateScalingParametersRequest {
 
 export namespace UpdateScalingParametersRequest {
   export function isa(o: any): o is UpdateScalingParametersRequest {
-    return _smithy.isa(o, "UpdateScalingParametersRequest");
+    return __isa(o, "UpdateScalingParametersRequest");
   }
 }
 
@@ -2260,7 +2259,7 @@ export interface UpdateScalingParametersResponse extends $MetadataBearer {
 
 export namespace UpdateScalingParametersResponse {
   export function isa(o: any): o is UpdateScalingParametersResponse {
-    return _smithy.isa(o, "UpdateScalingParametersResponse");
+    return __isa(o, "UpdateScalingParametersResponse");
   }
 }
 
@@ -2282,7 +2281,7 @@ export interface UpdateServiceAccessPoliciesRequest {
 
 export namespace UpdateServiceAccessPoliciesRequest {
   export function isa(o: any): o is UpdateServiceAccessPoliciesRequest {
-    return _smithy.isa(o, "UpdateServiceAccessPoliciesRequest");
+    return __isa(o, "UpdateServiceAccessPoliciesRequest");
   }
 }
 
@@ -2299,7 +2298,7 @@ export interface UpdateServiceAccessPoliciesResponse extends $MetadataBearer {
 
 export namespace UpdateServiceAccessPoliciesResponse {
   export function isa(o: any): o is UpdateServiceAccessPoliciesResponse {
-    return _smithy.isa(o, "UpdateServiceAccessPoliciesResponse");
+    return __isa(o, "UpdateServiceAccessPoliciesResponse");
   }
 }
 
@@ -2307,7 +2306,7 @@ export namespace UpdateServiceAccessPoliciesResponse {
  * <p>The request was rejected because it has invalid parameters.</p>
  */
 export interface ValidationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ValidationException";
   $fault: "client";
@@ -2324,6 +2323,6 @@ export interface ValidationException
 
 export namespace ValidationException {
   export function isa(o: any): o is ValidationException {
-    return _smithy.isa(o, "ValidationException");
+    return __isa(o, "ValidationException");
   }
 }

--- a/clients/client-cloudtrail/models/index.ts
+++ b/clients/client-cloudtrail/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -22,7 +25,7 @@ export interface AddTagsRequest {
 
 export namespace AddTagsRequest {
   export function isa(o: any): o is AddTagsRequest {
-    return _smithy.isa(o, "AddTagsRequest");
+    return __isa(o, "AddTagsRequest");
   }
 }
 
@@ -35,7 +38,7 @@ export interface AddTagsResponse extends $MetadataBearer {
 
 export namespace AddTagsResponse {
   export function isa(o: any): o is AddTagsResponse {
-    return _smithy.isa(o, "AddTagsResponse");
+    return __isa(o, "AddTagsResponse");
   }
 }
 
@@ -46,7 +49,7 @@ export namespace AddTagsResponse {
  *          </p>
  */
 export interface CloudTrailARNInvalidException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CloudTrailARNInvalidException";
   $fault: "client";
@@ -58,7 +61,7 @@ export interface CloudTrailARNInvalidException
 
 export namespace CloudTrailARNInvalidException {
   export function isa(o: any): o is CloudTrailARNInvalidException {
-    return _smithy.isa(o, "CloudTrailARNInvalidException");
+    return __isa(o, "CloudTrailARNInvalidException");
   }
 }
 
@@ -68,7 +71,7 @@ export namespace CloudTrailARNInvalidException {
  *          and <a href="https://docs.aws.amazon.com/awscloudtrail/latest/userguide/creating-an-organizational-trail-prepare.html">Prepare For Creating a Trail For Your Organization</a>. </p>
  */
 export interface CloudTrailAccessNotEnabledException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CloudTrailAccessNotEnabledException";
   $fault: "client";
@@ -80,7 +83,7 @@ export interface CloudTrailAccessNotEnabledException
 
 export namespace CloudTrailAccessNotEnabledException {
   export function isa(o: any): o is CloudTrailAccessNotEnabledException {
-    return _smithy.isa(o, "CloudTrailAccessNotEnabledException");
+    return __isa(o, "CloudTrailAccessNotEnabledException");
   }
 }
 
@@ -88,7 +91,7 @@ export namespace CloudTrailAccessNotEnabledException {
  * <p>Cannot set a CloudWatch Logs delivery for this region.</p>
  */
 export interface CloudWatchLogsDeliveryUnavailableException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CloudWatchLogsDeliveryUnavailableException";
   $fault: "client";
@@ -100,7 +103,7 @@ export interface CloudWatchLogsDeliveryUnavailableException
 
 export namespace CloudWatchLogsDeliveryUnavailableException {
   export function isa(o: any): o is CloudWatchLogsDeliveryUnavailableException {
-    return _smithy.isa(o, "CloudWatchLogsDeliveryUnavailableException");
+    return __isa(o, "CloudWatchLogsDeliveryUnavailableException");
   }
 }
 
@@ -215,7 +218,7 @@ export interface CreateTrailRequest {
 
 export namespace CreateTrailRequest {
   export function isa(o: any): o is CreateTrailRequest {
-    return _smithy.isa(o, "CreateTrailRequest");
+    return __isa(o, "CreateTrailRequest");
   }
 }
 
@@ -303,7 +306,7 @@ export interface CreateTrailResponse extends $MetadataBearer {
 
 export namespace CreateTrailResponse {
   export function isa(o: any): o is CreateTrailResponse {
-    return _smithy.isa(o, "CreateTrailResponse");
+    return __isa(o, "CreateTrailResponse");
   }
 }
 
@@ -410,7 +413,7 @@ export interface DataResource {
 
 export namespace DataResource {
   export function isa(o: any): o is DataResource {
-    return _smithy.isa(o, "DataResource");
+    return __isa(o, "DataResource");
   }
 }
 
@@ -430,7 +433,7 @@ export interface DeleteTrailRequest {
 
 export namespace DeleteTrailRequest {
   export function isa(o: any): o is DeleteTrailRequest {
-    return _smithy.isa(o, "DeleteTrailRequest");
+    return __isa(o, "DeleteTrailRequest");
   }
 }
 
@@ -443,7 +446,7 @@ export interface DeleteTrailResponse extends $MetadataBearer {
 
 export namespace DeleteTrailResponse {
   export function isa(o: any): o is DeleteTrailResponse {
-    return _smithy.isa(o, "DeleteTrailResponse");
+    return __isa(o, "DeleteTrailResponse");
   }
 }
 
@@ -484,7 +487,7 @@ export interface DescribeTrailsRequest {
 
 export namespace DescribeTrailsRequest {
   export function isa(o: any): o is DescribeTrailsRequest {
-    return _smithy.isa(o, "DescribeTrailsRequest");
+    return __isa(o, "DescribeTrailsRequest");
   }
 }
 
@@ -503,7 +506,7 @@ export interface DescribeTrailsResponse extends $MetadataBearer {
 
 export namespace DescribeTrailsResponse {
   export function isa(o: any): o is DescribeTrailsResponse {
-    return _smithy.isa(o, "DescribeTrailsResponse");
+    return __isa(o, "DescribeTrailsResponse");
   }
 }
 
@@ -561,7 +564,7 @@ export interface Event {
 
 export namespace Event {
   export function isa(o: any): o is Event {
-    return _smithy.isa(o, "Event");
+    return __isa(o, "Event");
   }
 }
 
@@ -615,7 +618,7 @@ export interface EventSelector {
 
 export namespace EventSelector {
   export function isa(o: any): o is EventSelector {
-    return _smithy.isa(o, "EventSelector");
+    return __isa(o, "EventSelector");
   }
 }
 
@@ -652,7 +655,7 @@ export interface GetEventSelectorsRequest {
 
 export namespace GetEventSelectorsRequest {
   export function isa(o: any): o is GetEventSelectorsRequest {
-    return _smithy.isa(o, "GetEventSelectorsRequest");
+    return __isa(o, "GetEventSelectorsRequest");
   }
 }
 
@@ -671,7 +674,7 @@ export interface GetEventSelectorsResponse extends $MetadataBearer {
 
 export namespace GetEventSelectorsResponse {
   export function isa(o: any): o is GetEventSelectorsResponse {
-    return _smithy.isa(o, "GetEventSelectorsResponse");
+    return __isa(o, "GetEventSelectorsResponse");
   }
 }
 
@@ -708,7 +711,7 @@ export interface GetInsightSelectorsRequest {
 
 export namespace GetInsightSelectorsRequest {
   export function isa(o: any): o is GetInsightSelectorsRequest {
-    return _smithy.isa(o, "GetInsightSelectorsRequest");
+    return __isa(o, "GetInsightSelectorsRequest");
   }
 }
 
@@ -727,7 +730,7 @@ export interface GetInsightSelectorsResponse extends $MetadataBearer {
 
 export namespace GetInsightSelectorsResponse {
   export function isa(o: any): o is GetInsightSelectorsResponse {
-    return _smithy.isa(o, "GetInsightSelectorsResponse");
+    return __isa(o, "GetInsightSelectorsResponse");
   }
 }
 
@@ -741,7 +744,7 @@ export interface GetTrailRequest {
 
 export namespace GetTrailRequest {
   export function isa(o: any): o is GetTrailRequest {
-    return _smithy.isa(o, "GetTrailRequest");
+    return __isa(o, "GetTrailRequest");
   }
 }
 
@@ -755,7 +758,7 @@ export interface GetTrailResponse extends $MetadataBearer {
 
 export namespace GetTrailResponse {
   export function isa(o: any): o is GetTrailResponse {
-    return _smithy.isa(o, "GetTrailResponse");
+    return __isa(o, "GetTrailResponse");
   }
 }
 
@@ -775,7 +778,7 @@ export interface GetTrailStatusRequest {
 
 export namespace GetTrailStatusRequest {
   export function isa(o: any): o is GetTrailStatusRequest {
-    return _smithy.isa(o, "GetTrailStatusRequest");
+    return __isa(o, "GetTrailStatusRequest");
   }
 }
 
@@ -890,7 +893,7 @@ export interface GetTrailStatusResponse extends $MetadataBearer {
 
 export namespace GetTrailStatusResponse {
   export function isa(o: any): o is GetTrailStatusResponse {
-    return _smithy.isa(o, "GetTrailStatusResponse");
+    return __isa(o, "GetTrailStatusResponse");
   }
 }
 
@@ -898,7 +901,7 @@ export namespace GetTrailStatusResponse {
  * <p>If you run <code>GetInsightSelectors</code> on a trail that does not have Insights events enabled, the operation throws the exception <code>InsightNotEnabledException</code>.</p>
  */
 export interface InsightNotEnabledException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InsightNotEnabledException";
   $fault: "client";
@@ -910,7 +913,7 @@ export interface InsightNotEnabledException
 
 export namespace InsightNotEnabledException {
   export function isa(o: any): o is InsightNotEnabledException {
-    return _smithy.isa(o, "InsightNotEnabledException");
+    return __isa(o, "InsightNotEnabledException");
   }
 }
 
@@ -927,7 +930,7 @@ export interface InsightSelector {
 
 export namespace InsightSelector {
   export function isa(o: any): o is InsightSelector {
-    return _smithy.isa(o, "InsightSelector");
+    return __isa(o, "InsightSelector");
   }
 }
 
@@ -941,7 +944,7 @@ export enum InsightType {
  *          <a href="https://docs.aws.amazon.com/awscloudtrail/latest/userguide/creating-an-organizational-trail-prepare.html">Prepare For Creating a Trail For Your Organization</a>.</p>
  */
 export interface InsufficientDependencyServiceAccessPermissionException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InsufficientDependencyServiceAccessPermissionException";
   $fault: "client";
@@ -955,10 +958,7 @@ export namespace InsufficientDependencyServiceAccessPermissionException {
   export function isa(
     o: any
   ): o is InsufficientDependencyServiceAccessPermissionException {
-    return _smithy.isa(
-      o,
-      "InsufficientDependencyServiceAccessPermissionException"
-    );
+    return __isa(o, "InsufficientDependencyServiceAccessPermissionException");
   }
 }
 
@@ -966,7 +966,7 @@ export namespace InsufficientDependencyServiceAccessPermissionException {
  * <p>This exception is thrown when the policy on the S3 bucket or KMS key is not sufficient.</p>
  */
 export interface InsufficientEncryptionPolicyException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InsufficientEncryptionPolicyException";
   $fault: "client";
@@ -978,7 +978,7 @@ export interface InsufficientEncryptionPolicyException
 
 export namespace InsufficientEncryptionPolicyException {
   export function isa(o: any): o is InsufficientEncryptionPolicyException {
-    return _smithy.isa(o, "InsufficientEncryptionPolicyException");
+    return __isa(o, "InsufficientEncryptionPolicyException");
   }
 }
 
@@ -986,7 +986,7 @@ export namespace InsufficientEncryptionPolicyException {
  * <p>This exception is thrown when the policy on the S3 bucket is not sufficient.</p>
  */
 export interface InsufficientS3BucketPolicyException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InsufficientS3BucketPolicyException";
   $fault: "client";
@@ -998,7 +998,7 @@ export interface InsufficientS3BucketPolicyException
 
 export namespace InsufficientS3BucketPolicyException {
   export function isa(o: any): o is InsufficientS3BucketPolicyException {
-    return _smithy.isa(o, "InsufficientS3BucketPolicyException");
+    return __isa(o, "InsufficientS3BucketPolicyException");
   }
 }
 
@@ -1006,7 +1006,7 @@ export namespace InsufficientS3BucketPolicyException {
  * <p>This exception is thrown when the policy on the SNS topic is not sufficient.</p>
  */
 export interface InsufficientSnsTopicPolicyException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InsufficientSnsTopicPolicyException";
   $fault: "client";
@@ -1018,7 +1018,7 @@ export interface InsufficientSnsTopicPolicyException
 
 export namespace InsufficientSnsTopicPolicyException {
   export function isa(o: any): o is InsufficientSnsTopicPolicyException {
-    return _smithy.isa(o, "InsufficientSnsTopicPolicyException");
+    return __isa(o, "InsufficientSnsTopicPolicyException");
   }
 }
 
@@ -1026,7 +1026,7 @@ export namespace InsufficientSnsTopicPolicyException {
  * <p>This exception is thrown when the provided CloudWatch log group is not valid.</p>
  */
 export interface InvalidCloudWatchLogsLogGroupArnException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidCloudWatchLogsLogGroupArnException";
   $fault: "client";
@@ -1038,7 +1038,7 @@ export interface InvalidCloudWatchLogsLogGroupArnException
 
 export namespace InvalidCloudWatchLogsLogGroupArnException {
   export function isa(o: any): o is InvalidCloudWatchLogsLogGroupArnException {
-    return _smithy.isa(o, "InvalidCloudWatchLogsLogGroupArnException");
+    return __isa(o, "InvalidCloudWatchLogsLogGroupArnException");
   }
 }
 
@@ -1046,7 +1046,7 @@ export namespace InvalidCloudWatchLogsLogGroupArnException {
  * <p>This exception is thrown when the provided role is not valid.</p>
  */
 export interface InvalidCloudWatchLogsRoleArnException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidCloudWatchLogsRoleArnException";
   $fault: "client";
@@ -1058,7 +1058,7 @@ export interface InvalidCloudWatchLogsRoleArnException
 
 export namespace InvalidCloudWatchLogsRoleArnException {
   export function isa(o: any): o is InvalidCloudWatchLogsRoleArnException {
-    return _smithy.isa(o, "InvalidCloudWatchLogsRoleArnException");
+    return __isa(o, "InvalidCloudWatchLogsRoleArnException");
   }
 }
 
@@ -1066,7 +1066,7 @@ export namespace InvalidCloudWatchLogsRoleArnException {
  * <p>Occurs if an event category that is not valid is specified as a value of <code>EventCategory</code>.</p>
  */
 export interface InvalidEventCategoryException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidEventCategoryException";
   $fault: "client";
@@ -1078,7 +1078,7 @@ export interface InvalidEventCategoryException
 
 export namespace InvalidEventCategoryException {
   export function isa(o: any): o is InvalidEventCategoryException {
-    return _smithy.isa(o, "InvalidEventCategoryException");
+    return __isa(o, "InvalidEventCategoryException");
   }
 }
 
@@ -1104,7 +1104,7 @@ export namespace InvalidEventCategoryException {
  *          </ul>
  */
 export interface InvalidEventSelectorsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidEventSelectorsException";
   $fault: "client";
@@ -1116,7 +1116,7 @@ export interface InvalidEventSelectorsException
 
 export namespace InvalidEventSelectorsException {
   export function isa(o: any): o is InvalidEventSelectorsException {
-    return _smithy.isa(o, "InvalidEventSelectorsException");
+    return __isa(o, "InvalidEventSelectorsException");
   }
 }
 
@@ -1124,7 +1124,7 @@ export namespace InvalidEventSelectorsException {
  * <p>This exception is thrown when an operation is called on a trail from a region other than the region in which the trail was created.</p>
  */
 export interface InvalidHomeRegionException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidHomeRegionException";
   $fault: "client";
@@ -1136,7 +1136,7 @@ export interface InvalidHomeRegionException
 
 export namespace InvalidHomeRegionException {
   export function isa(o: any): o is InvalidHomeRegionException {
-    return _smithy.isa(o, "InvalidHomeRegionException");
+    return __isa(o, "InvalidHomeRegionException");
   }
 }
 
@@ -1145,7 +1145,7 @@ export namespace InvalidHomeRegionException {
  *          is not valid, or the specified insight type in the <code>InsightSelectors</code> statement is not a valid insight type.</p>
  */
 export interface InvalidInsightSelectorsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidInsightSelectorsException";
   $fault: "client";
@@ -1157,7 +1157,7 @@ export interface InvalidInsightSelectorsException
 
 export namespace InvalidInsightSelectorsException {
   export function isa(o: any): o is InvalidInsightSelectorsException {
-    return _smithy.isa(o, "InvalidInsightSelectorsException");
+    return __isa(o, "InvalidInsightSelectorsException");
   }
 }
 
@@ -1165,7 +1165,7 @@ export namespace InvalidInsightSelectorsException {
  * <p>This exception is thrown when the KMS key ARN is invalid.</p>
  */
 export interface InvalidKmsKeyIdException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidKmsKeyIdException";
   $fault: "client";
@@ -1177,7 +1177,7 @@ export interface InvalidKmsKeyIdException
 
 export namespace InvalidKmsKeyIdException {
   export function isa(o: any): o is InvalidKmsKeyIdException {
-    return _smithy.isa(o, "InvalidKmsKeyIdException");
+    return __isa(o, "InvalidKmsKeyIdException");
   }
 }
 
@@ -1185,7 +1185,7 @@ export namespace InvalidKmsKeyIdException {
  * <p>Occurs when an invalid lookup attribute is specified.</p>
  */
 export interface InvalidLookupAttributesException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidLookupAttributesException";
   $fault: "client";
@@ -1197,7 +1197,7 @@ export interface InvalidLookupAttributesException
 
 export namespace InvalidLookupAttributesException {
   export function isa(o: any): o is InvalidLookupAttributesException {
-    return _smithy.isa(o, "InvalidLookupAttributesException");
+    return __isa(o, "InvalidLookupAttributesException");
   }
 }
 
@@ -1205,7 +1205,7 @@ export namespace InvalidLookupAttributesException {
  * <p>This exception is thrown if the limit specified is invalid.</p>
  */
 export interface InvalidMaxResultsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidMaxResultsException";
   $fault: "client";
@@ -1217,7 +1217,7 @@ export interface InvalidMaxResultsException
 
 export namespace InvalidMaxResultsException {
   export function isa(o: any): o is InvalidMaxResultsException {
-    return _smithy.isa(o, "InvalidMaxResultsException");
+    return __isa(o, "InvalidMaxResultsException");
   }
 }
 
@@ -1225,7 +1225,7 @@ export namespace InvalidMaxResultsException {
  * <p>Invalid token or token that was previously used in a request with different parameters. This exception is thrown if the token is invalid.</p>
  */
 export interface InvalidNextTokenException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidNextTokenException";
   $fault: "client";
@@ -1237,7 +1237,7 @@ export interface InvalidNextTokenException
 
 export namespace InvalidNextTokenException {
   export function isa(o: any): o is InvalidNextTokenException {
-    return _smithy.isa(o, "InvalidNextTokenException");
+    return __isa(o, "InvalidNextTokenException");
   }
 }
 
@@ -1245,7 +1245,7 @@ export namespace InvalidNextTokenException {
  * <p>This exception is thrown when the combination of parameters provided is not valid.</p>
  */
 export interface InvalidParameterCombinationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidParameterCombinationException";
   $fault: "client";
@@ -1257,7 +1257,7 @@ export interface InvalidParameterCombinationException
 
 export namespace InvalidParameterCombinationException {
   export function isa(o: any): o is InvalidParameterCombinationException {
-    return _smithy.isa(o, "InvalidParameterCombinationException");
+    return __isa(o, "InvalidParameterCombinationException");
   }
 }
 
@@ -1265,7 +1265,7 @@ export namespace InvalidParameterCombinationException {
  * <p>This exception is thrown when the provided S3 bucket name is not valid.</p>
  */
 export interface InvalidS3BucketNameException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidS3BucketNameException";
   $fault: "client";
@@ -1277,7 +1277,7 @@ export interface InvalidS3BucketNameException
 
 export namespace InvalidS3BucketNameException {
   export function isa(o: any): o is InvalidS3BucketNameException {
-    return _smithy.isa(o, "InvalidS3BucketNameException");
+    return __isa(o, "InvalidS3BucketNameException");
   }
 }
 
@@ -1285,7 +1285,7 @@ export namespace InvalidS3BucketNameException {
  * <p>This exception is thrown when the provided S3 prefix is not valid.</p>
  */
 export interface InvalidS3PrefixException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidS3PrefixException";
   $fault: "client";
@@ -1297,7 +1297,7 @@ export interface InvalidS3PrefixException
 
 export namespace InvalidS3PrefixException {
   export function isa(o: any): o is InvalidS3PrefixException {
-    return _smithy.isa(o, "InvalidS3PrefixException");
+    return __isa(o, "InvalidS3PrefixException");
   }
 }
 
@@ -1305,7 +1305,7 @@ export namespace InvalidS3PrefixException {
  * <p>This exception is thrown when the provided SNS topic name is not valid.</p>
  */
 export interface InvalidSnsTopicNameException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidSnsTopicNameException";
   $fault: "client";
@@ -1317,7 +1317,7 @@ export interface InvalidSnsTopicNameException
 
 export namespace InvalidSnsTopicNameException {
   export function isa(o: any): o is InvalidSnsTopicNameException {
-    return _smithy.isa(o, "InvalidSnsTopicNameException");
+    return __isa(o, "InvalidSnsTopicNameException");
   }
 }
 
@@ -1326,7 +1326,7 @@ export namespace InvalidSnsTopicNameException {
  *          It can also occur if there are duplicate tags or too many tags on the resource.</p>
  */
 export interface InvalidTagParameterException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidTagParameterException";
   $fault: "client";
@@ -1338,7 +1338,7 @@ export interface InvalidTagParameterException
 
 export namespace InvalidTagParameterException {
   export function isa(o: any): o is InvalidTagParameterException {
-    return _smithy.isa(o, "InvalidTagParameterException");
+    return __isa(o, "InvalidTagParameterException");
   }
 }
 
@@ -1346,7 +1346,7 @@ export namespace InvalidTagParameterException {
  * <p>Occurs if the timestamp values are invalid. Either the start time occurs after the end time or the time range is outside the range of possible values.</p>
  */
 export interface InvalidTimeRangeException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidTimeRangeException";
   $fault: "client";
@@ -1358,7 +1358,7 @@ export interface InvalidTimeRangeException
 
 export namespace InvalidTimeRangeException {
   export function isa(o: any): o is InvalidTimeRangeException {
-    return _smithy.isa(o, "InvalidTimeRangeException");
+    return __isa(o, "InvalidTimeRangeException");
   }
 }
 
@@ -1366,7 +1366,7 @@ export namespace InvalidTimeRangeException {
  * <p>Reserved for future use.</p>
  */
 export interface InvalidTokenException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidTokenException";
   $fault: "client";
@@ -1378,7 +1378,7 @@ export interface InvalidTokenException
 
 export namespace InvalidTokenException {
   export function isa(o: any): o is InvalidTokenException {
-    return _smithy.isa(o, "InvalidTokenException");
+    return __isa(o, "InvalidTokenException");
   }
 }
 
@@ -1404,7 +1404,7 @@ export namespace InvalidTokenException {
  *          </ul>
  */
 export interface InvalidTrailNameException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidTrailNameException";
   $fault: "client";
@@ -1416,14 +1416,14 @@ export interface InvalidTrailNameException
 
 export namespace InvalidTrailNameException {
   export function isa(o: any): o is InvalidTrailNameException {
-    return _smithy.isa(o, "InvalidTrailNameException");
+    return __isa(o, "InvalidTrailNameException");
   }
 }
 
 /**
  * <p>This exception is thrown when there is an issue with the specified KMS key and the trail can’t be updated.</p>
  */
-export interface KmsException extends _smithy.SmithyException, $MetadataBearer {
+export interface KmsException extends __SmithyException, $MetadataBearer {
   name: "KmsException";
   $fault: "client";
   /**
@@ -1434,7 +1434,7 @@ export interface KmsException extends _smithy.SmithyException, $MetadataBearer {
 
 export namespace KmsException {
   export function isa(o: any): o is KmsException {
-    return _smithy.isa(o, "KmsException");
+    return __isa(o, "KmsException");
   }
 }
 
@@ -1442,7 +1442,7 @@ export namespace KmsException {
  * <p>This exception is no longer in use.</p>
  */
 export interface KmsKeyDisabledException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "KmsKeyDisabledException";
   $fault: "client";
@@ -1454,7 +1454,7 @@ export interface KmsKeyDisabledException
 
 export namespace KmsKeyDisabledException {
   export function isa(o: any): o is KmsKeyDisabledException {
-    return _smithy.isa(o, "KmsKeyDisabledException");
+    return __isa(o, "KmsKeyDisabledException");
   }
 }
 
@@ -1462,7 +1462,7 @@ export namespace KmsKeyDisabledException {
  * <p>This exception is thrown when the KMS key does not exist, or when the S3 bucket and the KMS key are not in the same region.</p>
  */
 export interface KmsKeyNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "KmsKeyNotFoundException";
   $fault: "client";
@@ -1474,7 +1474,7 @@ export interface KmsKeyNotFoundException
 
 export namespace KmsKeyNotFoundException {
   export function isa(o: any): o is KmsKeyNotFoundException {
-    return _smithy.isa(o, "KmsKeyNotFoundException");
+    return __isa(o, "KmsKeyNotFoundException");
   }
 }
 
@@ -1501,7 +1501,7 @@ export interface ListPublicKeysRequest {
 
 export namespace ListPublicKeysRequest {
   export function isa(o: any): o is ListPublicKeysRequest {
-    return _smithy.isa(o, "ListPublicKeysRequest");
+    return __isa(o, "ListPublicKeysRequest");
   }
 }
 
@@ -1526,7 +1526,7 @@ export interface ListPublicKeysResponse extends $MetadataBearer {
 
 export namespace ListPublicKeysResponse {
   export function isa(o: any): o is ListPublicKeysResponse {
-    return _smithy.isa(o, "ListPublicKeysResponse");
+    return __isa(o, "ListPublicKeysResponse");
   }
 }
 
@@ -1551,7 +1551,7 @@ export interface ListTagsRequest {
 
 export namespace ListTagsRequest {
   export function isa(o: any): o is ListTagsRequest {
-    return _smithy.isa(o, "ListTagsRequest");
+    return __isa(o, "ListTagsRequest");
   }
 }
 
@@ -1573,7 +1573,7 @@ export interface ListTagsResponse extends $MetadataBearer {
 
 export namespace ListTagsResponse {
   export function isa(o: any): o is ListTagsResponse {
-    return _smithy.isa(o, "ListTagsResponse");
+    return __isa(o, "ListTagsResponse");
   }
 }
 
@@ -1590,7 +1590,7 @@ export interface ListTrailsRequest {
 
 export namespace ListTrailsRequest {
   export function isa(o: any): o is ListTrailsRequest {
-    return _smithy.isa(o, "ListTrailsRequest");
+    return __isa(o, "ListTrailsRequest");
   }
 }
 
@@ -1612,7 +1612,7 @@ export interface ListTrailsResponse extends $MetadataBearer {
 
 export namespace ListTrailsResponse {
   export function isa(o: any): o is ListTrailsResponse {
-    return _smithy.isa(o, "ListTrailsResponse");
+    return __isa(o, "ListTrailsResponse");
   }
 }
 
@@ -1634,7 +1634,7 @@ export interface LookupAttribute {
 
 export namespace LookupAttribute {
   export function isa(o: any): o is LookupAttribute {
-    return _smithy.isa(o, "LookupAttribute");
+    return __isa(o, "LookupAttribute");
   }
 }
 
@@ -1689,7 +1689,7 @@ export interface LookupEventsRequest {
 
 export namespace LookupEventsRequest {
   export function isa(o: any): o is LookupEventsRequest {
-    return _smithy.isa(o, "LookupEventsRequest");
+    return __isa(o, "LookupEventsRequest");
   }
 }
 
@@ -1714,7 +1714,7 @@ export interface LookupEventsResponse extends $MetadataBearer {
 
 export namespace LookupEventsResponse {
   export function isa(o: any): o is LookupEventsResponse {
-    return _smithy.isa(o, "LookupEventsResponse");
+    return __isa(o, "LookupEventsResponse");
   }
 }
 
@@ -1722,7 +1722,7 @@ export namespace LookupEventsResponse {
  * <p>This exception is thrown when the maximum number of trails is reached.</p>
  */
 export interface MaximumNumberOfTrailsExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "MaximumNumberOfTrailsExceededException";
   $fault: "client";
@@ -1734,7 +1734,7 @@ export interface MaximumNumberOfTrailsExceededException
 
 export namespace MaximumNumberOfTrailsExceededException {
   export function isa(o: any): o is MaximumNumberOfTrailsExceededException {
-    return _smithy.isa(o, "MaximumNumberOfTrailsExceededException");
+    return __isa(o, "MaximumNumberOfTrailsExceededException");
   }
 }
 
@@ -1744,7 +1744,7 @@ export namespace MaximumNumberOfTrailsExceededException {
  *          <a href="https://docs.aws.amazon.com/awscloudtrail/latest/userguide/creating-an-organizational-trail-prepare.html">Prepare For Creating a Trail For Your Organization</a>.</p>
  */
 export interface NotOrganizationMasterAccountException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "NotOrganizationMasterAccountException";
   $fault: "client";
@@ -1756,7 +1756,7 @@ export interface NotOrganizationMasterAccountException
 
 export namespace NotOrganizationMasterAccountException {
   export function isa(o: any): o is NotOrganizationMasterAccountException {
-    return _smithy.isa(o, "NotOrganizationMasterAccountException");
+    return __isa(o, "NotOrganizationMasterAccountException");
   }
 }
 
@@ -1764,7 +1764,7 @@ export namespace NotOrganizationMasterAccountException {
  * <p>This exception is thrown when the requested operation is not permitted.</p>
  */
 export interface OperationNotPermittedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "OperationNotPermittedException";
   $fault: "client";
@@ -1776,7 +1776,7 @@ export interface OperationNotPermittedException
 
 export namespace OperationNotPermittedException {
   export function isa(o: any): o is OperationNotPermittedException {
-    return _smithy.isa(o, "OperationNotPermittedException");
+    return __isa(o, "OperationNotPermittedException");
   }
 }
 
@@ -1786,7 +1786,7 @@ export namespace OperationNotPermittedException {
  *          <a href="https://docs.aws.amazon.com/awscloudtrail/latest/userguide/creating-an-organizational-trail-prepare.html">Prepare For Creating a Trail For Your Organization</a>.</p>
  */
 export interface OrganizationNotInAllFeaturesModeException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "OrganizationNotInAllFeaturesModeException";
   $fault: "client";
@@ -1798,7 +1798,7 @@ export interface OrganizationNotInAllFeaturesModeException
 
 export namespace OrganizationNotInAllFeaturesModeException {
   export function isa(o: any): o is OrganizationNotInAllFeaturesModeException {
-    return _smithy.isa(o, "OrganizationNotInAllFeaturesModeException");
+    return __isa(o, "OrganizationNotInAllFeaturesModeException");
   }
 }
 
@@ -1807,7 +1807,7 @@ export namespace OrganizationNotInAllFeaturesModeException {
  *          To make this request, sign in using the credentials of an account that belongs to an organization.</p>
  */
 export interface OrganizationsNotInUseException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "OrganizationsNotInUseException";
   $fault: "client";
@@ -1819,7 +1819,7 @@ export interface OrganizationsNotInUseException
 
 export namespace OrganizationsNotInUseException {
   export function isa(o: any): o is OrganizationsNotInUseException {
-    return _smithy.isa(o, "OrganizationsNotInUseException");
+    return __isa(o, "OrganizationsNotInUseException");
   }
 }
 
@@ -1851,7 +1851,7 @@ export interface PublicKey {
 
 export namespace PublicKey {
   export function isa(o: any): o is PublicKey {
-    return _smithy.isa(o, "PublicKey");
+    return __isa(o, "PublicKey");
   }
 }
 
@@ -1893,7 +1893,7 @@ export interface PutEventSelectorsRequest {
 
 export namespace PutEventSelectorsRequest {
   export function isa(o: any): o is PutEventSelectorsRequest {
-    return _smithy.isa(o, "PutEventSelectorsRequest");
+    return __isa(o, "PutEventSelectorsRequest");
   }
 }
 
@@ -1916,7 +1916,7 @@ export interface PutEventSelectorsResponse extends $MetadataBearer {
 
 export namespace PutEventSelectorsResponse {
   export function isa(o: any): o is PutEventSelectorsResponse {
-    return _smithy.isa(o, "PutEventSelectorsResponse");
+    return __isa(o, "PutEventSelectorsResponse");
   }
 }
 
@@ -1935,7 +1935,7 @@ export interface PutInsightSelectorsRequest {
 
 export namespace PutInsightSelectorsRequest {
   export function isa(o: any): o is PutInsightSelectorsRequest {
-    return _smithy.isa(o, "PutInsightSelectorsRequest");
+    return __isa(o, "PutInsightSelectorsRequest");
   }
 }
 
@@ -1954,7 +1954,7 @@ export interface PutInsightSelectorsResponse extends $MetadataBearer {
 
 export namespace PutInsightSelectorsResponse {
   export function isa(o: any): o is PutInsightSelectorsResponse {
-    return _smithy.isa(o, "PutInsightSelectorsResponse");
+    return __isa(o, "PutInsightSelectorsResponse");
   }
 }
 
@@ -1985,7 +1985,7 @@ export interface RemoveTagsRequest {
 
 export namespace RemoveTagsRequest {
   export function isa(o: any): o is RemoveTagsRequest {
-    return _smithy.isa(o, "RemoveTagsRequest");
+    return __isa(o, "RemoveTagsRequest");
   }
 }
 
@@ -1998,7 +1998,7 @@ export interface RemoveTagsResponse extends $MetadataBearer {
 
 export namespace RemoveTagsResponse {
   export function isa(o: any): o is RemoveTagsResponse {
-    return _smithy.isa(o, "RemoveTagsResponse");
+    return __isa(o, "RemoveTagsResponse");
   }
 }
 
@@ -2023,7 +2023,7 @@ export interface Resource {
 
 export namespace Resource {
   export function isa(o: any): o is Resource {
-    return _smithy.isa(o, "Resource");
+    return __isa(o, "Resource");
   }
 }
 
@@ -2031,7 +2031,7 @@ export namespace Resource {
  * <p>This exception is thrown when the specified resource is not found.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -2043,7 +2043,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -2065,7 +2065,7 @@ export interface ResourceTag {
 
 export namespace ResourceTag {
   export function isa(o: any): o is ResourceTag {
-    return _smithy.isa(o, "ResourceTag");
+    return __isa(o, "ResourceTag");
   }
 }
 
@@ -2073,7 +2073,7 @@ export namespace ResourceTag {
  * <p>This exception is thrown when the specified resource type is not supported by CloudTrail.</p>
  */
 export interface ResourceTypeNotSupportedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceTypeNotSupportedException";
   $fault: "client";
@@ -2085,7 +2085,7 @@ export interface ResourceTypeNotSupportedException
 
 export namespace ResourceTypeNotSupportedException {
   export function isa(o: any): o is ResourceTypeNotSupportedException {
-    return _smithy.isa(o, "ResourceTypeNotSupportedException");
+    return __isa(o, "ResourceTypeNotSupportedException");
   }
 }
 
@@ -2093,7 +2093,7 @@ export namespace ResourceTypeNotSupportedException {
  * <p>This exception is thrown when the specified S3 bucket does not exist.</p>
  */
 export interface S3BucketDoesNotExistException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "S3BucketDoesNotExistException";
   $fault: "client";
@@ -2105,7 +2105,7 @@ export interface S3BucketDoesNotExistException
 
 export namespace S3BucketDoesNotExistException {
   export function isa(o: any): o is S3BucketDoesNotExistException {
-    return _smithy.isa(o, "S3BucketDoesNotExistException");
+    return __isa(o, "S3BucketDoesNotExistException");
   }
 }
 
@@ -2125,7 +2125,7 @@ export interface StartLoggingRequest {
 
 export namespace StartLoggingRequest {
   export function isa(o: any): o is StartLoggingRequest {
-    return _smithy.isa(o, "StartLoggingRequest");
+    return __isa(o, "StartLoggingRequest");
   }
 }
 
@@ -2138,7 +2138,7 @@ export interface StartLoggingResponse extends $MetadataBearer {
 
 export namespace StartLoggingResponse {
   export function isa(o: any): o is StartLoggingResponse {
-    return _smithy.isa(o, "StartLoggingResponse");
+    return __isa(o, "StartLoggingResponse");
   }
 }
 
@@ -2158,7 +2158,7 @@ export interface StopLoggingRequest {
 
 export namespace StopLoggingRequest {
   export function isa(o: any): o is StopLoggingRequest {
-    return _smithy.isa(o, "StopLoggingRequest");
+    return __isa(o, "StopLoggingRequest");
   }
 }
 
@@ -2171,7 +2171,7 @@ export interface StopLoggingResponse extends $MetadataBearer {
 
 export namespace StopLoggingResponse {
   export function isa(o: any): o is StopLoggingResponse {
-    return _smithy.isa(o, "StopLoggingResponse");
+    return __isa(o, "StopLoggingResponse");
   }
 }
 
@@ -2193,7 +2193,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -2201,7 +2201,7 @@ export namespace Tag {
  * <p>The number of tags per trail has exceeded the permitted amount. Currently, the limit is 50.</p>
  */
 export interface TagsLimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TagsLimitExceededException";
   $fault: "client";
@@ -2213,7 +2213,7 @@ export interface TagsLimitExceededException
 
 export namespace TagsLimitExceededException {
   export function isa(o: any): o is TagsLimitExceededException {
-    return _smithy.isa(o, "TagsLimitExceededException");
+    return __isa(o, "TagsLimitExceededException");
   }
 }
 
@@ -2318,7 +2318,7 @@ export interface Trail {
 
 export namespace Trail {
   export function isa(o: any): o is Trail {
-    return _smithy.isa(o, "Trail");
+    return __isa(o, "Trail");
   }
 }
 
@@ -2326,7 +2326,7 @@ export namespace Trail {
  * <p>This exception is thrown when the specified trail already exists.</p>
  */
 export interface TrailAlreadyExistsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TrailAlreadyExistsException";
   $fault: "client";
@@ -2338,7 +2338,7 @@ export interface TrailAlreadyExistsException
 
 export namespace TrailAlreadyExistsException {
   export function isa(o: any): o is TrailAlreadyExistsException {
-    return _smithy.isa(o, "TrailAlreadyExistsException");
+    return __isa(o, "TrailAlreadyExistsException");
   }
 }
 
@@ -2365,7 +2365,7 @@ export interface TrailInfo {
 
 export namespace TrailInfo {
   export function isa(o: any): o is TrailInfo {
-    return _smithy.isa(o, "TrailInfo");
+    return __isa(o, "TrailInfo");
   }
 }
 
@@ -2373,7 +2373,7 @@ export namespace TrailInfo {
  * <p>This exception is thrown when the trail with the given name is not found.</p>
  */
 export interface TrailNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TrailNotFoundException";
   $fault: "client";
@@ -2385,7 +2385,7 @@ export interface TrailNotFoundException
 
 export namespace TrailNotFoundException {
   export function isa(o: any): o is TrailNotFoundException {
-    return _smithy.isa(o, "TrailNotFoundException");
+    return __isa(o, "TrailNotFoundException");
   }
 }
 
@@ -2393,7 +2393,7 @@ export namespace TrailNotFoundException {
  * <p>This exception is no longer in use.</p>
  */
 export interface TrailNotProvidedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TrailNotProvidedException";
   $fault: "client";
@@ -2405,7 +2405,7 @@ export interface TrailNotProvidedException
 
 export namespace TrailNotProvidedException {
   export function isa(o: any): o is TrailNotProvidedException {
-    return _smithy.isa(o, "TrailNotProvidedException");
+    return __isa(o, "TrailNotProvidedException");
   }
 }
 
@@ -2413,7 +2413,7 @@ export namespace TrailNotProvidedException {
  * <p>This exception is thrown when the requested operation is not supported.</p>
  */
 export interface UnsupportedOperationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UnsupportedOperationException";
   $fault: "client";
@@ -2425,7 +2425,7 @@ export interface UnsupportedOperationException
 
 export namespace UnsupportedOperationException {
   export function isa(o: any): o is UnsupportedOperationException {
-    return _smithy.isa(o, "UnsupportedOperationException");
+    return __isa(o, "UnsupportedOperationException");
   }
 }
 
@@ -2543,7 +2543,7 @@ export interface UpdateTrailRequest {
 
 export namespace UpdateTrailRequest {
   export function isa(o: any): o is UpdateTrailRequest {
-    return _smithy.isa(o, "UpdateTrailRequest");
+    return __isa(o, "UpdateTrailRequest");
   }
 }
 
@@ -2633,6 +2633,6 @@ export interface UpdateTrailResponse extends $MetadataBearer {
 
 export namespace UpdateTrailResponse {
   export function isa(o: any): o is UpdateTrailResponse {
-    return _smithy.isa(o, "UpdateTrailResponse");
+    return __isa(o, "UpdateTrailResponse");
   }
 }

--- a/clients/client-cloudwatch-events/models/index.ts
+++ b/clients/client-cloudwatch-events/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export interface ActivateEventSourceRequest {
@@ -11,7 +14,7 @@ export interface ActivateEventSourceRequest {
 
 export namespace ActivateEventSourceRequest {
   export function isa(o: any): o is ActivateEventSourceRequest {
-    return _smithy.isa(o, "ActivateEventSourceRequest");
+    return __isa(o, "ActivateEventSourceRequest");
   }
 }
 
@@ -49,7 +52,7 @@ export interface AwsVpcConfiguration {
 
 export namespace AwsVpcConfiguration {
   export function isa(o: any): o is AwsVpcConfiguration {
-    return _smithy.isa(o, "AwsVpcConfiguration");
+    return __isa(o, "AwsVpcConfiguration");
   }
 }
 
@@ -69,7 +72,7 @@ export interface BatchArrayProperties {
 
 export namespace BatchArrayProperties {
   export function isa(o: any): o is BatchArrayProperties {
-    return _smithy.isa(o, "BatchArrayProperties");
+    return __isa(o, "BatchArrayProperties");
   }
 }
 
@@ -106,7 +109,7 @@ export interface BatchParameters {
 
 export namespace BatchParameters {
   export function isa(o: any): o is BatchParameters {
-    return _smithy.isa(o, "BatchParameters");
+    return __isa(o, "BatchParameters");
   }
 }
 
@@ -126,7 +129,7 @@ export interface BatchRetryStrategy {
 
 export namespace BatchRetryStrategy {
   export function isa(o: any): o is BatchRetryStrategy {
-    return _smithy.isa(o, "BatchRetryStrategy");
+    return __isa(o, "BatchRetryStrategy");
   }
 }
 
@@ -163,7 +166,7 @@ export interface Condition {
 
 export namespace Condition {
   export function isa(o: any): o is Condition {
-    return _smithy.isa(o, "Condition");
+    return __isa(o, "Condition");
   }
 }
 
@@ -188,7 +191,7 @@ export interface CreateEventBusRequest {
 
 export namespace CreateEventBusRequest {
   export function isa(o: any): o is CreateEventBusRequest {
-    return _smithy.isa(o, "CreateEventBusRequest");
+    return __isa(o, "CreateEventBusRequest");
   }
 }
 
@@ -202,7 +205,7 @@ export interface CreateEventBusResponse extends $MetadataBearer {
 
 export namespace CreateEventBusResponse {
   export function isa(o: any): o is CreateEventBusResponse {
-    return _smithy.isa(o, "CreateEventBusResponse");
+    return __isa(o, "CreateEventBusResponse");
   }
 }
 
@@ -226,7 +229,7 @@ export interface CreatePartnerEventSourceRequest {
 
 export namespace CreatePartnerEventSourceRequest {
   export function isa(o: any): o is CreatePartnerEventSourceRequest {
-    return _smithy.isa(o, "CreatePartnerEventSourceRequest");
+    return __isa(o, "CreatePartnerEventSourceRequest");
   }
 }
 
@@ -240,7 +243,7 @@ export interface CreatePartnerEventSourceResponse extends $MetadataBearer {
 
 export namespace CreatePartnerEventSourceResponse {
   export function isa(o: any): o is CreatePartnerEventSourceResponse {
-    return _smithy.isa(o, "CreatePartnerEventSourceResponse");
+    return __isa(o, "CreatePartnerEventSourceResponse");
   }
 }
 
@@ -254,7 +257,7 @@ export interface DeactivateEventSourceRequest {
 
 export namespace DeactivateEventSourceRequest {
   export function isa(o: any): o is DeactivateEventSourceRequest {
-    return _smithy.isa(o, "DeactivateEventSourceRequest");
+    return __isa(o, "DeactivateEventSourceRequest");
   }
 }
 
@@ -268,7 +271,7 @@ export interface DeleteEventBusRequest {
 
 export namespace DeleteEventBusRequest {
   export function isa(o: any): o is DeleteEventBusRequest {
-    return _smithy.isa(o, "DeleteEventBusRequest");
+    return __isa(o, "DeleteEventBusRequest");
   }
 }
 
@@ -287,7 +290,7 @@ export interface DeletePartnerEventSourceRequest {
 
 export namespace DeletePartnerEventSourceRequest {
   export function isa(o: any): o is DeletePartnerEventSourceRequest {
-    return _smithy.isa(o, "DeletePartnerEventSourceRequest");
+    return __isa(o, "DeletePartnerEventSourceRequest");
   }
 }
 
@@ -314,7 +317,7 @@ export interface DeleteRuleRequest {
 
 export namespace DeleteRuleRequest {
   export function isa(o: any): o is DeleteRuleRequest {
-    return _smithy.isa(o, "DeleteRuleRequest");
+    return __isa(o, "DeleteRuleRequest");
   }
 }
 
@@ -328,7 +331,7 @@ export interface DescribeEventBusRequest {
 
 export namespace DescribeEventBusRequest {
   export function isa(o: any): o is DescribeEventBusRequest {
-    return _smithy.isa(o, "DescribeEventBusRequest");
+    return __isa(o, "DescribeEventBusRequest");
   }
 }
 
@@ -352,7 +355,7 @@ export interface DescribeEventBusResponse extends $MetadataBearer {
 
 export namespace DescribeEventBusResponse {
   export function isa(o: any): o is DescribeEventBusResponse {
-    return _smithy.isa(o, "DescribeEventBusResponse");
+    return __isa(o, "DescribeEventBusResponse");
   }
 }
 
@@ -366,7 +369,7 @@ export interface DescribeEventSourceRequest {
 
 export namespace DescribeEventSourceRequest {
   export function isa(o: any): o is DescribeEventSourceRequest {
-    return _smithy.isa(o, "DescribeEventSourceRequest");
+    return __isa(o, "DescribeEventSourceRequest");
   }
 }
 
@@ -410,7 +413,7 @@ export interface DescribeEventSourceResponse extends $MetadataBearer {
 
 export namespace DescribeEventSourceResponse {
   export function isa(o: any): o is DescribeEventSourceResponse {
-    return _smithy.isa(o, "DescribeEventSourceResponse");
+    return __isa(o, "DescribeEventSourceResponse");
   }
 }
 
@@ -424,7 +427,7 @@ export interface DescribePartnerEventSourceRequest {
 
 export namespace DescribePartnerEventSourceRequest {
   export function isa(o: any): o is DescribePartnerEventSourceRequest {
-    return _smithy.isa(o, "DescribePartnerEventSourceRequest");
+    return __isa(o, "DescribePartnerEventSourceRequest");
   }
 }
 
@@ -443,7 +446,7 @@ export interface DescribePartnerEventSourceResponse extends $MetadataBearer {
 
 export namespace DescribePartnerEventSourceResponse {
   export function isa(o: any): o is DescribePartnerEventSourceResponse {
-    return _smithy.isa(o, "DescribePartnerEventSourceResponse");
+    return __isa(o, "DescribePartnerEventSourceResponse");
   }
 }
 
@@ -462,7 +465,7 @@ export interface DescribeRuleRequest {
 
 export namespace DescribeRuleRequest {
   export function isa(o: any): o is DescribeRuleRequest {
-    return _smithy.isa(o, "DescribeRuleRequest");
+    return __isa(o, "DescribeRuleRequest");
   }
 }
 
@@ -518,7 +521,7 @@ export interface DescribeRuleResponse extends $MetadataBearer {
 
 export namespace DescribeRuleResponse {
   export function isa(o: any): o is DescribeRuleResponse {
-    return _smithy.isa(o, "DescribeRuleResponse");
+    return __isa(o, "DescribeRuleResponse");
   }
 }
 
@@ -537,7 +540,7 @@ export interface DisableRuleRequest {
 
 export namespace DisableRuleRequest {
   export function isa(o: any): o is DisableRuleRequest {
-    return _smithy.isa(o, "DisableRuleRequest");
+    return __isa(o, "DisableRuleRequest");
   }
 }
 
@@ -596,7 +599,7 @@ export interface EcsParameters {
 
 export namespace EcsParameters {
   export function isa(o: any): o is EcsParameters {
-    return _smithy.isa(o, "EcsParameters");
+    return __isa(o, "EcsParameters");
   }
 }
 
@@ -615,7 +618,7 @@ export interface EnableRuleRequest {
 
 export namespace EnableRuleRequest {
   export function isa(o: any): o is EnableRuleRequest {
-    return _smithy.isa(o, "EnableRuleRequest");
+    return __isa(o, "EnableRuleRequest");
   }
 }
 
@@ -645,7 +648,7 @@ export interface EventBus {
 
 export namespace EventBus {
   export function isa(o: any): o is EventBus {
-    return _smithy.isa(o, "EventBus");
+    return __isa(o, "EventBus");
   }
 }
 
@@ -693,7 +696,7 @@ export interface EventSource {
 
 export namespace EventSource {
   export function isa(o: any): o is EventSource {
-    return _smithy.isa(o, "EventSource");
+    return __isa(o, "EventSource");
   }
 }
 
@@ -773,7 +776,7 @@ export interface InputTransformer {
 
 export namespace InputTransformer {
   export function isa(o: any): o is InputTransformer {
-    return _smithy.isa(o, "InputTransformer");
+    return __isa(o, "InputTransformer");
   }
 }
 
@@ -793,7 +796,7 @@ export interface KinesisParameters {
 
 export namespace KinesisParameters {
   export function isa(o: any): o is KinesisParameters {
-    return _smithy.isa(o, "KinesisParameters");
+    return __isa(o, "KinesisParameters");
   }
 }
 
@@ -825,7 +828,7 @@ export interface ListEventBusesRequest {
 
 export namespace ListEventBusesRequest {
   export function isa(o: any): o is ListEventBusesRequest {
-    return _smithy.isa(o, "ListEventBusesRequest");
+    return __isa(o, "ListEventBusesRequest");
   }
 }
 
@@ -844,7 +847,7 @@ export interface ListEventBusesResponse extends $MetadataBearer {
 
 export namespace ListEventBusesResponse {
   export function isa(o: any): o is ListEventBusesResponse {
-    return _smithy.isa(o, "ListEventBusesResponse");
+    return __isa(o, "ListEventBusesResponse");
   }
 }
 
@@ -871,7 +874,7 @@ export interface ListEventSourcesRequest {
 
 export namespace ListEventSourcesRequest {
   export function isa(o: any): o is ListEventSourcesRequest {
-    return _smithy.isa(o, "ListEventSourcesRequest");
+    return __isa(o, "ListEventSourcesRequest");
   }
 }
 
@@ -890,7 +893,7 @@ export interface ListEventSourcesResponse extends $MetadataBearer {
 
 export namespace ListEventSourcesResponse {
   export function isa(o: any): o is ListEventSourcesResponse {
-    return _smithy.isa(o, "ListEventSourcesResponse");
+    return __isa(o, "ListEventSourcesResponse");
   }
 }
 
@@ -916,7 +919,7 @@ export interface ListPartnerEventSourceAccountsRequest {
 
 export namespace ListPartnerEventSourceAccountsRequest {
   export function isa(o: any): o is ListPartnerEventSourceAccountsRequest {
-    return _smithy.isa(o, "ListPartnerEventSourceAccountsRequest");
+    return __isa(o, "ListPartnerEventSourceAccountsRequest");
   }
 }
 
@@ -936,7 +939,7 @@ export interface ListPartnerEventSourceAccountsResponse
 
 export namespace ListPartnerEventSourceAccountsResponse {
   export function isa(o: any): o is ListPartnerEventSourceAccountsResponse {
-    return _smithy.isa(o, "ListPartnerEventSourceAccountsResponse");
+    return __isa(o, "ListPartnerEventSourceAccountsResponse");
   }
 }
 
@@ -963,7 +966,7 @@ export interface ListPartnerEventSourcesRequest {
 
 export namespace ListPartnerEventSourcesRequest {
   export function isa(o: any): o is ListPartnerEventSourcesRequest {
-    return _smithy.isa(o, "ListPartnerEventSourcesRequest");
+    return __isa(o, "ListPartnerEventSourcesRequest");
   }
 }
 
@@ -982,7 +985,7 @@ export interface ListPartnerEventSourcesResponse extends $MetadataBearer {
 
 export namespace ListPartnerEventSourcesResponse {
   export function isa(o: any): o is ListPartnerEventSourcesResponse {
-    return _smithy.isa(o, "ListPartnerEventSourcesResponse");
+    return __isa(o, "ListPartnerEventSourcesResponse");
   }
 }
 
@@ -1011,7 +1014,7 @@ export interface ListRuleNamesByTargetRequest {
 
 export namespace ListRuleNamesByTargetRequest {
   export function isa(o: any): o is ListRuleNamesByTargetRequest {
-    return _smithy.isa(o, "ListRuleNamesByTargetRequest");
+    return __isa(o, "ListRuleNamesByTargetRequest");
   }
 }
 
@@ -1030,7 +1033,7 @@ export interface ListRuleNamesByTargetResponse extends $MetadataBearer {
 
 export namespace ListRuleNamesByTargetResponse {
   export function isa(o: any): o is ListRuleNamesByTargetResponse {
-    return _smithy.isa(o, "ListRuleNamesByTargetResponse");
+    return __isa(o, "ListRuleNamesByTargetResponse");
   }
 }
 
@@ -1059,7 +1062,7 @@ export interface ListRulesRequest {
 
 export namespace ListRulesRequest {
   export function isa(o: any): o is ListRulesRequest {
-    return _smithy.isa(o, "ListRulesRequest");
+    return __isa(o, "ListRulesRequest");
   }
 }
 
@@ -1078,7 +1081,7 @@ export interface ListRulesResponse extends $MetadataBearer {
 
 export namespace ListRulesResponse {
   export function isa(o: any): o is ListRulesResponse {
-    return _smithy.isa(o, "ListRulesResponse");
+    return __isa(o, "ListRulesResponse");
   }
 }
 
@@ -1092,7 +1095,7 @@ export interface ListTagsForResourceRequest {
 
 export namespace ListTagsForResourceRequest {
   export function isa(o: any): o is ListTagsForResourceRequest {
-    return _smithy.isa(o, "ListTagsForResourceRequest");
+    return __isa(o, "ListTagsForResourceRequest");
   }
 }
 
@@ -1106,7 +1109,7 @@ export interface ListTagsForResourceResponse extends $MetadataBearer {
 
 export namespace ListTagsForResourceResponse {
   export function isa(o: any): o is ListTagsForResourceResponse {
-    return _smithy.isa(o, "ListTagsForResourceResponse");
+    return __isa(o, "ListTagsForResourceResponse");
   }
 }
 
@@ -1135,7 +1138,7 @@ export interface ListTargetsByRuleRequest {
 
 export namespace ListTargetsByRuleRequest {
   export function isa(o: any): o is ListTargetsByRuleRequest {
-    return _smithy.isa(o, "ListTargetsByRuleRequest");
+    return __isa(o, "ListTargetsByRuleRequest");
   }
 }
 
@@ -1154,7 +1157,7 @@ export interface ListTargetsByRuleResponse extends $MetadataBearer {
 
 export namespace ListTargetsByRuleResponse {
   export function isa(o: any): o is ListTargetsByRuleResponse {
-    return _smithy.isa(o, "ListTargetsByRuleResponse");
+    return __isa(o, "ListTargetsByRuleResponse");
   }
 }
 
@@ -1173,7 +1176,7 @@ export interface NetworkConfiguration {
 
 export namespace NetworkConfiguration {
   export function isa(o: any): o is NetworkConfiguration {
-    return _smithy.isa(o, "NetworkConfiguration");
+    return __isa(o, "NetworkConfiguration");
   }
 }
 
@@ -1196,7 +1199,7 @@ export interface PartnerEventSource {
 
 export namespace PartnerEventSource {
   export function isa(o: any): o is PartnerEventSource {
-    return _smithy.isa(o, "PartnerEventSource");
+    return __isa(o, "PartnerEventSource");
   }
 }
 
@@ -1233,7 +1236,7 @@ export interface PartnerEventSourceAccount {
 
 export namespace PartnerEventSourceAccount {
   export function isa(o: any): o is PartnerEventSourceAccount {
-    return _smithy.isa(o, "PartnerEventSourceAccount");
+    return __isa(o, "PartnerEventSourceAccount");
   }
 }
 
@@ -1247,7 +1250,7 @@ export interface PutEventsRequest {
 
 export namespace PutEventsRequest {
   export function isa(o: any): o is PutEventsRequest {
-    return _smithy.isa(o, "PutEventsRequest");
+    return __isa(o, "PutEventsRequest");
   }
 }
 
@@ -1294,7 +1297,7 @@ export interface PutEventsRequestEntry {
 
 export namespace PutEventsRequestEntry {
   export function isa(o: any): o is PutEventsRequestEntry {
-    return _smithy.isa(o, "PutEventsRequestEntry");
+    return __isa(o, "PutEventsRequestEntry");
   }
 }
 
@@ -1315,7 +1318,7 @@ export interface PutEventsResponse extends $MetadataBearer {
 
 export namespace PutEventsResponse {
   export function isa(o: any): o is PutEventsResponse {
-    return _smithy.isa(o, "PutEventsResponse");
+    return __isa(o, "PutEventsResponse");
   }
 }
 
@@ -1342,7 +1345,7 @@ export interface PutEventsResultEntry {
 
 export namespace PutEventsResultEntry {
   export function isa(o: any): o is PutEventsResultEntry {
-    return _smithy.isa(o, "PutEventsResultEntry");
+    return __isa(o, "PutEventsResultEntry");
   }
 }
 
@@ -1356,7 +1359,7 @@ export interface PutPartnerEventsRequest {
 
 export namespace PutPartnerEventsRequest {
   export function isa(o: any): o is PutPartnerEventsRequest {
-    return _smithy.isa(o, "PutPartnerEventsRequest");
+    return __isa(o, "PutPartnerEventsRequest");
   }
 }
 
@@ -1396,7 +1399,7 @@ export interface PutPartnerEventsRequestEntry {
 
 export namespace PutPartnerEventsRequestEntry {
   export function isa(o: any): o is PutPartnerEventsRequestEntry {
-    return _smithy.isa(o, "PutPartnerEventsRequestEntry");
+    return __isa(o, "PutPartnerEventsRequestEntry");
   }
 }
 
@@ -1416,7 +1419,7 @@ export interface PutPartnerEventsResponse extends $MetadataBearer {
 
 export namespace PutPartnerEventsResponse {
   export function isa(o: any): o is PutPartnerEventsResponse {
-    return _smithy.isa(o, "PutPartnerEventsResponse");
+    return __isa(o, "PutPartnerEventsResponse");
   }
 }
 
@@ -1443,7 +1446,7 @@ export interface PutPartnerEventsResultEntry {
 
 export namespace PutPartnerEventsResultEntry {
   export function isa(o: any): o is PutPartnerEventsResultEntry {
-    return _smithy.isa(o, "PutPartnerEventsResultEntry");
+    return __isa(o, "PutPartnerEventsResultEntry");
   }
 }
 
@@ -1497,7 +1500,7 @@ export interface PutPermissionRequest {
 
 export namespace PutPermissionRequest {
   export function isa(o: any): o is PutPermissionRequest {
-    return _smithy.isa(o, "PutPermissionRequest");
+    return __isa(o, "PutPermissionRequest");
   }
 }
 
@@ -1548,7 +1551,7 @@ export interface PutRuleRequest {
 
 export namespace PutRuleRequest {
   export function isa(o: any): o is PutRuleRequest {
-    return _smithy.isa(o, "PutRuleRequest");
+    return __isa(o, "PutRuleRequest");
   }
 }
 
@@ -1562,7 +1565,7 @@ export interface PutRuleResponse extends $MetadataBearer {
 
 export namespace PutRuleResponse {
   export function isa(o: any): o is PutRuleResponse {
-    return _smithy.isa(o, "PutRuleResponse");
+    return __isa(o, "PutRuleResponse");
   }
 }
 
@@ -1586,7 +1589,7 @@ export interface PutTargetsRequest {
 
 export namespace PutTargetsRequest {
   export function isa(o: any): o is PutTargetsRequest {
-    return _smithy.isa(o, "PutTargetsRequest");
+    return __isa(o, "PutTargetsRequest");
   }
 }
 
@@ -1605,7 +1608,7 @@ export interface PutTargetsResponse extends $MetadataBearer {
 
 export namespace PutTargetsResponse {
   export function isa(o: any): o is PutTargetsResponse {
-    return _smithy.isa(o, "PutTargetsResponse");
+    return __isa(o, "PutTargetsResponse");
   }
 }
 
@@ -1633,7 +1636,7 @@ export interface PutTargetsResultEntry {
 
 export namespace PutTargetsResultEntry {
   export function isa(o: any): o is PutTargetsResultEntry {
-    return _smithy.isa(o, "PutTargetsResultEntry");
+    return __isa(o, "PutTargetsResultEntry");
   }
 }
 
@@ -1652,7 +1655,7 @@ export interface RemovePermissionRequest {
 
 export namespace RemovePermissionRequest {
   export function isa(o: any): o is RemovePermissionRequest {
-    return _smithy.isa(o, "RemovePermissionRequest");
+    return __isa(o, "RemovePermissionRequest");
   }
 }
 
@@ -1685,7 +1688,7 @@ export interface RemoveTargetsRequest {
 
 export namespace RemoveTargetsRequest {
   export function isa(o: any): o is RemoveTargetsRequest {
-    return _smithy.isa(o, "RemoveTargetsRequest");
+    return __isa(o, "RemoveTargetsRequest");
   }
 }
 
@@ -1704,7 +1707,7 @@ export interface RemoveTargetsResponse extends $MetadataBearer {
 
 export namespace RemoveTargetsResponse {
   export function isa(o: any): o is RemoveTargetsResponse {
-    return _smithy.isa(o, "RemoveTargetsResponse");
+    return __isa(o, "RemoveTargetsResponse");
   }
 }
 
@@ -1732,7 +1735,7 @@ export interface RemoveTargetsResultEntry {
 
 export namespace RemoveTargetsResultEntry {
   export function isa(o: any): o is RemoveTargetsResultEntry {
-    return _smithy.isa(o, "RemoveTargetsResultEntry");
+    return __isa(o, "RemoveTargetsResultEntry");
   }
 }
 
@@ -1791,7 +1794,7 @@ export interface Rule {
 
 export namespace Rule {
   export function isa(o: any): o is Rule {
-    return _smithy.isa(o, "Rule");
+    return __isa(o, "Rule");
   }
 }
 
@@ -1815,7 +1818,7 @@ export interface RunCommandParameters {
 
 export namespace RunCommandParameters {
   export function isa(o: any): o is RunCommandParameters {
-    return _smithy.isa(o, "RunCommandParameters");
+    return __isa(o, "RunCommandParameters");
   }
 }
 
@@ -1842,7 +1845,7 @@ export interface RunCommandTarget {
 
 export namespace RunCommandTarget {
   export function isa(o: any): o is RunCommandTarget {
-    return _smithy.isa(o, "RunCommandTarget");
+    return __isa(o, "RunCommandTarget");
   }
 }
 
@@ -1859,7 +1862,7 @@ export interface SqsParameters {
 
 export namespace SqsParameters {
   export function isa(o: any): o is SqsParameters {
-    return _smithy.isa(o, "SqsParameters");
+    return __isa(o, "SqsParameters");
   }
 }
 
@@ -1882,7 +1885,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -1901,7 +1904,7 @@ export interface TagResourceRequest {
 
 export namespace TagResourceRequest {
   export function isa(o: any): o is TagResourceRequest {
-    return _smithy.isa(o, "TagResourceRequest");
+    return __isa(o, "TagResourceRequest");
   }
 }
 
@@ -1911,7 +1914,7 @@ export interface TagResourceResponse extends $MetadataBearer {
 
 export namespace TagResourceResponse {
   export function isa(o: any): o is TagResourceResponse {
-    return _smithy.isa(o, "TagResourceResponse");
+    return __isa(o, "TagResourceResponse");
   }
 }
 
@@ -1999,7 +2002,7 @@ export interface Target {
 
 export namespace Target {
   export function isa(o: any): o is Target {
-    return _smithy.isa(o, "Target");
+    return __isa(o, "Target");
   }
 }
 
@@ -2019,7 +2022,7 @@ export interface TestEventPatternRequest {
 
 export namespace TestEventPatternRequest {
   export function isa(o: any): o is TestEventPatternRequest {
-    return _smithy.isa(o, "TestEventPatternRequest");
+    return __isa(o, "TestEventPatternRequest");
   }
 }
 
@@ -2033,7 +2036,7 @@ export interface TestEventPatternResponse extends $MetadataBearer {
 
 export namespace TestEventPatternResponse {
   export function isa(o: any): o is TestEventPatternResponse {
-    return _smithy.isa(o, "TestEventPatternResponse");
+    return __isa(o, "TestEventPatternResponse");
   }
 }
 
@@ -2052,7 +2055,7 @@ export interface UntagResourceRequest {
 
 export namespace UntagResourceRequest {
   export function isa(o: any): o is UntagResourceRequest {
-    return _smithy.isa(o, "UntagResourceRequest");
+    return __isa(o, "UntagResourceRequest");
   }
 }
 
@@ -2062,7 +2065,7 @@ export interface UntagResourceResponse extends $MetadataBearer {
 
 export namespace UntagResourceResponse {
   export function isa(o: any): o is UntagResourceResponse {
-    return _smithy.isa(o, "UntagResourceResponse");
+    return __isa(o, "UntagResourceResponse");
   }
 }
 
@@ -2070,7 +2073,7 @@ export namespace UntagResourceResponse {
  * <p>There is concurrent modification on a resource.</p>
  */
 export interface ConcurrentModificationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ConcurrentModificationException";
   $fault: "client";
@@ -2079,16 +2082,14 @@ export interface ConcurrentModificationException
 
 export namespace ConcurrentModificationException {
   export function isa(o: any): o is ConcurrentModificationException {
-    return _smithy.isa(o, "ConcurrentModificationException");
+    return __isa(o, "ConcurrentModificationException");
   }
 }
 
 /**
  * <p>This exception occurs due to unexpected causes.</p>
  */
-export interface InternalException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface InternalException extends __SmithyException, $MetadataBearer {
   name: "InternalException";
   $fault: "server";
   message?: string;
@@ -2096,7 +2097,7 @@ export interface InternalException
 
 export namespace InternalException {
   export function isa(o: any): o is InternalException {
-    return _smithy.isa(o, "InternalException");
+    return __isa(o, "InternalException");
   }
 }
 
@@ -2104,7 +2105,7 @@ export namespace InternalException {
  * <p>The event pattern isn't valid.</p>
  */
 export interface InvalidEventPatternException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidEventPatternException";
   $fault: "client";
@@ -2113,7 +2114,7 @@ export interface InvalidEventPatternException
 
 export namespace InvalidEventPatternException {
   export function isa(o: any): o is InvalidEventPatternException {
-    return _smithy.isa(o, "InvalidEventPatternException");
+    return __isa(o, "InvalidEventPatternException");
   }
 }
 
@@ -2121,7 +2122,7 @@ export namespace InvalidEventPatternException {
  * <p>The specified state isn't a valid state for an event source.</p>
  */
 export interface InvalidStateException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidStateException";
   $fault: "client";
@@ -2130,7 +2131,7 @@ export interface InvalidStateException
 
 export namespace InvalidStateException {
   export function isa(o: any): o is InvalidStateException {
-    return _smithy.isa(o, "InvalidStateException");
+    return __isa(o, "InvalidStateException");
   }
 }
 
@@ -2138,7 +2139,7 @@ export namespace InvalidStateException {
  * <p>You tried to create more resources than is allowed.</p>
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -2147,7 +2148,7 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
@@ -2161,7 +2162,7 @@ export namespace LimitExceededException {
  *                 <code>UntagResource</code>. </p>
  */
 export interface ManagedRuleException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ManagedRuleException";
   $fault: "client";
@@ -2170,7 +2171,7 @@ export interface ManagedRuleException
 
 export namespace ManagedRuleException {
   export function isa(o: any): o is ManagedRuleException {
-    return _smithy.isa(o, "ManagedRuleException");
+    return __isa(o, "ManagedRuleException");
   }
 }
 
@@ -2178,7 +2179,7 @@ export namespace ManagedRuleException {
  * <p>The event bus policy is too long. For more information, see the limits.</p>
  */
 export interface PolicyLengthExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "PolicyLengthExceededException";
   $fault: "client";
@@ -2187,7 +2188,7 @@ export interface PolicyLengthExceededException
 
 export namespace PolicyLengthExceededException {
   export function isa(o: any): o is PolicyLengthExceededException {
-    return _smithy.isa(o, "PolicyLengthExceededException");
+    return __isa(o, "PolicyLengthExceededException");
   }
 }
 
@@ -2195,7 +2196,7 @@ export namespace PolicyLengthExceededException {
  * <p>The resource that you're trying to create already exists.</p>
  */
 export interface ResourceAlreadyExistsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceAlreadyExistsException";
   $fault: "client";
@@ -2204,7 +2205,7 @@ export interface ResourceAlreadyExistsException
 
 export namespace ResourceAlreadyExistsException {
   export function isa(o: any): o is ResourceAlreadyExistsException {
-    return _smithy.isa(o, "ResourceAlreadyExistsException");
+    return __isa(o, "ResourceAlreadyExistsException");
   }
 }
 
@@ -2212,7 +2213,7 @@ export namespace ResourceAlreadyExistsException {
  * <p>An entity that you specified doesn't exist.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -2221,6 +2222,6 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }

--- a/clients/client-cloudwatch-events/protocols/Aws_json1_1.ts
+++ b/clients/client-cloudwatch-events/protocols/Aws_json1_1.ts
@@ -652,6 +652,7 @@ export async function deserializeAws_json1_1ActivateEventSourceCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: ActivateEventSourceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -894,6 +895,7 @@ export async function deserializeAws_json1_1DeactivateEventSourceCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeactivateEventSourceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -959,6 +961,7 @@ export async function deserializeAws_json1_1DeleteEventBusCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1DeleteEventBusCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteEventBusCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1013,6 +1016,7 @@ export async function deserializeAws_json1_1DeletePartnerEventSourceCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeletePartnerEventSourceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1064,6 +1068,7 @@ export async function deserializeAws_json1_1DeleteRuleCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1DeleteRuleCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteRuleCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1397,6 +1402,7 @@ export async function deserializeAws_json1_1DisableRuleCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1DisableRuleCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DisableRuleCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1469,6 +1475,7 @@ export async function deserializeAws_json1_1EnableRuleCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1EnableRuleCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: EnableRuleCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2154,6 +2161,7 @@ export async function deserializeAws_json1_1PutPermissionCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1PutPermissionCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: PutPermissionCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2401,6 +2409,7 @@ export async function deserializeAws_json1_1RemovePermissionCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1RemovePermissionCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: RemovePermissionCommandOutput = {
     $metadata: deserializeMetadata(output)
   };

--- a/clients/client-cloudwatch-logs/models/index.ts
+++ b/clients/client-cloudwatch-logs/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export interface AssociateKmsKeyRequest {
@@ -17,7 +20,7 @@ export interface AssociateKmsKeyRequest {
 
 export namespace AssociateKmsKeyRequest {
   export function isa(o: any): o is AssociateKmsKeyRequest {
-    return _smithy.isa(o, "AssociateKmsKeyRequest");
+    return __isa(o, "AssociateKmsKeyRequest");
   }
 }
 
@@ -31,7 +34,7 @@ export interface CancelExportTaskRequest {
 
 export namespace CancelExportTaskRequest {
   export function isa(o: any): o is CancelExportTaskRequest {
-    return _smithy.isa(o, "CancelExportTaskRequest");
+    return __isa(o, "CancelExportTaskRequest");
   }
 }
 
@@ -81,7 +84,7 @@ export interface CreateExportTaskRequest {
 
 export namespace CreateExportTaskRequest {
   export function isa(o: any): o is CreateExportTaskRequest {
-    return _smithy.isa(o, "CreateExportTaskRequest");
+    return __isa(o, "CreateExportTaskRequest");
   }
 }
 
@@ -95,7 +98,7 @@ export interface CreateExportTaskResponse extends $MetadataBearer {
 
 export namespace CreateExportTaskResponse {
   export function isa(o: any): o is CreateExportTaskResponse {
-    return _smithy.isa(o, "CreateExportTaskResponse");
+    return __isa(o, "CreateExportTaskResponse");
   }
 }
 
@@ -120,7 +123,7 @@ export interface CreateLogGroupRequest {
 
 export namespace CreateLogGroupRequest {
   export function isa(o: any): o is CreateLogGroupRequest {
-    return _smithy.isa(o, "CreateLogGroupRequest");
+    return __isa(o, "CreateLogGroupRequest");
   }
 }
 
@@ -139,7 +142,7 @@ export interface CreateLogStreamRequest {
 
 export namespace CreateLogStreamRequest {
   export function isa(o: any): o is CreateLogStreamRequest {
-    return _smithy.isa(o, "CreateLogStreamRequest");
+    return __isa(o, "CreateLogStreamRequest");
   }
 }
 
@@ -147,7 +150,7 @@ export namespace CreateLogStreamRequest {
  * <p>The event was already logged.</p>
  */
 export interface DataAlreadyAcceptedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DataAlreadyAcceptedException";
   $fault: "client";
@@ -157,7 +160,7 @@ export interface DataAlreadyAcceptedException
 
 export namespace DataAlreadyAcceptedException {
   export function isa(o: any): o is DataAlreadyAcceptedException {
-    return _smithy.isa(o, "DataAlreadyAcceptedException");
+    return __isa(o, "DataAlreadyAcceptedException");
   }
 }
 
@@ -171,7 +174,7 @@ export interface DeleteDestinationRequest {
 
 export namespace DeleteDestinationRequest {
   export function isa(o: any): o is DeleteDestinationRequest {
-    return _smithy.isa(o, "DeleteDestinationRequest");
+    return __isa(o, "DeleteDestinationRequest");
   }
 }
 
@@ -185,7 +188,7 @@ export interface DeleteLogGroupRequest {
 
 export namespace DeleteLogGroupRequest {
   export function isa(o: any): o is DeleteLogGroupRequest {
-    return _smithy.isa(o, "DeleteLogGroupRequest");
+    return __isa(o, "DeleteLogGroupRequest");
   }
 }
 
@@ -204,7 +207,7 @@ export interface DeleteLogStreamRequest {
 
 export namespace DeleteLogStreamRequest {
   export function isa(o: any): o is DeleteLogStreamRequest {
-    return _smithy.isa(o, "DeleteLogStreamRequest");
+    return __isa(o, "DeleteLogStreamRequest");
   }
 }
 
@@ -223,7 +226,7 @@ export interface DeleteMetricFilterRequest {
 
 export namespace DeleteMetricFilterRequest {
   export function isa(o: any): o is DeleteMetricFilterRequest {
-    return _smithy.isa(o, "DeleteMetricFilterRequest");
+    return __isa(o, "DeleteMetricFilterRequest");
   }
 }
 
@@ -237,7 +240,7 @@ export interface DeleteResourcePolicyRequest {
 
 export namespace DeleteResourcePolicyRequest {
   export function isa(o: any): o is DeleteResourcePolicyRequest {
-    return _smithy.isa(o, "DeleteResourcePolicyRequest");
+    return __isa(o, "DeleteResourcePolicyRequest");
   }
 }
 
@@ -251,7 +254,7 @@ export interface DeleteRetentionPolicyRequest {
 
 export namespace DeleteRetentionPolicyRequest {
   export function isa(o: any): o is DeleteRetentionPolicyRequest {
-    return _smithy.isa(o, "DeleteRetentionPolicyRequest");
+    return __isa(o, "DeleteRetentionPolicyRequest");
   }
 }
 
@@ -270,7 +273,7 @@ export interface DeleteSubscriptionFilterRequest {
 
 export namespace DeleteSubscriptionFilterRequest {
   export function isa(o: any): o is DeleteSubscriptionFilterRequest {
-    return _smithy.isa(o, "DeleteSubscriptionFilterRequest");
+    return __isa(o, "DeleteSubscriptionFilterRequest");
   }
 }
 
@@ -294,7 +297,7 @@ export interface DescribeDestinationsRequest {
 
 export namespace DescribeDestinationsRequest {
   export function isa(o: any): o is DescribeDestinationsRequest {
-    return _smithy.isa(o, "DescribeDestinationsRequest");
+    return __isa(o, "DescribeDestinationsRequest");
   }
 }
 
@@ -313,7 +316,7 @@ export interface DescribeDestinationsResponse extends $MetadataBearer {
 
 export namespace DescribeDestinationsResponse {
   export function isa(o: any): o is DescribeDestinationsResponse {
-    return _smithy.isa(o, "DescribeDestinationsResponse");
+    return __isa(o, "DescribeDestinationsResponse");
   }
 }
 
@@ -342,7 +345,7 @@ export interface DescribeExportTasksRequest {
 
 export namespace DescribeExportTasksRequest {
   export function isa(o: any): o is DescribeExportTasksRequest {
-    return _smithy.isa(o, "DescribeExportTasksRequest");
+    return __isa(o, "DescribeExportTasksRequest");
   }
 }
 
@@ -361,7 +364,7 @@ export interface DescribeExportTasksResponse extends $MetadataBearer {
 
 export namespace DescribeExportTasksResponse {
   export function isa(o: any): o is DescribeExportTasksResponse {
-    return _smithy.isa(o, "DescribeExportTasksResponse");
+    return __isa(o, "DescribeExportTasksResponse");
   }
 }
 
@@ -385,7 +388,7 @@ export interface DescribeLogGroupsRequest {
 
 export namespace DescribeLogGroupsRequest {
   export function isa(o: any): o is DescribeLogGroupsRequest {
-    return _smithy.isa(o, "DescribeLogGroupsRequest");
+    return __isa(o, "DescribeLogGroupsRequest");
   }
 }
 
@@ -404,7 +407,7 @@ export interface DescribeLogGroupsResponse extends $MetadataBearer {
 
 export namespace DescribeLogGroupsResponse {
   export function isa(o: any): o is DescribeLogGroupsResponse {
-    return _smithy.isa(o, "DescribeLogGroupsResponse");
+    return __isa(o, "DescribeLogGroupsResponse");
   }
 }
 
@@ -455,7 +458,7 @@ export interface DescribeLogStreamsRequest {
 
 export namespace DescribeLogStreamsRequest {
   export function isa(o: any): o is DescribeLogStreamsRequest {
-    return _smithy.isa(o, "DescribeLogStreamsRequest");
+    return __isa(o, "DescribeLogStreamsRequest");
   }
 }
 
@@ -474,7 +477,7 @@ export interface DescribeLogStreamsResponse extends $MetadataBearer {
 
 export namespace DescribeLogStreamsResponse {
   export function isa(o: any): o is DescribeLogStreamsResponse {
-    return _smithy.isa(o, "DescribeLogStreamsResponse");
+    return __isa(o, "DescribeLogStreamsResponse");
   }
 }
 
@@ -515,7 +518,7 @@ export interface DescribeMetricFiltersRequest {
 
 export namespace DescribeMetricFiltersRequest {
   export function isa(o: any): o is DescribeMetricFiltersRequest {
-    return _smithy.isa(o, "DescribeMetricFiltersRequest");
+    return __isa(o, "DescribeMetricFiltersRequest");
   }
 }
 
@@ -534,7 +537,7 @@ export interface DescribeMetricFiltersResponse extends $MetadataBearer {
 
 export namespace DescribeMetricFiltersResponse {
   export function isa(o: any): o is DescribeMetricFiltersResponse {
-    return _smithy.isa(o, "DescribeMetricFiltersResponse");
+    return __isa(o, "DescribeMetricFiltersResponse");
   }
 }
 
@@ -564,7 +567,7 @@ export interface DescribeQueriesRequest {
 
 export namespace DescribeQueriesRequest {
   export function isa(o: any): o is DescribeQueriesRequest {
-    return _smithy.isa(o, "DescribeQueriesRequest");
+    return __isa(o, "DescribeQueriesRequest");
   }
 }
 
@@ -583,7 +586,7 @@ export interface DescribeQueriesResponse extends $MetadataBearer {
 
 export namespace DescribeQueriesResponse {
   export function isa(o: any): o is DescribeQueriesResponse {
-    return _smithy.isa(o, "DescribeQueriesResponse");
+    return __isa(o, "DescribeQueriesResponse");
   }
 }
 
@@ -602,7 +605,7 @@ export interface DescribeResourcePoliciesRequest {
 
 export namespace DescribeResourcePoliciesRequest {
   export function isa(o: any): o is DescribeResourcePoliciesRequest {
-    return _smithy.isa(o, "DescribeResourcePoliciesRequest");
+    return __isa(o, "DescribeResourcePoliciesRequest");
   }
 }
 
@@ -621,7 +624,7 @@ export interface DescribeResourcePoliciesResponse extends $MetadataBearer {
 
 export namespace DescribeResourcePoliciesResponse {
   export function isa(o: any): o is DescribeResourcePoliciesResponse {
-    return _smithy.isa(o, "DescribeResourcePoliciesResponse");
+    return __isa(o, "DescribeResourcePoliciesResponse");
   }
 }
 
@@ -650,7 +653,7 @@ export interface DescribeSubscriptionFiltersRequest {
 
 export namespace DescribeSubscriptionFiltersRequest {
   export function isa(o: any): o is DescribeSubscriptionFiltersRequest {
-    return _smithy.isa(o, "DescribeSubscriptionFiltersRequest");
+    return __isa(o, "DescribeSubscriptionFiltersRequest");
   }
 }
 
@@ -669,7 +672,7 @@ export interface DescribeSubscriptionFiltersResponse extends $MetadataBearer {
 
 export namespace DescribeSubscriptionFiltersResponse {
   export function isa(o: any): o is DescribeSubscriptionFiltersResponse {
-    return _smithy.isa(o, "DescribeSubscriptionFiltersResponse");
+    return __isa(o, "DescribeSubscriptionFiltersResponse");
   }
 }
 
@@ -714,7 +717,7 @@ export interface Destination {
 
 export namespace Destination {
   export function isa(o: any): o is Destination {
-    return _smithy.isa(o, "Destination");
+    return __isa(o, "Destination");
   }
 }
 
@@ -728,7 +731,7 @@ export interface DisassociateKmsKeyRequest {
 
 export namespace DisassociateKmsKeyRequest {
   export function isa(o: any): o is DisassociateKmsKeyRequest {
-    return _smithy.isa(o, "DisassociateKmsKeyRequest");
+    return __isa(o, "DisassociateKmsKeyRequest");
   }
 }
 
@@ -792,7 +795,7 @@ export interface ExportTask {
 
 export namespace ExportTask {
   export function isa(o: any): o is ExportTask {
-    return _smithy.isa(o, "ExportTask");
+    return __isa(o, "ExportTask");
   }
 }
 
@@ -816,7 +819,7 @@ export interface ExportTaskExecutionInfo {
 
 export namespace ExportTaskExecutionInfo {
   export function isa(o: any): o is ExportTaskExecutionInfo {
-    return _smithy.isa(o, "ExportTaskExecutionInfo");
+    return __isa(o, "ExportTaskExecutionInfo");
   }
 }
 
@@ -838,7 +841,7 @@ export interface ExportTaskStatus {
 
 export namespace ExportTaskStatus {
   export function isa(o: any): o is ExportTaskStatus {
-    return _smithy.isa(o, "ExportTaskStatus");
+    return __isa(o, "ExportTaskStatus");
   }
 }
 
@@ -916,7 +919,7 @@ export interface FilterLogEventsRequest {
 
 export namespace FilterLogEventsRequest {
   export function isa(o: any): o is FilterLogEventsRequest {
-    return _smithy.isa(o, "FilterLogEventsRequest");
+    return __isa(o, "FilterLogEventsRequest");
   }
 }
 
@@ -940,7 +943,7 @@ export interface FilterLogEventsResponse extends $MetadataBearer {
 
 export namespace FilterLogEventsResponse {
   export function isa(o: any): o is FilterLogEventsResponse {
-    return _smithy.isa(o, "FilterLogEventsResponse");
+    return __isa(o, "FilterLogEventsResponse");
   }
 }
 
@@ -979,7 +982,7 @@ export interface FilteredLogEvent {
 
 export namespace FilteredLogEvent {
   export function isa(o: any): o is FilteredLogEvent {
-    return _smithy.isa(o, "FilteredLogEvent");
+    return __isa(o, "FilteredLogEvent");
   }
 }
 
@@ -1032,7 +1035,7 @@ export interface GetLogEventsRequest {
 
 export namespace GetLogEventsRequest {
   export function isa(o: any): o is GetLogEventsRequest {
-    return _smithy.isa(o, "GetLogEventsRequest");
+    return __isa(o, "GetLogEventsRequest");
   }
 }
 
@@ -1058,7 +1061,7 @@ export interface GetLogEventsResponse extends $MetadataBearer {
 
 export namespace GetLogEventsResponse {
   export function isa(o: any): o is GetLogEventsResponse {
-    return _smithy.isa(o, "GetLogEventsResponse");
+    return __isa(o, "GetLogEventsResponse");
   }
 }
 
@@ -1081,7 +1084,7 @@ export interface GetLogGroupFieldsRequest {
 
 export namespace GetLogGroupFieldsRequest {
   export function isa(o: any): o is GetLogGroupFieldsRequest {
-    return _smithy.isa(o, "GetLogGroupFieldsRequest");
+    return __isa(o, "GetLogGroupFieldsRequest");
   }
 }
 
@@ -1096,7 +1099,7 @@ export interface GetLogGroupFieldsResponse extends $MetadataBearer {
 
 export namespace GetLogGroupFieldsResponse {
   export function isa(o: any): o is GetLogGroupFieldsResponse {
-    return _smithy.isa(o, "GetLogGroupFieldsResponse");
+    return __isa(o, "GetLogGroupFieldsResponse");
   }
 }
 
@@ -1113,7 +1116,7 @@ export interface GetLogRecordRequest {
 
 export namespace GetLogRecordRequest {
   export function isa(o: any): o is GetLogRecordRequest {
-    return _smithy.isa(o, "GetLogRecordRequest");
+    return __isa(o, "GetLogRecordRequest");
   }
 }
 
@@ -1127,7 +1130,7 @@ export interface GetLogRecordResponse extends $MetadataBearer {
 
 export namespace GetLogRecordResponse {
   export function isa(o: any): o is GetLogRecordResponse {
-    return _smithy.isa(o, "GetLogRecordResponse");
+    return __isa(o, "GetLogRecordResponse");
   }
 }
 
@@ -1141,7 +1144,7 @@ export interface GetQueryResultsRequest {
 
 export namespace GetQueryResultsRequest {
   export function isa(o: any): o is GetQueryResultsRequest {
-    return _smithy.isa(o, "GetQueryResultsRequest");
+    return __isa(o, "GetQueryResultsRequest");
   }
 }
 
@@ -1174,7 +1177,7 @@ export interface GetQueryResultsResponse extends $MetadataBearer {
 
 export namespace GetQueryResultsResponse {
   export function isa(o: any): o is GetQueryResultsResponse {
-    return _smithy.isa(o, "GetQueryResultsResponse");
+    return __isa(o, "GetQueryResultsResponse");
   }
 }
 
@@ -1198,7 +1201,7 @@ export interface InputLogEvent {
 
 export namespace InputLogEvent {
   export function isa(o: any): o is InputLogEvent {
-    return _smithy.isa(o, "InputLogEvent");
+    return __isa(o, "InputLogEvent");
   }
 }
 
@@ -1206,7 +1209,7 @@ export namespace InputLogEvent {
  * <p>The operation is not valid on the specified resource.</p>
  */
 export interface InvalidOperationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidOperationException";
   $fault: "client";
@@ -1215,7 +1218,7 @@ export interface InvalidOperationException
 
 export namespace InvalidOperationException {
   export function isa(o: any): o is InvalidOperationException {
-    return _smithy.isa(o, "InvalidOperationException");
+    return __isa(o, "InvalidOperationException");
   }
 }
 
@@ -1223,7 +1226,7 @@ export namespace InvalidOperationException {
  * <p>A parameter is specified incorrectly.</p>
  */
 export interface InvalidParameterException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidParameterException";
   $fault: "client";
@@ -1232,7 +1235,7 @@ export interface InvalidParameterException
 
 export namespace InvalidParameterException {
   export function isa(o: any): o is InvalidParameterException {
-    return _smithy.isa(o, "InvalidParameterException");
+    return __isa(o, "InvalidParameterException");
   }
 }
 
@@ -1242,7 +1245,7 @@ export namespace InvalidParameterException {
  *     message. </p>
  */
 export interface InvalidSequenceTokenException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidSequenceTokenException";
   $fault: "client";
@@ -1252,7 +1255,7 @@ export interface InvalidSequenceTokenException
 
 export namespace InvalidSequenceTokenException {
   export function isa(o: any): o is InvalidSequenceTokenException {
-    return _smithy.isa(o, "InvalidSequenceTokenException");
+    return __isa(o, "InvalidSequenceTokenException");
   }
 }
 
@@ -1260,7 +1263,7 @@ export namespace InvalidSequenceTokenException {
  * <p>You have reached the maximum number of resources that can be created.</p>
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -1269,7 +1272,7 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
@@ -1283,7 +1286,7 @@ export interface ListTagsLogGroupRequest {
 
 export namespace ListTagsLogGroupRequest {
   export function isa(o: any): o is ListTagsLogGroupRequest {
-    return _smithy.isa(o, "ListTagsLogGroupRequest");
+    return __isa(o, "ListTagsLogGroupRequest");
   }
 }
 
@@ -1297,7 +1300,7 @@ export interface ListTagsLogGroupResponse extends $MetadataBearer {
 
 export namespace ListTagsLogGroupResponse {
   export function isa(o: any): o is ListTagsLogGroupResponse {
-    return _smithy.isa(o, "ListTagsLogGroupResponse");
+    return __isa(o, "ListTagsLogGroupResponse");
   }
 }
 
@@ -1346,7 +1349,7 @@ export interface LogGroup {
 
 export namespace LogGroup {
   export function isa(o: any): o is LogGroup {
-    return _smithy.isa(o, "LogGroup");
+    return __isa(o, "LogGroup");
   }
 }
 
@@ -1369,7 +1372,7 @@ export interface LogGroupField {
 
 export namespace LogGroupField {
   export function isa(o: any): o is LogGroupField {
-    return _smithy.isa(o, "LogGroupField");
+    return __isa(o, "LogGroupField");
   }
 }
 
@@ -1433,7 +1436,7 @@ export interface LogStream {
 
 export namespace LogStream {
   export function isa(o: any): o is LogStream {
-    return _smithy.isa(o, "LogStream");
+    return __isa(o, "LogStream");
   }
 }
 
@@ -1445,7 +1448,7 @@ export namespace LogStream {
  *       <a href="https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/CWL_QuerySyntax.html">CloudWatch Logs Insights Query Syntax</a>.</p>
  */
 export interface MalformedQueryException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "MalformedQueryException";
   $fault: "client";
@@ -1458,7 +1461,7 @@ export interface MalformedQueryException
 
 export namespace MalformedQueryException {
   export function isa(o: any): o is MalformedQueryException {
-    return _smithy.isa(o, "MalformedQueryException");
+    return __isa(o, "MalformedQueryException");
   }
 }
 
@@ -1499,7 +1502,7 @@ export interface MetricFilter {
 
 export namespace MetricFilter {
   export function isa(o: any): o is MetricFilter {
-    return _smithy.isa(o, "MetricFilter");
+    return __isa(o, "MetricFilter");
   }
 }
 
@@ -1526,7 +1529,7 @@ export interface MetricFilterMatchRecord {
 
 export namespace MetricFilterMatchRecord {
   export function isa(o: any): o is MetricFilterMatchRecord {
-    return _smithy.isa(o, "MetricFilterMatchRecord");
+    return __isa(o, "MetricFilterMatchRecord");
   }
 }
 
@@ -1560,7 +1563,7 @@ export interface MetricTransformation {
 
 export namespace MetricTransformation {
   export function isa(o: any): o is MetricTransformation {
-    return _smithy.isa(o, "MetricTransformation");
+    return __isa(o, "MetricTransformation");
   }
 }
 
@@ -1568,7 +1571,7 @@ export namespace MetricTransformation {
  * <p>Multiple requests to update the same resource were in conflict.</p>
  */
 export interface OperationAbortedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "OperationAbortedException";
   $fault: "client";
@@ -1577,7 +1580,7 @@ export interface OperationAbortedException
 
 export namespace OperationAbortedException {
   export function isa(o: any): o is OperationAbortedException {
-    return _smithy.isa(o, "OperationAbortedException");
+    return __isa(o, "OperationAbortedException");
   }
 }
 
@@ -1611,7 +1614,7 @@ export interface OutputLogEvent {
 
 export namespace OutputLogEvent {
   export function isa(o: any): o is OutputLogEvent {
-    return _smithy.isa(o, "OutputLogEvent");
+    return __isa(o, "OutputLogEvent");
   }
 }
 
@@ -1631,7 +1634,7 @@ export interface PutDestinationPolicyRequest {
 
 export namespace PutDestinationPolicyRequest {
   export function isa(o: any): o is PutDestinationPolicyRequest {
-    return _smithy.isa(o, "PutDestinationPolicyRequest");
+    return __isa(o, "PutDestinationPolicyRequest");
   }
 }
 
@@ -1656,7 +1659,7 @@ export interface PutDestinationRequest {
 
 export namespace PutDestinationRequest {
   export function isa(o: any): o is PutDestinationRequest {
-    return _smithy.isa(o, "PutDestinationRequest");
+    return __isa(o, "PutDestinationRequest");
   }
 }
 
@@ -1670,7 +1673,7 @@ export interface PutDestinationResponse extends $MetadataBearer {
 
 export namespace PutDestinationResponse {
   export function isa(o: any): o is PutDestinationResponse {
-    return _smithy.isa(o, "PutDestinationResponse");
+    return __isa(o, "PutDestinationResponse");
   }
 }
 
@@ -1703,7 +1706,7 @@ export interface PutLogEventsRequest {
 
 export namespace PutLogEventsRequest {
   export function isa(o: any): o is PutLogEventsRequest {
-    return _smithy.isa(o, "PutLogEventsRequest");
+    return __isa(o, "PutLogEventsRequest");
   }
 }
 
@@ -1722,7 +1725,7 @@ export interface PutLogEventsResponse extends $MetadataBearer {
 
 export namespace PutLogEventsResponse {
   export function isa(o: any): o is PutLogEventsResponse {
-    return _smithy.isa(o, "PutLogEventsResponse");
+    return __isa(o, "PutLogEventsResponse");
   }
 }
 
@@ -1751,7 +1754,7 @@ export interface PutMetricFilterRequest {
 
 export namespace PutMetricFilterRequest {
   export function isa(o: any): o is PutMetricFilterRequest {
-    return _smithy.isa(o, "PutMetricFilterRequest");
+    return __isa(o, "PutMetricFilterRequest");
   }
 }
 
@@ -1792,7 +1795,7 @@ export interface PutResourcePolicyRequest {
 
 export namespace PutResourcePolicyRequest {
   export function isa(o: any): o is PutResourcePolicyRequest {
-    return _smithy.isa(o, "PutResourcePolicyRequest");
+    return __isa(o, "PutResourcePolicyRequest");
   }
 }
 
@@ -1806,7 +1809,7 @@ export interface PutResourcePolicyResponse extends $MetadataBearer {
 
 export namespace PutResourcePolicyResponse {
   export function isa(o: any): o is PutResourcePolicyResponse {
-    return _smithy.isa(o, "PutResourcePolicyResponse");
+    return __isa(o, "PutResourcePolicyResponse");
   }
 }
 
@@ -1826,7 +1829,7 @@ export interface PutRetentionPolicyRequest {
 
 export namespace PutRetentionPolicyRequest {
   export function isa(o: any): o is PutRetentionPolicyRequest {
-    return _smithy.isa(o, "PutRetentionPolicyRequest");
+    return __isa(o, "PutRetentionPolicyRequest");
   }
 }
 
@@ -1892,7 +1895,7 @@ export interface PutSubscriptionFilterRequest {
 
 export namespace PutSubscriptionFilterRequest {
   export function isa(o: any): o is PutSubscriptionFilterRequest {
-    return _smithy.isa(o, "PutSubscriptionFilterRequest");
+    return __isa(o, "PutSubscriptionFilterRequest");
   }
 }
 
@@ -1914,7 +1917,7 @@ export interface QueryCompileError {
 
 export namespace QueryCompileError {
   export function isa(o: any): o is QueryCompileError {
-    return _smithy.isa(o, "QueryCompileError");
+    return __isa(o, "QueryCompileError");
   }
 }
 
@@ -1936,7 +1939,7 @@ export interface QueryCompileErrorLocation {
 
 export namespace QueryCompileErrorLocation {
   export function isa(o: any): o is QueryCompileErrorLocation {
-    return _smithy.isa(o, "QueryCompileErrorLocation");
+    return __isa(o, "QueryCompileErrorLocation");
   }
 }
 
@@ -1974,7 +1977,7 @@ export interface QueryInfo {
 
 export namespace QueryInfo {
   export function isa(o: any): o is QueryInfo {
-    return _smithy.isa(o, "QueryInfo");
+    return __isa(o, "QueryInfo");
   }
 }
 
@@ -2002,7 +2005,7 @@ export interface QueryStatistics {
 
 export namespace QueryStatistics {
   export function isa(o: any): o is QueryStatistics {
-    return _smithy.isa(o, "QueryStatistics");
+    return __isa(o, "QueryStatistics");
   }
 }
 
@@ -2037,7 +2040,7 @@ export interface RejectedLogEventsInfo {
 
 export namespace RejectedLogEventsInfo {
   export function isa(o: any): o is RejectedLogEventsInfo {
-    return _smithy.isa(o, "RejectedLogEventsInfo");
+    return __isa(o, "RejectedLogEventsInfo");
   }
 }
 
@@ -2045,7 +2048,7 @@ export namespace RejectedLogEventsInfo {
  * <p>The specified resource already exists.</p>
  */
 export interface ResourceAlreadyExistsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceAlreadyExistsException";
   $fault: "client";
@@ -2054,7 +2057,7 @@ export interface ResourceAlreadyExistsException
 
 export namespace ResourceAlreadyExistsException {
   export function isa(o: any): o is ResourceAlreadyExistsException {
-    return _smithy.isa(o, "ResourceAlreadyExistsException");
+    return __isa(o, "ResourceAlreadyExistsException");
   }
 }
 
@@ -2062,7 +2065,7 @@ export namespace ResourceAlreadyExistsException {
  * <p>The specified resource does not exist.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -2071,7 +2074,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -2099,7 +2102,7 @@ export interface ResourcePolicy {
 
 export namespace ResourcePolicy {
   export function isa(o: any): o is ResourcePolicy {
-    return _smithy.isa(o, "ResourcePolicy");
+    return __isa(o, "ResourcePolicy");
   }
 }
 
@@ -2121,7 +2124,7 @@ export interface ResultField {
 
 export namespace ResultField {
   export function isa(o: any): o is ResultField {
-    return _smithy.isa(o, "ResultField");
+    return __isa(o, "ResultField");
   }
 }
 
@@ -2143,7 +2146,7 @@ export interface SearchedLogStream {
 
 export namespace SearchedLogStream {
   export function isa(o: any): o is SearchedLogStream {
-    return _smithy.isa(o, "SearchedLogStream");
+    return __isa(o, "SearchedLogStream");
   }
 }
 
@@ -2151,7 +2154,7 @@ export namespace SearchedLogStream {
  * <p>The service cannot complete the request.</p>
  */
 export interface ServiceUnavailableException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ServiceUnavailableException";
   $fault: "server";
@@ -2160,7 +2163,7 @@ export interface ServiceUnavailableException
 
 export namespace ServiceUnavailableException {
   export function isa(o: any): o is ServiceUnavailableException {
-    return _smithy.isa(o, "ServiceUnavailableException");
+    return __isa(o, "ServiceUnavailableException");
   }
 }
 
@@ -2209,7 +2212,7 @@ export interface StartQueryRequest {
 
 export namespace StartQueryRequest {
   export function isa(o: any): o is StartQueryRequest {
-    return _smithy.isa(o, "StartQueryRequest");
+    return __isa(o, "StartQueryRequest");
   }
 }
 
@@ -2223,7 +2226,7 @@ export interface StartQueryResponse extends $MetadataBearer {
 
 export namespace StartQueryResponse {
   export function isa(o: any): o is StartQueryResponse {
-    return _smithy.isa(o, "StartQueryResponse");
+    return __isa(o, "StartQueryResponse");
   }
 }
 
@@ -2238,7 +2241,7 @@ export interface StopQueryRequest {
 
 export namespace StopQueryRequest {
   export function isa(o: any): o is StopQueryRequest {
-    return _smithy.isa(o, "StopQueryRequest");
+    return __isa(o, "StopQueryRequest");
   }
 }
 
@@ -2252,7 +2255,7 @@ export interface StopQueryResponse extends $MetadataBearer {
 
 export namespace StopQueryResponse {
   export function isa(o: any): o is StopQueryResponse {
-    return _smithy.isa(o, "StopQueryResponse");
+    return __isa(o, "StopQueryResponse");
   }
 }
 
@@ -2303,7 +2306,7 @@ export interface SubscriptionFilter {
 
 export namespace SubscriptionFilter {
   export function isa(o: any): o is SubscriptionFilter {
-    return _smithy.isa(o, "SubscriptionFilter");
+    return __isa(o, "SubscriptionFilter");
   }
 }
 
@@ -2322,7 +2325,7 @@ export interface TagLogGroupRequest {
 
 export namespace TagLogGroupRequest {
   export function isa(o: any): o is TagLogGroupRequest {
-    return _smithy.isa(o, "TagLogGroupRequest");
+    return __isa(o, "TagLogGroupRequest");
   }
 }
 
@@ -2343,7 +2346,7 @@ export interface TestMetricFilterRequest {
 
 export namespace TestMetricFilterRequest {
   export function isa(o: any): o is TestMetricFilterRequest {
-    return _smithy.isa(o, "TestMetricFilterRequest");
+    return __isa(o, "TestMetricFilterRequest");
   }
 }
 
@@ -2357,7 +2360,7 @@ export interface TestMetricFilterResponse extends $MetadataBearer {
 
 export namespace TestMetricFilterResponse {
   export function isa(o: any): o is TestMetricFilterResponse {
-    return _smithy.isa(o, "TestMetricFilterResponse");
+    return __isa(o, "TestMetricFilterResponse");
   }
 }
 
@@ -2365,7 +2368,7 @@ export namespace TestMetricFilterResponse {
  * <p>The most likely cause is an invalid AWS access key ID or secret key.</p>
  */
 export interface UnrecognizedClientException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UnrecognizedClientException";
   $fault: "client";
@@ -2374,7 +2377,7 @@ export interface UnrecognizedClientException
 
 export namespace UnrecognizedClientException {
   export function isa(o: any): o is UnrecognizedClientException {
-    return _smithy.isa(o, "UnrecognizedClientException");
+    return __isa(o, "UnrecognizedClientException");
   }
 }
 
@@ -2393,6 +2396,6 @@ export interface UntagLogGroupRequest {
 
 export namespace UntagLogGroupRequest {
   export function isa(o: any): o is UntagLogGroupRequest {
-    return _smithy.isa(o, "UntagLogGroupRequest");
+    return __isa(o, "UntagLogGroupRequest");
   }
 }

--- a/clients/client-cloudwatch-logs/protocols/Aws_json1_1.ts
+++ b/clients/client-cloudwatch-logs/protocols/Aws_json1_1.ts
@@ -809,6 +809,7 @@ export async function deserializeAws_json1_1AssociateKmsKeyCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1AssociateKmsKeyCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: AssociateKmsKeyCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -881,6 +882,7 @@ export async function deserializeAws_json1_1CancelExportTaskCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1CancelExportTaskCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: CancelExportTaskCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1044,6 +1046,7 @@ export async function deserializeAws_json1_1CreateLogGroupCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1CreateLogGroupCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: CreateLogGroupCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1123,6 +1126,7 @@ export async function deserializeAws_json1_1CreateLogStreamCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1CreateLogStreamCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: CreateLogStreamCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1195,6 +1199,7 @@ export async function deserializeAws_json1_1DeleteDestinationCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1DeleteDestinationCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteDestinationCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1267,6 +1272,7 @@ export async function deserializeAws_json1_1DeleteLogGroupCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1DeleteLogGroupCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteLogGroupCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1339,6 +1345,7 @@ export async function deserializeAws_json1_1DeleteLogStreamCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1DeleteLogStreamCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteLogStreamCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1414,6 +1421,7 @@ export async function deserializeAws_json1_1DeleteMetricFilterCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteMetricFilterCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1489,6 +1497,7 @@ export async function deserializeAws_json1_1DeleteResourcePolicyCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteResourcePolicyCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1557,6 +1566,7 @@ export async function deserializeAws_json1_1DeleteRetentionPolicyCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteRetentionPolicyCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1632,6 +1642,7 @@ export async function deserializeAws_json1_1DeleteSubscriptionFilterCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteSubscriptionFilterCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2263,6 +2274,7 @@ export async function deserializeAws_json1_1DisassociateKmsKeyCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DisassociateKmsKeyCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2835,6 +2847,7 @@ export async function deserializeAws_json1_1PutDestinationPolicyCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: PutDestinationPolicyCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2991,6 +3004,7 @@ export async function deserializeAws_json1_1PutMetricFilterCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1PutMetricFilterCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: PutMetricFilterCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -3143,6 +3157,7 @@ export async function deserializeAws_json1_1PutRetentionPolicyCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: PutRetentionPolicyCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -3218,6 +3233,7 @@ export async function deserializeAws_json1_1PutSubscriptionFilterCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: PutSubscriptionFilterCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -3451,6 +3467,7 @@ export async function deserializeAws_json1_1TagLogGroupCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1TagLogGroupCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: TagLogGroupCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -3572,6 +3589,7 @@ export async function deserializeAws_json1_1UntagLogGroupCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1UntagLogGroupCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: UntagLogGroupCommandOutput = {
     $metadata: deserializeMetadata(output)
   };

--- a/clients/client-cloudwatch/models/index.ts
+++ b/clients/client-cloudwatch/models/index.ts
@@ -1,11 +1,14 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
  * <p>Parameters were used together that cannot be used together.</p>
  */
 export interface InvalidParameterCombinationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidParameterCombinationException";
   $fault: "client";
@@ -17,7 +20,7 @@ export interface InvalidParameterCombinationException
 
 export namespace InvalidParameterCombinationException {
   export function isa(o: any): o is InvalidParameterCombinationException {
-    return _smithy.isa(o, "InvalidParameterCombinationException");
+    return __isa(o, "InvalidParameterCombinationException");
   }
 }
 
@@ -25,7 +28,7 @@ export namespace InvalidParameterCombinationException {
  * <p>The value of an input parameter is bad or out-of-range.</p>
  */
 export interface InvalidParameterValueException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidParameterValueException";
   $fault: "client";
@@ -37,7 +40,7 @@ export interface InvalidParameterValueException
 
 export namespace InvalidParameterValueException {
   export function isa(o: any): o is InvalidParameterValueException {
-    return _smithy.isa(o, "InvalidParameterValueException");
+    return __isa(o, "InvalidParameterValueException");
   }
 }
 
@@ -45,7 +48,7 @@ export namespace InvalidParameterValueException {
  * <p>An input parameter that is required is missing.</p>
  */
 export interface MissingRequiredParameterException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "MissingRequiredParameterException";
   $fault: "client";
@@ -57,7 +60,7 @@ export interface MissingRequiredParameterException
 
 export namespace MissingRequiredParameterException {
   export function isa(o: any): o is MissingRequiredParameterException {
-    return _smithy.isa(o, "MissingRequiredParameterException");
+    return __isa(o, "MissingRequiredParameterException");
   }
 }
 
@@ -94,7 +97,7 @@ export interface AlarmHistoryItem {
 
 export namespace AlarmHistoryItem {
   export function isa(o: any): o is AlarmHistoryItem {
-    return _smithy.isa(o, "AlarmHistoryItem");
+    return __isa(o, "AlarmHistoryItem");
   }
 }
 
@@ -142,7 +145,7 @@ export interface AnomalyDetector {
 
 export namespace AnomalyDetector {
   export function isa(o: any): o is AnomalyDetector {
-    return _smithy.isa(o, "AnomalyDetector");
+    return __isa(o, "AnomalyDetector");
   }
 }
 
@@ -172,7 +175,7 @@ export interface AnomalyDetectorConfiguration {
 
 export namespace AnomalyDetectorConfiguration {
   export function isa(o: any): o is AnomalyDetectorConfiguration {
-    return _smithy.isa(o, "AnomalyDetectorConfiguration");
+    return __isa(o, "AnomalyDetectorConfiguration");
   }
 }
 
@@ -194,7 +197,7 @@ export type ComparisonOperator =
  * <p>More than one process tried to modify a resource at the same time.</p>
  */
 export interface ConcurrentModificationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ConcurrentModificationException";
   $fault: "client";
@@ -203,7 +206,7 @@ export interface ConcurrentModificationException
 
 export namespace ConcurrentModificationException {
   export function isa(o: any): o is ConcurrentModificationException {
-    return _smithy.isa(o, "ConcurrentModificationException");
+    return __isa(o, "ConcurrentModificationException");
   }
 }
 
@@ -236,7 +239,7 @@ export interface DashboardEntry {
 
 export namespace DashboardEntry {
   export function isa(o: any): o is DashboardEntry {
-    return _smithy.isa(o, "DashboardEntry");
+    return __isa(o, "DashboardEntry");
   }
 }
 
@@ -244,7 +247,7 @@ export namespace DashboardEntry {
  * <p>Some part of the dashboard data is invalid.</p>
  */
 export interface DashboardInvalidInputError
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DashboardInvalidInputError";
   $fault: "client";
@@ -254,7 +257,7 @@ export interface DashboardInvalidInputError
 
 export namespace DashboardInvalidInputError {
   export function isa(o: any): o is DashboardInvalidInputError {
-    return _smithy.isa(o, "DashboardInvalidInputError");
+    return __isa(o, "DashboardInvalidInputError");
   }
 }
 
@@ -262,7 +265,7 @@ export namespace DashboardInvalidInputError {
  * <p>The specified dashboard does not exist.</p>
  */
 export interface DashboardNotFoundError
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DashboardNotFoundError";
   $fault: "client";
@@ -271,7 +274,7 @@ export interface DashboardNotFoundError
 
 export namespace DashboardNotFoundError {
   export function isa(o: any): o is DashboardNotFoundError {
-    return _smithy.isa(o, "DashboardNotFoundError");
+    return __isa(o, "DashboardNotFoundError");
   }
 }
 
@@ -293,7 +296,7 @@ export interface DashboardValidationMessage {
 
 export namespace DashboardValidationMessage {
   export function isa(o: any): o is DashboardValidationMessage {
-    return _smithy.isa(o, "DashboardValidationMessage");
+    return __isa(o, "DashboardValidationMessage");
   }
 }
 
@@ -346,7 +349,7 @@ export interface Datapoint {
 
 export namespace Datapoint {
   export function isa(o: any): o is Datapoint {
-    return _smithy.isa(o, "Datapoint");
+    return __isa(o, "Datapoint");
   }
 }
 
@@ -360,7 +363,7 @@ export interface DeleteAlarmsInput {
 
 export namespace DeleteAlarmsInput {
   export function isa(o: any): o is DeleteAlarmsInput {
-    return _smithy.isa(o, "DeleteAlarmsInput");
+    return __isa(o, "DeleteAlarmsInput");
   }
 }
 
@@ -389,7 +392,7 @@ export interface DeleteAnomalyDetectorInput {
 
 export namespace DeleteAnomalyDetectorInput {
   export function isa(o: any): o is DeleteAnomalyDetectorInput {
-    return _smithy.isa(o, "DeleteAnomalyDetectorInput");
+    return __isa(o, "DeleteAnomalyDetectorInput");
   }
 }
 
@@ -399,7 +402,7 @@ export interface DeleteAnomalyDetectorOutput extends $MetadataBearer {
 
 export namespace DeleteAnomalyDetectorOutput {
   export function isa(o: any): o is DeleteAnomalyDetectorOutput {
-    return _smithy.isa(o, "DeleteAnomalyDetectorOutput");
+    return __isa(o, "DeleteAnomalyDetectorOutput");
   }
 }
 
@@ -413,7 +416,7 @@ export interface DeleteDashboardsInput {
 
 export namespace DeleteDashboardsInput {
   export function isa(o: any): o is DeleteDashboardsInput {
-    return _smithy.isa(o, "DeleteDashboardsInput");
+    return __isa(o, "DeleteDashboardsInput");
   }
 }
 
@@ -423,7 +426,7 @@ export interface DeleteDashboardsOutput extends $MetadataBearer {
 
 export namespace DeleteDashboardsOutput {
   export function isa(o: any): o is DeleteDashboardsOutput {
-    return _smithy.isa(o, "DeleteDashboardsOutput");
+    return __isa(o, "DeleteDashboardsOutput");
   }
 }
 
@@ -437,7 +440,7 @@ export interface DeleteInsightRulesInput {
 
 export namespace DeleteInsightRulesInput {
   export function isa(o: any): o is DeleteInsightRulesInput {
-    return _smithy.isa(o, "DeleteInsightRulesInput");
+    return __isa(o, "DeleteInsightRulesInput");
   }
 }
 
@@ -451,7 +454,7 @@ export interface DeleteInsightRulesOutput extends $MetadataBearer {
 
 export namespace DeleteInsightRulesOutput {
   export function isa(o: any): o is DeleteInsightRulesOutput {
-    return _smithy.isa(o, "DeleteInsightRulesOutput");
+    return __isa(o, "DeleteInsightRulesOutput");
   }
 }
 
@@ -491,7 +494,7 @@ export interface DescribeAlarmHistoryInput {
 
 export namespace DescribeAlarmHistoryInput {
   export function isa(o: any): o is DescribeAlarmHistoryInput {
-    return _smithy.isa(o, "DescribeAlarmHistoryInput");
+    return __isa(o, "DescribeAlarmHistoryInput");
   }
 }
 
@@ -510,7 +513,7 @@ export interface DescribeAlarmHistoryOutput extends $MetadataBearer {
 
 export namespace DescribeAlarmHistoryOutput {
   export function isa(o: any): o is DescribeAlarmHistoryOutput {
-    return _smithy.isa(o, "DescribeAlarmHistoryOutput");
+    return __isa(o, "DescribeAlarmHistoryOutput");
   }
 }
 
@@ -557,7 +560,7 @@ export interface DescribeAlarmsForMetricInput {
 
 export namespace DescribeAlarmsForMetricInput {
   export function isa(o: any): o is DescribeAlarmsForMetricInput {
-    return _smithy.isa(o, "DescribeAlarmsForMetricInput");
+    return __isa(o, "DescribeAlarmsForMetricInput");
   }
 }
 
@@ -571,7 +574,7 @@ export interface DescribeAlarmsForMetricOutput extends $MetadataBearer {
 
 export namespace DescribeAlarmsForMetricOutput {
   export function isa(o: any): o is DescribeAlarmsForMetricOutput {
-    return _smithy.isa(o, "DescribeAlarmsForMetricOutput");
+    return __isa(o, "DescribeAlarmsForMetricOutput");
   }
 }
 
@@ -612,7 +615,7 @@ export interface DescribeAlarmsInput {
 
 export namespace DescribeAlarmsInput {
   export function isa(o: any): o is DescribeAlarmsInput {
-    return _smithy.isa(o, "DescribeAlarmsInput");
+    return __isa(o, "DescribeAlarmsInput");
   }
 }
 
@@ -631,7 +634,7 @@ export interface DescribeAlarmsOutput extends $MetadataBearer {
 
 export namespace DescribeAlarmsOutput {
   export function isa(o: any): o is DescribeAlarmsOutput {
-    return _smithy.isa(o, "DescribeAlarmsOutput");
+    return __isa(o, "DescribeAlarmsOutput");
   }
 }
 
@@ -673,7 +676,7 @@ export interface DescribeAnomalyDetectorsInput {
 
 export namespace DescribeAnomalyDetectorsInput {
   export function isa(o: any): o is DescribeAnomalyDetectorsInput {
-    return _smithy.isa(o, "DescribeAnomalyDetectorsInput");
+    return __isa(o, "DescribeAnomalyDetectorsInput");
   }
 }
 
@@ -693,7 +696,7 @@ export interface DescribeAnomalyDetectorsOutput extends $MetadataBearer {
 
 export namespace DescribeAnomalyDetectorsOutput {
   export function isa(o: any): o is DescribeAnomalyDetectorsOutput {
-    return _smithy.isa(o, "DescribeAnomalyDetectorsOutput");
+    return __isa(o, "DescribeAnomalyDetectorsOutput");
   }
 }
 
@@ -712,7 +715,7 @@ export interface DescribeInsightRulesInput {
 
 export namespace DescribeInsightRulesInput {
   export function isa(o: any): o is DescribeInsightRulesInput {
-    return _smithy.isa(o, "DescribeInsightRulesInput");
+    return __isa(o, "DescribeInsightRulesInput");
   }
 }
 
@@ -731,7 +734,7 @@ export interface DescribeInsightRulesOutput extends $MetadataBearer {
 
 export namespace DescribeInsightRulesOutput {
   export function isa(o: any): o is DescribeInsightRulesOutput {
-    return _smithy.isa(o, "DescribeInsightRulesOutput");
+    return __isa(o, "DescribeInsightRulesOutput");
   }
 }
 
@@ -753,7 +756,7 @@ export interface Dimension {
 
 export namespace Dimension {
   export function isa(o: any): o is Dimension {
-    return _smithy.isa(o, "Dimension");
+    return __isa(o, "Dimension");
   }
 }
 
@@ -775,7 +778,7 @@ export interface DimensionFilter {
 
 export namespace DimensionFilter {
   export function isa(o: any): o is DimensionFilter {
-    return _smithy.isa(o, "DimensionFilter");
+    return __isa(o, "DimensionFilter");
   }
 }
 
@@ -789,7 +792,7 @@ export interface DisableAlarmActionsInput {
 
 export namespace DisableAlarmActionsInput {
   export function isa(o: any): o is DisableAlarmActionsInput {
-    return _smithy.isa(o, "DisableAlarmActionsInput");
+    return __isa(o, "DisableAlarmActionsInput");
   }
 }
 
@@ -803,7 +806,7 @@ export interface DisableInsightRulesInput {
 
 export namespace DisableInsightRulesInput {
   export function isa(o: any): o is DisableInsightRulesInput {
-    return _smithy.isa(o, "DisableInsightRulesInput");
+    return __isa(o, "DisableInsightRulesInput");
   }
 }
 
@@ -817,7 +820,7 @@ export interface DisableInsightRulesOutput extends $MetadataBearer {
 
 export namespace DisableInsightRulesOutput {
   export function isa(o: any): o is DisableInsightRulesOutput {
-    return _smithy.isa(o, "DisableInsightRulesOutput");
+    return __isa(o, "DisableInsightRulesOutput");
   }
 }
 
@@ -831,7 +834,7 @@ export interface EnableAlarmActionsInput {
 
 export namespace EnableAlarmActionsInput {
   export function isa(o: any): o is EnableAlarmActionsInput {
-    return _smithy.isa(o, "EnableAlarmActionsInput");
+    return __isa(o, "EnableAlarmActionsInput");
   }
 }
 
@@ -845,7 +848,7 @@ export interface EnableInsightRulesInput {
 
 export namespace EnableInsightRulesInput {
   export function isa(o: any): o is EnableInsightRulesInput {
-    return _smithy.isa(o, "EnableInsightRulesInput");
+    return __isa(o, "EnableInsightRulesInput");
   }
 }
 
@@ -859,7 +862,7 @@ export interface EnableInsightRulesOutput extends $MetadataBearer {
 
 export namespace EnableInsightRulesOutput {
   export function isa(o: any): o is EnableInsightRulesOutput {
-    return _smithy.isa(o, "EnableInsightRulesOutput");
+    return __isa(o, "EnableInsightRulesOutput");
   }
 }
 
@@ -873,7 +876,7 @@ export interface GetDashboardInput {
 
 export namespace GetDashboardInput {
   export function isa(o: any): o is GetDashboardInput {
-    return _smithy.isa(o, "GetDashboardInput");
+    return __isa(o, "GetDashboardInput");
   }
 }
 
@@ -899,7 +902,7 @@ export interface GetDashboardOutput extends $MetadataBearer {
 
 export namespace GetDashboardOutput {
   export function isa(o: any): o is GetDashboardOutput {
-    return _smithy.isa(o, "GetDashboardOutput");
+    return __isa(o, "GetDashboardOutput");
   }
 }
 
@@ -982,7 +985,7 @@ export interface GetInsightRuleReportInput {
 
 export namespace GetInsightRuleReportInput {
   export function isa(o: any): o is GetInsightRuleReportInput {
-    return _smithy.isa(o, "GetInsightRuleReportInput");
+    return __isa(o, "GetInsightRuleReportInput");
   }
 }
 
@@ -1023,7 +1026,7 @@ export interface GetInsightRuleReportOutput extends $MetadataBearer {
 
 export namespace GetInsightRuleReportOutput {
   export function isa(o: any): o is GetInsightRuleReportOutput {
-    return _smithy.isa(o, "GetInsightRuleReportOutput");
+    return __isa(o, "GetInsightRuleReportOutput");
   }
 }
 
@@ -1101,7 +1104,7 @@ export interface GetMetricDataInput {
 
 export namespace GetMetricDataInput {
   export function isa(o: any): o is GetMetricDataInput {
-    return _smithy.isa(o, "GetMetricDataInput");
+    return __isa(o, "GetMetricDataInput");
   }
 }
 
@@ -1131,7 +1134,7 @@ export interface GetMetricDataOutput extends $MetadataBearer {
 
 export namespace GetMetricDataOutput {
   export function isa(o: any): o is GetMetricDataOutput {
-    return _smithy.isa(o, "GetMetricDataOutput");
+    return __isa(o, "GetMetricDataOutput");
   }
 }
 
@@ -1240,7 +1243,7 @@ export interface GetMetricStatisticsInput {
 
 export namespace GetMetricStatisticsInput {
   export function isa(o: any): o is GetMetricStatisticsInput {
-    return _smithy.isa(o, "GetMetricStatisticsInput");
+    return __isa(o, "GetMetricStatisticsInput");
   }
 }
 
@@ -1259,7 +1262,7 @@ export interface GetMetricStatisticsOutput extends $MetadataBearer {
 
 export namespace GetMetricStatisticsOutput {
   export function isa(o: any): o is GetMetricStatisticsOutput {
-    return _smithy.isa(o, "GetMetricStatisticsOutput");
+    return __isa(o, "GetMetricStatisticsOutput");
   }
 }
 
@@ -1325,7 +1328,7 @@ export interface GetMetricWidgetImageInput {
 
 export namespace GetMetricWidgetImageInput {
   export function isa(o: any): o is GetMetricWidgetImageInput {
-    return _smithy.isa(o, "GetMetricWidgetImageInput");
+    return __isa(o, "GetMetricWidgetImageInput");
   }
 }
 
@@ -1339,7 +1342,7 @@ export interface GetMetricWidgetImageOutput extends $MetadataBearer {
 
 export namespace GetMetricWidgetImageOutput {
   export function isa(o: any): o is GetMetricWidgetImageOutput {
-    return _smithy.isa(o, "GetMetricWidgetImageOutput");
+    return __isa(o, "GetMetricWidgetImageOutput");
   }
 }
 
@@ -1378,7 +1381,7 @@ export interface InsightRule {
 
 export namespace InsightRule {
   export function isa(o: any): o is InsightRule {
-    return _smithy.isa(o, "InsightRule");
+    return __isa(o, "InsightRule");
   }
 }
 
@@ -1408,7 +1411,7 @@ export interface InsightRuleContributor {
 
 export namespace InsightRuleContributor {
   export function isa(o: any): o is InsightRuleContributor {
-    return _smithy.isa(o, "InsightRuleContributor");
+    return __isa(o, "InsightRuleContributor");
   }
 }
 
@@ -1431,7 +1434,7 @@ export interface InsightRuleContributorDatapoint {
 
 export namespace InsightRuleContributorDatapoint {
   export function isa(o: any): o is InsightRuleContributorDatapoint {
-    return _smithy.isa(o, "InsightRuleContributorDatapoint");
+    return __isa(o, "InsightRuleContributorDatapoint");
   }
 }
 
@@ -1493,7 +1496,7 @@ export interface InsightRuleMetricDatapoint {
 
 export namespace InsightRuleMetricDatapoint {
   export function isa(o: any): o is InsightRuleMetricDatapoint {
-    return _smithy.isa(o, "InsightRuleMetricDatapoint");
+    return __isa(o, "InsightRuleMetricDatapoint");
   }
 }
 
@@ -1501,7 +1504,7 @@ export namespace InsightRuleMetricDatapoint {
  * <p>Request processing has failed due to some unknown error, exception, or failure.</p>
  */
 export interface InternalServiceFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalServiceFault";
   $fault: "server";
@@ -1513,16 +1516,14 @@ export interface InternalServiceFault
 
 export namespace InternalServiceFault {
   export function isa(o: any): o is InternalServiceFault {
-    return _smithy.isa(o, "InternalServiceFault");
+    return __isa(o, "InternalServiceFault");
   }
 }
 
 /**
  * <p>Data was not syntactically valid JSON.</p>
  */
-export interface InvalidFormatFault
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface InvalidFormatFault extends __SmithyException, $MetadataBearer {
   name: "InvalidFormatFault";
   $fault: "client";
   /**
@@ -1533,16 +1534,14 @@ export interface InvalidFormatFault
 
 export namespace InvalidFormatFault {
   export function isa(o: any): o is InvalidFormatFault {
-    return _smithy.isa(o, "InvalidFormatFault");
+    return __isa(o, "InvalidFormatFault");
   }
 }
 
 /**
  * <p>The next token specified is invalid.</p>
  */
-export interface InvalidNextToken
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface InvalidNextToken extends __SmithyException, $MetadataBearer {
   name: "InvalidNextToken";
   $fault: "client";
   /**
@@ -1553,7 +1552,7 @@ export interface InvalidNextToken
 
 export namespace InvalidNextToken {
   export function isa(o: any): o is InvalidNextToken {
-    return _smithy.isa(o, "InvalidNextToken");
+    return __isa(o, "InvalidNextToken");
   }
 }
 
@@ -1561,7 +1560,7 @@ export namespace InvalidNextToken {
  * <p>The operation exceeded one or more limits.</p>
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -1570,16 +1569,14 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
 /**
  * <p>The quota for alarms for this customer has already been reached.</p>
  */
-export interface LimitExceededFault
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface LimitExceededFault extends __SmithyException, $MetadataBearer {
   name: "LimitExceededFault";
   $fault: "client";
   /**
@@ -1590,7 +1587,7 @@ export interface LimitExceededFault
 
 export namespace LimitExceededFault {
   export function isa(o: any): o is LimitExceededFault {
-    return _smithy.isa(o, "LimitExceededFault");
+    return __isa(o, "LimitExceededFault");
   }
 }
 
@@ -1613,7 +1610,7 @@ export interface ListDashboardsInput {
 
 export namespace ListDashboardsInput {
   export function isa(o: any): o is ListDashboardsInput {
-    return _smithy.isa(o, "ListDashboardsInput");
+    return __isa(o, "ListDashboardsInput");
   }
 }
 
@@ -1632,7 +1629,7 @@ export interface ListDashboardsOutput extends $MetadataBearer {
 
 export namespace ListDashboardsOutput {
   export function isa(o: any): o is ListDashboardsOutput {
-    return _smithy.isa(o, "ListDashboardsOutput");
+    return __isa(o, "ListDashboardsOutput");
   }
 }
 
@@ -1662,7 +1659,7 @@ export interface ListMetricsInput {
 
 export namespace ListMetricsInput {
   export function isa(o: any): o is ListMetricsInput {
-    return _smithy.isa(o, "ListMetricsInput");
+    return __isa(o, "ListMetricsInput");
   }
 }
 
@@ -1681,7 +1678,7 @@ export interface ListMetricsOutput extends $MetadataBearer {
 
 export namespace ListMetricsOutput {
   export function isa(o: any): o is ListMetricsOutput {
-    return _smithy.isa(o, "ListMetricsOutput");
+    return __isa(o, "ListMetricsOutput");
   }
 }
 
@@ -1696,7 +1693,7 @@ export interface ListTagsForResourceInput {
 
 export namespace ListTagsForResourceInput {
   export function isa(o: any): o is ListTagsForResourceInput {
-    return _smithy.isa(o, "ListTagsForResourceInput");
+    return __isa(o, "ListTagsForResourceInput");
   }
 }
 
@@ -1710,7 +1707,7 @@ export interface ListTagsForResourceOutput extends $MetadataBearer {
 
 export namespace ListTagsForResourceOutput {
   export function isa(o: any): o is ListTagsForResourceOutput {
-    return _smithy.isa(o, "ListTagsForResourceOutput");
+    return __isa(o, "ListTagsForResourceOutput");
   }
 }
 
@@ -1732,7 +1729,7 @@ export interface MessageData {
 
 export namespace MessageData {
   export function isa(o: any): o is MessageData {
-    return _smithy.isa(o, "MessageData");
+    return __isa(o, "MessageData");
   }
 }
 
@@ -1759,7 +1756,7 @@ export interface Metric {
 
 export namespace Metric {
   export function isa(o: any): o is Metric {
-    return _smithy.isa(o, "Metric");
+    return __isa(o, "Metric");
   }
 }
 
@@ -1924,7 +1921,7 @@ export interface MetricAlarm {
 
 export namespace MetricAlarm {
   export function isa(o: any): o is MetricAlarm {
-    return _smithy.isa(o, "MetricAlarm");
+    return __isa(o, "MetricAlarm");
   }
 }
 
@@ -2015,7 +2012,7 @@ export interface MetricDataQuery {
 
 export namespace MetricDataQuery {
   export function isa(o: any): o is MetricDataQuery {
-    return _smithy.isa(o, "MetricDataQuery");
+    return __isa(o, "MetricDataQuery");
   }
 }
 
@@ -2067,7 +2064,7 @@ export interface MetricDataResult {
 
 export namespace MetricDataResult {
   export function isa(o: any): o is MetricDataResult {
-    return _smithy.isa(o, "MetricDataResult");
+    return __isa(o, "MetricDataResult");
   }
 }
 
@@ -2146,7 +2143,7 @@ export interface MetricDatum {
 
 export namespace MetricDatum {
   export function isa(o: any): o is MetricDatum {
-    return _smithy.isa(o, "MetricDatum");
+    return __isa(o, "MetricDatum");
   }
 }
 
@@ -2197,7 +2194,7 @@ export interface MetricStat {
 
 export namespace MetricStat {
   export function isa(o: any): o is MetricStat {
-    return _smithy.isa(o, "MetricStat");
+    return __isa(o, "MetricStat");
   }
 }
 
@@ -2230,7 +2227,7 @@ export interface PartialFailure {
 
 export namespace PartialFailure {
   export function isa(o: any): o is PartialFailure {
-    return _smithy.isa(o, "PartialFailure");
+    return __isa(o, "PartialFailure");
   }
 }
 
@@ -2270,7 +2267,7 @@ export interface PutAnomalyDetectorInput {
 
 export namespace PutAnomalyDetectorInput {
   export function isa(o: any): o is PutAnomalyDetectorInput {
-    return _smithy.isa(o, "PutAnomalyDetectorInput");
+    return __isa(o, "PutAnomalyDetectorInput");
   }
 }
 
@@ -2280,7 +2277,7 @@ export interface PutAnomalyDetectorOutput extends $MetadataBearer {
 
 export namespace PutAnomalyDetectorOutput {
   export function isa(o: any): o is PutAnomalyDetectorOutput {
-    return _smithy.isa(o, "PutAnomalyDetectorOutput");
+    return __isa(o, "PutAnomalyDetectorOutput");
   }
 }
 
@@ -2304,7 +2301,7 @@ export interface PutDashboardInput {
 
 export namespace PutDashboardInput {
   export function isa(o: any): o is PutDashboardInput {
-    return _smithy.isa(o, "PutDashboardInput");
+    return __isa(o, "PutDashboardInput");
   }
 }
 
@@ -2321,7 +2318,7 @@ export interface PutDashboardOutput extends $MetadataBearer {
 
 export namespace PutDashboardOutput {
   export function isa(o: any): o is PutDashboardOutput {
-    return _smithy.isa(o, "PutDashboardOutput");
+    return __isa(o, "PutDashboardOutput");
   }
 }
 
@@ -2347,7 +2344,7 @@ export interface PutInsightRuleInput {
 
 export namespace PutInsightRuleInput {
   export function isa(o: any): o is PutInsightRuleInput {
-    return _smithy.isa(o, "PutInsightRuleInput");
+    return __isa(o, "PutInsightRuleInput");
   }
 }
 
@@ -2357,7 +2354,7 @@ export interface PutInsightRuleOutput extends $MetadataBearer {
 
 export namespace PutInsightRuleOutput {
   export function isa(o: any): o is PutInsightRuleOutput {
-    return _smithy.isa(o, "PutInsightRuleOutput");
+    return __isa(o, "PutInsightRuleOutput");
   }
 }
 
@@ -2608,7 +2605,7 @@ export interface PutMetricAlarmInput {
 
 export namespace PutMetricAlarmInput {
   export function isa(o: any): o is PutMetricAlarmInput {
-    return _smithy.isa(o, "PutMetricAlarmInput");
+    return __isa(o, "PutMetricAlarmInput");
   }
 }
 
@@ -2630,7 +2627,7 @@ export interface PutMetricDataInput {
 
 export namespace PutMetricDataInput {
   export function isa(o: any): o is PutMetricDataInput {
-    return _smithy.isa(o, "PutMetricDataInput");
+    return __isa(o, "PutMetricDataInput");
   }
 }
 
@@ -2655,16 +2652,14 @@ export interface Range {
 
 export namespace Range {
   export function isa(o: any): o is Range {
-    return _smithy.isa(o, "Range");
+    return __isa(o, "Range");
   }
 }
 
 /**
  * <p>The named resource does not exist.</p>
  */
-export interface ResourceNotFound
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface ResourceNotFound extends __SmithyException, $MetadataBearer {
   name: "ResourceNotFound";
   $fault: "client";
   /**
@@ -2675,7 +2670,7 @@ export interface ResourceNotFound
 
 export namespace ResourceNotFound {
   export function isa(o: any): o is ResourceNotFound {
-    return _smithy.isa(o, "ResourceNotFound");
+    return __isa(o, "ResourceNotFound");
   }
 }
 
@@ -2683,7 +2678,7 @@ export namespace ResourceNotFound {
  * <p>The named resource does not exist.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -2694,7 +2689,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -2729,7 +2724,7 @@ export interface SetAlarmStateInput {
 
 export namespace SetAlarmStateInput {
   export function isa(o: any): o is SetAlarmStateInput {
-    return _smithy.isa(o, "SetAlarmStateInput");
+    return __isa(o, "SetAlarmStateInput");
   }
 }
 
@@ -2799,7 +2794,7 @@ export interface StatisticSet {
 
 export namespace StatisticSet {
   export function isa(o: any): o is StatisticSet {
-    return _smithy.isa(o, "StatisticSet");
+    return __isa(o, "StatisticSet");
   }
 }
 
@@ -2828,7 +2823,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -2850,7 +2845,7 @@ export interface TagResourceInput {
 
 export namespace TagResourceInput {
   export function isa(o: any): o is TagResourceInput {
-    return _smithy.isa(o, "TagResourceInput");
+    return __isa(o, "TagResourceInput");
   }
 }
 
@@ -2860,7 +2855,7 @@ export interface TagResourceOutput extends $MetadataBearer {
 
 export namespace TagResourceOutput {
   export function isa(o: any): o is TagResourceOutput {
-    return _smithy.isa(o, "TagResourceOutput");
+    return __isa(o, "TagResourceOutput");
   }
 }
 
@@ -2880,7 +2875,7 @@ export interface UntagResourceInput {
 
 export namespace UntagResourceInput {
   export function isa(o: any): o is UntagResourceInput {
-    return _smithy.isa(o, "UntagResourceInput");
+    return __isa(o, "UntagResourceInput");
   }
 }
 
@@ -2890,6 +2885,6 @@ export interface UntagResourceOutput extends $MetadataBearer {
 
 export namespace UntagResourceOutput {
   export function isa(o: any): o is UntagResourceOutput {
-    return _smithy.isa(o, "UntagResourceOutput");
+    return __isa(o, "UntagResourceOutput");
   }
 }

--- a/clients/client-cloudwatch/protocols/Aws_query.ts
+++ b/clients/client-cloudwatch/protocols/Aws_query.ts
@@ -699,6 +699,7 @@ export async function deserializeAws_queryDeleteAlarmsCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_queryDeleteAlarmsCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteAlarmsCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1277,6 +1278,7 @@ export async function deserializeAws_queryDisableAlarmActionsCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_queryDisableAlarmActionsCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DisableAlarmActionsCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1385,6 +1387,7 @@ export async function deserializeAws_queryEnableAlarmActionsCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_queryEnableAlarmActionsCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: EnableAlarmActionsCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2256,6 +2259,7 @@ export async function deserializeAws_queryPutMetricAlarmCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_queryPutMetricAlarmCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: PutMetricAlarmCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2306,6 +2310,7 @@ export async function deserializeAws_queryPutMetricDataCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_queryPutMetricDataCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: PutMetricDataCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2377,6 +2382,7 @@ export async function deserializeAws_querySetAlarmStateCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_querySetAlarmStateCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: SetAlarmStateCommandOutput = {
     $metadata: deserializeMetadata(output)
   };

--- a/clients/client-codebuild/models/index.ts
+++ b/clients/client-codebuild/models/index.ts
@@ -1,11 +1,14 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
  * <p>An AWS service limit was exceeded for the calling AWS account.</p>
  */
 export interface AccountLimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AccountLimitExceededException";
   $fault: "client";
@@ -14,7 +17,7 @@ export interface AccountLimitExceededException
 
 export namespace AccountLimitExceededException {
   export function isa(o: any): o is AccountLimitExceededException {
-    return _smithy.isa(o, "AccountLimitExceededException");
+    return __isa(o, "AccountLimitExceededException");
   }
 }
 
@@ -50,7 +53,7 @@ export interface BatchDeleteBuildsInput {
 
 export namespace BatchDeleteBuildsInput {
   export function isa(o: any): o is BatchDeleteBuildsInput {
-    return _smithy.isa(o, "BatchDeleteBuildsInput");
+    return __isa(o, "BatchDeleteBuildsInput");
   }
 }
 
@@ -69,7 +72,7 @@ export interface BatchDeleteBuildsOutput extends $MetadataBearer {
 
 export namespace BatchDeleteBuildsOutput {
   export function isa(o: any): o is BatchDeleteBuildsOutput {
-    return _smithy.isa(o, "BatchDeleteBuildsOutput");
+    return __isa(o, "BatchDeleteBuildsOutput");
   }
 }
 
@@ -83,7 +86,7 @@ export interface BatchGetBuildsInput {
 
 export namespace BatchGetBuildsInput {
   export function isa(o: any): o is BatchGetBuildsInput {
-    return _smithy.isa(o, "BatchGetBuildsInput");
+    return __isa(o, "BatchGetBuildsInput");
   }
 }
 
@@ -102,7 +105,7 @@ export interface BatchGetBuildsOutput extends $MetadataBearer {
 
 export namespace BatchGetBuildsOutput {
   export function isa(o: any): o is BatchGetBuildsOutput {
-    return _smithy.isa(o, "BatchGetBuildsOutput");
+    return __isa(o, "BatchGetBuildsOutput");
   }
 }
 
@@ -117,7 +120,7 @@ export interface BatchGetProjectsInput {
 
 export namespace BatchGetProjectsInput {
   export function isa(o: any): o is BatchGetProjectsInput {
-    return _smithy.isa(o, "BatchGetProjectsInput");
+    return __isa(o, "BatchGetProjectsInput");
   }
 }
 
@@ -136,7 +139,7 @@ export interface BatchGetProjectsOutput extends $MetadataBearer {
 
 export namespace BatchGetProjectsOutput {
   export function isa(o: any): o is BatchGetProjectsOutput {
-    return _smithy.isa(o, "BatchGetProjectsOutput");
+    return __isa(o, "BatchGetProjectsOutput");
   }
 }
 
@@ -152,7 +155,7 @@ export interface BatchGetReportGroupsInput {
 
 export namespace BatchGetReportGroupsInput {
   export function isa(o: any): o is BatchGetReportGroupsInput {
-    return _smithy.isa(o, "BatchGetReportGroupsInput");
+    return __isa(o, "BatchGetReportGroupsInput");
   }
 }
 
@@ -175,7 +178,7 @@ export interface BatchGetReportGroupsOutput extends $MetadataBearer {
 
 export namespace BatchGetReportGroupsOutput {
   export function isa(o: any): o is BatchGetReportGroupsOutput {
-    return _smithy.isa(o, "BatchGetReportGroupsOutput");
+    return __isa(o, "BatchGetReportGroupsOutput");
   }
 }
 
@@ -191,7 +194,7 @@ export interface BatchGetReportsInput {
 
 export namespace BatchGetReportsInput {
   export function isa(o: any): o is BatchGetReportsInput {
-    return _smithy.isa(o, "BatchGetReportsInput");
+    return __isa(o, "BatchGetReportsInput");
   }
 }
 
@@ -214,7 +217,7 @@ export interface BatchGetReportsOutput extends $MetadataBearer {
 
 export namespace BatchGetReportsOutput {
   export function isa(o: any): o is BatchGetReportsOutput {
-    return _smithy.isa(o, "BatchGetReportsOutput");
+    return __isa(o, "BatchGetReportsOutput");
   }
 }
 
@@ -473,7 +476,7 @@ export interface Build {
 
 export namespace Build {
   export function isa(o: any): o is Build {
-    return _smithy.isa(o, "Build");
+    return __isa(o, "Build");
   }
 }
 
@@ -530,7 +533,7 @@ export interface BuildArtifacts {
 
 export namespace BuildArtifacts {
   export function isa(o: any): o is BuildArtifacts {
-    return _smithy.isa(o, "BuildArtifacts");
+    return __isa(o, "BuildArtifacts");
   }
 }
 
@@ -552,7 +555,7 @@ export interface BuildNotDeleted {
 
 export namespace BuildNotDeleted {
   export function isa(o: any): o is BuildNotDeleted {
-    return _smithy.isa(o, "BuildNotDeleted");
+    return __isa(o, "BuildNotDeleted");
   }
 }
 
@@ -680,7 +683,7 @@ export interface BuildPhase {
 
 export namespace BuildPhase {
   export function isa(o: any): o is BuildPhase {
-    return _smithy.isa(o, "BuildPhase");
+    return __isa(o, "BuildPhase");
   }
 }
 
@@ -745,7 +748,7 @@ export interface CloudWatchLogsConfig {
 
 export namespace CloudWatchLogsConfig {
   export function isa(o: any): o is CloudWatchLogsConfig {
-    return _smithy.isa(o, "CloudWatchLogsConfig");
+    return __isa(o, "CloudWatchLogsConfig");
   }
 }
 
@@ -904,7 +907,7 @@ export interface CreateProjectInput {
 
 export namespace CreateProjectInput {
   export function isa(o: any): o is CreateProjectInput {
-    return _smithy.isa(o, "CreateProjectInput");
+    return __isa(o, "CreateProjectInput");
   }
 }
 
@@ -918,7 +921,7 @@ export interface CreateProjectOutput extends $MetadataBearer {
 
 export namespace CreateProjectOutput {
   export function isa(o: any): o is CreateProjectOutput {
-    return _smithy.isa(o, "CreateProjectOutput");
+    return __isa(o, "CreateProjectOutput");
   }
 }
 
@@ -948,7 +951,7 @@ export interface CreateReportGroupInput {
 
 export namespace CreateReportGroupInput {
   export function isa(o: any): o is CreateReportGroupInput {
-    return _smithy.isa(o, "CreateReportGroupInput");
+    return __isa(o, "CreateReportGroupInput");
   }
 }
 
@@ -964,7 +967,7 @@ export interface CreateReportGroupOutput extends $MetadataBearer {
 
 export namespace CreateReportGroupOutput {
   export function isa(o: any): o is CreateReportGroupOutput {
-    return _smithy.isa(o, "CreateReportGroupOutput");
+    return __isa(o, "CreateReportGroupOutput");
   }
 }
 
@@ -1003,7 +1006,7 @@ export interface CreateWebhookInput {
 
 export namespace CreateWebhookInput {
   export function isa(o: any): o is CreateWebhookInput {
-    return _smithy.isa(o, "CreateWebhookInput");
+    return __isa(o, "CreateWebhookInput");
   }
 }
 
@@ -1018,7 +1021,7 @@ export interface CreateWebhookOutput extends $MetadataBearer {
 
 export namespace CreateWebhookOutput {
   export function isa(o: any): o is CreateWebhookOutput {
-    return _smithy.isa(o, "CreateWebhookOutput");
+    return __isa(o, "CreateWebhookOutput");
   }
 }
 
@@ -1036,7 +1039,7 @@ export interface DeleteProjectInput {
 
 export namespace DeleteProjectInput {
   export function isa(o: any): o is DeleteProjectInput {
-    return _smithy.isa(o, "DeleteProjectInput");
+    return __isa(o, "DeleteProjectInput");
   }
 }
 
@@ -1046,7 +1049,7 @@ export interface DeleteProjectOutput extends $MetadataBearer {
 
 export namespace DeleteProjectOutput {
   export function isa(o: any): o is DeleteProjectOutput {
-    return _smithy.isa(o, "DeleteProjectOutput");
+    return __isa(o, "DeleteProjectOutput");
   }
 }
 
@@ -1062,7 +1065,7 @@ export interface DeleteReportGroupInput {
 
 export namespace DeleteReportGroupInput {
   export function isa(o: any): o is DeleteReportGroupInput {
-    return _smithy.isa(o, "DeleteReportGroupInput");
+    return __isa(o, "DeleteReportGroupInput");
   }
 }
 
@@ -1072,7 +1075,7 @@ export interface DeleteReportGroupOutput extends $MetadataBearer {
 
 export namespace DeleteReportGroupOutput {
   export function isa(o: any): o is DeleteReportGroupOutput {
-    return _smithy.isa(o, "DeleteReportGroupOutput");
+    return __isa(o, "DeleteReportGroupOutput");
   }
 }
 
@@ -1088,7 +1091,7 @@ export interface DeleteReportInput {
 
 export namespace DeleteReportInput {
   export function isa(o: any): o is DeleteReportInput {
-    return _smithy.isa(o, "DeleteReportInput");
+    return __isa(o, "DeleteReportInput");
   }
 }
 
@@ -1098,7 +1101,7 @@ export interface DeleteReportOutput extends $MetadataBearer {
 
 export namespace DeleteReportOutput {
   export function isa(o: any): o is DeleteReportOutput {
-    return _smithy.isa(o, "DeleteReportOutput");
+    return __isa(o, "DeleteReportOutput");
   }
 }
 
@@ -1114,7 +1117,7 @@ export interface DeleteResourcePolicyInput {
 
 export namespace DeleteResourcePolicyInput {
   export function isa(o: any): o is DeleteResourcePolicyInput {
-    return _smithy.isa(o, "DeleteResourcePolicyInput");
+    return __isa(o, "DeleteResourcePolicyInput");
   }
 }
 
@@ -1124,7 +1127,7 @@ export interface DeleteResourcePolicyOutput extends $MetadataBearer {
 
 export namespace DeleteResourcePolicyOutput {
   export function isa(o: any): o is DeleteResourcePolicyOutput {
-    return _smithy.isa(o, "DeleteResourcePolicyOutput");
+    return __isa(o, "DeleteResourcePolicyOutput");
   }
 }
 
@@ -1138,7 +1141,7 @@ export interface DeleteSourceCredentialsInput {
 
 export namespace DeleteSourceCredentialsInput {
   export function isa(o: any): o is DeleteSourceCredentialsInput {
-    return _smithy.isa(o, "DeleteSourceCredentialsInput");
+    return __isa(o, "DeleteSourceCredentialsInput");
   }
 }
 
@@ -1154,7 +1157,7 @@ export interface DeleteSourceCredentialsOutput extends $MetadataBearer {
 
 export namespace DeleteSourceCredentialsOutput {
   export function isa(o: any): o is DeleteSourceCredentialsOutput {
-    return _smithy.isa(o, "DeleteSourceCredentialsOutput");
+    return __isa(o, "DeleteSourceCredentialsOutput");
   }
 }
 
@@ -1168,7 +1171,7 @@ export interface DeleteWebhookInput {
 
 export namespace DeleteWebhookInput {
   export function isa(o: any): o is DeleteWebhookInput {
-    return _smithy.isa(o, "DeleteWebhookInput");
+    return __isa(o, "DeleteWebhookInput");
   }
 }
 
@@ -1178,7 +1181,7 @@ export interface DeleteWebhookOutput extends $MetadataBearer {
 
 export namespace DeleteWebhookOutput {
   export function isa(o: any): o is DeleteWebhookOutput {
-    return _smithy.isa(o, "DeleteWebhookOutput");
+    return __isa(o, "DeleteWebhookOutput");
   }
 }
 
@@ -1220,7 +1223,7 @@ export interface DescribeTestCasesInput {
 
 export namespace DescribeTestCasesInput {
   export function isa(o: any): o is DescribeTestCasesInput {
-    return _smithy.isa(o, "DescribeTestCasesInput");
+    return __isa(o, "DescribeTestCasesInput");
   }
 }
 
@@ -1247,7 +1250,7 @@ export interface DescribeTestCasesOutput extends $MetadataBearer {
 
 export namespace DescribeTestCasesOutput {
   export function isa(o: any): o is DescribeTestCasesOutput {
-    return _smithy.isa(o, "DescribeTestCasesOutput");
+    return __isa(o, "DescribeTestCasesOutput");
   }
 }
 
@@ -1274,7 +1277,7 @@ export interface EnvironmentImage {
 
 export namespace EnvironmentImage {
   export function isa(o: any): o is EnvironmentImage {
-    return _smithy.isa(o, "EnvironmentImage");
+    return __isa(o, "EnvironmentImage");
   }
 }
 
@@ -1297,7 +1300,7 @@ export interface EnvironmentLanguage {
 
 export namespace EnvironmentLanguage {
   export function isa(o: any): o is EnvironmentLanguage {
-    return _smithy.isa(o, "EnvironmentLanguage");
+    return __isa(o, "EnvironmentLanguage");
   }
 }
 
@@ -1319,7 +1322,7 @@ export interface EnvironmentPlatform {
 
 export namespace EnvironmentPlatform {
   export function isa(o: any): o is EnvironmentPlatform {
-    return _smithy.isa(o, "EnvironmentPlatform");
+    return __isa(o, "EnvironmentPlatform");
   }
 }
 
@@ -1373,7 +1376,7 @@ export interface EnvironmentVariable {
 
 export namespace EnvironmentVariable {
   export function isa(o: any): o is EnvironmentVariable {
-    return _smithy.isa(o, "EnvironmentVariable");
+    return __isa(o, "EnvironmentVariable");
   }
 }
 
@@ -1414,7 +1417,7 @@ export interface ExportedEnvironmentVariable {
 
 export namespace ExportedEnvironmentVariable {
   export function isa(o: any): o is ExportedEnvironmentVariable {
-    return _smithy.isa(o, "ExportedEnvironmentVariable");
+    return __isa(o, "ExportedEnvironmentVariable");
   }
 }
 
@@ -1430,7 +1433,7 @@ export interface GetResourcePolicyInput {
 
 export namespace GetResourcePolicyInput {
   export function isa(o: any): o is GetResourcePolicyInput {
-    return _smithy.isa(o, "GetResourcePolicyInput");
+    return __isa(o, "GetResourcePolicyInput");
   }
 }
 
@@ -1446,7 +1449,7 @@ export interface GetResourcePolicyOutput extends $MetadataBearer {
 
 export namespace GetResourcePolicyOutput {
   export function isa(o: any): o is GetResourcePolicyOutput {
-    return _smithy.isa(o, "GetResourcePolicyOutput");
+    return __isa(o, "GetResourcePolicyOutput");
   }
 }
 
@@ -1467,7 +1470,7 @@ export interface GitSubmodulesConfig {
 
 export namespace GitSubmodulesConfig {
   export function isa(o: any): o is GitSubmodulesConfig {
-    return _smithy.isa(o, "GitSubmodulesConfig");
+    return __isa(o, "GitSubmodulesConfig");
   }
 }
 
@@ -1519,7 +1522,7 @@ export interface ImportSourceCredentialsInput {
 
 export namespace ImportSourceCredentialsInput {
   export function isa(o: any): o is ImportSourceCredentialsInput {
-    return _smithy.isa(o, "ImportSourceCredentialsInput");
+    return __isa(o, "ImportSourceCredentialsInput");
   }
 }
 
@@ -1535,7 +1538,7 @@ export interface ImportSourceCredentialsOutput extends $MetadataBearer {
 
 export namespace ImportSourceCredentialsOutput {
   export function isa(o: any): o is ImportSourceCredentialsOutput {
-    return _smithy.isa(o, "ImportSourceCredentialsOutput");
+    return __isa(o, "ImportSourceCredentialsOutput");
   }
 }
 
@@ -1543,7 +1546,7 @@ export namespace ImportSourceCredentialsOutput {
  * <p>The input value that was provided is not valid.</p>
  */
 export interface InvalidInputException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidInputException";
   $fault: "client";
@@ -1552,7 +1555,7 @@ export interface InvalidInputException
 
 export namespace InvalidInputException {
   export function isa(o: any): o is InvalidInputException {
-    return _smithy.isa(o, "InvalidInputException");
+    return __isa(o, "InvalidInputException");
   }
 }
 
@@ -1566,7 +1569,7 @@ export interface InvalidateProjectCacheInput {
 
 export namespace InvalidateProjectCacheInput {
   export function isa(o: any): o is InvalidateProjectCacheInput {
-    return _smithy.isa(o, "InvalidateProjectCacheInput");
+    return __isa(o, "InvalidateProjectCacheInput");
   }
 }
 
@@ -1576,7 +1579,7 @@ export interface InvalidateProjectCacheOutput extends $MetadataBearer {
 
 export namespace InvalidateProjectCacheOutput {
   export function isa(o: any): o is InvalidateProjectCacheOutput {
-    return _smithy.isa(o, "InvalidateProjectCacheOutput");
+    return __isa(o, "InvalidateProjectCacheOutput");
   }
 }
 
@@ -1628,7 +1631,7 @@ export interface ListBuildsForProjectInput {
 
 export namespace ListBuildsForProjectInput {
   export function isa(o: any): o is ListBuildsForProjectInput {
-    return _smithy.isa(o, "ListBuildsForProjectInput");
+    return __isa(o, "ListBuildsForProjectInput");
   }
 }
 
@@ -1650,7 +1653,7 @@ export interface ListBuildsForProjectOutput extends $MetadataBearer {
 
 export namespace ListBuildsForProjectOutput {
   export function isa(o: any): o is ListBuildsForProjectOutput {
-    return _smithy.isa(o, "ListBuildsForProjectOutput");
+    return __isa(o, "ListBuildsForProjectOutput");
   }
 }
 
@@ -1684,7 +1687,7 @@ export interface ListBuildsInput {
 
 export namespace ListBuildsInput {
   export function isa(o: any): o is ListBuildsInput {
-    return _smithy.isa(o, "ListBuildsInput");
+    return __isa(o, "ListBuildsInput");
   }
 }
 
@@ -1705,7 +1708,7 @@ export interface ListBuildsOutput extends $MetadataBearer {
 
 export namespace ListBuildsOutput {
   export function isa(o: any): o is ListBuildsOutput {
-    return _smithy.isa(o, "ListBuildsOutput");
+    return __isa(o, "ListBuildsOutput");
   }
 }
 
@@ -1715,7 +1718,7 @@ export interface ListCuratedEnvironmentImagesInput {
 
 export namespace ListCuratedEnvironmentImagesInput {
   export function isa(o: any): o is ListCuratedEnvironmentImagesInput {
-    return _smithy.isa(o, "ListCuratedEnvironmentImagesInput");
+    return __isa(o, "ListCuratedEnvironmentImagesInput");
   }
 }
 
@@ -1730,7 +1733,7 @@ export interface ListCuratedEnvironmentImagesOutput extends $MetadataBearer {
 
 export namespace ListCuratedEnvironmentImagesOutput {
   export function isa(o: any): o is ListCuratedEnvironmentImagesOutput {
-    return _smithy.isa(o, "ListCuratedEnvironmentImagesOutput");
+    return __isa(o, "ListCuratedEnvironmentImagesOutput");
   }
 }
 
@@ -1788,7 +1791,7 @@ export interface ListProjectsInput {
 
 export namespace ListProjectsInput {
   export function isa(o: any): o is ListProjectsInput {
-    return _smithy.isa(o, "ListProjectsInput");
+    return __isa(o, "ListProjectsInput");
   }
 }
 
@@ -1810,7 +1813,7 @@ export interface ListProjectsOutput extends $MetadataBearer {
 
 export namespace ListProjectsOutput {
   export function isa(o: any): o is ListProjectsOutput {
-    return _smithy.isa(o, "ListProjectsOutput");
+    return __isa(o, "ListProjectsOutput");
   }
 }
 
@@ -1868,7 +1871,7 @@ export interface ListReportGroupsInput {
 
 export namespace ListReportGroupsInput {
   export function isa(o: any): o is ListReportGroupsInput {
-    return _smithy.isa(o, "ListReportGroupsInput");
+    return __isa(o, "ListReportGroupsInput");
   }
 }
 
@@ -1895,7 +1898,7 @@ export interface ListReportGroupsOutput extends $MetadataBearer {
 
 export namespace ListReportGroupsOutput {
   export function isa(o: any): o is ListReportGroupsOutput {
-    return _smithy.isa(o, "ListReportGroupsOutput");
+    return __isa(o, "ListReportGroupsOutput");
   }
 }
 
@@ -1944,7 +1947,7 @@ export interface ListReportsForReportGroupInput {
 
 export namespace ListReportsForReportGroupInput {
   export function isa(o: any): o is ListReportsForReportGroupInput {
-    return _smithy.isa(o, "ListReportsForReportGroupInput");
+    return __isa(o, "ListReportsForReportGroupInput");
   }
 }
 
@@ -1971,7 +1974,7 @@ export interface ListReportsForReportGroupOutput extends $MetadataBearer {
 
 export namespace ListReportsForReportGroupOutput {
   export function isa(o: any): o is ListReportsForReportGroupOutput {
-    return _smithy.isa(o, "ListReportsForReportGroupOutput");
+    return __isa(o, "ListReportsForReportGroupOutput");
   }
 }
 
@@ -2025,7 +2028,7 @@ export interface ListReportsInput {
 
 export namespace ListReportsInput {
   export function isa(o: any): o is ListReportsInput {
-    return _smithy.isa(o, "ListReportsInput");
+    return __isa(o, "ListReportsInput");
   }
 }
 
@@ -2052,7 +2055,7 @@ export interface ListReportsOutput extends $MetadataBearer {
 
 export namespace ListReportsOutput {
   export function isa(o: any): o is ListReportsOutput {
-    return _smithy.isa(o, "ListReportsOutput");
+    return __isa(o, "ListReportsOutput");
   }
 }
 
@@ -2117,7 +2120,7 @@ export interface ListSharedProjectsInput {
 
 export namespace ListSharedProjectsInput {
   export function isa(o: any): o is ListSharedProjectsInput {
-    return _smithy.isa(o, "ListSharedProjectsInput");
+    return __isa(o, "ListSharedProjectsInput");
   }
 }
 
@@ -2144,7 +2147,7 @@ export interface ListSharedProjectsOutput extends $MetadataBearer {
 
 export namespace ListSharedProjectsOutput {
   export function isa(o: any): o is ListSharedProjectsOutput {
-    return _smithy.isa(o, "ListSharedProjectsOutput");
+    return __isa(o, "ListSharedProjectsOutput");
   }
 }
 
@@ -2209,7 +2212,7 @@ export interface ListSharedReportGroupsInput {
 
 export namespace ListSharedReportGroupsInput {
   export function isa(o: any): o is ListSharedReportGroupsInput {
-    return _smithy.isa(o, "ListSharedReportGroupsInput");
+    return __isa(o, "ListSharedReportGroupsInput");
   }
 }
 
@@ -2236,7 +2239,7 @@ export interface ListSharedReportGroupsOutput extends $MetadataBearer {
 
 export namespace ListSharedReportGroupsOutput {
   export function isa(o: any): o is ListSharedReportGroupsOutput {
-    return _smithy.isa(o, "ListSharedReportGroupsOutput");
+    return __isa(o, "ListSharedReportGroupsOutput");
   }
 }
 
@@ -2246,7 +2249,7 @@ export interface ListSourceCredentialsInput {
 
 export namespace ListSourceCredentialsInput {
   export function isa(o: any): o is ListSourceCredentialsInput {
-    return _smithy.isa(o, "ListSourceCredentialsInput");
+    return __isa(o, "ListSourceCredentialsInput");
   }
 }
 
@@ -2263,7 +2266,7 @@ export interface ListSourceCredentialsOutput extends $MetadataBearer {
 
 export namespace ListSourceCredentialsOutput {
   export function isa(o: any): o is ListSourceCredentialsOutput {
-    return _smithy.isa(o, "ListSourceCredentialsOutput");
+    return __isa(o, "ListSourceCredentialsOutput");
   }
 }
 
@@ -2287,7 +2290,7 @@ export interface LogsConfig {
 
 export namespace LogsConfig {
   export function isa(o: any): o is LogsConfig {
-    return _smithy.isa(o, "LogsConfig");
+    return __isa(o, "LogsConfig");
   }
 }
 
@@ -2352,7 +2355,7 @@ export interface LogsLocation {
 
 export namespace LogsLocation {
   export function isa(o: any): o is LogsLocation {
-    return _smithy.isa(o, "LogsLocation");
+    return __isa(o, "LogsLocation");
   }
 }
 
@@ -2374,7 +2377,7 @@ export interface NetworkInterface {
 
 export namespace NetworkInterface {
   export function isa(o: any): o is NetworkInterface {
-    return _smithy.isa(o, "NetworkInterface");
+    return __isa(o, "NetworkInterface");
   }
 }
 
@@ -2382,7 +2385,7 @@ export namespace NetworkInterface {
  * <p>There was a problem with the underlying OAuth provider.</p>
  */
 export interface OAuthProviderException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "OAuthProviderException";
   $fault: "client";
@@ -2391,7 +2394,7 @@ export interface OAuthProviderException
 
 export namespace OAuthProviderException {
   export function isa(o: any): o is OAuthProviderException {
-    return _smithy.isa(o, "OAuthProviderException");
+    return __isa(o, "OAuthProviderException");
   }
 }
 
@@ -2415,7 +2418,7 @@ export interface PhaseContext {
 
 export namespace PhaseContext {
   export function isa(o: any): o is PhaseContext {
-    return _smithy.isa(o, "PhaseContext");
+    return __isa(o, "PhaseContext");
   }
 }
 
@@ -2595,7 +2598,7 @@ export interface Project {
 
 export namespace Project {
   export function isa(o: any): o is Project {
-    return _smithy.isa(o, "Project");
+    return __isa(o, "Project");
   }
 }
 
@@ -2808,7 +2811,7 @@ export interface ProjectArtifacts {
 
 export namespace ProjectArtifacts {
   export function isa(o: any): o is ProjectArtifacts {
-    return _smithy.isa(o, "ProjectArtifacts");
+    return __isa(o, "ProjectArtifacts");
   }
 }
 
@@ -2834,7 +2837,7 @@ export interface ProjectBadge {
 
 export namespace ProjectBadge {
   export function isa(o: any): o is ProjectBadge {
-    return _smithy.isa(o, "ProjectBadge");
+    return __isa(o, "ProjectBadge");
   }
 }
 
@@ -2957,7 +2960,7 @@ export interface ProjectCache {
 
 export namespace ProjectCache {
   export function isa(o: any): o is ProjectCache {
-    return _smithy.isa(o, "ProjectCache");
+    return __isa(o, "ProjectCache");
   }
 }
 
@@ -3129,7 +3132,7 @@ export interface ProjectEnvironment {
 
 export namespace ProjectEnvironment {
   export function isa(o: any): o is ProjectEnvironment {
-    return _smithy.isa(o, "ProjectEnvironment");
+    return __isa(o, "ProjectEnvironment");
   }
 }
 
@@ -3296,7 +3299,7 @@ export interface ProjectSource {
 
 export namespace ProjectSource {
   export function isa(o: any): o is ProjectSource {
-    return _smithy.isa(o, "ProjectSource");
+    return __isa(o, "ProjectSource");
   }
 }
 
@@ -3348,7 +3351,7 @@ export interface ProjectSourceVersion {
 
 export namespace ProjectSourceVersion {
   export function isa(o: any): o is ProjectSourceVersion {
-    return _smithy.isa(o, "ProjectSourceVersion");
+    return __isa(o, "ProjectSourceVersion");
   }
 }
 
@@ -3375,7 +3378,7 @@ export interface PutResourcePolicyInput {
 
 export namespace PutResourcePolicyInput {
   export function isa(o: any): o is PutResourcePolicyInput {
-    return _smithy.isa(o, "PutResourcePolicyInput");
+    return __isa(o, "PutResourcePolicyInput");
   }
 }
 
@@ -3392,7 +3395,7 @@ export interface PutResourcePolicyOutput extends $MetadataBearer {
 
 export namespace PutResourcePolicyOutput {
   export function isa(o: any): o is PutResourcePolicyOutput {
-    return _smithy.isa(o, "PutResourcePolicyOutput");
+    return __isa(o, "PutResourcePolicyOutput");
   }
 }
 
@@ -3442,7 +3445,7 @@ export interface RegistryCredential {
 
 export namespace RegistryCredential {
   export function isa(o: any): o is RegistryCredential {
-    return _smithy.isa(o, "RegistryCredential");
+    return __isa(o, "RegistryCredential");
   }
 }
 
@@ -3533,7 +3536,7 @@ export interface Report {
 
 export namespace Report {
   export function isa(o: any): o is Report {
-    return _smithy.isa(o, "Report");
+    return __isa(o, "Report");
   }
 }
 
@@ -3573,7 +3576,7 @@ export interface ReportExportConfig {
 
 export namespace ReportExportConfig {
   export function isa(o: any): o is ReportExportConfig {
-    return _smithy.isa(o, "ReportExportConfig");
+    return __isa(o, "ReportExportConfig");
   }
 }
 
@@ -3599,7 +3602,7 @@ export interface ReportFilter {
 
 export namespace ReportFilter {
   export function isa(o: any): o is ReportFilter {
-    return _smithy.isa(o, "ReportFilter");
+    return __isa(o, "ReportFilter");
   }
 }
 
@@ -3656,7 +3659,7 @@ export interface ReportGroup {
 
 export namespace ReportGroup {
   export function isa(o: any): o is ReportGroup {
-    return _smithy.isa(o, "ReportGroup");
+    return __isa(o, "ReportGroup");
   }
 }
 
@@ -3688,7 +3691,7 @@ export enum ReportType {
  *          settings already exists.</p>
  */
 export interface ResourceAlreadyExistsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceAlreadyExistsException";
   $fault: "client";
@@ -3697,7 +3700,7 @@ export interface ResourceAlreadyExistsException
 
 export namespace ResourceAlreadyExistsException {
   export function isa(o: any): o is ResourceAlreadyExistsException {
-    return _smithy.isa(o, "ResourceAlreadyExistsException");
+    return __isa(o, "ResourceAlreadyExistsException");
   }
 }
 
@@ -3705,7 +3708,7 @@ export namespace ResourceAlreadyExistsException {
  * <p>The specified AWS resource cannot be found.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -3714,7 +3717,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -3757,7 +3760,7 @@ export interface S3LogsConfig {
 
 export namespace S3LogsConfig {
   export function isa(o: any): o is S3LogsConfig {
-    return _smithy.isa(o, "S3LogsConfig");
+    return __isa(o, "S3LogsConfig");
   }
 }
 
@@ -3816,7 +3819,7 @@ export interface S3ReportExportConfig {
 
 export namespace S3ReportExportConfig {
   export function isa(o: any): o is S3ReportExportConfig {
-    return _smithy.isa(o, "S3ReportExportConfig");
+    return __isa(o, "S3ReportExportConfig");
   }
 }
 
@@ -3863,7 +3866,7 @@ export interface SourceAuth {
 
 export namespace SourceAuth {
   export function isa(o: any): o is SourceAuth {
-    return _smithy.isa(o, "SourceAuth");
+    return __isa(o, "SourceAuth");
   }
 }
 
@@ -3903,7 +3906,7 @@ export interface SourceCredentialsInfo {
 
 export namespace SourceCredentialsInfo {
   export function isa(o: any): o is SourceCredentialsInfo {
-    return _smithy.isa(o, "SourceCredentialsInfo");
+    return __isa(o, "SourceCredentialsInfo");
   }
 }
 
@@ -4157,7 +4160,7 @@ export interface StartBuildInput {
 
 export namespace StartBuildInput {
   export function isa(o: any): o is StartBuildInput {
-    return _smithy.isa(o, "StartBuildInput");
+    return __isa(o, "StartBuildInput");
   }
 }
 
@@ -4171,7 +4174,7 @@ export interface StartBuildOutput extends $MetadataBearer {
 
 export namespace StartBuildOutput {
   export function isa(o: any): o is StartBuildOutput {
-    return _smithy.isa(o, "StartBuildOutput");
+    return __isa(o, "StartBuildOutput");
   }
 }
 
@@ -4194,7 +4197,7 @@ export interface StopBuildInput {
 
 export namespace StopBuildInput {
   export function isa(o: any): o is StopBuildInput {
-    return _smithy.isa(o, "StopBuildInput");
+    return __isa(o, "StopBuildInput");
   }
 }
 
@@ -4208,7 +4211,7 @@ export interface StopBuildOutput extends $MetadataBearer {
 
 export namespace StopBuildOutput {
   export function isa(o: any): o is StopBuildOutput {
-    return _smithy.isa(o, "StopBuildOutput");
+    return __isa(o, "StopBuildOutput");
   }
 }
 
@@ -4231,7 +4234,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -4303,7 +4306,7 @@ export interface TestCase {
 
 export namespace TestCase {
   export function isa(o: any): o is TestCase {
-    return _smithy.isa(o, "TestCase");
+    return __isa(o, "TestCase");
   }
 }
 
@@ -4326,7 +4329,7 @@ export interface TestCaseFilter {
 
 export namespace TestCaseFilter {
   export function isa(o: any): o is TestCaseFilter {
-    return _smithy.isa(o, "TestCaseFilter");
+    return __isa(o, "TestCaseFilter");
   }
 }
 
@@ -4361,7 +4364,7 @@ export interface TestReportSummary {
 
 export namespace TestReportSummary {
   export function isa(o: any): o is TestReportSummary {
-    return _smithy.isa(o, "TestReportSummary");
+    return __isa(o, "TestReportSummary");
   }
 }
 
@@ -4517,7 +4520,7 @@ export interface UpdateProjectInput {
 
 export namespace UpdateProjectInput {
   export function isa(o: any): o is UpdateProjectInput {
-    return _smithy.isa(o, "UpdateProjectInput");
+    return __isa(o, "UpdateProjectInput");
   }
 }
 
@@ -4531,7 +4534,7 @@ export interface UpdateProjectOutput extends $MetadataBearer {
 
 export namespace UpdateProjectOutput {
   export function isa(o: any): o is UpdateProjectOutput {
-    return _smithy.isa(o, "UpdateProjectOutput");
+    return __isa(o, "UpdateProjectOutput");
   }
 }
 
@@ -4566,7 +4569,7 @@ export interface UpdateReportGroupInput {
 
 export namespace UpdateReportGroupInput {
   export function isa(o: any): o is UpdateReportGroupInput {
-    return _smithy.isa(o, "UpdateReportGroupInput");
+    return __isa(o, "UpdateReportGroupInput");
   }
 }
 
@@ -4582,7 +4585,7 @@ export interface UpdateReportGroupOutput extends $MetadataBearer {
 
 export namespace UpdateReportGroupOutput {
   export function isa(o: any): o is UpdateReportGroupOutput {
-    return _smithy.isa(o, "UpdateReportGroupOutput");
+    return __isa(o, "UpdateReportGroupOutput");
   }
 }
 
@@ -4624,7 +4627,7 @@ export interface UpdateWebhookInput {
 
 export namespace UpdateWebhookInput {
   export function isa(o: any): o is UpdateWebhookInput {
-    return _smithy.isa(o, "UpdateWebhookInput");
+    return __isa(o, "UpdateWebhookInput");
   }
 }
 
@@ -4639,7 +4642,7 @@ export interface UpdateWebhookOutput extends $MetadataBearer {
 
 export namespace UpdateWebhookOutput {
   export function isa(o: any): o is UpdateWebhookOutput {
-    return _smithy.isa(o, "UpdateWebhookOutput");
+    return __isa(o, "UpdateWebhookOutput");
   }
 }
 
@@ -4666,7 +4669,7 @@ export interface VpcConfig {
 
 export namespace VpcConfig {
   export function isa(o: any): o is VpcConfig {
-    return _smithy.isa(o, "VpcConfig");
+    return __isa(o, "VpcConfig");
   }
 }
 
@@ -4728,7 +4731,7 @@ export interface Webhook {
 
 export namespace Webhook {
   export function isa(o: any): o is Webhook {
-    return _smithy.isa(o, "Webhook");
+    return __isa(o, "Webhook");
   }
 }
 
@@ -4842,7 +4845,7 @@ export interface WebhookFilter {
 
 export namespace WebhookFilter {
   export function isa(o: any): o is WebhookFilter {
-    return _smithy.isa(o, "WebhookFilter");
+    return __isa(o, "WebhookFilter");
   }
 }
 

--- a/clients/client-codecommit/models/index.ts
+++ b/clients/client-codecommit/models/index.ts
@@ -1,11 +1,14 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
  * <p>The specified Amazon Resource Name (ARN) does not exist in the AWS account.</p>
  */
 export interface ActorDoesNotExistException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ActorDoesNotExistException";
   $fault: "client";
@@ -17,7 +20,7 @@ export interface ActorDoesNotExistException
 
 export namespace ActorDoesNotExistException {
   export function isa(o: any): o is ActorDoesNotExistException {
-    return _smithy.isa(o, "ActorDoesNotExistException");
+    return __isa(o, "ActorDoesNotExistException");
   }
 }
 
@@ -39,7 +42,7 @@ export interface Approval {
 
 export namespace Approval {
   export function isa(o: any): o is Approval {
-    return _smithy.isa(o, "Approval");
+    return __isa(o, "Approval");
   }
 }
 
@@ -91,7 +94,7 @@ export interface ApprovalRule {
 
 export namespace ApprovalRule {
   export function isa(o: any): o is ApprovalRule {
-    return _smithy.isa(o, "ApprovalRule");
+    return __isa(o, "ApprovalRule");
   }
 }
 
@@ -99,7 +102,7 @@ export namespace ApprovalRule {
  * <p>The content for the approval rule is empty. You must provide some content for an approval rule. The content cannot be null.</p>
  */
 export interface ApprovalRuleContentRequiredException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ApprovalRuleContentRequiredException";
   $fault: "client";
@@ -111,7 +114,7 @@ export interface ApprovalRuleContentRequiredException
 
 export namespace ApprovalRuleContentRequiredException {
   export function isa(o: any): o is ApprovalRuleContentRequiredException {
-    return _smithy.isa(o, "ApprovalRuleContentRequiredException");
+    return __isa(o, "ApprovalRuleContentRequiredException");
   }
 }
 
@@ -119,7 +122,7 @@ export namespace ApprovalRuleContentRequiredException {
  * <p>The specified approval rule does not exist.</p>
  */
 export interface ApprovalRuleDoesNotExistException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ApprovalRuleDoesNotExistException";
   $fault: "client";
@@ -131,7 +134,7 @@ export interface ApprovalRuleDoesNotExistException
 
 export namespace ApprovalRuleDoesNotExistException {
   export function isa(o: any): o is ApprovalRuleDoesNotExistException {
-    return _smithy.isa(o, "ApprovalRuleDoesNotExistException");
+    return __isa(o, "ApprovalRuleDoesNotExistException");
   }
 }
 
@@ -158,7 +161,7 @@ export interface ApprovalRuleEventMetadata {
 
 export namespace ApprovalRuleEventMetadata {
   export function isa(o: any): o is ApprovalRuleEventMetadata {
-    return _smithy.isa(o, "ApprovalRuleEventMetadata");
+    return __isa(o, "ApprovalRuleEventMetadata");
   }
 }
 
@@ -167,7 +170,7 @@ export namespace ApprovalRuleEventMetadata {
  *             within the scope of a pull request.</p>
  */
 export interface ApprovalRuleNameAlreadyExistsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ApprovalRuleNameAlreadyExistsException";
   $fault: "client";
@@ -179,7 +182,7 @@ export interface ApprovalRuleNameAlreadyExistsException
 
 export namespace ApprovalRuleNameAlreadyExistsException {
   export function isa(o: any): o is ApprovalRuleNameAlreadyExistsException {
-    return _smithy.isa(o, "ApprovalRuleNameAlreadyExistsException");
+    return __isa(o, "ApprovalRuleNameAlreadyExistsException");
   }
 }
 
@@ -187,7 +190,7 @@ export namespace ApprovalRuleNameAlreadyExistsException {
  * <p>An approval rule name is required, but was not specified.</p>
  */
 export interface ApprovalRuleNameRequiredException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ApprovalRuleNameRequiredException";
   $fault: "client";
@@ -199,7 +202,7 @@ export interface ApprovalRuleNameRequiredException
 
 export namespace ApprovalRuleNameRequiredException {
   export function isa(o: any): o is ApprovalRuleNameRequiredException {
-    return _smithy.isa(o, "ApprovalRuleNameRequiredException");
+    return __isa(o, "ApprovalRuleNameRequiredException");
   }
 }
 
@@ -221,7 +224,7 @@ export interface ApprovalRuleOverriddenEventMetadata {
 
 export namespace ApprovalRuleOverriddenEventMetadata {
   export function isa(o: any): o is ApprovalRuleOverriddenEventMetadata {
-    return _smithy.isa(o, "ApprovalRuleOverriddenEventMetadata");
+    return __isa(o, "ApprovalRuleOverriddenEventMetadata");
   }
 }
 
@@ -273,7 +276,7 @@ export interface ApprovalRuleTemplate {
 
 export namespace ApprovalRuleTemplate {
   export function isa(o: any): o is ApprovalRuleTemplate {
-    return _smithy.isa(o, "ApprovalRuleTemplate");
+    return __isa(o, "ApprovalRuleTemplate");
   }
 }
 
@@ -281,7 +284,7 @@ export namespace ApprovalRuleTemplate {
  * <p>The content for the approval rule template is empty. You must provide some content for an approval rule template. The content cannot be null.</p>
  */
 export interface ApprovalRuleTemplateContentRequiredException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ApprovalRuleTemplateContentRequiredException";
   $fault: "client";
@@ -295,7 +298,7 @@ export namespace ApprovalRuleTemplateContentRequiredException {
   export function isa(
     o: any
   ): o is ApprovalRuleTemplateContentRequiredException {
-    return _smithy.isa(o, "ApprovalRuleTemplateContentRequiredException");
+    return __isa(o, "ApprovalRuleTemplateContentRequiredException");
   }
 }
 
@@ -304,7 +307,7 @@ export namespace ApprovalRuleTemplateContentRequiredException {
  *         was created, and then try again.</p>
  */
 export interface ApprovalRuleTemplateDoesNotExistException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ApprovalRuleTemplateDoesNotExistException";
   $fault: "client";
@@ -316,7 +319,7 @@ export interface ApprovalRuleTemplateDoesNotExistException
 
 export namespace ApprovalRuleTemplateDoesNotExistException {
   export function isa(o: any): o is ApprovalRuleTemplateDoesNotExistException {
-    return _smithy.isa(o, "ApprovalRuleTemplateDoesNotExistException");
+    return __isa(o, "ApprovalRuleTemplateDoesNotExistException");
   }
 }
 
@@ -325,7 +328,7 @@ export namespace ApprovalRuleTemplateDoesNotExistException {
  *         all associations, and then try again.</p>
  */
 export interface ApprovalRuleTemplateInUseException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ApprovalRuleTemplateInUseException";
   $fault: "client";
@@ -337,7 +340,7 @@ export interface ApprovalRuleTemplateInUseException
 
 export namespace ApprovalRuleTemplateInUseException {
   export function isa(o: any): o is ApprovalRuleTemplateInUseException {
-    return _smithy.isa(o, "ApprovalRuleTemplateInUseException");
+    return __isa(o, "ApprovalRuleTemplateInUseException");
   }
 }
 
@@ -347,7 +350,7 @@ export namespace ApprovalRuleTemplateInUseException {
  *             names must be unique.</p>
  */
 export interface ApprovalRuleTemplateNameAlreadyExistsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ApprovalRuleTemplateNameAlreadyExistsException";
   $fault: "client";
@@ -361,7 +364,7 @@ export namespace ApprovalRuleTemplateNameAlreadyExistsException {
   export function isa(
     o: any
   ): o is ApprovalRuleTemplateNameAlreadyExistsException {
-    return _smithy.isa(o, "ApprovalRuleTemplateNameAlreadyExistsException");
+    return __isa(o, "ApprovalRuleTemplateNameAlreadyExistsException");
   }
 }
 
@@ -369,7 +372,7 @@ export namespace ApprovalRuleTemplateNameAlreadyExistsException {
  * <p>An approval rule template name is required, but was not specified.</p>
  */
 export interface ApprovalRuleTemplateNameRequiredException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ApprovalRuleTemplateNameRequiredException";
   $fault: "client";
@@ -381,7 +384,7 @@ export interface ApprovalRuleTemplateNameRequiredException
 
 export namespace ApprovalRuleTemplateNameRequiredException {
   export function isa(o: any): o is ApprovalRuleTemplateNameRequiredException {
-    return _smithy.isa(o, "ApprovalRuleTemplateNameRequiredException");
+    return __isa(o, "ApprovalRuleTemplateNameRequiredException");
   }
 }
 
@@ -408,7 +411,7 @@ export interface ApprovalStateChangedEventMetadata {
 
 export namespace ApprovalStateChangedEventMetadata {
   export function isa(o: any): o is ApprovalStateChangedEventMetadata {
-    return _smithy.isa(o, "ApprovalStateChangedEventMetadata");
+    return __isa(o, "ApprovalStateChangedEventMetadata");
   }
 }
 
@@ -416,7 +419,7 @@ export namespace ApprovalStateChangedEventMetadata {
  * <p>An approval state is required, but was not specified.</p>
  */
 export interface ApprovalStateRequiredException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ApprovalStateRequiredException";
   $fault: "client";
@@ -428,7 +431,7 @@ export interface ApprovalStateRequiredException
 
 export namespace ApprovalStateRequiredException {
   export function isa(o: any): o is ApprovalStateRequiredException {
-    return _smithy.isa(o, "ApprovalStateRequiredException");
+    return __isa(o, "ApprovalStateRequiredException");
   }
 }
 
@@ -449,7 +452,7 @@ export namespace AssociateApprovalRuleTemplateWithRepositoryInput {
   export function isa(
     o: any
   ): o is AssociateApprovalRuleTemplateWithRepositoryInput {
-    return _smithy.isa(o, "AssociateApprovalRuleTemplateWithRepositoryInput");
+    return __isa(o, "AssociateApprovalRuleTemplateWithRepositoryInput");
   }
 }
 
@@ -457,7 +460,7 @@ export namespace AssociateApprovalRuleTemplateWithRepositoryInput {
  * <p>The specified Amazon Resource Name (ARN) does not exist in the AWS account.</p>
  */
 export interface AuthorDoesNotExistException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AuthorDoesNotExistException";
   $fault: "client";
@@ -469,7 +472,7 @@ export interface AuthorDoesNotExistException
 
 export namespace AuthorDoesNotExistException {
   export function isa(o: any): o is AuthorDoesNotExistException {
-    return _smithy.isa(o, "AuthorDoesNotExistException");
+    return __isa(o, "AuthorDoesNotExistException");
   }
 }
 
@@ -498,10 +501,7 @@ export namespace BatchAssociateApprovalRuleTemplateWithRepositoriesError {
   export function isa(
     o: any
   ): o is BatchAssociateApprovalRuleTemplateWithRepositoriesError {
-    return _smithy.isa(
-      o,
-      "BatchAssociateApprovalRuleTemplateWithRepositoriesError"
-    );
+    return __isa(o, "BatchAssociateApprovalRuleTemplateWithRepositoriesError");
   }
 }
 
@@ -525,10 +525,7 @@ export namespace BatchAssociateApprovalRuleTemplateWithRepositoriesInput {
   export function isa(
     o: any
   ): o is BatchAssociateApprovalRuleTemplateWithRepositoriesInput {
-    return _smithy.isa(
-      o,
-      "BatchAssociateApprovalRuleTemplateWithRepositoriesInput"
-    );
+    return __isa(o, "BatchAssociateApprovalRuleTemplateWithRepositoriesInput");
   }
 }
 
@@ -552,10 +549,7 @@ export namespace BatchAssociateApprovalRuleTemplateWithRepositoriesOutput {
   export function isa(
     o: any
   ): o is BatchAssociateApprovalRuleTemplateWithRepositoriesOutput {
-    return _smithy.isa(
-      o,
-      "BatchAssociateApprovalRuleTemplateWithRepositoriesOutput"
-    );
+    return __isa(o, "BatchAssociateApprovalRuleTemplateWithRepositoriesOutput");
   }
 }
 
@@ -582,7 +576,7 @@ export interface BatchDescribeMergeConflictsError {
 
 export namespace BatchDescribeMergeConflictsError {
   export function isa(o: any): o is BatchDescribeMergeConflictsError {
-    return _smithy.isa(o, "BatchDescribeMergeConflictsError");
+    return __isa(o, "BatchDescribeMergeConflictsError");
   }
 }
 
@@ -649,7 +643,7 @@ export interface BatchDescribeMergeConflictsInput {
 
 export namespace BatchDescribeMergeConflictsInput {
   export function isa(o: any): o is BatchDescribeMergeConflictsInput {
-    return _smithy.isa(o, "BatchDescribeMergeConflictsInput");
+    return __isa(o, "BatchDescribeMergeConflictsInput");
   }
 }
 
@@ -688,7 +682,7 @@ export interface BatchDescribeMergeConflictsOutput extends $MetadataBearer {
 
 export namespace BatchDescribeMergeConflictsOutput {
   export function isa(o: any): o is BatchDescribeMergeConflictsOutput {
-    return _smithy.isa(o, "BatchDescribeMergeConflictsOutput");
+    return __isa(o, "BatchDescribeMergeConflictsOutput");
   }
 }
 
@@ -718,7 +712,7 @@ export namespace BatchDisassociateApprovalRuleTemplateFromRepositoriesError {
   export function isa(
     o: any
   ): o is BatchDisassociateApprovalRuleTemplateFromRepositoriesError {
-    return _smithy.isa(
+    return __isa(
       o,
       "BatchDisassociateApprovalRuleTemplateFromRepositoriesError"
     );
@@ -746,7 +740,7 @@ export namespace BatchDisassociateApprovalRuleTemplateFromRepositoriesInput {
   export function isa(
     o: any
   ): o is BatchDisassociateApprovalRuleTemplateFromRepositoriesInput {
-    return _smithy.isa(
+    return __isa(
       o,
       "BatchDisassociateApprovalRuleTemplateFromRepositoriesInput"
     );
@@ -774,7 +768,7 @@ export namespace BatchDisassociateApprovalRuleTemplateFromRepositoriesOutput {
   export function isa(
     o: any
   ): o is BatchDisassociateApprovalRuleTemplateFromRepositoriesOutput {
-    return _smithy.isa(
+    return __isa(
       o,
       "BatchDisassociateApprovalRuleTemplateFromRepositoriesOutput"
     );
@@ -804,7 +798,7 @@ export interface BatchGetCommitsError {
 
 export namespace BatchGetCommitsError {
   export function isa(o: any): o is BatchGetCommitsError {
-    return _smithy.isa(o, "BatchGetCommitsError");
+    return __isa(o, "BatchGetCommitsError");
   }
 }
 
@@ -827,7 +821,7 @@ export interface BatchGetCommitsInput {
 
 export namespace BatchGetCommitsInput {
   export function isa(o: any): o is BatchGetCommitsInput {
-    return _smithy.isa(o, "BatchGetCommitsInput");
+    return __isa(o, "BatchGetCommitsInput");
   }
 }
 
@@ -848,7 +842,7 @@ export interface BatchGetCommitsOutput extends $MetadataBearer {
 
 export namespace BatchGetCommitsOutput {
   export function isa(o: any): o is BatchGetCommitsOutput {
-    return _smithy.isa(o, "BatchGetCommitsOutput");
+    return __isa(o, "BatchGetCommitsOutput");
   }
 }
 
@@ -868,7 +862,7 @@ export interface BatchGetRepositoriesInput {
 
 export namespace BatchGetRepositoriesInput {
   export function isa(o: any): o is BatchGetRepositoriesInput {
-    return _smithy.isa(o, "BatchGetRepositoriesInput");
+    return __isa(o, "BatchGetRepositoriesInput");
   }
 }
 
@@ -890,7 +884,7 @@ export interface BatchGetRepositoriesOutput extends $MetadataBearer {
 
 export namespace BatchGetRepositoriesOutput {
   export function isa(o: any): o is BatchGetRepositoriesOutput {
-    return _smithy.isa(o, "BatchGetRepositoriesOutput");
+    return __isa(o, "BatchGetRepositoriesOutput");
   }
 }
 
@@ -898,7 +892,7 @@ export namespace BatchGetRepositoriesOutput {
  * <p>The before commit ID and the after commit ID are the same, which is not valid. The before commit ID and the after commit ID must be different commit IDs.</p>
  */
 export interface BeforeCommitIdAndAfterCommitIdAreSameException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "BeforeCommitIdAndAfterCommitIdAreSameException";
   $fault: "client";
@@ -912,7 +906,7 @@ export namespace BeforeCommitIdAndAfterCommitIdAreSameException {
   export function isa(
     o: any
   ): o is BeforeCommitIdAndAfterCommitIdAreSameException {
-    return _smithy.isa(o, "BeforeCommitIdAndAfterCommitIdAreSameException");
+    return __isa(o, "BeforeCommitIdAndAfterCommitIdAreSameException");
   }
 }
 
@@ -920,7 +914,7 @@ export namespace BeforeCommitIdAndAfterCommitIdAreSameException {
  * <p>The specified blob does not exist.</p>
  */
 export interface BlobIdDoesNotExistException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "BlobIdDoesNotExistException";
   $fault: "client";
@@ -932,7 +926,7 @@ export interface BlobIdDoesNotExistException
 
 export namespace BlobIdDoesNotExistException {
   export function isa(o: any): o is BlobIdDoesNotExistException {
-    return _smithy.isa(o, "BlobIdDoesNotExistException");
+    return __isa(o, "BlobIdDoesNotExistException");
   }
 }
 
@@ -940,7 +934,7 @@ export namespace BlobIdDoesNotExistException {
  * <p>A blob ID is required, but was not specified.</p>
  */
 export interface BlobIdRequiredException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "BlobIdRequiredException";
   $fault: "client";
@@ -952,7 +946,7 @@ export interface BlobIdRequiredException
 
 export namespace BlobIdRequiredException {
   export function isa(o: any): o is BlobIdRequiredException {
-    return _smithy.isa(o, "BlobIdRequiredException");
+    return __isa(o, "BlobIdRequiredException");
   }
 }
 
@@ -997,7 +991,7 @@ export interface BlobMetadata {
 
 export namespace BlobMetadata {
   export function isa(o: any): o is BlobMetadata {
-    return _smithy.isa(o, "BlobMetadata");
+    return __isa(o, "BlobMetadata");
   }
 }
 
@@ -1005,7 +999,7 @@ export namespace BlobMetadata {
  * <p>The specified branch does not exist.</p>
  */
 export interface BranchDoesNotExistException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "BranchDoesNotExistException";
   $fault: "client";
@@ -1017,7 +1011,7 @@ export interface BranchDoesNotExistException
 
 export namespace BranchDoesNotExistException {
   export function isa(o: any): o is BranchDoesNotExistException {
-    return _smithy.isa(o, "BranchDoesNotExistException");
+    return __isa(o, "BranchDoesNotExistException");
   }
 }
 
@@ -1039,7 +1033,7 @@ export interface BranchInfo {
 
 export namespace BranchInfo {
   export function isa(o: any): o is BranchInfo {
-    return _smithy.isa(o, "BranchInfo");
+    return __isa(o, "BranchInfo");
   }
 }
 
@@ -1047,7 +1041,7 @@ export namespace BranchInfo {
  * <p>The specified branch name already exists.</p>
  */
 export interface BranchNameExistsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "BranchNameExistsException";
   $fault: "client";
@@ -1059,7 +1053,7 @@ export interface BranchNameExistsException
 
 export namespace BranchNameExistsException {
   export function isa(o: any): o is BranchNameExistsException {
-    return _smithy.isa(o, "BranchNameExistsException");
+    return __isa(o, "BranchNameExistsException");
   }
 }
 
@@ -1068,7 +1062,7 @@ export namespace BranchNameExistsException {
  *             branch in the repository. For a list of valid branch names, use <a>ListBranches</a>.</p>
  */
 export interface BranchNameIsTagNameException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "BranchNameIsTagNameException";
   $fault: "client";
@@ -1080,7 +1074,7 @@ export interface BranchNameIsTagNameException
 
 export namespace BranchNameIsTagNameException {
   export function isa(o: any): o is BranchNameIsTagNameException {
-    return _smithy.isa(o, "BranchNameIsTagNameException");
+    return __isa(o, "BranchNameIsTagNameException");
   }
 }
 
@@ -1088,7 +1082,7 @@ export namespace BranchNameIsTagNameException {
  * <p>A branch name is required, but was not specified.</p>
  */
 export interface BranchNameRequiredException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "BranchNameRequiredException";
   $fault: "client";
@@ -1100,7 +1094,7 @@ export interface BranchNameRequiredException
 
 export namespace BranchNameRequiredException {
   export function isa(o: any): o is BranchNameRequiredException {
-    return _smithy.isa(o, "BranchNameRequiredException");
+    return __isa(o, "BranchNameRequiredException");
   }
 }
 
@@ -1109,7 +1103,7 @@ export namespace BranchNameRequiredException {
  *             approval rule template and applied to the pull request automatically.</p>
  */
 export interface CannotDeleteApprovalRuleFromTemplateException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CannotDeleteApprovalRuleFromTemplateException";
   $fault: "client";
@@ -1123,7 +1117,7 @@ export namespace CannotDeleteApprovalRuleFromTemplateException {
   export function isa(
     o: any
   ): o is CannotDeleteApprovalRuleFromTemplateException {
-    return _smithy.isa(o, "CannotDeleteApprovalRuleFromTemplateException");
+    return __isa(o, "CannotDeleteApprovalRuleFromTemplateException");
   }
 }
 
@@ -1132,7 +1126,7 @@ export namespace CannotDeleteApprovalRuleFromTemplateException {
  *             approval rule template and applied to the pull request automatically.</p>
  */
 export interface CannotModifyApprovalRuleFromTemplateException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CannotModifyApprovalRuleFromTemplateException";
   $fault: "client";
@@ -1146,7 +1140,7 @@ export namespace CannotModifyApprovalRuleFromTemplateException {
   export function isa(
     o: any
   ): o is CannotModifyApprovalRuleFromTemplateException {
-    return _smithy.isa(o, "CannotModifyApprovalRuleFromTemplateException");
+    return __isa(o, "CannotModifyApprovalRuleFromTemplateException");
   }
 }
 
@@ -1164,7 +1158,7 @@ export enum ChangeTypeEnum {
  *             request that used that token.</p>
  */
 export interface ClientRequestTokenRequiredException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ClientRequestTokenRequiredException";
   $fault: "client";
@@ -1176,7 +1170,7 @@ export interface ClientRequestTokenRequiredException
 
 export namespace ClientRequestTokenRequiredException {
   export function isa(o: any): o is ClientRequestTokenRequiredException {
-    return _smithy.isa(o, "ClientRequestTokenRequiredException");
+    return __isa(o, "ClientRequestTokenRequiredException");
   }
 }
 
@@ -1231,7 +1225,7 @@ export interface Comment {
 
 export namespace Comment {
   export function isa(o: any): o is Comment {
-    return _smithy.isa(o, "Comment");
+    return __isa(o, "Comment");
   }
 }
 
@@ -1239,7 +1233,7 @@ export namespace Comment {
  * <p>The comment is empty. You must provide some content for a comment. The content cannot be null.</p>
  */
 export interface CommentContentRequiredException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CommentContentRequiredException";
   $fault: "client";
@@ -1251,7 +1245,7 @@ export interface CommentContentRequiredException
 
 export namespace CommentContentRequiredException {
   export function isa(o: any): o is CommentContentRequiredException {
-    return _smithy.isa(o, "CommentContentRequiredException");
+    return __isa(o, "CommentContentRequiredException");
   }
 }
 
@@ -1259,7 +1253,7 @@ export namespace CommentContentRequiredException {
  * <p>The comment is too large. Comments are limited to 1,000 characters.</p>
  */
 export interface CommentContentSizeLimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CommentContentSizeLimitExceededException";
   $fault: "client";
@@ -1271,7 +1265,7 @@ export interface CommentContentSizeLimitExceededException
 
 export namespace CommentContentSizeLimitExceededException {
   export function isa(o: any): o is CommentContentSizeLimitExceededException {
-    return _smithy.isa(o, "CommentContentSizeLimitExceededException");
+    return __isa(o, "CommentContentSizeLimitExceededException");
   }
 }
 
@@ -1279,7 +1273,7 @@ export namespace CommentContentSizeLimitExceededException {
  * <p>This comment has already been deleted. You cannot edit or delete a deleted comment.</p>
  */
 export interface CommentDeletedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CommentDeletedException";
   $fault: "client";
@@ -1291,7 +1285,7 @@ export interface CommentDeletedException
 
 export namespace CommentDeletedException {
   export function isa(o: any): o is CommentDeletedException {
-    return _smithy.isa(o, "CommentDeletedException");
+    return __isa(o, "CommentDeletedException");
   }
 }
 
@@ -1300,7 +1294,7 @@ export namespace CommentDeletedException {
  *             then try again.</p>
  */
 export interface CommentDoesNotExistException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CommentDoesNotExistException";
   $fault: "client";
@@ -1312,7 +1306,7 @@ export interface CommentDoesNotExistException
 
 export namespace CommentDoesNotExistException {
   export function isa(o: any): o is CommentDoesNotExistException {
-    return _smithy.isa(o, "CommentDoesNotExistException");
+    return __isa(o, "CommentDoesNotExistException");
   }
 }
 
@@ -1320,7 +1314,7 @@ export namespace CommentDoesNotExistException {
  * <p>The comment ID is missing or null. A comment ID is required.</p>
  */
 export interface CommentIdRequiredException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CommentIdRequiredException";
   $fault: "client";
@@ -1332,7 +1326,7 @@ export interface CommentIdRequiredException
 
 export namespace CommentIdRequiredException {
   export function isa(o: any): o is CommentIdRequiredException {
-    return _smithy.isa(o, "CommentIdRequiredException");
+    return __isa(o, "CommentIdRequiredException");
   }
 }
 
@@ -1340,7 +1334,7 @@ export namespace CommentIdRequiredException {
  * <p>You cannot modify or delete this comment. Only comment authors can modify or delete their comments.</p>
  */
 export interface CommentNotCreatedByCallerException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CommentNotCreatedByCallerException";
   $fault: "client";
@@ -1352,7 +1346,7 @@ export interface CommentNotCreatedByCallerException
 
 export namespace CommentNotCreatedByCallerException {
   export function isa(o: any): o is CommentNotCreatedByCallerException {
-    return _smithy.isa(o, "CommentNotCreatedByCallerException");
+    return __isa(o, "CommentNotCreatedByCallerException");
   }
 }
 
@@ -1403,7 +1397,7 @@ export interface CommentsForComparedCommit {
 
 export namespace CommentsForComparedCommit {
   export function isa(o: any): o is CommentsForComparedCommit {
-    return _smithy.isa(o, "CommentsForComparedCommit");
+    return __isa(o, "CommentsForComparedCommit");
   }
 }
 
@@ -1460,7 +1454,7 @@ export interface CommentsForPullRequest {
 
 export namespace CommentsForPullRequest {
   export function isa(o: any): o is CommentsForPullRequest {
-    return _smithy.isa(o, "CommentsForPullRequest");
+    return __isa(o, "CommentsForPullRequest");
   }
 }
 
@@ -1514,7 +1508,7 @@ export interface Commit {
 
 export namespace Commit {
   export function isa(o: any): o is Commit {
-    return _smithy.isa(o, "Commit");
+    return __isa(o, "Commit");
   }
 }
 
@@ -1522,7 +1516,7 @@ export namespace Commit {
  * <p>The specified commit does not exist or no commit was specified, and the specified repository has no default branch.</p>
  */
 export interface CommitDoesNotExistException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CommitDoesNotExistException";
   $fault: "client";
@@ -1534,7 +1528,7 @@ export interface CommitDoesNotExistException
 
 export namespace CommitDoesNotExistException {
   export function isa(o: any): o is CommitDoesNotExistException {
-    return _smithy.isa(o, "CommitDoesNotExistException");
+    return __isa(o, "CommitDoesNotExistException");
   }
 }
 
@@ -1542,7 +1536,7 @@ export namespace CommitDoesNotExistException {
  * <p>The specified commit ID does not exist.</p>
  */
 export interface CommitIdDoesNotExistException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CommitIdDoesNotExistException";
   $fault: "client";
@@ -1554,7 +1548,7 @@ export interface CommitIdDoesNotExistException
 
 export namespace CommitIdDoesNotExistException {
   export function isa(o: any): o is CommitIdDoesNotExistException {
-    return _smithy.isa(o, "CommitIdDoesNotExistException");
+    return __isa(o, "CommitIdDoesNotExistException");
   }
 }
 
@@ -1562,7 +1556,7 @@ export namespace CommitIdDoesNotExistException {
  * <p>A commit ID was not specified.</p>
  */
 export interface CommitIdRequiredException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CommitIdRequiredException";
   $fault: "client";
@@ -1574,7 +1568,7 @@ export interface CommitIdRequiredException
 
 export namespace CommitIdRequiredException {
   export function isa(o: any): o is CommitIdRequiredException {
-    return _smithy.isa(o, "CommitIdRequiredException");
+    return __isa(o, "CommitIdRequiredException");
   }
 }
 
@@ -1582,7 +1576,7 @@ export namespace CommitIdRequiredException {
  * <p>The maximum number of allowed commit IDs in a batch request is 100. Verify that your batch requests contains no more than 100 commit IDs, and then try again.</p>
  */
 export interface CommitIdsLimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CommitIdsLimitExceededException";
   $fault: "client";
@@ -1594,7 +1588,7 @@ export interface CommitIdsLimitExceededException
 
 export namespace CommitIdsLimitExceededException {
   export function isa(o: any): o is CommitIdsLimitExceededException {
-    return _smithy.isa(o, "CommitIdsLimitExceededException");
+    return __isa(o, "CommitIdsLimitExceededException");
   }
 }
 
@@ -1602,7 +1596,7 @@ export namespace CommitIdsLimitExceededException {
  * <p>A list of commit IDs is required, but was either not specified or the list was empty.</p>
  */
 export interface CommitIdsListRequiredException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CommitIdsListRequiredException";
   $fault: "client";
@@ -1614,7 +1608,7 @@ export interface CommitIdsListRequiredException
 
 export namespace CommitIdsListRequiredException {
   export function isa(o: any): o is CommitIdsListRequiredException {
-    return _smithy.isa(o, "CommitIdsListRequiredException");
+    return __isa(o, "CommitIdsListRequiredException");
   }
 }
 
@@ -1622,7 +1616,7 @@ export namespace CommitIdsListRequiredException {
  * <p>The commit message is too long. Provide a shorter string. </p>
  */
 export interface CommitMessageLengthExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CommitMessageLengthExceededException";
   $fault: "client";
@@ -1634,7 +1628,7 @@ export interface CommitMessageLengthExceededException
 
 export namespace CommitMessageLengthExceededException {
   export function isa(o: any): o is CommitMessageLengthExceededException {
-    return _smithy.isa(o, "CommitMessageLengthExceededException");
+    return __isa(o, "CommitMessageLengthExceededException");
   }
 }
 
@@ -1642,7 +1636,7 @@ export namespace CommitMessageLengthExceededException {
  * <p>A commit was not specified.</p>
  */
 export interface CommitRequiredException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CommitRequiredException";
   $fault: "client";
@@ -1654,7 +1648,7 @@ export interface CommitRequiredException
 
 export namespace CommitRequiredException {
   export function isa(o: any): o is CommitRequiredException {
-    return _smithy.isa(o, "CommitRequiredException");
+    return __isa(o, "CommitRequiredException");
   }
 }
 
@@ -1662,7 +1656,7 @@ export namespace CommitRequiredException {
  * <p>The merge cannot be completed because the target branch has been modified. Another user might have modified the target branch while the merge was in progress. Wait a few minutes, and then try again.</p>
  */
 export interface ConcurrentReferenceUpdateException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ConcurrentReferenceUpdateException";
   $fault: "client";
@@ -1674,7 +1668,7 @@ export interface ConcurrentReferenceUpdateException
 
 export namespace ConcurrentReferenceUpdateException {
   export function isa(o: any): o is ConcurrentReferenceUpdateException {
-    return _smithy.isa(o, "ConcurrentReferenceUpdateException");
+    return __isa(o, "ConcurrentReferenceUpdateException");
   }
 }
 
@@ -1696,7 +1690,7 @@ export interface Conflict {
 
 export namespace Conflict {
   export function isa(o: any): o is Conflict {
-    return _smithy.isa(o, "Conflict");
+    return __isa(o, "Conflict");
   }
 }
 
@@ -1763,7 +1757,7 @@ export interface ConflictMetadata {
 
 export namespace ConflictMetadata {
   export function isa(o: any): o is ConflictMetadata {
-    return _smithy.isa(o, "ConflictMetadata");
+    return __isa(o, "ConflictMetadata");
   }
 }
 
@@ -1791,7 +1785,7 @@ export interface ConflictResolution {
 
 export namespace ConflictResolution {
   export function isa(o: any): o is ConflictResolution {
-    return _smithy.isa(o, "ConflictResolution");
+    return __isa(o, "ConflictResolution");
   }
 }
 
@@ -1869,7 +1863,7 @@ export interface CreateApprovalRuleTemplateInput {
 
 export namespace CreateApprovalRuleTemplateInput {
   export function isa(o: any): o is CreateApprovalRuleTemplateInput {
-    return _smithy.isa(o, "CreateApprovalRuleTemplateInput");
+    return __isa(o, "CreateApprovalRuleTemplateInput");
   }
 }
 
@@ -1883,7 +1877,7 @@ export interface CreateApprovalRuleTemplateOutput extends $MetadataBearer {
 
 export namespace CreateApprovalRuleTemplateOutput {
   export function isa(o: any): o is CreateApprovalRuleTemplateOutput {
-    return _smithy.isa(o, "CreateApprovalRuleTemplateOutput");
+    return __isa(o, "CreateApprovalRuleTemplateOutput");
   }
 }
 
@@ -1910,7 +1904,7 @@ export interface CreateBranchInput {
 
 export namespace CreateBranchInput {
   export function isa(o: any): o is CreateBranchInput {
-    return _smithy.isa(o, "CreateBranchInput");
+    return __isa(o, "CreateBranchInput");
   }
 }
 
@@ -1974,7 +1968,7 @@ export interface CreateCommitInput {
 
 export namespace CreateCommitInput {
   export function isa(o: any): o is CreateCommitInput {
-    return _smithy.isa(o, "CreateCommitInput");
+    return __isa(o, "CreateCommitInput");
   }
 }
 
@@ -2008,7 +2002,7 @@ export interface CreateCommitOutput extends $MetadataBearer {
 
 export namespace CreateCommitOutput {
   export function isa(o: any): o is CreateCommitOutput {
-    return _smithy.isa(o, "CreateCommitOutput");
+    return __isa(o, "CreateCommitOutput");
   }
 }
 
@@ -2074,7 +2068,7 @@ export interface CreatePullRequestApprovalRuleInput {
 
 export namespace CreatePullRequestApprovalRuleInput {
   export function isa(o: any): o is CreatePullRequestApprovalRuleInput {
-    return _smithy.isa(o, "CreatePullRequestApprovalRuleInput");
+    return __isa(o, "CreatePullRequestApprovalRuleInput");
   }
 }
 
@@ -2088,7 +2082,7 @@ export interface CreatePullRequestApprovalRuleOutput extends $MetadataBearer {
 
 export namespace CreatePullRequestApprovalRuleOutput {
   export function isa(o: any): o is CreatePullRequestApprovalRuleOutput {
-    return _smithy.isa(o, "CreatePullRequestApprovalRuleOutput");
+    return __isa(o, "CreatePullRequestApprovalRuleOutput");
   }
 }
 
@@ -2127,7 +2121,7 @@ export interface CreatePullRequestInput {
 
 export namespace CreatePullRequestInput {
   export function isa(o: any): o is CreatePullRequestInput {
-    return _smithy.isa(o, "CreatePullRequestInput");
+    return __isa(o, "CreatePullRequestInput");
   }
 }
 
@@ -2141,7 +2135,7 @@ export interface CreatePullRequestOutput extends $MetadataBearer {
 
 export namespace CreatePullRequestOutput {
   export function isa(o: any): o is CreatePullRequestOutput {
-    return _smithy.isa(o, "CreatePullRequestOutput");
+    return __isa(o, "CreatePullRequestOutput");
   }
 }
 
@@ -2182,7 +2176,7 @@ export interface CreateRepositoryInput {
 
 export namespace CreateRepositoryInput {
   export function isa(o: any): o is CreateRepositoryInput {
-    return _smithy.isa(o, "CreateRepositoryInput");
+    return __isa(o, "CreateRepositoryInput");
   }
 }
 
@@ -2199,7 +2193,7 @@ export interface CreateRepositoryOutput extends $MetadataBearer {
 
 export namespace CreateRepositoryOutput {
   export function isa(o: any): o is CreateRepositoryOutput {
-    return _smithy.isa(o, "CreateRepositoryOutput");
+    return __isa(o, "CreateRepositoryOutput");
   }
 }
 
@@ -2274,7 +2268,7 @@ export interface CreateUnreferencedMergeCommitInput {
 
 export namespace CreateUnreferencedMergeCommitInput {
   export function isa(o: any): o is CreateUnreferencedMergeCommitInput {
-    return _smithy.isa(o, "CreateUnreferencedMergeCommitInput");
+    return __isa(o, "CreateUnreferencedMergeCommitInput");
   }
 }
 
@@ -2293,7 +2287,7 @@ export interface CreateUnreferencedMergeCommitOutput extends $MetadataBearer {
 
 export namespace CreateUnreferencedMergeCommitOutput {
   export function isa(o: any): o is CreateUnreferencedMergeCommitOutput {
-    return _smithy.isa(o, "CreateUnreferencedMergeCommitOutput");
+    return __isa(o, "CreateUnreferencedMergeCommitOutput");
   }
 }
 
@@ -2301,7 +2295,7 @@ export namespace CreateUnreferencedMergeCommitOutput {
  * <p>The specified branch is the default branch for the repository, and cannot be deleted. To delete this branch, you must first set another branch as the default branch.</p>
  */
 export interface DefaultBranchCannotBeDeletedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DefaultBranchCannotBeDeletedException";
   $fault: "client";
@@ -2313,7 +2307,7 @@ export interface DefaultBranchCannotBeDeletedException
 
 export namespace DefaultBranchCannotBeDeletedException {
   export function isa(o: any): o is DefaultBranchCannotBeDeletedException {
-    return _smithy.isa(o, "DefaultBranchCannotBeDeletedException");
+    return __isa(o, "DefaultBranchCannotBeDeletedException");
   }
 }
 
@@ -2327,7 +2321,7 @@ export interface DeleteApprovalRuleTemplateInput {
 
 export namespace DeleteApprovalRuleTemplateInput {
   export function isa(o: any): o is DeleteApprovalRuleTemplateInput {
-    return _smithy.isa(o, "DeleteApprovalRuleTemplateInput");
+    return __isa(o, "DeleteApprovalRuleTemplateInput");
   }
 }
 
@@ -2342,7 +2336,7 @@ export interface DeleteApprovalRuleTemplateOutput extends $MetadataBearer {
 
 export namespace DeleteApprovalRuleTemplateOutput {
   export function isa(o: any): o is DeleteApprovalRuleTemplateOutput {
-    return _smithy.isa(o, "DeleteApprovalRuleTemplateOutput");
+    return __isa(o, "DeleteApprovalRuleTemplateOutput");
   }
 }
 
@@ -2364,7 +2358,7 @@ export interface DeleteBranchInput {
 
 export namespace DeleteBranchInput {
   export function isa(o: any): o is DeleteBranchInput {
-    return _smithy.isa(o, "DeleteBranchInput");
+    return __isa(o, "DeleteBranchInput");
   }
 }
 
@@ -2381,7 +2375,7 @@ export interface DeleteBranchOutput extends $MetadataBearer {
 
 export namespace DeleteBranchOutput {
   export function isa(o: any): o is DeleteBranchOutput {
-    return _smithy.isa(o, "DeleteBranchOutput");
+    return __isa(o, "DeleteBranchOutput");
   }
 }
 
@@ -2396,7 +2390,7 @@ export interface DeleteCommentContentInput {
 
 export namespace DeleteCommentContentInput {
   export function isa(o: any): o is DeleteCommentContentInput {
-    return _smithy.isa(o, "DeleteCommentContentInput");
+    return __isa(o, "DeleteCommentContentInput");
   }
 }
 
@@ -2410,7 +2404,7 @@ export interface DeleteCommentContentOutput extends $MetadataBearer {
 
 export namespace DeleteCommentContentOutput {
   export function isa(o: any): o is DeleteCommentContentOutput {
-    return _smithy.isa(o, "DeleteCommentContentOutput");
+    return __isa(o, "DeleteCommentContentOutput");
   }
 }
 
@@ -2427,7 +2421,7 @@ export interface DeleteFileEntry {
 
 export namespace DeleteFileEntry {
   export function isa(o: any): o is DeleteFileEntry {
-    return _smithy.isa(o, "DeleteFileEntry");
+    return __isa(o, "DeleteFileEntry");
   }
 }
 
@@ -2487,7 +2481,7 @@ export interface DeleteFileInput {
 
 export namespace DeleteFileInput {
   export function isa(o: any): o is DeleteFileInput {
-    return _smithy.isa(o, "DeleteFileInput");
+    return __isa(o, "DeleteFileInput");
   }
 }
 
@@ -2517,7 +2511,7 @@ export interface DeleteFileOutput extends $MetadataBearer {
 
 export namespace DeleteFileOutput {
   export function isa(o: any): o is DeleteFileOutput {
-    return _smithy.isa(o, "DeleteFileOutput");
+    return __isa(o, "DeleteFileOutput");
   }
 }
 
@@ -2536,7 +2530,7 @@ export interface DeletePullRequestApprovalRuleInput {
 
 export namespace DeletePullRequestApprovalRuleInput {
   export function isa(o: any): o is DeletePullRequestApprovalRuleInput {
-    return _smithy.isa(o, "DeletePullRequestApprovalRuleInput");
+    return __isa(o, "DeletePullRequestApprovalRuleInput");
   }
 }
 
@@ -2554,7 +2548,7 @@ export interface DeletePullRequestApprovalRuleOutput extends $MetadataBearer {
 
 export namespace DeletePullRequestApprovalRuleOutput {
   export function isa(o: any): o is DeletePullRequestApprovalRuleOutput {
-    return _smithy.isa(o, "DeletePullRequestApprovalRuleOutput");
+    return __isa(o, "DeletePullRequestApprovalRuleOutput");
   }
 }
 
@@ -2571,7 +2565,7 @@ export interface DeleteRepositoryInput {
 
 export namespace DeleteRepositoryInput {
   export function isa(o: any): o is DeleteRepositoryInput {
-    return _smithy.isa(o, "DeleteRepositoryInput");
+    return __isa(o, "DeleteRepositoryInput");
   }
 }
 
@@ -2588,7 +2582,7 @@ export interface DeleteRepositoryOutput extends $MetadataBearer {
 
 export namespace DeleteRepositoryOutput {
   export function isa(o: any): o is DeleteRepositoryOutput {
-    return _smithy.isa(o, "DeleteRepositoryOutput");
+    return __isa(o, "DeleteRepositoryOutput");
   }
 }
 
@@ -2650,7 +2644,7 @@ export interface DescribeMergeConflictsInput {
 
 export namespace DescribeMergeConflictsInput {
   export function isa(o: any): o is DescribeMergeConflictsInput {
-    return _smithy.isa(o, "DescribeMergeConflictsInput");
+    return __isa(o, "DescribeMergeConflictsInput");
   }
 }
 
@@ -2689,7 +2683,7 @@ export interface DescribeMergeConflictsOutput extends $MetadataBearer {
 
 export namespace DescribeMergeConflictsOutput {
   export function isa(o: any): o is DescribeMergeConflictsOutput {
-    return _smithy.isa(o, "DescribeMergeConflictsOutput");
+    return __isa(o, "DescribeMergeConflictsOutput");
   }
 }
 
@@ -2727,7 +2721,7 @@ export interface DescribePullRequestEventsInput {
 
 export namespace DescribePullRequestEventsInput {
   export function isa(o: any): o is DescribePullRequestEventsInput {
-    return _smithy.isa(o, "DescribePullRequestEventsInput");
+    return __isa(o, "DescribePullRequestEventsInput");
   }
 }
 
@@ -2746,7 +2740,7 @@ export interface DescribePullRequestEventsOutput extends $MetadataBearer {
 
 export namespace DescribePullRequestEventsOutput {
   export function isa(o: any): o is DescribePullRequestEventsOutput {
-    return _smithy.isa(o, "DescribePullRequestEventsOutput");
+    return __isa(o, "DescribePullRequestEventsOutput");
   }
 }
 
@@ -2775,7 +2769,7 @@ export interface Difference {
 
 export namespace Difference {
   export function isa(o: any): o is Difference {
-    return _smithy.isa(o, "Difference");
+    return __isa(o, "Difference");
   }
 }
 
@@ -2784,7 +2778,7 @@ export namespace Difference {
  *         Either provide a different name for the file, or specify a different path for the file.</p>
  */
 export interface DirectoryNameConflictsWithFileNameException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DirectoryNameConflictsWithFileNameException";
   $fault: "client";
@@ -2798,7 +2792,7 @@ export namespace DirectoryNameConflictsWithFileNameException {
   export function isa(
     o: any
   ): o is DirectoryNameConflictsWithFileNameException {
-    return _smithy.isa(o, "DirectoryNameConflictsWithFileNameException");
+    return __isa(o, "DirectoryNameConflictsWithFileNameException");
   }
 }
 
@@ -2819,10 +2813,7 @@ export namespace DisassociateApprovalRuleTemplateFromRepositoryInput {
   export function isa(
     o: any
   ): o is DisassociateApprovalRuleTemplateFromRepositoryInput {
-    return _smithy.isa(
-      o,
-      "DisassociateApprovalRuleTemplateFromRepositoryInput"
-    );
+    return __isa(o, "DisassociateApprovalRuleTemplateFromRepositoryInput");
   }
 }
 
@@ -2830,7 +2821,7 @@ export namespace DisassociateApprovalRuleTemplateFromRepositoryInput {
  * <p>An encryption integrity check failed.</p>
  */
 export interface EncryptionIntegrityChecksFailedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "EncryptionIntegrityChecksFailedException";
   $fault: "server";
@@ -2842,7 +2833,7 @@ export interface EncryptionIntegrityChecksFailedException
 
 export namespace EncryptionIntegrityChecksFailedException {
   export function isa(o: any): o is EncryptionIntegrityChecksFailedException {
-    return _smithy.isa(o, "EncryptionIntegrityChecksFailedException");
+    return __isa(o, "EncryptionIntegrityChecksFailedException");
   }
 }
 
@@ -2850,7 +2841,7 @@ export namespace EncryptionIntegrityChecksFailedException {
  * <p>An encryption key could not be accessed.</p>
  */
 export interface EncryptionKeyAccessDeniedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "EncryptionKeyAccessDeniedException";
   $fault: "client";
@@ -2862,7 +2853,7 @@ export interface EncryptionKeyAccessDeniedException
 
 export namespace EncryptionKeyAccessDeniedException {
   export function isa(o: any): o is EncryptionKeyAccessDeniedException {
-    return _smithy.isa(o, "EncryptionKeyAccessDeniedException");
+    return __isa(o, "EncryptionKeyAccessDeniedException");
   }
 }
 
@@ -2870,7 +2861,7 @@ export namespace EncryptionKeyAccessDeniedException {
  * <p>The encryption key is disabled.</p>
  */
 export interface EncryptionKeyDisabledException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "EncryptionKeyDisabledException";
   $fault: "client";
@@ -2882,7 +2873,7 @@ export interface EncryptionKeyDisabledException
 
 export namespace EncryptionKeyDisabledException {
   export function isa(o: any): o is EncryptionKeyDisabledException {
-    return _smithy.isa(o, "EncryptionKeyDisabledException");
+    return __isa(o, "EncryptionKeyDisabledException");
   }
 }
 
@@ -2890,7 +2881,7 @@ export namespace EncryptionKeyDisabledException {
  * <p>No encryption key was found.</p>
  */
 export interface EncryptionKeyNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "EncryptionKeyNotFoundException";
   $fault: "client";
@@ -2902,7 +2893,7 @@ export interface EncryptionKeyNotFoundException
 
 export namespace EncryptionKeyNotFoundException {
   export function isa(o: any): o is EncryptionKeyNotFoundException {
-    return _smithy.isa(o, "EncryptionKeyNotFoundException");
+    return __isa(o, "EncryptionKeyNotFoundException");
   }
 }
 
@@ -2910,7 +2901,7 @@ export namespace EncryptionKeyNotFoundException {
  * <p>The encryption key is not available.</p>
  */
 export interface EncryptionKeyUnavailableException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "EncryptionKeyUnavailableException";
   $fault: "client";
@@ -2922,7 +2913,7 @@ export interface EncryptionKeyUnavailableException
 
 export namespace EncryptionKeyUnavailableException {
   export function isa(o: any): o is EncryptionKeyUnavailableException {
-    return _smithy.isa(o, "EncryptionKeyUnavailableException");
+    return __isa(o, "EncryptionKeyUnavailableException");
   }
 }
 
@@ -2943,7 +2934,7 @@ export interface EvaluatePullRequestApprovalRulesInput {
 
 export namespace EvaluatePullRequestApprovalRulesInput {
   export function isa(o: any): o is EvaluatePullRequestApprovalRulesInput {
-    return _smithy.isa(o, "EvaluatePullRequestApprovalRulesInput");
+    return __isa(o, "EvaluatePullRequestApprovalRulesInput");
   }
 }
 
@@ -2959,7 +2950,7 @@ export interface EvaluatePullRequestApprovalRulesOutput
 
 export namespace EvaluatePullRequestApprovalRulesOutput {
   export function isa(o: any): o is EvaluatePullRequestApprovalRulesOutput {
-    return _smithy.isa(o, "EvaluatePullRequestApprovalRulesOutput");
+    return __isa(o, "EvaluatePullRequestApprovalRulesOutput");
   }
 }
 
@@ -2991,7 +2982,7 @@ export interface Evaluation {
 
 export namespace Evaluation {
   export function isa(o: any): o is Evaluation {
-    return _smithy.isa(o, "Evaluation");
+    return __isa(o, "Evaluation");
   }
 }
 
@@ -3023,7 +3014,7 @@ export interface File {
 
 export namespace File {
   export function isa(o: any): o is File {
-    return _smithy.isa(o, "File");
+    return __isa(o, "File");
   }
 }
 
@@ -3033,7 +3024,7 @@ export namespace File {
  *             provide the file content directly.</p>
  */
 export interface FileContentAndSourceFileSpecifiedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "FileContentAndSourceFileSpecifiedException";
   $fault: "client";
@@ -3045,7 +3036,7 @@ export interface FileContentAndSourceFileSpecifiedException
 
 export namespace FileContentAndSourceFileSpecifiedException {
   export function isa(o: any): o is FileContentAndSourceFileSpecifiedException {
-    return _smithy.isa(o, "FileContentAndSourceFileSpecifiedException");
+    return __isa(o, "FileContentAndSourceFileSpecifiedException");
   }
 }
 
@@ -3053,7 +3044,7 @@ export namespace FileContentAndSourceFileSpecifiedException {
  * <p>The file cannot be added because it is empty. Empty files cannot be added to the repository with this API.</p>
  */
 export interface FileContentRequiredException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "FileContentRequiredException";
   $fault: "client";
@@ -3065,7 +3056,7 @@ export interface FileContentRequiredException
 
 export namespace FileContentRequiredException {
   export function isa(o: any): o is FileContentRequiredException {
-    return _smithy.isa(o, "FileContentRequiredException");
+    return __isa(o, "FileContentRequiredException");
   }
 }
 
@@ -3075,7 +3066,7 @@ export namespace FileContentRequiredException {
  *             client.</p>
  */
 export interface FileContentSizeLimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "FileContentSizeLimitExceededException";
   $fault: "client";
@@ -3087,7 +3078,7 @@ export interface FileContentSizeLimitExceededException
 
 export namespace FileContentSizeLimitExceededException {
   export function isa(o: any): o is FileContentSizeLimitExceededException {
-    return _smithy.isa(o, "FileContentSizeLimitExceededException");
+    return __isa(o, "FileContentSizeLimitExceededException");
   }
 }
 
@@ -3096,7 +3087,7 @@ export namespace FileContentSizeLimitExceededException {
  *             full path, and extension.</p>
  */
 export interface FileDoesNotExistException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "FileDoesNotExistException";
   $fault: "client";
@@ -3108,7 +3099,7 @@ export interface FileDoesNotExistException
 
 export namespace FileDoesNotExistException {
   export function isa(o: any): o is FileDoesNotExistException {
-    return _smithy.isa(o, "FileDoesNotExistException");
+    return __isa(o, "FileDoesNotExistException");
   }
 }
 
@@ -3116,7 +3107,7 @@ export namespace FileDoesNotExistException {
  * <p>The commit cannot be created because no files have been specified as added, updated, or changed (PutFile or DeleteFile) for the commit.</p>
  */
 export interface FileEntryRequiredException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "FileEntryRequiredException";
   $fault: "client";
@@ -3128,7 +3119,7 @@ export interface FileEntryRequiredException
 
 export namespace FileEntryRequiredException {
   export function isa(o: any): o is FileEntryRequiredException {
-    return _smithy.isa(o, "FileEntryRequiredException");
+    return __isa(o, "FileEntryRequiredException");
   }
 }
 
@@ -3156,7 +3147,7 @@ export interface FileMetadata {
 
 export namespace FileMetadata {
   export function isa(o: any): o is FileMetadata {
-    return _smithy.isa(o, "FileMetadata");
+    return __isa(o, "FileMetadata");
   }
 }
 
@@ -3165,7 +3156,7 @@ export namespace FileMetadata {
  *             required to update mode permissions for a file.</p>
  */
 export interface FileModeRequiredException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "FileModeRequiredException";
   $fault: "client";
@@ -3177,7 +3168,7 @@ export interface FileModeRequiredException
 
 export namespace FileModeRequiredException {
   export function isa(o: any): o is FileModeRequiredException {
-    return _smithy.isa(o, "FileModeRequiredException");
+    return __isa(o, "FileModeRequiredException");
   }
 }
 
@@ -3210,7 +3201,7 @@ export interface FileModes {
 
 export namespace FileModes {
   export function isa(o: any): o is FileModes {
-    return _smithy.isa(o, "FileModes");
+    return __isa(o, "FileModes");
   }
 }
 
@@ -3219,7 +3210,7 @@ export namespace FileModes {
  *         another name for the file, or add the file in a directory that does not match the file name.</p>
  */
 export interface FileNameConflictsWithDirectoryNameException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "FileNameConflictsWithDirectoryNameException";
   $fault: "client";
@@ -3233,7 +3224,7 @@ export namespace FileNameConflictsWithDirectoryNameException {
   export function isa(
     o: any
   ): o is FileNameConflictsWithDirectoryNameException {
-    return _smithy.isa(o, "FileNameConflictsWithDirectoryNameException");
+    return __isa(o, "FileNameConflictsWithDirectoryNameException");
   }
 }
 
@@ -3242,7 +3233,7 @@ export namespace FileNameConflictsWithDirectoryNameException {
  *         have valid file paths that do not point to a submodule.</p>
  */
 export interface FilePathConflictsWithSubmodulePathException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "FilePathConflictsWithSubmodulePathException";
   $fault: "client";
@@ -3256,7 +3247,7 @@ export namespace FilePathConflictsWithSubmodulePathException {
   export function isa(
     o: any
   ): o is FilePathConflictsWithSubmodulePathException {
-    return _smithy.isa(o, "FilePathConflictsWithSubmodulePathException");
+    return __isa(o, "FilePathConflictsWithSubmodulePathException");
   }
 }
 
@@ -3283,7 +3274,7 @@ export interface FileSizes {
 
 export namespace FileSizes {
   export function isa(o: any): o is FileSizes {
-    return _smithy.isa(o, "FileSizes");
+    return __isa(o, "FileSizes");
   }
 }
 
@@ -3292,7 +3283,7 @@ export namespace FileSizes {
  *             <a href="https://docs.aws.amazon.com/codecommit/latest/userguide/limits.html">AWS CodeCommit User Guide</a>.</p>
  */
 export interface FileTooLargeException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "FileTooLargeException";
   $fault: "client";
@@ -3304,7 +3295,7 @@ export interface FileTooLargeException
 
 export namespace FileTooLargeException {
   export function isa(o: any): o is FileTooLargeException {
-    return _smithy.isa(o, "FileTooLargeException");
+    return __isa(o, "FileTooLargeException");
   }
 }
 
@@ -3331,7 +3322,7 @@ export interface Folder {
 
 export namespace Folder {
   export function isa(o: any): o is Folder {
-    return _smithy.isa(o, "Folder");
+    return __isa(o, "Folder");
   }
 }
 
@@ -3341,7 +3332,7 @@ export namespace Folder {
  *         or split the changes across multiple folders.</p>
  */
 export interface FolderContentSizeLimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "FolderContentSizeLimitExceededException";
   $fault: "client";
@@ -3353,7 +3344,7 @@ export interface FolderContentSizeLimitExceededException
 
 export namespace FolderContentSizeLimitExceededException {
   export function isa(o: any): o is FolderContentSizeLimitExceededException {
-    return _smithy.isa(o, "FolderContentSizeLimitExceededException");
+    return __isa(o, "FolderContentSizeLimitExceededException");
   }
 }
 
@@ -3362,7 +3353,7 @@ export namespace FolderContentSizeLimitExceededException {
  *             not enter the full path to the folder.</p>
  */
 export interface FolderDoesNotExistException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "FolderDoesNotExistException";
   $fault: "client";
@@ -3374,7 +3365,7 @@ export interface FolderDoesNotExistException
 
 export namespace FolderDoesNotExistException {
   export function isa(o: any): o is FolderDoesNotExistException {
-    return _smithy.isa(o, "FolderDoesNotExistException");
+    return __isa(o, "FolderDoesNotExistException");
   }
 }
 
@@ -3388,7 +3379,7 @@ export interface GetApprovalRuleTemplateInput {
 
 export namespace GetApprovalRuleTemplateInput {
   export function isa(o: any): o is GetApprovalRuleTemplateInput {
-    return _smithy.isa(o, "GetApprovalRuleTemplateInput");
+    return __isa(o, "GetApprovalRuleTemplateInput");
   }
 }
 
@@ -3402,7 +3393,7 @@ export interface GetApprovalRuleTemplateOutput extends $MetadataBearer {
 
 export namespace GetApprovalRuleTemplateOutput {
   export function isa(o: any): o is GetApprovalRuleTemplateOutput {
-    return _smithy.isa(o, "GetApprovalRuleTemplateOutput");
+    return __isa(o, "GetApprovalRuleTemplateOutput");
   }
 }
 
@@ -3424,7 +3415,7 @@ export interface GetBlobInput {
 
 export namespace GetBlobInput {
   export function isa(o: any): o is GetBlobInput {
-    return _smithy.isa(o, "GetBlobInput");
+    return __isa(o, "GetBlobInput");
   }
 }
 
@@ -3441,7 +3432,7 @@ export interface GetBlobOutput extends $MetadataBearer {
 
 export namespace GetBlobOutput {
   export function isa(o: any): o is GetBlobOutput {
-    return _smithy.isa(o, "GetBlobOutput");
+    return __isa(o, "GetBlobOutput");
   }
 }
 
@@ -3463,7 +3454,7 @@ export interface GetBranchInput {
 
 export namespace GetBranchInput {
   export function isa(o: any): o is GetBranchInput {
-    return _smithy.isa(o, "GetBranchInput");
+    return __isa(o, "GetBranchInput");
   }
 }
 
@@ -3480,7 +3471,7 @@ export interface GetBranchOutput extends $MetadataBearer {
 
 export namespace GetBranchOutput {
   export function isa(o: any): o is GetBranchOutput {
-    return _smithy.isa(o, "GetBranchOutput");
+    return __isa(o, "GetBranchOutput");
   }
 }
 
@@ -3495,7 +3486,7 @@ export interface GetCommentInput {
 
 export namespace GetCommentInput {
   export function isa(o: any): o is GetCommentInput {
-    return _smithy.isa(o, "GetCommentInput");
+    return __isa(o, "GetCommentInput");
   }
 }
 
@@ -3509,7 +3500,7 @@ export interface GetCommentOutput extends $MetadataBearer {
 
 export namespace GetCommentOutput {
   export function isa(o: any): o is GetCommentOutput {
-    return _smithy.isa(o, "GetCommentOutput");
+    return __isa(o, "GetCommentOutput");
   }
 }
 
@@ -3546,7 +3537,7 @@ export interface GetCommentsForComparedCommitInput {
 
 export namespace GetCommentsForComparedCommitInput {
   export function isa(o: any): o is GetCommentsForComparedCommitInput {
-    return _smithy.isa(o, "GetCommentsForComparedCommitInput");
+    return __isa(o, "GetCommentsForComparedCommitInput");
   }
 }
 
@@ -3565,7 +3556,7 @@ export interface GetCommentsForComparedCommitOutput extends $MetadataBearer {
 
 export namespace GetCommentsForComparedCommitOutput {
   export function isa(o: any): o is GetCommentsForComparedCommitOutput {
-    return _smithy.isa(o, "GetCommentsForComparedCommitOutput");
+    return __isa(o, "GetCommentsForComparedCommitOutput");
   }
 }
 
@@ -3606,7 +3597,7 @@ export interface GetCommentsForPullRequestInput {
 
 export namespace GetCommentsForPullRequestInput {
   export function isa(o: any): o is GetCommentsForPullRequestInput {
-    return _smithy.isa(o, "GetCommentsForPullRequestInput");
+    return __isa(o, "GetCommentsForPullRequestInput");
   }
 }
 
@@ -3625,7 +3616,7 @@ export interface GetCommentsForPullRequestOutput extends $MetadataBearer {
 
 export namespace GetCommentsForPullRequestOutput {
   export function isa(o: any): o is GetCommentsForPullRequestOutput {
-    return _smithy.isa(o, "GetCommentsForPullRequestOutput");
+    return __isa(o, "GetCommentsForPullRequestOutput");
   }
 }
 
@@ -3647,7 +3638,7 @@ export interface GetCommitInput {
 
 export namespace GetCommitInput {
   export function isa(o: any): o is GetCommitInput {
-    return _smithy.isa(o, "GetCommitInput");
+    return __isa(o, "GetCommitInput");
   }
 }
 
@@ -3664,7 +3655,7 @@ export interface GetCommitOutput extends $MetadataBearer {
 
 export namespace GetCommitOutput {
   export function isa(o: any): o is GetCommitOutput {
-    return _smithy.isa(o, "GetCommitOutput");
+    return __isa(o, "GetCommitOutput");
   }
 }
 
@@ -3718,7 +3709,7 @@ export interface GetDifferencesInput {
 
 export namespace GetDifferencesInput {
   export function isa(o: any): o is GetDifferencesInput {
-    return _smithy.isa(o, "GetDifferencesInput");
+    return __isa(o, "GetDifferencesInput");
   }
 }
 
@@ -3738,7 +3729,7 @@ export interface GetDifferencesOutput extends $MetadataBearer {
 
 export namespace GetDifferencesOutput {
   export function isa(o: any): o is GetDifferencesOutput {
-    return _smithy.isa(o, "GetDifferencesOutput");
+    return __isa(o, "GetDifferencesOutput");
   }
 }
 
@@ -3766,7 +3757,7 @@ export interface GetFileInput {
 
 export namespace GetFileInput {
   export function isa(o: any): o is GetFileInput {
-    return _smithy.isa(o, "GetFileInput");
+    return __isa(o, "GetFileInput");
   }
 }
 
@@ -3811,7 +3802,7 @@ export interface GetFileOutput extends $MetadataBearer {
 
 export namespace GetFileOutput {
   export function isa(o: any): o is GetFileOutput {
-    return _smithy.isa(o, "GetFileOutput");
+    return __isa(o, "GetFileOutput");
   }
 }
 
@@ -3840,7 +3831,7 @@ export interface GetFolderInput {
 
 export namespace GetFolderInput {
   export function isa(o: any): o is GetFolderInput {
-    return _smithy.isa(o, "GetFolderInput");
+    return __isa(o, "GetFolderInput");
   }
 }
 
@@ -3886,7 +3877,7 @@ export interface GetFolderOutput extends $MetadataBearer {
 
 export namespace GetFolderOutput {
   export function isa(o: any): o is GetFolderOutput {
-    return _smithy.isa(o, "GetFolderOutput");
+    return __isa(o, "GetFolderOutput");
   }
 }
 
@@ -3927,7 +3918,7 @@ export interface GetMergeCommitInput {
 
 export namespace GetMergeCommitInput {
   export function isa(o: any): o is GetMergeCommitInput {
-    return _smithy.isa(o, "GetMergeCommitInput");
+    return __isa(o, "GetMergeCommitInput");
   }
 }
 
@@ -3958,7 +3949,7 @@ export interface GetMergeCommitOutput extends $MetadataBearer {
 
 export namespace GetMergeCommitOutput {
   export function isa(o: any): o is GetMergeCommitOutput {
-    return _smithy.isa(o, "GetMergeCommitOutput");
+    return __isa(o, "GetMergeCommitOutput");
   }
 }
 
@@ -4015,7 +4006,7 @@ export interface GetMergeConflictsInput {
 
 export namespace GetMergeConflictsInput {
   export function isa(o: any): o is GetMergeConflictsInput {
-    return _smithy.isa(o, "GetMergeConflictsInput");
+    return __isa(o, "GetMergeConflictsInput");
   }
 }
 
@@ -4055,7 +4046,7 @@ export interface GetMergeConflictsOutput extends $MetadataBearer {
 
 export namespace GetMergeConflictsOutput {
   export function isa(o: any): o is GetMergeConflictsOutput {
-    return _smithy.isa(o, "GetMergeConflictsOutput");
+    return __isa(o, "GetMergeConflictsOutput");
   }
 }
 
@@ -4096,7 +4087,7 @@ export interface GetMergeOptionsInput {
 
 export namespace GetMergeOptionsInput {
   export function isa(o: any): o is GetMergeOptionsInput {
-    return _smithy.isa(o, "GetMergeOptionsInput");
+    return __isa(o, "GetMergeOptionsInput");
   }
 }
 
@@ -4125,7 +4116,7 @@ export interface GetMergeOptionsOutput extends $MetadataBearer {
 
 export namespace GetMergeOptionsOutput {
   export function isa(o: any): o is GetMergeOptionsOutput {
-    return _smithy.isa(o, "GetMergeOptionsOutput");
+    return __isa(o, "GetMergeOptionsOutput");
   }
 }
 
@@ -4144,7 +4135,7 @@ export interface GetPullRequestApprovalStatesInput {
 
 export namespace GetPullRequestApprovalStatesInput {
   export function isa(o: any): o is GetPullRequestApprovalStatesInput {
-    return _smithy.isa(o, "GetPullRequestApprovalStatesInput");
+    return __isa(o, "GetPullRequestApprovalStatesInput");
   }
 }
 
@@ -4158,7 +4149,7 @@ export interface GetPullRequestApprovalStatesOutput extends $MetadataBearer {
 
 export namespace GetPullRequestApprovalStatesOutput {
   export function isa(o: any): o is GetPullRequestApprovalStatesOutput {
-    return _smithy.isa(o, "GetPullRequestApprovalStatesOutput");
+    return __isa(o, "GetPullRequestApprovalStatesOutput");
   }
 }
 
@@ -4172,7 +4163,7 @@ export interface GetPullRequestInput {
 
 export namespace GetPullRequestInput {
   export function isa(o: any): o is GetPullRequestInput {
-    return _smithy.isa(o, "GetPullRequestInput");
+    return __isa(o, "GetPullRequestInput");
   }
 }
 
@@ -4186,7 +4177,7 @@ export interface GetPullRequestOutput extends $MetadataBearer {
 
 export namespace GetPullRequestOutput {
   export function isa(o: any): o is GetPullRequestOutput {
-    return _smithy.isa(o, "GetPullRequestOutput");
+    return __isa(o, "GetPullRequestOutput");
   }
 }
 
@@ -4207,7 +4198,7 @@ export interface GetPullRequestOverrideStateInput {
 
 export namespace GetPullRequestOverrideStateInput {
   export function isa(o: any): o is GetPullRequestOverrideStateInput {
-    return _smithy.isa(o, "GetPullRequestOverrideStateInput");
+    return __isa(o, "GetPullRequestOverrideStateInput");
   }
 }
 
@@ -4226,7 +4217,7 @@ export interface GetPullRequestOverrideStateOutput extends $MetadataBearer {
 
 export namespace GetPullRequestOverrideStateOutput {
   export function isa(o: any): o is GetPullRequestOverrideStateOutput {
-    return _smithy.isa(o, "GetPullRequestOverrideStateOutput");
+    return __isa(o, "GetPullRequestOverrideStateOutput");
   }
 }
 
@@ -4243,7 +4234,7 @@ export interface GetRepositoryInput {
 
 export namespace GetRepositoryInput {
   export function isa(o: any): o is GetRepositoryInput {
-    return _smithy.isa(o, "GetRepositoryInput");
+    return __isa(o, "GetRepositoryInput");
   }
 }
 
@@ -4260,7 +4251,7 @@ export interface GetRepositoryOutput extends $MetadataBearer {
 
 export namespace GetRepositoryOutput {
   export function isa(o: any): o is GetRepositoryOutput {
-    return _smithy.isa(o, "GetRepositoryOutput");
+    return __isa(o, "GetRepositoryOutput");
   }
 }
 
@@ -4277,7 +4268,7 @@ export interface GetRepositoryTriggersInput {
 
 export namespace GetRepositoryTriggersInput {
   export function isa(o: any): o is GetRepositoryTriggersInput {
-    return _smithy.isa(o, "GetRepositoryTriggersInput");
+    return __isa(o, "GetRepositoryTriggersInput");
   }
 }
 
@@ -4299,7 +4290,7 @@ export interface GetRepositoryTriggersOutput extends $MetadataBearer {
 
 export namespace GetRepositoryTriggersOutput {
   export function isa(o: any): o is GetRepositoryTriggersOutput {
-    return _smithy.isa(o, "GetRepositoryTriggersOutput");
+    return __isa(o, "GetRepositoryTriggersOutput");
   }
 }
 
@@ -4308,7 +4299,7 @@ export namespace GetRepositoryTriggersOutput {
  *             the token has been used in a previous request and cannot be reused.</p>
  */
 export interface IdempotencyParameterMismatchException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "IdempotencyParameterMismatchException";
   $fault: "client";
@@ -4320,7 +4311,7 @@ export interface IdempotencyParameterMismatchException
 
 export namespace IdempotencyParameterMismatchException {
   export function isa(o: any): o is IdempotencyParameterMismatchException {
-    return _smithy.isa(o, "IdempotencyParameterMismatchException");
+    return __isa(o, "IdempotencyParameterMismatchException");
   }
 }
 
@@ -4329,7 +4320,7 @@ export namespace IdempotencyParameterMismatchException {
  *             and then try again.</p>
  */
 export interface InvalidActorArnException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidActorArnException";
   $fault: "client";
@@ -4341,7 +4332,7 @@ export interface InvalidActorArnException
 
 export namespace InvalidActorArnException {
   export function isa(o: any): o is InvalidActorArnException {
-    return _smithy.isa(o, "InvalidActorArnException");
+    return __isa(o, "InvalidActorArnException");
   }
 }
 
@@ -4349,7 +4340,7 @@ export namespace InvalidActorArnException {
  * <p>The content for the approval rule is not valid.</p>
  */
 export interface InvalidApprovalRuleContentException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidApprovalRuleContentException";
   $fault: "client";
@@ -4361,7 +4352,7 @@ export interface InvalidApprovalRuleContentException
 
 export namespace InvalidApprovalRuleContentException {
   export function isa(o: any): o is InvalidApprovalRuleContentException {
-    return _smithy.isa(o, "InvalidApprovalRuleContentException");
+    return __isa(o, "InvalidApprovalRuleContentException");
   }
 }
 
@@ -4369,7 +4360,7 @@ export namespace InvalidApprovalRuleContentException {
  * <p>The name for the approval rule is not valid.</p>
  */
 export interface InvalidApprovalRuleNameException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidApprovalRuleNameException";
   $fault: "client";
@@ -4381,7 +4372,7 @@ export interface InvalidApprovalRuleNameException
 
 export namespace InvalidApprovalRuleNameException {
   export function isa(o: any): o is InvalidApprovalRuleNameException {
-    return _smithy.isa(o, "InvalidApprovalRuleNameException");
+    return __isa(o, "InvalidApprovalRuleNameException");
   }
 }
 
@@ -4389,7 +4380,7 @@ export namespace InvalidApprovalRuleNameException {
  * <p>The content of the approval rule template is not valid.</p>
  */
 export interface InvalidApprovalRuleTemplateContentException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidApprovalRuleTemplateContentException";
   $fault: "client";
@@ -4403,7 +4394,7 @@ export namespace InvalidApprovalRuleTemplateContentException {
   export function isa(
     o: any
   ): o is InvalidApprovalRuleTemplateContentException {
-    return _smithy.isa(o, "InvalidApprovalRuleTemplateContentException");
+    return __isa(o, "InvalidApprovalRuleTemplateContentException");
   }
 }
 
@@ -4414,7 +4405,7 @@ export namespace InvalidApprovalRuleTemplateContentException {
  *             Guide</a>.</p>
  */
 export interface InvalidApprovalRuleTemplateDescriptionException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidApprovalRuleTemplateDescriptionException";
   $fault: "client";
@@ -4428,7 +4419,7 @@ export namespace InvalidApprovalRuleTemplateDescriptionException {
   export function isa(
     o: any
   ): o is InvalidApprovalRuleTemplateDescriptionException {
-    return _smithy.isa(o, "InvalidApprovalRuleTemplateDescriptionException");
+    return __isa(o, "InvalidApprovalRuleTemplateDescriptionException");
   }
 }
 
@@ -4439,7 +4430,7 @@ export namespace InvalidApprovalRuleTemplateDescriptionException {
  *                 CodeCommit User Guide</a>.</p>
  */
 export interface InvalidApprovalRuleTemplateNameException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidApprovalRuleTemplateNameException";
   $fault: "client";
@@ -4451,7 +4442,7 @@ export interface InvalidApprovalRuleTemplateNameException
 
 export namespace InvalidApprovalRuleTemplateNameException {
   export function isa(o: any): o is InvalidApprovalRuleTemplateNameException {
-    return _smithy.isa(o, "InvalidApprovalRuleTemplateNameException");
+    return __isa(o, "InvalidApprovalRuleTemplateNameException");
   }
 }
 
@@ -4459,7 +4450,7 @@ export namespace InvalidApprovalRuleTemplateNameException {
  * <p>The state for the approval is not valid. Valid values include APPROVE and REVOKE. </p>
  */
 export interface InvalidApprovalStateException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidApprovalStateException";
   $fault: "client";
@@ -4471,7 +4462,7 @@ export interface InvalidApprovalStateException
 
 export namespace InvalidApprovalStateException {
   export function isa(o: any): o is InvalidApprovalStateException {
-    return _smithy.isa(o, "InvalidApprovalStateException");
+    return __isa(o, "InvalidApprovalStateException");
   }
 }
 
@@ -4479,7 +4470,7 @@ export namespace InvalidApprovalStateException {
  * <p>The Amazon Resource Name (ARN) is not valid. Make sure that you have provided the full ARN for the author of the pull request, and then try again.</p>
  */
 export interface InvalidAuthorArnException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidAuthorArnException";
   $fault: "client";
@@ -4491,7 +4482,7 @@ export interface InvalidAuthorArnException
 
 export namespace InvalidAuthorArnException {
   export function isa(o: any): o is InvalidAuthorArnException {
-    return _smithy.isa(o, "InvalidAuthorArnException");
+    return __isa(o, "InvalidAuthorArnException");
   }
 }
 
@@ -4499,7 +4490,7 @@ export namespace InvalidAuthorArnException {
  * <p>The specified blob is not valid.</p>
  */
 export interface InvalidBlobIdException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidBlobIdException";
   $fault: "client";
@@ -4511,7 +4502,7 @@ export interface InvalidBlobIdException
 
 export namespace InvalidBlobIdException {
   export function isa(o: any): o is InvalidBlobIdException {
-    return _smithy.isa(o, "InvalidBlobIdException");
+    return __isa(o, "InvalidBlobIdException");
   }
 }
 
@@ -4519,7 +4510,7 @@ export namespace InvalidBlobIdException {
  * <p>The specified reference name is not valid.</p>
  */
 export interface InvalidBranchNameException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidBranchNameException";
   $fault: "client";
@@ -4531,7 +4522,7 @@ export interface InvalidBranchNameException
 
 export namespace InvalidBranchNameException {
   export function isa(o: any): o is InvalidBranchNameException {
-    return _smithy.isa(o, "InvalidBranchNameException");
+    return __isa(o, "InvalidBranchNameException");
   }
 }
 
@@ -4539,7 +4530,7 @@ export namespace InvalidBranchNameException {
  * <p>The client request token is not valid.</p>
  */
 export interface InvalidClientRequestTokenException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidClientRequestTokenException";
   $fault: "client";
@@ -4551,7 +4542,7 @@ export interface InvalidClientRequestTokenException
 
 export namespace InvalidClientRequestTokenException {
   export function isa(o: any): o is InvalidClientRequestTokenException {
-    return _smithy.isa(o, "InvalidClientRequestTokenException");
+    return __isa(o, "InvalidClientRequestTokenException");
   }
 }
 
@@ -4559,7 +4550,7 @@ export namespace InvalidClientRequestTokenException {
  * <p>The comment ID is not in a valid format. Make sure that you have provided the full comment ID.</p>
  */
 export interface InvalidCommentIdException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidCommentIdException";
   $fault: "client";
@@ -4571,7 +4562,7 @@ export interface InvalidCommentIdException
 
 export namespace InvalidCommentIdException {
   export function isa(o: any): o is InvalidCommentIdException {
-    return _smithy.isa(o, "InvalidCommentIdException");
+    return __isa(o, "InvalidCommentIdException");
   }
 }
 
@@ -4579,7 +4570,7 @@ export namespace InvalidCommentIdException {
  * <p>The specified commit is not valid.</p>
  */
 export interface InvalidCommitException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidCommitException";
   $fault: "client";
@@ -4591,7 +4582,7 @@ export interface InvalidCommitException
 
 export namespace InvalidCommitException {
   export function isa(o: any): o is InvalidCommitException {
-    return _smithy.isa(o, "InvalidCommitException");
+    return __isa(o, "InvalidCommitException");
   }
 }
 
@@ -4599,7 +4590,7 @@ export namespace InvalidCommitException {
  * <p>The specified commit ID is not valid.</p>
  */
 export interface InvalidCommitIdException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidCommitIdException";
   $fault: "client";
@@ -4611,7 +4602,7 @@ export interface InvalidCommitIdException
 
 export namespace InvalidCommitIdException {
   export function isa(o: any): o is InvalidCommitIdException {
-    return _smithy.isa(o, "InvalidCommitIdException");
+    return __isa(o, "InvalidCommitIdException");
   }
 }
 
@@ -4619,7 +4610,7 @@ export namespace InvalidCommitIdException {
  * <p>The specified conflict detail level is not valid.</p>
  */
 export interface InvalidConflictDetailLevelException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidConflictDetailLevelException";
   $fault: "client";
@@ -4631,7 +4622,7 @@ export interface InvalidConflictDetailLevelException
 
 export namespace InvalidConflictDetailLevelException {
   export function isa(o: any): o is InvalidConflictDetailLevelException {
-    return _smithy.isa(o, "InvalidConflictDetailLevelException");
+    return __isa(o, "InvalidConflictDetailLevelException");
   }
 }
 
@@ -4639,7 +4630,7 @@ export namespace InvalidConflictDetailLevelException {
  * <p>The specified conflict resolution list is not valid.</p>
  */
 export interface InvalidConflictResolutionException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidConflictResolutionException";
   $fault: "client";
@@ -4651,7 +4642,7 @@ export interface InvalidConflictResolutionException
 
 export namespace InvalidConflictResolutionException {
   export function isa(o: any): o is InvalidConflictResolutionException {
-    return _smithy.isa(o, "InvalidConflictResolutionException");
+    return __isa(o, "InvalidConflictResolutionException");
   }
 }
 
@@ -4659,7 +4650,7 @@ export namespace InvalidConflictResolutionException {
  * <p>The specified conflict resolution strategy is not valid.</p>
  */
 export interface InvalidConflictResolutionStrategyException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidConflictResolutionStrategyException";
   $fault: "client";
@@ -4671,7 +4662,7 @@ export interface InvalidConflictResolutionStrategyException
 
 export namespace InvalidConflictResolutionStrategyException {
   export function isa(o: any): o is InvalidConflictResolutionStrategyException {
-    return _smithy.isa(o, "InvalidConflictResolutionStrategyException");
+    return __isa(o, "InvalidConflictResolutionStrategyException");
   }
 }
 
@@ -4679,7 +4670,7 @@ export namespace InvalidConflictResolutionStrategyException {
  * <p>The specified continuation token is not valid.</p>
  */
 export interface InvalidContinuationTokenException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidContinuationTokenException";
   $fault: "client";
@@ -4691,7 +4682,7 @@ export interface InvalidContinuationTokenException
 
 export namespace InvalidContinuationTokenException {
   export function isa(o: any): o is InvalidContinuationTokenException {
-    return _smithy.isa(o, "InvalidContinuationTokenException");
+    return __isa(o, "InvalidContinuationTokenException");
   }
 }
 
@@ -4699,7 +4690,7 @@ export namespace InvalidContinuationTokenException {
  * <p>The specified deletion parameter is not valid.</p>
  */
 export interface InvalidDeletionParameterException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidDeletionParameterException";
   $fault: "client";
@@ -4711,7 +4702,7 @@ export interface InvalidDeletionParameterException
 
 export namespace InvalidDeletionParameterException {
   export function isa(o: any): o is InvalidDeletionParameterException {
-    return _smithy.isa(o, "InvalidDeletionParameterException");
+    return __isa(o, "InvalidDeletionParameterException");
   }
 }
 
@@ -4720,7 +4711,7 @@ export namespace InvalidDeletionParameterException {
  *             characters.</p>
  */
 export interface InvalidDescriptionException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidDescriptionException";
   $fault: "client";
@@ -4732,7 +4723,7 @@ export interface InvalidDescriptionException
 
 export namespace InvalidDescriptionException {
   export function isa(o: any): o is InvalidDescriptionException {
-    return _smithy.isa(o, "InvalidDescriptionException");
+    return __isa(o, "InvalidDescriptionException");
   }
 }
 
@@ -4740,7 +4731,7 @@ export namespace InvalidDescriptionException {
  * <p>The destination commit specifier is not valid. You must provide a valid branch name, tag, or full commit ID. </p>
  */
 export interface InvalidDestinationCommitSpecifierException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidDestinationCommitSpecifierException";
   $fault: "client";
@@ -4752,7 +4743,7 @@ export interface InvalidDestinationCommitSpecifierException
 
 export namespace InvalidDestinationCommitSpecifierException {
   export function isa(o: any): o is InvalidDestinationCommitSpecifierException {
-    return _smithy.isa(o, "InvalidDestinationCommitSpecifierException");
+    return __isa(o, "InvalidDestinationCommitSpecifierException");
   }
 }
 
@@ -4761,7 +4752,7 @@ export namespace InvalidDestinationCommitSpecifierException {
  *         allowed for an email address.</p>
  */
 export interface InvalidEmailException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidEmailException";
   $fault: "client";
@@ -4773,7 +4764,7 @@ export interface InvalidEmailException
 
 export namespace InvalidEmailException {
   export function isa(o: any): o is InvalidEmailException {
-    return _smithy.isa(o, "InvalidEmailException");
+    return __isa(o, "InvalidEmailException");
   }
 }
 
@@ -4782,7 +4773,7 @@ export namespace InvalidEmailException {
  *             extension.</p>
  */
 export interface InvalidFileLocationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidFileLocationException";
   $fault: "client";
@@ -4794,7 +4785,7 @@ export interface InvalidFileLocationException
 
 export namespace InvalidFileLocationException {
   export function isa(o: any): o is InvalidFileLocationException {
-    return _smithy.isa(o, "InvalidFileLocationException");
+    return __isa(o, "InvalidFileLocationException");
   }
 }
 
@@ -4802,7 +4793,7 @@ export namespace InvalidFileLocationException {
  * <p>The specified file mode permission is not valid. For a list of valid file mode permissions, see <a>PutFile</a>. </p>
  */
 export interface InvalidFileModeException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidFileModeException";
   $fault: "client";
@@ -4814,7 +4805,7 @@ export interface InvalidFileModeException
 
 export namespace InvalidFileModeException {
   export function isa(o: any): o is InvalidFileModeException {
-    return _smithy.isa(o, "InvalidFileModeException");
+    return __isa(o, "InvalidFileModeException");
   }
 }
 
@@ -4822,7 +4813,7 @@ export namespace InvalidFileModeException {
  * <p>The position is not valid. Make sure that the line number exists in the version of the file you want to comment on.</p>
  */
 export interface InvalidFilePositionException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidFilePositionException";
   $fault: "client";
@@ -4834,7 +4825,7 @@ export interface InvalidFilePositionException
 
 export namespace InvalidFilePositionException {
   export function isa(o: any): o is InvalidFilePositionException {
-    return _smithy.isa(o, "InvalidFilePositionException");
+    return __isa(o, "InvalidFilePositionException");
   }
 }
 
@@ -4842,7 +4833,7 @@ export namespace InvalidFilePositionException {
  * <p>The specified value for the number of conflict files to return is not valid.</p>
  */
 export interface InvalidMaxConflictFilesException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidMaxConflictFilesException";
   $fault: "client";
@@ -4854,7 +4845,7 @@ export interface InvalidMaxConflictFilesException
 
 export namespace InvalidMaxConflictFilesException {
   export function isa(o: any): o is InvalidMaxConflictFilesException {
-    return _smithy.isa(o, "InvalidMaxConflictFilesException");
+    return __isa(o, "InvalidMaxConflictFilesException");
   }
 }
 
@@ -4862,7 +4853,7 @@ export namespace InvalidMaxConflictFilesException {
  * <p>The specified value for the number of merge hunks to return is not valid.</p>
  */
 export interface InvalidMaxMergeHunksException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidMaxMergeHunksException";
   $fault: "client";
@@ -4874,7 +4865,7 @@ export interface InvalidMaxMergeHunksException
 
 export namespace InvalidMaxMergeHunksException {
   export function isa(o: any): o is InvalidMaxMergeHunksException {
-    return _smithy.isa(o, "InvalidMaxMergeHunksException");
+    return __isa(o, "InvalidMaxMergeHunksException");
   }
 }
 
@@ -4882,7 +4873,7 @@ export namespace InvalidMaxMergeHunksException {
  * <p>The specified number of maximum results is not valid.</p>
  */
 export interface InvalidMaxResultsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidMaxResultsException";
   $fault: "client";
@@ -4894,7 +4885,7 @@ export interface InvalidMaxResultsException
 
 export namespace InvalidMaxResultsException {
   export function isa(o: any): o is InvalidMaxResultsException {
-    return _smithy.isa(o, "InvalidMaxResultsException");
+    return __isa(o, "InvalidMaxResultsException");
   }
 }
 
@@ -4902,7 +4893,7 @@ export namespace InvalidMaxResultsException {
  * <p>The specified merge option is not valid for this operation. Not all merge strategies are supported for all operations.</p>
  */
 export interface InvalidMergeOptionException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidMergeOptionException";
   $fault: "client";
@@ -4914,7 +4905,7 @@ export interface InvalidMergeOptionException
 
 export namespace InvalidMergeOptionException {
   export function isa(o: any): o is InvalidMergeOptionException {
-    return _smithy.isa(o, "InvalidMergeOptionException");
+    return __isa(o, "InvalidMergeOptionException");
   }
 }
 
@@ -4922,7 +4913,7 @@ export namespace InvalidMergeOptionException {
  * <p>The specified sort order is not valid.</p>
  */
 export interface InvalidOrderException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidOrderException";
   $fault: "client";
@@ -4934,7 +4925,7 @@ export interface InvalidOrderException
 
 export namespace InvalidOrderException {
   export function isa(o: any): o is InvalidOrderException {
-    return _smithy.isa(o, "InvalidOrderException");
+    return __isa(o, "InvalidOrderException");
   }
 }
 
@@ -4942,7 +4933,7 @@ export namespace InvalidOrderException {
  * <p>The override status is not valid. Valid statuses are OVERRIDE and REVOKE.</p>
  */
 export interface InvalidOverrideStatusException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidOverrideStatusException";
   $fault: "client";
@@ -4954,7 +4945,7 @@ export interface InvalidOverrideStatusException
 
 export namespace InvalidOverrideStatusException {
   export function isa(o: any): o is InvalidOverrideStatusException {
-    return _smithy.isa(o, "InvalidOverrideStatusException");
+    return __isa(o, "InvalidOverrideStatusException");
   }
 }
 
@@ -4963,7 +4954,7 @@ export namespace InvalidOverrideStatusException {
  *         want to add or update a file.</p>
  */
 export interface InvalidParentCommitIdException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidParentCommitIdException";
   $fault: "client";
@@ -4975,7 +4966,7 @@ export interface InvalidParentCommitIdException
 
 export namespace InvalidParentCommitIdException {
   export function isa(o: any): o is InvalidParentCommitIdException {
-    return _smithy.isa(o, "InvalidParentCommitIdException");
+    return __isa(o, "InvalidParentCommitIdException");
   }
 }
 
@@ -4983,7 +4974,7 @@ export namespace InvalidParentCommitIdException {
  * <p>The specified path is not valid.</p>
  */
 export interface InvalidPathException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidPathException";
   $fault: "client";
@@ -4995,7 +4986,7 @@ export interface InvalidPathException
 
 export namespace InvalidPathException {
   export function isa(o: any): o is InvalidPathException {
-    return _smithy.isa(o, "InvalidPathException");
+    return __isa(o, "InvalidPathException");
   }
 }
 
@@ -5003,7 +4994,7 @@ export namespace InvalidPathException {
  * <p>The pull request event type is not valid. </p>
  */
 export interface InvalidPullRequestEventTypeException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidPullRequestEventTypeException";
   $fault: "client";
@@ -5015,7 +5006,7 @@ export interface InvalidPullRequestEventTypeException
 
 export namespace InvalidPullRequestEventTypeException {
   export function isa(o: any): o is InvalidPullRequestEventTypeException {
-    return _smithy.isa(o, "InvalidPullRequestEventTypeException");
+    return __isa(o, "InvalidPullRequestEventTypeException");
   }
 }
 
@@ -5023,7 +5014,7 @@ export namespace InvalidPullRequestEventTypeException {
  * <p>The pull request ID is not valid. Make sure that you have provided the full ID and that the pull request is in the specified repository, and then try again.</p>
  */
 export interface InvalidPullRequestIdException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidPullRequestIdException";
   $fault: "client";
@@ -5035,7 +5026,7 @@ export interface InvalidPullRequestIdException
 
 export namespace InvalidPullRequestIdException {
   export function isa(o: any): o is InvalidPullRequestIdException {
-    return _smithy.isa(o, "InvalidPullRequestIdException");
+    return __isa(o, "InvalidPullRequestIdException");
   }
 }
 
@@ -5043,7 +5034,7 @@ export namespace InvalidPullRequestIdException {
  * <p>The pull request status is not valid. The only valid values are <code>OPEN</code> and <code>CLOSED</code>.</p>
  */
 export interface InvalidPullRequestStatusException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidPullRequestStatusException";
   $fault: "client";
@@ -5055,7 +5046,7 @@ export interface InvalidPullRequestStatusException
 
 export namespace InvalidPullRequestStatusException {
   export function isa(o: any): o is InvalidPullRequestStatusException {
-    return _smithy.isa(o, "InvalidPullRequestStatusException");
+    return __isa(o, "InvalidPullRequestStatusException");
   }
 }
 
@@ -5063,7 +5054,7 @@ export namespace InvalidPullRequestStatusException {
  * <p>The pull request status update is not valid. The only valid update is from <code>OPEN</code> to <code>CLOSED</code>.</p>
  */
 export interface InvalidPullRequestStatusUpdateException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidPullRequestStatusUpdateException";
   $fault: "client";
@@ -5075,7 +5066,7 @@ export interface InvalidPullRequestStatusUpdateException
 
 export namespace InvalidPullRequestStatusUpdateException {
   export function isa(o: any): o is InvalidPullRequestStatusUpdateException {
-    return _smithy.isa(o, "InvalidPullRequestStatusUpdateException");
+    return __isa(o, "InvalidPullRequestStatusUpdateException");
   }
 }
 
@@ -5085,7 +5076,7 @@ export namespace InvalidPullRequestStatusUpdateException {
  *                 Git References</a> or consult your Git documentation.</p>
  */
 export interface InvalidReferenceNameException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidReferenceNameException";
   $fault: "client";
@@ -5097,7 +5088,7 @@ export interface InvalidReferenceNameException
 
 export namespace InvalidReferenceNameException {
   export function isa(o: any): o is InvalidReferenceNameException {
-    return _smithy.isa(o, "InvalidReferenceNameException");
+    return __isa(o, "InvalidReferenceNameException");
   }
 }
 
@@ -5105,7 +5096,7 @@ export namespace InvalidReferenceNameException {
  * <p>Either the enum is not in a valid format, or the specified file version enum is not valid in respect to the current file version.</p>
  */
 export interface InvalidRelativeFileVersionEnumException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidRelativeFileVersionEnumException";
   $fault: "client";
@@ -5117,7 +5108,7 @@ export interface InvalidRelativeFileVersionEnumException
 
 export namespace InvalidRelativeFileVersionEnumException {
   export function isa(o: any): o is InvalidRelativeFileVersionEnumException {
-    return _smithy.isa(o, "InvalidRelativeFileVersionEnumException");
+    return __isa(o, "InvalidRelativeFileVersionEnumException");
   }
 }
 
@@ -5125,7 +5116,7 @@ export namespace InvalidRelativeFileVersionEnumException {
  * <p>Automerge was specified for resolving the conflict, but the replacement type is not valid or content is missing. </p>
  */
 export interface InvalidReplacementContentException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidReplacementContentException";
   $fault: "client";
@@ -5137,7 +5128,7 @@ export interface InvalidReplacementContentException
 
 export namespace InvalidReplacementContentException {
   export function isa(o: any): o is InvalidReplacementContentException {
-    return _smithy.isa(o, "InvalidReplacementContentException");
+    return __isa(o, "InvalidReplacementContentException");
   }
 }
 
@@ -5145,7 +5136,7 @@ export namespace InvalidReplacementContentException {
  * <p>Automerge was specified for resolving the conflict, but the specified replacement type is not valid.</p>
  */
 export interface InvalidReplacementTypeException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidReplacementTypeException";
   $fault: "client";
@@ -5157,7 +5148,7 @@ export interface InvalidReplacementTypeException
 
 export namespace InvalidReplacementTypeException {
   export function isa(o: any): o is InvalidReplacementTypeException {
-    return _smithy.isa(o, "InvalidReplacementTypeException");
+    return __isa(o, "InvalidReplacementTypeException");
   }
 }
 
@@ -5165,7 +5156,7 @@ export namespace InvalidReplacementTypeException {
  * <p>The specified repository description is not valid.</p>
  */
 export interface InvalidRepositoryDescriptionException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidRepositoryDescriptionException";
   $fault: "client";
@@ -5177,7 +5168,7 @@ export interface InvalidRepositoryDescriptionException
 
 export namespace InvalidRepositoryDescriptionException {
   export function isa(o: any): o is InvalidRepositoryDescriptionException {
-    return _smithy.isa(o, "InvalidRepositoryDescriptionException");
+    return __isa(o, "InvalidRepositoryDescriptionException");
   }
 }
 
@@ -5191,7 +5182,7 @@ export namespace InvalidRepositoryDescriptionException {
  *          </note>
  */
 export interface InvalidRepositoryNameException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidRepositoryNameException";
   $fault: "client";
@@ -5203,7 +5194,7 @@ export interface InvalidRepositoryNameException
 
 export namespace InvalidRepositoryNameException {
   export function isa(o: any): o is InvalidRepositoryNameException {
-    return _smithy.isa(o, "InvalidRepositoryNameException");
+    return __isa(o, "InvalidRepositoryNameException");
   }
 }
 
@@ -5211,7 +5202,7 @@ export namespace InvalidRepositoryNameException {
  * <p>One or more branch names specified for the trigger is not valid.</p>
  */
 export interface InvalidRepositoryTriggerBranchNameException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidRepositoryTriggerBranchNameException";
   $fault: "client";
@@ -5225,7 +5216,7 @@ export namespace InvalidRepositoryTriggerBranchNameException {
   export function isa(
     o: any
   ): o is InvalidRepositoryTriggerBranchNameException {
-    return _smithy.isa(o, "InvalidRepositoryTriggerBranchNameException");
+    return __isa(o, "InvalidRepositoryTriggerBranchNameException");
   }
 }
 
@@ -5233,7 +5224,7 @@ export namespace InvalidRepositoryTriggerBranchNameException {
  * <p>The custom data provided for the trigger is not valid.</p>
  */
 export interface InvalidRepositoryTriggerCustomDataException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidRepositoryTriggerCustomDataException";
   $fault: "client";
@@ -5247,7 +5238,7 @@ export namespace InvalidRepositoryTriggerCustomDataException {
   export function isa(
     o: any
   ): o is InvalidRepositoryTriggerCustomDataException {
-    return _smithy.isa(o, "InvalidRepositoryTriggerCustomDataException");
+    return __isa(o, "InvalidRepositoryTriggerCustomDataException");
   }
 }
 
@@ -5255,7 +5246,7 @@ export namespace InvalidRepositoryTriggerCustomDataException {
  * <p>The Amazon Resource Name (ARN) for the trigger is not valid for the specified destination. The most common reason for this error is that the ARN does not meet the requirements for the service type.</p>
  */
 export interface InvalidRepositoryTriggerDestinationArnException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidRepositoryTriggerDestinationArnException";
   $fault: "client";
@@ -5269,7 +5260,7 @@ export namespace InvalidRepositoryTriggerDestinationArnException {
   export function isa(
     o: any
   ): o is InvalidRepositoryTriggerDestinationArnException {
-    return _smithy.isa(o, "InvalidRepositoryTriggerDestinationArnException");
+    return __isa(o, "InvalidRepositoryTriggerDestinationArnException");
   }
 }
 
@@ -5277,7 +5268,7 @@ export namespace InvalidRepositoryTriggerDestinationArnException {
  * <p>One or more events specified for the trigger is not valid. Check to make sure that all events specified match the requirements for allowed events.</p>
  */
 export interface InvalidRepositoryTriggerEventsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidRepositoryTriggerEventsException";
   $fault: "client";
@@ -5289,7 +5280,7 @@ export interface InvalidRepositoryTriggerEventsException
 
 export namespace InvalidRepositoryTriggerEventsException {
   export function isa(o: any): o is InvalidRepositoryTriggerEventsException {
-    return _smithy.isa(o, "InvalidRepositoryTriggerEventsException");
+    return __isa(o, "InvalidRepositoryTriggerEventsException");
   }
 }
 
@@ -5297,7 +5288,7 @@ export namespace InvalidRepositoryTriggerEventsException {
  * <p>The name of the trigger is not valid.</p>
  */
 export interface InvalidRepositoryTriggerNameException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidRepositoryTriggerNameException";
   $fault: "client";
@@ -5309,7 +5300,7 @@ export interface InvalidRepositoryTriggerNameException
 
 export namespace InvalidRepositoryTriggerNameException {
   export function isa(o: any): o is InvalidRepositoryTriggerNameException {
-    return _smithy.isa(o, "InvalidRepositoryTriggerNameException");
+    return __isa(o, "InvalidRepositoryTriggerNameException");
   }
 }
 
@@ -5319,7 +5310,7 @@ export namespace InvalidRepositoryTriggerNameException {
  *             trigger.</p>
  */
 export interface InvalidRepositoryTriggerRegionException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidRepositoryTriggerRegionException";
   $fault: "client";
@@ -5331,7 +5322,7 @@ export interface InvalidRepositoryTriggerRegionException
 
 export namespace InvalidRepositoryTriggerRegionException {
   export function isa(o: any): o is InvalidRepositoryTriggerRegionException {
-    return _smithy.isa(o, "InvalidRepositoryTriggerRegionException");
+    return __isa(o, "InvalidRepositoryTriggerRegionException");
   }
 }
 
@@ -5341,7 +5332,7 @@ export namespace InvalidRepositoryTriggerRegionException {
  *             in the AWS CodeCommit User Guide.</p>
  */
 export interface InvalidResourceArnException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidResourceArnException";
   $fault: "client";
@@ -5353,7 +5344,7 @@ export interface InvalidResourceArnException
 
 export namespace InvalidResourceArnException {
   export function isa(o: any): o is InvalidResourceArnException {
-    return _smithy.isa(o, "InvalidResourceArnException");
+    return __isa(o, "InvalidResourceArnException");
   }
 }
 
@@ -5361,7 +5352,7 @@ export namespace InvalidResourceArnException {
  * <p>The revision ID is not valid. Use GetPullRequest to determine the value.</p>
  */
 export interface InvalidRevisionIdException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidRevisionIdException";
   $fault: "client";
@@ -5373,7 +5364,7 @@ export interface InvalidRevisionIdException
 
 export namespace InvalidRevisionIdException {
   export function isa(o: any): o is InvalidRevisionIdException {
-    return _smithy.isa(o, "InvalidRevisionIdException");
+    return __isa(o, "InvalidRevisionIdException");
   }
 }
 
@@ -5381,7 +5372,7 @@ export namespace InvalidRevisionIdException {
  * <p>The SHA-256 hash signature for the rule content is not valid.</p>
  */
 export interface InvalidRuleContentSha256Exception
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidRuleContentSha256Exception";
   $fault: "client";
@@ -5393,7 +5384,7 @@ export interface InvalidRuleContentSha256Exception
 
 export namespace InvalidRuleContentSha256Exception {
   export function isa(o: any): o is InvalidRuleContentSha256Exception {
-    return _smithy.isa(o, "InvalidRuleContentSha256Exception");
+    return __isa(o, "InvalidRuleContentSha256Exception");
   }
 }
 
@@ -5401,7 +5392,7 @@ export namespace InvalidRuleContentSha256Exception {
  * <p>The specified sort by value is not valid.</p>
  */
 export interface InvalidSortByException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidSortByException";
   $fault: "client";
@@ -5413,7 +5404,7 @@ export interface InvalidSortByException
 
 export namespace InvalidSortByException {
   export function isa(o: any): o is InvalidSortByException {
-    return _smithy.isa(o, "InvalidSortByException");
+    return __isa(o, "InvalidSortByException");
   }
 }
 
@@ -5421,7 +5412,7 @@ export namespace InvalidSortByException {
  * <p>The source commit specifier is not valid. You must provide a valid branch name, tag, or full commit ID.</p>
  */
 export interface InvalidSourceCommitSpecifierException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidSourceCommitSpecifierException";
   $fault: "client";
@@ -5433,7 +5424,7 @@ export interface InvalidSourceCommitSpecifierException
 
 export namespace InvalidSourceCommitSpecifierException {
   export function isa(o: any): o is InvalidSourceCommitSpecifierException {
-    return _smithy.isa(o, "InvalidSourceCommitSpecifierException");
+    return __isa(o, "InvalidSourceCommitSpecifierException");
   }
 }
 
@@ -5441,7 +5432,7 @@ export namespace InvalidSourceCommitSpecifierException {
  * <p>The specified tag is not valid. Key names cannot be prefixed with aws:.</p>
  */
 export interface InvalidSystemTagUsageException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidSystemTagUsageException";
   $fault: "client";
@@ -5453,7 +5444,7 @@ export interface InvalidSystemTagUsageException
 
 export namespace InvalidSystemTagUsageException {
   export function isa(o: any): o is InvalidSystemTagUsageException {
-    return _smithy.isa(o, "InvalidSystemTagUsageException");
+    return __isa(o, "InvalidSystemTagUsageException");
   }
 }
 
@@ -5461,7 +5452,7 @@ export namespace InvalidSystemTagUsageException {
  * <p>The list of tags is not valid.</p>
  */
 export interface InvalidTagKeysListException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidTagKeysListException";
   $fault: "client";
@@ -5473,7 +5464,7 @@ export interface InvalidTagKeysListException
 
 export namespace InvalidTagKeysListException {
   export function isa(o: any): o is InvalidTagKeysListException {
-    return _smithy.isa(o, "InvalidTagKeysListException");
+    return __isa(o, "InvalidTagKeysListException");
   }
 }
 
@@ -5481,7 +5472,7 @@ export namespace InvalidTagKeysListException {
  * <p>The map of tags is not valid.</p>
  */
 export interface InvalidTagsMapException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidTagsMapException";
   $fault: "client";
@@ -5493,7 +5484,7 @@ export interface InvalidTagsMapException
 
 export namespace InvalidTagsMapException {
   export function isa(o: any): o is InvalidTagsMapException {
-    return _smithy.isa(o, "InvalidTagsMapException");
+    return __isa(o, "InvalidTagsMapException");
   }
 }
 
@@ -5501,7 +5492,7 @@ export namespace InvalidTagsMapException {
  * <p>The specified target branch is not valid.</p>
  */
 export interface InvalidTargetBranchException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidTargetBranchException";
   $fault: "client";
@@ -5513,7 +5504,7 @@ export interface InvalidTargetBranchException
 
 export namespace InvalidTargetBranchException {
   export function isa(o: any): o is InvalidTargetBranchException {
-    return _smithy.isa(o, "InvalidTargetBranchException");
+    return __isa(o, "InvalidTargetBranchException");
   }
 }
 
@@ -5521,7 +5512,7 @@ export namespace InvalidTargetBranchException {
  * <p>The target for the pull request is not valid. A target must contain the full values for the repository name, source branch, and destination branch for the pull request.</p>
  */
 export interface InvalidTargetException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidTargetException";
   $fault: "client";
@@ -5533,7 +5524,7 @@ export interface InvalidTargetException
 
 export namespace InvalidTargetException {
   export function isa(o: any): o is InvalidTargetException {
-    return _smithy.isa(o, "InvalidTargetException");
+    return __isa(o, "InvalidTargetException");
   }
 }
 
@@ -5542,7 +5533,7 @@ export namespace InvalidTargetException {
  *             the repository name, source branch, and destination branch for a pull request.</p>
  */
 export interface InvalidTargetsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidTargetsException";
   $fault: "client";
@@ -5554,7 +5545,7 @@ export interface InvalidTargetsException
 
 export namespace InvalidTargetsException {
   export function isa(o: any): o is InvalidTargetsException {
-    return _smithy.isa(o, "InvalidTargetsException");
+    return __isa(o, "InvalidTargetsException");
   }
 }
 
@@ -5562,7 +5553,7 @@ export namespace InvalidTargetsException {
  * <p>The title of the pull request is not valid. Pull request titles cannot exceed 100 characters in length.</p>
  */
 export interface InvalidTitleException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidTitleException";
   $fault: "client";
@@ -5574,7 +5565,7 @@ export interface InvalidTitleException
 
 export namespace InvalidTitleException {
   export function isa(o: any): o is InvalidTitleException {
-    return _smithy.isa(o, "InvalidTitleException");
+    return __isa(o, "InvalidTitleException");
   }
 }
 
@@ -5601,7 +5592,7 @@ export interface IsBinaryFile {
 
 export namespace IsBinaryFile {
   export function isa(o: any): o is IsBinaryFile {
-    return _smithy.isa(o, "IsBinaryFile");
+    return __isa(o, "IsBinaryFile");
   }
 }
 
@@ -5621,7 +5612,7 @@ export interface ListApprovalRuleTemplatesInput {
 
 export namespace ListApprovalRuleTemplatesInput {
   export function isa(o: any): o is ListApprovalRuleTemplatesInput {
-    return _smithy.isa(o, "ListApprovalRuleTemplatesInput");
+    return __isa(o, "ListApprovalRuleTemplatesInput");
   }
 }
 
@@ -5640,7 +5631,7 @@ export interface ListApprovalRuleTemplatesOutput extends $MetadataBearer {
 
 export namespace ListApprovalRuleTemplatesOutput {
   export function isa(o: any): o is ListApprovalRuleTemplatesOutput {
-    return _smithy.isa(o, "ListApprovalRuleTemplatesOutput");
+    return __isa(o, "ListApprovalRuleTemplatesOutput");
   }
 }
 
@@ -5667,10 +5658,7 @@ export namespace ListAssociatedApprovalRuleTemplatesForRepositoryInput {
   export function isa(
     o: any
   ): o is ListAssociatedApprovalRuleTemplatesForRepositoryInput {
-    return _smithy.isa(
-      o,
-      "ListAssociatedApprovalRuleTemplatesForRepositoryInput"
-    );
+    return __isa(o, "ListAssociatedApprovalRuleTemplatesForRepositoryInput");
   }
 }
 
@@ -5692,10 +5680,7 @@ export namespace ListAssociatedApprovalRuleTemplatesForRepositoryOutput {
   export function isa(
     o: any
   ): o is ListAssociatedApprovalRuleTemplatesForRepositoryOutput {
-    return _smithy.isa(
-      o,
-      "ListAssociatedApprovalRuleTemplatesForRepositoryOutput"
-    );
+    return __isa(o, "ListAssociatedApprovalRuleTemplatesForRepositoryOutput");
   }
 }
 
@@ -5717,7 +5702,7 @@ export interface ListBranchesInput {
 
 export namespace ListBranchesInput {
   export function isa(o: any): o is ListBranchesInput {
-    return _smithy.isa(o, "ListBranchesInput");
+    return __isa(o, "ListBranchesInput");
   }
 }
 
@@ -5739,7 +5724,7 @@ export interface ListBranchesOutput extends $MetadataBearer {
 
 export namespace ListBranchesOutput {
   export function isa(o: any): o is ListBranchesOutput {
-    return _smithy.isa(o, "ListBranchesOutput");
+    return __isa(o, "ListBranchesOutput");
   }
 }
 
@@ -5775,7 +5760,7 @@ export interface ListPullRequestsInput {
 
 export namespace ListPullRequestsInput {
   export function isa(o: any): o is ListPullRequestsInput {
-    return _smithy.isa(o, "ListPullRequestsInput");
+    return __isa(o, "ListPullRequestsInput");
   }
 }
 
@@ -5794,7 +5779,7 @@ export interface ListPullRequestsOutput extends $MetadataBearer {
 
 export namespace ListPullRequestsOutput {
   export function isa(o: any): o is ListPullRequestsOutput {
-    return _smithy.isa(o, "ListPullRequestsOutput");
+    return __isa(o, "ListPullRequestsOutput");
   }
 }
 
@@ -5821,7 +5806,7 @@ export namespace ListRepositoriesForApprovalRuleTemplateInput {
   export function isa(
     o: any
   ): o is ListRepositoriesForApprovalRuleTemplateInput {
-    return _smithy.isa(o, "ListRepositoriesForApprovalRuleTemplateInput");
+    return __isa(o, "ListRepositoriesForApprovalRuleTemplateInput");
   }
 }
 
@@ -5843,7 +5828,7 @@ export namespace ListRepositoriesForApprovalRuleTemplateOutput {
   export function isa(
     o: any
   ): o is ListRepositoriesForApprovalRuleTemplateOutput {
-    return _smithy.isa(o, "ListRepositoriesForApprovalRuleTemplateOutput");
+    return __isa(o, "ListRepositoriesForApprovalRuleTemplateOutput");
   }
 }
 
@@ -5872,7 +5857,7 @@ export interface ListRepositoriesInput {
 
 export namespace ListRepositoriesInput {
   export function isa(o: any): o is ListRepositoriesInput {
-    return _smithy.isa(o, "ListRepositoriesInput");
+    return __isa(o, "ListRepositoriesInput");
   }
 }
 
@@ -5896,7 +5881,7 @@ export interface ListRepositoriesOutput extends $MetadataBearer {
 
 export namespace ListRepositoriesOutput {
   export function isa(o: any): o is ListRepositoriesOutput {
-    return _smithy.isa(o, "ListRepositoriesOutput");
+    return __isa(o, "ListRepositoriesOutput");
   }
 }
 
@@ -5917,7 +5902,7 @@ export interface ListTagsForResourceInput {
 
 export namespace ListTagsForResourceInput {
   export function isa(o: any): o is ListTagsForResourceInput {
-    return _smithy.isa(o, "ListTagsForResourceInput");
+    return __isa(o, "ListTagsForResourceInput");
   }
 }
 
@@ -5936,7 +5921,7 @@ export interface ListTagsForResourceOutput extends $MetadataBearer {
 
 export namespace ListTagsForResourceOutput {
   export function isa(o: any): o is ListTagsForResourceOutput {
-    return _smithy.isa(o, "ListTagsForResourceOutput");
+    return __isa(o, "ListTagsForResourceOutput");
   }
 }
 
@@ -5964,7 +5949,7 @@ export interface Location {
 
 export namespace Location {
   export function isa(o: any): o is Location {
-    return _smithy.isa(o, "Location");
+    return __isa(o, "Location");
   }
 }
 
@@ -5972,7 +5957,7 @@ export namespace Location {
  * <p>The pull request cannot be merged automatically into the destination branch. You must manually merge the branches and resolve any conflicts.</p>
  */
 export interface ManualMergeRequiredException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ManualMergeRequiredException";
   $fault: "client";
@@ -5984,7 +5969,7 @@ export interface ManualMergeRequiredException
 
 export namespace ManualMergeRequiredException {
   export function isa(o: any): o is ManualMergeRequiredException {
-    return _smithy.isa(o, "ManualMergeRequiredException");
+    return __isa(o, "ManualMergeRequiredException");
   }
 }
 
@@ -5992,7 +5977,7 @@ export namespace ManualMergeRequiredException {
  * <p>The number of branches for the trigger was exceeded.</p>
  */
 export interface MaximumBranchesExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "MaximumBranchesExceededException";
   $fault: "client";
@@ -6004,7 +5989,7 @@ export interface MaximumBranchesExceededException
 
 export namespace MaximumBranchesExceededException {
   export function isa(o: any): o is MaximumBranchesExceededException {
-    return _smithy.isa(o, "MaximumBranchesExceededException");
+    return __isa(o, "MaximumBranchesExceededException");
   }
 }
 
@@ -6012,7 +5997,7 @@ export namespace MaximumBranchesExceededException {
  * <p>The number of allowed conflict resolution entries was exceeded.</p>
  */
 export interface MaximumConflictResolutionEntriesExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "MaximumConflictResolutionEntriesExceededException";
   $fault: "client";
@@ -6026,7 +6011,7 @@ export namespace MaximumConflictResolutionEntriesExceededException {
   export function isa(
     o: any
   ): o is MaximumConflictResolutionEntriesExceededException {
-    return _smithy.isa(o, "MaximumConflictResolutionEntriesExceededException");
+    return __isa(o, "MaximumConflictResolutionEntriesExceededException");
   }
 }
 
@@ -6034,7 +6019,7 @@ export namespace MaximumConflictResolutionEntriesExceededException {
  * <p>The number of files to load exceeds the allowed limit.</p>
  */
 export interface MaximumFileContentToLoadExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "MaximumFileContentToLoadExceededException";
   $fault: "client";
@@ -6046,7 +6031,7 @@ export interface MaximumFileContentToLoadExceededException
 
 export namespace MaximumFileContentToLoadExceededException {
   export function isa(o: any): o is MaximumFileContentToLoadExceededException {
-    return _smithy.isa(o, "MaximumFileContentToLoadExceededException");
+    return __isa(o, "MaximumFileContentToLoadExceededException");
   }
 }
 
@@ -6055,7 +6040,7 @@ export namespace MaximumFileContentToLoadExceededException {
  *         that can be changed in a single commit. Consider using a Git client for these changes.</p>
  */
 export interface MaximumFileEntriesExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "MaximumFileEntriesExceededException";
   $fault: "client";
@@ -6067,7 +6052,7 @@ export interface MaximumFileEntriesExceededException
 
 export namespace MaximumFileEntriesExceededException {
   export function isa(o: any): o is MaximumFileEntriesExceededException {
-    return _smithy.isa(o, "MaximumFileEntriesExceededException");
+    return __isa(o, "MaximumFileEntriesExceededException");
   }
 }
 
@@ -6075,7 +6060,7 @@ export namespace MaximumFileEntriesExceededException {
  * <p>The number of items to compare between the source or destination branches and the merge base has exceeded the maximum allowed.</p>
  */
 export interface MaximumItemsToCompareExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "MaximumItemsToCompareExceededException";
   $fault: "client";
@@ -6087,7 +6072,7 @@ export interface MaximumItemsToCompareExceededException
 
 export namespace MaximumItemsToCompareExceededException {
   export function isa(o: any): o is MaximumItemsToCompareExceededException {
-    return _smithy.isa(o, "MaximumItemsToCompareExceededException");
+    return __isa(o, "MaximumItemsToCompareExceededException");
   }
 }
 
@@ -6095,7 +6080,7 @@ export namespace MaximumItemsToCompareExceededException {
  * <p>The number of approvals required for the approval rule exceeds the maximum number allowed.</p>
  */
 export interface MaximumNumberOfApprovalsExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "MaximumNumberOfApprovalsExceededException";
   $fault: "client";
@@ -6107,7 +6092,7 @@ export interface MaximumNumberOfApprovalsExceededException
 
 export namespace MaximumNumberOfApprovalsExceededException {
   export function isa(o: any): o is MaximumNumberOfApprovalsExceededException {
-    return _smithy.isa(o, "MaximumNumberOfApprovalsExceededException");
+    return __isa(o, "MaximumNumberOfApprovalsExceededException");
   }
 }
 
@@ -6116,7 +6101,7 @@ export namespace MaximumNumberOfApprovalsExceededException {
  *             The maximum number of open pull requests for a repository is 1,000. Close one or more open pull requests, and then try again.</p>
  */
 export interface MaximumOpenPullRequestsExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "MaximumOpenPullRequestsExceededException";
   $fault: "client";
@@ -6128,7 +6113,7 @@ export interface MaximumOpenPullRequestsExceededException
 
 export namespace MaximumOpenPullRequestsExceededException {
   export function isa(o: any): o is MaximumOpenPullRequestsExceededException {
-    return _smithy.isa(o, "MaximumOpenPullRequestsExceededException");
+    return __isa(o, "MaximumOpenPullRequestsExceededException");
   }
 }
 
@@ -6136,7 +6121,7 @@ export namespace MaximumOpenPullRequestsExceededException {
  * <p>The maximum number of allowed repository names was exceeded. Currently, this number is 100.</p>
  */
 export interface MaximumRepositoryNamesExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "MaximumRepositoryNamesExceededException";
   $fault: "client";
@@ -6148,7 +6133,7 @@ export interface MaximumRepositoryNamesExceededException
 
 export namespace MaximumRepositoryNamesExceededException {
   export function isa(o: any): o is MaximumRepositoryNamesExceededException {
-    return _smithy.isa(o, "MaximumRepositoryNamesExceededException");
+    return __isa(o, "MaximumRepositoryNamesExceededException");
   }
 }
 
@@ -6156,7 +6141,7 @@ export namespace MaximumRepositoryNamesExceededException {
  * <p>The number of triggers allowed for the repository was exceeded.</p>
  */
 export interface MaximumRepositoryTriggersExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "MaximumRepositoryTriggersExceededException";
   $fault: "client";
@@ -6168,7 +6153,7 @@ export interface MaximumRepositoryTriggersExceededException
 
 export namespace MaximumRepositoryTriggersExceededException {
   export function isa(o: any): o is MaximumRepositoryTriggersExceededException {
-    return _smithy.isa(o, "MaximumRepositoryTriggersExceededException");
+    return __isa(o, "MaximumRepositoryTriggersExceededException");
   }
 }
 
@@ -6177,7 +6162,7 @@ export namespace MaximumRepositoryTriggersExceededException {
  *         approval rule templates with a repository.</p>
  */
 export interface MaximumRuleTemplatesAssociatedWithRepositoryException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "MaximumRuleTemplatesAssociatedWithRepositoryException";
   $fault: "client";
@@ -6191,10 +6176,7 @@ export namespace MaximumRuleTemplatesAssociatedWithRepositoryException {
   export function isa(
     o: any
   ): o is MaximumRuleTemplatesAssociatedWithRepositoryException {
-    return _smithy.isa(
-      o,
-      "MaximumRuleTemplatesAssociatedWithRepositoryException"
-    );
+    return __isa(o, "MaximumRuleTemplatesAssociatedWithRepositoryException");
   }
 }
 
@@ -6225,7 +6207,7 @@ export interface MergeBranchesByFastForwardInput {
 
 export namespace MergeBranchesByFastForwardInput {
   export function isa(o: any): o is MergeBranchesByFastForwardInput {
-    return _smithy.isa(o, "MergeBranchesByFastForwardInput");
+    return __isa(o, "MergeBranchesByFastForwardInput");
   }
 }
 
@@ -6244,7 +6226,7 @@ export interface MergeBranchesByFastForwardOutput extends $MetadataBearer {
 
 export namespace MergeBranchesByFastForwardOutput {
   export function isa(o: any): o is MergeBranchesByFastForwardOutput {
-    return _smithy.isa(o, "MergeBranchesByFastForwardOutput");
+    return __isa(o, "MergeBranchesByFastForwardOutput");
   }
 }
 
@@ -6320,7 +6302,7 @@ export interface MergeBranchesBySquashInput {
 
 export namespace MergeBranchesBySquashInput {
   export function isa(o: any): o is MergeBranchesBySquashInput {
-    return _smithy.isa(o, "MergeBranchesBySquashInput");
+    return __isa(o, "MergeBranchesBySquashInput");
   }
 }
 
@@ -6339,7 +6321,7 @@ export interface MergeBranchesBySquashOutput extends $MetadataBearer {
 
 export namespace MergeBranchesBySquashOutput {
   export function isa(o: any): o is MergeBranchesBySquashOutput {
-    return _smithy.isa(o, "MergeBranchesBySquashOutput");
+    return __isa(o, "MergeBranchesBySquashOutput");
   }
 }
 
@@ -6415,7 +6397,7 @@ export interface MergeBranchesByThreeWayInput {
 
 export namespace MergeBranchesByThreeWayInput {
   export function isa(o: any): o is MergeBranchesByThreeWayInput {
-    return _smithy.isa(o, "MergeBranchesByThreeWayInput");
+    return __isa(o, "MergeBranchesByThreeWayInput");
   }
 }
 
@@ -6434,7 +6416,7 @@ export interface MergeBranchesByThreeWayOutput extends $MetadataBearer {
 
 export namespace MergeBranchesByThreeWayOutput {
   export function isa(o: any): o is MergeBranchesByThreeWayOutput {
-    return _smithy.isa(o, "MergeBranchesByThreeWayOutput");
+    return __isa(o, "MergeBranchesByThreeWayOutput");
   }
 }
 
@@ -6470,7 +6452,7 @@ export interface MergeHunk {
 
 export namespace MergeHunk {
   export function isa(o: any): o is MergeHunk {
-    return _smithy.isa(o, "MergeHunk");
+    return __isa(o, "MergeHunk");
   }
 }
 
@@ -6498,7 +6480,7 @@ export interface MergeHunkDetail {
 
 export namespace MergeHunkDetail {
   export function isa(o: any): o is MergeHunkDetail {
-    return _smithy.isa(o, "MergeHunkDetail");
+    return __isa(o, "MergeHunkDetail");
   }
 }
 
@@ -6530,7 +6512,7 @@ export interface MergeMetadata {
 
 export namespace MergeMetadata {
   export function isa(o: any): o is MergeMetadata {
-    return _smithy.isa(o, "MergeMetadata");
+    return __isa(o, "MergeMetadata");
   }
 }
 
@@ -6553,7 +6535,7 @@ export interface MergeOperations {
 
 export namespace MergeOperations {
   export function isa(o: any): o is MergeOperations {
-    return _smithy.isa(o, "MergeOperations");
+    return __isa(o, "MergeOperations");
   }
 }
 
@@ -6561,7 +6543,7 @@ export namespace MergeOperations {
  * <p>A merge option or stategy is required, and none was provided.</p>
  */
 export interface MergeOptionRequiredException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "MergeOptionRequiredException";
   $fault: "client";
@@ -6573,7 +6555,7 @@ export interface MergeOptionRequiredException
 
 export namespace MergeOptionRequiredException {
   export function isa(o: any): o is MergeOptionRequiredException {
-    return _smithy.isa(o, "MergeOptionRequiredException");
+    return __isa(o, "MergeOptionRequiredException");
   }
 }
 
@@ -6604,7 +6586,7 @@ export interface MergePullRequestByFastForwardInput {
 
 export namespace MergePullRequestByFastForwardInput {
   export function isa(o: any): o is MergePullRequestByFastForwardInput {
-    return _smithy.isa(o, "MergePullRequestByFastForwardInput");
+    return __isa(o, "MergePullRequestByFastForwardInput");
   }
 }
 
@@ -6618,7 +6600,7 @@ export interface MergePullRequestByFastForwardOutput extends $MetadataBearer {
 
 export namespace MergePullRequestByFastForwardOutput {
   export function isa(o: any): o is MergePullRequestByFastForwardOutput {
-    return _smithy.isa(o, "MergePullRequestByFastForwardOutput");
+    return __isa(o, "MergePullRequestByFastForwardOutput");
   }
 }
 
@@ -6688,7 +6670,7 @@ export interface MergePullRequestBySquashInput {
 
 export namespace MergePullRequestBySquashInput {
   export function isa(o: any): o is MergePullRequestBySquashInput {
-    return _smithy.isa(o, "MergePullRequestBySquashInput");
+    return __isa(o, "MergePullRequestBySquashInput");
   }
 }
 
@@ -6702,7 +6684,7 @@ export interface MergePullRequestBySquashOutput extends $MetadataBearer {
 
 export namespace MergePullRequestBySquashOutput {
   export function isa(o: any): o is MergePullRequestBySquashOutput {
-    return _smithy.isa(o, "MergePullRequestBySquashOutput");
+    return __isa(o, "MergePullRequestBySquashOutput");
   }
 }
 
@@ -6772,7 +6754,7 @@ export interface MergePullRequestByThreeWayInput {
 
 export namespace MergePullRequestByThreeWayInput {
   export function isa(o: any): o is MergePullRequestByThreeWayInput {
-    return _smithy.isa(o, "MergePullRequestByThreeWayInput");
+    return __isa(o, "MergePullRequestByThreeWayInput");
   }
 }
 
@@ -6786,7 +6768,7 @@ export interface MergePullRequestByThreeWayOutput extends $MetadataBearer {
 
 export namespace MergePullRequestByThreeWayOutput {
   export function isa(o: any): o is MergePullRequestByThreeWayOutput {
-    return _smithy.isa(o, "MergePullRequestByThreeWayOutput");
+    return __isa(o, "MergePullRequestByThreeWayOutput");
   }
 }
 
@@ -6794,7 +6776,7 @@ export namespace MergePullRequestByThreeWayOutput {
  * <p>More than one conflict resolution entries exists for the conflict. A conflict can have only one conflict resolution entry.</p>
  */
 export interface MultipleConflictResolutionEntriesException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "MultipleConflictResolutionEntriesException";
   $fault: "client";
@@ -6806,7 +6788,7 @@ export interface MultipleConflictResolutionEntriesException
 
 export namespace MultipleConflictResolutionEntriesException {
   export function isa(o: any): o is MultipleConflictResolutionEntriesException {
-    return _smithy.isa(o, "MultipleConflictResolutionEntriesException");
+    return __isa(o, "MultipleConflictResolutionEntriesException");
   }
 }
 
@@ -6814,7 +6796,7 @@ export namespace MultipleConflictResolutionEntriesException {
  * <p>You cannot include more than one repository in a pull request. Make sure you have specified only one repository name in your request, and then try again.</p>
  */
 export interface MultipleRepositoriesInPullRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "MultipleRepositoriesInPullRequestException";
   $fault: "client";
@@ -6826,7 +6808,7 @@ export interface MultipleRepositoriesInPullRequestException
 
 export namespace MultipleRepositoriesInPullRequestException {
   export function isa(o: any): o is MultipleRepositoriesInPullRequestException {
-    return _smithy.isa(o, "MultipleRepositoriesInPullRequestException");
+    return __isa(o, "MultipleRepositoriesInPullRequestException");
   }
 }
 
@@ -6834,7 +6816,7 @@ export namespace MultipleRepositoriesInPullRequestException {
  * <p>The user name is not valid because it has exceeded the character limit for author names. </p>
  */
 export interface NameLengthExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "NameLengthExceededException";
   $fault: "client";
@@ -6846,16 +6828,14 @@ export interface NameLengthExceededException
 
 export namespace NameLengthExceededException {
   export function isa(o: any): o is NameLengthExceededException {
-    return _smithy.isa(o, "NameLengthExceededException");
+    return __isa(o, "NameLengthExceededException");
   }
 }
 
 /**
  * <p>The commit cannot be created because no changes will be made to the repository as a result of this commit. A commit must contain at least one change.</p>
  */
-export interface NoChangeException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface NoChangeException extends __SmithyException, $MetadataBearer {
   name: "NoChangeException";
   $fault: "client";
   /**
@@ -6866,7 +6846,7 @@ export interface NoChangeException
 
 export namespace NoChangeException {
   export function isa(o: any): o is NoChangeException {
-    return _smithy.isa(o, "NoChangeException");
+    return __isa(o, "NoChangeException");
   }
 }
 
@@ -6874,7 +6854,7 @@ export namespace NoChangeException {
  * <p>The maximum number of approval rule templates has been exceeded for this AWS Region. </p>
  */
 export interface NumberOfRuleTemplatesExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "NumberOfRuleTemplatesExceededException";
   $fault: "client";
@@ -6886,7 +6866,7 @@ export interface NumberOfRuleTemplatesExceededException
 
 export namespace NumberOfRuleTemplatesExceededException {
   export function isa(o: any): o is NumberOfRuleTemplatesExceededException {
-    return _smithy.isa(o, "NumberOfRuleTemplatesExceededException");
+    return __isa(o, "NumberOfRuleTemplatesExceededException");
   }
 }
 
@@ -6894,7 +6874,7 @@ export namespace NumberOfRuleTemplatesExceededException {
  * <p>The approval rule cannot be added. The pull request has the maximum number of approval rules associated with it.</p>
  */
 export interface NumberOfRulesExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "NumberOfRulesExceededException";
   $fault: "client";
@@ -6906,7 +6886,7 @@ export interface NumberOfRulesExceededException
 
 export namespace NumberOfRulesExceededException {
   export function isa(o: any): o is NumberOfRulesExceededException {
-    return _smithy.isa(o, "NumberOfRulesExceededException");
+    return __isa(o, "NumberOfRulesExceededException");
   }
 }
 
@@ -6940,7 +6920,7 @@ export interface ObjectTypes {
 
 export namespace ObjectTypes {
   export function isa(o: any): o is ObjectTypes {
-    return _smithy.isa(o, "ObjectTypes");
+    return __isa(o, "ObjectTypes");
   }
 }
 
@@ -6967,7 +6947,7 @@ export interface OriginApprovalRuleTemplate {
 
 export namespace OriginApprovalRuleTemplate {
   export function isa(o: any): o is OriginApprovalRuleTemplate {
-    return _smithy.isa(o, "OriginApprovalRuleTemplate");
+    return __isa(o, "OriginApprovalRuleTemplate");
   }
 }
 
@@ -6975,7 +6955,7 @@ export namespace OriginApprovalRuleTemplate {
  * <p>The pull request has already had its approval rules set to override.</p>
  */
 export interface OverrideAlreadySetException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "OverrideAlreadySetException";
   $fault: "client";
@@ -6987,7 +6967,7 @@ export interface OverrideAlreadySetException
 
 export namespace OverrideAlreadySetException {
   export function isa(o: any): o is OverrideAlreadySetException {
-    return _smithy.isa(o, "OverrideAlreadySetException");
+    return __isa(o, "OverrideAlreadySetException");
   }
 }
 
@@ -7015,7 +6995,7 @@ export interface OverridePullRequestApprovalRulesInput {
 
 export namespace OverridePullRequestApprovalRulesInput {
   export function isa(o: any): o is OverridePullRequestApprovalRulesInput {
-    return _smithy.isa(o, "OverridePullRequestApprovalRulesInput");
+    return __isa(o, "OverridePullRequestApprovalRulesInput");
   }
 }
 
@@ -7028,7 +7008,7 @@ export enum OverrideStatus {
  * <p>An override status is required, but no value was provided. Valid values include OVERRIDE and REVOKE.</p>
  */
 export interface OverrideStatusRequiredException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "OverrideStatusRequiredException";
   $fault: "client";
@@ -7040,7 +7020,7 @@ export interface OverrideStatusRequiredException
 
 export namespace OverrideStatusRequiredException {
   export function isa(o: any): o is OverrideStatusRequiredException {
-    return _smithy.isa(o, "OverrideStatusRequiredException");
+    return __isa(o, "OverrideStatusRequiredException");
   }
 }
 
@@ -7048,7 +7028,7 @@ export namespace OverrideStatusRequiredException {
  * <p>The parent commit ID is not valid because it does not exist. The specified parent commit ID does not exist in the specified branch of the repository.</p>
  */
 export interface ParentCommitDoesNotExistException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ParentCommitDoesNotExistException";
   $fault: "client";
@@ -7060,7 +7040,7 @@ export interface ParentCommitDoesNotExistException
 
 export namespace ParentCommitDoesNotExistException {
   export function isa(o: any): o is ParentCommitDoesNotExistException {
-    return _smithy.isa(o, "ParentCommitDoesNotExistException");
+    return __isa(o, "ParentCommitDoesNotExistException");
   }
 }
 
@@ -7069,7 +7049,7 @@ export namespace ParentCommitDoesNotExistException {
  *         of the branch, use <a>GetBranch</a>.</p>
  */
 export interface ParentCommitIdOutdatedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ParentCommitIdOutdatedException";
   $fault: "client";
@@ -7081,7 +7061,7 @@ export interface ParentCommitIdOutdatedException
 
 export namespace ParentCommitIdOutdatedException {
   export function isa(o: any): o is ParentCommitIdOutdatedException {
-    return _smithy.isa(o, "ParentCommitIdOutdatedException");
+    return __isa(o, "ParentCommitIdOutdatedException");
   }
 }
 
@@ -7090,7 +7070,7 @@ export namespace ParentCommitIdOutdatedException {
  *         (for example, git pull or git log).</p>
  */
 export interface ParentCommitIdRequiredException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ParentCommitIdRequiredException";
   $fault: "client";
@@ -7102,7 +7082,7 @@ export interface ParentCommitIdRequiredException
 
 export namespace ParentCommitIdRequiredException {
   export function isa(o: any): o is ParentCommitIdRequiredException {
-    return _smithy.isa(o, "ParentCommitIdRequiredException");
+    return __isa(o, "ParentCommitIdRequiredException");
   }
 }
 
@@ -7110,7 +7090,7 @@ export namespace ParentCommitIdRequiredException {
  * <p>The specified path does not exist.</p>
  */
 export interface PathDoesNotExistException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "PathDoesNotExistException";
   $fault: "client";
@@ -7122,7 +7102,7 @@ export interface PathDoesNotExistException
 
 export namespace PathDoesNotExistException {
   export function isa(o: any): o is PathDoesNotExistException {
-    return _smithy.isa(o, "PathDoesNotExistException");
+    return __isa(o, "PathDoesNotExistException");
   }
 }
 
@@ -7130,7 +7110,7 @@ export namespace PathDoesNotExistException {
  * <p>The folderPath for a location cannot be null.</p>
  */
 export interface PathRequiredException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "PathRequiredException";
   $fault: "client";
@@ -7142,7 +7122,7 @@ export interface PathRequiredException
 
 export namespace PathRequiredException {
   export function isa(o: any): o is PathRequiredException {
-    return _smithy.isa(o, "PathRequiredException");
+    return __isa(o, "PathRequiredException");
   }
 }
 
@@ -7187,7 +7167,7 @@ export interface PostCommentForComparedCommitInput {
 
 export namespace PostCommentForComparedCommitInput {
   export function isa(o: any): o is PostCommentForComparedCommitInput {
-    return _smithy.isa(o, "PostCommentForComparedCommitInput");
+    return __isa(o, "PostCommentForComparedCommitInput");
   }
 }
 
@@ -7231,7 +7211,7 @@ export interface PostCommentForComparedCommitOutput extends $MetadataBearer {
 
 export namespace PostCommentForComparedCommitOutput {
   export function isa(o: any): o is PostCommentForComparedCommitOutput {
-    return _smithy.isa(o, "PostCommentForComparedCommitOutput");
+    return __isa(o, "PostCommentForComparedCommitOutput");
   }
 }
 
@@ -7280,7 +7260,7 @@ export interface PostCommentForPullRequestInput {
 
 export namespace PostCommentForPullRequestInput {
   export function isa(o: any): o is PostCommentForPullRequestInput {
-    return _smithy.isa(o, "PostCommentForPullRequestInput");
+    return __isa(o, "PostCommentForPullRequestInput");
   }
 }
 
@@ -7331,7 +7311,7 @@ export interface PostCommentForPullRequestOutput extends $MetadataBearer {
 
 export namespace PostCommentForPullRequestOutput {
   export function isa(o: any): o is PostCommentForPullRequestOutput {
-    return _smithy.isa(o, "PostCommentForPullRequestOutput");
+    return __isa(o, "PostCommentForPullRequestOutput");
   }
 }
 
@@ -7359,7 +7339,7 @@ export interface PostCommentReplyInput {
 
 export namespace PostCommentReplyInput {
   export function isa(o: any): o is PostCommentReplyInput {
-    return _smithy.isa(o, "PostCommentReplyInput");
+    return __isa(o, "PostCommentReplyInput");
   }
 }
 
@@ -7373,7 +7353,7 @@ export interface PostCommentReplyOutput extends $MetadataBearer {
 
 export namespace PostCommentReplyOutput {
   export function isa(o: any): o is PostCommentReplyOutput {
-    return _smithy.isa(o, "PostCommentReplyOutput");
+    return __isa(o, "PostCommentReplyOutput");
   }
 }
 
@@ -7444,7 +7424,7 @@ export interface PullRequest {
 
 export namespace PullRequest {
   export function isa(o: any): o is PullRequest {
-    return _smithy.isa(o, "PullRequest");
+    return __isa(o, "PullRequest");
   }
 }
 
@@ -7452,7 +7432,7 @@ export namespace PullRequest {
  * <p>The pull request status cannot be updated because it is already closed.</p>
  */
 export interface PullRequestAlreadyClosedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "PullRequestAlreadyClosedException";
   $fault: "client";
@@ -7464,7 +7444,7 @@ export interface PullRequestAlreadyClosedException
 
 export namespace PullRequestAlreadyClosedException {
   export function isa(o: any): o is PullRequestAlreadyClosedException {
-    return _smithy.isa(o, "PullRequestAlreadyClosedException");
+    return __isa(o, "PullRequestAlreadyClosedException");
   }
 }
 
@@ -7472,7 +7452,7 @@ export namespace PullRequestAlreadyClosedException {
  * <p>The pull request cannot be merged because one or more approval rules applied to the pull request have conditions that have not been met.</p>
  */
 export interface PullRequestApprovalRulesNotSatisfiedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "PullRequestApprovalRulesNotSatisfiedException";
   $fault: "client";
@@ -7486,7 +7466,7 @@ export namespace PullRequestApprovalRulesNotSatisfiedException {
   export function isa(
     o: any
   ): o is PullRequestApprovalRulesNotSatisfiedException {
-    return _smithy.isa(o, "PullRequestApprovalRulesNotSatisfiedException");
+    return __isa(o, "PullRequestApprovalRulesNotSatisfiedException");
   }
 }
 
@@ -7495,7 +7475,7 @@ export namespace PullRequestApprovalRulesNotSatisfiedException {
  *         request that you created.</p>
  */
 export interface PullRequestCannotBeApprovedByAuthorException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "PullRequestCannotBeApprovedByAuthorException";
   $fault: "client";
@@ -7509,7 +7489,7 @@ export namespace PullRequestCannotBeApprovedByAuthorException {
   export function isa(
     o: any
   ): o is PullRequestCannotBeApprovedByAuthorException {
-    return _smithy.isa(o, "PullRequestCannotBeApprovedByAuthorException");
+    return __isa(o, "PullRequestCannotBeApprovedByAuthorException");
   }
 }
 
@@ -7541,7 +7521,7 @@ export interface PullRequestCreatedEventMetadata {
 
 export namespace PullRequestCreatedEventMetadata {
   export function isa(o: any): o is PullRequestCreatedEventMetadata {
-    return _smithy.isa(o, "PullRequestCreatedEventMetadata");
+    return __isa(o, "PullRequestCreatedEventMetadata");
   }
 }
 
@@ -7549,7 +7529,7 @@ export namespace PullRequestCreatedEventMetadata {
  * <p>The pull request ID could not be found. Make sure that you have specified the correct repository name and pull request ID, and then try again.</p>
  */
 export interface PullRequestDoesNotExistException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "PullRequestDoesNotExistException";
   $fault: "client";
@@ -7561,7 +7541,7 @@ export interface PullRequestDoesNotExistException
 
 export namespace PullRequestDoesNotExistException {
   export function isa(o: any): o is PullRequestDoesNotExistException {
-    return _smithy.isa(o, "PullRequestDoesNotExistException");
+    return __isa(o, "PullRequestDoesNotExistException");
   }
 }
 
@@ -7632,7 +7612,7 @@ export interface PullRequestEvent {
 
 export namespace PullRequestEvent {
   export function isa(o: any): o is PullRequestEvent {
-    return _smithy.isa(o, "PullRequestEvent");
+    return __isa(o, "PullRequestEvent");
   }
 }
 
@@ -7652,7 +7632,7 @@ export enum PullRequestEventType {
  * <p>A pull request ID is required, but none was provided.</p>
  */
 export interface PullRequestIdRequiredException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "PullRequestIdRequiredException";
   $fault: "client";
@@ -7664,7 +7644,7 @@ export interface PullRequestIdRequiredException
 
 export namespace PullRequestIdRequiredException {
   export function isa(o: any): o is PullRequestIdRequiredException {
-    return _smithy.isa(o, "PullRequestIdRequiredException");
+    return __isa(o, "PullRequestIdRequiredException");
   }
 }
 
@@ -7691,7 +7671,7 @@ export interface PullRequestMergedStateChangedEventMetadata {
 
 export namespace PullRequestMergedStateChangedEventMetadata {
   export function isa(o: any): o is PullRequestMergedStateChangedEventMetadata {
-    return _smithy.isa(o, "PullRequestMergedStateChangedEventMetadata");
+    return __isa(o, "PullRequestMergedStateChangedEventMetadata");
   }
 }
 
@@ -7725,7 +7705,7 @@ export namespace PullRequestSourceReferenceUpdatedEventMetadata {
   export function isa(
     o: any
   ): o is PullRequestSourceReferenceUpdatedEventMetadata {
-    return _smithy.isa(o, "PullRequestSourceReferenceUpdatedEventMetadata");
+    return __isa(o, "PullRequestSourceReferenceUpdatedEventMetadata");
   }
 }
 
@@ -7742,7 +7722,7 @@ export interface PullRequestStatusChangedEventMetadata {
 
 export namespace PullRequestStatusChangedEventMetadata {
   export function isa(o: any): o is PullRequestStatusChangedEventMetadata {
-    return _smithy.isa(o, "PullRequestStatusChangedEventMetadata");
+    return __isa(o, "PullRequestStatusChangedEventMetadata");
   }
 }
 
@@ -7755,7 +7735,7 @@ export enum PullRequestStatusEnum {
  * <p>A pull request status is required, but none was provided.</p>
  */
 export interface PullRequestStatusRequiredException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "PullRequestStatusRequiredException";
   $fault: "client";
@@ -7767,7 +7747,7 @@ export interface PullRequestStatusRequiredException
 
 export namespace PullRequestStatusRequiredException {
   export function isa(o: any): o is PullRequestStatusRequiredException {
-    return _smithy.isa(o, "PullRequestStatusRequiredException");
+    return __isa(o, "PullRequestStatusRequiredException");
   }
 }
 
@@ -7817,7 +7797,7 @@ export interface PullRequestTarget {
 
 export namespace PullRequestTarget {
   export function isa(o: any): o is PullRequestTarget {
-    return _smithy.isa(o, "PullRequestTarget");
+    return __isa(o, "PullRequestTarget");
   }
 }
 
@@ -7850,7 +7830,7 @@ export interface PutFileEntry {
 
 export namespace PutFileEntry {
   export function isa(o: any): o is PutFileEntry {
-    return _smithy.isa(o, "PutFileEntry");
+    return __isa(o, "PutFileEntry");
   }
 }
 
@@ -7858,7 +7838,7 @@ export namespace PutFileEntry {
  * <p>The commit cannot be created because one or more files specified in the commit reference both a file and a folder.</p>
  */
 export interface PutFileEntryConflictException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "PutFileEntryConflictException";
   $fault: "client";
@@ -7870,7 +7850,7 @@ export interface PutFileEntryConflictException
 
 export namespace PutFileEntryConflictException {
   export function isa(o: any): o is PutFileEntryConflictException {
-    return _smithy.isa(o, "PutFileEntryConflictException");
+    return __isa(o, "PutFileEntryConflictException");
   }
 }
 
@@ -7935,7 +7915,7 @@ export interface PutFileInput {
 
 export namespace PutFileInput {
   export function isa(o: any): o is PutFileInput {
-    return _smithy.isa(o, "PutFileInput");
+    return __isa(o, "PutFileInput");
   }
 }
 
@@ -7959,7 +7939,7 @@ export interface PutFileOutput extends $MetadataBearer {
 
 export namespace PutFileOutput {
   export function isa(o: any): o is PutFileOutput {
-    return _smithy.isa(o, "PutFileOutput");
+    return __isa(o, "PutFileOutput");
   }
 }
 
@@ -7981,7 +7961,7 @@ export interface PutRepositoryTriggersInput {
 
 export namespace PutRepositoryTriggersInput {
   export function isa(o: any): o is PutRepositoryTriggersInput {
-    return _smithy.isa(o, "PutRepositoryTriggersInput");
+    return __isa(o, "PutRepositoryTriggersInput");
   }
 }
 
@@ -7998,7 +7978,7 @@ export interface PutRepositoryTriggersOutput extends $MetadataBearer {
 
 export namespace PutRepositoryTriggersOutput {
   export function isa(o: any): o is PutRepositoryTriggersOutput {
-    return _smithy.isa(o, "PutRepositoryTriggersOutput");
+    return __isa(o, "PutRepositoryTriggersOutput");
   }
 }
 
@@ -8006,7 +7986,7 @@ export namespace PutRepositoryTriggersOutput {
  * <p>The specified reference does not exist. You must provide a full commit ID.</p>
  */
 export interface ReferenceDoesNotExistException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ReferenceDoesNotExistException";
   $fault: "client";
@@ -8018,7 +7998,7 @@ export interface ReferenceDoesNotExistException
 
 export namespace ReferenceDoesNotExistException {
   export function isa(o: any): o is ReferenceDoesNotExistException {
-    return _smithy.isa(o, "ReferenceDoesNotExistException");
+    return __isa(o, "ReferenceDoesNotExistException");
   }
 }
 
@@ -8026,7 +8006,7 @@ export namespace ReferenceDoesNotExistException {
  * <p>A reference name is required, but none was provided.</p>
  */
 export interface ReferenceNameRequiredException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ReferenceNameRequiredException";
   $fault: "client";
@@ -8038,7 +8018,7 @@ export interface ReferenceNameRequiredException
 
 export namespace ReferenceNameRequiredException {
   export function isa(o: any): o is ReferenceNameRequiredException {
-    return _smithy.isa(o, "ReferenceNameRequiredException");
+    return __isa(o, "ReferenceNameRequiredException");
   }
 }
 
@@ -8046,7 +8026,7 @@ export namespace ReferenceNameRequiredException {
  * <p>The specified reference is not a supported type. </p>
  */
 export interface ReferenceTypeNotSupportedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ReferenceTypeNotSupportedException";
   $fault: "client";
@@ -8058,7 +8038,7 @@ export interface ReferenceTypeNotSupportedException
 
 export namespace ReferenceTypeNotSupportedException {
   export function isa(o: any): o is ReferenceTypeNotSupportedException {
-    return _smithy.isa(o, "ReferenceTypeNotSupportedException");
+    return __isa(o, "ReferenceTypeNotSupportedException");
   }
 }
 
@@ -8095,7 +8075,7 @@ export interface ReplaceContentEntry {
 
 export namespace ReplaceContentEntry {
   export function isa(o: any): o is ReplaceContentEntry {
-    return _smithy.isa(o, "ReplaceContentEntry");
+    return __isa(o, "ReplaceContentEntry");
   }
 }
 
@@ -8103,7 +8083,7 @@ export namespace ReplaceContentEntry {
  * <p>USE_NEW_CONTENT was specified, but no replacement content has been provided.</p>
  */
 export interface ReplacementContentRequiredException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ReplacementContentRequiredException";
   $fault: "client";
@@ -8115,7 +8095,7 @@ export interface ReplacementContentRequiredException
 
 export namespace ReplacementContentRequiredException {
   export function isa(o: any): o is ReplacementContentRequiredException {
-    return _smithy.isa(o, "ReplacementContentRequiredException");
+    return __isa(o, "ReplacementContentRequiredException");
   }
 }
 
@@ -8130,7 +8110,7 @@ export enum ReplacementTypeEnum {
  * <p>A replacement type is required.</p>
  */
 export interface ReplacementTypeRequiredException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ReplacementTypeRequiredException";
   $fault: "client";
@@ -8142,7 +8122,7 @@ export interface ReplacementTypeRequiredException
 
 export namespace ReplacementTypeRequiredException {
   export function isa(o: any): o is ReplacementTypeRequiredException {
-    return _smithy.isa(o, "ReplacementTypeRequiredException");
+    return __isa(o, "ReplacementTypeRequiredException");
   }
 }
 
@@ -8150,7 +8130,7 @@ export namespace ReplacementTypeRequiredException {
  * <p>The specified repository does not exist.</p>
  */
 export interface RepositoryDoesNotExistException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "RepositoryDoesNotExistException";
   $fault: "client";
@@ -8162,7 +8142,7 @@ export interface RepositoryDoesNotExistException
 
 export namespace RepositoryDoesNotExistException {
   export function isa(o: any): o is RepositoryDoesNotExistException {
-    return _smithy.isa(o, "RepositoryDoesNotExistException");
+    return __isa(o, "RepositoryDoesNotExistException");
   }
 }
 
@@ -8170,7 +8150,7 @@ export namespace RepositoryDoesNotExistException {
  * <p>A repository resource limit was exceeded.</p>
  */
 export interface RepositoryLimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "RepositoryLimitExceededException";
   $fault: "client";
@@ -8182,7 +8162,7 @@ export interface RepositoryLimitExceededException
 
 export namespace RepositoryLimitExceededException {
   export function isa(o: any): o is RepositoryLimitExceededException {
-    return _smithy.isa(o, "RepositoryLimitExceededException");
+    return __isa(o, "RepositoryLimitExceededException");
   }
 }
 
@@ -8244,7 +8224,7 @@ export interface RepositoryMetadata {
 
 export namespace RepositoryMetadata {
   export function isa(o: any): o is RepositoryMetadata {
-    return _smithy.isa(o, "RepositoryMetadata");
+    return __isa(o, "RepositoryMetadata");
   }
 }
 
@@ -8252,7 +8232,7 @@ export namespace RepositoryMetadata {
  * <p>The specified repository name already exists.</p>
  */
 export interface RepositoryNameExistsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "RepositoryNameExistsException";
   $fault: "client";
@@ -8264,7 +8244,7 @@ export interface RepositoryNameExistsException
 
 export namespace RepositoryNameExistsException {
   export function isa(o: any): o is RepositoryNameExistsException {
-    return _smithy.isa(o, "RepositoryNameExistsException");
+    return __isa(o, "RepositoryNameExistsException");
   }
 }
 
@@ -8286,7 +8266,7 @@ export interface RepositoryNameIdPair {
 
 export namespace RepositoryNameIdPair {
   export function isa(o: any): o is RepositoryNameIdPair {
-    return _smithy.isa(o, "RepositoryNameIdPair");
+    return __isa(o, "RepositoryNameIdPair");
   }
 }
 
@@ -8294,7 +8274,7 @@ export namespace RepositoryNameIdPair {
  * <p>A repository name is required, but was not specified.</p>
  */
 export interface RepositoryNameRequiredException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "RepositoryNameRequiredException";
   $fault: "client";
@@ -8306,7 +8286,7 @@ export interface RepositoryNameRequiredException
 
 export namespace RepositoryNameRequiredException {
   export function isa(o: any): o is RepositoryNameRequiredException {
-    return _smithy.isa(o, "RepositoryNameRequiredException");
+    return __isa(o, "RepositoryNameRequiredException");
   }
 }
 
@@ -8314,7 +8294,7 @@ export namespace RepositoryNameRequiredException {
  * <p>At least one repository name object is required, but was not specified.</p>
  */
 export interface RepositoryNamesRequiredException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "RepositoryNamesRequiredException";
   $fault: "client";
@@ -8326,7 +8306,7 @@ export interface RepositoryNamesRequiredException
 
 export namespace RepositoryNamesRequiredException {
   export function isa(o: any): o is RepositoryNamesRequiredException {
-    return _smithy.isa(o, "RepositoryNamesRequiredException");
+    return __isa(o, "RepositoryNamesRequiredException");
   }
 }
 
@@ -8334,7 +8314,7 @@ export namespace RepositoryNamesRequiredException {
  * <p>The repository does not contain any pull requests with that pull request ID. Use GetPullRequest to verify the correct repository name for the pull request ID.</p>
  */
 export interface RepositoryNotAssociatedWithPullRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "RepositoryNotAssociatedWithPullRequestException";
   $fault: "client";
@@ -8348,7 +8328,7 @@ export namespace RepositoryNotAssociatedWithPullRequestException {
   export function isa(
     o: any
   ): o is RepositoryNotAssociatedWithPullRequestException {
-    return _smithy.isa(o, "RepositoryNotAssociatedWithPullRequestException");
+    return __isa(o, "RepositoryNotAssociatedWithPullRequestException");
   }
 }
 
@@ -8397,7 +8377,7 @@ export interface RepositoryTrigger {
 
 export namespace RepositoryTrigger {
   export function isa(o: any): o is RepositoryTrigger {
-    return _smithy.isa(o, "RepositoryTrigger");
+    return __isa(o, "RepositoryTrigger");
   }
 }
 
@@ -8406,7 +8386,7 @@ export namespace RepositoryTrigger {
  *             configuration.</p>
  */
 export interface RepositoryTriggerBranchNameListRequiredException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "RepositoryTriggerBranchNameListRequiredException";
   $fault: "client";
@@ -8420,7 +8400,7 @@ export namespace RepositoryTriggerBranchNameListRequiredException {
   export function isa(
     o: any
   ): o is RepositoryTriggerBranchNameListRequiredException {
-    return _smithy.isa(o, "RepositoryTriggerBranchNameListRequiredException");
+    return __isa(o, "RepositoryTriggerBranchNameListRequiredException");
   }
 }
 
@@ -8429,7 +8409,7 @@ export namespace RepositoryTriggerBranchNameListRequiredException {
  *             specified.</p>
  */
 export interface RepositoryTriggerDestinationArnRequiredException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "RepositoryTriggerDestinationArnRequiredException";
   $fault: "client";
@@ -8443,7 +8423,7 @@ export namespace RepositoryTriggerDestinationArnRequiredException {
   export function isa(
     o: any
   ): o is RepositoryTriggerDestinationArnRequiredException {
-    return _smithy.isa(o, "RepositoryTriggerDestinationArnRequiredException");
+    return __isa(o, "RepositoryTriggerDestinationArnRequiredException");
   }
 }
 
@@ -8458,7 +8438,7 @@ export enum RepositoryTriggerEventEnum {
  * <p>At least one event for the trigger is required, but was not specified.</p>
  */
 export interface RepositoryTriggerEventsListRequiredException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "RepositoryTriggerEventsListRequiredException";
   $fault: "client";
@@ -8472,7 +8452,7 @@ export namespace RepositoryTriggerEventsListRequiredException {
   export function isa(
     o: any
   ): o is RepositoryTriggerEventsListRequiredException {
-    return _smithy.isa(o, "RepositoryTriggerEventsListRequiredException");
+    return __isa(o, "RepositoryTriggerEventsListRequiredException");
   }
 }
 
@@ -8494,7 +8474,7 @@ export interface RepositoryTriggerExecutionFailure {
 
 export namespace RepositoryTriggerExecutionFailure {
   export function isa(o: any): o is RepositoryTriggerExecutionFailure {
-    return _smithy.isa(o, "RepositoryTriggerExecutionFailure");
+    return __isa(o, "RepositoryTriggerExecutionFailure");
   }
 }
 
@@ -8502,7 +8482,7 @@ export namespace RepositoryTriggerExecutionFailure {
  * <p>A name for the trigger is required, but was not specified.</p>
  */
 export interface RepositoryTriggerNameRequiredException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "RepositoryTriggerNameRequiredException";
   $fault: "client";
@@ -8514,7 +8494,7 @@ export interface RepositoryTriggerNameRequiredException
 
 export namespace RepositoryTriggerNameRequiredException {
   export function isa(o: any): o is RepositoryTriggerNameRequiredException {
-    return _smithy.isa(o, "RepositoryTriggerNameRequiredException");
+    return __isa(o, "RepositoryTriggerNameRequiredException");
   }
 }
 
@@ -8522,7 +8502,7 @@ export namespace RepositoryTriggerNameRequiredException {
  * <p>The list of triggers for the repository is required, but was not specified.</p>
  */
 export interface RepositoryTriggersListRequiredException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "RepositoryTriggersListRequiredException";
   $fault: "client";
@@ -8534,7 +8514,7 @@ export interface RepositoryTriggersListRequiredException
 
 export namespace RepositoryTriggersListRequiredException {
   export function isa(o: any): o is RepositoryTriggersListRequiredException {
-    return _smithy.isa(o, "RepositoryTriggersListRequiredException");
+    return __isa(o, "RepositoryTriggersListRequiredException");
   }
 }
 
@@ -8544,7 +8524,7 @@ export namespace RepositoryTriggersListRequiredException {
  *             in the AWS CodeCommit User Guide.</p>
  */
 export interface ResourceArnRequiredException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceArnRequiredException";
   $fault: "client";
@@ -8556,7 +8536,7 @@ export interface ResourceArnRequiredException
 
 export namespace ResourceArnRequiredException {
   export function isa(o: any): o is ResourceArnRequiredException {
-    return _smithy.isa(o, "ResourceArnRequiredException");
+    return __isa(o, "ResourceArnRequiredException");
   }
 }
 
@@ -8564,7 +8544,7 @@ export namespace ResourceArnRequiredException {
  * <p>The commit cannot be created because one of the changes specifies copying or moving a .gitkeep file.</p>
  */
 export interface RestrictedSourceFileException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "RestrictedSourceFileException";
   $fault: "client";
@@ -8576,7 +8556,7 @@ export interface RestrictedSourceFileException
 
 export namespace RestrictedSourceFileException {
   export function isa(o: any): o is RestrictedSourceFileException {
-    return _smithy.isa(o, "RestrictedSourceFileException");
+    return __isa(o, "RestrictedSourceFileException");
   }
 }
 
@@ -8584,7 +8564,7 @@ export namespace RestrictedSourceFileException {
  * <p>A revision ID is required, but was not provided.</p>
  */
 export interface RevisionIdRequiredException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "RevisionIdRequiredException";
   $fault: "client";
@@ -8596,7 +8576,7 @@ export interface RevisionIdRequiredException
 
 export namespace RevisionIdRequiredException {
   export function isa(o: any): o is RevisionIdRequiredException {
-    return _smithy.isa(o, "RevisionIdRequiredException");
+    return __isa(o, "RevisionIdRequiredException");
   }
 }
 
@@ -8604,7 +8584,7 @@ export namespace RevisionIdRequiredException {
  * <p>The revision ID provided in the request does not match the current revision ID. Use GetPullRequest to retrieve the current revision ID.</p>
  */
 export interface RevisionNotCurrentException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "RevisionNotCurrentException";
   $fault: "client";
@@ -8616,7 +8596,7 @@ export interface RevisionNotCurrentException
 
 export namespace RevisionNotCurrentException {
   export function isa(o: any): o is RevisionNotCurrentException {
-    return _smithy.isa(o, "RevisionNotCurrentException");
+    return __isa(o, "RevisionNotCurrentException");
   }
 }
 
@@ -8625,7 +8605,7 @@ export namespace RevisionNotCurrentException {
  *         that you specified.</p>
  */
 export interface SameFileContentException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "SameFileContentException";
   $fault: "client";
@@ -8637,7 +8617,7 @@ export interface SameFileContentException
 
 export namespace SameFileContentException {
   export function isa(o: any): o is SameFileContentException {
-    return _smithy.isa(o, "SameFileContentException");
+    return __isa(o, "SameFileContentException");
   }
 }
 
@@ -8647,7 +8627,7 @@ export namespace SameFileContentException {
  *         file as part of the same commit.</p>
  */
 export interface SamePathRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "SamePathRequestException";
   $fault: "client";
@@ -8659,7 +8639,7 @@ export interface SamePathRequestException
 
 export namespace SamePathRequestException {
   export function isa(o: any): o is SamePathRequestException {
-    return _smithy.isa(o, "SamePathRequestException");
+    return __isa(o, "SamePathRequestException");
   }
 }
 
@@ -8681,7 +8661,7 @@ export interface SetFileModeEntry {
 
 export namespace SetFileModeEntry {
   export function isa(o: any): o is SetFileModeEntry {
-    return _smithy.isa(o, "SetFileModeEntry");
+    return __isa(o, "SetFileModeEntry");
   }
 }
 
@@ -8695,7 +8675,7 @@ export enum SortByEnum {
  *             specify different branches for the source and destination.</p>
  */
 export interface SourceAndDestinationAreSameException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "SourceAndDestinationAreSameException";
   $fault: "client";
@@ -8707,7 +8687,7 @@ export interface SourceAndDestinationAreSameException
 
 export namespace SourceAndDestinationAreSameException {
   export function isa(o: any): o is SourceAndDestinationAreSameException {
-    return _smithy.isa(o, "SourceAndDestinationAreSameException");
+    return __isa(o, "SourceAndDestinationAreSameException");
   }
 }
 
@@ -8715,7 +8695,7 @@ export namespace SourceAndDestinationAreSameException {
  * <p>The commit cannot be created because no source files or file content have been specified for the commit.</p>
  */
 export interface SourceFileOrContentRequiredException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "SourceFileOrContentRequiredException";
   $fault: "client";
@@ -8727,7 +8707,7 @@ export interface SourceFileOrContentRequiredException
 
 export namespace SourceFileOrContentRequiredException {
   export function isa(o: any): o is SourceFileOrContentRequiredException {
-    return _smithy.isa(o, "SourceFileOrContentRequiredException");
+    return __isa(o, "SourceFileOrContentRequiredException");
   }
 }
 
@@ -8749,7 +8729,7 @@ export interface SourceFileSpecifier {
 
 export namespace SourceFileSpecifier {
   export function isa(o: any): o is SourceFileSpecifier {
-    return _smithy.isa(o, "SourceFileSpecifier");
+    return __isa(o, "SourceFileSpecifier");
   }
 }
 
@@ -8776,7 +8756,7 @@ export interface SubModule {
 
 export namespace SubModule {
   export function isa(o: any): o is SubModule {
-    return _smithy.isa(o, "SubModule");
+    return __isa(o, "SubModule");
   }
 }
 
@@ -8808,7 +8788,7 @@ export interface SymbolicLink {
 
 export namespace SymbolicLink {
   export function isa(o: any): o is SymbolicLink {
-    return _smithy.isa(o, "SymbolicLink");
+    return __isa(o, "SymbolicLink");
   }
 }
 
@@ -8816,7 +8796,7 @@ export namespace SymbolicLink {
  * <p>A list of tag keys is required. The list cannot be empty or null.</p>
  */
 export interface TagKeysListRequiredException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TagKeysListRequiredException";
   $fault: "client";
@@ -8828,16 +8808,14 @@ export interface TagKeysListRequiredException
 
 export namespace TagKeysListRequiredException {
   export function isa(o: any): o is TagKeysListRequiredException {
-    return _smithy.isa(o, "TagKeysListRequiredException");
+    return __isa(o, "TagKeysListRequiredException");
   }
 }
 
 /**
  * <p>The tag policy is not valid.</p>
  */
-export interface TagPolicyException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface TagPolicyException extends __SmithyException, $MetadataBearer {
   name: "TagPolicyException";
   $fault: "client";
   /**
@@ -8848,7 +8826,7 @@ export interface TagPolicyException
 
 export namespace TagPolicyException {
   export function isa(o: any): o is TagPolicyException {
-    return _smithy.isa(o, "TagPolicyException");
+    return __isa(o, "TagPolicyException");
   }
 }
 
@@ -8867,7 +8845,7 @@ export interface TagResourceInput {
 
 export namespace TagResourceInput {
   export function isa(o: any): o is TagResourceInput {
-    return _smithy.isa(o, "TagResourceInput");
+    return __isa(o, "TagResourceInput");
   }
 }
 
@@ -8875,7 +8853,7 @@ export namespace TagResourceInput {
  * <p>A map of tags is required.</p>
  */
 export interface TagsMapRequiredException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TagsMapRequiredException";
   $fault: "client";
@@ -8887,7 +8865,7 @@ export interface TagsMapRequiredException
 
 export namespace TagsMapRequiredException {
   export function isa(o: any): o is TagsMapRequiredException {
-    return _smithy.isa(o, "TagsMapRequiredException");
+    return __isa(o, "TagsMapRequiredException");
   }
 }
 
@@ -8915,7 +8893,7 @@ export interface Target {
 
 export namespace Target {
   export function isa(o: any): o is Target {
-    return _smithy.isa(o, "Target");
+    return __isa(o, "Target");
   }
 }
 
@@ -8923,7 +8901,7 @@ export namespace Target {
  * <p>A pull request target is required. It cannot be empty or null. A pull request target must contain the full values for the repository name, source branch, and destination branch for the pull request.</p>
  */
 export interface TargetRequiredException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TargetRequiredException";
   $fault: "client";
@@ -8935,7 +8913,7 @@ export interface TargetRequiredException
 
 export namespace TargetRequiredException {
   export function isa(o: any): o is TargetRequiredException {
-    return _smithy.isa(o, "TargetRequiredException");
+    return __isa(o, "TargetRequiredException");
   }
 }
 
@@ -8943,7 +8921,7 @@ export namespace TargetRequiredException {
  * <p>An array of target objects is required. It cannot be empty or null.</p>
  */
 export interface TargetsRequiredException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TargetsRequiredException";
   $fault: "client";
@@ -8955,7 +8933,7 @@ export interface TargetsRequiredException
 
 export namespace TargetsRequiredException {
   export function isa(o: any): o is TargetsRequiredException {
-    return _smithy.isa(o, "TargetsRequiredException");
+    return __isa(o, "TargetsRequiredException");
   }
 }
 
@@ -8977,7 +8955,7 @@ export interface TestRepositoryTriggersInput {
 
 export namespace TestRepositoryTriggersInput {
   export function isa(o: any): o is TestRepositoryTriggersInput {
-    return _smithy.isa(o, "TestRepositoryTriggersInput");
+    return __isa(o, "TestRepositoryTriggersInput");
   }
 }
 
@@ -9000,7 +8978,7 @@ export interface TestRepositoryTriggersOutput extends $MetadataBearer {
 
 export namespace TestRepositoryTriggersOutput {
   export function isa(o: any): o is TestRepositoryTriggersOutput {
-    return _smithy.isa(o, "TestRepositoryTriggersOutput");
+    return __isa(o, "TestRepositoryTriggersOutput");
   }
 }
 
@@ -9009,7 +8987,7 @@ export namespace TestRepositoryTriggersOutput {
  *             The pull request might have been updated. Make sure that you have the latest changes.</p>
  */
 export interface TipOfSourceReferenceIsDifferentException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TipOfSourceReferenceIsDifferentException";
   $fault: "client";
@@ -9021,7 +8999,7 @@ export interface TipOfSourceReferenceIsDifferentException
 
 export namespace TipOfSourceReferenceIsDifferentException {
   export function isa(o: any): o is TipOfSourceReferenceIsDifferentException {
-    return _smithy.isa(o, "TipOfSourceReferenceIsDifferentException");
+    return __isa(o, "TipOfSourceReferenceIsDifferentException");
   }
 }
 
@@ -9030,7 +9008,7 @@ export namespace TipOfSourceReferenceIsDifferentException {
  *             any merge conflicts. Locally compare the specifiers using <code>git diff</code> or a diff tool.</p>
  */
 export interface TipsDivergenceExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TipsDivergenceExceededException";
   $fault: "client";
@@ -9042,7 +9020,7 @@ export interface TipsDivergenceExceededException
 
 export namespace TipsDivergenceExceededException {
   export function isa(o: any): o is TipsDivergenceExceededException {
-    return _smithy.isa(o, "TipsDivergenceExceededException");
+    return __isa(o, "TipsDivergenceExceededException");
   }
 }
 
@@ -9050,7 +9028,7 @@ export namespace TipsDivergenceExceededException {
  * <p>A pull request title is required. It cannot be empty or null.</p>
  */
 export interface TitleRequiredException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TitleRequiredException";
   $fault: "client";
@@ -9062,7 +9040,7 @@ export interface TitleRequiredException
 
 export namespace TitleRequiredException {
   export function isa(o: any): o is TitleRequiredException {
-    return _smithy.isa(o, "TitleRequiredException");
+    return __isa(o, "TitleRequiredException");
   }
 }
 
@@ -9070,7 +9048,7 @@ export namespace TitleRequiredException {
  * <p>The maximum number of tags for an AWS CodeCommit resource has been exceeded.</p>
  */
 export interface TooManyTagsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyTagsException";
   $fault: "client";
@@ -9082,7 +9060,7 @@ export interface TooManyTagsException
 
 export namespace TooManyTagsException {
   export function isa(o: any): o is TooManyTagsException {
-    return _smithy.isa(o, "TooManyTagsException");
+    return __isa(o, "TooManyTagsException");
   }
 }
 
@@ -9101,7 +9079,7 @@ export interface UntagResourceInput {
 
 export namespace UntagResourceInput {
   export function isa(o: any): o is UntagResourceInput {
-    return _smithy.isa(o, "UntagResourceInput");
+    return __isa(o, "UntagResourceInput");
   }
 }
 
@@ -9128,7 +9106,7 @@ export interface UpdateApprovalRuleTemplateContentInput {
 
 export namespace UpdateApprovalRuleTemplateContentInput {
   export function isa(o: any): o is UpdateApprovalRuleTemplateContentInput {
-    return _smithy.isa(o, "UpdateApprovalRuleTemplateContentInput");
+    return __isa(o, "UpdateApprovalRuleTemplateContentInput");
   }
 }
 
@@ -9143,7 +9121,7 @@ export interface UpdateApprovalRuleTemplateContentOutput
 
 export namespace UpdateApprovalRuleTemplateContentOutput {
   export function isa(o: any): o is UpdateApprovalRuleTemplateContentOutput {
-    return _smithy.isa(o, "UpdateApprovalRuleTemplateContentOutput");
+    return __isa(o, "UpdateApprovalRuleTemplateContentOutput");
   }
 }
 
@@ -9162,7 +9140,7 @@ export interface UpdateApprovalRuleTemplateDescriptionInput {
 
 export namespace UpdateApprovalRuleTemplateDescriptionInput {
   export function isa(o: any): o is UpdateApprovalRuleTemplateDescriptionInput {
-    return _smithy.isa(o, "UpdateApprovalRuleTemplateDescriptionInput");
+    return __isa(o, "UpdateApprovalRuleTemplateDescriptionInput");
   }
 }
 
@@ -9179,7 +9157,7 @@ export namespace UpdateApprovalRuleTemplateDescriptionOutput {
   export function isa(
     o: any
   ): o is UpdateApprovalRuleTemplateDescriptionOutput {
-    return _smithy.isa(o, "UpdateApprovalRuleTemplateDescriptionOutput");
+    return __isa(o, "UpdateApprovalRuleTemplateDescriptionOutput");
   }
 }
 
@@ -9198,7 +9176,7 @@ export interface UpdateApprovalRuleTemplateNameInput {
 
 export namespace UpdateApprovalRuleTemplateNameInput {
   export function isa(o: any): o is UpdateApprovalRuleTemplateNameInput {
-    return _smithy.isa(o, "UpdateApprovalRuleTemplateNameInput");
+    return __isa(o, "UpdateApprovalRuleTemplateNameInput");
   }
 }
 
@@ -9212,7 +9190,7 @@ export interface UpdateApprovalRuleTemplateNameOutput extends $MetadataBearer {
 
 export namespace UpdateApprovalRuleTemplateNameOutput {
   export function isa(o: any): o is UpdateApprovalRuleTemplateNameOutput {
-    return _smithy.isa(o, "UpdateApprovalRuleTemplateNameOutput");
+    return __isa(o, "UpdateApprovalRuleTemplateNameOutput");
   }
 }
 
@@ -9232,7 +9210,7 @@ export interface UpdateCommentInput {
 
 export namespace UpdateCommentInput {
   export function isa(o: any): o is UpdateCommentInput {
-    return _smithy.isa(o, "UpdateCommentInput");
+    return __isa(o, "UpdateCommentInput");
   }
 }
 
@@ -9246,7 +9224,7 @@ export interface UpdateCommentOutput extends $MetadataBearer {
 
 export namespace UpdateCommentOutput {
   export function isa(o: any): o is UpdateCommentOutput {
-    return _smithy.isa(o, "UpdateCommentOutput");
+    return __isa(o, "UpdateCommentOutput");
   }
 }
 
@@ -9268,7 +9246,7 @@ export interface UpdateDefaultBranchInput {
 
 export namespace UpdateDefaultBranchInput {
   export function isa(o: any): o is UpdateDefaultBranchInput {
-    return _smithy.isa(o, "UpdateDefaultBranchInput");
+    return __isa(o, "UpdateDefaultBranchInput");
   }
 }
 
@@ -9339,7 +9317,7 @@ export interface UpdatePullRequestApprovalRuleContentInput {
 
 export namespace UpdatePullRequestApprovalRuleContentInput {
   export function isa(o: any): o is UpdatePullRequestApprovalRuleContentInput {
-    return _smithy.isa(o, "UpdatePullRequestApprovalRuleContentInput");
+    return __isa(o, "UpdatePullRequestApprovalRuleContentInput");
   }
 }
 
@@ -9354,7 +9332,7 @@ export interface UpdatePullRequestApprovalRuleContentOutput
 
 export namespace UpdatePullRequestApprovalRuleContentOutput {
   export function isa(o: any): o is UpdatePullRequestApprovalRuleContentOutput {
-    return _smithy.isa(o, "UpdatePullRequestApprovalRuleContentOutput");
+    return __isa(o, "UpdatePullRequestApprovalRuleContentOutput");
   }
 }
 
@@ -9378,7 +9356,7 @@ export interface UpdatePullRequestApprovalStateInput {
 
 export namespace UpdatePullRequestApprovalStateInput {
   export function isa(o: any): o is UpdatePullRequestApprovalStateInput {
-    return _smithy.isa(o, "UpdatePullRequestApprovalStateInput");
+    return __isa(o, "UpdatePullRequestApprovalStateInput");
   }
 }
 
@@ -9398,7 +9376,7 @@ export interface UpdatePullRequestDescriptionInput {
 
 export namespace UpdatePullRequestDescriptionInput {
   export function isa(o: any): o is UpdatePullRequestDescriptionInput {
-    return _smithy.isa(o, "UpdatePullRequestDescriptionInput");
+    return __isa(o, "UpdatePullRequestDescriptionInput");
   }
 }
 
@@ -9412,7 +9390,7 @@ export interface UpdatePullRequestDescriptionOutput extends $MetadataBearer {
 
 export namespace UpdatePullRequestDescriptionOutput {
   export function isa(o: any): o is UpdatePullRequestDescriptionOutput {
-    return _smithy.isa(o, "UpdatePullRequestDescriptionOutput");
+    return __isa(o, "UpdatePullRequestDescriptionOutput");
   }
 }
 
@@ -9433,7 +9411,7 @@ export interface UpdatePullRequestStatusInput {
 
 export namespace UpdatePullRequestStatusInput {
   export function isa(o: any): o is UpdatePullRequestStatusInput {
-    return _smithy.isa(o, "UpdatePullRequestStatusInput");
+    return __isa(o, "UpdatePullRequestStatusInput");
   }
 }
 
@@ -9447,7 +9425,7 @@ export interface UpdatePullRequestStatusOutput extends $MetadataBearer {
 
 export namespace UpdatePullRequestStatusOutput {
   export function isa(o: any): o is UpdatePullRequestStatusOutput {
-    return _smithy.isa(o, "UpdatePullRequestStatusOutput");
+    return __isa(o, "UpdatePullRequestStatusOutput");
   }
 }
 
@@ -9466,7 +9444,7 @@ export interface UpdatePullRequestTitleInput {
 
 export namespace UpdatePullRequestTitleInput {
   export function isa(o: any): o is UpdatePullRequestTitleInput {
-    return _smithy.isa(o, "UpdatePullRequestTitleInput");
+    return __isa(o, "UpdatePullRequestTitleInput");
   }
 }
 
@@ -9480,7 +9458,7 @@ export interface UpdatePullRequestTitleOutput extends $MetadataBearer {
 
 export namespace UpdatePullRequestTitleOutput {
   export function isa(o: any): o is UpdatePullRequestTitleOutput {
-    return _smithy.isa(o, "UpdatePullRequestTitleOutput");
+    return __isa(o, "UpdatePullRequestTitleOutput");
   }
 }
 
@@ -9502,7 +9480,7 @@ export interface UpdateRepositoryDescriptionInput {
 
 export namespace UpdateRepositoryDescriptionInput {
   export function isa(o: any): o is UpdateRepositoryDescriptionInput {
-    return _smithy.isa(o, "UpdateRepositoryDescriptionInput");
+    return __isa(o, "UpdateRepositoryDescriptionInput");
   }
 }
 
@@ -9524,7 +9502,7 @@ export interface UpdateRepositoryNameInput {
 
 export namespace UpdateRepositoryNameInput {
   export function isa(o: any): o is UpdateRepositoryNameInput {
-    return _smithy.isa(o, "UpdateRepositoryNameInput");
+    return __isa(o, "UpdateRepositoryNameInput");
   }
 }
 
@@ -9551,6 +9529,6 @@ export interface UserInfo {
 
 export namespace UserInfo {
   export function isa(o: any): o is UserInfo {
-    return _smithy.isa(o, "UserInfo");
+    return __isa(o, "UserInfo");
   }
 }

--- a/clients/client-codecommit/protocols/Aws_json1_1.ts
+++ b/clients/client-codecommit/protocols/Aws_json1_1.ts
@@ -1756,6 +1756,7 @@ export async function deserializeAws_json1_1AssociateApprovalRuleTemplateWithRep
       context
     );
   }
+  await collectBody(output.body, context);
   const response: AssociateApprovalRuleTemplateWithRepositoryCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2667,6 +2668,7 @@ export async function deserializeAws_json1_1CreateBranchCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1CreateBranchCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: CreateBranchCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -5046,6 +5048,7 @@ export async function deserializeAws_json1_1DisassociateApprovalRuleTemplateFrom
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DisassociateApprovalRuleTemplateFromRepositoryCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -10066,6 +10069,7 @@ export async function deserializeAws_json1_1OverridePullRequestApprovalRulesComm
       context
     );
   }
+  await collectBody(output.body, context);
   const response: OverridePullRequestApprovalRulesCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -11238,6 +11242,7 @@ export async function deserializeAws_json1_1TagResourceCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1TagResourceCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: TagResourceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -11544,6 +11549,7 @@ export async function deserializeAws_json1_1UntagResourceCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1UntagResourceCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: UntagResourceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -12015,6 +12021,7 @@ export async function deserializeAws_json1_1UpdateDefaultBranchCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: UpdateDefaultBranchCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -12306,6 +12313,7 @@ export async function deserializeAws_json1_1UpdatePullRequestApprovalStateComman
       context
     );
   }
+  await collectBody(output.body, context);
   const response: UpdatePullRequestApprovalStateCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -12778,6 +12786,7 @@ export async function deserializeAws_json1_1UpdateRepositoryDescriptionCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: UpdateRepositoryDescriptionCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -12888,6 +12897,7 @@ export async function deserializeAws_json1_1UpdateRepositoryNameCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: UpdateRepositoryNameCommandOutput = {
     $metadata: deserializeMetadata(output)
   };

--- a/clients/client-codedeploy/models/index.ts
+++ b/clients/client-codedeploy/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -21,7 +24,7 @@ export interface AddTagsToOnPremisesInstancesInput {
 
 export namespace AddTagsToOnPremisesInstancesInput {
   export function isa(o: any): o is AddTagsToOnPremisesInstancesInput {
-    return _smithy.isa(o, "AddTagsToOnPremisesInstancesInput");
+    return __isa(o, "AddTagsToOnPremisesInstancesInput");
   }
 }
 
@@ -39,7 +42,7 @@ export interface Alarm {
 
 export namespace Alarm {
   export function isa(o: any): o is Alarm {
-    return _smithy.isa(o, "Alarm");
+    return __isa(o, "Alarm");
   }
 }
 
@@ -78,7 +81,7 @@ export interface AlarmConfiguration {
 
 export namespace AlarmConfiguration {
   export function isa(o: any): o is AlarmConfiguration {
-    return _smithy.isa(o, "AlarmConfiguration");
+    return __isa(o, "AlarmConfiguration");
   }
 }
 
@@ -86,7 +89,7 @@ export namespace AlarmConfiguration {
  * <p>The maximum number of alarms for a deployment group (10) was exceeded.</p>
  */
 export interface AlarmsLimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AlarmsLimitExceededException";
   $fault: "client";
@@ -98,7 +101,7 @@ export interface AlarmsLimitExceededException
 
 export namespace AlarmsLimitExceededException {
   export function isa(o: any): o is AlarmsLimitExceededException {
-    return _smithy.isa(o, "AlarmsLimitExceededException");
+    return __isa(o, "AlarmsLimitExceededException");
   }
 }
 
@@ -131,7 +134,7 @@ export interface AppSpecContent {
 
 export namespace AppSpecContent {
   export function isa(o: any): o is AppSpecContent {
-    return _smithy.isa(o, "AppSpecContent");
+    return __isa(o, "AppSpecContent");
   }
 }
 
@@ -140,7 +143,7 @@ export namespace AppSpecContent {
  *             exists.</p>
  */
 export interface ApplicationAlreadyExistsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ApplicationAlreadyExistsException";
   $fault: "client";
@@ -152,7 +155,7 @@ export interface ApplicationAlreadyExistsException
 
 export namespace ApplicationAlreadyExistsException {
   export function isa(o: any): o is ApplicationAlreadyExistsException {
-    return _smithy.isa(o, "ApplicationAlreadyExistsException");
+    return __isa(o, "ApplicationAlreadyExistsException");
   }
 }
 
@@ -160,7 +163,7 @@ export namespace ApplicationAlreadyExistsException {
  * <p>The application does not exist with the IAM user or AWS account.</p>
  */
 export interface ApplicationDoesNotExistException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ApplicationDoesNotExistException";
   $fault: "client";
@@ -172,7 +175,7 @@ export interface ApplicationDoesNotExistException
 
 export namespace ApplicationDoesNotExistException {
   export function isa(o: any): o is ApplicationDoesNotExistException {
-    return _smithy.isa(o, "ApplicationDoesNotExistException");
+    return __isa(o, "ApplicationDoesNotExistException");
   }
 }
 
@@ -216,7 +219,7 @@ export interface ApplicationInfo {
 
 export namespace ApplicationInfo {
   export function isa(o: any): o is ApplicationInfo {
-    return _smithy.isa(o, "ApplicationInfo");
+    return __isa(o, "ApplicationInfo");
   }
 }
 
@@ -224,7 +227,7 @@ export namespace ApplicationInfo {
  * <p>More applications were attempted to be created than are allowed.</p>
  */
 export interface ApplicationLimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ApplicationLimitExceededException";
   $fault: "client";
@@ -236,7 +239,7 @@ export interface ApplicationLimitExceededException
 
 export namespace ApplicationLimitExceededException {
   export function isa(o: any): o is ApplicationLimitExceededException {
-    return _smithy.isa(o, "ApplicationLimitExceededException");
+    return __isa(o, "ApplicationLimitExceededException");
   }
 }
 
@@ -244,7 +247,7 @@ export namespace ApplicationLimitExceededException {
  * <p>The minimum number of required application names was not specified.</p>
  */
 export interface ApplicationNameRequiredException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ApplicationNameRequiredException";
   $fault: "client";
@@ -256,7 +259,7 @@ export interface ApplicationNameRequiredException
 
 export namespace ApplicationNameRequiredException {
   export function isa(o: any): o is ApplicationNameRequiredException {
-    return _smithy.isa(o, "ApplicationNameRequiredException");
+    return __isa(o, "ApplicationNameRequiredException");
   }
 }
 
@@ -272,7 +275,7 @@ export enum ApplicationRevisionSortBy {
  *         </p>
  */
 export interface ArnNotSupportedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ArnNotSupportedException";
   $fault: "client";
@@ -284,7 +287,7 @@ export interface ArnNotSupportedException
 
 export namespace ArnNotSupportedException {
   export function isa(o: any): o is ArnNotSupportedException {
-    return _smithy.isa(o, "ArnNotSupportedException");
+    return __isa(o, "ArnNotSupportedException");
   }
 }
 
@@ -308,7 +311,7 @@ export interface AutoRollbackConfiguration {
 
 export namespace AutoRollbackConfiguration {
   export function isa(o: any): o is AutoRollbackConfiguration {
-    return _smithy.isa(o, "AutoRollbackConfiguration");
+    return __isa(o, "AutoRollbackConfiguration");
   }
 }
 
@@ -336,7 +339,7 @@ export interface AutoScalingGroup {
 
 export namespace AutoScalingGroup {
   export function isa(o: any): o is AutoScalingGroup {
-    return _smithy.isa(o, "AutoScalingGroup");
+    return __isa(o, "AutoScalingGroup");
   }
 }
 
@@ -360,7 +363,7 @@ export interface BatchGetApplicationRevisionsInput {
 
 export namespace BatchGetApplicationRevisionsInput {
   export function isa(o: any): o is BatchGetApplicationRevisionsInput {
-    return _smithy.isa(o, "BatchGetApplicationRevisionsInput");
+    return __isa(o, "BatchGetApplicationRevisionsInput");
   }
 }
 
@@ -387,7 +390,7 @@ export interface BatchGetApplicationRevisionsOutput extends $MetadataBearer {
 
 export namespace BatchGetApplicationRevisionsOutput {
   export function isa(o: any): o is BatchGetApplicationRevisionsOutput {
-    return _smithy.isa(o, "BatchGetApplicationRevisionsOutput");
+    return __isa(o, "BatchGetApplicationRevisionsOutput");
   }
 }
 
@@ -404,7 +407,7 @@ export interface BatchGetApplicationsInput {
 
 export namespace BatchGetApplicationsInput {
   export function isa(o: any): o is BatchGetApplicationsInput {
-    return _smithy.isa(o, "BatchGetApplicationsInput");
+    return __isa(o, "BatchGetApplicationsInput");
   }
 }
 
@@ -421,7 +424,7 @@ export interface BatchGetApplicationsOutput extends $MetadataBearer {
 
 export namespace BatchGetApplicationsOutput {
   export function isa(o: any): o is BatchGetApplicationsOutput {
-    return _smithy.isa(o, "BatchGetApplicationsOutput");
+    return __isa(o, "BatchGetApplicationsOutput");
   }
 }
 
@@ -444,7 +447,7 @@ export interface BatchGetDeploymentGroupsInput {
 
 export namespace BatchGetDeploymentGroupsInput {
   export function isa(o: any): o is BatchGetDeploymentGroupsInput {
-    return _smithy.isa(o, "BatchGetDeploymentGroupsInput");
+    return __isa(o, "BatchGetDeploymentGroupsInput");
   }
 }
 
@@ -466,7 +469,7 @@ export interface BatchGetDeploymentGroupsOutput extends $MetadataBearer {
 
 export namespace BatchGetDeploymentGroupsOutput {
   export function isa(o: any): o is BatchGetDeploymentGroupsOutput {
-    return _smithy.isa(o, "BatchGetDeploymentGroupsOutput");
+    return __isa(o, "BatchGetDeploymentGroupsOutput");
   }
 }
 
@@ -488,7 +491,7 @@ export interface BatchGetDeploymentInstancesInput {
 
 export namespace BatchGetDeploymentInstancesInput {
   export function isa(o: any): o is BatchGetDeploymentInstancesInput {
-    return _smithy.isa(o, "BatchGetDeploymentInstancesInput");
+    return __isa(o, "BatchGetDeploymentInstancesInput");
   }
 }
 
@@ -510,7 +513,7 @@ export interface BatchGetDeploymentInstancesOutput extends $MetadataBearer {
 
 export namespace BatchGetDeploymentInstancesOutput {
   export function isa(o: any): o is BatchGetDeploymentInstancesOutput {
-    return _smithy.isa(o, "BatchGetDeploymentInstancesOutput");
+    return __isa(o, "BatchGetDeploymentInstancesOutput");
   }
 }
 
@@ -548,7 +551,7 @@ export interface BatchGetDeploymentTargetsInput {
 
 export namespace BatchGetDeploymentTargetsInput {
   export function isa(o: any): o is BatchGetDeploymentTargetsInput {
-    return _smithy.isa(o, "BatchGetDeploymentTargetsInput");
+    return __isa(o, "BatchGetDeploymentTargetsInput");
   }
 }
 
@@ -581,7 +584,7 @@ export interface BatchGetDeploymentTargetsOutput extends $MetadataBearer {
 
 export namespace BatchGetDeploymentTargetsOutput {
   export function isa(o: any): o is BatchGetDeploymentTargetsOutput {
-    return _smithy.isa(o, "BatchGetDeploymentTargetsOutput");
+    return __isa(o, "BatchGetDeploymentTargetsOutput");
   }
 }
 
@@ -598,7 +601,7 @@ export interface BatchGetDeploymentsInput {
 
 export namespace BatchGetDeploymentsInput {
   export function isa(o: any): o is BatchGetDeploymentsInput {
-    return _smithy.isa(o, "BatchGetDeploymentsInput");
+    return __isa(o, "BatchGetDeploymentsInput");
   }
 }
 
@@ -615,7 +618,7 @@ export interface BatchGetDeploymentsOutput extends $MetadataBearer {
 
 export namespace BatchGetDeploymentsOutput {
   export function isa(o: any): o is BatchGetDeploymentsOutput {
-    return _smithy.isa(o, "BatchGetDeploymentsOutput");
+    return __isa(o, "BatchGetDeploymentsOutput");
   }
 }
 
@@ -632,7 +635,7 @@ export interface BatchGetOnPremisesInstancesInput {
 
 export namespace BatchGetOnPremisesInstancesInput {
   export function isa(o: any): o is BatchGetOnPremisesInstancesInput {
-    return _smithy.isa(o, "BatchGetOnPremisesInstancesInput");
+    return __isa(o, "BatchGetOnPremisesInstancesInput");
   }
 }
 
@@ -649,7 +652,7 @@ export interface BatchGetOnPremisesInstancesOutput extends $MetadataBearer {
 
 export namespace BatchGetOnPremisesInstancesOutput {
   export function isa(o: any): o is BatchGetOnPremisesInstancesOutput {
-    return _smithy.isa(o, "BatchGetOnPremisesInstancesOutput");
+    return __isa(o, "BatchGetOnPremisesInstancesOutput");
   }
 }
 
@@ -657,7 +660,7 @@ export namespace BatchGetOnPremisesInstancesOutput {
  * <p>The maximum number of names or IDs allowed for this request (100) was exceeded.</p>
  */
 export interface BatchLimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "BatchLimitExceededException";
   $fault: "client";
@@ -669,7 +672,7 @@ export interface BatchLimitExceededException
 
 export namespace BatchLimitExceededException {
   export function isa(o: any): o is BatchLimitExceededException {
-    return _smithy.isa(o, "BatchLimitExceededException");
+    return __isa(o, "BatchLimitExceededException");
   }
 }
 
@@ -699,7 +702,7 @@ export interface BlueGreenDeploymentConfiguration {
 
 export namespace BlueGreenDeploymentConfiguration {
   export function isa(o: any): o is BlueGreenDeploymentConfiguration {
-    return _smithy.isa(o, "BlueGreenDeploymentConfiguration");
+    return __isa(o, "BlueGreenDeploymentConfiguration");
   }
 }
 
@@ -744,7 +747,7 @@ export interface BlueInstanceTerminationOption {
 
 export namespace BlueInstanceTerminationOption {
   export function isa(o: any): o is BlueInstanceTerminationOption {
-    return _smithy.isa(o, "BlueInstanceTerminationOption");
+    return __isa(o, "BlueInstanceTerminationOption");
   }
 }
 
@@ -752,7 +755,7 @@ export namespace BlueInstanceTerminationOption {
  * <p>A bucket name is required, but was not provided.</p>
  */
 export interface BucketNameFilterRequiredException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "BucketNameFilterRequiredException";
   $fault: "client";
@@ -764,7 +767,7 @@ export interface BucketNameFilterRequiredException
 
 export namespace BucketNameFilterRequiredException {
   export function isa(o: any): o is BucketNameFilterRequiredException {
-    return _smithy.isa(o, "BucketNameFilterRequiredException");
+    return __isa(o, "BucketNameFilterRequiredException");
   }
 }
 
@@ -800,7 +803,7 @@ export interface ContinueDeploymentInput {
 
 export namespace ContinueDeploymentInput {
   export function isa(o: any): o is ContinueDeploymentInput {
-    return _smithy.isa(o, "ContinueDeploymentInput");
+    return __isa(o, "ContinueDeploymentInput");
   }
 }
 
@@ -832,7 +835,7 @@ export interface CreateApplicationInput {
 
 export namespace CreateApplicationInput {
   export function isa(o: any): o is CreateApplicationInput {
-    return _smithy.isa(o, "CreateApplicationInput");
+    return __isa(o, "CreateApplicationInput");
   }
 }
 
@@ -849,7 +852,7 @@ export interface CreateApplicationOutput extends $MetadataBearer {
 
 export namespace CreateApplicationOutput {
   export function isa(o: any): o is CreateApplicationOutput {
-    return _smithy.isa(o, "CreateApplicationOutput");
+    return __isa(o, "CreateApplicationOutput");
   }
 }
 
@@ -899,7 +902,7 @@ export interface CreateDeploymentConfigInput {
 
 export namespace CreateDeploymentConfigInput {
   export function isa(o: any): o is CreateDeploymentConfigInput {
-    return _smithy.isa(o, "CreateDeploymentConfigInput");
+    return __isa(o, "CreateDeploymentConfigInput");
   }
 }
 
@@ -916,7 +919,7 @@ export interface CreateDeploymentConfigOutput extends $MetadataBearer {
 
 export namespace CreateDeploymentConfigOutput {
   export function isa(o: any): o is CreateDeploymentConfigOutput {
-    return _smithy.isa(o, "CreateDeploymentConfigOutput");
+    return __isa(o, "CreateDeploymentConfigOutput");
   }
 }
 
@@ -1040,7 +1043,7 @@ export interface CreateDeploymentGroupInput {
 
 export namespace CreateDeploymentGroupInput {
   export function isa(o: any): o is CreateDeploymentGroupInput {
-    return _smithy.isa(o, "CreateDeploymentGroupInput");
+    return __isa(o, "CreateDeploymentGroupInput");
   }
 }
 
@@ -1057,7 +1060,7 @@ export interface CreateDeploymentGroupOutput extends $MetadataBearer {
 
 export namespace CreateDeploymentGroupOutput {
   export function isa(o: any): o is CreateDeploymentGroupOutput {
-    return _smithy.isa(o, "CreateDeploymentGroupOutput");
+    return __isa(o, "CreateDeploymentGroupOutput");
   }
 }
 
@@ -1167,7 +1170,7 @@ export interface CreateDeploymentInput {
 
 export namespace CreateDeploymentInput {
   export function isa(o: any): o is CreateDeploymentInput {
-    return _smithy.isa(o, "CreateDeploymentInput");
+    return __isa(o, "CreateDeploymentInput");
   }
 }
 
@@ -1184,7 +1187,7 @@ export interface CreateDeploymentOutput extends $MetadataBearer {
 
 export namespace CreateDeploymentOutput {
   export function isa(o: any): o is CreateDeploymentOutput {
-    return _smithy.isa(o, "CreateDeploymentOutput");
+    return __isa(o, "CreateDeploymentOutput");
   }
 }
 
@@ -1202,7 +1205,7 @@ export interface DeleteApplicationInput {
 
 export namespace DeleteApplicationInput {
   export function isa(o: any): o is DeleteApplicationInput {
-    return _smithy.isa(o, "DeleteApplicationInput");
+    return __isa(o, "DeleteApplicationInput");
   }
 }
 
@@ -1220,7 +1223,7 @@ export interface DeleteDeploymentConfigInput {
 
 export namespace DeleteDeploymentConfigInput {
   export function isa(o: any): o is DeleteDeploymentConfigInput {
-    return _smithy.isa(o, "DeleteDeploymentConfigInput");
+    return __isa(o, "DeleteDeploymentConfigInput");
   }
 }
 
@@ -1243,7 +1246,7 @@ export interface DeleteDeploymentGroupInput {
 
 export namespace DeleteDeploymentGroupInput {
   export function isa(o: any): o is DeleteDeploymentGroupInput {
-    return _smithy.isa(o, "DeleteDeploymentGroupInput");
+    return __isa(o, "DeleteDeploymentGroupInput");
   }
 }
 
@@ -1264,7 +1267,7 @@ export interface DeleteDeploymentGroupOutput extends $MetadataBearer {
 
 export namespace DeleteDeploymentGroupOutput {
   export function isa(o: any): o is DeleteDeploymentGroupOutput {
-    return _smithy.isa(o, "DeleteDeploymentGroupOutput");
+    return __isa(o, "DeleteDeploymentGroupOutput");
   }
 }
 
@@ -1281,7 +1284,7 @@ export interface DeleteGitHubAccountTokenInput {
 
 export namespace DeleteGitHubAccountTokenInput {
   export function isa(o: any): o is DeleteGitHubAccountTokenInput {
-    return _smithy.isa(o, "DeleteGitHubAccountTokenInput");
+    return __isa(o, "DeleteGitHubAccountTokenInput");
   }
 }
 
@@ -1298,7 +1301,7 @@ export interface DeleteGitHubAccountTokenOutput extends $MetadataBearer {
 
 export namespace DeleteGitHubAccountTokenOutput {
   export function isa(o: any): o is DeleteGitHubAccountTokenOutput {
-    return _smithy.isa(o, "DeleteGitHubAccountTokenOutput");
+    return __isa(o, "DeleteGitHubAccountTokenOutput");
   }
 }
 
@@ -1306,7 +1309,7 @@ export namespace DeleteGitHubAccountTokenOutput {
  * <p>The deployment is already complete.</p>
  */
 export interface DeploymentAlreadyCompletedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DeploymentAlreadyCompletedException";
   $fault: "client";
@@ -1318,7 +1321,7 @@ export interface DeploymentAlreadyCompletedException
 
 export namespace DeploymentAlreadyCompletedException {
   export function isa(o: any): o is DeploymentAlreadyCompletedException {
-    return _smithy.isa(o, "DeploymentAlreadyCompletedException");
+    return __isa(o, "DeploymentAlreadyCompletedException");
   }
 }
 
@@ -1327,7 +1330,7 @@ export namespace DeploymentAlreadyCompletedException {
  *             already exists .</p>
  */
 export interface DeploymentConfigAlreadyExistsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DeploymentConfigAlreadyExistsException";
   $fault: "client";
@@ -1339,7 +1342,7 @@ export interface DeploymentConfigAlreadyExistsException
 
 export namespace DeploymentConfigAlreadyExistsException {
   export function isa(o: any): o is DeploymentConfigAlreadyExistsException {
-    return _smithy.isa(o, "DeploymentConfigAlreadyExistsException");
+    return __isa(o, "DeploymentConfigAlreadyExistsException");
   }
 }
 
@@ -1347,7 +1350,7 @@ export namespace DeploymentConfigAlreadyExistsException {
  * <p>The deployment configuration does not exist with the IAM user or AWS account.</p>
  */
 export interface DeploymentConfigDoesNotExistException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DeploymentConfigDoesNotExistException";
   $fault: "client";
@@ -1359,7 +1362,7 @@ export interface DeploymentConfigDoesNotExistException
 
 export namespace DeploymentConfigDoesNotExistException {
   export function isa(o: any): o is DeploymentConfigDoesNotExistException {
-    return _smithy.isa(o, "DeploymentConfigDoesNotExistException");
+    return __isa(o, "DeploymentConfigDoesNotExistException");
   }
 }
 
@@ -1367,7 +1370,7 @@ export namespace DeploymentConfigDoesNotExistException {
  * <p>The deployment configuration is still in use.</p>
  */
 export interface DeploymentConfigInUseException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DeploymentConfigInUseException";
   $fault: "client";
@@ -1379,7 +1382,7 @@ export interface DeploymentConfigInUseException
 
 export namespace DeploymentConfigInUseException {
   export function isa(o: any): o is DeploymentConfigInUseException {
-    return _smithy.isa(o, "DeploymentConfigInUseException");
+    return __isa(o, "DeploymentConfigInUseException");
   }
 }
 
@@ -1422,7 +1425,7 @@ export interface DeploymentConfigInfo {
 
 export namespace DeploymentConfigInfo {
   export function isa(o: any): o is DeploymentConfigInfo {
-    return _smithy.isa(o, "DeploymentConfigInfo");
+    return __isa(o, "DeploymentConfigInfo");
   }
 }
 
@@ -1430,7 +1433,7 @@ export namespace DeploymentConfigInfo {
  * <p>The deployment configurations limit was exceeded.</p>
  */
 export interface DeploymentConfigLimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DeploymentConfigLimitExceededException";
   $fault: "client";
@@ -1442,7 +1445,7 @@ export interface DeploymentConfigLimitExceededException
 
 export namespace DeploymentConfigLimitExceededException {
   export function isa(o: any): o is DeploymentConfigLimitExceededException {
-    return _smithy.isa(o, "DeploymentConfigLimitExceededException");
+    return __isa(o, "DeploymentConfigLimitExceededException");
   }
 }
 
@@ -1450,7 +1453,7 @@ export namespace DeploymentConfigLimitExceededException {
  * <p>The deployment configuration name was not specified.</p>
  */
 export interface DeploymentConfigNameRequiredException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DeploymentConfigNameRequiredException";
   $fault: "client";
@@ -1462,7 +1465,7 @@ export interface DeploymentConfigNameRequiredException
 
 export namespace DeploymentConfigNameRequiredException {
   export function isa(o: any): o is DeploymentConfigNameRequiredException {
-    return _smithy.isa(o, "DeploymentConfigNameRequiredException");
+    return __isa(o, "DeploymentConfigNameRequiredException");
   }
 }
 
@@ -1476,7 +1479,7 @@ export enum DeploymentCreator {
  * <p>The deployment with the IAM user or AWS account does not exist.</p>
  */
 export interface DeploymentDoesNotExistException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DeploymentDoesNotExistException";
   $fault: "client";
@@ -1488,7 +1491,7 @@ export interface DeploymentDoesNotExistException
 
 export namespace DeploymentDoesNotExistException {
   export function isa(o: any): o is DeploymentDoesNotExistException {
-    return _smithy.isa(o, "DeploymentDoesNotExistException");
+    return __isa(o, "DeploymentDoesNotExistException");
   }
 }
 
@@ -1497,7 +1500,7 @@ export namespace DeploymentDoesNotExistException {
  *             exists.</p>
  */
 export interface DeploymentGroupAlreadyExistsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DeploymentGroupAlreadyExistsException";
   $fault: "client";
@@ -1509,7 +1512,7 @@ export interface DeploymentGroupAlreadyExistsException
 
 export namespace DeploymentGroupAlreadyExistsException {
   export function isa(o: any): o is DeploymentGroupAlreadyExistsException {
-    return _smithy.isa(o, "DeploymentGroupAlreadyExistsException");
+    return __isa(o, "DeploymentGroupAlreadyExistsException");
   }
 }
 
@@ -1517,7 +1520,7 @@ export namespace DeploymentGroupAlreadyExistsException {
  * <p>The named deployment group with the IAM user or AWS account does not exist.</p>
  */
 export interface DeploymentGroupDoesNotExistException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DeploymentGroupDoesNotExistException";
   $fault: "client";
@@ -1529,7 +1532,7 @@ export interface DeploymentGroupDoesNotExistException
 
 export namespace DeploymentGroupDoesNotExistException {
   export function isa(o: any): o is DeploymentGroupDoesNotExistException {
-    return _smithy.isa(o, "DeploymentGroupDoesNotExistException");
+    return __isa(o, "DeploymentGroupDoesNotExistException");
   }
 }
 
@@ -1661,7 +1664,7 @@ export interface DeploymentGroupInfo {
 
 export namespace DeploymentGroupInfo {
   export function isa(o: any): o is DeploymentGroupInfo {
-    return _smithy.isa(o, "DeploymentGroupInfo");
+    return __isa(o, "DeploymentGroupInfo");
   }
 }
 
@@ -1669,7 +1672,7 @@ export namespace DeploymentGroupInfo {
  * <p> The deployment groups limit was exceeded.</p>
  */
 export interface DeploymentGroupLimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DeploymentGroupLimitExceededException";
   $fault: "client";
@@ -1681,7 +1684,7 @@ export interface DeploymentGroupLimitExceededException
 
 export namespace DeploymentGroupLimitExceededException {
   export function isa(o: any): o is DeploymentGroupLimitExceededException {
-    return _smithy.isa(o, "DeploymentGroupLimitExceededException");
+    return __isa(o, "DeploymentGroupLimitExceededException");
   }
 }
 
@@ -1689,7 +1692,7 @@ export namespace DeploymentGroupLimitExceededException {
  * <p>The deployment group name was not specified.</p>
  */
 export interface DeploymentGroupNameRequiredException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DeploymentGroupNameRequiredException";
   $fault: "client";
@@ -1701,7 +1704,7 @@ export interface DeploymentGroupNameRequiredException
 
 export namespace DeploymentGroupNameRequiredException {
   export function isa(o: any): o is DeploymentGroupNameRequiredException {
-    return _smithy.isa(o, "DeploymentGroupNameRequiredException");
+    return __isa(o, "DeploymentGroupNameRequiredException");
   }
 }
 
@@ -1709,7 +1712,7 @@ export namespace DeploymentGroupNameRequiredException {
  * <p>At least one deployment ID must be specified.</p>
  */
 export interface DeploymentIdRequiredException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DeploymentIdRequiredException";
   $fault: "client";
@@ -1721,7 +1724,7 @@ export interface DeploymentIdRequiredException
 
 export namespace DeploymentIdRequiredException {
   export function isa(o: any): o is DeploymentIdRequiredException {
-    return _smithy.isa(o, "DeploymentIdRequiredException");
+    return __isa(o, "DeploymentIdRequiredException");
   }
 }
 
@@ -1932,7 +1935,7 @@ export interface DeploymentInfo {
 
 export namespace DeploymentInfo {
   export function isa(o: any): o is DeploymentInfo {
-    return _smithy.isa(o, "DeploymentInfo");
+    return __isa(o, "DeploymentInfo");
   }
 }
 
@@ -1940,7 +1943,7 @@ export namespace DeploymentInfo {
  * <p>The deployment does not have a status of Ready and can't continue yet.</p>
  */
 export interface DeploymentIsNotInReadyStateException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DeploymentIsNotInReadyStateException";
   $fault: "client";
@@ -1952,7 +1955,7 @@ export interface DeploymentIsNotInReadyStateException
 
 export namespace DeploymentIsNotInReadyStateException {
   export function isa(o: any): o is DeploymentIsNotInReadyStateException {
-    return _smithy.isa(o, "DeploymentIsNotInReadyStateException");
+    return __isa(o, "DeploymentIsNotInReadyStateException");
   }
 }
 
@@ -1960,7 +1963,7 @@ export namespace DeploymentIsNotInReadyStateException {
  * <p>The number of allowed deployments was exceeded.</p>
  */
 export interface DeploymentLimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DeploymentLimitExceededException";
   $fault: "client";
@@ -1972,7 +1975,7 @@ export interface DeploymentLimitExceededException
 
 export namespace DeploymentLimitExceededException {
   export function isa(o: any): o is DeploymentLimitExceededException {
-    return _smithy.isa(o, "DeploymentLimitExceededException");
+    return __isa(o, "DeploymentLimitExceededException");
   }
 }
 
@@ -1980,7 +1983,7 @@ export namespace DeploymentLimitExceededException {
  * <p>The specified deployment has not started.</p>
  */
 export interface DeploymentNotStartedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DeploymentNotStartedException";
   $fault: "client";
@@ -1992,7 +1995,7 @@ export interface DeploymentNotStartedException
 
 export namespace DeploymentNotStartedException {
   export function isa(o: any): o is DeploymentNotStartedException {
-    return _smithy.isa(o, "DeploymentNotStartedException");
+    return __isa(o, "DeploymentNotStartedException");
   }
 }
 
@@ -2041,7 +2044,7 @@ export interface DeploymentOverview {
 
 export namespace DeploymentOverview {
   export function isa(o: any): o is DeploymentOverview {
-    return _smithy.isa(o, "DeploymentOverview");
+    return __isa(o, "DeploymentOverview");
   }
 }
 
@@ -2085,7 +2088,7 @@ export interface DeploymentReadyOption {
 
 export namespace DeploymentReadyOption {
   export function isa(o: any): o is DeploymentReadyOption {
-    return _smithy.isa(o, "DeploymentReadyOption");
+    return __isa(o, "DeploymentReadyOption");
   }
 }
 
@@ -2118,7 +2121,7 @@ export interface DeploymentStyle {
 
 export namespace DeploymentStyle {
   export function isa(o: any): o is DeploymentStyle {
-    return _smithy.isa(o, "DeploymentStyle");
+    return __isa(o, "DeploymentStyle");
   }
 }
 
@@ -2153,7 +2156,7 @@ export interface DeploymentTarget {
 
 export namespace DeploymentTarget {
   export function isa(o: any): o is DeploymentTarget {
-    return _smithy.isa(o, "DeploymentTarget");
+    return __isa(o, "DeploymentTarget");
   }
 }
 
@@ -2161,7 +2164,7 @@ export namespace DeploymentTarget {
  * <p> The provided target ID does not belong to the attempted deployment. </p>
  */
 export interface DeploymentTargetDoesNotExistException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DeploymentTargetDoesNotExistException";
   $fault: "client";
@@ -2173,7 +2176,7 @@ export interface DeploymentTargetDoesNotExistException
 
 export namespace DeploymentTargetDoesNotExistException {
   export function isa(o: any): o is DeploymentTargetDoesNotExistException {
-    return _smithy.isa(o, "DeploymentTargetDoesNotExistException");
+    return __isa(o, "DeploymentTargetDoesNotExistException");
   }
 }
 
@@ -2181,7 +2184,7 @@ export namespace DeploymentTargetDoesNotExistException {
  * <p> A deployment target ID was not provided. </p>
  */
 export interface DeploymentTargetIdRequiredException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DeploymentTargetIdRequiredException";
   $fault: "client";
@@ -2193,7 +2196,7 @@ export interface DeploymentTargetIdRequiredException
 
 export namespace DeploymentTargetIdRequiredException {
   export function isa(o: any): o is DeploymentTargetIdRequiredException {
-    return _smithy.isa(o, "DeploymentTargetIdRequiredException");
+    return __isa(o, "DeploymentTargetIdRequiredException");
   }
 }
 
@@ -2203,7 +2206,7 @@ export namespace DeploymentTargetIdRequiredException {
  *             one item. This exception does not apply to EC2/On-premises deployments. </p>
  */
 export interface DeploymentTargetListSizeExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DeploymentTargetListSizeExceededException";
   $fault: "client";
@@ -2215,7 +2218,7 @@ export interface DeploymentTargetListSizeExceededException
 
 export namespace DeploymentTargetListSizeExceededException {
   export function isa(o: any): o is DeploymentTargetListSizeExceededException {
-    return _smithy.isa(o, "DeploymentTargetListSizeExceededException");
+    return __isa(o, "DeploymentTargetListSizeExceededException");
   }
 }
 
@@ -2248,7 +2251,7 @@ export interface DeregisterOnPremisesInstanceInput {
 
 export namespace DeregisterOnPremisesInstanceInput {
   export function isa(o: any): o is DeregisterOnPremisesInstanceInput {
-    return _smithy.isa(o, "DeregisterOnPremisesInstanceInput");
+    return __isa(o, "DeregisterOnPremisesInstanceInput");
   }
 }
 
@@ -2256,7 +2259,7 @@ export namespace DeregisterOnPremisesInstanceInput {
  * <p>The description is too long.</p>
  */
 export interface DescriptionTooLongException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DescriptionTooLongException";
   $fault: "client";
@@ -2268,7 +2271,7 @@ export interface DescriptionTooLongException
 
 export namespace DescriptionTooLongException {
   export function isa(o: any): o is DescriptionTooLongException {
-    return _smithy.isa(o, "DescriptionTooLongException");
+    return __isa(o, "DescriptionTooLongException");
   }
 }
 
@@ -2324,7 +2327,7 @@ export interface Diagnostics {
 
 export namespace Diagnostics {
   export function isa(o: any): o is Diagnostics {
-    return _smithy.isa(o, "Diagnostics");
+    return __isa(o, "Diagnostics");
   }
 }
 
@@ -2362,7 +2365,7 @@ export interface EC2TagFilter {
 
 export namespace EC2TagFilter {
   export function isa(o: any): o is EC2TagFilter {
-    return _smithy.isa(o, "EC2TagFilter");
+    return __isa(o, "EC2TagFilter");
   }
 }
 
@@ -2387,7 +2390,7 @@ export interface EC2TagSet {
 
 export namespace EC2TagSet {
   export function isa(o: any): o is EC2TagSet {
-    return _smithy.isa(o, "EC2TagSet");
+    return __isa(o, "EC2TagSet");
   }
 }
 
@@ -2410,7 +2413,7 @@ export interface ECSService {
 
 export namespace ECSService {
   export function isa(o: any): o is ECSService {
-    return _smithy.isa(o, "ECSService");
+    return __isa(o, "ECSService");
   }
 }
 
@@ -2419,7 +2422,7 @@ export namespace ECSService {
  *             ECS service can be associated with only one deployment group. </p>
  */
 export interface ECSServiceMappingLimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ECSServiceMappingLimitExceededException";
   $fault: "client";
@@ -2431,7 +2434,7 @@ export interface ECSServiceMappingLimitExceededException
 
 export namespace ECSServiceMappingLimitExceededException {
   export function isa(o: any): o is ECSServiceMappingLimitExceededException {
-    return _smithy.isa(o, "ECSServiceMappingLimitExceededException");
+    return __isa(o, "ECSServiceMappingLimitExceededException");
   }
 }
 
@@ -2480,7 +2483,7 @@ export interface ECSTarget {
 
 export namespace ECSTarget {
   export function isa(o: any): o is ECSTarget {
-    return _smithy.isa(o, "ECSTarget");
+    return __isa(o, "ECSTarget");
   }
 }
 
@@ -2562,7 +2565,7 @@ export interface ECSTaskSet {
 
 export namespace ECSTaskSet {
   export function isa(o: any): o is ECSTaskSet {
-    return _smithy.isa(o, "ECSTaskSet");
+    return __isa(o, "ECSTaskSet");
   }
 }
 
@@ -2585,7 +2588,7 @@ export interface ELBInfo {
 
 export namespace ELBInfo {
   export function isa(o: any): o is ELBInfo {
-    return _smithy.isa(o, "ELBInfo");
+    return __isa(o, "ELBInfo");
   }
 }
 
@@ -2698,7 +2701,7 @@ export interface ErrorInformation {
 
 export namespace ErrorInformation {
   export function isa(o: any): o is ErrorInformation {
-    return _smithy.isa(o, "ErrorInformation");
+    return __isa(o, "ErrorInformation");
   }
 }
 
@@ -2741,7 +2744,7 @@ export interface GenericRevisionInfo {
 
 export namespace GenericRevisionInfo {
   export function isa(o: any): o is GenericRevisionInfo {
-    return _smithy.isa(o, "GenericRevisionInfo");
+    return __isa(o, "GenericRevisionInfo");
   }
 }
 
@@ -2759,7 +2762,7 @@ export interface GetApplicationInput {
 
 export namespace GetApplicationInput {
   export function isa(o: any): o is GetApplicationInput {
-    return _smithy.isa(o, "GetApplicationInput");
+    return __isa(o, "GetApplicationInput");
   }
 }
 
@@ -2776,7 +2779,7 @@ export interface GetApplicationOutput extends $MetadataBearer {
 
 export namespace GetApplicationOutput {
   export function isa(o: any): o is GetApplicationOutput {
-    return _smithy.isa(o, "GetApplicationOutput");
+    return __isa(o, "GetApplicationOutput");
   }
 }
 
@@ -2798,7 +2801,7 @@ export interface GetApplicationRevisionInput {
 
 export namespace GetApplicationRevisionInput {
   export function isa(o: any): o is GetApplicationRevisionInput {
-    return _smithy.isa(o, "GetApplicationRevisionInput");
+    return __isa(o, "GetApplicationRevisionInput");
   }
 }
 
@@ -2825,7 +2828,7 @@ export interface GetApplicationRevisionOutput extends $MetadataBearer {
 
 export namespace GetApplicationRevisionOutput {
   export function isa(o: any): o is GetApplicationRevisionOutput {
-    return _smithy.isa(o, "GetApplicationRevisionOutput");
+    return __isa(o, "GetApplicationRevisionOutput");
   }
 }
 
@@ -2843,7 +2846,7 @@ export interface GetDeploymentConfigInput {
 
 export namespace GetDeploymentConfigInput {
   export function isa(o: any): o is GetDeploymentConfigInput {
-    return _smithy.isa(o, "GetDeploymentConfigInput");
+    return __isa(o, "GetDeploymentConfigInput");
   }
 }
 
@@ -2860,7 +2863,7 @@ export interface GetDeploymentConfigOutput extends $MetadataBearer {
 
 export namespace GetDeploymentConfigOutput {
   export function isa(o: any): o is GetDeploymentConfigOutput {
-    return _smithy.isa(o, "GetDeploymentConfigOutput");
+    return __isa(o, "GetDeploymentConfigOutput");
   }
 }
 
@@ -2883,7 +2886,7 @@ export interface GetDeploymentGroupInput {
 
 export namespace GetDeploymentGroupInput {
   export function isa(o: any): o is GetDeploymentGroupInput {
-    return _smithy.isa(o, "GetDeploymentGroupInput");
+    return __isa(o, "GetDeploymentGroupInput");
   }
 }
 
@@ -2900,7 +2903,7 @@ export interface GetDeploymentGroupOutput extends $MetadataBearer {
 
 export namespace GetDeploymentGroupOutput {
   export function isa(o: any): o is GetDeploymentGroupOutput {
-    return _smithy.isa(o, "GetDeploymentGroupOutput");
+    return __isa(o, "GetDeploymentGroupOutput");
   }
 }
 
@@ -2917,7 +2920,7 @@ export interface GetDeploymentInput {
 
 export namespace GetDeploymentInput {
   export function isa(o: any): o is GetDeploymentInput {
-    return _smithy.isa(o, "GetDeploymentInput");
+    return __isa(o, "GetDeploymentInput");
   }
 }
 
@@ -2939,7 +2942,7 @@ export interface GetDeploymentInstanceInput {
 
 export namespace GetDeploymentInstanceInput {
   export function isa(o: any): o is GetDeploymentInstanceInput {
-    return _smithy.isa(o, "GetDeploymentInstanceInput");
+    return __isa(o, "GetDeploymentInstanceInput");
   }
 }
 
@@ -2956,7 +2959,7 @@ export interface GetDeploymentInstanceOutput extends $MetadataBearer {
 
 export namespace GetDeploymentInstanceOutput {
   export function isa(o: any): o is GetDeploymentInstanceOutput {
-    return _smithy.isa(o, "GetDeploymentInstanceOutput");
+    return __isa(o, "GetDeploymentInstanceOutput");
   }
 }
 
@@ -2973,7 +2976,7 @@ export interface GetDeploymentOutput extends $MetadataBearer {
 
 export namespace GetDeploymentOutput {
   export function isa(o: any): o is GetDeploymentOutput {
-    return _smithy.isa(o, "GetDeploymentOutput");
+    return __isa(o, "GetDeploymentOutput");
   }
 }
 
@@ -2992,7 +2995,7 @@ export interface GetDeploymentTargetInput {
 
 export namespace GetDeploymentTargetInput {
   export function isa(o: any): o is GetDeploymentTargetInput {
-    return _smithy.isa(o, "GetDeploymentTargetInput");
+    return __isa(o, "GetDeploymentTargetInput");
   }
 }
 
@@ -3010,7 +3013,7 @@ export interface GetDeploymentTargetOutput extends $MetadataBearer {
 
 export namespace GetDeploymentTargetOutput {
   export function isa(o: any): o is GetDeploymentTargetOutput {
-    return _smithy.isa(o, "GetDeploymentTargetOutput");
+    return __isa(o, "GetDeploymentTargetOutput");
   }
 }
 
@@ -3027,7 +3030,7 @@ export interface GetOnPremisesInstanceInput {
 
 export namespace GetOnPremisesInstanceInput {
   export function isa(o: any): o is GetOnPremisesInstanceInput {
-    return _smithy.isa(o, "GetOnPremisesInstanceInput");
+    return __isa(o, "GetOnPremisesInstanceInput");
   }
 }
 
@@ -3044,7 +3047,7 @@ export interface GetOnPremisesInstanceOutput extends $MetadataBearer {
 
 export namespace GetOnPremisesInstanceOutput {
   export function isa(o: any): o is GetOnPremisesInstanceOutput {
-    return _smithy.isa(o, "GetOnPremisesInstanceOutput");
+    return __isa(o, "GetOnPremisesInstanceOutput");
   }
 }
 
@@ -3052,7 +3055,7 @@ export namespace GetOnPremisesInstanceOutput {
  * <p>No GitHub account connection exists with the named specified in the call.</p>
  */
 export interface GitHubAccountTokenDoesNotExistException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "GitHubAccountTokenDoesNotExistException";
   $fault: "client";
@@ -3064,7 +3067,7 @@ export interface GitHubAccountTokenDoesNotExistException
 
 export namespace GitHubAccountTokenDoesNotExistException {
   export function isa(o: any): o is GitHubAccountTokenDoesNotExistException {
-    return _smithy.isa(o, "GitHubAccountTokenDoesNotExistException");
+    return __isa(o, "GitHubAccountTokenDoesNotExistException");
   }
 }
 
@@ -3072,7 +3075,7 @@ export namespace GitHubAccountTokenDoesNotExistException {
  * <p>The call is missing a required GitHub account connection name.</p>
  */
 export interface GitHubAccountTokenNameRequiredException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "GitHubAccountTokenNameRequiredException";
   $fault: "client";
@@ -3084,7 +3087,7 @@ export interface GitHubAccountTokenNameRequiredException
 
 export namespace GitHubAccountTokenNameRequiredException {
   export function isa(o: any): o is GitHubAccountTokenNameRequiredException {
-    return _smithy.isa(o, "GitHubAccountTokenNameRequiredException");
+    return __isa(o, "GitHubAccountTokenNameRequiredException");
   }
 }
 
@@ -3109,7 +3112,7 @@ export interface GitHubLocation {
 
 export namespace GitHubLocation {
   export function isa(o: any): o is GitHubLocation {
-    return _smithy.isa(o, "GitHubLocation");
+    return __isa(o, "GitHubLocation");
   }
 }
 
@@ -3142,7 +3145,7 @@ export interface GreenFleetProvisioningOption {
 
 export namespace GreenFleetProvisioningOption {
   export function isa(o: any): o is GreenFleetProvisioningOption {
-    return _smithy.isa(o, "GreenFleetProvisioningOption");
+    return __isa(o, "GreenFleetProvisioningOption");
   }
 }
 
@@ -3151,7 +3154,7 @@ export namespace GreenFleetProvisioningOption {
  *             ARN in the request.</p>
  */
 export interface IamArnRequiredException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "IamArnRequiredException";
   $fault: "client";
@@ -3163,7 +3166,7 @@ export interface IamArnRequiredException
 
 export namespace IamArnRequiredException {
   export function isa(o: any): o is IamArnRequiredException {
-    return _smithy.isa(o, "IamArnRequiredException");
+    return __isa(o, "IamArnRequiredException");
   }
 }
 
@@ -3172,7 +3175,7 @@ export namespace IamArnRequiredException {
  *             different instance.</p>
  */
 export interface IamSessionArnAlreadyRegisteredException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "IamSessionArnAlreadyRegisteredException";
   $fault: "client";
@@ -3184,7 +3187,7 @@ export interface IamSessionArnAlreadyRegisteredException
 
 export namespace IamSessionArnAlreadyRegisteredException {
   export function isa(o: any): o is IamSessionArnAlreadyRegisteredException {
-    return _smithy.isa(o, "IamSessionArnAlreadyRegisteredException");
+    return __isa(o, "IamSessionArnAlreadyRegisteredException");
   }
 }
 
@@ -3192,7 +3195,7 @@ export namespace IamSessionArnAlreadyRegisteredException {
  * <p>The specified IAM user ARN is already registered with an on-premises instance.</p>
  */
 export interface IamUserArnAlreadyRegisteredException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "IamUserArnAlreadyRegisteredException";
   $fault: "client";
@@ -3204,7 +3207,7 @@ export interface IamUserArnAlreadyRegisteredException
 
 export namespace IamUserArnAlreadyRegisteredException {
   export function isa(o: any): o is IamUserArnAlreadyRegisteredException {
-    return _smithy.isa(o, "IamUserArnAlreadyRegisteredException");
+    return __isa(o, "IamUserArnAlreadyRegisteredException");
   }
 }
 
@@ -3212,7 +3215,7 @@ export namespace IamUserArnAlreadyRegisteredException {
  * <p>An IAM user ARN was not specified.</p>
  */
 export interface IamUserArnRequiredException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "IamUserArnRequiredException";
   $fault: "client";
@@ -3224,7 +3227,7 @@ export interface IamUserArnRequiredException
 
 export namespace IamUserArnRequiredException {
   export function isa(o: any): o is IamUserArnRequiredException {
-    return _smithy.isa(o, "IamUserArnRequiredException");
+    return __isa(o, "IamUserArnRequiredException");
   }
 }
 
@@ -3237,7 +3240,7 @@ export enum InstanceAction {
  * <p>The specified instance does not exist in the deployment group.</p>
  */
 export interface InstanceDoesNotExistException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InstanceDoesNotExistException";
   $fault: "client";
@@ -3249,7 +3252,7 @@ export interface InstanceDoesNotExistException
 
 export namespace InstanceDoesNotExistException {
   export function isa(o: any): o is InstanceDoesNotExistException {
-    return _smithy.isa(o, "InstanceDoesNotExistException");
+    return __isa(o, "InstanceDoesNotExistException");
   }
 }
 
@@ -3257,7 +3260,7 @@ export namespace InstanceDoesNotExistException {
  * <p>The instance ID was not specified.</p>
  */
 export interface InstanceIdRequiredException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InstanceIdRequiredException";
   $fault: "client";
@@ -3269,7 +3272,7 @@ export interface InstanceIdRequiredException
 
 export namespace InstanceIdRequiredException {
   export function isa(o: any): o is InstanceIdRequiredException {
-    return _smithy.isa(o, "InstanceIdRequiredException");
+    return __isa(o, "InstanceIdRequiredException");
   }
 }
 
@@ -3317,7 +3320,7 @@ export interface InstanceInfo {
 
 export namespace InstanceInfo {
   export function isa(o: any): o is InstanceInfo {
-    return _smithy.isa(o, "InstanceInfo");
+    return __isa(o, "InstanceInfo");
   }
 }
 
@@ -3326,7 +3329,7 @@ export namespace InstanceInfo {
  *             exceeded.</p>
  */
 export interface InstanceLimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InstanceLimitExceededException";
   $fault: "client";
@@ -3338,7 +3341,7 @@ export interface InstanceLimitExceededException
 
 export namespace InstanceLimitExceededException {
   export function isa(o: any): o is InstanceLimitExceededException {
-    return _smithy.isa(o, "InstanceLimitExceededException");
+    return __isa(o, "InstanceLimitExceededException");
   }
 }
 
@@ -3346,7 +3349,7 @@ export namespace InstanceLimitExceededException {
  * <p>The specified on-premises instance name is already registered.</p>
  */
 export interface InstanceNameAlreadyRegisteredException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InstanceNameAlreadyRegisteredException";
   $fault: "client";
@@ -3358,7 +3361,7 @@ export interface InstanceNameAlreadyRegisteredException
 
 export namespace InstanceNameAlreadyRegisteredException {
   export function isa(o: any): o is InstanceNameAlreadyRegisteredException {
-    return _smithy.isa(o, "InstanceNameAlreadyRegisteredException");
+    return __isa(o, "InstanceNameAlreadyRegisteredException");
   }
 }
 
@@ -3366,7 +3369,7 @@ export namespace InstanceNameAlreadyRegisteredException {
  * <p>An on-premises instance name was not specified.</p>
  */
 export interface InstanceNameRequiredException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InstanceNameRequiredException";
   $fault: "client";
@@ -3378,7 +3381,7 @@ export interface InstanceNameRequiredException
 
 export namespace InstanceNameRequiredException {
   export function isa(o: any): o is InstanceNameRequiredException {
-    return _smithy.isa(o, "InstanceNameRequiredException");
+    return __isa(o, "InstanceNameRequiredException");
   }
 }
 
@@ -3386,7 +3389,7 @@ export namespace InstanceNameRequiredException {
  * <p>The specified on-premises instance is not registered.</p>
  */
 export interface InstanceNotRegisteredException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InstanceNotRegisteredException";
   $fault: "client";
@@ -3398,7 +3401,7 @@ export interface InstanceNotRegisteredException
 
 export namespace InstanceNotRegisteredException {
   export function isa(o: any): o is InstanceNotRegisteredException {
-    return _smithy.isa(o, "InstanceNotRegisteredException");
+    return __isa(o, "InstanceNotRegisteredException");
   }
 }
 
@@ -3479,7 +3482,7 @@ export interface InstanceSummary {
 
 export namespace InstanceSummary {
   export function isa(o: any): o is InstanceSummary {
-    return _smithy.isa(o, "InstanceSummary");
+    return __isa(o, "InstanceSummary");
   }
 }
 
@@ -3529,7 +3532,7 @@ export interface InstanceTarget {
 
 export namespace InstanceTarget {
   export function isa(o: any): o is InstanceTarget {
-    return _smithy.isa(o, "InstanceTarget");
+    return __isa(o, "InstanceTarget");
   }
 }
 
@@ -3559,7 +3562,7 @@ export enum _InstanceType {
  *          </ul>
  */
 export interface InvalidAlarmConfigException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidAlarmConfigException";
   $fault: "client";
@@ -3571,7 +3574,7 @@ export interface InvalidAlarmConfigException
 
 export namespace InvalidAlarmConfigException {
   export function isa(o: any): o is InvalidAlarmConfigException {
-    return _smithy.isa(o, "InvalidAlarmConfigException");
+    return __isa(o, "InvalidAlarmConfigException");
   }
 }
 
@@ -3579,7 +3582,7 @@ export namespace InvalidAlarmConfigException {
  * <p>The application name was specified in an invalid format.</p>
  */
 export interface InvalidApplicationNameException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidApplicationNameException";
   $fault: "client";
@@ -3591,7 +3594,7 @@ export interface InvalidApplicationNameException
 
 export namespace InvalidApplicationNameException {
   export function isa(o: any): o is InvalidApplicationNameException {
-    return _smithy.isa(o, "InvalidApplicationNameException");
+    return __isa(o, "InvalidApplicationNameException");
   }
 }
 
@@ -3601,7 +3604,7 @@ export namespace InvalidApplicationNameException {
  *         </p>
  */
 export interface InvalidArnException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidArnException";
   $fault: "client";
@@ -3613,7 +3616,7 @@ export interface InvalidArnException
 
 export namespace InvalidArnException {
   export function isa(o: any): o is InvalidArnException {
-    return _smithy.isa(o, "InvalidArnException");
+    return __isa(o, "InvalidArnException");
   }
 }
 
@@ -3623,7 +3626,7 @@ export namespace InvalidArnException {
  *             were listed.</p>
  */
 export interface InvalidAutoRollbackConfigException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidAutoRollbackConfigException";
   $fault: "client";
@@ -3635,7 +3638,7 @@ export interface InvalidAutoRollbackConfigException
 
 export namespace InvalidAutoRollbackConfigException {
   export function isa(o: any): o is InvalidAutoRollbackConfigException {
-    return _smithy.isa(o, "InvalidAutoRollbackConfigException");
+    return __isa(o, "InvalidAutoRollbackConfigException");
   }
 }
 
@@ -3643,7 +3646,7 @@ export namespace InvalidAutoRollbackConfigException {
  * <p>The Auto Scaling group was specified in an invalid format or does not exist.</p>
  */
 export interface InvalidAutoScalingGroupException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidAutoScalingGroupException";
   $fault: "client";
@@ -3655,7 +3658,7 @@ export interface InvalidAutoScalingGroupException
 
 export namespace InvalidAutoScalingGroupException {
   export function isa(o: any): o is InvalidAutoScalingGroupException {
-    return _smithy.isa(o, "InvalidAutoScalingGroupException");
+    return __isa(o, "InvalidAutoScalingGroupException");
   }
 }
 
@@ -3664,7 +3667,7 @@ export namespace InvalidAutoScalingGroupException {
  *             format. For information about deployment configuration format, see <a>CreateDeploymentConfig</a>.</p>
  */
 export interface InvalidBlueGreenDeploymentConfigurationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidBlueGreenDeploymentConfigurationException";
   $fault: "client";
@@ -3678,7 +3681,7 @@ export namespace InvalidBlueGreenDeploymentConfigurationException {
   export function isa(
     o: any
   ): o is InvalidBlueGreenDeploymentConfigurationException {
-    return _smithy.isa(o, "InvalidBlueGreenDeploymentConfigurationException");
+    return __isa(o, "InvalidBlueGreenDeploymentConfigurationException");
   }
 }
 
@@ -3686,7 +3689,7 @@ export namespace InvalidBlueGreenDeploymentConfigurationException {
  * <p>The bucket name either doesn't exist or was specified in an invalid format.</p>
  */
 export interface InvalidBucketNameFilterException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidBucketNameFilterException";
   $fault: "client";
@@ -3698,7 +3701,7 @@ export interface InvalidBucketNameFilterException
 
 export namespace InvalidBucketNameFilterException {
   export function isa(o: any): o is InvalidBucketNameFilterException {
-    return _smithy.isa(o, "InvalidBucketNameFilterException");
+    return __isa(o, "InvalidBucketNameFilterException");
   }
 }
 
@@ -3707,7 +3710,7 @@ export namespace InvalidBucketNameFilterException {
  *                 <code>Server</code>.</p>
  */
 export interface InvalidComputePlatformException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidComputePlatformException";
   $fault: "client";
@@ -3719,7 +3722,7 @@ export interface InvalidComputePlatformException
 
 export namespace InvalidComputePlatformException {
   export function isa(o: any): o is InvalidComputePlatformException {
-    return _smithy.isa(o, "InvalidComputePlatformException");
+    return __isa(o, "InvalidComputePlatformException");
   }
 }
 
@@ -3727,7 +3730,7 @@ export namespace InvalidComputePlatformException {
  * <p>The deployed state filter was specified in an invalid format.</p>
  */
 export interface InvalidDeployedStateFilterException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidDeployedStateFilterException";
   $fault: "client";
@@ -3739,7 +3742,7 @@ export interface InvalidDeployedStateFilterException
 
 export namespace InvalidDeployedStateFilterException {
   export function isa(o: any): o is InvalidDeployedStateFilterException {
-    return _smithy.isa(o, "InvalidDeployedStateFilterException");
+    return __isa(o, "InvalidDeployedStateFilterException");
   }
 }
 
@@ -3747,7 +3750,7 @@ export namespace InvalidDeployedStateFilterException {
  * <p>The deployment configuration name was specified in an invalid format.</p>
  */
 export interface InvalidDeploymentConfigNameException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidDeploymentConfigNameException";
   $fault: "client";
@@ -3759,7 +3762,7 @@ export interface InvalidDeploymentConfigNameException
 
 export namespace InvalidDeploymentConfigNameException {
   export function isa(o: any): o is InvalidDeploymentConfigNameException {
-    return _smithy.isa(o, "InvalidDeploymentConfigNameException");
+    return __isa(o, "InvalidDeploymentConfigNameException");
   }
 }
 
@@ -3767,7 +3770,7 @@ export namespace InvalidDeploymentConfigNameException {
  * <p>The deployment group name was specified in an invalid format.</p>
  */
 export interface InvalidDeploymentGroupNameException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidDeploymentGroupNameException";
   $fault: "client";
@@ -3779,7 +3782,7 @@ export interface InvalidDeploymentGroupNameException
 
 export namespace InvalidDeploymentGroupNameException {
   export function isa(o: any): o is InvalidDeploymentGroupNameException {
-    return _smithy.isa(o, "InvalidDeploymentGroupNameException");
+    return __isa(o, "InvalidDeploymentGroupNameException");
   }
 }
 
@@ -3787,7 +3790,7 @@ export namespace InvalidDeploymentGroupNameException {
  * <p>At least one of the deployment IDs was specified in an invalid format.</p>
  */
 export interface InvalidDeploymentIdException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidDeploymentIdException";
   $fault: "client";
@@ -3799,7 +3802,7 @@ export interface InvalidDeploymentIdException
 
 export namespace InvalidDeploymentIdException {
   export function isa(o: any): o is InvalidDeploymentIdException {
-    return _smithy.isa(o, "InvalidDeploymentIdException");
+    return __isa(o, "InvalidDeploymentIdException");
   }
 }
 
@@ -3808,7 +3811,7 @@ export namespace InvalidDeploymentIdException {
  *             supported for blue/green deployments only.</p>
  */
 export interface InvalidDeploymentInstanceTypeException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidDeploymentInstanceTypeException";
   $fault: "client";
@@ -3820,7 +3823,7 @@ export interface InvalidDeploymentInstanceTypeException
 
 export namespace InvalidDeploymentInstanceTypeException {
   export function isa(o: any): o is InvalidDeploymentInstanceTypeException {
-    return _smithy.isa(o, "InvalidDeploymentInstanceTypeException");
+    return __isa(o, "InvalidDeploymentInstanceTypeException");
   }
 }
 
@@ -3828,7 +3831,7 @@ export namespace InvalidDeploymentInstanceTypeException {
  * <p>The specified deployment status doesn't exist or cannot be determined.</p>
  */
 export interface InvalidDeploymentStatusException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidDeploymentStatusException";
   $fault: "client";
@@ -3840,7 +3843,7 @@ export interface InvalidDeploymentStatusException
 
 export namespace InvalidDeploymentStatusException {
   export function isa(o: any): o is InvalidDeploymentStatusException {
-    return _smithy.isa(o, "InvalidDeploymentStatusException");
+    return __isa(o, "InvalidDeploymentStatusException");
   }
 }
 
@@ -3850,7 +3853,7 @@ export namespace InvalidDeploymentStatusException {
  *             "WITHOUT_TRAFFIC_CONTROL."</p>
  */
 export interface InvalidDeploymentStyleException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidDeploymentStyleException";
   $fault: "client";
@@ -3862,7 +3865,7 @@ export interface InvalidDeploymentStyleException
 
 export namespace InvalidDeploymentStyleException {
   export function isa(o: any): o is InvalidDeploymentStyleException {
-    return _smithy.isa(o, "InvalidDeploymentStyleException");
+    return __isa(o, "InvalidDeploymentStyleException");
   }
 }
 
@@ -3870,7 +3873,7 @@ export namespace InvalidDeploymentStyleException {
  * <p> The target ID provided was not valid. </p>
  */
 export interface InvalidDeploymentTargetIdException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidDeploymentTargetIdException";
   $fault: "client";
@@ -3882,7 +3885,7 @@ export interface InvalidDeploymentTargetIdException
 
 export namespace InvalidDeploymentTargetIdException {
   export function isa(o: any): o is InvalidDeploymentTargetIdException {
-    return _smithy.isa(o, "InvalidDeploymentTargetIdException");
+    return __isa(o, "InvalidDeploymentTargetIdException");
   }
 }
 
@@ -3890,7 +3893,7 @@ export namespace InvalidDeploymentTargetIdException {
  * <p> The wait type is invalid. </p>
  */
 export interface InvalidDeploymentWaitTypeException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidDeploymentWaitTypeException";
   $fault: "client";
@@ -3902,7 +3905,7 @@ export interface InvalidDeploymentWaitTypeException
 
 export namespace InvalidDeploymentWaitTypeException {
   export function isa(o: any): o is InvalidDeploymentWaitTypeException {
-    return _smithy.isa(o, "InvalidDeploymentWaitTypeException");
+    return __isa(o, "InvalidDeploymentWaitTypeException");
   }
 }
 
@@ -3911,7 +3914,7 @@ export namespace InvalidDeploymentWaitTypeException {
  *             these data types can be used in a single call.</p>
  */
 export interface InvalidEC2TagCombinationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidEC2TagCombinationException";
   $fault: "client";
@@ -3923,7 +3926,7 @@ export interface InvalidEC2TagCombinationException
 
 export namespace InvalidEC2TagCombinationException {
   export function isa(o: any): o is InvalidEC2TagCombinationException {
-    return _smithy.isa(o, "InvalidEC2TagCombinationException");
+    return __isa(o, "InvalidEC2TagCombinationException");
   }
 }
 
@@ -3931,7 +3934,7 @@ export namespace InvalidEC2TagCombinationException {
  * <p>The tag was specified in an invalid format.</p>
  */
 export interface InvalidEC2TagException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidEC2TagException";
   $fault: "client";
@@ -3943,7 +3946,7 @@ export interface InvalidEC2TagException
 
 export namespace InvalidEC2TagException {
   export function isa(o: any): o is InvalidEC2TagException {
-    return _smithy.isa(o, "InvalidEC2TagException");
+    return __isa(o, "InvalidEC2TagException");
   }
 }
 
@@ -3951,7 +3954,7 @@ export namespace InvalidEC2TagException {
  * <p> The Amazon ECS service identifier is not valid. </p>
  */
 export interface InvalidECSServiceException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidECSServiceException";
   $fault: "client";
@@ -3963,7 +3966,7 @@ export interface InvalidECSServiceException
 
 export namespace InvalidECSServiceException {
   export function isa(o: any): o is InvalidECSServiceException {
-    return _smithy.isa(o, "InvalidECSServiceException");
+    return __isa(o, "InvalidECSServiceException");
   }
 }
 
@@ -3974,7 +3977,7 @@ export namespace InvalidECSServiceException {
  *             "OVERWRITE," and "RETAIN."</p>
  */
 export interface InvalidFileExistsBehaviorException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidFileExistsBehaviorException";
   $fault: "client";
@@ -3986,7 +3989,7 @@ export interface InvalidFileExistsBehaviorException
 
 export namespace InvalidFileExistsBehaviorException {
   export function isa(o: any): o is InvalidFileExistsBehaviorException {
-    return _smithy.isa(o, "InvalidFileExistsBehaviorException");
+    return __isa(o, "InvalidFileExistsBehaviorException");
   }
 }
 
@@ -3994,7 +3997,7 @@ export namespace InvalidFileExistsBehaviorException {
  * <p>The GitHub token is not valid.</p>
  */
 export interface InvalidGitHubAccountTokenException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidGitHubAccountTokenException";
   $fault: "client";
@@ -4006,7 +4009,7 @@ export interface InvalidGitHubAccountTokenException
 
 export namespace InvalidGitHubAccountTokenException {
   export function isa(o: any): o is InvalidGitHubAccountTokenException {
-    return _smithy.isa(o, "InvalidGitHubAccountTokenException");
+    return __isa(o, "InvalidGitHubAccountTokenException");
   }
 }
 
@@ -4014,7 +4017,7 @@ export namespace InvalidGitHubAccountTokenException {
  * <p>The format of the specified GitHub account connection name is invalid.</p>
  */
 export interface InvalidGitHubAccountTokenNameException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidGitHubAccountTokenNameException";
   $fault: "client";
@@ -4026,7 +4029,7 @@ export interface InvalidGitHubAccountTokenNameException
 
 export namespace InvalidGitHubAccountTokenNameException {
   export function isa(o: any): o is InvalidGitHubAccountTokenNameException {
-    return _smithy.isa(o, "InvalidGitHubAccountTokenNameException");
+    return __isa(o, "InvalidGitHubAccountTokenNameException");
   }
 }
 
@@ -4034,7 +4037,7 @@ export namespace InvalidGitHubAccountTokenNameException {
  * <p>The IAM session ARN was specified in an invalid format.</p>
  */
 export interface InvalidIamSessionArnException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidIamSessionArnException";
   $fault: "client";
@@ -4046,7 +4049,7 @@ export interface InvalidIamSessionArnException
 
 export namespace InvalidIamSessionArnException {
   export function isa(o: any): o is InvalidIamSessionArnException {
-    return _smithy.isa(o, "InvalidIamSessionArnException");
+    return __isa(o, "InvalidIamSessionArnException");
   }
 }
 
@@ -4054,7 +4057,7 @@ export namespace InvalidIamSessionArnException {
  * <p>The IAM user ARN was specified in an invalid format.</p>
  */
 export interface InvalidIamUserArnException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidIamUserArnException";
   $fault: "client";
@@ -4066,7 +4069,7 @@ export interface InvalidIamUserArnException
 
 export namespace InvalidIamUserArnException {
   export function isa(o: any): o is InvalidIamUserArnException {
-    return _smithy.isa(o, "InvalidIamUserArnException");
+    return __isa(o, "InvalidIamUserArnException");
   }
 }
 
@@ -4076,7 +4079,7 @@ export namespace InvalidIamUserArnException {
  *             or <code>false</code> is expected.</p>
  */
 export interface InvalidIgnoreApplicationStopFailuresValueException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidIgnoreApplicationStopFailuresValueException";
   $fault: "client";
@@ -4090,7 +4093,7 @@ export namespace InvalidIgnoreApplicationStopFailuresValueException {
   export function isa(
     o: any
   ): o is InvalidIgnoreApplicationStopFailuresValueException {
-    return _smithy.isa(o, "InvalidIgnoreApplicationStopFailuresValueException");
+    return __isa(o, "InvalidIgnoreApplicationStopFailuresValueException");
   }
 }
 
@@ -4098,7 +4101,7 @@ export namespace InvalidIgnoreApplicationStopFailuresValueException {
  * <p>The input was specified in an invalid format.</p>
  */
 export interface InvalidInputException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidInputException";
   $fault: "client";
@@ -4110,7 +4113,7 @@ export interface InvalidInputException
 
 export namespace InvalidInputException {
   export function isa(o: any): o is InvalidInputException {
-    return _smithy.isa(o, "InvalidInputException");
+    return __isa(o, "InvalidInputException");
   }
 }
 
@@ -4118,7 +4121,7 @@ export namespace InvalidInputException {
  * <p>The on-premises instance name was specified in an invalid format.</p>
  */
 export interface InvalidInstanceNameException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidInstanceNameException";
   $fault: "client";
@@ -4130,7 +4133,7 @@ export interface InvalidInstanceNameException
 
 export namespace InvalidInstanceNameException {
   export function isa(o: any): o is InvalidInstanceNameException {
-    return _smithy.isa(o, "InvalidInstanceNameException");
+    return __isa(o, "InvalidInstanceNameException");
   }
 }
 
@@ -4138,7 +4141,7 @@ export namespace InvalidInstanceNameException {
  * <p>The specified instance status does not exist.</p>
  */
 export interface InvalidInstanceStatusException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidInstanceStatusException";
   $fault: "client";
@@ -4150,7 +4153,7 @@ export interface InvalidInstanceStatusException
 
 export namespace InvalidInstanceStatusException {
   export function isa(o: any): o is InvalidInstanceStatusException {
-    return _smithy.isa(o, "InvalidInstanceStatusException");
+    return __isa(o, "InvalidInstanceStatusException");
   }
 }
 
@@ -4160,7 +4163,7 @@ export namespace InvalidInstanceStatusException {
  *             environment.</p>
  */
 export interface InvalidInstanceTypeException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidInstanceTypeException";
   $fault: "client";
@@ -4172,7 +4175,7 @@ export interface InvalidInstanceTypeException
 
 export namespace InvalidInstanceTypeException {
   export function isa(o: any): o is InvalidInstanceTypeException {
-    return _smithy.isa(o, "InvalidInstanceTypeException");
+    return __isa(o, "InvalidInstanceTypeException");
   }
 }
 
@@ -4180,7 +4183,7 @@ export namespace InvalidInstanceTypeException {
  * <p>The specified key prefix filter was specified in an invalid format.</p>
  */
 export interface InvalidKeyPrefixFilterException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidKeyPrefixFilterException";
   $fault: "client";
@@ -4192,7 +4195,7 @@ export interface InvalidKeyPrefixFilterException
 
 export namespace InvalidKeyPrefixFilterException {
   export function isa(o: any): o is InvalidKeyPrefixFilterException {
-    return _smithy.isa(o, "InvalidKeyPrefixFilterException");
+    return __isa(o, "InvalidKeyPrefixFilterException");
   }
 }
 
@@ -4202,7 +4205,7 @@ export namespace InvalidKeyPrefixFilterException {
  *             valid.</p>
  */
 export interface InvalidLifecycleEventHookExecutionIdException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidLifecycleEventHookExecutionIdException";
   $fault: "client";
@@ -4216,7 +4219,7 @@ export namespace InvalidLifecycleEventHookExecutionIdException {
   export function isa(
     o: any
   ): o is InvalidLifecycleEventHookExecutionIdException {
-    return _smithy.isa(o, "InvalidLifecycleEventHookExecutionIdException");
+    return __isa(o, "InvalidLifecycleEventHookExecutionIdException");
   }
 }
 
@@ -4225,7 +4228,7 @@ export namespace InvalidLifecycleEventHookExecutionIdException {
  *             It should return <code>Succeeded</code> or <code>Failed</code>.</p>
  */
 export interface InvalidLifecycleEventHookExecutionStatusException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidLifecycleEventHookExecutionStatusException";
   $fault: "client";
@@ -4239,7 +4242,7 @@ export namespace InvalidLifecycleEventHookExecutionStatusException {
   export function isa(
     o: any
   ): o is InvalidLifecycleEventHookExecutionStatusException {
-    return _smithy.isa(o, "InvalidLifecycleEventHookExecutionStatusException");
+    return __isa(o, "InvalidLifecycleEventHookExecutionStatusException");
   }
 }
 
@@ -4247,7 +4250,7 @@ export namespace InvalidLifecycleEventHookExecutionStatusException {
  * <p>An invalid load balancer name, or no load balancer name, was specified.</p>
  */
 export interface InvalidLoadBalancerInfoException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidLoadBalancerInfoException";
   $fault: "client";
@@ -4259,7 +4262,7 @@ export interface InvalidLoadBalancerInfoException
 
 export namespace InvalidLoadBalancerInfoException {
   export function isa(o: any): o is InvalidLoadBalancerInfoException {
-    return _smithy.isa(o, "InvalidLoadBalancerInfoException");
+    return __isa(o, "InvalidLoadBalancerInfoException");
   }
 }
 
@@ -4267,7 +4270,7 @@ export namespace InvalidLoadBalancerInfoException {
  * <p>The minimum healthy instance value was specified in an invalid format.</p>
  */
 export interface InvalidMinimumHealthyHostValueException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidMinimumHealthyHostValueException";
   $fault: "client";
@@ -4279,7 +4282,7 @@ export interface InvalidMinimumHealthyHostValueException
 
 export namespace InvalidMinimumHealthyHostValueException {
   export function isa(o: any): o is InvalidMinimumHealthyHostValueException {
-    return _smithy.isa(o, "InvalidMinimumHealthyHostValueException");
+    return __isa(o, "InvalidMinimumHealthyHostValueException");
   }
 }
 
@@ -4287,7 +4290,7 @@ export namespace InvalidMinimumHealthyHostValueException {
  * <p>The next token was specified in an invalid format.</p>
  */
 export interface InvalidNextTokenException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidNextTokenException";
   $fault: "client";
@@ -4299,7 +4302,7 @@ export interface InvalidNextTokenException
 
 export namespace InvalidNextTokenException {
   export function isa(o: any): o is InvalidNextTokenException {
-    return _smithy.isa(o, "InvalidNextTokenException");
+    return __isa(o, "InvalidNextTokenException");
   }
 }
 
@@ -4308,7 +4311,7 @@ export namespace InvalidNextTokenException {
  *             but only one of these data types can be used in a single call.</p>
  */
 export interface InvalidOnPremisesTagCombinationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidOnPremisesTagCombinationException";
   $fault: "client";
@@ -4320,7 +4323,7 @@ export interface InvalidOnPremisesTagCombinationException
 
 export namespace InvalidOnPremisesTagCombinationException {
   export function isa(o: any): o is InvalidOnPremisesTagCombinationException {
-    return _smithy.isa(o, "InvalidOnPremisesTagCombinationException");
+    return __isa(o, "InvalidOnPremisesTagCombinationException");
   }
 }
 
@@ -4328,7 +4331,7 @@ export namespace InvalidOnPremisesTagCombinationException {
  * <p>An invalid operation was detected.</p>
  */
 export interface InvalidOperationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidOperationException";
   $fault: "client";
@@ -4340,7 +4343,7 @@ export interface InvalidOperationException
 
 export namespace InvalidOperationException {
   export function isa(o: any): o is InvalidOperationException {
-    return _smithy.isa(o, "InvalidOperationException");
+    return __isa(o, "InvalidOperationException");
   }
 }
 
@@ -4348,7 +4351,7 @@ export namespace InvalidOperationException {
  * <p>The registration status was specified in an invalid format.</p>
  */
 export interface InvalidRegistrationStatusException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidRegistrationStatusException";
   $fault: "client";
@@ -4360,7 +4363,7 @@ export interface InvalidRegistrationStatusException
 
 export namespace InvalidRegistrationStatusException {
   export function isa(o: any): o is InvalidRegistrationStatusException {
-    return _smithy.isa(o, "InvalidRegistrationStatusException");
+    return __isa(o, "InvalidRegistrationStatusException");
   }
 }
 
@@ -4368,7 +4371,7 @@ export namespace InvalidRegistrationStatusException {
  * <p>The revision was specified in an invalid format.</p>
  */
 export interface InvalidRevisionException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidRevisionException";
   $fault: "client";
@@ -4380,7 +4383,7 @@ export interface InvalidRevisionException
 
 export namespace InvalidRevisionException {
   export function isa(o: any): o is InvalidRevisionException {
-    return _smithy.isa(o, "InvalidRevisionException");
+    return __isa(o, "InvalidRevisionException");
   }
 }
 
@@ -4390,7 +4393,7 @@ export namespace InvalidRevisionException {
  *             Amazon EC2 Auto Scaling.</p>
  */
 export interface InvalidRoleException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidRoleException";
   $fault: "client";
@@ -4402,7 +4405,7 @@ export interface InvalidRoleException
 
 export namespace InvalidRoleException {
   export function isa(o: any): o is InvalidRoleException {
-    return _smithy.isa(o, "InvalidRoleException");
+    return __isa(o, "InvalidRoleException");
   }
 }
 
@@ -4411,7 +4414,7 @@ export namespace InvalidRoleException {
  *             format.</p>
  */
 export interface InvalidSortByException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidSortByException";
   $fault: "client";
@@ -4423,7 +4426,7 @@ export interface InvalidSortByException
 
 export namespace InvalidSortByException {
   export function isa(o: any): o is InvalidSortByException {
-    return _smithy.isa(o, "InvalidSortByException");
+    return __isa(o, "InvalidSortByException");
   }
 }
 
@@ -4431,7 +4434,7 @@ export namespace InvalidSortByException {
  * <p>The sort order was specified in an invalid format.</p>
  */
 export interface InvalidSortOrderException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidSortOrderException";
   $fault: "client";
@@ -4443,7 +4446,7 @@ export interface InvalidSortOrderException
 
 export namespace InvalidSortOrderException {
   export function isa(o: any): o is InvalidSortOrderException {
-    return _smithy.isa(o, "InvalidSortOrderException");
+    return __isa(o, "InvalidSortOrderException");
   }
 }
 
@@ -4451,7 +4454,7 @@ export namespace InvalidSortOrderException {
  * <p>The tag was specified in an invalid format.</p>
  */
 export interface InvalidTagException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidTagException";
   $fault: "client";
@@ -4463,7 +4466,7 @@ export interface InvalidTagException
 
 export namespace InvalidTagException {
   export function isa(o: any): o is InvalidTagException {
-    return _smithy.isa(o, "InvalidTagException");
+    return __isa(o, "InvalidTagException");
   }
 }
 
@@ -4471,7 +4474,7 @@ export namespace InvalidTagException {
  * <p>The tag filter was specified in an invalid format.</p>
  */
 export interface InvalidTagFilterException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidTagFilterException";
   $fault: "client";
@@ -4483,7 +4486,7 @@ export interface InvalidTagFilterException
 
 export namespace InvalidTagFilterException {
   export function isa(o: any): o is InvalidTagFilterException {
-    return _smithy.isa(o, "InvalidTagFilterException");
+    return __isa(o, "InvalidTagFilterException");
   }
 }
 
@@ -4493,7 +4496,7 @@ export namespace InvalidTagFilterException {
  *         </p>
  */
 export interface InvalidTagsToAddException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidTagsToAddException";
   $fault: "client";
@@ -4505,7 +4508,7 @@ export interface InvalidTagsToAddException
 
 export namespace InvalidTagsToAddException {
   export function isa(o: any): o is InvalidTagsToAddException {
-    return _smithy.isa(o, "InvalidTagsToAddException");
+    return __isa(o, "InvalidTagsToAddException");
   }
 }
 
@@ -4513,7 +4516,7 @@ export namespace InvalidTagsToAddException {
  * <p> The target filter name is invalid. </p>
  */
 export interface InvalidTargetFilterNameException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidTargetFilterNameException";
   $fault: "client";
@@ -4525,7 +4528,7 @@ export interface InvalidTargetFilterNameException
 
 export namespace InvalidTargetFilterNameException {
   export function isa(o: any): o is InvalidTargetFilterNameException {
-    return _smithy.isa(o, "InvalidTargetFilterNameException");
+    return __isa(o, "InvalidTargetFilterNameException");
   }
 }
 
@@ -4533,7 +4536,7 @@ export namespace InvalidTargetFilterNameException {
  * <p> A target group pair associated with this deployment is not valid. </p>
  */
 export interface InvalidTargetGroupPairException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidTargetGroupPairException";
   $fault: "client";
@@ -4545,7 +4548,7 @@ export interface InvalidTargetGroupPairException
 
 export namespace InvalidTargetGroupPairException {
   export function isa(o: any): o is InvalidTargetGroupPairException {
-    return _smithy.isa(o, "InvalidTargetGroupPairException");
+    return __isa(o, "InvalidTargetGroupPairException");
   }
 }
 
@@ -4568,7 +4571,7 @@ export namespace InvalidTargetGroupPairException {
  *          </ul>
  */
 export interface InvalidTargetInstancesException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidTargetInstancesException";
   $fault: "client";
@@ -4580,7 +4583,7 @@ export interface InvalidTargetInstancesException
 
 export namespace InvalidTargetInstancesException {
   export function isa(o: any): o is InvalidTargetInstancesException {
-    return _smithy.isa(o, "InvalidTargetInstancesException");
+    return __isa(o, "InvalidTargetInstancesException");
   }
 }
 
@@ -4588,7 +4591,7 @@ export namespace InvalidTargetInstancesException {
  * <p>The specified time range was specified in an invalid format.</p>
  */
 export interface InvalidTimeRangeException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidTimeRangeException";
   $fault: "client";
@@ -4600,7 +4603,7 @@ export interface InvalidTimeRangeException
 
 export namespace InvalidTimeRangeException {
   export function isa(o: any): o is InvalidTimeRangeException {
-    return _smithy.isa(o, "InvalidTimeRangeException");
+    return __isa(o, "InvalidTimeRangeException");
   }
 }
 
@@ -4609,7 +4612,7 @@ export namespace InvalidTimeRangeException {
  *             invalid.</p>
  */
 export interface InvalidTrafficRoutingConfigurationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidTrafficRoutingConfigurationException";
   $fault: "client";
@@ -4623,7 +4626,7 @@ export namespace InvalidTrafficRoutingConfigurationException {
   export function isa(
     o: any
   ): o is InvalidTrafficRoutingConfigurationException {
-    return _smithy.isa(o, "InvalidTrafficRoutingConfigurationException");
+    return __isa(o, "InvalidTrafficRoutingConfigurationException");
   }
 }
 
@@ -4631,7 +4634,7 @@ export namespace InvalidTrafficRoutingConfigurationException {
  * <p>The trigger was specified in an invalid format.</p>
  */
 export interface InvalidTriggerConfigException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidTriggerConfigException";
   $fault: "client";
@@ -4643,7 +4646,7 @@ export interface InvalidTriggerConfigException
 
 export namespace InvalidTriggerConfigException {
   export function isa(o: any): o is InvalidTriggerConfigException {
-    return _smithy.isa(o, "InvalidTriggerConfigException");
+    return __isa(o, "InvalidTriggerConfigException");
   }
 }
 
@@ -4653,7 +4656,7 @@ export namespace InvalidTriggerConfigException {
  *             or <code>false</code> is expected.</p>
  */
 export interface InvalidUpdateOutdatedInstancesOnlyValueException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidUpdateOutdatedInstancesOnlyValueException";
   $fault: "client";
@@ -4667,7 +4670,7 @@ export namespace InvalidUpdateOutdatedInstancesOnlyValueException {
   export function isa(
     o: any
   ): o is InvalidUpdateOutdatedInstancesOnlyValueException {
-    return _smithy.isa(o, "InvalidUpdateOutdatedInstancesOnlyValueException");
+    return __isa(o, "InvalidUpdateOutdatedInstancesOnlyValueException");
   }
 }
 
@@ -4717,7 +4720,7 @@ export interface LambdaFunctionInfo {
 
 export namespace LambdaFunctionInfo {
   export function isa(o: any): o is LambdaFunctionInfo {
-    return _smithy.isa(o, "LambdaFunctionInfo");
+    return __isa(o, "LambdaFunctionInfo");
   }
 }
 
@@ -4769,7 +4772,7 @@ export interface LambdaTarget {
 
 export namespace LambdaTarget {
   export function isa(o: any): o is LambdaTarget {
-    return _smithy.isa(o, "LambdaTarget");
+    return __isa(o, "LambdaTarget");
   }
 }
 
@@ -4804,7 +4807,7 @@ export interface LastDeploymentInfo {
 
 export namespace LastDeploymentInfo {
   export function isa(o: any): o is LastDeploymentInfo {
-    return _smithy.isa(o, "LastDeploymentInfo");
+    return __isa(o, "LastDeploymentInfo");
   }
 }
 
@@ -4871,7 +4874,7 @@ export interface LifecycleEvent {
 
 export namespace LifecycleEvent {
   export function isa(o: any): o is LifecycleEvent {
-    return _smithy.isa(o, "LifecycleEvent");
+    return __isa(o, "LifecycleEvent");
   }
 }
 
@@ -4880,7 +4883,7 @@ export namespace LifecycleEvent {
  *             occurred.</p>
  */
 export interface LifecycleEventAlreadyCompletedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LifecycleEventAlreadyCompletedException";
   $fault: "client";
@@ -4892,7 +4895,7 @@ export interface LifecycleEventAlreadyCompletedException
 
 export namespace LifecycleEventAlreadyCompletedException {
   export function isa(o: any): o is LifecycleEventAlreadyCompletedException {
-    return _smithy.isa(o, "LifecycleEventAlreadyCompletedException");
+    return __isa(o, "LifecycleEventAlreadyCompletedException");
   }
 }
 
@@ -4909,7 +4912,7 @@ export enum LifecycleEventStatus {
  * <p>The limit for lifecycle hooks was exceeded.</p>
  */
 export interface LifecycleHookLimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LifecycleHookLimitExceededException";
   $fault: "client";
@@ -4921,7 +4924,7 @@ export interface LifecycleHookLimitExceededException
 
 export namespace LifecycleHookLimitExceededException {
   export function isa(o: any): o is LifecycleHookLimitExceededException {
-    return _smithy.isa(o, "LifecycleHookLimitExceededException");
+    return __isa(o, "LifecycleHookLimitExceededException");
   }
 }
 
@@ -5011,7 +5014,7 @@ export interface ListApplicationRevisionsInput {
 
 export namespace ListApplicationRevisionsInput {
   export function isa(o: any): o is ListApplicationRevisionsInput {
-    return _smithy.isa(o, "ListApplicationRevisionsInput");
+    return __isa(o, "ListApplicationRevisionsInput");
   }
 }
 
@@ -5035,7 +5038,7 @@ export interface ListApplicationRevisionsOutput extends $MetadataBearer {
 
 export namespace ListApplicationRevisionsOutput {
   export function isa(o: any): o is ListApplicationRevisionsOutput {
-    return _smithy.isa(o, "ListApplicationRevisionsOutput");
+    return __isa(o, "ListApplicationRevisionsOutput");
   }
 }
 
@@ -5053,7 +5056,7 @@ export interface ListApplicationsInput {
 
 export namespace ListApplicationsInput {
   export function isa(o: any): o is ListApplicationsInput {
-    return _smithy.isa(o, "ListApplicationsInput");
+    return __isa(o, "ListApplicationsInput");
   }
 }
 
@@ -5077,7 +5080,7 @@ export interface ListApplicationsOutput extends $MetadataBearer {
 
 export namespace ListApplicationsOutput {
   export function isa(o: any): o is ListApplicationsOutput {
-    return _smithy.isa(o, "ListApplicationsOutput");
+    return __isa(o, "ListApplicationsOutput");
   }
 }
 
@@ -5095,7 +5098,7 @@ export interface ListDeploymentConfigsInput {
 
 export namespace ListDeploymentConfigsInput {
   export function isa(o: any): o is ListDeploymentConfigsInput {
-    return _smithy.isa(o, "ListDeploymentConfigsInput");
+    return __isa(o, "ListDeploymentConfigsInput");
   }
 }
 
@@ -5120,7 +5123,7 @@ export interface ListDeploymentConfigsOutput extends $MetadataBearer {
 
 export namespace ListDeploymentConfigsOutput {
   export function isa(o: any): o is ListDeploymentConfigsOutput {
-    return _smithy.isa(o, "ListDeploymentConfigsOutput");
+    return __isa(o, "ListDeploymentConfigsOutput");
   }
 }
 
@@ -5144,7 +5147,7 @@ export interface ListDeploymentGroupsInput {
 
 export namespace ListDeploymentGroupsInput {
   export function isa(o: any): o is ListDeploymentGroupsInput {
-    return _smithy.isa(o, "ListDeploymentGroupsInput");
+    return __isa(o, "ListDeploymentGroupsInput");
   }
 }
 
@@ -5173,7 +5176,7 @@ export interface ListDeploymentGroupsOutput extends $MetadataBearer {
 
 export namespace ListDeploymentGroupsOutput {
   export function isa(o: any): o is ListDeploymentGroupsOutput {
-    return _smithy.isa(o, "ListDeploymentGroupsOutput");
+    return __isa(o, "ListDeploymentGroupsOutput");
   }
 }
 
@@ -5229,7 +5232,7 @@ export interface ListDeploymentInstancesInput {
 
 export namespace ListDeploymentInstancesInput {
   export function isa(o: any): o is ListDeploymentInstancesInput {
-    return _smithy.isa(o, "ListDeploymentInstancesInput");
+    return __isa(o, "ListDeploymentInstancesInput");
   }
 }
 
@@ -5253,7 +5256,7 @@ export interface ListDeploymentInstancesOutput extends $MetadataBearer {
 
 export namespace ListDeploymentInstancesOutput {
   export function isa(o: any): o is ListDeploymentInstancesOutput {
-    return _smithy.isa(o, "ListDeploymentInstancesOutput");
+    return __isa(o, "ListDeploymentInstancesOutput");
   }
 }
 
@@ -5291,7 +5294,7 @@ export interface ListDeploymentTargetsInput {
 
 export namespace ListDeploymentTargetsInput {
   export function isa(o: any): o is ListDeploymentTargetsInput {
-    return _smithy.isa(o, "ListDeploymentTargetsInput");
+    return __isa(o, "ListDeploymentTargetsInput");
   }
 }
 
@@ -5312,7 +5315,7 @@ export interface ListDeploymentTargetsOutput extends $MetadataBearer {
 
 export namespace ListDeploymentTargetsOutput {
   export function isa(o: any): o is ListDeploymentTargetsOutput {
-    return _smithy.isa(o, "ListDeploymentTargetsOutput");
+    return __isa(o, "ListDeploymentTargetsOutput");
   }
 }
 
@@ -5383,7 +5386,7 @@ export interface ListDeploymentsInput {
 
 export namespace ListDeploymentsInput {
   export function isa(o: any): o is ListDeploymentsInput {
-    return _smithy.isa(o, "ListDeploymentsInput");
+    return __isa(o, "ListDeploymentsInput");
   }
 }
 
@@ -5407,7 +5410,7 @@ export interface ListDeploymentsOutput extends $MetadataBearer {
 
 export namespace ListDeploymentsOutput {
   export function isa(o: any): o is ListDeploymentsOutput {
-    return _smithy.isa(o, "ListDeploymentsOutput");
+    return __isa(o, "ListDeploymentsOutput");
   }
 }
 
@@ -5425,7 +5428,7 @@ export interface ListGitHubAccountTokenNamesInput {
 
 export namespace ListGitHubAccountTokenNamesInput {
   export function isa(o: any): o is ListGitHubAccountTokenNamesInput {
-    return _smithy.isa(o, "ListGitHubAccountTokenNamesInput");
+    return __isa(o, "ListGitHubAccountTokenNamesInput");
   }
 }
 
@@ -5449,7 +5452,7 @@ export interface ListGitHubAccountTokenNamesOutput extends $MetadataBearer {
 
 export namespace ListGitHubAccountTokenNamesOutput {
   export function isa(o: any): o is ListGitHubAccountTokenNamesOutput {
-    return _smithy.isa(o, "ListGitHubAccountTokenNamesOutput");
+    return __isa(o, "ListGitHubAccountTokenNamesOutput");
   }
 }
 
@@ -5488,7 +5491,7 @@ export interface ListOnPremisesInstancesInput {
 
 export namespace ListOnPremisesInstancesInput {
   export function isa(o: any): o is ListOnPremisesInstancesInput {
-    return _smithy.isa(o, "ListOnPremisesInstancesInput");
+    return __isa(o, "ListOnPremisesInstancesInput");
   }
 }
 
@@ -5512,7 +5515,7 @@ export interface ListOnPremisesInstancesOutput extends $MetadataBearer {
 
 export namespace ListOnPremisesInstancesOutput {
   export function isa(o: any): o is ListOnPremisesInstancesOutput {
-    return _smithy.isa(o, "ListOnPremisesInstancesOutput");
+    return __isa(o, "ListOnPremisesInstancesOutput");
   }
 }
 
@@ -5541,7 +5544,7 @@ export interface ListTagsForResourceInput {
 
 export namespace ListTagsForResourceInput {
   export function isa(o: any): o is ListTagsForResourceInput {
-    return _smithy.isa(o, "ListTagsForResourceInput");
+    return __isa(o, "ListTagsForResourceInput");
   }
 }
 
@@ -5565,7 +5568,7 @@ export interface ListTagsForResourceOutput extends $MetadataBearer {
 
 export namespace ListTagsForResourceOutput {
   export function isa(o: any): o is ListTagsForResourceOutput {
-    return _smithy.isa(o, "ListTagsForResourceOutput");
+    return __isa(o, "ListTagsForResourceOutput");
   }
 }
 
@@ -5604,7 +5607,7 @@ export interface LoadBalancerInfo {
 
 export namespace LoadBalancerInfo {
   export function isa(o: any): o is LoadBalancerInfo {
-    return _smithy.isa(o, "LoadBalancerInfo");
+    return __isa(o, "LoadBalancerInfo");
   }
 }
 
@@ -5654,7 +5657,7 @@ export interface MinimumHealthyHosts {
 
 export namespace MinimumHealthyHosts {
   export function isa(o: any): o is MinimumHealthyHosts {
-    return _smithy.isa(o, "MinimumHealthyHosts");
+    return __isa(o, "MinimumHealthyHosts");
   }
 }
 
@@ -5665,7 +5668,7 @@ export type MinimumHealthyHostsType = "FLEET_PERCENT" | "HOST_COUNT";
  *             ARN type.</p>
  */
 export interface MultipleIamArnsProvidedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "MultipleIamArnsProvidedException";
   $fault: "client";
@@ -5677,7 +5680,7 @@ export interface MultipleIamArnsProvidedException
 
 export namespace MultipleIamArnsProvidedException {
   export function isa(o: any): o is MultipleIamArnsProvidedException {
-    return _smithy.isa(o, "MultipleIamArnsProvidedException");
+    return __isa(o, "MultipleIamArnsProvidedException");
   }
 }
 
@@ -5696,7 +5699,7 @@ export interface OnPremisesTagSet {
 
 export namespace OnPremisesTagSet {
   export function isa(o: any): o is OnPremisesTagSet {
-    return _smithy.isa(o, "OnPremisesTagSet");
+    return __isa(o, "OnPremisesTagSet");
   }
 }
 
@@ -5704,7 +5707,7 @@ export namespace OnPremisesTagSet {
  * <p>The API used does not support the deployment.</p>
  */
 export interface OperationNotSupportedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "OperationNotSupportedException";
   $fault: "client";
@@ -5716,7 +5719,7 @@ export interface OperationNotSupportedException
 
 export namespace OperationNotSupportedException {
   export function isa(o: any): o is OperationNotSupportedException {
-    return _smithy.isa(o, "OperationNotSupportedException");
+    return __isa(o, "OperationNotSupportedException");
   }
 }
 
@@ -5743,7 +5746,7 @@ export interface PutLifecycleEventHookExecutionStatusInput {
 
 export namespace PutLifecycleEventHookExecutionStatusInput {
   export function isa(o: any): o is PutLifecycleEventHookExecutionStatusInput {
-    return _smithy.isa(o, "PutLifecycleEventHookExecutionStatusInput");
+    return __isa(o, "PutLifecycleEventHookExecutionStatusInput");
   }
 }
 
@@ -5759,7 +5762,7 @@ export interface PutLifecycleEventHookExecutionStatusOutput
 
 export namespace PutLifecycleEventHookExecutionStatusOutput {
   export function isa(o: any): o is PutLifecycleEventHookExecutionStatusOutput {
-    return _smithy.isa(o, "PutLifecycleEventHookExecutionStatusOutput");
+    return __isa(o, "PutLifecycleEventHookExecutionStatusOutput");
   }
 }
 
@@ -5784,7 +5787,7 @@ export interface RawString {
 
 export namespace RawString {
   export function isa(o: any): o is RawString {
-    return _smithy.isa(o, "RawString");
+    return __isa(o, "RawString");
   }
 }
 
@@ -5813,7 +5816,7 @@ export interface RegisterApplicationRevisionInput {
 
 export namespace RegisterApplicationRevisionInput {
   export function isa(o: any): o is RegisterApplicationRevisionInput {
-    return _smithy.isa(o, "RegisterApplicationRevisionInput");
+    return __isa(o, "RegisterApplicationRevisionInput");
   }
 }
 
@@ -5840,7 +5843,7 @@ export interface RegisterOnPremisesInstanceInput {
 
 export namespace RegisterOnPremisesInstanceInput {
   export function isa(o: any): o is RegisterOnPremisesInstanceInput {
-    return _smithy.isa(o, "RegisterOnPremisesInstanceInput");
+    return __isa(o, "RegisterOnPremisesInstanceInput");
   }
 }
 
@@ -5867,7 +5870,7 @@ export interface RemoveTagsFromOnPremisesInstancesInput {
 
 export namespace RemoveTagsFromOnPremisesInstancesInput {
   export function isa(o: any): o is RemoveTagsFromOnPremisesInstancesInput {
-    return _smithy.isa(o, "RemoveTagsFromOnPremisesInstancesInput");
+    return __isa(o, "RemoveTagsFromOnPremisesInstancesInput");
   }
 }
 
@@ -5877,7 +5880,7 @@ export namespace RemoveTagsFromOnPremisesInstancesInput {
  *         </p>
  */
 export interface ResourceArnRequiredException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceArnRequiredException";
   $fault: "client";
@@ -5889,7 +5892,7 @@ export interface ResourceArnRequiredException
 
 export namespace ResourceArnRequiredException {
   export function isa(o: any): o is ResourceArnRequiredException {
-    return _smithy.isa(o, "ResourceArnRequiredException");
+    return __isa(o, "ResourceArnRequiredException");
   }
 }
 
@@ -5897,7 +5900,7 @@ export namespace ResourceArnRequiredException {
  * <p>The specified resource could not be validated.</p>
  */
 export interface ResourceValidationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceValidationException";
   $fault: "client";
@@ -5909,7 +5912,7 @@ export interface ResourceValidationException
 
 export namespace ResourceValidationException {
   export function isa(o: any): o is ResourceValidationException {
-    return _smithy.isa(o, "ResourceValidationException");
+    return __isa(o, "ResourceValidationException");
   }
 }
 
@@ -5917,7 +5920,7 @@ export namespace ResourceValidationException {
  * <p>The named revision does not exist with the IAM user or AWS account.</p>
  */
 export interface RevisionDoesNotExistException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "RevisionDoesNotExistException";
   $fault: "client";
@@ -5929,7 +5932,7 @@ export interface RevisionDoesNotExistException
 
 export namespace RevisionDoesNotExistException {
   export function isa(o: any): o is RevisionDoesNotExistException {
-    return _smithy.isa(o, "RevisionDoesNotExistException");
+    return __isa(o, "RevisionDoesNotExistException");
   }
 }
 
@@ -5952,7 +5955,7 @@ export interface RevisionInfo {
 
 export namespace RevisionInfo {
   export function isa(o: any): o is RevisionInfo {
-    return _smithy.isa(o, "RevisionInfo");
+    return __isa(o, "RevisionInfo");
   }
 }
 
@@ -6004,7 +6007,7 @@ export interface RevisionLocation {
 
 export namespace RevisionLocation {
   export function isa(o: any): o is RevisionLocation {
-    return _smithy.isa(o, "RevisionLocation");
+    return __isa(o, "RevisionLocation");
   }
 }
 
@@ -6019,7 +6022,7 @@ export enum RevisionLocationType {
  * <p>The revision ID was not specified.</p>
  */
 export interface RevisionRequiredException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "RevisionRequiredException";
   $fault: "client";
@@ -6031,7 +6034,7 @@ export interface RevisionRequiredException
 
 export namespace RevisionRequiredException {
   export function isa(o: any): o is RevisionRequiredException {
-    return _smithy.isa(o, "RevisionRequiredException");
+    return __isa(o, "RevisionRequiredException");
   }
 }
 
@@ -6039,7 +6042,7 @@ export namespace RevisionRequiredException {
  * <p>The role ID was not specified.</p>
  */
 export interface RoleRequiredException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "RoleRequiredException";
   $fault: "client";
@@ -6051,7 +6054,7 @@ export interface RoleRequiredException
 
 export namespace RoleRequiredException {
   export function isa(o: any): o is RoleRequiredException {
-    return _smithy.isa(o, "RoleRequiredException");
+    return __isa(o, "RoleRequiredException");
   }
 }
 
@@ -6080,7 +6083,7 @@ export interface RollbackInfo {
 
 export namespace RollbackInfo {
   export function isa(o: any): o is RollbackInfo {
-    return _smithy.isa(o, "RollbackInfo");
+    return __isa(o, "RollbackInfo");
   }
 }
 
@@ -6135,7 +6138,7 @@ export interface S3Location {
 
 export namespace S3Location {
   export function isa(o: any): o is S3Location {
-    return _smithy.isa(o, "S3Location");
+    return __isa(o, "S3Location");
   }
 }
 
@@ -6150,7 +6153,7 @@ export interface SkipWaitTimeForInstanceTerminationInput {
 
 export namespace SkipWaitTimeForInstanceTerminationInput {
   export function isa(o: any): o is SkipWaitTimeForInstanceTerminationInput {
-    return _smithy.isa(o, "SkipWaitTimeForInstanceTerminationInput");
+    return __isa(o, "SkipWaitTimeForInstanceTerminationInput");
   }
 }
 
@@ -6178,7 +6181,7 @@ export interface StopDeploymentInput {
 
 export namespace StopDeploymentInput {
   export function isa(o: any): o is StopDeploymentInput {
-    return _smithy.isa(o, "StopDeploymentInput");
+    return __isa(o, "StopDeploymentInput");
   }
 }
 
@@ -6208,7 +6211,7 @@ export interface StopDeploymentOutput extends $MetadataBearer {
 
 export namespace StopDeploymentOutput {
   export function isa(o: any): o is StopDeploymentOutput {
-    return _smithy.isa(o, "StopDeploymentOutput");
+    return __isa(o, "StopDeploymentOutput");
   }
 }
 
@@ -6235,7 +6238,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -6273,7 +6276,7 @@ export interface TagFilter {
 
 export namespace TagFilter {
   export function isa(o: any): o is TagFilter {
-    return _smithy.isa(o, "TagFilter");
+    return __isa(o, "TagFilter");
   }
 }
 
@@ -6287,7 +6290,7 @@ export enum TagFilterType {
  * <p>The maximum allowed number of tags was exceeded.</p>
  */
 export interface TagLimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TagLimitExceededException";
   $fault: "client";
@@ -6299,7 +6302,7 @@ export interface TagLimitExceededException
 
 export namespace TagLimitExceededException {
   export function isa(o: any): o is TagLimitExceededException {
-    return _smithy.isa(o, "TagLimitExceededException");
+    return __isa(o, "TagLimitExceededException");
   }
 }
 
@@ -6307,7 +6310,7 @@ export namespace TagLimitExceededException {
  * <p>A tag was not specified.</p>
  */
 export interface TagRequiredException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TagRequiredException";
   $fault: "client";
@@ -6319,7 +6322,7 @@ export interface TagRequiredException
 
 export namespace TagRequiredException {
   export function isa(o: any): o is TagRequiredException {
-    return _smithy.isa(o, "TagRequiredException");
+    return __isa(o, "TagRequiredException");
   }
 }
 
@@ -6342,7 +6345,7 @@ export interface TagResourceInput {
 
 export namespace TagResourceInput {
   export function isa(o: any): o is TagResourceInput {
-    return _smithy.isa(o, "TagResourceInput");
+    return __isa(o, "TagResourceInput");
   }
 }
 
@@ -6352,7 +6355,7 @@ export interface TagResourceOutput extends $MetadataBearer {
 
 export namespace TagResourceOutput {
   export function isa(o: any): o is TagResourceOutput {
-    return _smithy.isa(o, "TagResourceOutput");
+    return __isa(o, "TagResourceOutput");
   }
 }
 
@@ -6361,7 +6364,7 @@ export namespace TagResourceOutput {
  *             limit of 3.</p>
  */
 export interface TagSetListLimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TagSetListLimitExceededException";
   $fault: "client";
@@ -6373,7 +6376,7 @@ export interface TagSetListLimitExceededException
 
 export namespace TagSetListLimitExceededException {
   export function isa(o: any): o is TagSetListLimitExceededException {
-    return _smithy.isa(o, "TagSetListLimitExceededException");
+    return __isa(o, "TagSetListLimitExceededException");
   }
 }
 
@@ -6401,7 +6404,7 @@ export interface TargetGroupInfo {
 
 export namespace TargetGroupInfo {
   export function isa(o: any): o is TargetGroupInfo {
-    return _smithy.isa(o, "TargetGroupInfo");
+    return __isa(o, "TargetGroupInfo");
   }
 }
 
@@ -6432,7 +6435,7 @@ export interface TargetGroupPairInfo {
 
 export namespace TargetGroupPairInfo {
   export function isa(o: any): o is TargetGroupPairInfo {
-    return _smithy.isa(o, "TargetGroupPairInfo");
+    return __isa(o, "TargetGroupPairInfo");
   }
 }
 
@@ -6465,7 +6468,7 @@ export interface TargetInstances {
 
 export namespace TargetInstances {
   export function isa(o: any): o is TargetInstances {
-    return _smithy.isa(o, "TargetInstances");
+    return __isa(o, "TargetInstances");
   }
 }
 
@@ -6488,7 +6491,7 @@ export enum TargetStatus {
  * <p>An API function was called too frequently.</p>
  */
 export interface ThrottlingException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ThrottlingException";
   $fault: "client";
@@ -6500,7 +6503,7 @@ export interface ThrottlingException
 
 export namespace ThrottlingException {
   export function isa(o: any): o is ThrottlingException {
-    return _smithy.isa(o, "ThrottlingException");
+    return __isa(o, "ThrottlingException");
   }
 }
 
@@ -6526,7 +6529,7 @@ export interface TimeBasedCanary {
 
 export namespace TimeBasedCanary {
   export function isa(o: any): o is TimeBasedCanary {
-    return _smithy.isa(o, "TimeBasedCanary");
+    return __isa(o, "TimeBasedCanary");
   }
 }
 
@@ -6553,7 +6556,7 @@ export interface TimeBasedLinear {
 
 export namespace TimeBasedLinear {
   export function isa(o: any): o is TimeBasedLinear {
-    return _smithy.isa(o, "TimeBasedLinear");
+    return __isa(o, "TimeBasedLinear");
   }
 }
 
@@ -6581,7 +6584,7 @@ export interface TimeRange {
 
 export namespace TimeRange {
   export function isa(o: any): o is TimeRange {
-    return _smithy.isa(o, "TimeRange");
+    return __isa(o, "TimeRange");
   }
 }
 
@@ -6600,7 +6603,7 @@ export interface TrafficRoute {
 
 export namespace TrafficRoute {
   export function isa(o: any): o is TrafficRoute {
-    return _smithy.isa(o, "TrafficRoute");
+    return __isa(o, "TrafficRoute");
   }
 }
 
@@ -6634,7 +6637,7 @@ export interface TrafficRoutingConfig {
 
 export namespace TrafficRoutingConfig {
   export function isa(o: any): o is TrafficRoutingConfig {
-    return _smithy.isa(o, "TrafficRoutingConfig");
+    return __isa(o, "TrafficRoutingConfig");
   }
 }
 
@@ -6668,7 +6671,7 @@ export interface TriggerConfig {
 
 export namespace TriggerConfig {
   export function isa(o: any): o is TriggerConfig {
-    return _smithy.isa(o, "TriggerConfig");
+    return __isa(o, "TriggerConfig");
   }
 }
 
@@ -6689,7 +6692,7 @@ export enum TriggerEventType {
  * <p>The maximum allowed number of triggers was exceeded.</p>
  */
 export interface TriggerTargetsLimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TriggerTargetsLimitExceededException";
   $fault: "client";
@@ -6701,7 +6704,7 @@ export interface TriggerTargetsLimitExceededException
 
 export namespace TriggerTargetsLimitExceededException {
   export function isa(o: any): o is TriggerTargetsLimitExceededException {
-    return _smithy.isa(o, "TriggerTargetsLimitExceededException");
+    return __isa(o, "TriggerTargetsLimitExceededException");
   }
 }
 
@@ -6709,7 +6712,7 @@ export namespace TriggerTargetsLimitExceededException {
  * <p>A call was submitted that is not supported for the specified deployment type.</p>
  */
 export interface UnsupportedActionForDeploymentTypeException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UnsupportedActionForDeploymentTypeException";
   $fault: "client";
@@ -6723,7 +6726,7 @@ export namespace UnsupportedActionForDeploymentTypeException {
   export function isa(
     o: any
   ): o is UnsupportedActionForDeploymentTypeException {
-    return _smithy.isa(o, "UnsupportedActionForDeploymentTypeException");
+    return __isa(o, "UnsupportedActionForDeploymentTypeException");
   }
 }
 
@@ -6747,7 +6750,7 @@ export interface UntagResourceInput {
 
 export namespace UntagResourceInput {
   export function isa(o: any): o is UntagResourceInput {
-    return _smithy.isa(o, "UntagResourceInput");
+    return __isa(o, "UntagResourceInput");
   }
 }
 
@@ -6757,7 +6760,7 @@ export interface UntagResourceOutput extends $MetadataBearer {
 
 export namespace UntagResourceOutput {
   export function isa(o: any): o is UntagResourceOutput {
-    return _smithy.isa(o, "UntagResourceOutput");
+    return __isa(o, "UntagResourceOutput");
   }
 }
 
@@ -6779,7 +6782,7 @@ export interface UpdateApplicationInput {
 
 export namespace UpdateApplicationInput {
   export function isa(o: any): o is UpdateApplicationInput {
-    return _smithy.isa(o, "UpdateApplicationInput");
+    return __isa(o, "UpdateApplicationInput");
   }
 }
 
@@ -6892,7 +6895,7 @@ export interface UpdateDeploymentGroupInput {
 
 export namespace UpdateDeploymentGroupInput {
   export function isa(o: any): o is UpdateDeploymentGroupInput {
-    return _smithy.isa(o, "UpdateDeploymentGroupInput");
+    return __isa(o, "UpdateDeploymentGroupInput");
   }
 }
 
@@ -6913,6 +6916,6 @@ export interface UpdateDeploymentGroupOutput extends $MetadataBearer {
 
 export namespace UpdateDeploymentGroupOutput {
   export function isa(o: any): o is UpdateDeploymentGroupOutput {
-    return _smithy.isa(o, "UpdateDeploymentGroupOutput");
+    return __isa(o, "UpdateDeploymentGroupOutput");
   }
 }

--- a/clients/client-codedeploy/protocols/Aws_json1_1.ts
+++ b/clients/client-codedeploy/protocols/Aws_json1_1.ts
@@ -1098,6 +1098,7 @@ export async function deserializeAws_json1_1AddTagsToOnPremisesInstancesCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: AddTagsToOnPremisesInstancesCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1839,6 +1840,7 @@ export async function deserializeAws_json1_1ContinueDeploymentCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: ContinueDeploymentCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2617,6 +2619,7 @@ export async function deserializeAws_json1_1DeleteApplicationCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1DeleteApplicationCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteApplicationCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2685,6 +2688,7 @@ export async function deserializeAws_json1_1DeleteDeploymentConfigCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteDeploymentConfigCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2937,6 +2941,7 @@ export async function deserializeAws_json1_1DeregisterOnPremisesInstanceCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeregisterOnPremisesInstanceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -4683,6 +4688,7 @@ export async function deserializeAws_json1_1RegisterApplicationRevisionCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: RegisterApplicationRevisionCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -4772,6 +4778,7 @@ export async function deserializeAws_json1_1RegisterOnPremisesInstanceCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: RegisterOnPremisesInstanceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -4889,6 +4896,7 @@ export async function deserializeAws_json1_1RemoveTagsFromOnPremisesInstancesCom
       context
     );
   }
+  await collectBody(output.body, context);
   const response: RemoveTagsFromOnPremisesInstancesCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -4985,6 +4993,7 @@ export async function deserializeAws_json1_1SkipWaitTimeForInstanceTerminationCo
       context
     );
   }
+  await collectBody(output.body, context);
   const response: SkipWaitTimeForInstanceTerminationCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -5365,6 +5374,7 @@ export async function deserializeAws_json1_1UpdateApplicationCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1UpdateApplicationCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: UpdateApplicationCommandOutput = {
     $metadata: deserializeMetadata(output)
   };

--- a/clients/client-codeguru-reviewer/models/index.ts
+++ b/clients/client-codeguru-reviewer/models/index.ts
@@ -1,11 +1,14 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
  * <p>You do not have sufficient access to perform this action.</p>
  */
 export interface AccessDeniedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AccessDeniedException";
   $fault: "client";
@@ -14,7 +17,7 @@ export interface AccessDeniedException
 
 export namespace AccessDeniedException {
   export function isa(o: any): o is AccessDeniedException {
-    return _smithy.isa(o, "AccessDeniedException");
+    return __isa(o, "AccessDeniedException");
   }
 }
 
@@ -49,7 +52,7 @@ export interface AssociateRepositoryRequest {
 
 export namespace AssociateRepositoryRequest {
   export function isa(o: any): o is AssociateRepositoryRequest {
-    return _smithy.isa(o, "AssociateRepositoryRequest");
+    return __isa(o, "AssociateRepositoryRequest");
   }
 }
 
@@ -63,7 +66,7 @@ export interface AssociateRepositoryResponse extends $MetadataBearer {
 
 export namespace AssociateRepositoryResponse {
   export function isa(o: any): o is AssociateRepositoryResponse {
-    return _smithy.isa(o, "AssociateRepositoryResponse");
+    return __isa(o, "AssociateRepositoryResponse");
   }
 }
 
@@ -80,7 +83,7 @@ export interface CodeCommitRepository {
 
 export namespace CodeCommitRepository {
   export function isa(o: any): o is CodeCommitRepository {
-    return _smithy.isa(o, "CodeCommitRepository");
+    return __isa(o, "CodeCommitRepository");
   }
 }
 
@@ -90,9 +93,7 @@ export namespace CodeCommitRepository {
  *         before retrying this request.
  *       </p>
  */
-export interface ConflictException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface ConflictException extends __SmithyException, $MetadataBearer {
   name: "ConflictException";
   $fault: "client";
   Message?: string;
@@ -100,7 +101,7 @@ export interface ConflictException
 
 export namespace ConflictException {
   export function isa(o: any): o is ConflictException {
-    return _smithy.isa(o, "ConflictException");
+    return __isa(o, "ConflictException");
   }
 }
 
@@ -114,7 +115,7 @@ export interface DescribeRepositoryAssociationRequest {
 
 export namespace DescribeRepositoryAssociationRequest {
   export function isa(o: any): o is DescribeRepositoryAssociationRequest {
-    return _smithy.isa(o, "DescribeRepositoryAssociationRequest");
+    return __isa(o, "DescribeRepositoryAssociationRequest");
   }
 }
 
@@ -128,7 +129,7 @@ export interface DescribeRepositoryAssociationResponse extends $MetadataBearer {
 
 export namespace DescribeRepositoryAssociationResponse {
   export function isa(o: any): o is DescribeRepositoryAssociationResponse {
-    return _smithy.isa(o, "DescribeRepositoryAssociationResponse");
+    return __isa(o, "DescribeRepositoryAssociationResponse");
   }
 }
 
@@ -142,7 +143,7 @@ export interface DisassociateRepositoryRequest {
 
 export namespace DisassociateRepositoryRequest {
   export function isa(o: any): o is DisassociateRepositoryRequest {
-    return _smithy.isa(o, "DisassociateRepositoryRequest");
+    return __isa(o, "DisassociateRepositoryRequest");
   }
 }
 
@@ -156,7 +157,7 @@ export interface DisassociateRepositoryResponse extends $MetadataBearer {
 
 export namespace DisassociateRepositoryResponse {
   export function isa(o: any): o is DisassociateRepositoryResponse {
-    return _smithy.isa(o, "DisassociateRepositoryResponse");
+    return __isa(o, "DisassociateRepositoryResponse");
   }
 }
 
@@ -164,7 +165,7 @@ export namespace DisassociateRepositoryResponse {
  * <p>The server encountered an internal error and is unable to complete the request.</p>
  */
 export interface InternalServerException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalServerException";
   $fault: "server";
@@ -173,7 +174,7 @@ export interface InternalServerException
 
 export namespace InternalServerException {
   export function isa(o: any): o is InternalServerException {
-    return _smithy.isa(o, "InternalServerException");
+    return __isa(o, "InternalServerException");
   }
 }
 
@@ -228,7 +229,7 @@ export interface ListRepositoryAssociationsRequest {
 
 export namespace ListRepositoryAssociationsRequest {
   export function isa(o: any): o is ListRepositoryAssociationsRequest {
-    return _smithy.isa(o, "ListRepositoryAssociationsRequest");
+    return __isa(o, "ListRepositoryAssociationsRequest");
   }
 }
 
@@ -250,16 +251,14 @@ export interface ListRepositoryAssociationsResponse extends $MetadataBearer {
 
 export namespace ListRepositoryAssociationsResponse {
   export function isa(o: any): o is ListRepositoryAssociationsResponse {
-    return _smithy.isa(o, "ListRepositoryAssociationsResponse");
+    return __isa(o, "ListRepositoryAssociationsResponse");
   }
 }
 
 /**
  * <p>The resource specified in the request was not found.</p>
  */
-export interface NotFoundException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface NotFoundException extends __SmithyException, $MetadataBearer {
   name: "NotFoundException";
   $fault: "client";
   Message?: string;
@@ -267,7 +266,7 @@ export interface NotFoundException
 
 export namespace NotFoundException {
   export function isa(o: any): o is NotFoundException {
-    return _smithy.isa(o, "NotFoundException");
+    return __isa(o, "NotFoundException");
   }
 }
 
@@ -289,7 +288,7 @@ export interface Repository {
 
 export namespace Repository {
   export function isa(o: any): o is Repository {
-    return _smithy.isa(o, "Repository");
+    return __isa(o, "Repository");
   }
 }
 
@@ -346,7 +345,7 @@ export interface RepositoryAssociation {
 
 export namespace RepositoryAssociation {
   export function isa(o: any): o is RepositoryAssociation {
-    return _smithy.isa(o, "RepositoryAssociation");
+    return __isa(o, "RepositoryAssociation");
   }
 }
 
@@ -425,7 +424,7 @@ export interface RepositoryAssociationSummary {
 
 export namespace RepositoryAssociationSummary {
   export function isa(o: any): o is RepositoryAssociationSummary {
-    return _smithy.isa(o, "RepositoryAssociationSummary");
+    return __isa(o, "RepositoryAssociationSummary");
   }
 }
 
@@ -433,7 +432,7 @@ export namespace RepositoryAssociationSummary {
  * <p>The request was denied due to request throttling.</p>
  */
 export interface ThrottlingException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ThrottlingException";
   $fault: "client";
@@ -442,7 +441,7 @@ export interface ThrottlingException
 
 export namespace ThrottlingException {
   export function isa(o: any): o is ThrottlingException {
-    return _smithy.isa(o, "ThrottlingException");
+    return __isa(o, "ThrottlingException");
   }
 }
 
@@ -450,7 +449,7 @@ export namespace ThrottlingException {
  * <p>The input fails to satisfy the specified constraints.</p>
  */
 export interface ValidationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ValidationException";
   $fault: "client";
@@ -459,6 +458,6 @@ export interface ValidationException
 
 export namespace ValidationException {
   export function isa(o: any): o is ValidationException {
-    return _smithy.isa(o, "ValidationException");
+    return __isa(o, "ValidationException");
   }
 }

--- a/clients/client-codeguru-reviewer/protocols/Aws_restJson1_1.ts
+++ b/clients/client-codeguru-reviewer/protocols/Aws_restJson1_1.ts
@@ -30,7 +30,10 @@ import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  extendedEncodeURIComponent as __extendedEncodeURIComponent
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -79,7 +82,7 @@ export async function serializeAws_restJson1_1DescribeRepositoryAssociationComma
   headers["Content-Type"] = "";
   let resolvedPath = "/associations/{AssociationArn}";
   if (input.AssociationArn !== undefined) {
-    const labelValue: string = input.AssociationArn.toString();
+    const labelValue: string = input.AssociationArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: AssociationArn."
@@ -87,7 +90,7 @@ export async function serializeAws_restJson1_1DescribeRepositoryAssociationComma
     }
     resolvedPath = resolvedPath.replace(
       "{AssociationArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AssociationArn.");
@@ -109,7 +112,7 @@ export async function serializeAws_restJson1_1DisassociateRepositoryCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/associations/{AssociationArn}";
   if (input.AssociationArn !== undefined) {
-    const labelValue: string = input.AssociationArn.toString();
+    const labelValue: string = input.AssociationArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: AssociationArn."
@@ -117,7 +120,7 @@ export async function serializeAws_restJson1_1DisassociateRepositoryCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{AssociationArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AssociationArn.");
@@ -140,22 +143,34 @@ export async function serializeAws_restJson1_1ListRepositoryAssociationsCommand(
   let resolvedPath = "/associations";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["MaxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("MaxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.Names !== undefined) {
-    query["Name"] = input.Names;
+    query[__extendedEncodeURIComponent("Name")] = input.Names.map(entry =>
+      __extendedEncodeURIComponent(entry)
+    );
   }
   if (input.NextToken !== undefined) {
-    query["NextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("NextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   if (input.Owners !== undefined) {
-    query["Owner"] = input.Owners;
+    query[__extendedEncodeURIComponent("Owner")] = input.Owners.map(entry =>
+      __extendedEncodeURIComponent(entry)
+    );
   }
   if (input.ProviderTypes !== undefined) {
-    query["ProviderType"] = input.ProviderTypes;
+    query[
+      __extendedEncodeURIComponent("ProviderType")
+    ] = input.ProviderTypes.map(entry => __extendedEncodeURIComponent(entry));
   }
   if (input.States !== undefined) {
-    query["State"] = input.States;
+    query[__extendedEncodeURIComponent("State")] = input.States.map(entry =>
+      __extendedEncodeURIComponent(entry)
+    );
   }
   return new __HttpRequest({
     ...context.endpoint,

--- a/clients/client-codeguruprofiler/models/index.ts
+++ b/clients/client-codeguruprofiler/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -19,7 +22,7 @@ export interface AggregatedProfileTime {
 
 export namespace AggregatedProfileTime {
   export function isa(o: any): o is AggregatedProfileTime {
-    return _smithy.isa(o, "AggregatedProfileTime");
+    return __isa(o, "AggregatedProfileTime");
   }
 }
 
@@ -41,9 +44,7 @@ export enum AggregationPeriod {
 /**
  * Request can can cause an inconsistent state for the resource.
  */
-export interface ConflictException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface ConflictException extends __SmithyException, $MetadataBearer {
   name: "ConflictException";
   $fault: "client";
   message: string | undefined;
@@ -51,7 +52,7 @@ export interface ConflictException
 
 export namespace ConflictException {
   export function isa(o: any): o is ConflictException {
-    return _smithy.isa(o, "ConflictException");
+    return __isa(o, "ConflictException");
   }
 }
 
@@ -59,7 +60,7 @@ export namespace ConflictException {
  * Unexpected error during processing of request.
  */
 export interface InternalServerException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalServerException";
   $fault: "server";
@@ -68,7 +69,7 @@ export interface InternalServerException
 
 export namespace InternalServerException {
   export function isa(o: any): o is InternalServerException {
-    return _smithy.isa(o, "InternalServerException");
+    return __isa(o, "InternalServerException");
   }
 }
 
@@ -87,7 +88,7 @@ export enum OrderBy {
  * Request references a resource which does not exist.
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -96,7 +97,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -104,7 +105,7 @@ export namespace ResourceNotFoundException {
  * Request would cause a service quota to be exceeded.
  */
 export interface ServiceQuotaExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ServiceQuotaExceededException";
   $fault: "client";
@@ -113,7 +114,7 @@ export interface ServiceQuotaExceededException
 
 export namespace ServiceQuotaExceededException {
   export function isa(o: any): o is ServiceQuotaExceededException {
-    return _smithy.isa(o, "ServiceQuotaExceededException");
+    return __isa(o, "ServiceQuotaExceededException");
   }
 }
 
@@ -121,7 +122,7 @@ export namespace ServiceQuotaExceededException {
  * Request was denied due to request throttling.
  */
 export interface ThrottlingException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ThrottlingException";
   $fault: "client";
@@ -130,7 +131,7 @@ export interface ThrottlingException
 
 export namespace ThrottlingException {
   export function isa(o: any): o is ThrottlingException {
-    return _smithy.isa(o, "ThrottlingException");
+    return __isa(o, "ThrottlingException");
   }
 }
 
@@ -138,7 +139,7 @@ export namespace ThrottlingException {
  * The input fails to satisfy the constraints of the API.
  */
 export interface ValidationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ValidationException";
   $fault: "client";
@@ -147,7 +148,7 @@ export interface ValidationException
 
 export namespace ValidationException {
   export function isa(o: any): o is ValidationException {
-    return _smithy.isa(o, "ValidationException");
+    return __isa(o, "ValidationException");
   }
 }
 
@@ -169,7 +170,7 @@ export interface AgentConfiguration {
 
 export namespace AgentConfiguration {
   export function isa(o: any): o is AgentConfiguration {
-    return _smithy.isa(o, "AgentConfiguration");
+    return __isa(o, "AgentConfiguration");
   }
 }
 
@@ -191,7 +192,7 @@ export interface ConfigureAgentRequest {
 
 export namespace ConfigureAgentRequest {
   export function isa(o: any): o is ConfigureAgentRequest {
-    return _smithy.isa(o, "ConfigureAgentRequest");
+    return __isa(o, "ConfigureAgentRequest");
   }
 }
 
@@ -208,7 +209,7 @@ export interface ConfigureAgentResponse extends $MetadataBearer {
 
 export namespace ConfigureAgentResponse {
   export function isa(o: any): o is ConfigureAgentResponse {
-    return _smithy.isa(o, "ConfigureAgentResponse");
+    return __isa(o, "ConfigureAgentResponse");
   }
 }
 
@@ -226,7 +227,7 @@ export interface AgentOrchestrationConfig {
 
 export namespace AgentOrchestrationConfig {
   export function isa(o: any): o is AgentOrchestrationConfig {
-    return _smithy.isa(o, "AgentOrchestrationConfig");
+    return __isa(o, "AgentOrchestrationConfig");
   }
 }
 
@@ -254,7 +255,7 @@ export interface CreateProfilingGroupRequest {
 
 export namespace CreateProfilingGroupRequest {
   export function isa(o: any): o is CreateProfilingGroupRequest {
-    return _smithy.isa(o, "CreateProfilingGroupRequest");
+    return __isa(o, "CreateProfilingGroupRequest");
   }
 }
 
@@ -271,7 +272,7 @@ export interface CreateProfilingGroupResponse extends $MetadataBearer {
 
 export namespace CreateProfilingGroupResponse {
   export function isa(o: any): o is CreateProfilingGroupResponse {
-    return _smithy.isa(o, "CreateProfilingGroupResponse");
+    return __isa(o, "CreateProfilingGroupResponse");
   }
 }
 
@@ -288,7 +289,7 @@ export interface DeleteProfilingGroupRequest {
 
 export namespace DeleteProfilingGroupRequest {
   export function isa(o: any): o is DeleteProfilingGroupRequest {
-    return _smithy.isa(o, "DeleteProfilingGroupRequest");
+    return __isa(o, "DeleteProfilingGroupRequest");
   }
 }
 
@@ -301,7 +302,7 @@ export interface DeleteProfilingGroupResponse extends $MetadataBearer {
 
 export namespace DeleteProfilingGroupResponse {
   export function isa(o: any): o is DeleteProfilingGroupResponse {
-    return _smithy.isa(o, "DeleteProfilingGroupResponse");
+    return __isa(o, "DeleteProfilingGroupResponse");
   }
 }
 
@@ -318,7 +319,7 @@ export interface DescribeProfilingGroupRequest {
 
 export namespace DescribeProfilingGroupRequest {
   export function isa(o: any): o is DescribeProfilingGroupRequest {
-    return _smithy.isa(o, "DescribeProfilingGroupRequest");
+    return __isa(o, "DescribeProfilingGroupRequest");
   }
 }
 
@@ -335,7 +336,7 @@ export interface DescribeProfilingGroupResponse extends $MetadataBearer {
 
 export namespace DescribeProfilingGroupResponse {
   export function isa(o: any): o is DescribeProfilingGroupResponse {
-    return _smithy.isa(o, "DescribeProfilingGroupResponse");
+    return __isa(o, "DescribeProfilingGroupResponse");
   }
 }
 
@@ -362,7 +363,7 @@ export interface ListProfilingGroupsRequest {
 
 export namespace ListProfilingGroupsRequest {
   export function isa(o: any): o is ListProfilingGroupsRequest {
-    return _smithy.isa(o, "ListProfilingGroupsRequest");
+    return __isa(o, "ListProfilingGroupsRequest");
   }
 }
 
@@ -389,7 +390,7 @@ export interface ListProfilingGroupsResponse extends $MetadataBearer {
 
 export namespace ListProfilingGroupsResponse {
   export function isa(o: any): o is ListProfilingGroupsResponse {
-    return _smithy.isa(o, "ListProfilingGroupsResponse");
+    return __isa(o, "ListProfilingGroupsResponse");
   }
 }
 
@@ -432,7 +433,7 @@ export interface ProfilingGroupDescription {
 
 export namespace ProfilingGroupDescription {
   export function isa(o: any): o is ProfilingGroupDescription {
-    return _smithy.isa(o, "ProfilingGroupDescription");
+    return __isa(o, "ProfilingGroupDescription");
   }
 }
 
@@ -459,7 +460,7 @@ export interface ProfilingStatus {
 
 export namespace ProfilingStatus {
   export function isa(o: any): o is ProfilingStatus {
-    return _smithy.isa(o, "ProfilingStatus");
+    return __isa(o, "ProfilingStatus");
   }
 }
 
@@ -481,7 +482,7 @@ export interface UpdateProfilingGroupRequest {
 
 export namespace UpdateProfilingGroupRequest {
   export function isa(o: any): o is UpdateProfilingGroupRequest {
-    return _smithy.isa(o, "UpdateProfilingGroupRequest");
+    return __isa(o, "UpdateProfilingGroupRequest");
   }
 }
 
@@ -498,7 +499,7 @@ export interface UpdateProfilingGroupResponse extends $MetadataBearer {
 
 export namespace UpdateProfilingGroupResponse {
   export function isa(o: any): o is UpdateProfilingGroupResponse {
-    return _smithy.isa(o, "UpdateProfilingGroupResponse");
+    return __isa(o, "UpdateProfilingGroupResponse");
   }
 }
 
@@ -543,7 +544,7 @@ export interface GetProfileRequest {
 
 export namespace GetProfileRequest {
   export function isa(o: any): o is GetProfileRequest {
-    return _smithy.isa(o, "GetProfileRequest");
+    return __isa(o, "GetProfileRequest");
   }
 }
 
@@ -571,7 +572,7 @@ export interface GetProfileResponse extends $MetadataBearer {
 
 export namespace GetProfileResponse {
   export function isa(o: any): o is GetProfileResponse {
-    return _smithy.isa(o, "GetProfileResponse");
+    return __isa(o, "GetProfileResponse");
   }
 }
 
@@ -619,7 +620,7 @@ export interface ListProfileTimesRequest {
 
 export namespace ListProfileTimesRequest {
   export function isa(o: any): o is ListProfileTimesRequest {
-    return _smithy.isa(o, "ListProfileTimesRequest");
+    return __isa(o, "ListProfileTimesRequest");
   }
 }
 
@@ -641,7 +642,7 @@ export interface ListProfileTimesResponse extends $MetadataBearer {
 
 export namespace ListProfileTimesResponse {
   export function isa(o: any): o is ListProfileTimesResponse {
-    return _smithy.isa(o, "ListProfileTimesResponse");
+    return __isa(o, "ListProfileTimesResponse");
   }
 }
 
@@ -658,7 +659,7 @@ export interface ProfileTime {
 
 export namespace ProfileTime {
   export function isa(o: any): o is ProfileTime {
-    return _smithy.isa(o, "ProfileTime");
+    return __isa(o, "ProfileTime");
   }
 }
 
@@ -692,7 +693,7 @@ export interface PostAgentProfileRequest {
 
 export namespace PostAgentProfileRequest {
   export function isa(o: any): o is PostAgentProfileRequest {
-    return _smithy.isa(o, "PostAgentProfileRequest");
+    return __isa(o, "PostAgentProfileRequest");
   }
 }
 
@@ -705,6 +706,6 @@ export interface PostAgentProfileResponse extends $MetadataBearer {
 
 export namespace PostAgentProfileResponse {
   export function isa(o: any): o is PostAgentProfileResponse {
-    return _smithy.isa(o, "PostAgentProfileResponse");
+    return __isa(o, "PostAgentProfileResponse");
   }
 }

--- a/clients/client-codeguruprofiler/protocols/Aws_restJson1_1.ts
+++ b/clients/client-codeguruprofiler/protocols/Aws_restJson1_1.ts
@@ -52,7 +52,10 @@ import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  extendedEncodeURIComponent as __extendedEncodeURIComponent
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -69,7 +72,7 @@ export async function serializeAws_restJson1_1ConfigureAgentCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/profilingGroups/{profilingGroupName}/configureAgent";
   if (input.profilingGroupName !== undefined) {
-    const labelValue: string = input.profilingGroupName.toString();
+    const labelValue: string = input.profilingGroupName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: profilingGroupName."
@@ -77,7 +80,7 @@ export async function serializeAws_restJson1_1ConfigureAgentCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{profilingGroupName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -109,7 +112,9 @@ export async function serializeAws_restJson1_1CreateProfilingGroupCommand(
   let resolvedPath = "/profilingGroups";
   const query: any = {};
   if (input.clientToken !== undefined) {
-    query["clientToken"] = input.clientToken.toString();
+    query[
+      __extendedEncodeURIComponent("clientToken")
+    ] = __extendedEncodeURIComponent(input.clientToken);
   }
   let body: any;
   const bodyParams: any = {};
@@ -144,7 +149,7 @@ export async function serializeAws_restJson1_1DeleteProfilingGroupCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/profilingGroups/{profilingGroupName}";
   if (input.profilingGroupName !== undefined) {
-    const labelValue: string = input.profilingGroupName.toString();
+    const labelValue: string = input.profilingGroupName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: profilingGroupName."
@@ -152,7 +157,7 @@ export async function serializeAws_restJson1_1DeleteProfilingGroupCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{profilingGroupName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -176,7 +181,7 @@ export async function serializeAws_restJson1_1DescribeProfilingGroupCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/profilingGroups/{profilingGroupName}";
   if (input.profilingGroupName !== undefined) {
-    const labelValue: string = input.profilingGroupName.toString();
+    const labelValue: string = input.profilingGroupName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: profilingGroupName."
@@ -184,7 +189,7 @@ export async function serializeAws_restJson1_1DescribeProfilingGroupCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{profilingGroupName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -209,13 +214,19 @@ export async function serializeAws_restJson1_1ListProfilingGroupsCommand(
   let resolvedPath = "/profilingGroups";
   const query: any = {};
   if (input.includeDescription !== undefined) {
-    query["includeDescription"] = input.includeDescription.toString();
+    query[
+      __extendedEncodeURIComponent("includeDescription")
+    ] = __extendedEncodeURIComponent(input.includeDescription.toString());
   }
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -235,7 +246,7 @@ export async function serializeAws_restJson1_1UpdateProfilingGroupCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/profilingGroups/{profilingGroupName}";
   if (input.profilingGroupName !== undefined) {
-    const labelValue: string = input.profilingGroupName.toString();
+    const labelValue: string = input.profilingGroupName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: profilingGroupName."
@@ -243,7 +254,7 @@ export async function serializeAws_restJson1_1UpdateProfilingGroupCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{profilingGroupName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -278,11 +289,11 @@ export async function serializeAws_restJson1_1GetProfileCommand(
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.accept !== undefined) {
-    headers["Accept"] = input.accept.toString();
+    headers["Accept"] = input.accept;
   }
   let resolvedPath = "/profilingGroups/{profilingGroupName}/profile";
   if (input.profilingGroupName !== undefined) {
-    const labelValue: string = input.profilingGroupName.toString();
+    const labelValue: string = input.profilingGroupName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: profilingGroupName."
@@ -290,7 +301,7 @@ export async function serializeAws_restJson1_1GetProfileCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{profilingGroupName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -299,16 +310,24 @@ export async function serializeAws_restJson1_1GetProfileCommand(
   }
   const query: any = {};
   if (input.endTime !== undefined) {
-    query["endTime"] = input.endTime.toISOString();
+    query[
+      __extendedEncodeURIComponent("endTime")
+    ] = __extendedEncodeURIComponent(input.endTime.toISOString());
   }
   if (input.maxDepth !== undefined) {
-    query["maxDepth"] = input.maxDepth.toString();
+    query[
+      __extendedEncodeURIComponent("maxDepth")
+    ] = __extendedEncodeURIComponent(input.maxDepth.toString());
   }
   if (input.period !== undefined) {
-    query["period"] = input.period.toString();
+    query[
+      __extendedEncodeURIComponent("period")
+    ] = __extendedEncodeURIComponent(input.period);
   }
   if (input.startTime !== undefined) {
-    query["startTime"] = input.startTime.toISOString();
+    query[
+      __extendedEncodeURIComponent("startTime")
+    ] = __extendedEncodeURIComponent(input.startTime.toISOString());
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -328,7 +347,7 @@ export async function serializeAws_restJson1_1ListProfileTimesCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/profilingGroups/{profilingGroupName}/profileTimes";
   if (input.profilingGroupName !== undefined) {
-    const labelValue: string = input.profilingGroupName.toString();
+    const labelValue: string = input.profilingGroupName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: profilingGroupName."
@@ -336,7 +355,7 @@ export async function serializeAws_restJson1_1ListProfileTimesCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{profilingGroupName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -345,22 +364,34 @@ export async function serializeAws_restJson1_1ListProfileTimesCommand(
   }
   const query: any = {};
   if (input.endTime !== undefined) {
-    query["endTime"] = input.endTime.toISOString();
+    query[
+      __extendedEncodeURIComponent("endTime")
+    ] = __extendedEncodeURIComponent(input.endTime.toISOString());
   }
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   if (input.orderBy !== undefined) {
-    query["orderBy"] = input.orderBy.toString();
+    query[
+      __extendedEncodeURIComponent("orderBy")
+    ] = __extendedEncodeURIComponent(input.orderBy);
   }
   if (input.period !== undefined) {
-    query["period"] = input.period.toString();
+    query[
+      __extendedEncodeURIComponent("period")
+    ] = __extendedEncodeURIComponent(input.period);
   }
   if (input.startTime !== undefined) {
-    query["startTime"] = input.startTime.toISOString();
+    query[
+      __extendedEncodeURIComponent("startTime")
+    ] = __extendedEncodeURIComponent(input.startTime.toISOString());
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -379,11 +410,11 @@ export async function serializeAws_restJson1_1PostAgentProfileCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/octet-stream";
   if (input.contentType !== undefined) {
-    headers["Content-Type"] = input.contentType.toString();
+    headers["Content-Type"] = input.contentType;
   }
   let resolvedPath = "/profilingGroups/{profilingGroupName}/agentProfile";
   if (input.profilingGroupName !== undefined) {
-    const labelValue: string = input.profilingGroupName.toString();
+    const labelValue: string = input.profilingGroupName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: profilingGroupName."
@@ -391,7 +422,7 @@ export async function serializeAws_restJson1_1PostAgentProfileCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{profilingGroupName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -400,7 +431,9 @@ export async function serializeAws_restJson1_1PostAgentProfileCommand(
   }
   const query: any = {};
   if (input.profileToken !== undefined) {
-    query["profileToken"] = input.profileToken.toString();
+    query[
+      __extendedEncodeURIComponent("profileToken")
+    ] = __extendedEncodeURIComponent(input.profileToken);
   }
   let body: any;
   if (input.agentProfile !== undefined) {
@@ -594,6 +627,7 @@ export async function deserializeAws_restJson1_1DeleteProfilingGroupCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeleteProfilingGroupResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -1073,6 +1107,7 @@ export async function deserializeAws_restJson1_1PostAgentProfileCommand(
     $metadata: deserializeMetadata(output),
     __type: "PostAgentProfileResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 

--- a/clients/client-codepipeline/models/index.ts
+++ b/clients/client-codepipeline/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -22,7 +25,7 @@ export interface AcknowledgeJobInput {
 
 export namespace AcknowledgeJobInput {
   export function isa(o: any): o is AcknowledgeJobInput {
-    return _smithy.isa(o, "AcknowledgeJobInput");
+    return __isa(o, "AcknowledgeJobInput");
   }
 }
 
@@ -39,7 +42,7 @@ export interface AcknowledgeJobOutput extends $MetadataBearer {
 
 export namespace AcknowledgeJobOutput {
   export function isa(o: any): o is AcknowledgeJobOutput {
-    return _smithy.isa(o, "AcknowledgeJobOutput");
+    return __isa(o, "AcknowledgeJobOutput");
   }
 }
 
@@ -68,7 +71,7 @@ export interface AcknowledgeThirdPartyJobInput {
 
 export namespace AcknowledgeThirdPartyJobInput {
   export function isa(o: any): o is AcknowledgeThirdPartyJobInput {
-    return _smithy.isa(o, "AcknowledgeThirdPartyJobInput");
+    return __isa(o, "AcknowledgeThirdPartyJobInput");
   }
 }
 
@@ -85,7 +88,7 @@ export interface AcknowledgeThirdPartyJobOutput extends $MetadataBearer {
 
 export namespace AcknowledgeThirdPartyJobOutput {
   export function isa(o: any): o is AcknowledgeThirdPartyJobOutput {
-    return _smithy.isa(o, "AcknowledgeThirdPartyJobOutput");
+    return __isa(o, "AcknowledgeThirdPartyJobOutput");
   }
 }
 
@@ -143,7 +146,7 @@ export interface ActionConfigurationProperty {
 
 export namespace ActionConfigurationProperty {
   export function isa(o: any): o is ActionConfigurationProperty {
-    return _smithy.isa(o, "ActionConfigurationProperty");
+    return __isa(o, "ActionConfigurationProperty");
   }
 }
 
@@ -223,7 +226,7 @@ export interface ActionDeclaration {
 
 export namespace ActionDeclaration {
   export function isa(o: any): o is ActionDeclaration {
-    return _smithy.isa(o, "ActionDeclaration");
+    return __isa(o, "ActionDeclaration");
   }
 }
 
@@ -285,7 +288,7 @@ export interface ActionExecution {
 
 export namespace ActionExecution {
   export function isa(o: any): o is ActionExecution {
-    return _smithy.isa(o, "ActionExecution");
+    return __isa(o, "ActionExecution");
   }
 }
 
@@ -350,7 +353,7 @@ export interface ActionExecutionDetail {
 
 export namespace ActionExecutionDetail {
   export function isa(o: any): o is ActionExecutionDetail {
-    return _smithy.isa(o, "ActionExecutionDetail");
+    return __isa(o, "ActionExecutionDetail");
   }
 }
 
@@ -367,7 +370,7 @@ export interface ActionExecutionFilter {
 
 export namespace ActionExecutionFilter {
   export function isa(o: any): o is ActionExecutionFilter {
-    return _smithy.isa(o, "ActionExecutionFilter");
+    return __isa(o, "ActionExecutionFilter");
   }
 }
 
@@ -418,7 +421,7 @@ export interface ActionExecutionInput {
 
 export namespace ActionExecutionInput {
   export function isa(o: any): o is ActionExecutionInput {
-    return _smithy.isa(o, "ActionExecutionInput");
+    return __isa(o, "ActionExecutionInput");
   }
 }
 
@@ -449,7 +452,7 @@ export interface ActionExecutionOutput {
 
 export namespace ActionExecutionOutput {
   export function isa(o: any): o is ActionExecutionOutput {
-    return _smithy.isa(o, "ActionExecutionOutput");
+    return __isa(o, "ActionExecutionOutput");
   }
 }
 
@@ -477,7 +480,7 @@ export interface ActionExecutionResult {
 
 export namespace ActionExecutionResult {
   export function isa(o: any): o is ActionExecutionResult {
-    return _smithy.isa(o, "ActionExecutionResult");
+    return __isa(o, "ActionExecutionResult");
   }
 }
 
@@ -492,7 +495,7 @@ export enum ActionExecutionStatus {
  * <p>The specified action cannot be found.</p>
  */
 export interface ActionNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ActionNotFoundException";
   $fault: "client";
@@ -504,7 +507,7 @@ export interface ActionNotFoundException
 
 export namespace ActionNotFoundException {
   export function isa(o: any): o is ActionNotFoundException {
-    return _smithy.isa(o, "ActionNotFoundException");
+    return __isa(o, "ActionNotFoundException");
   }
 }
 
@@ -534,7 +537,7 @@ export interface ActionRevision {
 
 export namespace ActionRevision {
   export function isa(o: any): o is ActionRevision {
-    return _smithy.isa(o, "ActionRevision");
+    return __isa(o, "ActionRevision");
   }
 }
 
@@ -573,7 +576,7 @@ export interface ActionState {
 
 export namespace ActionState {
   export function isa(o: any): o is ActionState {
-    return _smithy.isa(o, "ActionState");
+    return __isa(o, "ActionState");
   }
 }
 
@@ -610,7 +613,7 @@ export interface ActionType {
 
 export namespace ActionType {
   export function isa(o: any): o is ActionType {
-    return _smithy.isa(o, "ActionType");
+    return __isa(o, "ActionType");
   }
 }
 
@@ -650,7 +653,7 @@ export interface ActionTypeSettings {
 
 export namespace ActionTypeSettings {
   export function isa(o: any): o is ActionTypeSettings {
-    return _smithy.isa(o, "ActionTypeSettings");
+    return __isa(o, "ActionTypeSettings");
   }
 }
 
@@ -658,7 +661,7 @@ export namespace ActionTypeSettings {
  * <p>The approval action has already been approved or rejected.</p>
  */
 export interface ApprovalAlreadyCompletedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ApprovalAlreadyCompletedException";
   $fault: "client";
@@ -670,7 +673,7 @@ export interface ApprovalAlreadyCompletedException
 
 export namespace ApprovalAlreadyCompletedException {
   export function isa(o: any): o is ApprovalAlreadyCompletedException {
-    return _smithy.isa(o, "ApprovalAlreadyCompletedException");
+    return __isa(o, "ApprovalAlreadyCompletedException");
   }
 }
 
@@ -693,7 +696,7 @@ export interface ApprovalResult {
 
 export namespace ApprovalResult {
   export function isa(o: any): o is ApprovalResult {
-    return _smithy.isa(o, "ApprovalResult");
+    return __isa(o, "ApprovalResult");
   }
 }
 
@@ -720,7 +723,7 @@ export interface ArtifactDetail {
 
 export namespace ArtifactDetail {
   export function isa(o: any): o is ArtifactDetail {
-    return _smithy.isa(o, "ArtifactDetail");
+    return __isa(o, "ArtifactDetail");
   }
 }
 
@@ -742,7 +745,7 @@ export interface ArtifactDetails {
 
 export namespace ArtifactDetails {
   export function isa(o: any): o is ArtifactDetails {
-    return _smithy.isa(o, "ArtifactDetails");
+    return __isa(o, "ArtifactDetails");
   }
 }
 
@@ -791,7 +794,7 @@ export interface ArtifactRevision {
 
 export namespace ArtifactRevision {
   export function isa(o: any): o is ArtifactRevision {
-    return _smithy.isa(o, "ArtifactRevision");
+    return __isa(o, "ArtifactRevision");
   }
 }
 
@@ -830,7 +833,7 @@ export interface ArtifactStore {
 
 export namespace ArtifactStore {
   export function isa(o: any): o is ArtifactStore {
-    return _smithy.isa(o, "ArtifactStore");
+    return __isa(o, "ArtifactStore");
   }
 }
 
@@ -856,7 +859,7 @@ export interface BlockerDeclaration {
 
 export namespace BlockerDeclaration {
   export function isa(o: any): o is BlockerDeclaration {
-    return _smithy.isa(o, "BlockerDeclaration");
+    return __isa(o, "BlockerDeclaration");
   }
 }
 
@@ -868,7 +871,7 @@ export enum BlockerType {
  * <p>Unable to modify the tag due to a simultaneous update request.</p>
  */
 export interface ConcurrentModificationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ConcurrentModificationException";
   $fault: "client";
@@ -877,7 +880,7 @@ export interface ConcurrentModificationException
 
 export namespace ConcurrentModificationException {
   export function isa(o: any): o is ConcurrentModificationException {
-    return _smithy.isa(o, "ConcurrentModificationException");
+    return __isa(o, "ConcurrentModificationException");
   }
 }
 
@@ -943,7 +946,7 @@ export interface CreateCustomActionTypeInput {
 
 export namespace CreateCustomActionTypeInput {
   export function isa(o: any): o is CreateCustomActionTypeInput {
-    return _smithy.isa(o, "CreateCustomActionTypeInput");
+    return __isa(o, "CreateCustomActionTypeInput");
   }
 }
 
@@ -965,7 +968,7 @@ export interface CreateCustomActionTypeOutput extends $MetadataBearer {
 
 export namespace CreateCustomActionTypeOutput {
   export function isa(o: any): o is CreateCustomActionTypeOutput {
-    return _smithy.isa(o, "CreateCustomActionTypeOutput");
+    return __isa(o, "CreateCustomActionTypeOutput");
   }
 }
 
@@ -988,7 +991,7 @@ export interface CreatePipelineInput {
 
 export namespace CreatePipelineInput {
   export function isa(o: any): o is CreatePipelineInput {
-    return _smithy.isa(o, "CreatePipelineInput");
+    return __isa(o, "CreatePipelineInput");
   }
 }
 
@@ -1011,7 +1014,7 @@ export interface CreatePipelineOutput extends $MetadataBearer {
 
 export namespace CreatePipelineOutput {
   export function isa(o: any): o is CreatePipelineOutput {
-    return _smithy.isa(o, "CreatePipelineOutput");
+    return __isa(o, "CreatePipelineOutput");
   }
 }
 
@@ -1041,7 +1044,7 @@ export interface DeleteCustomActionTypeInput {
 
 export namespace DeleteCustomActionTypeInput {
   export function isa(o: any): o is DeleteCustomActionTypeInput {
-    return _smithy.isa(o, "DeleteCustomActionTypeInput");
+    return __isa(o, "DeleteCustomActionTypeInput");
   }
 }
 
@@ -1058,7 +1061,7 @@ export interface DeletePipelineInput {
 
 export namespace DeletePipelineInput {
   export function isa(o: any): o is DeletePipelineInput {
-    return _smithy.isa(o, "DeletePipelineInput");
+    return __isa(o, "DeletePipelineInput");
   }
 }
 
@@ -1072,7 +1075,7 @@ export interface DeleteWebhookInput {
 
 export namespace DeleteWebhookInput {
   export function isa(o: any): o is DeleteWebhookInput {
-    return _smithy.isa(o, "DeleteWebhookInput");
+    return __isa(o, "DeleteWebhookInput");
   }
 }
 
@@ -1082,7 +1085,7 @@ export interface DeleteWebhookOutput extends $MetadataBearer {
 
 export namespace DeleteWebhookOutput {
   export function isa(o: any): o is DeleteWebhookOutput {
-    return _smithy.isa(o, "DeleteWebhookOutput");
+    return __isa(o, "DeleteWebhookOutput");
   }
 }
 
@@ -1096,7 +1099,7 @@ export interface DeregisterWebhookWithThirdPartyInput {
 
 export namespace DeregisterWebhookWithThirdPartyInput {
   export function isa(o: any): o is DeregisterWebhookWithThirdPartyInput {
-    return _smithy.isa(o, "DeregisterWebhookWithThirdPartyInput");
+    return __isa(o, "DeregisterWebhookWithThirdPartyInput");
   }
 }
 
@@ -1106,7 +1109,7 @@ export interface DeregisterWebhookWithThirdPartyOutput extends $MetadataBearer {
 
 export namespace DeregisterWebhookWithThirdPartyOutput {
   export function isa(o: any): o is DeregisterWebhookWithThirdPartyOutput {
-    return _smithy.isa(o, "DeregisterWebhookWithThirdPartyOutput");
+    return __isa(o, "DeregisterWebhookWithThirdPartyOutput");
   }
 }
 
@@ -1145,7 +1148,7 @@ export interface DisableStageTransitionInput {
 
 export namespace DisableStageTransitionInput {
   export function isa(o: any): o is DisableStageTransitionInput {
-    return _smithy.isa(o, "DisableStageTransitionInput");
+    return __isa(o, "DisableStageTransitionInput");
   }
 }
 
@@ -1157,7 +1160,7 @@ export namespace DisableStageTransitionInput {
  *             again.</p>
  */
 export interface DuplicatedStopRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DuplicatedStopRequestException";
   $fault: "client";
@@ -1166,7 +1169,7 @@ export interface DuplicatedStopRequestException
 
 export namespace DuplicatedStopRequestException {
   export function isa(o: any): o is DuplicatedStopRequestException {
-    return _smithy.isa(o, "DuplicatedStopRequestException");
+    return __isa(o, "DuplicatedStopRequestException");
   }
 }
 
@@ -1197,7 +1200,7 @@ export interface EnableStageTransitionInput {
 
 export namespace EnableStageTransitionInput {
   export function isa(o: any): o is EnableStageTransitionInput {
-    return _smithy.isa(o, "EnableStageTransitionInput");
+    return __isa(o, "EnableStageTransitionInput");
   }
 }
 
@@ -1219,7 +1222,7 @@ export interface ErrorDetails {
 
 export namespace ErrorDetails {
   export function isa(o: any): o is ErrorDetails {
-    return _smithy.isa(o, "ErrorDetails");
+    return __isa(o, "ErrorDetails");
   }
 }
 
@@ -1244,7 +1247,7 @@ export interface ExecutionTrigger {
 
 export namespace ExecutionTrigger {
   export function isa(o: any): o is ExecutionTrigger {
-    return _smithy.isa(o, "ExecutionTrigger");
+    return __isa(o, "ExecutionTrigger");
   }
 }
 
@@ -1261,7 +1264,7 @@ export interface GetJobDetailsInput {
 
 export namespace GetJobDetailsInput {
   export function isa(o: any): o is GetJobDetailsInput {
-    return _smithy.isa(o, "GetJobDetailsInput");
+    return __isa(o, "GetJobDetailsInput");
   }
 }
 
@@ -1282,7 +1285,7 @@ export interface GetJobDetailsOutput extends $MetadataBearer {
 
 export namespace GetJobDetailsOutput {
   export function isa(o: any): o is GetJobDetailsOutput {
-    return _smithy.isa(o, "GetJobDetailsOutput");
+    return __isa(o, "GetJobDetailsOutput");
   }
 }
 
@@ -1305,7 +1308,7 @@ export interface GetPipelineExecutionInput {
 
 export namespace GetPipelineExecutionInput {
   export function isa(o: any): o is GetPipelineExecutionInput {
-    return _smithy.isa(o, "GetPipelineExecutionInput");
+    return __isa(o, "GetPipelineExecutionInput");
   }
 }
 
@@ -1322,7 +1325,7 @@ export interface GetPipelineExecutionOutput extends $MetadataBearer {
 
 export namespace GetPipelineExecutionOutput {
   export function isa(o: any): o is GetPipelineExecutionOutput {
-    return _smithy.isa(o, "GetPipelineExecutionOutput");
+    return __isa(o, "GetPipelineExecutionOutput");
   }
 }
 
@@ -1346,7 +1349,7 @@ export interface GetPipelineInput {
 
 export namespace GetPipelineInput {
   export function isa(o: any): o is GetPipelineInput {
-    return _smithy.isa(o, "GetPipelineInput");
+    return __isa(o, "GetPipelineInput");
   }
 }
 
@@ -1370,7 +1373,7 @@ export interface GetPipelineOutput extends $MetadataBearer {
 
 export namespace GetPipelineOutput {
   export function isa(o: any): o is GetPipelineOutput {
-    return _smithy.isa(o, "GetPipelineOutput");
+    return __isa(o, "GetPipelineOutput");
   }
 }
 
@@ -1387,7 +1390,7 @@ export interface GetPipelineStateInput {
 
 export namespace GetPipelineStateInput {
   export function isa(o: any): o is GetPipelineStateInput {
-    return _smithy.isa(o, "GetPipelineStateInput");
+    return __isa(o, "GetPipelineStateInput");
   }
 }
 
@@ -1429,7 +1432,7 @@ export interface GetPipelineStateOutput extends $MetadataBearer {
 
 export namespace GetPipelineStateOutput {
   export function isa(o: any): o is GetPipelineStateOutput {
-    return _smithy.isa(o, "GetPipelineStateOutput");
+    return __isa(o, "GetPipelineStateOutput");
   }
 }
 
@@ -1452,7 +1455,7 @@ export interface GetThirdPartyJobDetailsInput {
 
 export namespace GetThirdPartyJobDetailsInput {
   export function isa(o: any): o is GetThirdPartyJobDetailsInput {
-    return _smithy.isa(o, "GetThirdPartyJobDetailsInput");
+    return __isa(o, "GetThirdPartyJobDetailsInput");
   }
 }
 
@@ -1470,7 +1473,7 @@ export interface GetThirdPartyJobDetailsOutput extends $MetadataBearer {
 
 export namespace GetThirdPartyJobDetailsOutput {
   export function isa(o: any): o is GetThirdPartyJobDetailsOutput {
-    return _smithy.isa(o, "GetThirdPartyJobDetailsOutput");
+    return __isa(o, "GetThirdPartyJobDetailsOutput");
   }
 }
 
@@ -1493,7 +1496,7 @@ export interface InputArtifact {
 
 export namespace InputArtifact {
   export function isa(o: any): o is InputArtifact {
-    return _smithy.isa(o, "InputArtifact");
+    return __isa(o, "InputArtifact");
   }
 }
 
@@ -1501,7 +1504,7 @@ export namespace InputArtifact {
  * <p>The action declaration was specified in an invalid format.</p>
  */
 export interface InvalidActionDeclarationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidActionDeclarationException";
   $fault: "client";
@@ -1513,7 +1516,7 @@ export interface InvalidActionDeclarationException
 
 export namespace InvalidActionDeclarationException {
   export function isa(o: any): o is InvalidActionDeclarationException {
-    return _smithy.isa(o, "InvalidActionDeclarationException");
+    return __isa(o, "InvalidActionDeclarationException");
   }
 }
 
@@ -1521,7 +1524,7 @@ export namespace InvalidActionDeclarationException {
  * <p>The approval request already received a response or has expired.</p>
  */
 export interface InvalidApprovalTokenException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidApprovalTokenException";
   $fault: "client";
@@ -1533,7 +1536,7 @@ export interface InvalidApprovalTokenException
 
 export namespace InvalidApprovalTokenException {
   export function isa(o: any): o is InvalidApprovalTokenException {
-    return _smithy.isa(o, "InvalidApprovalTokenException");
+    return __isa(o, "InvalidApprovalTokenException");
   }
 }
 
@@ -1541,7 +1544,7 @@ export namespace InvalidApprovalTokenException {
  * <p>The specified resource ARN is invalid.</p>
  */
 export interface InvalidArnException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidArnException";
   $fault: "client";
@@ -1550,7 +1553,7 @@ export interface InvalidArnException
 
 export namespace InvalidArnException {
   export function isa(o: any): o is InvalidArnException {
-    return _smithy.isa(o, "InvalidArnException");
+    return __isa(o, "InvalidArnException");
   }
 }
 
@@ -1558,7 +1561,7 @@ export namespace InvalidArnException {
  * <p>Reserved for future use.</p>
  */
 export interface InvalidBlockerDeclarationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidBlockerDeclarationException";
   $fault: "client";
@@ -1570,7 +1573,7 @@ export interface InvalidBlockerDeclarationException
 
 export namespace InvalidBlockerDeclarationException {
   export function isa(o: any): o is InvalidBlockerDeclarationException {
-    return _smithy.isa(o, "InvalidBlockerDeclarationException");
+    return __isa(o, "InvalidBlockerDeclarationException");
   }
 }
 
@@ -1578,7 +1581,7 @@ export namespace InvalidBlockerDeclarationException {
  * <p>The client token was specified in an invalid format</p>
  */
 export interface InvalidClientTokenException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidClientTokenException";
   $fault: "client";
@@ -1590,7 +1593,7 @@ export interface InvalidClientTokenException
 
 export namespace InvalidClientTokenException {
   export function isa(o: any): o is InvalidClientTokenException {
-    return _smithy.isa(o, "InvalidClientTokenException");
+    return __isa(o, "InvalidClientTokenException");
   }
 }
 
@@ -1598,7 +1601,7 @@ export namespace InvalidClientTokenException {
  * <p>The job was specified in an invalid format or cannot be found.</p>
  */
 export interface InvalidJobException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidJobException";
   $fault: "client";
@@ -1610,7 +1613,7 @@ export interface InvalidJobException
 
 export namespace InvalidJobException {
   export function isa(o: any): o is InvalidJobException {
-    return _smithy.isa(o, "InvalidJobException");
+    return __isa(o, "InvalidJobException");
   }
 }
 
@@ -1619,7 +1622,7 @@ export namespace InvalidJobException {
  *             you provide is the token returned by a previous call.</p>
  */
 export interface InvalidNextTokenException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidNextTokenException";
   $fault: "client";
@@ -1631,7 +1634,7 @@ export interface InvalidNextTokenException
 
 export namespace InvalidNextTokenException {
   export function isa(o: any): o is InvalidNextTokenException {
-    return _smithy.isa(o, "InvalidNextTokenException");
+    return __isa(o, "InvalidNextTokenException");
   }
 }
 
@@ -1639,7 +1642,7 @@ export namespace InvalidNextTokenException {
  * <p>The stage declaration was specified in an invalid format.</p>
  */
 export interface InvalidStageDeclarationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidStageDeclarationException";
   $fault: "client";
@@ -1651,7 +1654,7 @@ export interface InvalidStageDeclarationException
 
 export namespace InvalidStageDeclarationException {
   export function isa(o: any): o is InvalidStageDeclarationException {
-    return _smithy.isa(o, "InvalidStageDeclarationException");
+    return __isa(o, "InvalidStageDeclarationException");
   }
 }
 
@@ -1659,7 +1662,7 @@ export namespace InvalidStageDeclarationException {
  * <p>The structure was specified in an invalid format.</p>
  */
 export interface InvalidStructureException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidStructureException";
   $fault: "client";
@@ -1671,7 +1674,7 @@ export interface InvalidStructureException
 
 export namespace InvalidStructureException {
   export function isa(o: any): o is InvalidStructureException {
-    return _smithy.isa(o, "InvalidStructureException");
+    return __isa(o, "InvalidStructureException");
   }
 }
 
@@ -1679,7 +1682,7 @@ export namespace InvalidStructureException {
  * <p>The specified resource tags are invalid.</p>
  */
 export interface InvalidTagsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidTagsException";
   $fault: "client";
@@ -1688,7 +1691,7 @@ export interface InvalidTagsException
 
 export namespace InvalidTagsException {
   export function isa(o: any): o is InvalidTagsException {
-    return _smithy.isa(o, "InvalidTagsException");
+    return __isa(o, "InvalidTagsException");
   }
 }
 
@@ -1696,7 +1699,7 @@ export namespace InvalidTagsException {
  * <p>The specified authentication type is in an invalid format.</p>
  */
 export interface InvalidWebhookAuthenticationParametersException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidWebhookAuthenticationParametersException";
   $fault: "client";
@@ -1710,7 +1713,7 @@ export namespace InvalidWebhookAuthenticationParametersException {
   export function isa(
     o: any
   ): o is InvalidWebhookAuthenticationParametersException {
-    return _smithy.isa(o, "InvalidWebhookAuthenticationParametersException");
+    return __isa(o, "InvalidWebhookAuthenticationParametersException");
   }
 }
 
@@ -1718,7 +1721,7 @@ export namespace InvalidWebhookAuthenticationParametersException {
  * <p>The specified event filter rule is in an invalid format.</p>
  */
 export interface InvalidWebhookFilterPatternException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidWebhookFilterPatternException";
   $fault: "client";
@@ -1730,7 +1733,7 @@ export interface InvalidWebhookFilterPatternException
 
 export namespace InvalidWebhookFilterPatternException {
   export function isa(o: any): o is InvalidWebhookFilterPatternException {
-    return _smithy.isa(o, "InvalidWebhookFilterPatternException");
+    return __isa(o, "InvalidWebhookFilterPatternException");
   }
 }
 
@@ -1763,7 +1766,7 @@ export interface Job {
 
 export namespace Job {
   export function isa(o: any): o is Job {
-    return _smithy.isa(o, "Job");
+    return __isa(o, "Job");
   }
 }
 
@@ -1825,7 +1828,7 @@ export interface JobData {
 
 export namespace JobData {
   export function isa(o: any): o is JobData {
-    return _smithy.isa(o, "JobData");
+    return __isa(o, "JobData");
   }
 }
 
@@ -1853,7 +1856,7 @@ export interface JobDetails {
 
 export namespace JobDetails {
   export function isa(o: any): o is JobDetails {
-    return _smithy.isa(o, "JobDetails");
+    return __isa(o, "JobDetails");
   }
 }
 
@@ -1862,7 +1865,7 @@ export namespace JobDetails {
  *             allowed for the account.</p>
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -1874,7 +1877,7 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
@@ -1911,7 +1914,7 @@ export interface ListActionExecutionsInput {
 
 export namespace ListActionExecutionsInput {
   export function isa(o: any): o is ListActionExecutionsInput {
-    return _smithy.isa(o, "ListActionExecutionsInput");
+    return __isa(o, "ListActionExecutionsInput");
   }
 }
 
@@ -1932,7 +1935,7 @@ export interface ListActionExecutionsOutput extends $MetadataBearer {
 
 export namespace ListActionExecutionsOutput {
   export function isa(o: any): o is ListActionExecutionsOutput {
-    return _smithy.isa(o, "ListActionExecutionsOutput");
+    return __isa(o, "ListActionExecutionsOutput");
   }
 }
 
@@ -1955,7 +1958,7 @@ export interface ListActionTypesInput {
 
 export namespace ListActionTypesInput {
   export function isa(o: any): o is ListActionTypesInput {
-    return _smithy.isa(o, "ListActionTypesInput");
+    return __isa(o, "ListActionTypesInput");
   }
 }
 
@@ -1979,7 +1982,7 @@ export interface ListActionTypesOutput extends $MetadataBearer {
 
 export namespace ListActionTypesOutput {
   export function isa(o: any): o is ListActionTypesOutput {
-    return _smithy.isa(o, "ListActionTypesOutput");
+    return __isa(o, "ListActionTypesOutput");
   }
 }
 
@@ -2012,7 +2015,7 @@ export interface ListPipelineExecutionsInput {
 
 export namespace ListPipelineExecutionsInput {
   export function isa(o: any): o is ListPipelineExecutionsInput {
-    return _smithy.isa(o, "ListPipelineExecutionsInput");
+    return __isa(o, "ListPipelineExecutionsInput");
   }
 }
 
@@ -2036,7 +2039,7 @@ export interface ListPipelineExecutionsOutput extends $MetadataBearer {
 
 export namespace ListPipelineExecutionsOutput {
   export function isa(o: any): o is ListPipelineExecutionsOutput {
-    return _smithy.isa(o, "ListPipelineExecutionsOutput");
+    return __isa(o, "ListPipelineExecutionsOutput");
   }
 }
 
@@ -2054,7 +2057,7 @@ export interface ListPipelinesInput {
 
 export namespace ListPipelinesInput {
   export function isa(o: any): o is ListPipelinesInput {
-    return _smithy.isa(o, "ListPipelinesInput");
+    return __isa(o, "ListPipelinesInput");
   }
 }
 
@@ -2078,7 +2081,7 @@ export interface ListPipelinesOutput extends $MetadataBearer {
 
 export namespace ListPipelinesOutput {
   export function isa(o: any): o is ListPipelinesOutput {
-    return _smithy.isa(o, "ListPipelinesOutput");
+    return __isa(o, "ListPipelinesOutput");
   }
 }
 
@@ -2104,7 +2107,7 @@ export interface ListTagsForResourceInput {
 
 export namespace ListTagsForResourceInput {
   export function isa(o: any): o is ListTagsForResourceInput {
-    return _smithy.isa(o, "ListTagsForResourceInput");
+    return __isa(o, "ListTagsForResourceInput");
   }
 }
 
@@ -2126,7 +2129,7 @@ export interface ListTagsForResourceOutput extends $MetadataBearer {
 
 export namespace ListTagsForResourceOutput {
   export function isa(o: any): o is ListTagsForResourceOutput {
-    return _smithy.isa(o, "ListTagsForResourceOutput");
+    return __isa(o, "ListTagsForResourceOutput");
   }
 }
 
@@ -2179,7 +2182,7 @@ export interface ListWebhookItem {
 
 export namespace ListWebhookItem {
   export function isa(o: any): o is ListWebhookItem {
-    return _smithy.isa(o, "ListWebhookItem");
+    return __isa(o, "ListWebhookItem");
   }
 }
 
@@ -2200,7 +2203,7 @@ export interface ListWebhooksInput {
 
 export namespace ListWebhooksInput {
   export function isa(o: any): o is ListWebhooksInput {
-    return _smithy.isa(o, "ListWebhooksInput");
+    return __isa(o, "ListWebhooksInput");
   }
 }
 
@@ -2222,7 +2225,7 @@ export interface ListWebhooksOutput extends $MetadataBearer {
 
 export namespace ListWebhooksOutput {
   export function isa(o: any): o is ListWebhooksOutput {
-    return _smithy.isa(o, "ListWebhooksOutput");
+    return __isa(o, "ListWebhooksOutput");
   }
 }
 
@@ -2231,7 +2234,7 @@ export namespace ListWebhooksOutput {
  *             associated with the request is out of date.</p>
  */
 export interface NotLatestPipelineExecutionException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "NotLatestPipelineExecutionException";
   $fault: "client";
@@ -2243,7 +2246,7 @@ export interface NotLatestPipelineExecutionException
 
 export namespace NotLatestPipelineExecutionException {
   export function isa(o: any): o is NotLatestPipelineExecutionException {
-    return _smithy.isa(o, "NotLatestPipelineExecutionException");
+    return __isa(o, "NotLatestPipelineExecutionException");
   }
 }
 
@@ -2266,7 +2269,7 @@ export interface OutputArtifact {
 
 export namespace OutputArtifact {
   export function isa(o: any): o is OutputArtifact {
-    return _smithy.isa(o, "OutputArtifact");
+    return __isa(o, "OutputArtifact");
   }
 }
 
@@ -2327,7 +2330,7 @@ export interface PipelineDeclaration {
 
 export namespace PipelineDeclaration {
   export function isa(o: any): o is PipelineDeclaration {
-    return _smithy.isa(o, "PipelineDeclaration");
+    return __isa(o, "PipelineDeclaration");
   }
 }
 
@@ -2390,7 +2393,7 @@ export interface PipelineExecution {
 
 export namespace PipelineExecution {
   export function isa(o: any): o is PipelineExecution {
-    return _smithy.isa(o, "PipelineExecution");
+    return __isa(o, "PipelineExecution");
   }
 }
 
@@ -2399,7 +2402,7 @@ export namespace PipelineExecution {
  *             execution ID does not belong to the specified pipeline. </p>
  */
 export interface PipelineExecutionNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "PipelineExecutionNotFoundException";
   $fault: "client";
@@ -2411,7 +2414,7 @@ export interface PipelineExecutionNotFoundException
 
 export namespace PipelineExecutionNotFoundException {
   export function isa(o: any): o is PipelineExecutionNotFoundException {
-    return _smithy.isa(o, "PipelineExecutionNotFoundException");
+    return __isa(o, "PipelineExecutionNotFoundException");
   }
 }
 
@@ -2420,7 +2423,7 @@ export namespace PipelineExecutionNotFoundException {
  *                 <code>Stopped</code> state, or it might no longer be in progress.</p>
  */
 export interface PipelineExecutionNotStoppableException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "PipelineExecutionNotStoppableException";
   $fault: "client";
@@ -2429,7 +2432,7 @@ export interface PipelineExecutionNotStoppableException
 
 export namespace PipelineExecutionNotStoppableException {
   export function isa(o: any): o is PipelineExecutionNotStoppableException {
-    return _smithy.isa(o, "PipelineExecutionNotStoppableException");
+    return __isa(o, "PipelineExecutionNotStoppableException");
   }
 }
 
@@ -2513,7 +2516,7 @@ export interface PipelineExecutionSummary {
 
 export namespace PipelineExecutionSummary {
   export function isa(o: any): o is PipelineExecutionSummary {
-    return _smithy.isa(o, "PipelineExecutionSummary");
+    return __isa(o, "PipelineExecutionSummary");
   }
 }
 
@@ -2540,7 +2543,7 @@ export interface PipelineMetadata {
 
 export namespace PipelineMetadata {
   export function isa(o: any): o is PipelineMetadata {
-    return _smithy.isa(o, "PipelineMetadata");
+    return __isa(o, "PipelineMetadata");
   }
 }
 
@@ -2548,7 +2551,7 @@ export namespace PipelineMetadata {
  * <p>The specified pipeline name is already in use.</p>
  */
 export interface PipelineNameInUseException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "PipelineNameInUseException";
   $fault: "client";
@@ -2560,7 +2563,7 @@ export interface PipelineNameInUseException
 
 export namespace PipelineNameInUseException {
   export function isa(o: any): o is PipelineNameInUseException {
-    return _smithy.isa(o, "PipelineNameInUseException");
+    return __isa(o, "PipelineNameInUseException");
   }
 }
 
@@ -2568,7 +2571,7 @@ export namespace PipelineNameInUseException {
  * <p>The pipeline was specified in an invalid format or cannot be found.</p>
  */
 export interface PipelineNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "PipelineNotFoundException";
   $fault: "client";
@@ -2580,7 +2583,7 @@ export interface PipelineNotFoundException
 
 export namespace PipelineNotFoundException {
   export function isa(o: any): o is PipelineNotFoundException {
-    return _smithy.isa(o, "PipelineNotFoundException");
+    return __isa(o, "PipelineNotFoundException");
   }
 }
 
@@ -2613,7 +2616,7 @@ export interface PipelineSummary {
 
 export namespace PipelineSummary {
   export function isa(o: any): o is PipelineSummary {
-    return _smithy.isa(o, "PipelineSummary");
+    return __isa(o, "PipelineSummary");
   }
 }
 
@@ -2622,7 +2625,7 @@ export namespace PipelineSummary {
  *             found.</p>
  */
 export interface PipelineVersionNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "PipelineVersionNotFoundException";
   $fault: "client";
@@ -2634,7 +2637,7 @@ export interface PipelineVersionNotFoundException
 
 export namespace PipelineVersionNotFoundException {
   export function isa(o: any): o is PipelineVersionNotFoundException {
-    return _smithy.isa(o, "PipelineVersionNotFoundException");
+    return __isa(o, "PipelineVersionNotFoundException");
   }
 }
 
@@ -2664,7 +2667,7 @@ export interface PollForJobsInput {
 
 export namespace PollForJobsInput {
   export function isa(o: any): o is PollForJobsInput {
-    return _smithy.isa(o, "PollForJobsInput");
+    return __isa(o, "PollForJobsInput");
   }
 }
 
@@ -2681,7 +2684,7 @@ export interface PollForJobsOutput extends $MetadataBearer {
 
 export namespace PollForJobsOutput {
   export function isa(o: any): o is PollForJobsOutput {
-    return _smithy.isa(o, "PollForJobsOutput");
+    return __isa(o, "PollForJobsOutput");
   }
 }
 
@@ -2703,7 +2706,7 @@ export interface PollForThirdPartyJobsInput {
 
 export namespace PollForThirdPartyJobsInput {
   export function isa(o: any): o is PollForThirdPartyJobsInput {
-    return _smithy.isa(o, "PollForThirdPartyJobsInput");
+    return __isa(o, "PollForThirdPartyJobsInput");
   }
 }
 
@@ -2720,7 +2723,7 @@ export interface PollForThirdPartyJobsOutput extends $MetadataBearer {
 
 export namespace PollForThirdPartyJobsOutput {
   export function isa(o: any): o is PollForThirdPartyJobsOutput {
-    return _smithy.isa(o, "PollForThirdPartyJobsOutput");
+    return __isa(o, "PollForThirdPartyJobsOutput");
   }
 }
 
@@ -2753,7 +2756,7 @@ export interface PutActionRevisionInput {
 
 export namespace PutActionRevisionInput {
   export function isa(o: any): o is PutActionRevisionInput {
-    return _smithy.isa(o, "PutActionRevisionInput");
+    return __isa(o, "PutActionRevisionInput");
   }
 }
 
@@ -2776,7 +2779,7 @@ export interface PutActionRevisionOutput extends $MetadataBearer {
 
 export namespace PutActionRevisionOutput {
   export function isa(o: any): o is PutActionRevisionOutput {
-    return _smithy.isa(o, "PutActionRevisionOutput");
+    return __isa(o, "PutActionRevisionOutput");
   }
 }
 
@@ -2815,7 +2818,7 @@ export interface PutApprovalResultInput {
 
 export namespace PutApprovalResultInput {
   export function isa(o: any): o is PutApprovalResultInput {
-    return _smithy.isa(o, "PutApprovalResultInput");
+    return __isa(o, "PutApprovalResultInput");
   }
 }
 
@@ -2832,7 +2835,7 @@ export interface PutApprovalResultOutput extends $MetadataBearer {
 
 export namespace PutApprovalResultOutput {
   export function isa(o: any): o is PutApprovalResultOutput {
-    return _smithy.isa(o, "PutApprovalResultOutput");
+    return __isa(o, "PutApprovalResultOutput");
   }
 }
 
@@ -2855,7 +2858,7 @@ export interface PutJobFailureResultInput {
 
 export namespace PutJobFailureResultInput {
   export function isa(o: any): o is PutJobFailureResultInput {
-    return _smithy.isa(o, "PutJobFailureResultInput");
+    return __isa(o, "PutJobFailureResultInput");
   }
 }
 
@@ -2901,7 +2904,7 @@ export interface PutJobSuccessResultInput {
 
 export namespace PutJobSuccessResultInput {
   export function isa(o: any): o is PutJobSuccessResultInput {
-    return _smithy.isa(o, "PutJobSuccessResultInput");
+    return __isa(o, "PutJobSuccessResultInput");
   }
 }
 
@@ -2931,7 +2934,7 @@ export interface PutThirdPartyJobFailureResultInput {
 
 export namespace PutThirdPartyJobFailureResultInput {
   export function isa(o: any): o is PutThirdPartyJobFailureResultInput {
-    return _smithy.isa(o, "PutThirdPartyJobFailureResultInput");
+    return __isa(o, "PutThirdPartyJobFailureResultInput");
   }
 }
 
@@ -2976,7 +2979,7 @@ export interface PutThirdPartyJobSuccessResultInput {
 
 export namespace PutThirdPartyJobSuccessResultInput {
   export function isa(o: any): o is PutThirdPartyJobSuccessResultInput {
-    return _smithy.isa(o, "PutThirdPartyJobSuccessResultInput");
+    return __isa(o, "PutThirdPartyJobSuccessResultInput");
   }
 }
 
@@ -2998,7 +3001,7 @@ export interface PutWebhookInput {
 
 export namespace PutWebhookInput {
   export function isa(o: any): o is PutWebhookInput {
-    return _smithy.isa(o, "PutWebhookInput");
+    return __isa(o, "PutWebhookInput");
   }
 }
 
@@ -3013,7 +3016,7 @@ export interface PutWebhookOutput extends $MetadataBearer {
 
 export namespace PutWebhookOutput {
   export function isa(o: any): o is PutWebhookOutput {
-    return _smithy.isa(o, "PutWebhookOutput");
+    return __isa(o, "PutWebhookOutput");
   }
 }
 
@@ -3028,7 +3031,7 @@ export interface RegisterWebhookWithThirdPartyInput {
 
 export namespace RegisterWebhookWithThirdPartyInput {
   export function isa(o: any): o is RegisterWebhookWithThirdPartyInput {
-    return _smithy.isa(o, "RegisterWebhookWithThirdPartyInput");
+    return __isa(o, "RegisterWebhookWithThirdPartyInput");
   }
 }
 
@@ -3038,7 +3041,7 @@ export interface RegisterWebhookWithThirdPartyOutput extends $MetadataBearer {
 
 export namespace RegisterWebhookWithThirdPartyOutput {
   export function isa(o: any): o is RegisterWebhookWithThirdPartyOutput {
-    return _smithy.isa(o, "RegisterWebhookWithThirdPartyOutput");
+    return __isa(o, "RegisterWebhookWithThirdPartyOutput");
   }
 }
 
@@ -3072,7 +3075,7 @@ export interface RetryStageExecutionInput {
 
 export namespace RetryStageExecutionInput {
   export function isa(o: any): o is RetryStageExecutionInput {
-    return _smithy.isa(o, "RetryStageExecutionInput");
+    return __isa(o, "RetryStageExecutionInput");
   }
 }
 
@@ -3089,7 +3092,7 @@ export interface RetryStageExecutionOutput extends $MetadataBearer {
 
 export namespace RetryStageExecutionOutput {
   export function isa(o: any): o is RetryStageExecutionOutput {
-    return _smithy.isa(o, "RetryStageExecutionOutput");
+    return __isa(o, "RetryStageExecutionOutput");
   }
 }
 
@@ -3111,7 +3114,7 @@ export interface S3Location {
 
 export namespace S3Location {
   export function isa(o: any): o is S3Location {
-    return _smithy.isa(o, "S3Location");
+    return __isa(o, "S3Location");
   }
 }
 
@@ -3150,7 +3153,7 @@ export interface SourceRevision {
 
 export namespace SourceRevision {
   export function isa(o: any): o is SourceRevision {
-    return _smithy.isa(o, "SourceRevision");
+    return __isa(o, "SourceRevision");
   }
 }
 
@@ -3177,7 +3180,7 @@ export interface StageDeclaration {
 
 export namespace StageDeclaration {
   export function isa(o: any): o is StageDeclaration {
-    return _smithy.isa(o, "StageDeclaration");
+    return __isa(o, "StageDeclaration");
   }
 }
 
@@ -3200,7 +3203,7 @@ export interface StageExecution {
 
 export namespace StageExecution {
   export function isa(o: any): o is StageExecution {
-    return _smithy.isa(o, "StageExecution");
+    return __isa(o, "StageExecution");
   }
 }
 
@@ -3216,7 +3219,7 @@ export enum StageExecutionStatus {
  * <p>The stage was specified in an invalid format or cannot be found.</p>
  */
 export interface StageNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "StageNotFoundException";
   $fault: "client";
@@ -3228,7 +3231,7 @@ export interface StageNotFoundException
 
 export namespace StageNotFoundException {
   export function isa(o: any): o is StageNotFoundException {
-    return _smithy.isa(o, "StageNotFoundException");
+    return __isa(o, "StageNotFoundException");
   }
 }
 
@@ -3238,7 +3241,7 @@ export namespace StageNotFoundException {
  *             actions.</p>
  */
 export interface StageNotRetryableException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "StageNotRetryableException";
   $fault: "client";
@@ -3250,7 +3253,7 @@ export interface StageNotRetryableException
 
 export namespace StageNotRetryableException {
   export function isa(o: any): o is StageNotRetryableException {
-    return _smithy.isa(o, "StageNotRetryableException");
+    return __isa(o, "StageNotRetryableException");
   }
 }
 
@@ -3287,7 +3290,7 @@ export interface StageState {
 
 export namespace StageState {
   export function isa(o: any): o is StageState {
-    return _smithy.isa(o, "StageState");
+    return __isa(o, "StageState");
   }
 }
 
@@ -3315,7 +3318,7 @@ export interface StartPipelineExecutionInput {
 
 export namespace StartPipelineExecutionInput {
   export function isa(o: any): o is StartPipelineExecutionInput {
-    return _smithy.isa(o, "StartPipelineExecutionInput");
+    return __isa(o, "StartPipelineExecutionInput");
   }
 }
 
@@ -3333,7 +3336,7 @@ export interface StartPipelineExecutionOutput extends $MetadataBearer {
 
 export namespace StartPipelineExecutionOutput {
   export function isa(o: any): o is StartPipelineExecutionOutput {
-    return _smithy.isa(o, "StartPipelineExecutionOutput");
+    return __isa(o, "StartPipelineExecutionOutput");
   }
 }
 
@@ -3350,7 +3353,7 @@ export interface StopExecutionTrigger {
 
 export namespace StopExecutionTrigger {
   export function isa(o: any): o is StopExecutionTrigger {
-    return _smithy.isa(o, "StopExecutionTrigger");
+    return __isa(o, "StopExecutionTrigger");
   }
 }
 
@@ -3385,7 +3388,7 @@ export interface StopPipelineExecutionInput {
 
 export namespace StopPipelineExecutionInput {
   export function isa(o: any): o is StopPipelineExecutionInput {
-    return _smithy.isa(o, "StopPipelineExecutionInput");
+    return __isa(o, "StopPipelineExecutionInput");
   }
 }
 
@@ -3399,7 +3402,7 @@ export interface StopPipelineExecutionOutput extends $MetadataBearer {
 
 export namespace StopPipelineExecutionOutput {
   export function isa(o: any): o is StopPipelineExecutionOutput {
-    return _smithy.isa(o, "StopPipelineExecutionOutput");
+    return __isa(o, "StopPipelineExecutionOutput");
   }
 }
 
@@ -3421,7 +3424,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -3440,7 +3443,7 @@ export interface TagResourceInput {
 
 export namespace TagResourceInput {
   export function isa(o: any): o is TagResourceInput {
-    return _smithy.isa(o, "TagResourceInput");
+    return __isa(o, "TagResourceInput");
   }
 }
 
@@ -3450,7 +3453,7 @@ export interface TagResourceOutput extends $MetadataBearer {
 
 export namespace TagResourceOutput {
   export function isa(o: any): o is TagResourceOutput {
-    return _smithy.isa(o, "TagResourceOutput");
+    return __isa(o, "TagResourceOutput");
   }
 }
 
@@ -3475,7 +3478,7 @@ export interface ThirdPartyJob {
 
 export namespace ThirdPartyJob {
   export function isa(o: any): o is ThirdPartyJob {
-    return _smithy.isa(o, "ThirdPartyJob");
+    return __isa(o, "ThirdPartyJob");
   }
 }
 
@@ -3542,7 +3545,7 @@ export interface ThirdPartyJobData {
 
 export namespace ThirdPartyJobData {
   export function isa(o: any): o is ThirdPartyJobData {
-    return _smithy.isa(o, "ThirdPartyJobData");
+    return __isa(o, "ThirdPartyJobData");
   }
 }
 
@@ -3571,7 +3574,7 @@ export interface ThirdPartyJobDetails {
 
 export namespace ThirdPartyJobDetails {
   export function isa(o: any): o is ThirdPartyJobDetails {
-    return _smithy.isa(o, "ThirdPartyJobDetails");
+    return __isa(o, "ThirdPartyJobDetails");
   }
 }
 
@@ -3579,7 +3582,7 @@ export namespace ThirdPartyJobDetails {
  * <p>The tags limit for a resource has been exceeded.</p>
  */
 export interface TooManyTagsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyTagsException";
   $fault: "client";
@@ -3588,7 +3591,7 @@ export interface TooManyTagsException
 
 export namespace TooManyTagsException {
   export function isa(o: any): o is TooManyTagsException {
-    return _smithy.isa(o, "TooManyTagsException");
+    return __isa(o, "TooManyTagsException");
   }
 }
 
@@ -3623,7 +3626,7 @@ export interface TransitionState {
 
 export namespace TransitionState {
   export function isa(o: any): o is TransitionState {
-    return _smithy.isa(o, "TransitionState");
+    return __isa(o, "TransitionState");
   }
 }
 
@@ -3651,7 +3654,7 @@ export interface UntagResourceInput {
 
 export namespace UntagResourceInput {
   export function isa(o: any): o is UntagResourceInput {
-    return _smithy.isa(o, "UntagResourceInput");
+    return __isa(o, "UntagResourceInput");
   }
 }
 
@@ -3661,7 +3664,7 @@ export interface UntagResourceOutput extends $MetadataBearer {
 
 export namespace UntagResourceOutput {
   export function isa(o: any): o is UntagResourceOutput {
-    return _smithy.isa(o, "UntagResourceOutput");
+    return __isa(o, "UntagResourceOutput");
   }
 }
 
@@ -3678,7 +3681,7 @@ export interface UpdatePipelineInput {
 
 export namespace UpdatePipelineInput {
   export function isa(o: any): o is UpdatePipelineInput {
-    return _smithy.isa(o, "UpdatePipelineInput");
+    return __isa(o, "UpdatePipelineInput");
   }
 }
 
@@ -3695,7 +3698,7 @@ export interface UpdatePipelineOutput extends $MetadataBearer {
 
 export namespace UpdatePipelineOutput {
   export function isa(o: any): o is UpdatePipelineOutput {
-    return _smithy.isa(o, "UpdatePipelineOutput");
+    return __isa(o, "UpdatePipelineOutput");
   }
 }
 
@@ -3720,7 +3723,7 @@ export interface WebhookAuthConfiguration {
 
 export namespace WebhookAuthConfiguration {
   export function isa(o: any): o is WebhookAuthConfiguration {
-    return _smithy.isa(o, "WebhookAuthConfiguration");
+    return __isa(o, "WebhookAuthConfiguration");
   }
 }
 
@@ -3791,7 +3794,7 @@ export interface WebhookDefinition {
 
 export namespace WebhookDefinition {
   export function isa(o: any): o is WebhookDefinition {
-    return _smithy.isa(o, "WebhookDefinition");
+    return __isa(o, "WebhookDefinition");
   }
 }
 
@@ -3825,7 +3828,7 @@ export interface WebhookFilterRule {
 
 export namespace WebhookFilterRule {
   export function isa(o: any): o is WebhookFilterRule {
-    return _smithy.isa(o, "WebhookFilterRule");
+    return __isa(o, "WebhookFilterRule");
   }
 }
 
@@ -3834,7 +3837,7 @@ export namespace WebhookFilterRule {
  *             found.</p>
  */
 export interface WebhookNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "WebhookNotFoundException";
   $fault: "client";
@@ -3842,7 +3845,7 @@ export interface WebhookNotFoundException
 
 export namespace WebhookNotFoundException {
   export function isa(o: any): o is WebhookNotFoundException {
-    return _smithy.isa(o, "WebhookNotFoundException");
+    return __isa(o, "WebhookNotFoundException");
   }
 }
 
@@ -3872,7 +3875,7 @@ export interface AWSSessionCredentials {
 
 export namespace AWSSessionCredentials {
   export function isa(o: any): o is AWSSessionCredentials {
-    return _smithy.isa(o, "AWSSessionCredentials");
+    return __isa(o, "AWSSessionCredentials");
   }
 }
 
@@ -3898,7 +3901,7 @@ export interface ActionConfiguration {
 
 export namespace ActionConfiguration {
   export function isa(o: any): o is ActionConfiguration {
-    return _smithy.isa(o, "ActionConfiguration");
+    return __isa(o, "ActionConfiguration");
   }
 }
 
@@ -3921,7 +3924,7 @@ export interface ActionContext {
 
 export namespace ActionContext {
   export function isa(o: any): o is ActionContext {
-    return _smithy.isa(o, "ActionContext");
+    return __isa(o, "ActionContext");
   }
 }
 
@@ -3964,7 +3967,7 @@ export interface ActionTypeId {
 
 export namespace ActionTypeId {
   export function isa(o: any): o is ActionTypeId {
-    return _smithy.isa(o, "ActionTypeId");
+    return __isa(o, "ActionTypeId");
   }
 }
 
@@ -3972,7 +3975,7 @@ export namespace ActionTypeId {
  * <p>The specified action type cannot be found.</p>
  */
 export interface ActionTypeNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ActionTypeNotFoundException";
   $fault: "client";
@@ -3984,7 +3987,7 @@ export interface ActionTypeNotFoundException
 
 export namespace ActionTypeNotFoundException {
   export function isa(o: any): o is ActionTypeNotFoundException {
-    return _smithy.isa(o, "ActionTypeNotFoundException");
+    return __isa(o, "ActionTypeNotFoundException");
   }
 }
 
@@ -4013,7 +4016,7 @@ export interface Artifact {
 
 export namespace Artifact {
   export function isa(o: any): o is Artifact {
-    return _smithy.isa(o, "Artifact");
+    return __isa(o, "Artifact");
   }
 }
 
@@ -4035,7 +4038,7 @@ export interface ArtifactLocation {
 
 export namespace ArtifactLocation {
   export function isa(o: any): o is ArtifactLocation {
-    return _smithy.isa(o, "ArtifactLocation");
+    return __isa(o, "ArtifactLocation");
   }
 }
 
@@ -4072,7 +4075,7 @@ export interface CurrentRevision {
 
 export namespace CurrentRevision {
   export function isa(o: any): o is CurrentRevision {
-    return _smithy.isa(o, "CurrentRevision");
+    return __isa(o, "CurrentRevision");
   }
 }
 
@@ -4102,7 +4105,7 @@ export interface EncryptionKey {
 
 export namespace EncryptionKey {
   export function isa(o: any): o is EncryptionKey {
-    return _smithy.isa(o, "EncryptionKey");
+    return __isa(o, "EncryptionKey");
   }
 }
 
@@ -4136,7 +4139,7 @@ export interface ExecutionDetails {
 
 export namespace ExecutionDetails {
   export function isa(o: any): o is ExecutionDetails {
-    return _smithy.isa(o, "ExecutionDetails");
+    return __isa(o, "ExecutionDetails");
   }
 }
 
@@ -4163,7 +4166,7 @@ export interface FailureDetails {
 
 export namespace FailureDetails {
   export function isa(o: any): o is FailureDetails {
-    return _smithy.isa(o, "FailureDetails");
+    return __isa(o, "FailureDetails");
   }
 }
 
@@ -4180,7 +4183,7 @@ export enum FailureType {
  * <p>The job state was specified in an invalid format.</p>
  */
 export interface InvalidJobStateException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidJobStateException";
   $fault: "client";
@@ -4192,7 +4195,7 @@ export interface InvalidJobStateException
 
 export namespace InvalidJobStateException {
   export function isa(o: any): o is InvalidJobStateException {
-    return _smithy.isa(o, "InvalidJobStateException");
+    return __isa(o, "InvalidJobStateException");
   }
 }
 
@@ -4200,7 +4203,7 @@ export namespace InvalidJobStateException {
  * <p>The nonce was specified in an invalid format.</p>
  */
 export interface InvalidNonceException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidNonceException";
   $fault: "client";
@@ -4212,7 +4215,7 @@ export interface InvalidNonceException
 
 export namespace InvalidNonceException {
   export function isa(o: any): o is InvalidNonceException {
-    return _smithy.isa(o, "InvalidNonceException");
+    return __isa(o, "InvalidNonceException");
   }
 }
 
@@ -4220,7 +4223,7 @@ export namespace InvalidNonceException {
  * <p>The job was specified in an invalid format or cannot be found.</p>
  */
 export interface JobNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "JobNotFoundException";
   $fault: "client";
@@ -4232,7 +4235,7 @@ export interface JobNotFoundException
 
 export namespace JobNotFoundException {
   export function isa(o: any): o is JobNotFoundException {
-    return _smithy.isa(o, "JobNotFoundException");
+    return __isa(o, "JobNotFoundException");
   }
 }
 
@@ -4250,7 +4253,7 @@ export enum JobStatus {
  * <p>Exceeded the total size limit for all variables in the pipeline.</p>
  */
 export interface OutputVariablesSizeExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "OutputVariablesSizeExceededException";
   $fault: "client";
@@ -4259,7 +4262,7 @@ export interface OutputVariablesSizeExceededException
 
 export namespace OutputVariablesSizeExceededException {
   export function isa(o: any): o is OutputVariablesSizeExceededException {
-    return _smithy.isa(o, "OutputVariablesSizeExceededException");
+    return __isa(o, "OutputVariablesSizeExceededException");
   }
 }
 
@@ -4303,7 +4306,7 @@ export interface PipelineContext {
 
 export namespace PipelineContext {
   export function isa(o: any): o is PipelineContext {
-    return _smithy.isa(o, "PipelineContext");
+    return __isa(o, "PipelineContext");
   }
 }
 
@@ -4311,7 +4314,7 @@ export namespace PipelineContext {
  * <p>The resource was specified in an invalid format.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -4323,7 +4326,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -4346,7 +4349,7 @@ export interface S3ArtifactLocation {
 
 export namespace S3ArtifactLocation {
   export function isa(o: any): o is S3ArtifactLocation {
-    return _smithy.isa(o, "S3ArtifactLocation");
+    return __isa(o, "S3ArtifactLocation");
   }
 }
 
@@ -4363,7 +4366,7 @@ export interface StageContext {
 
 export namespace StageContext {
   export function isa(o: any): o is StageContext {
-    return _smithy.isa(o, "StageContext");
+    return __isa(o, "StageContext");
   }
 }
 
@@ -4371,7 +4374,7 @@ export namespace StageContext {
  * <p>The validation was specified in an invalid format.</p>
  */
 export interface ValidationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ValidationException";
   $fault: "client";
@@ -4383,6 +4386,6 @@ export interface ValidationException
 
 export namespace ValidationException {
   export function isa(o: any): o is ValidationException {
-    return _smithy.isa(o, "ValidationException");
+    return __isa(o, "ValidationException");
   }
 }

--- a/clients/client-codepipeline/protocols/Aws_json1_1.ts
+++ b/clients/client-codepipeline/protocols/Aws_json1_1.ts
@@ -1193,6 +1193,7 @@ export async function deserializeAws_json1_1DeleteCustomActionTypeCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteCustomActionTypeCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1251,6 +1252,7 @@ export async function deserializeAws_json1_1DeletePipelineCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1DeletePipelineCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeletePipelineCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1444,6 +1446,7 @@ export async function deserializeAws_json1_1DisableStageTransitionCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DisableStageTransitionCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1512,6 +1515,7 @@ export async function deserializeAws_json1_1EnableStageTransitionCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: EnableStageTransitionCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2648,6 +2652,7 @@ export async function deserializeAws_json1_1PutJobFailureResultCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: PutJobFailureResultCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2716,6 +2721,7 @@ export async function deserializeAws_json1_1PutJobSuccessResultCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: PutJobSuccessResultCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2791,6 +2797,7 @@ export async function deserializeAws_json1_1PutThirdPartyJobFailureResultCommand
       context
     );
   }
+  await collectBody(output.body, context);
   const response: PutThirdPartyJobFailureResultCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2866,6 +2873,7 @@ export async function deserializeAws_json1_1PutThirdPartyJobSuccessResultCommand
       context
     );
   }
+  await collectBody(output.body, context);
   const response: PutThirdPartyJobSuccessResultCommandOutput = {
     $metadata: deserializeMetadata(output)
   };

--- a/clients/client-codestar-connections/models/index.ts
+++ b/clients/client-codestar-connections/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -41,7 +44,7 @@ export interface Connection {
 
 export namespace Connection {
   export function isa(o: any): o is Connection {
-    return _smithy.isa(o, "Connection");
+    return __isa(o, "Connection");
   }
 }
 
@@ -68,7 +71,7 @@ export interface CreateConnectionInput {
 
 export namespace CreateConnectionInput {
   export function isa(o: any): o is CreateConnectionInput {
-    return _smithy.isa(o, "CreateConnectionInput");
+    return __isa(o, "CreateConnectionInput");
   }
 }
 
@@ -86,7 +89,7 @@ export interface CreateConnectionOutput extends $MetadataBearer {
 
 export namespace CreateConnectionOutput {
   export function isa(o: any): o is CreateConnectionOutput {
-    return _smithy.isa(o, "CreateConnectionOutput");
+    return __isa(o, "CreateConnectionOutput");
   }
 }
 
@@ -103,7 +106,7 @@ export interface DeleteConnectionInput {
 
 export namespace DeleteConnectionInput {
   export function isa(o: any): o is DeleteConnectionInput {
-    return _smithy.isa(o, "DeleteConnectionInput");
+    return __isa(o, "DeleteConnectionInput");
   }
 }
 
@@ -113,7 +116,7 @@ export interface DeleteConnectionOutput extends $MetadataBearer {
 
 export namespace DeleteConnectionOutput {
   export function isa(o: any): o is DeleteConnectionOutput {
-    return _smithy.isa(o, "DeleteConnectionOutput");
+    return __isa(o, "DeleteConnectionOutput");
   }
 }
 
@@ -127,7 +130,7 @@ export interface GetConnectionInput {
 
 export namespace GetConnectionInput {
   export function isa(o: any): o is GetConnectionInput {
-    return _smithy.isa(o, "GetConnectionInput");
+    return __isa(o, "GetConnectionInput");
   }
 }
 
@@ -141,7 +144,7 @@ export interface GetConnectionOutput extends $MetadataBearer {
 
 export namespace GetConnectionOutput {
   export function isa(o: any): o is GetConnectionOutput {
-    return _smithy.isa(o, "GetConnectionOutput");
+    return __isa(o, "GetConnectionOutput");
   }
 }
 
@@ -149,7 +152,7 @@ export namespace GetConnectionOutput {
  * <p>Exceeded the maximum limit for connections.</p>
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -158,7 +161,7 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
@@ -185,7 +188,7 @@ export interface ListConnectionsInput {
 
 export namespace ListConnectionsInput {
   export function isa(o: any): o is ListConnectionsInput {
-    return _smithy.isa(o, "ListConnectionsInput");
+    return __isa(o, "ListConnectionsInput");
   }
 }
 
@@ -207,7 +210,7 @@ export interface ListConnectionsOutput extends $MetadataBearer {
 
 export namespace ListConnectionsOutput {
   export function isa(o: any): o is ListConnectionsOutput {
-    return _smithy.isa(o, "ListConnectionsOutput");
+    return __isa(o, "ListConnectionsOutput");
   }
 }
 
@@ -219,7 +222,7 @@ export enum ProviderType {
  * <p>Resource not found. Verify the connection resource ARN and try again.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -228,6 +231,6 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }

--- a/clients/client-codestar-notifications/models/index.ts
+++ b/clients/client-codestar-notifications/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -6,7 +9,7 @@ import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
  *       permissions.</p>
  */
 export interface AccessDeniedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AccessDeniedException";
   $fault: "client";
@@ -15,7 +18,7 @@ export interface AccessDeniedException
 
 export namespace AccessDeniedException {
   export function isa(o: any): o is AccessDeniedException {
-    return _smithy.isa(o, "AccessDeniedException");
+    return __isa(o, "AccessDeniedException");
   }
 }
 
@@ -24,7 +27,7 @@ export namespace AccessDeniedException {
  *       another process. Wait a few minutes and try again.</p>
  */
 export interface ConcurrentModificationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ConcurrentModificationException";
   $fault: "client";
@@ -33,7 +36,7 @@ export interface ConcurrentModificationException
 
 export namespace ConcurrentModificationException {
   export function isa(o: any): o is ConcurrentModificationException {
-    return _smithy.isa(o, "ConcurrentModificationException");
+    return __isa(o, "ConcurrentModificationException");
   }
 }
 
@@ -41,7 +44,7 @@ export namespace ConcurrentModificationException {
  * <p>Some or all of the configuration is incomplete, missing, or not valid.</p>
  */
 export interface ConfigurationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ConfigurationException";
   $fault: "client";
@@ -50,7 +53,7 @@ export interface ConfigurationException
 
 export namespace ConfigurationException {
   export function isa(o: any): o is ConfigurationException {
-    return _smithy.isa(o, "ConfigurationException");
+    return __isa(o, "ConfigurationException");
   }
 }
 
@@ -113,7 +116,7 @@ export interface CreateNotificationRuleRequest {
 
 export namespace CreateNotificationRuleRequest {
   export function isa(o: any): o is CreateNotificationRuleRequest {
-    return _smithy.isa(o, "CreateNotificationRuleRequest");
+    return __isa(o, "CreateNotificationRuleRequest");
   }
 }
 
@@ -127,7 +130,7 @@ export interface CreateNotificationRuleResult extends $MetadataBearer {
 
 export namespace CreateNotificationRuleResult {
   export function isa(o: any): o is CreateNotificationRuleResult {
-    return _smithy.isa(o, "CreateNotificationRuleResult");
+    return __isa(o, "CreateNotificationRuleResult");
   }
 }
 
@@ -141,7 +144,7 @@ export interface DeleteNotificationRuleRequest {
 
 export namespace DeleteNotificationRuleRequest {
   export function isa(o: any): o is DeleteNotificationRuleRequest {
-    return _smithy.isa(o, "DeleteNotificationRuleRequest");
+    return __isa(o, "DeleteNotificationRuleRequest");
   }
 }
 
@@ -155,7 +158,7 @@ export interface DeleteNotificationRuleResult extends $MetadataBearer {
 
 export namespace DeleteNotificationRuleResult {
   export function isa(o: any): o is DeleteNotificationRuleResult {
-    return _smithy.isa(o, "DeleteNotificationRuleResult");
+    return __isa(o, "DeleteNotificationRuleResult");
   }
 }
 
@@ -176,7 +179,7 @@ export interface DeleteTargetRequest {
 
 export namespace DeleteTargetRequest {
   export function isa(o: any): o is DeleteTargetRequest {
-    return _smithy.isa(o, "DeleteTargetRequest");
+    return __isa(o, "DeleteTargetRequest");
   }
 }
 
@@ -186,7 +189,7 @@ export interface DeleteTargetResult extends $MetadataBearer {
 
 export namespace DeleteTargetResult {
   export function isa(o: any): o is DeleteTargetResult {
-    return _smithy.isa(o, "DeleteTargetResult");
+    return __isa(o, "DeleteTargetResult");
   }
 }
 
@@ -200,7 +203,7 @@ export interface DescribeNotificationRuleRequest {
 
 export namespace DescribeNotificationRuleRequest {
   export function isa(o: any): o is DescribeNotificationRuleRequest {
-    return _smithy.isa(o, "DescribeNotificationRuleRequest");
+    return __isa(o, "DescribeNotificationRuleRequest");
   }
 }
 
@@ -269,7 +272,7 @@ export interface DescribeNotificationRuleResult extends $MetadataBearer {
 
 export namespace DescribeNotificationRuleResult {
   export function isa(o: any): o is DescribeNotificationRuleResult {
-    return _smithy.isa(o, "DescribeNotificationRuleResult");
+    return __isa(o, "DescribeNotificationRuleResult");
   }
 }
 
@@ -306,7 +309,7 @@ export interface EventTypeSummary {
 
 export namespace EventTypeSummary {
   export function isa(o: any): o is EventTypeSummary {
-    return _smithy.isa(o, "EventTypeSummary");
+    return __isa(o, "EventTypeSummary");
   }
 }
 
@@ -314,7 +317,7 @@ export namespace EventTypeSummary {
  * <p>The value for the enumeration token used in the request to return the next batch of the results is not valid. </p>
  */
 export interface InvalidNextTokenException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidNextTokenException";
   $fault: "client";
@@ -323,7 +326,7 @@ export interface InvalidNextTokenException
 
 export namespace InvalidNextTokenException {
   export function isa(o: any): o is InvalidNextTokenException {
-    return _smithy.isa(o, "InvalidNextTokenException");
+    return __isa(o, "InvalidNextTokenException");
   }
 }
 
@@ -333,7 +336,7 @@ export namespace InvalidNextTokenException {
  *             information, see Limits.</p>
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -342,7 +345,7 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
@@ -366,7 +369,7 @@ export interface ListEventTypesFilter {
 
 export namespace ListEventTypesFilter {
   export function isa(o: any): o is ListEventTypesFilter {
-    return _smithy.isa(o, "ListEventTypesFilter");
+    return __isa(o, "ListEventTypesFilter");
   }
 }
 
@@ -397,7 +400,7 @@ export interface ListEventTypesRequest {
 
 export namespace ListEventTypesRequest {
   export function isa(o: any): o is ListEventTypesRequest {
-    return _smithy.isa(o, "ListEventTypesRequest");
+    return __isa(o, "ListEventTypesRequest");
   }
 }
 
@@ -417,7 +420,7 @@ export interface ListEventTypesResult extends $MetadataBearer {
 
 export namespace ListEventTypesResult {
   export function isa(o: any): o is ListEventTypesResult {
-    return _smithy.isa(o, "ListEventTypesResult");
+    return __isa(o, "ListEventTypesResult");
   }
 }
 
@@ -441,7 +444,7 @@ export interface ListNotificationRulesFilter {
 
 export namespace ListNotificationRulesFilter {
   export function isa(o: any): o is ListNotificationRulesFilter {
-    return _smithy.isa(o, "ListNotificationRulesFilter");
+    return __isa(o, "ListNotificationRulesFilter");
   }
 }
 
@@ -478,7 +481,7 @@ export interface ListNotificationRulesRequest {
 
 export namespace ListNotificationRulesRequest {
   export function isa(o: any): o is ListNotificationRulesRequest {
-    return _smithy.isa(o, "ListNotificationRulesRequest");
+    return __isa(o, "ListNotificationRulesRequest");
   }
 }
 
@@ -497,7 +500,7 @@ export interface ListNotificationRulesResult extends $MetadataBearer {
 
 export namespace ListNotificationRulesResult {
   export function isa(o: any): o is ListNotificationRulesResult {
-    return _smithy.isa(o, "ListNotificationRulesResult");
+    return __isa(o, "ListNotificationRulesResult");
   }
 }
 
@@ -511,7 +514,7 @@ export interface ListTagsForResourceRequest {
 
 export namespace ListTagsForResourceRequest {
   export function isa(o: any): o is ListTagsForResourceRequest {
-    return _smithy.isa(o, "ListTagsForResourceRequest");
+    return __isa(o, "ListTagsForResourceRequest");
   }
 }
 
@@ -525,7 +528,7 @@ export interface ListTagsForResourceResult extends $MetadataBearer {
 
 export namespace ListTagsForResourceResult {
   export function isa(o: any): o is ListTagsForResourceResult {
-    return _smithy.isa(o, "ListTagsForResourceResult");
+    return __isa(o, "ListTagsForResourceResult");
   }
 }
 
@@ -553,7 +556,7 @@ export interface ListTargetsFilter {
 
 export namespace ListTargetsFilter {
   export function isa(o: any): o is ListTargetsFilter {
-    return _smithy.isa(o, "ListTargetsFilter");
+    return __isa(o, "ListTargetsFilter");
   }
 }
 
@@ -589,7 +592,7 @@ export interface ListTargetsRequest {
 
 export namespace ListTargetsRequest {
   export function isa(o: any): o is ListTargetsRequest {
-    return _smithy.isa(o, "ListTargetsRequest");
+    return __isa(o, "ListTargetsRequest");
   }
 }
 
@@ -609,7 +612,7 @@ export interface ListTargetsResult extends $MetadataBearer {
 
 export namespace ListTargetsResult {
   export function isa(o: any): o is ListTargetsResult {
-    return _smithy.isa(o, "ListTargetsResult");
+    return __isa(o, "ListTargetsResult");
   }
 }
 
@@ -636,7 +639,7 @@ export interface NotificationRuleSummary {
 
 export namespace NotificationRuleSummary {
   export function isa(o: any): o is NotificationRuleSummary {
-    return _smithy.isa(o, "NotificationRuleSummary");
+    return __isa(o, "NotificationRuleSummary");
   }
 }
 
@@ -645,7 +648,7 @@ export namespace NotificationRuleSummary {
  *             unique in your AWS account.</p>
  */
 export interface ResourceAlreadyExistsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceAlreadyExistsException";
   $fault: "client";
@@ -654,7 +657,7 @@ export interface ResourceAlreadyExistsException
 
 export namespace ResourceAlreadyExistsException {
   export function isa(o: any): o is ResourceAlreadyExistsException {
-    return _smithy.isa(o, "ResourceAlreadyExistsException");
+    return __isa(o, "ResourceAlreadyExistsException");
   }
 }
 
@@ -662,7 +665,7 @@ export namespace ResourceAlreadyExistsException {
  * <p>AWS CodeStar Notifications can't find a resource that matches the provided ARN. </p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -671,7 +674,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -696,7 +699,7 @@ export interface SubscribeRequest {
 
 export namespace SubscribeRequest {
   export function isa(o: any): o is SubscribeRequest {
-    return _smithy.isa(o, "SubscribeRequest");
+    return __isa(o, "SubscribeRequest");
   }
 }
 
@@ -710,7 +713,7 @@ export interface SubscribeResult extends $MetadataBearer {
 
 export namespace SubscribeResult {
   export function isa(o: any): o is SubscribeResult {
-    return _smithy.isa(o, "SubscribeResult");
+    return __isa(o, "SubscribeResult");
   }
 }
 
@@ -729,7 +732,7 @@ export interface TagResourceRequest {
 
 export namespace TagResourceRequest {
   export function isa(o: any): o is TagResourceRequest {
-    return _smithy.isa(o, "TagResourceRequest");
+    return __isa(o, "TagResourceRequest");
   }
 }
 
@@ -743,7 +746,7 @@ export interface TagResourceResult extends $MetadataBearer {
 
 export namespace TagResourceResult {
   export function isa(o: any): o is TagResourceResult {
-    return _smithy.isa(o, "TagResourceResult");
+    return __isa(o, "TagResourceResult");
   }
 }
 
@@ -765,7 +768,7 @@ export interface Target {
 
 export namespace Target {
   export function isa(o: any): o is Target {
-    return _smithy.isa(o, "Target");
+    return __isa(o, "Target");
   }
 }
 
@@ -800,7 +803,7 @@ export interface TargetSummary {
 
 export namespace TargetSummary {
   export function isa(o: any): o is TargetSummary {
-    return _smithy.isa(o, "TargetSummary");
+    return __isa(o, "TargetSummary");
   }
 }
 
@@ -819,7 +822,7 @@ export interface UnsubscribeRequest {
 
 export namespace UnsubscribeRequest {
   export function isa(o: any): o is UnsubscribeRequest {
-    return _smithy.isa(o, "UnsubscribeRequest");
+    return __isa(o, "UnsubscribeRequest");
   }
 }
 
@@ -833,7 +836,7 @@ export interface UnsubscribeResult extends $MetadataBearer {
 
 export namespace UnsubscribeResult {
   export function isa(o: any): o is UnsubscribeResult {
-    return _smithy.isa(o, "UnsubscribeResult");
+    return __isa(o, "UnsubscribeResult");
   }
 }
 
@@ -853,7 +856,7 @@ export interface UntagResourceRequest {
 
 export namespace UntagResourceRequest {
   export function isa(o: any): o is UntagResourceRequest {
-    return _smithy.isa(o, "UntagResourceRequest");
+    return __isa(o, "UntagResourceRequest");
   }
 }
 
@@ -863,7 +866,7 @@ export interface UntagResourceResult extends $MetadataBearer {
 
 export namespace UntagResourceResult {
   export function isa(o: any): o is UntagResourceResult {
-    return _smithy.isa(o, "UntagResourceResult");
+    return __isa(o, "UntagResourceResult");
   }
 }
 
@@ -906,7 +909,7 @@ export interface UpdateNotificationRuleRequest {
 
 export namespace UpdateNotificationRuleRequest {
   export function isa(o: any): o is UpdateNotificationRuleRequest {
-    return _smithy.isa(o, "UpdateNotificationRuleRequest");
+    return __isa(o, "UpdateNotificationRuleRequest");
   }
 }
 
@@ -916,7 +919,7 @@ export interface UpdateNotificationRuleResult extends $MetadataBearer {
 
 export namespace UpdateNotificationRuleResult {
   export function isa(o: any): o is UpdateNotificationRuleResult {
-    return _smithy.isa(o, "UpdateNotificationRuleResult");
+    return __isa(o, "UpdateNotificationRuleResult");
   }
 }
 
@@ -924,7 +927,7 @@ export namespace UpdateNotificationRuleResult {
  * <p>One or more parameter values are not valid.</p>
  */
 export interface ValidationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ValidationException";
   $fault: "client";
@@ -933,6 +936,6 @@ export interface ValidationException
 
 export namespace ValidationException {
   export function isa(o: any): o is ValidationException {
-    return _smithy.isa(o, "ValidationException");
+    return __isa(o, "ValidationException");
   }
 }

--- a/clients/client-codestar-notifications/protocols/Aws_restJson1_1.ts
+++ b/clients/client-codestar-notifications/protocols/Aws_restJson1_1.ts
@@ -655,6 +655,7 @@ export async function deserializeAws_restJson1_1DeleteTargetCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeleteTargetResult"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -1269,6 +1270,7 @@ export async function deserializeAws_restJson1_1UntagResourceCommand(
     $metadata: deserializeMetadata(output),
     __type: "UntagResourceResult"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -1334,6 +1336,7 @@ export async function deserializeAws_restJson1_1UpdateNotificationRuleCommand(
     $metadata: deserializeMetadata(output),
     __type: "UpdateNotificationRuleResult"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 

--- a/clients/client-codestar/models/index.ts
+++ b/clients/client-codestar/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export interface AssociateTeamMemberRequest {
@@ -35,7 +38,7 @@ export interface AssociateTeamMemberRequest {
 
 export namespace AssociateTeamMemberRequest {
   export function isa(o: any): o is AssociateTeamMemberRequest {
-    return _smithy.isa(o, "AssociateTeamMemberRequest");
+    return __isa(o, "AssociateTeamMemberRequest");
   }
 }
 
@@ -50,7 +53,7 @@ export interface AssociateTeamMemberResult extends $MetadataBearer {
 
 export namespace AssociateTeamMemberResult {
   export function isa(o: any): o is AssociateTeamMemberResult {
-    return _smithy.isa(o, "AssociateTeamMemberResult");
+    return __isa(o, "AssociateTeamMemberResult");
   }
 }
 
@@ -76,7 +79,7 @@ export interface Code {
 
 export namespace Code {
   export function isa(o: any): o is Code {
-    return _smithy.isa(o, "Code");
+    return __isa(o, "Code");
   }
 }
 
@@ -94,7 +97,7 @@ export interface CodeCommitCodeDestination {
 
 export namespace CodeCommitCodeDestination {
   export function isa(o: any): o is CodeCommitCodeDestination {
-    return _smithy.isa(o, "CodeCommitCodeDestination");
+    return __isa(o, "CodeCommitCodeDestination");
   }
 }
 
@@ -119,7 +122,7 @@ export interface CodeDestination {
 
 export namespace CodeDestination {
   export function isa(o: any): o is CodeDestination {
-    return _smithy.isa(o, "CodeDestination");
+    return __isa(o, "CodeDestination");
   }
 }
 
@@ -138,7 +141,7 @@ export interface CodeSource {
 
 export namespace CodeSource {
   export function isa(o: any): o is CodeSource {
-    return _smithy.isa(o, "CodeSource");
+    return __isa(o, "CodeSource");
   }
 }
 
@@ -147,7 +150,7 @@ export namespace CodeSource {
  *       your change.</p>
  */
 export interface ConcurrentModificationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ConcurrentModificationException";
   $fault: "server";
@@ -156,7 +159,7 @@ export interface ConcurrentModificationException
 
 export namespace ConcurrentModificationException {
   export function isa(o: any): o is ConcurrentModificationException {
-    return _smithy.isa(o, "ConcurrentModificationException");
+    return __isa(o, "ConcurrentModificationException");
   }
 }
 
@@ -203,7 +206,7 @@ export interface CreateProjectRequest {
 
 export namespace CreateProjectRequest {
   export function isa(o: any): o is CreateProjectRequest {
-    return _smithy.isa(o, "CreateProjectRequest");
+    return __isa(o, "CreateProjectRequest");
   }
 }
 
@@ -233,7 +236,7 @@ export interface CreateProjectResult extends $MetadataBearer {
 
 export namespace CreateProjectResult {
   export function isa(o: any): o is CreateProjectResult {
-    return _smithy.isa(o, "CreateProjectResult");
+    return __isa(o, "CreateProjectResult");
   }
 }
 
@@ -265,7 +268,7 @@ export interface CreateUserProfileRequest {
 
 export namespace CreateUserProfileRequest {
   export function isa(o: any): o is CreateUserProfileRequest {
-    return _smithy.isa(o, "CreateUserProfileRequest");
+    return __isa(o, "CreateUserProfileRequest");
   }
 }
 
@@ -306,7 +309,7 @@ export interface CreateUserProfileResult extends $MetadataBearer {
 
 export namespace CreateUserProfileResult {
   export function isa(o: any): o is CreateUserProfileResult {
-    return _smithy.isa(o, "CreateUserProfileResult");
+    return __isa(o, "CreateUserProfileResult");
   }
 }
 
@@ -334,7 +337,7 @@ export interface DeleteProjectRequest {
 
 export namespace DeleteProjectRequest {
   export function isa(o: any): o is DeleteProjectRequest {
-    return _smithy.isa(o, "DeleteProjectRequest");
+    return __isa(o, "DeleteProjectRequest");
   }
 }
 
@@ -354,7 +357,7 @@ export interface DeleteProjectResult extends $MetadataBearer {
 
 export namespace DeleteProjectResult {
   export function isa(o: any): o is DeleteProjectResult {
-    return _smithy.isa(o, "DeleteProjectResult");
+    return __isa(o, "DeleteProjectResult");
   }
 }
 
@@ -368,7 +371,7 @@ export interface DeleteUserProfileRequest {
 
 export namespace DeleteUserProfileRequest {
   export function isa(o: any): o is DeleteUserProfileRequest {
-    return _smithy.isa(o, "DeleteUserProfileRequest");
+    return __isa(o, "DeleteUserProfileRequest");
   }
 }
 
@@ -382,7 +385,7 @@ export interface DeleteUserProfileResult extends $MetadataBearer {
 
 export namespace DeleteUserProfileResult {
   export function isa(o: any): o is DeleteUserProfileResult {
-    return _smithy.isa(o, "DeleteUserProfileResult");
+    return __isa(o, "DeleteUserProfileResult");
   }
 }
 
@@ -396,7 +399,7 @@ export interface DescribeProjectRequest {
 
 export namespace DescribeProjectRequest {
   export function isa(o: any): o is DescribeProjectRequest {
-    return _smithy.isa(o, "DescribeProjectRequest");
+    return __isa(o, "DescribeProjectRequest");
   }
 }
 
@@ -452,7 +455,7 @@ export interface DescribeProjectResult extends $MetadataBearer {
 
 export namespace DescribeProjectResult {
   export function isa(o: any): o is DescribeProjectResult {
-    return _smithy.isa(o, "DescribeProjectResult");
+    return __isa(o, "DescribeProjectResult");
   }
 }
 
@@ -466,7 +469,7 @@ export interface DescribeUserProfileRequest {
 
 export namespace DescribeUserProfileRequest {
   export function isa(o: any): o is DescribeUserProfileRequest {
-    return _smithy.isa(o, "DescribeUserProfileRequest");
+    return __isa(o, "DescribeUserProfileRequest");
   }
 }
 
@@ -517,7 +520,7 @@ export interface DescribeUserProfileResult extends $MetadataBearer {
 
 export namespace DescribeUserProfileResult {
   export function isa(o: any): o is DescribeUserProfileResult {
-    return _smithy.isa(o, "DescribeUserProfileResult");
+    return __isa(o, "DescribeUserProfileResult");
   }
 }
 
@@ -537,7 +540,7 @@ export interface DisassociateTeamMemberRequest {
 
 export namespace DisassociateTeamMemberRequest {
   export function isa(o: any): o is DisassociateTeamMemberRequest {
-    return _smithy.isa(o, "DisassociateTeamMemberRequest");
+    return __isa(o, "DisassociateTeamMemberRequest");
   }
 }
 
@@ -547,7 +550,7 @@ export interface DisassociateTeamMemberResult extends $MetadataBearer {
 
 export namespace DisassociateTeamMemberResult {
   export function isa(o: any): o is DisassociateTeamMemberResult {
-    return _smithy.isa(o, "DisassociateTeamMemberResult");
+    return __isa(o, "DisassociateTeamMemberResult");
   }
 }
 
@@ -597,7 +600,7 @@ export interface GitHubCodeDestination {
 
 export namespace GitHubCodeDestination {
   export function isa(o: any): o is GitHubCodeDestination {
-    return _smithy.isa(o, "GitHubCodeDestination");
+    return __isa(o, "GitHubCodeDestination");
   }
 }
 
@@ -605,7 +608,7 @@ export namespace GitHubCodeDestination {
  * <p>The next token is not valid.</p>
  */
 export interface InvalidNextTokenException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidNextTokenException";
   $fault: "client";
@@ -614,7 +617,7 @@ export interface InvalidNextTokenException
 
 export namespace InvalidNextTokenException {
   export function isa(o: any): o is InvalidNextTokenException {
-    return _smithy.isa(o, "InvalidNextTokenException");
+    return __isa(o, "InvalidNextTokenException");
   }
 }
 
@@ -622,7 +625,7 @@ export namespace InvalidNextTokenException {
  * <p>The service role is not valid.</p>
  */
 export interface InvalidServiceRoleException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidServiceRoleException";
   $fault: "client";
@@ -631,7 +634,7 @@ export interface InvalidServiceRoleException
 
 export namespace InvalidServiceRoleException {
   export function isa(o: any): o is InvalidServiceRoleException {
-    return _smithy.isa(o, "InvalidServiceRoleException");
+    return __isa(o, "InvalidServiceRoleException");
   }
 }
 
@@ -639,7 +642,7 @@ export namespace InvalidServiceRoleException {
  * <p>A resource limit has been exceeded.</p>
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -648,7 +651,7 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
@@ -668,7 +671,7 @@ export interface ListProjectsRequest {
 
 export namespace ListProjectsRequest {
   export function isa(o: any): o is ListProjectsRequest {
-    return _smithy.isa(o, "ListProjectsRequest");
+    return __isa(o, "ListProjectsRequest");
   }
 }
 
@@ -688,7 +691,7 @@ export interface ListProjectsResult extends $MetadataBearer {
 
 export namespace ListProjectsResult {
   export function isa(o: any): o is ListProjectsResult {
-    return _smithy.isa(o, "ListProjectsResult");
+    return __isa(o, "ListProjectsResult");
   }
 }
 
@@ -713,7 +716,7 @@ export interface ListResourcesRequest {
 
 export namespace ListResourcesRequest {
   export function isa(o: any): o is ListResourcesRequest {
-    return _smithy.isa(o, "ListResourcesRequest");
+    return __isa(o, "ListResourcesRequest");
   }
 }
 
@@ -733,7 +736,7 @@ export interface ListResourcesResult extends $MetadataBearer {
 
 export namespace ListResourcesResult {
   export function isa(o: any): o is ListResourcesResult {
-    return _smithy.isa(o, "ListResourcesResult");
+    return __isa(o, "ListResourcesResult");
   }
 }
 
@@ -757,7 +760,7 @@ export interface ListTagsForProjectRequest {
 
 export namespace ListTagsForProjectRequest {
   export function isa(o: any): o is ListTagsForProjectRequest {
-    return _smithy.isa(o, "ListTagsForProjectRequest");
+    return __isa(o, "ListTagsForProjectRequest");
   }
 }
 
@@ -776,7 +779,7 @@ export interface ListTagsForProjectResult extends $MetadataBearer {
 
 export namespace ListTagsForProjectResult {
   export function isa(o: any): o is ListTagsForProjectResult {
-    return _smithy.isa(o, "ListTagsForProjectResult");
+    return __isa(o, "ListTagsForProjectResult");
   }
 }
 
@@ -801,7 +804,7 @@ export interface ListTeamMembersRequest {
 
 export namespace ListTeamMembersRequest {
   export function isa(o: any): o is ListTeamMembersRequest {
-    return _smithy.isa(o, "ListTeamMembersRequest");
+    return __isa(o, "ListTeamMembersRequest");
   }
 }
 
@@ -821,7 +824,7 @@ export interface ListTeamMembersResult extends $MetadataBearer {
 
 export namespace ListTeamMembersResult {
   export function isa(o: any): o is ListTeamMembersResult {
-    return _smithy.isa(o, "ListTeamMembersResult");
+    return __isa(o, "ListTeamMembersResult");
   }
 }
 
@@ -841,7 +844,7 @@ export interface ListUserProfilesRequest {
 
 export namespace ListUserProfilesRequest {
   export function isa(o: any): o is ListUserProfilesRequest {
-    return _smithy.isa(o, "ListUserProfilesRequest");
+    return __isa(o, "ListUserProfilesRequest");
   }
 }
 
@@ -861,7 +864,7 @@ export interface ListUserProfilesResult extends $MetadataBearer {
 
 export namespace ListUserProfilesResult {
   export function isa(o: any): o is ListUserProfilesResult {
-    return _smithy.isa(o, "ListUserProfilesResult");
+    return __isa(o, "ListUserProfilesResult");
   }
 }
 
@@ -870,7 +873,7 @@ export namespace ListUserProfilesResult {
  *       AWS CodeStar project IDs must be unique within a region for the AWS account.</p>
  */
 export interface ProjectAlreadyExistsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ProjectAlreadyExistsException";
   $fault: "client";
@@ -879,7 +882,7 @@ export interface ProjectAlreadyExistsException
 
 export namespace ProjectAlreadyExistsException {
   export function isa(o: any): o is ProjectAlreadyExistsException {
-    return _smithy.isa(o, "ProjectAlreadyExistsException");
+    return __isa(o, "ProjectAlreadyExistsException");
   }
 }
 
@@ -887,7 +890,7 @@ export namespace ProjectAlreadyExistsException {
  * <p>Project configuration information is required but not specified.</p>
  */
 export interface ProjectConfigurationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ProjectConfigurationException";
   $fault: "client";
@@ -896,7 +899,7 @@ export interface ProjectConfigurationException
 
 export namespace ProjectConfigurationException {
   export function isa(o: any): o is ProjectConfigurationException {
-    return _smithy.isa(o, "ProjectConfigurationException");
+    return __isa(o, "ProjectConfigurationException");
   }
 }
 
@@ -905,7 +908,7 @@ export namespace ProjectConfigurationException {
  *       during project creation. The project could not be created in AWS CodeStar.</p>
  */
 export interface ProjectCreationFailedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ProjectCreationFailedException";
   $fault: "client";
@@ -914,7 +917,7 @@ export interface ProjectCreationFailedException
 
 export namespace ProjectCreationFailedException {
   export function isa(o: any): o is ProjectCreationFailedException {
-    return _smithy.isa(o, "ProjectCreationFailedException");
+    return __isa(o, "ProjectCreationFailedException");
   }
 }
 
@@ -922,7 +925,7 @@ export namespace ProjectCreationFailedException {
  * <p>The specified AWS CodeStar project was not found.</p>
  */
 export interface ProjectNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ProjectNotFoundException";
   $fault: "client";
@@ -931,7 +934,7 @@ export interface ProjectNotFoundException
 
 export namespace ProjectNotFoundException {
   export function isa(o: any): o is ProjectNotFoundException {
-    return _smithy.isa(o, "ProjectNotFoundException");
+    return __isa(o, "ProjectNotFoundException");
   }
 }
 
@@ -955,7 +958,7 @@ export interface ProjectStatus {
 
 export namespace ProjectStatus {
   export function isa(o: any): o is ProjectStatus {
-    return _smithy.isa(o, "ProjectStatus");
+    return __isa(o, "ProjectStatus");
   }
 }
 
@@ -977,7 +980,7 @@ export interface ProjectSummary {
 
 export namespace ProjectSummary {
   export function isa(o: any): o is ProjectSummary {
-    return _smithy.isa(o, "ProjectSummary");
+    return __isa(o, "ProjectSummary");
   }
 }
 
@@ -994,7 +997,7 @@ export interface Resource {
 
 export namespace Resource {
   export function isa(o: any): o is Resource {
-    return _smithy.isa(o, "Resource");
+    return __isa(o, "Resource");
   }
 }
 
@@ -1019,7 +1022,7 @@ export interface S3Location {
 
 export namespace S3Location {
   export function isa(o: any): o is S3Location {
-    return _smithy.isa(o, "S3Location");
+    return __isa(o, "S3Location");
   }
 }
 
@@ -1038,7 +1041,7 @@ export interface TagProjectRequest {
 
 export namespace TagProjectRequest {
   export function isa(o: any): o is TagProjectRequest {
-    return _smithy.isa(o, "TagProjectRequest");
+    return __isa(o, "TagProjectRequest");
   }
 }
 
@@ -1052,7 +1055,7 @@ export interface TagProjectResult extends $MetadataBearer {
 
 export namespace TagProjectResult {
   export function isa(o: any): o is TagProjectResult {
-    return _smithy.isa(o, "TagProjectResult");
+    return __isa(o, "TagProjectResult");
   }
 }
 
@@ -1082,7 +1085,7 @@ export interface TeamMember {
 
 export namespace TeamMember {
   export function isa(o: any): o is TeamMember {
-    return _smithy.isa(o, "TeamMember");
+    return __isa(o, "TeamMember");
   }
 }
 
@@ -1090,7 +1093,7 @@ export namespace TeamMember {
  * <p>The team member is already associated with a role in this project.</p>
  */
 export interface TeamMemberAlreadyAssociatedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TeamMemberAlreadyAssociatedException";
   $fault: "client";
@@ -1099,7 +1102,7 @@ export interface TeamMemberAlreadyAssociatedException
 
 export namespace TeamMemberAlreadyAssociatedException {
   export function isa(o: any): o is TeamMemberAlreadyAssociatedException {
-    return _smithy.isa(o, "TeamMemberAlreadyAssociatedException");
+    return __isa(o, "TeamMemberAlreadyAssociatedException");
   }
 }
 
@@ -1107,7 +1110,7 @@ export namespace TeamMemberAlreadyAssociatedException {
  * <p>The specified team member was not found.</p>
  */
 export interface TeamMemberNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TeamMemberNotFoundException";
   $fault: "client";
@@ -1116,7 +1119,7 @@ export interface TeamMemberNotFoundException
 
 export namespace TeamMemberNotFoundException {
   export function isa(o: any): o is TeamMemberNotFoundException {
-    return _smithy.isa(o, "TeamMemberNotFoundException");
+    return __isa(o, "TeamMemberNotFoundException");
   }
 }
 
@@ -1147,7 +1150,7 @@ export interface Toolchain {
 
 export namespace Toolchain {
   export function isa(o: any): o is Toolchain {
-    return _smithy.isa(o, "Toolchain");
+    return __isa(o, "Toolchain");
   }
 }
 
@@ -1166,7 +1169,7 @@ export interface ToolchainSource {
 
 export namespace ToolchainSource {
   export function isa(o: any): o is ToolchainSource {
-    return _smithy.isa(o, "ToolchainSource");
+    return __isa(o, "ToolchainSource");
   }
 }
 
@@ -1185,7 +1188,7 @@ export interface UntagProjectRequest {
 
 export namespace UntagProjectRequest {
   export function isa(o: any): o is UntagProjectRequest {
-    return _smithy.isa(o, "UntagProjectRequest");
+    return __isa(o, "UntagProjectRequest");
   }
 }
 
@@ -1195,7 +1198,7 @@ export interface UntagProjectResult extends $MetadataBearer {
 
 export namespace UntagProjectResult {
   export function isa(o: any): o is UntagProjectResult {
-    return _smithy.isa(o, "UntagProjectResult");
+    return __isa(o, "UntagProjectResult");
   }
 }
 
@@ -1219,7 +1222,7 @@ export interface UpdateProjectRequest {
 
 export namespace UpdateProjectRequest {
   export function isa(o: any): o is UpdateProjectRequest {
-    return _smithy.isa(o, "UpdateProjectRequest");
+    return __isa(o, "UpdateProjectRequest");
   }
 }
 
@@ -1229,7 +1232,7 @@ export interface UpdateProjectResult extends $MetadataBearer {
 
 export namespace UpdateProjectResult {
   export function isa(o: any): o is UpdateProjectResult {
-    return _smithy.isa(o, "UpdateProjectResult");
+    return __isa(o, "UpdateProjectResult");
   }
 }
 
@@ -1263,7 +1266,7 @@ export interface UpdateTeamMemberRequest {
 
 export namespace UpdateTeamMemberRequest {
   export function isa(o: any): o is UpdateTeamMemberRequest {
-    return _smithy.isa(o, "UpdateTeamMemberRequest");
+    return __isa(o, "UpdateTeamMemberRequest");
   }
 }
 
@@ -1289,7 +1292,7 @@ export interface UpdateTeamMemberResult extends $MetadataBearer {
 
 export namespace UpdateTeamMemberResult {
   export function isa(o: any): o is UpdateTeamMemberResult {
-    return _smithy.isa(o, "UpdateTeamMemberResult");
+    return __isa(o, "UpdateTeamMemberResult");
   }
 }
 
@@ -1322,7 +1325,7 @@ export interface UpdateUserProfileRequest {
 
 export namespace UpdateUserProfileRequest {
   export function isa(o: any): o is UpdateUserProfileRequest {
-    return _smithy.isa(o, "UpdateUserProfileRequest");
+    return __isa(o, "UpdateUserProfileRequest");
   }
 }
 
@@ -1364,7 +1367,7 @@ export interface UpdateUserProfileResult extends $MetadataBearer {
 
 export namespace UpdateUserProfileResult {
   export function isa(o: any): o is UpdateUserProfileResult {
-    return _smithy.isa(o, "UpdateUserProfileResult");
+    return __isa(o, "UpdateUserProfileResult");
   }
 }
 
@@ -1373,7 +1376,7 @@ export namespace UpdateUserProfileResult {
  *       CodeStar user profile names must be unique within a region for the AWS account. </p>
  */
 export interface UserProfileAlreadyExistsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UserProfileAlreadyExistsException";
   $fault: "client";
@@ -1382,7 +1385,7 @@ export interface UserProfileAlreadyExistsException
 
 export namespace UserProfileAlreadyExistsException {
   export function isa(o: any): o is UserProfileAlreadyExistsException {
-    return _smithy.isa(o, "UserProfileAlreadyExistsException");
+    return __isa(o, "UserProfileAlreadyExistsException");
   }
 }
 
@@ -1390,7 +1393,7 @@ export namespace UserProfileAlreadyExistsException {
  * <p>The user profile was not found.</p>
  */
 export interface UserProfileNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UserProfileNotFoundException";
   $fault: "client";
@@ -1399,7 +1402,7 @@ export interface UserProfileNotFoundException
 
 export namespace UserProfileNotFoundException {
   export function isa(o: any): o is UserProfileNotFoundException {
-    return _smithy.isa(o, "UserProfileNotFoundException");
+    return __isa(o, "UserProfileNotFoundException");
   }
 }
 
@@ -1440,7 +1443,7 @@ export interface UserProfileSummary {
 
 export namespace UserProfileSummary {
   export function isa(o: any): o is UserProfileSummary {
-    return _smithy.isa(o, "UserProfileSummary");
+    return __isa(o, "UserProfileSummary");
   }
 }
 
@@ -1448,7 +1451,7 @@ export namespace UserProfileSummary {
  * <p>The specified input is either not valid, or it could not be validated.</p>
  */
 export interface ValidationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ValidationException";
   $fault: "client";
@@ -1457,6 +1460,6 @@ export interface ValidationException
 
 export namespace ValidationException {
   export function isa(o: any): o is ValidationException {
-    return _smithy.isa(o, "ValidationException");
+    return __isa(o, "ValidationException");
   }
 }

--- a/clients/client-cognito-identity-provider/models/index.ts
+++ b/clients/client-cognito-identity-provider/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -14,7 +17,7 @@ export interface AccountRecoverySettingType {
 
 export namespace AccountRecoverySettingType {
   export function isa(o: any): o is AccountRecoverySettingType {
-    return _smithy.isa(o, "AccountRecoverySettingType");
+    return __isa(o, "AccountRecoverySettingType");
   }
 }
 
@@ -56,7 +59,7 @@ export interface AccountTakeoverActionType {
 
 export namespace AccountTakeoverActionType {
   export function isa(o: any): o is AccountTakeoverActionType {
-    return _smithy.isa(o, "AccountTakeoverActionType");
+    return __isa(o, "AccountTakeoverActionType");
   }
 }
 
@@ -83,7 +86,7 @@ export interface AccountTakeoverActionsType {
 
 export namespace AccountTakeoverActionsType {
   export function isa(o: any): o is AccountTakeoverActionsType {
-    return _smithy.isa(o, "AccountTakeoverActionsType");
+    return __isa(o, "AccountTakeoverActionsType");
   }
 }
 
@@ -113,7 +116,7 @@ export interface AccountTakeoverRiskConfigurationType {
 
 export namespace AccountTakeoverRiskConfigurationType {
   export function isa(o: any): o is AccountTakeoverRiskConfigurationType {
-    return _smithy.isa(o, "AccountTakeoverRiskConfigurationType");
+    return __isa(o, "AccountTakeoverRiskConfigurationType");
   }
 }
 
@@ -135,7 +138,7 @@ export interface AddCustomAttributesRequest {
 
 export namespace AddCustomAttributesRequest {
   export function isa(o: any): o is AddCustomAttributesRequest {
-    return _smithy.isa(o, "AddCustomAttributesRequest");
+    return __isa(o, "AddCustomAttributesRequest");
   }
 }
 
@@ -149,7 +152,7 @@ export interface AddCustomAttributesResponse extends $MetadataBearer {
 
 export namespace AddCustomAttributesResponse {
   export function isa(o: any): o is AddCustomAttributesResponse {
-    return _smithy.isa(o, "AddCustomAttributesResponse");
+    return __isa(o, "AddCustomAttributesResponse");
   }
 }
 
@@ -173,7 +176,7 @@ export interface AdminAddUserToGroupRequest {
 
 export namespace AdminAddUserToGroupRequest {
   export function isa(o: any): o is AdminAddUserToGroupRequest {
-    return _smithy.isa(o, "AdminAddUserToGroupRequest");
+    return __isa(o, "AdminAddUserToGroupRequest");
   }
 }
 
@@ -230,7 +233,7 @@ export interface AdminConfirmSignUpRequest {
 
 export namespace AdminConfirmSignUpRequest {
   export function isa(o: any): o is AdminConfirmSignUpRequest {
-    return _smithy.isa(o, "AdminConfirmSignUpRequest");
+    return __isa(o, "AdminConfirmSignUpRequest");
   }
 }
 
@@ -244,7 +247,7 @@ export interface AdminConfirmSignUpResponse extends $MetadataBearer {
 
 export namespace AdminConfirmSignUpResponse {
   export function isa(o: any): o is AdminConfirmSignUpResponse {
-    return _smithy.isa(o, "AdminConfirmSignUpResponse");
+    return __isa(o, "AdminConfirmSignUpResponse");
   }
 }
 
@@ -282,7 +285,7 @@ export interface AdminCreateUserConfigType {
 
 export namespace AdminCreateUserConfigType {
   export function isa(o: any): o is AdminCreateUserConfigType {
-    return _smithy.isa(o, "AdminCreateUserConfigType");
+    return __isa(o, "AdminCreateUserConfigType");
   }
 }
 
@@ -435,7 +438,7 @@ export interface AdminCreateUserRequest {
 
 export namespace AdminCreateUserRequest {
   export function isa(o: any): o is AdminCreateUserRequest {
-    return _smithy.isa(o, "AdminCreateUserRequest");
+    return __isa(o, "AdminCreateUserRequest");
   }
 }
 
@@ -452,7 +455,7 @@ export interface AdminCreateUserResponse extends $MetadataBearer {
 
 export namespace AdminCreateUserResponse {
   export function isa(o: any): o is AdminCreateUserResponse {
-    return _smithy.isa(o, "AdminCreateUserResponse");
+    return __isa(o, "AdminCreateUserResponse");
   }
 }
 
@@ -481,7 +484,7 @@ export interface AdminDeleteUserAttributesRequest {
 
 export namespace AdminDeleteUserAttributesRequest {
   export function isa(o: any): o is AdminDeleteUserAttributesRequest {
-    return _smithy.isa(o, "AdminDeleteUserAttributesRequest");
+    return __isa(o, "AdminDeleteUserAttributesRequest");
   }
 }
 
@@ -495,7 +498,7 @@ export interface AdminDeleteUserAttributesResponse extends $MetadataBearer {
 
 export namespace AdminDeleteUserAttributesResponse {
   export function isa(o: any): o is AdminDeleteUserAttributesResponse {
-    return _smithy.isa(o, "AdminDeleteUserAttributesResponse");
+    return __isa(o, "AdminDeleteUserAttributesResponse");
   }
 }
 
@@ -517,7 +520,7 @@ export interface AdminDeleteUserRequest {
 
 export namespace AdminDeleteUserRequest {
   export function isa(o: any): o is AdminDeleteUserRequest {
-    return _smithy.isa(o, "AdminDeleteUserRequest");
+    return __isa(o, "AdminDeleteUserRequest");
   }
 }
 
@@ -536,7 +539,7 @@ export interface AdminDisableProviderForUserRequest {
 
 export namespace AdminDisableProviderForUserRequest {
   export function isa(o: any): o is AdminDisableProviderForUserRequest {
-    return _smithy.isa(o, "AdminDisableProviderForUserRequest");
+    return __isa(o, "AdminDisableProviderForUserRequest");
   }
 }
 
@@ -546,7 +549,7 @@ export interface AdminDisableProviderForUserResponse extends $MetadataBearer {
 
 export namespace AdminDisableProviderForUserResponse {
   export function isa(o: any): o is AdminDisableProviderForUserResponse {
-    return _smithy.isa(o, "AdminDisableProviderForUserResponse");
+    return __isa(o, "AdminDisableProviderForUserResponse");
   }
 }
 
@@ -568,7 +571,7 @@ export interface AdminDisableUserRequest {
 
 export namespace AdminDisableUserRequest {
   export function isa(o: any): o is AdminDisableUserRequest {
-    return _smithy.isa(o, "AdminDisableUserRequest");
+    return __isa(o, "AdminDisableUserRequest");
   }
 }
 
@@ -582,7 +585,7 @@ export interface AdminDisableUserResponse extends $MetadataBearer {
 
 export namespace AdminDisableUserResponse {
   export function isa(o: any): o is AdminDisableUserResponse {
-    return _smithy.isa(o, "AdminDisableUserResponse");
+    return __isa(o, "AdminDisableUserResponse");
   }
 }
 
@@ -604,7 +607,7 @@ export interface AdminEnableUserRequest {
 
 export namespace AdminEnableUserRequest {
   export function isa(o: any): o is AdminEnableUserRequest {
-    return _smithy.isa(o, "AdminEnableUserRequest");
+    return __isa(o, "AdminEnableUserRequest");
   }
 }
 
@@ -618,7 +621,7 @@ export interface AdminEnableUserResponse extends $MetadataBearer {
 
 export namespace AdminEnableUserResponse {
   export function isa(o: any): o is AdminEnableUserResponse {
-    return _smithy.isa(o, "AdminEnableUserResponse");
+    return __isa(o, "AdminEnableUserResponse");
   }
 }
 
@@ -645,7 +648,7 @@ export interface AdminForgetDeviceRequest {
 
 export namespace AdminForgetDeviceRequest {
   export function isa(o: any): o is AdminForgetDeviceRequest {
-    return _smithy.isa(o, "AdminForgetDeviceRequest");
+    return __isa(o, "AdminForgetDeviceRequest");
   }
 }
 
@@ -672,7 +675,7 @@ export interface AdminGetDeviceRequest {
 
 export namespace AdminGetDeviceRequest {
   export function isa(o: any): o is AdminGetDeviceRequest {
-    return _smithy.isa(o, "AdminGetDeviceRequest");
+    return __isa(o, "AdminGetDeviceRequest");
   }
 }
 
@@ -689,7 +692,7 @@ export interface AdminGetDeviceResponse extends $MetadataBearer {
 
 export namespace AdminGetDeviceResponse {
   export function isa(o: any): o is AdminGetDeviceResponse {
-    return _smithy.isa(o, "AdminGetDeviceResponse");
+    return __isa(o, "AdminGetDeviceResponse");
   }
 }
 
@@ -712,7 +715,7 @@ export interface AdminGetUserRequest {
 
 export namespace AdminGetUserRequest {
   export function isa(o: any): o is AdminGetUserRequest {
-    return _smithy.isa(o, "AdminGetUserRequest");
+    return __isa(o, "AdminGetUserRequest");
   }
 }
 
@@ -802,7 +805,7 @@ export interface AdminGetUserResponse extends $MetadataBearer {
 
 export namespace AdminGetUserResponse {
   export function isa(o: any): o is AdminGetUserResponse {
-    return _smithy.isa(o, "AdminGetUserResponse");
+    return __isa(o, "AdminGetUserResponse");
   }
 }
 
@@ -1002,7 +1005,7 @@ export interface AdminInitiateAuthRequest {
 
 export namespace AdminInitiateAuthRequest {
   export function isa(o: any): o is AdminInitiateAuthRequest {
-    return _smithy.isa(o, "AdminInitiateAuthRequest");
+    return __isa(o, "AdminInitiateAuthRequest");
   }
 }
 
@@ -1109,7 +1112,7 @@ export interface AdminInitiateAuthResponse extends $MetadataBearer {
 
 export namespace AdminInitiateAuthResponse {
   export function isa(o: any): o is AdminInitiateAuthResponse {
-    return _smithy.isa(o, "AdminInitiateAuthResponse");
+    return __isa(o, "AdminInitiateAuthResponse");
   }
 }
 
@@ -1163,7 +1166,7 @@ export interface AdminLinkProviderForUserRequest {
 
 export namespace AdminLinkProviderForUserRequest {
   export function isa(o: any): o is AdminLinkProviderForUserRequest {
-    return _smithy.isa(o, "AdminLinkProviderForUserRequest");
+    return __isa(o, "AdminLinkProviderForUserRequest");
   }
 }
 
@@ -1173,7 +1176,7 @@ export interface AdminLinkProviderForUserResponse extends $MetadataBearer {
 
 export namespace AdminLinkProviderForUserResponse {
   export function isa(o: any): o is AdminLinkProviderForUserResponse {
-    return _smithy.isa(o, "AdminLinkProviderForUserResponse");
+    return __isa(o, "AdminLinkProviderForUserResponse");
   }
 }
 
@@ -1205,7 +1208,7 @@ export interface AdminListDevicesRequest {
 
 export namespace AdminListDevicesRequest {
   export function isa(o: any): o is AdminListDevicesRequest {
-    return _smithy.isa(o, "AdminListDevicesRequest");
+    return __isa(o, "AdminListDevicesRequest");
   }
 }
 
@@ -1227,7 +1230,7 @@ export interface AdminListDevicesResponse extends $MetadataBearer {
 
 export namespace AdminListDevicesResponse {
   export function isa(o: any): o is AdminListDevicesResponse {
-    return _smithy.isa(o, "AdminListDevicesResponse");
+    return __isa(o, "AdminListDevicesResponse");
   }
 }
 
@@ -1257,7 +1260,7 @@ export interface AdminListGroupsForUserRequest {
 
 export namespace AdminListGroupsForUserRequest {
   export function isa(o: any): o is AdminListGroupsForUserRequest {
-    return _smithy.isa(o, "AdminListGroupsForUserRequest");
+    return __isa(o, "AdminListGroupsForUserRequest");
   }
 }
 
@@ -1277,7 +1280,7 @@ export interface AdminListGroupsForUserResponse extends $MetadataBearer {
 
 export namespace AdminListGroupsForUserResponse {
   export function isa(o: any): o is AdminListGroupsForUserResponse {
-    return _smithy.isa(o, "AdminListGroupsForUserResponse");
+    return __isa(o, "AdminListGroupsForUserResponse");
   }
 }
 
@@ -1306,7 +1309,7 @@ export interface AdminListUserAuthEventsRequest {
 
 export namespace AdminListUserAuthEventsRequest {
   export function isa(o: any): o is AdminListUserAuthEventsRequest {
-    return _smithy.isa(o, "AdminListUserAuthEventsRequest");
+    return __isa(o, "AdminListUserAuthEventsRequest");
   }
 }
 
@@ -1327,7 +1330,7 @@ export interface AdminListUserAuthEventsResponse extends $MetadataBearer {
 
 export namespace AdminListUserAuthEventsResponse {
   export function isa(o: any): o is AdminListUserAuthEventsResponse {
-    return _smithy.isa(o, "AdminListUserAuthEventsResponse");
+    return __isa(o, "AdminListUserAuthEventsResponse");
   }
 }
 
@@ -1351,7 +1354,7 @@ export interface AdminRemoveUserFromGroupRequest {
 
 export namespace AdminRemoveUserFromGroupRequest {
   export function isa(o: any): o is AdminRemoveUserFromGroupRequest {
-    return _smithy.isa(o, "AdminRemoveUserFromGroupRequest");
+    return __isa(o, "AdminRemoveUserFromGroupRequest");
   }
 }
 
@@ -1409,7 +1412,7 @@ export interface AdminResetUserPasswordRequest {
 
 export namespace AdminResetUserPasswordRequest {
   export function isa(o: any): o is AdminResetUserPasswordRequest {
-    return _smithy.isa(o, "AdminResetUserPasswordRequest");
+    return __isa(o, "AdminResetUserPasswordRequest");
   }
 }
 
@@ -1423,7 +1426,7 @@ export interface AdminResetUserPasswordResponse extends $MetadataBearer {
 
 export namespace AdminResetUserPasswordResponse {
   export function isa(o: any): o is AdminResetUserPasswordResponse {
-    return _smithy.isa(o, "AdminResetUserPasswordResponse");
+    return __isa(o, "AdminResetUserPasswordResponse");
   }
 }
 
@@ -1550,7 +1553,7 @@ export interface AdminRespondToAuthChallengeRequest {
 
 export namespace AdminRespondToAuthChallengeRequest {
   export function isa(o: any): o is AdminRespondToAuthChallengeRequest {
-    return _smithy.isa(o, "AdminRespondToAuthChallengeRequest");
+    return __isa(o, "AdminRespondToAuthChallengeRequest");
   }
 }
 
@@ -1586,7 +1589,7 @@ export interface AdminRespondToAuthChallengeResponse extends $MetadataBearer {
 
 export namespace AdminRespondToAuthChallengeResponse {
   export function isa(o: any): o is AdminRespondToAuthChallengeResponse {
-    return _smithy.isa(o, "AdminRespondToAuthChallengeResponse");
+    return __isa(o, "AdminRespondToAuthChallengeResponse");
   }
 }
 
@@ -1615,7 +1618,7 @@ export interface AdminSetUserMFAPreferenceRequest {
 
 export namespace AdminSetUserMFAPreferenceRequest {
   export function isa(o: any): o is AdminSetUserMFAPreferenceRequest {
-    return _smithy.isa(o, "AdminSetUserMFAPreferenceRequest");
+    return __isa(o, "AdminSetUserMFAPreferenceRequest");
   }
 }
 
@@ -1625,7 +1628,7 @@ export interface AdminSetUserMFAPreferenceResponse extends $MetadataBearer {
 
 export namespace AdminSetUserMFAPreferenceResponse {
   export function isa(o: any): o is AdminSetUserMFAPreferenceResponse {
-    return _smithy.isa(o, "AdminSetUserMFAPreferenceResponse");
+    return __isa(o, "AdminSetUserMFAPreferenceResponse");
   }
 }
 
@@ -1656,7 +1659,7 @@ export interface AdminSetUserPasswordRequest {
 
 export namespace AdminSetUserPasswordRequest {
   export function isa(o: any): o is AdminSetUserPasswordRequest {
-    return _smithy.isa(o, "AdminSetUserPasswordRequest");
+    return __isa(o, "AdminSetUserPasswordRequest");
   }
 }
 
@@ -1666,7 +1669,7 @@ export interface AdminSetUserPasswordResponse extends $MetadataBearer {
 
 export namespace AdminSetUserPasswordResponse {
   export function isa(o: any): o is AdminSetUserPasswordResponse {
-    return _smithy.isa(o, "AdminSetUserPasswordResponse");
+    return __isa(o, "AdminSetUserPasswordResponse");
   }
 }
 
@@ -1696,7 +1699,7 @@ export interface AdminSetUserSettingsRequest {
 
 export namespace AdminSetUserSettingsRequest {
   export function isa(o: any): o is AdminSetUserSettingsRequest {
-    return _smithy.isa(o, "AdminSetUserSettingsRequest");
+    return __isa(o, "AdminSetUserSettingsRequest");
   }
 }
 
@@ -1710,7 +1713,7 @@ export interface AdminSetUserSettingsResponse extends $MetadataBearer {
 
 export namespace AdminSetUserSettingsResponse {
   export function isa(o: any): o is AdminSetUserSettingsResponse {
-    return _smithy.isa(o, "AdminSetUserSettingsResponse");
+    return __isa(o, "AdminSetUserSettingsResponse");
   }
 }
 
@@ -1739,7 +1742,7 @@ export interface AdminUpdateAuthEventFeedbackRequest {
 
 export namespace AdminUpdateAuthEventFeedbackRequest {
   export function isa(o: any): o is AdminUpdateAuthEventFeedbackRequest {
-    return _smithy.isa(o, "AdminUpdateAuthEventFeedbackRequest");
+    return __isa(o, "AdminUpdateAuthEventFeedbackRequest");
   }
 }
 
@@ -1749,7 +1752,7 @@ export interface AdminUpdateAuthEventFeedbackResponse extends $MetadataBearer {
 
 export namespace AdminUpdateAuthEventFeedbackResponse {
   export function isa(o: any): o is AdminUpdateAuthEventFeedbackResponse {
-    return _smithy.isa(o, "AdminUpdateAuthEventFeedbackResponse");
+    return __isa(o, "AdminUpdateAuthEventFeedbackResponse");
   }
 }
 
@@ -1781,7 +1784,7 @@ export interface AdminUpdateDeviceStatusRequest {
 
 export namespace AdminUpdateDeviceStatusRequest {
   export function isa(o: any): o is AdminUpdateDeviceStatusRequest {
-    return _smithy.isa(o, "AdminUpdateDeviceStatusRequest");
+    return __isa(o, "AdminUpdateDeviceStatusRequest");
   }
 }
 
@@ -1794,7 +1797,7 @@ export interface AdminUpdateDeviceStatusResponse extends $MetadataBearer {
 
 export namespace AdminUpdateDeviceStatusResponse {
   export function isa(o: any): o is AdminUpdateDeviceStatusResponse {
-    return _smithy.isa(o, "AdminUpdateDeviceStatusResponse");
+    return __isa(o, "AdminUpdateDeviceStatusResponse");
   }
 }
 
@@ -1859,7 +1862,7 @@ export interface AdminUpdateUserAttributesRequest {
 
 export namespace AdminUpdateUserAttributesRequest {
   export function isa(o: any): o is AdminUpdateUserAttributesRequest {
-    return _smithy.isa(o, "AdminUpdateUserAttributesRequest");
+    return __isa(o, "AdminUpdateUserAttributesRequest");
   }
 }
 
@@ -1873,7 +1876,7 @@ export interface AdminUpdateUserAttributesResponse extends $MetadataBearer {
 
 export namespace AdminUpdateUserAttributesResponse {
   export function isa(o: any): o is AdminUpdateUserAttributesResponse {
-    return _smithy.isa(o, "AdminUpdateUserAttributesResponse");
+    return __isa(o, "AdminUpdateUserAttributesResponse");
   }
 }
 
@@ -1895,7 +1898,7 @@ export interface AdminUserGlobalSignOutRequest {
 
 export namespace AdminUserGlobalSignOutRequest {
   export function isa(o: any): o is AdminUserGlobalSignOutRequest {
-    return _smithy.isa(o, "AdminUserGlobalSignOutRequest");
+    return __isa(o, "AdminUserGlobalSignOutRequest");
   }
 }
 
@@ -1908,7 +1911,7 @@ export interface AdminUserGlobalSignOutResponse extends $MetadataBearer {
 
 export namespace AdminUserGlobalSignOutResponse {
   export function isa(o: any): o is AdminUserGlobalSignOutResponse {
-    return _smithy.isa(o, "AdminUserGlobalSignOutResponse");
+    return __isa(o, "AdminUserGlobalSignOutResponse");
   }
 }
 
@@ -1930,7 +1933,7 @@ export enum AliasAttributeType {
  *             exception tells user that an account with this email or phone already exists.</p>
  */
 export interface AliasExistsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AliasExistsException";
   $fault: "client";
@@ -1942,7 +1945,7 @@ export interface AliasExistsException
 
 export namespace AliasExistsException {
   export function isa(o: any): o is AliasExistsException {
-    return _smithy.isa(o, "AliasExistsException");
+    return __isa(o, "AliasExistsException");
   }
 }
 
@@ -1977,7 +1980,7 @@ export interface AnalyticsConfigurationType {
 
 export namespace AnalyticsConfigurationType {
   export function isa(o: any): o is AnalyticsConfigurationType {
-    return _smithy.isa(o, "AnalyticsConfigurationType");
+    return __isa(o, "AnalyticsConfigurationType");
   }
 }
 
@@ -1996,7 +1999,7 @@ export interface AnalyticsMetadataType {
 
 export namespace AnalyticsMetadataType {
   export function isa(o: any): o is AnalyticsMetadataType {
-    return _smithy.isa(o, "AnalyticsMetadataType");
+    return __isa(o, "AnalyticsMetadataType");
   }
 }
 
@@ -2016,7 +2019,7 @@ export interface AssociateSoftwareTokenRequest {
 
 export namespace AssociateSoftwareTokenRequest {
   export function isa(o: any): o is AssociateSoftwareTokenRequest {
-    return _smithy.isa(o, "AssociateSoftwareTokenRequest");
+    return __isa(o, "AssociateSoftwareTokenRequest");
   }
 }
 
@@ -2037,7 +2040,7 @@ export interface AssociateSoftwareTokenResponse extends $MetadataBearer {
 
 export namespace AssociateSoftwareTokenResponse {
   export function isa(o: any): o is AssociateSoftwareTokenResponse {
-    return _smithy.isa(o, "AssociateSoftwareTokenResponse");
+    return __isa(o, "AssociateSoftwareTokenResponse");
   }
 }
 
@@ -2066,7 +2069,7 @@ export interface AttributeType {
 
 export namespace AttributeType {
   export function isa(o: any): o is AttributeType {
-    return _smithy.isa(o, "AttributeType");
+    return __isa(o, "AttributeType");
   }
 }
 
@@ -2120,7 +2123,7 @@ export interface AuthEventType {
 
 export namespace AuthEventType {
   export function isa(o: any): o is AuthEventType {
-    return _smithy.isa(o, "AuthEventType");
+    return __isa(o, "AuthEventType");
   }
 }
 
@@ -2172,7 +2175,7 @@ export interface AuthenticationResultType {
 
 export namespace AuthenticationResultType {
   export function isa(o: any): o is AuthenticationResultType {
-    return _smithy.isa(o, "AuthenticationResultType");
+    return __isa(o, "AuthenticationResultType");
   }
 }
 
@@ -2217,7 +2220,7 @@ export interface ChallengeResponseType {
 
 export namespace ChallengeResponseType {
   export function isa(o: any): o is ChallengeResponseType {
-    return _smithy.isa(o, "ChallengeResponseType");
+    return __isa(o, "ChallengeResponseType");
   }
 }
 
@@ -2244,7 +2247,7 @@ export interface ChangePasswordRequest {
 
 export namespace ChangePasswordRequest {
   export function isa(o: any): o is ChangePasswordRequest {
-    return _smithy.isa(o, "ChangePasswordRequest");
+    return __isa(o, "ChangePasswordRequest");
   }
 }
 
@@ -2257,7 +2260,7 @@ export interface ChangePasswordResponse extends $MetadataBearer {
 
 export namespace ChangePasswordResponse {
   export function isa(o: any): o is ChangePasswordResponse {
-    return _smithy.isa(o, "ChangePasswordResponse");
+    return __isa(o, "ChangePasswordResponse");
   }
 }
 
@@ -2284,7 +2287,7 @@ export interface CodeDeliveryDetailsType {
 
 export namespace CodeDeliveryDetailsType {
   export function isa(o: any): o is CodeDeliveryDetailsType {
-    return _smithy.isa(o, "CodeDeliveryDetailsType");
+    return __isa(o, "CodeDeliveryDetailsType");
   }
 }
 
@@ -2293,7 +2296,7 @@ export namespace CodeDeliveryDetailsType {
  *             successfully.</p>
  */
 export interface CodeDeliveryFailureException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CodeDeliveryFailureException";
   $fault: "client";
@@ -2305,7 +2308,7 @@ export interface CodeDeliveryFailureException
 
 export namespace CodeDeliveryFailureException {
   export function isa(o: any): o is CodeDeliveryFailureException {
-    return _smithy.isa(o, "CodeDeliveryFailureException");
+    return __isa(o, "CodeDeliveryFailureException");
   }
 }
 
@@ -2314,7 +2317,7 @@ export namespace CodeDeliveryFailureException {
  *             expecting.</p>
  */
 export interface CodeMismatchException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CodeMismatchException";
   $fault: "client";
@@ -2326,7 +2329,7 @@ export interface CodeMismatchException
 
 export namespace CodeMismatchException {
   export function isa(o: any): o is CodeMismatchException {
-    return _smithy.isa(o, "CodeMismatchException");
+    return __isa(o, "CodeMismatchException");
   }
 }
 
@@ -2343,7 +2346,7 @@ export interface CompromisedCredentialsActionsType {
 
 export namespace CompromisedCredentialsActionsType {
   export function isa(o: any): o is CompromisedCredentialsActionsType {
-    return _smithy.isa(o, "CompromisedCredentialsActionsType");
+    return __isa(o, "CompromisedCredentialsActionsType");
   }
 }
 
@@ -2373,7 +2376,7 @@ export namespace CompromisedCredentialsRiskConfigurationType {
   export function isa(
     o: any
   ): o is CompromisedCredentialsRiskConfigurationType {
-    return _smithy.isa(o, "CompromisedCredentialsRiskConfigurationType");
+    return __isa(o, "CompromisedCredentialsRiskConfigurationType");
   }
 }
 
@@ -2382,7 +2385,7 @@ export namespace CompromisedCredentialsRiskConfigurationType {
  *             concurrently.</p>
  */
 export interface ConcurrentModificationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ConcurrentModificationException";
   $fault: "client";
@@ -2394,7 +2397,7 @@ export interface ConcurrentModificationException
 
 export namespace ConcurrentModificationException {
   export function isa(o: any): o is ConcurrentModificationException {
-    return _smithy.isa(o, "ConcurrentModificationException");
+    return __isa(o, "ConcurrentModificationException");
   }
 }
 
@@ -2426,7 +2429,7 @@ export interface ConfirmDeviceRequest {
 
 export namespace ConfirmDeviceRequest {
   export function isa(o: any): o is ConfirmDeviceRequest {
-    return _smithy.isa(o, "ConfirmDeviceRequest");
+    return __isa(o, "ConfirmDeviceRequest");
   }
 }
 
@@ -2444,7 +2447,7 @@ export interface ConfirmDeviceResponse extends $MetadataBearer {
 
 export namespace ConfirmDeviceResponse {
   export function isa(o: any): o is ConfirmDeviceResponse {
-    return _smithy.isa(o, "ConfirmDeviceResponse");
+    return __isa(o, "ConfirmDeviceResponse");
   }
 }
 
@@ -2532,7 +2535,7 @@ export interface ConfirmForgotPasswordRequest {
 
 export namespace ConfirmForgotPasswordRequest {
   export function isa(o: any): o is ConfirmForgotPasswordRequest {
-    return _smithy.isa(o, "ConfirmForgotPasswordRequest");
+    return __isa(o, "ConfirmForgotPasswordRequest");
   }
 }
 
@@ -2546,7 +2549,7 @@ export interface ConfirmForgotPasswordResponse extends $MetadataBearer {
 
 export namespace ConfirmForgotPasswordResponse {
   export function isa(o: any): o is ConfirmForgotPasswordResponse {
-    return _smithy.isa(o, "ConfirmForgotPasswordResponse");
+    return __isa(o, "ConfirmForgotPasswordResponse");
   }
 }
 
@@ -2637,7 +2640,7 @@ export interface ConfirmSignUpRequest {
 
 export namespace ConfirmSignUpRequest {
   export function isa(o: any): o is ConfirmSignUpRequest {
-    return _smithy.isa(o, "ConfirmSignUpRequest");
+    return __isa(o, "ConfirmSignUpRequest");
   }
 }
 
@@ -2650,7 +2653,7 @@ export interface ConfirmSignUpResponse extends $MetadataBearer {
 
 export namespace ConfirmSignUpResponse {
   export function isa(o: any): o is ConfirmSignUpResponse {
-    return _smithy.isa(o, "ConfirmSignUpResponse");
+    return __isa(o, "ConfirmSignUpResponse");
   }
 }
 
@@ -2689,7 +2692,7 @@ export interface ContextDataType {
 
 export namespace ContextDataType {
   export function isa(o: any): o is ContextDataType {
-    return _smithy.isa(o, "ContextDataType");
+    return __isa(o, "ContextDataType");
   }
 }
 
@@ -2736,7 +2739,7 @@ export interface CreateGroupRequest {
 
 export namespace CreateGroupRequest {
   export function isa(o: any): o is CreateGroupRequest {
-    return _smithy.isa(o, "CreateGroupRequest");
+    return __isa(o, "CreateGroupRequest");
   }
 }
 
@@ -2750,7 +2753,7 @@ export interface CreateGroupResponse extends $MetadataBearer {
 
 export namespace CreateGroupResponse {
   export function isa(o: any): o is CreateGroupResponse {
-    return _smithy.isa(o, "CreateGroupResponse");
+    return __isa(o, "CreateGroupResponse");
   }
 }
 
@@ -2791,7 +2794,7 @@ export interface CreateIdentityProviderRequest {
 
 export namespace CreateIdentityProviderRequest {
   export function isa(o: any): o is CreateIdentityProviderRequest {
-    return _smithy.isa(o, "CreateIdentityProviderRequest");
+    return __isa(o, "CreateIdentityProviderRequest");
   }
 }
 
@@ -2805,7 +2808,7 @@ export interface CreateIdentityProviderResponse extends $MetadataBearer {
 
 export namespace CreateIdentityProviderResponse {
   export function isa(o: any): o is CreateIdentityProviderResponse {
-    return _smithy.isa(o, "CreateIdentityProviderResponse");
+    return __isa(o, "CreateIdentityProviderResponse");
   }
 }
 
@@ -2837,7 +2840,7 @@ export interface CreateResourceServerRequest {
 
 export namespace CreateResourceServerRequest {
   export function isa(o: any): o is CreateResourceServerRequest {
-    return _smithy.isa(o, "CreateResourceServerRequest");
+    return __isa(o, "CreateResourceServerRequest");
   }
 }
 
@@ -2851,7 +2854,7 @@ export interface CreateResourceServerResponse extends $MetadataBearer {
 
 export namespace CreateResourceServerResponse {
   export function isa(o: any): o is CreateResourceServerResponse {
-    return _smithy.isa(o, "CreateResourceServerResponse");
+    return __isa(o, "CreateResourceServerResponse");
   }
 }
 
@@ -2878,7 +2881,7 @@ export interface CreateUserImportJobRequest {
 
 export namespace CreateUserImportJobRequest {
   export function isa(o: any): o is CreateUserImportJobRequest {
-    return _smithy.isa(o, "CreateUserImportJobRequest");
+    return __isa(o, "CreateUserImportJobRequest");
   }
 }
 
@@ -2896,7 +2899,7 @@ export interface CreateUserImportJobResponse extends $MetadataBearer {
 
 export namespace CreateUserImportJobResponse {
   export function isa(o: any): o is CreateUserImportJobResponse {
-    return _smithy.isa(o, "CreateUserImportJobResponse");
+    return __isa(o, "CreateUserImportJobResponse");
   }
 }
 
@@ -3122,7 +3125,7 @@ export interface CreateUserPoolClientRequest {
 
 export namespace CreateUserPoolClientRequest {
   export function isa(o: any): o is CreateUserPoolClientRequest {
-    return _smithy.isa(o, "CreateUserPoolClientRequest");
+    return __isa(o, "CreateUserPoolClientRequest");
   }
 }
 
@@ -3139,7 +3142,7 @@ export interface CreateUserPoolClientResponse extends $MetadataBearer {
 
 export namespace CreateUserPoolClientResponse {
   export function isa(o: any): o is CreateUserPoolClientResponse {
-    return _smithy.isa(o, "CreateUserPoolClientResponse");
+    return __isa(o, "CreateUserPoolClientResponse");
   }
 }
 
@@ -3168,7 +3171,7 @@ export interface CreateUserPoolDomainRequest {
 
 export namespace CreateUserPoolDomainRequest {
   export function isa(o: any): o is CreateUserPoolDomainRequest {
-    return _smithy.isa(o, "CreateUserPoolDomainRequest");
+    return __isa(o, "CreateUserPoolDomainRequest");
   }
 }
 
@@ -3183,7 +3186,7 @@ export interface CreateUserPoolDomainResponse extends $MetadataBearer {
 
 export namespace CreateUserPoolDomainResponse {
   export function isa(o: any): o is CreateUserPoolDomainResponse {
-    return _smithy.isa(o, "CreateUserPoolDomainResponse");
+    return __isa(o, "CreateUserPoolDomainResponse");
   }
 }
 
@@ -3315,7 +3318,7 @@ export interface CreateUserPoolRequest {
 
 export namespace CreateUserPoolRequest {
   export function isa(o: any): o is CreateUserPoolRequest {
-    return _smithy.isa(o, "CreateUserPoolRequest");
+    return __isa(o, "CreateUserPoolRequest");
   }
 }
 
@@ -3332,7 +3335,7 @@ export interface CreateUserPoolResponse extends $MetadataBearer {
 
 export namespace CreateUserPoolResponse {
   export function isa(o: any): o is CreateUserPoolResponse {
-    return _smithy.isa(o, "CreateUserPoolResponse");
+    return __isa(o, "CreateUserPoolResponse");
   }
 }
 
@@ -3351,7 +3354,7 @@ export interface CustomDomainConfigType {
 
 export namespace CustomDomainConfigType {
   export function isa(o: any): o is CustomDomainConfigType {
-    return _smithy.isa(o, "CustomDomainConfigType");
+    return __isa(o, "CustomDomainConfigType");
   }
 }
 
@@ -3375,7 +3378,7 @@ export interface DeleteGroupRequest {
 
 export namespace DeleteGroupRequest {
   export function isa(o: any): o is DeleteGroupRequest {
-    return _smithy.isa(o, "DeleteGroupRequest");
+    return __isa(o, "DeleteGroupRequest");
   }
 }
 
@@ -3394,7 +3397,7 @@ export interface DeleteIdentityProviderRequest {
 
 export namespace DeleteIdentityProviderRequest {
   export function isa(o: any): o is DeleteIdentityProviderRequest {
-    return _smithy.isa(o, "DeleteIdentityProviderRequest");
+    return __isa(o, "DeleteIdentityProviderRequest");
   }
 }
 
@@ -3413,7 +3416,7 @@ export interface DeleteResourceServerRequest {
 
 export namespace DeleteResourceServerRequest {
   export function isa(o: any): o is DeleteResourceServerRequest {
-    return _smithy.isa(o, "DeleteResourceServerRequest");
+    return __isa(o, "DeleteResourceServerRequest");
   }
 }
 
@@ -3437,7 +3440,7 @@ export interface DeleteUserAttributesRequest {
 
 export namespace DeleteUserAttributesRequest {
   export function isa(o: any): o is DeleteUserAttributesRequest {
-    return _smithy.isa(o, "DeleteUserAttributesRequest");
+    return __isa(o, "DeleteUserAttributesRequest");
   }
 }
 
@@ -3450,7 +3453,7 @@ export interface DeleteUserAttributesResponse extends $MetadataBearer {
 
 export namespace DeleteUserAttributesResponse {
   export function isa(o: any): o is DeleteUserAttributesResponse {
-    return _smithy.isa(o, "DeleteUserAttributesResponse");
+    return __isa(o, "DeleteUserAttributesResponse");
   }
 }
 
@@ -3472,7 +3475,7 @@ export interface DeleteUserPoolClientRequest {
 
 export namespace DeleteUserPoolClientRequest {
   export function isa(o: any): o is DeleteUserPoolClientRequest {
-    return _smithy.isa(o, "DeleteUserPoolClientRequest");
+    return __isa(o, "DeleteUserPoolClientRequest");
   }
 }
 
@@ -3491,7 +3494,7 @@ export interface DeleteUserPoolDomainRequest {
 
 export namespace DeleteUserPoolDomainRequest {
   export function isa(o: any): o is DeleteUserPoolDomainRequest {
-    return _smithy.isa(o, "DeleteUserPoolDomainRequest");
+    return __isa(o, "DeleteUserPoolDomainRequest");
   }
 }
 
@@ -3501,7 +3504,7 @@ export interface DeleteUserPoolDomainResponse extends $MetadataBearer {
 
 export namespace DeleteUserPoolDomainResponse {
   export function isa(o: any): o is DeleteUserPoolDomainResponse {
-    return _smithy.isa(o, "DeleteUserPoolDomainResponse");
+    return __isa(o, "DeleteUserPoolDomainResponse");
   }
 }
 
@@ -3518,7 +3521,7 @@ export interface DeleteUserPoolRequest {
 
 export namespace DeleteUserPoolRequest {
   export function isa(o: any): o is DeleteUserPoolRequest {
-    return _smithy.isa(o, "DeleteUserPoolRequest");
+    return __isa(o, "DeleteUserPoolRequest");
   }
 }
 
@@ -3535,7 +3538,7 @@ export interface DeleteUserRequest {
 
 export namespace DeleteUserRequest {
   export function isa(o: any): o is DeleteUserRequest {
-    return _smithy.isa(o, "DeleteUserRequest");
+    return __isa(o, "DeleteUserRequest");
   }
 }
 
@@ -3559,7 +3562,7 @@ export interface DescribeIdentityProviderRequest {
 
 export namespace DescribeIdentityProviderRequest {
   export function isa(o: any): o is DescribeIdentityProviderRequest {
-    return _smithy.isa(o, "DescribeIdentityProviderRequest");
+    return __isa(o, "DescribeIdentityProviderRequest");
   }
 }
 
@@ -3573,7 +3576,7 @@ export interface DescribeIdentityProviderResponse extends $MetadataBearer {
 
 export namespace DescribeIdentityProviderResponse {
   export function isa(o: any): o is DescribeIdentityProviderResponse {
-    return _smithy.isa(o, "DescribeIdentityProviderResponse");
+    return __isa(o, "DescribeIdentityProviderResponse");
   }
 }
 
@@ -3592,7 +3595,7 @@ export interface DescribeResourceServerRequest {
 
 export namespace DescribeResourceServerRequest {
   export function isa(o: any): o is DescribeResourceServerRequest {
-    return _smithy.isa(o, "DescribeResourceServerRequest");
+    return __isa(o, "DescribeResourceServerRequest");
   }
 }
 
@@ -3606,7 +3609,7 @@ export interface DescribeResourceServerResponse extends $MetadataBearer {
 
 export namespace DescribeResourceServerResponse {
   export function isa(o: any): o is DescribeResourceServerResponse {
-    return _smithy.isa(o, "DescribeResourceServerResponse");
+    return __isa(o, "DescribeResourceServerResponse");
   }
 }
 
@@ -3625,7 +3628,7 @@ export interface DescribeRiskConfigurationRequest {
 
 export namespace DescribeRiskConfigurationRequest {
   export function isa(o: any): o is DescribeRiskConfigurationRequest {
-    return _smithy.isa(o, "DescribeRiskConfigurationRequest");
+    return __isa(o, "DescribeRiskConfigurationRequest");
   }
 }
 
@@ -3639,7 +3642,7 @@ export interface DescribeRiskConfigurationResponse extends $MetadataBearer {
 
 export namespace DescribeRiskConfigurationResponse {
   export function isa(o: any): o is DescribeRiskConfigurationResponse {
-    return _smithy.isa(o, "DescribeRiskConfigurationResponse");
+    return __isa(o, "DescribeRiskConfigurationResponse");
   }
 }
 
@@ -3661,7 +3664,7 @@ export interface DescribeUserImportJobRequest {
 
 export namespace DescribeUserImportJobRequest {
   export function isa(o: any): o is DescribeUserImportJobRequest {
-    return _smithy.isa(o, "DescribeUserImportJobRequest");
+    return __isa(o, "DescribeUserImportJobRequest");
   }
 }
 
@@ -3679,7 +3682,7 @@ export interface DescribeUserImportJobResponse extends $MetadataBearer {
 
 export namespace DescribeUserImportJobResponse {
   export function isa(o: any): o is DescribeUserImportJobResponse {
-    return _smithy.isa(o, "DescribeUserImportJobResponse");
+    return __isa(o, "DescribeUserImportJobResponse");
   }
 }
 
@@ -3701,7 +3704,7 @@ export interface DescribeUserPoolClientRequest {
 
 export namespace DescribeUserPoolClientRequest {
   export function isa(o: any): o is DescribeUserPoolClientRequest {
-    return _smithy.isa(o, "DescribeUserPoolClientRequest");
+    return __isa(o, "DescribeUserPoolClientRequest");
   }
 }
 
@@ -3719,7 +3722,7 @@ export interface DescribeUserPoolClientResponse extends $MetadataBearer {
 
 export namespace DescribeUserPoolClientResponse {
   export function isa(o: any): o is DescribeUserPoolClientResponse {
-    return _smithy.isa(o, "DescribeUserPoolClientResponse");
+    return __isa(o, "DescribeUserPoolClientResponse");
   }
 }
 
@@ -3733,7 +3736,7 @@ export interface DescribeUserPoolDomainRequest {
 
 export namespace DescribeUserPoolDomainRequest {
   export function isa(o: any): o is DescribeUserPoolDomainRequest {
-    return _smithy.isa(o, "DescribeUserPoolDomainRequest");
+    return __isa(o, "DescribeUserPoolDomainRequest");
   }
 }
 
@@ -3747,7 +3750,7 @@ export interface DescribeUserPoolDomainResponse extends $MetadataBearer {
 
 export namespace DescribeUserPoolDomainResponse {
   export function isa(o: any): o is DescribeUserPoolDomainResponse {
-    return _smithy.isa(o, "DescribeUserPoolDomainResponse");
+    return __isa(o, "DescribeUserPoolDomainResponse");
   }
 }
 
@@ -3764,7 +3767,7 @@ export interface DescribeUserPoolRequest {
 
 export namespace DescribeUserPoolRequest {
   export function isa(o: any): o is DescribeUserPoolRequest {
-    return _smithy.isa(o, "DescribeUserPoolRequest");
+    return __isa(o, "DescribeUserPoolRequest");
   }
 }
 
@@ -3781,7 +3784,7 @@ export interface DescribeUserPoolResponse extends $MetadataBearer {
 
 export namespace DescribeUserPoolResponse {
   export function isa(o: any): o is DescribeUserPoolResponse {
-    return _smithy.isa(o, "DescribeUserPoolResponse");
+    return __isa(o, "DescribeUserPoolResponse");
   }
 }
 
@@ -3804,7 +3807,7 @@ export interface DeviceConfigurationType {
 
 export namespace DeviceConfigurationType {
   export function isa(o: any): o is DeviceConfigurationType {
-    return _smithy.isa(o, "DeviceConfigurationType");
+    return __isa(o, "DeviceConfigurationType");
   }
 }
 
@@ -3831,7 +3834,7 @@ export interface DeviceSecretVerifierConfigType {
 
 export namespace DeviceSecretVerifierConfigType {
   export function isa(o: any): o is DeviceSecretVerifierConfigType {
-    return _smithy.isa(o, "DeviceSecretVerifierConfigType");
+    return __isa(o, "DeviceSecretVerifierConfigType");
   }
 }
 
@@ -3868,7 +3871,7 @@ export interface DeviceType {
 
 export namespace DeviceType {
   export function isa(o: any): o is DeviceType {
-    return _smithy.isa(o, "DeviceType");
+    return __isa(o, "DeviceType");
   }
 }
 
@@ -3921,7 +3924,7 @@ export interface DomainDescriptionType {
 
 export namespace DomainDescriptionType {
   export function isa(o: any): o is DomainDescriptionType {
-    return _smithy.isa(o, "DomainDescriptionType");
+    return __isa(o, "DomainDescriptionType");
   }
 }
 
@@ -3938,7 +3941,7 @@ export enum DomainStatusType {
  *             pool.</p>
  */
 export interface DuplicateProviderException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DuplicateProviderException";
   $fault: "client";
@@ -3947,7 +3950,7 @@ export interface DuplicateProviderException
 
 export namespace DuplicateProviderException {
   export function isa(o: any): o is DuplicateProviderException {
-    return _smithy.isa(o, "DuplicateProviderException");
+    return __isa(o, "DuplicateProviderException");
   }
 }
 
@@ -4042,7 +4045,7 @@ export interface EmailConfigurationType {
 
 export namespace EmailConfigurationType {
   export function isa(o: any): o is EmailConfigurationType {
-    return _smithy.isa(o, "EmailConfigurationType");
+    return __isa(o, "EmailConfigurationType");
   }
 }
 
@@ -4056,7 +4059,7 @@ export enum EmailSendingAccountType {
  *             configure the software token TOTP multi-factor authentication (MFA).</p>
  */
 export interface EnableSoftwareTokenMFAException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "EnableSoftwareTokenMFAException";
   $fault: "client";
@@ -4065,7 +4068,7 @@ export interface EnableSoftwareTokenMFAException
 
 export namespace EnableSoftwareTokenMFAException {
   export function isa(o: any): o is EnableSoftwareTokenMFAException {
-    return _smithy.isa(o, "EnableSoftwareTokenMFAException");
+    return __isa(o, "EnableSoftwareTokenMFAException");
   }
 }
 
@@ -4102,7 +4105,7 @@ export interface EventContextDataType {
 
 export namespace EventContextDataType {
   export function isa(o: any): o is EventContextDataType {
-    return _smithy.isa(o, "EventContextDataType");
+    return __isa(o, "EventContextDataType");
   }
 }
 
@@ -4129,7 +4132,7 @@ export interface EventFeedbackType {
 
 export namespace EventFeedbackType {
   export function isa(o: any): o is EventFeedbackType {
-    return _smithy.isa(o, "EventFeedbackType");
+    return __isa(o, "EventFeedbackType");
   }
 }
 
@@ -4162,7 +4165,7 @@ export interface EventRiskType {
 
 export namespace EventRiskType {
   export function isa(o: any): o is EventRiskType {
-    return _smithy.isa(o, "EventRiskType");
+    return __isa(o, "EventRiskType");
   }
 }
 
@@ -4176,7 +4179,7 @@ export enum EventType {
  * <p>This exception is thrown if a code has expired.</p>
  */
 export interface ExpiredCodeException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ExpiredCodeException";
   $fault: "client";
@@ -4188,7 +4191,7 @@ export interface ExpiredCodeException
 
 export namespace ExpiredCodeException {
   export function isa(o: any): o is ExpiredCodeException {
-    return _smithy.isa(o, "ExpiredCodeException");
+    return __isa(o, "ExpiredCodeException");
   }
 }
 
@@ -4226,7 +4229,7 @@ export interface ForgetDeviceRequest {
 
 export namespace ForgetDeviceRequest {
   export function isa(o: any): o is ForgetDeviceRequest {
-    return _smithy.isa(o, "ForgetDeviceRequest");
+    return __isa(o, "ForgetDeviceRequest");
   }
 }
 
@@ -4305,7 +4308,7 @@ export interface ForgotPasswordRequest {
 
 export namespace ForgotPasswordRequest {
   export function isa(o: any): o is ForgotPasswordRequest {
-    return _smithy.isa(o, "ForgotPasswordRequest");
+    return __isa(o, "ForgotPasswordRequest");
   }
 }
 
@@ -4324,7 +4327,7 @@ export interface ForgotPasswordResponse extends $MetadataBearer {
 
 export namespace ForgotPasswordResponse {
   export function isa(o: any): o is ForgotPasswordResponse {
-    return _smithy.isa(o, "ForgotPasswordResponse");
+    return __isa(o, "ForgotPasswordResponse");
   }
 }
 
@@ -4342,7 +4345,7 @@ export interface GetCSVHeaderRequest {
 
 export namespace GetCSVHeaderRequest {
   export function isa(o: any): o is GetCSVHeaderRequest {
-    return _smithy.isa(o, "GetCSVHeaderRequest");
+    return __isa(o, "GetCSVHeaderRequest");
   }
 }
 
@@ -4365,7 +4368,7 @@ export interface GetCSVHeaderResponse extends $MetadataBearer {
 
 export namespace GetCSVHeaderResponse {
   export function isa(o: any): o is GetCSVHeaderResponse {
-    return _smithy.isa(o, "GetCSVHeaderResponse");
+    return __isa(o, "GetCSVHeaderResponse");
   }
 }
 
@@ -4387,7 +4390,7 @@ export interface GetDeviceRequest {
 
 export namespace GetDeviceRequest {
   export function isa(o: any): o is GetDeviceRequest {
-    return _smithy.isa(o, "GetDeviceRequest");
+    return __isa(o, "GetDeviceRequest");
   }
 }
 
@@ -4404,7 +4407,7 @@ export interface GetDeviceResponse extends $MetadataBearer {
 
 export namespace GetDeviceResponse {
   export function isa(o: any): o is GetDeviceResponse {
-    return _smithy.isa(o, "GetDeviceResponse");
+    return __isa(o, "GetDeviceResponse");
   }
 }
 
@@ -4423,7 +4426,7 @@ export interface GetGroupRequest {
 
 export namespace GetGroupRequest {
   export function isa(o: any): o is GetGroupRequest {
-    return _smithy.isa(o, "GetGroupRequest");
+    return __isa(o, "GetGroupRequest");
   }
 }
 
@@ -4437,7 +4440,7 @@ export interface GetGroupResponse extends $MetadataBearer {
 
 export namespace GetGroupResponse {
   export function isa(o: any): o is GetGroupResponse {
-    return _smithy.isa(o, "GetGroupResponse");
+    return __isa(o, "GetGroupResponse");
   }
 }
 
@@ -4456,7 +4459,7 @@ export interface GetIdentityProviderByIdentifierRequest {
 
 export namespace GetIdentityProviderByIdentifierRequest {
   export function isa(o: any): o is GetIdentityProviderByIdentifierRequest {
-    return _smithy.isa(o, "GetIdentityProviderByIdentifierRequest");
+    return __isa(o, "GetIdentityProviderByIdentifierRequest");
   }
 }
 
@@ -4471,7 +4474,7 @@ export interface GetIdentityProviderByIdentifierResponse
 
 export namespace GetIdentityProviderByIdentifierResponse {
   export function isa(o: any): o is GetIdentityProviderByIdentifierResponse {
-    return _smithy.isa(o, "GetIdentityProviderByIdentifierResponse");
+    return __isa(o, "GetIdentityProviderByIdentifierResponse");
   }
 }
 
@@ -4488,7 +4491,7 @@ export interface GetSigningCertificateRequest {
 
 export namespace GetSigningCertificateRequest {
   export function isa(o: any): o is GetSigningCertificateRequest {
-    return _smithy.isa(o, "GetSigningCertificateRequest");
+    return __isa(o, "GetSigningCertificateRequest");
   }
 }
 
@@ -4505,7 +4508,7 @@ export interface GetSigningCertificateResponse extends $MetadataBearer {
 
 export namespace GetSigningCertificateResponse {
   export function isa(o: any): o is GetSigningCertificateResponse {
-    return _smithy.isa(o, "GetSigningCertificateResponse");
+    return __isa(o, "GetSigningCertificateResponse");
   }
 }
 
@@ -4524,7 +4527,7 @@ export interface GetUICustomizationRequest {
 
 export namespace GetUICustomizationRequest {
   export function isa(o: any): o is GetUICustomizationRequest {
-    return _smithy.isa(o, "GetUICustomizationRequest");
+    return __isa(o, "GetUICustomizationRequest");
   }
 }
 
@@ -4538,7 +4541,7 @@ export interface GetUICustomizationResponse extends $MetadataBearer {
 
 export namespace GetUICustomizationResponse {
   export function isa(o: any): o is GetUICustomizationResponse {
-    return _smithy.isa(o, "GetUICustomizationResponse");
+    return __isa(o, "GetUICustomizationResponse");
   }
 }
 
@@ -4598,7 +4601,7 @@ export interface GetUserAttributeVerificationCodeRequest {
 
 export namespace GetUserAttributeVerificationCodeRequest {
   export function isa(o: any): o is GetUserAttributeVerificationCodeRequest {
-    return _smithy.isa(o, "GetUserAttributeVerificationCodeRequest");
+    return __isa(o, "GetUserAttributeVerificationCodeRequest");
   }
 }
 
@@ -4618,7 +4621,7 @@ export interface GetUserAttributeVerificationCodeResponse
 
 export namespace GetUserAttributeVerificationCodeResponse {
   export function isa(o: any): o is GetUserAttributeVerificationCodeResponse {
-    return _smithy.isa(o, "GetUserAttributeVerificationCodeResponse");
+    return __isa(o, "GetUserAttributeVerificationCodeResponse");
   }
 }
 
@@ -4632,7 +4635,7 @@ export interface GetUserPoolMfaConfigRequest {
 
 export namespace GetUserPoolMfaConfigRequest {
   export function isa(o: any): o is GetUserPoolMfaConfigRequest {
-    return _smithy.isa(o, "GetUserPoolMfaConfigRequest");
+    return __isa(o, "GetUserPoolMfaConfigRequest");
   }
 }
 
@@ -4670,7 +4673,7 @@ export interface GetUserPoolMfaConfigResponse extends $MetadataBearer {
 
 export namespace GetUserPoolMfaConfigResponse {
   export function isa(o: any): o is GetUserPoolMfaConfigResponse {
-    return _smithy.isa(o, "GetUserPoolMfaConfigResponse");
+    return __isa(o, "GetUserPoolMfaConfigResponse");
   }
 }
 
@@ -4688,7 +4691,7 @@ export interface GetUserRequest {
 
 export namespace GetUserRequest {
   export function isa(o: any): o is GetUserRequest {
-    return _smithy.isa(o, "GetUserRequest");
+    return __isa(o, "GetUserRequest");
   }
 }
 
@@ -4734,7 +4737,7 @@ export interface GetUserResponse extends $MetadataBearer {
 
 export namespace GetUserResponse {
   export function isa(o: any): o is GetUserResponse {
-    return _smithy.isa(o, "GetUserResponse");
+    return __isa(o, "GetUserResponse");
   }
 }
 
@@ -4751,7 +4754,7 @@ export interface GlobalSignOutRequest {
 
 export namespace GlobalSignOutRequest {
   export function isa(o: any): o is GlobalSignOutRequest {
-    return _smithy.isa(o, "GlobalSignOutRequest");
+    return __isa(o, "GlobalSignOutRequest");
   }
 }
 
@@ -4764,7 +4767,7 @@ export interface GlobalSignOutResponse extends $MetadataBearer {
 
 export namespace GlobalSignOutResponse {
   export function isa(o: any): o is GlobalSignOutResponse {
-    return _smithy.isa(o, "GlobalSignOutResponse");
+    return __isa(o, "GlobalSignOutResponse");
   }
 }
 
@@ -4773,7 +4776,7 @@ export namespace GlobalSignOutResponse {
  *             the user pool.</p>
  */
 export interface GroupExistsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "GroupExistsException";
   $fault: "client";
@@ -4782,7 +4785,7 @@ export interface GroupExistsException
 
 export namespace GroupExistsException {
   export function isa(o: any): o is GroupExistsException {
-    return _smithy.isa(o, "GroupExistsException");
+    return __isa(o, "GroupExistsException");
   }
 }
 
@@ -4842,7 +4845,7 @@ export interface GroupType {
 
 export namespace GroupType {
   export function isa(o: any): o is GroupType {
-    return _smithy.isa(o, "GroupType");
+    return __isa(o, "GroupType");
   }
 }
 
@@ -4864,7 +4867,7 @@ export interface HttpHeader {
 
 export namespace HttpHeader {
   export function isa(o: any): o is HttpHeader {
-    return _smithy.isa(o, "HttpHeader");
+    return __isa(o, "HttpHeader");
   }
 }
 
@@ -4918,7 +4921,7 @@ export interface IdentityProviderType {
 
 export namespace IdentityProviderType {
   export function isa(o: any): o is IdentityProviderType {
-    return _smithy.isa(o, "IdentityProviderType");
+    return __isa(o, "IdentityProviderType");
   }
 }
 
@@ -5113,7 +5116,7 @@ export interface InitiateAuthRequest {
 
 export namespace InitiateAuthRequest {
   export function isa(o: any): o is InitiateAuthRequest {
-    return _smithy.isa(o, "InitiateAuthRequest");
+    return __isa(o, "InitiateAuthRequest");
   }
 }
 
@@ -5198,7 +5201,7 @@ export interface InitiateAuthResponse extends $MetadataBearer {
 
 export namespace InitiateAuthResponse {
   export function isa(o: any): o is InitiateAuthResponse {
-    return _smithy.isa(o, "InitiateAuthResponse");
+    return __isa(o, "InitiateAuthResponse");
   }
 }
 
@@ -5206,7 +5209,7 @@ export namespace InitiateAuthResponse {
  * <p>This exception is thrown when Amazon Cognito encounters an internal error.</p>
  */
 export interface InternalErrorException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalErrorException";
   $fault: "server";
@@ -5218,7 +5221,7 @@ export interface InternalErrorException
 
 export namespace InternalErrorException {
   export function isa(o: any): o is InternalErrorException {
-    return _smithy.isa(o, "InternalErrorException");
+    return __isa(o, "InternalErrorException");
   }
 }
 
@@ -5227,7 +5230,7 @@ export namespace InternalErrorException {
  *             identity. HTTP status code: 400.</p>
  */
 export interface InvalidEmailRoleAccessPolicyException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidEmailRoleAccessPolicyException";
   $fault: "client";
@@ -5240,7 +5243,7 @@ export interface InvalidEmailRoleAccessPolicyException
 
 export namespace InvalidEmailRoleAccessPolicyException {
   export function isa(o: any): o is InvalidEmailRoleAccessPolicyException {
-    return _smithy.isa(o, "InvalidEmailRoleAccessPolicyException");
+    return __isa(o, "InvalidEmailRoleAccessPolicyException");
   }
 }
 
@@ -5249,7 +5252,7 @@ export namespace InvalidEmailRoleAccessPolicyException {
  *             Lambda response.</p>
  */
 export interface InvalidLambdaResponseException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidLambdaResponseException";
   $fault: "client";
@@ -5262,7 +5265,7 @@ export interface InvalidLambdaResponseException
 
 export namespace InvalidLambdaResponseException {
   export function isa(o: any): o is InvalidLambdaResponseException {
-    return _smithy.isa(o, "InvalidLambdaResponseException");
+    return __isa(o, "InvalidLambdaResponseException");
   }
 }
 
@@ -5270,7 +5273,7 @@ export namespace InvalidLambdaResponseException {
  * <p>This exception is thrown when the specified OAuth flow is invalid.</p>
  */
 export interface InvalidOAuthFlowException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidOAuthFlowException";
   $fault: "client";
@@ -5279,7 +5282,7 @@ export interface InvalidOAuthFlowException
 
 export namespace InvalidOAuthFlowException {
   export function isa(o: any): o is InvalidOAuthFlowException {
-    return _smithy.isa(o, "InvalidOAuthFlowException");
+    return __isa(o, "InvalidOAuthFlowException");
   }
 }
 
@@ -5288,7 +5291,7 @@ export namespace InvalidOAuthFlowException {
  *             parameter.</p>
  */
 export interface InvalidParameterException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidParameterException";
   $fault: "client";
@@ -5301,7 +5304,7 @@ export interface InvalidParameterException
 
 export namespace InvalidParameterException {
   export function isa(o: any): o is InvalidParameterException {
-    return _smithy.isa(o, "InvalidParameterException");
+    return __isa(o, "InvalidParameterException");
   }
 }
 
@@ -5310,7 +5313,7 @@ export namespace InvalidParameterException {
  *             password.</p>
  */
 export interface InvalidPasswordException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidPasswordException";
   $fault: "client";
@@ -5323,7 +5326,7 @@ export interface InvalidPasswordException
 
 export namespace InvalidPasswordException {
   export function isa(o: any): o is InvalidPasswordException {
-    return _smithy.isa(o, "InvalidPasswordException");
+    return __isa(o, "InvalidPasswordException");
   }
 }
 
@@ -5332,7 +5335,7 @@ export namespace InvalidPasswordException {
  *             permission to publish using Amazon SNS.</p>
  */
 export interface InvalidSmsRoleAccessPolicyException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidSmsRoleAccessPolicyException";
   $fault: "client";
@@ -5345,7 +5348,7 @@ export interface InvalidSmsRoleAccessPolicyException
 
 export namespace InvalidSmsRoleAccessPolicyException {
   export function isa(o: any): o is InvalidSmsRoleAccessPolicyException {
-    return _smithy.isa(o, "InvalidSmsRoleAccessPolicyException");
+    return __isa(o, "InvalidSmsRoleAccessPolicyException");
   }
 }
 
@@ -5355,7 +5358,7 @@ export namespace InvalidSmsRoleAccessPolicyException {
  *             not match what is provided in the SMS configuration for the user pool.</p>
  */
 export interface InvalidSmsRoleTrustRelationshipException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidSmsRoleTrustRelationshipException";
   $fault: "client";
@@ -5368,7 +5371,7 @@ export interface InvalidSmsRoleTrustRelationshipException
 
 export namespace InvalidSmsRoleTrustRelationshipException {
   export function isa(o: any): o is InvalidSmsRoleTrustRelationshipException {
-    return _smithy.isa(o, "InvalidSmsRoleTrustRelationshipException");
+    return __isa(o, "InvalidSmsRoleTrustRelationshipException");
   }
 }
 
@@ -5376,7 +5379,7 @@ export namespace InvalidSmsRoleTrustRelationshipException {
  * <p>This exception is thrown when the user pool configuration is invalid.</p>
  */
 export interface InvalidUserPoolConfigurationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidUserPoolConfigurationException";
   $fault: "client";
@@ -5388,7 +5391,7 @@ export interface InvalidUserPoolConfigurationException
 
 export namespace InvalidUserPoolConfigurationException {
   export function isa(o: any): o is InvalidUserPoolConfigurationException {
-    return _smithy.isa(o, "InvalidUserPoolConfigurationException");
+    return __isa(o, "InvalidUserPoolConfigurationException");
   }
 }
 
@@ -5450,7 +5453,7 @@ export interface LambdaConfigType {
 
 export namespace LambdaConfigType {
   export function isa(o: any): o is LambdaConfigType {
-    return _smithy.isa(o, "LambdaConfigType");
+    return __isa(o, "LambdaConfigType");
   }
 }
 
@@ -5459,7 +5462,7 @@ export namespace LambdaConfigType {
  *             resource.</p>
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -5471,7 +5474,7 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
@@ -5498,7 +5501,7 @@ export interface ListDevicesRequest {
 
 export namespace ListDevicesRequest {
   export function isa(o: any): o is ListDevicesRequest {
-    return _smithy.isa(o, "ListDevicesRequest");
+    return __isa(o, "ListDevicesRequest");
   }
 }
 
@@ -5520,7 +5523,7 @@ export interface ListDevicesResponse extends $MetadataBearer {
 
 export namespace ListDevicesResponse {
   export function isa(o: any): o is ListDevicesResponse {
-    return _smithy.isa(o, "ListDevicesResponse");
+    return __isa(o, "ListDevicesResponse");
   }
 }
 
@@ -5545,7 +5548,7 @@ export interface ListGroupsRequest {
 
 export namespace ListGroupsRequest {
   export function isa(o: any): o is ListGroupsRequest {
-    return _smithy.isa(o, "ListGroupsRequest");
+    return __isa(o, "ListGroupsRequest");
   }
 }
 
@@ -5565,7 +5568,7 @@ export interface ListGroupsResponse extends $MetadataBearer {
 
 export namespace ListGroupsResponse {
   export function isa(o: any): o is ListGroupsResponse {
-    return _smithy.isa(o, "ListGroupsResponse");
+    return __isa(o, "ListGroupsResponse");
   }
 }
 
@@ -5589,7 +5592,7 @@ export interface ListIdentityProvidersRequest {
 
 export namespace ListIdentityProvidersRequest {
   export function isa(o: any): o is ListIdentityProvidersRequest {
-    return _smithy.isa(o, "ListIdentityProvidersRequest");
+    return __isa(o, "ListIdentityProvidersRequest");
   }
 }
 
@@ -5608,7 +5611,7 @@ export interface ListIdentityProvidersResponse extends $MetadataBearer {
 
 export namespace ListIdentityProvidersResponse {
   export function isa(o: any): o is ListIdentityProvidersResponse {
-    return _smithy.isa(o, "ListIdentityProvidersResponse");
+    return __isa(o, "ListIdentityProvidersResponse");
   }
 }
 
@@ -5632,7 +5635,7 @@ export interface ListResourceServersRequest {
 
 export namespace ListResourceServersRequest {
   export function isa(o: any): o is ListResourceServersRequest {
-    return _smithy.isa(o, "ListResourceServersRequest");
+    return __isa(o, "ListResourceServersRequest");
   }
 }
 
@@ -5651,7 +5654,7 @@ export interface ListResourceServersResponse extends $MetadataBearer {
 
 export namespace ListResourceServersResponse {
   export function isa(o: any): o is ListResourceServersResponse {
-    return _smithy.isa(o, "ListResourceServersResponse");
+    return __isa(o, "ListResourceServersResponse");
   }
 }
 
@@ -5665,7 +5668,7 @@ export interface ListTagsForResourceRequest {
 
 export namespace ListTagsForResourceRequest {
   export function isa(o: any): o is ListTagsForResourceRequest {
-    return _smithy.isa(o, "ListTagsForResourceRequest");
+    return __isa(o, "ListTagsForResourceRequest");
   }
 }
 
@@ -5679,7 +5682,7 @@ export interface ListTagsForResourceResponse extends $MetadataBearer {
 
 export namespace ListTagsForResourceResponse {
   export function isa(o: any): o is ListTagsForResourceResponse {
-    return _smithy.isa(o, "ListTagsForResourceResponse");
+    return __isa(o, "ListTagsForResourceResponse");
   }
 }
 
@@ -5708,7 +5711,7 @@ export interface ListUserImportJobsRequest {
 
 export namespace ListUserImportJobsRequest {
   export function isa(o: any): o is ListUserImportJobsRequest {
-    return _smithy.isa(o, "ListUserImportJobsRequest");
+    return __isa(o, "ListUserImportJobsRequest");
   }
 }
 
@@ -5732,7 +5735,7 @@ export interface ListUserImportJobsResponse extends $MetadataBearer {
 
 export namespace ListUserImportJobsResponse {
   export function isa(o: any): o is ListUserImportJobsResponse {
-    return _smithy.isa(o, "ListUserImportJobsResponse");
+    return __isa(o, "ListUserImportJobsResponse");
   }
 }
 
@@ -5761,7 +5764,7 @@ export interface ListUserPoolClientsRequest {
 
 export namespace ListUserPoolClientsRequest {
   export function isa(o: any): o is ListUserPoolClientsRequest {
-    return _smithy.isa(o, "ListUserPoolClientsRequest");
+    return __isa(o, "ListUserPoolClientsRequest");
   }
 }
 
@@ -5784,7 +5787,7 @@ export interface ListUserPoolClientsResponse extends $MetadataBearer {
 
 export namespace ListUserPoolClientsResponse {
   export function isa(o: any): o is ListUserPoolClientsResponse {
-    return _smithy.isa(o, "ListUserPoolClientsResponse");
+    return __isa(o, "ListUserPoolClientsResponse");
   }
 }
 
@@ -5808,7 +5811,7 @@ export interface ListUserPoolsRequest {
 
 export namespace ListUserPoolsRequest {
   export function isa(o: any): o is ListUserPoolsRequest {
-    return _smithy.isa(o, "ListUserPoolsRequest");
+    return __isa(o, "ListUserPoolsRequest");
   }
 }
 
@@ -5831,7 +5834,7 @@ export interface ListUserPoolsResponse extends $MetadataBearer {
 
 export namespace ListUserPoolsResponse {
   export function isa(o: any): o is ListUserPoolsResponse {
-    return _smithy.isa(o, "ListUserPoolsResponse");
+    return __isa(o, "ListUserPoolsResponse");
   }
 }
 
@@ -5861,7 +5864,7 @@ export interface ListUsersInGroupRequest {
 
 export namespace ListUsersInGroupRequest {
   export function isa(o: any): o is ListUsersInGroupRequest {
-    return _smithy.isa(o, "ListUsersInGroupRequest");
+    return __isa(o, "ListUsersInGroupRequest");
   }
 }
 
@@ -5881,7 +5884,7 @@ export interface ListUsersInGroupResponse extends $MetadataBearer {
 
 export namespace ListUsersInGroupResponse {
   export function isa(o: any): o is ListUsersInGroupResponse {
-    return _smithy.isa(o, "ListUsersInGroupResponse");
+    return __isa(o, "ListUsersInGroupResponse");
   }
 }
 
@@ -5999,7 +6002,7 @@ export interface ListUsersRequest {
 
 export namespace ListUsersRequest {
   export function isa(o: any): o is ListUsersRequest {
-    return _smithy.isa(o, "ListUsersRequest");
+    return __isa(o, "ListUsersRequest");
   }
 }
 
@@ -6022,7 +6025,7 @@ export interface ListUsersResponse extends $MetadataBearer {
 
 export namespace ListUsersResponse {
   export function isa(o: any): o is ListUsersResponse {
-    return _smithy.isa(o, "ListUsersResponse");
+    return __isa(o, "ListUsersResponse");
   }
 }
 
@@ -6031,7 +6034,7 @@ export namespace ListUsersResponse {
  *             (MFA) method.</p>
  */
 export interface MFAMethodNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "MFAMethodNotFoundException";
   $fault: "client";
@@ -6044,7 +6047,7 @@ export interface MFAMethodNotFoundException
 
 export namespace MFAMethodNotFoundException {
   export function isa(o: any): o is MFAMethodNotFoundException {
-    return _smithy.isa(o, "MFAMethodNotFoundException");
+    return __isa(o, "MFAMethodNotFoundException");
   }
 }
 
@@ -6073,7 +6076,7 @@ export interface MFAOptionType {
 
 export namespace MFAOptionType {
   export function isa(o: any): o is MFAOptionType {
-    return _smithy.isa(o, "MFAOptionType");
+    return __isa(o, "MFAOptionType");
   }
 }
 
@@ -6105,7 +6108,7 @@ export interface MessageTemplateType {
 
 export namespace MessageTemplateType {
   export function isa(o: any): o is MessageTemplateType {
-    return _smithy.isa(o, "MessageTemplateType");
+    return __isa(o, "MessageTemplateType");
   }
 }
 
@@ -6127,7 +6130,7 @@ export interface NewDeviceMetadataType {
 
 export namespace NewDeviceMetadataType {
   export function isa(o: any): o is NewDeviceMetadataType {
-    return _smithy.isa(o, "NewDeviceMetadataType");
+    return __isa(o, "NewDeviceMetadataType");
   }
 }
 
@@ -6135,7 +6138,7 @@ export namespace NewDeviceMetadataType {
  * <p>This exception is thrown when a user is not authorized.</p>
  */
 export interface NotAuthorizedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "NotAuthorizedException";
   $fault: "client";
@@ -6148,7 +6151,7 @@ export interface NotAuthorizedException
 
 export namespace NotAuthorizedException {
   export function isa(o: any): o is NotAuthorizedException {
-    return _smithy.isa(o, "NotAuthorizedException");
+    return __isa(o, "NotAuthorizedException");
   }
 }
 
@@ -6193,7 +6196,7 @@ export interface NotifyConfigurationType {
 
 export namespace NotifyConfigurationType {
   export function isa(o: any): o is NotifyConfigurationType {
-    return _smithy.isa(o, "NotifyConfigurationType");
+    return __isa(o, "NotifyConfigurationType");
   }
 }
 
@@ -6220,7 +6223,7 @@ export interface NotifyEmailType {
 
 export namespace NotifyEmailType {
   export function isa(o: any): o is NotifyEmailType {
-    return _smithy.isa(o, "NotifyEmailType");
+    return __isa(o, "NotifyEmailType");
   }
 }
 
@@ -6242,7 +6245,7 @@ export interface NumberAttributeConstraintsType {
 
 export namespace NumberAttributeConstraintsType {
   export function isa(o: any): o is NumberAttributeConstraintsType {
-    return _smithy.isa(o, "NumberAttributeConstraintsType");
+    return __isa(o, "NumberAttributeConstraintsType");
   }
 }
 
@@ -6302,7 +6305,7 @@ export interface PasswordPolicyType {
 
 export namespace PasswordPolicyType {
   export function isa(o: any): o is PasswordPolicyType {
-    return _smithy.isa(o, "PasswordPolicyType");
+    return __isa(o, "PasswordPolicyType");
   }
 }
 
@@ -6310,7 +6313,7 @@ export namespace PasswordPolicyType {
  * <p>This exception is thrown when a password reset is required.</p>
  */
 export interface PasswordResetRequiredException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "PasswordResetRequiredException";
   $fault: "client";
@@ -6322,7 +6325,7 @@ export interface PasswordResetRequiredException
 
 export namespace PasswordResetRequiredException {
   export function isa(o: any): o is PasswordResetRequiredException {
-    return _smithy.isa(o, "PasswordResetRequiredException");
+    return __isa(o, "PasswordResetRequiredException");
   }
 }
 
@@ -6330,7 +6333,7 @@ export namespace PasswordResetRequiredException {
  * <p>This exception is thrown when a precondition is not met.</p>
  */
 export interface PreconditionNotMetException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "PreconditionNotMetException";
   $fault: "client";
@@ -6342,7 +6345,7 @@ export interface PreconditionNotMetException
 
 export namespace PreconditionNotMetException {
   export function isa(o: any): o is PreconditionNotMetException {
-    return _smithy.isa(o, "PreconditionNotMetException");
+    return __isa(o, "PreconditionNotMetException");
   }
 }
 
@@ -6379,7 +6382,7 @@ export interface ProviderDescription {
 
 export namespace ProviderDescription {
   export function isa(o: any): o is ProviderDescription {
-    return _smithy.isa(o, "ProviderDescription");
+    return __isa(o, "ProviderDescription");
   }
 }
 
@@ -6408,7 +6411,7 @@ export interface ProviderUserIdentifierType {
 
 export namespace ProviderUserIdentifierType {
   export function isa(o: any): o is ProviderUserIdentifierType {
-    return _smithy.isa(o, "ProviderUserIdentifierType");
+    return __isa(o, "ProviderUserIdentifierType");
   }
 }
 
@@ -6436,7 +6439,7 @@ export interface RecoveryOptionType {
 
 export namespace RecoveryOptionType {
   export function isa(o: any): o is RecoveryOptionType {
-    return _smithy.isa(o, "RecoveryOptionType");
+    return __isa(o, "RecoveryOptionType");
   }
 }
 
@@ -6513,7 +6516,7 @@ export interface ResendConfirmationCodeRequest {
 
 export namespace ResendConfirmationCodeRequest {
   export function isa(o: any): o is ResendConfirmationCodeRequest {
-    return _smithy.isa(o, "ResendConfirmationCodeRequest");
+    return __isa(o, "ResendConfirmationCodeRequest");
   }
 }
 
@@ -6532,7 +6535,7 @@ export interface ResendConfirmationCodeResponse extends $MetadataBearer {
 
 export namespace ResendConfirmationCodeResponse {
   export function isa(o: any): o is ResendConfirmationCodeResponse {
-    return _smithy.isa(o, "ResendConfirmationCodeResponse");
+    return __isa(o, "ResendConfirmationCodeResponse");
   }
 }
 
@@ -6541,7 +6544,7 @@ export namespace ResendConfirmationCodeResponse {
  *             resource.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -6554,7 +6557,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -6576,7 +6579,7 @@ export interface ResourceServerScopeType {
 
 export namespace ResourceServerScopeType {
   export function isa(o: any): o is ResourceServerScopeType {
-    return _smithy.isa(o, "ResourceServerScopeType");
+    return __isa(o, "ResourceServerScopeType");
   }
 }
 
@@ -6608,7 +6611,7 @@ export interface ResourceServerType {
 
 export namespace ResourceServerType {
   export function isa(o: any): o is ResourceServerType {
-    return _smithy.isa(o, "ResourceServerType");
+    return __isa(o, "ResourceServerType");
   }
 }
 
@@ -6736,7 +6739,7 @@ export interface RespondToAuthChallengeRequest {
 
 export namespace RespondToAuthChallengeRequest {
   export function isa(o: any): o is RespondToAuthChallengeRequest {
-    return _smithy.isa(o, "RespondToAuthChallengeRequest");
+    return __isa(o, "RespondToAuthChallengeRequest");
   }
 }
 
@@ -6773,7 +6776,7 @@ export interface RespondToAuthChallengeResponse extends $MetadataBearer {
 
 export namespace RespondToAuthChallengeResponse {
   export function isa(o: any): o is RespondToAuthChallengeResponse {
-    return _smithy.isa(o, "RespondToAuthChallengeResponse");
+    return __isa(o, "RespondToAuthChallengeResponse");
   }
 }
 
@@ -6819,7 +6822,7 @@ export interface RiskConfigurationType {
 
 export namespace RiskConfigurationType {
   export function isa(o: any): o is RiskConfigurationType {
-    return _smithy.isa(o, "RiskConfigurationType");
+    return __isa(o, "RiskConfigurationType");
   }
 }
 
@@ -6850,7 +6853,7 @@ export interface RiskExceptionConfigurationType {
 
 export namespace RiskExceptionConfigurationType {
   export function isa(o: any): o is RiskExceptionConfigurationType {
-    return _smithy.isa(o, "RiskExceptionConfigurationType");
+    return __isa(o, "RiskExceptionConfigurationType");
   }
 }
 
@@ -6878,7 +6881,7 @@ export interface SMSMfaSettingsType {
 
 export namespace SMSMfaSettingsType {
   export function isa(o: any): o is SMSMfaSettingsType {
-    return _smithy.isa(o, "SMSMfaSettingsType");
+    return __isa(o, "SMSMfaSettingsType");
   }
 }
 
@@ -6932,7 +6935,7 @@ export interface SchemaAttributeType {
 
 export namespace SchemaAttributeType {
   export function isa(o: any): o is SchemaAttributeType {
-    return _smithy.isa(o, "SchemaAttributeType");
+    return __isa(o, "SchemaAttributeType");
   }
 }
 
@@ -6940,7 +6943,7 @@ export namespace SchemaAttributeType {
  * <p>This exception is thrown when the specified scope does not exist.</p>
  */
 export interface ScopeDoesNotExistException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ScopeDoesNotExistException";
   $fault: "client";
@@ -6949,7 +6952,7 @@ export interface ScopeDoesNotExistException
 
 export namespace ScopeDoesNotExistException {
   export function isa(o: any): o is ScopeDoesNotExistException {
-    return _smithy.isa(o, "ScopeDoesNotExistException");
+    return __isa(o, "ScopeDoesNotExistException");
   }
 }
 
@@ -6988,7 +6991,7 @@ export interface SetRiskConfigurationRequest {
 
 export namespace SetRiskConfigurationRequest {
   export function isa(o: any): o is SetRiskConfigurationRequest {
-    return _smithy.isa(o, "SetRiskConfigurationRequest");
+    return __isa(o, "SetRiskConfigurationRequest");
   }
 }
 
@@ -7002,7 +7005,7 @@ export interface SetRiskConfigurationResponse extends $MetadataBearer {
 
 export namespace SetRiskConfigurationResponse {
   export function isa(o: any): o is SetRiskConfigurationResponse {
-    return _smithy.isa(o, "SetRiskConfigurationResponse");
+    return __isa(o, "SetRiskConfigurationResponse");
   }
 }
 
@@ -7031,7 +7034,7 @@ export interface SetUICustomizationRequest {
 
 export namespace SetUICustomizationRequest {
   export function isa(o: any): o is SetUICustomizationRequest {
-    return _smithy.isa(o, "SetUICustomizationRequest");
+    return __isa(o, "SetUICustomizationRequest");
   }
 }
 
@@ -7045,7 +7048,7 @@ export interface SetUICustomizationResponse extends $MetadataBearer {
 
 export namespace SetUICustomizationResponse {
   export function isa(o: any): o is SetUICustomizationResponse {
-    return _smithy.isa(o, "SetUICustomizationResponse");
+    return __isa(o, "SetUICustomizationResponse");
   }
 }
 
@@ -7069,7 +7072,7 @@ export interface SetUserMFAPreferenceRequest {
 
 export namespace SetUserMFAPreferenceRequest {
   export function isa(o: any): o is SetUserMFAPreferenceRequest {
-    return _smithy.isa(o, "SetUserMFAPreferenceRequest");
+    return __isa(o, "SetUserMFAPreferenceRequest");
   }
 }
 
@@ -7079,7 +7082,7 @@ export interface SetUserMFAPreferenceResponse extends $MetadataBearer {
 
 export namespace SetUserMFAPreferenceResponse {
   export function isa(o: any): o is SetUserMFAPreferenceResponse {
-    return _smithy.isa(o, "SetUserMFAPreferenceResponse");
+    return __isa(o, "SetUserMFAPreferenceResponse");
   }
 }
 
@@ -7122,7 +7125,7 @@ export interface SetUserPoolMfaConfigRequest {
 
 export namespace SetUserPoolMfaConfigRequest {
   export function isa(o: any): o is SetUserPoolMfaConfigRequest {
-    return _smithy.isa(o, "SetUserPoolMfaConfigRequest");
+    return __isa(o, "SetUserPoolMfaConfigRequest");
   }
 }
 
@@ -7160,7 +7163,7 @@ export interface SetUserPoolMfaConfigResponse extends $MetadataBearer {
 
 export namespace SetUserPoolMfaConfigResponse {
   export function isa(o: any): o is SetUserPoolMfaConfigResponse {
-    return _smithy.isa(o, "SetUserPoolMfaConfigResponse");
+    return __isa(o, "SetUserPoolMfaConfigResponse");
   }
 }
 
@@ -7183,7 +7186,7 @@ export interface SetUserSettingsRequest {
 
 export namespace SetUserSettingsRequest {
   export function isa(o: any): o is SetUserSettingsRequest {
-    return _smithy.isa(o, "SetUserSettingsRequest");
+    return __isa(o, "SetUserSettingsRequest");
   }
 }
 
@@ -7196,7 +7199,7 @@ export interface SetUserSettingsResponse extends $MetadataBearer {
 
 export namespace SetUserSettingsResponse {
   export function isa(o: any): o is SetUserSettingsResponse {
-    return _smithy.isa(o, "SetUserSettingsResponse");
+    return __isa(o, "SetUserSettingsResponse");
   }
 }
 
@@ -7290,7 +7293,7 @@ export interface SignUpRequest {
 
 export namespace SignUpRequest {
   export function isa(o: any): o is SignUpRequest {
-    return _smithy.isa(o, "SignUpRequest");
+    return __isa(o, "SignUpRequest");
   }
 }
 
@@ -7320,7 +7323,7 @@ export interface SignUpResponse extends $MetadataBearer {
 
 export namespace SignUpResponse {
   export function isa(o: any): o is SignUpResponse {
-    return _smithy.isa(o, "SignUpResponse");
+    return __isa(o, "SignUpResponse");
   }
 }
 
@@ -7343,7 +7346,7 @@ export interface SmsConfigurationType {
 
 export namespace SmsConfigurationType {
   export function isa(o: any): o is SmsConfigurationType {
-    return _smithy.isa(o, "SmsConfigurationType");
+    return __isa(o, "SmsConfigurationType");
   }
 }
 
@@ -7365,7 +7368,7 @@ export interface SmsMfaConfigType {
 
 export namespace SmsMfaConfigType {
   export function isa(o: any): o is SmsMfaConfigType {
-    return _smithy.isa(o, "SmsMfaConfigType");
+    return __isa(o, "SmsMfaConfigType");
   }
 }
 
@@ -7374,7 +7377,7 @@ export namespace SmsMfaConfigType {
  *             (MFA) is not enabled for the user pool.</p>
  */
 export interface SoftwareTokenMFANotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "SoftwareTokenMFANotFoundException";
   $fault: "client";
@@ -7383,7 +7386,7 @@ export interface SoftwareTokenMFANotFoundException
 
 export namespace SoftwareTokenMFANotFoundException {
   export function isa(o: any): o is SoftwareTokenMFANotFoundException {
-    return _smithy.isa(o, "SoftwareTokenMFANotFoundException");
+    return __isa(o, "SoftwareTokenMFANotFoundException");
   }
 }
 
@@ -7400,7 +7403,7 @@ export interface SoftwareTokenMfaConfigType {
 
 export namespace SoftwareTokenMfaConfigType {
   export function isa(o: any): o is SoftwareTokenMfaConfigType {
-    return _smithy.isa(o, "SoftwareTokenMfaConfigType");
+    return __isa(o, "SoftwareTokenMfaConfigType");
   }
 }
 
@@ -7422,7 +7425,7 @@ export interface SoftwareTokenMfaSettingsType {
 
 export namespace SoftwareTokenMfaSettingsType {
   export function isa(o: any): o is SoftwareTokenMfaSettingsType {
-    return _smithy.isa(o, "SoftwareTokenMfaSettingsType");
+    return __isa(o, "SoftwareTokenMfaSettingsType");
   }
 }
 
@@ -7444,7 +7447,7 @@ export interface StartUserImportJobRequest {
 
 export namespace StartUserImportJobRequest {
   export function isa(o: any): o is StartUserImportJobRequest {
-    return _smithy.isa(o, "StartUserImportJobRequest");
+    return __isa(o, "StartUserImportJobRequest");
   }
 }
 
@@ -7462,7 +7465,7 @@ export interface StartUserImportJobResponse extends $MetadataBearer {
 
 export namespace StartUserImportJobResponse {
   export function isa(o: any): o is StartUserImportJobResponse {
-    return _smithy.isa(o, "StartUserImportJobResponse");
+    return __isa(o, "StartUserImportJobResponse");
   }
 }
 
@@ -7489,7 +7492,7 @@ export interface StopUserImportJobRequest {
 
 export namespace StopUserImportJobRequest {
   export function isa(o: any): o is StopUserImportJobRequest {
-    return _smithy.isa(o, "StopUserImportJobRequest");
+    return __isa(o, "StopUserImportJobRequest");
   }
 }
 
@@ -7507,7 +7510,7 @@ export interface StopUserImportJobResponse extends $MetadataBearer {
 
 export namespace StopUserImportJobResponse {
   export function isa(o: any): o is StopUserImportJobResponse {
-    return _smithy.isa(o, "StopUserImportJobResponse");
+    return __isa(o, "StopUserImportJobResponse");
   }
 }
 
@@ -7529,7 +7532,7 @@ export interface StringAttributeConstraintsType {
 
 export namespace StringAttributeConstraintsType {
   export function isa(o: any): o is StringAttributeConstraintsType {
-    return _smithy.isa(o, "StringAttributeConstraintsType");
+    return __isa(o, "StringAttributeConstraintsType");
   }
 }
 
@@ -7548,7 +7551,7 @@ export interface TagResourceRequest {
 
 export namespace TagResourceRequest {
   export function isa(o: any): o is TagResourceRequest {
-    return _smithy.isa(o, "TagResourceRequest");
+    return __isa(o, "TagResourceRequest");
   }
 }
 
@@ -7558,7 +7561,7 @@ export interface TagResourceResponse extends $MetadataBearer {
 
 export namespace TagResourceResponse {
   export function isa(o: any): o is TagResourceResponse {
-    return _smithy.isa(o, "TagResourceResponse");
+    return __isa(o, "TagResourceResponse");
   }
 }
 
@@ -7567,7 +7570,7 @@ export namespace TagResourceResponse {
  *             action (e.g., sign in).</p>
  */
 export interface TooManyFailedAttemptsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyFailedAttemptsException";
   $fault: "client";
@@ -7580,7 +7583,7 @@ export interface TooManyFailedAttemptsException
 
 export namespace TooManyFailedAttemptsException {
   export function isa(o: any): o is TooManyFailedAttemptsException {
-    return _smithy.isa(o, "TooManyFailedAttemptsException");
+    return __isa(o, "TooManyFailedAttemptsException");
   }
 }
 
@@ -7589,7 +7592,7 @@ export namespace TooManyFailedAttemptsException {
  *             operation.</p>
  */
 export interface TooManyRequestsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyRequestsException";
   $fault: "client";
@@ -7602,7 +7605,7 @@ export interface TooManyRequestsException
 
 export namespace TooManyRequestsException {
   export function isa(o: any): o is TooManyRequestsException {
-    return _smithy.isa(o, "TooManyRequestsException");
+    return __isa(o, "TooManyRequestsException");
   }
 }
 
@@ -7650,7 +7653,7 @@ export interface UICustomizationType {
 
 export namespace UICustomizationType {
   export function isa(o: any): o is UICustomizationType {
-    return _smithy.isa(o, "UICustomizationType");
+    return __isa(o, "UICustomizationType");
   }
 }
 
@@ -7659,7 +7662,7 @@ export namespace UICustomizationType {
  *             exception with the AWS Lambda service.</p>
  */
 export interface UnexpectedLambdaException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UnexpectedLambdaException";
   $fault: "client";
@@ -7672,7 +7675,7 @@ export interface UnexpectedLambdaException
 
 export namespace UnexpectedLambdaException {
   export function isa(o: any): o is UnexpectedLambdaException {
-    return _smithy.isa(o, "UnexpectedLambdaException");
+    return __isa(o, "UnexpectedLambdaException");
   }
 }
 
@@ -7680,7 +7683,7 @@ export namespace UnexpectedLambdaException {
  * <p>This exception is thrown when the specified identifier is not supported.</p>
  */
 export interface UnsupportedIdentityProviderException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UnsupportedIdentityProviderException";
   $fault: "client";
@@ -7689,7 +7692,7 @@ export interface UnsupportedIdentityProviderException
 
 export namespace UnsupportedIdentityProviderException {
   export function isa(o: any): o is UnsupportedIdentityProviderException {
-    return _smithy.isa(o, "UnsupportedIdentityProviderException");
+    return __isa(o, "UnsupportedIdentityProviderException");
   }
 }
 
@@ -7697,7 +7700,7 @@ export namespace UnsupportedIdentityProviderException {
  * <p>The request failed because the user is in an unsupported state.</p>
  */
 export interface UnsupportedUserStateException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UnsupportedUserStateException";
   $fault: "client";
@@ -7709,7 +7712,7 @@ export interface UnsupportedUserStateException
 
 export namespace UnsupportedUserStateException {
   export function isa(o: any): o is UnsupportedUserStateException {
-    return _smithy.isa(o, "UnsupportedUserStateException");
+    return __isa(o, "UnsupportedUserStateException");
   }
 }
 
@@ -7728,7 +7731,7 @@ export interface UntagResourceRequest {
 
 export namespace UntagResourceRequest {
   export function isa(o: any): o is UntagResourceRequest {
-    return _smithy.isa(o, "UntagResourceRequest");
+    return __isa(o, "UntagResourceRequest");
   }
 }
 
@@ -7738,7 +7741,7 @@ export interface UntagResourceResponse extends $MetadataBearer {
 
 export namespace UntagResourceResponse {
   export function isa(o: any): o is UntagResourceResponse {
-    return _smithy.isa(o, "UntagResourceResponse");
+    return __isa(o, "UntagResourceResponse");
   }
 }
 
@@ -7772,7 +7775,7 @@ export interface UpdateAuthEventFeedbackRequest {
 
 export namespace UpdateAuthEventFeedbackRequest {
   export function isa(o: any): o is UpdateAuthEventFeedbackRequest {
-    return _smithy.isa(o, "UpdateAuthEventFeedbackRequest");
+    return __isa(o, "UpdateAuthEventFeedbackRequest");
   }
 }
 
@@ -7782,7 +7785,7 @@ export interface UpdateAuthEventFeedbackResponse extends $MetadataBearer {
 
 export namespace UpdateAuthEventFeedbackResponse {
   export function isa(o: any): o is UpdateAuthEventFeedbackResponse {
-    return _smithy.isa(o, "UpdateAuthEventFeedbackResponse");
+    return __isa(o, "UpdateAuthEventFeedbackResponse");
   }
 }
 
@@ -7809,7 +7812,7 @@ export interface UpdateDeviceStatusRequest {
 
 export namespace UpdateDeviceStatusRequest {
   export function isa(o: any): o is UpdateDeviceStatusRequest {
-    return _smithy.isa(o, "UpdateDeviceStatusRequest");
+    return __isa(o, "UpdateDeviceStatusRequest");
   }
 }
 
@@ -7822,7 +7825,7 @@ export interface UpdateDeviceStatusResponse extends $MetadataBearer {
 
 export namespace UpdateDeviceStatusResponse {
   export function isa(o: any): o is UpdateDeviceStatusResponse {
-    return _smithy.isa(o, "UpdateDeviceStatusResponse");
+    return __isa(o, "UpdateDeviceStatusResponse");
   }
 }
 
@@ -7859,7 +7862,7 @@ export interface UpdateGroupRequest {
 
 export namespace UpdateGroupRequest {
   export function isa(o: any): o is UpdateGroupRequest {
-    return _smithy.isa(o, "UpdateGroupRequest");
+    return __isa(o, "UpdateGroupRequest");
   }
 }
 
@@ -7873,7 +7876,7 @@ export interface UpdateGroupResponse extends $MetadataBearer {
 
 export namespace UpdateGroupResponse {
   export function isa(o: any): o is UpdateGroupResponse {
-    return _smithy.isa(o, "UpdateGroupResponse");
+    return __isa(o, "UpdateGroupResponse");
   }
 }
 
@@ -7908,7 +7911,7 @@ export interface UpdateIdentityProviderRequest {
 
 export namespace UpdateIdentityProviderRequest {
   export function isa(o: any): o is UpdateIdentityProviderRequest {
-    return _smithy.isa(o, "UpdateIdentityProviderRequest");
+    return __isa(o, "UpdateIdentityProviderRequest");
   }
 }
 
@@ -7922,7 +7925,7 @@ export interface UpdateIdentityProviderResponse extends $MetadataBearer {
 
 export namespace UpdateIdentityProviderResponse {
   export function isa(o: any): o is UpdateIdentityProviderResponse {
-    return _smithy.isa(o, "UpdateIdentityProviderResponse");
+    return __isa(o, "UpdateIdentityProviderResponse");
   }
 }
 
@@ -7951,7 +7954,7 @@ export interface UpdateResourceServerRequest {
 
 export namespace UpdateResourceServerRequest {
   export function isa(o: any): o is UpdateResourceServerRequest {
-    return _smithy.isa(o, "UpdateResourceServerRequest");
+    return __isa(o, "UpdateResourceServerRequest");
   }
 }
 
@@ -7965,7 +7968,7 @@ export interface UpdateResourceServerResponse extends $MetadataBearer {
 
 export namespace UpdateResourceServerResponse {
   export function isa(o: any): o is UpdateResourceServerResponse {
-    return _smithy.isa(o, "UpdateResourceServerResponse");
+    return __isa(o, "UpdateResourceServerResponse");
   }
 }
 
@@ -8024,7 +8027,7 @@ export interface UpdateUserAttributesRequest {
 
 export namespace UpdateUserAttributesRequest {
   export function isa(o: any): o is UpdateUserAttributesRequest {
-    return _smithy.isa(o, "UpdateUserAttributesRequest");
+    return __isa(o, "UpdateUserAttributesRequest");
   }
 }
 
@@ -8043,7 +8046,7 @@ export interface UpdateUserAttributesResponse extends $MetadataBearer {
 
 export namespace UpdateUserAttributesResponse {
   export function isa(o: any): o is UpdateUserAttributesResponse {
-    return _smithy.isa(o, "UpdateUserAttributesResponse");
+    return __isa(o, "UpdateUserAttributesResponse");
   }
 }
 
@@ -8259,7 +8262,7 @@ export interface UpdateUserPoolClientRequest {
 
 export namespace UpdateUserPoolClientRequest {
   export function isa(o: any): o is UpdateUserPoolClientRequest {
-    return _smithy.isa(o, "UpdateUserPoolClientRequest");
+    return __isa(o, "UpdateUserPoolClientRequest");
   }
 }
 
@@ -8278,7 +8281,7 @@ export interface UpdateUserPoolClientResponse extends $MetadataBearer {
 
 export namespace UpdateUserPoolClientResponse {
   export function isa(o: any): o is UpdateUserPoolClientResponse {
-    return _smithy.isa(o, "UpdateUserPoolClientResponse");
+    return __isa(o, "UpdateUserPoolClientResponse");
   }
 }
 
@@ -8311,7 +8314,7 @@ export interface UpdateUserPoolDomainRequest {
 
 export namespace UpdateUserPoolDomainRequest {
   export function isa(o: any): o is UpdateUserPoolDomainRequest {
-    return _smithy.isa(o, "UpdateUserPoolDomainRequest");
+    return __isa(o, "UpdateUserPoolDomainRequest");
   }
 }
 
@@ -8329,7 +8332,7 @@ export interface UpdateUserPoolDomainResponse extends $MetadataBearer {
 
 export namespace UpdateUserPoolDomainResponse {
   export function isa(o: any): o is UpdateUserPoolDomainResponse {
-    return _smithy.isa(o, "UpdateUserPoolDomainResponse");
+    return __isa(o, "UpdateUserPoolDomainResponse");
   }
 }
 
@@ -8448,7 +8451,7 @@ export interface UpdateUserPoolRequest {
 
 export namespace UpdateUserPoolRequest {
   export function isa(o: any): o is UpdateUserPoolRequest {
-    return _smithy.isa(o, "UpdateUserPoolRequest");
+    return __isa(o, "UpdateUserPoolRequest");
   }
 }
 
@@ -8462,7 +8465,7 @@ export interface UpdateUserPoolResponse extends $MetadataBearer {
 
 export namespace UpdateUserPoolResponse {
   export function isa(o: any): o is UpdateUserPoolResponse {
-    return _smithy.isa(o, "UpdateUserPoolResponse");
+    return __isa(o, "UpdateUserPoolResponse");
   }
 }
 
@@ -8483,7 +8486,7 @@ export interface UserContextDataType {
 
 export namespace UserContextDataType {
   export function isa(o: any): o is UserContextDataType {
-    return _smithy.isa(o, "UserContextDataType");
+    return __isa(o, "UserContextDataType");
   }
 }
 
@@ -8492,7 +8495,7 @@ export namespace UserContextDataType {
  *             job is in progress for that pool.</p>
  */
 export interface UserImportInProgressException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UserImportInProgressException";
   $fault: "client";
@@ -8504,7 +8507,7 @@ export interface UserImportInProgressException
 
 export namespace UserImportInProgressException {
   export function isa(o: any): o is UserImportInProgressException {
-    return _smithy.isa(o, "UserImportInProgressException");
+    return __isa(o, "UserImportInProgressException");
   }
 }
 
@@ -8634,7 +8637,7 @@ export interface UserImportJobType {
 
 export namespace UserImportJobType {
   export function isa(o: any): o is UserImportJobType {
-    return _smithy.isa(o, "UserImportJobType");
+    return __isa(o, "UserImportJobType");
   }
 }
 
@@ -8643,7 +8646,7 @@ export namespace UserImportJobType {
  *             exception with the AWS Lambda service.</p>
  */
 export interface UserLambdaValidationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UserLambdaValidationException";
   $fault: "client";
@@ -8656,7 +8659,7 @@ export interface UserLambdaValidationException
 
 export namespace UserLambdaValidationException {
   export function isa(o: any): o is UserLambdaValidationException {
-    return _smithy.isa(o, "UserLambdaValidationException");
+    return __isa(o, "UserLambdaValidationException");
   }
 }
 
@@ -8664,7 +8667,7 @@ export namespace UserLambdaValidationException {
  * <p>This exception is thrown when a user is not confirmed successfully.</p>
  */
 export interface UserNotConfirmedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UserNotConfirmedException";
   $fault: "client";
@@ -8676,7 +8679,7 @@ export interface UserNotConfirmedException
 
 export namespace UserNotConfirmedException {
   export function isa(o: any): o is UserNotConfirmedException {
-    return _smithy.isa(o, "UserNotConfirmedException");
+    return __isa(o, "UserNotConfirmedException");
   }
 }
 
@@ -8684,7 +8687,7 @@ export namespace UserNotConfirmedException {
  * <p>This exception is thrown when a user is not found.</p>
  */
 export interface UserNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UserNotFoundException";
   $fault: "client";
@@ -8696,7 +8699,7 @@ export interface UserNotFoundException
 
 export namespace UserNotFoundException {
   export function isa(o: any): o is UserNotFoundException {
-    return _smithy.isa(o, "UserNotFoundException");
+    return __isa(o, "UserNotFoundException");
   }
 }
 
@@ -8704,7 +8707,7 @@ export namespace UserNotFoundException {
  * <p>This exception is thrown when user pool add-ons are not enabled.</p>
  */
 export interface UserPoolAddOnNotEnabledException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UserPoolAddOnNotEnabledException";
   $fault: "client";
@@ -8713,7 +8716,7 @@ export interface UserPoolAddOnNotEnabledException
 
 export namespace UserPoolAddOnNotEnabledException {
   export function isa(o: any): o is UserPoolAddOnNotEnabledException {
-    return _smithy.isa(o, "UserPoolAddOnNotEnabledException");
+    return __isa(o, "UserPoolAddOnNotEnabledException");
   }
 }
 
@@ -8730,7 +8733,7 @@ export interface UserPoolAddOnsType {
 
 export namespace UserPoolAddOnsType {
   export function isa(o: any): o is UserPoolAddOnsType {
-    return _smithy.isa(o, "UserPoolAddOnsType");
+    return __isa(o, "UserPoolAddOnsType");
   }
 }
 
@@ -8758,7 +8761,7 @@ export interface UserPoolClientDescription {
 
 export namespace UserPoolClientDescription {
   export function isa(o: any): o is UserPoolClientDescription {
-    return _smithy.isa(o, "UserPoolClientDescription");
+    return __isa(o, "UserPoolClientDescription");
   }
 }
 
@@ -8989,7 +8992,7 @@ export interface UserPoolClientType {
 
 export namespace UserPoolClientType {
   export function isa(o: any): o is UserPoolClientType {
-    return _smithy.isa(o, "UserPoolClientType");
+    return __isa(o, "UserPoolClientType");
   }
 }
 
@@ -9031,7 +9034,7 @@ export interface UserPoolDescriptionType {
 
 export namespace UserPoolDescriptionType {
   export function isa(o: any): o is UserPoolDescriptionType {
-    return _smithy.isa(o, "UserPoolDescriptionType");
+    return __isa(o, "UserPoolDescriptionType");
   }
 }
 
@@ -9054,7 +9057,7 @@ export interface UserPoolPolicyType {
 
 export namespace UserPoolPolicyType {
   export function isa(o: any): o is UserPoolPolicyType {
-    return _smithy.isa(o, "UserPoolPolicyType");
+    return __isa(o, "UserPoolPolicyType");
   }
 }
 
@@ -9062,7 +9065,7 @@ export namespace UserPoolPolicyType {
  * <p>This exception is thrown when a user pool tag cannot be set or updated.</p>
  */
 export interface UserPoolTaggingException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UserPoolTaggingException";
   $fault: "client";
@@ -9071,7 +9074,7 @@ export interface UserPoolTaggingException
 
 export namespace UserPoolTaggingException {
   export function isa(o: any): o is UserPoolTaggingException {
-    return _smithy.isa(o, "UserPoolTaggingException");
+    return __isa(o, "UserPoolTaggingException");
   }
 }
 
@@ -9256,7 +9259,7 @@ export interface UserPoolType {
 
 export namespace UserPoolType {
   export function isa(o: any): o is UserPoolType {
-    return _smithy.isa(o, "UserPoolType");
+    return __isa(o, "UserPoolType");
   }
 }
 
@@ -9339,7 +9342,7 @@ export interface UserType {
 
 export namespace UserType {
   export function isa(o: any): o is UserType {
-    return _smithy.isa(o, "UserType");
+    return __isa(o, "UserType");
   }
 }
 
@@ -9353,7 +9356,7 @@ export enum UsernameAttributeType {
  *             exists in the user pool.</p>
  */
 export interface UsernameExistsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UsernameExistsException";
   $fault: "client";
@@ -9365,7 +9368,7 @@ export interface UsernameExistsException
 
 export namespace UsernameExistsException {
   export function isa(o: any): o is UsernameExistsException {
-    return _smithy.isa(o, "UsernameExistsException");
+    return __isa(o, "UsernameExistsException");
   }
 }
 
@@ -9408,7 +9411,7 @@ export interface VerificationMessageTemplateType {
 
 export namespace VerificationMessageTemplateType {
   export function isa(o: any): o is VerificationMessageTemplateType {
-    return _smithy.isa(o, "VerificationMessageTemplateType");
+    return __isa(o, "VerificationMessageTemplateType");
   }
 }
 
@@ -9443,7 +9446,7 @@ export interface VerifySoftwareTokenRequest {
 
 export namespace VerifySoftwareTokenRequest {
   export function isa(o: any): o is VerifySoftwareTokenRequest {
-    return _smithy.isa(o, "VerifySoftwareTokenRequest");
+    return __isa(o, "VerifySoftwareTokenRequest");
   }
 }
 
@@ -9463,7 +9466,7 @@ export interface VerifySoftwareTokenResponse extends $MetadataBearer {
 
 export namespace VerifySoftwareTokenResponse {
   export function isa(o: any): o is VerifySoftwareTokenResponse {
-    return _smithy.isa(o, "VerifySoftwareTokenResponse");
+    return __isa(o, "VerifySoftwareTokenResponse");
   }
 }
 
@@ -9495,7 +9498,7 @@ export interface VerifyUserAttributeRequest {
 
 export namespace VerifyUserAttributeRequest {
   export function isa(o: any): o is VerifyUserAttributeRequest {
-    return _smithy.isa(o, "VerifyUserAttributeRequest");
+    return __isa(o, "VerifyUserAttributeRequest");
   }
 }
 
@@ -9509,6 +9512,6 @@ export interface VerifyUserAttributeResponse extends $MetadataBearer {
 
 export namespace VerifyUserAttributeResponse {
   export function isa(o: any): o is VerifyUserAttributeResponse {
-    return _smithy.isa(o, "VerifyUserAttributeResponse");
+    return __isa(o, "VerifyUserAttributeResponse");
   }
 }

--- a/clients/client-cognito-identity-provider/protocols/Aws_json1_1.ts
+++ b/clients/client-cognito-identity-provider/protocols/Aws_json1_1.ts
@@ -2255,6 +2255,7 @@ export async function deserializeAws_json1_1AdminAddUserToGroupCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: AdminAddUserToGroupCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2631,6 +2632,7 @@ export async function deserializeAws_json1_1AdminDeleteUserCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1AdminDeleteUserCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: AdminDeleteUserCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -3100,6 +3102,7 @@ export async function deserializeAws_json1_1AdminForgetDeviceCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1AdminForgetDeviceCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: AdminForgetDeviceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -3928,6 +3931,7 @@ export async function deserializeAws_json1_1AdminRemoveUserFromGroupCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: AdminRemoveUserFromGroupCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -6448,6 +6452,7 @@ export async function deserializeAws_json1_1DeleteGroupCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1DeleteGroupCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteGroupCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -6530,6 +6535,7 @@ export async function deserializeAws_json1_1DeleteIdentityProviderCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteIdentityProviderCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -6619,6 +6625,7 @@ export async function deserializeAws_json1_1DeleteResourceServerCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteResourceServerCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -6698,6 +6705,7 @@ export async function deserializeAws_json1_1DeleteUserCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1DeleteUserCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteUserCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -6906,6 +6914,7 @@ export async function deserializeAws_json1_1DeleteUserPoolCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1DeleteUserPoolCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteUserPoolCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -6995,6 +7004,7 @@ export async function deserializeAws_json1_1DeleteUserPoolClientCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteUserPoolClientCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -7782,6 +7792,7 @@ export async function deserializeAws_json1_1ForgetDeviceCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1ForgetDeviceCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: ForgetDeviceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };

--- a/clients/client-cognito-identity/models/index.ts
+++ b/clients/client-cognito-identity/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export enum AmbiguousRoleResolutionType {
@@ -37,7 +40,7 @@ export interface CognitoIdentityProvider {
 
 export namespace CognitoIdentityProvider {
   export function isa(o: any): o is CognitoIdentityProvider {
-    return _smithy.isa(o, "CognitoIdentityProvider");
+    return __isa(o, "CognitoIdentityProvider");
   }
 }
 
@@ -45,7 +48,7 @@ export namespace CognitoIdentityProvider {
  * <p>Thrown if there are parallel requests to modify a resource.</p>
  */
 export interface ConcurrentModificationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ConcurrentModificationException";
   $fault: "client";
@@ -57,7 +60,7 @@ export interface ConcurrentModificationException
 
 export namespace ConcurrentModificationException {
   export function isa(o: any): o is ConcurrentModificationException {
-    return _smithy.isa(o, "ConcurrentModificationException");
+    return __isa(o, "ConcurrentModificationException");
   }
 }
 
@@ -124,7 +127,7 @@ export interface CreateIdentityPoolInput {
 
 export namespace CreateIdentityPoolInput {
   export function isa(o: any): o is CreateIdentityPoolInput {
-    return _smithy.isa(o, "CreateIdentityPoolInput");
+    return __isa(o, "CreateIdentityPoolInput");
   }
 }
 
@@ -156,7 +159,7 @@ export interface Credentials {
 
 export namespace Credentials {
   export function isa(o: any): o is Credentials {
-    return _smithy.isa(o, "Credentials");
+    return __isa(o, "Credentials");
   }
 }
 
@@ -173,7 +176,7 @@ export interface DeleteIdentitiesInput {
 
 export namespace DeleteIdentitiesInput {
   export function isa(o: any): o is DeleteIdentitiesInput {
-    return _smithy.isa(o, "DeleteIdentitiesInput");
+    return __isa(o, "DeleteIdentitiesInput");
   }
 }
 
@@ -192,7 +195,7 @@ export interface DeleteIdentitiesResponse extends $MetadataBearer {
 
 export namespace DeleteIdentitiesResponse {
   export function isa(o: any): o is DeleteIdentitiesResponse {
-    return _smithy.isa(o, "DeleteIdentitiesResponse");
+    return __isa(o, "DeleteIdentitiesResponse");
   }
 }
 
@@ -209,7 +212,7 @@ export interface DeleteIdentityPoolInput {
 
 export namespace DeleteIdentityPoolInput {
   export function isa(o: any): o is DeleteIdentityPoolInput {
-    return _smithy.isa(o, "DeleteIdentityPoolInput");
+    return __isa(o, "DeleteIdentityPoolInput");
   }
 }
 
@@ -226,7 +229,7 @@ export interface DescribeIdentityInput {
 
 export namespace DescribeIdentityInput {
   export function isa(o: any): o is DescribeIdentityInput {
-    return _smithy.isa(o, "DescribeIdentityInput");
+    return __isa(o, "DescribeIdentityInput");
   }
 }
 
@@ -243,7 +246,7 @@ export interface DescribeIdentityPoolInput {
 
 export namespace DescribeIdentityPoolInput {
   export function isa(o: any): o is DescribeIdentityPoolInput {
-    return _smithy.isa(o, "DescribeIdentityPoolInput");
+    return __isa(o, "DescribeIdentityPoolInput");
   }
 }
 
@@ -252,7 +255,7 @@ export namespace DescribeIdentityPoolInput {
  *          different identity ID.</p>
  */
 export interface DeveloperUserAlreadyRegisteredException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DeveloperUserAlreadyRegisteredException";
   $fault: "client";
@@ -264,7 +267,7 @@ export interface DeveloperUserAlreadyRegisteredException
 
 export namespace DeveloperUserAlreadyRegisteredException {
   export function isa(o: any): o is DeveloperUserAlreadyRegisteredException {
-    return _smithy.isa(o, "DeveloperUserAlreadyRegisteredException");
+    return __isa(o, "DeveloperUserAlreadyRegisteredException");
   }
 }
 
@@ -278,7 +281,7 @@ export enum ErrorCode {
  *          responding</p>
  */
 export interface ExternalServiceException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ExternalServiceException";
   $fault: "client";
@@ -290,7 +293,7 @@ export interface ExternalServiceException
 
 export namespace ExternalServiceException {
   export function isa(o: any): o is ExternalServiceException {
-    return _smithy.isa(o, "ExternalServiceException");
+    return __isa(o, "ExternalServiceException");
   }
 }
 
@@ -328,7 +331,7 @@ export interface GetCredentialsForIdentityInput {
 
 export namespace GetCredentialsForIdentityInput {
   export function isa(o: any): o is GetCredentialsForIdentityInput {
-    return _smithy.isa(o, "GetCredentialsForIdentityInput");
+    return __isa(o, "GetCredentialsForIdentityInput");
   }
 }
 
@@ -351,7 +354,7 @@ export interface GetCredentialsForIdentityResponse extends $MetadataBearer {
 
 export namespace GetCredentialsForIdentityResponse {
   export function isa(o: any): o is GetCredentialsForIdentityResponse {
-    return _smithy.isa(o, "GetCredentialsForIdentityResponse");
+    return __isa(o, "GetCredentialsForIdentityResponse");
   }
 }
 
@@ -407,7 +410,7 @@ export interface GetIdInput {
 
 export namespace GetIdInput {
   export function isa(o: any): o is GetIdInput {
-    return _smithy.isa(o, "GetIdInput");
+    return __isa(o, "GetIdInput");
   }
 }
 
@@ -424,7 +427,7 @@ export interface GetIdResponse extends $MetadataBearer {
 
 export namespace GetIdResponse {
   export function isa(o: any): o is GetIdResponse {
-    return _smithy.isa(o, "GetIdResponse");
+    return __isa(o, "GetIdResponse");
   }
 }
 
@@ -441,7 +444,7 @@ export interface GetIdentityPoolRolesInput {
 
 export namespace GetIdentityPoolRolesInput {
   export function isa(o: any): o is GetIdentityPoolRolesInput {
-    return _smithy.isa(o, "GetIdentityPoolRolesInput");
+    return __isa(o, "GetIdentityPoolRolesInput");
   }
 }
 
@@ -473,7 +476,7 @@ export interface GetIdentityPoolRolesResponse extends $MetadataBearer {
 
 export namespace GetIdentityPoolRolesResponse {
   export function isa(o: any): o is GetIdentityPoolRolesResponse {
-    return _smithy.isa(o, "GetIdentityPoolRolesResponse");
+    return __isa(o, "GetIdentityPoolRolesResponse");
   }
 }
 
@@ -521,7 +524,7 @@ export interface GetOpenIdTokenForDeveloperIdentityInput {
 
 export namespace GetOpenIdTokenForDeveloperIdentityInput {
   export function isa(o: any): o is GetOpenIdTokenForDeveloperIdentityInput {
-    return _smithy.isa(o, "GetOpenIdTokenForDeveloperIdentityInput");
+    return __isa(o, "GetOpenIdTokenForDeveloperIdentityInput");
   }
 }
 
@@ -545,7 +548,7 @@ export interface GetOpenIdTokenForDeveloperIdentityResponse
 
 export namespace GetOpenIdTokenForDeveloperIdentityResponse {
   export function isa(o: any): o is GetOpenIdTokenForDeveloperIdentityResponse {
-    return _smithy.isa(o, "GetOpenIdTokenForDeveloperIdentityResponse");
+    return __isa(o, "GetOpenIdTokenForDeveloperIdentityResponse");
   }
 }
 
@@ -570,7 +573,7 @@ export interface GetOpenIdTokenInput {
 
 export namespace GetOpenIdTokenInput {
   export function isa(o: any): o is GetOpenIdTokenInput {
-    return _smithy.isa(o, "GetOpenIdTokenInput");
+    return __isa(o, "GetOpenIdTokenInput");
   }
 }
 
@@ -593,7 +596,7 @@ export interface GetOpenIdTokenResponse extends $MetadataBearer {
 
 export namespace GetOpenIdTokenResponse {
   export function isa(o: any): o is GetOpenIdTokenResponse {
-    return _smithy.isa(o, "GetOpenIdTokenResponse");
+    return __isa(o, "GetOpenIdTokenResponse");
   }
 }
 
@@ -625,7 +628,7 @@ export interface IdentityDescription extends $MetadataBearer {
 
 export namespace IdentityDescription {
   export function isa(o: any): o is IdentityDescription {
-    return _smithy.isa(o, "IdentityDescription");
+    return __isa(o, "IdentityDescription");
   }
 }
 
@@ -691,7 +694,7 @@ export interface IdentityPool extends $MetadataBearer {
 
 export namespace IdentityPool {
   export function isa(o: any): o is IdentityPool {
-    return _smithy.isa(o, "IdentityPool");
+    return __isa(o, "IdentityPool");
   }
 }
 
@@ -713,7 +716,7 @@ export interface IdentityPoolShortDescription {
 
 export namespace IdentityPoolShortDescription {
   export function isa(o: any): o is IdentityPoolShortDescription {
-    return _smithy.isa(o, "IdentityPoolShortDescription");
+    return __isa(o, "IdentityPoolShortDescription");
   }
 }
 
@@ -721,7 +724,7 @@ export namespace IdentityPoolShortDescription {
  * <p>Thrown when the service encounters an error during processing the request.</p>
  */
 export interface InternalErrorException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalErrorException";
   $fault: "server";
@@ -733,7 +736,7 @@ export interface InternalErrorException
 
 export namespace InternalErrorException {
   export function isa(o: any): o is InternalErrorException {
-    return _smithy.isa(o, "InternalErrorException");
+    return __isa(o, "InternalErrorException");
   }
 }
 
@@ -742,7 +745,7 @@ export namespace InternalErrorException {
  *          (auth/unauth) or if the AssumeRole fails.</p>
  */
 export interface InvalidIdentityPoolConfigurationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidIdentityPoolConfigurationException";
   $fault: "client";
@@ -755,7 +758,7 @@ export interface InvalidIdentityPoolConfigurationException
 
 export namespace InvalidIdentityPoolConfigurationException {
   export function isa(o: any): o is InvalidIdentityPoolConfigurationException {
-    return _smithy.isa(o, "InvalidIdentityPoolConfigurationException");
+    return __isa(o, "InvalidIdentityPoolConfigurationException");
   }
 }
 
@@ -763,7 +766,7 @@ export namespace InvalidIdentityPoolConfigurationException {
  * <p>Thrown for missing or bad input parameter(s).</p>
  */
 export interface InvalidParameterException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidParameterException";
   $fault: "client";
@@ -775,7 +778,7 @@ export interface InvalidParameterException
 
 export namespace InvalidParameterException {
   export function isa(o: any): o is InvalidParameterException {
-    return _smithy.isa(o, "InvalidParameterException");
+    return __isa(o, "InvalidParameterException");
   }
 }
 
@@ -783,7 +786,7 @@ export namespace InvalidParameterException {
  * <p>Thrown when the total number of user pools has exceeded a preset limit.</p>
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -795,7 +798,7 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
@@ -828,7 +831,7 @@ export interface ListIdentitiesInput {
 
 export namespace ListIdentitiesInput {
   export function isa(o: any): o is ListIdentitiesInput {
-    return _smithy.isa(o, "ListIdentitiesInput");
+    return __isa(o, "ListIdentitiesInput");
   }
 }
 
@@ -855,7 +858,7 @@ export interface ListIdentitiesResponse extends $MetadataBearer {
 
 export namespace ListIdentitiesResponse {
   export function isa(o: any): o is ListIdentitiesResponse {
-    return _smithy.isa(o, "ListIdentitiesResponse");
+    return __isa(o, "ListIdentitiesResponse");
   }
 }
 
@@ -877,7 +880,7 @@ export interface ListIdentityPoolsInput {
 
 export namespace ListIdentityPoolsInput {
   export function isa(o: any): o is ListIdentityPoolsInput {
-    return _smithy.isa(o, "ListIdentityPoolsInput");
+    return __isa(o, "ListIdentityPoolsInput");
   }
 }
 
@@ -899,7 +902,7 @@ export interface ListIdentityPoolsResponse extends $MetadataBearer {
 
 export namespace ListIdentityPoolsResponse {
   export function isa(o: any): o is ListIdentityPoolsResponse {
-    return _smithy.isa(o, "ListIdentityPoolsResponse");
+    return __isa(o, "ListIdentityPoolsResponse");
   }
 }
 
@@ -914,7 +917,7 @@ export interface ListTagsForResourceInput {
 
 export namespace ListTagsForResourceInput {
   export function isa(o: any): o is ListTagsForResourceInput {
-    return _smithy.isa(o, "ListTagsForResourceInput");
+    return __isa(o, "ListTagsForResourceInput");
   }
 }
 
@@ -928,7 +931,7 @@ export interface ListTagsForResourceResponse extends $MetadataBearer {
 
 export namespace ListTagsForResourceResponse {
   export function isa(o: any): o is ListTagsForResourceResponse {
-    return _smithy.isa(o, "ListTagsForResourceResponse");
+    return __isa(o, "ListTagsForResourceResponse");
   }
 }
 
@@ -972,7 +975,7 @@ export interface LookupDeveloperIdentityInput {
 
 export namespace LookupDeveloperIdentityInput {
   export function isa(o: any): o is LookupDeveloperIdentityInput {
-    return _smithy.isa(o, "LookupDeveloperIdentityInput");
+    return __isa(o, "LookupDeveloperIdentityInput");
   }
 }
 
@@ -1007,7 +1010,7 @@ export interface LookupDeveloperIdentityResponse extends $MetadataBearer {
 
 export namespace LookupDeveloperIdentityResponse {
   export function isa(o: any): o is LookupDeveloperIdentityResponse {
-    return _smithy.isa(o, "LookupDeveloperIdentityResponse");
+    return __isa(o, "LookupDeveloperIdentityResponse");
   }
 }
 
@@ -1042,7 +1045,7 @@ export interface MappingRule {
 
 export namespace MappingRule {
   export function isa(o: any): o is MappingRule {
-    return _smithy.isa(o, "MappingRule");
+    return __isa(o, "MappingRule");
   }
 }
 
@@ -1087,7 +1090,7 @@ export interface MergeDeveloperIdentitiesInput {
 
 export namespace MergeDeveloperIdentitiesInput {
   export function isa(o: any): o is MergeDeveloperIdentitiesInput {
-    return _smithy.isa(o, "MergeDeveloperIdentitiesInput");
+    return __isa(o, "MergeDeveloperIdentitiesInput");
   }
 }
 
@@ -1105,7 +1108,7 @@ export interface MergeDeveloperIdentitiesResponse extends $MetadataBearer {
 
 export namespace MergeDeveloperIdentitiesResponse {
   export function isa(o: any): o is MergeDeveloperIdentitiesResponse {
-    return _smithy.isa(o, "MergeDeveloperIdentitiesResponse");
+    return __isa(o, "MergeDeveloperIdentitiesResponse");
   }
 }
 
@@ -1113,7 +1116,7 @@ export namespace MergeDeveloperIdentitiesResponse {
  * <p>Thrown when a user is not authorized to access the requested resource.</p>
  */
 export interface NotAuthorizedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "NotAuthorizedException";
   $fault: "client";
@@ -1125,7 +1128,7 @@ export interface NotAuthorizedException
 
 export namespace NotAuthorizedException {
   export function isa(o: any): o is NotAuthorizedException {
-    return _smithy.isa(o, "NotAuthorizedException");
+    return __isa(o, "NotAuthorizedException");
   }
 }
 
@@ -1134,7 +1137,7 @@ export namespace NotAuthorizedException {
  *          account.</p>
  */
 export interface ResourceConflictException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceConflictException";
   $fault: "client";
@@ -1146,7 +1149,7 @@ export interface ResourceConflictException
 
 export namespace ResourceConflictException {
   export function isa(o: any): o is ResourceConflictException {
-    return _smithy.isa(o, "ResourceConflictException");
+    return __isa(o, "ResourceConflictException");
   }
 }
 
@@ -1155,7 +1158,7 @@ export namespace ResourceConflictException {
  *          exist.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -1167,7 +1170,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -1204,7 +1207,7 @@ export interface RoleMapping {
 
 export namespace RoleMapping {
   export function isa(o: any): o is RoleMapping {
-    return _smithy.isa(o, "RoleMapping");
+    return __isa(o, "RoleMapping");
   }
 }
 
@@ -1227,7 +1230,7 @@ export interface RulesConfigurationType {
 
 export namespace RulesConfigurationType {
   export function isa(o: any): o is RulesConfigurationType {
-    return _smithy.isa(o, "RulesConfigurationType");
+    return __isa(o, "RulesConfigurationType");
   }
 }
 
@@ -1259,7 +1262,7 @@ export interface SetIdentityPoolRolesInput {
 
 export namespace SetIdentityPoolRolesInput {
   export function isa(o: any): o is SetIdentityPoolRolesInput {
-    return _smithy.isa(o, "SetIdentityPoolRolesInput");
+    return __isa(o, "SetIdentityPoolRolesInput");
   }
 }
 
@@ -1278,7 +1281,7 @@ export interface TagResourceInput {
 
 export namespace TagResourceInput {
   export function isa(o: any): o is TagResourceInput {
-    return _smithy.isa(o, "TagResourceInput");
+    return __isa(o, "TagResourceInput");
   }
 }
 
@@ -1288,7 +1291,7 @@ export interface TagResourceResponse extends $MetadataBearer {
 
 export namespace TagResourceResponse {
   export function isa(o: any): o is TagResourceResponse {
-    return _smithy.isa(o, "TagResourceResponse");
+    return __isa(o, "TagResourceResponse");
   }
 }
 
@@ -1296,7 +1299,7 @@ export namespace TagResourceResponse {
  * <p>Thrown when a request is throttled.</p>
  */
 export interface TooManyRequestsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyRequestsException";
   $fault: "client";
@@ -1308,7 +1311,7 @@ export interface TooManyRequestsException
 
 export namespace TooManyRequestsException {
   export function isa(o: any): o is TooManyRequestsException {
-    return _smithy.isa(o, "TooManyRequestsException");
+    return __isa(o, "TooManyRequestsException");
   }
 }
 
@@ -1340,7 +1343,7 @@ export interface UnlinkDeveloperIdentityInput {
 
 export namespace UnlinkDeveloperIdentityInput {
   export function isa(o: any): o is UnlinkDeveloperIdentityInput {
-    return _smithy.isa(o, "UnlinkDeveloperIdentityInput");
+    return __isa(o, "UnlinkDeveloperIdentityInput");
   }
 }
 
@@ -1368,7 +1371,7 @@ export interface UnlinkIdentityInput {
 
 export namespace UnlinkIdentityInput {
   export function isa(o: any): o is UnlinkIdentityInput {
-    return _smithy.isa(o, "UnlinkIdentityInput");
+    return __isa(o, "UnlinkIdentityInput");
   }
 }
 
@@ -1391,7 +1394,7 @@ export interface UnprocessedIdentityId {
 
 export namespace UnprocessedIdentityId {
   export function isa(o: any): o is UnprocessedIdentityId {
-    return _smithy.isa(o, "UnprocessedIdentityId");
+    return __isa(o, "UnprocessedIdentityId");
   }
 }
 
@@ -1411,7 +1414,7 @@ export interface UntagResourceInput {
 
 export namespace UntagResourceInput {
   export function isa(o: any): o is UntagResourceInput {
-    return _smithy.isa(o, "UntagResourceInput");
+    return __isa(o, "UntagResourceInput");
   }
 }
 
@@ -1421,6 +1424,6 @@ export interface UntagResourceResponse extends $MetadataBearer {
 
 export namespace UntagResourceResponse {
   export function isa(o: any): o is UntagResourceResponse {
-    return _smithy.isa(o, "UntagResourceResponse");
+    return __isa(o, "UntagResourceResponse");
   }
 }

--- a/clients/client-cognito-identity/protocols/Aws_json1_1.ts
+++ b/clients/client-cognito-identity/protocols/Aws_json1_1.ts
@@ -613,6 +613,7 @@ export async function deserializeAws_json1_1DeleteIdentityPoolCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteIdentityPoolCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1827,6 +1828,7 @@ export async function deserializeAws_json1_1SetIdentityPoolRolesCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: SetIdentityPoolRolesCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2007,6 +2009,7 @@ export async function deserializeAws_json1_1UnlinkDeveloperIdentityCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: UnlinkDeveloperIdentityCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2093,6 +2096,7 @@ export async function deserializeAws_json1_1UnlinkIdentityCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1UnlinkIdentityCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: UnlinkIdentityCommandOutput = {
     $metadata: deserializeMetadata(output)
   };

--- a/clients/client-cognito-sync/models/index.ts
+++ b/clients/client-cognito-sync/models/index.ts
@@ -1,11 +1,14 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
  * <p>An exception thrown when a bulk publish operation is requested less than 24 hours after a previous bulk publish operation completed successfully.</p>
  */
 export interface AlreadyStreamedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AlreadyStreamedException";
   $fault: "client";
@@ -17,7 +20,7 @@ export interface AlreadyStreamedException
 
 export namespace AlreadyStreamedException {
   export function isa(o: any): o is AlreadyStreamedException {
-    return _smithy.isa(o, "AlreadyStreamedException");
+    return __isa(o, "AlreadyStreamedException");
   }
 }
 
@@ -34,7 +37,7 @@ export interface BulkPublishRequest {
 
 export namespace BulkPublishRequest {
   export function isa(o: any): o is BulkPublishRequest {
-    return _smithy.isa(o, "BulkPublishRequest");
+    return __isa(o, "BulkPublishRequest");
   }
 }
 
@@ -51,7 +54,7 @@ export interface BulkPublishResponse extends $MetadataBearer {
 
 export namespace BulkPublishResponse {
   export function isa(o: any): o is BulkPublishResponse {
-    return _smithy.isa(o, "BulkPublishResponse");
+    return __isa(o, "BulkPublishResponse");
   }
 }
 
@@ -98,7 +101,7 @@ export interface CognitoStreams {
 
 export namespace CognitoStreams {
   export function isa(o: any): o is CognitoStreams {
-    return _smithy.isa(o, "CognitoStreams");
+    return __isa(o, "CognitoStreams");
   }
 }
 
@@ -106,7 +109,7 @@ export namespace CognitoStreams {
  * <p>Thrown if there are parallel requests to modify a resource.</p>
  */
 export interface ConcurrentModificationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ConcurrentModificationException";
   $fault: "client";
@@ -118,7 +121,7 @@ export interface ConcurrentModificationException
 
 export namespace ConcurrentModificationException {
   export function isa(o: any): o is ConcurrentModificationException {
-    return _smithy.isa(o, "ConcurrentModificationException");
+    return __isa(o, "ConcurrentModificationException");
   }
 }
 
@@ -169,7 +172,7 @@ export interface Dataset {
 
 export namespace Dataset {
   export function isa(o: any): o is Dataset {
-    return _smithy.isa(o, "Dataset");
+    return __isa(o, "Dataset");
   }
 }
 
@@ -199,7 +202,7 @@ export interface DeleteDatasetRequest {
 
 export namespace DeleteDatasetRequest {
   export function isa(o: any): o is DeleteDatasetRequest {
-    return _smithy.isa(o, "DeleteDatasetRequest");
+    return __isa(o, "DeleteDatasetRequest");
   }
 }
 
@@ -219,7 +222,7 @@ export interface DeleteDatasetResponse extends $MetadataBearer {
 
 export namespace DeleteDatasetResponse {
   export function isa(o: any): o is DeleteDatasetResponse {
-    return _smithy.isa(o, "DeleteDatasetResponse");
+    return __isa(o, "DeleteDatasetResponse");
   }
 }
 
@@ -250,7 +253,7 @@ export interface DescribeDatasetRequest {
 
 export namespace DescribeDatasetRequest {
   export function isa(o: any): o is DescribeDatasetRequest {
-    return _smithy.isa(o, "DescribeDatasetRequest");
+    return __isa(o, "DescribeDatasetRequest");
   }
 }
 
@@ -270,7 +273,7 @@ export interface DescribeDatasetResponse extends $MetadataBearer {
 
 export namespace DescribeDatasetResponse {
   export function isa(o: any): o is DescribeDatasetResponse {
-    return _smithy.isa(o, "DescribeDatasetResponse");
+    return __isa(o, "DescribeDatasetResponse");
   }
 }
 
@@ -288,7 +291,7 @@ export interface DescribeIdentityPoolUsageRequest {
 
 export namespace DescribeIdentityPoolUsageRequest {
   export function isa(o: any): o is DescribeIdentityPoolUsageRequest {
-    return _smithy.isa(o, "DescribeIdentityPoolUsageRequest");
+    return __isa(o, "DescribeIdentityPoolUsageRequest");
   }
 }
 
@@ -305,7 +308,7 @@ export interface DescribeIdentityPoolUsageResponse extends $MetadataBearer {
 
 export namespace DescribeIdentityPoolUsageResponse {
   export function isa(o: any): o is DescribeIdentityPoolUsageResponse {
-    return _smithy.isa(o, "DescribeIdentityPoolUsageResponse");
+    return __isa(o, "DescribeIdentityPoolUsageResponse");
   }
 }
 
@@ -329,7 +332,7 @@ export interface DescribeIdentityUsageRequest {
 
 export namespace DescribeIdentityUsageRequest {
   export function isa(o: any): o is DescribeIdentityUsageRequest {
-    return _smithy.isa(o, "DescribeIdentityUsageRequest");
+    return __isa(o, "DescribeIdentityUsageRequest");
   }
 }
 
@@ -346,7 +349,7 @@ export interface DescribeIdentityUsageResponse extends $MetadataBearer {
 
 export namespace DescribeIdentityUsageResponse {
   export function isa(o: any): o is DescribeIdentityUsageResponse {
-    return _smithy.isa(o, "DescribeIdentityUsageResponse");
+    return __isa(o, "DescribeIdentityUsageResponse");
   }
 }
 
@@ -354,7 +357,7 @@ export namespace DescribeIdentityUsageResponse {
  * <p>An exception thrown when there is an IN_PROGRESS bulk publish operation for the given identity pool.</p>
  */
 export interface DuplicateRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DuplicateRequestException";
   $fault: "client";
@@ -366,7 +369,7 @@ export interface DuplicateRequestException
 
 export namespace DuplicateRequestException {
   export function isa(o: any): o is DuplicateRequestException {
-    return _smithy.isa(o, "DuplicateRequestException");
+    return __isa(o, "DuplicateRequestException");
   }
 }
 
@@ -383,7 +386,7 @@ export interface GetBulkPublishDetailsRequest {
 
 export namespace GetBulkPublishDetailsRequest {
   export function isa(o: any): o is GetBulkPublishDetailsRequest {
-    return _smithy.isa(o, "GetBulkPublishDetailsRequest");
+    return __isa(o, "GetBulkPublishDetailsRequest");
   }
 }
 
@@ -434,7 +437,7 @@ export interface GetBulkPublishDetailsResponse extends $MetadataBearer {
 
 export namespace GetBulkPublishDetailsResponse {
   export function isa(o: any): o is GetBulkPublishDetailsResponse {
-    return _smithy.isa(o, "GetBulkPublishDetailsResponse");
+    return __isa(o, "GetBulkPublishDetailsResponse");
   }
 }
 
@@ -451,7 +454,7 @@ export interface GetCognitoEventsRequest {
 
 export namespace GetCognitoEventsRequest {
   export function isa(o: any): o is GetCognitoEventsRequest {
-    return _smithy.isa(o, "GetCognitoEventsRequest");
+    return __isa(o, "GetCognitoEventsRequest");
   }
 }
 
@@ -468,7 +471,7 @@ export interface GetCognitoEventsResponse extends $MetadataBearer {
 
 export namespace GetCognitoEventsResponse {
   export function isa(o: any): o is GetCognitoEventsResponse {
-    return _smithy.isa(o, "GetCognitoEventsResponse");
+    return __isa(o, "GetCognitoEventsResponse");
   }
 }
 
@@ -485,7 +488,7 @@ export interface GetIdentityPoolConfigurationRequest {
 
 export namespace GetIdentityPoolConfigurationRequest {
   export function isa(o: any): o is GetIdentityPoolConfigurationRequest {
-    return _smithy.isa(o, "GetIdentityPoolConfigurationRequest");
+    return __isa(o, "GetIdentityPoolConfigurationRequest");
   }
 }
 
@@ -512,7 +515,7 @@ export interface GetIdentityPoolConfigurationResponse extends $MetadataBearer {
 
 export namespace GetIdentityPoolConfigurationResponse {
   export function isa(o: any): o is GetIdentityPoolConfigurationResponse {
-    return _smithy.isa(o, "GetIdentityPoolConfigurationResponse");
+    return __isa(o, "GetIdentityPoolConfigurationResponse");
   }
 }
 
@@ -545,7 +548,7 @@ export interface IdentityPoolUsage {
 
 export namespace IdentityPoolUsage {
   export function isa(o: any): o is IdentityPoolUsage {
-    return _smithy.isa(o, "IdentityPoolUsage");
+    return __isa(o, "IdentityPoolUsage");
   }
 }
 
@@ -584,7 +587,7 @@ export interface IdentityUsage {
 
 export namespace IdentityUsage {
   export function isa(o: any): o is IdentityUsage {
-    return _smithy.isa(o, "IdentityUsage");
+    return __isa(o, "IdentityUsage");
   }
 }
 
@@ -592,7 +595,7 @@ export namespace IdentityUsage {
  * <p>Indicates an internal service error.</p>
  */
 export interface InternalErrorException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalErrorException";
   $fault: "server";
@@ -604,7 +607,7 @@ export interface InternalErrorException
 
 export namespace InternalErrorException {
   export function isa(o: any): o is InternalErrorException {
-    return _smithy.isa(o, "InternalErrorException");
+    return __isa(o, "InternalErrorException");
   }
 }
 
@@ -612,7 +615,7 @@ export namespace InternalErrorException {
  * <p>This exception is thrown when Amazon Cognito detects an invalid configuration.</p>
  */
 export interface InvalidConfigurationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidConfigurationException";
   $fault: "client";
@@ -624,7 +627,7 @@ export interface InvalidConfigurationException
 
 export namespace InvalidConfigurationException {
   export function isa(o: any): o is InvalidConfigurationException {
-    return _smithy.isa(o, "InvalidConfigurationException");
+    return __isa(o, "InvalidConfigurationException");
   }
 }
 
@@ -632,7 +635,7 @@ export namespace InvalidConfigurationException {
  * <p>The AWS Lambda function returned invalid output or an exception.</p>
  */
 export interface InvalidLambdaFunctionOutputException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidLambdaFunctionOutputException";
   $fault: "client";
@@ -644,7 +647,7 @@ export interface InvalidLambdaFunctionOutputException
 
 export namespace InvalidLambdaFunctionOutputException {
   export function isa(o: any): o is InvalidLambdaFunctionOutputException {
-    return _smithy.isa(o, "InvalidLambdaFunctionOutputException");
+    return __isa(o, "InvalidLambdaFunctionOutputException");
   }
 }
 
@@ -652,7 +655,7 @@ export namespace InvalidLambdaFunctionOutputException {
  * <p>Thrown when a request parameter does not comply with the associated constraints.</p>
  */
 export interface InvalidParameterException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidParameterException";
   $fault: "client";
@@ -664,7 +667,7 @@ export interface InvalidParameterException
 
 export namespace InvalidParameterException {
   export function isa(o: any): o is InvalidParameterException {
-    return _smithy.isa(o, "InvalidParameterException");
+    return __isa(o, "InvalidParameterException");
   }
 }
 
@@ -674,7 +677,7 @@ export namespace InvalidParameterException {
  *         Cognito Events</a>.</p>
  */
 export interface LambdaSocketTimeoutException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LambdaSocketTimeoutException";
   $fault: "client";
@@ -683,7 +686,7 @@ export interface LambdaSocketTimeoutException
 
 export namespace LambdaSocketTimeoutException {
   export function isa(o: any): o is LambdaSocketTimeoutException {
-    return _smithy.isa(o, "LambdaSocketTimeoutException");
+    return __isa(o, "LambdaSocketTimeoutException");
   }
 }
 
@@ -691,7 +694,7 @@ export namespace LambdaSocketTimeoutException {
  * <p>AWS Lambda throttled your account, please contact AWS Support</p>
  */
 export interface LambdaThrottledException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LambdaThrottledException";
   $fault: "client";
@@ -703,7 +706,7 @@ export interface LambdaThrottledException
 
 export namespace LambdaThrottledException {
   export function isa(o: any): o is LambdaThrottledException {
-    return _smithy.isa(o, "LambdaThrottledException");
+    return __isa(o, "LambdaThrottledException");
   }
 }
 
@@ -711,7 +714,7 @@ export namespace LambdaThrottledException {
  * <p>Thrown when the limit on the number of objects or operations has been exceeded.</p>
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -723,7 +726,7 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
@@ -755,7 +758,7 @@ export interface ListDatasetsRequest {
 
 export namespace ListDatasetsRequest {
   export function isa(o: any): o is ListDatasetsRequest {
-    return _smithy.isa(o, "ListDatasetsRequest");
+    return __isa(o, "ListDatasetsRequest");
   }
 }
 
@@ -782,7 +785,7 @@ export interface ListDatasetsResponse extends $MetadataBearer {
 
 export namespace ListDatasetsResponse {
   export function isa(o: any): o is ListDatasetsResponse {
-    return _smithy.isa(o, "ListDatasetsResponse");
+    return __isa(o, "ListDatasetsResponse");
   }
 }
 
@@ -804,7 +807,7 @@ export interface ListIdentityPoolUsageRequest {
 
 export namespace ListIdentityPoolUsageRequest {
   export function isa(o: any): o is ListIdentityPoolUsageRequest {
-    return _smithy.isa(o, "ListIdentityPoolUsageRequest");
+    return __isa(o, "ListIdentityPoolUsageRequest");
   }
 }
 
@@ -836,7 +839,7 @@ export interface ListIdentityPoolUsageResponse extends $MetadataBearer {
 
 export namespace ListIdentityPoolUsageResponse {
   export function isa(o: any): o is ListIdentityPoolUsageResponse {
-    return _smithy.isa(o, "ListIdentityPoolUsageResponse");
+    return __isa(o, "ListIdentityPoolUsageResponse");
   }
 }
 
@@ -883,7 +886,7 @@ export interface ListRecordsRequest {
 
 export namespace ListRecordsRequest {
   export function isa(o: any): o is ListRecordsRequest {
-    return _smithy.isa(o, "ListRecordsRequest");
+    return __isa(o, "ListRecordsRequest");
   }
 }
 
@@ -940,7 +943,7 @@ export interface ListRecordsResponse extends $MetadataBearer {
 
 export namespace ListRecordsResponse {
   export function isa(o: any): o is ListRecordsResponse {
-    return _smithy.isa(o, "ListRecordsResponse");
+    return __isa(o, "ListRecordsResponse");
   }
 }
 
@@ -948,7 +951,7 @@ export namespace ListRecordsResponse {
  * <p>Thrown when a user is not authorized to access the requested resource.</p>
  */
 export interface NotAuthorizedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "NotAuthorizedException";
   $fault: "client";
@@ -960,7 +963,7 @@ export interface NotAuthorizedException
 
 export namespace NotAuthorizedException {
   export function isa(o: any): o is NotAuthorizedException {
-    return _smithy.isa(o, "NotAuthorizedException");
+    return __isa(o, "NotAuthorizedException");
   }
 }
 
@@ -986,7 +989,7 @@ export interface PushSync {
 
 export namespace PushSync {
   export function isa(o: any): o is PushSync {
-    return _smithy.isa(o, "PushSync");
+    return __isa(o, "PushSync");
   }
 }
 
@@ -1028,7 +1031,7 @@ export interface _Record {
 
 export namespace _Record {
   export function isa(o: any): o is _Record {
-    return _smithy.isa(o, "Record");
+    return __isa(o, "Record");
   }
 }
 
@@ -1065,7 +1068,7 @@ export interface RecordPatch {
 
 export namespace RecordPatch {
   export function isa(o: any): o is RecordPatch {
-    return _smithy.isa(o, "RecordPatch");
+    return __isa(o, "RecordPatch");
   }
 }
 
@@ -1097,7 +1100,7 @@ export interface RegisterDeviceRequest {
 
 export namespace RegisterDeviceRequest {
   export function isa(o: any): o is RegisterDeviceRequest {
-    return _smithy.isa(o, "RegisterDeviceRequest");
+    return __isa(o, "RegisterDeviceRequest");
   }
 }
 
@@ -1114,7 +1117,7 @@ export interface RegisterDeviceResponse extends $MetadataBearer {
 
 export namespace RegisterDeviceResponse {
   export function isa(o: any): o is RegisterDeviceResponse {
-    return _smithy.isa(o, "RegisterDeviceResponse");
+    return __isa(o, "RegisterDeviceResponse");
   }
 }
 
@@ -1122,7 +1125,7 @@ export namespace RegisterDeviceResponse {
  * <p>Thrown if an update can't be applied because the resource was changed by another call and this would result in a conflict.</p>
  */
 export interface ResourceConflictException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceConflictException";
   $fault: "client";
@@ -1134,7 +1137,7 @@ export interface ResourceConflictException
 
 export namespace ResourceConflictException {
   export function isa(o: any): o is ResourceConflictException {
-    return _smithy.isa(o, "ResourceConflictException");
+    return __isa(o, "ResourceConflictException");
   }
 }
 
@@ -1142,7 +1145,7 @@ export namespace ResourceConflictException {
  * <p>Thrown if the resource doesn't exist.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -1154,7 +1157,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -1176,7 +1179,7 @@ export interface SetCognitoEventsRequest {
 
 export namespace SetCognitoEventsRequest {
   export function isa(o: any): o is SetCognitoEventsRequest {
-    return _smithy.isa(o, "SetCognitoEventsRequest");
+    return __isa(o, "SetCognitoEventsRequest");
   }
 }
 
@@ -1203,7 +1206,7 @@ export interface SetIdentityPoolConfigurationRequest {
 
 export namespace SetIdentityPoolConfigurationRequest {
   export function isa(o: any): o is SetIdentityPoolConfigurationRequest {
-    return _smithy.isa(o, "SetIdentityPoolConfigurationRequest");
+    return __isa(o, "SetIdentityPoolConfigurationRequest");
   }
 }
 
@@ -1230,7 +1233,7 @@ export interface SetIdentityPoolConfigurationResponse extends $MetadataBearer {
 
 export namespace SetIdentityPoolConfigurationResponse {
   export function isa(o: any): o is SetIdentityPoolConfigurationResponse {
-    return _smithy.isa(o, "SetIdentityPoolConfigurationResponse");
+    return __isa(o, "SetIdentityPoolConfigurationResponse");
   }
 }
 
@@ -1264,7 +1267,7 @@ export interface SubscribeToDatasetRequest {
 
 export namespace SubscribeToDatasetRequest {
   export function isa(o: any): o is SubscribeToDatasetRequest {
-    return _smithy.isa(o, "SubscribeToDatasetRequest");
+    return __isa(o, "SubscribeToDatasetRequest");
   }
 }
 
@@ -1277,7 +1280,7 @@ export interface SubscribeToDatasetResponse extends $MetadataBearer {
 
 export namespace SubscribeToDatasetResponse {
   export function isa(o: any): o is SubscribeToDatasetResponse {
-    return _smithy.isa(o, "SubscribeToDatasetResponse");
+    return __isa(o, "SubscribeToDatasetResponse");
   }
 }
 
@@ -1285,7 +1288,7 @@ export namespace SubscribeToDatasetResponse {
  * <p>Thrown if the request is throttled.</p>
  */
 export interface TooManyRequestsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyRequestsException";
   $fault: "client";
@@ -1297,7 +1300,7 @@ export interface TooManyRequestsException
 
 export namespace TooManyRequestsException {
   export function isa(o: any): o is TooManyRequestsException {
-    return _smithy.isa(o, "TooManyRequestsException");
+    return __isa(o, "TooManyRequestsException");
   }
 }
 
@@ -1329,7 +1332,7 @@ export interface UnsubscribeFromDatasetRequest {
 
 export namespace UnsubscribeFromDatasetRequest {
   export function isa(o: any): o is UnsubscribeFromDatasetRequest {
-    return _smithy.isa(o, "UnsubscribeFromDatasetRequest");
+    return __isa(o, "UnsubscribeFromDatasetRequest");
   }
 }
 
@@ -1342,7 +1345,7 @@ export interface UnsubscribeFromDatasetResponse extends $MetadataBearer {
 
 export namespace UnsubscribeFromDatasetResponse {
   export function isa(o: any): o is UnsubscribeFromDatasetResponse {
-    return _smithy.isa(o, "UnsubscribeFromDatasetResponse");
+    return __isa(o, "UnsubscribeFromDatasetResponse");
   }
 }
 
@@ -1389,7 +1392,7 @@ export interface UpdateRecordsRequest {
 
 export namespace UpdateRecordsRequest {
   export function isa(o: any): o is UpdateRecordsRequest {
-    return _smithy.isa(o, "UpdateRecordsRequest");
+    return __isa(o, "UpdateRecordsRequest");
   }
 }
 
@@ -1406,6 +1409,6 @@ export interface UpdateRecordsResponse extends $MetadataBearer {
 
 export namespace UpdateRecordsResponse {
   export function isa(o: any): o is UpdateRecordsResponse {
-    return _smithy.isa(o, "UpdateRecordsResponse");
+    return __isa(o, "UpdateRecordsResponse");
   }
 }

--- a/clients/client-cognito-sync/protocols/Aws_restJson1_1.ts
+++ b/clients/client-cognito-sync/protocols/Aws_restJson1_1.ts
@@ -93,7 +93,10 @@ import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  extendedEncodeURIComponent as __extendedEncodeURIComponent
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -109,7 +112,7 @@ export async function serializeAws_restJson1_1BulkPublishCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/identitypools/{IdentityPoolId}/bulkpublish";
   if (input.IdentityPoolId !== undefined) {
-    const labelValue: string = input.IdentityPoolId.toString();
+    const labelValue: string = input.IdentityPoolId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: IdentityPoolId."
@@ -117,7 +120,7 @@ export async function serializeAws_restJson1_1BulkPublishCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{IdentityPoolId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: IdentityPoolId.");
@@ -140,7 +143,7 @@ export async function serializeAws_restJson1_1DeleteDatasetCommand(
   let resolvedPath =
     "/identitypools/{IdentityPoolId}/identities/{IdentityId}/datasets/{DatasetName}";
   if (input.DatasetName !== undefined) {
-    const labelValue: string = input.DatasetName.toString();
+    const labelValue: string = input.DatasetName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: DatasetName."
@@ -148,25 +151,25 @@ export async function serializeAws_restJson1_1DeleteDatasetCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{DatasetName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DatasetName.");
   }
   if (input.IdentityId !== undefined) {
-    const labelValue: string = input.IdentityId.toString();
+    const labelValue: string = input.IdentityId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: IdentityId.");
     }
     resolvedPath = resolvedPath.replace(
       "{IdentityId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: IdentityId.");
   }
   if (input.IdentityPoolId !== undefined) {
-    const labelValue: string = input.IdentityPoolId.toString();
+    const labelValue: string = input.IdentityPoolId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: IdentityPoolId."
@@ -174,7 +177,7 @@ export async function serializeAws_restJson1_1DeleteDatasetCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{IdentityPoolId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: IdentityPoolId.");
@@ -197,7 +200,7 @@ export async function serializeAws_restJson1_1DescribeDatasetCommand(
   let resolvedPath =
     "/identitypools/{IdentityPoolId}/identities/{IdentityId}/datasets/{DatasetName}";
   if (input.DatasetName !== undefined) {
-    const labelValue: string = input.DatasetName.toString();
+    const labelValue: string = input.DatasetName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: DatasetName."
@@ -205,25 +208,25 @@ export async function serializeAws_restJson1_1DescribeDatasetCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{DatasetName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DatasetName.");
   }
   if (input.IdentityId !== undefined) {
-    const labelValue: string = input.IdentityId.toString();
+    const labelValue: string = input.IdentityId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: IdentityId.");
     }
     resolvedPath = resolvedPath.replace(
       "{IdentityId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: IdentityId.");
   }
   if (input.IdentityPoolId !== undefined) {
-    const labelValue: string = input.IdentityPoolId.toString();
+    const labelValue: string = input.IdentityPoolId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: IdentityPoolId."
@@ -231,7 +234,7 @@ export async function serializeAws_restJson1_1DescribeDatasetCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{IdentityPoolId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: IdentityPoolId.");
@@ -253,7 +256,7 @@ export async function serializeAws_restJson1_1DescribeIdentityPoolUsageCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/identitypools/{IdentityPoolId}";
   if (input.IdentityPoolId !== undefined) {
-    const labelValue: string = input.IdentityPoolId.toString();
+    const labelValue: string = input.IdentityPoolId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: IdentityPoolId."
@@ -261,7 +264,7 @@ export async function serializeAws_restJson1_1DescribeIdentityPoolUsageCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{IdentityPoolId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: IdentityPoolId.");
@@ -283,19 +286,19 @@ export async function serializeAws_restJson1_1DescribeIdentityUsageCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/identitypools/{IdentityPoolId}/identities/{IdentityId}";
   if (input.IdentityId !== undefined) {
-    const labelValue: string = input.IdentityId.toString();
+    const labelValue: string = input.IdentityId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: IdentityId.");
     }
     resolvedPath = resolvedPath.replace(
       "{IdentityId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: IdentityId.");
   }
   if (input.IdentityPoolId !== undefined) {
-    const labelValue: string = input.IdentityPoolId.toString();
+    const labelValue: string = input.IdentityPoolId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: IdentityPoolId."
@@ -303,7 +306,7 @@ export async function serializeAws_restJson1_1DescribeIdentityUsageCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{IdentityPoolId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: IdentityPoolId.");
@@ -325,7 +328,7 @@ export async function serializeAws_restJson1_1GetBulkPublishDetailsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/identitypools/{IdentityPoolId}/getBulkPublishDetails";
   if (input.IdentityPoolId !== undefined) {
-    const labelValue: string = input.IdentityPoolId.toString();
+    const labelValue: string = input.IdentityPoolId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: IdentityPoolId."
@@ -333,7 +336,7 @@ export async function serializeAws_restJson1_1GetBulkPublishDetailsCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{IdentityPoolId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: IdentityPoolId.");
@@ -355,7 +358,7 @@ export async function serializeAws_restJson1_1GetCognitoEventsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/identitypools/{IdentityPoolId}/events";
   if (input.IdentityPoolId !== undefined) {
-    const labelValue: string = input.IdentityPoolId.toString();
+    const labelValue: string = input.IdentityPoolId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: IdentityPoolId."
@@ -363,7 +366,7 @@ export async function serializeAws_restJson1_1GetCognitoEventsCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{IdentityPoolId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: IdentityPoolId.");
@@ -385,7 +388,7 @@ export async function serializeAws_restJson1_1GetIdentityPoolConfigurationComman
   headers["Content-Type"] = "";
   let resolvedPath = "/identitypools/{IdentityPoolId}/configuration";
   if (input.IdentityPoolId !== undefined) {
-    const labelValue: string = input.IdentityPoolId.toString();
+    const labelValue: string = input.IdentityPoolId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: IdentityPoolId."
@@ -393,7 +396,7 @@ export async function serializeAws_restJson1_1GetIdentityPoolConfigurationComman
     }
     resolvedPath = resolvedPath.replace(
       "{IdentityPoolId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: IdentityPoolId.");
@@ -416,19 +419,19 @@ export async function serializeAws_restJson1_1ListDatasetsCommand(
   let resolvedPath =
     "/identitypools/{IdentityPoolId}/identities/{IdentityId}/datasets";
   if (input.IdentityId !== undefined) {
-    const labelValue: string = input.IdentityId.toString();
+    const labelValue: string = input.IdentityId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: IdentityId.");
     }
     resolvedPath = resolvedPath.replace(
       "{IdentityId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: IdentityId.");
   }
   if (input.IdentityPoolId !== undefined) {
-    const labelValue: string = input.IdentityPoolId.toString();
+    const labelValue: string = input.IdentityPoolId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: IdentityPoolId."
@@ -436,17 +439,21 @@ export async function serializeAws_restJson1_1ListDatasetsCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{IdentityPoolId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: IdentityPoolId.");
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults);
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -467,10 +474,14 @@ export async function serializeAws_restJson1_1ListIdentityPoolUsageCommand(
   let resolvedPath = "/identitypools";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -491,7 +502,7 @@ export async function serializeAws_restJson1_1ListRecordsCommand(
   let resolvedPath =
     "/identitypools/{IdentityPoolId}/identities/{IdentityId}/datasets/{DatasetName}/records";
   if (input.DatasetName !== undefined) {
-    const labelValue: string = input.DatasetName.toString();
+    const labelValue: string = input.DatasetName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: DatasetName."
@@ -499,25 +510,25 @@ export async function serializeAws_restJson1_1ListRecordsCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{DatasetName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DatasetName.");
   }
   if (input.IdentityId !== undefined) {
-    const labelValue: string = input.IdentityId.toString();
+    const labelValue: string = input.IdentityId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: IdentityId.");
     }
     resolvedPath = resolvedPath.replace(
       "{IdentityId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: IdentityId.");
   }
   if (input.IdentityPoolId !== undefined) {
-    const labelValue: string = input.IdentityPoolId.toString();
+    const labelValue: string = input.IdentityPoolId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: IdentityPoolId."
@@ -525,23 +536,31 @@ export async function serializeAws_restJson1_1ListRecordsCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{IdentityPoolId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: IdentityPoolId.");
   }
   const query: any = {};
   if (input.LastSyncCount !== undefined) {
-    query["lastSyncCount"] = input.LastSyncCount.toString();
+    query[
+      __extendedEncodeURIComponent("lastSyncCount")
+    ] = __extendedEncodeURIComponent(input.LastSyncCount.toString());
   }
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   if (input.SyncSessionToken !== undefined) {
-    query["syncSessionToken"] = input.SyncSessionToken.toString();
+    query[
+      __extendedEncodeURIComponent("syncSessionToken")
+    ] = __extendedEncodeURIComponent(input.SyncSessionToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -562,19 +581,19 @@ export async function serializeAws_restJson1_1RegisterDeviceCommand(
   let resolvedPath =
     "/identitypools/{IdentityPoolId}/identity/{IdentityId}/device";
   if (input.IdentityId !== undefined) {
-    const labelValue: string = input.IdentityId.toString();
+    const labelValue: string = input.IdentityId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: IdentityId.");
     }
     resolvedPath = resolvedPath.replace(
       "{IdentityId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: IdentityId.");
   }
   if (input.IdentityPoolId !== undefined) {
-    const labelValue: string = input.IdentityPoolId.toString();
+    const labelValue: string = input.IdentityPoolId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: IdentityPoolId."
@@ -582,7 +601,7 @@ export async function serializeAws_restJson1_1RegisterDeviceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{IdentityPoolId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: IdentityPoolId.");
@@ -614,7 +633,7 @@ export async function serializeAws_restJson1_1SetCognitoEventsCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/identitypools/{IdentityPoolId}/events";
   if (input.IdentityPoolId !== undefined) {
-    const labelValue: string = input.IdentityPoolId.toString();
+    const labelValue: string = input.IdentityPoolId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: IdentityPoolId."
@@ -622,7 +641,7 @@ export async function serializeAws_restJson1_1SetCognitoEventsCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{IdentityPoolId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: IdentityPoolId.");
@@ -654,7 +673,7 @@ export async function serializeAws_restJson1_1SetIdentityPoolConfigurationComman
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/identitypools/{IdentityPoolId}/configuration";
   if (input.IdentityPoolId !== undefined) {
-    const labelValue: string = input.IdentityPoolId.toString();
+    const labelValue: string = input.IdentityPoolId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: IdentityPoolId."
@@ -662,7 +681,7 @@ export async function serializeAws_restJson1_1SetIdentityPoolConfigurationComman
     }
     resolvedPath = resolvedPath.replace(
       "{IdentityPoolId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: IdentityPoolId.");
@@ -701,7 +720,7 @@ export async function serializeAws_restJson1_1SubscribeToDatasetCommand(
   let resolvedPath =
     "/identitypools/{IdentityPoolId}/identities/{IdentityId}/datasets/{DatasetName}/subscriptions/{DeviceId}";
   if (input.DatasetName !== undefined) {
-    const labelValue: string = input.DatasetName.toString();
+    const labelValue: string = input.DatasetName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: DatasetName."
@@ -709,37 +728,37 @@ export async function serializeAws_restJson1_1SubscribeToDatasetCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{DatasetName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DatasetName.");
   }
   if (input.DeviceId !== undefined) {
-    const labelValue: string = input.DeviceId.toString();
+    const labelValue: string = input.DeviceId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DeviceId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DeviceId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DeviceId.");
   }
   if (input.IdentityId !== undefined) {
-    const labelValue: string = input.IdentityId.toString();
+    const labelValue: string = input.IdentityId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: IdentityId.");
     }
     resolvedPath = resolvedPath.replace(
       "{IdentityId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: IdentityId.");
   }
   if (input.IdentityPoolId !== undefined) {
-    const labelValue: string = input.IdentityPoolId.toString();
+    const labelValue: string = input.IdentityPoolId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: IdentityPoolId."
@@ -747,7 +766,7 @@ export async function serializeAws_restJson1_1SubscribeToDatasetCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{IdentityPoolId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: IdentityPoolId.");
@@ -770,7 +789,7 @@ export async function serializeAws_restJson1_1UnsubscribeFromDatasetCommand(
   let resolvedPath =
     "/identitypools/{IdentityPoolId}/identities/{IdentityId}/datasets/{DatasetName}/subscriptions/{DeviceId}";
   if (input.DatasetName !== undefined) {
-    const labelValue: string = input.DatasetName.toString();
+    const labelValue: string = input.DatasetName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: DatasetName."
@@ -778,37 +797,37 @@ export async function serializeAws_restJson1_1UnsubscribeFromDatasetCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{DatasetName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DatasetName.");
   }
   if (input.DeviceId !== undefined) {
-    const labelValue: string = input.DeviceId.toString();
+    const labelValue: string = input.DeviceId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DeviceId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DeviceId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DeviceId.");
   }
   if (input.IdentityId !== undefined) {
-    const labelValue: string = input.IdentityId.toString();
+    const labelValue: string = input.IdentityId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: IdentityId.");
     }
     resolvedPath = resolvedPath.replace(
       "{IdentityId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: IdentityId.");
   }
   if (input.IdentityPoolId !== undefined) {
-    const labelValue: string = input.IdentityPoolId.toString();
+    const labelValue: string = input.IdentityPoolId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: IdentityPoolId."
@@ -816,7 +835,7 @@ export async function serializeAws_restJson1_1UnsubscribeFromDatasetCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{IdentityPoolId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: IdentityPoolId.");
@@ -837,12 +856,12 @@ export async function serializeAws_restJson1_1UpdateRecordsCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.ClientContext !== undefined) {
-    headers["x-amz-Client-Context"] = input.ClientContext.toString();
+    headers["x-amz-Client-Context"] = input.ClientContext;
   }
   let resolvedPath =
     "/identitypools/{IdentityPoolId}/identities/{IdentityId}/datasets/{DatasetName}";
   if (input.DatasetName !== undefined) {
-    const labelValue: string = input.DatasetName.toString();
+    const labelValue: string = input.DatasetName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: DatasetName."
@@ -850,25 +869,25 @@ export async function serializeAws_restJson1_1UpdateRecordsCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{DatasetName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DatasetName.");
   }
   if (input.IdentityId !== undefined) {
-    const labelValue: string = input.IdentityId.toString();
+    const labelValue: string = input.IdentityId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: IdentityId.");
     }
     resolvedPath = resolvedPath.replace(
       "{IdentityId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: IdentityId.");
   }
   if (input.IdentityPoolId !== undefined) {
-    const labelValue: string = input.IdentityPoolId.toString();
+    const labelValue: string = input.IdentityPoolId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: IdentityPoolId."
@@ -876,7 +895,7 @@ export async function serializeAws_restJson1_1UpdateRecordsCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{IdentityPoolId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: IdentityPoolId.");
@@ -2028,6 +2047,7 @@ export async function deserializeAws_restJson1_1SetCognitoEventsCommand(
   const contents: SetCognitoEventsCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2212,6 +2232,7 @@ export async function deserializeAws_restJson1_1SubscribeToDatasetCommand(
     $metadata: deserializeMetadata(output),
     __type: "SubscribeToDatasetResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2298,6 +2319,7 @@ export async function deserializeAws_restJson1_1UnsubscribeFromDatasetCommand(
     $metadata: deserializeMetadata(output),
     __type: "UnsubscribeFromDatasetResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 

--- a/clients/client-comprehend/models/index.ts
+++ b/clients/client-comprehend/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -22,7 +25,7 @@ export interface BatchDetectDominantLanguageItemResult {
 
 export namespace BatchDetectDominantLanguageItemResult {
   export function isa(o: any): o is BatchDetectDominantLanguageItemResult {
-    return _smithy.isa(o, "BatchDetectDominantLanguageItemResult");
+    return __isa(o, "BatchDetectDominantLanguageItemResult");
   }
 }
 
@@ -38,7 +41,7 @@ export interface BatchDetectDominantLanguageRequest {
 
 export namespace BatchDetectDominantLanguageRequest {
   export function isa(o: any): o is BatchDetectDominantLanguageRequest {
-    return _smithy.isa(o, "BatchDetectDominantLanguageRequest");
+    return __isa(o, "BatchDetectDominantLanguageRequest");
   }
 }
 
@@ -63,7 +66,7 @@ export interface BatchDetectDominantLanguageResponse extends $MetadataBearer {
 
 export namespace BatchDetectDominantLanguageResponse {
   export function isa(o: any): o is BatchDetectDominantLanguageResponse {
-    return _smithy.isa(o, "BatchDetectDominantLanguageResponse");
+    return __isa(o, "BatchDetectDominantLanguageResponse");
   }
 }
 
@@ -88,7 +91,7 @@ export interface BatchDetectEntitiesItemResult {
 
 export namespace BatchDetectEntitiesItemResult {
   export function isa(o: any): o is BatchDetectEntitiesItemResult {
-    return _smithy.isa(o, "BatchDetectEntitiesItemResult");
+    return __isa(o, "BatchDetectEntitiesItemResult");
   }
 }
 
@@ -111,7 +114,7 @@ export interface BatchDetectEntitiesRequest {
 
 export namespace BatchDetectEntitiesRequest {
   export function isa(o: any): o is BatchDetectEntitiesRequest {
-    return _smithy.isa(o, "BatchDetectEntitiesRequest");
+    return __isa(o, "BatchDetectEntitiesRequest");
   }
 }
 
@@ -136,7 +139,7 @@ export interface BatchDetectEntitiesResponse extends $MetadataBearer {
 
 export namespace BatchDetectEntitiesResponse {
   export function isa(o: any): o is BatchDetectEntitiesResponse {
-    return _smithy.isa(o, "BatchDetectEntitiesResponse");
+    return __isa(o, "BatchDetectEntitiesResponse");
   }
 }
 
@@ -161,7 +164,7 @@ export interface BatchDetectKeyPhrasesItemResult {
 
 export namespace BatchDetectKeyPhrasesItemResult {
   export function isa(o: any): o is BatchDetectKeyPhrasesItemResult {
-    return _smithy.isa(o, "BatchDetectKeyPhrasesItemResult");
+    return __isa(o, "BatchDetectKeyPhrasesItemResult");
   }
 }
 
@@ -184,7 +187,7 @@ export interface BatchDetectKeyPhrasesRequest {
 
 export namespace BatchDetectKeyPhrasesRequest {
   export function isa(o: any): o is BatchDetectKeyPhrasesRequest {
-    return _smithy.isa(o, "BatchDetectKeyPhrasesRequest");
+    return __isa(o, "BatchDetectKeyPhrasesRequest");
   }
 }
 
@@ -209,7 +212,7 @@ export interface BatchDetectKeyPhrasesResponse extends $MetadataBearer {
 
 export namespace BatchDetectKeyPhrasesResponse {
   export function isa(o: any): o is BatchDetectKeyPhrasesResponse {
-    return _smithy.isa(o, "BatchDetectKeyPhrasesResponse");
+    return __isa(o, "BatchDetectKeyPhrasesResponse");
   }
 }
 
@@ -239,7 +242,7 @@ export interface BatchDetectSentimentItemResult {
 
 export namespace BatchDetectSentimentItemResult {
   export function isa(o: any): o is BatchDetectSentimentItemResult {
-    return _smithy.isa(o, "BatchDetectSentimentItemResult");
+    return __isa(o, "BatchDetectSentimentItemResult");
   }
 }
 
@@ -262,7 +265,7 @@ export interface BatchDetectSentimentRequest {
 
 export namespace BatchDetectSentimentRequest {
   export function isa(o: any): o is BatchDetectSentimentRequest {
-    return _smithy.isa(o, "BatchDetectSentimentRequest");
+    return __isa(o, "BatchDetectSentimentRequest");
   }
 }
 
@@ -287,7 +290,7 @@ export interface BatchDetectSentimentResponse extends $MetadataBearer {
 
 export namespace BatchDetectSentimentResponse {
   export function isa(o: any): o is BatchDetectSentimentResponse {
-    return _smithy.isa(o, "BatchDetectSentimentResponse");
+    return __isa(o, "BatchDetectSentimentResponse");
   }
 }
 
@@ -310,7 +313,7 @@ export interface BatchDetectSyntaxItemResult {
 
 export namespace BatchDetectSyntaxItemResult {
   export function isa(o: any): o is BatchDetectSyntaxItemResult {
-    return _smithy.isa(o, "BatchDetectSyntaxItemResult");
+    return __isa(o, "BatchDetectSyntaxItemResult");
   }
 }
 
@@ -333,7 +336,7 @@ export interface BatchDetectSyntaxRequest {
 
 export namespace BatchDetectSyntaxRequest {
   export function isa(o: any): o is BatchDetectSyntaxRequest {
-    return _smithy.isa(o, "BatchDetectSyntaxRequest");
+    return __isa(o, "BatchDetectSyntaxRequest");
   }
 }
 
@@ -358,7 +361,7 @@ export interface BatchDetectSyntaxResponse extends $MetadataBearer {
 
 export namespace BatchDetectSyntaxResponse {
   export function isa(o: any): o is BatchDetectSyntaxResponse {
-    return _smithy.isa(o, "BatchDetectSyntaxResponse");
+    return __isa(o, "BatchDetectSyntaxResponse");
   }
 }
 
@@ -387,7 +390,7 @@ export interface BatchItemError {
 
 export namespace BatchItemError {
   export function isa(o: any): o is BatchItemError {
-    return _smithy.isa(o, "BatchItemError");
+    return __isa(o, "BatchItemError");
   }
 }
 
@@ -396,7 +399,7 @@ export namespace BatchItemError {
  *       with fewer documents.</p>
  */
 export interface BatchSizeLimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "BatchSizeLimitExceededException";
   $fault: "client";
@@ -405,7 +408,7 @@ export interface BatchSizeLimitExceededException
 
 export namespace BatchSizeLimitExceededException {
   export function isa(o: any): o is BatchSizeLimitExceededException {
-    return _smithy.isa(o, "BatchSizeLimitExceededException");
+    return __isa(o, "BatchSizeLimitExceededException");
   }
 }
 
@@ -471,7 +474,7 @@ export interface ClassifierEvaluationMetrics {
 
 export namespace ClassifierEvaluationMetrics {
   export function isa(o: any): o is ClassifierEvaluationMetrics {
-    return _smithy.isa(o, "ClassifierEvaluationMetrics");
+    return __isa(o, "ClassifierEvaluationMetrics");
   }
 }
 
@@ -505,7 +508,7 @@ export interface ClassifierMetadata {
 
 export namespace ClassifierMetadata {
   export function isa(o: any): o is ClassifierMetadata {
-    return _smithy.isa(o, "ClassifierMetadata");
+    return __isa(o, "ClassifierMetadata");
   }
 }
 
@@ -524,7 +527,7 @@ export interface ClassifyDocumentRequest {
 
 export namespace ClassifyDocumentRequest {
   export function isa(o: any): o is ClassifyDocumentRequest {
-    return _smithy.isa(o, "ClassifyDocumentRequest");
+    return __isa(o, "ClassifyDocumentRequest");
   }
 }
 
@@ -546,7 +549,7 @@ export interface ClassifyDocumentResponse extends $MetadataBearer {
 
 export namespace ClassifyDocumentResponse {
   export function isa(o: any): o is ClassifyDocumentResponse {
-    return _smithy.isa(o, "ClassifyDocumentResponse");
+    return __isa(o, "ClassifyDocumentResponse");
   }
 }
 
@@ -554,7 +557,7 @@ export namespace ClassifyDocumentResponse {
  * <p>Concurrent modification of the tags associated with an Amazon Comprehend resource is not supported. </p>
  */
 export interface ConcurrentModificationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ConcurrentModificationException";
   $fault: "client";
@@ -563,7 +566,7 @@ export interface ConcurrentModificationException
 
 export namespace ConcurrentModificationException {
   export function isa(o: any): o is ConcurrentModificationException {
-    return _smithy.isa(o, "ConcurrentModificationException");
+    return __isa(o, "ConcurrentModificationException");
   }
 }
 
@@ -643,7 +646,7 @@ export interface CreateDocumentClassifierRequest {
 
 export namespace CreateDocumentClassifierRequest {
   export function isa(o: any): o is CreateDocumentClassifierRequest {
-    return _smithy.isa(o, "CreateDocumentClassifierRequest");
+    return __isa(o, "CreateDocumentClassifierRequest");
   }
 }
 
@@ -657,7 +660,7 @@ export interface CreateDocumentClassifierResponse extends $MetadataBearer {
 
 export namespace CreateDocumentClassifierResponse {
   export function isa(o: any): o is CreateDocumentClassifierResponse {
-    return _smithy.isa(o, "CreateDocumentClassifierResponse");
+    return __isa(o, "CreateDocumentClassifierResponse");
   }
 }
 
@@ -695,7 +698,7 @@ export interface CreateEndpointRequest {
 
 export namespace CreateEndpointRequest {
   export function isa(o: any): o is CreateEndpointRequest {
-    return _smithy.isa(o, "CreateEndpointRequest");
+    return __isa(o, "CreateEndpointRequest");
   }
 }
 
@@ -709,7 +712,7 @@ export interface CreateEndpointResponse extends $MetadataBearer {
 
 export namespace CreateEndpointResponse {
   export function isa(o: any): o is CreateEndpointResponse {
-    return _smithy.isa(o, "CreateEndpointResponse");
+    return __isa(o, "CreateEndpointResponse");
   }
 }
 
@@ -775,7 +778,7 @@ export interface CreateEntityRecognizerRequest {
 
 export namespace CreateEntityRecognizerRequest {
   export function isa(o: any): o is CreateEntityRecognizerRequest {
-    return _smithy.isa(o, "CreateEntityRecognizerRequest");
+    return __isa(o, "CreateEntityRecognizerRequest");
   }
 }
 
@@ -789,7 +792,7 @@ export interface CreateEntityRecognizerResponse extends $MetadataBearer {
 
 export namespace CreateEntityRecognizerResponse {
   export function isa(o: any): o is CreateEntityRecognizerResponse {
-    return _smithy.isa(o, "CreateEntityRecognizerResponse");
+    return __isa(o, "CreateEntityRecognizerResponse");
   }
 }
 
@@ -803,7 +806,7 @@ export interface DeleteDocumentClassifierRequest {
 
 export namespace DeleteDocumentClassifierRequest {
   export function isa(o: any): o is DeleteDocumentClassifierRequest {
-    return _smithy.isa(o, "DeleteDocumentClassifierRequest");
+    return __isa(o, "DeleteDocumentClassifierRequest");
   }
 }
 
@@ -813,7 +816,7 @@ export interface DeleteDocumentClassifierResponse extends $MetadataBearer {
 
 export namespace DeleteDocumentClassifierResponse {
   export function isa(o: any): o is DeleteDocumentClassifierResponse {
-    return _smithy.isa(o, "DeleteDocumentClassifierResponse");
+    return __isa(o, "DeleteDocumentClassifierResponse");
   }
 }
 
@@ -827,7 +830,7 @@ export interface DeleteEndpointRequest {
 
 export namespace DeleteEndpointRequest {
   export function isa(o: any): o is DeleteEndpointRequest {
-    return _smithy.isa(o, "DeleteEndpointRequest");
+    return __isa(o, "DeleteEndpointRequest");
   }
 }
 
@@ -837,7 +840,7 @@ export interface DeleteEndpointResponse extends $MetadataBearer {
 
 export namespace DeleteEndpointResponse {
   export function isa(o: any): o is DeleteEndpointResponse {
-    return _smithy.isa(o, "DeleteEndpointResponse");
+    return __isa(o, "DeleteEndpointResponse");
   }
 }
 
@@ -851,7 +854,7 @@ export interface DeleteEntityRecognizerRequest {
 
 export namespace DeleteEntityRecognizerRequest {
   export function isa(o: any): o is DeleteEntityRecognizerRequest {
-    return _smithy.isa(o, "DeleteEntityRecognizerRequest");
+    return __isa(o, "DeleteEntityRecognizerRequest");
   }
 }
 
@@ -861,7 +864,7 @@ export interface DeleteEntityRecognizerResponse extends $MetadataBearer {
 
 export namespace DeleteEntityRecognizerResponse {
   export function isa(o: any): o is DeleteEntityRecognizerResponse {
-    return _smithy.isa(o, "DeleteEntityRecognizerResponse");
+    return __isa(o, "DeleteEntityRecognizerResponse");
   }
 }
 
@@ -876,7 +879,7 @@ export interface DescribeDocumentClassificationJobRequest {
 
 export namespace DescribeDocumentClassificationJobRequest {
   export function isa(o: any): o is DescribeDocumentClassificationJobRequest {
-    return _smithy.isa(o, "DescribeDocumentClassificationJobRequest");
+    return __isa(o, "DescribeDocumentClassificationJobRequest");
   }
 }
 
@@ -892,7 +895,7 @@ export interface DescribeDocumentClassificationJobResponse
 
 export namespace DescribeDocumentClassificationJobResponse {
   export function isa(o: any): o is DescribeDocumentClassificationJobResponse {
-    return _smithy.isa(o, "DescribeDocumentClassificationJobResponse");
+    return __isa(o, "DescribeDocumentClassificationJobResponse");
   }
 }
 
@@ -907,7 +910,7 @@ export interface DescribeDocumentClassifierRequest {
 
 export namespace DescribeDocumentClassifierRequest {
   export function isa(o: any): o is DescribeDocumentClassifierRequest {
-    return _smithy.isa(o, "DescribeDocumentClassifierRequest");
+    return __isa(o, "DescribeDocumentClassifierRequest");
   }
 }
 
@@ -921,7 +924,7 @@ export interface DescribeDocumentClassifierResponse extends $MetadataBearer {
 
 export namespace DescribeDocumentClassifierResponse {
   export function isa(o: any): o is DescribeDocumentClassifierResponse {
-    return _smithy.isa(o, "DescribeDocumentClassifierResponse");
+    return __isa(o, "DescribeDocumentClassifierResponse");
   }
 }
 
@@ -938,7 +941,7 @@ export namespace DescribeDominantLanguageDetectionJobRequest {
   export function isa(
     o: any
   ): o is DescribeDominantLanguageDetectionJobRequest {
-    return _smithy.isa(o, "DescribeDominantLanguageDetectionJobRequest");
+    return __isa(o, "DescribeDominantLanguageDetectionJobRequest");
   }
 }
 
@@ -956,7 +959,7 @@ export namespace DescribeDominantLanguageDetectionJobResponse {
   export function isa(
     o: any
   ): o is DescribeDominantLanguageDetectionJobResponse {
-    return _smithy.isa(o, "DescribeDominantLanguageDetectionJobResponse");
+    return __isa(o, "DescribeDominantLanguageDetectionJobResponse");
   }
 }
 
@@ -970,7 +973,7 @@ export interface DescribeEndpointRequest {
 
 export namespace DescribeEndpointRequest {
   export function isa(o: any): o is DescribeEndpointRequest {
-    return _smithy.isa(o, "DescribeEndpointRequest");
+    return __isa(o, "DescribeEndpointRequest");
   }
 }
 
@@ -984,7 +987,7 @@ export interface DescribeEndpointResponse extends $MetadataBearer {
 
 export namespace DescribeEndpointResponse {
   export function isa(o: any): o is DescribeEndpointResponse {
-    return _smithy.isa(o, "DescribeEndpointResponse");
+    return __isa(o, "DescribeEndpointResponse");
   }
 }
 
@@ -999,7 +1002,7 @@ export interface DescribeEntitiesDetectionJobRequest {
 
 export namespace DescribeEntitiesDetectionJobRequest {
   export function isa(o: any): o is DescribeEntitiesDetectionJobRequest {
-    return _smithy.isa(o, "DescribeEntitiesDetectionJobRequest");
+    return __isa(o, "DescribeEntitiesDetectionJobRequest");
   }
 }
 
@@ -1013,7 +1016,7 @@ export interface DescribeEntitiesDetectionJobResponse extends $MetadataBearer {
 
 export namespace DescribeEntitiesDetectionJobResponse {
   export function isa(o: any): o is DescribeEntitiesDetectionJobResponse {
-    return _smithy.isa(o, "DescribeEntitiesDetectionJobResponse");
+    return __isa(o, "DescribeEntitiesDetectionJobResponse");
   }
 }
 
@@ -1027,7 +1030,7 @@ export interface DescribeEntityRecognizerRequest {
 
 export namespace DescribeEntityRecognizerRequest {
   export function isa(o: any): o is DescribeEntityRecognizerRequest {
-    return _smithy.isa(o, "DescribeEntityRecognizerRequest");
+    return __isa(o, "DescribeEntityRecognizerRequest");
   }
 }
 
@@ -1041,7 +1044,7 @@ export interface DescribeEntityRecognizerResponse extends $MetadataBearer {
 
 export namespace DescribeEntityRecognizerResponse {
   export function isa(o: any): o is DescribeEntityRecognizerResponse {
-    return _smithy.isa(o, "DescribeEntityRecognizerResponse");
+    return __isa(o, "DescribeEntityRecognizerResponse");
   }
 }
 
@@ -1056,7 +1059,7 @@ export interface DescribeKeyPhrasesDetectionJobRequest {
 
 export namespace DescribeKeyPhrasesDetectionJobRequest {
   export function isa(o: any): o is DescribeKeyPhrasesDetectionJobRequest {
-    return _smithy.isa(o, "DescribeKeyPhrasesDetectionJobRequest");
+    return __isa(o, "DescribeKeyPhrasesDetectionJobRequest");
   }
 }
 
@@ -1072,7 +1075,7 @@ export interface DescribeKeyPhrasesDetectionJobResponse
 
 export namespace DescribeKeyPhrasesDetectionJobResponse {
   export function isa(o: any): o is DescribeKeyPhrasesDetectionJobResponse {
-    return _smithy.isa(o, "DescribeKeyPhrasesDetectionJobResponse");
+    return __isa(o, "DescribeKeyPhrasesDetectionJobResponse");
   }
 }
 
@@ -1087,7 +1090,7 @@ export interface DescribeSentimentDetectionJobRequest {
 
 export namespace DescribeSentimentDetectionJobRequest {
   export function isa(o: any): o is DescribeSentimentDetectionJobRequest {
-    return _smithy.isa(o, "DescribeSentimentDetectionJobRequest");
+    return __isa(o, "DescribeSentimentDetectionJobRequest");
   }
 }
 
@@ -1101,7 +1104,7 @@ export interface DescribeSentimentDetectionJobResponse extends $MetadataBearer {
 
 export namespace DescribeSentimentDetectionJobResponse {
   export function isa(o: any): o is DescribeSentimentDetectionJobResponse {
-    return _smithy.isa(o, "DescribeSentimentDetectionJobResponse");
+    return __isa(o, "DescribeSentimentDetectionJobResponse");
   }
 }
 
@@ -1115,7 +1118,7 @@ export interface DescribeTopicsDetectionJobRequest {
 
 export namespace DescribeTopicsDetectionJobRequest {
   export function isa(o: any): o is DescribeTopicsDetectionJobRequest {
-    return _smithy.isa(o, "DescribeTopicsDetectionJobRequest");
+    return __isa(o, "DescribeTopicsDetectionJobRequest");
   }
 }
 
@@ -1129,7 +1132,7 @@ export interface DescribeTopicsDetectionJobResponse extends $MetadataBearer {
 
 export namespace DescribeTopicsDetectionJobResponse {
   export function isa(o: any): o is DescribeTopicsDetectionJobResponse {
-    return _smithy.isa(o, "DescribeTopicsDetectionJobResponse");
+    return __isa(o, "DescribeTopicsDetectionJobResponse");
   }
 }
 
@@ -1144,7 +1147,7 @@ export interface DetectDominantLanguageRequest {
 
 export namespace DetectDominantLanguageRequest {
   export function isa(o: any): o is DetectDominantLanguageRequest {
-    return _smithy.isa(o, "DetectDominantLanguageRequest");
+    return __isa(o, "DetectDominantLanguageRequest");
   }
 }
 
@@ -1161,7 +1164,7 @@ export interface DetectDominantLanguageResponse extends $MetadataBearer {
 
 export namespace DetectDominantLanguageResponse {
   export function isa(o: any): o is DetectDominantLanguageResponse {
-    return _smithy.isa(o, "DetectDominantLanguageResponse");
+    return __isa(o, "DetectDominantLanguageResponse");
   }
 }
 
@@ -1183,7 +1186,7 @@ export interface DetectEntitiesRequest {
 
 export namespace DetectEntitiesRequest {
   export function isa(o: any): o is DetectEntitiesRequest {
-    return _smithy.isa(o, "DetectEntitiesRequest");
+    return __isa(o, "DetectEntitiesRequest");
   }
 }
 
@@ -1199,7 +1202,7 @@ export interface DetectEntitiesResponse extends $MetadataBearer {
 
 export namespace DetectEntitiesResponse {
   export function isa(o: any): o is DetectEntitiesResponse {
-    return _smithy.isa(o, "DetectEntitiesResponse");
+    return __isa(o, "DetectEntitiesResponse");
   }
 }
 
@@ -1221,7 +1224,7 @@ export interface DetectKeyPhrasesRequest {
 
 export namespace DetectKeyPhrasesRequest {
   export function isa(o: any): o is DetectKeyPhrasesRequest {
-    return _smithy.isa(o, "DetectKeyPhrasesRequest");
+    return __isa(o, "DetectKeyPhrasesRequest");
   }
 }
 
@@ -1237,7 +1240,7 @@ export interface DetectKeyPhrasesResponse extends $MetadataBearer {
 
 export namespace DetectKeyPhrasesResponse {
   export function isa(o: any): o is DetectKeyPhrasesResponse {
-    return _smithy.isa(o, "DetectKeyPhrasesResponse");
+    return __isa(o, "DetectKeyPhrasesResponse");
   }
 }
 
@@ -1259,7 +1262,7 @@ export interface DetectSentimentRequest {
 
 export namespace DetectSentimentRequest {
   export function isa(o: any): o is DetectSentimentRequest {
-    return _smithy.isa(o, "DetectSentimentRequest");
+    return __isa(o, "DetectSentimentRequest");
   }
 }
 
@@ -1279,7 +1282,7 @@ export interface DetectSentimentResponse extends $MetadataBearer {
 
 export namespace DetectSentimentResponse {
   export function isa(o: any): o is DetectSentimentResponse {
-    return _smithy.isa(o, "DetectSentimentResponse");
+    return __isa(o, "DetectSentimentResponse");
   }
 }
 
@@ -1300,7 +1303,7 @@ export interface DetectSyntaxRequest {
 
 export namespace DetectSyntaxRequest {
   export function isa(o: any): o is DetectSyntaxRequest {
-    return _smithy.isa(o, "DetectSyntaxRequest");
+    return __isa(o, "DetectSyntaxRequest");
   }
 }
 
@@ -1316,7 +1319,7 @@ export interface DetectSyntaxResponse extends $MetadataBearer {
 
 export namespace DetectSyntaxResponse {
   export function isa(o: any): o is DetectSyntaxResponse {
-    return _smithy.isa(o, "DetectSyntaxResponse");
+    return __isa(o, "DetectSyntaxResponse");
   }
 }
 
@@ -1338,7 +1341,7 @@ export interface DocumentClass {
 
 export namespace DocumentClass {
   export function isa(o: any): o is DocumentClass {
-    return _smithy.isa(o, "DocumentClass");
+    return __isa(o, "DocumentClass");
   }
 }
 
@@ -1376,7 +1379,7 @@ export interface DocumentClassificationJobFilter {
 
 export namespace DocumentClassificationJobFilter {
   export function isa(o: any): o is DocumentClassificationJobFilter {
-    return _smithy.isa(o, "DocumentClassificationJobFilter");
+    return __isa(o, "DocumentClassificationJobFilter");
   }
 }
 
@@ -1464,7 +1467,7 @@ export interface DocumentClassificationJobProperties {
 
 export namespace DocumentClassificationJobProperties {
   export function isa(o: any): o is DocumentClassificationJobProperties {
-    return _smithy.isa(o, "DocumentClassificationJobProperties");
+    return __isa(o, "DocumentClassificationJobProperties");
   }
 }
 
@@ -1497,7 +1500,7 @@ export interface DocumentClassifierFilter {
 
 export namespace DocumentClassifierFilter {
   export function isa(o: any): o is DocumentClassifierFilter {
-    return _smithy.isa(o, "DocumentClassifierFilter");
+    return __isa(o, "DocumentClassifierFilter");
   }
 }
 
@@ -1529,7 +1532,7 @@ export interface DocumentClassifierInputDataConfig {
 
 export namespace DocumentClassifierInputDataConfig {
   export function isa(o: any): o is DocumentClassifierInputDataConfig {
-    return _smithy.isa(o, "DocumentClassifierInputDataConfig");
+    return __isa(o, "DocumentClassifierInputDataConfig");
   }
 }
 
@@ -1582,7 +1585,7 @@ export interface DocumentClassifierOutputDataConfig {
 
 export namespace DocumentClassifierOutputDataConfig {
   export function isa(o: any): o is DocumentClassifierOutputDataConfig {
-    return _smithy.isa(o, "DocumentClassifierOutputDataConfig");
+    return __isa(o, "DocumentClassifierOutputDataConfig");
   }
 }
 
@@ -1692,7 +1695,7 @@ export interface DocumentClassifierProperties {
 
 export namespace DocumentClassifierProperties {
   export function isa(o: any): o is DocumentClassifierProperties {
-    return _smithy.isa(o, "DocumentClassifierProperties");
+    return __isa(o, "DocumentClassifierProperties");
   }
 }
 
@@ -1714,7 +1717,7 @@ export interface DocumentLabel {
 
 export namespace DocumentLabel {
   export function isa(o: any): o is DocumentLabel {
-    return _smithy.isa(o, "DocumentLabel");
+    return __isa(o, "DocumentLabel");
   }
 }
 
@@ -1739,7 +1742,7 @@ export interface DominantLanguage {
 
 export namespace DominantLanguage {
   export function isa(o: any): o is DominantLanguage {
-    return _smithy.isa(o, "DominantLanguage");
+    return __isa(o, "DominantLanguage");
   }
 }
 
@@ -1777,7 +1780,7 @@ export interface DominantLanguageDetectionJobFilter {
 
 export namespace DominantLanguageDetectionJobFilter {
   export function isa(o: any): o is DominantLanguageDetectionJobFilter {
-    return _smithy.isa(o, "DominantLanguageDetectionJobFilter");
+    return __isa(o, "DominantLanguageDetectionJobFilter");
   }
 }
 
@@ -1859,7 +1862,7 @@ export interface DominantLanguageDetectionJobProperties {
 
 export namespace DominantLanguageDetectionJobProperties {
   export function isa(o: any): o is DominantLanguageDetectionJobProperties {
-    return _smithy.isa(o, "DominantLanguageDetectionJobProperties");
+    return __isa(o, "DominantLanguageDetectionJobProperties");
   }
 }
 
@@ -1892,7 +1895,7 @@ export interface EndpointFilter {
 
 export namespace EndpointFilter {
   export function isa(o: any): o is EndpointFilter {
-    return _smithy.isa(o, "EndpointFilter");
+    return __isa(o, "EndpointFilter");
   }
 }
 
@@ -1946,7 +1949,7 @@ export interface EndpointProperties {
 
 export namespace EndpointProperties {
   export function isa(o: any): o is EndpointProperties {
-    return _smithy.isa(o, "EndpointProperties");
+    return __isa(o, "EndpointProperties");
   }
 }
 
@@ -1992,7 +1995,7 @@ export interface EntitiesDetectionJobFilter {
 
 export namespace EntitiesDetectionJobFilter {
   export function isa(o: any): o is EntitiesDetectionJobFilter {
-    return _smithy.isa(o, "EntitiesDetectionJobFilter");
+    return __isa(o, "EntitiesDetectionJobFilter");
   }
 }
 
@@ -2084,7 +2087,7 @@ export interface EntitiesDetectionJobProperties {
 
 export namespace EntitiesDetectionJobProperties {
   export function isa(o: any): o is EntitiesDetectionJobProperties {
-    return _smithy.isa(o, "EntitiesDetectionJobProperties");
+    return __isa(o, "EntitiesDetectionJobProperties");
   }
 }
 
@@ -2129,7 +2132,7 @@ export interface Entity {
 
 export namespace Entity {
   export function isa(o: any): o is Entity {
-    return _smithy.isa(o, "Entity");
+    return __isa(o, "Entity");
   }
 }
 
@@ -2147,7 +2150,7 @@ export interface EntityRecognizerAnnotations {
 
 export namespace EntityRecognizerAnnotations {
   export function isa(o: any): o is EntityRecognizerAnnotations {
-    return _smithy.isa(o, "EntityRecognizerAnnotations");
+    return __isa(o, "EntityRecognizerAnnotations");
   }
 }
 
@@ -2165,7 +2168,7 @@ export interface EntityRecognizerDocuments {
 
 export namespace EntityRecognizerDocuments {
   export function isa(o: any): o is EntityRecognizerDocuments {
-    return _smithy.isa(o, "EntityRecognizerDocuments");
+    return __isa(o, "EntityRecognizerDocuments");
   }
 }
 
@@ -2182,7 +2185,7 @@ export interface EntityRecognizerEntityList {
 
 export namespace EntityRecognizerEntityList {
   export function isa(o: any): o is EntityRecognizerEntityList {
-    return _smithy.isa(o, "EntityRecognizerEntityList");
+    return __isa(o, "EntityRecognizerEntityList");
   }
 }
 
@@ -2215,7 +2218,7 @@ export interface EntityRecognizerEvaluationMetrics {
 
 export namespace EntityRecognizerEvaluationMetrics {
   export function isa(o: any): o is EntityRecognizerEvaluationMetrics {
-    return _smithy.isa(o, "EntityRecognizerEvaluationMetrics");
+    return __isa(o, "EntityRecognizerEvaluationMetrics");
   }
 }
 
@@ -2247,7 +2250,7 @@ export interface EntityRecognizerFilter {
 
 export namespace EntityRecognizerFilter {
   export function isa(o: any): o is EntityRecognizerFilter {
-    return _smithy.isa(o, "EntityRecognizerFilter");
+    return __isa(o, "EntityRecognizerFilter");
   }
 }
 
@@ -2279,7 +2282,7 @@ export interface EntityRecognizerInputDataConfig {
 
 export namespace EntityRecognizerInputDataConfig {
   export function isa(o: any): o is EntityRecognizerInputDataConfig {
-    return _smithy.isa(o, "EntityRecognizerInputDataConfig");
+    return __isa(o, "EntityRecognizerInputDataConfig");
   }
 }
 
@@ -2311,7 +2314,7 @@ export interface EntityRecognizerMetadata {
 
 export namespace EntityRecognizerMetadata {
   export function isa(o: any): o is EntityRecognizerMetadata {
-    return _smithy.isa(o, "EntityRecognizerMetadata");
+    return __isa(o, "EntityRecognizerMetadata");
   }
 }
 
@@ -2340,7 +2343,7 @@ export namespace EntityRecognizerMetadataEntityTypesListItem {
   export function isa(
     o: any
   ): o is EntityRecognizerMetadataEntityTypesListItem {
-    return _smithy.isa(o, "EntityRecognizerMetadataEntityTypesListItem");
+    return __isa(o, "EntityRecognizerMetadataEntityTypesListItem");
   }
 }
 
@@ -2430,7 +2433,7 @@ export interface EntityRecognizerProperties {
 
 export namespace EntityRecognizerProperties {
   export function isa(o: any): o is EntityRecognizerProperties {
-    return _smithy.isa(o, "EntityRecognizerProperties");
+    return __isa(o, "EntityRecognizerProperties");
   }
 }
 
@@ -2475,7 +2478,7 @@ export interface EntityTypesEvaluationMetrics {
 
 export namespace EntityTypesEvaluationMetrics {
   export function isa(o: any): o is EntityTypesEvaluationMetrics {
-    return _smithy.isa(o, "EntityTypesEvaluationMetrics");
+    return __isa(o, "EntityTypesEvaluationMetrics");
   }
 }
 
@@ -2492,7 +2495,7 @@ export interface EntityTypesListItem {
 
 export namespace EntityTypesListItem {
   export function isa(o: any): o is EntityTypesListItem {
-    return _smithy.isa(o, "EntityTypesListItem");
+    return __isa(o, "EntityTypesListItem");
   }
 }
 
@@ -2533,7 +2536,7 @@ export interface InputDataConfig {
 
 export namespace InputDataConfig {
   export function isa(o: any): o is InputDataConfig {
-    return _smithy.isa(o, "InputDataConfig");
+    return __isa(o, "InputDataConfig");
   }
 }
 
@@ -2546,7 +2549,7 @@ export enum InputFormat {
  * <p>An internal server error occurred. Retry your request.</p>
  */
 export interface InternalServerException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalServerException";
   $fault: "server";
@@ -2555,7 +2558,7 @@ export interface InternalServerException
 
 export namespace InternalServerException {
   export function isa(o: any): o is InternalServerException {
-    return _smithy.isa(o, "InternalServerException");
+    return __isa(o, "InternalServerException");
   }
 }
 
@@ -2564,7 +2567,7 @@ export namespace InternalServerException {
  *       Specify a different filter.</p>
  */
 export interface InvalidFilterException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidFilterException";
   $fault: "client";
@@ -2573,7 +2576,7 @@ export interface InvalidFilterException
 
 export namespace InvalidFilterException {
   export function isa(o: any): o is InvalidFilterException {
-    return _smithy.isa(o, "InvalidFilterException");
+    return __isa(o, "InvalidFilterException");
   }
 }
 
@@ -2582,7 +2585,7 @@ export namespace InvalidFilterException {
  *       is invalid.</p>
  */
 export interface InvalidRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidRequestException";
   $fault: "client";
@@ -2591,7 +2594,7 @@ export interface InvalidRequestException
 
 export namespace InvalidRequestException {
   export function isa(o: any): o is InvalidRequestException {
-    return _smithy.isa(o, "InvalidRequestException");
+    return __isa(o, "InvalidRequestException");
   }
 }
 
@@ -2599,7 +2602,7 @@ export namespace InvalidRequestException {
  * <p>The specified job was not found. Check the job ID and try again.</p>
  */
 export interface JobNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "JobNotFoundException";
   $fault: "client";
@@ -2608,7 +2611,7 @@ export interface JobNotFoundException
 
 export namespace JobNotFoundException {
   export function isa(o: any): o is JobNotFoundException {
-    return _smithy.isa(o, "JobNotFoundException");
+    return __isa(o, "JobNotFoundException");
   }
 }
 
@@ -2656,7 +2659,7 @@ export interface KeyPhrase {
 
 export namespace KeyPhrase {
   export function isa(o: any): o is KeyPhrase {
-    return _smithy.isa(o, "KeyPhrase");
+    return __isa(o, "KeyPhrase");
   }
 }
 
@@ -2694,7 +2697,7 @@ export interface KeyPhrasesDetectionJobFilter {
 
 export namespace KeyPhrasesDetectionJobFilter {
   export function isa(o: any): o is KeyPhrasesDetectionJobFilter {
-    return _smithy.isa(o, "KeyPhrasesDetectionJobFilter");
+    return __isa(o, "KeyPhrasesDetectionJobFilter");
   }
 }
 
@@ -2781,7 +2784,7 @@ export interface KeyPhrasesDetectionJobProperties {
 
 export namespace KeyPhrasesDetectionJobProperties {
   export function isa(o: any): o is KeyPhrasesDetectionJobProperties {
-    return _smithy.isa(o, "KeyPhrasesDetectionJobProperties");
+    return __isa(o, "KeyPhrasesDetectionJobProperties");
   }
 }
 
@@ -2789,7 +2792,7 @@ export namespace KeyPhrasesDetectionJobProperties {
  * <p>The KMS customer managed key (CMK) entered cannot be validated. Verify the key and re-enter it.</p>
  */
 export interface KmsKeyValidationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "KmsKeyValidationException";
   $fault: "client";
@@ -2798,7 +2801,7 @@ export interface KmsKeyValidationException
 
 export namespace KmsKeyValidationException {
   export function isa(o: any): o is KmsKeyValidationException {
-    return _smithy.isa(o, "KmsKeyValidationException");
+    return __isa(o, "KmsKeyValidationException");
   }
 }
 
@@ -2838,7 +2841,7 @@ export interface ListDocumentClassificationJobsRequest {
 
 export namespace ListDocumentClassificationJobsRequest {
   export function isa(o: any): o is ListDocumentClassificationJobsRequest {
-    return _smithy.isa(o, "ListDocumentClassificationJobsRequest");
+    return __isa(o, "ListDocumentClassificationJobsRequest");
   }
 }
 
@@ -2860,7 +2863,7 @@ export interface ListDocumentClassificationJobsResponse
 
 export namespace ListDocumentClassificationJobsResponse {
   export function isa(o: any): o is ListDocumentClassificationJobsResponse {
-    return _smithy.isa(o, "ListDocumentClassificationJobsResponse");
+    return __isa(o, "ListDocumentClassificationJobsResponse");
   }
 }
 
@@ -2885,7 +2888,7 @@ export interface ListDocumentClassifiersRequest {
 
 export namespace ListDocumentClassifiersRequest {
   export function isa(o: any): o is ListDocumentClassifiersRequest {
-    return _smithy.isa(o, "ListDocumentClassifiersRequest");
+    return __isa(o, "ListDocumentClassifiersRequest");
   }
 }
 
@@ -2904,7 +2907,7 @@ export interface ListDocumentClassifiersResponse extends $MetadataBearer {
 
 export namespace ListDocumentClassifiersResponse {
   export function isa(o: any): o is ListDocumentClassifiersResponse {
-    return _smithy.isa(o, "ListDocumentClassifiersResponse");
+    return __isa(o, "ListDocumentClassifiersResponse");
   }
 }
 
@@ -2929,7 +2932,7 @@ export interface ListDominantLanguageDetectionJobsRequest {
 
 export namespace ListDominantLanguageDetectionJobsRequest {
   export function isa(o: any): o is ListDominantLanguageDetectionJobsRequest {
-    return _smithy.isa(o, "ListDominantLanguageDetectionJobsRequest");
+    return __isa(o, "ListDominantLanguageDetectionJobsRequest");
   }
 }
 
@@ -2951,7 +2954,7 @@ export interface ListDominantLanguageDetectionJobsResponse
 
 export namespace ListDominantLanguageDetectionJobsResponse {
   export function isa(o: any): o is ListDominantLanguageDetectionJobsResponse {
-    return _smithy.isa(o, "ListDominantLanguageDetectionJobsResponse");
+    return __isa(o, "ListDominantLanguageDetectionJobsResponse");
   }
 }
 
@@ -2976,7 +2979,7 @@ export interface ListEndpointsRequest {
 
 export namespace ListEndpointsRequest {
   export function isa(o: any): o is ListEndpointsRequest {
-    return _smithy.isa(o, "ListEndpointsRequest");
+    return __isa(o, "ListEndpointsRequest");
   }
 }
 
@@ -2995,7 +2998,7 @@ export interface ListEndpointsResponse extends $MetadataBearer {
 
 export namespace ListEndpointsResponse {
   export function isa(o: any): o is ListEndpointsResponse {
-    return _smithy.isa(o, "ListEndpointsResponse");
+    return __isa(o, "ListEndpointsResponse");
   }
 }
 
@@ -3020,7 +3023,7 @@ export interface ListEntitiesDetectionJobsRequest {
 
 export namespace ListEntitiesDetectionJobsRequest {
   export function isa(o: any): o is ListEntitiesDetectionJobsRequest {
-    return _smithy.isa(o, "ListEntitiesDetectionJobsRequest");
+    return __isa(o, "ListEntitiesDetectionJobsRequest");
   }
 }
 
@@ -3039,7 +3042,7 @@ export interface ListEntitiesDetectionJobsResponse extends $MetadataBearer {
 
 export namespace ListEntitiesDetectionJobsResponse {
   export function isa(o: any): o is ListEntitiesDetectionJobsResponse {
-    return _smithy.isa(o, "ListEntitiesDetectionJobsResponse");
+    return __isa(o, "ListEntitiesDetectionJobsResponse");
   }
 }
 
@@ -3063,7 +3066,7 @@ export interface ListEntityRecognizersRequest {
 
 export namespace ListEntityRecognizersRequest {
   export function isa(o: any): o is ListEntityRecognizersRequest {
-    return _smithy.isa(o, "ListEntityRecognizersRequest");
+    return __isa(o, "ListEntityRecognizersRequest");
   }
 }
 
@@ -3082,7 +3085,7 @@ export interface ListEntityRecognizersResponse extends $MetadataBearer {
 
 export namespace ListEntityRecognizersResponse {
   export function isa(o: any): o is ListEntityRecognizersResponse {
-    return _smithy.isa(o, "ListEntityRecognizersResponse");
+    return __isa(o, "ListEntityRecognizersResponse");
   }
 }
 
@@ -3107,7 +3110,7 @@ export interface ListKeyPhrasesDetectionJobsRequest {
 
 export namespace ListKeyPhrasesDetectionJobsRequest {
   export function isa(o: any): o is ListKeyPhrasesDetectionJobsRequest {
-    return _smithy.isa(o, "ListKeyPhrasesDetectionJobsRequest");
+    return __isa(o, "ListKeyPhrasesDetectionJobsRequest");
   }
 }
 
@@ -3128,7 +3131,7 @@ export interface ListKeyPhrasesDetectionJobsResponse extends $MetadataBearer {
 
 export namespace ListKeyPhrasesDetectionJobsResponse {
   export function isa(o: any): o is ListKeyPhrasesDetectionJobsResponse {
-    return _smithy.isa(o, "ListKeyPhrasesDetectionJobsResponse");
+    return __isa(o, "ListKeyPhrasesDetectionJobsResponse");
   }
 }
 
@@ -3153,7 +3156,7 @@ export interface ListSentimentDetectionJobsRequest {
 
 export namespace ListSentimentDetectionJobsRequest {
   export function isa(o: any): o is ListSentimentDetectionJobsRequest {
-    return _smithy.isa(o, "ListSentimentDetectionJobsRequest");
+    return __isa(o, "ListSentimentDetectionJobsRequest");
   }
 }
 
@@ -3172,7 +3175,7 @@ export interface ListSentimentDetectionJobsResponse extends $MetadataBearer {
 
 export namespace ListSentimentDetectionJobsResponse {
   export function isa(o: any): o is ListSentimentDetectionJobsResponse {
-    return _smithy.isa(o, "ListSentimentDetectionJobsResponse");
+    return __isa(o, "ListSentimentDetectionJobsResponse");
   }
 }
 
@@ -3186,7 +3189,7 @@ export interface ListTagsForResourceRequest {
 
 export namespace ListTagsForResourceRequest {
   export function isa(o: any): o is ListTagsForResourceRequest {
-    return _smithy.isa(o, "ListTagsForResourceRequest");
+    return __isa(o, "ListTagsForResourceRequest");
   }
 }
 
@@ -3206,7 +3209,7 @@ export interface ListTagsForResourceResponse extends $MetadataBearer {
 
 export namespace ListTagsForResourceResponse {
   export function isa(o: any): o is ListTagsForResourceResponse {
-    return _smithy.isa(o, "ListTagsForResourceResponse");
+    return __isa(o, "ListTagsForResourceResponse");
   }
 }
 
@@ -3231,7 +3234,7 @@ export interface ListTopicsDetectionJobsRequest {
 
 export namespace ListTopicsDetectionJobsRequest {
   export function isa(o: any): o is ListTopicsDetectionJobsRequest {
-    return _smithy.isa(o, "ListTopicsDetectionJobsRequest");
+    return __isa(o, "ListTopicsDetectionJobsRequest");
   }
 }
 
@@ -3250,7 +3253,7 @@ export interface ListTopicsDetectionJobsResponse extends $MetadataBearer {
 
 export namespace ListTopicsDetectionJobsResponse {
   export function isa(o: any): o is ListTopicsDetectionJobsResponse {
-    return _smithy.isa(o, "ListTopicsDetectionJobsResponse");
+    return __isa(o, "ListTopicsDetectionJobsResponse");
   }
 }
 
@@ -3308,7 +3311,7 @@ export interface OutputDataConfig {
 
 export namespace OutputDataConfig {
   export function isa(o: any): o is OutputDataConfig {
-    return _smithy.isa(o, "OutputDataConfig");
+    return __isa(o, "OutputDataConfig");
   }
 }
 
@@ -3332,7 +3335,7 @@ export interface PartOfSpeechTag {
 
 export namespace PartOfSpeechTag {
   export function isa(o: any): o is PartOfSpeechTag {
-    return _smithy.isa(o, "PartOfSpeechTag");
+    return __isa(o, "PartOfSpeechTag");
   }
 }
 
@@ -3361,7 +3364,7 @@ export enum PartOfSpeechTagType {
  * <p>The specified name is already in use. Use a different name and try your request again.</p>
  */
 export interface ResourceInUseException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceInUseException";
   $fault: "client";
@@ -3370,7 +3373,7 @@ export interface ResourceInUseException
 
 export namespace ResourceInUseException {
   export function isa(o: any): o is ResourceInUseException {
-    return _smithy.isa(o, "ResourceInUseException");
+    return __isa(o, "ResourceInUseException");
   }
 }
 
@@ -3378,7 +3381,7 @@ export namespace ResourceInUseException {
  * <p>The maximum number of recognizers per account has been exceeded. Review the recognizers, perform cleanup, and then try your request again.</p>
  */
 export interface ResourceLimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceLimitExceededException";
   $fault: "client";
@@ -3387,7 +3390,7 @@ export interface ResourceLimitExceededException
 
 export namespace ResourceLimitExceededException {
   export function isa(o: any): o is ResourceLimitExceededException {
-    return _smithy.isa(o, "ResourceLimitExceededException");
+    return __isa(o, "ResourceLimitExceededException");
   }
 }
 
@@ -3395,7 +3398,7 @@ export namespace ResourceLimitExceededException {
  * <p>The specified resource ARN was not found. Check the ARN and try your request again.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -3404,7 +3407,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -3413,7 +3416,7 @@ export namespace ResourceNotFoundException {
  *       the <code>TRAINED</code> state and try your request again.</p>
  */
 export interface ResourceUnavailableException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceUnavailableException";
   $fault: "client";
@@ -3422,7 +3425,7 @@ export interface ResourceUnavailableException
 
 export namespace ResourceUnavailableException {
   export function isa(o: any): o is ResourceUnavailableException {
-    return _smithy.isa(o, "ResourceUnavailableException");
+    return __isa(o, "ResourceUnavailableException");
   }
 }
 
@@ -3460,7 +3463,7 @@ export interface SentimentDetectionJobFilter {
 
 export namespace SentimentDetectionJobFilter {
   export function isa(o: any): o is SentimentDetectionJobFilter {
-    return _smithy.isa(o, "SentimentDetectionJobFilter");
+    return __isa(o, "SentimentDetectionJobFilter");
   }
 }
 
@@ -3547,7 +3550,7 @@ export interface SentimentDetectionJobProperties {
 
 export namespace SentimentDetectionJobProperties {
   export function isa(o: any): o is SentimentDetectionJobProperties {
-    return _smithy.isa(o, "SentimentDetectionJobProperties");
+    return __isa(o, "SentimentDetectionJobProperties");
   }
 }
 
@@ -3584,7 +3587,7 @@ export interface SentimentScore {
 
 export namespace SentimentScore {
   export function isa(o: any): o is SentimentScore {
-    return _smithy.isa(o, "SentimentScore");
+    return __isa(o, "SentimentScore");
   }
 }
 
@@ -3655,7 +3658,7 @@ export interface StartDocumentClassificationJobRequest {
 
 export namespace StartDocumentClassificationJobRequest {
   export function isa(o: any): o is StartDocumentClassificationJobRequest {
-    return _smithy.isa(o, "StartDocumentClassificationJobRequest");
+    return __isa(o, "StartDocumentClassificationJobRequest");
   }
 }
 
@@ -3696,7 +3699,7 @@ export interface StartDocumentClassificationJobResponse
 
 export namespace StartDocumentClassificationJobResponse {
   export function isa(o: any): o is StartDocumentClassificationJobResponse {
-    return _smithy.isa(o, "StartDocumentClassificationJobResponse");
+    return __isa(o, "StartDocumentClassificationJobResponse");
   }
 }
 
@@ -3754,7 +3757,7 @@ export interface StartDominantLanguageDetectionJobRequest {
 
 export namespace StartDominantLanguageDetectionJobRequest {
   export function isa(o: any): o is StartDominantLanguageDetectionJobRequest {
-    return _smithy.isa(o, "StartDominantLanguageDetectionJobRequest");
+    return __isa(o, "StartDominantLanguageDetectionJobRequest");
   }
 }
 
@@ -3789,7 +3792,7 @@ export interface StartDominantLanguageDetectionJobResponse
 
 export namespace StartDominantLanguageDetectionJobResponse {
   export function isa(o: any): o is StartDominantLanguageDetectionJobResponse {
-    return _smithy.isa(o, "StartDominantLanguageDetectionJobResponse");
+    return __isa(o, "StartDominantLanguageDetectionJobResponse");
   }
 }
 
@@ -3861,7 +3864,7 @@ export interface StartEntitiesDetectionJobRequest {
 
 export namespace StartEntitiesDetectionJobRequest {
   export function isa(o: any): o is StartEntitiesDetectionJobRequest {
-    return _smithy.isa(o, "StartEntitiesDetectionJobRequest");
+    return __isa(o, "StartEntitiesDetectionJobRequest");
   }
 }
 
@@ -3901,7 +3904,7 @@ export interface StartEntitiesDetectionJobResponse extends $MetadataBearer {
 
 export namespace StartEntitiesDetectionJobResponse {
   export function isa(o: any): o is StartEntitiesDetectionJobResponse {
-    return _smithy.isa(o, "StartEntitiesDetectionJobResponse");
+    return __isa(o, "StartEntitiesDetectionJobResponse");
   }
 }
 
@@ -3966,7 +3969,7 @@ export interface StartKeyPhrasesDetectionJobRequest {
 
 export namespace StartKeyPhrasesDetectionJobRequest {
   export function isa(o: any): o is StartKeyPhrasesDetectionJobRequest {
-    return _smithy.isa(o, "StartKeyPhrasesDetectionJobRequest");
+    return __isa(o, "StartKeyPhrasesDetectionJobRequest");
   }
 }
 
@@ -4000,7 +4003,7 @@ export interface StartKeyPhrasesDetectionJobResponse extends $MetadataBearer {
 
 export namespace StartKeyPhrasesDetectionJobResponse {
   export function isa(o: any): o is StartKeyPhrasesDetectionJobResponse {
-    return _smithy.isa(o, "StartKeyPhrasesDetectionJobResponse");
+    return __isa(o, "StartKeyPhrasesDetectionJobResponse");
   }
 }
 
@@ -4065,7 +4068,7 @@ export interface StartSentimentDetectionJobRequest {
 
 export namespace StartSentimentDetectionJobRequest {
   export function isa(o: any): o is StartSentimentDetectionJobRequest {
-    return _smithy.isa(o, "StartSentimentDetectionJobRequest");
+    return __isa(o, "StartSentimentDetectionJobRequest");
   }
 }
 
@@ -4099,7 +4102,7 @@ export interface StartSentimentDetectionJobResponse extends $MetadataBearer {
 
 export namespace StartSentimentDetectionJobResponse {
   export function isa(o: any): o is StartSentimentDetectionJobResponse {
-    return _smithy.isa(o, "StartSentimentDetectionJobResponse");
+    return __isa(o, "StartSentimentDetectionJobResponse");
   }
 }
 
@@ -4164,7 +4167,7 @@ export interface StartTopicsDetectionJobRequest {
 
 export namespace StartTopicsDetectionJobRequest {
   export function isa(o: any): o is StartTopicsDetectionJobRequest {
-    return _smithy.isa(o, "StartTopicsDetectionJobRequest");
+    return __isa(o, "StartTopicsDetectionJobRequest");
   }
 }
 
@@ -4200,7 +4203,7 @@ export interface StartTopicsDetectionJobResponse extends $MetadataBearer {
 
 export namespace StartTopicsDetectionJobResponse {
   export function isa(o: any): o is StartTopicsDetectionJobResponse {
-    return _smithy.isa(o, "StartTopicsDetectionJobResponse");
+    return __isa(o, "StartTopicsDetectionJobResponse");
   }
 }
 
@@ -4214,7 +4217,7 @@ export interface StopDominantLanguageDetectionJobRequest {
 
 export namespace StopDominantLanguageDetectionJobRequest {
   export function isa(o: any): o is StopDominantLanguageDetectionJobRequest {
-    return _smithy.isa(o, "StopDominantLanguageDetectionJobRequest");
+    return __isa(o, "StopDominantLanguageDetectionJobRequest");
   }
 }
 
@@ -4236,7 +4239,7 @@ export interface StopDominantLanguageDetectionJobResponse
 
 export namespace StopDominantLanguageDetectionJobResponse {
   export function isa(o: any): o is StopDominantLanguageDetectionJobResponse {
-    return _smithy.isa(o, "StopDominantLanguageDetectionJobResponse");
+    return __isa(o, "StopDominantLanguageDetectionJobResponse");
   }
 }
 
@@ -4250,7 +4253,7 @@ export interface StopEntitiesDetectionJobRequest {
 
 export namespace StopEntitiesDetectionJobRequest {
   export function isa(o: any): o is StopEntitiesDetectionJobRequest {
-    return _smithy.isa(o, "StopEntitiesDetectionJobRequest");
+    return __isa(o, "StopEntitiesDetectionJobRequest");
   }
 }
 
@@ -4271,7 +4274,7 @@ export interface StopEntitiesDetectionJobResponse extends $MetadataBearer {
 
 export namespace StopEntitiesDetectionJobResponse {
   export function isa(o: any): o is StopEntitiesDetectionJobResponse {
-    return _smithy.isa(o, "StopEntitiesDetectionJobResponse");
+    return __isa(o, "StopEntitiesDetectionJobResponse");
   }
 }
 
@@ -4285,7 +4288,7 @@ export interface StopKeyPhrasesDetectionJobRequest {
 
 export namespace StopKeyPhrasesDetectionJobRequest {
   export function isa(o: any): o is StopKeyPhrasesDetectionJobRequest {
-    return _smithy.isa(o, "StopKeyPhrasesDetectionJobRequest");
+    return __isa(o, "StopKeyPhrasesDetectionJobRequest");
   }
 }
 
@@ -4306,7 +4309,7 @@ export interface StopKeyPhrasesDetectionJobResponse extends $MetadataBearer {
 
 export namespace StopKeyPhrasesDetectionJobResponse {
   export function isa(o: any): o is StopKeyPhrasesDetectionJobResponse {
-    return _smithy.isa(o, "StopKeyPhrasesDetectionJobResponse");
+    return __isa(o, "StopKeyPhrasesDetectionJobResponse");
   }
 }
 
@@ -4320,7 +4323,7 @@ export interface StopSentimentDetectionJobRequest {
 
 export namespace StopSentimentDetectionJobRequest {
   export function isa(o: any): o is StopSentimentDetectionJobRequest {
-    return _smithy.isa(o, "StopSentimentDetectionJobRequest");
+    return __isa(o, "StopSentimentDetectionJobRequest");
   }
 }
 
@@ -4341,7 +4344,7 @@ export interface StopSentimentDetectionJobResponse extends $MetadataBearer {
 
 export namespace StopSentimentDetectionJobResponse {
   export function isa(o: any): o is StopSentimentDetectionJobResponse {
-    return _smithy.isa(o, "StopSentimentDetectionJobResponse");
+    return __isa(o, "StopSentimentDetectionJobResponse");
   }
 }
 
@@ -4355,7 +4358,7 @@ export interface StopTrainingDocumentClassifierRequest {
 
 export namespace StopTrainingDocumentClassifierRequest {
   export function isa(o: any): o is StopTrainingDocumentClassifierRequest {
-    return _smithy.isa(o, "StopTrainingDocumentClassifierRequest");
+    return __isa(o, "StopTrainingDocumentClassifierRequest");
   }
 }
 
@@ -4366,7 +4369,7 @@ export interface StopTrainingDocumentClassifierResponse
 
 export namespace StopTrainingDocumentClassifierResponse {
   export function isa(o: any): o is StopTrainingDocumentClassifierResponse {
-    return _smithy.isa(o, "StopTrainingDocumentClassifierResponse");
+    return __isa(o, "StopTrainingDocumentClassifierResponse");
   }
 }
 
@@ -4380,7 +4383,7 @@ export interface StopTrainingEntityRecognizerRequest {
 
 export namespace StopTrainingEntityRecognizerRequest {
   export function isa(o: any): o is StopTrainingEntityRecognizerRequest {
-    return _smithy.isa(o, "StopTrainingEntityRecognizerRequest");
+    return __isa(o, "StopTrainingEntityRecognizerRequest");
   }
 }
 
@@ -4390,7 +4393,7 @@ export interface StopTrainingEntityRecognizerResponse extends $MetadataBearer {
 
 export namespace StopTrainingEntityRecognizerResponse {
   export function isa(o: any): o is StopTrainingEntityRecognizerResponse {
-    return _smithy.isa(o, "StopTrainingEntityRecognizerResponse");
+    return __isa(o, "StopTrainingEntityRecognizerResponse");
   }
 }
 
@@ -4440,7 +4443,7 @@ export interface SyntaxToken {
 
 export namespace SyntaxToken {
   export function isa(o: any): o is SyntaxToken {
-    return _smithy.isa(o, "SyntaxToken");
+    return __isa(o, "SyntaxToken");
   }
 }
 
@@ -4462,7 +4465,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -4481,7 +4484,7 @@ export interface TagResourceRequest {
 
 export namespace TagResourceRequest {
   export function isa(o: any): o is TagResourceRequest {
-    return _smithy.isa(o, "TagResourceRequest");
+    return __isa(o, "TagResourceRequest");
   }
 }
 
@@ -4491,7 +4494,7 @@ export interface TagResourceResponse extends $MetadataBearer {
 
 export namespace TagResourceResponse {
   export function isa(o: any): o is TagResourceResponse {
-    return _smithy.isa(o, "TagResourceResponse");
+    return __isa(o, "TagResourceResponse");
   }
 }
 
@@ -4499,7 +4502,7 @@ export namespace TagResourceResponse {
  * <p>The size of the input text exceeds the limit. Use a smaller document.</p>
  */
 export interface TextSizeLimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TextSizeLimitExceededException";
   $fault: "client";
@@ -4508,7 +4511,7 @@ export interface TextSizeLimitExceededException
 
 export namespace TextSizeLimitExceededException {
   export function isa(o: any): o is TextSizeLimitExceededException {
-    return _smithy.isa(o, "TextSizeLimitExceededException");
+    return __isa(o, "TextSizeLimitExceededException");
   }
 }
 
@@ -4516,7 +4519,7 @@ export namespace TextSizeLimitExceededException {
  * <p>The number of requests exceeds the limit. Resubmit your request later.</p>
  */
 export interface TooManyRequestsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyRequestsException";
   $fault: "client";
@@ -4525,7 +4528,7 @@ export interface TooManyRequestsException
 
 export namespace TooManyRequestsException {
   export function isa(o: any): o is TooManyRequestsException {
-    return _smithy.isa(o, "TooManyRequestsException");
+    return __isa(o, "TooManyRequestsException");
   }
 }
 
@@ -4533,7 +4536,7 @@ export namespace TooManyRequestsException {
  * <p>The request contains more tag keys than can be associated with a resource (50 tag keys per resource).</p>
  */
 export interface TooManyTagKeysException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyTagKeysException";
   $fault: "client";
@@ -4542,7 +4545,7 @@ export interface TooManyTagKeysException
 
 export namespace TooManyTagKeysException {
   export function isa(o: any): o is TooManyTagKeysException {
-    return _smithy.isa(o, "TooManyTagKeysException");
+    return __isa(o, "TooManyTagKeysException");
   }
 }
 
@@ -4551,7 +4554,7 @@ export namespace TooManyTagKeysException {
  *       number of tags includes both existing tags and those included in your current request.    </p>
  */
 export interface TooManyTagsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyTagsException";
   $fault: "client";
@@ -4560,7 +4563,7 @@ export interface TooManyTagsException
 
 export namespace TooManyTagsException {
   export function isa(o: any): o is TooManyTagsException {
-    return _smithy.isa(o, "TooManyTagsException");
+    return __isa(o, "TooManyTagsException");
   }
 }
 
@@ -4598,7 +4601,7 @@ export interface TopicsDetectionJobFilter {
 
 export namespace TopicsDetectionJobFilter {
   export function isa(o: any): o is TopicsDetectionJobFilter {
-    return _smithy.isa(o, "TopicsDetectionJobFilter");
+    return __isa(o, "TopicsDetectionJobFilter");
   }
 }
 
@@ -4686,7 +4689,7 @@ export interface TopicsDetectionJobProperties {
 
 export namespace TopicsDetectionJobProperties {
   export function isa(o: any): o is TopicsDetectionJobProperties {
-    return _smithy.isa(o, "TopicsDetectionJobProperties");
+    return __isa(o, "TopicsDetectionJobProperties");
   }
 }
 
@@ -4696,7 +4699,7 @@ export namespace TopicsDetectionJobProperties {
  *       all supported languages. For a list of supported languages, see <a>supported-languages</a>. </p>
  */
 export interface UnsupportedLanguageException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UnsupportedLanguageException";
   $fault: "client";
@@ -4705,7 +4708,7 @@ export interface UnsupportedLanguageException
 
 export namespace UnsupportedLanguageException {
   export function isa(o: any): o is UnsupportedLanguageException {
-    return _smithy.isa(o, "UnsupportedLanguageException");
+    return __isa(o, "UnsupportedLanguageException");
   }
 }
 
@@ -4726,7 +4729,7 @@ export interface UntagResourceRequest {
 
 export namespace UntagResourceRequest {
   export function isa(o: any): o is UntagResourceRequest {
-    return _smithy.isa(o, "UntagResourceRequest");
+    return __isa(o, "UntagResourceRequest");
   }
 }
 
@@ -4736,7 +4739,7 @@ export interface UntagResourceResponse extends $MetadataBearer {
 
 export namespace UntagResourceResponse {
   export function isa(o: any): o is UntagResourceResponse {
-    return _smithy.isa(o, "UntagResourceResponse");
+    return __isa(o, "UntagResourceResponse");
   }
 }
 
@@ -4756,7 +4759,7 @@ export interface UpdateEndpointRequest {
 
 export namespace UpdateEndpointRequest {
   export function isa(o: any): o is UpdateEndpointRequest {
-    return _smithy.isa(o, "UpdateEndpointRequest");
+    return __isa(o, "UpdateEndpointRequest");
   }
 }
 
@@ -4766,7 +4769,7 @@ export interface UpdateEndpointResponse extends $MetadataBearer {
 
 export namespace UpdateEndpointResponse {
   export function isa(o: any): o is UpdateEndpointResponse {
-    return _smithy.isa(o, "UpdateEndpointResponse");
+    return __isa(o, "UpdateEndpointResponse");
   }
 }
 
@@ -4793,6 +4796,6 @@ export interface VpcConfig {
 
 export namespace VpcConfig {
   export function isa(o: any): o is VpcConfig {
-    return _smithy.isa(o, "VpcConfig");
+    return __isa(o, "VpcConfig");
   }
 }

--- a/clients/client-comprehendmedical/models/index.ts
+++ b/clients/client-comprehendmedical/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -57,7 +60,7 @@ export interface Attribute {
 
 export namespace Attribute {
   export function isa(o: any): o is Attribute {
-    return _smithy.isa(o, "Attribute");
+    return __isa(o, "Attribute");
   }
 }
 
@@ -101,7 +104,7 @@ export interface ComprehendMedicalAsyncJobFilter {
 
 export namespace ComprehendMedicalAsyncJobFilter {
   export function isa(o: any): o is ComprehendMedicalAsyncJobFilter {
-    return _smithy.isa(o, "ComprehendMedicalAsyncJobFilter");
+    return __isa(o, "ComprehendMedicalAsyncJobFilter");
   }
 }
 
@@ -188,7 +191,7 @@ export interface ComprehendMedicalAsyncJobProperties {
 
 export namespace ComprehendMedicalAsyncJobProperties {
   export function isa(o: any): o is ComprehendMedicalAsyncJobProperties {
-    return _smithy.isa(o, "ComprehendMedicalAsyncJobProperties");
+    return __isa(o, "ComprehendMedicalAsyncJobProperties");
   }
 }
 
@@ -204,7 +207,7 @@ export interface DescribeEntitiesDetectionV2JobRequest {
 
 export namespace DescribeEntitiesDetectionV2JobRequest {
   export function isa(o: any): o is DescribeEntitiesDetectionV2JobRequest {
-    return _smithy.isa(o, "DescribeEntitiesDetectionV2JobRequest");
+    return __isa(o, "DescribeEntitiesDetectionV2JobRequest");
   }
 }
 
@@ -219,7 +222,7 @@ export interface DescribeEntitiesDetectionV2JobResponse
 
 export namespace DescribeEntitiesDetectionV2JobResponse {
   export function isa(o: any): o is DescribeEntitiesDetectionV2JobResponse {
-    return _smithy.isa(o, "DescribeEntitiesDetectionV2JobResponse");
+    return __isa(o, "DescribeEntitiesDetectionV2JobResponse");
   }
 }
 
@@ -234,7 +237,7 @@ export interface DescribePHIDetectionJobRequest {
 
 export namespace DescribePHIDetectionJobRequest {
   export function isa(o: any): o is DescribePHIDetectionJobRequest {
-    return _smithy.isa(o, "DescribePHIDetectionJobRequest");
+    return __isa(o, "DescribePHIDetectionJobRequest");
   }
 }
 
@@ -248,7 +251,7 @@ export interface DescribePHIDetectionJobResponse extends $MetadataBearer {
 
 export namespace DescribePHIDetectionJobResponse {
   export function isa(o: any): o is DescribePHIDetectionJobResponse {
-    return _smithy.isa(o, "DescribePHIDetectionJobResponse");
+    return __isa(o, "DescribePHIDetectionJobResponse");
   }
 }
 
@@ -263,7 +266,7 @@ export interface DetectEntitiesRequest {
 
 export namespace DetectEntitiesRequest {
   export function isa(o: any): o is DetectEntitiesRequest {
-    return _smithy.isa(o, "DetectEntitiesRequest");
+    return __isa(o, "DetectEntitiesRequest");
   }
 }
 
@@ -297,7 +300,7 @@ export interface DetectEntitiesResponse extends $MetadataBearer {
 
 export namespace DetectEntitiesResponse {
   export function isa(o: any): o is DetectEntitiesResponse {
-    return _smithy.isa(o, "DetectEntitiesResponse");
+    return __isa(o, "DetectEntitiesResponse");
   }
 }
 
@@ -312,7 +315,7 @@ export interface DetectEntitiesV2Request {
 
 export namespace DetectEntitiesV2Request {
   export function isa(o: any): o is DetectEntitiesV2Request {
-    return _smithy.isa(o, "DetectEntitiesV2Request");
+    return __isa(o, "DetectEntitiesV2Request");
   }
 }
 
@@ -346,7 +349,7 @@ export interface DetectEntitiesV2Response extends $MetadataBearer {
 
 export namespace DetectEntitiesV2Response {
   export function isa(o: any): o is DetectEntitiesV2Response {
-    return _smithy.isa(o, "DetectEntitiesV2Response");
+    return __isa(o, "DetectEntitiesV2Response");
   }
 }
 
@@ -361,7 +364,7 @@ export interface DetectPHIRequest {
 
 export namespace DetectPHIRequest {
   export function isa(o: any): o is DetectPHIRequest {
-    return _smithy.isa(o, "DetectPHIRequest");
+    return __isa(o, "DetectPHIRequest");
   }
 }
 
@@ -390,7 +393,7 @@ export interface DetectPHIResponse extends $MetadataBearer {
 
 export namespace DetectPHIResponse {
   export function isa(o: any): o is DetectPHIResponse {
-    return _smithy.isa(o, "DetectPHIResponse");
+    return __isa(o, "DetectPHIResponse");
   }
 }
 
@@ -450,7 +453,7 @@ export interface Entity {
 
 export namespace Entity {
   export function isa(o: any): o is Entity {
-    return _smithy.isa(o, "Entity");
+    return __isa(o, "Entity");
   }
 }
 
@@ -551,7 +554,7 @@ export interface ICD10CMAttribute {
 
 export namespace ICD10CMAttribute {
   export function isa(o: any): o is ICD10CMAttribute {
-    return _smithy.isa(o, "ICD10CMAttribute");
+    return __isa(o, "ICD10CMAttribute");
   }
 }
 
@@ -588,7 +591,7 @@ export interface ICD10CMConcept {
 
 export namespace ICD10CMConcept {
   export function isa(o: any): o is ICD10CMConcept {
-    return _smithy.isa(o, "ICD10CMConcept");
+    return __isa(o, "ICD10CMConcept");
   }
 }
 
@@ -664,7 +667,7 @@ export interface ICD10CMEntity {
 
 export namespace ICD10CMEntity {
   export function isa(o: any): o is ICD10CMEntity {
-    return _smithy.isa(o, "ICD10CMEntity");
+    return __isa(o, "ICD10CMEntity");
   }
 }
 
@@ -697,7 +700,7 @@ export interface ICD10CMTrait {
 
 export namespace ICD10CMTrait {
   export function isa(o: any): o is ICD10CMTrait {
-    return _smithy.isa(o, "ICD10CMTrait");
+    return __isa(o, "ICD10CMTrait");
   }
 }
 
@@ -719,7 +722,7 @@ export interface InferICD10CMRequest {
 
 export namespace InferICD10CMRequest {
   export function isa(o: any): o is InferICD10CMRequest {
-    return _smithy.isa(o, "InferICD10CMRequest");
+    return __isa(o, "InferICD10CMRequest");
   }
 }
 
@@ -747,7 +750,7 @@ export interface InferICD10CMResponse extends $MetadataBearer {
 
 export namespace InferICD10CMResponse {
   export function isa(o: any): o is InferICD10CMResponse {
-    return _smithy.isa(o, "InferICD10CMResponse");
+    return __isa(o, "InferICD10CMResponse");
   }
 }
 
@@ -762,7 +765,7 @@ export interface InferRxNormRequest {
 
 export namespace InferRxNormRequest {
   export function isa(o: any): o is InferRxNormRequest {
-    return _smithy.isa(o, "InferRxNormRequest");
+    return __isa(o, "InferRxNormRequest");
   }
 }
 
@@ -790,7 +793,7 @@ export interface InferRxNormResponse extends $MetadataBearer {
 
 export namespace InferRxNormResponse {
   export function isa(o: any): o is InferRxNormResponse {
-    return _smithy.isa(o, "InferRxNormResponse");
+    return __isa(o, "InferRxNormResponse");
   }
 }
 
@@ -815,7 +818,7 @@ export interface InputDataConfig {
 
 export namespace InputDataConfig {
   export function isa(o: any): o is InputDataConfig {
-    return _smithy.isa(o, "InputDataConfig");
+    return __isa(o, "InputDataConfig");
   }
 }
 
@@ -823,7 +826,7 @@ export namespace InputDataConfig {
  * <p> An internal server error occurred. Retry your request. </p>
  */
 export interface InternalServerException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalServerException";
   $fault: "server";
@@ -832,7 +835,7 @@ export interface InternalServerException
 
 export namespace InternalServerException {
   export function isa(o: any): o is InternalServerException {
-    return _smithy.isa(o, "InternalServerException");
+    return __isa(o, "InternalServerException");
   }
 }
 
@@ -841,7 +844,7 @@ export namespace InternalServerException {
  *    request.</p>
  */
 export interface InvalidEncodingException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidEncodingException";
   $fault: "client";
@@ -850,7 +853,7 @@ export interface InvalidEncodingException
 
 export namespace InvalidEncodingException {
   export function isa(o: any): o is InvalidEncodingException {
-    return _smithy.isa(o, "InvalidEncodingException");
+    return __isa(o, "InvalidEncodingException");
   }
 }
 
@@ -859,7 +862,7 @@ export namespace InvalidEncodingException {
  *    then retry the request.</p>
  */
 export interface InvalidRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidRequestException";
   $fault: "client";
@@ -868,7 +871,7 @@ export interface InvalidRequestException
 
 export namespace InvalidRequestException {
   export function isa(o: any): o is InvalidRequestException {
-    return _smithy.isa(o, "InvalidRequestException");
+    return __isa(o, "InvalidRequestException");
   }
 }
 
@@ -907,7 +910,7 @@ export interface ListEntitiesDetectionV2JobsRequest {
 
 export namespace ListEntitiesDetectionV2JobsRequest {
   export function isa(o: any): o is ListEntitiesDetectionV2JobsRequest {
-    return _smithy.isa(o, "ListEntitiesDetectionV2JobsRequest");
+    return __isa(o, "ListEntitiesDetectionV2JobsRequest");
   }
 }
 
@@ -928,7 +931,7 @@ export interface ListEntitiesDetectionV2JobsResponse extends $MetadataBearer {
 
 export namespace ListEntitiesDetectionV2JobsResponse {
   export function isa(o: any): o is ListEntitiesDetectionV2JobsResponse {
-    return _smithy.isa(o, "ListEntitiesDetectionV2JobsResponse");
+    return __isa(o, "ListEntitiesDetectionV2JobsResponse");
   }
 }
 
@@ -953,7 +956,7 @@ export interface ListPHIDetectionJobsRequest {
 
 export namespace ListPHIDetectionJobsRequest {
   export function isa(o: any): o is ListPHIDetectionJobsRequest {
-    return _smithy.isa(o, "ListPHIDetectionJobsRequest");
+    return __isa(o, "ListPHIDetectionJobsRequest");
   }
 }
 
@@ -974,7 +977,7 @@ export interface ListPHIDetectionJobsResponse extends $MetadataBearer {
 
 export namespace ListPHIDetectionJobsResponse {
   export function isa(o: any): o is ListPHIDetectionJobsResponse {
-    return _smithy.isa(o, "ListPHIDetectionJobsResponse");
+    return __isa(o, "ListPHIDetectionJobsResponse");
   }
 }
 
@@ -1000,7 +1003,7 @@ export interface OutputDataConfig {
 
 export namespace OutputDataConfig {
   export function isa(o: any): o is OutputDataConfig {
-    return _smithy.isa(o, "OutputDataConfig");
+    return __isa(o, "OutputDataConfig");
   }
 }
 
@@ -1009,7 +1012,7 @@ export namespace OutputDataConfig {
  *    ARN and try your request again.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -1018,7 +1021,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -1079,7 +1082,7 @@ export interface RxNormAttribute {
 
 export namespace RxNormAttribute {
   export function isa(o: any): o is RxNormAttribute {
-    return _smithy.isa(o, "RxNormAttribute");
+    return __isa(o, "RxNormAttribute");
   }
 }
 
@@ -1118,7 +1121,7 @@ export interface RxNormConcept {
 
 export namespace RxNormConcept {
   export function isa(o: any): o is RxNormConcept {
-    return _smithy.isa(o, "RxNormConcept");
+    return __isa(o, "RxNormConcept");
   }
 }
 
@@ -1192,7 +1195,7 @@ export interface RxNormEntity {
 
 export namespace RxNormEntity {
   export function isa(o: any): o is RxNormEntity {
-    return _smithy.isa(o, "RxNormEntity");
+    return __isa(o, "RxNormEntity");
   }
 }
 
@@ -1225,7 +1228,7 @@ export interface RxNormTrait {
 
 export namespace RxNormTrait {
   export function isa(o: any): o is RxNormTrait {
-    return _smithy.isa(o, "RxNormTrait");
+    return __isa(o, "RxNormTrait");
   }
 }
 
@@ -1238,7 +1241,7 @@ export enum RxNormTraitName {
  *   </p>
  */
 export interface ServiceUnavailableException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ServiceUnavailableException";
   $fault: "server";
@@ -1247,7 +1250,7 @@ export interface ServiceUnavailableException
 
 export namespace ServiceUnavailableException {
   export function isa(o: any): o is ServiceUnavailableException {
-    return _smithy.isa(o, "ServiceUnavailableException");
+    return __isa(o, "ServiceUnavailableException");
   }
 }
 
@@ -1294,7 +1297,7 @@ export interface StartEntitiesDetectionV2JobRequest {
 
 export namespace StartEntitiesDetectionV2JobRequest {
   export function isa(o: any): o is StartEntitiesDetectionV2JobRequest {
-    return _smithy.isa(o, "StartEntitiesDetectionV2JobRequest");
+    return __isa(o, "StartEntitiesDetectionV2JobRequest");
   }
 }
 
@@ -1309,7 +1312,7 @@ export interface StartEntitiesDetectionV2JobResponse extends $MetadataBearer {
 
 export namespace StartEntitiesDetectionV2JobResponse {
   export function isa(o: any): o is StartEntitiesDetectionV2JobResponse {
-    return _smithy.isa(o, "StartEntitiesDetectionV2JobResponse");
+    return __isa(o, "StartEntitiesDetectionV2JobResponse");
   }
 }
 
@@ -1356,7 +1359,7 @@ export interface StartPHIDetectionJobRequest {
 
 export namespace StartPHIDetectionJobRequest {
   export function isa(o: any): o is StartPHIDetectionJobRequest {
-    return _smithy.isa(o, "StartPHIDetectionJobRequest");
+    return __isa(o, "StartPHIDetectionJobRequest");
   }
 }
 
@@ -1371,7 +1374,7 @@ export interface StartPHIDetectionJobResponse extends $MetadataBearer {
 
 export namespace StartPHIDetectionJobResponse {
   export function isa(o: any): o is StartPHIDetectionJobResponse {
-    return _smithy.isa(o, "StartPHIDetectionJobResponse");
+    return __isa(o, "StartPHIDetectionJobResponse");
   }
 }
 
@@ -1385,7 +1388,7 @@ export interface StopEntitiesDetectionV2JobRequest {
 
 export namespace StopEntitiesDetectionV2JobRequest {
   export function isa(o: any): o is StopEntitiesDetectionV2JobRequest {
-    return _smithy.isa(o, "StopEntitiesDetectionV2JobRequest");
+    return __isa(o, "StopEntitiesDetectionV2JobRequest");
   }
 }
 
@@ -1399,7 +1402,7 @@ export interface StopEntitiesDetectionV2JobResponse extends $MetadataBearer {
 
 export namespace StopEntitiesDetectionV2JobResponse {
   export function isa(o: any): o is StopEntitiesDetectionV2JobResponse {
-    return _smithy.isa(o, "StopEntitiesDetectionV2JobResponse");
+    return __isa(o, "StopEntitiesDetectionV2JobResponse");
   }
 }
 
@@ -1413,7 +1416,7 @@ export interface StopPHIDetectionJobRequest {
 
 export namespace StopPHIDetectionJobRequest {
   export function isa(o: any): o is StopPHIDetectionJobRequest {
-    return _smithy.isa(o, "StopPHIDetectionJobRequest");
+    return __isa(o, "StopPHIDetectionJobRequest");
   }
 }
 
@@ -1427,7 +1430,7 @@ export interface StopPHIDetectionJobResponse extends $MetadataBearer {
 
 export namespace StopPHIDetectionJobResponse {
   export function isa(o: any): o is StopPHIDetectionJobResponse {
-    return _smithy.isa(o, "StopPHIDetectionJobResponse");
+    return __isa(o, "StopPHIDetectionJobResponse");
   }
 }
 
@@ -1436,7 +1439,7 @@ export namespace StopPHIDetectionJobResponse {
  *    use a smaller document and then retry your request. </p>
  */
 export interface TextSizeLimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TextSizeLimitExceededException";
   $fault: "client";
@@ -1445,7 +1448,7 @@ export interface TextSizeLimitExceededException
 
 export namespace TextSizeLimitExceededException {
   export function isa(o: any): o is TextSizeLimitExceededException {
-    return _smithy.isa(o, "TextSizeLimitExceededException");
+    return __isa(o, "TextSizeLimitExceededException");
   }
 }
 
@@ -1455,7 +1458,7 @@ export namespace TextSizeLimitExceededException {
  *    increase. </p>
  */
 export interface TooManyRequestsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyRequestsException";
   $fault: "client";
@@ -1464,7 +1467,7 @@ export interface TooManyRequestsException
 
 export namespace TooManyRequestsException {
   export function isa(o: any): o is TooManyRequestsException {
-    return _smithy.isa(o, "TooManyRequestsException");
+    return __isa(o, "TooManyRequestsException");
   }
 }
 
@@ -1486,7 +1489,7 @@ export interface Trait {
 
 export namespace Trait {
   export function isa(o: any): o is Trait {
-    return _smithy.isa(o, "Trait");
+    return __isa(o, "Trait");
   }
 }
 
@@ -1510,7 +1513,7 @@ export interface UnmappedAttribute {
 
 export namespace UnmappedAttribute {
   export function isa(o: any): o is UnmappedAttribute {
-    return _smithy.isa(o, "UnmappedAttribute");
+    return __isa(o, "UnmappedAttribute");
   }
 }
 
@@ -1519,7 +1522,7 @@ export namespace UnmappedAttribute {
  *    entered and try your request again.</p>
  */
 export interface ValidationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ValidationException";
   $fault: "client";
@@ -1528,6 +1531,6 @@ export interface ValidationException
 
 export namespace ValidationException {
   export function isa(o: any): o is ValidationException {
-    return _smithy.isa(o, "ValidationException");
+    return __isa(o, "ValidationException");
   }
 }

--- a/clients/client-compute-optimizer/models/index.ts
+++ b/clients/client-compute-optimizer/models/index.ts
@@ -1,11 +1,14 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
  * <p>You do not have sufficient access to perform this action.</p>
  */
 export interface AccessDeniedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AccessDeniedException";
   $fault: "client";
@@ -14,7 +17,7 @@ export interface AccessDeniedException
 
 export namespace AccessDeniedException {
   export function isa(o: any): o is AccessDeniedException {
-    return _smithy.isa(o, "AccessDeniedException");
+    return __isa(o, "AccessDeniedException");
   }
 }
 
@@ -46,7 +49,7 @@ export interface AutoScalingGroupConfiguration {
 
 export namespace AutoScalingGroupConfiguration {
   export function isa(o: any): o is AutoScalingGroupConfiguration {
-    return _smithy.isa(o, "AutoScalingGroupConfiguration");
+    return __isa(o, "AutoScalingGroupConfiguration");
   }
 }
 
@@ -130,7 +133,7 @@ export interface AutoScalingGroupRecommendation {
 
 export namespace AutoScalingGroupRecommendation {
   export function isa(o: any): o is AutoScalingGroupRecommendation {
-    return _smithy.isa(o, "AutoScalingGroupRecommendation");
+    return __isa(o, "AutoScalingGroupRecommendation");
   }
 }
 
@@ -168,7 +171,7 @@ export interface AutoScalingGroupRecommendationOption {
 
 export namespace AutoScalingGroupRecommendationOption {
   export function isa(o: any): o is AutoScalingGroupRecommendationOption {
-    return _smithy.isa(o, "AutoScalingGroupRecommendationOption");
+    return __isa(o, "AutoScalingGroupRecommendationOption");
   }
 }
 
@@ -204,7 +207,7 @@ export interface Filter {
 
 export namespace Filter {
   export function isa(o: any): o is Filter {
-    return _smithy.isa(o, "Filter");
+    return __isa(o, "Filter");
   }
 }
 
@@ -255,7 +258,7 @@ export interface GetAutoScalingGroupRecommendationsRequest {
 
 export namespace GetAutoScalingGroupRecommendationsRequest {
   export function isa(o: any): o is GetAutoScalingGroupRecommendationsRequest {
-    return _smithy.isa(o, "GetAutoScalingGroupRecommendationsRequest");
+    return __isa(o, "GetAutoScalingGroupRecommendationsRequest");
   }
 }
 
@@ -284,7 +287,7 @@ export interface GetAutoScalingGroupRecommendationsResponse
 
 export namespace GetAutoScalingGroupRecommendationsResponse {
   export function isa(o: any): o is GetAutoScalingGroupRecommendationsResponse {
-    return _smithy.isa(o, "GetAutoScalingGroupRecommendationsResponse");
+    return __isa(o, "GetAutoScalingGroupRecommendationsResponse");
   }
 }
 
@@ -323,7 +326,7 @@ export interface GetEC2InstanceRecommendationsRequest {
 
 export namespace GetEC2InstanceRecommendationsRequest {
   export function isa(o: any): o is GetEC2InstanceRecommendationsRequest {
-    return _smithy.isa(o, "GetEC2InstanceRecommendationsRequest");
+    return __isa(o, "GetEC2InstanceRecommendationsRequest");
   }
 }
 
@@ -351,7 +354,7 @@ export interface GetEC2InstanceRecommendationsResponse extends $MetadataBearer {
 
 export namespace GetEC2InstanceRecommendationsResponse {
   export function isa(o: any): o is GetEC2InstanceRecommendationsResponse {
-    return _smithy.isa(o, "GetEC2InstanceRecommendationsResponse");
+    return __isa(o, "GetEC2InstanceRecommendationsResponse");
   }
 }
 
@@ -388,7 +391,7 @@ export namespace GetEC2RecommendationProjectedMetricsRequest {
   export function isa(
     o: any
   ): o is GetEC2RecommendationProjectedMetricsRequest {
-    return _smithy.isa(o, "GetEC2RecommendationProjectedMetricsRequest");
+    return __isa(o, "GetEC2RecommendationProjectedMetricsRequest");
   }
 }
 
@@ -405,7 +408,7 @@ export namespace GetEC2RecommendationProjectedMetricsResponse {
   export function isa(
     o: any
   ): o is GetEC2RecommendationProjectedMetricsResponse {
-    return _smithy.isa(o, "GetEC2RecommendationProjectedMetricsResponse");
+    return __isa(o, "GetEC2RecommendationProjectedMetricsResponse");
   }
 }
 
@@ -415,7 +418,7 @@ export interface GetEnrollmentStatusRequest {
 
 export namespace GetEnrollmentStatusRequest {
   export function isa(o: any): o is GetEnrollmentStatusRequest {
-    return _smithy.isa(o, "GetEnrollmentStatusRequest");
+    return __isa(o, "GetEnrollmentStatusRequest");
   }
 }
 
@@ -442,7 +445,7 @@ export interface GetEnrollmentStatusResponse extends $MetadataBearer {
 
 export namespace GetEnrollmentStatusResponse {
   export function isa(o: any): o is GetEnrollmentStatusResponse {
-    return _smithy.isa(o, "GetEnrollmentStatusResponse");
+    return __isa(o, "GetEnrollmentStatusResponse");
   }
 }
 
@@ -472,7 +475,7 @@ export interface GetRecommendationError {
 
 export namespace GetRecommendationError {
   export function isa(o: any): o is GetRecommendationError {
-    return _smithy.isa(o, "GetRecommendationError");
+    return __isa(o, "GetRecommendationError");
   }
 }
 
@@ -499,7 +502,7 @@ export interface GetRecommendationSummariesRequest {
 
 export namespace GetRecommendationSummariesRequest {
   export function isa(o: any): o is GetRecommendationSummariesRequest {
-    return _smithy.isa(o, "GetRecommendationSummariesRequest");
+    return __isa(o, "GetRecommendationSummariesRequest");
   }
 }
 
@@ -520,7 +523,7 @@ export interface GetRecommendationSummariesResponse extends $MetadataBearer {
 
 export namespace GetRecommendationSummariesResponse {
   export function isa(o: any): o is GetRecommendationSummariesResponse {
-    return _smithy.isa(o, "GetRecommendationSummariesResponse");
+    return __isa(o, "GetRecommendationSummariesResponse");
   }
 }
 
@@ -622,7 +625,7 @@ export interface InstanceRecommendation {
 
 export namespace InstanceRecommendation {
   export function isa(o: any): o is InstanceRecommendation {
-    return _smithy.isa(o, "InstanceRecommendation");
+    return __isa(o, "InstanceRecommendation");
   }
 }
 
@@ -660,7 +663,7 @@ export interface InstanceRecommendationOption {
 
 export namespace InstanceRecommendationOption {
   export function isa(o: any): o is InstanceRecommendationOption {
-    return _smithy.isa(o, "InstanceRecommendationOption");
+    return __isa(o, "InstanceRecommendationOption");
   }
 }
 
@@ -669,7 +672,7 @@ export namespace InstanceRecommendationOption {
  *             failure.</p>
  */
 export interface InternalServerException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalServerException";
   $fault: "server";
@@ -678,7 +681,7 @@ export interface InternalServerException
 
 export namespace InternalServerException {
   export function isa(o: any): o is InternalServerException {
-    return _smithy.isa(o, "InternalServerException");
+    return __isa(o, "InternalServerException");
   }
 }
 
@@ -686,7 +689,7 @@ export namespace InternalServerException {
  * <p>An invalid or out-of-range value was supplied for the input parameter.</p>
  */
 export interface InvalidParameterValueException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidParameterValueException";
   $fault: "client";
@@ -695,7 +698,7 @@ export interface InvalidParameterValueException
 
 export namespace InvalidParameterValueException {
   export function isa(o: any): o is InvalidParameterValueException {
-    return _smithy.isa(o, "InvalidParameterValueException");
+    return __isa(o, "InvalidParameterValueException");
   }
 }
 
@@ -714,7 +717,7 @@ export enum MetricStatistic {
  *             certificate.</p>
  */
 export interface MissingAuthenticationToken
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "MissingAuthenticationToken";
   $fault: "client";
@@ -723,7 +726,7 @@ export interface MissingAuthenticationToken
 
 export namespace MissingAuthenticationToken {
   export function isa(o: any): o is MissingAuthenticationToken {
-    return _smithy.isa(o, "MissingAuthenticationToken");
+    return __isa(o, "MissingAuthenticationToken");
   }
 }
 
@@ -731,7 +734,7 @@ export namespace MissingAuthenticationToken {
  * <p>You must opt in to the service to perform this action.</p>
  */
 export interface OptInRequiredException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "OptInRequiredException";
   $fault: "client";
@@ -740,7 +743,7 @@ export interface OptInRequiredException
 
 export namespace OptInRequiredException {
   export function isa(o: any): o is OptInRequiredException {
-    return _smithy.isa(o, "OptInRequiredException");
+    return __isa(o, "OptInRequiredException");
   }
 }
 
@@ -772,7 +775,7 @@ export interface ProjectedMetric {
 
 export namespace ProjectedMetric {
   export function isa(o: any): o is ProjectedMetric {
-    return _smithy.isa(o, "ProjectedMetric");
+    return __isa(o, "ProjectedMetric");
   }
 }
 
@@ -795,7 +798,7 @@ export interface RecommendationSource {
 
 export namespace RecommendationSource {
   export function isa(o: any): o is RecommendationSource {
-    return _smithy.isa(o, "RecommendationSource");
+    return __isa(o, "RecommendationSource");
   }
 }
 
@@ -827,7 +830,7 @@ export interface RecommendationSummary {
 
 export namespace RecommendationSummary {
   export function isa(o: any): o is RecommendationSummary {
-    return _smithy.isa(o, "RecommendationSummary");
+    return __isa(o, "RecommendationSummary");
   }
 }
 
@@ -858,7 +861,7 @@ export interface RecommendedOptionProjectedMetric {
 
 export namespace RecommendedOptionProjectedMetric {
   export function isa(o: any): o is RecommendedOptionProjectedMetric {
-    return _smithy.isa(o, "RecommendedOptionProjectedMetric");
+    return __isa(o, "RecommendedOptionProjectedMetric");
   }
 }
 
@@ -866,7 +869,7 @@ export namespace RecommendedOptionProjectedMetric {
  * <p>The specified resource was not found.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -875,7 +878,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -883,7 +886,7 @@ export namespace ResourceNotFoundException {
  * <p>The request has failed due to a temporary failure of the server.</p>
  */
 export interface ServiceUnavailableException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ServiceUnavailableException";
   $fault: "server";
@@ -892,7 +895,7 @@ export interface ServiceUnavailableException
 
 export namespace ServiceUnavailableException {
   export function isa(o: any): o is ServiceUnavailableException {
-    return _smithy.isa(o, "ServiceUnavailableException");
+    return __isa(o, "ServiceUnavailableException");
   }
 }
 
@@ -921,7 +924,7 @@ export interface Summary {
 
 export namespace Summary {
   export function isa(o: any): o is Summary {
-    return _smithy.isa(o, "Summary");
+    return __isa(o, "Summary");
   }
 }
 
@@ -929,7 +932,7 @@ export namespace Summary {
  * <p>The limit on the number of requests per second was exceeded.</p>
  */
 export interface ThrottlingException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ThrottlingException";
   $fault: "client";
@@ -938,7 +941,7 @@ export interface ThrottlingException
 
 export namespace ThrottlingException {
   export function isa(o: any): o is ThrottlingException {
-    return _smithy.isa(o, "ThrottlingException");
+    return __isa(o, "ThrottlingException");
   }
 }
 
@@ -960,7 +963,7 @@ export interface UpdateEnrollmentStatusRequest {
 
 export namespace UpdateEnrollmentStatusRequest {
   export function isa(o: any): o is UpdateEnrollmentStatusRequest {
-    return _smithy.isa(o, "UpdateEnrollmentStatusRequest");
+    return __isa(o, "UpdateEnrollmentStatusRequest");
   }
 }
 
@@ -981,7 +984,7 @@ export interface UpdateEnrollmentStatusResponse extends $MetadataBearer {
 
 export namespace UpdateEnrollmentStatusResponse {
   export function isa(o: any): o is UpdateEnrollmentStatusResponse {
-    return _smithy.isa(o, "UpdateEnrollmentStatusResponse");
+    return __isa(o, "UpdateEnrollmentStatusResponse");
   }
 }
 
@@ -1012,6 +1015,6 @@ export interface UtilizationMetric {
 
 export namespace UtilizationMetric {
   export function isa(o: any): o is UtilizationMetric {
-    return _smithy.isa(o, "UtilizationMetric");
+    return __isa(o, "UtilizationMetric");
   }
 }

--- a/clients/client-config-service/models/index.ts
+++ b/clients/client-config-service/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -26,7 +29,7 @@ export interface AccountAggregationSource {
 
 export namespace AccountAggregationSource {
   export function isa(o: any): o is AccountAggregationSource {
-    return _smithy.isa(o, "AccountAggregationSource");
+    return __isa(o, "AccountAggregationSource");
   }
 }
 
@@ -64,7 +67,7 @@ export interface AggregateComplianceByConfigRule {
 
 export namespace AggregateComplianceByConfigRule {
   export function isa(o: any): o is AggregateComplianceByConfigRule {
-    return _smithy.isa(o, "AggregateComplianceByConfigRule");
+    return __isa(o, "AggregateComplianceByConfigRule");
   }
 }
 
@@ -89,7 +92,7 @@ export interface AggregateComplianceCount {
 
 export namespace AggregateComplianceCount {
   export function isa(o: any): o is AggregateComplianceCount {
-    return _smithy.isa(o, "AggregateComplianceCount");
+    return __isa(o, "AggregateComplianceCount");
   }
 }
 
@@ -147,7 +150,7 @@ export interface AggregateEvaluationResult {
 
 export namespace AggregateEvaluationResult {
   export function isa(o: any): o is AggregateEvaluationResult {
-    return _smithy.isa(o, "AggregateEvaluationResult");
+    return __isa(o, "AggregateEvaluationResult");
   }
 }
 
@@ -184,7 +187,7 @@ export interface AggregateResourceIdentifier {
 
 export namespace AggregateResourceIdentifier {
   export function isa(o: any): o is AggregateResourceIdentifier {
-    return _smithy.isa(o, "AggregateResourceIdentifier");
+    return __isa(o, "AggregateResourceIdentifier");
   }
 }
 
@@ -248,7 +251,7 @@ export interface AggregatedSourceStatus {
 
 export namespace AggregatedSourceStatus {
   export function isa(o: any): o is AggregatedSourceStatus {
-    return _smithy.isa(o, "AggregatedSourceStatus");
+    return __isa(o, "AggregatedSourceStatus");
   }
 }
 
@@ -295,7 +298,7 @@ export interface AggregationAuthorization {
 
 export namespace AggregationAuthorization {
   export function isa(o: any): o is AggregationAuthorization {
-    return _smithy.isa(o, "AggregationAuthorization");
+    return __isa(o, "AggregationAuthorization");
   }
 }
 
@@ -380,7 +383,7 @@ export interface BaseConfigurationItem {
 
 export namespace BaseConfigurationItem {
   export function isa(o: any): o is BaseConfigurationItem {
-    return _smithy.isa(o, "BaseConfigurationItem");
+    return __isa(o, "BaseConfigurationItem");
   }
 }
 
@@ -399,7 +402,7 @@ export interface BatchGetAggregateResourceConfigRequest {
 
 export namespace BatchGetAggregateResourceConfigRequest {
   export function isa(o: any): o is BatchGetAggregateResourceConfigRequest {
-    return _smithy.isa(o, "BatchGetAggregateResourceConfigRequest");
+    return __isa(o, "BatchGetAggregateResourceConfigRequest");
   }
 }
 
@@ -419,7 +422,7 @@ export interface BatchGetAggregateResourceConfigResponse
 
 export namespace BatchGetAggregateResourceConfigResponse {
   export function isa(o: any): o is BatchGetAggregateResourceConfigResponse {
-    return _smithy.isa(o, "BatchGetAggregateResourceConfigResponse");
+    return __isa(o, "BatchGetAggregateResourceConfigResponse");
   }
 }
 
@@ -435,7 +438,7 @@ export interface BatchGetResourceConfigRequest {
 
 export namespace BatchGetResourceConfigRequest {
   export function isa(o: any): o is BatchGetResourceConfigRequest {
-    return _smithy.isa(o, "BatchGetResourceConfigRequest");
+    return __isa(o, "BatchGetResourceConfigRequest");
   }
 }
 
@@ -461,7 +464,7 @@ export interface BatchGetResourceConfigResponse extends $MetadataBearer {
 
 export namespace BatchGetResourceConfigResponse {
   export function isa(o: any): o is BatchGetResourceConfigResponse {
-    return _smithy.isa(o, "BatchGetResourceConfigResponse");
+    return __isa(o, "BatchGetResourceConfigResponse");
   }
 }
 
@@ -507,7 +510,7 @@ export interface Compliance {
 
 export namespace Compliance {
   export function isa(o: any): o is Compliance {
-    return _smithy.isa(o, "Compliance");
+    return __isa(o, "Compliance");
   }
 }
 
@@ -532,7 +535,7 @@ export interface ComplianceByConfigRule {
 
 export namespace ComplianceByConfigRule {
   export function isa(o: any): o is ComplianceByConfigRule {
-    return _smithy.isa(o, "ComplianceByConfigRule");
+    return __isa(o, "ComplianceByConfigRule");
   }
 }
 
@@ -564,7 +567,7 @@ export interface ComplianceByResource {
 
 export namespace ComplianceByResource {
   export function isa(o: any): o is ComplianceByResource {
-    return _smithy.isa(o, "ComplianceByResource");
+    return __isa(o, "ComplianceByResource");
   }
 }
 
@@ -589,7 +592,7 @@ export interface ComplianceContributorCount {
 
 export namespace ComplianceContributorCount {
   export function isa(o: any): o is ComplianceContributorCount {
-    return _smithy.isa(o, "ComplianceContributorCount");
+    return __isa(o, "ComplianceContributorCount");
   }
 }
 
@@ -622,7 +625,7 @@ export interface ComplianceSummary {
 
 export namespace ComplianceSummary {
   export function isa(o: any): o is ComplianceSummary {
-    return _smithy.isa(o, "ComplianceSummary");
+    return __isa(o, "ComplianceSummary");
   }
 }
 
@@ -647,7 +650,7 @@ export interface ComplianceSummaryByResourceType {
 
 export namespace ComplianceSummaryByResourceType {
   export function isa(o: any): o is ComplianceSummaryByResourceType {
-    return _smithy.isa(o, "ComplianceSummaryByResourceType");
+    return __isa(o, "ComplianceSummaryByResourceType");
   }
 }
 
@@ -699,7 +702,7 @@ export interface ConfigExportDeliveryInfo {
 
 export namespace ConfigExportDeliveryInfo {
   export function isa(o: any): o is ConfigExportDeliveryInfo {
-    return _smithy.isa(o, "ConfigExportDeliveryInfo");
+    return __isa(o, "ConfigExportDeliveryInfo");
   }
 }
 
@@ -834,7 +837,7 @@ export interface ConfigRule {
 
 export namespace ConfigRule {
   export function isa(o: any): o is ConfigRule {
-    return _smithy.isa(o, "ConfigRule");
+    return __isa(o, "ConfigRule");
   }
 }
 
@@ -874,7 +877,7 @@ export interface ConfigRuleComplianceFilters {
 
 export namespace ConfigRuleComplianceFilters {
   export function isa(o: any): o is ConfigRuleComplianceFilters {
-    return _smithy.isa(o, "ConfigRuleComplianceFilters");
+    return __isa(o, "ConfigRuleComplianceFilters");
   }
 }
 
@@ -897,7 +900,7 @@ export interface ConfigRuleComplianceSummaryFilters {
 
 export namespace ConfigRuleComplianceSummaryFilters {
   export function isa(o: any): o is ConfigRuleComplianceSummaryFilters {
-    return _smithy.isa(o, "ConfigRuleComplianceSummaryFilters");
+    return __isa(o, "ConfigRuleComplianceSummaryFilters");
   }
 }
 
@@ -995,7 +998,7 @@ export interface ConfigRuleEvaluationStatus {
 
 export namespace ConfigRuleEvaluationStatus {
   export function isa(o: any): o is ConfigRuleEvaluationStatus {
-    return _smithy.isa(o, "ConfigRuleEvaluationStatus");
+    return __isa(o, "ConfigRuleEvaluationStatus");
   }
 }
 
@@ -1082,7 +1085,7 @@ export interface ConfigSnapshotDeliveryProperties {
 
 export namespace ConfigSnapshotDeliveryProperties {
   export function isa(o: any): o is ConfigSnapshotDeliveryProperties {
-    return _smithy.isa(o, "ConfigSnapshotDeliveryProperties");
+    return __isa(o, "ConfigSnapshotDeliveryProperties");
   }
 }
 
@@ -1119,7 +1122,7 @@ export interface ConfigStreamDeliveryInfo {
 
 export namespace ConfigStreamDeliveryInfo {
   export function isa(o: any): o is ConfigStreamDeliveryInfo {
-    return _smithy.isa(o, "ConfigStreamDeliveryInfo");
+    return __isa(o, "ConfigStreamDeliveryInfo");
   }
 }
 
@@ -1166,7 +1169,7 @@ export interface ConfigurationAggregator {
 
 export namespace ConfigurationAggregator {
   export function isa(o: any): o is ConfigurationAggregator {
-    return _smithy.isa(o, "ConfigurationAggregator");
+    return __isa(o, "ConfigurationAggregator");
   }
 }
 
@@ -1286,7 +1289,7 @@ export interface ConfigurationItem {
 
 export namespace ConfigurationItem {
   export function isa(o: any): o is ConfigurationItem {
-    return _smithy.isa(o, "ConfigurationItem");
+    return __isa(o, "ConfigurationItem");
   }
 }
 
@@ -1326,7 +1329,7 @@ export interface ConfigurationRecorder {
 
 export namespace ConfigurationRecorder {
   export function isa(o: any): o is ConfigurationRecorder {
-    return _smithy.isa(o, "ConfigurationRecorder");
+    return __isa(o, "ConfigurationRecorder");
   }
 }
 
@@ -1380,7 +1383,7 @@ export interface ConfigurationRecorderStatus {
 
 export namespace ConfigurationRecorderStatus {
   export function isa(o: any): o is ConfigurationRecorderStatus {
-    return _smithy.isa(o, "ConfigurationRecorderStatus");
+    return __isa(o, "ConfigurationRecorderStatus");
   }
 }
 
@@ -1403,7 +1406,7 @@ export interface ConformancePackComplianceFilters {
 
 export namespace ConformancePackComplianceFilters {
   export function isa(o: any): o is ConformancePackComplianceFilters {
-    return _smithy.isa(o, "ConformancePackComplianceFilters");
+    return __isa(o, "ConformancePackComplianceFilters");
   }
 }
 
@@ -1428,7 +1431,7 @@ export interface ConformancePackComplianceSummary {
 
 export namespace ConformancePackComplianceSummary {
   export function isa(o: any): o is ConformancePackComplianceSummary {
-    return _smithy.isa(o, "ConformancePackComplianceSummary");
+    return __isa(o, "ConformancePackComplianceSummary");
   }
 }
 
@@ -1485,7 +1488,7 @@ export interface ConformancePackDetail {
 
 export namespace ConformancePackDetail {
   export function isa(o: any): o is ConformancePackDetail {
-    return _smithy.isa(o, "ConformancePackDetail");
+    return __isa(o, "ConformancePackDetail");
   }
 }
 
@@ -1521,7 +1524,7 @@ export interface ConformancePackEvaluationFilters {
 
 export namespace ConformancePackEvaluationFilters {
   export function isa(o: any): o is ConformancePackEvaluationFilters {
-    return _smithy.isa(o, "ConformancePackEvaluationFilters");
+    return __isa(o, "ConformancePackEvaluationFilters");
   }
 }
 
@@ -1558,7 +1561,7 @@ export interface ConformancePackEvaluationResult {
 
 export namespace ConformancePackEvaluationResult {
   export function isa(o: any): o is ConformancePackEvaluationResult {
-    return _smithy.isa(o, "ConformancePackEvaluationResult");
+    return __isa(o, "ConformancePackEvaluationResult");
   }
 }
 
@@ -1581,7 +1584,7 @@ export interface ConformancePackInputParameter {
 
 export namespace ConformancePackInputParameter {
   export function isa(o: any): o is ConformancePackInputParameter {
-    return _smithy.isa(o, "ConformancePackInputParameter");
+    return __isa(o, "ConformancePackInputParameter");
   }
 }
 
@@ -1604,7 +1607,7 @@ export interface ConformancePackRuleCompliance {
 
 export namespace ConformancePackRuleCompliance {
   export function isa(o: any): o is ConformancePackRuleCompliance {
-    return _smithy.isa(o, "ConformancePackRuleCompliance");
+    return __isa(o, "ConformancePackRuleCompliance");
   }
 }
 
@@ -1682,7 +1685,7 @@ export interface ConformancePackStatusDetail {
 
 export namespace ConformancePackStatusDetail {
   export function isa(o: any): o is ConformancePackStatusDetail {
-    return _smithy.isa(o, "ConformancePackStatusDetail");
+    return __isa(o, "ConformancePackStatusDetail");
   }
 }
 
@@ -1690,7 +1693,7 @@ export namespace ConformancePackStatusDetail {
  * <p>You have specified a template that is not valid or supported.</p>
  */
 export interface ConformancePackTemplateValidationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ConformancePackTemplateValidationException";
   $fault: "client";
@@ -1702,7 +1705,7 @@ export interface ConformancePackTemplateValidationException
 
 export namespace ConformancePackTemplateValidationException {
   export function isa(o: any): o is ConformancePackTemplateValidationException {
-    return _smithy.isa(o, "ConformancePackTemplateValidationException");
+    return __isa(o, "ConformancePackTemplateValidationException");
   }
 }
 
@@ -1722,7 +1725,7 @@ export interface DeleteAggregationAuthorizationRequest {
 
 export namespace DeleteAggregationAuthorizationRequest {
   export function isa(o: any): o is DeleteAggregationAuthorizationRequest {
-    return _smithy.isa(o, "DeleteAggregationAuthorizationRequest");
+    return __isa(o, "DeleteAggregationAuthorizationRequest");
   }
 }
 
@@ -1740,7 +1743,7 @@ export interface DeleteConfigRuleRequest {
 
 export namespace DeleteConfigRuleRequest {
   export function isa(o: any): o is DeleteConfigRuleRequest {
-    return _smithy.isa(o, "DeleteConfigRuleRequest");
+    return __isa(o, "DeleteConfigRuleRequest");
   }
 }
 
@@ -1754,7 +1757,7 @@ export interface DeleteConfigurationAggregatorRequest {
 
 export namespace DeleteConfigurationAggregatorRequest {
   export function isa(o: any): o is DeleteConfigurationAggregatorRequest {
-    return _smithy.isa(o, "DeleteConfigurationAggregatorRequest");
+    return __isa(o, "DeleteConfigurationAggregatorRequest");
   }
 }
 
@@ -1774,7 +1777,7 @@ export interface DeleteConfigurationRecorderRequest {
 
 export namespace DeleteConfigurationRecorderRequest {
   export function isa(o: any): o is DeleteConfigurationRecorderRequest {
-    return _smithy.isa(o, "DeleteConfigurationRecorderRequest");
+    return __isa(o, "DeleteConfigurationRecorderRequest");
   }
 }
 
@@ -1788,7 +1791,7 @@ export interface DeleteConformancePackRequest {
 
 export namespace DeleteConformancePackRequest {
   export function isa(o: any): o is DeleteConformancePackRequest {
-    return _smithy.isa(o, "DeleteConformancePackRequest");
+    return __isa(o, "DeleteConformancePackRequest");
   }
 }
 
@@ -1807,7 +1810,7 @@ export interface DeleteDeliveryChannelRequest {
 
 export namespace DeleteDeliveryChannelRequest {
   export function isa(o: any): o is DeleteDeliveryChannelRequest {
-    return _smithy.isa(o, "DeleteDeliveryChannelRequest");
+    return __isa(o, "DeleteDeliveryChannelRequest");
   }
 }
 
@@ -1825,7 +1828,7 @@ export interface DeleteEvaluationResultsRequest {
 
 export namespace DeleteEvaluationResultsRequest {
   export function isa(o: any): o is DeleteEvaluationResultsRequest {
-    return _smithy.isa(o, "DeleteEvaluationResultsRequest");
+    return __isa(o, "DeleteEvaluationResultsRequest");
   }
 }
 
@@ -1839,7 +1842,7 @@ export interface DeleteEvaluationResultsResponse extends $MetadataBearer {
 
 export namespace DeleteEvaluationResultsResponse {
   export function isa(o: any): o is DeleteEvaluationResultsResponse {
-    return _smithy.isa(o, "DeleteEvaluationResultsResponse");
+    return __isa(o, "DeleteEvaluationResultsResponse");
   }
 }
 
@@ -1853,7 +1856,7 @@ export interface DeleteOrganizationConfigRuleRequest {
 
 export namespace DeleteOrganizationConfigRuleRequest {
   export function isa(o: any): o is DeleteOrganizationConfigRuleRequest {
-    return _smithy.isa(o, "DeleteOrganizationConfigRuleRequest");
+    return __isa(o, "DeleteOrganizationConfigRuleRequest");
   }
 }
 
@@ -1867,7 +1870,7 @@ export interface DeleteOrganizationConformancePackRequest {
 
 export namespace DeleteOrganizationConformancePackRequest {
   export function isa(o: any): o is DeleteOrganizationConformancePackRequest {
-    return _smithy.isa(o, "DeleteOrganizationConformancePackRequest");
+    return __isa(o, "DeleteOrganizationConformancePackRequest");
   }
 }
 
@@ -1887,7 +1890,7 @@ export interface DeletePendingAggregationRequestRequest {
 
 export namespace DeletePendingAggregationRequestRequest {
   export function isa(o: any): o is DeletePendingAggregationRequestRequest {
-    return _smithy.isa(o, "DeletePendingAggregationRequestRequest");
+    return __isa(o, "DeletePendingAggregationRequestRequest");
   }
 }
 
@@ -1906,7 +1909,7 @@ export interface DeleteRemediationConfigurationRequest {
 
 export namespace DeleteRemediationConfigurationRequest {
   export function isa(o: any): o is DeleteRemediationConfigurationRequest {
-    return _smithy.isa(o, "DeleteRemediationConfigurationRequest");
+    return __isa(o, "DeleteRemediationConfigurationRequest");
   }
 }
 
@@ -1917,7 +1920,7 @@ export interface DeleteRemediationConfigurationResponse
 
 export namespace DeleteRemediationConfigurationResponse {
   export function isa(o: any): o is DeleteRemediationConfigurationResponse {
-    return _smithy.isa(o, "DeleteRemediationConfigurationResponse");
+    return __isa(o, "DeleteRemediationConfigurationResponse");
   }
 }
 
@@ -1936,7 +1939,7 @@ export interface DeleteRemediationExceptionsRequest {
 
 export namespace DeleteRemediationExceptionsRequest {
   export function isa(o: any): o is DeleteRemediationExceptionsRequest {
-    return _smithy.isa(o, "DeleteRemediationExceptionsRequest");
+    return __isa(o, "DeleteRemediationExceptionsRequest");
   }
 }
 
@@ -1950,7 +1953,7 @@ export interface DeleteRemediationExceptionsResponse extends $MetadataBearer {
 
 export namespace DeleteRemediationExceptionsResponse {
   export function isa(o: any): o is DeleteRemediationExceptionsResponse {
-    return _smithy.isa(o, "DeleteRemediationExceptionsResponse");
+    return __isa(o, "DeleteRemediationExceptionsResponse");
   }
 }
 
@@ -1969,7 +1972,7 @@ export interface DeleteResourceConfigRequest {
 
 export namespace DeleteResourceConfigRequest {
   export function isa(o: any): o is DeleteResourceConfigRequest {
-    return _smithy.isa(o, "DeleteResourceConfigRequest");
+    return __isa(o, "DeleteResourceConfigRequest");
   }
 }
 
@@ -1983,7 +1986,7 @@ export interface DeleteRetentionConfigurationRequest {
 
 export namespace DeleteRetentionConfigurationRequest {
   export function isa(o: any): o is DeleteRetentionConfigurationRequest {
-    return _smithy.isa(o, "DeleteRetentionConfigurationRequest");
+    return __isa(o, "DeleteRetentionConfigurationRequest");
   }
 }
 
@@ -2002,7 +2005,7 @@ export interface DeliverConfigSnapshotRequest {
 
 export namespace DeliverConfigSnapshotRequest {
   export function isa(o: any): o is DeliverConfigSnapshotRequest {
-    return _smithy.isa(o, "DeliverConfigSnapshotRequest");
+    return __isa(o, "DeliverConfigSnapshotRequest");
   }
 }
 
@@ -2020,7 +2023,7 @@ export interface DeliverConfigSnapshotResponse extends $MetadataBearer {
 
 export namespace DeliverConfigSnapshotResponse {
   export function isa(o: any): o is DeliverConfigSnapshotResponse {
-    return _smithy.isa(o, "DeliverConfigSnapshotResponse");
+    return __isa(o, "DeliverConfigSnapshotResponse");
   }
 }
 
@@ -2075,7 +2078,7 @@ export interface DeliveryChannel {
 
 export namespace DeliveryChannel {
   export function isa(o: any): o is DeliveryChannel {
-    return _smithy.isa(o, "DeliveryChannel");
+    return __isa(o, "DeliveryChannel");
   }
 }
 
@@ -2113,7 +2116,7 @@ export interface DeliveryChannelStatus {
 
 export namespace DeliveryChannelStatus {
   export function isa(o: any): o is DeliveryChannelStatus {
-    return _smithy.isa(o, "DeliveryChannelStatus");
+    return __isa(o, "DeliveryChannelStatus");
   }
 }
 
@@ -2155,7 +2158,7 @@ export namespace DescribeAggregateComplianceByConfigRulesRequest {
   export function isa(
     o: any
   ): o is DescribeAggregateComplianceByConfigRulesRequest {
-    return _smithy.isa(o, "DescribeAggregateComplianceByConfigRulesRequest");
+    return __isa(o, "DescribeAggregateComplianceByConfigRulesRequest");
   }
 }
 
@@ -2179,7 +2182,7 @@ export namespace DescribeAggregateComplianceByConfigRulesResponse {
   export function isa(
     o: any
   ): o is DescribeAggregateComplianceByConfigRulesResponse {
-    return _smithy.isa(o, "DescribeAggregateComplianceByConfigRulesResponse");
+    return __isa(o, "DescribeAggregateComplianceByConfigRulesResponse");
   }
 }
 
@@ -2201,7 +2204,7 @@ export interface DescribeAggregationAuthorizationsRequest {
 
 export namespace DescribeAggregationAuthorizationsRequest {
   export function isa(o: any): o is DescribeAggregationAuthorizationsRequest {
-    return _smithy.isa(o, "DescribeAggregationAuthorizationsRequest");
+    return __isa(o, "DescribeAggregationAuthorizationsRequest");
   }
 }
 
@@ -2223,7 +2226,7 @@ export interface DescribeAggregationAuthorizationsResponse
 
 export namespace DescribeAggregationAuthorizationsResponse {
   export function isa(o: any): o is DescribeAggregationAuthorizationsResponse {
-    return _smithy.isa(o, "DescribeAggregationAuthorizationsResponse");
+    return __isa(o, "DescribeAggregationAuthorizationsResponse");
   }
 }
 
@@ -2254,7 +2257,7 @@ export interface DescribeComplianceByConfigRuleRequest {
 
 export namespace DescribeComplianceByConfigRuleRequest {
   export function isa(o: any): o is DescribeComplianceByConfigRuleRequest {
-    return _smithy.isa(o, "DescribeComplianceByConfigRuleRequest");
+    return __isa(o, "DescribeComplianceByConfigRuleRequest");
   }
 }
 
@@ -2279,7 +2282,7 @@ export interface DescribeComplianceByConfigRuleResponse
 
 export namespace DescribeComplianceByConfigRuleResponse {
   export function isa(o: any): o is DescribeComplianceByConfigRuleResponse {
-    return _smithy.isa(o, "DescribeComplianceByConfigRuleResponse");
+    return __isa(o, "DescribeComplianceByConfigRuleResponse");
   }
 }
 
@@ -2327,7 +2330,7 @@ export interface DescribeComplianceByResourceRequest {
 
 export namespace DescribeComplianceByResourceRequest {
   export function isa(o: any): o is DescribeComplianceByResourceRequest {
-    return _smithy.isa(o, "DescribeComplianceByResourceRequest");
+    return __isa(o, "DescribeComplianceByResourceRequest");
   }
 }
 
@@ -2351,7 +2354,7 @@ export interface DescribeComplianceByResourceResponse extends $MetadataBearer {
 
 export namespace DescribeComplianceByResourceResponse {
   export function isa(o: any): o is DescribeComplianceByResourceResponse {
-    return _smithy.isa(o, "DescribeComplianceByResourceResponse");
+    return __isa(o, "DescribeComplianceByResourceResponse");
   }
 }
 
@@ -2390,7 +2393,7 @@ export interface DescribeConfigRuleEvaluationStatusRequest {
 
 export namespace DescribeConfigRuleEvaluationStatusRequest {
   export function isa(o: any): o is DescribeConfigRuleEvaluationStatusRequest {
-    return _smithy.isa(o, "DescribeConfigRuleEvaluationStatusRequest");
+    return __isa(o, "DescribeConfigRuleEvaluationStatusRequest");
   }
 }
 
@@ -2415,7 +2418,7 @@ export interface DescribeConfigRuleEvaluationStatusResponse
 
 export namespace DescribeConfigRuleEvaluationStatusResponse {
   export function isa(o: any): o is DescribeConfigRuleEvaluationStatusResponse {
-    return _smithy.isa(o, "DescribeConfigRuleEvaluationStatusResponse");
+    return __isa(o, "DescribeConfigRuleEvaluationStatusResponse");
   }
 }
 
@@ -2441,7 +2444,7 @@ export interface DescribeConfigRulesRequest {
 
 export namespace DescribeConfigRulesRequest {
   export function isa(o: any): o is DescribeConfigRulesRequest {
-    return _smithy.isa(o, "DescribeConfigRulesRequest");
+    return __isa(o, "DescribeConfigRulesRequest");
   }
 }
 
@@ -2464,7 +2467,7 @@ export interface DescribeConfigRulesResponse extends $MetadataBearer {
 
 export namespace DescribeConfigRulesResponse {
   export function isa(o: any): o is DescribeConfigRulesResponse {
-    return _smithy.isa(o, "DescribeConfigRulesResponse");
+    return __isa(o, "DescribeConfigRulesResponse");
   }
 }
 
@@ -2512,10 +2515,7 @@ export namespace DescribeConfigurationAggregatorSourcesStatusRequest {
   export function isa(
     o: any
   ): o is DescribeConfigurationAggregatorSourcesStatusRequest {
-    return _smithy.isa(
-      o,
-      "DescribeConfigurationAggregatorSourcesStatusRequest"
-    );
+    return __isa(o, "DescribeConfigurationAggregatorSourcesStatusRequest");
   }
 }
 
@@ -2539,10 +2539,7 @@ export namespace DescribeConfigurationAggregatorSourcesStatusResponse {
   export function isa(
     o: any
   ): o is DescribeConfigurationAggregatorSourcesStatusResponse {
-    return _smithy.isa(
-      o,
-      "DescribeConfigurationAggregatorSourcesStatusResponse"
-    );
+    return __isa(o, "DescribeConfigurationAggregatorSourcesStatusResponse");
   }
 }
 
@@ -2569,7 +2566,7 @@ export interface DescribeConfigurationAggregatorsRequest {
 
 export namespace DescribeConfigurationAggregatorsRequest {
   export function isa(o: any): o is DescribeConfigurationAggregatorsRequest {
-    return _smithy.isa(o, "DescribeConfigurationAggregatorsRequest");
+    return __isa(o, "DescribeConfigurationAggregatorsRequest");
   }
 }
 
@@ -2590,7 +2587,7 @@ export interface DescribeConfigurationAggregatorsResponse
 
 export namespace DescribeConfigurationAggregatorsResponse {
   export function isa(o: any): o is DescribeConfigurationAggregatorsResponse {
-    return _smithy.isa(o, "DescribeConfigurationAggregatorsResponse");
+    return __isa(o, "DescribeConfigurationAggregatorsResponse");
   }
 }
 
@@ -2610,7 +2607,7 @@ export interface DescribeConfigurationRecorderStatusRequest {
 
 export namespace DescribeConfigurationRecorderStatusRequest {
   export function isa(o: any): o is DescribeConfigurationRecorderStatusRequest {
-    return _smithy.isa(o, "DescribeConfigurationRecorderStatusRequest");
+    return __isa(o, "DescribeConfigurationRecorderStatusRequest");
   }
 }
 
@@ -2632,7 +2629,7 @@ export namespace DescribeConfigurationRecorderStatusResponse {
   export function isa(
     o: any
   ): o is DescribeConfigurationRecorderStatusResponse {
-    return _smithy.isa(o, "DescribeConfigurationRecorderStatusResponse");
+    return __isa(o, "DescribeConfigurationRecorderStatusResponse");
   }
 }
 
@@ -2649,7 +2646,7 @@ export interface DescribeConfigurationRecordersRequest {
 
 export namespace DescribeConfigurationRecordersRequest {
   export function isa(o: any): o is DescribeConfigurationRecordersRequest {
-    return _smithy.isa(o, "DescribeConfigurationRecordersRequest");
+    return __isa(o, "DescribeConfigurationRecordersRequest");
   }
 }
 
@@ -2668,7 +2665,7 @@ export interface DescribeConfigurationRecordersResponse
 
 export namespace DescribeConfigurationRecordersResponse {
   export function isa(o: any): o is DescribeConfigurationRecordersResponse {
-    return _smithy.isa(o, "DescribeConfigurationRecordersResponse");
+    return __isa(o, "DescribeConfigurationRecordersResponse");
   }
 }
 
@@ -2697,7 +2694,7 @@ export interface DescribeConformancePackComplianceRequest {
 
 export namespace DescribeConformancePackComplianceRequest {
   export function isa(o: any): o is DescribeConformancePackComplianceRequest {
-    return _smithy.isa(o, "DescribeConformancePackComplianceRequest");
+    return __isa(o, "DescribeConformancePackComplianceRequest");
   }
 }
 
@@ -2724,7 +2721,7 @@ export interface DescribeConformancePackComplianceResponse
 
 export namespace DescribeConformancePackComplianceResponse {
   export function isa(o: any): o is DescribeConformancePackComplianceResponse {
-    return _smithy.isa(o, "DescribeConformancePackComplianceResponse");
+    return __isa(o, "DescribeConformancePackComplianceResponse");
   }
 }
 
@@ -2748,7 +2745,7 @@ export interface DescribeConformancePackStatusRequest {
 
 export namespace DescribeConformancePackStatusRequest {
   export function isa(o: any): o is DescribeConformancePackStatusRequest {
-    return _smithy.isa(o, "DescribeConformancePackStatusRequest");
+    return __isa(o, "DescribeConformancePackStatusRequest");
   }
 }
 
@@ -2767,7 +2764,7 @@ export interface DescribeConformancePackStatusResponse extends $MetadataBearer {
 
 export namespace DescribeConformancePackStatusResponse {
   export function isa(o: any): o is DescribeConformancePackStatusResponse {
-    return _smithy.isa(o, "DescribeConformancePackStatusResponse");
+    return __isa(o, "DescribeConformancePackStatusResponse");
   }
 }
 
@@ -2791,7 +2788,7 @@ export interface DescribeConformancePacksRequest {
 
 export namespace DescribeConformancePacksRequest {
   export function isa(o: any): o is DescribeConformancePacksRequest {
-    return _smithy.isa(o, "DescribeConformancePacksRequest");
+    return __isa(o, "DescribeConformancePacksRequest");
   }
 }
 
@@ -2810,7 +2807,7 @@ export interface DescribeConformancePacksResponse extends $MetadataBearer {
 
 export namespace DescribeConformancePacksResponse {
   export function isa(o: any): o is DescribeConformancePacksResponse {
-    return _smithy.isa(o, "DescribeConformancePacksResponse");
+    return __isa(o, "DescribeConformancePacksResponse");
   }
 }
 
@@ -2828,7 +2825,7 @@ export interface DescribeDeliveryChannelStatusRequest {
 
 export namespace DescribeDeliveryChannelStatusRequest {
   export function isa(o: any): o is DescribeDeliveryChannelStatusRequest {
-    return _smithy.isa(o, "DescribeDeliveryChannelStatusRequest");
+    return __isa(o, "DescribeDeliveryChannelStatusRequest");
   }
 }
 
@@ -2846,7 +2843,7 @@ export interface DescribeDeliveryChannelStatusResponse extends $MetadataBearer {
 
 export namespace DescribeDeliveryChannelStatusResponse {
   export function isa(o: any): o is DescribeDeliveryChannelStatusResponse {
-    return _smithy.isa(o, "DescribeDeliveryChannelStatusResponse");
+    return __isa(o, "DescribeDeliveryChannelStatusResponse");
   }
 }
 
@@ -2864,7 +2861,7 @@ export interface DescribeDeliveryChannelsRequest {
 
 export namespace DescribeDeliveryChannelsRequest {
   export function isa(o: any): o is DescribeDeliveryChannelsRequest {
-    return _smithy.isa(o, "DescribeDeliveryChannelsRequest");
+    return __isa(o, "DescribeDeliveryChannelsRequest");
   }
 }
 
@@ -2883,7 +2880,7 @@ export interface DescribeDeliveryChannelsResponse extends $MetadataBearer {
 
 export namespace DescribeDeliveryChannelsResponse {
   export function isa(o: any): o is DescribeDeliveryChannelsResponse {
-    return _smithy.isa(o, "DescribeDeliveryChannelsResponse");
+    return __isa(o, "DescribeDeliveryChannelsResponse");
   }
 }
 
@@ -2909,7 +2906,7 @@ export namespace DescribeOrganizationConfigRuleStatusesRequest {
   export function isa(
     o: any
   ): o is DescribeOrganizationConfigRuleStatusesRequest {
-    return _smithy.isa(o, "DescribeOrganizationConfigRuleStatusesRequest");
+    return __isa(o, "DescribeOrganizationConfigRuleStatusesRequest");
   }
 }
 
@@ -2931,7 +2928,7 @@ export namespace DescribeOrganizationConfigRuleStatusesResponse {
   export function isa(
     o: any
   ): o is DescribeOrganizationConfigRuleStatusesResponse {
-    return _smithy.isa(o, "DescribeOrganizationConfigRuleStatusesResponse");
+    return __isa(o, "DescribeOrganizationConfigRuleStatusesResponse");
   }
 }
 
@@ -2955,7 +2952,7 @@ export interface DescribeOrganizationConfigRulesRequest {
 
 export namespace DescribeOrganizationConfigRulesRequest {
   export function isa(o: any): o is DescribeOrganizationConfigRulesRequest {
-    return _smithy.isa(o, "DescribeOrganizationConfigRulesRequest");
+    return __isa(o, "DescribeOrganizationConfigRulesRequest");
   }
 }
 
@@ -2975,7 +2972,7 @@ export interface DescribeOrganizationConfigRulesResponse
 
 export namespace DescribeOrganizationConfigRulesResponse {
   export function isa(o: any): o is DescribeOrganizationConfigRulesResponse {
-    return _smithy.isa(o, "DescribeOrganizationConfigRulesResponse");
+    return __isa(o, "DescribeOrganizationConfigRulesResponse");
   }
 }
 
@@ -3003,7 +3000,7 @@ export namespace DescribeOrganizationConformancePackStatusesRequest {
   export function isa(
     o: any
   ): o is DescribeOrganizationConformancePackStatusesRequest {
-    return _smithy.isa(o, "DescribeOrganizationConformancePackStatusesRequest");
+    return __isa(o, "DescribeOrganizationConformancePackStatusesRequest");
   }
 }
 
@@ -3027,10 +3024,7 @@ export namespace DescribeOrganizationConformancePackStatusesResponse {
   export function isa(
     o: any
   ): o is DescribeOrganizationConformancePackStatusesResponse {
-    return _smithy.isa(
-      o,
-      "DescribeOrganizationConformancePackStatusesResponse"
-    );
+    return __isa(o, "DescribeOrganizationConformancePackStatusesResponse");
   }
 }
 
@@ -3058,7 +3052,7 @@ export namespace DescribeOrganizationConformancePacksRequest {
   export function isa(
     o: any
   ): o is DescribeOrganizationConformancePacksRequest {
-    return _smithy.isa(o, "DescribeOrganizationConformancePacksRequest");
+    return __isa(o, "DescribeOrganizationConformancePacksRequest");
   }
 }
 
@@ -3081,7 +3075,7 @@ export namespace DescribeOrganizationConformancePacksResponse {
   export function isa(
     o: any
   ): o is DescribeOrganizationConformancePacksResponse {
-    return _smithy.isa(o, "DescribeOrganizationConformancePacksResponse");
+    return __isa(o, "DescribeOrganizationConformancePacksResponse");
   }
 }
 
@@ -3103,7 +3097,7 @@ export interface DescribePendingAggregationRequestsRequest {
 
 export namespace DescribePendingAggregationRequestsRequest {
   export function isa(o: any): o is DescribePendingAggregationRequestsRequest {
-    return _smithy.isa(o, "DescribePendingAggregationRequestsRequest");
+    return __isa(o, "DescribePendingAggregationRequestsRequest");
   }
 }
 
@@ -3124,7 +3118,7 @@ export interface DescribePendingAggregationRequestsResponse
 
 export namespace DescribePendingAggregationRequestsResponse {
   export function isa(o: any): o is DescribePendingAggregationRequestsResponse {
-    return _smithy.isa(o, "DescribePendingAggregationRequestsResponse");
+    return __isa(o, "DescribePendingAggregationRequestsResponse");
   }
 }
 
@@ -3138,7 +3132,7 @@ export interface DescribeRemediationConfigurationsRequest {
 
 export namespace DescribeRemediationConfigurationsRequest {
   export function isa(o: any): o is DescribeRemediationConfigurationsRequest {
-    return _smithy.isa(o, "DescribeRemediationConfigurationsRequest");
+    return __isa(o, "DescribeRemediationConfigurationsRequest");
   }
 }
 
@@ -3153,7 +3147,7 @@ export interface DescribeRemediationConfigurationsResponse
 
 export namespace DescribeRemediationConfigurationsResponse {
   export function isa(o: any): o is DescribeRemediationConfigurationsResponse {
-    return _smithy.isa(o, "DescribeRemediationConfigurationsResponse");
+    return __isa(o, "DescribeRemediationConfigurationsResponse");
   }
 }
 
@@ -3182,7 +3176,7 @@ export interface DescribeRemediationExceptionsRequest {
 
 export namespace DescribeRemediationExceptionsRequest {
   export function isa(o: any): o is DescribeRemediationExceptionsRequest {
-    return _smithy.isa(o, "DescribeRemediationExceptionsRequest");
+    return __isa(o, "DescribeRemediationExceptionsRequest");
   }
 }
 
@@ -3201,7 +3195,7 @@ export interface DescribeRemediationExceptionsResponse extends $MetadataBearer {
 
 export namespace DescribeRemediationExceptionsResponse {
   export function isa(o: any): o is DescribeRemediationExceptionsResponse {
-    return _smithy.isa(o, "DescribeRemediationExceptionsResponse");
+    return __isa(o, "DescribeRemediationExceptionsResponse");
   }
 }
 
@@ -3230,7 +3224,7 @@ export interface DescribeRemediationExecutionStatusRequest {
 
 export namespace DescribeRemediationExecutionStatusRequest {
   export function isa(o: any): o is DescribeRemediationExecutionStatusRequest {
-    return _smithy.isa(o, "DescribeRemediationExecutionStatusRequest");
+    return __isa(o, "DescribeRemediationExecutionStatusRequest");
   }
 }
 
@@ -3250,7 +3244,7 @@ export interface DescribeRemediationExecutionStatusResponse
 
 export namespace DescribeRemediationExecutionStatusResponse {
   export function isa(o: any): o is DescribeRemediationExecutionStatusResponse {
-    return _smithy.isa(o, "DescribeRemediationExecutionStatusResponse");
+    return __isa(o, "DescribeRemediationExecutionStatusResponse");
   }
 }
 
@@ -3277,7 +3271,7 @@ export interface DescribeRetentionConfigurationsRequest {
 
 export namespace DescribeRetentionConfigurationsRequest {
   export function isa(o: any): o is DescribeRetentionConfigurationsRequest {
-    return _smithy.isa(o, "DescribeRetentionConfigurationsRequest");
+    return __isa(o, "DescribeRetentionConfigurationsRequest");
   }
 }
 
@@ -3299,7 +3293,7 @@ export interface DescribeRetentionConfigurationsResponse
 
 export namespace DescribeRetentionConfigurationsResponse {
   export function isa(o: any): o is DescribeRetentionConfigurationsResponse {
-    return _smithy.isa(o, "DescribeRetentionConfigurationsResponse");
+    return __isa(o, "DescribeRetentionConfigurationsResponse");
   }
 }
 
@@ -3355,7 +3349,7 @@ export interface Evaluation {
 
 export namespace Evaluation {
   export function isa(o: any): o is Evaluation {
-    return _smithy.isa(o, "Evaluation");
+    return __isa(o, "Evaluation");
   }
 }
 
@@ -3410,7 +3404,7 @@ export interface EvaluationResult {
 
 export namespace EvaluationResult {
   export function isa(o: any): o is EvaluationResult {
-    return _smithy.isa(o, "EvaluationResult");
+    return __isa(o, "EvaluationResult");
   }
 }
 
@@ -3437,7 +3431,7 @@ export interface EvaluationResultIdentifier {
 
 export namespace EvaluationResultIdentifier {
   export function isa(o: any): o is EvaluationResultIdentifier {
-    return _smithy.isa(o, "EvaluationResultIdentifier");
+    return __isa(o, "EvaluationResultIdentifier");
   }
 }
 
@@ -3467,7 +3461,7 @@ export interface EvaluationResultQualifier {
 
 export namespace EvaluationResultQualifier {
   export function isa(o: any): o is EvaluationResultQualifier {
-    return _smithy.isa(o, "EvaluationResultQualifier");
+    return __isa(o, "EvaluationResultQualifier");
   }
 }
 
@@ -3488,7 +3482,7 @@ export interface ExecutionControls {
 
 export namespace ExecutionControls {
   export function isa(o: any): o is ExecutionControls {
-    return _smithy.isa(o, "ExecutionControls");
+    return __isa(o, "ExecutionControls");
   }
 }
 
@@ -3510,7 +3504,7 @@ export interface FailedDeleteRemediationExceptionsBatch {
 
 export namespace FailedDeleteRemediationExceptionsBatch {
   export function isa(o: any): o is FailedDeleteRemediationExceptionsBatch {
-    return _smithy.isa(o, "FailedDeleteRemediationExceptionsBatch");
+    return __isa(o, "FailedDeleteRemediationExceptionsBatch");
   }
 }
 
@@ -3532,7 +3526,7 @@ export interface FailedRemediationBatch {
 
 export namespace FailedRemediationBatch {
   export function isa(o: any): o is FailedRemediationBatch {
-    return _smithy.isa(o, "FailedRemediationBatch");
+    return __isa(o, "FailedRemediationBatch");
   }
 }
 
@@ -3554,7 +3548,7 @@ export interface FailedRemediationExceptionBatch {
 
 export namespace FailedRemediationExceptionBatch {
   export function isa(o: any): o is FailedRemediationExceptionBatch {
-    return _smithy.isa(o, "FailedRemediationExceptionBatch");
+    return __isa(o, "FailedRemediationExceptionBatch");
   }
 }
 
@@ -3571,7 +3565,7 @@ export interface FieldInfo {
 
 export namespace FieldInfo {
   export function isa(o: any): o is FieldInfo {
-    return _smithy.isa(o, "FieldInfo");
+    return __isa(o, "FieldInfo");
   }
 }
 
@@ -3629,7 +3623,7 @@ export namespace GetAggregateComplianceDetailsByConfigRuleRequest {
   export function isa(
     o: any
   ): o is GetAggregateComplianceDetailsByConfigRuleRequest {
-    return _smithy.isa(o, "GetAggregateComplianceDetailsByConfigRuleRequest");
+    return __isa(o, "GetAggregateComplianceDetailsByConfigRuleRequest");
   }
 }
 
@@ -3652,7 +3646,7 @@ export namespace GetAggregateComplianceDetailsByConfigRuleResponse {
   export function isa(
     o: any
   ): o is GetAggregateComplianceDetailsByConfigRuleResponse {
-    return _smithy.isa(o, "GetAggregateComplianceDetailsByConfigRuleResponse");
+    return __isa(o, "GetAggregateComplianceDetailsByConfigRuleResponse");
   }
 }
 
@@ -3692,7 +3686,7 @@ export namespace GetAggregateConfigRuleComplianceSummaryRequest {
   export function isa(
     o: any
   ): o is GetAggregateConfigRuleComplianceSummaryRequest {
-    return _smithy.isa(o, "GetAggregateConfigRuleComplianceSummaryRequest");
+    return __isa(o, "GetAggregateConfigRuleComplianceSummaryRequest");
   }
 }
 
@@ -3720,7 +3714,7 @@ export namespace GetAggregateConfigRuleComplianceSummaryResponse {
   export function isa(
     o: any
   ): o is GetAggregateConfigRuleComplianceSummaryResponse {
-    return _smithy.isa(o, "GetAggregateConfigRuleComplianceSummaryResponse");
+    return __isa(o, "GetAggregateConfigRuleComplianceSummaryResponse");
   }
 }
 
@@ -3756,7 +3750,7 @@ export namespace GetAggregateDiscoveredResourceCountsRequest {
   export function isa(
     o: any
   ): o is GetAggregateDiscoveredResourceCountsRequest {
-    return _smithy.isa(o, "GetAggregateDiscoveredResourceCountsRequest");
+    return __isa(o, "GetAggregateDiscoveredResourceCountsRequest");
   }
 }
 
@@ -3788,7 +3782,7 @@ export namespace GetAggregateDiscoveredResourceCountsResponse {
   export function isa(
     o: any
   ): o is GetAggregateDiscoveredResourceCountsResponse {
-    return _smithy.isa(o, "GetAggregateDiscoveredResourceCountsResponse");
+    return __isa(o, "GetAggregateDiscoveredResourceCountsResponse");
   }
 }
 
@@ -3807,7 +3801,7 @@ export interface GetAggregateResourceConfigRequest {
 
 export namespace GetAggregateResourceConfigRequest {
   export function isa(o: any): o is GetAggregateResourceConfigRequest {
-    return _smithy.isa(o, "GetAggregateResourceConfigRequest");
+    return __isa(o, "GetAggregateResourceConfigRequest");
   }
 }
 
@@ -3821,7 +3815,7 @@ export interface GetAggregateResourceConfigResponse extends $MetadataBearer {
 
 export namespace GetAggregateResourceConfigResponse {
   export function isa(o: any): o is GetAggregateResourceConfigResponse {
-    return _smithy.isa(o, "GetAggregateResourceConfigResponse");
+    return __isa(o, "GetAggregateResourceConfigResponse");
   }
 }
 
@@ -3861,7 +3855,7 @@ export interface GetComplianceDetailsByConfigRuleRequest {
 
 export namespace GetComplianceDetailsByConfigRuleRequest {
   export function isa(o: any): o is GetComplianceDetailsByConfigRuleRequest {
-    return _smithy.isa(o, "GetComplianceDetailsByConfigRuleRequest");
+    return __isa(o, "GetComplianceDetailsByConfigRuleRequest");
   }
 }
 
@@ -3886,7 +3880,7 @@ export interface GetComplianceDetailsByConfigRuleResponse
 
 export namespace GetComplianceDetailsByConfigRuleResponse {
   export function isa(o: any): o is GetComplianceDetailsByConfigRuleResponse {
-    return _smithy.isa(o, "GetComplianceDetailsByConfigRuleResponse");
+    return __isa(o, "GetComplianceDetailsByConfigRuleResponse");
   }
 }
 
@@ -3925,7 +3919,7 @@ export interface GetComplianceDetailsByResourceRequest {
 
 export namespace GetComplianceDetailsByResourceRequest {
   export function isa(o: any): o is GetComplianceDetailsByResourceRequest {
-    return _smithy.isa(o, "GetComplianceDetailsByResourceRequest");
+    return __isa(o, "GetComplianceDetailsByResourceRequest");
   }
 }
 
@@ -3950,7 +3944,7 @@ export interface GetComplianceDetailsByResourceResponse
 
 export namespace GetComplianceDetailsByResourceResponse {
   export function isa(o: any): o is GetComplianceDetailsByResourceResponse {
-    return _smithy.isa(o, "GetComplianceDetailsByResourceResponse");
+    return __isa(o, "GetComplianceDetailsByResourceResponse");
   }
 }
 
@@ -3970,7 +3964,7 @@ export interface GetComplianceSummaryByConfigRuleResponse
 
 export namespace GetComplianceSummaryByConfigRuleResponse {
   export function isa(o: any): o is GetComplianceSummaryByConfigRuleResponse {
-    return _smithy.isa(o, "GetComplianceSummaryByConfigRuleResponse");
+    return __isa(o, "GetComplianceSummaryByConfigRuleResponse");
   }
 }
 
@@ -3993,7 +3987,7 @@ export interface GetComplianceSummaryByResourceTypeRequest {
 
 export namespace GetComplianceSummaryByResourceTypeRequest {
   export function isa(o: any): o is GetComplianceSummaryByResourceTypeRequest {
-    return _smithy.isa(o, "GetComplianceSummaryByResourceTypeRequest");
+    return __isa(o, "GetComplianceSummaryByResourceTypeRequest");
   }
 }
 
@@ -4014,7 +4008,7 @@ export interface GetComplianceSummaryByResourceTypeResponse
 
 export namespace GetComplianceSummaryByResourceTypeResponse {
   export function isa(o: any): o is GetComplianceSummaryByResourceTypeResponse {
-    return _smithy.isa(o, "GetComplianceSummaryByResourceTypeResponse");
+    return __isa(o, "GetComplianceSummaryByResourceTypeResponse");
   }
 }
 
@@ -4043,7 +4037,7 @@ export interface GetConformancePackComplianceDetailsRequest {
 
 export namespace GetConformancePackComplianceDetailsRequest {
   export function isa(o: any): o is GetConformancePackComplianceDetailsRequest {
-    return _smithy.isa(o, "GetConformancePackComplianceDetailsRequest");
+    return __isa(o, "GetConformancePackComplianceDetailsRequest");
   }
 }
 
@@ -4070,7 +4064,7 @@ export namespace GetConformancePackComplianceDetailsResponse {
   export function isa(
     o: any
   ): o is GetConformancePackComplianceDetailsResponse {
-    return _smithy.isa(o, "GetConformancePackComplianceDetailsResponse");
+    return __isa(o, "GetConformancePackComplianceDetailsResponse");
   }
 }
 
@@ -4094,7 +4088,7 @@ export interface GetConformancePackComplianceSummaryRequest {
 
 export namespace GetConformancePackComplianceSummaryRequest {
   export function isa(o: any): o is GetConformancePackComplianceSummaryRequest {
-    return _smithy.isa(o, "GetConformancePackComplianceSummaryRequest");
+    return __isa(o, "GetConformancePackComplianceSummaryRequest");
   }
 }
 
@@ -4118,7 +4112,7 @@ export namespace GetConformancePackComplianceSummaryResponse {
   export function isa(
     o: any
   ): o is GetConformancePackComplianceSummaryResponse {
-    return _smithy.isa(o, "GetConformancePackComplianceSummaryResponse");
+    return __isa(o, "GetConformancePackComplianceSummaryResponse");
   }
 }
 
@@ -4161,7 +4155,7 @@ export interface GetDiscoveredResourceCountsRequest {
 
 export namespace GetDiscoveredResourceCountsRequest {
   export function isa(o: any): o is GetDiscoveredResourceCountsRequest {
-    return _smithy.isa(o, "GetDiscoveredResourceCountsRequest");
+    return __isa(o, "GetDiscoveredResourceCountsRequest");
   }
 }
 
@@ -4214,7 +4208,7 @@ export interface GetDiscoveredResourceCountsResponse extends $MetadataBearer {
 
 export namespace GetDiscoveredResourceCountsResponse {
   export function isa(o: any): o is GetDiscoveredResourceCountsResponse {
-    return _smithy.isa(o, "GetDiscoveredResourceCountsResponse");
+    return __isa(o, "GetDiscoveredResourceCountsResponse");
   }
 }
 
@@ -4245,7 +4239,7 @@ export namespace GetOrganizationConfigRuleDetailedStatusRequest {
   export function isa(
     o: any
   ): o is GetOrganizationConfigRuleDetailedStatusRequest {
-    return _smithy.isa(o, "GetOrganizationConfigRuleDetailedStatusRequest");
+    return __isa(o, "GetOrganizationConfigRuleDetailedStatusRequest");
   }
 }
 
@@ -4267,7 +4261,7 @@ export namespace GetOrganizationConfigRuleDetailedStatusResponse {
   export function isa(
     o: any
   ): o is GetOrganizationConfigRuleDetailedStatusResponse {
-    return _smithy.isa(o, "GetOrganizationConfigRuleDetailedStatusResponse");
+    return __isa(o, "GetOrganizationConfigRuleDetailedStatusResponse");
   }
 }
 
@@ -4299,10 +4293,7 @@ export namespace GetOrganizationConformancePackDetailedStatusRequest {
   export function isa(
     o: any
   ): o is GetOrganizationConformancePackDetailedStatusRequest {
-    return _smithy.isa(
-      o,
-      "GetOrganizationConformancePackDetailedStatusRequest"
-    );
+    return __isa(o, "GetOrganizationConformancePackDetailedStatusRequest");
   }
 }
 
@@ -4326,10 +4317,7 @@ export namespace GetOrganizationConformancePackDetailedStatusResponse {
   export function isa(
     o: any
   ): o is GetOrganizationConformancePackDetailedStatusResponse {
-    return _smithy.isa(
-      o,
-      "GetOrganizationConformancePackDetailedStatusResponse"
-    );
+    return __isa(o, "GetOrganizationConformancePackDetailedStatusResponse");
   }
 }
 
@@ -4388,7 +4376,7 @@ export interface GetResourceConfigHistoryRequest {
 
 export namespace GetResourceConfigHistoryRequest {
   export function isa(o: any): o is GetResourceConfigHistoryRequest {
-    return _smithy.isa(o, "GetResourceConfigHistoryRequest");
+    return __isa(o, "GetResourceConfigHistoryRequest");
   }
 }
 
@@ -4413,7 +4401,7 @@ export interface GetResourceConfigHistoryResponse extends $MetadataBearer {
 
 export namespace GetResourceConfigHistoryResponse {
   export function isa(o: any): o is GetResourceConfigHistoryResponse {
-    return _smithy.isa(o, "GetResourceConfigHistoryResponse");
+    return __isa(o, "GetResourceConfigHistoryResponse");
   }
 }
 
@@ -4435,7 +4423,7 @@ export interface GroupedResourceCount {
 
 export namespace GroupedResourceCount {
   export function isa(o: any): o is GroupedResourceCount {
-    return _smithy.isa(o, "GroupedResourceCount");
+    return __isa(o, "GroupedResourceCount");
   }
 }
 
@@ -4444,7 +4432,7 @@ export namespace GroupedResourceCount {
  * 			write to it.</p>
  */
 export interface InsufficientDeliveryPolicyException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InsufficientDeliveryPolicyException";
   $fault: "client";
@@ -4456,7 +4444,7 @@ export interface InsufficientDeliveryPolicyException
 
 export namespace InsufficientDeliveryPolicyException {
   export function isa(o: any): o is InsufficientDeliveryPolicyException {
-    return _smithy.isa(o, "InsufficientDeliveryPolicyException");
+    return __isa(o, "InsufficientDeliveryPolicyException");
   }
 }
 
@@ -4486,7 +4474,7 @@ export namespace InsufficientDeliveryPolicyException {
  *          </ul>
  */
 export interface InsufficientPermissionsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InsufficientPermissionsException";
   $fault: "client";
@@ -4498,7 +4486,7 @@ export interface InsufficientPermissionsException
 
 export namespace InsufficientPermissionsException {
   export function isa(o: any): o is InsufficientPermissionsException {
-    return _smithy.isa(o, "InsufficientPermissionsException");
+    return __isa(o, "InsufficientPermissionsException");
   }
 }
 
@@ -4507,7 +4495,7 @@ export namespace InsufficientPermissionsException {
  * 			valid.</p>
  */
 export interface InvalidConfigurationRecorderNameException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidConfigurationRecorderNameException";
   $fault: "client";
@@ -4519,7 +4507,7 @@ export interface InvalidConfigurationRecorderNameException
 
 export namespace InvalidConfigurationRecorderNameException {
   export function isa(o: any): o is InvalidConfigurationRecorderNameException {
-    return _smithy.isa(o, "InvalidConfigurationRecorderNameException");
+    return __isa(o, "InvalidConfigurationRecorderNameException");
   }
 }
 
@@ -4527,7 +4515,7 @@ export namespace InvalidConfigurationRecorderNameException {
  * <p>The specified delivery channel name is not valid.</p>
  */
 export interface InvalidDeliveryChannelNameException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidDeliveryChannelNameException";
   $fault: "client";
@@ -4539,7 +4527,7 @@ export interface InvalidDeliveryChannelNameException
 
 export namespace InvalidDeliveryChannelNameException {
   export function isa(o: any): o is InvalidDeliveryChannelNameException {
-    return _smithy.isa(o, "InvalidDeliveryChannelNameException");
+    return __isa(o, "InvalidDeliveryChannelNameException");
   }
 }
 
@@ -4547,7 +4535,7 @@ export namespace InvalidDeliveryChannelNameException {
  * <p>The syntax of the query is incorrect.</p>
  */
 export interface InvalidExpressionException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidExpressionException";
   $fault: "client";
@@ -4559,7 +4547,7 @@ export interface InvalidExpressionException
 
 export namespace InvalidExpressionException {
   export function isa(o: any): o is InvalidExpressionException {
-    return _smithy.isa(o, "InvalidExpressionException");
+    return __isa(o, "InvalidExpressionException");
   }
 }
 
@@ -4567,7 +4555,7 @@ export namespace InvalidExpressionException {
  * <p>The specified limit is outside the allowable range.</p>
  */
 export interface InvalidLimitException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidLimitException";
   $fault: "client";
@@ -4579,7 +4567,7 @@ export interface InvalidLimitException
 
 export namespace InvalidLimitException {
   export function isa(o: any): o is InvalidLimitException {
-    return _smithy.isa(o, "InvalidLimitException");
+    return __isa(o, "InvalidLimitException");
   }
 }
 
@@ -4589,7 +4577,7 @@ export namespace InvalidLimitException {
  * 			response to get the next page of results.</p>
  */
 export interface InvalidNextTokenException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidNextTokenException";
   $fault: "client";
@@ -4601,7 +4589,7 @@ export interface InvalidNextTokenException
 
 export namespace InvalidNextTokenException {
   export function isa(o: any): o is InvalidNextTokenException {
-    return _smithy.isa(o, "InvalidNextTokenException");
+    return __isa(o, "InvalidNextTokenException");
   }
 }
 
@@ -4610,7 +4598,7 @@ export namespace InvalidNextTokenException {
  * 			that your parameters are valid and try again.</p>
  */
 export interface InvalidParameterValueException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidParameterValueException";
   $fault: "client";
@@ -4622,7 +4610,7 @@ export interface InvalidParameterValueException
 
 export namespace InvalidParameterValueException {
   export function isa(o: any): o is InvalidParameterValueException {
-    return _smithy.isa(o, "InvalidParameterValueException");
+    return __isa(o, "InvalidParameterValueException");
   }
 }
 
@@ -4630,7 +4618,7 @@ export namespace InvalidParameterValueException {
  * <p>AWS Config throws an exception if the recording group does not contain a valid list of resource types. Invalid values might also be incorrectly formatted.</p>
  */
 export interface InvalidRecordingGroupException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidRecordingGroupException";
   $fault: "client";
@@ -4642,7 +4630,7 @@ export interface InvalidRecordingGroupException
 
 export namespace InvalidRecordingGroupException {
   export function isa(o: any): o is InvalidRecordingGroupException {
-    return _smithy.isa(o, "InvalidRecordingGroupException");
+    return __isa(o, "InvalidRecordingGroupException");
   }
 }
 
@@ -4650,7 +4638,7 @@ export namespace InvalidRecordingGroupException {
  * <p>The specified <code>ResultToken</code> is invalid.</p>
  */
 export interface InvalidResultTokenException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidResultTokenException";
   $fault: "client";
@@ -4662,7 +4650,7 @@ export interface InvalidResultTokenException
 
 export namespace InvalidResultTokenException {
   export function isa(o: any): o is InvalidResultTokenException {
-    return _smithy.isa(o, "InvalidResultTokenException");
+    return __isa(o, "InvalidResultTokenException");
   }
 }
 
@@ -4670,7 +4658,7 @@ export namespace InvalidResultTokenException {
  * <p>You have provided a null or empty role ARN.</p>
  */
 export interface InvalidRoleException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidRoleException";
   $fault: "client";
@@ -4682,7 +4670,7 @@ export interface InvalidRoleException
 
 export namespace InvalidRoleException {
   export function isa(o: any): o is InvalidRoleException {
-    return _smithy.isa(o, "InvalidRoleException");
+    return __isa(o, "InvalidRoleException");
   }
 }
 
@@ -4690,7 +4678,7 @@ export namespace InvalidRoleException {
  * <p>The specified Amazon S3 key prefix is not valid.</p>
  */
 export interface InvalidS3KeyPrefixException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidS3KeyPrefixException";
   $fault: "client";
@@ -4702,7 +4690,7 @@ export interface InvalidS3KeyPrefixException
 
 export namespace InvalidS3KeyPrefixException {
   export function isa(o: any): o is InvalidS3KeyPrefixException {
-    return _smithy.isa(o, "InvalidS3KeyPrefixException");
+    return __isa(o, "InvalidS3KeyPrefixException");
   }
 }
 
@@ -4710,7 +4698,7 @@ export namespace InvalidS3KeyPrefixException {
  * <p>The specified Amazon SNS topic does not exist.</p>
  */
 export interface InvalidSNSTopicARNException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidSNSTopicARNException";
   $fault: "client";
@@ -4722,7 +4710,7 @@ export interface InvalidSNSTopicARNException
 
 export namespace InvalidSNSTopicARNException {
   export function isa(o: any): o is InvalidSNSTopicARNException {
-    return _smithy.isa(o, "InvalidSNSTopicARNException");
+    return __isa(o, "InvalidSNSTopicARNException");
   }
 }
 
@@ -4731,7 +4719,7 @@ export namespace InvalidSNSTopicARNException {
  * 			chronologically before the later time.</p>
  */
 export interface InvalidTimeRangeException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidTimeRangeException";
   $fault: "client";
@@ -4743,7 +4731,7 @@ export interface InvalidTimeRangeException
 
 export namespace InvalidTimeRangeException {
   export function isa(o: any): o is InvalidTimeRangeException {
-    return _smithy.isa(o, "InvalidTimeRangeException");
+    return __isa(o, "InvalidTimeRangeException");
   }
 }
 
@@ -4752,7 +4740,7 @@ export namespace InvalidTimeRangeException {
  * 			the configuration recorder is running.</p>
  */
 export interface LastDeliveryChannelDeleteFailedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LastDeliveryChannelDeleteFailedException";
   $fault: "client";
@@ -4764,7 +4752,7 @@ export interface LastDeliveryChannelDeleteFailedException
 
 export namespace LastDeliveryChannelDeleteFailedException {
   export function isa(o: any): o is LastDeliveryChannelDeleteFailedException {
-    return _smithy.isa(o, "LastDeliveryChannelDeleteFailedException");
+    return __isa(o, "LastDeliveryChannelDeleteFailedException");
   }
 }
 
@@ -4777,7 +4765,7 @@ export namespace LastDeliveryChannelDeleteFailedException {
  * 			limit.</p>
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -4789,7 +4777,7 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
@@ -4823,7 +4811,7 @@ export interface ListAggregateDiscoveredResourcesRequest {
 
 export namespace ListAggregateDiscoveredResourcesRequest {
   export function isa(o: any): o is ListAggregateDiscoveredResourcesRequest {
-    return _smithy.isa(o, "ListAggregateDiscoveredResourcesRequest");
+    return __isa(o, "ListAggregateDiscoveredResourcesRequest");
   }
 }
 
@@ -4843,7 +4831,7 @@ export interface ListAggregateDiscoveredResourcesResponse
 
 export namespace ListAggregateDiscoveredResourcesResponse {
   export function isa(o: any): o is ListAggregateDiscoveredResourcesResponse {
-    return _smithy.isa(o, "ListAggregateDiscoveredResourcesResponse");
+    return __isa(o, "ListAggregateDiscoveredResourcesResponse");
   }
 }
 
@@ -4897,7 +4885,7 @@ export interface ListDiscoveredResourcesRequest {
 
 export namespace ListDiscoveredResourcesRequest {
   export function isa(o: any): o is ListDiscoveredResourcesRequest {
-    return _smithy.isa(o, "ListDiscoveredResourcesRequest");
+    return __isa(o, "ListDiscoveredResourcesRequest");
   }
 }
 
@@ -4922,7 +4910,7 @@ export interface ListDiscoveredResourcesResponse extends $MetadataBearer {
 
 export namespace ListDiscoveredResourcesResponse {
   export function isa(o: any): o is ListDiscoveredResourcesResponse {
-    return _smithy.isa(o, "ListDiscoveredResourcesResponse");
+    return __isa(o, "ListDiscoveredResourcesResponse");
   }
 }
 
@@ -4946,7 +4934,7 @@ export interface ListTagsForResourceRequest {
 
 export namespace ListTagsForResourceRequest {
   export function isa(o: any): o is ListTagsForResourceRequest {
-    return _smithy.isa(o, "ListTagsForResourceRequest");
+    return __isa(o, "ListTagsForResourceRequest");
   }
 }
 
@@ -4965,7 +4953,7 @@ export interface ListTagsForResourceResponse extends $MetadataBearer {
 
 export namespace ListTagsForResourceResponse {
   export function isa(o: any): o is ListTagsForResourceResponse {
-    return _smithy.isa(o, "ListTagsForResourceResponse");
+    return __isa(o, "ListTagsForResourceResponse");
   }
 }
 
@@ -4974,7 +4962,7 @@ export namespace ListTagsForResourceResponse {
  * 			Delete unused resources using <code>DeleteResourceConfig</code>.</p>
  */
 export interface MaxActiveResourcesExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "MaxActiveResourcesExceededException";
   $fault: "client";
@@ -4986,7 +4974,7 @@ export interface MaxActiveResourcesExceededException
 
 export namespace MaxActiveResourcesExceededException {
   export function isa(o: any): o is MaxActiveResourcesExceededException {
-    return _smithy.isa(o, "MaxActiveResourcesExceededException");
+    return __isa(o, "MaxActiveResourcesExceededException");
   }
 }
 
@@ -4996,7 +4984,7 @@ export namespace MaxActiveResourcesExceededException {
  * 			deactivated rules before you add new rules.</p>
  */
 export interface MaxNumberOfConfigRulesExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "MaxNumberOfConfigRulesExceededException";
   $fault: "client";
@@ -5008,7 +4996,7 @@ export interface MaxNumberOfConfigRulesExceededException
 
 export namespace MaxNumberOfConfigRulesExceededException {
   export function isa(o: any): o is MaxNumberOfConfigRulesExceededException {
-    return _smithy.isa(o, "MaxNumberOfConfigRulesExceededException");
+    return __isa(o, "MaxNumberOfConfigRulesExceededException");
   }
 }
 
@@ -5017,7 +5005,7 @@ export namespace MaxNumberOfConfigRulesExceededException {
  * 			create.</p>
  */
 export interface MaxNumberOfConfigurationRecordersExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "MaxNumberOfConfigurationRecordersExceededException";
   $fault: "client";
@@ -5031,7 +5019,7 @@ export namespace MaxNumberOfConfigurationRecordersExceededException {
   export function isa(
     o: any
   ): o is MaxNumberOfConfigurationRecordersExceededException {
-    return _smithy.isa(o, "MaxNumberOfConfigurationRecordersExceededException");
+    return __isa(o, "MaxNumberOfConfigurationRecordersExceededException");
   }
 }
 
@@ -5039,7 +5027,7 @@ export namespace MaxNumberOfConfigurationRecordersExceededException {
  * <p>You have reached the limit (6) of the number of conformance packs in an account (6 conformance pack with 25 AWS Config rules per pack).</p>
  */
 export interface MaxNumberOfConformancePacksExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "MaxNumberOfConformancePacksExceededException";
   $fault: "client";
@@ -5053,7 +5041,7 @@ export namespace MaxNumberOfConformancePacksExceededException {
   export function isa(
     o: any
   ): o is MaxNumberOfConformancePacksExceededException {
-    return _smithy.isa(o, "MaxNumberOfConformancePacksExceededException");
+    return __isa(o, "MaxNumberOfConformancePacksExceededException");
   }
 }
 
@@ -5062,7 +5050,7 @@ export namespace MaxNumberOfConformancePacksExceededException {
  * 			you can create.</p>
  */
 export interface MaxNumberOfDeliveryChannelsExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "MaxNumberOfDeliveryChannelsExceededException";
   $fault: "client";
@@ -5076,7 +5064,7 @@ export namespace MaxNumberOfDeliveryChannelsExceededException {
   export function isa(
     o: any
   ): o is MaxNumberOfDeliveryChannelsExceededException {
-    return _smithy.isa(o, "MaxNumberOfDeliveryChannelsExceededException");
+    return __isa(o, "MaxNumberOfDeliveryChannelsExceededException");
   }
 }
 
@@ -5084,7 +5072,7 @@ export namespace MaxNumberOfDeliveryChannelsExceededException {
  * <p>You have reached the limit of the number of organization config rules you can create.</p>
  */
 export interface MaxNumberOfOrganizationConfigRulesExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "MaxNumberOfOrganizationConfigRulesExceededException";
   $fault: "client";
@@ -5098,10 +5086,7 @@ export namespace MaxNumberOfOrganizationConfigRulesExceededException {
   export function isa(
     o: any
   ): o is MaxNumberOfOrganizationConfigRulesExceededException {
-    return _smithy.isa(
-      o,
-      "MaxNumberOfOrganizationConfigRulesExceededException"
-    );
+    return __isa(o, "MaxNumberOfOrganizationConfigRulesExceededException");
   }
 }
 
@@ -5109,7 +5094,7 @@ export namespace MaxNumberOfOrganizationConfigRulesExceededException {
  * <p>You have reached the limit (6) of the number of organization conformance packs in an account (6 conformance pack with 25 AWS Config rules per pack per account).</p>
  */
 export interface MaxNumberOfOrganizationConformancePacksExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "MaxNumberOfOrganizationConformancePacksExceededException";
   $fault: "client";
@@ -5123,10 +5108,7 @@ export namespace MaxNumberOfOrganizationConformancePacksExceededException {
   export function isa(
     o: any
   ): o is MaxNumberOfOrganizationConformancePacksExceededException {
-    return _smithy.isa(
-      o,
-      "MaxNumberOfOrganizationConformancePacksExceededException"
-    );
+    return __isa(o, "MaxNumberOfOrganizationConformancePacksExceededException");
   }
 }
 
@@ -5134,7 +5116,7 @@ export namespace MaxNumberOfOrganizationConformancePacksExceededException {
  * <p>Failed to add the retention configuration because a retention configuration with that name already exists.</p>
  */
 export interface MaxNumberOfRetentionConfigurationsExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "MaxNumberOfRetentionConfigurationsExceededException";
   $fault: "client";
@@ -5148,10 +5130,7 @@ export namespace MaxNumberOfRetentionConfigurationsExceededException {
   export function isa(
     o: any
   ): o is MaxNumberOfRetentionConfigurationsExceededException {
-    return _smithy.isa(
-      o,
-      "MaxNumberOfRetentionConfigurationsExceededException"
-    );
+    return __isa(o, "MaxNumberOfRetentionConfigurationsExceededException");
   }
 }
 
@@ -5256,7 +5235,7 @@ export interface MemberAccountStatus {
 
 export namespace MemberAccountStatus {
   export function isa(o: any): o is MemberAccountStatus {
-    return _smithy.isa(o, "MemberAccountStatus");
+    return __isa(o, "MemberAccountStatus");
   }
 }
 
@@ -5273,7 +5252,7 @@ export enum MessageType {
  * 			recorder.</p>
  */
 export interface NoAvailableConfigurationRecorderException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "NoAvailableConfigurationRecorderException";
   $fault: "client";
@@ -5285,7 +5264,7 @@ export interface NoAvailableConfigurationRecorderException
 
 export namespace NoAvailableConfigurationRecorderException {
   export function isa(o: any): o is NoAvailableConfigurationRecorderException {
-    return _smithy.isa(o, "NoAvailableConfigurationRecorderException");
+    return __isa(o, "NoAvailableConfigurationRecorderException");
   }
 }
 
@@ -5294,7 +5273,7 @@ export namespace NoAvailableConfigurationRecorderException {
  * 			configurations.</p>
  */
 export interface NoAvailableDeliveryChannelException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "NoAvailableDeliveryChannelException";
   $fault: "client";
@@ -5306,7 +5285,7 @@ export interface NoAvailableDeliveryChannelException
 
 export namespace NoAvailableDeliveryChannelException {
   export function isa(o: any): o is NoAvailableDeliveryChannelException {
-    return _smithy.isa(o, "NoAvailableDeliveryChannelException");
+    return __isa(o, "NoAvailableDeliveryChannelException");
   }
 }
 
@@ -5314,7 +5293,7 @@ export namespace NoAvailableDeliveryChannelException {
  * <p>Organization is no longer available.</p>
  */
 export interface NoAvailableOrganizationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "NoAvailableOrganizationException";
   $fault: "client";
@@ -5326,7 +5305,7 @@ export interface NoAvailableOrganizationException
 
 export namespace NoAvailableOrganizationException {
   export function isa(o: any): o is NoAvailableOrganizationException {
-    return _smithy.isa(o, "NoAvailableOrganizationException");
+    return __isa(o, "NoAvailableOrganizationException");
   }
 }
 
@@ -5334,7 +5313,7 @@ export namespace NoAvailableOrganizationException {
  * <p>There is no configuration recorder running.</p>
  */
 export interface NoRunningConfigurationRecorderException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "NoRunningConfigurationRecorderException";
   $fault: "client";
@@ -5346,7 +5325,7 @@ export interface NoRunningConfigurationRecorderException
 
 export namespace NoRunningConfigurationRecorderException {
   export function isa(o: any): o is NoRunningConfigurationRecorderException {
-    return _smithy.isa(o, "NoRunningConfigurationRecorderException");
+    return __isa(o, "NoRunningConfigurationRecorderException");
   }
 }
 
@@ -5354,7 +5333,7 @@ export namespace NoRunningConfigurationRecorderException {
  * <p>The specified Amazon S3 bucket does not exist.</p>
  */
 export interface NoSuchBucketException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "NoSuchBucketException";
   $fault: "client";
@@ -5366,7 +5345,7 @@ export interface NoSuchBucketException
 
 export namespace NoSuchBucketException {
   export function isa(o: any): o is NoSuchBucketException {
-    return _smithy.isa(o, "NoSuchBucketException");
+    return __isa(o, "NoSuchBucketException");
   }
 }
 
@@ -5375,7 +5354,7 @@ export namespace NoSuchBucketException {
  * 			that the rule names are correct and try again.</p>
  */
 export interface NoSuchConfigRuleException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "NoSuchConfigRuleException";
   $fault: "client";
@@ -5387,7 +5366,7 @@ export interface NoSuchConfigRuleException
 
 export namespace NoSuchConfigRuleException {
   export function isa(o: any): o is NoSuchConfigRuleException {
-    return _smithy.isa(o, "NoSuchConfigRuleException");
+    return __isa(o, "NoSuchConfigRuleException");
   }
 }
 
@@ -5395,7 +5374,7 @@ export namespace NoSuchConfigRuleException {
  * <p>AWS Config rule that you passed in the filter does not exist.</p>
  */
 export interface NoSuchConfigRuleInConformancePackException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "NoSuchConfigRuleInConformancePackException";
   $fault: "client";
@@ -5407,7 +5386,7 @@ export interface NoSuchConfigRuleInConformancePackException
 
 export namespace NoSuchConfigRuleInConformancePackException {
   export function isa(o: any): o is NoSuchConfigRuleInConformancePackException {
-    return _smithy.isa(o, "NoSuchConfigRuleInConformancePackException");
+    return __isa(o, "NoSuchConfigRuleInConformancePackException");
   }
 }
 
@@ -5415,7 +5394,7 @@ export namespace NoSuchConfigRuleInConformancePackException {
  * <p>You have specified a configuration aggregator that does not exist.</p>
  */
 export interface NoSuchConfigurationAggregatorException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "NoSuchConfigurationAggregatorException";
   $fault: "client";
@@ -5427,7 +5406,7 @@ export interface NoSuchConfigurationAggregatorException
 
 export namespace NoSuchConfigurationAggregatorException {
   export function isa(o: any): o is NoSuchConfigurationAggregatorException {
-    return _smithy.isa(o, "NoSuchConfigurationAggregatorException");
+    return __isa(o, "NoSuchConfigurationAggregatorException");
   }
 }
 
@@ -5436,7 +5415,7 @@ export namespace NoSuchConfigurationAggregatorException {
  * 			exist.</p>
  */
 export interface NoSuchConfigurationRecorderException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "NoSuchConfigurationRecorderException";
   $fault: "client";
@@ -5448,7 +5427,7 @@ export interface NoSuchConfigurationRecorderException
 
 export namespace NoSuchConfigurationRecorderException {
   export function isa(o: any): o is NoSuchConfigurationRecorderException {
-    return _smithy.isa(o, "NoSuchConfigurationRecorderException");
+    return __isa(o, "NoSuchConfigurationRecorderException");
   }
 }
 
@@ -5456,7 +5435,7 @@ export namespace NoSuchConfigurationRecorderException {
  * <p>You specified one or more conformance packs that do not exist.</p>
  */
 export interface NoSuchConformancePackException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "NoSuchConformancePackException";
   $fault: "client";
@@ -5468,7 +5447,7 @@ export interface NoSuchConformancePackException
 
 export namespace NoSuchConformancePackException {
   export function isa(o: any): o is NoSuchConformancePackException {
-    return _smithy.isa(o, "NoSuchConformancePackException");
+    return __isa(o, "NoSuchConformancePackException");
   }
 }
 
@@ -5477,7 +5456,7 @@ export namespace NoSuchConformancePackException {
  * 			exist.</p>
  */
 export interface NoSuchDeliveryChannelException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "NoSuchDeliveryChannelException";
   $fault: "client";
@@ -5489,7 +5468,7 @@ export interface NoSuchDeliveryChannelException
 
 export namespace NoSuchDeliveryChannelException {
   export function isa(o: any): o is NoSuchDeliveryChannelException {
-    return _smithy.isa(o, "NoSuchDeliveryChannelException");
+    return __isa(o, "NoSuchDeliveryChannelException");
   }
 }
 
@@ -5497,7 +5476,7 @@ export namespace NoSuchDeliveryChannelException {
  * <p>You specified one or more organization config rules that do not exist.</p>
  */
 export interface NoSuchOrganizationConfigRuleException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "NoSuchOrganizationConfigRuleException";
   $fault: "client";
@@ -5509,7 +5488,7 @@ export interface NoSuchOrganizationConfigRuleException
 
 export namespace NoSuchOrganizationConfigRuleException {
   export function isa(o: any): o is NoSuchOrganizationConfigRuleException {
-    return _smithy.isa(o, "NoSuchOrganizationConfigRuleException");
+    return __isa(o, "NoSuchOrganizationConfigRuleException");
   }
 }
 
@@ -5518,7 +5497,7 @@ export namespace NoSuchOrganizationConfigRuleException {
  * 		       <p>For DeleteOrganizationConformancePack, you tried to delete an organization conformance pack that does not exist.</p>
  */
 export interface NoSuchOrganizationConformancePackException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "NoSuchOrganizationConformancePackException";
   $fault: "client";
@@ -5530,7 +5509,7 @@ export interface NoSuchOrganizationConformancePackException
 
 export namespace NoSuchOrganizationConformancePackException {
   export function isa(o: any): o is NoSuchOrganizationConformancePackException {
-    return _smithy.isa(o, "NoSuchOrganizationConformancePackException");
+    return __isa(o, "NoSuchOrganizationConformancePackException");
   }
 }
 
@@ -5538,7 +5517,7 @@ export namespace NoSuchOrganizationConformancePackException {
  * <p>You specified an AWS Config rule without a remediation configuration.</p>
  */
 export interface NoSuchRemediationConfigurationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "NoSuchRemediationConfigurationException";
   $fault: "client";
@@ -5550,7 +5529,7 @@ export interface NoSuchRemediationConfigurationException
 
 export namespace NoSuchRemediationConfigurationException {
   export function isa(o: any): o is NoSuchRemediationConfigurationException {
-    return _smithy.isa(o, "NoSuchRemediationConfigurationException");
+    return __isa(o, "NoSuchRemediationConfigurationException");
   }
 }
 
@@ -5558,7 +5537,7 @@ export namespace NoSuchRemediationConfigurationException {
  * <p>You tried to delete a remediation exception that does not exist.</p>
  */
 export interface NoSuchRemediationExceptionException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "NoSuchRemediationExceptionException";
   $fault: "client";
@@ -5570,7 +5549,7 @@ export interface NoSuchRemediationExceptionException
 
 export namespace NoSuchRemediationExceptionException {
   export function isa(o: any): o is NoSuchRemediationExceptionException {
-    return _smithy.isa(o, "NoSuchRemediationExceptionException");
+    return __isa(o, "NoSuchRemediationExceptionException");
   }
 }
 
@@ -5578,7 +5557,7 @@ export namespace NoSuchRemediationExceptionException {
  * <p>You have specified a retention configuration that does not exist.</p>
  */
 export interface NoSuchRetentionConfigurationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "NoSuchRetentionConfigurationException";
   $fault: "client";
@@ -5590,7 +5569,7 @@ export interface NoSuchRetentionConfigurationException
 
 export namespace NoSuchRetentionConfigurationException {
   export function isa(o: any): o is NoSuchRetentionConfigurationException {
-    return _smithy.isa(o, "NoSuchRetentionConfigurationException");
+    return __isa(o, "NoSuchRetentionConfigurationException");
   }
 }
 
@@ -5599,7 +5578,7 @@ export namespace NoSuchRetentionConfigurationException {
  * 		       <p>For all OrganizationConfigRule and OrganizationConformancePack APIs, AWS Config throws an exception if APIs are called from member accounts. All APIs must be called from organization master account.</p>
  */
 export interface OrganizationAccessDeniedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "OrganizationAccessDeniedException";
   $fault: "client";
@@ -5611,7 +5590,7 @@ export interface OrganizationAccessDeniedException
 
 export namespace OrganizationAccessDeniedException {
   export function isa(o: any): o is OrganizationAccessDeniedException {
-    return _smithy.isa(o, "OrganizationAccessDeniedException");
+    return __isa(o, "OrganizationAccessDeniedException");
   }
 }
 
@@ -5641,7 +5620,7 @@ export interface OrganizationAggregationSource {
 
 export namespace OrganizationAggregationSource {
   export function isa(o: any): o is OrganizationAggregationSource {
-    return _smithy.isa(o, "OrganizationAggregationSource");
+    return __isa(o, "OrganizationAggregationSource");
   }
 }
 
@@ -5649,7 +5628,7 @@ export namespace OrganizationAggregationSource {
  * <p>AWS Config resource cannot be created because your organization does not have all features enabled.</p>
  */
 export interface OrganizationAllFeaturesNotEnabledException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "OrganizationAllFeaturesNotEnabledException";
   $fault: "client";
@@ -5661,7 +5640,7 @@ export interface OrganizationAllFeaturesNotEnabledException
 
 export namespace OrganizationAllFeaturesNotEnabledException {
   export function isa(o: any): o is OrganizationAllFeaturesNotEnabledException {
-    return _smithy.isa(o, "OrganizationAllFeaturesNotEnabledException");
+    return __isa(o, "OrganizationAllFeaturesNotEnabledException");
   }
 }
 
@@ -5703,7 +5682,7 @@ export interface OrganizationConfigRule {
 
 export namespace OrganizationConfigRule {
   export function isa(o: any): o is OrganizationConfigRule {
-    return _smithy.isa(o, "OrganizationConfigRule");
+    return __isa(o, "OrganizationConfigRule");
   }
 }
 
@@ -5782,7 +5761,7 @@ export interface OrganizationConfigRuleStatus {
 
 export namespace OrganizationConfigRuleStatus {
   export function isa(o: any): o is OrganizationConfigRuleStatus {
-    return _smithy.isa(o, "OrganizationConfigRuleStatus");
+    return __isa(o, "OrganizationConfigRuleStatus");
   }
 }
 
@@ -5836,7 +5815,7 @@ export interface OrganizationConformancePack {
 
 export namespace OrganizationConformancePack {
   export function isa(o: any): o is OrganizationConformancePack {
-    return _smithy.isa(o, "OrganizationConformancePack");
+    return __isa(o, "OrganizationConformancePack");
   }
 }
 
@@ -5925,7 +5904,7 @@ export interface OrganizationConformancePackDetailedStatus {
 
 export namespace OrganizationConformancePackDetailedStatus {
   export function isa(o: any): o is OrganizationConformancePackDetailedStatus {
-    return _smithy.isa(o, "OrganizationConformancePackDetailedStatus");
+    return __isa(o, "OrganizationConformancePackDetailedStatus");
   }
 }
 
@@ -6010,7 +5989,7 @@ export interface OrganizationConformancePackStatus {
 
 export namespace OrganizationConformancePackStatus {
   export function isa(o: any): o is OrganizationConformancePackStatus {
-    return _smithy.isa(o, "OrganizationConformancePackStatus");
+    return __isa(o, "OrganizationConformancePackStatus");
   }
 }
 
@@ -6018,7 +5997,7 @@ export namespace OrganizationConformancePackStatus {
  * <p>You have specified a template that is not valid or supported.</p>
  */
 export interface OrganizationConformancePackTemplateValidationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "OrganizationConformancePackTemplateValidationException";
   $fault: "client";
@@ -6032,10 +6011,7 @@ export namespace OrganizationConformancePackTemplateValidationException {
   export function isa(
     o: any
   ): o is OrganizationConformancePackTemplateValidationException {
-    return _smithy.isa(
-      o,
-      "OrganizationConformancePackTemplateValidationException"
-    );
+    return __isa(o, "OrganizationConformancePackTemplateValidationException");
   }
 }
 
@@ -6119,7 +6095,7 @@ export interface OrganizationCustomRuleMetadata {
 
 export namespace OrganizationCustomRuleMetadata {
   export function isa(o: any): o is OrganizationCustomRuleMetadata {
-    return _smithy.isa(o, "OrganizationCustomRuleMetadata");
+    return __isa(o, "OrganizationCustomRuleMetadata");
   }
 }
 
@@ -6180,7 +6156,7 @@ export interface OrganizationManagedRuleMetadata {
 
 export namespace OrganizationManagedRuleMetadata {
   export function isa(o: any): o is OrganizationManagedRuleMetadata {
-    return _smithy.isa(o, "OrganizationManagedRuleMetadata");
+    return __isa(o, "OrganizationManagedRuleMetadata");
   }
 }
 
@@ -6257,7 +6233,7 @@ export interface OrganizationResourceDetailedStatusFilters {
 
 export namespace OrganizationResourceDetailedStatusFilters {
   export function isa(o: any): o is OrganizationResourceDetailedStatusFilters {
-    return _smithy.isa(o, "OrganizationResourceDetailedStatusFilters");
+    return __isa(o, "OrganizationResourceDetailedStatusFilters");
   }
 }
 
@@ -6289,7 +6265,7 @@ export enum OrganizationRuleStatus {
  * <p>The configuration item size is outside the allowable range.</p>
  */
 export interface OversizedConfigurationItemException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "OversizedConfigurationItemException";
   $fault: "client";
@@ -6301,7 +6277,7 @@ export interface OversizedConfigurationItemException
 
 export namespace OversizedConfigurationItemException {
   export function isa(o: any): o is OversizedConfigurationItemException {
-    return _smithy.isa(o, "OversizedConfigurationItemException");
+    return __isa(o, "OversizedConfigurationItemException");
   }
 }
 
@@ -6331,7 +6307,7 @@ export interface PendingAggregationRequest {
 
 export namespace PendingAggregationRequest {
   export function isa(o: any): o is PendingAggregationRequest {
-    return _smithy.isa(o, "PendingAggregationRequest");
+    return __isa(o, "PendingAggregationRequest");
   }
 }
 
@@ -6355,7 +6331,7 @@ export interface PutAggregationAuthorizationRequest {
 
 export namespace PutAggregationAuthorizationRequest {
   export function isa(o: any): o is PutAggregationAuthorizationRequest {
-    return _smithy.isa(o, "PutAggregationAuthorizationRequest");
+    return __isa(o, "PutAggregationAuthorizationRequest");
   }
 }
 
@@ -6371,7 +6347,7 @@ export interface PutAggregationAuthorizationResponse extends $MetadataBearer {
 
 export namespace PutAggregationAuthorizationResponse {
   export function isa(o: any): o is PutAggregationAuthorizationResponse {
-    return _smithy.isa(o, "PutAggregationAuthorizationResponse");
+    return __isa(o, "PutAggregationAuthorizationResponse");
   }
 }
 
@@ -6390,7 +6366,7 @@ export interface PutConfigRuleRequest {
 
 export namespace PutConfigRuleRequest {
   export function isa(o: any): o is PutConfigRuleRequest {
-    return _smithy.isa(o, "PutConfigRuleRequest");
+    return __isa(o, "PutConfigRuleRequest");
   }
 }
 
@@ -6421,7 +6397,7 @@ export interface PutConfigurationAggregatorRequest {
 
 export namespace PutConfigurationAggregatorRequest {
   export function isa(o: any): o is PutConfigurationAggregatorRequest {
-    return _smithy.isa(o, "PutConfigurationAggregatorRequest");
+    return __isa(o, "PutConfigurationAggregatorRequest");
   }
 }
 
@@ -6435,7 +6411,7 @@ export interface PutConfigurationAggregatorResponse extends $MetadataBearer {
 
 export namespace PutConfigurationAggregatorResponse {
   export function isa(o: any): o is PutConfigurationAggregatorResponse {
-    return _smithy.isa(o, "PutConfigurationAggregatorResponse");
+    return __isa(o, "PutConfigurationAggregatorResponse");
   }
 }
 
@@ -6454,7 +6430,7 @@ export interface PutConfigurationRecorderRequest {
 
 export namespace PutConfigurationRecorderRequest {
   export function isa(o: any): o is PutConfigurationRecorderRequest {
-    return _smithy.isa(o, "PutConfigurationRecorderRequest");
+    return __isa(o, "PutConfigurationRecorderRequest");
   }
 }
 
@@ -6499,7 +6475,7 @@ export interface PutConformancePackRequest {
 
 export namespace PutConformancePackRequest {
   export function isa(o: any): o is PutConformancePackRequest {
-    return _smithy.isa(o, "PutConformancePackRequest");
+    return __isa(o, "PutConformancePackRequest");
   }
 }
 
@@ -6513,7 +6489,7 @@ export interface PutConformancePackResponse extends $MetadataBearer {
 
 export namespace PutConformancePackResponse {
   export function isa(o: any): o is PutConformancePackResponse {
-    return _smithy.isa(o, "PutConformancePackResponse");
+    return __isa(o, "PutConformancePackResponse");
   }
 }
 
@@ -6533,7 +6509,7 @@ export interface PutDeliveryChannelRequest {
 
 export namespace PutDeliveryChannelRequest {
   export function isa(o: any): o is PutDeliveryChannelRequest {
-    return _smithy.isa(o, "PutDeliveryChannelRequest");
+    return __isa(o, "PutDeliveryChannelRequest");
   }
 }
 
@@ -6576,7 +6552,7 @@ export interface PutEvaluationsRequest {
 
 export namespace PutEvaluationsRequest {
   export function isa(o: any): o is PutEvaluationsRequest {
-    return _smithy.isa(o, "PutEvaluationsRequest");
+    return __isa(o, "PutEvaluationsRequest");
   }
 }
 
@@ -6594,7 +6570,7 @@ export interface PutEvaluationsResponse extends $MetadataBearer {
 
 export namespace PutEvaluationsResponse {
   export function isa(o: any): o is PutEvaluationsResponse {
-    return _smithy.isa(o, "PutEvaluationsResponse");
+    return __isa(o, "PutEvaluationsResponse");
   }
 }
 
@@ -6623,7 +6599,7 @@ export interface PutOrganizationConfigRuleRequest {
 
 export namespace PutOrganizationConfigRuleRequest {
   export function isa(o: any): o is PutOrganizationConfigRuleRequest {
-    return _smithy.isa(o, "PutOrganizationConfigRuleRequest");
+    return __isa(o, "PutOrganizationConfigRuleRequest");
   }
 }
 
@@ -6637,7 +6613,7 @@ export interface PutOrganizationConfigRuleResponse extends $MetadataBearer {
 
 export namespace PutOrganizationConfigRuleResponse {
   export function isa(o: any): o is PutOrganizationConfigRuleResponse {
-    return _smithy.isa(o, "PutOrganizationConfigRuleResponse");
+    return __isa(o, "PutOrganizationConfigRuleResponse");
   }
 }
 
@@ -6689,7 +6665,7 @@ export interface PutOrganizationConformancePackRequest {
 
 export namespace PutOrganizationConformancePackRequest {
   export function isa(o: any): o is PutOrganizationConformancePackRequest {
-    return _smithy.isa(o, "PutOrganizationConformancePackRequest");
+    return __isa(o, "PutOrganizationConformancePackRequest");
   }
 }
 
@@ -6704,7 +6680,7 @@ export interface PutOrganizationConformancePackResponse
 
 export namespace PutOrganizationConformancePackResponse {
   export function isa(o: any): o is PutOrganizationConformancePackResponse {
-    return _smithy.isa(o, "PutOrganizationConformancePackResponse");
+    return __isa(o, "PutOrganizationConformancePackResponse");
   }
 }
 
@@ -6718,7 +6694,7 @@ export interface PutRemediationConfigurationsRequest {
 
 export namespace PutRemediationConfigurationsRequest {
   export function isa(o: any): o is PutRemediationConfigurationsRequest {
-    return _smithy.isa(o, "PutRemediationConfigurationsRequest");
+    return __isa(o, "PutRemediationConfigurationsRequest");
   }
 }
 
@@ -6732,7 +6708,7 @@ export interface PutRemediationConfigurationsResponse extends $MetadataBearer {
 
 export namespace PutRemediationConfigurationsResponse {
   export function isa(o: any): o is PutRemediationConfigurationsResponse {
-    return _smithy.isa(o, "PutRemediationConfigurationsResponse");
+    return __isa(o, "PutRemediationConfigurationsResponse");
   }
 }
 
@@ -6761,7 +6737,7 @@ export interface PutRemediationExceptionsRequest {
 
 export namespace PutRemediationExceptionsRequest {
   export function isa(o: any): o is PutRemediationExceptionsRequest {
-    return _smithy.isa(o, "PutRemediationExceptionsRequest");
+    return __isa(o, "PutRemediationExceptionsRequest");
   }
 }
 
@@ -6775,7 +6751,7 @@ export interface PutRemediationExceptionsResponse extends $MetadataBearer {
 
 export namespace PutRemediationExceptionsResponse {
   export function isa(o: any): o is PutRemediationExceptionsResponse {
-    return _smithy.isa(o, "PutRemediationExceptionsResponse");
+    return __isa(o, "PutRemediationExceptionsResponse");
   }
 }
 
@@ -6820,7 +6796,7 @@ export interface PutResourceConfigRequest {
 
 export namespace PutResourceConfigRequest {
   export function isa(o: any): o is PutResourceConfigRequest {
-    return _smithy.isa(o, "PutResourceConfigRequest");
+    return __isa(o, "PutResourceConfigRequest");
   }
 }
 
@@ -6839,7 +6815,7 @@ export interface PutRetentionConfigurationRequest {
 
 export namespace PutRetentionConfigurationRequest {
   export function isa(o: any): o is PutRetentionConfigurationRequest {
-    return _smithy.isa(o, "PutRetentionConfigurationRequest");
+    return __isa(o, "PutRetentionConfigurationRequest");
   }
 }
 
@@ -6853,7 +6829,7 @@ export interface PutRetentionConfigurationResponse extends $MetadataBearer {
 
 export namespace PutRetentionConfigurationResponse {
   export function isa(o: any): o is PutRetentionConfigurationResponse {
-    return _smithy.isa(o, "PutRetentionConfigurationResponse");
+    return __isa(o, "PutRetentionConfigurationResponse");
   }
 }
 
@@ -6870,7 +6846,7 @@ export interface QueryInfo {
 
 export namespace QueryInfo {
   export function isa(o: any): o is QueryInfo {
-    return _smithy.isa(o, "QueryInfo");
+    return __isa(o, "QueryInfo");
   }
 }
 
@@ -6963,7 +6939,7 @@ export interface RecordingGroup {
 
 export namespace RecordingGroup {
   export function isa(o: any): o is RecordingGroup {
-    return _smithy.isa(o, "RecordingGroup");
+    return __isa(o, "RecordingGroup");
   }
 }
 
@@ -6998,7 +6974,7 @@ export interface Relationship {
 
 export namespace Relationship {
   export function isa(o: any): o is Relationship {
-    return _smithy.isa(o, "Relationship");
+    return __isa(o, "Relationship");
   }
 }
 
@@ -7072,7 +7048,7 @@ export interface RemediationConfiguration {
 
 export namespace RemediationConfiguration {
   export function isa(o: any): o is RemediationConfiguration {
-    return _smithy.isa(o, "RemediationConfiguration");
+    return __isa(o, "RemediationConfiguration");
   }
 }
 
@@ -7109,7 +7085,7 @@ export interface RemediationException {
 
 export namespace RemediationException {
   export function isa(o: any): o is RemediationException {
-    return _smithy.isa(o, "RemediationException");
+    return __isa(o, "RemediationException");
   }
 }
 
@@ -7131,7 +7107,7 @@ export interface RemediationExceptionResourceKey {
 
 export namespace RemediationExceptionResourceKey {
   export function isa(o: any): o is RemediationExceptionResourceKey {
-    return _smithy.isa(o, "RemediationExceptionResourceKey");
+    return __isa(o, "RemediationExceptionResourceKey");
   }
 }
 
@@ -7176,7 +7152,7 @@ export interface RemediationExecutionStatus {
 
 export namespace RemediationExecutionStatus {
   export function isa(o: any): o is RemediationExecutionStatus {
-    return _smithy.isa(o, "RemediationExecutionStatus");
+    return __isa(o, "RemediationExecutionStatus");
   }
 }
 
@@ -7213,7 +7189,7 @@ export interface RemediationExecutionStep {
 
 export namespace RemediationExecutionStep {
   export function isa(o: any): o is RemediationExecutionStep {
-    return _smithy.isa(o, "RemediationExecutionStep");
+    return __isa(o, "RemediationExecutionStep");
   }
 }
 
@@ -7227,7 +7203,7 @@ export enum RemediationExecutionStepState {
  * <p>Remediation action is in progress. You can either cancel execution in AWS Systems Manager or wait and try again later. </p>
  */
 export interface RemediationInProgressException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "RemediationInProgressException";
   $fault: "client";
@@ -7239,7 +7215,7 @@ export interface RemediationInProgressException
 
 export namespace RemediationInProgressException {
   export function isa(o: any): o is RemediationInProgressException {
-    return _smithy.isa(o, "RemediationInProgressException");
+    return __isa(o, "RemediationInProgressException");
   }
 }
 
@@ -7261,7 +7237,7 @@ export interface RemediationParameterValue {
 
 export namespace RemediationParameterValue {
   export function isa(o: any): o is RemediationParameterValue {
-    return _smithy.isa(o, "RemediationParameterValue");
+    return __isa(o, "RemediationParameterValue");
   }
 }
 
@@ -7289,7 +7265,7 @@ export interface ResourceCount {
 
 export namespace ResourceCount {
   export function isa(o: any): o is ResourceCount {
-    return _smithy.isa(o, "ResourceCount");
+    return __isa(o, "ResourceCount");
   }
 }
 
@@ -7316,7 +7292,7 @@ export interface ResourceCountFilters {
 
 export namespace ResourceCountFilters {
   export function isa(o: any): o is ResourceCountFilters {
-    return _smithy.isa(o, "ResourceCountFilters");
+    return __isa(o, "ResourceCountFilters");
   }
 }
 
@@ -7354,7 +7330,7 @@ export interface ResourceFilters {
 
 export namespace ResourceFilters {
   export function isa(o: any): o is ResourceFilters {
-    return _smithy.isa(o, "ResourceFilters");
+    return __isa(o, "ResourceFilters");
   }
 }
 
@@ -7389,7 +7365,7 @@ export interface ResourceIdentifier {
 
 export namespace ResourceIdentifier {
   export function isa(o: any): o is ResourceIdentifier {
-    return _smithy.isa(o, "ResourceIdentifier");
+    return __isa(o, "ResourceIdentifier");
   }
 }
 
@@ -7420,7 +7396,7 @@ export namespace ResourceIdentifier {
  *          </ul>
  */
 export interface ResourceInUseException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceInUseException";
   $fault: "client";
@@ -7432,7 +7408,7 @@ export interface ResourceInUseException
 
 export namespace ResourceInUseException {
   export function isa(o: any): o is ResourceInUseException {
-    return _smithy.isa(o, "ResourceInUseException");
+    return __isa(o, "ResourceInUseException");
   }
 }
 
@@ -7455,7 +7431,7 @@ export interface ResourceKey {
 
 export namespace ResourceKey {
   export function isa(o: any): o is ResourceKey {
-    return _smithy.isa(o, "ResourceKey");
+    return __isa(o, "ResourceKey");
   }
 }
 
@@ -7464,7 +7440,7 @@ export namespace ResourceKey {
  * 			been discovered.</p>
  */
 export interface ResourceNotDiscoveredException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotDiscoveredException";
   $fault: "client";
@@ -7476,7 +7452,7 @@ export interface ResourceNotDiscoveredException
 
 export namespace ResourceNotDiscoveredException {
   export function isa(o: any): o is ResourceNotDiscoveredException {
-    return _smithy.isa(o, "ResourceNotDiscoveredException");
+    return __isa(o, "ResourceNotDiscoveredException");
   }
 }
 
@@ -7484,7 +7460,7 @@ export namespace ResourceNotDiscoveredException {
  * <p>You have specified a resource that does not exist.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -7496,7 +7472,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -7606,7 +7582,7 @@ export interface ResourceValue {
 
 export namespace ResourceValue {
   export function isa(o: any): o is ResourceValue {
-    return _smithy.isa(o, "ResourceValue");
+    return __isa(o, "ResourceValue");
   }
 }
 
@@ -7635,7 +7611,7 @@ export interface RetentionConfiguration {
 
 export namespace RetentionConfiguration {
   export function isa(o: any): o is RetentionConfiguration {
-    return _smithy.isa(o, "RetentionConfiguration");
+    return __isa(o, "RetentionConfiguration");
   }
 }
 
@@ -7683,7 +7659,7 @@ export interface Scope {
 
 export namespace Scope {
   export function isa(o: any): o is Scope {
-    return _smithy.isa(o, "Scope");
+    return __isa(o, "Scope");
   }
 }
 
@@ -7707,7 +7683,7 @@ export interface SelectResourceConfigRequest {
 
 export namespace SelectResourceConfigRequest {
   export function isa(o: any): o is SelectResourceConfigRequest {
-    return _smithy.isa(o, "SelectResourceConfigRequest");
+    return __isa(o, "SelectResourceConfigRequest");
   }
 }
 
@@ -7731,7 +7707,7 @@ export interface SelectResourceConfigResponse extends $MetadataBearer {
 
 export namespace SelectResourceConfigResponse {
   export function isa(o: any): o is SelectResourceConfigResponse {
-    return _smithy.isa(o, "SelectResourceConfigResponse");
+    return __isa(o, "SelectResourceConfigResponse");
   }
 }
 
@@ -7767,7 +7743,7 @@ export interface Source {
 
 export namespace Source {
   export function isa(o: any): o is Source {
-    return _smithy.isa(o, "Source");
+    return __isa(o, "Source");
   }
 }
 
@@ -7858,7 +7834,7 @@ export interface SourceDetail {
 
 export namespace SourceDetail {
   export function isa(o: any): o is SourceDetail {
-    return _smithy.isa(o, "SourceDetail");
+    return __isa(o, "SourceDetail");
   }
 }
 
@@ -7882,7 +7858,7 @@ export interface SsmControls {
 
 export namespace SsmControls {
   export function isa(o: any): o is SsmControls {
-    return _smithy.isa(o, "SsmControls");
+    return __isa(o, "SsmControls");
   }
 }
 
@@ -7900,7 +7876,7 @@ export interface StartConfigRulesEvaluationRequest {
 
 export namespace StartConfigRulesEvaluationRequest {
   export function isa(o: any): o is StartConfigRulesEvaluationRequest {
-    return _smithy.isa(o, "StartConfigRulesEvaluationRequest");
+    return __isa(o, "StartConfigRulesEvaluationRequest");
   }
 }
 
@@ -7914,7 +7890,7 @@ export interface StartConfigRulesEvaluationResponse extends $MetadataBearer {
 
 export namespace StartConfigRulesEvaluationResponse {
   export function isa(o: any): o is StartConfigRulesEvaluationResponse {
-    return _smithy.isa(o, "StartConfigRulesEvaluationResponse");
+    return __isa(o, "StartConfigRulesEvaluationResponse");
   }
 }
 
@@ -7933,7 +7909,7 @@ export interface StartConfigurationRecorderRequest {
 
 export namespace StartConfigurationRecorderRequest {
   export function isa(o: any): o is StartConfigurationRecorderRequest {
-    return _smithy.isa(o, "StartConfigurationRecorderRequest");
+    return __isa(o, "StartConfigurationRecorderRequest");
   }
 }
 
@@ -7952,7 +7928,7 @@ export interface StartRemediationExecutionRequest {
 
 export namespace StartRemediationExecutionRequest {
   export function isa(o: any): o is StartRemediationExecutionRequest {
-    return _smithy.isa(o, "StartRemediationExecutionRequest");
+    return __isa(o, "StartRemediationExecutionRequest");
   }
 }
 
@@ -7971,7 +7947,7 @@ export interface StartRemediationExecutionResponse extends $MetadataBearer {
 
 export namespace StartRemediationExecutionResponse {
   export function isa(o: any): o is StartRemediationExecutionResponse {
-    return _smithy.isa(o, "StartRemediationExecutionResponse");
+    return __isa(o, "StartRemediationExecutionResponse");
   }
 }
 
@@ -7988,7 +7964,7 @@ export interface StaticValue {
 
 export namespace StaticValue {
   export function isa(o: any): o is StaticValue {
-    return _smithy.isa(o, "StaticValue");
+    return __isa(o, "StaticValue");
   }
 }
 
@@ -8053,7 +8029,7 @@ export interface StatusDetailFilters {
 
 export namespace StatusDetailFilters {
   export function isa(o: any): o is StatusDetailFilters {
-    return _smithy.isa(o, "StatusDetailFilters");
+    return __isa(o, "StatusDetailFilters");
   }
 }
 
@@ -8070,7 +8046,7 @@ export interface StopConfigurationRecorderRequest {
 
 export namespace StopConfigurationRecorderRequest {
   export function isa(o: any): o is StopConfigurationRecorderRequest {
-    return _smithy.isa(o, "StopConfigurationRecorderRequest");
+    return __isa(o, "StopConfigurationRecorderRequest");
   }
 }
 
@@ -8094,7 +8070,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -8113,7 +8089,7 @@ export interface TagResourceRequest {
 
 export namespace TagResourceRequest {
   export function isa(o: any): o is TagResourceRequest {
-    return _smithy.isa(o, "TagResourceRequest");
+    return __isa(o, "TagResourceRequest");
   }
 }
 
@@ -8121,7 +8097,7 @@ export namespace TagResourceRequest {
  * <p>You have reached the limit of the number of tags you can use. You have more than 50 tags.</p>
  */
 export interface TooManyTagsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyTagsException";
   $fault: "client";
@@ -8133,7 +8109,7 @@ export interface TooManyTagsException
 
 export namespace TooManyTagsException {
   export function isa(o: any): o is TooManyTagsException {
-    return _smithy.isa(o, "TooManyTagsException");
+    return __isa(o, "TooManyTagsException");
   }
 }
 
@@ -8152,7 +8128,7 @@ export interface UntagResourceRequest {
 
 export namespace UntagResourceRequest {
   export function isa(o: any): o is UntagResourceRequest {
-    return _smithy.isa(o, "UntagResourceRequest");
+    return __isa(o, "UntagResourceRequest");
   }
 }
 
@@ -8160,7 +8136,7 @@ export namespace UntagResourceRequest {
  * <p>The requested action is not valid.</p>
  */
 export interface ValidationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ValidationException";
   $fault: "client";
@@ -8172,6 +8148,6 @@ export interface ValidationException
 
 export namespace ValidationException {
   export function isa(o: any): o is ValidationException {
-    return _smithy.isa(o, "ValidationException");
+    return __isa(o, "ValidationException");
   }
 }

--- a/clients/client-config-service/protocols/Aws_json1_1.ts
+++ b/clients/client-config-service/protocols/Aws_json1_1.ts
@@ -1915,6 +1915,7 @@ export async function deserializeAws_json1_1DeleteAggregationAuthorizationComman
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteAggregationAuthorizationCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1966,6 +1967,7 @@ export async function deserializeAws_json1_1DeleteConfigRuleCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1DeleteConfigRuleCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteConfigRuleCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2027,6 +2029,7 @@ export async function deserializeAws_json1_1DeleteConfigurationAggregatorCommand
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteConfigurationAggregatorCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2081,6 +2084,7 @@ export async function deserializeAws_json1_1DeleteConfigurationRecorderCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteConfigurationRecorderCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2135,6 +2139,7 @@ export async function deserializeAws_json1_1DeleteConformancePackCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteConformancePackCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2196,6 +2201,7 @@ export async function deserializeAws_json1_1DeleteDeliveryChannelCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteDeliveryChannelCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2326,6 +2332,7 @@ export async function deserializeAws_json1_1DeleteOrganizationConfigRuleCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteOrganizationConfigRuleCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2394,6 +2401,7 @@ export async function deserializeAws_json1_1DeleteOrganizationConformancePackCom
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteOrganizationConformancePackCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2462,6 +2470,7 @@ export async function deserializeAws_json1_1DeletePendingAggregationRequestComma
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeletePendingAggregationRequestCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2647,6 +2656,7 @@ export async function deserializeAws_json1_1DeleteResourceConfigCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteResourceConfigCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2708,6 +2718,7 @@ export async function deserializeAws_json1_1DeleteRetentionConfigurationCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteRetentionConfigurationCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -6011,6 +6022,7 @@ export async function deserializeAws_json1_1PutConfigRuleCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1PutConfigRuleCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: PutConfigRuleCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -6190,6 +6202,7 @@ export async function deserializeAws_json1_1PutConfigurationRecorderCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: PutConfigurationRecorderCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -6352,6 +6365,7 @@ export async function deserializeAws_json1_1PutDeliveryChannelCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: PutDeliveryChannelCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -6868,6 +6882,7 @@ export async function deserializeAws_json1_1PutResourceConfigCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1PutResourceConfigCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: PutResourceConfigCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -7168,6 +7183,7 @@ export async function deserializeAws_json1_1StartConfigurationRecorderCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: StartConfigurationRecorderCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -7305,6 +7321,7 @@ export async function deserializeAws_json1_1StopConfigurationRecorderCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: StopConfigurationRecorderCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -7356,6 +7373,7 @@ export async function deserializeAws_json1_1TagResourceCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1TagResourceCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: TagResourceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -7421,6 +7439,7 @@ export async function deserializeAws_json1_1UntagResourceCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1UntagResourceCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: UntagResourceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };

--- a/clients/client-connect/models/index.ts
+++ b/clients/client-connect/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export enum Channel {
@@ -24,7 +27,7 @@ export interface ChatMessage {
 
 export namespace ChatMessage {
   export function isa(o: any): o is ChatMessage {
-    return _smithy.isa(o, "ChatMessage");
+    return __isa(o, "ChatMessage");
   }
 }
 
@@ -53,7 +56,7 @@ export interface ParticipantDetails {
 
 export namespace ParticipantDetails {
   export function isa(o: any): o is ParticipantDetails {
-    return _smithy.isa(o, "ParticipantDetails");
+    return __isa(o, "ParticipantDetails");
   }
 }
 
@@ -334,7 +337,7 @@ export interface CurrentMetric {
 
 export namespace CurrentMetric {
   export function isa(o: any): o is CurrentMetric {
-    return _smithy.isa(o, "CurrentMetric");
+    return __isa(o, "CurrentMetric");
   }
 }
 
@@ -356,7 +359,7 @@ export interface CurrentMetricData {
 
 export namespace CurrentMetricData {
   export function isa(o: any): o is CurrentMetricData {
-    return _smithy.isa(o, "CurrentMetricData");
+    return __isa(o, "CurrentMetricData");
   }
 }
 
@@ -394,7 +397,7 @@ export interface CurrentMetricResult {
 
 export namespace CurrentMetricResult {
   export function isa(o: any): o is CurrentMetricResult {
-    return _smithy.isa(o, "CurrentMetricResult");
+    return __isa(o, "CurrentMetricResult");
   }
 }
 
@@ -416,7 +419,7 @@ export interface Dimensions {
 
 export namespace Dimensions {
   export function isa(o: any): o is Dimensions {
-    return _smithy.isa(o, "Dimensions");
+    return __isa(o, "Dimensions");
   }
 }
 
@@ -439,7 +442,7 @@ export interface Filters {
 
 export namespace Filters {
   export function isa(o: any): o is Filters {
-    return _smithy.isa(o, "Filters");
+    return __isa(o, "Filters");
   }
 }
 
@@ -476,7 +479,7 @@ export interface HistoricalMetric {
 
 export namespace HistoricalMetric {
   export function isa(o: any): o is HistoricalMetric {
-    return _smithy.isa(o, "HistoricalMetric");
+    return __isa(o, "HistoricalMetric");
   }
 }
 
@@ -498,7 +501,7 @@ export interface HistoricalMetricData {
 
 export namespace HistoricalMetricData {
   export function isa(o: any): o is HistoricalMetricData {
-    return _smithy.isa(o, "HistoricalMetricData");
+    return __isa(o, "HistoricalMetricData");
   }
 }
 
@@ -548,7 +551,7 @@ export interface HistoricalMetricResult {
 
 export namespace HistoricalMetricResult {
   export function isa(o: any): o is HistoricalMetricResult {
-    return _smithy.isa(o, "HistoricalMetricResult");
+    return __isa(o, "HistoricalMetricResult");
   }
 }
 
@@ -570,7 +573,7 @@ export interface QueueReference {
 
 export namespace QueueReference {
   export function isa(o: any): o is QueueReference {
-    return _smithy.isa(o, "QueueReference");
+    return __isa(o, "QueueReference");
   }
 }
 
@@ -598,7 +601,7 @@ export interface Threshold {
 
 export namespace Threshold {
   export function isa(o: any): o is Threshold {
-    return _smithy.isa(o, "Threshold");
+    return __isa(o, "Threshold");
   }
 }
 
@@ -636,7 +639,7 @@ export interface ContactFlowSummary {
 
 export namespace ContactFlowSummary {
   export function isa(o: any): o is ContactFlowSummary {
-    return _smithy.isa(o, "ContactFlowSummary");
+    return __isa(o, "ContactFlowSummary");
   }
 }
 
@@ -644,7 +647,7 @@ export namespace ContactFlowSummary {
  * <p>The contact with the specified ID is not active or does not exist.</p>
  */
 export interface ContactNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ContactNotFoundException";
   $fault: "client";
@@ -656,7 +659,7 @@ export interface ContactNotFoundException
 
 export namespace ContactNotFoundException {
   export function isa(o: any): o is ContactNotFoundException {
-    return _smithy.isa(o, "ContactNotFoundException");
+    return __isa(o, "ContactNotFoundException");
   }
 }
 
@@ -724,7 +727,7 @@ export interface CreateUserRequest {
 
 export namespace CreateUserRequest {
   export function isa(o: any): o is CreateUserRequest {
-    return _smithy.isa(o, "CreateUserRequest");
+    return __isa(o, "CreateUserRequest");
   }
 }
 
@@ -743,7 +746,7 @@ export interface CreateUserResponse extends $MetadataBearer {
 
 export namespace CreateUserResponse {
   export function isa(o: any): o is CreateUserResponse {
-    return _smithy.isa(o, "CreateUserResponse");
+    return __isa(o, "CreateUserResponse");
   }
 }
 
@@ -776,7 +779,7 @@ export interface Credentials {
 
 export namespace Credentials {
   export function isa(o: any): o is Credentials {
-    return _smithy.isa(o, "Credentials");
+    return __isa(o, "Credentials");
   }
 }
 
@@ -795,7 +798,7 @@ export interface DeleteUserRequest {
 
 export namespace DeleteUserRequest {
   export function isa(o: any): o is DeleteUserRequest {
-    return _smithy.isa(o, "DeleteUserRequest");
+    return __isa(o, "DeleteUserRequest");
   }
 }
 
@@ -814,7 +817,7 @@ export interface DescribeUserHierarchyGroupRequest {
 
 export namespace DescribeUserHierarchyGroupRequest {
   export function isa(o: any): o is DescribeUserHierarchyGroupRequest {
-    return _smithy.isa(o, "DescribeUserHierarchyGroupRequest");
+    return __isa(o, "DescribeUserHierarchyGroupRequest");
   }
 }
 
@@ -828,7 +831,7 @@ export interface DescribeUserHierarchyGroupResponse extends $MetadataBearer {
 
 export namespace DescribeUserHierarchyGroupResponse {
   export function isa(o: any): o is DescribeUserHierarchyGroupResponse {
-    return _smithy.isa(o, "DescribeUserHierarchyGroupResponse");
+    return __isa(o, "DescribeUserHierarchyGroupResponse");
   }
 }
 
@@ -842,7 +845,7 @@ export interface DescribeUserHierarchyStructureRequest {
 
 export namespace DescribeUserHierarchyStructureRequest {
   export function isa(o: any): o is DescribeUserHierarchyStructureRequest {
-    return _smithy.isa(o, "DescribeUserHierarchyStructureRequest");
+    return __isa(o, "DescribeUserHierarchyStructureRequest");
   }
 }
 
@@ -857,7 +860,7 @@ export interface DescribeUserHierarchyStructureResponse
 
 export namespace DescribeUserHierarchyStructureResponse {
   export function isa(o: any): o is DescribeUserHierarchyStructureResponse {
-    return _smithy.isa(o, "DescribeUserHierarchyStructureResponse");
+    return __isa(o, "DescribeUserHierarchyStructureResponse");
   }
 }
 
@@ -876,7 +879,7 @@ export interface DescribeUserRequest {
 
 export namespace DescribeUserRequest {
   export function isa(o: any): o is DescribeUserRequest {
-    return _smithy.isa(o, "DescribeUserRequest");
+    return __isa(o, "DescribeUserRequest");
   }
 }
 
@@ -890,7 +893,7 @@ export interface DescribeUserResponse extends $MetadataBearer {
 
 export namespace DescribeUserResponse {
   export function isa(o: any): o is DescribeUserResponse {
-    return _smithy.isa(o, "DescribeUserResponse");
+    return __isa(o, "DescribeUserResponse");
   }
 }
 
@@ -898,7 +901,7 @@ export namespace DescribeUserResponse {
  * <p>Outbound calls to the destination number are not allowed.</p>
  */
 export interface DestinationNotAllowedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DestinationNotAllowedException";
   $fault: "client";
@@ -910,7 +913,7 @@ export interface DestinationNotAllowedException
 
 export namespace DestinationNotAllowedException {
   export function isa(o: any): o is DestinationNotAllowedException {
-    return _smithy.isa(o, "DestinationNotAllowedException");
+    return __isa(o, "DestinationNotAllowedException");
   }
 }
 
@@ -918,7 +921,7 @@ export namespace DestinationNotAllowedException {
  * <p>A resource with the specified name already exists.</p>
  */
 export interface DuplicateResourceException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DuplicateResourceException";
   $fault: "client";
@@ -927,7 +930,7 @@ export interface DuplicateResourceException
 
 export namespace DuplicateResourceException {
   export function isa(o: any): o is DuplicateResourceException {
-    return _smithy.isa(o, "DuplicateResourceException");
+    return __isa(o, "DuplicateResourceException");
   }
 }
 
@@ -946,7 +949,7 @@ export interface GetContactAttributesRequest {
 
 export namespace GetContactAttributesRequest {
   export function isa(o: any): o is GetContactAttributesRequest {
-    return _smithy.isa(o, "GetContactAttributesRequest");
+    return __isa(o, "GetContactAttributesRequest");
   }
 }
 
@@ -960,7 +963,7 @@ export interface GetContactAttributesResponse extends $MetadataBearer {
 
 export namespace GetContactAttributesResponse {
   export function isa(o: any): o is GetContactAttributesResponse {
-    return _smithy.isa(o, "GetContactAttributesResponse");
+    return __isa(o, "GetContactAttributesResponse");
   }
 }
 
@@ -1065,7 +1068,7 @@ export interface GetCurrentMetricDataRequest {
 
 export namespace GetCurrentMetricDataRequest {
   export function isa(o: any): o is GetCurrentMetricDataRequest {
-    return _smithy.isa(o, "GetCurrentMetricDataRequest");
+    return __isa(o, "GetCurrentMetricDataRequest");
   }
 }
 
@@ -1091,7 +1094,7 @@ export interface GetCurrentMetricDataResponse extends $MetadataBearer {
 
 export namespace GetCurrentMetricDataResponse {
   export function isa(o: any): o is GetCurrentMetricDataResponse {
-    return _smithy.isa(o, "GetCurrentMetricDataResponse");
+    return __isa(o, "GetCurrentMetricDataResponse");
   }
 }
 
@@ -1105,7 +1108,7 @@ export interface GetFederationTokenRequest {
 
 export namespace GetFederationTokenRequest {
   export function isa(o: any): o is GetFederationTokenRequest {
-    return _smithy.isa(o, "GetFederationTokenRequest");
+    return __isa(o, "GetFederationTokenRequest");
   }
 }
 
@@ -1119,7 +1122,7 @@ export interface GetFederationTokenResponse extends $MetadataBearer {
 
 export namespace GetFederationTokenResponse {
   export function isa(o: any): o is GetFederationTokenResponse {
-    return _smithy.isa(o, "GetFederationTokenResponse");
+    return __isa(o, "GetFederationTokenResponse");
   }
 }
 
@@ -1313,7 +1316,7 @@ export interface GetMetricDataRequest {
 
 export namespace GetMetricDataRequest {
   export function isa(o: any): o is GetMetricDataRequest {
-    return _smithy.isa(o, "GetMetricDataRequest");
+    return __isa(o, "GetMetricDataRequest");
   }
 }
 
@@ -1335,7 +1338,7 @@ export interface GetMetricDataResponse extends $MetadataBearer {
 
 export namespace GetMetricDataResponse {
   export function isa(o: any): o is GetMetricDataResponse {
-    return _smithy.isa(o, "GetMetricDataResponse");
+    return __isa(o, "GetMetricDataResponse");
   }
 }
 
@@ -1372,7 +1375,7 @@ export interface HierarchyGroup {
 
 export namespace HierarchyGroup {
   export function isa(o: any): o is HierarchyGroup {
-    return _smithy.isa(o, "HierarchyGroup");
+    return __isa(o, "HierarchyGroup");
   }
 }
 
@@ -1399,7 +1402,7 @@ export interface HierarchyGroupSummary {
 
 export namespace HierarchyGroupSummary {
   export function isa(o: any): o is HierarchyGroupSummary {
-    return _smithy.isa(o, "HierarchyGroupSummary");
+    return __isa(o, "HierarchyGroupSummary");
   }
 }
 
@@ -1426,7 +1429,7 @@ export interface HierarchyLevel {
 
 export namespace HierarchyLevel {
   export function isa(o: any): o is HierarchyLevel {
-    return _smithy.isa(o, "HierarchyLevel");
+    return __isa(o, "HierarchyLevel");
   }
 }
 
@@ -1463,7 +1466,7 @@ export interface HierarchyPath {
 
 export namespace HierarchyPath {
   export function isa(o: any): o is HierarchyPath {
-    return _smithy.isa(o, "HierarchyPath");
+    return __isa(o, "HierarchyPath");
   }
 }
 
@@ -1500,7 +1503,7 @@ export interface HierarchyStructure {
 
 export namespace HierarchyStructure {
   export function isa(o: any): o is HierarchyStructure {
-    return _smithy.isa(o, "HierarchyStructure");
+    return __isa(o, "HierarchyStructure");
   }
 }
 
@@ -1527,7 +1530,7 @@ export interface HoursOfOperationSummary {
 
 export namespace HoursOfOperationSummary {
   export function isa(o: any): o is HoursOfOperationSummary {
-    return _smithy.isa(o, "HoursOfOperationSummary");
+    return __isa(o, "HoursOfOperationSummary");
   }
 }
 
@@ -1535,7 +1538,7 @@ export namespace HoursOfOperationSummary {
  * <p>Request processing failed due to an error or failure with the service.</p>
  */
 export interface InternalServiceException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalServiceException";
   $fault: "server";
@@ -1547,7 +1550,7 @@ export interface InternalServiceException
 
 export namespace InternalServiceException {
   export function isa(o: any): o is InternalServiceException {
-    return _smithy.isa(o, "InternalServiceException");
+    return __isa(o, "InternalServiceException");
   }
 }
 
@@ -1555,7 +1558,7 @@ export namespace InternalServiceException {
  * <p>One or more of the specified parameters are not valid.</p>
  */
 export interface InvalidParameterException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidParameterException";
   $fault: "client";
@@ -1567,7 +1570,7 @@ export interface InvalidParameterException
 
 export namespace InvalidParameterException {
   export function isa(o: any): o is InvalidParameterException {
-    return _smithy.isa(o, "InvalidParameterException");
+    return __isa(o, "InvalidParameterException");
   }
 }
 
@@ -1575,7 +1578,7 @@ export namespace InvalidParameterException {
  * <p>The request is not valid.</p>
  */
 export interface InvalidRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidRequestException";
   $fault: "client";
@@ -1587,7 +1590,7 @@ export interface InvalidRequestException
 
 export namespace InvalidRequestException {
   export function isa(o: any): o is InvalidRequestException {
-    return _smithy.isa(o, "InvalidRequestException");
+    return __isa(o, "InvalidRequestException");
   }
 }
 
@@ -1595,7 +1598,7 @@ export namespace InvalidRequestException {
  * <p>The allowed limit for the resource has been exceeded.</p>
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -1607,7 +1610,7 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
@@ -1637,7 +1640,7 @@ export interface ListContactFlowsRequest {
 
 export namespace ListContactFlowsRequest {
   export function isa(o: any): o is ListContactFlowsRequest {
-    return _smithy.isa(o, "ListContactFlowsRequest");
+    return __isa(o, "ListContactFlowsRequest");
   }
 }
 
@@ -1656,7 +1659,7 @@ export interface ListContactFlowsResponse extends $MetadataBearer {
 
 export namespace ListContactFlowsResponse {
   export function isa(o: any): o is ListContactFlowsResponse {
-    return _smithy.isa(o, "ListContactFlowsResponse");
+    return __isa(o, "ListContactFlowsResponse");
   }
 }
 
@@ -1681,7 +1684,7 @@ export interface ListHoursOfOperationsRequest {
 
 export namespace ListHoursOfOperationsRequest {
   export function isa(o: any): o is ListHoursOfOperationsRequest {
-    return _smithy.isa(o, "ListHoursOfOperationsRequest");
+    return __isa(o, "ListHoursOfOperationsRequest");
   }
 }
 
@@ -1700,7 +1703,7 @@ export interface ListHoursOfOperationsResponse extends $MetadataBearer {
 
 export namespace ListHoursOfOperationsResponse {
   export function isa(o: any): o is ListHoursOfOperationsResponse {
-    return _smithy.isa(o, "ListHoursOfOperationsResponse");
+    return __isa(o, "ListHoursOfOperationsResponse");
   }
 }
 
@@ -1735,7 +1738,7 @@ export interface ListPhoneNumbersRequest {
 
 export namespace ListPhoneNumbersRequest {
   export function isa(o: any): o is ListPhoneNumbersRequest {
-    return _smithy.isa(o, "ListPhoneNumbersRequest");
+    return __isa(o, "ListPhoneNumbersRequest");
   }
 }
 
@@ -1754,7 +1757,7 @@ export interface ListPhoneNumbersResponse extends $MetadataBearer {
 
 export namespace ListPhoneNumbersResponse {
   export function isa(o: any): o is ListPhoneNumbersResponse {
-    return _smithy.isa(o, "ListPhoneNumbersResponse");
+    return __isa(o, "ListPhoneNumbersResponse");
   }
 }
 
@@ -1784,7 +1787,7 @@ export interface ListQueuesRequest {
 
 export namespace ListQueuesRequest {
   export function isa(o: any): o is ListQueuesRequest {
-    return _smithy.isa(o, "ListQueuesRequest");
+    return __isa(o, "ListQueuesRequest");
   }
 }
 
@@ -1803,7 +1806,7 @@ export interface ListQueuesResponse extends $MetadataBearer {
 
 export namespace ListQueuesResponse {
   export function isa(o: any): o is ListQueuesResponse {
-    return _smithy.isa(o, "ListQueuesResponse");
+    return __isa(o, "ListQueuesResponse");
   }
 }
 
@@ -1828,7 +1831,7 @@ export interface ListRoutingProfilesRequest {
 
 export namespace ListRoutingProfilesRequest {
   export function isa(o: any): o is ListRoutingProfilesRequest {
-    return _smithy.isa(o, "ListRoutingProfilesRequest");
+    return __isa(o, "ListRoutingProfilesRequest");
   }
 }
 
@@ -1847,7 +1850,7 @@ export interface ListRoutingProfilesResponse extends $MetadataBearer {
 
 export namespace ListRoutingProfilesResponse {
   export function isa(o: any): o is ListRoutingProfilesResponse {
-    return _smithy.isa(o, "ListRoutingProfilesResponse");
+    return __isa(o, "ListRoutingProfilesResponse");
   }
 }
 
@@ -1872,7 +1875,7 @@ export interface ListSecurityProfilesRequest {
 
 export namespace ListSecurityProfilesRequest {
   export function isa(o: any): o is ListSecurityProfilesRequest {
-    return _smithy.isa(o, "ListSecurityProfilesRequest");
+    return __isa(o, "ListSecurityProfilesRequest");
   }
 }
 
@@ -1891,7 +1894,7 @@ export interface ListSecurityProfilesResponse extends $MetadataBearer {
 
 export namespace ListSecurityProfilesResponse {
   export function isa(o: any): o is ListSecurityProfilesResponse {
-    return _smithy.isa(o, "ListSecurityProfilesResponse");
+    return __isa(o, "ListSecurityProfilesResponse");
   }
 }
 
@@ -1905,7 +1908,7 @@ export interface ListTagsForResourceRequest {
 
 export namespace ListTagsForResourceRequest {
   export function isa(o: any): o is ListTagsForResourceRequest {
-    return _smithy.isa(o, "ListTagsForResourceRequest");
+    return __isa(o, "ListTagsForResourceRequest");
   }
 }
 
@@ -1919,7 +1922,7 @@ export interface ListTagsForResourceResponse extends $MetadataBearer {
 
 export namespace ListTagsForResourceResponse {
   export function isa(o: any): o is ListTagsForResourceResponse {
-    return _smithy.isa(o, "ListTagsForResourceResponse");
+    return __isa(o, "ListTagsForResourceResponse");
   }
 }
 
@@ -1944,7 +1947,7 @@ export interface ListUserHierarchyGroupsRequest {
 
 export namespace ListUserHierarchyGroupsRequest {
   export function isa(o: any): o is ListUserHierarchyGroupsRequest {
-    return _smithy.isa(o, "ListUserHierarchyGroupsRequest");
+    return __isa(o, "ListUserHierarchyGroupsRequest");
   }
 }
 
@@ -1963,7 +1966,7 @@ export interface ListUserHierarchyGroupsResponse extends $MetadataBearer {
 
 export namespace ListUserHierarchyGroupsResponse {
   export function isa(o: any): o is ListUserHierarchyGroupsResponse {
-    return _smithy.isa(o, "ListUserHierarchyGroupsResponse");
+    return __isa(o, "ListUserHierarchyGroupsResponse");
   }
 }
 
@@ -1988,7 +1991,7 @@ export interface ListUsersRequest {
 
 export namespace ListUsersRequest {
   export function isa(o: any): o is ListUsersRequest {
-    return _smithy.isa(o, "ListUsersRequest");
+    return __isa(o, "ListUsersRequest");
   }
 }
 
@@ -2007,7 +2010,7 @@ export interface ListUsersResponse extends $MetadataBearer {
 
 export namespace ListUsersResponse {
   export function isa(o: any): o is ListUsersResponse {
-    return _smithy.isa(o, "ListUsersResponse");
+    return __isa(o, "ListUsersResponse");
   }
 }
 
@@ -2015,7 +2018,7 @@ export namespace ListUsersResponse {
  * <p>The contact is not permitted.</p>
  */
 export interface OutboundContactNotPermittedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "OutboundContactNotPermittedException";
   $fault: "client";
@@ -2027,7 +2030,7 @@ export interface OutboundContactNotPermittedException
 
 export namespace OutboundContactNotPermittedException {
   export function isa(o: any): o is OutboundContactNotPermittedException {
-    return _smithy.isa(o, "OutboundContactNotPermittedException");
+    return __isa(o, "OutboundContactNotPermittedException");
   }
 }
 
@@ -2064,7 +2067,7 @@ export interface PhoneNumberSummary {
 
 export namespace PhoneNumberSummary {
   export function isa(o: any): o is PhoneNumberSummary {
-    return _smithy.isa(o, "PhoneNumberSummary");
+    return __isa(o, "PhoneNumberSummary");
   }
 }
 
@@ -2096,7 +2099,7 @@ export interface QueueSummary {
 
 export namespace QueueSummary {
   export function isa(o: any): o is QueueSummary {
-    return _smithy.isa(o, "QueueSummary");
+    return __isa(o, "QueueSummary");
   }
 }
 
@@ -2104,7 +2107,7 @@ export namespace QueueSummary {
  * <p>The specified resource was not found.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -2116,7 +2119,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -2143,7 +2146,7 @@ export interface RoutingProfileSummary {
 
 export namespace RoutingProfileSummary {
   export function isa(o: any): o is RoutingProfileSummary {
-    return _smithy.isa(o, "RoutingProfileSummary");
+    return __isa(o, "RoutingProfileSummary");
   }
 }
 
@@ -2170,7 +2173,7 @@ export interface SecurityProfileSummary {
 
 export namespace SecurityProfileSummary {
   export function isa(o: any): o is SecurityProfileSummary {
-    return _smithy.isa(o, "SecurityProfileSummary");
+    return __isa(o, "SecurityProfileSummary");
   }
 }
 
@@ -2213,7 +2216,7 @@ export interface StartChatContactRequest {
 
 export namespace StartChatContactRequest {
   export function isa(o: any): o is StartChatContactRequest {
-    return _smithy.isa(o, "StartChatContactRequest");
+    return __isa(o, "StartChatContactRequest");
   }
 }
 
@@ -2239,7 +2242,7 @@ export interface StartChatContactResponse extends $MetadataBearer {
 
 export namespace StartChatContactResponse {
   export function isa(o: any): o is StartChatContactResponse {
-    return _smithy.isa(o, "StartChatContactResponse");
+    return __isa(o, "StartChatContactResponse");
   }
 }
 
@@ -2292,7 +2295,7 @@ export interface StartOutboundVoiceContactRequest {
 
 export namespace StartOutboundVoiceContactRequest {
   export function isa(o: any): o is StartOutboundVoiceContactRequest {
-    return _smithy.isa(o, "StartOutboundVoiceContactRequest");
+    return __isa(o, "StartOutboundVoiceContactRequest");
   }
 }
 
@@ -2306,7 +2309,7 @@ export interface StartOutboundVoiceContactResponse extends $MetadataBearer {
 
 export namespace StartOutboundVoiceContactResponse {
   export function isa(o: any): o is StartOutboundVoiceContactResponse {
-    return _smithy.isa(o, "StartOutboundVoiceContactResponse");
+    return __isa(o, "StartOutboundVoiceContactResponse");
   }
 }
 
@@ -2325,7 +2328,7 @@ export interface StopContactRequest {
 
 export namespace StopContactRequest {
   export function isa(o: any): o is StopContactRequest {
-    return _smithy.isa(o, "StopContactRequest");
+    return __isa(o, "StopContactRequest");
   }
 }
 
@@ -2335,7 +2338,7 @@ export interface StopContactResponse extends $MetadataBearer {
 
 export namespace StopContactResponse {
   export function isa(o: any): o is StopContactResponse {
-    return _smithy.isa(o, "StopContactResponse");
+    return __isa(o, "StopContactResponse");
   }
 }
 
@@ -2354,7 +2357,7 @@ export interface TagResourceRequest {
 
 export namespace TagResourceRequest {
   export function isa(o: any): o is TagResourceRequest {
-    return _smithy.isa(o, "TagResourceRequest");
+    return __isa(o, "TagResourceRequest");
   }
 }
 
@@ -2362,7 +2365,7 @@ export namespace TagResourceRequest {
  * <p>The throttling limit has been exceeded.</p>
  */
 export interface ThrottlingException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ThrottlingException";
   $fault: "client";
@@ -2371,7 +2374,7 @@ export interface ThrottlingException
 
 export namespace ThrottlingException {
   export function isa(o: any): o is ThrottlingException {
-    return _smithy.isa(o, "ThrottlingException");
+    return __isa(o, "ThrottlingException");
   }
 }
 
@@ -2390,7 +2393,7 @@ export interface UntagResourceRequest {
 
 export namespace UntagResourceRequest {
   export function isa(o: any): o is UntagResourceRequest {
-    return _smithy.isa(o, "UntagResourceRequest");
+    return __isa(o, "UntagResourceRequest");
   }
 }
 
@@ -2418,7 +2421,7 @@ export interface UpdateContactAttributesRequest {
 
 export namespace UpdateContactAttributesRequest {
   export function isa(o: any): o is UpdateContactAttributesRequest {
-    return _smithy.isa(o, "UpdateContactAttributesRequest");
+    return __isa(o, "UpdateContactAttributesRequest");
   }
 }
 
@@ -2428,7 +2431,7 @@ export interface UpdateContactAttributesResponse extends $MetadataBearer {
 
 export namespace UpdateContactAttributesResponse {
   export function isa(o: any): o is UpdateContactAttributesResponse {
-    return _smithy.isa(o, "UpdateContactAttributesResponse");
+    return __isa(o, "UpdateContactAttributesResponse");
   }
 }
 
@@ -2452,7 +2455,7 @@ export interface UpdateUserHierarchyRequest {
 
 export namespace UpdateUserHierarchyRequest {
   export function isa(o: any): o is UpdateUserHierarchyRequest {
-    return _smithy.isa(o, "UpdateUserHierarchyRequest");
+    return __isa(o, "UpdateUserHierarchyRequest");
   }
 }
 
@@ -2476,7 +2479,7 @@ export interface UpdateUserIdentityInfoRequest {
 
 export namespace UpdateUserIdentityInfoRequest {
   export function isa(o: any): o is UpdateUserIdentityInfoRequest {
-    return _smithy.isa(o, "UpdateUserIdentityInfoRequest");
+    return __isa(o, "UpdateUserIdentityInfoRequest");
   }
 }
 
@@ -2500,7 +2503,7 @@ export interface UpdateUserPhoneConfigRequest {
 
 export namespace UpdateUserPhoneConfigRequest {
   export function isa(o: any): o is UpdateUserPhoneConfigRequest {
-    return _smithy.isa(o, "UpdateUserPhoneConfigRequest");
+    return __isa(o, "UpdateUserPhoneConfigRequest");
   }
 }
 
@@ -2524,7 +2527,7 @@ export interface UpdateUserRoutingProfileRequest {
 
 export namespace UpdateUserRoutingProfileRequest {
   export function isa(o: any): o is UpdateUserRoutingProfileRequest {
-    return _smithy.isa(o, "UpdateUserRoutingProfileRequest");
+    return __isa(o, "UpdateUserRoutingProfileRequest");
   }
 }
 
@@ -2548,7 +2551,7 @@ export interface UpdateUserSecurityProfilesRequest {
 
 export namespace UpdateUserSecurityProfilesRequest {
   export function isa(o: any): o is UpdateUserSecurityProfilesRequest {
-    return _smithy.isa(o, "UpdateUserSecurityProfilesRequest");
+    return __isa(o, "UpdateUserSecurityProfilesRequest");
   }
 }
 
@@ -2610,7 +2613,7 @@ export interface User {
 
 export namespace User {
   export function isa(o: any): o is User {
-    return _smithy.isa(o, "User");
+    return __isa(o, "User");
   }
 }
 
@@ -2640,7 +2643,7 @@ export interface UserIdentityInfo {
 
 export namespace UserIdentityInfo {
   export function isa(o: any): o is UserIdentityInfo {
-    return _smithy.isa(o, "UserIdentityInfo");
+    return __isa(o, "UserIdentityInfo");
   }
 }
 
@@ -2648,7 +2651,7 @@ export namespace UserIdentityInfo {
  * <p>No user with the specified credentials was found in the Amazon Connect instance.</p>
  */
 export interface UserNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UserNotFoundException";
   $fault: "client";
@@ -2657,7 +2660,7 @@ export interface UserNotFoundException
 
 export namespace UserNotFoundException {
   export function isa(o: any): o is UserNotFoundException {
-    return _smithy.isa(o, "UserNotFoundException");
+    return __isa(o, "UserNotFoundException");
   }
 }
 
@@ -2689,7 +2692,7 @@ export interface UserPhoneConfig {
 
 export namespace UserPhoneConfig {
   export function isa(o: any): o is UserPhoneConfig {
-    return _smithy.isa(o, "UserPhoneConfig");
+    return __isa(o, "UserPhoneConfig");
   }
 }
 
@@ -2716,6 +2719,6 @@ export interface UserSummary {
 
 export namespace UserSummary {
   export function isa(o: any): o is UserSummary {
-    return _smithy.isa(o, "UserSummary");
+    return __isa(o, "UserSummary");
   }
 }

--- a/clients/client-connect/protocols/Aws_restJson1_1.ts
+++ b/clients/client-connect/protocols/Aws_restJson1_1.ts
@@ -161,7 +161,10 @@ import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  extendedEncodeURIComponent as __extendedEncodeURIComponent
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -178,13 +181,13 @@ export async function serializeAws_restJson1_1CreateUserCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/users/{InstanceId}";
   if (input.InstanceId !== undefined) {
-    const labelValue: string = input.InstanceId.toString();
+    const labelValue: string = input.InstanceId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: InstanceId.");
     }
     resolvedPath = resolvedPath.replace(
       "{InstanceId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: InstanceId.");
@@ -248,25 +251,25 @@ export async function serializeAws_restJson1_1DeleteUserCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/users/{InstanceId}/{UserId}";
   if (input.InstanceId !== undefined) {
-    const labelValue: string = input.InstanceId.toString();
+    const labelValue: string = input.InstanceId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: InstanceId.");
     }
     resolvedPath = resolvedPath.replace(
       "{InstanceId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: InstanceId.");
   }
   if (input.UserId !== undefined) {
-    const labelValue: string = input.UserId.toString();
+    const labelValue: string = input.UserId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: UserId.");
     }
     resolvedPath = resolvedPath.replace(
       "{UserId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: UserId.");
@@ -288,25 +291,25 @@ export async function serializeAws_restJson1_1DescribeUserCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/users/{InstanceId}/{UserId}";
   if (input.InstanceId !== undefined) {
-    const labelValue: string = input.InstanceId.toString();
+    const labelValue: string = input.InstanceId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: InstanceId.");
     }
     resolvedPath = resolvedPath.replace(
       "{InstanceId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: InstanceId.");
   }
   if (input.UserId !== undefined) {
-    const labelValue: string = input.UserId.toString();
+    const labelValue: string = input.UserId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: UserId.");
     }
     resolvedPath = resolvedPath.replace(
       "{UserId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: UserId.");
@@ -328,7 +331,7 @@ export async function serializeAws_restJson1_1DescribeUserHierarchyGroupCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/user-hierarchy-groups/{InstanceId}/{HierarchyGroupId}";
   if (input.HierarchyGroupId !== undefined) {
-    const labelValue: string = input.HierarchyGroupId.toString();
+    const labelValue: string = input.HierarchyGroupId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: HierarchyGroupId."
@@ -336,7 +339,7 @@ export async function serializeAws_restJson1_1DescribeUserHierarchyGroupCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{HierarchyGroupId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -344,13 +347,13 @@ export async function serializeAws_restJson1_1DescribeUserHierarchyGroupCommand(
     );
   }
   if (input.InstanceId !== undefined) {
-    const labelValue: string = input.InstanceId.toString();
+    const labelValue: string = input.InstanceId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: InstanceId.");
     }
     resolvedPath = resolvedPath.replace(
       "{InstanceId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: InstanceId.");
@@ -372,13 +375,13 @@ export async function serializeAws_restJson1_1DescribeUserHierarchyStructureComm
   headers["Content-Type"] = "";
   let resolvedPath = "/user-hierarchy-structure/{InstanceId}";
   if (input.InstanceId !== undefined) {
-    const labelValue: string = input.InstanceId.toString();
+    const labelValue: string = input.InstanceId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: InstanceId.");
     }
     resolvedPath = resolvedPath.replace(
       "{InstanceId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: InstanceId.");
@@ -400,7 +403,7 @@ export async function serializeAws_restJson1_1GetContactAttributesCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/contact/attributes/{InstanceId}/{InitialContactId}";
   if (input.InitialContactId !== undefined) {
-    const labelValue: string = input.InitialContactId.toString();
+    const labelValue: string = input.InitialContactId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: InitialContactId."
@@ -408,7 +411,7 @@ export async function serializeAws_restJson1_1GetContactAttributesCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{InitialContactId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -416,13 +419,13 @@ export async function serializeAws_restJson1_1GetContactAttributesCommand(
     );
   }
   if (input.InstanceId !== undefined) {
-    const labelValue: string = input.InstanceId.toString();
+    const labelValue: string = input.InstanceId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: InstanceId.");
     }
     resolvedPath = resolvedPath.replace(
       "{InstanceId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: InstanceId.");
@@ -444,13 +447,13 @@ export async function serializeAws_restJson1_1GetCurrentMetricDataCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/metrics/current/{InstanceId}";
   if (input.InstanceId !== undefined) {
-    const labelValue: string = input.InstanceId.toString();
+    const labelValue: string = input.InstanceId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: InstanceId.");
     }
     resolvedPath = resolvedPath.replace(
       "{InstanceId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: InstanceId.");
@@ -500,13 +503,13 @@ export async function serializeAws_restJson1_1GetFederationTokenCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/user/federate/{InstanceId}";
   if (input.InstanceId !== undefined) {
-    const labelValue: string = input.InstanceId.toString();
+    const labelValue: string = input.InstanceId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: InstanceId.");
     }
     resolvedPath = resolvedPath.replace(
       "{InstanceId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: InstanceId.");
@@ -528,13 +531,13 @@ export async function serializeAws_restJson1_1GetMetricDataCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/metrics/historical/{InstanceId}";
   if (input.InstanceId !== undefined) {
-    const labelValue: string = input.InstanceId.toString();
+    const labelValue: string = input.InstanceId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: InstanceId.");
     }
     resolvedPath = resolvedPath.replace(
       "{InstanceId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: InstanceId.");
@@ -590,26 +593,34 @@ export async function serializeAws_restJson1_1ListContactFlowsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/contact-flows-summary/{InstanceId}";
   if (input.InstanceId !== undefined) {
-    const labelValue: string = input.InstanceId.toString();
+    const labelValue: string = input.InstanceId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: InstanceId.");
     }
     resolvedPath = resolvedPath.replace(
       "{InstanceId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: InstanceId.");
   }
   const query: any = {};
   if (input.ContactFlowTypes !== undefined) {
-    query["contactFlowTypes"] = input.ContactFlowTypes;
+    query[
+      __extendedEncodeURIComponent("contactFlowTypes")
+    ] = input.ContactFlowTypes.map(entry =>
+      __extendedEncodeURIComponent(entry)
+    );
   }
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -629,23 +640,27 @@ export async function serializeAws_restJson1_1ListHoursOfOperationsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/hours-of-operations-summary/{InstanceId}";
   if (input.InstanceId !== undefined) {
-    const labelValue: string = input.InstanceId.toString();
+    const labelValue: string = input.InstanceId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: InstanceId.");
     }
     resolvedPath = resolvedPath.replace(
       "{InstanceId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: InstanceId.");
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -665,29 +680,41 @@ export async function serializeAws_restJson1_1ListPhoneNumbersCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/phone-numbers-summary/{InstanceId}";
   if (input.InstanceId !== undefined) {
-    const labelValue: string = input.InstanceId.toString();
+    const labelValue: string = input.InstanceId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: InstanceId.");
     }
     resolvedPath = resolvedPath.replace(
       "{InstanceId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: InstanceId.");
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   if (input.PhoneNumberCountryCodes !== undefined) {
-    query["phoneNumberCountryCodes"] = input.PhoneNumberCountryCodes;
+    query[
+      __extendedEncodeURIComponent("phoneNumberCountryCodes")
+    ] = input.PhoneNumberCountryCodes.map(entry =>
+      __extendedEncodeURIComponent(entry)
+    );
   }
   if (input.PhoneNumberTypes !== undefined) {
-    query["phoneNumberTypes"] = input.PhoneNumberTypes;
+    query[
+      __extendedEncodeURIComponent("phoneNumberTypes")
+    ] = input.PhoneNumberTypes.map(entry =>
+      __extendedEncodeURIComponent(entry)
+    );
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -707,26 +734,32 @@ export async function serializeAws_restJson1_1ListQueuesCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/queues-summary/{InstanceId}";
   if (input.InstanceId !== undefined) {
-    const labelValue: string = input.InstanceId.toString();
+    const labelValue: string = input.InstanceId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: InstanceId.");
     }
     resolvedPath = resolvedPath.replace(
       "{InstanceId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: InstanceId.");
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   if (input.QueueTypes !== undefined) {
-    query["queueTypes"] = input.QueueTypes;
+    query[
+      __extendedEncodeURIComponent("queueTypes")
+    ] = input.QueueTypes.map(entry => __extendedEncodeURIComponent(entry));
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -746,23 +779,27 @@ export async function serializeAws_restJson1_1ListRoutingProfilesCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/routing-profiles-summary/{InstanceId}";
   if (input.InstanceId !== undefined) {
-    const labelValue: string = input.InstanceId.toString();
+    const labelValue: string = input.InstanceId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: InstanceId.");
     }
     resolvedPath = resolvedPath.replace(
       "{InstanceId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: InstanceId.");
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -782,23 +819,27 @@ export async function serializeAws_restJson1_1ListSecurityProfilesCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/security-profiles-summary/{InstanceId}";
   if (input.InstanceId !== undefined) {
-    const labelValue: string = input.InstanceId.toString();
+    const labelValue: string = input.InstanceId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: InstanceId.");
     }
     resolvedPath = resolvedPath.replace(
       "{InstanceId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: InstanceId.");
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -818,7 +859,7 @@ export async function serializeAws_restJson1_1ListTagsForResourceCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/tags/{resourceArn}";
   if (input.resourceArn !== undefined) {
-    const labelValue: string = input.resourceArn.toString();
+    const labelValue: string = input.resourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: resourceArn."
@@ -826,7 +867,7 @@ export async function serializeAws_restJson1_1ListTagsForResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{resourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: resourceArn.");
@@ -848,23 +889,27 @@ export async function serializeAws_restJson1_1ListUserHierarchyGroupsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/user-hierarchy-groups-summary/{InstanceId}";
   if (input.InstanceId !== undefined) {
-    const labelValue: string = input.InstanceId.toString();
+    const labelValue: string = input.InstanceId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: InstanceId.");
     }
     resolvedPath = resolvedPath.replace(
       "{InstanceId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: InstanceId.");
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -884,23 +929,27 @@ export async function serializeAws_restJson1_1ListUsersCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/users-summary/{InstanceId}";
   if (input.InstanceId !== undefined) {
-    const labelValue: string = input.InstanceId.toString();
+    const labelValue: string = input.InstanceId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: InstanceId.");
     }
     resolvedPath = resolvedPath.replace(
       "{InstanceId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: InstanceId.");
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1045,7 +1094,7 @@ export async function serializeAws_restJson1_1TagResourceCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/tags/{resourceArn}";
   if (input.resourceArn !== undefined) {
-    const labelValue: string = input.resourceArn.toString();
+    const labelValue: string = input.resourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: resourceArn."
@@ -1053,7 +1102,7 @@ export async function serializeAws_restJson1_1TagResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{resourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: resourceArn.");
@@ -1082,7 +1131,7 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/tags/{resourceArn}";
   if (input.resourceArn !== undefined) {
-    const labelValue: string = input.resourceArn.toString();
+    const labelValue: string = input.resourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: resourceArn."
@@ -1090,14 +1139,16 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{resourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: resourceArn.");
   }
   const query: any = {};
   if (input.tagKeys !== undefined) {
-    query["tagKeys"] = input.tagKeys;
+    query[__extendedEncodeURIComponent("tagKeys")] = input.tagKeys.map(entry =>
+      __extendedEncodeURIComponent(entry)
+    );
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1149,25 +1200,25 @@ export async function serializeAws_restJson1_1UpdateUserHierarchyCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/users/{InstanceId}/{UserId}/hierarchy";
   if (input.InstanceId !== undefined) {
-    const labelValue: string = input.InstanceId.toString();
+    const labelValue: string = input.InstanceId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: InstanceId.");
     }
     resolvedPath = resolvedPath.replace(
       "{InstanceId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: InstanceId.");
   }
   if (input.UserId !== undefined) {
-    const labelValue: string = input.UserId.toString();
+    const labelValue: string = input.UserId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: UserId.");
     }
     resolvedPath = resolvedPath.replace(
       "{UserId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: UserId.");
@@ -1196,25 +1247,25 @@ export async function serializeAws_restJson1_1UpdateUserIdentityInfoCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/users/{InstanceId}/{UserId}/identity-info";
   if (input.InstanceId !== undefined) {
-    const labelValue: string = input.InstanceId.toString();
+    const labelValue: string = input.InstanceId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: InstanceId.");
     }
     resolvedPath = resolvedPath.replace(
       "{InstanceId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: InstanceId.");
   }
   if (input.UserId !== undefined) {
-    const labelValue: string = input.UserId.toString();
+    const labelValue: string = input.UserId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: UserId.");
     }
     resolvedPath = resolvedPath.replace(
       "{UserId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: UserId.");
@@ -1246,25 +1297,25 @@ export async function serializeAws_restJson1_1UpdateUserPhoneConfigCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/users/{InstanceId}/{UserId}/phone-config";
   if (input.InstanceId !== undefined) {
-    const labelValue: string = input.InstanceId.toString();
+    const labelValue: string = input.InstanceId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: InstanceId.");
     }
     resolvedPath = resolvedPath.replace(
       "{InstanceId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: InstanceId.");
   }
   if (input.UserId !== undefined) {
-    const labelValue: string = input.UserId.toString();
+    const labelValue: string = input.UserId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: UserId.");
     }
     resolvedPath = resolvedPath.replace(
       "{UserId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: UserId.");
@@ -1296,25 +1347,25 @@ export async function serializeAws_restJson1_1UpdateUserRoutingProfileCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/users/{InstanceId}/{UserId}/routing-profile";
   if (input.InstanceId !== undefined) {
-    const labelValue: string = input.InstanceId.toString();
+    const labelValue: string = input.InstanceId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: InstanceId.");
     }
     resolvedPath = resolvedPath.replace(
       "{InstanceId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: InstanceId.");
   }
   if (input.UserId !== undefined) {
-    const labelValue: string = input.UserId.toString();
+    const labelValue: string = input.UserId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: UserId.");
     }
     resolvedPath = resolvedPath.replace(
       "{UserId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: UserId.");
@@ -1343,25 +1394,25 @@ export async function serializeAws_restJson1_1UpdateUserSecurityProfilesCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/users/{InstanceId}/{UserId}/security-profiles";
   if (input.InstanceId !== undefined) {
-    const labelValue: string = input.InstanceId.toString();
+    const labelValue: string = input.InstanceId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: InstanceId.");
     }
     resolvedPath = resolvedPath.replace(
       "{InstanceId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: InstanceId.");
   }
   if (input.UserId !== undefined) {
-    const labelValue: string = input.UserId.toString();
+    const labelValue: string = input.UserId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: UserId.");
     }
     resolvedPath = resolvedPath.replace(
       "{UserId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: UserId.");
@@ -1496,6 +1547,7 @@ export async function deserializeAws_restJson1_1DeleteUserCommand(
   const contents: DeleteUserCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -3196,6 +3248,7 @@ export async function deserializeAws_restJson1_1StopContactCommand(
     $metadata: deserializeMetadata(output),
     __type: "StopContactResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -3271,6 +3324,7 @@ export async function deserializeAws_restJson1_1TagResourceCommand(
   const contents: TagResourceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -3346,6 +3400,7 @@ export async function deserializeAws_restJson1_1UntagResourceCommand(
   const contents: UntagResourceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -3425,6 +3480,7 @@ export async function deserializeAws_restJson1_1UpdateContactAttributesCommand(
     $metadata: deserializeMetadata(output),
     __type: "UpdateContactAttributesResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -3496,6 +3552,7 @@ export async function deserializeAws_restJson1_1UpdateUserHierarchyCommand(
   const contents: UpdateUserHierarchyCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -3574,6 +3631,7 @@ export async function deserializeAws_restJson1_1UpdateUserIdentityInfoCommand(
   const contents: UpdateUserIdentityInfoCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -3652,6 +3710,7 @@ export async function deserializeAws_restJson1_1UpdateUserPhoneConfigCommand(
   const contents: UpdateUserPhoneConfigCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -3730,6 +3789,7 @@ export async function deserializeAws_restJson1_1UpdateUserRoutingProfileCommand(
   const contents: UpdateUserRoutingProfileCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -3808,6 +3868,7 @@ export async function deserializeAws_restJson1_1UpdateUserSecurityProfilesComman
   const contents: UpdateUserSecurityProfilesCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 

--- a/clients/client-connectparticipant/models/index.ts
+++ b/clients/client-connectparticipant/models/index.ts
@@ -1,11 +1,14 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
  * <p>You do not have sufficient access to perform this action.</p>
  */
 export interface AccessDeniedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AccessDeniedException";
   $fault: "client";
@@ -14,7 +17,7 @@ export interface AccessDeniedException
 
 export namespace AccessDeniedException {
   export function isa(o: any): o is AccessDeniedException {
-    return _smithy.isa(o, "AccessDeniedException");
+    return __isa(o, "AccessDeniedException");
   }
 }
 
@@ -33,7 +36,7 @@ export interface CreateParticipantConnectionRequest {
 
 export namespace CreateParticipantConnectionRequest {
   export function isa(o: any): o is CreateParticipantConnectionRequest {
-    return _smithy.isa(o, "CreateParticipantConnectionRequest");
+    return __isa(o, "CreateParticipantConnectionRequest");
   }
 }
 
@@ -53,7 +56,7 @@ export interface CreateParticipantConnectionResponse extends $MetadataBearer {
 
 export namespace CreateParticipantConnectionResponse {
   export function isa(o: any): o is CreateParticipantConnectionResponse {
-    return _smithy.isa(o, "CreateParticipantConnectionResponse");
+    return __isa(o, "CreateParticipantConnectionResponse");
   }
 }
 
@@ -73,7 +76,7 @@ export interface DisconnectParticipantRequest {
 
 export namespace DisconnectParticipantRequest {
   export function isa(o: any): o is DisconnectParticipantRequest {
-    return _smithy.isa(o, "DisconnectParticipantRequest");
+    return __isa(o, "DisconnectParticipantRequest");
   }
 }
 
@@ -83,7 +86,7 @@ export interface DisconnectParticipantResponse extends $MetadataBearer {
 
 export namespace DisconnectParticipantResponse {
   export function isa(o: any): o is DisconnectParticipantResponse {
-    return _smithy.isa(o, "DisconnectParticipantResponse");
+    return __isa(o, "DisconnectParticipantResponse");
   }
 }
 
@@ -129,7 +132,7 @@ export interface GetTranscriptRequest {
 
 export namespace GetTranscriptRequest {
   export function isa(o: any): o is GetTranscriptRequest {
-    return _smithy.isa(o, "GetTranscriptRequest");
+    return __isa(o, "GetTranscriptRequest");
   }
 }
 
@@ -154,7 +157,7 @@ export interface GetTranscriptResponse extends $MetadataBearer {
 
 export namespace GetTranscriptResponse {
   export function isa(o: any): o is GetTranscriptResponse {
-    return _smithy.isa(o, "GetTranscriptResponse");
+    return __isa(o, "GetTranscriptResponse");
   }
 }
 
@@ -162,7 +165,7 @@ export namespace GetTranscriptResponse {
  * <p>This exception occurs when there is an internal failure in the Amazon Connect service.</p>
  */
 export interface InternalServerException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalServerException";
   $fault: "server";
@@ -171,7 +174,7 @@ export interface InternalServerException
 
 export namespace InternalServerException {
   export function isa(o: any): o is InternalServerException {
-    return _smithy.isa(o, "InternalServerException");
+    return __isa(o, "InternalServerException");
   }
 }
 
@@ -211,7 +214,7 @@ export interface SendEventRequest {
 
 export namespace SendEventRequest {
   export function isa(o: any): o is SendEventRequest {
-    return _smithy.isa(o, "SendEventRequest");
+    return __isa(o, "SendEventRequest");
   }
 }
 
@@ -232,7 +235,7 @@ export interface SendEventResponse extends $MetadataBearer {
 
 export namespace SendEventResponse {
   export function isa(o: any): o is SendEventResponse {
-    return _smithy.isa(o, "SendEventResponse");
+    return __isa(o, "SendEventResponse");
   }
 }
 
@@ -262,7 +265,7 @@ export interface SendMessageRequest {
 
 export namespace SendMessageRequest {
   export function isa(o: any): o is SendMessageRequest {
-    return _smithy.isa(o, "SendMessageRequest");
+    return __isa(o, "SendMessageRequest");
   }
 }
 
@@ -283,7 +286,7 @@ export interface SendMessageResponse extends $MetadataBearer {
 
 export namespace SendMessageResponse {
   export function isa(o: any): o is SendMessageResponse {
-    return _smithy.isa(o, "SendMessageResponse");
+    return __isa(o, "SendMessageResponse");
   }
 }
 
@@ -291,7 +294,7 @@ export namespace SendMessageResponse {
  * <p>The request was denied due to request throttling.</p>
  */
 export interface ThrottlingException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ThrottlingException";
   $fault: "client";
@@ -300,7 +303,7 @@ export interface ThrottlingException
 
 export namespace ThrottlingException {
   export function isa(o: any): o is ThrottlingException {
-    return _smithy.isa(o, "ThrottlingException");
+    return __isa(o, "ThrottlingException");
   }
 }
 
@@ -308,7 +311,7 @@ export namespace ThrottlingException {
  * <p>The input fails to satisfy the constraints specified by Amazon Connect.</p>
  */
 export interface ValidationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ValidationException";
   $fault: "client";
@@ -317,7 +320,7 @@ export interface ValidationException
 
 export namespace ValidationException {
   export function isa(o: any): o is ValidationException {
-    return _smithy.isa(o, "ValidationException");
+    return __isa(o, "ValidationException");
   }
 }
 
@@ -377,7 +380,7 @@ export interface Item {
 
 export namespace Item {
   export function isa(o: any): o is Item {
-    return _smithy.isa(o, "Item");
+    return __isa(o, "Item");
   }
 }
 
@@ -417,7 +420,7 @@ export interface StartPosition {
 
 export namespace StartPosition {
   export function isa(o: any): o is StartPosition {
-    return _smithy.isa(o, "StartPosition");
+    return __isa(o, "StartPosition");
   }
 }
 
@@ -441,7 +444,7 @@ export interface ConnectionCredentials {
 
 export namespace ConnectionCredentials {
   export function isa(o: any): o is ConnectionCredentials {
-    return _smithy.isa(o, "ConnectionCredentials");
+    return __isa(o, "ConnectionCredentials");
   }
 }
 
@@ -476,6 +479,6 @@ export interface Websocket {
 
 export namespace Websocket {
   export function isa(o: any): o is Websocket {
-    return _smithy.isa(o, "Websocket");
+    return __isa(o, "Websocket");
   }
 }

--- a/clients/client-connectparticipant/protocols/Aws_restJson1_1.ts
+++ b/clients/client-connectparticipant/protocols/Aws_restJson1_1.ts
@@ -49,7 +49,7 @@ export async function serializeAws_restJson1_1CreateParticipantConnectionCommand
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.ParticipantToken !== undefined) {
-    headers["X-Amz-Bearer"] = input.ParticipantToken.toString();
+    headers["X-Amz-Bearer"] = input.ParticipantToken;
   }
   let resolvedPath = "/participant/connection";
   let body: any;
@@ -78,7 +78,7 @@ export async function serializeAws_restJson1_1DisconnectParticipantCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.ConnectionToken !== undefined) {
-    headers["X-Amz-Bearer"] = input.ConnectionToken.toString();
+    headers["X-Amz-Bearer"] = input.ConnectionToken;
   }
   let resolvedPath = "/participant/disconnect";
   let body: any;
@@ -107,7 +107,7 @@ export async function serializeAws_restJson1_1GetTranscriptCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.ConnectionToken !== undefined) {
-    headers["X-Amz-Bearer"] = input.ConnectionToken.toString();
+    headers["X-Amz-Bearer"] = input.ConnectionToken;
   }
   let resolvedPath = "/participant/transcript";
   let body: any;
@@ -151,7 +151,7 @@ export async function serializeAws_restJson1_1SendEventCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.ConnectionToken !== undefined) {
-    headers["X-Amz-Bearer"] = input.ConnectionToken.toString();
+    headers["X-Amz-Bearer"] = input.ConnectionToken;
   }
   let resolvedPath = "/participant/event";
   let body: any;
@@ -186,7 +186,7 @@ export async function serializeAws_restJson1_1SendMessageCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.ConnectionToken !== undefined) {
-    headers["X-Amz-Bearer"] = input.ConnectionToken.toString();
+    headers["X-Amz-Bearer"] = input.ConnectionToken;
   }
   let resolvedPath = "/participant/message";
   let body: any;
@@ -318,6 +318,7 @@ export async function deserializeAws_restJson1_1DisconnectParticipantCommand(
     $metadata: deserializeMetadata(output),
     __type: "DisconnectParticipantResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 

--- a/clients/client-cost-and-usage-report-service/models/index.ts
+++ b/clients/client-cost-and-usage-report-service/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export enum AWSRegion {
@@ -41,7 +44,7 @@ export interface DeleteReportDefinitionRequest {
 
 export namespace DeleteReportDefinitionRequest {
   export function isa(o: any): o is DeleteReportDefinitionRequest {
-    return _smithy.isa(o, "DeleteReportDefinitionRequest");
+    return __isa(o, "DeleteReportDefinitionRequest");
   }
 }
 
@@ -58,7 +61,7 @@ export interface DeleteReportDefinitionResponse extends $MetadataBearer {
 
 export namespace DeleteReportDefinitionResponse {
   export function isa(o: any): o is DeleteReportDefinitionResponse {
-    return _smithy.isa(o, "DeleteReportDefinitionResponse");
+    return __isa(o, "DeleteReportDefinitionResponse");
   }
 }
 
@@ -80,7 +83,7 @@ export interface DescribeReportDefinitionsRequest {
 
 export namespace DescribeReportDefinitionsRequest {
   export function isa(o: any): o is DescribeReportDefinitionsRequest {
-    return _smithy.isa(o, "DescribeReportDefinitionsRequest");
+    return __isa(o, "DescribeReportDefinitionsRequest");
   }
 }
 
@@ -102,7 +105,7 @@ export interface DescribeReportDefinitionsResponse extends $MetadataBearer {
 
 export namespace DescribeReportDefinitionsResponse {
   export function isa(o: any): o is DescribeReportDefinitionsResponse {
-    return _smithy.isa(o, "DescribeReportDefinitionsResponse");
+    return __isa(o, "DescribeReportDefinitionsResponse");
   }
 }
 
@@ -110,7 +113,7 @@ export namespace DescribeReportDefinitionsResponse {
  * <p>A report with the specified name already exists in the account. Specify a different report name.</p>
  */
 export interface DuplicateReportNameException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DuplicateReportNameException";
   $fault: "client";
@@ -122,7 +125,7 @@ export interface DuplicateReportNameException
 
 export namespace DuplicateReportNameException {
   export function isa(o: any): o is DuplicateReportNameException {
-    return _smithy.isa(o, "DuplicateReportNameException");
+    return __isa(o, "DuplicateReportNameException");
   }
 }
 
@@ -130,7 +133,7 @@ export namespace DuplicateReportNameException {
  * <p>An error on the server occurred during the processing of your request. Try again later.</p>
  */
 export interface InternalErrorException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalErrorException";
   $fault: "server";
@@ -142,7 +145,7 @@ export interface InternalErrorException
 
 export namespace InternalErrorException {
   export function isa(o: any): o is InternalErrorException {
-    return _smithy.isa(o, "InternalErrorException");
+    return __isa(o, "InternalErrorException");
   }
 }
 
@@ -165,7 +168,7 @@ export interface ModifyReportDefinitionRequest {
 
 export namespace ModifyReportDefinitionRequest {
   export function isa(o: any): o is ModifyReportDefinitionRequest {
-    return _smithy.isa(o, "ModifyReportDefinitionRequest");
+    return __isa(o, "ModifyReportDefinitionRequest");
   }
 }
 
@@ -175,7 +178,7 @@ export interface ModifyReportDefinitionResponse extends $MetadataBearer {
 
 export namespace ModifyReportDefinitionResponse {
   export function isa(o: any): o is ModifyReportDefinitionResponse {
-    return _smithy.isa(o, "ModifyReportDefinitionResponse");
+    return __isa(o, "ModifyReportDefinitionResponse");
   }
 }
 
@@ -193,7 +196,7 @@ export interface PutReportDefinitionRequest {
 
 export namespace PutReportDefinitionRequest {
   export function isa(o: any): o is PutReportDefinitionRequest {
-    return _smithy.isa(o, "PutReportDefinitionRequest");
+    return __isa(o, "PutReportDefinitionRequest");
   }
 }
 
@@ -206,7 +209,7 @@ export interface PutReportDefinitionResponse extends $MetadataBearer {
 
 export namespace PutReportDefinitionResponse {
   export function isa(o: any): o is PutReportDefinitionResponse {
-    return _smithy.isa(o, "PutReportDefinitionResponse");
+    return __isa(o, "PutReportDefinitionResponse");
   }
 }
 
@@ -280,7 +283,7 @@ export interface ReportDefinition {
 
 export namespace ReportDefinition {
   export function isa(o: any): o is ReportDefinition {
-    return _smithy.isa(o, "ReportDefinition");
+    return __isa(o, "ReportDefinition");
   }
 }
 
@@ -293,7 +296,7 @@ export enum ReportFormat {
  * <p>This account already has five reports defined. To define a new report, you must delete an existing report.</p>
  */
 export interface ReportLimitReachedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ReportLimitReachedException";
   $fault: "client";
@@ -305,7 +308,7 @@ export interface ReportLimitReachedException
 
 export namespace ReportLimitReachedException {
   export function isa(o: any): o is ReportLimitReachedException {
-    return _smithy.isa(o, "ReportLimitReachedException");
+    return __isa(o, "ReportLimitReachedException");
   }
 }
 
@@ -327,7 +330,7 @@ export enum TimeUnit {
  * <p>The input fails to satisfy the constraints specified by an AWS service.</p>
  */
 export interface ValidationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ValidationException";
   $fault: "client";
@@ -339,6 +342,6 @@ export interface ValidationException
 
 export namespace ValidationException {
   export function isa(o: any): o is ValidationException {
-    return _smithy.isa(o, "ValidationException");
+    return __isa(o, "ValidationException");
   }
 }

--- a/clients/client-cost-explorer/models/index.ts
+++ b/clients/client-cost-explorer/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export enum AccountScope {
@@ -10,7 +13,7 @@ export enum AccountScope {
  * <p>The requested report expired. Update the date interval and try again.</p>
  */
 export interface BillExpirationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "BillExpirationException";
   $fault: "client";
@@ -19,7 +22,7 @@ export interface BillExpirationException
 
 export namespace BillExpirationException {
   export function isa(o: any): o is BillExpirationException {
-    return _smithy.isa(o, "BillExpirationException");
+    return __isa(o, "BillExpirationException");
   }
 }
 
@@ -80,7 +83,7 @@ export interface CostCategory {
 
 export namespace CostCategory {
   export function isa(o: any): o is CostCategory {
-    return _smithy.isa(o, "CostCategory");
+    return __isa(o, "CostCategory");
   }
 }
 
@@ -124,7 +127,7 @@ export interface CostCategoryReference {
 
 export namespace CostCategoryReference {
   export function isa(o: any): o is CostCategoryReference {
-    return _smithy.isa(o, "CostCategoryReference");
+    return __isa(o, "CostCategoryReference");
   }
 }
 
@@ -154,7 +157,7 @@ export interface CostCategoryRule {
 
 export namespace CostCategoryRule {
   export function isa(o: any): o is CostCategoryRule {
-    return _smithy.isa(o, "CostCategoryRule");
+    return __isa(o, "CostCategoryRule");
   }
 }
 
@@ -187,7 +190,7 @@ export interface CostCategoryValues {
 
 export namespace CostCategoryValues {
   export function isa(o: any): o is CostCategoryValues {
-    return _smithy.isa(o, "CostCategoryValues");
+    return __isa(o, "CostCategoryValues");
   }
 }
 
@@ -215,7 +218,7 @@ export interface Coverage {
 
 export namespace Coverage {
   export function isa(o: any): o is Coverage {
-    return _smithy.isa(o, "Coverage");
+    return __isa(o, "Coverage");
   }
 }
 
@@ -244,7 +247,7 @@ export interface CoverageByTime {
 
 export namespace CoverageByTime {
   export function isa(o: any): o is CoverageByTime {
-    return _smithy.isa(o, "CoverageByTime");
+    return __isa(o, "CoverageByTime");
   }
 }
 
@@ -261,7 +264,7 @@ export interface CoverageCost {
 
 export namespace CoverageCost {
   export function isa(o: any): o is CoverageCost {
-    return _smithy.isa(o, "CoverageCost");
+    return __isa(o, "CoverageCost");
   }
 }
 
@@ -293,7 +296,7 @@ export interface CoverageHours {
 
 export namespace CoverageHours {
   export function isa(o: any): o is CoverageHours {
-    return _smithy.isa(o, "CoverageHours");
+    return __isa(o, "CoverageHours");
   }
 }
 
@@ -335,7 +338,7 @@ export interface CoverageNormalizedUnits {
 
 export namespace CoverageNormalizedUnits {
   export function isa(o: any): o is CoverageNormalizedUnits {
-    return _smithy.isa(o, "CoverageNormalizedUnits");
+    return __isa(o, "CoverageNormalizedUnits");
   }
 }
 
@@ -364,7 +367,7 @@ export interface CreateCostCategoryDefinitionRequest {
 
 export namespace CreateCostCategoryDefinitionRequest {
   export function isa(o: any): o is CreateCostCategoryDefinitionRequest {
-    return _smithy.isa(o, "CreateCostCategoryDefinitionRequest");
+    return __isa(o, "CreateCostCategoryDefinitionRequest");
   }
 }
 
@@ -387,7 +390,7 @@ export interface CreateCostCategoryDefinitionResponse extends $MetadataBearer {
 
 export namespace CreateCostCategoryDefinitionResponse {
   export function isa(o: any): o is CreateCostCategoryDefinitionResponse {
-    return _smithy.isa(o, "CreateCostCategoryDefinitionResponse");
+    return __isa(o, "CreateCostCategoryDefinitionResponse");
   }
 }
 
@@ -449,7 +452,7 @@ export interface CurrentInstance {
 
 export namespace CurrentInstance {
   export function isa(o: any): o is CurrentInstance {
-    return _smithy.isa(o, "CurrentInstance");
+    return __isa(o, "CurrentInstance");
   }
 }
 
@@ -457,7 +460,7 @@ export namespace CurrentInstance {
  * <p>The requested data is unavailable.</p>
  */
 export interface DataUnavailableException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DataUnavailableException";
   $fault: "client";
@@ -466,7 +469,7 @@ export interface DataUnavailableException
 
 export namespace DataUnavailableException {
   export function isa(o: any): o is DataUnavailableException {
-    return _smithy.isa(o, "DataUnavailableException");
+    return __isa(o, "DataUnavailableException");
   }
 }
 
@@ -495,7 +498,7 @@ export interface DateInterval {
 
 export namespace DateInterval {
   export function isa(o: any): o is DateInterval {
-    return _smithy.isa(o, "DateInterval");
+    return __isa(o, "DateInterval");
   }
 }
 
@@ -511,7 +514,7 @@ export interface DeleteCostCategoryDefinitionRequest {
 
 export namespace DeleteCostCategoryDefinitionRequest {
   export function isa(o: any): o is DeleteCostCategoryDefinitionRequest {
-    return _smithy.isa(o, "DeleteCostCategoryDefinitionRequest");
+    return __isa(o, "DeleteCostCategoryDefinitionRequest");
   }
 }
 
@@ -534,7 +537,7 @@ export interface DeleteCostCategoryDefinitionResponse extends $MetadataBearer {
 
 export namespace DeleteCostCategoryDefinitionResponse {
   export function isa(o: any): o is DeleteCostCategoryDefinitionResponse {
-    return _smithy.isa(o, "DeleteCostCategoryDefinitionResponse");
+    return __isa(o, "DeleteCostCategoryDefinitionResponse");
   }
 }
 
@@ -557,7 +560,7 @@ export interface DescribeCostCategoryDefinitionRequest {
 
 export namespace DescribeCostCategoryDefinitionRequest {
   export function isa(o: any): o is DescribeCostCategoryDefinitionRequest {
-    return _smithy.isa(o, "DescribeCostCategoryDefinitionRequest");
+    return __isa(o, "DescribeCostCategoryDefinitionRequest");
   }
 }
 
@@ -579,7 +582,7 @@ export interface DescribeCostCategoryDefinitionResponse
 
 export namespace DescribeCostCategoryDefinitionResponse {
   export function isa(o: any): o is DescribeCostCategoryDefinitionResponse {
-    return _smithy.isa(o, "DescribeCostCategoryDefinitionResponse");
+    return __isa(o, "DescribeCostCategoryDefinitionResponse");
   }
 }
 
@@ -640,7 +643,7 @@ export interface DimensionValues {
 
 export namespace DimensionValues {
   export function isa(o: any): o is DimensionValues {
-    return _smithy.isa(o, "DimensionValues");
+    return __isa(o, "DimensionValues");
   }
 }
 
@@ -663,7 +666,7 @@ export interface DimensionValuesWithAttributes {
 
 export namespace DimensionValuesWithAttributes {
   export function isa(o: any): o is DimensionValuesWithAttributes {
-    return _smithy.isa(o, "DimensionValuesWithAttributes");
+    return __isa(o, "DimensionValuesWithAttributes");
   }
 }
 
@@ -716,7 +719,7 @@ export interface EC2InstanceDetails {
 
 export namespace EC2InstanceDetails {
   export function isa(o: any): o is EC2InstanceDetails {
-    return _smithy.isa(o, "EC2InstanceDetails");
+    return __isa(o, "EC2InstanceDetails");
   }
 }
 
@@ -773,7 +776,7 @@ export interface EC2ResourceDetails {
 
 export namespace EC2ResourceDetails {
   export function isa(o: any): o is EC2ResourceDetails {
-    return _smithy.isa(o, "EC2ResourceDetails");
+    return __isa(o, "EC2ResourceDetails");
   }
 }
 
@@ -800,7 +803,7 @@ export interface EC2ResourceUtilization {
 
 export namespace EC2ResourceUtilization {
   export function isa(o: any): o is EC2ResourceUtilization {
-    return _smithy.isa(o, "EC2ResourceUtilization");
+    return __isa(o, "EC2ResourceUtilization");
   }
 }
 
@@ -819,7 +822,7 @@ export interface EC2Specification {
 
 export namespace EC2Specification {
   export function isa(o: any): o is EC2Specification {
-    return _smithy.isa(o, "EC2Specification");
+    return __isa(o, "EC2Specification");
   }
 }
 
@@ -857,7 +860,7 @@ export interface ESInstanceDetails {
 
 export namespace ESInstanceDetails {
   export function isa(o: any): o is ESInstanceDetails {
-    return _smithy.isa(o, "ESInstanceDetails");
+    return __isa(o, "ESInstanceDetails");
   }
 }
 
@@ -900,7 +903,7 @@ export interface ElastiCacheInstanceDetails {
 
 export namespace ElastiCacheInstanceDetails {
   export function isa(o: any): o is ElastiCacheInstanceDetails {
-    return _smithy.isa(o, "ElastiCacheInstanceDetails");
+    return __isa(o, "ElastiCacheInstanceDetails");
   }
 }
 
@@ -997,7 +1000,7 @@ export interface Expression {
 
 export namespace Expression {
   export function isa(o: any): o is Expression {
-    return _smithy.isa(o, "Expression");
+    return __isa(o, "Expression");
   }
 }
 
@@ -1029,7 +1032,7 @@ export interface ForecastResult {
 
 export namespace ForecastResult {
   export function isa(o: any): o is ForecastResult {
-    return _smithy.isa(o, "ForecastResult");
+    return __isa(o, "ForecastResult");
   }
 }
 
@@ -1090,7 +1093,7 @@ export interface GetCostAndUsageRequest {
 
 export namespace GetCostAndUsageRequest {
   export function isa(o: any): o is GetCostAndUsageRequest {
-    return _smithy.isa(o, "GetCostAndUsageRequest");
+    return __isa(o, "GetCostAndUsageRequest");
   }
 }
 
@@ -1114,7 +1117,7 @@ export interface GetCostAndUsageResponse extends $MetadataBearer {
 
 export namespace GetCostAndUsageResponse {
   export function isa(o: any): o is GetCostAndUsageResponse {
-    return _smithy.isa(o, "GetCostAndUsageResponse");
+    return __isa(o, "GetCostAndUsageResponse");
   }
 }
 
@@ -1178,7 +1181,7 @@ export interface GetCostAndUsageWithResourcesRequest {
 
 export namespace GetCostAndUsageWithResourcesRequest {
   export function isa(o: any): o is GetCostAndUsageWithResourcesRequest {
-    return _smithy.isa(o, "GetCostAndUsageWithResourcesRequest");
+    return __isa(o, "GetCostAndUsageWithResourcesRequest");
   }
 }
 
@@ -1203,7 +1206,7 @@ export interface GetCostAndUsageWithResourcesResponse extends $MetadataBearer {
 
 export namespace GetCostAndUsageWithResourcesResponse {
   export function isa(o: any): o is GetCostAndUsageWithResourcesResponse {
-    return _smithy.isa(o, "GetCostAndUsageWithResourcesResponse");
+    return __isa(o, "GetCostAndUsageWithResourcesResponse");
   }
 }
 
@@ -1260,7 +1263,7 @@ export interface GetCostForecastRequest {
 
 export namespace GetCostForecastRequest {
   export function isa(o: any): o is GetCostForecastRequest {
-    return _smithy.isa(o, "GetCostForecastRequest");
+    return __isa(o, "GetCostForecastRequest");
   }
 }
 
@@ -1280,7 +1283,7 @@ export interface GetCostForecastResponse extends $MetadataBearer {
 
 export namespace GetCostForecastResponse {
   export function isa(o: any): o is GetCostForecastResponse {
-    return _smithy.isa(o, "GetCostForecastResponse");
+    return __isa(o, "GetCostForecastResponse");
   }
 }
 
@@ -1428,7 +1431,7 @@ export interface GetDimensionValuesRequest {
 
 export namespace GetDimensionValuesRequest {
   export function isa(o: any): o is GetDimensionValuesRequest {
-    return _smithy.isa(o, "GetDimensionValuesRequest");
+    return __isa(o, "GetDimensionValuesRequest");
   }
 }
 
@@ -1564,7 +1567,7 @@ export interface GetDimensionValuesResponse extends $MetadataBearer {
 
 export namespace GetDimensionValuesResponse {
   export function isa(o: any): o is GetDimensionValuesResponse {
-    return _smithy.isa(o, "GetDimensionValuesResponse");
+    return __isa(o, "GetDimensionValuesResponse");
   }
 }
 
@@ -1688,7 +1691,7 @@ export interface GetReservationCoverageRequest {
 
 export namespace GetReservationCoverageRequest {
   export function isa(o: any): o is GetReservationCoverageRequest {
-    return _smithy.isa(o, "GetReservationCoverageRequest");
+    return __isa(o, "GetReservationCoverageRequest");
   }
 }
 
@@ -1712,7 +1715,7 @@ export interface GetReservationCoverageResponse extends $MetadataBearer {
 
 export namespace GetReservationCoverageResponse {
   export function isa(o: any): o is GetReservationCoverageResponse {
-    return _smithy.isa(o, "GetReservationCoverageResponse");
+    return __isa(o, "GetReservationCoverageResponse");
   }
 }
 
@@ -1771,7 +1774,7 @@ export namespace GetReservationPurchaseRecommendationRequest {
   export function isa(
     o: any
   ): o is GetReservationPurchaseRecommendationRequest {
-    return _smithy.isa(o, "GetReservationPurchaseRecommendationRequest");
+    return __isa(o, "GetReservationPurchaseRecommendationRequest");
   }
 }
 
@@ -1798,7 +1801,7 @@ export namespace GetReservationPurchaseRecommendationResponse {
   export function isa(
     o: any
   ): o is GetReservationPurchaseRecommendationResponse {
-    return _smithy.isa(o, "GetReservationPurchaseRecommendationResponse");
+    return __isa(o, "GetReservationPurchaseRecommendationResponse");
   }
 }
 
@@ -1876,7 +1879,7 @@ export interface GetReservationUtilizationRequest {
 
 export namespace GetReservationUtilizationRequest {
   export function isa(o: any): o is GetReservationUtilizationRequest {
-    return _smithy.isa(o, "GetReservationUtilizationRequest");
+    return __isa(o, "GetReservationUtilizationRequest");
   }
 }
 
@@ -1900,7 +1903,7 @@ export interface GetReservationUtilizationResponse extends $MetadataBearer {
 
 export namespace GetReservationUtilizationResponse {
   export function isa(o: any): o is GetReservationUtilizationResponse {
-    return _smithy.isa(o, "GetReservationUtilizationResponse");
+    return __isa(o, "GetReservationUtilizationResponse");
   }
 }
 
@@ -1980,7 +1983,7 @@ export interface GetRightsizingRecommendationRequest {
 
 export namespace GetRightsizingRecommendationRequest {
   export function isa(o: any): o is GetRightsizingRecommendationRequest {
-    return _smithy.isa(o, "GetRightsizingRecommendationRequest");
+    return __isa(o, "GetRightsizingRecommendationRequest");
   }
 }
 
@@ -2009,7 +2012,7 @@ export interface GetRightsizingRecommendationResponse extends $MetadataBearer {
 
 export namespace GetRightsizingRecommendationResponse {
   export function isa(o: any): o is GetRightsizingRecommendationResponse {
-    return _smithy.isa(o, "GetRightsizingRecommendationResponse");
+    return __isa(o, "GetRightsizingRecommendationResponse");
   }
 }
 
@@ -2080,7 +2083,7 @@ export interface GetSavingsPlansCoverageRequest {
 
 export namespace GetSavingsPlansCoverageRequest {
   export function isa(o: any): o is GetSavingsPlansCoverageRequest {
-    return _smithy.isa(o, "GetSavingsPlansCoverageRequest");
+    return __isa(o, "GetSavingsPlansCoverageRequest");
   }
 }
 
@@ -2099,7 +2102,7 @@ export interface GetSavingsPlansCoverageResponse extends $MetadataBearer {
 
 export namespace GetSavingsPlansCoverageResponse {
   export function isa(o: any): o is GetSavingsPlansCoverageResponse {
-    return _smithy.isa(o, "GetSavingsPlansCoverageResponse");
+    return __isa(o, "GetSavingsPlansCoverageResponse");
   }
 }
 
@@ -2140,7 +2143,7 @@ export namespace GetSavingsPlansPurchaseRecommendationRequest {
   export function isa(
     o: any
   ): o is GetSavingsPlansPurchaseRecommendationRequest {
-    return _smithy.isa(o, "GetSavingsPlansPurchaseRecommendationRequest");
+    return __isa(o, "GetSavingsPlansPurchaseRecommendationRequest");
   }
 }
 
@@ -2167,7 +2170,7 @@ export namespace GetSavingsPlansPurchaseRecommendationResponse {
   export function isa(
     o: any
   ): o is GetSavingsPlansPurchaseRecommendationResponse {
-    return _smithy.isa(o, "GetSavingsPlansPurchaseRecommendationResponse");
+    return __isa(o, "GetSavingsPlansPurchaseRecommendationResponse");
   }
 }
 
@@ -2227,7 +2230,7 @@ export interface GetSavingsPlansUtilizationDetailsRequest {
 
 export namespace GetSavingsPlansUtilizationDetailsRequest {
   export function isa(o: any): o is GetSavingsPlansUtilizationDetailsRequest {
-    return _smithy.isa(o, "GetSavingsPlansUtilizationDetailsRequest");
+    return __isa(o, "GetSavingsPlansUtilizationDetailsRequest");
   }
 }
 
@@ -2260,7 +2263,7 @@ export interface GetSavingsPlansUtilizationDetailsResponse
 
 export namespace GetSavingsPlansUtilizationDetailsResponse {
   export function isa(o: any): o is GetSavingsPlansUtilizationDetailsResponse {
-    return _smithy.isa(o, "GetSavingsPlansUtilizationDetailsResponse");
+    return __isa(o, "GetSavingsPlansUtilizationDetailsResponse");
   }
 }
 
@@ -2321,7 +2324,7 @@ export interface GetSavingsPlansUtilizationRequest {
 
 export namespace GetSavingsPlansUtilizationRequest {
   export function isa(o: any): o is GetSavingsPlansUtilizationRequest {
-    return _smithy.isa(o, "GetSavingsPlansUtilizationRequest");
+    return __isa(o, "GetSavingsPlansUtilizationRequest");
   }
 }
 
@@ -2340,7 +2343,7 @@ export interface GetSavingsPlansUtilizationResponse extends $MetadataBearer {
 
 export namespace GetSavingsPlansUtilizationResponse {
   export function isa(o: any): o is GetSavingsPlansUtilizationResponse {
-    return _smithy.isa(o, "GetSavingsPlansUtilizationResponse");
+    return __isa(o, "GetSavingsPlansUtilizationResponse");
   }
 }
 
@@ -2370,7 +2373,7 @@ export interface GetTagsRequest {
 
 export namespace GetTagsRequest {
   export function isa(o: any): o is GetTagsRequest {
-    return _smithy.isa(o, "GetTagsRequest");
+    return __isa(o, "GetTagsRequest");
   }
 }
 
@@ -2399,7 +2402,7 @@ export interface GetTagsResponse extends $MetadataBearer {
 
 export namespace GetTagsResponse {
   export function isa(o: any): o is GetTagsResponse {
-    return _smithy.isa(o, "GetTagsResponse");
+    return __isa(o, "GetTagsResponse");
   }
 }
 
@@ -2446,7 +2449,7 @@ export interface GetUsageForecastRequest {
 
 export namespace GetUsageForecastRequest {
   export function isa(o: any): o is GetUsageForecastRequest {
-    return _smithy.isa(o, "GetUsageForecastRequest");
+    return __isa(o, "GetUsageForecastRequest");
   }
 }
 
@@ -2466,7 +2469,7 @@ export interface GetUsageForecastResponse extends $MetadataBearer {
 
 export namespace GetUsageForecastResponse {
   export function isa(o: any): o is GetUsageForecastResponse {
-    return _smithy.isa(o, "GetUsageForecastResponse");
+    return __isa(o, "GetUsageForecastResponse");
   }
 }
 
@@ -2494,7 +2497,7 @@ export interface Group {
 
 export namespace Group {
   export function isa(o: any): o is Group {
-    return _smithy.isa(o, "Group");
+    return __isa(o, "Group");
   }
 }
 
@@ -2517,7 +2520,7 @@ export interface GroupDefinition {
 
 export namespace GroupDefinition {
   export function isa(o: any): o is GroupDefinition {
-    return _smithy.isa(o, "GroupDefinition");
+    return __isa(o, "GroupDefinition");
   }
 }
 
@@ -2560,7 +2563,7 @@ export interface InstanceDetails {
 
 export namespace InstanceDetails {
   export function isa(o: any): o is InstanceDetails {
-    return _smithy.isa(o, "InstanceDetails");
+    return __isa(o, "InstanceDetails");
   }
 }
 
@@ -2568,7 +2571,7 @@ export namespace InstanceDetails {
  * <p>The pagination token is invalid. Try again without a pagination token.</p>
  */
 export interface InvalidNextTokenException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidNextTokenException";
   $fault: "client";
@@ -2577,7 +2580,7 @@ export interface InvalidNextTokenException
 
 export namespace InvalidNextTokenException {
   export function isa(o: any): o is InvalidNextTokenException {
-    return _smithy.isa(o, "InvalidNextTokenException");
+    return __isa(o, "InvalidNextTokenException");
   }
 }
 
@@ -2585,7 +2588,7 @@ export namespace InvalidNextTokenException {
  * <p>You made too many calls in a short period of time. Try again later.</p>
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -2594,7 +2597,7 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
@@ -2618,7 +2621,7 @@ export interface ListCostCategoryDefinitionsRequest {
 
 export namespace ListCostCategoryDefinitionsRequest {
   export function isa(o: any): o is ListCostCategoryDefinitionsRequest {
-    return _smithy.isa(o, "ListCostCategoryDefinitionsRequest");
+    return __isa(o, "ListCostCategoryDefinitionsRequest");
   }
 }
 
@@ -2641,7 +2644,7 @@ export interface ListCostCategoryDefinitionsResponse extends $MetadataBearer {
 
 export namespace ListCostCategoryDefinitionsResponse {
   export function isa(o: any): o is ListCostCategoryDefinitionsResponse {
-    return _smithy.isa(o, "ListCostCategoryDefinitionsResponse");
+    return __isa(o, "ListCostCategoryDefinitionsResponse");
   }
 }
 
@@ -2679,7 +2682,7 @@ export interface MetricValue {
 
 export namespace MetricValue {
   export function isa(o: any): o is MetricValue {
-    return _smithy.isa(o, "MetricValue");
+    return __isa(o, "MetricValue");
   }
 }
 
@@ -2696,7 +2699,7 @@ export interface ModifyRecommendationDetail {
 
 export namespace ModifyRecommendationDetail {
   export function isa(o: any): o is ModifyRecommendationDetail {
-    return _smithy.isa(o, "ModifyRecommendationDetail");
+    return __isa(o, "ModifyRecommendationDetail");
   }
 }
 
@@ -2769,7 +2772,7 @@ export interface RDSInstanceDetails {
 
 export namespace RDSInstanceDetails {
   export function isa(o: any): o is RDSInstanceDetails {
-    return _smithy.isa(o, "RDSInstanceDetails");
+    return __isa(o, "RDSInstanceDetails");
   }
 }
 
@@ -2807,7 +2810,7 @@ export interface RedshiftInstanceDetails {
 
 export namespace RedshiftInstanceDetails {
   export function isa(o: any): o is RedshiftInstanceDetails {
-    return _smithy.isa(o, "RedshiftInstanceDetails");
+    return __isa(o, "RedshiftInstanceDetails");
   }
 }
 
@@ -2816,7 +2819,7 @@ export namespace RedshiftInstanceDetails {
  *             without a pagination token.</p>
  */
 export interface RequestChangedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "RequestChangedException";
   $fault: "client";
@@ -2825,7 +2828,7 @@ export interface RequestChangedException
 
 export namespace RequestChangedException {
   export function isa(o: any): o is RequestChangedException {
-    return _smithy.isa(o, "RequestChangedException");
+    return __isa(o, "RequestChangedException");
   }
 }
 
@@ -2919,7 +2922,7 @@ export interface ReservationAggregates {
 
 export namespace ReservationAggregates {
   export function isa(o: any): o is ReservationAggregates {
-    return _smithy.isa(o, "ReservationAggregates");
+    return __isa(o, "ReservationAggregates");
   }
 }
 
@@ -2942,7 +2945,7 @@ export interface ReservationCoverageGroup {
 
 export namespace ReservationCoverageGroup {
   export function isa(o: any): o is ReservationCoverageGroup {
-    return _smithy.isa(o, "ReservationCoverageGroup");
+    return __isa(o, "ReservationCoverageGroup");
   }
 }
 
@@ -2994,7 +2997,7 @@ export interface ReservationPurchaseRecommendation {
 
 export namespace ReservationPurchaseRecommendation {
   export function isa(o: any): o is ReservationPurchaseRecommendation {
-    return _smithy.isa(o, "ReservationPurchaseRecommendation");
+    return __isa(o, "ReservationPurchaseRecommendation");
   }
 }
 
@@ -3117,7 +3120,7 @@ export interface ReservationPurchaseRecommendationDetail {
 
 export namespace ReservationPurchaseRecommendationDetail {
   export function isa(o: any): o is ReservationPurchaseRecommendationDetail {
-    return _smithy.isa(o, "ReservationPurchaseRecommendationDetail");
+    return __isa(o, "ReservationPurchaseRecommendationDetail");
   }
 }
 
@@ -3140,7 +3143,7 @@ export interface ReservationPurchaseRecommendationMetadata {
 
 export namespace ReservationPurchaseRecommendationMetadata {
   export function isa(o: any): o is ReservationPurchaseRecommendationMetadata {
-    return _smithy.isa(o, "ReservationPurchaseRecommendationMetadata");
+    return __isa(o, "ReservationPurchaseRecommendationMetadata");
   }
 }
 
@@ -3171,7 +3174,7 @@ export interface ReservationPurchaseRecommendationSummary {
 
 export namespace ReservationPurchaseRecommendationSummary {
   export function isa(o: any): o is ReservationPurchaseRecommendationSummary {
-    return _smithy.isa(o, "ReservationPurchaseRecommendationSummary");
+    return __isa(o, "ReservationPurchaseRecommendationSummary");
   }
 }
 
@@ -3203,7 +3206,7 @@ export interface ReservationUtilizationGroup {
 
 export namespace ReservationUtilizationGroup {
   export function isa(o: any): o is ReservationUtilizationGroup {
-    return _smithy.isa(o, "ReservationUtilizationGroup");
+    return __isa(o, "ReservationUtilizationGroup");
   }
 }
 
@@ -3220,7 +3223,7 @@ export interface ResourceDetails {
 
 export namespace ResourceDetails {
   export function isa(o: any): o is ResourceDetails {
-    return _smithy.isa(o, "ResourceDetails");
+    return __isa(o, "ResourceDetails");
   }
 }
 
@@ -3230,7 +3233,7 @@ export namespace ResourceDetails {
  *         </p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -3239,7 +3242,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -3256,7 +3259,7 @@ export interface ResourceUtilization {
 
 export namespace ResourceUtilization {
   export function isa(o: any): o is ResourceUtilization {
-    return _smithy.isa(o, "ResourceUtilization");
+    return __isa(o, "ResourceUtilization");
   }
 }
 
@@ -3289,7 +3292,7 @@ export interface ResultByTime {
 
 export namespace ResultByTime {
   export function isa(o: any): o is ResultByTime {
-    return _smithy.isa(o, "ResultByTime");
+    return __isa(o, "ResultByTime");
   }
 }
 
@@ -3326,7 +3329,7 @@ export interface RightsizingRecommendation {
 
 export namespace RightsizingRecommendation {
   export function isa(o: any): o is RightsizingRecommendation {
-    return _smithy.isa(o, "RightsizingRecommendation");
+    return __isa(o, "RightsizingRecommendation");
   }
 }
 
@@ -3353,7 +3356,7 @@ export interface RightsizingRecommendationMetadata {
 
 export namespace RightsizingRecommendationMetadata {
   export function isa(o: any): o is RightsizingRecommendationMetadata {
-    return _smithy.isa(o, "RightsizingRecommendationMetadata");
+    return __isa(o, "RightsizingRecommendationMetadata");
   }
 }
 
@@ -3385,7 +3388,7 @@ export interface RightsizingRecommendationSummary {
 
 export namespace RightsizingRecommendationSummary {
   export function isa(o: any): o is RightsizingRecommendationSummary {
-    return _smithy.isa(o, "RightsizingRecommendationSummary");
+    return __isa(o, "RightsizingRecommendationSummary");
   }
 }
 
@@ -3417,7 +3420,7 @@ export interface SavingsPlansAmortizedCommitment {
 
 export namespace SavingsPlansAmortizedCommitment {
   export function isa(o: any): o is SavingsPlansAmortizedCommitment {
-    return _smithy.isa(o, "SavingsPlansAmortizedCommitment");
+    return __isa(o, "SavingsPlansAmortizedCommitment");
   }
 }
 
@@ -3445,7 +3448,7 @@ export interface SavingsPlansCoverage {
 
 export namespace SavingsPlansCoverage {
   export function isa(o: any): o is SavingsPlansCoverage {
-    return _smithy.isa(o, "SavingsPlansCoverage");
+    return __isa(o, "SavingsPlansCoverage");
   }
 }
 
@@ -3477,7 +3480,7 @@ export interface SavingsPlansCoverageData {
 
 export namespace SavingsPlansCoverageData {
   export function isa(o: any): o is SavingsPlansCoverageData {
-    return _smithy.isa(o, "SavingsPlansCoverageData");
+    return __isa(o, "SavingsPlansCoverageData");
   }
 }
 
@@ -3504,7 +3507,7 @@ export interface SavingsPlansDetails {
 
 export namespace SavingsPlansDetails {
   export function isa(o: any): o is SavingsPlansDetails {
-    return _smithy.isa(o, "SavingsPlansDetails");
+    return __isa(o, "SavingsPlansDetails");
   }
 }
 
@@ -3548,7 +3551,7 @@ export interface SavingsPlansPurchaseRecommendation {
 
 export namespace SavingsPlansPurchaseRecommendation {
   export function isa(o: any): o is SavingsPlansPurchaseRecommendation {
-    return _smithy.isa(o, "SavingsPlansPurchaseRecommendation");
+    return __isa(o, "SavingsPlansPurchaseRecommendation");
   }
 }
 
@@ -3642,7 +3645,7 @@ export interface SavingsPlansPurchaseRecommendationDetail {
 
 export namespace SavingsPlansPurchaseRecommendationDetail {
   export function isa(o: any): o is SavingsPlansPurchaseRecommendationDetail {
-    return _smithy.isa(o, "SavingsPlansPurchaseRecommendationDetail");
+    return __isa(o, "SavingsPlansPurchaseRecommendationDetail");
   }
 }
 
@@ -3664,7 +3667,7 @@ export interface SavingsPlansPurchaseRecommendationMetadata {
 
 export namespace SavingsPlansPurchaseRecommendationMetadata {
   export function isa(o: any): o is SavingsPlansPurchaseRecommendationMetadata {
-    return _smithy.isa(o, "SavingsPlansPurchaseRecommendationMetadata");
+    return __isa(o, "SavingsPlansPurchaseRecommendationMetadata");
   }
 }
 
@@ -3733,7 +3736,7 @@ export interface SavingsPlansPurchaseRecommendationSummary {
 
 export namespace SavingsPlansPurchaseRecommendationSummary {
   export function isa(o: any): o is SavingsPlansPurchaseRecommendationSummary {
-    return _smithy.isa(o, "SavingsPlansPurchaseRecommendationSummary");
+    return __isa(o, "SavingsPlansPurchaseRecommendationSummary");
   }
 }
 
@@ -3757,7 +3760,7 @@ export interface SavingsPlansSavings {
 
 export namespace SavingsPlansSavings {
   export function isa(o: any): o is SavingsPlansSavings {
-    return _smithy.isa(o, "SavingsPlansSavings");
+    return __isa(o, "SavingsPlansSavings");
   }
 }
 
@@ -3789,7 +3792,7 @@ export interface SavingsPlansUtilization {
 
 export namespace SavingsPlansUtilization {
   export function isa(o: any): o is SavingsPlansUtilization {
-    return _smithy.isa(o, "SavingsPlansUtilization");
+    return __isa(o, "SavingsPlansUtilization");
   }
 }
 
@@ -3816,7 +3819,7 @@ export interface SavingsPlansUtilizationAggregates {
 
 export namespace SavingsPlansUtilizationAggregates {
   export function isa(o: any): o is SavingsPlansUtilizationAggregates {
-    return _smithy.isa(o, "SavingsPlansUtilizationAggregates");
+    return __isa(o, "SavingsPlansUtilizationAggregates");
   }
 }
 
@@ -3849,7 +3852,7 @@ export interface SavingsPlansUtilizationByTime {
 
 export namespace SavingsPlansUtilizationByTime {
   export function isa(o: any): o is SavingsPlansUtilizationByTime {
-    return _smithy.isa(o, "SavingsPlansUtilizationByTime");
+    return __isa(o, "SavingsPlansUtilizationByTime");
   }
 }
 
@@ -3886,7 +3889,7 @@ export interface SavingsPlansUtilizationDetail {
 
 export namespace SavingsPlansUtilizationDetail {
   export function isa(o: any): o is SavingsPlansUtilizationDetail {
-    return _smithy.isa(o, "SavingsPlansUtilizationDetail");
+    return __isa(o, "SavingsPlansUtilizationDetail");
   }
 }
 
@@ -3896,7 +3899,7 @@ export namespace SavingsPlansUtilizationDetail {
  *         </p>
  */
 export interface ServiceQuotaExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ServiceQuotaExceededException";
   $fault: "client";
@@ -3905,7 +3908,7 @@ export interface ServiceQuotaExceededException
 
 export namespace ServiceQuotaExceededException {
   export function isa(o: any): o is ServiceQuotaExceededException {
-    return _smithy.isa(o, "ServiceQuotaExceededException");
+    return __isa(o, "ServiceQuotaExceededException");
   }
 }
 
@@ -3924,7 +3927,7 @@ export interface ServiceSpecification {
 
 export namespace ServiceSpecification {
   export function isa(o: any): o is ServiceSpecification {
-    return _smithy.isa(o, "ServiceSpecification");
+    return __isa(o, "ServiceSpecification");
   }
 }
 
@@ -3951,7 +3954,7 @@ export interface TagValues {
 
 export namespace TagValues {
   export function isa(o: any): o is TagValues {
-    return _smithy.isa(o, "TagValues");
+    return __isa(o, "TagValues");
   }
 }
 
@@ -3993,7 +3996,7 @@ export interface TargetInstance {
 
 export namespace TargetInstance {
   export function isa(o: any): o is TargetInstance {
-    return _smithy.isa(o, "TargetInstance");
+    return __isa(o, "TargetInstance");
   }
 }
 
@@ -4020,7 +4023,7 @@ export interface TerminateRecommendationDetail {
 
 export namespace TerminateRecommendationDetail {
   export function isa(o: any): o is TerminateRecommendationDetail {
-    return _smithy.isa(o, "TerminateRecommendationDetail");
+    return __isa(o, "TerminateRecommendationDetail");
   }
 }
 
@@ -4028,7 +4031,7 @@ export namespace TerminateRecommendationDetail {
  * <p>Cost Explorer was unable to identify the usage unit. Provide <code>UsageType/UsageTypeGroup</code> filter selections that contain matching units, for example: <code>hours</code>.</p>
  */
 export interface UnresolvableUsageUnitException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UnresolvableUsageUnitException";
   $fault: "client";
@@ -4037,7 +4040,7 @@ export interface UnresolvableUsageUnitException
 
 export namespace UnresolvableUsageUnitException {
   export function isa(o: any): o is UnresolvableUsageUnitException {
-    return _smithy.isa(o, "UnresolvableUsageUnitException");
+    return __isa(o, "UnresolvableUsageUnitException");
   }
 }
 
@@ -4065,7 +4068,7 @@ export interface UpdateCostCategoryDefinitionRequest {
 
 export namespace UpdateCostCategoryDefinitionRequest {
   export function isa(o: any): o is UpdateCostCategoryDefinitionRequest {
-    return _smithy.isa(o, "UpdateCostCategoryDefinitionRequest");
+    return __isa(o, "UpdateCostCategoryDefinitionRequest");
   }
 }
 
@@ -4088,7 +4091,7 @@ export interface UpdateCostCategoryDefinitionResponse extends $MetadataBearer {
 
 export namespace UpdateCostCategoryDefinitionResponse {
   export function isa(o: any): o is UpdateCostCategoryDefinitionResponse {
-    return _smithy.isa(o, "UpdateCostCategoryDefinitionResponse");
+    return __isa(o, "UpdateCostCategoryDefinitionResponse");
   }
 }
 
@@ -4115,6 +4118,6 @@ export interface UtilizationByTime {
 
 export namespace UtilizationByTime {
   export function isa(o: any): o is UtilizationByTime {
-    return _smithy.isa(o, "UtilizationByTime");
+    return __isa(o, "UtilizationByTime");
   }
 }

--- a/clients/client-data-pipeline/models/index.ts
+++ b/clients/client-data-pipeline/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -24,7 +27,7 @@ export interface ActivatePipelineInput {
 
 export namespace ActivatePipelineInput {
   export function isa(o: any): o is ActivatePipelineInput {
-    return _smithy.isa(o, "ActivatePipelineInput");
+    return __isa(o, "ActivatePipelineInput");
   }
 }
 
@@ -37,7 +40,7 @@ export interface ActivatePipelineOutput extends $MetadataBearer {
 
 export namespace ActivatePipelineOutput {
   export function isa(o: any): o is ActivatePipelineOutput {
-    return _smithy.isa(o, "ActivatePipelineOutput");
+    return __isa(o, "ActivatePipelineOutput");
   }
 }
 
@@ -59,7 +62,7 @@ export interface AddTagsInput {
 
 export namespace AddTagsInput {
   export function isa(o: any): o is AddTagsInput {
-    return _smithy.isa(o, "AddTagsInput");
+    return __isa(o, "AddTagsInput");
   }
 }
 
@@ -72,7 +75,7 @@ export interface AddTagsOutput extends $MetadataBearer {
 
 export namespace AddTagsOutput {
   export function isa(o: any): o is AddTagsOutput {
-    return _smithy.isa(o, "AddTagsOutput");
+    return __isa(o, "AddTagsOutput");
   }
 }
 
@@ -113,7 +116,7 @@ export interface CreatePipelineInput {
 
 export namespace CreatePipelineInput {
   export function isa(o: any): o is CreatePipelineInput {
-    return _smithy.isa(o, "CreatePipelineInput");
+    return __isa(o, "CreatePipelineInput");
   }
 }
 
@@ -130,7 +133,7 @@ export interface CreatePipelineOutput extends $MetadataBearer {
 
 export namespace CreatePipelineOutput {
   export function isa(o: any): o is CreatePipelineOutput {
-    return _smithy.isa(o, "CreatePipelineOutput");
+    return __isa(o, "CreatePipelineOutput");
   }
 }
 
@@ -155,7 +158,7 @@ export interface DeactivatePipelineInput {
 
 export namespace DeactivatePipelineInput {
   export function isa(o: any): o is DeactivatePipelineInput {
-    return _smithy.isa(o, "DeactivatePipelineInput");
+    return __isa(o, "DeactivatePipelineInput");
   }
 }
 
@@ -168,7 +171,7 @@ export interface DeactivatePipelineOutput extends $MetadataBearer {
 
 export namespace DeactivatePipelineOutput {
   export function isa(o: any): o is DeactivatePipelineOutput {
-    return _smithy.isa(o, "DeactivatePipelineOutput");
+    return __isa(o, "DeactivatePipelineOutput");
   }
 }
 
@@ -185,7 +188,7 @@ export interface DeletePipelineInput {
 
 export namespace DeletePipelineInput {
   export function isa(o: any): o is DeletePipelineInput {
-    return _smithy.isa(o, "DeletePipelineInput");
+    return __isa(o, "DeletePipelineInput");
   }
 }
 
@@ -219,7 +222,7 @@ export interface DescribeObjectsInput {
 
 export namespace DescribeObjectsInput {
   export function isa(o: any): o is DescribeObjectsInput {
-    return _smithy.isa(o, "DescribeObjectsInput");
+    return __isa(o, "DescribeObjectsInput");
   }
 }
 
@@ -247,7 +250,7 @@ export interface DescribeObjectsOutput extends $MetadataBearer {
 
 export namespace DescribeObjectsOutput {
   export function isa(o: any): o is DescribeObjectsOutput {
-    return _smithy.isa(o, "DescribeObjectsOutput");
+    return __isa(o, "DescribeObjectsOutput");
   }
 }
 
@@ -265,7 +268,7 @@ export interface DescribePipelinesInput {
 
 export namespace DescribePipelinesInput {
   export function isa(o: any): o is DescribePipelinesInput {
-    return _smithy.isa(o, "DescribePipelinesInput");
+    return __isa(o, "DescribePipelinesInput");
   }
 }
 
@@ -282,7 +285,7 @@ export interface DescribePipelinesOutput extends $MetadataBearer {
 
 export namespace DescribePipelinesOutput {
   export function isa(o: any): o is DescribePipelinesOutput {
-    return _smithy.isa(o, "DescribePipelinesOutput");
+    return __isa(o, "DescribePipelinesOutput");
   }
 }
 
@@ -309,7 +312,7 @@ export interface EvaluateExpressionInput {
 
 export namespace EvaluateExpressionInput {
   export function isa(o: any): o is EvaluateExpressionInput {
-    return _smithy.isa(o, "EvaluateExpressionInput");
+    return __isa(o, "EvaluateExpressionInput");
   }
 }
 
@@ -326,7 +329,7 @@ export interface EvaluateExpressionOutput extends $MetadataBearer {
 
 export namespace EvaluateExpressionOutput {
   export function isa(o: any): o is EvaluateExpressionOutput {
-    return _smithy.isa(o, "EvaluateExpressionOutput");
+    return __isa(o, "EvaluateExpressionOutput");
   }
 }
 
@@ -353,7 +356,7 @@ export interface Field {
 
 export namespace Field {
   export function isa(o: any): o is Field {
-    return _smithy.isa(o, "Field");
+    return __isa(o, "Field");
   }
 }
 
@@ -377,7 +380,7 @@ export interface GetPipelineDefinitionInput {
 
 export namespace GetPipelineDefinitionInput {
   export function isa(o: any): o is GetPipelineDefinitionInput {
-    return _smithy.isa(o, "GetPipelineDefinitionInput");
+    return __isa(o, "GetPipelineDefinitionInput");
   }
 }
 
@@ -404,7 +407,7 @@ export interface GetPipelineDefinitionOutput extends $MetadataBearer {
 
 export namespace GetPipelineDefinitionOutput {
   export function isa(o: any): o is GetPipelineDefinitionOutput {
-    return _smithy.isa(o, "GetPipelineDefinitionOutput");
+    return __isa(o, "GetPipelineDefinitionOutput");
   }
 }
 
@@ -428,7 +431,7 @@ export interface InstanceIdentity {
 
 export namespace InstanceIdentity {
   export function isa(o: any): o is InstanceIdentity {
-    return _smithy.isa(o, "InstanceIdentity");
+    return __isa(o, "InstanceIdentity");
   }
 }
 
@@ -436,7 +439,7 @@ export namespace InstanceIdentity {
  * <p>An internal service error occurred.</p>
  */
 export interface InternalServiceError
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalServiceError";
   $fault: "server";
@@ -448,7 +451,7 @@ export interface InternalServiceError
 
 export namespace InternalServiceError {
   export function isa(o: any): o is InternalServiceError {
-    return _smithy.isa(o, "InternalServiceError");
+    return __isa(o, "InternalServiceError");
   }
 }
 
@@ -456,7 +459,7 @@ export namespace InternalServiceError {
  * <p>The request was not valid. Verify that your request was properly formatted, that the signature was generated with the correct credentials, and that you haven't exceeded any of the service limits for your account.</p>
  */
 export interface InvalidRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidRequestException";
   $fault: "client";
@@ -468,7 +471,7 @@ export interface InvalidRequestException
 
 export namespace InvalidRequestException {
   export function isa(o: any): o is InvalidRequestException {
-    return _smithy.isa(o, "InvalidRequestException");
+    return __isa(o, "InvalidRequestException");
   }
 }
 
@@ -487,7 +490,7 @@ export interface ListPipelinesInput {
 
 export namespace ListPipelinesInput {
   export function isa(o: any): o is ListPipelinesInput {
-    return _smithy.isa(o, "ListPipelinesInput");
+    return __isa(o, "ListPipelinesInput");
   }
 }
 
@@ -516,7 +519,7 @@ export interface ListPipelinesOutput extends $MetadataBearer {
 
 export namespace ListPipelinesOutput {
   export function isa(o: any): o is ListPipelinesOutput {
-    return _smithy.isa(o, "ListPipelinesOutput");
+    return __isa(o, "ListPipelinesOutput");
   }
 }
 
@@ -592,7 +595,7 @@ export interface Operator {
 
 export namespace Operator {
   export function isa(o: any): o is Operator {
-    return _smithy.isa(o, "Operator");
+    return __isa(o, "Operator");
   }
 }
 
@@ -622,7 +625,7 @@ export interface ParameterAttribute {
 
 export namespace ParameterAttribute {
   export function isa(o: any): o is ParameterAttribute {
-    return _smithy.isa(o, "ParameterAttribute");
+    return __isa(o, "ParameterAttribute");
   }
 }
 
@@ -644,7 +647,7 @@ export interface ParameterObject {
 
 export namespace ParameterObject {
   export function isa(o: any): o is ParameterObject {
-    return _smithy.isa(o, "ParameterObject");
+    return __isa(o, "ParameterObject");
   }
 }
 
@@ -666,7 +669,7 @@ export interface ParameterValue {
 
 export namespace ParameterValue {
   export function isa(o: any): o is ParameterValue {
-    return _smithy.isa(o, "ParameterValue");
+    return __isa(o, "ParameterValue");
   }
 }
 
@@ -674,7 +677,7 @@ export namespace ParameterValue {
  * <p>The specified pipeline has been deleted.</p>
  */
 export interface PipelineDeletedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "PipelineDeletedException";
   $fault: "client";
@@ -686,7 +689,7 @@ export interface PipelineDeletedException
 
 export namespace PipelineDeletedException {
   export function isa(o: any): o is PipelineDeletedException {
-    return _smithy.isa(o, "PipelineDeletedException");
+    return __isa(o, "PipelineDeletedException");
   }
 }
 
@@ -724,7 +727,7 @@ export interface PipelineDescription {
 
 export namespace PipelineDescription {
   export function isa(o: any): o is PipelineDescription {
-    return _smithy.isa(o, "PipelineDescription");
+    return __isa(o, "PipelineDescription");
   }
 }
 
@@ -746,7 +749,7 @@ export interface PipelineIdName {
 
 export namespace PipelineIdName {
   export function isa(o: any): o is PipelineIdName {
-    return _smithy.isa(o, "PipelineIdName");
+    return __isa(o, "PipelineIdName");
   }
 }
 
@@ -754,7 +757,7 @@ export namespace PipelineIdName {
  * <p>The specified pipeline was not found. Verify that you used the correct user and account identifiers.</p>
  */
 export interface PipelineNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "PipelineNotFoundException";
   $fault: "client";
@@ -766,7 +769,7 @@ export interface PipelineNotFoundException
 
 export namespace PipelineNotFoundException {
   export function isa(o: any): o is PipelineNotFoundException {
-    return _smithy.isa(o, "PipelineNotFoundException");
+    return __isa(o, "PipelineNotFoundException");
   }
 }
 
@@ -793,7 +796,7 @@ export interface PipelineObject {
 
 export namespace PipelineObject {
   export function isa(o: any): o is PipelineObject {
-    return _smithy.isa(o, "PipelineObject");
+    return __isa(o, "PipelineObject");
   }
 }
 
@@ -822,7 +825,7 @@ export interface PollForTaskInput {
 
 export namespace PollForTaskInput {
   export function isa(o: any): o is PollForTaskInput {
-    return _smithy.isa(o, "PollForTaskInput");
+    return __isa(o, "PollForTaskInput");
   }
 }
 
@@ -841,7 +844,7 @@ export interface PollForTaskOutput extends $MetadataBearer {
 
 export namespace PollForTaskOutput {
   export function isa(o: any): o is PollForTaskOutput {
-    return _smithy.isa(o, "PollForTaskOutput");
+    return __isa(o, "PollForTaskOutput");
   }
 }
 
@@ -873,7 +876,7 @@ export interface PutPipelineDefinitionInput {
 
 export namespace PutPipelineDefinitionInput {
   export function isa(o: any): o is PutPipelineDefinitionInput {
-    return _smithy.isa(o, "PutPipelineDefinitionInput");
+    return __isa(o, "PutPipelineDefinitionInput");
   }
 }
 
@@ -901,7 +904,7 @@ export interface PutPipelineDefinitionOutput extends $MetadataBearer {
 
 export namespace PutPipelineDefinitionOutput {
   export function isa(o: any): o is PutPipelineDefinitionOutput {
-    return _smithy.isa(o, "PutPipelineDefinitionOutput");
+    return __isa(o, "PutPipelineDefinitionOutput");
   }
 }
 
@@ -918,7 +921,7 @@ export interface Query {
 
 export namespace Query {
   export function isa(o: any): o is Query {
-    return _smithy.isa(o, "Query");
+    return __isa(o, "Query");
   }
 }
 
@@ -960,7 +963,7 @@ export interface QueryObjectsInput {
 
 export namespace QueryObjectsInput {
   export function isa(o: any): o is QueryObjectsInput {
-    return _smithy.isa(o, "QueryObjectsInput");
+    return __isa(o, "QueryObjectsInput");
   }
 }
 
@@ -988,7 +991,7 @@ export interface QueryObjectsOutput extends $MetadataBearer {
 
 export namespace QueryObjectsOutput {
   export function isa(o: any): o is QueryObjectsOutput {
-    return _smithy.isa(o, "QueryObjectsOutput");
+    return __isa(o, "QueryObjectsOutput");
   }
 }
 
@@ -1010,7 +1013,7 @@ export interface RemoveTagsInput {
 
 export namespace RemoveTagsInput {
   export function isa(o: any): o is RemoveTagsInput {
-    return _smithy.isa(o, "RemoveTagsInput");
+    return __isa(o, "RemoveTagsInput");
   }
 }
 
@@ -1023,7 +1026,7 @@ export interface RemoveTagsOutput extends $MetadataBearer {
 
 export namespace RemoveTagsOutput {
   export function isa(o: any): o is RemoveTagsOutput {
-    return _smithy.isa(o, "RemoveTagsOutput");
+    return __isa(o, "RemoveTagsOutput");
   }
 }
 
@@ -1045,7 +1048,7 @@ export interface ReportTaskProgressInput {
 
 export namespace ReportTaskProgressInput {
   export function isa(o: any): o is ReportTaskProgressInput {
-    return _smithy.isa(o, "ReportTaskProgressInput");
+    return __isa(o, "ReportTaskProgressInput");
   }
 }
 
@@ -1062,7 +1065,7 @@ export interface ReportTaskProgressOutput extends $MetadataBearer {
 
 export namespace ReportTaskProgressOutput {
   export function isa(o: any): o is ReportTaskProgressOutput {
-    return _smithy.isa(o, "ReportTaskProgressOutput");
+    return __isa(o, "ReportTaskProgressOutput");
   }
 }
 
@@ -1091,7 +1094,7 @@ export interface ReportTaskRunnerHeartbeatInput {
 
 export namespace ReportTaskRunnerHeartbeatInput {
   export function isa(o: any): o is ReportTaskRunnerHeartbeatInput {
-    return _smithy.isa(o, "ReportTaskRunnerHeartbeatInput");
+    return __isa(o, "ReportTaskRunnerHeartbeatInput");
   }
 }
 
@@ -1108,7 +1111,7 @@ export interface ReportTaskRunnerHeartbeatOutput extends $MetadataBearer {
 
 export namespace ReportTaskRunnerHeartbeatOutput {
   export function isa(o: any): o is ReportTaskRunnerHeartbeatOutput {
-    return _smithy.isa(o, "ReportTaskRunnerHeartbeatOutput");
+    return __isa(o, "ReportTaskRunnerHeartbeatOutput");
   }
 }
 
@@ -1130,7 +1133,7 @@ export interface Selector {
 
 export namespace Selector {
   export function isa(o: any): o is Selector {
-    return _smithy.isa(o, "Selector");
+    return __isa(o, "Selector");
   }
 }
 
@@ -1158,7 +1161,7 @@ export interface SetStatusInput {
 
 export namespace SetStatusInput {
   export function isa(o: any): o is SetStatusInput {
-    return _smithy.isa(o, "SetStatusInput");
+    return __isa(o, "SetStatusInput");
   }
 }
 
@@ -1195,7 +1198,7 @@ export interface SetTaskStatusInput {
 
 export namespace SetTaskStatusInput {
   export function isa(o: any): o is SetTaskStatusInput {
-    return _smithy.isa(o, "SetTaskStatusInput");
+    return __isa(o, "SetTaskStatusInput");
   }
 }
 
@@ -1208,7 +1211,7 @@ export interface SetTaskStatusOutput extends $MetadataBearer {
 
 export namespace SetTaskStatusOutput {
   export function isa(o: any): o is SetTaskStatusOutput {
-    return _smithy.isa(o, "SetTaskStatusOutput");
+    return __isa(o, "SetTaskStatusOutput");
   }
 }
 
@@ -1233,7 +1236,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -1241,7 +1244,7 @@ export namespace Tag {
  * <p>The specified task was not found.</p>
  */
 export interface TaskNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TaskNotFoundException";
   $fault: "client";
@@ -1253,7 +1256,7 @@ export interface TaskNotFoundException
 
 export namespace TaskNotFoundException {
   export function isa(o: any): o is TaskNotFoundException {
-    return _smithy.isa(o, "TaskNotFoundException");
+    return __isa(o, "TaskNotFoundException");
   }
 }
 
@@ -1285,7 +1288,7 @@ export interface TaskObject {
 
 export namespace TaskObject {
   export function isa(o: any): o is TaskObject {
-    return _smithy.isa(o, "TaskObject");
+    return __isa(o, "TaskObject");
   }
 }
 
@@ -1323,7 +1326,7 @@ export interface ValidatePipelineDefinitionInput {
 
 export namespace ValidatePipelineDefinitionInput {
   export function isa(o: any): o is ValidatePipelineDefinitionInput {
-    return _smithy.isa(o, "ValidatePipelineDefinitionInput");
+    return __isa(o, "ValidatePipelineDefinitionInput");
   }
 }
 
@@ -1350,7 +1353,7 @@ export interface ValidatePipelineDefinitionOutput extends $MetadataBearer {
 
 export namespace ValidatePipelineDefinitionOutput {
   export function isa(o: any): o is ValidatePipelineDefinitionOutput {
-    return _smithy.isa(o, "ValidatePipelineDefinitionOutput");
+    return __isa(o, "ValidatePipelineDefinitionOutput");
   }
 }
 
@@ -1372,7 +1375,7 @@ export interface ValidationError {
 
 export namespace ValidationError {
   export function isa(o: any): o is ValidationError {
-    return _smithy.isa(o, "ValidationError");
+    return __isa(o, "ValidationError");
   }
 }
 
@@ -1394,6 +1397,6 @@ export interface ValidationWarning {
 
 export namespace ValidationWarning {
   export function isa(o: any): o is ValidationWarning {
-    return _smithy.isa(o, "ValidationWarning");
+    return __isa(o, "ValidationWarning");
   }
 }

--- a/clients/client-data-pipeline/protocols/Aws_json1_1.ts
+++ b/clients/client-data-pipeline/protocols/Aws_json1_1.ts
@@ -701,6 +701,7 @@ export async function deserializeAws_json1_1DeletePipelineCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1DeletePipelineCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeletePipelineCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1610,6 +1611,7 @@ export async function deserializeAws_json1_1SetStatusCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1SetStatusCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: SetStatusCommandOutput = {
     $metadata: deserializeMetadata(output)
   };

--- a/clients/client-database-migration-service/models/index.ts
+++ b/clients/client-database-migration-service/models/index.ts
@@ -1,13 +1,14 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
  * <p>AWS DMS was denied access to the endpoint. Check that the
  *             role is correctly configured.</p>
  */
-export interface AccessDeniedFault
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface AccessDeniedFault extends __SmithyException, $MetadataBearer {
   name: "AccessDeniedFault";
   $fault: "client";
   /**
@@ -18,7 +19,7 @@ export interface AccessDeniedFault
 
 export namespace AccessDeniedFault {
   export function isa(o: any): o is AccessDeniedFault {
-    return _smithy.isa(o, "AccessDeniedFault");
+    return __isa(o, "AccessDeniedFault");
   }
 }
 
@@ -26,7 +27,7 @@ export namespace AccessDeniedFault {
  * <p>There are not enough resources allocated to the database migration.</p>
  */
 export interface InsufficientResourceCapacityFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InsufficientResourceCapacityFault";
   $fault: "client";
@@ -38,7 +39,7 @@ export interface InsufficientResourceCapacityFault
 
 export namespace InsufficientResourceCapacityFault {
   export function isa(o: any): o is InsufficientResourceCapacityFault {
-    return _smithy.isa(o, "InsufficientResourceCapacityFault");
+    return __isa(o, "InsufficientResourceCapacityFault");
   }
 }
 
@@ -46,7 +47,7 @@ export namespace InsufficientResourceCapacityFault {
  * <p>The certificate was not valid.</p>
  */
 export interface InvalidCertificateFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidCertificateFault";
   $fault: "client";
@@ -55,7 +56,7 @@ export interface InvalidCertificateFault
 
 export namespace InvalidCertificateFault {
   export function isa(o: any): o is InvalidCertificateFault {
-    return _smithy.isa(o, "InvalidCertificateFault");
+    return __isa(o, "InvalidCertificateFault");
   }
 }
 
@@ -63,7 +64,7 @@ export namespace InvalidCertificateFault {
  * <p>The resource is in a state that prevents it from being used for database migration.</p>
  */
 export interface InvalidResourceStateFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidResourceStateFault";
   $fault: "client";
@@ -75,16 +76,14 @@ export interface InvalidResourceStateFault
 
 export namespace InvalidResourceStateFault {
   export function isa(o: any): o is InvalidResourceStateFault {
-    return _smithy.isa(o, "InvalidResourceStateFault");
+    return __isa(o, "InvalidResourceStateFault");
   }
 }
 
 /**
  * <p>The subnet provided is invalid.</p>
  */
-export interface InvalidSubnet
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface InvalidSubnet extends __SmithyException, $MetadataBearer {
   name: "InvalidSubnet";
   $fault: "client";
   /**
@@ -95,7 +94,7 @@ export interface InvalidSubnet
 
 export namespace InvalidSubnet {
   export function isa(o: any): o is InvalidSubnet {
-    return _smithy.isa(o, "InvalidSubnet");
+    return __isa(o, "InvalidSubnet");
   }
 }
 
@@ -103,7 +102,7 @@ export namespace InvalidSubnet {
  * <p>The ciphertext references a key that doesn't exist or that the DMS account doesn't have access to.</p>
  */
 export interface KMSAccessDeniedFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "KMSAccessDeniedFault";
   $fault: "client";
@@ -112,16 +111,14 @@ export interface KMSAccessDeniedFault
 
 export namespace KMSAccessDeniedFault {
   export function isa(o: any): o is KMSAccessDeniedFault {
-    return _smithy.isa(o, "KMSAccessDeniedFault");
+    return __isa(o, "KMSAccessDeniedFault");
   }
 }
 
 /**
  * <p>The specified master key (CMK) isn't enabled.</p>
  */
-export interface KMSDisabledFault
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface KMSDisabledFault extends __SmithyException, $MetadataBearer {
   name: "KMSDisabledFault";
   $fault: "client";
   message?: string;
@@ -129,7 +126,7 @@ export interface KMSDisabledFault
 
 export namespace KMSDisabledFault {
   export function isa(o: any): o is KMSDisabledFault {
-    return _smithy.isa(o, "KMSDisabledFault");
+    return __isa(o, "KMSDisabledFault");
   }
 }
 
@@ -137,7 +134,7 @@ export namespace KMSDisabledFault {
  * <p>The state of the specified AWS KMS resource isn't valid for this request.</p>
  */
 export interface KMSInvalidStateFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "KMSInvalidStateFault";
   $fault: "client";
@@ -146,7 +143,7 @@ export interface KMSInvalidStateFault
 
 export namespace KMSInvalidStateFault {
   export function isa(o: any): o is KMSInvalidStateFault {
-    return _smithy.isa(o, "KMSInvalidStateFault");
+    return __isa(o, "KMSInvalidStateFault");
   }
 }
 
@@ -154,7 +151,7 @@ export namespace KMSInvalidStateFault {
  * <p>AWS DMS cannot access the AWS KMS key.</p>
  */
 export interface KMSKeyNotAccessibleFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "KMSKeyNotAccessibleFault";
   $fault: "client";
@@ -166,16 +163,14 @@ export interface KMSKeyNotAccessibleFault
 
 export namespace KMSKeyNotAccessibleFault {
   export function isa(o: any): o is KMSKeyNotAccessibleFault {
-    return _smithy.isa(o, "KMSKeyNotAccessibleFault");
+    return __isa(o, "KMSKeyNotAccessibleFault");
   }
 }
 
 /**
  * <p>The specified AWS KMS entity or resource can't be found.</p>
  */
-export interface KMSNotFoundFault
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface KMSNotFoundFault extends __SmithyException, $MetadataBearer {
   name: "KMSNotFoundFault";
   $fault: "client";
   message?: string;
@@ -183,16 +178,14 @@ export interface KMSNotFoundFault
 
 export namespace KMSNotFoundFault {
   export function isa(o: any): o is KMSNotFoundFault {
-    return _smithy.isa(o, "KMSNotFoundFault");
+    return __isa(o, "KMSNotFoundFault");
   }
 }
 
 /**
  * <p>This request triggered AWS KMS request throttling.</p>
  */
-export interface KMSThrottlingFault
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface KMSThrottlingFault extends __SmithyException, $MetadataBearer {
   name: "KMSThrottlingFault";
   $fault: "client";
   message?: string;
@@ -200,7 +193,7 @@ export interface KMSThrottlingFault
 
 export namespace KMSThrottlingFault {
   export function isa(o: any): o is KMSThrottlingFault {
-    return _smithy.isa(o, "KMSThrottlingFault");
+    return __isa(o, "KMSThrottlingFault");
   }
 }
 
@@ -208,7 +201,7 @@ export namespace KMSThrottlingFault {
  * <p>The replication subnet group does not cover enough Availability Zones (AZs). Edit the replication subnet group and add more AZs.</p>
  */
 export interface ReplicationSubnetGroupDoesNotCoverEnoughAZs
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ReplicationSubnetGroupDoesNotCoverEnoughAZs";
   $fault: "client";
@@ -222,7 +215,7 @@ export namespace ReplicationSubnetGroupDoesNotCoverEnoughAZs {
   export function isa(
     o: any
   ): o is ReplicationSubnetGroupDoesNotCoverEnoughAZs {
-    return _smithy.isa(o, "ReplicationSubnetGroupDoesNotCoverEnoughAZs");
+    return __isa(o, "ReplicationSubnetGroupDoesNotCoverEnoughAZs");
   }
 }
 
@@ -230,7 +223,7 @@ export namespace ReplicationSubnetGroupDoesNotCoverEnoughAZs {
  * <p>The resource you are attempting to create already exists.</p>
  */
 export interface ResourceAlreadyExistsFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceAlreadyExistsFault";
   $fault: "client";
@@ -244,7 +237,7 @@ export interface ResourceAlreadyExistsFault
 
 export namespace ResourceAlreadyExistsFault {
   export function isa(o: any): o is ResourceAlreadyExistsFault {
-    return _smithy.isa(o, "ResourceAlreadyExistsFault");
+    return __isa(o, "ResourceAlreadyExistsFault");
   }
 }
 
@@ -252,7 +245,7 @@ export namespace ResourceAlreadyExistsFault {
  * <p>The resource could not be found.</p>
  */
 export interface ResourceNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundFault";
   $fault: "client";
@@ -264,7 +257,7 @@ export interface ResourceNotFoundFault
 
 export namespace ResourceNotFoundFault {
   export function isa(o: any): o is ResourceNotFoundFault {
-    return _smithy.isa(o, "ResourceNotFoundFault");
+    return __isa(o, "ResourceNotFoundFault");
   }
 }
 
@@ -272,7 +265,7 @@ export namespace ResourceNotFoundFault {
  * <p>The quota for this resource quota has been exceeded.</p>
  */
 export interface ResourceQuotaExceededFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceQuotaExceededFault";
   $fault: "client";
@@ -284,7 +277,7 @@ export interface ResourceQuotaExceededFault
 
 export namespace ResourceQuotaExceededFault {
   export function isa(o: any): o is ResourceQuotaExceededFault {
-    return _smithy.isa(o, "ResourceQuotaExceededFault");
+    return __isa(o, "ResourceQuotaExceededFault");
   }
 }
 
@@ -292,7 +285,7 @@ export namespace ResourceQuotaExceededFault {
  * <p>The SNS topic is invalid.</p>
  */
 export interface SNSInvalidTopicFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "SNSInvalidTopicFault";
   $fault: "client";
@@ -304,7 +297,7 @@ export interface SNSInvalidTopicFault
 
 export namespace SNSInvalidTopicFault {
   export function isa(o: any): o is SNSInvalidTopicFault {
-    return _smithy.isa(o, "SNSInvalidTopicFault");
+    return __isa(o, "SNSInvalidTopicFault");
   }
 }
 
@@ -312,7 +305,7 @@ export namespace SNSInvalidTopicFault {
  * <p>You are not authorized for the SNS subscription.</p>
  */
 export interface SNSNoAuthorizationFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "SNSNoAuthorizationFault";
   $fault: "client";
@@ -324,7 +317,7 @@ export interface SNSNoAuthorizationFault
 
 export namespace SNSNoAuthorizationFault {
   export function isa(o: any): o is SNSNoAuthorizationFault {
-    return _smithy.isa(o, "SNSNoAuthorizationFault");
+    return __isa(o, "SNSNoAuthorizationFault");
   }
 }
 
@@ -332,7 +325,7 @@ export namespace SNSNoAuthorizationFault {
  * <p>The storage quota has been exceeded.</p>
  */
 export interface StorageQuotaExceededFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "StorageQuotaExceededFault";
   $fault: "client";
@@ -344,16 +337,14 @@ export interface StorageQuotaExceededFault
 
 export namespace StorageQuotaExceededFault {
   export function isa(o: any): o is StorageQuotaExceededFault {
-    return _smithy.isa(o, "StorageQuotaExceededFault");
+    return __isa(o, "StorageQuotaExceededFault");
   }
 }
 
 /**
  * <p>The specified subnet is already in use.</p>
  */
-export interface SubnetAlreadyInUse
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface SubnetAlreadyInUse extends __SmithyException, $MetadataBearer {
   name: "SubnetAlreadyInUse";
   $fault: "client";
   /**
@@ -364,7 +355,7 @@ export interface SubnetAlreadyInUse
 
 export namespace SubnetAlreadyInUse {
   export function isa(o: any): o is SubnetAlreadyInUse {
-    return _smithy.isa(o, "SubnetAlreadyInUse");
+    return __isa(o, "SubnetAlreadyInUse");
   }
 }
 
@@ -372,7 +363,7 @@ export namespace SubnetAlreadyInUse {
  * <p>An upgrade dependency is preventing the database migration.</p>
  */
 export interface UpgradeDependencyFailureFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UpgradeDependencyFailureFault";
   $fault: "client";
@@ -384,7 +375,7 @@ export interface UpgradeDependencyFailureFault
 
 export namespace UpgradeDependencyFailureFault {
   export function isa(o: any): o is UpgradeDependencyFailureFault {
-    return _smithy.isa(o, "UpgradeDependencyFailureFault");
+    return __isa(o, "UpgradeDependencyFailureFault");
   }
 }
 
@@ -412,7 +403,7 @@ export interface AccountQuota {
 
 export namespace AccountQuota {
   export function isa(o: any): o is AccountQuota {
-    return _smithy.isa(o, "AccountQuota");
+    return __isa(o, "AccountQuota");
   }
 }
 
@@ -435,7 +426,7 @@ export interface AddTagsToResourceMessage {
 
 export namespace AddTagsToResourceMessage {
   export function isa(o: any): o is AddTagsToResourceMessage {
-    return _smithy.isa(o, "AddTagsToResourceMessage");
+    return __isa(o, "AddTagsToResourceMessage");
   }
 }
 
@@ -448,7 +439,7 @@ export interface AddTagsToResourceResponse extends $MetadataBearer {
 
 export namespace AddTagsToResourceResponse {
   export function isa(o: any): o is AddTagsToResourceResponse {
-    return _smithy.isa(o, "AddTagsToResourceResponse");
+    return __isa(o, "AddTagsToResourceResponse");
   }
 }
 
@@ -494,7 +485,7 @@ export interface ApplyPendingMaintenanceActionMessage {
 
 export namespace ApplyPendingMaintenanceActionMessage {
   export function isa(o: any): o is ApplyPendingMaintenanceActionMessage {
-    return _smithy.isa(o, "ApplyPendingMaintenanceActionMessage");
+    return __isa(o, "ApplyPendingMaintenanceActionMessage");
   }
 }
 
@@ -511,7 +502,7 @@ export interface ApplyPendingMaintenanceActionResponse extends $MetadataBearer {
 
 export namespace ApplyPendingMaintenanceActionResponse {
   export function isa(o: any): o is ApplyPendingMaintenanceActionResponse {
-    return _smithy.isa(o, "ApplyPendingMaintenanceActionResponse");
+    return __isa(o, "ApplyPendingMaintenanceActionResponse");
   }
 }
 
@@ -539,7 +530,7 @@ export interface AvailabilityZone {
 
 export namespace AvailabilityZone {
   export function isa(o: any): o is AvailabilityZone {
-    return _smithy.isa(o, "AvailabilityZone");
+    return __isa(o, "AvailabilityZone");
   }
 }
 
@@ -604,7 +595,7 @@ export interface Certificate {
 
 export namespace Certificate {
   export function isa(o: any): o is Certificate {
-    return _smithy.isa(o, "Certificate");
+    return __isa(o, "Certificate");
   }
 }
 
@@ -654,7 +645,7 @@ export interface Connection {
 
 export namespace Connection {
   export function isa(o: any): o is Connection {
-    return _smithy.isa(o, "Connection");
+    return __isa(o, "Connection");
   }
 }
 
@@ -838,7 +829,7 @@ export interface CreateEndpointMessage {
 
 export namespace CreateEndpointMessage {
   export function isa(o: any): o is CreateEndpointMessage {
-    return _smithy.isa(o, "CreateEndpointMessage");
+    return __isa(o, "CreateEndpointMessage");
   }
 }
 
@@ -855,7 +846,7 @@ export interface CreateEndpointResponse extends $MetadataBearer {
 
 export namespace CreateEndpointResponse {
   export function isa(o: any): o is CreateEndpointResponse {
-    return _smithy.isa(o, "CreateEndpointResponse");
+    return __isa(o, "CreateEndpointResponse");
   }
 }
 
@@ -917,7 +908,7 @@ export interface CreateEventSubscriptionMessage {
 
 export namespace CreateEventSubscriptionMessage {
   export function isa(o: any): o is CreateEventSubscriptionMessage {
-    return _smithy.isa(o, "CreateEventSubscriptionMessage");
+    return __isa(o, "CreateEventSubscriptionMessage");
   }
 }
 
@@ -934,7 +925,7 @@ export interface CreateEventSubscriptionResponse extends $MetadataBearer {
 
 export namespace CreateEventSubscriptionResponse {
   export function isa(o: any): o is CreateEventSubscriptionResponse {
-    return _smithy.isa(o, "CreateEventSubscriptionResponse");
+    return __isa(o, "CreateEventSubscriptionResponse");
   }
 }
 
@@ -1060,7 +1051,7 @@ export interface CreateReplicationInstanceMessage {
 
 export namespace CreateReplicationInstanceMessage {
   export function isa(o: any): o is CreateReplicationInstanceMessage {
-    return _smithy.isa(o, "CreateReplicationInstanceMessage");
+    return __isa(o, "CreateReplicationInstanceMessage");
   }
 }
 
@@ -1077,7 +1068,7 @@ export interface CreateReplicationInstanceResponse extends $MetadataBearer {
 
 export namespace CreateReplicationInstanceResponse {
   export function isa(o: any): o is CreateReplicationInstanceResponse {
-    return _smithy.isa(o, "CreateReplicationInstanceResponse");
+    return __isa(o, "CreateReplicationInstanceResponse");
   }
 }
 
@@ -1114,7 +1105,7 @@ export interface CreateReplicationSubnetGroupMessage {
 
 export namespace CreateReplicationSubnetGroupMessage {
   export function isa(o: any): o is CreateReplicationSubnetGroupMessage {
-    return _smithy.isa(o, "CreateReplicationSubnetGroupMessage");
+    return __isa(o, "CreateReplicationSubnetGroupMessage");
   }
 }
 
@@ -1131,7 +1122,7 @@ export interface CreateReplicationSubnetGroupResponse extends $MetadataBearer {
 
 export namespace CreateReplicationSubnetGroupResponse {
   export function isa(o: any): o is CreateReplicationSubnetGroupResponse {
-    return _smithy.isa(o, "CreateReplicationSubnetGroupResponse");
+    return __isa(o, "CreateReplicationSubnetGroupResponse");
   }
 }
 
@@ -1237,7 +1228,7 @@ export interface CreateReplicationTaskMessage {
 
 export namespace CreateReplicationTaskMessage {
   export function isa(o: any): o is CreateReplicationTaskMessage {
-    return _smithy.isa(o, "CreateReplicationTaskMessage");
+    return __isa(o, "CreateReplicationTaskMessage");
   }
 }
 
@@ -1254,7 +1245,7 @@ export interface CreateReplicationTaskResponse extends $MetadataBearer {
 
 export namespace CreateReplicationTaskResponse {
   export function isa(o: any): o is CreateReplicationTaskResponse {
-    return _smithy.isa(o, "CreateReplicationTaskResponse");
+    return __isa(o, "CreateReplicationTaskResponse");
   }
 }
 
@@ -1273,7 +1264,7 @@ export interface DeleteCertificateMessage {
 
 export namespace DeleteCertificateMessage {
   export function isa(o: any): o is DeleteCertificateMessage {
-    return _smithy.isa(o, "DeleteCertificateMessage");
+    return __isa(o, "DeleteCertificateMessage");
   }
 }
 
@@ -1287,7 +1278,7 @@ export interface DeleteCertificateResponse extends $MetadataBearer {
 
 export namespace DeleteCertificateResponse {
   export function isa(o: any): o is DeleteCertificateResponse {
-    return _smithy.isa(o, "DeleteCertificateResponse");
+    return __isa(o, "DeleteCertificateResponse");
   }
 }
 
@@ -1309,7 +1300,7 @@ export interface DeleteConnectionMessage {
 
 export namespace DeleteConnectionMessage {
   export function isa(o: any): o is DeleteConnectionMessage {
-    return _smithy.isa(o, "DeleteConnectionMessage");
+    return __isa(o, "DeleteConnectionMessage");
   }
 }
 
@@ -1326,7 +1317,7 @@ export interface DeleteConnectionResponse extends $MetadataBearer {
 
 export namespace DeleteConnectionResponse {
   export function isa(o: any): o is DeleteConnectionResponse {
-    return _smithy.isa(o, "DeleteConnectionResponse");
+    return __isa(o, "DeleteConnectionResponse");
   }
 }
 
@@ -1343,7 +1334,7 @@ export interface DeleteEndpointMessage {
 
 export namespace DeleteEndpointMessage {
   export function isa(o: any): o is DeleteEndpointMessage {
-    return _smithy.isa(o, "DeleteEndpointMessage");
+    return __isa(o, "DeleteEndpointMessage");
   }
 }
 
@@ -1360,7 +1351,7 @@ export interface DeleteEndpointResponse extends $MetadataBearer {
 
 export namespace DeleteEndpointResponse {
   export function isa(o: any): o is DeleteEndpointResponse {
-    return _smithy.isa(o, "DeleteEndpointResponse");
+    return __isa(o, "DeleteEndpointResponse");
   }
 }
 
@@ -1377,7 +1368,7 @@ export interface DeleteEventSubscriptionMessage {
 
 export namespace DeleteEventSubscriptionMessage {
   export function isa(o: any): o is DeleteEventSubscriptionMessage {
-    return _smithy.isa(o, "DeleteEventSubscriptionMessage");
+    return __isa(o, "DeleteEventSubscriptionMessage");
   }
 }
 
@@ -1394,7 +1385,7 @@ export interface DeleteEventSubscriptionResponse extends $MetadataBearer {
 
 export namespace DeleteEventSubscriptionResponse {
   export function isa(o: any): o is DeleteEventSubscriptionResponse {
-    return _smithy.isa(o, "DeleteEventSubscriptionResponse");
+    return __isa(o, "DeleteEventSubscriptionResponse");
   }
 }
 
@@ -1411,7 +1402,7 @@ export interface DeleteReplicationInstanceMessage {
 
 export namespace DeleteReplicationInstanceMessage {
   export function isa(o: any): o is DeleteReplicationInstanceMessage {
-    return _smithy.isa(o, "DeleteReplicationInstanceMessage");
+    return __isa(o, "DeleteReplicationInstanceMessage");
   }
 }
 
@@ -1428,7 +1419,7 @@ export interface DeleteReplicationInstanceResponse extends $MetadataBearer {
 
 export namespace DeleteReplicationInstanceResponse {
   export function isa(o: any): o is DeleteReplicationInstanceResponse {
-    return _smithy.isa(o, "DeleteReplicationInstanceResponse");
+    return __isa(o, "DeleteReplicationInstanceResponse");
   }
 }
 
@@ -1445,7 +1436,7 @@ export interface DeleteReplicationSubnetGroupMessage {
 
 export namespace DeleteReplicationSubnetGroupMessage {
   export function isa(o: any): o is DeleteReplicationSubnetGroupMessage {
-    return _smithy.isa(o, "DeleteReplicationSubnetGroupMessage");
+    return __isa(o, "DeleteReplicationSubnetGroupMessage");
   }
 }
 
@@ -1458,7 +1449,7 @@ export interface DeleteReplicationSubnetGroupResponse extends $MetadataBearer {
 
 export namespace DeleteReplicationSubnetGroupResponse {
   export function isa(o: any): o is DeleteReplicationSubnetGroupResponse {
-    return _smithy.isa(o, "DeleteReplicationSubnetGroupResponse");
+    return __isa(o, "DeleteReplicationSubnetGroupResponse");
   }
 }
 
@@ -1475,7 +1466,7 @@ export interface DeleteReplicationTaskMessage {
 
 export namespace DeleteReplicationTaskMessage {
   export function isa(o: any): o is DeleteReplicationTaskMessage {
-    return _smithy.isa(o, "DeleteReplicationTaskMessage");
+    return __isa(o, "DeleteReplicationTaskMessage");
   }
 }
 
@@ -1492,7 +1483,7 @@ export interface DeleteReplicationTaskResponse extends $MetadataBearer {
 
 export namespace DeleteReplicationTaskResponse {
   export function isa(o: any): o is DeleteReplicationTaskResponse {
-    return _smithy.isa(o, "DeleteReplicationTaskResponse");
+    return __isa(o, "DeleteReplicationTaskResponse");
   }
 }
 
@@ -1505,7 +1496,7 @@ export interface DescribeAccountAttributesMessage {
 
 export namespace DescribeAccountAttributesMessage {
   export function isa(o: any): o is DescribeAccountAttributesMessage {
-    return _smithy.isa(o, "DescribeAccountAttributesMessage");
+    return __isa(o, "DescribeAccountAttributesMessage");
   }
 }
 
@@ -1538,7 +1529,7 @@ export interface DescribeAccountAttributesResponse extends $MetadataBearer {
 
 export namespace DescribeAccountAttributesResponse {
   export function isa(o: any): o is DescribeAccountAttributesResponse {
-    return _smithy.isa(o, "DescribeAccountAttributesResponse");
+    return __isa(o, "DescribeAccountAttributesResponse");
   }
 }
 
@@ -1567,7 +1558,7 @@ export interface DescribeCertificatesMessage {
 
 export namespace DescribeCertificatesMessage {
   export function isa(o: any): o is DescribeCertificatesMessage {
-    return _smithy.isa(o, "DescribeCertificatesMessage");
+    return __isa(o, "DescribeCertificatesMessage");
   }
 }
 
@@ -1587,7 +1578,7 @@ export interface DescribeCertificatesResponse extends $MetadataBearer {
 
 export namespace DescribeCertificatesResponse {
   export function isa(o: any): o is DescribeCertificatesResponse {
-    return _smithy.isa(o, "DescribeCertificatesResponse");
+    return __isa(o, "DescribeCertificatesResponse");
   }
 }
 
@@ -1621,7 +1612,7 @@ export interface DescribeConnectionsMessage {
 
 export namespace DescribeConnectionsMessage {
   export function isa(o: any): o is DescribeConnectionsMessage {
-    return _smithy.isa(o, "DescribeConnectionsMessage");
+    return __isa(o, "DescribeConnectionsMessage");
   }
 }
 
@@ -1645,7 +1636,7 @@ export interface DescribeConnectionsResponse extends $MetadataBearer {
 
 export namespace DescribeConnectionsResponse {
   export function isa(o: any): o is DescribeConnectionsResponse {
-    return _smithy.isa(o, "DescribeConnectionsResponse");
+    return __isa(o, "DescribeConnectionsResponse");
   }
 }
 
@@ -1679,7 +1670,7 @@ export interface DescribeEndpointTypesMessage {
 
 export namespace DescribeEndpointTypesMessage {
   export function isa(o: any): o is DescribeEndpointTypesMessage {
-    return _smithy.isa(o, "DescribeEndpointTypesMessage");
+    return __isa(o, "DescribeEndpointTypesMessage");
   }
 }
 
@@ -1703,7 +1694,7 @@ export interface DescribeEndpointTypesResponse extends $MetadataBearer {
 
 export namespace DescribeEndpointTypesResponse {
   export function isa(o: any): o is DescribeEndpointTypesResponse {
-    return _smithy.isa(o, "DescribeEndpointTypesResponse");
+    return __isa(o, "DescribeEndpointTypesResponse");
   }
 }
 
@@ -1737,7 +1728,7 @@ export interface DescribeEndpointsMessage {
 
 export namespace DescribeEndpointsMessage {
   export function isa(o: any): o is DescribeEndpointsMessage {
-    return _smithy.isa(o, "DescribeEndpointsMessage");
+    return __isa(o, "DescribeEndpointsMessage");
   }
 }
 
@@ -1761,7 +1752,7 @@ export interface DescribeEndpointsResponse extends $MetadataBearer {
 
 export namespace DescribeEndpointsResponse {
   export function isa(o: any): o is DescribeEndpointsResponse {
-    return _smithy.isa(o, "DescribeEndpointsResponse");
+    return __isa(o, "DescribeEndpointsResponse");
   }
 }
 
@@ -1784,7 +1775,7 @@ export interface DescribeEventCategoriesMessage {
 
 export namespace DescribeEventCategoriesMessage {
   export function isa(o: any): o is DescribeEventCategoriesMessage {
-    return _smithy.isa(o, "DescribeEventCategoriesMessage");
+    return __isa(o, "DescribeEventCategoriesMessage");
   }
 }
 
@@ -1801,7 +1792,7 @@ export interface DescribeEventCategoriesResponse extends $MetadataBearer {
 
 export namespace DescribeEventCategoriesResponse {
   export function isa(o: any): o is DescribeEventCategoriesResponse {
-    return _smithy.isa(o, "DescribeEventCategoriesResponse");
+    return __isa(o, "DescribeEventCategoriesResponse");
   }
 }
 
@@ -1839,7 +1830,7 @@ export interface DescribeEventSubscriptionsMessage {
 
 export namespace DescribeEventSubscriptionsMessage {
   export function isa(o: any): o is DescribeEventSubscriptionsMessage {
-    return _smithy.isa(o, "DescribeEventSubscriptionsMessage");
+    return __isa(o, "DescribeEventSubscriptionsMessage");
   }
 }
 
@@ -1863,7 +1854,7 @@ export interface DescribeEventSubscriptionsResponse extends $MetadataBearer {
 
 export namespace DescribeEventSubscriptionsResponse {
   export function isa(o: any): o is DescribeEventSubscriptionsResponse {
-    return _smithy.isa(o, "DescribeEventSubscriptionsResponse");
+    return __isa(o, "DescribeEventSubscriptionsResponse");
   }
 }
 
@@ -1927,7 +1918,7 @@ export interface DescribeEventsMessage {
 
 export namespace DescribeEventsMessage {
   export function isa(o: any): o is DescribeEventsMessage {
-    return _smithy.isa(o, "DescribeEventsMessage");
+    return __isa(o, "DescribeEventsMessage");
   }
 }
 
@@ -1951,7 +1942,7 @@ export interface DescribeEventsResponse extends $MetadataBearer {
 
 export namespace DescribeEventsResponse {
   export function isa(o: any): o is DescribeEventsResponse {
-    return _smithy.isa(o, "DescribeEventsResponse");
+    return __isa(o, "DescribeEventsResponse");
   }
 }
 
@@ -1981,7 +1972,7 @@ export namespace DescribeOrderableReplicationInstancesMessage {
   export function isa(
     o: any
   ): o is DescribeOrderableReplicationInstancesMessage {
-    return _smithy.isa(o, "DescribeOrderableReplicationInstancesMessage");
+    return __isa(o, "DescribeOrderableReplicationInstancesMessage");
   }
 }
 
@@ -2008,7 +1999,7 @@ export namespace DescribeOrderableReplicationInstancesResponse {
   export function isa(
     o: any
   ): o is DescribeOrderableReplicationInstancesResponse {
-    return _smithy.isa(o, "DescribeOrderableReplicationInstancesResponse");
+    return __isa(o, "DescribeOrderableReplicationInstancesResponse");
   }
 }
 
@@ -2046,7 +2037,7 @@ export interface DescribePendingMaintenanceActionsMessage {
 
 export namespace DescribePendingMaintenanceActionsMessage {
   export function isa(o: any): o is DescribePendingMaintenanceActionsMessage {
-    return _smithy.isa(o, "DescribePendingMaintenanceActionsMessage");
+    return __isa(o, "DescribePendingMaintenanceActionsMessage");
   }
 }
 
@@ -2071,7 +2062,7 @@ export interface DescribePendingMaintenanceActionsResponse
 
 export namespace DescribePendingMaintenanceActionsResponse {
   export function isa(o: any): o is DescribePendingMaintenanceActionsResponse {
-    return _smithy.isa(o, "DescribePendingMaintenanceActionsResponse");
+    return __isa(o, "DescribePendingMaintenanceActionsResponse");
   }
 }
 
@@ -2088,7 +2079,7 @@ export interface DescribeRefreshSchemasStatusMessage {
 
 export namespace DescribeRefreshSchemasStatusMessage {
   export function isa(o: any): o is DescribeRefreshSchemasStatusMessage {
-    return _smithy.isa(o, "DescribeRefreshSchemasStatusMessage");
+    return __isa(o, "DescribeRefreshSchemasStatusMessage");
   }
 }
 
@@ -2105,7 +2096,7 @@ export interface DescribeRefreshSchemasStatusResponse extends $MetadataBearer {
 
 export namespace DescribeRefreshSchemasStatusResponse {
   export function isa(o: any): o is DescribeRefreshSchemasStatusResponse {
-    return _smithy.isa(o, "DescribeRefreshSchemasStatusResponse");
+    return __isa(o, "DescribeRefreshSchemasStatusResponse");
   }
 }
 
@@ -2135,7 +2126,7 @@ export interface DescribeReplicationInstanceTaskLogsMessage {
 
 export namespace DescribeReplicationInstanceTaskLogsMessage {
   export function isa(o: any): o is DescribeReplicationInstanceTaskLogsMessage {
-    return _smithy.isa(o, "DescribeReplicationInstanceTaskLogsMessage");
+    return __isa(o, "DescribeReplicationInstanceTaskLogsMessage");
   }
 }
 
@@ -2165,7 +2156,7 @@ export namespace DescribeReplicationInstanceTaskLogsResponse {
   export function isa(
     o: any
   ): o is DescribeReplicationInstanceTaskLogsResponse {
-    return _smithy.isa(o, "DescribeReplicationInstanceTaskLogsResponse");
+    return __isa(o, "DescribeReplicationInstanceTaskLogsResponse");
   }
 }
 
@@ -2200,7 +2191,7 @@ export interface DescribeReplicationInstancesMessage {
 
 export namespace DescribeReplicationInstancesMessage {
   export function isa(o: any): o is DescribeReplicationInstancesMessage {
-    return _smithy.isa(o, "DescribeReplicationInstancesMessage");
+    return __isa(o, "DescribeReplicationInstancesMessage");
   }
 }
 
@@ -2224,7 +2215,7 @@ export interface DescribeReplicationInstancesResponse extends $MetadataBearer {
 
 export namespace DescribeReplicationInstancesResponse {
   export function isa(o: any): o is DescribeReplicationInstancesResponse {
-    return _smithy.isa(o, "DescribeReplicationInstancesResponse");
+    return __isa(o, "DescribeReplicationInstancesResponse");
   }
 }
 
@@ -2257,7 +2248,7 @@ export interface DescribeReplicationSubnetGroupsMessage {
 
 export namespace DescribeReplicationSubnetGroupsMessage {
   export function isa(o: any): o is DescribeReplicationSubnetGroupsMessage {
-    return _smithy.isa(o, "DescribeReplicationSubnetGroupsMessage");
+    return __isa(o, "DescribeReplicationSubnetGroupsMessage");
   }
 }
 
@@ -2282,7 +2273,7 @@ export interface DescribeReplicationSubnetGroupsResponse
 
 export namespace DescribeReplicationSubnetGroupsResponse {
   export function isa(o: any): o is DescribeReplicationSubnetGroupsResponse {
-    return _smithy.isa(o, "DescribeReplicationSubnetGroupsResponse");
+    return __isa(o, "DescribeReplicationSubnetGroupsResponse");
   }
 }
 
@@ -2319,7 +2310,7 @@ export namespace DescribeReplicationTaskAssessmentResultsMessage {
   export function isa(
     o: any
   ): o is DescribeReplicationTaskAssessmentResultsMessage {
-    return _smithy.isa(o, "DescribeReplicationTaskAssessmentResultsMessage");
+    return __isa(o, "DescribeReplicationTaskAssessmentResultsMessage");
   }
 }
 
@@ -2351,7 +2342,7 @@ export namespace DescribeReplicationTaskAssessmentResultsResponse {
   export function isa(
     o: any
   ): o is DescribeReplicationTaskAssessmentResultsResponse {
-    return _smithy.isa(o, "DescribeReplicationTaskAssessmentResultsResponse");
+    return __isa(o, "DescribeReplicationTaskAssessmentResultsResponse");
   }
 }
 
@@ -2393,7 +2384,7 @@ export interface DescribeReplicationTasksMessage {
 
 export namespace DescribeReplicationTasksMessage {
   export function isa(o: any): o is DescribeReplicationTasksMessage {
-    return _smithy.isa(o, "DescribeReplicationTasksMessage");
+    return __isa(o, "DescribeReplicationTasksMessage");
   }
 }
 
@@ -2417,7 +2408,7 @@ export interface DescribeReplicationTasksResponse extends $MetadataBearer {
 
 export namespace DescribeReplicationTasksResponse {
   export function isa(o: any): o is DescribeReplicationTasksResponse {
-    return _smithy.isa(o, "DescribeReplicationTasksResponse");
+    return __isa(o, "DescribeReplicationTasksResponse");
   }
 }
 
@@ -2450,7 +2441,7 @@ export interface DescribeSchemasMessage {
 
 export namespace DescribeSchemasMessage {
   export function isa(o: any): o is DescribeSchemasMessage {
-    return _smithy.isa(o, "DescribeSchemasMessage");
+    return __isa(o, "DescribeSchemasMessage");
   }
 }
 
@@ -2474,7 +2465,7 @@ export interface DescribeSchemasResponse extends $MetadataBearer {
 
 export namespace DescribeSchemasResponse {
   export function isa(o: any): o is DescribeSchemasResponse {
-    return _smithy.isa(o, "DescribeSchemasResponse");
+    return __isa(o, "DescribeSchemasResponse");
   }
 }
 
@@ -2515,7 +2506,7 @@ export interface DescribeTableStatisticsMessage {
 
 export namespace DescribeTableStatisticsMessage {
   export function isa(o: any): o is DescribeTableStatisticsMessage {
-    return _smithy.isa(o, "DescribeTableStatisticsMessage");
+    return __isa(o, "DescribeTableStatisticsMessage");
   }
 }
 
@@ -2544,7 +2535,7 @@ export interface DescribeTableStatisticsResponse extends $MetadataBearer {
 
 export namespace DescribeTableStatisticsResponse {
   export function isa(o: any): o is DescribeTableStatisticsResponse {
-    return _smithy.isa(o, "DescribeTableStatisticsResponse");
+    return __isa(o, "DescribeTableStatisticsResponse");
   }
 }
 
@@ -2573,7 +2564,7 @@ export interface DmsTransferSettings {
 
 export namespace DmsTransferSettings {
   export function isa(o: any): o is DmsTransferSettings {
-    return _smithy.isa(o, "DmsTransferSettings");
+    return __isa(o, "DmsTransferSettings");
   }
 }
 
@@ -2590,7 +2581,7 @@ export interface DynamoDbSettings {
 
 export namespace DynamoDbSettings {
   export function isa(o: any): o is DynamoDbSettings {
-    return _smithy.isa(o, "DynamoDbSettings");
+    return __isa(o, "DynamoDbSettings");
   }
 }
 
@@ -2624,7 +2615,7 @@ export interface ElasticsearchSettings {
 
 export namespace ElasticsearchSettings {
   export function isa(o: any): o is ElasticsearchSettings {
-    return _smithy.isa(o, "ElasticsearchSettings");
+    return __isa(o, "ElasticsearchSettings");
   }
 }
 
@@ -2807,7 +2798,7 @@ export interface Endpoint {
 
 export namespace Endpoint {
   export function isa(o: any): o is Endpoint {
-    return _smithy.isa(o, "Endpoint");
+    return __isa(o, "Endpoint");
   }
 }
 
@@ -2845,7 +2836,7 @@ export interface Event {
 
 export namespace Event {
   export function isa(o: any): o is Event {
-    return _smithy.isa(o, "Event");
+    return __isa(o, "Event");
   }
 }
 
@@ -2869,7 +2860,7 @@ export interface EventCategoryGroup {
 
 export namespace EventCategoryGroup {
   export function isa(o: any): o is EventCategoryGroup {
-    return _smithy.isa(o, "EventCategoryGroup");
+    return __isa(o, "EventCategoryGroup");
   }
 }
 
@@ -2935,7 +2926,7 @@ export interface EventSubscription {
 
 export namespace EventSubscription {
   export function isa(o: any): o is EventSubscription {
-    return _smithy.isa(o, "EventSubscription");
+    return __isa(o, "EventSubscription");
   }
 }
 
@@ -2957,7 +2948,7 @@ export interface Filter {
 
 export namespace Filter {
   export function isa(o: any): o is Filter {
-    return _smithy.isa(o, "Filter");
+    return __isa(o, "Filter");
   }
 }
 
@@ -2988,7 +2979,7 @@ export interface ImportCertificateMessage {
 
 export namespace ImportCertificateMessage {
   export function isa(o: any): o is ImportCertificateMessage {
-    return _smithy.isa(o, "ImportCertificateMessage");
+    return __isa(o, "ImportCertificateMessage");
   }
 }
 
@@ -3002,7 +2993,7 @@ export interface ImportCertificateResponse extends $MetadataBearer {
 
 export namespace ImportCertificateResponse {
   export function isa(o: any): o is ImportCertificateResponse {
-    return _smithy.isa(o, "ImportCertificateResponse");
+    return __isa(o, "ImportCertificateResponse");
   }
 }
 
@@ -3031,7 +3022,7 @@ export interface KinesisSettings {
 
 export namespace KinesisSettings {
   export function isa(o: any): o is KinesisSettings {
-    return _smithy.isa(o, "KinesisSettings");
+    return __isa(o, "KinesisSettings");
   }
 }
 
@@ -3049,7 +3040,7 @@ export interface ListTagsForResourceMessage {
 
 export namespace ListTagsForResourceMessage {
   export function isa(o: any): o is ListTagsForResourceMessage {
-    return _smithy.isa(o, "ListTagsForResourceMessage");
+    return __isa(o, "ListTagsForResourceMessage");
   }
 }
 
@@ -3066,7 +3057,7 @@ export interface ListTagsForResourceResponse extends $MetadataBearer {
 
 export namespace ListTagsForResourceResponse {
   export function isa(o: any): o is ListTagsForResourceResponse {
-    return _smithy.isa(o, "ListTagsForResourceResponse");
+    return __isa(o, "ListTagsForResourceResponse");
   }
 }
 
@@ -3236,7 +3227,7 @@ export interface ModifyEndpointMessage {
 
 export namespace ModifyEndpointMessage {
   export function isa(o: any): o is ModifyEndpointMessage {
-    return _smithy.isa(o, "ModifyEndpointMessage");
+    return __isa(o, "ModifyEndpointMessage");
   }
 }
 
@@ -3253,7 +3244,7 @@ export interface ModifyEndpointResponse extends $MetadataBearer {
 
 export namespace ModifyEndpointResponse {
   export function isa(o: any): o is ModifyEndpointResponse {
-    return _smithy.isa(o, "ModifyEndpointResponse");
+    return __isa(o, "ModifyEndpointResponse");
   }
 }
 
@@ -3294,7 +3285,7 @@ export interface ModifyEventSubscriptionMessage {
 
 export namespace ModifyEventSubscriptionMessage {
   export function isa(o: any): o is ModifyEventSubscriptionMessage {
-    return _smithy.isa(o, "ModifyEventSubscriptionMessage");
+    return __isa(o, "ModifyEventSubscriptionMessage");
   }
 }
 
@@ -3311,7 +3302,7 @@ export interface ModifyEventSubscriptionResponse extends $MetadataBearer {
 
 export namespace ModifyEventSubscriptionResponse {
   export function isa(o: any): o is ModifyEventSubscriptionResponse {
-    return _smithy.isa(o, "ModifyEventSubscriptionResponse");
+    return __isa(o, "ModifyEventSubscriptionResponse");
   }
 }
 
@@ -3404,7 +3395,7 @@ export interface ModifyReplicationInstanceMessage {
 
 export namespace ModifyReplicationInstanceMessage {
   export function isa(o: any): o is ModifyReplicationInstanceMessage {
-    return _smithy.isa(o, "ModifyReplicationInstanceMessage");
+    return __isa(o, "ModifyReplicationInstanceMessage");
   }
 }
 
@@ -3421,7 +3412,7 @@ export interface ModifyReplicationInstanceResponse extends $MetadataBearer {
 
 export namespace ModifyReplicationInstanceResponse {
   export function isa(o: any): o is ModifyReplicationInstanceResponse {
-    return _smithy.isa(o, "ModifyReplicationInstanceResponse");
+    return __isa(o, "ModifyReplicationInstanceResponse");
   }
 }
 
@@ -3448,7 +3439,7 @@ export interface ModifyReplicationSubnetGroupMessage {
 
 export namespace ModifyReplicationSubnetGroupMessage {
   export function isa(o: any): o is ModifyReplicationSubnetGroupMessage {
-    return _smithy.isa(o, "ModifyReplicationSubnetGroupMessage");
+    return __isa(o, "ModifyReplicationSubnetGroupMessage");
   }
 }
 
@@ -3465,7 +3456,7 @@ export interface ModifyReplicationSubnetGroupResponse extends $MetadataBearer {
 
 export namespace ModifyReplicationSubnetGroupResponse {
   export function isa(o: any): o is ModifyReplicationSubnetGroupResponse {
-    return _smithy.isa(o, "ModifyReplicationSubnetGroupResponse");
+    return __isa(o, "ModifyReplicationSubnetGroupResponse");
   }
 }
 
@@ -3553,7 +3544,7 @@ export interface ModifyReplicationTaskMessage {
 
 export namespace ModifyReplicationTaskMessage {
   export function isa(o: any): o is ModifyReplicationTaskMessage {
-    return _smithy.isa(o, "ModifyReplicationTaskMessage");
+    return __isa(o, "ModifyReplicationTaskMessage");
   }
 }
 
@@ -3570,7 +3561,7 @@ export interface ModifyReplicationTaskResponse extends $MetadataBearer {
 
 export namespace ModifyReplicationTaskResponse {
   export function isa(o: any): o is ModifyReplicationTaskResponse {
-    return _smithy.isa(o, "ModifyReplicationTaskResponse");
+    return __isa(o, "ModifyReplicationTaskResponse");
   }
 }
 
@@ -3661,7 +3652,7 @@ export interface MongoDbSettings {
 
 export namespace MongoDbSettings {
   export function isa(o: any): o is MongoDbSettings {
-    return _smithy.isa(o, "MongoDbSettings");
+    return __isa(o, "MongoDbSettings");
   }
 }
 
@@ -3734,7 +3725,7 @@ export interface OrderableReplicationInstance {
 
 export namespace OrderableReplicationInstance {
   export function isa(o: any): o is OrderableReplicationInstance {
-    return _smithy.isa(o, "OrderableReplicationInstance");
+    return __isa(o, "OrderableReplicationInstance");
   }
 }
 
@@ -3792,7 +3783,7 @@ export interface PendingMaintenanceAction {
 
 export namespace PendingMaintenanceAction {
   export function isa(o: any): o is PendingMaintenanceAction {
-    return _smithy.isa(o, "PendingMaintenanceAction");
+    return __isa(o, "PendingMaintenanceAction");
   }
 }
 
@@ -3813,7 +3804,7 @@ export interface RebootReplicationInstanceMessage {
 
 export namespace RebootReplicationInstanceMessage {
   export function isa(o: any): o is RebootReplicationInstanceMessage {
-    return _smithy.isa(o, "RebootReplicationInstanceMessage");
+    return __isa(o, "RebootReplicationInstanceMessage");
   }
 }
 
@@ -3827,7 +3818,7 @@ export interface RebootReplicationInstanceResponse extends $MetadataBearer {
 
 export namespace RebootReplicationInstanceResponse {
   export function isa(o: any): o is RebootReplicationInstanceResponse {
-    return _smithy.isa(o, "RebootReplicationInstanceResponse");
+    return __isa(o, "RebootReplicationInstanceResponse");
   }
 }
 
@@ -4010,7 +4001,7 @@ export interface RedshiftSettings {
 
 export namespace RedshiftSettings {
   export function isa(o: any): o is RedshiftSettings {
-    return _smithy.isa(o, "RedshiftSettings");
+    return __isa(o, "RedshiftSettings");
   }
 }
 
@@ -4032,7 +4023,7 @@ export interface RefreshSchemasMessage {
 
 export namespace RefreshSchemasMessage {
   export function isa(o: any): o is RefreshSchemasMessage {
-    return _smithy.isa(o, "RefreshSchemasMessage");
+    return __isa(o, "RefreshSchemasMessage");
   }
 }
 
@@ -4049,7 +4040,7 @@ export interface RefreshSchemasResponse extends $MetadataBearer {
 
 export namespace RefreshSchemasResponse {
   export function isa(o: any): o is RefreshSchemasResponse {
-    return _smithy.isa(o, "RefreshSchemasResponse");
+    return __isa(o, "RefreshSchemasResponse");
   }
 }
 
@@ -4086,7 +4077,7 @@ export interface RefreshSchemasStatus {
 
 export namespace RefreshSchemasStatus {
   export function isa(o: any): o is RefreshSchemasStatus {
-    return _smithy.isa(o, "RefreshSchemasStatus");
+    return __isa(o, "RefreshSchemasStatus");
   }
 }
 
@@ -4129,7 +4120,7 @@ export interface ReloadTablesMessage {
 
 export namespace ReloadTablesMessage {
   export function isa(o: any): o is ReloadTablesMessage {
-    return _smithy.isa(o, "ReloadTablesMessage");
+    return __isa(o, "ReloadTablesMessage");
   }
 }
 
@@ -4143,7 +4134,7 @@ export interface ReloadTablesResponse extends $MetadataBearer {
 
 export namespace ReloadTablesResponse {
   export function isa(o: any): o is ReloadTablesResponse {
-    return _smithy.isa(o, "ReloadTablesResponse");
+    return __isa(o, "ReloadTablesResponse");
   }
 }
 
@@ -4165,7 +4156,7 @@ export interface RemoveTagsFromResourceMessage {
 
 export namespace RemoveTagsFromResourceMessage {
   export function isa(o: any): o is RemoveTagsFromResourceMessage {
-    return _smithy.isa(o, "RemoveTagsFromResourceMessage");
+    return __isa(o, "RemoveTagsFromResourceMessage");
   }
 }
 
@@ -4178,7 +4169,7 @@ export interface RemoveTagsFromResourceResponse extends $MetadataBearer {
 
 export namespace RemoveTagsFromResourceResponse {
   export function isa(o: any): o is RemoveTagsFromResourceResponse {
-    return _smithy.isa(o, "RemoveTagsFromResourceResponse");
+    return __isa(o, "RemoveTagsFromResourceResponse");
   }
 }
 
@@ -4342,7 +4333,7 @@ export interface ReplicationInstance {
 
 export namespace ReplicationInstance {
   export function isa(o: any): o is ReplicationInstance {
-    return _smithy.isa(o, "ReplicationInstance");
+    return __isa(o, "ReplicationInstance");
   }
 }
 
@@ -4369,7 +4360,7 @@ export interface ReplicationInstanceTaskLog {
 
 export namespace ReplicationInstanceTaskLog {
   export function isa(o: any): o is ReplicationInstanceTaskLog {
-    return _smithy.isa(o, "ReplicationInstanceTaskLog");
+    return __isa(o, "ReplicationInstanceTaskLog");
   }
 }
 
@@ -4407,7 +4398,7 @@ export interface ReplicationPendingModifiedValues {
 
 export namespace ReplicationPendingModifiedValues {
   export function isa(o: any): o is ReplicationPendingModifiedValues {
-    return _smithy.isa(o, "ReplicationPendingModifiedValues");
+    return __isa(o, "ReplicationPendingModifiedValues");
   }
 }
 
@@ -4444,7 +4435,7 @@ export interface ReplicationSubnetGroup {
 
 export namespace ReplicationSubnetGroup {
   export function isa(o: any): o is ReplicationSubnetGroup {
-    return _smithy.isa(o, "ReplicationSubnetGroup");
+    return __isa(o, "ReplicationSubnetGroup");
   }
 }
 
@@ -4566,7 +4557,7 @@ export interface ReplicationTask {
 
 export namespace ReplicationTask {
   export function isa(o: any): o is ReplicationTask {
-    return _smithy.isa(o, "ReplicationTask");
+    return __isa(o, "ReplicationTask");
   }
 }
 
@@ -4614,7 +4605,7 @@ export interface ReplicationTaskAssessmentResult {
 
 export namespace ReplicationTaskAssessmentResult {
   export function isa(o: any): o is ReplicationTaskAssessmentResult {
-    return _smithy.isa(o, "ReplicationTaskAssessmentResult");
+    return __isa(o, "ReplicationTaskAssessmentResult");
   }
 }
 
@@ -4682,7 +4673,7 @@ export interface ReplicationTaskStats {
 
 export namespace ReplicationTaskStats {
   export function isa(o: any): o is ReplicationTaskStats {
-    return _smithy.isa(o, "ReplicationTaskStats");
+    return __isa(o, "ReplicationTaskStats");
   }
 }
 
@@ -4706,7 +4697,7 @@ export interface ResourcePendingMaintenanceActions {
 
 export namespace ResourcePendingMaintenanceActions {
   export function isa(o: any): o is ResourcePendingMaintenanceActions {
-    return _smithy.isa(o, "ResourcePendingMaintenanceActions");
+    return __isa(o, "ResourcePendingMaintenanceActions");
   }
 }
 
@@ -5020,7 +5011,7 @@ export interface S3Settings {
 
 export namespace S3Settings {
   export function isa(o: any): o is S3Settings {
-    return _smithy.isa(o, "S3Settings");
+    return __isa(o, "S3Settings");
   }
 }
 
@@ -5039,7 +5030,7 @@ export interface StartReplicationTaskAssessmentMessage {
 
 export namespace StartReplicationTaskAssessmentMessage {
   export function isa(o: any): o is StartReplicationTaskAssessmentMessage {
-    return _smithy.isa(o, "StartReplicationTaskAssessmentMessage");
+    return __isa(o, "StartReplicationTaskAssessmentMessage");
   }
 }
 
@@ -5057,7 +5048,7 @@ export interface StartReplicationTaskAssessmentResponse
 
 export namespace StartReplicationTaskAssessmentResponse {
   export function isa(o: any): o is StartReplicationTaskAssessmentResponse {
-    return _smithy.isa(o, "StartReplicationTaskAssessmentResponse");
+    return __isa(o, "StartReplicationTaskAssessmentResponse");
   }
 }
 
@@ -5114,7 +5105,7 @@ export interface StartReplicationTaskMessage {
 
 export namespace StartReplicationTaskMessage {
   export function isa(o: any): o is StartReplicationTaskMessage {
-    return _smithy.isa(o, "StartReplicationTaskMessage");
+    return __isa(o, "StartReplicationTaskMessage");
   }
 }
 
@@ -5131,7 +5122,7 @@ export interface StartReplicationTaskResponse extends $MetadataBearer {
 
 export namespace StartReplicationTaskResponse {
   export function isa(o: any): o is StartReplicationTaskResponse {
-    return _smithy.isa(o, "StartReplicationTaskResponse");
+    return __isa(o, "StartReplicationTaskResponse");
   }
 }
 
@@ -5154,7 +5145,7 @@ export interface StopReplicationTaskMessage {
 
 export namespace StopReplicationTaskMessage {
   export function isa(o: any): o is StopReplicationTaskMessage {
-    return _smithy.isa(o, "StopReplicationTaskMessage");
+    return __isa(o, "StopReplicationTaskMessage");
   }
 }
 
@@ -5171,7 +5162,7 @@ export interface StopReplicationTaskResponse extends $MetadataBearer {
 
 export namespace StopReplicationTaskResponse {
   export function isa(o: any): o is StopReplicationTaskResponse {
-    return _smithy.isa(o, "StopReplicationTaskResponse");
+    return __isa(o, "StopReplicationTaskResponse");
   }
 }
 
@@ -5198,7 +5189,7 @@ export interface Subnet {
 
 export namespace Subnet {
   export function isa(o: any): o is Subnet {
-    return _smithy.isa(o, "Subnet");
+    return __isa(o, "Subnet");
   }
 }
 
@@ -5233,7 +5224,7 @@ export interface SupportedEndpointType {
 
 export namespace SupportedEndpointType {
   export function isa(o: any): o is SupportedEndpointType {
-    return _smithy.isa(o, "SupportedEndpointType");
+    return __isa(o, "SupportedEndpointType");
   }
 }
 
@@ -5361,7 +5352,7 @@ export interface TableStatistics {
 
 export namespace TableStatistics {
   export function isa(o: any): o is TableStatistics {
-    return _smithy.isa(o, "TableStatistics");
+    return __isa(o, "TableStatistics");
   }
 }
 
@@ -5383,7 +5374,7 @@ export interface TableToReload {
 
 export namespace TableToReload {
   export function isa(o: any): o is TableToReload {
-    return _smithy.isa(o, "TableToReload");
+    return __isa(o, "TableToReload");
   }
 }
 
@@ -5411,7 +5402,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -5433,7 +5424,7 @@ export interface TestConnectionMessage {
 
 export namespace TestConnectionMessage {
   export function isa(o: any): o is TestConnectionMessage {
-    return _smithy.isa(o, "TestConnectionMessage");
+    return __isa(o, "TestConnectionMessage");
   }
 }
 
@@ -5450,7 +5441,7 @@ export interface TestConnectionResponse extends $MetadataBearer {
 
 export namespace TestConnectionResponse {
   export function isa(o: any): o is TestConnectionResponse {
-    return _smithy.isa(o, "TestConnectionResponse");
+    return __isa(o, "TestConnectionResponse");
   }
 }
 
@@ -5472,6 +5463,6 @@ export interface VpcSecurityGroupMembership {
 
 export namespace VpcSecurityGroupMembership {
   export function isa(o: any): o is VpcSecurityGroupMembership {
-    return _smithy.isa(o, "VpcSecurityGroupMembership");
+    return __isa(o, "VpcSecurityGroupMembership");
   }
 }

--- a/clients/client-dataexchange/models/index.ts
+++ b/clients/client-dataexchange/models/index.ts
@@ -1,11 +1,14 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
  * <p>Access to the resource is denied.</p>
  */
 export interface AccessDeniedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AccessDeniedException";
   $fault: "client";
@@ -17,7 +20,7 @@ export interface AccessDeniedException
 
 export namespace AccessDeniedException {
   export function isa(o: any): o is AccessDeniedException {
-    return _smithy.isa(o, "AccessDeniedException");
+    return __isa(o, "AccessDeniedException");
   }
 }
 
@@ -44,7 +47,7 @@ export interface AssetDestinationEntry {
 
 export namespace AssetDestinationEntry {
   export function isa(o: any): o is AssetDestinationEntry {
-    return _smithy.isa(o, "AssetDestinationEntry");
+    return __isa(o, "AssetDestinationEntry");
   }
 }
 
@@ -58,7 +61,7 @@ export interface AssetDetails {
 
 export namespace AssetDetails {
   export function isa(o: any): o is AssetDetails {
-    return _smithy.isa(o, "AssetDetails");
+    return __isa(o, "AssetDetails");
   }
 }
 
@@ -120,7 +123,7 @@ export interface AssetEntry {
 
 export namespace AssetEntry {
   export function isa(o: any): o is AssetEntry {
-    return _smithy.isa(o, "AssetEntry");
+    return __isa(o, "AssetEntry");
   }
 }
 
@@ -142,7 +145,7 @@ export interface AssetSourceEntry {
 
 export namespace AssetSourceEntry {
   export function isa(o: any): o is AssetSourceEntry {
-    return _smithy.isa(o, "AssetSourceEntry");
+    return __isa(o, "AssetSourceEntry");
   }
 }
 
@@ -160,7 +163,7 @@ export interface CancelJobRequest {
 
 export namespace CancelJobRequest {
   export function isa(o: any): o is CancelJobRequest {
-    return _smithy.isa(o, "CancelJobRequest");
+    return __isa(o, "CancelJobRequest");
   }
 }
 
@@ -177,9 +180,7 @@ export enum Code {
 /**
  * <p>The request couldn't be completed because it conflicted with the current state of the resource.</p>
  */
-export interface ConflictException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface ConflictException extends __SmithyException, $MetadataBearer {
   name: "ConflictException";
   $fault: "client";
   /**
@@ -200,7 +201,7 @@ export interface ConflictException
 
 export namespace ConflictException {
   export function isa(o: any): o is ConflictException {
-    return _smithy.isa(o, "ConflictException");
+    return __isa(o, "ConflictException");
   }
 }
 
@@ -232,7 +233,7 @@ export interface CreateDataSetRequest {
 
 export namespace CreateDataSetRequest {
   export function isa(o: any): o is CreateDataSetRequest {
-    return _smithy.isa(o, "CreateDataSetRequest");
+    return __isa(o, "CreateDataSetRequest");
   }
 }
 
@@ -296,7 +297,7 @@ export interface CreateDataSetResponse extends $MetadataBearer {
 
 export namespace CreateDataSetResponse {
   export function isa(o: any): o is CreateDataSetResponse {
-    return _smithy.isa(o, "CreateDataSetResponse");
+    return __isa(o, "CreateDataSetResponse");
   }
 }
 
@@ -318,7 +319,7 @@ export interface CreateJobRequest {
 
 export namespace CreateJobRequest {
   export function isa(o: any): o is CreateJobRequest {
-    return _smithy.isa(o, "CreateJobRequest");
+    return __isa(o, "CreateJobRequest");
   }
 }
 
@@ -367,7 +368,7 @@ export interface CreateJobResponse extends $MetadataBearer {
 
 export namespace CreateJobResponse {
   export function isa(o: any): o is CreateJobResponse {
-    return _smithy.isa(o, "CreateJobResponse");
+    return __isa(o, "CreateJobResponse");
   }
 }
 
@@ -394,7 +395,7 @@ export interface CreateRevisionRequest {
 
 export namespace CreateRevisionRequest {
   export function isa(o: any): o is CreateRevisionRequest {
-    return _smithy.isa(o, "CreateRevisionRequest");
+    return __isa(o, "CreateRevisionRequest");
   }
 }
 
@@ -448,7 +449,7 @@ export interface CreateRevisionResponse extends $MetadataBearer {
 
 export namespace CreateRevisionResponse {
   export function isa(o: any): o is CreateRevisionResponse {
-    return _smithy.isa(o, "CreateRevisionResponse");
+    return __isa(o, "CreateRevisionResponse");
   }
 }
 
@@ -510,7 +511,7 @@ export interface DataSetEntry {
 
 export namespace DataSetEntry {
   export function isa(o: any): o is DataSetEntry {
-    return _smithy.isa(o, "DataSetEntry");
+    return __isa(o, "DataSetEntry");
   }
 }
 
@@ -534,7 +535,7 @@ export interface DeleteAssetRequest {
 
 export namespace DeleteAssetRequest {
   export function isa(o: any): o is DeleteAssetRequest {
-    return _smithy.isa(o, "DeleteAssetRequest");
+    return __isa(o, "DeleteAssetRequest");
   }
 }
 
@@ -548,7 +549,7 @@ export interface DeleteDataSetRequest {
 
 export namespace DeleteDataSetRequest {
   export function isa(o: any): o is DeleteDataSetRequest {
-    return _smithy.isa(o, "DeleteDataSetRequest");
+    return __isa(o, "DeleteDataSetRequest");
   }
 }
 
@@ -567,7 +568,7 @@ export interface DeleteRevisionRequest {
 
 export namespace DeleteRevisionRequest {
   export function isa(o: any): o is DeleteRevisionRequest {
-    return _smithy.isa(o, "DeleteRevisionRequest");
+    return __isa(o, "DeleteRevisionRequest");
   }
 }
 
@@ -582,7 +583,7 @@ export interface Details {
 
 export namespace Details {
   export function isa(o: any): o is Details {
-    return _smithy.isa(o, "Details");
+    return __isa(o, "Details");
   }
 }
 
@@ -609,7 +610,7 @@ export interface ExportAssetToSignedUrlRequestDetails {
 
 export namespace ExportAssetToSignedUrlRequestDetails {
   export function isa(o: any): o is ExportAssetToSignedUrlRequestDetails {
-    return _smithy.isa(o, "ExportAssetToSignedUrlRequestDetails");
+    return __isa(o, "ExportAssetToSignedUrlRequestDetails");
   }
 }
 
@@ -646,7 +647,7 @@ export interface ExportAssetToSignedUrlResponseDetails {
 
 export namespace ExportAssetToSignedUrlResponseDetails {
   export function isa(o: any): o is ExportAssetToSignedUrlResponseDetails {
-    return _smithy.isa(o, "ExportAssetToSignedUrlResponseDetails");
+    return __isa(o, "ExportAssetToSignedUrlResponseDetails");
   }
 }
 
@@ -673,7 +674,7 @@ export interface ExportAssetsToS3RequestDetails {
 
 export namespace ExportAssetsToS3RequestDetails {
   export function isa(o: any): o is ExportAssetsToS3RequestDetails {
-    return _smithy.isa(o, "ExportAssetsToS3RequestDetails");
+    return __isa(o, "ExportAssetsToS3RequestDetails");
   }
 }
 
@@ -700,7 +701,7 @@ export interface ExportAssetsToS3ResponseDetails {
 
 export namespace ExportAssetsToS3ResponseDetails {
   export function isa(o: any): o is ExportAssetsToS3ResponseDetails {
-    return _smithy.isa(o, "ExportAssetsToS3ResponseDetails");
+    return __isa(o, "ExportAssetsToS3ResponseDetails");
   }
 }
 
@@ -724,7 +725,7 @@ export interface GetAssetRequest {
 
 export namespace GetAssetRequest {
   export function isa(o: any): o is GetAssetRequest {
-    return _smithy.isa(o, "GetAssetRequest");
+    return __isa(o, "GetAssetRequest");
   }
 }
 
@@ -783,7 +784,7 @@ export interface GetAssetResponse extends $MetadataBearer {
 
 export namespace GetAssetResponse {
   export function isa(o: any): o is GetAssetResponse {
-    return _smithy.isa(o, "GetAssetResponse");
+    return __isa(o, "GetAssetResponse");
   }
 }
 
@@ -797,7 +798,7 @@ export interface GetDataSetRequest {
 
 export namespace GetDataSetRequest {
   export function isa(o: any): o is GetDataSetRequest {
-    return _smithy.isa(o, "GetDataSetRequest");
+    return __isa(o, "GetDataSetRequest");
   }
 }
 
@@ -861,7 +862,7 @@ export interface GetDataSetResponse extends $MetadataBearer {
 
 export namespace GetDataSetResponse {
   export function isa(o: any): o is GetDataSetResponse {
-    return _smithy.isa(o, "GetDataSetResponse");
+    return __isa(o, "GetDataSetResponse");
   }
 }
 
@@ -875,7 +876,7 @@ export interface GetJobRequest {
 
 export namespace GetJobRequest {
   export function isa(o: any): o is GetJobRequest {
-    return _smithy.isa(o, "GetJobRequest");
+    return __isa(o, "GetJobRequest");
   }
 }
 
@@ -924,7 +925,7 @@ export interface GetJobResponse extends $MetadataBearer {
 
 export namespace GetJobResponse {
   export function isa(o: any): o is GetJobResponse {
-    return _smithy.isa(o, "GetJobResponse");
+    return __isa(o, "GetJobResponse");
   }
 }
 
@@ -943,7 +944,7 @@ export interface GetRevisionRequest {
 
 export namespace GetRevisionRequest {
   export function isa(o: any): o is GetRevisionRequest {
-    return _smithy.isa(o, "GetRevisionRequest");
+    return __isa(o, "GetRevisionRequest");
   }
 }
 
@@ -997,7 +998,7 @@ export interface GetRevisionResponse extends $MetadataBearer {
 
 export namespace GetRevisionResponse {
   export function isa(o: any): o is GetRevisionResponse {
-    return _smithy.isa(o, "GetRevisionResponse");
+    return __isa(o, "GetRevisionResponse");
   }
 }
 
@@ -1011,7 +1012,7 @@ export interface ImportAssetFromSignedUrlJobErrorDetails {
 
 export namespace ImportAssetFromSignedUrlJobErrorDetails {
   export function isa(o: any): o is ImportAssetFromSignedUrlJobErrorDetails {
-    return _smithy.isa(o, "ImportAssetFromSignedUrlJobErrorDetails");
+    return __isa(o, "ImportAssetFromSignedUrlJobErrorDetails");
   }
 }
 
@@ -1043,7 +1044,7 @@ export interface ImportAssetFromSignedUrlRequestDetails {
 
 export namespace ImportAssetFromSignedUrlRequestDetails {
   export function isa(o: any): o is ImportAssetFromSignedUrlRequestDetails {
-    return _smithy.isa(o, "ImportAssetFromSignedUrlRequestDetails");
+    return __isa(o, "ImportAssetFromSignedUrlRequestDetails");
   }
 }
 
@@ -1085,7 +1086,7 @@ export interface ImportAssetFromSignedUrlResponseDetails {
 
 export namespace ImportAssetFromSignedUrlResponseDetails {
   export function isa(o: any): o is ImportAssetFromSignedUrlResponseDetails {
-    return _smithy.isa(o, "ImportAssetFromSignedUrlResponseDetails");
+    return __isa(o, "ImportAssetFromSignedUrlResponseDetails");
   }
 }
 
@@ -1112,7 +1113,7 @@ export interface ImportAssetsFromS3RequestDetails {
 
 export namespace ImportAssetsFromS3RequestDetails {
   export function isa(o: any): o is ImportAssetsFromS3RequestDetails {
-    return _smithy.isa(o, "ImportAssetsFromS3RequestDetails");
+    return __isa(o, "ImportAssetsFromS3RequestDetails");
   }
 }
 
@@ -1139,7 +1140,7 @@ export interface ImportAssetsFromS3ResponseDetails {
 
 export namespace ImportAssetsFromS3ResponseDetails {
   export function isa(o: any): o is ImportAssetsFromS3ResponseDetails {
-    return _smithy.isa(o, "ImportAssetsFromS3ResponseDetails");
+    return __isa(o, "ImportAssetsFromS3ResponseDetails");
   }
 }
 
@@ -1147,7 +1148,7 @@ export namespace ImportAssetsFromS3ResponseDetails {
  * An exception occurred with the service.
  */
 export interface InternalServerException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalServerException";
   $fault: "server";
@@ -1159,7 +1160,7 @@ export interface InternalServerException
 
 export namespace InternalServerException {
   export function isa(o: any): o is InternalServerException {
-    return _smithy.isa(o, "InternalServerException");
+    return __isa(o, "InternalServerException");
   }
 }
 
@@ -1211,7 +1212,7 @@ export interface JobEntry {
 
 export namespace JobEntry {
   export function isa(o: any): o is JobEntry {
-    return _smithy.isa(o, "JobEntry");
+    return __isa(o, "JobEntry");
   }
 }
 
@@ -1254,7 +1255,7 @@ export interface JobError {
 
 export namespace JobError {
   export function isa(o: any): o is JobError {
-    return _smithy.isa(o, "JobError");
+    return __isa(o, "JobError");
   }
 }
 
@@ -1303,7 +1304,7 @@ export interface ListDataSetRevisionsRequest {
 
 export namespace ListDataSetRevisionsRequest {
   export function isa(o: any): o is ListDataSetRevisionsRequest {
-    return _smithy.isa(o, "ListDataSetRevisionsRequest");
+    return __isa(o, "ListDataSetRevisionsRequest");
   }
 }
 
@@ -1322,7 +1323,7 @@ export interface ListDataSetRevisionsResponse extends $MetadataBearer {
 
 export namespace ListDataSetRevisionsResponse {
   export function isa(o: any): o is ListDataSetRevisionsResponse {
-    return _smithy.isa(o, "ListDataSetRevisionsResponse");
+    return __isa(o, "ListDataSetRevisionsResponse");
   }
 }
 
@@ -1346,7 +1347,7 @@ export interface ListDataSetsRequest {
 
 export namespace ListDataSetsRequest {
   export function isa(o: any): o is ListDataSetsRequest {
-    return _smithy.isa(o, "ListDataSetsRequest");
+    return __isa(o, "ListDataSetsRequest");
   }
 }
 
@@ -1365,7 +1366,7 @@ export interface ListDataSetsResponse extends $MetadataBearer {
 
 export namespace ListDataSetsResponse {
   export function isa(o: any): o is ListDataSetsResponse {
-    return _smithy.isa(o, "ListDataSetsResponse");
+    return __isa(o, "ListDataSetsResponse");
   }
 }
 
@@ -1394,7 +1395,7 @@ export interface ListJobsRequest {
 
 export namespace ListJobsRequest {
   export function isa(o: any): o is ListJobsRequest {
-    return _smithy.isa(o, "ListJobsRequest");
+    return __isa(o, "ListJobsRequest");
   }
 }
 
@@ -1413,7 +1414,7 @@ export interface ListJobsResponse extends $MetadataBearer {
 
 export namespace ListJobsResponse {
   export function isa(o: any): o is ListJobsResponse {
-    return _smithy.isa(o, "ListJobsResponse");
+    return __isa(o, "ListJobsResponse");
   }
 }
 
@@ -1442,7 +1443,7 @@ export interface ListRevisionAssetsRequest {
 
 export namespace ListRevisionAssetsRequest {
   export function isa(o: any): o is ListRevisionAssetsRequest {
-    return _smithy.isa(o, "ListRevisionAssetsRequest");
+    return __isa(o, "ListRevisionAssetsRequest");
   }
 }
 
@@ -1461,7 +1462,7 @@ export interface ListRevisionAssetsResponse extends $MetadataBearer {
 
 export namespace ListRevisionAssetsResponse {
   export function isa(o: any): o is ListRevisionAssetsResponse {
-    return _smithy.isa(o, "ListRevisionAssetsResponse");
+    return __isa(o, "ListRevisionAssetsResponse");
   }
 }
 
@@ -1475,7 +1476,7 @@ export interface ListTagsForResourceRequest {
 
 export namespace ListTagsForResourceRequest {
   export function isa(o: any): o is ListTagsForResourceRequest {
-    return _smithy.isa(o, "ListTagsForResourceRequest");
+    return __isa(o, "ListTagsForResourceRequest");
   }
 }
 
@@ -1489,7 +1490,7 @@ export interface ListTagsForResourceResponse extends $MetadataBearer {
 
 export namespace ListTagsForResourceResponse {
   export function isa(o: any): o is ListTagsForResourceResponse {
-    return _smithy.isa(o, "ListTagsForResourceResponse");
+    return __isa(o, "ListTagsForResourceResponse");
   }
 }
 
@@ -1505,7 +1506,7 @@ export interface OriginDetails {
 
 export namespace OriginDetails {
   export function isa(o: any): o is OriginDetails {
-    return _smithy.isa(o, "OriginDetails");
+    return __isa(o, "OriginDetails");
   }
 }
 
@@ -1537,7 +1538,7 @@ export interface RequestDetails {
 
 export namespace RequestDetails {
   export function isa(o: any): o is RequestDetails {
-    return _smithy.isa(o, "RequestDetails");
+    return __isa(o, "RequestDetails");
   }
 }
 
@@ -1545,7 +1546,7 @@ export namespace RequestDetails {
  * <p>The resource couldn't be found.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -1567,7 +1568,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -1606,7 +1607,7 @@ export interface ResponseDetails {
 
 export namespace ResponseDetails {
   export function isa(o: any): o is ResponseDetails {
-    return _smithy.isa(o, "ResponseDetails");
+    return __isa(o, "ResponseDetails");
   }
 }
 
@@ -1658,7 +1659,7 @@ export interface RevisionEntry {
 
 export namespace RevisionEntry {
   export function isa(o: any): o is RevisionEntry {
-    return _smithy.isa(o, "RevisionEntry");
+    return __isa(o, "RevisionEntry");
   }
 }
 
@@ -1675,7 +1676,7 @@ export interface S3SnapshotAsset {
 
 export namespace S3SnapshotAsset {
   export function isa(o: any): o is S3SnapshotAsset {
-    return _smithy.isa(o, "S3SnapshotAsset");
+    return __isa(o, "S3SnapshotAsset");
   }
 }
 
@@ -1683,7 +1684,7 @@ export namespace S3SnapshotAsset {
  * <p>The request has exceeded the quotas imposed by the service.</p>
  */
 export interface ServiceLimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ServiceLimitExceededException";
   $fault: "client";
@@ -1705,7 +1706,7 @@ export interface ServiceLimitExceededException
 
 export namespace ServiceLimitExceededException {
   export function isa(o: any): o is ServiceLimitExceededException {
-    return _smithy.isa(o, "ServiceLimitExceededException");
+    return __isa(o, "ServiceLimitExceededException");
   }
 }
 
@@ -1719,7 +1720,7 @@ export interface StartJobRequest {
 
 export namespace StartJobRequest {
   export function isa(o: any): o is StartJobRequest {
-    return _smithy.isa(o, "StartJobRequest");
+    return __isa(o, "StartJobRequest");
   }
 }
 
@@ -1729,7 +1730,7 @@ export interface StartJobResponse extends $MetadataBearer {
 
 export namespace StartJobResponse {
   export function isa(o: any): o is StartJobResponse {
-    return _smithy.isa(o, "StartJobResponse");
+    return __isa(o, "StartJobResponse");
   }
 }
 
@@ -1760,7 +1761,7 @@ export interface TagResourceRequest {
 
 export namespace TagResourceRequest {
   export function isa(o: any): o is TagResourceRequest {
-    return _smithy.isa(o, "TagResourceRequest");
+    return __isa(o, "TagResourceRequest");
   }
 }
 
@@ -1768,7 +1769,7 @@ export namespace TagResourceRequest {
  * <p>The limit on the number of requests per second was exceeded.</p>
  */
 export interface ThrottlingException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ThrottlingException";
   $fault: "client";
@@ -1780,7 +1781,7 @@ export interface ThrottlingException
 
 export namespace ThrottlingException {
   export function isa(o: any): o is ThrottlingException {
-    return _smithy.isa(o, "ThrottlingException");
+    return __isa(o, "ThrottlingException");
   }
 }
 
@@ -1806,7 +1807,7 @@ export interface UntagResourceRequest {
 
 export namespace UntagResourceRequest {
   export function isa(o: any): o is UntagResourceRequest {
-    return _smithy.isa(o, "UntagResourceRequest");
+    return __isa(o, "UntagResourceRequest");
   }
 }
 
@@ -1838,7 +1839,7 @@ export interface UpdateAssetRequest {
 
 export namespace UpdateAssetRequest {
   export function isa(o: any): o is UpdateAssetRequest {
-    return _smithy.isa(o, "UpdateAssetRequest");
+    return __isa(o, "UpdateAssetRequest");
   }
 }
 
@@ -1897,7 +1898,7 @@ export interface UpdateAssetResponse extends $MetadataBearer {
 
 export namespace UpdateAssetResponse {
   export function isa(o: any): o is UpdateAssetResponse {
-    return _smithy.isa(o, "UpdateAssetResponse");
+    return __isa(o, "UpdateAssetResponse");
   }
 }
 
@@ -1924,7 +1925,7 @@ export interface UpdateDataSetRequest {
 
 export namespace UpdateDataSetRequest {
   export function isa(o: any): o is UpdateDataSetRequest {
-    return _smithy.isa(o, "UpdateDataSetRequest");
+    return __isa(o, "UpdateDataSetRequest");
   }
 }
 
@@ -1983,7 +1984,7 @@ export interface UpdateDataSetResponse extends $MetadataBearer {
 
 export namespace UpdateDataSetResponse {
   export function isa(o: any): o is UpdateDataSetResponse {
-    return _smithy.isa(o, "UpdateDataSetResponse");
+    return __isa(o, "UpdateDataSetResponse");
   }
 }
 
@@ -2015,7 +2016,7 @@ export interface UpdateRevisionRequest {
 
 export namespace UpdateRevisionRequest {
   export function isa(o: any): o is UpdateRevisionRequest {
-    return _smithy.isa(o, "UpdateRevisionRequest");
+    return __isa(o, "UpdateRevisionRequest");
   }
 }
 
@@ -2064,7 +2065,7 @@ export interface UpdateRevisionResponse extends $MetadataBearer {
 
 export namespace UpdateRevisionResponse {
   export function isa(o: any): o is UpdateRevisionResponse {
-    return _smithy.isa(o, "UpdateRevisionResponse");
+    return __isa(o, "UpdateRevisionResponse");
   }
 }
 
@@ -2072,7 +2073,7 @@ export namespace UpdateRevisionResponse {
  * <p>The request was invalid.</p>
  */
 export interface ValidationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ValidationException";
   $fault: "client";
@@ -2084,6 +2085,6 @@ export interface ValidationException
 
 export namespace ValidationException {
   export function isa(o: any): o is ValidationException {
-    return _smithy.isa(o, "ValidationException");
+    return __isa(o, "ValidationException");
   }
 }

--- a/clients/client-dataexchange/protocols/Aws_restJson1_1.ts
+++ b/clients/client-dataexchange/protocols/Aws_restJson1_1.ts
@@ -121,7 +121,10 @@ import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  extendedEncodeURIComponent as __extendedEncodeURIComponent
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -137,13 +140,13 @@ export async function serializeAws_restJson1_1CancelJobCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/jobs/{JobId}";
   if (input.JobId !== undefined) {
-    const labelValue: string = input.JobId.toString();
+    const labelValue: string = input.JobId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: JobId.");
     }
     resolvedPath = resolvedPath.replace(
       "{JobId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: JobId.");
@@ -229,13 +232,13 @@ export async function serializeAws_restJson1_1CreateRevisionCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v1/data-sets/{DataSetId}/revisions";
   if (input.DataSetId !== undefined) {
-    const labelValue: string = input.DataSetId.toString();
+    const labelValue: string = input.DataSetId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DataSetId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DataSetId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DataSetId.");
@@ -271,37 +274,37 @@ export async function serializeAws_restJson1_1DeleteAssetCommand(
   let resolvedPath =
     "/v1/data-sets/{DataSetId}/revisions/{RevisionId}/assets/{AssetId}";
   if (input.AssetId !== undefined) {
-    const labelValue: string = input.AssetId.toString();
+    const labelValue: string = input.AssetId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: AssetId.");
     }
     resolvedPath = resolvedPath.replace(
       "{AssetId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AssetId.");
   }
   if (input.DataSetId !== undefined) {
-    const labelValue: string = input.DataSetId.toString();
+    const labelValue: string = input.DataSetId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DataSetId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DataSetId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DataSetId.");
   }
   if (input.RevisionId !== undefined) {
-    const labelValue: string = input.RevisionId.toString();
+    const labelValue: string = input.RevisionId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: RevisionId.");
     }
     resolvedPath = resolvedPath.replace(
       "{RevisionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: RevisionId.");
@@ -323,13 +326,13 @@ export async function serializeAws_restJson1_1DeleteDataSetCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/data-sets/{DataSetId}";
   if (input.DataSetId !== undefined) {
-    const labelValue: string = input.DataSetId.toString();
+    const labelValue: string = input.DataSetId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DataSetId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DataSetId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DataSetId.");
@@ -351,25 +354,25 @@ export async function serializeAws_restJson1_1DeleteRevisionCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/data-sets/{DataSetId}/revisions/{RevisionId}";
   if (input.DataSetId !== undefined) {
-    const labelValue: string = input.DataSetId.toString();
+    const labelValue: string = input.DataSetId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DataSetId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DataSetId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DataSetId.");
   }
   if (input.RevisionId !== undefined) {
-    const labelValue: string = input.RevisionId.toString();
+    const labelValue: string = input.RevisionId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: RevisionId.");
     }
     resolvedPath = resolvedPath.replace(
       "{RevisionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: RevisionId.");
@@ -392,37 +395,37 @@ export async function serializeAws_restJson1_1GetAssetCommand(
   let resolvedPath =
     "/v1/data-sets/{DataSetId}/revisions/{RevisionId}/assets/{AssetId}";
   if (input.AssetId !== undefined) {
-    const labelValue: string = input.AssetId.toString();
+    const labelValue: string = input.AssetId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: AssetId.");
     }
     resolvedPath = resolvedPath.replace(
       "{AssetId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AssetId.");
   }
   if (input.DataSetId !== undefined) {
-    const labelValue: string = input.DataSetId.toString();
+    const labelValue: string = input.DataSetId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DataSetId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DataSetId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DataSetId.");
   }
   if (input.RevisionId !== undefined) {
-    const labelValue: string = input.RevisionId.toString();
+    const labelValue: string = input.RevisionId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: RevisionId.");
     }
     resolvedPath = resolvedPath.replace(
       "{RevisionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: RevisionId.");
@@ -444,13 +447,13 @@ export async function serializeAws_restJson1_1GetDataSetCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/data-sets/{DataSetId}";
   if (input.DataSetId !== undefined) {
-    const labelValue: string = input.DataSetId.toString();
+    const labelValue: string = input.DataSetId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DataSetId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DataSetId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DataSetId.");
@@ -472,13 +475,13 @@ export async function serializeAws_restJson1_1GetJobCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/jobs/{JobId}";
   if (input.JobId !== undefined) {
-    const labelValue: string = input.JobId.toString();
+    const labelValue: string = input.JobId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: JobId.");
     }
     resolvedPath = resolvedPath.replace(
       "{JobId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: JobId.");
@@ -500,25 +503,25 @@ export async function serializeAws_restJson1_1GetRevisionCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/data-sets/{DataSetId}/revisions/{RevisionId}";
   if (input.DataSetId !== undefined) {
-    const labelValue: string = input.DataSetId.toString();
+    const labelValue: string = input.DataSetId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DataSetId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DataSetId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DataSetId.");
   }
   if (input.RevisionId !== undefined) {
-    const labelValue: string = input.RevisionId.toString();
+    const labelValue: string = input.RevisionId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: RevisionId.");
     }
     resolvedPath = resolvedPath.replace(
       "{RevisionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: RevisionId.");
@@ -540,23 +543,27 @@ export async function serializeAws_restJson1_1ListDataSetRevisionsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/data-sets/{DataSetId}/revisions";
   if (input.DataSetId !== undefined) {
-    const labelValue: string = input.DataSetId.toString();
+    const labelValue: string = input.DataSetId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DataSetId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DataSetId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DataSetId.");
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -577,13 +584,19 @@ export async function serializeAws_restJson1_1ListDataSetsCommand(
   let resolvedPath = "/v1/data-sets";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   if (input.Origin !== undefined) {
-    query["origin"] = input.Origin.toString();
+    query[
+      __extendedEncodeURIComponent("origin")
+    ] = __extendedEncodeURIComponent(input.Origin);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -604,16 +617,24 @@ export async function serializeAws_restJson1_1ListJobsCommand(
   let resolvedPath = "/v1/jobs";
   const query: any = {};
   if (input.DataSetId !== undefined) {
-    query["dataSetId"] = input.DataSetId.toString();
+    query[
+      __extendedEncodeURIComponent("dataSetId")
+    ] = __extendedEncodeURIComponent(input.DataSetId);
   }
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   if (input.RevisionId !== undefined) {
-    query["revisionId"] = input.RevisionId.toString();
+    query[
+      __extendedEncodeURIComponent("revisionId")
+    ] = __extendedEncodeURIComponent(input.RevisionId);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -633,35 +654,39 @@ export async function serializeAws_restJson1_1ListRevisionAssetsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/data-sets/{DataSetId}/revisions/{RevisionId}/assets";
   if (input.DataSetId !== undefined) {
-    const labelValue: string = input.DataSetId.toString();
+    const labelValue: string = input.DataSetId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DataSetId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DataSetId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DataSetId.");
   }
   if (input.RevisionId !== undefined) {
-    const labelValue: string = input.RevisionId.toString();
+    const labelValue: string = input.RevisionId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: RevisionId.");
     }
     resolvedPath = resolvedPath.replace(
       "{RevisionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: RevisionId.");
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -681,7 +706,7 @@ export async function serializeAws_restJson1_1ListTagsForResourceCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/tags/{ResourceArn}";
   if (input.ResourceArn !== undefined) {
-    const labelValue: string = input.ResourceArn.toString();
+    const labelValue: string = input.ResourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ResourceArn."
@@ -689,7 +714,7 @@ export async function serializeAws_restJson1_1ListTagsForResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ResourceArn.");
@@ -711,13 +736,13 @@ export async function serializeAws_restJson1_1StartJobCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/jobs/{JobId}";
   if (input.JobId !== undefined) {
-    const labelValue: string = input.JobId.toString();
+    const labelValue: string = input.JobId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: JobId.");
     }
     resolvedPath = resolvedPath.replace(
       "{JobId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: JobId.");
@@ -739,7 +764,7 @@ export async function serializeAws_restJson1_1TagResourceCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/tags/{ResourceArn}";
   if (input.ResourceArn !== undefined) {
-    const labelValue: string = input.ResourceArn.toString();
+    const labelValue: string = input.ResourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ResourceArn."
@@ -747,7 +772,7 @@ export async function serializeAws_restJson1_1TagResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ResourceArn.");
@@ -779,7 +804,7 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/tags/{ResourceArn}";
   if (input.ResourceArn !== undefined) {
-    const labelValue: string = input.ResourceArn.toString();
+    const labelValue: string = input.ResourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ResourceArn."
@@ -787,14 +812,16 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ResourceArn.");
   }
   const query: any = {};
   if (input.TagKeys !== undefined) {
-    query["tagKeys"] = input.TagKeys;
+    query[__extendedEncodeURIComponent("tagKeys")] = input.TagKeys.map(entry =>
+      __extendedEncodeURIComponent(entry)
+    );
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -815,37 +842,37 @@ export async function serializeAws_restJson1_1UpdateAssetCommand(
   let resolvedPath =
     "/v1/data-sets/{DataSetId}/revisions/{RevisionId}/assets/{AssetId}";
   if (input.AssetId !== undefined) {
-    const labelValue: string = input.AssetId.toString();
+    const labelValue: string = input.AssetId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: AssetId.");
     }
     resolvedPath = resolvedPath.replace(
       "{AssetId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AssetId.");
   }
   if (input.DataSetId !== undefined) {
-    const labelValue: string = input.DataSetId.toString();
+    const labelValue: string = input.DataSetId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DataSetId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DataSetId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DataSetId.");
   }
   if (input.RevisionId !== undefined) {
-    const labelValue: string = input.RevisionId.toString();
+    const labelValue: string = input.RevisionId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: RevisionId.");
     }
     resolvedPath = resolvedPath.replace(
       "{RevisionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: RevisionId.");
@@ -874,13 +901,13 @@ export async function serializeAws_restJson1_1UpdateDataSetCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v1/data-sets/{DataSetId}";
   if (input.DataSetId !== undefined) {
-    const labelValue: string = input.DataSetId.toString();
+    const labelValue: string = input.DataSetId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DataSetId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DataSetId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DataSetId.");
@@ -912,25 +939,25 @@ export async function serializeAws_restJson1_1UpdateRevisionCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v1/data-sets/{DataSetId}/revisions/{RevisionId}";
   if (input.DataSetId !== undefined) {
-    const labelValue: string = input.DataSetId.toString();
+    const labelValue: string = input.DataSetId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DataSetId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DataSetId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DataSetId.");
   }
   if (input.RevisionId !== undefined) {
-    const labelValue: string = input.RevisionId.toString();
+    const labelValue: string = input.RevisionId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: RevisionId.");
     }
     resolvedPath = resolvedPath.replace(
       "{RevisionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: RevisionId.");
@@ -964,6 +991,7 @@ export async function deserializeAws_restJson1_1CancelJobCommand(
   const contents: CancelJobCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -1394,6 +1422,7 @@ export async function deserializeAws_restJson1_1DeleteAssetCommand(
   const contents: DeleteAssetCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -1476,6 +1505,7 @@ export async function deserializeAws_restJson1_1DeleteDataSetCommand(
   const contents: DeleteDataSetCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -1561,6 +1591,7 @@ export async function deserializeAws_restJson1_1DeleteRevisionCommand(
   const contents: DeleteRevisionCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2467,6 +2498,7 @@ export async function deserializeAws_restJson1_1StartJobCommand(
     $metadata: deserializeMetadata(output),
     __type: "StartJobResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2549,6 +2581,7 @@ export async function deserializeAws_restJson1_1TagResourceCommand(
   const contents: TagResourceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2589,6 +2622,7 @@ export async function deserializeAws_restJson1_1UntagResourceCommand(
   const contents: UntagResourceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 

--- a/clients/client-datasync/models/index.ts
+++ b/clients/client-datasync/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -26,7 +29,7 @@ export interface AgentListEntry {
 
 export namespace AgentListEntry {
   export function isa(o: any): o is AgentListEntry {
-    return _smithy.isa(o, "AgentListEntry");
+    return __isa(o, "AgentListEntry");
   }
 }
 
@@ -53,7 +56,7 @@ export interface CancelTaskExecutionRequest {
 
 export namespace CancelTaskExecutionRequest {
   export function isa(o: any): o is CancelTaskExecutionRequest {
-    return _smithy.isa(o, "CancelTaskExecutionRequest");
+    return __isa(o, "CancelTaskExecutionRequest");
   }
 }
 
@@ -63,7 +66,7 @@ export interface CancelTaskExecutionResponse extends $MetadataBearer {
 
 export namespace CancelTaskExecutionResponse {
   export function isa(o: any): o is CancelTaskExecutionResponse {
-    return _smithy.isa(o, "CancelTaskExecutionResponse");
+    return __isa(o, "CancelTaskExecutionResponse");
   }
 }
 
@@ -131,7 +134,7 @@ export interface CreateAgentRequest {
 
 export namespace CreateAgentRequest {
   export function isa(o: any): o is CreateAgentRequest {
-    return _smithy.isa(o, "CreateAgentRequest");
+    return __isa(o, "CreateAgentRequest");
   }
 }
 
@@ -149,7 +152,7 @@ export interface CreateAgentResponse extends $MetadataBearer {
 
 export namespace CreateAgentResponse {
   export function isa(o: any): o is CreateAgentResponse {
-    return _smithy.isa(o, "CreateAgentResponse");
+    return __isa(o, "CreateAgentResponse");
   }
 }
 
@@ -213,7 +216,7 @@ export interface CreateLocationEfsRequest {
 
 export namespace CreateLocationEfsRequest {
   export function isa(o: any): o is CreateLocationEfsRequest {
-    return _smithy.isa(o, "CreateLocationEfsRequest");
+    return __isa(o, "CreateLocationEfsRequest");
   }
 }
 
@@ -231,7 +234,7 @@ export interface CreateLocationEfsResponse extends $MetadataBearer {
 
 export namespace CreateLocationEfsResponse {
   export function isa(o: any): o is CreateLocationEfsResponse {
-    return _smithy.isa(o, "CreateLocationEfsResponse");
+    return __isa(o, "CreateLocationEfsResponse");
   }
 }
 
@@ -292,7 +295,7 @@ export interface CreateLocationNfsRequest {
 
 export namespace CreateLocationNfsRequest {
   export function isa(o: any): o is CreateLocationNfsRequest {
-    return _smithy.isa(o, "CreateLocationNfsRequest");
+    return __isa(o, "CreateLocationNfsRequest");
   }
 }
 
@@ -310,7 +313,7 @@ export interface CreateLocationNfsResponse extends $MetadataBearer {
 
 export namespace CreateLocationNfsResponse {
   export function isa(o: any): o is CreateLocationNfsResponse {
-    return _smithy.isa(o, "CreateLocationNfsResponse");
+    return __isa(o, "CreateLocationNfsResponse");
   }
 }
 
@@ -356,7 +359,7 @@ export interface CreateLocationS3Request {
 
 export namespace CreateLocationS3Request {
   export function isa(o: any): o is CreateLocationS3Request {
-    return _smithy.isa(o, "CreateLocationS3Request");
+    return __isa(o, "CreateLocationS3Request");
   }
 }
 
@@ -374,7 +377,7 @@ export interface CreateLocationS3Response extends $MetadataBearer {
 
 export namespace CreateLocationS3Response {
   export function isa(o: any): o is CreateLocationS3Response {
-    return _smithy.isa(o, "CreateLocationS3Response");
+    return __isa(o, "CreateLocationS3Response");
   }
 }
 
@@ -451,7 +454,7 @@ export interface CreateLocationSmbRequest {
 
 export namespace CreateLocationSmbRequest {
   export function isa(o: any): o is CreateLocationSmbRequest {
-    return _smithy.isa(o, "CreateLocationSmbRequest");
+    return __isa(o, "CreateLocationSmbRequest");
   }
 }
 
@@ -469,7 +472,7 @@ export interface CreateLocationSmbResponse extends $MetadataBearer {
 
 export namespace CreateLocationSmbResponse {
   export function isa(o: any): o is CreateLocationSmbResponse {
-    return _smithy.isa(o, "CreateLocationSmbResponse");
+    return __isa(o, "CreateLocationSmbResponse");
   }
 }
 
@@ -545,7 +548,7 @@ export interface CreateTaskRequest {
 
 export namespace CreateTaskRequest {
   export function isa(o: any): o is CreateTaskRequest {
-    return _smithy.isa(o, "CreateTaskRequest");
+    return __isa(o, "CreateTaskRequest");
   }
 }
 
@@ -562,7 +565,7 @@ export interface CreateTaskResponse extends $MetadataBearer {
 
 export namespace CreateTaskResponse {
   export function isa(o: any): o is CreateTaskResponse {
-    return _smithy.isa(o, "CreateTaskResponse");
+    return __isa(o, "CreateTaskResponse");
   }
 }
 
@@ -580,7 +583,7 @@ export interface DeleteAgentRequest {
 
 export namespace DeleteAgentRequest {
   export function isa(o: any): o is DeleteAgentRequest {
-    return _smithy.isa(o, "DeleteAgentRequest");
+    return __isa(o, "DeleteAgentRequest");
   }
 }
 
@@ -590,7 +593,7 @@ export interface DeleteAgentResponse extends $MetadataBearer {
 
 export namespace DeleteAgentResponse {
   export function isa(o: any): o is DeleteAgentResponse {
-    return _smithy.isa(o, "DeleteAgentResponse");
+    return __isa(o, "DeleteAgentResponse");
   }
 }
 
@@ -607,7 +610,7 @@ export interface DeleteLocationRequest {
 
 export namespace DeleteLocationRequest {
   export function isa(o: any): o is DeleteLocationRequest {
-    return _smithy.isa(o, "DeleteLocationRequest");
+    return __isa(o, "DeleteLocationRequest");
   }
 }
 
@@ -617,7 +620,7 @@ export interface DeleteLocationResponse extends $MetadataBearer {
 
 export namespace DeleteLocationResponse {
   export function isa(o: any): o is DeleteLocationResponse {
-    return _smithy.isa(o, "DeleteLocationResponse");
+    return __isa(o, "DeleteLocationResponse");
   }
 }
 
@@ -634,7 +637,7 @@ export interface DeleteTaskRequest {
 
 export namespace DeleteTaskRequest {
   export function isa(o: any): o is DeleteTaskRequest {
-    return _smithy.isa(o, "DeleteTaskRequest");
+    return __isa(o, "DeleteTaskRequest");
   }
 }
 
@@ -644,7 +647,7 @@ export interface DeleteTaskResponse extends $MetadataBearer {
 
 export namespace DeleteTaskResponse {
   export function isa(o: any): o is DeleteTaskResponse {
-    return _smithy.isa(o, "DeleteTaskResponse");
+    return __isa(o, "DeleteTaskResponse");
   }
 }
 
@@ -661,7 +664,7 @@ export interface DescribeAgentRequest {
 
 export namespace DescribeAgentRequest {
   export function isa(o: any): o is DescribeAgentRequest {
-    return _smithy.isa(o, "DescribeAgentRequest");
+    return __isa(o, "DescribeAgentRequest");
   }
 }
 
@@ -713,7 +716,7 @@ export interface DescribeAgentResponse extends $MetadataBearer {
 
 export namespace DescribeAgentResponse {
   export function isa(o: any): o is DescribeAgentResponse {
-    return _smithy.isa(o, "DescribeAgentResponse");
+    return __isa(o, "DescribeAgentResponse");
   }
 }
 
@@ -730,7 +733,7 @@ export interface DescribeLocationEfsRequest {
 
 export namespace DescribeLocationEfsRequest {
   export function isa(o: any): o is DescribeLocationEfsRequest {
-    return _smithy.isa(o, "DescribeLocationEfsRequest");
+    return __isa(o, "DescribeLocationEfsRequest");
   }
 }
 
@@ -765,7 +768,7 @@ export interface DescribeLocationEfsResponse extends $MetadataBearer {
 
 export namespace DescribeLocationEfsResponse {
   export function isa(o: any): o is DescribeLocationEfsResponse {
-    return _smithy.isa(o, "DescribeLocationEfsResponse");
+    return __isa(o, "DescribeLocationEfsResponse");
   }
 }
 
@@ -782,7 +785,7 @@ export interface DescribeLocationNfsRequest {
 
 export namespace DescribeLocationNfsRequest {
   export function isa(o: any): o is DescribeLocationNfsRequest {
-    return _smithy.isa(o, "DescribeLocationNfsRequest");
+    return __isa(o, "DescribeLocationNfsRequest");
   }
 }
 
@@ -820,7 +823,7 @@ export interface DescribeLocationNfsResponse extends $MetadataBearer {
 
 export namespace DescribeLocationNfsResponse {
   export function isa(o: any): o is DescribeLocationNfsResponse {
-    return _smithy.isa(o, "DescribeLocationNfsResponse");
+    return __isa(o, "DescribeLocationNfsResponse");
   }
 }
 
@@ -837,7 +840,7 @@ export interface DescribeLocationS3Request {
 
 export namespace DescribeLocationS3Request {
   export function isa(o: any): o is DescribeLocationS3Request {
-    return _smithy.isa(o, "DescribeLocationS3Request");
+    return __isa(o, "DescribeLocationS3Request");
   }
 }
 
@@ -881,7 +884,7 @@ export interface DescribeLocationS3Response extends $MetadataBearer {
 
 export namespace DescribeLocationS3Response {
   export function isa(o: any): o is DescribeLocationS3Response {
-    return _smithy.isa(o, "DescribeLocationS3Response");
+    return __isa(o, "DescribeLocationS3Response");
   }
 }
 
@@ -898,7 +901,7 @@ export interface DescribeLocationSmbRequest {
 
 export namespace DescribeLocationSmbRequest {
   export function isa(o: any): o is DescribeLocationSmbRequest {
-    return _smithy.isa(o, "DescribeLocationSmbRequest");
+    return __isa(o, "DescribeLocationSmbRequest");
   }
 }
 
@@ -947,7 +950,7 @@ export interface DescribeLocationSmbResponse extends $MetadataBearer {
 
 export namespace DescribeLocationSmbResponse {
   export function isa(o: any): o is DescribeLocationSmbResponse {
-    return _smithy.isa(o, "DescribeLocationSmbResponse");
+    return __isa(o, "DescribeLocationSmbResponse");
   }
 }
 
@@ -964,7 +967,7 @@ export interface DescribeTaskExecutionRequest {
 
 export namespace DescribeTaskExecutionRequest {
   export function isa(o: any): o is DescribeTaskExecutionRequest {
-    return _smithy.isa(o, "DescribeTaskExecutionRequest");
+    return __isa(o, "DescribeTaskExecutionRequest");
   }
 }
 
@@ -1075,7 +1078,7 @@ export interface DescribeTaskExecutionResponse extends $MetadataBearer {
 
 export namespace DescribeTaskExecutionResponse {
   export function isa(o: any): o is DescribeTaskExecutionResponse {
-    return _smithy.isa(o, "DescribeTaskExecutionResponse");
+    return __isa(o, "DescribeTaskExecutionResponse");
   }
 }
 
@@ -1092,7 +1095,7 @@ export interface DescribeTaskRequest {
 
 export namespace DescribeTaskRequest {
   export function isa(o: any): o is DescribeTaskRequest {
-    return _smithy.isa(o, "DescribeTaskRequest");
+    return __isa(o, "DescribeTaskRequest");
   }
 }
 
@@ -1204,7 +1207,7 @@ export interface DescribeTaskResponse extends $MetadataBearer {
 
 export namespace DescribeTaskResponse {
   export function isa(o: any): o is DescribeTaskResponse {
-    return _smithy.isa(o, "DescribeTaskResponse");
+    return __isa(o, "DescribeTaskResponse");
   }
 }
 
@@ -1231,7 +1234,7 @@ export interface Ec2Config {
 
 export namespace Ec2Config {
   export function isa(o: any): o is Ec2Config {
-    return _smithy.isa(o, "Ec2Config");
+    return __isa(o, "Ec2Config");
   }
 }
 
@@ -1265,7 +1268,7 @@ export interface FilterRule {
 
 export namespace FilterRule {
   export function isa(o: any): o is FilterRule {
-    return _smithy.isa(o, "FilterRule");
+    return __isa(o, "FilterRule");
   }
 }
 
@@ -1283,9 +1286,7 @@ export enum Gid {
 /**
  * <p>This exception is thrown when an error occurs in the AWS DataSync service.</p>
  */
-export interface InternalException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface InternalException extends __SmithyException, $MetadataBearer {
   name: "InternalException";
   $fault: "server";
   errorCode?: string;
@@ -1294,7 +1295,7 @@ export interface InternalException
 
 export namespace InternalException {
   export function isa(o: any): o is InternalException {
-    return _smithy.isa(o, "InternalException");
+    return __isa(o, "InternalException");
   }
 }
 
@@ -1302,7 +1303,7 @@ export namespace InternalException {
  * <p>This exception is thrown when the client submits a malformed request.</p>
  */
 export interface InvalidRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidRequestException";
   $fault: "client";
@@ -1312,7 +1313,7 @@ export interface InvalidRequestException
 
 export namespace InvalidRequestException {
   export function isa(o: any): o is InvalidRequestException {
-    return _smithy.isa(o, "InvalidRequestException");
+    return __isa(o, "InvalidRequestException");
   }
 }
 
@@ -1335,7 +1336,7 @@ export interface ListAgentsRequest {
 
 export namespace ListAgentsRequest {
   export function isa(o: any): o is ListAgentsRequest {
-    return _smithy.isa(o, "ListAgentsRequest");
+    return __isa(o, "ListAgentsRequest");
   }
 }
 
@@ -1358,7 +1359,7 @@ export interface ListAgentsResponse extends $MetadataBearer {
 
 export namespace ListAgentsResponse {
   export function isa(o: any): o is ListAgentsResponse {
-    return _smithy.isa(o, "ListAgentsResponse");
+    return __isa(o, "ListAgentsResponse");
   }
 }
 
@@ -1381,7 +1382,7 @@ export interface ListLocationsRequest {
 
 export namespace ListLocationsRequest {
   export function isa(o: any): o is ListLocationsRequest {
-    return _smithy.isa(o, "ListLocationsRequest");
+    return __isa(o, "ListLocationsRequest");
   }
 }
 
@@ -1404,7 +1405,7 @@ export interface ListLocationsResponse extends $MetadataBearer {
 
 export namespace ListLocationsResponse {
   export function isa(o: any): o is ListLocationsResponse {
-    return _smithy.isa(o, "ListLocationsResponse");
+    return __isa(o, "ListLocationsResponse");
   }
 }
 
@@ -1432,7 +1433,7 @@ export interface ListTagsForResourceRequest {
 
 export namespace ListTagsForResourceRequest {
   export function isa(o: any): o is ListTagsForResourceRequest {
-    return _smithy.isa(o, "ListTagsForResourceRequest");
+    return __isa(o, "ListTagsForResourceRequest");
   }
 }
 
@@ -1455,7 +1456,7 @@ export interface ListTagsForResourceResponse extends $MetadataBearer {
 
 export namespace ListTagsForResourceResponse {
   export function isa(o: any): o is ListTagsForResourceResponse {
-    return _smithy.isa(o, "ListTagsForResourceResponse");
+    return __isa(o, "ListTagsForResourceResponse");
   }
 }
 
@@ -1483,7 +1484,7 @@ export interface ListTaskExecutionsRequest {
 
 export namespace ListTaskExecutionsRequest {
   export function isa(o: any): o is ListTaskExecutionsRequest {
-    return _smithy.isa(o, "ListTaskExecutionsRequest");
+    return __isa(o, "ListTaskExecutionsRequest");
   }
 }
 
@@ -1506,7 +1507,7 @@ export interface ListTaskExecutionsResponse extends $MetadataBearer {
 
 export namespace ListTaskExecutionsResponse {
   export function isa(o: any): o is ListTaskExecutionsResponse {
-    return _smithy.isa(o, "ListTaskExecutionsResponse");
+    return __isa(o, "ListTaskExecutionsResponse");
   }
 }
 
@@ -1529,7 +1530,7 @@ export interface ListTasksRequest {
 
 export namespace ListTasksRequest {
   export function isa(o: any): o is ListTasksRequest {
-    return _smithy.isa(o, "ListTasksRequest");
+    return __isa(o, "ListTasksRequest");
   }
 }
 
@@ -1552,7 +1553,7 @@ export interface ListTasksResponse extends $MetadataBearer {
 
 export namespace ListTasksResponse {
   export function isa(o: any): o is ListTasksResponse {
-    return _smithy.isa(o, "ListTasksResponse");
+    return __isa(o, "ListTasksResponse");
   }
 }
 
@@ -1591,7 +1592,7 @@ export interface LocationListEntry {
 
 export namespace LocationListEntry {
   export function isa(o: any): o is LocationListEntry {
-    return _smithy.isa(o, "LocationListEntry");
+    return __isa(o, "LocationListEntry");
   }
 }
 
@@ -1643,7 +1644,7 @@ export interface NfsMountOptions {
 
 export namespace NfsMountOptions {
   export function isa(o: any): o is NfsMountOptions {
-    return _smithy.isa(o, "NfsMountOptions");
+    return __isa(o, "NfsMountOptions");
   }
 }
 
@@ -1668,7 +1669,7 @@ export interface OnPremConfig {
 
 export namespace OnPremConfig {
   export function isa(o: any): o is OnPremConfig {
-    return _smithy.isa(o, "OnPremConfig");
+    return __isa(o, "OnPremConfig");
   }
 }
 
@@ -1809,7 +1810,7 @@ export interface Options {
 
 export namespace Options {
   export function isa(o: any): o is Options {
-    return _smithy.isa(o, "Options");
+    return __isa(o, "Options");
   }
 }
 
@@ -1874,7 +1875,7 @@ export interface PrivateLinkConfig {
 
 export namespace PrivateLinkConfig {
   export function isa(o: any): o is PrivateLinkConfig {
-    return _smithy.isa(o, "PrivateLinkConfig");
+    return __isa(o, "PrivateLinkConfig");
   }
 }
 
@@ -1895,7 +1896,7 @@ export interface S3Config {
 
 export namespace S3Config {
   export function isa(o: any): o is S3Config {
-    return _smithy.isa(o, "S3Config");
+    return __isa(o, "S3Config");
   }
 }
 
@@ -1924,7 +1925,7 @@ export interface SmbMountOptions {
 
 export namespace SmbMountOptions {
   export function isa(o: any): o is SmbMountOptions {
-    return _smithy.isa(o, "SmbMountOptions");
+    return __isa(o, "SmbMountOptions");
   }
 }
 
@@ -1968,7 +1969,7 @@ export interface StartTaskExecutionRequest {
 
 export namespace StartTaskExecutionRequest {
   export function isa(o: any): o is StartTaskExecutionRequest {
-    return _smithy.isa(o, "StartTaskExecutionRequest");
+    return __isa(o, "StartTaskExecutionRequest");
   }
 }
 
@@ -1986,7 +1987,7 @@ export interface StartTaskExecutionResponse extends $MetadataBearer {
 
 export namespace StartTaskExecutionResponse {
   export function isa(o: any): o is StartTaskExecutionResponse {
-    return _smithy.isa(o, "StartTaskExecutionResponse");
+    return __isa(o, "StartTaskExecutionResponse");
   }
 }
 
@@ -2010,7 +2011,7 @@ export interface TagListEntry {
 
 export namespace TagListEntry {
   export function isa(o: any): o is TagListEntry {
-    return _smithy.isa(o, "TagListEntry");
+    return __isa(o, "TagListEntry");
   }
 }
 
@@ -2032,7 +2033,7 @@ export interface TagResourceRequest {
 
 export namespace TagResourceRequest {
   export function isa(o: any): o is TagResourceRequest {
-    return _smithy.isa(o, "TagResourceRequest");
+    return __isa(o, "TagResourceRequest");
   }
 }
 
@@ -2042,7 +2043,7 @@ export interface TagResourceResponse extends $MetadataBearer {
 
 export namespace TagResourceResponse {
   export function isa(o: any): o is TagResourceResponse {
-    return _smithy.isa(o, "TagResourceResponse");
+    return __isa(o, "TagResourceResponse");
   }
 }
 
@@ -2066,7 +2067,7 @@ export interface TaskExecutionListEntry {
 
 export namespace TaskExecutionListEntry {
   export function isa(o: any): o is TaskExecutionListEntry {
-    return _smithy.isa(o, "TaskExecutionListEntry");
+    return __isa(o, "TaskExecutionListEntry");
   }
 }
 
@@ -2130,7 +2131,7 @@ export interface TaskExecutionResultDetail {
 
 export namespace TaskExecutionResultDetail {
   export function isa(o: any): o is TaskExecutionResultDetail {
-    return _smithy.isa(o, "TaskExecutionResultDetail");
+    return __isa(o, "TaskExecutionResultDetail");
   }
 }
 
@@ -2170,7 +2171,7 @@ export interface TaskListEntry {
 
 export namespace TaskListEntry {
   export function isa(o: any): o is TaskListEntry {
-    return _smithy.isa(o, "TaskListEntry");
+    return __isa(o, "TaskListEntry");
   }
 }
 
@@ -2194,7 +2195,7 @@ export interface TaskSchedule {
 
 export namespace TaskSchedule {
   export function isa(o: any): o is TaskSchedule {
-    return _smithy.isa(o, "TaskSchedule");
+    return __isa(o, "TaskSchedule");
   }
 }
 
@@ -2231,7 +2232,7 @@ export interface UntagResourceRequest {
 
 export namespace UntagResourceRequest {
   export function isa(o: any): o is UntagResourceRequest {
-    return _smithy.isa(o, "UntagResourceRequest");
+    return __isa(o, "UntagResourceRequest");
   }
 }
 
@@ -2241,7 +2242,7 @@ export interface UntagResourceResponse extends $MetadataBearer {
 
 export namespace UntagResourceResponse {
   export function isa(o: any): o is UntagResourceResponse {
-    return _smithy.isa(o, "UntagResourceResponse");
+    return __isa(o, "UntagResourceResponse");
   }
 }
 
@@ -2263,7 +2264,7 @@ export interface UpdateAgentRequest {
 
 export namespace UpdateAgentRequest {
   export function isa(o: any): o is UpdateAgentRequest {
-    return _smithy.isa(o, "UpdateAgentRequest");
+    return __isa(o, "UpdateAgentRequest");
   }
 }
 
@@ -2273,7 +2274,7 @@ export interface UpdateAgentResponse extends $MetadataBearer {
 
 export namespace UpdateAgentResponse {
   export function isa(o: any): o is UpdateAgentResponse {
-    return _smithy.isa(o, "UpdateAgentResponse");
+    return __isa(o, "UpdateAgentResponse");
   }
 }
 
@@ -2330,7 +2331,7 @@ export interface UpdateTaskRequest {
 
 export namespace UpdateTaskRequest {
   export function isa(o: any): o is UpdateTaskRequest {
-    return _smithy.isa(o, "UpdateTaskRequest");
+    return __isa(o, "UpdateTaskRequest");
   }
 }
 
@@ -2340,7 +2341,7 @@ export interface UpdateTaskResponse extends $MetadataBearer {
 
 export namespace UpdateTaskResponse {
   export function isa(o: any): o is UpdateTaskResponse {
-    return _smithy.isa(o, "UpdateTaskResponse");
+    return __isa(o, "UpdateTaskResponse");
   }
 }
 

--- a/clients/client-dax/models/index.ts
+++ b/clients/client-dax/models/index.ts
@@ -1,11 +1,14 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
  * <p>Two or more incompatible parameters were specified.</p>
  */
 export interface InvalidParameterCombinationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidParameterCombinationException";
   $fault: "client";
@@ -14,7 +17,7 @@ export interface InvalidParameterCombinationException
 
 export namespace InvalidParameterCombinationException {
   export function isa(o: any): o is InvalidParameterCombinationException {
-    return _smithy.isa(o, "InvalidParameterCombinationException");
+    return __isa(o, "InvalidParameterCombinationException");
   }
 }
 
@@ -22,7 +25,7 @@ export namespace InvalidParameterCombinationException {
  * <p>The value for a parameter is invalid.</p>
  */
 export interface InvalidParameterValueException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidParameterValueException";
   $fault: "client";
@@ -31,7 +34,7 @@ export interface InvalidParameterValueException
 
 export namespace InvalidParameterValueException {
   export function isa(o: any): o is InvalidParameterValueException {
-    return _smithy.isa(o, "InvalidParameterValueException");
+    return __isa(o, "InvalidParameterValueException");
   }
 }
 
@@ -142,7 +145,7 @@ export interface Cluster {
 
 export namespace Cluster {
   export function isa(o: any): o is Cluster {
-    return _smithy.isa(o, "Cluster");
+    return __isa(o, "Cluster");
   }
 }
 
@@ -302,7 +305,7 @@ export interface CreateClusterRequest {
 
 export namespace CreateClusterRequest {
   export function isa(o: any): o is CreateClusterRequest {
-    return _smithy.isa(o, "CreateClusterRequest");
+    return __isa(o, "CreateClusterRequest");
   }
 }
 
@@ -316,7 +319,7 @@ export interface CreateClusterResponse extends $MetadataBearer {
 
 export namespace CreateClusterResponse {
   export function isa(o: any): o is CreateClusterResponse {
-    return _smithy.isa(o, "CreateClusterResponse");
+    return __isa(o, "CreateClusterResponse");
   }
 }
 
@@ -336,7 +339,7 @@ export interface CreateParameterGroupRequest {
 
 export namespace CreateParameterGroupRequest {
   export function isa(o: any): o is CreateParameterGroupRequest {
-    return _smithy.isa(o, "CreateParameterGroupRequest");
+    return __isa(o, "CreateParameterGroupRequest");
   }
 }
 
@@ -351,7 +354,7 @@ export interface CreateParameterGroupResponse extends $MetadataBearer {
 
 export namespace CreateParameterGroupResponse {
   export function isa(o: any): o is CreateParameterGroupResponse {
-    return _smithy.isa(o, "CreateParameterGroupResponse");
+    return __isa(o, "CreateParameterGroupResponse");
   }
 }
 
@@ -375,7 +378,7 @@ export interface CreateSubnetGroupRequest {
 
 export namespace CreateSubnetGroupRequest {
   export function isa(o: any): o is CreateSubnetGroupRequest {
-    return _smithy.isa(o, "CreateSubnetGroupRequest");
+    return __isa(o, "CreateSubnetGroupRequest");
   }
 }
 
@@ -390,7 +393,7 @@ export interface CreateSubnetGroupResponse extends $MetadataBearer {
 
 export namespace CreateSubnetGroupResponse {
   export function isa(o: any): o is CreateSubnetGroupResponse {
-    return _smithy.isa(o, "CreateSubnetGroupResponse");
+    return __isa(o, "CreateSubnetGroupResponse");
   }
 }
 
@@ -419,7 +422,7 @@ export interface DecreaseReplicationFactorRequest {
 
 export namespace DecreaseReplicationFactorRequest {
   export function isa(o: any): o is DecreaseReplicationFactorRequest {
-    return _smithy.isa(o, "DecreaseReplicationFactorRequest");
+    return __isa(o, "DecreaseReplicationFactorRequest");
   }
 }
 
@@ -434,7 +437,7 @@ export interface DecreaseReplicationFactorResponse extends $MetadataBearer {
 
 export namespace DecreaseReplicationFactorResponse {
   export function isa(o: any): o is DecreaseReplicationFactorResponse {
-    return _smithy.isa(o, "DecreaseReplicationFactorResponse");
+    return __isa(o, "DecreaseReplicationFactorResponse");
   }
 }
 
@@ -448,7 +451,7 @@ export interface DeleteClusterRequest {
 
 export namespace DeleteClusterRequest {
   export function isa(o: any): o is DeleteClusterRequest {
-    return _smithy.isa(o, "DeleteClusterRequest");
+    return __isa(o, "DeleteClusterRequest");
   }
 }
 
@@ -462,7 +465,7 @@ export interface DeleteClusterResponse extends $MetadataBearer {
 
 export namespace DeleteClusterResponse {
   export function isa(o: any): o is DeleteClusterResponse {
-    return _smithy.isa(o, "DeleteClusterResponse");
+    return __isa(o, "DeleteClusterResponse");
   }
 }
 
@@ -476,7 +479,7 @@ export interface DeleteParameterGroupRequest {
 
 export namespace DeleteParameterGroupRequest {
   export function isa(o: any): o is DeleteParameterGroupRequest {
-    return _smithy.isa(o, "DeleteParameterGroupRequest");
+    return __isa(o, "DeleteParameterGroupRequest");
   }
 }
 
@@ -491,7 +494,7 @@ export interface DeleteParameterGroupResponse extends $MetadataBearer {
 
 export namespace DeleteParameterGroupResponse {
   export function isa(o: any): o is DeleteParameterGroupResponse {
-    return _smithy.isa(o, "DeleteParameterGroupResponse");
+    return __isa(o, "DeleteParameterGroupResponse");
   }
 }
 
@@ -505,7 +508,7 @@ export interface DeleteSubnetGroupRequest {
 
 export namespace DeleteSubnetGroupRequest {
   export function isa(o: any): o is DeleteSubnetGroupRequest {
-    return _smithy.isa(o, "DeleteSubnetGroupRequest");
+    return __isa(o, "DeleteSubnetGroupRequest");
   }
 }
 
@@ -520,7 +523,7 @@ export interface DeleteSubnetGroupResponse extends $MetadataBearer {
 
 export namespace DeleteSubnetGroupResponse {
   export function isa(o: any): o is DeleteSubnetGroupResponse {
-    return _smithy.isa(o, "DeleteSubnetGroupResponse");
+    return __isa(o, "DeleteSubnetGroupResponse");
   }
 }
 
@@ -550,7 +553,7 @@ export interface DescribeClustersRequest {
 
 export namespace DescribeClustersRequest {
   export function isa(o: any): o is DescribeClustersRequest {
-    return _smithy.isa(o, "DescribeClustersRequest");
+    return __isa(o, "DescribeClustersRequest");
   }
 }
 
@@ -570,7 +573,7 @@ export interface DescribeClustersResponse extends $MetadataBearer {
 
 export namespace DescribeClustersResponse {
   export function isa(o: any): o is DescribeClustersResponse {
-    return _smithy.isa(o, "DescribeClustersResponse");
+    return __isa(o, "DescribeClustersResponse");
   }
 }
 
@@ -595,7 +598,7 @@ export interface DescribeDefaultParametersRequest {
 
 export namespace DescribeDefaultParametersRequest {
   export function isa(o: any): o is DescribeDefaultParametersRequest {
-    return _smithy.isa(o, "DescribeDefaultParametersRequest");
+    return __isa(o, "DescribeDefaultParametersRequest");
   }
 }
 
@@ -614,7 +617,7 @@ export interface DescribeDefaultParametersResponse extends $MetadataBearer {
 
 export namespace DescribeDefaultParametersResponse {
   export function isa(o: any): o is DescribeDefaultParametersResponse {
-    return _smithy.isa(o, "DescribeDefaultParametersResponse");
+    return __isa(o, "DescribeDefaultParametersResponse");
   }
 }
 
@@ -668,7 +671,7 @@ export interface DescribeEventsRequest {
 
 export namespace DescribeEventsRequest {
   export function isa(o: any): o is DescribeEventsRequest {
-    return _smithy.isa(o, "DescribeEventsRequest");
+    return __isa(o, "DescribeEventsRequest");
   }
 }
 
@@ -687,7 +690,7 @@ export interface DescribeEventsResponse extends $MetadataBearer {
 
 export namespace DescribeEventsResponse {
   export function isa(o: any): o is DescribeEventsResponse {
-    return _smithy.isa(o, "DescribeEventsResponse");
+    return __isa(o, "DescribeEventsResponse");
   }
 }
 
@@ -717,7 +720,7 @@ export interface DescribeParameterGroupsRequest {
 
 export namespace DescribeParameterGroupsRequest {
   export function isa(o: any): o is DescribeParameterGroupsRequest {
-    return _smithy.isa(o, "DescribeParameterGroupsRequest");
+    return __isa(o, "DescribeParameterGroupsRequest");
   }
 }
 
@@ -736,7 +739,7 @@ export interface DescribeParameterGroupsResponse extends $MetadataBearer {
 
 export namespace DescribeParameterGroupsResponse {
   export function isa(o: any): o is DescribeParameterGroupsResponse {
-    return _smithy.isa(o, "DescribeParameterGroupsResponse");
+    return __isa(o, "DescribeParameterGroupsResponse");
   }
 }
 
@@ -772,7 +775,7 @@ export interface DescribeParametersRequest {
 
 export namespace DescribeParametersRequest {
   export function isa(o: any): o is DescribeParametersRequest {
-    return _smithy.isa(o, "DescribeParametersRequest");
+    return __isa(o, "DescribeParametersRequest");
   }
 }
 
@@ -791,7 +794,7 @@ export interface DescribeParametersResponse extends $MetadataBearer {
 
 export namespace DescribeParametersResponse {
   export function isa(o: any): o is DescribeParametersResponse {
-    return _smithy.isa(o, "DescribeParametersResponse");
+    return __isa(o, "DescribeParametersResponse");
   }
 }
 
@@ -821,7 +824,7 @@ export interface DescribeSubnetGroupsRequest {
 
 export namespace DescribeSubnetGroupsRequest {
   export function isa(o: any): o is DescribeSubnetGroupsRequest {
-    return _smithy.isa(o, "DescribeSubnetGroupsRequest");
+    return __isa(o, "DescribeSubnetGroupsRequest");
   }
 }
 
@@ -840,7 +843,7 @@ export interface DescribeSubnetGroupsResponse extends $MetadataBearer {
 
 export namespace DescribeSubnetGroupsResponse {
   export function isa(o: any): o is DescribeSubnetGroupsResponse {
-    return _smithy.isa(o, "DescribeSubnetGroupsResponse");
+    return __isa(o, "DescribeSubnetGroupsResponse");
   }
 }
 
@@ -864,7 +867,7 @@ export interface Endpoint {
 
 export namespace Endpoint {
   export function isa(o: any): o is Endpoint {
-    return _smithy.isa(o, "Endpoint");
+    return __isa(o, "Endpoint");
   }
 }
 
@@ -900,7 +903,7 @@ export interface Event {
 
 export namespace Event {
   export function isa(o: any): o is Event {
-    return _smithy.isa(o, "Event");
+    return __isa(o, "Event");
   }
 }
 
@@ -926,7 +929,7 @@ export interface IncreaseReplicationFactorRequest {
 
 export namespace IncreaseReplicationFactorRequest {
   export function isa(o: any): o is IncreaseReplicationFactorRequest {
-    return _smithy.isa(o, "IncreaseReplicationFactorRequest");
+    return __isa(o, "IncreaseReplicationFactorRequest");
   }
 }
 
@@ -940,7 +943,7 @@ export interface IncreaseReplicationFactorResponse extends $MetadataBearer {
 
 export namespace IncreaseReplicationFactorResponse {
   export function isa(o: any): o is IncreaseReplicationFactorResponse {
-    return _smithy.isa(o, "IncreaseReplicationFactorResponse");
+    return __isa(o, "IncreaseReplicationFactorResponse");
   }
 }
 
@@ -963,7 +966,7 @@ export interface ListTagsRequest {
 
 export namespace ListTagsRequest {
   export function isa(o: any): o is ListTagsRequest {
-    return _smithy.isa(o, "ListTagsRequest");
+    return __isa(o, "ListTagsRequest");
   }
 }
 
@@ -983,7 +986,7 @@ export interface ListTagsResponse extends $MetadataBearer {
 
 export namespace ListTagsResponse {
   export function isa(o: any): o is ListTagsResponse {
-    return _smithy.isa(o, "ListTagsResponse");
+    return __isa(o, "ListTagsResponse");
   }
 }
 
@@ -1029,7 +1032,7 @@ export interface Node {
 
 export namespace Node {
   export function isa(o: any): o is Node {
-    return _smithy.isa(o, "Node");
+    return __isa(o, "Node");
   }
 }
 
@@ -1052,7 +1055,7 @@ export interface NodeTypeSpecificValue {
 
 export namespace NodeTypeSpecificValue {
   export function isa(o: any): o is NodeTypeSpecificValue {
-    return _smithy.isa(o, "NodeTypeSpecificValue");
+    return __isa(o, "NodeTypeSpecificValue");
   }
 }
 
@@ -1076,7 +1079,7 @@ export interface NotificationConfiguration {
 
 export namespace NotificationConfiguration {
   export function isa(o: any): o is NotificationConfiguration {
-    return _smithy.isa(o, "NotificationConfiguration");
+    return __isa(o, "NotificationConfiguration");
   }
 }
 
@@ -1143,7 +1146,7 @@ export interface Parameter {
 
 export namespace Parameter {
   export function isa(o: any): o is Parameter {
-    return _smithy.isa(o, "Parameter");
+    return __isa(o, "Parameter");
   }
 }
 
@@ -1166,7 +1169,7 @@ export interface ParameterGroup {
 
 export namespace ParameterGroup {
   export function isa(o: any): o is ParameterGroup {
-    return _smithy.isa(o, "ParameterGroup");
+    return __isa(o, "ParameterGroup");
   }
 }
 
@@ -1193,7 +1196,7 @@ export interface ParameterGroupStatus {
 
 export namespace ParameterGroupStatus {
   export function isa(o: any): o is ParameterGroupStatus {
-    return _smithy.isa(o, "ParameterGroupStatus");
+    return __isa(o, "ParameterGroupStatus");
   }
 }
 
@@ -1215,7 +1218,7 @@ export interface ParameterNameValue {
 
 export namespace ParameterNameValue {
   export function isa(o: any): o is ParameterNameValue {
-    return _smithy.isa(o, "ParameterNameValue");
+    return __isa(o, "ParameterNameValue");
   }
 }
 
@@ -1236,7 +1239,7 @@ export interface RebootNodeRequest {
 
 export namespace RebootNodeRequest {
   export function isa(o: any): o is RebootNodeRequest {
-    return _smithy.isa(o, "RebootNodeRequest");
+    return __isa(o, "RebootNodeRequest");
   }
 }
 
@@ -1250,7 +1253,7 @@ export interface RebootNodeResponse extends $MetadataBearer {
 
 export namespace RebootNodeResponse {
   export function isa(o: any): o is RebootNodeResponse {
-    return _smithy.isa(o, "RebootNodeResponse");
+    return __isa(o, "RebootNodeResponse");
   }
 }
 
@@ -1285,7 +1288,7 @@ export interface SSEDescription {
 
 export namespace SSEDescription {
   export function isa(o: any): o is SSEDescription {
-    return _smithy.isa(o, "SSEDescription");
+    return __isa(o, "SSEDescription");
   }
 }
 
@@ -1302,7 +1305,7 @@ export interface SSESpecification {
 
 export namespace SSESpecification {
   export function isa(o: any): o is SSESpecification {
-    return _smithy.isa(o, "SSESpecification");
+    return __isa(o, "SSESpecification");
   }
 }
 
@@ -1326,7 +1329,7 @@ export interface SecurityGroupMembership {
 
 export namespace SecurityGroupMembership {
   export function isa(o: any): o is SecurityGroupMembership {
-    return _smithy.isa(o, "SecurityGroupMembership");
+    return __isa(o, "SecurityGroupMembership");
   }
 }
 
@@ -1352,7 +1355,7 @@ export interface Subnet {
 
 export namespace Subnet {
   export function isa(o: any): o is Subnet {
-    return _smithy.isa(o, "Subnet");
+    return __isa(o, "Subnet");
   }
 }
 
@@ -1396,7 +1399,7 @@ export interface SubnetGroup {
 
 export namespace SubnetGroup {
   export function isa(o: any): o is SubnetGroup {
-    return _smithy.isa(o, "SubnetGroup");
+    return __isa(o, "SubnetGroup");
   }
 }
 
@@ -1425,7 +1428,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -1444,7 +1447,7 @@ export interface TagResourceRequest {
 
 export namespace TagResourceRequest {
   export function isa(o: any): o is TagResourceRequest {
-    return _smithy.isa(o, "TagResourceRequest");
+    return __isa(o, "TagResourceRequest");
   }
 }
 
@@ -1458,7 +1461,7 @@ export interface TagResourceResponse extends $MetadataBearer {
 
 export namespace TagResourceResponse {
   export function isa(o: any): o is TagResourceResponse {
-    return _smithy.isa(o, "TagResourceResponse");
+    return __isa(o, "TagResourceResponse");
   }
 }
 
@@ -1477,7 +1480,7 @@ export interface UntagResourceRequest {
 
 export namespace UntagResourceRequest {
   export function isa(o: any): o is UntagResourceRequest {
-    return _smithy.isa(o, "UntagResourceRequest");
+    return __isa(o, "UntagResourceRequest");
   }
 }
 
@@ -1491,7 +1494,7 @@ export interface UntagResourceResponse extends $MetadataBearer {
 
 export namespace UntagResourceResponse {
   export function isa(o: any): o is UntagResourceResponse {
-    return _smithy.isa(o, "UntagResourceResponse");
+    return __isa(o, "UntagResourceResponse");
   }
 }
 
@@ -1538,7 +1541,7 @@ export interface UpdateClusterRequest {
 
 export namespace UpdateClusterRequest {
   export function isa(o: any): o is UpdateClusterRequest {
-    return _smithy.isa(o, "UpdateClusterRequest");
+    return __isa(o, "UpdateClusterRequest");
   }
 }
 
@@ -1552,7 +1555,7 @@ export interface UpdateClusterResponse extends $MetadataBearer {
 
 export namespace UpdateClusterResponse {
   export function isa(o: any): o is UpdateClusterResponse {
-    return _smithy.isa(o, "UpdateClusterResponse");
+    return __isa(o, "UpdateClusterResponse");
   }
 }
 
@@ -1572,7 +1575,7 @@ export interface UpdateParameterGroupRequest {
 
 export namespace UpdateParameterGroupRequest {
   export function isa(o: any): o is UpdateParameterGroupRequest {
-    return _smithy.isa(o, "UpdateParameterGroupRequest");
+    return __isa(o, "UpdateParameterGroupRequest");
   }
 }
 
@@ -1586,7 +1589,7 @@ export interface UpdateParameterGroupResponse extends $MetadataBearer {
 
 export namespace UpdateParameterGroupResponse {
   export function isa(o: any): o is UpdateParameterGroupResponse {
-    return _smithy.isa(o, "UpdateParameterGroupResponse");
+    return __isa(o, "UpdateParameterGroupResponse");
   }
 }
 
@@ -1610,7 +1613,7 @@ export interface UpdateSubnetGroupRequest {
 
 export namespace UpdateSubnetGroupRequest {
   export function isa(o: any): o is UpdateSubnetGroupRequest {
-    return _smithy.isa(o, "UpdateSubnetGroupRequest");
+    return __isa(o, "UpdateSubnetGroupRequest");
   }
 }
 
@@ -1624,7 +1627,7 @@ export interface UpdateSubnetGroupResponse extends $MetadataBearer {
 
 export namespace UpdateSubnetGroupResponse {
   export function isa(o: any): o is UpdateSubnetGroupResponse {
-    return _smithy.isa(o, "UpdateSubnetGroupResponse");
+    return __isa(o, "UpdateSubnetGroupResponse");
   }
 }
 
@@ -1632,7 +1635,7 @@ export namespace UpdateSubnetGroupResponse {
  * <p>You already have a DAX cluster with the given identifier.</p>
  */
 export interface ClusterAlreadyExistsFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ClusterAlreadyExistsFault";
   $fault: "client";
@@ -1641,7 +1644,7 @@ export interface ClusterAlreadyExistsFault
 
 export namespace ClusterAlreadyExistsFault {
   export function isa(o: any): o is ClusterAlreadyExistsFault {
-    return _smithy.isa(o, "ClusterAlreadyExistsFault");
+    return __isa(o, "ClusterAlreadyExistsFault");
   }
 }
 
@@ -1649,7 +1652,7 @@ export namespace ClusterAlreadyExistsFault {
  * <p>The requested cluster ID does not refer to an existing DAX cluster.</p>
  */
 export interface ClusterNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ClusterNotFoundFault";
   $fault: "client";
@@ -1658,7 +1661,7 @@ export interface ClusterNotFoundFault
 
 export namespace ClusterNotFoundFault {
   export function isa(o: any): o is ClusterNotFoundFault {
-    return _smithy.isa(o, "ClusterNotFoundFault");
+    return __isa(o, "ClusterNotFoundFault");
   }
 }
 
@@ -1667,7 +1670,7 @@ export namespace ClusterNotFoundFault {
  *             account.</p>
  */
 export interface ClusterQuotaForCustomerExceededFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ClusterQuotaForCustomerExceededFault";
   $fault: "client";
@@ -1676,7 +1679,7 @@ export interface ClusterQuotaForCustomerExceededFault
 
 export namespace ClusterQuotaForCustomerExceededFault {
   export function isa(o: any): o is ClusterQuotaForCustomerExceededFault {
-    return _smithy.isa(o, "ClusterQuotaForCustomerExceededFault");
+    return __isa(o, "ClusterQuotaForCustomerExceededFault");
   }
 }
 
@@ -1685,7 +1688,7 @@ export namespace ClusterQuotaForCustomerExceededFault {
  *             resize an already-existing cluster). </p>
  */
 export interface InsufficientClusterCapacityFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InsufficientClusterCapacityFault";
   $fault: "client";
@@ -1694,16 +1697,14 @@ export interface InsufficientClusterCapacityFault
 
 export namespace InsufficientClusterCapacityFault {
   export function isa(o: any): o is InsufficientClusterCapacityFault {
-    return _smithy.isa(o, "InsufficientClusterCapacityFault");
+    return __isa(o, "InsufficientClusterCapacityFault");
   }
 }
 
 /**
  * <p>The Amazon Resource Name (ARN) supplied in the request is not valid.</p>
  */
-export interface InvalidARNFault
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface InvalidARNFault extends __SmithyException, $MetadataBearer {
   name: "InvalidARNFault";
   $fault: "client";
   message?: string;
@@ -1711,7 +1712,7 @@ export interface InvalidARNFault
 
 export namespace InvalidARNFault {
   export function isa(o: any): o is InvalidARNFault {
-    return _smithy.isa(o, "InvalidARNFault");
+    return __isa(o, "InvalidARNFault");
   }
 }
 
@@ -1720,7 +1721,7 @@ export namespace InvalidARNFault {
  *             state.</p>
  */
 export interface InvalidClusterStateFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidClusterStateFault";
   $fault: "client";
@@ -1729,7 +1730,7 @@ export interface InvalidClusterStateFault
 
 export namespace InvalidClusterStateFault {
   export function isa(o: any): o is InvalidClusterStateFault {
-    return _smithy.isa(o, "InvalidClusterStateFault");
+    return __isa(o, "InvalidClusterStateFault");
   }
 }
 
@@ -1737,7 +1738,7 @@ export namespace InvalidClusterStateFault {
  * <p>One or more parameters in a parameter group are in an invalid state.</p>
  */
 export interface InvalidParameterGroupStateFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidParameterGroupStateFault";
   $fault: "client";
@@ -1746,16 +1747,14 @@ export interface InvalidParameterGroupStateFault
 
 export namespace InvalidParameterGroupStateFault {
   export function isa(o: any): o is InvalidParameterGroupStateFault {
-    return _smithy.isa(o, "InvalidParameterGroupStateFault");
+    return __isa(o, "InvalidParameterGroupStateFault");
   }
 }
 
 /**
  * <p>An invalid subnet identifier was specified.</p>
  */
-export interface InvalidSubnet
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface InvalidSubnet extends __SmithyException, $MetadataBearer {
   name: "InvalidSubnet";
   $fault: "client";
   message?: string;
@@ -1763,7 +1762,7 @@ export interface InvalidSubnet
 
 export namespace InvalidSubnet {
   export function isa(o: any): o is InvalidSubnet {
-    return _smithy.isa(o, "InvalidSubnet");
+    return __isa(o, "InvalidSubnet");
   }
 }
 
@@ -1771,7 +1770,7 @@ export namespace InvalidSubnet {
  * <p>The VPC network is in an invalid state.</p>
  */
 export interface InvalidVPCNetworkStateFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidVPCNetworkStateFault";
   $fault: "client";
@@ -1780,16 +1779,14 @@ export interface InvalidVPCNetworkStateFault
 
 export namespace InvalidVPCNetworkStateFault {
   export function isa(o: any): o is InvalidVPCNetworkStateFault {
-    return _smithy.isa(o, "InvalidVPCNetworkStateFault");
+    return __isa(o, "InvalidVPCNetworkStateFault");
   }
 }
 
 /**
  * <p>None of the nodes in the cluster have the given node ID.</p>
  */
-export interface NodeNotFoundFault
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface NodeNotFoundFault extends __SmithyException, $MetadataBearer {
   name: "NodeNotFoundFault";
   $fault: "client";
   message?: string;
@@ -1797,7 +1794,7 @@ export interface NodeNotFoundFault
 
 export namespace NodeNotFoundFault {
   export function isa(o: any): o is NodeNotFoundFault {
-    return _smithy.isa(o, "NodeNotFoundFault");
+    return __isa(o, "NodeNotFoundFault");
   }
 }
 
@@ -1806,7 +1803,7 @@ export namespace NodeNotFoundFault {
  *             cluster.</p>
  */
 export interface NodeQuotaForClusterExceededFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "NodeQuotaForClusterExceededFault";
   $fault: "client";
@@ -1815,7 +1812,7 @@ export interface NodeQuotaForClusterExceededFault
 
 export namespace NodeQuotaForClusterExceededFault {
   export function isa(o: any): o is NodeQuotaForClusterExceededFault {
-    return _smithy.isa(o, "NodeQuotaForClusterExceededFault");
+    return __isa(o, "NodeQuotaForClusterExceededFault");
   }
 }
 
@@ -1824,7 +1821,7 @@ export namespace NodeQuotaForClusterExceededFault {
  *             account.</p>
  */
 export interface NodeQuotaForCustomerExceededFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "NodeQuotaForCustomerExceededFault";
   $fault: "client";
@@ -1833,7 +1830,7 @@ export interface NodeQuotaForCustomerExceededFault
 
 export namespace NodeQuotaForCustomerExceededFault {
   export function isa(o: any): o is NodeQuotaForCustomerExceededFault {
-    return _smithy.isa(o, "NodeQuotaForCustomerExceededFault");
+    return __isa(o, "NodeQuotaForCustomerExceededFault");
   }
 }
 
@@ -1841,7 +1838,7 @@ export namespace NodeQuotaForCustomerExceededFault {
  * <p>The specified parameter group already exists.</p>
  */
 export interface ParameterGroupAlreadyExistsFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ParameterGroupAlreadyExistsFault";
   $fault: "client";
@@ -1850,7 +1847,7 @@ export interface ParameterGroupAlreadyExistsFault
 
 export namespace ParameterGroupAlreadyExistsFault {
   export function isa(o: any): o is ParameterGroupAlreadyExistsFault {
-    return _smithy.isa(o, "ParameterGroupAlreadyExistsFault");
+    return __isa(o, "ParameterGroupAlreadyExistsFault");
   }
 }
 
@@ -1858,7 +1855,7 @@ export namespace ParameterGroupAlreadyExistsFault {
  * <p>The specified parameter group does not exist.</p>
  */
 export interface ParameterGroupNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ParameterGroupNotFoundFault";
   $fault: "client";
@@ -1867,7 +1864,7 @@ export interface ParameterGroupNotFoundFault
 
 export namespace ParameterGroupNotFoundFault {
   export function isa(o: any): o is ParameterGroupNotFoundFault {
-    return _smithy.isa(o, "ParameterGroupNotFoundFault");
+    return __isa(o, "ParameterGroupNotFoundFault");
   }
 }
 
@@ -1875,7 +1872,7 @@ export namespace ParameterGroupNotFoundFault {
  * <p>You have attempted to exceed the maximum number of parameter groups.</p>
  */
 export interface ParameterGroupQuotaExceededFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ParameterGroupQuotaExceededFault";
   $fault: "client";
@@ -1884,7 +1881,7 @@ export interface ParameterGroupQuotaExceededFault
 
 export namespace ParameterGroupQuotaExceededFault {
   export function isa(o: any): o is ParameterGroupQuotaExceededFault {
-    return _smithy.isa(o, "ParameterGroupQuotaExceededFault");
+    return __isa(o, "ParameterGroupQuotaExceededFault");
   }
 }
 
@@ -1892,7 +1889,7 @@ export namespace ParameterGroupQuotaExceededFault {
  * <p>The specified service linked role (SLR) was not found.</p>
  */
 export interface ServiceLinkedRoleNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ServiceLinkedRoleNotFoundFault";
   $fault: "client";
@@ -1901,7 +1898,7 @@ export interface ServiceLinkedRoleNotFoundFault
 
 export namespace ServiceLinkedRoleNotFoundFault {
   export function isa(o: any): o is ServiceLinkedRoleNotFoundFault {
-    return _smithy.isa(o, "ServiceLinkedRoleNotFoundFault");
+    return __isa(o, "ServiceLinkedRoleNotFoundFault");
   }
 }
 
@@ -1909,7 +1906,7 @@ export namespace ServiceLinkedRoleNotFoundFault {
  * <p>The specified subnet group already exists.</p>
  */
 export interface SubnetGroupAlreadyExistsFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "SubnetGroupAlreadyExistsFault";
   $fault: "client";
@@ -1918,7 +1915,7 @@ export interface SubnetGroupAlreadyExistsFault
 
 export namespace SubnetGroupAlreadyExistsFault {
   export function isa(o: any): o is SubnetGroupAlreadyExistsFault {
-    return _smithy.isa(o, "SubnetGroupAlreadyExistsFault");
+    return __isa(o, "SubnetGroupAlreadyExistsFault");
   }
 }
 
@@ -1926,7 +1923,7 @@ export namespace SubnetGroupAlreadyExistsFault {
  * <p>The specified subnet group is currently in use.</p>
  */
 export interface SubnetGroupInUseFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "SubnetGroupInUseFault";
   $fault: "client";
@@ -1935,7 +1932,7 @@ export interface SubnetGroupInUseFault
 
 export namespace SubnetGroupInUseFault {
   export function isa(o: any): o is SubnetGroupInUseFault {
-    return _smithy.isa(o, "SubnetGroupInUseFault");
+    return __isa(o, "SubnetGroupInUseFault");
   }
 }
 
@@ -1944,7 +1941,7 @@ export namespace SubnetGroupInUseFault {
  *             group.</p>
  */
 export interface SubnetGroupNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "SubnetGroupNotFoundFault";
   $fault: "client";
@@ -1953,7 +1950,7 @@ export interface SubnetGroupNotFoundFault
 
 export namespace SubnetGroupNotFoundFault {
   export function isa(o: any): o is SubnetGroupNotFoundFault {
-    return _smithy.isa(o, "SubnetGroupNotFoundFault");
+    return __isa(o, "SubnetGroupNotFoundFault");
   }
 }
 
@@ -1962,7 +1959,7 @@ export namespace SubnetGroupNotFoundFault {
  *             subnets in a subnet group.</p>
  */
 export interface SubnetGroupQuotaExceededFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "SubnetGroupQuotaExceededFault";
   $fault: "client";
@@ -1971,14 +1968,14 @@ export interface SubnetGroupQuotaExceededFault
 
 export namespace SubnetGroupQuotaExceededFault {
   export function isa(o: any): o is SubnetGroupQuotaExceededFault {
-    return _smithy.isa(o, "SubnetGroupQuotaExceededFault");
+    return __isa(o, "SubnetGroupQuotaExceededFault");
   }
 }
 
 /**
  * <p>The requested subnet is being used by another subnet group.</p>
  */
-export interface SubnetInUse extends _smithy.SmithyException, $MetadataBearer {
+export interface SubnetInUse extends __SmithyException, $MetadataBearer {
   name: "SubnetInUse";
   $fault: "client";
   message?: string;
@@ -1986,7 +1983,7 @@ export interface SubnetInUse extends _smithy.SmithyException, $MetadataBearer {
 
 export namespace SubnetInUse {
   export function isa(o: any): o is SubnetInUse {
-    return _smithy.isa(o, "SubnetInUse");
+    return __isa(o, "SubnetInUse");
   }
 }
 
@@ -1995,7 +1992,7 @@ export namespace SubnetInUse {
  *             subnets in a subnet group.</p>
  */
 export interface SubnetQuotaExceededFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "SubnetQuotaExceededFault";
   $fault: "client";
@@ -2004,16 +2001,14 @@ export interface SubnetQuotaExceededFault
 
 export namespace SubnetQuotaExceededFault {
   export function isa(o: any): o is SubnetQuotaExceededFault {
-    return _smithy.isa(o, "SubnetQuotaExceededFault");
+    return __isa(o, "SubnetQuotaExceededFault");
   }
 }
 
 /**
  * <p>The tag does not exist.</p>
  */
-export interface TagNotFoundFault
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface TagNotFoundFault extends __SmithyException, $MetadataBearer {
   name: "TagNotFoundFault";
   $fault: "client";
   message?: string;
@@ -2021,7 +2016,7 @@ export interface TagNotFoundFault
 
 export namespace TagNotFoundFault {
   export function isa(o: any): o is TagNotFoundFault {
-    return _smithy.isa(o, "TagNotFoundFault");
+    return __isa(o, "TagNotFoundFault");
   }
 }
 
@@ -2029,7 +2024,7 @@ export namespace TagNotFoundFault {
  * <p>You have exceeded the maximum number of tags for this DAX cluster.</p>
  */
 export interface TagQuotaPerResourceExceeded
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TagQuotaPerResourceExceeded";
   $fault: "client";
@@ -2038,6 +2033,6 @@ export interface TagQuotaPerResourceExceeded
 
 export namespace TagQuotaPerResourceExceeded {
   export function isa(o: any): o is TagQuotaPerResourceExceeded {
-    return _smithy.isa(o, "TagQuotaPerResourceExceeded");
+    return __isa(o, "TagQuotaPerResourceExceeded");
   }
 }

--- a/clients/client-detective/models/index.ts
+++ b/clients/client-detective/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export interface AcceptInvitationRequest {
@@ -13,7 +16,7 @@ export interface AcceptInvitationRequest {
 
 export namespace AcceptInvitationRequest {
   export function isa(o: any): o is AcceptInvitationRequest {
-    return _smithy.isa(o, "AcceptInvitationRequest");
+    return __isa(o, "AcceptInvitationRequest");
   }
 }
 
@@ -37,16 +40,14 @@ export interface Account {
 
 export namespace Account {
   export function isa(o: any): o is Account {
-    return _smithy.isa(o, "Account");
+    return __isa(o, "Account");
   }
 }
 
 /**
  * <p>The request attempted an invalid action.</p>
  */
-export interface ConflictException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface ConflictException extends __SmithyException, $MetadataBearer {
   name: "ConflictException";
   $fault: "client";
   Message?: string;
@@ -54,7 +55,7 @@ export interface ConflictException
 
 export namespace ConflictException {
   export function isa(o: any): o is ConflictException {
-    return _smithy.isa(o, "ConflictException");
+    return __isa(o, "ConflictException");
   }
 }
 
@@ -68,7 +69,7 @@ export interface CreateGraphResponse extends $MetadataBearer {
 
 export namespace CreateGraphResponse {
   export function isa(o: any): o is CreateGraphResponse {
-    return _smithy.isa(o, "CreateGraphResponse");
+    return __isa(o, "CreateGraphResponse");
   }
 }
 
@@ -96,7 +97,7 @@ export interface CreateMembersRequest {
 
 export namespace CreateMembersRequest {
   export function isa(o: any): o is CreateMembersRequest {
-    return _smithy.isa(o, "CreateMembersRequest");
+    return __isa(o, "CreateMembersRequest");
   }
 }
 
@@ -119,7 +120,7 @@ export interface CreateMembersResponse extends $MetadataBearer {
 
 export namespace CreateMembersResponse {
   export function isa(o: any): o is CreateMembersResponse {
-    return _smithy.isa(o, "CreateMembersResponse");
+    return __isa(o, "CreateMembersResponse");
   }
 }
 
@@ -133,7 +134,7 @@ export interface DeleteGraphRequest {
 
 export namespace DeleteGraphRequest {
   export function isa(o: any): o is DeleteGraphRequest {
-    return _smithy.isa(o, "DeleteGraphRequest");
+    return __isa(o, "DeleteGraphRequest");
   }
 }
 
@@ -153,7 +154,7 @@ export interface DeleteMembersRequest {
 
 export namespace DeleteMembersRequest {
   export function isa(o: any): o is DeleteMembersRequest {
-    return _smithy.isa(o, "DeleteMembersRequest");
+    return __isa(o, "DeleteMembersRequest");
   }
 }
 
@@ -175,7 +176,7 @@ export interface DeleteMembersResponse extends $MetadataBearer {
 
 export namespace DeleteMembersResponse {
   export function isa(o: any): o is DeleteMembersResponse {
-    return _smithy.isa(o, "DeleteMembersResponse");
+    return __isa(o, "DeleteMembersResponse");
   }
 }
 
@@ -191,7 +192,7 @@ export interface DisassociateMembershipRequest {
 
 export namespace DisassociateMembershipRequest {
   export function isa(o: any): o is DisassociateMembershipRequest {
-    return _smithy.isa(o, "DisassociateMembershipRequest");
+    return __isa(o, "DisassociateMembershipRequest");
   }
 }
 
@@ -213,7 +214,7 @@ export interface GetMembersRequest {
 
 export namespace GetMembersRequest {
   export function isa(o: any): o is GetMembersRequest {
-    return _smithy.isa(o, "GetMembersRequest");
+    return __isa(o, "GetMembersRequest");
   }
 }
 
@@ -234,7 +235,7 @@ export interface GetMembersResponse extends $MetadataBearer {
 
 export namespace GetMembersResponse {
   export function isa(o: any): o is GetMembersResponse {
-    return _smithy.isa(o, "GetMembersResponse");
+    return __isa(o, "GetMembersResponse");
   }
 }
 
@@ -259,7 +260,7 @@ export interface Graph {
 
 export namespace Graph {
   export function isa(o: any): o is Graph {
-    return _smithy.isa(o, "Graph");
+    return __isa(o, "Graph");
   }
 }
 
@@ -267,7 +268,7 @@ export namespace Graph {
  * <p>The request was valid but failed because of a problem with the service.</p>
  */
 export interface InternalServerException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalServerException";
   $fault: "server";
@@ -276,7 +277,7 @@ export interface InternalServerException
 
 export namespace InternalServerException {
   export function isa(o: any): o is InternalServerException {
-    return _smithy.isa(o, "InternalServerException");
+    return __isa(o, "InternalServerException");
   }
 }
 
@@ -298,7 +299,7 @@ export interface ListGraphsRequest {
 
 export namespace ListGraphsRequest {
   export function isa(o: any): o is ListGraphsRequest {
-    return _smithy.isa(o, "ListGraphsRequest");
+    return __isa(o, "ListGraphsRequest");
   }
 }
 
@@ -318,7 +319,7 @@ export interface ListGraphsResponse extends $MetadataBearer {
 
 export namespace ListGraphsResponse {
   export function isa(o: any): o is ListGraphsResponse {
-    return _smithy.isa(o, "ListGraphsResponse");
+    return __isa(o, "ListGraphsResponse");
   }
 }
 
@@ -341,7 +342,7 @@ export interface ListInvitationsRequest {
 
 export namespace ListInvitationsRequest {
   export function isa(o: any): o is ListInvitationsRequest {
-    return _smithy.isa(o, "ListInvitationsRequest");
+    return __isa(o, "ListInvitationsRequest");
   }
 }
 
@@ -362,7 +363,7 @@ export interface ListInvitationsResponse extends $MetadataBearer {
 
 export namespace ListInvitationsResponse {
   export function isa(o: any): o is ListInvitationsResponse {
-    return _smithy.isa(o, "ListInvitationsResponse");
+    return __isa(o, "ListInvitationsResponse");
   }
 }
 
@@ -389,7 +390,7 @@ export interface ListMembersRequest {
 
 export namespace ListMembersRequest {
   export function isa(o: any): o is ListMembersRequest {
-    return _smithy.isa(o, "ListMembersRequest");
+    return __isa(o, "ListMembersRequest");
   }
 }
 
@@ -412,7 +413,7 @@ export interface ListMembersResponse extends $MetadataBearer {
 
 export namespace ListMembersResponse {
   export function isa(o: any): o is ListMembersResponse {
-    return _smithy.isa(o, "ListMembersResponse");
+    return __isa(o, "ListMembersResponse");
   }
 }
 
@@ -493,7 +494,7 @@ export interface MemberDetail {
 
 export namespace MemberDetail {
   export function isa(o: any): o is MemberDetail {
-    return _smithy.isa(o, "MemberDetail");
+    return __isa(o, "MemberDetail");
   }
 }
 
@@ -516,7 +517,7 @@ export interface RejectInvitationRequest {
 
 export namespace RejectInvitationRequest {
   export function isa(o: any): o is RejectInvitationRequest {
-    return _smithy.isa(o, "RejectInvitationRequest");
+    return __isa(o, "RejectInvitationRequest");
   }
 }
 
@@ -524,7 +525,7 @@ export namespace RejectInvitationRequest {
  * <p>The request refers to a nonexistent resource.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -533,7 +534,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -542,7 +543,7 @@ export namespace ResourceNotFoundException {
  *          the maximum allowed. A behavior graph cannot have more than 1000 member accounts.</p>
  */
 export interface ServiceQuotaExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ServiceQuotaExceededException";
   $fault: "client";
@@ -551,7 +552,7 @@ export interface ServiceQuotaExceededException
 
 export namespace ServiceQuotaExceededException {
   export function isa(o: any): o is ServiceQuotaExceededException {
-    return _smithy.isa(o, "ServiceQuotaExceededException");
+    return __isa(o, "ServiceQuotaExceededException");
   }
 }
 
@@ -577,7 +578,7 @@ export interface UnprocessedAccount {
 
 export namespace UnprocessedAccount {
   export function isa(o: any): o is UnprocessedAccount {
-    return _smithy.isa(o, "UnprocessedAccount");
+    return __isa(o, "UnprocessedAccount");
   }
 }
 
@@ -585,7 +586,7 @@ export namespace UnprocessedAccount {
  * <p>The request parameters are invalid.</p>
  */
 export interface ValidationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ValidationException";
   $fault: "client";
@@ -594,6 +595,6 @@ export interface ValidationException
 
 export namespace ValidationException {
   export function isa(o: any): o is ValidationException {
-    return _smithy.isa(o, "ValidationException");
+    return __isa(o, "ValidationException");
   }
 }

--- a/clients/client-detective/protocols/Aws_restJson1_1.ts
+++ b/clients/client-detective/protocols/Aws_restJson1_1.ts
@@ -357,6 +357,7 @@ export async function deserializeAws_restJson1_1AcceptInvitationCommand(
   const contents: AcceptInvitationCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -572,6 +573,7 @@ export async function deserializeAws_restJson1_1DeleteGraphCommand(
   const contents: DeleteGraphCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -723,6 +725,7 @@ export async function deserializeAws_restJson1_1DisassociateMembershipCommand(
   const contents: DisassociateMembershipCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -1085,6 +1088,7 @@ export async function deserializeAws_restJson1_1RejectInvitationCommand(
   const contents: RejectInvitationCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 

--- a/clients/client-device-farm/models/index.ts
+++ b/clients/client-device-farm/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -58,16 +61,14 @@ export interface AccountSettings {
 
 export namespace AccountSettings {
   export function isa(o: any): o is AccountSettings {
-    return _smithy.isa(o, "AccountSettings");
+    return __isa(o, "AccountSettings");
   }
 }
 
 /**
  * <p>An invalid argument was specified.</p>
  */
-export interface ArgumentException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface ArgumentException extends __SmithyException, $MetadataBearer {
   name: "ArgumentException";
   $fault: "client";
   /**
@@ -78,7 +79,7 @@ export interface ArgumentException
 
 export namespace ArgumentException {
   export function isa(o: any): o is ArgumentException {
-    return _smithy.isa(o, "ArgumentException");
+    return __isa(o, "ArgumentException");
   }
 }
 
@@ -204,7 +205,7 @@ export interface Artifact {
 
 export namespace Artifact {
   export function isa(o: any): o is Artifact {
-    return _smithy.isa(o, "Artifact");
+    return __isa(o, "Artifact");
   }
 }
 
@@ -275,7 +276,7 @@ export interface CPU {
 
 export namespace CPU {
   export function isa(o: any): o is CPU {
-    return _smithy.isa(o, "CPU");
+    return __isa(o, "CPU");
   }
 }
 
@@ -283,7 +284,7 @@ export namespace CPU {
  * <p>The requested object could not be deleted.</p>
  */
 export interface CannotDeleteException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CannotDeleteException";
   $fault: "client";
@@ -292,7 +293,7 @@ export interface CannotDeleteException
 
 export namespace CannotDeleteException {
   export function isa(o: any): o is CannotDeleteException {
-    return _smithy.isa(o, "CannotDeleteException");
+    return __isa(o, "CannotDeleteException");
   }
 }
 
@@ -339,7 +340,7 @@ export interface Counters {
 
 export namespace Counters {
   export function isa(o: any): o is Counters {
-    return _smithy.isa(o, "Counters");
+    return __isa(o, "Counters");
   }
 }
 
@@ -381,7 +382,7 @@ export interface CreateDevicePoolRequest {
 
 export namespace CreateDevicePoolRequest {
   export function isa(o: any): o is CreateDevicePoolRequest {
-    return _smithy.isa(o, "CreateDevicePoolRequest");
+    return __isa(o, "CreateDevicePoolRequest");
   }
 }
 
@@ -398,7 +399,7 @@ export interface CreateDevicePoolResult extends $MetadataBearer {
 
 export namespace CreateDevicePoolResult {
   export function isa(o: any): o is CreateDevicePoolResult {
-    return _smithy.isa(o, "CreateDevicePoolResult");
+    return __isa(o, "CreateDevicePoolResult");
   }
 }
 
@@ -437,7 +438,7 @@ export interface CreateInstanceProfileRequest {
 
 export namespace CreateInstanceProfileRequest {
   export function isa(o: any): o is CreateInstanceProfileRequest {
-    return _smithy.isa(o, "CreateInstanceProfileRequest");
+    return __isa(o, "CreateInstanceProfileRequest");
   }
 }
 
@@ -451,7 +452,7 @@ export interface CreateInstanceProfileResult extends $MetadataBearer {
 
 export namespace CreateInstanceProfileResult {
   export function isa(o: any): o is CreateInstanceProfileResult {
-    return _smithy.isa(o, "CreateInstanceProfileResult");
+    return __isa(o, "CreateInstanceProfileResult");
   }
 }
 
@@ -528,7 +529,7 @@ export interface CreateNetworkProfileRequest {
 
 export namespace CreateNetworkProfileRequest {
   export function isa(o: any): o is CreateNetworkProfileRequest {
-    return _smithy.isa(o, "CreateNetworkProfileRequest");
+    return __isa(o, "CreateNetworkProfileRequest");
   }
 }
 
@@ -543,7 +544,7 @@ export interface CreateNetworkProfileResult extends $MetadataBearer {
 
 export namespace CreateNetworkProfileResult {
   export function isa(o: any): o is CreateNetworkProfileResult {
-    return _smithy.isa(o, "CreateNetworkProfileResult");
+    return __isa(o, "CreateNetworkProfileResult");
   }
 }
 
@@ -566,7 +567,7 @@ export interface CreateProjectRequest {
 
 export namespace CreateProjectRequest {
   export function isa(o: any): o is CreateProjectRequest {
-    return _smithy.isa(o, "CreateProjectRequest");
+    return __isa(o, "CreateProjectRequest");
   }
 }
 
@@ -583,7 +584,7 @@ export interface CreateProjectResult extends $MetadataBearer {
 
 export namespace CreateProjectResult {
   export function isa(o: any): o is CreateProjectResult {
-    return _smithy.isa(o, "CreateProjectResult");
+    return __isa(o, "CreateProjectResult");
   }
 }
 
@@ -606,7 +607,7 @@ export interface CreateRemoteAccessSessionConfiguration {
 
 export namespace CreateRemoteAccessSessionConfiguration {
   export function isa(o: any): o is CreateRemoteAccessSessionConfiguration {
-    return _smithy.isa(o, "CreateRemoteAccessSessionConfiguration");
+    return __isa(o, "CreateRemoteAccessSessionConfiguration");
   }
 }
 
@@ -712,7 +713,7 @@ export interface CreateRemoteAccessSessionRequest {
 
 export namespace CreateRemoteAccessSessionRequest {
   export function isa(o: any): o is CreateRemoteAccessSessionRequest {
-    return _smithy.isa(o, "CreateRemoteAccessSessionRequest");
+    return __isa(o, "CreateRemoteAccessSessionRequest");
   }
 }
 
@@ -731,7 +732,7 @@ export interface CreateRemoteAccessSessionResult extends $MetadataBearer {
 
 export namespace CreateRemoteAccessSessionResult {
   export function isa(o: any): o is CreateRemoteAccessSessionResult {
-    return _smithy.isa(o, "CreateRemoteAccessSessionResult");
+    return __isa(o, "CreateRemoteAccessSessionResult");
   }
 }
 
@@ -750,7 +751,7 @@ export interface CreateTestGridProjectRequest {
 
 export namespace CreateTestGridProjectRequest {
   export function isa(o: any): o is CreateTestGridProjectRequest {
-    return _smithy.isa(o, "CreateTestGridProjectRequest");
+    return __isa(o, "CreateTestGridProjectRequest");
   }
 }
 
@@ -764,7 +765,7 @@ export interface CreateTestGridProjectResult extends $MetadataBearer {
 
 export namespace CreateTestGridProjectResult {
   export function isa(o: any): o is CreateTestGridProjectResult {
-    return _smithy.isa(o, "CreateTestGridProjectResult");
+    return __isa(o, "CreateTestGridProjectResult");
   }
 }
 
@@ -784,7 +785,7 @@ export interface CreateTestGridUrlRequest {
 
 export namespace CreateTestGridUrlRequest {
   export function isa(o: any): o is CreateTestGridUrlRequest {
-    return _smithy.isa(o, "CreateTestGridUrlRequest");
+    return __isa(o, "CreateTestGridUrlRequest");
   }
 }
 
@@ -804,7 +805,7 @@ export interface CreateTestGridUrlResult extends $MetadataBearer {
 
 export namespace CreateTestGridUrlResult {
   export function isa(o: any): o is CreateTestGridUrlResult {
-    return _smithy.isa(o, "CreateTestGridUrlResult");
+    return __isa(o, "CreateTestGridUrlResult");
   }
 }
 
@@ -940,7 +941,7 @@ export interface CreateUploadRequest {
 
 export namespace CreateUploadRequest {
   export function isa(o: any): o is CreateUploadRequest {
-    return _smithy.isa(o, "CreateUploadRequest");
+    return __isa(o, "CreateUploadRequest");
   }
 }
 
@@ -957,7 +958,7 @@ export interface CreateUploadResult extends $MetadataBearer {
 
 export namespace CreateUploadResult {
   export function isa(o: any): o is CreateUploadResult {
-    return _smithy.isa(o, "CreateUploadResult");
+    return __isa(o, "CreateUploadResult");
   }
 }
 
@@ -988,7 +989,7 @@ export interface CreateVPCEConfigurationRequest {
 
 export namespace CreateVPCEConfigurationRequest {
   export function isa(o: any): o is CreateVPCEConfigurationRequest {
-    return _smithy.isa(o, "CreateVPCEConfigurationRequest");
+    return __isa(o, "CreateVPCEConfigurationRequest");
   }
 }
 
@@ -1002,7 +1003,7 @@ export interface CreateVPCEConfigurationResult extends $MetadataBearer {
 
 export namespace CreateVPCEConfigurationResult {
   export function isa(o: any): o is CreateVPCEConfigurationResult {
-    return _smithy.isa(o, "CreateVPCEConfigurationResult");
+    return __isa(o, "CreateVPCEConfigurationResult");
   }
 }
 
@@ -1041,7 +1042,7 @@ export interface CustomerArtifactPaths {
 
 export namespace CustomerArtifactPaths {
   export function isa(o: any): o is CustomerArtifactPaths {
-    return _smithy.isa(o, "CustomerArtifactPaths");
+    return __isa(o, "CustomerArtifactPaths");
   }
 }
 
@@ -1058,7 +1059,7 @@ export interface DeleteDevicePoolRequest {
 
 export namespace DeleteDevicePoolRequest {
   export function isa(o: any): o is DeleteDevicePoolRequest {
-    return _smithy.isa(o, "DeleteDevicePoolRequest");
+    return __isa(o, "DeleteDevicePoolRequest");
   }
 }
 
@@ -1071,7 +1072,7 @@ export interface DeleteDevicePoolResult extends $MetadataBearer {
 
 export namespace DeleteDevicePoolResult {
   export function isa(o: any): o is DeleteDevicePoolResult {
-    return _smithy.isa(o, "DeleteDevicePoolResult");
+    return __isa(o, "DeleteDevicePoolResult");
   }
 }
 
@@ -1086,7 +1087,7 @@ export interface DeleteInstanceProfileRequest {
 
 export namespace DeleteInstanceProfileRequest {
   export function isa(o: any): o is DeleteInstanceProfileRequest {
-    return _smithy.isa(o, "DeleteInstanceProfileRequest");
+    return __isa(o, "DeleteInstanceProfileRequest");
   }
 }
 
@@ -1096,7 +1097,7 @@ export interface DeleteInstanceProfileResult extends $MetadataBearer {
 
 export namespace DeleteInstanceProfileResult {
   export function isa(o: any): o is DeleteInstanceProfileResult {
-    return _smithy.isa(o, "DeleteInstanceProfileResult");
+    return __isa(o, "DeleteInstanceProfileResult");
   }
 }
 
@@ -1110,7 +1111,7 @@ export interface DeleteNetworkProfileRequest {
 
 export namespace DeleteNetworkProfileRequest {
   export function isa(o: any): o is DeleteNetworkProfileRequest {
-    return _smithy.isa(o, "DeleteNetworkProfileRequest");
+    return __isa(o, "DeleteNetworkProfileRequest");
   }
 }
 
@@ -1120,7 +1121,7 @@ export interface DeleteNetworkProfileResult extends $MetadataBearer {
 
 export namespace DeleteNetworkProfileResult {
   export function isa(o: any): o is DeleteNetworkProfileResult {
-    return _smithy.isa(o, "DeleteNetworkProfileResult");
+    return __isa(o, "DeleteNetworkProfileResult");
   }
 }
 
@@ -1137,7 +1138,7 @@ export interface DeleteProjectRequest {
 
 export namespace DeleteProjectRequest {
   export function isa(o: any): o is DeleteProjectRequest {
-    return _smithy.isa(o, "DeleteProjectRequest");
+    return __isa(o, "DeleteProjectRequest");
   }
 }
 
@@ -1150,7 +1151,7 @@ export interface DeleteProjectResult extends $MetadataBearer {
 
 export namespace DeleteProjectResult {
   export function isa(o: any): o is DeleteProjectResult {
-    return _smithy.isa(o, "DeleteProjectResult");
+    return __isa(o, "DeleteProjectResult");
   }
 }
 
@@ -1168,7 +1169,7 @@ export interface DeleteRemoteAccessSessionRequest {
 
 export namespace DeleteRemoteAccessSessionRequest {
   export function isa(o: any): o is DeleteRemoteAccessSessionRequest {
-    return _smithy.isa(o, "DeleteRemoteAccessSessionRequest");
+    return __isa(o, "DeleteRemoteAccessSessionRequest");
   }
 }
 
@@ -1182,7 +1183,7 @@ export interface DeleteRemoteAccessSessionResult extends $MetadataBearer {
 
 export namespace DeleteRemoteAccessSessionResult {
   export function isa(o: any): o is DeleteRemoteAccessSessionResult {
-    return _smithy.isa(o, "DeleteRemoteAccessSessionResult");
+    return __isa(o, "DeleteRemoteAccessSessionResult");
   }
 }
 
@@ -1199,7 +1200,7 @@ export interface DeleteRunRequest {
 
 export namespace DeleteRunRequest {
   export function isa(o: any): o is DeleteRunRequest {
-    return _smithy.isa(o, "DeleteRunRequest");
+    return __isa(o, "DeleteRunRequest");
   }
 }
 
@@ -1212,7 +1213,7 @@ export interface DeleteRunResult extends $MetadataBearer {
 
 export namespace DeleteRunResult {
   export function isa(o: any): o is DeleteRunResult {
-    return _smithy.isa(o, "DeleteRunResult");
+    return __isa(o, "DeleteRunResult");
   }
 }
 
@@ -1226,7 +1227,7 @@ export interface DeleteTestGridProjectRequest {
 
 export namespace DeleteTestGridProjectRequest {
   export function isa(o: any): o is DeleteTestGridProjectRequest {
-    return _smithy.isa(o, "DeleteTestGridProjectRequest");
+    return __isa(o, "DeleteTestGridProjectRequest");
   }
 }
 
@@ -1236,7 +1237,7 @@ export interface DeleteTestGridProjectResult extends $MetadataBearer {
 
 export namespace DeleteTestGridProjectResult {
   export function isa(o: any): o is DeleteTestGridProjectResult {
-    return _smithy.isa(o, "DeleteTestGridProjectResult");
+    return __isa(o, "DeleteTestGridProjectResult");
   }
 }
 
@@ -1253,7 +1254,7 @@ export interface DeleteUploadRequest {
 
 export namespace DeleteUploadRequest {
   export function isa(o: any): o is DeleteUploadRequest {
-    return _smithy.isa(o, "DeleteUploadRequest");
+    return __isa(o, "DeleteUploadRequest");
   }
 }
 
@@ -1266,7 +1267,7 @@ export interface DeleteUploadResult extends $MetadataBearer {
 
 export namespace DeleteUploadResult {
   export function isa(o: any): o is DeleteUploadResult {
-    return _smithy.isa(o, "DeleteUploadResult");
+    return __isa(o, "DeleteUploadResult");
   }
 }
 
@@ -1281,7 +1282,7 @@ export interface DeleteVPCEConfigurationRequest {
 
 export namespace DeleteVPCEConfigurationRequest {
   export function isa(o: any): o is DeleteVPCEConfigurationRequest {
-    return _smithy.isa(o, "DeleteVPCEConfigurationRequest");
+    return __isa(o, "DeleteVPCEConfigurationRequest");
   }
 }
 
@@ -1291,7 +1292,7 @@ export interface DeleteVPCEConfigurationResult extends $MetadataBearer {
 
 export namespace DeleteVPCEConfigurationResult {
   export function isa(o: any): o is DeleteVPCEConfigurationResult {
-    return _smithy.isa(o, "DeleteVPCEConfigurationResult");
+    return __isa(o, "DeleteVPCEConfigurationResult");
   }
 }
 
@@ -1430,7 +1431,7 @@ export interface Device {
 
 export namespace Device {
   export function isa(o: any): o is Device {
-    return _smithy.isa(o, "Device");
+    return __isa(o, "Device");
   }
 }
 
@@ -1603,7 +1604,7 @@ export interface DeviceFilter {
 
 export namespace DeviceFilter {
   export function isa(o: any): o is DeviceFilter {
-    return _smithy.isa(o, "DeviceFilter");
+    return __isa(o, "DeviceFilter");
   }
 }
 
@@ -1665,7 +1666,7 @@ export interface DeviceInstance {
 
 export namespace DeviceInstance {
   export function isa(o: any): o is DeviceInstance {
-    return _smithy.isa(o, "DeviceInstance");
+    return __isa(o, "DeviceInstance");
   }
 }
 
@@ -1696,7 +1697,7 @@ export interface DeviceMinutes {
 
 export namespace DeviceMinutes {
   export function isa(o: any): o is DeviceMinutes {
-    return _smithy.isa(o, "DeviceMinutes");
+    return __isa(o, "DeviceMinutes");
   }
 }
 
@@ -1759,7 +1760,7 @@ export interface DevicePool {
 
 export namespace DevicePool {
   export function isa(o: any): o is DevicePool {
-    return _smithy.isa(o, "DevicePool");
+    return __isa(o, "DevicePool");
   }
 }
 
@@ -1786,7 +1787,7 @@ export interface DevicePoolCompatibilityResult {
 
 export namespace DevicePoolCompatibilityResult {
   export function isa(o: any): o is DevicePoolCompatibilityResult {
-    return _smithy.isa(o, "DevicePoolCompatibilityResult");
+    return __isa(o, "DevicePoolCompatibilityResult");
   }
 }
 
@@ -1935,7 +1936,7 @@ export interface DeviceSelectionConfiguration {
 
 export namespace DeviceSelectionConfiguration {
   export function isa(o: any): o is DeviceSelectionConfiguration {
-    return _smithy.isa(o, "DeviceSelectionConfiguration");
+    return __isa(o, "DeviceSelectionConfiguration");
   }
 }
 
@@ -1964,7 +1965,7 @@ export interface DeviceSelectionResult {
 
 export namespace DeviceSelectionResult {
   export function isa(o: any): o is DeviceSelectionResult {
-    return _smithy.isa(o, "DeviceSelectionResult");
+    return __isa(o, "DeviceSelectionResult");
   }
 }
 
@@ -2005,7 +2006,7 @@ export interface ExecutionConfiguration {
 
 export namespace ExecutionConfiguration {
   export function isa(o: any): o is ExecutionConfiguration {
-    return _smithy.isa(o, "ExecutionConfiguration");
+    return __isa(o, "ExecutionConfiguration");
   }
 }
 
@@ -2045,7 +2046,7 @@ export interface GetAccountSettingsRequest {
 
 export namespace GetAccountSettingsRequest {
   export function isa(o: any): o is GetAccountSettingsRequest {
-    return _smithy.isa(o, "GetAccountSettingsRequest");
+    return __isa(o, "GetAccountSettingsRequest");
   }
 }
 
@@ -2063,7 +2064,7 @@ export interface GetAccountSettingsResult extends $MetadataBearer {
 
 export namespace GetAccountSettingsResult {
   export function isa(o: any): o is GetAccountSettingsResult {
-    return _smithy.isa(o, "GetAccountSettingsResult");
+    return __isa(o, "GetAccountSettingsResult");
   }
 }
 
@@ -2078,7 +2079,7 @@ export interface GetDeviceInstanceRequest {
 
 export namespace GetDeviceInstanceRequest {
   export function isa(o: any): o is GetDeviceInstanceRequest {
-    return _smithy.isa(o, "GetDeviceInstanceRequest");
+    return __isa(o, "GetDeviceInstanceRequest");
   }
 }
 
@@ -2092,7 +2093,7 @@ export interface GetDeviceInstanceResult extends $MetadataBearer {
 
 export namespace GetDeviceInstanceResult {
   export function isa(o: any): o is GetDeviceInstanceResult {
-    return _smithy.isa(o, "GetDeviceInstanceResult");
+    return __isa(o, "GetDeviceInstanceResult");
   }
 }
 
@@ -2187,7 +2188,7 @@ export interface GetDevicePoolCompatibilityRequest {
 
 export namespace GetDevicePoolCompatibilityRequest {
   export function isa(o: any): o is GetDevicePoolCompatibilityRequest {
-    return _smithy.isa(o, "GetDevicePoolCompatibilityRequest");
+    return __isa(o, "GetDevicePoolCompatibilityRequest");
   }
 }
 
@@ -2209,7 +2210,7 @@ export interface GetDevicePoolCompatibilityResult extends $MetadataBearer {
 
 export namespace GetDevicePoolCompatibilityResult {
   export function isa(o: any): o is GetDevicePoolCompatibilityResult {
-    return _smithy.isa(o, "GetDevicePoolCompatibilityResult");
+    return __isa(o, "GetDevicePoolCompatibilityResult");
   }
 }
 
@@ -2226,7 +2227,7 @@ export interface GetDevicePoolRequest {
 
 export namespace GetDevicePoolRequest {
   export function isa(o: any): o is GetDevicePoolRequest {
-    return _smithy.isa(o, "GetDevicePoolRequest");
+    return __isa(o, "GetDevicePoolRequest");
   }
 }
 
@@ -2243,7 +2244,7 @@ export interface GetDevicePoolResult extends $MetadataBearer {
 
 export namespace GetDevicePoolResult {
   export function isa(o: any): o is GetDevicePoolResult {
-    return _smithy.isa(o, "GetDevicePoolResult");
+    return __isa(o, "GetDevicePoolResult");
   }
 }
 
@@ -2260,7 +2261,7 @@ export interface GetDeviceRequest {
 
 export namespace GetDeviceRequest {
   export function isa(o: any): o is GetDeviceRequest {
-    return _smithy.isa(o, "GetDeviceRequest");
+    return __isa(o, "GetDeviceRequest");
   }
 }
 
@@ -2277,7 +2278,7 @@ export interface GetDeviceResult extends $MetadataBearer {
 
 export namespace GetDeviceResult {
   export function isa(o: any): o is GetDeviceResult {
-    return _smithy.isa(o, "GetDeviceResult");
+    return __isa(o, "GetDeviceResult");
   }
 }
 
@@ -2291,7 +2292,7 @@ export interface GetInstanceProfileRequest {
 
 export namespace GetInstanceProfileRequest {
   export function isa(o: any): o is GetInstanceProfileRequest {
-    return _smithy.isa(o, "GetInstanceProfileRequest");
+    return __isa(o, "GetInstanceProfileRequest");
   }
 }
 
@@ -2305,7 +2306,7 @@ export interface GetInstanceProfileResult extends $MetadataBearer {
 
 export namespace GetInstanceProfileResult {
   export function isa(o: any): o is GetInstanceProfileResult {
-    return _smithy.isa(o, "GetInstanceProfileResult");
+    return __isa(o, "GetInstanceProfileResult");
   }
 }
 
@@ -2322,7 +2323,7 @@ export interface GetJobRequest {
 
 export namespace GetJobRequest {
   export function isa(o: any): o is GetJobRequest {
-    return _smithy.isa(o, "GetJobRequest");
+    return __isa(o, "GetJobRequest");
   }
 }
 
@@ -2339,7 +2340,7 @@ export interface GetJobResult extends $MetadataBearer {
 
 export namespace GetJobResult {
   export function isa(o: any): o is GetJobResult {
-    return _smithy.isa(o, "GetJobResult");
+    return __isa(o, "GetJobResult");
   }
 }
 
@@ -2353,7 +2354,7 @@ export interface GetNetworkProfileRequest {
 
 export namespace GetNetworkProfileRequest {
   export function isa(o: any): o is GetNetworkProfileRequest {
-    return _smithy.isa(o, "GetNetworkProfileRequest");
+    return __isa(o, "GetNetworkProfileRequest");
   }
 }
 
@@ -2367,7 +2368,7 @@ export interface GetNetworkProfileResult extends $MetadataBearer {
 
 export namespace GetNetworkProfileResult {
   export function isa(o: any): o is GetNetworkProfileResult {
-    return _smithy.isa(o, "GetNetworkProfileResult");
+    return __isa(o, "GetNetworkProfileResult");
   }
 }
 
@@ -2386,7 +2387,7 @@ export interface GetOfferingStatusRequest {
 
 export namespace GetOfferingStatusRequest {
   export function isa(o: any): o is GetOfferingStatusRequest {
-    return _smithy.isa(o, "GetOfferingStatusRequest");
+    return __isa(o, "GetOfferingStatusRequest");
   }
 }
 
@@ -2414,7 +2415,7 @@ export interface GetOfferingStatusResult extends $MetadataBearer {
 
 export namespace GetOfferingStatusResult {
   export function isa(o: any): o is GetOfferingStatusResult {
-    return _smithy.isa(o, "GetOfferingStatusResult");
+    return __isa(o, "GetOfferingStatusResult");
   }
 }
 
@@ -2431,7 +2432,7 @@ export interface GetProjectRequest {
 
 export namespace GetProjectRequest {
   export function isa(o: any): o is GetProjectRequest {
-    return _smithy.isa(o, "GetProjectRequest");
+    return __isa(o, "GetProjectRequest");
   }
 }
 
@@ -2448,7 +2449,7 @@ export interface GetProjectResult extends $MetadataBearer {
 
 export namespace GetProjectResult {
   export function isa(o: any): o is GetProjectResult {
-    return _smithy.isa(o, "GetProjectResult");
+    return __isa(o, "GetProjectResult");
   }
 }
 
@@ -2467,7 +2468,7 @@ export interface GetRemoteAccessSessionRequest {
 
 export namespace GetRemoteAccessSessionRequest {
   export function isa(o: any): o is GetRemoteAccessSessionRequest {
-    return _smithy.isa(o, "GetRemoteAccessSessionRequest");
+    return __isa(o, "GetRemoteAccessSessionRequest");
   }
 }
 
@@ -2486,7 +2487,7 @@ export interface GetRemoteAccessSessionResult extends $MetadataBearer {
 
 export namespace GetRemoteAccessSessionResult {
   export function isa(o: any): o is GetRemoteAccessSessionResult {
-    return _smithy.isa(o, "GetRemoteAccessSessionResult");
+    return __isa(o, "GetRemoteAccessSessionResult");
   }
 }
 
@@ -2503,7 +2504,7 @@ export interface GetRunRequest {
 
 export namespace GetRunRequest {
   export function isa(o: any): o is GetRunRequest {
-    return _smithy.isa(o, "GetRunRequest");
+    return __isa(o, "GetRunRequest");
   }
 }
 
@@ -2520,7 +2521,7 @@ export interface GetRunResult extends $MetadataBearer {
 
 export namespace GetRunResult {
   export function isa(o: any): o is GetRunResult {
-    return _smithy.isa(o, "GetRunResult");
+    return __isa(o, "GetRunResult");
   }
 }
 
@@ -2537,7 +2538,7 @@ export interface GetSuiteRequest {
 
 export namespace GetSuiteRequest {
   export function isa(o: any): o is GetSuiteRequest {
-    return _smithy.isa(o, "GetSuiteRequest");
+    return __isa(o, "GetSuiteRequest");
   }
 }
 
@@ -2554,7 +2555,7 @@ export interface GetSuiteResult extends $MetadataBearer {
 
 export namespace GetSuiteResult {
   export function isa(o: any): o is GetSuiteResult {
-    return _smithy.isa(o, "GetSuiteResult");
+    return __isa(o, "GetSuiteResult");
   }
 }
 
@@ -2568,7 +2569,7 @@ export interface GetTestGridProjectRequest {
 
 export namespace GetTestGridProjectRequest {
   export function isa(o: any): o is GetTestGridProjectRequest {
-    return _smithy.isa(o, "GetTestGridProjectRequest");
+    return __isa(o, "GetTestGridProjectRequest");
   }
 }
 
@@ -2582,7 +2583,7 @@ export interface GetTestGridProjectResult extends $MetadataBearer {
 
 export namespace GetTestGridProjectResult {
   export function isa(o: any): o is GetTestGridProjectResult {
-    return _smithy.isa(o, "GetTestGridProjectResult");
+    return __isa(o, "GetTestGridProjectResult");
   }
 }
 
@@ -2606,7 +2607,7 @@ export interface GetTestGridSessionRequest {
 
 export namespace GetTestGridSessionRequest {
   export function isa(o: any): o is GetTestGridSessionRequest {
-    return _smithy.isa(o, "GetTestGridSessionRequest");
+    return __isa(o, "GetTestGridSessionRequest");
   }
 }
 
@@ -2620,7 +2621,7 @@ export interface GetTestGridSessionResult extends $MetadataBearer {
 
 export namespace GetTestGridSessionResult {
   export function isa(o: any): o is GetTestGridSessionResult {
-    return _smithy.isa(o, "GetTestGridSessionResult");
+    return __isa(o, "GetTestGridSessionResult");
   }
 }
 
@@ -2637,7 +2638,7 @@ export interface GetTestRequest {
 
 export namespace GetTestRequest {
   export function isa(o: any): o is GetTestRequest {
-    return _smithy.isa(o, "GetTestRequest");
+    return __isa(o, "GetTestRequest");
   }
 }
 
@@ -2654,7 +2655,7 @@ export interface GetTestResult extends $MetadataBearer {
 
 export namespace GetTestResult {
   export function isa(o: any): o is GetTestResult {
-    return _smithy.isa(o, "GetTestResult");
+    return __isa(o, "GetTestResult");
   }
 }
 
@@ -2671,7 +2672,7 @@ export interface GetUploadRequest {
 
 export namespace GetUploadRequest {
   export function isa(o: any): o is GetUploadRequest {
-    return _smithy.isa(o, "GetUploadRequest");
+    return __isa(o, "GetUploadRequest");
   }
 }
 
@@ -2689,7 +2690,7 @@ export interface GetUploadResult extends $MetadataBearer {
 
 export namespace GetUploadResult {
   export function isa(o: any): o is GetUploadResult {
-    return _smithy.isa(o, "GetUploadResult");
+    return __isa(o, "GetUploadResult");
   }
 }
 
@@ -2704,7 +2705,7 @@ export interface GetVPCEConfigurationRequest {
 
 export namespace GetVPCEConfigurationRequest {
   export function isa(o: any): o is GetVPCEConfigurationRequest {
-    return _smithy.isa(o, "GetVPCEConfigurationRequest");
+    return __isa(o, "GetVPCEConfigurationRequest");
   }
 }
 
@@ -2718,7 +2719,7 @@ export interface GetVPCEConfigurationResult extends $MetadataBearer {
 
 export namespace GetVPCEConfigurationResult {
   export function isa(o: any): o is GetVPCEConfigurationResult {
-    return _smithy.isa(o, "GetVPCEConfigurationResult");
+    return __isa(o, "GetVPCEConfigurationResult");
   }
 }
 
@@ -2726,7 +2727,7 @@ export namespace GetVPCEConfigurationResult {
  * <p>An entity with the same name already exists.</p>
  */
 export interface IdempotencyException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "IdempotencyException";
   $fault: "client";
@@ -2738,7 +2739,7 @@ export interface IdempotencyException
 
 export namespace IdempotencyException {
   export function isa(o: any): o is IdempotencyException {
-    return _smithy.isa(o, "IdempotencyException");
+    return __isa(o, "IdempotencyException");
   }
 }
 
@@ -2781,7 +2782,7 @@ export interface IncompatibilityMessage {
 
 export namespace IncompatibilityMessage {
   export function isa(o: any): o is IncompatibilityMessage {
-    return _smithy.isa(o, "IncompatibilityMessage");
+    return __isa(o, "IncompatibilityMessage");
   }
 }
 
@@ -2805,7 +2806,7 @@ export interface InstallToRemoteAccessSessionRequest {
 
 export namespace InstallToRemoteAccessSessionRequest {
   export function isa(o: any): o is InstallToRemoteAccessSessionRequest {
-    return _smithy.isa(o, "InstallToRemoteAccessSessionRequest");
+    return __isa(o, "InstallToRemoteAccessSessionRequest");
   }
 }
 
@@ -2823,7 +2824,7 @@ export interface InstallToRemoteAccessSessionResult extends $MetadataBearer {
 
 export namespace InstallToRemoteAccessSessionResult {
   export function isa(o: any): o is InstallToRemoteAccessSessionResult {
-    return _smithy.isa(o, "InstallToRemoteAccessSessionResult");
+    return __isa(o, "InstallToRemoteAccessSessionResult");
   }
 }
 
@@ -2870,7 +2871,7 @@ export interface InstanceProfile {
 
 export namespace InstanceProfile {
   export function isa(o: any): o is InstanceProfile {
-    return _smithy.isa(o, "InstanceProfile");
+    return __isa(o, "InstanceProfile");
   }
 }
 
@@ -2892,7 +2893,7 @@ export enum InteractionMode {
  *          error. </p>
  */
 export interface InternalServiceException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalServiceException";
   $fault: "server";
@@ -2901,7 +2902,7 @@ export interface InternalServiceException
 
 export namespace InternalServiceException {
   export function isa(o: any): o is InternalServiceException {
-    return _smithy.isa(o, "InternalServiceException");
+    return __isa(o, "InternalServiceException");
   }
 }
 
@@ -2910,7 +2911,7 @@ export namespace InternalServiceException {
  *             to update this VPC endpoint configuration.</p>
  */
 export interface InvalidOperationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidOperationException";
   $fault: "client";
@@ -2919,7 +2920,7 @@ export interface InvalidOperationException
 
 export namespace InvalidOperationException {
   export function isa(o: any): o is InvalidOperationException {
-    return _smithy.isa(o, "InvalidOperationException");
+    return __isa(o, "InvalidOperationException");
   }
 }
 
@@ -3118,7 +3119,7 @@ export interface Job {
 
 export namespace Job {
   export function isa(o: any): o is Job {
-    return _smithy.isa(o, "Job");
+    return __isa(o, "Job");
   }
 }
 
@@ -3126,7 +3127,7 @@ export namespace Job {
  * <p>A limit was exceeded.</p>
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -3138,7 +3139,7 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
@@ -3178,7 +3179,7 @@ export interface ListArtifactsRequest {
 
 export namespace ListArtifactsRequest {
   export function isa(o: any): o is ListArtifactsRequest {
-    return _smithy.isa(o, "ListArtifactsRequest");
+    return __isa(o, "ListArtifactsRequest");
   }
 }
 
@@ -3202,7 +3203,7 @@ export interface ListArtifactsResult extends $MetadataBearer {
 
 export namespace ListArtifactsResult {
   export function isa(o: any): o is ListArtifactsResult {
-    return _smithy.isa(o, "ListArtifactsResult");
+    return __isa(o, "ListArtifactsResult");
   }
 }
 
@@ -3222,7 +3223,7 @@ export interface ListDeviceInstancesRequest {
 
 export namespace ListDeviceInstancesRequest {
   export function isa(o: any): o is ListDeviceInstancesRequest {
-    return _smithy.isa(o, "ListDeviceInstancesRequest");
+    return __isa(o, "ListDeviceInstancesRequest");
   }
 }
 
@@ -3242,7 +3243,7 @@ export interface ListDeviceInstancesResult extends $MetadataBearer {
 
 export namespace ListDeviceInstancesResult {
   export function isa(o: any): o is ListDeviceInstancesResult {
-    return _smithy.isa(o, "ListDeviceInstancesResult");
+    return __isa(o, "ListDeviceInstancesResult");
   }
 }
 
@@ -3281,7 +3282,7 @@ export interface ListDevicePoolsRequest {
 
 export namespace ListDevicePoolsRequest {
   export function isa(o: any): o is ListDevicePoolsRequest {
-    return _smithy.isa(o, "ListDevicePoolsRequest");
+    return __isa(o, "ListDevicePoolsRequest");
   }
 }
 
@@ -3305,7 +3306,7 @@ export interface ListDevicePoolsResult extends $MetadataBearer {
 
 export namespace ListDevicePoolsResult {
   export function isa(o: any): o is ListDevicePoolsResult {
-    return _smithy.isa(o, "ListDevicePoolsResult");
+    return __isa(o, "ListDevicePoolsResult");
   }
 }
 
@@ -3423,7 +3424,7 @@ export interface ListDevicesRequest {
 
 export namespace ListDevicesRequest {
   export function isa(o: any): o is ListDevicesRequest {
-    return _smithy.isa(o, "ListDevicesRequest");
+    return __isa(o, "ListDevicesRequest");
   }
 }
 
@@ -3447,7 +3448,7 @@ export interface ListDevicesResult extends $MetadataBearer {
 
 export namespace ListDevicesResult {
   export function isa(o: any): o is ListDevicesResult {
-    return _smithy.isa(o, "ListDevicesResult");
+    return __isa(o, "ListDevicesResult");
   }
 }
 
@@ -3467,7 +3468,7 @@ export interface ListInstanceProfilesRequest {
 
 export namespace ListInstanceProfilesRequest {
   export function isa(o: any): o is ListInstanceProfilesRequest {
-    return _smithy.isa(o, "ListInstanceProfilesRequest");
+    return __isa(o, "ListInstanceProfilesRequest");
   }
 }
 
@@ -3487,7 +3488,7 @@ export interface ListInstanceProfilesResult extends $MetadataBearer {
 
 export namespace ListInstanceProfilesResult {
   export function isa(o: any): o is ListInstanceProfilesResult {
-    return _smithy.isa(o, "ListInstanceProfilesResult");
+    return __isa(o, "ListInstanceProfilesResult");
   }
 }
 
@@ -3510,7 +3511,7 @@ export interface ListJobsRequest {
 
 export namespace ListJobsRequest {
   export function isa(o: any): o is ListJobsRequest {
-    return _smithy.isa(o, "ListJobsRequest");
+    return __isa(o, "ListJobsRequest");
   }
 }
 
@@ -3534,7 +3535,7 @@ export interface ListJobsResult extends $MetadataBearer {
 
 export namespace ListJobsResult {
   export function isa(o: any): o is ListJobsResult {
-    return _smithy.isa(o, "ListJobsResult");
+    return __isa(o, "ListJobsResult");
   }
 }
 
@@ -3560,7 +3561,7 @@ export interface ListNetworkProfilesRequest {
 
 export namespace ListNetworkProfilesRequest {
   export function isa(o: any): o is ListNetworkProfilesRequest {
-    return _smithy.isa(o, "ListNetworkProfilesRequest");
+    return __isa(o, "ListNetworkProfilesRequest");
   }
 }
 
@@ -3580,7 +3581,7 @@ export interface ListNetworkProfilesResult extends $MetadataBearer {
 
 export namespace ListNetworkProfilesResult {
   export function isa(o: any): o is ListNetworkProfilesResult {
-    return _smithy.isa(o, "ListNetworkProfilesResult");
+    return __isa(o, "ListNetworkProfilesResult");
   }
 }
 
@@ -3595,7 +3596,7 @@ export interface ListOfferingPromotionsRequest {
 
 export namespace ListOfferingPromotionsRequest {
   export function isa(o: any): o is ListOfferingPromotionsRequest {
-    return _smithy.isa(o, "ListOfferingPromotionsRequest");
+    return __isa(o, "ListOfferingPromotionsRequest");
   }
 }
 
@@ -3615,7 +3616,7 @@ export interface ListOfferingPromotionsResult extends $MetadataBearer {
 
 export namespace ListOfferingPromotionsResult {
   export function isa(o: any): o is ListOfferingPromotionsResult {
-    return _smithy.isa(o, "ListOfferingPromotionsResult");
+    return __isa(o, "ListOfferingPromotionsResult");
   }
 }
 
@@ -3633,7 +3634,7 @@ export interface ListOfferingTransactionsRequest {
 
 export namespace ListOfferingTransactionsRequest {
   export function isa(o: any): o is ListOfferingTransactionsRequest {
-    return _smithy.isa(o, "ListOfferingTransactionsRequest");
+    return __isa(o, "ListOfferingTransactionsRequest");
   }
 }
 
@@ -3657,7 +3658,7 @@ export interface ListOfferingTransactionsResult extends $MetadataBearer {
 
 export namespace ListOfferingTransactionsResult {
   export function isa(o: any): o is ListOfferingTransactionsResult {
-    return _smithy.isa(o, "ListOfferingTransactionsResult");
+    return __isa(o, "ListOfferingTransactionsResult");
   }
 }
 
@@ -3675,7 +3676,7 @@ export interface ListOfferingsRequest {
 
 export namespace ListOfferingsRequest {
   export function isa(o: any): o is ListOfferingsRequest {
-    return _smithy.isa(o, "ListOfferingsRequest");
+    return __isa(o, "ListOfferingsRequest");
   }
 }
 
@@ -3698,7 +3699,7 @@ export interface ListOfferingsResult extends $MetadataBearer {
 
 export namespace ListOfferingsResult {
   export function isa(o: any): o is ListOfferingsResult {
-    return _smithy.isa(o, "ListOfferingsResult");
+    return __isa(o, "ListOfferingsResult");
   }
 }
 
@@ -3723,7 +3724,7 @@ export interface ListProjectsRequest {
 
 export namespace ListProjectsRequest {
   export function isa(o: any): o is ListProjectsRequest {
-    return _smithy.isa(o, "ListProjectsRequest");
+    return __isa(o, "ListProjectsRequest");
   }
 }
 
@@ -3747,7 +3748,7 @@ export interface ListProjectsResult extends $MetadataBearer {
 
 export namespace ListProjectsResult {
   export function isa(o: any): o is ListProjectsResult {
-    return _smithy.isa(o, "ListProjectsResult");
+    return __isa(o, "ListProjectsResult");
   }
 }
 
@@ -3772,7 +3773,7 @@ export interface ListRemoteAccessSessionsRequest {
 
 export namespace ListRemoteAccessSessionsRequest {
   export function isa(o: any): o is ListRemoteAccessSessionsRequest {
-    return _smithy.isa(o, "ListRemoteAccessSessionsRequest");
+    return __isa(o, "ListRemoteAccessSessionsRequest");
   }
 }
 
@@ -3797,7 +3798,7 @@ export interface ListRemoteAccessSessionsResult extends $MetadataBearer {
 
 export namespace ListRemoteAccessSessionsResult {
   export function isa(o: any): o is ListRemoteAccessSessionsResult {
-    return _smithy.isa(o, "ListRemoteAccessSessionsResult");
+    return __isa(o, "ListRemoteAccessSessionsResult");
   }
 }
 
@@ -3821,7 +3822,7 @@ export interface ListRunsRequest {
 
 export namespace ListRunsRequest {
   export function isa(o: any): o is ListRunsRequest {
-    return _smithy.isa(o, "ListRunsRequest");
+    return __isa(o, "ListRunsRequest");
   }
 }
 
@@ -3845,7 +3846,7 @@ export interface ListRunsResult extends $MetadataBearer {
 
 export namespace ListRunsResult {
   export function isa(o: any): o is ListRunsResult {
-    return _smithy.isa(o, "ListRunsResult");
+    return __isa(o, "ListRunsResult");
   }
 }
 
@@ -3868,7 +3869,7 @@ export interface ListSamplesRequest {
 
 export namespace ListSamplesRequest {
   export function isa(o: any): o is ListSamplesRequest {
-    return _smithy.isa(o, "ListSamplesRequest");
+    return __isa(o, "ListSamplesRequest");
   }
 }
 
@@ -3892,7 +3893,7 @@ export interface ListSamplesResult extends $MetadataBearer {
 
 export namespace ListSamplesResult {
   export function isa(o: any): o is ListSamplesResult {
-    return _smithy.isa(o, "ListSamplesResult");
+    return __isa(o, "ListSamplesResult");
   }
 }
 
@@ -3915,7 +3916,7 @@ export interface ListSuitesRequest {
 
 export namespace ListSuitesRequest {
   export function isa(o: any): o is ListSuitesRequest {
-    return _smithy.isa(o, "ListSuitesRequest");
+    return __isa(o, "ListSuitesRequest");
   }
 }
 
@@ -3939,7 +3940,7 @@ export interface ListSuitesResult extends $MetadataBearer {
 
 export namespace ListSuitesResult {
   export function isa(o: any): o is ListSuitesResult {
-    return _smithy.isa(o, "ListSuitesResult");
+    return __isa(o, "ListSuitesResult");
   }
 }
 
@@ -3957,7 +3958,7 @@ export interface ListTagsForResourceRequest {
 
 export namespace ListTagsForResourceRequest {
   export function isa(o: any): o is ListTagsForResourceRequest {
-    return _smithy.isa(o, "ListTagsForResourceRequest");
+    return __isa(o, "ListTagsForResourceRequest");
   }
 }
 
@@ -3972,7 +3973,7 @@ export interface ListTagsForResourceResponse extends $MetadataBearer {
 
 export namespace ListTagsForResourceResponse {
   export function isa(o: any): o is ListTagsForResourceResponse {
-    return _smithy.isa(o, "ListTagsForResourceResponse");
+    return __isa(o, "ListTagsForResourceResponse");
   }
 }
 
@@ -3991,7 +3992,7 @@ export interface ListTestGridProjectsRequest {
 
 export namespace ListTestGridProjectsRequest {
   export function isa(o: any): o is ListTestGridProjectsRequest {
-    return _smithy.isa(o, "ListTestGridProjectsRequest");
+    return __isa(o, "ListTestGridProjectsRequest");
   }
 }
 
@@ -4011,7 +4012,7 @@ export interface ListTestGridProjectsResult extends $MetadataBearer {
 
 export namespace ListTestGridProjectsResult {
   export function isa(o: any): o is ListTestGridProjectsResult {
-    return _smithy.isa(o, "ListTestGridProjectsResult");
+    return __isa(o, "ListTestGridProjectsResult");
   }
 }
 
@@ -4035,7 +4036,7 @@ export interface ListTestGridSessionActionsRequest {
 
 export namespace ListTestGridSessionActionsRequest {
   export function isa(o: any): o is ListTestGridSessionActionsRequest {
-    return _smithy.isa(o, "ListTestGridSessionActionsRequest");
+    return __isa(o, "ListTestGridSessionActionsRequest");
   }
 }
 
@@ -4054,7 +4055,7 @@ export interface ListTestGridSessionActionsResult extends $MetadataBearer {
 
 export namespace ListTestGridSessionActionsResult {
   export function isa(o: any): o is ListTestGridSessionActionsResult {
-    return _smithy.isa(o, "ListTestGridSessionActionsResult");
+    return __isa(o, "ListTestGridSessionActionsResult");
   }
 }
 
@@ -4083,7 +4084,7 @@ export interface ListTestGridSessionArtifactsRequest {
 
 export namespace ListTestGridSessionArtifactsRequest {
   export function isa(o: any): o is ListTestGridSessionArtifactsRequest {
-    return _smithy.isa(o, "ListTestGridSessionArtifactsRequest");
+    return __isa(o, "ListTestGridSessionArtifactsRequest");
   }
 }
 
@@ -4102,7 +4103,7 @@ export interface ListTestGridSessionArtifactsResult extends $MetadataBearer {
 
 export namespace ListTestGridSessionArtifactsResult {
   export function isa(o: any): o is ListTestGridSessionArtifactsResult {
-    return _smithy.isa(o, "ListTestGridSessionArtifactsResult");
+    return __isa(o, "ListTestGridSessionArtifactsResult");
   }
 }
 
@@ -4151,7 +4152,7 @@ export interface ListTestGridSessionsRequest {
 
 export namespace ListTestGridSessionsRequest {
   export function isa(o: any): o is ListTestGridSessionsRequest {
-    return _smithy.isa(o, "ListTestGridSessionsRequest");
+    return __isa(o, "ListTestGridSessionsRequest");
   }
 }
 
@@ -4170,7 +4171,7 @@ export interface ListTestGridSessionsResult extends $MetadataBearer {
 
 export namespace ListTestGridSessionsResult {
   export function isa(o: any): o is ListTestGridSessionsResult {
-    return _smithy.isa(o, "ListTestGridSessionsResult");
+    return __isa(o, "ListTestGridSessionsResult");
   }
 }
 
@@ -4193,7 +4194,7 @@ export interface ListTestsRequest {
 
 export namespace ListTestsRequest {
   export function isa(o: any): o is ListTestsRequest {
-    return _smithy.isa(o, "ListTestsRequest");
+    return __isa(o, "ListTestsRequest");
   }
 }
 
@@ -4217,7 +4218,7 @@ export interface ListTestsResult extends $MetadataBearer {
 
 export namespace ListTestsResult {
   export function isa(o: any): o is ListTestsResult {
-    return _smithy.isa(o, "ListTestsResult");
+    return __isa(o, "ListTestsResult");
   }
 }
 
@@ -4240,7 +4241,7 @@ export interface ListUniqueProblemsRequest {
 
 export namespace ListUniqueProblemsRequest {
   export function isa(o: any): o is ListUniqueProblemsRequest {
-    return _smithy.isa(o, "ListUniqueProblemsRequest");
+    return __isa(o, "ListUniqueProblemsRequest");
   }
 }
 
@@ -4288,7 +4289,7 @@ export interface ListUniqueProblemsResult extends $MetadataBearer {
 
 export namespace ListUniqueProblemsResult {
   export function isa(o: any): o is ListUniqueProblemsResult {
-    return _smithy.isa(o, "ListUniqueProblemsResult");
+    return __isa(o, "ListUniqueProblemsResult");
   }
 }
 
@@ -4416,7 +4417,7 @@ export interface ListUploadsRequest {
 
 export namespace ListUploadsRequest {
   export function isa(o: any): o is ListUploadsRequest {
-    return _smithy.isa(o, "ListUploadsRequest");
+    return __isa(o, "ListUploadsRequest");
   }
 }
 
@@ -4440,7 +4441,7 @@ export interface ListUploadsResult extends $MetadataBearer {
 
 export namespace ListUploadsResult {
   export function isa(o: any): o is ListUploadsResult {
-    return _smithy.isa(o, "ListUploadsResult");
+    return __isa(o, "ListUploadsResult");
   }
 }
 
@@ -4460,7 +4461,7 @@ export interface ListVPCEConfigurationsRequest {
 
 export namespace ListVPCEConfigurationsRequest {
   export function isa(o: any): o is ListVPCEConfigurationsRequest {
-    return _smithy.isa(o, "ListVPCEConfigurationsRequest");
+    return __isa(o, "ListVPCEConfigurationsRequest");
   }
 }
 
@@ -4481,7 +4482,7 @@ export interface ListVPCEConfigurationsResult extends $MetadataBearer {
 
 export namespace ListVPCEConfigurationsResult {
   export function isa(o: any): o is ListVPCEConfigurationsResult {
-    return _smithy.isa(o, "ListVPCEConfigurationsResult");
+    return __isa(o, "ListVPCEConfigurationsResult");
   }
 }
 
@@ -4505,7 +4506,7 @@ export interface Location {
 
 export namespace Location {
   export function isa(o: any): o is Location {
-    return _smithy.isa(o, "Location");
+    return __isa(o, "Location");
   }
 }
 
@@ -4527,7 +4528,7 @@ export interface MonetaryAmount {
 
 export namespace MonetaryAmount {
   export function isa(o: any): o is MonetaryAmount {
-    return _smithy.isa(o, "MonetaryAmount");
+    return __isa(o, "MonetaryAmount");
   }
 }
 
@@ -4606,7 +4607,7 @@ export interface NetworkProfile {
 
 export namespace NetworkProfile {
   export function isa(o: any): o is NetworkProfile {
-    return _smithy.isa(o, "NetworkProfile");
+    return __isa(o, "NetworkProfile");
   }
 }
 
@@ -4620,7 +4621,7 @@ export enum NetworkProfileType {
  *             transaction.</p>
  */
 export interface NotEligibleException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "NotEligibleException";
   $fault: "client";
@@ -4632,16 +4633,14 @@ export interface NotEligibleException
 
 export namespace NotEligibleException {
   export function isa(o: any): o is NotEligibleException {
-    return _smithy.isa(o, "NotEligibleException");
+    return __isa(o, "NotEligibleException");
   }
 }
 
 /**
  * <p>The specified entity was not found.</p>
  */
-export interface NotFoundException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface NotFoundException extends __SmithyException, $MetadataBearer {
   name: "NotFoundException";
   $fault: "client";
   /**
@@ -4652,7 +4651,7 @@ export interface NotFoundException
 
 export namespace NotFoundException {
   export function isa(o: any): o is NotFoundException {
-    return _smithy.isa(o, "NotFoundException");
+    return __isa(o, "NotFoundException");
   }
 }
 
@@ -4689,7 +4688,7 @@ export interface Offering {
 
 export namespace Offering {
   export function isa(o: any): o is Offering {
-    return _smithy.isa(o, "Offering");
+    return __isa(o, "Offering");
   }
 }
 
@@ -4711,7 +4710,7 @@ export interface OfferingPromotion {
 
 export namespace OfferingPromotion {
   export function isa(o: any): o is OfferingPromotion {
-    return _smithy.isa(o, "OfferingPromotion");
+    return __isa(o, "OfferingPromotion");
   }
 }
 
@@ -4743,7 +4742,7 @@ export interface OfferingStatus {
 
 export namespace OfferingStatus {
   export function isa(o: any): o is OfferingStatus {
-    return _smithy.isa(o, "OfferingStatus");
+    return __isa(o, "OfferingStatus");
   }
 }
 
@@ -4780,7 +4779,7 @@ export interface OfferingTransaction {
 
 export namespace OfferingTransaction {
   export function isa(o: any): o is OfferingTransaction {
-    return _smithy.isa(o, "OfferingTransaction");
+    return __isa(o, "OfferingTransaction");
   }
 }
 
@@ -4861,7 +4860,7 @@ export interface Problem {
 
 export namespace Problem {
   export function isa(o: any): o is Problem {
-    return _smithy.isa(o, "Problem");
+    return __isa(o, "Problem");
   }
 }
 
@@ -4883,7 +4882,7 @@ export interface ProblemDetail {
 
 export namespace ProblemDetail {
   export function isa(o: any): o is ProblemDetail {
-    return _smithy.isa(o, "ProblemDetail");
+    return __isa(o, "ProblemDetail");
   }
 }
 
@@ -4917,7 +4916,7 @@ export interface Project {
 
 export namespace Project {
   export function isa(o: any): o is Project {
-    return _smithy.isa(o, "Project");
+    return __isa(o, "Project");
   }
 }
 
@@ -4944,7 +4943,7 @@ export interface PurchaseOfferingRequest {
 
 export namespace PurchaseOfferingRequest {
   export function isa(o: any): o is PurchaseOfferingRequest {
-    return _smithy.isa(o, "PurchaseOfferingRequest");
+    return __isa(o, "PurchaseOfferingRequest");
   }
 }
 
@@ -4961,7 +4960,7 @@ export interface PurchaseOfferingResult extends $MetadataBearer {
 
 export namespace PurchaseOfferingResult {
   export function isa(o: any): o is PurchaseOfferingResult {
-    return _smithy.isa(o, "PurchaseOfferingResult");
+    return __isa(o, "PurchaseOfferingResult");
   }
 }
 
@@ -4994,7 +4993,7 @@ export interface Radios {
 
 export namespace Radios {
   export function isa(o: any): o is Radios {
-    return _smithy.isa(o, "Radios");
+    return __isa(o, "Radios");
   }
 }
 
@@ -5016,7 +5015,7 @@ export interface RecurringCharge {
 
 export namespace RecurringCharge {
   export function isa(o: any): o is RecurringCharge {
-    return _smithy.isa(o, "RecurringCharge");
+    return __isa(o, "RecurringCharge");
   }
 }
 
@@ -5224,7 +5223,7 @@ export interface RemoteAccessSession {
 
 export namespace RemoteAccessSession {
   export function isa(o: any): o is RemoteAccessSession {
-    return _smithy.isa(o, "RemoteAccessSession");
+    return __isa(o, "RemoteAccessSession");
   }
 }
 
@@ -5246,7 +5245,7 @@ export interface RenewOfferingRequest {
 
 export namespace RenewOfferingRequest {
   export function isa(o: any): o is RenewOfferingRequest {
-    return _smithy.isa(o, "RenewOfferingRequest");
+    return __isa(o, "RenewOfferingRequest");
   }
 }
 
@@ -5263,7 +5262,7 @@ export interface RenewOfferingResult extends $MetadataBearer {
 
 export namespace RenewOfferingResult {
   export function isa(o: any): o is RenewOfferingResult {
-    return _smithy.isa(o, "RenewOfferingResult");
+    return __isa(o, "RenewOfferingResult");
   }
 }
 
@@ -5286,7 +5285,7 @@ export interface Resolution {
 
 export namespace Resolution {
   export function isa(o: any): o is Resolution {
-    return _smithy.isa(o, "Resolution");
+    return __isa(o, "Resolution");
   }
 }
 
@@ -5413,7 +5412,7 @@ export interface Rule {
 
 export namespace Rule {
   export function isa(o: any): o is Rule {
-    return _smithy.isa(o, "Rule");
+    return __isa(o, "Rule");
   }
 }
 
@@ -5730,7 +5729,7 @@ export interface Run {
 
 export namespace Run {
   export function isa(o: any): o is Run {
-    return _smithy.isa(o, "Run");
+    return __isa(o, "Run");
   }
 }
 
@@ -5817,7 +5816,7 @@ export interface Sample {
 
 export namespace Sample {
   export function isa(o: any): o is Sample {
-    return _smithy.isa(o, "Sample");
+    return __isa(o, "Sample");
   }
 }
 
@@ -5903,7 +5902,7 @@ export interface ScheduleRunConfiguration {
 
 export namespace ScheduleRunConfiguration {
   export function isa(o: any): o is ScheduleRunConfiguration {
-    return _smithy.isa(o, "ScheduleRunConfiguration");
+    return __isa(o, "ScheduleRunConfiguration");
   }
 }
 
@@ -5964,7 +5963,7 @@ export interface ScheduleRunRequest {
 
 export namespace ScheduleRunRequest {
   export function isa(o: any): o is ScheduleRunRequest {
-    return _smithy.isa(o, "ScheduleRunRequest");
+    return __isa(o, "ScheduleRunRequest");
   }
 }
 
@@ -5981,7 +5980,7 @@ export interface ScheduleRunResult extends $MetadataBearer {
 
 export namespace ScheduleRunResult {
   export function isa(o: any): o is ScheduleRunResult {
-    return _smithy.isa(o, "ScheduleRunResult");
+    return __isa(o, "ScheduleRunResult");
   }
 }
 
@@ -6212,7 +6211,7 @@ export interface ScheduleRunTest {
 
 export namespace ScheduleRunTest {
   export function isa(o: any): o is ScheduleRunTest {
-    return _smithy.isa(o, "ScheduleRunTest");
+    return __isa(o, "ScheduleRunTest");
   }
 }
 
@@ -6220,7 +6219,7 @@ export namespace ScheduleRunTest {
  * <p>There was a problem with the service account.</p>
  */
 export interface ServiceAccountException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ServiceAccountException";
   $fault: "client";
@@ -6232,7 +6231,7 @@ export interface ServiceAccountException
 
 export namespace ServiceAccountException {
   export function isa(o: any): o is ServiceAccountException {
-    return _smithy.isa(o, "ServiceAccountException");
+    return __isa(o, "ServiceAccountException");
   }
 }
 
@@ -6246,7 +6245,7 @@ export interface StopJobRequest {
 
 export namespace StopJobRequest {
   export function isa(o: any): o is StopJobRequest {
-    return _smithy.isa(o, "StopJobRequest");
+    return __isa(o, "StopJobRequest");
   }
 }
 
@@ -6260,7 +6259,7 @@ export interface StopJobResult extends $MetadataBearer {
 
 export namespace StopJobResult {
   export function isa(o: any): o is StopJobResult {
-    return _smithy.isa(o, "StopJobResult");
+    return __isa(o, "StopJobResult");
   }
 }
 
@@ -6277,7 +6276,7 @@ export interface StopRemoteAccessSessionRequest {
 
 export namespace StopRemoteAccessSessionRequest {
   export function isa(o: any): o is StopRemoteAccessSessionRequest {
-    return _smithy.isa(o, "StopRemoteAccessSessionRequest");
+    return __isa(o, "StopRemoteAccessSessionRequest");
   }
 }
 
@@ -6296,7 +6295,7 @@ export interface StopRemoteAccessSessionResult extends $MetadataBearer {
 
 export namespace StopRemoteAccessSessionResult {
   export function isa(o: any): o is StopRemoteAccessSessionResult {
-    return _smithy.isa(o, "StopRemoteAccessSessionResult");
+    return __isa(o, "StopRemoteAccessSessionResult");
   }
 }
 
@@ -6313,7 +6312,7 @@ export interface StopRunRequest {
 
 export namespace StopRunRequest {
   export function isa(o: any): o is StopRunRequest {
-    return _smithy.isa(o, "StopRunRequest");
+    return __isa(o, "StopRunRequest");
   }
 }
 
@@ -6330,7 +6329,7 @@ export interface StopRunResult extends $MetadataBearer {
 
 export namespace StopRunResult {
   export function isa(o: any): o is StopRunResult {
-    return _smithy.isa(o, "StopRunResult");
+    return __isa(o, "StopRunResult");
   }
 }
 
@@ -6513,7 +6512,7 @@ export interface Suite {
 
 export namespace Suite {
   export function isa(o: any): o is Suite {
-    return _smithy.isa(o, "Suite");
+    return __isa(o, "Suite");
   }
 }
 
@@ -6539,7 +6538,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -6547,7 +6546,7 @@ export namespace Tag {
  * <p>The operation was not successful. Try again.</p>
  */
 export interface TagOperationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TagOperationException";
   $fault: "client";
@@ -6557,7 +6556,7 @@ export interface TagOperationException
 
 export namespace TagOperationException {
   export function isa(o: any): o is TagOperationException {
-    return _smithy.isa(o, "TagOperationException");
+    return __isa(o, "TagOperationException");
   }
 }
 
@@ -6565,9 +6564,7 @@ export namespace TagOperationException {
  * <p>The request doesn't comply with the AWS Identity and Access Management (IAM) tag
  *             policy. Correct your request and then retry it.</p>
  */
-export interface TagPolicyException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface TagPolicyException extends __SmithyException, $MetadataBearer {
   name: "TagPolicyException";
   $fault: "client";
   message?: string;
@@ -6576,7 +6573,7 @@ export interface TagPolicyException
 
 export namespace TagPolicyException {
   export function isa(o: any): o is TagPolicyException {
-    return _smithy.isa(o, "TagPolicyException");
+    return __isa(o, "TagPolicyException");
   }
 }
 
@@ -6600,7 +6597,7 @@ export interface TagResourceRequest {
 
 export namespace TagResourceRequest {
   export function isa(o: any): o is TagResourceRequest {
-    return _smithy.isa(o, "TagResourceRequest");
+    return __isa(o, "TagResourceRequest");
   }
 }
 
@@ -6610,7 +6607,7 @@ export interface TagResourceResponse extends $MetadataBearer {
 
 export namespace TagResourceResponse {
   export function isa(o: any): o is TagResourceResponse {
-    return _smithy.isa(o, "TagResourceResponse");
+    return __isa(o, "TagResourceResponse");
   }
 }
 
@@ -6792,7 +6789,7 @@ export interface Test {
 
 export namespace Test {
   export function isa(o: any): o is Test {
-    return _smithy.isa(o, "Test");
+    return __isa(o, "Test");
   }
 }
 
@@ -6824,7 +6821,7 @@ export interface TestGridProject {
 
 export namespace TestGridProject {
   export function isa(o: any): o is TestGridProject {
-    return _smithy.isa(o, "TestGridProject");
+    return __isa(o, "TestGridProject");
   }
 }
 
@@ -6867,7 +6864,7 @@ export interface TestGridSession {
 
 export namespace TestGridSession {
   export function isa(o: any): o is TestGridSession {
-    return _smithy.isa(o, "TestGridSession");
+    return __isa(o, "TestGridSession");
   }
 }
 
@@ -6904,7 +6901,7 @@ export interface TestGridSessionAction {
 
 export namespace TestGridSessionAction {
   export function isa(o: any): o is TestGridSessionAction {
-    return _smithy.isa(o, "TestGridSessionAction");
+    return __isa(o, "TestGridSessionAction");
   }
 }
 
@@ -6935,7 +6932,7 @@ export interface TestGridSessionArtifact {
 
 export namespace TestGridSessionArtifact {
   export function isa(o: any): o is TestGridSessionArtifact {
-    return _smithy.isa(o, "TestGridSessionArtifact");
+    return __isa(o, "TestGridSessionArtifact");
   }
 }
 
@@ -6985,7 +6982,7 @@ export enum TestType {
  *             can be applied to a repository is 50. </p>
  */
 export interface TooManyTagsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyTagsException";
   $fault: "client";
@@ -6995,7 +6992,7 @@ export interface TooManyTagsException
 
 export namespace TooManyTagsException {
   export function isa(o: any): o is TooManyTagsException {
-    return _smithy.isa(o, "TooManyTagsException");
+    return __isa(o, "TooManyTagsException");
   }
 }
 
@@ -7018,7 +7015,7 @@ export interface TrialMinutes {
 
 export namespace TrialMinutes {
   export function isa(o: any): o is TrialMinutes {
-    return _smithy.isa(o, "TrialMinutes");
+    return __isa(o, "TrialMinutes");
   }
 }
 
@@ -7040,7 +7037,7 @@ export interface UniqueProblem {
 
 export namespace UniqueProblem {
   export function isa(o: any): o is UniqueProblem {
-    return _smithy.isa(o, "UniqueProblem");
+    return __isa(o, "UniqueProblem");
   }
 }
 
@@ -7063,7 +7060,7 @@ export interface UntagResourceRequest {
 
 export namespace UntagResourceRequest {
   export function isa(o: any): o is UntagResourceRequest {
-    return _smithy.isa(o, "UntagResourceRequest");
+    return __isa(o, "UntagResourceRequest");
   }
 }
 
@@ -7073,7 +7070,7 @@ export interface UntagResourceResponse extends $MetadataBearer {
 
 export namespace UntagResourceResponse {
   export function isa(o: any): o is UntagResourceResponse {
-    return _smithy.isa(o, "UntagResourceResponse");
+    return __isa(o, "UntagResourceResponse");
   }
 }
 
@@ -7097,7 +7094,7 @@ export interface UpdateDeviceInstanceRequest {
 
 export namespace UpdateDeviceInstanceRequest {
   export function isa(o: any): o is UpdateDeviceInstanceRequest {
-    return _smithy.isa(o, "UpdateDeviceInstanceRequest");
+    return __isa(o, "UpdateDeviceInstanceRequest");
   }
 }
 
@@ -7111,7 +7108,7 @@ export interface UpdateDeviceInstanceResult extends $MetadataBearer {
 
 export namespace UpdateDeviceInstanceResult {
   export function isa(o: any): o is UpdateDeviceInstanceResult {
-    return _smithy.isa(o, "UpdateDeviceInstanceResult");
+    return __isa(o, "UpdateDeviceInstanceResult");
   }
 }
 
@@ -7166,7 +7163,7 @@ export interface UpdateDevicePoolRequest {
 
 export namespace UpdateDevicePoolRequest {
   export function isa(o: any): o is UpdateDevicePoolRequest {
-    return _smithy.isa(o, "UpdateDevicePoolRequest");
+    return __isa(o, "UpdateDevicePoolRequest");
   }
 }
 
@@ -7183,7 +7180,7 @@ export interface UpdateDevicePoolResult extends $MetadataBearer {
 
 export namespace UpdateDevicePoolResult {
   export function isa(o: any): o is UpdateDevicePoolResult {
-    return _smithy.isa(o, "UpdateDevicePoolResult");
+    return __isa(o, "UpdateDevicePoolResult");
   }
 }
 
@@ -7227,7 +7224,7 @@ export interface UpdateInstanceProfileRequest {
 
 export namespace UpdateInstanceProfileRequest {
   export function isa(o: any): o is UpdateInstanceProfileRequest {
-    return _smithy.isa(o, "UpdateInstanceProfileRequest");
+    return __isa(o, "UpdateInstanceProfileRequest");
   }
 }
 
@@ -7241,7 +7238,7 @@ export interface UpdateInstanceProfileResult extends $MetadataBearer {
 
 export namespace UpdateInstanceProfileResult {
   export function isa(o: any): o is UpdateInstanceProfileResult {
-    return _smithy.isa(o, "UpdateInstanceProfileResult");
+    return __isa(o, "UpdateInstanceProfileResult");
   }
 }
 
@@ -7320,7 +7317,7 @@ export interface UpdateNetworkProfileRequest {
 
 export namespace UpdateNetworkProfileRequest {
   export function isa(o: any): o is UpdateNetworkProfileRequest {
-    return _smithy.isa(o, "UpdateNetworkProfileRequest");
+    return __isa(o, "UpdateNetworkProfileRequest");
   }
 }
 
@@ -7334,7 +7331,7 @@ export interface UpdateNetworkProfileResult extends $MetadataBearer {
 
 export namespace UpdateNetworkProfileResult {
   export function isa(o: any): o is UpdateNetworkProfileResult {
-    return _smithy.isa(o, "UpdateNetworkProfileResult");
+    return __isa(o, "UpdateNetworkProfileResult");
   }
 }
 
@@ -7361,7 +7358,7 @@ export interface UpdateProjectRequest {
 
 export namespace UpdateProjectRequest {
   export function isa(o: any): o is UpdateProjectRequest {
-    return _smithy.isa(o, "UpdateProjectRequest");
+    return __isa(o, "UpdateProjectRequest");
   }
 }
 
@@ -7378,7 +7375,7 @@ export interface UpdateProjectResult extends $MetadataBearer {
 
 export namespace UpdateProjectResult {
   export function isa(o: any): o is UpdateProjectResult {
-    return _smithy.isa(o, "UpdateProjectResult");
+    return __isa(o, "UpdateProjectResult");
   }
 }
 
@@ -7402,7 +7399,7 @@ export interface UpdateTestGridProjectRequest {
 
 export namespace UpdateTestGridProjectRequest {
   export function isa(o: any): o is UpdateTestGridProjectRequest {
-    return _smithy.isa(o, "UpdateTestGridProjectRequest");
+    return __isa(o, "UpdateTestGridProjectRequest");
   }
 }
 
@@ -7416,7 +7413,7 @@ export interface UpdateTestGridProjectResult extends $MetadataBearer {
 
 export namespace UpdateTestGridProjectResult {
   export function isa(o: any): o is UpdateTestGridProjectResult {
-    return _smithy.isa(o, "UpdateTestGridProjectResult");
+    return __isa(o, "UpdateTestGridProjectResult");
   }
 }
 
@@ -7446,7 +7443,7 @@ export interface UpdateUploadRequest {
 
 export namespace UpdateUploadRequest {
   export function isa(o: any): o is UpdateUploadRequest {
-    return _smithy.isa(o, "UpdateUploadRequest");
+    return __isa(o, "UpdateUploadRequest");
   }
 }
 
@@ -7460,7 +7457,7 @@ export interface UpdateUploadResult extends $MetadataBearer {
 
 export namespace UpdateUploadResult {
   export function isa(o: any): o is UpdateUploadResult {
-    return _smithy.isa(o, "UpdateUploadResult");
+    return __isa(o, "UpdateUploadResult");
   }
 }
 
@@ -7497,7 +7494,7 @@ export interface UpdateVPCEConfigurationRequest {
 
 export namespace UpdateVPCEConfigurationRequest {
   export function isa(o: any): o is UpdateVPCEConfigurationRequest {
-    return _smithy.isa(o, "UpdateVPCEConfigurationRequest");
+    return __isa(o, "UpdateVPCEConfigurationRequest");
   }
 }
 
@@ -7511,7 +7508,7 @@ export interface UpdateVPCEConfigurationResult extends $MetadataBearer {
 
 export namespace UpdateVPCEConfigurationResult {
   export function isa(o: any): o is UpdateVPCEConfigurationResult {
-    return _smithy.isa(o, "UpdateVPCEConfigurationResult");
+    return __isa(o, "UpdateVPCEConfigurationResult");
   }
 }
 
@@ -7698,7 +7695,7 @@ export interface Upload {
 
 export namespace Upload {
   export function isa(o: any): o is Upload {
-    return _smithy.isa(o, "Upload");
+    return __isa(o, "Upload");
   }
 }
 
@@ -7784,6 +7781,6 @@ export interface VPCEConfiguration {
 
 export namespace VPCEConfiguration {
   export function isa(o: any): o is VPCEConfiguration {
-    return _smithy.isa(o, "VPCEConfiguration");
+    return __isa(o, "VPCEConfiguration");
   }
 }

--- a/clients/client-direct-connect/models/index.ts
+++ b/clients/client-direct-connect/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export interface AcceptDirectConnectGatewayAssociationProposalRequest {
@@ -29,10 +32,7 @@ export namespace AcceptDirectConnectGatewayAssociationProposalRequest {
   export function isa(
     o: any
   ): o is AcceptDirectConnectGatewayAssociationProposalRequest {
-    return _smithy.isa(
-      o,
-      "AcceptDirectConnectGatewayAssociationProposalRequest"
-    );
+    return __isa(o, "AcceptDirectConnectGatewayAssociationProposalRequest");
   }
 }
 
@@ -49,10 +49,7 @@ export namespace AcceptDirectConnectGatewayAssociationProposalResult {
   export function isa(
     o: any
   ): o is AcceptDirectConnectGatewayAssociationProposalResult {
-    return _smithy.isa(
-      o,
-      "AcceptDirectConnectGatewayAssociationProposalResult"
-    );
+    return __isa(o, "AcceptDirectConnectGatewayAssociationProposalResult");
   }
 }
 
@@ -94,7 +91,7 @@ export interface AllocateConnectionOnInterconnectRequest {
 
 export namespace AllocateConnectionOnInterconnectRequest {
   export function isa(o: any): o is AllocateConnectionOnInterconnectRequest {
-    return _smithy.isa(o, "AllocateConnectionOnInterconnectRequest");
+    return __isa(o, "AllocateConnectionOnInterconnectRequest");
   }
 }
 
@@ -133,7 +130,7 @@ export interface AllocateHostedConnectionRequest {
 
 export namespace AllocateHostedConnectionRequest {
   export function isa(o: any): o is AllocateHostedConnectionRequest {
-    return _smithy.isa(o, "AllocateHostedConnectionRequest");
+    return __isa(o, "AllocateHostedConnectionRequest");
   }
 }
 
@@ -159,7 +156,7 @@ export interface AllocatePrivateVirtualInterfaceRequest {
 
 export namespace AllocatePrivateVirtualInterfaceRequest {
   export function isa(o: any): o is AllocatePrivateVirtualInterfaceRequest {
-    return _smithy.isa(o, "AllocatePrivateVirtualInterfaceRequest");
+    return __isa(o, "AllocatePrivateVirtualInterfaceRequest");
   }
 }
 
@@ -185,7 +182,7 @@ export interface AllocatePublicVirtualInterfaceRequest {
 
 export namespace AllocatePublicVirtualInterfaceRequest {
   export function isa(o: any): o is AllocatePublicVirtualInterfaceRequest {
-    return _smithy.isa(o, "AllocatePublicVirtualInterfaceRequest");
+    return __isa(o, "AllocatePublicVirtualInterfaceRequest");
   }
 }
 
@@ -211,7 +208,7 @@ export interface AllocateTransitVirtualInterfaceRequest {
 
 export namespace AllocateTransitVirtualInterfaceRequest {
   export function isa(o: any): o is AllocateTransitVirtualInterfaceRequest {
-    return _smithy.isa(o, "AllocateTransitVirtualInterfaceRequest");
+    return __isa(o, "AllocateTransitVirtualInterfaceRequest");
   }
 }
 
@@ -225,7 +222,7 @@ export interface AllocateTransitVirtualInterfaceResult extends $MetadataBearer {
 
 export namespace AllocateTransitVirtualInterfaceResult {
   export function isa(o: any): o is AllocateTransitVirtualInterfaceResult {
-    return _smithy.isa(o, "AllocateTransitVirtualInterfaceResult");
+    return __isa(o, "AllocateTransitVirtualInterfaceResult");
   }
 }
 
@@ -244,7 +241,7 @@ export interface AssociateConnectionWithLagRequest {
 
 export namespace AssociateConnectionWithLagRequest {
   export function isa(o: any): o is AssociateConnectionWithLagRequest {
-    return _smithy.isa(o, "AssociateConnectionWithLagRequest");
+    return __isa(o, "AssociateConnectionWithLagRequest");
   }
 }
 
@@ -263,7 +260,7 @@ export interface AssociateHostedConnectionRequest {
 
 export namespace AssociateHostedConnectionRequest {
   export function isa(o: any): o is AssociateHostedConnectionRequest {
-    return _smithy.isa(o, "AssociateHostedConnectionRequest");
+    return __isa(o, "AssociateHostedConnectionRequest");
   }
 }
 
@@ -282,7 +279,7 @@ export interface AssociateVirtualInterfaceRequest {
 
 export namespace AssociateVirtualInterfaceRequest {
   export function isa(o: any): o is AssociateVirtualInterfaceRequest {
-    return _smithy.isa(o, "AssociateVirtualInterfaceRequest");
+    return __isa(o, "AssociateVirtualInterfaceRequest");
   }
 }
 
@@ -314,7 +311,7 @@ export interface AssociatedGateway {
 
 export namespace AssociatedGateway {
   export function isa(o: any): o is AssociatedGateway {
-    return _smithy.isa(o, "AssociatedGateway");
+    return __isa(o, "AssociatedGateway");
   }
 }
 
@@ -408,7 +405,7 @@ export interface BGPPeer {
 
 export namespace BGPPeer {
   export function isa(o: any): o is BGPPeer {
-    return _smithy.isa(o, "BGPPeer");
+    return __isa(o, "BGPPeer");
   }
 }
 
@@ -436,7 +433,7 @@ export interface ConfirmConnectionRequest {
 
 export namespace ConfirmConnectionRequest {
   export function isa(o: any): o is ConfirmConnectionRequest {
-    return _smithy.isa(o, "ConfirmConnectionRequest");
+    return __isa(o, "ConfirmConnectionRequest");
   }
 }
 
@@ -488,7 +485,7 @@ export interface ConfirmConnectionResponse extends $MetadataBearer {
 
 export namespace ConfirmConnectionResponse {
   export function isa(o: any): o is ConfirmConnectionResponse {
-    return _smithy.isa(o, "ConfirmConnectionResponse");
+    return __isa(o, "ConfirmConnectionResponse");
   }
 }
 
@@ -512,7 +509,7 @@ export interface ConfirmPrivateVirtualInterfaceRequest {
 
 export namespace ConfirmPrivateVirtualInterfaceRequest {
   export function isa(o: any): o is ConfirmPrivateVirtualInterfaceRequest {
-    return _smithy.isa(o, "ConfirmPrivateVirtualInterfaceRequest");
+    return __isa(o, "ConfirmPrivateVirtualInterfaceRequest");
   }
 }
 
@@ -565,7 +562,7 @@ export interface ConfirmPrivateVirtualInterfaceResponse
 
 export namespace ConfirmPrivateVirtualInterfaceResponse {
   export function isa(o: any): o is ConfirmPrivateVirtualInterfaceResponse {
-    return _smithy.isa(o, "ConfirmPrivateVirtualInterfaceResponse");
+    return __isa(o, "ConfirmPrivateVirtualInterfaceResponse");
   }
 }
 
@@ -579,7 +576,7 @@ export interface ConfirmPublicVirtualInterfaceRequest {
 
 export namespace ConfirmPublicVirtualInterfaceRequest {
   export function isa(o: any): o is ConfirmPublicVirtualInterfaceRequest {
-    return _smithy.isa(o, "ConfirmPublicVirtualInterfaceRequest");
+    return __isa(o, "ConfirmPublicVirtualInterfaceRequest");
   }
 }
 
@@ -631,7 +628,7 @@ export interface ConfirmPublicVirtualInterfaceResponse extends $MetadataBearer {
 
 export namespace ConfirmPublicVirtualInterfaceResponse {
   export function isa(o: any): o is ConfirmPublicVirtualInterfaceResponse {
-    return _smithy.isa(o, "ConfirmPublicVirtualInterfaceResponse");
+    return __isa(o, "ConfirmPublicVirtualInterfaceResponse");
   }
 }
 
@@ -650,7 +647,7 @@ export interface ConfirmTransitVirtualInterfaceRequest {
 
 export namespace ConfirmTransitVirtualInterfaceRequest {
   export function isa(o: any): o is ConfirmTransitVirtualInterfaceRequest {
-    return _smithy.isa(o, "ConfirmTransitVirtualInterfaceRequest");
+    return __isa(o, "ConfirmTransitVirtualInterfaceRequest");
   }
 }
 
@@ -703,7 +700,7 @@ export interface ConfirmTransitVirtualInterfaceResponse
 
 export namespace ConfirmTransitVirtualInterfaceResponse {
   export function isa(o: any): o is ConfirmTransitVirtualInterfaceResponse {
-    return _smithy.isa(o, "ConfirmTransitVirtualInterfaceResponse");
+    return __isa(o, "ConfirmTransitVirtualInterfaceResponse");
   }
 }
 
@@ -838,7 +835,7 @@ export interface Connection extends $MetadataBearer {
 
 export namespace Connection {
   export function isa(o: any): o is Connection {
-    return _smithy.isa(o, "Connection");
+    return __isa(o, "Connection");
   }
 }
 
@@ -863,7 +860,7 @@ export interface Connections extends $MetadataBearer {
 
 export namespace Connections {
   export function isa(o: any): o is Connections {
-    return _smithy.isa(o, "Connections");
+    return __isa(o, "Connections");
   }
 }
 
@@ -882,7 +879,7 @@ export interface CreateBGPPeerRequest {
 
 export namespace CreateBGPPeerRequest {
   export function isa(o: any): o is CreateBGPPeerRequest {
-    return _smithy.isa(o, "CreateBGPPeerRequest");
+    return __isa(o, "CreateBGPPeerRequest");
   }
 }
 
@@ -896,7 +893,7 @@ export interface CreateBGPPeerResponse extends $MetadataBearer {
 
 export namespace CreateBGPPeerResponse {
   export function isa(o: any): o is CreateBGPPeerResponse {
-    return _smithy.isa(o, "CreateBGPPeerResponse");
+    return __isa(o, "CreateBGPPeerResponse");
   }
 }
 
@@ -935,7 +932,7 @@ export interface CreateConnectionRequest {
 
 export namespace CreateConnectionRequest {
   export function isa(o: any): o is CreateConnectionRequest {
-    return _smithy.isa(o, "CreateConnectionRequest");
+    return __isa(o, "CreateConnectionRequest");
   }
 }
 
@@ -971,10 +968,7 @@ export namespace CreateDirectConnectGatewayAssociationProposalRequest {
   export function isa(
     o: any
   ): o is CreateDirectConnectGatewayAssociationProposalRequest {
-    return _smithy.isa(
-      o,
-      "CreateDirectConnectGatewayAssociationProposalRequest"
-    );
+    return __isa(o, "CreateDirectConnectGatewayAssociationProposalRequest");
   }
 }
 
@@ -991,10 +985,7 @@ export namespace CreateDirectConnectGatewayAssociationProposalResult {
   export function isa(
     o: any
   ): o is CreateDirectConnectGatewayAssociationProposalResult {
-    return _smithy.isa(
-      o,
-      "CreateDirectConnectGatewayAssociationProposalResult"
-    );
+    return __isa(o, "CreateDirectConnectGatewayAssociationProposalResult");
   }
 }
 
@@ -1027,7 +1018,7 @@ export namespace CreateDirectConnectGatewayAssociationRequest {
   export function isa(
     o: any
   ): o is CreateDirectConnectGatewayAssociationRequest {
-    return _smithy.isa(o, "CreateDirectConnectGatewayAssociationRequest");
+    return __isa(o, "CreateDirectConnectGatewayAssociationRequest");
   }
 }
 
@@ -1044,7 +1035,7 @@ export namespace CreateDirectConnectGatewayAssociationResult {
   export function isa(
     o: any
   ): o is CreateDirectConnectGatewayAssociationResult {
-    return _smithy.isa(o, "CreateDirectConnectGatewayAssociationResult");
+    return __isa(o, "CreateDirectConnectGatewayAssociationResult");
   }
 }
 
@@ -1065,7 +1056,7 @@ export interface CreateDirectConnectGatewayRequest {
 
 export namespace CreateDirectConnectGatewayRequest {
   export function isa(o: any): o is CreateDirectConnectGatewayRequest {
-    return _smithy.isa(o, "CreateDirectConnectGatewayRequest");
+    return __isa(o, "CreateDirectConnectGatewayRequest");
   }
 }
 
@@ -1079,7 +1070,7 @@ export interface CreateDirectConnectGatewayResult extends $MetadataBearer {
 
 export namespace CreateDirectConnectGatewayResult {
   export function isa(o: any): o is CreateDirectConnectGatewayResult {
-    return _smithy.isa(o, "CreateDirectConnectGatewayResult");
+    return __isa(o, "CreateDirectConnectGatewayResult");
   }
 }
 
@@ -1118,7 +1109,7 @@ export interface CreateInterconnectRequest {
 
 export namespace CreateInterconnectRequest {
   export function isa(o: any): o is CreateInterconnectRequest {
-    return _smithy.isa(o, "CreateInterconnectRequest");
+    return __isa(o, "CreateInterconnectRequest");
   }
 }
 
@@ -1167,7 +1158,7 @@ export interface CreateLagRequest {
 
 export namespace CreateLagRequest {
   export function isa(o: any): o is CreateLagRequest {
-    return _smithy.isa(o, "CreateLagRequest");
+    return __isa(o, "CreateLagRequest");
   }
 }
 
@@ -1186,7 +1177,7 @@ export interface CreatePrivateVirtualInterfaceRequest {
 
 export namespace CreatePrivateVirtualInterfaceRequest {
   export function isa(o: any): o is CreatePrivateVirtualInterfaceRequest {
-    return _smithy.isa(o, "CreatePrivateVirtualInterfaceRequest");
+    return __isa(o, "CreatePrivateVirtualInterfaceRequest");
   }
 }
 
@@ -1205,7 +1196,7 @@ export interface CreatePublicVirtualInterfaceRequest {
 
 export namespace CreatePublicVirtualInterfaceRequest {
   export function isa(o: any): o is CreatePublicVirtualInterfaceRequest {
-    return _smithy.isa(o, "CreatePublicVirtualInterfaceRequest");
+    return __isa(o, "CreatePublicVirtualInterfaceRequest");
   }
 }
 
@@ -1224,7 +1215,7 @@ export interface CreateTransitVirtualInterfaceRequest {
 
 export namespace CreateTransitVirtualInterfaceRequest {
   export function isa(o: any): o is CreateTransitVirtualInterfaceRequest {
-    return _smithy.isa(o, "CreateTransitVirtualInterfaceRequest");
+    return __isa(o, "CreateTransitVirtualInterfaceRequest");
   }
 }
 
@@ -1238,7 +1229,7 @@ export interface CreateTransitVirtualInterfaceResult extends $MetadataBearer {
 
 export namespace CreateTransitVirtualInterfaceResult {
   export function isa(o: any): o is CreateTransitVirtualInterfaceResult {
-    return _smithy.isa(o, "CreateTransitVirtualInterfaceResult");
+    return __isa(o, "CreateTransitVirtualInterfaceResult");
   }
 }
 
@@ -1267,7 +1258,7 @@ export interface DeleteBGPPeerRequest {
 
 export namespace DeleteBGPPeerRequest {
   export function isa(o: any): o is DeleteBGPPeerRequest {
-    return _smithy.isa(o, "DeleteBGPPeerRequest");
+    return __isa(o, "DeleteBGPPeerRequest");
   }
 }
 
@@ -1281,7 +1272,7 @@ export interface DeleteBGPPeerResponse extends $MetadataBearer {
 
 export namespace DeleteBGPPeerResponse {
   export function isa(o: any): o is DeleteBGPPeerResponse {
-    return _smithy.isa(o, "DeleteBGPPeerResponse");
+    return __isa(o, "DeleteBGPPeerResponse");
   }
 }
 
@@ -1295,7 +1286,7 @@ export interface DeleteConnectionRequest {
 
 export namespace DeleteConnectionRequest {
   export function isa(o: any): o is DeleteConnectionRequest {
-    return _smithy.isa(o, "DeleteConnectionRequest");
+    return __isa(o, "DeleteConnectionRequest");
   }
 }
 
@@ -1311,10 +1302,7 @@ export namespace DeleteDirectConnectGatewayAssociationProposalRequest {
   export function isa(
     o: any
   ): o is DeleteDirectConnectGatewayAssociationProposalRequest {
-    return _smithy.isa(
-      o,
-      "DeleteDirectConnectGatewayAssociationProposalRequest"
-    );
+    return __isa(o, "DeleteDirectConnectGatewayAssociationProposalRequest");
   }
 }
 
@@ -1331,10 +1319,7 @@ export namespace DeleteDirectConnectGatewayAssociationProposalResult {
   export function isa(
     o: any
   ): o is DeleteDirectConnectGatewayAssociationProposalResult {
-    return _smithy.isa(
-      o,
-      "DeleteDirectConnectGatewayAssociationProposalResult"
-    );
+    return __isa(o, "DeleteDirectConnectGatewayAssociationProposalResult");
   }
 }
 
@@ -1360,7 +1345,7 @@ export namespace DeleteDirectConnectGatewayAssociationRequest {
   export function isa(
     o: any
   ): o is DeleteDirectConnectGatewayAssociationRequest {
-    return _smithy.isa(o, "DeleteDirectConnectGatewayAssociationRequest");
+    return __isa(o, "DeleteDirectConnectGatewayAssociationRequest");
   }
 }
 
@@ -1377,7 +1362,7 @@ export namespace DeleteDirectConnectGatewayAssociationResult {
   export function isa(
     o: any
   ): o is DeleteDirectConnectGatewayAssociationResult {
-    return _smithy.isa(o, "DeleteDirectConnectGatewayAssociationResult");
+    return __isa(o, "DeleteDirectConnectGatewayAssociationResult");
   }
 }
 
@@ -1391,7 +1376,7 @@ export interface DeleteDirectConnectGatewayRequest {
 
 export namespace DeleteDirectConnectGatewayRequest {
   export function isa(o: any): o is DeleteDirectConnectGatewayRequest {
-    return _smithy.isa(o, "DeleteDirectConnectGatewayRequest");
+    return __isa(o, "DeleteDirectConnectGatewayRequest");
   }
 }
 
@@ -1405,7 +1390,7 @@ export interface DeleteDirectConnectGatewayResult extends $MetadataBearer {
 
 export namespace DeleteDirectConnectGatewayResult {
   export function isa(o: any): o is DeleteDirectConnectGatewayResult {
-    return _smithy.isa(o, "DeleteDirectConnectGatewayResult");
+    return __isa(o, "DeleteDirectConnectGatewayResult");
   }
 }
 
@@ -1419,7 +1404,7 @@ export interface DeleteInterconnectRequest {
 
 export namespace DeleteInterconnectRequest {
   export function isa(o: any): o is DeleteInterconnectRequest {
-    return _smithy.isa(o, "DeleteInterconnectRequest");
+    return __isa(o, "DeleteInterconnectRequest");
   }
 }
 
@@ -1464,7 +1449,7 @@ export interface DeleteInterconnectResponse extends $MetadataBearer {
 
 export namespace DeleteInterconnectResponse {
   export function isa(o: any): o is DeleteInterconnectResponse {
-    return _smithy.isa(o, "DeleteInterconnectResponse");
+    return __isa(o, "DeleteInterconnectResponse");
   }
 }
 
@@ -1478,7 +1463,7 @@ export interface DeleteLagRequest {
 
 export namespace DeleteLagRequest {
   export function isa(o: any): o is DeleteLagRequest {
-    return _smithy.isa(o, "DeleteLagRequest");
+    return __isa(o, "DeleteLagRequest");
   }
 }
 
@@ -1492,7 +1477,7 @@ export interface DeleteVirtualInterfaceRequest {
 
 export namespace DeleteVirtualInterfaceRequest {
   export function isa(o: any): o is DeleteVirtualInterfaceRequest {
-    return _smithy.isa(o, "DeleteVirtualInterfaceRequest");
+    return __isa(o, "DeleteVirtualInterfaceRequest");
   }
 }
 
@@ -1544,7 +1529,7 @@ export interface DeleteVirtualInterfaceResponse extends $MetadataBearer {
 
 export namespace DeleteVirtualInterfaceResponse {
   export function isa(o: any): o is DeleteVirtualInterfaceResponse {
-    return _smithy.isa(o, "DeleteVirtualInterfaceResponse");
+    return __isa(o, "DeleteVirtualInterfaceResponse");
   }
 }
 
@@ -1569,7 +1554,7 @@ export interface DescribeConnectionLoaRequest {
 
 export namespace DescribeConnectionLoaRequest {
   export function isa(o: any): o is DescribeConnectionLoaRequest {
-    return _smithy.isa(o, "DescribeConnectionLoaRequest");
+    return __isa(o, "DescribeConnectionLoaRequest");
   }
 }
 
@@ -1583,7 +1568,7 @@ export interface DescribeConnectionLoaResponse extends $MetadataBearer {
 
 export namespace DescribeConnectionLoaResponse {
   export function isa(o: any): o is DescribeConnectionLoaResponse {
-    return _smithy.isa(o, "DescribeConnectionLoaResponse");
+    return __isa(o, "DescribeConnectionLoaResponse");
   }
 }
 
@@ -1597,7 +1582,7 @@ export interface DescribeConnectionsOnInterconnectRequest {
 
 export namespace DescribeConnectionsOnInterconnectRequest {
   export function isa(o: any): o is DescribeConnectionsOnInterconnectRequest {
-    return _smithy.isa(o, "DescribeConnectionsOnInterconnectRequest");
+    return __isa(o, "DescribeConnectionsOnInterconnectRequest");
   }
 }
 
@@ -1611,7 +1596,7 @@ export interface DescribeConnectionsRequest {
 
 export namespace DescribeConnectionsRequest {
   export function isa(o: any): o is DescribeConnectionsRequest {
-    return _smithy.isa(o, "DescribeConnectionsRequest");
+    return __isa(o, "DescribeConnectionsRequest");
   }
 }
 
@@ -1650,10 +1635,7 @@ export namespace DescribeDirectConnectGatewayAssociationProposalsRequest {
   export function isa(
     o: any
   ): o is DescribeDirectConnectGatewayAssociationProposalsRequest {
-    return _smithy.isa(
-      o,
-      "DescribeDirectConnectGatewayAssociationProposalsRequest"
-    );
+    return __isa(o, "DescribeDirectConnectGatewayAssociationProposalsRequest");
   }
 }
 
@@ -1677,10 +1659,7 @@ export namespace DescribeDirectConnectGatewayAssociationProposalsResult {
   export function isa(
     o: any
   ): o is DescribeDirectConnectGatewayAssociationProposalsResult {
-    return _smithy.isa(
-      o,
-      "DescribeDirectConnectGatewayAssociationProposalsResult"
-    );
+    return __isa(o, "DescribeDirectConnectGatewayAssociationProposalsResult");
   }
 }
 
@@ -1724,7 +1703,7 @@ export namespace DescribeDirectConnectGatewayAssociationsRequest {
   export function isa(
     o: any
   ): o is DescribeDirectConnectGatewayAssociationsRequest {
-    return _smithy.isa(o, "DescribeDirectConnectGatewayAssociationsRequest");
+    return __isa(o, "DescribeDirectConnectGatewayAssociationsRequest");
   }
 }
 
@@ -1746,7 +1725,7 @@ export namespace DescribeDirectConnectGatewayAssociationsResult {
   export function isa(
     o: any
   ): o is DescribeDirectConnectGatewayAssociationsResult {
-    return _smithy.isa(o, "DescribeDirectConnectGatewayAssociationsResult");
+    return __isa(o, "DescribeDirectConnectGatewayAssociationsResult");
   }
 }
 
@@ -1780,7 +1759,7 @@ export namespace DescribeDirectConnectGatewayAttachmentsRequest {
   export function isa(
     o: any
   ): o is DescribeDirectConnectGatewayAttachmentsRequest {
-    return _smithy.isa(o, "DescribeDirectConnectGatewayAttachmentsRequest");
+    return __isa(o, "DescribeDirectConnectGatewayAttachmentsRequest");
   }
 }
 
@@ -1802,7 +1781,7 @@ export namespace DescribeDirectConnectGatewayAttachmentsResult {
   export function isa(
     o: any
   ): o is DescribeDirectConnectGatewayAttachmentsResult {
-    return _smithy.isa(o, "DescribeDirectConnectGatewayAttachmentsResult");
+    return __isa(o, "DescribeDirectConnectGatewayAttachmentsResult");
   }
 }
 
@@ -1829,7 +1808,7 @@ export interface DescribeDirectConnectGatewaysRequest {
 
 export namespace DescribeDirectConnectGatewaysRequest {
   export function isa(o: any): o is DescribeDirectConnectGatewaysRequest {
-    return _smithy.isa(o, "DescribeDirectConnectGatewaysRequest");
+    return __isa(o, "DescribeDirectConnectGatewaysRequest");
   }
 }
 
@@ -1848,7 +1827,7 @@ export interface DescribeDirectConnectGatewaysResult extends $MetadataBearer {
 
 export namespace DescribeDirectConnectGatewaysResult {
   export function isa(o: any): o is DescribeDirectConnectGatewaysResult {
-    return _smithy.isa(o, "DescribeDirectConnectGatewaysResult");
+    return __isa(o, "DescribeDirectConnectGatewaysResult");
   }
 }
 
@@ -1862,7 +1841,7 @@ export interface DescribeHostedConnectionsRequest {
 
 export namespace DescribeHostedConnectionsRequest {
   export function isa(o: any): o is DescribeHostedConnectionsRequest {
-    return _smithy.isa(o, "DescribeHostedConnectionsRequest");
+    return __isa(o, "DescribeHostedConnectionsRequest");
   }
 }
 
@@ -1886,7 +1865,7 @@ export interface DescribeInterconnectLoaRequest {
 
 export namespace DescribeInterconnectLoaRequest {
   export function isa(o: any): o is DescribeInterconnectLoaRequest {
-    return _smithy.isa(o, "DescribeInterconnectLoaRequest");
+    return __isa(o, "DescribeInterconnectLoaRequest");
   }
 }
 
@@ -1900,7 +1879,7 @@ export interface DescribeInterconnectLoaResponse extends $MetadataBearer {
 
 export namespace DescribeInterconnectLoaResponse {
   export function isa(o: any): o is DescribeInterconnectLoaResponse {
-    return _smithy.isa(o, "DescribeInterconnectLoaResponse");
+    return __isa(o, "DescribeInterconnectLoaResponse");
   }
 }
 
@@ -1914,7 +1893,7 @@ export interface DescribeInterconnectsRequest {
 
 export namespace DescribeInterconnectsRequest {
   export function isa(o: any): o is DescribeInterconnectsRequest {
-    return _smithy.isa(o, "DescribeInterconnectsRequest");
+    return __isa(o, "DescribeInterconnectsRequest");
   }
 }
 
@@ -1928,7 +1907,7 @@ export interface DescribeLagsRequest {
 
 export namespace DescribeLagsRequest {
   export function isa(o: any): o is DescribeLagsRequest {
-    return _smithy.isa(o, "DescribeLagsRequest");
+    return __isa(o, "DescribeLagsRequest");
   }
 }
 
@@ -1953,7 +1932,7 @@ export interface DescribeLoaRequest {
 
 export namespace DescribeLoaRequest {
   export function isa(o: any): o is DescribeLoaRequest {
-    return _smithy.isa(o, "DescribeLoaRequest");
+    return __isa(o, "DescribeLoaRequest");
   }
 }
 
@@ -1967,7 +1946,7 @@ export interface DescribeTagsRequest {
 
 export namespace DescribeTagsRequest {
   export function isa(o: any): o is DescribeTagsRequest {
-    return _smithy.isa(o, "DescribeTagsRequest");
+    return __isa(o, "DescribeTagsRequest");
   }
 }
 
@@ -1981,7 +1960,7 @@ export interface DescribeTagsResponse extends $MetadataBearer {
 
 export namespace DescribeTagsResponse {
   export function isa(o: any): o is DescribeTagsResponse {
-    return _smithy.isa(o, "DescribeTagsResponse");
+    return __isa(o, "DescribeTagsResponse");
   }
 }
 
@@ -2000,7 +1979,7 @@ export interface DescribeVirtualInterfacesRequest {
 
 export namespace DescribeVirtualInterfacesRequest {
   export function isa(o: any): o is DescribeVirtualInterfacesRequest {
-    return _smithy.isa(o, "DescribeVirtualInterfacesRequest");
+    return __isa(o, "DescribeVirtualInterfacesRequest");
   }
 }
 
@@ -2008,7 +1987,7 @@ export namespace DescribeVirtualInterfacesRequest {
  * <p>One or more parameters are not valid.</p>
  */
 export interface DirectConnectClientException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DirectConnectClientException";
   $fault: "client";
@@ -2017,7 +1996,7 @@ export interface DirectConnectClientException
 
 export namespace DirectConnectClientException {
   export function isa(o: any): o is DirectConnectClientException {
-    return _smithy.isa(o, "DirectConnectClientException");
+    return __isa(o, "DirectConnectClientException");
   }
 }
 
@@ -2077,7 +2056,7 @@ export interface DirectConnectGateway {
 
 export namespace DirectConnectGateway {
   export function isa(o: any): o is DirectConnectGateway {
-    return _smithy.isa(o, "DirectConnectGateway");
+    return __isa(o, "DirectConnectGateway");
   }
 }
 
@@ -2157,7 +2136,7 @@ export interface DirectConnectGatewayAssociation {
 
 export namespace DirectConnectGatewayAssociation {
   export function isa(o: any): o is DirectConnectGatewayAssociation {
-    return _smithy.isa(o, "DirectConnectGatewayAssociation");
+    return __isa(o, "DirectConnectGatewayAssociation");
   }
 }
 
@@ -2218,7 +2197,7 @@ export interface DirectConnectGatewayAssociationProposal {
 
 export namespace DirectConnectGatewayAssociationProposal {
   export function isa(o: any): o is DirectConnectGatewayAssociationProposal {
-    return _smithy.isa(o, "DirectConnectGatewayAssociationProposal");
+    return __isa(o, "DirectConnectGatewayAssociationProposal");
   }
 }
 
@@ -2295,7 +2274,7 @@ export interface DirectConnectGatewayAttachment {
 
 export namespace DirectConnectGatewayAttachment {
   export function isa(o: any): o is DirectConnectGatewayAttachment {
-    return _smithy.isa(o, "DirectConnectGatewayAttachment");
+    return __isa(o, "DirectConnectGatewayAttachment");
   }
 }
 
@@ -2319,7 +2298,7 @@ export type DirectConnectGatewayState =
  * <p>A server-side error occurred.</p>
  */
 export interface DirectConnectServerException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DirectConnectServerException";
   $fault: "client";
@@ -2328,7 +2307,7 @@ export interface DirectConnectServerException
 
 export namespace DirectConnectServerException {
   export function isa(o: any): o is DirectConnectServerException {
-    return _smithy.isa(o, "DirectConnectServerException");
+    return __isa(o, "DirectConnectServerException");
   }
 }
 
@@ -2347,7 +2326,7 @@ export interface DisassociateConnectionFromLagRequest {
 
 export namespace DisassociateConnectionFromLagRequest {
   export function isa(o: any): o is DisassociateConnectionFromLagRequest {
-    return _smithy.isa(o, "DisassociateConnectionFromLagRequest");
+    return __isa(o, "DisassociateConnectionFromLagRequest");
   }
 }
 
@@ -2355,7 +2334,7 @@ export namespace DisassociateConnectionFromLagRequest {
  * <p>A tag key was specified more than once.</p>
  */
 export interface DuplicateTagKeysException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DuplicateTagKeysException";
   $fault: "client";
@@ -2364,7 +2343,7 @@ export interface DuplicateTagKeysException
 
 export namespace DuplicateTagKeysException {
   export function isa(o: any): o is DuplicateTagKeysException {
-    return _smithy.isa(o, "DuplicateTagKeysException");
+    return __isa(o, "DuplicateTagKeysException");
   }
 }
 
@@ -2488,7 +2467,7 @@ export interface Interconnect extends $MetadataBearer {
 
 export namespace Interconnect {
   export function isa(o: any): o is Interconnect {
-    return _smithy.isa(o, "Interconnect");
+    return __isa(o, "Interconnect");
   }
 }
 
@@ -2511,7 +2490,7 @@ export interface Interconnects extends $MetadataBearer {
 
 export namespace Interconnects {
   export function isa(o: any): o is Interconnects {
-    return _smithy.isa(o, "Interconnects");
+    return __isa(o, "Interconnects");
   }
 }
 
@@ -2640,7 +2619,7 @@ export interface Lag extends $MetadataBearer {
 
 export namespace Lag {
   export function isa(o: any): o is Lag {
-    return _smithy.isa(o, "Lag");
+    return __isa(o, "Lag");
   }
 }
 
@@ -2663,7 +2642,7 @@ export interface Lags extends $MetadataBearer {
 
 export namespace Lags {
   export function isa(o: any): o is Lags {
-    return _smithy.isa(o, "Lags");
+    return __isa(o, "Lags");
   }
 }
 
@@ -2685,7 +2664,7 @@ export interface Loa extends $MetadataBearer {
 
 export namespace Loa {
   export function isa(o: any): o is Loa {
-    return _smithy.isa(o, "Loa");
+    return __isa(o, "Loa");
   }
 }
 
@@ -2726,7 +2705,7 @@ export interface Location {
 
 export namespace Location {
   export function isa(o: any): o is Location {
-    return _smithy.isa(o, "Location");
+    return __isa(o, "Location");
   }
 }
 
@@ -2740,7 +2719,7 @@ export interface Locations extends $MetadataBearer {
 
 export namespace Locations {
   export function isa(o: any): o is Locations {
-    return _smithy.isa(o, "Locations");
+    return __isa(o, "Locations");
   }
 }
 
@@ -2777,7 +2756,7 @@ export interface NewBGPPeer {
 
 export namespace NewBGPPeer {
   export function isa(o: any): o is NewBGPPeer {
-    return _smithy.isa(o, "NewBGPPeer");
+    return __isa(o, "NewBGPPeer");
   }
 }
 
@@ -2845,7 +2824,7 @@ export interface NewPrivateVirtualInterface {
 
 export namespace NewPrivateVirtualInterface {
   export function isa(o: any): o is NewPrivateVirtualInterface {
-    return _smithy.isa(o, "NewPrivateVirtualInterface");
+    return __isa(o, "NewPrivateVirtualInterface");
   }
 }
 
@@ -2903,7 +2882,7 @@ export interface NewPrivateVirtualInterfaceAllocation {
 
 export namespace NewPrivateVirtualInterfaceAllocation {
   export function isa(o: any): o is NewPrivateVirtualInterfaceAllocation {
-    return _smithy.isa(o, "NewPrivateVirtualInterfaceAllocation");
+    return __isa(o, "NewPrivateVirtualInterfaceAllocation");
   }
 }
 
@@ -2961,7 +2940,7 @@ export interface NewPublicVirtualInterface {
 
 export namespace NewPublicVirtualInterface {
   export function isa(o: any): o is NewPublicVirtualInterface {
-    return _smithy.isa(o, "NewPublicVirtualInterface");
+    return __isa(o, "NewPublicVirtualInterface");
   }
 }
 
@@ -3019,7 +2998,7 @@ export interface NewPublicVirtualInterfaceAllocation {
 
 export namespace NewPublicVirtualInterfaceAllocation {
   export function isa(o: any): o is NewPublicVirtualInterfaceAllocation {
-    return _smithy.isa(o, "NewPublicVirtualInterfaceAllocation");
+    return __isa(o, "NewPublicVirtualInterfaceAllocation");
   }
 }
 
@@ -3082,7 +3061,7 @@ export interface NewTransitVirtualInterface {
 
 export namespace NewTransitVirtualInterface {
   export function isa(o: any): o is NewTransitVirtualInterface {
-    return _smithy.isa(o, "NewTransitVirtualInterface");
+    return __isa(o, "NewTransitVirtualInterface");
   }
 }
 
@@ -3140,7 +3119,7 @@ export interface NewTransitVirtualInterfaceAllocation {
 
 export namespace NewTransitVirtualInterfaceAllocation {
   export function isa(o: any): o is NewTransitVirtualInterfaceAllocation {
-    return _smithy.isa(o, "NewTransitVirtualInterfaceAllocation");
+    return __isa(o, "NewTransitVirtualInterfaceAllocation");
   }
 }
 
@@ -3162,7 +3141,7 @@ export interface ResourceTag {
 
 export namespace ResourceTag {
   export function isa(o: any): o is ResourceTag {
-    return _smithy.isa(o, "ResourceTag");
+    return __isa(o, "ResourceTag");
   }
 }
 
@@ -3180,7 +3159,7 @@ export interface RouteFilterPrefix {
 
 export namespace RouteFilterPrefix {
   export function isa(o: any): o is RouteFilterPrefix {
-    return _smithy.isa(o, "RouteFilterPrefix");
+    return __isa(o, "RouteFilterPrefix");
   }
 }
 
@@ -3202,7 +3181,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -3221,7 +3200,7 @@ export interface TagResourceRequest {
 
 export namespace TagResourceRequest {
   export function isa(o: any): o is TagResourceRequest {
-    return _smithy.isa(o, "TagResourceRequest");
+    return __isa(o, "TagResourceRequest");
   }
 }
 
@@ -3231,7 +3210,7 @@ export interface TagResourceResponse extends $MetadataBearer {
 
 export namespace TagResourceResponse {
   export function isa(o: any): o is TagResourceResponse {
-    return _smithy.isa(o, "TagResourceResponse");
+    return __isa(o, "TagResourceResponse");
   }
 }
 
@@ -3239,7 +3218,7 @@ export namespace TagResourceResponse {
  * <p>You have reached the limit on the number of tags that can be assigned.</p>
  */
 export interface TooManyTagsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyTagsException";
   $fault: "client";
@@ -3248,7 +3227,7 @@ export interface TooManyTagsException
 
 export namespace TooManyTagsException {
   export function isa(o: any): o is TooManyTagsException {
-    return _smithy.isa(o, "TooManyTagsException");
+    return __isa(o, "TooManyTagsException");
   }
 }
 
@@ -3267,7 +3246,7 @@ export interface UntagResourceRequest {
 
 export namespace UntagResourceRequest {
   export function isa(o: any): o is UntagResourceRequest {
-    return _smithy.isa(o, "UntagResourceRequest");
+    return __isa(o, "UntagResourceRequest");
   }
 }
 
@@ -3277,7 +3256,7 @@ export interface UntagResourceResponse extends $MetadataBearer {
 
 export namespace UntagResourceResponse {
   export function isa(o: any): o is UntagResourceResponse {
-    return _smithy.isa(o, "UntagResourceResponse");
+    return __isa(o, "UntagResourceResponse");
   }
 }
 
@@ -3303,7 +3282,7 @@ export namespace UpdateDirectConnectGatewayAssociationRequest {
   export function isa(
     o: any
   ): o is UpdateDirectConnectGatewayAssociationRequest {
-    return _smithy.isa(o, "UpdateDirectConnectGatewayAssociationRequest");
+    return __isa(o, "UpdateDirectConnectGatewayAssociationRequest");
   }
 }
 
@@ -3320,7 +3299,7 @@ export namespace UpdateDirectConnectGatewayAssociationResult {
   export function isa(
     o: any
   ): o is UpdateDirectConnectGatewayAssociationResult {
-    return _smithy.isa(o, "UpdateDirectConnectGatewayAssociationResult");
+    return __isa(o, "UpdateDirectConnectGatewayAssociationResult");
   }
 }
 
@@ -3344,7 +3323,7 @@ export interface UpdateLagRequest {
 
 export namespace UpdateLagRequest {
   export function isa(o: any): o is UpdateLagRequest {
-    return _smithy.isa(o, "UpdateLagRequest");
+    return __isa(o, "UpdateLagRequest");
   }
 }
 
@@ -3363,7 +3342,7 @@ export interface UpdateVirtualInterfaceAttributesRequest {
 
 export namespace UpdateVirtualInterfaceAttributesRequest {
   export function isa(o: any): o is UpdateVirtualInterfaceAttributesRequest {
-    return _smithy.isa(o, "UpdateVirtualInterfaceAttributesRequest");
+    return __isa(o, "UpdateVirtualInterfaceAttributesRequest");
   }
 }
 
@@ -3403,7 +3382,7 @@ export interface VirtualGateway {
 
 export namespace VirtualGateway {
   export function isa(o: any): o is VirtualGateway {
-    return _smithy.isa(o, "VirtualGateway");
+    return __isa(o, "VirtualGateway");
   }
 }
 
@@ -3417,7 +3396,7 @@ export interface VirtualGateways extends $MetadataBearer {
 
 export namespace VirtualGateways {
   export function isa(o: any): o is VirtualGateways {
-    return _smithy.isa(o, "VirtualGateways");
+    return __isa(o, "VirtualGateways");
   }
 }
 
@@ -3589,7 +3568,7 @@ export interface VirtualInterface extends $MetadataBearer {
 
 export namespace VirtualInterface {
   export function isa(o: any): o is VirtualInterface {
-    return _smithy.isa(o, "VirtualInterface");
+    return __isa(o, "VirtualInterface");
   }
 }
 
@@ -3614,6 +3593,6 @@ export interface VirtualInterfaces extends $MetadataBearer {
 
 export namespace VirtualInterfaces {
   export function isa(o: any): o is VirtualInterfaces {
-    return _smithy.isa(o, "VirtualInterfaces");
+    return __isa(o, "VirtualInterfaces");
   }
 }

--- a/clients/client-directory-service/models/index.ts
+++ b/clients/client-directory-service/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export interface AcceptSharedDirectoryRequest {
@@ -11,7 +14,7 @@ export interface AcceptSharedDirectoryRequest {
 
 export namespace AcceptSharedDirectoryRequest {
   export function isa(o: any): o is AcceptSharedDirectoryRequest {
-    return _smithy.isa(o, "AcceptSharedDirectoryRequest");
+    return __isa(o, "AcceptSharedDirectoryRequest");
   }
 }
 
@@ -25,7 +28,7 @@ export interface AcceptSharedDirectoryResult extends $MetadataBearer {
 
 export namespace AcceptSharedDirectoryResult {
   export function isa(o: any): o is AcceptSharedDirectoryResult {
-    return _smithy.isa(o, "AcceptSharedDirectoryResult");
+    return __isa(o, "AcceptSharedDirectoryResult");
   }
 }
 
@@ -33,7 +36,7 @@ export namespace AcceptSharedDirectoryResult {
  * <p>You do not have sufficient access to perform this action.</p>
  */
 export interface AccessDeniedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AccessDeniedException";
   $fault: "client";
@@ -50,7 +53,7 @@ export interface AccessDeniedException
 
 export namespace AccessDeniedException {
   export function isa(o: any): o is AccessDeniedException {
-    return _smithy.isa(o, "AccessDeniedException");
+    return __isa(o, "AccessDeniedException");
   }
 }
 
@@ -139,7 +142,7 @@ export interface AddIpRoutesRequest {
 
 export namespace AddIpRoutesRequest {
   export function isa(o: any): o is AddIpRoutesRequest {
-    return _smithy.isa(o, "AddIpRoutesRequest");
+    return __isa(o, "AddIpRoutesRequest");
   }
 }
 
@@ -149,7 +152,7 @@ export interface AddIpRoutesResult extends $MetadataBearer {
 
 export namespace AddIpRoutesResult {
   export function isa(o: any): o is AddIpRoutesResult {
-    return _smithy.isa(o, "AddIpRoutesResult");
+    return __isa(o, "AddIpRoutesResult");
   }
 }
 
@@ -168,7 +171,7 @@ export interface AddTagsToResourceRequest {
 
 export namespace AddTagsToResourceRequest {
   export function isa(o: any): o is AddTagsToResourceRequest {
-    return _smithy.isa(o, "AddTagsToResourceRequest");
+    return __isa(o, "AddTagsToResourceRequest");
   }
 }
 
@@ -178,7 +181,7 @@ export interface AddTagsToResourceResult extends $MetadataBearer {
 
 export namespace AddTagsToResourceResult {
   export function isa(o: any): o is AddTagsToResourceResult {
-    return _smithy.isa(o, "AddTagsToResourceResult");
+    return __isa(o, "AddTagsToResourceResult");
   }
 }
 
@@ -200,7 +203,7 @@ export interface Attribute {
 
 export namespace Attribute {
   export function isa(o: any): o is Attribute {
-    return _smithy.isa(o, "Attribute");
+    return __isa(o, "Attribute");
   }
 }
 
@@ -208,7 +211,7 @@ export namespace Attribute {
  * <p>An authentication error occurred.</p>
  */
 export interface AuthenticationFailedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AuthenticationFailedException";
   $fault: "client";
@@ -225,7 +228,7 @@ export interface AuthenticationFailedException
 
 export namespace AuthenticationFailedException {
   export function isa(o: any): o is AuthenticationFailedException {
-    return _smithy.isa(o, "AuthenticationFailedException");
+    return __isa(o, "AuthenticationFailedException");
   }
 }
 
@@ -244,7 +247,7 @@ export interface CancelSchemaExtensionRequest {
 
 export namespace CancelSchemaExtensionRequest {
   export function isa(o: any): o is CancelSchemaExtensionRequest {
-    return _smithy.isa(o, "CancelSchemaExtensionRequest");
+    return __isa(o, "CancelSchemaExtensionRequest");
   }
 }
 
@@ -254,7 +257,7 @@ export interface CancelSchemaExtensionResult extends $MetadataBearer {
 
 export namespace CancelSchemaExtensionResult {
   export function isa(o: any): o is CancelSchemaExtensionResult {
-    return _smithy.isa(o, "CancelSchemaExtensionResult");
+    return __isa(o, "CancelSchemaExtensionResult");
   }
 }
 
@@ -296,7 +299,7 @@ export interface Certificate {
 
 export namespace Certificate {
   export function isa(o: any): o is Certificate {
-    return _smithy.isa(o, "Certificate");
+    return __isa(o, "Certificate");
   }
 }
 
@@ -304,7 +307,7 @@ export namespace Certificate {
  * <p>The certificate has already been registered into the system.</p>
  */
 export interface CertificateAlreadyExistsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CertificateAlreadyExistsException";
   $fault: "client";
@@ -321,7 +324,7 @@ export interface CertificateAlreadyExistsException
 
 export namespace CertificateAlreadyExistsException {
   export function isa(o: any): o is CertificateAlreadyExistsException {
-    return _smithy.isa(o, "CertificateAlreadyExistsException");
+    return __isa(o, "CertificateAlreadyExistsException");
   }
 }
 
@@ -329,7 +332,7 @@ export namespace CertificateAlreadyExistsException {
  * <p>The certificate is not present in the system for describe or deregister activities.</p>
  */
 export interface CertificateDoesNotExistException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CertificateDoesNotExistException";
   $fault: "client";
@@ -346,7 +349,7 @@ export interface CertificateDoesNotExistException
 
 export namespace CertificateDoesNotExistException {
   export function isa(o: any): o is CertificateDoesNotExistException {
-    return _smithy.isa(o, "CertificateDoesNotExistException");
+    return __isa(o, "CertificateDoesNotExistException");
   }
 }
 
@@ -355,7 +358,7 @@ export namespace CertificateDoesNotExistException {
  *       without disabling LDAP security.</p>
  */
 export interface CertificateInUseException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CertificateInUseException";
   $fault: "client";
@@ -372,7 +375,7 @@ export interface CertificateInUseException
 
 export namespace CertificateInUseException {
   export function isa(o: any): o is CertificateInUseException {
-    return _smithy.isa(o, "CertificateInUseException");
+    return __isa(o, "CertificateInUseException");
   }
 }
 
@@ -399,7 +402,7 @@ export interface CertificateInfo {
 
 export namespace CertificateInfo {
   export function isa(o: any): o is CertificateInfo {
-    return _smithy.isa(o, "CertificateInfo");
+    return __isa(o, "CertificateInfo");
   }
 }
 
@@ -407,7 +410,7 @@ export namespace CertificateInfo {
  * <p>The certificate could not be added because the certificate limit has been reached.</p>
  */
 export interface CertificateLimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CertificateLimitExceededException";
   $fault: "client";
@@ -424,7 +427,7 @@ export interface CertificateLimitExceededException
 
 export namespace CertificateLimitExceededException {
   export function isa(o: any): o is CertificateLimitExceededException {
-    return _smithy.isa(o, "CertificateLimitExceededException");
+    return __isa(o, "CertificateLimitExceededException");
   }
 }
 
@@ -440,9 +443,7 @@ export enum CertificateState {
 /**
  * <p>A client exception has occurred.</p>
  */
-export interface ClientException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface ClientException extends __SmithyException, $MetadataBearer {
   name: "ClientException";
   $fault: "client";
   /**
@@ -458,7 +459,7 @@ export interface ClientException
 
 export namespace ClientException {
   export function isa(o: any): o is ClientException {
-    return _smithy.isa(o, "ClientException");
+    return __isa(o, "ClientException");
   }
 }
 
@@ -486,7 +487,7 @@ export interface Computer {
 
 export namespace Computer {
   export function isa(o: any): o is Computer {
-    return _smithy.isa(o, "Computer");
+    return __isa(o, "Computer");
   }
 }
 
@@ -515,7 +516,7 @@ export interface ConditionalForwarder {
 
 export namespace ConditionalForwarder {
   export function isa(o: any): o is ConditionalForwarder {
-    return _smithy.isa(o, "ConditionalForwarder");
+    return __isa(o, "ConditionalForwarder");
   }
 }
 
@@ -564,7 +565,7 @@ export interface ConnectDirectoryRequest {
 
 export namespace ConnectDirectoryRequest {
   export function isa(o: any): o is ConnectDirectoryRequest {
-    return _smithy.isa(o, "ConnectDirectoryRequest");
+    return __isa(o, "ConnectDirectoryRequest");
   }
 }
 
@@ -581,7 +582,7 @@ export interface ConnectDirectoryResult extends $MetadataBearer {
 
 export namespace ConnectDirectoryResult {
   export function isa(o: any): o is ConnectDirectoryResult {
-    return _smithy.isa(o, "ConnectDirectoryResult");
+    return __isa(o, "ConnectDirectoryResult");
   }
 }
 
@@ -605,7 +606,7 @@ export interface CreateAliasRequest {
 
 export namespace CreateAliasRequest {
   export function isa(o: any): o is CreateAliasRequest {
-    return _smithy.isa(o, "CreateAliasRequest");
+    return __isa(o, "CreateAliasRequest");
   }
 }
 
@@ -627,7 +628,7 @@ export interface CreateAliasResult extends $MetadataBearer {
 
 export namespace CreateAliasResult {
   export function isa(o: any): o is CreateAliasResult {
-    return _smithy.isa(o, "CreateAliasResult");
+    return __isa(o, "CreateAliasResult");
   }
 }
 
@@ -665,7 +666,7 @@ export interface CreateComputerRequest {
 
 export namespace CreateComputerRequest {
   export function isa(o: any): o is CreateComputerRequest {
-    return _smithy.isa(o, "CreateComputerRequest");
+    return __isa(o, "CreateComputerRequest");
   }
 }
 
@@ -682,7 +683,7 @@ export interface CreateComputerResult extends $MetadataBearer {
 
 export namespace CreateComputerResult {
   export function isa(o: any): o is CreateComputerResult {
-    return _smithy.isa(o, "CreateComputerResult");
+    return __isa(o, "CreateComputerResult");
   }
 }
 
@@ -709,7 +710,7 @@ export interface CreateConditionalForwarderRequest {
 
 export namespace CreateConditionalForwarderRequest {
   export function isa(o: any): o is CreateConditionalForwarderRequest {
-    return _smithy.isa(o, "CreateConditionalForwarderRequest");
+    return __isa(o, "CreateConditionalForwarderRequest");
   }
 }
 
@@ -722,7 +723,7 @@ export interface CreateConditionalForwarderResult extends $MetadataBearer {
 
 export namespace CreateConditionalForwarderResult {
   export function isa(o: any): o is CreateConditionalForwarderResult {
-    return _smithy.isa(o, "CreateConditionalForwarderResult");
+    return __isa(o, "CreateConditionalForwarderResult");
   }
 }
 
@@ -773,7 +774,7 @@ export interface CreateDirectoryRequest {
 
 export namespace CreateDirectoryRequest {
   export function isa(o: any): o is CreateDirectoryRequest {
-    return _smithy.isa(o, "CreateDirectoryRequest");
+    return __isa(o, "CreateDirectoryRequest");
   }
 }
 
@@ -790,7 +791,7 @@ export interface CreateDirectoryResult extends $MetadataBearer {
 
 export namespace CreateDirectoryResult {
   export function isa(o: any): o is CreateDirectoryResult {
-    return _smithy.isa(o, "CreateDirectoryResult");
+    return __isa(o, "CreateDirectoryResult");
   }
 }
 
@@ -810,7 +811,7 @@ export interface CreateLogSubscriptionRequest {
 
 export namespace CreateLogSubscriptionRequest {
   export function isa(o: any): o is CreateLogSubscriptionRequest {
-    return _smithy.isa(o, "CreateLogSubscriptionRequest");
+    return __isa(o, "CreateLogSubscriptionRequest");
   }
 }
 
@@ -820,7 +821,7 @@ export interface CreateLogSubscriptionResult extends $MetadataBearer {
 
 export namespace CreateLogSubscriptionResult {
   export function isa(o: any): o is CreateLogSubscriptionResult {
-    return _smithy.isa(o, "CreateLogSubscriptionResult");
+    return __isa(o, "CreateLogSubscriptionResult");
   }
 }
 
@@ -870,7 +871,7 @@ export interface CreateMicrosoftADRequest {
 
 export namespace CreateMicrosoftADRequest {
   export function isa(o: any): o is CreateMicrosoftADRequest {
-    return _smithy.isa(o, "CreateMicrosoftADRequest");
+    return __isa(o, "CreateMicrosoftADRequest");
   }
 }
 
@@ -887,7 +888,7 @@ export interface CreateMicrosoftADResult extends $MetadataBearer {
 
 export namespace CreateMicrosoftADResult {
   export function isa(o: any): o is CreateMicrosoftADResult {
-    return _smithy.isa(o, "CreateMicrosoftADResult");
+    return __isa(o, "CreateMicrosoftADResult");
   }
 }
 
@@ -909,7 +910,7 @@ export interface CreateSnapshotRequest {
 
 export namespace CreateSnapshotRequest {
   export function isa(o: any): o is CreateSnapshotRequest {
-    return _smithy.isa(o, "CreateSnapshotRequest");
+    return __isa(o, "CreateSnapshotRequest");
   }
 }
 
@@ -926,7 +927,7 @@ export interface CreateSnapshotResult extends $MetadataBearer {
 
 export namespace CreateSnapshotResult {
   export function isa(o: any): o is CreateSnapshotResult {
-    return _smithy.isa(o, "CreateSnapshotResult");
+    return __isa(o, "CreateSnapshotResult");
   }
 }
 
@@ -974,7 +975,7 @@ export interface CreateTrustRequest {
 
 export namespace CreateTrustRequest {
   export function isa(o: any): o is CreateTrustRequest {
-    return _smithy.isa(o, "CreateTrustRequest");
+    return __isa(o, "CreateTrustRequest");
   }
 }
 
@@ -991,7 +992,7 @@ export interface CreateTrustResult extends $MetadataBearer {
 
 export namespace CreateTrustResult {
   export function isa(o: any): o is CreateTrustResult {
-    return _smithy.isa(o, "CreateTrustResult");
+    return __isa(o, "CreateTrustResult");
   }
 }
 
@@ -1013,7 +1014,7 @@ export interface DeleteConditionalForwarderRequest {
 
 export namespace DeleteConditionalForwarderRequest {
   export function isa(o: any): o is DeleteConditionalForwarderRequest {
-    return _smithy.isa(o, "DeleteConditionalForwarderRequest");
+    return __isa(o, "DeleteConditionalForwarderRequest");
   }
 }
 
@@ -1026,7 +1027,7 @@ export interface DeleteConditionalForwarderResult extends $MetadataBearer {
 
 export namespace DeleteConditionalForwarderResult {
   export function isa(o: any): o is DeleteConditionalForwarderResult {
-    return _smithy.isa(o, "DeleteConditionalForwarderResult");
+    return __isa(o, "DeleteConditionalForwarderResult");
   }
 }
 
@@ -1043,7 +1044,7 @@ export interface DeleteDirectoryRequest {
 
 export namespace DeleteDirectoryRequest {
   export function isa(o: any): o is DeleteDirectoryRequest {
-    return _smithy.isa(o, "DeleteDirectoryRequest");
+    return __isa(o, "DeleteDirectoryRequest");
   }
 }
 
@@ -1060,7 +1061,7 @@ export interface DeleteDirectoryResult extends $MetadataBearer {
 
 export namespace DeleteDirectoryResult {
   export function isa(o: any): o is DeleteDirectoryResult {
-    return _smithy.isa(o, "DeleteDirectoryResult");
+    return __isa(o, "DeleteDirectoryResult");
   }
 }
 
@@ -1074,7 +1075,7 @@ export interface DeleteLogSubscriptionRequest {
 
 export namespace DeleteLogSubscriptionRequest {
   export function isa(o: any): o is DeleteLogSubscriptionRequest {
-    return _smithy.isa(o, "DeleteLogSubscriptionRequest");
+    return __isa(o, "DeleteLogSubscriptionRequest");
   }
 }
 
@@ -1084,7 +1085,7 @@ export interface DeleteLogSubscriptionResult extends $MetadataBearer {
 
 export namespace DeleteLogSubscriptionResult {
   export function isa(o: any): o is DeleteLogSubscriptionResult {
-    return _smithy.isa(o, "DeleteLogSubscriptionResult");
+    return __isa(o, "DeleteLogSubscriptionResult");
   }
 }
 
@@ -1101,7 +1102,7 @@ export interface DeleteSnapshotRequest {
 
 export namespace DeleteSnapshotRequest {
   export function isa(o: any): o is DeleteSnapshotRequest {
-    return _smithy.isa(o, "DeleteSnapshotRequest");
+    return __isa(o, "DeleteSnapshotRequest");
   }
 }
 
@@ -1118,7 +1119,7 @@ export interface DeleteSnapshotResult extends $MetadataBearer {
 
 export namespace DeleteSnapshotResult {
   export function isa(o: any): o is DeleteSnapshotResult {
-    return _smithy.isa(o, "DeleteSnapshotResult");
+    return __isa(o, "DeleteSnapshotResult");
   }
 }
 
@@ -1140,7 +1141,7 @@ export interface DeleteTrustRequest {
 
 export namespace DeleteTrustRequest {
   export function isa(o: any): o is DeleteTrustRequest {
-    return _smithy.isa(o, "DeleteTrustRequest");
+    return __isa(o, "DeleteTrustRequest");
   }
 }
 
@@ -1157,7 +1158,7 @@ export interface DeleteTrustResult extends $MetadataBearer {
 
 export namespace DeleteTrustResult {
   export function isa(o: any): o is DeleteTrustResult {
-    return _smithy.isa(o, "DeleteTrustResult");
+    return __isa(o, "DeleteTrustResult");
   }
 }
 
@@ -1176,7 +1177,7 @@ export interface DeregisterCertificateRequest {
 
 export namespace DeregisterCertificateRequest {
   export function isa(o: any): o is DeregisterCertificateRequest {
-    return _smithy.isa(o, "DeregisterCertificateRequest");
+    return __isa(o, "DeregisterCertificateRequest");
   }
 }
 
@@ -1186,7 +1187,7 @@ export interface DeregisterCertificateResult extends $MetadataBearer {
 
 export namespace DeregisterCertificateResult {
   export function isa(o: any): o is DeregisterCertificateResult {
-    return _smithy.isa(o, "DeregisterCertificateResult");
+    return __isa(o, "DeregisterCertificateResult");
   }
 }
 
@@ -1208,7 +1209,7 @@ export interface DeregisterEventTopicRequest {
 
 export namespace DeregisterEventTopicRequest {
   export function isa(o: any): o is DeregisterEventTopicRequest {
-    return _smithy.isa(o, "DeregisterEventTopicRequest");
+    return __isa(o, "DeregisterEventTopicRequest");
   }
 }
 
@@ -1221,7 +1222,7 @@ export interface DeregisterEventTopicResult extends $MetadataBearer {
 
 export namespace DeregisterEventTopicResult {
   export function isa(o: any): o is DeregisterEventTopicResult {
-    return _smithy.isa(o, "DeregisterEventTopicResult");
+    return __isa(o, "DeregisterEventTopicResult");
   }
 }
 
@@ -1240,7 +1241,7 @@ export interface DescribeCertificateRequest {
 
 export namespace DescribeCertificateRequest {
   export function isa(o: any): o is DescribeCertificateRequest {
-    return _smithy.isa(o, "DescribeCertificateRequest");
+    return __isa(o, "DescribeCertificateRequest");
   }
 }
 
@@ -1255,7 +1256,7 @@ export interface DescribeCertificateResult extends $MetadataBearer {
 
 export namespace DescribeCertificateResult {
   export function isa(o: any): o is DescribeCertificateResult {
-    return _smithy.isa(o, "DescribeCertificateResult");
+    return __isa(o, "DescribeCertificateResult");
   }
 }
 
@@ -1277,7 +1278,7 @@ export interface DescribeConditionalForwardersRequest {
 
 export namespace DescribeConditionalForwardersRequest {
   export function isa(o: any): o is DescribeConditionalForwardersRequest {
-    return _smithy.isa(o, "DescribeConditionalForwardersRequest");
+    return __isa(o, "DescribeConditionalForwardersRequest");
   }
 }
 
@@ -1294,7 +1295,7 @@ export interface DescribeConditionalForwardersResult extends $MetadataBearer {
 
 export namespace DescribeConditionalForwardersResult {
   export function isa(o: any): o is DescribeConditionalForwardersResult {
-    return _smithy.isa(o, "DescribeConditionalForwardersResult");
+    return __isa(o, "DescribeConditionalForwardersResult");
   }
 }
 
@@ -1323,7 +1324,7 @@ export interface DescribeDirectoriesRequest {
 
 export namespace DescribeDirectoriesRequest {
   export function isa(o: any): o is DescribeDirectoriesRequest {
-    return _smithy.isa(o, "DescribeDirectoriesRequest");
+    return __isa(o, "DescribeDirectoriesRequest");
   }
 }
 
@@ -1350,7 +1351,7 @@ export interface DescribeDirectoriesResult extends $MetadataBearer {
 
 export namespace DescribeDirectoriesResult {
   export function isa(o: any): o is DescribeDirectoriesResult {
-    return _smithy.isa(o, "DescribeDirectoriesResult");
+    return __isa(o, "DescribeDirectoriesResult");
   }
 }
 
@@ -1379,7 +1380,7 @@ export interface DescribeDomainControllersRequest {
 
 export namespace DescribeDomainControllersRequest {
   export function isa(o: any): o is DescribeDomainControllersRequest {
-    return _smithy.isa(o, "DescribeDomainControllersRequest");
+    return __isa(o, "DescribeDomainControllersRequest");
   }
 }
 
@@ -1398,7 +1399,7 @@ export interface DescribeDomainControllersResult extends $MetadataBearer {
 
 export namespace DescribeDomainControllersResult {
   export function isa(o: any): o is DescribeDomainControllersResult {
-    return _smithy.isa(o, "DescribeDomainControllersResult");
+    return __isa(o, "DescribeDomainControllersResult");
   }
 }
 
@@ -1421,7 +1422,7 @@ export interface DescribeEventTopicsRequest {
 
 export namespace DescribeEventTopicsRequest {
   export function isa(o: any): o is DescribeEventTopicsRequest {
-    return _smithy.isa(o, "DescribeEventTopicsRequest");
+    return __isa(o, "DescribeEventTopicsRequest");
   }
 }
 
@@ -1438,7 +1439,7 @@ export interface DescribeEventTopicsResult extends $MetadataBearer {
 
 export namespace DescribeEventTopicsResult {
   export function isa(o: any): o is DescribeEventTopicsResult {
-    return _smithy.isa(o, "DescribeEventTopicsResult");
+    return __isa(o, "DescribeEventTopicsResult");
   }
 }
 
@@ -1468,7 +1469,7 @@ export interface DescribeLDAPSSettingsRequest {
 
 export namespace DescribeLDAPSSettingsRequest {
   export function isa(o: any): o is DescribeLDAPSSettingsRequest {
-    return _smithy.isa(o, "DescribeLDAPSSettingsRequest");
+    return __isa(o, "DescribeLDAPSSettingsRequest");
   }
 }
 
@@ -1488,7 +1489,7 @@ export interface DescribeLDAPSSettingsResult extends $MetadataBearer {
 
 export namespace DescribeLDAPSSettingsResult {
   export function isa(o: any): o is DescribeLDAPSSettingsResult {
-    return _smithy.isa(o, "DescribeLDAPSSettingsResult");
+    return __isa(o, "DescribeLDAPSSettingsResult");
   }
 }
 
@@ -1519,7 +1520,7 @@ export interface DescribeSharedDirectoriesRequest {
 
 export namespace DescribeSharedDirectoriesRequest {
   export function isa(o: any): o is DescribeSharedDirectoriesRequest {
-    return _smithy.isa(o, "DescribeSharedDirectoriesRequest");
+    return __isa(o, "DescribeSharedDirectoriesRequest");
   }
 }
 
@@ -1539,7 +1540,7 @@ export interface DescribeSharedDirectoriesResult extends $MetadataBearer {
 
 export namespace DescribeSharedDirectoriesResult {
   export function isa(o: any): o is DescribeSharedDirectoriesResult {
-    return _smithy.isa(o, "DescribeSharedDirectoriesResult");
+    return __isa(o, "DescribeSharedDirectoriesResult");
   }
 }
 
@@ -1574,7 +1575,7 @@ export interface DescribeSnapshotsRequest {
 
 export namespace DescribeSnapshotsRequest {
   export function isa(o: any): o is DescribeSnapshotsRequest {
-    return _smithy.isa(o, "DescribeSnapshotsRequest");
+    return __isa(o, "DescribeSnapshotsRequest");
   }
 }
 
@@ -1601,7 +1602,7 @@ export interface DescribeSnapshotsResult extends $MetadataBearer {
 
 export namespace DescribeSnapshotsResult {
   export function isa(o: any): o is DescribeSnapshotsResult {
-    return _smithy.isa(o, "DescribeSnapshotsResult");
+    return __isa(o, "DescribeSnapshotsResult");
   }
 }
 
@@ -1635,7 +1636,7 @@ export interface DescribeTrustsRequest {
 
 export namespace DescribeTrustsRequest {
   export function isa(o: any): o is DescribeTrustsRequest {
-    return _smithy.isa(o, "DescribeTrustsRequest");
+    return __isa(o, "DescribeTrustsRequest");
   }
 }
 
@@ -1662,7 +1663,7 @@ export interface DescribeTrustsResult extends $MetadataBearer {
 
 export namespace DescribeTrustsResult {
   export function isa(o: any): o is DescribeTrustsResult {
-    return _smithy.isa(o, "DescribeTrustsResult");
+    return __isa(o, "DescribeTrustsResult");
   }
 }
 
@@ -1670,7 +1671,7 @@ export namespace DescribeTrustsResult {
  * <p>The specified directory has already been shared with this AWS account.</p>
  */
 export interface DirectoryAlreadySharedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DirectoryAlreadySharedException";
   $fault: "client";
@@ -1687,7 +1688,7 @@ export interface DirectoryAlreadySharedException
 
 export namespace DirectoryAlreadySharedException {
   export function isa(o: any): o is DirectoryAlreadySharedException {
-    return _smithy.isa(o, "DirectoryAlreadySharedException");
+    return __isa(o, "DirectoryAlreadySharedException");
   }
 }
 
@@ -1732,7 +1733,7 @@ export interface DirectoryConnectSettings {
 
 export namespace DirectoryConnectSettings {
   export function isa(o: any): o is DirectoryConnectSettings {
-    return _smithy.isa(o, "DirectoryConnectSettings");
+    return __isa(o, "DirectoryConnectSettings");
   }
 }
 
@@ -1774,7 +1775,7 @@ export interface DirectoryConnectSettingsDescription {
 
 export namespace DirectoryConnectSettingsDescription {
   export function isa(o: any): o is DirectoryConnectSettingsDescription {
-    return _smithy.isa(o, "DirectoryConnectSettingsDescription");
+    return __isa(o, "DirectoryConnectSettingsDescription");
   }
 }
 
@@ -1922,7 +1923,7 @@ export interface DirectoryDescription {
 
 export namespace DirectoryDescription {
   export function isa(o: any): o is DirectoryDescription {
-    return _smithy.isa(o, "DirectoryDescription");
+    return __isa(o, "DirectoryDescription");
   }
 }
 
@@ -1930,7 +1931,7 @@ export namespace DirectoryDescription {
  * <p>The specified directory does not exist in the system.</p>
  */
 export interface DirectoryDoesNotExistException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DirectoryDoesNotExistException";
   $fault: "client";
@@ -1947,7 +1948,7 @@ export interface DirectoryDoesNotExistException
 
 export namespace DirectoryDoesNotExistException {
   export function isa(o: any): o is DirectoryDoesNotExistException {
-    return _smithy.isa(o, "DirectoryDoesNotExistException");
+    return __isa(o, "DirectoryDoesNotExistException");
   }
 }
 
@@ -1962,7 +1963,7 @@ export enum DirectoryEdition {
  *             region.</p>
  */
 export interface DirectoryLimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DirectoryLimitExceededException";
   $fault: "client";
@@ -1979,7 +1980,7 @@ export interface DirectoryLimitExceededException
 
 export namespace DirectoryLimitExceededException {
   export function isa(o: any): o is DirectoryLimitExceededException {
-    return _smithy.isa(o, "DirectoryLimitExceededException");
+    return __isa(o, "DirectoryLimitExceededException");
   }
 }
 
@@ -2036,7 +2037,7 @@ export interface DirectoryLimits {
 
 export namespace DirectoryLimits {
   export function isa(o: any): o is DirectoryLimits {
-    return _smithy.isa(o, "DirectoryLimits");
+    return __isa(o, "DirectoryLimits");
   }
 }
 
@@ -2044,7 +2045,7 @@ export namespace DirectoryLimits {
  * <p>The specified directory has not been shared with this AWS account.</p>
  */
 export interface DirectoryNotSharedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DirectoryNotSharedException";
   $fault: "client";
@@ -2061,7 +2062,7 @@ export interface DirectoryNotSharedException
 
 export namespace DirectoryNotSharedException {
   export function isa(o: any): o is DirectoryNotSharedException {
-    return _smithy.isa(o, "DirectoryNotSharedException");
+    return __isa(o, "DirectoryNotSharedException");
   }
 }
 
@@ -2095,7 +2096,7 @@ export enum DirectoryType {
  * <p>The specified directory is unavailable or could not be found.</p>
  */
 export interface DirectoryUnavailableException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DirectoryUnavailableException";
   $fault: "client";
@@ -2112,7 +2113,7 @@ export interface DirectoryUnavailableException
 
 export namespace DirectoryUnavailableException {
   export function isa(o: any): o is DirectoryUnavailableException {
-    return _smithy.isa(o, "DirectoryUnavailableException");
+    return __isa(o, "DirectoryUnavailableException");
   }
 }
 
@@ -2134,7 +2135,7 @@ export interface DirectoryVpcSettings {
 
 export namespace DirectoryVpcSettings {
   export function isa(o: any): o is DirectoryVpcSettings {
-    return _smithy.isa(o, "DirectoryVpcSettings");
+    return __isa(o, "DirectoryVpcSettings");
   }
 }
 
@@ -2166,7 +2167,7 @@ export interface DirectoryVpcSettingsDescription {
 
 export namespace DirectoryVpcSettingsDescription {
   export function isa(o: any): o is DirectoryVpcSettingsDescription {
-    return _smithy.isa(o, "DirectoryVpcSettingsDescription");
+    return __isa(o, "DirectoryVpcSettingsDescription");
   }
 }
 
@@ -2186,7 +2187,7 @@ export interface DisableLDAPSRequest {
 
 export namespace DisableLDAPSRequest {
   export function isa(o: any): o is DisableLDAPSRequest {
-    return _smithy.isa(o, "DisableLDAPSRequest");
+    return __isa(o, "DisableLDAPSRequest");
   }
 }
 
@@ -2196,7 +2197,7 @@ export interface DisableLDAPSResult extends $MetadataBearer {
 
 export namespace DisableLDAPSResult {
   export function isa(o: any): o is DisableLDAPSResult {
-    return _smithy.isa(o, "DisableLDAPSResult");
+    return __isa(o, "DisableLDAPSResult");
   }
 }
 
@@ -2213,7 +2214,7 @@ export interface DisableRadiusRequest {
 
 export namespace DisableRadiusRequest {
   export function isa(o: any): o is DisableRadiusRequest {
-    return _smithy.isa(o, "DisableRadiusRequest");
+    return __isa(o, "DisableRadiusRequest");
   }
 }
 
@@ -2226,7 +2227,7 @@ export interface DisableRadiusResult extends $MetadataBearer {
 
 export namespace DisableRadiusResult {
   export function isa(o: any): o is DisableRadiusResult {
-    return _smithy.isa(o, "DisableRadiusResult");
+    return __isa(o, "DisableRadiusResult");
   }
 }
 
@@ -2258,7 +2259,7 @@ export interface DisableSsoRequest {
 
 export namespace DisableSsoRequest {
   export function isa(o: any): o is DisableSsoRequest {
-    return _smithy.isa(o, "DisableSsoRequest");
+    return __isa(o, "DisableSsoRequest");
   }
 }
 
@@ -2271,7 +2272,7 @@ export interface DisableSsoResult extends $MetadataBearer {
 
 export namespace DisableSsoResult {
   export function isa(o: any): o is DisableSsoResult {
-    return _smithy.isa(o, "DisableSsoResult");
+    return __isa(o, "DisableSsoResult");
   }
 }
 
@@ -2333,7 +2334,7 @@ export interface DomainController {
 
 export namespace DomainController {
   export function isa(o: any): o is DomainController {
-    return _smithy.isa(o, "DomainController");
+    return __isa(o, "DomainController");
   }
 }
 
@@ -2341,7 +2342,7 @@ export namespace DomainController {
  * <p>The maximum allowed number of domain controllers per directory was exceeded. The default limit per directory is 20 domain controllers.</p>
  */
 export interface DomainControllerLimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DomainControllerLimitExceededException";
   $fault: "client";
@@ -2358,7 +2359,7 @@ export interface DomainControllerLimitExceededException
 
 export namespace DomainControllerLimitExceededException {
   export function isa(o: any): o is DomainControllerLimitExceededException {
-    return _smithy.isa(o, "DomainControllerLimitExceededException");
+    return __isa(o, "DomainControllerLimitExceededException");
   }
 }
 
@@ -2388,7 +2389,7 @@ export interface EnableLDAPSRequest {
 
 export namespace EnableLDAPSRequest {
   export function isa(o: any): o is EnableLDAPSRequest {
-    return _smithy.isa(o, "EnableLDAPSRequest");
+    return __isa(o, "EnableLDAPSRequest");
   }
 }
 
@@ -2398,7 +2399,7 @@ export interface EnableLDAPSResult extends $MetadataBearer {
 
 export namespace EnableLDAPSResult {
   export function isa(o: any): o is EnableLDAPSResult {
-    return _smithy.isa(o, "EnableLDAPSResult");
+    return __isa(o, "EnableLDAPSResult");
   }
 }
 
@@ -2420,7 +2421,7 @@ export interface EnableRadiusRequest {
 
 export namespace EnableRadiusRequest {
   export function isa(o: any): o is EnableRadiusRequest {
-    return _smithy.isa(o, "EnableRadiusRequest");
+    return __isa(o, "EnableRadiusRequest");
   }
 }
 
@@ -2433,7 +2434,7 @@ export interface EnableRadiusResult extends $MetadataBearer {
 
 export namespace EnableRadiusResult {
   export function isa(o: any): o is EnableRadiusResult {
-    return _smithy.isa(o, "EnableRadiusResult");
+    return __isa(o, "EnableRadiusResult");
   }
 }
 
@@ -2465,7 +2466,7 @@ export interface EnableSsoRequest {
 
 export namespace EnableSsoRequest {
   export function isa(o: any): o is EnableSsoRequest {
-    return _smithy.isa(o, "EnableSsoRequest");
+    return __isa(o, "EnableSsoRequest");
   }
 }
 
@@ -2478,7 +2479,7 @@ export interface EnableSsoResult extends $MetadataBearer {
 
 export namespace EnableSsoResult {
   export function isa(o: any): o is EnableSsoResult {
-    return _smithy.isa(o, "EnableSsoResult");
+    return __isa(o, "EnableSsoResult");
   }
 }
 
@@ -2486,7 +2487,7 @@ export namespace EnableSsoResult {
  * <p>The specified entity already exists.</p>
  */
 export interface EntityAlreadyExistsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "EntityAlreadyExistsException";
   $fault: "client";
@@ -2503,7 +2504,7 @@ export interface EntityAlreadyExistsException
 
 export namespace EntityAlreadyExistsException {
   export function isa(o: any): o is EntityAlreadyExistsException {
-    return _smithy.isa(o, "EntityAlreadyExistsException");
+    return __isa(o, "EntityAlreadyExistsException");
   }
 }
 
@@ -2511,7 +2512,7 @@ export namespace EntityAlreadyExistsException {
  * <p>The specified entity could not be found.</p>
  */
 export interface EntityDoesNotExistException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "EntityDoesNotExistException";
   $fault: "client";
@@ -2528,7 +2529,7 @@ export interface EntityDoesNotExistException
 
 export namespace EntityDoesNotExistException {
   export function isa(o: any): o is EntityDoesNotExistException {
-    return _smithy.isa(o, "EntityDoesNotExistException");
+    return __isa(o, "EntityDoesNotExistException");
   }
 }
 
@@ -2565,7 +2566,7 @@ export interface EventTopic {
 
 export namespace EventTopic {
   export function isa(o: any): o is EventTopic {
-    return _smithy.isa(o, "EventTopic");
+    return __isa(o, "EventTopic");
   }
 }
 
@@ -2578,7 +2579,7 @@ export interface GetDirectoryLimitsRequest {
 
 export namespace GetDirectoryLimitsRequest {
   export function isa(o: any): o is GetDirectoryLimitsRequest {
-    return _smithy.isa(o, "GetDirectoryLimitsRequest");
+    return __isa(o, "GetDirectoryLimitsRequest");
   }
 }
 
@@ -2596,7 +2597,7 @@ export interface GetDirectoryLimitsResult extends $MetadataBearer {
 
 export namespace GetDirectoryLimitsResult {
   export function isa(o: any): o is GetDirectoryLimitsResult {
-    return _smithy.isa(o, "GetDirectoryLimitsResult");
+    return __isa(o, "GetDirectoryLimitsResult");
   }
 }
 
@@ -2613,7 +2614,7 @@ export interface GetSnapshotLimitsRequest {
 
 export namespace GetSnapshotLimitsRequest {
   export function isa(o: any): o is GetSnapshotLimitsRequest {
-    return _smithy.isa(o, "GetSnapshotLimitsRequest");
+    return __isa(o, "GetSnapshotLimitsRequest");
   }
 }
 
@@ -2631,7 +2632,7 @@ export interface GetSnapshotLimitsResult extends $MetadataBearer {
 
 export namespace GetSnapshotLimitsResult {
   export function isa(o: any): o is GetSnapshotLimitsResult {
-    return _smithy.isa(o, "GetSnapshotLimitsResult");
+    return __isa(o, "GetSnapshotLimitsResult");
   }
 }
 
@@ -2639,7 +2640,7 @@ export namespace GetSnapshotLimitsResult {
  * <p>The account does not have sufficient permission to perform the operation.</p>
  */
 export interface InsufficientPermissionsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InsufficientPermissionsException";
   $fault: "client";
@@ -2656,7 +2657,7 @@ export interface InsufficientPermissionsException
 
 export namespace InsufficientPermissionsException {
   export function isa(o: any): o is InsufficientPermissionsException {
-    return _smithy.isa(o, "InsufficientPermissionsException");
+    return __isa(o, "InsufficientPermissionsException");
   }
 }
 
@@ -2664,7 +2665,7 @@ export namespace InsufficientPermissionsException {
  * <p>The certificate PEM that was provided has incorrect encoding.</p>
  */
 export interface InvalidCertificateException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidCertificateException";
   $fault: "client";
@@ -2681,7 +2682,7 @@ export interface InvalidCertificateException
 
 export namespace InvalidCertificateException {
   export function isa(o: any): o is InvalidCertificateException {
-    return _smithy.isa(o, "InvalidCertificateException");
+    return __isa(o, "InvalidCertificateException");
   }
 }
 
@@ -2690,7 +2691,7 @@ export namespace InvalidCertificateException {
  *       status.</p>
  */
 export interface InvalidLDAPSStatusException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidLDAPSStatusException";
   $fault: "client";
@@ -2707,7 +2708,7 @@ export interface InvalidLDAPSStatusException
 
 export namespace InvalidLDAPSStatusException {
   export function isa(o: any): o is InvalidLDAPSStatusException {
-    return _smithy.isa(o, "InvalidLDAPSStatusException");
+    return __isa(o, "InvalidLDAPSStatusException");
   }
 }
 
@@ -2715,7 +2716,7 @@ export namespace InvalidLDAPSStatusException {
  * <p>The <code>NextToken</code> value is not valid.</p>
  */
 export interface InvalidNextTokenException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidNextTokenException";
   $fault: "client";
@@ -2732,7 +2733,7 @@ export interface InvalidNextTokenException
 
 export namespace InvalidNextTokenException {
   export function isa(o: any): o is InvalidNextTokenException {
-    return _smithy.isa(o, "InvalidNextTokenException");
+    return __isa(o, "InvalidNextTokenException");
   }
 }
 
@@ -2740,7 +2741,7 @@ export namespace InvalidNextTokenException {
  * <p>One or more parameters are not valid.</p>
  */
 export interface InvalidParameterException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidParameterException";
   $fault: "client";
@@ -2757,7 +2758,7 @@ export interface InvalidParameterException
 
 export namespace InvalidParameterException {
   export function isa(o: any): o is InvalidParameterException {
-    return _smithy.isa(o, "InvalidParameterException");
+    return __isa(o, "InvalidParameterException");
   }
 }
 
@@ -2765,7 +2766,7 @@ export namespace InvalidParameterException {
  * <p>The new password provided by the user does not meet the password complexity requirements defined in your directory.</p>
  */
 export interface InvalidPasswordException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidPasswordException";
   $fault: "client";
@@ -2782,7 +2783,7 @@ export interface InvalidPasswordException
 
 export namespace InvalidPasswordException {
   export function isa(o: any): o is InvalidPasswordException {
-    return _smithy.isa(o, "InvalidPasswordException");
+    return __isa(o, "InvalidPasswordException");
   }
 }
 
@@ -2790,7 +2791,7 @@ export namespace InvalidPasswordException {
  * <p>The specified shared target is not valid.</p>
  */
 export interface InvalidTargetException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidTargetException";
   $fault: "client";
@@ -2807,7 +2808,7 @@ export interface InvalidTargetException
 
 export namespace InvalidTargetException {
   export function isa(o: any): o is InvalidTargetException {
-    return _smithy.isa(o, "InvalidTargetException");
+    return __isa(o, "InvalidTargetException");
   }
 }
 
@@ -2829,7 +2830,7 @@ export interface IpRoute {
 
 export namespace IpRoute {
   export function isa(o: any): o is IpRoute {
-    return _smithy.isa(o, "IpRoute");
+    return __isa(o, "IpRoute");
   }
 }
 
@@ -2871,7 +2872,7 @@ export interface IpRouteInfo {
 
 export namespace IpRouteInfo {
   export function isa(o: any): o is IpRouteInfo {
-    return _smithy.isa(o, "IpRouteInfo");
+    return __isa(o, "IpRouteInfo");
   }
 }
 
@@ -2879,7 +2880,7 @@ export namespace IpRouteInfo {
  * <p>The maximum allowed number of IP addresses was exceeded. The default limit is 100 IP address blocks.</p>
  */
 export interface IpRouteLimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "IpRouteLimitExceededException";
   $fault: "client";
@@ -2896,7 +2897,7 @@ export interface IpRouteLimitExceededException
 
 export namespace IpRouteLimitExceededException {
   export function isa(o: any): o is IpRouteLimitExceededException {
-    return _smithy.isa(o, "IpRouteLimitExceededException");
+    return __isa(o, "IpRouteLimitExceededException");
   }
 }
 
@@ -2932,7 +2933,7 @@ export interface LDAPSSettingInfo {
 
 export namespace LDAPSSettingInfo {
   export function isa(o: any): o is LDAPSSettingInfo {
-    return _smithy.isa(o, "LDAPSSettingInfo");
+    return __isa(o, "LDAPSSettingInfo");
   }
 }
 
@@ -2970,7 +2971,7 @@ export interface ListCertificatesRequest {
 
 export namespace ListCertificatesRequest {
   export function isa(o: any): o is ListCertificatesRequest {
-    return _smithy.isa(o, "ListCertificatesRequest");
+    return __isa(o, "ListCertificatesRequest");
   }
 }
 
@@ -2991,7 +2992,7 @@ export interface ListCertificatesResult extends $MetadataBearer {
 
 export namespace ListCertificatesResult {
   export function isa(o: any): o is ListCertificatesResult {
-    return _smithy.isa(o, "ListCertificatesResult");
+    return __isa(o, "ListCertificatesResult");
   }
 }
 
@@ -3016,7 +3017,7 @@ export interface ListIpRoutesRequest {
 
 export namespace ListIpRoutesRequest {
   export function isa(o: any): o is ListIpRoutesRequest {
-    return _smithy.isa(o, "ListIpRoutesRequest");
+    return __isa(o, "ListIpRoutesRequest");
   }
 }
 
@@ -3036,7 +3037,7 @@ export interface ListIpRoutesResult extends $MetadataBearer {
 
 export namespace ListIpRoutesResult {
   export function isa(o: any): o is ListIpRoutesResult {
-    return _smithy.isa(o, "ListIpRoutesResult");
+    return __isa(o, "ListIpRoutesResult");
   }
 }
 
@@ -3060,7 +3061,7 @@ export interface ListLogSubscriptionsRequest {
 
 export namespace ListLogSubscriptionsRequest {
   export function isa(o: any): o is ListLogSubscriptionsRequest {
-    return _smithy.isa(o, "ListLogSubscriptionsRequest");
+    return __isa(o, "ListLogSubscriptionsRequest");
   }
 }
 
@@ -3079,7 +3080,7 @@ export interface ListLogSubscriptionsResult extends $MetadataBearer {
 
 export namespace ListLogSubscriptionsResult {
   export function isa(o: any): o is ListLogSubscriptionsResult {
-    return _smithy.isa(o, "ListLogSubscriptionsResult");
+    return __isa(o, "ListLogSubscriptionsResult");
   }
 }
 
@@ -3103,7 +3104,7 @@ export interface ListSchemaExtensionsRequest {
 
 export namespace ListSchemaExtensionsRequest {
   export function isa(o: any): o is ListSchemaExtensionsRequest {
-    return _smithy.isa(o, "ListSchemaExtensionsRequest");
+    return __isa(o, "ListSchemaExtensionsRequest");
   }
 }
 
@@ -3122,7 +3123,7 @@ export interface ListSchemaExtensionsResult extends $MetadataBearer {
 
 export namespace ListSchemaExtensionsResult {
   export function isa(o: any): o is ListSchemaExtensionsResult {
-    return _smithy.isa(o, "ListSchemaExtensionsResult");
+    return __isa(o, "ListSchemaExtensionsResult");
   }
 }
 
@@ -3146,7 +3147,7 @@ export interface ListTagsForResourceRequest {
 
 export namespace ListTagsForResourceRequest {
   export function isa(o: any): o is ListTagsForResourceRequest {
-    return _smithy.isa(o, "ListTagsForResourceRequest");
+    return __isa(o, "ListTagsForResourceRequest");
   }
 }
 
@@ -3165,7 +3166,7 @@ export interface ListTagsForResourceResult extends $MetadataBearer {
 
 export namespace ListTagsForResourceResult {
   export function isa(o: any): o is ListTagsForResourceResult {
-    return _smithy.isa(o, "ListTagsForResourceResult");
+    return __isa(o, "ListTagsForResourceResult");
   }
 }
 
@@ -3192,7 +3193,7 @@ export interface LogSubscription {
 
 export namespace LogSubscription {
   export function isa(o: any): o is LogSubscription {
-    return _smithy.isa(o, "LogSubscription");
+    return __isa(o, "LogSubscription");
   }
 }
 
@@ -3201,7 +3202,7 @@ export namespace LogSubscription {
  *       registered with the system.</p>
  */
 export interface NoAvailableCertificateException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "NoAvailableCertificateException";
   $fault: "client";
@@ -3218,7 +3219,7 @@ export interface NoAvailableCertificateException
 
 export namespace NoAvailableCertificateException {
   export function isa(o: any): o is NoAvailableCertificateException {
-    return _smithy.isa(o, "NoAvailableCertificateException");
+    return __isa(o, "NoAvailableCertificateException");
   }
 }
 
@@ -3226,7 +3227,7 @@ export namespace NoAvailableCertificateException {
  * <p>Exception encountered while trying to access your AWS organization.</p>
  */
 export interface OrganizationsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "OrganizationsException";
   $fault: "client";
@@ -3243,7 +3244,7 @@ export interface OrganizationsException
 
 export namespace OrganizationsException {
   export function isa(o: any): o is OrganizationsException {
-    return _smithy.isa(o, "OrganizationsException");
+    return __isa(o, "OrganizationsException");
   }
 }
 
@@ -3285,7 +3286,7 @@ export interface OwnerDirectoryDescription {
 
 export namespace OwnerDirectoryDescription {
   export function isa(o: any): o is OwnerDirectoryDescription {
-    return _smithy.isa(o, "OwnerDirectoryDescription");
+    return __isa(o, "OwnerDirectoryDescription");
   }
 }
 
@@ -3344,7 +3345,7 @@ export interface RadiusSettings {
 
 export namespace RadiusSettings {
   export function isa(o: any): o is RadiusSettings {
-    return _smithy.isa(o, "RadiusSettings");
+    return __isa(o, "RadiusSettings");
   }
 }
 
@@ -3369,7 +3370,7 @@ export interface RegisterCertificateRequest {
 
 export namespace RegisterCertificateRequest {
   export function isa(o: any): o is RegisterCertificateRequest {
-    return _smithy.isa(o, "RegisterCertificateRequest");
+    return __isa(o, "RegisterCertificateRequest");
   }
 }
 
@@ -3383,7 +3384,7 @@ export interface RegisterCertificateResult extends $MetadataBearer {
 
 export namespace RegisterCertificateResult {
   export function isa(o: any): o is RegisterCertificateResult {
-    return _smithy.isa(o, "RegisterCertificateResult");
+    return __isa(o, "RegisterCertificateResult");
   }
 }
 
@@ -3405,7 +3406,7 @@ export interface RegisterEventTopicRequest {
 
 export namespace RegisterEventTopicRequest {
   export function isa(o: any): o is RegisterEventTopicRequest {
-    return _smithy.isa(o, "RegisterEventTopicRequest");
+    return __isa(o, "RegisterEventTopicRequest");
   }
 }
 
@@ -3418,7 +3419,7 @@ export interface RegisterEventTopicResult extends $MetadataBearer {
 
 export namespace RegisterEventTopicResult {
   export function isa(o: any): o is RegisterEventTopicResult {
-    return _smithy.isa(o, "RegisterEventTopicResult");
+    return __isa(o, "RegisterEventTopicResult");
   }
 }
 
@@ -3432,7 +3433,7 @@ export interface RejectSharedDirectoryRequest {
 
 export namespace RejectSharedDirectoryRequest {
   export function isa(o: any): o is RejectSharedDirectoryRequest {
-    return _smithy.isa(o, "RejectSharedDirectoryRequest");
+    return __isa(o, "RejectSharedDirectoryRequest");
   }
 }
 
@@ -3446,7 +3447,7 @@ export interface RejectSharedDirectoryResult extends $MetadataBearer {
 
 export namespace RejectSharedDirectoryResult {
   export function isa(o: any): o is RejectSharedDirectoryResult {
-    return _smithy.isa(o, "RejectSharedDirectoryResult");
+    return __isa(o, "RejectSharedDirectoryResult");
   }
 }
 
@@ -3465,7 +3466,7 @@ export interface RemoveIpRoutesRequest {
 
 export namespace RemoveIpRoutesRequest {
   export function isa(o: any): o is RemoveIpRoutesRequest {
-    return _smithy.isa(o, "RemoveIpRoutesRequest");
+    return __isa(o, "RemoveIpRoutesRequest");
   }
 }
 
@@ -3475,7 +3476,7 @@ export interface RemoveIpRoutesResult extends $MetadataBearer {
 
 export namespace RemoveIpRoutesResult {
   export function isa(o: any): o is RemoveIpRoutesResult {
-    return _smithy.isa(o, "RemoveIpRoutesResult");
+    return __isa(o, "RemoveIpRoutesResult");
   }
 }
 
@@ -3494,7 +3495,7 @@ export interface RemoveTagsFromResourceRequest {
 
 export namespace RemoveTagsFromResourceRequest {
   export function isa(o: any): o is RemoveTagsFromResourceRequest {
-    return _smithy.isa(o, "RemoveTagsFromResourceRequest");
+    return __isa(o, "RemoveTagsFromResourceRequest");
   }
 }
 
@@ -3504,7 +3505,7 @@ export interface RemoveTagsFromResourceResult extends $MetadataBearer {
 
 export namespace RemoveTagsFromResourceResult {
   export function isa(o: any): o is RemoveTagsFromResourceResult {
-    return _smithy.isa(o, "RemoveTagsFromResourceResult");
+    return __isa(o, "RemoveTagsFromResourceResult");
   }
 }
 
@@ -3532,7 +3533,7 @@ export interface ResetUserPasswordRequest {
 
 export namespace ResetUserPasswordRequest {
   export function isa(o: any): o is ResetUserPasswordRequest {
-    return _smithy.isa(o, "ResetUserPasswordRequest");
+    return __isa(o, "ResetUserPasswordRequest");
   }
 }
 
@@ -3542,7 +3543,7 @@ export interface ResetUserPasswordResult extends $MetadataBearer {
 
 export namespace ResetUserPasswordResult {
   export function isa(o: any): o is ResetUserPasswordResult {
-    return _smithy.isa(o, "ResetUserPasswordResult");
+    return __isa(o, "ResetUserPasswordResult");
   }
 }
 
@@ -3559,7 +3560,7 @@ export interface RestoreFromSnapshotRequest {
 
 export namespace RestoreFromSnapshotRequest {
   export function isa(o: any): o is RestoreFromSnapshotRequest {
-    return _smithy.isa(o, "RestoreFromSnapshotRequest");
+    return __isa(o, "RestoreFromSnapshotRequest");
   }
 }
 
@@ -3572,7 +3573,7 @@ export interface RestoreFromSnapshotResult extends $MetadataBearer {
 
 export namespace RestoreFromSnapshotResult {
   export function isa(o: any): o is RestoreFromSnapshotResult {
-    return _smithy.isa(o, "RestoreFromSnapshotResult");
+    return __isa(o, "RestoreFromSnapshotResult");
   }
 }
 
@@ -3619,7 +3620,7 @@ export interface SchemaExtensionInfo {
 
 export namespace SchemaExtensionInfo {
   export function isa(o: any): o is SchemaExtensionInfo {
-    return _smithy.isa(o, "SchemaExtensionInfo");
+    return __isa(o, "SchemaExtensionInfo");
   }
 }
 
@@ -3643,9 +3644,7 @@ export enum SelectiveAuth {
 /**
  * <p>An exception has occurred in AWS Directory Service.</p>
  */
-export interface ServiceException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface ServiceException extends __SmithyException, $MetadataBearer {
   name: "ServiceException";
   $fault: "server";
   /**
@@ -3661,7 +3660,7 @@ export interface ServiceException
 
 export namespace ServiceException {
   export function isa(o: any): o is ServiceException {
-    return _smithy.isa(o, "ServiceException");
+    return __isa(o, "ServiceException");
   }
 }
 
@@ -3694,7 +3693,7 @@ export interface ShareDirectoryRequest {
 
 export namespace ShareDirectoryRequest {
   export function isa(o: any): o is ShareDirectoryRequest {
-    return _smithy.isa(o, "ShareDirectoryRequest");
+    return __isa(o, "ShareDirectoryRequest");
   }
 }
 
@@ -3709,7 +3708,7 @@ export interface ShareDirectoryResult extends $MetadataBearer {
 
 export namespace ShareDirectoryResult {
   export function isa(o: any): o is ShareDirectoryResult {
-    return _smithy.isa(o, "ShareDirectoryResult");
+    return __isa(o, "ShareDirectoryResult");
   }
 }
 
@@ -3717,7 +3716,7 @@ export namespace ShareDirectoryResult {
  * <p>The maximum number of AWS accounts that you can share with this directory has been reached.</p>
  */
 export interface ShareLimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ShareLimitExceededException";
   $fault: "client";
@@ -3734,7 +3733,7 @@ export interface ShareLimitExceededException
 
 export namespace ShareLimitExceededException {
   export function isa(o: any): o is ShareLimitExceededException {
-    return _smithy.isa(o, "ShareLimitExceededException");
+    return __isa(o, "ShareLimitExceededException");
   }
 }
 
@@ -3773,7 +3772,7 @@ export interface ShareTarget {
 
 export namespace ShareTarget {
   export function isa(o: any): o is ShareTarget {
-    return _smithy.isa(o, "ShareTarget");
+    return __isa(o, "ShareTarget");
   }
 }
 
@@ -3835,7 +3834,7 @@ export interface SharedDirectory {
 
 export namespace SharedDirectory {
   export function isa(o: any): o is SharedDirectory {
-    return _smithy.isa(o, "SharedDirectory");
+    return __isa(o, "SharedDirectory");
   }
 }
 
@@ -3877,7 +3876,7 @@ export interface Snapshot {
 
 export namespace Snapshot {
   export function isa(o: any): o is Snapshot {
-    return _smithy.isa(o, "Snapshot");
+    return __isa(o, "Snapshot");
   }
 }
 
@@ -3887,7 +3886,7 @@ export namespace Snapshot {
  *       directory.</p>
  */
 export interface SnapshotLimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "SnapshotLimitExceededException";
   $fault: "client";
@@ -3904,7 +3903,7 @@ export interface SnapshotLimitExceededException
 
 export namespace SnapshotLimitExceededException {
   export function isa(o: any): o is SnapshotLimitExceededException {
-    return _smithy.isa(o, "SnapshotLimitExceededException");
+    return __isa(o, "SnapshotLimitExceededException");
   }
 }
 
@@ -3931,7 +3930,7 @@ export interface SnapshotLimits {
 
 export namespace SnapshotLimits {
   export function isa(o: any): o is SnapshotLimits {
-    return _smithy.isa(o, "SnapshotLimits");
+    return __isa(o, "SnapshotLimits");
   }
 }
 
@@ -3971,7 +3970,7 @@ export interface StartSchemaExtensionRequest {
 
 export namespace StartSchemaExtensionRequest {
   export function isa(o: any): o is StartSchemaExtensionRequest {
-    return _smithy.isa(o, "StartSchemaExtensionRequest");
+    return __isa(o, "StartSchemaExtensionRequest");
   }
 }
 
@@ -3985,7 +3984,7 @@ export interface StartSchemaExtensionResult extends $MetadataBearer {
 
 export namespace StartSchemaExtensionResult {
   export function isa(o: any): o is StartSchemaExtensionResult {
-    return _smithy.isa(o, "StartSchemaExtensionResult");
+    return __isa(o, "StartSchemaExtensionResult");
   }
 }
 
@@ -4007,7 +4006,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -4015,7 +4014,7 @@ export namespace Tag {
  * <p>The maximum allowed number of tags was exceeded.</p>
  */
 export interface TagLimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TagLimitExceededException";
   $fault: "client";
@@ -4032,7 +4031,7 @@ export interface TagLimitExceededException
 
 export namespace TagLimitExceededException {
   export function isa(o: any): o is TagLimitExceededException {
-    return _smithy.isa(o, "TagLimitExceededException");
+    return __isa(o, "TagLimitExceededException");
   }
 }
 
@@ -4110,7 +4109,7 @@ export interface Trust {
 
 export namespace Trust {
   export function isa(o: any): o is Trust {
-    return _smithy.isa(o, "Trust");
+    return __isa(o, "Trust");
   }
 }
 
@@ -4154,7 +4153,7 @@ export interface UnshareDirectoryRequest {
 
 export namespace UnshareDirectoryRequest {
   export function isa(o: any): o is UnshareDirectoryRequest {
-    return _smithy.isa(o, "UnshareDirectoryRequest");
+    return __isa(o, "UnshareDirectoryRequest");
   }
 }
 
@@ -4168,7 +4167,7 @@ export interface UnshareDirectoryResult extends $MetadataBearer {
 
 export namespace UnshareDirectoryResult {
   export function isa(o: any): o is UnshareDirectoryResult {
-    return _smithy.isa(o, "UnshareDirectoryResult");
+    return __isa(o, "UnshareDirectoryResult");
   }
 }
 
@@ -4190,7 +4189,7 @@ export interface UnshareTarget {
 
 export namespace UnshareTarget {
   export function isa(o: any): o is UnshareTarget {
-    return _smithy.isa(o, "UnshareTarget");
+    return __isa(o, "UnshareTarget");
   }
 }
 
@@ -4198,7 +4197,7 @@ export namespace UnshareTarget {
  * <p>The operation is not supported.</p>
  */
 export interface UnsupportedOperationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UnsupportedOperationException";
   $fault: "client";
@@ -4215,7 +4214,7 @@ export interface UnsupportedOperationException
 
 export namespace UnsupportedOperationException {
   export function isa(o: any): o is UnsupportedOperationException {
-    return _smithy.isa(o, "UnsupportedOperationException");
+    return __isa(o, "UnsupportedOperationException");
   }
 }
 
@@ -4242,7 +4241,7 @@ export interface UpdateConditionalForwarderRequest {
 
 export namespace UpdateConditionalForwarderRequest {
   export function isa(o: any): o is UpdateConditionalForwarderRequest {
-    return _smithy.isa(o, "UpdateConditionalForwarderRequest");
+    return __isa(o, "UpdateConditionalForwarderRequest");
   }
 }
 
@@ -4255,7 +4254,7 @@ export interface UpdateConditionalForwarderResult extends $MetadataBearer {
 
 export namespace UpdateConditionalForwarderResult {
   export function isa(o: any): o is UpdateConditionalForwarderResult {
-    return _smithy.isa(o, "UpdateConditionalForwarderResult");
+    return __isa(o, "UpdateConditionalForwarderResult");
   }
 }
 
@@ -4274,7 +4273,7 @@ export interface UpdateNumberOfDomainControllersRequest {
 
 export namespace UpdateNumberOfDomainControllersRequest {
   export function isa(o: any): o is UpdateNumberOfDomainControllersRequest {
-    return _smithy.isa(o, "UpdateNumberOfDomainControllersRequest");
+    return __isa(o, "UpdateNumberOfDomainControllersRequest");
   }
 }
 
@@ -4284,7 +4283,7 @@ export interface UpdateNumberOfDomainControllersResult extends $MetadataBearer {
 
 export namespace UpdateNumberOfDomainControllersResult {
   export function isa(o: any): o is UpdateNumberOfDomainControllersResult {
-    return _smithy.isa(o, "UpdateNumberOfDomainControllersResult");
+    return __isa(o, "UpdateNumberOfDomainControllersResult");
   }
 }
 
@@ -4306,7 +4305,7 @@ export interface UpdateRadiusRequest {
 
 export namespace UpdateRadiusRequest {
   export function isa(o: any): o is UpdateRadiusRequest {
-    return _smithy.isa(o, "UpdateRadiusRequest");
+    return __isa(o, "UpdateRadiusRequest");
   }
 }
 
@@ -4319,7 +4318,7 @@ export interface UpdateRadiusResult extends $MetadataBearer {
 
 export namespace UpdateRadiusResult {
   export function isa(o: any): o is UpdateRadiusResult {
-    return _smithy.isa(o, "UpdateRadiusResult");
+    return __isa(o, "UpdateRadiusResult");
   }
 }
 
@@ -4338,7 +4337,7 @@ export interface UpdateTrustRequest {
 
 export namespace UpdateTrustRequest {
   export function isa(o: any): o is UpdateTrustRequest {
-    return _smithy.isa(o, "UpdateTrustRequest");
+    return __isa(o, "UpdateTrustRequest");
   }
 }
 
@@ -4357,7 +4356,7 @@ export interface UpdateTrustResult extends $MetadataBearer {
 
 export namespace UpdateTrustResult {
   export function isa(o: any): o is UpdateTrustResult {
-    return _smithy.isa(o, "UpdateTrustResult");
+    return __isa(o, "UpdateTrustResult");
   }
 }
 
@@ -4365,7 +4364,7 @@ export namespace UpdateTrustResult {
  * <p>The user provided a username that does not exist in your directory.</p>
  */
 export interface UserDoesNotExistException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UserDoesNotExistException";
   $fault: "client";
@@ -4382,7 +4381,7 @@ export interface UserDoesNotExistException
 
 export namespace UserDoesNotExistException {
   export function isa(o: any): o is UserDoesNotExistException {
-    return _smithy.isa(o, "UserDoesNotExistException");
+    return __isa(o, "UserDoesNotExistException");
   }
 }
 
@@ -4399,7 +4398,7 @@ export interface VerifyTrustRequest {
 
 export namespace VerifyTrustRequest {
   export function isa(o: any): o is VerifyTrustRequest {
-    return _smithy.isa(o, "VerifyTrustRequest");
+    return __isa(o, "VerifyTrustRequest");
   }
 }
 
@@ -4416,6 +4415,6 @@ export interface VerifyTrustResult extends $MetadataBearer {
 
 export namespace VerifyTrustResult {
   export function isa(o: any): o is VerifyTrustResult {
-    return _smithy.isa(o, "VerifyTrustResult");
+    return __isa(o, "VerifyTrustResult");
   }
 }

--- a/clients/client-dlm/models/index.ts
+++ b/clients/client-dlm/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export interface CreateLifecyclePolicyRequest {
@@ -31,7 +34,7 @@ export interface CreateLifecyclePolicyRequest {
 
 export namespace CreateLifecyclePolicyRequest {
   export function isa(o: any): o is CreateLifecyclePolicyRequest {
-    return _smithy.isa(o, "CreateLifecyclePolicyRequest");
+    return __isa(o, "CreateLifecyclePolicyRequest");
   }
 }
 
@@ -45,7 +48,7 @@ export interface CreateLifecyclePolicyResponse extends $MetadataBearer {
 
 export namespace CreateLifecyclePolicyResponse {
   export function isa(o: any): o is CreateLifecyclePolicyResponse {
-    return _smithy.isa(o, "CreateLifecyclePolicyResponse");
+    return __isa(o, "CreateLifecyclePolicyResponse");
   }
 }
 
@@ -72,7 +75,7 @@ export interface CreateRule {
 
 export namespace CreateRule {
   export function isa(o: any): o is CreateRule {
-    return _smithy.isa(o, "CreateRule");
+    return __isa(o, "CreateRule");
   }
 }
 
@@ -94,7 +97,7 @@ export interface CrossRegionCopyRetainRule {
 
 export namespace CrossRegionCopyRetainRule {
   export function isa(o: any): o is CrossRegionCopyRetainRule {
-    return _smithy.isa(o, "CrossRegionCopyRetainRule");
+    return __isa(o, "CrossRegionCopyRetainRule");
   }
 }
 
@@ -131,7 +134,7 @@ export interface CrossRegionCopyRule {
 
 export namespace CrossRegionCopyRule {
   export function isa(o: any): o is CrossRegionCopyRule {
-    return _smithy.isa(o, "CrossRegionCopyRule");
+    return __isa(o, "CrossRegionCopyRule");
   }
 }
 
@@ -145,7 +148,7 @@ export interface DeleteLifecyclePolicyRequest {
 
 export namespace DeleteLifecyclePolicyRequest {
   export function isa(o: any): o is DeleteLifecyclePolicyRequest {
-    return _smithy.isa(o, "DeleteLifecyclePolicyRequest");
+    return __isa(o, "DeleteLifecyclePolicyRequest");
   }
 }
 
@@ -155,7 +158,7 @@ export interface DeleteLifecyclePolicyResponse extends $MetadataBearer {
 
 export namespace DeleteLifecyclePolicyResponse {
   export function isa(o: any): o is DeleteLifecyclePolicyResponse {
-    return _smithy.isa(o, "DeleteLifecyclePolicyResponse");
+    return __isa(o, "DeleteLifecyclePolicyResponse");
   }
 }
 
@@ -187,7 +190,7 @@ export interface FastRestoreRule {
 
 export namespace FastRestoreRule {
   export function isa(o: any): o is FastRestoreRule {
-    return _smithy.isa(o, "FastRestoreRule");
+    return __isa(o, "FastRestoreRule");
   }
 }
 
@@ -221,7 +224,7 @@ export interface GetLifecyclePoliciesRequest {
 
 export namespace GetLifecyclePoliciesRequest {
   export function isa(o: any): o is GetLifecyclePoliciesRequest {
-    return _smithy.isa(o, "GetLifecyclePoliciesRequest");
+    return __isa(o, "GetLifecyclePoliciesRequest");
   }
 }
 
@@ -235,7 +238,7 @@ export interface GetLifecyclePoliciesResponse extends $MetadataBearer {
 
 export namespace GetLifecyclePoliciesResponse {
   export function isa(o: any): o is GetLifecyclePoliciesResponse {
-    return _smithy.isa(o, "GetLifecyclePoliciesResponse");
+    return __isa(o, "GetLifecyclePoliciesResponse");
   }
 }
 
@@ -249,7 +252,7 @@ export interface GetLifecyclePolicyRequest {
 
 export namespace GetLifecyclePolicyRequest {
   export function isa(o: any): o is GetLifecyclePolicyRequest {
-    return _smithy.isa(o, "GetLifecyclePolicyRequest");
+    return __isa(o, "GetLifecyclePolicyRequest");
   }
 }
 
@@ -263,7 +266,7 @@ export interface GetLifecyclePolicyResponse extends $MetadataBearer {
 
 export namespace GetLifecyclePolicyResponse {
   export function isa(o: any): o is GetLifecyclePolicyResponse {
-    return _smithy.isa(o, "GetLifecyclePolicyResponse");
+    return __isa(o, "GetLifecyclePolicyResponse");
   }
 }
 
@@ -277,7 +280,7 @@ export enum GettablePolicyStateValues {
  * <p>The service failed in an unexpected way.</p>
  */
 export interface InternalServerException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalServerException";
   $fault: "server";
@@ -287,7 +290,7 @@ export interface InternalServerException
 
 export namespace InternalServerException {
   export function isa(o: any): o is InternalServerException {
-    return _smithy.isa(o, "InternalServerException");
+    return __isa(o, "InternalServerException");
   }
 }
 
@@ -299,7 +302,7 @@ export enum IntervalUnitValues {
  * <p>Bad request. The request is missing required parameters or has invalid parameters.</p>
  */
 export interface InvalidRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidRequestException";
   $fault: "client";
@@ -318,7 +321,7 @@ export interface InvalidRequestException
 
 export namespace InvalidRequestException {
   export function isa(o: any): o is InvalidRequestException {
-    return _smithy.isa(o, "InvalidRequestException");
+    return __isa(o, "InvalidRequestException");
   }
 }
 
@@ -380,7 +383,7 @@ export interface LifecyclePolicy {
 
 export namespace LifecyclePolicy {
   export function isa(o: any): o is LifecyclePolicy {
-    return _smithy.isa(o, "LifecyclePolicy");
+    return __isa(o, "LifecyclePolicy");
   }
 }
 
@@ -412,7 +415,7 @@ export interface LifecyclePolicySummary {
 
 export namespace LifecyclePolicySummary {
   export function isa(o: any): o is LifecyclePolicySummary {
-    return _smithy.isa(o, "LifecyclePolicySummary");
+    return __isa(o, "LifecyclePolicySummary");
   }
 }
 
@@ -420,7 +423,7 @@ export namespace LifecyclePolicySummary {
  * <p>The request failed because a limit was exceeded.</p>
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -434,7 +437,7 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
@@ -448,7 +451,7 @@ export interface ListTagsForResourceRequest {
 
 export namespace ListTagsForResourceRequest {
   export function isa(o: any): o is ListTagsForResourceRequest {
-    return _smithy.isa(o, "ListTagsForResourceRequest");
+    return __isa(o, "ListTagsForResourceRequest");
   }
 }
 
@@ -462,7 +465,7 @@ export interface ListTagsForResourceResponse extends $MetadataBearer {
 
 export namespace ListTagsForResourceResponse {
   export function isa(o: any): o is ListTagsForResourceResponse {
-    return _smithy.isa(o, "ListTagsForResourceResponse");
+    return __isa(o, "ListTagsForResourceResponse");
   }
 }
 
@@ -479,7 +482,7 @@ export interface _Parameters {
 
 export namespace _Parameters {
   export function isa(o: any): o is _Parameters {
-    return _smithy.isa(o, "Parameters");
+    return __isa(o, "Parameters");
   }
 }
 
@@ -516,7 +519,7 @@ export interface PolicyDetails {
 
 export namespace PolicyDetails {
   export function isa(o: any): o is PolicyDetails {
-    return _smithy.isa(o, "PolicyDetails");
+    return __isa(o, "PolicyDetails");
   }
 }
 
@@ -528,7 +531,7 @@ export enum PolicyTypeValues {
  * <p>A requested resource was not found.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -547,7 +550,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -579,7 +582,7 @@ export interface RetainRule {
 
 export namespace RetainRule {
   export function isa(o: any): o is RetainRule {
-    return _smithy.isa(o, "RetainRule");
+    return __isa(o, "RetainRule");
   }
 }
 
@@ -638,7 +641,7 @@ export interface Schedule {
 
 export namespace Schedule {
   export function isa(o: any): o is Schedule {
-    return _smithy.isa(o, "Schedule");
+    return __isa(o, "Schedule");
   }
 }
 
@@ -665,7 +668,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -684,7 +687,7 @@ export interface TagResourceRequest {
 
 export namespace TagResourceRequest {
   export function isa(o: any): o is TagResourceRequest {
-    return _smithy.isa(o, "TagResourceRequest");
+    return __isa(o, "TagResourceRequest");
   }
 }
 
@@ -694,7 +697,7 @@ export interface TagResourceResponse extends $MetadataBearer {
 
 export namespace TagResourceResponse {
   export function isa(o: any): o is TagResourceResponse {
-    return _smithy.isa(o, "TagResourceResponse");
+    return __isa(o, "TagResourceResponse");
   }
 }
 
@@ -713,7 +716,7 @@ export interface UntagResourceRequest {
 
 export namespace UntagResourceRequest {
   export function isa(o: any): o is UntagResourceRequest {
-    return _smithy.isa(o, "UntagResourceRequest");
+    return __isa(o, "UntagResourceRequest");
   }
 }
 
@@ -723,7 +726,7 @@ export interface UntagResourceResponse extends $MetadataBearer {
 
 export namespace UntagResourceResponse {
   export function isa(o: any): o is UntagResourceResponse {
-    return _smithy.isa(o, "UntagResourceResponse");
+    return __isa(o, "UntagResourceResponse");
   }
 }
 
@@ -757,7 +760,7 @@ export interface UpdateLifecyclePolicyRequest {
 
 export namespace UpdateLifecyclePolicyRequest {
   export function isa(o: any): o is UpdateLifecyclePolicyRequest {
-    return _smithy.isa(o, "UpdateLifecyclePolicyRequest");
+    return __isa(o, "UpdateLifecyclePolicyRequest");
   }
 }
 
@@ -767,6 +770,6 @@ export interface UpdateLifecyclePolicyResponse extends $MetadataBearer {
 
 export namespace UpdateLifecyclePolicyResponse {
   export function isa(o: any): o is UpdateLifecyclePolicyResponse {
-    return _smithy.isa(o, "UpdateLifecyclePolicyResponse");
+    return __isa(o, "UpdateLifecyclePolicyResponse");
   }
 }

--- a/clients/client-dlm/protocols/Aws_restJson1_1.ts
+++ b/clients/client-dlm/protocols/Aws_restJson1_1.ts
@@ -52,7 +52,10 @@ import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  extendedEncodeURIComponent as __extendedEncodeURIComponent
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -106,13 +109,13 @@ export async function serializeAws_restJson1_1DeleteLifecyclePolicyCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/policies/{PolicyId}";
   if (input.PolicyId !== undefined) {
-    const labelValue: string = input.PolicyId.toString();
+    const labelValue: string = input.PolicyId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: PolicyId.");
     }
     resolvedPath = resolvedPath.replace(
       "{PolicyId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: PolicyId.");
@@ -135,19 +138,29 @@ export async function serializeAws_restJson1_1GetLifecyclePoliciesCommand(
   let resolvedPath = "/policies";
   const query: any = {};
   if (input.PolicyIds !== undefined) {
-    query["policyIds"] = input.PolicyIds;
+    query[
+      __extendedEncodeURIComponent("policyIds")
+    ] = input.PolicyIds.map(entry => __extendedEncodeURIComponent(entry));
   }
   if (input.ResourceTypes !== undefined) {
-    query["resourceTypes"] = input.ResourceTypes;
+    query[
+      __extendedEncodeURIComponent("resourceTypes")
+    ] = input.ResourceTypes.map(entry => __extendedEncodeURIComponent(entry));
   }
   if (input.State !== undefined) {
-    query["state"] = input.State.toString();
+    query[__extendedEncodeURIComponent("state")] = __extendedEncodeURIComponent(
+      input.State
+    );
   }
   if (input.TagsToAdd !== undefined) {
-    query["tagsToAdd"] = input.TagsToAdd;
+    query[
+      __extendedEncodeURIComponent("tagsToAdd")
+    ] = input.TagsToAdd.map(entry => __extendedEncodeURIComponent(entry));
   }
   if (input.TargetTags !== undefined) {
-    query["targetTags"] = input.TargetTags;
+    query[
+      __extendedEncodeURIComponent("targetTags")
+    ] = input.TargetTags.map(entry => __extendedEncodeURIComponent(entry));
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -167,13 +180,13 @@ export async function serializeAws_restJson1_1GetLifecyclePolicyCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/policies/{PolicyId}";
   if (input.PolicyId !== undefined) {
-    const labelValue: string = input.PolicyId.toString();
+    const labelValue: string = input.PolicyId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: PolicyId.");
     }
     resolvedPath = resolvedPath.replace(
       "{PolicyId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: PolicyId.");
@@ -195,7 +208,7 @@ export async function serializeAws_restJson1_1ListTagsForResourceCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/tags/{ResourceArn}";
   if (input.ResourceArn !== undefined) {
-    const labelValue: string = input.ResourceArn.toString();
+    const labelValue: string = input.ResourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ResourceArn."
@@ -203,7 +216,7 @@ export async function serializeAws_restJson1_1ListTagsForResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ResourceArn.");
@@ -225,7 +238,7 @@ export async function serializeAws_restJson1_1TagResourceCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/tags/{ResourceArn}";
   if (input.ResourceArn !== undefined) {
-    const labelValue: string = input.ResourceArn.toString();
+    const labelValue: string = input.ResourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ResourceArn."
@@ -233,7 +246,7 @@ export async function serializeAws_restJson1_1TagResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ResourceArn.");
@@ -262,7 +275,7 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/tags/{ResourceArn}";
   if (input.ResourceArn !== undefined) {
-    const labelValue: string = input.ResourceArn.toString();
+    const labelValue: string = input.ResourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ResourceArn."
@@ -270,14 +283,16 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ResourceArn.");
   }
   const query: any = {};
   if (input.TagKeys !== undefined) {
-    query["tagKeys"] = input.TagKeys;
+    query[__extendedEncodeURIComponent("tagKeys")] = input.TagKeys.map(entry =>
+      __extendedEncodeURIComponent(entry)
+    );
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -297,13 +312,13 @@ export async function serializeAws_restJson1_1UpdateLifecyclePolicyCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/policies/{PolicyId}";
   if (input.PolicyId !== undefined) {
-    const labelValue: string = input.PolicyId.toString();
+    const labelValue: string = input.PolicyId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: PolicyId.");
     }
     resolvedPath = resolvedPath.replace(
       "{PolicyId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: PolicyId.");
@@ -420,6 +435,7 @@ export async function deserializeAws_restJson1_1DeleteLifecyclePolicyCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeleteLifecyclePolicyResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -705,6 +721,7 @@ export async function deserializeAws_restJson1_1TagResourceCommand(
     $metadata: deserializeMetadata(output),
     __type: "TagResourceResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -767,6 +784,7 @@ export async function deserializeAws_restJson1_1UntagResourceCommand(
     $metadata: deserializeMetadata(output),
     __type: "UntagResourceResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -832,6 +850,7 @@ export async function deserializeAws_restJson1_1UpdateLifecyclePolicyCommand(
     $metadata: deserializeMetadata(output),
     __type: "UpdateLifecyclePolicyResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 

--- a/clients/client-docdb/models/index.ts
+++ b/clients/client-docdb/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -8,7 +11,7 @@ import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
  *             using IAM.</p>
  */
 export interface AuthorizationNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AuthorizationNotFoundFault";
   $fault: "client";
@@ -17,7 +20,7 @@ export interface AuthorizationNotFoundFault
 
 export namespace AuthorizationNotFoundFault {
   export function isa(o: any): o is AuthorizationNotFoundFault {
-    return _smithy.isa(o, "AuthorizationNotFoundFault");
+    return __isa(o, "AuthorizationNotFoundFault");
   }
 }
 
@@ -26,7 +29,7 @@ export namespace AuthorizationNotFoundFault {
  *             <code>CertificateIdentifier</code> doesn't refer to an existing certificate. </p>
  */
 export interface CertificateNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CertificateNotFoundFault";
   $fault: "client";
@@ -35,7 +38,7 @@ export interface CertificateNotFoundFault
 
 export namespace CertificateNotFoundFault {
   export function isa(o: any): o is CertificateNotFoundFault {
-    return _smithy.isa(o, "CertificateNotFoundFault");
+    return __isa(o, "CertificateNotFoundFault");
   }
 }
 
@@ -43,7 +46,7 @@ export namespace CertificateNotFoundFault {
  * <p>You already have a DB cluster with the given identifier.</p>
  */
 export interface DBClusterAlreadyExistsFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBClusterAlreadyExistsFault";
   $fault: "client";
@@ -52,7 +55,7 @@ export interface DBClusterAlreadyExistsFault
 
 export namespace DBClusterAlreadyExistsFault {
   export function isa(o: any): o is DBClusterAlreadyExistsFault {
-    return _smithy.isa(o, "DBClusterAlreadyExistsFault");
+    return __isa(o, "DBClusterAlreadyExistsFault");
   }
 }
 
@@ -61,7 +64,7 @@ export namespace DBClusterAlreadyExistsFault {
  *             <code>DBClusterIdentifier</code> doesn't refer to an existing DB cluster. </p>
  */
 export interface DBClusterNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBClusterNotFoundFault";
   $fault: "client";
@@ -70,7 +73,7 @@ export interface DBClusterNotFoundFault
 
 export namespace DBClusterNotFoundFault {
   export function isa(o: any): o is DBClusterNotFoundFault {
-    return _smithy.isa(o, "DBClusterNotFoundFault");
+    return __isa(o, "DBClusterNotFoundFault");
   }
 }
 
@@ -80,7 +83,7 @@ export namespace DBClusterNotFoundFault {
  *             parameter group. </p>
  */
 export interface DBClusterParameterGroupNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBClusterParameterGroupNotFoundFault";
   $fault: "client";
@@ -89,7 +92,7 @@ export interface DBClusterParameterGroupNotFoundFault
 
 export namespace DBClusterParameterGroupNotFoundFault {
   export function isa(o: any): o is DBClusterParameterGroupNotFoundFault {
-    return _smithy.isa(o, "DBClusterParameterGroupNotFoundFault");
+    return __isa(o, "DBClusterParameterGroupNotFoundFault");
   }
 }
 
@@ -98,7 +101,7 @@ export namespace DBClusterParameterGroupNotFoundFault {
  *             DB clusters.</p>
  */
 export interface DBClusterQuotaExceededFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBClusterQuotaExceededFault";
   $fault: "client";
@@ -107,7 +110,7 @@ export interface DBClusterQuotaExceededFault
 
 export namespace DBClusterQuotaExceededFault {
   export function isa(o: any): o is DBClusterQuotaExceededFault {
-    return _smithy.isa(o, "DBClusterQuotaExceededFault");
+    return __isa(o, "DBClusterQuotaExceededFault");
   }
 }
 
@@ -115,7 +118,7 @@ export namespace DBClusterQuotaExceededFault {
  * <p>You already have a DB cluster snapshot with the given identifier.</p>
  */
 export interface DBClusterSnapshotAlreadyExistsFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBClusterSnapshotAlreadyExistsFault";
   $fault: "client";
@@ -124,7 +127,7 @@ export interface DBClusterSnapshotAlreadyExistsFault
 
 export namespace DBClusterSnapshotAlreadyExistsFault {
   export function isa(o: any): o is DBClusterSnapshotAlreadyExistsFault {
-    return _smithy.isa(o, "DBClusterSnapshotAlreadyExistsFault");
+    return __isa(o, "DBClusterSnapshotAlreadyExistsFault");
   }
 }
 
@@ -134,7 +137,7 @@ export namespace DBClusterSnapshotAlreadyExistsFault {
  *             snapshot. </p>
  */
 export interface DBClusterSnapshotNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBClusterSnapshotNotFoundFault";
   $fault: "client";
@@ -143,7 +146,7 @@ export interface DBClusterSnapshotNotFoundFault
 
 export namespace DBClusterSnapshotNotFoundFault {
   export function isa(o: any): o is DBClusterSnapshotNotFoundFault {
-    return _smithy.isa(o, "DBClusterSnapshotNotFoundFault");
+    return __isa(o, "DBClusterSnapshotNotFoundFault");
   }
 }
 
@@ -151,7 +154,7 @@ export namespace DBClusterSnapshotNotFoundFault {
  * <p>You already have a DB instance with the given identifier.</p>
  */
 export interface DBInstanceAlreadyExistsFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBInstanceAlreadyExistsFault";
   $fault: "client";
@@ -160,7 +163,7 @@ export interface DBInstanceAlreadyExistsFault
 
 export namespace DBInstanceAlreadyExistsFault {
   export function isa(o: any): o is DBInstanceAlreadyExistsFault {
-    return _smithy.isa(o, "DBInstanceAlreadyExistsFault");
+    return __isa(o, "DBInstanceAlreadyExistsFault");
   }
 }
 
@@ -169,7 +172,7 @@ export namespace DBInstanceAlreadyExistsFault {
  *             <code>DBInstanceIdentifier</code> doesn't refer to an existing DB instance. </p>
  */
 export interface DBInstanceNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBInstanceNotFoundFault";
   $fault: "client";
@@ -178,7 +181,7 @@ export interface DBInstanceNotFoundFault
 
 export namespace DBInstanceNotFoundFault {
   export function isa(o: any): o is DBInstanceNotFoundFault {
-    return _smithy.isa(o, "DBInstanceNotFoundFault");
+    return __isa(o, "DBInstanceNotFoundFault");
   }
 }
 
@@ -186,7 +189,7 @@ export namespace DBInstanceNotFoundFault {
  * <p>A DB parameter group with the same name already exists.</p>
  */
 export interface DBParameterGroupAlreadyExistsFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBParameterGroupAlreadyExistsFault";
   $fault: "client";
@@ -195,7 +198,7 @@ export interface DBParameterGroupAlreadyExistsFault
 
 export namespace DBParameterGroupAlreadyExistsFault {
   export function isa(o: any): o is DBParameterGroupAlreadyExistsFault {
-    return _smithy.isa(o, "DBParameterGroupAlreadyExistsFault");
+    return __isa(o, "DBParameterGroupAlreadyExistsFault");
   }
 }
 
@@ -205,7 +208,7 @@ export namespace DBParameterGroupAlreadyExistsFault {
  *             group. </p>
  */
 export interface DBParameterGroupNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBParameterGroupNotFoundFault";
   $fault: "client";
@@ -214,7 +217,7 @@ export interface DBParameterGroupNotFoundFault
 
 export namespace DBParameterGroupNotFoundFault {
   export function isa(o: any): o is DBParameterGroupNotFoundFault {
-    return _smithy.isa(o, "DBParameterGroupNotFoundFault");
+    return __isa(o, "DBParameterGroupNotFoundFault");
   }
 }
 
@@ -223,7 +226,7 @@ export namespace DBParameterGroupNotFoundFault {
  *             groups.</p>
  */
 export interface DBParameterGroupQuotaExceededFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBParameterGroupQuotaExceededFault";
   $fault: "client";
@@ -232,7 +235,7 @@ export interface DBParameterGroupQuotaExceededFault
 
 export namespace DBParameterGroupQuotaExceededFault {
   export function isa(o: any): o is DBParameterGroupQuotaExceededFault {
-    return _smithy.isa(o, "DBParameterGroupQuotaExceededFault");
+    return __isa(o, "DBParameterGroupQuotaExceededFault");
   }
 }
 
@@ -241,7 +244,7 @@ export namespace DBParameterGroupQuotaExceededFault {
  *             <code>DBSecurityGroupName</code> doesn't refer to an existing DB security group. </p>
  */
 export interface DBSecurityGroupNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBSecurityGroupNotFoundFault";
   $fault: "client";
@@ -250,7 +253,7 @@ export interface DBSecurityGroupNotFoundFault
 
 export namespace DBSecurityGroupNotFoundFault {
   export function isa(o: any): o is DBSecurityGroupNotFoundFault {
-    return _smithy.isa(o, "DBSecurityGroupNotFoundFault");
+    return __isa(o, "DBSecurityGroupNotFoundFault");
   }
 }
 
@@ -259,7 +262,7 @@ export namespace DBSecurityGroupNotFoundFault {
  *             <code>DBSnapshotIdentifier</code> is already being used by an existing snapshot. </p>
  */
 export interface DBSnapshotAlreadyExistsFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBSnapshotAlreadyExistsFault";
   $fault: "client";
@@ -268,7 +271,7 @@ export interface DBSnapshotAlreadyExistsFault
 
 export namespace DBSnapshotAlreadyExistsFault {
   export function isa(o: any): o is DBSnapshotAlreadyExistsFault {
-    return _smithy.isa(o, "DBSnapshotAlreadyExistsFault");
+    return __isa(o, "DBSnapshotAlreadyExistsFault");
   }
 }
 
@@ -277,7 +280,7 @@ export namespace DBSnapshotAlreadyExistsFault {
  *             <code>DBSnapshotIdentifier</code> doesn't refer to an existing DB snapshot. </p>
  */
 export interface DBSnapshotNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBSnapshotNotFoundFault";
   $fault: "client";
@@ -286,7 +289,7 @@ export interface DBSnapshotNotFoundFault
 
 export namespace DBSnapshotNotFoundFault {
   export function isa(o: any): o is DBSnapshotNotFoundFault {
-    return _smithy.isa(o, "DBSnapshotNotFoundFault");
+    return __isa(o, "DBSnapshotNotFoundFault");
   }
 }
 
@@ -295,7 +298,7 @@ export namespace DBSnapshotNotFoundFault {
  *             <code>DBSubnetGroupName</code> is already being used by an existing DB subnet group. </p>
  */
 export interface DBSubnetGroupAlreadyExistsFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBSubnetGroupAlreadyExistsFault";
   $fault: "client";
@@ -304,7 +307,7 @@ export interface DBSubnetGroupAlreadyExistsFault
 
 export namespace DBSubnetGroupAlreadyExistsFault {
   export function isa(o: any): o is DBSubnetGroupAlreadyExistsFault {
-    return _smithy.isa(o, "DBSubnetGroupAlreadyExistsFault");
+    return __isa(o, "DBSubnetGroupAlreadyExistsFault");
   }
 }
 
@@ -313,7 +316,7 @@ export namespace DBSubnetGroupAlreadyExistsFault {
  *             there is only one Availability Zone.</p>
  */
 export interface DBSubnetGroupDoesNotCoverEnoughAZs
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBSubnetGroupDoesNotCoverEnoughAZs";
   $fault: "client";
@@ -322,7 +325,7 @@ export interface DBSubnetGroupDoesNotCoverEnoughAZs
 
 export namespace DBSubnetGroupDoesNotCoverEnoughAZs {
   export function isa(o: any): o is DBSubnetGroupDoesNotCoverEnoughAZs {
-    return _smithy.isa(o, "DBSubnetGroupDoesNotCoverEnoughAZs");
+    return __isa(o, "DBSubnetGroupDoesNotCoverEnoughAZs");
   }
 }
 
@@ -331,7 +334,7 @@ export namespace DBSubnetGroupDoesNotCoverEnoughAZs {
  *             <code>DBSubnetGroupName</code> doesn't refer to an existing DB subnet group. </p>
  */
 export interface DBSubnetGroupNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBSubnetGroupNotFoundFault";
   $fault: "client";
@@ -340,7 +343,7 @@ export interface DBSubnetGroupNotFoundFault
 
 export namespace DBSubnetGroupNotFoundFault {
   export function isa(o: any): o is DBSubnetGroupNotFoundFault {
-    return _smithy.isa(o, "DBSubnetGroupNotFoundFault");
+    return __isa(o, "DBSubnetGroupNotFoundFault");
   }
 }
 
@@ -348,7 +351,7 @@ export namespace DBSubnetGroupNotFoundFault {
  * <p>The request would cause you to exceed the allowed number of DB subnet groups.</p>
  */
 export interface DBSubnetGroupQuotaExceededFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBSubnetGroupQuotaExceededFault";
   $fault: "client";
@@ -357,7 +360,7 @@ export interface DBSubnetGroupQuotaExceededFault
 
 export namespace DBSubnetGroupQuotaExceededFault {
   export function isa(o: any): o is DBSubnetGroupQuotaExceededFault {
-    return _smithy.isa(o, "DBSubnetGroupQuotaExceededFault");
+    return __isa(o, "DBSubnetGroupQuotaExceededFault");
   }
 }
 
@@ -366,7 +369,7 @@ export namespace DBSubnetGroupQuotaExceededFault {
  *             group.</p>
  */
 export interface DBSubnetQuotaExceededFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBSubnetQuotaExceededFault";
   $fault: "client";
@@ -375,7 +378,7 @@ export interface DBSubnetQuotaExceededFault
 
 export namespace DBSubnetQuotaExceededFault {
   export function isa(o: any): o is DBSubnetQuotaExceededFault {
-    return _smithy.isa(o, "DBSubnetQuotaExceededFault");
+    return __isa(o, "DBSubnetQuotaExceededFault");
   }
 }
 
@@ -384,7 +387,7 @@ export namespace DBSubnetQuotaExceededFault {
  *             modified.</p>
  */
 export interface DBUpgradeDependencyFailureFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBUpgradeDependencyFailureFault";
   $fault: "client";
@@ -393,7 +396,7 @@ export interface DBUpgradeDependencyFailureFault
 
 export namespace DBUpgradeDependencyFailureFault {
   export function isa(o: any): o is DBUpgradeDependencyFailureFault {
-    return _smithy.isa(o, "DBUpgradeDependencyFailureFault");
+    return __isa(o, "DBUpgradeDependencyFailureFault");
   }
 }
 
@@ -401,7 +404,7 @@ export namespace DBUpgradeDependencyFailureFault {
  * <p>The request would cause you to exceed the allowed number of DB instances.</p>
  */
 export interface InstanceQuotaExceededFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InstanceQuotaExceededFault";
   $fault: "client";
@@ -410,7 +413,7 @@ export interface InstanceQuotaExceededFault
 
 export namespace InstanceQuotaExceededFault {
   export function isa(o: any): o is InstanceQuotaExceededFault {
-    return _smithy.isa(o, "InstanceQuotaExceededFault");
+    return __isa(o, "InstanceQuotaExceededFault");
   }
 }
 
@@ -418,7 +421,7 @@ export namespace InstanceQuotaExceededFault {
  * <p>The DB cluster doesn't have enough capacity for the current operation.</p>
  */
 export interface InsufficientDBClusterCapacityFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InsufficientDBClusterCapacityFault";
   $fault: "client";
@@ -427,7 +430,7 @@ export interface InsufficientDBClusterCapacityFault
 
 export namespace InsufficientDBClusterCapacityFault {
   export function isa(o: any): o is InsufficientDBClusterCapacityFault {
-    return _smithy.isa(o, "InsufficientDBClusterCapacityFault");
+    return __isa(o, "InsufficientDBClusterCapacityFault");
   }
 }
 
@@ -436,7 +439,7 @@ export namespace InsufficientDBClusterCapacityFault {
  *             Zone.</p>
  */
 export interface InsufficientDBInstanceCapacityFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InsufficientDBInstanceCapacityFault";
   $fault: "client";
@@ -445,7 +448,7 @@ export interface InsufficientDBInstanceCapacityFault
 
 export namespace InsufficientDBInstanceCapacityFault {
   export function isa(o: any): o is InsufficientDBInstanceCapacityFault {
-    return _smithy.isa(o, "InsufficientDBInstanceCapacityFault");
+    return __isa(o, "InsufficientDBInstanceCapacityFault");
   }
 }
 
@@ -455,7 +458,7 @@ export namespace InsufficientDBInstanceCapacityFault {
  *             that have more storage available. </p>
  */
 export interface InsufficientStorageClusterCapacityFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InsufficientStorageClusterCapacityFault";
   $fault: "client";
@@ -464,7 +467,7 @@ export interface InsufficientStorageClusterCapacityFault
 
 export namespace InsufficientStorageClusterCapacityFault {
   export function isa(o: any): o is InsufficientStorageClusterCapacityFault {
-    return _smithy.isa(o, "InsufficientStorageClusterCapacityFault");
+    return __isa(o, "InsufficientStorageClusterCapacityFault");
   }
 }
 
@@ -472,7 +475,7 @@ export namespace InsufficientStorageClusterCapacityFault {
  * <p>The provided value isn't a valid DB cluster snapshot state.</p>
  */
 export interface InvalidDBClusterSnapshotStateFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidDBClusterSnapshotStateFault";
   $fault: "client";
@@ -481,7 +484,7 @@ export interface InvalidDBClusterSnapshotStateFault
 
 export namespace InvalidDBClusterSnapshotStateFault {
   export function isa(o: any): o is InvalidDBClusterSnapshotStateFault {
-    return _smithy.isa(o, "InvalidDBClusterSnapshotStateFault");
+    return __isa(o, "InvalidDBClusterSnapshotStateFault");
   }
 }
 
@@ -489,7 +492,7 @@ export namespace InvalidDBClusterSnapshotStateFault {
  * <p>The DB cluster isn't in a valid state.</p>
  */
 export interface InvalidDBClusterStateFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidDBClusterStateFault";
   $fault: "client";
@@ -498,7 +501,7 @@ export interface InvalidDBClusterStateFault
 
 export namespace InvalidDBClusterStateFault {
   export function isa(o: any): o is InvalidDBClusterStateFault {
-    return _smithy.isa(o, "InvalidDBClusterStateFault");
+    return __isa(o, "InvalidDBClusterStateFault");
   }
 }
 
@@ -507,7 +510,7 @@ export namespace InvalidDBClusterStateFault {
  *         </p>
  */
 export interface InvalidDBInstanceStateFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidDBInstanceStateFault";
   $fault: "client";
@@ -516,7 +519,7 @@ export interface InvalidDBInstanceStateFault
 
 export namespace InvalidDBInstanceStateFault {
   export function isa(o: any): o is InvalidDBInstanceStateFault {
-    return _smithy.isa(o, "InvalidDBInstanceStateFault");
+    return __isa(o, "InvalidDBInstanceStateFault");
   }
 }
 
@@ -526,7 +529,7 @@ export namespace InvalidDBInstanceStateFault {
  *             is in this state.</p>
  */
 export interface InvalidDBParameterGroupStateFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidDBParameterGroupStateFault";
   $fault: "client";
@@ -535,7 +538,7 @@ export interface InvalidDBParameterGroupStateFault
 
 export namespace InvalidDBParameterGroupStateFault {
   export function isa(o: any): o is InvalidDBParameterGroupStateFault {
-    return _smithy.isa(o, "InvalidDBParameterGroupStateFault");
+    return __isa(o, "InvalidDBParameterGroupStateFault");
   }
 }
 
@@ -543,7 +546,7 @@ export namespace InvalidDBParameterGroupStateFault {
  * <p>The state of the DB security group doesn't allow deletion.</p>
  */
 export interface InvalidDBSecurityGroupStateFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidDBSecurityGroupStateFault";
   $fault: "client";
@@ -552,7 +555,7 @@ export interface InvalidDBSecurityGroupStateFault
 
 export namespace InvalidDBSecurityGroupStateFault {
   export function isa(o: any): o is InvalidDBSecurityGroupStateFault {
-    return _smithy.isa(o, "InvalidDBSecurityGroupStateFault");
+    return __isa(o, "InvalidDBSecurityGroupStateFault");
   }
 }
 
@@ -560,7 +563,7 @@ export namespace InvalidDBSecurityGroupStateFault {
  * <p>The state of the DB snapshot doesn't allow deletion.</p>
  */
 export interface InvalidDBSnapshotStateFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidDBSnapshotStateFault";
   $fault: "client";
@@ -569,7 +572,7 @@ export interface InvalidDBSnapshotStateFault
 
 export namespace InvalidDBSnapshotStateFault {
   export function isa(o: any): o is InvalidDBSnapshotStateFault {
-    return _smithy.isa(o, "InvalidDBSnapshotStateFault");
+    return __isa(o, "InvalidDBSnapshotStateFault");
   }
 }
 
@@ -577,7 +580,7 @@ export namespace InvalidDBSnapshotStateFault {
  * <p>The DB subnet group can't be deleted because it's in use.</p>
  */
 export interface InvalidDBSubnetGroupStateFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidDBSubnetGroupStateFault";
   $fault: "client";
@@ -586,7 +589,7 @@ export interface InvalidDBSubnetGroupStateFault
 
 export namespace InvalidDBSubnetGroupStateFault {
   export function isa(o: any): o is InvalidDBSubnetGroupStateFault {
-    return _smithy.isa(o, "InvalidDBSubnetGroupStateFault");
+    return __isa(o, "InvalidDBSubnetGroupStateFault");
   }
 }
 
@@ -594,7 +597,7 @@ export namespace InvalidDBSubnetGroupStateFault {
  * <p> The DB subnet isn't in the <i>available</i> state. </p>
  */
 export interface InvalidDBSubnetStateFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidDBSubnetStateFault";
   $fault: "client";
@@ -603,7 +606,7 @@ export interface InvalidDBSubnetStateFault
 
 export namespace InvalidDBSubnetStateFault {
   export function isa(o: any): o is InvalidDBSubnetStateFault {
-    return _smithy.isa(o, "InvalidDBSubnetStateFault");
+    return __isa(o, "InvalidDBSubnetStateFault");
   }
 }
 
@@ -612,7 +615,7 @@ export namespace InvalidDBSubnetStateFault {
  *             instance.</p>
  */
 export interface InvalidRestoreFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidRestoreFault";
   $fault: "client";
@@ -621,7 +624,7 @@ export interface InvalidRestoreFault
 
 export namespace InvalidRestoreFault {
   export function isa(o: any): o is InvalidRestoreFault {
-    return _smithy.isa(o, "InvalidRestoreFault");
+    return __isa(o, "InvalidRestoreFault");
   }
 }
 
@@ -629,9 +632,7 @@ export namespace InvalidRestoreFault {
  * <p>The requested subnet is not valid, or multiple subnets were requested that are not all
  *             in a common virtual private cloud (VPC).</p>
  */
-export interface InvalidSubnet
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface InvalidSubnet extends __SmithyException, $MetadataBearer {
   name: "InvalidSubnet";
   $fault: "client";
   message?: string;
@@ -639,7 +640,7 @@ export interface InvalidSubnet
 
 export namespace InvalidSubnet {
   export function isa(o: any): o is InvalidSubnet {
-    return _smithy.isa(o, "InvalidSubnet");
+    return __isa(o, "InvalidSubnet");
   }
 }
 
@@ -648,7 +649,7 @@ export namespace InvalidSubnet {
  *             because of changes that were made.</p>
  */
 export interface InvalidVPCNetworkStateFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidVPCNetworkStateFault";
   $fault: "client";
@@ -657,7 +658,7 @@ export interface InvalidVPCNetworkStateFault
 
 export namespace InvalidVPCNetworkStateFault {
   export function isa(o: any): o is InvalidVPCNetworkStateFault {
-    return _smithy.isa(o, "InvalidVPCNetworkStateFault");
+    return __isa(o, "InvalidVPCNetworkStateFault");
   }
 }
 
@@ -665,7 +666,7 @@ export namespace InvalidVPCNetworkStateFault {
  * <p>An error occurred when accessing an AWS KMS key.</p>
  */
 export interface KMSKeyNotAccessibleFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "KMSKeyNotAccessibleFault";
   $fault: "client";
@@ -674,7 +675,7 @@ export interface KMSKeyNotAccessibleFault
 
 export namespace KMSKeyNotAccessibleFault {
   export function isa(o: any): o is KMSKeyNotAccessibleFault {
-    return _smithy.isa(o, "KMSKeyNotAccessibleFault");
+    return __isa(o, "KMSKeyNotAccessibleFault");
   }
 }
 
@@ -682,7 +683,7 @@ export namespace KMSKeyNotAccessibleFault {
  * <p>The specified resource ID was not found.</p>
  */
 export interface ResourceNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundFault";
   $fault: "client";
@@ -691,7 +692,7 @@ export interface ResourceNotFoundFault
 
 export namespace ResourceNotFoundFault {
   export function isa(o: any): o is ResourceNotFoundFault {
-    return _smithy.isa(o, "ResourceNotFoundFault");
+    return __isa(o, "ResourceNotFoundFault");
   }
 }
 
@@ -700,7 +701,7 @@ export namespace ResourceNotFoundFault {
  *             snapshot with. </p>
  */
 export interface SharedSnapshotQuotaExceededFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "SharedSnapshotQuotaExceededFault";
   $fault: "client";
@@ -709,7 +710,7 @@ export interface SharedSnapshotQuotaExceededFault
 
 export namespace SharedSnapshotQuotaExceededFault {
   export function isa(o: any): o is SharedSnapshotQuotaExceededFault {
-    return _smithy.isa(o, "SharedSnapshotQuotaExceededFault");
+    return __isa(o, "SharedSnapshotQuotaExceededFault");
   }
 }
 
@@ -717,7 +718,7 @@ export namespace SharedSnapshotQuotaExceededFault {
  * <p>The request would cause you to exceed the allowed number of DB snapshots.</p>
  */
 export interface SnapshotQuotaExceededFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "SnapshotQuotaExceededFault";
   $fault: "client";
@@ -726,7 +727,7 @@ export interface SnapshotQuotaExceededFault
 
 export namespace SnapshotQuotaExceededFault {
   export function isa(o: any): o is SnapshotQuotaExceededFault {
-    return _smithy.isa(o, "SnapshotQuotaExceededFault");
+    return __isa(o, "SnapshotQuotaExceededFault");
   }
 }
 
@@ -735,7 +736,7 @@ export namespace SnapshotQuotaExceededFault {
  *             all DB instances.</p>
  */
 export interface StorageQuotaExceededFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "StorageQuotaExceededFault";
   $fault: "client";
@@ -744,7 +745,7 @@ export interface StorageQuotaExceededFault
 
 export namespace StorageQuotaExceededFault {
   export function isa(o: any): o is StorageQuotaExceededFault {
-    return _smithy.isa(o, "StorageQuotaExceededFault");
+    return __isa(o, "StorageQuotaExceededFault");
   }
 }
 
@@ -753,7 +754,7 @@ export namespace StorageQuotaExceededFault {
  *             instance. </p>
  */
 export interface StorageTypeNotSupportedFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "StorageTypeNotSupportedFault";
   $fault: "client";
@@ -762,16 +763,14 @@ export interface StorageTypeNotSupportedFault
 
 export namespace StorageTypeNotSupportedFault {
   export function isa(o: any): o is StorageTypeNotSupportedFault {
-    return _smithy.isa(o, "StorageTypeNotSupportedFault");
+    return __isa(o, "StorageTypeNotSupportedFault");
   }
 }
 
 /**
  * <p>The DB subnet is already in use in the Availability Zone.</p>
  */
-export interface SubnetAlreadyInUse
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface SubnetAlreadyInUse extends __SmithyException, $MetadataBearer {
   name: "SubnetAlreadyInUse";
   $fault: "client";
   message?: string;
@@ -779,7 +778,7 @@ export interface SubnetAlreadyInUse
 
 export namespace SubnetAlreadyInUse {
   export function isa(o: any): o is SubnetAlreadyInUse {
-    return _smithy.isa(o, "SubnetAlreadyInUse");
+    return __isa(o, "SubnetAlreadyInUse");
   }
 }
 
@@ -802,7 +801,7 @@ export interface AddTagsToResourceMessage {
 
 export namespace AddTagsToResourceMessage {
   export function isa(o: any): o is AddTagsToResourceMessage {
-    return _smithy.isa(o, "AddTagsToResourceMessage");
+    return __isa(o, "AddTagsToResourceMessage");
   }
 }
 
@@ -852,7 +851,7 @@ export interface ApplyPendingMaintenanceActionMessage {
 
 export namespace ApplyPendingMaintenanceActionMessage {
   export function isa(o: any): o is ApplyPendingMaintenanceActionMessage {
-    return _smithy.isa(o, "ApplyPendingMaintenanceActionMessage");
+    return __isa(o, "ApplyPendingMaintenanceActionMessage");
   }
 }
 
@@ -866,7 +865,7 @@ export interface ApplyPendingMaintenanceActionResult extends $MetadataBearer {
 
 export namespace ApplyPendingMaintenanceActionResult {
   export function isa(o: any): o is ApplyPendingMaintenanceActionResult {
-    return _smithy.isa(o, "ApplyPendingMaintenanceActionResult");
+    return __isa(o, "ApplyPendingMaintenanceActionResult");
   }
 }
 
@@ -883,7 +882,7 @@ export interface AvailabilityZone {
 
 export namespace AvailabilityZone {
   export function isa(o: any): o is AvailabilityZone {
-    return _smithy.isa(o, "AvailabilityZone");
+    return __isa(o, "AvailabilityZone");
   }
 }
 
@@ -935,7 +934,7 @@ export interface Certificate {
 
 export namespace Certificate {
   export function isa(o: any): o is Certificate {
-    return _smithy.isa(o, "Certificate");
+    return __isa(o, "Certificate");
   }
 }
 
@@ -957,7 +956,7 @@ export interface CertificateMessage extends $MetadataBearer {
 
 export namespace CertificateMessage {
   export function isa(o: any): o is CertificateMessage {
-    return _smithy.isa(o, "CertificateMessage");
+    return __isa(o, "CertificateMessage");
   }
 }
 
@@ -983,7 +982,7 @@ export interface CloudwatchLogsExportConfiguration {
 
 export namespace CloudwatchLogsExportConfiguration {
   export function isa(o: any): o is CloudwatchLogsExportConfiguration {
-    return _smithy.isa(o, "CloudwatchLogsExportConfiguration");
+    return __isa(o, "CloudwatchLogsExportConfiguration");
   }
 }
 
@@ -1049,7 +1048,7 @@ export interface CopyDBClusterParameterGroupMessage {
 
 export namespace CopyDBClusterParameterGroupMessage {
   export function isa(o: any): o is CopyDBClusterParameterGroupMessage {
-    return _smithy.isa(o, "CopyDBClusterParameterGroupMessage");
+    return __isa(o, "CopyDBClusterParameterGroupMessage");
   }
 }
 
@@ -1063,7 +1062,7 @@ export interface CopyDBClusterParameterGroupResult extends $MetadataBearer {
 
 export namespace CopyDBClusterParameterGroupResult {
   export function isa(o: any): o is CopyDBClusterParameterGroupResult {
-    return _smithy.isa(o, "CopyDBClusterParameterGroupResult");
+    return __isa(o, "CopyDBClusterParameterGroupResult");
   }
 }
 
@@ -1188,7 +1187,7 @@ export interface CopyDBClusterSnapshotMessage {
 
 export namespace CopyDBClusterSnapshotMessage {
   export function isa(o: any): o is CopyDBClusterSnapshotMessage {
-    return _smithy.isa(o, "CopyDBClusterSnapshotMessage");
+    return __isa(o, "CopyDBClusterSnapshotMessage");
   }
 }
 
@@ -1202,7 +1201,7 @@ export interface CopyDBClusterSnapshotResult extends $MetadataBearer {
 
 export namespace CopyDBClusterSnapshotResult {
   export function isa(o: any): o is CopyDBClusterSnapshotResult {
-    return _smithy.isa(o, "CopyDBClusterSnapshotResult");
+    return __isa(o, "CopyDBClusterSnapshotResult");
   }
 }
 
@@ -1399,7 +1398,7 @@ export interface CreateDBClusterMessage {
 
 export namespace CreateDBClusterMessage {
   export function isa(o: any): o is CreateDBClusterMessage {
-    return _smithy.isa(o, "CreateDBClusterMessage");
+    return __isa(o, "CreateDBClusterMessage");
   }
 }
 
@@ -1441,7 +1440,7 @@ export interface CreateDBClusterParameterGroupMessage {
 
 export namespace CreateDBClusterParameterGroupMessage {
   export function isa(o: any): o is CreateDBClusterParameterGroupMessage {
-    return _smithy.isa(o, "CreateDBClusterParameterGroupMessage");
+    return __isa(o, "CreateDBClusterParameterGroupMessage");
   }
 }
 
@@ -1455,7 +1454,7 @@ export interface CreateDBClusterParameterGroupResult extends $MetadataBearer {
 
 export namespace CreateDBClusterParameterGroupResult {
   export function isa(o: any): o is CreateDBClusterParameterGroupResult {
-    return _smithy.isa(o, "CreateDBClusterParameterGroupResult");
+    return __isa(o, "CreateDBClusterParameterGroupResult");
   }
 }
 
@@ -1469,7 +1468,7 @@ export interface CreateDBClusterResult extends $MetadataBearer {
 
 export namespace CreateDBClusterResult {
   export function isa(o: any): o is CreateDBClusterResult {
-    return _smithy.isa(o, "CreateDBClusterResult");
+    return __isa(o, "CreateDBClusterResult");
   }
 }
 
@@ -1520,7 +1519,7 @@ export interface CreateDBClusterSnapshotMessage {
 
 export namespace CreateDBClusterSnapshotMessage {
   export function isa(o: any): o is CreateDBClusterSnapshotMessage {
-    return _smithy.isa(o, "CreateDBClusterSnapshotMessage");
+    return __isa(o, "CreateDBClusterSnapshotMessage");
   }
 }
 
@@ -1534,7 +1533,7 @@ export interface CreateDBClusterSnapshotResult extends $MetadataBearer {
 
 export namespace CreateDBClusterSnapshotResult {
   export function isa(o: any): o is CreateDBClusterSnapshotResult {
-    return _smithy.isa(o, "CreateDBClusterSnapshotResult");
+    return __isa(o, "CreateDBClusterSnapshotResult");
   }
 }
 
@@ -1629,7 +1628,7 @@ export interface CreateDBInstanceMessage {
 
 export namespace CreateDBInstanceMessage {
   export function isa(o: any): o is CreateDBInstanceMessage {
-    return _smithy.isa(o, "CreateDBInstanceMessage");
+    return __isa(o, "CreateDBInstanceMessage");
   }
 }
 
@@ -1643,7 +1642,7 @@ export interface CreateDBInstanceResult extends $MetadataBearer {
 
 export namespace CreateDBInstanceResult {
   export function isa(o: any): o is CreateDBInstanceResult {
-    return _smithy.isa(o, "CreateDBInstanceResult");
+    return __isa(o, "CreateDBInstanceResult");
   }
 }
 
@@ -1679,7 +1678,7 @@ export interface CreateDBSubnetGroupMessage {
 
 export namespace CreateDBSubnetGroupMessage {
   export function isa(o: any): o is CreateDBSubnetGroupMessage {
-    return _smithy.isa(o, "CreateDBSubnetGroupMessage");
+    return __isa(o, "CreateDBSubnetGroupMessage");
   }
 }
 
@@ -1693,7 +1692,7 @@ export interface CreateDBSubnetGroupResult extends $MetadataBearer {
 
 export namespace CreateDBSubnetGroupResult {
   export function isa(o: any): o is CreateDBSubnetGroupResult {
-    return _smithy.isa(o, "CreateDBSubnetGroupResult");
+    return __isa(o, "CreateDBSubnetGroupResult");
   }
 }
 
@@ -1876,7 +1875,7 @@ export interface DBCluster {
 
 export namespace DBCluster {
   export function isa(o: any): o is DBCluster {
-    return _smithy.isa(o, "DBCluster");
+    return __isa(o, "DBCluster");
   }
 }
 
@@ -1911,7 +1910,7 @@ export interface DBClusterMember {
 
 export namespace DBClusterMember {
   export function isa(o: any): o is DBClusterMember {
-    return _smithy.isa(o, "DBClusterMember");
+    return __isa(o, "DBClusterMember");
   }
 }
 
@@ -1935,7 +1934,7 @@ export interface DBClusterMessage extends $MetadataBearer {
 
 export namespace DBClusterMessage {
   export function isa(o: any): o is DBClusterMessage {
-    return _smithy.isa(o, "DBClusterMessage");
+    return __isa(o, "DBClusterMessage");
   }
 }
 
@@ -1969,7 +1968,7 @@ export interface DBClusterParameterGroup {
 
 export namespace DBClusterParameterGroup {
   export function isa(o: any): o is DBClusterParameterGroup {
-    return _smithy.isa(o, "DBClusterParameterGroup");
+    return __isa(o, "DBClusterParameterGroup");
   }
 }
 
@@ -1993,7 +1992,7 @@ export interface DBClusterParameterGroupDetails extends $MetadataBearer {
 
 export namespace DBClusterParameterGroupDetails {
   export function isa(o: any): o is DBClusterParameterGroupDetails {
-    return _smithy.isa(o, "DBClusterParameterGroupDetails");
+    return __isa(o, "DBClusterParameterGroupDetails");
   }
 }
 
@@ -2025,7 +2024,7 @@ export interface DBClusterParameterGroupNameMessage extends $MetadataBearer {
 
 export namespace DBClusterParameterGroupNameMessage {
   export function isa(o: any): o is DBClusterParameterGroupNameMessage {
-    return _smithy.isa(o, "DBClusterParameterGroupNameMessage");
+    return __isa(o, "DBClusterParameterGroupNameMessage");
   }
 }
 
@@ -2049,7 +2048,7 @@ export interface DBClusterParameterGroupsMessage extends $MetadataBearer {
 
 export namespace DBClusterParameterGroupsMessage {
   export function isa(o: any): o is DBClusterParameterGroupsMessage {
-    return _smithy.isa(o, "DBClusterParameterGroupsMessage");
+    return __isa(o, "DBClusterParameterGroupsMessage");
   }
 }
 
@@ -2092,7 +2091,7 @@ export interface DBClusterRole {
 
 export namespace DBClusterRole {
   export function isa(o: any): o is DBClusterRole {
-    return _smithy.isa(o, "DBClusterRole");
+    return __isa(o, "DBClusterRole");
   }
 }
 
@@ -2196,7 +2195,7 @@ export interface DBClusterSnapshot {
 
 export namespace DBClusterSnapshot {
   export function isa(o: any): o is DBClusterSnapshot {
-    return _smithy.isa(o, "DBClusterSnapshot");
+    return __isa(o, "DBClusterSnapshot");
   }
 }
 
@@ -2227,7 +2226,7 @@ export interface DBClusterSnapshotAttribute {
 
 export namespace DBClusterSnapshotAttribute {
   export function isa(o: any): o is DBClusterSnapshotAttribute {
-    return _smithy.isa(o, "DBClusterSnapshotAttribute");
+    return __isa(o, "DBClusterSnapshotAttribute");
   }
 }
 
@@ -2250,7 +2249,7 @@ export interface DBClusterSnapshotAttributesResult {
 
 export namespace DBClusterSnapshotAttributesResult {
   export function isa(o: any): o is DBClusterSnapshotAttributesResult {
-    return _smithy.isa(o, "DBClusterSnapshotAttributesResult");
+    return __isa(o, "DBClusterSnapshotAttributesResult");
   }
 }
 
@@ -2274,7 +2273,7 @@ export interface DBClusterSnapshotMessage extends $MetadataBearer {
 
 export namespace DBClusterSnapshotMessage {
   export function isa(o: any): o is DBClusterSnapshotMessage {
-    return _smithy.isa(o, "DBClusterSnapshotMessage");
+    return __isa(o, "DBClusterSnapshotMessage");
   }
 }
 
@@ -2328,7 +2327,7 @@ export interface DBEngineVersion {
 
 export namespace DBEngineVersion {
   export function isa(o: any): o is DBEngineVersion {
-    return _smithy.isa(o, "DBEngineVersion");
+    return __isa(o, "DBEngineVersion");
   }
 }
 
@@ -2352,7 +2351,7 @@ export interface DBEngineVersionMessage extends $MetadataBearer {
 
 export namespace DBEngineVersionMessage {
   export function isa(o: any): o is DBEngineVersionMessage {
-    return _smithy.isa(o, "DBEngineVersionMessage");
+    return __isa(o, "DBEngineVersionMessage");
   }
 }
 
@@ -2509,7 +2508,7 @@ export interface DBInstance {
 
 export namespace DBInstance {
   export function isa(o: any): o is DBInstance {
-    return _smithy.isa(o, "DBInstance");
+    return __isa(o, "DBInstance");
   }
 }
 
@@ -2533,7 +2532,7 @@ export interface DBInstanceMessage extends $MetadataBearer {
 
 export namespace DBInstanceMessage {
   export function isa(o: any): o is DBInstanceMessage {
-    return _smithy.isa(o, "DBInstanceMessage");
+    return __isa(o, "DBInstanceMessage");
   }
 }
 
@@ -2569,7 +2568,7 @@ export interface DBInstanceStatusInfo {
 
 export namespace DBInstanceStatusInfo {
   export function isa(o: any): o is DBInstanceStatusInfo {
-    return _smithy.isa(o, "DBInstanceStatusInfo");
+    return __isa(o, "DBInstanceStatusInfo");
   }
 }
 
@@ -2611,7 +2610,7 @@ export interface DBSubnetGroup {
 
 export namespace DBSubnetGroup {
   export function isa(o: any): o is DBSubnetGroup {
-    return _smithy.isa(o, "DBSubnetGroup");
+    return __isa(o, "DBSubnetGroup");
   }
 }
 
@@ -2635,7 +2634,7 @@ export interface DBSubnetGroupMessage extends $MetadataBearer {
 
 export namespace DBSubnetGroupMessage {
   export function isa(o: any): o is DBSubnetGroupMessage {
-    return _smithy.isa(o, "DBSubnetGroupMessage");
+    return __isa(o, "DBSubnetGroupMessage");
   }
 }
 
@@ -2695,7 +2694,7 @@ export interface DeleteDBClusterMessage {
 
 export namespace DeleteDBClusterMessage {
   export function isa(o: any): o is DeleteDBClusterMessage {
-    return _smithy.isa(o, "DeleteDBClusterMessage");
+    return __isa(o, "DeleteDBClusterMessage");
   }
 }
 
@@ -2724,7 +2723,7 @@ export interface DeleteDBClusterParameterGroupMessage {
 
 export namespace DeleteDBClusterParameterGroupMessage {
   export function isa(o: any): o is DeleteDBClusterParameterGroupMessage {
-    return _smithy.isa(o, "DeleteDBClusterParameterGroupMessage");
+    return __isa(o, "DeleteDBClusterParameterGroupMessage");
   }
 }
 
@@ -2738,7 +2737,7 @@ export interface DeleteDBClusterResult extends $MetadataBearer {
 
 export namespace DeleteDBClusterResult {
   export function isa(o: any): o is DeleteDBClusterResult {
-    return _smithy.isa(o, "DeleteDBClusterResult");
+    return __isa(o, "DeleteDBClusterResult");
   }
 }
 
@@ -2757,7 +2756,7 @@ export interface DeleteDBClusterSnapshotMessage {
 
 export namespace DeleteDBClusterSnapshotMessage {
   export function isa(o: any): o is DeleteDBClusterSnapshotMessage {
-    return _smithy.isa(o, "DeleteDBClusterSnapshotMessage");
+    return __isa(o, "DeleteDBClusterSnapshotMessage");
   }
 }
 
@@ -2771,7 +2770,7 @@ export interface DeleteDBClusterSnapshotResult extends $MetadataBearer {
 
 export namespace DeleteDBClusterSnapshotResult {
   export function isa(o: any): o is DeleteDBClusterSnapshotResult {
-    return _smithy.isa(o, "DeleteDBClusterSnapshotResult");
+    return __isa(o, "DeleteDBClusterSnapshotResult");
   }
 }
 
@@ -2795,7 +2794,7 @@ export interface DeleteDBInstanceMessage {
 
 export namespace DeleteDBInstanceMessage {
   export function isa(o: any): o is DeleteDBInstanceMessage {
-    return _smithy.isa(o, "DeleteDBInstanceMessage");
+    return __isa(o, "DeleteDBInstanceMessage");
   }
 }
 
@@ -2809,7 +2808,7 @@ export interface DeleteDBInstanceResult extends $MetadataBearer {
 
 export namespace DeleteDBInstanceResult {
   export function isa(o: any): o is DeleteDBInstanceResult {
-    return _smithy.isa(o, "DeleteDBInstanceResult");
+    return __isa(o, "DeleteDBInstanceResult");
   }
 }
 
@@ -2834,7 +2833,7 @@ export interface DeleteDBSubnetGroupMessage {
 
 export namespace DeleteDBSubnetGroupMessage {
   export function isa(o: any): o is DeleteDBSubnetGroupMessage {
-    return _smithy.isa(o, "DeleteDBSubnetGroupMessage");
+    return __isa(o, "DeleteDBSubnetGroupMessage");
   }
 }
 
@@ -2887,7 +2886,7 @@ export interface DescribeCertificatesMessage {
 
 export namespace DescribeCertificatesMessage {
   export function isa(o: any): o is DescribeCertificatesMessage {
-    return _smithy.isa(o, "DescribeCertificatesMessage");
+    return __isa(o, "DescribeCertificatesMessage");
   }
 }
 
@@ -2932,7 +2931,7 @@ export interface DescribeDBClusterParameterGroupsMessage {
 
 export namespace DescribeDBClusterParameterGroupsMessage {
   export function isa(o: any): o is DescribeDBClusterParameterGroupsMessage {
-    return _smithy.isa(o, "DescribeDBClusterParameterGroupsMessage");
+    return __isa(o, "DescribeDBClusterParameterGroupsMessage");
   }
 }
 
@@ -2985,7 +2984,7 @@ export interface DescribeDBClusterParametersMessage {
 
 export namespace DescribeDBClusterParametersMessage {
   export function isa(o: any): o is DescribeDBClusterParametersMessage {
-    return _smithy.isa(o, "DescribeDBClusterParametersMessage");
+    return __isa(o, "DescribeDBClusterParametersMessage");
   }
 }
 
@@ -3002,7 +3001,7 @@ export interface DescribeDBClusterSnapshotAttributesMessage {
 
 export namespace DescribeDBClusterSnapshotAttributesMessage {
   export function isa(o: any): o is DescribeDBClusterSnapshotAttributesMessage {
-    return _smithy.isa(o, "DescribeDBClusterSnapshotAttributesMessage");
+    return __isa(o, "DescribeDBClusterSnapshotAttributesMessage");
   }
 }
 
@@ -3018,7 +3017,7 @@ export interface DescribeDBClusterSnapshotAttributesResult
 
 export namespace DescribeDBClusterSnapshotAttributesResult {
   export function isa(o: any): o is DescribeDBClusterSnapshotAttributesResult {
-    return _smithy.isa(o, "DescribeDBClusterSnapshotAttributesResult");
+    return __isa(o, "DescribeDBClusterSnapshotAttributesResult");
   }
 }
 
@@ -3135,7 +3134,7 @@ export interface DescribeDBClusterSnapshotsMessage {
 
 export namespace DescribeDBClusterSnapshotsMessage {
   export function isa(o: any): o is DescribeDBClusterSnapshotsMessage {
-    return _smithy.isa(o, "DescribeDBClusterSnapshotsMessage");
+    return __isa(o, "DescribeDBClusterSnapshotsMessage");
   }
 }
 
@@ -3190,7 +3189,7 @@ export interface DescribeDBClustersMessage {
 
 export namespace DescribeDBClustersMessage {
   export function isa(o: any): o is DescribeDBClustersMessage {
-    return _smithy.isa(o, "DescribeDBClustersMessage");
+    return __isa(o, "DescribeDBClustersMessage");
   }
 }
 
@@ -3267,7 +3266,7 @@ export interface DescribeDBEngineVersionsMessage {
 
 export namespace DescribeDBEngineVersionsMessage {
   export function isa(o: any): o is DescribeDBEngineVersionsMessage {
-    return _smithy.isa(o, "DescribeDBEngineVersionsMessage");
+    return __isa(o, "DescribeDBEngineVersionsMessage");
   }
 }
 
@@ -3330,7 +3329,7 @@ export interface DescribeDBInstancesMessage {
 
 export namespace DescribeDBInstancesMessage {
   export function isa(o: any): o is DescribeDBInstancesMessage {
-    return _smithy.isa(o, "DescribeDBInstancesMessage");
+    return __isa(o, "DescribeDBInstancesMessage");
   }
 }
 
@@ -3368,7 +3367,7 @@ export interface DescribeDBSubnetGroupsMessage {
 
 export namespace DescribeDBSubnetGroupsMessage {
   export function isa(o: any): o is DescribeDBSubnetGroupsMessage {
-    return _smithy.isa(o, "DescribeDBSubnetGroupsMessage");
+    return __isa(o, "DescribeDBSubnetGroupsMessage");
   }
 }
 
@@ -3409,7 +3408,7 @@ export namespace DescribeEngineDefaultClusterParametersMessage {
   export function isa(
     o: any
   ): o is DescribeEngineDefaultClusterParametersMessage {
-    return _smithy.isa(o, "DescribeEngineDefaultClusterParametersMessage");
+    return __isa(o, "DescribeEngineDefaultClusterParametersMessage");
   }
 }
 
@@ -3427,7 +3426,7 @@ export namespace DescribeEngineDefaultClusterParametersResult {
   export function isa(
     o: any
   ): o is DescribeEngineDefaultClusterParametersResult {
-    return _smithy.isa(o, "DescribeEngineDefaultClusterParametersResult");
+    return __isa(o, "DescribeEngineDefaultClusterParametersResult");
   }
 }
 
@@ -3452,7 +3451,7 @@ export interface DescribeEventCategoriesMessage {
 
 export namespace DescribeEventCategoriesMessage {
   export function isa(o: any): o is DescribeEventCategoriesMessage {
-    return _smithy.isa(o, "DescribeEventCategoriesMessage");
+    return __isa(o, "DescribeEventCategoriesMessage");
   }
 }
 
@@ -3549,7 +3548,7 @@ export interface DescribeEventsMessage {
 
 export namespace DescribeEventsMessage {
   export function isa(o: any): o is DescribeEventsMessage {
-    return _smithy.isa(o, "DescribeEventsMessage");
+    return __isa(o, "DescribeEventsMessage");
   }
 }
 
@@ -3611,7 +3610,7 @@ export interface DescribeOrderableDBInstanceOptionsMessage {
 
 export namespace DescribeOrderableDBInstanceOptionsMessage {
   export function isa(o: any): o is DescribeOrderableDBInstanceOptionsMessage {
-    return _smithy.isa(o, "DescribeOrderableDBInstanceOptionsMessage");
+    return __isa(o, "DescribeOrderableDBInstanceOptionsMessage");
   }
 }
 
@@ -3665,7 +3664,7 @@ export interface DescribePendingMaintenanceActionsMessage {
 
 export namespace DescribePendingMaintenanceActionsMessage {
   export function isa(o: any): o is DescribePendingMaintenanceActionsMessage {
-    return _smithy.isa(o, "DescribePendingMaintenanceActionsMessage");
+    return __isa(o, "DescribePendingMaintenanceActionsMessage");
   }
 }
 
@@ -3693,7 +3692,7 @@ export interface Endpoint {
 
 export namespace Endpoint {
   export function isa(o: any): o is Endpoint {
-    return _smithy.isa(o, "Endpoint");
+    return __isa(o, "Endpoint");
   }
 }
 
@@ -3724,7 +3723,7 @@ export interface EngineDefaults {
 
 export namespace EngineDefaults {
   export function isa(o: any): o is EngineDefaults {
-    return _smithy.isa(o, "EngineDefaults");
+    return __isa(o, "EngineDefaults");
   }
 }
 
@@ -3766,7 +3765,7 @@ export interface Event {
 
 export namespace Event {
   export function isa(o: any): o is Event {
-    return _smithy.isa(o, "Event");
+    return __isa(o, "Event");
   }
 }
 
@@ -3788,7 +3787,7 @@ export interface EventCategoriesMap {
 
 export namespace EventCategoriesMap {
   export function isa(o: any): o is EventCategoriesMap {
-    return _smithy.isa(o, "EventCategoriesMap");
+    return __isa(o, "EventCategoriesMap");
   }
 }
 
@@ -3805,7 +3804,7 @@ export interface EventCategoriesMessage extends $MetadataBearer {
 
 export namespace EventCategoriesMessage {
   export function isa(o: any): o is EventCategoriesMessage {
-    return _smithy.isa(o, "EventCategoriesMessage");
+    return __isa(o, "EventCategoriesMessage");
   }
 }
 
@@ -3829,7 +3828,7 @@ export interface EventsMessage extends $MetadataBearer {
 
 export namespace EventsMessage {
   export function isa(o: any): o is EventsMessage {
-    return _smithy.isa(o, "EventsMessage");
+    return __isa(o, "EventsMessage");
   }
 }
 
@@ -3860,7 +3859,7 @@ export interface FailoverDBClusterMessage {
 
 export namespace FailoverDBClusterMessage {
   export function isa(o: any): o is FailoverDBClusterMessage {
-    return _smithy.isa(o, "FailoverDBClusterMessage");
+    return __isa(o, "FailoverDBClusterMessage");
   }
 }
 
@@ -3874,7 +3873,7 @@ export interface FailoverDBClusterResult extends $MetadataBearer {
 
 export namespace FailoverDBClusterResult {
   export function isa(o: any): o is FailoverDBClusterResult {
-    return _smithy.isa(o, "FailoverDBClusterResult");
+    return __isa(o, "FailoverDBClusterResult");
   }
 }
 
@@ -3898,7 +3897,7 @@ export interface Filter {
 
 export namespace Filter {
   export function isa(o: any): o is Filter {
-    return _smithy.isa(o, "Filter");
+    return __isa(o, "Filter");
   }
 }
 
@@ -3921,7 +3920,7 @@ export interface ListTagsForResourceMessage {
 
 export namespace ListTagsForResourceMessage {
   export function isa(o: any): o is ListTagsForResourceMessage {
-    return _smithy.isa(o, "ListTagsForResourceMessage");
+    return __isa(o, "ListTagsForResourceMessage");
   }
 }
 
@@ -4079,7 +4078,7 @@ export interface ModifyDBClusterMessage {
 
 export namespace ModifyDBClusterMessage {
   export function isa(o: any): o is ModifyDBClusterMessage {
-    return _smithy.isa(o, "ModifyDBClusterMessage");
+    return __isa(o, "ModifyDBClusterMessage");
   }
 }
 
@@ -4101,7 +4100,7 @@ export interface ModifyDBClusterParameterGroupMessage {
 
 export namespace ModifyDBClusterParameterGroupMessage {
   export function isa(o: any): o is ModifyDBClusterParameterGroupMessage {
-    return _smithy.isa(o, "ModifyDBClusterParameterGroupMessage");
+    return __isa(o, "ModifyDBClusterParameterGroupMessage");
   }
 }
 
@@ -4115,7 +4114,7 @@ export interface ModifyDBClusterResult extends $MetadataBearer {
 
 export namespace ModifyDBClusterResult {
   export function isa(o: any): o is ModifyDBClusterResult {
-    return _smithy.isa(o, "ModifyDBClusterResult");
+    return __isa(o, "ModifyDBClusterResult");
   }
 }
 
@@ -4162,7 +4161,7 @@ export interface ModifyDBClusterSnapshotAttributeMessage {
 
 export namespace ModifyDBClusterSnapshotAttributeMessage {
   export function isa(o: any): o is ModifyDBClusterSnapshotAttributeMessage {
-    return _smithy.isa(o, "ModifyDBClusterSnapshotAttributeMessage");
+    return __isa(o, "ModifyDBClusterSnapshotAttributeMessage");
   }
 }
 
@@ -4178,7 +4177,7 @@ export interface ModifyDBClusterSnapshotAttributeResult
 
 export namespace ModifyDBClusterSnapshotAttributeResult {
   export function isa(o: any): o is ModifyDBClusterSnapshotAttributeResult {
-    return _smithy.isa(o, "ModifyDBClusterSnapshotAttributeResult");
+    return __isa(o, "ModifyDBClusterSnapshotAttributeResult");
   }
 }
 
@@ -4287,7 +4286,7 @@ export interface ModifyDBInstanceMessage {
 
 export namespace ModifyDBInstanceMessage {
   export function isa(o: any): o is ModifyDBInstanceMessage {
-    return _smithy.isa(o, "ModifyDBInstanceMessage");
+    return __isa(o, "ModifyDBInstanceMessage");
   }
 }
 
@@ -4301,7 +4300,7 @@ export interface ModifyDBInstanceResult extends $MetadataBearer {
 
 export namespace ModifyDBInstanceResult {
   export function isa(o: any): o is ModifyDBInstanceResult {
-    return _smithy.isa(o, "ModifyDBInstanceResult");
+    return __isa(o, "ModifyDBInstanceResult");
   }
 }
 
@@ -4333,7 +4332,7 @@ export interface ModifyDBSubnetGroupMessage {
 
 export namespace ModifyDBSubnetGroupMessage {
   export function isa(o: any): o is ModifyDBSubnetGroupMessage {
-    return _smithy.isa(o, "ModifyDBSubnetGroupMessage");
+    return __isa(o, "ModifyDBSubnetGroupMessage");
   }
 }
 
@@ -4347,7 +4346,7 @@ export interface ModifyDBSubnetGroupResult extends $MetadataBearer {
 
 export namespace ModifyDBSubnetGroupResult {
   export function isa(o: any): o is ModifyDBSubnetGroupResult {
-    return _smithy.isa(o, "ModifyDBSubnetGroupResult");
+    return __isa(o, "ModifyDBSubnetGroupResult");
   }
 }
 
@@ -4389,7 +4388,7 @@ export interface OrderableDBInstanceOption {
 
 export namespace OrderableDBInstanceOption {
   export function isa(o: any): o is OrderableDBInstanceOption {
-    return _smithy.isa(o, "OrderableDBInstanceOption");
+    return __isa(o, "OrderableDBInstanceOption");
   }
 }
 
@@ -4413,7 +4412,7 @@ export interface OrderableDBInstanceOptionsMessage extends $MetadataBearer {
 
 export namespace OrderableDBInstanceOptionsMessage {
   export function isa(o: any): o is OrderableDBInstanceOptionsMessage {
-    return _smithy.isa(o, "OrderableDBInstanceOptionsMessage");
+    return __isa(o, "OrderableDBInstanceOptionsMessage");
   }
 }
 
@@ -4477,7 +4476,7 @@ export interface Parameter {
 
 export namespace Parameter {
   export function isa(o: any): o is Parameter {
-    return _smithy.isa(o, "Parameter");
+    return __isa(o, "Parameter");
   }
 }
 
@@ -4502,7 +4501,7 @@ export interface PendingCloudwatchLogsExports {
 
 export namespace PendingCloudwatchLogsExports {
   export function isa(o: any): o is PendingCloudwatchLogsExports {
-    return _smithy.isa(o, "PendingCloudwatchLogsExports");
+    return __isa(o, "PendingCloudwatchLogsExports");
   }
 }
 
@@ -4550,7 +4549,7 @@ export interface PendingMaintenanceAction {
 
 export namespace PendingMaintenanceAction {
   export function isa(o: any): o is PendingMaintenanceAction {
-    return _smithy.isa(o, "PendingMaintenanceAction");
+    return __isa(o, "PendingMaintenanceAction");
   }
 }
 
@@ -4574,7 +4573,7 @@ export interface PendingMaintenanceActionsMessage extends $MetadataBearer {
 
 export namespace PendingMaintenanceActionsMessage {
   export function isa(o: any): o is PendingMaintenanceActionsMessage {
-    return _smithy.isa(o, "PendingMaintenanceActionsMessage");
+    return __isa(o, "PendingMaintenanceActionsMessage");
   }
 }
 
@@ -4667,7 +4666,7 @@ export interface PendingModifiedValues {
 
 export namespace PendingModifiedValues {
   export function isa(o: any): o is PendingModifiedValues {
-    return _smithy.isa(o, "PendingModifiedValues");
+    return __isa(o, "PendingModifiedValues");
   }
 }
 
@@ -4697,7 +4696,7 @@ export interface RebootDBInstanceMessage {
 
 export namespace RebootDBInstanceMessage {
   export function isa(o: any): o is RebootDBInstanceMessage {
-    return _smithy.isa(o, "RebootDBInstanceMessage");
+    return __isa(o, "RebootDBInstanceMessage");
   }
 }
 
@@ -4711,7 +4710,7 @@ export interface RebootDBInstanceResult extends $MetadataBearer {
 
 export namespace RebootDBInstanceResult {
   export function isa(o: any): o is RebootDBInstanceResult {
-    return _smithy.isa(o, "RebootDBInstanceResult");
+    return __isa(o, "RebootDBInstanceResult");
   }
 }
 
@@ -4734,7 +4733,7 @@ export interface RemoveTagsFromResourceMessage {
 
 export namespace RemoveTagsFromResourceMessage {
   export function isa(o: any): o is RemoveTagsFromResourceMessage {
-    return _smithy.isa(o, "RemoveTagsFromResourceMessage");
+    return __isa(o, "RemoveTagsFromResourceMessage");
   }
 }
 
@@ -4766,7 +4765,7 @@ export interface ResetDBClusterParameterGroupMessage {
 
 export namespace ResetDBClusterParameterGroupMessage {
   export function isa(o: any): o is ResetDBClusterParameterGroupMessage {
-    return _smithy.isa(o, "ResetDBClusterParameterGroupMessage");
+    return __isa(o, "ResetDBClusterParameterGroupMessage");
   }
 }
 
@@ -4790,7 +4789,7 @@ export interface ResourcePendingMaintenanceActions {
 
 export namespace ResourcePendingMaintenanceActions {
   export function isa(o: any): o is ResourcePendingMaintenanceActions {
-    return _smithy.isa(o, "ResourcePendingMaintenanceActions");
+    return __isa(o, "ResourcePendingMaintenanceActions");
   }
 }
 
@@ -4918,7 +4917,7 @@ export interface RestoreDBClusterFromSnapshotMessage {
 
 export namespace RestoreDBClusterFromSnapshotMessage {
   export function isa(o: any): o is RestoreDBClusterFromSnapshotMessage {
-    return _smithy.isa(o, "RestoreDBClusterFromSnapshotMessage");
+    return __isa(o, "RestoreDBClusterFromSnapshotMessage");
   }
 }
 
@@ -4932,7 +4931,7 @@ export interface RestoreDBClusterFromSnapshotResult extends $MetadataBearer {
 
 export namespace RestoreDBClusterFromSnapshotResult {
   export function isa(o: any): o is RestoreDBClusterFromSnapshotResult {
-    return _smithy.isa(o, "RestoreDBClusterFromSnapshotResult");
+    return __isa(o, "RestoreDBClusterFromSnapshotResult");
   }
 }
 
@@ -5076,7 +5075,7 @@ export interface RestoreDBClusterToPointInTimeMessage {
 
 export namespace RestoreDBClusterToPointInTimeMessage {
   export function isa(o: any): o is RestoreDBClusterToPointInTimeMessage {
-    return _smithy.isa(o, "RestoreDBClusterToPointInTimeMessage");
+    return __isa(o, "RestoreDBClusterToPointInTimeMessage");
   }
 }
 
@@ -5090,7 +5089,7 @@ export interface RestoreDBClusterToPointInTimeResult extends $MetadataBearer {
 
 export namespace RestoreDBClusterToPointInTimeResult {
   export function isa(o: any): o is RestoreDBClusterToPointInTimeResult {
-    return _smithy.isa(o, "RestoreDBClusterToPointInTimeResult");
+    return __isa(o, "RestoreDBClusterToPointInTimeResult");
   }
 }
 
@@ -5114,7 +5113,7 @@ export interface StartDBClusterMessage {
 
 export namespace StartDBClusterMessage {
   export function isa(o: any): o is StartDBClusterMessage {
-    return _smithy.isa(o, "StartDBClusterMessage");
+    return __isa(o, "StartDBClusterMessage");
   }
 }
 
@@ -5128,7 +5127,7 @@ export interface StartDBClusterResult extends $MetadataBearer {
 
 export namespace StartDBClusterResult {
   export function isa(o: any): o is StartDBClusterResult {
-    return _smithy.isa(o, "StartDBClusterResult");
+    return __isa(o, "StartDBClusterResult");
   }
 }
 
@@ -5144,7 +5143,7 @@ export interface StopDBClusterMessage {
 
 export namespace StopDBClusterMessage {
   export function isa(o: any): o is StopDBClusterMessage {
-    return _smithy.isa(o, "StopDBClusterMessage");
+    return __isa(o, "StopDBClusterMessage");
   }
 }
 
@@ -5158,7 +5157,7 @@ export interface StopDBClusterResult extends $MetadataBearer {
 
 export namespace StopDBClusterResult {
   export function isa(o: any): o is StopDBClusterResult {
-    return _smithy.isa(o, "StopDBClusterResult");
+    return __isa(o, "StopDBClusterResult");
   }
 }
 
@@ -5185,7 +5184,7 @@ export interface Subnet {
 
 export namespace Subnet {
   export function isa(o: any): o is Subnet {
-    return _smithy.isa(o, "Subnet");
+    return __isa(o, "Subnet");
   }
 }
 
@@ -5213,7 +5212,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -5230,7 +5229,7 @@ export interface TagListMessage extends $MetadataBearer {
 
 export namespace TagListMessage {
   export function isa(o: any): o is TagListMessage {
-    return _smithy.isa(o, "TagListMessage");
+    return __isa(o, "TagListMessage");
   }
 }
 
@@ -5270,7 +5269,7 @@ export interface UpgradeTarget {
 
 export namespace UpgradeTarget {
   export function isa(o: any): o is UpgradeTarget {
-    return _smithy.isa(o, "UpgradeTarget");
+    return __isa(o, "UpgradeTarget");
   }
 }
 
@@ -5293,6 +5292,6 @@ export interface VpcSecurityGroupMembership {
 
 export namespace VpcSecurityGroupMembership {
   export function isa(o: any): o is VpcSecurityGroupMembership {
-    return _smithy.isa(o, "VpcSecurityGroupMembership");
+    return __isa(o, "VpcSecurityGroupMembership");
   }
 }

--- a/clients/client-docdb/protocols/Aws_query.ts
+++ b/clients/client-docdb/protocols/Aws_query.ts
@@ -1085,6 +1085,7 @@ export async function deserializeAws_queryAddTagsToResourceCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_queryAddTagsToResourceCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: AddTagsToResourceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2039,6 +2040,7 @@ export async function deserializeAws_queryDeleteDBClusterParameterGroupCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteDBClusterParameterGroupCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2250,6 +2252,7 @@ export async function deserializeAws_queryDeleteDBSubnetGroupCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_queryDeleteDBSubnetGroupCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteDBSubnetGroupCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -3835,6 +3838,7 @@ export async function deserializeAws_queryRemoveTagsFromResourceCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: RemoveTagsFromResourceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };

--- a/clients/client-dynamodb-streams/models/index.ts
+++ b/clients/client-dynamodb-streams/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -25,7 +28,7 @@ export interface DescribeStreamInput {
 
 export namespace DescribeStreamInput {
   export function isa(o: any): o is DescribeStreamInput {
-    return _smithy.isa(o, "DescribeStreamInput");
+    return __isa(o, "DescribeStreamInput");
   }
 }
 
@@ -42,7 +45,7 @@ export interface DescribeStreamOutput extends $MetadataBearer {
 
 export namespace DescribeStreamOutput {
   export function isa(o: any): o is DescribeStreamOutput {
-    return _smithy.isa(o, "DescribeStreamOutput");
+    return __isa(o, "DescribeStreamOutput");
   }
 }
 
@@ -52,7 +55,7 @@ export namespace DescribeStreamOutput {
  *       action.</p>
  */
 export interface ExpiredIteratorException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ExpiredIteratorException";
   $fault: "client";
@@ -64,7 +67,7 @@ export interface ExpiredIteratorException
 
 export namespace ExpiredIteratorException {
   export function isa(o: any): o is ExpiredIteratorException {
-    return _smithy.isa(o, "ExpiredIteratorException");
+    return __isa(o, "ExpiredIteratorException");
   }
 }
 
@@ -86,7 +89,7 @@ export interface GetRecordsInput {
 
 export namespace GetRecordsInput {
   export function isa(o: any): o is GetRecordsInput {
-    return _smithy.isa(o, "GetRecordsInput");
+    return __isa(o, "GetRecordsInput");
   }
 }
 
@@ -110,7 +113,7 @@ export interface GetRecordsOutput extends $MetadataBearer {
 
 export namespace GetRecordsOutput {
   export function isa(o: any): o is GetRecordsOutput {
-    return _smithy.isa(o, "GetRecordsOutput");
+    return __isa(o, "GetRecordsOutput");
   }
 }
 
@@ -166,7 +169,7 @@ export interface GetShardIteratorInput {
 
 export namespace GetShardIteratorInput {
   export function isa(o: any): o is GetShardIteratorInput {
-    return _smithy.isa(o, "GetShardIteratorInput");
+    return __isa(o, "GetShardIteratorInput");
   }
 }
 
@@ -183,7 +186,7 @@ export interface GetShardIteratorOutput extends $MetadataBearer {
 
 export namespace GetShardIteratorOutput {
   export function isa(o: any): o is GetShardIteratorOutput {
-    return _smithy.isa(o, "GetShardIteratorOutput");
+    return __isa(o, "GetShardIteratorOutput");
   }
 }
 
@@ -206,7 +209,7 @@ export interface Identity {
 
 export namespace Identity {
   export function isa(o: any): o is Identity {
-    return _smithy.isa(o, "Identity");
+    return __isa(o, "Identity");
   }
 }
 
@@ -235,7 +238,7 @@ export interface ListStreamsInput {
 
 export namespace ListStreamsInput {
   export function isa(o: any): o is ListStreamsInput {
-    return _smithy.isa(o, "ListStreamsInput");
+    return __isa(o, "ListStreamsInput");
   }
 }
 
@@ -262,7 +265,7 @@ export interface ListStreamsOutput extends $MetadataBearer {
 
 export namespace ListStreamsOutput {
   export function isa(o: any): o is ListStreamsOutput {
-    return _smithy.isa(o, "ListStreamsOutput");
+    return __isa(o, "ListStreamsOutput");
   }
 }
 
@@ -338,7 +341,7 @@ export interface _Record {
 
 export namespace _Record {
   export function isa(o: any): o is _Record {
-    return _smithy.isa(o, "Record");
+    return __isa(o, "Record");
   }
 }
 
@@ -360,7 +363,7 @@ export interface SequenceNumberRange {
 
 export namespace SequenceNumberRange {
   export function isa(o: any): o is SequenceNumberRange {
-    return _smithy.isa(o, "SequenceNumberRange");
+    return __isa(o, "SequenceNumberRange");
   }
 }
 
@@ -387,7 +390,7 @@ export interface Shard {
 
 export namespace Shard {
   export function isa(o: any): o is Shard {
-    return _smithy.isa(o, "Shard");
+    return __isa(o, "Shard");
   }
 }
 
@@ -435,7 +438,7 @@ export interface _Stream {
 
 export namespace _Stream {
   export function isa(o: any): o is _Stream {
-    return _smithy.isa(o, "Stream");
+    return __isa(o, "Stream");
   }
 }
 
@@ -548,7 +551,7 @@ export interface StreamDescription {
 
 export namespace StreamDescription {
   export function isa(o: any): o is StreamDescription {
-    return _smithy.isa(o, "StreamDescription");
+    return __isa(o, "StreamDescription");
   }
 }
 
@@ -613,7 +616,7 @@ export interface StreamRecord {
 
 export namespace StreamRecord {
   export function isa(o: any): o is StreamRecord {
-    return _smithy.isa(o, "StreamRecord");
+    return __isa(o, "StreamRecord");
   }
 }
 
@@ -634,7 +637,7 @@ export type StreamStatus = "DISABLED" | "DISABLING" | "ENABLED" | "ENABLING";
  *          </ul>
  */
 export interface TrimmedDataAccessException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TrimmedDataAccessException";
   $fault: "client";
@@ -646,7 +649,7 @@ export interface TrimmedDataAccessException
 
 export namespace TrimmedDataAccessException {
   export function isa(o: any): o is TrimmedDataAccessException {
-    return _smithy.isa(o, "TrimmedDataAccessException");
+    return __isa(o, "TrimmedDataAccessException");
   }
 }
 
@@ -709,7 +712,7 @@ export interface AttributeValue {
 
 export namespace AttributeValue {
   export function isa(o: any): o is AttributeValue {
-    return _smithy.isa(o, "AttributeValue");
+    return __isa(o, "AttributeValue");
   }
 }
 
@@ -717,7 +720,7 @@ export namespace AttributeValue {
  * <p>An error occurred on the server side.</p>
  */
 export interface InternalServerError
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalServerError";
   $fault: "server";
@@ -729,7 +732,7 @@ export interface InternalServerError
 
 export namespace InternalServerError {
   export function isa(o: any): o is InternalServerError {
-    return _smithy.isa(o, "InternalServerError");
+    return __isa(o, "InternalServerError");
   }
 }
 
@@ -763,7 +766,7 @@ export interface KeySchemaElement {
 
 export namespace KeySchemaElement {
   export function isa(o: any): o is KeySchemaElement {
-    return _smithy.isa(o, "KeySchemaElement");
+    return __isa(o, "KeySchemaElement");
   }
 }
 
@@ -777,7 +780,7 @@ export type KeyType = "HASH" | "RANGE";
  *         Backoff</a> in the <i>Amazon DynamoDB Developer Guide</i>.</p>
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -789,7 +792,7 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
@@ -797,7 +800,7 @@ export namespace LimitExceededException {
  * <p>The operation tried to access a nonexistent stream.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -809,7 +812,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 

--- a/clients/client-dynamodb/models/index.ts
+++ b/clients/client-dynamodb/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export interface DescribeEndpointsRequest {
@@ -7,7 +10,7 @@ export interface DescribeEndpointsRequest {
 
 export namespace DescribeEndpointsRequest {
   export function isa(o: any): o is DescribeEndpointsRequest {
-    return _smithy.isa(o, "DescribeEndpointsRequest");
+    return __isa(o, "DescribeEndpointsRequest");
   }
 }
 
@@ -21,7 +24,7 @@ export interface DescribeEndpointsResponse extends $MetadataBearer {
 
 export namespace DescribeEndpointsResponse {
   export function isa(o: any): o is DescribeEndpointsResponse {
-    return _smithy.isa(o, "DescribeEndpointsResponse");
+    return __isa(o, "DescribeEndpointsResponse");
   }
 }
 
@@ -43,12 +46,12 @@ export interface Endpoint {
 
 export namespace Endpoint {
   export function isa(o: any): o is Endpoint {
-    return _smithy.isa(o, "Endpoint");
+    return __isa(o, "Endpoint");
   }
 }
 
 export interface InvalidEndpointException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidEndpointException";
   $fault: "client";
@@ -57,7 +60,7 @@ export interface InvalidEndpointException
 
 export namespace InvalidEndpointException {
   export function isa(o: any): o is InvalidEndpointException {
-    return _smithy.isa(o, "InvalidEndpointException");
+    return __isa(o, "InvalidEndpointException");
   }
 }
 
@@ -99,7 +102,7 @@ export interface ArchivalSummary {
 
 export namespace ArchivalSummary {
   export function isa(o: any): o is ArchivalSummary {
-    return _smithy.isa(o, "ArchivalSummary");
+    return __isa(o, "ArchivalSummary");
   }
 }
 
@@ -137,7 +140,7 @@ export interface AttributeDefinition {
 
 export namespace AttributeDefinition {
   export function isa(o: any): o is AttributeDefinition {
-    return _smithy.isa(o, "AttributeDefinition");
+    return __isa(o, "AttributeDefinition");
   }
 }
 
@@ -234,7 +237,7 @@ export interface AttributeValue {
 
 export namespace AttributeValue {
   export function isa(o: any): o is AttributeValue {
-    return _smithy.isa(o, "AttributeValue");
+    return __isa(o, "AttributeValue");
   }
 }
 
@@ -354,7 +357,7 @@ export interface AttributeValueUpdate {
 
 export namespace AttributeValueUpdate {
   export function isa(o: any): o is AttributeValueUpdate {
-    return _smithy.isa(o, "AttributeValueUpdate");
+    return __isa(o, "AttributeValueUpdate");
   }
 }
 
@@ -376,7 +379,7 @@ export interface AutoScalingPolicyDescription {
 
 export namespace AutoScalingPolicyDescription {
   export function isa(o: any): o is AutoScalingPolicyDescription {
-    return _smithy.isa(o, "AutoScalingPolicyDescription");
+    return __isa(o, "AutoScalingPolicyDescription");
   }
 }
 
@@ -400,7 +403,7 @@ export interface AutoScalingPolicyUpdate {
 
 export namespace AutoScalingPolicyUpdate {
   export function isa(o: any): o is AutoScalingPolicyUpdate {
-    return _smithy.isa(o, "AutoScalingPolicyUpdate");
+    return __isa(o, "AutoScalingPolicyUpdate");
   }
 }
 
@@ -438,7 +441,7 @@ export interface AutoScalingSettingsDescription {
 
 export namespace AutoScalingSettingsDescription {
   export function isa(o: any): o is AutoScalingSettingsDescription {
-    return _smithy.isa(o, "AutoScalingSettingsDescription");
+    return __isa(o, "AutoScalingSettingsDescription");
   }
 }
 
@@ -476,7 +479,7 @@ export interface AutoScalingSettingsUpdate {
 
 export namespace AutoScalingSettingsUpdate {
   export function isa(o: any): o is AutoScalingSettingsUpdate {
-    return _smithy.isa(o, "AutoScalingSettingsUpdate");
+    return __isa(o, "AutoScalingSettingsUpdate");
   }
 }
 
@@ -522,7 +525,7 @@ export namespace AutoScalingTargetTrackingScalingPolicyConfigurationDescription 
   export function isa(
     o: any
   ): o is AutoScalingTargetTrackingScalingPolicyConfigurationDescription {
-    return _smithy.isa(
+    return __isa(
       o,
       "AutoScalingTargetTrackingScalingPolicyConfigurationDescription"
     );
@@ -571,7 +574,7 @@ export namespace AutoScalingTargetTrackingScalingPolicyConfigurationUpdate {
   export function isa(
     o: any
   ): o is AutoScalingTargetTrackingScalingPolicyConfigurationUpdate {
-    return _smithy.isa(
+    return __isa(
       o,
       "AutoScalingTargetTrackingScalingPolicyConfigurationUpdate"
     );
@@ -601,7 +604,7 @@ export interface BackupDescription {
 
 export namespace BackupDescription {
   export function isa(o: any): o is BackupDescription {
-    return _smithy.isa(o, "BackupDescription");
+    return __isa(o, "BackupDescription");
   }
 }
 
@@ -666,7 +669,7 @@ export interface BackupDetails {
 
 export namespace BackupDetails {
   export function isa(o: any): o is BackupDetails {
-    return _smithy.isa(o, "BackupDetails");
+    return __isa(o, "BackupDetails");
   }
 }
 
@@ -674,7 +677,7 @@ export namespace BackupDetails {
  * <p>There is another ongoing conflicting backup control plane operation on the table. The backup is either being created, deleted or restored to a table.</p>
  */
 export interface BackupInUseException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "BackupInUseException";
   $fault: "client";
@@ -683,7 +686,7 @@ export interface BackupInUseException
 
 export namespace BackupInUseException {
   export function isa(o: any): o is BackupInUseException {
-    return _smithy.isa(o, "BackupInUseException");
+    return __isa(o, "BackupInUseException");
   }
 }
 
@@ -691,7 +694,7 @@ export namespace BackupInUseException {
  * <p>Backup not found for the given BackupARN. </p>
  */
 export interface BackupNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "BackupNotFoundException";
   $fault: "client";
@@ -700,7 +703,7 @@ export interface BackupNotFoundException
 
 export namespace BackupNotFoundException {
   export function isa(o: any): o is BackupNotFoundException {
-    return _smithy.isa(o, "BackupNotFoundException");
+    return __isa(o, "BackupNotFoundException");
   }
 }
 
@@ -783,7 +786,7 @@ export interface BackupSummary {
 
 export namespace BackupSummary {
   export function isa(o: any): o is BackupSummary {
-    return _smithy.isa(o, "BackupSummary");
+    return __isa(o, "BackupSummary");
   }
 }
 
@@ -912,7 +915,7 @@ export interface BatchGetItemInput {
 
 export namespace BatchGetItemInput {
   export function isa(o: any): o is BatchGetItemInput {
-    return _smithy.isa(o, "BatchGetItemInput");
+    return __isa(o, "BatchGetItemInput");
   }
 }
 
@@ -976,7 +979,7 @@ export interface BatchGetItemOutput extends $MetadataBearer {
 
 export namespace BatchGetItemOutput {
   export function isa(o: any): o is BatchGetItemOutput {
-    return _smithy.isa(o, "BatchGetItemOutput");
+    return __isa(o, "BatchGetItemOutput");
   }
 }
 
@@ -1055,7 +1058,7 @@ export interface BatchWriteItemInput {
 
 export namespace BatchWriteItemInput {
   export function isa(o: any): o is BatchWriteItemInput {
-    return _smithy.isa(o, "BatchWriteItemInput");
+    return __isa(o, "BatchWriteItemInput");
   }
 }
 
@@ -1149,7 +1152,7 @@ export interface BatchWriteItemOutput extends $MetadataBearer {
 
 export namespace BatchWriteItemOutput {
   export function isa(o: any): o is BatchWriteItemOutput {
-    return _smithy.isa(o, "BatchWriteItemOutput");
+    return __isa(o, "BatchWriteItemOutput");
   }
 }
 
@@ -1184,7 +1187,7 @@ export interface BillingModeSummary {
 
 export namespace BillingModeSummary {
   export function isa(o: any): o is BillingModeSummary {
-    return _smithy.isa(o, "BillingModeSummary");
+    return __isa(o, "BillingModeSummary");
   }
 }
 
@@ -1215,7 +1218,7 @@ export interface CancellationReason {
 
 export namespace CancellationReason {
   export function isa(o: any): o is CancellationReason {
-    return _smithy.isa(o, "CancellationReason");
+    return __isa(o, "CancellationReason");
   }
 }
 
@@ -1242,7 +1245,7 @@ export interface Capacity {
 
 export namespace Capacity {
   export function isa(o: any): o is Capacity {
-    return _smithy.isa(o, "Capacity");
+    return __isa(o, "Capacity");
   }
 }
 
@@ -1449,7 +1452,7 @@ export interface Condition {
 
 export namespace Condition {
   export function isa(o: any): o is Condition {
-    return _smithy.isa(o, "Condition");
+    return __isa(o, "Condition");
   }
 }
 
@@ -1498,7 +1501,7 @@ export interface ConditionCheck {
 
 export namespace ConditionCheck {
   export function isa(o: any): o is ConditionCheck {
-    return _smithy.isa(o, "ConditionCheck");
+    return __isa(o, "ConditionCheck");
   }
 }
 
@@ -1506,7 +1509,7 @@ export namespace ConditionCheck {
  * <p>A condition specified in the operation could not be evaluated.</p>
  */
 export interface ConditionalCheckFailedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ConditionalCheckFailedException";
   $fault: "client";
@@ -1518,7 +1521,7 @@ export interface ConditionalCheckFailedException
 
 export namespace ConditionalCheckFailedException {
   export function isa(o: any): o is ConditionalCheckFailedException {
-    return _smithy.isa(o, "ConditionalCheckFailedException");
+    return __isa(o, "ConditionalCheckFailedException");
   }
 }
 
@@ -1571,7 +1574,7 @@ export interface ConsumedCapacity {
 
 export namespace ConsumedCapacity {
   export function isa(o: any): o is ConsumedCapacity {
-    return _smithy.isa(o, "ConsumedCapacity");
+    return __isa(o, "ConsumedCapacity");
   }
 }
 
@@ -1595,7 +1598,7 @@ export interface ContinuousBackupsDescription {
 
 export namespace ContinuousBackupsDescription {
   export function isa(o: any): o is ContinuousBackupsDescription {
-    return _smithy.isa(o, "ContinuousBackupsDescription");
+    return __isa(o, "ContinuousBackupsDescription");
   }
 }
 
@@ -1605,7 +1608,7 @@ export type ContinuousBackupsStatus = "DISABLED" | "ENABLED";
  * <p>Backups have not yet been enabled for this table.</p>
  */
 export interface ContinuousBackupsUnavailableException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ContinuousBackupsUnavailableException";
   $fault: "client";
@@ -1614,7 +1617,7 @@ export interface ContinuousBackupsUnavailableException
 
 export namespace ContinuousBackupsUnavailableException {
   export function isa(o: any): o is ContinuousBackupsUnavailableException {
-    return _smithy.isa(o, "ContinuousBackupsUnavailableException");
+    return __isa(o, "ContinuousBackupsUnavailableException");
   }
 }
 
@@ -1650,7 +1653,7 @@ export interface ContributorInsightsSummary {
 
 export namespace ContributorInsightsSummary {
   export function isa(o: any): o is ContributorInsightsSummary {
-    return _smithy.isa(o, "ContributorInsightsSummary");
+    return __isa(o, "ContributorInsightsSummary");
   }
 }
 
@@ -1669,7 +1672,7 @@ export interface CreateBackupInput {
 
 export namespace CreateBackupInput {
   export function isa(o: any): o is CreateBackupInput {
-    return _smithy.isa(o, "CreateBackupInput");
+    return __isa(o, "CreateBackupInput");
   }
 }
 
@@ -1683,7 +1686,7 @@ export interface CreateBackupOutput extends $MetadataBearer {
 
 export namespace CreateBackupOutput {
   export function isa(o: any): o is CreateBackupOutput {
-    return _smithy.isa(o, "CreateBackupOutput");
+    return __isa(o, "CreateBackupOutput");
   }
 }
 
@@ -1718,7 +1721,7 @@ export interface CreateGlobalSecondaryIndexAction {
 
 export namespace CreateGlobalSecondaryIndexAction {
   export function isa(o: any): o is CreateGlobalSecondaryIndexAction {
-    return _smithy.isa(o, "CreateGlobalSecondaryIndexAction");
+    return __isa(o, "CreateGlobalSecondaryIndexAction");
   }
 }
 
@@ -1737,7 +1740,7 @@ export interface CreateGlobalTableInput {
 
 export namespace CreateGlobalTableInput {
   export function isa(o: any): o is CreateGlobalTableInput {
-    return _smithy.isa(o, "CreateGlobalTableInput");
+    return __isa(o, "CreateGlobalTableInput");
   }
 }
 
@@ -1751,7 +1754,7 @@ export interface CreateGlobalTableOutput extends $MetadataBearer {
 
 export namespace CreateGlobalTableOutput {
   export function isa(o: any): o is CreateGlobalTableOutput {
-    return _smithy.isa(o, "CreateGlobalTableOutput");
+    return __isa(o, "CreateGlobalTableOutput");
   }
 }
 
@@ -1768,7 +1771,7 @@ export interface CreateReplicaAction {
 
 export namespace CreateReplicaAction {
   export function isa(o: any): o is CreateReplicaAction {
-    return _smithy.isa(o, "CreateReplicaAction");
+    return __isa(o, "CreateReplicaAction");
   }
 }
 
@@ -1804,7 +1807,7 @@ export interface CreateReplicationGroupMemberAction {
 
 export namespace CreateReplicationGroupMemberAction {
   export function isa(o: any): o is CreateReplicationGroupMemberAction {
-    return _smithy.isa(o, "CreateReplicationGroupMemberAction");
+    return __isa(o, "CreateReplicationGroupMemberAction");
   }
 }
 
@@ -2069,7 +2072,7 @@ export interface CreateTableInput {
 
 export namespace CreateTableInput {
   export function isa(o: any): o is CreateTableInput {
-    return _smithy.isa(o, "CreateTableInput");
+    return __isa(o, "CreateTableInput");
   }
 }
 
@@ -2086,7 +2089,7 @@ export interface CreateTableOutput extends $MetadataBearer {
 
 export namespace CreateTableOutput {
   export function isa(o: any): o is CreateTableOutput {
-    return _smithy.isa(o, "CreateTableOutput");
+    return __isa(o, "CreateTableOutput");
   }
 }
 
@@ -2134,7 +2137,7 @@ export interface Delete {
 
 export namespace Delete {
   export function isa(o: any): o is Delete {
-    return _smithy.isa(o, "Delete");
+    return __isa(o, "Delete");
   }
 }
 
@@ -2148,7 +2151,7 @@ export interface DeleteBackupInput {
 
 export namespace DeleteBackupInput {
   export function isa(o: any): o is DeleteBackupInput {
-    return _smithy.isa(o, "DeleteBackupInput");
+    return __isa(o, "DeleteBackupInput");
   }
 }
 
@@ -2162,7 +2165,7 @@ export interface DeleteBackupOutput extends $MetadataBearer {
 
 export namespace DeleteBackupOutput {
   export function isa(o: any): o is DeleteBackupOutput {
-    return _smithy.isa(o, "DeleteBackupOutput");
+    return __isa(o, "DeleteBackupOutput");
   }
 }
 
@@ -2179,7 +2182,7 @@ export interface DeleteGlobalSecondaryIndexAction {
 
 export namespace DeleteGlobalSecondaryIndexAction {
   export function isa(o: any): o is DeleteGlobalSecondaryIndexAction {
-    return _smithy.isa(o, "DeleteGlobalSecondaryIndexAction");
+    return __isa(o, "DeleteGlobalSecondaryIndexAction");
   }
 }
 
@@ -2354,7 +2357,7 @@ export interface DeleteItemInput {
 
 export namespace DeleteItemInput {
   export function isa(o: any): o is DeleteItemInput {
-    return _smithy.isa(o, "DeleteItemInput");
+    return __isa(o, "DeleteItemInput");
   }
 }
 
@@ -2413,7 +2416,7 @@ export interface DeleteItemOutput extends $MetadataBearer {
 
 export namespace DeleteItemOutput {
   export function isa(o: any): o is DeleteItemOutput {
-    return _smithy.isa(o, "DeleteItemOutput");
+    return __isa(o, "DeleteItemOutput");
   }
 }
 
@@ -2430,7 +2433,7 @@ export interface DeleteReplicaAction {
 
 export namespace DeleteReplicaAction {
   export function isa(o: any): o is DeleteReplicaAction {
-    return _smithy.isa(o, "DeleteReplicaAction");
+    return __isa(o, "DeleteReplicaAction");
   }
 }
 
@@ -2447,7 +2450,7 @@ export interface DeleteReplicationGroupMemberAction {
 
 export namespace DeleteReplicationGroupMemberAction {
   export function isa(o: any): o is DeleteReplicationGroupMemberAction {
-    return _smithy.isa(o, "DeleteReplicationGroupMemberAction");
+    return __isa(o, "DeleteReplicationGroupMemberAction");
   }
 }
 
@@ -2464,7 +2467,7 @@ export interface DeleteRequest {
 
 export namespace DeleteRequest {
   export function isa(o: any): o is DeleteRequest {
-    return _smithy.isa(o, "DeleteRequest");
+    return __isa(o, "DeleteRequest");
   }
 }
 
@@ -2481,7 +2484,7 @@ export interface DeleteTableInput {
 
 export namespace DeleteTableInput {
   export function isa(o: any): o is DeleteTableInput {
-    return _smithy.isa(o, "DeleteTableInput");
+    return __isa(o, "DeleteTableInput");
   }
 }
 
@@ -2498,7 +2501,7 @@ export interface DeleteTableOutput extends $MetadataBearer {
 
 export namespace DeleteTableOutput {
   export function isa(o: any): o is DeleteTableOutput {
-    return _smithy.isa(o, "DeleteTableOutput");
+    return __isa(o, "DeleteTableOutput");
   }
 }
 
@@ -2512,7 +2515,7 @@ export interface DescribeBackupInput {
 
 export namespace DescribeBackupInput {
   export function isa(o: any): o is DescribeBackupInput {
-    return _smithy.isa(o, "DescribeBackupInput");
+    return __isa(o, "DescribeBackupInput");
   }
 }
 
@@ -2526,7 +2529,7 @@ export interface DescribeBackupOutput extends $MetadataBearer {
 
 export namespace DescribeBackupOutput {
   export function isa(o: any): o is DescribeBackupOutput {
-    return _smithy.isa(o, "DescribeBackupOutput");
+    return __isa(o, "DescribeBackupOutput");
   }
 }
 
@@ -2540,7 +2543,7 @@ export interface DescribeContinuousBackupsInput {
 
 export namespace DescribeContinuousBackupsInput {
   export function isa(o: any): o is DescribeContinuousBackupsInput {
-    return _smithy.isa(o, "DescribeContinuousBackupsInput");
+    return __isa(o, "DescribeContinuousBackupsInput");
   }
 }
 
@@ -2554,7 +2557,7 @@ export interface DescribeContinuousBackupsOutput extends $MetadataBearer {
 
 export namespace DescribeContinuousBackupsOutput {
   export function isa(o: any): o is DescribeContinuousBackupsOutput {
-    return _smithy.isa(o, "DescribeContinuousBackupsOutput");
+    return __isa(o, "DescribeContinuousBackupsOutput");
   }
 }
 
@@ -2573,7 +2576,7 @@ export interface DescribeContributorInsightsInput {
 
 export namespace DescribeContributorInsightsInput {
   export function isa(o: any): o is DescribeContributorInsightsInput {
-    return _smithy.isa(o, "DescribeContributorInsightsInput");
+    return __isa(o, "DescribeContributorInsightsInput");
   }
 }
 
@@ -2628,7 +2631,7 @@ export interface DescribeContributorInsightsOutput extends $MetadataBearer {
 
 export namespace DescribeContributorInsightsOutput {
   export function isa(o: any): o is DescribeContributorInsightsOutput {
-    return _smithy.isa(o, "DescribeContributorInsightsOutput");
+    return __isa(o, "DescribeContributorInsightsOutput");
   }
 }
 
@@ -2642,7 +2645,7 @@ export interface DescribeGlobalTableInput {
 
 export namespace DescribeGlobalTableInput {
   export function isa(o: any): o is DescribeGlobalTableInput {
-    return _smithy.isa(o, "DescribeGlobalTableInput");
+    return __isa(o, "DescribeGlobalTableInput");
   }
 }
 
@@ -2656,7 +2659,7 @@ export interface DescribeGlobalTableOutput extends $MetadataBearer {
 
 export namespace DescribeGlobalTableOutput {
   export function isa(o: any): o is DescribeGlobalTableOutput {
-    return _smithy.isa(o, "DescribeGlobalTableOutput");
+    return __isa(o, "DescribeGlobalTableOutput");
   }
 }
 
@@ -2670,7 +2673,7 @@ export interface DescribeGlobalTableSettingsInput {
 
 export namespace DescribeGlobalTableSettingsInput {
   export function isa(o: any): o is DescribeGlobalTableSettingsInput {
-    return _smithy.isa(o, "DescribeGlobalTableSettingsInput");
+    return __isa(o, "DescribeGlobalTableSettingsInput");
   }
 }
 
@@ -2689,7 +2692,7 @@ export interface DescribeGlobalTableSettingsOutput extends $MetadataBearer {
 
 export namespace DescribeGlobalTableSettingsOutput {
   export function isa(o: any): o is DescribeGlobalTableSettingsOutput {
-    return _smithy.isa(o, "DescribeGlobalTableSettingsOutput");
+    return __isa(o, "DescribeGlobalTableSettingsOutput");
   }
 }
 
@@ -2702,7 +2705,7 @@ export interface DescribeLimitsInput {
 
 export namespace DescribeLimitsInput {
   export function isa(o: any): o is DescribeLimitsInput {
-    return _smithy.isa(o, "DescribeLimitsInput");
+    return __isa(o, "DescribeLimitsInput");
   }
 }
 
@@ -2740,7 +2743,7 @@ export interface DescribeLimitsOutput extends $MetadataBearer {
 
 export namespace DescribeLimitsOutput {
   export function isa(o: any): o is DescribeLimitsOutput {
-    return _smithy.isa(o, "DescribeLimitsOutput");
+    return __isa(o, "DescribeLimitsOutput");
   }
 }
 
@@ -2757,7 +2760,7 @@ export interface DescribeTableInput {
 
 export namespace DescribeTableInput {
   export function isa(o: any): o is DescribeTableInput {
-    return _smithy.isa(o, "DescribeTableInput");
+    return __isa(o, "DescribeTableInput");
   }
 }
 
@@ -2774,7 +2777,7 @@ export interface DescribeTableOutput extends $MetadataBearer {
 
 export namespace DescribeTableOutput {
   export function isa(o: any): o is DescribeTableOutput {
-    return _smithy.isa(o, "DescribeTableOutput");
+    return __isa(o, "DescribeTableOutput");
   }
 }
 
@@ -2788,7 +2791,7 @@ export interface DescribeTableReplicaAutoScalingInput {
 
 export namespace DescribeTableReplicaAutoScalingInput {
   export function isa(o: any): o is DescribeTableReplicaAutoScalingInput {
-    return _smithy.isa(o, "DescribeTableReplicaAutoScalingInput");
+    return __isa(o, "DescribeTableReplicaAutoScalingInput");
   }
 }
 
@@ -2802,7 +2805,7 @@ export interface DescribeTableReplicaAutoScalingOutput extends $MetadataBearer {
 
 export namespace DescribeTableReplicaAutoScalingOutput {
   export function isa(o: any): o is DescribeTableReplicaAutoScalingOutput {
-    return _smithy.isa(o, "DescribeTableReplicaAutoScalingOutput");
+    return __isa(o, "DescribeTableReplicaAutoScalingOutput");
   }
 }
 
@@ -2816,7 +2819,7 @@ export interface DescribeTimeToLiveInput {
 
 export namespace DescribeTimeToLiveInput {
   export function isa(o: any): o is DescribeTimeToLiveInput {
-    return _smithy.isa(o, "DescribeTimeToLiveInput");
+    return __isa(o, "DescribeTimeToLiveInput");
   }
 }
 
@@ -2830,7 +2833,7 @@ export interface DescribeTimeToLiveOutput extends $MetadataBearer {
 
 export namespace DescribeTimeToLiveOutput {
   export function isa(o: any): o is DescribeTimeToLiveOutput {
-    return _smithy.isa(o, "DescribeTimeToLiveOutput");
+    return __isa(o, "DescribeTimeToLiveOutput");
   }
 }
 
@@ -3069,7 +3072,7 @@ export interface ExpectedAttributeValue {
 
 export namespace ExpectedAttributeValue {
   export function isa(o: any): o is ExpectedAttributeValue {
-    return _smithy.isa(o, "ExpectedAttributeValue");
+    return __isa(o, "ExpectedAttributeValue");
   }
 }
 
@@ -3091,7 +3094,7 @@ export interface FailureException {
 
 export namespace FailureException {
   export function isa(o: any): o is FailureException {
-    return _smithy.isa(o, "FailureException");
+    return __isa(o, "FailureException");
   }
 }
 
@@ -3130,7 +3133,7 @@ export interface Get {
 
 export namespace Get {
   export function isa(o: any): o is Get {
-    return _smithy.isa(o, "Get");
+    return __isa(o, "Get");
   }
 }
 
@@ -3239,7 +3242,7 @@ export interface GetItemInput {
 
 export namespace GetItemInput {
   export function isa(o: any): o is GetItemInput {
-    return _smithy.isa(o, "GetItemInput");
+    return __isa(o, "GetItemInput");
   }
 }
 
@@ -3267,7 +3270,7 @@ export interface GetItemOutput extends $MetadataBearer {
 
 export namespace GetItemOutput {
   export function isa(o: any): o is GetItemOutput {
-    return _smithy.isa(o, "GetItemOutput");
+    return __isa(o, "GetItemOutput");
   }
 }
 
@@ -3320,7 +3323,7 @@ export interface GlobalSecondaryIndex {
 
 export namespace GlobalSecondaryIndex {
   export function isa(o: any): o is GlobalSecondaryIndex {
-    return _smithy.isa(o, "GlobalSecondaryIndex");
+    return __isa(o, "GlobalSecondaryIndex");
   }
 }
 
@@ -3344,7 +3347,7 @@ export interface GlobalSecondaryIndexAutoScalingUpdate {
 
 export namespace GlobalSecondaryIndexAutoScalingUpdate {
   export function isa(o: any): o is GlobalSecondaryIndexAutoScalingUpdate {
-    return _smithy.isa(o, "GlobalSecondaryIndexAutoScalingUpdate");
+    return __isa(o, "GlobalSecondaryIndexAutoScalingUpdate");
   }
 }
 
@@ -3450,7 +3453,7 @@ export interface GlobalSecondaryIndexDescription {
 
 export namespace GlobalSecondaryIndexDescription {
   export function isa(o: any): o is GlobalSecondaryIndexDescription {
-    return _smithy.isa(o, "GlobalSecondaryIndexDescription");
+    return __isa(o, "GlobalSecondaryIndexDescription");
   }
 }
 
@@ -3504,7 +3507,7 @@ export interface GlobalSecondaryIndexInfo {
 
 export namespace GlobalSecondaryIndexInfo {
   export function isa(o: any): o is GlobalSecondaryIndexInfo {
-    return _smithy.isa(o, "GlobalSecondaryIndexInfo");
+    return __isa(o, "GlobalSecondaryIndexInfo");
   }
 }
 
@@ -3569,7 +3572,7 @@ export interface GlobalSecondaryIndexUpdate {
 
 export namespace GlobalSecondaryIndexUpdate {
   export function isa(o: any): o is GlobalSecondaryIndexUpdate {
-    return _smithy.isa(o, "GlobalSecondaryIndexUpdate");
+    return __isa(o, "GlobalSecondaryIndexUpdate");
   }
 }
 
@@ -3591,7 +3594,7 @@ export interface GlobalTable {
 
 export namespace GlobalTable {
   export function isa(o: any): o is GlobalTable {
-    return _smithy.isa(o, "GlobalTable");
+    return __isa(o, "GlobalTable");
   }
 }
 
@@ -3599,7 +3602,7 @@ export namespace GlobalTable {
  * <p>The specified global table already exists.</p>
  */
 export interface GlobalTableAlreadyExistsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "GlobalTableAlreadyExistsException";
   $fault: "client";
@@ -3608,7 +3611,7 @@ export interface GlobalTableAlreadyExistsException
 
 export namespace GlobalTableAlreadyExistsException {
   export function isa(o: any): o is GlobalTableAlreadyExistsException {
-    return _smithy.isa(o, "GlobalTableAlreadyExistsException");
+    return __isa(o, "GlobalTableAlreadyExistsException");
   }
 }
 
@@ -3663,7 +3666,7 @@ export interface GlobalTableDescription {
 
 export namespace GlobalTableDescription {
   export function isa(o: any): o is GlobalTableDescription {
-    return _smithy.isa(o, "GlobalTableDescription");
+    return __isa(o, "GlobalTableDescription");
   }
 }
 
@@ -3694,7 +3697,7 @@ export namespace GlobalTableGlobalSecondaryIndexSettingsUpdate {
   export function isa(
     o: any
   ): o is GlobalTableGlobalSecondaryIndexSettingsUpdate {
-    return _smithy.isa(o, "GlobalTableGlobalSecondaryIndexSettingsUpdate");
+    return __isa(o, "GlobalTableGlobalSecondaryIndexSettingsUpdate");
   }
 }
 
@@ -3702,7 +3705,7 @@ export namespace GlobalTableGlobalSecondaryIndexSettingsUpdate {
  * <p>The specified global table does not exist.</p>
  */
 export interface GlobalTableNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "GlobalTableNotFoundException";
   $fault: "client";
@@ -3711,7 +3714,7 @@ export interface GlobalTableNotFoundException
 
 export namespace GlobalTableNotFoundException {
   export function isa(o: any): o is GlobalTableNotFoundException {
-    return _smithy.isa(o, "GlobalTableNotFoundException");
+    return __isa(o, "GlobalTableNotFoundException");
   }
 }
 
@@ -3722,7 +3725,7 @@ export type GlobalTableStatus = "ACTIVE" | "CREATING" | "DELETING" | "UPDATING";
  *       with an idempotent token that was already used.</p>
  */
 export interface IdempotentParameterMismatchException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "IdempotentParameterMismatchException";
   $fault: "client";
@@ -3731,7 +3734,7 @@ export interface IdempotentParameterMismatchException
 
 export namespace IdempotentParameterMismatchException {
   export function isa(o: any): o is IdempotentParameterMismatchException {
-    return _smithy.isa(o, "IdempotentParameterMismatchException");
+    return __isa(o, "IdempotentParameterMismatchException");
   }
 }
 
@@ -3739,7 +3742,7 @@ export namespace IdempotentParameterMismatchException {
  * <p>The operation tried to access a nonexistent index.</p>
  */
 export interface IndexNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "IndexNotFoundException";
   $fault: "client";
@@ -3748,7 +3751,7 @@ export interface IndexNotFoundException
 
 export namespace IndexNotFoundException {
   export function isa(o: any): o is IndexNotFoundException {
-    return _smithy.isa(o, "IndexNotFoundException");
+    return __isa(o, "IndexNotFoundException");
   }
 }
 
@@ -3758,7 +3761,7 @@ export type IndexStatus = "ACTIVE" | "CREATING" | "DELETING" | "UPDATING";
  * <p>An error occurred on the server side.</p>
  */
 export interface InternalServerError
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalServerError";
   $fault: "server";
@@ -3770,7 +3773,7 @@ export interface InternalServerError
 
 export namespace InternalServerError {
   export function isa(o: any): o is InternalServerError {
-    return _smithy.isa(o, "InternalServerError");
+    return __isa(o, "InternalServerError");
   }
 }
 
@@ -3778,7 +3781,7 @@ export namespace InternalServerError {
  * <p>An invalid restore time was specified. RestoreDateTime must be between EarliestRestorableDateTime and LatestRestorableDateTime.</p>
  */
 export interface InvalidRestoreTimeException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidRestoreTimeException";
   $fault: "client";
@@ -3787,7 +3790,7 @@ export interface InvalidRestoreTimeException
 
 export namespace InvalidRestoreTimeException {
   export function isa(o: any): o is InvalidRestoreTimeException {
-    return _smithy.isa(o, "InvalidRestoreTimeException");
+    return __isa(o, "InvalidRestoreTimeException");
   }
 }
 
@@ -3812,7 +3815,7 @@ export interface ItemCollectionMetrics {
 
 export namespace ItemCollectionMetrics {
   export function isa(o: any): o is ItemCollectionMetrics {
-    return _smithy.isa(o, "ItemCollectionMetrics");
+    return __isa(o, "ItemCollectionMetrics");
   }
 }
 
@@ -3820,7 +3823,7 @@ export namespace ItemCollectionMetrics {
  * <p>An item collection is too large. This exception is only returned for tables that have one or more local secondary indexes.</p>
  */
 export interface ItemCollectionSizeLimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ItemCollectionSizeLimitExceededException";
   $fault: "client";
@@ -3832,7 +3835,7 @@ export interface ItemCollectionSizeLimitExceededException
 
 export namespace ItemCollectionSizeLimitExceededException {
   export function isa(o: any): o is ItemCollectionSizeLimitExceededException {
-    return _smithy.isa(o, "ItemCollectionSizeLimitExceededException");
+    return __isa(o, "ItemCollectionSizeLimitExceededException");
   }
 }
 
@@ -3849,7 +3852,7 @@ export interface ItemResponse {
 
 export namespace ItemResponse {
   export function isa(o: any): o is ItemResponse {
-    return _smithy.isa(o, "ItemResponse");
+    return __isa(o, "ItemResponse");
   }
 }
 
@@ -3895,7 +3898,7 @@ export interface KeySchemaElement {
 
 export namespace KeySchemaElement {
   export function isa(o: any): o is KeySchemaElement {
-    return _smithy.isa(o, "KeySchemaElement");
+    return __isa(o, "KeySchemaElement");
   }
 }
 
@@ -3982,7 +3985,7 @@ export interface KeysAndAttributes {
 
 export namespace KeysAndAttributes {
   export function isa(o: any): o is KeysAndAttributes {
-    return _smithy.isa(o, "KeysAndAttributes");
+    return __isa(o, "KeysAndAttributes");
   }
 }
 
@@ -3998,7 +4001,7 @@ export namespace KeysAndAttributes {
  *         <p>There is a soft account limit of 256 tables.</p>
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -4010,7 +4013,7 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
@@ -4069,7 +4072,7 @@ export interface ListBackupsInput {
 
 export namespace ListBackupsInput {
   export function isa(o: any): o is ListBackupsInput {
-    return _smithy.isa(o, "ListBackupsInput");
+    return __isa(o, "ListBackupsInput");
   }
 }
 
@@ -4099,7 +4102,7 @@ export interface ListBackupsOutput extends $MetadataBearer {
 
 export namespace ListBackupsOutput {
   export function isa(o: any): o is ListBackupsOutput {
-    return _smithy.isa(o, "ListBackupsOutput");
+    return __isa(o, "ListBackupsOutput");
   }
 }
 
@@ -4123,7 +4126,7 @@ export interface ListContributorInsightsInput {
 
 export namespace ListContributorInsightsInput {
   export function isa(o: any): o is ListContributorInsightsInput {
-    return _smithy.isa(o, "ListContributorInsightsInput");
+    return __isa(o, "ListContributorInsightsInput");
   }
 }
 
@@ -4142,7 +4145,7 @@ export interface ListContributorInsightsOutput extends $MetadataBearer {
 
 export namespace ListContributorInsightsOutput {
   export function isa(o: any): o is ListContributorInsightsOutput {
-    return _smithy.isa(o, "ListContributorInsightsOutput");
+    return __isa(o, "ListContributorInsightsOutput");
   }
 }
 
@@ -4166,7 +4169,7 @@ export interface ListGlobalTablesInput {
 
 export namespace ListGlobalTablesInput {
   export function isa(o: any): o is ListGlobalTablesInput {
-    return _smithy.isa(o, "ListGlobalTablesInput");
+    return __isa(o, "ListGlobalTablesInput");
   }
 }
 
@@ -4185,7 +4188,7 @@ export interface ListGlobalTablesOutput extends $MetadataBearer {
 
 export namespace ListGlobalTablesOutput {
   export function isa(o: any): o is ListGlobalTablesOutput {
-    return _smithy.isa(o, "ListGlobalTablesOutput");
+    return __isa(o, "ListGlobalTablesOutput");
   }
 }
 
@@ -4209,7 +4212,7 @@ export interface ListTablesInput {
 
 export namespace ListTablesInput {
   export function isa(o: any): o is ListTablesInput {
-    return _smithy.isa(o, "ListTablesInput");
+    return __isa(o, "ListTablesInput");
   }
 }
 
@@ -4238,7 +4241,7 @@ export interface ListTablesOutput extends $MetadataBearer {
 
 export namespace ListTablesOutput {
   export function isa(o: any): o is ListTablesOutput {
-    return _smithy.isa(o, "ListTablesOutput");
+    return __isa(o, "ListTablesOutput");
   }
 }
 
@@ -4258,7 +4261,7 @@ export interface ListTagsOfResourceInput {
 
 export namespace ListTagsOfResourceInput {
   export function isa(o: any): o is ListTagsOfResourceInput {
-    return _smithy.isa(o, "ListTagsOfResourceInput");
+    return __isa(o, "ListTagsOfResourceInput");
   }
 }
 
@@ -4278,7 +4281,7 @@ export interface ListTagsOfResourceOutput extends $MetadataBearer {
 
 export namespace ListTagsOfResourceOutput {
   export function isa(o: any): o is ListTagsOfResourceOutput {
-    return _smithy.isa(o, "ListTagsOfResourceOutput");
+    return __isa(o, "ListTagsOfResourceOutput");
   }
 }
 
@@ -4325,7 +4328,7 @@ export interface LocalSecondaryIndex {
 
 export namespace LocalSecondaryIndex {
   export function isa(o: any): o is LocalSecondaryIndex {
-    return _smithy.isa(o, "LocalSecondaryIndex");
+    return __isa(o, "LocalSecondaryIndex");
   }
 }
 
@@ -4387,7 +4390,7 @@ export interface LocalSecondaryIndexDescription {
 
 export namespace LocalSecondaryIndexDescription {
   export function isa(o: any): o is LocalSecondaryIndexDescription {
-    return _smithy.isa(o, "LocalSecondaryIndexDescription");
+    return __isa(o, "LocalSecondaryIndexDescription");
   }
 }
 
@@ -4433,7 +4436,7 @@ export interface LocalSecondaryIndexInfo {
 
 export namespace LocalSecondaryIndexInfo {
   export function isa(o: any): o is LocalSecondaryIndexInfo {
-    return _smithy.isa(o, "LocalSecondaryIndexInfo");
+    return __isa(o, "LocalSecondaryIndexInfo");
   }
 }
 
@@ -4477,7 +4480,7 @@ export interface PointInTimeRecoveryDescription {
 
 export namespace PointInTimeRecoveryDescription {
   export function isa(o: any): o is PointInTimeRecoveryDescription {
-    return _smithy.isa(o, "PointInTimeRecoveryDescription");
+    return __isa(o, "PointInTimeRecoveryDescription");
   }
 }
 
@@ -4494,7 +4497,7 @@ export interface PointInTimeRecoverySpecification {
 
 export namespace PointInTimeRecoverySpecification {
   export function isa(o: any): o is PointInTimeRecoverySpecification {
-    return _smithy.isa(o, "PointInTimeRecoverySpecification");
+    return __isa(o, "PointInTimeRecoverySpecification");
   }
 }
 
@@ -4504,7 +4507,7 @@ export type PointInTimeRecoveryStatus = "DISABLED" | "ENABLED";
  * <p>Point in time recovery has not yet been enabled for this source table.</p>
  */
 export interface PointInTimeRecoveryUnavailableException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "PointInTimeRecoveryUnavailableException";
   $fault: "client";
@@ -4513,7 +4516,7 @@ export interface PointInTimeRecoveryUnavailableException
 
 export namespace PointInTimeRecoveryUnavailableException {
   export function isa(o: any): o is PointInTimeRecoveryUnavailableException {
-    return _smithy.isa(o, "PointInTimeRecoveryUnavailableException");
+    return __isa(o, "PointInTimeRecoveryUnavailableException");
   }
 }
 
@@ -4554,7 +4557,7 @@ export interface Projection {
 
 export namespace Projection {
   export function isa(o: any): o is Projection {
-    return _smithy.isa(o, "Projection");
+    return __isa(o, "Projection");
   }
 }
 
@@ -4586,7 +4589,7 @@ export interface ProvisionedThroughput {
 
 export namespace ProvisionedThroughput {
   export function isa(o: any): o is ProvisionedThroughput {
-    return _smithy.isa(o, "ProvisionedThroughput");
+    return __isa(o, "ProvisionedThroughput");
   }
 }
 
@@ -4628,7 +4631,7 @@ export interface ProvisionedThroughputDescription {
 
 export namespace ProvisionedThroughputDescription {
   export function isa(o: any): o is ProvisionedThroughputDescription {
-    return _smithy.isa(o, "ProvisionedThroughputDescription");
+    return __isa(o, "ProvisionedThroughputDescription");
   }
 }
 
@@ -4640,7 +4643,7 @@ export namespace ProvisionedThroughputDescription {
  *         Backoff</a> in the <i>Amazon DynamoDB Developer Guide</i>.</p>
  */
 export interface ProvisionedThroughputExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ProvisionedThroughputExceededException";
   $fault: "client";
@@ -4652,7 +4655,7 @@ export interface ProvisionedThroughputExceededException
 
 export namespace ProvisionedThroughputExceededException {
   export function isa(o: any): o is ProvisionedThroughputExceededException {
-    return _smithy.isa(o, "ProvisionedThroughputExceededException");
+    return __isa(o, "ProvisionedThroughputExceededException");
   }
 }
 
@@ -4671,7 +4674,7 @@ export interface ProvisionedThroughputOverride {
 
 export namespace ProvisionedThroughputOverride {
   export function isa(o: any): o is ProvisionedThroughputOverride {
-    return _smithy.isa(o, "ProvisionedThroughputOverride");
+    return __isa(o, "ProvisionedThroughputOverride");
   }
 }
 
@@ -4722,7 +4725,7 @@ export interface Put {
 
 export namespace Put {
   export function isa(o: any): o is Put {
-    return _smithy.isa(o, "Put");
+    return __isa(o, "Put");
   }
 }
 
@@ -4901,7 +4904,7 @@ export interface PutItemInput {
 
 export namespace PutItemInput {
   export function isa(o: any): o is PutItemInput {
-    return _smithy.isa(o, "PutItemInput");
+    return __isa(o, "PutItemInput");
   }
 }
 
@@ -4958,7 +4961,7 @@ export interface PutItemOutput extends $MetadataBearer {
 
 export namespace PutItemOutput {
   export function isa(o: any): o is PutItemOutput {
-    return _smithy.isa(o, "PutItemOutput");
+    return __isa(o, "PutItemOutput");
   }
 }
 
@@ -4979,7 +4982,7 @@ export interface PutRequest {
 
 export namespace PutRequest {
   export function isa(o: any): o is PutRequest {
-    return _smithy.isa(o, "PutRequest");
+    return __isa(o, "PutRequest");
   }
 }
 
@@ -5346,7 +5349,7 @@ export interface QueryInput {
 
 export namespace QueryInput {
   export function isa(o: any): o is QueryInput {
-    return _smithy.isa(o, "QueryInput");
+    return __isa(o, "QueryInput");
   }
 }
 
@@ -5400,7 +5403,7 @@ export interface QueryOutput extends $MetadataBearer {
 
 export namespace QueryOutput {
   export function isa(o: any): o is QueryOutput {
-    return _smithy.isa(o, "QueryOutput");
+    return __isa(o, "QueryOutput");
   }
 }
 
@@ -5417,7 +5420,7 @@ export interface Replica {
 
 export namespace Replica {
   export function isa(o: any): o is Replica {
-    return _smithy.isa(o, "Replica");
+    return __isa(o, "Replica");
   }
 }
 
@@ -5425,7 +5428,7 @@ export namespace Replica {
  * <p>The specified replica is already part of the global table.</p>
  */
 export interface ReplicaAlreadyExistsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ReplicaAlreadyExistsException";
   $fault: "client";
@@ -5434,7 +5437,7 @@ export interface ReplicaAlreadyExistsException
 
 export namespace ReplicaAlreadyExistsException {
   export function isa(o: any): o is ReplicaAlreadyExistsException {
-    return _smithy.isa(o, "ReplicaAlreadyExistsException");
+    return __isa(o, "ReplicaAlreadyExistsException");
   }
 }
 
@@ -5493,7 +5496,7 @@ export interface ReplicaAutoScalingDescription {
 
 export namespace ReplicaAutoScalingDescription {
   export function isa(o: any): o is ReplicaAutoScalingDescription {
-    return _smithy.isa(o, "ReplicaAutoScalingDescription");
+    return __isa(o, "ReplicaAutoScalingDescription");
   }
 }
 
@@ -5524,7 +5527,7 @@ export interface ReplicaAutoScalingUpdate {
 
 export namespace ReplicaAutoScalingUpdate {
   export function isa(o: any): o is ReplicaAutoScalingUpdate {
-    return _smithy.isa(o, "ReplicaAutoScalingUpdate");
+    return __isa(o, "ReplicaAutoScalingUpdate");
   }
 }
 
@@ -5592,7 +5595,7 @@ export interface ReplicaDescription {
 
 export namespace ReplicaDescription {
   export function isa(o: any): o is ReplicaDescription {
-    return _smithy.isa(o, "ReplicaDescription");
+    return __isa(o, "ReplicaDescription");
   }
 }
 
@@ -5615,7 +5618,7 @@ export interface ReplicaGlobalSecondaryIndex {
 
 export namespace ReplicaGlobalSecondaryIndex {
   export function isa(o: any): o is ReplicaGlobalSecondaryIndex {
-    return _smithy.isa(o, "ReplicaGlobalSecondaryIndex");
+    return __isa(o, "ReplicaGlobalSecondaryIndex");
   }
 }
 
@@ -5669,7 +5672,7 @@ export namespace ReplicaGlobalSecondaryIndexAutoScalingDescription {
   export function isa(
     o: any
   ): o is ReplicaGlobalSecondaryIndexAutoScalingDescription {
-    return _smithy.isa(o, "ReplicaGlobalSecondaryIndexAutoScalingDescription");
+    return __isa(o, "ReplicaGlobalSecondaryIndexAutoScalingDescription");
   }
 }
 
@@ -5695,7 +5698,7 @@ export namespace ReplicaGlobalSecondaryIndexAutoScalingUpdate {
   export function isa(
     o: any
   ): o is ReplicaGlobalSecondaryIndexAutoScalingUpdate {
-    return _smithy.isa(o, "ReplicaGlobalSecondaryIndexAutoScalingUpdate");
+    return __isa(o, "ReplicaGlobalSecondaryIndexAutoScalingUpdate");
   }
 }
 
@@ -5717,7 +5720,7 @@ export interface ReplicaGlobalSecondaryIndexDescription {
 
 export namespace ReplicaGlobalSecondaryIndexDescription {
   export function isa(o: any): o is ReplicaGlobalSecondaryIndexDescription {
-    return _smithy.isa(o, "ReplicaGlobalSecondaryIndexDescription");
+    return __isa(o, "ReplicaGlobalSecondaryIndexDescription");
   }
 }
 
@@ -5781,7 +5784,7 @@ export namespace ReplicaGlobalSecondaryIndexSettingsDescription {
   export function isa(
     o: any
   ): o is ReplicaGlobalSecondaryIndexSettingsDescription {
-    return _smithy.isa(o, "ReplicaGlobalSecondaryIndexSettingsDescription");
+    return __isa(o, "ReplicaGlobalSecondaryIndexSettingsDescription");
   }
 }
 
@@ -5809,7 +5812,7 @@ export interface ReplicaGlobalSecondaryIndexSettingsUpdate {
 
 export namespace ReplicaGlobalSecondaryIndexSettingsUpdate {
   export function isa(o: any): o is ReplicaGlobalSecondaryIndexSettingsUpdate {
-    return _smithy.isa(o, "ReplicaGlobalSecondaryIndexSettingsUpdate");
+    return __isa(o, "ReplicaGlobalSecondaryIndexSettingsUpdate");
   }
 }
 
@@ -5817,7 +5820,7 @@ export namespace ReplicaGlobalSecondaryIndexSettingsUpdate {
  * <p>The specified replica is no longer part of the global table.</p>
  */
 export interface ReplicaNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ReplicaNotFoundException";
   $fault: "client";
@@ -5826,7 +5829,7 @@ export interface ReplicaNotFoundException
 
 export namespace ReplicaNotFoundException {
   export function isa(o: any): o is ReplicaNotFoundException {
-    return _smithy.isa(o, "ReplicaNotFoundException");
+    return __isa(o, "ReplicaNotFoundException");
   }
 }
 
@@ -5903,7 +5906,7 @@ export interface ReplicaSettingsDescription {
 
 export namespace ReplicaSettingsDescription {
   export function isa(o: any): o is ReplicaSettingsDescription {
-    return _smithy.isa(o, "ReplicaSettingsDescription");
+    return __isa(o, "ReplicaSettingsDescription");
   }
 }
 
@@ -5940,7 +5943,7 @@ export interface ReplicaSettingsUpdate {
 
 export namespace ReplicaSettingsUpdate {
   export function isa(o: any): o is ReplicaSettingsUpdate {
-    return _smithy.isa(o, "ReplicaSettingsUpdate");
+    return __isa(o, "ReplicaSettingsUpdate");
   }
 }
 
@@ -5980,7 +5983,7 @@ export interface ReplicaUpdate {
 
 export namespace ReplicaUpdate {
   export function isa(o: any): o is ReplicaUpdate {
-    return _smithy.isa(o, "ReplicaUpdate");
+    return __isa(o, "ReplicaUpdate");
   }
 }
 
@@ -6023,7 +6026,7 @@ export interface ReplicationGroupUpdate {
 
 export namespace ReplicationGroupUpdate {
   export function isa(o: any): o is ReplicationGroupUpdate {
-    return _smithy.isa(o, "ReplicationGroupUpdate");
+    return __isa(o, "ReplicationGroupUpdate");
   }
 }
 
@@ -6031,7 +6034,7 @@ export namespace ReplicationGroupUpdate {
  * <p>Throughput exceeds the current throughput limit for your account. Please contact AWS Support at <a href="https://aws.amazon.com/support">AWS Support</a> to request a limit increase.</p>
  */
 export interface RequestLimitExceeded
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "RequestLimitExceeded";
   $fault: "client";
@@ -6040,7 +6043,7 @@ export interface RequestLimitExceeded
 
 export namespace RequestLimitExceeded {
   export function isa(o: any): o is RequestLimitExceeded {
-    return _smithy.isa(o, "RequestLimitExceeded");
+    return __isa(o, "RequestLimitExceeded");
   }
 }
 
@@ -6050,7 +6053,7 @@ export namespace RequestLimitExceeded {
  *       state.</p>
  */
 export interface ResourceInUseException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceInUseException";
   $fault: "client";
@@ -6062,7 +6065,7 @@ export interface ResourceInUseException
 
 export namespace ResourceInUseException {
   export function isa(o: any): o is ResourceInUseException {
-    return _smithy.isa(o, "ResourceInUseException");
+    return __isa(o, "ResourceInUseException");
   }
 }
 
@@ -6071,7 +6074,7 @@ export namespace ResourceInUseException {
  *       correctly, or its status might not be <code>ACTIVE</code>.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -6083,7 +6086,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -6115,7 +6118,7 @@ export interface RestoreSummary {
 
 export namespace RestoreSummary {
   export function isa(o: any): o is RestoreSummary {
-    return _smithy.isa(o, "RestoreSummary");
+    return __isa(o, "RestoreSummary");
   }
 }
 
@@ -6158,7 +6161,7 @@ export interface RestoreTableFromBackupInput {
 
 export namespace RestoreTableFromBackupInput {
   export function isa(o: any): o is RestoreTableFromBackupInput {
-    return _smithy.isa(o, "RestoreTableFromBackupInput");
+    return __isa(o, "RestoreTableFromBackupInput");
   }
 }
 
@@ -6172,7 +6175,7 @@ export interface RestoreTableFromBackupOutput extends $MetadataBearer {
 
 export namespace RestoreTableFromBackupOutput {
   export function isa(o: any): o is RestoreTableFromBackupOutput {
-    return _smithy.isa(o, "RestoreTableFromBackupOutput");
+    return __isa(o, "RestoreTableFromBackupOutput");
   }
 }
 
@@ -6226,7 +6229,7 @@ export interface RestoreTableToPointInTimeInput {
 
 export namespace RestoreTableToPointInTimeInput {
   export function isa(o: any): o is RestoreTableToPointInTimeInput {
-    return _smithy.isa(o, "RestoreTableToPointInTimeInput");
+    return __isa(o, "RestoreTableToPointInTimeInput");
   }
 }
 
@@ -6240,7 +6243,7 @@ export interface RestoreTableToPointInTimeOutput extends $MetadataBearer {
 
 export namespace RestoreTableToPointInTimeOutput {
   export function isa(o: any): o is RestoreTableToPointInTimeOutput {
-    return _smithy.isa(o, "RestoreTableToPointInTimeOutput");
+    return __isa(o, "RestoreTableToPointInTimeOutput");
   }
 }
 
@@ -6307,7 +6310,7 @@ export interface SSEDescription {
 
 export namespace SSEDescription {
   export function isa(o: any): o is SSEDescription {
-    return _smithy.isa(o, "SSEDescription");
+    return __isa(o, "SSEDescription");
   }
 }
 
@@ -6347,7 +6350,7 @@ export interface SSESpecification {
 
 export namespace SSESpecification {
   export function isa(o: any): o is SSESpecification {
-    return _smithy.isa(o, "SSESpecification");
+    return __isa(o, "SSESpecification");
   }
 }
 
@@ -6634,7 +6637,7 @@ export interface ScanInput {
 
 export namespace ScanInput {
   export function isa(o: any): o is ScanInput {
-    return _smithy.isa(o, "ScanInput");
+    return __isa(o, "ScanInput");
   }
 }
 
@@ -6693,7 +6696,7 @@ export interface ScanOutput extends $MetadataBearer {
 
 export namespace ScanOutput {
   export function isa(o: any): o is ScanOutput {
-    return _smithy.isa(o, "ScanOutput");
+    return __isa(o, "ScanOutput");
   }
 }
 
@@ -6767,7 +6770,7 @@ export interface SourceTableDetails {
 
 export namespace SourceTableDetails {
   export function isa(o: any): o is SourceTableDetails {
-    return _smithy.isa(o, "SourceTableDetails");
+    return __isa(o, "SourceTableDetails");
   }
 }
 
@@ -6806,7 +6809,7 @@ export interface SourceTableFeatureDetails {
 
 export namespace SourceTableFeatureDetails {
   export function isa(o: any): o is SourceTableFeatureDetails {
-    return _smithy.isa(o, "SourceTableFeatureDetails");
+    return __isa(o, "SourceTableFeatureDetails");
   }
 }
 
@@ -6852,7 +6855,7 @@ export interface StreamSpecification {
 
 export namespace StreamSpecification {
   export function isa(o: any): o is StreamSpecification {
-    return _smithy.isa(o, "StreamSpecification");
+    return __isa(o, "StreamSpecification");
   }
 }
 
@@ -6866,7 +6869,7 @@ export type StreamViewType =
  * <p>A target table with the specified name already exists. </p>
  */
 export interface TableAlreadyExistsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TableAlreadyExistsException";
   $fault: "client";
@@ -6875,7 +6878,7 @@ export interface TableAlreadyExistsException
 
 export namespace TableAlreadyExistsException {
   export function isa(o: any): o is TableAlreadyExistsException {
-    return _smithy.isa(o, "TableAlreadyExistsException");
+    return __isa(o, "TableAlreadyExistsException");
   }
 }
 
@@ -6920,7 +6923,7 @@ export interface TableAutoScalingDescription {
 
 export namespace TableAutoScalingDescription {
   export function isa(o: any): o is TableAutoScalingDescription {
-    return _smithy.isa(o, "TableAutoScalingDescription");
+    return __isa(o, "TableAutoScalingDescription");
   }
 }
 
@@ -7303,7 +7306,7 @@ export interface TableDescription {
 
 export namespace TableDescription {
   export function isa(o: any): o is TableDescription {
-    return _smithy.isa(o, "TableDescription");
+    return __isa(o, "TableDescription");
   }
 }
 
@@ -7311,7 +7314,7 @@ export namespace TableDescription {
  * <p>A target table with the specified name is either being created or deleted. </p>
  */
 export interface TableInUseException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TableInUseException";
   $fault: "client";
@@ -7320,7 +7323,7 @@ export interface TableInUseException
 
 export namespace TableInUseException {
   export function isa(o: any): o is TableInUseException {
-    return _smithy.isa(o, "TableInUseException");
+    return __isa(o, "TableInUseException");
   }
 }
 
@@ -7328,7 +7331,7 @@ export namespace TableInUseException {
  * <p>A source table with the name <code>TableName</code> does not currently exist within the subscriber's account.</p>
  */
 export interface TableNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TableNotFoundException";
   $fault: "client";
@@ -7337,7 +7340,7 @@ export interface TableNotFoundException
 
 export namespace TableNotFoundException {
   export function isa(o: any): o is TableNotFoundException {
-    return _smithy.isa(o, "TableNotFoundException");
+    return __isa(o, "TableNotFoundException");
   }
 }
 
@@ -7378,7 +7381,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -7397,7 +7400,7 @@ export interface TagResourceInput {
 
 export namespace TagResourceInput {
   export function isa(o: any): o is TagResourceInput {
-    return _smithy.isa(o, "TagResourceInput");
+    return __isa(o, "TagResourceInput");
   }
 }
 
@@ -7419,7 +7422,7 @@ export interface TimeToLiveDescription {
 
 export namespace TimeToLiveDescription {
   export function isa(o: any): o is TimeToLiveDescription {
-    return _smithy.isa(o, "TimeToLiveDescription");
+    return __isa(o, "TimeToLiveDescription");
   }
 }
 
@@ -7443,7 +7446,7 @@ export interface TimeToLiveSpecification {
 
 export namespace TimeToLiveSpecification {
   export function isa(o: any): o is TimeToLiveSpecification {
-    return _smithy.isa(o, "TimeToLiveSpecification");
+    return __isa(o, "TimeToLiveSpecification");
   }
 }
 
@@ -7468,7 +7471,7 @@ export interface TransactGetItem {
 
 export namespace TransactGetItem {
   export function isa(o: any): o is TransactGetItem {
-    return _smithy.isa(o, "TransactGetItem");
+    return __isa(o, "TransactGetItem");
   }
 }
 
@@ -7490,7 +7493,7 @@ export interface TransactGetItemsInput {
 
 export namespace TransactGetItemsInput {
   export function isa(o: any): o is TransactGetItemsInput {
-    return _smithy.isa(o, "TransactGetItemsInput");
+    return __isa(o, "TransactGetItemsInput");
   }
 }
 
@@ -7520,7 +7523,7 @@ export interface TransactGetItemsOutput extends $MetadataBearer {
 
 export namespace TransactGetItemsOutput {
   export function isa(o: any): o is TransactGetItemsOutput {
-    return _smithy.isa(o, "TransactGetItemsOutput");
+    return __isa(o, "TransactGetItemsOutput");
   }
 }
 
@@ -7552,7 +7555,7 @@ export interface TransactWriteItem {
 
 export namespace TransactWriteItem {
   export function isa(o: any): o is TransactWriteItem {
-    return _smithy.isa(o, "TransactWriteItem");
+    return __isa(o, "TransactWriteItem");
   }
 }
 
@@ -7619,7 +7622,7 @@ export interface TransactWriteItemsInput {
 
 export namespace TransactWriteItemsInput {
   export function isa(o: any): o is TransactWriteItemsInput {
-    return _smithy.isa(o, "TransactWriteItemsInput");
+    return __isa(o, "TransactWriteItemsInput");
   }
 }
 
@@ -7644,7 +7647,7 @@ export interface TransactWriteItemsOutput extends $MetadataBearer {
 
 export namespace TransactWriteItemsOutput {
   export function isa(o: any): o is TransactWriteItemsOutput {
-    return _smithy.isa(o, "TransactWriteItemsOutput");
+    return __isa(o, "TransactWriteItemsOutput");
   }
 }
 
@@ -7854,7 +7857,7 @@ export namespace TransactWriteItemsOutput {
  *          </ul>
  */
 export interface TransactionCanceledException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TransactionCanceledException";
   $fault: "client";
@@ -7868,7 +7871,7 @@ export interface TransactionCanceledException
 
 export namespace TransactionCanceledException {
   export function isa(o: any): o is TransactionCanceledException {
-    return _smithy.isa(o, "TransactionCanceledException");
+    return __isa(o, "TransactionCanceledException");
   }
 }
 
@@ -7876,7 +7879,7 @@ export namespace TransactionCanceledException {
  * <p>Operation was rejected because there is an ongoing transaction for the item.</p>
  */
 export interface TransactionConflictException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TransactionConflictException";
   $fault: "client";
@@ -7885,7 +7888,7 @@ export interface TransactionConflictException
 
 export namespace TransactionConflictException {
   export function isa(o: any): o is TransactionConflictException {
-    return _smithy.isa(o, "TransactionConflictException");
+    return __isa(o, "TransactionConflictException");
   }
 }
 
@@ -7893,7 +7896,7 @@ export namespace TransactionConflictException {
  * <p>The transaction with the given request token is already in progress.</p>
  */
 export interface TransactionInProgressException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TransactionInProgressException";
   $fault: "client";
@@ -7902,7 +7905,7 @@ export interface TransactionInProgressException
 
 export namespace TransactionInProgressException {
   export function isa(o: any): o is TransactionInProgressException {
-    return _smithy.isa(o, "TransactionInProgressException");
+    return __isa(o, "TransactionInProgressException");
   }
 }
 
@@ -7923,7 +7926,7 @@ export interface UntagResourceInput {
 
 export namespace UntagResourceInput {
   export function isa(o: any): o is UntagResourceInput {
-    return _smithy.isa(o, "UntagResourceInput");
+    return __isa(o, "UntagResourceInput");
   }
 }
 
@@ -7978,7 +7981,7 @@ export interface Update {
 
 export namespace Update {
   export function isa(o: any): o is Update {
-    return _smithy.isa(o, "Update");
+    return __isa(o, "Update");
   }
 }
 
@@ -7999,7 +8002,7 @@ export interface UpdateContinuousBackupsInput {
 
 export namespace UpdateContinuousBackupsInput {
   export function isa(o: any): o is UpdateContinuousBackupsInput {
-    return _smithy.isa(o, "UpdateContinuousBackupsInput");
+    return __isa(o, "UpdateContinuousBackupsInput");
   }
 }
 
@@ -8013,7 +8016,7 @@ export interface UpdateContinuousBackupsOutput extends $MetadataBearer {
 
 export namespace UpdateContinuousBackupsOutput {
   export function isa(o: any): o is UpdateContinuousBackupsOutput {
-    return _smithy.isa(o, "UpdateContinuousBackupsOutput");
+    return __isa(o, "UpdateContinuousBackupsOutput");
   }
 }
 
@@ -8037,7 +8040,7 @@ export interface UpdateContributorInsightsInput {
 
 export namespace UpdateContributorInsightsInput {
   export function isa(o: any): o is UpdateContributorInsightsInput {
-    return _smithy.isa(o, "UpdateContributorInsightsInput");
+    return __isa(o, "UpdateContributorInsightsInput");
   }
 }
 
@@ -8061,7 +8064,7 @@ export interface UpdateContributorInsightsOutput extends $MetadataBearer {
 
 export namespace UpdateContributorInsightsOutput {
   export function isa(o: any): o is UpdateContributorInsightsOutput {
-    return _smithy.isa(o, "UpdateContributorInsightsOutput");
+    return __isa(o, "UpdateContributorInsightsOutput");
   }
 }
 
@@ -8084,7 +8087,7 @@ export interface UpdateGlobalSecondaryIndexAction {
 
 export namespace UpdateGlobalSecondaryIndexAction {
   export function isa(o: any): o is UpdateGlobalSecondaryIndexAction {
-    return _smithy.isa(o, "UpdateGlobalSecondaryIndexAction");
+    return __isa(o, "UpdateGlobalSecondaryIndexAction");
   }
 }
 
@@ -8103,7 +8106,7 @@ export interface UpdateGlobalTableInput {
 
 export namespace UpdateGlobalTableInput {
   export function isa(o: any): o is UpdateGlobalTableInput {
-    return _smithy.isa(o, "UpdateGlobalTableInput");
+    return __isa(o, "UpdateGlobalTableInput");
   }
 }
 
@@ -8117,7 +8120,7 @@ export interface UpdateGlobalTableOutput extends $MetadataBearer {
 
 export namespace UpdateGlobalTableOutput {
   export function isa(o: any): o is UpdateGlobalTableOutput {
-    return _smithy.isa(o, "UpdateGlobalTableOutput");
+    return __isa(o, "UpdateGlobalTableOutput");
   }
 }
 
@@ -8171,7 +8174,7 @@ export interface UpdateGlobalTableSettingsInput {
 
 export namespace UpdateGlobalTableSettingsInput {
   export function isa(o: any): o is UpdateGlobalTableSettingsInput {
-    return _smithy.isa(o, "UpdateGlobalTableSettingsInput");
+    return __isa(o, "UpdateGlobalTableSettingsInput");
   }
 }
 
@@ -8190,7 +8193,7 @@ export interface UpdateGlobalTableSettingsOutput extends $MetadataBearer {
 
 export namespace UpdateGlobalTableSettingsOutput {
   export function isa(o: any): o is UpdateGlobalTableSettingsOutput {
-    return _smithy.isa(o, "UpdateGlobalTableSettingsOutput");
+    return __isa(o, "UpdateGlobalTableSettingsOutput");
   }
 }
 
@@ -8479,7 +8482,7 @@ export interface UpdateItemInput {
 
 export namespace UpdateItemInput {
   export function isa(o: any): o is UpdateItemInput {
-    return _smithy.isa(o, "UpdateItemInput");
+    return __isa(o, "UpdateItemInput");
   }
 }
 
@@ -8538,7 +8541,7 @@ export interface UpdateItemOutput extends $MetadataBearer {
 
 export namespace UpdateItemOutput {
   export function isa(o: any): o is UpdateItemOutput {
-    return _smithy.isa(o, "UpdateItemOutput");
+    return __isa(o, "UpdateItemOutput");
   }
 }
 
@@ -8574,7 +8577,7 @@ export interface UpdateReplicationGroupMemberAction {
 
 export namespace UpdateReplicationGroupMemberAction {
   export function isa(o: any): o is UpdateReplicationGroupMemberAction {
-    return _smithy.isa(o, "UpdateReplicationGroupMemberAction");
+    return __isa(o, "UpdateReplicationGroupMemberAction");
   }
 }
 
@@ -8665,7 +8668,7 @@ export interface UpdateTableInput {
 
 export namespace UpdateTableInput {
   export function isa(o: any): o is UpdateTableInput {
-    return _smithy.isa(o, "UpdateTableInput");
+    return __isa(o, "UpdateTableInput");
   }
 }
 
@@ -8682,7 +8685,7 @@ export interface UpdateTableOutput extends $MetadataBearer {
 
 export namespace UpdateTableOutput {
   export function isa(o: any): o is UpdateTableOutput {
-    return _smithy.isa(o, "UpdateTableOutput");
+    return __isa(o, "UpdateTableOutput");
   }
 }
 
@@ -8714,7 +8717,7 @@ export interface UpdateTableReplicaAutoScalingInput {
 
 export namespace UpdateTableReplicaAutoScalingInput {
   export function isa(o: any): o is UpdateTableReplicaAutoScalingInput {
-    return _smithy.isa(o, "UpdateTableReplicaAutoScalingInput");
+    return __isa(o, "UpdateTableReplicaAutoScalingInput");
   }
 }
 
@@ -8728,7 +8731,7 @@ export interface UpdateTableReplicaAutoScalingOutput extends $MetadataBearer {
 
 export namespace UpdateTableReplicaAutoScalingOutput {
   export function isa(o: any): o is UpdateTableReplicaAutoScalingOutput {
-    return _smithy.isa(o, "UpdateTableReplicaAutoScalingOutput");
+    return __isa(o, "UpdateTableReplicaAutoScalingOutput");
   }
 }
 
@@ -8750,7 +8753,7 @@ export interface UpdateTimeToLiveInput {
 
 export namespace UpdateTimeToLiveInput {
   export function isa(o: any): o is UpdateTimeToLiveInput {
-    return _smithy.isa(o, "UpdateTimeToLiveInput");
+    return __isa(o, "UpdateTimeToLiveInput");
   }
 }
 
@@ -8764,7 +8767,7 @@ export interface UpdateTimeToLiveOutput extends $MetadataBearer {
 
 export namespace UpdateTimeToLiveOutput {
   export function isa(o: any): o is UpdateTimeToLiveOutput {
-    return _smithy.isa(o, "UpdateTimeToLiveOutput");
+    return __isa(o, "UpdateTimeToLiveOutput");
   }
 }
 
@@ -8789,6 +8792,6 @@ export interface WriteRequest {
 
 export namespace WriteRequest {
   export function isa(o: any): o is WriteRequest {
-    return _smithy.isa(o, "WriteRequest");
+    return __isa(o, "WriteRequest");
   }
 }

--- a/clients/client-dynamodb/protocols/Aws_json1_0.ts
+++ b/clients/client-dynamodb/protocols/Aws_json1_0.ts
@@ -3207,6 +3207,7 @@ export async function deserializeAws_json1_0TagResourceCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_0TagResourceCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: TagResourceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -3485,6 +3486,7 @@ export async function deserializeAws_json1_0UntagResourceCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_0UntagResourceCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: UntagResourceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };

--- a/clients/client-ebs/models/index.ts
+++ b/clients/client-ebs/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -19,7 +22,7 @@ export interface Block {
 
 export namespace Block {
   export function isa(o: any): o is Block {
-    return _smithy.isa(o, "Block");
+    return __isa(o, "Block");
   }
 }
 
@@ -50,7 +53,7 @@ export interface ChangedBlock {
 
 export namespace ChangedBlock {
   export function isa(o: any): o is ChangedBlock {
-    return _smithy.isa(o, "ChangedBlock");
+    return __isa(o, "ChangedBlock");
   }
 }
 
@@ -86,7 +89,7 @@ export interface GetSnapshotBlockRequest {
 
 export namespace GetSnapshotBlockRequest {
   export function isa(o: any): o is GetSnapshotBlockRequest {
-    return _smithy.isa(o, "GetSnapshotBlockRequest");
+    return __isa(o, "GetSnapshotBlockRequest");
   }
 }
 
@@ -115,7 +118,7 @@ export interface GetSnapshotBlockResponse extends $MetadataBearer {
 
 export namespace GetSnapshotBlockResponse {
   export function isa(o: any): o is GetSnapshotBlockResponse {
-    return _smithy.isa(o, "GetSnapshotBlockResponse");
+    return __isa(o, "GetSnapshotBlockResponse");
   }
 }
 
@@ -153,7 +156,7 @@ export interface ListChangedBlocksRequest {
 
 export namespace ListChangedBlocksRequest {
   export function isa(o: any): o is ListChangedBlocksRequest {
-    return _smithy.isa(o, "ListChangedBlocksRequest");
+    return __isa(o, "ListChangedBlocksRequest");
   }
 }
 
@@ -188,7 +191,7 @@ export interface ListChangedBlocksResponse extends $MetadataBearer {
 
 export namespace ListChangedBlocksResponse {
   export function isa(o: any): o is ListChangedBlocksResponse {
-    return _smithy.isa(o, "ListChangedBlocksResponse");
+    return __isa(o, "ListChangedBlocksResponse");
   }
 }
 
@@ -218,7 +221,7 @@ export interface ListSnapshotBlocksRequest {
 
 export namespace ListSnapshotBlocksRequest {
   export function isa(o: any): o is ListSnapshotBlocksRequest {
-    return _smithy.isa(o, "ListSnapshotBlocksRequest");
+    return __isa(o, "ListSnapshotBlocksRequest");
   }
 }
 
@@ -253,7 +256,7 @@ export interface ListSnapshotBlocksResponse extends $MetadataBearer {
 
 export namespace ListSnapshotBlocksResponse {
   export function isa(o: any): o is ListSnapshotBlocksResponse {
-    return _smithy.isa(o, "ListSnapshotBlocksResponse");
+    return __isa(o, "ListSnapshotBlocksResponse");
   }
 }
 
@@ -261,7 +264,7 @@ export namespace ListSnapshotBlocksResponse {
  * <p>The specified resource does not exist.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -270,7 +273,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -278,7 +281,7 @@ export namespace ResourceNotFoundException {
  * <p>The input fails to satisfy the constraints of the EBS direct APIs.</p>
  */
 export interface ValidationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ValidationException";
   $fault: "client";
@@ -291,7 +294,7 @@ export interface ValidationException
 
 export namespace ValidationException {
   export function isa(o: any): o is ValidationException {
-    return _smithy.isa(o, "ValidationException");
+    return __isa(o, "ValidationException");
   }
 }
 

--- a/clients/client-ebs/protocols/Aws_restJson1_1.ts
+++ b/clients/client-ebs/protocols/Aws_restJson1_1.ts
@@ -20,7 +20,10 @@ import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  extendedEncodeURIComponent as __extendedEncodeURIComponent
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -42,26 +45,28 @@ export async function serializeAws_restJson1_1GetSnapshotBlockCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{BlockIndex}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: BlockIndex.");
   }
   if (input.SnapshotId !== undefined) {
-    const labelValue: string = input.SnapshotId.toString();
+    const labelValue: string = input.SnapshotId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: SnapshotId.");
     }
     resolvedPath = resolvedPath.replace(
       "{SnapshotId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: SnapshotId.");
   }
   const query: any = {};
   if (input.BlockToken !== undefined) {
-    query["blockToken"] = input.BlockToken.toString();
+    query[
+      __extendedEncodeURIComponent("blockToken")
+    ] = __extendedEncodeURIComponent(input.BlockToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -81,7 +86,7 @@ export async function serializeAws_restJson1_1ListChangedBlocksCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/snapshots/{SecondSnapshotId}/changedblocks";
   if (input.SecondSnapshotId !== undefined) {
-    const labelValue: string = input.SecondSnapshotId.toString();
+    const labelValue: string = input.SecondSnapshotId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: SecondSnapshotId."
@@ -89,7 +94,7 @@ export async function serializeAws_restJson1_1ListChangedBlocksCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{SecondSnapshotId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -98,16 +103,24 @@ export async function serializeAws_restJson1_1ListChangedBlocksCommand(
   }
   const query: any = {};
   if (input.FirstSnapshotId !== undefined) {
-    query["firstSnapshotId"] = input.FirstSnapshotId.toString();
+    query[
+      __extendedEncodeURIComponent("firstSnapshotId")
+    ] = __extendedEncodeURIComponent(input.FirstSnapshotId);
   }
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["pageToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("pageToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   if (input.StartingBlockIndex !== undefined) {
-    query["startingBlockIndex"] = input.StartingBlockIndex.toString();
+    query[
+      __extendedEncodeURIComponent("startingBlockIndex")
+    ] = __extendedEncodeURIComponent(input.StartingBlockIndex.toString());
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -127,26 +140,32 @@ export async function serializeAws_restJson1_1ListSnapshotBlocksCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/snapshots/{SnapshotId}/blocks";
   if (input.SnapshotId !== undefined) {
-    const labelValue: string = input.SnapshotId.toString();
+    const labelValue: string = input.SnapshotId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: SnapshotId.");
     }
     resolvedPath = resolvedPath.replace(
       "{SnapshotId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: SnapshotId.");
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["pageToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("pageToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   if (input.StartingBlockIndex !== undefined) {
-    query["startingBlockIndex"] = input.StartingBlockIndex.toString();
+    query[
+      __extendedEncodeURIComponent("startingBlockIndex")
+    ] = __extendedEncodeURIComponent(input.StartingBlockIndex.toString());
   }
   return new __HttpRequest({
     ...context.endpoint,

--- a/clients/client-ec2-instance-connect/models/index.ts
+++ b/clients/client-ec2-instance-connect/models/index.ts
@@ -1,12 +1,13 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
  * <p>Indicates that either your AWS credentials are invalid or you do not have access to the EC2 instance.</p>
  */
-export interface AuthException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface AuthException extends __SmithyException, $MetadataBearer {
   name: "AuthException";
   $fault: "client";
   Message?: string;
@@ -14,7 +15,7 @@ export interface AuthException
 
 export namespace AuthException {
   export function isa(o: any): o is AuthException {
-    return _smithy.isa(o, "AuthException");
+    return __isa(o, "AuthException");
   }
 }
 
@@ -22,7 +23,7 @@ export namespace AuthException {
  * <p>Indicates that the instance requested was not found in the given zone.  Check that you have provided a valid instance ID and the correct zone.</p>
  */
 export interface EC2InstanceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "EC2InstanceNotFoundException";
   $fault: "client";
@@ -31,7 +32,7 @@ export interface EC2InstanceNotFoundException
 
 export namespace EC2InstanceNotFoundException {
   export function isa(o: any): o is EC2InstanceNotFoundException {
-    return _smithy.isa(o, "EC2InstanceNotFoundException");
+    return __isa(o, "EC2InstanceNotFoundException");
   }
 }
 
@@ -39,7 +40,7 @@ export namespace EC2InstanceNotFoundException {
  * <p>Indicates that you provided bad input.  Ensure you have a valid instance ID, the correct zone, and a valid SSH public key.</p>
  */
 export interface InvalidArgsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidArgsException";
   $fault: "client";
@@ -48,7 +49,7 @@ export interface InvalidArgsException
 
 export namespace InvalidArgsException {
   export function isa(o: any): o is InvalidArgsException {
-    return _smithy.isa(o, "InvalidArgsException");
+    return __isa(o, "InvalidArgsException");
   }
 }
 
@@ -77,7 +78,7 @@ export interface SendSSHPublicKeyRequest {
 
 export namespace SendSSHPublicKeyRequest {
   export function isa(o: any): o is SendSSHPublicKeyRequest {
-    return _smithy.isa(o, "SendSSHPublicKeyRequest");
+    return __isa(o, "SendSSHPublicKeyRequest");
   }
 }
 
@@ -96,16 +97,14 @@ export interface SendSSHPublicKeyResponse extends $MetadataBearer {
 
 export namespace SendSSHPublicKeyResponse {
   export function isa(o: any): o is SendSSHPublicKeyResponse {
-    return _smithy.isa(o, "SendSSHPublicKeyResponse");
+    return __isa(o, "SendSSHPublicKeyResponse");
   }
 }
 
 /**
  * <p>Indicates that the service encountered an error.  Follow the message's instructions and try again.</p>
  */
-export interface ServiceException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface ServiceException extends __SmithyException, $MetadataBearer {
   name: "ServiceException";
   $fault: "server";
   Message?: string;
@@ -113,7 +112,7 @@ export interface ServiceException
 
 export namespace ServiceException {
   export function isa(o: any): o is ServiceException {
-    return _smithy.isa(o, "ServiceException");
+    return __isa(o, "ServiceException");
   }
 }
 
@@ -121,7 +120,7 @@ export namespace ServiceException {
  * <p>Indicates you have been making requests too frequently and have been throttled.  Wait for a while and try again.  If higher call volume is warranted contact AWS Support.</p>
  */
 export interface ThrottlingException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ThrottlingException";
   $fault: "client";
@@ -130,6 +129,6 @@ export interface ThrottlingException
 
 export namespace ThrottlingException {
   export function isa(o: any): o is ThrottlingException {
-    return _smithy.isa(o, "ThrottlingException");
+    return __isa(o, "ThrottlingException");
   }
 }

--- a/clients/client-ec2/models/index.ts
+++ b/clients/client-ec2/models/index.ts
@@ -1,4 +1,4 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import { isa as __isa } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -30,7 +30,7 @@ export namespace AcceptReservedInstancesExchangeQuoteRequest {
   export function isa(
     o: any
   ): o is AcceptReservedInstancesExchangeQuoteRequest {
-    return _smithy.isa(o, "AcceptReservedInstancesExchangeQuoteRequest");
+    return __isa(o, "AcceptReservedInstancesExchangeQuoteRequest");
   }
 }
 
@@ -48,7 +48,7 @@ export interface AcceptReservedInstancesExchangeQuoteResult
 
 export namespace AcceptReservedInstancesExchangeQuoteResult {
   export function isa(o: any): o is AcceptReservedInstancesExchangeQuoteResult {
-    return _smithy.isa(o, "AcceptReservedInstancesExchangeQuoteResult");
+    return __isa(o, "AcceptReservedInstancesExchangeQuoteResult");
   }
 }
 
@@ -71,7 +71,7 @@ export namespace AcceptTransitGatewayPeeringAttachmentRequest {
   export function isa(
     o: any
   ): o is AcceptTransitGatewayPeeringAttachmentRequest {
-    return _smithy.isa(o, "AcceptTransitGatewayPeeringAttachmentRequest");
+    return __isa(o, "AcceptTransitGatewayPeeringAttachmentRequest");
   }
 }
 
@@ -88,7 +88,7 @@ export namespace AcceptTransitGatewayPeeringAttachmentResult {
   export function isa(
     o: any
   ): o is AcceptTransitGatewayPeeringAttachmentResult {
-    return _smithy.isa(o, "AcceptTransitGatewayPeeringAttachmentResult");
+    return __isa(o, "AcceptTransitGatewayPeeringAttachmentResult");
   }
 }
 
@@ -109,7 +109,7 @@ export interface AcceptTransitGatewayVpcAttachmentRequest {
 
 export namespace AcceptTransitGatewayVpcAttachmentRequest {
   export function isa(o: any): o is AcceptTransitGatewayVpcAttachmentRequest {
-    return _smithy.isa(o, "AcceptTransitGatewayVpcAttachmentRequest");
+    return __isa(o, "AcceptTransitGatewayVpcAttachmentRequest");
   }
 }
 
@@ -124,7 +124,7 @@ export interface AcceptTransitGatewayVpcAttachmentResult
 
 export namespace AcceptTransitGatewayVpcAttachmentResult {
   export function isa(o: any): o is AcceptTransitGatewayVpcAttachmentResult {
-    return _smithy.isa(o, "AcceptTransitGatewayVpcAttachmentResult");
+    return __isa(o, "AcceptTransitGatewayVpcAttachmentResult");
   }
 }
 
@@ -150,7 +150,7 @@ export interface AcceptVpcEndpointConnectionsRequest {
 
 export namespace AcceptVpcEndpointConnectionsRequest {
   export function isa(o: any): o is AcceptVpcEndpointConnectionsRequest {
-    return _smithy.isa(o, "AcceptVpcEndpointConnectionsRequest");
+    return __isa(o, "AcceptVpcEndpointConnectionsRequest");
   }
 }
 
@@ -165,7 +165,7 @@ export interface AcceptVpcEndpointConnectionsResult extends $MetadataBearer {
 
 export namespace AcceptVpcEndpointConnectionsResult {
   export function isa(o: any): o is AcceptVpcEndpointConnectionsResult {
-    return _smithy.isa(o, "AcceptVpcEndpointConnectionsResult");
+    return __isa(o, "AcceptVpcEndpointConnectionsResult");
   }
 }
 
@@ -187,7 +187,7 @@ export interface AcceptVpcPeeringConnectionRequest {
 
 export namespace AcceptVpcPeeringConnectionRequest {
   export function isa(o: any): o is AcceptVpcPeeringConnectionRequest {
-    return _smithy.isa(o, "AcceptVpcPeeringConnectionRequest");
+    return __isa(o, "AcceptVpcPeeringConnectionRequest");
   }
 }
 
@@ -201,7 +201,7 @@ export interface AcceptVpcPeeringConnectionResult extends $MetadataBearer {
 
 export namespace AcceptVpcPeeringConnectionResult {
   export function isa(o: any): o is AcceptVpcPeeringConnectionResult {
-    return _smithy.isa(o, "AcceptVpcPeeringConnectionResult");
+    return __isa(o, "AcceptVpcPeeringConnectionResult");
   }
 }
 
@@ -223,7 +223,7 @@ export interface AccountAttribute {
 
 export namespace AccountAttribute {
   export function isa(o: any): o is AccountAttribute {
-    return _smithy.isa(o, "AccountAttribute");
+    return __isa(o, "AccountAttribute");
   }
 }
 
@@ -242,7 +242,7 @@ export interface AccountAttributeValue {
 
 export namespace AccountAttributeValue {
   export function isa(o: any): o is AccountAttributeValue {
-    return _smithy.isa(o, "AccountAttributeValue");
+    return __isa(o, "AccountAttributeValue");
   }
 }
 
@@ -276,7 +276,7 @@ export interface ActiveInstance {
 
 export namespace ActiveInstance {
   export function isa(o: any): o is ActiveInstance {
-    return _smithy.isa(o, "ActiveInstance");
+    return __isa(o, "ActiveInstance");
   }
 }
 
@@ -361,7 +361,7 @@ export interface Address {
 
 export namespace Address {
   export function isa(o: any): o is Address {
-    return _smithy.isa(o, "Address");
+    return __isa(o, "Address");
   }
 }
 
@@ -383,7 +383,7 @@ export interface AdvertiseByoipCidrRequest {
 
 export namespace AdvertiseByoipCidrRequest {
   export function isa(o: any): o is AdvertiseByoipCidrRequest {
-    return _smithy.isa(o, "AdvertiseByoipCidrRequest");
+    return __isa(o, "AdvertiseByoipCidrRequest");
   }
 }
 
@@ -397,7 +397,7 @@ export interface AdvertiseByoipCidrResult extends $MetadataBearer {
 
 export namespace AdvertiseByoipCidrResult {
   export function isa(o: any): o is AdvertiseByoipCidrResult {
-    return _smithy.isa(o, "AdvertiseByoipCidrResult");
+    return __isa(o, "AdvertiseByoipCidrResult");
   }
 }
 
@@ -449,7 +449,7 @@ export interface AllocateAddressRequest {
 
 export namespace AllocateAddressRequest {
   export function isa(o: any): o is AllocateAddressRequest {
-    return _smithy.isa(o, "AllocateAddressRequest");
+    return __isa(o, "AllocateAddressRequest");
   }
 }
 
@@ -494,7 +494,7 @@ export interface AllocateAddressResult extends $MetadataBearer {
 
 export namespace AllocateAddressResult {
   export function isa(o: any): o is AllocateAddressResult {
-    return _smithy.isa(o, "AllocateAddressResult");
+    return __isa(o, "AllocateAddressResult");
   }
 }
 
@@ -570,7 +570,7 @@ export interface AllocateHostsRequest {
 
 export namespace AllocateHostsRequest {
   export function isa(o: any): o is AllocateHostsRequest {
-    return _smithy.isa(o, "AllocateHostsRequest");
+    return __isa(o, "AllocateHostsRequest");
   }
 }
 
@@ -588,7 +588,7 @@ export interface AllocateHostsResult extends $MetadataBearer {
 
 export namespace AllocateHostsResult {
   export function isa(o: any): o is AllocateHostsResult {
-    return _smithy.isa(o, "AllocateHostsResult");
+    return __isa(o, "AllocateHostsResult");
   }
 }
 
@@ -624,7 +624,7 @@ export interface AllowedPrincipal {
 
 export namespace AllowedPrincipal {
   export function isa(o: any): o is AllowedPrincipal {
-    return _smithy.isa(o, "AllowedPrincipal");
+    return __isa(o, "AllowedPrincipal");
   }
 }
 
@@ -658,7 +658,7 @@ export namespace ApplySecurityGroupsToClientVpnTargetNetworkRequest {
   export function isa(
     o: any
   ): o is ApplySecurityGroupsToClientVpnTargetNetworkRequest {
-    return _smithy.isa(o, "ApplySecurityGroupsToClientVpnTargetNetworkRequest");
+    return __isa(o, "ApplySecurityGroupsToClientVpnTargetNetworkRequest");
   }
 }
 
@@ -675,7 +675,7 @@ export namespace ApplySecurityGroupsToClientVpnTargetNetworkResult {
   export function isa(
     o: any
   ): o is ApplySecurityGroupsToClientVpnTargetNetworkResult {
-    return _smithy.isa(o, "ApplySecurityGroupsToClientVpnTargetNetworkResult");
+    return __isa(o, "ApplySecurityGroupsToClientVpnTargetNetworkResult");
   }
 }
 
@@ -705,7 +705,7 @@ export interface AssignIpv6AddressesRequest {
 
 export namespace AssignIpv6AddressesRequest {
   export function isa(o: any): o is AssignIpv6AddressesRequest {
-    return _smithy.isa(o, "AssignIpv6AddressesRequest");
+    return __isa(o, "AssignIpv6AddressesRequest");
   }
 }
 
@@ -724,7 +724,7 @@ export interface AssignIpv6AddressesResult extends $MetadataBearer {
 
 export namespace AssignIpv6AddressesResult {
   export function isa(o: any): o is AssignIpv6AddressesResult {
-    return _smithy.isa(o, "AssignIpv6AddressesResult");
+    return __isa(o, "AssignIpv6AddressesResult");
   }
 }
 
@@ -757,7 +757,7 @@ export interface AssignPrivateIpAddressesRequest {
 
 export namespace AssignPrivateIpAddressesRequest {
   export function isa(o: any): o is AssignPrivateIpAddressesRequest {
-    return _smithy.isa(o, "AssignPrivateIpAddressesRequest");
+    return __isa(o, "AssignPrivateIpAddressesRequest");
   }
 }
 
@@ -776,7 +776,7 @@ export interface AssignPrivateIpAddressesResult extends $MetadataBearer {
 
 export namespace AssignPrivateIpAddressesResult {
   export function isa(o: any): o is AssignPrivateIpAddressesResult {
-    return _smithy.isa(o, "AssignPrivateIpAddressesResult");
+    return __isa(o, "AssignPrivateIpAddressesResult");
   }
 }
 
@@ -793,7 +793,7 @@ export interface AssignedPrivateIpAddress {
 
 export namespace AssignedPrivateIpAddress {
   export function isa(o: any): o is AssignedPrivateIpAddress {
-    return _smithy.isa(o, "AssignedPrivateIpAddress");
+    return __isa(o, "AssignedPrivateIpAddress");
   }
 }
 
@@ -840,7 +840,7 @@ export interface AssociateAddressRequest {
 
 export namespace AssociateAddressRequest {
   export function isa(o: any): o is AssociateAddressRequest {
-    return _smithy.isa(o, "AssociateAddressRequest");
+    return __isa(o, "AssociateAddressRequest");
   }
 }
 
@@ -854,7 +854,7 @@ export interface AssociateAddressResult extends $MetadataBearer {
 
 export namespace AssociateAddressResult {
   export function isa(o: any): o is AssociateAddressResult {
-    return _smithy.isa(o, "AssociateAddressResult");
+    return __isa(o, "AssociateAddressResult");
   }
 }
 
@@ -883,7 +883,7 @@ export interface AssociateClientVpnTargetNetworkRequest {
 
 export namespace AssociateClientVpnTargetNetworkRequest {
   export function isa(o: any): o is AssociateClientVpnTargetNetworkRequest {
-    return _smithy.isa(o, "AssociateClientVpnTargetNetworkRequest");
+    return __isa(o, "AssociateClientVpnTargetNetworkRequest");
   }
 }
 
@@ -902,7 +902,7 @@ export interface AssociateClientVpnTargetNetworkResult extends $MetadataBearer {
 
 export namespace AssociateClientVpnTargetNetworkResult {
   export function isa(o: any): o is AssociateClientVpnTargetNetworkResult {
-    return _smithy.isa(o, "AssociateClientVpnTargetNetworkResult");
+    return __isa(o, "AssociateClientVpnTargetNetworkResult");
   }
 }
 
@@ -929,7 +929,7 @@ export interface AssociateDhcpOptionsRequest {
 
 export namespace AssociateDhcpOptionsRequest {
   export function isa(o: any): o is AssociateDhcpOptionsRequest {
-    return _smithy.isa(o, "AssociateDhcpOptionsRequest");
+    return __isa(o, "AssociateDhcpOptionsRequest");
   }
 }
 
@@ -948,7 +948,7 @@ export interface AssociateIamInstanceProfileRequest {
 
 export namespace AssociateIamInstanceProfileRequest {
   export function isa(o: any): o is AssociateIamInstanceProfileRequest {
-    return _smithy.isa(o, "AssociateIamInstanceProfileRequest");
+    return __isa(o, "AssociateIamInstanceProfileRequest");
   }
 }
 
@@ -962,7 +962,7 @@ export interface AssociateIamInstanceProfileResult extends $MetadataBearer {
 
 export namespace AssociateIamInstanceProfileResult {
   export function isa(o: any): o is AssociateIamInstanceProfileResult {
-    return _smithy.isa(o, "AssociateIamInstanceProfileResult");
+    return __isa(o, "AssociateIamInstanceProfileResult");
   }
 }
 
@@ -993,7 +993,7 @@ export interface AssociateRouteTableRequest {
 
 export namespace AssociateRouteTableRequest {
   export function isa(o: any): o is AssociateRouteTableRequest {
-    return _smithy.isa(o, "AssociateRouteTableRequest");
+    return __isa(o, "AssociateRouteTableRequest");
   }
 }
 
@@ -1013,7 +1013,7 @@ export interface AssociateRouteTableResult extends $MetadataBearer {
 
 export namespace AssociateRouteTableResult {
   export function isa(o: any): o is AssociateRouteTableResult {
-    return _smithy.isa(o, "AssociateRouteTableResult");
+    return __isa(o, "AssociateRouteTableResult");
   }
 }
 
@@ -1033,7 +1033,7 @@ export interface AssociateSubnetCidrBlockRequest {
 
 export namespace AssociateSubnetCidrBlockRequest {
   export function isa(o: any): o is AssociateSubnetCidrBlockRequest {
-    return _smithy.isa(o, "AssociateSubnetCidrBlockRequest");
+    return __isa(o, "AssociateSubnetCidrBlockRequest");
   }
 }
 
@@ -1052,7 +1052,7 @@ export interface AssociateSubnetCidrBlockResult extends $MetadataBearer {
 
 export namespace AssociateSubnetCidrBlockResult {
   export function isa(o: any): o is AssociateSubnetCidrBlockResult {
-    return _smithy.isa(o, "AssociateSubnetCidrBlockResult");
+    return __isa(o, "AssociateSubnetCidrBlockResult");
   }
 }
 
@@ -1085,7 +1085,7 @@ export namespace AssociateTransitGatewayMulticastDomainRequest {
   export function isa(
     o: any
   ): o is AssociateTransitGatewayMulticastDomainRequest {
-    return _smithy.isa(o, "AssociateTransitGatewayMulticastDomainRequest");
+    return __isa(o, "AssociateTransitGatewayMulticastDomainRequest");
   }
 }
 
@@ -1102,7 +1102,7 @@ export namespace AssociateTransitGatewayMulticastDomainResult {
   export function isa(
     o: any
   ): o is AssociateTransitGatewayMulticastDomainResult {
-    return _smithy.isa(o, "AssociateTransitGatewayMulticastDomainResult");
+    return __isa(o, "AssociateTransitGatewayMulticastDomainResult");
   }
 }
 
@@ -1128,7 +1128,7 @@ export interface AssociateTransitGatewayRouteTableRequest {
 
 export namespace AssociateTransitGatewayRouteTableRequest {
   export function isa(o: any): o is AssociateTransitGatewayRouteTableRequest {
-    return _smithy.isa(o, "AssociateTransitGatewayRouteTableRequest");
+    return __isa(o, "AssociateTransitGatewayRouteTableRequest");
   }
 }
 
@@ -1143,7 +1143,7 @@ export interface AssociateTransitGatewayRouteTableResult
 
 export namespace AssociateTransitGatewayRouteTableResult {
   export function isa(o: any): o is AssociateTransitGatewayRouteTableResult {
-    return _smithy.isa(o, "AssociateTransitGatewayRouteTableResult");
+    return __isa(o, "AssociateTransitGatewayRouteTableResult");
   }
 }
 
@@ -1185,7 +1185,7 @@ export interface AssociateVpcCidrBlockRequest {
 
 export namespace AssociateVpcCidrBlockRequest {
   export function isa(o: any): o is AssociateVpcCidrBlockRequest {
-    return _smithy.isa(o, "AssociateVpcCidrBlockRequest");
+    return __isa(o, "AssociateVpcCidrBlockRequest");
   }
 }
 
@@ -1209,7 +1209,7 @@ export interface AssociateVpcCidrBlockResult extends $MetadataBearer {
 
 export namespace AssociateVpcCidrBlockResult {
   export function isa(o: any): o is AssociateVpcCidrBlockResult {
-    return _smithy.isa(o, "AssociateVpcCidrBlockResult");
+    return __isa(o, "AssociateVpcCidrBlockResult");
   }
 }
 
@@ -1233,7 +1233,7 @@ export interface AssociatedTargetNetwork {
 
 export namespace AssociatedTargetNetwork {
   export function isa(o: any): o is AssociatedTargetNetwork {
-    return _smithy.isa(o, "AssociatedTargetNetwork");
+    return __isa(o, "AssociatedTargetNetwork");
   }
 }
 
@@ -1255,7 +1255,7 @@ export interface AssociationStatus {
 
 export namespace AssociationStatus {
   export function isa(o: any): o is AssociationStatus {
-    return _smithy.isa(o, "AssociationStatus");
+    return __isa(o, "AssociationStatus");
   }
 }
 
@@ -1293,7 +1293,7 @@ export interface AttachClassicLinkVpcRequest {
 
 export namespace AttachClassicLinkVpcRequest {
   export function isa(o: any): o is AttachClassicLinkVpcRequest {
-    return _smithy.isa(o, "AttachClassicLinkVpcRequest");
+    return __isa(o, "AttachClassicLinkVpcRequest");
   }
 }
 
@@ -1307,7 +1307,7 @@ export interface AttachClassicLinkVpcResult extends $MetadataBearer {
 
 export namespace AttachClassicLinkVpcResult {
   export function isa(o: any): o is AttachClassicLinkVpcResult {
-    return _smithy.isa(o, "AttachClassicLinkVpcResult");
+    return __isa(o, "AttachClassicLinkVpcResult");
   }
 }
 
@@ -1333,7 +1333,7 @@ export interface AttachInternetGatewayRequest {
 
 export namespace AttachInternetGatewayRequest {
   export function isa(o: any): o is AttachInternetGatewayRequest {
-    return _smithy.isa(o, "AttachInternetGatewayRequest");
+    return __isa(o, "AttachInternetGatewayRequest");
   }
 }
 
@@ -1367,7 +1367,7 @@ export interface AttachNetworkInterfaceRequest {
 
 export namespace AttachNetworkInterfaceRequest {
   export function isa(o: any): o is AttachNetworkInterfaceRequest {
-    return _smithy.isa(o, "AttachNetworkInterfaceRequest");
+    return __isa(o, "AttachNetworkInterfaceRequest");
   }
 }
 
@@ -1384,7 +1384,7 @@ export interface AttachNetworkInterfaceResult extends $MetadataBearer {
 
 export namespace AttachNetworkInterfaceResult {
   export function isa(o: any): o is AttachNetworkInterfaceResult {
-    return _smithy.isa(o, "AttachNetworkInterfaceResult");
+    return __isa(o, "AttachNetworkInterfaceResult");
   }
 }
 
@@ -1416,7 +1416,7 @@ export interface AttachVolumeRequest {
 
 export namespace AttachVolumeRequest {
   export function isa(o: any): o is AttachVolumeRequest {
-    return _smithy.isa(o, "AttachVolumeRequest");
+    return __isa(o, "AttachVolumeRequest");
   }
 }
 
@@ -1445,7 +1445,7 @@ export interface AttachVpnGatewayRequest {
 
 export namespace AttachVpnGatewayRequest {
   export function isa(o: any): o is AttachVpnGatewayRequest {
-    return _smithy.isa(o, "AttachVpnGatewayRequest");
+    return __isa(o, "AttachVpnGatewayRequest");
   }
 }
 
@@ -1462,7 +1462,7 @@ export interface AttachVpnGatewayResult extends $MetadataBearer {
 
 export namespace AttachVpnGatewayResult {
   export function isa(o: any): o is AttachVpnGatewayResult {
-    return _smithy.isa(o, "AttachVpnGatewayResult");
+    return __isa(o, "AttachVpnGatewayResult");
   }
 }
 
@@ -1485,7 +1485,7 @@ export interface AttributeBooleanValue {
 
 export namespace AttributeBooleanValue {
   export function isa(o: any): o is AttributeBooleanValue {
-    return _smithy.isa(o, "AttributeBooleanValue");
+    return __isa(o, "AttributeBooleanValue");
   }
 }
 
@@ -1502,7 +1502,7 @@ export interface AttributeValue {
 
 export namespace AttributeValue {
   export function isa(o: any): o is AttributeValue {
-    return _smithy.isa(o, "AttributeValue");
+    return __isa(o, "AttributeValue");
   }
 }
 
@@ -1544,7 +1544,7 @@ export interface AuthorizationRule {
 
 export namespace AuthorizationRule {
   export function isa(o: any): o is AuthorizationRule {
-    return _smithy.isa(o, "AuthorizationRule");
+    return __isa(o, "AuthorizationRule");
   }
 }
 
@@ -1589,7 +1589,7 @@ export interface AuthorizeClientVpnIngressRequest {
 
 export namespace AuthorizeClientVpnIngressRequest {
   export function isa(o: any): o is AuthorizeClientVpnIngressRequest {
-    return _smithy.isa(o, "AuthorizeClientVpnIngressRequest");
+    return __isa(o, "AuthorizeClientVpnIngressRequest");
   }
 }
 
@@ -1603,7 +1603,7 @@ export interface AuthorizeClientVpnIngressResult extends $MetadataBearer {
 
 export namespace AuthorizeClientVpnIngressResult {
   export function isa(o: any): o is AuthorizeClientVpnIngressResult {
-    return _smithy.isa(o, "AuthorizeClientVpnIngressResult");
+    return __isa(o, "AuthorizeClientVpnIngressResult");
   }
 }
 
@@ -1663,7 +1663,7 @@ export interface AuthorizeSecurityGroupEgressRequest {
 
 export namespace AuthorizeSecurityGroupEgressRequest {
   export function isa(o: any): o is AuthorizeSecurityGroupEgressRequest {
-    return _smithy.isa(o, "AuthorizeSecurityGroupEgressRequest");
+    return __isa(o, "AuthorizeSecurityGroupEgressRequest");
   }
 }
 
@@ -1748,7 +1748,7 @@ export interface AuthorizeSecurityGroupIngressRequest {
 
 export namespace AuthorizeSecurityGroupIngressRequest {
   export function isa(o: any): o is AuthorizeSecurityGroupIngressRequest {
-    return _smithy.isa(o, "AuthorizeSecurityGroupIngressRequest");
+    return __isa(o, "AuthorizeSecurityGroupIngressRequest");
   }
 }
 
@@ -1808,7 +1808,7 @@ export interface AvailabilityZone {
 
 export namespace AvailabilityZone {
   export function isa(o: any): o is AvailabilityZone {
-    return _smithy.isa(o, "AvailabilityZone");
+    return __isa(o, "AvailabilityZone");
   }
 }
 
@@ -1825,7 +1825,7 @@ export interface AvailabilityZoneMessage {
 
 export namespace AvailabilityZoneMessage {
   export function isa(o: any): o is AvailabilityZoneMessage {
-    return _smithy.isa(o, "AvailabilityZoneMessage");
+    return __isa(o, "AvailabilityZoneMessage");
   }
 }
 
@@ -1861,7 +1861,7 @@ export interface AvailableCapacity {
 
 export namespace AvailableCapacity {
   export function isa(o: any): o is AvailableCapacity {
-    return _smithy.isa(o, "AvailableCapacity");
+    return __isa(o, "AvailableCapacity");
   }
 }
 
@@ -1882,7 +1882,7 @@ export interface BlobAttributeValue {
 
 export namespace BlobAttributeValue {
   export function isa(o: any): o is BlobAttributeValue {
-    return _smithy.isa(o, "BlobAttributeValue");
+    return __isa(o, "BlobAttributeValue");
   }
 }
 
@@ -1925,7 +1925,7 @@ export interface BlockDeviceMapping {
 
 export namespace BlockDeviceMapping {
   export function isa(o: any): o is BlockDeviceMapping {
-    return _smithy.isa(o, "BlockDeviceMapping");
+    return __isa(o, "BlockDeviceMapping");
   }
 }
 
@@ -1957,7 +1957,7 @@ export interface BundleInstanceRequest {
 
 export namespace BundleInstanceRequest {
   export function isa(o: any): o is BundleInstanceRequest {
-    return _smithy.isa(o, "BundleInstanceRequest");
+    return __isa(o, "BundleInstanceRequest");
   }
 }
 
@@ -1974,7 +1974,7 @@ export interface BundleInstanceResult extends $MetadataBearer {
 
 export namespace BundleInstanceResult {
   export function isa(o: any): o is BundleInstanceResult {
-    return _smithy.isa(o, "BundleInstanceResult");
+    return __isa(o, "BundleInstanceResult");
   }
 }
 
@@ -2026,7 +2026,7 @@ export interface BundleTask {
 
 export namespace BundleTask {
   export function isa(o: any): o is BundleTask {
-    return _smithy.isa(o, "BundleTask");
+    return __isa(o, "BundleTask");
   }
 }
 
@@ -2048,7 +2048,7 @@ export interface BundleTaskError {
 
 export namespace BundleTaskError {
   export function isa(o: any): o is BundleTaskError {
-    return _smithy.isa(o, "BundleTaskError");
+    return __isa(o, "BundleTaskError");
   }
 }
 
@@ -2090,7 +2090,7 @@ export interface ByoipCidr {
 
 export namespace ByoipCidr {
   export function isa(o: any): o is ByoipCidr {
-    return _smithy.isa(o, "ByoipCidr");
+    return __isa(o, "ByoipCidr");
   }
 }
 
@@ -2131,7 +2131,7 @@ export interface CancelBundleTaskRequest {
 
 export namespace CancelBundleTaskRequest {
   export function isa(o: any): o is CancelBundleTaskRequest {
-    return _smithy.isa(o, "CancelBundleTaskRequest");
+    return __isa(o, "CancelBundleTaskRequest");
   }
 }
 
@@ -2148,7 +2148,7 @@ export interface CancelBundleTaskResult extends $MetadataBearer {
 
 export namespace CancelBundleTaskResult {
   export function isa(o: any): o is CancelBundleTaskResult {
-    return _smithy.isa(o, "CancelBundleTaskResult");
+    return __isa(o, "CancelBundleTaskResult");
   }
 }
 
@@ -2167,7 +2167,7 @@ export interface CancelCapacityReservationRequest {
 
 export namespace CancelCapacityReservationRequest {
   export function isa(o: any): o is CancelCapacityReservationRequest {
-    return _smithy.isa(o, "CancelCapacityReservationRequest");
+    return __isa(o, "CancelCapacityReservationRequest");
   }
 }
 
@@ -2181,7 +2181,7 @@ export interface CancelCapacityReservationResult extends $MetadataBearer {
 
 export namespace CancelCapacityReservationResult {
   export function isa(o: any): o is CancelCapacityReservationResult {
-    return _smithy.isa(o, "CancelCapacityReservationResult");
+    return __isa(o, "CancelCapacityReservationResult");
   }
 }
 
@@ -2207,7 +2207,7 @@ export interface CancelConversionRequest {
 
 export namespace CancelConversionRequest {
   export function isa(o: any): o is CancelConversionRequest {
-    return _smithy.isa(o, "CancelConversionRequest");
+    return __isa(o, "CancelConversionRequest");
   }
 }
 
@@ -2221,7 +2221,7 @@ export interface CancelExportTaskRequest {
 
 export namespace CancelExportTaskRequest {
   export function isa(o: any): o is CancelExportTaskRequest {
-    return _smithy.isa(o, "CancelExportTaskRequest");
+    return __isa(o, "CancelExportTaskRequest");
   }
 }
 
@@ -2247,7 +2247,7 @@ export interface CancelImportTaskRequest {
 
 export namespace CancelImportTaskRequest {
   export function isa(o: any): o is CancelImportTaskRequest {
-    return _smithy.isa(o, "CancelImportTaskRequest");
+    return __isa(o, "CancelImportTaskRequest");
   }
 }
 
@@ -2271,7 +2271,7 @@ export interface CancelImportTaskResult extends $MetadataBearer {
 
 export namespace CancelImportTaskResult {
   export function isa(o: any): o is CancelImportTaskResult {
-    return _smithy.isa(o, "CancelImportTaskResult");
+    return __isa(o, "CancelImportTaskResult");
   }
 }
 
@@ -2288,7 +2288,7 @@ export interface CancelReservedInstancesListingRequest {
 
 export namespace CancelReservedInstancesListingRequest {
   export function isa(o: any): o is CancelReservedInstancesListingRequest {
-    return _smithy.isa(o, "CancelReservedInstancesListingRequest");
+    return __isa(o, "CancelReservedInstancesListingRequest");
   }
 }
 
@@ -2305,7 +2305,7 @@ export interface CancelReservedInstancesListingResult extends $MetadataBearer {
 
 export namespace CancelReservedInstancesListingResult {
   export function isa(o: any): o is CancelReservedInstancesListingResult {
-    return _smithy.isa(o, "CancelReservedInstancesListingResult");
+    return __isa(o, "CancelReservedInstancesListingResult");
   }
 }
 
@@ -2327,7 +2327,7 @@ export interface CancelSpotFleetRequestsError {
 
 export namespace CancelSpotFleetRequestsError {
   export function isa(o: any): o is CancelSpotFleetRequestsError {
-    return _smithy.isa(o, "CancelSpotFleetRequestsError");
+    return __isa(o, "CancelSpotFleetRequestsError");
   }
 }
 
@@ -2349,7 +2349,7 @@ export interface CancelSpotFleetRequestsErrorItem {
 
 export namespace CancelSpotFleetRequestsErrorItem {
   export function isa(o: any): o is CancelSpotFleetRequestsErrorItem {
-    return _smithy.isa(o, "CancelSpotFleetRequestsErrorItem");
+    return __isa(o, "CancelSpotFleetRequestsErrorItem");
   }
 }
 
@@ -2378,7 +2378,7 @@ export interface CancelSpotFleetRequestsRequest {
 
 export namespace CancelSpotFleetRequestsRequest {
   export function isa(o: any): o is CancelSpotFleetRequestsRequest {
-    return _smithy.isa(o, "CancelSpotFleetRequestsRequest");
+    return __isa(o, "CancelSpotFleetRequestsRequest");
   }
 }
 
@@ -2400,7 +2400,7 @@ export interface CancelSpotFleetRequestsResponse extends $MetadataBearer {
 
 export namespace CancelSpotFleetRequestsResponse {
   export function isa(o: any): o is CancelSpotFleetRequestsResponse {
-    return _smithy.isa(o, "CancelSpotFleetRequestsResponse");
+    return __isa(o, "CancelSpotFleetRequestsResponse");
   }
 }
 
@@ -2427,7 +2427,7 @@ export interface CancelSpotFleetRequestsSuccessItem {
 
 export namespace CancelSpotFleetRequestsSuccessItem {
   export function isa(o: any): o is CancelSpotFleetRequestsSuccessItem {
-    return _smithy.isa(o, "CancelSpotFleetRequestsSuccessItem");
+    return __isa(o, "CancelSpotFleetRequestsSuccessItem");
   }
 }
 
@@ -2458,7 +2458,7 @@ export interface CancelSpotInstanceRequestsRequest {
 
 export namespace CancelSpotInstanceRequestsRequest {
   export function isa(o: any): o is CancelSpotInstanceRequestsRequest {
-    return _smithy.isa(o, "CancelSpotInstanceRequestsRequest");
+    return __isa(o, "CancelSpotInstanceRequestsRequest");
   }
 }
 
@@ -2475,7 +2475,7 @@ export interface CancelSpotInstanceRequestsResult extends $MetadataBearer {
 
 export namespace CancelSpotInstanceRequestsResult {
   export function isa(o: any): o is CancelSpotInstanceRequestsResult {
-    return _smithy.isa(o, "CancelSpotInstanceRequestsResult");
+    return __isa(o, "CancelSpotInstanceRequestsResult");
   }
 }
 
@@ -2497,7 +2497,7 @@ export interface CancelledSpotInstanceRequest {
 
 export namespace CancelledSpotInstanceRequest {
   export function isa(o: any): o is CancelledSpotInstanceRequest {
-    return _smithy.isa(o, "CancelledSpotInstanceRequest");
+    return __isa(o, "CancelledSpotInstanceRequest");
   }
 }
 
@@ -2668,7 +2668,7 @@ export interface CapacityReservation {
 
 export namespace CapacityReservation {
   export function isa(o: any): o is CapacityReservation {
-    return _smithy.isa(o, "CapacityReservation");
+    return __isa(o, "CapacityReservation");
   }
 }
 
@@ -2717,7 +2717,7 @@ export interface CapacityReservationOptions {
 
 export namespace CapacityReservationOptions {
   export function isa(o: any): o is CapacityReservationOptions {
-    return _smithy.isa(o, "CapacityReservationOptions");
+    return __isa(o, "CapacityReservationOptions");
   }
 }
 
@@ -2751,7 +2751,7 @@ export interface CapacityReservationOptionsRequest {
 
 export namespace CapacityReservationOptionsRequest {
   export function isa(o: any): o is CapacityReservationOptionsRequest {
-    return _smithy.isa(o, "CapacityReservationOptionsRequest");
+    return __isa(o, "CapacityReservationOptionsRequest");
   }
 }
 
@@ -2794,7 +2794,7 @@ export interface CapacityReservationSpecification {
 
 export namespace CapacityReservationSpecification {
   export function isa(o: any): o is CapacityReservationSpecification {
-    return _smithy.isa(o, "CapacityReservationSpecification");
+    return __isa(o, "CapacityReservationSpecification");
   }
 }
 
@@ -2833,7 +2833,7 @@ export interface CapacityReservationSpecificationResponse {
 
 export namespace CapacityReservationSpecificationResponse {
   export function isa(o: any): o is CapacityReservationSpecificationResponse {
-    return _smithy.isa(o, "CapacityReservationSpecificationResponse");
+    return __isa(o, "CapacityReservationSpecificationResponse");
   }
 }
 
@@ -2857,7 +2857,7 @@ export interface CapacityReservationTarget {
 
 export namespace CapacityReservationTarget {
   export function isa(o: any): o is CapacityReservationTarget {
-    return _smithy.isa(o, "CapacityReservationTarget");
+    return __isa(o, "CapacityReservationTarget");
   }
 }
 
@@ -2874,7 +2874,7 @@ export interface CapacityReservationTargetResponse {
 
 export namespace CapacityReservationTargetResponse {
   export function isa(o: any): o is CapacityReservationTargetResponse {
-    return _smithy.isa(o, "CapacityReservationTargetResponse");
+    return __isa(o, "CapacityReservationTargetResponse");
   }
 }
 
@@ -2893,7 +2893,7 @@ export interface CertificateAuthentication {
 
 export namespace CertificateAuthentication {
   export function isa(o: any): o is CertificateAuthentication {
-    return _smithy.isa(o, "CertificateAuthentication");
+    return __isa(o, "CertificateAuthentication");
   }
 }
 
@@ -2911,7 +2911,7 @@ export interface CertificateAuthenticationRequest {
 
 export namespace CertificateAuthenticationRequest {
   export function isa(o: any): o is CertificateAuthenticationRequest {
-    return _smithy.isa(o, "CertificateAuthenticationRequest");
+    return __isa(o, "CertificateAuthenticationRequest");
   }
 }
 
@@ -2934,7 +2934,7 @@ export interface CidrAuthorizationContext {
 
 export namespace CidrAuthorizationContext {
   export function isa(o: any): o is CidrAuthorizationContext {
-    return _smithy.isa(o, "CidrAuthorizationContext");
+    return __isa(o, "CidrAuthorizationContext");
   }
 }
 
@@ -2951,7 +2951,7 @@ export interface CidrBlock {
 
 export namespace CidrBlock {
   export function isa(o: any): o is CidrBlock {
-    return _smithy.isa(o, "CidrBlock");
+    return __isa(o, "CidrBlock");
   }
 }
 
@@ -2973,7 +2973,7 @@ export interface ClassicLinkDnsSupport {
 
 export namespace ClassicLinkDnsSupport {
   export function isa(o: any): o is ClassicLinkDnsSupport {
-    return _smithy.isa(o, "ClassicLinkDnsSupport");
+    return __isa(o, "ClassicLinkDnsSupport");
   }
 }
 
@@ -3005,7 +3005,7 @@ export interface ClassicLinkInstance {
 
 export namespace ClassicLinkInstance {
   export function isa(o: any): o is ClassicLinkInstance {
-    return _smithy.isa(o, "ClassicLinkInstance");
+    return __isa(o, "ClassicLinkInstance");
   }
 }
 
@@ -3022,7 +3022,7 @@ export interface ClassicLoadBalancer {
 
 export namespace ClassicLoadBalancer {
   export function isa(o: any): o is ClassicLoadBalancer {
-    return _smithy.isa(o, "ClassicLoadBalancer");
+    return __isa(o, "ClassicLoadBalancer");
   }
 }
 
@@ -3040,7 +3040,7 @@ export interface ClassicLoadBalancersConfig {
 
 export namespace ClassicLoadBalancersConfig {
   export function isa(o: any): o is ClassicLoadBalancersConfig {
-    return _smithy.isa(o, "ClassicLoadBalancersConfig");
+    return __isa(o, "ClassicLoadBalancersConfig");
   }
 }
 
@@ -3062,7 +3062,7 @@ export interface ClientCertificateRevocationListStatus {
 
 export namespace ClientCertificateRevocationListStatus {
   export function isa(o: any): o is ClientCertificateRevocationListStatus {
-    return _smithy.isa(o, "ClientCertificateRevocationListStatus");
+    return __isa(o, "ClientCertificateRevocationListStatus");
   }
 }
 
@@ -3096,7 +3096,7 @@ export interface ClientData {
 
 export namespace ClientData {
   export function isa(o: any): o is ClientData {
-    return _smithy.isa(o, "ClientData");
+    return __isa(o, "ClientData");
   }
 }
 
@@ -3125,7 +3125,7 @@ export interface ClientVpnAuthentication {
 
 export namespace ClientVpnAuthentication {
   export function isa(o: any): o is ClientVpnAuthentication {
-    return _smithy.isa(o, "ClientVpnAuthentication");
+    return __isa(o, "ClientVpnAuthentication");
   }
 }
 
@@ -3155,7 +3155,7 @@ export interface ClientVpnAuthenticationRequest {
 
 export namespace ClientVpnAuthenticationRequest {
   export function isa(o: any): o is ClientVpnAuthenticationRequest {
-    return _smithy.isa(o, "ClientVpnAuthenticationRequest");
+    return __isa(o, "ClientVpnAuthenticationRequest");
   }
 }
 
@@ -3181,7 +3181,7 @@ export interface ClientVpnAuthorizationRuleStatus {
 
 export namespace ClientVpnAuthorizationRuleStatus {
   export function isa(o: any): o is ClientVpnAuthorizationRuleStatus {
-    return _smithy.isa(o, "ClientVpnAuthorizationRuleStatus");
+    return __isa(o, "ClientVpnAuthorizationRuleStatus");
   }
 }
 
@@ -3266,7 +3266,7 @@ export interface ClientVpnConnection {
 
 export namespace ClientVpnConnection {
   export function isa(o: any): o is ClientVpnConnection {
-    return _smithy.isa(o, "ClientVpnConnection");
+    return __isa(o, "ClientVpnConnection");
   }
 }
 
@@ -3288,7 +3288,7 @@ export interface ClientVpnConnectionStatus {
 
 export namespace ClientVpnConnectionStatus {
   export function isa(o: any): o is ClientVpnConnectionStatus {
-    return _smithy.isa(o, "ClientVpnConnectionStatus");
+    return __isa(o, "ClientVpnConnectionStatus");
   }
 }
 
@@ -3393,7 +3393,7 @@ export interface ClientVpnEndpoint {
 
 export namespace ClientVpnEndpoint {
   export function isa(o: any): o is ClientVpnEndpoint {
-    return _smithy.isa(o, "ClientVpnEndpoint");
+    return __isa(o, "ClientVpnEndpoint");
   }
 }
 
@@ -3437,7 +3437,7 @@ export interface ClientVpnEndpointStatus {
 
 export namespace ClientVpnEndpointStatus {
   export function isa(o: any): o is ClientVpnEndpointStatus {
-    return _smithy.isa(o, "ClientVpnEndpointStatus");
+    return __isa(o, "ClientVpnEndpointStatus");
   }
 }
 
@@ -3493,7 +3493,7 @@ export interface ClientVpnRoute {
 
 export namespace ClientVpnRoute {
   export function isa(o: any): o is ClientVpnRoute {
-    return _smithy.isa(o, "ClientVpnRoute");
+    return __isa(o, "ClientVpnRoute");
   }
 }
 
@@ -3515,7 +3515,7 @@ export interface ClientVpnRouteStatus {
 
 export namespace ClientVpnRouteStatus {
   export function isa(o: any): o is ClientVpnRouteStatus {
-    return _smithy.isa(o, "ClientVpnRouteStatus");
+    return __isa(o, "ClientVpnRouteStatus");
   }
 }
 
@@ -3553,7 +3553,7 @@ export interface CoipAddressUsage {
 
 export namespace CoipAddressUsage {
   export function isa(o: any): o is CoipAddressUsage {
-    return _smithy.isa(o, "CoipAddressUsage");
+    return __isa(o, "CoipAddressUsage");
   }
 }
 
@@ -3585,7 +3585,7 @@ export interface CoipPool {
 
 export namespace CoipPool {
   export function isa(o: any): o is CoipPool {
-    return _smithy.isa(o, "CoipPool");
+    return __isa(o, "CoipPool");
   }
 }
 
@@ -3611,7 +3611,7 @@ export interface ConfirmProductInstanceRequest {
 
 export namespace ConfirmProductInstanceRequest {
   export function isa(o: any): o is ConfirmProductInstanceRequest {
-    return _smithy.isa(o, "ConfirmProductInstanceRequest");
+    return __isa(o, "ConfirmProductInstanceRequest");
   }
 }
 
@@ -3632,7 +3632,7 @@ export interface ConfirmProductInstanceResult extends $MetadataBearer {
 
 export namespace ConfirmProductInstanceResult {
   export function isa(o: any): o is ConfirmProductInstanceResult {
-    return _smithy.isa(o, "ConfirmProductInstanceResult");
+    return __isa(o, "ConfirmProductInstanceResult");
   }
 }
 
@@ -3659,7 +3659,7 @@ export interface ConnectionLogOptions {
 
 export namespace ConnectionLogOptions {
   export function isa(o: any): o is ConnectionLogOptions {
-    return _smithy.isa(o, "ConnectionLogOptions");
+    return __isa(o, "ConnectionLogOptions");
   }
 }
 
@@ -3686,7 +3686,7 @@ export interface ConnectionLogResponseOptions {
 
 export namespace ConnectionLogResponseOptions {
   export function isa(o: any): o is ConnectionLogResponseOptions {
-    return _smithy.isa(o, "ConnectionLogResponseOptions");
+    return __isa(o, "ConnectionLogResponseOptions");
   }
 }
 
@@ -3735,7 +3735,7 @@ export interface ConnectionNotification {
 
 export namespace ConnectionNotification {
   export function isa(o: any): o is ConnectionNotification {
-    return _smithy.isa(o, "ConnectionNotification");
+    return __isa(o, "ConnectionNotification");
   }
 }
 
@@ -3794,7 +3794,7 @@ export interface ConversionTask {
 
 export namespace ConversionTask {
   export function isa(o: any): o is ConversionTask {
-    return _smithy.isa(o, "ConversionTask");
+    return __isa(o, "ConversionTask");
   }
 }
 
@@ -3842,7 +3842,7 @@ export interface CopyFpgaImageRequest {
 
 export namespace CopyFpgaImageRequest {
   export function isa(o: any): o is CopyFpgaImageRequest {
-    return _smithy.isa(o, "CopyFpgaImageRequest");
+    return __isa(o, "CopyFpgaImageRequest");
   }
 }
 
@@ -3856,7 +3856,7 @@ export interface CopyFpgaImageResult extends $MetadataBearer {
 
 export namespace CopyFpgaImageResult {
   export function isa(o: any): o is CopyFpgaImageResult {
-    return _smithy.isa(o, "CopyFpgaImageResult");
+    return __isa(o, "CopyFpgaImageResult");
   }
 }
 
@@ -3943,7 +3943,7 @@ export interface CopyImageRequest {
 
 export namespace CopyImageRequest {
   export function isa(o: any): o is CopyImageRequest {
-    return _smithy.isa(o, "CopyImageRequest");
+    return __isa(o, "CopyImageRequest");
   }
 }
 
@@ -3960,7 +3960,7 @@ export interface CopyImageResult extends $MetadataBearer {
 
 export namespace CopyImageResult {
   export function isa(o: any): o is CopyImageResult {
-    return _smithy.isa(o, "CopyImageResult");
+    return __isa(o, "CopyImageResult");
   }
 }
 
@@ -4058,7 +4058,7 @@ export interface CopySnapshotRequest {
 
 export namespace CopySnapshotRequest {
   export function isa(o: any): o is CopySnapshotRequest {
-    return _smithy.isa(o, "CopySnapshotRequest");
+    return __isa(o, "CopySnapshotRequest");
   }
 }
 
@@ -4077,7 +4077,7 @@ export interface CopySnapshotResult extends $MetadataBearer {
 
 export namespace CopySnapshotResult {
   export function isa(o: any): o is CopySnapshotResult {
-    return _smithy.isa(o, "CopySnapshotResult");
+    return __isa(o, "CopySnapshotResult");
   }
 }
 
@@ -4101,7 +4101,7 @@ export interface CpuOptions {
 
 export namespace CpuOptions {
   export function isa(o: any): o is CpuOptions {
-    return _smithy.isa(o, "CpuOptions");
+    return __isa(o, "CpuOptions");
   }
 }
 
@@ -4126,7 +4126,7 @@ export interface CpuOptionsRequest {
 
 export namespace CpuOptionsRequest {
   export function isa(o: any): o is CpuOptionsRequest {
-    return _smithy.isa(o, "CpuOptionsRequest");
+    return __isa(o, "CpuOptionsRequest");
   }
 }
 
@@ -4264,7 +4264,7 @@ export interface CreateCapacityReservationRequest {
 
 export namespace CreateCapacityReservationRequest {
   export function isa(o: any): o is CreateCapacityReservationRequest {
-    return _smithy.isa(o, "CreateCapacityReservationRequest");
+    return __isa(o, "CreateCapacityReservationRequest");
   }
 }
 
@@ -4278,7 +4278,7 @@ export interface CreateCapacityReservationResult extends $MetadataBearer {
 
 export namespace CreateCapacityReservationResult {
   export function isa(o: any): o is CreateCapacityReservationResult {
-    return _smithy.isa(o, "CreateCapacityReservationResult");
+    return __isa(o, "CreateCapacityReservationResult");
   }
 }
 
@@ -4374,7 +4374,7 @@ export interface CreateClientVpnEndpointRequest {
 
 export namespace CreateClientVpnEndpointRequest {
   export function isa(o: any): o is CreateClientVpnEndpointRequest {
-    return _smithy.isa(o, "CreateClientVpnEndpointRequest");
+    return __isa(o, "CreateClientVpnEndpointRequest");
   }
 }
 
@@ -4398,7 +4398,7 @@ export interface CreateClientVpnEndpointResult extends $MetadataBearer {
 
 export namespace CreateClientVpnEndpointResult {
   export function isa(o: any): o is CreateClientVpnEndpointResult {
-    return _smithy.isa(o, "CreateClientVpnEndpointResult");
+    return __isa(o, "CreateClientVpnEndpointResult");
   }
 }
 
@@ -4451,7 +4451,7 @@ export interface CreateClientVpnRouteRequest {
 
 export namespace CreateClientVpnRouteRequest {
   export function isa(o: any): o is CreateClientVpnRouteRequest {
-    return _smithy.isa(o, "CreateClientVpnRouteRequest");
+    return __isa(o, "CreateClientVpnRouteRequest");
   }
 }
 
@@ -4465,7 +4465,7 @@ export interface CreateClientVpnRouteResult extends $MetadataBearer {
 
 export namespace CreateClientVpnRouteResult {
   export function isa(o: any): o is CreateClientVpnRouteResult {
-    return _smithy.isa(o, "CreateClientVpnRouteResult");
+    return __isa(o, "CreateClientVpnRouteResult");
   }
 }
 
@@ -4511,7 +4511,7 @@ export interface CreateCustomerGatewayRequest {
 
 export namespace CreateCustomerGatewayRequest {
   export function isa(o: any): o is CreateCustomerGatewayRequest {
-    return _smithy.isa(o, "CreateCustomerGatewayRequest");
+    return __isa(o, "CreateCustomerGatewayRequest");
   }
 }
 
@@ -4528,7 +4528,7 @@ export interface CreateCustomerGatewayResult extends $MetadataBearer {
 
 export namespace CreateCustomerGatewayResult {
   export function isa(o: any): o is CreateCustomerGatewayResult {
-    return _smithy.isa(o, "CreateCustomerGatewayResult");
+    return __isa(o, "CreateCustomerGatewayResult");
   }
 }
 
@@ -4549,7 +4549,7 @@ export interface CreateDefaultSubnetRequest {
 
 export namespace CreateDefaultSubnetRequest {
   export function isa(o: any): o is CreateDefaultSubnetRequest {
-    return _smithy.isa(o, "CreateDefaultSubnetRequest");
+    return __isa(o, "CreateDefaultSubnetRequest");
   }
 }
 
@@ -4563,7 +4563,7 @@ export interface CreateDefaultSubnetResult extends $MetadataBearer {
 
 export namespace CreateDefaultSubnetResult {
   export function isa(o: any): o is CreateDefaultSubnetResult {
-    return _smithy.isa(o, "CreateDefaultSubnetResult");
+    return __isa(o, "CreateDefaultSubnetResult");
   }
 }
 
@@ -4579,7 +4579,7 @@ export interface CreateDefaultVpcRequest {
 
 export namespace CreateDefaultVpcRequest {
   export function isa(o: any): o is CreateDefaultVpcRequest {
-    return _smithy.isa(o, "CreateDefaultVpcRequest");
+    return __isa(o, "CreateDefaultVpcRequest");
   }
 }
 
@@ -4593,7 +4593,7 @@ export interface CreateDefaultVpcResult extends $MetadataBearer {
 
 export namespace CreateDefaultVpcResult {
   export function isa(o: any): o is CreateDefaultVpcResult {
-    return _smithy.isa(o, "CreateDefaultVpcResult");
+    return __isa(o, "CreateDefaultVpcResult");
   }
 }
 
@@ -4614,7 +4614,7 @@ export interface CreateDhcpOptionsRequest {
 
 export namespace CreateDhcpOptionsRequest {
   export function isa(o: any): o is CreateDhcpOptionsRequest {
-    return _smithy.isa(o, "CreateDhcpOptionsRequest");
+    return __isa(o, "CreateDhcpOptionsRequest");
   }
 }
 
@@ -4628,7 +4628,7 @@ export interface CreateDhcpOptionsResult extends $MetadataBearer {
 
 export namespace CreateDhcpOptionsResult {
   export function isa(o: any): o is CreateDhcpOptionsResult {
-    return _smithy.isa(o, "CreateDhcpOptionsResult");
+    return __isa(o, "CreateDhcpOptionsResult");
   }
 }
 
@@ -4656,7 +4656,7 @@ export interface CreateEgressOnlyInternetGatewayRequest {
 
 export namespace CreateEgressOnlyInternetGatewayRequest {
   export function isa(o: any): o is CreateEgressOnlyInternetGatewayRequest {
-    return _smithy.isa(o, "CreateEgressOnlyInternetGatewayRequest");
+    return __isa(o, "CreateEgressOnlyInternetGatewayRequest");
   }
 }
 
@@ -4676,7 +4676,7 @@ export interface CreateEgressOnlyInternetGatewayResult extends $MetadataBearer {
 
 export namespace CreateEgressOnlyInternetGatewayResult {
   export function isa(o: any): o is CreateEgressOnlyInternetGatewayResult {
-    return _smithy.isa(o, "CreateEgressOnlyInternetGatewayResult");
+    return __isa(o, "CreateEgressOnlyInternetGatewayResult");
   }
 }
 
@@ -4711,7 +4711,7 @@ export interface CreateFleetError {
 
 export namespace CreateFleetError {
   export function isa(o: any): o is CreateFleetError {
-    return _smithy.isa(o, "CreateFleetError");
+    return __isa(o, "CreateFleetError");
   }
 }
 
@@ -4750,7 +4750,7 @@ export interface CreateFleetInstance {
 
 export namespace CreateFleetInstance {
   export function isa(o: any): o is CreateFleetInstance {
-    return _smithy.isa(o, "CreateFleetInstance");
+    return __isa(o, "CreateFleetInstance");
   }
 }
 
@@ -4846,7 +4846,7 @@ export interface CreateFleetRequest {
 
 export namespace CreateFleetRequest {
   export function isa(o: any): o is CreateFleetRequest {
-    return _smithy.isa(o, "CreateFleetRequest");
+    return __isa(o, "CreateFleetRequest");
   }
 }
 
@@ -4872,7 +4872,7 @@ export interface CreateFleetResult extends $MetadataBearer {
 
 export namespace CreateFleetResult {
   export function isa(o: any): o is CreateFleetResult {
-    return _smithy.isa(o, "CreateFleetResult");
+    return __isa(o, "CreateFleetResult");
   }
 }
 
@@ -4965,7 +4965,7 @@ export interface CreateFlowLogsRequest {
 
 export namespace CreateFlowLogsRequest {
   export function isa(o: any): o is CreateFlowLogsRequest {
-    return _smithy.isa(o, "CreateFlowLogsRequest");
+    return __isa(o, "CreateFlowLogsRequest");
   }
 }
 
@@ -4990,7 +4990,7 @@ export interface CreateFlowLogsResult extends $MetadataBearer {
 
 export namespace CreateFlowLogsResult {
   export function isa(o: any): o is CreateFlowLogsResult {
-    return _smithy.isa(o, "CreateFlowLogsResult");
+    return __isa(o, "CreateFlowLogsResult");
   }
 }
 
@@ -5037,7 +5037,7 @@ export interface CreateFpgaImageRequest {
 
 export namespace CreateFpgaImageRequest {
   export function isa(o: any): o is CreateFpgaImageRequest {
-    return _smithy.isa(o, "CreateFpgaImageRequest");
+    return __isa(o, "CreateFpgaImageRequest");
   }
 }
 
@@ -5056,7 +5056,7 @@ export interface CreateFpgaImageResult extends $MetadataBearer {
 
 export namespace CreateFpgaImageResult {
   export function isa(o: any): o is CreateFpgaImageResult {
-    return _smithy.isa(o, "CreateFpgaImageResult");
+    return __isa(o, "CreateFpgaImageResult");
   }
 }
 
@@ -5098,7 +5098,7 @@ export interface CreateImageRequest {
 
 export namespace CreateImageRequest {
   export function isa(o: any): o is CreateImageRequest {
-    return _smithy.isa(o, "CreateImageRequest");
+    return __isa(o, "CreateImageRequest");
   }
 }
 
@@ -5112,7 +5112,7 @@ export interface CreateImageResult extends $MetadataBearer {
 
 export namespace CreateImageResult {
   export function isa(o: any): o is CreateImageResult {
-    return _smithy.isa(o, "CreateImageResult");
+    return __isa(o, "CreateImageResult");
   }
 }
 
@@ -5141,7 +5141,7 @@ export interface CreateInstanceExportTaskRequest {
 
 export namespace CreateInstanceExportTaskRequest {
   export function isa(o: any): o is CreateInstanceExportTaskRequest {
-    return _smithy.isa(o, "CreateInstanceExportTaskRequest");
+    return __isa(o, "CreateInstanceExportTaskRequest");
   }
 }
 
@@ -5155,7 +5155,7 @@ export interface CreateInstanceExportTaskResult extends $MetadataBearer {
 
 export namespace CreateInstanceExportTaskResult {
   export function isa(o: any): o is CreateInstanceExportTaskResult {
-    return _smithy.isa(o, "CreateInstanceExportTaskResult");
+    return __isa(o, "CreateInstanceExportTaskResult");
   }
 }
 
@@ -5171,7 +5171,7 @@ export interface CreateInternetGatewayRequest {
 
 export namespace CreateInternetGatewayRequest {
   export function isa(o: any): o is CreateInternetGatewayRequest {
-    return _smithy.isa(o, "CreateInternetGatewayRequest");
+    return __isa(o, "CreateInternetGatewayRequest");
   }
 }
 
@@ -5185,7 +5185,7 @@ export interface CreateInternetGatewayResult extends $MetadataBearer {
 
 export namespace CreateInternetGatewayResult {
   export function isa(o: any): o is CreateInternetGatewayResult {
-    return _smithy.isa(o, "CreateInternetGatewayResult");
+    return __isa(o, "CreateInternetGatewayResult");
   }
 }
 
@@ -5207,7 +5207,7 @@ export interface CreateKeyPairRequest {
 
 export namespace CreateKeyPairRequest {
   export function isa(o: any): o is CreateKeyPairRequest {
-    return _smithy.isa(o, "CreateKeyPairRequest");
+    return __isa(o, "CreateKeyPairRequest");
   }
 }
 
@@ -5252,7 +5252,7 @@ export interface CreateLaunchTemplateRequest {
 
 export namespace CreateLaunchTemplateRequest {
   export function isa(o: any): o is CreateLaunchTemplateRequest {
-    return _smithy.isa(o, "CreateLaunchTemplateRequest");
+    return __isa(o, "CreateLaunchTemplateRequest");
   }
 }
 
@@ -5266,7 +5266,7 @@ export interface CreateLaunchTemplateResult extends $MetadataBearer {
 
 export namespace CreateLaunchTemplateResult {
   export function isa(o: any): o is CreateLaunchTemplateResult {
-    return _smithy.isa(o, "CreateLaunchTemplateResult");
+    return __isa(o, "CreateLaunchTemplateResult");
   }
 }
 
@@ -5322,7 +5322,7 @@ export interface CreateLaunchTemplateVersionRequest {
 
 export namespace CreateLaunchTemplateVersionRequest {
   export function isa(o: any): o is CreateLaunchTemplateVersionRequest {
-    return _smithy.isa(o, "CreateLaunchTemplateVersionRequest");
+    return __isa(o, "CreateLaunchTemplateVersionRequest");
   }
 }
 
@@ -5336,7 +5336,7 @@ export interface CreateLaunchTemplateVersionResult extends $MetadataBearer {
 
 export namespace CreateLaunchTemplateVersionResult {
   export function isa(o: any): o is CreateLaunchTemplateVersionResult {
-    return _smithy.isa(o, "CreateLaunchTemplateVersionResult");
+    return __isa(o, "CreateLaunchTemplateVersionResult");
   }
 }
 
@@ -5368,7 +5368,7 @@ export interface CreateLocalGatewayRouteRequest {
 
 export namespace CreateLocalGatewayRouteRequest {
   export function isa(o: any): o is CreateLocalGatewayRouteRequest {
-    return _smithy.isa(o, "CreateLocalGatewayRouteRequest");
+    return __isa(o, "CreateLocalGatewayRouteRequest");
   }
 }
 
@@ -5382,7 +5382,7 @@ export interface CreateLocalGatewayRouteResult extends $MetadataBearer {
 
 export namespace CreateLocalGatewayRouteResult {
   export function isa(o: any): o is CreateLocalGatewayRouteResult {
-    return _smithy.isa(o, "CreateLocalGatewayRouteResult");
+    return __isa(o, "CreateLocalGatewayRouteResult");
   }
 }
 
@@ -5410,7 +5410,7 @@ export namespace CreateLocalGatewayRouteTableVpcAssociationRequest {
   export function isa(
     o: any
   ): o is CreateLocalGatewayRouteTableVpcAssociationRequest {
-    return _smithy.isa(o, "CreateLocalGatewayRouteTableVpcAssociationRequest");
+    return __isa(o, "CreateLocalGatewayRouteTableVpcAssociationRequest");
   }
 }
 
@@ -5427,7 +5427,7 @@ export namespace CreateLocalGatewayRouteTableVpcAssociationResult {
   export function isa(
     o: any
   ): o is CreateLocalGatewayRouteTableVpcAssociationResult {
-    return _smithy.isa(o, "CreateLocalGatewayRouteTableVpcAssociationResult");
+    return __isa(o, "CreateLocalGatewayRouteTableVpcAssociationResult");
   }
 }
 
@@ -5454,7 +5454,7 @@ export interface CreateNatGatewayRequest {
 
 export namespace CreateNatGatewayRequest {
   export function isa(o: any): o is CreateNatGatewayRequest {
-    return _smithy.isa(o, "CreateNatGatewayRequest");
+    return __isa(o, "CreateNatGatewayRequest");
   }
 }
 
@@ -5473,7 +5473,7 @@ export interface CreateNatGatewayResult extends $MetadataBearer {
 
 export namespace CreateNatGatewayResult {
   export function isa(o: any): o is CreateNatGatewayResult {
-    return _smithy.isa(o, "CreateNatGatewayResult");
+    return __isa(o, "CreateNatGatewayResult");
   }
 }
 
@@ -5544,7 +5544,7 @@ export interface CreateNetworkAclEntryRequest {
 
 export namespace CreateNetworkAclEntryRequest {
   export function isa(o: any): o is CreateNetworkAclEntryRequest {
-    return _smithy.isa(o, "CreateNetworkAclEntryRequest");
+    return __isa(o, "CreateNetworkAclEntryRequest");
   }
 }
 
@@ -5565,7 +5565,7 @@ export interface CreateNetworkAclRequest {
 
 export namespace CreateNetworkAclRequest {
   export function isa(o: any): o is CreateNetworkAclRequest {
-    return _smithy.isa(o, "CreateNetworkAclRequest");
+    return __isa(o, "CreateNetworkAclRequest");
   }
 }
 
@@ -5579,7 +5579,7 @@ export interface CreateNetworkAclResult extends $MetadataBearer {
 
 export namespace CreateNetworkAclResult {
   export function isa(o: any): o is CreateNetworkAclResult {
-    return _smithy.isa(o, "CreateNetworkAclResult");
+    return __isa(o, "CreateNetworkAclResult");
   }
 }
 
@@ -5618,7 +5618,7 @@ export interface CreateNetworkInterfacePermissionRequest {
 
 export namespace CreateNetworkInterfacePermissionRequest {
   export function isa(o: any): o is CreateNetworkInterfacePermissionRequest {
-    return _smithy.isa(o, "CreateNetworkInterfacePermissionRequest");
+    return __isa(o, "CreateNetworkInterfacePermissionRequest");
   }
 }
 
@@ -5636,7 +5636,7 @@ export interface CreateNetworkInterfacePermissionResult
 
 export namespace CreateNetworkInterfacePermissionResult {
   export function isa(o: any): o is CreateNetworkInterfacePermissionResult {
-    return _smithy.isa(o, "CreateNetworkInterfacePermissionResult");
+    return __isa(o, "CreateNetworkInterfacePermissionResult");
   }
 }
 
@@ -5716,7 +5716,7 @@ export interface CreateNetworkInterfaceRequest {
 
 export namespace CreateNetworkInterfaceRequest {
   export function isa(o: any): o is CreateNetworkInterfaceRequest {
-    return _smithy.isa(o, "CreateNetworkInterfaceRequest");
+    return __isa(o, "CreateNetworkInterfaceRequest");
   }
 }
 
@@ -5733,7 +5733,7 @@ export interface CreateNetworkInterfaceResult extends $MetadataBearer {
 
 export namespace CreateNetworkInterfaceResult {
   export function isa(o: any): o is CreateNetworkInterfaceResult {
-    return _smithy.isa(o, "CreateNetworkInterfaceResult");
+    return __isa(o, "CreateNetworkInterfaceResult");
   }
 }
 
@@ -5767,7 +5767,7 @@ export interface CreatePlacementGroupRequest {
 
 export namespace CreatePlacementGroupRequest {
   export function isa(o: any): o is CreatePlacementGroupRequest {
-    return _smithy.isa(o, "CreatePlacementGroupRequest");
+    return __isa(o, "CreatePlacementGroupRequest");
   }
 }
 
@@ -5801,7 +5801,7 @@ export interface CreateReservedInstancesListingRequest {
 
 export namespace CreateReservedInstancesListingRequest {
   export function isa(o: any): o is CreateReservedInstancesListingRequest {
-    return _smithy.isa(o, "CreateReservedInstancesListingRequest");
+    return __isa(o, "CreateReservedInstancesListingRequest");
   }
 }
 
@@ -5818,7 +5818,7 @@ export interface CreateReservedInstancesListingResult extends $MetadataBearer {
 
 export namespace CreateReservedInstancesListingResult {
   export function isa(o: any): o is CreateReservedInstancesListingResult {
-    return _smithy.isa(o, "CreateReservedInstancesListingResult");
+    return __isa(o, "CreateReservedInstancesListingResult");
   }
 }
 
@@ -5890,7 +5890,7 @@ export interface CreateRouteRequest {
 
 export namespace CreateRouteRequest {
   export function isa(o: any): o is CreateRouteRequest {
-    return _smithy.isa(o, "CreateRouteRequest");
+    return __isa(o, "CreateRouteRequest");
   }
 }
 
@@ -5904,7 +5904,7 @@ export interface CreateRouteResult extends $MetadataBearer {
 
 export namespace CreateRouteResult {
   export function isa(o: any): o is CreateRouteResult {
-    return _smithy.isa(o, "CreateRouteResult");
+    return __isa(o, "CreateRouteResult");
   }
 }
 
@@ -5925,7 +5925,7 @@ export interface CreateRouteTableRequest {
 
 export namespace CreateRouteTableRequest {
   export function isa(o: any): o is CreateRouteTableRequest {
-    return _smithy.isa(o, "CreateRouteTableRequest");
+    return __isa(o, "CreateRouteTableRequest");
   }
 }
 
@@ -5939,7 +5939,7 @@ export interface CreateRouteTableResult extends $MetadataBearer {
 
 export namespace CreateRouteTableResult {
   export function isa(o: any): o is CreateRouteTableResult {
-    return _smithy.isa(o, "CreateRouteTableResult");
+    return __isa(o, "CreateRouteTableResult");
   }
 }
 
@@ -5977,7 +5977,7 @@ export interface CreateSecurityGroupRequest {
 
 export namespace CreateSecurityGroupRequest {
   export function isa(o: any): o is CreateSecurityGroupRequest {
-    return _smithy.isa(o, "CreateSecurityGroupRequest");
+    return __isa(o, "CreateSecurityGroupRequest");
   }
 }
 
@@ -5991,7 +5991,7 @@ export interface CreateSecurityGroupResult extends $MetadataBearer {
 
 export namespace CreateSecurityGroupResult {
   export function isa(o: any): o is CreateSecurityGroupResult {
-    return _smithy.isa(o, "CreateSecurityGroupResult");
+    return __isa(o, "CreateSecurityGroupResult");
   }
 }
 
@@ -6022,7 +6022,7 @@ export interface CreateSnapshotRequest {
 
 export namespace CreateSnapshotRequest {
   export function isa(o: any): o is CreateSnapshotRequest {
-    return _smithy.isa(o, "CreateSnapshotRequest");
+    return __isa(o, "CreateSnapshotRequest");
   }
 }
 
@@ -6058,7 +6058,7 @@ export interface CreateSnapshotsRequest {
 
 export namespace CreateSnapshotsRequest {
   export function isa(o: any): o is CreateSnapshotsRequest {
-    return _smithy.isa(o, "CreateSnapshotsRequest");
+    return __isa(o, "CreateSnapshotsRequest");
   }
 }
 
@@ -6072,7 +6072,7 @@ export interface CreateSnapshotsResult extends $MetadataBearer {
 
 export namespace CreateSnapshotsResult {
   export function isa(o: any): o is CreateSnapshotsResult {
-    return _smithy.isa(o, "CreateSnapshotsResult");
+    return __isa(o, "CreateSnapshotsResult");
   }
 }
 
@@ -6101,7 +6101,7 @@ export interface CreateSpotDatafeedSubscriptionRequest {
 
 export namespace CreateSpotDatafeedSubscriptionRequest {
   export function isa(o: any): o is CreateSpotDatafeedSubscriptionRequest {
-    return _smithy.isa(o, "CreateSpotDatafeedSubscriptionRequest");
+    return __isa(o, "CreateSpotDatafeedSubscriptionRequest");
   }
 }
 
@@ -6118,7 +6118,7 @@ export interface CreateSpotDatafeedSubscriptionResult extends $MetadataBearer {
 
 export namespace CreateSpotDatafeedSubscriptionResult {
   export function isa(o: any): o is CreateSpotDatafeedSubscriptionResult {
-    return _smithy.isa(o, "CreateSpotDatafeedSubscriptionResult");
+    return __isa(o, "CreateSpotDatafeedSubscriptionResult");
   }
 }
 
@@ -6169,7 +6169,7 @@ export interface CreateSubnetRequest {
 
 export namespace CreateSubnetRequest {
   export function isa(o: any): o is CreateSubnetRequest {
-    return _smithy.isa(o, "CreateSubnetRequest");
+    return __isa(o, "CreateSubnetRequest");
   }
 }
 
@@ -6183,7 +6183,7 @@ export interface CreateSubnetResult extends $MetadataBearer {
 
 export namespace CreateSubnetResult {
   export function isa(o: any): o is CreateSubnetResult {
-    return _smithy.isa(o, "CreateSubnetResult");
+    return __isa(o, "CreateSubnetResult");
   }
 }
 
@@ -6211,7 +6211,7 @@ export interface CreateTagsRequest {
 
 export namespace CreateTagsRequest {
   export function isa(o: any): o is CreateTagsRequest {
-    return _smithy.isa(o, "CreateTagsRequest");
+    return __isa(o, "CreateTagsRequest");
   }
 }
 
@@ -6242,7 +6242,7 @@ export interface CreateTrafficMirrorFilterRequest {
 
 export namespace CreateTrafficMirrorFilterRequest {
   export function isa(o: any): o is CreateTrafficMirrorFilterRequest {
-    return _smithy.isa(o, "CreateTrafficMirrorFilterRequest");
+    return __isa(o, "CreateTrafficMirrorFilterRequest");
   }
 }
 
@@ -6261,7 +6261,7 @@ export interface CreateTrafficMirrorFilterResult extends $MetadataBearer {
 
 export namespace CreateTrafficMirrorFilterResult {
   export function isa(o: any): o is CreateTrafficMirrorFilterResult {
-    return _smithy.isa(o, "CreateTrafficMirrorFilterResult");
+    return __isa(o, "CreateTrafficMirrorFilterResult");
   }
 }
 
@@ -6334,7 +6334,7 @@ export interface CreateTrafficMirrorFilterRuleRequest {
 
 export namespace CreateTrafficMirrorFilterRuleRequest {
   export function isa(o: any): o is CreateTrafficMirrorFilterRuleRequest {
-    return _smithy.isa(o, "CreateTrafficMirrorFilterRuleRequest");
+    return __isa(o, "CreateTrafficMirrorFilterRuleRequest");
   }
 }
 
@@ -6353,7 +6353,7 @@ export interface CreateTrafficMirrorFilterRuleResult extends $MetadataBearer {
 
 export namespace CreateTrafficMirrorFilterRuleResult {
   export function isa(o: any): o is CreateTrafficMirrorFilterRuleResult {
-    return _smithy.isa(o, "CreateTrafficMirrorFilterRuleResult");
+    return __isa(o, "CreateTrafficMirrorFilterRuleResult");
   }
 }
 
@@ -6423,7 +6423,7 @@ export interface CreateTrafficMirrorSessionRequest {
 
 export namespace CreateTrafficMirrorSessionRequest {
   export function isa(o: any): o is CreateTrafficMirrorSessionRequest {
-    return _smithy.isa(o, "CreateTrafficMirrorSessionRequest");
+    return __isa(o, "CreateTrafficMirrorSessionRequest");
   }
 }
 
@@ -6442,7 +6442,7 @@ export interface CreateTrafficMirrorSessionResult extends $MetadataBearer {
 
 export namespace CreateTrafficMirrorSessionResult {
   export function isa(o: any): o is CreateTrafficMirrorSessionResult {
-    return _smithy.isa(o, "CreateTrafficMirrorSessionResult");
+    return __isa(o, "CreateTrafficMirrorSessionResult");
   }
 }
 
@@ -6483,7 +6483,7 @@ export interface CreateTrafficMirrorTargetRequest {
 
 export namespace CreateTrafficMirrorTargetRequest {
   export function isa(o: any): o is CreateTrafficMirrorTargetRequest {
-    return _smithy.isa(o, "CreateTrafficMirrorTargetRequest");
+    return __isa(o, "CreateTrafficMirrorTargetRequest");
   }
 }
 
@@ -6502,7 +6502,7 @@ export interface CreateTrafficMirrorTargetResult extends $MetadataBearer {
 
 export namespace CreateTrafficMirrorTargetResult {
   export function isa(o: any): o is CreateTrafficMirrorTargetResult {
-    return _smithy.isa(o, "CreateTrafficMirrorTargetResult");
+    return __isa(o, "CreateTrafficMirrorTargetResult");
   }
 }
 
@@ -6528,7 +6528,7 @@ export interface CreateTransitGatewayMulticastDomainRequest {
 
 export namespace CreateTransitGatewayMulticastDomainRequest {
   export function isa(o: any): o is CreateTransitGatewayMulticastDomainRequest {
-    return _smithy.isa(o, "CreateTransitGatewayMulticastDomainRequest");
+    return __isa(o, "CreateTransitGatewayMulticastDomainRequest");
   }
 }
 
@@ -6543,7 +6543,7 @@ export interface CreateTransitGatewayMulticastDomainResult
 
 export namespace CreateTransitGatewayMulticastDomainResult {
   export function isa(o: any): o is CreateTransitGatewayMulticastDomainResult {
-    return _smithy.isa(o, "CreateTransitGatewayMulticastDomainResult");
+    return __isa(o, "CreateTransitGatewayMulticastDomainResult");
   }
 }
 
@@ -6586,7 +6586,7 @@ export namespace CreateTransitGatewayPeeringAttachmentRequest {
   export function isa(
     o: any
   ): o is CreateTransitGatewayPeeringAttachmentRequest {
-    return _smithy.isa(o, "CreateTransitGatewayPeeringAttachmentRequest");
+    return __isa(o, "CreateTransitGatewayPeeringAttachmentRequest");
   }
 }
 
@@ -6603,7 +6603,7 @@ export namespace CreateTransitGatewayPeeringAttachmentResult {
   export function isa(
     o: any
   ): o is CreateTransitGatewayPeeringAttachmentResult {
-    return _smithy.isa(o, "CreateTransitGatewayPeeringAttachmentResult");
+    return __isa(o, "CreateTransitGatewayPeeringAttachmentResult");
   }
 }
 
@@ -6634,7 +6634,7 @@ export interface CreateTransitGatewayRequest {
 
 export namespace CreateTransitGatewayRequest {
   export function isa(o: any): o is CreateTransitGatewayRequest {
-    return _smithy.isa(o, "CreateTransitGatewayRequest");
+    return __isa(o, "CreateTransitGatewayRequest");
   }
 }
 
@@ -6648,7 +6648,7 @@ export interface CreateTransitGatewayResult extends $MetadataBearer {
 
 export namespace CreateTransitGatewayResult {
   export function isa(o: any): o is CreateTransitGatewayResult {
-    return _smithy.isa(o, "CreateTransitGatewayResult");
+    return __isa(o, "CreateTransitGatewayResult");
   }
 }
 
@@ -6685,7 +6685,7 @@ export interface CreateTransitGatewayRouteRequest {
 
 export namespace CreateTransitGatewayRouteRequest {
   export function isa(o: any): o is CreateTransitGatewayRouteRequest {
-    return _smithy.isa(o, "CreateTransitGatewayRouteRequest");
+    return __isa(o, "CreateTransitGatewayRouteRequest");
   }
 }
 
@@ -6699,7 +6699,7 @@ export interface CreateTransitGatewayRouteResult extends $MetadataBearer {
 
 export namespace CreateTransitGatewayRouteResult {
   export function isa(o: any): o is CreateTransitGatewayRouteResult {
-    return _smithy.isa(o, "CreateTransitGatewayRouteResult");
+    return __isa(o, "CreateTransitGatewayRouteResult");
   }
 }
 
@@ -6725,7 +6725,7 @@ export interface CreateTransitGatewayRouteTableRequest {
 
 export namespace CreateTransitGatewayRouteTableRequest {
   export function isa(o: any): o is CreateTransitGatewayRouteTableRequest {
-    return _smithy.isa(o, "CreateTransitGatewayRouteTableRequest");
+    return __isa(o, "CreateTransitGatewayRouteTableRequest");
   }
 }
 
@@ -6739,7 +6739,7 @@ export interface CreateTransitGatewayRouteTableResult extends $MetadataBearer {
 
 export namespace CreateTransitGatewayRouteTableResult {
   export function isa(o: any): o is CreateTransitGatewayRouteTableResult {
-    return _smithy.isa(o, "CreateTransitGatewayRouteTableResult");
+    return __isa(o, "CreateTransitGatewayRouteTableResult");
   }
 }
 
@@ -6782,7 +6782,7 @@ export interface CreateTransitGatewayVpcAttachmentRequest {
 
 export namespace CreateTransitGatewayVpcAttachmentRequest {
   export function isa(o: any): o is CreateTransitGatewayVpcAttachmentRequest {
-    return _smithy.isa(o, "CreateTransitGatewayVpcAttachmentRequest");
+    return __isa(o, "CreateTransitGatewayVpcAttachmentRequest");
   }
 }
 
@@ -6806,7 +6806,7 @@ export namespace CreateTransitGatewayVpcAttachmentRequestOptions {
   export function isa(
     o: any
   ): o is CreateTransitGatewayVpcAttachmentRequestOptions {
-    return _smithy.isa(o, "CreateTransitGatewayVpcAttachmentRequestOptions");
+    return __isa(o, "CreateTransitGatewayVpcAttachmentRequestOptions");
   }
 }
 
@@ -6821,7 +6821,7 @@ export interface CreateTransitGatewayVpcAttachmentResult
 
 export namespace CreateTransitGatewayVpcAttachmentResult {
   export function isa(o: any): o is CreateTransitGatewayVpcAttachmentResult {
-    return _smithy.isa(o, "CreateTransitGatewayVpcAttachmentResult");
+    return __isa(o, "CreateTransitGatewayVpcAttachmentResult");
   }
 }
 
@@ -6844,7 +6844,7 @@ export interface CreateVolumePermission {
 
 export namespace CreateVolumePermission {
   export function isa(o: any): o is CreateVolumePermission {
-    return _smithy.isa(o, "CreateVolumePermission");
+    return __isa(o, "CreateVolumePermission");
   }
 }
 
@@ -6866,7 +6866,7 @@ export interface CreateVolumePermissionModifications {
 
 export namespace CreateVolumePermissionModifications {
   export function isa(o: any): o is CreateVolumePermissionModifications {
-    return _smithy.isa(o, "CreateVolumePermissionModifications");
+    return __isa(o, "CreateVolumePermissionModifications");
   }
 }
 
@@ -6976,7 +6976,7 @@ export interface CreateVolumeRequest {
 
 export namespace CreateVolumeRequest {
   export function isa(o: any): o is CreateVolumeRequest {
-    return _smithy.isa(o, "CreateVolumeRequest");
+    return __isa(o, "CreateVolumeRequest");
   }
 }
 
@@ -7023,7 +7023,7 @@ export namespace CreateVpcEndpointConnectionNotificationRequest {
   export function isa(
     o: any
   ): o is CreateVpcEndpointConnectionNotificationRequest {
-    return _smithy.isa(o, "CreateVpcEndpointConnectionNotificationRequest");
+    return __isa(o, "CreateVpcEndpointConnectionNotificationRequest");
   }
 }
 
@@ -7046,7 +7046,7 @@ export namespace CreateVpcEndpointConnectionNotificationResult {
   export function isa(
     o: any
   ): o is CreateVpcEndpointConnectionNotificationResult {
-    return _smithy.isa(o, "CreateVpcEndpointConnectionNotificationResult");
+    return __isa(o, "CreateVpcEndpointConnectionNotificationResult");
   }
 }
 
@@ -7130,7 +7130,7 @@ export interface CreateVpcEndpointRequest {
 
 export namespace CreateVpcEndpointRequest {
   export function isa(o: any): o is CreateVpcEndpointRequest {
-    return _smithy.isa(o, "CreateVpcEndpointRequest");
+    return __isa(o, "CreateVpcEndpointRequest");
   }
 }
 
@@ -7153,7 +7153,7 @@ export interface CreateVpcEndpointResult extends $MetadataBearer {
 
 export namespace CreateVpcEndpointResult {
   export function isa(o: any): o is CreateVpcEndpointResult {
-    return _smithy.isa(o, "CreateVpcEndpointResult");
+    return __isa(o, "CreateVpcEndpointResult");
   }
 }
 
@@ -7195,7 +7195,7 @@ export namespace CreateVpcEndpointServiceConfigurationRequest {
   export function isa(
     o: any
   ): o is CreateVpcEndpointServiceConfigurationRequest {
-    return _smithy.isa(o, "CreateVpcEndpointServiceConfigurationRequest");
+    return __isa(o, "CreateVpcEndpointServiceConfigurationRequest");
   }
 }
 
@@ -7218,7 +7218,7 @@ export namespace CreateVpcEndpointServiceConfigurationResult {
   export function isa(
     o: any
   ): o is CreateVpcEndpointServiceConfigurationResult {
-    return _smithy.isa(o, "CreateVpcEndpointServiceConfigurationResult");
+    return __isa(o, "CreateVpcEndpointServiceConfigurationResult");
   }
 }
 
@@ -7259,7 +7259,7 @@ export interface CreateVpcPeeringConnectionRequest {
 
 export namespace CreateVpcPeeringConnectionRequest {
   export function isa(o: any): o is CreateVpcPeeringConnectionRequest {
-    return _smithy.isa(o, "CreateVpcPeeringConnectionRequest");
+    return __isa(o, "CreateVpcPeeringConnectionRequest");
   }
 }
 
@@ -7273,7 +7273,7 @@ export interface CreateVpcPeeringConnectionResult extends $MetadataBearer {
 
 export namespace CreateVpcPeeringConnectionResult {
   export function isa(o: any): o is CreateVpcPeeringConnectionResult {
-    return _smithy.isa(o, "CreateVpcPeeringConnectionResult");
+    return __isa(o, "CreateVpcPeeringConnectionResult");
   }
 }
 
@@ -7331,7 +7331,7 @@ export interface CreateVpcRequest {
 
 export namespace CreateVpcRequest {
   export function isa(o: any): o is CreateVpcRequest {
-    return _smithy.isa(o, "CreateVpcRequest");
+    return __isa(o, "CreateVpcRequest");
   }
 }
 
@@ -7345,7 +7345,7 @@ export interface CreateVpcResult extends $MetadataBearer {
 
 export namespace CreateVpcResult {
   export function isa(o: any): o is CreateVpcResult {
-    return _smithy.isa(o, "CreateVpcResult");
+    return __isa(o, "CreateVpcResult");
   }
 }
 
@@ -7389,7 +7389,7 @@ export interface CreateVpnConnectionRequest {
 
 export namespace CreateVpnConnectionRequest {
   export function isa(o: any): o is CreateVpnConnectionRequest {
-    return _smithy.isa(o, "CreateVpnConnectionRequest");
+    return __isa(o, "CreateVpnConnectionRequest");
   }
 }
 
@@ -7406,7 +7406,7 @@ export interface CreateVpnConnectionResult extends $MetadataBearer {
 
 export namespace CreateVpnConnectionResult {
   export function isa(o: any): o is CreateVpnConnectionResult {
-    return _smithy.isa(o, "CreateVpnConnectionResult");
+    return __isa(o, "CreateVpnConnectionResult");
   }
 }
 
@@ -7428,7 +7428,7 @@ export interface CreateVpnConnectionRouteRequest {
 
 export namespace CreateVpnConnectionRouteRequest {
   export function isa(o: any): o is CreateVpnConnectionRouteRequest {
-    return _smithy.isa(o, "CreateVpnConnectionRouteRequest");
+    return __isa(o, "CreateVpnConnectionRouteRequest");
   }
 }
 
@@ -7463,7 +7463,7 @@ export interface CreateVpnGatewayRequest {
 
 export namespace CreateVpnGatewayRequest {
   export function isa(o: any): o is CreateVpnGatewayRequest {
-    return _smithy.isa(o, "CreateVpnGatewayRequest");
+    return __isa(o, "CreateVpnGatewayRequest");
   }
 }
 
@@ -7480,7 +7480,7 @@ export interface CreateVpnGatewayResult extends $MetadataBearer {
 
 export namespace CreateVpnGatewayResult {
   export function isa(o: any): o is CreateVpnGatewayResult {
-    return _smithy.isa(o, "CreateVpnGatewayResult");
+    return __isa(o, "CreateVpnGatewayResult");
   }
 }
 
@@ -7498,7 +7498,7 @@ export interface CreditSpecification {
 
 export namespace CreditSpecification {
   export function isa(o: any): o is CreditSpecification {
-    return _smithy.isa(o, "CreditSpecification");
+    return __isa(o, "CreditSpecification");
   }
 }
 
@@ -7516,7 +7516,7 @@ export interface CreditSpecificationRequest {
 
 export namespace CreditSpecificationRequest {
   export function isa(o: any): o is CreditSpecificationRequest {
-    return _smithy.isa(o, "CreditSpecificationRequest");
+    return __isa(o, "CreditSpecificationRequest");
   }
 }
 
@@ -7571,7 +7571,7 @@ export interface CustomerGateway {
 
 export namespace CustomerGateway {
   export function isa(o: any): o is CustomerGateway {
-    return _smithy.isa(o, "CustomerGateway");
+    return __isa(o, "CustomerGateway");
   }
 }
 
@@ -7601,7 +7601,7 @@ export interface DeleteClientVpnEndpointRequest {
 
 export namespace DeleteClientVpnEndpointRequest {
   export function isa(o: any): o is DeleteClientVpnEndpointRequest {
-    return _smithy.isa(o, "DeleteClientVpnEndpointRequest");
+    return __isa(o, "DeleteClientVpnEndpointRequest");
   }
 }
 
@@ -7615,7 +7615,7 @@ export interface DeleteClientVpnEndpointResult extends $MetadataBearer {
 
 export namespace DeleteClientVpnEndpointResult {
   export function isa(o: any): o is DeleteClientVpnEndpointResult {
-    return _smithy.isa(o, "DeleteClientVpnEndpointResult");
+    return __isa(o, "DeleteClientVpnEndpointResult");
   }
 }
 
@@ -7644,7 +7644,7 @@ export interface DeleteClientVpnRouteRequest {
 
 export namespace DeleteClientVpnRouteRequest {
   export function isa(o: any): o is DeleteClientVpnRouteRequest {
-    return _smithy.isa(o, "DeleteClientVpnRouteRequest");
+    return __isa(o, "DeleteClientVpnRouteRequest");
   }
 }
 
@@ -7658,7 +7658,7 @@ export interface DeleteClientVpnRouteResult extends $MetadataBearer {
 
 export namespace DeleteClientVpnRouteResult {
   export function isa(o: any): o is DeleteClientVpnRouteResult {
-    return _smithy.isa(o, "DeleteClientVpnRouteResult");
+    return __isa(o, "DeleteClientVpnRouteResult");
   }
 }
 
@@ -7682,7 +7682,7 @@ export interface DeleteCustomerGatewayRequest {
 
 export namespace DeleteCustomerGatewayRequest {
   export function isa(o: any): o is DeleteCustomerGatewayRequest {
-    return _smithy.isa(o, "DeleteCustomerGatewayRequest");
+    return __isa(o, "DeleteCustomerGatewayRequest");
   }
 }
 
@@ -7703,7 +7703,7 @@ export interface DeleteDhcpOptionsRequest {
 
 export namespace DeleteDhcpOptionsRequest {
   export function isa(o: any): o is DeleteDhcpOptionsRequest {
-    return _smithy.isa(o, "DeleteDhcpOptionsRequest");
+    return __isa(o, "DeleteDhcpOptionsRequest");
   }
 }
 
@@ -7724,7 +7724,7 @@ export interface DeleteEgressOnlyInternetGatewayRequest {
 
 export namespace DeleteEgressOnlyInternetGatewayRequest {
   export function isa(o: any): o is DeleteEgressOnlyInternetGatewayRequest {
-    return _smithy.isa(o, "DeleteEgressOnlyInternetGatewayRequest");
+    return __isa(o, "DeleteEgressOnlyInternetGatewayRequest");
   }
 }
 
@@ -7738,7 +7738,7 @@ export interface DeleteEgressOnlyInternetGatewayResult extends $MetadataBearer {
 
 export namespace DeleteEgressOnlyInternetGatewayResult {
   export function isa(o: any): o is DeleteEgressOnlyInternetGatewayResult {
-    return _smithy.isa(o, "DeleteEgressOnlyInternetGatewayResult");
+    return __isa(o, "DeleteEgressOnlyInternetGatewayResult");
   }
 }
 
@@ -7760,7 +7760,7 @@ export interface DeleteFleetError {
 
 export namespace DeleteFleetError {
   export function isa(o: any): o is DeleteFleetError {
-    return _smithy.isa(o, "DeleteFleetError");
+    return __isa(o, "DeleteFleetError");
   }
 }
 
@@ -7789,7 +7789,7 @@ export interface DeleteFleetErrorItem {
 
 export namespace DeleteFleetErrorItem {
   export function isa(o: any): o is DeleteFleetErrorItem {
-    return _smithy.isa(o, "DeleteFleetErrorItem");
+    return __isa(o, "DeleteFleetErrorItem");
   }
 }
 
@@ -7816,7 +7816,7 @@ export interface DeleteFleetSuccessItem {
 
 export namespace DeleteFleetSuccessItem {
   export function isa(o: any): o is DeleteFleetSuccessItem {
-    return _smithy.isa(o, "DeleteFleetSuccessItem");
+    return __isa(o, "DeleteFleetSuccessItem");
   }
 }
 
@@ -7843,7 +7843,7 @@ export interface DeleteFleetsRequest {
 
 export namespace DeleteFleetsRequest {
   export function isa(o: any): o is DeleteFleetsRequest {
-    return _smithy.isa(o, "DeleteFleetsRequest");
+    return __isa(o, "DeleteFleetsRequest");
   }
 }
 
@@ -7862,7 +7862,7 @@ export interface DeleteFleetsResult extends $MetadataBearer {
 
 export namespace DeleteFleetsResult {
   export function isa(o: any): o is DeleteFleetsResult {
-    return _smithy.isa(o, "DeleteFleetsResult");
+    return __isa(o, "DeleteFleetsResult");
   }
 }
 
@@ -7884,7 +7884,7 @@ export interface DeleteFlowLogsRequest {
 
 export namespace DeleteFlowLogsRequest {
   export function isa(o: any): o is DeleteFlowLogsRequest {
-    return _smithy.isa(o, "DeleteFlowLogsRequest");
+    return __isa(o, "DeleteFlowLogsRequest");
   }
 }
 
@@ -7898,7 +7898,7 @@ export interface DeleteFlowLogsResult extends $MetadataBearer {
 
 export namespace DeleteFlowLogsResult {
   export function isa(o: any): o is DeleteFlowLogsResult {
-    return _smithy.isa(o, "DeleteFlowLogsResult");
+    return __isa(o, "DeleteFlowLogsResult");
   }
 }
 
@@ -7919,7 +7919,7 @@ export interface DeleteFpgaImageRequest {
 
 export namespace DeleteFpgaImageRequest {
   export function isa(o: any): o is DeleteFpgaImageRequest {
-    return _smithy.isa(o, "DeleteFpgaImageRequest");
+    return __isa(o, "DeleteFpgaImageRequest");
   }
 }
 
@@ -7933,7 +7933,7 @@ export interface DeleteFpgaImageResult extends $MetadataBearer {
 
 export namespace DeleteFpgaImageResult {
   export function isa(o: any): o is DeleteFpgaImageResult {
-    return _smithy.isa(o, "DeleteFpgaImageResult");
+    return __isa(o, "DeleteFpgaImageResult");
   }
 }
 
@@ -7954,7 +7954,7 @@ export interface DeleteInternetGatewayRequest {
 
 export namespace DeleteInternetGatewayRequest {
   export function isa(o: any): o is DeleteInternetGatewayRequest {
-    return _smithy.isa(o, "DeleteInternetGatewayRequest");
+    return __isa(o, "DeleteInternetGatewayRequest");
   }
 }
 
@@ -7975,7 +7975,7 @@ export interface DeleteKeyPairRequest {
 
 export namespace DeleteKeyPairRequest {
   export function isa(o: any): o is DeleteKeyPairRequest {
-    return _smithy.isa(o, "DeleteKeyPairRequest");
+    return __isa(o, "DeleteKeyPairRequest");
   }
 }
 
@@ -8004,7 +8004,7 @@ export interface DeleteLaunchTemplateRequest {
 
 export namespace DeleteLaunchTemplateRequest {
   export function isa(o: any): o is DeleteLaunchTemplateRequest {
-    return _smithy.isa(o, "DeleteLaunchTemplateRequest");
+    return __isa(o, "DeleteLaunchTemplateRequest");
   }
 }
 
@@ -8018,7 +8018,7 @@ export interface DeleteLaunchTemplateResult extends $MetadataBearer {
 
 export namespace DeleteLaunchTemplateResult {
   export function isa(o: any): o is DeleteLaunchTemplateResult {
-    return _smithy.isa(o, "DeleteLaunchTemplateResult");
+    return __isa(o, "DeleteLaunchTemplateResult");
   }
 }
 
@@ -8052,7 +8052,7 @@ export interface DeleteLaunchTemplateVersionsRequest {
 
 export namespace DeleteLaunchTemplateVersionsRequest {
   export function isa(o: any): o is DeleteLaunchTemplateVersionsRequest {
-    return _smithy.isa(o, "DeleteLaunchTemplateVersionsRequest");
+    return __isa(o, "DeleteLaunchTemplateVersionsRequest");
   }
 }
 
@@ -8086,7 +8086,7 @@ export namespace DeleteLaunchTemplateVersionsResponseErrorItem {
   export function isa(
     o: any
   ): o is DeleteLaunchTemplateVersionsResponseErrorItem {
-    return _smithy.isa(o, "DeleteLaunchTemplateVersionsResponseErrorItem");
+    return __isa(o, "DeleteLaunchTemplateVersionsResponseErrorItem");
   }
 }
 
@@ -8115,7 +8115,7 @@ export namespace DeleteLaunchTemplateVersionsResponseSuccessItem {
   export function isa(
     o: any
   ): o is DeleteLaunchTemplateVersionsResponseSuccessItem {
-    return _smithy.isa(o, "DeleteLaunchTemplateVersionsResponseSuccessItem");
+    return __isa(o, "DeleteLaunchTemplateVersionsResponseSuccessItem");
   }
 }
 
@@ -8139,7 +8139,7 @@ export interface DeleteLaunchTemplateVersionsResult extends $MetadataBearer {
 
 export namespace DeleteLaunchTemplateVersionsResult {
   export function isa(o: any): o is DeleteLaunchTemplateVersionsResult {
-    return _smithy.isa(o, "DeleteLaunchTemplateVersionsResult");
+    return __isa(o, "DeleteLaunchTemplateVersionsResult");
   }
 }
 
@@ -8165,7 +8165,7 @@ export interface DeleteLocalGatewayRouteRequest {
 
 export namespace DeleteLocalGatewayRouteRequest {
   export function isa(o: any): o is DeleteLocalGatewayRouteRequest {
-    return _smithy.isa(o, "DeleteLocalGatewayRouteRequest");
+    return __isa(o, "DeleteLocalGatewayRouteRequest");
   }
 }
 
@@ -8179,7 +8179,7 @@ export interface DeleteLocalGatewayRouteResult extends $MetadataBearer {
 
 export namespace DeleteLocalGatewayRouteResult {
   export function isa(o: any): o is DeleteLocalGatewayRouteResult {
-    return _smithy.isa(o, "DeleteLocalGatewayRouteResult");
+    return __isa(o, "DeleteLocalGatewayRouteResult");
   }
 }
 
@@ -8202,7 +8202,7 @@ export namespace DeleteLocalGatewayRouteTableVpcAssociationRequest {
   export function isa(
     o: any
   ): o is DeleteLocalGatewayRouteTableVpcAssociationRequest {
-    return _smithy.isa(o, "DeleteLocalGatewayRouteTableVpcAssociationRequest");
+    return __isa(o, "DeleteLocalGatewayRouteTableVpcAssociationRequest");
   }
 }
 
@@ -8219,7 +8219,7 @@ export namespace DeleteLocalGatewayRouteTableVpcAssociationResult {
   export function isa(
     o: any
   ): o is DeleteLocalGatewayRouteTableVpcAssociationResult {
-    return _smithy.isa(o, "DeleteLocalGatewayRouteTableVpcAssociationResult");
+    return __isa(o, "DeleteLocalGatewayRouteTableVpcAssociationResult");
   }
 }
 
@@ -8233,7 +8233,7 @@ export interface DeleteNatGatewayRequest {
 
 export namespace DeleteNatGatewayRequest {
   export function isa(o: any): o is DeleteNatGatewayRequest {
-    return _smithy.isa(o, "DeleteNatGatewayRequest");
+    return __isa(o, "DeleteNatGatewayRequest");
   }
 }
 
@@ -8247,7 +8247,7 @@ export interface DeleteNatGatewayResult extends $MetadataBearer {
 
 export namespace DeleteNatGatewayResult {
   export function isa(o: any): o is DeleteNatGatewayResult {
-    return _smithy.isa(o, "DeleteNatGatewayResult");
+    return __isa(o, "DeleteNatGatewayResult");
   }
 }
 
@@ -8278,7 +8278,7 @@ export interface DeleteNetworkAclEntryRequest {
 
 export namespace DeleteNetworkAclEntryRequest {
   export function isa(o: any): o is DeleteNetworkAclEntryRequest {
-    return _smithy.isa(o, "DeleteNetworkAclEntryRequest");
+    return __isa(o, "DeleteNetworkAclEntryRequest");
   }
 }
 
@@ -8299,7 +8299,7 @@ export interface DeleteNetworkAclRequest {
 
 export namespace DeleteNetworkAclRequest {
   export function isa(o: any): o is DeleteNetworkAclRequest {
-    return _smithy.isa(o, "DeleteNetworkAclRequest");
+    return __isa(o, "DeleteNetworkAclRequest");
   }
 }
 
@@ -8329,7 +8329,7 @@ export interface DeleteNetworkInterfacePermissionRequest {
 
 export namespace DeleteNetworkInterfacePermissionRequest {
   export function isa(o: any): o is DeleteNetworkInterfacePermissionRequest {
-    return _smithy.isa(o, "DeleteNetworkInterfacePermissionRequest");
+    return __isa(o, "DeleteNetworkInterfacePermissionRequest");
   }
 }
 
@@ -8347,7 +8347,7 @@ export interface DeleteNetworkInterfacePermissionResult
 
 export namespace DeleteNetworkInterfacePermissionResult {
   export function isa(o: any): o is DeleteNetworkInterfacePermissionResult {
-    return _smithy.isa(o, "DeleteNetworkInterfacePermissionResult");
+    return __isa(o, "DeleteNetworkInterfacePermissionResult");
   }
 }
 
@@ -8371,7 +8371,7 @@ export interface DeleteNetworkInterfaceRequest {
 
 export namespace DeleteNetworkInterfaceRequest {
   export function isa(o: any): o is DeleteNetworkInterfaceRequest {
-    return _smithy.isa(o, "DeleteNetworkInterfaceRequest");
+    return __isa(o, "DeleteNetworkInterfaceRequest");
   }
 }
 
@@ -8392,7 +8392,7 @@ export interface DeletePlacementGroupRequest {
 
 export namespace DeletePlacementGroupRequest {
   export function isa(o: any): o is DeletePlacementGroupRequest {
-    return _smithy.isa(o, "DeletePlacementGroupRequest");
+    return __isa(o, "DeletePlacementGroupRequest");
   }
 }
 
@@ -8414,7 +8414,7 @@ export interface DeleteQueuedReservedInstancesError {
 
 export namespace DeleteQueuedReservedInstancesError {
   export function isa(o: any): o is DeleteQueuedReservedInstancesError {
-    return _smithy.isa(o, "DeleteQueuedReservedInstancesError");
+    return __isa(o, "DeleteQueuedReservedInstancesError");
   }
 }
 
@@ -8441,7 +8441,7 @@ export interface DeleteQueuedReservedInstancesRequest {
 
 export namespace DeleteQueuedReservedInstancesRequest {
   export function isa(o: any): o is DeleteQueuedReservedInstancesRequest {
-    return _smithy.isa(o, "DeleteQueuedReservedInstancesRequest");
+    return __isa(o, "DeleteQueuedReservedInstancesRequest");
   }
 }
 
@@ -8460,7 +8460,7 @@ export interface DeleteQueuedReservedInstancesResult extends $MetadataBearer {
 
 export namespace DeleteQueuedReservedInstancesResult {
   export function isa(o: any): o is DeleteQueuedReservedInstancesResult {
-    return _smithy.isa(o, "DeleteQueuedReservedInstancesResult");
+    return __isa(o, "DeleteQueuedReservedInstancesResult");
   }
 }
 
@@ -8491,7 +8491,7 @@ export interface DeleteRouteRequest {
 
 export namespace DeleteRouteRequest {
   export function isa(o: any): o is DeleteRouteRequest {
-    return _smithy.isa(o, "DeleteRouteRequest");
+    return __isa(o, "DeleteRouteRequest");
   }
 }
 
@@ -8512,7 +8512,7 @@ export interface DeleteRouteTableRequest {
 
 export namespace DeleteRouteTableRequest {
   export function isa(o: any): o is DeleteRouteTableRequest {
-    return _smithy.isa(o, "DeleteRouteTableRequest");
+    return __isa(o, "DeleteRouteTableRequest");
   }
 }
 
@@ -8538,7 +8538,7 @@ export interface DeleteSecurityGroupRequest {
 
 export namespace DeleteSecurityGroupRequest {
   export function isa(o: any): o is DeleteSecurityGroupRequest {
-    return _smithy.isa(o, "DeleteSecurityGroupRequest");
+    return __isa(o, "DeleteSecurityGroupRequest");
   }
 }
 
@@ -8559,7 +8559,7 @@ export interface DeleteSnapshotRequest {
 
 export namespace DeleteSnapshotRequest {
   export function isa(o: any): o is DeleteSnapshotRequest {
-    return _smithy.isa(o, "DeleteSnapshotRequest");
+    return __isa(o, "DeleteSnapshotRequest");
   }
 }
 
@@ -8578,7 +8578,7 @@ export interface DeleteSpotDatafeedSubscriptionRequest {
 
 export namespace DeleteSpotDatafeedSubscriptionRequest {
   export function isa(o: any): o is DeleteSpotDatafeedSubscriptionRequest {
-    return _smithy.isa(o, "DeleteSpotDatafeedSubscriptionRequest");
+    return __isa(o, "DeleteSpotDatafeedSubscriptionRequest");
   }
 }
 
@@ -8599,7 +8599,7 @@ export interface DeleteSubnetRequest {
 
 export namespace DeleteSubnetRequest {
   export function isa(o: any): o is DeleteSubnetRequest {
-    return _smithy.isa(o, "DeleteSubnetRequest");
+    return __isa(o, "DeleteSubnetRequest");
   }
 }
 
@@ -8632,7 +8632,7 @@ export interface DeleteTagsRequest {
 
 export namespace DeleteTagsRequest {
   export function isa(o: any): o is DeleteTagsRequest {
-    return _smithy.isa(o, "DeleteTagsRequest");
+    return __isa(o, "DeleteTagsRequest");
   }
 }
 
@@ -8653,7 +8653,7 @@ export interface DeleteTrafficMirrorFilterRequest {
 
 export namespace DeleteTrafficMirrorFilterRequest {
   export function isa(o: any): o is DeleteTrafficMirrorFilterRequest {
-    return _smithy.isa(o, "DeleteTrafficMirrorFilterRequest");
+    return __isa(o, "DeleteTrafficMirrorFilterRequest");
   }
 }
 
@@ -8667,7 +8667,7 @@ export interface DeleteTrafficMirrorFilterResult extends $MetadataBearer {
 
 export namespace DeleteTrafficMirrorFilterResult {
   export function isa(o: any): o is DeleteTrafficMirrorFilterResult {
-    return _smithy.isa(o, "DeleteTrafficMirrorFilterResult");
+    return __isa(o, "DeleteTrafficMirrorFilterResult");
   }
 }
 
@@ -8688,7 +8688,7 @@ export interface DeleteTrafficMirrorFilterRuleRequest {
 
 export namespace DeleteTrafficMirrorFilterRuleRequest {
   export function isa(o: any): o is DeleteTrafficMirrorFilterRuleRequest {
-    return _smithy.isa(o, "DeleteTrafficMirrorFilterRuleRequest");
+    return __isa(o, "DeleteTrafficMirrorFilterRuleRequest");
   }
 }
 
@@ -8702,7 +8702,7 @@ export interface DeleteTrafficMirrorFilterRuleResult extends $MetadataBearer {
 
 export namespace DeleteTrafficMirrorFilterRuleResult {
   export function isa(o: any): o is DeleteTrafficMirrorFilterRuleResult {
-    return _smithy.isa(o, "DeleteTrafficMirrorFilterRuleResult");
+    return __isa(o, "DeleteTrafficMirrorFilterRuleResult");
   }
 }
 
@@ -8723,7 +8723,7 @@ export interface DeleteTrafficMirrorSessionRequest {
 
 export namespace DeleteTrafficMirrorSessionRequest {
   export function isa(o: any): o is DeleteTrafficMirrorSessionRequest {
-    return _smithy.isa(o, "DeleteTrafficMirrorSessionRequest");
+    return __isa(o, "DeleteTrafficMirrorSessionRequest");
   }
 }
 
@@ -8737,7 +8737,7 @@ export interface DeleteTrafficMirrorSessionResult extends $MetadataBearer {
 
 export namespace DeleteTrafficMirrorSessionResult {
   export function isa(o: any): o is DeleteTrafficMirrorSessionResult {
-    return _smithy.isa(o, "DeleteTrafficMirrorSessionResult");
+    return __isa(o, "DeleteTrafficMirrorSessionResult");
   }
 }
 
@@ -8758,7 +8758,7 @@ export interface DeleteTrafficMirrorTargetRequest {
 
 export namespace DeleteTrafficMirrorTargetRequest {
   export function isa(o: any): o is DeleteTrafficMirrorTargetRequest {
-    return _smithy.isa(o, "DeleteTrafficMirrorTargetRequest");
+    return __isa(o, "DeleteTrafficMirrorTargetRequest");
   }
 }
 
@@ -8772,7 +8772,7 @@ export interface DeleteTrafficMirrorTargetResult extends $MetadataBearer {
 
 export namespace DeleteTrafficMirrorTargetResult {
   export function isa(o: any): o is DeleteTrafficMirrorTargetResult {
-    return _smithy.isa(o, "DeleteTrafficMirrorTargetResult");
+    return __isa(o, "DeleteTrafficMirrorTargetResult");
   }
 }
 
@@ -8793,7 +8793,7 @@ export interface DeleteTransitGatewayMulticastDomainRequest {
 
 export namespace DeleteTransitGatewayMulticastDomainRequest {
   export function isa(o: any): o is DeleteTransitGatewayMulticastDomainRequest {
-    return _smithy.isa(o, "DeleteTransitGatewayMulticastDomainRequest");
+    return __isa(o, "DeleteTransitGatewayMulticastDomainRequest");
   }
 }
 
@@ -8808,7 +8808,7 @@ export interface DeleteTransitGatewayMulticastDomainResult
 
 export namespace DeleteTransitGatewayMulticastDomainResult {
   export function isa(o: any): o is DeleteTransitGatewayMulticastDomainResult {
-    return _smithy.isa(o, "DeleteTransitGatewayMulticastDomainResult");
+    return __isa(o, "DeleteTransitGatewayMulticastDomainResult");
   }
 }
 
@@ -8831,7 +8831,7 @@ export namespace DeleteTransitGatewayPeeringAttachmentRequest {
   export function isa(
     o: any
   ): o is DeleteTransitGatewayPeeringAttachmentRequest {
-    return _smithy.isa(o, "DeleteTransitGatewayPeeringAttachmentRequest");
+    return __isa(o, "DeleteTransitGatewayPeeringAttachmentRequest");
   }
 }
 
@@ -8848,7 +8848,7 @@ export namespace DeleteTransitGatewayPeeringAttachmentResult {
   export function isa(
     o: any
   ): o is DeleteTransitGatewayPeeringAttachmentResult {
-    return _smithy.isa(o, "DeleteTransitGatewayPeeringAttachmentResult");
+    return __isa(o, "DeleteTransitGatewayPeeringAttachmentResult");
   }
 }
 
@@ -8869,7 +8869,7 @@ export interface DeleteTransitGatewayRequest {
 
 export namespace DeleteTransitGatewayRequest {
   export function isa(o: any): o is DeleteTransitGatewayRequest {
-    return _smithy.isa(o, "DeleteTransitGatewayRequest");
+    return __isa(o, "DeleteTransitGatewayRequest");
   }
 }
 
@@ -8883,7 +8883,7 @@ export interface DeleteTransitGatewayResult extends $MetadataBearer {
 
 export namespace DeleteTransitGatewayResult {
   export function isa(o: any): o is DeleteTransitGatewayResult {
-    return _smithy.isa(o, "DeleteTransitGatewayResult");
+    return __isa(o, "DeleteTransitGatewayResult");
   }
 }
 
@@ -8909,7 +8909,7 @@ export interface DeleteTransitGatewayRouteRequest {
 
 export namespace DeleteTransitGatewayRouteRequest {
   export function isa(o: any): o is DeleteTransitGatewayRouteRequest {
-    return _smithy.isa(o, "DeleteTransitGatewayRouteRequest");
+    return __isa(o, "DeleteTransitGatewayRouteRequest");
   }
 }
 
@@ -8923,7 +8923,7 @@ export interface DeleteTransitGatewayRouteResult extends $MetadataBearer {
 
 export namespace DeleteTransitGatewayRouteResult {
   export function isa(o: any): o is DeleteTransitGatewayRouteResult {
-    return _smithy.isa(o, "DeleteTransitGatewayRouteResult");
+    return __isa(o, "DeleteTransitGatewayRouteResult");
   }
 }
 
@@ -8944,7 +8944,7 @@ export interface DeleteTransitGatewayRouteTableRequest {
 
 export namespace DeleteTransitGatewayRouteTableRequest {
   export function isa(o: any): o is DeleteTransitGatewayRouteTableRequest {
-    return _smithy.isa(o, "DeleteTransitGatewayRouteTableRequest");
+    return __isa(o, "DeleteTransitGatewayRouteTableRequest");
   }
 }
 
@@ -8958,7 +8958,7 @@ export interface DeleteTransitGatewayRouteTableResult extends $MetadataBearer {
 
 export namespace DeleteTransitGatewayRouteTableResult {
   export function isa(o: any): o is DeleteTransitGatewayRouteTableResult {
-    return _smithy.isa(o, "DeleteTransitGatewayRouteTableResult");
+    return __isa(o, "DeleteTransitGatewayRouteTableResult");
   }
 }
 
@@ -8979,7 +8979,7 @@ export interface DeleteTransitGatewayVpcAttachmentRequest {
 
 export namespace DeleteTransitGatewayVpcAttachmentRequest {
   export function isa(o: any): o is DeleteTransitGatewayVpcAttachmentRequest {
-    return _smithy.isa(o, "DeleteTransitGatewayVpcAttachmentRequest");
+    return __isa(o, "DeleteTransitGatewayVpcAttachmentRequest");
   }
 }
 
@@ -8994,7 +8994,7 @@ export interface DeleteTransitGatewayVpcAttachmentResult
 
 export namespace DeleteTransitGatewayVpcAttachmentResult {
   export function isa(o: any): o is DeleteTransitGatewayVpcAttachmentResult {
-    return _smithy.isa(o, "DeleteTransitGatewayVpcAttachmentResult");
+    return __isa(o, "DeleteTransitGatewayVpcAttachmentResult");
   }
 }
 
@@ -9015,7 +9015,7 @@ export interface DeleteVolumeRequest {
 
 export namespace DeleteVolumeRequest {
   export function isa(o: any): o is DeleteVolumeRequest {
-    return _smithy.isa(o, "DeleteVolumeRequest");
+    return __isa(o, "DeleteVolumeRequest");
   }
 }
 
@@ -9038,7 +9038,7 @@ export namespace DeleteVpcEndpointConnectionNotificationsRequest {
   export function isa(
     o: any
   ): o is DeleteVpcEndpointConnectionNotificationsRequest {
-    return _smithy.isa(o, "DeleteVpcEndpointConnectionNotificationsRequest");
+    return __isa(o, "DeleteVpcEndpointConnectionNotificationsRequest");
   }
 }
 
@@ -9056,7 +9056,7 @@ export namespace DeleteVpcEndpointConnectionNotificationsResult {
   export function isa(
     o: any
   ): o is DeleteVpcEndpointConnectionNotificationsResult {
-    return _smithy.isa(o, "DeleteVpcEndpointConnectionNotificationsResult");
+    return __isa(o, "DeleteVpcEndpointConnectionNotificationsResult");
   }
 }
 
@@ -9079,7 +9079,7 @@ export namespace DeleteVpcEndpointServiceConfigurationsRequest {
   export function isa(
     o: any
   ): o is DeleteVpcEndpointServiceConfigurationsRequest {
-    return _smithy.isa(o, "DeleteVpcEndpointServiceConfigurationsRequest");
+    return __isa(o, "DeleteVpcEndpointServiceConfigurationsRequest");
   }
 }
 
@@ -9097,7 +9097,7 @@ export namespace DeleteVpcEndpointServiceConfigurationsResult {
   export function isa(
     o: any
   ): o is DeleteVpcEndpointServiceConfigurationsResult {
-    return _smithy.isa(o, "DeleteVpcEndpointServiceConfigurationsResult");
+    return __isa(o, "DeleteVpcEndpointServiceConfigurationsResult");
   }
 }
 
@@ -9121,7 +9121,7 @@ export interface DeleteVpcEndpointsRequest {
 
 export namespace DeleteVpcEndpointsRequest {
   export function isa(o: any): o is DeleteVpcEndpointsRequest {
-    return _smithy.isa(o, "DeleteVpcEndpointsRequest");
+    return __isa(o, "DeleteVpcEndpointsRequest");
   }
 }
 
@@ -9138,7 +9138,7 @@ export interface DeleteVpcEndpointsResult extends $MetadataBearer {
 
 export namespace DeleteVpcEndpointsResult {
   export function isa(o: any): o is DeleteVpcEndpointsResult {
-    return _smithy.isa(o, "DeleteVpcEndpointsResult");
+    return __isa(o, "DeleteVpcEndpointsResult");
   }
 }
 
@@ -9159,7 +9159,7 @@ export interface DeleteVpcPeeringConnectionRequest {
 
 export namespace DeleteVpcPeeringConnectionRequest {
   export function isa(o: any): o is DeleteVpcPeeringConnectionRequest {
-    return _smithy.isa(o, "DeleteVpcPeeringConnectionRequest");
+    return __isa(o, "DeleteVpcPeeringConnectionRequest");
   }
 }
 
@@ -9173,7 +9173,7 @@ export interface DeleteVpcPeeringConnectionResult extends $MetadataBearer {
 
 export namespace DeleteVpcPeeringConnectionResult {
   export function isa(o: any): o is DeleteVpcPeeringConnectionResult {
-    return _smithy.isa(o, "DeleteVpcPeeringConnectionResult");
+    return __isa(o, "DeleteVpcPeeringConnectionResult");
   }
 }
 
@@ -9194,7 +9194,7 @@ export interface DeleteVpcRequest {
 
 export namespace DeleteVpcRequest {
   export function isa(o: any): o is DeleteVpcRequest {
-    return _smithy.isa(o, "DeleteVpcRequest");
+    return __isa(o, "DeleteVpcRequest");
   }
 }
 
@@ -9218,7 +9218,7 @@ export interface DeleteVpnConnectionRequest {
 
 export namespace DeleteVpnConnectionRequest {
   export function isa(o: any): o is DeleteVpnConnectionRequest {
-    return _smithy.isa(o, "DeleteVpnConnectionRequest");
+    return __isa(o, "DeleteVpnConnectionRequest");
   }
 }
 
@@ -9240,7 +9240,7 @@ export interface DeleteVpnConnectionRouteRequest {
 
 export namespace DeleteVpnConnectionRouteRequest {
   export function isa(o: any): o is DeleteVpnConnectionRouteRequest {
-    return _smithy.isa(o, "DeleteVpnConnectionRouteRequest");
+    return __isa(o, "DeleteVpnConnectionRouteRequest");
   }
 }
 
@@ -9264,7 +9264,7 @@ export interface DeleteVpnGatewayRequest {
 
 export namespace DeleteVpnGatewayRequest {
   export function isa(o: any): o is DeleteVpnGatewayRequest {
-    return _smithy.isa(o, "DeleteVpnGatewayRequest");
+    return __isa(o, "DeleteVpnGatewayRequest");
   }
 }
 
@@ -9286,7 +9286,7 @@ export interface DeprovisionByoipCidrRequest {
 
 export namespace DeprovisionByoipCidrRequest {
   export function isa(o: any): o is DeprovisionByoipCidrRequest {
-    return _smithy.isa(o, "DeprovisionByoipCidrRequest");
+    return __isa(o, "DeprovisionByoipCidrRequest");
   }
 }
 
@@ -9300,7 +9300,7 @@ export interface DeprovisionByoipCidrResult extends $MetadataBearer {
 
 export namespace DeprovisionByoipCidrResult {
   export function isa(o: any): o is DeprovisionByoipCidrResult {
-    return _smithy.isa(o, "DeprovisionByoipCidrResult");
+    return __isa(o, "DeprovisionByoipCidrResult");
   }
 }
 
@@ -9324,7 +9324,7 @@ export interface DeregisterImageRequest {
 
 export namespace DeregisterImageRequest {
   export function isa(o: any): o is DeregisterImageRequest {
-    return _smithy.isa(o, "DeregisterImageRequest");
+    return __isa(o, "DeregisterImageRequest");
   }
 }
 
@@ -9357,10 +9357,7 @@ export namespace DeregisterTransitGatewayMulticastGroupMembersRequest {
   export function isa(
     o: any
   ): o is DeregisterTransitGatewayMulticastGroupMembersRequest {
-    return _smithy.isa(
-      o,
-      "DeregisterTransitGatewayMulticastGroupMembersRequest"
-    );
+    return __isa(o, "DeregisterTransitGatewayMulticastGroupMembersRequest");
   }
 }
 
@@ -9377,10 +9374,7 @@ export namespace DeregisterTransitGatewayMulticastGroupMembersResult {
   export function isa(
     o: any
   ): o is DeregisterTransitGatewayMulticastGroupMembersResult {
-    return _smithy.isa(
-      o,
-      "DeregisterTransitGatewayMulticastGroupMembersResult"
-    );
+    return __isa(o, "DeregisterTransitGatewayMulticastGroupMembersResult");
   }
 }
 
@@ -9413,10 +9407,7 @@ export namespace DeregisterTransitGatewayMulticastGroupSourcesRequest {
   export function isa(
     o: any
   ): o is DeregisterTransitGatewayMulticastGroupSourcesRequest {
-    return _smithy.isa(
-      o,
-      "DeregisterTransitGatewayMulticastGroupSourcesRequest"
-    );
+    return __isa(o, "DeregisterTransitGatewayMulticastGroupSourcesRequest");
   }
 }
 
@@ -9433,10 +9424,7 @@ export namespace DeregisterTransitGatewayMulticastGroupSourcesResult {
   export function isa(
     o: any
   ): o is DeregisterTransitGatewayMulticastGroupSourcesResult {
-    return _smithy.isa(
-      o,
-      "DeregisterTransitGatewayMulticastGroupSourcesResult"
-    );
+    return __isa(o, "DeregisterTransitGatewayMulticastGroupSourcesResult");
   }
 }
 
@@ -9457,7 +9445,7 @@ export interface DescribeAccountAttributesRequest {
 
 export namespace DescribeAccountAttributesRequest {
   export function isa(o: any): o is DescribeAccountAttributesRequest {
-    return _smithy.isa(o, "DescribeAccountAttributesRequest");
+    return __isa(o, "DescribeAccountAttributesRequest");
   }
 }
 
@@ -9471,7 +9459,7 @@ export interface DescribeAccountAttributesResult extends $MetadataBearer {
 
 export namespace DescribeAccountAttributesResult {
   export function isa(o: any): o is DescribeAccountAttributesResult {
-    return _smithy.isa(o, "DescribeAccountAttributesResult");
+    return __isa(o, "DescribeAccountAttributesResult");
   }
 }
 
@@ -9551,7 +9539,7 @@ export interface DescribeAddressesRequest {
 
 export namespace DescribeAddressesRequest {
   export function isa(o: any): o is DescribeAddressesRequest {
-    return _smithy.isa(o, "DescribeAddressesRequest");
+    return __isa(o, "DescribeAddressesRequest");
   }
 }
 
@@ -9565,7 +9553,7 @@ export interface DescribeAddressesResult extends $MetadataBearer {
 
 export namespace DescribeAddressesResult {
   export function isa(o: any): o is DescribeAddressesResult {
-    return _smithy.isa(o, "DescribeAddressesResult");
+    return __isa(o, "DescribeAddressesResult");
   }
 }
 
@@ -9581,7 +9569,7 @@ export interface DescribeAggregateIdFormatRequest {
 
 export namespace DescribeAggregateIdFormatRequest {
   export function isa(o: any): o is DescribeAggregateIdFormatRequest {
-    return _smithy.isa(o, "DescribeAggregateIdFormatRequest");
+    return __isa(o, "DescribeAggregateIdFormatRequest");
   }
 }
 
@@ -9602,7 +9590,7 @@ export interface DescribeAggregateIdFormatResult extends $MetadataBearer {
 
 export namespace DescribeAggregateIdFormatResult {
   export function isa(o: any): o is DescribeAggregateIdFormatResult {
-    return _smithy.isa(o, "DescribeAggregateIdFormatResult");
+    return __isa(o, "DescribeAggregateIdFormatResult");
   }
 }
 
@@ -9677,7 +9665,7 @@ export interface DescribeAvailabilityZonesRequest {
 
 export namespace DescribeAvailabilityZonesRequest {
   export function isa(o: any): o is DescribeAvailabilityZonesRequest {
-    return _smithy.isa(o, "DescribeAvailabilityZonesRequest");
+    return __isa(o, "DescribeAvailabilityZonesRequest");
   }
 }
 
@@ -9691,7 +9679,7 @@ export interface DescribeAvailabilityZonesResult extends $MetadataBearer {
 
 export namespace DescribeAvailabilityZonesResult {
   export function isa(o: any): o is DescribeAvailabilityZonesResult {
-    return _smithy.isa(o, "DescribeAvailabilityZonesResult");
+    return __isa(o, "DescribeAvailabilityZonesResult");
   }
 }
 
@@ -9761,7 +9749,7 @@ export interface DescribeBundleTasksRequest {
 
 export namespace DescribeBundleTasksRequest {
   export function isa(o: any): o is DescribeBundleTasksRequest {
-    return _smithy.isa(o, "DescribeBundleTasksRequest");
+    return __isa(o, "DescribeBundleTasksRequest");
   }
 }
 
@@ -9775,7 +9763,7 @@ export interface DescribeBundleTasksResult extends $MetadataBearer {
 
 export namespace DescribeBundleTasksResult {
   export function isa(o: any): o is DescribeBundleTasksResult {
-    return _smithy.isa(o, "DescribeBundleTasksResult");
+    return __isa(o, "DescribeBundleTasksResult");
   }
 }
 
@@ -9802,7 +9790,7 @@ export interface DescribeByoipCidrsRequest {
 
 export namespace DescribeByoipCidrsRequest {
   export function isa(o: any): o is DescribeByoipCidrsRequest {
-    return _smithy.isa(o, "DescribeByoipCidrsRequest");
+    return __isa(o, "DescribeByoipCidrsRequest");
   }
 }
 
@@ -9821,7 +9809,7 @@ export interface DescribeByoipCidrsResult extends $MetadataBearer {
 
 export namespace DescribeByoipCidrsResult {
   export function isa(o: any): o is DescribeByoipCidrsResult {
-    return _smithy.isa(o, "DescribeByoipCidrsResult");
+    return __isa(o, "DescribeByoipCidrsResult");
   }
 }
 
@@ -9855,7 +9843,7 @@ export interface DescribeCapacityReservationsRequest {
 
 export namespace DescribeCapacityReservationsRequest {
   export function isa(o: any): o is DescribeCapacityReservationsRequest {
-    return _smithy.isa(o, "DescribeCapacityReservationsRequest");
+    return __isa(o, "DescribeCapacityReservationsRequest");
   }
 }
 
@@ -9874,7 +9862,7 @@ export interface DescribeCapacityReservationsResult extends $MetadataBearer {
 
 export namespace DescribeCapacityReservationsResult {
   export function isa(o: any): o is DescribeCapacityReservationsResult {
-    return _smithy.isa(o, "DescribeCapacityReservationsResult");
+    return __isa(o, "DescribeCapacityReservationsResult");
   }
 }
 
@@ -9941,7 +9929,7 @@ export interface DescribeClassicLinkInstancesRequest {
 
 export namespace DescribeClassicLinkInstancesRequest {
   export function isa(o: any): o is DescribeClassicLinkInstancesRequest {
-    return _smithy.isa(o, "DescribeClassicLinkInstancesRequest");
+    return __isa(o, "DescribeClassicLinkInstancesRequest");
   }
 }
 
@@ -9960,7 +9948,7 @@ export interface DescribeClassicLinkInstancesResult extends $MetadataBearer {
 
 export namespace DescribeClassicLinkInstancesResult {
   export function isa(o: any): o is DescribeClassicLinkInstancesResult {
-    return _smithy.isa(o, "DescribeClassicLinkInstancesResult");
+    return __isa(o, "DescribeClassicLinkInstancesResult");
   }
 }
 
@@ -10009,7 +9997,7 @@ export interface DescribeClientVpnAuthorizationRulesRequest {
 
 export namespace DescribeClientVpnAuthorizationRulesRequest {
   export function isa(o: any): o is DescribeClientVpnAuthorizationRulesRequest {
-    return _smithy.isa(o, "DescribeClientVpnAuthorizationRulesRequest");
+    return __isa(o, "DescribeClientVpnAuthorizationRulesRequest");
   }
 }
 
@@ -10029,7 +10017,7 @@ export interface DescribeClientVpnAuthorizationRulesResult
 
 export namespace DescribeClientVpnAuthorizationRulesResult {
   export function isa(o: any): o is DescribeClientVpnAuthorizationRulesResult {
-    return _smithy.isa(o, "DescribeClientVpnAuthorizationRulesResult");
+    return __isa(o, "DescribeClientVpnAuthorizationRulesResult");
   }
 }
 
@@ -10074,7 +10062,7 @@ export interface DescribeClientVpnConnectionsRequest {
 
 export namespace DescribeClientVpnConnectionsRequest {
   export function isa(o: any): o is DescribeClientVpnConnectionsRequest {
-    return _smithy.isa(o, "DescribeClientVpnConnectionsRequest");
+    return __isa(o, "DescribeClientVpnConnectionsRequest");
   }
 }
 
@@ -10093,7 +10081,7 @@ export interface DescribeClientVpnConnectionsResult extends $MetadataBearer {
 
 export namespace DescribeClientVpnConnectionsResult {
   export function isa(o: any): o is DescribeClientVpnConnectionsResult {
-    return _smithy.isa(o, "DescribeClientVpnConnectionsResult");
+    return __isa(o, "DescribeClientVpnConnectionsResult");
   }
 }
 
@@ -10138,7 +10126,7 @@ export interface DescribeClientVpnEndpointsRequest {
 
 export namespace DescribeClientVpnEndpointsRequest {
   export function isa(o: any): o is DescribeClientVpnEndpointsRequest {
-    return _smithy.isa(o, "DescribeClientVpnEndpointsRequest");
+    return __isa(o, "DescribeClientVpnEndpointsRequest");
   }
 }
 
@@ -10157,7 +10145,7 @@ export interface DescribeClientVpnEndpointsResult extends $MetadataBearer {
 
 export namespace DescribeClientVpnEndpointsResult {
   export function isa(o: any): o is DescribeClientVpnEndpointsResult {
-    return _smithy.isa(o, "DescribeClientVpnEndpointsResult");
+    return __isa(o, "DescribeClientVpnEndpointsResult");
   }
 }
 
@@ -10205,7 +10193,7 @@ export interface DescribeClientVpnRoutesRequest {
 
 export namespace DescribeClientVpnRoutesRequest {
   export function isa(o: any): o is DescribeClientVpnRoutesRequest {
-    return _smithy.isa(o, "DescribeClientVpnRoutesRequest");
+    return __isa(o, "DescribeClientVpnRoutesRequest");
   }
 }
 
@@ -10224,7 +10212,7 @@ export interface DescribeClientVpnRoutesResult extends $MetadataBearer {
 
 export namespace DescribeClientVpnRoutesResult {
   export function isa(o: any): o is DescribeClientVpnRoutesResult {
-    return _smithy.isa(o, "DescribeClientVpnRoutesResult");
+    return __isa(o, "DescribeClientVpnRoutesResult");
   }
 }
 
@@ -10277,7 +10265,7 @@ export interface DescribeClientVpnTargetNetworksRequest {
 
 export namespace DescribeClientVpnTargetNetworksRequest {
   export function isa(o: any): o is DescribeClientVpnTargetNetworksRequest {
-    return _smithy.isa(o, "DescribeClientVpnTargetNetworksRequest");
+    return __isa(o, "DescribeClientVpnTargetNetworksRequest");
   }
 }
 
@@ -10296,7 +10284,7 @@ export interface DescribeClientVpnTargetNetworksResult extends $MetadataBearer {
 
 export namespace DescribeClientVpnTargetNetworksResult {
   export function isa(o: any): o is DescribeClientVpnTargetNetworksResult {
-    return _smithy.isa(o, "DescribeClientVpnTargetNetworksResult");
+    return __isa(o, "DescribeClientVpnTargetNetworksResult");
   }
 }
 
@@ -10347,7 +10335,7 @@ export interface DescribeCoipPoolsRequest {
 
 export namespace DescribeCoipPoolsRequest {
   export function isa(o: any): o is DescribeCoipPoolsRequest {
-    return _smithy.isa(o, "DescribeCoipPoolsRequest");
+    return __isa(o, "DescribeCoipPoolsRequest");
   }
 }
 
@@ -10366,7 +10354,7 @@ export interface DescribeCoipPoolsResult extends $MetadataBearer {
 
 export namespace DescribeCoipPoolsResult {
   export function isa(o: any): o is DescribeCoipPoolsResult {
-    return _smithy.isa(o, "DescribeCoipPoolsResult");
+    return __isa(o, "DescribeCoipPoolsResult");
   }
 }
 
@@ -10387,7 +10375,7 @@ export interface DescribeConversionTasksRequest {
 
 export namespace DescribeConversionTasksRequest {
   export function isa(o: any): o is DescribeConversionTasksRequest {
-    return _smithy.isa(o, "DescribeConversionTasksRequest");
+    return __isa(o, "DescribeConversionTasksRequest");
   }
 }
 
@@ -10401,7 +10389,7 @@ export interface DescribeConversionTasksResult extends $MetadataBearer {
 
 export namespace DescribeConversionTasksResult {
   export function isa(o: any): o is DescribeConversionTasksResult {
-    return _smithy.isa(o, "DescribeConversionTasksResult");
+    return __isa(o, "DescribeConversionTasksResult");
   }
 }
 
@@ -10462,7 +10450,7 @@ export interface DescribeCustomerGatewaysRequest {
 
 export namespace DescribeCustomerGatewaysRequest {
   export function isa(o: any): o is DescribeCustomerGatewaysRequest {
-    return _smithy.isa(o, "DescribeCustomerGatewaysRequest");
+    return __isa(o, "DescribeCustomerGatewaysRequest");
   }
 }
 
@@ -10479,7 +10467,7 @@ export interface DescribeCustomerGatewaysResult extends $MetadataBearer {
 
 export namespace DescribeCustomerGatewaysResult {
   export function isa(o: any): o is DescribeCustomerGatewaysResult {
-    return _smithy.isa(o, "DescribeCustomerGatewaysResult");
+    return __isa(o, "DescribeCustomerGatewaysResult");
   }
 }
 
@@ -10544,7 +10532,7 @@ export interface DescribeDhcpOptionsRequest {
 
 export namespace DescribeDhcpOptionsRequest {
   export function isa(o: any): o is DescribeDhcpOptionsRequest {
-    return _smithy.isa(o, "DescribeDhcpOptionsRequest");
+    return __isa(o, "DescribeDhcpOptionsRequest");
   }
 }
 
@@ -10563,7 +10551,7 @@ export interface DescribeDhcpOptionsResult extends $MetadataBearer {
 
 export namespace DescribeDhcpOptionsResult {
   export function isa(o: any): o is DescribeDhcpOptionsResult {
-    return _smithy.isa(o, "DescribeDhcpOptionsResult");
+    return __isa(o, "DescribeDhcpOptionsResult");
   }
 }
 
@@ -10611,7 +10599,7 @@ export interface DescribeEgressOnlyInternetGatewaysRequest {
 
 export namespace DescribeEgressOnlyInternetGatewaysRequest {
   export function isa(o: any): o is DescribeEgressOnlyInternetGatewaysRequest {
-    return _smithy.isa(o, "DescribeEgressOnlyInternetGatewaysRequest");
+    return __isa(o, "DescribeEgressOnlyInternetGatewaysRequest");
   }
 }
 
@@ -10631,7 +10619,7 @@ export interface DescribeEgressOnlyInternetGatewaysResult
 
 export namespace DescribeEgressOnlyInternetGatewaysResult {
   export function isa(o: any): o is DescribeEgressOnlyInternetGatewaysResult {
-    return _smithy.isa(o, "DescribeEgressOnlyInternetGatewaysResult");
+    return __isa(o, "DescribeEgressOnlyInternetGatewaysResult");
   }
 }
 
@@ -10696,7 +10684,7 @@ export interface DescribeElasticGpusRequest {
 
 export namespace DescribeElasticGpusRequest {
   export function isa(o: any): o is DescribeElasticGpusRequest {
-    return _smithy.isa(o, "DescribeElasticGpusRequest");
+    return __isa(o, "DescribeElasticGpusRequest");
   }
 }
 
@@ -10723,7 +10711,7 @@ export interface DescribeElasticGpusResult extends $MetadataBearer {
 
 export namespace DescribeElasticGpusResult {
   export function isa(o: any): o is DescribeElasticGpusResult {
-    return _smithy.isa(o, "DescribeElasticGpusResult");
+    return __isa(o, "DescribeElasticGpusResult");
   }
 }
 
@@ -10760,7 +10748,7 @@ export interface DescribeExportImageTasksRequest {
 
 export namespace DescribeExportImageTasksRequest {
   export function isa(o: any): o is DescribeExportImageTasksRequest {
-    return _smithy.isa(o, "DescribeExportImageTasksRequest");
+    return __isa(o, "DescribeExportImageTasksRequest");
   }
 }
 
@@ -10780,7 +10768,7 @@ export interface DescribeExportImageTasksResult extends $MetadataBearer {
 
 export namespace DescribeExportImageTasksResult {
   export function isa(o: any): o is DescribeExportImageTasksResult {
-    return _smithy.isa(o, "DescribeExportImageTasksResult");
+    return __isa(o, "DescribeExportImageTasksResult");
   }
 }
 
@@ -10799,7 +10787,7 @@ export interface DescribeExportTasksRequest {
 
 export namespace DescribeExportTasksRequest {
   export function isa(o: any): o is DescribeExportTasksRequest {
-    return _smithy.isa(o, "DescribeExportTasksRequest");
+    return __isa(o, "DescribeExportTasksRequest");
   }
 }
 
@@ -10813,7 +10801,7 @@ export interface DescribeExportTasksResult extends $MetadataBearer {
 
 export namespace DescribeExportTasksResult {
   export function isa(o: any): o is DescribeExportTasksResult {
-    return _smithy.isa(o, "DescribeExportTasksResult");
+    return __isa(o, "DescribeExportTasksResult");
   }
 }
 
@@ -10892,7 +10880,7 @@ export interface DescribeFastSnapshotRestoreSuccessItem {
 
 export namespace DescribeFastSnapshotRestoreSuccessItem {
   export function isa(o: any): o is DescribeFastSnapshotRestoreSuccessItem {
-    return _smithy.isa(o, "DescribeFastSnapshotRestoreSuccessItem");
+    return __isa(o, "DescribeFastSnapshotRestoreSuccessItem");
   }
 }
 
@@ -10947,7 +10935,7 @@ export interface DescribeFastSnapshotRestoresRequest {
 
 export namespace DescribeFastSnapshotRestoresRequest {
   export function isa(o: any): o is DescribeFastSnapshotRestoresRequest {
-    return _smithy.isa(o, "DescribeFastSnapshotRestoresRequest");
+    return __isa(o, "DescribeFastSnapshotRestoresRequest");
   }
 }
 
@@ -10966,7 +10954,7 @@ export interface DescribeFastSnapshotRestoresResult extends $MetadataBearer {
 
 export namespace DescribeFastSnapshotRestoresResult {
   export function isa(o: any): o is DescribeFastSnapshotRestoresResult {
-    return _smithy.isa(o, "DescribeFastSnapshotRestoresResult");
+    return __isa(o, "DescribeFastSnapshotRestoresResult");
   }
 }
 
@@ -11001,7 +10989,7 @@ export interface DescribeFleetError {
 
 export namespace DescribeFleetError {
   export function isa(o: any): o is DescribeFleetError {
-    return _smithy.isa(o, "DescribeFleetError");
+    return __isa(o, "DescribeFleetError");
   }
 }
 
@@ -11045,7 +11033,7 @@ export interface DescribeFleetHistoryRequest {
 
 export namespace DescribeFleetHistoryRequest {
   export function isa(o: any): o is DescribeFleetHistoryRequest {
-    return _smithy.isa(o, "DescribeFleetHistoryRequest");
+    return __isa(o, "DescribeFleetHistoryRequest");
   }
 }
 
@@ -11084,7 +11072,7 @@ export interface DescribeFleetHistoryResult extends $MetadataBearer {
 
 export namespace DescribeFleetHistoryResult {
   export function isa(o: any): o is DescribeFleetHistoryResult {
-    return _smithy.isa(o, "DescribeFleetHistoryResult");
+    return __isa(o, "DescribeFleetHistoryResult");
   }
 }
 
@@ -11128,7 +11116,7 @@ export interface DescribeFleetInstancesRequest {
 
 export namespace DescribeFleetInstancesRequest {
   export function isa(o: any): o is DescribeFleetInstancesRequest {
-    return _smithy.isa(o, "DescribeFleetInstancesRequest");
+    return __isa(o, "DescribeFleetInstancesRequest");
   }
 }
 
@@ -11153,7 +11141,7 @@ export interface DescribeFleetInstancesResult extends $MetadataBearer {
 
 export namespace DescribeFleetInstancesResult {
   export function isa(o: any): o is DescribeFleetInstancesResult {
-    return _smithy.isa(o, "DescribeFleetInstancesResult");
+    return __isa(o, "DescribeFleetInstancesResult");
   }
 }
 
@@ -11192,7 +11180,7 @@ export interface DescribeFleetsInstances {
 
 export namespace DescribeFleetsInstances {
   export function isa(o: any): o is DescribeFleetsInstances {
-    return _smithy.isa(o, "DescribeFleetsInstances");
+    return __isa(o, "DescribeFleetsInstances");
   }
 }
 
@@ -11261,7 +11249,7 @@ export interface DescribeFleetsRequest {
 
 export namespace DescribeFleetsRequest {
   export function isa(o: any): o is DescribeFleetsRequest {
-    return _smithy.isa(o, "DescribeFleetsRequest");
+    return __isa(o, "DescribeFleetsRequest");
   }
 }
 
@@ -11280,7 +11268,7 @@ export interface DescribeFleetsResult extends $MetadataBearer {
 
 export namespace DescribeFleetsResult {
   export function isa(o: any): o is DescribeFleetsResult {
-    return _smithy.isa(o, "DescribeFleetsResult");
+    return __isa(o, "DescribeFleetsResult");
   }
 }
 
@@ -11348,7 +11336,7 @@ export interface DescribeFlowLogsRequest {
 
 export namespace DescribeFlowLogsRequest {
   export function isa(o: any): o is DescribeFlowLogsRequest {
-    return _smithy.isa(o, "DescribeFlowLogsRequest");
+    return __isa(o, "DescribeFlowLogsRequest");
   }
 }
 
@@ -11367,7 +11355,7 @@ export interface DescribeFlowLogsResult extends $MetadataBearer {
 
 export namespace DescribeFlowLogsResult {
   export function isa(o: any): o is DescribeFlowLogsResult {
-    return _smithy.isa(o, "DescribeFlowLogsResult");
+    return __isa(o, "DescribeFlowLogsResult");
   }
 }
 
@@ -11393,7 +11381,7 @@ export interface DescribeFpgaImageAttributeRequest {
 
 export namespace DescribeFpgaImageAttributeRequest {
   export function isa(o: any): o is DescribeFpgaImageAttributeRequest {
-    return _smithy.isa(o, "DescribeFpgaImageAttributeRequest");
+    return __isa(o, "DescribeFpgaImageAttributeRequest");
   }
 }
 
@@ -11407,7 +11395,7 @@ export interface DescribeFpgaImageAttributeResult extends $MetadataBearer {
 
 export namespace DescribeFpgaImageAttributeResult {
   export function isa(o: any): o is DescribeFpgaImageAttributeResult {
-    return _smithy.isa(o, "DescribeFpgaImageAttributeResult");
+    return __isa(o, "DescribeFpgaImageAttributeResult");
   }
 }
 
@@ -11495,7 +11483,7 @@ export interface DescribeFpgaImagesRequest {
 
 export namespace DescribeFpgaImagesRequest {
   export function isa(o: any): o is DescribeFpgaImagesRequest {
-    return _smithy.isa(o, "DescribeFpgaImagesRequest");
+    return __isa(o, "DescribeFpgaImagesRequest");
   }
 }
 
@@ -11514,7 +11502,7 @@ export interface DescribeFpgaImagesResult extends $MetadataBearer {
 
 export namespace DescribeFpgaImagesResult {
   export function isa(o: any): o is DescribeFpgaImagesResult {
-    return _smithy.isa(o, "DescribeFpgaImagesResult");
+    return __isa(o, "DescribeFpgaImagesResult");
   }
 }
 
@@ -11571,7 +11559,7 @@ export interface DescribeHostReservationOfferingsRequest {
 
 export namespace DescribeHostReservationOfferingsRequest {
   export function isa(o: any): o is DescribeHostReservationOfferingsRequest {
-    return _smithy.isa(o, "DescribeHostReservationOfferingsRequest");
+    return __isa(o, "DescribeHostReservationOfferingsRequest");
   }
 }
 
@@ -11591,7 +11579,7 @@ export interface DescribeHostReservationOfferingsResult
 
 export namespace DescribeHostReservationOfferingsResult {
   export function isa(o: any): o is DescribeHostReservationOfferingsResult {
-    return _smithy.isa(o, "DescribeHostReservationOfferingsResult");
+    return __isa(o, "DescribeHostReservationOfferingsResult");
   }
 }
 
@@ -11647,7 +11635,7 @@ export interface DescribeHostReservationsRequest {
 
 export namespace DescribeHostReservationsRequest {
   export function isa(o: any): o is DescribeHostReservationsRequest {
-    return _smithy.isa(o, "DescribeHostReservationsRequest");
+    return __isa(o, "DescribeHostReservationsRequest");
   }
 }
 
@@ -11666,7 +11654,7 @@ export interface DescribeHostReservationsResult extends $MetadataBearer {
 
 export namespace DescribeHostReservationsResult {
   export function isa(o: any): o is DescribeHostReservationsResult {
-    return _smithy.isa(o, "DescribeHostReservationsResult");
+    return __isa(o, "DescribeHostReservationsResult");
   }
 }
 
@@ -11735,7 +11723,7 @@ export interface DescribeHostsRequest {
 
 export namespace DescribeHostsRequest {
   export function isa(o: any): o is DescribeHostsRequest {
-    return _smithy.isa(o, "DescribeHostsRequest");
+    return __isa(o, "DescribeHostsRequest");
   }
 }
 
@@ -11754,7 +11742,7 @@ export interface DescribeHostsResult extends $MetadataBearer {
 
 export namespace DescribeHostsResult {
   export function isa(o: any): o is DescribeHostsResult {
-    return _smithy.isa(o, "DescribeHostsResult");
+    return __isa(o, "DescribeHostsResult");
   }
 }
 
@@ -11798,7 +11786,7 @@ export namespace DescribeIamInstanceProfileAssociationsRequest {
   export function isa(
     o: any
   ): o is DescribeIamInstanceProfileAssociationsRequest {
-    return _smithy.isa(o, "DescribeIamInstanceProfileAssociationsRequest");
+    return __isa(o, "DescribeIamInstanceProfileAssociationsRequest");
   }
 }
 
@@ -11820,7 +11808,7 @@ export namespace DescribeIamInstanceProfileAssociationsResult {
   export function isa(
     o: any
   ): o is DescribeIamInstanceProfileAssociationsResult {
-    return _smithy.isa(o, "DescribeIamInstanceProfileAssociationsResult");
+    return __isa(o, "DescribeIamInstanceProfileAssociationsResult");
   }
 }
 
@@ -11847,7 +11835,7 @@ export interface DescribeIdFormatRequest {
 
 export namespace DescribeIdFormatRequest {
   export function isa(o: any): o is DescribeIdFormatRequest {
-    return _smithy.isa(o, "DescribeIdFormatRequest");
+    return __isa(o, "DescribeIdFormatRequest");
   }
 }
 
@@ -11861,7 +11849,7 @@ export interface DescribeIdFormatResult extends $MetadataBearer {
 
 export namespace DescribeIdFormatResult {
   export function isa(o: any): o is DescribeIdFormatResult {
-    return _smithy.isa(o, "DescribeIdFormatResult");
+    return __isa(o, "DescribeIdFormatResult");
   }
 }
 
@@ -11893,7 +11881,7 @@ export interface DescribeIdentityIdFormatRequest {
 
 export namespace DescribeIdentityIdFormatRequest {
   export function isa(o: any): o is DescribeIdentityIdFormatRequest {
-    return _smithy.isa(o, "DescribeIdentityIdFormatRequest");
+    return __isa(o, "DescribeIdentityIdFormatRequest");
   }
 }
 
@@ -11907,7 +11895,7 @@ export interface DescribeIdentityIdFormatResult extends $MetadataBearer {
 
 export namespace DescribeIdentityIdFormatResult {
   export function isa(o: any): o is DescribeIdentityIdFormatResult {
-    return _smithy.isa(o, "DescribeIdentityIdFormatResult");
+    return __isa(o, "DescribeIdentityIdFormatResult");
   }
 }
 
@@ -11940,7 +11928,7 @@ export interface DescribeImageAttributeRequest {
 
 export namespace DescribeImageAttributeRequest {
   export function isa(o: any): o is DescribeImageAttributeRequest {
-    return _smithy.isa(o, "DescribeImageAttributeRequest");
+    return __isa(o, "DescribeImageAttributeRequest");
   }
 }
 
@@ -12129,7 +12117,7 @@ export interface DescribeImagesRequest {
 
 export namespace DescribeImagesRequest {
   export function isa(o: any): o is DescribeImagesRequest {
-    return _smithy.isa(o, "DescribeImagesRequest");
+    return __isa(o, "DescribeImagesRequest");
   }
 }
 
@@ -12143,7 +12131,7 @@ export interface DescribeImagesResult extends $MetadataBearer {
 
 export namespace DescribeImagesResult {
   export function isa(o: any): o is DescribeImagesResult {
-    return _smithy.isa(o, "DescribeImagesResult");
+    return __isa(o, "DescribeImagesResult");
   }
 }
 
@@ -12180,7 +12168,7 @@ export interface DescribeImportImageTasksRequest {
 
 export namespace DescribeImportImageTasksRequest {
   export function isa(o: any): o is DescribeImportImageTasksRequest {
-    return _smithy.isa(o, "DescribeImportImageTasksRequest");
+    return __isa(o, "DescribeImportImageTasksRequest");
   }
 }
 
@@ -12201,7 +12189,7 @@ export interface DescribeImportImageTasksResult extends $MetadataBearer {
 
 export namespace DescribeImportImageTasksResult {
   export function isa(o: any): o is DescribeImportImageTasksResult {
-    return _smithy.isa(o, "DescribeImportImageTasksResult");
+    return __isa(o, "DescribeImportImageTasksResult");
   }
 }
 
@@ -12238,7 +12226,7 @@ export interface DescribeImportSnapshotTasksRequest {
 
 export namespace DescribeImportSnapshotTasksRequest {
   export function isa(o: any): o is DescribeImportSnapshotTasksRequest {
-    return _smithy.isa(o, "DescribeImportSnapshotTasksRequest");
+    return __isa(o, "DescribeImportSnapshotTasksRequest");
   }
 }
 
@@ -12259,7 +12247,7 @@ export interface DescribeImportSnapshotTasksResult extends $MetadataBearer {
 
 export namespace DescribeImportSnapshotTasksResult {
   export function isa(o: any): o is DescribeImportSnapshotTasksResult {
-    return _smithy.isa(o, "DescribeImportSnapshotTasksResult");
+    return __isa(o, "DescribeImportSnapshotTasksResult");
   }
 }
 
@@ -12286,7 +12274,7 @@ export interface DescribeInstanceAttributeRequest {
 
 export namespace DescribeInstanceAttributeRequest {
   export function isa(o: any): o is DescribeInstanceAttributeRequest {
-    return _smithy.isa(o, "DescribeInstanceAttributeRequest");
+    return __isa(o, "DescribeInstanceAttributeRequest");
   }
 }
 
@@ -12335,7 +12323,7 @@ export namespace DescribeInstanceCreditSpecificationsRequest {
   export function isa(
     o: any
   ): o is DescribeInstanceCreditSpecificationsRequest {
-    return _smithy.isa(o, "DescribeInstanceCreditSpecificationsRequest");
+    return __isa(o, "DescribeInstanceCreditSpecificationsRequest");
   }
 }
 
@@ -12356,7 +12344,7 @@ export interface DescribeInstanceCreditSpecificationsResult
 
 export namespace DescribeInstanceCreditSpecificationsResult {
   export function isa(o: any): o is DescribeInstanceCreditSpecificationsResult {
-    return _smithy.isa(o, "DescribeInstanceCreditSpecificationsResult");
+    return __isa(o, "DescribeInstanceCreditSpecificationsResult");
   }
 }
 
@@ -12481,7 +12469,7 @@ export interface DescribeInstanceStatusRequest {
 
 export namespace DescribeInstanceStatusRequest {
   export function isa(o: any): o is DescribeInstanceStatusRequest {
-    return _smithy.isa(o, "DescribeInstanceStatusRequest");
+    return __isa(o, "DescribeInstanceStatusRequest");
   }
 }
 
@@ -12501,7 +12489,7 @@ export interface DescribeInstanceStatusResult extends $MetadataBearer {
 
 export namespace DescribeInstanceStatusResult {
   export function isa(o: any): o is DescribeInstanceStatusResult {
-    return _smithy.isa(o, "DescribeInstanceStatusResult");
+    return __isa(o, "DescribeInstanceStatusResult");
   }
 }
 
@@ -12549,7 +12537,7 @@ export interface DescribeInstanceTypeOfferingsRequest {
 
 export namespace DescribeInstanceTypeOfferingsRequest {
   export function isa(o: any): o is DescribeInstanceTypeOfferingsRequest {
-    return _smithy.isa(o, "DescribeInstanceTypeOfferingsRequest");
+    return __isa(o, "DescribeInstanceTypeOfferingsRequest");
   }
 }
 
@@ -12569,7 +12557,7 @@ export interface DescribeInstanceTypeOfferingsResult extends $MetadataBearer {
 
 export namespace DescribeInstanceTypeOfferingsResult {
   export function isa(o: any): o is DescribeInstanceTypeOfferingsResult {
-    return _smithy.isa(o, "DescribeInstanceTypeOfferingsResult");
+    return __isa(o, "DescribeInstanceTypeOfferingsResult");
   }
 }
 
@@ -12722,7 +12710,7 @@ export interface DescribeInstanceTypesRequest {
 
 export namespace DescribeInstanceTypesRequest {
   export function isa(o: any): o is DescribeInstanceTypesRequest {
-    return _smithy.isa(o, "DescribeInstanceTypesRequest");
+    return __isa(o, "DescribeInstanceTypesRequest");
   }
 }
 
@@ -12743,7 +12731,7 @@ export interface DescribeInstanceTypesResult extends $MetadataBearer {
 
 export namespace DescribeInstanceTypesResult {
   export function isa(o: any): o is DescribeInstanceTypesResult {
-    return _smithy.isa(o, "DescribeInstanceTypesResult");
+    return __isa(o, "DescribeInstanceTypesResult");
   }
 }
 
@@ -13233,7 +13221,7 @@ export interface DescribeInstancesRequest {
 
 export namespace DescribeInstancesRequest {
   export function isa(o: any): o is DescribeInstancesRequest {
-    return _smithy.isa(o, "DescribeInstancesRequest");
+    return __isa(o, "DescribeInstancesRequest");
   }
 }
 
@@ -13253,7 +13241,7 @@ export interface DescribeInstancesResult extends $MetadataBearer {
 
 export namespace DescribeInstancesResult {
   export function isa(o: any): o is DescribeInstancesResult {
-    return _smithy.isa(o, "DescribeInstancesResult");
+    return __isa(o, "DescribeInstancesResult");
   }
 }
 
@@ -13319,7 +13307,7 @@ export interface DescribeInternetGatewaysRequest {
 
 export namespace DescribeInternetGatewaysRequest {
   export function isa(o: any): o is DescribeInternetGatewaysRequest {
-    return _smithy.isa(o, "DescribeInternetGatewaysRequest");
+    return __isa(o, "DescribeInternetGatewaysRequest");
   }
 }
 
@@ -13338,7 +13326,7 @@ export interface DescribeInternetGatewaysResult extends $MetadataBearer {
 
 export namespace DescribeInternetGatewaysResult {
   export function isa(o: any): o is DescribeInternetGatewaysResult {
-    return _smithy.isa(o, "DescribeInternetGatewaysResult");
+    return __isa(o, "DescribeInternetGatewaysResult");
   }
 }
 
@@ -13386,7 +13374,7 @@ export interface DescribeIpv6PoolsRequest {
 
 export namespace DescribeIpv6PoolsRequest {
   export function isa(o: any): o is DescribeIpv6PoolsRequest {
-    return _smithy.isa(o, "DescribeIpv6PoolsRequest");
+    return __isa(o, "DescribeIpv6PoolsRequest");
   }
 }
 
@@ -13405,7 +13393,7 @@ export interface DescribeIpv6PoolsResult extends $MetadataBearer {
 
 export namespace DescribeIpv6PoolsResult {
   export function isa(o: any): o is DescribeIpv6PoolsResult {
-    return _smithy.isa(o, "DescribeIpv6PoolsResult");
+    return __isa(o, "DescribeIpv6PoolsResult");
   }
 }
 
@@ -13447,7 +13435,7 @@ export interface DescribeKeyPairsRequest {
 
 export namespace DescribeKeyPairsRequest {
   export function isa(o: any): o is DescribeKeyPairsRequest {
-    return _smithy.isa(o, "DescribeKeyPairsRequest");
+    return __isa(o, "DescribeKeyPairsRequest");
   }
 }
 
@@ -13461,7 +13449,7 @@ export interface DescribeKeyPairsResult extends $MetadataBearer {
 
 export namespace DescribeKeyPairsResult {
   export function isa(o: any): o is DescribeKeyPairsResult {
-    return _smithy.isa(o, "DescribeKeyPairsResult");
+    return __isa(o, "DescribeKeyPairsResult");
   }
 }
 
@@ -13559,7 +13547,7 @@ export interface DescribeLaunchTemplateVersionsRequest {
 
 export namespace DescribeLaunchTemplateVersionsRequest {
   export function isa(o: any): o is DescribeLaunchTemplateVersionsRequest {
-    return _smithy.isa(o, "DescribeLaunchTemplateVersionsRequest");
+    return __isa(o, "DescribeLaunchTemplateVersionsRequest");
   }
 }
 
@@ -13579,7 +13567,7 @@ export interface DescribeLaunchTemplateVersionsResult extends $MetadataBearer {
 
 export namespace DescribeLaunchTemplateVersionsResult {
   export function isa(o: any): o is DescribeLaunchTemplateVersionsResult {
-    return _smithy.isa(o, "DescribeLaunchTemplateVersionsResult");
+    return __isa(o, "DescribeLaunchTemplateVersionsResult");
   }
 }
 
@@ -13642,7 +13630,7 @@ export interface DescribeLaunchTemplatesRequest {
 
 export namespace DescribeLaunchTemplatesRequest {
   export function isa(o: any): o is DescribeLaunchTemplatesRequest {
-    return _smithy.isa(o, "DescribeLaunchTemplatesRequest");
+    return __isa(o, "DescribeLaunchTemplatesRequest");
   }
 }
 
@@ -13662,7 +13650,7 @@ export interface DescribeLaunchTemplatesResult extends $MetadataBearer {
 
 export namespace DescribeLaunchTemplatesResult {
   export function isa(o: any): o is DescribeLaunchTemplatesResult {
-    return _smithy.isa(o, "DescribeLaunchTemplatesResult");
+    return __isa(o, "DescribeLaunchTemplatesResult");
   }
 }
 
@@ -13701,7 +13689,7 @@ export namespace DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociations
   export function isa(
     o: any
   ): o is DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsRequest {
-    return _smithy.isa(
+    return __isa(
       o,
       "DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsRequest"
     );
@@ -13728,7 +13716,7 @@ export namespace DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociations
   export function isa(
     o: any
   ): o is DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsResult {
-    return _smithy.isa(
+    return __isa(
       o,
       "DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsResult"
     );
@@ -13770,10 +13758,7 @@ export namespace DescribeLocalGatewayRouteTableVpcAssociationsRequest {
   export function isa(
     o: any
   ): o is DescribeLocalGatewayRouteTableVpcAssociationsRequest {
-    return _smithy.isa(
-      o,
-      "DescribeLocalGatewayRouteTableVpcAssociationsRequest"
-    );
+    return __isa(o, "DescribeLocalGatewayRouteTableVpcAssociationsRequest");
   }
 }
 
@@ -13797,10 +13782,7 @@ export namespace DescribeLocalGatewayRouteTableVpcAssociationsResult {
   export function isa(
     o: any
   ): o is DescribeLocalGatewayRouteTableVpcAssociationsResult {
-    return _smithy.isa(
-      o,
-      "DescribeLocalGatewayRouteTableVpcAssociationsResult"
-    );
+    return __isa(o, "DescribeLocalGatewayRouteTableVpcAssociationsResult");
   }
 }
 
@@ -13837,7 +13819,7 @@ export interface DescribeLocalGatewayRouteTablesRequest {
 
 export namespace DescribeLocalGatewayRouteTablesRequest {
   export function isa(o: any): o is DescribeLocalGatewayRouteTablesRequest {
-    return _smithy.isa(o, "DescribeLocalGatewayRouteTablesRequest");
+    return __isa(o, "DescribeLocalGatewayRouteTablesRequest");
   }
 }
 
@@ -13856,7 +13838,7 @@ export interface DescribeLocalGatewayRouteTablesResult extends $MetadataBearer {
 
 export namespace DescribeLocalGatewayRouteTablesResult {
   export function isa(o: any): o is DescribeLocalGatewayRouteTablesResult {
-    return _smithy.isa(o, "DescribeLocalGatewayRouteTablesResult");
+    return __isa(o, "DescribeLocalGatewayRouteTablesResult");
   }
 }
 
@@ -13895,7 +13877,7 @@ export namespace DescribeLocalGatewayVirtualInterfaceGroupsRequest {
   export function isa(
     o: any
   ): o is DescribeLocalGatewayVirtualInterfaceGroupsRequest {
-    return _smithy.isa(o, "DescribeLocalGatewayVirtualInterfaceGroupsRequest");
+    return __isa(o, "DescribeLocalGatewayVirtualInterfaceGroupsRequest");
   }
 }
 
@@ -13917,7 +13899,7 @@ export namespace DescribeLocalGatewayVirtualInterfaceGroupsResult {
   export function isa(
     o: any
   ): o is DescribeLocalGatewayVirtualInterfaceGroupsResult {
-    return _smithy.isa(o, "DescribeLocalGatewayVirtualInterfaceGroupsResult");
+    return __isa(o, "DescribeLocalGatewayVirtualInterfaceGroupsResult");
   }
 }
 
@@ -13956,7 +13938,7 @@ export namespace DescribeLocalGatewayVirtualInterfacesRequest {
   export function isa(
     o: any
   ): o is DescribeLocalGatewayVirtualInterfacesRequest {
-    return _smithy.isa(o, "DescribeLocalGatewayVirtualInterfacesRequest");
+    return __isa(o, "DescribeLocalGatewayVirtualInterfacesRequest");
   }
 }
 
@@ -13978,7 +13960,7 @@ export namespace DescribeLocalGatewayVirtualInterfacesResult {
   export function isa(
     o: any
   ): o is DescribeLocalGatewayVirtualInterfacesResult {
-    return _smithy.isa(o, "DescribeLocalGatewayVirtualInterfacesResult");
+    return __isa(o, "DescribeLocalGatewayVirtualInterfacesResult");
   }
 }
 
@@ -14015,7 +13997,7 @@ export interface DescribeLocalGatewaysRequest {
 
 export namespace DescribeLocalGatewaysRequest {
   export function isa(o: any): o is DescribeLocalGatewaysRequest {
-    return _smithy.isa(o, "DescribeLocalGatewaysRequest");
+    return __isa(o, "DescribeLocalGatewaysRequest");
   }
 }
 
@@ -14034,7 +14016,7 @@ export interface DescribeLocalGatewaysResult extends $MetadataBearer {
 
 export namespace DescribeLocalGatewaysResult {
   export function isa(o: any): o is DescribeLocalGatewaysResult {
-    return _smithy.isa(o, "DescribeLocalGatewaysResult");
+    return __isa(o, "DescribeLocalGatewaysResult");
   }
 }
 
@@ -14081,7 +14063,7 @@ export interface DescribeMovingAddressesRequest {
 
 export namespace DescribeMovingAddressesRequest {
   export function isa(o: any): o is DescribeMovingAddressesRequest {
-    return _smithy.isa(o, "DescribeMovingAddressesRequest");
+    return __isa(o, "DescribeMovingAddressesRequest");
   }
 }
 
@@ -14100,7 +14082,7 @@ export interface DescribeMovingAddressesResult extends $MetadataBearer {
 
 export namespace DescribeMovingAddressesResult {
   export function isa(o: any): o is DescribeMovingAddressesResult {
-    return _smithy.isa(o, "DescribeMovingAddressesResult");
+    return __isa(o, "DescribeMovingAddressesResult");
   }
 }
 
@@ -14158,7 +14140,7 @@ export interface DescribeNatGatewaysRequest {
 
 export namespace DescribeNatGatewaysRequest {
   export function isa(o: any): o is DescribeNatGatewaysRequest {
-    return _smithy.isa(o, "DescribeNatGatewaysRequest");
+    return __isa(o, "DescribeNatGatewaysRequest");
   }
 }
 
@@ -14177,7 +14159,7 @@ export interface DescribeNatGatewaysResult extends $MetadataBearer {
 
 export namespace DescribeNatGatewaysResult {
   export function isa(o: any): o is DescribeNatGatewaysResult {
-    return _smithy.isa(o, "DescribeNatGatewaysResult");
+    return __isa(o, "DescribeNatGatewaysResult");
   }
 }
 
@@ -14291,7 +14273,7 @@ export interface DescribeNetworkAclsRequest {
 
 export namespace DescribeNetworkAclsRequest {
   export function isa(o: any): o is DescribeNetworkAclsRequest {
-    return _smithy.isa(o, "DescribeNetworkAclsRequest");
+    return __isa(o, "DescribeNetworkAclsRequest");
   }
 }
 
@@ -14310,7 +14292,7 @@ export interface DescribeNetworkAclsResult extends $MetadataBearer {
 
 export namespace DescribeNetworkAclsResult {
   export function isa(o: any): o is DescribeNetworkAclsResult {
-    return _smithy.isa(o, "DescribeNetworkAclsResult");
+    return __isa(o, "DescribeNetworkAclsResult");
   }
 }
 
@@ -14339,7 +14321,7 @@ export interface DescribeNetworkInterfaceAttributeRequest {
 
 export namespace DescribeNetworkInterfaceAttributeRequest {
   export function isa(o: any): o is DescribeNetworkInterfaceAttributeRequest {
-    return _smithy.isa(o, "DescribeNetworkInterfaceAttributeRequest");
+    return __isa(o, "DescribeNetworkInterfaceAttributeRequest");
   }
 }
 
@@ -14377,7 +14359,7 @@ export interface DescribeNetworkInterfaceAttributeResult
 
 export namespace DescribeNetworkInterfaceAttributeResult {
   export function isa(o: any): o is DescribeNetworkInterfaceAttributeResult {
-    return _smithy.isa(o, "DescribeNetworkInterfaceAttributeResult");
+    return __isa(o, "DescribeNetworkInterfaceAttributeResult");
   }
 }
 
@@ -14438,7 +14420,7 @@ export interface DescribeNetworkInterfacePermissionsRequest {
 
 export namespace DescribeNetworkInterfacePermissionsRequest {
   export function isa(o: any): o is DescribeNetworkInterfacePermissionsRequest {
-    return _smithy.isa(o, "DescribeNetworkInterfacePermissionsRequest");
+    return __isa(o, "DescribeNetworkInterfacePermissionsRequest");
   }
 }
 
@@ -14461,7 +14443,7 @@ export interface DescribeNetworkInterfacePermissionsResult
 
 export namespace DescribeNetworkInterfacePermissionsResult {
   export function isa(o: any): o is DescribeNetworkInterfacePermissionsResult {
-    return _smithy.isa(o, "DescribeNetworkInterfacePermissionsResult");
+    return __isa(o, "DescribeNetworkInterfacePermissionsResult");
   }
 }
 
@@ -14660,7 +14642,7 @@ export interface DescribeNetworkInterfacesRequest {
 
 export namespace DescribeNetworkInterfacesRequest {
   export function isa(o: any): o is DescribeNetworkInterfacesRequest {
-    return _smithy.isa(o, "DescribeNetworkInterfacesRequest");
+    return __isa(o, "DescribeNetworkInterfacesRequest");
   }
 }
 
@@ -14682,7 +14664,7 @@ export interface DescribeNetworkInterfacesResult extends $MetadataBearer {
 
 export namespace DescribeNetworkInterfacesResult {
   export function isa(o: any): o is DescribeNetworkInterfacesResult {
-    return _smithy.isa(o, "DescribeNetworkInterfacesResult");
+    return __isa(o, "DescribeNetworkInterfacesResult");
   }
 }
 
@@ -14733,7 +14715,7 @@ export interface DescribePlacementGroupsRequest {
 
 export namespace DescribePlacementGroupsRequest {
   export function isa(o: any): o is DescribePlacementGroupsRequest {
-    return _smithy.isa(o, "DescribePlacementGroupsRequest");
+    return __isa(o, "DescribePlacementGroupsRequest");
   }
 }
 
@@ -14747,7 +14729,7 @@ export interface DescribePlacementGroupsResult extends $MetadataBearer {
 
 export namespace DescribePlacementGroupsResult {
   export function isa(o: any): o is DescribePlacementGroupsResult {
-    return _smithy.isa(o, "DescribePlacementGroupsResult");
+    return __isa(o, "DescribePlacementGroupsResult");
   }
 }
 
@@ -14794,7 +14776,7 @@ export interface DescribePrefixListsRequest {
 
 export namespace DescribePrefixListsRequest {
   export function isa(o: any): o is DescribePrefixListsRequest {
-    return _smithy.isa(o, "DescribePrefixListsRequest");
+    return __isa(o, "DescribePrefixListsRequest");
   }
 }
 
@@ -14813,7 +14795,7 @@ export interface DescribePrefixListsResult extends $MetadataBearer {
 
 export namespace DescribePrefixListsResult {
   export function isa(o: any): o is DescribePrefixListsResult {
-    return _smithy.isa(o, "DescribePrefixListsResult");
+    return __isa(o, "DescribePrefixListsResult");
   }
 }
 
@@ -14858,7 +14840,7 @@ export interface DescribePrincipalIdFormatRequest {
 
 export namespace DescribePrincipalIdFormatRequest {
   export function isa(o: any): o is DescribePrincipalIdFormatRequest {
-    return _smithy.isa(o, "DescribePrincipalIdFormatRequest");
+    return __isa(o, "DescribePrincipalIdFormatRequest");
   }
 }
 
@@ -14877,7 +14859,7 @@ export interface DescribePrincipalIdFormatResult extends $MetadataBearer {
 
 export namespace DescribePrincipalIdFormatResult {
   export function isa(o: any): o is DescribePrincipalIdFormatResult {
-    return _smithy.isa(o, "DescribePrincipalIdFormatResult");
+    return __isa(o, "DescribePrincipalIdFormatResult");
   }
 }
 
@@ -14902,7 +14884,7 @@ export interface DescribePublicIpv4PoolsRequest {
 
 export namespace DescribePublicIpv4PoolsRequest {
   export function isa(o: any): o is DescribePublicIpv4PoolsRequest {
-    return _smithy.isa(o, "DescribePublicIpv4PoolsRequest");
+    return __isa(o, "DescribePublicIpv4PoolsRequest");
   }
 }
 
@@ -14921,7 +14903,7 @@ export interface DescribePublicIpv4PoolsResult extends $MetadataBearer {
 
 export namespace DescribePublicIpv4PoolsResult {
   export function isa(o: any): o is DescribePublicIpv4PoolsResult {
-    return _smithy.isa(o, "DescribePublicIpv4PoolsResult");
+    return __isa(o, "DescribePublicIpv4PoolsResult");
   }
 }
 
@@ -14967,7 +14949,7 @@ export interface DescribeRegionsRequest {
 
 export namespace DescribeRegionsRequest {
   export function isa(o: any): o is DescribeRegionsRequest {
-    return _smithy.isa(o, "DescribeRegionsRequest");
+    return __isa(o, "DescribeRegionsRequest");
   }
 }
 
@@ -14981,7 +14963,7 @@ export interface DescribeRegionsResult extends $MetadataBearer {
 
 export namespace DescribeRegionsResult {
   export function isa(o: any): o is DescribeRegionsResult {
-    return _smithy.isa(o, "DescribeRegionsResult");
+    return __isa(o, "DescribeRegionsResult");
   }
 }
 
@@ -15027,7 +15009,7 @@ export interface DescribeReservedInstancesListingsRequest {
 
 export namespace DescribeReservedInstancesListingsRequest {
   export function isa(o: any): o is DescribeReservedInstancesListingsRequest {
-    return _smithy.isa(o, "DescribeReservedInstancesListingsRequest");
+    return __isa(o, "DescribeReservedInstancesListingsRequest");
   }
 }
 
@@ -15045,7 +15027,7 @@ export interface DescribeReservedInstancesListingsResult
 
 export namespace DescribeReservedInstancesListingsResult {
   export function isa(o: any): o is DescribeReservedInstancesListingsResult {
-    return _smithy.isa(o, "DescribeReservedInstancesListingsResult");
+    return __isa(o, "DescribeReservedInstancesListingsResult");
   }
 }
 
@@ -15129,7 +15111,7 @@ export namespace DescribeReservedInstancesModificationsRequest {
   export function isa(
     o: any
   ): o is DescribeReservedInstancesModificationsRequest {
-    return _smithy.isa(o, "DescribeReservedInstancesModificationsRequest");
+    return __isa(o, "DescribeReservedInstancesModificationsRequest");
   }
 }
 
@@ -15155,7 +15137,7 @@ export namespace DescribeReservedInstancesModificationsResult {
   export function isa(
     o: any
   ): o is DescribeReservedInstancesModificationsResult {
-    return _smithy.isa(o, "DescribeReservedInstancesModificationsResult");
+    return __isa(o, "DescribeReservedInstancesModificationsResult");
   }
 }
 
@@ -15317,7 +15299,7 @@ export interface DescribeReservedInstancesOfferingsRequest {
 
 export namespace DescribeReservedInstancesOfferingsRequest {
   export function isa(o: any): o is DescribeReservedInstancesOfferingsRequest {
-    return _smithy.isa(o, "DescribeReservedInstancesOfferingsRequest");
+    return __isa(o, "DescribeReservedInstancesOfferingsRequest");
   }
 }
 
@@ -15341,7 +15323,7 @@ export interface DescribeReservedInstancesOfferingsResult
 
 export namespace DescribeReservedInstancesOfferingsResult {
   export function isa(o: any): o is DescribeReservedInstancesOfferingsResult {
-    return _smithy.isa(o, "DescribeReservedInstancesOfferingsResult");
+    return __isa(o, "DescribeReservedInstancesOfferingsResult");
   }
 }
 
@@ -15448,7 +15430,7 @@ export interface DescribeReservedInstancesRequest {
 
 export namespace DescribeReservedInstancesRequest {
   export function isa(o: any): o is DescribeReservedInstancesRequest {
-    return _smithy.isa(o, "DescribeReservedInstancesRequest");
+    return __isa(o, "DescribeReservedInstancesRequest");
   }
 }
 
@@ -15465,7 +15447,7 @@ export interface DescribeReservedInstancesResult extends $MetadataBearer {
 
 export namespace DescribeReservedInstancesResult {
   export function isa(o: any): o is DescribeReservedInstancesResult {
-    return _smithy.isa(o, "DescribeReservedInstancesResult");
+    return __isa(o, "DescribeReservedInstancesResult");
   }
 }
 
@@ -15608,7 +15590,7 @@ export interface DescribeRouteTablesRequest {
 
 export namespace DescribeRouteTablesRequest {
   export function isa(o: any): o is DescribeRouteTablesRequest {
-    return _smithy.isa(o, "DescribeRouteTablesRequest");
+    return __isa(o, "DescribeRouteTablesRequest");
   }
 }
 
@@ -15630,7 +15612,7 @@ export interface DescribeRouteTablesResult extends $MetadataBearer {
 
 export namespace DescribeRouteTablesResult {
   export function isa(o: any): o is DescribeRouteTablesResult {
-    return _smithy.isa(o, "DescribeRouteTablesResult");
+    return __isa(o, "DescribeRouteTablesResult");
   }
 }
 
@@ -15708,7 +15690,7 @@ export namespace DescribeScheduledInstanceAvailabilityRequest {
   export function isa(
     o: any
   ): o is DescribeScheduledInstanceAvailabilityRequest {
-    return _smithy.isa(o, "DescribeScheduledInstanceAvailabilityRequest");
+    return __isa(o, "DescribeScheduledInstanceAvailabilityRequest");
   }
 }
 
@@ -15733,7 +15715,7 @@ export namespace DescribeScheduledInstanceAvailabilityResult {
   export function isa(
     o: any
   ): o is DescribeScheduledInstanceAvailabilityResult {
-    return _smithy.isa(o, "DescribeScheduledInstanceAvailabilityResult");
+    return __isa(o, "DescribeScheduledInstanceAvailabilityResult");
   }
 }
 
@@ -15798,7 +15780,7 @@ export interface DescribeScheduledInstancesRequest {
 
 export namespace DescribeScheduledInstancesRequest {
   export function isa(o: any): o is DescribeScheduledInstancesRequest {
-    return _smithy.isa(o, "DescribeScheduledInstancesRequest");
+    return __isa(o, "DescribeScheduledInstancesRequest");
   }
 }
 
@@ -15820,7 +15802,7 @@ export interface DescribeScheduledInstancesResult extends $MetadataBearer {
 
 export namespace DescribeScheduledInstancesResult {
   export function isa(o: any): o is DescribeScheduledInstancesResult {
-    return _smithy.isa(o, "DescribeScheduledInstancesResult");
+    return __isa(o, "DescribeScheduledInstancesResult");
   }
 }
 
@@ -15841,7 +15823,7 @@ export interface DescribeSecurityGroupReferencesRequest {
 
 export namespace DescribeSecurityGroupReferencesRequest {
   export function isa(o: any): o is DescribeSecurityGroupReferencesRequest {
-    return _smithy.isa(o, "DescribeSecurityGroupReferencesRequest");
+    return __isa(o, "DescribeSecurityGroupReferencesRequest");
   }
 }
 
@@ -15855,7 +15837,7 @@ export interface DescribeSecurityGroupReferencesResult extends $MetadataBearer {
 
 export namespace DescribeSecurityGroupReferencesResult {
   export function isa(o: any): o is DescribeSecurityGroupReferencesResult {
-    return _smithy.isa(o, "DescribeSecurityGroupReferencesResult");
+    return __isa(o, "DescribeSecurityGroupReferencesResult");
   }
 }
 
@@ -16027,7 +16009,7 @@ export interface DescribeSecurityGroupsRequest {
 
 export namespace DescribeSecurityGroupsRequest {
   export function isa(o: any): o is DescribeSecurityGroupsRequest {
-    return _smithy.isa(o, "DescribeSecurityGroupsRequest");
+    return __isa(o, "DescribeSecurityGroupsRequest");
   }
 }
 
@@ -16046,7 +16028,7 @@ export interface DescribeSecurityGroupsResult extends $MetadataBearer {
 
 export namespace DescribeSecurityGroupsResult {
   export function isa(o: any): o is DescribeSecurityGroupsResult {
-    return _smithy.isa(o, "DescribeSecurityGroupsResult");
+    return __isa(o, "DescribeSecurityGroupsResult");
   }
 }
 
@@ -16072,7 +16054,7 @@ export interface DescribeSnapshotAttributeRequest {
 
 export namespace DescribeSnapshotAttributeRequest {
   export function isa(o: any): o is DescribeSnapshotAttributeRequest {
-    return _smithy.isa(o, "DescribeSnapshotAttributeRequest");
+    return __isa(o, "DescribeSnapshotAttributeRequest");
   }
 }
 
@@ -16097,7 +16079,7 @@ export interface DescribeSnapshotAttributeResult extends $MetadataBearer {
 
 export namespace DescribeSnapshotAttributeResult {
   export function isa(o: any): o is DescribeSnapshotAttributeResult {
-    return _smithy.isa(o, "DescribeSnapshotAttributeResult");
+    return __isa(o, "DescribeSnapshotAttributeResult");
   }
 }
 
@@ -16213,7 +16195,7 @@ export interface DescribeSnapshotsRequest {
 
 export namespace DescribeSnapshotsRequest {
   export function isa(o: any): o is DescribeSnapshotsRequest {
-    return _smithy.isa(o, "DescribeSnapshotsRequest");
+    return __isa(o, "DescribeSnapshotsRequest");
   }
 }
 
@@ -16235,7 +16217,7 @@ export interface DescribeSnapshotsResult extends $MetadataBearer {
 
 export namespace DescribeSnapshotsResult {
   export function isa(o: any): o is DescribeSnapshotsResult {
-    return _smithy.isa(o, "DescribeSnapshotsResult");
+    return __isa(o, "DescribeSnapshotsResult");
   }
 }
 
@@ -16254,7 +16236,7 @@ export interface DescribeSpotDatafeedSubscriptionRequest {
 
 export namespace DescribeSpotDatafeedSubscriptionRequest {
   export function isa(o: any): o is DescribeSpotDatafeedSubscriptionRequest {
-    return _smithy.isa(o, "DescribeSpotDatafeedSubscriptionRequest");
+    return __isa(o, "DescribeSpotDatafeedSubscriptionRequest");
   }
 }
 
@@ -16272,7 +16254,7 @@ export interface DescribeSpotDatafeedSubscriptionResult
 
 export namespace DescribeSpotDatafeedSubscriptionResult {
   export function isa(o: any): o is DescribeSpotDatafeedSubscriptionResult {
-    return _smithy.isa(o, "DescribeSpotDatafeedSubscriptionResult");
+    return __isa(o, "DescribeSpotDatafeedSubscriptionResult");
   }
 }
 
@@ -16309,7 +16291,7 @@ export interface DescribeSpotFleetInstancesRequest {
 
 export namespace DescribeSpotFleetInstancesRequest {
   export function isa(o: any): o is DescribeSpotFleetInstancesRequest {
-    return _smithy.isa(o, "DescribeSpotFleetInstancesRequest");
+    return __isa(o, "DescribeSpotFleetInstancesRequest");
   }
 }
 
@@ -16337,7 +16319,7 @@ export interface DescribeSpotFleetInstancesResponse extends $MetadataBearer {
 
 export namespace DescribeSpotFleetInstancesResponse {
   export function isa(o: any): o is DescribeSpotFleetInstancesResponse {
-    return _smithy.isa(o, "DescribeSpotFleetInstancesResponse");
+    return __isa(o, "DescribeSpotFleetInstancesResponse");
   }
 }
 
@@ -16384,7 +16366,7 @@ export interface DescribeSpotFleetRequestHistoryRequest {
 
 export namespace DescribeSpotFleetRequestHistoryRequest {
   export function isa(o: any): o is DescribeSpotFleetRequestHistoryRequest {
-    return _smithy.isa(o, "DescribeSpotFleetRequestHistoryRequest");
+    return __isa(o, "DescribeSpotFleetRequestHistoryRequest");
   }
 }
 
@@ -16424,7 +16406,7 @@ export interface DescribeSpotFleetRequestHistoryResponse
 
 export namespace DescribeSpotFleetRequestHistoryResponse {
   export function isa(o: any): o is DescribeSpotFleetRequestHistoryResponse {
-    return _smithy.isa(o, "DescribeSpotFleetRequestHistoryResponse");
+    return __isa(o, "DescribeSpotFleetRequestHistoryResponse");
   }
 }
 
@@ -16461,7 +16443,7 @@ export interface DescribeSpotFleetRequestsRequest {
 
 export namespace DescribeSpotFleetRequestsRequest {
   export function isa(o: any): o is DescribeSpotFleetRequestsRequest {
-    return _smithy.isa(o, "DescribeSpotFleetRequestsRequest");
+    return __isa(o, "DescribeSpotFleetRequestsRequest");
   }
 }
 
@@ -16483,7 +16465,7 @@ export interface DescribeSpotFleetRequestsResponse extends $MetadataBearer {
 
 export namespace DescribeSpotFleetRequestsResponse {
   export function isa(o: any): o is DescribeSpotFleetRequestsResponse {
-    return _smithy.isa(o, "DescribeSpotFleetRequestsResponse");
+    return __isa(o, "DescribeSpotFleetRequestsResponse");
   }
 }
 
@@ -16695,7 +16677,7 @@ export interface DescribeSpotInstanceRequestsRequest {
 
 export namespace DescribeSpotInstanceRequestsRequest {
   export function isa(o: any): o is DescribeSpotInstanceRequestsRequest {
-    return _smithy.isa(o, "DescribeSpotInstanceRequestsRequest");
+    return __isa(o, "DescribeSpotInstanceRequestsRequest");
   }
 }
 
@@ -16718,7 +16700,7 @@ export interface DescribeSpotInstanceRequestsResult extends $MetadataBearer {
 
 export namespace DescribeSpotInstanceRequestsResult {
   export function isa(o: any): o is DescribeSpotInstanceRequestsResult {
-    return _smithy.isa(o, "DescribeSpotInstanceRequestsResult");
+    return __isa(o, "DescribeSpotInstanceRequestsResult");
   }
 }
 
@@ -16809,7 +16791,7 @@ export interface DescribeSpotPriceHistoryRequest {
 
 export namespace DescribeSpotPriceHistoryRequest {
   export function isa(o: any): o is DescribeSpotPriceHistoryRequest {
-    return _smithy.isa(o, "DescribeSpotPriceHistoryRequest");
+    return __isa(o, "DescribeSpotPriceHistoryRequest");
   }
 }
 
@@ -16832,7 +16814,7 @@ export interface DescribeSpotPriceHistoryResult extends $MetadataBearer {
 
 export namespace DescribeSpotPriceHistoryResult {
   export function isa(o: any): o is DescribeSpotPriceHistoryResult {
-    return _smithy.isa(o, "DescribeSpotPriceHistoryResult");
+    return __isa(o, "DescribeSpotPriceHistoryResult");
   }
 }
 
@@ -16863,7 +16845,7 @@ export interface DescribeStaleSecurityGroupsRequest {
 
 export namespace DescribeStaleSecurityGroupsRequest {
   export function isa(o: any): o is DescribeStaleSecurityGroupsRequest {
-    return _smithy.isa(o, "DescribeStaleSecurityGroupsRequest");
+    return __isa(o, "DescribeStaleSecurityGroupsRequest");
   }
 }
 
@@ -16882,7 +16864,7 @@ export interface DescribeStaleSecurityGroupsResult extends $MetadataBearer {
 
 export namespace DescribeStaleSecurityGroupsResult {
   export function isa(o: any): o is DescribeStaleSecurityGroupsResult {
-    return _smithy.isa(o, "DescribeStaleSecurityGroupsResult");
+    return __isa(o, "DescribeStaleSecurityGroupsResult");
   }
 }
 
@@ -16993,7 +16975,7 @@ export interface DescribeSubnetsRequest {
 
 export namespace DescribeSubnetsRequest {
   export function isa(o: any): o is DescribeSubnetsRequest {
-    return _smithy.isa(o, "DescribeSubnetsRequest");
+    return __isa(o, "DescribeSubnetsRequest");
   }
 }
 
@@ -17012,7 +16994,7 @@ export interface DescribeSubnetsResult extends $MetadataBearer {
 
 export namespace DescribeSubnetsResult {
   export function isa(o: any): o is DescribeSubnetsResult {
-    return _smithy.isa(o, "DescribeSubnetsResult");
+    return __isa(o, "DescribeSubnetsResult");
   }
 }
 
@@ -17079,7 +17061,7 @@ export interface DescribeTagsRequest {
 
 export namespace DescribeTagsRequest {
   export function isa(o: any): o is DescribeTagsRequest {
-    return _smithy.isa(o, "DescribeTagsRequest");
+    return __isa(o, "DescribeTagsRequest");
   }
 }
 
@@ -17099,7 +17081,7 @@ export interface DescribeTagsResult extends $MetadataBearer {
 
 export namespace DescribeTagsResult {
   export function isa(o: any): o is DescribeTagsResult {
-    return _smithy.isa(o, "DescribeTagsResult");
+    return __isa(o, "DescribeTagsResult");
   }
 }
 
@@ -17146,7 +17128,7 @@ export interface DescribeTrafficMirrorFiltersRequest {
 
 export namespace DescribeTrafficMirrorFiltersRequest {
   export function isa(o: any): o is DescribeTrafficMirrorFiltersRequest {
-    return _smithy.isa(o, "DescribeTrafficMirrorFiltersRequest");
+    return __isa(o, "DescribeTrafficMirrorFiltersRequest");
   }
 }
 
@@ -17165,7 +17147,7 @@ export interface DescribeTrafficMirrorFiltersResult extends $MetadataBearer {
 
 export namespace DescribeTrafficMirrorFiltersResult {
   export function isa(o: any): o is DescribeTrafficMirrorFiltersResult {
-    return _smithy.isa(o, "DescribeTrafficMirrorFiltersResult");
+    return __isa(o, "DescribeTrafficMirrorFiltersResult");
   }
 }
 
@@ -17240,7 +17222,7 @@ export interface DescribeTrafficMirrorSessionsRequest {
 
 export namespace DescribeTrafficMirrorSessionsRequest {
   export function isa(o: any): o is DescribeTrafficMirrorSessionsRequest {
-    return _smithy.isa(o, "DescribeTrafficMirrorSessionsRequest");
+    return __isa(o, "DescribeTrafficMirrorSessionsRequest");
   }
 }
 
@@ -17259,7 +17241,7 @@ export interface DescribeTrafficMirrorSessionsResult extends $MetadataBearer {
 
 export namespace DescribeTrafficMirrorSessionsResult {
   export function isa(o: any): o is DescribeTrafficMirrorSessionsResult {
-    return _smithy.isa(o, "DescribeTrafficMirrorSessionsResult");
+    return __isa(o, "DescribeTrafficMirrorSessionsResult");
   }
 }
 
@@ -17318,7 +17300,7 @@ export interface DescribeTrafficMirrorTargetsRequest {
 
 export namespace DescribeTrafficMirrorTargetsRequest {
   export function isa(o: any): o is DescribeTrafficMirrorTargetsRequest {
-    return _smithy.isa(o, "DescribeTrafficMirrorTargetsRequest");
+    return __isa(o, "DescribeTrafficMirrorTargetsRequest");
   }
 }
 
@@ -17337,7 +17319,7 @@ export interface DescribeTrafficMirrorTargetsResult extends $MetadataBearer {
 
 export namespace DescribeTrafficMirrorTargetsResult {
   export function isa(o: any): o is DescribeTrafficMirrorTargetsResult {
-    return _smithy.isa(o, "DescribeTrafficMirrorTargetsResult");
+    return __isa(o, "DescribeTrafficMirrorTargetsResult");
   }
 }
 
@@ -17413,7 +17395,7 @@ export interface DescribeTransitGatewayAttachmentsRequest {
 
 export namespace DescribeTransitGatewayAttachmentsRequest {
   export function isa(o: any): o is DescribeTransitGatewayAttachmentsRequest {
-    return _smithy.isa(o, "DescribeTransitGatewayAttachmentsRequest");
+    return __isa(o, "DescribeTransitGatewayAttachmentsRequest");
   }
 }
 
@@ -17433,7 +17415,7 @@ export interface DescribeTransitGatewayAttachmentsResult
 
 export namespace DescribeTransitGatewayAttachmentsResult {
   export function isa(o: any): o is DescribeTransitGatewayAttachmentsResult {
-    return _smithy.isa(o, "DescribeTransitGatewayAttachmentsResult");
+    return __isa(o, "DescribeTransitGatewayAttachmentsResult");
   }
 }
 
@@ -17486,7 +17468,7 @@ export namespace DescribeTransitGatewayMulticastDomainsRequest {
   export function isa(
     o: any
   ): o is DescribeTransitGatewayMulticastDomainsRequest {
-    return _smithy.isa(o, "DescribeTransitGatewayMulticastDomainsRequest");
+    return __isa(o, "DescribeTransitGatewayMulticastDomainsRequest");
   }
 }
 
@@ -17508,7 +17490,7 @@ export namespace DescribeTransitGatewayMulticastDomainsResult {
   export function isa(
     o: any
   ): o is DescribeTransitGatewayMulticastDomainsResult {
-    return _smithy.isa(o, "DescribeTransitGatewayMulticastDomainsResult");
+    return __isa(o, "DescribeTransitGatewayMulticastDomainsResult");
   }
 }
 
@@ -17547,7 +17529,7 @@ export namespace DescribeTransitGatewayPeeringAttachmentsRequest {
   export function isa(
     o: any
   ): o is DescribeTransitGatewayPeeringAttachmentsRequest {
-    return _smithy.isa(o, "DescribeTransitGatewayPeeringAttachmentsRequest");
+    return __isa(o, "DescribeTransitGatewayPeeringAttachmentsRequest");
   }
 }
 
@@ -17569,7 +17551,7 @@ export namespace DescribeTransitGatewayPeeringAttachmentsResult {
   export function isa(
     o: any
   ): o is DescribeTransitGatewayPeeringAttachmentsResult {
-    return _smithy.isa(o, "DescribeTransitGatewayPeeringAttachmentsResult");
+    return __isa(o, "DescribeTransitGatewayPeeringAttachmentsResult");
   }
 }
 
@@ -17630,7 +17612,7 @@ export interface DescribeTransitGatewayRouteTablesRequest {
 
 export namespace DescribeTransitGatewayRouteTablesRequest {
   export function isa(o: any): o is DescribeTransitGatewayRouteTablesRequest {
-    return _smithy.isa(o, "DescribeTransitGatewayRouteTablesRequest");
+    return __isa(o, "DescribeTransitGatewayRouteTablesRequest");
   }
 }
 
@@ -17650,7 +17632,7 @@ export interface DescribeTransitGatewayRouteTablesResult
 
 export namespace DescribeTransitGatewayRouteTablesResult {
   export function isa(o: any): o is DescribeTransitGatewayRouteTablesResult {
-    return _smithy.isa(o, "DescribeTransitGatewayRouteTablesResult");
+    return __isa(o, "DescribeTransitGatewayRouteTablesResult");
   }
 }
 
@@ -17707,7 +17689,7 @@ export namespace DescribeTransitGatewayVpcAttachmentsRequest {
   export function isa(
     o: any
   ): o is DescribeTransitGatewayVpcAttachmentsRequest {
-    return _smithy.isa(o, "DescribeTransitGatewayVpcAttachmentsRequest");
+    return __isa(o, "DescribeTransitGatewayVpcAttachmentsRequest");
   }
 }
 
@@ -17727,7 +17709,7 @@ export interface DescribeTransitGatewayVpcAttachmentsResult
 
 export namespace DescribeTransitGatewayVpcAttachmentsResult {
   export function isa(o: any): o is DescribeTransitGatewayVpcAttachmentsResult {
-    return _smithy.isa(o, "DescribeTransitGatewayVpcAttachmentsResult");
+    return __isa(o, "DescribeTransitGatewayVpcAttachmentsResult");
   }
 }
 
@@ -17812,7 +17794,7 @@ export interface DescribeTransitGatewaysRequest {
 
 export namespace DescribeTransitGatewaysRequest {
   export function isa(o: any): o is DescribeTransitGatewaysRequest {
-    return _smithy.isa(o, "DescribeTransitGatewaysRequest");
+    return __isa(o, "DescribeTransitGatewaysRequest");
   }
 }
 
@@ -17831,7 +17813,7 @@ export interface DescribeTransitGatewaysResult extends $MetadataBearer {
 
 export namespace DescribeTransitGatewaysResult {
   export function isa(o: any): o is DescribeTransitGatewaysResult {
-    return _smithy.isa(o, "DescribeTransitGatewaysResult");
+    return __isa(o, "DescribeTransitGatewaysResult");
   }
 }
 
@@ -17857,7 +17839,7 @@ export interface DescribeVolumeAttributeRequest {
 
 export namespace DescribeVolumeAttributeRequest {
   export function isa(o: any): o is DescribeVolumeAttributeRequest {
-    return _smithy.isa(o, "DescribeVolumeAttributeRequest");
+    return __isa(o, "DescribeVolumeAttributeRequest");
   }
 }
 
@@ -17881,7 +17863,7 @@ export interface DescribeVolumeAttributeResult extends $MetadataBearer {
 
 export namespace DescribeVolumeAttributeResult {
   export function isa(o: any): o is DescribeVolumeAttributeResult {
-    return _smithy.isa(o, "DescribeVolumeAttributeResult");
+    return __isa(o, "DescribeVolumeAttributeResult");
   }
 }
 
@@ -17989,7 +17971,7 @@ export interface DescribeVolumeStatusRequest {
 
 export namespace DescribeVolumeStatusRequest {
   export function isa(o: any): o is DescribeVolumeStatusRequest {
-    return _smithy.isa(o, "DescribeVolumeStatusRequest");
+    return __isa(o, "DescribeVolumeStatusRequest");
   }
 }
 
@@ -18009,7 +17991,7 @@ export interface DescribeVolumeStatusResult extends $MetadataBearer {
 
 export namespace DescribeVolumeStatusResult {
   export function isa(o: any): o is DescribeVolumeStatusResult {
-    return _smithy.isa(o, "DescribeVolumeStatusResult");
+    return __isa(o, "DescribeVolumeStatusResult");
   }
 }
 
@@ -18049,7 +18031,7 @@ export interface DescribeVolumesModificationsRequest {
 
 export namespace DescribeVolumesModificationsRequest {
   export function isa(o: any): o is DescribeVolumesModificationsRequest {
-    return _smithy.isa(o, "DescribeVolumesModificationsRequest");
+    return __isa(o, "DescribeVolumesModificationsRequest");
   }
 }
 
@@ -18068,7 +18050,7 @@ export interface DescribeVolumesModificationsResult extends $MetadataBearer {
 
 export namespace DescribeVolumesModificationsResult {
   export function isa(o: any): o is DescribeVolumesModificationsResult {
-    return _smithy.isa(o, "DescribeVolumesModificationsResult");
+    return __isa(o, "DescribeVolumesModificationsResult");
   }
 }
 
@@ -18190,7 +18172,7 @@ export interface DescribeVolumesRequest {
 
 export namespace DescribeVolumesRequest {
   export function isa(o: any): o is DescribeVolumesRequest {
-    return _smithy.isa(o, "DescribeVolumesRequest");
+    return __isa(o, "DescribeVolumesRequest");
   }
 }
 
@@ -18212,7 +18194,7 @@ export interface DescribeVolumesResult extends $MetadataBearer {
 
 export namespace DescribeVolumesResult {
   export function isa(o: any): o is DescribeVolumesResult {
-    return _smithy.isa(o, "DescribeVolumesResult");
+    return __isa(o, "DescribeVolumesResult");
   }
 }
 
@@ -18238,7 +18220,7 @@ export interface DescribeVpcAttributeRequest {
 
 export namespace DescribeVpcAttributeRequest {
   export function isa(o: any): o is DescribeVpcAttributeRequest {
-    return _smithy.isa(o, "DescribeVpcAttributeRequest");
+    return __isa(o, "DescribeVpcAttributeRequest");
   }
 }
 
@@ -18267,7 +18249,7 @@ export interface DescribeVpcAttributeResult extends $MetadataBearer {
 
 export namespace DescribeVpcAttributeResult {
   export function isa(o: any): o is DescribeVpcAttributeResult {
-    return _smithy.isa(o, "DescribeVpcAttributeResult");
+    return __isa(o, "DescribeVpcAttributeResult");
   }
 }
 
@@ -18292,7 +18274,7 @@ export interface DescribeVpcClassicLinkDnsSupportRequest {
 
 export namespace DescribeVpcClassicLinkDnsSupportRequest {
   export function isa(o: any): o is DescribeVpcClassicLinkDnsSupportRequest {
-    return _smithy.isa(o, "DescribeVpcClassicLinkDnsSupportRequest");
+    return __isa(o, "DescribeVpcClassicLinkDnsSupportRequest");
   }
 }
 
@@ -18312,7 +18294,7 @@ export interface DescribeVpcClassicLinkDnsSupportResult
 
 export namespace DescribeVpcClassicLinkDnsSupportResult {
   export function isa(o: any): o is DescribeVpcClassicLinkDnsSupportResult {
-    return _smithy.isa(o, "DescribeVpcClassicLinkDnsSupportResult");
+    return __isa(o, "DescribeVpcClassicLinkDnsSupportResult");
   }
 }
 
@@ -18354,7 +18336,7 @@ export interface DescribeVpcClassicLinkRequest {
 
 export namespace DescribeVpcClassicLinkRequest {
   export function isa(o: any): o is DescribeVpcClassicLinkRequest {
-    return _smithy.isa(o, "DescribeVpcClassicLinkRequest");
+    return __isa(o, "DescribeVpcClassicLinkRequest");
   }
 }
 
@@ -18368,7 +18350,7 @@ export interface DescribeVpcClassicLinkResult extends $MetadataBearer {
 
 export namespace DescribeVpcClassicLinkResult {
   export function isa(o: any): o is DescribeVpcClassicLinkResult {
-    return _smithy.isa(o, "DescribeVpcClassicLinkResult");
+    return __isa(o, "DescribeVpcClassicLinkResult");
   }
 }
 
@@ -18437,7 +18419,7 @@ export namespace DescribeVpcEndpointConnectionNotificationsRequest {
   export function isa(
     o: any
   ): o is DescribeVpcEndpointConnectionNotificationsRequest {
-    return _smithy.isa(o, "DescribeVpcEndpointConnectionNotificationsRequest");
+    return __isa(o, "DescribeVpcEndpointConnectionNotificationsRequest");
   }
 }
 
@@ -18460,7 +18442,7 @@ export namespace DescribeVpcEndpointConnectionNotificationsResult {
   export function isa(
     o: any
   ): o is DescribeVpcEndpointConnectionNotificationsResult {
-    return _smithy.isa(o, "DescribeVpcEndpointConnectionNotificationsResult");
+    return __isa(o, "DescribeVpcEndpointConnectionNotificationsResult");
   }
 }
 
@@ -18517,7 +18499,7 @@ export interface DescribeVpcEndpointConnectionsRequest {
 
 export namespace DescribeVpcEndpointConnectionsRequest {
   export function isa(o: any): o is DescribeVpcEndpointConnectionsRequest {
-    return _smithy.isa(o, "DescribeVpcEndpointConnectionsRequest");
+    return __isa(o, "DescribeVpcEndpointConnectionsRequest");
   }
 }
 
@@ -18536,7 +18518,7 @@ export interface DescribeVpcEndpointConnectionsResult extends $MetadataBearer {
 
 export namespace DescribeVpcEndpointConnectionsResult {
   export function isa(o: any): o is DescribeVpcEndpointConnectionsResult {
-    return _smithy.isa(o, "DescribeVpcEndpointConnectionsResult");
+    return __isa(o, "DescribeVpcEndpointConnectionsResult");
   }
 }
 
@@ -18602,7 +18584,7 @@ export namespace DescribeVpcEndpointServiceConfigurationsRequest {
   export function isa(
     o: any
   ): o is DescribeVpcEndpointServiceConfigurationsRequest {
-    return _smithy.isa(o, "DescribeVpcEndpointServiceConfigurationsRequest");
+    return __isa(o, "DescribeVpcEndpointServiceConfigurationsRequest");
   }
 }
 
@@ -18624,7 +18606,7 @@ export namespace DescribeVpcEndpointServiceConfigurationsResult {
   export function isa(
     o: any
   ): o is DescribeVpcEndpointServiceConfigurationsResult {
-    return _smithy.isa(o, "DescribeVpcEndpointServiceConfigurationsResult");
+    return __isa(o, "DescribeVpcEndpointServiceConfigurationsResult");
   }
 }
 
@@ -18678,7 +18660,7 @@ export namespace DescribeVpcEndpointServicePermissionsRequest {
   export function isa(
     o: any
   ): o is DescribeVpcEndpointServicePermissionsRequest {
-    return _smithy.isa(o, "DescribeVpcEndpointServicePermissionsRequest");
+    return __isa(o, "DescribeVpcEndpointServicePermissionsRequest");
   }
 }
 
@@ -18700,7 +18682,7 @@ export namespace DescribeVpcEndpointServicePermissionsResult {
   export function isa(
     o: any
   ): o is DescribeVpcEndpointServicePermissionsResult {
-    return _smithy.isa(o, "DescribeVpcEndpointServicePermissionsResult");
+    return __isa(o, "DescribeVpcEndpointServicePermissionsResult");
   }
 }
 
@@ -18754,7 +18736,7 @@ export interface DescribeVpcEndpointServicesRequest {
 
 export namespace DescribeVpcEndpointServicesRequest {
   export function isa(o: any): o is DescribeVpcEndpointServicesRequest {
-    return _smithy.isa(o, "DescribeVpcEndpointServicesRequest");
+    return __isa(o, "DescribeVpcEndpointServicesRequest");
   }
 }
 
@@ -18781,7 +18763,7 @@ export interface DescribeVpcEndpointServicesResult extends $MetadataBearer {
 
 export namespace DescribeVpcEndpointServicesResult {
   export function isa(o: any): o is DescribeVpcEndpointServicesResult {
-    return _smithy.isa(o, "DescribeVpcEndpointServicesResult");
+    return __isa(o, "DescribeVpcEndpointServicesResult");
   }
 }
 
@@ -18850,7 +18832,7 @@ export interface DescribeVpcEndpointsRequest {
 
 export namespace DescribeVpcEndpointsRequest {
   export function isa(o: any): o is DescribeVpcEndpointsRequest {
-    return _smithy.isa(o, "DescribeVpcEndpointsRequest");
+    return __isa(o, "DescribeVpcEndpointsRequest");
   }
 }
 
@@ -18872,7 +18854,7 @@ export interface DescribeVpcEndpointsResult extends $MetadataBearer {
 
 export namespace DescribeVpcEndpointsResult {
   export function isa(o: any): o is DescribeVpcEndpointsResult {
-    return _smithy.isa(o, "DescribeVpcEndpointsResult");
+    return __isa(o, "DescribeVpcEndpointsResult");
   }
 }
 
@@ -18971,7 +18953,7 @@ export interface DescribeVpcPeeringConnectionsRequest {
 
 export namespace DescribeVpcPeeringConnectionsRequest {
   export function isa(o: any): o is DescribeVpcPeeringConnectionsRequest {
-    return _smithy.isa(o, "DescribeVpcPeeringConnectionsRequest");
+    return __isa(o, "DescribeVpcPeeringConnectionsRequest");
   }
 }
 
@@ -18990,7 +18972,7 @@ export interface DescribeVpcPeeringConnectionsResult extends $MetadataBearer {
 
 export namespace DescribeVpcPeeringConnectionsResult {
   export function isa(o: any): o is DescribeVpcPeeringConnectionsResult {
-    return _smithy.isa(o, "DescribeVpcPeeringConnectionsResult");
+    return __isa(o, "DescribeVpcPeeringConnectionsResult");
   }
 }
 
@@ -19100,7 +19082,7 @@ export interface DescribeVpcsRequest {
 
 export namespace DescribeVpcsRequest {
   export function isa(o: any): o is DescribeVpcsRequest {
-    return _smithy.isa(o, "DescribeVpcsRequest");
+    return __isa(o, "DescribeVpcsRequest");
   }
 }
 
@@ -19119,7 +19101,7 @@ export interface DescribeVpcsResult extends $MetadataBearer {
 
 export namespace DescribeVpcsResult {
   export function isa(o: any): o is DescribeVpcsResult {
-    return _smithy.isa(o, "DescribeVpcsResult");
+    return __isa(o, "DescribeVpcsResult");
   }
 }
 
@@ -19200,7 +19182,7 @@ export interface DescribeVpnConnectionsRequest {
 
 export namespace DescribeVpnConnectionsRequest {
   export function isa(o: any): o is DescribeVpnConnectionsRequest {
-    return _smithy.isa(o, "DescribeVpnConnectionsRequest");
+    return __isa(o, "DescribeVpnConnectionsRequest");
   }
 }
 
@@ -19217,7 +19199,7 @@ export interface DescribeVpnConnectionsResult extends $MetadataBearer {
 
 export namespace DescribeVpnConnectionsResult {
   export function isa(o: any): o is DescribeVpnConnectionsResult {
-    return _smithy.isa(o, "DescribeVpnConnectionsResult");
+    return __isa(o, "DescribeVpnConnectionsResult");
   }
 }
 
@@ -19286,7 +19268,7 @@ export interface DescribeVpnGatewaysRequest {
 
 export namespace DescribeVpnGatewaysRequest {
   export function isa(o: any): o is DescribeVpnGatewaysRequest {
-    return _smithy.isa(o, "DescribeVpnGatewaysRequest");
+    return __isa(o, "DescribeVpnGatewaysRequest");
   }
 }
 
@@ -19303,7 +19285,7 @@ export interface DescribeVpnGatewaysResult extends $MetadataBearer {
 
 export namespace DescribeVpnGatewaysResult {
   export function isa(o: any): o is DescribeVpnGatewaysResult {
-    return _smithy.isa(o, "DescribeVpnGatewaysResult");
+    return __isa(o, "DescribeVpnGatewaysResult");
   }
 }
 
@@ -19329,7 +19311,7 @@ export interface DetachClassicLinkVpcRequest {
 
 export namespace DetachClassicLinkVpcRequest {
   export function isa(o: any): o is DetachClassicLinkVpcRequest {
-    return _smithy.isa(o, "DetachClassicLinkVpcRequest");
+    return __isa(o, "DetachClassicLinkVpcRequest");
   }
 }
 
@@ -19343,7 +19325,7 @@ export interface DetachClassicLinkVpcResult extends $MetadataBearer {
 
 export namespace DetachClassicLinkVpcResult {
   export function isa(o: any): o is DetachClassicLinkVpcResult {
-    return _smithy.isa(o, "DetachClassicLinkVpcResult");
+    return __isa(o, "DetachClassicLinkVpcResult");
   }
 }
 
@@ -19369,7 +19351,7 @@ export interface DetachInternetGatewayRequest {
 
 export namespace DetachInternetGatewayRequest {
   export function isa(o: any): o is DetachInternetGatewayRequest {
-    return _smithy.isa(o, "DetachInternetGatewayRequest");
+    return __isa(o, "DetachInternetGatewayRequest");
   }
 }
 
@@ -19415,7 +19397,7 @@ export interface DetachNetworkInterfaceRequest {
 
 export namespace DetachNetworkInterfaceRequest {
   export function isa(o: any): o is DetachNetworkInterfaceRequest {
-    return _smithy.isa(o, "DetachNetworkInterfaceRequest");
+    return __isa(o, "DetachNetworkInterfaceRequest");
   }
 }
 
@@ -19456,7 +19438,7 @@ export interface DetachVolumeRequest {
 
 export namespace DetachVolumeRequest {
   export function isa(o: any): o is DetachVolumeRequest {
-    return _smithy.isa(o, "DetachVolumeRequest");
+    return __isa(o, "DetachVolumeRequest");
   }
 }
 
@@ -19485,7 +19467,7 @@ export interface DetachVpnGatewayRequest {
 
 export namespace DetachVpnGatewayRequest {
   export function isa(o: any): o is DetachVpnGatewayRequest {
-    return _smithy.isa(o, "DetachVpnGatewayRequest");
+    return __isa(o, "DetachVpnGatewayRequest");
   }
 }
 
@@ -19509,7 +19491,7 @@ export interface DhcpConfiguration {
 
 export namespace DhcpConfiguration {
   export function isa(o: any): o is DhcpConfiguration {
-    return _smithy.isa(o, "DhcpConfiguration");
+    return __isa(o, "DhcpConfiguration");
   }
 }
 
@@ -19541,7 +19523,7 @@ export interface DhcpOptions {
 
 export namespace DhcpOptions {
   export function isa(o: any): o is DhcpOptions {
-    return _smithy.isa(o, "DhcpOptions");
+    return __isa(o, "DhcpOptions");
   }
 }
 
@@ -19558,7 +19540,7 @@ export interface DirectoryServiceAuthentication {
 
 export namespace DirectoryServiceAuthentication {
   export function isa(o: any): o is DirectoryServiceAuthentication {
-    return _smithy.isa(o, "DirectoryServiceAuthentication");
+    return __isa(o, "DirectoryServiceAuthentication");
   }
 }
 
@@ -19575,7 +19557,7 @@ export interface DirectoryServiceAuthenticationRequest {
 
 export namespace DirectoryServiceAuthenticationRequest {
   export function isa(o: any): o is DirectoryServiceAuthenticationRequest {
-    return _smithy.isa(o, "DirectoryServiceAuthenticationRequest");
+    return __isa(o, "DirectoryServiceAuthenticationRequest");
   }
 }
 
@@ -19591,7 +19573,7 @@ export interface DisableEbsEncryptionByDefaultRequest {
 
 export namespace DisableEbsEncryptionByDefaultRequest {
   export function isa(o: any): o is DisableEbsEncryptionByDefaultRequest {
-    return _smithy.isa(o, "DisableEbsEncryptionByDefaultRequest");
+    return __isa(o, "DisableEbsEncryptionByDefaultRequest");
   }
 }
 
@@ -19605,7 +19587,7 @@ export interface DisableEbsEncryptionByDefaultResult extends $MetadataBearer {
 
 export namespace DisableEbsEncryptionByDefaultResult {
   export function isa(o: any): o is DisableEbsEncryptionByDefaultResult {
-    return _smithy.isa(o, "DisableEbsEncryptionByDefaultResult");
+    return __isa(o, "DisableEbsEncryptionByDefaultResult");
   }
 }
 
@@ -19629,7 +19611,7 @@ export interface DisableFastSnapshotRestoreErrorItem {
 
 export namespace DisableFastSnapshotRestoreErrorItem {
   export function isa(o: any): o is DisableFastSnapshotRestoreErrorItem {
-    return _smithy.isa(o, "DisableFastSnapshotRestoreErrorItem");
+    return __isa(o, "DisableFastSnapshotRestoreErrorItem");
   }
 }
 
@@ -19651,7 +19633,7 @@ export interface DisableFastSnapshotRestoreStateError {
 
 export namespace DisableFastSnapshotRestoreStateError {
   export function isa(o: any): o is DisableFastSnapshotRestoreStateError {
-    return _smithy.isa(o, "DisableFastSnapshotRestoreStateError");
+    return __isa(o, "DisableFastSnapshotRestoreStateError");
   }
 }
 
@@ -19673,7 +19655,7 @@ export interface DisableFastSnapshotRestoreStateErrorItem {
 
 export namespace DisableFastSnapshotRestoreStateErrorItem {
   export function isa(o: any): o is DisableFastSnapshotRestoreStateErrorItem {
-    return _smithy.isa(o, "DisableFastSnapshotRestoreStateErrorItem");
+    return __isa(o, "DisableFastSnapshotRestoreStateErrorItem");
   }
 }
 
@@ -19752,7 +19734,7 @@ export interface DisableFastSnapshotRestoreSuccessItem {
 
 export namespace DisableFastSnapshotRestoreSuccessItem {
   export function isa(o: any): o is DisableFastSnapshotRestoreSuccessItem {
-    return _smithy.isa(o, "DisableFastSnapshotRestoreSuccessItem");
+    return __isa(o, "DisableFastSnapshotRestoreSuccessItem");
   }
 }
 
@@ -19778,7 +19760,7 @@ export interface DisableFastSnapshotRestoresRequest {
 
 export namespace DisableFastSnapshotRestoresRequest {
   export function isa(o: any): o is DisableFastSnapshotRestoresRequest {
-    return _smithy.isa(o, "DisableFastSnapshotRestoresRequest");
+    return __isa(o, "DisableFastSnapshotRestoresRequest");
   }
 }
 
@@ -19797,7 +19779,7 @@ export interface DisableFastSnapshotRestoresResult extends $MetadataBearer {
 
 export namespace DisableFastSnapshotRestoresResult {
   export function isa(o: any): o is DisableFastSnapshotRestoresResult {
-    return _smithy.isa(o, "DisableFastSnapshotRestoresResult");
+    return __isa(o, "DisableFastSnapshotRestoresResult");
   }
 }
 
@@ -19825,7 +19807,7 @@ export namespace DisableTransitGatewayRouteTablePropagationRequest {
   export function isa(
     o: any
   ): o is DisableTransitGatewayRouteTablePropagationRequest {
-    return _smithy.isa(o, "DisableTransitGatewayRouteTablePropagationRequest");
+    return __isa(o, "DisableTransitGatewayRouteTablePropagationRequest");
   }
 }
 
@@ -19842,7 +19824,7 @@ export namespace DisableTransitGatewayRouteTablePropagationResult {
   export function isa(
     o: any
   ): o is DisableTransitGatewayRouteTablePropagationResult {
-    return _smithy.isa(o, "DisableTransitGatewayRouteTablePropagationResult");
+    return __isa(o, "DisableTransitGatewayRouteTablePropagationResult");
   }
 }
 
@@ -19864,7 +19846,7 @@ export interface DisableVgwRoutePropagationRequest {
 
 export namespace DisableVgwRoutePropagationRequest {
   export function isa(o: any): o is DisableVgwRoutePropagationRequest {
-    return _smithy.isa(o, "DisableVgwRoutePropagationRequest");
+    return __isa(o, "DisableVgwRoutePropagationRequest");
   }
 }
 
@@ -19878,7 +19860,7 @@ export interface DisableVpcClassicLinkDnsSupportRequest {
 
 export namespace DisableVpcClassicLinkDnsSupportRequest {
   export function isa(o: any): o is DisableVpcClassicLinkDnsSupportRequest {
-    return _smithy.isa(o, "DisableVpcClassicLinkDnsSupportRequest");
+    return __isa(o, "DisableVpcClassicLinkDnsSupportRequest");
   }
 }
 
@@ -19892,7 +19874,7 @@ export interface DisableVpcClassicLinkDnsSupportResult extends $MetadataBearer {
 
 export namespace DisableVpcClassicLinkDnsSupportResult {
   export function isa(o: any): o is DisableVpcClassicLinkDnsSupportResult {
-    return _smithy.isa(o, "DisableVpcClassicLinkDnsSupportResult");
+    return __isa(o, "DisableVpcClassicLinkDnsSupportResult");
   }
 }
 
@@ -19913,7 +19895,7 @@ export interface DisableVpcClassicLinkRequest {
 
 export namespace DisableVpcClassicLinkRequest {
   export function isa(o: any): o is DisableVpcClassicLinkRequest {
-    return _smithy.isa(o, "DisableVpcClassicLinkRequest");
+    return __isa(o, "DisableVpcClassicLinkRequest");
   }
 }
 
@@ -19927,7 +19909,7 @@ export interface DisableVpcClassicLinkResult extends $MetadataBearer {
 
 export namespace DisableVpcClassicLinkResult {
   export function isa(o: any): o is DisableVpcClassicLinkResult {
-    return _smithy.isa(o, "DisableVpcClassicLinkResult");
+    return __isa(o, "DisableVpcClassicLinkResult");
   }
 }
 
@@ -19953,7 +19935,7 @@ export interface DisassociateAddressRequest {
 
 export namespace DisassociateAddressRequest {
   export function isa(o: any): o is DisassociateAddressRequest {
-    return _smithy.isa(o, "DisassociateAddressRequest");
+    return __isa(o, "DisassociateAddressRequest");
   }
 }
 
@@ -19977,7 +19959,7 @@ export interface DisassociateClientVpnTargetNetworkRequest {
 
 export namespace DisassociateClientVpnTargetNetworkRequest {
   export function isa(o: any): o is DisassociateClientVpnTargetNetworkRequest {
-    return _smithy.isa(o, "DisassociateClientVpnTargetNetworkRequest");
+    return __isa(o, "DisassociateClientVpnTargetNetworkRequest");
   }
 }
 
@@ -19997,7 +19979,7 @@ export interface DisassociateClientVpnTargetNetworkResult
 
 export namespace DisassociateClientVpnTargetNetworkResult {
   export function isa(o: any): o is DisassociateClientVpnTargetNetworkResult {
-    return _smithy.isa(o, "DisassociateClientVpnTargetNetworkResult");
+    return __isa(o, "DisassociateClientVpnTargetNetworkResult");
   }
 }
 
@@ -20011,7 +19993,7 @@ export interface DisassociateIamInstanceProfileRequest {
 
 export namespace DisassociateIamInstanceProfileRequest {
   export function isa(o: any): o is DisassociateIamInstanceProfileRequest {
-    return _smithy.isa(o, "DisassociateIamInstanceProfileRequest");
+    return __isa(o, "DisassociateIamInstanceProfileRequest");
   }
 }
 
@@ -20025,7 +20007,7 @@ export interface DisassociateIamInstanceProfileResult extends $MetadataBearer {
 
 export namespace DisassociateIamInstanceProfileResult {
   export function isa(o: any): o is DisassociateIamInstanceProfileResult {
-    return _smithy.isa(o, "DisassociateIamInstanceProfileResult");
+    return __isa(o, "DisassociateIamInstanceProfileResult");
   }
 }
 
@@ -20046,7 +20028,7 @@ export interface DisassociateRouteTableRequest {
 
 export namespace DisassociateRouteTableRequest {
   export function isa(o: any): o is DisassociateRouteTableRequest {
-    return _smithy.isa(o, "DisassociateRouteTableRequest");
+    return __isa(o, "DisassociateRouteTableRequest");
   }
 }
 
@@ -20060,7 +20042,7 @@ export interface DisassociateSubnetCidrBlockRequest {
 
 export namespace DisassociateSubnetCidrBlockRequest {
   export function isa(o: any): o is DisassociateSubnetCidrBlockRequest {
-    return _smithy.isa(o, "DisassociateSubnetCidrBlockRequest");
+    return __isa(o, "DisassociateSubnetCidrBlockRequest");
   }
 }
 
@@ -20079,7 +20061,7 @@ export interface DisassociateSubnetCidrBlockResult extends $MetadataBearer {
 
 export namespace DisassociateSubnetCidrBlockResult {
   export function isa(o: any): o is DisassociateSubnetCidrBlockResult {
-    return _smithy.isa(o, "DisassociateSubnetCidrBlockResult");
+    return __isa(o, "DisassociateSubnetCidrBlockResult");
   }
 }
 
@@ -20112,7 +20094,7 @@ export namespace DisassociateTransitGatewayMulticastDomainRequest {
   export function isa(
     o: any
   ): o is DisassociateTransitGatewayMulticastDomainRequest {
-    return _smithy.isa(o, "DisassociateTransitGatewayMulticastDomainRequest");
+    return __isa(o, "DisassociateTransitGatewayMulticastDomainRequest");
   }
 }
 
@@ -20129,7 +20111,7 @@ export namespace DisassociateTransitGatewayMulticastDomainResult {
   export function isa(
     o: any
   ): o is DisassociateTransitGatewayMulticastDomainResult {
-    return _smithy.isa(o, "DisassociateTransitGatewayMulticastDomainResult");
+    return __isa(o, "DisassociateTransitGatewayMulticastDomainResult");
   }
 }
 
@@ -20157,7 +20139,7 @@ export namespace DisassociateTransitGatewayRouteTableRequest {
   export function isa(
     o: any
   ): o is DisassociateTransitGatewayRouteTableRequest {
-    return _smithy.isa(o, "DisassociateTransitGatewayRouteTableRequest");
+    return __isa(o, "DisassociateTransitGatewayRouteTableRequest");
   }
 }
 
@@ -20172,7 +20154,7 @@ export interface DisassociateTransitGatewayRouteTableResult
 
 export namespace DisassociateTransitGatewayRouteTableResult {
   export function isa(o: any): o is DisassociateTransitGatewayRouteTableResult {
-    return _smithy.isa(o, "DisassociateTransitGatewayRouteTableResult");
+    return __isa(o, "DisassociateTransitGatewayRouteTableResult");
   }
 }
 
@@ -20186,7 +20168,7 @@ export interface DisassociateVpcCidrBlockRequest {
 
 export namespace DisassociateVpcCidrBlockRequest {
   export function isa(o: any): o is DisassociateVpcCidrBlockRequest {
-    return _smithy.isa(o, "DisassociateVpcCidrBlockRequest");
+    return __isa(o, "DisassociateVpcCidrBlockRequest");
   }
 }
 
@@ -20210,7 +20192,7 @@ export interface DisassociateVpcCidrBlockResult extends $MetadataBearer {
 
 export namespace DisassociateVpcCidrBlockResult {
   export function isa(o: any): o is DisassociateVpcCidrBlockResult {
-    return _smithy.isa(o, "DisassociateVpcCidrBlockResult");
+    return __isa(o, "DisassociateVpcCidrBlockResult");
   }
 }
 
@@ -20237,7 +20219,7 @@ export interface DiskImage {
 
 export namespace DiskImage {
   export function isa(o: any): o is DiskImage {
-    return _smithy.isa(o, "DiskImage");
+    return __isa(o, "DiskImage");
   }
 }
 
@@ -20272,7 +20254,7 @@ export interface DiskImageDescription {
 
 export namespace DiskImageDescription {
   export function isa(o: any): o is DiskImageDescription {
-    return _smithy.isa(o, "DiskImageDescription");
+    return __isa(o, "DiskImageDescription");
   }
 }
 
@@ -20303,7 +20285,7 @@ export interface DiskImageDetail {
 
 export namespace DiskImageDetail {
   export function isa(o: any): o is DiskImageDetail {
-    return _smithy.isa(o, "DiskImageDetail");
+    return __isa(o, "DiskImageDetail");
   }
 }
 
@@ -20327,7 +20309,7 @@ export interface DiskImageVolumeDescription {
 
 export namespace DiskImageVolumeDescription {
   export function isa(o: any): o is DiskImageVolumeDescription {
-    return _smithy.isa(o, "DiskImageVolumeDescription");
+    return __isa(o, "DiskImageVolumeDescription");
   }
 }
 
@@ -20354,7 +20336,7 @@ export interface DiskInfo {
 
 export namespace DiskInfo {
   export function isa(o: any): o is DiskInfo {
-    return _smithy.isa(o, "DiskInfo");
+    return __isa(o, "DiskInfo");
   }
 }
 
@@ -20378,7 +20360,7 @@ export interface DnsEntry {
 
 export namespace DnsEntry {
   export function isa(o: any): o is DnsEntry {
-    return _smithy.isa(o, "DnsEntry");
+    return __isa(o, "DnsEntry");
   }
 }
 
@@ -20409,7 +20391,7 @@ export interface DnsServersOptionsModifyStructure {
 
 export namespace DnsServersOptionsModifyStructure {
   export function isa(o: any): o is DnsServersOptionsModifyStructure {
-    return _smithy.isa(o, "DnsServersOptionsModifyStructure");
+    return __isa(o, "DnsServersOptionsModifyStructure");
   }
 }
 
@@ -20501,7 +20483,7 @@ export interface EbsBlockDevice {
 
 export namespace EbsBlockDevice {
   export function isa(o: any): o is EbsBlockDevice {
-    return _smithy.isa(o, "EbsBlockDevice");
+    return __isa(o, "EbsBlockDevice");
   }
 }
 
@@ -20526,7 +20508,7 @@ export interface EbsInfo {
 
 export namespace EbsInfo {
   export function isa(o: any): o is EbsInfo {
-    return _smithy.isa(o, "EbsInfo");
+    return __isa(o, "EbsInfo");
   }
 }
 
@@ -20558,7 +20540,7 @@ export interface EbsInstanceBlockDevice {
 
 export namespace EbsInstanceBlockDevice {
   export function isa(o: any): o is EbsInstanceBlockDevice {
-    return _smithy.isa(o, "EbsInstanceBlockDevice");
+    return __isa(o, "EbsInstanceBlockDevice");
   }
 }
 
@@ -20581,7 +20563,7 @@ export interface EbsInstanceBlockDeviceSpecification {
 
 export namespace EbsInstanceBlockDeviceSpecification {
   export function isa(o: any): o is EbsInstanceBlockDeviceSpecification {
-    return _smithy.isa(o, "EbsInstanceBlockDeviceSpecification");
+    return __isa(o, "EbsInstanceBlockDeviceSpecification");
   }
 }
 
@@ -20610,7 +20592,7 @@ export interface EgressOnlyInternetGateway {
 
 export namespace EgressOnlyInternetGateway {
   export function isa(o: any): o is EgressOnlyInternetGateway {
-    return _smithy.isa(o, "EgressOnlyInternetGateway");
+    return __isa(o, "EgressOnlyInternetGateway");
   }
 }
 
@@ -20643,7 +20625,7 @@ export interface ElasticGpuAssociation {
 
 export namespace ElasticGpuAssociation {
   export function isa(o: any): o is ElasticGpuAssociation {
-    return _smithy.isa(o, "ElasticGpuAssociation");
+    return __isa(o, "ElasticGpuAssociation");
   }
 }
 
@@ -20660,7 +20642,7 @@ export interface ElasticGpuHealth {
 
 export namespace ElasticGpuHealth {
   export function isa(o: any): o is ElasticGpuHealth {
-    return _smithy.isa(o, "ElasticGpuHealth");
+    return __isa(o, "ElasticGpuHealth");
   }
 }
 
@@ -20679,7 +20661,7 @@ export interface ElasticGpuSpecification {
 
 export namespace ElasticGpuSpecification {
   export function isa(o: any): o is ElasticGpuSpecification {
-    return _smithy.isa(o, "ElasticGpuSpecification");
+    return __isa(o, "ElasticGpuSpecification");
   }
 }
 
@@ -20696,7 +20678,7 @@ export interface ElasticGpuSpecificationResponse {
 
 export namespace ElasticGpuSpecificationResponse {
   export function isa(o: any): o is ElasticGpuSpecificationResponse {
-    return _smithy.isa(o, "ElasticGpuSpecificationResponse");
+    return __isa(o, "ElasticGpuSpecificationResponse");
   }
 }
 
@@ -20752,7 +20734,7 @@ export interface ElasticGpus {
 
 export namespace ElasticGpus {
   export function isa(o: any): o is ElasticGpus {
-    return _smithy.isa(o, "ElasticGpus");
+    return __isa(o, "ElasticGpus");
   }
 }
 
@@ -20781,7 +20763,7 @@ export interface ElasticInferenceAccelerator {
 
 export namespace ElasticInferenceAccelerator {
   export function isa(o: any): o is ElasticInferenceAccelerator {
-    return _smithy.isa(o, "ElasticInferenceAccelerator");
+    return __isa(o, "ElasticInferenceAccelerator");
   }
 }
 
@@ -20823,7 +20805,7 @@ export interface ElasticInferenceAcceleratorAssociation {
 
 export namespace ElasticInferenceAcceleratorAssociation {
   export function isa(o: any): o is ElasticInferenceAcceleratorAssociation {
-    return _smithy.isa(o, "ElasticInferenceAcceleratorAssociation");
+    return __isa(o, "ElasticInferenceAcceleratorAssociation");
   }
 }
 
@@ -20841,7 +20823,7 @@ export interface EnableEbsEncryptionByDefaultRequest {
 
 export namespace EnableEbsEncryptionByDefaultRequest {
   export function isa(o: any): o is EnableEbsEncryptionByDefaultRequest {
-    return _smithy.isa(o, "EnableEbsEncryptionByDefaultRequest");
+    return __isa(o, "EnableEbsEncryptionByDefaultRequest");
   }
 }
 
@@ -20855,7 +20837,7 @@ export interface EnableEbsEncryptionByDefaultResult extends $MetadataBearer {
 
 export namespace EnableEbsEncryptionByDefaultResult {
   export function isa(o: any): o is EnableEbsEncryptionByDefaultResult {
-    return _smithy.isa(o, "EnableEbsEncryptionByDefaultResult");
+    return __isa(o, "EnableEbsEncryptionByDefaultResult");
   }
 }
 
@@ -20879,7 +20861,7 @@ export interface EnableFastSnapshotRestoreErrorItem {
 
 export namespace EnableFastSnapshotRestoreErrorItem {
   export function isa(o: any): o is EnableFastSnapshotRestoreErrorItem {
-    return _smithy.isa(o, "EnableFastSnapshotRestoreErrorItem");
+    return __isa(o, "EnableFastSnapshotRestoreErrorItem");
   }
 }
 
@@ -20901,7 +20883,7 @@ export interface EnableFastSnapshotRestoreStateError {
 
 export namespace EnableFastSnapshotRestoreStateError {
   export function isa(o: any): o is EnableFastSnapshotRestoreStateError {
-    return _smithy.isa(o, "EnableFastSnapshotRestoreStateError");
+    return __isa(o, "EnableFastSnapshotRestoreStateError");
   }
 }
 
@@ -20923,7 +20905,7 @@ export interface EnableFastSnapshotRestoreStateErrorItem {
 
 export namespace EnableFastSnapshotRestoreStateErrorItem {
   export function isa(o: any): o is EnableFastSnapshotRestoreStateErrorItem {
-    return _smithy.isa(o, "EnableFastSnapshotRestoreStateErrorItem");
+    return __isa(o, "EnableFastSnapshotRestoreStateErrorItem");
   }
 }
 
@@ -21002,7 +20984,7 @@ export interface EnableFastSnapshotRestoreSuccessItem {
 
 export namespace EnableFastSnapshotRestoreSuccessItem {
   export function isa(o: any): o is EnableFastSnapshotRestoreSuccessItem {
-    return _smithy.isa(o, "EnableFastSnapshotRestoreSuccessItem");
+    return __isa(o, "EnableFastSnapshotRestoreSuccessItem");
   }
 }
 
@@ -21029,7 +21011,7 @@ export interface EnableFastSnapshotRestoresRequest {
 
 export namespace EnableFastSnapshotRestoresRequest {
   export function isa(o: any): o is EnableFastSnapshotRestoresRequest {
-    return _smithy.isa(o, "EnableFastSnapshotRestoresRequest");
+    return __isa(o, "EnableFastSnapshotRestoresRequest");
   }
 }
 
@@ -21048,7 +21030,7 @@ export interface EnableFastSnapshotRestoresResult extends $MetadataBearer {
 
 export namespace EnableFastSnapshotRestoresResult {
   export function isa(o: any): o is EnableFastSnapshotRestoresResult {
-    return _smithy.isa(o, "EnableFastSnapshotRestoresResult");
+    return __isa(o, "EnableFastSnapshotRestoresResult");
   }
 }
 
@@ -21076,7 +21058,7 @@ export namespace EnableTransitGatewayRouteTablePropagationRequest {
   export function isa(
     o: any
   ): o is EnableTransitGatewayRouteTablePropagationRequest {
-    return _smithy.isa(o, "EnableTransitGatewayRouteTablePropagationRequest");
+    return __isa(o, "EnableTransitGatewayRouteTablePropagationRequest");
   }
 }
 
@@ -21093,7 +21075,7 @@ export namespace EnableTransitGatewayRouteTablePropagationResult {
   export function isa(
     o: any
   ): o is EnableTransitGatewayRouteTablePropagationResult {
-    return _smithy.isa(o, "EnableTransitGatewayRouteTablePropagationResult");
+    return __isa(o, "EnableTransitGatewayRouteTablePropagationResult");
   }
 }
 
@@ -21115,7 +21097,7 @@ export interface EnableVgwRoutePropagationRequest {
 
 export namespace EnableVgwRoutePropagationRequest {
   export function isa(o: any): o is EnableVgwRoutePropagationRequest {
-    return _smithy.isa(o, "EnableVgwRoutePropagationRequest");
+    return __isa(o, "EnableVgwRoutePropagationRequest");
   }
 }
 
@@ -21136,7 +21118,7 @@ export interface EnableVolumeIORequest {
 
 export namespace EnableVolumeIORequest {
   export function isa(o: any): o is EnableVolumeIORequest {
-    return _smithy.isa(o, "EnableVolumeIORequest");
+    return __isa(o, "EnableVolumeIORequest");
   }
 }
 
@@ -21150,7 +21132,7 @@ export interface EnableVpcClassicLinkDnsSupportRequest {
 
 export namespace EnableVpcClassicLinkDnsSupportRequest {
   export function isa(o: any): o is EnableVpcClassicLinkDnsSupportRequest {
-    return _smithy.isa(o, "EnableVpcClassicLinkDnsSupportRequest");
+    return __isa(o, "EnableVpcClassicLinkDnsSupportRequest");
   }
 }
 
@@ -21164,7 +21146,7 @@ export interface EnableVpcClassicLinkDnsSupportResult extends $MetadataBearer {
 
 export namespace EnableVpcClassicLinkDnsSupportResult {
   export function isa(o: any): o is EnableVpcClassicLinkDnsSupportResult {
-    return _smithy.isa(o, "EnableVpcClassicLinkDnsSupportResult");
+    return __isa(o, "EnableVpcClassicLinkDnsSupportResult");
   }
 }
 
@@ -21185,7 +21167,7 @@ export interface EnableVpcClassicLinkRequest {
 
 export namespace EnableVpcClassicLinkRequest {
   export function isa(o: any): o is EnableVpcClassicLinkRequest {
-    return _smithy.isa(o, "EnableVpcClassicLinkRequest");
+    return __isa(o, "EnableVpcClassicLinkRequest");
   }
 }
 
@@ -21199,7 +21181,7 @@ export interface EnableVpcClassicLinkResult extends $MetadataBearer {
 
 export namespace EnableVpcClassicLinkResult {
   export function isa(o: any): o is EnableVpcClassicLinkResult {
-    return _smithy.isa(o, "EnableVpcClassicLinkResult");
+    return __isa(o, "EnableVpcClassicLinkResult");
   }
 }
 
@@ -21337,7 +21319,7 @@ export interface EventInformation {
 
 export namespace EventInformation {
   export function isa(o: any): o is EventInformation {
-    return _smithy.isa(o, "EventInformation");
+    return __isa(o, "EventInformation");
   }
 }
 
@@ -21370,10 +21352,7 @@ export namespace ExportClientVpnClientCertificateRevocationListRequest {
   export function isa(
     o: any
   ): o is ExportClientVpnClientCertificateRevocationListRequest {
-    return _smithy.isa(
-      o,
-      "ExportClientVpnClientCertificateRevocationListRequest"
-    );
+    return __isa(o, "ExportClientVpnClientCertificateRevocationListRequest");
   }
 }
 
@@ -21395,10 +21374,7 @@ export namespace ExportClientVpnClientCertificateRevocationListResult {
   export function isa(
     o: any
   ): o is ExportClientVpnClientCertificateRevocationListResult {
-    return _smithy.isa(
-      o,
-      "ExportClientVpnClientCertificateRevocationListResult"
-    );
+    return __isa(o, "ExportClientVpnClientCertificateRevocationListResult");
   }
 }
 
@@ -21417,7 +21393,7 @@ export interface ExportClientVpnClientConfigurationRequest {
 
 export namespace ExportClientVpnClientConfigurationRequest {
   export function isa(o: any): o is ExportClientVpnClientConfigurationRequest {
-    return _smithy.isa(o, "ExportClientVpnClientConfigurationRequest");
+    return __isa(o, "ExportClientVpnClientConfigurationRequest");
   }
 }
 
@@ -21432,7 +21408,7 @@ export interface ExportClientVpnClientConfigurationResult
 
 export namespace ExportClientVpnClientConfigurationResult {
   export function isa(o: any): o is ExportClientVpnClientConfigurationResult {
-    return _smithy.isa(o, "ExportClientVpnClientConfigurationResult");
+    return __isa(o, "ExportClientVpnClientConfigurationResult");
   }
 }
 
@@ -21482,7 +21458,7 @@ export interface ExportImageRequest {
 
 export namespace ExportImageRequest {
   export function isa(o: any): o is ExportImageRequest {
-    return _smithy.isa(o, "ExportImageRequest");
+    return __isa(o, "ExportImageRequest");
   }
 }
 
@@ -21537,7 +21513,7 @@ export interface ExportImageResult extends $MetadataBearer {
 
 export namespace ExportImageResult {
   export function isa(o: any): o is ExportImageResult {
-    return _smithy.isa(o, "ExportImageResult");
+    return __isa(o, "ExportImageResult");
   }
 }
 
@@ -21585,7 +21561,7 @@ export interface ExportImageTask {
 
 export namespace ExportImageTask {
   export function isa(o: any): o is ExportImageTask {
-    return _smithy.isa(o, "ExportImageTask");
+    return __isa(o, "ExportImageTask");
   }
 }
 
@@ -21632,7 +21608,7 @@ export interface ExportTask {
 
 export namespace ExportTask {
   export function isa(o: any): o is ExportTask {
-    return _smithy.isa(o, "ExportTask");
+    return __isa(o, "ExportTask");
   }
 }
 
@@ -21654,7 +21630,7 @@ export interface ExportTaskS3Location {
 
 export namespace ExportTaskS3Location {
   export function isa(o: any): o is ExportTaskS3Location {
-    return _smithy.isa(o, "ExportTaskS3Location");
+    return __isa(o, "ExportTaskS3Location");
   }
 }
 
@@ -21676,7 +21652,7 @@ export interface ExportTaskS3LocationRequest {
 
 export namespace ExportTaskS3LocationRequest {
   export function isa(o: any): o is ExportTaskS3LocationRequest {
-    return _smithy.isa(o, "ExportTaskS3LocationRequest");
+    return __isa(o, "ExportTaskS3LocationRequest");
   }
 }
 
@@ -21716,7 +21692,7 @@ export interface ExportToS3Task {
 
 export namespace ExportToS3Task {
   export function isa(o: any): o is ExportToS3Task {
-    return _smithy.isa(o, "ExportToS3Task");
+    return __isa(o, "ExportToS3Task");
   }
 }
 
@@ -21751,7 +21727,7 @@ export interface ExportToS3TaskSpecification {
 
 export namespace ExportToS3TaskSpecification {
   export function isa(o: any): o is ExportToS3TaskSpecification {
-    return _smithy.isa(o, "ExportToS3TaskSpecification");
+    return __isa(o, "ExportToS3TaskSpecification");
   }
 }
 
@@ -21821,7 +21797,7 @@ export interface ExportTransitGatewayRoutesRequest {
 
 export namespace ExportTransitGatewayRoutesRequest {
   export function isa(o: any): o is ExportTransitGatewayRoutesRequest {
-    return _smithy.isa(o, "ExportTransitGatewayRoutesRequest");
+    return __isa(o, "ExportTransitGatewayRoutesRequest");
   }
 }
 
@@ -21836,7 +21812,7 @@ export interface ExportTransitGatewayRoutesResult extends $MetadataBearer {
 
 export namespace ExportTransitGatewayRoutesResult {
   export function isa(o: any): o is ExportTransitGatewayRoutesResult {
-    return _smithy.isa(o, "ExportTransitGatewayRoutesResult");
+    return __isa(o, "ExportTransitGatewayRoutesResult");
   }
 }
 
@@ -21858,7 +21834,7 @@ export interface FailedQueuedPurchaseDeletion {
 
 export namespace FailedQueuedPurchaseDeletion {
   export function isa(o: any): o is FailedQueuedPurchaseDeletion {
-    return _smithy.isa(o, "FailedQueuedPurchaseDeletion");
+    return __isa(o, "FailedQueuedPurchaseDeletion");
   }
 }
 
@@ -21941,7 +21917,7 @@ export interface Filter {
 
 export namespace Filter {
   export function isa(o: any): o is Filter {
-    return _smithy.isa(o, "Filter");
+    return __isa(o, "Filter");
   }
 }
 
@@ -22092,7 +22068,7 @@ export interface FleetData {
 
 export namespace FleetData {
   export function isa(o: any): o is FleetData {
-    return _smithy.isa(o, "FleetData");
+    return __isa(o, "FleetData");
   }
 }
 
@@ -22126,7 +22102,7 @@ export interface FleetLaunchTemplateConfig {
 
 export namespace FleetLaunchTemplateConfig {
   export function isa(o: any): o is FleetLaunchTemplateConfig {
-    return _smithy.isa(o, "FleetLaunchTemplateConfig");
+    return __isa(o, "FleetLaunchTemplateConfig");
   }
 }
 
@@ -22150,7 +22126,7 @@ export interface FleetLaunchTemplateConfigRequest {
 
 export namespace FleetLaunchTemplateConfigRequest {
   export function isa(o: any): o is FleetLaunchTemplateConfigRequest {
-    return _smithy.isa(o, "FleetLaunchTemplateConfigRequest");
+    return __isa(o, "FleetLaunchTemplateConfigRequest");
   }
 }
 
@@ -22201,7 +22177,7 @@ export interface FleetLaunchTemplateOverrides {
 
 export namespace FleetLaunchTemplateOverrides {
   export function isa(o: any): o is FleetLaunchTemplateOverrides {
-    return _smithy.isa(o, "FleetLaunchTemplateOverrides");
+    return __isa(o, "FleetLaunchTemplateOverrides");
   }
 }
 
@@ -22252,7 +22228,7 @@ export interface FleetLaunchTemplateOverridesRequest {
 
 export namespace FleetLaunchTemplateOverridesRequest {
   export function isa(o: any): o is FleetLaunchTemplateOverridesRequest {
-    return _smithy.isa(o, "FleetLaunchTemplateOverridesRequest");
+    return __isa(o, "FleetLaunchTemplateOverridesRequest");
   }
 }
 
@@ -22279,7 +22255,7 @@ export interface FleetLaunchTemplateSpecification {
 
 export namespace FleetLaunchTemplateSpecification {
   export function isa(o: any): o is FleetLaunchTemplateSpecification {
-    return _smithy.isa(o, "FleetLaunchTemplateSpecification");
+    return __isa(o, "FleetLaunchTemplateSpecification");
   }
 }
 
@@ -22307,7 +22283,7 @@ export interface FleetLaunchTemplateSpecificationRequest {
 
 export namespace FleetLaunchTemplateSpecificationRequest {
   export function isa(o: any): o is FleetLaunchTemplateSpecificationRequest {
-    return _smithy.isa(o, "FleetLaunchTemplateSpecificationRequest");
+    return __isa(o, "FleetLaunchTemplateSpecificationRequest");
   }
 }
 
@@ -22410,7 +22386,7 @@ export interface FlowLog {
 
 export namespace FlowLog {
   export function isa(o: any): o is FlowLog {
-    return _smithy.isa(o, "FlowLog");
+    return __isa(o, "FlowLog");
   }
 }
 
@@ -22444,7 +22420,7 @@ export interface FpgaDeviceInfo {
 
 export namespace FpgaDeviceInfo {
   export function isa(o: any): o is FpgaDeviceInfo {
-    return _smithy.isa(o, "FpgaDeviceInfo");
+    return __isa(o, "FpgaDeviceInfo");
   }
 }
 
@@ -22461,7 +22437,7 @@ export interface FpgaDeviceMemoryInfo {
 
 export namespace FpgaDeviceMemoryInfo {
   export function isa(o: any): o is FpgaDeviceMemoryInfo {
-    return _smithy.isa(o, "FpgaDeviceMemoryInfo");
+    return __isa(o, "FpgaDeviceMemoryInfo");
   }
 }
 
@@ -22548,7 +22524,7 @@ export interface FpgaImage {
 
 export namespace FpgaImage {
   export function isa(o: any): o is FpgaImage {
-    return _smithy.isa(o, "FpgaImage");
+    return __isa(o, "FpgaImage");
   }
 }
 
@@ -22585,7 +22561,7 @@ export interface FpgaImageAttribute {
 
 export namespace FpgaImageAttribute {
   export function isa(o: any): o is FpgaImageAttribute {
-    return _smithy.isa(o, "FpgaImageAttribute");
+    return __isa(o, "FpgaImageAttribute");
   }
 }
 
@@ -22631,7 +22607,7 @@ export interface FpgaImageState {
 
 export namespace FpgaImageState {
   export function isa(o: any): o is FpgaImageState {
-    return _smithy.isa(o, "FpgaImageState");
+    return __isa(o, "FpgaImageState");
   }
 }
 
@@ -22659,7 +22635,7 @@ export interface FpgaInfo {
 
 export namespace FpgaInfo {
   export function isa(o: any): o is FpgaInfo {
-    return _smithy.isa(o, "FpgaInfo");
+    return __isa(o, "FpgaInfo");
   }
 }
 
@@ -22693,7 +22669,7 @@ export interface GetAssociatedIpv6PoolCidrsRequest {
 
 export namespace GetAssociatedIpv6PoolCidrsRequest {
   export function isa(o: any): o is GetAssociatedIpv6PoolCidrsRequest {
-    return _smithy.isa(o, "GetAssociatedIpv6PoolCidrsRequest");
+    return __isa(o, "GetAssociatedIpv6PoolCidrsRequest");
   }
 }
 
@@ -22712,7 +22688,7 @@ export interface GetAssociatedIpv6PoolCidrsResult extends $MetadataBearer {
 
 export namespace GetAssociatedIpv6PoolCidrsResult {
   export function isa(o: any): o is GetAssociatedIpv6PoolCidrsResult {
-    return _smithy.isa(o, "GetAssociatedIpv6PoolCidrsResult");
+    return __isa(o, "GetAssociatedIpv6PoolCidrsResult");
   }
 }
 
@@ -22742,7 +22718,7 @@ export interface GetCapacityReservationUsageRequest {
 
 export namespace GetCapacityReservationUsageRequest {
   export function isa(o: any): o is GetCapacityReservationUsageRequest {
-    return _smithy.isa(o, "GetCapacityReservationUsageRequest");
+    return __isa(o, "GetCapacityReservationUsageRequest");
   }
 }
 
@@ -22813,7 +22789,7 @@ export interface GetCapacityReservationUsageResult extends $MetadataBearer {
 
 export namespace GetCapacityReservationUsageResult {
   export function isa(o: any): o is GetCapacityReservationUsageResult {
-    return _smithy.isa(o, "GetCapacityReservationUsageResult");
+    return __isa(o, "GetCapacityReservationUsageResult");
   }
 }
 
@@ -22878,7 +22854,7 @@ export interface GetCoipPoolUsageRequest {
 
 export namespace GetCoipPoolUsageRequest {
   export function isa(o: any): o is GetCoipPoolUsageRequest {
-    return _smithy.isa(o, "GetCoipPoolUsageRequest");
+    return __isa(o, "GetCoipPoolUsageRequest");
   }
 }
 
@@ -22902,7 +22878,7 @@ export interface GetCoipPoolUsageResult extends $MetadataBearer {
 
 export namespace GetCoipPoolUsageResult {
   export function isa(o: any): o is GetCoipPoolUsageResult {
-    return _smithy.isa(o, "GetCoipPoolUsageResult");
+    return __isa(o, "GetCoipPoolUsageResult");
   }
 }
 
@@ -22929,7 +22905,7 @@ export interface GetConsoleOutputRequest {
 
 export namespace GetConsoleOutputRequest {
   export function isa(o: any): o is GetConsoleOutputRequest {
-    return _smithy.isa(o, "GetConsoleOutputRequest");
+    return __isa(o, "GetConsoleOutputRequest");
   }
 }
 
@@ -22954,7 +22930,7 @@ export interface GetConsoleOutputResult extends $MetadataBearer {
 
 export namespace GetConsoleOutputResult {
   export function isa(o: any): o is GetConsoleOutputResult {
-    return _smithy.isa(o, "GetConsoleOutputResult");
+    return __isa(o, "GetConsoleOutputResult");
   }
 }
 
@@ -22981,7 +22957,7 @@ export interface GetConsoleScreenshotRequest {
 
 export namespace GetConsoleScreenshotRequest {
   export function isa(o: any): o is GetConsoleScreenshotRequest {
-    return _smithy.isa(o, "GetConsoleScreenshotRequest");
+    return __isa(o, "GetConsoleScreenshotRequest");
   }
 }
 
@@ -23000,7 +22976,7 @@ export interface GetConsoleScreenshotResult extends $MetadataBearer {
 
 export namespace GetConsoleScreenshotResult {
   export function isa(o: any): o is GetConsoleScreenshotResult {
-    return _smithy.isa(o, "GetConsoleScreenshotResult");
+    return __isa(o, "GetConsoleScreenshotResult");
   }
 }
 
@@ -23021,7 +22997,7 @@ export interface GetDefaultCreditSpecificationRequest {
 
 export namespace GetDefaultCreditSpecificationRequest {
   export function isa(o: any): o is GetDefaultCreditSpecificationRequest {
-    return _smithy.isa(o, "GetDefaultCreditSpecificationRequest");
+    return __isa(o, "GetDefaultCreditSpecificationRequest");
   }
 }
 
@@ -23035,7 +23011,7 @@ export interface GetDefaultCreditSpecificationResult extends $MetadataBearer {
 
 export namespace GetDefaultCreditSpecificationResult {
   export function isa(o: any): o is GetDefaultCreditSpecificationResult {
-    return _smithy.isa(o, "GetDefaultCreditSpecificationResult");
+    return __isa(o, "GetDefaultCreditSpecificationResult");
   }
 }
 
@@ -23051,7 +23027,7 @@ export interface GetEbsDefaultKmsKeyIdRequest {
 
 export namespace GetEbsDefaultKmsKeyIdRequest {
   export function isa(o: any): o is GetEbsDefaultKmsKeyIdRequest {
-    return _smithy.isa(o, "GetEbsDefaultKmsKeyIdRequest");
+    return __isa(o, "GetEbsDefaultKmsKeyIdRequest");
   }
 }
 
@@ -23065,7 +23041,7 @@ export interface GetEbsDefaultKmsKeyIdResult extends $MetadataBearer {
 
 export namespace GetEbsDefaultKmsKeyIdResult {
   export function isa(o: any): o is GetEbsDefaultKmsKeyIdResult {
-    return _smithy.isa(o, "GetEbsDefaultKmsKeyIdResult");
+    return __isa(o, "GetEbsDefaultKmsKeyIdResult");
   }
 }
 
@@ -23081,7 +23057,7 @@ export interface GetEbsEncryptionByDefaultRequest {
 
 export namespace GetEbsEncryptionByDefaultRequest {
   export function isa(o: any): o is GetEbsEncryptionByDefaultRequest {
-    return _smithy.isa(o, "GetEbsEncryptionByDefaultRequest");
+    return __isa(o, "GetEbsEncryptionByDefaultRequest");
   }
 }
 
@@ -23095,7 +23071,7 @@ export interface GetEbsEncryptionByDefaultResult extends $MetadataBearer {
 
 export namespace GetEbsEncryptionByDefaultResult {
   export function isa(o: any): o is GetEbsEncryptionByDefaultResult {
-    return _smithy.isa(o, "GetEbsEncryptionByDefaultResult");
+    return __isa(o, "GetEbsEncryptionByDefaultResult");
   }
 }
 
@@ -23114,7 +23090,7 @@ export interface GetHostReservationPurchasePreviewRequest {
 
 export namespace GetHostReservationPurchasePreviewRequest {
   export function isa(o: any): o is GetHostReservationPurchasePreviewRequest {
-    return _smithy.isa(o, "GetHostReservationPurchasePreviewRequest");
+    return __isa(o, "GetHostReservationPurchasePreviewRequest");
   }
 }
 
@@ -23147,7 +23123,7 @@ export interface GetHostReservationPurchasePreviewResult
 
 export namespace GetHostReservationPurchasePreviewResult {
   export function isa(o: any): o is GetHostReservationPurchasePreviewResult {
-    return _smithy.isa(o, "GetHostReservationPurchasePreviewResult");
+    return __isa(o, "GetHostReservationPurchasePreviewResult");
   }
 }
 
@@ -23169,7 +23145,7 @@ export interface GetLaunchTemplateDataRequest {
 
 export namespace GetLaunchTemplateDataRequest {
   export function isa(o: any): o is GetLaunchTemplateDataRequest {
-    return _smithy.isa(o, "GetLaunchTemplateDataRequest");
+    return __isa(o, "GetLaunchTemplateDataRequest");
   }
 }
 
@@ -23183,7 +23159,7 @@ export interface GetLaunchTemplateDataResult extends $MetadataBearer {
 
 export namespace GetLaunchTemplateDataResult {
   export function isa(o: any): o is GetLaunchTemplateDataResult {
-    return _smithy.isa(o, "GetLaunchTemplateDataResult");
+    return __isa(o, "GetLaunchTemplateDataResult");
   }
 }
 
@@ -23204,7 +23180,7 @@ export interface GetPasswordDataRequest {
 
 export namespace GetPasswordDataRequest {
   export function isa(o: any): o is GetPasswordDataRequest {
-    return _smithy.isa(o, "GetPasswordDataRequest");
+    return __isa(o, "GetPasswordDataRequest");
   }
 }
 
@@ -23229,7 +23205,7 @@ export interface GetPasswordDataResult extends $MetadataBearer {
 
 export namespace GetPasswordDataResult {
   export function isa(o: any): o is GetPasswordDataResult {
-    return _smithy.isa(o, "GetPasswordDataResult");
+    return __isa(o, "GetPasswordDataResult");
   }
 }
 
@@ -23259,7 +23235,7 @@ export interface GetReservedInstancesExchangeQuoteRequest {
 
 export namespace GetReservedInstancesExchangeQuoteRequest {
   export function isa(o: any): o is GetReservedInstancesExchangeQuoteRequest {
-    return _smithy.isa(o, "GetReservedInstancesExchangeQuoteRequest");
+    return __isa(o, "GetReservedInstancesExchangeQuoteRequest");
   }
 }
 
@@ -23317,7 +23293,7 @@ export interface GetReservedInstancesExchangeQuoteResult
 
 export namespace GetReservedInstancesExchangeQuoteResult {
   export function isa(o: any): o is GetReservedInstancesExchangeQuoteResult {
-    return _smithy.isa(o, "GetReservedInstancesExchangeQuoteResult");
+    return __isa(o, "GetReservedInstancesExchangeQuoteResult");
   }
 }
 
@@ -23362,7 +23338,7 @@ export namespace GetTransitGatewayAttachmentPropagationsRequest {
   export function isa(
     o: any
   ): o is GetTransitGatewayAttachmentPropagationsRequest {
-    return _smithy.isa(o, "GetTransitGatewayAttachmentPropagationsRequest");
+    return __isa(o, "GetTransitGatewayAttachmentPropagationsRequest");
   }
 }
 
@@ -23386,7 +23362,7 @@ export namespace GetTransitGatewayAttachmentPropagationsResult {
   export function isa(
     o: any
   ): o is GetTransitGatewayAttachmentPropagationsResult {
-    return _smithy.isa(o, "GetTransitGatewayAttachmentPropagationsResult");
+    return __isa(o, "GetTransitGatewayAttachmentPropagationsResult");
   }
 }
 
@@ -23451,10 +23427,7 @@ export namespace GetTransitGatewayMulticastDomainAssociationsRequest {
   export function isa(
     o: any
   ): o is GetTransitGatewayMulticastDomainAssociationsRequest {
-    return _smithy.isa(
-      o,
-      "GetTransitGatewayMulticastDomainAssociationsRequest"
-    );
+    return __isa(o, "GetTransitGatewayMulticastDomainAssociationsRequest");
   }
 }
 
@@ -23476,7 +23449,7 @@ export namespace GetTransitGatewayMulticastDomainAssociationsResult {
   export function isa(
     o: any
   ): o is GetTransitGatewayMulticastDomainAssociationsResult {
-    return _smithy.isa(o, "GetTransitGatewayMulticastDomainAssociationsResult");
+    return __isa(o, "GetTransitGatewayMulticastDomainAssociationsResult");
   }
 }
 
@@ -23529,7 +23502,7 @@ export namespace GetTransitGatewayRouteTableAssociationsRequest {
   export function isa(
     o: any
   ): o is GetTransitGatewayRouteTableAssociationsRequest {
-    return _smithy.isa(o, "GetTransitGatewayRouteTableAssociationsRequest");
+    return __isa(o, "GetTransitGatewayRouteTableAssociationsRequest");
   }
 }
 
@@ -23551,7 +23524,7 @@ export namespace GetTransitGatewayRouteTableAssociationsResult {
   export function isa(
     o: any
   ): o is GetTransitGatewayRouteTableAssociationsResult {
-    return _smithy.isa(o, "GetTransitGatewayRouteTableAssociationsResult");
+    return __isa(o, "GetTransitGatewayRouteTableAssociationsResult");
   }
 }
 
@@ -23604,7 +23577,7 @@ export namespace GetTransitGatewayRouteTablePropagationsRequest {
   export function isa(
     o: any
   ): o is GetTransitGatewayRouteTablePropagationsRequest {
-    return _smithy.isa(o, "GetTransitGatewayRouteTablePropagationsRequest");
+    return __isa(o, "GetTransitGatewayRouteTablePropagationsRequest");
   }
 }
 
@@ -23628,7 +23601,7 @@ export namespace GetTransitGatewayRouteTablePropagationsResult {
   export function isa(
     o: any
   ): o is GetTransitGatewayRouteTablePropagationsResult {
-    return _smithy.isa(o, "GetTransitGatewayRouteTablePropagationsResult");
+    return __isa(o, "GetTransitGatewayRouteTablePropagationsResult");
   }
 }
 
@@ -23660,7 +23633,7 @@ export interface GpuDeviceInfo {
 
 export namespace GpuDeviceInfo {
   export function isa(o: any): o is GpuDeviceInfo {
-    return _smithy.isa(o, "GpuDeviceInfo");
+    return __isa(o, "GpuDeviceInfo");
   }
 }
 
@@ -23677,7 +23650,7 @@ export interface GpuDeviceMemoryInfo {
 
 export namespace GpuDeviceMemoryInfo {
   export function isa(o: any): o is GpuDeviceMemoryInfo {
-    return _smithy.isa(o, "GpuDeviceMemoryInfo");
+    return __isa(o, "GpuDeviceMemoryInfo");
   }
 }
 
@@ -23699,7 +23672,7 @@ export interface GpuInfo {
 
 export namespace GpuInfo {
   export function isa(o: any): o is GpuInfo {
-    return _smithy.isa(o, "GpuInfo");
+    return __isa(o, "GpuInfo");
   }
 }
 
@@ -23721,7 +23694,7 @@ export interface GroupIdentifier {
 
 export namespace GroupIdentifier {
   export function isa(o: any): o is GroupIdentifier {
-    return _smithy.isa(o, "GroupIdentifier");
+    return __isa(o, "GroupIdentifier");
   }
 }
 
@@ -23743,7 +23716,7 @@ export interface HibernationOptions {
 
 export namespace HibernationOptions {
   export function isa(o: any): o is HibernationOptions {
-    return _smithy.isa(o, "HibernationOptions");
+    return __isa(o, "HibernationOptions");
   }
 }
 
@@ -23767,7 +23740,7 @@ export interface HibernationOptionsRequest {
 
 export namespace HibernationOptionsRequest {
   export function isa(o: any): o is HibernationOptionsRequest {
-    return _smithy.isa(o, "HibernationOptionsRequest");
+    return __isa(o, "HibernationOptionsRequest");
   }
 }
 
@@ -23812,7 +23785,7 @@ export interface HistoryRecord {
 
 export namespace HistoryRecord {
   export function isa(o: any): o is HistoryRecord {
-    return _smithy.isa(o, "HistoryRecord");
+    return __isa(o, "HistoryRecord");
   }
 }
 
@@ -23840,7 +23813,7 @@ export interface HistoryRecordEntry {
 
 export namespace HistoryRecordEntry {
   export function isa(o: any): o is HistoryRecordEntry {
-    return _smithy.isa(o, "HistoryRecordEntry");
+    return __isa(o, "HistoryRecordEntry");
   }
 }
 
@@ -23944,7 +23917,7 @@ export interface Host {
 
 export namespace Host {
   export function isa(o: any): o is Host {
-    return _smithy.isa(o, "Host");
+    return __isa(o, "Host");
   }
 }
 
@@ -23971,7 +23944,7 @@ export interface HostInstance {
 
 export namespace HostInstance {
   export function isa(o: any): o is HostInstance {
-    return _smithy.isa(o, "HostInstance");
+    return __isa(o, "HostInstance");
   }
 }
 
@@ -24019,7 +23992,7 @@ export interface HostOffering {
 
 export namespace HostOffering {
   export function isa(o: any): o is HostOffering {
-    return _smithy.isa(o, "HostOffering");
+    return __isa(o, "HostOffering");
   }
 }
 
@@ -24058,7 +24031,7 @@ export interface HostProperties {
 
 export namespace HostProperties {
   export function isa(o: any): o is HostProperties {
-    return _smithy.isa(o, "HostProperties");
+    return __isa(o, "HostProperties");
   }
 }
 
@@ -24149,7 +24122,7 @@ export interface HostReservation {
 
 export namespace HostReservation {
   export function isa(o: any): o is HostReservation {
-    return _smithy.isa(o, "HostReservation");
+    return __isa(o, "HostReservation");
   }
 }
 
@@ -24175,7 +24148,7 @@ export interface IKEVersionsListValue {
 
 export namespace IKEVersionsListValue {
   export function isa(o: any): o is IKEVersionsListValue {
-    return _smithy.isa(o, "IKEVersionsListValue");
+    return __isa(o, "IKEVersionsListValue");
   }
 }
 
@@ -24192,7 +24165,7 @@ export interface IKEVersionsRequestListValue {
 
 export namespace IKEVersionsRequestListValue {
   export function isa(o: any): o is IKEVersionsRequestListValue {
-    return _smithy.isa(o, "IKEVersionsRequestListValue");
+    return __isa(o, "IKEVersionsRequestListValue");
   }
 }
 
@@ -24214,7 +24187,7 @@ export interface IamInstanceProfile {
 
 export namespace IamInstanceProfile {
   export function isa(o: any): o is IamInstanceProfile {
-    return _smithy.isa(o, "IamInstanceProfile");
+    return __isa(o, "IamInstanceProfile");
   }
 }
 
@@ -24251,7 +24224,7 @@ export interface IamInstanceProfileAssociation {
 
 export namespace IamInstanceProfileAssociation {
   export function isa(o: any): o is IamInstanceProfileAssociation {
-    return _smithy.isa(o, "IamInstanceProfileAssociation");
+    return __isa(o, "IamInstanceProfileAssociation");
   }
 }
 
@@ -24280,7 +24253,7 @@ export interface IamInstanceProfileSpecification {
 
 export namespace IamInstanceProfileSpecification {
   export function isa(o: any): o is IamInstanceProfileSpecification {
-    return _smithy.isa(o, "IamInstanceProfileSpecification");
+    return __isa(o, "IamInstanceProfileSpecification");
   }
 }
 
@@ -24302,7 +24275,7 @@ export interface IcmpTypeCode {
 
 export namespace IcmpTypeCode {
   export function isa(o: any): o is IcmpTypeCode {
-    return _smithy.isa(o, "IcmpTypeCode");
+    return __isa(o, "IcmpTypeCode");
   }
 }
 
@@ -24329,7 +24302,7 @@ export interface IdFormat {
 
 export namespace IdFormat {
   export function isa(o: any): o is IdFormat {
-    return _smithy.isa(o, "IdFormat");
+    return __isa(o, "IdFormat");
   }
 }
 
@@ -24464,7 +24437,7 @@ export interface Image {
 
 export namespace Image {
   export function isa(o: any): o is Image {
-    return _smithy.isa(o, "Image");
+    return __isa(o, "Image");
   }
 }
 
@@ -24516,7 +24489,7 @@ export interface ImageAttribute extends $MetadataBearer {
 
 export namespace ImageAttribute {
   export function isa(o: any): o is ImageAttribute {
-    return _smithy.isa(o, "ImageAttribute");
+    return __isa(o, "ImageAttribute");
   }
 }
 
@@ -24570,7 +24543,7 @@ export interface ImageDiskContainer {
 
 export namespace ImageDiskContainer {
   export function isa(o: any): o is ImageDiskContainer {
-    return _smithy.isa(o, "ImageDiskContainer");
+    return __isa(o, "ImageDiskContainer");
   }
 }
 
@@ -24608,10 +24581,7 @@ export namespace ImportClientVpnClientCertificateRevocationListRequest {
   export function isa(
     o: any
   ): o is ImportClientVpnClientCertificateRevocationListRequest {
-    return _smithy.isa(
-      o,
-      "ImportClientVpnClientCertificateRevocationListRequest"
-    );
+    return __isa(o, "ImportClientVpnClientCertificateRevocationListRequest");
   }
 }
 
@@ -24628,10 +24598,7 @@ export namespace ImportClientVpnClientCertificateRevocationListResult {
   export function isa(
     o: any
   ): o is ImportClientVpnClientCertificateRevocationListResult {
-    return _smithy.isa(
-      o,
-      "ImportClientVpnClientCertificateRevocationListResult"
-    );
+    return __isa(o, "ImportClientVpnClientCertificateRevocationListResult");
   }
 }
 
@@ -24648,7 +24615,7 @@ export interface ImportImageLicenseConfigurationRequest {
 
 export namespace ImportImageLicenseConfigurationRequest {
   export function isa(o: any): o is ImportImageLicenseConfigurationRequest {
-    return _smithy.isa(o, "ImportImageLicenseConfigurationRequest");
+    return __isa(o, "ImportImageLicenseConfigurationRequest");
   }
 }
 
@@ -24665,7 +24632,7 @@ export interface ImportImageLicenseConfigurationResponse {
 
 export namespace ImportImageLicenseConfigurationResponse {
   export function isa(o: any): o is ImportImageLicenseConfigurationResponse {
-    return _smithy.isa(o, "ImportImageLicenseConfigurationResponse");
+    return __isa(o, "ImportImageLicenseConfigurationResponse");
   }
 }
 
@@ -24777,7 +24744,7 @@ export interface ImportImageRequest {
 
 export namespace ImportImageRequest {
   export function isa(o: any): o is ImportImageRequest {
-    return _smithy.isa(o, "ImportImageRequest");
+    return __isa(o, "ImportImageRequest");
   }
 }
 
@@ -24857,7 +24824,7 @@ export interface ImportImageResult extends $MetadataBearer {
 
 export namespace ImportImageResult {
   export function isa(o: any): o is ImportImageResult {
-    return _smithy.isa(o, "ImportImageResult");
+    return __isa(o, "ImportImageResult");
   }
 }
 
@@ -24949,7 +24916,7 @@ export interface ImportImageTask {
 
 export namespace ImportImageTask {
   export function isa(o: any): o is ImportImageTask {
-    return _smithy.isa(o, "ImportImageTask");
+    return __isa(o, "ImportImageTask");
   }
 }
 
@@ -25018,7 +24985,7 @@ export interface ImportInstanceLaunchSpecification {
 
 export namespace ImportInstanceLaunchSpecification {
   export function isa(o: any): o is ImportInstanceLaunchSpecification {
-    return _smithy.isa(o, "ImportInstanceLaunchSpecification");
+    return __isa(o, "ImportInstanceLaunchSpecification");
   }
 }
 
@@ -25054,7 +25021,7 @@ export interface ImportInstanceRequest {
 
 export namespace ImportInstanceRequest {
   export function isa(o: any): o is ImportInstanceRequest {
-    return _smithy.isa(o, "ImportInstanceRequest");
+    return __isa(o, "ImportInstanceRequest");
   }
 }
 
@@ -25068,7 +25035,7 @@ export interface ImportInstanceResult extends $MetadataBearer {
 
 export namespace ImportInstanceResult {
   export function isa(o: any): o is ImportInstanceResult {
-    return _smithy.isa(o, "ImportInstanceResult");
+    return __isa(o, "ImportInstanceResult");
   }
 }
 
@@ -25100,7 +25067,7 @@ export interface ImportInstanceTaskDetails {
 
 export namespace ImportInstanceTaskDetails {
   export function isa(o: any): o is ImportInstanceTaskDetails {
-    return _smithy.isa(o, "ImportInstanceTaskDetails");
+    return __isa(o, "ImportInstanceTaskDetails");
   }
 }
 
@@ -25147,7 +25114,7 @@ export interface ImportInstanceVolumeDetailItem {
 
 export namespace ImportInstanceVolumeDetailItem {
   export function isa(o: any): o is ImportInstanceVolumeDetailItem {
-    return _smithy.isa(o, "ImportInstanceVolumeDetailItem");
+    return __isa(o, "ImportInstanceVolumeDetailItem");
   }
 }
 
@@ -25173,7 +25140,7 @@ export interface ImportKeyPairRequest {
 
 export namespace ImportKeyPairRequest {
   export function isa(o: any): o is ImportKeyPairRequest {
-    return _smithy.isa(o, "ImportKeyPairRequest");
+    return __isa(o, "ImportKeyPairRequest");
   }
 }
 
@@ -25192,7 +25159,7 @@ export interface ImportKeyPairResult extends $MetadataBearer {
 
 export namespace ImportKeyPairResult {
   export function isa(o: any): o is ImportKeyPairResult {
-    return _smithy.isa(o, "ImportKeyPairResult");
+    return __isa(o, "ImportKeyPairResult");
   }
 }
 
@@ -25267,7 +25234,7 @@ export interface ImportSnapshotRequest {
 
 export namespace ImportSnapshotRequest {
   export function isa(o: any): o is ImportSnapshotRequest {
-    return _smithy.isa(o, "ImportSnapshotRequest");
+    return __isa(o, "ImportSnapshotRequest");
   }
 }
 
@@ -25291,7 +25258,7 @@ export interface ImportSnapshotResult extends $MetadataBearer {
 
 export namespace ImportSnapshotResult {
   export function isa(o: any): o is ImportSnapshotResult {
-    return _smithy.isa(o, "ImportSnapshotResult");
+    return __isa(o, "ImportSnapshotResult");
   }
 }
 
@@ -25323,7 +25290,7 @@ export interface ImportSnapshotTask {
 
 export namespace ImportSnapshotTask {
   export function isa(o: any): o is ImportSnapshotTask {
-    return _smithy.isa(o, "ImportSnapshotTask");
+    return __isa(o, "ImportSnapshotTask");
   }
 }
 
@@ -25359,7 +25326,7 @@ export interface ImportVolumeRequest {
 
 export namespace ImportVolumeRequest {
   export function isa(o: any): o is ImportVolumeRequest {
-    return _smithy.isa(o, "ImportVolumeRequest");
+    return __isa(o, "ImportVolumeRequest");
   }
 }
 
@@ -25373,7 +25340,7 @@ export interface ImportVolumeResult extends $MetadataBearer {
 
 export namespace ImportVolumeResult {
   export function isa(o: any): o is ImportVolumeResult {
-    return _smithy.isa(o, "ImportVolumeResult");
+    return __isa(o, "ImportVolumeResult");
   }
 }
 
@@ -25410,7 +25377,7 @@ export interface ImportVolumeTaskDetails {
 
 export namespace ImportVolumeTaskDetails {
   export function isa(o: any): o is ImportVolumeTaskDetails {
-    return _smithy.isa(o, "ImportVolumeTaskDetails");
+    return __isa(o, "ImportVolumeTaskDetails");
   }
 }
 
@@ -25427,7 +25394,7 @@ export interface InferenceAcceleratorInfo {
 
 export namespace InferenceAcceleratorInfo {
   export function isa(o: any): o is InferenceAcceleratorInfo {
-    return _smithy.isa(o, "InferenceAcceleratorInfo");
+    return __isa(o, "InferenceAcceleratorInfo");
   }
 }
 
@@ -25454,7 +25421,7 @@ export interface InferenceDeviceInfo {
 
 export namespace InferenceDeviceInfo {
   export function isa(o: any): o is InferenceDeviceInfo {
-    return _smithy.isa(o, "InferenceDeviceInfo");
+    return __isa(o, "InferenceDeviceInfo");
   }
 }
 
@@ -25725,7 +25692,7 @@ export interface Instance {
 
 export namespace Instance {
   export function isa(o: any): o is Instance {
-    return _smithy.isa(o, "Instance");
+    return __isa(o, "Instance");
   }
 }
 
@@ -25818,7 +25785,7 @@ export interface InstanceAttribute extends $MetadataBearer {
 
 export namespace InstanceAttribute {
   export function isa(o: any): o is InstanceAttribute {
-    return _smithy.isa(o, "InstanceAttribute");
+    return __isa(o, "InstanceAttribute");
   }
 }
 
@@ -25857,7 +25824,7 @@ export interface InstanceBlockDeviceMapping {
 
 export namespace InstanceBlockDeviceMapping {
   export function isa(o: any): o is InstanceBlockDeviceMapping {
-    return _smithy.isa(o, "InstanceBlockDeviceMapping");
+    return __isa(o, "InstanceBlockDeviceMapping");
   }
 }
 
@@ -25890,7 +25857,7 @@ export interface InstanceBlockDeviceMappingSpecification {
 
 export namespace InstanceBlockDeviceMappingSpecification {
   export function isa(o: any): o is InstanceBlockDeviceMappingSpecification {
-    return _smithy.isa(o, "InstanceBlockDeviceMappingSpecification");
+    return __isa(o, "InstanceBlockDeviceMappingSpecification");
   }
 }
 
@@ -25920,7 +25887,7 @@ export interface InstanceCapacity {
 
 export namespace InstanceCapacity {
   export function isa(o: any): o is InstanceCapacity {
-    return _smithy.isa(o, "InstanceCapacity");
+    return __isa(o, "InstanceCapacity");
   }
 }
 
@@ -25942,7 +25909,7 @@ export interface InstanceCount {
 
 export namespace InstanceCount {
   export function isa(o: any): o is InstanceCount {
-    return _smithy.isa(o, "InstanceCount");
+    return __isa(o, "InstanceCount");
   }
 }
 
@@ -25965,7 +25932,7 @@ export interface InstanceCreditSpecification {
 
 export namespace InstanceCreditSpecification {
   export function isa(o: any): o is InstanceCreditSpecification {
-    return _smithy.isa(o, "InstanceCreditSpecification");
+    return __isa(o, "InstanceCreditSpecification");
   }
 }
 
@@ -25988,7 +25955,7 @@ export interface InstanceCreditSpecificationRequest {
 
 export namespace InstanceCreditSpecificationRequest {
   export function isa(o: any): o is InstanceCreditSpecificationRequest {
-    return _smithy.isa(o, "InstanceCreditSpecificationRequest");
+    return __isa(o, "InstanceCreditSpecificationRequest");
   }
 }
 
@@ -26010,7 +25977,7 @@ export interface InstanceExportDetails {
 
 export namespace InstanceExportDetails {
   export function isa(o: any): o is InstanceExportDetails {
-    return _smithy.isa(o, "InstanceExportDetails");
+    return __isa(o, "InstanceExportDetails");
   }
 }
 
@@ -26032,7 +25999,7 @@ export interface InstanceFamilyCreditSpecification {
 
 export namespace InstanceFamilyCreditSpecification {
   export function isa(o: any): o is InstanceFamilyCreditSpecification {
-    return _smithy.isa(o, "InstanceFamilyCreditSpecification");
+    return __isa(o, "InstanceFamilyCreditSpecification");
   }
 }
 
@@ -26056,7 +26023,7 @@ export interface InstanceIpv6Address {
 
 export namespace InstanceIpv6Address {
   export function isa(o: any): o is InstanceIpv6Address {
-    return _smithy.isa(o, "InstanceIpv6Address");
+    return __isa(o, "InstanceIpv6Address");
   }
 }
 
@@ -26073,7 +26040,7 @@ export interface InstanceIpv6AddressRequest {
 
 export namespace InstanceIpv6AddressRequest {
   export function isa(o: any): o is InstanceIpv6AddressRequest {
-    return _smithy.isa(o, "InstanceIpv6AddressRequest");
+    return __isa(o, "InstanceIpv6AddressRequest");
   }
 }
 
@@ -26102,7 +26069,7 @@ export interface InstanceMarketOptionsRequest {
 
 export namespace InstanceMarketOptionsRequest {
   export function isa(o: any): o is InstanceMarketOptionsRequest {
-    return _smithy.isa(o, "InstanceMarketOptionsRequest");
+    return __isa(o, "InstanceMarketOptionsRequest");
   }
 }
 
@@ -26151,7 +26118,7 @@ export interface InstanceMetadataOptionsRequest {
 
 export namespace InstanceMetadataOptionsRequest {
   export function isa(o: any): o is InstanceMetadataOptionsRequest {
-    return _smithy.isa(o, "InstanceMetadataOptionsRequest");
+    return __isa(o, "InstanceMetadataOptionsRequest");
   }
 }
 
@@ -26207,7 +26174,7 @@ export interface InstanceMetadataOptionsResponse {
 
 export namespace InstanceMetadataOptionsResponse {
   export function isa(o: any): o is InstanceMetadataOptionsResponse {
-    return _smithy.isa(o, "InstanceMetadataOptionsResponse");
+    return __isa(o, "InstanceMetadataOptionsResponse");
   }
 }
 
@@ -26231,7 +26198,7 @@ export interface InstanceMonitoring {
 
 export namespace InstanceMonitoring {
   export function isa(o: any): o is InstanceMonitoring {
-    return _smithy.isa(o, "InstanceMonitoring");
+    return __isa(o, "InstanceMonitoring");
   }
 }
 
@@ -26326,7 +26293,7 @@ export interface InstanceNetworkInterface {
 
 export namespace InstanceNetworkInterface {
   export function isa(o: any): o is InstanceNetworkInterface {
-    return _smithy.isa(o, "InstanceNetworkInterface");
+    return __isa(o, "InstanceNetworkInterface");
   }
 }
 
@@ -26353,7 +26320,7 @@ export interface InstanceNetworkInterfaceAssociation {
 
 export namespace InstanceNetworkInterfaceAssociation {
   export function isa(o: any): o is InstanceNetworkInterfaceAssociation {
-    return _smithy.isa(o, "InstanceNetworkInterfaceAssociation");
+    return __isa(o, "InstanceNetworkInterfaceAssociation");
   }
 }
 
@@ -26390,7 +26357,7 @@ export interface InstanceNetworkInterfaceAttachment {
 
 export namespace InstanceNetworkInterfaceAttachment {
   export function isa(o: any): o is InstanceNetworkInterfaceAttachment {
-    return _smithy.isa(o, "InstanceNetworkInterfaceAttachment");
+    return __isa(o, "InstanceNetworkInterfaceAttachment");
   }
 }
 
@@ -26490,7 +26457,7 @@ export interface InstanceNetworkInterfaceSpecification {
 
 export namespace InstanceNetworkInterfaceSpecification {
   export function isa(o: any): o is InstanceNetworkInterfaceSpecification {
-    return _smithy.isa(o, "InstanceNetworkInterfaceSpecification");
+    return __isa(o, "InstanceNetworkInterfaceSpecification");
   }
 }
 
@@ -26522,7 +26489,7 @@ export interface InstancePrivateIpAddress {
 
 export namespace InstancePrivateIpAddress {
   export function isa(o: any): o is InstancePrivateIpAddress {
-    return _smithy.isa(o, "InstancePrivateIpAddress");
+    return __isa(o, "InstancePrivateIpAddress");
   }
 }
 
@@ -26544,7 +26511,7 @@ export interface InstanceSpecification {
 
 export namespace InstanceSpecification {
   export function isa(o: any): o is InstanceSpecification {
-    return _smithy.isa(o, "InstanceSpecification");
+    return __isa(o, "InstanceSpecification");
   }
 }
 
@@ -26607,7 +26574,7 @@ export interface InstanceState {
 
 export namespace InstanceState {
   export function isa(o: any): o is InstanceState {
-    return _smithy.isa(o, "InstanceState");
+    return __isa(o, "InstanceState");
   }
 }
 
@@ -26634,7 +26601,7 @@ export interface InstanceStateChange {
 
 export namespace InstanceStateChange {
   export function isa(o: any): o is InstanceStateChange {
-    return _smithy.isa(o, "InstanceStateChange");
+    return __isa(o, "InstanceStateChange");
   }
 }
 
@@ -26692,7 +26659,7 @@ export interface InstanceStatus {
 
 export namespace InstanceStatus {
   export function isa(o: any): o is InstanceStatus {
-    return _smithy.isa(o, "InstanceStatus");
+    return __isa(o, "InstanceStatus");
   }
 }
 
@@ -26720,7 +26687,7 @@ export interface InstanceStatusDetails {
 
 export namespace InstanceStatusDetails {
   export function isa(o: any): o is InstanceStatusDetails {
-    return _smithy.isa(o, "InstanceStatusDetails");
+    return __isa(o, "InstanceStatusDetails");
   }
 }
 
@@ -26765,7 +26732,7 @@ export interface InstanceStatusEvent {
 
 export namespace InstanceStatusEvent {
   export function isa(o: any): o is InstanceStatusEvent {
-    return _smithy.isa(o, "InstanceStatusEvent");
+    return __isa(o, "InstanceStatusEvent");
   }
 }
 
@@ -26787,7 +26754,7 @@ export interface InstanceStatusSummary {
 
 export namespace InstanceStatusSummary {
   export function isa(o: any): o is InstanceStatusSummary {
-    return _smithy.isa(o, "InstanceStatusSummary");
+    return __isa(o, "InstanceStatusSummary");
   }
 }
 
@@ -26809,7 +26776,7 @@ export interface InstanceStorageInfo {
 
 export namespace InstanceStorageInfo {
   export function isa(o: any): o is InstanceStorageInfo {
-    return _smithy.isa(o, "InstanceStorageInfo");
+    return __isa(o, "InstanceStorageInfo");
   }
 }
 
@@ -27210,7 +27177,7 @@ export interface InstanceTypeInfo {
 
 export namespace InstanceTypeInfo {
   export function isa(o: any): o is InstanceTypeInfo {
-    return _smithy.isa(o, "InstanceTypeInfo");
+    return __isa(o, "InstanceTypeInfo");
   }
 }
 
@@ -27239,7 +27206,7 @@ export interface InstanceTypeOffering {
 
 export namespace InstanceTypeOffering {
   export function isa(o: any): o is InstanceTypeOffering {
-    return _smithy.isa(o, "InstanceTypeOffering");
+    return __isa(o, "InstanceTypeOffering");
   }
 }
 
@@ -27261,7 +27228,7 @@ export interface InstanceUsage {
 
 export namespace InstanceUsage {
   export function isa(o: any): o is InstanceUsage {
-    return _smithy.isa(o, "InstanceUsage");
+    return __isa(o, "InstanceUsage");
   }
 }
 
@@ -27295,7 +27262,7 @@ export interface InternetGateway {
 
 export namespace InternetGateway {
   export function isa(o: any): o is InternetGateway {
-    return _smithy.isa(o, "InternetGateway");
+    return __isa(o, "InternetGateway");
   }
 }
 
@@ -27320,7 +27287,7 @@ export interface InternetGatewayAttachment {
 
 export namespace InternetGatewayAttachment {
   export function isa(o: any): o is InternetGatewayAttachment {
-    return _smithy.isa(o, "InternetGatewayAttachment");
+    return __isa(o, "InternetGatewayAttachment");
   }
 }
 
@@ -27380,7 +27347,7 @@ export interface IpPermission {
 
 export namespace IpPermission {
   export function isa(o: any): o is IpPermission {
-    return _smithy.isa(o, "IpPermission");
+    return __isa(o, "IpPermission");
   }
 }
 
@@ -27405,7 +27372,7 @@ export interface IpRange {
 
 export namespace IpRange {
   export function isa(o: any): o is IpRange {
-    return _smithy.isa(o, "IpRange");
+    return __isa(o, "IpRange");
   }
 }
 
@@ -27427,7 +27394,7 @@ export interface Ipv6CidrAssociation {
 
 export namespace Ipv6CidrAssociation {
   export function isa(o: any): o is Ipv6CidrAssociation {
-    return _smithy.isa(o, "Ipv6CidrAssociation");
+    return __isa(o, "Ipv6CidrAssociation");
   }
 }
 
@@ -27444,7 +27411,7 @@ export interface Ipv6CidrBlock {
 
 export namespace Ipv6CidrBlock {
   export function isa(o: any): o is Ipv6CidrBlock {
-    return _smithy.isa(o, "Ipv6CidrBlock");
+    return __isa(o, "Ipv6CidrBlock");
   }
 }
 
@@ -27476,7 +27443,7 @@ export interface Ipv6Pool {
 
 export namespace Ipv6Pool {
   export function isa(o: any): o is Ipv6Pool {
-    return _smithy.isa(o, "Ipv6Pool");
+    return __isa(o, "Ipv6Pool");
   }
 }
 
@@ -27501,7 +27468,7 @@ export interface Ipv6Range {
 
 export namespace Ipv6Range {
   export function isa(o: any): o is Ipv6Range {
-    return _smithy.isa(o, "Ipv6Range");
+    return __isa(o, "Ipv6Range");
   }
 }
 
@@ -27535,7 +27502,7 @@ export interface KeyPair extends $MetadataBearer {
 
 export namespace KeyPair {
   export function isa(o: any): o is KeyPair {
-    return _smithy.isa(o, "KeyPair");
+    return __isa(o, "KeyPair");
   }
 }
 
@@ -27568,7 +27535,7 @@ export interface KeyPairInfo {
 
 export namespace KeyPairInfo {
   export function isa(o: any): o is KeyPairInfo {
-    return _smithy.isa(o, "KeyPairInfo");
+    return __isa(o, "KeyPairInfo");
   }
 }
 
@@ -27590,7 +27557,7 @@ export interface LastError {
 
 export namespace LastError {
   export function isa(o: any): o is LastError {
-    return _smithy.isa(o, "LastError");
+    return __isa(o, "LastError");
   }
 }
 
@@ -27612,7 +27579,7 @@ export interface LaunchPermission {
 
 export namespace LaunchPermission {
   export function isa(o: any): o is LaunchPermission {
-    return _smithy.isa(o, "LaunchPermission");
+    return __isa(o, "LaunchPermission");
   }
 }
 
@@ -27634,7 +27601,7 @@ export interface LaunchPermissionModifications {
 
 export namespace LaunchPermissionModifications {
   export function isa(o: any): o is LaunchPermissionModifications {
-    return _smithy.isa(o, "LaunchPermissionModifications");
+    return __isa(o, "LaunchPermissionModifications");
   }
 }
 
@@ -27724,7 +27691,7 @@ export interface LaunchSpecification {
 
 export namespace LaunchSpecification {
   export function isa(o: any): o is LaunchSpecification {
-    return _smithy.isa(o, "LaunchSpecification");
+    return __isa(o, "LaunchSpecification");
   }
 }
 
@@ -27771,7 +27738,7 @@ export interface LaunchTemplate {
 
 export namespace LaunchTemplate {
   export function isa(o: any): o is LaunchTemplate {
-    return _smithy.isa(o, "LaunchTemplate");
+    return __isa(o, "LaunchTemplate");
   }
 }
 
@@ -27794,7 +27761,7 @@ export interface LaunchTemplateAndOverridesResponse {
 
 export namespace LaunchTemplateAndOverridesResponse {
   export function isa(o: any): o is LaunchTemplateAndOverridesResponse {
-    return _smithy.isa(o, "LaunchTemplateAndOverridesResponse");
+    return __isa(o, "LaunchTemplateAndOverridesResponse");
   }
 }
 
@@ -27826,7 +27793,7 @@ export interface LaunchTemplateBlockDeviceMapping {
 
 export namespace LaunchTemplateBlockDeviceMapping {
   export function isa(o: any): o is LaunchTemplateBlockDeviceMapping {
-    return _smithy.isa(o, "LaunchTemplateBlockDeviceMapping");
+    return __isa(o, "LaunchTemplateBlockDeviceMapping");
   }
 }
 
@@ -27858,7 +27825,7 @@ export interface LaunchTemplateBlockDeviceMappingRequest {
 
 export namespace LaunchTemplateBlockDeviceMappingRequest {
   export function isa(o: any): o is LaunchTemplateBlockDeviceMappingRequest {
-    return _smithy.isa(o, "LaunchTemplateBlockDeviceMappingRequest");
+    return __isa(o, "LaunchTemplateBlockDeviceMappingRequest");
   }
 }
 
@@ -27897,10 +27864,7 @@ export namespace LaunchTemplateCapacityReservationSpecificationRequest {
   export function isa(
     o: any
   ): o is LaunchTemplateCapacityReservationSpecificationRequest {
-    return _smithy.isa(
-      o,
-      "LaunchTemplateCapacityReservationSpecificationRequest"
-    );
+    return __isa(o, "LaunchTemplateCapacityReservationSpecificationRequest");
   }
 }
 
@@ -27936,10 +27900,7 @@ export namespace LaunchTemplateCapacityReservationSpecificationResponse {
   export function isa(
     o: any
   ): o is LaunchTemplateCapacityReservationSpecificationResponse {
-    return _smithy.isa(
-      o,
-      "LaunchTemplateCapacityReservationSpecificationResponse"
-    );
+    return __isa(o, "LaunchTemplateCapacityReservationSpecificationResponse");
   }
 }
 
@@ -27961,7 +27922,7 @@ export interface LaunchTemplateConfig {
 
 export namespace LaunchTemplateConfig {
   export function isa(o: any): o is LaunchTemplateConfig {
-    return _smithy.isa(o, "LaunchTemplateConfig");
+    return __isa(o, "LaunchTemplateConfig");
   }
 }
 
@@ -27983,7 +27944,7 @@ export interface LaunchTemplateCpuOptions {
 
 export namespace LaunchTemplateCpuOptions {
   export function isa(o: any): o is LaunchTemplateCpuOptions {
-    return _smithy.isa(o, "LaunchTemplateCpuOptions");
+    return __isa(o, "LaunchTemplateCpuOptions");
   }
 }
 
@@ -28007,7 +27968,7 @@ export interface LaunchTemplateCpuOptionsRequest {
 
 export namespace LaunchTemplateCpuOptionsRequest {
   export function isa(o: any): o is LaunchTemplateCpuOptionsRequest {
-    return _smithy.isa(o, "LaunchTemplateCpuOptionsRequest");
+    return __isa(o, "LaunchTemplateCpuOptionsRequest");
   }
 }
 
@@ -28054,7 +28015,7 @@ export interface LaunchTemplateEbsBlockDevice {
 
 export namespace LaunchTemplateEbsBlockDevice {
   export function isa(o: any): o is LaunchTemplateEbsBlockDevice {
-    return _smithy.isa(o, "LaunchTemplateEbsBlockDevice");
+    return __isa(o, "LaunchTemplateEbsBlockDevice");
   }
 }
 
@@ -28104,7 +28065,7 @@ export interface LaunchTemplateEbsBlockDeviceRequest {
 
 export namespace LaunchTemplateEbsBlockDeviceRequest {
   export function isa(o: any): o is LaunchTemplateEbsBlockDeviceRequest {
-    return _smithy.isa(o, "LaunchTemplateEbsBlockDeviceRequest");
+    return __isa(o, "LaunchTemplateEbsBlockDeviceRequest");
   }
 }
 
@@ -28133,7 +28094,7 @@ export interface LaunchTemplateElasticInferenceAccelerator {
 
 export namespace LaunchTemplateElasticInferenceAccelerator {
   export function isa(o: any): o is LaunchTemplateElasticInferenceAccelerator {
-    return _smithy.isa(o, "LaunchTemplateElasticInferenceAccelerator");
+    return __isa(o, "LaunchTemplateElasticInferenceAccelerator");
   }
 }
 
@@ -28164,7 +28125,7 @@ export namespace LaunchTemplateElasticInferenceAcceleratorResponse {
   export function isa(
     o: any
   ): o is LaunchTemplateElasticInferenceAcceleratorResponse {
-    return _smithy.isa(o, "LaunchTemplateElasticInferenceAcceleratorResponse");
+    return __isa(o, "LaunchTemplateElasticInferenceAcceleratorResponse");
   }
 }
 
@@ -28190,7 +28151,7 @@ export interface LaunchTemplateHibernationOptions {
 
 export namespace LaunchTemplateHibernationOptions {
   export function isa(o: any): o is LaunchTemplateHibernationOptions {
-    return _smithy.isa(o, "LaunchTemplateHibernationOptions");
+    return __isa(o, "LaunchTemplateHibernationOptions");
   }
 }
 
@@ -28211,7 +28172,7 @@ export interface LaunchTemplateHibernationOptionsRequest {
 
 export namespace LaunchTemplateHibernationOptionsRequest {
   export function isa(o: any): o is LaunchTemplateHibernationOptionsRequest {
-    return _smithy.isa(o, "LaunchTemplateHibernationOptionsRequest");
+    return __isa(o, "LaunchTemplateHibernationOptionsRequest");
   }
 }
 
@@ -28240,7 +28201,7 @@ export namespace LaunchTemplateIamInstanceProfileSpecification {
   export function isa(
     o: any
   ): o is LaunchTemplateIamInstanceProfileSpecification {
-    return _smithy.isa(o, "LaunchTemplateIamInstanceProfileSpecification");
+    return __isa(o, "LaunchTemplateIamInstanceProfileSpecification");
   }
 }
 
@@ -28264,10 +28225,7 @@ export namespace LaunchTemplateIamInstanceProfileSpecificationRequest {
   export function isa(
     o: any
   ): o is LaunchTemplateIamInstanceProfileSpecificationRequest {
-    return _smithy.isa(
-      o,
-      "LaunchTemplateIamInstanceProfileSpecificationRequest"
-    );
+    return __isa(o, "LaunchTemplateIamInstanceProfileSpecificationRequest");
   }
 }
 
@@ -28289,7 +28247,7 @@ export interface LaunchTemplateInstanceMarketOptions {
 
 export namespace LaunchTemplateInstanceMarketOptions {
   export function isa(o: any): o is LaunchTemplateInstanceMarketOptions {
-    return _smithy.isa(o, "LaunchTemplateInstanceMarketOptions");
+    return __isa(o, "LaunchTemplateInstanceMarketOptions");
   }
 }
 
@@ -28311,7 +28269,7 @@ export interface LaunchTemplateInstanceMarketOptionsRequest {
 
 export namespace LaunchTemplateInstanceMarketOptionsRequest {
   export function isa(o: any): o is LaunchTemplateInstanceMarketOptionsRequest {
-    return _smithy.isa(o, "LaunchTemplateInstanceMarketOptionsRequest");
+    return __isa(o, "LaunchTemplateInstanceMarketOptionsRequest");
   }
 }
 
@@ -28360,7 +28318,7 @@ export interface LaunchTemplateInstanceMetadataOptions {
 
 export namespace LaunchTemplateInstanceMetadataOptions {
   export function isa(o: any): o is LaunchTemplateInstanceMetadataOptions {
-    return _smithy.isa(o, "LaunchTemplateInstanceMetadataOptions");
+    return __isa(o, "LaunchTemplateInstanceMetadataOptions");
   }
 }
 
@@ -28398,7 +28356,7 @@ export namespace LaunchTemplateInstanceMetadataOptionsRequest {
   export function isa(
     o: any
   ): o is LaunchTemplateInstanceMetadataOptionsRequest {
-    return _smithy.isa(o, "LaunchTemplateInstanceMetadataOptionsRequest");
+    return __isa(o, "LaunchTemplateInstanceMetadataOptionsRequest");
   }
 }
 
@@ -28479,10 +28437,7 @@ export namespace LaunchTemplateInstanceNetworkInterfaceSpecification {
   export function isa(
     o: any
   ): o is LaunchTemplateInstanceNetworkInterfaceSpecification {
-    return _smithy.isa(
-      o,
-      "LaunchTemplateInstanceNetworkInterfaceSpecification"
-    );
+    return __isa(o, "LaunchTemplateInstanceNetworkInterfaceSpecification");
   }
 }
 
@@ -28566,7 +28521,7 @@ export namespace LaunchTemplateInstanceNetworkInterfaceSpecificationRequest {
   export function isa(
     o: any
   ): o is LaunchTemplateInstanceNetworkInterfaceSpecificationRequest {
-    return _smithy.isa(
+    return __isa(
       o,
       "LaunchTemplateInstanceNetworkInterfaceSpecificationRequest"
     );
@@ -28586,7 +28541,7 @@ export interface LaunchTemplateLicenseConfiguration {
 
 export namespace LaunchTemplateLicenseConfiguration {
   export function isa(o: any): o is LaunchTemplateLicenseConfiguration {
-    return _smithy.isa(o, "LaunchTemplateLicenseConfiguration");
+    return __isa(o, "LaunchTemplateLicenseConfiguration");
   }
 }
 
@@ -28603,7 +28558,7 @@ export interface LaunchTemplateLicenseConfigurationRequest {
 
 export namespace LaunchTemplateLicenseConfigurationRequest {
   export function isa(o: any): o is LaunchTemplateLicenseConfigurationRequest {
-    return _smithy.isa(o, "LaunchTemplateLicenseConfigurationRequest");
+    return __isa(o, "LaunchTemplateLicenseConfigurationRequest");
   }
 }
 
@@ -28649,7 +28604,7 @@ export interface LaunchTemplateOverrides {
 
 export namespace LaunchTemplateOverrides {
   export function isa(o: any): o is LaunchTemplateOverrides {
-    return _smithy.isa(o, "LaunchTemplateOverrides");
+    return __isa(o, "LaunchTemplateOverrides");
   }
 }
 
@@ -28702,7 +28657,7 @@ export interface LaunchTemplatePlacement {
 
 export namespace LaunchTemplatePlacement {
   export function isa(o: any): o is LaunchTemplatePlacement {
-    return _smithy.isa(o, "LaunchTemplatePlacement");
+    return __isa(o, "LaunchTemplatePlacement");
   }
 }
 
@@ -28757,7 +28712,7 @@ export interface LaunchTemplatePlacementRequest {
 
 export namespace LaunchTemplatePlacementRequest {
   export function isa(o: any): o is LaunchTemplatePlacementRequest {
-    return _smithy.isa(o, "LaunchTemplatePlacementRequest");
+    return __isa(o, "LaunchTemplatePlacementRequest");
   }
 }
 
@@ -28786,7 +28741,7 @@ export interface LaunchTemplateSpecification {
 
 export namespace LaunchTemplateSpecification {
   export function isa(o: any): o is LaunchTemplateSpecification {
-    return _smithy.isa(o, "LaunchTemplateSpecification");
+    return __isa(o, "LaunchTemplateSpecification");
   }
 }
 
@@ -28823,7 +28778,7 @@ export interface LaunchTemplateSpotMarketOptions {
 
 export namespace LaunchTemplateSpotMarketOptions {
   export function isa(o: any): o is LaunchTemplateSpotMarketOptions {
-    return _smithy.isa(o, "LaunchTemplateSpotMarketOptions");
+    return __isa(o, "LaunchTemplateSpotMarketOptions");
   }
 }
 
@@ -28863,7 +28818,7 @@ export interface LaunchTemplateSpotMarketOptionsRequest {
 
 export namespace LaunchTemplateSpotMarketOptionsRequest {
   export function isa(o: any): o is LaunchTemplateSpotMarketOptionsRequest {
-    return _smithy.isa(o, "LaunchTemplateSpotMarketOptionsRequest");
+    return __isa(o, "LaunchTemplateSpotMarketOptionsRequest");
   }
 }
 
@@ -28885,7 +28840,7 @@ export interface LaunchTemplateTagSpecification {
 
 export namespace LaunchTemplateTagSpecification {
   export function isa(o: any): o is LaunchTemplateTagSpecification {
-    return _smithy.isa(o, "LaunchTemplateTagSpecification");
+    return __isa(o, "LaunchTemplateTagSpecification");
   }
 }
 
@@ -28909,7 +28864,7 @@ export interface LaunchTemplateTagSpecificationRequest {
 
 export namespace LaunchTemplateTagSpecificationRequest {
   export function isa(o: any): o is LaunchTemplateTagSpecificationRequest {
-    return _smithy.isa(o, "LaunchTemplateTagSpecificationRequest");
+    return __isa(o, "LaunchTemplateTagSpecificationRequest");
   }
 }
 
@@ -28961,7 +28916,7 @@ export interface LaunchTemplateVersion {
 
 export namespace LaunchTemplateVersion {
   export function isa(o: any): o is LaunchTemplateVersion {
-    return _smithy.isa(o, "LaunchTemplateVersion");
+    return __isa(o, "LaunchTemplateVersion");
   }
 }
 
@@ -28979,7 +28934,7 @@ export interface LaunchTemplatesMonitoring {
 
 export namespace LaunchTemplatesMonitoring {
   export function isa(o: any): o is LaunchTemplatesMonitoring {
-    return _smithy.isa(o, "LaunchTemplatesMonitoring");
+    return __isa(o, "LaunchTemplatesMonitoring");
   }
 }
 
@@ -28996,7 +28951,7 @@ export interface LaunchTemplatesMonitoringRequest {
 
 export namespace LaunchTemplatesMonitoringRequest {
   export function isa(o: any): o is LaunchTemplatesMonitoringRequest {
-    return _smithy.isa(o, "LaunchTemplatesMonitoringRequest");
+    return __isa(o, "LaunchTemplatesMonitoringRequest");
   }
 }
 
@@ -29013,7 +28968,7 @@ export interface LicenseConfiguration {
 
 export namespace LicenseConfiguration {
   export function isa(o: any): o is LicenseConfiguration {
-    return _smithy.isa(o, "LicenseConfiguration");
+    return __isa(o, "LicenseConfiguration");
   }
 }
 
@@ -29030,7 +28985,7 @@ export interface LicenseConfigurationRequest {
 
 export namespace LicenseConfigurationRequest {
   export function isa(o: any): o is LicenseConfigurationRequest {
-    return _smithy.isa(o, "LicenseConfigurationRequest");
+    return __isa(o, "LicenseConfigurationRequest");
   }
 }
 
@@ -29056,7 +29011,7 @@ export interface LoadBalancersConfig {
 
 export namespace LoadBalancersConfig {
   export function isa(o: any): o is LoadBalancersConfig {
-    return _smithy.isa(o, "LoadBalancersConfig");
+    return __isa(o, "LoadBalancersConfig");
   }
 }
 
@@ -29078,7 +29033,7 @@ export interface LoadPermission {
 
 export namespace LoadPermission {
   export function isa(o: any): o is LoadPermission {
-    return _smithy.isa(o, "LoadPermission");
+    return __isa(o, "LoadPermission");
   }
 }
 
@@ -29100,7 +29055,7 @@ export interface LoadPermissionModifications {
 
 export namespace LoadPermissionModifications {
   export function isa(o: any): o is LoadPermissionModifications {
-    return _smithy.isa(o, "LoadPermissionModifications");
+    return __isa(o, "LoadPermissionModifications");
   }
 }
 
@@ -29122,7 +29077,7 @@ export interface LoadPermissionRequest {
 
 export namespace LoadPermissionRequest {
   export function isa(o: any): o is LoadPermissionRequest {
-    return _smithy.isa(o, "LoadPermissionRequest");
+    return __isa(o, "LoadPermissionRequest");
   }
 }
 
@@ -29159,7 +29114,7 @@ export interface LocalGateway {
 
 export namespace LocalGateway {
   export function isa(o: any): o is LocalGateway {
-    return _smithy.isa(o, "LocalGateway");
+    return __isa(o, "LocalGateway");
   }
 }
 
@@ -29196,7 +29151,7 @@ export interface LocalGatewayRoute {
 
 export namespace LocalGatewayRoute {
   export function isa(o: any): o is LocalGatewayRoute {
-    return _smithy.isa(o, "LocalGatewayRoute");
+    return __isa(o, "LocalGatewayRoute");
   }
 }
 
@@ -29240,7 +29195,7 @@ export interface LocalGatewayRouteTable {
 
 export namespace LocalGatewayRouteTable {
   export function isa(o: any): o is LocalGatewayRouteTable {
-    return _smithy.isa(o, "LocalGatewayRouteTable");
+    return __isa(o, "LocalGatewayRouteTable");
   }
 }
 
@@ -29284,10 +29239,7 @@ export namespace LocalGatewayRouteTableVirtualInterfaceGroupAssociation {
   export function isa(
     o: any
   ): o is LocalGatewayRouteTableVirtualInterfaceGroupAssociation {
-    return _smithy.isa(
-      o,
-      "LocalGatewayRouteTableVirtualInterfaceGroupAssociation"
-    );
+    return __isa(o, "LocalGatewayRouteTableVirtualInterfaceGroupAssociation");
   }
 }
 
@@ -29329,7 +29281,7 @@ export interface LocalGatewayRouteTableVpcAssociation {
 
 export namespace LocalGatewayRouteTableVpcAssociation {
   export function isa(o: any): o is LocalGatewayRouteTableVpcAssociation {
-    return _smithy.isa(o, "LocalGatewayRouteTableVpcAssociation");
+    return __isa(o, "LocalGatewayRouteTableVpcAssociation");
   }
 }
 
@@ -29383,7 +29335,7 @@ export interface LocalGatewayVirtualInterface {
 
 export namespace LocalGatewayVirtualInterface {
   export function isa(o: any): o is LocalGatewayVirtualInterface {
-    return _smithy.isa(o, "LocalGatewayVirtualInterface");
+    return __isa(o, "LocalGatewayVirtualInterface");
   }
 }
 
@@ -29415,7 +29367,7 @@ export interface LocalGatewayVirtualInterfaceGroup {
 
 export namespace LocalGatewayVirtualInterfaceGroup {
   export function isa(o: any): o is LocalGatewayVirtualInterfaceGroup {
-    return _smithy.isa(o, "LocalGatewayVirtualInterfaceGroup");
+    return __isa(o, "LocalGatewayVirtualInterfaceGroup");
   }
 }
 
@@ -29443,7 +29395,7 @@ export interface MemoryInfo {
 
 export namespace MemoryInfo {
   export function isa(o: any): o is MemoryInfo {
-    return _smithy.isa(o, "MemoryInfo");
+    return __isa(o, "MemoryInfo");
   }
 }
 
@@ -29499,7 +29451,7 @@ export interface ModifyCapacityReservationRequest {
 
 export namespace ModifyCapacityReservationRequest {
   export function isa(o: any): o is ModifyCapacityReservationRequest {
-    return _smithy.isa(o, "ModifyCapacityReservationRequest");
+    return __isa(o, "ModifyCapacityReservationRequest");
   }
 }
 
@@ -29513,7 +29465,7 @@ export interface ModifyCapacityReservationResult extends $MetadataBearer {
 
 export namespace ModifyCapacityReservationResult {
   export function isa(o: any): o is ModifyCapacityReservationResult {
-    return _smithy.isa(o, "ModifyCapacityReservationResult");
+    return __isa(o, "ModifyCapacityReservationResult");
   }
 }
 
@@ -29585,7 +29537,7 @@ export interface ModifyClientVpnEndpointRequest {
 
 export namespace ModifyClientVpnEndpointRequest {
   export function isa(o: any): o is ModifyClientVpnEndpointRequest {
-    return _smithy.isa(o, "ModifyClientVpnEndpointRequest");
+    return __isa(o, "ModifyClientVpnEndpointRequest");
   }
 }
 
@@ -29599,7 +29551,7 @@ export interface ModifyClientVpnEndpointResult extends $MetadataBearer {
 
 export namespace ModifyClientVpnEndpointResult {
   export function isa(o: any): o is ModifyClientVpnEndpointResult {
-    return _smithy.isa(o, "ModifyClientVpnEndpointResult");
+    return __isa(o, "ModifyClientVpnEndpointResult");
   }
 }
 
@@ -29627,7 +29579,7 @@ export interface ModifyDefaultCreditSpecificationRequest {
 
 export namespace ModifyDefaultCreditSpecificationRequest {
   export function isa(o: any): o is ModifyDefaultCreditSpecificationRequest {
-    return _smithy.isa(o, "ModifyDefaultCreditSpecificationRequest");
+    return __isa(o, "ModifyDefaultCreditSpecificationRequest");
   }
 }
 
@@ -29642,7 +29594,7 @@ export interface ModifyDefaultCreditSpecificationResult
 
 export namespace ModifyDefaultCreditSpecificationResult {
   export function isa(o: any): o is ModifyDefaultCreditSpecificationResult {
-    return _smithy.isa(o, "ModifyDefaultCreditSpecificationResult");
+    return __isa(o, "ModifyDefaultCreditSpecificationResult");
   }
 }
 
@@ -29683,7 +29635,7 @@ export interface ModifyEbsDefaultKmsKeyIdRequest {
 
 export namespace ModifyEbsDefaultKmsKeyIdRequest {
   export function isa(o: any): o is ModifyEbsDefaultKmsKeyIdRequest {
-    return _smithy.isa(o, "ModifyEbsDefaultKmsKeyIdRequest");
+    return __isa(o, "ModifyEbsDefaultKmsKeyIdRequest");
   }
 }
 
@@ -29697,7 +29649,7 @@ export interface ModifyEbsDefaultKmsKeyIdResult extends $MetadataBearer {
 
 export namespace ModifyEbsDefaultKmsKeyIdResult {
   export function isa(o: any): o is ModifyEbsDefaultKmsKeyIdResult {
-    return _smithy.isa(o, "ModifyEbsDefaultKmsKeyIdResult");
+    return __isa(o, "ModifyEbsDefaultKmsKeyIdResult");
   }
 }
 
@@ -29731,7 +29683,7 @@ export interface ModifyFleetRequest {
 
 export namespace ModifyFleetRequest {
   export function isa(o: any): o is ModifyFleetRequest {
-    return _smithy.isa(o, "ModifyFleetRequest");
+    return __isa(o, "ModifyFleetRequest");
   }
 }
 
@@ -29745,7 +29697,7 @@ export interface ModifyFleetResult extends $MetadataBearer {
 
 export namespace ModifyFleetResult {
   export function isa(o: any): o is ModifyFleetResult {
-    return _smithy.isa(o, "ModifyFleetResult");
+    return __isa(o, "ModifyFleetResult");
   }
 }
 
@@ -29807,7 +29759,7 @@ export interface ModifyFpgaImageAttributeRequest {
 
 export namespace ModifyFpgaImageAttributeRequest {
   export function isa(o: any): o is ModifyFpgaImageAttributeRequest {
-    return _smithy.isa(o, "ModifyFpgaImageAttributeRequest");
+    return __isa(o, "ModifyFpgaImageAttributeRequest");
   }
 }
 
@@ -29821,7 +29773,7 @@ export interface ModifyFpgaImageAttributeResult extends $MetadataBearer {
 
 export namespace ModifyFpgaImageAttributeResult {
   export function isa(o: any): o is ModifyFpgaImageAttributeResult {
-    return _smithy.isa(o, "ModifyFpgaImageAttributeResult");
+    return __isa(o, "ModifyFpgaImageAttributeResult");
   }
 }
 
@@ -29870,7 +29822,7 @@ export interface ModifyHostsRequest {
 
 export namespace ModifyHostsRequest {
   export function isa(o: any): o is ModifyHostsRequest {
-    return _smithy.isa(o, "ModifyHostsRequest");
+    return __isa(o, "ModifyHostsRequest");
   }
 }
 
@@ -29890,7 +29842,7 @@ export interface ModifyHostsResult extends $MetadataBearer {
 
 export namespace ModifyHostsResult {
   export function isa(o: any): o is ModifyHostsResult {
-    return _smithy.isa(o, "ModifyHostsResult");
+    return __isa(o, "ModifyHostsResult");
   }
 }
 
@@ -29920,7 +29872,7 @@ export interface ModifyIdFormatRequest {
 
 export namespace ModifyIdFormatRequest {
   export function isa(o: any): o is ModifyIdFormatRequest {
-    return _smithy.isa(o, "ModifyIdFormatRequest");
+    return __isa(o, "ModifyIdFormatRequest");
   }
 }
 
@@ -29957,7 +29909,7 @@ export interface ModifyIdentityIdFormatRequest {
 
 export namespace ModifyIdentityIdFormatRequest {
   export function isa(o: any): o is ModifyIdentityIdFormatRequest {
-    return _smithy.isa(o, "ModifyIdentityIdFormatRequest");
+    return __isa(o, "ModifyIdentityIdFormatRequest");
   }
 }
 
@@ -30026,7 +29978,7 @@ export interface ModifyImageAttributeRequest {
 
 export namespace ModifyImageAttributeRequest {
   export function isa(o: any): o is ModifyImageAttributeRequest {
-    return _smithy.isa(o, "ModifyImageAttributeRequest");
+    return __isa(o, "ModifyImageAttributeRequest");
   }
 }
 
@@ -30149,7 +30101,7 @@ export interface ModifyInstanceAttributeRequest {
 
 export namespace ModifyInstanceAttributeRequest {
   export function isa(o: any): o is ModifyInstanceAttributeRequest {
-    return _smithy.isa(o, "ModifyInstanceAttributeRequest");
+    return __isa(o, "ModifyInstanceAttributeRequest");
   }
 }
 
@@ -30177,7 +30129,7 @@ export namespace ModifyInstanceCapacityReservationAttributesRequest {
   export function isa(
     o: any
   ): o is ModifyInstanceCapacityReservationAttributesRequest {
-    return _smithy.isa(o, "ModifyInstanceCapacityReservationAttributesRequest");
+    return __isa(o, "ModifyInstanceCapacityReservationAttributesRequest");
   }
 }
 
@@ -30194,7 +30146,7 @@ export namespace ModifyInstanceCapacityReservationAttributesResult {
   export function isa(
     o: any
   ): o is ModifyInstanceCapacityReservationAttributesResult {
-    return _smithy.isa(o, "ModifyInstanceCapacityReservationAttributesResult");
+    return __isa(o, "ModifyInstanceCapacityReservationAttributesResult");
   }
 }
 
@@ -30224,7 +30176,7 @@ export interface ModifyInstanceCreditSpecificationRequest {
 
 export namespace ModifyInstanceCreditSpecificationRequest {
   export function isa(o: any): o is ModifyInstanceCreditSpecificationRequest {
-    return _smithy.isa(o, "ModifyInstanceCreditSpecificationRequest");
+    return __isa(o, "ModifyInstanceCreditSpecificationRequest");
   }
 }
 
@@ -30250,7 +30202,7 @@ export interface ModifyInstanceCreditSpecificationResult
 
 export namespace ModifyInstanceCreditSpecificationResult {
   export function isa(o: any): o is ModifyInstanceCreditSpecificationResult {
-    return _smithy.isa(o, "ModifyInstanceCreditSpecificationResult");
+    return __isa(o, "ModifyInstanceCreditSpecificationResult");
   }
 }
 
@@ -30281,7 +30233,7 @@ export interface ModifyInstanceEventStartTimeRequest {
 
 export namespace ModifyInstanceEventStartTimeRequest {
   export function isa(o: any): o is ModifyInstanceEventStartTimeRequest {
-    return _smithy.isa(o, "ModifyInstanceEventStartTimeRequest");
+    return __isa(o, "ModifyInstanceEventStartTimeRequest");
   }
 }
 
@@ -30295,7 +30247,7 @@ export interface ModifyInstanceEventStartTimeResult extends $MetadataBearer {
 
 export namespace ModifyInstanceEventStartTimeResult {
   export function isa(o: any): o is ModifyInstanceEventStartTimeResult {
-    return _smithy.isa(o, "ModifyInstanceEventStartTimeResult");
+    return __isa(o, "ModifyInstanceEventStartTimeResult");
   }
 }
 
@@ -30346,7 +30298,7 @@ export interface ModifyInstanceMetadataOptionsRequest {
 
 export namespace ModifyInstanceMetadataOptionsRequest {
   export function isa(o: any): o is ModifyInstanceMetadataOptionsRequest {
-    return _smithy.isa(o, "ModifyInstanceMetadataOptionsRequest");
+    return __isa(o, "ModifyInstanceMetadataOptionsRequest");
   }
 }
 
@@ -30365,7 +30317,7 @@ export interface ModifyInstanceMetadataOptionsResult extends $MetadataBearer {
 
 export namespace ModifyInstanceMetadataOptionsResult {
   export function isa(o: any): o is ModifyInstanceMetadataOptionsResult {
-    return _smithy.isa(o, "ModifyInstanceMetadataOptionsResult");
+    return __isa(o, "ModifyInstanceMetadataOptionsResult");
   }
 }
 
@@ -30414,7 +30366,7 @@ export interface ModifyInstancePlacementRequest {
 
 export namespace ModifyInstancePlacementRequest {
   export function isa(o: any): o is ModifyInstancePlacementRequest {
-    return _smithy.isa(o, "ModifyInstancePlacementRequest");
+    return __isa(o, "ModifyInstancePlacementRequest");
   }
 }
 
@@ -30428,7 +30380,7 @@ export interface ModifyInstancePlacementResult extends $MetadataBearer {
 
 export namespace ModifyInstancePlacementResult {
   export function isa(o: any): o is ModifyInstancePlacementResult {
-    return _smithy.isa(o, "ModifyInstancePlacementResult");
+    return __isa(o, "ModifyInstancePlacementResult");
   }
 }
 
@@ -30470,7 +30422,7 @@ export interface ModifyLaunchTemplateRequest {
 
 export namespace ModifyLaunchTemplateRequest {
   export function isa(o: any): o is ModifyLaunchTemplateRequest {
-    return _smithy.isa(o, "ModifyLaunchTemplateRequest");
+    return __isa(o, "ModifyLaunchTemplateRequest");
   }
 }
 
@@ -30484,7 +30436,7 @@ export interface ModifyLaunchTemplateResult extends $MetadataBearer {
 
 export namespace ModifyLaunchTemplateResult {
   export function isa(o: any): o is ModifyLaunchTemplateResult {
-    return _smithy.isa(o, "ModifyLaunchTemplateResult");
+    return __isa(o, "ModifyLaunchTemplateResult");
   }
 }
 
@@ -30533,7 +30485,7 @@ export interface ModifyNetworkInterfaceAttributeRequest {
 
 export namespace ModifyNetworkInterfaceAttributeRequest {
   export function isa(o: any): o is ModifyNetworkInterfaceAttributeRequest {
-    return _smithy.isa(o, "ModifyNetworkInterfaceAttributeRequest");
+    return __isa(o, "ModifyNetworkInterfaceAttributeRequest");
   }
 }
 
@@ -30561,7 +30513,7 @@ export interface ModifyReservedInstancesRequest {
 
 export namespace ModifyReservedInstancesRequest {
   export function isa(o: any): o is ModifyReservedInstancesRequest {
-    return _smithy.isa(o, "ModifyReservedInstancesRequest");
+    return __isa(o, "ModifyReservedInstancesRequest");
   }
 }
 
@@ -30578,7 +30530,7 @@ export interface ModifyReservedInstancesResult extends $MetadataBearer {
 
 export namespace ModifyReservedInstancesResult {
   export function isa(o: any): o is ModifyReservedInstancesResult {
-    return _smithy.isa(o, "ModifyReservedInstancesResult");
+    return __isa(o, "ModifyReservedInstancesResult");
   }
 }
 
@@ -30624,7 +30576,7 @@ export interface ModifySnapshotAttributeRequest {
 
 export namespace ModifySnapshotAttributeRequest {
   export function isa(o: any): o is ModifySnapshotAttributeRequest {
-    return _smithy.isa(o, "ModifySnapshotAttributeRequest");
+    return __isa(o, "ModifySnapshotAttributeRequest");
   }
 }
 
@@ -30656,7 +30608,7 @@ export interface ModifySpotFleetRequestRequest {
 
 export namespace ModifySpotFleetRequestRequest {
   export function isa(o: any): o is ModifySpotFleetRequestRequest {
-    return _smithy.isa(o, "ModifySpotFleetRequestRequest");
+    return __isa(o, "ModifySpotFleetRequestRequest");
   }
 }
 
@@ -30673,7 +30625,7 @@ export interface ModifySpotFleetRequestResponse extends $MetadataBearer {
 
 export namespace ModifySpotFleetRequestResponse {
   export function isa(o: any): o is ModifySpotFleetRequestResponse {
-    return _smithy.isa(o, "ModifySpotFleetRequestResponse");
+    return __isa(o, "ModifySpotFleetRequestResponse");
   }
 }
 
@@ -30704,7 +30656,7 @@ export interface ModifySubnetAttributeRequest {
 
 export namespace ModifySubnetAttributeRequest {
   export function isa(o: any): o is ModifySubnetAttributeRequest {
-    return _smithy.isa(o, "ModifySubnetAttributeRequest");
+    return __isa(o, "ModifySubnetAttributeRequest");
   }
 }
 
@@ -30737,7 +30689,7 @@ export namespace ModifyTrafficMirrorFilterNetworkServicesRequest {
   export function isa(
     o: any
   ): o is ModifyTrafficMirrorFilterNetworkServicesRequest {
-    return _smithy.isa(o, "ModifyTrafficMirrorFilterNetworkServicesRequest");
+    return __isa(o, "ModifyTrafficMirrorFilterNetworkServicesRequest");
   }
 }
 
@@ -30754,7 +30706,7 @@ export namespace ModifyTrafficMirrorFilterNetworkServicesResult {
   export function isa(
     o: any
   ): o is ModifyTrafficMirrorFilterNetworkServicesResult {
-    return _smithy.isa(o, "ModifyTrafficMirrorFilterNetworkServicesResult");
+    return __isa(o, "ModifyTrafficMirrorFilterNetworkServicesResult");
   }
 }
 
@@ -30827,7 +30779,7 @@ export interface ModifyTrafficMirrorFilterRuleRequest {
 
 export namespace ModifyTrafficMirrorFilterRuleRequest {
   export function isa(o: any): o is ModifyTrafficMirrorFilterRuleRequest {
-    return _smithy.isa(o, "ModifyTrafficMirrorFilterRuleRequest");
+    return __isa(o, "ModifyTrafficMirrorFilterRuleRequest");
   }
 }
 
@@ -30841,7 +30793,7 @@ export interface ModifyTrafficMirrorFilterRuleResult extends $MetadataBearer {
 
 export namespace ModifyTrafficMirrorFilterRuleResult {
   export function isa(o: any): o is ModifyTrafficMirrorFilterRuleResult {
-    return _smithy.isa(o, "ModifyTrafficMirrorFilterRuleResult");
+    return __isa(o, "ModifyTrafficMirrorFilterRuleResult");
   }
 }
 
@@ -30899,7 +30851,7 @@ export interface ModifyTrafficMirrorSessionRequest {
 
 export namespace ModifyTrafficMirrorSessionRequest {
   export function isa(o: any): o is ModifyTrafficMirrorSessionRequest {
-    return _smithy.isa(o, "ModifyTrafficMirrorSessionRequest");
+    return __isa(o, "ModifyTrafficMirrorSessionRequest");
   }
 }
 
@@ -30913,7 +30865,7 @@ export interface ModifyTrafficMirrorSessionResult extends $MetadataBearer {
 
 export namespace ModifyTrafficMirrorSessionResult {
   export function isa(o: any): o is ModifyTrafficMirrorSessionResult {
-    return _smithy.isa(o, "ModifyTrafficMirrorSessionResult");
+    return __isa(o, "ModifyTrafficMirrorSessionResult");
   }
 }
 
@@ -30952,7 +30904,7 @@ export interface ModifyTransitGatewayVpcAttachmentRequest {
 
 export namespace ModifyTransitGatewayVpcAttachmentRequest {
   export function isa(o: any): o is ModifyTransitGatewayVpcAttachmentRequest {
-    return _smithy.isa(o, "ModifyTransitGatewayVpcAttachmentRequest");
+    return __isa(o, "ModifyTransitGatewayVpcAttachmentRequest");
   }
 }
 
@@ -30976,7 +30928,7 @@ export namespace ModifyTransitGatewayVpcAttachmentRequestOptions {
   export function isa(
     o: any
   ): o is ModifyTransitGatewayVpcAttachmentRequestOptions {
-    return _smithy.isa(o, "ModifyTransitGatewayVpcAttachmentRequestOptions");
+    return __isa(o, "ModifyTransitGatewayVpcAttachmentRequestOptions");
   }
 }
 
@@ -30991,7 +30943,7 @@ export interface ModifyTransitGatewayVpcAttachmentResult
 
 export namespace ModifyTransitGatewayVpcAttachmentResult {
   export function isa(o: any): o is ModifyTransitGatewayVpcAttachmentResult {
-    return _smithy.isa(o, "ModifyTransitGatewayVpcAttachmentResult");
+    return __isa(o, "ModifyTransitGatewayVpcAttachmentResult");
   }
 }
 
@@ -31017,7 +30969,7 @@ export interface ModifyVolumeAttributeRequest {
 
 export namespace ModifyVolumeAttributeRequest {
   export function isa(o: any): o is ModifyVolumeAttributeRequest {
-    return _smithy.isa(o, "ModifyVolumeAttributeRequest");
+    return __isa(o, "ModifyVolumeAttributeRequest");
   }
 }
 
@@ -31062,7 +31014,7 @@ export interface ModifyVolumeRequest {
 
 export namespace ModifyVolumeRequest {
   export function isa(o: any): o is ModifyVolumeRequest {
-    return _smithy.isa(o, "ModifyVolumeRequest");
+    return __isa(o, "ModifyVolumeRequest");
   }
 }
 
@@ -31076,7 +31028,7 @@ export interface ModifyVolumeResult extends $MetadataBearer {
 
 export namespace ModifyVolumeResult {
   export function isa(o: any): o is ModifyVolumeResult {
-    return _smithy.isa(o, "ModifyVolumeResult");
+    return __isa(o, "ModifyVolumeResult");
   }
 }
 
@@ -31106,7 +31058,7 @@ export interface ModifyVpcAttributeRequest {
 
 export namespace ModifyVpcAttributeRequest {
   export function isa(o: any): o is ModifyVpcAttributeRequest {
-    return _smithy.isa(o, "ModifyVpcAttributeRequest");
+    return __isa(o, "ModifyVpcAttributeRequest");
   }
 }
 
@@ -31140,7 +31092,7 @@ export namespace ModifyVpcEndpointConnectionNotificationRequest {
   export function isa(
     o: any
   ): o is ModifyVpcEndpointConnectionNotificationRequest {
-    return _smithy.isa(o, "ModifyVpcEndpointConnectionNotificationRequest");
+    return __isa(o, "ModifyVpcEndpointConnectionNotificationRequest");
   }
 }
 
@@ -31157,7 +31109,7 @@ export namespace ModifyVpcEndpointConnectionNotificationResult {
   export function isa(
     o: any
   ): o is ModifyVpcEndpointConnectionNotificationResult {
-    return _smithy.isa(o, "ModifyVpcEndpointConnectionNotificationResult");
+    return __isa(o, "ModifyVpcEndpointConnectionNotificationResult");
   }
 }
 
@@ -31229,7 +31181,7 @@ export interface ModifyVpcEndpointRequest {
 
 export namespace ModifyVpcEndpointRequest {
   export function isa(o: any): o is ModifyVpcEndpointRequest {
-    return _smithy.isa(o, "ModifyVpcEndpointRequest");
+    return __isa(o, "ModifyVpcEndpointRequest");
   }
 }
 
@@ -31243,7 +31195,7 @@ export interface ModifyVpcEndpointResult extends $MetadataBearer {
 
 export namespace ModifyVpcEndpointResult {
   export function isa(o: any): o is ModifyVpcEndpointResult {
-    return _smithy.isa(o, "ModifyVpcEndpointResult");
+    return __isa(o, "ModifyVpcEndpointResult");
   }
 }
 
@@ -31293,7 +31245,7 @@ export namespace ModifyVpcEndpointServiceConfigurationRequest {
   export function isa(
     o: any
   ): o is ModifyVpcEndpointServiceConfigurationRequest {
-    return _smithy.isa(o, "ModifyVpcEndpointServiceConfigurationRequest");
+    return __isa(o, "ModifyVpcEndpointServiceConfigurationRequest");
   }
 }
 
@@ -31310,7 +31262,7 @@ export namespace ModifyVpcEndpointServiceConfigurationResult {
   export function isa(
     o: any
   ): o is ModifyVpcEndpointServiceConfigurationResult {
-    return _smithy.isa(o, "ModifyVpcEndpointServiceConfigurationResult");
+    return __isa(o, "ModifyVpcEndpointServiceConfigurationResult");
   }
 }
 
@@ -31344,7 +31296,7 @@ export interface ModifyVpcEndpointServicePermissionsRequest {
 
 export namespace ModifyVpcEndpointServicePermissionsRequest {
   export function isa(o: any): o is ModifyVpcEndpointServicePermissionsRequest {
-    return _smithy.isa(o, "ModifyVpcEndpointServicePermissionsRequest");
+    return __isa(o, "ModifyVpcEndpointServicePermissionsRequest");
   }
 }
 
@@ -31359,7 +31311,7 @@ export interface ModifyVpcEndpointServicePermissionsResult
 
 export namespace ModifyVpcEndpointServicePermissionsResult {
   export function isa(o: any): o is ModifyVpcEndpointServicePermissionsResult {
-    return _smithy.isa(o, "ModifyVpcEndpointServicePermissionsResult");
+    return __isa(o, "ModifyVpcEndpointServicePermissionsResult");
   }
 }
 
@@ -31390,7 +31342,7 @@ export interface ModifyVpcPeeringConnectionOptionsRequest {
 
 export namespace ModifyVpcPeeringConnectionOptionsRequest {
   export function isa(o: any): o is ModifyVpcPeeringConnectionOptionsRequest {
-    return _smithy.isa(o, "ModifyVpcPeeringConnectionOptionsRequest");
+    return __isa(o, "ModifyVpcPeeringConnectionOptionsRequest");
   }
 }
 
@@ -31410,7 +31362,7 @@ export interface ModifyVpcPeeringConnectionOptionsResult
 
 export namespace ModifyVpcPeeringConnectionOptionsResult {
   export function isa(o: any): o is ModifyVpcPeeringConnectionOptionsResult {
-    return _smithy.isa(o, "ModifyVpcPeeringConnectionOptionsResult");
+    return __isa(o, "ModifyVpcPeeringConnectionOptionsResult");
   }
 }
 
@@ -31436,7 +31388,7 @@ export interface ModifyVpcTenancyRequest {
 
 export namespace ModifyVpcTenancyRequest {
   export function isa(o: any): o is ModifyVpcTenancyRequest {
-    return _smithy.isa(o, "ModifyVpcTenancyRequest");
+    return __isa(o, "ModifyVpcTenancyRequest");
   }
 }
 
@@ -31451,7 +31403,7 @@ export interface ModifyVpcTenancyResult extends $MetadataBearer {
 
 export namespace ModifyVpcTenancyResult {
   export function isa(o: any): o is ModifyVpcTenancyResult {
-    return _smithy.isa(o, "ModifyVpcTenancyResult");
+    return __isa(o, "ModifyVpcTenancyResult");
   }
 }
 
@@ -31487,7 +31439,7 @@ export interface ModifyVpnConnectionRequest {
 
 export namespace ModifyVpnConnectionRequest {
   export function isa(o: any): o is ModifyVpnConnectionRequest {
-    return _smithy.isa(o, "ModifyVpnConnectionRequest");
+    return __isa(o, "ModifyVpnConnectionRequest");
   }
 }
 
@@ -31501,7 +31453,7 @@ export interface ModifyVpnConnectionResult extends $MetadataBearer {
 
 export namespace ModifyVpnConnectionResult {
   export function isa(o: any): o is ModifyVpnConnectionResult {
-    return _smithy.isa(o, "ModifyVpnConnectionResult");
+    return __isa(o, "ModifyVpnConnectionResult");
   }
 }
 
@@ -31527,7 +31479,7 @@ export interface ModifyVpnTunnelCertificateRequest {
 
 export namespace ModifyVpnTunnelCertificateRequest {
   export function isa(o: any): o is ModifyVpnTunnelCertificateRequest {
-    return _smithy.isa(o, "ModifyVpnTunnelCertificateRequest");
+    return __isa(o, "ModifyVpnTunnelCertificateRequest");
   }
 }
 
@@ -31541,7 +31493,7 @@ export interface ModifyVpnTunnelCertificateResult extends $MetadataBearer {
 
 export namespace ModifyVpnTunnelCertificateResult {
   export function isa(o: any): o is ModifyVpnTunnelCertificateResult {
-    return _smithy.isa(o, "ModifyVpnTunnelCertificateResult");
+    return __isa(o, "ModifyVpnTunnelCertificateResult");
   }
 }
 
@@ -31572,7 +31524,7 @@ export interface ModifyVpnTunnelOptionsRequest {
 
 export namespace ModifyVpnTunnelOptionsRequest {
   export function isa(o: any): o is ModifyVpnTunnelOptionsRequest {
-    return _smithy.isa(o, "ModifyVpnTunnelOptionsRequest");
+    return __isa(o, "ModifyVpnTunnelOptionsRequest");
   }
 }
 
@@ -31586,7 +31538,7 @@ export interface ModifyVpnTunnelOptionsResult extends $MetadataBearer {
 
 export namespace ModifyVpnTunnelOptionsResult {
   export function isa(o: any): o is ModifyVpnTunnelOptionsResult {
-    return _smithy.isa(o, "ModifyVpnTunnelOptionsResult");
+    return __isa(o, "ModifyVpnTunnelOptionsResult");
   }
 }
 
@@ -31753,7 +31705,7 @@ export interface ModifyVpnTunnelOptionsSpecification {
 
 export namespace ModifyVpnTunnelOptionsSpecification {
   export function isa(o: any): o is ModifyVpnTunnelOptionsSpecification {
-    return _smithy.isa(o, "ModifyVpnTunnelOptionsSpecification");
+    return __isa(o, "ModifyVpnTunnelOptionsSpecification");
   }
 }
 
@@ -31774,7 +31726,7 @@ export interface MonitorInstancesRequest {
 
 export namespace MonitorInstancesRequest {
   export function isa(o: any): o is MonitorInstancesRequest {
-    return _smithy.isa(o, "MonitorInstancesRequest");
+    return __isa(o, "MonitorInstancesRequest");
   }
 }
 
@@ -31788,7 +31740,7 @@ export interface MonitorInstancesResult extends $MetadataBearer {
 
 export namespace MonitorInstancesResult {
   export function isa(o: any): o is MonitorInstancesResult {
-    return _smithy.isa(o, "MonitorInstancesResult");
+    return __isa(o, "MonitorInstancesResult");
   }
 }
 
@@ -31806,7 +31758,7 @@ export interface Monitoring {
 
 export namespace Monitoring {
   export function isa(o: any): o is Monitoring {
-    return _smithy.isa(o, "Monitoring");
+    return __isa(o, "Monitoring");
   }
 }
 
@@ -31829,7 +31781,7 @@ export interface MoveAddressToVpcRequest {
 
 export namespace MoveAddressToVpcRequest {
   export function isa(o: any): o is MoveAddressToVpcRequest {
-    return _smithy.isa(o, "MoveAddressToVpcRequest");
+    return __isa(o, "MoveAddressToVpcRequest");
   }
 }
 
@@ -31848,7 +31800,7 @@ export interface MoveAddressToVpcResult extends $MetadataBearer {
 
 export namespace MoveAddressToVpcResult {
   export function isa(o: any): o is MoveAddressToVpcResult {
-    return _smithy.isa(o, "MoveAddressToVpcResult");
+    return __isa(o, "MoveAddressToVpcResult");
   }
 }
 
@@ -31872,7 +31824,7 @@ export interface MovingAddressStatus {
 
 export namespace MovingAddressStatus {
   export function isa(o: any): o is MovingAddressStatus {
-    return _smithy.isa(o, "MovingAddressStatus");
+    return __isa(o, "MovingAddressStatus");
   }
 }
 
@@ -31991,7 +31943,7 @@ export interface NatGateway {
 
 export namespace NatGateway {
   export function isa(o: any): o is NatGateway {
-    return _smithy.isa(o, "NatGateway");
+    return __isa(o, "NatGateway");
   }
 }
 
@@ -32023,7 +31975,7 @@ export interface NatGatewayAddress {
 
 export namespace NatGatewayAddress {
   export function isa(o: any): o is NatGatewayAddress {
-    return _smithy.isa(o, "NatGatewayAddress");
+    return __isa(o, "NatGatewayAddress");
   }
 }
 
@@ -32078,7 +32030,7 @@ export interface NetworkAcl {
 
 export namespace NetworkAcl {
   export function isa(o: any): o is NetworkAcl {
-    return _smithy.isa(o, "NetworkAcl");
+    return __isa(o, "NetworkAcl");
   }
 }
 
@@ -32105,7 +32057,7 @@ export interface NetworkAclAssociation {
 
 export namespace NetworkAclAssociation {
   export function isa(o: any): o is NetworkAclAssociation {
-    return _smithy.isa(o, "NetworkAclAssociation");
+    return __isa(o, "NetworkAclAssociation");
   }
 }
 
@@ -32157,7 +32109,7 @@ export interface NetworkAclEntry {
 
 export namespace NetworkAclEntry {
   export function isa(o: any): o is NetworkAclEntry {
-    return _smithy.isa(o, "NetworkAclEntry");
+    return __isa(o, "NetworkAclEntry");
   }
 }
 
@@ -32199,7 +32151,7 @@ export interface NetworkInfo {
 
 export namespace NetworkInfo {
   export function isa(o: any): o is NetworkInfo {
-    return _smithy.isa(o, "NetworkInfo");
+    return __isa(o, "NetworkInfo");
   }
 }
 
@@ -32316,7 +32268,7 @@ export interface NetworkInterface {
 
 export namespace NetworkInterface {
   export function isa(o: any): o is NetworkInterface {
-    return _smithy.isa(o, "NetworkInterface");
+    return __isa(o, "NetworkInterface");
   }
 }
 
@@ -32353,7 +32305,7 @@ export interface NetworkInterfaceAssociation {
 
 export namespace NetworkInterfaceAssociation {
   export function isa(o: any): o is NetworkInterfaceAssociation {
-    return _smithy.isa(o, "NetworkInterfaceAssociation");
+    return __isa(o, "NetworkInterfaceAssociation");
   }
 }
 
@@ -32400,7 +32352,7 @@ export interface NetworkInterfaceAttachment {
 
 export namespace NetworkInterfaceAttachment {
   export function isa(o: any): o is NetworkInterfaceAttachment {
-    return _smithy.isa(o, "NetworkInterfaceAttachment");
+    return __isa(o, "NetworkInterfaceAttachment");
   }
 }
 
@@ -32422,7 +32374,7 @@ export interface NetworkInterfaceAttachmentChanges {
 
 export namespace NetworkInterfaceAttachmentChanges {
   export function isa(o: any): o is NetworkInterfaceAttachmentChanges {
-    return _smithy.isa(o, "NetworkInterfaceAttachmentChanges");
+    return __isa(o, "NetworkInterfaceAttachmentChanges");
   }
 }
 
@@ -32447,7 +32399,7 @@ export interface NetworkInterfaceIpv6Address {
 
 export namespace NetworkInterfaceIpv6Address {
   export function isa(o: any): o is NetworkInterfaceIpv6Address {
-    return _smithy.isa(o, "NetworkInterfaceIpv6Address");
+    return __isa(o, "NetworkInterfaceIpv6Address");
   }
 }
 
@@ -32489,7 +32441,7 @@ export interface NetworkInterfacePermission {
 
 export namespace NetworkInterfacePermission {
   export function isa(o: any): o is NetworkInterfacePermission {
-    return _smithy.isa(o, "NetworkInterfacePermission");
+    return __isa(o, "NetworkInterfacePermission");
   }
 }
 
@@ -32511,7 +32463,7 @@ export interface NetworkInterfacePermissionState {
 
 export namespace NetworkInterfacePermissionState {
   export function isa(o: any): o is NetworkInterfacePermissionState {
-    return _smithy.isa(o, "NetworkInterfacePermissionState");
+    return __isa(o, "NetworkInterfacePermissionState");
   }
 }
 
@@ -32549,7 +32501,7 @@ export interface NetworkInterfacePrivateIpAddress {
 
 export namespace NetworkInterfacePrivateIpAddress {
   export function isa(o: any): o is NetworkInterfacePrivateIpAddress {
-    return _smithy.isa(o, "NetworkInterfacePrivateIpAddress");
+    return __isa(o, "NetworkInterfacePrivateIpAddress");
   }
 }
 
@@ -32580,7 +32532,7 @@ export interface NewDhcpConfiguration {
 
 export namespace NewDhcpConfiguration {
   export function isa(o: any): o is NewDhcpConfiguration {
-    return _smithy.isa(o, "NewDhcpConfiguration");
+    return __isa(o, "NewDhcpConfiguration");
   }
 }
 
@@ -32648,7 +32600,7 @@ export interface OnDemandOptions {
 
 export namespace OnDemandOptions {
   export function isa(o: any): o is OnDemandOptions {
-    return _smithy.isa(o, "OnDemandOptions");
+    return __isa(o, "OnDemandOptions");
   }
 }
 
@@ -32698,7 +32650,7 @@ export interface OnDemandOptionsRequest {
 
 export namespace OnDemandOptionsRequest {
   export function isa(o: any): o is OnDemandOptionsRequest {
-    return _smithy.isa(o, "OnDemandOptionsRequest");
+    return __isa(o, "OnDemandOptionsRequest");
   }
 }
 
@@ -32738,7 +32690,7 @@ export interface PciId {
 
 export namespace PciId {
   export function isa(o: any): o is PciId {
-    return _smithy.isa(o, "PciId");
+    return __isa(o, "PciId");
   }
 }
 
@@ -32760,7 +32712,7 @@ export interface PeeringAttachmentStatus {
 
 export namespace PeeringAttachmentStatus {
   export function isa(o: any): o is PeeringAttachmentStatus {
-    return _smithy.isa(o, "PeeringAttachmentStatus");
+    return __isa(o, "PeeringAttachmentStatus");
   }
 }
 
@@ -32790,7 +32742,7 @@ export interface PeeringConnectionOptions {
 
 export namespace PeeringConnectionOptions {
   export function isa(o: any): o is PeeringConnectionOptions {
-    return _smithy.isa(o, "PeeringConnectionOptions");
+    return __isa(o, "PeeringConnectionOptions");
   }
 }
 
@@ -32819,7 +32771,7 @@ export interface PeeringConnectionOptionsRequest {
 
 export namespace PeeringConnectionOptionsRequest {
   export function isa(o: any): o is PeeringConnectionOptionsRequest {
-    return _smithy.isa(o, "PeeringConnectionOptionsRequest");
+    return __isa(o, "PeeringConnectionOptionsRequest");
   }
 }
 
@@ -32846,7 +32798,7 @@ export interface PeeringTgwInfo {
 
 export namespace PeeringTgwInfo {
   export function isa(o: any): o is PeeringTgwInfo {
-    return _smithy.isa(o, "PeeringTgwInfo");
+    return __isa(o, "PeeringTgwInfo");
   }
 }
 
@@ -32865,7 +32817,7 @@ export interface Phase1DHGroupNumbersListValue {
 
 export namespace Phase1DHGroupNumbersListValue {
   export function isa(o: any): o is Phase1DHGroupNumbersListValue {
-    return _smithy.isa(o, "Phase1DHGroupNumbersListValue");
+    return __isa(o, "Phase1DHGroupNumbersListValue");
   }
 }
 
@@ -32882,7 +32834,7 @@ export interface Phase1DHGroupNumbersRequestListValue {
 
 export namespace Phase1DHGroupNumbersRequestListValue {
   export function isa(o: any): o is Phase1DHGroupNumbersRequestListValue {
-    return _smithy.isa(o, "Phase1DHGroupNumbersRequestListValue");
+    return __isa(o, "Phase1DHGroupNumbersRequestListValue");
   }
 }
 
@@ -32899,7 +32851,7 @@ export interface Phase1EncryptionAlgorithmsListValue {
 
 export namespace Phase1EncryptionAlgorithmsListValue {
   export function isa(o: any): o is Phase1EncryptionAlgorithmsListValue {
-    return _smithy.isa(o, "Phase1EncryptionAlgorithmsListValue");
+    return __isa(o, "Phase1EncryptionAlgorithmsListValue");
   }
 }
 
@@ -32916,7 +32868,7 @@ export interface Phase1EncryptionAlgorithmsRequestListValue {
 
 export namespace Phase1EncryptionAlgorithmsRequestListValue {
   export function isa(o: any): o is Phase1EncryptionAlgorithmsRequestListValue {
-    return _smithy.isa(o, "Phase1EncryptionAlgorithmsRequestListValue");
+    return __isa(o, "Phase1EncryptionAlgorithmsRequestListValue");
   }
 }
 
@@ -32933,7 +32885,7 @@ export interface Phase1IntegrityAlgorithmsListValue {
 
 export namespace Phase1IntegrityAlgorithmsListValue {
   export function isa(o: any): o is Phase1IntegrityAlgorithmsListValue {
-    return _smithy.isa(o, "Phase1IntegrityAlgorithmsListValue");
+    return __isa(o, "Phase1IntegrityAlgorithmsListValue");
   }
 }
 
@@ -32950,7 +32902,7 @@ export interface Phase1IntegrityAlgorithmsRequestListValue {
 
 export namespace Phase1IntegrityAlgorithmsRequestListValue {
   export function isa(o: any): o is Phase1IntegrityAlgorithmsRequestListValue {
-    return _smithy.isa(o, "Phase1IntegrityAlgorithmsRequestListValue");
+    return __isa(o, "Phase1IntegrityAlgorithmsRequestListValue");
   }
 }
 
@@ -32967,7 +32919,7 @@ export interface Phase2DHGroupNumbersListValue {
 
 export namespace Phase2DHGroupNumbersListValue {
   export function isa(o: any): o is Phase2DHGroupNumbersListValue {
-    return _smithy.isa(o, "Phase2DHGroupNumbersListValue");
+    return __isa(o, "Phase2DHGroupNumbersListValue");
   }
 }
 
@@ -32984,7 +32936,7 @@ export interface Phase2DHGroupNumbersRequestListValue {
 
 export namespace Phase2DHGroupNumbersRequestListValue {
   export function isa(o: any): o is Phase2DHGroupNumbersRequestListValue {
-    return _smithy.isa(o, "Phase2DHGroupNumbersRequestListValue");
+    return __isa(o, "Phase2DHGroupNumbersRequestListValue");
   }
 }
 
@@ -33001,7 +32953,7 @@ export interface Phase2EncryptionAlgorithmsListValue {
 
 export namespace Phase2EncryptionAlgorithmsListValue {
   export function isa(o: any): o is Phase2EncryptionAlgorithmsListValue {
-    return _smithy.isa(o, "Phase2EncryptionAlgorithmsListValue");
+    return __isa(o, "Phase2EncryptionAlgorithmsListValue");
   }
 }
 
@@ -33018,7 +32970,7 @@ export interface Phase2EncryptionAlgorithmsRequestListValue {
 
 export namespace Phase2EncryptionAlgorithmsRequestListValue {
   export function isa(o: any): o is Phase2EncryptionAlgorithmsRequestListValue {
-    return _smithy.isa(o, "Phase2EncryptionAlgorithmsRequestListValue");
+    return __isa(o, "Phase2EncryptionAlgorithmsRequestListValue");
   }
 }
 
@@ -33035,7 +32987,7 @@ export interface Phase2IntegrityAlgorithmsListValue {
 
 export namespace Phase2IntegrityAlgorithmsListValue {
   export function isa(o: any): o is Phase2IntegrityAlgorithmsListValue {
-    return _smithy.isa(o, "Phase2IntegrityAlgorithmsListValue");
+    return __isa(o, "Phase2IntegrityAlgorithmsListValue");
   }
 }
 
@@ -33052,7 +33004,7 @@ export interface Phase2IntegrityAlgorithmsRequestListValue {
 
 export namespace Phase2IntegrityAlgorithmsRequestListValue {
   export function isa(o: any): o is Phase2IntegrityAlgorithmsRequestListValue {
-    return _smithy.isa(o, "Phase2IntegrityAlgorithmsRequestListValue");
+    return __isa(o, "Phase2IntegrityAlgorithmsRequestListValue");
   }
 }
 
@@ -33113,7 +33065,7 @@ export interface Placement {
 
 export namespace Placement {
   export function isa(o: any): o is Placement {
-    return _smithy.isa(o, "Placement");
+    return __isa(o, "Placement");
   }
 }
 
@@ -33156,7 +33108,7 @@ export interface PlacementGroup {
 
 export namespace PlacementGroup {
   export function isa(o: any): o is PlacementGroup {
-    return _smithy.isa(o, "PlacementGroup");
+    return __isa(o, "PlacementGroup");
   }
 }
 
@@ -33173,7 +33125,7 @@ export interface PlacementGroupInfo {
 
 export namespace PlacementGroupInfo {
   export function isa(o: any): o is PlacementGroupInfo {
-    return _smithy.isa(o, "PlacementGroupInfo");
+    return __isa(o, "PlacementGroupInfo");
   }
 }
 
@@ -33198,7 +33150,7 @@ export interface PlacementResponse {
 
 export namespace PlacementResponse {
   export function isa(o: any): o is PlacementResponse {
-    return _smithy.isa(o, "PlacementResponse");
+    return __isa(o, "PlacementResponse");
   }
 }
 
@@ -33219,7 +33171,7 @@ export interface PoolCidrBlock {
 
 export namespace PoolCidrBlock {
   export function isa(o: any): o is PoolCidrBlock {
-    return _smithy.isa(o, "PoolCidrBlock");
+    return __isa(o, "PoolCidrBlock");
   }
 }
 
@@ -33241,7 +33193,7 @@ export interface PortRange {
 
 export namespace PortRange {
   export function isa(o: any): o is PortRange {
-    return _smithy.isa(o, "PortRange");
+    return __isa(o, "PortRange");
   }
 }
 
@@ -33268,7 +33220,7 @@ export interface PrefixList {
 
 export namespace PrefixList {
   export function isa(o: any): o is PrefixList {
-    return _smithy.isa(o, "PrefixList");
+    return __isa(o, "PrefixList");
   }
 }
 
@@ -33292,7 +33244,7 @@ export interface PrefixListId {
 
 export namespace PrefixListId {
   export function isa(o: any): o is PrefixListId {
-    return _smithy.isa(o, "PrefixListId");
+    return __isa(o, "PrefixListId");
   }
 }
 
@@ -33326,7 +33278,7 @@ export interface PriceSchedule {
 
 export namespace PriceSchedule {
   export function isa(o: any): o is PriceSchedule {
-    return _smithy.isa(o, "PriceSchedule");
+    return __isa(o, "PriceSchedule");
   }
 }
 
@@ -33354,7 +33306,7 @@ export interface PriceScheduleSpecification {
 
 export namespace PriceScheduleSpecification {
   export function isa(o: any): o is PriceScheduleSpecification {
-    return _smithy.isa(o, "PriceScheduleSpecification");
+    return __isa(o, "PriceScheduleSpecification");
   }
 }
 
@@ -33376,7 +33328,7 @@ export interface PricingDetail {
 
 export namespace PricingDetail {
   export function isa(o: any): o is PricingDetail {
-    return _smithy.isa(o, "PricingDetail");
+    return __isa(o, "PricingDetail");
   }
 }
 
@@ -33398,7 +33350,7 @@ export interface PrincipalIdFormat {
 
 export namespace PrincipalIdFormat {
   export function isa(o: any): o is PrincipalIdFormat {
-    return _smithy.isa(o, "PrincipalIdFormat");
+    return __isa(o, "PrincipalIdFormat");
   }
 }
 
@@ -33445,7 +33397,7 @@ export interface PrivateDnsNameConfiguration {
 
 export namespace PrivateDnsNameConfiguration {
   export function isa(o: any): o is PrivateDnsNameConfiguration {
-    return _smithy.isa(o, "PrivateDnsNameConfiguration");
+    return __isa(o, "PrivateDnsNameConfiguration");
   }
 }
 
@@ -33468,7 +33420,7 @@ export interface PrivateIpAddressSpecification {
 
 export namespace PrivateIpAddressSpecification {
   export function isa(o: any): o is PrivateIpAddressSpecification {
-    return _smithy.isa(o, "PrivateIpAddressSpecification");
+    return __isa(o, "PrivateIpAddressSpecification");
   }
 }
 
@@ -33490,7 +33442,7 @@ export interface ProcessorInfo {
 
 export namespace ProcessorInfo {
   export function isa(o: any): o is ProcessorInfo {
-    return _smithy.isa(o, "ProcessorInfo");
+    return __isa(o, "ProcessorInfo");
   }
 }
 
@@ -33512,7 +33464,7 @@ export interface ProductCode {
 
 export namespace ProductCode {
   export function isa(o: any): o is ProductCode {
-    return _smithy.isa(o, "ProductCode");
+    return __isa(o, "ProductCode");
   }
 }
 
@@ -33531,7 +33483,7 @@ export interface PropagatingVgw {
 
 export namespace PropagatingVgw {
   export function isa(o: any): o is PropagatingVgw {
-    return _smithy.isa(o, "PropagatingVgw");
+    return __isa(o, "PropagatingVgw");
   }
 }
 
@@ -33572,7 +33524,7 @@ export interface ProvisionByoipCidrRequest {
 
 export namespace ProvisionByoipCidrRequest {
   export function isa(o: any): o is ProvisionByoipCidrRequest {
-    return _smithy.isa(o, "ProvisionByoipCidrRequest");
+    return __isa(o, "ProvisionByoipCidrRequest");
   }
 }
 
@@ -33586,7 +33538,7 @@ export interface ProvisionByoipCidrResult extends $MetadataBearer {
 
 export namespace ProvisionByoipCidrResult {
   export function isa(o: any): o is ProvisionByoipCidrResult {
-    return _smithy.isa(o, "ProvisionByoipCidrResult");
+    return __isa(o, "ProvisionByoipCidrResult");
   }
 }
 
@@ -33623,7 +33575,7 @@ export interface ProvisionedBandwidth {
 
 export namespace ProvisionedBandwidth {
   export function isa(o: any): o is ProvisionedBandwidth {
-    return _smithy.isa(o, "ProvisionedBandwidth");
+    return __isa(o, "ProvisionedBandwidth");
   }
 }
 
@@ -33660,7 +33612,7 @@ export interface PublicIpv4Pool {
 
 export namespace PublicIpv4Pool {
   export function isa(o: any): o is PublicIpv4Pool {
-    return _smithy.isa(o, "PublicIpv4Pool");
+    return __isa(o, "PublicIpv4Pool");
   }
 }
 
@@ -33692,7 +33644,7 @@ export interface PublicIpv4PoolRange {
 
 export namespace PublicIpv4PoolRange {
   export function isa(o: any): o is PublicIpv4PoolRange {
-    return _smithy.isa(o, "PublicIpv4PoolRange");
+    return __isa(o, "PublicIpv4PoolRange");
   }
 }
 
@@ -33747,7 +33699,7 @@ export interface Purchase {
 
 export namespace Purchase {
   export function isa(o: any): o is Purchase {
-    return _smithy.isa(o, "Purchase");
+    return __isa(o, "Purchase");
   }
 }
 
@@ -33788,7 +33740,7 @@ export interface PurchaseHostReservationRequest {
 
 export namespace PurchaseHostReservationRequest {
   export function isa(o: any): o is PurchaseHostReservationRequest {
-    return _smithy.isa(o, "PurchaseHostReservationRequest");
+    return __isa(o, "PurchaseHostReservationRequest");
   }
 }
 
@@ -33824,7 +33776,7 @@ export interface PurchaseHostReservationResult extends $MetadataBearer {
 
 export namespace PurchaseHostReservationResult {
   export function isa(o: any): o is PurchaseHostReservationResult {
-    return _smithy.isa(o, "PurchaseHostReservationResult");
+    return __isa(o, "PurchaseHostReservationResult");
   }
 }
 
@@ -33846,7 +33798,7 @@ export interface PurchaseRequest {
 
 export namespace PurchaseRequest {
   export function isa(o: any): o is PurchaseRequest {
-    return _smithy.isa(o, "PurchaseRequest");
+    return __isa(o, "PurchaseRequest");
   }
 }
 
@@ -33885,7 +33837,7 @@ export interface PurchaseReservedInstancesOfferingRequest {
 
 export namespace PurchaseReservedInstancesOfferingRequest {
   export function isa(o: any): o is PurchaseReservedInstancesOfferingRequest {
-    return _smithy.isa(o, "PurchaseReservedInstancesOfferingRequest");
+    return __isa(o, "PurchaseReservedInstancesOfferingRequest");
   }
 }
 
@@ -33903,7 +33855,7 @@ export interface PurchaseReservedInstancesOfferingResult
 
 export namespace PurchaseReservedInstancesOfferingResult {
   export function isa(o: any): o is PurchaseReservedInstancesOfferingResult {
-    return _smithy.isa(o, "PurchaseReservedInstancesOfferingResult");
+    return __isa(o, "PurchaseReservedInstancesOfferingResult");
   }
 }
 
@@ -33933,7 +33885,7 @@ export interface PurchaseScheduledInstancesRequest {
 
 export namespace PurchaseScheduledInstancesRequest {
   export function isa(o: any): o is PurchaseScheduledInstancesRequest {
-    return _smithy.isa(o, "PurchaseScheduledInstancesRequest");
+    return __isa(o, "PurchaseScheduledInstancesRequest");
   }
 }
 
@@ -33950,7 +33902,7 @@ export interface PurchaseScheduledInstancesResult extends $MetadataBearer {
 
 export namespace PurchaseScheduledInstancesResult {
   export function isa(o: any): o is PurchaseScheduledInstancesResult {
-    return _smithy.isa(o, "PurchaseScheduledInstancesResult");
+    return __isa(o, "PurchaseScheduledInstancesResult");
   }
 }
 
@@ -33977,7 +33929,7 @@ export interface RebootInstancesRequest {
 
 export namespace RebootInstancesRequest {
   export function isa(o: any): o is RebootInstancesRequest {
-    return _smithy.isa(o, "RebootInstancesRequest");
+    return __isa(o, "RebootInstancesRequest");
   }
 }
 
@@ -33999,7 +33951,7 @@ export interface RecurringCharge {
 
 export namespace RecurringCharge {
   export function isa(o: any): o is RecurringCharge {
-    return _smithy.isa(o, "RecurringCharge");
+    return __isa(o, "RecurringCharge");
   }
 }
 
@@ -34029,7 +33981,7 @@ export interface Region {
 
 export namespace Region {
   export function isa(o: any): o is Region {
-    return _smithy.isa(o, "Region");
+    return __isa(o, "Region");
   }
 }
 
@@ -34120,7 +34072,7 @@ export interface RegisterImageRequest {
 
 export namespace RegisterImageRequest {
   export function isa(o: any): o is RegisterImageRequest {
-    return _smithy.isa(o, "RegisterImageRequest");
+    return __isa(o, "RegisterImageRequest");
   }
 }
 
@@ -34137,7 +34089,7 @@ export interface RegisterImageResult extends $MetadataBearer {
 
 export namespace RegisterImageResult {
   export function isa(o: any): o is RegisterImageResult {
-    return _smithy.isa(o, "RegisterImageResult");
+    return __isa(o, "RegisterImageResult");
   }
 }
 
@@ -34170,7 +34122,7 @@ export namespace RegisterTransitGatewayMulticastGroupMembersRequest {
   export function isa(
     o: any
   ): o is RegisterTransitGatewayMulticastGroupMembersRequest {
-    return _smithy.isa(o, "RegisterTransitGatewayMulticastGroupMembersRequest");
+    return __isa(o, "RegisterTransitGatewayMulticastGroupMembersRequest");
   }
 }
 
@@ -34187,7 +34139,7 @@ export namespace RegisterTransitGatewayMulticastGroupMembersResult {
   export function isa(
     o: any
   ): o is RegisterTransitGatewayMulticastGroupMembersResult {
-    return _smithy.isa(o, "RegisterTransitGatewayMulticastGroupMembersResult");
+    return __isa(o, "RegisterTransitGatewayMulticastGroupMembersResult");
   }
 }
 
@@ -34220,7 +34172,7 @@ export namespace RegisterTransitGatewayMulticastGroupSourcesRequest {
   export function isa(
     o: any
   ): o is RegisterTransitGatewayMulticastGroupSourcesRequest {
-    return _smithy.isa(o, "RegisterTransitGatewayMulticastGroupSourcesRequest");
+    return __isa(o, "RegisterTransitGatewayMulticastGroupSourcesRequest");
   }
 }
 
@@ -34237,7 +34189,7 @@ export namespace RegisterTransitGatewayMulticastGroupSourcesResult {
   export function isa(
     o: any
   ): o is RegisterTransitGatewayMulticastGroupSourcesResult {
-    return _smithy.isa(o, "RegisterTransitGatewayMulticastGroupSourcesResult");
+    return __isa(o, "RegisterTransitGatewayMulticastGroupSourcesResult");
   }
 }
 
@@ -34260,7 +34212,7 @@ export namespace RejectTransitGatewayPeeringAttachmentRequest {
   export function isa(
     o: any
   ): o is RejectTransitGatewayPeeringAttachmentRequest {
-    return _smithy.isa(o, "RejectTransitGatewayPeeringAttachmentRequest");
+    return __isa(o, "RejectTransitGatewayPeeringAttachmentRequest");
   }
 }
 
@@ -34277,7 +34229,7 @@ export namespace RejectTransitGatewayPeeringAttachmentResult {
   export function isa(
     o: any
   ): o is RejectTransitGatewayPeeringAttachmentResult {
-    return _smithy.isa(o, "RejectTransitGatewayPeeringAttachmentResult");
+    return __isa(o, "RejectTransitGatewayPeeringAttachmentResult");
   }
 }
 
@@ -34298,7 +34250,7 @@ export interface RejectTransitGatewayVpcAttachmentRequest {
 
 export namespace RejectTransitGatewayVpcAttachmentRequest {
   export function isa(o: any): o is RejectTransitGatewayVpcAttachmentRequest {
-    return _smithy.isa(o, "RejectTransitGatewayVpcAttachmentRequest");
+    return __isa(o, "RejectTransitGatewayVpcAttachmentRequest");
   }
 }
 
@@ -34313,7 +34265,7 @@ export interface RejectTransitGatewayVpcAttachmentResult
 
 export namespace RejectTransitGatewayVpcAttachmentResult {
   export function isa(o: any): o is RejectTransitGatewayVpcAttachmentResult {
-    return _smithy.isa(o, "RejectTransitGatewayVpcAttachmentResult");
+    return __isa(o, "RejectTransitGatewayVpcAttachmentResult");
   }
 }
 
@@ -34339,7 +34291,7 @@ export interface RejectVpcEndpointConnectionsRequest {
 
 export namespace RejectVpcEndpointConnectionsRequest {
   export function isa(o: any): o is RejectVpcEndpointConnectionsRequest {
-    return _smithy.isa(o, "RejectVpcEndpointConnectionsRequest");
+    return __isa(o, "RejectVpcEndpointConnectionsRequest");
   }
 }
 
@@ -34353,7 +34305,7 @@ export interface RejectVpcEndpointConnectionsResult extends $MetadataBearer {
 
 export namespace RejectVpcEndpointConnectionsResult {
   export function isa(o: any): o is RejectVpcEndpointConnectionsResult {
-    return _smithy.isa(o, "RejectVpcEndpointConnectionsResult");
+    return __isa(o, "RejectVpcEndpointConnectionsResult");
   }
 }
 
@@ -34374,7 +34326,7 @@ export interface RejectVpcPeeringConnectionRequest {
 
 export namespace RejectVpcPeeringConnectionRequest {
   export function isa(o: any): o is RejectVpcPeeringConnectionRequest {
-    return _smithy.isa(o, "RejectVpcPeeringConnectionRequest");
+    return __isa(o, "RejectVpcPeeringConnectionRequest");
   }
 }
 
@@ -34388,7 +34340,7 @@ export interface RejectVpcPeeringConnectionResult extends $MetadataBearer {
 
 export namespace RejectVpcPeeringConnectionResult {
   export function isa(o: any): o is RejectVpcPeeringConnectionResult {
-    return _smithy.isa(o, "RejectVpcPeeringConnectionResult");
+    return __isa(o, "RejectVpcPeeringConnectionResult");
   }
 }
 
@@ -34423,7 +34375,7 @@ export interface ReleaseAddressRequest {
 
 export namespace ReleaseAddressRequest {
   export function isa(o: any): o is ReleaseAddressRequest {
-    return _smithy.isa(o, "ReleaseAddressRequest");
+    return __isa(o, "ReleaseAddressRequest");
   }
 }
 
@@ -34437,7 +34389,7 @@ export interface ReleaseHostsRequest {
 
 export namespace ReleaseHostsRequest {
   export function isa(o: any): o is ReleaseHostsRequest {
-    return _smithy.isa(o, "ReleaseHostsRequest");
+    return __isa(o, "ReleaseHostsRequest");
   }
 }
 
@@ -34457,7 +34409,7 @@ export interface ReleaseHostsResult extends $MetadataBearer {
 
 export namespace ReleaseHostsResult {
   export function isa(o: any): o is ReleaseHostsResult {
-    return _smithy.isa(o, "ReleaseHostsResult");
+    return __isa(o, "ReleaseHostsResult");
   }
 }
 
@@ -34478,7 +34430,7 @@ export namespace ReplaceIamInstanceProfileAssociationRequest {
   export function isa(
     o: any
   ): o is ReplaceIamInstanceProfileAssociationRequest {
-    return _smithy.isa(o, "ReplaceIamInstanceProfileAssociationRequest");
+    return __isa(o, "ReplaceIamInstanceProfileAssociationRequest");
   }
 }
 
@@ -34493,7 +34445,7 @@ export interface ReplaceIamInstanceProfileAssociationResult
 
 export namespace ReplaceIamInstanceProfileAssociationResult {
   export function isa(o: any): o is ReplaceIamInstanceProfileAssociationResult {
-    return _smithy.isa(o, "ReplaceIamInstanceProfileAssociationResult");
+    return __isa(o, "ReplaceIamInstanceProfileAssociationResult");
   }
 }
 
@@ -34519,7 +34471,7 @@ export interface ReplaceNetworkAclAssociationRequest {
 
 export namespace ReplaceNetworkAclAssociationRequest {
   export function isa(o: any): o is ReplaceNetworkAclAssociationRequest {
-    return _smithy.isa(o, "ReplaceNetworkAclAssociationRequest");
+    return __isa(o, "ReplaceNetworkAclAssociationRequest");
   }
 }
 
@@ -34533,7 +34485,7 @@ export interface ReplaceNetworkAclAssociationResult extends $MetadataBearer {
 
 export namespace ReplaceNetworkAclAssociationResult {
   export function isa(o: any): o is ReplaceNetworkAclAssociationResult {
-    return _smithy.isa(o, "ReplaceNetworkAclAssociationResult");
+    return __isa(o, "ReplaceNetworkAclAssociationResult");
   }
 }
 
@@ -34604,7 +34556,7 @@ export interface ReplaceNetworkAclEntryRequest {
 
 export namespace ReplaceNetworkAclEntryRequest {
   export function isa(o: any): o is ReplaceNetworkAclEntryRequest {
-    return _smithy.isa(o, "ReplaceNetworkAclEntryRequest");
+    return __isa(o, "ReplaceNetworkAclEntryRequest");
   }
 }
 
@@ -34682,7 +34634,7 @@ export interface ReplaceRouteRequest {
 
 export namespace ReplaceRouteRequest {
   export function isa(o: any): o is ReplaceRouteRequest {
-    return _smithy.isa(o, "ReplaceRouteRequest");
+    return __isa(o, "ReplaceRouteRequest");
   }
 }
 
@@ -34708,7 +34660,7 @@ export interface ReplaceRouteTableAssociationRequest {
 
 export namespace ReplaceRouteTableAssociationRequest {
   export function isa(o: any): o is ReplaceRouteTableAssociationRequest {
-    return _smithy.isa(o, "ReplaceRouteTableAssociationRequest");
+    return __isa(o, "ReplaceRouteTableAssociationRequest");
   }
 }
 
@@ -34727,7 +34679,7 @@ export interface ReplaceRouteTableAssociationResult extends $MetadataBearer {
 
 export namespace ReplaceRouteTableAssociationResult {
   export function isa(o: any): o is ReplaceRouteTableAssociationResult {
-    return _smithy.isa(o, "ReplaceRouteTableAssociationResult");
+    return __isa(o, "ReplaceRouteTableAssociationResult");
   }
 }
 
@@ -34763,7 +34715,7 @@ export interface ReplaceTransitGatewayRouteRequest {
 
 export namespace ReplaceTransitGatewayRouteRequest {
   export function isa(o: any): o is ReplaceTransitGatewayRouteRequest {
-    return _smithy.isa(o, "ReplaceTransitGatewayRouteRequest");
+    return __isa(o, "ReplaceTransitGatewayRouteRequest");
   }
 }
 
@@ -34777,7 +34729,7 @@ export interface ReplaceTransitGatewayRouteResult extends $MetadataBearer {
 
 export namespace ReplaceTransitGatewayRouteResult {
   export function isa(o: any): o is ReplaceTransitGatewayRouteResult {
-    return _smithy.isa(o, "ReplaceTransitGatewayRouteResult");
+    return __isa(o, "ReplaceTransitGatewayRouteResult");
   }
 }
 
@@ -34878,7 +34830,7 @@ export interface ReportInstanceStatusRequest {
 
 export namespace ReportInstanceStatusRequest {
   export function isa(o: any): o is ReportInstanceStatusRequest {
-    return _smithy.isa(o, "ReportInstanceStatusRequest");
+    return __isa(o, "ReportInstanceStatusRequest");
   }
 }
 
@@ -35075,7 +35027,7 @@ export interface RequestLaunchTemplateData {
 
 export namespace RequestLaunchTemplateData {
   export function isa(o: any): o is RequestLaunchTemplateData {
-    return _smithy.isa(o, "RequestLaunchTemplateData");
+    return __isa(o, "RequestLaunchTemplateData");
   }
 }
 
@@ -35099,7 +35051,7 @@ export interface RequestSpotFleetRequest {
 
 export namespace RequestSpotFleetRequest {
   export function isa(o: any): o is RequestSpotFleetRequest {
-    return _smithy.isa(o, "RequestSpotFleetRequest");
+    return __isa(o, "RequestSpotFleetRequest");
   }
 }
 
@@ -35116,7 +35068,7 @@ export interface RequestSpotFleetResponse extends $MetadataBearer {
 
 export namespace RequestSpotFleetResponse {
   export function isa(o: any): o is RequestSpotFleetResponse {
-    return _smithy.isa(o, "RequestSpotFleetResponse");
+    return __isa(o, "RequestSpotFleetResponse");
   }
 }
 
@@ -35207,7 +35159,7 @@ export interface RequestSpotInstancesRequest {
 
 export namespace RequestSpotInstancesRequest {
   export function isa(o: any): o is RequestSpotInstancesRequest {
-    return _smithy.isa(o, "RequestSpotInstancesRequest");
+    return __isa(o, "RequestSpotInstancesRequest");
   }
 }
 
@@ -35224,7 +35176,7 @@ export interface RequestSpotInstancesResult extends $MetadataBearer {
 
 export namespace RequestSpotInstancesResult {
   export function isa(o: any): o is RequestSpotInstancesResult {
-    return _smithy.isa(o, "RequestSpotInstancesResult");
+    return __isa(o, "RequestSpotInstancesResult");
   }
 }
 
@@ -35323,7 +35275,7 @@ export interface RequestSpotLaunchSpecification {
 
 export namespace RequestSpotLaunchSpecification {
   export function isa(o: any): o is RequestSpotLaunchSpecification {
-    return _smithy.isa(o, "RequestSpotLaunchSpecification");
+    return __isa(o, "RequestSpotLaunchSpecification");
   }
 }
 
@@ -35361,7 +35313,7 @@ export interface Reservation extends $MetadataBearer {
 
 export namespace Reservation {
   export function isa(o: any): o is Reservation {
-    return _smithy.isa(o, "Reservation");
+    return __isa(o, "Reservation");
   }
 }
 
@@ -35395,7 +35347,7 @@ export interface ReservationValue {
 
 export namespace ReservationValue {
   export function isa(o: any): o is ReservationValue {
-    return _smithy.isa(o, "ReservationValue");
+    return __isa(o, "ReservationValue");
   }
 }
 
@@ -35418,7 +35370,7 @@ export interface ReservedInstanceLimitPrice {
 
 export namespace ReservedInstanceLimitPrice {
   export function isa(o: any): o is ReservedInstanceLimitPrice {
-    return _smithy.isa(o, "ReservedInstanceLimitPrice");
+    return __isa(o, "ReservedInstanceLimitPrice");
   }
 }
 
@@ -35440,7 +35392,7 @@ export interface ReservedInstanceReservationValue {
 
 export namespace ReservedInstanceReservationValue {
   export function isa(o: any): o is ReservedInstanceReservationValue {
-    return _smithy.isa(o, "ReservedInstanceReservationValue");
+    return __isa(o, "ReservedInstanceReservationValue");
   }
 }
 
@@ -35551,7 +35503,7 @@ export interface ReservedInstances {
 
 export namespace ReservedInstances {
   export function isa(o: any): o is ReservedInstances {
-    return _smithy.isa(o, "ReservedInstances");
+    return __isa(o, "ReservedInstances");
   }
 }
 
@@ -35591,7 +35543,7 @@ export interface ReservedInstancesConfiguration {
 
 export namespace ReservedInstancesConfiguration {
   export function isa(o: any): o is ReservedInstancesConfiguration {
-    return _smithy.isa(o, "ReservedInstancesConfiguration");
+    return __isa(o, "ReservedInstancesConfiguration");
   }
 }
 
@@ -35608,7 +35560,7 @@ export interface ReservedInstancesId {
 
 export namespace ReservedInstancesId {
   export function isa(o: any): o is ReservedInstancesId {
-    return _smithy.isa(o, "ReservedInstancesId");
+    return __isa(o, "ReservedInstancesId");
   }
 }
 
@@ -35671,7 +35623,7 @@ export interface ReservedInstancesListing {
 
 export namespace ReservedInstancesListing {
   export function isa(o: any): o is ReservedInstancesListing {
-    return _smithy.isa(o, "ReservedInstancesListing");
+    return __isa(o, "ReservedInstancesListing");
   }
 }
 
@@ -35730,7 +35682,7 @@ export interface ReservedInstancesModification {
 
 export namespace ReservedInstancesModification {
   export function isa(o: any): o is ReservedInstancesModification {
-    return _smithy.isa(o, "ReservedInstancesModification");
+    return __isa(o, "ReservedInstancesModification");
   }
 }
 
@@ -35752,7 +35704,7 @@ export interface ReservedInstancesModificationResult {
 
 export namespace ReservedInstancesModificationResult {
   export function isa(o: any): o is ReservedInstancesModificationResult {
-    return _smithy.isa(o, "ReservedInstancesModificationResult");
+    return __isa(o, "ReservedInstancesModificationResult");
   }
 }
 
@@ -35845,7 +35797,7 @@ export interface ReservedInstancesOffering {
 
 export namespace ReservedInstancesOffering {
   export function isa(o: any): o is ReservedInstancesOffering {
-    return _smithy.isa(o, "ReservedInstancesOffering");
+    return __isa(o, "ReservedInstancesOffering");
   }
 }
 
@@ -35861,7 +35813,7 @@ export interface ResetEbsDefaultKmsKeyIdRequest {
 
 export namespace ResetEbsDefaultKmsKeyIdRequest {
   export function isa(o: any): o is ResetEbsDefaultKmsKeyIdRequest {
-    return _smithy.isa(o, "ResetEbsDefaultKmsKeyIdRequest");
+    return __isa(o, "ResetEbsDefaultKmsKeyIdRequest");
   }
 }
 
@@ -35875,7 +35827,7 @@ export interface ResetEbsDefaultKmsKeyIdResult extends $MetadataBearer {
 
 export namespace ResetEbsDefaultKmsKeyIdResult {
   export function isa(o: any): o is ResetEbsDefaultKmsKeyIdResult {
-    return _smithy.isa(o, "ResetEbsDefaultKmsKeyIdResult");
+    return __isa(o, "ResetEbsDefaultKmsKeyIdResult");
   }
 }
 
@@ -35903,7 +35855,7 @@ export interface ResetFpgaImageAttributeRequest {
 
 export namespace ResetFpgaImageAttributeRequest {
   export function isa(o: any): o is ResetFpgaImageAttributeRequest {
-    return _smithy.isa(o, "ResetFpgaImageAttributeRequest");
+    return __isa(o, "ResetFpgaImageAttributeRequest");
   }
 }
 
@@ -35917,7 +35869,7 @@ export interface ResetFpgaImageAttributeResult extends $MetadataBearer {
 
 export namespace ResetFpgaImageAttributeResult {
   export function isa(o: any): o is ResetFpgaImageAttributeResult {
-    return _smithy.isa(o, "ResetFpgaImageAttributeResult");
+    return __isa(o, "ResetFpgaImageAttributeResult");
   }
 }
 
@@ -35948,7 +35900,7 @@ export interface ResetImageAttributeRequest {
 
 export namespace ResetImageAttributeRequest {
   export function isa(o: any): o is ResetImageAttributeRequest {
-    return _smithy.isa(o, "ResetImageAttributeRequest");
+    return __isa(o, "ResetImageAttributeRequest");
   }
 }
 
@@ -35979,7 +35931,7 @@ export interface ResetInstanceAttributeRequest {
 
 export namespace ResetInstanceAttributeRequest {
   export function isa(o: any): o is ResetInstanceAttributeRequest {
-    return _smithy.isa(o, "ResetInstanceAttributeRequest");
+    return __isa(o, "ResetInstanceAttributeRequest");
   }
 }
 
@@ -36008,7 +35960,7 @@ export interface ResetNetworkInterfaceAttributeRequest {
 
 export namespace ResetNetworkInterfaceAttributeRequest {
   export function isa(o: any): o is ResetNetworkInterfaceAttributeRequest {
-    return _smithy.isa(o, "ResetNetworkInterfaceAttributeRequest");
+    return __isa(o, "ResetNetworkInterfaceAttributeRequest");
   }
 }
 
@@ -36035,7 +35987,7 @@ export interface ResetSnapshotAttributeRequest {
 
 export namespace ResetSnapshotAttributeRequest {
   export function isa(o: any): o is ResetSnapshotAttributeRequest {
-    return _smithy.isa(o, "ResetSnapshotAttributeRequest");
+    return __isa(o, "ResetSnapshotAttributeRequest");
   }
 }
 
@@ -36096,7 +36048,7 @@ export interface ResponseError {
 
 export namespace ResponseError {
   export function isa(o: any): o is ResponseError {
-    return _smithy.isa(o, "ResponseError");
+    return __isa(o, "ResponseError");
   }
 }
 
@@ -36250,7 +36202,7 @@ export interface ResponseLaunchTemplateData {
 
 export namespace ResponseLaunchTemplateData {
   export function isa(o: any): o is ResponseLaunchTemplateData {
-    return _smithy.isa(o, "ResponseLaunchTemplateData");
+    return __isa(o, "ResponseLaunchTemplateData");
   }
 }
 
@@ -36271,7 +36223,7 @@ export interface RestoreAddressToClassicRequest {
 
 export namespace RestoreAddressToClassicRequest {
   export function isa(o: any): o is RestoreAddressToClassicRequest {
-    return _smithy.isa(o, "RestoreAddressToClassicRequest");
+    return __isa(o, "RestoreAddressToClassicRequest");
   }
 }
 
@@ -36290,7 +36242,7 @@ export interface RestoreAddressToClassicResult extends $MetadataBearer {
 
 export namespace RestoreAddressToClassicResult {
   export function isa(o: any): o is RestoreAddressToClassicResult {
-    return _smithy.isa(o, "RestoreAddressToClassicResult");
+    return __isa(o, "RestoreAddressToClassicResult");
   }
 }
 
@@ -36324,7 +36276,7 @@ export interface RevokeClientVpnIngressRequest {
 
 export namespace RevokeClientVpnIngressRequest {
   export function isa(o: any): o is RevokeClientVpnIngressRequest {
-    return _smithy.isa(o, "RevokeClientVpnIngressRequest");
+    return __isa(o, "RevokeClientVpnIngressRequest");
   }
 }
 
@@ -36338,7 +36290,7 @@ export interface RevokeClientVpnIngressResult extends $MetadataBearer {
 
 export namespace RevokeClientVpnIngressResult {
   export function isa(o: any): o is RevokeClientVpnIngressResult {
-    return _smithy.isa(o, "RevokeClientVpnIngressResult");
+    return __isa(o, "RevokeClientVpnIngressResult");
   }
 }
 
@@ -36397,7 +36349,7 @@ export interface RevokeSecurityGroupEgressRequest {
 
 export namespace RevokeSecurityGroupEgressRequest {
   export function isa(o: any): o is RevokeSecurityGroupEgressRequest {
-    return _smithy.isa(o, "RevokeSecurityGroupEgressRequest");
+    return __isa(o, "RevokeSecurityGroupEgressRequest");
   }
 }
 
@@ -36465,7 +36417,7 @@ export interface RevokeSecurityGroupIngressRequest {
 
 export namespace RevokeSecurityGroupIngressRequest {
   export function isa(o: any): o is RevokeSecurityGroupIngressRequest {
-    return _smithy.isa(o, "RevokeSecurityGroupIngressRequest");
+    return __isa(o, "RevokeSecurityGroupIngressRequest");
   }
 }
 
@@ -36565,7 +36517,7 @@ export interface Route {
 
 export namespace Route {
   export function isa(o: any): o is Route {
-    return _smithy.isa(o, "Route");
+    return __isa(o, "Route");
   }
 }
 
@@ -36619,7 +36571,7 @@ export interface RouteTable {
 
 export namespace RouteTable {
   export function isa(o: any): o is RouteTable {
-    return _smithy.isa(o, "RouteTable");
+    return __isa(o, "RouteTable");
   }
 }
 
@@ -36661,7 +36613,7 @@ export interface RouteTableAssociation {
 
 export namespace RouteTableAssociation {
   export function isa(o: any): o is RouteTableAssociation {
-    return _smithy.isa(o, "RouteTableAssociation");
+    return __isa(o, "RouteTableAssociation");
   }
 }
 
@@ -36683,7 +36635,7 @@ export interface RouteTableAssociationState {
 
 export namespace RouteTableAssociationState {
   export function isa(o: any): o is RouteTableAssociationState {
-    return _smithy.isa(o, "RouteTableAssociationState");
+    return __isa(o, "RouteTableAssociationState");
   }
 }
 
@@ -36710,7 +36662,7 @@ export interface RunInstancesMonitoringEnabled {
 
 export namespace RunInstancesMonitoringEnabled {
   export function isa(o: any): o is RunInstancesMonitoringEnabled {
-    return _smithy.isa(o, "RunInstancesMonitoringEnabled");
+    return __isa(o, "RunInstancesMonitoringEnabled");
   }
 }
 
@@ -37006,7 +36958,7 @@ export interface RunInstancesRequest {
 
 export namespace RunInstancesRequest {
   export function isa(o: any): o is RunInstancesRequest {
-    return _smithy.isa(o, "RunInstancesRequest");
+    return __isa(o, "RunInstancesRequest");
   }
 }
 
@@ -37048,7 +37000,7 @@ export interface RunScheduledInstancesRequest {
 
 export namespace RunScheduledInstancesRequest {
   export function isa(o: any): o is RunScheduledInstancesRequest {
-    return _smithy.isa(o, "RunScheduledInstancesRequest");
+    return __isa(o, "RunScheduledInstancesRequest");
   }
 }
 
@@ -37065,7 +37017,7 @@ export interface RunScheduledInstancesResult extends $MetadataBearer {
 
 export namespace RunScheduledInstancesResult {
   export function isa(o: any): o is RunScheduledInstancesResult {
-    return _smithy.isa(o, "RunScheduledInstancesResult");
+    return __isa(o, "RunScheduledInstancesResult");
   }
 }
 
@@ -37103,7 +37055,7 @@ export interface S3Storage {
 
 export namespace S3Storage {
   export function isa(o: any): o is S3Storage {
-    return _smithy.isa(o, "S3Storage");
+    return __isa(o, "S3Storage");
   }
 }
 
@@ -37190,7 +37142,7 @@ export interface ScheduledInstance {
 
 export namespace ScheduledInstance {
   export function isa(o: any): o is ScheduledInstance {
-    return _smithy.isa(o, "ScheduledInstance");
+    return __isa(o, "ScheduledInstance");
   }
 }
 
@@ -37267,7 +37219,7 @@ export interface ScheduledInstanceAvailability {
 
 export namespace ScheduledInstanceAvailability {
   export function isa(o: any): o is ScheduledInstanceAvailability {
-    return _smithy.isa(o, "ScheduledInstanceAvailability");
+    return __isa(o, "ScheduledInstanceAvailability");
   }
 }
 
@@ -37305,7 +37257,7 @@ export interface ScheduledInstanceRecurrence {
 
 export namespace ScheduledInstanceRecurrence {
   export function isa(o: any): o is ScheduledInstanceRecurrence {
-    return _smithy.isa(o, "ScheduledInstanceRecurrence");
+    return __isa(o, "ScheduledInstanceRecurrence");
   }
 }
 
@@ -37346,7 +37298,7 @@ export interface ScheduledInstanceRecurrenceRequest {
 
 export namespace ScheduledInstanceRecurrenceRequest {
   export function isa(o: any): o is ScheduledInstanceRecurrenceRequest {
-    return _smithy.isa(o, "ScheduledInstanceRecurrenceRequest");
+    return __isa(o, "ScheduledInstanceRecurrenceRequest");
   }
 }
 
@@ -37383,7 +37335,7 @@ export interface ScheduledInstancesBlockDeviceMapping {
 
 export namespace ScheduledInstancesBlockDeviceMapping {
   export function isa(o: any): o is ScheduledInstancesBlockDeviceMapping {
-    return _smithy.isa(o, "ScheduledInstancesBlockDeviceMapping");
+    return __isa(o, "ScheduledInstancesBlockDeviceMapping");
   }
 }
 
@@ -37440,7 +37392,7 @@ export interface ScheduledInstancesEbs {
 
 export namespace ScheduledInstancesEbs {
   export function isa(o: any): o is ScheduledInstancesEbs {
-    return _smithy.isa(o, "ScheduledInstancesEbs");
+    return __isa(o, "ScheduledInstancesEbs");
   }
 }
 
@@ -37462,7 +37414,7 @@ export interface ScheduledInstancesIamInstanceProfile {
 
 export namespace ScheduledInstancesIamInstanceProfile {
   export function isa(o: any): o is ScheduledInstancesIamInstanceProfile {
-    return _smithy.isa(o, "ScheduledInstancesIamInstanceProfile");
+    return __isa(o, "ScheduledInstancesIamInstanceProfile");
   }
 }
 
@@ -37479,7 +37431,7 @@ export interface ScheduledInstancesIpv6Address {
 
 export namespace ScheduledInstancesIpv6Address {
   export function isa(o: any): o is ScheduledInstancesIpv6Address {
-    return _smithy.isa(o, "ScheduledInstancesIpv6Address");
+    return __isa(o, "ScheduledInstancesIpv6Address");
   }
 }
 
@@ -37565,7 +37517,7 @@ export interface ScheduledInstancesLaunchSpecification {
 
 export namespace ScheduledInstancesLaunchSpecification {
   export function isa(o: any): o is ScheduledInstancesLaunchSpecification {
-    return _smithy.isa(o, "ScheduledInstancesLaunchSpecification");
+    return __isa(o, "ScheduledInstancesLaunchSpecification");
   }
 }
 
@@ -37582,7 +37534,7 @@ export interface ScheduledInstancesMonitoring {
 
 export namespace ScheduledInstancesMonitoring {
   export function isa(o: any): o is ScheduledInstancesMonitoring {
-    return _smithy.isa(o, "ScheduledInstancesMonitoring");
+    return __isa(o, "ScheduledInstancesMonitoring");
   }
 }
 
@@ -37658,7 +37610,7 @@ export interface ScheduledInstancesNetworkInterface {
 
 export namespace ScheduledInstancesNetworkInterface {
   export function isa(o: any): o is ScheduledInstancesNetworkInterface {
-    return _smithy.isa(o, "ScheduledInstancesNetworkInterface");
+    return __isa(o, "ScheduledInstancesNetworkInterface");
   }
 }
 
@@ -37680,7 +37632,7 @@ export interface ScheduledInstancesPlacement {
 
 export namespace ScheduledInstancesPlacement {
   export function isa(o: any): o is ScheduledInstancesPlacement {
-    return _smithy.isa(o, "ScheduledInstancesPlacement");
+    return __isa(o, "ScheduledInstancesPlacement");
   }
 }
 
@@ -37702,7 +37654,7 @@ export interface ScheduledInstancesPrivateIpAddressConfig {
 
 export namespace ScheduledInstancesPrivateIpAddressConfig {
   export function isa(o: any): o is ScheduledInstancesPrivateIpAddressConfig {
-    return _smithy.isa(o, "ScheduledInstancesPrivateIpAddressConfig");
+    return __isa(o, "ScheduledInstancesPrivateIpAddressConfig");
   }
 }
 
@@ -37739,7 +37691,7 @@ export interface SearchLocalGatewayRoutesRequest {
 
 export namespace SearchLocalGatewayRoutesRequest {
   export function isa(o: any): o is SearchLocalGatewayRoutesRequest {
-    return _smithy.isa(o, "SearchLocalGatewayRoutesRequest");
+    return __isa(o, "SearchLocalGatewayRoutesRequest");
   }
 }
 
@@ -37758,7 +37710,7 @@ export interface SearchLocalGatewayRoutesResult extends $MetadataBearer {
 
 export namespace SearchLocalGatewayRoutesResult {
   export function isa(o: any): o is SearchLocalGatewayRoutesResult {
-    return _smithy.isa(o, "SearchLocalGatewayRoutesResult");
+    return __isa(o, "SearchLocalGatewayRoutesResult");
   }
 }
 
@@ -37837,7 +37789,7 @@ export interface SearchTransitGatewayMulticastGroupsRequest {
 
 export namespace SearchTransitGatewayMulticastGroupsRequest {
   export function isa(o: any): o is SearchTransitGatewayMulticastGroupsRequest {
-    return _smithy.isa(o, "SearchTransitGatewayMulticastGroupsRequest");
+    return __isa(o, "SearchTransitGatewayMulticastGroupsRequest");
   }
 }
 
@@ -37857,7 +37809,7 @@ export interface SearchTransitGatewayMulticastGroupsResult
 
 export namespace SearchTransitGatewayMulticastGroupsResult {
   export function isa(o: any): o is SearchTransitGatewayMulticastGroupsResult {
-    return _smithy.isa(o, "SearchTransitGatewayMulticastGroupsResult");
+    return __isa(o, "SearchTransitGatewayMulticastGroupsResult");
   }
 }
 
@@ -37927,7 +37879,7 @@ export interface SearchTransitGatewayRoutesRequest {
 
 export namespace SearchTransitGatewayRoutesRequest {
   export function isa(o: any): o is SearchTransitGatewayRoutesRequest {
-    return _smithy.isa(o, "SearchTransitGatewayRoutesRequest");
+    return __isa(o, "SearchTransitGatewayRoutesRequest");
   }
 }
 
@@ -37946,7 +37898,7 @@ export interface SearchTransitGatewayRoutesResult extends $MetadataBearer {
 
 export namespace SearchTransitGatewayRoutesResult {
   export function isa(o: any): o is SearchTransitGatewayRoutesResult {
-    return _smithy.isa(o, "SearchTransitGatewayRoutesResult");
+    return __isa(o, "SearchTransitGatewayRoutesResult");
   }
 }
 
@@ -37998,7 +37950,7 @@ export interface SecurityGroup {
 
 export namespace SecurityGroup {
   export function isa(o: any): o is SecurityGroup {
-    return _smithy.isa(o, "SecurityGroup");
+    return __isa(o, "SecurityGroup");
   }
 }
 
@@ -38020,7 +37972,7 @@ export interface SecurityGroupIdentifier {
 
 export namespace SecurityGroupIdentifier {
   export function isa(o: any): o is SecurityGroupIdentifier {
-    return _smithy.isa(o, "SecurityGroupIdentifier");
+    return __isa(o, "SecurityGroupIdentifier");
   }
 }
 
@@ -38047,7 +37999,7 @@ export interface SecurityGroupReference {
 
 export namespace SecurityGroupReference {
   export function isa(o: any): o is SecurityGroupReference {
-    return _smithy.isa(o, "SecurityGroupReference");
+    return __isa(o, "SecurityGroupReference");
   }
 }
 
@@ -38068,7 +38020,7 @@ export interface SendDiagnosticInterruptRequest {
 
 export namespace SendDiagnosticInterruptRequest {
   export function isa(o: any): o is SendDiagnosticInterruptRequest {
-    return _smithy.isa(o, "SendDiagnosticInterruptRequest");
+    return __isa(o, "SendDiagnosticInterruptRequest");
   }
 }
 
@@ -38141,7 +38093,7 @@ export interface ServiceConfiguration {
 
 export namespace ServiceConfiguration {
   export function isa(o: any): o is ServiceConfiguration {
-    return _smithy.isa(o, "ServiceConfiguration");
+    return __isa(o, "ServiceConfiguration");
   }
 }
 
@@ -38215,7 +38167,7 @@ export interface ServiceDetail {
 
 export namespace ServiceDetail {
   export function isa(o: any): o is ServiceDetail {
-    return _smithy.isa(o, "ServiceDetail");
+    return __isa(o, "ServiceDetail");
   }
 }
 
@@ -38245,7 +38197,7 @@ export interface ServiceTypeDetail {
 
 export namespace ServiceTypeDetail {
   export function isa(o: any): o is ServiceTypeDetail {
-    return _smithy.isa(o, "ServiceTypeDetail");
+    return __isa(o, "ServiceTypeDetail");
   }
 }
 
@@ -38269,7 +38221,7 @@ export interface SlotDateTimeRangeRequest {
 
 export namespace SlotDateTimeRangeRequest {
   export function isa(o: any): o is SlotDateTimeRangeRequest {
-    return _smithy.isa(o, "SlotDateTimeRangeRequest");
+    return __isa(o, "SlotDateTimeRangeRequest");
   }
 }
 
@@ -38291,7 +38243,7 @@ export interface SlotStartTimeRangeRequest {
 
 export namespace SlotStartTimeRangeRequest {
   export function isa(o: any): o is SlotStartTimeRangeRequest {
-    return _smithy.isa(o, "SlotStartTimeRangeRequest");
+    return __isa(o, "SlotStartTimeRangeRequest");
   }
 }
 
@@ -38386,7 +38338,7 @@ export interface Snapshot extends $MetadataBearer {
 
 export namespace Snapshot {
   export function isa(o: any): o is Snapshot {
-    return _smithy.isa(o, "Snapshot");
+    return __isa(o, "Snapshot");
   }
 }
 
@@ -38450,7 +38402,7 @@ export interface SnapshotDetail {
 
 export namespace SnapshotDetail {
   export function isa(o: any): o is SnapshotDetail {
-    return _smithy.isa(o, "SnapshotDetail");
+    return __isa(o, "SnapshotDetail");
   }
 }
 
@@ -38485,7 +38437,7 @@ export interface SnapshotDiskContainer {
 
 export namespace SnapshotDiskContainer {
   export function isa(o: any): o is SnapshotDiskContainer {
-    return _smithy.isa(o, "SnapshotDiskContainer");
+    return __isa(o, "SnapshotDiskContainer");
   }
 }
 
@@ -38549,7 +38501,7 @@ export interface SnapshotInfo {
 
 export namespace SnapshotInfo {
   export function isa(o: any): o is SnapshotInfo {
-    return _smithy.isa(o, "SnapshotInfo");
+    return __isa(o, "SnapshotInfo");
   }
 }
 
@@ -38619,7 +38571,7 @@ export interface SnapshotTaskDetail {
 
 export namespace SnapshotTaskDetail {
   export function isa(o: any): o is SnapshotTaskDetail {
-    return _smithy.isa(o, "SnapshotTaskDetail");
+    return __isa(o, "SnapshotTaskDetail");
   }
 }
 
@@ -38662,7 +38614,7 @@ export interface SpotDatafeedSubscription {
 
 export namespace SpotDatafeedSubscription {
   export function isa(o: any): o is SpotDatafeedSubscription {
-    return _smithy.isa(o, "SpotDatafeedSubscription");
+    return __isa(o, "SpotDatafeedSubscription");
   }
 }
 
@@ -38777,7 +38729,7 @@ export interface SpotFleetLaunchSpecification {
 
 export namespace SpotFleetLaunchSpecification {
   export function isa(o: any): o is SpotFleetLaunchSpecification {
-    return _smithy.isa(o, "SpotFleetLaunchSpecification");
+    return __isa(o, "SpotFleetLaunchSpecification");
   }
 }
 
@@ -38796,7 +38748,7 @@ export interface SpotFleetMonitoring {
 
 export namespace SpotFleetMonitoring {
   export function isa(o: any): o is SpotFleetMonitoring {
-    return _smithy.isa(o, "SpotFleetMonitoring");
+    return __isa(o, "SpotFleetMonitoring");
   }
 }
 
@@ -38838,7 +38790,7 @@ export interface SpotFleetRequestConfig {
 
 export namespace SpotFleetRequestConfig {
   export function isa(o: any): o is SpotFleetRequestConfig {
-    return _smithy.isa(o, "SpotFleetRequestConfig");
+    return __isa(o, "SpotFleetRequestConfig");
   }
 }
 
@@ -39027,7 +38979,7 @@ export interface SpotFleetRequestConfigData {
 
 export namespace SpotFleetRequestConfigData {
   export function isa(o: any): o is SpotFleetRequestConfigData {
-    return _smithy.isa(o, "SpotFleetRequestConfigData");
+    return __isa(o, "SpotFleetRequestConfigData");
   }
 }
 
@@ -39049,7 +39001,7 @@ export interface SpotFleetTagSpecification {
 
 export namespace SpotFleetTagSpecification {
   export function isa(o: any): o is SpotFleetTagSpecification {
-    return _smithy.isa(o, "SpotFleetTagSpecification");
+    return __isa(o, "SpotFleetTagSpecification");
   }
 }
 
@@ -39167,7 +39119,7 @@ export interface SpotInstanceRequest {
 
 export namespace SpotInstanceRequest {
   export function isa(o: any): o is SpotInstanceRequest {
-    return _smithy.isa(o, "SpotInstanceRequest");
+    return __isa(o, "SpotInstanceRequest");
   }
 }
 
@@ -39196,7 +39148,7 @@ export interface SpotInstanceStateFault {
 
 export namespace SpotInstanceStateFault {
   export function isa(o: any): o is SpotInstanceStateFault {
-    return _smithy.isa(o, "SpotInstanceStateFault");
+    return __isa(o, "SpotInstanceStateFault");
   }
 }
 
@@ -39224,7 +39176,7 @@ export interface SpotInstanceStatus {
 
 export namespace SpotInstanceStatus {
   export function isa(o: any): o is SpotInstanceStatus {
-    return _smithy.isa(o, "SpotInstanceStatus");
+    return __isa(o, "SpotInstanceStatus");
   }
 }
 
@@ -39271,7 +39223,7 @@ export interface SpotMarketOptions {
 
 export namespace SpotMarketOptions {
   export function isa(o: any): o is SpotMarketOptions {
-    return _smithy.isa(o, "SpotMarketOptions");
+    return __isa(o, "SpotMarketOptions");
   }
 }
 
@@ -39332,7 +39284,7 @@ export interface SpotOptions {
 
 export namespace SpotOptions {
   export function isa(o: any): o is SpotOptions {
-    return _smithy.isa(o, "SpotOptions");
+    return __isa(o, "SpotOptions");
   }
 }
 
@@ -39393,7 +39345,7 @@ export interface SpotOptionsRequest {
 
 export namespace SpotOptionsRequest {
   export function isa(o: any): o is SpotOptionsRequest {
-    return _smithy.isa(o, "SpotOptionsRequest");
+    return __isa(o, "SpotOptionsRequest");
   }
 }
 
@@ -39423,7 +39375,7 @@ export interface SpotPlacement {
 
 export namespace SpotPlacement {
   export function isa(o: any): o is SpotPlacement {
-    return _smithy.isa(o, "SpotPlacement");
+    return __isa(o, "SpotPlacement");
   }
 }
 
@@ -39460,7 +39412,7 @@ export interface SpotPrice {
 
 export namespace SpotPrice {
   export function isa(o: any): o is SpotPrice {
-    return _smithy.isa(o, "SpotPrice");
+    return __isa(o, "SpotPrice");
   }
 }
 
@@ -39504,7 +39456,7 @@ export interface StaleIpPermission {
 
 export namespace StaleIpPermission {
   export function isa(o: any): o is StaleIpPermission {
-    return _smithy.isa(o, "StaleIpPermission");
+    return __isa(o, "StaleIpPermission");
   }
 }
 
@@ -39546,7 +39498,7 @@ export interface StaleSecurityGroup {
 
 export namespace StaleSecurityGroup {
   export function isa(o: any): o is StaleSecurityGroup {
-    return _smithy.isa(o, "StaleSecurityGroup");
+    return __isa(o, "StaleSecurityGroup");
   }
 }
 
@@ -39572,7 +39524,7 @@ export interface StartInstancesRequest {
 
 export namespace StartInstancesRequest {
   export function isa(o: any): o is StartInstancesRequest {
-    return _smithy.isa(o, "StartInstancesRequest");
+    return __isa(o, "StartInstancesRequest");
   }
 }
 
@@ -39586,7 +39538,7 @@ export interface StartInstancesResult extends $MetadataBearer {
 
 export namespace StartInstancesResult {
   export function isa(o: any): o is StartInstancesResult {
-    return _smithy.isa(o, "StartInstancesResult");
+    return __isa(o, "StartInstancesResult");
   }
 }
 
@@ -39609,10 +39561,7 @@ export namespace StartVpcEndpointServicePrivateDnsVerificationRequest {
   export function isa(
     o: any
   ): o is StartVpcEndpointServicePrivateDnsVerificationRequest {
-    return _smithy.isa(
-      o,
-      "StartVpcEndpointServicePrivateDnsVerificationRequest"
-    );
+    return __isa(o, "StartVpcEndpointServicePrivateDnsVerificationRequest");
   }
 }
 
@@ -39629,10 +39578,7 @@ export namespace StartVpcEndpointServicePrivateDnsVerificationResult {
   export function isa(
     o: any
   ): o is StartVpcEndpointServicePrivateDnsVerificationResult {
-    return _smithy.isa(
-      o,
-      "StartVpcEndpointServicePrivateDnsVerificationResult"
-    );
+    return __isa(o, "StartVpcEndpointServicePrivateDnsVerificationResult");
   }
 }
 
@@ -39732,7 +39678,7 @@ export interface StateReason {
 
 export namespace StateReason {
   export function isa(o: any): o is StateReason {
-    return _smithy.isa(o, "StateReason");
+    return __isa(o, "StateReason");
   }
 }
 
@@ -39787,7 +39733,7 @@ export interface StopInstancesRequest {
 
 export namespace StopInstancesRequest {
   export function isa(o: any): o is StopInstancesRequest {
-    return _smithy.isa(o, "StopInstancesRequest");
+    return __isa(o, "StopInstancesRequest");
   }
 }
 
@@ -39801,7 +39747,7 @@ export interface StopInstancesResult extends $MetadataBearer {
 
 export namespace StopInstancesResult {
   export function isa(o: any): o is StopInstancesResult {
-    return _smithy.isa(o, "StopInstancesResult");
+    return __isa(o, "StopInstancesResult");
   }
 }
 
@@ -39818,7 +39764,7 @@ export interface Storage {
 
 export namespace Storage {
   export function isa(o: any): o is Storage {
-    return _smithy.isa(o, "Storage");
+    return __isa(o, "Storage");
   }
 }
 
@@ -39840,7 +39786,7 @@ export interface StorageLocation {
 
 export namespace StorageLocation {
   export function isa(o: any): o is StorageLocation {
-    return _smithy.isa(o, "StorageLocation");
+    return __isa(o, "StorageLocation");
   }
 }
 
@@ -39929,7 +39875,7 @@ export interface Subnet {
 
 export namespace Subnet {
   export function isa(o: any): o is Subnet {
-    return _smithy.isa(o, "Subnet");
+    return __isa(o, "Subnet");
   }
 }
 
@@ -39951,7 +39897,7 @@ export interface SubnetAssociation {
 
 export namespace SubnetAssociation {
   export function isa(o: any): o is SubnetAssociation {
-    return _smithy.isa(o, "SubnetAssociation");
+    return __isa(o, "SubnetAssociation");
   }
 }
 
@@ -39973,7 +39919,7 @@ export interface SubnetCidrBlockState {
 
 export namespace SubnetCidrBlockState {
   export function isa(o: any): o is SubnetCidrBlockState {
-    return _smithy.isa(o, "SubnetCidrBlockState");
+    return __isa(o, "SubnetCidrBlockState");
   }
 }
 
@@ -40008,7 +39954,7 @@ export interface SubnetIpv6CidrBlockAssociation {
 
 export namespace SubnetIpv6CidrBlockAssociation {
   export function isa(o: any): o is SubnetIpv6CidrBlockAssociation {
-    return _smithy.isa(o, "SubnetIpv6CidrBlockAssociation");
+    return __isa(o, "SubnetIpv6CidrBlockAssociation");
   }
 }
 
@@ -40028,7 +39974,7 @@ export interface SuccessfulInstanceCreditSpecificationItem {
 
 export namespace SuccessfulInstanceCreditSpecificationItem {
   export function isa(o: any): o is SuccessfulInstanceCreditSpecificationItem {
-    return _smithy.isa(o, "SuccessfulInstanceCreditSpecificationItem");
+    return __isa(o, "SuccessfulInstanceCreditSpecificationItem");
   }
 }
 
@@ -40045,7 +39991,7 @@ export interface SuccessfulQueuedPurchaseDeletion {
 
 export namespace SuccessfulQueuedPurchaseDeletion {
   export function isa(o: any): o is SuccessfulQueuedPurchaseDeletion {
-    return _smithy.isa(o, "SuccessfulQueuedPurchaseDeletion");
+    return __isa(o, "SuccessfulQueuedPurchaseDeletion");
   }
 }
 
@@ -40077,7 +40023,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -40109,7 +40055,7 @@ export interface TagDescription {
 
 export namespace TagDescription {
   export function isa(o: any): o is TagDescription {
-    return _smithy.isa(o, "TagDescription");
+    return __isa(o, "TagDescription");
   }
 }
 
@@ -40138,7 +40084,7 @@ export interface TagSpecification {
 
 export namespace TagSpecification {
   export function isa(o: any): o is TagSpecification {
-    return _smithy.isa(o, "TagSpecification");
+    return __isa(o, "TagSpecification");
   }
 }
 
@@ -40183,7 +40129,7 @@ export interface TargetCapacitySpecification {
 
 export namespace TargetCapacitySpecification {
   export function isa(o: any): o is TargetCapacitySpecification {
-    return _smithy.isa(o, "TargetCapacitySpecification");
+    return __isa(o, "TargetCapacitySpecification");
   }
 }
 
@@ -40227,7 +40173,7 @@ export interface TargetCapacitySpecificationRequest {
 
 export namespace TargetCapacitySpecificationRequest {
   export function isa(o: any): o is TargetCapacitySpecificationRequest {
-    return _smithy.isa(o, "TargetCapacitySpecificationRequest");
+    return __isa(o, "TargetCapacitySpecificationRequest");
   }
 }
 
@@ -40250,7 +40196,7 @@ export interface TargetConfiguration {
 
 export namespace TargetConfiguration {
   export function isa(o: any): o is TargetConfiguration {
-    return _smithy.isa(o, "TargetConfiguration");
+    return __isa(o, "TargetConfiguration");
   }
 }
 
@@ -40273,7 +40219,7 @@ export interface TargetConfigurationRequest {
 
 export namespace TargetConfigurationRequest {
   export function isa(o: any): o is TargetConfigurationRequest {
-    return _smithy.isa(o, "TargetConfigurationRequest");
+    return __isa(o, "TargetConfigurationRequest");
   }
 }
 
@@ -40290,7 +40236,7 @@ export interface TargetGroup {
 
 export namespace TargetGroup {
   export function isa(o: any): o is TargetGroup {
-    return _smithy.isa(o, "TargetGroup");
+    return __isa(o, "TargetGroup");
   }
 }
 
@@ -40308,7 +40254,7 @@ export interface TargetGroupsConfig {
 
 export namespace TargetGroupsConfig {
   export function isa(o: any): o is TargetGroupsConfig {
-    return _smithy.isa(o, "TargetGroupsConfig");
+    return __isa(o, "TargetGroupsConfig");
   }
 }
 
@@ -40350,7 +40296,7 @@ export interface TargetNetwork {
 
 export namespace TargetNetwork {
   export function isa(o: any): o is TargetNetwork {
-    return _smithy.isa(o, "TargetNetwork");
+    return __isa(o, "TargetNetwork");
   }
 }
 
@@ -40373,7 +40319,7 @@ export interface TargetReservationValue {
 
 export namespace TargetReservationValue {
   export function isa(o: any): o is TargetReservationValue {
-    return _smithy.isa(o, "TargetReservationValue");
+    return __isa(o, "TargetReservationValue");
   }
 }
 
@@ -40407,7 +40353,7 @@ export interface TerminateClientVpnConnectionsRequest {
 
 export namespace TerminateClientVpnConnectionsRequest {
   export function isa(o: any): o is TerminateClientVpnConnectionsRequest {
-    return _smithy.isa(o, "TerminateClientVpnConnectionsRequest");
+    return __isa(o, "TerminateClientVpnConnectionsRequest");
   }
 }
 
@@ -40431,7 +40377,7 @@ export interface TerminateClientVpnConnectionsResult extends $MetadataBearer {
 
 export namespace TerminateClientVpnConnectionsResult {
   export function isa(o: any): o is TerminateClientVpnConnectionsResult {
-    return _smithy.isa(o, "TerminateClientVpnConnectionsResult");
+    return __isa(o, "TerminateClientVpnConnectionsResult");
   }
 }
 
@@ -40458,7 +40404,7 @@ export interface TerminateConnectionStatus {
 
 export namespace TerminateConnectionStatus {
   export function isa(o: any): o is TerminateConnectionStatus {
-    return _smithy.isa(o, "TerminateConnectionStatus");
+    return __isa(o, "TerminateConnectionStatus");
   }
 }
 
@@ -40481,7 +40427,7 @@ export interface TerminateInstancesRequest {
 
 export namespace TerminateInstancesRequest {
   export function isa(o: any): o is TerminateInstancesRequest {
-    return _smithy.isa(o, "TerminateInstancesRequest");
+    return __isa(o, "TerminateInstancesRequest");
   }
 }
 
@@ -40495,7 +40441,7 @@ export interface TerminateInstancesResult extends $MetadataBearer {
 
 export namespace TerminateInstancesResult {
   export function isa(o: any): o is TerminateInstancesResult {
-    return _smithy.isa(o, "TerminateInstancesResult");
+    return __isa(o, "TerminateInstancesResult");
   }
 }
 
@@ -40539,7 +40485,7 @@ export interface TrafficMirrorFilter {
 
 export namespace TrafficMirrorFilter {
   export function isa(o: any): o is TrafficMirrorFilter {
-    return _smithy.isa(o, "TrafficMirrorFilter");
+    return __isa(o, "TrafficMirrorFilter");
   }
 }
 
@@ -40606,7 +40552,7 @@ export interface TrafficMirrorFilterRule {
 
 export namespace TrafficMirrorFilterRule {
   export function isa(o: any): o is TrafficMirrorFilterRule {
-    return _smithy.isa(o, "TrafficMirrorFilterRule");
+    return __isa(o, "TrafficMirrorFilterRule");
   }
 }
 
@@ -40636,7 +40582,7 @@ export interface TrafficMirrorPortRange {
 
 export namespace TrafficMirrorPortRange {
   export function isa(o: any): o is TrafficMirrorPortRange {
-    return _smithy.isa(o, "TrafficMirrorPortRange");
+    return __isa(o, "TrafficMirrorPortRange");
   }
 }
 
@@ -40658,7 +40604,7 @@ export interface TrafficMirrorPortRangeRequest {
 
 export namespace TrafficMirrorPortRangeRequest {
   export function isa(o: any): o is TrafficMirrorPortRangeRequest {
-    return _smithy.isa(o, "TrafficMirrorPortRangeRequest");
+    return __isa(o, "TrafficMirrorPortRangeRequest");
   }
 }
 
@@ -40723,7 +40669,7 @@ export interface TrafficMirrorSession {
 
 export namespace TrafficMirrorSession {
   export function isa(o: any): o is TrafficMirrorSession {
-    return _smithy.isa(o, "TrafficMirrorSession");
+    return __isa(o, "TrafficMirrorSession");
   }
 }
 
@@ -40775,7 +40721,7 @@ export interface TrafficMirrorTarget {
 
 export namespace TrafficMirrorTarget {
   export function isa(o: any): o is TrafficMirrorTarget {
-    return _smithy.isa(o, "TrafficMirrorTarget");
+    return __isa(o, "TrafficMirrorTarget");
   }
 }
 
@@ -40833,7 +40779,7 @@ export interface TransitGateway {
 
 export namespace TransitGateway {
   export function isa(o: any): o is TransitGateway {
-    return _smithy.isa(o, "TransitGateway");
+    return __isa(o, "TransitGateway");
   }
 }
 
@@ -40870,7 +40816,7 @@ export interface TransitGatewayAssociation {
 
 export namespace TransitGatewayAssociation {
   export function isa(o: any): o is TransitGatewayAssociation {
-    return _smithy.isa(o, "TransitGatewayAssociation");
+    return __isa(o, "TransitGatewayAssociation");
   }
 }
 
@@ -40938,7 +40884,7 @@ export interface TransitGatewayAttachment {
 
 export namespace TransitGatewayAttachment {
   export function isa(o: any): o is TransitGatewayAttachment {
-    return _smithy.isa(o, "TransitGatewayAttachment");
+    return __isa(o, "TransitGatewayAttachment");
   }
 }
 
@@ -40960,7 +40906,7 @@ export interface TransitGatewayAttachmentAssociation {
 
 export namespace TransitGatewayAttachmentAssociation {
   export function isa(o: any): o is TransitGatewayAttachmentAssociation {
-    return _smithy.isa(o, "TransitGatewayAttachmentAssociation");
+    return __isa(o, "TransitGatewayAttachmentAssociation");
   }
 }
 
@@ -40982,7 +40928,7 @@ export interface TransitGatewayAttachmentPropagation {
 
 export namespace TransitGatewayAttachmentPropagation {
   export function isa(o: any): o is TransitGatewayAttachmentPropagation {
-    return _smithy.isa(o, "TransitGatewayAttachmentPropagation");
+    return __isa(o, "TransitGatewayAttachmentPropagation");
   }
 }
 
@@ -41037,7 +40983,7 @@ export namespace TransitGatewayMulticastDeregisteredGroupMembers {
   export function isa(
     o: any
   ): o is TransitGatewayMulticastDeregisteredGroupMembers {
-    return _smithy.isa(o, "TransitGatewayMulticastDeregisteredGroupMembers");
+    return __isa(o, "TransitGatewayMulticastDeregisteredGroupMembers");
   }
 }
 
@@ -41066,7 +41012,7 @@ export namespace TransitGatewayMulticastDeregisteredGroupSources {
   export function isa(
     o: any
   ): o is TransitGatewayMulticastDeregisteredGroupSources {
-    return _smithy.isa(o, "TransitGatewayMulticastDeregisteredGroupSources");
+    return __isa(o, "TransitGatewayMulticastDeregisteredGroupSources");
   }
 }
 
@@ -41103,7 +41049,7 @@ export interface TransitGatewayMulticastDomain {
 
 export namespace TransitGatewayMulticastDomain {
   export function isa(o: any): o is TransitGatewayMulticastDomain {
-    return _smithy.isa(o, "TransitGatewayMulticastDomain");
+    return __isa(o, "TransitGatewayMulticastDomain");
   }
 }
 
@@ -41135,7 +41081,7 @@ export interface TransitGatewayMulticastDomainAssociation {
 
 export namespace TransitGatewayMulticastDomainAssociation {
   export function isa(o: any): o is TransitGatewayMulticastDomainAssociation {
-    return _smithy.isa(o, "TransitGatewayMulticastDomainAssociation");
+    return __isa(o, "TransitGatewayMulticastDomainAssociation");
   }
 }
 
@@ -41172,7 +41118,7 @@ export interface TransitGatewayMulticastDomainAssociations {
 
 export namespace TransitGatewayMulticastDomainAssociations {
   export function isa(o: any): o is TransitGatewayMulticastDomainAssociations {
-    return _smithy.isa(o, "TransitGatewayMulticastDomainAssociations");
+    return __isa(o, "TransitGatewayMulticastDomainAssociations");
   }
 }
 
@@ -41240,7 +41186,7 @@ export interface TransitGatewayMulticastGroup {
 
 export namespace TransitGatewayMulticastGroup {
   export function isa(o: any): o is TransitGatewayMulticastGroup {
-    return _smithy.isa(o, "TransitGatewayMulticastGroup");
+    return __isa(o, "TransitGatewayMulticastGroup");
   }
 }
 
@@ -41269,7 +41215,7 @@ export namespace TransitGatewayMulticastRegisteredGroupMembers {
   export function isa(
     o: any
   ): o is TransitGatewayMulticastRegisteredGroupMembers {
-    return _smithy.isa(o, "TransitGatewayMulticastRegisteredGroupMembers");
+    return __isa(o, "TransitGatewayMulticastRegisteredGroupMembers");
   }
 }
 
@@ -41298,7 +41244,7 @@ export namespace TransitGatewayMulticastRegisteredGroupSources {
   export function isa(
     o: any
   ): o is TransitGatewayMulticastRegisteredGroupSources {
-    return _smithy.isa(o, "TransitGatewayMulticastRegisteredGroupSources");
+    return __isa(o, "TransitGatewayMulticastRegisteredGroupSources");
   }
 }
 
@@ -41356,7 +41302,7 @@ export interface TransitGatewayOptions {
 
 export namespace TransitGatewayOptions {
   export function isa(o: any): o is TransitGatewayOptions {
-    return _smithy.isa(o, "TransitGatewayOptions");
+    return __isa(o, "TransitGatewayOptions");
   }
 }
 
@@ -41403,7 +41349,7 @@ export interface TransitGatewayPeeringAttachment {
 
 export namespace TransitGatewayPeeringAttachment {
   export function isa(o: any): o is TransitGatewayPeeringAttachment {
-    return _smithy.isa(o, "TransitGatewayPeeringAttachment");
+    return __isa(o, "TransitGatewayPeeringAttachment");
   }
 }
 
@@ -41440,7 +41386,7 @@ export interface TransitGatewayPropagation {
 
 export namespace TransitGatewayPropagation {
   export function isa(o: any): o is TransitGatewayPropagation {
-    return _smithy.isa(o, "TransitGatewayPropagation");
+    return __isa(o, "TransitGatewayPropagation");
   }
 }
 
@@ -41494,7 +41440,7 @@ export interface TransitGatewayRequestOptions {
 
 export namespace TransitGatewayRequestOptions {
   export function isa(o: any): o is TransitGatewayRequestOptions {
-    return _smithy.isa(o, "TransitGatewayRequestOptions");
+    return __isa(o, "TransitGatewayRequestOptions");
   }
 }
 
@@ -41526,7 +41472,7 @@ export interface TransitGatewayRoute {
 
 export namespace TransitGatewayRoute {
   export function isa(o: any): o is TransitGatewayRoute {
-    return _smithy.isa(o, "TransitGatewayRoute");
+    return __isa(o, "TransitGatewayRoute");
   }
 }
 
@@ -41553,7 +41499,7 @@ export interface TransitGatewayRouteAttachment {
 
 export namespace TransitGatewayRouteAttachment {
   export function isa(o: any): o is TransitGatewayRouteAttachment {
-    return _smithy.isa(o, "TransitGatewayRouteAttachment");
+    return __isa(o, "TransitGatewayRouteAttachment");
   }
 }
 
@@ -41607,7 +41553,7 @@ export interface TransitGatewayRouteTable {
 
 export namespace TransitGatewayRouteTable {
   export function isa(o: any): o is TransitGatewayRouteTable {
-    return _smithy.isa(o, "TransitGatewayRouteTable");
+    return __isa(o, "TransitGatewayRouteTable");
   }
 }
 
@@ -41639,7 +41585,7 @@ export interface TransitGatewayRouteTableAssociation {
 
 export namespace TransitGatewayRouteTableAssociation {
   export function isa(o: any): o is TransitGatewayRouteTableAssociation {
-    return _smithy.isa(o, "TransitGatewayRouteTableAssociation");
+    return __isa(o, "TransitGatewayRouteTableAssociation");
   }
 }
 
@@ -41671,7 +41617,7 @@ export interface TransitGatewayRouteTablePropagation {
 
 export namespace TransitGatewayRouteTablePropagation {
   export function isa(o: any): o is TransitGatewayRouteTablePropagation {
-    return _smithy.isa(o, "TransitGatewayRouteTablePropagation");
+    return __isa(o, "TransitGatewayRouteTablePropagation");
   }
 }
 
@@ -41743,7 +41689,7 @@ export interface TransitGatewayVpcAttachment {
 
 export namespace TransitGatewayVpcAttachment {
   export function isa(o: any): o is TransitGatewayVpcAttachment {
-    return _smithy.isa(o, "TransitGatewayVpcAttachment");
+    return __isa(o, "TransitGatewayVpcAttachment");
   }
 }
 
@@ -41765,7 +41711,7 @@ export interface TransitGatewayVpcAttachmentOptions {
 
 export namespace TransitGatewayVpcAttachmentOptions {
   export function isa(o: any): o is TransitGatewayVpcAttachmentOptions {
-    return _smithy.isa(o, "TransitGatewayVpcAttachmentOptions");
+    return __isa(o, "TransitGatewayVpcAttachmentOptions");
   }
 }
 
@@ -41860,7 +41806,7 @@ export interface TunnelOption {
 
 export namespace TunnelOption {
   export function isa(o: any): o is TunnelOption {
-    return _smithy.isa(o, "TunnelOption");
+    return __isa(o, "TunnelOption");
   }
 }
 
@@ -41879,7 +41825,7 @@ export interface UnassignIpv6AddressesRequest {
 
 export namespace UnassignIpv6AddressesRequest {
   export function isa(o: any): o is UnassignIpv6AddressesRequest {
-    return _smithy.isa(o, "UnassignIpv6AddressesRequest");
+    return __isa(o, "UnassignIpv6AddressesRequest");
   }
 }
 
@@ -41898,7 +41844,7 @@ export interface UnassignIpv6AddressesResult extends $MetadataBearer {
 
 export namespace UnassignIpv6AddressesResult {
   export function isa(o: any): o is UnassignIpv6AddressesResult {
-    return _smithy.isa(o, "UnassignIpv6AddressesResult");
+    return __isa(o, "UnassignIpv6AddressesResult");
   }
 }
 
@@ -41920,7 +41866,7 @@ export interface UnassignPrivateIpAddressesRequest {
 
 export namespace UnassignPrivateIpAddressesRequest {
   export function isa(o: any): o is UnassignPrivateIpAddressesRequest {
-    return _smithy.isa(o, "UnassignPrivateIpAddressesRequest");
+    return __isa(o, "UnassignPrivateIpAddressesRequest");
   }
 }
 
@@ -41943,7 +41889,7 @@ export interface UnmonitorInstancesRequest {
 
 export namespace UnmonitorInstancesRequest {
   export function isa(o: any): o is UnmonitorInstancesRequest {
-    return _smithy.isa(o, "UnmonitorInstancesRequest");
+    return __isa(o, "UnmonitorInstancesRequest");
   }
 }
 
@@ -41957,7 +41903,7 @@ export interface UnmonitorInstancesResult extends $MetadataBearer {
 
 export namespace UnmonitorInstancesResult {
   export function isa(o: any): o is UnmonitorInstancesResult {
-    return _smithy.isa(o, "UnmonitorInstancesResult");
+    return __isa(o, "UnmonitorInstancesResult");
   }
 }
 
@@ -41990,7 +41936,7 @@ export namespace UnsuccessfulInstanceCreditSpecificationItem {
   export function isa(
     o: any
   ): o is UnsuccessfulInstanceCreditSpecificationItem {
-    return _smithy.isa(o, "UnsuccessfulInstanceCreditSpecificationItem");
+    return __isa(o, "UnsuccessfulInstanceCreditSpecificationItem");
   }
 }
 
@@ -42015,7 +41961,7 @@ export namespace UnsuccessfulInstanceCreditSpecificationItemError {
   export function isa(
     o: any
   ): o is UnsuccessfulInstanceCreditSpecificationItemError {
-    return _smithy.isa(o, "UnsuccessfulInstanceCreditSpecificationItemError");
+    return __isa(o, "UnsuccessfulInstanceCreditSpecificationItemError");
   }
 }
 
@@ -42037,7 +41983,7 @@ export interface UnsuccessfulItem {
 
 export namespace UnsuccessfulItem {
   export function isa(o: any): o is UnsuccessfulItem {
-    return _smithy.isa(o, "UnsuccessfulItem");
+    return __isa(o, "UnsuccessfulItem");
   }
 }
 
@@ -42059,7 +42005,7 @@ export interface UnsuccessfulItemError {
 
 export namespace UnsuccessfulItemError {
   export function isa(o: any): o is UnsuccessfulItemError {
-    return _smithy.isa(o, "UnsuccessfulItemError");
+    return __isa(o, "UnsuccessfulItemError");
   }
 }
 
@@ -42095,7 +42041,7 @@ export namespace UpdateSecurityGroupRuleDescriptionsEgressRequest {
   export function isa(
     o: any
   ): o is UpdateSecurityGroupRuleDescriptionsEgressRequest {
-    return _smithy.isa(o, "UpdateSecurityGroupRuleDescriptionsEgressRequest");
+    return __isa(o, "UpdateSecurityGroupRuleDescriptionsEgressRequest");
   }
 }
 
@@ -42112,7 +42058,7 @@ export namespace UpdateSecurityGroupRuleDescriptionsEgressResult {
   export function isa(
     o: any
   ): o is UpdateSecurityGroupRuleDescriptionsEgressResult {
-    return _smithy.isa(o, "UpdateSecurityGroupRuleDescriptionsEgressResult");
+    return __isa(o, "UpdateSecurityGroupRuleDescriptionsEgressResult");
   }
 }
 
@@ -42148,7 +42094,7 @@ export namespace UpdateSecurityGroupRuleDescriptionsIngressRequest {
   export function isa(
     o: any
   ): o is UpdateSecurityGroupRuleDescriptionsIngressRequest {
-    return _smithy.isa(o, "UpdateSecurityGroupRuleDescriptionsIngressRequest");
+    return __isa(o, "UpdateSecurityGroupRuleDescriptionsIngressRequest");
   }
 }
 
@@ -42165,7 +42111,7 @@ export namespace UpdateSecurityGroupRuleDescriptionsIngressResult {
   export function isa(
     o: any
   ): o is UpdateSecurityGroupRuleDescriptionsIngressResult {
-    return _smithy.isa(o, "UpdateSecurityGroupRuleDescriptionsIngressResult");
+    return __isa(o, "UpdateSecurityGroupRuleDescriptionsIngressResult");
   }
 }
 
@@ -42189,7 +42135,7 @@ export interface UserBucket {
 
 export namespace UserBucket {
   export function isa(o: any): o is UserBucket {
-    return _smithy.isa(o, "UserBucket");
+    return __isa(o, "UserBucket");
   }
 }
 
@@ -42211,7 +42157,7 @@ export interface UserBucketDetails {
 
 export namespace UserBucketDetails {
   export function isa(o: any): o is UserBucketDetails {
-    return _smithy.isa(o, "UserBucketDetails");
+    return __isa(o, "UserBucketDetails");
   }
 }
 
@@ -42229,7 +42175,7 @@ export interface UserData {
 
 export namespace UserData {
   export function isa(o: any): o is UserData {
-    return _smithy.isa(o, "UserData");
+    return __isa(o, "UserData");
   }
 }
 
@@ -42288,7 +42234,7 @@ export interface UserIdGroupPair {
 
 export namespace UserIdGroupPair {
   export function isa(o: any): o is UserIdGroupPair {
-    return _smithy.isa(o, "UserIdGroupPair");
+    return __isa(o, "UserIdGroupPair");
   }
 }
 
@@ -42325,7 +42271,7 @@ export interface VCpuInfo {
 
 export namespace VCpuInfo {
   export function isa(o: any): o is VCpuInfo {
-    return _smithy.isa(o, "VCpuInfo");
+    return __isa(o, "VCpuInfo");
   }
 }
 
@@ -42367,7 +42313,7 @@ export interface VgwTelemetry {
 
 export namespace VgwTelemetry {
   export function isa(o: any): o is VgwTelemetry {
-    return _smithy.isa(o, "VgwTelemetry");
+    return __isa(o, "VgwTelemetry");
   }
 }
 
@@ -42466,7 +42412,7 @@ export interface Volume extends $MetadataBearer {
 
 export namespace Volume {
   export function isa(o: any): o is Volume {
-    return _smithy.isa(o, "Volume");
+    return __isa(o, "Volume");
   }
 }
 
@@ -42508,7 +42454,7 @@ export interface VolumeAttachment extends $MetadataBearer {
 
 export namespace VolumeAttachment {
   export function isa(o: any): o is VolumeAttachment {
-    return _smithy.isa(o, "VolumeAttachment");
+    return __isa(o, "VolumeAttachment");
   }
 }
 
@@ -42534,7 +42480,7 @@ export interface VolumeDetail {
 
 export namespace VolumeDetail {
   export function isa(o: any): o is VolumeDetail {
-    return _smithy.isa(o, "VolumeDetail");
+    return __isa(o, "VolumeDetail");
   }
 }
 
@@ -42608,7 +42554,7 @@ export interface VolumeModification {
 
 export namespace VolumeModification {
   export function isa(o: any): o is VolumeModification {
-    return _smithy.isa(o, "VolumeModification");
+    return __isa(o, "VolumeModification");
   }
 }
 
@@ -42654,7 +42600,7 @@ export interface VolumeStatusAction {
 
 export namespace VolumeStatusAction {
   export function isa(o: any): o is VolumeStatusAction {
-    return _smithy.isa(o, "VolumeStatusAction");
+    return __isa(o, "VolumeStatusAction");
   }
 }
 
@@ -42676,7 +42622,7 @@ export interface VolumeStatusDetails {
 
 export namespace VolumeStatusDetails {
   export function isa(o: any): o is VolumeStatusDetails {
-    return _smithy.isa(o, "VolumeStatusDetails");
+    return __isa(o, "VolumeStatusDetails");
   }
 }
 
@@ -42713,7 +42659,7 @@ export interface VolumeStatusEvent {
 
 export namespace VolumeStatusEvent {
   export function isa(o: any): o is VolumeStatusEvent {
-    return _smithy.isa(o, "VolumeStatusEvent");
+    return __isa(o, "VolumeStatusEvent");
   }
 }
 
@@ -42735,7 +42681,7 @@ export interface VolumeStatusInfo {
 
 export namespace VolumeStatusInfo {
   export function isa(o: any): o is VolumeStatusInfo {
-    return _smithy.isa(o, "VolumeStatusInfo");
+    return __isa(o, "VolumeStatusInfo");
   }
 }
 
@@ -42779,7 +42725,7 @@ export interface VolumeStatusItem {
 
 export namespace VolumeStatusItem {
   export function isa(o: any): o is VolumeStatusItem {
-    return _smithy.isa(o, "VolumeStatusItem");
+    return __isa(o, "VolumeStatusItem");
   }
 }
 
@@ -42846,7 +42792,7 @@ export interface Vpc {
 
 export namespace Vpc {
   export function isa(o: any): o is Vpc {
-    return _smithy.isa(o, "Vpc");
+    return __isa(o, "Vpc");
   }
 }
 
@@ -42868,7 +42814,7 @@ export interface VpcAttachment {
 
 export namespace VpcAttachment {
   export function isa(o: any): o is VpcAttachment {
-    return _smithy.isa(o, "VpcAttachment");
+    return __isa(o, "VpcAttachment");
   }
 }
 
@@ -42897,7 +42843,7 @@ export interface VpcCidrBlockAssociation {
 
 export namespace VpcCidrBlockAssociation {
   export function isa(o: any): o is VpcCidrBlockAssociation {
-    return _smithy.isa(o, "VpcCidrBlockAssociation");
+    return __isa(o, "VpcCidrBlockAssociation");
   }
 }
 
@@ -42919,7 +42865,7 @@ export interface VpcCidrBlockState {
 
 export namespace VpcCidrBlockState {
   export function isa(o: any): o is VpcCidrBlockState {
-    return _smithy.isa(o, "VpcCidrBlockState");
+    return __isa(o, "VpcCidrBlockState");
   }
 }
 
@@ -42954,7 +42900,7 @@ export interface VpcClassicLink {
 
 export namespace VpcClassicLink {
   export function isa(o: any): o is VpcClassicLink {
-    return _smithy.isa(o, "VpcClassicLink");
+    return __isa(o, "VpcClassicLink");
   }
 }
 
@@ -43052,7 +42998,7 @@ export interface VpcEndpoint {
 
 export namespace VpcEndpoint {
   export function isa(o: any): o is VpcEndpoint {
-    return _smithy.isa(o, "VpcEndpoint");
+    return __isa(o, "VpcEndpoint");
   }
 }
 
@@ -43099,7 +43045,7 @@ export interface VpcEndpointConnection {
 
 export namespace VpcEndpointConnection {
   export function isa(o: any): o is VpcEndpointConnection {
-    return _smithy.isa(o, "VpcEndpointConnection");
+    return __isa(o, "VpcEndpointConnection");
   }
 }
 
@@ -43141,7 +43087,7 @@ export interface VpcIpv6CidrBlockAssociation {
 
 export namespace VpcIpv6CidrBlockAssociation {
   export function isa(o: any): o is VpcIpv6CidrBlockAssociation {
-    return _smithy.isa(o, "VpcIpv6CidrBlockAssociation");
+    return __isa(o, "VpcIpv6CidrBlockAssociation");
   }
 }
 
@@ -43183,7 +43129,7 @@ export interface VpcPeeringConnection {
 
 export namespace VpcPeeringConnection {
   export function isa(o: any): o is VpcPeeringConnection {
-    return _smithy.isa(o, "VpcPeeringConnection");
+    return __isa(o, "VpcPeeringConnection");
   }
 }
 
@@ -43210,7 +43156,7 @@ export interface VpcPeeringConnectionOptionsDescription {
 
 export namespace VpcPeeringConnectionOptionsDescription {
   export function isa(o: any): o is VpcPeeringConnectionOptionsDescription {
-    return _smithy.isa(o, "VpcPeeringConnectionOptionsDescription");
+    return __isa(o, "VpcPeeringConnectionOptionsDescription");
   }
 }
 
@@ -43232,7 +43178,7 @@ export interface VpcPeeringConnectionStateReason {
 
 export namespace VpcPeeringConnectionStateReason {
   export function isa(o: any): o is VpcPeeringConnectionStateReason {
-    return _smithy.isa(o, "VpcPeeringConnectionStateReason");
+    return __isa(o, "VpcPeeringConnectionStateReason");
   }
 }
 
@@ -43290,7 +43236,7 @@ export interface VpcPeeringConnectionVpcInfo {
 
 export namespace VpcPeeringConnectionVpcInfo {
   export function isa(o: any): o is VpcPeeringConnectionVpcInfo {
-    return _smithy.isa(o, "VpcPeeringConnectionVpcInfo");
+    return __isa(o, "VpcPeeringConnectionVpcInfo");
   }
 }
 
@@ -43370,7 +43316,7 @@ export interface VpnConnection {
 
 export namespace VpnConnection {
   export function isa(o: any): o is VpnConnection {
-    return _smithy.isa(o, "VpnConnection");
+    return __isa(o, "VpnConnection");
   }
 }
 
@@ -43397,7 +43343,7 @@ export interface VpnConnectionOptions {
 
 export namespace VpnConnectionOptions {
   export function isa(o: any): o is VpnConnectionOptions {
-    return _smithy.isa(o, "VpnConnectionOptions");
+    return __isa(o, "VpnConnectionOptions");
   }
 }
 
@@ -43430,7 +43376,7 @@ export interface VpnConnectionOptionsSpecification {
 
 export namespace VpnConnectionOptionsSpecification {
   export function isa(o: any): o is VpnConnectionOptionsSpecification {
-    return _smithy.isa(o, "VpnConnectionOptionsSpecification");
+    return __isa(o, "VpnConnectionOptionsSpecification");
   }
 }
 
@@ -43479,7 +43425,7 @@ export interface VpnGateway {
 
 export namespace VpnGateway {
   export function isa(o: any): o is VpnGateway {
-    return _smithy.isa(o, "VpnGateway");
+    return __isa(o, "VpnGateway");
   }
 }
 
@@ -43510,7 +43456,7 @@ export interface VpnStaticRoute {
 
 export namespace VpnStaticRoute {
   export function isa(o: any): o is VpnStaticRoute {
-    return _smithy.isa(o, "VpnStaticRoute");
+    return __isa(o, "VpnStaticRoute");
   }
 }
 
@@ -43679,7 +43625,7 @@ export interface VpnTunnelOptionsSpecification {
 
 export namespace VpnTunnelOptionsSpecification {
   export function isa(o: any): o is VpnTunnelOptionsSpecification {
-    return _smithy.isa(o, "VpnTunnelOptionsSpecification");
+    return __isa(o, "VpnTunnelOptionsSpecification");
   }
 }
 
@@ -43700,7 +43646,7 @@ export interface WithdrawByoipCidrRequest {
 
 export namespace WithdrawByoipCidrRequest {
   export function isa(o: any): o is WithdrawByoipCidrRequest {
-    return _smithy.isa(o, "WithdrawByoipCidrRequest");
+    return __isa(o, "WithdrawByoipCidrRequest");
   }
 }
 
@@ -43714,7 +43660,7 @@ export interface WithdrawByoipCidrResult extends $MetadataBearer {
 
 export namespace WithdrawByoipCidrResult {
   export function isa(o: any): o is WithdrawByoipCidrResult {
-    return _smithy.isa(o, "WithdrawByoipCidrResult");
+    return __isa(o, "WithdrawByoipCidrResult");
   }
 }
 

--- a/clients/client-ec2/protocols/Aws_ec2.ts
+++ b/clients/client-ec2/protocols/Aws_ec2.ts
@@ -10603,6 +10603,7 @@ export async function deserializeAws_ec2AssociateDhcpOptionsCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_ec2AssociateDhcpOptionsCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: AssociateDhcpOptionsCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -11040,6 +11041,7 @@ export async function deserializeAws_ec2AttachInternetGatewayCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_ec2AttachInternetGatewayCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: AttachInternetGatewayCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -11309,6 +11311,7 @@ export async function deserializeAws_ec2AuthorizeSecurityGroupEgressCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: AuthorizeSecurityGroupEgressCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -11360,6 +11363,7 @@ export async function deserializeAws_ec2AuthorizeSecurityGroupIngressCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: AuthorizeSecurityGroupIngressCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -11570,6 +11574,7 @@ export async function deserializeAws_ec2CancelConversionTaskCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_ec2CancelConversionTaskCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: CancelConversionTaskCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -11618,6 +11623,7 @@ export async function deserializeAws_ec2CancelExportTaskCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_ec2CancelExportTaskCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: CancelExportTaskCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -13245,6 +13251,7 @@ export async function deserializeAws_ec2CreateNetworkAclEntryCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_ec2CreateNetworkAclEntryCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: CreateNetworkAclEntryCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -13408,6 +13415,7 @@ export async function deserializeAws_ec2CreatePlacementGroupCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_ec2CreatePlacementGroupCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: CreatePlacementGroupCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -13892,6 +13900,7 @@ export async function deserializeAws_ec2CreateTagsCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_ec2CreateTagsCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: CreateTagsCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -14901,6 +14910,7 @@ export async function deserializeAws_ec2CreateVpnConnectionRouteCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: CreateVpnConnectionRouteCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -15111,6 +15121,7 @@ export async function deserializeAws_ec2DeleteCustomerGatewayCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_ec2DeleteCustomerGatewayCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteCustomerGatewayCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -15159,6 +15170,7 @@ export async function deserializeAws_ec2DeleteDhcpOptionsCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_ec2DeleteDhcpOptionsCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteDhcpOptionsCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -15425,6 +15437,7 @@ export async function deserializeAws_ec2DeleteInternetGatewayCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_ec2DeleteInternetGatewayCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteInternetGatewayCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -15473,6 +15486,7 @@ export async function deserializeAws_ec2DeleteKeyPairCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_ec2DeleteKeyPairCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteKeyPairCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -15801,6 +15815,7 @@ export async function deserializeAws_ec2DeleteNetworkAclCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_ec2DeleteNetworkAclCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteNetworkAclCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -15849,6 +15864,7 @@ export async function deserializeAws_ec2DeleteNetworkAclEntryCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_ec2DeleteNetworkAclEntryCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteNetworkAclEntryCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -15900,6 +15916,7 @@ export async function deserializeAws_ec2DeleteNetworkInterfaceCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteNetworkInterfaceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -16007,6 +16024,7 @@ export async function deserializeAws_ec2DeletePlacementGroupCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_ec2DeletePlacementGroupCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeletePlacementGroupCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -16114,6 +16132,7 @@ export async function deserializeAws_ec2DeleteRouteCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_ec2DeleteRouteCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteRouteCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -16162,6 +16181,7 @@ export async function deserializeAws_ec2DeleteRouteTableCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_ec2DeleteRouteTableCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteRouteTableCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -16210,6 +16230,7 @@ export async function deserializeAws_ec2DeleteSecurityGroupCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_ec2DeleteSecurityGroupCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteSecurityGroupCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -16258,6 +16279,7 @@ export async function deserializeAws_ec2DeleteSnapshotCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_ec2DeleteSnapshotCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteSnapshotCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -16309,6 +16331,7 @@ export async function deserializeAws_ec2DeleteSpotDatafeedSubscriptionCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteSpotDatafeedSubscriptionCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -16357,6 +16380,7 @@ export async function deserializeAws_ec2DeleteSubnetCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_ec2DeleteSubnetCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteSubnetCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -16405,6 +16429,7 @@ export async function deserializeAws_ec2DeleteTagsCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_ec2DeleteTagsCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteTagsCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -17025,6 +17050,7 @@ export async function deserializeAws_ec2DeleteVolumeCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_ec2DeleteVolumeCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteVolumeCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -17073,6 +17099,7 @@ export async function deserializeAws_ec2DeleteVpcCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_ec2DeleteVpcCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteVpcCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -17348,6 +17375,7 @@ export async function deserializeAws_ec2DeleteVpnConnectionCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_ec2DeleteVpnConnectionCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteVpnConnectionCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -17399,6 +17427,7 @@ export async function deserializeAws_ec2DeleteVpnConnectionRouteCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteVpnConnectionRouteCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -17447,6 +17476,7 @@ export async function deserializeAws_ec2DeleteVpnGatewayCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_ec2DeleteVpnGatewayCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteVpnGatewayCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -17548,6 +17578,7 @@ export async function deserializeAws_ec2DeregisterImageCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_ec2DeregisterImageCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeregisterImageCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -24074,6 +24105,7 @@ export async function deserializeAws_ec2DetachInternetGatewayCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_ec2DetachInternetGatewayCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DetachInternetGatewayCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -24125,6 +24157,7 @@ export async function deserializeAws_ec2DetachNetworkInterfaceCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DetachNetworkInterfaceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -24226,6 +24259,7 @@ export async function deserializeAws_ec2DetachVpnGatewayCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_ec2DetachVpnGatewayCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DetachVpnGatewayCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -24451,6 +24485,7 @@ export async function deserializeAws_ec2DisableVgwRoutePropagationCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DisableVgwRoutePropagationCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -24611,6 +24646,7 @@ export async function deserializeAws_ec2DisassociateAddressCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_ec2DisassociateAddressCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DisassociateAddressCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -24780,6 +24816,7 @@ export async function deserializeAws_ec2DisassociateRouteTableCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DisassociateRouteTableCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -25235,6 +25272,7 @@ export async function deserializeAws_ec2EnableVgwRoutePropagationCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: EnableVgwRoutePropagationCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -25283,6 +25321,7 @@ export async function deserializeAws_ec2EnableVolumeIOCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_ec2EnableVolumeIOCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: EnableVolumeIOCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -27282,6 +27321,7 @@ export async function deserializeAws_ec2ModifyIdFormatCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_ec2ModifyIdFormatCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: ModifyIdFormatCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -27333,6 +27373,7 @@ export async function deserializeAws_ec2ModifyIdentityIdFormatCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: ModifyIdentityIdFormatCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -27381,6 +27422,7 @@ export async function deserializeAws_ec2ModifyImageAttributeCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_ec2ModifyImageAttributeCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: ModifyImageAttributeCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -27432,6 +27474,7 @@ export async function deserializeAws_ec2ModifyInstanceAttributeCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: ModifyInstanceAttributeCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -27828,6 +27871,7 @@ export async function deserializeAws_ec2ModifyNetworkInterfaceAttributeCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: ModifyNetworkInterfaceAttributeCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -27935,6 +27979,7 @@ export async function deserializeAws_ec2ModifySnapshotAttributeCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: ModifySnapshotAttributeCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -28039,6 +28084,7 @@ export async function deserializeAws_ec2ModifySubnetAttributeCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_ec2ModifySubnetAttributeCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: ModifySubnetAttributeCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -28373,6 +28419,7 @@ export async function deserializeAws_ec2ModifyVolumeAttributeCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_ec2ModifyVolumeAttributeCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: ModifyVolumeAttributeCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -28421,6 +28468,7 @@ export async function deserializeAws_ec2ModifyVpcAttributeCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_ec2ModifyVpcAttributeCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: ModifyVpcAttributeCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -29306,6 +29354,7 @@ export async function deserializeAws_ec2RebootInstancesCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_ec2RebootInstancesCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: RebootInstancesCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -29758,6 +29807,7 @@ export async function deserializeAws_ec2ReleaseAddressCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_ec2ReleaseAddressCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: ReleaseAddressCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -29980,6 +30030,7 @@ export async function deserializeAws_ec2ReplaceNetworkAclEntryCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: ReplaceNetworkAclEntryCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -30028,6 +30079,7 @@ export async function deserializeAws_ec2ReplaceRouteCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_ec2ReplaceRouteCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: ReplaceRouteCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -30191,6 +30243,7 @@ export async function deserializeAws_ec2ReportInstanceStatusCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_ec2ReportInstanceStatusCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: ReportInstanceStatusCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -30457,6 +30510,7 @@ export async function deserializeAws_ec2ResetImageAttributeCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_ec2ResetImageAttributeCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: ResetImageAttributeCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -30508,6 +30562,7 @@ export async function deserializeAws_ec2ResetInstanceAttributeCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: ResetInstanceAttributeCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -30559,6 +30614,7 @@ export async function deserializeAws_ec2ResetNetworkInterfaceAttributeCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: ResetNetworkInterfaceAttributeCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -30610,6 +30666,7 @@ export async function deserializeAws_ec2ResetSnapshotAttributeCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: ResetSnapshotAttributeCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -30773,6 +30830,7 @@ export async function deserializeAws_ec2RevokeSecurityGroupEgressCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: RevokeSecurityGroupEgressCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -30824,6 +30882,7 @@ export async function deserializeAws_ec2RevokeSecurityGroupIngressCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: RevokeSecurityGroupIngressCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -31152,6 +31211,7 @@ export async function deserializeAws_ec2SendDiagnosticInterruptCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: SendDiagnosticInterruptCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -31533,6 +31593,7 @@ export async function deserializeAws_ec2UnassignPrivateIpAddressesCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: UnassignPrivateIpAddressesCommandOutput = {
     $metadata: deserializeMetadata(output)
   };

--- a/clients/client-ecr/models/index.ts
+++ b/clients/client-ecr/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -19,7 +22,7 @@ export interface Attribute {
 
 export namespace Attribute {
   export function isa(o: any): o is Attribute {
-    return _smithy.isa(o, "Attribute");
+    return __isa(o, "Attribute");
   }
 }
 
@@ -53,7 +56,7 @@ export interface AuthorizationData {
 
 export namespace AuthorizationData {
   export function isa(o: any): o is AuthorizationData {
-    return _smithy.isa(o, "AuthorizationData");
+    return __isa(o, "AuthorizationData");
   }
 }
 
@@ -78,7 +81,7 @@ export interface BatchCheckLayerAvailabilityRequest {
 
 export namespace BatchCheckLayerAvailabilityRequest {
   export function isa(o: any): o is BatchCheckLayerAvailabilityRequest {
-    return _smithy.isa(o, "BatchCheckLayerAvailabilityRequest");
+    return __isa(o, "BatchCheckLayerAvailabilityRequest");
   }
 }
 
@@ -98,7 +101,7 @@ export interface BatchCheckLayerAvailabilityResponse extends $MetadataBearer {
 
 export namespace BatchCheckLayerAvailabilityResponse {
   export function isa(o: any): o is BatchCheckLayerAvailabilityResponse {
-    return _smithy.isa(o, "BatchCheckLayerAvailabilityResponse");
+    return __isa(o, "BatchCheckLayerAvailabilityResponse");
   }
 }
 
@@ -129,7 +132,7 @@ export interface BatchDeleteImageRequest {
 
 export namespace BatchDeleteImageRequest {
   export function isa(o: any): o is BatchDeleteImageRequest {
-    return _smithy.isa(o, "BatchDeleteImageRequest");
+    return __isa(o, "BatchDeleteImageRequest");
   }
 }
 
@@ -148,7 +151,7 @@ export interface BatchDeleteImageResponse extends $MetadataBearer {
 
 export namespace BatchDeleteImageResponse {
   export function isa(o: any): o is BatchDeleteImageResponse {
-    return _smithy.isa(o, "BatchDeleteImageResponse");
+    return __isa(o, "BatchDeleteImageResponse");
   }
 }
 
@@ -184,7 +187,7 @@ export interface BatchGetImageRequest {
 
 export namespace BatchGetImageRequest {
   export function isa(o: any): o is BatchGetImageRequest {
-    return _smithy.isa(o, "BatchGetImageRequest");
+    return __isa(o, "BatchGetImageRequest");
   }
 }
 
@@ -203,7 +206,7 @@ export interface BatchGetImageResponse extends $MetadataBearer {
 
 export namespace BatchGetImageResponse {
   export function isa(o: any): o is BatchGetImageResponse {
-    return _smithy.isa(o, "BatchGetImageResponse");
+    return __isa(o, "BatchGetImageResponse");
   }
 }
 
@@ -234,7 +237,7 @@ export interface CompleteLayerUploadRequest {
 
 export namespace CompleteLayerUploadRequest {
   export function isa(o: any): o is CompleteLayerUploadRequest {
-    return _smithy.isa(o, "CompleteLayerUploadRequest");
+    return __isa(o, "CompleteLayerUploadRequest");
   }
 }
 
@@ -263,7 +266,7 @@ export interface CompleteLayerUploadResponse extends $MetadataBearer {
 
 export namespace CompleteLayerUploadResponse {
   export function isa(o: any): o is CompleteLayerUploadResponse {
-    return _smithy.isa(o, "CompleteLayerUploadResponse");
+    return __isa(o, "CompleteLayerUploadResponse");
   }
 }
 
@@ -302,7 +305,7 @@ export interface CreateRepositoryRequest {
 
 export namespace CreateRepositoryRequest {
   export function isa(o: any): o is CreateRepositoryRequest {
-    return _smithy.isa(o, "CreateRepositoryRequest");
+    return __isa(o, "CreateRepositoryRequest");
   }
 }
 
@@ -316,7 +319,7 @@ export interface CreateRepositoryResponse extends $MetadataBearer {
 
 export namespace CreateRepositoryResponse {
   export function isa(o: any): o is CreateRepositoryResponse {
-    return _smithy.isa(o, "CreateRepositoryResponse");
+    return __isa(o, "CreateRepositoryResponse");
   }
 }
 
@@ -336,7 +339,7 @@ export interface DeleteLifecyclePolicyRequest {
 
 export namespace DeleteLifecyclePolicyRequest {
   export function isa(o: any): o is DeleteLifecyclePolicyRequest {
-    return _smithy.isa(o, "DeleteLifecyclePolicyRequest");
+    return __isa(o, "DeleteLifecyclePolicyRequest");
   }
 }
 
@@ -365,7 +368,7 @@ export interface DeleteLifecyclePolicyResponse extends $MetadataBearer {
 
 export namespace DeleteLifecyclePolicyResponse {
   export function isa(o: any): o is DeleteLifecyclePolicyResponse {
-    return _smithy.isa(o, "DeleteLifecyclePolicyResponse");
+    return __isa(o, "DeleteLifecyclePolicyResponse");
   }
 }
 
@@ -386,7 +389,7 @@ export interface DeleteRepositoryPolicyRequest {
 
 export namespace DeleteRepositoryPolicyRequest {
   export function isa(o: any): o is DeleteRepositoryPolicyRequest {
-    return _smithy.isa(o, "DeleteRepositoryPolicyRequest");
+    return __isa(o, "DeleteRepositoryPolicyRequest");
   }
 }
 
@@ -410,7 +413,7 @@ export interface DeleteRepositoryPolicyResponse extends $MetadataBearer {
 
 export namespace DeleteRepositoryPolicyResponse {
   export function isa(o: any): o is DeleteRepositoryPolicyResponse {
-    return _smithy.isa(o, "DeleteRepositoryPolicyResponse");
+    return __isa(o, "DeleteRepositoryPolicyResponse");
   }
 }
 
@@ -435,7 +438,7 @@ export interface DeleteRepositoryRequest {
 
 export namespace DeleteRepositoryRequest {
   export function isa(o: any): o is DeleteRepositoryRequest {
-    return _smithy.isa(o, "DeleteRepositoryRequest");
+    return __isa(o, "DeleteRepositoryRequest");
   }
 }
 
@@ -449,7 +452,7 @@ export interface DeleteRepositoryResponse extends $MetadataBearer {
 
 export namespace DeleteRepositoryResponse {
   export function isa(o: any): o is DeleteRepositoryResponse {
-    return _smithy.isa(o, "DeleteRepositoryResponse");
+    return __isa(o, "DeleteRepositoryResponse");
   }
 }
 
@@ -497,7 +500,7 @@ export interface DescribeImageScanFindingsRequest {
 
 export namespace DescribeImageScanFindingsRequest {
   export function isa(o: any): o is DescribeImageScanFindingsRequest {
-    return _smithy.isa(o, "DescribeImageScanFindingsRequest");
+    return __isa(o, "DescribeImageScanFindingsRequest");
   }
 }
 
@@ -540,7 +543,7 @@ export interface DescribeImageScanFindingsResponse extends $MetadataBearer {
 
 export namespace DescribeImageScanFindingsResponse {
   export function isa(o: any): o is DescribeImageScanFindingsResponse {
-    return _smithy.isa(o, "DescribeImageScanFindingsResponse");
+    return __isa(o, "DescribeImageScanFindingsResponse");
   }
 }
 
@@ -560,7 +563,7 @@ export interface DescribeImagesFilter {
 
 export namespace DescribeImagesFilter {
   export function isa(o: any): o is DescribeImagesFilter {
-    return _smithy.isa(o, "DescribeImagesFilter");
+    return __isa(o, "DescribeImagesFilter");
   }
 }
 
@@ -614,7 +617,7 @@ export interface DescribeImagesRequest {
 
 export namespace DescribeImagesRequest {
   export function isa(o: any): o is DescribeImagesRequest {
-    return _smithy.isa(o, "DescribeImagesRequest");
+    return __isa(o, "DescribeImagesRequest");
   }
 }
 
@@ -638,7 +641,7 @@ export interface DescribeImagesResponse extends $MetadataBearer {
 
 export namespace DescribeImagesResponse {
   export function isa(o: any): o is DescribeImagesResponse {
-    return _smithy.isa(o, "DescribeImagesResponse");
+    return __isa(o, "DescribeImagesResponse");
   }
 }
 
@@ -687,7 +690,7 @@ export interface DescribeRepositoriesRequest {
 
 export namespace DescribeRepositoriesRequest {
   export function isa(o: any): o is DescribeRepositoriesRequest {
-    return _smithy.isa(o, "DescribeRepositoriesRequest");
+    return __isa(o, "DescribeRepositoriesRequest");
   }
 }
 
@@ -710,7 +713,7 @@ export interface DescribeRepositoriesResponse extends $MetadataBearer {
 
 export namespace DescribeRepositoriesResponse {
   export function isa(o: any): o is DescribeRepositoriesResponse {
-    return _smithy.isa(o, "DescribeRepositoriesResponse");
+    return __isa(o, "DescribeRepositoriesResponse");
   }
 }
 
@@ -718,7 +721,7 @@ export namespace DescribeRepositoriesResponse {
  * <p>The specified layer upload does not contain any layer parts.</p>
  */
 export interface EmptyUploadException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "EmptyUploadException";
   $fault: "client";
@@ -730,7 +733,7 @@ export interface EmptyUploadException
 
 export namespace EmptyUploadException {
   export function isa(o: any): o is EmptyUploadException {
-    return _smithy.isa(o, "EmptyUploadException");
+    return __isa(o, "EmptyUploadException");
   }
 }
 
@@ -754,7 +757,7 @@ export interface GetAuthorizationTokenRequest {
 
 export namespace GetAuthorizationTokenRequest {
   export function isa(o: any): o is GetAuthorizationTokenRequest {
-    return _smithy.isa(o, "GetAuthorizationTokenRequest");
+    return __isa(o, "GetAuthorizationTokenRequest");
   }
 }
 
@@ -769,7 +772,7 @@ export interface GetAuthorizationTokenResponse extends $MetadataBearer {
 
 export namespace GetAuthorizationTokenResponse {
   export function isa(o: any): o is GetAuthorizationTokenResponse {
-    return _smithy.isa(o, "GetAuthorizationTokenResponse");
+    return __isa(o, "GetAuthorizationTokenResponse");
   }
 }
 
@@ -794,7 +797,7 @@ export interface GetDownloadUrlForLayerRequest {
 
 export namespace GetDownloadUrlForLayerRequest {
   export function isa(o: any): o is GetDownloadUrlForLayerRequest {
-    return _smithy.isa(o, "GetDownloadUrlForLayerRequest");
+    return __isa(o, "GetDownloadUrlForLayerRequest");
   }
 }
 
@@ -813,7 +816,7 @@ export interface GetDownloadUrlForLayerResponse extends $MetadataBearer {
 
 export namespace GetDownloadUrlForLayerResponse {
   export function isa(o: any): o is GetDownloadUrlForLayerResponse {
-    return _smithy.isa(o, "GetDownloadUrlForLayerResponse");
+    return __isa(o, "GetDownloadUrlForLayerResponse");
   }
 }
 
@@ -869,7 +872,7 @@ export interface GetLifecyclePolicyPreviewRequest {
 
 export namespace GetLifecyclePolicyPreviewRequest {
   export function isa(o: any): o is GetLifecyclePolicyPreviewRequest {
-    return _smithy.isa(o, "GetLifecyclePolicyPreviewRequest");
+    return __isa(o, "GetLifecyclePolicyPreviewRequest");
   }
 }
 
@@ -917,7 +920,7 @@ export interface GetLifecyclePolicyPreviewResponse extends $MetadataBearer {
 
 export namespace GetLifecyclePolicyPreviewResponse {
   export function isa(o: any): o is GetLifecyclePolicyPreviewResponse {
-    return _smithy.isa(o, "GetLifecyclePolicyPreviewResponse");
+    return __isa(o, "GetLifecyclePolicyPreviewResponse");
   }
 }
 
@@ -937,7 +940,7 @@ export interface GetLifecyclePolicyRequest {
 
 export namespace GetLifecyclePolicyRequest {
   export function isa(o: any): o is GetLifecyclePolicyRequest {
-    return _smithy.isa(o, "GetLifecyclePolicyRequest");
+    return __isa(o, "GetLifecyclePolicyRequest");
   }
 }
 
@@ -966,7 +969,7 @@ export interface GetLifecyclePolicyResponse extends $MetadataBearer {
 
 export namespace GetLifecyclePolicyResponse {
   export function isa(o: any): o is GetLifecyclePolicyResponse {
-    return _smithy.isa(o, "GetLifecyclePolicyResponse");
+    return __isa(o, "GetLifecyclePolicyResponse");
   }
 }
 
@@ -986,7 +989,7 @@ export interface GetRepositoryPolicyRequest {
 
 export namespace GetRepositoryPolicyRequest {
   export function isa(o: any): o is GetRepositoryPolicyRequest {
-    return _smithy.isa(o, "GetRepositoryPolicyRequest");
+    return __isa(o, "GetRepositoryPolicyRequest");
   }
 }
 
@@ -1010,7 +1013,7 @@ export interface GetRepositoryPolicyResponse extends $MetadataBearer {
 
 export namespace GetRepositoryPolicyResponse {
   export function isa(o: any): o is GetRepositoryPolicyResponse {
-    return _smithy.isa(o, "GetRepositoryPolicyResponse");
+    return __isa(o, "GetRepositoryPolicyResponse");
   }
 }
 
@@ -1042,7 +1045,7 @@ export interface Image {
 
 export namespace Image {
   export function isa(o: any): o is Image {
-    return _smithy.isa(o, "Image");
+    return __isa(o, "Image");
   }
 }
 
@@ -1055,7 +1058,7 @@ export enum ImageActionType {
  *             or image tag after the last push.</p>
  */
 export interface ImageAlreadyExistsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ImageAlreadyExistsException";
   $fault: "client";
@@ -1067,7 +1070,7 @@ export interface ImageAlreadyExistsException
 
 export namespace ImageAlreadyExistsException {
   export function isa(o: any): o is ImageAlreadyExistsException {
-    return _smithy.isa(o, "ImageAlreadyExistsException");
+    return __isa(o, "ImageAlreadyExistsException");
   }
 }
 
@@ -1127,7 +1130,7 @@ export interface ImageDetail {
 
 export namespace ImageDetail {
   export function isa(o: any): o is ImageDetail {
-    return _smithy.isa(o, "ImageDetail");
+    return __isa(o, "ImageDetail");
   }
 }
 
@@ -1154,7 +1157,7 @@ export interface ImageFailure {
 
 export namespace ImageFailure {
   export function isa(o: any): o is ImageFailure {
-    return _smithy.isa(o, "ImageFailure");
+    return __isa(o, "ImageFailure");
   }
 }
 
@@ -1184,7 +1187,7 @@ export interface ImageIdentifier {
 
 export namespace ImageIdentifier {
   export function isa(o: any): o is ImageIdentifier {
-    return _smithy.isa(o, "ImageIdentifier");
+    return __isa(o, "ImageIdentifier");
   }
 }
 
@@ -1192,7 +1195,7 @@ export namespace ImageIdentifier {
  * <p>The image requested does not exist in the specified repository.</p>
  */
 export interface ImageNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ImageNotFoundException";
   $fault: "client";
@@ -1201,7 +1204,7 @@ export interface ImageNotFoundException
 
 export namespace ImageNotFoundException {
   export function isa(o: any): o is ImageNotFoundException {
-    return _smithy.isa(o, "ImageNotFoundException");
+    return __isa(o, "ImageNotFoundException");
   }
 }
 
@@ -1238,7 +1241,7 @@ export interface ImageScanFinding {
 
 export namespace ImageScanFinding {
   export function isa(o: any): o is ImageScanFinding {
-    return _smithy.isa(o, "ImageScanFinding");
+    return __isa(o, "ImageScanFinding");
   }
 }
 
@@ -1270,7 +1273,7 @@ export interface ImageScanFindings {
 
 export namespace ImageScanFindings {
   export function isa(o: any): o is ImageScanFindings {
-    return _smithy.isa(o, "ImageScanFindings");
+    return __isa(o, "ImageScanFindings");
   }
 }
 
@@ -1297,7 +1300,7 @@ export interface ImageScanFindingsSummary {
 
 export namespace ImageScanFindingsSummary {
   export function isa(o: any): o is ImageScanFindingsSummary {
-    return _smithy.isa(o, "ImageScanFindingsSummary");
+    return __isa(o, "ImageScanFindingsSummary");
   }
 }
 
@@ -1319,7 +1322,7 @@ export interface ImageScanStatus {
 
 export namespace ImageScanStatus {
   export function isa(o: any): o is ImageScanStatus {
-    return _smithy.isa(o, "ImageScanStatus");
+    return __isa(o, "ImageScanStatus");
   }
 }
 
@@ -1339,7 +1342,7 @@ export interface ImageScanningConfiguration {
 
 export namespace ImageScanningConfiguration {
   export function isa(o: any): o is ImageScanningConfiguration {
-    return _smithy.isa(o, "ImageScanningConfiguration");
+    return __isa(o, "ImageScanningConfiguration");
   }
 }
 
@@ -1348,7 +1351,7 @@ export namespace ImageScanningConfiguration {
  *             configured for tag immutability.</p>
  */
 export interface ImageTagAlreadyExistsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ImageTagAlreadyExistsException";
   $fault: "client";
@@ -1357,7 +1360,7 @@ export interface ImageTagAlreadyExistsException
 
 export namespace ImageTagAlreadyExistsException {
   export function isa(o: any): o is ImageTagAlreadyExistsException {
-    return _smithy.isa(o, "ImageTagAlreadyExistsException");
+    return __isa(o, "ImageTagAlreadyExistsException");
   }
 }
 
@@ -1382,7 +1385,7 @@ export interface InitiateLayerUploadRequest {
 
 export namespace InitiateLayerUploadRequest {
   export function isa(o: any): o is InitiateLayerUploadRequest {
-    return _smithy.isa(o, "InitiateLayerUploadRequest");
+    return __isa(o, "InitiateLayerUploadRequest");
   }
 }
 
@@ -1402,7 +1405,7 @@ export interface InitiateLayerUploadResponse extends $MetadataBearer {
 
 export namespace InitiateLayerUploadResponse {
   export function isa(o: any): o is InitiateLayerUploadResponse {
-    return _smithy.isa(o, "InitiateLayerUploadResponse");
+    return __isa(o, "InitiateLayerUploadResponse");
   }
 }
 
@@ -1411,7 +1414,7 @@ export namespace InitiateLayerUploadResponse {
  *             not match the digest specified.</p>
  */
 export interface InvalidLayerException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidLayerException";
   $fault: "client";
@@ -1423,7 +1426,7 @@ export interface InvalidLayerException
 
 export namespace InvalidLayerException {
   export function isa(o: any): o is InvalidLayerException {
-    return _smithy.isa(o, "InvalidLayerException");
+    return __isa(o, "InvalidLayerException");
   }
 }
 
@@ -1432,7 +1435,7 @@ export namespace InvalidLayerException {
  *             the last byte of a previous layer part upload.</p>
  */
 export interface InvalidLayerPartException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidLayerPartException";
   $fault: "client";
@@ -1465,7 +1468,7 @@ export interface InvalidLayerPartException
 
 export namespace InvalidLayerPartException {
   export function isa(o: any): o is InvalidLayerPartException {
-    return _smithy.isa(o, "InvalidLayerPartException");
+    return __isa(o, "InvalidLayerPartException");
   }
 }
 
@@ -1474,7 +1477,7 @@ export namespace InvalidLayerPartException {
  *             request.</p>
  */
 export interface InvalidParameterException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidParameterException";
   $fault: "client";
@@ -1486,7 +1489,7 @@ export interface InvalidParameterException
 
 export namespace InvalidParameterException {
   export function isa(o: any): o is InvalidParameterException {
-    return _smithy.isa(o, "InvalidParameterException");
+    return __isa(o, "InvalidParameterException");
   }
 }
 
@@ -1495,7 +1498,7 @@ export namespace InvalidParameterException {
  *             a maximum length of 256 characters.</p>
  */
 export interface InvalidTagParameterException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidTagParameterException";
   $fault: "client";
@@ -1504,7 +1507,7 @@ export interface InvalidTagParameterException
 
 export namespace InvalidTagParameterException {
   export function isa(o: any): o is InvalidTagParameterException {
-    return _smithy.isa(o, "InvalidTagParameterException");
+    return __isa(o, "InvalidTagParameterException");
   }
 }
 
@@ -1538,7 +1541,7 @@ export interface Layer {
 
 export namespace Layer {
   export function isa(o: any): o is Layer {
-    return _smithy.isa(o, "Layer");
+    return __isa(o, "Layer");
   }
 }
 
@@ -1546,7 +1549,7 @@ export namespace Layer {
  * <p>The image layer already exists in the associated repository.</p>
  */
 export interface LayerAlreadyExistsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LayerAlreadyExistsException";
   $fault: "client";
@@ -1558,7 +1561,7 @@ export interface LayerAlreadyExistsException
 
 export namespace LayerAlreadyExistsException {
   export function isa(o: any): o is LayerAlreadyExistsException {
-    return _smithy.isa(o, "LayerAlreadyExistsException");
+    return __isa(o, "LayerAlreadyExistsException");
   }
 }
 
@@ -1590,7 +1593,7 @@ export interface LayerFailure {
 
 export namespace LayerFailure {
   export function isa(o: any): o is LayerFailure {
-    return _smithy.isa(o, "LayerFailure");
+    return __isa(o, "LayerFailure");
   }
 }
 
@@ -1604,7 +1607,7 @@ export enum LayerFailureCode {
  *             Unassociated image layers may be cleaned up at any time.</p>
  */
 export interface LayerInaccessibleException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LayerInaccessibleException";
   $fault: "client";
@@ -1616,7 +1619,7 @@ export interface LayerInaccessibleException
 
 export namespace LayerInaccessibleException {
   export function isa(o: any): o is LayerInaccessibleException {
-    return _smithy.isa(o, "LayerInaccessibleException");
+    return __isa(o, "LayerInaccessibleException");
   }
 }
 
@@ -1624,7 +1627,7 @@ export namespace LayerInaccessibleException {
  * <p>Layer parts must be at least 5 MiB in size.</p>
  */
 export interface LayerPartTooSmallException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LayerPartTooSmallException";
   $fault: "client";
@@ -1636,7 +1639,7 @@ export interface LayerPartTooSmallException
 
 export namespace LayerPartTooSmallException {
   export function isa(o: any): o is LayerPartTooSmallException {
-    return _smithy.isa(o, "LayerPartTooSmallException");
+    return __isa(o, "LayerPartTooSmallException");
   }
 }
 
@@ -1645,7 +1648,7 @@ export namespace LayerPartTooSmallException {
  *             repository.</p>
  */
 export interface LayersNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LayersNotFoundException";
   $fault: "client";
@@ -1657,7 +1660,7 @@ export interface LayersNotFoundException
 
 export namespace LayersNotFoundException {
   export function isa(o: any): o is LayersNotFoundException {
-    return _smithy.isa(o, "LayersNotFoundException");
+    return __isa(o, "LayersNotFoundException");
   }
 }
 
@@ -1666,7 +1669,7 @@ export namespace LayersNotFoundException {
  *             repository.</p>
  */
 export interface LifecyclePolicyNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LifecyclePolicyNotFoundException";
   $fault: "client";
@@ -1675,7 +1678,7 @@ export interface LifecyclePolicyNotFoundException
 
 export namespace LifecyclePolicyNotFoundException {
   export function isa(o: any): o is LifecyclePolicyNotFoundException {
-    return _smithy.isa(o, "LifecyclePolicyNotFoundException");
+    return __isa(o, "LifecyclePolicyNotFoundException");
   }
 }
 
@@ -1692,7 +1695,7 @@ export interface LifecyclePolicyPreviewFilter {
 
 export namespace LifecyclePolicyPreviewFilter {
   export function isa(o: any): o is LifecyclePolicyPreviewFilter {
-    return _smithy.isa(o, "LifecyclePolicyPreviewFilter");
+    return __isa(o, "LifecyclePolicyPreviewFilter");
   }
 }
 
@@ -1701,7 +1704,7 @@ export namespace LifecyclePolicyPreviewFilter {
  *             later.</p>
  */
 export interface LifecyclePolicyPreviewInProgressException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LifecyclePolicyPreviewInProgressException";
   $fault: "client";
@@ -1710,7 +1713,7 @@ export interface LifecyclePolicyPreviewInProgressException
 
 export namespace LifecyclePolicyPreviewInProgressException {
   export function isa(o: any): o is LifecyclePolicyPreviewInProgressException {
-    return _smithy.isa(o, "LifecyclePolicyPreviewInProgressException");
+    return __isa(o, "LifecyclePolicyPreviewInProgressException");
   }
 }
 
@@ -1718,7 +1721,7 @@ export namespace LifecyclePolicyPreviewInProgressException {
  * <p>There is no dry run for this repository.</p>
  */
 export interface LifecyclePolicyPreviewNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LifecyclePolicyPreviewNotFoundException";
   $fault: "client";
@@ -1727,7 +1730,7 @@ export interface LifecyclePolicyPreviewNotFoundException
 
 export namespace LifecyclePolicyPreviewNotFoundException {
   export function isa(o: any): o is LifecyclePolicyPreviewNotFoundException {
-    return _smithy.isa(o, "LifecyclePolicyPreviewNotFoundException");
+    return __isa(o, "LifecyclePolicyPreviewNotFoundException");
   }
 }
 
@@ -1765,7 +1768,7 @@ export interface LifecyclePolicyPreviewResult {
 
 export namespace LifecyclePolicyPreviewResult {
   export function isa(o: any): o is LifecyclePolicyPreviewResult {
-    return _smithy.isa(o, "LifecyclePolicyPreviewResult");
+    return __isa(o, "LifecyclePolicyPreviewResult");
   }
 }
 
@@ -1789,7 +1792,7 @@ export interface LifecyclePolicyPreviewSummary {
 
 export namespace LifecyclePolicyPreviewSummary {
   export function isa(o: any): o is LifecyclePolicyPreviewSummary {
-    return _smithy.isa(o, "LifecyclePolicyPreviewSummary");
+    return __isa(o, "LifecyclePolicyPreviewSummary");
   }
 }
 
@@ -1806,7 +1809,7 @@ export interface LifecyclePolicyRuleAction {
 
 export namespace LifecyclePolicyRuleAction {
   export function isa(o: any): o is LifecyclePolicyRuleAction {
-    return _smithy.isa(o, "LifecyclePolicyRuleAction");
+    return __isa(o, "LifecyclePolicyRuleAction");
   }
 }
 
@@ -1816,7 +1819,7 @@ export namespace LifecyclePolicyRuleAction {
  *                 Limits</a> in the Amazon Elastic Container Registry User Guide.</p>
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -1828,7 +1831,7 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
@@ -1847,7 +1850,7 @@ export interface ListImagesFilter {
 
 export namespace ListImagesFilter {
   export function isa(o: any): o is ListImagesFilter {
-    return _smithy.isa(o, "ListImagesFilter");
+    return __isa(o, "ListImagesFilter");
   }
 }
 
@@ -1898,7 +1901,7 @@ export interface ListImagesRequest {
 
 export namespace ListImagesRequest {
   export function isa(o: any): o is ListImagesRequest {
-    return _smithy.isa(o, "ListImagesRequest");
+    return __isa(o, "ListImagesRequest");
   }
 }
 
@@ -1921,7 +1924,7 @@ export interface ListImagesResponse extends $MetadataBearer {
 
 export namespace ListImagesResponse {
   export function isa(o: any): o is ListImagesResponse {
-    return _smithy.isa(o, "ListImagesResponse");
+    return __isa(o, "ListImagesResponse");
   }
 }
 
@@ -1936,7 +1939,7 @@ export interface ListTagsForResourceRequest {
 
 export namespace ListTagsForResourceRequest {
   export function isa(o: any): o is ListTagsForResourceRequest {
-    return _smithy.isa(o, "ListTagsForResourceRequest");
+    return __isa(o, "ListTagsForResourceRequest");
   }
 }
 
@@ -1950,7 +1953,7 @@ export interface ListTagsForResourceResponse extends $MetadataBearer {
 
 export namespace ListTagsForResourceResponse {
   export function isa(o: any): o is ListTagsForResourceResponse {
-    return _smithy.isa(o, "ListTagsForResourceResponse");
+    return __isa(o, "ListTagsForResourceResponse");
   }
 }
 
@@ -1981,7 +1984,7 @@ export interface PutImageRequest {
 
 export namespace PutImageRequest {
   export function isa(o: any): o is PutImageRequest {
-    return _smithy.isa(o, "PutImageRequest");
+    return __isa(o, "PutImageRequest");
   }
 }
 
@@ -1995,7 +1998,7 @@ export interface PutImageResponse extends $MetadataBearer {
 
 export namespace PutImageResponse {
   export function isa(o: any): o is PutImageResponse {
-    return _smithy.isa(o, "PutImageResponse");
+    return __isa(o, "PutImageResponse");
   }
 }
 
@@ -2024,7 +2027,7 @@ export interface PutImageScanningConfigurationRequest {
 
 export namespace PutImageScanningConfigurationRequest {
   export function isa(o: any): o is PutImageScanningConfigurationRequest {
-    return _smithy.isa(o, "PutImageScanningConfigurationRequest");
+    return __isa(o, "PutImageScanningConfigurationRequest");
   }
 }
 
@@ -2048,7 +2051,7 @@ export interface PutImageScanningConfigurationResponse extends $MetadataBearer {
 
 export namespace PutImageScanningConfigurationResponse {
   export function isa(o: any): o is PutImageScanningConfigurationResponse {
-    return _smithy.isa(o, "PutImageScanningConfigurationResponse");
+    return __isa(o, "PutImageScanningConfigurationResponse");
   }
 }
 
@@ -2077,7 +2080,7 @@ export interface PutImageTagMutabilityRequest {
 
 export namespace PutImageTagMutabilityRequest {
   export function isa(o: any): o is PutImageTagMutabilityRequest {
-    return _smithy.isa(o, "PutImageTagMutabilityRequest");
+    return __isa(o, "PutImageTagMutabilityRequest");
   }
 }
 
@@ -2101,7 +2104,7 @@ export interface PutImageTagMutabilityResponse extends $MetadataBearer {
 
 export namespace PutImageTagMutabilityResponse {
   export function isa(o: any): o is PutImageTagMutabilityResponse {
-    return _smithy.isa(o, "PutImageTagMutabilityResponse");
+    return __isa(o, "PutImageTagMutabilityResponse");
   }
 }
 
@@ -2126,7 +2129,7 @@ export interface PutLifecyclePolicyRequest {
 
 export namespace PutLifecyclePolicyRequest {
   export function isa(o: any): o is PutLifecyclePolicyRequest {
-    return _smithy.isa(o, "PutLifecyclePolicyRequest");
+    return __isa(o, "PutLifecyclePolicyRequest");
   }
 }
 
@@ -2150,7 +2153,7 @@ export interface PutLifecyclePolicyResponse extends $MetadataBearer {
 
 export namespace PutLifecyclePolicyResponse {
   export function isa(o: any): o is PutLifecyclePolicyResponse {
-    return _smithy.isa(o, "PutLifecyclePolicyResponse");
+    return __isa(o, "PutLifecyclePolicyResponse");
   }
 }
 
@@ -2200,7 +2203,7 @@ export interface Repository {
 
 export namespace Repository {
   export function isa(o: any): o is Repository {
-    return _smithy.isa(o, "Repository");
+    return __isa(o, "Repository");
   }
 }
 
@@ -2208,7 +2211,7 @@ export namespace Repository {
  * <p>The specified repository already exists in the specified registry.</p>
  */
 export interface RepositoryAlreadyExistsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "RepositoryAlreadyExistsException";
   $fault: "client";
@@ -2220,7 +2223,7 @@ export interface RepositoryAlreadyExistsException
 
 export namespace RepositoryAlreadyExistsException {
   export function isa(o: any): o is RepositoryAlreadyExistsException {
-    return _smithy.isa(o, "RepositoryAlreadyExistsException");
+    return __isa(o, "RepositoryAlreadyExistsException");
   }
 }
 
@@ -2229,7 +2232,7 @@ export namespace RepositoryAlreadyExistsException {
  *             you must force the deletion with the <code>force</code> parameter.</p>
  */
 export interface RepositoryNotEmptyException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "RepositoryNotEmptyException";
   $fault: "client";
@@ -2241,7 +2244,7 @@ export interface RepositoryNotEmptyException
 
 export namespace RepositoryNotEmptyException {
   export function isa(o: any): o is RepositoryNotEmptyException {
-    return _smithy.isa(o, "RepositoryNotEmptyException");
+    return __isa(o, "RepositoryNotEmptyException");
   }
 }
 
@@ -2250,7 +2253,7 @@ export namespace RepositoryNotEmptyException {
  *             repository and ensure that you are performing operations on the correct registry.</p>
  */
 export interface RepositoryNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "RepositoryNotFoundException";
   $fault: "client";
@@ -2262,7 +2265,7 @@ export interface RepositoryNotFoundException
 
 export namespace RepositoryNotFoundException {
   export function isa(o: any): o is RepositoryNotFoundException {
-    return _smithy.isa(o, "RepositoryNotFoundException");
+    return __isa(o, "RepositoryNotFoundException");
   }
 }
 
@@ -2271,7 +2274,7 @@ export namespace RepositoryNotFoundException {
  *             repository policy.</p>
  */
 export interface RepositoryPolicyNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "RepositoryPolicyNotFoundException";
   $fault: "client";
@@ -2283,7 +2286,7 @@ export interface RepositoryPolicyNotFoundException
 
 export namespace RepositoryPolicyNotFoundException {
   export function isa(o: any): o is RepositoryPolicyNotFoundException {
-    return _smithy.isa(o, "RepositoryPolicyNotFoundException");
+    return __isa(o, "RepositoryPolicyNotFoundException");
   }
 }
 
@@ -2292,7 +2295,7 @@ export namespace RepositoryPolicyNotFoundException {
  *             the repository and try again.</p>
  */
 export interface ScanNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ScanNotFoundException";
   $fault: "client";
@@ -2301,7 +2304,7 @@ export interface ScanNotFoundException
 
 export namespace ScanNotFoundException {
   export function isa(o: any): o is ScanNotFoundException {
-    return _smithy.isa(o, "ScanNotFoundException");
+    return __isa(o, "ScanNotFoundException");
   }
 }
 
@@ -2314,9 +2317,7 @@ export enum ScanStatus {
 /**
  * <p>These errors are usually caused by a server-side issue.</p>
  */
-export interface ServerException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface ServerException extends __SmithyException, $MetadataBearer {
   name: "ServerException";
   $fault: "server";
   /**
@@ -2327,7 +2328,7 @@ export interface ServerException
 
 export namespace ServerException {
   export function isa(o: any): o is ServerException {
-    return _smithy.isa(o, "ServerException");
+    return __isa(o, "ServerException");
   }
 }
 
@@ -2362,7 +2363,7 @@ export interface SetRepositoryPolicyRequest {
 
 export namespace SetRepositoryPolicyRequest {
   export function isa(o: any): o is SetRepositoryPolicyRequest {
-    return _smithy.isa(o, "SetRepositoryPolicyRequest");
+    return __isa(o, "SetRepositoryPolicyRequest");
   }
 }
 
@@ -2386,7 +2387,7 @@ export interface SetRepositoryPolicyResponse extends $MetadataBearer {
 
 export namespace SetRepositoryPolicyResponse {
   export function isa(o: any): o is SetRepositoryPolicyResponse {
-    return _smithy.isa(o, "SetRepositoryPolicyResponse");
+    return __isa(o, "SetRepositoryPolicyResponse");
   }
 }
 
@@ -2411,7 +2412,7 @@ export interface StartImageScanRequest {
 
 export namespace StartImageScanRequest {
   export function isa(o: any): o is StartImageScanRequest {
-    return _smithy.isa(o, "StartImageScanRequest");
+    return __isa(o, "StartImageScanRequest");
   }
 }
 
@@ -2440,7 +2441,7 @@ export interface StartImageScanResponse extends $MetadataBearer {
 
 export namespace StartImageScanResponse {
   export function isa(o: any): o is StartImageScanResponse {
-    return _smithy.isa(o, "StartImageScanResponse");
+    return __isa(o, "StartImageScanResponse");
   }
 }
 
@@ -2466,7 +2467,7 @@ export interface StartLifecyclePolicyPreviewRequest {
 
 export namespace StartLifecyclePolicyPreviewRequest {
   export function isa(o: any): o is StartLifecyclePolicyPreviewRequest {
-    return _smithy.isa(o, "StartLifecyclePolicyPreviewRequest");
+    return __isa(o, "StartLifecyclePolicyPreviewRequest");
   }
 }
 
@@ -2495,7 +2496,7 @@ export interface StartLifecyclePolicyPreviewResponse extends $MetadataBearer {
 
 export namespace StartLifecyclePolicyPreviewResponse {
   export function isa(o: any): o is StartLifecyclePolicyPreviewResponse {
-    return _smithy.isa(o, "StartLifecyclePolicyPreviewResponse");
+    return __isa(o, "StartLifecyclePolicyPreviewResponse");
   }
 }
 
@@ -2522,7 +2523,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -2544,7 +2545,7 @@ export interface TagResourceRequest {
 
 export namespace TagResourceRequest {
   export function isa(o: any): o is TagResourceRequest {
-    return _smithy.isa(o, "TagResourceRequest");
+    return __isa(o, "TagResourceRequest");
   }
 }
 
@@ -2554,7 +2555,7 @@ export interface TagResourceResponse extends $MetadataBearer {
 
 export namespace TagResourceResponse {
   export function isa(o: any): o is TagResourceResponse {
-    return _smithy.isa(o, "TagResourceResponse");
+    return __isa(o, "TagResourceResponse");
   }
 }
 
@@ -2569,7 +2570,7 @@ export enum TagStatus {
  *             can be applied to a repository is 50.</p>
  */
 export interface TooManyTagsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyTagsException";
   $fault: "client";
@@ -2578,7 +2579,7 @@ export interface TooManyTagsException
 
 export namespace TooManyTagsException {
   export function isa(o: any): o is TooManyTagsException {
-    return _smithy.isa(o, "TooManyTagsException");
+    return __isa(o, "TooManyTagsException");
   }
 }
 
@@ -2598,7 +2599,7 @@ export interface UntagResourceRequest {
 
 export namespace UntagResourceRequest {
   export function isa(o: any): o is UntagResourceRequest {
-    return _smithy.isa(o, "UntagResourceRequest");
+    return __isa(o, "UntagResourceRequest");
   }
 }
 
@@ -2608,7 +2609,7 @@ export interface UntagResourceResponse extends $MetadataBearer {
 
 export namespace UntagResourceResponse {
   export function isa(o: any): o is UntagResourceResponse {
-    return _smithy.isa(o, "UntagResourceResponse");
+    return __isa(o, "UntagResourceResponse");
   }
 }
 
@@ -2649,7 +2650,7 @@ export interface UploadLayerPartRequest {
 
 export namespace UploadLayerPartRequest {
   export function isa(o: any): o is UploadLayerPartRequest {
-    return _smithy.isa(o, "UploadLayerPartRequest");
+    return __isa(o, "UploadLayerPartRequest");
   }
 }
 
@@ -2678,7 +2679,7 @@ export interface UploadLayerPartResponse extends $MetadataBearer {
 
 export namespace UploadLayerPartResponse {
   export function isa(o: any): o is UploadLayerPartResponse {
-    return _smithy.isa(o, "UploadLayerPartResponse");
+    return __isa(o, "UploadLayerPartResponse");
   }
 }
 
@@ -2687,7 +2688,7 @@ export namespace UploadLayerPartResponse {
  *             repository.</p>
  */
 export interface UploadNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UploadNotFoundException";
   $fault: "client";
@@ -2699,6 +2700,6 @@ export interface UploadNotFoundException
 
 export namespace UploadNotFoundException {
   export function isa(o: any): o is UploadNotFoundException {
-    return _smithy.isa(o, "UploadNotFoundException");
+    return __isa(o, "UploadNotFoundException");
   }
 }

--- a/clients/client-ecs/models/index.ts
+++ b/clients/client-ecs/models/index.ts
@@ -1,11 +1,14 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
  * <p>You do not have authorization to perform the requested action.</p>
  */
 export interface AccessDeniedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AccessDeniedException";
   $fault: "client";
@@ -14,7 +17,7 @@ export interface AccessDeniedException
 
 export namespace AccessDeniedException {
   export function isa(o: any): o is AccessDeniedException {
-    return _smithy.isa(o, "AccessDeniedException");
+    return __isa(o, "AccessDeniedException");
   }
 }
 
@@ -63,7 +66,7 @@ export interface Attachment {
 
 export namespace Attachment {
   export function isa(o: any): o is Attachment {
-    return _smithy.isa(o, "Attachment");
+    return __isa(o, "Attachment");
   }
 }
 
@@ -85,7 +88,7 @@ export interface AttachmentStateChange {
 
 export namespace AttachmentStateChange {
   export function isa(o: any): o is AttachmentStateChange {
-    return _smithy.isa(o, "AttachmentStateChange");
+    return __isa(o, "AttachmentStateChange");
   }
 }
 
@@ -124,7 +127,7 @@ export interface Attribute {
 
 export namespace Attribute {
   export function isa(o: any): o is Attribute {
-    return _smithy.isa(o, "Attribute");
+    return __isa(o, "Attribute");
   }
 }
 
@@ -134,7 +137,7 @@ export namespace Attribute {
  *             a resource with <a>DeleteAttributes</a>.</p>
  */
 export interface AttributeLimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AttributeLimitExceededException";
   $fault: "client";
@@ -143,7 +146,7 @@ export interface AttributeLimitExceededException
 
 export namespace AttributeLimitExceededException {
   export function isa(o: any): o is AttributeLimitExceededException {
-    return _smithy.isa(o, "AttributeLimitExceededException");
+    return __isa(o, "AttributeLimitExceededException");
   }
 }
 
@@ -182,7 +185,7 @@ export interface AutoScalingGroupProvider {
 
 export namespace AutoScalingGroupProvider {
   export function isa(o: any): o is AutoScalingGroupProvider {
-    return _smithy.isa(o, "AutoScalingGroupProvider");
+    return __isa(o, "AutoScalingGroupProvider");
   }
 }
 
@@ -221,16 +224,14 @@ export interface AwsVpcConfiguration {
 
 export namespace AwsVpcConfiguration {
   export function isa(o: any): o is AwsVpcConfiguration {
-    return _smithy.isa(o, "AwsVpcConfiguration");
+    return __isa(o, "AwsVpcConfiguration");
   }
 }
 
 /**
  * <p>Your AWS account has been blocked. For more information, contact <a href="http://aws.amazon.com/contact-us/">AWS Support</a>.</p>
  */
-export interface BlockedException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface BlockedException extends __SmithyException, $MetadataBearer {
   name: "BlockedException";
   $fault: "client";
   message?: string;
@@ -238,7 +239,7 @@ export interface BlockedException
 
 export namespace BlockedException {
   export function isa(o: any): o is BlockedException {
-    return _smithy.isa(o, "BlockedException");
+    return __isa(o, "BlockedException");
   }
 }
 
@@ -309,7 +310,7 @@ export interface CapacityProvider {
 
 export namespace CapacityProvider {
   export function isa(o: any): o is CapacityProvider {
-    return _smithy.isa(o, "CapacityProvider");
+    return __isa(o, "CapacityProvider");
   }
 }
 
@@ -354,7 +355,7 @@ export interface CapacityProviderStrategyItem {
 
 export namespace CapacityProviderStrategyItem {
   export function isa(o: any): o is CapacityProviderStrategyItem {
-    return _smithy.isa(o, "CapacityProviderStrategyItem");
+    return __isa(o, "CapacityProviderStrategyItem");
   }
 }
 
@@ -363,9 +364,7 @@ export namespace CapacityProviderStrategyItem {
  *             resource on behalf of a user that doesn't have permissions to use the action or
  *             resource, or specifying an identifier that is not valid.</p>
  */
-export interface ClientException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface ClientException extends __SmithyException, $MetadataBearer {
   name: "ClientException";
   $fault: "client";
   message?: string;
@@ -373,7 +372,7 @@ export interface ClientException
 
 export namespace ClientException {
   export function isa(o: any): o is ClientException {
-    return _smithy.isa(o, "ClientException");
+    return __isa(o, "ClientException");
   }
 }
 
@@ -569,7 +568,7 @@ export interface Cluster {
 
 export namespace Cluster {
   export function isa(o: any): o is Cluster {
-    return _smithy.isa(o, "Cluster");
+    return __isa(o, "Cluster");
   }
 }
 
@@ -579,7 +578,7 @@ export namespace Cluster {
  *                 <a>DeregisterContainerInstance</a>.</p>
  */
 export interface ClusterContainsContainerInstancesException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ClusterContainsContainerInstancesException";
   $fault: "client";
@@ -588,7 +587,7 @@ export interface ClusterContainsContainerInstancesException
 
 export namespace ClusterContainsContainerInstancesException {
   export function isa(o: any): o is ClusterContainsContainerInstancesException {
-    return _smithy.isa(o, "ClusterContainsContainerInstancesException");
+    return __isa(o, "ClusterContainsContainerInstancesException");
   }
 }
 
@@ -598,7 +597,7 @@ export namespace ClusterContainsContainerInstancesException {
  *             see <a>UpdateService</a> and <a>DeleteService</a>.</p>
  */
 export interface ClusterContainsServicesException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ClusterContainsServicesException";
   $fault: "client";
@@ -607,7 +606,7 @@ export interface ClusterContainsServicesException
 
 export namespace ClusterContainsServicesException {
   export function isa(o: any): o is ClusterContainsServicesException {
-    return _smithy.isa(o, "ClusterContainsServicesException");
+    return __isa(o, "ClusterContainsServicesException");
   }
 }
 
@@ -615,7 +614,7 @@ export namespace ClusterContainsServicesException {
  * <p>You cannot delete a cluster that has active tasks.</p>
  */
 export interface ClusterContainsTasksException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ClusterContainsTasksException";
   $fault: "client";
@@ -624,7 +623,7 @@ export interface ClusterContainsTasksException
 
 export namespace ClusterContainsTasksException {
   export function isa(o: any): o is ClusterContainsTasksException {
-    return _smithy.isa(o, "ClusterContainsTasksException");
+    return __isa(o, "ClusterContainsTasksException");
   }
 }
 
@@ -640,7 +639,7 @@ export enum ClusterField {
  *                 <a>ListClusters</a>. Amazon ECS clusters are Region-specific.</p>
  */
 export interface ClusterNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ClusterNotFoundException";
   $fault: "client";
@@ -649,7 +648,7 @@ export interface ClusterNotFoundException
 
 export namespace ClusterNotFoundException {
   export function isa(o: any): o is ClusterNotFoundException {
-    return _smithy.isa(o, "ClusterNotFoundException");
+    return __isa(o, "ClusterNotFoundException");
   }
 }
 
@@ -678,7 +677,7 @@ export interface ClusterSetting {
 
 export namespace ClusterSetting {
   export function isa(o: any): o is ClusterSetting {
-    return _smithy.isa(o, "ClusterSetting");
+    return __isa(o, "ClusterSetting");
   }
 }
 
@@ -793,7 +792,7 @@ export interface Container {
 
 export namespace Container {
   export function isa(o: any): o is Container {
-    return _smithy.isa(o, "Container");
+    return __isa(o, "Container");
   }
 }
 
@@ -1413,7 +1412,7 @@ export interface ContainerDefinition {
 
 export namespace ContainerDefinition {
   export function isa(o: any): o is ContainerDefinition {
-    return _smithy.isa(o, "ContainerDefinition");
+    return __isa(o, "ContainerDefinition");
   }
 }
 
@@ -1479,7 +1478,7 @@ export interface ContainerDependency {
 
 export namespace ContainerDependency {
   export function isa(o: any): o is ContainerDependency {
-    return _smithy.isa(o, "ContainerDependency");
+    return __isa(o, "ContainerDependency");
   }
 }
 
@@ -1653,7 +1652,7 @@ export interface ContainerInstance {
 
 export namespace ContainerInstance {
   export function isa(o: any): o is ContainerInstance {
-    return _smithy.isa(o, "ContainerInstance");
+    return __isa(o, "ContainerInstance");
   }
 }
 
@@ -1725,7 +1724,7 @@ export interface ContainerOverride {
 
 export namespace ContainerOverride {
   export function isa(o: any): o is ContainerOverride {
-    return _smithy.isa(o, "ContainerOverride");
+    return __isa(o, "ContainerOverride");
   }
 }
 
@@ -1773,7 +1772,7 @@ export interface ContainerStateChange {
 
 export namespace ContainerStateChange {
   export function isa(o: any): o is ContainerStateChange {
-    return _smithy.isa(o, "ContainerStateChange");
+    return __isa(o, "ContainerStateChange");
   }
 }
 
@@ -1832,7 +1831,7 @@ export interface CreateCapacityProviderRequest {
 
 export namespace CreateCapacityProviderRequest {
   export function isa(o: any): o is CreateCapacityProviderRequest {
-    return _smithy.isa(o, "CreateCapacityProviderRequest");
+    return __isa(o, "CreateCapacityProviderRequest");
   }
 }
 
@@ -1846,7 +1845,7 @@ export interface CreateCapacityProviderResponse extends $MetadataBearer {
 
 export namespace CreateCapacityProviderResponse {
   export function isa(o: any): o is CreateCapacityProviderResponse {
-    return _smithy.isa(o, "CreateCapacityProviderResponse");
+    return __isa(o, "CreateCapacityProviderResponse");
   }
 }
 
@@ -1945,7 +1944,7 @@ export interface CreateClusterRequest {
 
 export namespace CreateClusterRequest {
   export function isa(o: any): o is CreateClusterRequest {
-    return _smithy.isa(o, "CreateClusterRequest");
+    return __isa(o, "CreateClusterRequest");
   }
 }
 
@@ -1959,7 +1958,7 @@ export interface CreateClusterResponse extends $MetadataBearer {
 
 export namespace CreateClusterResponse {
   export function isa(o: any): o is CreateClusterResponse {
-    return _smithy.isa(o, "CreateClusterResponse");
+    return __isa(o, "CreateClusterResponse");
   }
 }
 
@@ -2251,7 +2250,7 @@ export interface CreateServiceRequest {
 
 export namespace CreateServiceRequest {
   export function isa(o: any): o is CreateServiceRequest {
-    return _smithy.isa(o, "CreateServiceRequest");
+    return __isa(o, "CreateServiceRequest");
   }
 }
 
@@ -2272,7 +2271,7 @@ export interface CreateServiceResponse extends $MetadataBearer {
 
 export namespace CreateServiceResponse {
   export function isa(o: any): o is CreateServiceResponse {
-    return _smithy.isa(o, "CreateServiceResponse");
+    return __isa(o, "CreateServiceResponse");
   }
 }
 
@@ -2373,7 +2372,7 @@ export interface CreateTaskSetRequest {
 
 export namespace CreateTaskSetRequest {
   export function isa(o: any): o is CreateTaskSetRequest {
-    return _smithy.isa(o, "CreateTaskSetRequest");
+    return __isa(o, "CreateTaskSetRequest");
   }
 }
 
@@ -2389,7 +2388,7 @@ export interface CreateTaskSetResponse extends $MetadataBearer {
 
 export namespace CreateTaskSetResponse {
   export function isa(o: any): o is CreateTaskSetResponse {
-    return _smithy.isa(o, "CreateTaskSetResponse");
+    return __isa(o, "CreateTaskSetResponse");
   }
 }
 
@@ -2418,7 +2417,7 @@ export interface DeleteAccountSettingRequest {
 
 export namespace DeleteAccountSettingRequest {
   export function isa(o: any): o is DeleteAccountSettingRequest {
-    return _smithy.isa(o, "DeleteAccountSettingRequest");
+    return __isa(o, "DeleteAccountSettingRequest");
   }
 }
 
@@ -2432,7 +2431,7 @@ export interface DeleteAccountSettingResponse extends $MetadataBearer {
 
 export namespace DeleteAccountSettingResponse {
   export function isa(o: any): o is DeleteAccountSettingResponse {
-    return _smithy.isa(o, "DeleteAccountSettingResponse");
+    return __isa(o, "DeleteAccountSettingResponse");
   }
 }
 
@@ -2455,7 +2454,7 @@ export interface DeleteAttributesRequest {
 
 export namespace DeleteAttributesRequest {
   export function isa(o: any): o is DeleteAttributesRequest {
-    return _smithy.isa(o, "DeleteAttributesRequest");
+    return __isa(o, "DeleteAttributesRequest");
   }
 }
 
@@ -2469,7 +2468,7 @@ export interface DeleteAttributesResponse extends $MetadataBearer {
 
 export namespace DeleteAttributesResponse {
   export function isa(o: any): o is DeleteAttributesResponse {
-    return _smithy.isa(o, "DeleteAttributesResponse");
+    return __isa(o, "DeleteAttributesResponse");
   }
 }
 
@@ -2483,7 +2482,7 @@ export interface DeleteClusterRequest {
 
 export namespace DeleteClusterRequest {
   export function isa(o: any): o is DeleteClusterRequest {
-    return _smithy.isa(o, "DeleteClusterRequest");
+    return __isa(o, "DeleteClusterRequest");
   }
 }
 
@@ -2497,7 +2496,7 @@ export interface DeleteClusterResponse extends $MetadataBearer {
 
 export namespace DeleteClusterResponse {
   export function isa(o: any): o is DeleteClusterResponse {
-    return _smithy.isa(o, "DeleteClusterResponse");
+    return __isa(o, "DeleteClusterResponse");
   }
 }
 
@@ -2524,7 +2523,7 @@ export interface DeleteServiceRequest {
 
 export namespace DeleteServiceRequest {
   export function isa(o: any): o is DeleteServiceRequest {
-    return _smithy.isa(o, "DeleteServiceRequest");
+    return __isa(o, "DeleteServiceRequest");
   }
 }
 
@@ -2538,7 +2537,7 @@ export interface DeleteServiceResponse extends $MetadataBearer {
 
 export namespace DeleteServiceResponse {
   export function isa(o: any): o is DeleteServiceResponse {
-    return _smithy.isa(o, "DeleteServiceResponse");
+    return __isa(o, "DeleteServiceResponse");
   }
 }
 
@@ -2570,7 +2569,7 @@ export interface DeleteTaskSetRequest {
 
 export namespace DeleteTaskSetRequest {
   export function isa(o: any): o is DeleteTaskSetRequest {
-    return _smithy.isa(o, "DeleteTaskSetRequest");
+    return __isa(o, "DeleteTaskSetRequest");
   }
 }
 
@@ -2586,7 +2585,7 @@ export interface DeleteTaskSetResponse extends $MetadataBearer {
 
 export namespace DeleteTaskSetResponse {
   export function isa(o: any): o is DeleteTaskSetResponse {
-    return _smithy.isa(o, "DeleteTaskSetResponse");
+    return __isa(o, "DeleteTaskSetResponse");
   }
 }
 
@@ -2684,7 +2683,7 @@ export interface Deployment {
 
 export namespace Deployment {
   export function isa(o: any): o is Deployment {
-    return _smithy.isa(o, "Deployment");
+    return __isa(o, "Deployment");
   }
 }
 
@@ -2746,7 +2745,7 @@ export interface DeploymentConfiguration {
 
 export namespace DeploymentConfiguration {
   export function isa(o: any): o is DeploymentConfiguration {
-    return _smithy.isa(o, "DeploymentConfiguration");
+    return __isa(o, "DeploymentConfiguration");
   }
 }
 
@@ -2786,7 +2785,7 @@ export interface DeploymentController {
 
 export namespace DeploymentController {
   export function isa(o: any): o is DeploymentController {
-    return _smithy.isa(o, "DeploymentController");
+    return __isa(o, "DeploymentController");
   }
 }
 
@@ -2827,7 +2826,7 @@ export interface DeregisterContainerInstanceRequest {
 
 export namespace DeregisterContainerInstanceRequest {
   export function isa(o: any): o is DeregisterContainerInstanceRequest {
-    return _smithy.isa(o, "DeregisterContainerInstanceRequest");
+    return __isa(o, "DeregisterContainerInstanceRequest");
   }
 }
 
@@ -2841,7 +2840,7 @@ export interface DeregisterContainerInstanceResponse extends $MetadataBearer {
 
 export namespace DeregisterContainerInstanceResponse {
   export function isa(o: any): o is DeregisterContainerInstanceResponse {
-    return _smithy.isa(o, "DeregisterContainerInstanceResponse");
+    return __isa(o, "DeregisterContainerInstanceResponse");
   }
 }
 
@@ -2857,7 +2856,7 @@ export interface DeregisterTaskDefinitionRequest {
 
 export namespace DeregisterTaskDefinitionRequest {
   export function isa(o: any): o is DeregisterTaskDefinitionRequest {
-    return _smithy.isa(o, "DeregisterTaskDefinitionRequest");
+    return __isa(o, "DeregisterTaskDefinitionRequest");
   }
 }
 
@@ -2871,7 +2870,7 @@ export interface DeregisterTaskDefinitionResponse extends $MetadataBearer {
 
 export namespace DeregisterTaskDefinitionResponse {
   export function isa(o: any): o is DeregisterTaskDefinitionResponse {
-    return _smithy.isa(o, "DeregisterTaskDefinitionResponse");
+    return __isa(o, "DeregisterTaskDefinitionResponse");
   }
 }
 
@@ -2920,7 +2919,7 @@ export interface DescribeCapacityProvidersRequest {
 
 export namespace DescribeCapacityProvidersRequest {
   export function isa(o: any): o is DescribeCapacityProvidersRequest {
-    return _smithy.isa(o, "DescribeCapacityProvidersRequest");
+    return __isa(o, "DescribeCapacityProvidersRequest");
   }
 }
 
@@ -2948,7 +2947,7 @@ export interface DescribeCapacityProvidersResponse extends $MetadataBearer {
 
 export namespace DescribeCapacityProvidersResponse {
   export function isa(o: any): o is DescribeCapacityProvidersResponse {
-    return _smithy.isa(o, "DescribeCapacityProvidersResponse");
+    return __isa(o, "DescribeCapacityProvidersResponse");
   }
 }
 
@@ -3003,7 +3002,7 @@ export interface DescribeClustersRequest {
 
 export namespace DescribeClustersRequest {
   export function isa(o: any): o is DescribeClustersRequest {
-    return _smithy.isa(o, "DescribeClustersRequest");
+    return __isa(o, "DescribeClustersRequest");
   }
 }
 
@@ -3022,7 +3021,7 @@ export interface DescribeClustersResponse extends $MetadataBearer {
 
 export namespace DescribeClustersResponse {
   export function isa(o: any): o is DescribeClustersResponse {
-    return _smithy.isa(o, "DescribeClustersResponse");
+    return __isa(o, "DescribeClustersResponse");
   }
 }
 
@@ -3051,7 +3050,7 @@ export interface DescribeContainerInstancesRequest {
 
 export namespace DescribeContainerInstancesRequest {
   export function isa(o: any): o is DescribeContainerInstancesRequest {
-    return _smithy.isa(o, "DescribeContainerInstancesRequest");
+    return __isa(o, "DescribeContainerInstancesRequest");
   }
 }
 
@@ -3070,7 +3069,7 @@ export interface DescribeContainerInstancesResponse extends $MetadataBearer {
 
 export namespace DescribeContainerInstancesResponse {
   export function isa(o: any): o is DescribeContainerInstancesResponse {
-    return _smithy.isa(o, "DescribeContainerInstancesResponse");
+    return __isa(o, "DescribeContainerInstancesResponse");
   }
 }
 
@@ -3099,7 +3098,7 @@ export interface DescribeServicesRequest {
 
 export namespace DescribeServicesRequest {
   export function isa(o: any): o is DescribeServicesRequest {
-    return _smithy.isa(o, "DescribeServicesRequest");
+    return __isa(o, "DescribeServicesRequest");
   }
 }
 
@@ -3118,7 +3117,7 @@ export interface DescribeServicesResponse extends $MetadataBearer {
 
 export namespace DescribeServicesResponse {
   export function isa(o: any): o is DescribeServicesResponse {
-    return _smithy.isa(o, "DescribeServicesResponse");
+    return __isa(o, "DescribeServicesResponse");
   }
 }
 
@@ -3142,7 +3141,7 @@ export interface DescribeTaskDefinitionRequest {
 
 export namespace DescribeTaskDefinitionRequest {
   export function isa(o: any): o is DescribeTaskDefinitionRequest {
-    return _smithy.isa(o, "DescribeTaskDefinitionRequest");
+    return __isa(o, "DescribeTaskDefinitionRequest");
   }
 }
 
@@ -3194,7 +3193,7 @@ export interface DescribeTaskDefinitionResponse extends $MetadataBearer {
 
 export namespace DescribeTaskDefinitionResponse {
   export function isa(o: any): o is DescribeTaskDefinitionResponse {
-    return _smithy.isa(o, "DescribeTaskDefinitionResponse");
+    return __isa(o, "DescribeTaskDefinitionResponse");
   }
 }
 
@@ -3220,7 +3219,7 @@ export interface DescribeTaskSetsRequest {
 
 export namespace DescribeTaskSetsRequest {
   export function isa(o: any): o is DescribeTaskSetsRequest {
-    return _smithy.isa(o, "DescribeTaskSetsRequest");
+    return __isa(o, "DescribeTaskSetsRequest");
   }
 }
 
@@ -3239,7 +3238,7 @@ export interface DescribeTaskSetsResponse extends $MetadataBearer {
 
 export namespace DescribeTaskSetsResponse {
   export function isa(o: any): o is DescribeTaskSetsResponse {
-    return _smithy.isa(o, "DescribeTaskSetsResponse");
+    return __isa(o, "DescribeTaskSetsResponse");
   }
 }
 
@@ -3267,7 +3266,7 @@ export interface DescribeTasksRequest {
 
 export namespace DescribeTasksRequest {
   export function isa(o: any): o is DescribeTasksRequest {
-    return _smithy.isa(o, "DescribeTasksRequest");
+    return __isa(o, "DescribeTasksRequest");
   }
 }
 
@@ -3286,7 +3285,7 @@ export interface DescribeTasksResponse extends $MetadataBearer {
 
 export namespace DescribeTasksResponse {
   export function isa(o: any): o is DescribeTasksResponse {
-    return _smithy.isa(o, "DescribeTasksResponse");
+    return __isa(o, "DescribeTasksResponse");
   }
 }
 
@@ -3321,7 +3320,7 @@ export interface Device {
 
 export namespace Device {
   export function isa(o: any): o is Device {
-    return _smithy.isa(o, "Device");
+    return __isa(o, "Device");
   }
 }
 
@@ -3348,7 +3347,7 @@ export interface DiscoverPollEndpointRequest {
 
 export namespace DiscoverPollEndpointRequest {
   export function isa(o: any): o is DiscoverPollEndpointRequest {
-    return _smithy.isa(o, "DiscoverPollEndpointRequest");
+    return __isa(o, "DiscoverPollEndpointRequest");
   }
 }
 
@@ -3367,7 +3366,7 @@ export interface DiscoverPollEndpointResponse extends $MetadataBearer {
 
 export namespace DiscoverPollEndpointResponse {
   export function isa(o: any): o is DiscoverPollEndpointResponse {
-    return _smithy.isa(o, "DiscoverPollEndpointResponse");
+    return __isa(o, "DiscoverPollEndpointResponse");
   }
 }
 
@@ -3428,7 +3427,7 @@ export interface DockerVolumeConfiguration {
 
 export namespace DockerVolumeConfiguration {
   export function isa(o: any): o is DockerVolumeConfiguration {
-    return _smithy.isa(o, "DockerVolumeConfiguration");
+    return __isa(o, "DockerVolumeConfiguration");
   }
 }
 
@@ -3461,7 +3460,7 @@ export interface EFSVolumeConfiguration {
 
 export namespace EFSVolumeConfiguration {
   export function isa(o: any): o is EFSVolumeConfiguration {
-    return _smithy.isa(o, "EFSVolumeConfiguration");
+    return __isa(o, "EFSVolumeConfiguration");
   }
 }
 
@@ -3488,7 +3487,7 @@ export interface Failure {
 
 export namespace Failure {
   export function isa(o: any): o is Failure {
-    return _smithy.isa(o, "Failure");
+    return __isa(o, "Failure");
   }
 }
 
@@ -3520,7 +3519,7 @@ export interface FirelensConfiguration {
 
 export namespace FirelensConfiguration {
   export function isa(o: any): o is FirelensConfiguration {
-    return _smithy.isa(o, "FirelensConfiguration");
+    return __isa(o, "FirelensConfiguration");
   }
 }
 
@@ -3602,7 +3601,7 @@ export interface HealthCheck {
 
 export namespace HealthCheck {
   export function isa(o: any): o is HealthCheck {
-    return _smithy.isa(o, "HealthCheck");
+    return __isa(o, "HealthCheck");
   }
 }
 
@@ -3631,7 +3630,7 @@ export interface HostEntry {
 
 export namespace HostEntry {
   export function isa(o: any): o is HostEntry {
-    return _smithy.isa(o, "HostEntry");
+    return __isa(o, "HostEntry");
   }
 }
 
@@ -3657,7 +3656,7 @@ export interface HostVolumeProperties {
 
 export namespace HostVolumeProperties {
   export function isa(o: any): o is HostVolumeProperties {
-    return _smithy.isa(o, "HostVolumeProperties");
+    return __isa(o, "HostVolumeProperties");
   }
 }
 
@@ -3682,7 +3681,7 @@ export interface InferenceAccelerator {
 
 export namespace InferenceAccelerator {
   export function isa(o: any): o is InferenceAccelerator {
-    return _smithy.isa(o, "InferenceAccelerator");
+    return __isa(o, "InferenceAccelerator");
   }
 }
 
@@ -3708,7 +3707,7 @@ export interface InferenceAcceleratorOverride {
 
 export namespace InferenceAcceleratorOverride {
   export function isa(o: any): o is InferenceAcceleratorOverride {
-    return _smithy.isa(o, "InferenceAcceleratorOverride");
+    return __isa(o, "InferenceAcceleratorOverride");
   }
 }
 
@@ -3717,7 +3716,7 @@ export namespace InferenceAcceleratorOverride {
  *             request.</p>
  */
 export interface InvalidParameterException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidParameterException";
   $fault: "client";
@@ -3726,7 +3725,7 @@ export interface InvalidParameterException
 
 export namespace InvalidParameterException {
   export function isa(o: any): o is InvalidParameterException {
-    return _smithy.isa(o, "InvalidParameterException");
+    return __isa(o, "InvalidParameterException");
   }
 }
 
@@ -3788,7 +3787,7 @@ export interface KernelCapabilities {
 
 export namespace KernelCapabilities {
   export function isa(o: any): o is KernelCapabilities {
-    return _smithy.isa(o, "KernelCapabilities");
+    return __isa(o, "KernelCapabilities");
   }
 }
 
@@ -3812,7 +3811,7 @@ export interface KeyValuePair {
 
 export namespace KeyValuePair {
   export function isa(o: any): o is KeyValuePair {
-    return _smithy.isa(o, "KeyValuePair");
+    return __isa(o, "KeyValuePair");
   }
 }
 
@@ -3825,7 +3824,7 @@ export enum LaunchType {
  * <p>The limit for the resource has been exceeded.</p>
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -3834,7 +3833,7 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
@@ -3928,7 +3927,7 @@ export interface LinuxParameters {
 
 export namespace LinuxParameters {
   export function isa(o: any): o is LinuxParameters {
-    return _smithy.isa(o, "LinuxParameters");
+    return __isa(o, "LinuxParameters");
   }
 }
 
@@ -3989,7 +3988,7 @@ export interface ListAccountSettingsRequest {
 
 export namespace ListAccountSettingsRequest {
   export function isa(o: any): o is ListAccountSettingsRequest {
-    return _smithy.isa(o, "ListAccountSettingsRequest");
+    return __isa(o, "ListAccountSettingsRequest");
   }
 }
 
@@ -4012,7 +4011,7 @@ export interface ListAccountSettingsResponse extends $MetadataBearer {
 
 export namespace ListAccountSettingsResponse {
   export function isa(o: any): o is ListAccountSettingsResponse {
-    return _smithy.isa(o, "ListAccountSettingsResponse");
+    return __isa(o, "ListAccountSettingsResponse");
   }
 }
 
@@ -4067,7 +4066,7 @@ export interface ListAttributesRequest {
 
 export namespace ListAttributesRequest {
   export function isa(o: any): o is ListAttributesRequest {
-    return _smithy.isa(o, "ListAttributesRequest");
+    return __isa(o, "ListAttributesRequest");
   }
 }
 
@@ -4090,7 +4089,7 @@ export interface ListAttributesResponse extends $MetadataBearer {
 
 export namespace ListAttributesResponse {
   export function isa(o: any): o is ListAttributesResponse {
-    return _smithy.isa(o, "ListAttributesResponse");
+    return __isa(o, "ListAttributesResponse");
   }
 }
 
@@ -4123,7 +4122,7 @@ export interface ListClustersRequest {
 
 export namespace ListClustersRequest {
   export function isa(o: any): o is ListClustersRequest {
-    return _smithy.isa(o, "ListClustersRequest");
+    return __isa(o, "ListClustersRequest");
   }
 }
 
@@ -4147,7 +4146,7 @@ export interface ListClustersResponse extends $MetadataBearer {
 
 export namespace ListClustersResponse {
   export function isa(o: any): o is ListClustersResponse {
-    return _smithy.isa(o, "ListClustersResponse");
+    return __isa(o, "ListClustersResponse");
   }
 }
 
@@ -4203,7 +4202,7 @@ export interface ListContainerInstancesRequest {
 
 export namespace ListContainerInstancesRequest {
   export function isa(o: any): o is ListContainerInstancesRequest {
-    return _smithy.isa(o, "ListContainerInstancesRequest");
+    return __isa(o, "ListContainerInstancesRequest");
   }
 }
 
@@ -4227,7 +4226,7 @@ export interface ListContainerInstancesResponse extends $MetadataBearer {
 
 export namespace ListContainerInstancesResponse {
   export function isa(o: any): o is ListContainerInstancesResponse {
-    return _smithy.isa(o, "ListContainerInstancesResponse");
+    return __isa(o, "ListContainerInstancesResponse");
   }
 }
 
@@ -4277,7 +4276,7 @@ export interface ListServicesRequest {
 
 export namespace ListServicesRequest {
   export function isa(o: any): o is ListServicesRequest {
-    return _smithy.isa(o, "ListServicesRequest");
+    return __isa(o, "ListServicesRequest");
   }
 }
 
@@ -4301,7 +4300,7 @@ export interface ListServicesResponse extends $MetadataBearer {
 
 export namespace ListServicesResponse {
   export function isa(o: any): o is ListServicesResponse {
-    return _smithy.isa(o, "ListServicesResponse");
+    return __isa(o, "ListServicesResponse");
   }
 }
 
@@ -4317,7 +4316,7 @@ export interface ListTagsForResourceRequest {
 
 export namespace ListTagsForResourceRequest {
   export function isa(o: any): o is ListTagsForResourceRequest {
-    return _smithy.isa(o, "ListTagsForResourceRequest");
+    return __isa(o, "ListTagsForResourceRequest");
   }
 }
 
@@ -4331,7 +4330,7 @@ export interface ListTagsForResourceResponse extends $MetadataBearer {
 
 export namespace ListTagsForResourceResponse {
   export function isa(o: any): o is ListTagsForResourceResponse {
-    return _smithy.isa(o, "ListTagsForResourceResponse");
+    return __isa(o, "ListTagsForResourceResponse");
   }
 }
 
@@ -4388,7 +4387,7 @@ export interface ListTaskDefinitionFamiliesRequest {
 
 export namespace ListTaskDefinitionFamiliesRequest {
   export function isa(o: any): o is ListTaskDefinitionFamiliesRequest {
-    return _smithy.isa(o, "ListTaskDefinitionFamiliesRequest");
+    return __isa(o, "ListTaskDefinitionFamiliesRequest");
   }
 }
 
@@ -4412,7 +4411,7 @@ export interface ListTaskDefinitionFamiliesResponse extends $MetadataBearer {
 
 export namespace ListTaskDefinitionFamiliesResponse {
   export function isa(o: any): o is ListTaskDefinitionFamiliesResponse {
-    return _smithy.isa(o, "ListTaskDefinitionFamiliesResponse");
+    return __isa(o, "ListTaskDefinitionFamiliesResponse");
   }
 }
 
@@ -4473,7 +4472,7 @@ export interface ListTaskDefinitionsRequest {
 
 export namespace ListTaskDefinitionsRequest {
   export function isa(o: any): o is ListTaskDefinitionsRequest {
-    return _smithy.isa(o, "ListTaskDefinitionsRequest");
+    return __isa(o, "ListTaskDefinitionsRequest");
   }
 }
 
@@ -4497,7 +4496,7 @@ export interface ListTaskDefinitionsResponse extends $MetadataBearer {
 
 export namespace ListTaskDefinitionsResponse {
   export function isa(o: any): o is ListTaskDefinitionsResponse {
-    return _smithy.isa(o, "ListTaskDefinitionsResponse");
+    return __isa(o, "ListTaskDefinitionsResponse");
   }
 }
 
@@ -4585,7 +4584,7 @@ export interface ListTasksRequest {
 
 export namespace ListTasksRequest {
   export function isa(o: any): o is ListTasksRequest {
-    return _smithy.isa(o, "ListTasksRequest");
+    return __isa(o, "ListTasksRequest");
   }
 }
 
@@ -4608,7 +4607,7 @@ export interface ListTasksResponse extends $MetadataBearer {
 
 export namespace ListTasksResponse {
   export function isa(o: any): o is ListTasksResponse {
-    return _smithy.isa(o, "ListTasksResponse");
+    return __isa(o, "ListTasksResponse");
   }
 }
 
@@ -4665,7 +4664,7 @@ export interface LoadBalancer {
 
 export namespace LoadBalancer {
   export function isa(o: any): o is LoadBalancer {
-    return _smithy.isa(o, "LoadBalancer");
+    return __isa(o, "LoadBalancer");
   }
 }
 
@@ -4753,7 +4752,7 @@ export interface LogConfiguration {
 
 export namespace LogConfiguration {
   export function isa(o: any): o is LogConfiguration {
-    return _smithy.isa(o, "LogConfiguration");
+    return __isa(o, "LogConfiguration");
   }
 }
 
@@ -4808,7 +4807,7 @@ export interface ManagedScaling {
 
 export namespace ManagedScaling {
   export function isa(o: any): o is ManagedScaling {
-    return _smithy.isa(o, "ManagedScaling");
+    return __isa(o, "ManagedScaling");
   }
 }
 
@@ -4829,7 +4828,7 @@ export enum ManagedTerminationProtection {
  *             version that does not use our version information.</p>
  */
 export interface MissingVersionException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "MissingVersionException";
   $fault: "client";
@@ -4838,7 +4837,7 @@ export interface MissingVersionException
 
 export namespace MissingVersionException {
   export function isa(o: any): o is MissingVersionException {
-    return _smithy.isa(o, "MissingVersionException");
+    return __isa(o, "MissingVersionException");
   }
 }
 
@@ -4868,7 +4867,7 @@ export interface MountPoint {
 
 export namespace MountPoint {
   export function isa(o: any): o is MountPoint {
-    return _smithy.isa(o, "MountPoint");
+    return __isa(o, "MountPoint");
   }
 }
 
@@ -4903,7 +4902,7 @@ export interface NetworkBinding {
 
 export namespace NetworkBinding {
   export function isa(o: any): o is NetworkBinding {
-    return _smithy.isa(o, "NetworkBinding");
+    return __isa(o, "NetworkBinding");
   }
 }
 
@@ -4923,7 +4922,7 @@ export interface NetworkConfiguration {
 
 export namespace NetworkConfiguration {
   export function isa(o: any): o is NetworkConfiguration {
-    return _smithy.isa(o, "NetworkConfiguration");
+    return __isa(o, "NetworkConfiguration");
   }
 }
 
@@ -4951,7 +4950,7 @@ export interface NetworkInterface {
 
 export namespace NetworkInterface {
   export function isa(o: any): o is NetworkInterface {
-    return _smithy.isa(o, "NetworkInterface");
+    return __isa(o, "NetworkInterface");
   }
 }
 
@@ -4968,7 +4967,7 @@ export enum NetworkMode {
  *             path to the current version.</p>
  */
 export interface NoUpdateAvailableException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "NoUpdateAvailableException";
   $fault: "client";
@@ -4977,7 +4976,7 @@ export interface NoUpdateAvailableException
 
 export namespace NoUpdateAvailableException {
   export function isa(o: any): o is NoUpdateAvailableException {
-    return _smithy.isa(o, "NoUpdateAvailableException");
+    return __isa(o, "NoUpdateAvailableException");
   }
 }
 
@@ -5016,7 +5015,7 @@ export interface PlacementConstraint {
 
 export namespace PlacementConstraint {
   export function isa(o: any): o is PlacementConstraint {
-    return _smithy.isa(o, "PlacementConstraint");
+    return __isa(o, "PlacementConstraint");
   }
 }
 
@@ -5056,7 +5055,7 @@ export interface PlacementStrategy {
 
 export namespace PlacementStrategy {
   export function isa(o: any): o is PlacementStrategy {
-    return _smithy.isa(o, "PlacementStrategy");
+    return __isa(o, "PlacementStrategy");
   }
 }
 
@@ -5088,7 +5087,7 @@ export interface PlatformDevice {
 
 export namespace PlatformDevice {
   export function isa(o: any): o is PlatformDevice {
-    return _smithy.isa(o, "PlatformDevice");
+    return __isa(o, "PlatformDevice");
   }
 }
 
@@ -5101,7 +5100,7 @@ export enum PlatformDeviceType {
  *             capabilities.</p>
  */
 export interface PlatformTaskDefinitionIncompatibilityException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "PlatformTaskDefinitionIncompatibilityException";
   $fault: "client";
@@ -5112,7 +5111,7 @@ export namespace PlatformTaskDefinitionIncompatibilityException {
   export function isa(
     o: any
   ): o is PlatformTaskDefinitionIncompatibilityException {
-    return _smithy.isa(o, "PlatformTaskDefinitionIncompatibilityException");
+    return __isa(o, "PlatformTaskDefinitionIncompatibilityException");
   }
 }
 
@@ -5120,7 +5119,7 @@ export namespace PlatformTaskDefinitionIncompatibilityException {
  * <p>The specified platform version does not exist.</p>
  */
 export interface PlatformUnknownException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "PlatformUnknownException";
   $fault: "client";
@@ -5129,7 +5128,7 @@ export interface PlatformUnknownException
 
 export namespace PlatformUnknownException {
   export function isa(o: any): o is PlatformUnknownException {
-    return _smithy.isa(o, "PlatformUnknownException");
+    return __isa(o, "PlatformUnknownException");
   }
 }
 
@@ -5206,7 +5205,7 @@ export interface PortMapping {
 
 export namespace PortMapping {
   export function isa(o: any): o is PortMapping {
-    return _smithy.isa(o, "PortMapping");
+    return __isa(o, "PortMapping");
   }
 }
 
@@ -5292,7 +5291,7 @@ export interface ProxyConfiguration {
 
 export namespace ProxyConfiguration {
   export function isa(o: any): o is ProxyConfiguration {
-    return _smithy.isa(o, "ProxyConfiguration");
+    return __isa(o, "ProxyConfiguration");
   }
 }
 
@@ -5323,7 +5322,7 @@ export interface PutAccountSettingDefaultRequest {
 
 export namespace PutAccountSettingDefaultRequest {
   export function isa(o: any): o is PutAccountSettingDefaultRequest {
-    return _smithy.isa(o, "PutAccountSettingDefaultRequest");
+    return __isa(o, "PutAccountSettingDefaultRequest");
   }
 }
 
@@ -5337,7 +5336,7 @@ export interface PutAccountSettingDefaultResponse extends $MetadataBearer {
 
 export namespace PutAccountSettingDefaultResponse {
   export function isa(o: any): o is PutAccountSettingDefaultResponse {
-    return _smithy.isa(o, "PutAccountSettingDefaultResponse");
+    return __isa(o, "PutAccountSettingDefaultResponse");
   }
 }
 
@@ -5374,7 +5373,7 @@ export interface PutAccountSettingRequest {
 
 export namespace PutAccountSettingRequest {
   export function isa(o: any): o is PutAccountSettingRequest {
-    return _smithy.isa(o, "PutAccountSettingRequest");
+    return __isa(o, "PutAccountSettingRequest");
   }
 }
 
@@ -5388,7 +5387,7 @@ export interface PutAccountSettingResponse extends $MetadataBearer {
 
 export namespace PutAccountSettingResponse {
   export function isa(o: any): o is PutAccountSettingResponse {
-    return _smithy.isa(o, "PutAccountSettingResponse");
+    return __isa(o, "PutAccountSettingResponse");
   }
 }
 
@@ -5409,7 +5408,7 @@ export interface PutAttributesRequest {
 
 export namespace PutAttributesRequest {
   export function isa(o: any): o is PutAttributesRequest {
-    return _smithy.isa(o, "PutAttributesRequest");
+    return __isa(o, "PutAttributesRequest");
   }
 }
 
@@ -5423,7 +5422,7 @@ export interface PutAttributesResponse extends $MetadataBearer {
 
 export namespace PutAttributesResponse {
   export function isa(o: any): o is PutAttributesResponse {
-    return _smithy.isa(o, "PutAttributesResponse");
+    return __isa(o, "PutAttributesResponse");
   }
 }
 
@@ -5471,7 +5470,7 @@ export interface PutClusterCapacityProvidersRequest {
 
 export namespace PutClusterCapacityProvidersRequest {
   export function isa(o: any): o is PutClusterCapacityProvidersRequest {
-    return _smithy.isa(o, "PutClusterCapacityProvidersRequest");
+    return __isa(o, "PutClusterCapacityProvidersRequest");
   }
 }
 
@@ -5488,7 +5487,7 @@ export interface PutClusterCapacityProvidersResponse extends $MetadataBearer {
 
 export namespace PutClusterCapacityProvidersResponse {
   export function isa(o: any): o is PutClusterCapacityProvidersResponse {
-    return _smithy.isa(o, "PutClusterCapacityProvidersResponse");
+    return __isa(o, "PutClusterCapacityProvidersResponse");
   }
 }
 
@@ -5584,7 +5583,7 @@ export interface RegisterContainerInstanceRequest {
 
 export namespace RegisterContainerInstanceRequest {
   export function isa(o: any): o is RegisterContainerInstanceRequest {
-    return _smithy.isa(o, "RegisterContainerInstanceRequest");
+    return __isa(o, "RegisterContainerInstanceRequest");
   }
 }
 
@@ -5598,7 +5597,7 @@ export interface RegisterContainerInstanceResponse extends $MetadataBearer {
 
 export namespace RegisterContainerInstanceResponse {
   export function isa(o: any): o is RegisterContainerInstanceResponse {
-    return _smithy.isa(o, "RegisterContainerInstanceResponse");
+    return __isa(o, "RegisterContainerInstanceResponse");
   }
 }
 
@@ -5871,7 +5870,7 @@ export interface RegisterTaskDefinitionRequest {
 
 export namespace RegisterTaskDefinitionRequest {
   export function isa(o: any): o is RegisterTaskDefinitionRequest {
-    return _smithy.isa(o, "RegisterTaskDefinitionRequest");
+    return __isa(o, "RegisterTaskDefinitionRequest");
   }
 }
 
@@ -5890,7 +5889,7 @@ export interface RegisterTaskDefinitionResponse extends $MetadataBearer {
 
 export namespace RegisterTaskDefinitionResponse {
   export function isa(o: any): o is RegisterTaskDefinitionResponse {
-    return _smithy.isa(o, "RegisterTaskDefinitionResponse");
+    return __isa(o, "RegisterTaskDefinitionResponse");
   }
 }
 
@@ -5914,7 +5913,7 @@ export interface RepositoryCredentials {
 
 export namespace RepositoryCredentials {
   export function isa(o: any): o is RepositoryCredentials {
-    return _smithy.isa(o, "RepositoryCredentials");
+    return __isa(o, "RepositoryCredentials");
   }
 }
 
@@ -5962,7 +5961,7 @@ export interface Resource {
 
 export namespace Resource {
   export function isa(o: any): o is Resource {
-    return _smithy.isa(o, "Resource");
+    return __isa(o, "Resource");
   }
 }
 
@@ -5970,7 +5969,7 @@ export namespace Resource {
  * <p>The specified resource is in-use and cannot be removed.</p>
  */
 export interface ResourceInUseException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceInUseException";
   $fault: "client";
@@ -5979,7 +5978,7 @@ export interface ResourceInUseException
 
 export namespace ResourceInUseException {
   export function isa(o: any): o is ResourceInUseException {
-    return _smithy.isa(o, "ResourceInUseException");
+    return __isa(o, "ResourceInUseException");
   }
 }
 
@@ -5987,7 +5986,7 @@ export namespace ResourceInUseException {
  * <p>The specified resource could not be found.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -5996,7 +5995,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -6030,7 +6029,7 @@ export interface ResourceRequirement {
 
 export namespace ResourceRequirement {
   export function isa(o: any): o is ResourceRequirement {
-    return _smithy.isa(o, "ResourceRequirement");
+    return __isa(o, "ResourceRequirement");
   }
 }
 
@@ -6217,7 +6216,7 @@ export interface RunTaskRequest {
 
 export namespace RunTaskRequest {
   export function isa(o: any): o is RunTaskRequest {
-    return _smithy.isa(o, "RunTaskRequest");
+    return __isa(o, "RunTaskRequest");
   }
 }
 
@@ -6237,7 +6236,7 @@ export interface RunTaskResponse extends $MetadataBearer {
 
 export namespace RunTaskResponse {
   export function isa(o: any): o is RunTaskResponse {
-    return _smithy.isa(o, "RunTaskResponse");
+    return __isa(o, "RunTaskResponse");
   }
 }
 
@@ -6261,7 +6260,7 @@ export interface Scale {
 
 export namespace Scale {
   export function isa(o: any): o is Scale {
-    return _smithy.isa(o, "Scale");
+    return __isa(o, "Scale");
   }
 }
 
@@ -6316,16 +6315,14 @@ export interface Secret {
 
 export namespace Secret {
   export function isa(o: any): o is Secret {
-    return _smithy.isa(o, "Secret");
+    return __isa(o, "Secret");
   }
 }
 
 /**
  * <p>These errors are usually caused by a server issue.</p>
  */
-export interface ServerException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface ServerException extends __SmithyException, $MetadataBearer {
   name: "ServerException";
   $fault: "server";
   message?: string;
@@ -6333,7 +6330,7 @@ export interface ServerException
 
 export namespace ServerException {
   export function isa(o: any): o is ServerException {
-    return _smithy.isa(o, "ServerException");
+    return __isa(o, "ServerException");
   }
 }
 
@@ -6573,7 +6570,7 @@ export interface Service {
 
 export namespace Service {
   export function isa(o: any): o is Service {
-    return _smithy.isa(o, "Service");
+    return __isa(o, "Service");
   }
 }
 
@@ -6600,7 +6597,7 @@ export interface ServiceEvent {
 
 export namespace ServiceEvent {
   export function isa(o: any): o is ServiceEvent {
-    return _smithy.isa(o, "ServiceEvent");
+    return __isa(o, "ServiceEvent");
   }
 }
 
@@ -6613,7 +6610,7 @@ export enum ServiceField {
  *             you have previously deleted a service, you can re-create it with <a>CreateService</a>.</p>
  */
 export interface ServiceNotActiveException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ServiceNotActiveException";
   $fault: "client";
@@ -6622,7 +6619,7 @@ export interface ServiceNotActiveException
 
 export namespace ServiceNotActiveException {
   export function isa(o: any): o is ServiceNotActiveException {
-    return _smithy.isa(o, "ServiceNotActiveException");
+    return __isa(o, "ServiceNotActiveException");
   }
 }
 
@@ -6632,7 +6629,7 @@ export namespace ServiceNotActiveException {
  *             Region-specific.</p>
  */
 export interface ServiceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ServiceNotFoundException";
   $fault: "client";
@@ -6641,7 +6638,7 @@ export interface ServiceNotFoundException
 
 export namespace ServiceNotFoundException {
   export function isa(o: any): o is ServiceNotFoundException {
-    return _smithy.isa(o, "ServiceNotFoundException");
+    return __isa(o, "ServiceNotFoundException");
   }
 }
 
@@ -6690,7 +6687,7 @@ export interface ServiceRegistry {
 
 export namespace ServiceRegistry {
   export function isa(o: any): o is ServiceRegistry {
-    return _smithy.isa(o, "ServiceRegistry");
+    return __isa(o, "ServiceRegistry");
   }
 }
 
@@ -6718,7 +6715,7 @@ export interface Setting {
 
 export namespace Setting {
   export function isa(o: any): o is Setting {
-    return _smithy.isa(o, "Setting");
+    return __isa(o, "Setting");
   }
 }
 
@@ -6857,7 +6854,7 @@ export interface StartTaskRequest {
 
 export namespace StartTaskRequest {
   export function isa(o: any): o is StartTaskRequest {
-    return _smithy.isa(o, "StartTaskRequest");
+    return __isa(o, "StartTaskRequest");
   }
 }
 
@@ -6877,7 +6874,7 @@ export interface StartTaskResponse extends $MetadataBearer {
 
 export namespace StartTaskResponse {
   export function isa(o: any): o is StartTaskResponse {
-    return _smithy.isa(o, "StartTaskResponse");
+    return __isa(o, "StartTaskResponse");
   }
 }
 
@@ -6905,7 +6902,7 @@ export interface StopTaskRequest {
 
 export namespace StopTaskRequest {
   export function isa(o: any): o is StopTaskRequest {
-    return _smithy.isa(o, "StopTaskRequest");
+    return __isa(o, "StopTaskRequest");
   }
 }
 
@@ -6919,7 +6916,7 @@ export interface StopTaskResponse extends $MetadataBearer {
 
 export namespace StopTaskResponse {
   export function isa(o: any): o is StopTaskResponse {
-    return _smithy.isa(o, "StopTaskResponse");
+    return __isa(o, "StopTaskResponse");
   }
 }
 
@@ -6939,7 +6936,7 @@ export interface SubmitAttachmentStateChangesRequest {
 
 export namespace SubmitAttachmentStateChangesRequest {
   export function isa(o: any): o is SubmitAttachmentStateChangesRequest {
-    return _smithy.isa(o, "SubmitAttachmentStateChangesRequest");
+    return __isa(o, "SubmitAttachmentStateChangesRequest");
   }
 }
 
@@ -6953,7 +6950,7 @@ export interface SubmitAttachmentStateChangesResponse extends $MetadataBearer {
 
 export namespace SubmitAttachmentStateChangesResponse {
   export function isa(o: any): o is SubmitAttachmentStateChangesResponse {
-    return _smithy.isa(o, "SubmitAttachmentStateChangesResponse");
+    return __isa(o, "SubmitAttachmentStateChangesResponse");
   }
 }
 
@@ -7002,7 +6999,7 @@ export interface SubmitContainerStateChangeRequest {
 
 export namespace SubmitContainerStateChangeRequest {
   export function isa(o: any): o is SubmitContainerStateChangeRequest {
-    return _smithy.isa(o, "SubmitContainerStateChangeRequest");
+    return __isa(o, "SubmitContainerStateChangeRequest");
   }
 }
 
@@ -7016,7 +7013,7 @@ export interface SubmitContainerStateChangeResponse extends $MetadataBearer {
 
 export namespace SubmitContainerStateChangeResponse {
   export function isa(o: any): o is SubmitContainerStateChangeResponse {
-    return _smithy.isa(o, "SubmitContainerStateChangeResponse");
+    return __isa(o, "SubmitContainerStateChangeResponse");
   }
 }
 
@@ -7070,7 +7067,7 @@ export interface SubmitTaskStateChangeRequest {
 
 export namespace SubmitTaskStateChangeRequest {
   export function isa(o: any): o is SubmitTaskStateChangeRequest {
-    return _smithy.isa(o, "SubmitTaskStateChangeRequest");
+    return __isa(o, "SubmitTaskStateChangeRequest");
   }
 }
 
@@ -7084,7 +7081,7 @@ export interface SubmitTaskStateChangeResponse extends $MetadataBearer {
 
 export namespace SubmitTaskStateChangeResponse {
   export function isa(o: any): o is SubmitTaskStateChangeResponse {
-    return _smithy.isa(o, "SubmitTaskStateChangeResponse");
+    return __isa(o, "SubmitTaskStateChangeResponse");
   }
 }
 
@@ -7128,7 +7125,7 @@ export interface SystemControl {
 
 export namespace SystemControl {
   export function isa(o: any): o is SystemControl {
-    return _smithy.isa(o, "SystemControl");
+    return __isa(o, "SystemControl");
   }
 }
 
@@ -7184,7 +7181,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -7236,7 +7233,7 @@ export interface TagResourceRequest {
 
 export namespace TagResourceRequest {
   export function isa(o: any): o is TagResourceRequest {
-    return _smithy.isa(o, "TagResourceRequest");
+    return __isa(o, "TagResourceRequest");
   }
 }
 
@@ -7246,7 +7243,7 @@ export interface TagResourceResponse extends $MetadataBearer {
 
 export namespace TagResourceResponse {
   export function isa(o: any): o is TagResourceResponse {
-    return _smithy.isa(o, "TagResourceResponse");
+    return __isa(o, "TagResourceResponse");
   }
 }
 
@@ -7256,7 +7253,7 @@ export namespace TagResourceResponse {
  *             cluster-specific and Region-specific.</p>
  */
 export interface TargetNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TargetNotFoundException";
   $fault: "client";
@@ -7265,7 +7262,7 @@ export interface TargetNotFoundException
 
 export namespace TargetNotFoundException {
   export function isa(o: any): o is TargetNotFoundException {
-    return _smithy.isa(o, "TargetNotFoundException");
+    return __isa(o, "TargetNotFoundException");
   }
 }
 
@@ -7563,7 +7560,7 @@ export interface Task {
 
 export namespace Task {
   export function isa(o: any): o is Task {
-    return _smithy.isa(o, "Task");
+    return __isa(o, "Task");
   }
 }
 
@@ -7825,7 +7822,7 @@ export interface TaskDefinition {
 
 export namespace TaskDefinition {
   export function isa(o: any): o is TaskDefinition {
-    return _smithy.isa(o, "TaskDefinition");
+    return __isa(o, "TaskDefinition");
   }
 }
 
@@ -7866,7 +7863,7 @@ export interface TaskDefinitionPlacementConstraint {
 
 export namespace TaskDefinitionPlacementConstraint {
   export function isa(o: any): o is TaskDefinitionPlacementConstraint {
-    return _smithy.isa(o, "TaskDefinitionPlacementConstraint");
+    return __isa(o, "TaskDefinitionPlacementConstraint");
   }
 }
 
@@ -7923,7 +7920,7 @@ export interface TaskOverride {
 
 export namespace TaskOverride {
   export function isa(o: any): o is TaskOverride {
-    return _smithy.isa(o, "TaskOverride");
+    return __isa(o, "TaskOverride");
   }
 }
 
@@ -8108,7 +8105,7 @@ export interface TaskSet {
 
 export namespace TaskSet {
   export function isa(o: any): o is TaskSet {
-    return _smithy.isa(o, "TaskSet");
+    return __isa(o, "TaskSet");
   }
 }
 
@@ -8118,7 +8115,7 @@ export namespace TaskSet {
  *             and Region.</p>
  */
 export interface TaskSetNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TaskSetNotFoundException";
   $fault: "client";
@@ -8127,7 +8124,7 @@ export interface TaskSetNotFoundException
 
 export namespace TaskSetNotFoundException {
   export function isa(o: any): o is TaskSetNotFoundException {
-    return _smithy.isa(o, "TaskSetNotFoundException");
+    return __isa(o, "TaskSetNotFoundException");
   }
 }
 
@@ -8167,7 +8164,7 @@ export interface Tmpfs {
 
 export namespace Tmpfs {
   export function isa(o: any): o is Tmpfs {
-    return _smithy.isa(o, "Tmpfs");
+    return __isa(o, "Tmpfs");
   }
 }
 
@@ -8199,7 +8196,7 @@ export interface Ulimit {
 
 export namespace Ulimit {
   export function isa(o: any): o is Ulimit {
-    return _smithy.isa(o, "Ulimit");
+    return __isa(o, "Ulimit");
   }
 }
 
@@ -8225,7 +8222,7 @@ export enum UlimitName {
  * <p>The specified task is not supported in this Region.</p>
  */
 export interface UnsupportedFeatureException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UnsupportedFeatureException";
   $fault: "client";
@@ -8234,7 +8231,7 @@ export interface UnsupportedFeatureException
 
 export namespace UnsupportedFeatureException {
   export function isa(o: any): o is UnsupportedFeatureException {
-    return _smithy.isa(o, "UnsupportedFeatureException");
+    return __isa(o, "UnsupportedFeatureException");
   }
 }
 
@@ -8255,7 +8252,7 @@ export interface UntagResourceRequest {
 
 export namespace UntagResourceRequest {
   export function isa(o: any): o is UntagResourceRequest {
-    return _smithy.isa(o, "UntagResourceRequest");
+    return __isa(o, "UntagResourceRequest");
   }
 }
 
@@ -8265,7 +8262,7 @@ export interface UntagResourceResponse extends $MetadataBearer {
 
 export namespace UntagResourceResponse {
   export function isa(o: any): o is UntagResourceResponse {
-    return _smithy.isa(o, "UntagResourceResponse");
+    return __isa(o, "UntagResourceResponse");
   }
 }
 
@@ -8287,7 +8284,7 @@ export interface UpdateClusterSettingsRequest {
 
 export namespace UpdateClusterSettingsRequest {
   export function isa(o: any): o is UpdateClusterSettingsRequest {
-    return _smithy.isa(o, "UpdateClusterSettingsRequest");
+    return __isa(o, "UpdateClusterSettingsRequest");
   }
 }
 
@@ -8304,7 +8301,7 @@ export interface UpdateClusterSettingsResponse extends $MetadataBearer {
 
 export namespace UpdateClusterSettingsResponse {
   export function isa(o: any): o is UpdateClusterSettingsResponse {
-    return _smithy.isa(o, "UpdateClusterSettingsResponse");
+    return __isa(o, "UpdateClusterSettingsResponse");
   }
 }
 
@@ -8325,7 +8322,7 @@ export interface UpdateContainerAgentRequest {
 
 export namespace UpdateContainerAgentRequest {
   export function isa(o: any): o is UpdateContainerAgentRequest {
-    return _smithy.isa(o, "UpdateContainerAgentRequest");
+    return __isa(o, "UpdateContainerAgentRequest");
   }
 }
 
@@ -8339,7 +8336,7 @@ export interface UpdateContainerAgentResponse extends $MetadataBearer {
 
 export namespace UpdateContainerAgentResponse {
   export function isa(o: any): o is UpdateContainerAgentResponse {
-    return _smithy.isa(o, "UpdateContainerAgentResponse");
+    return __isa(o, "UpdateContainerAgentResponse");
   }
 }
 
@@ -8370,7 +8367,7 @@ export interface UpdateContainerInstancesStateRequest {
 
 export namespace UpdateContainerInstancesStateRequest {
   export function isa(o: any): o is UpdateContainerInstancesStateRequest {
-    return _smithy.isa(o, "UpdateContainerInstancesStateRequest");
+    return __isa(o, "UpdateContainerInstancesStateRequest");
   }
 }
 
@@ -8389,7 +8386,7 @@ export interface UpdateContainerInstancesStateResponse extends $MetadataBearer {
 
 export namespace UpdateContainerInstancesStateResponse {
   export function isa(o: any): o is UpdateContainerInstancesStateResponse {
-    return _smithy.isa(o, "UpdateContainerInstancesStateResponse");
+    return __isa(o, "UpdateContainerInstancesStateResponse");
   }
 }
 
@@ -8401,7 +8398,7 @@ export namespace UpdateContainerInstancesStateResponse {
  *             where it stopped previously.</p>
  */
 export interface UpdateInProgressException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UpdateInProgressException";
   $fault: "client";
@@ -8410,7 +8407,7 @@ export interface UpdateInProgressException
 
 export namespace UpdateInProgressException {
   export function isa(o: any): o is UpdateInProgressException {
-    return _smithy.isa(o, "UpdateInProgressException");
+    return __isa(o, "UpdateInProgressException");
   }
 }
 
@@ -8436,7 +8433,7 @@ export interface UpdateServicePrimaryTaskSetRequest {
 
 export namespace UpdateServicePrimaryTaskSetRequest {
   export function isa(o: any): o is UpdateServicePrimaryTaskSetRequest {
-    return _smithy.isa(o, "UpdateServicePrimaryTaskSetRequest");
+    return __isa(o, "UpdateServicePrimaryTaskSetRequest");
   }
 }
 
@@ -8452,7 +8449,7 @@ export interface UpdateServicePrimaryTaskSetResponse extends $MetadataBearer {
 
 export namespace UpdateServicePrimaryTaskSetResponse {
   export function isa(o: any): o is UpdateServicePrimaryTaskSetResponse {
-    return _smithy.isa(o, "UpdateServicePrimaryTaskSetResponse");
+    return __isa(o, "UpdateServicePrimaryTaskSetResponse");
   }
 }
 
@@ -8538,7 +8535,7 @@ export interface UpdateServiceRequest {
 
 export namespace UpdateServiceRequest {
   export function isa(o: any): o is UpdateServiceRequest {
-    return _smithy.isa(o, "UpdateServiceRequest");
+    return __isa(o, "UpdateServiceRequest");
   }
 }
 
@@ -8552,7 +8549,7 @@ export interface UpdateServiceResponse extends $MetadataBearer {
 
 export namespace UpdateServiceResponse {
   export function isa(o: any): o is UpdateServiceResponse {
-    return _smithy.isa(o, "UpdateServiceResponse");
+    return __isa(o, "UpdateServiceResponse");
   }
 }
 
@@ -8583,7 +8580,7 @@ export interface UpdateTaskSetRequest {
 
 export namespace UpdateTaskSetRequest {
   export function isa(o: any): o is UpdateTaskSetRequest {
-    return _smithy.isa(o, "UpdateTaskSetRequest");
+    return __isa(o, "UpdateTaskSetRequest");
   }
 }
 
@@ -8599,7 +8596,7 @@ export interface UpdateTaskSetResponse extends $MetadataBearer {
 
 export namespace UpdateTaskSetResponse {
   export function isa(o: any): o is UpdateTaskSetResponse {
-    return _smithy.isa(o, "UpdateTaskSetResponse");
+    return __isa(o, "UpdateTaskSetResponse");
   }
 }
 
@@ -8628,7 +8625,7 @@ export interface VersionInfo {
 
 export namespace VersionInfo {
   export function isa(o: any): o is VersionInfo {
-    return _smithy.isa(o, "VersionInfo");
+    return __isa(o, "VersionInfo");
   }
 }
 
@@ -8690,7 +8687,7 @@ export interface Volume {
 
 export namespace Volume {
   export function isa(o: any): o is Volume {
-    return _smithy.isa(o, "Volume");
+    return __isa(o, "Volume");
   }
 }
 
@@ -8715,6 +8712,6 @@ export interface VolumeFrom {
 
 export namespace VolumeFrom {
   export function isa(o: any): o is VolumeFrom {
-    return _smithy.isa(o, "VolumeFrom");
+    return __isa(o, "VolumeFrom");
   }
 }

--- a/clients/client-efs/models/index.ts
+++ b/clients/client-efs/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -6,7 +9,7 @@ import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
  *             creation token you provided in the request.</p>
  */
 export interface AccessPointAlreadyExists
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AccessPointAlreadyExists";
   $fault: "client";
@@ -17,7 +20,7 @@ export interface AccessPointAlreadyExists
 
 export namespace AccessPointAlreadyExists {
   export function isa(o: any): o is AccessPointAlreadyExists {
-    return _smithy.isa(o, "AccessPointAlreadyExists");
+    return __isa(o, "AccessPointAlreadyExists");
   }
 }
 
@@ -26,7 +29,7 @@ export namespace AccessPointAlreadyExists {
  *             allowed per file system.</p>
  */
 export interface AccessPointLimitExceeded
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AccessPointLimitExceeded";
   $fault: "client";
@@ -36,7 +39,7 @@ export interface AccessPointLimitExceeded
 
 export namespace AccessPointLimitExceeded {
   export function isa(o: any): o is AccessPointLimitExceeded {
-    return _smithy.isa(o, "AccessPointLimitExceeded");
+    return __isa(o, "AccessPointLimitExceeded");
   }
 }
 
@@ -45,7 +48,7 @@ export namespace AccessPointLimitExceeded {
  *             requester's AWS account.</p>
  */
 export interface AccessPointNotFound
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AccessPointNotFound";
   $fault: "client";
@@ -55,7 +58,7 @@ export interface AccessPointNotFound
 
 export namespace AccessPointNotFound {
   export function isa(o: any): o is AccessPointNotFound {
-    return _smithy.isa(o, "AccessPointNotFound");
+    return __isa(o, "AccessPointNotFound");
   }
 }
 
@@ -63,7 +66,7 @@ export namespace AccessPointNotFound {
  * <p>Returned if the request is malformed or contains an error such as an invalid
  *             parameter value or a missing required parameter.</p>
  */
-export interface BadRequest extends _smithy.SmithyException, $MetadataBearer {
+export interface BadRequest extends __SmithyException, $MetadataBearer {
   name: "BadRequest";
   $fault: "client";
   ErrorCode: string | undefined;
@@ -72,7 +75,7 @@ export interface BadRequest extends _smithy.SmithyException, $MetadataBearer {
 
 export namespace BadRequest {
   export function isa(o: any): o is BadRequest {
-    return _smithy.isa(o, "BadRequest");
+    return __isa(o, "BadRequest");
   }
 }
 
@@ -80,9 +83,7 @@ export namespace BadRequest {
  * <p>The service timed out trying to fulfill the request, and the client should try the
  *             call again.</p>
  */
-export interface DependencyTimeout
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface DependencyTimeout extends __SmithyException, $MetadataBearer {
   name: "DependencyTimeout";
   $fault: "server";
   ErrorCode: string | undefined;
@@ -91,7 +92,7 @@ export interface DependencyTimeout
 
 export namespace DependencyTimeout {
   export function isa(o: any): o is DependencyTimeout {
-    return _smithy.isa(o, "DependencyTimeout");
+    return __isa(o, "DependencyTimeout");
   }
 }
 
@@ -100,7 +101,7 @@ export namespace DependencyTimeout {
  *             creation token you provided.</p>
  */
 export interface FileSystemAlreadyExists
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "FileSystemAlreadyExists";
   $fault: "client";
@@ -111,16 +112,14 @@ export interface FileSystemAlreadyExists
 
 export namespace FileSystemAlreadyExists {
   export function isa(o: any): o is FileSystemAlreadyExists {
-    return _smithy.isa(o, "FileSystemAlreadyExists");
+    return __isa(o, "FileSystemAlreadyExists");
   }
 }
 
 /**
  * <p>Returned if a file system has mount targets.</p>
  */
-export interface FileSystemInUse
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface FileSystemInUse extends __SmithyException, $MetadataBearer {
   name: "FileSystemInUse";
   $fault: "client";
   ErrorCode: string | undefined;
@@ -129,7 +128,7 @@ export interface FileSystemInUse
 
 export namespace FileSystemInUse {
   export function isa(o: any): o is FileSystemInUse {
-    return _smithy.isa(o, "FileSystemInUse");
+    return __isa(o, "FileSystemInUse");
   }
 }
 
@@ -138,7 +137,7 @@ export namespace FileSystemInUse {
  *             allowed per account.</p>
  */
 export interface FileSystemLimitExceeded
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "FileSystemLimitExceeded";
   $fault: "client";
@@ -148,7 +147,7 @@ export interface FileSystemLimitExceeded
 
 export namespace FileSystemLimitExceeded {
   export function isa(o: any): o is FileSystemLimitExceeded {
-    return _smithy.isa(o, "FileSystemLimitExceeded");
+    return __isa(o, "FileSystemLimitExceeded");
   }
 }
 
@@ -156,9 +155,7 @@ export namespace FileSystemLimitExceeded {
  * <p>Returned if the specified <code>FileSystemId</code> value doesn't exist in the
  *             requester's AWS account.</p>
  */
-export interface FileSystemNotFound
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface FileSystemNotFound extends __SmithyException, $MetadataBearer {
   name: "FileSystemNotFound";
   $fault: "client";
   ErrorCode: string | undefined;
@@ -167,7 +164,7 @@ export interface FileSystemNotFound
 
 export namespace FileSystemNotFound {
   export function isa(o: any): o is FileSystemNotFound {
-    return _smithy.isa(o, "FileSystemNotFound");
+    return __isa(o, "FileSystemNotFound");
   }
 }
 
@@ -175,7 +172,7 @@ export namespace FileSystemNotFound {
  * <p>Returned if the file system's lifecycle state is not "available".</p>
  */
 export interface IncorrectFileSystemLifeCycleState
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "IncorrectFileSystemLifeCycleState";
   $fault: "client";
@@ -185,7 +182,7 @@ export interface IncorrectFileSystemLifeCycleState
 
 export namespace IncorrectFileSystemLifeCycleState {
   export function isa(o: any): o is IncorrectFileSystemLifeCycleState {
-    return _smithy.isa(o, "IncorrectFileSystemLifeCycleState");
+    return __isa(o, "IncorrectFileSystemLifeCycleState");
   }
 }
 
@@ -194,7 +191,7 @@ export namespace IncorrectFileSystemLifeCycleState {
  *             operation.</p>
  */
 export interface IncorrectMountTargetState
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "IncorrectMountTargetState";
   $fault: "client";
@@ -204,7 +201,7 @@ export interface IncorrectMountTargetState
 
 export namespace IncorrectMountTargetState {
   export function isa(o: any): o is IncorrectMountTargetState {
-    return _smithy.isa(o, "IncorrectMountTargetState");
+    return __isa(o, "IncorrectMountTargetState");
   }
 }
 
@@ -216,7 +213,7 @@ export namespace IncorrectMountTargetState {
  *             throughput mode.</p>
  */
 export interface InsufficientThroughputCapacity
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InsufficientThroughputCapacity";
   $fault: "server";
@@ -226,7 +223,7 @@ export interface InsufficientThroughputCapacity
 
 export namespace InsufficientThroughputCapacity {
   export function isa(o: any): o is InsufficientThroughputCapacity {
-    return _smithy.isa(o, "InsufficientThroughputCapacity");
+    return __isa(o, "InsufficientThroughputCapacity");
   }
 }
 
@@ -234,7 +231,7 @@ export namespace InsufficientThroughputCapacity {
  * <p>Returned if an error occurred on the server side.</p>
  */
 export interface InternalServerError
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalServerError";
   $fault: "server";
@@ -244,7 +241,7 @@ export interface InternalServerError
 
 export namespace InternalServerError {
   export function isa(o: any): o is InternalServerError {
-    return _smithy.isa(o, "InternalServerError");
+    return __isa(o, "InternalServerError");
   }
 }
 
@@ -253,7 +250,7 @@ export namespace InternalServerError {
  *             parameter value or a missing required parameter. Returned in the case of a policy lockout safety check error.</p>
  */
 export interface InvalidPolicyException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidPolicyException";
   $fault: "client";
@@ -263,7 +260,7 @@ export interface InvalidPolicyException
 
 export namespace InvalidPolicyException {
   export function isa(o: any): o is InvalidPolicyException {
-    return _smithy.isa(o, "InvalidPolicyException");
+    return __isa(o, "InvalidPolicyException");
   }
 }
 
@@ -271,9 +268,7 @@ export namespace InvalidPolicyException {
  * <p>Returned if the request specified an <code>IpAddress</code> that is already in use
  *             in the subnet.</p>
  */
-export interface IpAddressInUse
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface IpAddressInUse extends __SmithyException, $MetadataBearer {
   name: "IpAddressInUse";
   $fault: "client";
   ErrorCode: string | undefined;
@@ -282,7 +277,7 @@ export interface IpAddressInUse
 
 export namespace IpAddressInUse {
   export function isa(o: any): o is IpAddressInUse {
-    return _smithy.isa(o, "IpAddressInUse");
+    return __isa(o, "IpAddressInUse");
   }
 }
 
@@ -291,7 +286,7 @@ export namespace IpAddressInUse {
  *             on the file system's existing mount targets.</p>
  */
 export interface MountTargetConflict
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "MountTargetConflict";
   $fault: "client";
@@ -301,7 +296,7 @@ export interface MountTargetConflict
 
 export namespace MountTargetConflict {
   export function isa(o: any): o is MountTargetConflict {
-    return _smithy.isa(o, "MountTargetConflict");
+    return __isa(o, "MountTargetConflict");
   }
 }
 
@@ -310,7 +305,7 @@ export namespace MountTargetConflict {
  *             caller's account.</p>
  */
 export interface MountTargetNotFound
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "MountTargetNotFound";
   $fault: "client";
@@ -320,7 +315,7 @@ export interface MountTargetNotFound
 
 export namespace MountTargetNotFound {
   export function isa(o: any): o is MountTargetNotFound {
-    return _smithy.isa(o, "MountTargetNotFound");
+    return __isa(o, "MountTargetNotFound");
   }
 }
 
@@ -332,7 +327,7 @@ export namespace MountTargetNotFound {
  *             entry in the table). </p>
  */
 export interface NetworkInterfaceLimitExceeded
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "NetworkInterfaceLimitExceeded";
   $fault: "client";
@@ -342,7 +337,7 @@ export interface NetworkInterfaceLimitExceeded
 
 export namespace NetworkInterfaceLimitExceeded {
   export function isa(o: any): o is NetworkInterfaceLimitExceeded {
-    return _smithy.isa(o, "NetworkInterfaceLimitExceeded");
+    return __isa(o, "NetworkInterfaceLimitExceeded");
   }
 }
 
@@ -351,7 +346,7 @@ export namespace NetworkInterfaceLimitExceeded {
  *             no free IP addresses in the subnet.</p>
  */
 export interface NoFreeAddressesInSubnet
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "NoFreeAddressesInSubnet";
   $fault: "client";
@@ -361,16 +356,14 @@ export interface NoFreeAddressesInSubnet
 
 export namespace NoFreeAddressesInSubnet {
   export function isa(o: any): o is NoFreeAddressesInSubnet {
-    return _smithy.isa(o, "NoFreeAddressesInSubnet");
+    return __isa(o, "NoFreeAddressesInSubnet");
   }
 }
 
 /**
  * <p>Returned if the default file system policy is in effect for the EFS file system specified.</p>
  */
-export interface PolicyNotFound
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface PolicyNotFound extends __SmithyException, $MetadataBearer {
   name: "PolicyNotFound";
   $fault: "client";
   ErrorCode?: string;
@@ -379,7 +372,7 @@ export interface PolicyNotFound
 
 export namespace PolicyNotFound {
   export function isa(o: any): o is PolicyNotFound {
-    return _smithy.isa(o, "PolicyNotFound");
+    return __isa(o, "PolicyNotFound");
   }
 }
 
@@ -388,7 +381,7 @@ export namespace PolicyNotFound {
  *             greater than five.</p>
  */
 export interface SecurityGroupLimitExceeded
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "SecurityGroupLimitExceeded";
   $fault: "client";
@@ -398,7 +391,7 @@ export interface SecurityGroupLimitExceeded
 
 export namespace SecurityGroupLimitExceeded {
   export function isa(o: any): o is SecurityGroupLimitExceeded {
-    return _smithy.isa(o, "SecurityGroupLimitExceeded");
+    return __isa(o, "SecurityGroupLimitExceeded");
   }
 }
 
@@ -407,7 +400,7 @@ export namespace SecurityGroupLimitExceeded {
  *             VPC.</p>
  */
 export interface SecurityGroupNotFound
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "SecurityGroupNotFound";
   $fault: "client";
@@ -417,7 +410,7 @@ export interface SecurityGroupNotFound
 
 export namespace SecurityGroupNotFound {
   export function isa(o: any): o is SecurityGroupNotFound {
-    return _smithy.isa(o, "SecurityGroupNotFound");
+    return __isa(o, "SecurityGroupNotFound");
   }
 }
 
@@ -425,9 +418,7 @@ export namespace SecurityGroupNotFound {
  * <p>Returned if there is no subnet with ID <code>SubnetId</code> provided in the
  *             request.</p>
  */
-export interface SubnetNotFound
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface SubnetNotFound extends __SmithyException, $MetadataBearer {
   name: "SubnetNotFound";
   $fault: "client";
   ErrorCode: string | undefined;
@@ -436,7 +427,7 @@ export interface SubnetNotFound
 
 export namespace SubnetNotFound {
   export function isa(o: any): o is SubnetNotFound {
-    return _smithy.isa(o, "SubnetNotFound");
+    return __isa(o, "SubnetNotFound");
   }
 }
 
@@ -445,7 +436,7 @@ export namespace SubnetNotFound {
  *             because the throughput limit of 1024 MiB/s has been reached.</p>
  */
 export interface ThroughputLimitExceeded
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ThroughputLimitExceeded";
   $fault: "client";
@@ -455,7 +446,7 @@ export interface ThroughputLimitExceeded
 
 export namespace ThroughputLimitExceeded {
   export function isa(o: any): o is ThroughputLimitExceeded {
-    return _smithy.isa(o, "ThroughputLimitExceeded");
+    return __isa(o, "ThroughputLimitExceeded");
   }
 }
 
@@ -463,9 +454,7 @@ export namespace ThroughputLimitExceeded {
  * <p>Returned if you don’t wait at least 24 hours before changing the throughput mode, or
  *             decreasing the Provisioned Throughput value.</p>
  */
-export interface TooManyRequests
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface TooManyRequests extends __SmithyException, $MetadataBearer {
   name: "TooManyRequests";
   $fault: "client";
   ErrorCode: string | undefined;
@@ -474,7 +463,7 @@ export interface TooManyRequests
 
 export namespace TooManyRequests {
   export function isa(o: any): o is TooManyRequests {
-    return _smithy.isa(o, "TooManyRequests");
+    return __isa(o, "TooManyRequests");
   }
 }
 
@@ -482,7 +471,7 @@ export namespace TooManyRequests {
  * <p></p>
  */
 export interface UnsupportedAvailabilityZone
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UnsupportedAvailabilityZone";
   $fault: "client";
@@ -492,7 +481,7 @@ export interface UnsupportedAvailabilityZone
 
 export namespace UnsupportedAvailabilityZone {
   export function isa(o: any): o is UnsupportedAvailabilityZone {
-    return _smithy.isa(o, "UnsupportedAvailabilityZone");
+    return __isa(o, "UnsupportedAvailabilityZone");
   }
 }
 
@@ -555,7 +544,7 @@ export interface AccessPointDescription extends $MetadataBearer {
 
 export namespace AccessPointDescription {
   export function isa(o: any): o is AccessPointDescription {
-    return _smithy.isa(o, "AccessPointDescription");
+    return __isa(o, "AccessPointDescription");
   }
 }
 
@@ -596,7 +585,7 @@ export interface CreateAccessPointRequest {
 
 export namespace CreateAccessPointRequest {
   export function isa(o: any): o is CreateAccessPointRequest {
-    return _smithy.isa(o, "CreateAccessPointRequest");
+    return __isa(o, "CreateAccessPointRequest");
   }
 }
 
@@ -685,7 +674,7 @@ export interface CreateFileSystemRequest {
 
 export namespace CreateFileSystemRequest {
   export function isa(o: any): o is CreateFileSystemRequest {
-    return _smithy.isa(o, "CreateFileSystemRequest");
+    return __isa(o, "CreateFileSystemRequest");
   }
 }
 
@@ -718,7 +707,7 @@ export interface CreateMountTargetRequest {
 
 export namespace CreateMountTargetRequest {
   export function isa(o: any): o is CreateMountTargetRequest {
-    return _smithy.isa(o, "CreateMountTargetRequest");
+    return __isa(o, "CreateMountTargetRequest");
   }
 }
 
@@ -742,7 +731,7 @@ export interface CreateTagsRequest {
 
 export namespace CreateTagsRequest {
   export function isa(o: any): o is CreateTagsRequest {
-    return _smithy.isa(o, "CreateTagsRequest");
+    return __isa(o, "CreateTagsRequest");
   }
 }
 
@@ -777,7 +766,7 @@ export interface CreationInfo {
 
 export namespace CreationInfo {
   export function isa(o: any): o is CreationInfo {
-    return _smithy.isa(o, "CreationInfo");
+    return __isa(o, "CreationInfo");
   }
 }
 
@@ -791,7 +780,7 @@ export interface DeleteAccessPointRequest {
 
 export namespace DeleteAccessPointRequest {
   export function isa(o: any): o is DeleteAccessPointRequest {
-    return _smithy.isa(o, "DeleteAccessPointRequest");
+    return __isa(o, "DeleteAccessPointRequest");
   }
 }
 
@@ -805,7 +794,7 @@ export interface DeleteFileSystemPolicyRequest {
 
 export namespace DeleteFileSystemPolicyRequest {
   export function isa(o: any): o is DeleteFileSystemPolicyRequest {
-    return _smithy.isa(o, "DeleteFileSystemPolicyRequest");
+    return __isa(o, "DeleteFileSystemPolicyRequest");
   }
 }
 
@@ -822,7 +811,7 @@ export interface DeleteFileSystemRequest {
 
 export namespace DeleteFileSystemRequest {
   export function isa(o: any): o is DeleteFileSystemRequest {
-    return _smithy.isa(o, "DeleteFileSystemRequest");
+    return __isa(o, "DeleteFileSystemRequest");
   }
 }
 
@@ -839,7 +828,7 @@ export interface DeleteMountTargetRequest {
 
 export namespace DeleteMountTargetRequest {
   export function isa(o: any): o is DeleteMountTargetRequest {
-    return _smithy.isa(o, "DeleteMountTargetRequest");
+    return __isa(o, "DeleteMountTargetRequest");
   }
 }
 
@@ -861,7 +850,7 @@ export interface DeleteTagsRequest {
 
 export namespace DeleteTagsRequest {
   export function isa(o: any): o is DeleteTagsRequest {
-    return _smithy.isa(o, "DeleteTagsRequest");
+    return __isa(o, "DeleteTagsRequest");
   }
 }
 
@@ -893,7 +882,7 @@ export interface DescribeAccessPointsRequest {
 
 export namespace DescribeAccessPointsRequest {
   export function isa(o: any): o is DescribeAccessPointsRequest {
-    return _smithy.isa(o, "DescribeAccessPointsRequest");
+    return __isa(o, "DescribeAccessPointsRequest");
   }
 }
 
@@ -913,7 +902,7 @@ export interface DescribeAccessPointsResponse extends $MetadataBearer {
 
 export namespace DescribeAccessPointsResponse {
   export function isa(o: any): o is DescribeAccessPointsResponse {
-    return _smithy.isa(o, "DescribeAccessPointsResponse");
+    return __isa(o, "DescribeAccessPointsResponse");
   }
 }
 
@@ -927,7 +916,7 @@ export interface DescribeFileSystemPolicyRequest {
 
 export namespace DescribeFileSystemPolicyRequest {
   export function isa(o: any): o is DescribeFileSystemPolicyRequest {
-    return _smithy.isa(o, "DescribeFileSystemPolicyRequest");
+    return __isa(o, "DescribeFileSystemPolicyRequest");
   }
 }
 
@@ -965,7 +954,7 @@ export interface DescribeFileSystemsRequest {
 
 export namespace DescribeFileSystemsRequest {
   export function isa(o: any): o is DescribeFileSystemsRequest {
-    return _smithy.isa(o, "DescribeFileSystemsRequest");
+    return __isa(o, "DescribeFileSystemsRequest");
   }
 }
 
@@ -990,7 +979,7 @@ export interface DescribeFileSystemsResponse extends $MetadataBearer {
 
 export namespace DescribeFileSystemsResponse {
   export function isa(o: any): o is DescribeFileSystemsResponse {
-    return _smithy.isa(o, "DescribeFileSystemsResponse");
+    return __isa(o, "DescribeFileSystemsResponse");
   }
 }
 
@@ -1005,7 +994,7 @@ export interface DescribeLifecycleConfigurationRequest {
 
 export namespace DescribeLifecycleConfigurationRequest {
   export function isa(o: any): o is DescribeLifecycleConfigurationRequest {
-    return _smithy.isa(o, "DescribeLifecycleConfigurationRequest");
+    return __isa(o, "DescribeLifecycleConfigurationRequest");
   }
 }
 
@@ -1022,7 +1011,7 @@ export interface DescribeMountTargetSecurityGroupsRequest {
 
 export namespace DescribeMountTargetSecurityGroupsRequest {
   export function isa(o: any): o is DescribeMountTargetSecurityGroupsRequest {
-    return _smithy.isa(o, "DescribeMountTargetSecurityGroupsRequest");
+    return __isa(o, "DescribeMountTargetSecurityGroupsRequest");
   }
 }
 
@@ -1037,7 +1026,7 @@ export interface DescribeMountTargetSecurityGroupsResponse
 
 export namespace DescribeMountTargetSecurityGroupsResponse {
   export function isa(o: any): o is DescribeMountTargetSecurityGroupsResponse {
-    return _smithy.isa(o, "DescribeMountTargetSecurityGroupsResponse");
+    return __isa(o, "DescribeMountTargetSecurityGroupsResponse");
   }
 }
 
@@ -1081,7 +1070,7 @@ export interface DescribeMountTargetsRequest {
 
 export namespace DescribeMountTargetsRequest {
   export function isa(o: any): o is DescribeMountTargetsRequest {
-    return _smithy.isa(o, "DescribeMountTargetsRequest");
+    return __isa(o, "DescribeMountTargetsRequest");
   }
 }
 
@@ -1112,7 +1101,7 @@ export interface DescribeMountTargetsResponse extends $MetadataBearer {
 
 export namespace DescribeMountTargetsResponse {
   export function isa(o: any): o is DescribeMountTargetsResponse {
-    return _smithy.isa(o, "DescribeMountTargetsResponse");
+    return __isa(o, "DescribeMountTargetsResponse");
   }
 }
 
@@ -1143,7 +1132,7 @@ export interface DescribeTagsRequest {
 
 export namespace DescribeTagsRequest {
   export function isa(o: any): o is DescribeTagsRequest {
-    return _smithy.isa(o, "DescribeTagsRequest");
+    return __isa(o, "DescribeTagsRequest");
   }
 }
 
@@ -1174,7 +1163,7 @@ export interface DescribeTagsResponse extends $MetadataBearer {
 
 export namespace DescribeTagsResponse {
   export function isa(o: any): o is DescribeTagsResponse {
-    return _smithy.isa(o, "DescribeTagsResponse");
+    return __isa(o, "DescribeTagsResponse");
   }
 }
 
@@ -1280,7 +1269,7 @@ export interface FileSystemDescription extends $MetadataBearer {
 
 export namespace FileSystemDescription {
   export function isa(o: any): o is FileSystemDescription {
-    return _smithy.isa(o, "FileSystemDescription");
+    return __isa(o, "FileSystemDescription");
   }
 }
 
@@ -1299,7 +1288,7 @@ export interface FileSystemPolicyDescription extends $MetadataBearer {
 
 export namespace FileSystemPolicyDescription {
   export function isa(o: any): o is FileSystemPolicyDescription {
-    return _smithy.isa(o, "FileSystemPolicyDescription");
+    return __isa(o, "FileSystemPolicyDescription");
   }
 }
 
@@ -1340,7 +1329,7 @@ export interface FileSystemSize {
 
 export namespace FileSystemSize {
   export function isa(o: any): o is FileSystemSize {
-    return _smithy.isa(o, "FileSystemSize");
+    return __isa(o, "FileSystemSize");
   }
 }
 
@@ -1363,7 +1352,7 @@ export interface LifecycleConfigurationDescription extends $MetadataBearer {
 
 export namespace LifecycleConfigurationDescription {
   export function isa(o: any): o is LifecycleConfigurationDescription {
-    return _smithy.isa(o, "LifecycleConfigurationDescription");
+    return __isa(o, "LifecycleConfigurationDescription");
   }
 }
 
@@ -1384,7 +1373,7 @@ export interface LifecyclePolicy {
 
 export namespace LifecyclePolicy {
   export function isa(o: any): o is LifecyclePolicy {
-    return _smithy.isa(o, "LifecyclePolicy");
+    return __isa(o, "LifecyclePolicy");
   }
 }
 
@@ -1408,7 +1397,7 @@ export interface ListTagsForResourceRequest {
 
 export namespace ListTagsForResourceRequest {
   export function isa(o: any): o is ListTagsForResourceRequest {
-    return _smithy.isa(o, "ListTagsForResourceRequest");
+    return __isa(o, "ListTagsForResourceRequest");
   }
 }
 
@@ -1428,7 +1417,7 @@ export interface ListTagsForResourceResponse extends $MetadataBearer {
 
 export namespace ListTagsForResourceResponse {
   export function isa(o: any): o is ListTagsForResourceResponse {
-    return _smithy.isa(o, "ListTagsForResourceResponse");
+    return __isa(o, "ListTagsForResourceResponse");
   }
 }
 
@@ -1450,7 +1439,7 @@ export interface ModifyMountTargetSecurityGroupsRequest {
 
 export namespace ModifyMountTargetSecurityGroupsRequest {
   export function isa(o: any): o is ModifyMountTargetSecurityGroupsRequest {
-    return _smithy.isa(o, "ModifyMountTargetSecurityGroupsRequest");
+    return __isa(o, "ModifyMountTargetSecurityGroupsRequest");
   }
 }
 
@@ -1511,7 +1500,7 @@ export interface MountTargetDescription extends $MetadataBearer {
 
 export namespace MountTargetDescription {
   export function isa(o: any): o is MountTargetDescription {
-    return _smithy.isa(o, "MountTargetDescription");
+    return __isa(o, "MountTargetDescription");
   }
 }
 
@@ -1544,7 +1533,7 @@ export interface PosixUser {
 
 export namespace PosixUser {
   export function isa(o: any): o is PosixUser {
-    return _smithy.isa(o, "PosixUser");
+    return __isa(o, "PosixUser");
   }
 }
 
@@ -1576,7 +1565,7 @@ export interface PutFileSystemPolicyRequest {
 
 export namespace PutFileSystemPolicyRequest {
   export function isa(o: any): o is PutFileSystemPolicyRequest {
-    return _smithy.isa(o, "PutFileSystemPolicyRequest");
+    return __isa(o, "PutFileSystemPolicyRequest");
   }
 }
 
@@ -1599,7 +1588,7 @@ export interface PutLifecycleConfigurationRequest {
 
 export namespace PutLifecycleConfigurationRequest {
   export function isa(o: any): o is PutLifecycleConfigurationRequest {
-    return _smithy.isa(o, "PutLifecycleConfigurationRequest");
+    return __isa(o, "PutLifecycleConfigurationRequest");
   }
 }
 
@@ -1634,7 +1623,7 @@ export interface RootDirectory {
 
 export namespace RootDirectory {
   export function isa(o: any): o is RootDirectory {
-    return _smithy.isa(o, "RootDirectory");
+    return __isa(o, "RootDirectory");
   }
 }
 
@@ -1658,7 +1647,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -1677,7 +1666,7 @@ export interface TagResourceRequest {
 
 export namespace TagResourceRequest {
   export function isa(o: any): o is TagResourceRequest {
-    return _smithy.isa(o, "TagResourceRequest");
+    return __isa(o, "TagResourceRequest");
   }
 }
 
@@ -1709,7 +1698,7 @@ export interface UntagResourceRequest {
 
 export namespace UntagResourceRequest {
   export function isa(o: any): o is UntagResourceRequest {
-    return _smithy.isa(o, "UntagResourceRequest");
+    return __isa(o, "UntagResourceRequest");
   }
 }
 
@@ -1738,6 +1727,6 @@ export interface UpdateFileSystemRequest {
 
 export namespace UpdateFileSystemRequest {
   export function isa(o: any): o is UpdateFileSystemRequest {
-    return _smithy.isa(o, "UpdateFileSystemRequest");
+    return __isa(o, "UpdateFileSystemRequest");
   }
 }

--- a/clients/client-efs/protocols/Aws_restJson1_1.ts
+++ b/clients/client-efs/protocols/Aws_restJson1_1.ts
@@ -131,7 +131,10 @@ import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  extendedEncodeURIComponent as __extendedEncodeURIComponent
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -272,7 +275,7 @@ export async function serializeAws_restJson1_1CreateTagsCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/2015-02-01/create-tags/{FileSystemId}";
   if (input.FileSystemId !== undefined) {
-    const labelValue: string = input.FileSystemId.toString();
+    const labelValue: string = input.FileSystemId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: FileSystemId."
@@ -280,7 +283,7 @@ export async function serializeAws_restJson1_1CreateTagsCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{FileSystemId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: FileSystemId.");
@@ -309,7 +312,7 @@ export async function serializeAws_restJson1_1DeleteAccessPointCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/2015-02-01/access-points/{AccessPointId}";
   if (input.AccessPointId !== undefined) {
-    const labelValue: string = input.AccessPointId.toString();
+    const labelValue: string = input.AccessPointId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: AccessPointId."
@@ -317,7 +320,7 @@ export async function serializeAws_restJson1_1DeleteAccessPointCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{AccessPointId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AccessPointId.");
@@ -339,7 +342,7 @@ export async function serializeAws_restJson1_1DeleteFileSystemCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/2015-02-01/file-systems/{FileSystemId}";
   if (input.FileSystemId !== undefined) {
-    const labelValue: string = input.FileSystemId.toString();
+    const labelValue: string = input.FileSystemId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: FileSystemId."
@@ -347,7 +350,7 @@ export async function serializeAws_restJson1_1DeleteFileSystemCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{FileSystemId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: FileSystemId.");
@@ -369,7 +372,7 @@ export async function serializeAws_restJson1_1DeleteFileSystemPolicyCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/2015-02-01/file-systems/{FileSystemId}/policy";
   if (input.FileSystemId !== undefined) {
-    const labelValue: string = input.FileSystemId.toString();
+    const labelValue: string = input.FileSystemId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: FileSystemId."
@@ -377,7 +380,7 @@ export async function serializeAws_restJson1_1DeleteFileSystemPolicyCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{FileSystemId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: FileSystemId.");
@@ -399,7 +402,7 @@ export async function serializeAws_restJson1_1DeleteMountTargetCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/2015-02-01/mount-targets/{MountTargetId}";
   if (input.MountTargetId !== undefined) {
-    const labelValue: string = input.MountTargetId.toString();
+    const labelValue: string = input.MountTargetId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: MountTargetId."
@@ -407,7 +410,7 @@ export async function serializeAws_restJson1_1DeleteMountTargetCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{MountTargetId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: MountTargetId.");
@@ -429,7 +432,7 @@ export async function serializeAws_restJson1_1DeleteTagsCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/2015-02-01/delete-tags/{FileSystemId}";
   if (input.FileSystemId !== undefined) {
-    const labelValue: string = input.FileSystemId.toString();
+    const labelValue: string = input.FileSystemId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: FileSystemId."
@@ -437,7 +440,7 @@ export async function serializeAws_restJson1_1DeleteTagsCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{FileSystemId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: FileSystemId.");
@@ -470,16 +473,24 @@ export async function serializeAws_restJson1_1DescribeAccessPointsCommand(
   let resolvedPath = "/2015-02-01/access-points";
   const query: any = {};
   if (input.AccessPointId !== undefined) {
-    query["AccessPointId"] = input.AccessPointId.toString();
+    query[
+      __extendedEncodeURIComponent("AccessPointId")
+    ] = __extendedEncodeURIComponent(input.AccessPointId);
   }
   if (input.FileSystemId !== undefined) {
-    query["FileSystemId"] = input.FileSystemId.toString();
+    query[
+      __extendedEncodeURIComponent("FileSystemId")
+    ] = __extendedEncodeURIComponent(input.FileSystemId);
   }
   if (input.MaxResults !== undefined) {
-    query["MaxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("MaxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["NextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("NextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -499,7 +510,7 @@ export async function serializeAws_restJson1_1DescribeFileSystemPolicyCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/2015-02-01/file-systems/{FileSystemId}/policy";
   if (input.FileSystemId !== undefined) {
-    const labelValue: string = input.FileSystemId.toString();
+    const labelValue: string = input.FileSystemId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: FileSystemId."
@@ -507,7 +518,7 @@ export async function serializeAws_restJson1_1DescribeFileSystemPolicyCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{FileSystemId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: FileSystemId.");
@@ -530,16 +541,24 @@ export async function serializeAws_restJson1_1DescribeFileSystemsCommand(
   let resolvedPath = "/2015-02-01/file-systems";
   const query: any = {};
   if (input.CreationToken !== undefined) {
-    query["CreationToken"] = input.CreationToken.toString();
+    query[
+      __extendedEncodeURIComponent("CreationToken")
+    ] = __extendedEncodeURIComponent(input.CreationToken);
   }
   if (input.FileSystemId !== undefined) {
-    query["FileSystemId"] = input.FileSystemId.toString();
+    query[
+      __extendedEncodeURIComponent("FileSystemId")
+    ] = __extendedEncodeURIComponent(input.FileSystemId);
   }
   if (input.Marker !== undefined) {
-    query["Marker"] = input.Marker.toString();
+    query[
+      __extendedEncodeURIComponent("Marker")
+    ] = __extendedEncodeURIComponent(input.Marker);
   }
   if (input.MaxItems !== undefined) {
-    query["MaxItems"] = input.MaxItems.toString();
+    query[
+      __extendedEncodeURIComponent("MaxItems")
+    ] = __extendedEncodeURIComponent(input.MaxItems.toString());
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -560,7 +579,7 @@ export async function serializeAws_restJson1_1DescribeLifecycleConfigurationComm
   let resolvedPath =
     "/2015-02-01/file-systems/{FileSystemId}/lifecycle-configuration";
   if (input.FileSystemId !== undefined) {
-    const labelValue: string = input.FileSystemId.toString();
+    const labelValue: string = input.FileSystemId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: FileSystemId."
@@ -568,7 +587,7 @@ export async function serializeAws_restJson1_1DescribeLifecycleConfigurationComm
     }
     resolvedPath = resolvedPath.replace(
       "{FileSystemId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: FileSystemId.");
@@ -591,7 +610,7 @@ export async function serializeAws_restJson1_1DescribeMountTargetSecurityGroupsC
   let resolvedPath =
     "/2015-02-01/mount-targets/{MountTargetId}/security-groups";
   if (input.MountTargetId !== undefined) {
-    const labelValue: string = input.MountTargetId.toString();
+    const labelValue: string = input.MountTargetId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: MountTargetId."
@@ -599,7 +618,7 @@ export async function serializeAws_restJson1_1DescribeMountTargetSecurityGroupsC
     }
     resolvedPath = resolvedPath.replace(
       "{MountTargetId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: MountTargetId.");
@@ -622,19 +641,29 @@ export async function serializeAws_restJson1_1DescribeMountTargetsCommand(
   let resolvedPath = "/2015-02-01/mount-targets";
   const query: any = {};
   if (input.AccessPointId !== undefined) {
-    query["AccessPointId"] = input.AccessPointId.toString();
+    query[
+      __extendedEncodeURIComponent("AccessPointId")
+    ] = __extendedEncodeURIComponent(input.AccessPointId);
   }
   if (input.FileSystemId !== undefined) {
-    query["FileSystemId"] = input.FileSystemId.toString();
+    query[
+      __extendedEncodeURIComponent("FileSystemId")
+    ] = __extendedEncodeURIComponent(input.FileSystemId);
   }
   if (input.Marker !== undefined) {
-    query["Marker"] = input.Marker.toString();
+    query[
+      __extendedEncodeURIComponent("Marker")
+    ] = __extendedEncodeURIComponent(input.Marker);
   }
   if (input.MaxItems !== undefined) {
-    query["MaxItems"] = input.MaxItems.toString();
+    query[
+      __extendedEncodeURIComponent("MaxItems")
+    ] = __extendedEncodeURIComponent(input.MaxItems.toString());
   }
   if (input.MountTargetId !== undefined) {
-    query["MountTargetId"] = input.MountTargetId.toString();
+    query[
+      __extendedEncodeURIComponent("MountTargetId")
+    ] = __extendedEncodeURIComponent(input.MountTargetId);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -654,7 +683,7 @@ export async function serializeAws_restJson1_1DescribeTagsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/2015-02-01/tags/{FileSystemId}";
   if (input.FileSystemId !== undefined) {
-    const labelValue: string = input.FileSystemId.toString();
+    const labelValue: string = input.FileSystemId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: FileSystemId."
@@ -662,17 +691,21 @@ export async function serializeAws_restJson1_1DescribeTagsCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{FileSystemId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: FileSystemId.");
   }
   const query: any = {};
   if (input.Marker !== undefined) {
-    query["Marker"] = input.Marker.toString();
+    query[
+      __extendedEncodeURIComponent("Marker")
+    ] = __extendedEncodeURIComponent(input.Marker);
   }
   if (input.MaxItems !== undefined) {
-    query["MaxItems"] = input.MaxItems.toString();
+    query[
+      __extendedEncodeURIComponent("MaxItems")
+    ] = __extendedEncodeURIComponent(input.MaxItems.toString());
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -692,23 +725,27 @@ export async function serializeAws_restJson1_1ListTagsForResourceCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/2015-02-01/resource-tags/{ResourceId}";
   if (input.ResourceId !== undefined) {
-    const labelValue: string = input.ResourceId.toString();
+    const labelValue: string = input.ResourceId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ResourceId.");
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ResourceId.");
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["MaxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("MaxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["NextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("NextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -729,7 +766,7 @@ export async function serializeAws_restJson1_1ModifyMountTargetSecurityGroupsCom
   let resolvedPath =
     "/2015-02-01/mount-targets/{MountTargetId}/security-groups";
   if (input.MountTargetId !== undefined) {
-    const labelValue: string = input.MountTargetId.toString();
+    const labelValue: string = input.MountTargetId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: MountTargetId."
@@ -737,7 +774,7 @@ export async function serializeAws_restJson1_1ModifyMountTargetSecurityGroupsCom
     }
     resolvedPath = resolvedPath.replace(
       "{MountTargetId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: MountTargetId.");
@@ -769,7 +806,7 @@ export async function serializeAws_restJson1_1PutFileSystemPolicyCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/2015-02-01/file-systems/{FileSystemId}/policy";
   if (input.FileSystemId !== undefined) {
-    const labelValue: string = input.FileSystemId.toString();
+    const labelValue: string = input.FileSystemId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: FileSystemId."
@@ -777,7 +814,7 @@ export async function serializeAws_restJson1_1PutFileSystemPolicyCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{FileSystemId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: FileSystemId.");
@@ -811,7 +848,7 @@ export async function serializeAws_restJson1_1PutLifecycleConfigurationCommand(
   let resolvedPath =
     "/2015-02-01/file-systems/{FileSystemId}/lifecycle-configuration";
   if (input.FileSystemId !== undefined) {
-    const labelValue: string = input.FileSystemId.toString();
+    const labelValue: string = input.FileSystemId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: FileSystemId."
@@ -819,7 +856,7 @@ export async function serializeAws_restJson1_1PutLifecycleConfigurationCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{FileSystemId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: FileSystemId.");
@@ -851,13 +888,13 @@ export async function serializeAws_restJson1_1TagResourceCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/2015-02-01/resource-tags/{ResourceId}";
   if (input.ResourceId !== undefined) {
-    const labelValue: string = input.ResourceId.toString();
+    const labelValue: string = input.ResourceId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ResourceId.");
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ResourceId.");
@@ -886,13 +923,13 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/2015-02-01/resource-tags/{ResourceId}";
   if (input.ResourceId !== undefined) {
-    const labelValue: string = input.ResourceId.toString();
+    const labelValue: string = input.ResourceId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ResourceId.");
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ResourceId.");
@@ -924,7 +961,7 @@ export async function serializeAws_restJson1_1UpdateFileSystemCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/2015-02-01/file-systems/{FileSystemId}";
   if (input.FileSystemId !== undefined) {
-    const labelValue: string = input.FileSystemId.toString();
+    const labelValue: string = input.FileSystemId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: FileSystemId."
@@ -932,7 +969,7 @@ export async function serializeAws_restJson1_1UpdateFileSystemCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{FileSystemId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: FileSystemId.");
@@ -1419,6 +1456,7 @@ export async function deserializeAws_restJson1_1CreateTagsCommand(
   const contents: CreateTagsCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -1483,6 +1521,7 @@ export async function deserializeAws_restJson1_1DeleteAccessPointCommand(
   const contents: DeleteAccessPointCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -1547,6 +1586,7 @@ export async function deserializeAws_restJson1_1DeleteFileSystemCommand(
   const contents: DeleteFileSystemCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -1618,6 +1658,7 @@ export async function deserializeAws_restJson1_1DeleteFileSystemPolicyCommand(
   const contents: DeleteFileSystemPolicyCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -1682,6 +1723,7 @@ export async function deserializeAws_restJson1_1DeleteMountTargetCommand(
   const contents: DeleteMountTargetCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -1750,6 +1792,7 @@ export async function deserializeAws_restJson1_1DeleteTagsCommand(
   const contents: DeleteTagsCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2457,6 +2500,7 @@ export async function deserializeAws_restJson1_1ModifyMountTargetSecurityGroupsC
   const contents: ModifyMountTargetSecurityGroupsCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2700,6 +2744,7 @@ export async function deserializeAws_restJson1_1TagResourceCommand(
   const contents: TagResourceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2768,6 +2813,7 @@ export async function deserializeAws_restJson1_1UntagResourceCommand(
   const contents: UntagResourceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 

--- a/clients/client-eks/models/index.ts
+++ b/clients/client-eks/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export type AMITypes = "AL2_x86_64" | "AL2_x86_64_GPU";
@@ -16,7 +19,7 @@ export interface AutoScalingGroup {
 
 export namespace AutoScalingGroup {
   export function isa(o: any): o is AutoScalingGroup {
-    return _smithy.isa(o, "AutoScalingGroup");
+    return __isa(o, "AutoScalingGroup");
   }
 }
 
@@ -25,7 +28,7 @@ export namespace AutoScalingGroup {
  *             will depend on the API, and will be documented in the error message.</p>
  */
 export interface BadRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "BadRequestException";
   $fault: "client";
@@ -34,7 +37,7 @@ export interface BadRequestException
 
 export namespace BadRequestException {
   export function isa(o: any): o is BadRequestException {
-    return _smithy.isa(o, "BadRequestException");
+    return __isa(o, "BadRequestException");
   }
 }
 
@@ -54,7 +57,7 @@ export interface Certificate {
 
 export namespace Certificate {
   export function isa(o: any): o is Certificate {
-    return _smithy.isa(o, "Certificate");
+    return __isa(o, "Certificate");
   }
 }
 
@@ -63,9 +66,7 @@ export namespace Certificate {
  *             action or resource on behalf of a user that doesn't have permissions to use the action
  *             or resource or specifying an identifier that is not valid.</p>
  */
-export interface ClientException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface ClientException extends __SmithyException, $MetadataBearer {
   name: "ClientException";
   $fault: "client";
   /**
@@ -82,7 +83,7 @@ export interface ClientException
 
 export namespace ClientException {
   export function isa(o: any): o is ClientException {
-    return _smithy.isa(o, "ClientException");
+    return __isa(o, "ClientException");
   }
 }
 
@@ -175,7 +176,7 @@ export interface Cluster {
 
 export namespace Cluster {
   export function isa(o: any): o is Cluster {
-    return _smithy.isa(o, "Cluster");
+    return __isa(o, "Cluster");
   }
 }
 
@@ -247,7 +248,7 @@ export interface CreateClusterRequest {
 
 export namespace CreateClusterRequest {
   export function isa(o: any): o is CreateClusterRequest {
-    return _smithy.isa(o, "CreateClusterRequest");
+    return __isa(o, "CreateClusterRequest");
   }
 }
 
@@ -261,7 +262,7 @@ export interface CreateClusterResponse extends $MetadataBearer {
 
 export namespace CreateClusterResponse {
   export function isa(o: any): o is CreateClusterResponse {
-    return _smithy.isa(o, "CreateClusterResponse");
+    return __isa(o, "CreateClusterResponse");
   }
 }
 
@@ -317,7 +318,7 @@ export interface CreateFargateProfileRequest {
 
 export namespace CreateFargateProfileRequest {
   export function isa(o: any): o is CreateFargateProfileRequest {
-    return _smithy.isa(o, "CreateFargateProfileRequest");
+    return __isa(o, "CreateFargateProfileRequest");
   }
 }
 
@@ -331,7 +332,7 @@ export interface CreateFargateProfileResponse extends $MetadataBearer {
 
 export namespace CreateFargateProfileResponse {
   export function isa(o: any): o is CreateFargateProfileResponse {
-    return _smithy.isa(o, "CreateFargateProfileResponse");
+    return __isa(o, "CreateFargateProfileResponse");
   }
 }
 
@@ -437,7 +438,7 @@ export interface CreateNodegroupRequest {
 
 export namespace CreateNodegroupRequest {
   export function isa(o: any): o is CreateNodegroupRequest {
-    return _smithy.isa(o, "CreateNodegroupRequest");
+    return __isa(o, "CreateNodegroupRequest");
   }
 }
 
@@ -451,7 +452,7 @@ export interface CreateNodegroupResponse extends $MetadataBearer {
 
 export namespace CreateNodegroupResponse {
   export function isa(o: any): o is CreateNodegroupResponse {
-    return _smithy.isa(o, "CreateNodegroupResponse");
+    return __isa(o, "CreateNodegroupResponse");
   }
 }
 
@@ -465,7 +466,7 @@ export interface DeleteClusterRequest {
 
 export namespace DeleteClusterRequest {
   export function isa(o: any): o is DeleteClusterRequest {
-    return _smithy.isa(o, "DeleteClusterRequest");
+    return __isa(o, "DeleteClusterRequest");
   }
 }
 
@@ -479,7 +480,7 @@ export interface DeleteClusterResponse extends $MetadataBearer {
 
 export namespace DeleteClusterResponse {
   export function isa(o: any): o is DeleteClusterResponse {
-    return _smithy.isa(o, "DeleteClusterResponse");
+    return __isa(o, "DeleteClusterResponse");
   }
 }
 
@@ -498,7 +499,7 @@ export interface DeleteFargateProfileRequest {
 
 export namespace DeleteFargateProfileRequest {
   export function isa(o: any): o is DeleteFargateProfileRequest {
-    return _smithy.isa(o, "DeleteFargateProfileRequest");
+    return __isa(o, "DeleteFargateProfileRequest");
   }
 }
 
@@ -512,7 +513,7 @@ export interface DeleteFargateProfileResponse extends $MetadataBearer {
 
 export namespace DeleteFargateProfileResponse {
   export function isa(o: any): o is DeleteFargateProfileResponse {
-    return _smithy.isa(o, "DeleteFargateProfileResponse");
+    return __isa(o, "DeleteFargateProfileResponse");
   }
 }
 
@@ -531,7 +532,7 @@ export interface DeleteNodegroupRequest {
 
 export namespace DeleteNodegroupRequest {
   export function isa(o: any): o is DeleteNodegroupRequest {
-    return _smithy.isa(o, "DeleteNodegroupRequest");
+    return __isa(o, "DeleteNodegroupRequest");
   }
 }
 
@@ -545,7 +546,7 @@ export interface DeleteNodegroupResponse extends $MetadataBearer {
 
 export namespace DeleteNodegroupResponse {
   export function isa(o: any): o is DeleteNodegroupResponse {
-    return _smithy.isa(o, "DeleteNodegroupResponse");
+    return __isa(o, "DeleteNodegroupResponse");
   }
 }
 
@@ -559,7 +560,7 @@ export interface DescribeClusterRequest {
 
 export namespace DescribeClusterRequest {
   export function isa(o: any): o is DescribeClusterRequest {
-    return _smithy.isa(o, "DescribeClusterRequest");
+    return __isa(o, "DescribeClusterRequest");
   }
 }
 
@@ -573,7 +574,7 @@ export interface DescribeClusterResponse extends $MetadataBearer {
 
 export namespace DescribeClusterResponse {
   export function isa(o: any): o is DescribeClusterResponse {
-    return _smithy.isa(o, "DescribeClusterResponse");
+    return __isa(o, "DescribeClusterResponse");
   }
 }
 
@@ -592,7 +593,7 @@ export interface DescribeFargateProfileRequest {
 
 export namespace DescribeFargateProfileRequest {
   export function isa(o: any): o is DescribeFargateProfileRequest {
-    return _smithy.isa(o, "DescribeFargateProfileRequest");
+    return __isa(o, "DescribeFargateProfileRequest");
   }
 }
 
@@ -606,7 +607,7 @@ export interface DescribeFargateProfileResponse extends $MetadataBearer {
 
 export namespace DescribeFargateProfileResponse {
   export function isa(o: any): o is DescribeFargateProfileResponse {
-    return _smithy.isa(o, "DescribeFargateProfileResponse");
+    return __isa(o, "DescribeFargateProfileResponse");
   }
 }
 
@@ -625,7 +626,7 @@ export interface DescribeNodegroupRequest {
 
 export namespace DescribeNodegroupRequest {
   export function isa(o: any): o is DescribeNodegroupRequest {
-    return _smithy.isa(o, "DescribeNodegroupRequest");
+    return __isa(o, "DescribeNodegroupRequest");
   }
 }
 
@@ -639,7 +640,7 @@ export interface DescribeNodegroupResponse extends $MetadataBearer {
 
 export namespace DescribeNodegroupResponse {
   export function isa(o: any): o is DescribeNodegroupResponse {
-    return _smithy.isa(o, "DescribeNodegroupResponse");
+    return __isa(o, "DescribeNodegroupResponse");
   }
 }
 
@@ -663,7 +664,7 @@ export interface DescribeUpdateRequest {
 
 export namespace DescribeUpdateRequest {
   export function isa(o: any): o is DescribeUpdateRequest {
-    return _smithy.isa(o, "DescribeUpdateRequest");
+    return __isa(o, "DescribeUpdateRequest");
   }
 }
 
@@ -677,7 +678,7 @@ export interface DescribeUpdateResponse extends $MetadataBearer {
 
 export namespace DescribeUpdateResponse {
   export function isa(o: any): o is DescribeUpdateResponse {
-    return _smithy.isa(o, "DescribeUpdateResponse");
+    return __isa(o, "DescribeUpdateResponse");
   }
 }
 
@@ -756,7 +757,7 @@ export interface ErrorDetail {
 
 export namespace ErrorDetail {
   export function isa(o: any): o is ErrorDetail {
-    return _smithy.isa(o, "ErrorDetail");
+    return __isa(o, "ErrorDetail");
   }
 }
 
@@ -818,7 +819,7 @@ export interface FargateProfile {
 
 export namespace FargateProfile {
   export function isa(o: any): o is FargateProfile {
-    return _smithy.isa(o, "FargateProfile");
+    return __isa(o, "FargateProfile");
   }
 }
 
@@ -841,7 +842,7 @@ export interface FargateProfileSelector {
 
 export namespace FargateProfileSelector {
   export function isa(o: any): o is FargateProfileSelector {
-    return _smithy.isa(o, "FargateProfileSelector");
+    return __isa(o, "FargateProfileSelector");
   }
 }
 
@@ -866,7 +867,7 @@ export interface Identity {
 
 export namespace Identity {
   export function isa(o: any): o is Identity {
-    return _smithy.isa(o, "Identity");
+    return __isa(o, "Identity");
   }
 }
 
@@ -875,7 +876,7 @@ export namespace Identity {
  *             request.</p>
  */
 export interface InvalidParameterException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidParameterException";
   $fault: "client";
@@ -898,7 +899,7 @@ export interface InvalidParameterException
 
 export namespace InvalidParameterException {
   export function isa(o: any): o is InvalidParameterException {
-    return _smithy.isa(o, "InvalidParameterException");
+    return __isa(o, "InvalidParameterException");
   }
 }
 
@@ -907,7 +908,7 @@ export namespace InvalidParameterException {
  *             and the associated operations.</p>
  */
 export interface InvalidRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidRequestException";
   $fault: "client";
@@ -925,7 +926,7 @@ export interface InvalidRequestException
 
 export namespace InvalidRequestException {
   export function isa(o: any): o is InvalidRequestException {
-    return _smithy.isa(o, "InvalidRequestException");
+    return __isa(o, "InvalidRequestException");
   }
 }
 
@@ -1032,7 +1033,7 @@ export interface Issue {
 
 export namespace Issue {
   export function isa(o: any): o is Issue {
-    return _smithy.isa(o, "Issue");
+    return __isa(o, "Issue");
   }
 }
 
@@ -1065,7 +1066,7 @@ export interface ListClustersRequest {
 
 export namespace ListClustersRequest {
   export function isa(o: any): o is ListClustersRequest {
-    return _smithy.isa(o, "ListClustersRequest");
+    return __isa(o, "ListClustersRequest");
   }
 }
 
@@ -1088,7 +1089,7 @@ export interface ListClustersResponse extends $MetadataBearer {
 
 export namespace ListClustersResponse {
   export function isa(o: any): o is ListClustersResponse {
-    return _smithy.isa(o, "ListClustersResponse");
+    return __isa(o, "ListClustersResponse");
   }
 }
 
@@ -1123,7 +1124,7 @@ export interface ListFargateProfilesRequest {
 
 export namespace ListFargateProfilesRequest {
   export function isa(o: any): o is ListFargateProfilesRequest {
-    return _smithy.isa(o, "ListFargateProfilesRequest");
+    return __isa(o, "ListFargateProfilesRequest");
   }
 }
 
@@ -1146,7 +1147,7 @@ export interface ListFargateProfilesResponse extends $MetadataBearer {
 
 export namespace ListFargateProfilesResponse {
   export function isa(o: any): o is ListFargateProfilesResponse {
-    return _smithy.isa(o, "ListFargateProfilesResponse");
+    return __isa(o, "ListFargateProfilesResponse");
   }
 }
 
@@ -1180,7 +1181,7 @@ export interface ListNodegroupsRequest {
 
 export namespace ListNodegroupsRequest {
   export function isa(o: any): o is ListNodegroupsRequest {
-    return _smithy.isa(o, "ListNodegroupsRequest");
+    return __isa(o, "ListNodegroupsRequest");
   }
 }
 
@@ -1203,7 +1204,7 @@ export interface ListNodegroupsResponse extends $MetadataBearer {
 
 export namespace ListNodegroupsResponse {
   export function isa(o: any): o is ListNodegroupsResponse {
-    return _smithy.isa(o, "ListNodegroupsResponse");
+    return __isa(o, "ListNodegroupsResponse");
   }
 }
 
@@ -1218,7 +1219,7 @@ export interface ListTagsForResourceRequest {
 
 export namespace ListTagsForResourceRequest {
   export function isa(o: any): o is ListTagsForResourceRequest {
-    return _smithy.isa(o, "ListTagsForResourceRequest");
+    return __isa(o, "ListTagsForResourceRequest");
   }
 }
 
@@ -1232,7 +1233,7 @@ export interface ListTagsForResourceResponse extends $MetadataBearer {
 
 export namespace ListTagsForResourceResponse {
   export function isa(o: any): o is ListTagsForResourceResponse {
-    return _smithy.isa(o, "ListTagsForResourceResponse");
+    return __isa(o, "ListTagsForResourceResponse");
   }
 }
 
@@ -1271,7 +1272,7 @@ export interface ListUpdatesRequest {
 
 export namespace ListUpdatesRequest {
   export function isa(o: any): o is ListUpdatesRequest {
-    return _smithy.isa(o, "ListUpdatesRequest");
+    return __isa(o, "ListUpdatesRequest");
   }
 }
 
@@ -1294,7 +1295,7 @@ export interface ListUpdatesResponse extends $MetadataBearer {
 
 export namespace ListUpdatesResponse {
   export function isa(o: any): o is ListUpdatesResponse {
-    return _smithy.isa(o, "ListUpdatesResponse");
+    return __isa(o, "ListUpdatesResponse");
   }
 }
 
@@ -1319,7 +1320,7 @@ export interface LogSetup {
 
 export namespace LogSetup {
   export function isa(o: any): o is LogSetup {
-    return _smithy.isa(o, "LogSetup");
+    return __isa(o, "LogSetup");
   }
 }
 
@@ -1344,7 +1345,7 @@ export interface Logging {
 
 export namespace Logging {
   export function isa(o: any): o is Logging {
-    return _smithy.isa(o, "Logging");
+    return __isa(o, "Logging");
   }
 }
 
@@ -1478,7 +1479,7 @@ export interface Nodegroup {
 
 export namespace Nodegroup {
   export function isa(o: any): o is Nodegroup {
-    return _smithy.isa(o, "Nodegroup");
+    return __isa(o, "Nodegroup");
   }
 }
 
@@ -1495,7 +1496,7 @@ export interface NodegroupHealth {
 
 export namespace NodegroupHealth {
   export function isa(o: any): o is NodegroupHealth {
-    return _smithy.isa(o, "NodegroupHealth");
+    return __isa(o, "NodegroupHealth");
   }
 }
 
@@ -1534,7 +1535,7 @@ export interface NodegroupResources {
 
 export namespace NodegroupResources {
   export function isa(o: any): o is NodegroupResources {
-    return _smithy.isa(o, "NodegroupResources");
+    return __isa(o, "NodegroupResources");
   }
 }
 
@@ -1564,7 +1565,7 @@ export interface NodegroupScalingConfig {
 
 export namespace NodegroupScalingConfig {
   export function isa(o: any): o is NodegroupScalingConfig {
-    return _smithy.isa(o, "NodegroupScalingConfig");
+    return __isa(o, "NodegroupScalingConfig");
   }
 }
 
@@ -1581,9 +1582,7 @@ export type NodegroupStatus =
  * <p>A service resource associated with the request could not be found. Clients should not
  *             retry such requests.</p>
  */
-export interface NotFoundException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface NotFoundException extends __SmithyException, $MetadataBearer {
   name: "NotFoundException";
   $fault: "client";
   message?: string;
@@ -1591,7 +1590,7 @@ export interface NotFoundException
 
 export namespace NotFoundException {
   export function isa(o: any): o is NotFoundException {
-    return _smithy.isa(o, "NotFoundException");
+    return __isa(o, "NotFoundException");
   }
 }
 
@@ -1609,7 +1608,7 @@ export interface OIDC {
 
 export namespace OIDC {
   export function isa(o: any): o is OIDC {
-    return _smithy.isa(o, "OIDC");
+    return __isa(o, "OIDC");
   }
 }
 
@@ -1638,7 +1637,7 @@ export interface RemoteAccessConfig {
 
 export namespace RemoteAccessConfig {
   export function isa(o: any): o is RemoteAccessConfig {
-    return _smithy.isa(o, "RemoteAccessConfig");
+    return __isa(o, "RemoteAccessConfig");
   }
 }
 
@@ -1646,7 +1645,7 @@ export namespace RemoteAccessConfig {
  * <p>The specified resource is in use.</p>
  */
 export interface ResourceInUseException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceInUseException";
   $fault: "client";
@@ -1664,7 +1663,7 @@ export interface ResourceInUseException
 
 export namespace ResourceInUseException {
   export function isa(o: any): o is ResourceInUseException {
-    return _smithy.isa(o, "ResourceInUseException");
+    return __isa(o, "ResourceInUseException");
   }
 }
 
@@ -1672,7 +1671,7 @@ export namespace ResourceInUseException {
  * <p>You have encountered a service limit on the specified resource.</p>
  */
 export interface ResourceLimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceLimitExceededException";
   $fault: "client";
@@ -1690,7 +1689,7 @@ export interface ResourceLimitExceededException
 
 export namespace ResourceLimitExceededException {
   export function isa(o: any): o is ResourceLimitExceededException {
-    return _smithy.isa(o, "ResourceLimitExceededException");
+    return __isa(o, "ResourceLimitExceededException");
   }
 }
 
@@ -1701,7 +1700,7 @@ export namespace ResourceLimitExceededException {
  *             Region-specific.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -1724,16 +1723,14 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
 /**
  * <p>These errors are usually caused by a server-side issue.</p>
  */
-export interface ServerException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface ServerException extends __SmithyException, $MetadataBearer {
   name: "ServerException";
   $fault: "server";
   /**
@@ -1750,7 +1747,7 @@ export interface ServerException
 
 export namespace ServerException {
   export function isa(o: any): o is ServerException {
-    return _smithy.isa(o, "ServerException");
+    return __isa(o, "ServerException");
   }
 }
 
@@ -1758,7 +1755,7 @@ export namespace ServerException {
  * <p>The service is unavailable. Back off and retry the operation.</p>
  */
 export interface ServiceUnavailableException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ServiceUnavailableException";
   $fault: "server";
@@ -1767,7 +1764,7 @@ export interface ServiceUnavailableException
 
 export namespace ServiceUnavailableException {
   export function isa(o: any): o is ServiceUnavailableException {
-    return _smithy.isa(o, "ServiceUnavailableException");
+    return __isa(o, "ServiceUnavailableException");
   }
 }
 
@@ -1787,7 +1784,7 @@ export interface TagResourceRequest {
 
 export namespace TagResourceRequest {
   export function isa(o: any): o is TagResourceRequest {
-    return _smithy.isa(o, "TagResourceRequest");
+    return __isa(o, "TagResourceRequest");
   }
 }
 
@@ -1797,7 +1794,7 @@ export interface TagResourceResponse extends $MetadataBearer {
 
 export namespace TagResourceResponse {
   export function isa(o: any): o is TagResourceResponse {
-    return _smithy.isa(o, "TagResourceResponse");
+    return __isa(o, "TagResourceResponse");
   }
 }
 
@@ -1807,7 +1804,7 @@ export namespace TagResourceResponse {
  *             your account, from which you can choose subnets for your cluster.</p>
  */
 export interface UnsupportedAvailabilityZoneException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UnsupportedAvailabilityZoneException";
   $fault: "client";
@@ -1831,7 +1828,7 @@ export interface UnsupportedAvailabilityZoneException
 
 export namespace UnsupportedAvailabilityZoneException {
   export function isa(o: any): o is UnsupportedAvailabilityZoneException {
-    return _smithy.isa(o, "UnsupportedAvailabilityZoneException");
+    return __isa(o, "UnsupportedAvailabilityZoneException");
   }
 }
 
@@ -1851,7 +1848,7 @@ export interface UntagResourceRequest {
 
 export namespace UntagResourceRequest {
   export function isa(o: any): o is UntagResourceRequest {
-    return _smithy.isa(o, "UntagResourceRequest");
+    return __isa(o, "UntagResourceRequest");
   }
 }
 
@@ -1861,7 +1858,7 @@ export interface UntagResourceResponse extends $MetadataBearer {
 
 export namespace UntagResourceResponse {
   export function isa(o: any): o is UntagResourceResponse {
-    return _smithy.isa(o, "UntagResourceResponse");
+    return __isa(o, "UntagResourceResponse");
   }
 }
 
@@ -1903,7 +1900,7 @@ export interface Update {
 
 export namespace Update {
   export function isa(o: any): o is Update {
-    return _smithy.isa(o, "Update");
+    return __isa(o, "Update");
   }
 }
 
@@ -1942,7 +1939,7 @@ export interface UpdateClusterConfigRequest {
 
 export namespace UpdateClusterConfigRequest {
   export function isa(o: any): o is UpdateClusterConfigRequest {
-    return _smithy.isa(o, "UpdateClusterConfigRequest");
+    return __isa(o, "UpdateClusterConfigRequest");
   }
 }
 
@@ -1956,7 +1953,7 @@ export interface UpdateClusterConfigResponse extends $MetadataBearer {
 
 export namespace UpdateClusterConfigResponse {
   export function isa(o: any): o is UpdateClusterConfigResponse {
-    return _smithy.isa(o, "UpdateClusterConfigResponse");
+    return __isa(o, "UpdateClusterConfigResponse");
   }
 }
 
@@ -1981,7 +1978,7 @@ export interface UpdateClusterVersionRequest {
 
 export namespace UpdateClusterVersionRequest {
   export function isa(o: any): o is UpdateClusterVersionRequest {
-    return _smithy.isa(o, "UpdateClusterVersionRequest");
+    return __isa(o, "UpdateClusterVersionRequest");
   }
 }
 
@@ -1995,7 +1992,7 @@ export interface UpdateClusterVersionResponse extends $MetadataBearer {
 
 export namespace UpdateClusterVersionResponse {
   export function isa(o: any): o is UpdateClusterVersionResponse {
-    return _smithy.isa(o, "UpdateClusterVersionResponse");
+    return __isa(o, "UpdateClusterVersionResponse");
   }
 }
 
@@ -2017,7 +2014,7 @@ export interface UpdateLabelsPayload {
 
 export namespace UpdateLabelsPayload {
   export function isa(o: any): o is UpdateLabelsPayload {
-    return _smithy.isa(o, "UpdateLabelsPayload");
+    return __isa(o, "UpdateLabelsPayload");
   }
 }
 
@@ -2053,7 +2050,7 @@ export interface UpdateNodegroupConfigRequest {
 
 export namespace UpdateNodegroupConfigRequest {
   export function isa(o: any): o is UpdateNodegroupConfigRequest {
-    return _smithy.isa(o, "UpdateNodegroupConfigRequest");
+    return __isa(o, "UpdateNodegroupConfigRequest");
   }
 }
 
@@ -2067,7 +2064,7 @@ export interface UpdateNodegroupConfigResponse extends $MetadataBearer {
 
 export namespace UpdateNodegroupConfigResponse {
   export function isa(o: any): o is UpdateNodegroupConfigResponse {
-    return _smithy.isa(o, "UpdateNodegroupConfigResponse");
+    return __isa(o, "UpdateNodegroupConfigResponse");
   }
 }
 
@@ -2117,7 +2114,7 @@ export interface UpdateNodegroupVersionRequest {
 
 export namespace UpdateNodegroupVersionRequest {
   export function isa(o: any): o is UpdateNodegroupVersionRequest {
-    return _smithy.isa(o, "UpdateNodegroupVersionRequest");
+    return __isa(o, "UpdateNodegroupVersionRequest");
   }
 }
 
@@ -2131,7 +2128,7 @@ export interface UpdateNodegroupVersionResponse extends $MetadataBearer {
 
 export namespace UpdateNodegroupVersionResponse {
   export function isa(o: any): o is UpdateNodegroupVersionResponse {
-    return _smithy.isa(o, "UpdateNodegroupVersionResponse");
+    return __isa(o, "UpdateNodegroupVersionResponse");
   }
 }
 
@@ -2153,7 +2150,7 @@ export interface UpdateParam {
 
 export namespace UpdateParam {
   export function isa(o: any): o is UpdateParam {
-    return _smithy.isa(o, "UpdateParam");
+    return __isa(o, "UpdateParam");
   }
 }
 
@@ -2249,7 +2246,7 @@ export interface VpcConfigRequest {
 
 export namespace VpcConfigRequest {
   export function isa(o: any): o is VpcConfigRequest {
-    return _smithy.isa(o, "VpcConfigRequest");
+    return __isa(o, "VpcConfigRequest");
   }
 }
 
@@ -2318,6 +2315,6 @@ export interface VpcConfigResponse {
 
 export namespace VpcConfigResponse {
   export function isa(o: any): o is VpcConfigResponse {
-    return _smithy.isa(o, "VpcConfigResponse");
+    return __isa(o, "VpcConfigResponse");
   }
 }

--- a/clients/client-eks/protocols/Aws_restJson1_1.ts
+++ b/clients/client-eks/protocols/Aws_restJson1_1.ts
@@ -121,7 +121,10 @@ import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  extendedEncodeURIComponent as __extendedEncodeURIComponent
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -188,7 +191,7 @@ export async function serializeAws_restJson1_1CreateFargateProfileCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/clusters/{clusterName}/fargate-profiles";
   if (input.clusterName !== undefined) {
-    const labelValue: string = input.clusterName.toString();
+    const labelValue: string = input.clusterName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: clusterName."
@@ -196,7 +199,7 @@ export async function serializeAws_restJson1_1CreateFargateProfileCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{clusterName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: clusterName.");
@@ -249,7 +252,7 @@ export async function serializeAws_restJson1_1CreateNodegroupCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/clusters/{clusterName}/node-groups";
   if (input.clusterName !== undefined) {
-    const labelValue: string = input.clusterName.toString();
+    const labelValue: string = input.clusterName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: clusterName."
@@ -257,7 +260,7 @@ export async function serializeAws_restJson1_1CreateNodegroupCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{clusterName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: clusterName.");
@@ -342,13 +345,13 @@ export async function serializeAws_restJson1_1DeleteClusterCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/clusters/{name}";
   if (input.name !== undefined) {
-    const labelValue: string = input.name.toString();
+    const labelValue: string = input.name;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: name.");
     }
     resolvedPath = resolvedPath.replace(
       "{name}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: name.");
@@ -371,7 +374,7 @@ export async function serializeAws_restJson1_1DeleteFargateProfileCommand(
   let resolvedPath =
     "/clusters/{clusterName}/fargate-profiles/{fargateProfileName}";
   if (input.clusterName !== undefined) {
-    const labelValue: string = input.clusterName.toString();
+    const labelValue: string = input.clusterName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: clusterName."
@@ -379,13 +382,13 @@ export async function serializeAws_restJson1_1DeleteFargateProfileCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{clusterName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: clusterName.");
   }
   if (input.fargateProfileName !== undefined) {
-    const labelValue: string = input.fargateProfileName.toString();
+    const labelValue: string = input.fargateProfileName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: fargateProfileName."
@@ -393,7 +396,7 @@ export async function serializeAws_restJson1_1DeleteFargateProfileCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{fargateProfileName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -417,7 +420,7 @@ export async function serializeAws_restJson1_1DeleteNodegroupCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/clusters/{clusterName}/node-groups/{nodegroupName}";
   if (input.clusterName !== undefined) {
-    const labelValue: string = input.clusterName.toString();
+    const labelValue: string = input.clusterName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: clusterName."
@@ -425,13 +428,13 @@ export async function serializeAws_restJson1_1DeleteNodegroupCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{clusterName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: clusterName.");
   }
   if (input.nodegroupName !== undefined) {
-    const labelValue: string = input.nodegroupName.toString();
+    const labelValue: string = input.nodegroupName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: nodegroupName."
@@ -439,7 +442,7 @@ export async function serializeAws_restJson1_1DeleteNodegroupCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{nodegroupName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: nodegroupName.");
@@ -461,13 +464,13 @@ export async function serializeAws_restJson1_1DescribeClusterCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/clusters/{name}";
   if (input.name !== undefined) {
-    const labelValue: string = input.name.toString();
+    const labelValue: string = input.name;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: name.");
     }
     resolvedPath = resolvedPath.replace(
       "{name}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: name.");
@@ -490,7 +493,7 @@ export async function serializeAws_restJson1_1DescribeFargateProfileCommand(
   let resolvedPath =
     "/clusters/{clusterName}/fargate-profiles/{fargateProfileName}";
   if (input.clusterName !== undefined) {
-    const labelValue: string = input.clusterName.toString();
+    const labelValue: string = input.clusterName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: clusterName."
@@ -498,13 +501,13 @@ export async function serializeAws_restJson1_1DescribeFargateProfileCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{clusterName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: clusterName.");
   }
   if (input.fargateProfileName !== undefined) {
-    const labelValue: string = input.fargateProfileName.toString();
+    const labelValue: string = input.fargateProfileName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: fargateProfileName."
@@ -512,7 +515,7 @@ export async function serializeAws_restJson1_1DescribeFargateProfileCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{fargateProfileName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -536,7 +539,7 @@ export async function serializeAws_restJson1_1DescribeNodegroupCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/clusters/{clusterName}/node-groups/{nodegroupName}";
   if (input.clusterName !== undefined) {
-    const labelValue: string = input.clusterName.toString();
+    const labelValue: string = input.clusterName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: clusterName."
@@ -544,13 +547,13 @@ export async function serializeAws_restJson1_1DescribeNodegroupCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{clusterName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: clusterName.");
   }
   if (input.nodegroupName !== undefined) {
-    const labelValue: string = input.nodegroupName.toString();
+    const labelValue: string = input.nodegroupName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: nodegroupName."
@@ -558,7 +561,7 @@ export async function serializeAws_restJson1_1DescribeNodegroupCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{nodegroupName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: nodegroupName.");
@@ -580,32 +583,34 @@ export async function serializeAws_restJson1_1DescribeUpdateCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/clusters/{name}/updates/{updateId}";
   if (input.name !== undefined) {
-    const labelValue: string = input.name.toString();
+    const labelValue: string = input.name;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: name.");
     }
     resolvedPath = resolvedPath.replace(
       "{name}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: name.");
   }
   if (input.updateId !== undefined) {
-    const labelValue: string = input.updateId.toString();
+    const labelValue: string = input.updateId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: updateId.");
     }
     resolvedPath = resolvedPath.replace(
       "{updateId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: updateId.");
   }
   const query: any = {};
   if (input.nodegroupName !== undefined) {
-    query["nodegroupName"] = input.nodegroupName.toString();
+    query[
+      __extendedEncodeURIComponent("nodegroupName")
+    ] = __extendedEncodeURIComponent(input.nodegroupName);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -626,10 +631,14 @@ export async function serializeAws_restJson1_1ListClustersCommand(
   let resolvedPath = "/clusters";
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -649,7 +658,7 @@ export async function serializeAws_restJson1_1ListFargateProfilesCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/clusters/{clusterName}/fargate-profiles";
   if (input.clusterName !== undefined) {
-    const labelValue: string = input.clusterName.toString();
+    const labelValue: string = input.clusterName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: clusterName."
@@ -657,17 +666,21 @@ export async function serializeAws_restJson1_1ListFargateProfilesCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{clusterName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: clusterName.");
   }
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -687,7 +700,7 @@ export async function serializeAws_restJson1_1ListNodegroupsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/clusters/{clusterName}/node-groups";
   if (input.clusterName !== undefined) {
-    const labelValue: string = input.clusterName.toString();
+    const labelValue: string = input.clusterName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: clusterName."
@@ -695,17 +708,21 @@ export async function serializeAws_restJson1_1ListNodegroupsCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{clusterName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: clusterName.");
   }
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -725,7 +742,7 @@ export async function serializeAws_restJson1_1ListTagsForResourceCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/tags/{resourceArn}";
   if (input.resourceArn !== undefined) {
-    const labelValue: string = input.resourceArn.toString();
+    const labelValue: string = input.resourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: resourceArn."
@@ -733,7 +750,7 @@ export async function serializeAws_restJson1_1ListTagsForResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{resourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: resourceArn.");
@@ -755,26 +772,32 @@ export async function serializeAws_restJson1_1ListUpdatesCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/clusters/{name}/updates";
   if (input.name !== undefined) {
-    const labelValue: string = input.name.toString();
+    const labelValue: string = input.name;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: name.");
     }
     resolvedPath = resolvedPath.replace(
       "{name}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: name.");
   }
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   if (input.nodegroupName !== undefined) {
-    query["nodegroupName"] = input.nodegroupName.toString();
+    query[
+      __extendedEncodeURIComponent("nodegroupName")
+    ] = __extendedEncodeURIComponent(input.nodegroupName);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -794,7 +817,7 @@ export async function serializeAws_restJson1_1TagResourceCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/tags/{resourceArn}";
   if (input.resourceArn !== undefined) {
-    const labelValue: string = input.resourceArn.toString();
+    const labelValue: string = input.resourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: resourceArn."
@@ -802,7 +825,7 @@ export async function serializeAws_restJson1_1TagResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{resourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: resourceArn.");
@@ -831,7 +854,7 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/tags/{resourceArn}";
   if (input.resourceArn !== undefined) {
-    const labelValue: string = input.resourceArn.toString();
+    const labelValue: string = input.resourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: resourceArn."
@@ -839,14 +862,16 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{resourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: resourceArn.");
   }
   const query: any = {};
   if (input.tagKeys !== undefined) {
-    query["tagKeys"] = input.tagKeys;
+    query[__extendedEncodeURIComponent("tagKeys")] = input.tagKeys.map(entry =>
+      __extendedEncodeURIComponent(entry)
+    );
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -866,13 +891,13 @@ export async function serializeAws_restJson1_1UpdateClusterConfigCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/clusters/{name}/update-config";
   if (input.name !== undefined) {
-    const labelValue: string = input.name.toString();
+    const labelValue: string = input.name;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: name.");
     }
     resolvedPath = resolvedPath.replace(
       "{name}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: name.");
@@ -916,13 +941,13 @@ export async function serializeAws_restJson1_1UpdateClusterVersionCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/clusters/{name}/updates";
   if (input.name !== undefined) {
-    const labelValue: string = input.name.toString();
+    const labelValue: string = input.name;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: name.");
     }
     resolvedPath = resolvedPath.replace(
       "{name}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: name.");
@@ -958,7 +983,7 @@ export async function serializeAws_restJson1_1UpdateNodegroupConfigCommand(
   let resolvedPath =
     "/clusters/{clusterName}/node-groups/{nodegroupName}/update-config";
   if (input.clusterName !== undefined) {
-    const labelValue: string = input.clusterName.toString();
+    const labelValue: string = input.clusterName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: clusterName."
@@ -966,13 +991,13 @@ export async function serializeAws_restJson1_1UpdateNodegroupConfigCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{clusterName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: clusterName.");
   }
   if (input.nodegroupName !== undefined) {
-    const labelValue: string = input.nodegroupName.toString();
+    const labelValue: string = input.nodegroupName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: nodegroupName."
@@ -980,7 +1005,7 @@ export async function serializeAws_restJson1_1UpdateNodegroupConfigCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{nodegroupName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: nodegroupName.");
@@ -1027,7 +1052,7 @@ export async function serializeAws_restJson1_1UpdateNodegroupVersionCommand(
   let resolvedPath =
     "/clusters/{clusterName}/node-groups/{nodegroupName}/update-version";
   if (input.clusterName !== undefined) {
-    const labelValue: string = input.clusterName.toString();
+    const labelValue: string = input.clusterName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: clusterName."
@@ -1035,13 +1060,13 @@ export async function serializeAws_restJson1_1UpdateNodegroupVersionCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{clusterName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: clusterName.");
   }
   if (input.nodegroupName !== undefined) {
-    const labelValue: string = input.nodegroupName.toString();
+    const labelValue: string = input.nodegroupName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: nodegroupName."
@@ -1049,7 +1074,7 @@ export async function serializeAws_restJson1_1UpdateNodegroupVersionCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{nodegroupName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: nodegroupName.");
@@ -2362,6 +2387,7 @@ export async function deserializeAws_restJson1_1TagResourceCommand(
     $metadata: deserializeMetadata(output),
     __type: "TagResourceResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2417,6 +2443,7 @@ export async function deserializeAws_restJson1_1UntagResourceCommand(
     $metadata: deserializeMetadata(output),
     __type: "UntagResourceResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 

--- a/clients/client-elastic-beanstalk/models/index.ts
+++ b/clients/client-elastic-beanstalk/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -21,7 +24,7 @@ export interface AbortEnvironmentUpdateMessage {
 
 export namespace AbortEnvironmentUpdateMessage {
   export function isa(o: any): o is AbortEnvironmentUpdateMessage {
-    return _smithy.isa(o, "AbortEnvironmentUpdateMessage");
+    return __isa(o, "AbortEnvironmentUpdateMessage");
   }
 }
 
@@ -79,7 +82,7 @@ export interface ApplicationDescription {
 
 export namespace ApplicationDescription {
   export function isa(o: any): o is ApplicationDescription {
-    return _smithy.isa(o, "ApplicationDescription");
+    return __isa(o, "ApplicationDescription");
   }
 }
 
@@ -96,7 +99,7 @@ export interface ApplicationDescriptionMessage extends $MetadataBearer {
 
 export namespace ApplicationDescriptionMessage {
   export function isa(o: any): o is ApplicationDescriptionMessage {
-    return _smithy.isa(o, "ApplicationDescriptionMessage");
+    return __isa(o, "ApplicationDescriptionMessage");
   }
 }
 
@@ -113,7 +116,7 @@ export interface ApplicationDescriptionsMessage extends $MetadataBearer {
 
 export namespace ApplicationDescriptionsMessage {
   export function isa(o: any): o is ApplicationDescriptionsMessage {
-    return _smithy.isa(o, "ApplicationDescriptionsMessage");
+    return __isa(o, "ApplicationDescriptionsMessage");
   }
 }
 
@@ -150,7 +153,7 @@ export interface ApplicationMetrics {
 
 export namespace ApplicationMetrics {
   export function isa(o: any): o is ApplicationMetrics {
-    return _smithy.isa(o, "ApplicationMetrics");
+    return __isa(o, "ApplicationMetrics");
   }
 }
 
@@ -183,7 +186,7 @@ export interface ApplicationResourceLifecycleConfig {
 
 export namespace ApplicationResourceLifecycleConfig {
   export function isa(o: any): o is ApplicationResourceLifecycleConfig {
-    return _smithy.isa(o, "ApplicationResourceLifecycleConfig");
+    return __isa(o, "ApplicationResourceLifecycleConfig");
   }
 }
 
@@ -205,7 +208,7 @@ export namespace ApplicationResourceLifecycleDescriptionMessage {
   export function isa(
     o: any
   ): o is ApplicationResourceLifecycleDescriptionMessage {
-    return _smithy.isa(o, "ApplicationResourceLifecycleDescriptionMessage");
+    return __isa(o, "ApplicationResourceLifecycleDescriptionMessage");
   }
 }
 
@@ -297,7 +300,7 @@ export interface ApplicationVersionDescription {
 
 export namespace ApplicationVersionDescription {
   export function isa(o: any): o is ApplicationVersionDescription {
-    return _smithy.isa(o, "ApplicationVersionDescription");
+    return __isa(o, "ApplicationVersionDescription");
   }
 }
 
@@ -315,7 +318,7 @@ export interface ApplicationVersionDescriptionMessage extends $MetadataBearer {
 
 export namespace ApplicationVersionDescriptionMessage {
   export function isa(o: any): o is ApplicationVersionDescriptionMessage {
-    return _smithy.isa(o, "ApplicationVersionDescriptionMessage");
+    return __isa(o, "ApplicationVersionDescriptionMessage");
   }
 }
 
@@ -339,7 +342,7 @@ export interface ApplicationVersionDescriptionsMessage extends $MetadataBearer {
 
 export namespace ApplicationVersionDescriptionsMessage {
   export function isa(o: any): o is ApplicationVersionDescriptionsMessage {
-    return _smithy.isa(o, "ApplicationVersionDescriptionsMessage");
+    return __isa(o, "ApplicationVersionDescriptionsMessage");
   }
 }
 
@@ -368,7 +371,7 @@ export interface ApplicationVersionLifecycleConfig {
 
 export namespace ApplicationVersionLifecycleConfig {
   export function isa(o: any): o is ApplicationVersionLifecycleConfig {
-    return _smithy.isa(o, "ApplicationVersionLifecycleConfig");
+    return __isa(o, "ApplicationVersionLifecycleConfig");
   }
 }
 
@@ -402,7 +405,7 @@ export interface ApplyEnvironmentManagedActionRequest {
 
 export namespace ApplyEnvironmentManagedActionRequest {
   export function isa(o: any): o is ApplyEnvironmentManagedActionRequest {
-    return _smithy.isa(o, "ApplyEnvironmentManagedActionRequest");
+    return __isa(o, "ApplyEnvironmentManagedActionRequest");
   }
 }
 
@@ -434,7 +437,7 @@ export interface ApplyEnvironmentManagedActionResult extends $MetadataBearer {
 
 export namespace ApplyEnvironmentManagedActionResult {
   export function isa(o: any): o is ApplyEnvironmentManagedActionResult {
-    return _smithy.isa(o, "ApplyEnvironmentManagedActionResult");
+    return __isa(o, "ApplyEnvironmentManagedActionResult");
   }
 }
 
@@ -451,7 +454,7 @@ export interface AutoScalingGroup {
 
 export namespace AutoScalingGroup {
   export function isa(o: any): o is AutoScalingGroup {
-    return _smithy.isa(o, "AutoScalingGroup");
+    return __isa(o, "AutoScalingGroup");
   }
 }
 
@@ -510,7 +513,7 @@ export interface BuildConfiguration {
 
 export namespace BuildConfiguration {
   export function isa(o: any): o is BuildConfiguration {
-    return _smithy.isa(o, "BuildConfiguration");
+    return __isa(o, "BuildConfiguration");
   }
 }
 
@@ -527,7 +530,7 @@ export interface Builder {
 
 export namespace Builder {
   export function isa(o: any): o is Builder {
-    return _smithy.isa(o, "Builder");
+    return __isa(o, "Builder");
   }
 }
 
@@ -593,7 +596,7 @@ export interface CPUUtilization {
 
 export namespace CPUUtilization {
   export function isa(o: any): o is CPUUtilization {
-    return _smithy.isa(o, "CPUUtilization");
+    return __isa(o, "CPUUtilization");
   }
 }
 
@@ -610,7 +613,7 @@ export interface CheckDNSAvailabilityMessage {
 
 export namespace CheckDNSAvailabilityMessage {
   export function isa(o: any): o is CheckDNSAvailabilityMessage {
-    return _smithy.isa(o, "CheckDNSAvailabilityMessage");
+    return __isa(o, "CheckDNSAvailabilityMessage");
   }
 }
 
@@ -643,7 +646,7 @@ export interface CheckDNSAvailabilityResultMessage extends $MetadataBearer {
 
 export namespace CheckDNSAvailabilityResultMessage {
   export function isa(o: any): o is CheckDNSAvailabilityResultMessage {
-    return _smithy.isa(o, "CheckDNSAvailabilityResultMessage");
+    return __isa(o, "CheckDNSAvailabilityResultMessage");
   }
 }
 
@@ -651,7 +654,7 @@ export namespace CheckDNSAvailabilityResultMessage {
  * <p>AWS CodeBuild is not available in the specified region.</p>
  */
 export interface CodeBuildNotInServiceRegionException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CodeBuildNotInServiceRegionException";
   $fault: "client";
@@ -663,7 +666,7 @@ export interface CodeBuildNotInServiceRegionException
 
 export namespace CodeBuildNotInServiceRegionException {
   export function isa(o: any): o is CodeBuildNotInServiceRegionException {
-    return _smithy.isa(o, "CodeBuildNotInServiceRegionException");
+    return __isa(o, "CodeBuildNotInServiceRegionException");
   }
 }
 
@@ -696,7 +699,7 @@ export interface ComposeEnvironmentsMessage {
 
 export namespace ComposeEnvironmentsMessage {
   export function isa(o: any): o is ComposeEnvironmentsMessage {
-    return _smithy.isa(o, "ComposeEnvironmentsMessage");
+    return __isa(o, "ComposeEnvironmentsMessage");
   }
 }
 
@@ -835,7 +838,7 @@ export interface ConfigurationOptionDescription {
 
 export namespace ConfigurationOptionDescription {
   export function isa(o: any): o is ConfigurationOptionDescription {
-    return _smithy.isa(o, "ConfigurationOptionDescription");
+    return __isa(o, "ConfigurationOptionDescription");
   }
 }
 
@@ -869,7 +872,7 @@ export interface ConfigurationOptionSetting {
 
 export namespace ConfigurationOptionSetting {
   export function isa(o: any): o is ConfigurationOptionSetting {
-    return _smithy.isa(o, "ConfigurationOptionSetting");
+    return __isa(o, "ConfigurationOptionSetting");
   }
 }
 
@@ -898,7 +901,7 @@ export interface ConfigurationOptionsDescription extends $MetadataBearer {
 
 export namespace ConfigurationOptionsDescription {
   export function isa(o: any): o is ConfigurationOptionsDescription {
-    return _smithy.isa(o, "ConfigurationOptionsDescription");
+    return __isa(o, "ConfigurationOptionsDescription");
   }
 }
 
@@ -987,7 +990,7 @@ export interface ConfigurationSettingsDescription extends $MetadataBearer {
 
 export namespace ConfigurationSettingsDescription {
   export function isa(o: any): o is ConfigurationSettingsDescription {
-    return _smithy.isa(o, "ConfigurationSettingsDescription");
+    return __isa(o, "ConfigurationSettingsDescription");
   }
 }
 
@@ -1005,7 +1008,7 @@ export interface ConfigurationSettingsDescriptions extends $MetadataBearer {
 
 export namespace ConfigurationSettingsDescriptions {
   export function isa(o: any): o is ConfigurationSettingsDescriptions {
-    return _smithy.isa(o, "ConfigurationSettingsDescriptions");
+    return __isa(o, "ConfigurationSettingsDescriptions");
   }
 }
 
@@ -1023,7 +1026,7 @@ export interface ConfigurationSettingsValidationMessages
 
 export namespace ConfigurationSettingsValidationMessages {
   export function isa(o: any): o is ConfigurationSettingsValidationMessages {
-    return _smithy.isa(o, "ConfigurationSettingsValidationMessages");
+    return __isa(o, "ConfigurationSettingsValidationMessages");
   }
 }
 
@@ -1060,7 +1063,7 @@ export interface CreateApplicationMessage {
 
 export namespace CreateApplicationMessage {
   export function isa(o: any): o is CreateApplicationMessage {
-    return _smithy.isa(o, "CreateApplicationMessage");
+    return __isa(o, "CreateApplicationMessage");
   }
 }
 
@@ -1146,7 +1149,7 @@ export interface CreateApplicationVersionMessage {
 
 export namespace CreateApplicationVersionMessage {
   export function isa(o: any): o is CreateApplicationVersionMessage {
-    return _smithy.isa(o, "CreateApplicationVersionMessage");
+    return __isa(o, "CreateApplicationVersionMessage");
   }
 }
 
@@ -1232,7 +1235,7 @@ export interface CreateConfigurationTemplateMessage {
 
 export namespace CreateConfigurationTemplateMessage {
   export function isa(o: any): o is CreateConfigurationTemplateMessage {
-    return _smithy.isa(o, "CreateConfigurationTemplateMessage");
+    return __isa(o, "CreateConfigurationTemplateMessage");
   }
 }
 
@@ -1335,7 +1338,7 @@ export interface CreateEnvironmentMessage {
 
 export namespace CreateEnvironmentMessage {
   export function isa(o: any): o is CreateEnvironmentMessage {
-    return _smithy.isa(o, "CreateEnvironmentMessage");
+    return __isa(o, "CreateEnvironmentMessage");
   }
 }
 
@@ -1379,7 +1382,7 @@ export interface CreatePlatformVersionRequest {
 
 export namespace CreatePlatformVersionRequest {
   export function isa(o: any): o is CreatePlatformVersionRequest {
-    return _smithy.isa(o, "CreatePlatformVersionRequest");
+    return __isa(o, "CreatePlatformVersionRequest");
   }
 }
 
@@ -1398,7 +1401,7 @@ export interface CreatePlatformVersionResult extends $MetadataBearer {
 
 export namespace CreatePlatformVersionResult {
   export function isa(o: any): o is CreatePlatformVersionResult {
-    return _smithy.isa(o, "CreatePlatformVersionResult");
+    return __isa(o, "CreatePlatformVersionResult");
   }
 }
 
@@ -1415,7 +1418,7 @@ export interface CreateStorageLocationResultMessage extends $MetadataBearer {
 
 export namespace CreateStorageLocationResultMessage {
   export function isa(o: any): o is CreateStorageLocationResultMessage {
-    return _smithy.isa(o, "CreateStorageLocationResultMessage");
+    return __isa(o, "CreateStorageLocationResultMessage");
   }
 }
 
@@ -1437,7 +1440,7 @@ export interface CustomAmi {
 
 export namespace CustomAmi {
   export function isa(o: any): o is CustomAmi {
-    return _smithy.isa(o, "CustomAmi");
+    return __isa(o, "CustomAmi");
   }
 }
 
@@ -1460,7 +1463,7 @@ export interface DeleteApplicationMessage {
 
 export namespace DeleteApplicationMessage {
   export function isa(o: any): o is DeleteApplicationMessage {
-    return _smithy.isa(o, "DeleteApplicationMessage");
+    return __isa(o, "DeleteApplicationMessage");
   }
 }
 
@@ -1489,7 +1492,7 @@ export interface DeleteApplicationVersionMessage {
 
 export namespace DeleteApplicationVersionMessage {
   export function isa(o: any): o is DeleteApplicationVersionMessage {
-    return _smithy.isa(o, "DeleteApplicationVersionMessage");
+    return __isa(o, "DeleteApplicationVersionMessage");
   }
 }
 
@@ -1511,7 +1514,7 @@ export interface DeleteConfigurationTemplateMessage {
 
 export namespace DeleteConfigurationTemplateMessage {
   export function isa(o: any): o is DeleteConfigurationTemplateMessage {
-    return _smithy.isa(o, "DeleteConfigurationTemplateMessage");
+    return __isa(o, "DeleteConfigurationTemplateMessage");
   }
 }
 
@@ -1533,7 +1536,7 @@ export interface DeleteEnvironmentConfigurationMessage {
 
 export namespace DeleteEnvironmentConfigurationMessage {
   export function isa(o: any): o is DeleteEnvironmentConfigurationMessage {
-    return _smithy.isa(o, "DeleteEnvironmentConfigurationMessage");
+    return __isa(o, "DeleteEnvironmentConfigurationMessage");
   }
 }
 
@@ -1547,7 +1550,7 @@ export interface DeletePlatformVersionRequest {
 
 export namespace DeletePlatformVersionRequest {
   export function isa(o: any): o is DeletePlatformVersionRequest {
-    return _smithy.isa(o, "DeletePlatformVersionRequest");
+    return __isa(o, "DeletePlatformVersionRequest");
   }
 }
 
@@ -1561,7 +1564,7 @@ export interface DeletePlatformVersionResult extends $MetadataBearer {
 
 export namespace DeletePlatformVersionResult {
   export function isa(o: any): o is DeletePlatformVersionResult {
-    return _smithy.isa(o, "DeletePlatformVersionResult");
+    return __isa(o, "DeletePlatformVersionResult");
   }
 }
 
@@ -1609,7 +1612,7 @@ export interface Deployment {
 
 export namespace Deployment {
   export function isa(o: any): o is Deployment {
-    return _smithy.isa(o, "Deployment");
+    return __isa(o, "Deployment");
   }
 }
 
@@ -1623,7 +1626,7 @@ export interface DescribeAccountAttributesResult extends $MetadataBearer {
 
 export namespace DescribeAccountAttributesResult {
   export function isa(o: any): o is DescribeAccountAttributesResult {
-    return _smithy.isa(o, "DescribeAccountAttributesResult");
+    return __isa(o, "DescribeAccountAttributesResult");
   }
 }
 
@@ -1661,7 +1664,7 @@ export interface DescribeApplicationVersionsMessage {
 
 export namespace DescribeApplicationVersionsMessage {
   export function isa(o: any): o is DescribeApplicationVersionsMessage {
-    return _smithy.isa(o, "DescribeApplicationVersionsMessage");
+    return __isa(o, "DescribeApplicationVersionsMessage");
   }
 }
 
@@ -1679,7 +1682,7 @@ export interface DescribeApplicationsMessage {
 
 export namespace DescribeApplicationsMessage {
   export function isa(o: any): o is DescribeApplicationsMessage {
-    return _smithy.isa(o, "DescribeApplicationsMessage");
+    return __isa(o, "DescribeApplicationsMessage");
   }
 }
 
@@ -1725,7 +1728,7 @@ export interface DescribeConfigurationOptionsMessage {
 
 export namespace DescribeConfigurationOptionsMessage {
   export function isa(o: any): o is DescribeConfigurationOptionsMessage {
-    return _smithy.isa(o, "DescribeConfigurationOptionsMessage");
+    return __isa(o, "DescribeConfigurationOptionsMessage");
   }
 }
 
@@ -1761,7 +1764,7 @@ export interface DescribeConfigurationSettingsMessage {
 
 export namespace DescribeConfigurationSettingsMessage {
   export function isa(o: any): o is DescribeConfigurationSettingsMessage {
-    return _smithy.isa(o, "DescribeConfigurationSettingsMessage");
+    return __isa(o, "DescribeConfigurationSettingsMessage");
   }
 }
 
@@ -1792,7 +1795,7 @@ export interface DescribeEnvironmentHealthRequest {
 
 export namespace DescribeEnvironmentHealthRequest {
   export function isa(o: any): o is DescribeEnvironmentHealthRequest {
-    return _smithy.isa(o, "DescribeEnvironmentHealthRequest");
+    return __isa(o, "DescribeEnvironmentHealthRequest");
   }
 }
 
@@ -1848,7 +1851,7 @@ export interface DescribeEnvironmentHealthResult extends $MetadataBearer {
 
 export namespace DescribeEnvironmentHealthResult {
   export function isa(o: any): o is DescribeEnvironmentHealthResult {
-    return _smithy.isa(o, "DescribeEnvironmentHealthResult");
+    return __isa(o, "DescribeEnvironmentHealthResult");
   }
 }
 
@@ -1882,7 +1885,7 @@ export namespace DescribeEnvironmentManagedActionHistoryRequest {
   export function isa(
     o: any
   ): o is DescribeEnvironmentManagedActionHistoryRequest {
-    return _smithy.isa(o, "DescribeEnvironmentManagedActionHistoryRequest");
+    return __isa(o, "DescribeEnvironmentManagedActionHistoryRequest");
   }
 }
 
@@ -1908,7 +1911,7 @@ export namespace DescribeEnvironmentManagedActionHistoryResult {
   export function isa(
     o: any
   ): o is DescribeEnvironmentManagedActionHistoryResult {
-    return _smithy.isa(o, "DescribeEnvironmentManagedActionHistoryResult");
+    return __isa(o, "DescribeEnvironmentManagedActionHistoryResult");
   }
 }
 
@@ -1935,7 +1938,7 @@ export interface DescribeEnvironmentManagedActionsRequest {
 
 export namespace DescribeEnvironmentManagedActionsRequest {
   export function isa(o: any): o is DescribeEnvironmentManagedActionsRequest {
-    return _smithy.isa(o, "DescribeEnvironmentManagedActionsRequest");
+    return __isa(o, "DescribeEnvironmentManagedActionsRequest");
   }
 }
 
@@ -1953,7 +1956,7 @@ export interface DescribeEnvironmentManagedActionsResult
 
 export namespace DescribeEnvironmentManagedActionsResult {
   export function isa(o: any): o is DescribeEnvironmentManagedActionsResult {
-    return _smithy.isa(o, "DescribeEnvironmentManagedActionsResult");
+    return __isa(o, "DescribeEnvironmentManagedActionsResult");
   }
 }
 
@@ -1981,7 +1984,7 @@ export interface DescribeEnvironmentResourcesMessage {
 
 export namespace DescribeEnvironmentResourcesMessage {
   export function isa(o: any): o is DescribeEnvironmentResourcesMessage {
-    return _smithy.isa(o, "DescribeEnvironmentResourcesMessage");
+    return __isa(o, "DescribeEnvironmentResourcesMessage");
   }
 }
 
@@ -2048,7 +2051,7 @@ export interface DescribeEnvironmentsMessage {
 
 export namespace DescribeEnvironmentsMessage {
   export function isa(o: any): o is DescribeEnvironmentsMessage {
-    return _smithy.isa(o, "DescribeEnvironmentsMessage");
+    return __isa(o, "DescribeEnvironmentsMessage");
   }
 }
 
@@ -2130,7 +2133,7 @@ export interface DescribeEventsMessage {
 
 export namespace DescribeEventsMessage {
   export function isa(o: any): o is DescribeEventsMessage {
-    return _smithy.isa(o, "DescribeEventsMessage");
+    return __isa(o, "DescribeEventsMessage");
   }
 }
 
@@ -2164,7 +2167,7 @@ export interface DescribeInstancesHealthRequest {
 
 export namespace DescribeInstancesHealthRequest {
   export function isa(o: any): o is DescribeInstancesHealthRequest {
-    return _smithy.isa(o, "DescribeInstancesHealthRequest");
+    return __isa(o, "DescribeInstancesHealthRequest");
   }
 }
 
@@ -2194,7 +2197,7 @@ export interface DescribeInstancesHealthResult extends $MetadataBearer {
 
 export namespace DescribeInstancesHealthResult {
   export function isa(o: any): o is DescribeInstancesHealthResult {
-    return _smithy.isa(o, "DescribeInstancesHealthResult");
+    return __isa(o, "DescribeInstancesHealthResult");
   }
 }
 
@@ -2208,7 +2211,7 @@ export interface DescribePlatformVersionRequest {
 
 export namespace DescribePlatformVersionRequest {
   export function isa(o: any): o is DescribePlatformVersionRequest {
-    return _smithy.isa(o, "DescribePlatformVersionRequest");
+    return __isa(o, "DescribePlatformVersionRequest");
   }
 }
 
@@ -2222,7 +2225,7 @@ export interface DescribePlatformVersionResult extends $MetadataBearer {
 
 export namespace DescribePlatformVersionResult {
   export function isa(o: any): o is DescribePlatformVersionResult {
-    return _smithy.isa(o, "DescribePlatformVersionResult");
+    return __isa(o, "DescribePlatformVersionResult");
   }
 }
 
@@ -2230,7 +2233,7 @@ export namespace DescribePlatformVersionResult {
  * <p>A generic service exception has occurred.</p>
  */
 export interface ElasticBeanstalkServiceException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ElasticBeanstalkServiceException";
   $fault: "client";
@@ -2242,7 +2245,7 @@ export interface ElasticBeanstalkServiceException
 
 export namespace ElasticBeanstalkServiceException {
   export function isa(o: any): o is ElasticBeanstalkServiceException {
-    return _smithy.isa(o, "ElasticBeanstalkServiceException");
+    return __isa(o, "ElasticBeanstalkServiceException");
   }
 }
 
@@ -2413,7 +2416,7 @@ export interface EnvironmentDescription extends $MetadataBearer {
 
 export namespace EnvironmentDescription {
   export function isa(o: any): o is EnvironmentDescription {
-    return _smithy.isa(o, "EnvironmentDescription");
+    return __isa(o, "EnvironmentDescription");
   }
 }
 
@@ -2436,7 +2439,7 @@ export interface EnvironmentDescriptionsMessage extends $MetadataBearer {
 
 export namespace EnvironmentDescriptionsMessage {
   export function isa(o: any): o is EnvironmentDescriptionsMessage {
-    return _smithy.isa(o, "EnvironmentDescriptionsMessage");
+    return __isa(o, "EnvironmentDescriptionsMessage");
   }
 }
 
@@ -2495,7 +2498,7 @@ export interface EnvironmentInfoDescription {
 
 export namespace EnvironmentInfoDescription {
   export function isa(o: any): o is EnvironmentInfoDescription {
-    return _smithy.isa(o, "EnvironmentInfoDescription");
+    return __isa(o, "EnvironmentInfoDescription");
   }
 }
 
@@ -2522,7 +2525,7 @@ export interface EnvironmentLink {
 
 export namespace EnvironmentLink {
   export function isa(o: any): o is EnvironmentLink {
-    return _smithy.isa(o, "EnvironmentLink");
+    return __isa(o, "EnvironmentLink");
   }
 }
 
@@ -2574,7 +2577,7 @@ export interface EnvironmentResourceDescription {
 
 export namespace EnvironmentResourceDescription {
   export function isa(o: any): o is EnvironmentResourceDescription {
-    return _smithy.isa(o, "EnvironmentResourceDescription");
+    return __isa(o, "EnvironmentResourceDescription");
   }
 }
 
@@ -2592,7 +2595,7 @@ export interface EnvironmentResourceDescriptionsMessage
 
 export namespace EnvironmentResourceDescriptionsMessage {
   export function isa(o: any): o is EnvironmentResourceDescriptionsMessage {
-    return _smithy.isa(o, "EnvironmentResourceDescriptionsMessage");
+    return __isa(o, "EnvironmentResourceDescriptionsMessage");
   }
 }
 
@@ -2610,7 +2613,7 @@ export interface EnvironmentResourcesDescription {
 
 export namespace EnvironmentResourcesDescription {
   export function isa(o: any): o is EnvironmentResourcesDescription {
-    return _smithy.isa(o, "EnvironmentResourcesDescription");
+    return __isa(o, "EnvironmentResourcesDescription");
   }
 }
 
@@ -2671,7 +2674,7 @@ export interface EnvironmentTier {
 
 export namespace EnvironmentTier {
   export function isa(o: any): o is EnvironmentTier {
-    return _smithy.isa(o, "EnvironmentTier");
+    return __isa(o, "EnvironmentTier");
   }
 }
 
@@ -2728,7 +2731,7 @@ export interface EventDescription {
 
 export namespace EventDescription {
   export function isa(o: any): o is EventDescription {
-    return _smithy.isa(o, "EventDescription");
+    return __isa(o, "EventDescription");
   }
 }
 
@@ -2751,7 +2754,7 @@ export interface EventDescriptionsMessage extends $MetadataBearer {
 
 export namespace EventDescriptionsMessage {
   export function isa(o: any): o is EventDescriptionsMessage {
-    return _smithy.isa(o, "EventDescriptionsMessage");
+    return __isa(o, "EventDescriptionsMessage");
   }
 }
 
@@ -2785,7 +2788,7 @@ export interface Instance {
 
 export namespace Instance {
   export function isa(o: any): o is Instance {
-    return _smithy.isa(o, "Instance");
+    return __isa(o, "Instance");
   }
 }
 
@@ -2853,7 +2856,7 @@ export interface InstanceHealthSummary {
 
 export namespace InstanceHealthSummary {
   export function isa(o: any): o is InstanceHealthSummary {
-    return _smithy.isa(o, "InstanceHealthSummary");
+    return __isa(o, "InstanceHealthSummary");
   }
 }
 
@@ -2876,7 +2879,7 @@ export enum InstancesHealthAttribute {
  *       services.</p>
  */
 export interface InsufficientPrivilegesException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InsufficientPrivilegesException";
   $fault: "client";
@@ -2888,7 +2891,7 @@ export interface InsufficientPrivilegesException
 
 export namespace InsufficientPrivilegesException {
   export function isa(o: any): o is InsufficientPrivilegesException {
-    return _smithy.isa(o, "InsufficientPrivilegesException");
+    return __isa(o, "InsufficientPrivilegesException");
   }
 }
 
@@ -2897,7 +2900,7 @@ export namespace InsufficientPrivilegesException {
  *       the operation again.</p>
  */
 export interface InvalidRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidRequestException";
   $fault: "client";
@@ -2909,7 +2912,7 @@ export interface InvalidRequestException
 
 export namespace InvalidRequestException {
   export function isa(o: any): o is InvalidRequestException {
-    return _smithy.isa(o, "InvalidRequestException");
+    return __isa(o, "InvalidRequestException");
   }
 }
 
@@ -2970,7 +2973,7 @@ export interface Latency {
 
 export namespace Latency {
   export function isa(o: any): o is Latency {
-    return _smithy.isa(o, "Latency");
+    return __isa(o, "Latency");
   }
 }
 
@@ -2987,7 +2990,7 @@ export interface LaunchConfiguration {
 
 export namespace LaunchConfiguration {
   export function isa(o: any): o is LaunchConfiguration {
-    return _smithy.isa(o, "LaunchConfiguration");
+    return __isa(o, "LaunchConfiguration");
   }
 }
 
@@ -3004,7 +3007,7 @@ export interface LaunchTemplate {
 
 export namespace LaunchTemplate {
   export function isa(o: any): o is LaunchTemplate {
-    return _smithy.isa(o, "LaunchTemplate");
+    return __isa(o, "LaunchTemplate");
   }
 }
 
@@ -3027,7 +3030,7 @@ export interface ListAvailableSolutionStacksResultMessage
 
 export namespace ListAvailableSolutionStacksResultMessage {
   export function isa(o: any): o is ListAvailableSolutionStacksResultMessage {
-    return _smithy.isa(o, "ListAvailableSolutionStacksResultMessage");
+    return __isa(o, "ListAvailableSolutionStacksResultMessage");
   }
 }
 
@@ -3054,7 +3057,7 @@ export interface ListPlatformVersionsRequest {
 
 export namespace ListPlatformVersionsRequest {
   export function isa(o: any): o is ListPlatformVersionsRequest {
-    return _smithy.isa(o, "ListPlatformVersionsRequest");
+    return __isa(o, "ListPlatformVersionsRequest");
   }
 }
 
@@ -3076,7 +3079,7 @@ export interface ListPlatformVersionsResult extends $MetadataBearer {
 
 export namespace ListPlatformVersionsResult {
   export function isa(o: any): o is ListPlatformVersionsResult {
-    return _smithy.isa(o, "ListPlatformVersionsResult");
+    return __isa(o, "ListPlatformVersionsResult");
   }
 }
 
@@ -3091,7 +3094,7 @@ export interface ListTagsForResourceMessage {
 
 export namespace ListTagsForResourceMessage {
   export function isa(o: any): o is ListTagsForResourceMessage {
-    return _smithy.isa(o, "ListTagsForResourceMessage");
+    return __isa(o, "ListTagsForResourceMessage");
   }
 }
 
@@ -3113,7 +3116,7 @@ export interface Listener {
 
 export namespace Listener {
   export function isa(o: any): o is Listener {
-    return _smithy.isa(o, "Listener");
+    return __isa(o, "Listener");
   }
 }
 
@@ -3130,7 +3133,7 @@ export interface LoadBalancer {
 
 export namespace LoadBalancer {
   export function isa(o: any): o is LoadBalancer {
-    return _smithy.isa(o, "LoadBalancer");
+    return __isa(o, "LoadBalancer");
   }
 }
 
@@ -3157,7 +3160,7 @@ export interface LoadBalancerDescription {
 
 export namespace LoadBalancerDescription {
   export function isa(o: any): o is LoadBalancerDescription {
-    return _smithy.isa(o, "LoadBalancerDescription");
+    return __isa(o, "LoadBalancerDescription");
   }
 }
 
@@ -3196,7 +3199,7 @@ export interface ManagedAction {
 
 export namespace ManagedAction {
   export function isa(o: any): o is ManagedAction {
-    return _smithy.isa(o, "ManagedAction");
+    return __isa(o, "ManagedAction");
   }
 }
 
@@ -3248,7 +3251,7 @@ export interface ManagedActionHistoryItem {
 
 export namespace ManagedActionHistoryItem {
   export function isa(o: any): o is ManagedActionHistoryItem {
-    return _smithy.isa(o, "ManagedActionHistoryItem");
+    return __isa(o, "ManagedActionHistoryItem");
   }
 }
 
@@ -3256,7 +3259,7 @@ export namespace ManagedActionHistoryItem {
  * <p>Cannot modify the managed action in its current state.</p>
  */
 export interface ManagedActionInvalidStateException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ManagedActionInvalidStateException";
   $fault: "client";
@@ -3268,7 +3271,7 @@ export interface ManagedActionInvalidStateException
 
 export namespace ManagedActionInvalidStateException {
   export function isa(o: any): o is ManagedActionInvalidStateException {
-    return _smithy.isa(o, "ManagedActionInvalidStateException");
+    return __isa(o, "ManagedActionInvalidStateException");
   }
 }
 
@@ -3298,7 +3301,7 @@ export interface MaxAgeRule {
 
 export namespace MaxAgeRule {
   export function isa(o: any): o is MaxAgeRule {
-    return _smithy.isa(o, "MaxAgeRule");
+    return __isa(o, "MaxAgeRule");
   }
 }
 
@@ -3328,7 +3331,7 @@ export interface MaxCountRule {
 
 export namespace MaxCountRule {
   export function isa(o: any): o is MaxCountRule {
-    return _smithy.isa(o, "MaxCountRule");
+    return __isa(o, "MaxCountRule");
   }
 }
 
@@ -3337,7 +3340,7 @@ export namespace MaxCountRule {
  *       element in this activity is already in progress.</p>
  */
 export interface OperationInProgressException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "OperationInProgressException";
   $fault: "client";
@@ -3349,7 +3352,7 @@ export interface OperationInProgressException
 
 export namespace OperationInProgressException {
   export function isa(o: any): o is OperationInProgressException {
-    return _smithy.isa(o, "OperationInProgressException");
+    return __isa(o, "OperationInProgressException");
   }
 }
 
@@ -3373,7 +3376,7 @@ export interface OptionRestrictionRegex {
 
 export namespace OptionRestrictionRegex {
   export function isa(o: any): o is OptionRestrictionRegex {
-    return _smithy.isa(o, "OptionRestrictionRegex");
+    return __isa(o, "OptionRestrictionRegex");
   }
 }
 
@@ -3400,7 +3403,7 @@ export interface OptionSpecification {
 
 export namespace OptionSpecification {
   export function isa(o: any): o is OptionSpecification {
-    return _smithy.isa(o, "OptionSpecification");
+    return __isa(o, "OptionSpecification");
   }
 }
 
@@ -3502,7 +3505,7 @@ export interface PlatformDescription {
 
 export namespace PlatformDescription {
   export function isa(o: any): o is PlatformDescription {
-    return _smithy.isa(o, "PlatformDescription");
+    return __isa(o, "PlatformDescription");
   }
 }
 
@@ -3561,7 +3564,7 @@ export interface PlatformFilter {
 
 export namespace PlatformFilter {
   export function isa(o: any): o is PlatformFilter {
-    return _smithy.isa(o, "PlatformFilter");
+    return __isa(o, "PlatformFilter");
   }
 }
 
@@ -3583,7 +3586,7 @@ export interface PlatformFramework {
 
 export namespace PlatformFramework {
   export function isa(o: any): o is PlatformFramework {
-    return _smithy.isa(o, "PlatformFramework");
+    return __isa(o, "PlatformFramework");
   }
 }
 
@@ -3605,7 +3608,7 @@ export interface PlatformProgrammingLanguage {
 
 export namespace PlatformProgrammingLanguage {
   export function isa(o: any): o is PlatformProgrammingLanguage {
-    return _smithy.isa(o, "PlatformProgrammingLanguage");
+    return __isa(o, "PlatformProgrammingLanguage");
   }
 }
 
@@ -3665,7 +3668,7 @@ export interface PlatformSummary {
 
 export namespace PlatformSummary {
   export function isa(o: any): o is PlatformSummary {
-    return _smithy.isa(o, "PlatformSummary");
+    return __isa(o, "PlatformSummary");
   }
 }
 
@@ -3673,7 +3676,7 @@ export namespace PlatformSummary {
  * <p>You cannot delete the platform version because there are still environments running on it.</p>
  */
 export interface PlatformVersionStillReferencedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "PlatformVersionStillReferencedException";
   $fault: "client";
@@ -3685,7 +3688,7 @@ export interface PlatformVersionStillReferencedException
 
 export namespace PlatformVersionStillReferencedException {
   export function isa(o: any): o is PlatformVersionStillReferencedException {
-    return _smithy.isa(o, "PlatformVersionStillReferencedException");
+    return __isa(o, "PlatformVersionStillReferencedException");
   }
 }
 
@@ -3707,7 +3710,7 @@ export interface Queue {
 
 export namespace Queue {
   export function isa(o: any): o is Queue {
-    return _smithy.isa(o, "Queue");
+    return __isa(o, "Queue");
   }
 }
 
@@ -3735,7 +3738,7 @@ export interface RebuildEnvironmentMessage {
 
 export namespace RebuildEnvironmentMessage {
   export function isa(o: any): o is RebuildEnvironmentMessage {
-    return _smithy.isa(o, "RebuildEnvironmentMessage");
+    return __isa(o, "RebuildEnvironmentMessage");
   }
 }
 
@@ -3773,7 +3776,7 @@ export interface RequestEnvironmentInfoMessage {
 
 export namespace RequestEnvironmentInfoMessage {
   export function isa(o: any): o is RequestEnvironmentInfoMessage {
-    return _smithy.isa(o, "RequestEnvironmentInfoMessage");
+    return __isa(o, "RequestEnvironmentInfoMessage");
   }
 }
 
@@ -3781,7 +3784,7 @@ export namespace RequestEnvironmentInfoMessage {
  * <p>A resource doesn't exist for the specified Amazon Resource Name (ARN).</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -3793,7 +3796,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -3812,7 +3815,7 @@ export interface ResourceQuota {
 
 export namespace ResourceQuota {
   export function isa(o: any): o is ResourceQuota {
-    return _smithy.isa(o, "ResourceQuota");
+    return __isa(o, "ResourceQuota");
   }
 }
 
@@ -3850,7 +3853,7 @@ export interface ResourceQuotas {
 
 export namespace ResourceQuotas {
   export function isa(o: any): o is ResourceQuotas {
-    return _smithy.isa(o, "ResourceQuotas");
+    return __isa(o, "ResourceQuotas");
   }
 }
 
@@ -3869,7 +3872,7 @@ export interface ResourceTagsDescriptionMessage extends $MetadataBearer {
 
 export namespace ResourceTagsDescriptionMessage {
   export function isa(o: any): o is ResourceTagsDescriptionMessage {
-    return _smithy.isa(o, "ResourceTagsDescriptionMessage");
+    return __isa(o, "ResourceTagsDescriptionMessage");
   }
 }
 
@@ -3877,7 +3880,7 @@ export namespace ResourceTagsDescriptionMessage {
  * <p>The type of the specified Amazon Resource Name (ARN) isn't supported for this operation.</p>
  */
 export interface ResourceTypeNotSupportedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceTypeNotSupportedException";
   $fault: "client";
@@ -3889,7 +3892,7 @@ export interface ResourceTypeNotSupportedException
 
 export namespace ResourceTypeNotSupportedException {
   export function isa(o: any): o is ResourceTypeNotSupportedException {
-    return _smithy.isa(o, "ResourceTypeNotSupportedException");
+    return __isa(o, "ResourceTypeNotSupportedException");
   }
 }
 
@@ -3917,7 +3920,7 @@ export interface RestartAppServerMessage {
 
 export namespace RestartAppServerMessage {
   export function isa(o: any): o is RestartAppServerMessage {
-    return _smithy.isa(o, "RestartAppServerMessage");
+    return __isa(o, "RestartAppServerMessage");
   }
 }
 
@@ -3953,7 +3956,7 @@ export interface RetrieveEnvironmentInfoMessage {
 
 export namespace RetrieveEnvironmentInfoMessage {
   export function isa(o: any): o is RetrieveEnvironmentInfoMessage {
-    return _smithy.isa(o, "RetrieveEnvironmentInfoMessage");
+    return __isa(o, "RetrieveEnvironmentInfoMessage");
   }
 }
 
@@ -3970,7 +3973,7 @@ export interface RetrieveEnvironmentInfoResultMessage extends $MetadataBearer {
 
 export namespace RetrieveEnvironmentInfoResultMessage {
   export function isa(o: any): o is RetrieveEnvironmentInfoResultMessage {
-    return _smithy.isa(o, "RetrieveEnvironmentInfoResultMessage");
+    return __isa(o, "RetrieveEnvironmentInfoResultMessage");
   }
 }
 
@@ -3992,7 +3995,7 @@ export interface S3Location {
 
 export namespace S3Location {
   export function isa(o: any): o is S3Location {
-    return _smithy.isa(o, "S3Location");
+    return __isa(o, "S3Location");
   }
 }
 
@@ -4012,7 +4015,7 @@ export namespace S3Location {
  *          </ul>
  */
 export interface S3LocationNotInServiceRegionException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "S3LocationNotInServiceRegionException";
   $fault: "client";
@@ -4024,7 +4027,7 @@ export interface S3LocationNotInServiceRegionException
 
 export namespace S3LocationNotInServiceRegionException {
   export function isa(o: any): o is S3LocationNotInServiceRegionException {
-    return _smithy.isa(o, "S3LocationNotInServiceRegionException");
+    return __isa(o, "S3LocationNotInServiceRegionException");
   }
 }
 
@@ -4032,7 +4035,7 @@ export namespace S3LocationNotInServiceRegionException {
  * <p>The specified account does not have a subscription to Amazon S3.</p>
  */
 export interface S3SubscriptionRequiredException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "S3SubscriptionRequiredException";
   $fault: "client";
@@ -4044,7 +4047,7 @@ export interface S3SubscriptionRequiredException
 
 export namespace S3SubscriptionRequiredException {
   export function isa(o: any): o is S3SubscriptionRequiredException {
-    return _smithy.isa(o, "S3SubscriptionRequiredException");
+    return __isa(o, "S3SubscriptionRequiredException");
   }
 }
 
@@ -4111,7 +4114,7 @@ export interface SingleInstanceHealth {
 
 export namespace SingleInstanceHealth {
   export function isa(o: any): o is SingleInstanceHealth {
-    return _smithy.isa(o, "SingleInstanceHealth");
+    return __isa(o, "SingleInstanceHealth");
   }
 }
 
@@ -4133,7 +4136,7 @@ export interface SolutionStackDescription {
 
 export namespace SolutionStackDescription {
   export function isa(o: any): o is SolutionStackDescription {
-    return _smithy.isa(o, "SolutionStackDescription");
+    return __isa(o, "SolutionStackDescription");
   }
 }
 
@@ -4199,7 +4202,7 @@ export interface SourceBuildInformation {
 
 export namespace SourceBuildInformation {
   export function isa(o: any): o is SourceBuildInformation {
-    return _smithy.isa(o, "SourceBuildInformation");
+    return __isa(o, "SourceBuildInformation");
   }
 }
 
@@ -4208,7 +4211,7 @@ export namespace SourceBuildInformation {
  *       The application version was deleted successfully.</p>
  */
 export interface SourceBundleDeletionException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "SourceBundleDeletionException";
   $fault: "client";
@@ -4220,7 +4223,7 @@ export interface SourceBundleDeletionException
 
 export namespace SourceBundleDeletionException {
   export function isa(o: any): o is SourceBundleDeletionException {
-    return _smithy.isa(o, "SourceBundleDeletionException");
+    return __isa(o, "SourceBundleDeletionException");
   }
 }
 
@@ -4242,7 +4245,7 @@ export interface SourceConfiguration {
 
 export namespace SourceConfiguration {
   export function isa(o: any): o is SourceConfiguration {
-    return _smithy.isa(o, "SourceConfiguration");
+    return __isa(o, "SourceConfiguration");
   }
 }
 
@@ -4284,7 +4287,7 @@ export interface StatusCodes {
 
 export namespace StatusCodes {
   export function isa(o: any): o is StatusCodes {
-    return _smithy.isa(o, "StatusCodes");
+    return __isa(o, "StatusCodes");
   }
 }
 
@@ -4331,7 +4334,7 @@ export interface SwapEnvironmentCNAMEsMessage {
 
 export namespace SwapEnvironmentCNAMEsMessage {
   export function isa(o: any): o is SwapEnvironmentCNAMEsMessage {
-    return _smithy.isa(o, "SwapEnvironmentCNAMEsMessage");
+    return __isa(o, "SwapEnvironmentCNAMEsMessage");
   }
 }
 
@@ -4355,7 +4358,7 @@ export interface SystemStatus {
 
 export namespace SystemStatus {
   export function isa(o: any): o is SystemStatus {
-    return _smithy.isa(o, "SystemStatus");
+    return __isa(o, "SystemStatus");
   }
 }
 
@@ -4377,7 +4380,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -4435,7 +4438,7 @@ export interface TerminateEnvironmentMessage {
 
 export namespace TerminateEnvironmentMessage {
   export function isa(o: any): o is TerminateEnvironmentMessage {
-    return _smithy.isa(o, "TerminateEnvironmentMessage");
+    return __isa(o, "TerminateEnvironmentMessage");
   }
 }
 
@@ -4443,7 +4446,7 @@ export namespace TerminateEnvironmentMessage {
  * <p>The specified account has reached its limit of application versions.</p>
  */
 export interface TooManyApplicationVersionsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyApplicationVersionsException";
   $fault: "client";
@@ -4455,7 +4458,7 @@ export interface TooManyApplicationVersionsException
 
 export namespace TooManyApplicationVersionsException {
   export function isa(o: any): o is TooManyApplicationVersionsException {
-    return _smithy.isa(o, "TooManyApplicationVersionsException");
+    return __isa(o, "TooManyApplicationVersionsException");
   }
 }
 
@@ -4463,7 +4466,7 @@ export namespace TooManyApplicationVersionsException {
  * <p>The specified account has reached its limit of applications.</p>
  */
 export interface TooManyApplicationsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyApplicationsException";
   $fault: "client";
@@ -4475,7 +4478,7 @@ export interface TooManyApplicationsException
 
 export namespace TooManyApplicationsException {
   export function isa(o: any): o is TooManyApplicationsException {
-    return _smithy.isa(o, "TooManyApplicationsException");
+    return __isa(o, "TooManyApplicationsException");
   }
 }
 
@@ -4483,7 +4486,7 @@ export namespace TooManyApplicationsException {
  * <p>The specified account has reached its limit of Amazon S3 buckets.</p>
  */
 export interface TooManyBucketsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyBucketsException";
   $fault: "client";
@@ -4495,7 +4498,7 @@ export interface TooManyBucketsException
 
 export namespace TooManyBucketsException {
   export function isa(o: any): o is TooManyBucketsException {
-    return _smithy.isa(o, "TooManyBucketsException");
+    return __isa(o, "TooManyBucketsException");
   }
 }
 
@@ -4503,7 +4506,7 @@ export namespace TooManyBucketsException {
  * <p>The specified account has reached its limit of configuration templates.</p>
  */
 export interface TooManyConfigurationTemplatesException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyConfigurationTemplatesException";
   $fault: "client";
@@ -4515,7 +4518,7 @@ export interface TooManyConfigurationTemplatesException
 
 export namespace TooManyConfigurationTemplatesException {
   export function isa(o: any): o is TooManyConfigurationTemplatesException {
-    return _smithy.isa(o, "TooManyConfigurationTemplatesException");
+    return __isa(o, "TooManyConfigurationTemplatesException");
   }
 }
 
@@ -4523,7 +4526,7 @@ export namespace TooManyConfigurationTemplatesException {
  * <p>The specified account has reached its limit of environments.</p>
  */
 export interface TooManyEnvironmentsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyEnvironmentsException";
   $fault: "client";
@@ -4535,7 +4538,7 @@ export interface TooManyEnvironmentsException
 
 export namespace TooManyEnvironmentsException {
   export function isa(o: any): o is TooManyEnvironmentsException {
-    return _smithy.isa(o, "TooManyEnvironmentsException");
+    return __isa(o, "TooManyEnvironmentsException");
   }
 }
 
@@ -4543,7 +4546,7 @@ export namespace TooManyEnvironmentsException {
  * <p>You have exceeded the maximum number of allowed platforms associated with the account.</p>
  */
 export interface TooManyPlatformsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyPlatformsException";
   $fault: "client";
@@ -4555,7 +4558,7 @@ export interface TooManyPlatformsException
 
 export namespace TooManyPlatformsException {
   export function isa(o: any): o is TooManyPlatformsException {
-    return _smithy.isa(o, "TooManyPlatformsException");
+    return __isa(o, "TooManyPlatformsException");
   }
 }
 
@@ -4566,7 +4569,7 @@ export namespace TooManyPlatformsException {
  *       and the tags this operation would add if it succeeded.</p>
  */
 export interface TooManyTagsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyTagsException";
   $fault: "client";
@@ -4578,7 +4581,7 @@ export interface TooManyTagsException
 
 export namespace TooManyTagsException {
   export function isa(o: any): o is TooManyTagsException {
-    return _smithy.isa(o, "TooManyTagsException");
+    return __isa(o, "TooManyTagsException");
   }
 }
 
@@ -4595,7 +4598,7 @@ export interface Trigger {
 
 export namespace Trigger {
   export function isa(o: any): o is Trigger {
-    return _smithy.isa(o, "Trigger");
+    return __isa(o, "Trigger");
   }
 }
 
@@ -4621,7 +4624,7 @@ export interface UpdateApplicationMessage {
 
 export namespace UpdateApplicationMessage {
   export function isa(o: any): o is UpdateApplicationMessage {
-    return _smithy.isa(o, "UpdateApplicationMessage");
+    return __isa(o, "UpdateApplicationMessage");
   }
 }
 
@@ -4640,7 +4643,7 @@ export interface UpdateApplicationResourceLifecycleMessage {
 
 export namespace UpdateApplicationResourceLifecycleMessage {
   export function isa(o: any): o is UpdateApplicationResourceLifecycleMessage {
-    return _smithy.isa(o, "UpdateApplicationResourceLifecycleMessage");
+    return __isa(o, "UpdateApplicationResourceLifecycleMessage");
   }
 }
 
@@ -4671,7 +4674,7 @@ export interface UpdateApplicationVersionMessage {
 
 export namespace UpdateApplicationVersionMessage {
   export function isa(o: any): o is UpdateApplicationVersionMessage {
-    return _smithy.isa(o, "UpdateApplicationVersionMessage");
+    return __isa(o, "UpdateApplicationVersionMessage");
   }
 }
 
@@ -4717,7 +4720,7 @@ export interface UpdateConfigurationTemplateMessage {
 
 export namespace UpdateConfigurationTemplateMessage {
   export function isa(o: any): o is UpdateConfigurationTemplateMessage {
-    return _smithy.isa(o, "UpdateConfigurationTemplateMessage");
+    return __isa(o, "UpdateConfigurationTemplateMessage");
   }
 }
 
@@ -4812,7 +4815,7 @@ export interface UpdateEnvironmentMessage {
 
 export namespace UpdateEnvironmentMessage {
   export function isa(o: any): o is UpdateEnvironmentMessage {
-    return _smithy.isa(o, "UpdateEnvironmentMessage");
+    return __isa(o, "UpdateEnvironmentMessage");
   }
 }
 
@@ -4839,7 +4842,7 @@ export interface UpdateTagsForResourceMessage {
 
 export namespace UpdateTagsForResourceMessage {
   export function isa(o: any): o is UpdateTagsForResourceMessage {
-    return _smithy.isa(o, "UpdateTagsForResourceMessage");
+    return __isa(o, "UpdateTagsForResourceMessage");
   }
 }
 
@@ -4874,7 +4877,7 @@ export interface ValidateConfigurationSettingsMessage {
 
 export namespace ValidateConfigurationSettingsMessage {
   export function isa(o: any): o is ValidateConfigurationSettingsMessage {
-    return _smithy.isa(o, "ValidateConfigurationSettingsMessage");
+    return __isa(o, "ValidateConfigurationSettingsMessage");
   }
 }
 
@@ -4918,7 +4921,7 @@ export interface ValidationMessage {
 
 export namespace ValidationMessage {
   export function isa(o: any): o is ValidationMessage {
-    return _smithy.isa(o, "ValidationMessage");
+    return __isa(o, "ValidationMessage");
   }
 }
 

--- a/clients/client-elastic-beanstalk/protocols/Aws_query.ts
+++ b/clients/client-elastic-beanstalk/protocols/Aws_query.ts
@@ -1117,6 +1117,7 @@ export async function deserializeAws_queryAbortEnvironmentUpdateCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: AbortEnvironmentUpdateCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1791,6 +1792,7 @@ export async function deserializeAws_queryDeleteApplicationCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_queryDeleteApplicationCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteApplicationCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1844,6 +1846,7 @@ export async function deserializeAws_queryDeleteApplicationVersionCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteApplicationVersionCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1918,6 +1921,7 @@ export async function deserializeAws_queryDeleteConfigurationTemplateCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteConfigurationTemplateCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1971,6 +1975,7 @@ export async function deserializeAws_queryDeleteEnvironmentConfigurationCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteEnvironmentConfigurationCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -3073,6 +3078,7 @@ export async function deserializeAws_queryRebuildEnvironmentCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_queryRebuildEnvironmentCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: RebuildEnvironmentCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -3126,6 +3132,7 @@ export async function deserializeAws_queryRequestEnvironmentInfoCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: RequestEnvironmentInfoCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -3169,6 +3176,7 @@ export async function deserializeAws_queryRestartAppServerCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_queryRestartAppServerCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: RestartAppServerCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -3269,6 +3277,7 @@ export async function deserializeAws_querySwapEnvironmentCNAMEsCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: SwapEnvironmentCNAMEsCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -3675,6 +3684,7 @@ export async function deserializeAws_queryUpdateTagsForResourceCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: UpdateTagsForResourceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };

--- a/clients/client-elastic-inference/models/index.ts
+++ b/clients/client-elastic-inference/models/index.ts
@@ -1,11 +1,14 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
  * Raised when a malformed input has been provided to the API.
  */
 export interface BadRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "BadRequestException";
   $fault: "client";
@@ -14,7 +17,7 @@ export interface BadRequestException
 
 export namespace BadRequestException {
   export function isa(o: any): o is BadRequestException {
-    return _smithy.isa(o, "BadRequestException");
+    return __isa(o, "BadRequestException");
   }
 }
 
@@ -22,7 +25,7 @@ export namespace BadRequestException {
  * Raised when an unexpected error occurred during request processing.
  */
 export interface InternalServerException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalServerException";
   $fault: "server";
@@ -31,7 +34,7 @@ export interface InternalServerException
 
 export namespace InternalServerException {
   export function isa(o: any): o is InternalServerException {
-    return _smithy.isa(o, "InternalServerException");
+    return __isa(o, "InternalServerException");
   }
 }
 
@@ -45,7 +48,7 @@ export interface ListTagsForResourceRequest {
 
 export namespace ListTagsForResourceRequest {
   export function isa(o: any): o is ListTagsForResourceRequest {
-    return _smithy.isa(o, "ListTagsForResourceRequest");
+    return __isa(o, "ListTagsForResourceRequest");
   }
 }
 
@@ -59,7 +62,7 @@ export interface ListTagsForResourceResult extends $MetadataBearer {
 
 export namespace ListTagsForResourceResult {
   export function isa(o: any): o is ListTagsForResourceResult {
-    return _smithy.isa(o, "ListTagsForResourceResult");
+    return __isa(o, "ListTagsForResourceResult");
   }
 }
 
@@ -67,7 +70,7 @@ export namespace ListTagsForResourceResult {
  * Raised when the requested resource cannot be found.
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -76,7 +79,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -95,7 +98,7 @@ export interface TagResourceRequest {
 
 export namespace TagResourceRequest {
   export function isa(o: any): o is TagResourceRequest {
-    return _smithy.isa(o, "TagResourceRequest");
+    return __isa(o, "TagResourceRequest");
   }
 }
 
@@ -105,7 +108,7 @@ export interface TagResourceResult extends $MetadataBearer {
 
 export namespace TagResourceResult {
   export function isa(o: any): o is TagResourceResult {
-    return _smithy.isa(o, "TagResourceResult");
+    return __isa(o, "TagResourceResult");
   }
 }
 
@@ -124,7 +127,7 @@ export interface UntagResourceRequest {
 
 export namespace UntagResourceRequest {
   export function isa(o: any): o is UntagResourceRequest {
-    return _smithy.isa(o, "UntagResourceRequest");
+    return __isa(o, "UntagResourceRequest");
   }
 }
 
@@ -134,6 +137,6 @@ export interface UntagResourceResult extends $MetadataBearer {
 
 export namespace UntagResourceResult {
   export function isa(o: any): o is UntagResourceResult {
-    return _smithy.isa(o, "UntagResourceResult");
+    return __isa(o, "UntagResourceResult");
   }
 }

--- a/clients/client-elastic-inference/protocols/Aws_restJson1_1.ts
+++ b/clients/client-elastic-inference/protocols/Aws_restJson1_1.ts
@@ -19,7 +19,10 @@ import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  extendedEncodeURIComponent as __extendedEncodeURIComponent
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -35,7 +38,7 @@ export async function serializeAws_restJson1_1ListTagsForResourceCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/tags/{resourceArn}";
   if (input.resourceArn !== undefined) {
-    const labelValue: string = input.resourceArn.toString();
+    const labelValue: string = input.resourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: resourceArn."
@@ -43,7 +46,7 @@ export async function serializeAws_restJson1_1ListTagsForResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{resourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: resourceArn.");
@@ -65,7 +68,7 @@ export async function serializeAws_restJson1_1TagResourceCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/tags/{resourceArn}";
   if (input.resourceArn !== undefined) {
-    const labelValue: string = input.resourceArn.toString();
+    const labelValue: string = input.resourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: resourceArn."
@@ -73,7 +76,7 @@ export async function serializeAws_restJson1_1TagResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{resourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: resourceArn.");
@@ -102,7 +105,7 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/tags/{resourceArn}";
   if (input.resourceArn !== undefined) {
-    const labelValue: string = input.resourceArn.toString();
+    const labelValue: string = input.resourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: resourceArn."
@@ -110,14 +113,16 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{resourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: resourceArn.");
   }
   const query: any = {};
   if (input.tagKeys !== undefined) {
-    query["tagKeys"] = input.tagKeys;
+    query[__extendedEncodeURIComponent("tagKeys")] = input.tagKeys.map(entry =>
+      __extendedEncodeURIComponent(entry)
+    );
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -210,6 +215,7 @@ export async function deserializeAws_restJson1_1TagResourceCommand(
     $metadata: deserializeMetadata(output),
     __type: "TagResourceResult"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -272,6 +278,7 @@ export async function deserializeAws_restJson1_1UntagResourceCommand(
     $metadata: deserializeMetadata(output),
     __type: "UntagResourceResult"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 

--- a/clients/client-elastic-load-balancing-v2/models/index.ts
+++ b/clients/client-elastic-load-balancing-v2/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -62,7 +65,7 @@ export interface Action {
 
 export namespace Action {
   export function isa(o: any): o is Action {
-    return _smithy.isa(o, "Action");
+    return __isa(o, "Action");
   }
 }
 
@@ -90,7 +93,7 @@ export interface AddListenerCertificatesInput {
 
 export namespace AddListenerCertificatesInput {
   export function isa(o: any): o is AddListenerCertificatesInput {
-    return _smithy.isa(o, "AddListenerCertificatesInput");
+    return __isa(o, "AddListenerCertificatesInput");
   }
 }
 
@@ -104,7 +107,7 @@ export interface AddListenerCertificatesOutput extends $MetadataBearer {
 
 export namespace AddListenerCertificatesOutput {
   export function isa(o: any): o is AddListenerCertificatesOutput {
-    return _smithy.isa(o, "AddListenerCertificatesOutput");
+    return __isa(o, "AddListenerCertificatesOutput");
   }
 }
 
@@ -123,7 +126,7 @@ export interface AddTagsInput {
 
 export namespace AddTagsInput {
   export function isa(o: any): o is AddTagsInput {
-    return _smithy.isa(o, "AddTagsInput");
+    return __isa(o, "AddTagsInput");
   }
 }
 
@@ -133,7 +136,7 @@ export interface AddTagsOutput extends $MetadataBearer {
 
 export namespace AddTagsOutput {
   export function isa(o: any): o is AddTagsOutput {
-    return _smithy.isa(o, "AddTagsOutput");
+    return __isa(o, "AddTagsOutput");
   }
 }
 
@@ -141,7 +144,7 @@ export namespace AddTagsOutput {
  * <p>The specified allocation ID does not exist.</p>
  */
 export interface AllocationIdNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AllocationIdNotFoundException";
   $fault: "client";
@@ -150,7 +153,7 @@ export interface AllocationIdNotFoundException
 
 export namespace AllocationIdNotFoundException {
   export function isa(o: any): o is AllocationIdNotFoundException {
-    return _smithy.isa(o, "AllocationIdNotFoundException");
+    return __isa(o, "AllocationIdNotFoundException");
   }
 }
 
@@ -223,7 +226,7 @@ export interface AuthenticateCognitoActionConfig {
 
 export namespace AuthenticateCognitoActionConfig {
   export function isa(o: any): o is AuthenticateCognitoActionConfig {
-    return _smithy.isa(o, "AuthenticateCognitoActionConfig");
+    return __isa(o, "AuthenticateCognitoActionConfig");
   }
 }
 
@@ -318,7 +321,7 @@ export interface AuthenticateOidcActionConfig {
 
 export namespace AuthenticateOidcActionConfig {
   export function isa(o: any): o is AuthenticateOidcActionConfig {
-    return _smithy.isa(o, "AuthenticateOidcActionConfig");
+    return __isa(o, "AuthenticateOidcActionConfig");
   }
 }
 
@@ -348,7 +351,7 @@ export interface AvailabilityZone {
 
 export namespace AvailabilityZone {
   export function isa(o: any): o is AvailabilityZone {
-    return _smithy.isa(o, "AvailabilityZone");
+    return __isa(o, "AvailabilityZone");
   }
 }
 
@@ -356,7 +359,7 @@ export namespace AvailabilityZone {
  * <p>The specified Availability Zone is not supported.</p>
  */
 export interface AvailabilityZoneNotSupportedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AvailabilityZoneNotSupportedException";
   $fault: "client";
@@ -365,7 +368,7 @@ export interface AvailabilityZoneNotSupportedException
 
 export namespace AvailabilityZoneNotSupportedException {
   export function isa(o: any): o is AvailabilityZoneNotSupportedException {
-    return _smithy.isa(o, "AvailabilityZoneNotSupportedException");
+    return __isa(o, "AvailabilityZoneNotSupportedException");
   }
 }
 
@@ -389,7 +392,7 @@ export interface Certificate {
 
 export namespace Certificate {
   export function isa(o: any): o is Certificate {
-    return _smithy.isa(o, "Certificate");
+    return __isa(o, "Certificate");
   }
 }
 
@@ -397,7 +400,7 @@ export namespace Certificate {
  * <p>The specified certificate does not exist.</p>
  */
 export interface CertificateNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CertificateNotFoundException";
   $fault: "client";
@@ -406,7 +409,7 @@ export interface CertificateNotFoundException
 
 export namespace CertificateNotFoundException {
   export function isa(o: any): o is CertificateNotFoundException {
-    return _smithy.isa(o, "CertificateNotFoundException");
+    return __isa(o, "CertificateNotFoundException");
   }
 }
 
@@ -428,7 +431,7 @@ export interface Cipher {
 
 export namespace Cipher {
   export function isa(o: any): o is Cipher {
-    return _smithy.isa(o, "Cipher");
+    return __isa(o, "Cipher");
   }
 }
 
@@ -483,7 +486,7 @@ export interface CreateListenerInput {
 
 export namespace CreateListenerInput {
   export function isa(o: any): o is CreateListenerInput {
-    return _smithy.isa(o, "CreateListenerInput");
+    return __isa(o, "CreateListenerInput");
   }
 }
 
@@ -497,7 +500,7 @@ export interface CreateListenerOutput extends $MetadataBearer {
 
 export namespace CreateListenerOutput {
   export function isa(o: any): o is CreateListenerOutput {
-    return _smithy.isa(o, "CreateListenerOutput");
+    return __isa(o, "CreateListenerOutput");
   }
 }
 
@@ -572,7 +575,7 @@ export interface CreateLoadBalancerInput {
 
 export namespace CreateLoadBalancerInput {
   export function isa(o: any): o is CreateLoadBalancerInput {
-    return _smithy.isa(o, "CreateLoadBalancerInput");
+    return __isa(o, "CreateLoadBalancerInput");
   }
 }
 
@@ -586,7 +589,7 @@ export interface CreateLoadBalancerOutput extends $MetadataBearer {
 
 export namespace CreateLoadBalancerOutput {
   export function isa(o: any): o is CreateLoadBalancerOutput {
-    return _smithy.isa(o, "CreateLoadBalancerOutput");
+    return __isa(o, "CreateLoadBalancerOutput");
   }
 }
 
@@ -631,7 +634,7 @@ export interface CreateRuleInput {
 
 export namespace CreateRuleInput {
   export function isa(o: any): o is CreateRuleInput {
-    return _smithy.isa(o, "CreateRuleInput");
+    return __isa(o, "CreateRuleInput");
   }
 }
 
@@ -645,7 +648,7 @@ export interface CreateRuleOutput extends $MetadataBearer {
 
 export namespace CreateRuleOutput {
   export function isa(o: any): o is CreateRuleOutput {
-    return _smithy.isa(o, "CreateRuleOutput");
+    return __isa(o, "CreateRuleOutput");
   }
 }
 
@@ -774,7 +777,7 @@ export interface CreateTargetGroupInput {
 
 export namespace CreateTargetGroupInput {
   export function isa(o: any): o is CreateTargetGroupInput {
-    return _smithy.isa(o, "CreateTargetGroupInput");
+    return __isa(o, "CreateTargetGroupInput");
   }
 }
 
@@ -788,7 +791,7 @@ export interface CreateTargetGroupOutput extends $MetadataBearer {
 
 export namespace CreateTargetGroupOutput {
   export function isa(o: any): o is CreateTargetGroupOutput {
-    return _smithy.isa(o, "CreateTargetGroupOutput");
+    return __isa(o, "CreateTargetGroupOutput");
   }
 }
 
@@ -802,7 +805,7 @@ export interface DeleteListenerInput {
 
 export namespace DeleteListenerInput {
   export function isa(o: any): o is DeleteListenerInput {
-    return _smithy.isa(o, "DeleteListenerInput");
+    return __isa(o, "DeleteListenerInput");
   }
 }
 
@@ -812,7 +815,7 @@ export interface DeleteListenerOutput extends $MetadataBearer {
 
 export namespace DeleteListenerOutput {
   export function isa(o: any): o is DeleteListenerOutput {
-    return _smithy.isa(o, "DeleteListenerOutput");
+    return __isa(o, "DeleteListenerOutput");
   }
 }
 
@@ -826,7 +829,7 @@ export interface DeleteLoadBalancerInput {
 
 export namespace DeleteLoadBalancerInput {
   export function isa(o: any): o is DeleteLoadBalancerInput {
-    return _smithy.isa(o, "DeleteLoadBalancerInput");
+    return __isa(o, "DeleteLoadBalancerInput");
   }
 }
 
@@ -836,7 +839,7 @@ export interface DeleteLoadBalancerOutput extends $MetadataBearer {
 
 export namespace DeleteLoadBalancerOutput {
   export function isa(o: any): o is DeleteLoadBalancerOutput {
-    return _smithy.isa(o, "DeleteLoadBalancerOutput");
+    return __isa(o, "DeleteLoadBalancerOutput");
   }
 }
 
@@ -850,7 +853,7 @@ export interface DeleteRuleInput {
 
 export namespace DeleteRuleInput {
   export function isa(o: any): o is DeleteRuleInput {
-    return _smithy.isa(o, "DeleteRuleInput");
+    return __isa(o, "DeleteRuleInput");
   }
 }
 
@@ -860,7 +863,7 @@ export interface DeleteRuleOutput extends $MetadataBearer {
 
 export namespace DeleteRuleOutput {
   export function isa(o: any): o is DeleteRuleOutput {
-    return _smithy.isa(o, "DeleteRuleOutput");
+    return __isa(o, "DeleteRuleOutput");
   }
 }
 
@@ -874,7 +877,7 @@ export interface DeleteTargetGroupInput {
 
 export namespace DeleteTargetGroupInput {
   export function isa(o: any): o is DeleteTargetGroupInput {
-    return _smithy.isa(o, "DeleteTargetGroupInput");
+    return __isa(o, "DeleteTargetGroupInput");
   }
 }
 
@@ -884,7 +887,7 @@ export interface DeleteTargetGroupOutput extends $MetadataBearer {
 
 export namespace DeleteTargetGroupOutput {
   export function isa(o: any): o is DeleteTargetGroupOutput {
-    return _smithy.isa(o, "DeleteTargetGroupOutput");
+    return __isa(o, "DeleteTargetGroupOutput");
   }
 }
 
@@ -904,7 +907,7 @@ export interface DeregisterTargetsInput {
 
 export namespace DeregisterTargetsInput {
   export function isa(o: any): o is DeregisterTargetsInput {
-    return _smithy.isa(o, "DeregisterTargetsInput");
+    return __isa(o, "DeregisterTargetsInput");
   }
 }
 
@@ -914,7 +917,7 @@ export interface DeregisterTargetsOutput extends $MetadataBearer {
 
 export namespace DeregisterTargetsOutput {
   export function isa(o: any): o is DeregisterTargetsOutput {
-    return _smithy.isa(o, "DeregisterTargetsOutput");
+    return __isa(o, "DeregisterTargetsOutput");
   }
 }
 
@@ -934,7 +937,7 @@ export interface DescribeAccountLimitsInput {
 
 export namespace DescribeAccountLimitsInput {
   export function isa(o: any): o is DescribeAccountLimitsInput {
-    return _smithy.isa(o, "DescribeAccountLimitsInput");
+    return __isa(o, "DescribeAccountLimitsInput");
   }
 }
 
@@ -954,7 +957,7 @@ export interface DescribeAccountLimitsOutput extends $MetadataBearer {
 
 export namespace DescribeAccountLimitsOutput {
   export function isa(o: any): o is DescribeAccountLimitsOutput {
-    return _smithy.isa(o, "DescribeAccountLimitsOutput");
+    return __isa(o, "DescribeAccountLimitsOutput");
   }
 }
 
@@ -979,7 +982,7 @@ export interface DescribeListenerCertificatesInput {
 
 export namespace DescribeListenerCertificatesInput {
   export function isa(o: any): o is DescribeListenerCertificatesInput {
-    return _smithy.isa(o, "DescribeListenerCertificatesInput");
+    return __isa(o, "DescribeListenerCertificatesInput");
   }
 }
 
@@ -999,7 +1002,7 @@ export interface DescribeListenerCertificatesOutput extends $MetadataBearer {
 
 export namespace DescribeListenerCertificatesOutput {
   export function isa(o: any): o is DescribeListenerCertificatesOutput {
-    return _smithy.isa(o, "DescribeListenerCertificatesOutput");
+    return __isa(o, "DescribeListenerCertificatesOutput");
   }
 }
 
@@ -1029,7 +1032,7 @@ export interface DescribeListenersInput {
 
 export namespace DescribeListenersInput {
   export function isa(o: any): o is DescribeListenersInput {
-    return _smithy.isa(o, "DescribeListenersInput");
+    return __isa(o, "DescribeListenersInput");
   }
 }
 
@@ -1049,7 +1052,7 @@ export interface DescribeListenersOutput extends $MetadataBearer {
 
 export namespace DescribeListenersOutput {
   export function isa(o: any): o is DescribeListenersOutput {
-    return _smithy.isa(o, "DescribeListenersOutput");
+    return __isa(o, "DescribeListenersOutput");
   }
 }
 
@@ -1063,7 +1066,7 @@ export interface DescribeLoadBalancerAttributesInput {
 
 export namespace DescribeLoadBalancerAttributesInput {
   export function isa(o: any): o is DescribeLoadBalancerAttributesInput {
-    return _smithy.isa(o, "DescribeLoadBalancerAttributesInput");
+    return __isa(o, "DescribeLoadBalancerAttributesInput");
   }
 }
 
@@ -1077,7 +1080,7 @@ export interface DescribeLoadBalancerAttributesOutput extends $MetadataBearer {
 
 export namespace DescribeLoadBalancerAttributesOutput {
   export function isa(o: any): o is DescribeLoadBalancerAttributesOutput {
-    return _smithy.isa(o, "DescribeLoadBalancerAttributesOutput");
+    return __isa(o, "DescribeLoadBalancerAttributesOutput");
   }
 }
 
@@ -1108,7 +1111,7 @@ export interface DescribeLoadBalancersInput {
 
 export namespace DescribeLoadBalancersInput {
   export function isa(o: any): o is DescribeLoadBalancersInput {
-    return _smithy.isa(o, "DescribeLoadBalancersInput");
+    return __isa(o, "DescribeLoadBalancersInput");
   }
 }
 
@@ -1128,7 +1131,7 @@ export interface DescribeLoadBalancersOutput extends $MetadataBearer {
 
 export namespace DescribeLoadBalancersOutput {
   export function isa(o: any): o is DescribeLoadBalancersOutput {
-    return _smithy.isa(o, "DescribeLoadBalancersOutput");
+    return __isa(o, "DescribeLoadBalancersOutput");
   }
 }
 
@@ -1158,7 +1161,7 @@ export interface DescribeRulesInput {
 
 export namespace DescribeRulesInput {
   export function isa(o: any): o is DescribeRulesInput {
-    return _smithy.isa(o, "DescribeRulesInput");
+    return __isa(o, "DescribeRulesInput");
   }
 }
 
@@ -1178,7 +1181,7 @@ export interface DescribeRulesOutput extends $MetadataBearer {
 
 export namespace DescribeRulesOutput {
   export function isa(o: any): o is DescribeRulesOutput {
-    return _smithy.isa(o, "DescribeRulesOutput");
+    return __isa(o, "DescribeRulesOutput");
   }
 }
 
@@ -1203,7 +1206,7 @@ export interface DescribeSSLPoliciesInput {
 
 export namespace DescribeSSLPoliciesInput {
   export function isa(o: any): o is DescribeSSLPoliciesInput {
-    return _smithy.isa(o, "DescribeSSLPoliciesInput");
+    return __isa(o, "DescribeSSLPoliciesInput");
   }
 }
 
@@ -1223,7 +1226,7 @@ export interface DescribeSSLPoliciesOutput extends $MetadataBearer {
 
 export namespace DescribeSSLPoliciesOutput {
   export function isa(o: any): o is DescribeSSLPoliciesOutput {
-    return _smithy.isa(o, "DescribeSSLPoliciesOutput");
+    return __isa(o, "DescribeSSLPoliciesOutput");
   }
 }
 
@@ -1237,7 +1240,7 @@ export interface DescribeTagsInput {
 
 export namespace DescribeTagsInput {
   export function isa(o: any): o is DescribeTagsInput {
-    return _smithy.isa(o, "DescribeTagsInput");
+    return __isa(o, "DescribeTagsInput");
   }
 }
 
@@ -1251,7 +1254,7 @@ export interface DescribeTagsOutput extends $MetadataBearer {
 
 export namespace DescribeTagsOutput {
   export function isa(o: any): o is DescribeTagsOutput {
-    return _smithy.isa(o, "DescribeTagsOutput");
+    return __isa(o, "DescribeTagsOutput");
   }
 }
 
@@ -1265,7 +1268,7 @@ export interface DescribeTargetGroupAttributesInput {
 
 export namespace DescribeTargetGroupAttributesInput {
   export function isa(o: any): o is DescribeTargetGroupAttributesInput {
-    return _smithy.isa(o, "DescribeTargetGroupAttributesInput");
+    return __isa(o, "DescribeTargetGroupAttributesInput");
   }
 }
 
@@ -1279,7 +1282,7 @@ export interface DescribeTargetGroupAttributesOutput extends $MetadataBearer {
 
 export namespace DescribeTargetGroupAttributesOutput {
   export function isa(o: any): o is DescribeTargetGroupAttributesOutput {
-    return _smithy.isa(o, "DescribeTargetGroupAttributesOutput");
+    return __isa(o, "DescribeTargetGroupAttributesOutput");
   }
 }
 
@@ -1314,7 +1317,7 @@ export interface DescribeTargetGroupsInput {
 
 export namespace DescribeTargetGroupsInput {
   export function isa(o: any): o is DescribeTargetGroupsInput {
-    return _smithy.isa(o, "DescribeTargetGroupsInput");
+    return __isa(o, "DescribeTargetGroupsInput");
   }
 }
 
@@ -1334,7 +1337,7 @@ export interface DescribeTargetGroupsOutput extends $MetadataBearer {
 
 export namespace DescribeTargetGroupsOutput {
   export function isa(o: any): o is DescribeTargetGroupsOutput {
-    return _smithy.isa(o, "DescribeTargetGroupsOutput");
+    return __isa(o, "DescribeTargetGroupsOutput");
   }
 }
 
@@ -1353,7 +1356,7 @@ export interface DescribeTargetHealthInput {
 
 export namespace DescribeTargetHealthInput {
   export function isa(o: any): o is DescribeTargetHealthInput {
-    return _smithy.isa(o, "DescribeTargetHealthInput");
+    return __isa(o, "DescribeTargetHealthInput");
   }
 }
 
@@ -1367,7 +1370,7 @@ export interface DescribeTargetHealthOutput extends $MetadataBearer {
 
 export namespace DescribeTargetHealthOutput {
   export function isa(o: any): o is DescribeTargetHealthOutput {
-    return _smithy.isa(o, "DescribeTargetHealthOutput");
+    return __isa(o, "DescribeTargetHealthOutput");
   }
 }
 
@@ -1375,7 +1378,7 @@ export namespace DescribeTargetHealthOutput {
  * <p>A listener with the specified port already exists.</p>
  */
 export interface DuplicateListenerException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DuplicateListenerException";
   $fault: "client";
@@ -1384,7 +1387,7 @@ export interface DuplicateListenerException
 
 export namespace DuplicateListenerException {
   export function isa(o: any): o is DuplicateListenerException {
-    return _smithy.isa(o, "DuplicateListenerException");
+    return __isa(o, "DuplicateListenerException");
   }
 }
 
@@ -1392,7 +1395,7 @@ export namespace DuplicateListenerException {
  * <p>A load balancer with the specified name already exists.</p>
  */
 export interface DuplicateLoadBalancerNameException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DuplicateLoadBalancerNameException";
   $fault: "client";
@@ -1401,7 +1404,7 @@ export interface DuplicateLoadBalancerNameException
 
 export namespace DuplicateLoadBalancerNameException {
   export function isa(o: any): o is DuplicateLoadBalancerNameException {
-    return _smithy.isa(o, "DuplicateLoadBalancerNameException");
+    return __isa(o, "DuplicateLoadBalancerNameException");
   }
 }
 
@@ -1409,7 +1412,7 @@ export namespace DuplicateLoadBalancerNameException {
  * <p>A tag key was specified more than once.</p>
  */
 export interface DuplicateTagKeysException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DuplicateTagKeysException";
   $fault: "client";
@@ -1418,7 +1421,7 @@ export interface DuplicateTagKeysException
 
 export namespace DuplicateTagKeysException {
   export function isa(o: any): o is DuplicateTagKeysException {
-    return _smithy.isa(o, "DuplicateTagKeysException");
+    return __isa(o, "DuplicateTagKeysException");
   }
 }
 
@@ -1426,7 +1429,7 @@ export namespace DuplicateTagKeysException {
  * <p>A target group with the specified name already exists.</p>
  */
 export interface DuplicateTargetGroupNameException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DuplicateTargetGroupNameException";
   $fault: "client";
@@ -1435,7 +1438,7 @@ export interface DuplicateTargetGroupNameException
 
 export namespace DuplicateTargetGroupNameException {
   export function isa(o: any): o is DuplicateTargetGroupNameException {
-    return _smithy.isa(o, "DuplicateTargetGroupNameException");
+    return __isa(o, "DuplicateTargetGroupNameException");
   }
 }
 
@@ -1463,7 +1466,7 @@ export interface FixedResponseActionConfig {
 
 export namespace FixedResponseActionConfig {
   export function isa(o: any): o is FixedResponseActionConfig {
-    return _smithy.isa(o, "FixedResponseActionConfig");
+    return __isa(o, "FixedResponseActionConfig");
   }
 }
 
@@ -1485,7 +1488,7 @@ export interface ForwardActionConfig {
 
 export namespace ForwardActionConfig {
   export function isa(o: any): o is ForwardActionConfig {
-    return _smithy.isa(o, "ForwardActionConfig");
+    return __isa(o, "ForwardActionConfig");
   }
 }
 
@@ -1494,7 +1497,7 @@ export namespace ForwardActionConfig {
  *       error.</p>
  */
 export interface HealthUnavailableException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "HealthUnavailableException";
   $fault: "server";
@@ -1503,7 +1506,7 @@ export interface HealthUnavailableException
 
 export namespace HealthUnavailableException {
   export function isa(o: any): o is HealthUnavailableException {
-    return _smithy.isa(o, "HealthUnavailableException");
+    return __isa(o, "HealthUnavailableException");
   }
 }
 
@@ -1524,7 +1527,7 @@ export interface HostHeaderConditionConfig {
 
 export namespace HostHeaderConditionConfig {
   export function isa(o: any): o is HostHeaderConditionConfig {
-    return _smithy.isa(o, "HostHeaderConditionConfig");
+    return __isa(o, "HostHeaderConditionConfig");
   }
 }
 
@@ -1555,7 +1558,7 @@ export interface HttpHeaderConditionConfig {
 
 export namespace HttpHeaderConditionConfig {
   export function isa(o: any): o is HttpHeaderConditionConfig {
-    return _smithy.isa(o, "HttpHeaderConditionConfig");
+    return __isa(o, "HttpHeaderConditionConfig");
   }
 }
 
@@ -1580,7 +1583,7 @@ export interface HttpRequestMethodConditionConfig {
 
 export namespace HttpRequestMethodConditionConfig {
   export function isa(o: any): o is HttpRequestMethodConditionConfig {
-    return _smithy.isa(o, "HttpRequestMethodConditionConfig");
+    return __isa(o, "HttpRequestMethodConditionConfig");
   }
 }
 
@@ -1588,7 +1591,7 @@ export namespace HttpRequestMethodConditionConfig {
  * <p>The specified configuration is not valid with this protocol.</p>
  */
 export interface IncompatibleProtocolsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "IncompatibleProtocolsException";
   $fault: "client";
@@ -1597,7 +1600,7 @@ export interface IncompatibleProtocolsException
 
 export namespace IncompatibleProtocolsException {
   export function isa(o: any): o is IncompatibleProtocolsException {
-    return _smithy.isa(o, "IncompatibleProtocolsException");
+    return __isa(o, "IncompatibleProtocolsException");
   }
 }
 
@@ -1605,7 +1608,7 @@ export namespace IncompatibleProtocolsException {
  * <p>The requested configuration is not valid.</p>
  */
 export interface InvalidConfigurationRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidConfigurationRequestException";
   $fault: "client";
@@ -1614,7 +1617,7 @@ export interface InvalidConfigurationRequestException
 
 export namespace InvalidConfigurationRequestException {
   export function isa(o: any): o is InvalidConfigurationRequestException {
-    return _smithy.isa(o, "InvalidConfigurationRequestException");
+    return __isa(o, "InvalidConfigurationRequestException");
   }
 }
 
@@ -1622,7 +1625,7 @@ export namespace InvalidConfigurationRequestException {
  * <p>The requested action is not valid.</p>
  */
 export interface InvalidLoadBalancerActionException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidLoadBalancerActionException";
   $fault: "client";
@@ -1631,7 +1634,7 @@ export interface InvalidLoadBalancerActionException
 
 export namespace InvalidLoadBalancerActionException {
   export function isa(o: any): o is InvalidLoadBalancerActionException {
-    return _smithy.isa(o, "InvalidLoadBalancerActionException");
+    return __isa(o, "InvalidLoadBalancerActionException");
   }
 }
 
@@ -1639,7 +1642,7 @@ export namespace InvalidLoadBalancerActionException {
  * <p>The requested scheme is not valid.</p>
  */
 export interface InvalidSchemeException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidSchemeException";
   $fault: "client";
@@ -1648,7 +1651,7 @@ export interface InvalidSchemeException
 
 export namespace InvalidSchemeException {
   export function isa(o: any): o is InvalidSchemeException {
-    return _smithy.isa(o, "InvalidSchemeException");
+    return __isa(o, "InvalidSchemeException");
   }
 }
 
@@ -1656,7 +1659,7 @@ export namespace InvalidSchemeException {
  * <p>The specified security group does not exist.</p>
  */
 export interface InvalidSecurityGroupException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidSecurityGroupException";
   $fault: "client";
@@ -1665,7 +1668,7 @@ export interface InvalidSecurityGroupException
 
 export namespace InvalidSecurityGroupException {
   export function isa(o: any): o is InvalidSecurityGroupException {
-    return _smithy.isa(o, "InvalidSecurityGroupException");
+    return __isa(o, "InvalidSecurityGroupException");
   }
 }
 
@@ -1673,7 +1676,7 @@ export namespace InvalidSecurityGroupException {
  * <p>The specified subnet is out of available addresses.</p>
  */
 export interface InvalidSubnetException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidSubnetException";
   $fault: "client";
@@ -1682,7 +1685,7 @@ export interface InvalidSubnetException
 
 export namespace InvalidSubnetException {
   export function isa(o: any): o is InvalidSubnetException {
-    return _smithy.isa(o, "InvalidSubnetException");
+    return __isa(o, "InvalidSubnetException");
   }
 }
 
@@ -1691,7 +1694,7 @@ export namespace InvalidSubnetException {
  *       an unsupported instance type.</p>
  */
 export interface InvalidTargetException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidTargetException";
   $fault: "client";
@@ -1700,7 +1703,7 @@ export interface InvalidTargetException
 
 export namespace InvalidTargetException {
   export function isa(o: any): o is InvalidTargetException {
-    return _smithy.isa(o, "InvalidTargetException");
+    return __isa(o, "InvalidTargetException");
   }
 }
 
@@ -1766,7 +1769,7 @@ export interface Limit {
 
 export namespace Limit {
   export function isa(o: any): o is Limit {
-    return _smithy.isa(o, "Limit");
+    return __isa(o, "Limit");
   }
 }
 
@@ -1814,7 +1817,7 @@ export interface Listener {
 
 export namespace Listener {
   export function isa(o: any): o is Listener {
-    return _smithy.isa(o, "Listener");
+    return __isa(o, "Listener");
   }
 }
 
@@ -1822,7 +1825,7 @@ export namespace Listener {
  * <p>The specified listener does not exist.</p>
  */
 export interface ListenerNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ListenerNotFoundException";
   $fault: "client";
@@ -1831,7 +1834,7 @@ export interface ListenerNotFoundException
 
 export namespace ListenerNotFoundException {
   export function isa(o: any): o is ListenerNotFoundException {
-    return _smithy.isa(o, "ListenerNotFoundException");
+    return __isa(o, "ListenerNotFoundException");
   }
 }
 
@@ -1912,7 +1915,7 @@ export interface LoadBalancer {
 
 export namespace LoadBalancer {
   export function isa(o: any): o is LoadBalancer {
-    return _smithy.isa(o, "LoadBalancer");
+    return __isa(o, "LoadBalancer");
   }
 }
 
@@ -1939,7 +1942,7 @@ export interface LoadBalancerAddress {
 
 export namespace LoadBalancerAddress {
   export function isa(o: any): o is LoadBalancerAddress {
-    return _smithy.isa(o, "LoadBalancerAddress");
+    return __isa(o, "LoadBalancerAddress");
   }
 }
 
@@ -2012,7 +2015,7 @@ export interface LoadBalancerAttribute {
 
 export namespace LoadBalancerAttribute {
   export function isa(o: any): o is LoadBalancerAttribute {
-    return _smithy.isa(o, "LoadBalancerAttribute");
+    return __isa(o, "LoadBalancerAttribute");
   }
 }
 
@@ -2020,7 +2023,7 @@ export namespace LoadBalancerAttribute {
  * <p>The specified load balancer does not exist.</p>
  */
 export interface LoadBalancerNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LoadBalancerNotFoundException";
   $fault: "client";
@@ -2029,7 +2032,7 @@ export interface LoadBalancerNotFoundException
 
 export namespace LoadBalancerNotFoundException {
   export function isa(o: any): o is LoadBalancerNotFoundException {
-    return _smithy.isa(o, "LoadBalancerNotFoundException");
+    return __isa(o, "LoadBalancerNotFoundException");
   }
 }
 
@@ -2059,7 +2062,7 @@ export interface LoadBalancerState {
 
 export namespace LoadBalancerState {
   export function isa(o: any): o is LoadBalancerState {
-    return _smithy.isa(o, "LoadBalancerState");
+    return __isa(o, "LoadBalancerState");
   }
 }
 
@@ -2092,7 +2095,7 @@ export interface Matcher {
 
 export namespace Matcher {
   export function isa(o: any): o is Matcher {
-    return _smithy.isa(o, "Matcher");
+    return __isa(o, "Matcher");
   }
 }
 
@@ -2148,7 +2151,7 @@ export interface ModifyListenerInput {
 
 export namespace ModifyListenerInput {
   export function isa(o: any): o is ModifyListenerInput {
-    return _smithy.isa(o, "ModifyListenerInput");
+    return __isa(o, "ModifyListenerInput");
   }
 }
 
@@ -2162,7 +2165,7 @@ export interface ModifyListenerOutput extends $MetadataBearer {
 
 export namespace ModifyListenerOutput {
   export function isa(o: any): o is ModifyListenerOutput {
-    return _smithy.isa(o, "ModifyListenerOutput");
+    return __isa(o, "ModifyListenerOutput");
   }
 }
 
@@ -2181,7 +2184,7 @@ export interface ModifyLoadBalancerAttributesInput {
 
 export namespace ModifyLoadBalancerAttributesInput {
   export function isa(o: any): o is ModifyLoadBalancerAttributesInput {
-    return _smithy.isa(o, "ModifyLoadBalancerAttributesInput");
+    return __isa(o, "ModifyLoadBalancerAttributesInput");
   }
 }
 
@@ -2195,7 +2198,7 @@ export interface ModifyLoadBalancerAttributesOutput extends $MetadataBearer {
 
 export namespace ModifyLoadBalancerAttributesOutput {
   export function isa(o: any): o is ModifyLoadBalancerAttributesOutput {
-    return _smithy.isa(o, "ModifyLoadBalancerAttributesOutput");
+    return __isa(o, "ModifyLoadBalancerAttributesOutput");
   }
 }
 
@@ -2235,7 +2238,7 @@ export interface ModifyRuleInput {
 
 export namespace ModifyRuleInput {
   export function isa(o: any): o is ModifyRuleInput {
-    return _smithy.isa(o, "ModifyRuleInput");
+    return __isa(o, "ModifyRuleInput");
   }
 }
 
@@ -2249,7 +2252,7 @@ export interface ModifyRuleOutput extends $MetadataBearer {
 
 export namespace ModifyRuleOutput {
   export function isa(o: any): o is ModifyRuleOutput {
-    return _smithy.isa(o, "ModifyRuleOutput");
+    return __isa(o, "ModifyRuleOutput");
   }
 }
 
@@ -2268,7 +2271,7 @@ export interface ModifyTargetGroupAttributesInput {
 
 export namespace ModifyTargetGroupAttributesInput {
   export function isa(o: any): o is ModifyTargetGroupAttributesInput {
-    return _smithy.isa(o, "ModifyTargetGroupAttributesInput");
+    return __isa(o, "ModifyTargetGroupAttributesInput");
   }
 }
 
@@ -2282,7 +2285,7 @@ export interface ModifyTargetGroupAttributesOutput extends $MetadataBearer {
 
 export namespace ModifyTargetGroupAttributesOutput {
   export function isa(o: any): o is ModifyTargetGroupAttributesOutput {
-    return _smithy.isa(o, "ModifyTargetGroupAttributesOutput");
+    return __isa(o, "ModifyTargetGroupAttributesOutput");
   }
 }
 
@@ -2355,7 +2358,7 @@ export interface ModifyTargetGroupInput {
 
 export namespace ModifyTargetGroupInput {
   export function isa(o: any): o is ModifyTargetGroupInput {
-    return _smithy.isa(o, "ModifyTargetGroupInput");
+    return __isa(o, "ModifyTargetGroupInput");
   }
 }
 
@@ -2369,7 +2372,7 @@ export interface ModifyTargetGroupOutput extends $MetadataBearer {
 
 export namespace ModifyTargetGroupOutput {
   export function isa(o: any): o is ModifyTargetGroupOutput {
-    return _smithy.isa(o, "ModifyTargetGroupOutput");
+    return __isa(o, "ModifyTargetGroupOutput");
   }
 }
 
@@ -2377,7 +2380,7 @@ export namespace ModifyTargetGroupOutput {
  * <p>This operation is not allowed.</p>
  */
 export interface OperationNotPermittedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "OperationNotPermittedException";
   $fault: "client";
@@ -2386,7 +2389,7 @@ export interface OperationNotPermittedException
 
 export namespace OperationNotPermittedException {
   export function isa(o: any): o is OperationNotPermittedException {
-    return _smithy.isa(o, "OperationNotPermittedException");
+    return __isa(o, "OperationNotPermittedException");
   }
 }
 
@@ -2409,7 +2412,7 @@ export interface PathPatternConditionConfig {
 
 export namespace PathPatternConditionConfig {
   export function isa(o: any): o is PathPatternConditionConfig {
-    return _smithy.isa(o, "PathPatternConditionConfig");
+    return __isa(o, "PathPatternConditionConfig");
   }
 }
 
@@ -2417,7 +2420,7 @@ export namespace PathPatternConditionConfig {
  * <p>The specified priority is in use.</p>
  */
 export interface PriorityInUseException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "PriorityInUseException";
   $fault: "client";
@@ -2426,7 +2429,7 @@ export interface PriorityInUseException
 
 export namespace PriorityInUseException {
   export function isa(o: any): o is PriorityInUseException {
-    return _smithy.isa(o, "PriorityInUseException");
+    return __isa(o, "PriorityInUseException");
   }
 }
 
@@ -2455,7 +2458,7 @@ export interface QueryStringConditionConfig {
 
 export namespace QueryStringConditionConfig {
   export function isa(o: any): o is QueryStringConditionConfig {
-    return _smithy.isa(o, "QueryStringConditionConfig");
+    return __isa(o, "QueryStringConditionConfig");
   }
 }
 
@@ -2477,7 +2480,7 @@ export interface QueryStringKeyValuePair {
 
 export namespace QueryStringKeyValuePair {
   export function isa(o: any): o is QueryStringKeyValuePair {
-    return _smithy.isa(o, "QueryStringKeyValuePair");
+    return __isa(o, "QueryStringKeyValuePair");
   }
 }
 
@@ -2546,7 +2549,7 @@ export interface RedirectActionConfig {
 
 export namespace RedirectActionConfig {
   export function isa(o: any): o is RedirectActionConfig {
-    return _smithy.isa(o, "RedirectActionConfig");
+    return __isa(o, "RedirectActionConfig");
   }
 }
 
@@ -2573,7 +2576,7 @@ export interface RegisterTargetsInput {
 
 export namespace RegisterTargetsInput {
   export function isa(o: any): o is RegisterTargetsInput {
-    return _smithy.isa(o, "RegisterTargetsInput");
+    return __isa(o, "RegisterTargetsInput");
   }
 }
 
@@ -2583,7 +2586,7 @@ export interface RegisterTargetsOutput extends $MetadataBearer {
 
 export namespace RegisterTargetsOutput {
   export function isa(o: any): o is RegisterTargetsOutput {
-    return _smithy.isa(o, "RegisterTargetsOutput");
+    return __isa(o, "RegisterTargetsOutput");
   }
 }
 
@@ -2603,7 +2606,7 @@ export interface RemoveListenerCertificatesInput {
 
 export namespace RemoveListenerCertificatesInput {
   export function isa(o: any): o is RemoveListenerCertificatesInput {
-    return _smithy.isa(o, "RemoveListenerCertificatesInput");
+    return __isa(o, "RemoveListenerCertificatesInput");
   }
 }
 
@@ -2613,7 +2616,7 @@ export interface RemoveListenerCertificatesOutput extends $MetadataBearer {
 
 export namespace RemoveListenerCertificatesOutput {
   export function isa(o: any): o is RemoveListenerCertificatesOutput {
-    return _smithy.isa(o, "RemoveListenerCertificatesOutput");
+    return __isa(o, "RemoveListenerCertificatesOutput");
   }
 }
 
@@ -2632,7 +2635,7 @@ export interface RemoveTagsInput {
 
 export namespace RemoveTagsInput {
   export function isa(o: any): o is RemoveTagsInput {
-    return _smithy.isa(o, "RemoveTagsInput");
+    return __isa(o, "RemoveTagsInput");
   }
 }
 
@@ -2642,7 +2645,7 @@ export interface RemoveTagsOutput extends $MetadataBearer {
 
 export namespace RemoveTagsOutput {
   export function isa(o: any): o is RemoveTagsOutput {
-    return _smithy.isa(o, "RemoveTagsOutput");
+    return __isa(o, "RemoveTagsOutput");
   }
 }
 
@@ -2650,7 +2653,7 @@ export namespace RemoveTagsOutput {
  * <p>A specified resource is in use.</p>
  */
 export interface ResourceInUseException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceInUseException";
   $fault: "client";
@@ -2659,7 +2662,7 @@ export interface ResourceInUseException
 
 export namespace ResourceInUseException {
   export function isa(o: any): o is ResourceInUseException {
-    return _smithy.isa(o, "ResourceInUseException");
+    return __isa(o, "ResourceInUseException");
   }
 }
 
@@ -2700,7 +2703,7 @@ export interface Rule {
 
 export namespace Rule {
   export function isa(o: any): o is Rule {
-    return _smithy.isa(o, "Rule");
+    return __isa(o, "Rule");
   }
 }
 
@@ -2830,7 +2833,7 @@ export interface RuleCondition {
 
 export namespace RuleCondition {
   export function isa(o: any): o is RuleCondition {
-    return _smithy.isa(o, "RuleCondition");
+    return __isa(o, "RuleCondition");
   }
 }
 
@@ -2838,7 +2841,7 @@ export namespace RuleCondition {
  * <p>The specified rule does not exist.</p>
  */
 export interface RuleNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "RuleNotFoundException";
   $fault: "client";
@@ -2847,7 +2850,7 @@ export interface RuleNotFoundException
 
 export namespace RuleNotFoundException {
   export function isa(o: any): o is RuleNotFoundException {
-    return _smithy.isa(o, "RuleNotFoundException");
+    return __isa(o, "RuleNotFoundException");
   }
 }
 
@@ -2869,7 +2872,7 @@ export interface RulePriorityPair {
 
 export namespace RulePriorityPair {
   export function isa(o: any): o is RulePriorityPair {
-    return _smithy.isa(o, "RulePriorityPair");
+    return __isa(o, "RulePriorityPair");
   }
 }
 
@@ -2877,7 +2880,7 @@ export namespace RulePriorityPair {
  * <p>The specified SSL policy does not exist.</p>
  */
 export interface SSLPolicyNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "SSLPolicyNotFoundException";
   $fault: "client";
@@ -2886,7 +2889,7 @@ export interface SSLPolicyNotFoundException
 
 export namespace SSLPolicyNotFoundException {
   export function isa(o: any): o is SSLPolicyNotFoundException {
-    return _smithy.isa(o, "SSLPolicyNotFoundException");
+    return __isa(o, "SSLPolicyNotFoundException");
   }
 }
 
@@ -2907,7 +2910,7 @@ export interface SetIpAddressTypeInput {
 
 export namespace SetIpAddressTypeInput {
   export function isa(o: any): o is SetIpAddressTypeInput {
-    return _smithy.isa(o, "SetIpAddressTypeInput");
+    return __isa(o, "SetIpAddressTypeInput");
   }
 }
 
@@ -2921,7 +2924,7 @@ export interface SetIpAddressTypeOutput extends $MetadataBearer {
 
 export namespace SetIpAddressTypeOutput {
   export function isa(o: any): o is SetIpAddressTypeOutput {
-    return _smithy.isa(o, "SetIpAddressTypeOutput");
+    return __isa(o, "SetIpAddressTypeOutput");
   }
 }
 
@@ -2935,7 +2938,7 @@ export interface SetRulePrioritiesInput {
 
 export namespace SetRulePrioritiesInput {
   export function isa(o: any): o is SetRulePrioritiesInput {
-    return _smithy.isa(o, "SetRulePrioritiesInput");
+    return __isa(o, "SetRulePrioritiesInput");
   }
 }
 
@@ -2949,7 +2952,7 @@ export interface SetRulePrioritiesOutput extends $MetadataBearer {
 
 export namespace SetRulePrioritiesOutput {
   export function isa(o: any): o is SetRulePrioritiesOutput {
-    return _smithy.isa(o, "SetRulePrioritiesOutput");
+    return __isa(o, "SetRulePrioritiesOutput");
   }
 }
 
@@ -2968,7 +2971,7 @@ export interface SetSecurityGroupsInput {
 
 export namespace SetSecurityGroupsInput {
   export function isa(o: any): o is SetSecurityGroupsInput {
-    return _smithy.isa(o, "SetSecurityGroupsInput");
+    return __isa(o, "SetSecurityGroupsInput");
   }
 }
 
@@ -2982,7 +2985,7 @@ export interface SetSecurityGroupsOutput extends $MetadataBearer {
 
 export namespace SetSecurityGroupsOutput {
   export function isa(o: any): o is SetSecurityGroupsOutput {
-    return _smithy.isa(o, "SetSecurityGroupsOutput");
+    return __isa(o, "SetSecurityGroupsOutput");
   }
 }
 
@@ -3015,7 +3018,7 @@ export interface SetSubnetsInput {
 
 export namespace SetSubnetsInput {
   export function isa(o: any): o is SetSubnetsInput {
-    return _smithy.isa(o, "SetSubnetsInput");
+    return __isa(o, "SetSubnetsInput");
   }
 }
 
@@ -3029,7 +3032,7 @@ export interface SetSubnetsOutput extends $MetadataBearer {
 
 export namespace SetSubnetsOutput {
   export function isa(o: any): o is SetSubnetsOutput {
-    return _smithy.isa(o, "SetSubnetsOutput");
+    return __isa(o, "SetSubnetsOutput");
   }
 }
 
@@ -3053,7 +3056,7 @@ export interface SourceIpConditionConfig {
 
 export namespace SourceIpConditionConfig {
   export function isa(o: any): o is SourceIpConditionConfig {
-    return _smithy.isa(o, "SourceIpConditionConfig");
+    return __isa(o, "SourceIpConditionConfig");
   }
 }
 
@@ -3080,7 +3083,7 @@ export interface SslPolicy {
 
 export namespace SslPolicy {
   export function isa(o: any): o is SslPolicy {
-    return _smithy.isa(o, "SslPolicy");
+    return __isa(o, "SslPolicy");
   }
 }
 
@@ -3107,7 +3110,7 @@ export interface SubnetMapping {
 
 export namespace SubnetMapping {
   export function isa(o: any): o is SubnetMapping {
-    return _smithy.isa(o, "SubnetMapping");
+    return __isa(o, "SubnetMapping");
   }
 }
 
@@ -3115,7 +3118,7 @@ export namespace SubnetMapping {
  * <p>The specified subnet does not exist.</p>
  */
 export interface SubnetNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "SubnetNotFoundException";
   $fault: "client";
@@ -3124,7 +3127,7 @@ export interface SubnetNotFoundException
 
 export namespace SubnetNotFoundException {
   export function isa(o: any): o is SubnetNotFoundException {
-    return _smithy.isa(o, "SubnetNotFoundException");
+    return __isa(o, "SubnetNotFoundException");
   }
 }
 
@@ -3146,7 +3149,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -3168,7 +3171,7 @@ export interface TagDescription {
 
 export namespace TagDescription {
   export function isa(o: any): o is TagDescription {
-    return _smithy.isa(o, "TagDescription");
+    return __isa(o, "TagDescription");
   }
 }
 
@@ -3206,7 +3209,7 @@ export interface TargetDescription {
 
 export namespace TargetDescription {
   export function isa(o: any): o is TargetDescription {
-    return _smithy.isa(o, "TargetDescription");
+    return __isa(o, "TargetDescription");
   }
 }
 
@@ -3305,7 +3308,7 @@ export interface TargetGroup {
 
 export namespace TargetGroup {
   export function isa(o: any): o is TargetGroup {
-    return _smithy.isa(o, "TargetGroup");
+    return __isa(o, "TargetGroup");
   }
 }
 
@@ -3313,7 +3316,7 @@ export namespace TargetGroup {
  * <p>You've reached the limit on the number of load balancers per target group.</p>
  */
 export interface TargetGroupAssociationLimitException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TargetGroupAssociationLimitException";
   $fault: "client";
@@ -3322,7 +3325,7 @@ export interface TargetGroupAssociationLimitException
 
 export namespace TargetGroupAssociationLimitException {
   export function isa(o: any): o is TargetGroupAssociationLimitException {
-    return _smithy.isa(o, "TargetGroupAssociationLimitException");
+    return __isa(o, "TargetGroupAssociationLimitException");
   }
 }
 
@@ -3412,7 +3415,7 @@ export interface TargetGroupAttribute {
 
 export namespace TargetGroupAttribute {
   export function isa(o: any): o is TargetGroupAttribute {
-    return _smithy.isa(o, "TargetGroupAttribute");
+    return __isa(o, "TargetGroupAttribute");
   }
 }
 
@@ -3420,7 +3423,7 @@ export namespace TargetGroupAttribute {
  * <p>The specified target group does not exist.</p>
  */
 export interface TargetGroupNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TargetGroupNotFoundException";
   $fault: "client";
@@ -3429,7 +3432,7 @@ export interface TargetGroupNotFoundException
 
 export namespace TargetGroupNotFoundException {
   export function isa(o: any): o is TargetGroupNotFoundException {
-    return _smithy.isa(o, "TargetGroupNotFoundException");
+    return __isa(o, "TargetGroupNotFoundException");
   }
 }
 
@@ -3452,7 +3455,7 @@ export interface TargetGroupStickinessConfig {
 
 export namespace TargetGroupStickinessConfig {
   export function isa(o: any): o is TargetGroupStickinessConfig {
-    return _smithy.isa(o, "TargetGroupStickinessConfig");
+    return __isa(o, "TargetGroupStickinessConfig");
   }
 }
 
@@ -3474,7 +3477,7 @@ export interface TargetGroupTuple {
 
 export namespace TargetGroupTuple {
   export function isa(o: any): o is TargetGroupTuple {
-    return _smithy.isa(o, "TargetGroupTuple");
+    return __isa(o, "TargetGroupTuple");
   }
 }
 
@@ -3588,7 +3591,7 @@ export interface TargetHealth {
 
 export namespace TargetHealth {
   export function isa(o: any): o is TargetHealth {
-    return _smithy.isa(o, "TargetHealth");
+    return __isa(o, "TargetHealth");
   }
 }
 
@@ -3615,7 +3618,7 @@ export interface TargetHealthDescription {
 
 export namespace TargetHealthDescription {
   export function isa(o: any): o is TargetHealthDescription {
-    return _smithy.isa(o, "TargetHealthDescription");
+    return __isa(o, "TargetHealthDescription");
   }
 }
 
@@ -3653,7 +3656,7 @@ export enum TargetTypeEnum {
  * <p>You've reached the limit on the number of actions per rule.</p>
  */
 export interface TooManyActionsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyActionsException";
   $fault: "client";
@@ -3662,7 +3665,7 @@ export interface TooManyActionsException
 
 export namespace TooManyActionsException {
   export function isa(o: any): o is TooManyActionsException {
-    return _smithy.isa(o, "TooManyActionsException");
+    return __isa(o, "TooManyActionsException");
   }
 }
 
@@ -3670,7 +3673,7 @@ export namespace TooManyActionsException {
  * <p>You've reached the limit on the number of certificates per load balancer.</p>
  */
 export interface TooManyCertificatesException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyCertificatesException";
   $fault: "client";
@@ -3679,7 +3682,7 @@ export interface TooManyCertificatesException
 
 export namespace TooManyCertificatesException {
   export function isa(o: any): o is TooManyCertificatesException {
-    return _smithy.isa(o, "TooManyCertificatesException");
+    return __isa(o, "TooManyCertificatesException");
   }
 }
 
@@ -3687,7 +3690,7 @@ export namespace TooManyCertificatesException {
  * <p>You've reached the limit on the number of listeners per load balancer.</p>
  */
 export interface TooManyListenersException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyListenersException";
   $fault: "client";
@@ -3696,7 +3699,7 @@ export interface TooManyListenersException
 
 export namespace TooManyListenersException {
   export function isa(o: any): o is TooManyListenersException {
-    return _smithy.isa(o, "TooManyListenersException");
+    return __isa(o, "TooManyListenersException");
   }
 }
 
@@ -3705,7 +3708,7 @@ export namespace TooManyListenersException {
  *       account.</p>
  */
 export interface TooManyLoadBalancersException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyLoadBalancersException";
   $fault: "client";
@@ -3714,7 +3717,7 @@ export interface TooManyLoadBalancersException
 
 export namespace TooManyLoadBalancersException {
   export function isa(o: any): o is TooManyLoadBalancersException {
-    return _smithy.isa(o, "TooManyLoadBalancersException");
+    return __isa(o, "TooManyLoadBalancersException");
   }
 }
 
@@ -3723,7 +3726,7 @@ export namespace TooManyLoadBalancersException {
  *       balancer.</p>
  */
 export interface TooManyRegistrationsForTargetIdException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyRegistrationsForTargetIdException";
   $fault: "client";
@@ -3732,7 +3735,7 @@ export interface TooManyRegistrationsForTargetIdException
 
 export namespace TooManyRegistrationsForTargetIdException {
   export function isa(o: any): o is TooManyRegistrationsForTargetIdException {
-    return _smithy.isa(o, "TooManyRegistrationsForTargetIdException");
+    return __isa(o, "TooManyRegistrationsForTargetIdException");
   }
 }
 
@@ -3740,7 +3743,7 @@ export namespace TooManyRegistrationsForTargetIdException {
  * <p>You've reached the limit on the number of rules per load balancer.</p>
  */
 export interface TooManyRulesException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyRulesException";
   $fault: "client";
@@ -3749,7 +3752,7 @@ export interface TooManyRulesException
 
 export namespace TooManyRulesException {
   export function isa(o: any): o is TooManyRulesException {
-    return _smithy.isa(o, "TooManyRulesException");
+    return __isa(o, "TooManyRulesException");
   }
 }
 
@@ -3757,7 +3760,7 @@ export namespace TooManyRulesException {
  * <p>You've reached the limit on the number of tags per load balancer.</p>
  */
 export interface TooManyTagsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyTagsException";
   $fault: "client";
@@ -3766,7 +3769,7 @@ export interface TooManyTagsException
 
 export namespace TooManyTagsException {
   export function isa(o: any): o is TooManyTagsException {
-    return _smithy.isa(o, "TooManyTagsException");
+    return __isa(o, "TooManyTagsException");
   }
 }
 
@@ -3774,7 +3777,7 @@ export namespace TooManyTagsException {
  * <p>You've reached the limit on the number of target groups for your AWS account.</p>
  */
 export interface TooManyTargetGroupsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyTargetGroupsException";
   $fault: "client";
@@ -3783,7 +3786,7 @@ export interface TooManyTargetGroupsException
 
 export namespace TooManyTargetGroupsException {
   export function isa(o: any): o is TooManyTargetGroupsException {
-    return _smithy.isa(o, "TooManyTargetGroupsException");
+    return __isa(o, "TooManyTargetGroupsException");
   }
 }
 
@@ -3791,7 +3794,7 @@ export namespace TooManyTargetGroupsException {
  * <p>You've reached the limit on the number of targets.</p>
  */
 export interface TooManyTargetsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyTargetsException";
   $fault: "client";
@@ -3800,7 +3803,7 @@ export interface TooManyTargetsException
 
 export namespace TooManyTargetsException {
   export function isa(o: any): o is TooManyTargetsException {
-    return _smithy.isa(o, "TooManyTargetsException");
+    return __isa(o, "TooManyTargetsException");
   }
 }
 
@@ -3810,7 +3813,7 @@ export namespace TooManyTargetsException {
  *         it is counted as only one use.</p>
  */
 export interface TooManyUniqueTargetGroupsPerLoadBalancerException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyUniqueTargetGroupsPerLoadBalancerException";
   $fault: "client";
@@ -3821,7 +3824,7 @@ export namespace TooManyUniqueTargetGroupsPerLoadBalancerException {
   export function isa(
     o: any
   ): o is TooManyUniqueTargetGroupsPerLoadBalancerException {
-    return _smithy.isa(o, "TooManyUniqueTargetGroupsPerLoadBalancerException");
+    return __isa(o, "TooManyUniqueTargetGroupsPerLoadBalancerException");
   }
 }
 
@@ -3829,7 +3832,7 @@ export namespace TooManyUniqueTargetGroupsPerLoadBalancerException {
  * <p>The specified protocol is not supported.</p>
  */
 export interface UnsupportedProtocolException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UnsupportedProtocolException";
   $fault: "client";
@@ -3838,6 +3841,6 @@ export interface UnsupportedProtocolException
 
 export namespace UnsupportedProtocolException {
   export function isa(o: any): o is UnsupportedProtocolException {
-    return _smithy.isa(o, "UnsupportedProtocolException");
+    return __isa(o, "UnsupportedProtocolException");
   }
 }

--- a/clients/client-elastic-load-balancing/models/index.ts
+++ b/clients/client-elastic-load-balancing/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -31,7 +34,7 @@ export interface AccessLog {
 
 export namespace AccessLog {
   export function isa(o: any): o is AccessLog {
-    return _smithy.isa(o, "AccessLog");
+    return __isa(o, "AccessLog");
   }
 }
 
@@ -39,7 +42,7 @@ export namespace AccessLog {
  * <p>The specified load balancer does not exist.</p>
  */
 export interface AccessPointNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AccessPointNotFoundException";
   $fault: "client";
@@ -48,7 +51,7 @@ export interface AccessPointNotFoundException
 
 export namespace AccessPointNotFoundException {
   export function isa(o: any): o is AccessPointNotFoundException {
-    return _smithy.isa(o, "AccessPointNotFoundException");
+    return __isa(o, "AccessPointNotFoundException");
   }
 }
 
@@ -70,7 +73,7 @@ export interface AddAvailabilityZonesInput {
 
 export namespace AddAvailabilityZonesInput {
   export function isa(o: any): o is AddAvailabilityZonesInput {
-    return _smithy.isa(o, "AddAvailabilityZonesInput");
+    return __isa(o, "AddAvailabilityZonesInput");
   }
 }
 
@@ -87,7 +90,7 @@ export interface AddAvailabilityZonesOutput extends $MetadataBearer {
 
 export namespace AddAvailabilityZonesOutput {
   export function isa(o: any): o is AddAvailabilityZonesOutput {
-    return _smithy.isa(o, "AddAvailabilityZonesOutput");
+    return __isa(o, "AddAvailabilityZonesOutput");
   }
 }
 
@@ -109,7 +112,7 @@ export interface AddTagsInput {
 
 export namespace AddTagsInput {
   export function isa(o: any): o is AddTagsInput {
-    return _smithy.isa(o, "AddTagsInput");
+    return __isa(o, "AddTagsInput");
   }
 }
 
@@ -122,7 +125,7 @@ export interface AddTagsOutput extends $MetadataBearer {
 
 export namespace AddTagsOutput {
   export function isa(o: any): o is AddTagsOutput {
-    return _smithy.isa(o, "AddTagsOutput");
+    return __isa(o, "AddTagsOutput");
   }
 }
 
@@ -144,7 +147,7 @@ export interface AdditionalAttribute {
 
 export namespace AdditionalAttribute {
   export function isa(o: any): o is AdditionalAttribute {
-    return _smithy.isa(o, "AdditionalAttribute");
+    return __isa(o, "AdditionalAttribute");
   }
 }
 
@@ -166,7 +169,7 @@ export interface AppCookieStickinessPolicy {
 
 export namespace AppCookieStickinessPolicy {
   export function isa(o: any): o is AppCookieStickinessPolicy {
-    return _smithy.isa(o, "AppCookieStickinessPolicy");
+    return __isa(o, "AppCookieStickinessPolicy");
   }
 }
 
@@ -188,7 +191,7 @@ export interface ApplySecurityGroupsToLoadBalancerInput {
 
 export namespace ApplySecurityGroupsToLoadBalancerInput {
   export function isa(o: any): o is ApplySecurityGroupsToLoadBalancerInput {
-    return _smithy.isa(o, "ApplySecurityGroupsToLoadBalancerInput");
+    return __isa(o, "ApplySecurityGroupsToLoadBalancerInput");
   }
 }
 
@@ -206,7 +209,7 @@ export interface ApplySecurityGroupsToLoadBalancerOutput
 
 export namespace ApplySecurityGroupsToLoadBalancerOutput {
   export function isa(o: any): o is ApplySecurityGroupsToLoadBalancerOutput {
-    return _smithy.isa(o, "ApplySecurityGroupsToLoadBalancerOutput");
+    return __isa(o, "ApplySecurityGroupsToLoadBalancerOutput");
   }
 }
 
@@ -228,7 +231,7 @@ export interface AttachLoadBalancerToSubnetsInput {
 
 export namespace AttachLoadBalancerToSubnetsInput {
   export function isa(o: any): o is AttachLoadBalancerToSubnetsInput {
-    return _smithy.isa(o, "AttachLoadBalancerToSubnetsInput");
+    return __isa(o, "AttachLoadBalancerToSubnetsInput");
   }
 }
 
@@ -245,7 +248,7 @@ export interface AttachLoadBalancerToSubnetsOutput extends $MetadataBearer {
 
 export namespace AttachLoadBalancerToSubnetsOutput {
   export function isa(o: any): o is AttachLoadBalancerToSubnetsOutput {
-    return _smithy.isa(o, "AttachLoadBalancerToSubnetsOutput");
+    return __isa(o, "AttachLoadBalancerToSubnetsOutput");
   }
 }
 
@@ -267,7 +270,7 @@ export interface BackendServerDescription {
 
 export namespace BackendServerDescription {
   export function isa(o: any): o is BackendServerDescription {
-    return _smithy.isa(o, "BackendServerDescription");
+    return __isa(o, "BackendServerDescription");
   }
 }
 
@@ -277,7 +280,7 @@ export namespace BackendServerDescription {
  *             indicate that the certificate is not fully available yet.</p>
  */
 export interface CertificateNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CertificateNotFoundException";
   $fault: "client";
@@ -286,7 +289,7 @@ export interface CertificateNotFoundException
 
 export namespace CertificateNotFoundException {
   export function isa(o: any): o is CertificateNotFoundException {
-    return _smithy.isa(o, "CertificateNotFoundException");
+    return __isa(o, "CertificateNotFoundException");
   }
 }
 
@@ -308,7 +311,7 @@ export interface ConfigureHealthCheckInput {
 
 export namespace ConfigureHealthCheckInput {
   export function isa(o: any): o is ConfigureHealthCheckInput {
-    return _smithy.isa(o, "ConfigureHealthCheckInput");
+    return __isa(o, "ConfigureHealthCheckInput");
   }
 }
 
@@ -325,7 +328,7 @@ export interface ConfigureHealthCheckOutput extends $MetadataBearer {
 
 export namespace ConfigureHealthCheckOutput {
   export function isa(o: any): o is ConfigureHealthCheckOutput {
-    return _smithy.isa(o, "ConfigureHealthCheckOutput");
+    return __isa(o, "ConfigureHealthCheckOutput");
   }
 }
 
@@ -347,7 +350,7 @@ export interface ConnectionDraining {
 
 export namespace ConnectionDraining {
   export function isa(o: any): o is ConnectionDraining {
-    return _smithy.isa(o, "ConnectionDraining");
+    return __isa(o, "ConnectionDraining");
   }
 }
 
@@ -364,7 +367,7 @@ export interface ConnectionSettings {
 
 export namespace ConnectionSettings {
   export function isa(o: any): o is ConnectionSettings {
-    return _smithy.isa(o, "ConnectionSettings");
+    return __isa(o, "ConnectionSettings");
   }
 }
 
@@ -424,7 +427,7 @@ export interface CreateAccessPointInput {
 
 export namespace CreateAccessPointInput {
   export function isa(o: any): o is CreateAccessPointInput {
-    return _smithy.isa(o, "CreateAccessPointInput");
+    return __isa(o, "CreateAccessPointInput");
   }
 }
 
@@ -441,7 +444,7 @@ export interface CreateAccessPointOutput extends $MetadataBearer {
 
 export namespace CreateAccessPointOutput {
   export function isa(o: any): o is CreateAccessPointOutput {
-    return _smithy.isa(o, "CreateAccessPointOutput");
+    return __isa(o, "CreateAccessPointOutput");
   }
 }
 
@@ -468,7 +471,7 @@ export interface CreateAppCookieStickinessPolicyInput {
 
 export namespace CreateAppCookieStickinessPolicyInput {
   export function isa(o: any): o is CreateAppCookieStickinessPolicyInput {
-    return _smithy.isa(o, "CreateAppCookieStickinessPolicyInput");
+    return __isa(o, "CreateAppCookieStickinessPolicyInput");
   }
 }
 
@@ -481,7 +484,7 @@ export interface CreateAppCookieStickinessPolicyOutput extends $MetadataBearer {
 
 export namespace CreateAppCookieStickinessPolicyOutput {
   export function isa(o: any): o is CreateAppCookieStickinessPolicyOutput {
-    return _smithy.isa(o, "CreateAppCookieStickinessPolicyOutput");
+    return __isa(o, "CreateAppCookieStickinessPolicyOutput");
   }
 }
 
@@ -508,7 +511,7 @@ export interface CreateLBCookieStickinessPolicyInput {
 
 export namespace CreateLBCookieStickinessPolicyInput {
   export function isa(o: any): o is CreateLBCookieStickinessPolicyInput {
-    return _smithy.isa(o, "CreateLBCookieStickinessPolicyInput");
+    return __isa(o, "CreateLBCookieStickinessPolicyInput");
   }
 }
 
@@ -521,7 +524,7 @@ export interface CreateLBCookieStickinessPolicyOutput extends $MetadataBearer {
 
 export namespace CreateLBCookieStickinessPolicyOutput {
   export function isa(o: any): o is CreateLBCookieStickinessPolicyOutput {
-    return _smithy.isa(o, "CreateLBCookieStickinessPolicyOutput");
+    return __isa(o, "CreateLBCookieStickinessPolicyOutput");
   }
 }
 
@@ -543,7 +546,7 @@ export interface CreateLoadBalancerListenerInput {
 
 export namespace CreateLoadBalancerListenerInput {
   export function isa(o: any): o is CreateLoadBalancerListenerInput {
-    return _smithy.isa(o, "CreateLoadBalancerListenerInput");
+    return __isa(o, "CreateLoadBalancerListenerInput");
   }
 }
 
@@ -556,7 +559,7 @@ export interface CreateLoadBalancerListenerOutput extends $MetadataBearer {
 
 export namespace CreateLoadBalancerListenerOutput {
   export function isa(o: any): o is CreateLoadBalancerListenerOutput {
-    return _smithy.isa(o, "CreateLoadBalancerListenerOutput");
+    return __isa(o, "CreateLoadBalancerListenerOutput");
   }
 }
 
@@ -589,7 +592,7 @@ export interface CreateLoadBalancerPolicyInput {
 
 export namespace CreateLoadBalancerPolicyInput {
   export function isa(o: any): o is CreateLoadBalancerPolicyInput {
-    return _smithy.isa(o, "CreateLoadBalancerPolicyInput");
+    return __isa(o, "CreateLoadBalancerPolicyInput");
   }
 }
 
@@ -602,7 +605,7 @@ export interface CreateLoadBalancerPolicyOutput extends $MetadataBearer {
 
 export namespace CreateLoadBalancerPolicyOutput {
   export function isa(o: any): o is CreateLoadBalancerPolicyOutput {
-    return _smithy.isa(o, "CreateLoadBalancerPolicyOutput");
+    return __isa(o, "CreateLoadBalancerPolicyOutput");
   }
 }
 
@@ -619,7 +622,7 @@ export interface CrossZoneLoadBalancing {
 
 export namespace CrossZoneLoadBalancing {
   export function isa(o: any): o is CrossZoneLoadBalancing {
-    return _smithy.isa(o, "CrossZoneLoadBalancing");
+    return __isa(o, "CrossZoneLoadBalancing");
   }
 }
 
@@ -636,7 +639,7 @@ export interface DeleteAccessPointInput {
 
 export namespace DeleteAccessPointInput {
   export function isa(o: any): o is DeleteAccessPointInput {
-    return _smithy.isa(o, "DeleteAccessPointInput");
+    return __isa(o, "DeleteAccessPointInput");
   }
 }
 
@@ -649,7 +652,7 @@ export interface DeleteAccessPointOutput extends $MetadataBearer {
 
 export namespace DeleteAccessPointOutput {
   export function isa(o: any): o is DeleteAccessPointOutput {
-    return _smithy.isa(o, "DeleteAccessPointOutput");
+    return __isa(o, "DeleteAccessPointOutput");
   }
 }
 
@@ -671,7 +674,7 @@ export interface DeleteLoadBalancerListenerInput {
 
 export namespace DeleteLoadBalancerListenerInput {
   export function isa(o: any): o is DeleteLoadBalancerListenerInput {
-    return _smithy.isa(o, "DeleteLoadBalancerListenerInput");
+    return __isa(o, "DeleteLoadBalancerListenerInput");
   }
 }
 
@@ -684,7 +687,7 @@ export interface DeleteLoadBalancerListenerOutput extends $MetadataBearer {
 
 export namespace DeleteLoadBalancerListenerOutput {
   export function isa(o: any): o is DeleteLoadBalancerListenerOutput {
-    return _smithy.isa(o, "DeleteLoadBalancerListenerOutput");
+    return __isa(o, "DeleteLoadBalancerListenerOutput");
   }
 }
 
@@ -706,7 +709,7 @@ export interface DeleteLoadBalancerPolicyInput {
 
 export namespace DeleteLoadBalancerPolicyInput {
   export function isa(o: any): o is DeleteLoadBalancerPolicyInput {
-    return _smithy.isa(o, "DeleteLoadBalancerPolicyInput");
+    return __isa(o, "DeleteLoadBalancerPolicyInput");
   }
 }
 
@@ -719,7 +722,7 @@ export interface DeleteLoadBalancerPolicyOutput extends $MetadataBearer {
 
 export namespace DeleteLoadBalancerPolicyOutput {
   export function isa(o: any): o is DeleteLoadBalancerPolicyOutput {
-    return _smithy.isa(o, "DeleteLoadBalancerPolicyOutput");
+    return __isa(o, "DeleteLoadBalancerPolicyOutput");
   }
 }
 
@@ -727,7 +730,7 @@ export namespace DeleteLoadBalancerPolicyOutput {
  * <p>A request made by Elastic Load Balancing to another service exceeds the maximum request rate permitted for your account.</p>
  */
 export interface DependencyThrottleException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DependencyThrottleException";
   $fault: "client";
@@ -736,7 +739,7 @@ export interface DependencyThrottleException
 
 export namespace DependencyThrottleException {
   export function isa(o: any): o is DependencyThrottleException {
-    return _smithy.isa(o, "DependencyThrottleException");
+    return __isa(o, "DependencyThrottleException");
   }
 }
 
@@ -758,7 +761,7 @@ export interface DeregisterEndPointsInput {
 
 export namespace DeregisterEndPointsInput {
   export function isa(o: any): o is DeregisterEndPointsInput {
-    return _smithy.isa(o, "DeregisterEndPointsInput");
+    return __isa(o, "DeregisterEndPointsInput");
   }
 }
 
@@ -775,7 +778,7 @@ export interface DeregisterEndPointsOutput extends $MetadataBearer {
 
 export namespace DeregisterEndPointsOutput {
   export function isa(o: any): o is DeregisterEndPointsOutput {
-    return _smithy.isa(o, "DeregisterEndPointsOutput");
+    return __isa(o, "DeregisterEndPointsOutput");
   }
 }
 
@@ -802,7 +805,7 @@ export interface DescribeAccessPointsInput {
 
 export namespace DescribeAccessPointsInput {
   export function isa(o: any): o is DescribeAccessPointsInput {
-    return _smithy.isa(o, "DescribeAccessPointsInput");
+    return __isa(o, "DescribeAccessPointsInput");
   }
 }
 
@@ -824,7 +827,7 @@ export interface DescribeAccessPointsOutput extends $MetadataBearer {
 
 export namespace DescribeAccessPointsOutput {
   export function isa(o: any): o is DescribeAccessPointsOutput {
-    return _smithy.isa(o, "DescribeAccessPointsOutput");
+    return __isa(o, "DescribeAccessPointsOutput");
   }
 }
 
@@ -843,7 +846,7 @@ export interface DescribeAccountLimitsInput {
 
 export namespace DescribeAccountLimitsInput {
   export function isa(o: any): o is DescribeAccountLimitsInput {
-    return _smithy.isa(o, "DescribeAccountLimitsInput");
+    return __isa(o, "DescribeAccountLimitsInput");
   }
 }
 
@@ -862,7 +865,7 @@ export interface DescribeAccountLimitsOutput extends $MetadataBearer {
 
 export namespace DescribeAccountLimitsOutput {
   export function isa(o: any): o is DescribeAccountLimitsOutput {
-    return _smithy.isa(o, "DescribeAccountLimitsOutput");
+    return __isa(o, "DescribeAccountLimitsOutput");
   }
 }
 
@@ -884,7 +887,7 @@ export interface DescribeEndPointStateInput {
 
 export namespace DescribeEndPointStateInput {
   export function isa(o: any): o is DescribeEndPointStateInput {
-    return _smithy.isa(o, "DescribeEndPointStateInput");
+    return __isa(o, "DescribeEndPointStateInput");
   }
 }
 
@@ -901,7 +904,7 @@ export interface DescribeEndPointStateOutput extends $MetadataBearer {
 
 export namespace DescribeEndPointStateOutput {
   export function isa(o: any): o is DescribeEndPointStateOutput {
-    return _smithy.isa(o, "DescribeEndPointStateOutput");
+    return __isa(o, "DescribeEndPointStateOutput");
   }
 }
 
@@ -918,7 +921,7 @@ export interface DescribeLoadBalancerAttributesInput {
 
 export namespace DescribeLoadBalancerAttributesInput {
   export function isa(o: any): o is DescribeLoadBalancerAttributesInput {
-    return _smithy.isa(o, "DescribeLoadBalancerAttributesInput");
+    return __isa(o, "DescribeLoadBalancerAttributesInput");
   }
 }
 
@@ -935,7 +938,7 @@ export interface DescribeLoadBalancerAttributesOutput extends $MetadataBearer {
 
 export namespace DescribeLoadBalancerAttributesOutput {
   export function isa(o: any): o is DescribeLoadBalancerAttributesOutput {
-    return _smithy.isa(o, "DescribeLoadBalancerAttributesOutput");
+    return __isa(o, "DescribeLoadBalancerAttributesOutput");
   }
 }
 
@@ -957,7 +960,7 @@ export interface DescribeLoadBalancerPoliciesInput {
 
 export namespace DescribeLoadBalancerPoliciesInput {
   export function isa(o: any): o is DescribeLoadBalancerPoliciesInput {
-    return _smithy.isa(o, "DescribeLoadBalancerPoliciesInput");
+    return __isa(o, "DescribeLoadBalancerPoliciesInput");
   }
 }
 
@@ -974,7 +977,7 @@ export interface DescribeLoadBalancerPoliciesOutput extends $MetadataBearer {
 
 export namespace DescribeLoadBalancerPoliciesOutput {
   export function isa(o: any): o is DescribeLoadBalancerPoliciesOutput {
-    return _smithy.isa(o, "DescribeLoadBalancerPoliciesOutput");
+    return __isa(o, "DescribeLoadBalancerPoliciesOutput");
   }
 }
 
@@ -991,7 +994,7 @@ export interface DescribeLoadBalancerPolicyTypesInput {
 
 export namespace DescribeLoadBalancerPolicyTypesInput {
   export function isa(o: any): o is DescribeLoadBalancerPolicyTypesInput {
-    return _smithy.isa(o, "DescribeLoadBalancerPolicyTypesInput");
+    return __isa(o, "DescribeLoadBalancerPolicyTypesInput");
   }
 }
 
@@ -1008,7 +1011,7 @@ export interface DescribeLoadBalancerPolicyTypesOutput extends $MetadataBearer {
 
 export namespace DescribeLoadBalancerPolicyTypesOutput {
   export function isa(o: any): o is DescribeLoadBalancerPolicyTypesOutput {
-    return _smithy.isa(o, "DescribeLoadBalancerPolicyTypesOutput");
+    return __isa(o, "DescribeLoadBalancerPolicyTypesOutput");
   }
 }
 
@@ -1025,7 +1028,7 @@ export interface DescribeTagsInput {
 
 export namespace DescribeTagsInput {
   export function isa(o: any): o is DescribeTagsInput {
-    return _smithy.isa(o, "DescribeTagsInput");
+    return __isa(o, "DescribeTagsInput");
   }
 }
 
@@ -1042,7 +1045,7 @@ export interface DescribeTagsOutput extends $MetadataBearer {
 
 export namespace DescribeTagsOutput {
   export function isa(o: any): o is DescribeTagsOutput {
-    return _smithy.isa(o, "DescribeTagsOutput");
+    return __isa(o, "DescribeTagsOutput");
   }
 }
 
@@ -1064,7 +1067,7 @@ export interface DetachLoadBalancerFromSubnetsInput {
 
 export namespace DetachLoadBalancerFromSubnetsInput {
   export function isa(o: any): o is DetachLoadBalancerFromSubnetsInput {
-    return _smithy.isa(o, "DetachLoadBalancerFromSubnetsInput");
+    return __isa(o, "DetachLoadBalancerFromSubnetsInput");
   }
 }
 
@@ -1081,7 +1084,7 @@ export interface DetachLoadBalancerFromSubnetsOutput extends $MetadataBearer {
 
 export namespace DetachLoadBalancerFromSubnetsOutput {
   export function isa(o: any): o is DetachLoadBalancerFromSubnetsOutput {
-    return _smithy.isa(o, "DetachLoadBalancerFromSubnetsOutput");
+    return __isa(o, "DetachLoadBalancerFromSubnetsOutput");
   }
 }
 
@@ -1089,7 +1092,7 @@ export namespace DetachLoadBalancerFromSubnetsOutput {
  * <p>The specified load balancer name already exists for this account.</p>
  */
 export interface DuplicateAccessPointNameException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DuplicateAccessPointNameException";
   $fault: "client";
@@ -1098,7 +1101,7 @@ export interface DuplicateAccessPointNameException
 
 export namespace DuplicateAccessPointNameException {
   export function isa(o: any): o is DuplicateAccessPointNameException {
-    return _smithy.isa(o, "DuplicateAccessPointNameException");
+    return __isa(o, "DuplicateAccessPointNameException");
   }
 }
 
@@ -1106,7 +1109,7 @@ export namespace DuplicateAccessPointNameException {
  * <p>A listener already exists for the specified load balancer name and port, but with a different instance port, protocol, or SSL certificate.</p>
  */
 export interface DuplicateListenerException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DuplicateListenerException";
   $fault: "client";
@@ -1115,7 +1118,7 @@ export interface DuplicateListenerException
 
 export namespace DuplicateListenerException {
   export function isa(o: any): o is DuplicateListenerException {
-    return _smithy.isa(o, "DuplicateListenerException");
+    return __isa(o, "DuplicateListenerException");
   }
 }
 
@@ -1123,7 +1126,7 @@ export namespace DuplicateListenerException {
  * <p>A policy with the specified name already exists for this load balancer.</p>
  */
 export interface DuplicatePolicyNameException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DuplicatePolicyNameException";
   $fault: "client";
@@ -1132,7 +1135,7 @@ export interface DuplicatePolicyNameException
 
 export namespace DuplicatePolicyNameException {
   export function isa(o: any): o is DuplicatePolicyNameException {
-    return _smithy.isa(o, "DuplicatePolicyNameException");
+    return __isa(o, "DuplicatePolicyNameException");
   }
 }
 
@@ -1140,7 +1143,7 @@ export namespace DuplicatePolicyNameException {
  * <p>A tag key was specified more than once.</p>
  */
 export interface DuplicateTagKeysException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DuplicateTagKeysException";
   $fault: "client";
@@ -1149,7 +1152,7 @@ export interface DuplicateTagKeysException
 
 export namespace DuplicateTagKeysException {
   export function isa(o: any): o is DuplicateTagKeysException {
-    return _smithy.isa(o, "DuplicateTagKeysException");
+    return __isa(o, "DuplicateTagKeysException");
   }
 }
 
@@ -1191,7 +1194,7 @@ export interface HealthCheck {
 
 export namespace HealthCheck {
   export function isa(o: any): o is HealthCheck {
-    return _smithy.isa(o, "HealthCheck");
+    return __isa(o, "HealthCheck");
   }
 }
 
@@ -1208,7 +1211,7 @@ export interface Instance {
 
 export namespace Instance {
   export function isa(o: any): o is Instance {
-    return _smithy.isa(o, "Instance");
+    return __isa(o, "Instance");
   }
 }
 
@@ -1307,7 +1310,7 @@ export interface InstanceState {
 
 export namespace InstanceState {
   export function isa(o: any): o is InstanceState {
-    return _smithy.isa(o, "InstanceState");
+    return __isa(o, "InstanceState");
   }
 }
 
@@ -1315,7 +1318,7 @@ export namespace InstanceState {
  * <p>The requested configuration change is not valid.</p>
  */
 export interface InvalidConfigurationRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidConfigurationRequestException";
   $fault: "client";
@@ -1324,7 +1327,7 @@ export interface InvalidConfigurationRequestException
 
 export namespace InvalidConfigurationRequestException {
   export function isa(o: any): o is InvalidConfigurationRequestException {
-    return _smithy.isa(o, "InvalidConfigurationRequestException");
+    return __isa(o, "InvalidConfigurationRequestException");
   }
 }
 
@@ -1332,7 +1335,7 @@ export namespace InvalidConfigurationRequestException {
  * <p>The specified endpoint is not valid.</p>
  */
 export interface InvalidEndPointException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidEndPointException";
   $fault: "client";
@@ -1341,7 +1344,7 @@ export interface InvalidEndPointException
 
 export namespace InvalidEndPointException {
   export function isa(o: any): o is InvalidEndPointException {
-    return _smithy.isa(o, "InvalidEndPointException");
+    return __isa(o, "InvalidEndPointException");
   }
 }
 
@@ -1349,7 +1352,7 @@ export namespace InvalidEndPointException {
  * <p>The specified value for the schema is not valid. You can only specify a scheme for load balancers in a VPC.</p>
  */
 export interface InvalidSchemeException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidSchemeException";
   $fault: "client";
@@ -1358,7 +1361,7 @@ export interface InvalidSchemeException
 
 export namespace InvalidSchemeException {
   export function isa(o: any): o is InvalidSchemeException {
-    return _smithy.isa(o, "InvalidSchemeException");
+    return __isa(o, "InvalidSchemeException");
   }
 }
 
@@ -1366,7 +1369,7 @@ export namespace InvalidSchemeException {
  * <p>One or more of the specified security groups do not exist.</p>
  */
 export interface InvalidSecurityGroupException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidSecurityGroupException";
   $fault: "client";
@@ -1375,7 +1378,7 @@ export interface InvalidSecurityGroupException
 
 export namespace InvalidSecurityGroupException {
   export function isa(o: any): o is InvalidSecurityGroupException {
-    return _smithy.isa(o, "InvalidSecurityGroupException");
+    return __isa(o, "InvalidSecurityGroupException");
   }
 }
 
@@ -1383,7 +1386,7 @@ export namespace InvalidSecurityGroupException {
  * <p>The specified VPC has no associated Internet gateway.</p>
  */
 export interface InvalidSubnetException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidSubnetException";
   $fault: "client";
@@ -1392,7 +1395,7 @@ export interface InvalidSubnetException
 
 export namespace InvalidSubnetException {
   export function isa(o: any): o is InvalidSubnetException {
-    return _smithy.isa(o, "InvalidSubnetException");
+    return __isa(o, "InvalidSubnetException");
   }
 }
 
@@ -1414,7 +1417,7 @@ export interface LBCookieStickinessPolicy {
 
 export namespace LBCookieStickinessPolicy {
   export function isa(o: any): o is LBCookieStickinessPolicy {
-    return _smithy.isa(o, "LBCookieStickinessPolicy");
+    return __isa(o, "LBCookieStickinessPolicy");
   }
 }
 
@@ -1447,7 +1450,7 @@ export interface Limit {
 
 export namespace Limit {
   export function isa(o: any): o is Limit {
-    return _smithy.isa(o, "Limit");
+    return __isa(o, "Limit");
   }
 }
 
@@ -1491,7 +1494,7 @@ export interface Listener {
 
 export namespace Listener {
   export function isa(o: any): o is Listener {
-    return _smithy.isa(o, "Listener");
+    return __isa(o, "Listener");
   }
 }
 
@@ -1513,7 +1516,7 @@ export interface ListenerDescription {
 
 export namespace ListenerDescription {
   export function isa(o: any): o is ListenerDescription {
-    return _smithy.isa(o, "ListenerDescription");
+    return __isa(o, "ListenerDescription");
   }
 }
 
@@ -1521,7 +1524,7 @@ export namespace ListenerDescription {
  * <p>The load balancer does not have a listener configured at the specified port.</p>
  */
 export interface ListenerNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ListenerNotFoundException";
   $fault: "client";
@@ -1530,7 +1533,7 @@ export interface ListenerNotFoundException
 
 export namespace ListenerNotFoundException {
   export function isa(o: any): o is ListenerNotFoundException {
-    return _smithy.isa(o, "ListenerNotFoundException");
+    return __isa(o, "ListenerNotFoundException");
   }
 }
 
@@ -1538,7 +1541,7 @@ export namespace ListenerNotFoundException {
  * <p>The specified load balancer attribute does not exist.</p>
  */
 export interface LoadBalancerAttributeNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LoadBalancerAttributeNotFoundException";
   $fault: "client";
@@ -1547,7 +1550,7 @@ export interface LoadBalancerAttributeNotFoundException
 
 export namespace LoadBalancerAttributeNotFoundException {
   export function isa(o: any): o is LoadBalancerAttributeNotFoundException {
-    return _smithy.isa(o, "LoadBalancerAttributeNotFoundException");
+    return __isa(o, "LoadBalancerAttributeNotFoundException");
   }
 }
 
@@ -1593,7 +1596,7 @@ export interface LoadBalancerAttributes {
 
 export namespace LoadBalancerAttributes {
   export function isa(o: any): o is LoadBalancerAttributes {
-    return _smithy.isa(o, "LoadBalancerAttributes");
+    return __isa(o, "LoadBalancerAttributes");
   }
 }
 
@@ -1692,7 +1695,7 @@ export interface LoadBalancerDescription {
 
 export namespace LoadBalancerDescription {
   export function isa(o: any): o is LoadBalancerDescription {
-    return _smithy.isa(o, "LoadBalancerDescription");
+    return __isa(o, "LoadBalancerDescription");
   }
 }
 
@@ -1714,7 +1717,7 @@ export interface ModifyLoadBalancerAttributesInput {
 
 export namespace ModifyLoadBalancerAttributesInput {
   export function isa(o: any): o is ModifyLoadBalancerAttributesInput {
-    return _smithy.isa(o, "ModifyLoadBalancerAttributesInput");
+    return __isa(o, "ModifyLoadBalancerAttributesInput");
   }
 }
 
@@ -1736,7 +1739,7 @@ export interface ModifyLoadBalancerAttributesOutput extends $MetadataBearer {
 
 export namespace ModifyLoadBalancerAttributesOutput {
   export function isa(o: any): o is ModifyLoadBalancerAttributesOutput {
-    return _smithy.isa(o, "ModifyLoadBalancerAttributesOutput");
+    return __isa(o, "ModifyLoadBalancerAttributesOutput");
   }
 }
 
@@ -1744,7 +1747,7 @@ export namespace ModifyLoadBalancerAttributesOutput {
  * <p>This operation is not allowed.</p>
  */
 export interface OperationNotPermittedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "OperationNotPermittedException";
   $fault: "client";
@@ -1753,7 +1756,7 @@ export interface OperationNotPermittedException
 
 export namespace OperationNotPermittedException {
   export function isa(o: any): o is OperationNotPermittedException {
-    return _smithy.isa(o, "OperationNotPermittedException");
+    return __isa(o, "OperationNotPermittedException");
   }
 }
 
@@ -1780,7 +1783,7 @@ export interface Policies {
 
 export namespace Policies {
   export function isa(o: any): o is Policies {
-    return _smithy.isa(o, "Policies");
+    return __isa(o, "Policies");
   }
 }
 
@@ -1802,7 +1805,7 @@ export interface PolicyAttribute {
 
 export namespace PolicyAttribute {
   export function isa(o: any): o is PolicyAttribute {
-    return _smithy.isa(o, "PolicyAttribute");
+    return __isa(o, "PolicyAttribute");
   }
 }
 
@@ -1824,7 +1827,7 @@ export interface PolicyAttributeDescription {
 
 export namespace PolicyAttributeDescription {
   export function isa(o: any): o is PolicyAttributeDescription {
-    return _smithy.isa(o, "PolicyAttributeDescription");
+    return __isa(o, "PolicyAttributeDescription");
   }
 }
 
@@ -1876,7 +1879,7 @@ export interface PolicyAttributeTypeDescription {
 
 export namespace PolicyAttributeTypeDescription {
   export function isa(o: any): o is PolicyAttributeTypeDescription {
-    return _smithy.isa(o, "PolicyAttributeTypeDescription");
+    return __isa(o, "PolicyAttributeTypeDescription");
   }
 }
 
@@ -1903,7 +1906,7 @@ export interface PolicyDescription {
 
 export namespace PolicyDescription {
   export function isa(o: any): o is PolicyDescription {
-    return _smithy.isa(o, "PolicyDescription");
+    return __isa(o, "PolicyDescription");
   }
 }
 
@@ -1911,7 +1914,7 @@ export namespace PolicyDescription {
  * <p>One or more of the specified policies do not exist.</p>
  */
 export interface PolicyNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "PolicyNotFoundException";
   $fault: "client";
@@ -1920,7 +1923,7 @@ export interface PolicyNotFoundException
 
 export namespace PolicyNotFoundException {
   export function isa(o: any): o is PolicyNotFoundException {
-    return _smithy.isa(o, "PolicyNotFoundException");
+    return __isa(o, "PolicyNotFoundException");
   }
 }
 
@@ -1947,7 +1950,7 @@ export interface PolicyTypeDescription {
 
 export namespace PolicyTypeDescription {
   export function isa(o: any): o is PolicyTypeDescription {
-    return _smithy.isa(o, "PolicyTypeDescription");
+    return __isa(o, "PolicyTypeDescription");
   }
 }
 
@@ -1955,7 +1958,7 @@ export namespace PolicyTypeDescription {
  * <p>One or more of the specified policy types do not exist.</p>
  */
 export interface PolicyTypeNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "PolicyTypeNotFoundException";
   $fault: "client";
@@ -1964,7 +1967,7 @@ export interface PolicyTypeNotFoundException
 
 export namespace PolicyTypeNotFoundException {
   export function isa(o: any): o is PolicyTypeNotFoundException {
-    return _smithy.isa(o, "PolicyTypeNotFoundException");
+    return __isa(o, "PolicyTypeNotFoundException");
   }
 }
 
@@ -1986,7 +1989,7 @@ export interface RegisterEndPointsInput {
 
 export namespace RegisterEndPointsInput {
   export function isa(o: any): o is RegisterEndPointsInput {
-    return _smithy.isa(o, "RegisterEndPointsInput");
+    return __isa(o, "RegisterEndPointsInput");
   }
 }
 
@@ -2003,7 +2006,7 @@ export interface RegisterEndPointsOutput extends $MetadataBearer {
 
 export namespace RegisterEndPointsOutput {
   export function isa(o: any): o is RegisterEndPointsOutput {
-    return _smithy.isa(o, "RegisterEndPointsOutput");
+    return __isa(o, "RegisterEndPointsOutput");
   }
 }
 
@@ -2025,7 +2028,7 @@ export interface RemoveAvailabilityZonesInput {
 
 export namespace RemoveAvailabilityZonesInput {
   export function isa(o: any): o is RemoveAvailabilityZonesInput {
-    return _smithy.isa(o, "RemoveAvailabilityZonesInput");
+    return __isa(o, "RemoveAvailabilityZonesInput");
   }
 }
 
@@ -2042,7 +2045,7 @@ export interface RemoveAvailabilityZonesOutput extends $MetadataBearer {
 
 export namespace RemoveAvailabilityZonesOutput {
   export function isa(o: any): o is RemoveAvailabilityZonesOutput {
-    return _smithy.isa(o, "RemoveAvailabilityZonesOutput");
+    return __isa(o, "RemoveAvailabilityZonesOutput");
   }
 }
 
@@ -2064,7 +2067,7 @@ export interface RemoveTagsInput {
 
 export namespace RemoveTagsInput {
   export function isa(o: any): o is RemoveTagsInput {
-    return _smithy.isa(o, "RemoveTagsInput");
+    return __isa(o, "RemoveTagsInput");
   }
 }
 
@@ -2077,7 +2080,7 @@ export interface RemoveTagsOutput extends $MetadataBearer {
 
 export namespace RemoveTagsOutput {
   export function isa(o: any): o is RemoveTagsOutput {
-    return _smithy.isa(o, "RemoveTagsOutput");
+    return __isa(o, "RemoveTagsOutput");
   }
 }
 
@@ -2104,7 +2107,7 @@ export interface SetLoadBalancerListenerSSLCertificateInput {
 
 export namespace SetLoadBalancerListenerSSLCertificateInput {
   export function isa(o: any): o is SetLoadBalancerListenerSSLCertificateInput {
-    return _smithy.isa(o, "SetLoadBalancerListenerSSLCertificateInput");
+    return __isa(o, "SetLoadBalancerListenerSSLCertificateInput");
   }
 }
 
@@ -2120,7 +2123,7 @@ export namespace SetLoadBalancerListenerSSLCertificateOutput {
   export function isa(
     o: any
   ): o is SetLoadBalancerListenerSSLCertificateOutput {
-    return _smithy.isa(o, "SetLoadBalancerListenerSSLCertificateOutput");
+    return __isa(o, "SetLoadBalancerListenerSSLCertificateOutput");
   }
 }
 
@@ -2149,7 +2152,7 @@ export namespace SetLoadBalancerPoliciesForBackendServerInput {
   export function isa(
     o: any
   ): o is SetLoadBalancerPoliciesForBackendServerInput {
-    return _smithy.isa(o, "SetLoadBalancerPoliciesForBackendServerInput");
+    return __isa(o, "SetLoadBalancerPoliciesForBackendServerInput");
   }
 }
 
@@ -2165,7 +2168,7 @@ export namespace SetLoadBalancerPoliciesForBackendServerOutput {
   export function isa(
     o: any
   ): o is SetLoadBalancerPoliciesForBackendServerOutput {
-    return _smithy.isa(o, "SetLoadBalancerPoliciesForBackendServerOutput");
+    return __isa(o, "SetLoadBalancerPoliciesForBackendServerOutput");
   }
 }
 
@@ -2192,7 +2195,7 @@ export interface SetLoadBalancerPoliciesOfListenerInput {
 
 export namespace SetLoadBalancerPoliciesOfListenerInput {
   export function isa(o: any): o is SetLoadBalancerPoliciesOfListenerInput {
-    return _smithy.isa(o, "SetLoadBalancerPoliciesOfListenerInput");
+    return __isa(o, "SetLoadBalancerPoliciesOfListenerInput");
   }
 }
 
@@ -2206,7 +2209,7 @@ export interface SetLoadBalancerPoliciesOfListenerOutput
 
 export namespace SetLoadBalancerPoliciesOfListenerOutput {
   export function isa(o: any): o is SetLoadBalancerPoliciesOfListenerOutput {
-    return _smithy.isa(o, "SetLoadBalancerPoliciesOfListenerOutput");
+    return __isa(o, "SetLoadBalancerPoliciesOfListenerOutput");
   }
 }
 
@@ -2228,7 +2231,7 @@ export interface SourceSecurityGroup {
 
 export namespace SourceSecurityGroup {
   export function isa(o: any): o is SourceSecurityGroup {
-    return _smithy.isa(o, "SourceSecurityGroup");
+    return __isa(o, "SourceSecurityGroup");
   }
 }
 
@@ -2236,7 +2239,7 @@ export namespace SourceSecurityGroup {
  * <p>One or more of the specified subnets do not exist.</p>
  */
 export interface SubnetNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "SubnetNotFoundException";
   $fault: "client";
@@ -2245,7 +2248,7 @@ export interface SubnetNotFoundException
 
 export namespace SubnetNotFoundException {
   export function isa(o: any): o is SubnetNotFoundException {
-    return _smithy.isa(o, "SubnetNotFoundException");
+    return __isa(o, "SubnetNotFoundException");
   }
 }
 
@@ -2267,7 +2270,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -2289,7 +2292,7 @@ export interface TagDescription {
 
 export namespace TagDescription {
   export function isa(o: any): o is TagDescription {
-    return _smithy.isa(o, "TagDescription");
+    return __isa(o, "TagDescription");
   }
 }
 
@@ -2306,7 +2309,7 @@ export interface TagKeyOnly {
 
 export namespace TagKeyOnly {
   export function isa(o: any): o is TagKeyOnly {
-    return _smithy.isa(o, "TagKeyOnly");
+    return __isa(o, "TagKeyOnly");
   }
 }
 
@@ -2314,7 +2317,7 @@ export namespace TagKeyOnly {
  * <p>The quota for the number of load balancers has been reached.</p>
  */
 export interface TooManyAccessPointsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyAccessPointsException";
   $fault: "client";
@@ -2323,7 +2326,7 @@ export interface TooManyAccessPointsException
 
 export namespace TooManyAccessPointsException {
   export function isa(o: any): o is TooManyAccessPointsException {
-    return _smithy.isa(o, "TooManyAccessPointsException");
+    return __isa(o, "TooManyAccessPointsException");
   }
 }
 
@@ -2331,7 +2334,7 @@ export namespace TooManyAccessPointsException {
  * <p>The quota for the number of policies for this load balancer has been reached.</p>
  */
 export interface TooManyPoliciesException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyPoliciesException";
   $fault: "client";
@@ -2340,7 +2343,7 @@ export interface TooManyPoliciesException
 
 export namespace TooManyPoliciesException {
   export function isa(o: any): o is TooManyPoliciesException {
-    return _smithy.isa(o, "TooManyPoliciesException");
+    return __isa(o, "TooManyPoliciesException");
   }
 }
 
@@ -2348,7 +2351,7 @@ export namespace TooManyPoliciesException {
  * <p>The quota for the number of tags that can be assigned to a load balancer has been reached.</p>
  */
 export interface TooManyTagsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyTagsException";
   $fault: "client";
@@ -2357,7 +2360,7 @@ export interface TooManyTagsException
 
 export namespace TooManyTagsException {
   export function isa(o: any): o is TooManyTagsException {
-    return _smithy.isa(o, "TooManyTagsException");
+    return __isa(o, "TooManyTagsException");
   }
 }
 
@@ -2365,7 +2368,7 @@ export namespace TooManyTagsException {
  * <p>The specified protocol or signature version is not supported.</p>
  */
 export interface UnsupportedProtocolException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UnsupportedProtocolException";
   $fault: "client";
@@ -2374,6 +2377,6 @@ export interface UnsupportedProtocolException
 
 export namespace UnsupportedProtocolException {
   export function isa(o: any): o is UnsupportedProtocolException {
-    return _smithy.isa(o, "UnsupportedProtocolException");
+    return __isa(o, "UnsupportedProtocolException");
   }
 }

--- a/clients/client-elastic-transcoder/models/index.ts
+++ b/clients/client-elastic-transcoder/models/index.ts
@@ -1,11 +1,14 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
  * <p>General authentication failure. The request was not signed correctly.</p>
  */
 export interface AccessDeniedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AccessDeniedException";
   $fault: "client";
@@ -14,12 +17,12 @@ export interface AccessDeniedException
 
 export namespace AccessDeniedException {
   export function isa(o: any): o is AccessDeniedException {
-    return _smithy.isa(o, "AccessDeniedException");
+    return __isa(o, "AccessDeniedException");
   }
 }
 
 export interface IncompatibleVersionException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "IncompatibleVersionException";
   $fault: "client";
@@ -28,7 +31,7 @@ export interface IncompatibleVersionException
 
 export namespace IncompatibleVersionException {
   export function isa(o: any): o is IncompatibleVersionException {
-    return _smithy.isa(o, "IncompatibleVersionException");
+    return __isa(o, "IncompatibleVersionException");
   }
 }
 
@@ -36,7 +39,7 @@ export namespace IncompatibleVersionException {
  * <p>Elastic Transcoder encountered an unexpected exception while trying to fulfill the request.</p>
  */
 export interface InternalServiceException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalServiceException";
   $fault: "server";
@@ -45,7 +48,7 @@ export interface InternalServiceException
 
 export namespace InternalServiceException {
   export function isa(o: any): o is InternalServiceException {
-    return _smithy.isa(o, "InternalServiceException");
+    return __isa(o, "InternalServiceException");
   }
 }
 
@@ -54,7 +57,7 @@ export namespace InternalServiceException {
  *             exceeds the maximum allowed.</p>
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -63,7 +66,7 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
@@ -72,7 +75,7 @@ export namespace LimitExceededException {
  *             to delete a pipeline that is currently in use.</p>
  */
 export interface ResourceInUseException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceInUseException";
   $fault: "client";
@@ -81,7 +84,7 @@ export interface ResourceInUseException
 
 export namespace ResourceInUseException {
   export function isa(o: any): o is ResourceInUseException {
-    return _smithy.isa(o, "ResourceInUseException");
+    return __isa(o, "ResourceInUseException");
   }
 }
 
@@ -90,7 +93,7 @@ export namespace ResourceInUseException {
  *             to which you're trying to add a job doesn't exist or is still being created.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -99,7 +102,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -107,7 +110,7 @@ export namespace ResourceNotFoundException {
  * <p>One or more required parameter values were not provided in the request.</p>
  */
 export interface ValidationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ValidationException";
   $fault: "client";
@@ -116,7 +119,7 @@ export interface ValidationException
 
 export namespace ValidationException {
   export function isa(o: any): o is ValidationException {
-    return _smithy.isa(o, "ValidationException");
+    return __isa(o, "ValidationException");
   }
 }
 
@@ -224,7 +227,7 @@ export interface Artwork {
 
 export namespace Artwork {
   export function isa(o: any): o is Artwork {
-    return _smithy.isa(o, "Artwork");
+    return __isa(o, "Artwork");
   }
 }
 
@@ -296,7 +299,7 @@ export interface AudioCodecOptions {
 
 export namespace AudioCodecOptions {
   export function isa(o: any): o is AudioCodecOptions {
-    return _smithy.isa(o, "AudioCodecOptions");
+    return __isa(o, "AudioCodecOptions");
   }
 }
 
@@ -565,7 +568,7 @@ export interface AudioParameters {
 
 export namespace AudioParameters {
   export function isa(o: any): o is AudioParameters {
-    return _smithy.isa(o, "AudioParameters");
+    return __isa(o, "AudioParameters");
   }
 }
 
@@ -584,7 +587,7 @@ export interface CancelJobRequest {
 
 export namespace CancelJobRequest {
   export function isa(o: any): o is CancelJobRequest {
-    return _smithy.isa(o, "CancelJobRequest");
+    return __isa(o, "CancelJobRequest");
   }
 }
 
@@ -598,7 +601,7 @@ export interface CancelJobResponse extends $MetadataBearer {
 
 export namespace CancelJobResponse {
   export function isa(o: any): o is CancelJobResponse {
-    return _smithy.isa(o, "CancelJobResponse");
+    return __isa(o, "CancelJobResponse");
   }
 }
 
@@ -695,7 +698,7 @@ export interface CaptionFormat {
 
 export namespace CaptionFormat {
   export function isa(o: any): o is CaptionFormat {
-    return _smithy.isa(o, "CaptionFormat");
+    return __isa(o, "CaptionFormat");
   }
 }
 
@@ -747,7 +750,7 @@ export interface CaptionSource {
 
 export namespace CaptionSource {
   export function isa(o: any): o is CaptionSource {
-    return _smithy.isa(o, "CaptionSource");
+    return __isa(o, "CaptionSource");
   }
 }
 
@@ -799,7 +802,7 @@ export interface Captions {
 
 export namespace Captions {
   export function isa(o: any): o is Captions {
-    return _smithy.isa(o, "Captions");
+    return __isa(o, "Captions");
   }
 }
 
@@ -816,7 +819,7 @@ export interface Clip {
 
 export namespace Clip {
   export function isa(o: any): o is Clip {
-    return _smithy.isa(o, "Clip");
+    return __isa(o, "Clip");
   }
 }
 
@@ -994,7 +997,7 @@ export interface CreateJobOutput {
 
 export namespace CreateJobOutput {
   export function isa(o: any): o is CreateJobOutput {
-    return _smithy.isa(o, "CreateJobOutput");
+    return __isa(o, "CreateJobOutput");
   }
 }
 
@@ -1082,7 +1085,7 @@ export interface CreateJobPlaylist {
 
 export namespace CreateJobPlaylist {
   export function isa(o: any): o is CreateJobPlaylist {
-    return _smithy.isa(o, "CreateJobPlaylist");
+    return __isa(o, "CreateJobPlaylist");
   }
 }
 
@@ -1150,7 +1153,7 @@ export interface CreateJobRequest {
 
 export namespace CreateJobRequest {
   export function isa(o: any): o is CreateJobRequest {
-    return _smithy.isa(o, "CreateJobRequest");
+    return __isa(o, "CreateJobRequest");
   }
 }
 
@@ -1167,7 +1170,7 @@ export interface CreateJobResponse extends $MetadataBearer {
 
 export namespace CreateJobResponse {
   export function isa(o: any): o is CreateJobResponse {
-    return _smithy.isa(o, "CreateJobResponse");
+    return __isa(o, "CreateJobResponse");
   }
 }
 
@@ -1478,7 +1481,7 @@ export interface CreatePipelineRequest {
 
 export namespace CreatePipelineRequest {
   export function isa(o: any): o is CreatePipelineRequest {
-    return _smithy.isa(o, "CreatePipelineRequest");
+    return __isa(o, "CreatePipelineRequest");
   }
 }
 
@@ -1503,7 +1506,7 @@ export interface CreatePipelineResponse extends $MetadataBearer {
 
 export namespace CreatePipelineResponse {
   export function isa(o: any): o is CreatePipelineResponse {
-    return _smithy.isa(o, "CreatePipelineResponse");
+    return __isa(o, "CreatePipelineResponse");
   }
 }
 
@@ -1549,7 +1552,7 @@ export interface CreatePresetRequest {
 
 export namespace CreatePresetRequest {
   export function isa(o: any): o is CreatePresetRequest {
-    return _smithy.isa(o, "CreatePresetRequest");
+    return __isa(o, "CreatePresetRequest");
   }
 }
 
@@ -1574,7 +1577,7 @@ export interface CreatePresetResponse extends $MetadataBearer {
 
 export namespace CreatePresetResponse {
   export function isa(o: any): o is CreatePresetResponse {
-    return _smithy.isa(o, "CreatePresetResponse");
+    return __isa(o, "CreatePresetResponse");
   }
 }
 
@@ -1591,7 +1594,7 @@ export interface DeletePipelineRequest {
 
 export namespace DeletePipelineRequest {
   export function isa(o: any): o is DeletePipelineRequest {
-    return _smithy.isa(o, "DeletePipelineRequest");
+    return __isa(o, "DeletePipelineRequest");
   }
 }
 
@@ -1604,7 +1607,7 @@ export interface DeletePipelineResponse extends $MetadataBearer {
 
 export namespace DeletePipelineResponse {
   export function isa(o: any): o is DeletePipelineResponse {
-    return _smithy.isa(o, "DeletePipelineResponse");
+    return __isa(o, "DeletePipelineResponse");
   }
 }
 
@@ -1621,7 +1624,7 @@ export interface DeletePresetRequest {
 
 export namespace DeletePresetRequest {
   export function isa(o: any): o is DeletePresetRequest {
-    return _smithy.isa(o, "DeletePresetRequest");
+    return __isa(o, "DeletePresetRequest");
   }
 }
 
@@ -1634,7 +1637,7 @@ export interface DeletePresetResponse extends $MetadataBearer {
 
 export namespace DeletePresetResponse {
   export function isa(o: any): o is DeletePresetResponse {
-    return _smithy.isa(o, "DeletePresetResponse");
+    return __isa(o, "DeletePresetResponse");
   }
 }
 
@@ -1671,7 +1674,7 @@ export interface DetectedProperties {
 
 export namespace DetectedProperties {
   export function isa(o: any): o is DetectedProperties {
-    return _smithy.isa(o, "DetectedProperties");
+    return __isa(o, "DetectedProperties");
   }
 }
 
@@ -1772,7 +1775,7 @@ export interface Encryption {
 
 export namespace Encryption {
   export function isa(o: any): o is Encryption {
-    return _smithy.isa(o, "Encryption");
+    return __isa(o, "Encryption");
   }
 }
 
@@ -1830,7 +1833,7 @@ export interface HlsContentProtection {
 
 export namespace HlsContentProtection {
   export function isa(o: any): o is HlsContentProtection {
-    return _smithy.isa(o, "HlsContentProtection");
+    return __isa(o, "HlsContentProtection");
   }
 }
 
@@ -1877,7 +1880,7 @@ export interface InputCaptions {
 
 export namespace InputCaptions {
   export function isa(o: any): o is InputCaptions {
-    return _smithy.isa(o, "InputCaptions");
+    return __isa(o, "InputCaptions");
   }
 }
 
@@ -1999,7 +2002,7 @@ export interface Job {
 
 export namespace Job {
   export function isa(o: any): o is Job {
-    return _smithy.isa(o, "Job");
+    return __isa(o, "Job");
   }
 }
 
@@ -2045,7 +2048,7 @@ export interface JobAlbumArt {
 
 export namespace JobAlbumArt {
   export function isa(o: any): o is JobAlbumArt {
-    return _smithy.isa(o, "JobAlbumArt");
+    return __isa(o, "JobAlbumArt");
   }
 }
 
@@ -2182,7 +2185,7 @@ export interface JobInput {
 
 export namespace JobInput {
   export function isa(o: any): o is JobInput {
-    return _smithy.isa(o, "JobInput");
+    return __isa(o, "JobInput");
   }
 }
 
@@ -2460,7 +2463,7 @@ export interface JobOutput {
 
 export namespace JobOutput {
   export function isa(o: any): o is JobOutput {
-    return _smithy.isa(o, "JobOutput");
+    return __isa(o, "JobOutput");
   }
 }
 
@@ -2496,7 +2499,7 @@ export interface JobWatermark {
 
 export namespace JobWatermark {
   export function isa(o: any): o is JobWatermark {
-    return _smithy.isa(o, "JobWatermark");
+    return __isa(o, "JobWatermark");
   }
 }
 
@@ -2526,7 +2529,7 @@ export interface ListJobsByPipelineRequest {
 
 export namespace ListJobsByPipelineRequest {
   export function isa(o: any): o is ListJobsByPipelineRequest {
-    return _smithy.isa(o, "ListJobsByPipelineRequest");
+    return __isa(o, "ListJobsByPipelineRequest");
   }
 }
 
@@ -2550,7 +2553,7 @@ export interface ListJobsByPipelineResponse extends $MetadataBearer {
 
 export namespace ListJobsByPipelineResponse {
   export function isa(o: any): o is ListJobsByPipelineResponse {
-    return _smithy.isa(o, "ListJobsByPipelineResponse");
+    return __isa(o, "ListJobsByPipelineResponse");
   }
 }
 
@@ -2583,7 +2586,7 @@ export interface ListJobsByStatusRequest {
 
 export namespace ListJobsByStatusRequest {
   export function isa(o: any): o is ListJobsByStatusRequest {
-    return _smithy.isa(o, "ListJobsByStatusRequest");
+    return __isa(o, "ListJobsByStatusRequest");
   }
 }
 
@@ -2609,7 +2612,7 @@ export interface ListJobsByStatusResponse extends $MetadataBearer {
 
 export namespace ListJobsByStatusResponse {
   export function isa(o: any): o is ListJobsByStatusResponse {
-    return _smithy.isa(o, "ListJobsByStatusResponse");
+    return __isa(o, "ListJobsByStatusResponse");
   }
 }
 
@@ -2634,7 +2637,7 @@ export interface ListPipelinesRequest {
 
 export namespace ListPipelinesRequest {
   export function isa(o: any): o is ListPipelinesRequest {
-    return _smithy.isa(o, "ListPipelinesRequest");
+    return __isa(o, "ListPipelinesRequest");
   }
 }
 
@@ -2658,7 +2661,7 @@ export interface ListPipelinesResponse extends $MetadataBearer {
 
 export namespace ListPipelinesResponse {
   export function isa(o: any): o is ListPipelinesResponse {
-    return _smithy.isa(o, "ListPipelinesResponse");
+    return __isa(o, "ListPipelinesResponse");
   }
 }
 
@@ -2683,7 +2686,7 @@ export interface ListPresetsRequest {
 
 export namespace ListPresetsRequest {
   export function isa(o: any): o is ListPresetsRequest {
-    return _smithy.isa(o, "ListPresetsRequest");
+    return __isa(o, "ListPresetsRequest");
   }
 }
 
@@ -2707,7 +2710,7 @@ export interface ListPresetsResponse extends $MetadataBearer {
 
 export namespace ListPresetsResponse {
   export function isa(o: any): o is ListPresetsResponse {
-    return _smithy.isa(o, "ListPresetsResponse");
+    return __isa(o, "ListPresetsResponse");
   }
 }
 
@@ -2742,7 +2745,7 @@ export interface Notifications {
 
 export namespace Notifications {
   export function isa(o: any): o is Notifications {
-    return _smithy.isa(o, "Notifications");
+    return __isa(o, "Notifications");
   }
 }
 
@@ -2817,7 +2820,7 @@ export interface Permission {
 
 export namespace Permission {
   export function isa(o: any): o is Permission {
-    return _smithy.isa(o, "Permission");
+    return __isa(o, "Permission");
   }
 }
 
@@ -3095,7 +3098,7 @@ export interface Pipeline {
 
 export namespace Pipeline {
   export function isa(o: any): o is Pipeline {
-    return _smithy.isa(o, "Pipeline");
+    return __isa(o, "Pipeline");
   }
 }
 
@@ -3156,7 +3159,7 @@ export interface PipelineOutputConfig {
 
 export namespace PipelineOutputConfig {
   export function isa(o: any): o is PipelineOutputConfig {
-    return _smithy.isa(o, "PipelineOutputConfig");
+    return __isa(o, "PipelineOutputConfig");
   }
 }
 
@@ -3218,7 +3221,7 @@ export interface PlayReadyDrm {
 
 export namespace PlayReadyDrm {
   export function isa(o: any): o is PlayReadyDrm {
-    return _smithy.isa(o, "PlayReadyDrm");
+    return __isa(o, "PlayReadyDrm");
   }
 }
 
@@ -3316,7 +3319,7 @@ export interface Playlist {
 
 export namespace Playlist {
   export function isa(o: any): o is Playlist {
-    return _smithy.isa(o, "Playlist");
+    return __isa(o, "Playlist");
   }
 }
 
@@ -3381,7 +3384,7 @@ export interface Preset {
 
 export namespace Preset {
   export function isa(o: any): o is Preset {
-    return _smithy.isa(o, "Preset");
+    return __isa(o, "Preset");
   }
 }
 
@@ -3615,7 +3618,7 @@ export interface PresetWatermark {
 
 export namespace PresetWatermark {
   export function isa(o: any): o is PresetWatermark {
-    return _smithy.isa(o, "PresetWatermark");
+    return __isa(o, "PresetWatermark");
   }
 }
 
@@ -3632,7 +3635,7 @@ export interface ReadJobRequest {
 
 export namespace ReadJobRequest {
   export function isa(o: any): o is ReadJobRequest {
-    return _smithy.isa(o, "ReadJobRequest");
+    return __isa(o, "ReadJobRequest");
   }
 }
 
@@ -3649,7 +3652,7 @@ export interface ReadJobResponse extends $MetadataBearer {
 
 export namespace ReadJobResponse {
   export function isa(o: any): o is ReadJobResponse {
-    return _smithy.isa(o, "ReadJobResponse");
+    return __isa(o, "ReadJobResponse");
   }
 }
 
@@ -3666,7 +3669,7 @@ export interface ReadPipelineRequest {
 
 export namespace ReadPipelineRequest {
   export function isa(o: any): o is ReadPipelineRequest {
-    return _smithy.isa(o, "ReadPipelineRequest");
+    return __isa(o, "ReadPipelineRequest");
   }
 }
 
@@ -3691,7 +3694,7 @@ export interface ReadPipelineResponse extends $MetadataBearer {
 
 export namespace ReadPipelineResponse {
   export function isa(o: any): o is ReadPipelineResponse {
-    return _smithy.isa(o, "ReadPipelineResponse");
+    return __isa(o, "ReadPipelineResponse");
   }
 }
 
@@ -3708,7 +3711,7 @@ export interface ReadPresetRequest {
 
 export namespace ReadPresetRequest {
   export function isa(o: any): o is ReadPresetRequest {
-    return _smithy.isa(o, "ReadPresetRequest");
+    return __isa(o, "ReadPresetRequest");
   }
 }
 
@@ -3725,7 +3728,7 @@ export interface ReadPresetResponse extends $MetadataBearer {
 
 export namespace ReadPresetResponse {
   export function isa(o: any): o is ReadPresetResponse {
-    return _smithy.isa(o, "ReadPresetResponse");
+    return __isa(o, "ReadPresetResponse");
   }
 }
 
@@ -3757,7 +3760,7 @@ export interface TestRoleRequest {
 
 export namespace TestRoleRequest {
   export function isa(o: any): o is TestRoleRequest {
-    return _smithy.isa(o, "TestRoleRequest");
+    return __isa(o, "TestRoleRequest");
   }
 }
 
@@ -3781,7 +3784,7 @@ export interface TestRoleResponse extends $MetadataBearer {
 
 export namespace TestRoleResponse {
   export function isa(o: any): o is TestRoleResponse {
-    return _smithy.isa(o, "TestRoleResponse");
+    return __isa(o, "TestRoleResponse");
   }
 }
 
@@ -3914,7 +3917,7 @@ export interface Thumbnails {
 
 export namespace Thumbnails {
   export function isa(o: any): o is Thumbnails {
-    return _smithy.isa(o, "Thumbnails");
+    return __isa(o, "Thumbnails");
   }
 }
 
@@ -3943,7 +3946,7 @@ export interface TimeSpan {
 
 export namespace TimeSpan {
   export function isa(o: any): o is TimeSpan {
-    return _smithy.isa(o, "TimeSpan");
+    return __isa(o, "TimeSpan");
   }
 }
 
@@ -3970,7 +3973,7 @@ export interface Timing {
 
 export namespace Timing {
   export function isa(o: any): o is Timing {
-    return _smithy.isa(o, "Timing");
+    return __isa(o, "Timing");
   }
 }
 
@@ -4021,7 +4024,7 @@ export interface UpdatePipelineNotificationsRequest {
 
 export namespace UpdatePipelineNotificationsRequest {
   export function isa(o: any): o is UpdatePipelineNotificationsRequest {
-    return _smithy.isa(o, "UpdatePipelineNotificationsRequest");
+    return __isa(o, "UpdatePipelineNotificationsRequest");
   }
 }
 
@@ -4039,7 +4042,7 @@ export interface UpdatePipelineNotificationsResponse extends $MetadataBearer {
 
 export namespace UpdatePipelineNotificationsResponse {
   export function isa(o: any): o is UpdatePipelineNotificationsResponse {
-    return _smithy.isa(o, "UpdatePipelineNotificationsResponse");
+    return __isa(o, "UpdatePipelineNotificationsResponse");
   }
 }
 
@@ -4317,7 +4320,7 @@ export interface UpdatePipelineRequest {
 
 export namespace UpdatePipelineRequest {
   export function isa(o: any): o is UpdatePipelineRequest {
-    return _smithy.isa(o, "UpdatePipelineRequest");
+    return __isa(o, "UpdatePipelineRequest");
   }
 }
 
@@ -4342,7 +4345,7 @@ export interface UpdatePipelineResponse extends $MetadataBearer {
 
 export namespace UpdatePipelineResponse {
   export function isa(o: any): o is UpdatePipelineResponse {
-    return _smithy.isa(o, "UpdatePipelineResponse");
+    return __isa(o, "UpdatePipelineResponse");
   }
 }
 
@@ -4374,7 +4377,7 @@ export interface UpdatePipelineStatusRequest {
 
 export namespace UpdatePipelineStatusRequest {
   export function isa(o: any): o is UpdatePipelineStatusRequest {
-    return _smithy.isa(o, "UpdatePipelineStatusRequest");
+    return __isa(o, "UpdatePipelineStatusRequest");
   }
 }
 
@@ -4392,7 +4395,7 @@ export interface UpdatePipelineStatusResponse extends $MetadataBearer {
 
 export namespace UpdatePipelineStatusResponse {
   export function isa(o: any): o is UpdatePipelineStatusResponse {
-    return _smithy.isa(o, "UpdatePipelineStatusResponse");
+    return __isa(o, "UpdatePipelineStatusResponse");
   }
 }
 
@@ -4973,7 +4976,7 @@ export interface VideoParameters {
 
 export namespace VideoParameters {
   export function isa(o: any): o is VideoParameters {
-    return _smithy.isa(o, "VideoParameters");
+    return __isa(o, "VideoParameters");
   }
 }
 
@@ -5001,6 +5004,6 @@ export interface Warning {
 
 export namespace Warning {
   export function isa(o: any): o is Warning {
-    return _smithy.isa(o, "Warning");
+    return __isa(o, "Warning");
   }
 }

--- a/clients/client-elastic-transcoder/protocols/Aws_restJson1_1.ts
+++ b/clients/client-elastic-transcoder/protocols/Aws_restJson1_1.ts
@@ -110,7 +110,10 @@ import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  extendedEncodeURIComponent as __extendedEncodeURIComponent
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -126,11 +129,14 @@ export async function serializeAws_restJson1_1CancelJobCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/2012-09-25/jobs/{Id}";
   if (input.Id !== undefined) {
-    const labelValue: string = input.Id.toString();
+    const labelValue: string = input.Id;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Id.");
     }
-    resolvedPath = resolvedPath.replace("{Id}", encodeURIComponent(labelValue));
+    resolvedPath = resolvedPath.replace(
+      "{Id}",
+      __extendedEncodeURIComponent(labelValue)
+    );
   } else {
     throw new Error("No value provided for input HTTP label: Id.");
   }
@@ -315,11 +321,14 @@ export async function serializeAws_restJson1_1DeletePipelineCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/2012-09-25/pipelines/{Id}";
   if (input.Id !== undefined) {
-    const labelValue: string = input.Id.toString();
+    const labelValue: string = input.Id;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Id.");
     }
-    resolvedPath = resolvedPath.replace("{Id}", encodeURIComponent(labelValue));
+    resolvedPath = resolvedPath.replace(
+      "{Id}",
+      __extendedEncodeURIComponent(labelValue)
+    );
   } else {
     throw new Error("No value provided for input HTTP label: Id.");
   }
@@ -340,11 +349,14 @@ export async function serializeAws_restJson1_1DeletePresetCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/2012-09-25/presets/{Id}";
   if (input.Id !== undefined) {
-    const labelValue: string = input.Id.toString();
+    const labelValue: string = input.Id;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Id.");
     }
-    resolvedPath = resolvedPath.replace("{Id}", encodeURIComponent(labelValue));
+    resolvedPath = resolvedPath.replace(
+      "{Id}",
+      __extendedEncodeURIComponent(labelValue)
+    );
   } else {
     throw new Error("No value provided for input HTTP label: Id.");
   }
@@ -365,23 +377,27 @@ export async function serializeAws_restJson1_1ListJobsByPipelineCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/2012-09-25/jobsByPipeline/{PipelineId}";
   if (input.PipelineId !== undefined) {
-    const labelValue: string = input.PipelineId.toString();
+    const labelValue: string = input.PipelineId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: PipelineId.");
     }
     resolvedPath = resolvedPath.replace(
       "{PipelineId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: PipelineId.");
   }
   const query: any = {};
   if (input.Ascending !== undefined) {
-    query["Ascending"] = input.Ascending.toString();
+    query[
+      __extendedEncodeURIComponent("Ascending")
+    ] = __extendedEncodeURIComponent(input.Ascending);
   }
   if (input.PageToken !== undefined) {
-    query["PageToken"] = input.PageToken.toString();
+    query[
+      __extendedEncodeURIComponent("PageToken")
+    ] = __extendedEncodeURIComponent(input.PageToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -401,23 +417,27 @@ export async function serializeAws_restJson1_1ListJobsByStatusCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/2012-09-25/jobsByStatus/{Status}";
   if (input.Status !== undefined) {
-    const labelValue: string = input.Status.toString();
+    const labelValue: string = input.Status;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Status.");
     }
     resolvedPath = resolvedPath.replace(
       "{Status}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Status.");
   }
   const query: any = {};
   if (input.Ascending !== undefined) {
-    query["Ascending"] = input.Ascending.toString();
+    query[
+      __extendedEncodeURIComponent("Ascending")
+    ] = __extendedEncodeURIComponent(input.Ascending);
   }
   if (input.PageToken !== undefined) {
-    query["PageToken"] = input.PageToken.toString();
+    query[
+      __extendedEncodeURIComponent("PageToken")
+    ] = __extendedEncodeURIComponent(input.PageToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -438,10 +458,14 @@ export async function serializeAws_restJson1_1ListPipelinesCommand(
   let resolvedPath = "/2012-09-25/pipelines";
   const query: any = {};
   if (input.Ascending !== undefined) {
-    query["Ascending"] = input.Ascending.toString();
+    query[
+      __extendedEncodeURIComponent("Ascending")
+    ] = __extendedEncodeURIComponent(input.Ascending);
   }
   if (input.PageToken !== undefined) {
-    query["PageToken"] = input.PageToken.toString();
+    query[
+      __extendedEncodeURIComponent("PageToken")
+    ] = __extendedEncodeURIComponent(input.PageToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -462,10 +486,14 @@ export async function serializeAws_restJson1_1ListPresetsCommand(
   let resolvedPath = "/2012-09-25/presets";
   const query: any = {};
   if (input.Ascending !== undefined) {
-    query["Ascending"] = input.Ascending.toString();
+    query[
+      __extendedEncodeURIComponent("Ascending")
+    ] = __extendedEncodeURIComponent(input.Ascending);
   }
   if (input.PageToken !== undefined) {
-    query["PageToken"] = input.PageToken.toString();
+    query[
+      __extendedEncodeURIComponent("PageToken")
+    ] = __extendedEncodeURIComponent(input.PageToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -485,11 +513,14 @@ export async function serializeAws_restJson1_1ReadJobCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/2012-09-25/jobs/{Id}";
   if (input.Id !== undefined) {
-    const labelValue: string = input.Id.toString();
+    const labelValue: string = input.Id;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Id.");
     }
-    resolvedPath = resolvedPath.replace("{Id}", encodeURIComponent(labelValue));
+    resolvedPath = resolvedPath.replace(
+      "{Id}",
+      __extendedEncodeURIComponent(labelValue)
+    );
   } else {
     throw new Error("No value provided for input HTTP label: Id.");
   }
@@ -510,11 +541,14 @@ export async function serializeAws_restJson1_1ReadPipelineCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/2012-09-25/pipelines/{Id}";
   if (input.Id !== undefined) {
-    const labelValue: string = input.Id.toString();
+    const labelValue: string = input.Id;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Id.");
     }
-    resolvedPath = resolvedPath.replace("{Id}", encodeURIComponent(labelValue));
+    resolvedPath = resolvedPath.replace(
+      "{Id}",
+      __extendedEncodeURIComponent(labelValue)
+    );
   } else {
     throw new Error("No value provided for input HTTP label: Id.");
   }
@@ -535,11 +569,14 @@ export async function serializeAws_restJson1_1ReadPresetCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/2012-09-25/presets/{Id}";
   if (input.Id !== undefined) {
-    const labelValue: string = input.Id.toString();
+    const labelValue: string = input.Id;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Id.");
     }
-    resolvedPath = resolvedPath.replace("{Id}", encodeURIComponent(labelValue));
+    resolvedPath = resolvedPath.replace(
+      "{Id}",
+      __extendedEncodeURIComponent(labelValue)
+    );
   } else {
     throw new Error("No value provided for input HTTP label: Id.");
   }
@@ -595,11 +632,14 @@ export async function serializeAws_restJson1_1UpdatePipelineCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/2012-09-25/pipelines/{Id}";
   if (input.Id !== undefined) {
-    const labelValue: string = input.Id.toString();
+    const labelValue: string = input.Id;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Id.");
     }
-    resolvedPath = resolvedPath.replace("{Id}", encodeURIComponent(labelValue));
+    resolvedPath = resolvedPath.replace(
+      "{Id}",
+      __extendedEncodeURIComponent(labelValue)
+    );
   } else {
     throw new Error("No value provided for input HTTP label: Id.");
   }
@@ -656,11 +696,14 @@ export async function serializeAws_restJson1_1UpdatePipelineNotificationsCommand
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/2012-09-25/pipelines/{Id}/notifications";
   if (input.Id !== undefined) {
-    const labelValue: string = input.Id.toString();
+    const labelValue: string = input.Id;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Id.");
     }
-    resolvedPath = resolvedPath.replace("{Id}", encodeURIComponent(labelValue));
+    resolvedPath = resolvedPath.replace(
+      "{Id}",
+      __extendedEncodeURIComponent(labelValue)
+    );
   } else {
     throw new Error("No value provided for input HTTP label: Id.");
   }
@@ -691,11 +734,14 @@ export async function serializeAws_restJson1_1UpdatePipelineStatusCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/2012-09-25/pipelines/{Id}/status";
   if (input.Id !== undefined) {
-    const labelValue: string = input.Id.toString();
+    const labelValue: string = input.Id;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Id.");
     }
-    resolvedPath = resolvedPath.replace("{Id}", encodeURIComponent(labelValue));
+    resolvedPath = resolvedPath.replace(
+      "{Id}",
+      __extendedEncodeURIComponent(labelValue)
+    );
   } else {
     throw new Error("No value provided for input HTTP label: Id.");
   }
@@ -726,6 +772,7 @@ export async function deserializeAws_restJson1_1CancelJobCommand(
     $metadata: deserializeMetadata(output),
     __type: "CancelJobResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -1086,6 +1133,7 @@ export async function deserializeAws_restJson1_1DeletePipelineCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeletePipelineResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -1169,6 +1217,7 @@ export async function deserializeAws_restJson1_1DeletePresetCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeletePresetResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 

--- a/clients/client-elasticache/models/index.ts
+++ b/clients/client-elasticache/models/index.ts
@@ -1,11 +1,14 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
  * <p>Two or more incompatible parameters were specified.</p>
  */
 export interface InvalidParameterCombinationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidParameterCombinationException";
   $fault: "client";
@@ -17,7 +20,7 @@ export interface InvalidParameterCombinationException
 
 export namespace InvalidParameterCombinationException {
   export function isa(o: any): o is InvalidParameterCombinationException {
-    return _smithy.isa(o, "InvalidParameterCombinationException");
+    return __isa(o, "InvalidParameterCombinationException");
   }
 }
 
@@ -25,7 +28,7 @@ export namespace InvalidParameterCombinationException {
  * <p>The value for a parameter is invalid.</p>
  */
 export interface InvalidParameterValueException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidParameterValueException";
   $fault: "client";
@@ -37,7 +40,7 @@ export interface InvalidParameterValueException
 
 export namespace InvalidParameterValueException {
   export function isa(o: any): o is InvalidParameterValueException {
-    return _smithy.isa(o, "InvalidParameterValueException");
+    return __isa(o, "InvalidParameterValueException");
   }
 }
 
@@ -45,7 +48,7 @@ export namespace InvalidParameterValueException {
  * <p>The customer has exceeded the allowed rate of API calls.</p>
  */
 export interface APICallRateForCustomerExceededFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "APICallRateForCustomerExceededFault";
   $fault: "client";
@@ -54,7 +57,7 @@ export interface APICallRateForCustomerExceededFault
 
 export namespace APICallRateForCustomerExceededFault {
   export function isa(o: any): o is APICallRateForCustomerExceededFault {
-    return _smithy.isa(o, "APICallRateForCustomerExceededFault");
+    return __isa(o, "APICallRateForCustomerExceededFault");
   }
 }
 
@@ -62,7 +65,7 @@ export namespace APICallRateForCustomerExceededFault {
  * <p>The specified Amazon EC2 security group is already authorized for the specified cache security group.</p>
  */
 export interface AuthorizationAlreadyExistsFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AuthorizationAlreadyExistsFault";
   $fault: "client";
@@ -71,7 +74,7 @@ export interface AuthorizationAlreadyExistsFault
 
 export namespace AuthorizationAlreadyExistsFault {
   export function isa(o: any): o is AuthorizationAlreadyExistsFault {
-    return _smithy.isa(o, "AuthorizationAlreadyExistsFault");
+    return __isa(o, "AuthorizationAlreadyExistsFault");
   }
 }
 
@@ -79,7 +82,7 @@ export namespace AuthorizationAlreadyExistsFault {
  * <p>The specified Amazon EC2 security group is not authorized for the specified cache security group.</p>
  */
 export interface AuthorizationNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AuthorizationNotFoundFault";
   $fault: "client";
@@ -88,7 +91,7 @@ export interface AuthorizationNotFoundFault
 
 export namespace AuthorizationNotFoundFault {
   export function isa(o: any): o is AuthorizationNotFoundFault {
-    return _smithy.isa(o, "AuthorizationNotFoundFault");
+    return __isa(o, "AuthorizationNotFoundFault");
   }
 }
 
@@ -96,7 +99,7 @@ export namespace AuthorizationNotFoundFault {
  * <p>You already have a cluster with the given identifier.</p>
  */
 export interface CacheClusterAlreadyExistsFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CacheClusterAlreadyExistsFault";
   $fault: "client";
@@ -105,7 +108,7 @@ export interface CacheClusterAlreadyExistsFault
 
 export namespace CacheClusterAlreadyExistsFault {
   export function isa(o: any): o is CacheClusterAlreadyExistsFault {
-    return _smithy.isa(o, "CacheClusterAlreadyExistsFault");
+    return __isa(o, "CacheClusterAlreadyExistsFault");
   }
 }
 
@@ -113,7 +116,7 @@ export namespace CacheClusterAlreadyExistsFault {
  * <p>The requested cluster ID does not refer to an existing cluster.</p>
  */
 export interface CacheClusterNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CacheClusterNotFoundFault";
   $fault: "client";
@@ -122,7 +125,7 @@ export interface CacheClusterNotFoundFault
 
 export namespace CacheClusterNotFoundFault {
   export function isa(o: any): o is CacheClusterNotFoundFault {
-    return _smithy.isa(o, "CacheClusterNotFoundFault");
+    return __isa(o, "CacheClusterNotFoundFault");
   }
 }
 
@@ -130,7 +133,7 @@ export namespace CacheClusterNotFoundFault {
  * <p>A cache parameter group with the requested name already exists.</p>
  */
 export interface CacheParameterGroupAlreadyExistsFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CacheParameterGroupAlreadyExistsFault";
   $fault: "client";
@@ -139,7 +142,7 @@ export interface CacheParameterGroupAlreadyExistsFault
 
 export namespace CacheParameterGroupAlreadyExistsFault {
   export function isa(o: any): o is CacheParameterGroupAlreadyExistsFault {
-    return _smithy.isa(o, "CacheParameterGroupAlreadyExistsFault");
+    return __isa(o, "CacheParameterGroupAlreadyExistsFault");
   }
 }
 
@@ -147,7 +150,7 @@ export namespace CacheParameterGroupAlreadyExistsFault {
  * <p>The requested cache parameter group name does not refer to an existing cache parameter group.</p>
  */
 export interface CacheParameterGroupNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CacheParameterGroupNotFoundFault";
   $fault: "client";
@@ -156,7 +159,7 @@ export interface CacheParameterGroupNotFoundFault
 
 export namespace CacheParameterGroupNotFoundFault {
   export function isa(o: any): o is CacheParameterGroupNotFoundFault {
-    return _smithy.isa(o, "CacheParameterGroupNotFoundFault");
+    return __isa(o, "CacheParameterGroupNotFoundFault");
   }
 }
 
@@ -164,7 +167,7 @@ export namespace CacheParameterGroupNotFoundFault {
  * <p>The request cannot be processed because it would exceed the maximum number of cache security groups.</p>
  */
 export interface CacheParameterGroupQuotaExceededFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CacheParameterGroupQuotaExceededFault";
   $fault: "client";
@@ -173,7 +176,7 @@ export interface CacheParameterGroupQuotaExceededFault
 
 export namespace CacheParameterGroupQuotaExceededFault {
   export function isa(o: any): o is CacheParameterGroupQuotaExceededFault {
-    return _smithy.isa(o, "CacheParameterGroupQuotaExceededFault");
+    return __isa(o, "CacheParameterGroupQuotaExceededFault");
   }
 }
 
@@ -181,7 +184,7 @@ export namespace CacheParameterGroupQuotaExceededFault {
  * <p>A cache security group with the specified name already exists.</p>
  */
 export interface CacheSecurityGroupAlreadyExistsFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CacheSecurityGroupAlreadyExistsFault";
   $fault: "client";
@@ -190,7 +193,7 @@ export interface CacheSecurityGroupAlreadyExistsFault
 
 export namespace CacheSecurityGroupAlreadyExistsFault {
   export function isa(o: any): o is CacheSecurityGroupAlreadyExistsFault {
-    return _smithy.isa(o, "CacheSecurityGroupAlreadyExistsFault");
+    return __isa(o, "CacheSecurityGroupAlreadyExistsFault");
   }
 }
 
@@ -198,7 +201,7 @@ export namespace CacheSecurityGroupAlreadyExistsFault {
  * <p>The requested cache security group name does not refer to an existing cache security group.</p>
  */
 export interface CacheSecurityGroupNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CacheSecurityGroupNotFoundFault";
   $fault: "client";
@@ -207,7 +210,7 @@ export interface CacheSecurityGroupNotFoundFault
 
 export namespace CacheSecurityGroupNotFoundFault {
   export function isa(o: any): o is CacheSecurityGroupNotFoundFault {
-    return _smithy.isa(o, "CacheSecurityGroupNotFoundFault");
+    return __isa(o, "CacheSecurityGroupNotFoundFault");
   }
 }
 
@@ -215,7 +218,7 @@ export namespace CacheSecurityGroupNotFoundFault {
  * <p>The request cannot be processed because it would exceed the allowed number of cache security groups.</p>
  */
 export interface CacheSecurityGroupQuotaExceededFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CacheSecurityGroupQuotaExceededFault";
   $fault: "client";
@@ -224,7 +227,7 @@ export interface CacheSecurityGroupQuotaExceededFault
 
 export namespace CacheSecurityGroupQuotaExceededFault {
   export function isa(o: any): o is CacheSecurityGroupQuotaExceededFault {
-    return _smithy.isa(o, "CacheSecurityGroupQuotaExceededFault");
+    return __isa(o, "CacheSecurityGroupQuotaExceededFault");
   }
 }
 
@@ -232,7 +235,7 @@ export namespace CacheSecurityGroupQuotaExceededFault {
  * <p>The requested cache subnet group name is already in use by an existing cache subnet group.</p>
  */
 export interface CacheSubnetGroupAlreadyExistsFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CacheSubnetGroupAlreadyExistsFault";
   $fault: "client";
@@ -241,7 +244,7 @@ export interface CacheSubnetGroupAlreadyExistsFault
 
 export namespace CacheSubnetGroupAlreadyExistsFault {
   export function isa(o: any): o is CacheSubnetGroupAlreadyExistsFault {
-    return _smithy.isa(o, "CacheSubnetGroupAlreadyExistsFault");
+    return __isa(o, "CacheSubnetGroupAlreadyExistsFault");
   }
 }
 
@@ -249,7 +252,7 @@ export namespace CacheSubnetGroupAlreadyExistsFault {
  * <p>The requested cache subnet group is currently in use.</p>
  */
 export interface CacheSubnetGroupInUse
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CacheSubnetGroupInUse";
   $fault: "client";
@@ -258,7 +261,7 @@ export interface CacheSubnetGroupInUse
 
 export namespace CacheSubnetGroupInUse {
   export function isa(o: any): o is CacheSubnetGroupInUse {
-    return _smithy.isa(o, "CacheSubnetGroupInUse");
+    return __isa(o, "CacheSubnetGroupInUse");
   }
 }
 
@@ -266,7 +269,7 @@ export namespace CacheSubnetGroupInUse {
  * <p>The requested cache subnet group name does not refer to an existing cache subnet group.</p>
  */
 export interface CacheSubnetGroupNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CacheSubnetGroupNotFoundFault";
   $fault: "client";
@@ -275,7 +278,7 @@ export interface CacheSubnetGroupNotFoundFault
 
 export namespace CacheSubnetGroupNotFoundFault {
   export function isa(o: any): o is CacheSubnetGroupNotFoundFault {
-    return _smithy.isa(o, "CacheSubnetGroupNotFoundFault");
+    return __isa(o, "CacheSubnetGroupNotFoundFault");
   }
 }
 
@@ -283,7 +286,7 @@ export namespace CacheSubnetGroupNotFoundFault {
  * <p>The request cannot be processed because it would exceed the allowed number of cache subnet groups.</p>
  */
 export interface CacheSubnetGroupQuotaExceededFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CacheSubnetGroupQuotaExceededFault";
   $fault: "client";
@@ -292,7 +295,7 @@ export interface CacheSubnetGroupQuotaExceededFault
 
 export namespace CacheSubnetGroupQuotaExceededFault {
   export function isa(o: any): o is CacheSubnetGroupQuotaExceededFault {
-    return _smithy.isa(o, "CacheSubnetGroupQuotaExceededFault");
+    return __isa(o, "CacheSubnetGroupQuotaExceededFault");
   }
 }
 
@@ -300,7 +303,7 @@ export namespace CacheSubnetGroupQuotaExceededFault {
  * <p>The request cannot be processed because it would exceed the allowed number of subnets in a cache subnet group.</p>
  */
 export interface CacheSubnetQuotaExceededFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CacheSubnetQuotaExceededFault";
   $fault: "client";
@@ -309,7 +312,7 @@ export interface CacheSubnetQuotaExceededFault
 
 export namespace CacheSubnetQuotaExceededFault {
   export function isa(o: any): o is CacheSubnetQuotaExceededFault {
-    return _smithy.isa(o, "CacheSubnetQuotaExceededFault");
+    return __isa(o, "CacheSubnetQuotaExceededFault");
   }
 }
 
@@ -317,7 +320,7 @@ export namespace CacheSubnetQuotaExceededFault {
  * <p>The request cannot be processed because it would exceed the allowed number of clusters per customer.</p>
  */
 export interface ClusterQuotaForCustomerExceededFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ClusterQuotaForCustomerExceededFault";
   $fault: "client";
@@ -326,7 +329,7 @@ export interface ClusterQuotaForCustomerExceededFault
 
 export namespace ClusterQuotaForCustomerExceededFault {
   export function isa(o: any): o is ClusterQuotaForCustomerExceededFault {
-    return _smithy.isa(o, "ClusterQuotaForCustomerExceededFault");
+    return __isa(o, "ClusterQuotaForCustomerExceededFault");
   }
 }
 
@@ -335,7 +338,7 @@ export namespace ClusterQuotaForCustomerExceededFault {
  *             For more information, see <a href="http://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/ErrorMessages.html#ErrorMessages.INSUFFICIENT_CACHE_CLUSTER_CAPACITY">InsufficientCacheClusterCapacity</a> in the ElastiCache User Guide.</p>
  */
 export interface InsufficientCacheClusterCapacityFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InsufficientCacheClusterCapacityFault";
   $fault: "client";
@@ -344,16 +347,14 @@ export interface InsufficientCacheClusterCapacityFault
 
 export namespace InsufficientCacheClusterCapacityFault {
   export function isa(o: any): o is InsufficientCacheClusterCapacityFault {
-    return _smithy.isa(o, "InsufficientCacheClusterCapacityFault");
+    return __isa(o, "InsufficientCacheClusterCapacityFault");
   }
 }
 
 /**
  * <p>The requested Amazon Resource Name (ARN) does not refer to an existing resource.</p>
  */
-export interface InvalidARNFault
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface InvalidARNFault extends __SmithyException, $MetadataBearer {
   name: "InvalidARNFault";
   $fault: "client";
   message?: string;
@@ -361,7 +362,7 @@ export interface InvalidARNFault
 
 export namespace InvalidARNFault {
   export function isa(o: any): o is InvalidARNFault {
-    return _smithy.isa(o, "InvalidARNFault");
+    return __isa(o, "InvalidARNFault");
   }
 }
 
@@ -369,7 +370,7 @@ export namespace InvalidARNFault {
  * <p>The requested cluster is not in the <code>available</code> state.</p>
  */
 export interface InvalidCacheClusterStateFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidCacheClusterStateFault";
   $fault: "client";
@@ -378,7 +379,7 @@ export interface InvalidCacheClusterStateFault
 
 export namespace InvalidCacheClusterStateFault {
   export function isa(o: any): o is InvalidCacheClusterStateFault {
-    return _smithy.isa(o, "InvalidCacheClusterStateFault");
+    return __isa(o, "InvalidCacheClusterStateFault");
   }
 }
 
@@ -386,7 +387,7 @@ export namespace InvalidCacheClusterStateFault {
  * <p>The current state of the cache parameter group does not allow the requested operation to occur.</p>
  */
 export interface InvalidCacheParameterGroupStateFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidCacheParameterGroupStateFault";
   $fault: "client";
@@ -395,7 +396,7 @@ export interface InvalidCacheParameterGroupStateFault
 
 export namespace InvalidCacheParameterGroupStateFault {
   export function isa(o: any): o is InvalidCacheParameterGroupStateFault {
-    return _smithy.isa(o, "InvalidCacheParameterGroupStateFault");
+    return __isa(o, "InvalidCacheParameterGroupStateFault");
   }
 }
 
@@ -403,7 +404,7 @@ export namespace InvalidCacheParameterGroupStateFault {
  * <p>The current state of the cache security group does not allow deletion.</p>
  */
 export interface InvalidCacheSecurityGroupStateFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidCacheSecurityGroupStateFault";
   $fault: "client";
@@ -412,16 +413,14 @@ export interface InvalidCacheSecurityGroupStateFault
 
 export namespace InvalidCacheSecurityGroupStateFault {
   export function isa(o: any): o is InvalidCacheSecurityGroupStateFault {
-    return _smithy.isa(o, "InvalidCacheSecurityGroupStateFault");
+    return __isa(o, "InvalidCacheSecurityGroupStateFault");
   }
 }
 
 /**
  * <p>The KMS key supplied is not valid.</p>
  */
-export interface InvalidKMSKeyFault
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface InvalidKMSKeyFault extends __SmithyException, $MetadataBearer {
   name: "InvalidKMSKeyFault";
   $fault: "client";
   message?: string;
@@ -429,7 +428,7 @@ export interface InvalidKMSKeyFault
 
 export namespace InvalidKMSKeyFault {
   export function isa(o: any): o is InvalidKMSKeyFault {
-    return _smithy.isa(o, "InvalidKMSKeyFault");
+    return __isa(o, "InvalidKMSKeyFault");
   }
 }
 
@@ -437,7 +436,7 @@ export namespace InvalidKMSKeyFault {
  * <p>The requested replication group is not in the <code>available</code> state.</p>
  */
 export interface InvalidReplicationGroupStateFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidReplicationGroupStateFault";
   $fault: "client";
@@ -446,7 +445,7 @@ export interface InvalidReplicationGroupStateFault
 
 export namespace InvalidReplicationGroupStateFault {
   export function isa(o: any): o is InvalidReplicationGroupStateFault {
-    return _smithy.isa(o, "InvalidReplicationGroupStateFault");
+    return __isa(o, "InvalidReplicationGroupStateFault");
   }
 }
 
@@ -454,7 +453,7 @@ export namespace InvalidReplicationGroupStateFault {
  * <p>The current state of the snapshot does not allow the requested operation to occur.</p>
  */
 export interface InvalidSnapshotStateFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidSnapshotStateFault";
   $fault: "client";
@@ -463,16 +462,14 @@ export interface InvalidSnapshotStateFault
 
 export namespace InvalidSnapshotStateFault {
   export function isa(o: any): o is InvalidSnapshotStateFault {
-    return _smithy.isa(o, "InvalidSnapshotStateFault");
+    return __isa(o, "InvalidSnapshotStateFault");
   }
 }
 
 /**
  * <p>An invalid subnet identifier was specified.</p>
  */
-export interface InvalidSubnet
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface InvalidSubnet extends __SmithyException, $MetadataBearer {
   name: "InvalidSubnet";
   $fault: "client";
   message?: string;
@@ -480,7 +477,7 @@ export interface InvalidSubnet
 
 export namespace InvalidSubnet {
   export function isa(o: any): o is InvalidSubnet {
-    return _smithy.isa(o, "InvalidSubnet");
+    return __isa(o, "InvalidSubnet");
   }
 }
 
@@ -488,7 +485,7 @@ export namespace InvalidSubnet {
  * <p>The VPC network is in an invalid state.</p>
  */
 export interface InvalidVPCNetworkStateFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidVPCNetworkStateFault";
   $fault: "client";
@@ -497,16 +494,14 @@ export interface InvalidVPCNetworkStateFault
 
 export namespace InvalidVPCNetworkStateFault {
   export function isa(o: any): o is InvalidVPCNetworkStateFault {
-    return _smithy.isa(o, "InvalidVPCNetworkStateFault");
+    return __isa(o, "InvalidVPCNetworkStateFault");
   }
 }
 
 /**
  * <p>The operation was not performed because no changes were required.</p>
  */
-export interface NoOperationFault
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface NoOperationFault extends __SmithyException, $MetadataBearer {
   name: "NoOperationFault";
   $fault: "client";
   message?: string;
@@ -514,7 +509,7 @@ export interface NoOperationFault
 
 export namespace NoOperationFault {
   export function isa(o: any): o is NoOperationFault {
-    return _smithy.isa(o, "NoOperationFault");
+    return __isa(o, "NoOperationFault");
   }
 }
 
@@ -523,7 +518,7 @@ export namespace NoOperationFault {
  *             Please verify that the node group exists and that you spelled the <code>NodeGroupId</code> value correctly.</p>
  */
 export interface NodeGroupNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "NodeGroupNotFoundFault";
   $fault: "client";
@@ -532,7 +527,7 @@ export interface NodeGroupNotFoundFault
 
 export namespace NodeGroupNotFoundFault {
   export function isa(o: any): o is NodeGroupNotFoundFault {
-    return _smithy.isa(o, "NodeGroupNotFoundFault");
+    return __isa(o, "NodeGroupNotFoundFault");
   }
 }
 
@@ -541,7 +536,7 @@ export namespace NodeGroupNotFoundFault {
  *             of node groups (shards) in a single replication group. The default maximum is 90</p>
  */
 export interface NodeGroupsPerReplicationGroupQuotaExceededFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "NodeGroupsPerReplicationGroupQuotaExceededFault";
   $fault: "client";
@@ -552,7 +547,7 @@ export namespace NodeGroupsPerReplicationGroupQuotaExceededFault {
   export function isa(
     o: any
   ): o is NodeGroupsPerReplicationGroupQuotaExceededFault {
-    return _smithy.isa(o, "NodeGroupsPerReplicationGroupQuotaExceededFault");
+    return __isa(o, "NodeGroupsPerReplicationGroupQuotaExceededFault");
   }
 }
 
@@ -560,7 +555,7 @@ export namespace NodeGroupsPerReplicationGroupQuotaExceededFault {
  * <p>The request cannot be processed because it would exceed the allowed number of cache nodes in a single cluster.</p>
  */
 export interface NodeQuotaForClusterExceededFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "NodeQuotaForClusterExceededFault";
   $fault: "client";
@@ -569,7 +564,7 @@ export interface NodeQuotaForClusterExceededFault
 
 export namespace NodeQuotaForClusterExceededFault {
   export function isa(o: any): o is NodeQuotaForClusterExceededFault {
-    return _smithy.isa(o, "NodeQuotaForClusterExceededFault");
+    return __isa(o, "NodeQuotaForClusterExceededFault");
   }
 }
 
@@ -577,7 +572,7 @@ export namespace NodeQuotaForClusterExceededFault {
  * <p>The request cannot be processed because it would exceed the allowed number of cache nodes per customer.</p>
  */
 export interface NodeQuotaForCustomerExceededFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "NodeQuotaForCustomerExceededFault";
   $fault: "client";
@@ -586,7 +581,7 @@ export interface NodeQuotaForCustomerExceededFault
 
 export namespace NodeQuotaForCustomerExceededFault {
   export function isa(o: any): o is NodeQuotaForCustomerExceededFault {
-    return _smithy.isa(o, "NodeQuotaForCustomerExceededFault");
+    return __isa(o, "NodeQuotaForCustomerExceededFault");
   }
 }
 
@@ -594,7 +589,7 @@ export namespace NodeQuotaForCustomerExceededFault {
  * <p>The specified replication group already exists.</p>
  */
 export interface ReplicationGroupAlreadyExistsFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ReplicationGroupAlreadyExistsFault";
   $fault: "client";
@@ -603,7 +598,7 @@ export interface ReplicationGroupAlreadyExistsFault
 
 export namespace ReplicationGroupAlreadyExistsFault {
   export function isa(o: any): o is ReplicationGroupAlreadyExistsFault {
-    return _smithy.isa(o, "ReplicationGroupAlreadyExistsFault");
+    return __isa(o, "ReplicationGroupAlreadyExistsFault");
   }
 }
 
@@ -611,7 +606,7 @@ export namespace ReplicationGroupAlreadyExistsFault {
  * <p>The targeted replication group is not available. </p>
  */
 export interface ReplicationGroupAlreadyUnderMigrationFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ReplicationGroupAlreadyUnderMigrationFault";
   $fault: "client";
@@ -620,7 +615,7 @@ export interface ReplicationGroupAlreadyUnderMigrationFault
 
 export namespace ReplicationGroupAlreadyUnderMigrationFault {
   export function isa(o: any): o is ReplicationGroupAlreadyUnderMigrationFault {
-    return _smithy.isa(o, "ReplicationGroupAlreadyUnderMigrationFault");
+    return __isa(o, "ReplicationGroupAlreadyUnderMigrationFault");
   }
 }
 
@@ -628,7 +623,7 @@ export namespace ReplicationGroupAlreadyUnderMigrationFault {
  * <p>The specified replication group does not exist.</p>
  */
 export interface ReplicationGroupNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ReplicationGroupNotFoundFault";
   $fault: "client";
@@ -637,7 +632,7 @@ export interface ReplicationGroupNotFoundFault
 
 export namespace ReplicationGroupNotFoundFault {
   export function isa(o: any): o is ReplicationGroupNotFoundFault {
-    return _smithy.isa(o, "ReplicationGroupNotFoundFault");
+    return __isa(o, "ReplicationGroupNotFoundFault");
   }
 }
 
@@ -645,7 +640,7 @@ export namespace ReplicationGroupNotFoundFault {
  * <p>The designated replication group is not available for data migration.</p>
  */
 export interface ReplicationGroupNotUnderMigrationFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ReplicationGroupNotUnderMigrationFault";
   $fault: "client";
@@ -654,7 +649,7 @@ export interface ReplicationGroupNotUnderMigrationFault
 
 export namespace ReplicationGroupNotUnderMigrationFault {
   export function isa(o: any): o is ReplicationGroupNotUnderMigrationFault {
-    return _smithy.isa(o, "ReplicationGroupNotUnderMigrationFault");
+    return __isa(o, "ReplicationGroupNotUnderMigrationFault");
   }
 }
 
@@ -662,7 +657,7 @@ export namespace ReplicationGroupNotUnderMigrationFault {
  * <p>You already have a reservation with the given identifier.</p>
  */
 export interface ReservedCacheNodeAlreadyExistsFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ReservedCacheNodeAlreadyExistsFault";
   $fault: "client";
@@ -671,7 +666,7 @@ export interface ReservedCacheNodeAlreadyExistsFault
 
 export namespace ReservedCacheNodeAlreadyExistsFault {
   export function isa(o: any): o is ReservedCacheNodeAlreadyExistsFault {
-    return _smithy.isa(o, "ReservedCacheNodeAlreadyExistsFault");
+    return __isa(o, "ReservedCacheNodeAlreadyExistsFault");
   }
 }
 
@@ -679,7 +674,7 @@ export namespace ReservedCacheNodeAlreadyExistsFault {
  * <p>The requested reserved cache node was not found.</p>
  */
 export interface ReservedCacheNodeNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ReservedCacheNodeNotFoundFault";
   $fault: "client";
@@ -688,7 +683,7 @@ export interface ReservedCacheNodeNotFoundFault
 
 export namespace ReservedCacheNodeNotFoundFault {
   export function isa(o: any): o is ReservedCacheNodeNotFoundFault {
-    return _smithy.isa(o, "ReservedCacheNodeNotFoundFault");
+    return __isa(o, "ReservedCacheNodeNotFoundFault");
   }
 }
 
@@ -696,7 +691,7 @@ export namespace ReservedCacheNodeNotFoundFault {
  * <p>The request cannot be processed because it would exceed the user's cache node quota.</p>
  */
 export interface ReservedCacheNodeQuotaExceededFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ReservedCacheNodeQuotaExceededFault";
   $fault: "client";
@@ -705,7 +700,7 @@ export interface ReservedCacheNodeQuotaExceededFault
 
 export namespace ReservedCacheNodeQuotaExceededFault {
   export function isa(o: any): o is ReservedCacheNodeQuotaExceededFault {
-    return _smithy.isa(o, "ReservedCacheNodeQuotaExceededFault");
+    return __isa(o, "ReservedCacheNodeQuotaExceededFault");
   }
 }
 
@@ -713,7 +708,7 @@ export namespace ReservedCacheNodeQuotaExceededFault {
  * <p>The requested cache node offering does not exist.</p>
  */
 export interface ReservedCacheNodesOfferingNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ReservedCacheNodesOfferingNotFoundFault";
   $fault: "client";
@@ -722,7 +717,7 @@ export interface ReservedCacheNodesOfferingNotFoundFault
 
 export namespace ReservedCacheNodesOfferingNotFoundFault {
   export function isa(o: any): o is ReservedCacheNodesOfferingNotFoundFault {
-    return _smithy.isa(o, "ReservedCacheNodesOfferingNotFoundFault");
+    return __isa(o, "ReservedCacheNodesOfferingNotFoundFault");
   }
 }
 
@@ -730,7 +725,7 @@ export namespace ReservedCacheNodesOfferingNotFoundFault {
  * <p>The specified service linked role (SLR) was not found.</p>
  */
 export interface ServiceLinkedRoleNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ServiceLinkedRoleNotFoundFault";
   $fault: "client";
@@ -739,7 +734,7 @@ export interface ServiceLinkedRoleNotFoundFault
 
 export namespace ServiceLinkedRoleNotFoundFault {
   export function isa(o: any): o is ServiceLinkedRoleNotFoundFault {
-    return _smithy.isa(o, "ServiceLinkedRoleNotFoundFault");
+    return __isa(o, "ServiceLinkedRoleNotFoundFault");
   }
 }
 
@@ -747,7 +742,7 @@ export namespace ServiceLinkedRoleNotFoundFault {
  * <p>The service update doesn't exist</p>
  */
 export interface ServiceUpdateNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ServiceUpdateNotFoundFault";
   $fault: "client";
@@ -756,7 +751,7 @@ export interface ServiceUpdateNotFoundFault
 
 export namespace ServiceUpdateNotFoundFault {
   export function isa(o: any): o is ServiceUpdateNotFoundFault {
-    return _smithy.isa(o, "ServiceUpdateNotFoundFault");
+    return __isa(o, "ServiceUpdateNotFoundFault");
   }
 }
 
@@ -764,7 +759,7 @@ export namespace ServiceUpdateNotFoundFault {
  * <p>You already have a snapshot with the given name.</p>
  */
 export interface SnapshotAlreadyExistsFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "SnapshotAlreadyExistsFault";
   $fault: "client";
@@ -773,7 +768,7 @@ export interface SnapshotAlreadyExistsFault
 
 export namespace SnapshotAlreadyExistsFault {
   export function isa(o: any): o is SnapshotAlreadyExistsFault {
-    return _smithy.isa(o, "SnapshotAlreadyExistsFault");
+    return __isa(o, "SnapshotAlreadyExistsFault");
   }
 }
 
@@ -791,7 +786,7 @@ export namespace SnapshotAlreadyExistsFault {
  *         <p>Neither of these are supported by ElastiCache.</p>
  */
 export interface SnapshotFeatureNotSupportedFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "SnapshotFeatureNotSupportedFault";
   $fault: "client";
@@ -800,7 +795,7 @@ export interface SnapshotFeatureNotSupportedFault
 
 export namespace SnapshotFeatureNotSupportedFault {
   export function isa(o: any): o is SnapshotFeatureNotSupportedFault {
-    return _smithy.isa(o, "SnapshotFeatureNotSupportedFault");
+    return __isa(o, "SnapshotFeatureNotSupportedFault");
   }
 }
 
@@ -808,7 +803,7 @@ export namespace SnapshotFeatureNotSupportedFault {
  * <p>The requested snapshot name does not refer to an existing snapshot.</p>
  */
 export interface SnapshotNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "SnapshotNotFoundFault";
   $fault: "client";
@@ -817,7 +812,7 @@ export interface SnapshotNotFoundFault
 
 export namespace SnapshotNotFoundFault {
   export function isa(o: any): o is SnapshotNotFoundFault {
-    return _smithy.isa(o, "SnapshotNotFoundFault");
+    return __isa(o, "SnapshotNotFoundFault");
   }
 }
 
@@ -825,7 +820,7 @@ export namespace SnapshotNotFoundFault {
  * <p>The request cannot be processed because it would exceed the maximum number of snapshots.</p>
  */
 export interface SnapshotQuotaExceededFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "SnapshotQuotaExceededFault";
   $fault: "client";
@@ -834,14 +829,14 @@ export interface SnapshotQuotaExceededFault
 
 export namespace SnapshotQuotaExceededFault {
   export function isa(o: any): o is SnapshotQuotaExceededFault {
-    return _smithy.isa(o, "SnapshotQuotaExceededFault");
+    return __isa(o, "SnapshotQuotaExceededFault");
   }
 }
 
 /**
  * <p>The requested subnet is being used by another cache subnet group.</p>
  */
-export interface SubnetInUse extends _smithy.SmithyException, $MetadataBearer {
+export interface SubnetInUse extends __SmithyException, $MetadataBearer {
   name: "SubnetInUse";
   $fault: "client";
   message?: string;
@@ -849,16 +844,14 @@ export interface SubnetInUse extends _smithy.SmithyException, $MetadataBearer {
 
 export namespace SubnetInUse {
   export function isa(o: any): o is SubnetInUse {
-    return _smithy.isa(o, "SubnetInUse");
+    return __isa(o, "SubnetInUse");
   }
 }
 
 /**
  * <p>The requested tag was not found on this resource.</p>
  */
-export interface TagNotFoundFault
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface TagNotFoundFault extends __SmithyException, $MetadataBearer {
   name: "TagNotFoundFault";
   $fault: "client";
   message?: string;
@@ -866,7 +859,7 @@ export interface TagNotFoundFault
 
 export namespace TagNotFoundFault {
   export function isa(o: any): o is TagNotFoundFault {
-    return _smithy.isa(o, "TagNotFoundFault");
+    return __isa(o, "TagNotFoundFault");
   }
 }
 
@@ -874,7 +867,7 @@ export namespace TagNotFoundFault {
  * <p>The request cannot be processed because it would cause the resource to have more than the allowed number of tags. The maximum number of tags permitted on a resource is 50.</p>
  */
 export interface TagQuotaPerResourceExceeded
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TagQuotaPerResourceExceeded";
   $fault: "client";
@@ -883,7 +876,7 @@ export interface TagQuotaPerResourceExceeded
 
 export namespace TagQuotaPerResourceExceeded {
   export function isa(o: any): o is TagQuotaPerResourceExceeded {
-    return _smithy.isa(o, "TagQuotaPerResourceExceeded");
+    return __isa(o, "TagQuotaPerResourceExceeded");
   }
 }
 
@@ -891,7 +884,7 @@ export namespace TagQuotaPerResourceExceeded {
  * <p>The <code>TestFailover</code> action is not available.</p>
  */
 export interface TestFailoverNotAvailableFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TestFailoverNotAvailableFault";
   $fault: "client";
@@ -900,7 +893,7 @@ export interface TestFailoverNotAvailableFault
 
 export namespace TestFailoverNotAvailableFault {
   export function isa(o: any): o is TestFailoverNotAvailableFault {
-    return _smithy.isa(o, "TestFailoverNotAvailableFault");
+    return __isa(o, "TestFailoverNotAvailableFault");
   }
 }
 
@@ -932,7 +925,7 @@ export interface AddTagsToResourceMessage {
 
 export namespace AddTagsToResourceMessage {
   export function isa(o: any): o is AddTagsToResourceMessage {
-    return _smithy.isa(o, "AddTagsToResourceMessage");
+    return __isa(o, "AddTagsToResourceMessage");
   }
 }
 
@@ -962,7 +955,7 @@ export interface AllowedNodeTypeModificationsMessage extends $MetadataBearer {
 
 export namespace AllowedNodeTypeModificationsMessage {
   export function isa(o: any): o is AllowedNodeTypeModificationsMessage {
-    return _smithy.isa(o, "AllowedNodeTypeModificationsMessage");
+    return __isa(o, "AllowedNodeTypeModificationsMessage");
   }
 }
 
@@ -995,7 +988,7 @@ export interface AuthorizeCacheSecurityGroupIngressMessage {
 
 export namespace AuthorizeCacheSecurityGroupIngressMessage {
   export function isa(o: any): o is AuthorizeCacheSecurityGroupIngressMessage {
-    return _smithy.isa(o, "AuthorizeCacheSecurityGroupIngressMessage");
+    return __isa(o, "AuthorizeCacheSecurityGroupIngressMessage");
   }
 }
 
@@ -1027,7 +1020,7 @@ export interface AuthorizeCacheSecurityGroupIngressResult
 
 export namespace AuthorizeCacheSecurityGroupIngressResult {
   export function isa(o: any): o is AuthorizeCacheSecurityGroupIngressResult {
-    return _smithy.isa(o, "AuthorizeCacheSecurityGroupIngressResult");
+    return __isa(o, "AuthorizeCacheSecurityGroupIngressResult");
   }
 }
 
@@ -1051,7 +1044,7 @@ export interface AvailabilityZone {
 
 export namespace AvailabilityZone {
   export function isa(o: any): o is AvailabilityZone {
-    return _smithy.isa(o, "AvailabilityZone");
+    return __isa(o, "AvailabilityZone");
   }
 }
 
@@ -1075,7 +1068,7 @@ export interface BatchApplyUpdateActionMessage {
 
 export namespace BatchApplyUpdateActionMessage {
   export function isa(o: any): o is BatchApplyUpdateActionMessage {
-    return _smithy.isa(o, "BatchApplyUpdateActionMessage");
+    return __isa(o, "BatchApplyUpdateActionMessage");
   }
 }
 
@@ -1099,7 +1092,7 @@ export interface BatchStopUpdateActionMessage {
 
 export namespace BatchStopUpdateActionMessage {
   export function isa(o: any): o is BatchStopUpdateActionMessage {
-    return _smithy.isa(o, "BatchStopUpdateActionMessage");
+    return __isa(o, "BatchStopUpdateActionMessage");
   }
 }
 
@@ -1497,7 +1490,7 @@ export interface CacheCluster {
 
 export namespace CacheCluster {
   export function isa(o: any): o is CacheCluster {
-    return _smithy.isa(o, "CacheCluster");
+    return __isa(o, "CacheCluster");
   }
 }
 
@@ -1519,7 +1512,7 @@ export interface CacheClusterMessage extends $MetadataBearer {
 
 export namespace CacheClusterMessage {
   export function isa(o: any): o is CacheClusterMessage {
-    return _smithy.isa(o, "CacheClusterMessage");
+    return __isa(o, "CacheClusterMessage");
   }
 }
 
@@ -1565,7 +1558,7 @@ export interface CacheEngineVersion {
 
 export namespace CacheEngineVersion {
   export function isa(o: any): o is CacheEngineVersion {
-    return _smithy.isa(o, "CacheEngineVersion");
+    return __isa(o, "CacheEngineVersion");
   }
 }
 
@@ -1588,7 +1581,7 @@ export interface CacheEngineVersionMessage extends $MetadataBearer {
 
 export namespace CacheEngineVersionMessage {
   export function isa(o: any): o is CacheEngineVersionMessage {
-    return _smithy.isa(o, "CacheEngineVersionMessage");
+    return __isa(o, "CacheEngineVersionMessage");
   }
 }
 
@@ -1800,7 +1793,7 @@ export interface CacheNode {
 
 export namespace CacheNode {
   export function isa(o: any): o is CacheNode {
-    return _smithy.isa(o, "CacheNode");
+    return __isa(o, "CacheNode");
   }
 }
 
@@ -1864,7 +1857,7 @@ export interface CacheNodeTypeSpecificParameter {
 
 export namespace CacheNodeTypeSpecificParameter {
   export function isa(o: any): o is CacheNodeTypeSpecificParameter {
-    return _smithy.isa(o, "CacheNodeTypeSpecificParameter");
+    return __isa(o, "CacheNodeTypeSpecificParameter");
   }
 }
 
@@ -1886,7 +1879,7 @@ export interface CacheNodeTypeSpecificValue {
 
 export namespace CacheNodeTypeSpecificValue {
   export function isa(o: any): o is CacheNodeTypeSpecificValue {
-    return _smithy.isa(o, "CacheNodeTypeSpecificValue");
+    return __isa(o, "CacheNodeTypeSpecificValue");
   }
 }
 
@@ -1938,7 +1931,7 @@ export interface CacheNodeUpdateStatus {
 
 export namespace CacheNodeUpdateStatus {
   export function isa(o: any): o is CacheNodeUpdateStatus {
-    return _smithy.isa(o, "CacheNodeUpdateStatus");
+    return __isa(o, "CacheNodeUpdateStatus");
   }
 }
 
@@ -1974,7 +1967,7 @@ export interface CacheParameterGroup {
 
 export namespace CacheParameterGroup {
   export function isa(o: any): o is CacheParameterGroup {
-    return _smithy.isa(o, "CacheParameterGroup");
+    return __isa(o, "CacheParameterGroup");
   }
 }
 
@@ -2002,7 +1995,7 @@ export interface CacheParameterGroupDetails extends $MetadataBearer {
 
 export namespace CacheParameterGroupDetails {
   export function isa(o: any): o is CacheParameterGroupDetails {
-    return _smithy.isa(o, "CacheParameterGroupDetails");
+    return __isa(o, "CacheParameterGroupDetails");
   }
 }
 
@@ -2031,7 +2024,7 @@ export interface CacheParameterGroupNameMessage extends $MetadataBearer {
 
 export namespace CacheParameterGroupNameMessage {
   export function isa(o: any): o is CacheParameterGroupNameMessage {
-    return _smithy.isa(o, "CacheParameterGroupNameMessage");
+    return __isa(o, "CacheParameterGroupNameMessage");
   }
 }
 
@@ -2059,7 +2052,7 @@ export interface CacheParameterGroupStatus {
 
 export namespace CacheParameterGroupStatus {
   export function isa(o: any): o is CacheParameterGroupStatus {
-    return _smithy.isa(o, "CacheParameterGroupStatus");
+    return __isa(o, "CacheParameterGroupStatus");
   }
 }
 
@@ -2082,7 +2075,7 @@ export interface CacheParameterGroupsMessage extends $MetadataBearer {
 
 export namespace CacheParameterGroupsMessage {
   export function isa(o: any): o is CacheParameterGroupsMessage {
-    return _smithy.isa(o, "CacheParameterGroupsMessage");
+    return __isa(o, "CacheParameterGroupsMessage");
   }
 }
 
@@ -2131,7 +2124,7 @@ export interface CacheSecurityGroup {
 
 export namespace CacheSecurityGroup {
   export function isa(o: any): o is CacheSecurityGroup {
-    return _smithy.isa(o, "CacheSecurityGroup");
+    return __isa(o, "CacheSecurityGroup");
   }
 }
 
@@ -2153,7 +2146,7 @@ export interface CacheSecurityGroupMembership {
 
 export namespace CacheSecurityGroupMembership {
   export function isa(o: any): o is CacheSecurityGroupMembership {
-    return _smithy.isa(o, "CacheSecurityGroupMembership");
+    return __isa(o, "CacheSecurityGroupMembership");
   }
 }
 
@@ -2175,7 +2168,7 @@ export interface CacheSecurityGroupMessage extends $MetadataBearer {
 
 export namespace CacheSecurityGroupMessage {
   export function isa(o: any): o is CacheSecurityGroupMessage {
-    return _smithy.isa(o, "CacheSecurityGroupMessage");
+    return __isa(o, "CacheSecurityGroupMessage");
   }
 }
 
@@ -2219,7 +2212,7 @@ export interface CacheSubnetGroup {
 
 export namespace CacheSubnetGroup {
   export function isa(o: any): o is CacheSubnetGroup {
-    return _smithy.isa(o, "CacheSubnetGroup");
+    return __isa(o, "CacheSubnetGroup");
   }
 }
 
@@ -2241,7 +2234,7 @@ export interface CacheSubnetGroupMessage extends $MetadataBearer {
 
 export namespace CacheSubnetGroupMessage {
   export function isa(o: any): o is CacheSubnetGroupMessage {
-    return _smithy.isa(o, "CacheSubnetGroupMessage");
+    return __isa(o, "CacheSubnetGroupMessage");
   }
 }
 
@@ -2262,7 +2255,7 @@ export interface CompleteMigrationMessage {
 
 export namespace CompleteMigrationMessage {
   export function isa(o: any): o is CompleteMigrationMessage {
-    return _smithy.isa(o, "CompleteMigrationMessage");
+    return __isa(o, "CompleteMigrationMessage");
   }
 }
 
@@ -2276,7 +2269,7 @@ export interface CompleteMigrationResponse extends $MetadataBearer {
 
 export namespace CompleteMigrationResponse {
   export function isa(o: any): o is CompleteMigrationResponse {
-    return _smithy.isa(o, "CompleteMigrationResponse");
+    return __isa(o, "CompleteMigrationResponse");
   }
 }
 
@@ -2329,7 +2322,7 @@ export interface ConfigureShard {
 
 export namespace ConfigureShard {
   export function isa(o: any): o is ConfigureShard {
-    return _smithy.isa(o, "ConfigureShard");
+    return __isa(o, "ConfigureShard");
   }
 }
 
@@ -2369,7 +2362,7 @@ export interface CopySnapshotMessage {
 
 export namespace CopySnapshotMessage {
   export function isa(o: any): o is CopySnapshotMessage {
-    return _smithy.isa(o, "CopySnapshotMessage");
+    return __isa(o, "CopySnapshotMessage");
   }
 }
 
@@ -2383,7 +2376,7 @@ export interface CopySnapshotResult extends $MetadataBearer {
 
 export namespace CopySnapshotResult {
   export function isa(o: any): o is CopySnapshotResult {
-    return _smithy.isa(o, "CopySnapshotResult");
+    return __isa(o, "CopySnapshotResult");
   }
 }
 
@@ -2819,7 +2812,7 @@ export interface CreateCacheClusterMessage {
 
 export namespace CreateCacheClusterMessage {
   export function isa(o: any): o is CreateCacheClusterMessage {
-    return _smithy.isa(o, "CreateCacheClusterMessage");
+    return __isa(o, "CreateCacheClusterMessage");
   }
 }
 
@@ -2833,7 +2826,7 @@ export interface CreateCacheClusterResult extends $MetadataBearer {
 
 export namespace CreateCacheClusterResult {
   export function isa(o: any): o is CreateCacheClusterResult {
-    return _smithy.isa(o, "CreateCacheClusterResult");
+    return __isa(o, "CreateCacheClusterResult");
   }
 }
 
@@ -2869,7 +2862,7 @@ export interface CreateCacheParameterGroupMessage {
 
 export namespace CreateCacheParameterGroupMessage {
   export function isa(o: any): o is CreateCacheParameterGroupMessage {
-    return _smithy.isa(o, "CreateCacheParameterGroupMessage");
+    return __isa(o, "CreateCacheParameterGroupMessage");
   }
 }
 
@@ -2883,7 +2876,7 @@ export interface CreateCacheParameterGroupResult extends $MetadataBearer {
 
 export namespace CreateCacheParameterGroupResult {
   export function isa(o: any): o is CreateCacheParameterGroupResult {
-    return _smithy.isa(o, "CreateCacheParameterGroupResult");
+    return __isa(o, "CreateCacheParameterGroupResult");
   }
 }
 
@@ -2908,7 +2901,7 @@ export interface CreateCacheSecurityGroupMessage {
 
 export namespace CreateCacheSecurityGroupMessage {
   export function isa(o: any): o is CreateCacheSecurityGroupMessage {
-    return _smithy.isa(o, "CreateCacheSecurityGroupMessage");
+    return __isa(o, "CreateCacheSecurityGroupMessage");
   }
 }
 
@@ -2939,7 +2932,7 @@ export interface CreateCacheSecurityGroupResult extends $MetadataBearer {
 
 export namespace CreateCacheSecurityGroupResult {
   export function isa(o: any): o is CreateCacheSecurityGroupResult {
-    return _smithy.isa(o, "CreateCacheSecurityGroupResult");
+    return __isa(o, "CreateCacheSecurityGroupResult");
   }
 }
 
@@ -2969,7 +2962,7 @@ export interface CreateCacheSubnetGroupMessage {
 
 export namespace CreateCacheSubnetGroupMessage {
   export function isa(o: any): o is CreateCacheSubnetGroupMessage {
-    return _smithy.isa(o, "CreateCacheSubnetGroupMessage");
+    return __isa(o, "CreateCacheSubnetGroupMessage");
   }
 }
 
@@ -2995,7 +2988,7 @@ export interface CreateCacheSubnetGroupResult extends $MetadataBearer {
 
 export namespace CreateCacheSubnetGroupResult {
   export function isa(o: any): o is CreateCacheSubnetGroupResult {
-    return _smithy.isa(o, "CreateCacheSubnetGroupResult");
+    return __isa(o, "CreateCacheSubnetGroupResult");
   }
 }
 
@@ -3525,7 +3518,7 @@ export interface CreateReplicationGroupMessage {
 
 export namespace CreateReplicationGroupMessage {
   export function isa(o: any): o is CreateReplicationGroupMessage {
-    return _smithy.isa(o, "CreateReplicationGroupMessage");
+    return __isa(o, "CreateReplicationGroupMessage");
   }
 }
 
@@ -3539,7 +3532,7 @@ export interface CreateReplicationGroupResult extends $MetadataBearer {
 
 export namespace CreateReplicationGroupResult {
   export function isa(o: any): o is CreateReplicationGroupResult {
-    return _smithy.isa(o, "CreateReplicationGroupResult");
+    return __isa(o, "CreateReplicationGroupResult");
   }
 }
 
@@ -3571,7 +3564,7 @@ export interface CreateSnapshotMessage {
 
 export namespace CreateSnapshotMessage {
   export function isa(o: any): o is CreateSnapshotMessage {
-    return _smithy.isa(o, "CreateSnapshotMessage");
+    return __isa(o, "CreateSnapshotMessage");
   }
 }
 
@@ -3585,7 +3578,7 @@ export interface CreateSnapshotResult extends $MetadataBearer {
 
 export namespace CreateSnapshotResult {
   export function isa(o: any): o is CreateSnapshotResult {
-    return _smithy.isa(o, "CreateSnapshotResult");
+    return __isa(o, "CreateSnapshotResult");
   }
 }
 
@@ -3607,7 +3600,7 @@ export interface CustomerNodeEndpoint {
 
 export namespace CustomerNodeEndpoint {
   export function isa(o: any): o is CustomerNodeEndpoint {
-    return _smithy.isa(o, "CustomerNodeEndpoint");
+    return __isa(o, "CustomerNodeEndpoint");
   }
 }
 
@@ -3665,7 +3658,7 @@ export interface DecreaseReplicaCountMessage {
 
 export namespace DecreaseReplicaCountMessage {
   export function isa(o: any): o is DecreaseReplicaCountMessage {
-    return _smithy.isa(o, "DecreaseReplicaCountMessage");
+    return __isa(o, "DecreaseReplicaCountMessage");
   }
 }
 
@@ -3679,7 +3672,7 @@ export interface DecreaseReplicaCountResult extends $MetadataBearer {
 
 export namespace DecreaseReplicaCountResult {
   export function isa(o: any): o is DecreaseReplicaCountResult {
-    return _smithy.isa(o, "DecreaseReplicaCountResult");
+    return __isa(o, "DecreaseReplicaCountResult");
   }
 }
 
@@ -3702,7 +3695,7 @@ export interface DeleteCacheClusterMessage {
 
 export namespace DeleteCacheClusterMessage {
   export function isa(o: any): o is DeleteCacheClusterMessage {
-    return _smithy.isa(o, "DeleteCacheClusterMessage");
+    return __isa(o, "DeleteCacheClusterMessage");
   }
 }
 
@@ -3716,7 +3709,7 @@ export interface DeleteCacheClusterResult extends $MetadataBearer {
 
 export namespace DeleteCacheClusterResult {
   export function isa(o: any): o is DeleteCacheClusterResult {
-    return _smithy.isa(o, "DeleteCacheClusterResult");
+    return __isa(o, "DeleteCacheClusterResult");
   }
 }
 
@@ -3736,7 +3729,7 @@ export interface DeleteCacheParameterGroupMessage {
 
 export namespace DeleteCacheParameterGroupMessage {
   export function isa(o: any): o is DeleteCacheParameterGroupMessage {
-    return _smithy.isa(o, "DeleteCacheParameterGroupMessage");
+    return __isa(o, "DeleteCacheParameterGroupMessage");
   }
 }
 
@@ -3756,7 +3749,7 @@ export interface DeleteCacheSecurityGroupMessage {
 
 export namespace DeleteCacheSecurityGroupMessage {
   export function isa(o: any): o is DeleteCacheSecurityGroupMessage {
-    return _smithy.isa(o, "DeleteCacheSecurityGroupMessage");
+    return __isa(o, "DeleteCacheSecurityGroupMessage");
   }
 }
 
@@ -3774,7 +3767,7 @@ export interface DeleteCacheSubnetGroupMessage {
 
 export namespace DeleteCacheSubnetGroupMessage {
   export function isa(o: any): o is DeleteCacheSubnetGroupMessage {
-    return _smithy.isa(o, "DeleteCacheSubnetGroupMessage");
+    return __isa(o, "DeleteCacheSubnetGroupMessage");
   }
 }
 
@@ -3805,7 +3798,7 @@ export interface DeleteReplicationGroupMessage {
 
 export namespace DeleteReplicationGroupMessage {
   export function isa(o: any): o is DeleteReplicationGroupMessage {
-    return _smithy.isa(o, "DeleteReplicationGroupMessage");
+    return __isa(o, "DeleteReplicationGroupMessage");
   }
 }
 
@@ -3819,7 +3812,7 @@ export interface DeleteReplicationGroupResult extends $MetadataBearer {
 
 export namespace DeleteReplicationGroupResult {
   export function isa(o: any): o is DeleteReplicationGroupResult {
-    return _smithy.isa(o, "DeleteReplicationGroupResult");
+    return __isa(o, "DeleteReplicationGroupResult");
   }
 }
 
@@ -3836,7 +3829,7 @@ export interface DeleteSnapshotMessage {
 
 export namespace DeleteSnapshotMessage {
   export function isa(o: any): o is DeleteSnapshotMessage {
-    return _smithy.isa(o, "DeleteSnapshotMessage");
+    return __isa(o, "DeleteSnapshotMessage");
   }
 }
 
@@ -3850,7 +3843,7 @@ export interface DeleteSnapshotResult extends $MetadataBearer {
 
 export namespace DeleteSnapshotResult {
   export function isa(o: any): o is DeleteSnapshotResult {
-    return _smithy.isa(o, "DeleteSnapshotResult");
+    return __isa(o, "DeleteSnapshotResult");
   }
 }
 
@@ -3899,7 +3892,7 @@ export interface DescribeCacheClustersMessage {
 
 export namespace DescribeCacheClustersMessage {
   export function isa(o: any): o is DescribeCacheClustersMessage {
-    return _smithy.isa(o, "DescribeCacheClustersMessage");
+    return __isa(o, "DescribeCacheClustersMessage");
   }
 }
 
@@ -3973,7 +3966,7 @@ export interface DescribeCacheEngineVersionsMessage {
 
 export namespace DescribeCacheEngineVersionsMessage {
   export function isa(o: any): o is DescribeCacheEngineVersionsMessage {
-    return _smithy.isa(o, "DescribeCacheEngineVersionsMessage");
+    return __isa(o, "DescribeCacheEngineVersionsMessage");
   }
 }
 
@@ -4007,7 +4000,7 @@ export interface DescribeCacheParameterGroupsMessage {
 
 export namespace DescribeCacheParameterGroupsMessage {
   export function isa(o: any): o is DescribeCacheParameterGroupsMessage {
-    return _smithy.isa(o, "DescribeCacheParameterGroupsMessage");
+    return __isa(o, "DescribeCacheParameterGroupsMessage");
   }
 }
 
@@ -4049,7 +4042,7 @@ export interface DescribeCacheParametersMessage {
 
 export namespace DescribeCacheParametersMessage {
   export function isa(o: any): o is DescribeCacheParametersMessage {
-    return _smithy.isa(o, "DescribeCacheParametersMessage");
+    return __isa(o, "DescribeCacheParametersMessage");
   }
 }
 
@@ -4083,7 +4076,7 @@ export interface DescribeCacheSecurityGroupsMessage {
 
 export namespace DescribeCacheSecurityGroupsMessage {
   export function isa(o: any): o is DescribeCacheSecurityGroupsMessage {
-    return _smithy.isa(o, "DescribeCacheSecurityGroupsMessage");
+    return __isa(o, "DescribeCacheSecurityGroupsMessage");
   }
 }
 
@@ -4118,7 +4111,7 @@ export interface DescribeCacheSubnetGroupsMessage {
 
 export namespace DescribeCacheSubnetGroupsMessage {
   export function isa(o: any): o is DescribeCacheSubnetGroupsMessage {
-    return _smithy.isa(o, "DescribeCacheSubnetGroupsMessage");
+    return __isa(o, "DescribeCacheSubnetGroupsMessage");
   }
 }
 
@@ -4161,7 +4154,7 @@ export interface DescribeEngineDefaultParametersMessage {
 
 export namespace DescribeEngineDefaultParametersMessage {
   export function isa(o: any): o is DescribeEngineDefaultParametersMessage {
-    return _smithy.isa(o, "DescribeEngineDefaultParametersMessage");
+    return __isa(o, "DescribeEngineDefaultParametersMessage");
   }
 }
 
@@ -4175,7 +4168,7 @@ export interface DescribeEngineDefaultParametersResult extends $MetadataBearer {
 
 export namespace DescribeEngineDefaultParametersResult {
   export function isa(o: any): o is DescribeEngineDefaultParametersResult {
-    return _smithy.isa(o, "DescribeEngineDefaultParametersResult");
+    return __isa(o, "DescribeEngineDefaultParametersResult");
   }
 }
 
@@ -4236,7 +4229,7 @@ export interface DescribeEventsMessage {
 
 export namespace DescribeEventsMessage {
   export function isa(o: any): o is DescribeEventsMessage {
-    return _smithy.isa(o, "DescribeEventsMessage");
+    return __isa(o, "DescribeEventsMessage");
   }
 }
 
@@ -4271,7 +4264,7 @@ export interface DescribeReplicationGroupsMessage {
 
 export namespace DescribeReplicationGroupsMessage {
   export function isa(o: any): o is DescribeReplicationGroupsMessage {
-    return _smithy.isa(o, "DescribeReplicationGroupsMessage");
+    return __isa(o, "DescribeReplicationGroupsMessage");
   }
 }
 
@@ -4502,7 +4495,7 @@ export interface DescribeReservedCacheNodesMessage {
 
 export namespace DescribeReservedCacheNodesMessage {
   export function isa(o: any): o is DescribeReservedCacheNodesMessage {
-    return _smithy.isa(o, "DescribeReservedCacheNodesMessage");
+    return __isa(o, "DescribeReservedCacheNodesMessage");
   }
 }
 
@@ -4730,7 +4723,7 @@ export interface DescribeReservedCacheNodesOfferingsMessage {
 
 export namespace DescribeReservedCacheNodesOfferingsMessage {
   export function isa(o: any): o is DescribeReservedCacheNodesOfferingsMessage {
-    return _smithy.isa(o, "DescribeReservedCacheNodesOfferingsMessage");
+    return __isa(o, "DescribeReservedCacheNodesOfferingsMessage");
   }
 }
 
@@ -4762,7 +4755,7 @@ export interface DescribeServiceUpdatesMessage {
 
 export namespace DescribeServiceUpdatesMessage {
   export function isa(o: any): o is DescribeServiceUpdatesMessage {
-    return _smithy.isa(o, "DescribeServiceUpdatesMessage");
+    return __isa(o, "DescribeServiceUpdatesMessage");
   }
 }
 
@@ -4787,7 +4780,7 @@ export interface DescribeSnapshotsListMessage extends $MetadataBearer {
 
 export namespace DescribeSnapshotsListMessage {
   export function isa(o: any): o is DescribeSnapshotsListMessage {
-    return _smithy.isa(o, "DescribeSnapshotsListMessage");
+    return __isa(o, "DescribeSnapshotsListMessage");
   }
 }
 
@@ -4846,7 +4839,7 @@ export interface DescribeSnapshotsMessage {
 
 export namespace DescribeSnapshotsMessage {
   export function isa(o: any): o is DescribeSnapshotsMessage {
-    return _smithy.isa(o, "DescribeSnapshotsMessage");
+    return __isa(o, "DescribeSnapshotsMessage");
   }
 }
 
@@ -4908,7 +4901,7 @@ export interface DescribeUpdateActionsMessage {
 
 export namespace DescribeUpdateActionsMessage {
   export function isa(o: any): o is DescribeUpdateActionsMessage {
-    return _smithy.isa(o, "DescribeUpdateActionsMessage");
+    return __isa(o, "DescribeUpdateActionsMessage");
   }
 }
 
@@ -4935,7 +4928,7 @@ export interface EC2SecurityGroup {
 
 export namespace EC2SecurityGroup {
   export function isa(o: any): o is EC2SecurityGroup {
-    return _smithy.isa(o, "EC2SecurityGroup");
+    return __isa(o, "EC2SecurityGroup");
   }
 }
 
@@ -4957,7 +4950,7 @@ export interface Endpoint {
 
 export namespace Endpoint {
   export function isa(o: any): o is Endpoint {
-    return _smithy.isa(o, "Endpoint");
+    return __isa(o, "Endpoint");
   }
 }
 
@@ -4998,7 +4991,7 @@ export interface EngineDefaults {
 
 export namespace EngineDefaults {
   export function isa(o: any): o is EngineDefaults {
-    return _smithy.isa(o, "EngineDefaults");
+    return __isa(o, "EngineDefaults");
   }
 }
 
@@ -5033,7 +5026,7 @@ export interface Event {
 
 export namespace Event {
   export function isa(o: any): o is Event {
-    return _smithy.isa(o, "Event");
+    return __isa(o, "Event");
   }
 }
 
@@ -5055,7 +5048,7 @@ export interface EventsMessage extends $MetadataBearer {
 
 export namespace EventsMessage {
   export function isa(o: any): o is EventsMessage {
-    return _smithy.isa(o, "EventsMessage");
+    return __isa(o, "EventsMessage");
   }
 }
 
@@ -5091,7 +5084,7 @@ export interface IncreaseReplicaCountMessage {
 
 export namespace IncreaseReplicaCountMessage {
   export function isa(o: any): o is IncreaseReplicaCountMessage {
-    return _smithy.isa(o, "IncreaseReplicaCountMessage");
+    return __isa(o, "IncreaseReplicaCountMessage");
   }
 }
 
@@ -5105,7 +5098,7 @@ export interface IncreaseReplicaCountResult extends $MetadataBearer {
 
 export namespace IncreaseReplicaCountResult {
   export function isa(o: any): o is IncreaseReplicaCountResult {
-    return _smithy.isa(o, "IncreaseReplicaCountResult");
+    return __isa(o, "IncreaseReplicaCountResult");
   }
 }
 
@@ -5140,7 +5133,7 @@ export interface ListAllowedNodeTypeModificationsMessage {
 
 export namespace ListAllowedNodeTypeModificationsMessage {
   export function isa(o: any): o is ListAllowedNodeTypeModificationsMessage {
-    return _smithy.isa(o, "ListAllowedNodeTypeModificationsMessage");
+    return __isa(o, "ListAllowedNodeTypeModificationsMessage");
   }
 }
 
@@ -5160,7 +5153,7 @@ export interface ListTagsForResourceMessage {
 
 export namespace ListTagsForResourceMessage {
   export function isa(o: any): o is ListTagsForResourceMessage {
-    return _smithy.isa(o, "ListTagsForResourceMessage");
+    return __isa(o, "ListTagsForResourceMessage");
   }
 }
 
@@ -5516,7 +5509,7 @@ export interface ModifyCacheClusterMessage {
 
 export namespace ModifyCacheClusterMessage {
   export function isa(o: any): o is ModifyCacheClusterMessage {
-    return _smithy.isa(o, "ModifyCacheClusterMessage");
+    return __isa(o, "ModifyCacheClusterMessage");
   }
 }
 
@@ -5530,7 +5523,7 @@ export interface ModifyCacheClusterResult extends $MetadataBearer {
 
 export namespace ModifyCacheClusterResult {
   export function isa(o: any): o is ModifyCacheClusterResult {
-    return _smithy.isa(o, "ModifyCacheClusterResult");
+    return __isa(o, "ModifyCacheClusterResult");
   }
 }
 
@@ -5552,7 +5545,7 @@ export interface ModifyCacheParameterGroupMessage {
 
 export namespace ModifyCacheParameterGroupMessage {
   export function isa(o: any): o is ModifyCacheParameterGroupMessage {
-    return _smithy.isa(o, "ModifyCacheParameterGroupMessage");
+    return __isa(o, "ModifyCacheParameterGroupMessage");
   }
 }
 
@@ -5582,7 +5575,7 @@ export interface ModifyCacheSubnetGroupMessage {
 
 export namespace ModifyCacheSubnetGroupMessage {
   export function isa(o: any): o is ModifyCacheSubnetGroupMessage {
-    return _smithy.isa(o, "ModifyCacheSubnetGroupMessage");
+    return __isa(o, "ModifyCacheSubnetGroupMessage");
   }
 }
 
@@ -5608,7 +5601,7 @@ export interface ModifyCacheSubnetGroupResult extends $MetadataBearer {
 
 export namespace ModifyCacheSubnetGroupResult {
   export function isa(o: any): o is ModifyCacheSubnetGroupResult {
-    return _smithy.isa(o, "ModifyCacheSubnetGroupResult");
+    return __isa(o, "ModifyCacheSubnetGroupResult");
   }
 }
 
@@ -5842,7 +5835,7 @@ export interface ModifyReplicationGroupMessage {
 
 export namespace ModifyReplicationGroupMessage {
   export function isa(o: any): o is ModifyReplicationGroupMessage {
-    return _smithy.isa(o, "ModifyReplicationGroupMessage");
+    return __isa(o, "ModifyReplicationGroupMessage");
   }
 }
 
@@ -5856,7 +5849,7 @@ export interface ModifyReplicationGroupResult extends $MetadataBearer {
 
 export namespace ModifyReplicationGroupResult {
   export function isa(o: any): o is ModifyReplicationGroupResult {
-    return _smithy.isa(o, "ModifyReplicationGroupResult");
+    return __isa(o, "ModifyReplicationGroupResult");
   }
 }
 
@@ -5922,7 +5915,7 @@ export namespace ModifyReplicationGroupShardConfigurationMessage {
   export function isa(
     o: any
   ): o is ModifyReplicationGroupShardConfigurationMessage {
-    return _smithy.isa(o, "ModifyReplicationGroupShardConfigurationMessage");
+    return __isa(o, "ModifyReplicationGroupShardConfigurationMessage");
   }
 }
 
@@ -5939,7 +5932,7 @@ export namespace ModifyReplicationGroupShardConfigurationResult {
   export function isa(
     o: any
   ): o is ModifyReplicationGroupShardConfigurationResult {
-    return _smithy.isa(o, "ModifyReplicationGroupShardConfigurationResult");
+    return __isa(o, "ModifyReplicationGroupShardConfigurationResult");
   }
 }
 
@@ -5986,7 +5979,7 @@ export interface NodeGroup {
 
 export namespace NodeGroup {
   export function isa(o: any): o is NodeGroup {
-    return _smithy.isa(o, "NodeGroup");
+    return __isa(o, "NodeGroup");
   }
 }
 
@@ -6031,7 +6024,7 @@ export interface NodeGroupConfiguration {
 
 export namespace NodeGroupConfiguration {
   export function isa(o: any): o is NodeGroupConfiguration {
-    return _smithy.isa(o, "NodeGroupConfiguration");
+    return __isa(o, "NodeGroupConfiguration");
   }
 }
 
@@ -6071,7 +6064,7 @@ export interface NodeGroupMember {
 
 export namespace NodeGroupMember {
   export function isa(o: any): o is NodeGroupMember {
-    return _smithy.isa(o, "NodeGroupMember");
+    return __isa(o, "NodeGroupMember");
   }
 }
 
@@ -6128,7 +6121,7 @@ export interface NodeGroupMemberUpdateStatus {
 
 export namespace NodeGroupMemberUpdateStatus {
   export function isa(o: any): o is NodeGroupMemberUpdateStatus {
-    return _smithy.isa(o, "NodeGroupMemberUpdateStatus");
+    return __isa(o, "NodeGroupMemberUpdateStatus");
   }
 }
 
@@ -6150,7 +6143,7 @@ export interface NodeGroupUpdateStatus {
 
 export namespace NodeGroupUpdateStatus {
   export function isa(o: any): o is NodeGroupUpdateStatus {
-    return _smithy.isa(o, "NodeGroupUpdateStatus");
+    return __isa(o, "NodeGroupUpdateStatus");
   }
 }
 
@@ -6197,7 +6190,7 @@ export interface NodeSnapshot {
 
 export namespace NodeSnapshot {
   export function isa(o: any): o is NodeSnapshot {
-    return _smithy.isa(o, "NodeSnapshot");
+    return __isa(o, "NodeSnapshot");
   }
 }
 
@@ -6235,7 +6228,7 @@ export interface NotificationConfiguration {
 
 export namespace NotificationConfiguration {
   export function isa(o: any): o is NotificationConfiguration {
-    return _smithy.isa(o, "NotificationConfiguration");
+    return __isa(o, "NotificationConfiguration");
   }
 }
 
@@ -6296,7 +6289,7 @@ export interface Parameter {
 
 export namespace Parameter {
   export function isa(o: any): o is Parameter {
-    return _smithy.isa(o, "Parameter");
+    return __isa(o, "Parameter");
   }
 }
 
@@ -6318,7 +6311,7 @@ export interface ParameterNameValue {
 
 export namespace ParameterNameValue {
   export function isa(o: any): o is ParameterNameValue {
-    return _smithy.isa(o, "ParameterNameValue");
+    return __isa(o, "ParameterNameValue");
   }
 }
 
@@ -6364,7 +6357,7 @@ export interface PendingModifiedValues {
 
 export namespace PendingModifiedValues {
   export function isa(o: any): o is PendingModifiedValues {
-    return _smithy.isa(o, "PendingModifiedValues");
+    return __isa(o, "PendingModifiedValues");
   }
 }
 
@@ -6396,7 +6389,7 @@ export interface ProcessedUpdateAction {
 
 export namespace ProcessedUpdateAction {
   export function isa(o: any): o is ProcessedUpdateAction {
-    return _smithy.isa(o, "ProcessedUpdateAction");
+    return __isa(o, "ProcessedUpdateAction");
   }
 }
 
@@ -6433,7 +6426,7 @@ export interface PurchaseReservedCacheNodesOfferingMessage {
 
 export namespace PurchaseReservedCacheNodesOfferingMessage {
   export function isa(o: any): o is PurchaseReservedCacheNodesOfferingMessage {
-    return _smithy.isa(o, "PurchaseReservedCacheNodesOfferingMessage");
+    return __isa(o, "PurchaseReservedCacheNodesOfferingMessage");
   }
 }
 
@@ -6448,7 +6441,7 @@ export interface PurchaseReservedCacheNodesOfferingResult
 
 export namespace PurchaseReservedCacheNodesOfferingResult {
   export function isa(o: any): o is PurchaseReservedCacheNodesOfferingResult {
-    return _smithy.isa(o, "PurchaseReservedCacheNodesOfferingResult");
+    return __isa(o, "PurchaseReservedCacheNodesOfferingResult");
   }
 }
 
@@ -6470,7 +6463,7 @@ export interface RebootCacheClusterMessage {
 
 export namespace RebootCacheClusterMessage {
   export function isa(o: any): o is RebootCacheClusterMessage {
-    return _smithy.isa(o, "RebootCacheClusterMessage");
+    return __isa(o, "RebootCacheClusterMessage");
   }
 }
 
@@ -6484,7 +6477,7 @@ export interface RebootCacheClusterResult extends $MetadataBearer {
 
 export namespace RebootCacheClusterResult {
   export function isa(o: any): o is RebootCacheClusterResult {
-    return _smithy.isa(o, "RebootCacheClusterResult");
+    return __isa(o, "RebootCacheClusterResult");
   }
 }
 
@@ -6507,7 +6500,7 @@ export interface RecurringCharge {
 
 export namespace RecurringCharge {
   export function isa(o: any): o is RecurringCharge {
-    return _smithy.isa(o, "RecurringCharge");
+    return __isa(o, "RecurringCharge");
   }
 }
 
@@ -6532,7 +6525,7 @@ export interface RemoveTagsFromResourceMessage {
 
 export namespace RemoveTagsFromResourceMessage {
   export function isa(o: any): o is RemoveTagsFromResourceMessage {
-    return _smithy.isa(o, "RemoveTagsFromResourceMessage");
+    return __isa(o, "RemoveTagsFromResourceMessage");
   }
 }
 
@@ -6693,7 +6686,7 @@ export interface ReplicationGroup {
 
 export namespace ReplicationGroup {
   export function isa(o: any): o is ReplicationGroup {
-    return _smithy.isa(o, "ReplicationGroup");
+    return __isa(o, "ReplicationGroup");
   }
 }
 
@@ -6715,7 +6708,7 @@ export interface ReplicationGroupMessage extends $MetadataBearer {
 
 export namespace ReplicationGroupMessage {
   export function isa(o: any): o is ReplicationGroupMessage {
-    return _smithy.isa(o, "ReplicationGroupMessage");
+    return __isa(o, "ReplicationGroupMessage");
   }
 }
 
@@ -6761,7 +6754,7 @@ export interface ReplicationGroupPendingModifiedValues {
 
 export namespace ReplicationGroupPendingModifiedValues {
   export function isa(o: any): o is ReplicationGroupPendingModifiedValues {
-    return _smithy.isa(o, "ReplicationGroupPendingModifiedValues");
+    return __isa(o, "ReplicationGroupPendingModifiedValues");
   }
 }
 
@@ -7002,7 +6995,7 @@ export interface ReservedCacheNode {
 
 export namespace ReservedCacheNode {
   export function isa(o: any): o is ReservedCacheNode {
-    return _smithy.isa(o, "ReservedCacheNode");
+    return __isa(o, "ReservedCacheNode");
   }
 }
 
@@ -7024,7 +7017,7 @@ export interface ReservedCacheNodeMessage extends $MetadataBearer {
 
 export namespace ReservedCacheNodeMessage {
   export function isa(o: any): o is ReservedCacheNodeMessage {
-    return _smithy.isa(o, "ReservedCacheNodeMessage");
+    return __isa(o, "ReservedCacheNodeMessage");
   }
 }
 
@@ -7237,7 +7230,7 @@ export interface ReservedCacheNodesOffering {
 
 export namespace ReservedCacheNodesOffering {
   export function isa(o: any): o is ReservedCacheNodesOffering {
-    return _smithy.isa(o, "ReservedCacheNodesOffering");
+    return __isa(o, "ReservedCacheNodesOffering");
   }
 }
 
@@ -7259,7 +7252,7 @@ export interface ReservedCacheNodesOfferingMessage extends $MetadataBearer {
 
 export namespace ReservedCacheNodesOfferingMessage {
   export function isa(o: any): o is ReservedCacheNodesOfferingMessage {
-    return _smithy.isa(o, "ReservedCacheNodesOfferingMessage");
+    return __isa(o, "ReservedCacheNodesOfferingMessage");
   }
 }
 
@@ -7295,7 +7288,7 @@ export interface ResetCacheParameterGroupMessage {
 
 export namespace ResetCacheParameterGroupMessage {
   export function isa(o: any): o is ResetCacheParameterGroupMessage {
-    return _smithy.isa(o, "ResetCacheParameterGroupMessage");
+    return __isa(o, "ResetCacheParameterGroupMessage");
   }
 }
 
@@ -7319,7 +7312,7 @@ export interface ReshardingConfiguration {
 
 export namespace ReshardingConfiguration {
   export function isa(o: any): o is ReshardingConfiguration {
-    return _smithy.isa(o, "ReshardingConfiguration");
+    return __isa(o, "ReshardingConfiguration");
   }
 }
 
@@ -7336,7 +7329,7 @@ export interface ReshardingStatus {
 
 export namespace ReshardingStatus {
   export function isa(o: any): o is ReshardingStatus {
-    return _smithy.isa(o, "ReshardingStatus");
+    return __isa(o, "ReshardingStatus");
   }
 }
 
@@ -7365,7 +7358,7 @@ export interface RevokeCacheSecurityGroupIngressMessage {
 
 export namespace RevokeCacheSecurityGroupIngressMessage {
   export function isa(o: any): o is RevokeCacheSecurityGroupIngressMessage {
-    return _smithy.isa(o, "RevokeCacheSecurityGroupIngressMessage");
+    return __isa(o, "RevokeCacheSecurityGroupIngressMessage");
   }
 }
 
@@ -7396,7 +7389,7 @@ export interface RevokeCacheSecurityGroupIngressResult extends $MetadataBearer {
 
 export namespace RevokeCacheSecurityGroupIngressResult {
   export function isa(o: any): o is RevokeCacheSecurityGroupIngressResult {
-    return _smithy.isa(o, "RevokeCacheSecurityGroupIngressResult");
+    return __isa(o, "RevokeCacheSecurityGroupIngressResult");
   }
 }
 
@@ -7420,7 +7413,7 @@ export interface SecurityGroupMembership {
 
 export namespace SecurityGroupMembership {
   export function isa(o: any): o is SecurityGroupMembership {
-    return _smithy.isa(o, "SecurityGroupMembership");
+    return __isa(o, "SecurityGroupMembership");
   }
 }
 
@@ -7492,7 +7485,7 @@ export interface ServiceUpdate {
 
 export namespace ServiceUpdate {
   export function isa(o: any): o is ServiceUpdate {
-    return _smithy.isa(o, "ServiceUpdate");
+    return __isa(o, "ServiceUpdate");
   }
 }
 
@@ -7531,7 +7524,7 @@ export interface ServiceUpdatesMessage extends $MetadataBearer {
 
 export namespace ServiceUpdatesMessage {
   export function isa(o: any): o is ServiceUpdatesMessage {
-    return _smithy.isa(o, "ServiceUpdatesMessage");
+    return __isa(o, "ServiceUpdatesMessage");
   }
 }
 
@@ -7554,7 +7547,7 @@ export interface SlotMigration {
 
 export namespace SlotMigration {
   export function isa(o: any): o is SlotMigration {
-    return _smithy.isa(o, "SlotMigration");
+    return __isa(o, "SlotMigration");
   }
 }
 
@@ -7924,7 +7917,7 @@ export interface Snapshot {
 
 export namespace Snapshot {
   export function isa(o: any): o is Snapshot {
-    return _smithy.isa(o, "Snapshot");
+    return __isa(o, "Snapshot");
   }
 }
 
@@ -7950,7 +7943,7 @@ export interface StartMigrationMessage {
 
 export namespace StartMigrationMessage {
   export function isa(o: any): o is StartMigrationMessage {
-    return _smithy.isa(o, "StartMigrationMessage");
+    return __isa(o, "StartMigrationMessage");
   }
 }
 
@@ -7964,7 +7957,7 @@ export interface StartMigrationResponse extends $MetadataBearer {
 
 export namespace StartMigrationResponse {
   export function isa(o: any): o is StartMigrationResponse {
-    return _smithy.isa(o, "StartMigrationResponse");
+    return __isa(o, "StartMigrationResponse");
   }
 }
 
@@ -7987,7 +7980,7 @@ export interface Subnet {
 
 export namespace Subnet {
   export function isa(o: any): o is Subnet {
-    return _smithy.isa(o, "Subnet");
+    return __isa(o, "Subnet");
   }
 }
 
@@ -8010,7 +8003,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -8028,7 +8021,7 @@ export interface TagListMessage extends $MetadataBearer {
 
 export namespace TagListMessage {
   export function isa(o: any): o is TagListMessage {
-    return _smithy.isa(o, "TagListMessage");
+    return __isa(o, "TagListMessage");
   }
 }
 
@@ -8050,7 +8043,7 @@ export interface TestFailoverMessage {
 
 export namespace TestFailoverMessage {
   export function isa(o: any): o is TestFailoverMessage {
-    return _smithy.isa(o, "TestFailoverMessage");
+    return __isa(o, "TestFailoverMessage");
   }
 }
 
@@ -8064,7 +8057,7 @@ export interface TestFailoverResult extends $MetadataBearer {
 
 export namespace TestFailoverResult {
   export function isa(o: any): o is TestFailoverResult {
-    return _smithy.isa(o, "TestFailoverResult");
+    return __isa(o, "TestFailoverResult");
   }
 }
 
@@ -8086,7 +8079,7 @@ export interface TimeRangeFilter {
 
 export namespace TimeRangeFilter {
   export function isa(o: any): o is TimeRangeFilter {
-    return _smithy.isa(o, "TimeRangeFilter");
+    return __isa(o, "TimeRangeFilter");
   }
 }
 
@@ -8123,7 +8116,7 @@ export interface UnprocessedUpdateAction {
 
 export namespace UnprocessedUpdateAction {
   export function isa(o: any): o is UnprocessedUpdateAction {
-    return _smithy.isa(o, "UnprocessedUpdateAction");
+    return __isa(o, "UnprocessedUpdateAction");
   }
 }
 
@@ -8221,7 +8214,7 @@ export interface UpdateAction {
 
 export namespace UpdateAction {
   export function isa(o: any): o is UpdateAction {
-    return _smithy.isa(o, "UpdateAction");
+    return __isa(o, "UpdateAction");
   }
 }
 
@@ -8240,7 +8233,7 @@ export interface UpdateActionResultsMessage extends $MetadataBearer {
 
 export namespace UpdateActionResultsMessage {
   export function isa(o: any): o is UpdateActionResultsMessage {
-    return _smithy.isa(o, "UpdateActionResultsMessage");
+    return __isa(o, "UpdateActionResultsMessage");
   }
 }
 
@@ -8271,6 +8264,6 @@ export interface UpdateActionsMessage extends $MetadataBearer {
 
 export namespace UpdateActionsMessage {
   export function isa(o: any): o is UpdateActionsMessage {
-    return _smithy.isa(o, "UpdateActionsMessage");
+    return __isa(o, "UpdateActionsMessage");
   }
 }

--- a/clients/client-elasticache/protocols/Aws_query.ts
+++ b/clients/client-elasticache/protocols/Aws_query.ts
@@ -2653,6 +2653,7 @@ export async function deserializeAws_queryDeleteCacheParameterGroupCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteCacheParameterGroupCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2727,6 +2728,7 @@ export async function deserializeAws_queryDeleteCacheSecurityGroupCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteCacheSecurityGroupCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2801,6 +2803,7 @@ export async function deserializeAws_queryDeleteCacheSubnetGroupCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteCacheSubnetGroupCommandOutput = {
     $metadata: deserializeMetadata(output)
   };

--- a/clients/client-elasticsearch-service/models/index.ts
+++ b/clients/client-elasticsearch-service/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -20,7 +23,7 @@ export interface AccessPoliciesStatus {
 
 export namespace AccessPoliciesStatus {
   export function isa(o: any): o is AccessPoliciesStatus {
-    return _smithy.isa(o, "AccessPoliciesStatus");
+    return __isa(o, "AccessPoliciesStatus");
   }
 }
 
@@ -42,7 +45,7 @@ export interface AddTagsRequest {
 
 export namespace AddTagsRequest {
   export function isa(o: any): o is AddTagsRequest {
-    return _smithy.isa(o, "AddTagsRequest");
+    return __isa(o, "AddTagsRequest");
   }
 }
 
@@ -101,7 +104,7 @@ export interface AdditionalLimit {
 
 export namespace AdditionalLimit {
   export function isa(o: any): o is AdditionalLimit {
-    return _smithy.isa(o, "AdditionalLimit");
+    return __isa(o, "AdditionalLimit");
   }
 }
 
@@ -129,7 +132,7 @@ export interface AdvancedOptionsStatus {
 
 export namespace AdvancedOptionsStatus {
   export function isa(o: any): o is AdvancedOptionsStatus {
-    return _smithy.isa(o, "AdvancedOptionsStatus");
+    return __isa(o, "AdvancedOptionsStatus");
   }
 }
 
@@ -148,7 +151,7 @@ export namespace CancelElasticsearchServiceSoftwareUpdateRequest {
   export function isa(
     o: any
   ): o is CancelElasticsearchServiceSoftwareUpdateRequest {
-    return _smithy.isa(o, "CancelElasticsearchServiceSoftwareUpdateRequest");
+    return __isa(o, "CancelElasticsearchServiceSoftwareUpdateRequest");
   }
 }
 
@@ -168,7 +171,7 @@ export namespace CancelElasticsearchServiceSoftwareUpdateResponse {
   export function isa(
     o: any
   ): o is CancelElasticsearchServiceSoftwareUpdateResponse {
-    return _smithy.isa(o, "CancelElasticsearchServiceSoftwareUpdateResponse");
+    return __isa(o, "CancelElasticsearchServiceSoftwareUpdateResponse");
   }
 }
 
@@ -200,7 +203,7 @@ export interface CognitoOptions {
 
 export namespace CognitoOptions {
   export function isa(o: any): o is CognitoOptions {
-    return _smithy.isa(o, "CognitoOptions");
+    return __isa(o, "CognitoOptions");
   }
 }
 
@@ -222,7 +225,7 @@ export interface CognitoOptionsStatus {
 
 export namespace CognitoOptionsStatus {
   export function isa(o: any): o is CognitoOptionsStatus {
-    return _smithy.isa(o, "CognitoOptionsStatus");
+    return __isa(o, "CognitoOptionsStatus");
   }
 }
 
@@ -255,7 +258,7 @@ export interface CompatibleVersionsMap {
 
 export namespace CompatibleVersionsMap {
   export function isa(o: any): o is CompatibleVersionsMap {
-    return _smithy.isa(o, "CompatibleVersionsMap");
+    return __isa(o, "CompatibleVersionsMap");
   }
 }
 
@@ -331,7 +334,7 @@ export interface CreateElasticsearchDomainRequest {
 
 export namespace CreateElasticsearchDomainRequest {
   export function isa(o: any): o is CreateElasticsearchDomainRequest {
-    return _smithy.isa(o, "CreateElasticsearchDomainRequest");
+    return __isa(o, "CreateElasticsearchDomainRequest");
   }
 }
 
@@ -348,7 +351,7 @@ export interface CreateElasticsearchDomainResponse extends $MetadataBearer {
 
 export namespace CreateElasticsearchDomainResponse {
   export function isa(o: any): o is CreateElasticsearchDomainResponse {
-    return _smithy.isa(o, "CreateElasticsearchDomainResponse");
+    return __isa(o, "CreateElasticsearchDomainResponse");
   }
 }
 
@@ -365,7 +368,7 @@ export interface DeleteElasticsearchDomainRequest {
 
 export namespace DeleteElasticsearchDomainRequest {
   export function isa(o: any): o is DeleteElasticsearchDomainRequest {
-    return _smithy.isa(o, "DeleteElasticsearchDomainRequest");
+    return __isa(o, "DeleteElasticsearchDomainRequest");
   }
 }
 
@@ -382,7 +385,7 @@ export interface DeleteElasticsearchDomainResponse extends $MetadataBearer {
 
 export namespace DeleteElasticsearchDomainResponse {
   export function isa(o: any): o is DeleteElasticsearchDomainResponse {
-    return _smithy.isa(o, "DeleteElasticsearchDomainResponse");
+    return __isa(o, "DeleteElasticsearchDomainResponse");
   }
 }
 
@@ -406,7 +409,7 @@ export interface DescribeElasticsearchDomainConfigRequest {
 
 export namespace DescribeElasticsearchDomainConfigRequest {
   export function isa(o: any): o is DescribeElasticsearchDomainConfigRequest {
-    return _smithy.isa(o, "DescribeElasticsearchDomainConfigRequest");
+    return __isa(o, "DescribeElasticsearchDomainConfigRequest");
   }
 }
 
@@ -424,7 +427,7 @@ export interface DescribeElasticsearchDomainConfigResponse
 
 export namespace DescribeElasticsearchDomainConfigResponse {
   export function isa(o: any): o is DescribeElasticsearchDomainConfigResponse {
-    return _smithy.isa(o, "DescribeElasticsearchDomainConfigResponse");
+    return __isa(o, "DescribeElasticsearchDomainConfigResponse");
   }
 }
 
@@ -441,7 +444,7 @@ export interface DescribeElasticsearchDomainRequest {
 
 export namespace DescribeElasticsearchDomainRequest {
   export function isa(o: any): o is DescribeElasticsearchDomainRequest {
-    return _smithy.isa(o, "DescribeElasticsearchDomainRequest");
+    return __isa(o, "DescribeElasticsearchDomainRequest");
   }
 }
 
@@ -458,7 +461,7 @@ export interface DescribeElasticsearchDomainResponse extends $MetadataBearer {
 
 export namespace DescribeElasticsearchDomainResponse {
   export function isa(o: any): o is DescribeElasticsearchDomainResponse {
-    return _smithy.isa(o, "DescribeElasticsearchDomainResponse");
+    return __isa(o, "DescribeElasticsearchDomainResponse");
   }
 }
 
@@ -475,7 +478,7 @@ export interface DescribeElasticsearchDomainsRequest {
 
 export namespace DescribeElasticsearchDomainsRequest {
   export function isa(o: any): o is DescribeElasticsearchDomainsRequest {
-    return _smithy.isa(o, "DescribeElasticsearchDomainsRequest");
+    return __isa(o, "DescribeElasticsearchDomainsRequest");
   }
 }
 
@@ -492,7 +495,7 @@ export interface DescribeElasticsearchDomainsResponse extends $MetadataBearer {
 
 export namespace DescribeElasticsearchDomainsResponse {
   export function isa(o: any): o is DescribeElasticsearchDomainsResponse {
-    return _smithy.isa(o, "DescribeElasticsearchDomainsResponse");
+    return __isa(o, "DescribeElasticsearchDomainsResponse");
   }
 }
 
@@ -547,7 +550,7 @@ export namespace DescribeElasticsearchInstanceTypeLimitsRequest {
   export function isa(
     o: any
   ): o is DescribeElasticsearchInstanceTypeLimitsRequest {
-    return _smithy.isa(o, "DescribeElasticsearchInstanceTypeLimitsRequest");
+    return __isa(o, "DescribeElasticsearchInstanceTypeLimitsRequest");
   }
 }
 
@@ -582,7 +585,7 @@ export namespace DescribeElasticsearchInstanceTypeLimitsResponse {
   export function isa(
     o: any
   ): o is DescribeElasticsearchInstanceTypeLimitsResponse {
-    return _smithy.isa(o, "DescribeElasticsearchInstanceTypeLimitsResponse");
+    return __isa(o, "DescribeElasticsearchInstanceTypeLimitsResponse");
   }
 }
 
@@ -612,10 +615,7 @@ export namespace DescribeReservedElasticsearchInstanceOfferingsRequest {
   export function isa(
     o: any
   ): o is DescribeReservedElasticsearchInstanceOfferingsRequest {
-    return _smithy.isa(
-      o,
-      "DescribeReservedElasticsearchInstanceOfferingsRequest"
-    );
+    return __isa(o, "DescribeReservedElasticsearchInstanceOfferingsRequest");
   }
 }
 
@@ -642,10 +642,7 @@ export namespace DescribeReservedElasticsearchInstanceOfferingsResponse {
   export function isa(
     o: any
   ): o is DescribeReservedElasticsearchInstanceOfferingsResponse {
-    return _smithy.isa(
-      o,
-      "DescribeReservedElasticsearchInstanceOfferingsResponse"
-    );
+    return __isa(o, "DescribeReservedElasticsearchInstanceOfferingsResponse");
   }
 }
 
@@ -675,7 +672,7 @@ export namespace DescribeReservedElasticsearchInstancesRequest {
   export function isa(
     o: any
   ): o is DescribeReservedElasticsearchInstancesRequest {
-    return _smithy.isa(o, "DescribeReservedElasticsearchInstancesRequest");
+    return __isa(o, "DescribeReservedElasticsearchInstancesRequest");
   }
 }
 
@@ -700,7 +697,7 @@ export namespace DescribeReservedElasticsearchInstancesResponse {
   export function isa(
     o: any
   ): o is DescribeReservedElasticsearchInstancesResponse {
-    return _smithy.isa(o, "DescribeReservedElasticsearchInstancesResponse");
+    return __isa(o, "DescribeReservedElasticsearchInstancesResponse");
   }
 }
 
@@ -728,7 +725,7 @@ export interface DomainEndpointOptions {
 
 export namespace DomainEndpointOptions {
   export function isa(o: any): o is DomainEndpointOptions {
-    return _smithy.isa(o, "DomainEndpointOptions");
+    return __isa(o, "DomainEndpointOptions");
   }
 }
 
@@ -750,7 +747,7 @@ export interface DomainEndpointOptionsStatus {
 
 export namespace DomainEndpointOptionsStatus {
   export function isa(o: any): o is DomainEndpointOptionsStatus {
-    return _smithy.isa(o, "DomainEndpointOptionsStatus");
+    return __isa(o, "DomainEndpointOptionsStatus");
   }
 }
 
@@ -764,7 +761,7 @@ export interface DomainInfo {
 
 export namespace DomainInfo {
   export function isa(o: any): o is DomainInfo {
-    return _smithy.isa(o, "DomainInfo");
+    return __isa(o, "DomainInfo");
   }
 }
 
@@ -796,7 +793,7 @@ export interface EBSOptions {
 
 export namespace EBSOptions {
   export function isa(o: any): o is EBSOptions {
-    return _smithy.isa(o, "EBSOptions");
+    return __isa(o, "EBSOptions");
   }
 }
 
@@ -818,7 +815,7 @@ export interface EBSOptionsStatus {
 
 export namespace EBSOptionsStatus {
   export function isa(o: any): o is EBSOptionsStatus {
-    return _smithy.isa(o, "EBSOptionsStatus");
+    return __isa(o, "EBSOptionsStatus");
   }
 }
 
@@ -944,7 +941,7 @@ export interface ElasticsearchClusterConfig {
 
 export namespace ElasticsearchClusterConfig {
   export function isa(o: any): o is ElasticsearchClusterConfig {
-    return _smithy.isa(o, "ElasticsearchClusterConfig");
+    return __isa(o, "ElasticsearchClusterConfig");
   }
 }
 
@@ -966,7 +963,7 @@ export interface ElasticsearchClusterConfigStatus {
 
 export namespace ElasticsearchClusterConfigStatus {
   export function isa(o: any): o is ElasticsearchClusterConfigStatus {
-    return _smithy.isa(o, "ElasticsearchClusterConfigStatus");
+    return __isa(o, "ElasticsearchClusterConfigStatus");
   }
 }
 
@@ -1038,7 +1035,7 @@ export interface ElasticsearchDomainConfig {
 
 export namespace ElasticsearchDomainConfig {
   export function isa(o: any): o is ElasticsearchDomainConfig {
-    return _smithy.isa(o, "ElasticsearchDomainConfig");
+    return __isa(o, "ElasticsearchDomainConfig");
   }
 }
 
@@ -1156,7 +1153,7 @@ export interface ElasticsearchDomainStatus {
 
 export namespace ElasticsearchDomainStatus {
   export function isa(o: any): o is ElasticsearchDomainStatus {
-    return _smithy.isa(o, "ElasticsearchDomainStatus");
+    return __isa(o, "ElasticsearchDomainStatus");
   }
 }
 
@@ -1178,7 +1175,7 @@ export interface ElasticsearchVersionStatus {
 
 export namespace ElasticsearchVersionStatus {
   export function isa(o: any): o is ElasticsearchVersionStatus {
-    return _smithy.isa(o, "ElasticsearchVersionStatus");
+    return __isa(o, "ElasticsearchVersionStatus");
   }
 }
 
@@ -1200,7 +1197,7 @@ export interface EncryptionAtRestOptions {
 
 export namespace EncryptionAtRestOptions {
   export function isa(o: any): o is EncryptionAtRestOptions {
-    return _smithy.isa(o, "EncryptionAtRestOptions");
+    return __isa(o, "EncryptionAtRestOptions");
   }
 }
 
@@ -1222,7 +1219,7 @@ export interface EncryptionAtRestOptionsStatus {
 
 export namespace EncryptionAtRestOptionsStatus {
   export function isa(o: any): o is EncryptionAtRestOptionsStatus {
-    return _smithy.isa(o, "EncryptionAtRestOptionsStatus");
+    return __isa(o, "EncryptionAtRestOptionsStatus");
   }
 }
 
@@ -1245,7 +1242,7 @@ export interface GetCompatibleElasticsearchVersionsRequest {
 
 export namespace GetCompatibleElasticsearchVersionsRequest {
   export function isa(o: any): o is GetCompatibleElasticsearchVersionsRequest {
-    return _smithy.isa(o, "GetCompatibleElasticsearchVersionsRequest");
+    return __isa(o, "GetCompatibleElasticsearchVersionsRequest");
   }
 }
 
@@ -1275,7 +1272,7 @@ export interface GetCompatibleElasticsearchVersionsResponse
 
 export namespace GetCompatibleElasticsearchVersionsResponse {
   export function isa(o: any): o is GetCompatibleElasticsearchVersionsResponse {
-    return _smithy.isa(o, "GetCompatibleElasticsearchVersionsResponse");
+    return __isa(o, "GetCompatibleElasticsearchVersionsResponse");
   }
 }
 
@@ -1313,7 +1310,7 @@ export interface GetUpgradeHistoryRequest {
 
 export namespace GetUpgradeHistoryRequest {
   export function isa(o: any): o is GetUpgradeHistoryRequest {
-    return _smithy.isa(o, "GetUpgradeHistoryRequest");
+    return __isa(o, "GetUpgradeHistoryRequest");
   }
 }
 
@@ -1351,7 +1348,7 @@ export interface GetUpgradeHistoryResponse extends $MetadataBearer {
 
 export namespace GetUpgradeHistoryResponse {
   export function isa(o: any): o is GetUpgradeHistoryResponse {
-    return _smithy.isa(o, "GetUpgradeHistoryResponse");
+    return __isa(o, "GetUpgradeHistoryResponse");
   }
 }
 
@@ -1374,7 +1371,7 @@ export interface GetUpgradeStatusRequest {
 
 export namespace GetUpgradeStatusRequest {
   export function isa(o: any): o is GetUpgradeStatusRequest {
-    return _smithy.isa(o, "GetUpgradeStatusRequest");
+    return __isa(o, "GetUpgradeStatusRequest");
   }
 }
 
@@ -1426,7 +1423,7 @@ export interface GetUpgradeStatusResponse extends $MetadataBearer {
 
 export namespace GetUpgradeStatusResponse {
   export function isa(o: any): o is GetUpgradeStatusResponse {
-    return _smithy.isa(o, "GetUpgradeStatusResponse");
+    return __isa(o, "GetUpgradeStatusResponse");
   }
 }
 
@@ -1455,7 +1452,7 @@ export interface InstanceCountLimits {
 
 export namespace InstanceCountLimits {
   export function isa(o: any): o is InstanceCountLimits {
-    return _smithy.isa(o, "InstanceCountLimits");
+    return __isa(o, "InstanceCountLimits");
   }
 }
 
@@ -1476,7 +1473,7 @@ export interface InstanceLimits {
 
 export namespace InstanceLimits {
   export function isa(o: any): o is InstanceLimits {
-    return _smithy.isa(o, "InstanceLimits");
+    return __isa(o, "InstanceLimits");
   }
 }
 
@@ -1526,7 +1523,7 @@ export interface Limits {
 
 export namespace Limits {
   export function isa(o: any): o is Limits {
-    return _smithy.isa(o, "Limits");
+    return __isa(o, "Limits");
   }
 }
 
@@ -1543,7 +1540,7 @@ export interface ListDomainNamesResponse extends $MetadataBearer {
 
 export namespace ListDomainNamesResponse {
   export function isa(o: any): o is ListDomainNamesResponse {
-    return _smithy.isa(o, "ListDomainNamesResponse");
+    return __isa(o, "ListDomainNamesResponse");
   }
 }
 
@@ -1590,7 +1587,7 @@ export interface ListElasticsearchInstanceTypesRequest {
 
 export namespace ListElasticsearchInstanceTypesRequest {
   export function isa(o: any): o is ListElasticsearchInstanceTypesRequest {
-    return _smithy.isa(o, "ListElasticsearchInstanceTypesRequest");
+    return __isa(o, "ListElasticsearchInstanceTypesRequest");
   }
 }
 
@@ -1628,7 +1625,7 @@ export interface ListElasticsearchInstanceTypesResponse
 
 export namespace ListElasticsearchInstanceTypesResponse {
   export function isa(o: any): o is ListElasticsearchInstanceTypesResponse {
-    return _smithy.isa(o, "ListElasticsearchInstanceTypesResponse");
+    return __isa(o, "ListElasticsearchInstanceTypesResponse");
   }
 }
 
@@ -1678,7 +1675,7 @@ export interface ListElasticsearchVersionsRequest {
 
 export namespace ListElasticsearchVersionsRequest {
   export function isa(o: any): o is ListElasticsearchVersionsRequest {
-    return _smithy.isa(o, "ListElasticsearchVersionsRequest");
+    return __isa(o, "ListElasticsearchVersionsRequest");
   }
 }
 
@@ -1710,7 +1707,7 @@ export interface ListElasticsearchVersionsResponse extends $MetadataBearer {
 
 export namespace ListElasticsearchVersionsResponse {
   export function isa(o: any): o is ListElasticsearchVersionsResponse {
-    return _smithy.isa(o, "ListElasticsearchVersionsResponse");
+    return __isa(o, "ListElasticsearchVersionsResponse");
   }
 }
 
@@ -1727,7 +1724,7 @@ export interface ListTagsRequest {
 
 export namespace ListTagsRequest {
   export function isa(o: any): o is ListTagsRequest {
-    return _smithy.isa(o, "ListTagsRequest");
+    return __isa(o, "ListTagsRequest");
   }
 }
 
@@ -1744,7 +1741,7 @@ export interface ListTagsResponse extends $MetadataBearer {
 
 export namespace ListTagsResponse {
   export function isa(o: any): o is ListTagsResponse {
-    return _smithy.isa(o, "ListTagsResponse");
+    return __isa(o, "ListTagsResponse");
   }
 }
 
@@ -1772,7 +1769,7 @@ export interface LogPublishingOption {
 
 export namespace LogPublishingOption {
   export function isa(o: any): o is LogPublishingOption {
-    return _smithy.isa(o, "LogPublishingOption");
+    return __isa(o, "LogPublishingOption");
   }
 }
 
@@ -1794,7 +1791,7 @@ export interface LogPublishingOptionsStatus {
 
 export namespace LogPublishingOptionsStatus {
   export function isa(o: any): o is LogPublishingOptionsStatus {
-    return _smithy.isa(o, "LogPublishingOptionsStatus");
+    return __isa(o, "LogPublishingOptionsStatus");
   }
 }
 
@@ -1816,7 +1813,7 @@ export interface NodeToNodeEncryptionOptions {
 
 export namespace NodeToNodeEncryptionOptions {
   export function isa(o: any): o is NodeToNodeEncryptionOptions {
-    return _smithy.isa(o, "NodeToNodeEncryptionOptions");
+    return __isa(o, "NodeToNodeEncryptionOptions");
   }
 }
 
@@ -1838,7 +1835,7 @@ export interface NodeToNodeEncryptionOptionsStatus {
 
 export namespace NodeToNodeEncryptionOptionsStatus {
   export function isa(o: any): o is NodeToNodeEncryptionOptionsStatus {
-    return _smithy.isa(o, "NodeToNodeEncryptionOptionsStatus");
+    return __isa(o, "NodeToNodeEncryptionOptionsStatus");
   }
 }
 
@@ -1877,7 +1874,7 @@ export interface OptionStatus {
 
 export namespace OptionStatus {
   export function isa(o: any): o is OptionStatus {
-    return _smithy.isa(o, "OptionStatus");
+    return __isa(o, "OptionStatus");
   }
 }
 
@@ -1906,10 +1903,7 @@ export namespace PurchaseReservedElasticsearchInstanceOfferingRequest {
   export function isa(
     o: any
   ): o is PurchaseReservedElasticsearchInstanceOfferingRequest {
-    return _smithy.isa(
-      o,
-      "PurchaseReservedElasticsearchInstanceOfferingRequest"
-    );
+    return __isa(o, "PurchaseReservedElasticsearchInstanceOfferingRequest");
   }
 }
 
@@ -1934,10 +1928,7 @@ export namespace PurchaseReservedElasticsearchInstanceOfferingResponse {
   export function isa(
     o: any
   ): o is PurchaseReservedElasticsearchInstanceOfferingResponse {
-    return _smithy.isa(
-      o,
-      "PurchaseReservedElasticsearchInstanceOfferingResponse"
-    );
+    return __isa(o, "PurchaseReservedElasticsearchInstanceOfferingResponse");
   }
 }
 
@@ -1959,7 +1950,7 @@ export interface RecurringCharge {
 
 export namespace RecurringCharge {
   export function isa(o: any): o is RecurringCharge {
-    return _smithy.isa(o, "RecurringCharge");
+    return __isa(o, "RecurringCharge");
   }
 }
 
@@ -1981,7 +1972,7 @@ export interface RemoveTagsRequest {
 
 export namespace RemoveTagsRequest {
   export function isa(o: any): o is RemoveTagsRequest {
-    return _smithy.isa(o, "RemoveTagsRequest");
+    return __isa(o, "RemoveTagsRequest");
   }
 }
 
@@ -2058,7 +2049,7 @@ export interface ReservedElasticsearchInstance {
 
 export namespace ReservedElasticsearchInstance {
   export function isa(o: any): o is ReservedElasticsearchInstance {
-    return _smithy.isa(o, "ReservedElasticsearchInstance");
+    return __isa(o, "ReservedElasticsearchInstance");
   }
 }
 
@@ -2110,7 +2101,7 @@ export interface ReservedElasticsearchInstanceOffering {
 
 export namespace ReservedElasticsearchInstanceOffering {
   export function isa(o: any): o is ReservedElasticsearchInstanceOffering {
-    return _smithy.isa(o, "ReservedElasticsearchInstanceOffering");
+    return __isa(o, "ReservedElasticsearchInstanceOffering");
   }
 }
 
@@ -2162,7 +2153,7 @@ export interface ServiceSoftwareOptions {
 
 export namespace ServiceSoftwareOptions {
   export function isa(o: any): o is ServiceSoftwareOptions {
-    return _smithy.isa(o, "ServiceSoftwareOptions");
+    return __isa(o, "ServiceSoftwareOptions");
   }
 }
 
@@ -2179,7 +2170,7 @@ export interface SnapshotOptions {
 
 export namespace SnapshotOptions {
   export function isa(o: any): o is SnapshotOptions {
-    return _smithy.isa(o, "SnapshotOptions");
+    return __isa(o, "SnapshotOptions");
   }
 }
 
@@ -2201,7 +2192,7 @@ export interface SnapshotOptionsStatus {
 
 export namespace SnapshotOptionsStatus {
   export function isa(o: any): o is SnapshotOptionsStatus {
-    return _smithy.isa(o, "SnapshotOptionsStatus");
+    return __isa(o, "SnapshotOptionsStatus");
   }
 }
 
@@ -2220,7 +2211,7 @@ export namespace StartElasticsearchServiceSoftwareUpdateRequest {
   export function isa(
     o: any
   ): o is StartElasticsearchServiceSoftwareUpdateRequest {
-    return _smithy.isa(o, "StartElasticsearchServiceSoftwareUpdateRequest");
+    return __isa(o, "StartElasticsearchServiceSoftwareUpdateRequest");
   }
 }
 
@@ -2240,7 +2231,7 @@ export namespace StartElasticsearchServiceSoftwareUpdateResponse {
   export function isa(
     o: any
   ): o is StartElasticsearchServiceSoftwareUpdateResponse {
-    return _smithy.isa(o, "StartElasticsearchServiceSoftwareUpdateResponse");
+    return __isa(o, "StartElasticsearchServiceSoftwareUpdateResponse");
   }
 }
 
@@ -2288,7 +2279,7 @@ export interface StorageType {
 
 export namespace StorageType {
   export function isa(o: any): o is StorageType {
-    return _smithy.isa(o, "StorageType");
+    return __isa(o, "StorageType");
   }
 }
 
@@ -2334,7 +2325,7 @@ export interface StorageTypeLimit {
 
 export namespace StorageTypeLimit {
   export function isa(o: any): o is StorageTypeLimit {
-    return _smithy.isa(o, "StorageTypeLimit");
+    return __isa(o, "StorageTypeLimit");
   }
 }
 
@@ -2362,7 +2353,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -2425,7 +2416,7 @@ export interface UpdateElasticsearchDomainConfigRequest {
 
 export namespace UpdateElasticsearchDomainConfigRequest {
   export function isa(o: any): o is UpdateElasticsearchDomainConfigRequest {
-    return _smithy.isa(o, "UpdateElasticsearchDomainConfigRequest");
+    return __isa(o, "UpdateElasticsearchDomainConfigRequest");
   }
 }
 
@@ -2443,7 +2434,7 @@ export interface UpdateElasticsearchDomainConfigResponse
 
 export namespace UpdateElasticsearchDomainConfigResponse {
   export function isa(o: any): o is UpdateElasticsearchDomainConfigResponse {
-    return _smithy.isa(o, "UpdateElasticsearchDomainConfigResponse");
+    return __isa(o, "UpdateElasticsearchDomainConfigResponse");
   }
 }
 
@@ -2479,7 +2470,7 @@ export interface UpgradeElasticsearchDomainRequest {
 
 export namespace UpgradeElasticsearchDomainRequest {
   export function isa(o: any): o is UpgradeElasticsearchDomainRequest {
-    return _smithy.isa(o, "UpgradeElasticsearchDomainRequest");
+    return __isa(o, "UpgradeElasticsearchDomainRequest");
   }
 }
 
@@ -2515,7 +2506,7 @@ export interface UpgradeElasticsearchDomainResponse extends $MetadataBearer {
 
 export namespace UpgradeElasticsearchDomainResponse {
   export function isa(o: any): o is UpgradeElasticsearchDomainResponse {
-    return _smithy.isa(o, "UpgradeElasticsearchDomainResponse");
+    return __isa(o, "UpgradeElasticsearchDomainResponse");
   }
 }
 
@@ -2561,7 +2552,7 @@ export interface UpgradeHistory {
 
 export namespace UpgradeHistory {
   export function isa(o: any): o is UpgradeHistory {
-    return _smithy.isa(o, "UpgradeHistory");
+    return __isa(o, "UpgradeHistory");
   }
 }
 
@@ -2616,7 +2607,7 @@ export interface UpgradeStepItem {
 
 export namespace UpgradeStepItem {
   export function isa(o: any): o is UpgradeStepItem {
-    return _smithy.isa(o, "UpgradeStepItem");
+    return __isa(o, "UpgradeStepItem");
   }
 }
 
@@ -2648,7 +2639,7 @@ export interface VPCDerivedInfo {
 
 export namespace VPCDerivedInfo {
   export function isa(o: any): o is VPCDerivedInfo {
-    return _smithy.isa(o, "VPCDerivedInfo");
+    return __isa(o, "VPCDerivedInfo");
   }
 }
 
@@ -2670,7 +2661,7 @@ export interface VPCDerivedInfoStatus {
 
 export namespace VPCDerivedInfoStatus {
   export function isa(o: any): o is VPCDerivedInfoStatus {
-    return _smithy.isa(o, "VPCDerivedInfoStatus");
+    return __isa(o, "VPCDerivedInfoStatus");
   }
 }
 
@@ -2692,7 +2683,7 @@ export interface VPCOptions {
 
 export namespace VPCOptions {
   export function isa(o: any): o is VPCOptions {
-    return _smithy.isa(o, "VPCOptions");
+    return __isa(o, "VPCOptions");
   }
 }
 
@@ -2711,16 +2702,14 @@ export interface ZoneAwarenessConfig {
 
 export namespace ZoneAwarenessConfig {
   export function isa(o: any): o is ZoneAwarenessConfig {
-    return _smithy.isa(o, "ZoneAwarenessConfig");
+    return __isa(o, "ZoneAwarenessConfig");
   }
 }
 
 /**
  * <p>An error occurred while processing the request.</p>
  */
-export interface BaseException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface BaseException extends __SmithyException, $MetadataBearer {
   name: "BaseException";
   $fault: "client";
   /**
@@ -2731,7 +2720,7 @@ export interface BaseException
 
 export namespace BaseException {
   export function isa(o: any): o is BaseException {
-    return _smithy.isa(o, "BaseException");
+    return __isa(o, "BaseException");
   }
 }
 
@@ -2739,7 +2728,7 @@ export namespace BaseException {
  * <p>An error occured because the client wanted to access a not supported operation. Gives http status code of 409.</p>
  */
 export interface DisabledOperationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DisabledOperationException";
   $fault: "client";
@@ -2751,16 +2740,14 @@ export interface DisabledOperationException
 
 export namespace DisabledOperationException {
   export function isa(o: any): o is DisabledOperationException {
-    return _smithy.isa(o, "DisabledOperationException");
+    return __isa(o, "DisabledOperationException");
   }
 }
 
 /**
  * <p>The request processing has failed because of an unknown error, exception or failure (the failure is internal to the service) . Gives http status code of 500.</p>
  */
-export interface InternalException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface InternalException extends __SmithyException, $MetadataBearer {
   name: "InternalException";
   $fault: "server";
   /**
@@ -2771,7 +2758,7 @@ export interface InternalException
 
 export namespace InternalException {
   export function isa(o: any): o is InternalException {
-    return _smithy.isa(o, "InternalException");
+    return __isa(o, "InternalException");
   }
 }
 
@@ -2779,7 +2766,7 @@ export namespace InternalException {
  * <p>An exception for trying to create or access sub-resource that is either invalid or not supported. Gives http status code of 409.</p>
  */
 export interface InvalidTypeException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidTypeException";
   $fault: "client";
@@ -2791,7 +2778,7 @@ export interface InvalidTypeException
 
 export namespace InvalidTypeException {
   export function isa(o: any): o is InvalidTypeException {
-    return _smithy.isa(o, "InvalidTypeException");
+    return __isa(o, "InvalidTypeException");
   }
 }
 
@@ -2799,7 +2786,7 @@ export namespace InvalidTypeException {
  * <p>An exception for trying to create more than allowed resources or sub-resources. Gives http status code of 409.</p>
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -2811,7 +2798,7 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
@@ -2819,7 +2806,7 @@ export namespace LimitExceededException {
  * <p>An exception for creating a resource that already exists. Gives http status code of 400.</p>
  */
 export interface ResourceAlreadyExistsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceAlreadyExistsException";
   $fault: "client";
@@ -2831,7 +2818,7 @@ export interface ResourceAlreadyExistsException
 
 export namespace ResourceAlreadyExistsException {
   export function isa(o: any): o is ResourceAlreadyExistsException {
-    return _smithy.isa(o, "ResourceAlreadyExistsException");
+    return __isa(o, "ResourceAlreadyExistsException");
   }
 }
 
@@ -2839,7 +2826,7 @@ export namespace ResourceAlreadyExistsException {
  * <p>An exception for accessing or deleting a resource that does not exist. Gives http status code of 400.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -2851,7 +2838,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -2859,7 +2846,7 @@ export namespace ResourceNotFoundException {
  * <p>An exception for missing / invalid input fields. Gives http status code of 400.</p>
  */
 export interface ValidationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ValidationException";
   $fault: "client";
@@ -2871,6 +2858,6 @@ export interface ValidationException
 
 export namespace ValidationException {
   export function isa(o: any): o is ValidationException {
-    return _smithy.isa(o, "ValidationException");
+    return __isa(o, "ValidationException");
   }
 }

--- a/clients/client-elasticsearch-service/protocols/Aws_restJson1_1.ts
+++ b/clients/client-elasticsearch-service/protocols/Aws_restJson1_1.ts
@@ -146,7 +146,10 @@ import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  extendedEncodeURIComponent as __extendedEncodeURIComponent
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -313,13 +316,13 @@ export async function serializeAws_restJson1_1DeleteElasticsearchDomainCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/2015-01-01/es/domain/{DomainName}";
   if (input.DomainName !== undefined) {
-    const labelValue: string = input.DomainName.toString();
+    const labelValue: string = input.DomainName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DomainName.");
     }
     resolvedPath = resolvedPath.replace(
       "{DomainName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DomainName.");
@@ -357,13 +360,13 @@ export async function serializeAws_restJson1_1DescribeElasticsearchDomainCommand
   headers["Content-Type"] = "";
   let resolvedPath = "/2015-01-01/es/domain/{DomainName}";
   if (input.DomainName !== undefined) {
-    const labelValue: string = input.DomainName.toString();
+    const labelValue: string = input.DomainName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DomainName.");
     }
     resolvedPath = resolvedPath.replace(
       "{DomainName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DomainName.");
@@ -385,13 +388,13 @@ export async function serializeAws_restJson1_1DescribeElasticsearchDomainConfigC
   headers["Content-Type"] = "";
   let resolvedPath = "/2015-01-01/es/domain/{DomainName}/config";
   if (input.DomainName !== undefined) {
-    const labelValue: string = input.DomainName.toString();
+    const labelValue: string = input.DomainName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DomainName.");
     }
     resolvedPath = resolvedPath.replace(
       "{DomainName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DomainName.");
@@ -440,7 +443,7 @@ export async function serializeAws_restJson1_1DescribeElasticsearchInstanceTypeL
   let resolvedPath =
     "/2015-01-01/es/instanceTypeLimits/{ElasticsearchVersion}/{InstanceType}";
   if (input.ElasticsearchVersion !== undefined) {
-    const labelValue: string = input.ElasticsearchVersion.toString();
+    const labelValue: string = input.ElasticsearchVersion;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ElasticsearchVersion."
@@ -448,7 +451,7 @@ export async function serializeAws_restJson1_1DescribeElasticsearchInstanceTypeL
     }
     resolvedPath = resolvedPath.replace(
       "{ElasticsearchVersion}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -456,7 +459,7 @@ export async function serializeAws_restJson1_1DescribeElasticsearchInstanceTypeL
     );
   }
   if (input.InstanceType !== undefined) {
-    const labelValue: string = input.InstanceType.toString();
+    const labelValue: string = input.InstanceType;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: InstanceType."
@@ -464,14 +467,16 @@ export async function serializeAws_restJson1_1DescribeElasticsearchInstanceTypeL
     }
     resolvedPath = resolvedPath.replace(
       "{InstanceType}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: InstanceType.");
   }
   const query: any = {};
   if (input.DomainName !== undefined) {
-    query["domainName"] = input.DomainName.toString();
+    query[
+      __extendedEncodeURIComponent("domainName")
+    ] = __extendedEncodeURIComponent(input.DomainName);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -492,15 +497,21 @@ export async function serializeAws_restJson1_1DescribeReservedElasticsearchInsta
   let resolvedPath = "/2015-01-01/es/reservedInstanceOfferings";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   if (input.ReservedElasticsearchInstanceOfferingId !== undefined) {
     query[
-      "offeringId"
-    ] = input.ReservedElasticsearchInstanceOfferingId.toString();
+      __extendedEncodeURIComponent("offeringId")
+    ] = __extendedEncodeURIComponent(
+      input.ReservedElasticsearchInstanceOfferingId
+    );
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -521,13 +532,19 @@ export async function serializeAws_restJson1_1DescribeReservedElasticsearchInsta
   let resolvedPath = "/2015-01-01/es/reservedInstances";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   if (input.ReservedElasticsearchInstanceId !== undefined) {
-    query["reservationId"] = input.ReservedElasticsearchInstanceId.toString();
+    query[
+      __extendedEncodeURIComponent("reservationId")
+    ] = __extendedEncodeURIComponent(input.ReservedElasticsearchInstanceId);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -548,7 +565,9 @@ export async function serializeAws_restJson1_1GetCompatibleElasticsearchVersions
   let resolvedPath = "/2015-01-01/es/compatibleVersions";
   const query: any = {};
   if (input.DomainName !== undefined) {
-    query["domainName"] = input.DomainName.toString();
+    query[
+      __extendedEncodeURIComponent("domainName")
+    ] = __extendedEncodeURIComponent(input.DomainName);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -568,23 +587,27 @@ export async function serializeAws_restJson1_1GetUpgradeHistoryCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/2015-01-01/es/upgradeDomain/{DomainName}/history";
   if (input.DomainName !== undefined) {
-    const labelValue: string = input.DomainName.toString();
+    const labelValue: string = input.DomainName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DomainName.");
     }
     resolvedPath = resolvedPath.replace(
       "{DomainName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DomainName.");
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -604,13 +627,13 @@ export async function serializeAws_restJson1_1GetUpgradeStatusCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/2015-01-01/es/upgradeDomain/{DomainName}/status";
   if (input.DomainName !== undefined) {
-    const labelValue: string = input.DomainName.toString();
+    const labelValue: string = input.DomainName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DomainName.");
     }
     resolvedPath = resolvedPath.replace(
       "{DomainName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DomainName.");
@@ -648,7 +671,7 @@ export async function serializeAws_restJson1_1ListElasticsearchInstanceTypesComm
   headers["Content-Type"] = "";
   let resolvedPath = "/2015-01-01/es/instanceTypes/{ElasticsearchVersion}";
   if (input.ElasticsearchVersion !== undefined) {
-    const labelValue: string = input.ElasticsearchVersion.toString();
+    const labelValue: string = input.ElasticsearchVersion;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ElasticsearchVersion."
@@ -656,7 +679,7 @@ export async function serializeAws_restJson1_1ListElasticsearchInstanceTypesComm
     }
     resolvedPath = resolvedPath.replace(
       "{ElasticsearchVersion}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -665,13 +688,19 @@ export async function serializeAws_restJson1_1ListElasticsearchInstanceTypesComm
   }
   const query: any = {};
   if (input.DomainName !== undefined) {
-    query["domainName"] = input.DomainName.toString();
+    query[
+      __extendedEncodeURIComponent("domainName")
+    ] = __extendedEncodeURIComponent(input.DomainName);
   }
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -692,10 +721,14 @@ export async function serializeAws_restJson1_1ListElasticsearchVersionsCommand(
   let resolvedPath = "/2015-01-01/es/versions";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -716,7 +749,9 @@ export async function serializeAws_restJson1_1ListTagsCommand(
   let resolvedPath = "/2015-01-01/tags";
   const query: any = {};
   if (input.ARN !== undefined) {
-    query["arn"] = input.ARN.toString();
+    query[__extendedEncodeURIComponent("arn")] = __extendedEncodeURIComponent(
+      input.ARN
+    );
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -818,13 +853,13 @@ export async function serializeAws_restJson1_1UpdateElasticsearchDomainConfigCom
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/2015-01-01/es/domain/{DomainName}/config";
   if (input.DomainName !== undefined) {
-    const labelValue: string = input.DomainName.toString();
+    const labelValue: string = input.DomainName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DomainName.");
     }
     resolvedPath = resolvedPath.replace(
       "{DomainName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DomainName.");
@@ -938,6 +973,7 @@ export async function deserializeAws_restJson1_1AddTagsCommand(
   const contents: AddTagsCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -1273,6 +1309,7 @@ export async function deserializeAws_restJson1_1DeleteElasticsearchServiceRoleCo
   const contents: DeleteElasticsearchServiceRoleCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2521,6 +2558,7 @@ export async function deserializeAws_restJson1_1RemoveTagsCommand(
   const contents: RemoveTagsCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 

--- a/clients/client-emr/models/index.ts
+++ b/clients/client-emr/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export enum ActionOnFailure {
@@ -23,7 +26,7 @@ export interface AddInstanceFleetInput {
 
 export namespace AddInstanceFleetInput {
   export function isa(o: any): o is AddInstanceFleetInput {
-    return _smithy.isa(o, "AddInstanceFleetInput");
+    return __isa(o, "AddInstanceFleetInput");
   }
 }
 
@@ -47,7 +50,7 @@ export interface AddInstanceFleetOutput extends $MetadataBearer {
 
 export namespace AddInstanceFleetOutput {
   export function isa(o: any): o is AddInstanceFleetOutput {
-    return _smithy.isa(o, "AddInstanceFleetOutput");
+    return __isa(o, "AddInstanceFleetOutput");
   }
 }
 
@@ -69,7 +72,7 @@ export interface AddInstanceGroupsInput {
 
 export namespace AddInstanceGroupsInput {
   export function isa(o: any): o is AddInstanceGroupsInput {
-    return _smithy.isa(o, "AddInstanceGroupsInput");
+    return __isa(o, "AddInstanceGroupsInput");
   }
 }
 
@@ -96,7 +99,7 @@ export interface AddInstanceGroupsOutput extends $MetadataBearer {
 
 export namespace AddInstanceGroupsOutput {
   export function isa(o: any): o is AddInstanceGroupsOutput {
-    return _smithy.isa(o, "AddInstanceGroupsOutput");
+    return __isa(o, "AddInstanceGroupsOutput");
   }
 }
 
@@ -119,7 +122,7 @@ export interface AddJobFlowStepsInput {
 
 export namespace AddJobFlowStepsInput {
   export function isa(o: any): o is AddJobFlowStepsInput {
-    return _smithy.isa(o, "AddJobFlowStepsInput");
+    return __isa(o, "AddJobFlowStepsInput");
   }
 }
 
@@ -136,7 +139,7 @@ export interface AddJobFlowStepsOutput extends $MetadataBearer {
 
 export namespace AddJobFlowStepsOutput {
   export function isa(o: any): o is AddJobFlowStepsOutput {
-    return _smithy.isa(o, "AddJobFlowStepsOutput");
+    return __isa(o, "AddJobFlowStepsOutput");
   }
 }
 
@@ -158,7 +161,7 @@ export interface AddTagsInput {
 
 export namespace AddTagsInput {
   export function isa(o: any): o is AddTagsInput {
-    return _smithy.isa(o, "AddTagsInput");
+    return __isa(o, "AddTagsInput");
   }
 }
 
@@ -171,7 +174,7 @@ export interface AddTagsOutput extends $MetadataBearer {
 
 export namespace AddTagsOutput {
   export function isa(o: any): o is AddTagsOutput {
-    return _smithy.isa(o, "AddTagsOutput");
+    return __isa(o, "AddTagsOutput");
   }
 }
 
@@ -210,7 +213,7 @@ export interface Application {
 
 export namespace Application {
   export function isa(o: any): o is Application {
-    return _smithy.isa(o, "Application");
+    return __isa(o, "Application");
   }
 }
 
@@ -232,7 +235,7 @@ export interface AutoScalingPolicy {
 
 export namespace AutoScalingPolicy {
   export function isa(o: any): o is AutoScalingPolicy {
-    return _smithy.isa(o, "AutoScalingPolicy");
+    return __isa(o, "AutoScalingPolicy");
   }
 }
 
@@ -259,7 +262,7 @@ export interface AutoScalingPolicyDescription {
 
 export namespace AutoScalingPolicyDescription {
   export function isa(o: any): o is AutoScalingPolicyDescription {
-    return _smithy.isa(o, "AutoScalingPolicyDescription");
+    return __isa(o, "AutoScalingPolicyDescription");
   }
 }
 
@@ -290,7 +293,7 @@ export interface AutoScalingPolicyStateChangeReason {
 
 export namespace AutoScalingPolicyStateChangeReason {
   export function isa(o: any): o is AutoScalingPolicyStateChangeReason {
-    return _smithy.isa(o, "AutoScalingPolicyStateChangeReason");
+    return __isa(o, "AutoScalingPolicyStateChangeReason");
   }
 }
 
@@ -318,7 +321,7 @@ export interface AutoScalingPolicyStatus {
 
 export namespace AutoScalingPolicyStatus {
   export function isa(o: any): o is AutoScalingPolicyStatus {
-    return _smithy.isa(o, "AutoScalingPolicyStatus");
+    return __isa(o, "AutoScalingPolicyStatus");
   }
 }
 
@@ -356,7 +359,7 @@ export interface BlockPublicAccessConfiguration {
 
 export namespace BlockPublicAccessConfiguration {
   export function isa(o: any): o is BlockPublicAccessConfiguration {
-    return _smithy.isa(o, "BlockPublicAccessConfiguration");
+    return __isa(o, "BlockPublicAccessConfiguration");
   }
 }
 
@@ -378,7 +381,7 @@ export interface BlockPublicAccessConfigurationMetadata {
 
 export namespace BlockPublicAccessConfigurationMetadata {
   export function isa(o: any): o is BlockPublicAccessConfigurationMetadata {
-    return _smithy.isa(o, "BlockPublicAccessConfigurationMetadata");
+    return __isa(o, "BlockPublicAccessConfigurationMetadata");
   }
 }
 
@@ -400,7 +403,7 @@ export interface BootstrapActionConfig {
 
 export namespace BootstrapActionConfig {
   export function isa(o: any): o is BootstrapActionConfig {
-    return _smithy.isa(o, "BootstrapActionConfig");
+    return __isa(o, "BootstrapActionConfig");
   }
 }
 
@@ -417,7 +420,7 @@ export interface BootstrapActionDetail {
 
 export namespace BootstrapActionDetail {
   export function isa(o: any): o is BootstrapActionDetail {
-    return _smithy.isa(o, "BootstrapActionDetail");
+    return __isa(o, "BootstrapActionDetail");
   }
 }
 
@@ -444,7 +447,7 @@ export interface CancelStepsInfo {
 
 export namespace CancelStepsInfo {
   export function isa(o: any): o is CancelStepsInfo {
-    return _smithy.isa(o, "CancelStepsInfo");
+    return __isa(o, "CancelStepsInfo");
   }
 }
 
@@ -471,7 +474,7 @@ export interface CancelStepsInput {
 
 export namespace CancelStepsInput {
   export function isa(o: any): o is CancelStepsInput {
-    return _smithy.isa(o, "CancelStepsInput");
+    return __isa(o, "CancelStepsInput");
   }
 }
 
@@ -488,7 +491,7 @@ export interface CancelStepsOutput extends $MetadataBearer {
 
 export namespace CancelStepsOutput {
   export function isa(o: any): o is CancelStepsOutput {
-    return _smithy.isa(o, "CancelStepsOutput");
+    return __isa(o, "CancelStepsOutput");
   }
 }
 
@@ -550,7 +553,7 @@ export interface CloudWatchAlarmDefinition {
 
 export namespace CloudWatchAlarmDefinition {
   export function isa(o: any): o is CloudWatchAlarmDefinition {
-    return _smithy.isa(o, "CloudWatchAlarmDefinition");
+    return __isa(o, "CloudWatchAlarmDefinition");
   }
 }
 
@@ -707,7 +710,7 @@ export interface Cluster {
 
 export namespace Cluster {
   export function isa(o: any): o is Cluster {
-    return _smithy.isa(o, "Cluster");
+    return __isa(o, "Cluster");
   }
 }
 
@@ -739,7 +742,7 @@ export interface ClusterStateChangeReason {
 
 export namespace ClusterStateChangeReason {
   export function isa(o: any): o is ClusterStateChangeReason {
-    return _smithy.isa(o, "ClusterStateChangeReason");
+    return __isa(o, "ClusterStateChangeReason");
   }
 }
 
@@ -777,7 +780,7 @@ export interface ClusterStatus {
 
 export namespace ClusterStatus {
   export function isa(o: any): o is ClusterStatus {
-    return _smithy.isa(o, "ClusterStatus");
+    return __isa(o, "ClusterStatus");
   }
 }
 
@@ -821,7 +824,7 @@ export interface ClusterSummary {
 
 export namespace ClusterSummary {
   export function isa(o: any): o is ClusterSummary {
-    return _smithy.isa(o, "ClusterSummary");
+    return __isa(o, "ClusterSummary");
   }
 }
 
@@ -848,7 +851,7 @@ export interface ClusterTimeline {
 
 export namespace ClusterTimeline {
   export function isa(o: any): o is ClusterTimeline {
-    return _smithy.isa(o, "ClusterTimeline");
+    return __isa(o, "ClusterTimeline");
   }
 }
 
@@ -875,7 +878,7 @@ export interface Command {
 
 export namespace Command {
   export function isa(o: any): o is Command {
-    return _smithy.isa(o, "Command");
+    return __isa(o, "Command");
   }
 }
 
@@ -912,7 +915,7 @@ export interface Configuration {
 
 export namespace Configuration {
   export function isa(o: any): o is Configuration {
-    return _smithy.isa(o, "Configuration");
+    return __isa(o, "Configuration");
   }
 }
 
@@ -931,7 +934,7 @@ export interface CreateSecurityConfigurationInput {
 
 export namespace CreateSecurityConfigurationInput {
   export function isa(o: any): o is CreateSecurityConfigurationInput {
-    return _smithy.isa(o, "CreateSecurityConfigurationInput");
+    return __isa(o, "CreateSecurityConfigurationInput");
   }
 }
 
@@ -950,7 +953,7 @@ export interface CreateSecurityConfigurationOutput extends $MetadataBearer {
 
 export namespace CreateSecurityConfigurationOutput {
   export function isa(o: any): o is CreateSecurityConfigurationOutput {
-    return _smithy.isa(o, "CreateSecurityConfigurationOutput");
+    return __isa(o, "CreateSecurityConfigurationOutput");
   }
 }
 
@@ -964,7 +967,7 @@ export interface DeleteSecurityConfigurationInput {
 
 export namespace DeleteSecurityConfigurationInput {
   export function isa(o: any): o is DeleteSecurityConfigurationInput {
-    return _smithy.isa(o, "DeleteSecurityConfigurationInput");
+    return __isa(o, "DeleteSecurityConfigurationInput");
   }
 }
 
@@ -974,7 +977,7 @@ export interface DeleteSecurityConfigurationOutput extends $MetadataBearer {
 
 export namespace DeleteSecurityConfigurationOutput {
   export function isa(o: any): o is DeleteSecurityConfigurationOutput {
-    return _smithy.isa(o, "DeleteSecurityConfigurationOutput");
+    return __isa(o, "DeleteSecurityConfigurationOutput");
   }
 }
 
@@ -991,7 +994,7 @@ export interface DescribeClusterInput {
 
 export namespace DescribeClusterInput {
   export function isa(o: any): o is DescribeClusterInput {
-    return _smithy.isa(o, "DescribeClusterInput");
+    return __isa(o, "DescribeClusterInput");
   }
 }
 
@@ -1008,7 +1011,7 @@ export interface DescribeClusterOutput extends $MetadataBearer {
 
 export namespace DescribeClusterOutput {
   export function isa(o: any): o is DescribeClusterOutput {
-    return _smithy.isa(o, "DescribeClusterOutput");
+    return __isa(o, "DescribeClusterOutput");
   }
 }
 
@@ -1040,7 +1043,7 @@ export interface DescribeJobFlowsInput {
 
 export namespace DescribeJobFlowsInput {
   export function isa(o: any): o is DescribeJobFlowsInput {
-    return _smithy.isa(o, "DescribeJobFlowsInput");
+    return __isa(o, "DescribeJobFlowsInput");
   }
 }
 
@@ -1057,7 +1060,7 @@ export interface DescribeJobFlowsOutput extends $MetadataBearer {
 
 export namespace DescribeJobFlowsOutput {
   export function isa(o: any): o is DescribeJobFlowsOutput {
-    return _smithy.isa(o, "DescribeJobFlowsOutput");
+    return __isa(o, "DescribeJobFlowsOutput");
   }
 }
 
@@ -1071,7 +1074,7 @@ export interface DescribeSecurityConfigurationInput {
 
 export namespace DescribeSecurityConfigurationInput {
   export function isa(o: any): o is DescribeSecurityConfigurationInput {
-    return _smithy.isa(o, "DescribeSecurityConfigurationInput");
+    return __isa(o, "DescribeSecurityConfigurationInput");
   }
 }
 
@@ -1095,7 +1098,7 @@ export interface DescribeSecurityConfigurationOutput extends $MetadataBearer {
 
 export namespace DescribeSecurityConfigurationOutput {
   export function isa(o: any): o is DescribeSecurityConfigurationOutput {
-    return _smithy.isa(o, "DescribeSecurityConfigurationOutput");
+    return __isa(o, "DescribeSecurityConfigurationOutput");
   }
 }
 
@@ -1117,7 +1120,7 @@ export interface DescribeStepInput {
 
 export namespace DescribeStepInput {
   export function isa(o: any): o is DescribeStepInput {
-    return _smithy.isa(o, "DescribeStepInput");
+    return __isa(o, "DescribeStepInput");
   }
 }
 
@@ -1134,7 +1137,7 @@ export interface DescribeStepOutput extends $MetadataBearer {
 
 export namespace DescribeStepOutput {
   export function isa(o: any): o is DescribeStepOutput {
-    return _smithy.isa(o, "DescribeStepOutput");
+    return __isa(o, "DescribeStepOutput");
   }
 }
 
@@ -1156,7 +1159,7 @@ export interface EbsBlockDevice {
 
 export namespace EbsBlockDevice {
   export function isa(o: any): o is EbsBlockDevice {
-    return _smithy.isa(o, "EbsBlockDevice");
+    return __isa(o, "EbsBlockDevice");
   }
 }
 
@@ -1178,7 +1181,7 @@ export interface EbsBlockDeviceConfig {
 
 export namespace EbsBlockDeviceConfig {
   export function isa(o: any): o is EbsBlockDeviceConfig {
-    return _smithy.isa(o, "EbsBlockDeviceConfig");
+    return __isa(o, "EbsBlockDeviceConfig");
   }
 }
 
@@ -1200,7 +1203,7 @@ export interface EbsConfiguration {
 
 export namespace EbsConfiguration {
   export function isa(o: any): o is EbsConfiguration {
-    return _smithy.isa(o, "EbsConfiguration");
+    return __isa(o, "EbsConfiguration");
   }
 }
 
@@ -1222,7 +1225,7 @@ export interface EbsVolume {
 
 export namespace EbsVolume {
   export function isa(o: any): o is EbsVolume {
-    return _smithy.isa(o, "EbsVolume");
+    return __isa(o, "EbsVolume");
   }
 }
 
@@ -1289,7 +1292,7 @@ export interface Ec2InstanceAttributes {
 
 export namespace Ec2InstanceAttributes {
   export function isa(o: any): o is Ec2InstanceAttributes {
-    return _smithy.isa(o, "Ec2InstanceAttributes");
+    return __isa(o, "Ec2InstanceAttributes");
   }
 }
 
@@ -1316,7 +1319,7 @@ export interface FailureDetails {
 
 export namespace FailureDetails {
   export function isa(o: any): o is FailureDetails {
-    return _smithy.isa(o, "FailureDetails");
+    return __isa(o, "FailureDetails");
   }
 }
 
@@ -1326,7 +1329,7 @@ export interface GetBlockPublicAccessConfigurationInput {
 
 export namespace GetBlockPublicAccessConfigurationInput {
   export function isa(o: any): o is GetBlockPublicAccessConfigurationInput {
-    return _smithy.isa(o, "GetBlockPublicAccessConfigurationInput");
+    return __isa(o, "GetBlockPublicAccessConfigurationInput");
   }
 }
 
@@ -1348,7 +1351,7 @@ export interface GetBlockPublicAccessConfigurationOutput
 
 export namespace GetBlockPublicAccessConfigurationOutput {
   export function isa(o: any): o is GetBlockPublicAccessConfigurationOutput {
-    return _smithy.isa(o, "GetBlockPublicAccessConfigurationOutput");
+    return __isa(o, "GetBlockPublicAccessConfigurationOutput");
   }
 }
 
@@ -1380,7 +1383,7 @@ export interface HadoopJarStepConfig {
 
 export namespace HadoopJarStepConfig {
   export function isa(o: any): o is HadoopJarStepConfig {
-    return _smithy.isa(o, "HadoopJarStepConfig");
+    return __isa(o, "HadoopJarStepConfig");
   }
 }
 
@@ -1412,7 +1415,7 @@ export interface HadoopStepConfig {
 
 export namespace HadoopStepConfig {
   export function isa(o: any): o is HadoopStepConfig {
-    return _smithy.isa(o, "HadoopStepConfig");
+    return __isa(o, "HadoopStepConfig");
   }
 }
 
@@ -1485,7 +1488,7 @@ export interface Instance {
 
 export namespace Instance {
   export function isa(o: any): o is Instance {
-    return _smithy.isa(o, "Instance");
+    return __isa(o, "Instance");
   }
 }
 
@@ -1566,7 +1569,7 @@ export interface InstanceFleet {
 
 export namespace InstanceFleet {
   export function isa(o: any): o is InstanceFleet {
-    return _smithy.isa(o, "InstanceFleet");
+    return __isa(o, "InstanceFleet");
   }
 }
 
@@ -1617,7 +1620,7 @@ export interface InstanceFleetConfig {
 
 export namespace InstanceFleetConfig {
   export function isa(o: any): o is InstanceFleetConfig {
-    return _smithy.isa(o, "InstanceFleetConfig");
+    return __isa(o, "InstanceFleetConfig");
   }
 }
 
@@ -1647,7 +1650,7 @@ export interface InstanceFleetModifyConfig {
 
 export namespace InstanceFleetModifyConfig {
   export function isa(o: any): o is InstanceFleetModifyConfig {
-    return _smithy.isa(o, "InstanceFleetModifyConfig");
+    return __isa(o, "InstanceFleetModifyConfig");
   }
 }
 
@@ -1667,7 +1670,7 @@ export interface InstanceFleetProvisioningSpecifications {
 
 export namespace InstanceFleetProvisioningSpecifications {
   export function isa(o: any): o is InstanceFleetProvisioningSpecifications {
-    return _smithy.isa(o, "InstanceFleetProvisioningSpecifications");
+    return __isa(o, "InstanceFleetProvisioningSpecifications");
   }
 }
 
@@ -1702,7 +1705,7 @@ export interface InstanceFleetStateChangeReason {
 
 export namespace InstanceFleetStateChangeReason {
   export function isa(o: any): o is InstanceFleetStateChangeReason {
-    return _smithy.isa(o, "InstanceFleetStateChangeReason");
+    return __isa(o, "InstanceFleetStateChangeReason");
   }
 }
 
@@ -1769,7 +1772,7 @@ export interface InstanceFleetStatus {
 
 export namespace InstanceFleetStatus {
   export function isa(o: any): o is InstanceFleetStatus {
-    return _smithy.isa(o, "InstanceFleetStatus");
+    return __isa(o, "InstanceFleetStatus");
   }
 }
 
@@ -1799,7 +1802,7 @@ export interface InstanceFleetTimeline {
 
 export namespace InstanceFleetTimeline {
   export function isa(o: any): o is InstanceFleetTimeline {
-    return _smithy.isa(o, "InstanceFleetTimeline");
+    return __isa(o, "InstanceFleetTimeline");
   }
 }
 
@@ -1907,7 +1910,7 @@ export interface InstanceGroup {
 
 export namespace InstanceGroup {
   export function isa(o: any): o is InstanceGroup {
-    return _smithy.isa(o, "InstanceGroup");
+    return __isa(o, "InstanceGroup");
   }
 }
 
@@ -1967,7 +1970,7 @@ export interface InstanceGroupConfig {
 
 export namespace InstanceGroupConfig {
   export function isa(o: any): o is InstanceGroupConfig {
-    return _smithy.isa(o, "InstanceGroupConfig");
+    return __isa(o, "InstanceGroupConfig");
   }
 }
 
@@ -2049,7 +2052,7 @@ export interface InstanceGroupDetail {
 
 export namespace InstanceGroupDetail {
   export function isa(o: any): o is InstanceGroupDetail {
-    return _smithy.isa(o, "InstanceGroupDetail");
+    return __isa(o, "InstanceGroupDetail");
   }
 }
 
@@ -2086,7 +2089,7 @@ export interface InstanceGroupModifyConfig {
 
 export namespace InstanceGroupModifyConfig {
   export function isa(o: any): o is InstanceGroupModifyConfig {
-    return _smithy.isa(o, "InstanceGroupModifyConfig");
+    return __isa(o, "InstanceGroupModifyConfig");
   }
 }
 
@@ -2122,7 +2125,7 @@ export interface InstanceGroupStateChangeReason {
 
 export namespace InstanceGroupStateChangeReason {
   export function isa(o: any): o is InstanceGroupStateChangeReason {
-    return _smithy.isa(o, "InstanceGroupStateChangeReason");
+    return __isa(o, "InstanceGroupStateChangeReason");
   }
 }
 
@@ -2156,7 +2159,7 @@ export interface InstanceGroupStatus {
 
 export namespace InstanceGroupStatus {
   export function isa(o: any): o is InstanceGroupStatus {
-    return _smithy.isa(o, "InstanceGroupStatus");
+    return __isa(o, "InstanceGroupStatus");
   }
 }
 
@@ -2183,7 +2186,7 @@ export interface InstanceGroupTimeline {
 
 export namespace InstanceGroupTimeline {
   export function isa(o: any): o is InstanceGroupTimeline {
-    return _smithy.isa(o, "InstanceGroupTimeline");
+    return __isa(o, "InstanceGroupTimeline");
   }
 }
 
@@ -2216,7 +2219,7 @@ export interface InstanceResizePolicy {
 
 export namespace InstanceResizePolicy {
   export function isa(o: any): o is InstanceResizePolicy {
-    return _smithy.isa(o, "InstanceResizePolicy");
+    return __isa(o, "InstanceResizePolicy");
   }
 }
 
@@ -2248,7 +2251,7 @@ export interface InstanceStateChangeReason {
 
 export namespace InstanceStateChangeReason {
   export function isa(o: any): o is InstanceStateChangeReason {
-    return _smithy.isa(o, "InstanceStateChangeReason");
+    return __isa(o, "InstanceStateChangeReason");
   }
 }
 
@@ -2283,7 +2286,7 @@ export interface InstanceStatus {
 
 export namespace InstanceStatus {
   export function isa(o: any): o is InstanceStatus {
-    return _smithy.isa(o, "InstanceStatus");
+    return __isa(o, "InstanceStatus");
   }
 }
 
@@ -2310,7 +2313,7 @@ export interface InstanceTimeline {
 
 export namespace InstanceTimeline {
   export function isa(o: any): o is InstanceTimeline {
-    return _smithy.isa(o, "InstanceTimeline");
+    return __isa(o, "InstanceTimeline");
   }
 }
 
@@ -2359,7 +2362,7 @@ export interface InstanceTypeConfig {
 
 export namespace InstanceTypeConfig {
   export function isa(o: any): o is InstanceTypeConfig {
-    return _smithy.isa(o, "InstanceTypeConfig");
+    return __isa(o, "InstanceTypeConfig");
   }
 }
 
@@ -2409,7 +2412,7 @@ export interface InstanceTypeSpecification {
 
 export namespace InstanceTypeSpecification {
   export function isa(o: any): o is InstanceTypeSpecification {
-    return _smithy.isa(o, "InstanceTypeSpecification");
+    return __isa(o, "InstanceTypeSpecification");
   }
 }
 
@@ -2417,7 +2420,7 @@ export namespace InstanceTypeSpecification {
  * <p>Indicates that an error occurred while processing the request and that the request was not completed.</p>
  */
 export interface InternalServerError
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalServerError";
   $fault: "server";
@@ -2425,7 +2428,7 @@ export interface InternalServerError
 
 export namespace InternalServerError {
   export function isa(o: any): o is InternalServerError {
-    return _smithy.isa(o, "InternalServerError");
+    return __isa(o, "InternalServerError");
   }
 }
 
@@ -2433,7 +2436,7 @@ export namespace InternalServerError {
  * <p>This exception occurs when there is an internal failure in the EMR service.</p>
  */
 export interface InternalServerException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalServerException";
   $fault: "server";
@@ -2445,7 +2448,7 @@ export interface InternalServerException
 
 export namespace InternalServerException {
   export function isa(o: any): o is InternalServerException {
-    return _smithy.isa(o, "InternalServerException");
+    return __isa(o, "InternalServerException");
   }
 }
 
@@ -2453,7 +2456,7 @@ export namespace InternalServerException {
  * <p>This exception occurs when there is something wrong with user input.</p>
  */
 export interface InvalidRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidRequestException";
   $fault: "client";
@@ -2470,7 +2473,7 @@ export interface InvalidRequestException
 
 export namespace InvalidRequestException {
   export function isa(o: any): o is InvalidRequestException {
-    return _smithy.isa(o, "InvalidRequestException");
+    return __isa(o, "InvalidRequestException");
   }
 }
 
@@ -2552,7 +2555,7 @@ export interface JobFlowDetail {
 
 export namespace JobFlowDetail {
   export function isa(o: any): o is JobFlowDetail {
-    return _smithy.isa(o, "JobFlowDetail");
+    return __isa(o, "JobFlowDetail");
   }
 }
 
@@ -2605,7 +2608,7 @@ export interface JobFlowExecutionStatusDetail {
 
 export namespace JobFlowExecutionStatusDetail {
   export function isa(o: any): o is JobFlowExecutionStatusDetail {
-    return _smithy.isa(o, "JobFlowExecutionStatusDetail");
+    return __isa(o, "JobFlowExecutionStatusDetail");
   }
 }
 
@@ -2708,7 +2711,7 @@ export interface JobFlowInstancesConfig {
 
 export namespace JobFlowInstancesConfig {
   export function isa(o: any): o is JobFlowInstancesConfig {
-    return _smithy.isa(o, "JobFlowInstancesConfig");
+    return __isa(o, "JobFlowInstancesConfig");
   }
 }
 
@@ -2785,7 +2788,7 @@ export interface JobFlowInstancesDetail {
 
 export namespace JobFlowInstancesDetail {
   export function isa(o: any): o is JobFlowInstancesDetail {
-    return _smithy.isa(o, "JobFlowInstancesDetail");
+    return __isa(o, "JobFlowInstancesDetail");
   }
 }
 
@@ -2823,7 +2826,7 @@ export interface KerberosAttributes {
 
 export namespace KerberosAttributes {
   export function isa(o: any): o is KerberosAttributes {
-    return _smithy.isa(o, "KerberosAttributes");
+    return __isa(o, "KerberosAttributes");
   }
 }
 
@@ -2845,7 +2848,7 @@ export interface KeyValue {
 
 export namespace KeyValue {
   export function isa(o: any): o is KeyValue {
-    return _smithy.isa(o, "KeyValue");
+    return __isa(o, "KeyValue");
   }
 }
 
@@ -2867,7 +2870,7 @@ export interface ListBootstrapActionsInput {
 
 export namespace ListBootstrapActionsInput {
   export function isa(o: any): o is ListBootstrapActionsInput {
-    return _smithy.isa(o, "ListBootstrapActionsInput");
+    return __isa(o, "ListBootstrapActionsInput");
   }
 }
 
@@ -2889,7 +2892,7 @@ export interface ListBootstrapActionsOutput extends $MetadataBearer {
 
 export namespace ListBootstrapActionsOutput {
   export function isa(o: any): o is ListBootstrapActionsOutput {
-    return _smithy.isa(o, "ListBootstrapActionsOutput");
+    return __isa(o, "ListBootstrapActionsOutput");
   }
 }
 
@@ -2921,7 +2924,7 @@ export interface ListClustersInput {
 
 export namespace ListClustersInput {
   export function isa(o: any): o is ListClustersInput {
-    return _smithy.isa(o, "ListClustersInput");
+    return __isa(o, "ListClustersInput");
   }
 }
 
@@ -2943,7 +2946,7 @@ export interface ListClustersOutput extends $MetadataBearer {
 
 export namespace ListClustersOutput {
   export function isa(o: any): o is ListClustersOutput {
-    return _smithy.isa(o, "ListClustersOutput");
+    return __isa(o, "ListClustersOutput");
   }
 }
 
@@ -2962,7 +2965,7 @@ export interface ListInstanceFleetsInput {
 
 export namespace ListInstanceFleetsInput {
   export function isa(o: any): o is ListInstanceFleetsInput {
-    return _smithy.isa(o, "ListInstanceFleetsInput");
+    return __isa(o, "ListInstanceFleetsInput");
   }
 }
 
@@ -2981,7 +2984,7 @@ export interface ListInstanceFleetsOutput extends $MetadataBearer {
 
 export namespace ListInstanceFleetsOutput {
   export function isa(o: any): o is ListInstanceFleetsOutput {
-    return _smithy.isa(o, "ListInstanceFleetsOutput");
+    return __isa(o, "ListInstanceFleetsOutput");
   }
 }
 
@@ -3003,7 +3006,7 @@ export interface ListInstanceGroupsInput {
 
 export namespace ListInstanceGroupsInput {
   export function isa(o: any): o is ListInstanceGroupsInput {
-    return _smithy.isa(o, "ListInstanceGroupsInput");
+    return __isa(o, "ListInstanceGroupsInput");
   }
 }
 
@@ -3025,7 +3028,7 @@ export interface ListInstanceGroupsOutput extends $MetadataBearer {
 
 export namespace ListInstanceGroupsOutput {
   export function isa(o: any): o is ListInstanceGroupsOutput {
-    return _smithy.isa(o, "ListInstanceGroupsOutput");
+    return __isa(o, "ListInstanceGroupsOutput");
   }
 }
 
@@ -3072,7 +3075,7 @@ export interface ListInstancesInput {
 
 export namespace ListInstancesInput {
   export function isa(o: any): o is ListInstancesInput {
-    return _smithy.isa(o, "ListInstancesInput");
+    return __isa(o, "ListInstancesInput");
   }
 }
 
@@ -3094,7 +3097,7 @@ export interface ListInstancesOutput extends $MetadataBearer {
 
 export namespace ListInstancesOutput {
   export function isa(o: any): o is ListInstancesOutput {
-    return _smithy.isa(o, "ListInstancesOutput");
+    return __isa(o, "ListInstancesOutput");
   }
 }
 
@@ -3108,7 +3111,7 @@ export interface ListSecurityConfigurationsInput {
 
 export namespace ListSecurityConfigurationsInput {
   export function isa(o: any): o is ListSecurityConfigurationsInput {
-    return _smithy.isa(o, "ListSecurityConfigurationsInput");
+    return __isa(o, "ListSecurityConfigurationsInput");
   }
 }
 
@@ -3127,7 +3130,7 @@ export interface ListSecurityConfigurationsOutput extends $MetadataBearer {
 
 export namespace ListSecurityConfigurationsOutput {
   export function isa(o: any): o is ListSecurityConfigurationsOutput {
-    return _smithy.isa(o, "ListSecurityConfigurationsOutput");
+    return __isa(o, "ListSecurityConfigurationsOutput");
   }
 }
 
@@ -3159,7 +3162,7 @@ export interface ListStepsInput {
 
 export namespace ListStepsInput {
   export function isa(o: any): o is ListStepsInput {
-    return _smithy.isa(o, "ListStepsInput");
+    return __isa(o, "ListStepsInput");
   }
 }
 
@@ -3181,7 +3184,7 @@ export interface ListStepsOutput extends $MetadataBearer {
 
 export namespace ListStepsOutput {
   export function isa(o: any): o is ListStepsOutput {
-    return _smithy.isa(o, "ListStepsOutput");
+    return __isa(o, "ListStepsOutput");
   }
 }
 
@@ -3208,7 +3211,7 @@ export interface MetricDimension {
 
 export namespace MetricDimension {
   export function isa(o: any): o is MetricDimension {
-    return _smithy.isa(o, "MetricDimension");
+    return __isa(o, "MetricDimension");
   }
 }
 
@@ -3227,7 +3230,7 @@ export interface ModifyClusterInput {
 
 export namespace ModifyClusterInput {
   export function isa(o: any): o is ModifyClusterInput {
-    return _smithy.isa(o, "ModifyClusterInput");
+    return __isa(o, "ModifyClusterInput");
   }
 }
 
@@ -3241,7 +3244,7 @@ export interface ModifyClusterOutput extends $MetadataBearer {
 
 export namespace ModifyClusterOutput {
   export function isa(o: any): o is ModifyClusterOutput {
-    return _smithy.isa(o, "ModifyClusterOutput");
+    return __isa(o, "ModifyClusterOutput");
   }
 }
 
@@ -3260,7 +3263,7 @@ export interface ModifyInstanceFleetInput {
 
 export namespace ModifyInstanceFleetInput {
   export function isa(o: any): o is ModifyInstanceFleetInput {
-    return _smithy.isa(o, "ModifyInstanceFleetInput");
+    return __isa(o, "ModifyInstanceFleetInput");
   }
 }
 
@@ -3282,7 +3285,7 @@ export interface ModifyInstanceGroupsInput {
 
 export namespace ModifyInstanceGroupsInput {
   export function isa(o: any): o is ModifyInstanceGroupsInput {
-    return _smithy.isa(o, "ModifyInstanceGroupsInput");
+    return __isa(o, "ModifyInstanceGroupsInput");
   }
 }
 
@@ -3307,7 +3310,7 @@ export interface PlacementType {
 
 export namespace PlacementType {
   export function isa(o: any): o is PlacementType {
-    return _smithy.isa(o, "PlacementType");
+    return __isa(o, "PlacementType");
   }
 }
 
@@ -3329,7 +3332,7 @@ export interface PortRange {
 
 export namespace PortRange {
   export function isa(o: any): o is PortRange {
-    return _smithy.isa(o, "PortRange");
+    return __isa(o, "PortRange");
   }
 }
 
@@ -3353,7 +3356,7 @@ export interface PutAutoScalingPolicyInput {
 
 export namespace PutAutoScalingPolicyInput {
   export function isa(o: any): o is PutAutoScalingPolicyInput {
-    return _smithy.isa(o, "PutAutoScalingPolicyInput");
+    return __isa(o, "PutAutoScalingPolicyInput");
   }
 }
 
@@ -3382,7 +3385,7 @@ export interface PutAutoScalingPolicyOutput extends $MetadataBearer {
 
 export namespace PutAutoScalingPolicyOutput {
   export function isa(o: any): o is PutAutoScalingPolicyOutput {
-    return _smithy.isa(o, "PutAutoScalingPolicyOutput");
+    return __isa(o, "PutAutoScalingPolicyOutput");
   }
 }
 
@@ -3396,7 +3399,7 @@ export interface PutBlockPublicAccessConfigurationInput {
 
 export namespace PutBlockPublicAccessConfigurationInput {
   export function isa(o: any): o is PutBlockPublicAccessConfigurationInput {
-    return _smithy.isa(o, "PutBlockPublicAccessConfigurationInput");
+    return __isa(o, "PutBlockPublicAccessConfigurationInput");
   }
 }
 
@@ -3407,7 +3410,7 @@ export interface PutBlockPublicAccessConfigurationOutput
 
 export namespace PutBlockPublicAccessConfigurationOutput {
   export function isa(o: any): o is PutBlockPublicAccessConfigurationOutput {
-    return _smithy.isa(o, "PutBlockPublicAccessConfigurationOutput");
+    return __isa(o, "PutBlockPublicAccessConfigurationOutput");
   }
 }
 
@@ -3426,7 +3429,7 @@ export interface RemoveAutoScalingPolicyInput {
 
 export namespace RemoveAutoScalingPolicyInput {
   export function isa(o: any): o is RemoveAutoScalingPolicyInput {
-    return _smithy.isa(o, "RemoveAutoScalingPolicyInput");
+    return __isa(o, "RemoveAutoScalingPolicyInput");
   }
 }
 
@@ -3436,7 +3439,7 @@ export interface RemoveAutoScalingPolicyOutput extends $MetadataBearer {
 
 export namespace RemoveAutoScalingPolicyOutput {
   export function isa(o: any): o is RemoveAutoScalingPolicyOutput {
-    return _smithy.isa(o, "RemoveAutoScalingPolicyOutput");
+    return __isa(o, "RemoveAutoScalingPolicyOutput");
   }
 }
 
@@ -3458,7 +3461,7 @@ export interface RemoveTagsInput {
 
 export namespace RemoveTagsInput {
   export function isa(o: any): o is RemoveTagsInput {
-    return _smithy.isa(o, "RemoveTagsInput");
+    return __isa(o, "RemoveTagsInput");
   }
 }
 
@@ -3471,7 +3474,7 @@ export interface RemoveTagsOutput extends $MetadataBearer {
 
 export namespace RemoveTagsOutput {
   export function isa(o: any): o is RemoveTagsOutput {
-    return _smithy.isa(o, "RemoveTagsOutput");
+    return __isa(o, "RemoveTagsOutput");
   }
 }
 
@@ -3649,7 +3652,7 @@ export interface RunJobFlowInput {
 
 export namespace RunJobFlowInput {
   export function isa(o: any): o is RunJobFlowInput {
-    return _smithy.isa(o, "RunJobFlowInput");
+    return __isa(o, "RunJobFlowInput");
   }
 }
 
@@ -3671,7 +3674,7 @@ export interface RunJobFlowOutput extends $MetadataBearer {
 
 export namespace RunJobFlowOutput {
   export function isa(o: any): o is RunJobFlowOutput {
-    return _smithy.isa(o, "RunJobFlowOutput");
+    return __isa(o, "RunJobFlowOutput");
   }
 }
 
@@ -3700,7 +3703,7 @@ export interface ScalingAction {
 
 export namespace ScalingAction {
   export function isa(o: any): o is ScalingAction {
-    return _smithy.isa(o, "ScalingAction");
+    return __isa(o, "ScalingAction");
   }
 }
 
@@ -3722,7 +3725,7 @@ export interface ScalingConstraints {
 
 export namespace ScalingConstraints {
   export function isa(o: any): o is ScalingConstraints {
-    return _smithy.isa(o, "ScalingConstraints");
+    return __isa(o, "ScalingConstraints");
   }
 }
 
@@ -3754,7 +3757,7 @@ export interface ScalingRule {
 
 export namespace ScalingRule {
   export function isa(o: any): o is ScalingRule {
-    return _smithy.isa(o, "ScalingRule");
+    return __isa(o, "ScalingRule");
   }
 }
 
@@ -3771,7 +3774,7 @@ export interface ScalingTrigger {
 
 export namespace ScalingTrigger {
   export function isa(o: any): o is ScalingTrigger {
-    return _smithy.isa(o, "ScalingTrigger");
+    return __isa(o, "ScalingTrigger");
   }
 }
 
@@ -3793,7 +3796,7 @@ export interface ScriptBootstrapActionConfig {
 
 export namespace ScriptBootstrapActionConfig {
   export function isa(o: any): o is ScriptBootstrapActionConfig {
-    return _smithy.isa(o, "ScriptBootstrapActionConfig");
+    return __isa(o, "ScriptBootstrapActionConfig");
   }
 }
 
@@ -3815,7 +3818,7 @@ export interface SecurityConfigurationSummary {
 
 export namespace SecurityConfigurationSummary {
   export function isa(o: any): o is SecurityConfigurationSummary {
-    return _smithy.isa(o, "SecurityConfigurationSummary");
+    return __isa(o, "SecurityConfigurationSummary");
   }
 }
 
@@ -3838,7 +3841,7 @@ export interface SetTerminationProtectionInput {
 
 export namespace SetTerminationProtectionInput {
   export function isa(o: any): o is SetTerminationProtectionInput {
-    return _smithy.isa(o, "SetTerminationProtectionInput");
+    return __isa(o, "SetTerminationProtectionInput");
   }
 }
 
@@ -3860,7 +3863,7 @@ export interface SetVisibleToAllUsersInput {
 
 export namespace SetVisibleToAllUsersInput {
   export function isa(o: any): o is SetVisibleToAllUsersInput {
-    return _smithy.isa(o, "SetVisibleToAllUsersInput");
+    return __isa(o, "SetVisibleToAllUsersInput");
   }
 }
 
@@ -3882,7 +3885,7 @@ export interface ShrinkPolicy {
 
 export namespace ShrinkPolicy {
   export function isa(o: any): o is ShrinkPolicy {
-    return _smithy.isa(o, "ShrinkPolicy");
+    return __isa(o, "ShrinkPolicy");
   }
 }
 
@@ -3909,7 +3912,7 @@ export interface SimpleScalingPolicyConfiguration {
 
 export namespace SimpleScalingPolicyConfiguration {
   export function isa(o: any): o is SimpleScalingPolicyConfiguration {
-    return _smithy.isa(o, "SimpleScalingPolicyConfiguration");
+    return __isa(o, "SimpleScalingPolicyConfiguration");
   }
 }
 
@@ -3940,7 +3943,7 @@ export interface SpotProvisioningSpecification {
 
 export namespace SpotProvisioningSpecification {
   export function isa(o: any): o is SpotProvisioningSpecification {
-    return _smithy.isa(o, "SpotProvisioningSpecification");
+    return __isa(o, "SpotProvisioningSpecification");
   }
 }
 
@@ -3989,7 +3992,7 @@ export interface Step {
 
 export namespace Step {
   export function isa(o: any): o is Step {
-    return _smithy.isa(o, "Step");
+    return __isa(o, "Step");
   }
 }
 
@@ -4018,7 +4021,7 @@ export interface StepConfig {
 
 export namespace StepConfig {
   export function isa(o: any): o is StepConfig {
-    return _smithy.isa(o, "StepConfig");
+    return __isa(o, "StepConfig");
   }
 }
 
@@ -4040,7 +4043,7 @@ export interface StepDetail {
 
 export namespace StepDetail {
   export function isa(o: any): o is StepDetail {
-    return _smithy.isa(o, "StepDetail");
+    return __isa(o, "StepDetail");
   }
 }
 
@@ -4086,7 +4089,7 @@ export interface StepExecutionStatusDetail {
 
 export namespace StepExecutionStatusDetail {
   export function isa(o: any): o is StepExecutionStatusDetail {
-    return _smithy.isa(o, "StepExecutionStatusDetail");
+    return __isa(o, "StepExecutionStatusDetail");
   }
 }
 
@@ -4118,7 +4121,7 @@ export interface StepStateChangeReason {
 
 export namespace StepStateChangeReason {
   export function isa(o: any): o is StepStateChangeReason {
-    return _smithy.isa(o, "StepStateChangeReason");
+    return __isa(o, "StepStateChangeReason");
   }
 }
 
@@ -4152,7 +4155,7 @@ export interface StepStatus {
 
 export namespace StepStatus {
   export function isa(o: any): o is StepStatus {
-    return _smithy.isa(o, "StepStatus");
+    return __isa(o, "StepStatus");
   }
 }
 
@@ -4189,7 +4192,7 @@ export interface StepSummary {
 
 export namespace StepSummary {
   export function isa(o: any): o is StepSummary {
-    return _smithy.isa(o, "StepSummary");
+    return __isa(o, "StepSummary");
   }
 }
 
@@ -4216,7 +4219,7 @@ export interface StepTimeline {
 
 export namespace StepTimeline {
   export function isa(o: any): o is StepTimeline {
-    return _smithy.isa(o, "StepTimeline");
+    return __isa(o, "StepTimeline");
   }
 }
 
@@ -4238,7 +4241,7 @@ export interface SupportedProductConfig {
 
 export namespace SupportedProductConfig {
   export function isa(o: any): o is SupportedProductConfig {
-    return _smithy.isa(o, "SupportedProductConfig");
+    return __isa(o, "SupportedProductConfig");
   }
 }
 
@@ -4266,7 +4269,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -4283,7 +4286,7 @@ export interface TerminateJobFlowsInput {
 
 export namespace TerminateJobFlowsInput {
   export function isa(o: any): o is TerminateJobFlowsInput {
-    return _smithy.isa(o, "TerminateJobFlowsInput");
+    return __isa(o, "TerminateJobFlowsInput");
   }
 }
 
@@ -4340,6 +4343,6 @@ export interface VolumeSpecification {
 
 export namespace VolumeSpecification {
   export function isa(o: any): o is VolumeSpecification {
-    return _smithy.isa(o, "VolumeSpecification");
+    return __isa(o, "VolumeSpecification");
   }
 }

--- a/clients/client-emr/protocols/Aws_json1_1.ts
+++ b/clients/client-emr/protocols/Aws_json1_1.ts
@@ -1964,6 +1964,7 @@ export async function deserializeAws_json1_1ModifyInstanceFleetCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: ModifyInstanceFleetCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2025,6 +2026,7 @@ export async function deserializeAws_json1_1ModifyInstanceGroupsCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: ModifyInstanceGroupsCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2371,6 +2373,7 @@ export async function deserializeAws_json1_1SetTerminationProtectionCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: SetTerminationProtectionCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2425,6 +2428,7 @@ export async function deserializeAws_json1_1SetVisibleToAllUsersCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: SetVisibleToAllUsersCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2476,6 +2480,7 @@ export async function deserializeAws_json1_1TerminateJobFlowsCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1TerminateJobFlowsCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: TerminateJobFlowsCommandOutput = {
     $metadata: deserializeMetadata(output)
   };

--- a/clients/client-eventbridge/models/index.ts
+++ b/clients/client-eventbridge/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export interface ActivateEventSourceRequest {
@@ -11,7 +14,7 @@ export interface ActivateEventSourceRequest {
 
 export namespace ActivateEventSourceRequest {
   export function isa(o: any): o is ActivateEventSourceRequest {
-    return _smithy.isa(o, "ActivateEventSourceRequest");
+    return __isa(o, "ActivateEventSourceRequest");
   }
 }
 
@@ -49,7 +52,7 @@ export interface AwsVpcConfiguration {
 
 export namespace AwsVpcConfiguration {
   export function isa(o: any): o is AwsVpcConfiguration {
-    return _smithy.isa(o, "AwsVpcConfiguration");
+    return __isa(o, "AwsVpcConfiguration");
   }
 }
 
@@ -69,7 +72,7 @@ export interface BatchArrayProperties {
 
 export namespace BatchArrayProperties {
   export function isa(o: any): o is BatchArrayProperties {
-    return _smithy.isa(o, "BatchArrayProperties");
+    return __isa(o, "BatchArrayProperties");
   }
 }
 
@@ -106,7 +109,7 @@ export interface BatchParameters {
 
 export namespace BatchParameters {
   export function isa(o: any): o is BatchParameters {
-    return _smithy.isa(o, "BatchParameters");
+    return __isa(o, "BatchParameters");
   }
 }
 
@@ -126,7 +129,7 @@ export interface BatchRetryStrategy {
 
 export namespace BatchRetryStrategy {
   export function isa(o: any): o is BatchRetryStrategy {
-    return _smithy.isa(o, "BatchRetryStrategy");
+    return __isa(o, "BatchRetryStrategy");
   }
 }
 
@@ -163,7 +166,7 @@ export interface Condition {
 
 export namespace Condition {
   export function isa(o: any): o is Condition {
-    return _smithy.isa(o, "Condition");
+    return __isa(o, "Condition");
   }
 }
 
@@ -188,7 +191,7 @@ export interface CreateEventBusRequest {
 
 export namespace CreateEventBusRequest {
   export function isa(o: any): o is CreateEventBusRequest {
-    return _smithy.isa(o, "CreateEventBusRequest");
+    return __isa(o, "CreateEventBusRequest");
   }
 }
 
@@ -202,7 +205,7 @@ export interface CreateEventBusResponse extends $MetadataBearer {
 
 export namespace CreateEventBusResponse {
   export function isa(o: any): o is CreateEventBusResponse {
-    return _smithy.isa(o, "CreateEventBusResponse");
+    return __isa(o, "CreateEventBusResponse");
   }
 }
 
@@ -226,7 +229,7 @@ export interface CreatePartnerEventSourceRequest {
 
 export namespace CreatePartnerEventSourceRequest {
   export function isa(o: any): o is CreatePartnerEventSourceRequest {
-    return _smithy.isa(o, "CreatePartnerEventSourceRequest");
+    return __isa(o, "CreatePartnerEventSourceRequest");
   }
 }
 
@@ -240,7 +243,7 @@ export interface CreatePartnerEventSourceResponse extends $MetadataBearer {
 
 export namespace CreatePartnerEventSourceResponse {
   export function isa(o: any): o is CreatePartnerEventSourceResponse {
-    return _smithy.isa(o, "CreatePartnerEventSourceResponse");
+    return __isa(o, "CreatePartnerEventSourceResponse");
   }
 }
 
@@ -254,7 +257,7 @@ export interface DeactivateEventSourceRequest {
 
 export namespace DeactivateEventSourceRequest {
   export function isa(o: any): o is DeactivateEventSourceRequest {
-    return _smithy.isa(o, "DeactivateEventSourceRequest");
+    return __isa(o, "DeactivateEventSourceRequest");
   }
 }
 
@@ -268,7 +271,7 @@ export interface DeleteEventBusRequest {
 
 export namespace DeleteEventBusRequest {
   export function isa(o: any): o is DeleteEventBusRequest {
-    return _smithy.isa(o, "DeleteEventBusRequest");
+    return __isa(o, "DeleteEventBusRequest");
   }
 }
 
@@ -287,7 +290,7 @@ export interface DeletePartnerEventSourceRequest {
 
 export namespace DeletePartnerEventSourceRequest {
   export function isa(o: any): o is DeletePartnerEventSourceRequest {
-    return _smithy.isa(o, "DeletePartnerEventSourceRequest");
+    return __isa(o, "DeletePartnerEventSourceRequest");
   }
 }
 
@@ -314,7 +317,7 @@ export interface DeleteRuleRequest {
 
 export namespace DeleteRuleRequest {
   export function isa(o: any): o is DeleteRuleRequest {
-    return _smithy.isa(o, "DeleteRuleRequest");
+    return __isa(o, "DeleteRuleRequest");
   }
 }
 
@@ -328,7 +331,7 @@ export interface DescribeEventBusRequest {
 
 export namespace DescribeEventBusRequest {
   export function isa(o: any): o is DescribeEventBusRequest {
-    return _smithy.isa(o, "DescribeEventBusRequest");
+    return __isa(o, "DescribeEventBusRequest");
   }
 }
 
@@ -352,7 +355,7 @@ export interface DescribeEventBusResponse extends $MetadataBearer {
 
 export namespace DescribeEventBusResponse {
   export function isa(o: any): o is DescribeEventBusResponse {
-    return _smithy.isa(o, "DescribeEventBusResponse");
+    return __isa(o, "DescribeEventBusResponse");
   }
 }
 
@@ -366,7 +369,7 @@ export interface DescribeEventSourceRequest {
 
 export namespace DescribeEventSourceRequest {
   export function isa(o: any): o is DescribeEventSourceRequest {
-    return _smithy.isa(o, "DescribeEventSourceRequest");
+    return __isa(o, "DescribeEventSourceRequest");
   }
 }
 
@@ -410,7 +413,7 @@ export interface DescribeEventSourceResponse extends $MetadataBearer {
 
 export namespace DescribeEventSourceResponse {
   export function isa(o: any): o is DescribeEventSourceResponse {
-    return _smithy.isa(o, "DescribeEventSourceResponse");
+    return __isa(o, "DescribeEventSourceResponse");
   }
 }
 
@@ -424,7 +427,7 @@ export interface DescribePartnerEventSourceRequest {
 
 export namespace DescribePartnerEventSourceRequest {
   export function isa(o: any): o is DescribePartnerEventSourceRequest {
-    return _smithy.isa(o, "DescribePartnerEventSourceRequest");
+    return __isa(o, "DescribePartnerEventSourceRequest");
   }
 }
 
@@ -443,7 +446,7 @@ export interface DescribePartnerEventSourceResponse extends $MetadataBearer {
 
 export namespace DescribePartnerEventSourceResponse {
   export function isa(o: any): o is DescribePartnerEventSourceResponse {
-    return _smithy.isa(o, "DescribePartnerEventSourceResponse");
+    return __isa(o, "DescribePartnerEventSourceResponse");
   }
 }
 
@@ -462,7 +465,7 @@ export interface DescribeRuleRequest {
 
 export namespace DescribeRuleRequest {
   export function isa(o: any): o is DescribeRuleRequest {
-    return _smithy.isa(o, "DescribeRuleRequest");
+    return __isa(o, "DescribeRuleRequest");
   }
 }
 
@@ -518,7 +521,7 @@ export interface DescribeRuleResponse extends $MetadataBearer {
 
 export namespace DescribeRuleResponse {
   export function isa(o: any): o is DescribeRuleResponse {
-    return _smithy.isa(o, "DescribeRuleResponse");
+    return __isa(o, "DescribeRuleResponse");
   }
 }
 
@@ -537,7 +540,7 @@ export interface DisableRuleRequest {
 
 export namespace DisableRuleRequest {
   export function isa(o: any): o is DisableRuleRequest {
-    return _smithy.isa(o, "DisableRuleRequest");
+    return __isa(o, "DisableRuleRequest");
   }
 }
 
@@ -596,7 +599,7 @@ export interface EcsParameters {
 
 export namespace EcsParameters {
   export function isa(o: any): o is EcsParameters {
-    return _smithy.isa(o, "EcsParameters");
+    return __isa(o, "EcsParameters");
   }
 }
 
@@ -615,7 +618,7 @@ export interface EnableRuleRequest {
 
 export namespace EnableRuleRequest {
   export function isa(o: any): o is EnableRuleRequest {
-    return _smithy.isa(o, "EnableRuleRequest");
+    return __isa(o, "EnableRuleRequest");
   }
 }
 
@@ -645,7 +648,7 @@ export interface EventBus {
 
 export namespace EventBus {
   export function isa(o: any): o is EventBus {
-    return _smithy.isa(o, "EventBus");
+    return __isa(o, "EventBus");
   }
 }
 
@@ -693,7 +696,7 @@ export interface EventSource {
 
 export namespace EventSource {
   export function isa(o: any): o is EventSource {
-    return _smithy.isa(o, "EventSource");
+    return __isa(o, "EventSource");
   }
 }
 
@@ -773,7 +776,7 @@ export interface InputTransformer {
 
 export namespace InputTransformer {
   export function isa(o: any): o is InputTransformer {
-    return _smithy.isa(o, "InputTransformer");
+    return __isa(o, "InputTransformer");
   }
 }
 
@@ -793,7 +796,7 @@ export interface KinesisParameters {
 
 export namespace KinesisParameters {
   export function isa(o: any): o is KinesisParameters {
-    return _smithy.isa(o, "KinesisParameters");
+    return __isa(o, "KinesisParameters");
   }
 }
 
@@ -825,7 +828,7 @@ export interface ListEventBusesRequest {
 
 export namespace ListEventBusesRequest {
   export function isa(o: any): o is ListEventBusesRequest {
-    return _smithy.isa(o, "ListEventBusesRequest");
+    return __isa(o, "ListEventBusesRequest");
   }
 }
 
@@ -844,7 +847,7 @@ export interface ListEventBusesResponse extends $MetadataBearer {
 
 export namespace ListEventBusesResponse {
   export function isa(o: any): o is ListEventBusesResponse {
-    return _smithy.isa(o, "ListEventBusesResponse");
+    return __isa(o, "ListEventBusesResponse");
   }
 }
 
@@ -871,7 +874,7 @@ export interface ListEventSourcesRequest {
 
 export namespace ListEventSourcesRequest {
   export function isa(o: any): o is ListEventSourcesRequest {
-    return _smithy.isa(o, "ListEventSourcesRequest");
+    return __isa(o, "ListEventSourcesRequest");
   }
 }
 
@@ -890,7 +893,7 @@ export interface ListEventSourcesResponse extends $MetadataBearer {
 
 export namespace ListEventSourcesResponse {
   export function isa(o: any): o is ListEventSourcesResponse {
-    return _smithy.isa(o, "ListEventSourcesResponse");
+    return __isa(o, "ListEventSourcesResponse");
   }
 }
 
@@ -916,7 +919,7 @@ export interface ListPartnerEventSourceAccountsRequest {
 
 export namespace ListPartnerEventSourceAccountsRequest {
   export function isa(o: any): o is ListPartnerEventSourceAccountsRequest {
-    return _smithy.isa(o, "ListPartnerEventSourceAccountsRequest");
+    return __isa(o, "ListPartnerEventSourceAccountsRequest");
   }
 }
 
@@ -936,7 +939,7 @@ export interface ListPartnerEventSourceAccountsResponse
 
 export namespace ListPartnerEventSourceAccountsResponse {
   export function isa(o: any): o is ListPartnerEventSourceAccountsResponse {
-    return _smithy.isa(o, "ListPartnerEventSourceAccountsResponse");
+    return __isa(o, "ListPartnerEventSourceAccountsResponse");
   }
 }
 
@@ -963,7 +966,7 @@ export interface ListPartnerEventSourcesRequest {
 
 export namespace ListPartnerEventSourcesRequest {
   export function isa(o: any): o is ListPartnerEventSourcesRequest {
-    return _smithy.isa(o, "ListPartnerEventSourcesRequest");
+    return __isa(o, "ListPartnerEventSourcesRequest");
   }
 }
 
@@ -982,7 +985,7 @@ export interface ListPartnerEventSourcesResponse extends $MetadataBearer {
 
 export namespace ListPartnerEventSourcesResponse {
   export function isa(o: any): o is ListPartnerEventSourcesResponse {
-    return _smithy.isa(o, "ListPartnerEventSourcesResponse");
+    return __isa(o, "ListPartnerEventSourcesResponse");
   }
 }
 
@@ -1011,7 +1014,7 @@ export interface ListRuleNamesByTargetRequest {
 
 export namespace ListRuleNamesByTargetRequest {
   export function isa(o: any): o is ListRuleNamesByTargetRequest {
-    return _smithy.isa(o, "ListRuleNamesByTargetRequest");
+    return __isa(o, "ListRuleNamesByTargetRequest");
   }
 }
 
@@ -1030,7 +1033,7 @@ export interface ListRuleNamesByTargetResponse extends $MetadataBearer {
 
 export namespace ListRuleNamesByTargetResponse {
   export function isa(o: any): o is ListRuleNamesByTargetResponse {
-    return _smithy.isa(o, "ListRuleNamesByTargetResponse");
+    return __isa(o, "ListRuleNamesByTargetResponse");
   }
 }
 
@@ -1059,7 +1062,7 @@ export interface ListRulesRequest {
 
 export namespace ListRulesRequest {
   export function isa(o: any): o is ListRulesRequest {
-    return _smithy.isa(o, "ListRulesRequest");
+    return __isa(o, "ListRulesRequest");
   }
 }
 
@@ -1078,7 +1081,7 @@ export interface ListRulesResponse extends $MetadataBearer {
 
 export namespace ListRulesResponse {
   export function isa(o: any): o is ListRulesResponse {
-    return _smithy.isa(o, "ListRulesResponse");
+    return __isa(o, "ListRulesResponse");
   }
 }
 
@@ -1092,7 +1095,7 @@ export interface ListTagsForResourceRequest {
 
 export namespace ListTagsForResourceRequest {
   export function isa(o: any): o is ListTagsForResourceRequest {
-    return _smithy.isa(o, "ListTagsForResourceRequest");
+    return __isa(o, "ListTagsForResourceRequest");
   }
 }
 
@@ -1106,7 +1109,7 @@ export interface ListTagsForResourceResponse extends $MetadataBearer {
 
 export namespace ListTagsForResourceResponse {
   export function isa(o: any): o is ListTagsForResourceResponse {
-    return _smithy.isa(o, "ListTagsForResourceResponse");
+    return __isa(o, "ListTagsForResourceResponse");
   }
 }
 
@@ -1135,7 +1138,7 @@ export interface ListTargetsByRuleRequest {
 
 export namespace ListTargetsByRuleRequest {
   export function isa(o: any): o is ListTargetsByRuleRequest {
-    return _smithy.isa(o, "ListTargetsByRuleRequest");
+    return __isa(o, "ListTargetsByRuleRequest");
   }
 }
 
@@ -1154,7 +1157,7 @@ export interface ListTargetsByRuleResponse extends $MetadataBearer {
 
 export namespace ListTargetsByRuleResponse {
   export function isa(o: any): o is ListTargetsByRuleResponse {
-    return _smithy.isa(o, "ListTargetsByRuleResponse");
+    return __isa(o, "ListTargetsByRuleResponse");
   }
 }
 
@@ -1173,7 +1176,7 @@ export interface NetworkConfiguration {
 
 export namespace NetworkConfiguration {
   export function isa(o: any): o is NetworkConfiguration {
-    return _smithy.isa(o, "NetworkConfiguration");
+    return __isa(o, "NetworkConfiguration");
   }
 }
 
@@ -1196,7 +1199,7 @@ export interface PartnerEventSource {
 
 export namespace PartnerEventSource {
   export function isa(o: any): o is PartnerEventSource {
-    return _smithy.isa(o, "PartnerEventSource");
+    return __isa(o, "PartnerEventSource");
   }
 }
 
@@ -1233,7 +1236,7 @@ export interface PartnerEventSourceAccount {
 
 export namespace PartnerEventSourceAccount {
   export function isa(o: any): o is PartnerEventSourceAccount {
-    return _smithy.isa(o, "PartnerEventSourceAccount");
+    return __isa(o, "PartnerEventSourceAccount");
   }
 }
 
@@ -1247,7 +1250,7 @@ export interface PutEventsRequest {
 
 export namespace PutEventsRequest {
   export function isa(o: any): o is PutEventsRequest {
-    return _smithy.isa(o, "PutEventsRequest");
+    return __isa(o, "PutEventsRequest");
   }
 }
 
@@ -1295,7 +1298,7 @@ export interface PutEventsRequestEntry {
 
 export namespace PutEventsRequestEntry {
   export function isa(o: any): o is PutEventsRequestEntry {
-    return _smithy.isa(o, "PutEventsRequestEntry");
+    return __isa(o, "PutEventsRequestEntry");
   }
 }
 
@@ -1316,7 +1319,7 @@ export interface PutEventsResponse extends $MetadataBearer {
 
 export namespace PutEventsResponse {
   export function isa(o: any): o is PutEventsResponse {
-    return _smithy.isa(o, "PutEventsResponse");
+    return __isa(o, "PutEventsResponse");
   }
 }
 
@@ -1343,7 +1346,7 @@ export interface PutEventsResultEntry {
 
 export namespace PutEventsResultEntry {
   export function isa(o: any): o is PutEventsResultEntry {
-    return _smithy.isa(o, "PutEventsResultEntry");
+    return __isa(o, "PutEventsResultEntry");
   }
 }
 
@@ -1357,7 +1360,7 @@ export interface PutPartnerEventsRequest {
 
 export namespace PutPartnerEventsRequest {
   export function isa(o: any): o is PutPartnerEventsRequest {
-    return _smithy.isa(o, "PutPartnerEventsRequest");
+    return __isa(o, "PutPartnerEventsRequest");
   }
 }
 
@@ -1397,7 +1400,7 @@ export interface PutPartnerEventsRequestEntry {
 
 export namespace PutPartnerEventsRequestEntry {
   export function isa(o: any): o is PutPartnerEventsRequestEntry {
-    return _smithy.isa(o, "PutPartnerEventsRequestEntry");
+    return __isa(o, "PutPartnerEventsRequestEntry");
   }
 }
 
@@ -1417,7 +1420,7 @@ export interface PutPartnerEventsResponse extends $MetadataBearer {
 
 export namespace PutPartnerEventsResponse {
   export function isa(o: any): o is PutPartnerEventsResponse {
-    return _smithy.isa(o, "PutPartnerEventsResponse");
+    return __isa(o, "PutPartnerEventsResponse");
   }
 }
 
@@ -1444,7 +1447,7 @@ export interface PutPartnerEventsResultEntry {
 
 export namespace PutPartnerEventsResultEntry {
   export function isa(o: any): o is PutPartnerEventsResultEntry {
-    return _smithy.isa(o, "PutPartnerEventsResultEntry");
+    return __isa(o, "PutPartnerEventsResultEntry");
   }
 }
 
@@ -1498,7 +1501,7 @@ export interface PutPermissionRequest {
 
 export namespace PutPermissionRequest {
   export function isa(o: any): o is PutPermissionRequest {
-    return _smithy.isa(o, "PutPermissionRequest");
+    return __isa(o, "PutPermissionRequest");
   }
 }
 
@@ -1550,7 +1553,7 @@ export interface PutRuleRequest {
 
 export namespace PutRuleRequest {
   export function isa(o: any): o is PutRuleRequest {
-    return _smithy.isa(o, "PutRuleRequest");
+    return __isa(o, "PutRuleRequest");
   }
 }
 
@@ -1564,7 +1567,7 @@ export interface PutRuleResponse extends $MetadataBearer {
 
 export namespace PutRuleResponse {
   export function isa(o: any): o is PutRuleResponse {
-    return _smithy.isa(o, "PutRuleResponse");
+    return __isa(o, "PutRuleResponse");
   }
 }
 
@@ -1588,7 +1591,7 @@ export interface PutTargetsRequest {
 
 export namespace PutTargetsRequest {
   export function isa(o: any): o is PutTargetsRequest {
-    return _smithy.isa(o, "PutTargetsRequest");
+    return __isa(o, "PutTargetsRequest");
   }
 }
 
@@ -1607,7 +1610,7 @@ export interface PutTargetsResponse extends $MetadataBearer {
 
 export namespace PutTargetsResponse {
   export function isa(o: any): o is PutTargetsResponse {
-    return _smithy.isa(o, "PutTargetsResponse");
+    return __isa(o, "PutTargetsResponse");
   }
 }
 
@@ -1635,7 +1638,7 @@ export interface PutTargetsResultEntry {
 
 export namespace PutTargetsResultEntry {
   export function isa(o: any): o is PutTargetsResultEntry {
-    return _smithy.isa(o, "PutTargetsResultEntry");
+    return __isa(o, "PutTargetsResultEntry");
   }
 }
 
@@ -1654,7 +1657,7 @@ export interface RemovePermissionRequest {
 
 export namespace RemovePermissionRequest {
   export function isa(o: any): o is RemovePermissionRequest {
-    return _smithy.isa(o, "RemovePermissionRequest");
+    return __isa(o, "RemovePermissionRequest");
   }
 }
 
@@ -1687,7 +1690,7 @@ export interface RemoveTargetsRequest {
 
 export namespace RemoveTargetsRequest {
   export function isa(o: any): o is RemoveTargetsRequest {
-    return _smithy.isa(o, "RemoveTargetsRequest");
+    return __isa(o, "RemoveTargetsRequest");
   }
 }
 
@@ -1706,7 +1709,7 @@ export interface RemoveTargetsResponse extends $MetadataBearer {
 
 export namespace RemoveTargetsResponse {
   export function isa(o: any): o is RemoveTargetsResponse {
-    return _smithy.isa(o, "RemoveTargetsResponse");
+    return __isa(o, "RemoveTargetsResponse");
   }
 }
 
@@ -1734,7 +1737,7 @@ export interface RemoveTargetsResultEntry {
 
 export namespace RemoveTargetsResultEntry {
   export function isa(o: any): o is RemoveTargetsResultEntry {
-    return _smithy.isa(o, "RemoveTargetsResultEntry");
+    return __isa(o, "RemoveTargetsResultEntry");
   }
 }
 
@@ -1793,7 +1796,7 @@ export interface Rule {
 
 export namespace Rule {
   export function isa(o: any): o is Rule {
-    return _smithy.isa(o, "Rule");
+    return __isa(o, "Rule");
   }
 }
 
@@ -1817,7 +1820,7 @@ export interface RunCommandParameters {
 
 export namespace RunCommandParameters {
   export function isa(o: any): o is RunCommandParameters {
-    return _smithy.isa(o, "RunCommandParameters");
+    return __isa(o, "RunCommandParameters");
   }
 }
 
@@ -1844,7 +1847,7 @@ export interface RunCommandTarget {
 
 export namespace RunCommandTarget {
   export function isa(o: any): o is RunCommandTarget {
-    return _smithy.isa(o, "RunCommandTarget");
+    return __isa(o, "RunCommandTarget");
   }
 }
 
@@ -1861,7 +1864,7 @@ export interface SqsParameters {
 
 export namespace SqsParameters {
   export function isa(o: any): o is SqsParameters {
-    return _smithy.isa(o, "SqsParameters");
+    return __isa(o, "SqsParameters");
   }
 }
 
@@ -1884,7 +1887,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -1903,7 +1906,7 @@ export interface TagResourceRequest {
 
 export namespace TagResourceRequest {
   export function isa(o: any): o is TagResourceRequest {
-    return _smithy.isa(o, "TagResourceRequest");
+    return __isa(o, "TagResourceRequest");
   }
 }
 
@@ -1913,7 +1916,7 @@ export interface TagResourceResponse extends $MetadataBearer {
 
 export namespace TagResourceResponse {
   export function isa(o: any): o is TagResourceResponse {
-    return _smithy.isa(o, "TagResourceResponse");
+    return __isa(o, "TagResourceResponse");
   }
 }
 
@@ -2001,7 +2004,7 @@ export interface Target {
 
 export namespace Target {
   export function isa(o: any): o is Target {
-    return _smithy.isa(o, "Target");
+    return __isa(o, "Target");
   }
 }
 
@@ -2021,7 +2024,7 @@ export interface TestEventPatternRequest {
 
 export namespace TestEventPatternRequest {
   export function isa(o: any): o is TestEventPatternRequest {
-    return _smithy.isa(o, "TestEventPatternRequest");
+    return __isa(o, "TestEventPatternRequest");
   }
 }
 
@@ -2035,7 +2038,7 @@ export interface TestEventPatternResponse extends $MetadataBearer {
 
 export namespace TestEventPatternResponse {
   export function isa(o: any): o is TestEventPatternResponse {
-    return _smithy.isa(o, "TestEventPatternResponse");
+    return __isa(o, "TestEventPatternResponse");
   }
 }
 
@@ -2054,7 +2057,7 @@ export interface UntagResourceRequest {
 
 export namespace UntagResourceRequest {
   export function isa(o: any): o is UntagResourceRequest {
-    return _smithy.isa(o, "UntagResourceRequest");
+    return __isa(o, "UntagResourceRequest");
   }
 }
 
@@ -2064,7 +2067,7 @@ export interface UntagResourceResponse extends $MetadataBearer {
 
 export namespace UntagResourceResponse {
   export function isa(o: any): o is UntagResourceResponse {
-    return _smithy.isa(o, "UntagResourceResponse");
+    return __isa(o, "UntagResourceResponse");
   }
 }
 
@@ -2072,7 +2075,7 @@ export namespace UntagResourceResponse {
  * <p>There is concurrent modification on a resource.</p>
  */
 export interface ConcurrentModificationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ConcurrentModificationException";
   $fault: "client";
@@ -2081,16 +2084,14 @@ export interface ConcurrentModificationException
 
 export namespace ConcurrentModificationException {
   export function isa(o: any): o is ConcurrentModificationException {
-    return _smithy.isa(o, "ConcurrentModificationException");
+    return __isa(o, "ConcurrentModificationException");
   }
 }
 
 /**
  * <p>This exception occurs due to unexpected causes.</p>
  */
-export interface InternalException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface InternalException extends __SmithyException, $MetadataBearer {
   name: "InternalException";
   $fault: "server";
   message?: string;
@@ -2098,7 +2099,7 @@ export interface InternalException
 
 export namespace InternalException {
   export function isa(o: any): o is InternalException {
-    return _smithy.isa(o, "InternalException");
+    return __isa(o, "InternalException");
   }
 }
 
@@ -2106,7 +2107,7 @@ export namespace InternalException {
  * <p>The event pattern isn't valid.</p>
  */
 export interface InvalidEventPatternException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidEventPatternException";
   $fault: "client";
@@ -2115,7 +2116,7 @@ export interface InvalidEventPatternException
 
 export namespace InvalidEventPatternException {
   export function isa(o: any): o is InvalidEventPatternException {
-    return _smithy.isa(o, "InvalidEventPatternException");
+    return __isa(o, "InvalidEventPatternException");
   }
 }
 
@@ -2123,7 +2124,7 @@ export namespace InvalidEventPatternException {
  * <p>The specified state isn't a valid state for an event source.</p>
  */
 export interface InvalidStateException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidStateException";
   $fault: "client";
@@ -2132,7 +2133,7 @@ export interface InvalidStateException
 
 export namespace InvalidStateException {
   export function isa(o: any): o is InvalidStateException {
-    return _smithy.isa(o, "InvalidStateException");
+    return __isa(o, "InvalidStateException");
   }
 }
 
@@ -2140,7 +2141,7 @@ export namespace InvalidStateException {
  * <p>You tried to create more resources than is allowed.</p>
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -2149,7 +2150,7 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
@@ -2163,7 +2164,7 @@ export namespace LimitExceededException {
  *                 <code>UntagResource</code>. </p>
  */
 export interface ManagedRuleException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ManagedRuleException";
   $fault: "client";
@@ -2172,7 +2173,7 @@ export interface ManagedRuleException
 
 export namespace ManagedRuleException {
   export function isa(o: any): o is ManagedRuleException {
-    return _smithy.isa(o, "ManagedRuleException");
+    return __isa(o, "ManagedRuleException");
   }
 }
 
@@ -2180,7 +2181,7 @@ export namespace ManagedRuleException {
  * <p>The event bus policy is too long. For more information, see the limits.</p>
  */
 export interface PolicyLengthExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "PolicyLengthExceededException";
   $fault: "client";
@@ -2189,7 +2190,7 @@ export interface PolicyLengthExceededException
 
 export namespace PolicyLengthExceededException {
   export function isa(o: any): o is PolicyLengthExceededException {
-    return _smithy.isa(o, "PolicyLengthExceededException");
+    return __isa(o, "PolicyLengthExceededException");
   }
 }
 
@@ -2197,7 +2198,7 @@ export namespace PolicyLengthExceededException {
  * <p>The resource that you're trying to create already exists.</p>
  */
 export interface ResourceAlreadyExistsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceAlreadyExistsException";
   $fault: "client";
@@ -2206,7 +2207,7 @@ export interface ResourceAlreadyExistsException
 
 export namespace ResourceAlreadyExistsException {
   export function isa(o: any): o is ResourceAlreadyExistsException {
-    return _smithy.isa(o, "ResourceAlreadyExistsException");
+    return __isa(o, "ResourceAlreadyExistsException");
   }
 }
 
@@ -2214,7 +2215,7 @@ export namespace ResourceAlreadyExistsException {
  * <p>An entity that you specified doesn't exist.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -2223,6 +2224,6 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }

--- a/clients/client-eventbridge/protocols/Aws_json1_1.ts
+++ b/clients/client-eventbridge/protocols/Aws_json1_1.ts
@@ -652,6 +652,7 @@ export async function deserializeAws_json1_1ActivateEventSourceCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: ActivateEventSourceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -894,6 +895,7 @@ export async function deserializeAws_json1_1DeactivateEventSourceCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeactivateEventSourceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -959,6 +961,7 @@ export async function deserializeAws_json1_1DeleteEventBusCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1DeleteEventBusCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteEventBusCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1013,6 +1016,7 @@ export async function deserializeAws_json1_1DeletePartnerEventSourceCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeletePartnerEventSourceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1064,6 +1068,7 @@ export async function deserializeAws_json1_1DeleteRuleCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1DeleteRuleCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteRuleCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1397,6 +1402,7 @@ export async function deserializeAws_json1_1DisableRuleCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1DisableRuleCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DisableRuleCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1469,6 +1475,7 @@ export async function deserializeAws_json1_1EnableRuleCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1EnableRuleCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: EnableRuleCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2154,6 +2161,7 @@ export async function deserializeAws_json1_1PutPermissionCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1PutPermissionCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: PutPermissionCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2401,6 +2409,7 @@ export async function deserializeAws_json1_1RemovePermissionCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1RemovePermissionCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: RemovePermissionCommandOutput = {
     $metadata: deserializeMetadata(output)
   };

--- a/clients/client-firehose/models/index.ts
+++ b/clients/client-firehose/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -32,7 +35,7 @@ export interface BufferingHints {
 
 export namespace BufferingHints {
   export function isa(o: any): o is BufferingHints {
-    return _smithy.isa(o, "BufferingHints");
+    return __isa(o, "BufferingHints");
   }
 }
 
@@ -61,7 +64,7 @@ export interface CloudWatchLoggingOptions {
 
 export namespace CloudWatchLoggingOptions {
   export function isa(o: any): o is CloudWatchLoggingOptions {
-    return _smithy.isa(o, "CloudWatchLoggingOptions");
+    return __isa(o, "CloudWatchLoggingOptions");
   }
 }
 
@@ -77,7 +80,7 @@ export enum CompressionFormat {
  *          it to update the destination.</p>
  */
 export interface ConcurrentModificationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ConcurrentModificationException";
   $fault: "client";
@@ -89,7 +92,7 @@ export interface ConcurrentModificationException
 
 export namespace ConcurrentModificationException {
   export function isa(o: any): o is ConcurrentModificationException {
-    return _smithy.isa(o, "ConcurrentModificationException");
+    return __isa(o, "ConcurrentModificationException");
   }
 }
 
@@ -135,7 +138,7 @@ export interface CopyCommand {
 
 export namespace CopyCommand {
   export function isa(o: any): o is CopyCommand {
-    return _smithy.isa(o, "CopyCommand");
+    return __isa(o, "CopyCommand");
   }
 }
 
@@ -218,7 +221,7 @@ export interface CreateDeliveryStreamInput {
 
 export namespace CreateDeliveryStreamInput {
   export function isa(o: any): o is CreateDeliveryStreamInput {
-    return _smithy.isa(o, "CreateDeliveryStreamInput");
+    return __isa(o, "CreateDeliveryStreamInput");
   }
 }
 
@@ -232,7 +235,7 @@ export interface CreateDeliveryStreamOutput extends $MetadataBearer {
 
 export namespace CreateDeliveryStreamOutput {
   export function isa(o: any): o is CreateDeliveryStreamOutput {
-    return _smithy.isa(o, "CreateDeliveryStreamOutput");
+    return __isa(o, "CreateDeliveryStreamOutput");
   }
 }
 
@@ -270,7 +273,7 @@ export interface DataFormatConversionConfiguration {
 
 export namespace DataFormatConversionConfiguration {
   export function isa(o: any): o is DataFormatConversionConfiguration {
-    return _smithy.isa(o, "DataFormatConversionConfiguration");
+    return __isa(o, "DataFormatConversionConfiguration");
   }
 }
 
@@ -295,7 +298,7 @@ export interface DeleteDeliveryStreamInput {
 
 export namespace DeleteDeliveryStreamInput {
   export function isa(o: any): o is DeleteDeliveryStreamInput {
-    return _smithy.isa(o, "DeleteDeliveryStreamInput");
+    return __isa(o, "DeleteDeliveryStreamInput");
   }
 }
 
@@ -305,7 +308,7 @@ export interface DeleteDeliveryStreamOutput extends $MetadataBearer {
 
 export namespace DeleteDeliveryStreamOutput {
   export function isa(o: any): o is DeleteDeliveryStreamOutput {
-    return _smithy.isa(o, "DeleteDeliveryStreamOutput");
+    return __isa(o, "DeleteDeliveryStreamOutput");
   }
 }
 
@@ -397,7 +400,7 @@ export interface DeliveryStreamDescription {
 
 export namespace DeliveryStreamDescription {
   export function isa(o: any): o is DeliveryStreamDescription {
-    return _smithy.isa(o, "DeliveryStreamDescription");
+    return __isa(o, "DeliveryStreamDescription");
   }
 }
 
@@ -437,7 +440,7 @@ export interface DeliveryStreamEncryptionConfiguration {
 
 export namespace DeliveryStreamEncryptionConfiguration {
   export function isa(o: any): o is DeliveryStreamEncryptionConfiguration {
-    return _smithy.isa(o, "DeliveryStreamEncryptionConfiguration");
+    return __isa(o, "DeliveryStreamEncryptionConfiguration");
   }
 }
 
@@ -470,7 +473,7 @@ export interface DeliveryStreamEncryptionConfigurationInput {
 
 export namespace DeliveryStreamEncryptionConfigurationInput {
   export function isa(o: any): o is DeliveryStreamEncryptionConfigurationInput {
-    return _smithy.isa(o, "DeliveryStreamEncryptionConfigurationInput");
+    return __isa(o, "DeliveryStreamEncryptionConfigurationInput");
   }
 }
 
@@ -526,7 +529,7 @@ export interface DescribeDeliveryStreamInput {
 
 export namespace DescribeDeliveryStreamInput {
   export function isa(o: any): o is DescribeDeliveryStreamInput {
-    return _smithy.isa(o, "DescribeDeliveryStreamInput");
+    return __isa(o, "DescribeDeliveryStreamInput");
   }
 }
 
@@ -540,7 +543,7 @@ export interface DescribeDeliveryStreamOutput extends $MetadataBearer {
 
 export namespace DescribeDeliveryStreamOutput {
   export function isa(o: any): o is DescribeDeliveryStreamOutput {
-    return _smithy.isa(o, "DescribeDeliveryStreamOutput");
+    return __isa(o, "DescribeDeliveryStreamOutput");
   }
 }
 
@@ -571,7 +574,7 @@ export interface Deserializer {
 
 export namespace Deserializer {
   export function isa(o: any): o is Deserializer {
-    return _smithy.isa(o, "Deserializer");
+    return __isa(o, "Deserializer");
   }
 }
 
@@ -613,7 +616,7 @@ export interface DestinationDescription {
 
 export namespace DestinationDescription {
   export function isa(o: any): o is DestinationDescription {
-    return _smithy.isa(o, "DestinationDescription");
+    return __isa(o, "DestinationDescription");
   }
 }
 
@@ -641,7 +644,7 @@ export interface ElasticsearchBufferingHints {
 
 export namespace ElasticsearchBufferingHints {
   export function isa(o: any): o is ElasticsearchBufferingHints {
-    return _smithy.isa(o, "ElasticsearchBufferingHints");
+    return __isa(o, "ElasticsearchBufferingHints");
   }
 }
 
@@ -741,7 +744,7 @@ export interface ElasticsearchDestinationConfiguration {
 
 export namespace ElasticsearchDestinationConfiguration {
   export function isa(o: any): o is ElasticsearchDestinationConfiguration {
-    return _smithy.isa(o, "ElasticsearchDestinationConfiguration");
+    return __isa(o, "ElasticsearchDestinationConfiguration");
   }
 }
 
@@ -817,7 +820,7 @@ export interface ElasticsearchDestinationDescription {
 
 export namespace ElasticsearchDestinationDescription {
   export function isa(o: any): o is ElasticsearchDestinationDescription {
-    return _smithy.isa(o, "ElasticsearchDestinationDescription");
+    return __isa(o, "ElasticsearchDestinationDescription");
   }
 }
 
@@ -905,7 +908,7 @@ export interface ElasticsearchDestinationUpdate {
 
 export namespace ElasticsearchDestinationUpdate {
   export function isa(o: any): o is ElasticsearchDestinationUpdate {
-    return _smithy.isa(o, "ElasticsearchDestinationUpdate");
+    return __isa(o, "ElasticsearchDestinationUpdate");
   }
 }
 
@@ -934,7 +937,7 @@ export interface ElasticsearchRetryOptions {
 
 export namespace ElasticsearchRetryOptions {
   export function isa(o: any): o is ElasticsearchRetryOptions {
-    return _smithy.isa(o, "ElasticsearchRetryOptions");
+    return __isa(o, "ElasticsearchRetryOptions");
   }
 }
 
@@ -959,7 +962,7 @@ export interface EncryptionConfiguration {
 
 export namespace EncryptionConfiguration {
   export function isa(o: any): o is EncryptionConfiguration {
-    return _smithy.isa(o, "EncryptionConfiguration");
+    return __isa(o, "EncryptionConfiguration");
   }
 }
 
@@ -1038,7 +1041,7 @@ export interface ExtendedS3DestinationConfiguration {
 
 export namespace ExtendedS3DestinationConfiguration {
   export function isa(o: any): o is ExtendedS3DestinationConfiguration {
-    return _smithy.isa(o, "ExtendedS3DestinationConfiguration");
+    return __isa(o, "ExtendedS3DestinationConfiguration");
   }
 }
 
@@ -1118,7 +1121,7 @@ export interface ExtendedS3DestinationDescription {
 
 export namespace ExtendedS3DestinationDescription {
   export function isa(o: any): o is ExtendedS3DestinationDescription {
-    return _smithy.isa(o, "ExtendedS3DestinationDescription");
+    return __isa(o, "ExtendedS3DestinationDescription");
   }
 }
 
@@ -1198,7 +1201,7 @@ export interface ExtendedS3DestinationUpdate {
 
 export namespace ExtendedS3DestinationUpdate {
   export function isa(o: any): o is ExtendedS3DestinationUpdate {
-    return _smithy.isa(o, "ExtendedS3DestinationUpdate");
+    return __isa(o, "ExtendedS3DestinationUpdate");
   }
 }
 
@@ -1221,7 +1224,7 @@ export interface FailureDescription {
 
 export namespace FailureDescription {
   export function isa(o: any): o is FailureDescription {
-    return _smithy.isa(o, "FailureDescription");
+    return __isa(o, "FailureDescription");
   }
 }
 
@@ -1247,7 +1250,7 @@ export interface HiveJsonSerDe {
 
 export namespace HiveJsonSerDe {
   export function isa(o: any): o is HiveJsonSerDe {
-    return _smithy.isa(o, "HiveJsonSerDe");
+    return __isa(o, "HiveJsonSerDe");
   }
 }
 
@@ -1265,7 +1268,7 @@ export interface InputFormatConfiguration {
 
 export namespace InputFormatConfiguration {
   export function isa(o: any): o is InputFormatConfiguration {
-    return _smithy.isa(o, "InputFormatConfiguration");
+    return __isa(o, "InputFormatConfiguration");
   }
 }
 
@@ -1273,7 +1276,7 @@ export namespace InputFormatConfiguration {
  * <p>The specified input parameter has a value that is not valid.</p>
  */
 export interface InvalidArgumentException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidArgumentException";
   $fault: "client";
@@ -1285,7 +1288,7 @@ export interface InvalidArgumentException
 
 export namespace InvalidArgumentException {
   export function isa(o: any): o is InvalidArgumentException {
-    return _smithy.isa(o, "InvalidArgumentException");
+    return __isa(o, "InvalidArgumentException");
   }
 }
 
@@ -1294,7 +1297,7 @@ export namespace InvalidArgumentException {
  *          the KMS service throws one of the following exception types: <code>AccessDeniedException</code>, <code>InvalidStateException</code>, <code>DisabledException</code>, or <code>NotFoundException</code>.</p>
  */
 export interface InvalidKMSResourceException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidKMSResourceException";
   $fault: "client";
@@ -1304,7 +1307,7 @@ export interface InvalidKMSResourceException
 
 export namespace InvalidKMSResourceException {
   export function isa(o: any): o is InvalidKMSResourceException {
-    return _smithy.isa(o, "InvalidKMSResourceException");
+    return __isa(o, "InvalidKMSResourceException");
   }
 }
 
@@ -1323,7 +1326,7 @@ export interface KMSEncryptionConfig {
 
 export namespace KMSEncryptionConfig {
   export function isa(o: any): o is KMSEncryptionConfig {
-    return _smithy.isa(o, "KMSEncryptionConfig");
+    return __isa(o, "KMSEncryptionConfig");
   }
 }
 
@@ -1352,7 +1355,7 @@ export interface KinesisStreamSourceConfiguration {
 
 export namespace KinesisStreamSourceConfiguration {
   export function isa(o: any): o is KinesisStreamSourceConfiguration {
-    return _smithy.isa(o, "KinesisStreamSourceConfiguration");
+    return __isa(o, "KinesisStreamSourceConfiguration");
   }
 }
 
@@ -1383,7 +1386,7 @@ export interface KinesisStreamSourceDescription {
 
 export namespace KinesisStreamSourceDescription {
   export function isa(o: any): o is KinesisStreamSourceDescription {
-    return _smithy.isa(o, "KinesisStreamSourceDescription");
+    return __isa(o, "KinesisStreamSourceDescription");
   }
 }
 
@@ -1391,7 +1394,7 @@ export namespace KinesisStreamSourceDescription {
  * <p>You have already reached the limit for a requested resource.</p>
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -1403,7 +1406,7 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
@@ -1444,7 +1447,7 @@ export interface ListDeliveryStreamsInput {
 
 export namespace ListDeliveryStreamsInput {
   export function isa(o: any): o is ListDeliveryStreamsInput {
-    return _smithy.isa(o, "ListDeliveryStreamsInput");
+    return __isa(o, "ListDeliveryStreamsInput");
   }
 }
 
@@ -1463,7 +1466,7 @@ export interface ListDeliveryStreamsOutput extends $MetadataBearer {
 
 export namespace ListDeliveryStreamsOutput {
   export function isa(o: any): o is ListDeliveryStreamsOutput {
-    return _smithy.isa(o, "ListDeliveryStreamsOutput");
+    return __isa(o, "ListDeliveryStreamsOutput");
   }
 }
 
@@ -1491,7 +1494,7 @@ export interface ListTagsForDeliveryStreamInput {
 
 export namespace ListTagsForDeliveryStreamInput {
   export function isa(o: any): o is ListTagsForDeliveryStreamInput {
-    return _smithy.isa(o, "ListTagsForDeliveryStreamInput");
+    return __isa(o, "ListTagsForDeliveryStreamInput");
   }
 }
 
@@ -1513,7 +1516,7 @@ export interface ListTagsForDeliveryStreamOutput extends $MetadataBearer {
 
 export namespace ListTagsForDeliveryStreamOutput {
   export function isa(o: any): o is ListTagsForDeliveryStreamOutput {
-    return _smithy.isa(o, "ListTagsForDeliveryStreamOutput");
+    return __isa(o, "ListTagsForDeliveryStreamOutput");
   }
 }
 
@@ -1555,7 +1558,7 @@ export interface OpenXJsonSerDe {
 
 export namespace OpenXJsonSerDe {
   export function isa(o: any): o is OpenXJsonSerDe {
-    return _smithy.isa(o, "OpenXJsonSerDe");
+    return __isa(o, "OpenXJsonSerDe");
   }
 }
 
@@ -1646,7 +1649,7 @@ export interface OrcSerDe {
 
 export namespace OrcSerDe {
   export function isa(o: any): o is OrcSerDe {
-    return _smithy.isa(o, "OrcSerDe");
+    return __isa(o, "OrcSerDe");
   }
 }
 
@@ -1664,7 +1667,7 @@ export interface OutputFormatConfiguration {
 
 export namespace OutputFormatConfiguration {
   export function isa(o: any): o is OutputFormatConfiguration {
-    return _smithy.isa(o, "OutputFormatConfiguration");
+    return __isa(o, "OutputFormatConfiguration");
   }
 }
 
@@ -1719,7 +1722,7 @@ export interface ParquetSerDe {
 
 export namespace ParquetSerDe {
   export function isa(o: any): o is ParquetSerDe {
-    return _smithy.isa(o, "ParquetSerDe");
+    return __isa(o, "ParquetSerDe");
   }
 }
 
@@ -1746,7 +1749,7 @@ export interface ProcessingConfiguration {
 
 export namespace ProcessingConfiguration {
   export function isa(o: any): o is ProcessingConfiguration {
-    return _smithy.isa(o, "ProcessingConfiguration");
+    return __isa(o, "ProcessingConfiguration");
   }
 }
 
@@ -1768,7 +1771,7 @@ export interface Processor {
 
 export namespace Processor {
   export function isa(o: any): o is Processor {
-    return _smithy.isa(o, "Processor");
+    return __isa(o, "Processor");
   }
 }
 
@@ -1790,7 +1793,7 @@ export interface ProcessorParameter {
 
 export namespace ProcessorParameter {
   export function isa(o: any): o is ProcessorParameter {
-    return _smithy.isa(o, "ProcessorParameter");
+    return __isa(o, "ProcessorParameter");
   }
 }
 
@@ -1819,7 +1822,7 @@ export interface PutRecordBatchInput {
 
 export namespace PutRecordBatchInput {
   export function isa(o: any): o is PutRecordBatchInput {
-    return _smithy.isa(o, "PutRecordBatchInput");
+    return __isa(o, "PutRecordBatchInput");
   }
 }
 
@@ -1847,7 +1850,7 @@ export interface PutRecordBatchOutput extends $MetadataBearer {
 
 export namespace PutRecordBatchOutput {
   export function isa(o: any): o is PutRecordBatchOutput {
-    return _smithy.isa(o, "PutRecordBatchOutput");
+    return __isa(o, "PutRecordBatchOutput");
   }
 }
 
@@ -1877,7 +1880,7 @@ export interface PutRecordBatchResponseEntry {
 
 export namespace PutRecordBatchResponseEntry {
   export function isa(o: any): o is PutRecordBatchResponseEntry {
-    return _smithy.isa(o, "PutRecordBatchResponseEntry");
+    return __isa(o, "PutRecordBatchResponseEntry");
   }
 }
 
@@ -1896,7 +1899,7 @@ export interface PutRecordInput {
 
 export namespace PutRecordInput {
   export function isa(o: any): o is PutRecordInput {
-    return _smithy.isa(o, "PutRecordInput");
+    return __isa(o, "PutRecordInput");
   }
 }
 
@@ -1915,7 +1918,7 @@ export interface PutRecordOutput extends $MetadataBearer {
 
 export namespace PutRecordOutput {
   export function isa(o: any): o is PutRecordOutput {
-    return _smithy.isa(o, "PutRecordOutput");
+    return __isa(o, "PutRecordOutput");
   }
 }
 
@@ -1933,7 +1936,7 @@ export interface _Record {
 
 export namespace _Record {
   export function isa(o: any): o is _Record {
-    return _smithy.isa(o, "Record");
+    return __isa(o, "Record");
   }
 }
 
@@ -2007,7 +2010,7 @@ export interface RedshiftDestinationConfiguration {
 
 export namespace RedshiftDestinationConfiguration {
   export function isa(o: any): o is RedshiftDestinationConfiguration {
-    return _smithy.isa(o, "RedshiftDestinationConfiguration");
+    return __isa(o, "RedshiftDestinationConfiguration");
   }
 }
 
@@ -2071,7 +2074,7 @@ export interface RedshiftDestinationDescription {
 
 export namespace RedshiftDestinationDescription {
   export function isa(o: any): o is RedshiftDestinationDescription {
-    return _smithy.isa(o, "RedshiftDestinationDescription");
+    return __isa(o, "RedshiftDestinationDescription");
   }
 }
 
@@ -2144,7 +2147,7 @@ export interface RedshiftDestinationUpdate {
 
 export namespace RedshiftDestinationUpdate {
   export function isa(o: any): o is RedshiftDestinationUpdate {
-    return _smithy.isa(o, "RedshiftDestinationUpdate");
+    return __isa(o, "RedshiftDestinationUpdate");
   }
 }
 
@@ -2166,7 +2169,7 @@ export interface RedshiftRetryOptions {
 
 export namespace RedshiftRetryOptions {
   export function isa(o: any): o is RedshiftRetryOptions {
-    return _smithy.isa(o, "RedshiftRetryOptions");
+    return __isa(o, "RedshiftRetryOptions");
   }
 }
 
@@ -2176,7 +2179,7 @@ export type RedshiftS3BackupMode = "Disabled" | "Enabled";
  * <p>The resource is already in use and not available for this operation.</p>
  */
 export interface ResourceInUseException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceInUseException";
   $fault: "client";
@@ -2188,7 +2191,7 @@ export interface ResourceInUseException
 
 export namespace ResourceInUseException {
   export function isa(o: any): o is ResourceInUseException {
-    return _smithy.isa(o, "ResourceInUseException");
+    return __isa(o, "ResourceInUseException");
   }
 }
 
@@ -2196,7 +2199,7 @@ export namespace ResourceInUseException {
  * <p>The specified resource could not be found.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -2208,7 +2211,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -2275,7 +2278,7 @@ export interface S3DestinationConfiguration {
 
 export namespace S3DestinationConfiguration {
   export function isa(o: any): o is S3DestinationConfiguration {
-    return _smithy.isa(o, "S3DestinationConfiguration");
+    return __isa(o, "S3DestinationConfiguration");
   }
 }
 
@@ -2337,7 +2340,7 @@ export interface S3DestinationDescription {
 
 export namespace S3DestinationDescription {
   export function isa(o: any): o is S3DestinationDescription {
-    return _smithy.isa(o, "S3DestinationDescription");
+    return __isa(o, "S3DestinationDescription");
   }
 }
 
@@ -2402,7 +2405,7 @@ export interface S3DestinationUpdate {
 
 export namespace S3DestinationUpdate {
   export function isa(o: any): o is S3DestinationUpdate {
-    return _smithy.isa(o, "S3DestinationUpdate");
+    return __isa(o, "S3DestinationUpdate");
   }
 }
 
@@ -2452,7 +2455,7 @@ export interface SchemaConfiguration {
 
 export namespace SchemaConfiguration {
   export function isa(o: any): o is SchemaConfiguration {
-    return _smithy.isa(o, "SchemaConfiguration");
+    return __isa(o, "SchemaConfiguration");
   }
 }
 
@@ -2479,7 +2482,7 @@ export interface Serializer {
 
 export namespace Serializer {
   export function isa(o: any): o is Serializer {
-    return _smithy.isa(o, "Serializer");
+    return __isa(o, "Serializer");
   }
 }
 
@@ -2490,7 +2493,7 @@ export namespace Serializer {
  *          Limits</a>.</p>
  */
 export interface ServiceUnavailableException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ServiceUnavailableException";
   $fault: "server";
@@ -2502,7 +2505,7 @@ export interface ServiceUnavailableException
 
 export namespace ServiceUnavailableException {
   export function isa(o: any): o is ServiceUnavailableException {
-    return _smithy.isa(o, "ServiceUnavailableException");
+    return __isa(o, "ServiceUnavailableException");
   }
 }
 
@@ -2521,7 +2524,7 @@ export interface SourceDescription {
 
 export namespace SourceDescription {
   export function isa(o: any): o is SourceDescription {
-    return _smithy.isa(o, "SourceDescription");
+    return __isa(o, "SourceDescription");
   }
 }
 
@@ -2588,7 +2591,7 @@ export interface SplunkDestinationConfiguration {
 
 export namespace SplunkDestinationConfiguration {
   export function isa(o: any): o is SplunkDestinationConfiguration {
-    return _smithy.isa(o, "SplunkDestinationConfiguration");
+    return __isa(o, "SplunkDestinationConfiguration");
   }
 }
 
@@ -2655,7 +2658,7 @@ export interface SplunkDestinationDescription {
 
 export namespace SplunkDestinationDescription {
   export function isa(o: any): o is SplunkDestinationDescription {
-    return _smithy.isa(o, "SplunkDestinationDescription");
+    return __isa(o, "SplunkDestinationDescription");
   }
 }
 
@@ -2723,7 +2726,7 @@ export interface SplunkDestinationUpdate {
 
 export namespace SplunkDestinationUpdate {
   export function isa(o: any): o is SplunkDestinationUpdate {
-    return _smithy.isa(o, "SplunkDestinationUpdate");
+    return __isa(o, "SplunkDestinationUpdate");
   }
 }
 
@@ -2744,7 +2747,7 @@ export interface SplunkRetryOptions {
 
 export namespace SplunkRetryOptions {
   export function isa(o: any): o is SplunkRetryOptions {
-    return _smithy.isa(o, "SplunkRetryOptions");
+    return __isa(o, "SplunkRetryOptions");
   }
 }
 
@@ -2767,7 +2770,7 @@ export interface StartDeliveryStreamEncryptionInput {
 
 export namespace StartDeliveryStreamEncryptionInput {
   export function isa(o: any): o is StartDeliveryStreamEncryptionInput {
-    return _smithy.isa(o, "StartDeliveryStreamEncryptionInput");
+    return __isa(o, "StartDeliveryStreamEncryptionInput");
   }
 }
 
@@ -2777,7 +2780,7 @@ export interface StartDeliveryStreamEncryptionOutput extends $MetadataBearer {
 
 export namespace StartDeliveryStreamEncryptionOutput {
   export function isa(o: any): o is StartDeliveryStreamEncryptionOutput {
-    return _smithy.isa(o, "StartDeliveryStreamEncryptionOutput");
+    return __isa(o, "StartDeliveryStreamEncryptionOutput");
   }
 }
 
@@ -2792,7 +2795,7 @@ export interface StopDeliveryStreamEncryptionInput {
 
 export namespace StopDeliveryStreamEncryptionInput {
   export function isa(o: any): o is StopDeliveryStreamEncryptionInput {
-    return _smithy.isa(o, "StopDeliveryStreamEncryptionInput");
+    return __isa(o, "StopDeliveryStreamEncryptionInput");
   }
 }
 
@@ -2802,7 +2805,7 @@ export interface StopDeliveryStreamEncryptionOutput extends $MetadataBearer {
 
 export namespace StopDeliveryStreamEncryptionOutput {
   export function isa(o: any): o is StopDeliveryStreamEncryptionOutput {
-    return _smithy.isa(o, "StopDeliveryStreamEncryptionOutput");
+    return __isa(o, "StopDeliveryStreamEncryptionOutput");
   }
 }
 
@@ -2824,7 +2827,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -2843,7 +2846,7 @@ export interface TagDeliveryStreamInput {
 
 export namespace TagDeliveryStreamInput {
   export function isa(o: any): o is TagDeliveryStreamInput {
-    return _smithy.isa(o, "TagDeliveryStreamInput");
+    return __isa(o, "TagDeliveryStreamInput");
   }
 }
 
@@ -2853,7 +2856,7 @@ export interface TagDeliveryStreamOutput extends $MetadataBearer {
 
 export namespace TagDeliveryStreamOutput {
   export function isa(o: any): o is TagDeliveryStreamOutput {
-    return _smithy.isa(o, "TagDeliveryStreamOutput");
+    return __isa(o, "TagDeliveryStreamOutput");
   }
 }
 
@@ -2872,7 +2875,7 @@ export interface UntagDeliveryStreamInput {
 
 export namespace UntagDeliveryStreamInput {
   export function isa(o: any): o is UntagDeliveryStreamInput {
-    return _smithy.isa(o, "UntagDeliveryStreamInput");
+    return __isa(o, "UntagDeliveryStreamInput");
   }
 }
 
@@ -2882,7 +2885,7 @@ export interface UntagDeliveryStreamOutput extends $MetadataBearer {
 
 export namespace UntagDeliveryStreamOutput {
   export function isa(o: any): o is UntagDeliveryStreamOutput {
-    return _smithy.isa(o, "UntagDeliveryStreamOutput");
+    return __isa(o, "UntagDeliveryStreamOutput");
   }
 }
 
@@ -2935,7 +2938,7 @@ export interface UpdateDestinationInput {
 
 export namespace UpdateDestinationInput {
   export function isa(o: any): o is UpdateDestinationInput {
-    return _smithy.isa(o, "UpdateDestinationInput");
+    return __isa(o, "UpdateDestinationInput");
   }
 }
 
@@ -2945,6 +2948,6 @@ export interface UpdateDestinationOutput extends $MetadataBearer {
 
 export namespace UpdateDestinationOutput {
   export function isa(o: any): o is UpdateDestinationOutput {
-    return _smithy.isa(o, "UpdateDestinationOutput");
+    return __isa(o, "UpdateDestinationOutput");
   }
 }

--- a/clients/client-fms/models/index.ts
+++ b/clients/client-fms/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export enum AccountRoleStatus {
@@ -21,7 +24,7 @@ export interface AssociateAdminAccountRequest {
 
 export namespace AssociateAdminAccountRequest {
   export function isa(o: any): o is AssociateAdminAccountRequest {
-    return _smithy.isa(o, "AssociateAdminAccountRequest");
+    return __isa(o, "AssociateAdminAccountRequest");
   }
 }
 
@@ -50,7 +53,7 @@ export interface ComplianceViolator {
 
 export namespace ComplianceViolator {
   export function isa(o: any): o is ComplianceViolator {
-    return _smithy.isa(o, "ComplianceViolator");
+    return __isa(o, "ComplianceViolator");
   }
 }
 
@@ -64,7 +67,7 @@ export interface DeleteNotificationChannelRequest {
 
 export namespace DeleteNotificationChannelRequest {
   export function isa(o: any): o is DeleteNotificationChannelRequest {
-    return _smithy.isa(o, "DeleteNotificationChannelRequest");
+    return __isa(o, "DeleteNotificationChannelRequest");
   }
 }
 
@@ -113,7 +116,7 @@ export interface DeletePolicyRequest {
 
 export namespace DeletePolicyRequest {
   export function isa(o: any): o is DeletePolicyRequest {
-    return _smithy.isa(o, "DeletePolicyRequest");
+    return __isa(o, "DeletePolicyRequest");
   }
 }
 
@@ -130,7 +133,7 @@ export interface DisassociateAdminAccountRequest {
 
 export namespace DisassociateAdminAccountRequest {
   export function isa(o: any): o is DisassociateAdminAccountRequest {
-    return _smithy.isa(o, "DisassociateAdminAccountRequest");
+    return __isa(o, "DisassociateAdminAccountRequest");
   }
 }
 
@@ -163,7 +166,7 @@ export interface EvaluationResult {
 
 export namespace EvaluationResult {
   export function isa(o: any): o is EvaluationResult {
-    return _smithy.isa(o, "EvaluationResult");
+    return __isa(o, "EvaluationResult");
   }
 }
 
@@ -173,7 +176,7 @@ export interface GetAdminAccountRequest {
 
 export namespace GetAdminAccountRequest {
   export function isa(o: any): o is GetAdminAccountRequest {
-    return _smithy.isa(o, "GetAdminAccountRequest");
+    return __isa(o, "GetAdminAccountRequest");
   }
 }
 
@@ -193,7 +196,7 @@ export interface GetAdminAccountResponse extends $MetadataBearer {
 
 export namespace GetAdminAccountResponse {
   export function isa(o: any): o is GetAdminAccountResponse {
-    return _smithy.isa(o, "GetAdminAccountResponse");
+    return __isa(o, "GetAdminAccountResponse");
   }
 }
 
@@ -213,7 +216,7 @@ export interface GetComplianceDetailRequest {
 
 export namespace GetComplianceDetailRequest {
   export function isa(o: any): o is GetComplianceDetailRequest {
-    return _smithy.isa(o, "GetComplianceDetailRequest");
+    return __isa(o, "GetComplianceDetailRequest");
   }
 }
 
@@ -228,7 +231,7 @@ export interface GetComplianceDetailResponse extends $MetadataBearer {
 
 export namespace GetComplianceDetailResponse {
   export function isa(o: any): o is GetComplianceDetailResponse {
-    return _smithy.isa(o, "GetComplianceDetailResponse");
+    return __isa(o, "GetComplianceDetailResponse");
   }
 }
 
@@ -238,7 +241,7 @@ export interface GetNotificationChannelRequest {
 
 export namespace GetNotificationChannelRequest {
   export function isa(o: any): o is GetNotificationChannelRequest {
-    return _smithy.isa(o, "GetNotificationChannelRequest");
+    return __isa(o, "GetNotificationChannelRequest");
   }
 }
 
@@ -257,7 +260,7 @@ export interface GetNotificationChannelResponse extends $MetadataBearer {
 
 export namespace GetNotificationChannelResponse {
   export function isa(o: any): o is GetNotificationChannelResponse {
-    return _smithy.isa(o, "GetNotificationChannelResponse");
+    return __isa(o, "GetNotificationChannelResponse");
   }
 }
 
@@ -271,7 +274,7 @@ export interface GetPolicyRequest {
 
 export namespace GetPolicyRequest {
   export function isa(o: any): o is GetPolicyRequest {
-    return _smithy.isa(o, "GetPolicyRequest");
+    return __isa(o, "GetPolicyRequest");
   }
 }
 
@@ -290,7 +293,7 @@ export interface GetPolicyResponse extends $MetadataBearer {
 
 export namespace GetPolicyResponse {
   export function isa(o: any): o is GetPolicyResponse {
-    return _smithy.isa(o, "GetPolicyResponse");
+    return __isa(o, "GetPolicyResponse");
   }
 }
 
@@ -341,7 +344,7 @@ export interface GetProtectionStatusRequest {
 
 export namespace GetProtectionStatusRequest {
   export function isa(o: any): o is GetProtectionStatusRequest {
-    return _smithy.isa(o, "GetProtectionStatusRequest");
+    return __isa(o, "GetProtectionStatusRequest");
   }
 }
 
@@ -396,7 +399,7 @@ export interface GetProtectionStatusResponse extends $MetadataBearer {
 
 export namespace GetProtectionStatusResponse {
   export function isa(o: any): o is GetProtectionStatusResponse {
-    return _smithy.isa(o, "GetProtectionStatusResponse");
+    return __isa(o, "GetProtectionStatusResponse");
   }
 }
 
@@ -405,7 +408,7 @@ export namespace GetProtectionStatusResponse {
  *       your request.</p>
  */
 export interface InternalErrorException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalErrorException";
   $fault: "client";
@@ -414,7 +417,7 @@ export interface InternalErrorException
 
 export namespace InternalErrorException {
   export function isa(o: any): o is InternalErrorException {
-    return _smithy.isa(o, "InternalErrorException");
+    return __isa(o, "InternalErrorException");
   }
 }
 
@@ -422,7 +425,7 @@ export namespace InternalErrorException {
  * <p>The parameters of the request were invalid.</p>
  */
 export interface InvalidInputException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidInputException";
   $fault: "client";
@@ -431,7 +434,7 @@ export interface InvalidInputException
 
 export namespace InvalidInputException {
   export function isa(o: any): o is InvalidInputException {
-    return _smithy.isa(o, "InvalidInputException");
+    return __isa(o, "InvalidInputException");
   }
 }
 
@@ -441,7 +444,7 @@ export namespace InvalidInputException {
  *       was already set as the AWS Firewall Manager administrator.</p>
  */
 export interface InvalidOperationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidOperationException";
   $fault: "client";
@@ -450,7 +453,7 @@ export interface InvalidOperationException
 
 export namespace InvalidOperationException {
   export function isa(o: any): o is InvalidOperationException {
-    return _smithy.isa(o, "InvalidOperationException");
+    return __isa(o, "InvalidOperationException");
   }
 }
 
@@ -458,7 +461,7 @@ export namespace InvalidOperationException {
  * <p>The value of the <code>Type</code> parameter is invalid.</p>
  */
 export interface InvalidTypeException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidTypeException";
   $fault: "client";
@@ -467,7 +470,7 @@ export interface InvalidTypeException
 
 export namespace InvalidTypeException {
   export function isa(o: any): o is InvalidTypeException {
-    return _smithy.isa(o, "InvalidTypeException");
+    return __isa(o, "InvalidTypeException");
   }
 }
 
@@ -478,7 +481,7 @@ export namespace InvalidTypeException {
  *         Manager Limits</a> in the <i>AWS WAF Developer Guide</i>.</p>
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -487,7 +490,7 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
@@ -521,7 +524,7 @@ export interface ListComplianceStatusRequest {
 
 export namespace ListComplianceStatusRequest {
   export function isa(o: any): o is ListComplianceStatusRequest {
-    return _smithy.isa(o, "ListComplianceStatusRequest");
+    return __isa(o, "ListComplianceStatusRequest");
   }
 }
 
@@ -545,7 +548,7 @@ export interface ListComplianceStatusResponse extends $MetadataBearer {
 
 export namespace ListComplianceStatusResponse {
   export function isa(o: any): o is ListComplianceStatusResponse {
-    return _smithy.isa(o, "ListComplianceStatusResponse");
+    return __isa(o, "ListComplianceStatusResponse");
   }
 }
 
@@ -572,7 +575,7 @@ export interface ListMemberAccountsRequest {
 
 export namespace ListMemberAccountsRequest {
   export function isa(o: any): o is ListMemberAccountsRequest {
-    return _smithy.isa(o, "ListMemberAccountsRequest");
+    return __isa(o, "ListMemberAccountsRequest");
   }
 }
 
@@ -595,7 +598,7 @@ export interface ListMemberAccountsResponse extends $MetadataBearer {
 
 export namespace ListMemberAccountsResponse {
   export function isa(o: any): o is ListMemberAccountsResponse {
-    return _smithy.isa(o, "ListMemberAccountsResponse");
+    return __isa(o, "ListMemberAccountsResponse");
   }
 }
 
@@ -624,7 +627,7 @@ export interface ListPoliciesRequest {
 
 export namespace ListPoliciesRequest {
   export function isa(o: any): o is ListPoliciesRequest {
-    return _smithy.isa(o, "ListPoliciesRequest");
+    return __isa(o, "ListPoliciesRequest");
   }
 }
 
@@ -647,7 +650,7 @@ export interface ListPoliciesResponse extends $MetadataBearer {
 
 export namespace ListPoliciesResponse {
   export function isa(o: any): o is ListPoliciesResponse {
-    return _smithy.isa(o, "ListPoliciesResponse");
+    return __isa(o, "ListPoliciesResponse");
   }
 }
 
@@ -661,7 +664,7 @@ export interface ListTagsForResourceRequest {
 
 export namespace ListTagsForResourceRequest {
   export function isa(o: any): o is ListTagsForResourceRequest {
-    return _smithy.isa(o, "ListTagsForResourceRequest");
+    return __isa(o, "ListTagsForResourceRequest");
   }
 }
 
@@ -675,7 +678,7 @@ export interface ListTagsForResourceResponse extends $MetadataBearer {
 
 export namespace ListTagsForResourceResponse {
   export function isa(o: any): o is ListTagsForResourceResponse {
-    return _smithy.isa(o, "ListTagsForResourceResponse");
+    return __isa(o, "ListTagsForResourceResponse");
   }
 }
 
@@ -766,7 +769,7 @@ export interface Policy {
 
 export namespace Policy {
   export function isa(o: any): o is Policy {
-    return _smithy.isa(o, "Policy");
+    return __isa(o, "Policy");
   }
 }
 
@@ -821,7 +824,7 @@ export interface PolicyComplianceDetail {
 
 export namespace PolicyComplianceDetail {
   export function isa(o: any): o is PolicyComplianceDetail {
-    return _smithy.isa(o, "PolicyComplianceDetail");
+    return __isa(o, "PolicyComplianceDetail");
   }
 }
 
@@ -873,7 +876,7 @@ export interface PolicyComplianceStatus {
 
 export namespace PolicyComplianceStatus {
   export function isa(o: any): o is PolicyComplianceStatus {
-    return _smithy.isa(o, "PolicyComplianceStatus");
+    return __isa(o, "PolicyComplianceStatus");
   }
 }
 
@@ -929,7 +932,7 @@ export interface PolicySummary {
 
 export namespace PolicySummary {
   export function isa(o: any): o is PolicySummary {
-    return _smithy.isa(o, "PolicySummary");
+    return __isa(o, "PolicySummary");
   }
 }
 
@@ -950,7 +953,7 @@ export interface PutNotificationChannelRequest {
 
 export namespace PutNotificationChannelRequest {
   export function isa(o: any): o is PutNotificationChannelRequest {
-    return _smithy.isa(o, "PutNotificationChannelRequest");
+    return __isa(o, "PutNotificationChannelRequest");
   }
 }
 
@@ -969,7 +972,7 @@ export interface PutPolicyRequest {
 
 export namespace PutPolicyRequest {
   export function isa(o: any): o is PutPolicyRequest {
-    return _smithy.isa(o, "PutPolicyRequest");
+    return __isa(o, "PutPolicyRequest");
   }
 }
 
@@ -988,7 +991,7 @@ export interface PutPolicyResponse extends $MetadataBearer {
 
 export namespace PutPolicyResponse {
   export function isa(o: any): o is PutPolicyResponse {
-    return _smithy.isa(o, "PutPolicyResponse");
+    return __isa(o, "PutPolicyResponse");
   }
 }
 
@@ -996,7 +999,7 @@ export namespace PutPolicyResponse {
  * <p>The specified resource was not found.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -1005,7 +1008,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -1033,7 +1036,7 @@ export interface ResourceTag {
 
 export namespace ResourceTag {
   export function isa(o: any): o is ResourceTag {
-    return _smithy.isa(o, "ResourceTag");
+    return __isa(o, "ResourceTag");
   }
 }
 
@@ -1101,7 +1104,7 @@ export interface SecurityServicePolicyData {
 
 export namespace SecurityServicePolicyData {
   export function isa(o: any): o is SecurityServicePolicyData {
-    return _smithy.isa(o, "SecurityServicePolicyData");
+    return __isa(o, "SecurityServicePolicyData");
   }
 }
 
@@ -1131,7 +1134,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -1150,7 +1153,7 @@ export interface TagResourceRequest {
 
 export namespace TagResourceRequest {
   export function isa(o: any): o is TagResourceRequest {
-    return _smithy.isa(o, "TagResourceRequest");
+    return __isa(o, "TagResourceRequest");
   }
 }
 
@@ -1160,7 +1163,7 @@ export interface TagResourceResponse extends $MetadataBearer {
 
 export namespace TagResourceResponse {
   export function isa(o: any): o is TagResourceResponse {
-    return _smithy.isa(o, "TagResourceResponse");
+    return __isa(o, "TagResourceResponse");
   }
 }
 
@@ -1179,7 +1182,7 @@ export interface UntagResourceRequest {
 
 export namespace UntagResourceRequest {
   export function isa(o: any): o is UntagResourceRequest {
-    return _smithy.isa(o, "UntagResourceRequest");
+    return __isa(o, "UntagResourceRequest");
   }
 }
 
@@ -1189,7 +1192,7 @@ export interface UntagResourceResponse extends $MetadataBearer {
 
 export namespace UntagResourceResponse {
   export function isa(o: any): o is UntagResourceResponse {
-    return _smithy.isa(o, "UntagResourceResponse");
+    return __isa(o, "UntagResourceResponse");
   }
 }
 

--- a/clients/client-fms/protocols/Aws_json1_1.ts
+++ b/clients/client-fms/protocols/Aws_json1_1.ts
@@ -367,6 +367,7 @@ export async function deserializeAws_json1_1AssociateAdminAccountCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: AssociateAdminAccountCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -442,6 +443,7 @@ export async function deserializeAws_json1_1DeleteNotificationChannelCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteNotificationChannelCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -507,6 +509,7 @@ export async function deserializeAws_json1_1DeletePolicyCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1DeletePolicyCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeletePolicyCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -575,6 +578,7 @@ export async function deserializeAws_json1_1DisassociateAdminAccountCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DisassociateAdminAccountCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1294,6 +1298,7 @@ export async function deserializeAws_json1_1PutNotificationChannelCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: PutNotificationChannelCommandOutput = {
     $metadata: deserializeMetadata(output)
   };

--- a/clients/client-forecast/models/index.ts
+++ b/clients/client-forecast/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export enum AttributeType {
@@ -27,7 +30,7 @@ export interface CategoricalParameterRange {
 
 export namespace CategoricalParameterRange {
   export function isa(o: any): o is CategoricalParameterRange {
-    return _smithy.isa(o, "CategoricalParameterRange");
+    return __isa(o, "CategoricalParameterRange");
   }
 }
 
@@ -88,7 +91,7 @@ export interface ContinuousParameterRange {
 
 export namespace ContinuousParameterRange {
   export function isa(o: any): o is ContinuousParameterRange {
-    return _smithy.isa(o, "ContinuousParameterRange");
+    return __isa(o, "ContinuousParameterRange");
   }
 }
 
@@ -120,7 +123,7 @@ export interface CreateDatasetGroupRequest {
 
 export namespace CreateDatasetGroupRequest {
   export function isa(o: any): o is CreateDatasetGroupRequest {
-    return _smithy.isa(o, "CreateDatasetGroupRequest");
+    return __isa(o, "CreateDatasetGroupRequest");
   }
 }
 
@@ -134,7 +137,7 @@ export interface CreateDatasetGroupResponse extends $MetadataBearer {
 
 export namespace CreateDatasetGroupResponse {
   export function isa(o: any): o is CreateDatasetGroupResponse {
-    return _smithy.isa(o, "CreateDatasetGroupResponse");
+    return __isa(o, "CreateDatasetGroupResponse");
   }
 }
 
@@ -185,7 +188,7 @@ export interface CreateDatasetImportJobRequest {
 
 export namespace CreateDatasetImportJobRequest {
   export function isa(o: any): o is CreateDatasetImportJobRequest {
-    return _smithy.isa(o, "CreateDatasetImportJobRequest");
+    return __isa(o, "CreateDatasetImportJobRequest");
   }
 }
 
@@ -199,7 +202,7 @@ export interface CreateDatasetImportJobResponse extends $MetadataBearer {
 
 export namespace CreateDatasetImportJobResponse {
   export function isa(o: any): o is CreateDatasetImportJobResponse {
-    return _smithy.isa(o, "CreateDatasetImportJobResponse");
+    return __isa(o, "CreateDatasetImportJobResponse");
   }
 }
 
@@ -252,7 +255,7 @@ export interface CreateDatasetRequest {
 
 export namespace CreateDatasetRequest {
   export function isa(o: any): o is CreateDatasetRequest {
-    return _smithy.isa(o, "CreateDatasetRequest");
+    return __isa(o, "CreateDatasetRequest");
   }
 }
 
@@ -266,7 +269,7 @@ export interface CreateDatasetResponse extends $MetadataBearer {
 
 export namespace CreateDatasetResponse {
   export function isa(o: any): o is CreateDatasetResponse {
-    return _smithy.isa(o, "CreateDatasetResponse");
+    return __isa(o, "CreateDatasetResponse");
   }
 }
 
@@ -294,7 +297,7 @@ export interface CreateForecastExportJobRequest {
 
 export namespace CreateForecastExportJobRequest {
   export function isa(o: any): o is CreateForecastExportJobRequest {
-    return _smithy.isa(o, "CreateForecastExportJobRequest");
+    return __isa(o, "CreateForecastExportJobRequest");
   }
 }
 
@@ -308,7 +311,7 @@ export interface CreateForecastExportJobResponse extends $MetadataBearer {
 
 export namespace CreateForecastExportJobResponse {
   export function isa(o: any): o is CreateForecastExportJobResponse {
-    return _smithy.isa(o, "CreateForecastExportJobResponse");
+    return __isa(o, "CreateForecastExportJobResponse");
   }
 }
 
@@ -336,7 +339,7 @@ export interface CreateForecastRequest {
 
 export namespace CreateForecastRequest {
   export function isa(o: any): o is CreateForecastRequest {
-    return _smithy.isa(o, "CreateForecastRequest");
+    return __isa(o, "CreateForecastRequest");
   }
 }
 
@@ -350,7 +353,7 @@ export interface CreateForecastResponse extends $MetadataBearer {
 
 export namespace CreateForecastResponse {
   export function isa(o: any): o is CreateForecastResponse {
-    return _smithy.isa(o, "CreateForecastResponse");
+    return __isa(o, "CreateForecastResponse");
   }
 }
 
@@ -482,7 +485,7 @@ export interface CreatePredictorRequest {
 
 export namespace CreatePredictorRequest {
   export function isa(o: any): o is CreatePredictorRequest {
-    return _smithy.isa(o, "CreatePredictorRequest");
+    return __isa(o, "CreatePredictorRequest");
   }
 }
 
@@ -496,7 +499,7 @@ export interface CreatePredictorResponse extends $MetadataBearer {
 
 export namespace CreatePredictorResponse {
   export function isa(o: any): o is CreatePredictorResponse {
-    return _smithy.isa(o, "CreatePredictorResponse");
+    return __isa(o, "CreatePredictorResponse");
   }
 }
 
@@ -516,7 +519,7 @@ export interface DataDestination {
 
 export namespace DataDestination {
   export function isa(o: any): o is DataDestination {
-    return _smithy.isa(o, "DataDestination");
+    return __isa(o, "DataDestination");
   }
 }
 
@@ -536,7 +539,7 @@ export interface DataSource {
 
 export namespace DataSource {
   export function isa(o: any): o is DataSource {
-    return _smithy.isa(o, "DataSource");
+    return __isa(o, "DataSource");
   }
 }
 
@@ -572,7 +575,7 @@ export interface DatasetGroupSummary {
 
 export namespace DatasetGroupSummary {
   export function isa(o: any): o is DatasetGroupSummary {
-    return _smithy.isa(o, "DatasetGroupSummary");
+    return __isa(o, "DatasetGroupSummary");
   }
 }
 
@@ -660,7 +663,7 @@ export interface DatasetImportJobSummary {
 
 export namespace DatasetImportJobSummary {
   export function isa(o: any): o is DatasetImportJobSummary {
-    return _smithy.isa(o, "DatasetImportJobSummary");
+    return __isa(o, "DatasetImportJobSummary");
   }
 }
 
@@ -708,7 +711,7 @@ export interface DatasetSummary {
 
 export namespace DatasetSummary {
   export function isa(o: any): o is DatasetSummary {
-    return _smithy.isa(o, "DatasetSummary");
+    return __isa(o, "DatasetSummary");
   }
 }
 
@@ -728,7 +731,7 @@ export interface DeleteDatasetGroupRequest {
 
 export namespace DeleteDatasetGroupRequest {
   export function isa(o: any): o is DeleteDatasetGroupRequest {
-    return _smithy.isa(o, "DeleteDatasetGroupRequest");
+    return __isa(o, "DeleteDatasetGroupRequest");
   }
 }
 
@@ -742,7 +745,7 @@ export interface DeleteDatasetImportJobRequest {
 
 export namespace DeleteDatasetImportJobRequest {
   export function isa(o: any): o is DeleteDatasetImportJobRequest {
-    return _smithy.isa(o, "DeleteDatasetImportJobRequest");
+    return __isa(o, "DeleteDatasetImportJobRequest");
   }
 }
 
@@ -756,7 +759,7 @@ export interface DeleteDatasetRequest {
 
 export namespace DeleteDatasetRequest {
   export function isa(o: any): o is DeleteDatasetRequest {
-    return _smithy.isa(o, "DeleteDatasetRequest");
+    return __isa(o, "DeleteDatasetRequest");
   }
 }
 
@@ -770,7 +773,7 @@ export interface DeleteForecastExportJobRequest {
 
 export namespace DeleteForecastExportJobRequest {
   export function isa(o: any): o is DeleteForecastExportJobRequest {
-    return _smithy.isa(o, "DeleteForecastExportJobRequest");
+    return __isa(o, "DeleteForecastExportJobRequest");
   }
 }
 
@@ -784,7 +787,7 @@ export interface DeleteForecastRequest {
 
 export namespace DeleteForecastRequest {
   export function isa(o: any): o is DeleteForecastRequest {
-    return _smithy.isa(o, "DeleteForecastRequest");
+    return __isa(o, "DeleteForecastRequest");
   }
 }
 
@@ -798,7 +801,7 @@ export interface DeletePredictorRequest {
 
 export namespace DeletePredictorRequest {
   export function isa(o: any): o is DeletePredictorRequest {
-    return _smithy.isa(o, "DeletePredictorRequest");
+    return __isa(o, "DeletePredictorRequest");
   }
 }
 
@@ -812,7 +815,7 @@ export interface DescribeDatasetGroupRequest {
 
 export namespace DescribeDatasetGroupRequest {
   export function isa(o: any): o is DescribeDatasetGroupRequest {
-    return _smithy.isa(o, "DescribeDatasetGroupRequest");
+    return __isa(o, "DescribeDatasetGroupRequest");
   }
 }
 
@@ -889,7 +892,7 @@ export interface DescribeDatasetGroupResponse extends $MetadataBearer {
 
 export namespace DescribeDatasetGroupResponse {
   export function isa(o: any): o is DescribeDatasetGroupResponse {
-    return _smithy.isa(o, "DescribeDatasetGroupResponse");
+    return __isa(o, "DescribeDatasetGroupResponse");
   }
 }
 
@@ -903,7 +906,7 @@ export interface DescribeDatasetImportJobRequest {
 
 export namespace DescribeDatasetImportJobRequest {
   export function isa(o: any): o is DescribeDatasetImportJobRequest {
-    return _smithy.isa(o, "DescribeDatasetImportJobRequest");
+    return __isa(o, "DescribeDatasetImportJobRequest");
   }
 }
 
@@ -1020,7 +1023,7 @@ export interface DescribeDatasetImportJobResponse extends $MetadataBearer {
 
 export namespace DescribeDatasetImportJobResponse {
   export function isa(o: any): o is DescribeDatasetImportJobResponse {
-    return _smithy.isa(o, "DescribeDatasetImportJobResponse");
+    return __isa(o, "DescribeDatasetImportJobResponse");
   }
 }
 
@@ -1034,7 +1037,7 @@ export interface DescribeDatasetRequest {
 
 export namespace DescribeDatasetRequest {
   export function isa(o: any): o is DescribeDatasetRequest {
-    return _smithy.isa(o, "DescribeDatasetRequest");
+    return __isa(o, "DescribeDatasetRequest");
   }
 }
 
@@ -1135,7 +1138,7 @@ export interface DescribeDatasetResponse extends $MetadataBearer {
 
 export namespace DescribeDatasetResponse {
   export function isa(o: any): o is DescribeDatasetResponse {
-    return _smithy.isa(o, "DescribeDatasetResponse");
+    return __isa(o, "DescribeDatasetResponse");
   }
 }
 
@@ -1149,7 +1152,7 @@ export interface DescribeForecastExportJobRequest {
 
 export namespace DescribeForecastExportJobRequest {
   export function isa(o: any): o is DescribeForecastExportJobRequest {
-    return _smithy.isa(o, "DescribeForecastExportJobRequest");
+    return __isa(o, "DescribeForecastExportJobRequest");
   }
 }
 
@@ -1221,7 +1224,7 @@ export interface DescribeForecastExportJobResponse extends $MetadataBearer {
 
 export namespace DescribeForecastExportJobResponse {
   export function isa(o: any): o is DescribeForecastExportJobResponse {
-    return _smithy.isa(o, "DescribeForecastExportJobResponse");
+    return __isa(o, "DescribeForecastExportJobResponse");
   }
 }
 
@@ -1235,7 +1238,7 @@ export interface DescribeForecastRequest {
 
 export namespace DescribeForecastRequest {
   export function isa(o: any): o is DescribeForecastRequest {
-    return _smithy.isa(o, "DescribeForecastRequest");
+    return __isa(o, "DescribeForecastRequest");
   }
 }
 
@@ -1315,7 +1318,7 @@ export interface DescribeForecastResponse extends $MetadataBearer {
 
 export namespace DescribeForecastResponse {
   export function isa(o: any): o is DescribeForecastResponse {
-    return _smithy.isa(o, "DescribeForecastResponse");
+    return __isa(o, "DescribeForecastResponse");
   }
 }
 
@@ -1329,7 +1332,7 @@ export interface DescribePredictorRequest {
 
 export namespace DescribePredictorRequest {
   export function isa(o: any): o is DescribePredictorRequest {
-    return _smithy.isa(o, "DescribePredictorRequest");
+    return __isa(o, "DescribePredictorRequest");
   }
 }
 
@@ -1474,7 +1477,7 @@ export interface DescribePredictorResponse extends $MetadataBearer {
 
 export namespace DescribePredictorResponse {
   export function isa(o: any): o is DescribePredictorResponse {
-    return _smithy.isa(o, "DescribePredictorResponse");
+    return __isa(o, "DescribePredictorResponse");
   }
 }
 
@@ -1510,7 +1513,7 @@ export interface EncryptionConfig {
 
 export namespace EncryptionConfig {
   export function isa(o: any): o is EncryptionConfig {
-    return _smithy.isa(o, "EncryptionConfig");
+    return __isa(o, "EncryptionConfig");
   }
 }
 
@@ -1542,7 +1545,7 @@ export interface EvaluationParameters {
 
 export namespace EvaluationParameters {
   export function isa(o: any): o is EvaluationParameters {
-    return _smithy.isa(o, "EvaluationParameters");
+    return __isa(o, "EvaluationParameters");
   }
 }
 
@@ -1567,7 +1570,7 @@ export interface EvaluationResult {
 
 export namespace EvaluationResult {
   export function isa(o: any): o is EvaluationResult {
-    return _smithy.isa(o, "EvaluationResult");
+    return __isa(o, "EvaluationResult");
   }
 }
 
@@ -1623,7 +1626,7 @@ export interface Featurization {
 
 export namespace Featurization {
   export function isa(o: any): o is Featurization {
-    return _smithy.isa(o, "Featurization");
+    return __isa(o, "Featurization");
   }
 }
 
@@ -1676,7 +1679,7 @@ export interface FeaturizationConfig {
 
 export namespace FeaturizationConfig {
   export function isa(o: any): o is FeaturizationConfig {
-    return _smithy.isa(o, "FeaturizationConfig");
+    return __isa(o, "FeaturizationConfig");
   }
 }
 
@@ -1737,7 +1740,7 @@ export interface FeaturizationMethod {
 
 export namespace FeaturizationMethod {
   export function isa(o: any): o is FeaturizationMethod {
-    return _smithy.isa(o, "FeaturizationMethod");
+    return __isa(o, "FeaturizationMethod");
   }
 }
 
@@ -1773,7 +1776,7 @@ export interface Filter {
 
 export namespace Filter {
   export function isa(o: any): o is Filter {
-    return _smithy.isa(o, "Filter");
+    return __isa(o, "Filter");
   }
 }
 
@@ -1850,7 +1853,7 @@ export interface ForecastExportJobSummary {
 
 export namespace ForecastExportJobSummary {
   export function isa(o: any): o is ForecastExportJobSummary {
-    return _smithy.isa(o, "ForecastExportJobSummary");
+    return __isa(o, "ForecastExportJobSummary");
   }
 }
 
@@ -1931,7 +1934,7 @@ export interface ForecastSummary {
 
 export namespace ForecastSummary {
   export function isa(o: any): o is ForecastSummary {
-    return _smithy.isa(o, "ForecastSummary");
+    return __isa(o, "ForecastSummary");
   }
 }
 
@@ -1945,7 +1948,7 @@ export interface GetAccuracyMetricsRequest {
 
 export namespace GetAccuracyMetricsRequest {
   export function isa(o: any): o is GetAccuracyMetricsRequest {
-    return _smithy.isa(o, "GetAccuracyMetricsRequest");
+    return __isa(o, "GetAccuracyMetricsRequest");
   }
 }
 
@@ -1959,7 +1962,7 @@ export interface GetAccuracyMetricsResponse extends $MetadataBearer {
 
 export namespace GetAccuracyMetricsResponse {
   export function isa(o: any): o is GetAccuracyMetricsResponse {
-    return _smithy.isa(o, "GetAccuracyMetricsResponse");
+    return __isa(o, "GetAccuracyMetricsResponse");
   }
 }
 
@@ -1984,7 +1987,7 @@ export interface HyperParameterTuningJobConfig {
 
 export namespace HyperParameterTuningJobConfig {
   export function isa(o: any): o is HyperParameterTuningJobConfig {
-    return _smithy.isa(o, "HyperParameterTuningJobConfig");
+    return __isa(o, "HyperParameterTuningJobConfig");
   }
 }
 
@@ -2009,7 +2012,7 @@ export interface InputDataConfig {
 
 export namespace InputDataConfig {
   export function isa(o: any): o is InputDataConfig {
-    return _smithy.isa(o, "InputDataConfig");
+    return __isa(o, "InputDataConfig");
   }
 }
 
@@ -2069,7 +2072,7 @@ export interface IntegerParameterRange {
 
 export namespace IntegerParameterRange {
   export function isa(o: any): o is IntegerParameterRange {
-    return _smithy.isa(o, "IntegerParameterRange");
+    return __isa(o, "IntegerParameterRange");
   }
 }
 
@@ -2078,7 +2081,7 @@ export namespace IntegerParameterRange {
  *       the valid range.</p>
  */
 export interface InvalidInputException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidInputException";
   $fault: "client";
@@ -2087,7 +2090,7 @@ export interface InvalidInputException
 
 export namespace InvalidInputException {
   export function isa(o: any): o is InvalidInputException {
-    return _smithy.isa(o, "InvalidInputException");
+    return __isa(o, "InvalidInputException");
   }
 }
 
@@ -2095,7 +2098,7 @@ export namespace InvalidInputException {
  * <p>The token is not valid. Tokens expire after 24 hours.</p>
  */
 export interface InvalidNextTokenException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidNextTokenException";
   $fault: "client";
@@ -2104,7 +2107,7 @@ export interface InvalidNextTokenException
 
 export namespace InvalidNextTokenException {
   export function isa(o: any): o is InvalidNextTokenException {
-    return _smithy.isa(o, "InvalidNextTokenException");
+    return __isa(o, "InvalidNextTokenException");
   }
 }
 
@@ -2112,7 +2115,7 @@ export namespace InvalidNextTokenException {
  * <p>The limit on the number of resources per account has been exceeded.</p>
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -2121,7 +2124,7 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
@@ -2142,7 +2145,7 @@ export interface ListDatasetGroupsRequest {
 
 export namespace ListDatasetGroupsRequest {
   export function isa(o: any): o is ListDatasetGroupsRequest {
-    return _smithy.isa(o, "ListDatasetGroupsRequest");
+    return __isa(o, "ListDatasetGroupsRequest");
   }
 }
 
@@ -2162,7 +2165,7 @@ export interface ListDatasetGroupsResponse extends $MetadataBearer {
 
 export namespace ListDatasetGroupsResponse {
   export function isa(o: any): o is ListDatasetGroupsResponse {
-    return _smithy.isa(o, "ListDatasetGroupsResponse");
+    return __isa(o, "ListDatasetGroupsResponse");
   }
 }
 
@@ -2217,7 +2220,7 @@ export interface ListDatasetImportJobsRequest {
 
 export namespace ListDatasetImportJobsRequest {
   export function isa(o: any): o is ListDatasetImportJobsRequest {
-    return _smithy.isa(o, "ListDatasetImportJobsRequest");
+    return __isa(o, "ListDatasetImportJobsRequest");
   }
 }
 
@@ -2237,7 +2240,7 @@ export interface ListDatasetImportJobsResponse extends $MetadataBearer {
 
 export namespace ListDatasetImportJobsResponse {
   export function isa(o: any): o is ListDatasetImportJobsResponse {
-    return _smithy.isa(o, "ListDatasetImportJobsResponse");
+    return __isa(o, "ListDatasetImportJobsResponse");
   }
 }
 
@@ -2258,7 +2261,7 @@ export interface ListDatasetsRequest {
 
 export namespace ListDatasetsRequest {
   export function isa(o: any): o is ListDatasetsRequest {
-    return _smithy.isa(o, "ListDatasetsRequest");
+    return __isa(o, "ListDatasetsRequest");
   }
 }
 
@@ -2278,7 +2281,7 @@ export interface ListDatasetsResponse extends $MetadataBearer {
 
 export namespace ListDatasetsResponse {
   export function isa(o: any): o is ListDatasetsResponse {
-    return _smithy.isa(o, "ListDatasetsResponse");
+    return __isa(o, "ListDatasetsResponse");
   }
 }
 
@@ -2334,7 +2337,7 @@ export interface ListForecastExportJobsRequest {
 
 export namespace ListForecastExportJobsRequest {
   export function isa(o: any): o is ListForecastExportJobsRequest {
-    return _smithy.isa(o, "ListForecastExportJobsRequest");
+    return __isa(o, "ListForecastExportJobsRequest");
   }
 }
 
@@ -2354,7 +2357,7 @@ export interface ListForecastExportJobsResponse extends $MetadataBearer {
 
 export namespace ListForecastExportJobsResponse {
   export function isa(o: any): o is ListForecastExportJobsResponse {
-    return _smithy.isa(o, "ListForecastExportJobsResponse");
+    return __isa(o, "ListForecastExportJobsResponse");
   }
 }
 
@@ -2408,7 +2411,7 @@ export interface ListForecastsRequest {
 
 export namespace ListForecastsRequest {
   export function isa(o: any): o is ListForecastsRequest {
-    return _smithy.isa(o, "ListForecastsRequest");
+    return __isa(o, "ListForecastsRequest");
   }
 }
 
@@ -2428,7 +2431,7 @@ export interface ListForecastsResponse extends $MetadataBearer {
 
 export namespace ListForecastsResponse {
   export function isa(o: any): o is ListForecastsResponse {
-    return _smithy.isa(o, "ListForecastsResponse");
+    return __isa(o, "ListForecastsResponse");
   }
 }
 
@@ -2482,7 +2485,7 @@ export interface ListPredictorsRequest {
 
 export namespace ListPredictorsRequest {
   export function isa(o: any): o is ListPredictorsRequest {
-    return _smithy.isa(o, "ListPredictorsRequest");
+    return __isa(o, "ListPredictorsRequest");
   }
 }
 
@@ -2502,7 +2505,7 @@ export interface ListPredictorsResponse extends $MetadataBearer {
 
 export namespace ListPredictorsResponse {
   export function isa(o: any): o is ListPredictorsResponse {
-    return _smithy.isa(o, "ListPredictorsResponse");
+    return __isa(o, "ListPredictorsResponse");
   }
 }
 
@@ -2526,7 +2529,7 @@ export interface Metrics {
 
 export namespace Metrics {
   export function isa(o: any): o is Metrics {
-    return _smithy.isa(o, "Metrics");
+    return __isa(o, "Metrics");
   }
 }
 
@@ -2556,7 +2559,7 @@ export interface ParameterRanges {
 
 export namespace ParameterRanges {
   export function isa(o: any): o is ParameterRanges {
-    return _smithy.isa(o, "ParameterRanges");
+    return __isa(o, "ParameterRanges");
   }
 }
 
@@ -2580,7 +2583,7 @@ export interface PredictorExecution {
 
 export namespace PredictorExecution {
   export function isa(o: any): o is PredictorExecution {
-    return _smithy.isa(o, "PredictorExecution");
+    return __isa(o, "PredictorExecution");
   }
 }
 
@@ -2601,7 +2604,7 @@ export interface PredictorExecutionDetails {
 
 export namespace PredictorExecutionDetails {
   export function isa(o: any): o is PredictorExecutionDetails {
-    return _smithy.isa(o, "PredictorExecutionDetails");
+    return __isa(o, "PredictorExecutionDetails");
   }
 }
 
@@ -2682,7 +2685,7 @@ export interface PredictorSummary {
 
 export namespace PredictorSummary {
   export function isa(o: any): o is PredictorSummary {
-    return _smithy.isa(o, "PredictorSummary");
+    return __isa(o, "PredictorSummary");
   }
 }
 
@@ -2690,7 +2693,7 @@ export namespace PredictorSummary {
  * <p>There is already a resource with this name. Try again with a different name.</p>
  */
 export interface ResourceAlreadyExistsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceAlreadyExistsException";
   $fault: "client";
@@ -2699,7 +2702,7 @@ export interface ResourceAlreadyExistsException
 
 export namespace ResourceAlreadyExistsException {
   export function isa(o: any): o is ResourceAlreadyExistsException {
-    return _smithy.isa(o, "ResourceAlreadyExistsException");
+    return __isa(o, "ResourceAlreadyExistsException");
   }
 }
 
@@ -2707,7 +2710,7 @@ export namespace ResourceAlreadyExistsException {
  * <p>The specified resource is in use.</p>
  */
 export interface ResourceInUseException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceInUseException";
   $fault: "client";
@@ -2716,7 +2719,7 @@ export interface ResourceInUseException
 
 export namespace ResourceInUseException {
   export function isa(o: any): o is ResourceInUseException {
-    return _smithy.isa(o, "ResourceInUseException");
+    return __isa(o, "ResourceInUseException");
   }
 }
 
@@ -2725,7 +2728,7 @@ export namespace ResourceInUseException {
  *       again.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -2734,7 +2737,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -2770,7 +2773,7 @@ export interface S3Config {
 
 export namespace S3Config {
   export function isa(o: any): o is S3Config {
-    return _smithy.isa(o, "S3Config");
+    return __isa(o, "S3Config");
   }
 }
 
@@ -2794,7 +2797,7 @@ export interface Schema {
 
 export namespace Schema {
   export function isa(o: any): o is Schema {
-    return _smithy.isa(o, "Schema");
+    return __isa(o, "Schema");
   }
 }
 
@@ -2818,7 +2821,7 @@ export interface SchemaAttribute {
 
 export namespace SchemaAttribute {
   export function isa(o: any): o is SchemaAttribute {
-    return _smithy.isa(o, "SchemaAttribute");
+    return __isa(o, "SchemaAttribute");
   }
 }
 
@@ -2871,7 +2874,7 @@ export interface Statistics {
 
 export namespace Statistics {
   export function isa(o: any): o is Statistics {
-    return _smithy.isa(o, "Statistics");
+    return __isa(o, "Statistics");
   }
 }
 
@@ -2913,7 +2916,7 @@ export interface SupplementaryFeature {
 
 export namespace SupplementaryFeature {
   export function isa(o: any): o is SupplementaryFeature {
-    return _smithy.isa(o, "SupplementaryFeature");
+    return __isa(o, "SupplementaryFeature");
   }
 }
 
@@ -2963,7 +2966,7 @@ export interface TestWindowSummary {
 
 export namespace TestWindowSummary {
   export function isa(o: any): o is TestWindowSummary {
-    return _smithy.isa(o, "TestWindowSummary");
+    return __isa(o, "TestWindowSummary");
   }
 }
 
@@ -2983,7 +2986,7 @@ export interface UpdateDatasetGroupRequest {
 
 export namespace UpdateDatasetGroupRequest {
   export function isa(o: any): o is UpdateDatasetGroupRequest {
-    return _smithy.isa(o, "UpdateDatasetGroupRequest");
+    return __isa(o, "UpdateDatasetGroupRequest");
   }
 }
 
@@ -2993,7 +2996,7 @@ export interface UpdateDatasetGroupResponse extends $MetadataBearer {
 
 export namespace UpdateDatasetGroupResponse {
   export function isa(o: any): o is UpdateDatasetGroupResponse {
-    return _smithy.isa(o, "UpdateDatasetGroupResponse");
+    return __isa(o, "UpdateDatasetGroupResponse");
   }
 }
 
@@ -3019,7 +3022,7 @@ export interface WeightedQuantileLoss {
 
 export namespace WeightedQuantileLoss {
   export function isa(o: any): o is WeightedQuantileLoss {
-    return _smithy.isa(o, "WeightedQuantileLoss");
+    return __isa(o, "WeightedQuantileLoss");
   }
 }
 
@@ -3070,6 +3073,6 @@ export interface WindowSummary {
 
 export namespace WindowSummary {
   export function isa(o: any): o is WindowSummary {
-    return _smithy.isa(o, "WindowSummary");
+    return __isa(o, "WindowSummary");
   }
 }

--- a/clients/client-forecast/protocols/Aws_json1_1.ts
+++ b/clients/client-forecast/protocols/Aws_json1_1.ts
@@ -1077,6 +1077,7 @@ export async function deserializeAws_json1_1DeleteDatasetCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1DeleteDatasetCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteDatasetCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1145,6 +1146,7 @@ export async function deserializeAws_json1_1DeleteDatasetGroupCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteDatasetGroupCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1213,6 +1215,7 @@ export async function deserializeAws_json1_1DeleteDatasetImportJobCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteDatasetImportJobCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1278,6 +1281,7 @@ export async function deserializeAws_json1_1DeleteForecastCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1DeleteForecastCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteForecastCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1346,6 +1350,7 @@ export async function deserializeAws_json1_1DeleteForecastExportJobCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteForecastExportJobCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1411,6 +1416,7 @@ export async function deserializeAws_json1_1DeletePredictorCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1DeletePredictorCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeletePredictorCommandOutput = {
     $metadata: deserializeMetadata(output)
   };

--- a/clients/client-forecastquery/models/index.ts
+++ b/clients/client-forecastquery/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -20,7 +23,7 @@ export interface DataPoint {
 
 export namespace DataPoint {
   export function isa(o: any): o is DataPoint {
-    return _smithy.isa(o, "DataPoint");
+    return __isa(o, "DataPoint");
   }
 }
 
@@ -50,7 +53,7 @@ export interface Forecast {
 
 export namespace Forecast {
   export function isa(o: any): o is Forecast {
-    return _smithy.isa(o, "Forecast");
+    return __isa(o, "Forecast");
   }
 }
 
@@ -58,7 +61,7 @@ export namespace Forecast {
  * <p>The value is invalid or is too long.</p>
  */
 export interface InvalidInputException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidInputException";
   $fault: "client";
@@ -67,7 +70,7 @@ export interface InvalidInputException
 
 export namespace InvalidInputException {
   export function isa(o: any): o is InvalidInputException {
-    return _smithy.isa(o, "InvalidInputException");
+    return __isa(o, "InvalidInputException");
   }
 }
 
@@ -75,7 +78,7 @@ export namespace InvalidInputException {
  * <p>The token is not valid. Tokens expire after 24 hours.</p>
  */
 export interface InvalidNextTokenException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidNextTokenException";
   $fault: "client";
@@ -84,7 +87,7 @@ export interface InvalidNextTokenException
 
 export namespace InvalidNextTokenException {
   export function isa(o: any): o is InvalidNextTokenException {
-    return _smithy.isa(o, "InvalidNextTokenException");
+    return __isa(o, "InvalidNextTokenException");
   }
 }
 
@@ -92,7 +95,7 @@ export namespace InvalidNextTokenException {
  * <p>The limit on the number of requests per second has been exceeded.</p>
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -101,7 +104,7 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
@@ -147,7 +150,7 @@ export interface QueryForecastRequest {
 
 export namespace QueryForecastRequest {
   export function isa(o: any): o is QueryForecastRequest {
-    return _smithy.isa(o, "QueryForecastRequest");
+    return __isa(o, "QueryForecastRequest");
   }
 }
 
@@ -161,7 +164,7 @@ export interface QueryForecastResponse extends $MetadataBearer {
 
 export namespace QueryForecastResponse {
   export function isa(o: any): o is QueryForecastResponse {
-    return _smithy.isa(o, "QueryForecastResponse");
+    return __isa(o, "QueryForecastResponse");
   }
 }
 
@@ -169,7 +172,7 @@ export namespace QueryForecastResponse {
  * <p>The specified resource is in use.</p>
  */
 export interface ResourceInUseException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceInUseException";
   $fault: "client";
@@ -178,7 +181,7 @@ export interface ResourceInUseException
 
 export namespace ResourceInUseException {
   export function isa(o: any): o is ResourceInUseException {
-    return _smithy.isa(o, "ResourceInUseException");
+    return __isa(o, "ResourceInUseException");
   }
 }
 
@@ -187,7 +190,7 @@ export namespace ResourceInUseException {
  *       again.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -196,6 +199,6 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }

--- a/clients/client-frauddetector/models/index.ts
+++ b/clients/client-frauddetector/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -24,7 +27,7 @@ export interface BatchCreateVariableError {
 
 export namespace BatchCreateVariableError {
   export function isa(o: any): o is BatchCreateVariableError {
-    return _smithy.isa(o, "BatchCreateVariableError");
+    return __isa(o, "BatchCreateVariableError");
   }
 }
 
@@ -38,7 +41,7 @@ export interface BatchCreateVariableRequest {
 
 export namespace BatchCreateVariableRequest {
   export function isa(o: any): o is BatchCreateVariableRequest {
-    return _smithy.isa(o, "BatchCreateVariableRequest");
+    return __isa(o, "BatchCreateVariableRequest");
   }
 }
 
@@ -52,7 +55,7 @@ export interface BatchCreateVariableResult extends $MetadataBearer {
 
 export namespace BatchCreateVariableResult {
   export function isa(o: any): o is BatchCreateVariableResult {
-    return _smithy.isa(o, "BatchCreateVariableResult");
+    return __isa(o, "BatchCreateVariableResult");
   }
 }
 
@@ -79,7 +82,7 @@ export interface BatchGetVariableError {
 
 export namespace BatchGetVariableError {
   export function isa(o: any): o is BatchGetVariableError {
-    return _smithy.isa(o, "BatchGetVariableError");
+    return __isa(o, "BatchGetVariableError");
   }
 }
 
@@ -93,7 +96,7 @@ export interface BatchGetVariableRequest {
 
 export namespace BatchGetVariableRequest {
   export function isa(o: any): o is BatchGetVariableRequest {
-    return _smithy.isa(o, "BatchGetVariableRequest");
+    return __isa(o, "BatchGetVariableRequest");
   }
 }
 
@@ -112,7 +115,7 @@ export interface BatchGetVariableResult extends $MetadataBearer {
 
 export namespace BatchGetVariableResult {
   export function isa(o: any): o is BatchGetVariableResult {
-    return _smithy.isa(o, "BatchGetVariableResult");
+    return __isa(o, "BatchGetVariableResult");
   }
 }
 
@@ -146,7 +149,7 @@ export interface CreateDetectorVersionRequest {
 
 export namespace CreateDetectorVersionRequest {
   export function isa(o: any): o is CreateDetectorVersionRequest {
-    return _smithy.isa(o, "CreateDetectorVersionRequest");
+    return __isa(o, "CreateDetectorVersionRequest");
   }
 }
 
@@ -170,7 +173,7 @@ export interface CreateDetectorVersionResult extends $MetadataBearer {
 
 export namespace CreateDetectorVersionResult {
   export function isa(o: any): o is CreateDetectorVersionResult {
-    return _smithy.isa(o, "CreateDetectorVersionResult");
+    return __isa(o, "CreateDetectorVersionResult");
   }
 }
 
@@ -194,7 +197,7 @@ export interface CreateModelVersionRequest {
 
 export namespace CreateModelVersionRequest {
   export function isa(o: any): o is CreateModelVersionRequest {
-    return _smithy.isa(o, "CreateModelVersionRequest");
+    return __isa(o, "CreateModelVersionRequest");
   }
 }
 
@@ -223,7 +226,7 @@ export interface CreateModelVersionResult extends $MetadataBearer {
 
 export namespace CreateModelVersionResult {
   export function isa(o: any): o is CreateModelVersionResult {
-    return _smithy.isa(o, "CreateModelVersionResult");
+    return __isa(o, "CreateModelVersionResult");
   }
 }
 
@@ -262,7 +265,7 @@ export interface CreateRuleRequest {
 
 export namespace CreateRuleRequest {
   export function isa(o: any): o is CreateRuleRequest {
-    return _smithy.isa(o, "CreateRuleRequest");
+    return __isa(o, "CreateRuleRequest");
   }
 }
 
@@ -276,7 +279,7 @@ export interface CreateRuleResult extends $MetadataBearer {
 
 export namespace CreateRuleResult {
   export function isa(o: any): o is CreateRuleResult {
-    return _smithy.isa(o, "CreateRuleResult");
+    return __isa(o, "CreateRuleResult");
   }
 }
 
@@ -315,7 +318,7 @@ export interface CreateVariableRequest {
 
 export namespace CreateVariableRequest {
   export function isa(o: any): o is CreateVariableRequest {
-    return _smithy.isa(o, "CreateVariableRequest");
+    return __isa(o, "CreateVariableRequest");
   }
 }
 
@@ -325,7 +328,7 @@ export interface CreateVariableResult extends $MetadataBearer {
 
 export namespace CreateVariableResult {
   export function isa(o: any): o is CreateVariableResult {
-    return _smithy.isa(o, "CreateVariableResult");
+    return __isa(o, "CreateVariableResult");
   }
 }
 
@@ -357,7 +360,7 @@ export interface DeleteDetectorVersionRequest {
 
 export namespace DeleteDetectorVersionRequest {
   export function isa(o: any): o is DeleteDetectorVersionRequest {
-    return _smithy.isa(o, "DeleteDetectorVersionRequest");
+    return __isa(o, "DeleteDetectorVersionRequest");
   }
 }
 
@@ -367,7 +370,7 @@ export interface DeleteDetectorVersionResult extends $MetadataBearer {
 
 export namespace DeleteDetectorVersionResult {
   export function isa(o: any): o is DeleteDetectorVersionResult {
-    return _smithy.isa(o, "DeleteDetectorVersionResult");
+    return __isa(o, "DeleteDetectorVersionResult");
   }
 }
 
@@ -381,7 +384,7 @@ export interface DeleteEventRequest {
 
 export namespace DeleteEventRequest {
   export function isa(o: any): o is DeleteEventRequest {
-    return _smithy.isa(o, "DeleteEventRequest");
+    return __isa(o, "DeleteEventRequest");
   }
 }
 
@@ -391,7 +394,7 @@ export interface DeleteEventResult extends $MetadataBearer {
 
 export namespace DeleteEventResult {
   export function isa(o: any): o is DeleteEventResult {
-    return _smithy.isa(o, "DeleteEventResult");
+    return __isa(o, "DeleteEventResult");
   }
 }
 
@@ -415,7 +418,7 @@ export interface DescribeDetectorRequest {
 
 export namespace DescribeDetectorRequest {
   export function isa(o: any): o is DescribeDetectorRequest {
-    return _smithy.isa(o, "DescribeDetectorRequest");
+    return __isa(o, "DescribeDetectorRequest");
   }
 }
 
@@ -439,7 +442,7 @@ export interface DescribeDetectorResult extends $MetadataBearer {
 
 export namespace DescribeDetectorResult {
   export function isa(o: any): o is DescribeDetectorResult {
-    return _smithy.isa(o, "DescribeDetectorResult");
+    return __isa(o, "DescribeDetectorResult");
   }
 }
 
@@ -473,7 +476,7 @@ export interface DescribeModelVersionsRequest {
 
 export namespace DescribeModelVersionsRequest {
   export function isa(o: any): o is DescribeModelVersionsRequest {
-    return _smithy.isa(o, "DescribeModelVersionsRequest");
+    return __isa(o, "DescribeModelVersionsRequest");
   }
 }
 
@@ -492,7 +495,7 @@ export interface DescribeModelVersionsResult extends $MetadataBearer {
 
 export namespace DescribeModelVersionsResult {
   export function isa(o: any): o is DescribeModelVersionsResult {
-    return _smithy.isa(o, "DescribeModelVersionsResult");
+    return __isa(o, "DescribeModelVersionsResult");
   }
 }
 
@@ -524,7 +527,7 @@ export interface Detector {
 
 export namespace Detector {
   export function isa(o: any): o is Detector {
-    return _smithy.isa(o, "Detector");
+    return __isa(o, "Detector");
   }
 }
 
@@ -562,7 +565,7 @@ export interface DetectorVersionSummary {
 
 export namespace DetectorVersionSummary {
   export function isa(o: any): o is DetectorVersionSummary {
-    return _smithy.isa(o, "DetectorVersionSummary");
+    return __isa(o, "DetectorVersionSummary");
   }
 }
 
@@ -614,7 +617,7 @@ export interface ExternalModel {
 
 export namespace ExternalModel {
   export function isa(o: any): o is ExternalModel {
-    return _smithy.isa(o, "ExternalModel");
+    return __isa(o, "ExternalModel");
   }
 }
 
@@ -633,7 +636,7 @@ export interface GetDetectorVersionRequest {
 
 export namespace GetDetectorVersionRequest {
   export function isa(o: any): o is GetDetectorVersionRequest {
-    return _smithy.isa(o, "GetDetectorVersionRequest");
+    return __isa(o, "GetDetectorVersionRequest");
   }
 }
 
@@ -688,7 +691,7 @@ export interface GetDetectorVersionResult extends $MetadataBearer {
 
 export namespace GetDetectorVersionResult {
   export function isa(o: any): o is GetDetectorVersionResult {
-    return _smithy.isa(o, "GetDetectorVersionResult");
+    return __isa(o, "GetDetectorVersionResult");
   }
 }
 
@@ -712,7 +715,7 @@ export interface GetDetectorsRequest {
 
 export namespace GetDetectorsRequest {
   export function isa(o: any): o is GetDetectorsRequest {
-    return _smithy.isa(o, "GetDetectorsRequest");
+    return __isa(o, "GetDetectorsRequest");
   }
 }
 
@@ -731,7 +734,7 @@ export interface GetDetectorsResult extends $MetadataBearer {
 
 export namespace GetDetectorsResult {
   export function isa(o: any): o is GetDetectorsResult {
-    return _smithy.isa(o, "GetDetectorsResult");
+    return __isa(o, "GetDetectorsResult");
   }
 }
 
@@ -755,7 +758,7 @@ export interface GetExternalModelsRequest {
 
 export namespace GetExternalModelsRequest {
   export function isa(o: any): o is GetExternalModelsRequest {
-    return _smithy.isa(o, "GetExternalModelsRequest");
+    return __isa(o, "GetExternalModelsRequest");
   }
 }
 
@@ -774,7 +777,7 @@ export interface GetExternalModelsResult extends $MetadataBearer {
 
 export namespace GetExternalModelsResult {
   export function isa(o: any): o is GetExternalModelsResult {
-    return _smithy.isa(o, "GetExternalModelsResult");
+    return __isa(o, "GetExternalModelsResult");
   }
 }
 
@@ -798,7 +801,7 @@ export interface GetModelVersionRequest {
 
 export namespace GetModelVersionRequest {
   export function isa(o: any): o is GetModelVersionRequest {
-    return _smithy.isa(o, "GetModelVersionRequest");
+    return __isa(o, "GetModelVersionRequest");
   }
 }
 
@@ -832,7 +835,7 @@ export interface GetModelVersionResult extends $MetadataBearer {
 
 export namespace GetModelVersionResult {
   export function isa(o: any): o is GetModelVersionResult {
-    return _smithy.isa(o, "GetModelVersionResult");
+    return __isa(o, "GetModelVersionResult");
   }
 }
 
@@ -861,7 +864,7 @@ export interface GetModelsRequest {
 
 export namespace GetModelsRequest {
   export function isa(o: any): o is GetModelsRequest {
-    return _smithy.isa(o, "GetModelsRequest");
+    return __isa(o, "GetModelsRequest");
   }
 }
 
@@ -880,7 +883,7 @@ export interface GetModelsResult extends $MetadataBearer {
 
 export namespace GetModelsResult {
   export function isa(o: any): o is GetModelsResult {
-    return _smithy.isa(o, "GetModelsResult");
+    return __isa(o, "GetModelsResult");
   }
 }
 
@@ -904,7 +907,7 @@ export interface GetOutcomesRequest {
 
 export namespace GetOutcomesRequest {
   export function isa(o: any): o is GetOutcomesRequest {
-    return _smithy.isa(o, "GetOutcomesRequest");
+    return __isa(o, "GetOutcomesRequest");
   }
 }
 
@@ -923,7 +926,7 @@ export interface GetOutcomesResult extends $MetadataBearer {
 
 export namespace GetOutcomesResult {
   export function isa(o: any): o is GetOutcomesResult {
-    return _smithy.isa(o, "GetOutcomesResult");
+    return __isa(o, "GetOutcomesResult");
   }
 }
 
@@ -957,7 +960,7 @@ export interface GetPredictionRequest {
 
 export namespace GetPredictionRequest {
   export function isa(o: any): o is GetPredictionRequest {
-    return _smithy.isa(o, "GetPredictionRequest");
+    return __isa(o, "GetPredictionRequest");
   }
 }
 
@@ -976,7 +979,7 @@ export interface GetPredictionResult extends $MetadataBearer {
 
 export namespace GetPredictionResult {
   export function isa(o: any): o is GetPredictionResult {
-    return _smithy.isa(o, "GetPredictionResult");
+    return __isa(o, "GetPredictionResult");
   }
 }
 
@@ -1010,7 +1013,7 @@ export interface GetRulesRequest {
 
 export namespace GetRulesRequest {
   export function isa(o: any): o is GetRulesRequest {
-    return _smithy.isa(o, "GetRulesRequest");
+    return __isa(o, "GetRulesRequest");
   }
 }
 
@@ -1029,7 +1032,7 @@ export interface GetRulesResult extends $MetadataBearer {
 
 export namespace GetRulesResult {
   export function isa(o: any): o is GetRulesResult {
-    return _smithy.isa(o, "GetRulesResult");
+    return __isa(o, "GetRulesResult");
   }
 }
 
@@ -1053,7 +1056,7 @@ export interface GetVariablesRequest {
 
 export namespace GetVariablesRequest {
   export function isa(o: any): o is GetVariablesRequest {
-    return _smithy.isa(o, "GetVariablesRequest");
+    return __isa(o, "GetVariablesRequest");
   }
 }
 
@@ -1072,7 +1075,7 @@ export interface GetVariablesResult extends $MetadataBearer {
 
 export namespace GetVariablesResult {
   export function isa(o: any): o is GetVariablesResult {
-    return _smithy.isa(o, "GetVariablesResult");
+    return __isa(o, "GetVariablesResult");
   }
 }
 
@@ -1099,7 +1102,7 @@ export interface LabelSchema {
 
 export namespace LabelSchema {
   export function isa(o: any): o is LabelSchema {
-    return _smithy.isa(o, "LabelSchema");
+    return __isa(o, "LabelSchema");
   }
 }
 
@@ -1155,7 +1158,7 @@ export interface Model {
 
 export namespace Model {
   export function isa(o: any): o is Model {
-    return _smithy.isa(o, "Model");
+    return __isa(o, "Model");
   }
 }
 
@@ -1177,7 +1180,7 @@ export interface ModelEndpointDataBlob {
 
 export namespace ModelEndpointDataBlob {
   export function isa(o: any): o is ModelEndpointDataBlob {
-    return _smithy.isa(o, "ModelEndpointDataBlob");
+    return __isa(o, "ModelEndpointDataBlob");
   }
 }
 
@@ -1221,7 +1224,7 @@ export interface ModelInputConfiguration {
 
 export namespace ModelInputConfiguration {
   export function isa(o: any): o is ModelInputConfiguration {
-    return _smithy.isa(o, "ModelInputConfiguration");
+    return __isa(o, "ModelInputConfiguration");
   }
 }
 
@@ -1253,7 +1256,7 @@ export interface ModelOutputConfiguration {
 
 export namespace ModelOutputConfiguration {
   export function isa(o: any): o is ModelOutputConfiguration {
-    return _smithy.isa(o, "ModelOutputConfiguration");
+    return __isa(o, "ModelOutputConfiguration");
   }
 }
 
@@ -1280,7 +1283,7 @@ export interface ModelScores {
 
 export namespace ModelScores {
   export function isa(o: any): o is ModelScores {
-    return _smithy.isa(o, "ModelScores");
+    return __isa(o, "ModelScores");
   }
 }
 
@@ -1310,7 +1313,7 @@ export interface ModelVariable {
 
 export namespace ModelVariable {
   export function isa(o: any): o is ModelVariable {
-    return _smithy.isa(o, "ModelVariable");
+    return __isa(o, "ModelVariable");
   }
 }
 
@@ -1337,7 +1340,7 @@ export interface ModelVersion {
 
 export namespace ModelVersion {
   export function isa(o: any): o is ModelVersion {
-    return _smithy.isa(o, "ModelVersion");
+    return __isa(o, "ModelVersion");
   }
 }
 
@@ -1409,7 +1412,7 @@ export interface ModelVersionDetail {
 
 export namespace ModelVersionDetail {
   export function isa(o: any): o is ModelVersionDetail {
-    return _smithy.isa(o, "ModelVersionDetail");
+    return __isa(o, "ModelVersionDetail");
   }
 }
 
@@ -1452,7 +1455,7 @@ export interface Outcome {
 
 export namespace Outcome {
   export function isa(o: any): o is Outcome {
-    return _smithy.isa(o, "Outcome");
+    return __isa(o, "Outcome");
   }
 }
 
@@ -1471,7 +1474,7 @@ export interface PutDetectorRequest {
 
 export namespace PutDetectorRequest {
   export function isa(o: any): o is PutDetectorRequest {
-    return _smithy.isa(o, "PutDetectorRequest");
+    return __isa(o, "PutDetectorRequest");
   }
 }
 
@@ -1481,7 +1484,7 @@ export interface PutDetectorResult extends $MetadataBearer {
 
 export namespace PutDetectorResult {
   export function isa(o: any): o is PutDetectorResult {
-    return _smithy.isa(o, "PutDetectorResult");
+    return __isa(o, "PutDetectorResult");
   }
 }
 
@@ -1520,7 +1523,7 @@ export interface PutExternalModelRequest {
 
 export namespace PutExternalModelRequest {
   export function isa(o: any): o is PutExternalModelRequest {
-    return _smithy.isa(o, "PutExternalModelRequest");
+    return __isa(o, "PutExternalModelRequest");
   }
 }
 
@@ -1530,7 +1533,7 @@ export interface PutExternalModelResult extends $MetadataBearer {
 
 export namespace PutExternalModelResult {
   export function isa(o: any): o is PutExternalModelResult {
-    return _smithy.isa(o, "PutExternalModelResult");
+    return __isa(o, "PutExternalModelResult");
   }
 }
 
@@ -1569,7 +1572,7 @@ export interface PutModelRequest {
 
 export namespace PutModelRequest {
   export function isa(o: any): o is PutModelRequest {
-    return _smithy.isa(o, "PutModelRequest");
+    return __isa(o, "PutModelRequest");
   }
 }
 
@@ -1579,7 +1582,7 @@ export interface PutModelResult extends $MetadataBearer {
 
 export namespace PutModelResult {
   export function isa(o: any): o is PutModelResult {
-    return _smithy.isa(o, "PutModelResult");
+    return __isa(o, "PutModelResult");
   }
 }
 
@@ -1598,7 +1601,7 @@ export interface PutOutcomeRequest {
 
 export namespace PutOutcomeRequest {
   export function isa(o: any): o is PutOutcomeRequest {
-    return _smithy.isa(o, "PutOutcomeRequest");
+    return __isa(o, "PutOutcomeRequest");
   }
 }
 
@@ -1608,7 +1611,7 @@ export interface PutOutcomeResult extends $MetadataBearer {
 
 export namespace PutOutcomeResult {
   export function isa(o: any): o is PutOutcomeResult {
-    return _smithy.isa(o, "PutOutcomeResult");
+    return __isa(o, "PutOutcomeResult");
   }
 }
 
@@ -1630,7 +1633,7 @@ export interface Role {
 
 export namespace Role {
   export function isa(o: any): o is Role {
-    return _smithy.isa(o, "Role");
+    return __isa(o, "Role");
   }
 }
 
@@ -1657,7 +1660,7 @@ export interface Rule {
 
 export namespace Rule {
   export function isa(o: any): o is Rule {
-    return _smithy.isa(o, "Rule");
+    return __isa(o, "Rule");
   }
 }
 
@@ -1714,7 +1717,7 @@ export interface RuleDetail {
 
 export namespace RuleDetail {
   export function isa(o: any): o is RuleDetail {
-    return _smithy.isa(o, "RuleDetail");
+    return __isa(o, "RuleDetail");
   }
 }
 
@@ -1736,7 +1739,7 @@ export interface TrainingDataSource {
 
 export namespace TrainingDataSource {
   export function isa(o: any): o is TrainingDataSource {
-    return _smithy.isa(o, "TrainingDataSource");
+    return __isa(o, "TrainingDataSource");
   }
 }
 
@@ -1760,7 +1763,7 @@ export interface UpdateDetectorVersionMetadataRequest {
 
 export namespace UpdateDetectorVersionMetadataRequest {
   export function isa(o: any): o is UpdateDetectorVersionMetadataRequest {
-    return _smithy.isa(o, "UpdateDetectorVersionMetadataRequest");
+    return __isa(o, "UpdateDetectorVersionMetadataRequest");
   }
 }
 
@@ -1770,7 +1773,7 @@ export interface UpdateDetectorVersionMetadataResult extends $MetadataBearer {
 
 export namespace UpdateDetectorVersionMetadataResult {
   export function isa(o: any): o is UpdateDetectorVersionMetadataResult {
-    return _smithy.isa(o, "UpdateDetectorVersionMetadataResult");
+    return __isa(o, "UpdateDetectorVersionMetadataResult");
   }
 }
 
@@ -1809,7 +1812,7 @@ export interface UpdateDetectorVersionRequest {
 
 export namespace UpdateDetectorVersionRequest {
   export function isa(o: any): o is UpdateDetectorVersionRequest {
-    return _smithy.isa(o, "UpdateDetectorVersionRequest");
+    return __isa(o, "UpdateDetectorVersionRequest");
   }
 }
 
@@ -1819,7 +1822,7 @@ export interface UpdateDetectorVersionResult extends $MetadataBearer {
 
 export namespace UpdateDetectorVersionResult {
   export function isa(o: any): o is UpdateDetectorVersionResult {
-    return _smithy.isa(o, "UpdateDetectorVersionResult");
+    return __isa(o, "UpdateDetectorVersionResult");
   }
 }
 
@@ -1843,7 +1846,7 @@ export interface UpdateDetectorVersionStatusRequest {
 
 export namespace UpdateDetectorVersionStatusRequest {
   export function isa(o: any): o is UpdateDetectorVersionStatusRequest {
-    return _smithy.isa(o, "UpdateDetectorVersionStatusRequest");
+    return __isa(o, "UpdateDetectorVersionStatusRequest");
   }
 }
 
@@ -1853,7 +1856,7 @@ export interface UpdateDetectorVersionStatusResult extends $MetadataBearer {
 
 export namespace UpdateDetectorVersionStatusResult {
   export function isa(o: any): o is UpdateDetectorVersionStatusResult {
-    return _smithy.isa(o, "UpdateDetectorVersionStatusResult");
+    return __isa(o, "UpdateDetectorVersionStatusResult");
   }
 }
 
@@ -1887,7 +1890,7 @@ export interface UpdateModelVersionRequest {
 
 export namespace UpdateModelVersionRequest {
   export function isa(o: any): o is UpdateModelVersionRequest {
-    return _smithy.isa(o, "UpdateModelVersionRequest");
+    return __isa(o, "UpdateModelVersionRequest");
   }
 }
 
@@ -1897,7 +1900,7 @@ export interface UpdateModelVersionResult extends $MetadataBearer {
 
 export namespace UpdateModelVersionResult {
   export function isa(o: any): o is UpdateModelVersionResult {
-    return _smithy.isa(o, "UpdateModelVersionResult");
+    return __isa(o, "UpdateModelVersionResult");
   }
 }
 
@@ -1916,7 +1919,7 @@ export interface UpdateRuleMetadataRequest {
 
 export namespace UpdateRuleMetadataRequest {
   export function isa(o: any): o is UpdateRuleMetadataRequest {
-    return _smithy.isa(o, "UpdateRuleMetadataRequest");
+    return __isa(o, "UpdateRuleMetadataRequest");
   }
 }
 
@@ -1926,7 +1929,7 @@ export interface UpdateRuleMetadataResult extends $MetadataBearer {
 
 export namespace UpdateRuleMetadataResult {
   export function isa(o: any): o is UpdateRuleMetadataResult {
-    return _smithy.isa(o, "UpdateRuleMetadataResult");
+    return __isa(o, "UpdateRuleMetadataResult");
   }
 }
 
@@ -1960,7 +1963,7 @@ export interface UpdateRuleVersionRequest {
 
 export namespace UpdateRuleVersionRequest {
   export function isa(o: any): o is UpdateRuleVersionRequest {
-    return _smithy.isa(o, "UpdateRuleVersionRequest");
+    return __isa(o, "UpdateRuleVersionRequest");
   }
 }
 
@@ -1974,7 +1977,7 @@ export interface UpdateRuleVersionResult extends $MetadataBearer {
 
 export namespace UpdateRuleVersionResult {
   export function isa(o: any): o is UpdateRuleVersionResult {
-    return _smithy.isa(o, "UpdateRuleVersionResult");
+    return __isa(o, "UpdateRuleVersionResult");
   }
 }
 
@@ -2003,7 +2006,7 @@ export interface UpdateVariableRequest {
 
 export namespace UpdateVariableRequest {
   export function isa(o: any): o is UpdateVariableRequest {
-    return _smithy.isa(o, "UpdateVariableRequest");
+    return __isa(o, "UpdateVariableRequest");
   }
 }
 
@@ -2013,7 +2016,7 @@ export interface UpdateVariableResult extends $MetadataBearer {
 
 export namespace UpdateVariableResult {
   export function isa(o: any): o is UpdateVariableResult {
-    return _smithy.isa(o, "UpdateVariableResult");
+    return __isa(o, "UpdateVariableResult");
   }
 }
 
@@ -2065,7 +2068,7 @@ export interface Variable {
 
 export namespace Variable {
   export function isa(o: any): o is Variable {
-    return _smithy.isa(o, "Variable");
+    return __isa(o, "Variable");
   }
 }
 
@@ -2107,7 +2110,7 @@ export interface VariableEntry {
 
 export namespace VariableEntry {
   export function isa(o: any): o is VariableEntry {
-    return _smithy.isa(o, "VariableEntry");
+    return __isa(o, "VariableEntry");
   }
 }
 
@@ -2115,7 +2118,7 @@ export namespace VariableEntry {
  * <p>An exception indicating an internal server error.</p>
  */
 export interface InternalServerException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalServerException";
   $fault: "server";
@@ -2124,7 +2127,7 @@ export interface InternalServerException
 
 export namespace InternalServerException {
   export function isa(o: any): o is InternalServerException {
-    return _smithy.isa(o, "InternalServerException");
+    return __isa(o, "InternalServerException");
   }
 }
 
@@ -2132,7 +2135,7 @@ export namespace InternalServerException {
  * <p>An exception indicating the specified resource was not found.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -2141,7 +2144,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -2149,7 +2152,7 @@ export namespace ResourceNotFoundException {
  * <p>An exception indicating a throttling error.</p>
  */
 export interface ThrottlingException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ThrottlingException";
   $fault: "client";
@@ -2158,7 +2161,7 @@ export interface ThrottlingException
 
 export namespace ThrottlingException {
   export function isa(o: any): o is ThrottlingException {
-    return _smithy.isa(o, "ThrottlingException");
+    return __isa(o, "ThrottlingException");
   }
 }
 
@@ -2166,7 +2169,7 @@ export namespace ThrottlingException {
  * <p>An exception indicating a specified value is not allowed.</p>
  */
 export interface ValidationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ValidationException";
   $fault: "client";
@@ -2175,6 +2178,6 @@ export interface ValidationException
 
 export namespace ValidationException {
   export function isa(o: any): o is ValidationException {
-    return _smithy.isa(o, "ValidationException");
+    return __isa(o, "ValidationException");
   }
 }

--- a/clients/client-fsx/models/index.ts
+++ b/clients/client-fsx/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -19,7 +22,7 @@ export interface ActiveDirectoryBackupAttributes {
 
 export namespace ActiveDirectoryBackupAttributes {
   export function isa(o: any): o is ActiveDirectoryBackupAttributes {
-    return _smithy.isa(o, "ActiveDirectoryBackupAttributes");
+    return __isa(o, "ActiveDirectoryBackupAttributes");
   }
 }
 
@@ -27,7 +30,7 @@ export namespace ActiveDirectoryBackupAttributes {
  * <p>An Active Directory error.</p>
  */
 export interface ActiveDirectoryError
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ActiveDirectoryError";
   $fault: "client";
@@ -49,7 +52,7 @@ export interface ActiveDirectoryError
 
 export namespace ActiveDirectoryError {
   export function isa(o: any): o is ActiveDirectoryError {
-    return _smithy.isa(o, "ActiveDirectoryError");
+    return __isa(o, "ActiveDirectoryError");
   }
 }
 
@@ -127,7 +130,7 @@ export interface Backup {
 
 export namespace Backup {
   export function isa(o: any): o is Backup {
-    return _smithy.isa(o, "Backup");
+    return __isa(o, "Backup");
   }
 }
 
@@ -145,7 +148,7 @@ export interface BackupFailureDetails {
 
 export namespace BackupFailureDetails {
   export function isa(o: any): o is BackupFailureDetails {
-    return _smithy.isa(o, "BackupFailureDetails");
+    return __isa(o, "BackupFailureDetails");
   }
 }
 
@@ -153,9 +156,7 @@ export namespace BackupFailureDetails {
  * <p>Another backup is already under way. Wait for completion before initiating
  *             additional backups of this file system.</p>
  */
-export interface BackupInProgress
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface BackupInProgress extends __SmithyException, $MetadataBearer {
   name: "BackupInProgress";
   $fault: "client";
   /**
@@ -166,7 +167,7 @@ export interface BackupInProgress
 
 export namespace BackupInProgress {
   export function isa(o: any): o is BackupInProgress {
-    return _smithy.isa(o, "BackupInProgress");
+    return __isa(o, "BackupInProgress");
   }
 }
 
@@ -180,9 +181,7 @@ export enum BackupLifecycle {
 /**
  * <p>No Amazon FSx backups were found based upon the supplied parameters.</p>
  */
-export interface BackupNotFound
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface BackupNotFound extends __SmithyException, $MetadataBearer {
   name: "BackupNotFound";
   $fault: "client";
   /**
@@ -193,7 +192,7 @@ export interface BackupNotFound
 
 export namespace BackupNotFound {
   export function isa(o: any): o is BackupNotFound {
-    return _smithy.isa(o, "BackupNotFound");
+    return __isa(o, "BackupNotFound");
   }
 }
 
@@ -201,9 +200,7 @@ export namespace BackupNotFound {
  * <p>You can't delete a backup while it's being used to restore a file
  *             system.</p>
  */
-export interface BackupRestoring
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface BackupRestoring extends __SmithyException, $MetadataBearer {
   name: "BackupRestoring";
   $fault: "client";
   /**
@@ -219,7 +216,7 @@ export interface BackupRestoring
 
 export namespace BackupRestoring {
   export function isa(o: any): o is BackupRestoring {
-    return _smithy.isa(o, "BackupRestoring");
+    return __isa(o, "BackupRestoring");
   }
 }
 
@@ -231,7 +228,7 @@ export enum BackupType {
 /**
  * <p>A generic error indicating a failure with a client request.</p>
  */
-export interface BadRequest extends _smithy.SmithyException, $MetadataBearer {
+export interface BadRequest extends __SmithyException, $MetadataBearer {
   name: "BadRequest";
   $fault: "client";
   /**
@@ -242,7 +239,7 @@ export interface BadRequest extends _smithy.SmithyException, $MetadataBearer {
 
 export namespace BadRequest {
   export function isa(o: any): o is BadRequest {
-    return _smithy.isa(o, "BadRequest");
+    return __isa(o, "BadRequest");
   }
 }
 
@@ -259,7 +256,7 @@ export interface CancelDataRepositoryTaskRequest {
 
 export namespace CancelDataRepositoryTaskRequest {
   export function isa(o: any): o is CancelDataRepositoryTaskRequest {
-    return _smithy.isa(o, "CancelDataRepositoryTaskRequest");
+    return __isa(o, "CancelDataRepositoryTaskRequest");
   }
 }
 
@@ -305,7 +302,7 @@ export interface CancelDataRepositoryTaskResponse extends $MetadataBearer {
 
 export namespace CancelDataRepositoryTaskResponse {
   export function isa(o: any): o is CancelDataRepositoryTaskResponse {
-    return _smithy.isa(o, "CancelDataRepositoryTaskResponse");
+    return __isa(o, "CancelDataRepositoryTaskResponse");
   }
 }
 
@@ -350,7 +347,7 @@ export interface CompletionReport {
 
 export namespace CompletionReport {
   export function isa(o: any): o is CompletionReport {
-    return _smithy.isa(o, "CompletionReport");
+    return __isa(o, "CompletionReport");
   }
 }
 
@@ -380,7 +377,7 @@ export interface CreateBackupRequest {
 
 export namespace CreateBackupRequest {
   export function isa(o: any): o is CreateBackupRequest {
-    return _smithy.isa(o, "CreateBackupRequest");
+    return __isa(o, "CreateBackupRequest");
   }
 }
 
@@ -397,7 +394,7 @@ export interface CreateBackupResponse extends $MetadataBearer {
 
 export namespace CreateBackupResponse {
   export function isa(o: any): o is CreateBackupResponse {
-    return _smithy.isa(o, "CreateBackupResponse");
+    return __isa(o, "CreateBackupResponse");
   }
 }
 
@@ -442,7 +439,7 @@ export interface CreateDataRepositoryTaskRequest {
 
 export namespace CreateDataRepositoryTaskRequest {
   export function isa(o: any): o is CreateDataRepositoryTaskRequest {
-    return _smithy.isa(o, "CreateDataRepositoryTaskRequest");
+    return __isa(o, "CreateDataRepositoryTaskRequest");
   }
 }
 
@@ -456,7 +453,7 @@ export interface CreateDataRepositoryTaskResponse extends $MetadataBearer {
 
 export namespace CreateDataRepositoryTaskResponse {
   export function isa(o: any): o is CreateDataRepositoryTaskResponse {
-    return _smithy.isa(o, "CreateDataRepositoryTaskResponse");
+    return __isa(o, "CreateDataRepositoryTaskResponse");
   }
 }
 
@@ -507,7 +504,7 @@ export interface CreateFileSystemFromBackupRequest {
 
 export namespace CreateFileSystemFromBackupRequest {
   export function isa(o: any): o is CreateFileSystemFromBackupRequest {
-    return _smithy.isa(o, "CreateFileSystemFromBackupRequest");
+    return __isa(o, "CreateFileSystemFromBackupRequest");
   }
 }
 
@@ -525,7 +522,7 @@ export interface CreateFileSystemFromBackupResponse extends $MetadataBearer {
 
 export namespace CreateFileSystemFromBackupResponse {
   export function isa(o: any): o is CreateFileSystemFromBackupResponse {
-    return _smithy.isa(o, "CreateFileSystemFromBackupResponse");
+    return __isa(o, "CreateFileSystemFromBackupResponse");
   }
 }
 
@@ -584,7 +581,7 @@ export interface CreateFileSystemLustreConfiguration {
 
 export namespace CreateFileSystemLustreConfiguration {
   export function isa(o: any): o is CreateFileSystemLustreConfiguration {
-    return _smithy.isa(o, "CreateFileSystemLustreConfiguration");
+    return __isa(o, "CreateFileSystemLustreConfiguration");
   }
 }
 
@@ -658,7 +655,7 @@ export interface CreateFileSystemRequest {
 
 export namespace CreateFileSystemRequest {
   export function isa(o: any): o is CreateFileSystemRequest {
-    return _smithy.isa(o, "CreateFileSystemRequest");
+    return __isa(o, "CreateFileSystemRequest");
   }
 }
 
@@ -675,7 +672,7 @@ export interface CreateFileSystemResponse extends $MetadataBearer {
 
 export namespace CreateFileSystemResponse {
   export function isa(o: any): o is CreateFileSystemResponse {
-    return _smithy.isa(o, "CreateFileSystemResponse");
+    return __isa(o, "CreateFileSystemResponse");
   }
 }
 
@@ -762,7 +759,7 @@ export interface CreateFileSystemWindowsConfiguration {
 
 export namespace CreateFileSystemWindowsConfiguration {
   export function isa(o: any): o is CreateFileSystemWindowsConfiguration {
-    return _smithy.isa(o, "CreateFileSystemWindowsConfiguration");
+    return __isa(o, "CreateFileSystemWindowsConfiguration");
   }
 }
 
@@ -801,7 +798,7 @@ export interface DataRepositoryConfiguration {
 
 export namespace DataRepositoryConfiguration {
   export function isa(o: any): o is DataRepositoryConfiguration {
-    return _smithy.isa(o, "DataRepositoryConfiguration");
+    return __isa(o, "DataRepositoryConfiguration");
   }
 }
 
@@ -923,7 +920,7 @@ export interface DataRepositoryTask {
 
 export namespace DataRepositoryTask {
   export function isa(o: any): o is DataRepositoryTask {
-    return _smithy.isa(o, "DataRepositoryTask");
+    return __isa(o, "DataRepositoryTask");
   }
 }
 
@@ -931,7 +928,7 @@ export namespace DataRepositoryTask {
  * <p>The data repository task could not be canceled because the task has already ended.</p>
  */
 export interface DataRepositoryTaskEnded
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DataRepositoryTaskEnded";
   $fault: "client";
@@ -943,7 +940,7 @@ export interface DataRepositoryTaskEnded
 
 export namespace DataRepositoryTaskEnded {
   export function isa(o: any): o is DataRepositoryTaskEnded {
-    return _smithy.isa(o, "DataRepositoryTaskEnded");
+    return __isa(o, "DataRepositoryTaskEnded");
   }
 }
 
@@ -952,7 +949,7 @@ export namespace DataRepositoryTaskEnded {
  *         Wait until the existing task has completed, then create the new task.</p>
  */
 export interface DataRepositoryTaskExecuting
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DataRepositoryTaskExecuting";
   $fault: "client";
@@ -964,7 +961,7 @@ export interface DataRepositoryTaskExecuting
 
 export namespace DataRepositoryTaskExecuting {
   export function isa(o: any): o is DataRepositoryTaskExecuting {
-    return _smithy.isa(o, "DataRepositoryTaskExecuting");
+    return __isa(o, "DataRepositoryTaskExecuting");
   }
 }
 
@@ -981,7 +978,7 @@ export interface DataRepositoryTaskFailureDetails {
 
 export namespace DataRepositoryTaskFailureDetails {
   export function isa(o: any): o is DataRepositoryTaskFailureDetails {
-    return _smithy.isa(o, "DataRepositoryTaskFailureDetails");
+    return __isa(o, "DataRepositoryTaskFailureDetails");
   }
 }
 
@@ -1015,7 +1012,7 @@ export interface DataRepositoryTaskFilter {
 
 export namespace DataRepositoryTaskFilter {
   export function isa(o: any): o is DataRepositoryTaskFilter {
-    return _smithy.isa(o, "DataRepositoryTaskFilter");
+    return __isa(o, "DataRepositoryTaskFilter");
   }
 }
 
@@ -1037,7 +1034,7 @@ export enum DataRepositoryTaskLifecycle {
  * <p>The data repository task or tasks you specified could not be found.</p>
  */
 export interface DataRepositoryTaskNotFound
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DataRepositoryTaskNotFound";
   $fault: "client";
@@ -1049,7 +1046,7 @@ export interface DataRepositoryTaskNotFound
 
 export namespace DataRepositoryTaskNotFound {
   export function isa(o: any): o is DataRepositoryTaskNotFound {
-    return _smithy.isa(o, "DataRepositoryTaskNotFound");
+    return __isa(o, "DataRepositoryTaskNotFound");
   }
 }
 
@@ -1084,7 +1081,7 @@ export interface DataRepositoryTaskStatus {
 
 export namespace DataRepositoryTaskStatus {
   export function isa(o: any): o is DataRepositoryTaskStatus {
-    return _smithy.isa(o, "DataRepositoryTaskStatus");
+    return __isa(o, "DataRepositoryTaskStatus");
   }
 }
 
@@ -1112,7 +1109,7 @@ export interface DeleteBackupRequest {
 
 export namespace DeleteBackupRequest {
   export function isa(o: any): o is DeleteBackupRequest {
-    return _smithy.isa(o, "DeleteBackupRequest");
+    return __isa(o, "DeleteBackupRequest");
   }
 }
 
@@ -1134,7 +1131,7 @@ export interface DeleteBackupResponse extends $MetadataBearer {
 
 export namespace DeleteBackupResponse {
   export function isa(o: any): o is DeleteBackupResponse {
-    return _smithy.isa(o, "DeleteBackupResponse");
+    return __isa(o, "DeleteBackupResponse");
   }
 }
 
@@ -1164,7 +1161,7 @@ export interface DeleteFileSystemRequest {
 
 export namespace DeleteFileSystemRequest {
   export function isa(o: any): o is DeleteFileSystemRequest {
-    return _smithy.isa(o, "DeleteFileSystemRequest");
+    return __isa(o, "DeleteFileSystemRequest");
   }
 }
 
@@ -1193,7 +1190,7 @@ export interface DeleteFileSystemResponse extends $MetadataBearer {
 
 export namespace DeleteFileSystemResponse {
   export function isa(o: any): o is DeleteFileSystemResponse {
-    return _smithy.isa(o, "DeleteFileSystemResponse");
+    return __isa(o, "DeleteFileSystemResponse");
   }
 }
 
@@ -1219,7 +1216,7 @@ export interface DeleteFileSystemWindowsConfiguration {
 
 export namespace DeleteFileSystemWindowsConfiguration {
   export function isa(o: any): o is DeleteFileSystemWindowsConfiguration {
-    return _smithy.isa(o, "DeleteFileSystemWindowsConfiguration");
+    return __isa(o, "DeleteFileSystemWindowsConfiguration");
   }
 }
 
@@ -1242,7 +1239,7 @@ export interface DeleteFileSystemWindowsResponse {
 
 export namespace DeleteFileSystemWindowsResponse {
   export function isa(o: any): o is DeleteFileSystemWindowsResponse {
-    return _smithy.isa(o, "DeleteFileSystemWindowsResponse");
+    return __isa(o, "DeleteFileSystemWindowsResponse");
   }
 }
 
@@ -1281,7 +1278,7 @@ export interface DescribeBackupsRequest {
 
 export namespace DescribeBackupsRequest {
   export function isa(o: any): o is DescribeBackupsRequest {
-    return _smithy.isa(o, "DescribeBackupsRequest");
+    return __isa(o, "DescribeBackupsRequest");
   }
 }
 
@@ -1305,7 +1302,7 @@ export interface DescribeBackupsResponse extends $MetadataBearer {
 
 export namespace DescribeBackupsResponse {
   export function isa(o: any): o is DescribeBackupsResponse {
-    return _smithy.isa(o, "DescribeBackupsResponse");
+    return __isa(o, "DescribeBackupsResponse");
   }
 }
 
@@ -1339,7 +1336,7 @@ export interface DescribeDataRepositoryTasksRequest {
 
 export namespace DescribeDataRepositoryTasksRequest {
   export function isa(o: any): o is DescribeDataRepositoryTasksRequest {
-    return _smithy.isa(o, "DescribeDataRepositoryTasksRequest");
+    return __isa(o, "DescribeDataRepositoryTasksRequest");
   }
 }
 
@@ -1360,7 +1357,7 @@ export interface DescribeDataRepositoryTasksResponse extends $MetadataBearer {
 
 export namespace DescribeDataRepositoryTasksResponse {
   export function isa(o: any): o is DescribeDataRepositoryTasksResponse {
-    return _smithy.isa(o, "DescribeDataRepositoryTasksResponse");
+    return __isa(o, "DescribeDataRepositoryTasksResponse");
   }
 }
 
@@ -1393,7 +1390,7 @@ export interface DescribeFileSystemsRequest {
 
 export namespace DescribeFileSystemsRequest {
   export function isa(o: any): o is DescribeFileSystemsRequest {
-    return _smithy.isa(o, "DescribeFileSystemsRequest");
+    return __isa(o, "DescribeFileSystemsRequest");
   }
 }
 
@@ -1417,7 +1414,7 @@ export interface DescribeFileSystemsResponse extends $MetadataBearer {
 
 export namespace DescribeFileSystemsResponse {
   export function isa(o: any): o is DescribeFileSystemsResponse {
-    return _smithy.isa(o, "DescribeFileSystemsResponse");
+    return __isa(o, "DescribeFileSystemsResponse");
   }
 }
 
@@ -1554,7 +1551,7 @@ export interface FileSystem {
 
 export namespace FileSystem {
   export function isa(o: any): o is FileSystem {
-    return _smithy.isa(o, "FileSystem");
+    return __isa(o, "FileSystem");
   }
 }
 
@@ -1572,7 +1569,7 @@ export interface FileSystemFailureDetails {
 
 export namespace FileSystemFailureDetails {
   export function isa(o: any): o is FileSystemFailureDetails {
-    return _smithy.isa(o, "FileSystemFailureDetails");
+    return __isa(o, "FileSystemFailureDetails");
   }
 }
 
@@ -1593,9 +1590,7 @@ export enum FileSystemMaintenanceOperation {
 /**
  * <p>No Amazon FSx file systems were found based upon supplied parameters.</p>
  */
-export interface FileSystemNotFound
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface FileSystemNotFound extends __SmithyException, $MetadataBearer {
   name: "FileSystemNotFound";
   $fault: "client";
   /**
@@ -1606,7 +1601,7 @@ export interface FileSystemNotFound
 
 export namespace FileSystemNotFound {
   export function isa(o: any): o is FileSystemNotFound {
-    return _smithy.isa(o, "FileSystemNotFound");
+    return __isa(o, "FileSystemNotFound");
   }
 }
 
@@ -1635,7 +1630,7 @@ export interface Filter {
 
 export namespace Filter {
   export function isa(o: any): o is Filter {
-    return _smithy.isa(o, "Filter");
+    return __isa(o, "Filter");
   }
 }
 
@@ -1650,7 +1645,7 @@ export enum FilterName {
  *             identify a single request.</p>
  */
 export interface IncompatibleParameterError
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "IncompatibleParameterError";
   $fault: "client";
@@ -1667,7 +1662,7 @@ export interface IncompatibleParameterError
 
 export namespace IncompatibleParameterError {
   export function isa(o: any): o is IncompatibleParameterError {
-    return _smithy.isa(o, "IncompatibleParameterError");
+    return __isa(o, "IncompatibleParameterError");
   }
 }
 
@@ -1675,7 +1670,7 @@ export namespace IncompatibleParameterError {
  * <p>A generic error indicating a server-side failure.</p>
  */
 export interface InternalServerError
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalServerError";
   $fault: "server";
@@ -1687,16 +1682,14 @@ export interface InternalServerError
 
 export namespace InternalServerError {
   export function isa(o: any): o is InternalServerError {
-    return _smithy.isa(o, "InternalServerError");
+    return __isa(o, "InternalServerError");
   }
 }
 
 /**
  * <p>The path provided for data repository export isn't valid.</p>
  */
-export interface InvalidExportPath
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface InvalidExportPath extends __SmithyException, $MetadataBearer {
   name: "InvalidExportPath";
   $fault: "client";
   /**
@@ -1707,16 +1700,14 @@ export interface InvalidExportPath
 
 export namespace InvalidExportPath {
   export function isa(o: any): o is InvalidExportPath {
-    return _smithy.isa(o, "InvalidExportPath");
+    return __isa(o, "InvalidExportPath");
   }
 }
 
 /**
  * <p>The path provided for data repository import isn't valid.</p>
  */
-export interface InvalidImportPath
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface InvalidImportPath extends __SmithyException, $MetadataBearer {
   name: "InvalidImportPath";
   $fault: "client";
   /**
@@ -1727,7 +1718,7 @@ export interface InvalidImportPath
 
 export namespace InvalidImportPath {
   export function isa(o: any): o is InvalidImportPath {
-    return _smithy.isa(o, "InvalidImportPath");
+    return __isa(o, "InvalidImportPath");
   }
 }
 
@@ -1740,7 +1731,7 @@ export namespace InvalidImportPath {
  *             that are either invalid or not part of the VPC specified.</p>
  */
 export interface InvalidNetworkSettings
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidNetworkSettings";
   $fault: "client";
@@ -1769,7 +1760,7 @@ export interface InvalidNetworkSettings
 
 export namespace InvalidNetworkSettings {
   export function isa(o: any): o is InvalidNetworkSettings {
-    return _smithy.isa(o, "InvalidNetworkSettings");
+    return __isa(o, "InvalidNetworkSettings");
   }
 }
 
@@ -1801,7 +1792,7 @@ export interface ListTagsForResourceRequest {
 
 export namespace ListTagsForResourceRequest {
   export function isa(o: any): o is ListTagsForResourceRequest {
-    return _smithy.isa(o, "ListTagsForResourceRequest");
+    return __isa(o, "ListTagsForResourceRequest");
   }
 }
 
@@ -1825,7 +1816,7 @@ export interface ListTagsForResourceResponse extends $MetadataBearer {
 
 export namespace ListTagsForResourceResponse {
   export function isa(o: any): o is ListTagsForResourceResponse {
-    return _smithy.isa(o, "ListTagsForResourceResponse");
+    return __isa(o, "ListTagsForResourceResponse");
   }
 }
 
@@ -1848,7 +1839,7 @@ export interface LustreFileSystemConfiguration {
 
 export namespace LustreFileSystemConfiguration {
   export function isa(o: any): o is LustreFileSystemConfiguration {
-    return _smithy.isa(o, "LustreFileSystemConfiguration");
+    return __isa(o, "LustreFileSystemConfiguration");
   }
 }
 
@@ -1856,7 +1847,7 @@ export namespace LustreFileSystemConfiguration {
  * <p>File system configuration is required for this operation.</p>
  */
 export interface MissingFileSystemConfiguration
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "MissingFileSystemConfiguration";
   $fault: "client";
@@ -1868,7 +1859,7 @@ export interface MissingFileSystemConfiguration
 
 export namespace MissingFileSystemConfiguration {
   export function isa(o: any): o is MissingFileSystemConfiguration {
-    return _smithy.isa(o, "MissingFileSystemConfiguration");
+    return __isa(o, "MissingFileSystemConfiguration");
   }
 }
 
@@ -1877,7 +1868,7 @@ export namespace MissingFileSystemConfiguration {
  *             Amazon FSx. Use the API of the relevant service to perform the operation. </p>
  */
 export interface NotServiceResourceError
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "NotServiceResourceError";
   $fault: "client";
@@ -1894,7 +1885,7 @@ export interface NotServiceResourceError
 
 export namespace NotServiceResourceError {
   export function isa(o: any): o is NotServiceResourceError {
-    return _smithy.isa(o, "NotServiceResourceError");
+    return __isa(o, "NotServiceResourceError");
   }
 }
 
@@ -1910,7 +1901,7 @@ export enum ReportScope {
  * <p>The resource specified does not support tagging. </p>
  */
 export interface ResourceDoesNotSupportTagging
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceDoesNotSupportTagging";
   $fault: "client";
@@ -1928,16 +1919,14 @@ export interface ResourceDoesNotSupportTagging
 
 export namespace ResourceDoesNotSupportTagging {
   export function isa(o: any): o is ResourceDoesNotSupportTagging {
-    return _smithy.isa(o, "ResourceDoesNotSupportTagging");
+    return __isa(o, "ResourceDoesNotSupportTagging");
   }
 }
 
 /**
  * <p>The resource specified by the Amazon Resource Name (ARN) can't be found.</p>
  */
-export interface ResourceNotFound
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface ResourceNotFound extends __SmithyException, $MetadataBearer {
   name: "ResourceNotFound";
   $fault: "client";
   /**
@@ -1953,7 +1942,7 @@ export interface ResourceNotFound
 
 export namespace ResourceNotFound {
   export function isa(o: any): o is ResourceNotFound {
-    return _smithy.isa(o, "ResourceNotFound");
+    return __isa(o, "ResourceNotFound");
   }
 }
 
@@ -1995,7 +1984,7 @@ export interface SelfManagedActiveDirectoryAttributes {
 
 export namespace SelfManagedActiveDirectoryAttributes {
   export function isa(o: any): o is SelfManagedActiveDirectoryAttributes {
-    return _smithy.isa(o, "SelfManagedActiveDirectoryAttributes");
+    return __isa(o, "SelfManagedActiveDirectoryAttributes");
   }
 }
 
@@ -2072,7 +2061,7 @@ export interface SelfManagedActiveDirectoryConfiguration {
 
 export namespace SelfManagedActiveDirectoryConfiguration {
   export function isa(o: any): o is SelfManagedActiveDirectoryConfiguration {
-    return _smithy.isa(o, "SelfManagedActiveDirectoryConfiguration");
+    return __isa(o, "SelfManagedActiveDirectoryConfiguration");
   }
 }
 
@@ -2107,7 +2096,7 @@ export namespace SelfManagedActiveDirectoryConfigurationUpdates {
   export function isa(
     o: any
   ): o is SelfManagedActiveDirectoryConfigurationUpdates {
-    return _smithy.isa(o, "SelfManagedActiveDirectoryConfigurationUpdates");
+    return __isa(o, "SelfManagedActiveDirectoryConfigurationUpdates");
   }
 }
 
@@ -2124,7 +2113,7 @@ export enum ServiceLimit {
  *             </p>
  */
 export interface ServiceLimitExceeded
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ServiceLimitExceeded";
   $fault: "client";
@@ -2141,7 +2130,7 @@ export interface ServiceLimitExceeded
 
 export namespace ServiceLimitExceeded {
   export function isa(o: any): o is ServiceLimitExceeded {
-    return _smithy.isa(o, "ServiceLimitExceeded");
+    return __isa(o, "ServiceLimitExceeded");
   }
 }
 
@@ -2167,7 +2156,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -2191,7 +2180,7 @@ export interface TagResourceRequest {
 
 export namespace TagResourceRequest {
   export function isa(o: any): o is TagResourceRequest {
-    return _smithy.isa(o, "TagResourceRequest");
+    return __isa(o, "TagResourceRequest");
   }
 }
 
@@ -2204,7 +2193,7 @@ export interface TagResourceResponse extends $MetadataBearer {
 
 export namespace TagResourceResponse {
   export function isa(o: any): o is TagResourceResponse {
-    return _smithy.isa(o, "TagResourceResponse");
+    return __isa(o, "TagResourceResponse");
   }
 }
 
@@ -2212,7 +2201,7 @@ export namespace TagResourceResponse {
  * <p>The requested operation is not supported for this resource or API.</p>
  */
 export interface UnsupportedOperation
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UnsupportedOperation";
   $fault: "client";
@@ -2224,7 +2213,7 @@ export interface UnsupportedOperation
 
 export namespace UnsupportedOperation {
   export function isa(o: any): o is UnsupportedOperation {
-    return _smithy.isa(o, "UnsupportedOperation");
+    return __isa(o, "UnsupportedOperation");
   }
 }
 
@@ -2247,7 +2236,7 @@ export interface UntagResourceRequest {
 
 export namespace UntagResourceRequest {
   export function isa(o: any): o is UntagResourceRequest {
-    return _smithy.isa(o, "UntagResourceRequest");
+    return __isa(o, "UntagResourceRequest");
   }
 }
 
@@ -2260,7 +2249,7 @@ export interface UntagResourceResponse extends $MetadataBearer {
 
 export namespace UntagResourceResponse {
   export function isa(o: any): o is UntagResourceResponse {
-    return _smithy.isa(o, "UntagResourceResponse");
+    return __isa(o, "UntagResourceResponse");
   }
 }
 
@@ -2278,7 +2267,7 @@ export interface UpdateFileSystemLustreConfiguration {
 
 export namespace UpdateFileSystemLustreConfiguration {
   export function isa(o: any): o is UpdateFileSystemLustreConfiguration {
-    return _smithy.isa(o, "UpdateFileSystemLustreConfiguration");
+    return __isa(o, "UpdateFileSystemLustreConfiguration");
   }
 }
 
@@ -2314,7 +2303,7 @@ export interface UpdateFileSystemRequest {
 
 export namespace UpdateFileSystemRequest {
   export function isa(o: any): o is UpdateFileSystemRequest {
-    return _smithy.isa(o, "UpdateFileSystemRequest");
+    return __isa(o, "UpdateFileSystemRequest");
   }
 }
 
@@ -2331,7 +2320,7 @@ export interface UpdateFileSystemResponse extends $MetadataBearer {
 
 export namespace UpdateFileSystemResponse {
   export function isa(o: any): o is UpdateFileSystemResponse {
-    return _smithy.isa(o, "UpdateFileSystemResponse");
+    return __isa(o, "UpdateFileSystemResponse");
   }
 }
 
@@ -2368,7 +2357,7 @@ export interface UpdateFileSystemWindowsConfiguration {
 
 export namespace UpdateFileSystemWindowsConfiguration {
   export function isa(o: any): o is UpdateFileSystemWindowsConfiguration {
-    return _smithy.isa(o, "UpdateFileSystemWindowsConfiguration");
+    return __isa(o, "UpdateFileSystemWindowsConfiguration");
   }
 }
 
@@ -2481,6 +2470,6 @@ export interface WindowsFileSystemConfiguration {
 
 export namespace WindowsFileSystemConfiguration {
   export function isa(o: any): o is WindowsFileSystemConfiguration {
-    return _smithy.isa(o, "WindowsFileSystemConfiguration");
+    return __isa(o, "WindowsFileSystemConfiguration");
   }
 }

--- a/clients/client-gamelift/models/index.ts
+++ b/clients/client-gamelift/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -26,7 +29,7 @@ export interface AcceptMatchInput {
 
 export namespace AcceptMatchInput {
   export function isa(o: any): o is AcceptMatchInput {
-    return _smithy.isa(o, "AcceptMatchInput");
+    return __isa(o, "AcceptMatchInput");
   }
 }
 
@@ -36,7 +39,7 @@ export interface AcceptMatchOutput extends $MetadataBearer {
 
 export namespace AcceptMatchOutput {
   export function isa(o: any): o is AcceptMatchOutput {
-    return _smithy.isa(o, "AcceptMatchOutput");
+    return __isa(o, "AcceptMatchOutput");
   }
 }
 
@@ -117,7 +120,7 @@ export interface Alias {
 
 export namespace Alias {
   export function isa(o: any): o is Alias {
-    return _smithy.isa(o, "Alias");
+    return __isa(o, "Alias");
   }
 }
 
@@ -155,7 +158,7 @@ export interface AttributeValue {
 
 export namespace AttributeValue {
   export function isa(o: any): o is AttributeValue {
-    return _smithy.isa(o, "AttributeValue");
+    return __isa(o, "AttributeValue");
   }
 }
 
@@ -185,7 +188,7 @@ export interface AwsCredentials {
 
 export namespace AwsCredentials {
   export function isa(o: any): o is AwsCredentials {
-    return _smithy.isa(o, "AwsCredentials");
+    return __isa(o, "AwsCredentials");
   }
 }
 
@@ -295,7 +298,7 @@ export interface Build {
 
 export namespace Build {
   export function isa(o: any): o is Build {
-    return _smithy.isa(o, "Build");
+    return __isa(o, "Build");
   }
 }
 
@@ -323,7 +326,7 @@ export interface CertificateConfiguration {
 
 export namespace CertificateConfiguration {
   export function isa(o: any): o is CertificateConfiguration {
-    return _smithy.isa(o, "CertificateConfiguration");
+    return __isa(o, "CertificateConfiguration");
   }
 }
 
@@ -344,9 +347,7 @@ export enum ComparisonOperatorType {
  *             resource associated with the request. Resolve the conflict before retrying this
  *             request.</p>
  */
-export interface ConflictException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface ConflictException extends __SmithyException, $MetadataBearer {
   name: "ConflictException";
   $fault: "client";
   Message?: string;
@@ -354,7 +355,7 @@ export interface ConflictException
 
 export namespace ConflictException {
   export function isa(o: any): o is ConflictException {
-    return _smithy.isa(o, "ConflictException");
+    return __isa(o, "ConflictException");
   }
 }
 
@@ -394,7 +395,7 @@ export interface CreateAliasInput {
 
 export namespace CreateAliasInput {
   export function isa(o: any): o is CreateAliasInput {
-    return _smithy.isa(o, "CreateAliasInput");
+    return __isa(o, "CreateAliasInput");
   }
 }
 
@@ -411,7 +412,7 @@ export interface CreateAliasOutput extends $MetadataBearer {
 
 export namespace CreateAliasOutput {
   export function isa(o: any): o is CreateAliasOutput {
-    return _smithy.isa(o, "CreateAliasOutput");
+    return __isa(o, "CreateAliasOutput");
   }
 }
 
@@ -466,7 +467,7 @@ export interface CreateBuildInput {
 
 export namespace CreateBuildInput {
   export function isa(o: any): o is CreateBuildInput {
-    return _smithy.isa(o, "CreateBuildInput");
+    return __isa(o, "CreateBuildInput");
   }
 }
 
@@ -497,7 +498,7 @@ export interface CreateBuildOutput extends $MetadataBearer {
 
 export namespace CreateBuildOutput {
   export function isa(o: any): o is CreateBuildOutput {
-    return _smithy.isa(o, "CreateBuildOutput");
+    return __isa(o, "CreateBuildOutput");
   }
 }
 
@@ -700,7 +701,7 @@ export interface CreateFleetInput {
 
 export namespace CreateFleetInput {
   export function isa(o: any): o is CreateFleetInput {
-    return _smithy.isa(o, "CreateFleetInput");
+    return __isa(o, "CreateFleetInput");
   }
 }
 
@@ -717,7 +718,7 @@ export interface CreateFleetOutput extends $MetadataBearer {
 
 export namespace CreateFleetOutput {
   export function isa(o: any): o is CreateFleetOutput {
-    return _smithy.isa(o, "CreateFleetOutput");
+    return __isa(o, "CreateFleetOutput");
   }
 }
 
@@ -791,7 +792,7 @@ export interface CreateGameSessionInput {
 
 export namespace CreateGameSessionInput {
   export function isa(o: any): o is CreateGameSessionInput {
-    return _smithy.isa(o, "CreateGameSessionInput");
+    return __isa(o, "CreateGameSessionInput");
   }
 }
 
@@ -808,7 +809,7 @@ export interface CreateGameSessionOutput extends $MetadataBearer {
 
 export namespace CreateGameSessionOutput {
   export function isa(o: any): o is CreateGameSessionOutput {
-    return _smithy.isa(o, "CreateGameSessionOutput");
+    return __isa(o, "CreateGameSessionOutput");
   }
 }
 
@@ -861,7 +862,7 @@ export interface CreateGameSessionQueueInput {
 
 export namespace CreateGameSessionQueueInput {
   export function isa(o: any): o is CreateGameSessionQueueInput {
-    return _smithy.isa(o, "CreateGameSessionQueueInput");
+    return __isa(o, "CreateGameSessionQueueInput");
   }
 }
 
@@ -878,7 +879,7 @@ export interface CreateGameSessionQueueOutput extends $MetadataBearer {
 
 export namespace CreateGameSessionQueueOutput {
   export function isa(o: any): o is CreateGameSessionQueueOutput {
-    return _smithy.isa(o, "CreateGameSessionQueueOutput");
+    return __isa(o, "CreateGameSessionQueueOutput");
   }
 }
 
@@ -989,7 +990,7 @@ export interface CreateMatchmakingConfigurationInput {
 
 export namespace CreateMatchmakingConfigurationInput {
   export function isa(o: any): o is CreateMatchmakingConfigurationInput {
-    return _smithy.isa(o, "CreateMatchmakingConfigurationInput");
+    return __isa(o, "CreateMatchmakingConfigurationInput");
   }
 }
 
@@ -1006,7 +1007,7 @@ export interface CreateMatchmakingConfigurationOutput extends $MetadataBearer {
 
 export namespace CreateMatchmakingConfigurationOutput {
   export function isa(o: any): o is CreateMatchmakingConfigurationOutput {
-    return _smithy.isa(o, "CreateMatchmakingConfigurationOutput");
+    return __isa(o, "CreateMatchmakingConfigurationOutput");
   }
 }
 
@@ -1044,7 +1045,7 @@ export interface CreateMatchmakingRuleSetInput {
 
 export namespace CreateMatchmakingRuleSetInput {
   export function isa(o: any): o is CreateMatchmakingRuleSetInput {
-    return _smithy.isa(o, "CreateMatchmakingRuleSetInput");
+    return __isa(o, "CreateMatchmakingRuleSetInput");
   }
 }
 
@@ -1061,7 +1062,7 @@ export interface CreateMatchmakingRuleSetOutput extends $MetadataBearer {
 
 export namespace CreateMatchmakingRuleSetOutput {
   export function isa(o: any): o is CreateMatchmakingRuleSetOutput {
-    return _smithy.isa(o, "CreateMatchmakingRuleSetOutput");
+    return __isa(o, "CreateMatchmakingRuleSetOutput");
   }
 }
 
@@ -1088,7 +1089,7 @@ export interface CreatePlayerSessionInput {
 
 export namespace CreatePlayerSessionInput {
   export function isa(o: any): o is CreatePlayerSessionInput {
-    return _smithy.isa(o, "CreatePlayerSessionInput");
+    return __isa(o, "CreatePlayerSessionInput");
   }
 }
 
@@ -1105,7 +1106,7 @@ export interface CreatePlayerSessionOutput extends $MetadataBearer {
 
 export namespace CreatePlayerSessionOutput {
   export function isa(o: any): o is CreatePlayerSessionOutput {
-    return _smithy.isa(o, "CreatePlayerSessionOutput");
+    return __isa(o, "CreatePlayerSessionOutput");
   }
 }
 
@@ -1135,7 +1136,7 @@ export interface CreatePlayerSessionsInput {
 
 export namespace CreatePlayerSessionsInput {
   export function isa(o: any): o is CreatePlayerSessionsInput {
-    return _smithy.isa(o, "CreatePlayerSessionsInput");
+    return __isa(o, "CreatePlayerSessionsInput");
   }
 }
 
@@ -1152,7 +1153,7 @@ export interface CreatePlayerSessionsOutput extends $MetadataBearer {
 
 export namespace CreatePlayerSessionsOutput {
   export function isa(o: any): o is CreatePlayerSessionsOutput {
-    return _smithy.isa(o, "CreatePlayerSessionsOutput");
+    return __isa(o, "CreatePlayerSessionsOutput");
   }
 }
 
@@ -1205,7 +1206,7 @@ export interface CreateScriptInput {
 
 export namespace CreateScriptInput {
   export function isa(o: any): o is CreateScriptInput {
-    return _smithy.isa(o, "CreateScriptInput");
+    return __isa(o, "CreateScriptInput");
   }
 }
 
@@ -1224,7 +1225,7 @@ export interface CreateScriptOutput extends $MetadataBearer {
 
 export namespace CreateScriptOutput {
   export function isa(o: any): o is CreateScriptOutput {
-    return _smithy.isa(o, "CreateScriptOutput");
+    return __isa(o, "CreateScriptOutput");
   }
 }
 
@@ -1250,7 +1251,7 @@ export interface CreateVpcPeeringAuthorizationInput {
 
 export namespace CreateVpcPeeringAuthorizationInput {
   export function isa(o: any): o is CreateVpcPeeringAuthorizationInput {
-    return _smithy.isa(o, "CreateVpcPeeringAuthorizationInput");
+    return __isa(o, "CreateVpcPeeringAuthorizationInput");
   }
 }
 
@@ -1267,7 +1268,7 @@ export interface CreateVpcPeeringAuthorizationOutput extends $MetadataBearer {
 
 export namespace CreateVpcPeeringAuthorizationOutput {
   export function isa(o: any): o is CreateVpcPeeringAuthorizationOutput {
-    return _smithy.isa(o, "CreateVpcPeeringAuthorizationOutput");
+    return __isa(o, "CreateVpcPeeringAuthorizationOutput");
   }
 }
 
@@ -1300,7 +1301,7 @@ export interface CreateVpcPeeringConnectionInput {
 
 export namespace CreateVpcPeeringConnectionInput {
   export function isa(o: any): o is CreateVpcPeeringConnectionInput {
-    return _smithy.isa(o, "CreateVpcPeeringConnectionInput");
+    return __isa(o, "CreateVpcPeeringConnectionInput");
   }
 }
 
@@ -1310,7 +1311,7 @@ export interface CreateVpcPeeringConnectionOutput extends $MetadataBearer {
 
 export namespace CreateVpcPeeringConnectionOutput {
   export function isa(o: any): o is CreateVpcPeeringConnectionOutput {
-    return _smithy.isa(o, "CreateVpcPeeringConnectionOutput");
+    return __isa(o, "CreateVpcPeeringConnectionOutput");
   }
 }
 
@@ -1328,7 +1329,7 @@ export interface DeleteAliasInput {
 
 export namespace DeleteAliasInput {
   export function isa(o: any): o is DeleteAliasInput {
-    return _smithy.isa(o, "DeleteAliasInput");
+    return __isa(o, "DeleteAliasInput");
   }
 }
 
@@ -1345,7 +1346,7 @@ export interface DeleteBuildInput {
 
 export namespace DeleteBuildInput {
   export function isa(o: any): o is DeleteBuildInput {
-    return _smithy.isa(o, "DeleteBuildInput");
+    return __isa(o, "DeleteBuildInput");
   }
 }
 
@@ -1362,7 +1363,7 @@ export interface DeleteFleetInput {
 
 export namespace DeleteFleetInput {
   export function isa(o: any): o is DeleteFleetInput {
-    return _smithy.isa(o, "DeleteFleetInput");
+    return __isa(o, "DeleteFleetInput");
   }
 }
 
@@ -1379,7 +1380,7 @@ export interface DeleteGameSessionQueueInput {
 
 export namespace DeleteGameSessionQueueInput {
   export function isa(o: any): o is DeleteGameSessionQueueInput {
-    return _smithy.isa(o, "DeleteGameSessionQueueInput");
+    return __isa(o, "DeleteGameSessionQueueInput");
   }
 }
 
@@ -1389,7 +1390,7 @@ export interface DeleteGameSessionQueueOutput extends $MetadataBearer {
 
 export namespace DeleteGameSessionQueueOutput {
   export function isa(o: any): o is DeleteGameSessionQueueOutput {
-    return _smithy.isa(o, "DeleteGameSessionQueueOutput");
+    return __isa(o, "DeleteGameSessionQueueOutput");
   }
 }
 
@@ -1406,7 +1407,7 @@ export interface DeleteMatchmakingConfigurationInput {
 
 export namespace DeleteMatchmakingConfigurationInput {
   export function isa(o: any): o is DeleteMatchmakingConfigurationInput {
-    return _smithy.isa(o, "DeleteMatchmakingConfigurationInput");
+    return __isa(o, "DeleteMatchmakingConfigurationInput");
   }
 }
 
@@ -1416,7 +1417,7 @@ export interface DeleteMatchmakingConfigurationOutput extends $MetadataBearer {
 
 export namespace DeleteMatchmakingConfigurationOutput {
   export function isa(o: any): o is DeleteMatchmakingConfigurationOutput {
-    return _smithy.isa(o, "DeleteMatchmakingConfigurationOutput");
+    return __isa(o, "DeleteMatchmakingConfigurationOutput");
   }
 }
 
@@ -1434,7 +1435,7 @@ export interface DeleteMatchmakingRuleSetInput {
 
 export namespace DeleteMatchmakingRuleSetInput {
   export function isa(o: any): o is DeleteMatchmakingRuleSetInput {
-    return _smithy.isa(o, "DeleteMatchmakingRuleSetInput");
+    return __isa(o, "DeleteMatchmakingRuleSetInput");
   }
 }
 
@@ -1447,7 +1448,7 @@ export interface DeleteMatchmakingRuleSetOutput extends $MetadataBearer {
 
 export namespace DeleteMatchmakingRuleSetOutput {
   export function isa(o: any): o is DeleteMatchmakingRuleSetOutput {
-    return _smithy.isa(o, "DeleteMatchmakingRuleSetOutput");
+    return __isa(o, "DeleteMatchmakingRuleSetOutput");
   }
 }
 
@@ -1469,7 +1470,7 @@ export interface DeleteScalingPolicyInput {
 
 export namespace DeleteScalingPolicyInput {
   export function isa(o: any): o is DeleteScalingPolicyInput {
-    return _smithy.isa(o, "DeleteScalingPolicyInput");
+    return __isa(o, "DeleteScalingPolicyInput");
   }
 }
 
@@ -1483,7 +1484,7 @@ export interface DeleteScriptInput {
 
 export namespace DeleteScriptInput {
   export function isa(o: any): o is DeleteScriptInput {
-    return _smithy.isa(o, "DeleteScriptInput");
+    return __isa(o, "DeleteScriptInput");
   }
 }
 
@@ -1509,7 +1510,7 @@ export interface DeleteVpcPeeringAuthorizationInput {
 
 export namespace DeleteVpcPeeringAuthorizationInput {
   export function isa(o: any): o is DeleteVpcPeeringAuthorizationInput {
-    return _smithy.isa(o, "DeleteVpcPeeringAuthorizationInput");
+    return __isa(o, "DeleteVpcPeeringAuthorizationInput");
   }
 }
 
@@ -1519,7 +1520,7 @@ export interface DeleteVpcPeeringAuthorizationOutput extends $MetadataBearer {
 
 export namespace DeleteVpcPeeringAuthorizationOutput {
   export function isa(o: any): o is DeleteVpcPeeringAuthorizationOutput {
-    return _smithy.isa(o, "DeleteVpcPeeringAuthorizationOutput");
+    return __isa(o, "DeleteVpcPeeringAuthorizationOutput");
   }
 }
 
@@ -1542,7 +1543,7 @@ export interface DeleteVpcPeeringConnectionInput {
 
 export namespace DeleteVpcPeeringConnectionInput {
   export function isa(o: any): o is DeleteVpcPeeringConnectionInput {
-    return _smithy.isa(o, "DeleteVpcPeeringConnectionInput");
+    return __isa(o, "DeleteVpcPeeringConnectionInput");
   }
 }
 
@@ -1552,7 +1553,7 @@ export interface DeleteVpcPeeringConnectionOutput extends $MetadataBearer {
 
 export namespace DeleteVpcPeeringConnectionOutput {
   export function isa(o: any): o is DeleteVpcPeeringConnectionOutput {
-    return _smithy.isa(o, "DeleteVpcPeeringConnectionOutput");
+    return __isa(o, "DeleteVpcPeeringConnectionOutput");
   }
 }
 
@@ -1570,7 +1571,7 @@ export interface DescribeAliasInput {
 
 export namespace DescribeAliasInput {
   export function isa(o: any): o is DescribeAliasInput {
-    return _smithy.isa(o, "DescribeAliasInput");
+    return __isa(o, "DescribeAliasInput");
   }
 }
 
@@ -1587,7 +1588,7 @@ export interface DescribeAliasOutput extends $MetadataBearer {
 
 export namespace DescribeAliasOutput {
   export function isa(o: any): o is DescribeAliasOutput {
-    return _smithy.isa(o, "DescribeAliasOutput");
+    return __isa(o, "DescribeAliasOutput");
   }
 }
 
@@ -1604,7 +1605,7 @@ export interface DescribeBuildInput {
 
 export namespace DescribeBuildInput {
   export function isa(o: any): o is DescribeBuildInput {
-    return _smithy.isa(o, "DescribeBuildInput");
+    return __isa(o, "DescribeBuildInput");
   }
 }
 
@@ -1621,7 +1622,7 @@ export interface DescribeBuildOutput extends $MetadataBearer {
 
 export namespace DescribeBuildOutput {
   export function isa(o: any): o is DescribeBuildOutput {
-    return _smithy.isa(o, "DescribeBuildOutput");
+    return __isa(o, "DescribeBuildOutput");
   }
 }
 
@@ -1643,7 +1644,7 @@ export interface DescribeEC2InstanceLimitsInput {
 
 export namespace DescribeEC2InstanceLimitsInput {
   export function isa(o: any): o is DescribeEC2InstanceLimitsInput {
-    return _smithy.isa(o, "DescribeEC2InstanceLimitsInput");
+    return __isa(o, "DescribeEC2InstanceLimitsInput");
   }
 }
 
@@ -1661,7 +1662,7 @@ export interface DescribeEC2InstanceLimitsOutput extends $MetadataBearer {
 
 export namespace DescribeEC2InstanceLimitsOutput {
   export function isa(o: any): o is DescribeEC2InstanceLimitsOutput {
-    return _smithy.isa(o, "DescribeEC2InstanceLimitsOutput");
+    return __isa(o, "DescribeEC2InstanceLimitsOutput");
   }
 }
 
@@ -1691,7 +1692,7 @@ export interface DescribeFleetAttributesInput {
 
 export namespace DescribeFleetAttributesInput {
   export function isa(o: any): o is DescribeFleetAttributesInput {
-    return _smithy.isa(o, "DescribeFleetAttributesInput");
+    return __isa(o, "DescribeFleetAttributesInput");
   }
 }
 
@@ -1714,7 +1715,7 @@ export interface DescribeFleetAttributesOutput extends $MetadataBearer {
 
 export namespace DescribeFleetAttributesOutput {
   export function isa(o: any): o is DescribeFleetAttributesOutput {
-    return _smithy.isa(o, "DescribeFleetAttributesOutput");
+    return __isa(o, "DescribeFleetAttributesOutput");
   }
 }
 
@@ -1744,7 +1745,7 @@ export interface DescribeFleetCapacityInput {
 
 export namespace DescribeFleetCapacityInput {
   export function isa(o: any): o is DescribeFleetCapacityInput {
-    return _smithy.isa(o, "DescribeFleetCapacityInput");
+    return __isa(o, "DescribeFleetCapacityInput");
   }
 }
 
@@ -1767,7 +1768,7 @@ export interface DescribeFleetCapacityOutput extends $MetadataBearer {
 
 export namespace DescribeFleetCapacityOutput {
   export function isa(o: any): o is DescribeFleetCapacityOutput {
-    return _smithy.isa(o, "DescribeFleetCapacityOutput");
+    return __isa(o, "DescribeFleetCapacityOutput");
   }
 }
 
@@ -1809,7 +1810,7 @@ export interface DescribeFleetEventsInput {
 
 export namespace DescribeFleetEventsInput {
   export function isa(o: any): o is DescribeFleetEventsInput {
-    return _smithy.isa(o, "DescribeFleetEventsInput");
+    return __isa(o, "DescribeFleetEventsInput");
   }
 }
 
@@ -1832,7 +1833,7 @@ export interface DescribeFleetEventsOutput extends $MetadataBearer {
 
 export namespace DescribeFleetEventsOutput {
   export function isa(o: any): o is DescribeFleetEventsOutput {
-    return _smithy.isa(o, "DescribeFleetEventsOutput");
+    return __isa(o, "DescribeFleetEventsOutput");
   }
 }
 
@@ -1850,7 +1851,7 @@ export interface DescribeFleetPortSettingsInput {
 
 export namespace DescribeFleetPortSettingsInput {
   export function isa(o: any): o is DescribeFleetPortSettingsInput {
-    return _smithy.isa(o, "DescribeFleetPortSettingsInput");
+    return __isa(o, "DescribeFleetPortSettingsInput");
   }
 }
 
@@ -1867,7 +1868,7 @@ export interface DescribeFleetPortSettingsOutput extends $MetadataBearer {
 
 export namespace DescribeFleetPortSettingsOutput {
   export function isa(o: any): o is DescribeFleetPortSettingsOutput {
-    return _smithy.isa(o, "DescribeFleetPortSettingsOutput");
+    return __isa(o, "DescribeFleetPortSettingsOutput");
   }
 }
 
@@ -1897,7 +1898,7 @@ export interface DescribeFleetUtilizationInput {
 
 export namespace DescribeFleetUtilizationInput {
   export function isa(o: any): o is DescribeFleetUtilizationInput {
-    return _smithy.isa(o, "DescribeFleetUtilizationInput");
+    return __isa(o, "DescribeFleetUtilizationInput");
   }
 }
 
@@ -1920,7 +1921,7 @@ export interface DescribeFleetUtilizationOutput extends $MetadataBearer {
 
 export namespace DescribeFleetUtilizationOutput {
   export function isa(o: any): o is DescribeFleetUtilizationOutput {
-    return _smithy.isa(o, "DescribeFleetUtilizationOutput");
+    return __isa(o, "DescribeFleetUtilizationOutput");
   }
 }
 
@@ -1966,7 +1967,7 @@ export interface DescribeGameSessionDetailsInput {
 
 export namespace DescribeGameSessionDetailsInput {
   export function isa(o: any): o is DescribeGameSessionDetailsInput {
-    return _smithy.isa(o, "DescribeGameSessionDetailsInput");
+    return __isa(o, "DescribeGameSessionDetailsInput");
   }
 }
 
@@ -1989,7 +1990,7 @@ export interface DescribeGameSessionDetailsOutput extends $MetadataBearer {
 
 export namespace DescribeGameSessionDetailsOutput {
   export function isa(o: any): o is DescribeGameSessionDetailsOutput {
-    return _smithy.isa(o, "DescribeGameSessionDetailsOutput");
+    return __isa(o, "DescribeGameSessionDetailsOutput");
   }
 }
 
@@ -2006,7 +2007,7 @@ export interface DescribeGameSessionPlacementInput {
 
 export namespace DescribeGameSessionPlacementInput {
   export function isa(o: any): o is DescribeGameSessionPlacementInput {
-    return _smithy.isa(o, "DescribeGameSessionPlacementInput");
+    return __isa(o, "DescribeGameSessionPlacementInput");
   }
 }
 
@@ -2023,7 +2024,7 @@ export interface DescribeGameSessionPlacementOutput extends $MetadataBearer {
 
 export namespace DescribeGameSessionPlacementOutput {
   export function isa(o: any): o is DescribeGameSessionPlacementOutput {
-    return _smithy.isa(o, "DescribeGameSessionPlacementOutput");
+    return __isa(o, "DescribeGameSessionPlacementOutput");
   }
 }
 
@@ -2051,7 +2052,7 @@ export interface DescribeGameSessionQueuesInput {
 
 export namespace DescribeGameSessionQueuesInput {
   export function isa(o: any): o is DescribeGameSessionQueuesInput {
-    return _smithy.isa(o, "DescribeGameSessionQueuesInput");
+    return __isa(o, "DescribeGameSessionQueuesInput");
   }
 }
 
@@ -2073,7 +2074,7 @@ export interface DescribeGameSessionQueuesOutput extends $MetadataBearer {
 
 export namespace DescribeGameSessionQueuesOutput {
   export function isa(o: any): o is DescribeGameSessionQueuesOutput {
-    return _smithy.isa(o, "DescribeGameSessionQueuesOutput");
+    return __isa(o, "DescribeGameSessionQueuesOutput");
   }
 }
 
@@ -2118,7 +2119,7 @@ export interface DescribeGameSessionsInput {
 
 export namespace DescribeGameSessionsInput {
   export function isa(o: any): o is DescribeGameSessionsInput {
-    return _smithy.isa(o, "DescribeGameSessionsInput");
+    return __isa(o, "DescribeGameSessionsInput");
   }
 }
 
@@ -2141,7 +2142,7 @@ export interface DescribeGameSessionsOutput extends $MetadataBearer {
 
 export namespace DescribeGameSessionsOutput {
   export function isa(o: any): o is DescribeGameSessionsOutput {
-    return _smithy.isa(o, "DescribeGameSessionsOutput");
+    return __isa(o, "DescribeGameSessionsOutput");
   }
 }
 
@@ -2175,7 +2176,7 @@ export interface DescribeInstancesInput {
 
 export namespace DescribeInstancesInput {
   export function isa(o: any): o is DescribeInstancesInput {
-    return _smithy.isa(o, "DescribeInstancesInput");
+    return __isa(o, "DescribeInstancesInput");
   }
 }
 
@@ -2197,7 +2198,7 @@ export interface DescribeInstancesOutput extends $MetadataBearer {
 
 export namespace DescribeInstancesOutput {
   export function isa(o: any): o is DescribeInstancesOutput {
-    return _smithy.isa(o, "DescribeInstancesOutput");
+    return __isa(o, "DescribeInstancesOutput");
   }
 }
 
@@ -2231,7 +2232,7 @@ export interface DescribeMatchmakingConfigurationsInput {
 
 export namespace DescribeMatchmakingConfigurationsInput {
   export function isa(o: any): o is DescribeMatchmakingConfigurationsInput {
-    return _smithy.isa(o, "DescribeMatchmakingConfigurationsInput");
+    return __isa(o, "DescribeMatchmakingConfigurationsInput");
   }
 }
 
@@ -2254,7 +2255,7 @@ export interface DescribeMatchmakingConfigurationsOutput
 
 export namespace DescribeMatchmakingConfigurationsOutput {
   export function isa(o: any): o is DescribeMatchmakingConfigurationsOutput {
-    return _smithy.isa(o, "DescribeMatchmakingConfigurationsOutput");
+    return __isa(o, "DescribeMatchmakingConfigurationsOutput");
   }
 }
 
@@ -2271,7 +2272,7 @@ export interface DescribeMatchmakingInput {
 
 export namespace DescribeMatchmakingInput {
   export function isa(o: any): o is DescribeMatchmakingInput {
-    return _smithy.isa(o, "DescribeMatchmakingInput");
+    return __isa(o, "DescribeMatchmakingInput");
   }
 }
 
@@ -2288,7 +2289,7 @@ export interface DescribeMatchmakingOutput extends $MetadataBearer {
 
 export namespace DescribeMatchmakingOutput {
   export function isa(o: any): o is DescribeMatchmakingOutput {
-    return _smithy.isa(o, "DescribeMatchmakingOutput");
+    return __isa(o, "DescribeMatchmakingOutput");
   }
 }
 
@@ -2317,7 +2318,7 @@ export interface DescribeMatchmakingRuleSetsInput {
 
 export namespace DescribeMatchmakingRuleSetsInput {
   export function isa(o: any): o is DescribeMatchmakingRuleSetsInput {
-    return _smithy.isa(o, "DescribeMatchmakingRuleSetsInput");
+    return __isa(o, "DescribeMatchmakingRuleSetsInput");
   }
 }
 
@@ -2339,7 +2340,7 @@ export interface DescribeMatchmakingRuleSetsOutput extends $MetadataBearer {
 
 export namespace DescribeMatchmakingRuleSetsOutput {
   export function isa(o: any): o is DescribeMatchmakingRuleSetsOutput {
-    return _smithy.isa(o, "DescribeMatchmakingRuleSetsOutput");
+    return __isa(o, "DescribeMatchmakingRuleSetsOutput");
   }
 }
 
@@ -2406,7 +2407,7 @@ export interface DescribePlayerSessionsInput {
 
 export namespace DescribePlayerSessionsInput {
   export function isa(o: any): o is DescribePlayerSessionsInput {
-    return _smithy.isa(o, "DescribePlayerSessionsInput");
+    return __isa(o, "DescribePlayerSessionsInput");
   }
 }
 
@@ -2429,7 +2430,7 @@ export interface DescribePlayerSessionsOutput extends $MetadataBearer {
 
 export namespace DescribePlayerSessionsOutput {
   export function isa(o: any): o is DescribePlayerSessionsOutput {
-    return _smithy.isa(o, "DescribePlayerSessionsOutput");
+    return __isa(o, "DescribePlayerSessionsOutput");
   }
 }
 
@@ -2447,7 +2448,7 @@ export interface DescribeRuntimeConfigurationInput {
 
 export namespace DescribeRuntimeConfigurationInput {
   export function isa(o: any): o is DescribeRuntimeConfigurationInput {
-    return _smithy.isa(o, "DescribeRuntimeConfigurationInput");
+    return __isa(o, "DescribeRuntimeConfigurationInput");
   }
 }
 
@@ -2465,7 +2466,7 @@ export interface DescribeRuntimeConfigurationOutput extends $MetadataBearer {
 
 export namespace DescribeRuntimeConfigurationOutput {
   export function isa(o: any): o is DescribeRuntimeConfigurationOutput {
-    return _smithy.isa(o, "DescribeRuntimeConfigurationOutput");
+    return __isa(o, "DescribeRuntimeConfigurationOutput");
   }
 }
 
@@ -2536,7 +2537,7 @@ export interface DescribeScalingPoliciesInput {
 
 export namespace DescribeScalingPoliciesInput {
   export function isa(o: any): o is DescribeScalingPoliciesInput {
-    return _smithy.isa(o, "DescribeScalingPoliciesInput");
+    return __isa(o, "DescribeScalingPoliciesInput");
   }
 }
 
@@ -2559,7 +2560,7 @@ export interface DescribeScalingPoliciesOutput extends $MetadataBearer {
 
 export namespace DescribeScalingPoliciesOutput {
   export function isa(o: any): o is DescribeScalingPoliciesOutput {
-    return _smithy.isa(o, "DescribeScalingPoliciesOutput");
+    return __isa(o, "DescribeScalingPoliciesOutput");
   }
 }
 
@@ -2574,7 +2575,7 @@ export interface DescribeScriptInput {
 
 export namespace DescribeScriptInput {
   export function isa(o: any): o is DescribeScriptInput {
-    return _smithy.isa(o, "DescribeScriptInput");
+    return __isa(o, "DescribeScriptInput");
   }
 }
 
@@ -2588,7 +2589,7 @@ export interface DescribeScriptOutput extends $MetadataBearer {
 
 export namespace DescribeScriptOutput {
   export function isa(o: any): o is DescribeScriptOutput {
-    return _smithy.isa(o, "DescribeScriptOutput");
+    return __isa(o, "DescribeScriptOutput");
   }
 }
 
@@ -2598,7 +2599,7 @@ export interface DescribeVpcPeeringAuthorizationsInput {
 
 export namespace DescribeVpcPeeringAuthorizationsInput {
   export function isa(o: any): o is DescribeVpcPeeringAuthorizationsInput {
-    return _smithy.isa(o, "DescribeVpcPeeringAuthorizationsInput");
+    return __isa(o, "DescribeVpcPeeringAuthorizationsInput");
   }
 }
 
@@ -2614,7 +2615,7 @@ export interface DescribeVpcPeeringAuthorizationsOutput
 
 export namespace DescribeVpcPeeringAuthorizationsOutput {
   export function isa(o: any): o is DescribeVpcPeeringAuthorizationsOutput {
-    return _smithy.isa(o, "DescribeVpcPeeringAuthorizationsOutput");
+    return __isa(o, "DescribeVpcPeeringAuthorizationsOutput");
   }
 }
 
@@ -2631,7 +2632,7 @@ export interface DescribeVpcPeeringConnectionsInput {
 
 export namespace DescribeVpcPeeringConnectionsInput {
   export function isa(o: any): o is DescribeVpcPeeringConnectionsInput {
-    return _smithy.isa(o, "DescribeVpcPeeringConnectionsInput");
+    return __isa(o, "DescribeVpcPeeringConnectionsInput");
   }
 }
 
@@ -2648,7 +2649,7 @@ export interface DescribeVpcPeeringConnectionsOutput extends $MetadataBearer {
 
 export namespace DescribeVpcPeeringConnectionsOutput {
   export function isa(o: any): o is DescribeVpcPeeringConnectionsOutput {
-    return _smithy.isa(o, "DescribeVpcPeeringConnectionsOutput");
+    return __isa(o, "DescribeVpcPeeringConnectionsOutput");
   }
 }
 
@@ -2671,7 +2672,7 @@ export interface DesiredPlayerSession {
 
 export namespace DesiredPlayerSession {
   export function isa(o: any): o is DesiredPlayerSession {
-    return _smithy.isa(o, "DesiredPlayerSession");
+    return __isa(o, "DesiredPlayerSession");
   }
 }
 
@@ -2765,7 +2766,7 @@ export interface EC2InstanceCounts {
 
 export namespace EC2InstanceCounts {
   export function isa(o: any): o is EC2InstanceCounts {
-    return _smithy.isa(o, "EC2InstanceCounts");
+    return __isa(o, "EC2InstanceCounts");
   }
 }
 
@@ -2798,7 +2799,7 @@ export interface EC2InstanceLimit {
 
 export namespace EC2InstanceLimit {
   export function isa(o: any): o is EC2InstanceLimit {
-    return _smithy.isa(o, "EC2InstanceLimit");
+    return __isa(o, "EC2InstanceLimit");
   }
 }
 
@@ -3038,7 +3039,7 @@ export interface Event {
 
 export namespace Event {
   export function isa(o: any): o is Event {
-    return _smithy.isa(o, "Event");
+    return __isa(o, "Event");
   }
 }
 
@@ -3323,7 +3324,7 @@ export interface FleetAttributes {
 
 export namespace FleetAttributes {
   export function isa(o: any): o is FleetAttributes {
-    return _smithy.isa(o, "FleetAttributes");
+    return __isa(o, "FleetAttributes");
   }
 }
 
@@ -3399,7 +3400,7 @@ export interface FleetCapacity {
 
 export namespace FleetCapacity {
   export function isa(o: any): o is FleetCapacity {
-    return _smithy.isa(o, "FleetCapacity");
+    return __isa(o, "FleetCapacity");
   }
 }
 
@@ -3409,7 +3410,7 @@ export namespace FleetCapacity {
  *             or after a waiting period.</p>
  */
 export interface FleetCapacityExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "FleetCapacityExceededException";
   $fault: "client";
@@ -3418,7 +3419,7 @@ export interface FleetCapacityExceededException
 
 export namespace FleetCapacityExceededException {
   export function isa(o: any): o is FleetCapacityExceededException {
-    return _smithy.isa(o, "FleetCapacityExceededException");
+    return __isa(o, "FleetCapacityExceededException");
   }
 }
 
@@ -3519,7 +3520,7 @@ export interface FleetUtilization {
 
 export namespace FleetUtilization {
   export function isa(o: any): o is FleetUtilization {
-    return _smithy.isa(o, "FleetUtilization");
+    return __isa(o, "FleetUtilization");
   }
 }
 
@@ -3545,7 +3546,7 @@ export interface GameProperty {
 
 export namespace GameProperty {
   export function isa(o: any): o is GameProperty {
-    return _smithy.isa(o, "GameProperty");
+    return __isa(o, "GameProperty");
   }
 }
 
@@ -3730,7 +3731,7 @@ export interface GameSession {
 
 export namespace GameSession {
   export function isa(o: any): o is GameSession {
-    return _smithy.isa(o, "GameSession");
+    return __isa(o, "GameSession");
   }
 }
 
@@ -3784,7 +3785,7 @@ export interface GameSessionConnectionInfo {
 
 export namespace GameSessionConnectionInfo {
   export function isa(o: any): o is GameSessionConnectionInfo {
-    return _smithy.isa(o, "GameSessionConnectionInfo");
+    return __isa(o, "GameSessionConnectionInfo");
   }
 }
 
@@ -3820,7 +3821,7 @@ export interface GameSessionDetail {
 
 export namespace GameSessionDetail {
   export function isa(o: any): o is GameSessionDetail {
-    return _smithy.isa(o, "GameSessionDetail");
+    return __isa(o, "GameSessionDetail");
   }
 }
 
@@ -3829,7 +3830,7 @@ export namespace GameSessionDetail {
  *             join. Clients can retry such requests immediately or after a waiting period.</p>
  */
 export interface GameSessionFullException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "GameSessionFullException";
   $fault: "client";
@@ -3838,7 +3839,7 @@ export interface GameSessionFullException
 
 export namespace GameSessionFullException {
   export function isa(o: any): o is GameSessionFullException {
-    return _smithy.isa(o, "GameSessionFullException");
+    return __isa(o, "GameSessionFullException");
   }
 }
 
@@ -4022,7 +4023,7 @@ export interface GameSessionPlacement {
 
 export namespace GameSessionPlacement {
   export function isa(o: any): o is GameSessionPlacement {
-    return _smithy.isa(o, "GameSessionPlacement");
+    return __isa(o, "GameSessionPlacement");
   }
 }
 
@@ -4115,7 +4116,7 @@ export interface GameSessionQueue {
 
 export namespace GameSessionQueue {
   export function isa(o: any): o is GameSessionQueue {
-    return _smithy.isa(o, "GameSessionQueue");
+    return __isa(o, "GameSessionQueue");
   }
 }
 
@@ -4158,7 +4159,7 @@ export interface GameSessionQueueDestination {
 
 export namespace GameSessionQueueDestination {
   export function isa(o: any): o is GameSessionQueueDestination {
-    return _smithy.isa(o, "GameSessionQueueDestination");
+    return __isa(o, "GameSessionQueueDestination");
   }
 }
 
@@ -4187,7 +4188,7 @@ export interface GetGameSessionLogUrlInput {
 
 export namespace GetGameSessionLogUrlInput {
   export function isa(o: any): o is GetGameSessionLogUrlInput {
-    return _smithy.isa(o, "GetGameSessionLogUrlInput");
+    return __isa(o, "GetGameSessionLogUrlInput");
   }
 }
 
@@ -4207,7 +4208,7 @@ export interface GetGameSessionLogUrlOutput extends $MetadataBearer {
 
 export namespace GetGameSessionLogUrlOutput {
   export function isa(o: any): o is GetGameSessionLogUrlOutput {
-    return _smithy.isa(o, "GetGameSessionLogUrlOutput");
+    return __isa(o, "GetGameSessionLogUrlOutput");
   }
 }
 
@@ -4234,7 +4235,7 @@ export interface GetInstanceAccessInput {
 
 export namespace GetInstanceAccessInput {
   export function isa(o: any): o is GetInstanceAccessInput {
-    return _smithy.isa(o, "GetInstanceAccessInput");
+    return __isa(o, "GetInstanceAccessInput");
   }
 }
 
@@ -4252,7 +4253,7 @@ export interface GetInstanceAccessOutput extends $MetadataBearer {
 
 export namespace GetInstanceAccessOutput {
   export function isa(o: any): o is GetInstanceAccessOutput {
-    return _smithy.isa(o, "GetInstanceAccessOutput");
+    return __isa(o, "GetInstanceAccessOutput");
   }
 }
 
@@ -4261,7 +4262,7 @@ export namespace GetInstanceAccessOutput {
  *             this conflict before retrying this request.</p>
  */
 export interface IdempotentParameterMismatchException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "IdempotentParameterMismatchException";
   $fault: "client";
@@ -4270,7 +4271,7 @@ export interface IdempotentParameterMismatchException
 
 export namespace IdempotentParameterMismatchException {
   export function isa(o: any): o is IdempotentParameterMismatchException {
-    return _smithy.isa(o, "IdempotentParameterMismatchException");
+    return __isa(o, "IdempotentParameterMismatchException");
   }
 }
 
@@ -4356,7 +4357,7 @@ export interface Instance {
 
 export namespace Instance {
   export function isa(o: any): o is Instance {
-    return _smithy.isa(o, "Instance");
+    return __isa(o, "Instance");
   }
 }
 
@@ -4394,7 +4395,7 @@ export interface InstanceAccess {
 
 export namespace InstanceAccess {
   export function isa(o: any): o is InstanceAccess {
-    return _smithy.isa(o, "InstanceAccess");
+    return __isa(o, "InstanceAccess");
   }
 }
 
@@ -4419,7 +4420,7 @@ export interface InstanceCredentials {
 
 export namespace InstanceCredentials {
   export function isa(o: any): o is InstanceCredentials {
-    return _smithy.isa(o, "InstanceCredentials");
+    return __isa(o, "InstanceCredentials");
   }
 }
 
@@ -4435,7 +4436,7 @@ export enum InstanceStatus {
  *             period.</p>
  */
 export interface InternalServiceException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalServiceException";
   $fault: "server";
@@ -4444,7 +4445,7 @@ export interface InternalServiceException
 
 export namespace InternalServiceException {
   export function isa(o: any): o is InternalServiceException {
-    return _smithy.isa(o, "InternalServiceException");
+    return __isa(o, "InternalServiceException");
   }
 }
 
@@ -4454,7 +4455,7 @@ export namespace InternalServiceException {
  *             retrying.</p>
  */
 export interface InvalidFleetStatusException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidFleetStatusException";
   $fault: "client";
@@ -4463,7 +4464,7 @@ export interface InvalidFleetStatusException
 
 export namespace InvalidFleetStatusException {
   export function isa(o: any): o is InvalidFleetStatusException {
-    return _smithy.isa(o, "InvalidFleetStatusException");
+    return __isa(o, "InvalidFleetStatusException");
   }
 }
 
@@ -4473,7 +4474,7 @@ export namespace InvalidFleetStatusException {
  *             retrying.</p>
  */
 export interface InvalidGameSessionStatusException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidGameSessionStatusException";
   $fault: "client";
@@ -4482,7 +4483,7 @@ export interface InvalidGameSessionStatusException
 
 export namespace InvalidGameSessionStatusException {
   export function isa(o: any): o is InvalidGameSessionStatusException {
-    return _smithy.isa(o, "InvalidGameSessionStatusException");
+    return __isa(o, "InvalidGameSessionStatusException");
   }
 }
 
@@ -4491,7 +4492,7 @@ export namespace InvalidGameSessionStatusException {
  *             parameter values before retrying.</p>
  */
 export interface InvalidRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidRequestException";
   $fault: "client";
@@ -4500,7 +4501,7 @@ export interface InvalidRequestException
 
 export namespace InvalidRequestException {
   export function isa(o: any): o is InvalidRequestException {
-    return _smithy.isa(o, "InvalidRequestException");
+    return __isa(o, "InvalidRequestException");
   }
 }
 
@@ -4540,7 +4541,7 @@ export interface IpPermission {
 
 export namespace IpPermission {
   export function isa(o: any): o is IpPermission {
-    return _smithy.isa(o, "IpPermission");
+    return __isa(o, "IpPermission");
   }
 }
 
@@ -4554,7 +4555,7 @@ export enum IpProtocol {
  *             limit. Resolve the issue before retrying.</p>
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -4563,7 +4564,7 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
@@ -4610,7 +4611,7 @@ export interface ListAliasesInput {
 
 export namespace ListAliasesInput {
   export function isa(o: any): o is ListAliasesInput {
-    return _smithy.isa(o, "ListAliasesInput");
+    return __isa(o, "ListAliasesInput");
   }
 }
 
@@ -4632,7 +4633,7 @@ export interface ListAliasesOutput extends $MetadataBearer {
 
 export namespace ListAliasesOutput {
   export function isa(o: any): o is ListAliasesOutput {
-    return _smithy.isa(o, "ListAliasesOutput");
+    return __isa(o, "ListAliasesOutput");
   }
 }
 
@@ -4680,7 +4681,7 @@ export interface ListBuildsInput {
 
 export namespace ListBuildsInput {
   export function isa(o: any): o is ListBuildsInput {
-    return _smithy.isa(o, "ListBuildsInput");
+    return __isa(o, "ListBuildsInput");
   }
 }
 
@@ -4702,7 +4703,7 @@ export interface ListBuildsOutput extends $MetadataBearer {
 
 export namespace ListBuildsOutput {
   export function isa(o: any): o is ListBuildsOutput {
-    return _smithy.isa(o, "ListBuildsOutput");
+    return __isa(o, "ListBuildsOutput");
   }
 }
 
@@ -4738,7 +4739,7 @@ export interface ListFleetsInput {
 
 export namespace ListFleetsInput {
   export function isa(o: any): o is ListFleetsInput {
-    return _smithy.isa(o, "ListFleetsInput");
+    return __isa(o, "ListFleetsInput");
   }
 }
 
@@ -4762,7 +4763,7 @@ export interface ListFleetsOutput extends $MetadataBearer {
 
 export namespace ListFleetsOutput {
   export function isa(o: any): o is ListFleetsOutput {
-    return _smithy.isa(o, "ListFleetsOutput");
+    return __isa(o, "ListFleetsOutput");
   }
 }
 
@@ -4781,7 +4782,7 @@ export interface ListScriptsInput {
 
 export namespace ListScriptsInput {
   export function isa(o: any): o is ListScriptsInput {
-    return _smithy.isa(o, "ListScriptsInput");
+    return __isa(o, "ListScriptsInput");
   }
 }
 
@@ -4800,7 +4801,7 @@ export interface ListScriptsOutput extends $MetadataBearer {
 
 export namespace ListScriptsOutput {
   export function isa(o: any): o is ListScriptsOutput {
-    return _smithy.isa(o, "ListScriptsOutput");
+    return __isa(o, "ListScriptsOutput");
   }
 }
 
@@ -4819,7 +4820,7 @@ export interface ListTagsForResourceRequest {
 
 export namespace ListTagsForResourceRequest {
   export function isa(o: any): o is ListTagsForResourceRequest {
-    return _smithy.isa(o, "ListTagsForResourceRequest");
+    return __isa(o, "ListTagsForResourceRequest");
   }
 }
 
@@ -4835,7 +4836,7 @@ export interface ListTagsForResourceResponse extends $MetadataBearer {
 
 export namespace ListTagsForResourceResponse {
   export function isa(o: any): o is ListTagsForResourceResponse {
-    return _smithy.isa(o, "ListTagsForResourceResponse");
+    return __isa(o, "ListTagsForResourceResponse");
   }
 }
 
@@ -4861,7 +4862,7 @@ export interface MatchedPlayerSession {
 
 export namespace MatchedPlayerSession {
   export function isa(o: any): o is MatchedPlayerSession {
-    return _smithy.isa(o, "MatchedPlayerSession");
+    return __isa(o, "MatchedPlayerSession");
   }
 }
 
@@ -4972,7 +4973,7 @@ export interface MatchmakingConfiguration {
 
 export namespace MatchmakingConfiguration {
   export function isa(o: any): o is MatchmakingConfiguration {
-    return _smithy.isa(o, "MatchmakingConfiguration");
+    return __isa(o, "MatchmakingConfiguration");
   }
 }
 
@@ -5052,7 +5053,7 @@ export interface MatchmakingRuleSet {
 
 export namespace MatchmakingRuleSet {
   export function isa(o: any): o is MatchmakingRuleSet {
-    return _smithy.isa(o, "MatchmakingRuleSet");
+    return __isa(o, "MatchmakingRuleSet");
   }
 }
 
@@ -5186,7 +5187,7 @@ export interface MatchmakingTicket {
 
 export namespace MatchmakingTicket {
   export function isa(o: any): o is MatchmakingTicket {
-    return _smithy.isa(o, "MatchmakingTicket");
+    return __isa(o, "MatchmakingTicket");
   }
 }
 
@@ -5207,9 +5208,7 @@ export type MetricName =
  * <p>A service resource associated with the request could not be found. Clients should
  *             not retry such requests.</p>
  */
-export interface NotFoundException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface NotFoundException extends __SmithyException, $MetadataBearer {
   name: "NotFoundException";
   $fault: "client";
   Message?: string;
@@ -5217,7 +5216,7 @@ export interface NotFoundException
 
 export namespace NotFoundException {
   export function isa(o: any): o is NotFoundException {
-    return _smithy.isa(o, "NotFoundException");
+    return __isa(o, "NotFoundException");
   }
 }
 
@@ -5283,7 +5282,7 @@ export interface PlacedPlayerSession {
 
 export namespace PlacedPlayerSession {
   export function isa(o: any): o is PlacedPlayerSession {
-    return _smithy.isa(o, "PlacedPlayerSession");
+    return __isa(o, "PlacedPlayerSession");
   }
 }
 
@@ -5326,7 +5325,7 @@ export interface Player {
 
 export namespace Player {
   export function isa(o: any): o is Player {
-    return _smithy.isa(o, "Player");
+    return __isa(o, "Player");
   }
 }
 
@@ -5359,7 +5358,7 @@ export interface PlayerLatency {
 
 export namespace PlayerLatency {
   export function isa(o: any): o is PlayerLatency {
-    return _smithy.isa(o, "PlayerLatency");
+    return __isa(o, "PlayerLatency");
   }
 }
 
@@ -5410,7 +5409,7 @@ export interface PlayerLatencyPolicy {
 
 export namespace PlayerLatencyPolicy {
   export function isa(o: any): o is PlayerLatencyPolicy {
-    return _smithy.isa(o, "PlayerLatencyPolicy");
+    return __isa(o, "PlayerLatencyPolicy");
   }
 }
 
@@ -5567,7 +5566,7 @@ export interface PlayerSession {
 
 export namespace PlayerSession {
   export function isa(o: any): o is PlayerSession {
-    return _smithy.isa(o, "PlayerSession");
+    return __isa(o, "PlayerSession");
   }
 }
 
@@ -5746,7 +5745,7 @@ export interface PutScalingPolicyInput {
 
 export namespace PutScalingPolicyInput {
   export function isa(o: any): o is PutScalingPolicyInput {
-    return _smithy.isa(o, "PutScalingPolicyInput");
+    return __isa(o, "PutScalingPolicyInput");
   }
 }
 
@@ -5763,7 +5762,7 @@ export interface PutScalingPolicyOutput extends $MetadataBearer {
 
 export namespace PutScalingPolicyOutput {
   export function isa(o: any): o is PutScalingPolicyOutput {
-    return _smithy.isa(o, "PutScalingPolicyOutput");
+    return __isa(o, "PutScalingPolicyOutput");
   }
 }
 
@@ -5780,7 +5779,7 @@ export interface RequestUploadCredentialsInput {
 
 export namespace RequestUploadCredentialsInput {
   export function isa(o: any): o is RequestUploadCredentialsInput {
-    return _smithy.isa(o, "RequestUploadCredentialsInput");
+    return __isa(o, "RequestUploadCredentialsInput");
   }
 }
 
@@ -5805,7 +5804,7 @@ export interface RequestUploadCredentialsOutput extends $MetadataBearer {
 
 export namespace RequestUploadCredentialsOutput {
   export function isa(o: any): o is RequestUploadCredentialsOutput {
-    return _smithy.isa(o, "RequestUploadCredentialsOutput");
+    return __isa(o, "RequestUploadCredentialsOutput");
   }
 }
 
@@ -5823,7 +5822,7 @@ export interface ResolveAliasInput {
 
 export namespace ResolveAliasInput {
   export function isa(o: any): o is ResolveAliasInput {
-    return _smithy.isa(o, "ResolveAliasInput");
+    return __isa(o, "ResolveAliasInput");
   }
 }
 
@@ -5847,7 +5846,7 @@ export interface ResolveAliasOutput extends $MetadataBearer {
 
 export namespace ResolveAliasOutput {
   export function isa(o: any): o is ResolveAliasOutput {
-    return _smithy.isa(o, "ResolveAliasOutput");
+    return __isa(o, "ResolveAliasOutput");
   }
 }
 
@@ -5879,7 +5878,7 @@ export interface ResourceCreationLimitPolicy {
 
 export namespace ResourceCreationLimitPolicy {
   export function isa(o: any): o is ResourceCreationLimitPolicy {
-    return _smithy.isa(o, "ResourceCreationLimitPolicy");
+    return __isa(o, "ResourceCreationLimitPolicy");
   }
 }
 
@@ -5952,7 +5951,7 @@ export interface RoutingStrategy {
 
 export namespace RoutingStrategy {
   export function isa(o: any): o is RoutingStrategy {
-    return _smithy.isa(o, "RoutingStrategy");
+    return __isa(o, "RoutingStrategy");
   }
 }
 
@@ -6043,7 +6042,7 @@ export interface RuntimeConfiguration {
 
 export namespace RuntimeConfiguration {
   export function isa(o: any): o is RuntimeConfiguration {
-    return _smithy.isa(o, "RuntimeConfiguration");
+    return __isa(o, "RuntimeConfiguration");
   }
 }
 
@@ -6081,7 +6080,7 @@ export interface S3Location {
 
 export namespace S3Location {
   export function isa(o: any): o is S3Location {
-    return _smithy.isa(o, "S3Location");
+    return __isa(o, "S3Location");
   }
 }
 
@@ -6337,7 +6336,7 @@ export interface ScalingPolicy {
 
 export namespace ScalingPolicy {
   export function isa(o: any): o is ScalingPolicy {
-    return _smithy.isa(o, "ScalingPolicy");
+    return __isa(o, "ScalingPolicy");
   }
 }
 
@@ -6428,7 +6427,7 @@ export interface Script {
 
 export namespace Script {
   export function isa(o: any): o is Script {
-    return _smithy.isa(o, "Script");
+    return __isa(o, "Script");
   }
 }
 
@@ -6554,7 +6553,7 @@ export interface SearchGameSessionsInput {
 
 export namespace SearchGameSessionsInput {
   export function isa(o: any): o is SearchGameSessionsInput {
-    return _smithy.isa(o, "SearchGameSessionsInput");
+    return __isa(o, "SearchGameSessionsInput");
   }
 }
 
@@ -6577,7 +6576,7 @@ export interface SearchGameSessionsOutput extends $MetadataBearer {
 
 export namespace SearchGameSessionsOutput {
   export function isa(o: any): o is SearchGameSessionsOutput {
-    return _smithy.isa(o, "SearchGameSessionsOutput");
+    return __isa(o, "SearchGameSessionsOutput");
   }
 }
 
@@ -6625,7 +6624,7 @@ export interface ServerProcess {
 
 export namespace ServerProcess {
   export function isa(o: any): o is ServerProcess {
-    return _smithy.isa(o, "ServerProcess");
+    return __isa(o, "ServerProcess");
   }
 }
 
@@ -6644,7 +6643,7 @@ export interface StartFleetActionsInput {
 
 export namespace StartFleetActionsInput {
   export function isa(o: any): o is StartFleetActionsInput {
-    return _smithy.isa(o, "StartFleetActionsInput");
+    return __isa(o, "StartFleetActionsInput");
   }
 }
 
@@ -6654,7 +6653,7 @@ export interface StartFleetActionsOutput extends $MetadataBearer {
 
 export namespace StartFleetActionsOutput {
   export function isa(o: any): o is StartFleetActionsOutput {
-    return _smithy.isa(o, "StartFleetActionsOutput");
+    return __isa(o, "StartFleetActionsOutput");
   }
 }
 
@@ -6712,7 +6711,7 @@ export interface StartGameSessionPlacementInput {
 
 export namespace StartGameSessionPlacementInput {
   export function isa(o: any): o is StartGameSessionPlacementInput {
-    return _smithy.isa(o, "StartGameSessionPlacementInput");
+    return __isa(o, "StartGameSessionPlacementInput");
   }
 }
 
@@ -6731,7 +6730,7 @@ export interface StartGameSessionPlacementOutput extends $MetadataBearer {
 
 export namespace StartGameSessionPlacementOutput {
   export function isa(o: any): o is StartGameSessionPlacementOutput {
-    return _smithy.isa(o, "StartGameSessionPlacementOutput");
+    return __isa(o, "StartGameSessionPlacementOutput");
   }
 }
 
@@ -6784,7 +6783,7 @@ export interface StartMatchBackfillInput {
 
 export namespace StartMatchBackfillInput {
   export function isa(o: any): o is StartMatchBackfillInput {
-    return _smithy.isa(o, "StartMatchBackfillInput");
+    return __isa(o, "StartMatchBackfillInput");
   }
 }
 
@@ -6803,7 +6802,7 @@ export interface StartMatchBackfillOutput extends $MetadataBearer {
 
 export namespace StartMatchBackfillOutput {
   export function isa(o: any): o is StartMatchBackfillOutput {
-    return _smithy.isa(o, "StartMatchBackfillOutput");
+    return __isa(o, "StartMatchBackfillOutput");
   }
 }
 
@@ -6837,7 +6836,7 @@ export interface StartMatchmakingInput {
 
 export namespace StartMatchmakingInput {
   export function isa(o: any): o is StartMatchmakingInput {
-    return _smithy.isa(o, "StartMatchmakingInput");
+    return __isa(o, "StartMatchmakingInput");
   }
 }
 
@@ -6856,7 +6855,7 @@ export interface StartMatchmakingOutput extends $MetadataBearer {
 
 export namespace StartMatchmakingOutput {
   export function isa(o: any): o is StartMatchmakingOutput {
-    return _smithy.isa(o, "StartMatchmakingOutput");
+    return __isa(o, "StartMatchmakingOutput");
   }
 }
 
@@ -6875,7 +6874,7 @@ export interface StopFleetActionsInput {
 
 export namespace StopFleetActionsInput {
   export function isa(o: any): o is StopFleetActionsInput {
-    return _smithy.isa(o, "StopFleetActionsInput");
+    return __isa(o, "StopFleetActionsInput");
   }
 }
 
@@ -6885,7 +6884,7 @@ export interface StopFleetActionsOutput extends $MetadataBearer {
 
 export namespace StopFleetActionsOutput {
   export function isa(o: any): o is StopFleetActionsOutput {
-    return _smithy.isa(o, "StopFleetActionsOutput");
+    return __isa(o, "StopFleetActionsOutput");
   }
 }
 
@@ -6902,7 +6901,7 @@ export interface StopGameSessionPlacementInput {
 
 export namespace StopGameSessionPlacementInput {
   export function isa(o: any): o is StopGameSessionPlacementInput {
-    return _smithy.isa(o, "StopGameSessionPlacementInput");
+    return __isa(o, "StopGameSessionPlacementInput");
   }
 }
 
@@ -6920,7 +6919,7 @@ export interface StopGameSessionPlacementOutput extends $MetadataBearer {
 
 export namespace StopGameSessionPlacementOutput {
   export function isa(o: any): o is StopGameSessionPlacementOutput {
-    return _smithy.isa(o, "StopGameSessionPlacementOutput");
+    return __isa(o, "StopGameSessionPlacementOutput");
   }
 }
 
@@ -6937,7 +6936,7 @@ export interface StopMatchmakingInput {
 
 export namespace StopMatchmakingInput {
   export function isa(o: any): o is StopMatchmakingInput {
-    return _smithy.isa(o, "StopMatchmakingInput");
+    return __isa(o, "StopMatchmakingInput");
   }
 }
 
@@ -6947,7 +6946,7 @@ export interface StopMatchmakingOutput extends $MetadataBearer {
 
 export namespace StopMatchmakingOutput {
   export function isa(o: any): o is StopMatchmakingOutput {
-    return _smithy.isa(o, "StopMatchmakingOutput");
+    return __isa(o, "StopMatchmakingOutput");
   }
 }
 
@@ -7006,7 +7005,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -7033,7 +7032,7 @@ export interface TagResourceRequest {
 
 export namespace TagResourceRequest {
   export function isa(o: any): o is TagResourceRequest {
-    return _smithy.isa(o, "TagResourceRequest");
+    return __isa(o, "TagResourceRequest");
   }
 }
 
@@ -7043,7 +7042,7 @@ export interface TagResourceResponse extends $MetadataBearer {
 
 export namespace TagResourceResponse {
   export function isa(o: any): o is TagResourceResponse {
-    return _smithy.isa(o, "TagResourceResponse");
+    return __isa(o, "TagResourceResponse");
   }
 }
 
@@ -7054,7 +7053,7 @@ export namespace TagResourceResponse {
  *         </p>
  */
 export interface TaggingFailedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TaggingFailedException";
   $fault: "client";
@@ -7063,7 +7062,7 @@ export interface TaggingFailedException
 
 export namespace TaggingFailedException {
   export function isa(o: any): o is TaggingFailedException {
-    return _smithy.isa(o, "TaggingFailedException");
+    return __isa(o, "TaggingFailedException");
   }
 }
 
@@ -7137,7 +7136,7 @@ export interface TargetConfiguration {
 
 export namespace TargetConfiguration {
   export function isa(o: any): o is TargetConfiguration {
-    return _smithy.isa(o, "TargetConfiguration");
+    return __isa(o, "TargetConfiguration");
   }
 }
 
@@ -7149,7 +7148,7 @@ export namespace TargetConfiguration {
  *         </p>
  */
 export interface TerminalRoutingStrategyException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TerminalRoutingStrategyException";
   $fault: "client";
@@ -7158,7 +7157,7 @@ export interface TerminalRoutingStrategyException
 
 export namespace TerminalRoutingStrategyException {
   export function isa(o: any): o is TerminalRoutingStrategyException {
-    return _smithy.isa(o, "TerminalRoutingStrategyException");
+    return __isa(o, "TerminalRoutingStrategyException");
   }
 }
 
@@ -7166,7 +7165,7 @@ export namespace TerminalRoutingStrategyException {
  * <p>The client failed authentication. Clients should not retry such requests.</p>
  */
 export interface UnauthorizedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UnauthorizedException";
   $fault: "client";
@@ -7175,7 +7174,7 @@ export interface UnauthorizedException
 
 export namespace UnauthorizedException {
   export function isa(o: any): o is UnauthorizedException {
-    return _smithy.isa(o, "UnauthorizedException");
+    return __isa(o, "UnauthorizedException");
   }
 }
 
@@ -7183,7 +7182,7 @@ export namespace UnauthorizedException {
  * <p>The requested operation is not supported in the Region specified.</p>
  */
 export interface UnsupportedRegionException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UnsupportedRegionException";
   $fault: "client";
@@ -7192,7 +7191,7 @@ export interface UnsupportedRegionException
 
 export namespace UnsupportedRegionException {
   export function isa(o: any): o is UnsupportedRegionException {
-    return _smithy.isa(o, "UnsupportedRegionException");
+    return __isa(o, "UnsupportedRegionException");
   }
 }
 
@@ -7217,7 +7216,7 @@ export interface UntagResourceRequest {
 
 export namespace UntagResourceRequest {
   export function isa(o: any): o is UntagResourceRequest {
-    return _smithy.isa(o, "UntagResourceRequest");
+    return __isa(o, "UntagResourceRequest");
   }
 }
 
@@ -7227,7 +7226,7 @@ export interface UntagResourceResponse extends $MetadataBearer {
 
 export namespace UntagResourceResponse {
   export function isa(o: any): o is UntagResourceResponse {
-    return _smithy.isa(o, "UntagResourceResponse");
+    return __isa(o, "UntagResourceResponse");
   }
 }
 
@@ -7261,7 +7260,7 @@ export interface UpdateAliasInput {
 
 export namespace UpdateAliasInput {
   export function isa(o: any): o is UpdateAliasInput {
-    return _smithy.isa(o, "UpdateAliasInput");
+    return __isa(o, "UpdateAliasInput");
   }
 }
 
@@ -7278,7 +7277,7 @@ export interface UpdateAliasOutput extends $MetadataBearer {
 
 export namespace UpdateAliasOutput {
   export function isa(o: any): o is UpdateAliasOutput {
-    return _smithy.isa(o, "UpdateAliasOutput");
+    return __isa(o, "UpdateAliasOutput");
   }
 }
 
@@ -7305,7 +7304,7 @@ export interface UpdateBuildInput {
 
 export namespace UpdateBuildInput {
   export function isa(o: any): o is UpdateBuildInput {
-    return _smithy.isa(o, "UpdateBuildInput");
+    return __isa(o, "UpdateBuildInput");
   }
 }
 
@@ -7322,7 +7321,7 @@ export interface UpdateBuildOutput extends $MetadataBearer {
 
 export namespace UpdateBuildOutput {
   export function isa(o: any): o is UpdateBuildOutput {
-    return _smithy.isa(o, "UpdateBuildOutput");
+    return __isa(o, "UpdateBuildOutput");
   }
 }
 
@@ -7384,7 +7383,7 @@ export interface UpdateFleetAttributesInput {
 
 export namespace UpdateFleetAttributesInput {
   export function isa(o: any): o is UpdateFleetAttributesInput {
-    return _smithy.isa(o, "UpdateFleetAttributesInput");
+    return __isa(o, "UpdateFleetAttributesInput");
   }
 }
 
@@ -7401,7 +7400,7 @@ export interface UpdateFleetAttributesOutput extends $MetadataBearer {
 
 export namespace UpdateFleetAttributesOutput {
   export function isa(o: any): o is UpdateFleetAttributesOutput {
-    return _smithy.isa(o, "UpdateFleetAttributesOutput");
+    return __isa(o, "UpdateFleetAttributesOutput");
   }
 }
 
@@ -7435,7 +7434,7 @@ export interface UpdateFleetCapacityInput {
 
 export namespace UpdateFleetCapacityInput {
   export function isa(o: any): o is UpdateFleetCapacityInput {
-    return _smithy.isa(o, "UpdateFleetCapacityInput");
+    return __isa(o, "UpdateFleetCapacityInput");
   }
 }
 
@@ -7452,7 +7451,7 @@ export interface UpdateFleetCapacityOutput extends $MetadataBearer {
 
 export namespace UpdateFleetCapacityOutput {
   export function isa(o: any): o is UpdateFleetCapacityOutput {
-    return _smithy.isa(o, "UpdateFleetCapacityOutput");
+    return __isa(o, "UpdateFleetCapacityOutput");
   }
 }
 
@@ -7480,7 +7479,7 @@ export interface UpdateFleetPortSettingsInput {
 
 export namespace UpdateFleetPortSettingsInput {
   export function isa(o: any): o is UpdateFleetPortSettingsInput {
-    return _smithy.isa(o, "UpdateFleetPortSettingsInput");
+    return __isa(o, "UpdateFleetPortSettingsInput");
   }
 }
 
@@ -7497,7 +7496,7 @@ export interface UpdateFleetPortSettingsOutput extends $MetadataBearer {
 
 export namespace UpdateFleetPortSettingsOutput {
   export function isa(o: any): o is UpdateFleetPortSettingsOutput {
-    return _smithy.isa(o, "UpdateFleetPortSettingsOutput");
+    return __isa(o, "UpdateFleetPortSettingsOutput");
   }
 }
 
@@ -7547,7 +7546,7 @@ export interface UpdateGameSessionInput {
 
 export namespace UpdateGameSessionInput {
   export function isa(o: any): o is UpdateGameSessionInput {
-    return _smithy.isa(o, "UpdateGameSessionInput");
+    return __isa(o, "UpdateGameSessionInput");
   }
 }
 
@@ -7564,7 +7563,7 @@ export interface UpdateGameSessionOutput extends $MetadataBearer {
 
 export namespace UpdateGameSessionOutput {
   export function isa(o: any): o is UpdateGameSessionOutput {
-    return _smithy.isa(o, "UpdateGameSessionOutput");
+    return __isa(o, "UpdateGameSessionOutput");
   }
 }
 
@@ -7603,7 +7602,7 @@ export interface UpdateGameSessionQueueInput {
 
 export namespace UpdateGameSessionQueueInput {
   export function isa(o: any): o is UpdateGameSessionQueueInput {
-    return _smithy.isa(o, "UpdateGameSessionQueueInput");
+    return __isa(o, "UpdateGameSessionQueueInput");
   }
 }
 
@@ -7620,7 +7619,7 @@ export interface UpdateGameSessionQueueOutput extends $MetadataBearer {
 
 export namespace UpdateGameSessionQueueOutput {
   export function isa(o: any): o is UpdateGameSessionQueueOutput {
-    return _smithy.isa(o, "UpdateGameSessionQueueOutput");
+    return __isa(o, "UpdateGameSessionQueueOutput");
   }
 }
 
@@ -7716,7 +7715,7 @@ export interface UpdateMatchmakingConfigurationInput {
 
 export namespace UpdateMatchmakingConfigurationInput {
   export function isa(o: any): o is UpdateMatchmakingConfigurationInput {
-    return _smithy.isa(o, "UpdateMatchmakingConfigurationInput");
+    return __isa(o, "UpdateMatchmakingConfigurationInput");
   }
 }
 
@@ -7733,7 +7732,7 @@ export interface UpdateMatchmakingConfigurationOutput extends $MetadataBearer {
 
 export namespace UpdateMatchmakingConfigurationOutput {
   export function isa(o: any): o is UpdateMatchmakingConfigurationOutput {
-    return _smithy.isa(o, "UpdateMatchmakingConfigurationOutput");
+    return __isa(o, "UpdateMatchmakingConfigurationOutput");
   }
 }
 
@@ -7762,7 +7761,7 @@ export interface UpdateRuntimeConfigurationInput {
 
 export namespace UpdateRuntimeConfigurationInput {
   export function isa(o: any): o is UpdateRuntimeConfigurationInput {
-    return _smithy.isa(o, "UpdateRuntimeConfigurationInput");
+    return __isa(o, "UpdateRuntimeConfigurationInput");
   }
 }
 
@@ -7780,7 +7779,7 @@ export interface UpdateRuntimeConfigurationOutput extends $MetadataBearer {
 
 export namespace UpdateRuntimeConfigurationOutput {
   export function isa(o: any): o is UpdateRuntimeConfigurationOutput {
-    return _smithy.isa(o, "UpdateRuntimeConfigurationOutput");
+    return __isa(o, "UpdateRuntimeConfigurationOutput");
   }
 }
 
@@ -7825,7 +7824,7 @@ export interface UpdateScriptInput {
 
 export namespace UpdateScriptInput {
   export function isa(o: any): o is UpdateScriptInput {
-    return _smithy.isa(o, "UpdateScriptInput");
+    return __isa(o, "UpdateScriptInput");
   }
 }
 
@@ -7844,7 +7843,7 @@ export interface UpdateScriptOutput extends $MetadataBearer {
 
 export namespace UpdateScriptOutput {
   export function isa(o: any): o is UpdateScriptOutput {
-    return _smithy.isa(o, "UpdateScriptOutput");
+    return __isa(o, "UpdateScriptOutput");
   }
 }
 
@@ -7861,7 +7860,7 @@ export interface ValidateMatchmakingRuleSetInput {
 
 export namespace ValidateMatchmakingRuleSetInput {
   export function isa(o: any): o is ValidateMatchmakingRuleSetInput {
-    return _smithy.isa(o, "ValidateMatchmakingRuleSetInput");
+    return __isa(o, "ValidateMatchmakingRuleSetInput");
   }
 }
 
@@ -7878,7 +7877,7 @@ export interface ValidateMatchmakingRuleSetOutput extends $MetadataBearer {
 
 export namespace ValidateMatchmakingRuleSetOutput {
   export function isa(o: any): o is ValidateMatchmakingRuleSetOutput {
-    return _smithy.isa(o, "ValidateMatchmakingRuleSetOutput");
+    return __isa(o, "ValidateMatchmakingRuleSetOutput");
   }
 }
 
@@ -7955,7 +7954,7 @@ export interface VpcPeeringAuthorization {
 
 export namespace VpcPeeringAuthorization {
   export function isa(o: any): o is VpcPeeringAuthorization {
-    return _smithy.isa(o, "VpcPeeringAuthorization");
+    return __isa(o, "VpcPeeringAuthorization");
   }
 }
 
@@ -8048,7 +8047,7 @@ export interface VpcPeeringConnection {
 
 export namespace VpcPeeringConnection {
   export function isa(o: any): o is VpcPeeringConnection {
-    return _smithy.isa(o, "VpcPeeringConnection");
+    return __isa(o, "VpcPeeringConnection");
   }
 }
 
@@ -8073,6 +8072,6 @@ export interface VpcPeeringConnectionStatus {
 
 export namespace VpcPeeringConnectionStatus {
   export function isa(o: any): o is VpcPeeringConnectionStatus {
-    return _smithy.isa(o, "VpcPeeringConnectionStatus");
+    return __isa(o, "VpcPeeringConnectionStatus");
   }
 }

--- a/clients/client-gamelift/protocols/Aws_json1_1.ts
+++ b/clients/client-gamelift/protocols/Aws_json1_1.ts
@@ -2742,6 +2742,7 @@ export async function deserializeAws_json1_1DeleteAliasCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1DeleteAliasCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteAliasCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2821,6 +2822,7 @@ export async function deserializeAws_json1_1DeleteBuildCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1DeleteBuildCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteBuildCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2900,6 +2902,7 @@ export async function deserializeAws_json1_1DeleteFleetCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1DeleteFleetCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteFleetCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -3256,6 +3259,7 @@ export async function deserializeAws_json1_1DeleteScalingPolicyCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteScalingPolicyCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -3328,6 +3332,7 @@ export async function deserializeAws_json1_1DeleteScriptCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1DeleteScriptCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteScriptCommandOutput = {
     $metadata: deserializeMetadata(output)
   };

--- a/clients/client-glacier/models/index.ts
+++ b/clients/client-glacier/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export enum ActionCode {
@@ -49,7 +52,7 @@ export interface CSVInput {
 
 export namespace CSVInput {
   export function isa(o: any): o is CSVInput {
-    return _smithy.isa(o, "CSVInput");
+    return __isa(o, "CSVInput");
   }
 }
 
@@ -90,7 +93,7 @@ export interface CSVOutput {
 
 export namespace CSVOutput {
   export function isa(o: any): o is CSVOutput {
-    return _smithy.isa(o, "CSVOutput");
+    return __isa(o, "CSVOutput");
   }
 }
 
@@ -131,7 +134,7 @@ export interface Encryption {
 
 export namespace Encryption {
   export function isa(o: any): o is Encryption {
-    return _smithy.isa(o, "Encryption");
+    return __isa(o, "Encryption");
   }
 }
 
@@ -310,7 +313,7 @@ export interface GlacierJobDescription extends $MetadataBearer {
 
 export namespace GlacierJobDescription {
   export function isa(o: any): o is GlacierJobDescription {
-    return _smithy.isa(o, "GlacierJobDescription");
+    return __isa(o, "GlacierJobDescription");
   }
 }
 
@@ -332,7 +335,7 @@ export interface Grant {
 
 export namespace Grant {
   export function isa(o: any): o is Grant {
-    return _smithy.isa(o, "Grant");
+    return __isa(o, "Grant");
   }
 }
 
@@ -369,7 +372,7 @@ export interface Grantee {
 
 export namespace Grantee {
   export function isa(o: any): o is Grantee {
-    return _smithy.isa(o, "Grantee");
+    return __isa(o, "Grantee");
   }
 }
 
@@ -386,7 +389,7 @@ export interface InputSerialization {
 
 export namespace InputSerialization {
   export function isa(o: any): o is InputSerialization {
-    return _smithy.isa(o, "InputSerialization");
+    return __isa(o, "InputSerialization");
   }
 }
 
@@ -433,7 +436,7 @@ export interface InventoryRetrievalJobDescription {
 
 export namespace InventoryRetrievalJobDescription {
   export function isa(o: any): o is InventoryRetrievalJobDescription {
-    return _smithy.isa(o, "InventoryRetrievalJobDescription");
+    return __isa(o, "InventoryRetrievalJobDescription");
   }
 }
 
@@ -450,7 +453,7 @@ export interface OutputLocation {
 
 export namespace OutputLocation {
   export function isa(o: any): o is OutputLocation {
-    return _smithy.isa(o, "OutputLocation");
+    return __isa(o, "OutputLocation");
   }
 }
 
@@ -467,7 +470,7 @@ export interface OutputSerialization {
 
 export namespace OutputSerialization {
   export function isa(o: any): o is OutputSerialization {
-    return _smithy.isa(o, "OutputSerialization");
+    return __isa(o, "OutputSerialization");
   }
 }
 
@@ -532,7 +535,7 @@ export interface S3Location {
 
 export namespace S3Location {
   export function isa(o: any): o is S3Location {
-    return _smithy.isa(o, "S3Location");
+    return __isa(o, "S3Location");
   }
 }
 
@@ -564,7 +567,7 @@ export interface SelectParameters {
 
 export namespace SelectParameters {
   export function isa(o: any): o is SelectParameters {
-    return _smithy.isa(o, "SelectParameters");
+    return __isa(o, "SelectParameters");
   }
 }
 
@@ -617,7 +620,7 @@ export interface AbortMultipartUploadInput {
 
 export namespace AbortMultipartUploadInput {
   export function isa(o: any): o is AbortMultipartUploadInput {
-    return _smithy.isa(o, "AbortMultipartUploadInput");
+    return __isa(o, "AbortMultipartUploadInput");
   }
 }
 
@@ -643,7 +646,7 @@ export interface AbortVaultLockInput {
 
 export namespace AbortVaultLockInput {
   export function isa(o: any): o is AbortVaultLockInput {
-    return _smithy.isa(o, "AbortVaultLockInput");
+    return __isa(o, "AbortVaultLockInput");
   }
 }
 
@@ -675,7 +678,7 @@ export interface AddTagsToVaultInput {
 
 export namespace AddTagsToVaultInput {
   export function isa(o: any): o is AddTagsToVaultInput {
-    return _smithy.isa(o, "AddTagsToVaultInput");
+    return __isa(o, "AddTagsToVaultInput");
   }
 }
 
@@ -705,7 +708,7 @@ export interface ArchiveCreationOutput extends $MetadataBearer {
 
 export namespace ArchiveCreationOutput {
   export function isa(o: any): o is ArchiveCreationOutput {
-    return _smithy.isa(o, "ArchiveCreationOutput");
+    return __isa(o, "ArchiveCreationOutput");
   }
 }
 
@@ -753,7 +756,7 @@ export interface CompleteMultipartUploadInput {
 
 export namespace CompleteMultipartUploadInput {
   export function isa(o: any): o is CompleteMultipartUploadInput {
-    return _smithy.isa(o, "CompleteMultipartUploadInput");
+    return __isa(o, "CompleteMultipartUploadInput");
   }
 }
 
@@ -784,7 +787,7 @@ export interface CompleteVaultLockInput {
 
 export namespace CompleteVaultLockInput {
   export function isa(o: any): o is CompleteVaultLockInput {
-    return _smithy.isa(o, "CompleteVaultLockInput");
+    return __isa(o, "CompleteVaultLockInput");
   }
 }
 
@@ -810,7 +813,7 @@ export interface CreateVaultInput {
 
 export namespace CreateVaultInput {
   export function isa(o: any): o is CreateVaultInput {
-    return _smithy.isa(o, "CreateVaultInput");
+    return __isa(o, "CreateVaultInput");
   }
 }
 
@@ -827,7 +830,7 @@ export interface CreateVaultOutput extends $MetadataBearer {
 
 export namespace CreateVaultOutput {
   export function isa(o: any): o is CreateVaultOutput {
-    return _smithy.isa(o, "CreateVaultOutput");
+    return __isa(o, "CreateVaultOutput");
   }
 }
 
@@ -845,7 +848,7 @@ export interface DataRetrievalPolicy {
 
 export namespace DataRetrievalPolicy {
   export function isa(o: any): o is DataRetrievalPolicy {
-    return _smithy.isa(o, "DataRetrievalPolicy");
+    return __isa(o, "DataRetrievalPolicy");
   }
 }
 
@@ -871,7 +874,7 @@ export interface DataRetrievalRule {
 
 export namespace DataRetrievalRule {
   export function isa(o: any): o is DataRetrievalRule {
-    return _smithy.isa(o, "DataRetrievalRule");
+    return __isa(o, "DataRetrievalRule");
   }
 }
 
@@ -902,7 +905,7 @@ export interface DeleteArchiveInput {
 
 export namespace DeleteArchiveInput {
   export function isa(o: any): o is DeleteArchiveInput {
-    return _smithy.isa(o, "DeleteArchiveInput");
+    return __isa(o, "DeleteArchiveInput");
   }
 }
 
@@ -928,7 +931,7 @@ export interface DeleteVaultAccessPolicyInput {
 
 export namespace DeleteVaultAccessPolicyInput {
   export function isa(o: any): o is DeleteVaultAccessPolicyInput {
-    return _smithy.isa(o, "DeleteVaultAccessPolicyInput");
+    return __isa(o, "DeleteVaultAccessPolicyInput");
   }
 }
 
@@ -954,7 +957,7 @@ export interface DeleteVaultInput {
 
 export namespace DeleteVaultInput {
   export function isa(o: any): o is DeleteVaultInput {
-    return _smithy.isa(o, "DeleteVaultInput");
+    return __isa(o, "DeleteVaultInput");
   }
 }
 
@@ -981,7 +984,7 @@ export interface DeleteVaultNotificationsInput {
 
 export namespace DeleteVaultNotificationsInput {
   export function isa(o: any): o is DeleteVaultNotificationsInput {
-    return _smithy.isa(o, "DeleteVaultNotificationsInput");
+    return __isa(o, "DeleteVaultNotificationsInput");
   }
 }
 
@@ -1012,7 +1015,7 @@ export interface DescribeJobInput {
 
 export namespace DescribeJobInput {
   export function isa(o: any): o is DescribeJobInput {
-    return _smithy.isa(o, "DescribeJobInput");
+    return __isa(o, "DescribeJobInput");
   }
 }
 
@@ -1039,7 +1042,7 @@ export interface DescribeVaultInput {
 
 export namespace DescribeVaultInput {
   export function isa(o: any): o is DescribeVaultInput {
-    return _smithy.isa(o, "DescribeVaultInput");
+    return __isa(o, "DescribeVaultInput");
   }
 }
 
@@ -1089,7 +1092,7 @@ export interface DescribeVaultOutput extends $MetadataBearer {
 
 export namespace DescribeVaultOutput {
   export function isa(o: any): o is DescribeVaultOutput {
-    return _smithy.isa(o, "DescribeVaultOutput");
+    return __isa(o, "DescribeVaultOutput");
   }
 }
 
@@ -1110,7 +1113,7 @@ export interface GetDataRetrievalPolicyInput {
 
 export namespace GetDataRetrievalPolicyInput {
   export function isa(o: any): o is GetDataRetrievalPolicyInput {
-    return _smithy.isa(o, "GetDataRetrievalPolicyInput");
+    return __isa(o, "GetDataRetrievalPolicyInput");
   }
 }
 
@@ -1128,7 +1131,7 @@ export interface GetDataRetrievalPolicyOutput extends $MetadataBearer {
 
 export namespace GetDataRetrievalPolicyOutput {
   export function isa(o: any): o is GetDataRetrievalPolicyOutput {
-    return _smithy.isa(o, "GetDataRetrievalPolicyOutput");
+    return __isa(o, "GetDataRetrievalPolicyOutput");
   }
 }
 
@@ -1199,7 +1202,7 @@ export interface GetJobOutputInput {
 
 export namespace GetJobOutputInput {
   export function isa(o: any): o is GetJobOutputInput {
-    return _smithy.isa(o, "GetJobOutputInput");
+    return __isa(o, "GetJobOutputInput");
   }
 }
 
@@ -1266,7 +1269,7 @@ export interface GetJobOutputOutput extends $MetadataBearer {
 
 export namespace GetJobOutputOutput {
   export function isa(o: any): o is GetJobOutputOutput {
-    return _smithy.isa(o, "GetJobOutputOutput");
+    return __isa(o, "GetJobOutputOutput");
   }
 }
 
@@ -1292,7 +1295,7 @@ export interface GetVaultAccessPolicyInput {
 
 export namespace GetVaultAccessPolicyInput {
   export function isa(o: any): o is GetVaultAccessPolicyInput {
-    return _smithy.isa(o, "GetVaultAccessPolicyInput");
+    return __isa(o, "GetVaultAccessPolicyInput");
   }
 }
 
@@ -1309,7 +1312,7 @@ export interface GetVaultAccessPolicyOutput extends $MetadataBearer {
 
 export namespace GetVaultAccessPolicyOutput {
   export function isa(o: any): o is GetVaultAccessPolicyOutput {
-    return _smithy.isa(o, "GetVaultAccessPolicyOutput");
+    return __isa(o, "GetVaultAccessPolicyOutput");
   }
 }
 
@@ -1335,7 +1338,7 @@ export interface GetVaultLockInput {
 
 export namespace GetVaultLockInput {
   export function isa(o: any): o is GetVaultLockInput {
-    return _smithy.isa(o, "GetVaultLockInput");
+    return __isa(o, "GetVaultLockInput");
   }
 }
 
@@ -1371,7 +1374,7 @@ export interface GetVaultLockOutput extends $MetadataBearer {
 
 export namespace GetVaultLockOutput {
   export function isa(o: any): o is GetVaultLockOutput {
-    return _smithy.isa(o, "GetVaultLockOutput");
+    return __isa(o, "GetVaultLockOutput");
   }
 }
 
@@ -1398,7 +1401,7 @@ export interface GetVaultNotificationsInput {
 
 export namespace GetVaultNotificationsInput {
   export function isa(o: any): o is GetVaultNotificationsInput {
-    return _smithy.isa(o, "GetVaultNotificationsInput");
+    return __isa(o, "GetVaultNotificationsInput");
   }
 }
 
@@ -1415,7 +1418,7 @@ export interface GetVaultNotificationsOutput extends $MetadataBearer {
 
 export namespace GetVaultNotificationsOutput {
   export function isa(o: any): o is GetVaultNotificationsOutput {
-    return _smithy.isa(o, "GetVaultNotificationsOutput");
+    return __isa(o, "GetVaultNotificationsOutput");
   }
 }
 
@@ -1446,7 +1449,7 @@ export interface InitiateJobInput {
 
 export namespace InitiateJobInput {
   export function isa(o: any): o is InitiateJobInput {
-    return _smithy.isa(o, "InitiateJobInput");
+    return __isa(o, "InitiateJobInput");
   }
 }
 
@@ -1473,7 +1476,7 @@ export interface InitiateJobOutput extends $MetadataBearer {
 
 export namespace InitiateJobOutput {
   export function isa(o: any): o is InitiateJobOutput {
-    return _smithy.isa(o, "InitiateJobOutput");
+    return __isa(o, "InitiateJobOutput");
   }
 }
 
@@ -1514,7 +1517,7 @@ export interface InitiateMultipartUploadInput {
 
 export namespace InitiateMultipartUploadInput {
   export function isa(o: any): o is InitiateMultipartUploadInput {
-    return _smithy.isa(o, "InitiateMultipartUploadInput");
+    return __isa(o, "InitiateMultipartUploadInput");
   }
 }
 
@@ -1537,7 +1540,7 @@ export interface InitiateMultipartUploadOutput extends $MetadataBearer {
 
 export namespace InitiateMultipartUploadOutput {
   export function isa(o: any): o is InitiateMultipartUploadOutput {
-    return _smithy.isa(o, "InitiateMultipartUploadOutput");
+    return __isa(o, "InitiateMultipartUploadOutput");
   }
 }
 
@@ -1569,7 +1572,7 @@ export interface InitiateVaultLockInput {
 
 export namespace InitiateVaultLockInput {
   export function isa(o: any): o is InitiateVaultLockInput {
-    return _smithy.isa(o, "InitiateVaultLockInput");
+    return __isa(o, "InitiateVaultLockInput");
   }
 }
 
@@ -1586,7 +1589,7 @@ export interface InitiateVaultLockOutput extends $MetadataBearer {
 
 export namespace InitiateVaultLockOutput {
   export function isa(o: any): o is InitiateVaultLockOutput {
-    return _smithy.isa(o, "InitiateVaultLockOutput");
+    return __isa(o, "InitiateVaultLockOutput");
   }
 }
 
@@ -1596,7 +1599,7 @@ export namespace InitiateVaultLockOutput {
  *          retrievals.</p>
  */
 export interface InsufficientCapacityException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InsufficientCapacityException";
   $fault: "client";
@@ -1607,7 +1610,7 @@ export interface InsufficientCapacityException
 
 export namespace InsufficientCapacityException {
   export function isa(o: any): o is InsufficientCapacityException {
-    return _smithy.isa(o, "InsufficientCapacityException");
+    return __isa(o, "InsufficientCapacityException");
   }
 }
 
@@ -1615,7 +1618,7 @@ export namespace InsufficientCapacityException {
  * <p>Returned if a parameter of the request is incorrectly specified.</p>
  */
 export interface InvalidParameterValueException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidParameterValueException";
   $fault: "client";
@@ -1637,7 +1640,7 @@ export interface InvalidParameterValueException
 
 export namespace InvalidParameterValueException {
   export function isa(o: any): o is InvalidParameterValueException {
-    return _smithy.isa(o, "InvalidParameterValueException");
+    return __isa(o, "InvalidParameterValueException");
   }
 }
 
@@ -1677,7 +1680,7 @@ export interface InventoryRetrievalJobInput {
 
 export namespace InventoryRetrievalJobInput {
   export function isa(o: any): o is InventoryRetrievalJobInput {
-    return _smithy.isa(o, "InventoryRetrievalJobInput");
+    return __isa(o, "InventoryRetrievalJobInput");
   }
 }
 
@@ -1761,7 +1764,7 @@ export interface JobParameters {
 
 export namespace JobParameters {
   export function isa(o: any): o is JobParameters {
-    return _smithy.isa(o, "JobParameters");
+    return __isa(o, "JobParameters");
   }
 }
 
@@ -1769,7 +1772,7 @@ export namespace JobParameters {
  * <p>Returned if the request results in a vault or account limit being exceeded.</p>
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -1791,7 +1794,7 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
@@ -1844,7 +1847,7 @@ export interface ListJobsInput {
 
 export namespace ListJobsInput {
   export function isa(o: any): o is ListJobsInput {
-    return _smithy.isa(o, "ListJobsInput");
+    return __isa(o, "ListJobsInput");
   }
 }
 
@@ -1871,7 +1874,7 @@ export interface ListJobsOutput extends $MetadataBearer {
 
 export namespace ListJobsOutput {
   export function isa(o: any): o is ListJobsOutput {
-    return _smithy.isa(o, "ListJobsOutput");
+    return __isa(o, "ListJobsOutput");
   }
 }
 
@@ -1912,7 +1915,7 @@ export interface ListMultipartUploadsInput {
 
 export namespace ListMultipartUploadsInput {
   export function isa(o: any): o is ListMultipartUploadsInput {
-    return _smithy.isa(o, "ListMultipartUploadsInput");
+    return __isa(o, "ListMultipartUploadsInput");
   }
 }
 
@@ -1936,7 +1939,7 @@ export interface ListMultipartUploadsOutput extends $MetadataBearer {
 
 export namespace ListMultipartUploadsOutput {
   export function isa(o: any): o is ListMultipartUploadsOutput {
-    return _smithy.isa(o, "ListMultipartUploadsOutput");
+    return __isa(o, "ListMultipartUploadsOutput");
   }
 }
 
@@ -1983,7 +1986,7 @@ export interface ListPartsInput {
 
 export namespace ListPartsInput {
   export function isa(o: any): o is ListPartsInput {
-    return _smithy.isa(o, "ListPartsInput");
+    return __isa(o, "ListPartsInput");
   }
 }
 
@@ -2037,7 +2040,7 @@ export interface ListPartsOutput extends $MetadataBearer {
 
 export namespace ListPartsOutput {
   export function isa(o: any): o is ListPartsOutput {
-    return _smithy.isa(o, "ListPartsOutput");
+    return __isa(o, "ListPartsOutput");
   }
 }
 
@@ -2054,7 +2057,7 @@ export interface ListProvisionedCapacityInput {
 
 export namespace ListProvisionedCapacityInput {
   export function isa(o: any): o is ListProvisionedCapacityInput {
-    return _smithy.isa(o, "ListProvisionedCapacityInput");
+    return __isa(o, "ListProvisionedCapacityInput");
   }
 }
 
@@ -2068,7 +2071,7 @@ export interface ListProvisionedCapacityOutput extends $MetadataBearer {
 
 export namespace ListProvisionedCapacityOutput {
   export function isa(o: any): o is ListProvisionedCapacityOutput {
-    return _smithy.isa(o, "ListProvisionedCapacityOutput");
+    return __isa(o, "ListProvisionedCapacityOutput");
   }
 }
 
@@ -2094,7 +2097,7 @@ export interface ListTagsForVaultInput {
 
 export namespace ListTagsForVaultInput {
   export function isa(o: any): o is ListTagsForVaultInput {
-    return _smithy.isa(o, "ListTagsForVaultInput");
+    return __isa(o, "ListTagsForVaultInput");
   }
 }
 
@@ -2111,7 +2114,7 @@ export interface ListTagsForVaultOutput extends $MetadataBearer {
 
 export namespace ListTagsForVaultOutput {
   export function isa(o: any): o is ListTagsForVaultOutput {
-    return _smithy.isa(o, "ListTagsForVaultOutput");
+    return __isa(o, "ListTagsForVaultOutput");
   }
 }
 
@@ -2146,7 +2149,7 @@ export interface ListVaultsInput {
 
 export namespace ListVaultsInput {
   export function isa(o: any): o is ListVaultsInput {
-    return _smithy.isa(o, "ListVaultsInput");
+    return __isa(o, "ListVaultsInput");
   }
 }
 
@@ -2169,7 +2172,7 @@ export interface ListVaultsOutput extends $MetadataBearer {
 
 export namespace ListVaultsOutput {
   export function isa(o: any): o is ListVaultsOutput {
-    return _smithy.isa(o, "ListVaultsOutput");
+    return __isa(o, "ListVaultsOutput");
   }
 }
 
@@ -2177,7 +2180,7 @@ export namespace ListVaultsOutput {
  * <p>Returned if a required header or parameter is missing from the request.</p>
  */
 export interface MissingParameterValueException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "MissingParameterValueException";
   $fault: "client";
@@ -2199,7 +2202,7 @@ export interface MissingParameterValueException
 
 export namespace MissingParameterValueException {
   export function isa(o: any): o is MissingParameterValueException {
-    return _smithy.isa(o, "MissingParameterValueException");
+    return __isa(o, "MissingParameterValueException");
   }
 }
 
@@ -2222,7 +2225,7 @@ export interface PartListElement {
 
 export namespace PartListElement {
   export function isa(o: any): o is PartListElement {
-    return _smithy.isa(o, "PartListElement");
+    return __isa(o, "PartListElement");
   }
 }
 
@@ -2231,7 +2234,7 @@ export namespace PartListElement {
  *          limit. For more information about data retrieval policies,</p>
  */
 export interface PolicyEnforcedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "PolicyEnforcedException";
   $fault: "client";
@@ -2253,7 +2256,7 @@ export interface PolicyEnforcedException
 
 export namespace PolicyEnforcedException {
   export function isa(o: any): o is PolicyEnforcedException {
-    return _smithy.isa(o, "PolicyEnforcedException");
+    return __isa(o, "PolicyEnforcedException");
   }
 }
 
@@ -2280,7 +2283,7 @@ export interface ProvisionedCapacityDescription {
 
 export namespace ProvisionedCapacityDescription {
   export function isa(o: any): o is ProvisionedCapacityDescription {
-    return _smithy.isa(o, "ProvisionedCapacityDescription");
+    return __isa(o, "ProvisionedCapacityDescription");
   }
 }
 
@@ -2297,7 +2300,7 @@ export interface PurchaseProvisionedCapacityInput {
 
 export namespace PurchaseProvisionedCapacityInput {
   export function isa(o: any): o is PurchaseProvisionedCapacityInput {
-    return _smithy.isa(o, "PurchaseProvisionedCapacityInput");
+    return __isa(o, "PurchaseProvisionedCapacityInput");
   }
 }
 
@@ -2311,7 +2314,7 @@ export interface PurchaseProvisionedCapacityOutput extends $MetadataBearer {
 
 export namespace PurchaseProvisionedCapacityOutput {
   export function isa(o: any): o is PurchaseProvisionedCapacityOutput {
-    return _smithy.isa(o, "PurchaseProvisionedCapacityOutput");
+    return __isa(o, "PurchaseProvisionedCapacityOutput");
   }
 }
 
@@ -2342,7 +2345,7 @@ export interface RemoveTagsFromVaultInput {
 
 export namespace RemoveTagsFromVaultInput {
   export function isa(o: any): o is RemoveTagsFromVaultInput {
-    return _smithy.isa(o, "RemoveTagsFromVaultInput");
+    return __isa(o, "RemoveTagsFromVaultInput");
   }
 }
 
@@ -2351,7 +2354,7 @@ export namespace RemoveTagsFromVaultInput {
  *          upload.</p>
  */
 export interface RequestTimeoutException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "RequestTimeoutException";
   $fault: "client";
@@ -2374,7 +2377,7 @@ export interface RequestTimeoutException
 
 export namespace RequestTimeoutException {
   export function isa(o: any): o is RequestTimeoutException {
-    return _smithy.isa(o, "RequestTimeoutException");
+    return __isa(o, "RequestTimeoutException");
   }
 }
 
@@ -2383,7 +2386,7 @@ export namespace RequestTimeoutException {
  *          exist.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -2406,7 +2409,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -2414,7 +2417,7 @@ export namespace ResourceNotFoundException {
  * <p>Returned if the service cannot complete the request.</p>
  */
 export interface ServiceUnavailableException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ServiceUnavailableException";
   $fault: "server";
@@ -2436,7 +2439,7 @@ export interface ServiceUnavailableException
 
 export namespace ServiceUnavailableException {
   export function isa(o: any): o is ServiceUnavailableException {
-    return _smithy.isa(o, "ServiceUnavailableException");
+    return __isa(o, "ServiceUnavailableException");
   }
 }
 
@@ -2462,7 +2465,7 @@ export interface SetDataRetrievalPolicyInput {
 
 export namespace SetDataRetrievalPolicyInput {
   export function isa(o: any): o is SetDataRetrievalPolicyInput {
-    return _smithy.isa(o, "SetDataRetrievalPolicyInput");
+    return __isa(o, "SetDataRetrievalPolicyInput");
   }
 }
 
@@ -2493,7 +2496,7 @@ export interface SetVaultAccessPolicyInput {
 
 export namespace SetVaultAccessPolicyInput {
   export function isa(o: any): o is SetVaultAccessPolicyInput {
-    return _smithy.isa(o, "SetVaultAccessPolicyInput");
+    return __isa(o, "SetVaultAccessPolicyInput");
   }
 }
 
@@ -2525,7 +2528,7 @@ export interface SetVaultNotificationsInput {
 
 export namespace SetVaultNotificationsInput {
   export function isa(o: any): o is SetVaultNotificationsInput {
-    return _smithy.isa(o, "SetVaultNotificationsInput");
+    return __isa(o, "SetVaultNotificationsInput");
   }
 }
 
@@ -2566,7 +2569,7 @@ export interface UploadArchiveInput {
 
 export namespace UploadArchiveInput {
   export function isa(o: any): o is UploadArchiveInput {
-    return _smithy.isa(o, "UploadArchiveInput");
+    return __isa(o, "UploadArchiveInput");
   }
 }
 
@@ -2606,7 +2609,7 @@ export interface UploadListElement {
 
 export namespace UploadListElement {
   export function isa(o: any): o is UploadListElement {
-    return _smithy.isa(o, "UploadListElement");
+    return __isa(o, "UploadListElement");
   }
 }
 
@@ -2656,7 +2659,7 @@ export interface UploadMultipartPartInput {
 
 export namespace UploadMultipartPartInput {
   export function isa(o: any): o is UploadMultipartPartInput {
-    return _smithy.isa(o, "UploadMultipartPartInput");
+    return __isa(o, "UploadMultipartPartInput");
   }
 }
 
@@ -2673,7 +2676,7 @@ export interface UploadMultipartPartOutput extends $MetadataBearer {
 
 export namespace UploadMultipartPartOutput {
   export function isa(o: any): o is UploadMultipartPartOutput {
-    return _smithy.isa(o, "UploadMultipartPartOutput");
+    return __isa(o, "UploadMultipartPartOutput");
   }
 }
 
@@ -2690,7 +2693,7 @@ export interface VaultAccessPolicy {
 
 export namespace VaultAccessPolicy {
   export function isa(o: any): o is VaultAccessPolicy {
-    return _smithy.isa(o, "VaultAccessPolicy");
+    return __isa(o, "VaultAccessPolicy");
   }
 }
 
@@ -2707,7 +2710,7 @@ export interface VaultLockPolicy {
 
 export namespace VaultLockPolicy {
   export function isa(o: any): o is VaultLockPolicy {
-    return _smithy.isa(o, "VaultLockPolicy");
+    return __isa(o, "VaultLockPolicy");
   }
 }
 
@@ -2731,6 +2734,6 @@ export interface VaultNotificationConfig {
 
 export namespace VaultNotificationConfig {
   export function isa(o: any): o is VaultNotificationConfig {
-    return _smithy.isa(o, "VaultNotificationConfig");
+    return __isa(o, "VaultNotificationConfig");
   }
 }

--- a/clients/client-glacier/protocols/Aws_restJson1_1.ts
+++ b/clients/client-glacier/protocols/Aws_restJson1_1.ts
@@ -167,7 +167,10 @@ import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  extendedEncodeURIComponent as __extendedEncodeURIComponent
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -184,37 +187,37 @@ export async function serializeAws_restJson1_1AbortMultipartUploadCommand(
   let resolvedPath =
     "/{accountId}/vaults/{vaultName}/multipart-uploads/{uploadId}";
   if (input.accountId !== undefined) {
-    const labelValue: string = input.accountId.toString();
+    const labelValue: string = input.accountId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: accountId.");
     }
     resolvedPath = resolvedPath.replace(
       "{accountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: accountId.");
   }
   if (input.uploadId !== undefined) {
-    const labelValue: string = input.uploadId.toString();
+    const labelValue: string = input.uploadId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: uploadId.");
     }
     resolvedPath = resolvedPath.replace(
       "{uploadId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: uploadId.");
   }
   if (input.vaultName !== undefined) {
-    const labelValue: string = input.vaultName.toString();
+    const labelValue: string = input.vaultName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: vaultName.");
     }
     resolvedPath = resolvedPath.replace(
       "{vaultName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: vaultName.");
@@ -236,25 +239,25 @@ export async function serializeAws_restJson1_1AbortVaultLockCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/{accountId}/vaults/{vaultName}/lock-policy";
   if (input.accountId !== undefined) {
-    const labelValue: string = input.accountId.toString();
+    const labelValue: string = input.accountId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: accountId.");
     }
     resolvedPath = resolvedPath.replace(
       "{accountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: accountId.");
   }
   if (input.vaultName !== undefined) {
-    const labelValue: string = input.vaultName.toString();
+    const labelValue: string = input.vaultName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: vaultName.");
     }
     resolvedPath = resolvedPath.replace(
       "{vaultName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: vaultName.");
@@ -276,25 +279,25 @@ export async function serializeAws_restJson1_1AddTagsToVaultCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/{accountId}/vaults/{vaultName}/tags";
   if (input.accountId !== undefined) {
-    const labelValue: string = input.accountId.toString();
+    const labelValue: string = input.accountId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: accountId.");
     }
     resolvedPath = resolvedPath.replace(
       "{accountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: accountId.");
   }
   if (input.vaultName !== undefined) {
-    const labelValue: string = input.vaultName.toString();
+    const labelValue: string = input.vaultName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: vaultName.");
     }
     resolvedPath = resolvedPath.replace(
       "{vaultName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: vaultName.");
@@ -326,45 +329,45 @@ export async function serializeAws_restJson1_1CompleteMultipartUploadCommand(
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.archiveSize !== undefined) {
-    headers["x-amz-archive-size"] = input.archiveSize.toString();
+    headers["x-amz-archive-size"] = input.archiveSize;
   }
   if (input.checksum !== undefined) {
-    headers["x-amz-sha256-tree-hash"] = input.checksum.toString();
+    headers["x-amz-sha256-tree-hash"] = input.checksum;
   }
   let resolvedPath =
     "/{accountId}/vaults/{vaultName}/multipart-uploads/{uploadId}";
   if (input.accountId !== undefined) {
-    const labelValue: string = input.accountId.toString();
+    const labelValue: string = input.accountId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: accountId.");
     }
     resolvedPath = resolvedPath.replace(
       "{accountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: accountId.");
   }
   if (input.uploadId !== undefined) {
-    const labelValue: string = input.uploadId.toString();
+    const labelValue: string = input.uploadId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: uploadId.");
     }
     resolvedPath = resolvedPath.replace(
       "{uploadId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: uploadId.");
   }
   if (input.vaultName !== undefined) {
-    const labelValue: string = input.vaultName.toString();
+    const labelValue: string = input.vaultName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: vaultName.");
     }
     resolvedPath = resolvedPath.replace(
       "{vaultName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: vaultName.");
@@ -386,37 +389,37 @@ export async function serializeAws_restJson1_1CompleteVaultLockCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/{accountId}/vaults/{vaultName}/lock-policy/{lockId}";
   if (input.accountId !== undefined) {
-    const labelValue: string = input.accountId.toString();
+    const labelValue: string = input.accountId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: accountId.");
     }
     resolvedPath = resolvedPath.replace(
       "{accountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: accountId.");
   }
   if (input.lockId !== undefined) {
-    const labelValue: string = input.lockId.toString();
+    const labelValue: string = input.lockId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: lockId.");
     }
     resolvedPath = resolvedPath.replace(
       "{lockId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: lockId.");
   }
   if (input.vaultName !== undefined) {
-    const labelValue: string = input.vaultName.toString();
+    const labelValue: string = input.vaultName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: vaultName.");
     }
     resolvedPath = resolvedPath.replace(
       "{vaultName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: vaultName.");
@@ -438,25 +441,25 @@ export async function serializeAws_restJson1_1CreateVaultCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/{accountId}/vaults/{vaultName}";
   if (input.accountId !== undefined) {
-    const labelValue: string = input.accountId.toString();
+    const labelValue: string = input.accountId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: accountId.");
     }
     resolvedPath = resolvedPath.replace(
       "{accountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: accountId.");
   }
   if (input.vaultName !== undefined) {
-    const labelValue: string = input.vaultName.toString();
+    const labelValue: string = input.vaultName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: vaultName.");
     }
     resolvedPath = resolvedPath.replace(
       "{vaultName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: vaultName.");
@@ -478,37 +481,37 @@ export async function serializeAws_restJson1_1DeleteArchiveCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/{accountId}/vaults/{vaultName}/archives/{archiveId}";
   if (input.accountId !== undefined) {
-    const labelValue: string = input.accountId.toString();
+    const labelValue: string = input.accountId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: accountId.");
     }
     resolvedPath = resolvedPath.replace(
       "{accountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: accountId.");
   }
   if (input.archiveId !== undefined) {
-    const labelValue: string = input.archiveId.toString();
+    const labelValue: string = input.archiveId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: archiveId.");
     }
     resolvedPath = resolvedPath.replace(
       "{archiveId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: archiveId.");
   }
   if (input.vaultName !== undefined) {
-    const labelValue: string = input.vaultName.toString();
+    const labelValue: string = input.vaultName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: vaultName.");
     }
     resolvedPath = resolvedPath.replace(
       "{vaultName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: vaultName.");
@@ -530,25 +533,25 @@ export async function serializeAws_restJson1_1DeleteVaultCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/{accountId}/vaults/{vaultName}";
   if (input.accountId !== undefined) {
-    const labelValue: string = input.accountId.toString();
+    const labelValue: string = input.accountId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: accountId.");
     }
     resolvedPath = resolvedPath.replace(
       "{accountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: accountId.");
   }
   if (input.vaultName !== undefined) {
-    const labelValue: string = input.vaultName.toString();
+    const labelValue: string = input.vaultName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: vaultName.");
     }
     resolvedPath = resolvedPath.replace(
       "{vaultName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: vaultName.");
@@ -570,25 +573,25 @@ export async function serializeAws_restJson1_1DeleteVaultAccessPolicyCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/{accountId}/vaults/{vaultName}/access-policy";
   if (input.accountId !== undefined) {
-    const labelValue: string = input.accountId.toString();
+    const labelValue: string = input.accountId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: accountId.");
     }
     resolvedPath = resolvedPath.replace(
       "{accountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: accountId.");
   }
   if (input.vaultName !== undefined) {
-    const labelValue: string = input.vaultName.toString();
+    const labelValue: string = input.vaultName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: vaultName.");
     }
     resolvedPath = resolvedPath.replace(
       "{vaultName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: vaultName.");
@@ -611,25 +614,25 @@ export async function serializeAws_restJson1_1DeleteVaultNotificationsCommand(
   let resolvedPath =
     "/{accountId}/vaults/{vaultName}/notification-configuration";
   if (input.accountId !== undefined) {
-    const labelValue: string = input.accountId.toString();
+    const labelValue: string = input.accountId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: accountId.");
     }
     resolvedPath = resolvedPath.replace(
       "{accountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: accountId.");
   }
   if (input.vaultName !== undefined) {
-    const labelValue: string = input.vaultName.toString();
+    const labelValue: string = input.vaultName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: vaultName.");
     }
     resolvedPath = resolvedPath.replace(
       "{vaultName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: vaultName.");
@@ -651,37 +654,37 @@ export async function serializeAws_restJson1_1DescribeJobCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/{accountId}/vaults/{vaultName}/jobs/{jobId}";
   if (input.accountId !== undefined) {
-    const labelValue: string = input.accountId.toString();
+    const labelValue: string = input.accountId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: accountId.");
     }
     resolvedPath = resolvedPath.replace(
       "{accountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: accountId.");
   }
   if (input.jobId !== undefined) {
-    const labelValue: string = input.jobId.toString();
+    const labelValue: string = input.jobId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: jobId.");
     }
     resolvedPath = resolvedPath.replace(
       "{jobId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: jobId.");
   }
   if (input.vaultName !== undefined) {
-    const labelValue: string = input.vaultName.toString();
+    const labelValue: string = input.vaultName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: vaultName.");
     }
     resolvedPath = resolvedPath.replace(
       "{vaultName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: vaultName.");
@@ -703,25 +706,25 @@ export async function serializeAws_restJson1_1DescribeVaultCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/{accountId}/vaults/{vaultName}";
   if (input.accountId !== undefined) {
-    const labelValue: string = input.accountId.toString();
+    const labelValue: string = input.accountId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: accountId.");
     }
     resolvedPath = resolvedPath.replace(
       "{accountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: accountId.");
   }
   if (input.vaultName !== undefined) {
-    const labelValue: string = input.vaultName.toString();
+    const labelValue: string = input.vaultName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: vaultName.");
     }
     resolvedPath = resolvedPath.replace(
       "{vaultName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: vaultName.");
@@ -743,13 +746,13 @@ export async function serializeAws_restJson1_1GetDataRetrievalPolicyCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/{accountId}/policies/data-retrieval";
   if (input.accountId !== undefined) {
-    const labelValue: string = input.accountId.toString();
+    const labelValue: string = input.accountId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: accountId.");
     }
     resolvedPath = resolvedPath.replace(
       "{accountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: accountId.");
@@ -770,41 +773,41 @@ export async function serializeAws_restJson1_1GetJobOutputCommand(
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.range !== undefined) {
-    headers["Range"] = input.range.toString();
+    headers["Range"] = input.range;
   }
   let resolvedPath = "/{accountId}/vaults/{vaultName}/jobs/{jobId}/output";
   if (input.accountId !== undefined) {
-    const labelValue: string = input.accountId.toString();
+    const labelValue: string = input.accountId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: accountId.");
     }
     resolvedPath = resolvedPath.replace(
       "{accountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: accountId.");
   }
   if (input.jobId !== undefined) {
-    const labelValue: string = input.jobId.toString();
+    const labelValue: string = input.jobId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: jobId.");
     }
     resolvedPath = resolvedPath.replace(
       "{jobId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: jobId.");
   }
   if (input.vaultName !== undefined) {
-    const labelValue: string = input.vaultName.toString();
+    const labelValue: string = input.vaultName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: vaultName.");
     }
     resolvedPath = resolvedPath.replace(
       "{vaultName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: vaultName.");
@@ -826,25 +829,25 @@ export async function serializeAws_restJson1_1GetVaultAccessPolicyCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/{accountId}/vaults/{vaultName}/access-policy";
   if (input.accountId !== undefined) {
-    const labelValue: string = input.accountId.toString();
+    const labelValue: string = input.accountId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: accountId.");
     }
     resolvedPath = resolvedPath.replace(
       "{accountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: accountId.");
   }
   if (input.vaultName !== undefined) {
-    const labelValue: string = input.vaultName.toString();
+    const labelValue: string = input.vaultName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: vaultName.");
     }
     resolvedPath = resolvedPath.replace(
       "{vaultName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: vaultName.");
@@ -866,25 +869,25 @@ export async function serializeAws_restJson1_1GetVaultLockCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/{accountId}/vaults/{vaultName}/lock-policy";
   if (input.accountId !== undefined) {
-    const labelValue: string = input.accountId.toString();
+    const labelValue: string = input.accountId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: accountId.");
     }
     resolvedPath = resolvedPath.replace(
       "{accountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: accountId.");
   }
   if (input.vaultName !== undefined) {
-    const labelValue: string = input.vaultName.toString();
+    const labelValue: string = input.vaultName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: vaultName.");
     }
     resolvedPath = resolvedPath.replace(
       "{vaultName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: vaultName.");
@@ -907,25 +910,25 @@ export async function serializeAws_restJson1_1GetVaultNotificationsCommand(
   let resolvedPath =
     "/{accountId}/vaults/{vaultName}/notification-configuration";
   if (input.accountId !== undefined) {
-    const labelValue: string = input.accountId.toString();
+    const labelValue: string = input.accountId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: accountId.");
     }
     resolvedPath = resolvedPath.replace(
       "{accountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: accountId.");
   }
   if (input.vaultName !== undefined) {
-    const labelValue: string = input.vaultName.toString();
+    const labelValue: string = input.vaultName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: vaultName.");
     }
     resolvedPath = resolvedPath.replace(
       "{vaultName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: vaultName.");
@@ -947,25 +950,25 @@ export async function serializeAws_restJson1_1InitiateJobCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/{accountId}/vaults/{vaultName}/jobs";
   if (input.accountId !== undefined) {
-    const labelValue: string = input.accountId.toString();
+    const labelValue: string = input.accountId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: accountId.");
     }
     resolvedPath = resolvedPath.replace(
       "{accountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: accountId.");
   }
   if (input.vaultName !== undefined) {
-    const labelValue: string = input.vaultName.toString();
+    const labelValue: string = input.vaultName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: vaultName.");
     }
     resolvedPath = resolvedPath.replace(
       "{vaultName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: vaultName.");
@@ -995,32 +998,32 @@ export async function serializeAws_restJson1_1InitiateMultipartUploadCommand(
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.archiveDescription !== undefined) {
-    headers["x-amz-archive-description"] = input.archiveDescription.toString();
+    headers["x-amz-archive-description"] = input.archiveDescription;
   }
   if (input.partSize !== undefined) {
-    headers["x-amz-part-size"] = input.partSize.toString();
+    headers["x-amz-part-size"] = input.partSize;
   }
   let resolvedPath = "/{accountId}/vaults/{vaultName}/multipart-uploads";
   if (input.accountId !== undefined) {
-    const labelValue: string = input.accountId.toString();
+    const labelValue: string = input.accountId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: accountId.");
     }
     resolvedPath = resolvedPath.replace(
       "{accountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: accountId.");
   }
   if (input.vaultName !== undefined) {
-    const labelValue: string = input.vaultName.toString();
+    const labelValue: string = input.vaultName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: vaultName.");
     }
     resolvedPath = resolvedPath.replace(
       "{vaultName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: vaultName.");
@@ -1042,25 +1045,25 @@ export async function serializeAws_restJson1_1InitiateVaultLockCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/{accountId}/vaults/{vaultName}/lock-policy";
   if (input.accountId !== undefined) {
-    const labelValue: string = input.accountId.toString();
+    const labelValue: string = input.accountId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: accountId.");
     }
     resolvedPath = resolvedPath.replace(
       "{accountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: accountId.");
   }
   if (input.vaultName !== undefined) {
-    const labelValue: string = input.vaultName.toString();
+    const labelValue: string = input.vaultName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: vaultName.");
     }
     resolvedPath = resolvedPath.replace(
       "{vaultName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: vaultName.");
@@ -1091,41 +1094,49 @@ export async function serializeAws_restJson1_1ListJobsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/{accountId}/vaults/{vaultName}/jobs";
   if (input.accountId !== undefined) {
-    const labelValue: string = input.accountId.toString();
+    const labelValue: string = input.accountId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: accountId.");
     }
     resolvedPath = resolvedPath.replace(
       "{accountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: accountId.");
   }
   if (input.vaultName !== undefined) {
-    const labelValue: string = input.vaultName.toString();
+    const labelValue: string = input.vaultName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: vaultName.");
     }
     resolvedPath = resolvedPath.replace(
       "{vaultName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: vaultName.");
   }
   const query: any = {};
   if (input.completed !== undefined) {
-    query["completed"] = input.completed.toString();
+    query[
+      __extendedEncodeURIComponent("completed")
+    ] = __extendedEncodeURIComponent(input.completed);
   }
   if (input.limit !== undefined) {
-    query["limit"] = input.limit.toString();
+    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
+      input.limit
+    );
   }
   if (input.marker !== undefined) {
-    query["marker"] = input.marker.toString();
+    query[
+      __extendedEncodeURIComponent("marker")
+    ] = __extendedEncodeURIComponent(input.marker);
   }
   if (input.statuscode !== undefined) {
-    query["statuscode"] = input.statuscode.toString();
+    query[
+      __extendedEncodeURIComponent("statuscode")
+    ] = __extendedEncodeURIComponent(input.statuscode);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1145,35 +1156,39 @@ export async function serializeAws_restJson1_1ListMultipartUploadsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/{accountId}/vaults/{vaultName}/multipart-uploads";
   if (input.accountId !== undefined) {
-    const labelValue: string = input.accountId.toString();
+    const labelValue: string = input.accountId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: accountId.");
     }
     resolvedPath = resolvedPath.replace(
       "{accountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: accountId.");
   }
   if (input.vaultName !== undefined) {
-    const labelValue: string = input.vaultName.toString();
+    const labelValue: string = input.vaultName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: vaultName.");
     }
     resolvedPath = resolvedPath.replace(
       "{vaultName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: vaultName.");
   }
   const query: any = {};
   if (input.limit !== undefined) {
-    query["limit"] = input.limit.toString();
+    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
+      input.limit
+    );
   }
   if (input.marker !== undefined) {
-    query["marker"] = input.marker.toString();
+    query[
+      __extendedEncodeURIComponent("marker")
+    ] = __extendedEncodeURIComponent(input.marker);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1194,47 +1209,51 @@ export async function serializeAws_restJson1_1ListPartsCommand(
   let resolvedPath =
     "/{accountId}/vaults/{vaultName}/multipart-uploads/{uploadId}";
   if (input.accountId !== undefined) {
-    const labelValue: string = input.accountId.toString();
+    const labelValue: string = input.accountId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: accountId.");
     }
     resolvedPath = resolvedPath.replace(
       "{accountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: accountId.");
   }
   if (input.uploadId !== undefined) {
-    const labelValue: string = input.uploadId.toString();
+    const labelValue: string = input.uploadId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: uploadId.");
     }
     resolvedPath = resolvedPath.replace(
       "{uploadId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: uploadId.");
   }
   if (input.vaultName !== undefined) {
-    const labelValue: string = input.vaultName.toString();
+    const labelValue: string = input.vaultName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: vaultName.");
     }
     resolvedPath = resolvedPath.replace(
       "{vaultName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: vaultName.");
   }
   const query: any = {};
   if (input.limit !== undefined) {
-    query["limit"] = input.limit.toString();
+    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
+      input.limit
+    );
   }
   if (input.marker !== undefined) {
-    query["marker"] = input.marker.toString();
+    query[
+      __extendedEncodeURIComponent("marker")
+    ] = __extendedEncodeURIComponent(input.marker);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1254,13 +1273,13 @@ export async function serializeAws_restJson1_1ListProvisionedCapacityCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/{accountId}/provisioned-capacity";
   if (input.accountId !== undefined) {
-    const labelValue: string = input.accountId.toString();
+    const labelValue: string = input.accountId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: accountId.");
     }
     resolvedPath = resolvedPath.replace(
       "{accountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: accountId.");
@@ -1282,25 +1301,25 @@ export async function serializeAws_restJson1_1ListTagsForVaultCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/{accountId}/vaults/{vaultName}/tags";
   if (input.accountId !== undefined) {
-    const labelValue: string = input.accountId.toString();
+    const labelValue: string = input.accountId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: accountId.");
     }
     resolvedPath = resolvedPath.replace(
       "{accountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: accountId.");
   }
   if (input.vaultName !== undefined) {
-    const labelValue: string = input.vaultName.toString();
+    const labelValue: string = input.vaultName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: vaultName.");
     }
     resolvedPath = resolvedPath.replace(
       "{vaultName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: vaultName.");
@@ -1322,23 +1341,27 @@ export async function serializeAws_restJson1_1ListVaultsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/{accountId}/vaults";
   if (input.accountId !== undefined) {
-    const labelValue: string = input.accountId.toString();
+    const labelValue: string = input.accountId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: accountId.");
     }
     resolvedPath = resolvedPath.replace(
       "{accountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: accountId.");
   }
   const query: any = {};
   if (input.limit !== undefined) {
-    query["limit"] = input.limit.toString();
+    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
+      input.limit
+    );
   }
   if (input.marker !== undefined) {
-    query["marker"] = input.marker.toString();
+    query[
+      __extendedEncodeURIComponent("marker")
+    ] = __extendedEncodeURIComponent(input.marker);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1358,13 +1381,13 @@ export async function serializeAws_restJson1_1PurchaseProvisionedCapacityCommand
   headers["Content-Type"] = "";
   let resolvedPath = "/{accountId}/provisioned-capacity";
   if (input.accountId !== undefined) {
-    const labelValue: string = input.accountId.toString();
+    const labelValue: string = input.accountId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: accountId.");
     }
     resolvedPath = resolvedPath.replace(
       "{accountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: accountId.");
@@ -1386,25 +1409,25 @@ export async function serializeAws_restJson1_1RemoveTagsFromVaultCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/{accountId}/vaults/{vaultName}/tags";
   if (input.accountId !== undefined) {
-    const labelValue: string = input.accountId.toString();
+    const labelValue: string = input.accountId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: accountId.");
     }
     resolvedPath = resolvedPath.replace(
       "{accountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: accountId.");
   }
   if (input.vaultName !== undefined) {
-    const labelValue: string = input.vaultName.toString();
+    const labelValue: string = input.vaultName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: vaultName.");
     }
     resolvedPath = resolvedPath.replace(
       "{vaultName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: vaultName.");
@@ -1440,13 +1463,13 @@ export async function serializeAws_restJson1_1SetDataRetrievalPolicyCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/{accountId}/policies/data-retrieval";
   if (input.accountId !== undefined) {
-    const labelValue: string = input.accountId.toString();
+    const labelValue: string = input.accountId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: accountId.");
     }
     resolvedPath = resolvedPath.replace(
       "{accountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: accountId.");
@@ -1478,25 +1501,25 @@ export async function serializeAws_restJson1_1SetVaultAccessPolicyCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/{accountId}/vaults/{vaultName}/access-policy";
   if (input.accountId !== undefined) {
-    const labelValue: string = input.accountId.toString();
+    const labelValue: string = input.accountId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: accountId.");
     }
     resolvedPath = resolvedPath.replace(
       "{accountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: accountId.");
   }
   if (input.vaultName !== undefined) {
-    const labelValue: string = input.vaultName.toString();
+    const labelValue: string = input.vaultName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: vaultName.");
     }
     resolvedPath = resolvedPath.replace(
       "{vaultName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: vaultName.");
@@ -1528,25 +1551,25 @@ export async function serializeAws_restJson1_1SetVaultNotificationsCommand(
   let resolvedPath =
     "/{accountId}/vaults/{vaultName}/notification-configuration";
   if (input.accountId !== undefined) {
-    const labelValue: string = input.accountId.toString();
+    const labelValue: string = input.accountId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: accountId.");
     }
     resolvedPath = resolvedPath.replace(
       "{accountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: accountId.");
   }
   if (input.vaultName !== undefined) {
-    const labelValue: string = input.vaultName.toString();
+    const labelValue: string = input.vaultName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: vaultName.");
     }
     resolvedPath = resolvedPath.replace(
       "{vaultName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: vaultName.");
@@ -1579,32 +1602,32 @@ export async function serializeAws_restJson1_1UploadArchiveCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/octet-stream";
   if (input.archiveDescription !== undefined) {
-    headers["x-amz-archive-description"] = input.archiveDescription.toString();
+    headers["x-amz-archive-description"] = input.archiveDescription;
   }
   if (input.checksum !== undefined) {
-    headers["x-amz-sha256-tree-hash"] = input.checksum.toString();
+    headers["x-amz-sha256-tree-hash"] = input.checksum;
   }
   let resolvedPath = "/{accountId}/vaults/{vaultName}/archives";
   if (input.accountId !== undefined) {
-    const labelValue: string = input.accountId.toString();
+    const labelValue: string = input.accountId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: accountId.");
     }
     resolvedPath = resolvedPath.replace(
       "{accountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: accountId.");
   }
   if (input.vaultName !== undefined) {
-    const labelValue: string = input.vaultName.toString();
+    const labelValue: string = input.vaultName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: vaultName.");
     }
     resolvedPath = resolvedPath.replace(
       "{vaultName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: vaultName.");
@@ -1630,45 +1653,45 @@ export async function serializeAws_restJson1_1UploadMultipartPartCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/octet-stream";
   if (input.checksum !== undefined) {
-    headers["x-amz-sha256-tree-hash"] = input.checksum.toString();
+    headers["x-amz-sha256-tree-hash"] = input.checksum;
   }
   if (input.range !== undefined) {
-    headers["Content-Range"] = input.range.toString();
+    headers["Content-Range"] = input.range;
   }
   let resolvedPath =
     "/{accountId}/vaults/{vaultName}/multipart-uploads/{uploadId}";
   if (input.accountId !== undefined) {
-    const labelValue: string = input.accountId.toString();
+    const labelValue: string = input.accountId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: accountId.");
     }
     resolvedPath = resolvedPath.replace(
       "{accountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: accountId.");
   }
   if (input.uploadId !== undefined) {
-    const labelValue: string = input.uploadId.toString();
+    const labelValue: string = input.uploadId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: uploadId.");
     }
     resolvedPath = resolvedPath.replace(
       "{uploadId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: uploadId.");
   }
   if (input.vaultName !== undefined) {
-    const labelValue: string = input.vaultName.toString();
+    const labelValue: string = input.vaultName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: vaultName.");
     }
     resolvedPath = resolvedPath.replace(
       "{vaultName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: vaultName.");
@@ -1700,6 +1723,7 @@ export async function deserializeAws_restJson1_1AbortMultipartUploadCommand(
   const contents: AbortMultipartUploadCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -1771,6 +1795,7 @@ export async function deserializeAws_restJson1_1AbortVaultLockCommand(
   const contents: AbortVaultLockCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -1842,6 +1867,7 @@ export async function deserializeAws_restJson1_1AddTagsToVaultCommand(
   const contents: AddTagsToVaultCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -1933,6 +1959,7 @@ export async function deserializeAws_restJson1_1CompleteMultipartUploadCommand(
   if (output.headers["location"] !== undefined) {
     contents.location = output.headers["location"];
   }
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2004,6 +2031,7 @@ export async function deserializeAws_restJson1_1CompleteVaultLockCommand(
   const contents: CompleteVaultLockCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2077,6 +2105,7 @@ export async function deserializeAws_restJson1_1CreateVaultCommand(
   if (output.headers["location"] !== undefined) {
     contents.location = output.headers["location"];
   }
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2145,6 +2174,7 @@ export async function deserializeAws_restJson1_1DeleteArchiveCommand(
   const contents: DeleteArchiveCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2213,6 +2243,7 @@ export async function deserializeAws_restJson1_1DeleteVaultCommand(
   const contents: DeleteVaultCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2284,6 +2315,7 @@ export async function deserializeAws_restJson1_1DeleteVaultAccessPolicyCommand(
   const contents: DeleteVaultAccessPolicyCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2355,6 +2387,7 @@ export async function deserializeAws_restJson1_1DeleteVaultNotificationsCommand(
   const contents: DeleteVaultNotificationsCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -3112,6 +3145,7 @@ export async function deserializeAws_restJson1_1InitiateJobCommand(
   if (output.headers["location"] !== undefined) {
     contents.location = output.headers["location"];
   }
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -3206,6 +3240,7 @@ export async function deserializeAws_restJson1_1InitiateMultipartUploadCommand(
   if (output.headers["x-amz-multipart-upload-id"] !== undefined) {
     contents.uploadId = output.headers["x-amz-multipart-upload-id"];
   }
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -3282,6 +3317,7 @@ export async function deserializeAws_restJson1_1InitiateVaultLockCommand(
   if (output.headers["x-amz-lock-id"] !== undefined) {
     contents.lockId = output.headers["x-amz-lock-id"];
   }
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -3855,6 +3891,7 @@ export async function deserializeAws_restJson1_1PurchaseProvisionedCapacityComma
   if (output.headers["x-amz-capacity-id"] !== undefined) {
     contents.capacityId = output.headers["x-amz-capacity-id"];
   }
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -3926,6 +3963,7 @@ export async function deserializeAws_restJson1_1RemoveTagsFromVaultCommand(
   const contents: RemoveTagsFromVaultCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -3997,6 +4035,7 @@ export async function deserializeAws_restJson1_1SetDataRetrievalPolicyCommand(
   const contents: SetDataRetrievalPolicyCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -4061,6 +4100,7 @@ export async function deserializeAws_restJson1_1SetVaultAccessPolicyCommand(
   const contents: SetVaultAccessPolicyCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -4132,6 +4172,7 @@ export async function deserializeAws_restJson1_1SetVaultNotificationsCommand(
   const contents: SetVaultNotificationsCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -4213,6 +4254,7 @@ export async function deserializeAws_restJson1_1UploadArchiveCommand(
   if (output.headers["location"] !== undefined) {
     contents.location = output.headers["location"];
   }
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -4296,6 +4338,7 @@ export async function deserializeAws_restJson1_1UploadMultipartPartCommand(
   if (output.headers["x-amz-sha256-tree-hash"] !== undefined) {
     contents.checksum = output.headers["x-amz-sha256-tree-hash"];
   }
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 

--- a/clients/client-global-accelerator/models/index.ts
+++ b/clients/client-global-accelerator/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -64,7 +67,7 @@ export interface Accelerator {
 
 export namespace Accelerator {
   export function isa(o: any): o is Accelerator {
-    return _smithy.isa(o, "Accelerator");
+    return __isa(o, "Accelerator");
   }
 }
 
@@ -98,7 +101,7 @@ export interface AcceleratorAttributes {
 
 export namespace AcceleratorAttributes {
   export function isa(o: any): o is AcceleratorAttributes {
-    return _smithy.isa(o, "AcceleratorAttributes");
+    return __isa(o, "AcceleratorAttributes");
   }
 }
 
@@ -106,7 +109,7 @@ export namespace AcceleratorAttributes {
  * <p>The accelerator that you specified could not be disabled.</p>
  */
 export interface AcceleratorNotDisabledException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AcceleratorNotDisabledException";
   $fault: "client";
@@ -115,7 +118,7 @@ export interface AcceleratorNotDisabledException
 
 export namespace AcceleratorNotDisabledException {
   export function isa(o: any): o is AcceleratorNotDisabledException {
-    return _smithy.isa(o, "AcceleratorNotDisabledException");
+    return __isa(o, "AcceleratorNotDisabledException");
   }
 }
 
@@ -123,7 +126,7 @@ export namespace AcceleratorNotDisabledException {
  * <p>The accelerator that you specified doesn't exist.</p>
  */
 export interface AcceleratorNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AcceleratorNotFoundException";
   $fault: "client";
@@ -132,7 +135,7 @@ export interface AcceleratorNotFoundException
 
 export namespace AcceleratorNotFoundException {
   export function isa(o: any): o is AcceleratorNotFoundException {
-    return _smithy.isa(o, "AcceleratorNotFoundException");
+    return __isa(o, "AcceleratorNotFoundException");
   }
 }
 
@@ -142,7 +145,7 @@ export type AcceleratorStatus = "DEPLOYED" | "IN_PROGRESS";
  * <p>You don't have access permission.</p>
  */
 export interface AccessDeniedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AccessDeniedException";
   $fault: "client";
@@ -151,7 +154,7 @@ export interface AccessDeniedException
 
 export namespace AccessDeniedException {
   export function isa(o: any): o is AccessDeniedException {
-    return _smithy.isa(o, "AccessDeniedException");
+    return __isa(o, "AccessDeniedException");
   }
 }
 
@@ -160,7 +163,7 @@ export namespace AccessDeniedException {
  * 			from a listener before you can delete it.</p>
  */
 export interface AssociatedEndpointGroupFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AssociatedEndpointGroupFoundException";
   $fault: "client";
@@ -169,7 +172,7 @@ export interface AssociatedEndpointGroupFoundException
 
 export namespace AssociatedEndpointGroupFoundException {
   export function isa(o: any): o is AssociatedEndpointGroupFoundException {
-    return _smithy.isa(o, "AssociatedEndpointGroupFoundException");
+    return __isa(o, "AssociatedEndpointGroupFoundException");
   }
 }
 
@@ -178,7 +181,7 @@ export namespace AssociatedEndpointGroupFoundException {
  * 			accelerator before you can delete it.</p>
  */
 export interface AssociatedListenerFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AssociatedListenerFoundException";
   $fault: "client";
@@ -187,7 +190,7 @@ export interface AssociatedListenerFoundException
 
 export namespace AssociatedListenerFoundException {
   export function isa(o: any): o is AssociatedListenerFoundException {
-    return _smithy.isa(o, "AssociatedListenerFoundException");
+    return __isa(o, "AssociatedListenerFoundException");
   }
 }
 
@@ -222,7 +225,7 @@ export interface CreateAcceleratorRequest {
 
 export namespace CreateAcceleratorRequest {
   export function isa(o: any): o is CreateAcceleratorRequest {
-    return _smithy.isa(o, "CreateAcceleratorRequest");
+    return __isa(o, "CreateAcceleratorRequest");
   }
 }
 
@@ -236,7 +239,7 @@ export interface CreateAcceleratorResponse extends $MetadataBearer {
 
 export namespace CreateAcceleratorResponse {
   export function isa(o: any): o is CreateAcceleratorResponse {
-    return _smithy.isa(o, "CreateAcceleratorResponse");
+    return __isa(o, "CreateAcceleratorResponse");
   }
 }
 
@@ -306,7 +309,7 @@ export interface CreateEndpointGroupRequest {
 
 export namespace CreateEndpointGroupRequest {
   export function isa(o: any): o is CreateEndpointGroupRequest {
-    return _smithy.isa(o, "CreateEndpointGroupRequest");
+    return __isa(o, "CreateEndpointGroupRequest");
   }
 }
 
@@ -320,7 +323,7 @@ export interface CreateEndpointGroupResponse extends $MetadataBearer {
 
 export namespace CreateEndpointGroupResponse {
   export function isa(o: any): o is CreateEndpointGroupResponse {
-    return _smithy.isa(o, "CreateEndpointGroupResponse");
+    return __isa(o, "CreateEndpointGroupResponse");
   }
 }
 
@@ -366,7 +369,7 @@ export interface CreateListenerRequest {
 
 export namespace CreateListenerRequest {
   export function isa(o: any): o is CreateListenerRequest {
-    return _smithy.isa(o, "CreateListenerRequest");
+    return __isa(o, "CreateListenerRequest");
   }
 }
 
@@ -380,7 +383,7 @@ export interface CreateListenerResponse extends $MetadataBearer {
 
 export namespace CreateListenerResponse {
   export function isa(o: any): o is CreateListenerResponse {
-    return _smithy.isa(o, "CreateListenerResponse");
+    return __isa(o, "CreateListenerResponse");
   }
 }
 
@@ -394,7 +397,7 @@ export interface DeleteAcceleratorRequest {
 
 export namespace DeleteAcceleratorRequest {
   export function isa(o: any): o is DeleteAcceleratorRequest {
-    return _smithy.isa(o, "DeleteAcceleratorRequest");
+    return __isa(o, "DeleteAcceleratorRequest");
   }
 }
 
@@ -408,7 +411,7 @@ export interface DeleteEndpointGroupRequest {
 
 export namespace DeleteEndpointGroupRequest {
   export function isa(o: any): o is DeleteEndpointGroupRequest {
-    return _smithy.isa(o, "DeleteEndpointGroupRequest");
+    return __isa(o, "DeleteEndpointGroupRequest");
   }
 }
 
@@ -422,7 +425,7 @@ export interface DeleteListenerRequest {
 
 export namespace DeleteListenerRequest {
   export function isa(o: any): o is DeleteListenerRequest {
-    return _smithy.isa(o, "DeleteListenerRequest");
+    return __isa(o, "DeleteListenerRequest");
   }
 }
 
@@ -436,7 +439,7 @@ export interface DescribeAcceleratorAttributesRequest {
 
 export namespace DescribeAcceleratorAttributesRequest {
   export function isa(o: any): o is DescribeAcceleratorAttributesRequest {
-    return _smithy.isa(o, "DescribeAcceleratorAttributesRequest");
+    return __isa(o, "DescribeAcceleratorAttributesRequest");
   }
 }
 
@@ -450,7 +453,7 @@ export interface DescribeAcceleratorAttributesResponse extends $MetadataBearer {
 
 export namespace DescribeAcceleratorAttributesResponse {
   export function isa(o: any): o is DescribeAcceleratorAttributesResponse {
-    return _smithy.isa(o, "DescribeAcceleratorAttributesResponse");
+    return __isa(o, "DescribeAcceleratorAttributesResponse");
   }
 }
 
@@ -464,7 +467,7 @@ export interface DescribeAcceleratorRequest {
 
 export namespace DescribeAcceleratorRequest {
   export function isa(o: any): o is DescribeAcceleratorRequest {
-    return _smithy.isa(o, "DescribeAcceleratorRequest");
+    return __isa(o, "DescribeAcceleratorRequest");
   }
 }
 
@@ -478,7 +481,7 @@ export interface DescribeAcceleratorResponse extends $MetadataBearer {
 
 export namespace DescribeAcceleratorResponse {
   export function isa(o: any): o is DescribeAcceleratorResponse {
-    return _smithy.isa(o, "DescribeAcceleratorResponse");
+    return __isa(o, "DescribeAcceleratorResponse");
   }
 }
 
@@ -492,7 +495,7 @@ export interface DescribeEndpointGroupRequest {
 
 export namespace DescribeEndpointGroupRequest {
   export function isa(o: any): o is DescribeEndpointGroupRequest {
-    return _smithy.isa(o, "DescribeEndpointGroupRequest");
+    return __isa(o, "DescribeEndpointGroupRequest");
   }
 }
 
@@ -506,7 +509,7 @@ export interface DescribeEndpointGroupResponse extends $MetadataBearer {
 
 export namespace DescribeEndpointGroupResponse {
   export function isa(o: any): o is DescribeEndpointGroupResponse {
-    return _smithy.isa(o, "DescribeEndpointGroupResponse");
+    return __isa(o, "DescribeEndpointGroupResponse");
   }
 }
 
@@ -520,7 +523,7 @@ export interface DescribeListenerRequest {
 
 export namespace DescribeListenerRequest {
   export function isa(o: any): o is DescribeListenerRequest {
-    return _smithy.isa(o, "DescribeListenerRequest");
+    return __isa(o, "DescribeListenerRequest");
   }
 }
 
@@ -534,7 +537,7 @@ export interface DescribeListenerResponse extends $MetadataBearer {
 
 export namespace DescribeListenerResponse {
   export function isa(o: any): o is DescribeListenerResponse {
-    return _smithy.isa(o, "DescribeListenerResponse");
+    return __isa(o, "DescribeListenerResponse");
   }
 }
 
@@ -572,7 +575,7 @@ export interface EndpointConfiguration {
 
 export namespace EndpointConfiguration {
   export function isa(o: any): o is EndpointConfiguration {
-    return _smithy.isa(o, "EndpointConfiguration");
+    return __isa(o, "EndpointConfiguration");
   }
 }
 
@@ -650,7 +653,7 @@ export interface EndpointDescription {
 
 export namespace EndpointDescription {
   export function isa(o: any): o is EndpointDescription {
-    return _smithy.isa(o, "EndpointDescription");
+    return __isa(o, "EndpointDescription");
   }
 }
 
@@ -718,7 +721,7 @@ export interface EndpointGroup {
 
 export namespace EndpointGroup {
   export function isa(o: any): o is EndpointGroup {
-    return _smithy.isa(o, "EndpointGroup");
+    return __isa(o, "EndpointGroup");
   }
 }
 
@@ -726,7 +729,7 @@ export namespace EndpointGroup {
  * <p>The endpoint group that you specified already exists.</p>
  */
 export interface EndpointGroupAlreadyExistsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "EndpointGroupAlreadyExistsException";
   $fault: "client";
@@ -735,7 +738,7 @@ export interface EndpointGroupAlreadyExistsException
 
 export namespace EndpointGroupAlreadyExistsException {
   export function isa(o: any): o is EndpointGroupAlreadyExistsException {
-    return _smithy.isa(o, "EndpointGroupAlreadyExistsException");
+    return __isa(o, "EndpointGroupAlreadyExistsException");
   }
 }
 
@@ -743,7 +746,7 @@ export namespace EndpointGroupAlreadyExistsException {
  * <p>The endpoint group that you specified doesn't exist.</p>
  */
 export interface EndpointGroupNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "EndpointGroupNotFoundException";
   $fault: "client";
@@ -752,7 +755,7 @@ export interface EndpointGroupNotFoundException
 
 export namespace EndpointGroupNotFoundException {
   export function isa(o: any): o is EndpointGroupNotFoundException {
-    return _smithy.isa(o, "EndpointGroupNotFoundException");
+    return __isa(o, "EndpointGroupNotFoundException");
   }
 }
 
@@ -768,7 +771,7 @@ export type HealthState = "HEALTHY" | "INITIAL" | "UNHEALTHY";
  * <p>There was an internal error for AWS Global Accelerator.</p>
  */
 export interface InternalServiceErrorException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalServiceErrorException";
   $fault: "server";
@@ -777,7 +780,7 @@ export interface InternalServiceErrorException
 
 export namespace InternalServiceErrorException {
   export function isa(o: any): o is InternalServiceErrorException {
-    return _smithy.isa(o, "InternalServiceErrorException");
+    return __isa(o, "InternalServiceErrorException");
   }
 }
 
@@ -785,7 +788,7 @@ export namespace InternalServiceErrorException {
  * <p>An argument that you specified is invalid.</p>
  */
 export interface InvalidArgumentException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidArgumentException";
   $fault: "client";
@@ -794,7 +797,7 @@ export interface InvalidArgumentException
 
 export namespace InvalidArgumentException {
   export function isa(o: any): o is InvalidArgumentException {
-    return _smithy.isa(o, "InvalidArgumentException");
+    return __isa(o, "InvalidArgumentException");
   }
 }
 
@@ -802,7 +805,7 @@ export namespace InvalidArgumentException {
  * <p>There isn't another item to return.</p>
  */
 export interface InvalidNextTokenException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidNextTokenException";
   $fault: "client";
@@ -811,7 +814,7 @@ export interface InvalidNextTokenException
 
 export namespace InvalidNextTokenException {
   export function isa(o: any): o is InvalidNextTokenException {
-    return _smithy.isa(o, "InvalidNextTokenException");
+    return __isa(o, "InvalidNextTokenException");
   }
 }
 
@@ -819,7 +822,7 @@ export namespace InvalidNextTokenException {
  * <p>The port numbers that you specified are not valid numbers or are not unique for this accelerator.</p>
  */
 export interface InvalidPortRangeException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidPortRangeException";
   $fault: "client";
@@ -828,7 +831,7 @@ export interface InvalidPortRangeException
 
 export namespace InvalidPortRangeException {
   export function isa(o: any): o is InvalidPortRangeException {
-    return _smithy.isa(o, "InvalidPortRangeException");
+    return __isa(o, "InvalidPortRangeException");
   }
 }
 
@@ -854,7 +857,7 @@ export interface IpSet {
 
 export namespace IpSet {
   export function isa(o: any): o is IpSet {
-    return _smithy.isa(o, "IpSet");
+    return __isa(o, "IpSet");
   }
 }
 
@@ -862,7 +865,7 @@ export namespace IpSet {
  * <p>Processing your request would cause you to exceed an AWS Global Accelerator limit.</p>
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -871,7 +874,7 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
@@ -890,7 +893,7 @@ export interface ListAcceleratorsRequest {
 
 export namespace ListAcceleratorsRequest {
   export function isa(o: any): o is ListAcceleratorsRequest {
-    return _smithy.isa(o, "ListAcceleratorsRequest");
+    return __isa(o, "ListAcceleratorsRequest");
   }
 }
 
@@ -909,7 +912,7 @@ export interface ListAcceleratorsResponse extends $MetadataBearer {
 
 export namespace ListAcceleratorsResponse {
   export function isa(o: any): o is ListAcceleratorsResponse {
-    return _smithy.isa(o, "ListAcceleratorsResponse");
+    return __isa(o, "ListAcceleratorsResponse");
   }
 }
 
@@ -933,7 +936,7 @@ export interface ListEndpointGroupsRequest {
 
 export namespace ListEndpointGroupsRequest {
   export function isa(o: any): o is ListEndpointGroupsRequest {
-    return _smithy.isa(o, "ListEndpointGroupsRequest");
+    return __isa(o, "ListEndpointGroupsRequest");
   }
 }
 
@@ -952,7 +955,7 @@ export interface ListEndpointGroupsResponse extends $MetadataBearer {
 
 export namespace ListEndpointGroupsResponse {
   export function isa(o: any): o is ListEndpointGroupsResponse {
-    return _smithy.isa(o, "ListEndpointGroupsResponse");
+    return __isa(o, "ListEndpointGroupsResponse");
   }
 }
 
@@ -976,7 +979,7 @@ export interface ListListenersRequest {
 
 export namespace ListListenersRequest {
   export function isa(o: any): o is ListListenersRequest {
-    return _smithy.isa(o, "ListListenersRequest");
+    return __isa(o, "ListListenersRequest");
   }
 }
 
@@ -995,7 +998,7 @@ export interface ListListenersResponse extends $MetadataBearer {
 
 export namespace ListListenersResponse {
   export function isa(o: any): o is ListListenersResponse {
-    return _smithy.isa(o, "ListListenersResponse");
+    return __isa(o, "ListListenersResponse");
   }
 }
 
@@ -1038,7 +1041,7 @@ export interface Listener {
 
 export namespace Listener {
   export function isa(o: any): o is Listener {
-    return _smithy.isa(o, "Listener");
+    return __isa(o, "Listener");
   }
 }
 
@@ -1046,7 +1049,7 @@ export namespace Listener {
  * <p>The listener that you specified doesn't exist.</p>
  */
 export interface ListenerNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ListenerNotFoundException";
   $fault: "client";
@@ -1055,7 +1058,7 @@ export interface ListenerNotFoundException
 
 export namespace ListenerNotFoundException {
   export function isa(o: any): o is ListenerNotFoundException {
-    return _smithy.isa(o, "ListenerNotFoundException");
+    return __isa(o, "ListenerNotFoundException");
   }
 }
 
@@ -1077,7 +1080,7 @@ export interface PortRange {
 
 export namespace PortRange {
   export function isa(o: any): o is PortRange {
-    return _smithy.isa(o, "PortRange");
+    return __isa(o, "PortRange");
   }
 }
 
@@ -1118,7 +1121,7 @@ export interface UpdateAcceleratorAttributesRequest {
 
 export namespace UpdateAcceleratorAttributesRequest {
   export function isa(o: any): o is UpdateAcceleratorAttributesRequest {
-    return _smithy.isa(o, "UpdateAcceleratorAttributesRequest");
+    return __isa(o, "UpdateAcceleratorAttributesRequest");
   }
 }
 
@@ -1132,7 +1135,7 @@ export interface UpdateAcceleratorAttributesResponse extends $MetadataBearer {
 
 export namespace UpdateAcceleratorAttributesResponse {
   export function isa(o: any): o is UpdateAcceleratorAttributesResponse {
-    return _smithy.isa(o, "UpdateAcceleratorAttributesResponse");
+    return __isa(o, "UpdateAcceleratorAttributesResponse");
   }
 }
 
@@ -1164,7 +1167,7 @@ export interface UpdateAcceleratorRequest {
 
 export namespace UpdateAcceleratorRequest {
   export function isa(o: any): o is UpdateAcceleratorRequest {
-    return _smithy.isa(o, "UpdateAcceleratorRequest");
+    return __isa(o, "UpdateAcceleratorRequest");
   }
 }
 
@@ -1178,7 +1181,7 @@ export interface UpdateAcceleratorResponse extends $MetadataBearer {
 
 export namespace UpdateAcceleratorResponse {
   export function isa(o: any): o is UpdateAcceleratorResponse {
-    return _smithy.isa(o, "UpdateAcceleratorResponse");
+    return __isa(o, "UpdateAcceleratorResponse");
   }
 }
 
@@ -1236,7 +1239,7 @@ export interface UpdateEndpointGroupRequest {
 
 export namespace UpdateEndpointGroupRequest {
   export function isa(o: any): o is UpdateEndpointGroupRequest {
-    return _smithy.isa(o, "UpdateEndpointGroupRequest");
+    return __isa(o, "UpdateEndpointGroupRequest");
   }
 }
 
@@ -1250,7 +1253,7 @@ export interface UpdateEndpointGroupResponse extends $MetadataBearer {
 
 export namespace UpdateEndpointGroupResponse {
   export function isa(o: any): o is UpdateEndpointGroupResponse {
-    return _smithy.isa(o, "UpdateEndpointGroupResponse");
+    return __isa(o, "UpdateEndpointGroupResponse");
   }
 }
 
@@ -1290,7 +1293,7 @@ export interface UpdateListenerRequest {
 
 export namespace UpdateListenerRequest {
   export function isa(o: any): o is UpdateListenerRequest {
-    return _smithy.isa(o, "UpdateListenerRequest");
+    return __isa(o, "UpdateListenerRequest");
   }
 }
 
@@ -1304,6 +1307,6 @@ export interface UpdateListenerResponse extends $MetadataBearer {
 
 export namespace UpdateListenerResponse {
   export function isa(o: any): o is UpdateListenerResponse {
-    return _smithy.isa(o, "UpdateListenerResponse");
+    return __isa(o, "UpdateListenerResponse");
   }
 }

--- a/clients/client-global-accelerator/protocols/Aws_json1_1.ts
+++ b/clients/client-global-accelerator/protocols/Aws_json1_1.ts
@@ -635,6 +635,7 @@ export async function deserializeAws_json1_1DeleteAcceleratorCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1DeleteAcceleratorCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteAcceleratorCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -717,6 +718,7 @@ export async function deserializeAws_json1_1DeleteEndpointGroupCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteEndpointGroupCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -782,6 +784,7 @@ export async function deserializeAws_json1_1DeleteListenerCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1DeleteListenerCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteListenerCommandOutput = {
     $metadata: deserializeMetadata(output)
   };

--- a/clients/client-glue/models/index.ts
+++ b/clients/client-glue/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export interface GetTagsRequest {
@@ -11,7 +14,7 @@ export interface GetTagsRequest {
 
 export namespace GetTagsRequest {
   export function isa(o: any): o is GetTagsRequest {
-    return _smithy.isa(o, "GetTagsRequest");
+    return __isa(o, "GetTagsRequest");
   }
 }
 
@@ -25,7 +28,7 @@ export interface GetTagsResponse extends $MetadataBearer {
 
 export namespace GetTagsResponse {
   export function isa(o: any): o is GetTagsResponse {
-    return _smithy.isa(o, "GetTagsResponse");
+    return __isa(o, "GetTagsResponse");
   }
 }
 
@@ -45,7 +48,7 @@ export interface TagResourceRequest {
 
 export namespace TagResourceRequest {
   export function isa(o: any): o is TagResourceRequest {
-    return _smithy.isa(o, "TagResourceRequest");
+    return __isa(o, "TagResourceRequest");
   }
 }
 
@@ -55,7 +58,7 @@ export interface TagResourceResponse extends $MetadataBearer {
 
 export namespace TagResourceResponse {
   export function isa(o: any): o is TagResourceResponse {
-    return _smithy.isa(o, "TagResourceResponse");
+    return __isa(o, "TagResourceResponse");
   }
 }
 
@@ -74,7 +77,7 @@ export interface UntagResourceRequest {
 
 export namespace UntagResourceRequest {
   export function isa(o: any): o is UntagResourceRequest {
-    return _smithy.isa(o, "UntagResourceRequest");
+    return __isa(o, "UntagResourceRequest");
   }
 }
 
@@ -84,7 +87,7 @@ export interface UntagResourceResponse extends $MetadataBearer {
 
 export namespace UntagResourceResponse {
   export function isa(o: any): o is UntagResourceResponse {
-    return _smithy.isa(o, "UntagResourceResponse");
+    return __isa(o, "UntagResourceResponse");
   }
 }
 
@@ -116,7 +119,7 @@ export type WorkerType = "G.1X" | "G.2X" | "Standard";
  * <p>Access to a resource was denied.</p>
  */
 export interface AccessDeniedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AccessDeniedException";
   $fault: "client";
@@ -128,7 +131,7 @@ export interface AccessDeniedException
 
 export namespace AccessDeniedException {
   export function isa(o: any): o is AccessDeniedException {
-    return _smithy.isa(o, "AccessDeniedException");
+    return __isa(o, "AccessDeniedException");
   }
 }
 
@@ -136,7 +139,7 @@ export namespace AccessDeniedException {
  * <p>A resource to be created or added already exists.</p>
  */
 export interface AlreadyExistsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AlreadyExistsException";
   $fault: "client";
@@ -148,7 +151,7 @@ export interface AlreadyExistsException
 
 export namespace AlreadyExistsException {
   export function isa(o: any): o is AlreadyExistsException {
-    return _smithy.isa(o, "AlreadyExistsException");
+    return __isa(o, "AlreadyExistsException");
   }
 }
 
@@ -156,7 +159,7 @@ export namespace AlreadyExistsException {
  * <p>Two processes are trying to modify a resource simultaneously.</p>
  */
 export interface ConcurrentModificationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ConcurrentModificationException";
   $fault: "client";
@@ -168,7 +171,7 @@ export interface ConcurrentModificationException
 
 export namespace ConcurrentModificationException {
   export function isa(o: any): o is ConcurrentModificationException {
-    return _smithy.isa(o, "ConcurrentModificationException");
+    return __isa(o, "ConcurrentModificationException");
   }
 }
 
@@ -176,7 +179,7 @@ export namespace ConcurrentModificationException {
  * <p>Too many jobs are being run concurrently.</p>
  */
 export interface ConcurrentRunsExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ConcurrentRunsExceededException";
   $fault: "client";
@@ -188,7 +191,7 @@ export interface ConcurrentRunsExceededException
 
 export namespace ConcurrentRunsExceededException {
   export function isa(o: any): o is ConcurrentRunsExceededException {
-    return _smithy.isa(o, "ConcurrentRunsExceededException");
+    return __isa(o, "ConcurrentRunsExceededException");
   }
 }
 
@@ -196,7 +199,7 @@ export namespace ConcurrentRunsExceededException {
  * <p>A specified condition was not satisfied.</p>
  */
 export interface ConditionCheckFailureException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ConditionCheckFailureException";
   $fault: "client";
@@ -208,7 +211,7 @@ export interface ConditionCheckFailureException
 
 export namespace ConditionCheckFailureException {
   export function isa(o: any): o is ConditionCheckFailureException {
-    return _smithy.isa(o, "ConditionCheckFailureException");
+    return __isa(o, "ConditionCheckFailureException");
   }
 }
 
@@ -216,7 +219,7 @@ export namespace ConditionCheckFailureException {
  * <p>A specified entity does not exist</p>
  */
 export interface EntityNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "EntityNotFoundException";
   $fault: "client";
@@ -228,7 +231,7 @@ export interface EntityNotFoundException
 
 export namespace EntityNotFoundException {
   export function isa(o: any): o is EntityNotFoundException {
-    return _smithy.isa(o, "EntityNotFoundException");
+    return __isa(o, "EntityNotFoundException");
   }
 }
 
@@ -250,7 +253,7 @@ export interface ErrorDetail {
 
 export namespace ErrorDetail {
   export function isa(o: any): o is ErrorDetail {
-    return _smithy.isa(o, "ErrorDetail");
+    return __isa(o, "ErrorDetail");
   }
 }
 
@@ -258,7 +261,7 @@ export namespace ErrorDetail {
  * <p>An encryption operation failed.</p>
  */
 export interface GlueEncryptionException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "GlueEncryptionException";
   $fault: "client";
@@ -270,7 +273,7 @@ export interface GlueEncryptionException
 
 export namespace GlueEncryptionException {
   export function isa(o: any): o is GlueEncryptionException {
-    return _smithy.isa(o, "GlueEncryptionException");
+    return __isa(o, "GlueEncryptionException");
   }
 }
 
@@ -278,7 +281,7 @@ export namespace GlueEncryptionException {
  * <p>The same unique identifier was associated with two different records.</p>
  */
 export interface IdempotentParameterMismatchException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "IdempotentParameterMismatchException";
   $fault: "client";
@@ -290,7 +293,7 @@ export interface IdempotentParameterMismatchException
 
 export namespace IdempotentParameterMismatchException {
   export function isa(o: any): o is IdempotentParameterMismatchException {
-    return _smithy.isa(o, "IdempotentParameterMismatchException");
+    return __isa(o, "IdempotentParameterMismatchException");
   }
 }
 
@@ -298,7 +301,7 @@ export namespace IdempotentParameterMismatchException {
  * <p>An internal service error occurred.</p>
  */
 export interface InternalServiceException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalServiceException";
   $fault: "server";
@@ -310,7 +313,7 @@ export interface InternalServiceException
 
 export namespace InternalServiceException {
   export function isa(o: any): o is InternalServiceException {
-    return _smithy.isa(o, "InternalServiceException");
+    return __isa(o, "InternalServiceException");
   }
 }
 
@@ -318,7 +321,7 @@ export namespace InternalServiceException {
  * <p>The input provided was not valid.</p>
  */
 export interface InvalidInputException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidInputException";
   $fault: "client";
@@ -330,7 +333,7 @@ export interface InvalidInputException
 
 export namespace InvalidInputException {
   export function isa(o: any): o is InvalidInputException {
-    return _smithy.isa(o, "InvalidInputException");
+    return __isa(o, "InvalidInputException");
   }
 }
 
@@ -338,7 +341,7 @@ export namespace InvalidInputException {
  * <p>The operation timed out.</p>
  */
 export interface OperationTimeoutException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "OperationTimeoutException";
   $fault: "client";
@@ -350,7 +353,7 @@ export interface OperationTimeoutException
 
 export namespace OperationTimeoutException {
   export function isa(o: any): o is OperationTimeoutException {
-    return _smithy.isa(o, "OperationTimeoutException");
+    return __isa(o, "OperationTimeoutException");
   }
 }
 
@@ -358,7 +361,7 @@ export namespace OperationTimeoutException {
  * <p>A resource numerical limit was exceeded.</p>
  */
 export interface ResourceNumberLimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNumberLimitExceededException";
   $fault: "client";
@@ -370,7 +373,7 @@ export interface ResourceNumberLimitExceededException
 
 export namespace ResourceNumberLimitExceededException {
   export function isa(o: any): o is ResourceNumberLimitExceededException {
-    return _smithy.isa(o, "ResourceNumberLimitExceededException");
+    return __isa(o, "ResourceNumberLimitExceededException");
   }
 }
 
@@ -378,7 +381,7 @@ export namespace ResourceNumberLimitExceededException {
  * <p>A value could not be validated.</p>
  */
 export interface ValidationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ValidationException";
   $fault: "client";
@@ -390,7 +393,7 @@ export interface ValidationException
 
 export namespace ValidationException {
   export function isa(o: any): o is ValidationException {
-    return _smithy.isa(o, "ValidationException");
+    return __isa(o, "ValidationException");
   }
 }
 
@@ -398,7 +401,7 @@ export namespace ValidationException {
  * <p>There was a version conflict.</p>
  */
 export interface VersionMismatchException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "VersionMismatchException";
   $fault: "client";
@@ -410,7 +413,7 @@ export interface VersionMismatchException
 
 export namespace VersionMismatchException {
   export function isa(o: any): o is VersionMismatchException {
-    return _smithy.isa(o, "VersionMismatchException");
+    return __isa(o, "VersionMismatchException");
   }
 }
 
@@ -442,7 +445,7 @@ export interface BatchCreatePartitionRequest {
 
 export namespace BatchCreatePartitionRequest {
   export function isa(o: any): o is BatchCreatePartitionRequest {
-    return _smithy.isa(o, "BatchCreatePartitionRequest");
+    return __isa(o, "BatchCreatePartitionRequest");
   }
 }
 
@@ -456,7 +459,7 @@ export interface BatchCreatePartitionResponse extends $MetadataBearer {
 
 export namespace BatchCreatePartitionResponse {
   export function isa(o: any): o is BatchCreatePartitionResponse {
-    return _smithy.isa(o, "BatchCreatePartitionResponse");
+    return __isa(o, "BatchCreatePartitionResponse");
   }
 }
 
@@ -476,7 +479,7 @@ export interface BatchDeleteConnectionRequest {
 
 export namespace BatchDeleteConnectionRequest {
   export function isa(o: any): o is BatchDeleteConnectionRequest {
-    return _smithy.isa(o, "BatchDeleteConnectionRequest");
+    return __isa(o, "BatchDeleteConnectionRequest");
   }
 }
 
@@ -497,7 +500,7 @@ export interface BatchDeleteConnectionResponse extends $MetadataBearer {
 
 export namespace BatchDeleteConnectionResponse {
   export function isa(o: any): o is BatchDeleteConnectionResponse {
-    return _smithy.isa(o, "BatchDeleteConnectionResponse");
+    return __isa(o, "BatchDeleteConnectionResponse");
   }
 }
 
@@ -529,7 +532,7 @@ export interface BatchDeletePartitionRequest {
 
 export namespace BatchDeletePartitionRequest {
   export function isa(o: any): o is BatchDeletePartitionRequest {
-    return _smithy.isa(o, "BatchDeletePartitionRequest");
+    return __isa(o, "BatchDeletePartitionRequest");
   }
 }
 
@@ -543,7 +546,7 @@ export interface BatchDeletePartitionResponse extends $MetadataBearer {
 
 export namespace BatchDeletePartitionResponse {
   export function isa(o: any): o is BatchDeletePartitionResponse {
-    return _smithy.isa(o, "BatchDeletePartitionResponse");
+    return __isa(o, "BatchDeletePartitionResponse");
   }
 }
 
@@ -569,7 +572,7 @@ export interface BatchDeleteTableRequest {
 
 export namespace BatchDeleteTableRequest {
   export function isa(o: any): o is BatchDeleteTableRequest {
-    return _smithy.isa(o, "BatchDeleteTableRequest");
+    return __isa(o, "BatchDeleteTableRequest");
   }
 }
 
@@ -583,7 +586,7 @@ export interface BatchDeleteTableResponse extends $MetadataBearer {
 
 export namespace BatchDeleteTableResponse {
   export function isa(o: any): o is BatchDeleteTableResponse {
-    return _smithy.isa(o, "BatchDeleteTableResponse");
+    return __isa(o, "BatchDeleteTableResponse");
   }
 }
 
@@ -615,7 +618,7 @@ export interface BatchDeleteTableVersionRequest {
 
 export namespace BatchDeleteTableVersionRequest {
   export function isa(o: any): o is BatchDeleteTableVersionRequest {
-    return _smithy.isa(o, "BatchDeleteTableVersionRequest");
+    return __isa(o, "BatchDeleteTableVersionRequest");
   }
 }
 
@@ -630,7 +633,7 @@ export interface BatchDeleteTableVersionResponse extends $MetadataBearer {
 
 export namespace BatchDeleteTableVersionResponse {
   export function isa(o: any): o is BatchDeleteTableVersionResponse {
-    return _smithy.isa(o, "BatchDeleteTableVersionResponse");
+    return __isa(o, "BatchDeleteTableVersionResponse");
   }
 }
 
@@ -660,7 +663,7 @@ export interface BatchGetPartitionRequest {
 
 export namespace BatchGetPartitionRequest {
   export function isa(o: any): o is BatchGetPartitionRequest {
-    return _smithy.isa(o, "BatchGetPartitionRequest");
+    return __isa(o, "BatchGetPartitionRequest");
   }
 }
 
@@ -680,7 +683,7 @@ export interface BatchGetPartitionResponse extends $MetadataBearer {
 
 export namespace BatchGetPartitionResponse {
   export function isa(o: any): o is BatchGetPartitionResponse {
-    return _smithy.isa(o, "BatchGetPartitionResponse");
+    return __isa(o, "BatchGetPartitionResponse");
   }
 }
 
@@ -713,7 +716,7 @@ export interface CatalogImportStatus {
 
 export namespace CatalogImportStatus {
   export function isa(o: any): o is CatalogImportStatus {
-    return _smithy.isa(o, "CatalogImportStatus");
+    return __isa(o, "CatalogImportStatus");
   }
 }
 
@@ -745,7 +748,7 @@ export interface Column {
 
 export namespace Column {
   export function isa(o: any): o is Column {
-    return _smithy.isa(o, "Column");
+    return __isa(o, "Column");
   }
 }
 
@@ -887,7 +890,7 @@ export interface Connection {
 
 export namespace Connection {
   export function isa(o: any): o is Connection {
-    return _smithy.isa(o, "Connection");
+    return __isa(o, "Connection");
   }
 }
 
@@ -931,7 +934,7 @@ export interface ConnectionInput {
 
 export namespace ConnectionInput {
   export function isa(o: any): o is ConnectionInput {
-    return _smithy.isa(o, "ConnectionInput");
+    return __isa(o, "ConnectionInput");
   }
 }
 
@@ -970,7 +973,7 @@ export interface ConnectionPasswordEncryption {
 
 export namespace ConnectionPasswordEncryption {
   export function isa(o: any): o is ConnectionPasswordEncryption {
-    return _smithy.isa(o, "ConnectionPasswordEncryption");
+    return __isa(o, "ConnectionPasswordEncryption");
   }
 }
 
@@ -1015,7 +1018,7 @@ export interface CreateConnectionRequest {
 
 export namespace CreateConnectionRequest {
   export function isa(o: any): o is CreateConnectionRequest {
-    return _smithy.isa(o, "CreateConnectionRequest");
+    return __isa(o, "CreateConnectionRequest");
   }
 }
 
@@ -1025,7 +1028,7 @@ export interface CreateConnectionResponse extends $MetadataBearer {
 
 export namespace CreateConnectionResponse {
   export function isa(o: any): o is CreateConnectionResponse {
-    return _smithy.isa(o, "CreateConnectionResponse");
+    return __isa(o, "CreateConnectionResponse");
   }
 }
 
@@ -1045,7 +1048,7 @@ export interface CreateDatabaseRequest {
 
 export namespace CreateDatabaseRequest {
   export function isa(o: any): o is CreateDatabaseRequest {
-    return _smithy.isa(o, "CreateDatabaseRequest");
+    return __isa(o, "CreateDatabaseRequest");
   }
 }
 
@@ -1055,7 +1058,7 @@ export interface CreateDatabaseResponse extends $MetadataBearer {
 
 export namespace CreateDatabaseResponse {
   export function isa(o: any): o is CreateDatabaseResponse {
-    return _smithy.isa(o, "CreateDatabaseResponse");
+    return __isa(o, "CreateDatabaseResponse");
   }
 }
 
@@ -1086,7 +1089,7 @@ export interface CreatePartitionRequest {
 
 export namespace CreatePartitionRequest {
   export function isa(o: any): o is CreatePartitionRequest {
-    return _smithy.isa(o, "CreatePartitionRequest");
+    return __isa(o, "CreatePartitionRequest");
   }
 }
 
@@ -1096,7 +1099,7 @@ export interface CreatePartitionResponse extends $MetadataBearer {
 
 export namespace CreatePartitionResponse {
   export function isa(o: any): o is CreatePartitionResponse {
-    return _smithy.isa(o, "CreatePartitionResponse");
+    return __isa(o, "CreatePartitionResponse");
   }
 }
 
@@ -1123,7 +1126,7 @@ export interface CreateTableRequest {
 
 export namespace CreateTableRequest {
   export function isa(o: any): o is CreateTableRequest {
-    return _smithy.isa(o, "CreateTableRequest");
+    return __isa(o, "CreateTableRequest");
   }
 }
 
@@ -1133,7 +1136,7 @@ export interface CreateTableResponse extends $MetadataBearer {
 
 export namespace CreateTableResponse {
   export function isa(o: any): o is CreateTableResponse {
-    return _smithy.isa(o, "CreateTableResponse");
+    return __isa(o, "CreateTableResponse");
   }
 }
 
@@ -1159,7 +1162,7 @@ export interface CreateUserDefinedFunctionRequest {
 
 export namespace CreateUserDefinedFunctionRequest {
   export function isa(o: any): o is CreateUserDefinedFunctionRequest {
-    return _smithy.isa(o, "CreateUserDefinedFunctionRequest");
+    return __isa(o, "CreateUserDefinedFunctionRequest");
   }
 }
 
@@ -1169,7 +1172,7 @@ export interface CreateUserDefinedFunctionResponse extends $MetadataBearer {
 
 export namespace CreateUserDefinedFunctionResponse {
   export function isa(o: any): o is CreateUserDefinedFunctionResponse {
-    return _smithy.isa(o, "CreateUserDefinedFunctionResponse");
+    return __isa(o, "CreateUserDefinedFunctionResponse");
   }
 }
 
@@ -1195,7 +1198,7 @@ export interface DataCatalogEncryptionSettings {
 
 export namespace DataCatalogEncryptionSettings {
   export function isa(o: any): o is DataCatalogEncryptionSettings {
-    return _smithy.isa(o, "DataCatalogEncryptionSettings");
+    return __isa(o, "DataCatalogEncryptionSettings");
   }
 }
 
@@ -1212,7 +1215,7 @@ export interface DataLakePrincipal {
 
 export namespace DataLakePrincipal {
   export function isa(o: any): o is DataLakePrincipal {
-    return _smithy.isa(o, "DataLakePrincipal");
+    return __isa(o, "DataLakePrincipal");
   }
 }
 
@@ -1257,7 +1260,7 @@ export interface Database {
 
 export namespace Database {
   export function isa(o: any): o is Database {
-    return _smithy.isa(o, "Database");
+    return __isa(o, "Database");
   }
 }
 
@@ -1297,7 +1300,7 @@ export interface DatabaseInput {
 
 export namespace DatabaseInput {
   export function isa(o: any): o is DatabaseInput {
-    return _smithy.isa(o, "DatabaseInput");
+    return __isa(o, "DatabaseInput");
   }
 }
 
@@ -1317,7 +1320,7 @@ export interface DeleteConnectionRequest {
 
 export namespace DeleteConnectionRequest {
   export function isa(o: any): o is DeleteConnectionRequest {
-    return _smithy.isa(o, "DeleteConnectionRequest");
+    return __isa(o, "DeleteConnectionRequest");
   }
 }
 
@@ -1327,7 +1330,7 @@ export interface DeleteConnectionResponse extends $MetadataBearer {
 
 export namespace DeleteConnectionResponse {
   export function isa(o: any): o is DeleteConnectionResponse {
-    return _smithy.isa(o, "DeleteConnectionResponse");
+    return __isa(o, "DeleteConnectionResponse");
   }
 }
 
@@ -1348,7 +1351,7 @@ export interface DeleteDatabaseRequest {
 
 export namespace DeleteDatabaseRequest {
   export function isa(o: any): o is DeleteDatabaseRequest {
-    return _smithy.isa(o, "DeleteDatabaseRequest");
+    return __isa(o, "DeleteDatabaseRequest");
   }
 }
 
@@ -1358,7 +1361,7 @@ export interface DeleteDatabaseResponse extends $MetadataBearer {
 
 export namespace DeleteDatabaseResponse {
   export function isa(o: any): o is DeleteDatabaseResponse {
-    return _smithy.isa(o, "DeleteDatabaseResponse");
+    return __isa(o, "DeleteDatabaseResponse");
   }
 }
 
@@ -1389,7 +1392,7 @@ export interface DeletePartitionRequest {
 
 export namespace DeletePartitionRequest {
   export function isa(o: any): o is DeletePartitionRequest {
-    return _smithy.isa(o, "DeletePartitionRequest");
+    return __isa(o, "DeletePartitionRequest");
   }
 }
 
@@ -1399,7 +1402,7 @@ export interface DeletePartitionResponse extends $MetadataBearer {
 
 export namespace DeletePartitionResponse {
   export function isa(o: any): o is DeletePartitionResponse {
-    return _smithy.isa(o, "DeletePartitionResponse");
+    return __isa(o, "DeletePartitionResponse");
   }
 }
 
@@ -1413,7 +1416,7 @@ export interface DeleteResourcePolicyRequest {
 
 export namespace DeleteResourcePolicyRequest {
   export function isa(o: any): o is DeleteResourcePolicyRequest {
-    return _smithy.isa(o, "DeleteResourcePolicyRequest");
+    return __isa(o, "DeleteResourcePolicyRequest");
   }
 }
 
@@ -1423,7 +1426,7 @@ export interface DeleteResourcePolicyResponse extends $MetadataBearer {
 
 export namespace DeleteResourcePolicyResponse {
   export function isa(o: any): o is DeleteResourcePolicyResponse {
-    return _smithy.isa(o, "DeleteResourcePolicyResponse");
+    return __isa(o, "DeleteResourcePolicyResponse");
   }
 }
 
@@ -1450,7 +1453,7 @@ export interface DeleteTableRequest {
 
 export namespace DeleteTableRequest {
   export function isa(o: any): o is DeleteTableRequest {
-    return _smithy.isa(o, "DeleteTableRequest");
+    return __isa(o, "DeleteTableRequest");
   }
 }
 
@@ -1460,7 +1463,7 @@ export interface DeleteTableResponse extends $MetadataBearer {
 
 export namespace DeleteTableResponse {
   export function isa(o: any): o is DeleteTableResponse {
-    return _smithy.isa(o, "DeleteTableResponse");
+    return __isa(o, "DeleteTableResponse");
   }
 }
 
@@ -1492,7 +1495,7 @@ export interface DeleteTableVersionRequest {
 
 export namespace DeleteTableVersionRequest {
   export function isa(o: any): o is DeleteTableVersionRequest {
-    return _smithy.isa(o, "DeleteTableVersionRequest");
+    return __isa(o, "DeleteTableVersionRequest");
   }
 }
 
@@ -1502,7 +1505,7 @@ export interface DeleteTableVersionResponse extends $MetadataBearer {
 
 export namespace DeleteTableVersionResponse {
   export function isa(o: any): o is DeleteTableVersionResponse {
-    return _smithy.isa(o, "DeleteTableVersionResponse");
+    return __isa(o, "DeleteTableVersionResponse");
   }
 }
 
@@ -1527,7 +1530,7 @@ export interface DeleteUserDefinedFunctionRequest {
 
 export namespace DeleteUserDefinedFunctionRequest {
   export function isa(o: any): o is DeleteUserDefinedFunctionRequest {
-    return _smithy.isa(o, "DeleteUserDefinedFunctionRequest");
+    return __isa(o, "DeleteUserDefinedFunctionRequest");
   }
 }
 
@@ -1537,7 +1540,7 @@ export interface DeleteUserDefinedFunctionResponse extends $MetadataBearer {
 
 export namespace DeleteUserDefinedFunctionResponse {
   export function isa(o: any): o is DeleteUserDefinedFunctionResponse {
-    return _smithy.isa(o, "DeleteUserDefinedFunctionResponse");
+    return __isa(o, "DeleteUserDefinedFunctionResponse");
   }
 }
 
@@ -1559,7 +1562,7 @@ export interface EncryptionAtRest {
 
 export namespace EncryptionAtRest {
   export function isa(o: any): o is EncryptionAtRest {
-    return _smithy.isa(o, "EncryptionAtRest");
+    return __isa(o, "EncryptionAtRest");
   }
 }
 
@@ -1573,7 +1576,7 @@ export interface GetCatalogImportStatusRequest {
 
 export namespace GetCatalogImportStatusRequest {
   export function isa(o: any): o is GetCatalogImportStatusRequest {
-    return _smithy.isa(o, "GetCatalogImportStatusRequest");
+    return __isa(o, "GetCatalogImportStatusRequest");
   }
 }
 
@@ -1587,7 +1590,7 @@ export interface GetCatalogImportStatusResponse extends $MetadataBearer {
 
 export namespace GetCatalogImportStatusResponse {
   export function isa(o: any): o is GetCatalogImportStatusResponse {
-    return _smithy.isa(o, "GetCatalogImportStatusResponse");
+    return __isa(o, "GetCatalogImportStatusResponse");
   }
 }
 
@@ -1616,7 +1619,7 @@ export interface GetConnectionRequest {
 
 export namespace GetConnectionRequest {
   export function isa(o: any): o is GetConnectionRequest {
-    return _smithy.isa(o, "GetConnectionRequest");
+    return __isa(o, "GetConnectionRequest");
   }
 }
 
@@ -1630,7 +1633,7 @@ export interface GetConnectionResponse extends $MetadataBearer {
 
 export namespace GetConnectionResponse {
   export function isa(o: any): o is GetConnectionResponse {
-    return _smithy.isa(o, "GetConnectionResponse");
+    return __isa(o, "GetConnectionResponse");
   }
 }
 
@@ -1655,7 +1658,7 @@ export interface GetConnectionsFilter {
 
 export namespace GetConnectionsFilter {
   export function isa(o: any): o is GetConnectionsFilter {
-    return _smithy.isa(o, "GetConnectionsFilter");
+    return __isa(o, "GetConnectionsFilter");
   }
 }
 
@@ -1694,7 +1697,7 @@ export interface GetConnectionsRequest {
 
 export namespace GetConnectionsRequest {
   export function isa(o: any): o is GetConnectionsRequest {
-    return _smithy.isa(o, "GetConnectionsRequest");
+    return __isa(o, "GetConnectionsRequest");
   }
 }
 
@@ -1714,7 +1717,7 @@ export interface GetConnectionsResponse extends $MetadataBearer {
 
 export namespace GetConnectionsResponse {
   export function isa(o: any): o is GetConnectionsResponse {
-    return _smithy.isa(o, "GetConnectionsResponse");
+    return __isa(o, "GetConnectionsResponse");
   }
 }
 
@@ -1729,7 +1732,7 @@ export interface GetDataCatalogEncryptionSettingsRequest {
 
 export namespace GetDataCatalogEncryptionSettingsRequest {
   export function isa(o: any): o is GetDataCatalogEncryptionSettingsRequest {
-    return _smithy.isa(o, "GetDataCatalogEncryptionSettingsRequest");
+    return __isa(o, "GetDataCatalogEncryptionSettingsRequest");
   }
 }
 
@@ -1744,7 +1747,7 @@ export interface GetDataCatalogEncryptionSettingsResponse
 
 export namespace GetDataCatalogEncryptionSettingsResponse {
   export function isa(o: any): o is GetDataCatalogEncryptionSettingsResponse {
-    return _smithy.isa(o, "GetDataCatalogEncryptionSettingsResponse");
+    return __isa(o, "GetDataCatalogEncryptionSettingsResponse");
   }
 }
 
@@ -1765,7 +1768,7 @@ export interface GetDatabaseRequest {
 
 export namespace GetDatabaseRequest {
   export function isa(o: any): o is GetDatabaseRequest {
-    return _smithy.isa(o, "GetDatabaseRequest");
+    return __isa(o, "GetDatabaseRequest");
   }
 }
 
@@ -1779,7 +1782,7 @@ export interface GetDatabaseResponse extends $MetadataBearer {
 
 export namespace GetDatabaseResponse {
   export function isa(o: any): o is GetDatabaseResponse {
-    return _smithy.isa(o, "GetDatabaseResponse");
+    return __isa(o, "GetDatabaseResponse");
   }
 }
 
@@ -1804,7 +1807,7 @@ export interface GetDatabasesRequest {
 
 export namespace GetDatabasesRequest {
   export function isa(o: any): o is GetDatabasesRequest {
-    return _smithy.isa(o, "GetDatabasesRequest");
+    return __isa(o, "GetDatabasesRequest");
   }
 }
 
@@ -1824,7 +1827,7 @@ export interface GetDatabasesResponse extends $MetadataBearer {
 
 export namespace GetDatabasesResponse {
   export function isa(o: any): o is GetDatabasesResponse {
-    return _smithy.isa(o, "GetDatabasesResponse");
+    return __isa(o, "GetDatabasesResponse");
   }
 }
 
@@ -1854,7 +1857,7 @@ export interface GetPartitionRequest {
 
 export namespace GetPartitionRequest {
   export function isa(o: any): o is GetPartitionRequest {
-    return _smithy.isa(o, "GetPartitionRequest");
+    return __isa(o, "GetPartitionRequest");
   }
 }
 
@@ -1869,7 +1872,7 @@ export interface GetPartitionResponse extends $MetadataBearer {
 
 export namespace GetPartitionResponse {
   export function isa(o: any): o is GetPartitionResponse {
-    return _smithy.isa(o, "GetPartitionResponse");
+    return __isa(o, "GetPartitionResponse");
   }
 }
 
@@ -2020,7 +2023,7 @@ export interface GetPartitionsRequest {
 
 export namespace GetPartitionsRequest {
   export function isa(o: any): o is GetPartitionsRequest {
-    return _smithy.isa(o, "GetPartitionsRequest");
+    return __isa(o, "GetPartitionsRequest");
   }
 }
 
@@ -2040,7 +2043,7 @@ export interface GetPartitionsResponse extends $MetadataBearer {
 
 export namespace GetPartitionsResponse {
   export function isa(o: any): o is GetPartitionsResponse {
-    return _smithy.isa(o, "GetPartitionsResponse");
+    return __isa(o, "GetPartitionsResponse");
   }
 }
 
@@ -2050,7 +2053,7 @@ export interface GetResourcePolicyRequest {
 
 export namespace GetResourcePolicyRequest {
   export function isa(o: any): o is GetResourcePolicyRequest {
-    return _smithy.isa(o, "GetResourcePolicyRequest");
+    return __isa(o, "GetResourcePolicyRequest");
   }
 }
 
@@ -2079,7 +2082,7 @@ export interface GetResourcePolicyResponse extends $MetadataBearer {
 
 export namespace GetResourcePolicyResponse {
   export function isa(o: any): o is GetResourcePolicyResponse {
-    return _smithy.isa(o, "GetResourcePolicyResponse");
+    return __isa(o, "GetResourcePolicyResponse");
   }
 }
 
@@ -2106,7 +2109,7 @@ export interface GetTableRequest {
 
 export namespace GetTableRequest {
   export function isa(o: any): o is GetTableRequest {
-    return _smithy.isa(o, "GetTableRequest");
+    return __isa(o, "GetTableRequest");
   }
 }
 
@@ -2120,7 +2123,7 @@ export interface GetTableResponse extends $MetadataBearer {
 
 export namespace GetTableResponse {
   export function isa(o: any): o is GetTableResponse {
-    return _smithy.isa(o, "GetTableResponse");
+    return __isa(o, "GetTableResponse");
   }
 }
 
@@ -2152,7 +2155,7 @@ export interface GetTableVersionRequest {
 
 export namespace GetTableVersionRequest {
   export function isa(o: any): o is GetTableVersionRequest {
-    return _smithy.isa(o, "GetTableVersionRequest");
+    return __isa(o, "GetTableVersionRequest");
   }
 }
 
@@ -2166,7 +2169,7 @@ export interface GetTableVersionResponse extends $MetadataBearer {
 
 export namespace GetTableVersionResponse {
   export function isa(o: any): o is GetTableVersionResponse {
-    return _smithy.isa(o, "GetTableVersionResponse");
+    return __isa(o, "GetTableVersionResponse");
   }
 }
 
@@ -2203,7 +2206,7 @@ export interface GetTableVersionsRequest {
 
 export namespace GetTableVersionsRequest {
   export function isa(o: any): o is GetTableVersionsRequest {
-    return _smithy.isa(o, "GetTableVersionsRequest");
+    return __isa(o, "GetTableVersionsRequest");
   }
 }
 
@@ -2224,7 +2227,7 @@ export interface GetTableVersionsResponse extends $MetadataBearer {
 
 export namespace GetTableVersionsResponse {
   export function isa(o: any): o is GetTableVersionsResponse {
-    return _smithy.isa(o, "GetTableVersionsResponse");
+    return __isa(o, "GetTableVersionsResponse");
   }
 }
 
@@ -2261,7 +2264,7 @@ export interface GetTablesRequest {
 
 export namespace GetTablesRequest {
   export function isa(o: any): o is GetTablesRequest {
-    return _smithy.isa(o, "GetTablesRequest");
+    return __isa(o, "GetTablesRequest");
   }
 }
 
@@ -2281,7 +2284,7 @@ export interface GetTablesResponse extends $MetadataBearer {
 
 export namespace GetTablesResponse {
   export function isa(o: any): o is GetTablesResponse {
-    return _smithy.isa(o, "GetTablesResponse");
+    return __isa(o, "GetTablesResponse");
   }
 }
 
@@ -2306,7 +2309,7 @@ export interface GetUserDefinedFunctionRequest {
 
 export namespace GetUserDefinedFunctionRequest {
   export function isa(o: any): o is GetUserDefinedFunctionRequest {
-    return _smithy.isa(o, "GetUserDefinedFunctionRequest");
+    return __isa(o, "GetUserDefinedFunctionRequest");
   }
 }
 
@@ -2320,7 +2323,7 @@ export interface GetUserDefinedFunctionResponse extends $MetadataBearer {
 
 export namespace GetUserDefinedFunctionResponse {
   export function isa(o: any): o is GetUserDefinedFunctionResponse {
-    return _smithy.isa(o, "GetUserDefinedFunctionResponse");
+    return __isa(o, "GetUserDefinedFunctionResponse");
   }
 }
 
@@ -2356,7 +2359,7 @@ export interface GetUserDefinedFunctionsRequest {
 
 export namespace GetUserDefinedFunctionsRequest {
   export function isa(o: any): o is GetUserDefinedFunctionsRequest {
-    return _smithy.isa(o, "GetUserDefinedFunctionsRequest");
+    return __isa(o, "GetUserDefinedFunctionsRequest");
   }
 }
 
@@ -2376,7 +2379,7 @@ export interface GetUserDefinedFunctionsResponse extends $MetadataBearer {
 
 export namespace GetUserDefinedFunctionsResponse {
   export function isa(o: any): o is GetUserDefinedFunctionsResponse {
-    return _smithy.isa(o, "GetUserDefinedFunctionsResponse");
+    return __isa(o, "GetUserDefinedFunctionsResponse");
   }
 }
 
@@ -2390,7 +2393,7 @@ export interface ImportCatalogToGlueRequest {
 
 export namespace ImportCatalogToGlueRequest {
   export function isa(o: any): o is ImportCatalogToGlueRequest {
-    return _smithy.isa(o, "ImportCatalogToGlueRequest");
+    return __isa(o, "ImportCatalogToGlueRequest");
   }
 }
 
@@ -2400,7 +2403,7 @@ export interface ImportCatalogToGlueResponse extends $MetadataBearer {
 
 export namespace ImportCatalogToGlueResponse {
   export function isa(o: any): o is ImportCatalogToGlueResponse {
-    return _smithy.isa(o, "ImportCatalogToGlueResponse");
+    return __isa(o, "ImportCatalogToGlueResponse");
   }
 }
 
@@ -2423,7 +2426,7 @@ export interface Order {
 
 export namespace Order {
   export function isa(o: any): o is Order {
-    return _smithy.isa(o, "Order");
+    return __isa(o, "Order");
   }
 }
 
@@ -2477,7 +2480,7 @@ export interface Partition {
 
 export namespace Partition {
   export function isa(o: any): o is Partition {
-    return _smithy.isa(o, "Partition");
+    return __isa(o, "Partition");
   }
 }
 
@@ -2499,7 +2502,7 @@ export interface PartitionError {
 
 export namespace PartitionError {
   export function isa(o: any): o is PartitionError {
-    return _smithy.isa(o, "PartitionError");
+    return __isa(o, "PartitionError");
   }
 }
 
@@ -2539,7 +2542,7 @@ export interface PartitionInput {
 
 export namespace PartitionInput {
   export function isa(o: any): o is PartitionInput {
-    return _smithy.isa(o, "PartitionInput");
+    return __isa(o, "PartitionInput");
   }
 }
 
@@ -2556,7 +2559,7 @@ export interface PartitionValueList {
 
 export namespace PartitionValueList {
   export function isa(o: any): o is PartitionValueList {
-    return _smithy.isa(o, "PartitionValueList");
+    return __isa(o, "PartitionValueList");
   }
 }
 
@@ -2597,7 +2600,7 @@ export interface PhysicalConnectionRequirements {
 
 export namespace PhysicalConnectionRequirements {
   export function isa(o: any): o is PhysicalConnectionRequirements {
-    return _smithy.isa(o, "PhysicalConnectionRequirements");
+    return __isa(o, "PhysicalConnectionRequirements");
   }
 }
 
@@ -2619,7 +2622,7 @@ export interface PrincipalPermissions {
 
 export namespace PrincipalPermissions {
   export function isa(o: any): o is PrincipalPermissions {
-    return _smithy.isa(o, "PrincipalPermissions");
+    return __isa(o, "PrincipalPermissions");
   }
 }
 
@@ -2652,7 +2655,7 @@ export interface PropertyPredicate {
 
 export namespace PropertyPredicate {
   export function isa(o: any): o is PropertyPredicate {
-    return _smithy.isa(o, "PropertyPredicate");
+    return __isa(o, "PropertyPredicate");
   }
 }
 
@@ -2672,7 +2675,7 @@ export interface PutDataCatalogEncryptionSettingsRequest {
 
 export namespace PutDataCatalogEncryptionSettingsRequest {
   export function isa(o: any): o is PutDataCatalogEncryptionSettingsRequest {
-    return _smithy.isa(o, "PutDataCatalogEncryptionSettingsRequest");
+    return __isa(o, "PutDataCatalogEncryptionSettingsRequest");
   }
 }
 
@@ -2683,7 +2686,7 @@ export interface PutDataCatalogEncryptionSettingsResponse
 
 export namespace PutDataCatalogEncryptionSettingsResponse {
   export function isa(o: any): o is PutDataCatalogEncryptionSettingsResponse {
-    return _smithy.isa(o, "PutDataCatalogEncryptionSettingsResponse");
+    return __isa(o, "PutDataCatalogEncryptionSettingsResponse");
   }
 }
 
@@ -2711,7 +2714,7 @@ export interface PutResourcePolicyRequest {
 
 export namespace PutResourcePolicyRequest {
   export function isa(o: any): o is PutResourcePolicyRequest {
-    return _smithy.isa(o, "PutResourcePolicyRequest");
+    return __isa(o, "PutResourcePolicyRequest");
   }
 }
 
@@ -2727,7 +2730,7 @@ export interface PutResourcePolicyResponse extends $MetadataBearer {
 
 export namespace PutResourcePolicyResponse {
   export function isa(o: any): o is PutResourcePolicyResponse {
-    return _smithy.isa(o, "PutResourcePolicyResponse");
+    return __isa(o, "PutResourcePolicyResponse");
   }
 }
 
@@ -2755,7 +2758,7 @@ export interface ResourceUri {
 
 export namespace ResourceUri {
   export function isa(o: any): o is ResourceUri {
-    return _smithy.isa(o, "ResourceUri");
+    return __isa(o, "ResourceUri");
   }
 }
 
@@ -2796,7 +2799,7 @@ export interface SearchTablesRequest {
 
 export namespace SearchTablesRequest {
   export function isa(o: any): o is SearchTablesRequest {
-    return _smithy.isa(o, "SearchTablesRequest");
+    return __isa(o, "SearchTablesRequest");
   }
 }
 
@@ -2815,7 +2818,7 @@ export interface SearchTablesResponse extends $MetadataBearer {
 
 export namespace SearchTablesResponse {
   export function isa(o: any): o is SearchTablesResponse {
-    return _smithy.isa(o, "SearchTablesResponse");
+    return __isa(o, "SearchTablesResponse");
   }
 }
 
@@ -2839,7 +2842,7 @@ export interface Segment {
 
 export namespace Segment {
   export function isa(o: any): o is Segment {
-    return _smithy.isa(o, "Segment");
+    return __isa(o, "Segment");
   }
 }
 
@@ -2868,7 +2871,7 @@ export interface SerDeInfo {
 
 export namespace SerDeInfo {
   export function isa(o: any): o is SerDeInfo {
-    return _smithy.isa(o, "SerDeInfo");
+    return __isa(o, "SerDeInfo");
   }
 }
 
@@ -2897,7 +2900,7 @@ export interface SkewedInfo {
 
 export namespace SkewedInfo {
   export function isa(o: any): o is SkewedInfo {
-    return _smithy.isa(o, "SkewedInfo");
+    return __isa(o, "SkewedInfo");
   }
 }
 
@@ -2924,7 +2927,7 @@ export interface SortCriterion {
 
 export namespace SortCriterion {
   export function isa(o: any): o is SortCriterion {
-    return _smithy.isa(o, "SortCriterion");
+    return __isa(o, "SortCriterion");
   }
 }
 
@@ -3005,7 +3008,7 @@ export interface StorageDescriptor {
 
 export namespace StorageDescriptor {
   export function isa(o: any): o is StorageDescriptor {
-    return _smithy.isa(o, "StorageDescriptor");
+    return __isa(o, "StorageDescriptor");
   }
 }
 
@@ -3113,7 +3116,7 @@ export interface Table {
 
 export namespace Table {
   export function isa(o: any): o is Table {
-    return _smithy.isa(o, "Table");
+    return __isa(o, "Table");
   }
 }
 
@@ -3135,7 +3138,7 @@ export interface TableError {
 
 export namespace TableError {
   export function isa(o: any): o is TableError {
-    return _smithy.isa(o, "TableError");
+    return __isa(o, "TableError");
   }
 }
 
@@ -3216,7 +3219,7 @@ export interface TableInput {
 
 export namespace TableInput {
   export function isa(o: any): o is TableInput {
-    return _smithy.isa(o, "TableInput");
+    return __isa(o, "TableInput");
   }
 }
 
@@ -3238,7 +3241,7 @@ export interface TableVersion {
 
 export namespace TableVersion {
   export function isa(o: any): o is TableVersion {
-    return _smithy.isa(o, "TableVersion");
+    return __isa(o, "TableVersion");
   }
 }
 
@@ -3265,7 +3268,7 @@ export interface TableVersionError {
 
 export namespace TableVersionError {
   export function isa(o: any): o is TableVersionError {
-    return _smithy.isa(o, "TableVersionError");
+    return __isa(o, "TableVersionError");
   }
 }
 
@@ -3291,7 +3294,7 @@ export interface UpdateConnectionRequest {
 
 export namespace UpdateConnectionRequest {
   export function isa(o: any): o is UpdateConnectionRequest {
-    return _smithy.isa(o, "UpdateConnectionRequest");
+    return __isa(o, "UpdateConnectionRequest");
   }
 }
 
@@ -3301,7 +3304,7 @@ export interface UpdateConnectionResponse extends $MetadataBearer {
 
 export namespace UpdateConnectionResponse {
   export function isa(o: any): o is UpdateConnectionResponse {
-    return _smithy.isa(o, "UpdateConnectionResponse");
+    return __isa(o, "UpdateConnectionResponse");
   }
 }
 
@@ -3328,7 +3331,7 @@ export interface UpdateDatabaseRequest {
 
 export namespace UpdateDatabaseRequest {
   export function isa(o: any): o is UpdateDatabaseRequest {
-    return _smithy.isa(o, "UpdateDatabaseRequest");
+    return __isa(o, "UpdateDatabaseRequest");
   }
 }
 
@@ -3338,7 +3341,7 @@ export interface UpdateDatabaseResponse extends $MetadataBearer {
 
 export namespace UpdateDatabaseResponse {
   export function isa(o: any): o is UpdateDatabaseResponse {
-    return _smithy.isa(o, "UpdateDatabaseResponse");
+    return __isa(o, "UpdateDatabaseResponse");
   }
 }
 
@@ -3374,7 +3377,7 @@ export interface UpdatePartitionRequest {
 
 export namespace UpdatePartitionRequest {
   export function isa(o: any): o is UpdatePartitionRequest {
-    return _smithy.isa(o, "UpdatePartitionRequest");
+    return __isa(o, "UpdatePartitionRequest");
   }
 }
 
@@ -3384,7 +3387,7 @@ export interface UpdatePartitionResponse extends $MetadataBearer {
 
 export namespace UpdatePartitionResponse {
   export function isa(o: any): o is UpdatePartitionResponse {
-    return _smithy.isa(o, "UpdatePartitionResponse");
+    return __isa(o, "UpdatePartitionResponse");
   }
 }
 
@@ -3418,7 +3421,7 @@ export interface UpdateTableRequest {
 
 export namespace UpdateTableRequest {
   export function isa(o: any): o is UpdateTableRequest {
-    return _smithy.isa(o, "UpdateTableRequest");
+    return __isa(o, "UpdateTableRequest");
   }
 }
 
@@ -3428,7 +3431,7 @@ export interface UpdateTableResponse extends $MetadataBearer {
 
 export namespace UpdateTableResponse {
   export function isa(o: any): o is UpdateTableResponse {
-    return _smithy.isa(o, "UpdateTableResponse");
+    return __isa(o, "UpdateTableResponse");
   }
 }
 
@@ -3460,7 +3463,7 @@ export interface UpdateUserDefinedFunctionRequest {
 
 export namespace UpdateUserDefinedFunctionRequest {
   export function isa(o: any): o is UpdateUserDefinedFunctionRequest {
-    return _smithy.isa(o, "UpdateUserDefinedFunctionRequest");
+    return __isa(o, "UpdateUserDefinedFunctionRequest");
   }
 }
 
@@ -3470,7 +3473,7 @@ export interface UpdateUserDefinedFunctionResponse extends $MetadataBearer {
 
 export namespace UpdateUserDefinedFunctionResponse {
   export function isa(o: any): o is UpdateUserDefinedFunctionResponse {
-    return _smithy.isa(o, "UpdateUserDefinedFunctionResponse");
+    return __isa(o, "UpdateUserDefinedFunctionResponse");
   }
 }
 
@@ -3513,7 +3516,7 @@ export interface UserDefinedFunction {
 
 export namespace UserDefinedFunction {
   export function isa(o: any): o is UserDefinedFunction {
-    return _smithy.isa(o, "UserDefinedFunction");
+    return __isa(o, "UserDefinedFunction");
   }
 }
 
@@ -3550,7 +3553,7 @@ export interface UserDefinedFunctionInput {
 
 export namespace UserDefinedFunctionInput {
   export function isa(o: any): o is UserDefinedFunctionInput {
-    return _smithy.isa(o, "UserDefinedFunctionInput");
+    return __isa(o, "UserDefinedFunctionInput");
   }
 }
 
@@ -3565,7 +3568,7 @@ export interface BatchGetDevEndpointsRequest {
 
 export namespace BatchGetDevEndpointsRequest {
   export function isa(o: any): o is BatchGetDevEndpointsRequest {
-    return _smithy.isa(o, "BatchGetDevEndpointsRequest");
+    return __isa(o, "BatchGetDevEndpointsRequest");
   }
 }
 
@@ -3584,7 +3587,7 @@ export interface BatchGetDevEndpointsResponse extends $MetadataBearer {
 
 export namespace BatchGetDevEndpointsResponse {
   export function isa(o: any): o is BatchGetDevEndpointsResponse {
-    return _smithy.isa(o, "BatchGetDevEndpointsResponse");
+    return __isa(o, "BatchGetDevEndpointsResponse");
   }
 }
 
@@ -3606,7 +3609,7 @@ export interface CloudWatchEncryption {
 
 export namespace CloudWatchEncryption {
   export function isa(o: any): o is CloudWatchEncryption {
-    return _smithy.isa(o, "CloudWatchEncryption");
+    return __isa(o, "CloudWatchEncryption");
   }
 }
 
@@ -3733,7 +3736,7 @@ export interface CreateDevEndpointRequest {
 
 export namespace CreateDevEndpointRequest {
   export function isa(o: any): o is CreateDevEndpointRequest {
-    return _smithy.isa(o, "CreateDevEndpointRequest");
+    return __isa(o, "CreateDevEndpointRequest");
   }
 }
 
@@ -3862,7 +3865,7 @@ export interface CreateDevEndpointResponse extends $MetadataBearer {
 
 export namespace CreateDevEndpointResponse {
   export function isa(o: any): o is CreateDevEndpointResponse {
-    return _smithy.isa(o, "CreateDevEndpointResponse");
+    return __isa(o, "CreateDevEndpointResponse");
   }
 }
 
@@ -3881,7 +3884,7 @@ export interface CreateSecurityConfigurationRequest {
 
 export namespace CreateSecurityConfigurationRequest {
   export function isa(o: any): o is CreateSecurityConfigurationRequest {
-    return _smithy.isa(o, "CreateSecurityConfigurationRequest");
+    return __isa(o, "CreateSecurityConfigurationRequest");
   }
 }
 
@@ -3900,7 +3903,7 @@ export interface CreateSecurityConfigurationResponse extends $MetadataBearer {
 
 export namespace CreateSecurityConfigurationResponse {
   export function isa(o: any): o is CreateSecurityConfigurationResponse {
-    return _smithy.isa(o, "CreateSecurityConfigurationResponse");
+    return __isa(o, "CreateSecurityConfigurationResponse");
   }
 }
 
@@ -3914,7 +3917,7 @@ export interface DeleteDevEndpointRequest {
 
 export namespace DeleteDevEndpointRequest {
   export function isa(o: any): o is DeleteDevEndpointRequest {
-    return _smithy.isa(o, "DeleteDevEndpointRequest");
+    return __isa(o, "DeleteDevEndpointRequest");
   }
 }
 
@@ -3924,7 +3927,7 @@ export interface DeleteDevEndpointResponse extends $MetadataBearer {
 
 export namespace DeleteDevEndpointResponse {
   export function isa(o: any): o is DeleteDevEndpointResponse {
-    return _smithy.isa(o, "DeleteDevEndpointResponse");
+    return __isa(o, "DeleteDevEndpointResponse");
   }
 }
 
@@ -3938,7 +3941,7 @@ export interface DeleteSecurityConfigurationRequest {
 
 export namespace DeleteSecurityConfigurationRequest {
   export function isa(o: any): o is DeleteSecurityConfigurationRequest {
-    return _smithy.isa(o, "DeleteSecurityConfigurationRequest");
+    return __isa(o, "DeleteSecurityConfigurationRequest");
   }
 }
 
@@ -3948,7 +3951,7 @@ export interface DeleteSecurityConfigurationResponse extends $MetadataBearer {
 
 export namespace DeleteSecurityConfigurationResponse {
   export function isa(o: any): o is DeleteSecurityConfigurationResponse {
-    return _smithy.isa(o, "DeleteSecurityConfigurationResponse");
+    return __isa(o, "DeleteSecurityConfigurationResponse");
   }
 }
 
@@ -4157,7 +4160,7 @@ export interface DevEndpoint {
 
 export namespace DevEndpoint {
   export function isa(o: any): o is DevEndpoint {
-    return _smithy.isa(o, "DevEndpoint");
+    return __isa(o, "DevEndpoint");
   }
 }
 
@@ -4190,7 +4193,7 @@ export interface DevEndpointCustomLibraries {
 
 export namespace DevEndpointCustomLibraries {
   export function isa(o: any): o is DevEndpointCustomLibraries {
-    return _smithy.isa(o, "DevEndpointCustomLibraries");
+    return __isa(o, "DevEndpointCustomLibraries");
   }
 }
 
@@ -4217,7 +4220,7 @@ export interface EncryptionConfiguration {
 
 export namespace EncryptionConfiguration {
   export function isa(o: any): o is EncryptionConfiguration {
-    return _smithy.isa(o, "EncryptionConfiguration");
+    return __isa(o, "EncryptionConfiguration");
   }
 }
 
@@ -4231,7 +4234,7 @@ export interface GetDevEndpointRequest {
 
 export namespace GetDevEndpointRequest {
   export function isa(o: any): o is GetDevEndpointRequest {
-    return _smithy.isa(o, "GetDevEndpointRequest");
+    return __isa(o, "GetDevEndpointRequest");
   }
 }
 
@@ -4245,7 +4248,7 @@ export interface GetDevEndpointResponse extends $MetadataBearer {
 
 export namespace GetDevEndpointResponse {
   export function isa(o: any): o is GetDevEndpointResponse {
-    return _smithy.isa(o, "GetDevEndpointResponse");
+    return __isa(o, "GetDevEndpointResponse");
   }
 }
 
@@ -4264,7 +4267,7 @@ export interface GetDevEndpointsRequest {
 
 export namespace GetDevEndpointsRequest {
   export function isa(o: any): o is GetDevEndpointsRequest {
-    return _smithy.isa(o, "GetDevEndpointsRequest");
+    return __isa(o, "GetDevEndpointsRequest");
   }
 }
 
@@ -4284,7 +4287,7 @@ export interface GetDevEndpointsResponse extends $MetadataBearer {
 
 export namespace GetDevEndpointsResponse {
   export function isa(o: any): o is GetDevEndpointsResponse {
-    return _smithy.isa(o, "GetDevEndpointsResponse");
+    return __isa(o, "GetDevEndpointsResponse");
   }
 }
 
@@ -4303,7 +4306,7 @@ export interface GetJobBookmarkRequest {
 
 export namespace GetJobBookmarkRequest {
   export function isa(o: any): o is GetJobBookmarkRequest {
-    return _smithy.isa(o, "GetJobBookmarkRequest");
+    return __isa(o, "GetJobBookmarkRequest");
   }
 }
 
@@ -4317,7 +4320,7 @@ export interface GetJobBookmarkResponse extends $MetadataBearer {
 
 export namespace GetJobBookmarkResponse {
   export function isa(o: any): o is GetJobBookmarkResponse {
-    return _smithy.isa(o, "GetJobBookmarkResponse");
+    return __isa(o, "GetJobBookmarkResponse");
   }
 }
 
@@ -4331,7 +4334,7 @@ export interface GetSecurityConfigurationRequest {
 
 export namespace GetSecurityConfigurationRequest {
   export function isa(o: any): o is GetSecurityConfigurationRequest {
-    return _smithy.isa(o, "GetSecurityConfigurationRequest");
+    return __isa(o, "GetSecurityConfigurationRequest");
   }
 }
 
@@ -4345,7 +4348,7 @@ export interface GetSecurityConfigurationResponse extends $MetadataBearer {
 
 export namespace GetSecurityConfigurationResponse {
   export function isa(o: any): o is GetSecurityConfigurationResponse {
-    return _smithy.isa(o, "GetSecurityConfigurationResponse");
+    return __isa(o, "GetSecurityConfigurationResponse");
   }
 }
 
@@ -4364,7 +4367,7 @@ export interface GetSecurityConfigurationsRequest {
 
 export namespace GetSecurityConfigurationsRequest {
   export function isa(o: any): o is GetSecurityConfigurationsRequest {
-    return _smithy.isa(o, "GetSecurityConfigurationsRequest");
+    return __isa(o, "GetSecurityConfigurationsRequest");
   }
 }
 
@@ -4384,7 +4387,7 @@ export interface GetSecurityConfigurationsResponse extends $MetadataBearer {
 
 export namespace GetSecurityConfigurationsResponse {
   export function isa(o: any): o is GetSecurityConfigurationsResponse {
-    return _smithy.isa(o, "GetSecurityConfigurationsResponse");
+    return __isa(o, "GetSecurityConfigurationsResponse");
   }
 }
 
@@ -4431,7 +4434,7 @@ export interface JobBookmarkEntry {
 
 export namespace JobBookmarkEntry {
   export function isa(o: any): o is JobBookmarkEntry {
-    return _smithy.isa(o, "JobBookmarkEntry");
+    return __isa(o, "JobBookmarkEntry");
   }
 }
 
@@ -4453,7 +4456,7 @@ export interface JobBookmarksEncryption {
 
 export namespace JobBookmarksEncryption {
   export function isa(o: any): o is JobBookmarksEncryption {
-    return _smithy.isa(o, "JobBookmarksEncryption");
+    return __isa(o, "JobBookmarksEncryption");
   }
 }
 
@@ -4477,7 +4480,7 @@ export interface ListDevEndpointsRequest {
 
 export namespace ListDevEndpointsRequest {
   export function isa(o: any): o is ListDevEndpointsRequest {
-    return _smithy.isa(o, "ListDevEndpointsRequest");
+    return __isa(o, "ListDevEndpointsRequest");
   }
 }
 
@@ -4498,7 +4501,7 @@ export interface ListDevEndpointsResponse extends $MetadataBearer {
 
 export namespace ListDevEndpointsResponse {
   export function isa(o: any): o is ListDevEndpointsResponse {
-    return _smithy.isa(o, "ListDevEndpointsResponse");
+    return __isa(o, "ListDevEndpointsResponse");
   }
 }
 
@@ -4517,7 +4520,7 @@ export interface ResetJobBookmarkRequest {
 
 export namespace ResetJobBookmarkRequest {
   export function isa(o: any): o is ResetJobBookmarkRequest {
-    return _smithy.isa(o, "ResetJobBookmarkRequest");
+    return __isa(o, "ResetJobBookmarkRequest");
   }
 }
 
@@ -4531,7 +4534,7 @@ export interface ResetJobBookmarkResponse extends $MetadataBearer {
 
 export namespace ResetJobBookmarkResponse {
   export function isa(o: any): o is ResetJobBookmarkResponse {
-    return _smithy.isa(o, "ResetJobBookmarkResponse");
+    return __isa(o, "ResetJobBookmarkResponse");
   }
 }
 
@@ -4553,7 +4556,7 @@ export interface S3Encryption {
 
 export namespace S3Encryption {
   export function isa(o: any): o is S3Encryption {
-    return _smithy.isa(o, "S3Encryption");
+    return __isa(o, "S3Encryption");
   }
 }
 
@@ -4580,7 +4583,7 @@ export interface SecurityConfiguration {
 
 export namespace SecurityConfiguration {
   export function isa(o: any): o is SecurityConfiguration {
-    return _smithy.isa(o, "SecurityConfiguration");
+    return __isa(o, "SecurityConfiguration");
   }
 }
 
@@ -4654,7 +4657,7 @@ export interface UpdateDevEndpointRequest {
 
 export namespace UpdateDevEndpointRequest {
   export function isa(o: any): o is UpdateDevEndpointRequest {
-    return _smithy.isa(o, "UpdateDevEndpointRequest");
+    return __isa(o, "UpdateDevEndpointRequest");
   }
 }
 
@@ -4664,7 +4667,7 @@ export interface UpdateDevEndpointResponse extends $MetadataBearer {
 
 export namespace UpdateDevEndpointResponse {
   export function isa(o: any): o is UpdateDevEndpointResponse {
-    return _smithy.isa(o, "UpdateDevEndpointResponse");
+    return __isa(o, "UpdateDevEndpointResponse");
   }
 }
 
@@ -4683,7 +4686,7 @@ export interface CancelMLTaskRunRequest {
 
 export namespace CancelMLTaskRunRequest {
   export function isa(o: any): o is CancelMLTaskRunRequest {
-    return _smithy.isa(o, "CancelMLTaskRunRequest");
+    return __isa(o, "CancelMLTaskRunRequest");
   }
 }
 
@@ -4707,7 +4710,7 @@ export interface CancelMLTaskRunResponse extends $MetadataBearer {
 
 export namespace CancelMLTaskRunResponse {
   export function isa(o: any): o is CancelMLTaskRunResponse {
-    return _smithy.isa(o, "CancelMLTaskRunResponse");
+    return __isa(o, "CancelMLTaskRunResponse");
   }
 }
 
@@ -4743,7 +4746,7 @@ export interface ConfusionMatrix {
 
 export namespace ConfusionMatrix {
   export function isa(o: any): o is ConfusionMatrix {
-    return _smithy.isa(o, "ConfusionMatrix");
+    return __isa(o, "ConfusionMatrix");
   }
 }
 
@@ -4875,7 +4878,7 @@ export interface CreateMLTransformRequest {
 
 export namespace CreateMLTransformRequest {
   export function isa(o: any): o is CreateMLTransformRequest {
-    return _smithy.isa(o, "CreateMLTransformRequest");
+    return __isa(o, "CreateMLTransformRequest");
   }
 }
 
@@ -4889,7 +4892,7 @@ export interface CreateMLTransformResponse extends $MetadataBearer {
 
 export namespace CreateMLTransformResponse {
   export function isa(o: any): o is CreateMLTransformResponse {
-    return _smithy.isa(o, "CreateMLTransformResponse");
+    return __isa(o, "CreateMLTransformResponse");
   }
 }
 
@@ -4903,7 +4906,7 @@ export interface DeleteMLTransformRequest {
 
 export namespace DeleteMLTransformRequest {
   export function isa(o: any): o is DeleteMLTransformRequest {
-    return _smithy.isa(o, "DeleteMLTransformRequest");
+    return __isa(o, "DeleteMLTransformRequest");
   }
 }
 
@@ -4917,7 +4920,7 @@ export interface DeleteMLTransformResponse extends $MetadataBearer {
 
 export namespace DeleteMLTransformResponse {
   export function isa(o: any): o is DeleteMLTransformResponse {
-    return _smithy.isa(o, "DeleteMLTransformResponse");
+    return __isa(o, "DeleteMLTransformResponse");
   }
 }
 
@@ -4939,7 +4942,7 @@ export interface EvaluationMetrics {
 
 export namespace EvaluationMetrics {
   export function isa(o: any): o is EvaluationMetrics {
-    return _smithy.isa(o, "EvaluationMetrics");
+    return __isa(o, "EvaluationMetrics");
   }
 }
 
@@ -4957,7 +4960,7 @@ export interface ExportLabelsTaskRunProperties {
 
 export namespace ExportLabelsTaskRunProperties {
   export function isa(o: any): o is ExportLabelsTaskRunProperties {
-    return _smithy.isa(o, "ExportLabelsTaskRunProperties");
+    return __isa(o, "ExportLabelsTaskRunProperties");
   }
 }
 
@@ -5006,7 +5009,7 @@ export interface FindMatchesMetrics {
 
 export namespace FindMatchesMetrics {
   export function isa(o: any): o is FindMatchesMetrics {
-    return _smithy.isa(o, "FindMatchesMetrics");
+    return __isa(o, "FindMatchesMetrics");
   }
 }
 
@@ -5056,7 +5059,7 @@ export interface FindMatchesParameters {
 
 export namespace FindMatchesParameters {
   export function isa(o: any): o is FindMatchesParameters {
-    return _smithy.isa(o, "FindMatchesParameters");
+    return __isa(o, "FindMatchesParameters");
   }
 }
 
@@ -5083,7 +5086,7 @@ export interface FindMatchesTaskRunProperties {
 
 export namespace FindMatchesTaskRunProperties {
   export function isa(o: any): o is FindMatchesTaskRunProperties {
-    return _smithy.isa(o, "FindMatchesTaskRunProperties");
+    return __isa(o, "FindMatchesTaskRunProperties");
   }
 }
 
@@ -5102,7 +5105,7 @@ export interface GetMLTaskRunRequest {
 
 export namespace GetMLTaskRunRequest {
   export function isa(o: any): o is GetMLTaskRunRequest {
-    return _smithy.isa(o, "GetMLTaskRunRequest");
+    return __isa(o, "GetMLTaskRunRequest");
   }
 }
 
@@ -5161,7 +5164,7 @@ export interface GetMLTaskRunResponse extends $MetadataBearer {
 
 export namespace GetMLTaskRunResponse {
   export function isa(o: any): o is GetMLTaskRunResponse {
-    return _smithy.isa(o, "GetMLTaskRunResponse");
+    return __isa(o, "GetMLTaskRunResponse");
   }
 }
 
@@ -5195,7 +5198,7 @@ export interface GetMLTaskRunsRequest {
 
 export namespace GetMLTaskRunsRequest {
   export function isa(o: any): o is GetMLTaskRunsRequest {
-    return _smithy.isa(o, "GetMLTaskRunsRequest");
+    return __isa(o, "GetMLTaskRunsRequest");
   }
 }
 
@@ -5214,7 +5217,7 @@ export interface GetMLTaskRunsResponse extends $MetadataBearer {
 
 export namespace GetMLTaskRunsResponse {
   export function isa(o: any): o is GetMLTaskRunsResponse {
-    return _smithy.isa(o, "GetMLTaskRunsResponse");
+    return __isa(o, "GetMLTaskRunsResponse");
   }
 }
 
@@ -5229,7 +5232,7 @@ export interface GetMLTransformRequest {
 
 export namespace GetMLTransformRequest {
   export function isa(o: any): o is GetMLTransformRequest {
-    return _smithy.isa(o, "GetMLTransformRequest");
+    return __isa(o, "GetMLTransformRequest");
   }
 }
 
@@ -5347,7 +5350,7 @@ export interface GetMLTransformResponse extends $MetadataBearer {
 
 export namespace GetMLTransformResponse {
   export function isa(o: any): o is GetMLTransformResponse {
-    return _smithy.isa(o, "GetMLTransformResponse");
+    return __isa(o, "GetMLTransformResponse");
   }
 }
 
@@ -5376,7 +5379,7 @@ export interface GetMLTransformsRequest {
 
 export namespace GetMLTransformsRequest {
   export function isa(o: any): o is GetMLTransformsRequest {
-    return _smithy.isa(o, "GetMLTransformsRequest");
+    return __isa(o, "GetMLTransformsRequest");
   }
 }
 
@@ -5395,7 +5398,7 @@ export interface GetMLTransformsResponse extends $MetadataBearer {
 
 export namespace GetMLTransformsResponse {
   export function isa(o: any): o is GetMLTransformsResponse {
-    return _smithy.isa(o, "GetMLTransformsResponse");
+    return __isa(o, "GetMLTransformsResponse");
   }
 }
 
@@ -5427,7 +5430,7 @@ export interface GlueTable {
 
 export namespace GlueTable {
   export function isa(o: any): o is GlueTable {
-    return _smithy.isa(o, "GlueTable");
+    return __isa(o, "GlueTable");
   }
 }
 
@@ -5450,7 +5453,7 @@ export interface ImportLabelsTaskRunProperties {
 
 export namespace ImportLabelsTaskRunProperties {
   export function isa(o: any): o is ImportLabelsTaskRunProperties {
-    return _smithy.isa(o, "ImportLabelsTaskRunProperties");
+    return __isa(o, "ImportLabelsTaskRunProperties");
   }
 }
 
@@ -5468,7 +5471,7 @@ export interface LabelingSetGenerationTaskRunProperties {
 
 export namespace LabelingSetGenerationTaskRunProperties {
   export function isa(o: any): o is LabelingSetGenerationTaskRunProperties {
-    return _smithy.isa(o, "LabelingSetGenerationTaskRunProperties");
+    return __isa(o, "LabelingSetGenerationTaskRunProperties");
   }
 }
 
@@ -5640,7 +5643,7 @@ export interface MLTransform {
 
 export namespace MLTransform {
   export function isa(o: any): o is MLTransform {
-    return _smithy.isa(o, "MLTransform");
+    return __isa(o, "MLTransform");
   }
 }
 
@@ -5648,7 +5651,7 @@ export namespace MLTransform {
  * <p>The machine learning transform is not ready to run.</p>
  */
 export interface MLTransformNotReadyException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "MLTransformNotReadyException";
   $fault: "client";
@@ -5660,7 +5663,7 @@ export interface MLTransformNotReadyException
 
 export namespace MLTransformNotReadyException {
   export function isa(o: any): o is MLTransformNotReadyException {
-    return _smithy.isa(o, "MLTransformNotReadyException");
+    return __isa(o, "MLTransformNotReadyException");
   }
 }
 
@@ -5683,7 +5686,7 @@ export interface SchemaColumn {
 
 export namespace SchemaColumn {
   export function isa(o: any): o is SchemaColumn {
-    return _smithy.isa(o, "SchemaColumn");
+    return __isa(o, "SchemaColumn");
   }
 }
 
@@ -5707,7 +5710,7 @@ export interface StartExportLabelsTaskRunRequest {
 
 export namespace StartExportLabelsTaskRunRequest {
   export function isa(o: any): o is StartExportLabelsTaskRunRequest {
-    return _smithy.isa(o, "StartExportLabelsTaskRunRequest");
+    return __isa(o, "StartExportLabelsTaskRunRequest");
   }
 }
 
@@ -5721,7 +5724,7 @@ export interface StartExportLabelsTaskRunResponse extends $MetadataBearer {
 
 export namespace StartExportLabelsTaskRunResponse {
   export function isa(o: any): o is StartExportLabelsTaskRunResponse {
-    return _smithy.isa(o, "StartExportLabelsTaskRunResponse");
+    return __isa(o, "StartExportLabelsTaskRunResponse");
   }
 }
 
@@ -5746,7 +5749,7 @@ export interface StartImportLabelsTaskRunRequest {
 
 export namespace StartImportLabelsTaskRunRequest {
   export function isa(o: any): o is StartImportLabelsTaskRunRequest {
-    return _smithy.isa(o, "StartImportLabelsTaskRunRequest");
+    return __isa(o, "StartImportLabelsTaskRunRequest");
   }
 }
 
@@ -5760,7 +5763,7 @@ export interface StartImportLabelsTaskRunResponse extends $MetadataBearer {
 
 export namespace StartImportLabelsTaskRunResponse {
   export function isa(o: any): o is StartImportLabelsTaskRunResponse {
-    return _smithy.isa(o, "StartImportLabelsTaskRunResponse");
+    return __isa(o, "StartImportLabelsTaskRunResponse");
   }
 }
 
@@ -5774,7 +5777,7 @@ export interface StartMLEvaluationTaskRunRequest {
 
 export namespace StartMLEvaluationTaskRunRequest {
   export function isa(o: any): o is StartMLEvaluationTaskRunRequest {
-    return _smithy.isa(o, "StartMLEvaluationTaskRunRequest");
+    return __isa(o, "StartMLEvaluationTaskRunRequest");
   }
 }
 
@@ -5788,7 +5791,7 @@ export interface StartMLEvaluationTaskRunResponse extends $MetadataBearer {
 
 export namespace StartMLEvaluationTaskRunResponse {
   export function isa(o: any): o is StartMLEvaluationTaskRunResponse {
-    return _smithy.isa(o, "StartMLEvaluationTaskRunResponse");
+    return __isa(o, "StartMLEvaluationTaskRunResponse");
   }
 }
 
@@ -5808,7 +5811,7 @@ export interface StartMLLabelingSetGenerationTaskRunRequest {
 
 export namespace StartMLLabelingSetGenerationTaskRunRequest {
   export function isa(o: any): o is StartMLLabelingSetGenerationTaskRunRequest {
-    return _smithy.isa(o, "StartMLLabelingSetGenerationTaskRunRequest");
+    return __isa(o, "StartMLLabelingSetGenerationTaskRunRequest");
   }
 }
 
@@ -5825,7 +5828,7 @@ export namespace StartMLLabelingSetGenerationTaskRunResponse {
   export function isa(
     o: any
   ): o is StartMLLabelingSetGenerationTaskRunResponse {
-    return _smithy.isa(o, "StartMLLabelingSetGenerationTaskRunResponse");
+    return __isa(o, "StartMLLabelingSetGenerationTaskRunResponse");
   }
 }
 
@@ -5887,7 +5890,7 @@ export interface TaskRun {
 
 export namespace TaskRun {
   export function isa(o: any): o is TaskRun {
-    return _smithy.isa(o, "TaskRun");
+    return __isa(o, "TaskRun");
   }
 }
 
@@ -5920,7 +5923,7 @@ export interface TaskRunFilterCriteria {
 
 export namespace TaskRunFilterCriteria {
   export function isa(o: any): o is TaskRunFilterCriteria {
-    return _smithy.isa(o, "TaskRunFilterCriteria");
+    return __isa(o, "TaskRunFilterCriteria");
   }
 }
 
@@ -5957,7 +5960,7 @@ export interface TaskRunProperties {
 
 export namespace TaskRunProperties {
   export function isa(o: any): o is TaskRunProperties {
-    return _smithy.isa(o, "TaskRunProperties");
+    return __isa(o, "TaskRunProperties");
   }
 }
 
@@ -5988,7 +5991,7 @@ export interface TaskRunSortCriteria {
 
 export namespace TaskRunSortCriteria {
   export function isa(o: any): o is TaskRunSortCriteria {
-    return _smithy.isa(o, "TaskRunSortCriteria");
+    return __isa(o, "TaskRunSortCriteria");
   }
 }
 
@@ -6067,7 +6070,7 @@ export interface TransformFilterCriteria {
 
 export namespace TransformFilterCriteria {
   export function isa(o: any): o is TransformFilterCriteria {
-    return _smithy.isa(o, "TransformFilterCriteria");
+    return __isa(o, "TransformFilterCriteria");
   }
 }
 
@@ -6091,7 +6094,7 @@ export interface TransformParameters {
 
 export namespace TransformParameters {
   export function isa(o: any): o is TransformParameters {
-    return _smithy.isa(o, "TransformParameters");
+    return __isa(o, "TransformParameters");
   }
 }
 
@@ -6123,7 +6126,7 @@ export interface TransformSortCriteria {
 
 export namespace TransformSortCriteria {
   export function isa(o: any): o is TransformSortCriteria {
-    return _smithy.isa(o, "TransformSortCriteria");
+    return __isa(o, "TransformSortCriteria");
   }
 }
 
@@ -6215,7 +6218,7 @@ export interface UpdateMLTransformRequest {
 
 export namespace UpdateMLTransformRequest {
   export function isa(o: any): o is UpdateMLTransformRequest {
-    return _smithy.isa(o, "UpdateMLTransformRequest");
+    return __isa(o, "UpdateMLTransformRequest");
   }
 }
 
@@ -6229,7 +6232,7 @@ export interface UpdateMLTransformResponse extends $MetadataBearer {
 
 export namespace UpdateMLTransformResponse {
   export function isa(o: any): o is UpdateMLTransformResponse {
-    return _smithy.isa(o, "UpdateMLTransformResponse");
+    return __isa(o, "UpdateMLTransformResponse");
   }
 }
 
@@ -6278,7 +6281,7 @@ export interface Action {
 
 export namespace Action {
   export function isa(o: any): o is Action {
-    return _smithy.isa(o, "Action");
+    return __isa(o, "Action");
   }
 }
 
@@ -6293,7 +6296,7 @@ export interface BatchGetJobsRequest {
 
 export namespace BatchGetJobsRequest {
   export function isa(o: any): o is BatchGetJobsRequest {
-    return _smithy.isa(o, "BatchGetJobsRequest");
+    return __isa(o, "BatchGetJobsRequest");
   }
 }
 
@@ -6312,7 +6315,7 @@ export interface BatchGetJobsResponse extends $MetadataBearer {
 
 export namespace BatchGetJobsResponse {
   export function isa(o: any): o is BatchGetJobsResponse {
-    return _smithy.isa(o, "BatchGetJobsResponse");
+    return __isa(o, "BatchGetJobsResponse");
   }
 }
 
@@ -6326,7 +6329,7 @@ export interface BatchGetTriggersRequest {
 
 export namespace BatchGetTriggersRequest {
   export function isa(o: any): o is BatchGetTriggersRequest {
-    return _smithy.isa(o, "BatchGetTriggersRequest");
+    return __isa(o, "BatchGetTriggersRequest");
   }
 }
 
@@ -6345,7 +6348,7 @@ export interface BatchGetTriggersResponse extends $MetadataBearer {
 
 export namespace BatchGetTriggersResponse {
   export function isa(o: any): o is BatchGetTriggersResponse {
-    return _smithy.isa(o, "BatchGetTriggersResponse");
+    return __isa(o, "BatchGetTriggersResponse");
   }
 }
 
@@ -6364,7 +6367,7 @@ export interface BatchGetWorkflowsRequest {
 
 export namespace BatchGetWorkflowsRequest {
   export function isa(o: any): o is BatchGetWorkflowsRequest {
-    return _smithy.isa(o, "BatchGetWorkflowsRequest");
+    return __isa(o, "BatchGetWorkflowsRequest");
   }
 }
 
@@ -6383,7 +6386,7 @@ export interface BatchGetWorkflowsResponse extends $MetadataBearer {
 
 export namespace BatchGetWorkflowsResponse {
   export function isa(o: any): o is BatchGetWorkflowsResponse {
-    return _smithy.isa(o, "BatchGetWorkflowsResponse");
+    return __isa(o, "BatchGetWorkflowsResponse");
   }
 }
 
@@ -6411,7 +6414,7 @@ export interface BatchStopJobRunError {
 
 export namespace BatchStopJobRunError {
   export function isa(o: any): o is BatchStopJobRunError {
-    return _smithy.isa(o, "BatchStopJobRunError");
+    return __isa(o, "BatchStopJobRunError");
   }
 }
 
@@ -6431,7 +6434,7 @@ export interface BatchStopJobRunRequest {
 
 export namespace BatchStopJobRunRequest {
   export function isa(o: any): o is BatchStopJobRunRequest {
-    return _smithy.isa(o, "BatchStopJobRunRequest");
+    return __isa(o, "BatchStopJobRunRequest");
   }
 }
 
@@ -6452,7 +6455,7 @@ export interface BatchStopJobRunResponse extends $MetadataBearer {
 
 export namespace BatchStopJobRunResponse {
   export function isa(o: any): o is BatchStopJobRunResponse {
-    return _smithy.isa(o, "BatchStopJobRunResponse");
+    return __isa(o, "BatchStopJobRunResponse");
   }
 }
 
@@ -6474,7 +6477,7 @@ export interface BatchStopJobRunSuccessfulSubmission {
 
 export namespace BatchStopJobRunSuccessfulSubmission {
   export function isa(o: any): o is BatchStopJobRunSuccessfulSubmission {
-    return _smithy.isa(o, "BatchStopJobRunSuccessfulSubmission");
+    return __isa(o, "BatchStopJobRunSuccessfulSubmission");
   }
 }
 
@@ -6513,7 +6516,7 @@ export interface Condition {
 
 export namespace Condition {
   export function isa(o: any): o is Condition {
-    return _smithy.isa(o, "Condition");
+    return __isa(o, "Condition");
   }
 }
 
@@ -6530,7 +6533,7 @@ export interface ConnectionsList {
 
 export namespace ConnectionsList {
   export function isa(o: any): o is ConnectionsList {
-    return _smithy.isa(o, "ConnectionsList");
+    return __isa(o, "ConnectionsList");
   }
 }
 
@@ -6572,7 +6575,7 @@ export interface Crawl {
 
 export namespace Crawl {
   export function isa(o: any): o is Crawl {
-    return _smithy.isa(o, "Crawl");
+    return __isa(o, "Crawl");
   }
 }
 
@@ -6596,7 +6599,7 @@ export interface CrawlerNodeDetails {
 
 export namespace CrawlerNodeDetails {
   export function isa(o: any): o is CrawlerNodeDetails {
-    return _smithy.isa(o, "CrawlerNodeDetails");
+    return __isa(o, "CrawlerNodeDetails");
   }
 }
 
@@ -6743,7 +6746,7 @@ export interface CreateJobRequest {
 
 export namespace CreateJobRequest {
   export function isa(o: any): o is CreateJobRequest {
-    return _smithy.isa(o, "CreateJobRequest");
+    return __isa(o, "CreateJobRequest");
   }
 }
 
@@ -6757,7 +6760,7 @@ export interface CreateJobResponse extends $MetadataBearer {
 
 export namespace CreateJobResponse {
   export function isa(o: any): o is CreateJobResponse {
-    return _smithy.isa(o, "CreateJobResponse");
+    return __isa(o, "CreateJobResponse");
   }
 }
 
@@ -6819,7 +6822,7 @@ export interface CreateTriggerRequest {
 
 export namespace CreateTriggerRequest {
   export function isa(o: any): o is CreateTriggerRequest {
-    return _smithy.isa(o, "CreateTriggerRequest");
+    return __isa(o, "CreateTriggerRequest");
   }
 }
 
@@ -6833,7 +6836,7 @@ export interface CreateTriggerResponse extends $MetadataBearer {
 
 export namespace CreateTriggerResponse {
   export function isa(o: any): o is CreateTriggerResponse {
-    return _smithy.isa(o, "CreateTriggerResponse");
+    return __isa(o, "CreateTriggerResponse");
   }
 }
 
@@ -6862,7 +6865,7 @@ export interface CreateWorkflowRequest {
 
 export namespace CreateWorkflowRequest {
   export function isa(o: any): o is CreateWorkflowRequest {
-    return _smithy.isa(o, "CreateWorkflowRequest");
+    return __isa(o, "CreateWorkflowRequest");
   }
 }
 
@@ -6876,7 +6879,7 @@ export interface CreateWorkflowResponse extends $MetadataBearer {
 
 export namespace CreateWorkflowResponse {
   export function isa(o: any): o is CreateWorkflowResponse {
-    return _smithy.isa(o, "CreateWorkflowResponse");
+    return __isa(o, "CreateWorkflowResponse");
   }
 }
 
@@ -6890,7 +6893,7 @@ export interface DeleteJobRequest {
 
 export namespace DeleteJobRequest {
   export function isa(o: any): o is DeleteJobRequest {
-    return _smithy.isa(o, "DeleteJobRequest");
+    return __isa(o, "DeleteJobRequest");
   }
 }
 
@@ -6904,7 +6907,7 @@ export interface DeleteJobResponse extends $MetadataBearer {
 
 export namespace DeleteJobResponse {
   export function isa(o: any): o is DeleteJobResponse {
-    return _smithy.isa(o, "DeleteJobResponse");
+    return __isa(o, "DeleteJobResponse");
   }
 }
 
@@ -6918,7 +6921,7 @@ export interface DeleteTriggerRequest {
 
 export namespace DeleteTriggerRequest {
   export function isa(o: any): o is DeleteTriggerRequest {
-    return _smithy.isa(o, "DeleteTriggerRequest");
+    return __isa(o, "DeleteTriggerRequest");
   }
 }
 
@@ -6932,7 +6935,7 @@ export interface DeleteTriggerResponse extends $MetadataBearer {
 
 export namespace DeleteTriggerResponse {
   export function isa(o: any): o is DeleteTriggerResponse {
-    return _smithy.isa(o, "DeleteTriggerResponse");
+    return __isa(o, "DeleteTriggerResponse");
   }
 }
 
@@ -6946,7 +6949,7 @@ export interface DeleteWorkflowRequest {
 
 export namespace DeleteWorkflowRequest {
   export function isa(o: any): o is DeleteWorkflowRequest {
-    return _smithy.isa(o, "DeleteWorkflowRequest");
+    return __isa(o, "DeleteWorkflowRequest");
   }
 }
 
@@ -6960,7 +6963,7 @@ export interface DeleteWorkflowResponse extends $MetadataBearer {
 
 export namespace DeleteWorkflowResponse {
   export function isa(o: any): o is DeleteWorkflowResponse {
-    return _smithy.isa(o, "DeleteWorkflowResponse");
+    return __isa(o, "DeleteWorkflowResponse");
   }
 }
 
@@ -6983,7 +6986,7 @@ export interface Edge {
 
 export namespace Edge {
   export function isa(o: any): o is Edge {
-    return _smithy.isa(o, "Edge");
+    return __isa(o, "Edge");
   }
 }
 
@@ -7002,7 +7005,7 @@ export interface ExecutionProperty {
 
 export namespace ExecutionProperty {
   export function isa(o: any): o is ExecutionProperty {
-    return _smithy.isa(o, "ExecutionProperty");
+    return __isa(o, "ExecutionProperty");
   }
 }
 
@@ -7016,7 +7019,7 @@ export interface GetJobRequest {
 
 export namespace GetJobRequest {
   export function isa(o: any): o is GetJobRequest {
-    return _smithy.isa(o, "GetJobRequest");
+    return __isa(o, "GetJobRequest");
   }
 }
 
@@ -7030,7 +7033,7 @@ export interface GetJobResponse extends $MetadataBearer {
 
 export namespace GetJobResponse {
   export function isa(o: any): o is GetJobResponse {
-    return _smithy.isa(o, "GetJobResponse");
+    return __isa(o, "GetJobResponse");
   }
 }
 
@@ -7054,7 +7057,7 @@ export interface GetJobRunRequest {
 
 export namespace GetJobRunRequest {
   export function isa(o: any): o is GetJobRunRequest {
-    return _smithy.isa(o, "GetJobRunRequest");
+    return __isa(o, "GetJobRunRequest");
   }
 }
 
@@ -7068,7 +7071,7 @@ export interface GetJobRunResponse extends $MetadataBearer {
 
 export namespace GetJobRunResponse {
   export function isa(o: any): o is GetJobRunResponse {
-    return _smithy.isa(o, "GetJobRunResponse");
+    return __isa(o, "GetJobRunResponse");
   }
 }
 
@@ -7092,7 +7095,7 @@ export interface GetJobRunsRequest {
 
 export namespace GetJobRunsRequest {
   export function isa(o: any): o is GetJobRunsRequest {
-    return _smithy.isa(o, "GetJobRunsRequest");
+    return __isa(o, "GetJobRunsRequest");
   }
 }
 
@@ -7111,7 +7114,7 @@ export interface GetJobRunsResponse extends $MetadataBearer {
 
 export namespace GetJobRunsResponse {
   export function isa(o: any): o is GetJobRunsResponse {
-    return _smithy.isa(o, "GetJobRunsResponse");
+    return __isa(o, "GetJobRunsResponse");
   }
 }
 
@@ -7130,7 +7133,7 @@ export interface GetJobsRequest {
 
 export namespace GetJobsRequest {
   export function isa(o: any): o is GetJobsRequest {
-    return _smithy.isa(o, "GetJobsRequest");
+    return __isa(o, "GetJobsRequest");
   }
 }
 
@@ -7149,7 +7152,7 @@ export interface GetJobsResponse extends $MetadataBearer {
 
 export namespace GetJobsResponse {
   export function isa(o: any): o is GetJobsResponse {
-    return _smithy.isa(o, "GetJobsResponse");
+    return __isa(o, "GetJobsResponse");
   }
 }
 
@@ -7163,7 +7166,7 @@ export interface GetTriggerRequest {
 
 export namespace GetTriggerRequest {
   export function isa(o: any): o is GetTriggerRequest {
-    return _smithy.isa(o, "GetTriggerRequest");
+    return __isa(o, "GetTriggerRequest");
   }
 }
 
@@ -7177,7 +7180,7 @@ export interface GetTriggerResponse extends $MetadataBearer {
 
 export namespace GetTriggerResponse {
   export function isa(o: any): o is GetTriggerResponse {
-    return _smithy.isa(o, "GetTriggerResponse");
+    return __isa(o, "GetTriggerResponse");
   }
 }
 
@@ -7202,7 +7205,7 @@ export interface GetTriggersRequest {
 
 export namespace GetTriggersRequest {
   export function isa(o: any): o is GetTriggersRequest {
-    return _smithy.isa(o, "GetTriggersRequest");
+    return __isa(o, "GetTriggersRequest");
   }
 }
 
@@ -7222,7 +7225,7 @@ export interface GetTriggersResponse extends $MetadataBearer {
 
 export namespace GetTriggersResponse {
   export function isa(o: any): o is GetTriggersResponse {
-    return _smithy.isa(o, "GetTriggersResponse");
+    return __isa(o, "GetTriggersResponse");
   }
 }
 
@@ -7241,7 +7244,7 @@ export interface GetWorkflowRequest {
 
 export namespace GetWorkflowRequest {
   export function isa(o: any): o is GetWorkflowRequest {
-    return _smithy.isa(o, "GetWorkflowRequest");
+    return __isa(o, "GetWorkflowRequest");
   }
 }
 
@@ -7255,7 +7258,7 @@ export interface GetWorkflowResponse extends $MetadataBearer {
 
 export namespace GetWorkflowResponse {
   export function isa(o: any): o is GetWorkflowResponse {
-    return _smithy.isa(o, "GetWorkflowResponse");
+    return __isa(o, "GetWorkflowResponse");
   }
 }
 
@@ -7274,7 +7277,7 @@ export interface GetWorkflowRunPropertiesRequest {
 
 export namespace GetWorkflowRunPropertiesRequest {
   export function isa(o: any): o is GetWorkflowRunPropertiesRequest {
-    return _smithy.isa(o, "GetWorkflowRunPropertiesRequest");
+    return __isa(o, "GetWorkflowRunPropertiesRequest");
   }
 }
 
@@ -7288,7 +7291,7 @@ export interface GetWorkflowRunPropertiesResponse extends $MetadataBearer {
 
 export namespace GetWorkflowRunPropertiesResponse {
   export function isa(o: any): o is GetWorkflowRunPropertiesResponse {
-    return _smithy.isa(o, "GetWorkflowRunPropertiesResponse");
+    return __isa(o, "GetWorkflowRunPropertiesResponse");
   }
 }
 
@@ -7312,7 +7315,7 @@ export interface GetWorkflowRunRequest {
 
 export namespace GetWorkflowRunRequest {
   export function isa(o: any): o is GetWorkflowRunRequest {
-    return _smithy.isa(o, "GetWorkflowRunRequest");
+    return __isa(o, "GetWorkflowRunRequest");
   }
 }
 
@@ -7326,7 +7329,7 @@ export interface GetWorkflowRunResponse extends $MetadataBearer {
 
 export namespace GetWorkflowRunResponse {
   export function isa(o: any): o is GetWorkflowRunResponse {
-    return _smithy.isa(o, "GetWorkflowRunResponse");
+    return __isa(o, "GetWorkflowRunResponse");
   }
 }
 
@@ -7355,7 +7358,7 @@ export interface GetWorkflowRunsRequest {
 
 export namespace GetWorkflowRunsRequest {
   export function isa(o: any): o is GetWorkflowRunsRequest {
-    return _smithy.isa(o, "GetWorkflowRunsRequest");
+    return __isa(o, "GetWorkflowRunsRequest");
   }
 }
 
@@ -7374,7 +7377,7 @@ export interface GetWorkflowRunsResponse extends $MetadataBearer {
 
 export namespace GetWorkflowRunsResponse {
   export function isa(o: any): o is GetWorkflowRunsResponse {
-    return _smithy.isa(o, "GetWorkflowRunsResponse");
+    return __isa(o, "GetWorkflowRunsResponse");
   }
 }
 
@@ -7530,7 +7533,7 @@ export interface Job {
 
 export namespace Job {
   export function isa(o: any): o is Job {
-    return _smithy.isa(o, "Job");
+    return __isa(o, "Job");
   }
 }
 
@@ -7559,7 +7562,7 @@ export interface JobCommand {
 
 export namespace JobCommand {
   export function isa(o: any): o is JobCommand {
-    return _smithy.isa(o, "JobCommand");
+    return __isa(o, "JobCommand");
   }
 }
 
@@ -7576,7 +7579,7 @@ export interface JobNodeDetails {
 
 export namespace JobNodeDetails {
   export function isa(o: any): o is JobNodeDetails {
-    return _smithy.isa(o, "JobNodeDetails");
+    return __isa(o, "JobNodeDetails");
   }
 }
 
@@ -7751,7 +7754,7 @@ export interface JobRun {
 
 export namespace JobRun {
   export function isa(o: any): o is JobRun {
-    return _smithy.isa(o, "JobRun");
+    return __isa(o, "JobRun");
   }
 }
 
@@ -7900,7 +7903,7 @@ export interface JobUpdate {
 
 export namespace JobUpdate {
   export function isa(o: any): o is JobUpdate {
-    return _smithy.isa(o, "JobUpdate");
+    return __isa(o, "JobUpdate");
   }
 }
 
@@ -7924,7 +7927,7 @@ export interface ListJobsRequest {
 
 export namespace ListJobsRequest {
   export function isa(o: any): o is ListJobsRequest {
-    return _smithy.isa(o, "ListJobsRequest");
+    return __isa(o, "ListJobsRequest");
   }
 }
 
@@ -7944,7 +7947,7 @@ export interface ListJobsResponse extends $MetadataBearer {
 
 export namespace ListJobsResponse {
   export function isa(o: any): o is ListJobsResponse {
-    return _smithy.isa(o, "ListJobsResponse");
+    return __isa(o, "ListJobsResponse");
   }
 }
 
@@ -7974,7 +7977,7 @@ export interface ListTriggersRequest {
 
 export namespace ListTriggersRequest {
   export function isa(o: any): o is ListTriggersRequest {
-    return _smithy.isa(o, "ListTriggersRequest");
+    return __isa(o, "ListTriggersRequest");
   }
 }
 
@@ -7994,7 +7997,7 @@ export interface ListTriggersResponse extends $MetadataBearer {
 
 export namespace ListTriggersResponse {
   export function isa(o: any): o is ListTriggersResponse {
-    return _smithy.isa(o, "ListTriggersResponse");
+    return __isa(o, "ListTriggersResponse");
   }
 }
 
@@ -8013,7 +8016,7 @@ export interface ListWorkflowsRequest {
 
 export namespace ListWorkflowsRequest {
   export function isa(o: any): o is ListWorkflowsRequest {
-    return _smithy.isa(o, "ListWorkflowsRequest");
+    return __isa(o, "ListWorkflowsRequest");
   }
 }
 
@@ -8032,7 +8035,7 @@ export interface ListWorkflowsResponse extends $MetadataBearer {
 
 export namespace ListWorkflowsResponse {
   export function isa(o: any): o is ListWorkflowsResponse {
-    return _smithy.isa(o, "ListWorkflowsResponse");
+    return __isa(o, "ListWorkflowsResponse");
   }
 }
 
@@ -8083,7 +8086,7 @@ export interface Node {
 
 export namespace Node {
   export function isa(o: any): o is Node {
-    return _smithy.isa(o, "Node");
+    return __isa(o, "Node");
   }
 }
 
@@ -8107,7 +8110,7 @@ export interface NotificationProperty {
 
 export namespace NotificationProperty {
   export function isa(o: any): o is NotificationProperty {
-    return _smithy.isa(o, "NotificationProperty");
+    return __isa(o, "NotificationProperty");
   }
 }
 
@@ -8130,7 +8133,7 @@ export interface Predecessor {
 
 export namespace Predecessor {
   export function isa(o: any): o is Predecessor {
-    return _smithy.isa(o, "Predecessor");
+    return __isa(o, "Predecessor");
   }
 }
 
@@ -8153,7 +8156,7 @@ export interface Predicate {
 
 export namespace Predicate {
   export function isa(o: any): o is Predicate {
-    return _smithy.isa(o, "Predicate");
+    return __isa(o, "Predicate");
   }
 }
 
@@ -8177,7 +8180,7 @@ export interface PutWorkflowRunPropertiesRequest {
 
 export namespace PutWorkflowRunPropertiesRequest {
   export function isa(o: any): o is PutWorkflowRunPropertiesRequest {
-    return _smithy.isa(o, "PutWorkflowRunPropertiesRequest");
+    return __isa(o, "PutWorkflowRunPropertiesRequest");
   }
 }
 
@@ -8187,7 +8190,7 @@ export interface PutWorkflowRunPropertiesResponse extends $MetadataBearer {
 
 export namespace PutWorkflowRunPropertiesResponse {
   export function isa(o: any): o is PutWorkflowRunPropertiesResponse {
-    return _smithy.isa(o, "PutWorkflowRunPropertiesResponse");
+    return __isa(o, "PutWorkflowRunPropertiesResponse");
   }
 }
 
@@ -8289,7 +8292,7 @@ export interface StartJobRunRequest {
 
 export namespace StartJobRunRequest {
   export function isa(o: any): o is StartJobRunRequest {
-    return _smithy.isa(o, "StartJobRunRequest");
+    return __isa(o, "StartJobRunRequest");
   }
 }
 
@@ -8303,7 +8306,7 @@ export interface StartJobRunResponse extends $MetadataBearer {
 
 export namespace StartJobRunResponse {
   export function isa(o: any): o is StartJobRunResponse {
-    return _smithy.isa(o, "StartJobRunResponse");
+    return __isa(o, "StartJobRunResponse");
   }
 }
 
@@ -8317,7 +8320,7 @@ export interface StartTriggerRequest {
 
 export namespace StartTriggerRequest {
   export function isa(o: any): o is StartTriggerRequest {
-    return _smithy.isa(o, "StartTriggerRequest");
+    return __isa(o, "StartTriggerRequest");
   }
 }
 
@@ -8331,7 +8334,7 @@ export interface StartTriggerResponse extends $MetadataBearer {
 
 export namespace StartTriggerResponse {
   export function isa(o: any): o is StartTriggerResponse {
-    return _smithy.isa(o, "StartTriggerResponse");
+    return __isa(o, "StartTriggerResponse");
   }
 }
 
@@ -8345,7 +8348,7 @@ export interface StartWorkflowRunRequest {
 
 export namespace StartWorkflowRunRequest {
   export function isa(o: any): o is StartWorkflowRunRequest {
-    return _smithy.isa(o, "StartWorkflowRunRequest");
+    return __isa(o, "StartWorkflowRunRequest");
   }
 }
 
@@ -8359,7 +8362,7 @@ export interface StartWorkflowRunResponse extends $MetadataBearer {
 
 export namespace StartWorkflowRunResponse {
   export function isa(o: any): o is StartWorkflowRunResponse {
-    return _smithy.isa(o, "StartWorkflowRunResponse");
+    return __isa(o, "StartWorkflowRunResponse");
   }
 }
 
@@ -8373,7 +8376,7 @@ export interface StopTriggerRequest {
 
 export namespace StopTriggerRequest {
   export function isa(o: any): o is StopTriggerRequest {
-    return _smithy.isa(o, "StopTriggerRequest");
+    return __isa(o, "StopTriggerRequest");
   }
 }
 
@@ -8387,7 +8390,7 @@ export interface StopTriggerResponse extends $MetadataBearer {
 
 export namespace StopTriggerResponse {
   export function isa(o: any): o is StopTriggerResponse {
-    return _smithy.isa(o, "StopTriggerResponse");
+    return __isa(o, "StopTriggerResponse");
   }
 }
 
@@ -8447,7 +8450,7 @@ export interface Trigger {
 
 export namespace Trigger {
   export function isa(o: any): o is Trigger {
-    return _smithy.isa(o, "Trigger");
+    return __isa(o, "Trigger");
   }
 }
 
@@ -8464,7 +8467,7 @@ export interface TriggerNodeDetails {
 
 export namespace TriggerNodeDetails {
   export function isa(o: any): o is TriggerNodeDetails {
-    return _smithy.isa(o, "TriggerNodeDetails");
+    return __isa(o, "TriggerNodeDetails");
   }
 }
 
@@ -8522,7 +8525,7 @@ export interface TriggerUpdate {
 
 export namespace TriggerUpdate {
   export function isa(o: any): o is TriggerUpdate {
-    return _smithy.isa(o, "TriggerUpdate");
+    return __isa(o, "TriggerUpdate");
   }
 }
 
@@ -8541,7 +8544,7 @@ export interface UpdateJobRequest {
 
 export namespace UpdateJobRequest {
   export function isa(o: any): o is UpdateJobRequest {
-    return _smithy.isa(o, "UpdateJobRequest");
+    return __isa(o, "UpdateJobRequest");
   }
 }
 
@@ -8555,7 +8558,7 @@ export interface UpdateJobResponse extends $MetadataBearer {
 
 export namespace UpdateJobResponse {
   export function isa(o: any): o is UpdateJobResponse {
-    return _smithy.isa(o, "UpdateJobResponse");
+    return __isa(o, "UpdateJobResponse");
   }
 }
 
@@ -8574,7 +8577,7 @@ export interface UpdateTriggerRequest {
 
 export namespace UpdateTriggerRequest {
   export function isa(o: any): o is UpdateTriggerRequest {
-    return _smithy.isa(o, "UpdateTriggerRequest");
+    return __isa(o, "UpdateTriggerRequest");
   }
 }
 
@@ -8588,7 +8591,7 @@ export interface UpdateTriggerResponse extends $MetadataBearer {
 
 export namespace UpdateTriggerResponse {
   export function isa(o: any): o is UpdateTriggerResponse {
-    return _smithy.isa(o, "UpdateTriggerResponse");
+    return __isa(o, "UpdateTriggerResponse");
   }
 }
 
@@ -8612,7 +8615,7 @@ export interface UpdateWorkflowRequest {
 
 export namespace UpdateWorkflowRequest {
   export function isa(o: any): o is UpdateWorkflowRequest {
-    return _smithy.isa(o, "UpdateWorkflowRequest");
+    return __isa(o, "UpdateWorkflowRequest");
   }
 }
 
@@ -8626,7 +8629,7 @@ export interface UpdateWorkflowResponse extends $MetadataBearer {
 
 export namespace UpdateWorkflowResponse {
   export function isa(o: any): o is UpdateWorkflowResponse {
-    return _smithy.isa(o, "UpdateWorkflowResponse");
+    return __isa(o, "UpdateWorkflowResponse");
   }
 }
 
@@ -8675,7 +8678,7 @@ export interface Workflow {
 
 export namespace Workflow {
   export function isa(o: any): o is Workflow {
-    return _smithy.isa(o, "Workflow");
+    return __isa(o, "Workflow");
   }
 }
 
@@ -8698,7 +8701,7 @@ export interface WorkflowGraph {
 
 export namespace WorkflowGraph {
   export function isa(o: any): o is WorkflowGraph {
-    return _smithy.isa(o, "WorkflowGraph");
+    return __isa(o, "WorkflowGraph");
   }
 }
 
@@ -8751,7 +8754,7 @@ export interface WorkflowRun {
 
 export namespace WorkflowRun {
   export function isa(o: any): o is WorkflowRun {
-    return _smithy.isa(o, "WorkflowRun");
+    return __isa(o, "WorkflowRun");
   }
 }
 
@@ -8793,7 +8796,7 @@ export interface WorkflowRunStatistics {
 
 export namespace WorkflowRunStatistics {
   export function isa(o: any): o is WorkflowRunStatistics {
-    return _smithy.isa(o, "WorkflowRunStatistics");
+    return __isa(o, "WorkflowRunStatistics");
   }
 }
 
@@ -8813,7 +8816,7 @@ export interface BatchGetCrawlersRequest {
 
 export namespace BatchGetCrawlersRequest {
   export function isa(o: any): o is BatchGetCrawlersRequest {
-    return _smithy.isa(o, "BatchGetCrawlersRequest");
+    return __isa(o, "BatchGetCrawlersRequest");
   }
 }
 
@@ -8832,7 +8835,7 @@ export interface BatchGetCrawlersResponse extends $MetadataBearer {
 
 export namespace BatchGetCrawlersResponse {
   export function isa(o: any): o is BatchGetCrawlersResponse {
-    return _smithy.isa(o, "BatchGetCrawlersResponse");
+    return __isa(o, "BatchGetCrawlersResponse");
   }
 }
 
@@ -8854,7 +8857,7 @@ export interface CatalogEntry {
 
 export namespace CatalogEntry {
   export function isa(o: any): o is CatalogEntry {
-    return _smithy.isa(o, "CatalogEntry");
+    return __isa(o, "CatalogEntry");
   }
 }
 
@@ -8876,7 +8879,7 @@ export interface CatalogTarget {
 
 export namespace CatalogTarget {
   export function isa(o: any): o is CatalogTarget {
-    return _smithy.isa(o, "CatalogTarget");
+    return __isa(o, "CatalogTarget");
   }
 }
 
@@ -8915,7 +8918,7 @@ export interface Classifier {
 
 export namespace Classifier {
   export function isa(o: any): o is Classifier {
-    return _smithy.isa(o, "Classifier");
+    return __isa(o, "Classifier");
   }
 }
 
@@ -8942,7 +8945,7 @@ export interface CodeGenEdge {
 
 export namespace CodeGenEdge {
   export function isa(o: any): o is CodeGenEdge {
-    return _smithy.isa(o, "CodeGenEdge");
+    return __isa(o, "CodeGenEdge");
   }
 }
 
@@ -8974,7 +8977,7 @@ export interface CodeGenNode {
 
 export namespace CodeGenNode {
   export function isa(o: any): o is CodeGenNode {
-    return _smithy.isa(o, "CodeGenNode");
+    return __isa(o, "CodeGenNode");
   }
 }
 
@@ -9001,7 +9004,7 @@ export interface CodeGenNodeArg {
 
 export namespace CodeGenNodeArg {
   export function isa(o: any): o is CodeGenNodeArg {
-    return _smithy.isa(o, "CodeGenNodeArg");
+    return __isa(o, "CodeGenNodeArg");
   }
 }
 
@@ -9107,7 +9110,7 @@ export interface Crawler {
 
 export namespace Crawler {
   export function isa(o: any): o is Crawler {
-    return _smithy.isa(o, "Crawler");
+    return __isa(o, "Crawler");
   }
 }
 
@@ -9159,7 +9162,7 @@ export interface CrawlerMetrics {
 
 export namespace CrawlerMetrics {
   export function isa(o: any): o is CrawlerMetrics {
-    return _smithy.isa(o, "CrawlerMetrics");
+    return __isa(o, "CrawlerMetrics");
   }
 }
 
@@ -9167,7 +9170,7 @@ export namespace CrawlerMetrics {
  * <p>The specified crawler is not running.</p>
  */
 export interface CrawlerNotRunningException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CrawlerNotRunningException";
   $fault: "client";
@@ -9179,7 +9182,7 @@ export interface CrawlerNotRunningException
 
 export namespace CrawlerNotRunningException {
   export function isa(o: any): o is CrawlerNotRunningException {
-    return _smithy.isa(o, "CrawlerNotRunningException");
+    return __isa(o, "CrawlerNotRunningException");
   }
 }
 
@@ -9187,7 +9190,7 @@ export namespace CrawlerNotRunningException {
  * <p>The operation cannot be performed because the crawler is already running.</p>
  */
 export interface CrawlerRunningException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CrawlerRunningException";
   $fault: "client";
@@ -9199,7 +9202,7 @@ export interface CrawlerRunningException
 
 export namespace CrawlerRunningException {
   export function isa(o: any): o is CrawlerRunningException {
-    return _smithy.isa(o, "CrawlerRunningException");
+    return __isa(o, "CrawlerRunningException");
   }
 }
 
@@ -9213,7 +9216,7 @@ export enum CrawlerState {
  * <p>The specified crawler is stopping.</p>
  */
 export interface CrawlerStoppingException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CrawlerStoppingException";
   $fault: "client";
@@ -9225,7 +9228,7 @@ export interface CrawlerStoppingException
 
 export namespace CrawlerStoppingException {
   export function isa(o: any): o is CrawlerStoppingException {
-    return _smithy.isa(o, "CrawlerStoppingException");
+    return __isa(o, "CrawlerStoppingException");
   }
 }
 
@@ -9257,7 +9260,7 @@ export interface CrawlerTargets {
 
 export namespace CrawlerTargets {
   export function isa(o: any): o is CrawlerTargets {
-    return _smithy.isa(o, "CrawlerTargets");
+    return __isa(o, "CrawlerTargets");
   }
 }
 
@@ -9290,7 +9293,7 @@ export interface CreateClassifierRequest {
 
 export namespace CreateClassifierRequest {
   export function isa(o: any): o is CreateClassifierRequest {
-    return _smithy.isa(o, "CreateClassifierRequest");
+    return __isa(o, "CreateClassifierRequest");
   }
 }
 
@@ -9300,7 +9303,7 @@ export interface CreateClassifierResponse extends $MetadataBearer {
 
 export namespace CreateClassifierResponse {
   export function isa(o: any): o is CreateClassifierResponse {
-    return _smithy.isa(o, "CreateClassifierResponse");
+    return __isa(o, "CreateClassifierResponse");
   }
 }
 
@@ -9380,7 +9383,7 @@ export interface CreateCrawlerRequest {
 
 export namespace CreateCrawlerRequest {
   export function isa(o: any): o is CreateCrawlerRequest {
-    return _smithy.isa(o, "CreateCrawlerRequest");
+    return __isa(o, "CreateCrawlerRequest");
   }
 }
 
@@ -9390,7 +9393,7 @@ export interface CreateCrawlerResponse extends $MetadataBearer {
 
 export namespace CreateCrawlerResponse {
   export function isa(o: any): o is CreateCrawlerResponse {
-    return _smithy.isa(o, "CreateCrawlerResponse");
+    return __isa(o, "CreateCrawlerResponse");
   }
 }
 
@@ -9437,7 +9440,7 @@ export interface CreateCsvClassifierRequest {
 
 export namespace CreateCsvClassifierRequest {
   export function isa(o: any): o is CreateCsvClassifierRequest {
-    return _smithy.isa(o, "CreateCsvClassifierRequest");
+    return __isa(o, "CreateCsvClassifierRequest");
   }
 }
 
@@ -9471,7 +9474,7 @@ export interface CreateGrokClassifierRequest {
 
 export namespace CreateGrokClassifierRequest {
   export function isa(o: any): o is CreateGrokClassifierRequest {
-    return _smithy.isa(o, "CreateGrokClassifierRequest");
+    return __isa(o, "CreateGrokClassifierRequest");
   }
 }
 
@@ -9494,7 +9497,7 @@ export interface CreateJsonClassifierRequest {
 
 export namespace CreateJsonClassifierRequest {
   export function isa(o: any): o is CreateJsonClassifierRequest {
-    return _smithy.isa(o, "CreateJsonClassifierRequest");
+    return __isa(o, "CreateJsonClassifierRequest");
   }
 }
 
@@ -9518,7 +9521,7 @@ export interface CreateScriptRequest {
 
 export namespace CreateScriptRequest {
   export function isa(o: any): o is CreateScriptRequest {
-    return _smithy.isa(o, "CreateScriptRequest");
+    return __isa(o, "CreateScriptRequest");
   }
 }
 
@@ -9537,7 +9540,7 @@ export interface CreateScriptResponse extends $MetadataBearer {
 
 export namespace CreateScriptResponse {
   export function isa(o: any): o is CreateScriptResponse {
-    return _smithy.isa(o, "CreateScriptResponse");
+    return __isa(o, "CreateScriptResponse");
   }
 }
 
@@ -9568,7 +9571,7 @@ export interface CreateXMLClassifierRequest {
 
 export namespace CreateXMLClassifierRequest {
   export function isa(o: any): o is CreateXMLClassifierRequest {
-    return _smithy.isa(o, "CreateXMLClassifierRequest");
+    return __isa(o, "CreateXMLClassifierRequest");
   }
 }
 
@@ -9632,7 +9635,7 @@ export interface CsvClassifier {
 
 export namespace CsvClassifier {
   export function isa(o: any): o is CsvClassifier {
-    return _smithy.isa(o, "CsvClassifier");
+    return __isa(o, "CsvClassifier");
   }
 }
 
@@ -9658,7 +9661,7 @@ export interface DeleteClassifierRequest {
 
 export namespace DeleteClassifierRequest {
   export function isa(o: any): o is DeleteClassifierRequest {
-    return _smithy.isa(o, "DeleteClassifierRequest");
+    return __isa(o, "DeleteClassifierRequest");
   }
 }
 
@@ -9668,7 +9671,7 @@ export interface DeleteClassifierResponse extends $MetadataBearer {
 
 export namespace DeleteClassifierResponse {
   export function isa(o: any): o is DeleteClassifierResponse {
-    return _smithy.isa(o, "DeleteClassifierResponse");
+    return __isa(o, "DeleteClassifierResponse");
   }
 }
 
@@ -9682,7 +9685,7 @@ export interface DeleteCrawlerRequest {
 
 export namespace DeleteCrawlerRequest {
   export function isa(o: any): o is DeleteCrawlerRequest {
-    return _smithy.isa(o, "DeleteCrawlerRequest");
+    return __isa(o, "DeleteCrawlerRequest");
   }
 }
 
@@ -9692,7 +9695,7 @@ export interface DeleteCrawlerResponse extends $MetadataBearer {
 
 export namespace DeleteCrawlerResponse {
   export function isa(o: any): o is DeleteCrawlerResponse {
-    return _smithy.isa(o, "DeleteCrawlerResponse");
+    return __isa(o, "DeleteCrawlerResponse");
   }
 }
 
@@ -9709,7 +9712,7 @@ export interface DynamoDBTarget {
 
 export namespace DynamoDBTarget {
   export function isa(o: any): o is DynamoDBTarget {
-    return _smithy.isa(o, "DynamoDBTarget");
+    return __isa(o, "DynamoDBTarget");
   }
 }
 
@@ -9723,7 +9726,7 @@ export interface GetClassifierRequest {
 
 export namespace GetClassifierRequest {
   export function isa(o: any): o is GetClassifierRequest {
-    return _smithy.isa(o, "GetClassifierRequest");
+    return __isa(o, "GetClassifierRequest");
   }
 }
 
@@ -9737,7 +9740,7 @@ export interface GetClassifierResponse extends $MetadataBearer {
 
 export namespace GetClassifierResponse {
   export function isa(o: any): o is GetClassifierResponse {
-    return _smithy.isa(o, "GetClassifierResponse");
+    return __isa(o, "GetClassifierResponse");
   }
 }
 
@@ -9756,7 +9759,7 @@ export interface GetClassifiersRequest {
 
 export namespace GetClassifiersRequest {
   export function isa(o: any): o is GetClassifiersRequest {
-    return _smithy.isa(o, "GetClassifiersRequest");
+    return __isa(o, "GetClassifiersRequest");
   }
 }
 
@@ -9776,7 +9779,7 @@ export interface GetClassifiersResponse extends $MetadataBearer {
 
 export namespace GetClassifiersResponse {
   export function isa(o: any): o is GetClassifiersResponse {
-    return _smithy.isa(o, "GetClassifiersResponse");
+    return __isa(o, "GetClassifiersResponse");
   }
 }
 
@@ -9800,7 +9803,7 @@ export interface GetCrawlerMetricsRequest {
 
 export namespace GetCrawlerMetricsRequest {
   export function isa(o: any): o is GetCrawlerMetricsRequest {
-    return _smithy.isa(o, "GetCrawlerMetricsRequest");
+    return __isa(o, "GetCrawlerMetricsRequest");
   }
 }
 
@@ -9820,7 +9823,7 @@ export interface GetCrawlerMetricsResponse extends $MetadataBearer {
 
 export namespace GetCrawlerMetricsResponse {
   export function isa(o: any): o is GetCrawlerMetricsResponse {
-    return _smithy.isa(o, "GetCrawlerMetricsResponse");
+    return __isa(o, "GetCrawlerMetricsResponse");
   }
 }
 
@@ -9834,7 +9837,7 @@ export interface GetCrawlerRequest {
 
 export namespace GetCrawlerRequest {
   export function isa(o: any): o is GetCrawlerRequest {
-    return _smithy.isa(o, "GetCrawlerRequest");
+    return __isa(o, "GetCrawlerRequest");
   }
 }
 
@@ -9848,7 +9851,7 @@ export interface GetCrawlerResponse extends $MetadataBearer {
 
 export namespace GetCrawlerResponse {
   export function isa(o: any): o is GetCrawlerResponse {
-    return _smithy.isa(o, "GetCrawlerResponse");
+    return __isa(o, "GetCrawlerResponse");
   }
 }
 
@@ -9867,7 +9870,7 @@ export interface GetCrawlersRequest {
 
 export namespace GetCrawlersRequest {
   export function isa(o: any): o is GetCrawlersRequest {
-    return _smithy.isa(o, "GetCrawlersRequest");
+    return __isa(o, "GetCrawlersRequest");
   }
 }
 
@@ -9887,7 +9890,7 @@ export interface GetCrawlersResponse extends $MetadataBearer {
 
 export namespace GetCrawlersResponse {
   export function isa(o: any): o is GetCrawlersResponse {
-    return _smithy.isa(o, "GetCrawlersResponse");
+    return __isa(o, "GetCrawlersResponse");
   }
 }
 
@@ -9901,7 +9904,7 @@ export interface GetDataflowGraphRequest {
 
 export namespace GetDataflowGraphRequest {
   export function isa(o: any): o is GetDataflowGraphRequest {
-    return _smithy.isa(o, "GetDataflowGraphRequest");
+    return __isa(o, "GetDataflowGraphRequest");
   }
 }
 
@@ -9920,7 +9923,7 @@ export interface GetDataflowGraphResponse extends $MetadataBearer {
 
 export namespace GetDataflowGraphResponse {
   export function isa(o: any): o is GetDataflowGraphResponse {
-    return _smithy.isa(o, "GetDataflowGraphResponse");
+    return __isa(o, "GetDataflowGraphResponse");
   }
 }
 
@@ -9944,7 +9947,7 @@ export interface GetMappingRequest {
 
 export namespace GetMappingRequest {
   export function isa(o: any): o is GetMappingRequest {
-    return _smithy.isa(o, "GetMappingRequest");
+    return __isa(o, "GetMappingRequest");
   }
 }
 
@@ -9958,7 +9961,7 @@ export interface GetMappingResponse extends $MetadataBearer {
 
 export namespace GetMappingResponse {
   export function isa(o: any): o is GetMappingResponse {
-    return _smithy.isa(o, "GetMappingResponse");
+    return __isa(o, "GetMappingResponse");
   }
 }
 
@@ -9992,7 +9995,7 @@ export interface GetPlanRequest {
 
 export namespace GetPlanRequest {
   export function isa(o: any): o is GetPlanRequest {
-    return _smithy.isa(o, "GetPlanRequest");
+    return __isa(o, "GetPlanRequest");
   }
 }
 
@@ -10011,7 +10014,7 @@ export interface GetPlanResponse extends $MetadataBearer {
 
 export namespace GetPlanResponse {
   export function isa(o: any): o is GetPlanResponse {
-    return _smithy.isa(o, "GetPlanResponse");
+    return __isa(o, "GetPlanResponse");
   }
 }
 
@@ -10062,7 +10065,7 @@ export interface GrokClassifier {
 
 export namespace GrokClassifier {
   export function isa(o: any): o is GrokClassifier {
-    return _smithy.isa(o, "GrokClassifier");
+    return __isa(o, "GrokClassifier");
   }
 }
 
@@ -10090,7 +10093,7 @@ export interface JdbcTarget {
 
 export namespace JdbcTarget {
   export function isa(o: any): o is JdbcTarget {
-    return _smithy.isa(o, "JdbcTarget");
+    return __isa(o, "JdbcTarget");
   }
 }
 
@@ -10128,7 +10131,7 @@ export interface JsonClassifier {
 
 export namespace JsonClassifier {
   export function isa(o: any): o is JsonClassifier {
-    return _smithy.isa(o, "JsonClassifier");
+    return __isa(o, "JsonClassifier");
   }
 }
 
@@ -10175,7 +10178,7 @@ export interface LastCrawlInfo {
 
 export namespace LastCrawlInfo {
   export function isa(o: any): o is LastCrawlInfo {
-    return _smithy.isa(o, "LastCrawlInfo");
+    return __isa(o, "LastCrawlInfo");
   }
 }
 
@@ -10205,7 +10208,7 @@ export interface ListCrawlersRequest {
 
 export namespace ListCrawlersRequest {
   export function isa(o: any): o is ListCrawlersRequest {
-    return _smithy.isa(o, "ListCrawlersRequest");
+    return __isa(o, "ListCrawlersRequest");
   }
 }
 
@@ -10225,7 +10228,7 @@ export interface ListCrawlersResponse extends $MetadataBearer {
 
 export namespace ListCrawlersResponse {
   export function isa(o: any): o is ListCrawlersResponse {
-    return _smithy.isa(o, "ListCrawlersResponse");
+    return __isa(o, "ListCrawlersResponse");
   }
 }
 
@@ -10252,7 +10255,7 @@ export interface Location {
 
 export namespace Location {
   export function isa(o: any): o is Location {
-    return _smithy.isa(o, "Location");
+    return __isa(o, "Location");
   }
 }
 
@@ -10294,7 +10297,7 @@ export interface MappingEntry {
 
 export namespace MappingEntry {
   export function isa(o: any): o is MappingEntry {
-    return _smithy.isa(o, "MappingEntry");
+    return __isa(o, "MappingEntry");
   }
 }
 
@@ -10302,7 +10305,7 @@ export namespace MappingEntry {
  * <p>There is no applicable schedule.</p>
  */
 export interface NoScheduleException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "NoScheduleException";
   $fault: "client";
@@ -10314,7 +10317,7 @@ export interface NoScheduleException
 
 export namespace NoScheduleException {
   export function isa(o: any): o is NoScheduleException {
-    return _smithy.isa(o, "NoScheduleException");
+    return __isa(o, "NoScheduleException");
   }
 }
 
@@ -10337,7 +10340,7 @@ export interface S3Target {
 
 export namespace S3Target {
   export function isa(o: any): o is S3Target {
-    return _smithy.isa(o, "S3Target");
+    return __isa(o, "S3Target");
   }
 }
 
@@ -10361,7 +10364,7 @@ export interface Schedule {
 
 export namespace Schedule {
   export function isa(o: any): o is Schedule {
-    return _smithy.isa(o, "Schedule");
+    return __isa(o, "Schedule");
   }
 }
 
@@ -10375,7 +10378,7 @@ export enum ScheduleState {
  * <p>The specified scheduler is not running.</p>
  */
 export interface SchedulerNotRunningException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "SchedulerNotRunningException";
   $fault: "client";
@@ -10387,7 +10390,7 @@ export interface SchedulerNotRunningException
 
 export namespace SchedulerNotRunningException {
   export function isa(o: any): o is SchedulerNotRunningException {
-    return _smithy.isa(o, "SchedulerNotRunningException");
+    return __isa(o, "SchedulerNotRunningException");
   }
 }
 
@@ -10395,7 +10398,7 @@ export namespace SchedulerNotRunningException {
  * <p>The specified scheduler is already running.</p>
  */
 export interface SchedulerRunningException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "SchedulerRunningException";
   $fault: "client";
@@ -10407,7 +10410,7 @@ export interface SchedulerRunningException
 
 export namespace SchedulerRunningException {
   export function isa(o: any): o is SchedulerRunningException {
-    return _smithy.isa(o, "SchedulerRunningException");
+    return __isa(o, "SchedulerRunningException");
   }
 }
 
@@ -10415,7 +10418,7 @@ export namespace SchedulerRunningException {
  * <p>The specified scheduler is transitioning.</p>
  */
 export interface SchedulerTransitioningException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "SchedulerTransitioningException";
   $fault: "client";
@@ -10427,7 +10430,7 @@ export interface SchedulerTransitioningException
 
 export namespace SchedulerTransitioningException {
   export function isa(o: any): o is SchedulerTransitioningException {
-    return _smithy.isa(o, "SchedulerTransitioningException");
+    return __isa(o, "SchedulerTransitioningException");
   }
 }
 
@@ -10449,7 +10452,7 @@ export interface SchemaChangePolicy {
 
 export namespace SchemaChangePolicy {
   export function isa(o: any): o is SchemaChangePolicy {
-    return _smithy.isa(o, "SchemaChangePolicy");
+    return __isa(o, "SchemaChangePolicy");
   }
 }
 
@@ -10463,7 +10466,7 @@ export interface StartCrawlerRequest {
 
 export namespace StartCrawlerRequest {
   export function isa(o: any): o is StartCrawlerRequest {
-    return _smithy.isa(o, "StartCrawlerRequest");
+    return __isa(o, "StartCrawlerRequest");
   }
 }
 
@@ -10473,7 +10476,7 @@ export interface StartCrawlerResponse extends $MetadataBearer {
 
 export namespace StartCrawlerResponse {
   export function isa(o: any): o is StartCrawlerResponse {
-    return _smithy.isa(o, "StartCrawlerResponse");
+    return __isa(o, "StartCrawlerResponse");
   }
 }
 
@@ -10487,7 +10490,7 @@ export interface StartCrawlerScheduleRequest {
 
 export namespace StartCrawlerScheduleRequest {
   export function isa(o: any): o is StartCrawlerScheduleRequest {
-    return _smithy.isa(o, "StartCrawlerScheduleRequest");
+    return __isa(o, "StartCrawlerScheduleRequest");
   }
 }
 
@@ -10497,7 +10500,7 @@ export interface StartCrawlerScheduleResponse extends $MetadataBearer {
 
 export namespace StartCrawlerScheduleResponse {
   export function isa(o: any): o is StartCrawlerScheduleResponse {
-    return _smithy.isa(o, "StartCrawlerScheduleResponse");
+    return __isa(o, "StartCrawlerScheduleResponse");
   }
 }
 
@@ -10511,7 +10514,7 @@ export interface StopCrawlerRequest {
 
 export namespace StopCrawlerRequest {
   export function isa(o: any): o is StopCrawlerRequest {
-    return _smithy.isa(o, "StopCrawlerRequest");
+    return __isa(o, "StopCrawlerRequest");
   }
 }
 
@@ -10521,7 +10524,7 @@ export interface StopCrawlerResponse extends $MetadataBearer {
 
 export namespace StopCrawlerResponse {
   export function isa(o: any): o is StopCrawlerResponse {
-    return _smithy.isa(o, "StopCrawlerResponse");
+    return __isa(o, "StopCrawlerResponse");
   }
 }
 
@@ -10535,7 +10538,7 @@ export interface StopCrawlerScheduleRequest {
 
 export namespace StopCrawlerScheduleRequest {
   export function isa(o: any): o is StopCrawlerScheduleRequest {
-    return _smithy.isa(o, "StopCrawlerScheduleRequest");
+    return __isa(o, "StopCrawlerScheduleRequest");
   }
 }
 
@@ -10545,7 +10548,7 @@ export interface StopCrawlerScheduleResponse extends $MetadataBearer {
 
 export namespace StopCrawlerScheduleResponse {
   export function isa(o: any): o is StopCrawlerScheduleResponse {
-    return _smithy.isa(o, "StopCrawlerScheduleResponse");
+    return __isa(o, "StopCrawlerScheduleResponse");
   }
 }
 
@@ -10579,7 +10582,7 @@ export interface UpdateClassifierRequest {
 
 export namespace UpdateClassifierRequest {
   export function isa(o: any): o is UpdateClassifierRequest {
-    return _smithy.isa(o, "UpdateClassifierRequest");
+    return __isa(o, "UpdateClassifierRequest");
   }
 }
 
@@ -10589,7 +10592,7 @@ export interface UpdateClassifierResponse extends $MetadataBearer {
 
 export namespace UpdateClassifierResponse {
   export function isa(o: any): o is UpdateClassifierResponse {
-    return _smithy.isa(o, "UpdateClassifierResponse");
+    return __isa(o, "UpdateClassifierResponse");
   }
 }
 
@@ -10663,7 +10666,7 @@ export interface UpdateCrawlerRequest {
 
 export namespace UpdateCrawlerRequest {
   export function isa(o: any): o is UpdateCrawlerRequest {
-    return _smithy.isa(o, "UpdateCrawlerRequest");
+    return __isa(o, "UpdateCrawlerRequest");
   }
 }
 
@@ -10673,7 +10676,7 @@ export interface UpdateCrawlerResponse extends $MetadataBearer {
 
 export namespace UpdateCrawlerResponse {
   export function isa(o: any): o is UpdateCrawlerResponse {
-    return _smithy.isa(o, "UpdateCrawlerResponse");
+    return __isa(o, "UpdateCrawlerResponse");
   }
 }
 
@@ -10694,7 +10697,7 @@ export interface UpdateCrawlerScheduleRequest {
 
 export namespace UpdateCrawlerScheduleRequest {
   export function isa(o: any): o is UpdateCrawlerScheduleRequest {
-    return _smithy.isa(o, "UpdateCrawlerScheduleRequest");
+    return __isa(o, "UpdateCrawlerScheduleRequest");
   }
 }
 
@@ -10704,7 +10707,7 @@ export interface UpdateCrawlerScheduleResponse extends $MetadataBearer {
 
 export namespace UpdateCrawlerScheduleResponse {
   export function isa(o: any): o is UpdateCrawlerScheduleResponse {
-    return _smithy.isa(o, "UpdateCrawlerScheduleResponse");
+    return __isa(o, "UpdateCrawlerScheduleResponse");
   }
 }
 
@@ -10752,7 +10755,7 @@ export interface UpdateCsvClassifierRequest {
 
 export namespace UpdateCsvClassifierRequest {
   export function isa(o: any): o is UpdateCsvClassifierRequest {
-    return _smithy.isa(o, "UpdateCsvClassifierRequest");
+    return __isa(o, "UpdateCsvClassifierRequest");
   }
 }
 
@@ -10786,7 +10789,7 @@ export interface UpdateGrokClassifierRequest {
 
 export namespace UpdateGrokClassifierRequest {
   export function isa(o: any): o is UpdateGrokClassifierRequest {
-    return _smithy.isa(o, "UpdateGrokClassifierRequest");
+    return __isa(o, "UpdateGrokClassifierRequest");
   }
 }
 
@@ -10809,7 +10812,7 @@ export interface UpdateJsonClassifierRequest {
 
 export namespace UpdateJsonClassifierRequest {
   export function isa(o: any): o is UpdateJsonClassifierRequest {
-    return _smithy.isa(o, "UpdateJsonClassifierRequest");
+    return __isa(o, "UpdateJsonClassifierRequest");
   }
 }
 
@@ -10840,7 +10843,7 @@ export interface UpdateXMLClassifierRequest {
 
 export namespace UpdateXMLClassifierRequest {
   export function isa(o: any): o is UpdateXMLClassifierRequest {
-    return _smithy.isa(o, "UpdateXMLClassifierRequest");
+    return __isa(o, "UpdateXMLClassifierRequest");
   }
 }
 
@@ -10886,6 +10889,6 @@ export interface XMLClassifier {
 
 export namespace XMLClassifier {
   export function isa(o: any): o is XMLClassifier {
-    return _smithy.isa(o, "XMLClassifier");
+    return __isa(o, "XMLClassifier");
   }
 }

--- a/clients/client-greengrass/models/index.ts
+++ b/clients/client-greengrass/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export interface AssociateRoleToGroupRequest {
@@ -16,7 +19,7 @@ export interface AssociateRoleToGroupRequest {
 
 export namespace AssociateRoleToGroupRequest {
   export function isa(o: any): o is AssociateRoleToGroupRequest {
-    return _smithy.isa(o, "AssociateRoleToGroupRequest");
+    return __isa(o, "AssociateRoleToGroupRequest");
   }
 }
 
@@ -30,7 +33,7 @@ export interface AssociateRoleToGroupResponse extends $MetadataBearer {
 
 export namespace AssociateRoleToGroupResponse {
   export function isa(o: any): o is AssociateRoleToGroupResponse {
-    return _smithy.isa(o, "AssociateRoleToGroupResponse");
+    return __isa(o, "AssociateRoleToGroupResponse");
   }
 }
 
@@ -44,7 +47,7 @@ export interface AssociateServiceRoleToAccountRequest {
 
 export namespace AssociateServiceRoleToAccountRequest {
   export function isa(o: any): o is AssociateServiceRoleToAccountRequest {
-    return _smithy.isa(o, "AssociateServiceRoleToAccountRequest");
+    return __isa(o, "AssociateServiceRoleToAccountRequest");
   }
 }
 
@@ -58,7 +61,7 @@ export interface AssociateServiceRoleToAccountResponse extends $MetadataBearer {
 
 export namespace AssociateServiceRoleToAccountResponse {
   export function isa(o: any): o is AssociateServiceRoleToAccountResponse {
-    return _smithy.isa(o, "AssociateServiceRoleToAccountResponse");
+    return __isa(o, "AssociateServiceRoleToAccountResponse");
   }
 }
 
@@ -66,7 +69,7 @@ export namespace AssociateServiceRoleToAccountResponse {
  * General error information.
  */
 export interface BadRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "BadRequestException";
   $fault: "client";
@@ -83,7 +86,7 @@ export interface BadRequestException
 
 export namespace BadRequestException {
   export function isa(o: any): o is BadRequestException {
-    return _smithy.isa(o, "BadRequestException");
+    return __isa(o, "BadRequestException");
   }
 }
 
@@ -110,7 +113,7 @@ export interface BulkDeployment {
 
 export namespace BulkDeployment {
   export function isa(o: any): o is BulkDeployment {
-    return _smithy.isa(o, "BulkDeployment");
+    return __isa(o, "BulkDeployment");
   }
 }
 
@@ -137,7 +140,7 @@ export interface BulkDeploymentMetrics {
 
 export namespace BulkDeploymentMetrics {
   export function isa(o: any): o is BulkDeploymentMetrics {
-    return _smithy.isa(o, "BulkDeploymentMetrics");
+    return __isa(o, "BulkDeploymentMetrics");
   }
 }
 
@@ -189,7 +192,7 @@ export interface BulkDeploymentResult {
 
 export namespace BulkDeploymentResult {
   export function isa(o: any): o is BulkDeploymentResult {
-    return _smithy.isa(o, "BulkDeploymentResult");
+    return __isa(o, "BulkDeploymentResult");
   }
 }
 
@@ -230,7 +233,7 @@ export interface ConnectivityInfo {
 
 export namespace ConnectivityInfo {
   export function isa(o: any): o is ConnectivityInfo {
-    return _smithy.isa(o, "ConnectivityInfo");
+    return __isa(o, "ConnectivityInfo");
   }
 }
 
@@ -257,7 +260,7 @@ export interface Connector {
 
 export namespace Connector {
   export function isa(o: any): o is Connector {
-    return _smithy.isa(o, "Connector");
+    return __isa(o, "Connector");
   }
 }
 
@@ -274,7 +277,7 @@ export interface ConnectorDefinitionVersion {
 
 export namespace ConnectorDefinitionVersion {
   export function isa(o: any): o is ConnectorDefinitionVersion {
-    return _smithy.isa(o, "ConnectorDefinitionVersion");
+    return __isa(o, "ConnectorDefinitionVersion");
   }
 }
 
@@ -306,7 +309,7 @@ export interface Core {
 
 export namespace Core {
   export function isa(o: any): o is Core {
-    return _smithy.isa(o, "Core");
+    return __isa(o, "Core");
   }
 }
 
@@ -323,7 +326,7 @@ export interface CoreDefinitionVersion {
 
 export namespace CoreDefinitionVersion {
   export function isa(o: any): o is CoreDefinitionVersion {
-    return _smithy.isa(o, "CoreDefinitionVersion");
+    return __isa(o, "CoreDefinitionVersion");
   }
 }
 
@@ -352,7 +355,7 @@ export interface CreateConnectorDefinitionRequest {
 
 export namespace CreateConnectorDefinitionRequest {
   export function isa(o: any): o is CreateConnectorDefinitionRequest {
-    return _smithy.isa(o, "CreateConnectorDefinitionRequest");
+    return __isa(o, "CreateConnectorDefinitionRequest");
   }
 }
 
@@ -396,7 +399,7 @@ export interface CreateConnectorDefinitionResponse extends $MetadataBearer {
 
 export namespace CreateConnectorDefinitionResponse {
   export function isa(o: any): o is CreateConnectorDefinitionResponse {
-    return _smithy.isa(o, "CreateConnectorDefinitionResponse");
+    return __isa(o, "CreateConnectorDefinitionResponse");
   }
 }
 
@@ -420,7 +423,7 @@ export interface CreateConnectorDefinitionVersionRequest {
 
 export namespace CreateConnectorDefinitionVersionRequest {
   export function isa(o: any): o is CreateConnectorDefinitionVersionRequest {
-    return _smithy.isa(o, "CreateConnectorDefinitionVersionRequest");
+    return __isa(o, "CreateConnectorDefinitionVersionRequest");
   }
 }
 
@@ -450,7 +453,7 @@ export interface CreateConnectorDefinitionVersionResponse
 
 export namespace CreateConnectorDefinitionVersionResponse {
   export function isa(o: any): o is CreateConnectorDefinitionVersionResponse {
-    return _smithy.isa(o, "CreateConnectorDefinitionVersionResponse");
+    return __isa(o, "CreateConnectorDefinitionVersionResponse");
   }
 }
 
@@ -482,7 +485,7 @@ export interface CreateCoreDefinitionRequest {
 
 export namespace CreateCoreDefinitionRequest {
   export function isa(o: any): o is CreateCoreDefinitionRequest {
-    return _smithy.isa(o, "CreateCoreDefinitionRequest");
+    return __isa(o, "CreateCoreDefinitionRequest");
   }
 }
 
@@ -526,7 +529,7 @@ export interface CreateCoreDefinitionResponse extends $MetadataBearer {
 
 export namespace CreateCoreDefinitionResponse {
   export function isa(o: any): o is CreateCoreDefinitionResponse {
-    return _smithy.isa(o, "CreateCoreDefinitionResponse");
+    return __isa(o, "CreateCoreDefinitionResponse");
   }
 }
 
@@ -550,7 +553,7 @@ export interface CreateCoreDefinitionVersionRequest {
 
 export namespace CreateCoreDefinitionVersionRequest {
   export function isa(o: any): o is CreateCoreDefinitionVersionRequest {
-    return _smithy.isa(o, "CreateCoreDefinitionVersionRequest");
+    return __isa(o, "CreateCoreDefinitionVersionRequest");
   }
 }
 
@@ -579,7 +582,7 @@ export interface CreateCoreDefinitionVersionResponse extends $MetadataBearer {
 
 export namespace CreateCoreDefinitionVersionResponse {
   export function isa(o: any): o is CreateCoreDefinitionVersionResponse {
-    return _smithy.isa(o, "CreateCoreDefinitionVersionResponse");
+    return __isa(o, "CreateCoreDefinitionVersionResponse");
   }
 }
 
@@ -613,7 +616,7 @@ export interface CreateDeploymentRequest {
 
 export namespace CreateDeploymentRequest {
   export function isa(o: any): o is CreateDeploymentRequest {
-    return _smithy.isa(o, "CreateDeploymentRequest");
+    return __isa(o, "CreateDeploymentRequest");
   }
 }
 
@@ -632,7 +635,7 @@ export interface CreateDeploymentResponse extends $MetadataBearer {
 
 export namespace CreateDeploymentResponse {
   export function isa(o: any): o is CreateDeploymentResponse {
-    return _smithy.isa(o, "CreateDeploymentResponse");
+    return __isa(o, "CreateDeploymentResponse");
   }
 }
 
@@ -661,7 +664,7 @@ export interface CreateDeviceDefinitionRequest {
 
 export namespace CreateDeviceDefinitionRequest {
   export function isa(o: any): o is CreateDeviceDefinitionRequest {
-    return _smithy.isa(o, "CreateDeviceDefinitionRequest");
+    return __isa(o, "CreateDeviceDefinitionRequest");
   }
 }
 
@@ -705,7 +708,7 @@ export interface CreateDeviceDefinitionResponse extends $MetadataBearer {
 
 export namespace CreateDeviceDefinitionResponse {
   export function isa(o: any): o is CreateDeviceDefinitionResponse {
-    return _smithy.isa(o, "CreateDeviceDefinitionResponse");
+    return __isa(o, "CreateDeviceDefinitionResponse");
   }
 }
 
@@ -729,7 +732,7 @@ export interface CreateDeviceDefinitionVersionRequest {
 
 export namespace CreateDeviceDefinitionVersionRequest {
   export function isa(o: any): o is CreateDeviceDefinitionVersionRequest {
-    return _smithy.isa(o, "CreateDeviceDefinitionVersionRequest");
+    return __isa(o, "CreateDeviceDefinitionVersionRequest");
   }
 }
 
@@ -758,7 +761,7 @@ export interface CreateDeviceDefinitionVersionResponse extends $MetadataBearer {
 
 export namespace CreateDeviceDefinitionVersionResponse {
   export function isa(o: any): o is CreateDeviceDefinitionVersionResponse {
-    return _smithy.isa(o, "CreateDeviceDefinitionVersionResponse");
+    return __isa(o, "CreateDeviceDefinitionVersionResponse");
   }
 }
 
@@ -787,7 +790,7 @@ export interface CreateFunctionDefinitionRequest {
 
 export namespace CreateFunctionDefinitionRequest {
   export function isa(o: any): o is CreateFunctionDefinitionRequest {
-    return _smithy.isa(o, "CreateFunctionDefinitionRequest");
+    return __isa(o, "CreateFunctionDefinitionRequest");
   }
 }
 
@@ -831,7 +834,7 @@ export interface CreateFunctionDefinitionResponse extends $MetadataBearer {
 
 export namespace CreateFunctionDefinitionResponse {
   export function isa(o: any): o is CreateFunctionDefinitionResponse {
-    return _smithy.isa(o, "CreateFunctionDefinitionResponse");
+    return __isa(o, "CreateFunctionDefinitionResponse");
   }
 }
 
@@ -863,7 +866,7 @@ export interface CreateFunctionDefinitionVersionRequest {
 
 export namespace CreateFunctionDefinitionVersionRequest {
   export function isa(o: any): o is CreateFunctionDefinitionVersionRequest {
-    return _smithy.isa(o, "CreateFunctionDefinitionVersionRequest");
+    return __isa(o, "CreateFunctionDefinitionVersionRequest");
   }
 }
 
@@ -893,7 +896,7 @@ export interface CreateFunctionDefinitionVersionResponse
 
 export namespace CreateFunctionDefinitionVersionResponse {
   export function isa(o: any): o is CreateFunctionDefinitionVersionResponse {
-    return _smithy.isa(o, "CreateFunctionDefinitionVersionResponse");
+    return __isa(o, "CreateFunctionDefinitionVersionResponse");
   }
 }
 
@@ -912,7 +915,7 @@ export interface CreateGroupCertificateAuthorityRequest {
 
 export namespace CreateGroupCertificateAuthorityRequest {
   export function isa(o: any): o is CreateGroupCertificateAuthorityRequest {
-    return _smithy.isa(o, "CreateGroupCertificateAuthorityRequest");
+    return __isa(o, "CreateGroupCertificateAuthorityRequest");
   }
 }
 
@@ -927,7 +930,7 @@ export interface CreateGroupCertificateAuthorityResponse
 
 export namespace CreateGroupCertificateAuthorityResponse {
   export function isa(o: any): o is CreateGroupCertificateAuthorityResponse {
-    return _smithy.isa(o, "CreateGroupCertificateAuthorityResponse");
+    return __isa(o, "CreateGroupCertificateAuthorityResponse");
   }
 }
 
@@ -956,7 +959,7 @@ export interface CreateGroupRequest {
 
 export namespace CreateGroupRequest {
   export function isa(o: any): o is CreateGroupRequest {
-    return _smithy.isa(o, "CreateGroupRequest");
+    return __isa(o, "CreateGroupRequest");
   }
 }
 
@@ -1000,7 +1003,7 @@ export interface CreateGroupResponse extends $MetadataBearer {
 
 export namespace CreateGroupResponse {
   export function isa(o: any): o is CreateGroupResponse {
-    return _smithy.isa(o, "CreateGroupResponse");
+    return __isa(o, "CreateGroupResponse");
   }
 }
 
@@ -1054,7 +1057,7 @@ export interface CreateGroupVersionRequest {
 
 export namespace CreateGroupVersionRequest {
   export function isa(o: any): o is CreateGroupVersionRequest {
-    return _smithy.isa(o, "CreateGroupVersionRequest");
+    return __isa(o, "CreateGroupVersionRequest");
   }
 }
 
@@ -1083,7 +1086,7 @@ export interface CreateGroupVersionResponse extends $MetadataBearer {
 
 export namespace CreateGroupVersionResponse {
   export function isa(o: any): o is CreateGroupVersionResponse {
-    return _smithy.isa(o, "CreateGroupVersionResponse");
+    return __isa(o, "CreateGroupVersionResponse");
   }
 }
 
@@ -1112,7 +1115,7 @@ export interface CreateLoggerDefinitionRequest {
 
 export namespace CreateLoggerDefinitionRequest {
   export function isa(o: any): o is CreateLoggerDefinitionRequest {
-    return _smithy.isa(o, "CreateLoggerDefinitionRequest");
+    return __isa(o, "CreateLoggerDefinitionRequest");
   }
 }
 
@@ -1156,7 +1159,7 @@ export interface CreateLoggerDefinitionResponse extends $MetadataBearer {
 
 export namespace CreateLoggerDefinitionResponse {
   export function isa(o: any): o is CreateLoggerDefinitionResponse {
-    return _smithy.isa(o, "CreateLoggerDefinitionResponse");
+    return __isa(o, "CreateLoggerDefinitionResponse");
   }
 }
 
@@ -1180,7 +1183,7 @@ export interface CreateLoggerDefinitionVersionRequest {
 
 export namespace CreateLoggerDefinitionVersionRequest {
   export function isa(o: any): o is CreateLoggerDefinitionVersionRequest {
-    return _smithy.isa(o, "CreateLoggerDefinitionVersionRequest");
+    return __isa(o, "CreateLoggerDefinitionVersionRequest");
   }
 }
 
@@ -1209,7 +1212,7 @@ export interface CreateLoggerDefinitionVersionResponse extends $MetadataBearer {
 
 export namespace CreateLoggerDefinitionVersionResponse {
   export function isa(o: any): o is CreateLoggerDefinitionVersionResponse {
-    return _smithy.isa(o, "CreateLoggerDefinitionVersionResponse");
+    return __isa(o, "CreateLoggerDefinitionVersionResponse");
   }
 }
 
@@ -1238,7 +1241,7 @@ export interface CreateResourceDefinitionRequest {
 
 export namespace CreateResourceDefinitionRequest {
   export function isa(o: any): o is CreateResourceDefinitionRequest {
-    return _smithy.isa(o, "CreateResourceDefinitionRequest");
+    return __isa(o, "CreateResourceDefinitionRequest");
   }
 }
 
@@ -1282,7 +1285,7 @@ export interface CreateResourceDefinitionResponse extends $MetadataBearer {
 
 export namespace CreateResourceDefinitionResponse {
   export function isa(o: any): o is CreateResourceDefinitionResponse {
-    return _smithy.isa(o, "CreateResourceDefinitionResponse");
+    return __isa(o, "CreateResourceDefinitionResponse");
   }
 }
 
@@ -1306,7 +1309,7 @@ export interface CreateResourceDefinitionVersionRequest {
 
 export namespace CreateResourceDefinitionVersionRequest {
   export function isa(o: any): o is CreateResourceDefinitionVersionRequest {
-    return _smithy.isa(o, "CreateResourceDefinitionVersionRequest");
+    return __isa(o, "CreateResourceDefinitionVersionRequest");
   }
 }
 
@@ -1336,7 +1339,7 @@ export interface CreateResourceDefinitionVersionResponse
 
 export namespace CreateResourceDefinitionVersionResponse {
   export function isa(o: any): o is CreateResourceDefinitionVersionResponse {
-    return _smithy.isa(o, "CreateResourceDefinitionVersionResponse");
+    return __isa(o, "CreateResourceDefinitionVersionResponse");
   }
 }
 
@@ -1383,7 +1386,7 @@ export interface CreateSoftwareUpdateJobRequest {
 
 export namespace CreateSoftwareUpdateJobRequest {
   export function isa(o: any): o is CreateSoftwareUpdateJobRequest {
-    return _smithy.isa(o, "CreateSoftwareUpdateJobRequest");
+    return __isa(o, "CreateSoftwareUpdateJobRequest");
   }
 }
 
@@ -1407,7 +1410,7 @@ export interface CreateSoftwareUpdateJobResponse extends $MetadataBearer {
 
 export namespace CreateSoftwareUpdateJobResponse {
   export function isa(o: any): o is CreateSoftwareUpdateJobResponse {
-    return _smithy.isa(o, "CreateSoftwareUpdateJobResponse");
+    return __isa(o, "CreateSoftwareUpdateJobResponse");
   }
 }
 
@@ -1436,7 +1439,7 @@ export interface CreateSubscriptionDefinitionRequest {
 
 export namespace CreateSubscriptionDefinitionRequest {
   export function isa(o: any): o is CreateSubscriptionDefinitionRequest {
-    return _smithy.isa(o, "CreateSubscriptionDefinitionRequest");
+    return __isa(o, "CreateSubscriptionDefinitionRequest");
   }
 }
 
@@ -1480,7 +1483,7 @@ export interface CreateSubscriptionDefinitionResponse extends $MetadataBearer {
 
 export namespace CreateSubscriptionDefinitionResponse {
   export function isa(o: any): o is CreateSubscriptionDefinitionResponse {
-    return _smithy.isa(o, "CreateSubscriptionDefinitionResponse");
+    return __isa(o, "CreateSubscriptionDefinitionResponse");
   }
 }
 
@@ -1504,7 +1507,7 @@ export interface CreateSubscriptionDefinitionVersionRequest {
 
 export namespace CreateSubscriptionDefinitionVersionRequest {
   export function isa(o: any): o is CreateSubscriptionDefinitionVersionRequest {
-    return _smithy.isa(o, "CreateSubscriptionDefinitionVersionRequest");
+    return __isa(o, "CreateSubscriptionDefinitionVersionRequest");
   }
 }
 
@@ -1536,7 +1539,7 @@ export namespace CreateSubscriptionDefinitionVersionResponse {
   export function isa(
     o: any
   ): o is CreateSubscriptionDefinitionVersionResponse {
-    return _smithy.isa(o, "CreateSubscriptionDefinitionVersionResponse");
+    return __isa(o, "CreateSubscriptionDefinitionVersionResponse");
   }
 }
 
@@ -1588,7 +1591,7 @@ export interface DefinitionInformation {
 
 export namespace DefinitionInformation {
   export function isa(o: any): o is DefinitionInformation {
-    return _smithy.isa(o, "DefinitionInformation");
+    return __isa(o, "DefinitionInformation");
   }
 }
 
@@ -1602,7 +1605,7 @@ export interface DeleteConnectorDefinitionRequest {
 
 export namespace DeleteConnectorDefinitionRequest {
   export function isa(o: any): o is DeleteConnectorDefinitionRequest {
-    return _smithy.isa(o, "DeleteConnectorDefinitionRequest");
+    return __isa(o, "DeleteConnectorDefinitionRequest");
   }
 }
 
@@ -1612,7 +1615,7 @@ export interface DeleteConnectorDefinitionResponse extends $MetadataBearer {
 
 export namespace DeleteConnectorDefinitionResponse {
   export function isa(o: any): o is DeleteConnectorDefinitionResponse {
-    return _smithy.isa(o, "DeleteConnectorDefinitionResponse");
+    return __isa(o, "DeleteConnectorDefinitionResponse");
   }
 }
 
@@ -1626,7 +1629,7 @@ export interface DeleteCoreDefinitionRequest {
 
 export namespace DeleteCoreDefinitionRequest {
   export function isa(o: any): o is DeleteCoreDefinitionRequest {
-    return _smithy.isa(o, "DeleteCoreDefinitionRequest");
+    return __isa(o, "DeleteCoreDefinitionRequest");
   }
 }
 
@@ -1636,7 +1639,7 @@ export interface DeleteCoreDefinitionResponse extends $MetadataBearer {
 
 export namespace DeleteCoreDefinitionResponse {
   export function isa(o: any): o is DeleteCoreDefinitionResponse {
-    return _smithy.isa(o, "DeleteCoreDefinitionResponse");
+    return __isa(o, "DeleteCoreDefinitionResponse");
   }
 }
 
@@ -1650,7 +1653,7 @@ export interface DeleteDeviceDefinitionRequest {
 
 export namespace DeleteDeviceDefinitionRequest {
   export function isa(o: any): o is DeleteDeviceDefinitionRequest {
-    return _smithy.isa(o, "DeleteDeviceDefinitionRequest");
+    return __isa(o, "DeleteDeviceDefinitionRequest");
   }
 }
 
@@ -1660,7 +1663,7 @@ export interface DeleteDeviceDefinitionResponse extends $MetadataBearer {
 
 export namespace DeleteDeviceDefinitionResponse {
   export function isa(o: any): o is DeleteDeviceDefinitionResponse {
-    return _smithy.isa(o, "DeleteDeviceDefinitionResponse");
+    return __isa(o, "DeleteDeviceDefinitionResponse");
   }
 }
 
@@ -1674,7 +1677,7 @@ export interface DeleteFunctionDefinitionRequest {
 
 export namespace DeleteFunctionDefinitionRequest {
   export function isa(o: any): o is DeleteFunctionDefinitionRequest {
-    return _smithy.isa(o, "DeleteFunctionDefinitionRequest");
+    return __isa(o, "DeleteFunctionDefinitionRequest");
   }
 }
 
@@ -1684,7 +1687,7 @@ export interface DeleteFunctionDefinitionResponse extends $MetadataBearer {
 
 export namespace DeleteFunctionDefinitionResponse {
   export function isa(o: any): o is DeleteFunctionDefinitionResponse {
-    return _smithy.isa(o, "DeleteFunctionDefinitionResponse");
+    return __isa(o, "DeleteFunctionDefinitionResponse");
   }
 }
 
@@ -1698,7 +1701,7 @@ export interface DeleteGroupRequest {
 
 export namespace DeleteGroupRequest {
   export function isa(o: any): o is DeleteGroupRequest {
-    return _smithy.isa(o, "DeleteGroupRequest");
+    return __isa(o, "DeleteGroupRequest");
   }
 }
 
@@ -1708,7 +1711,7 @@ export interface DeleteGroupResponse extends $MetadataBearer {
 
 export namespace DeleteGroupResponse {
   export function isa(o: any): o is DeleteGroupResponse {
-    return _smithy.isa(o, "DeleteGroupResponse");
+    return __isa(o, "DeleteGroupResponse");
   }
 }
 
@@ -1722,7 +1725,7 @@ export interface DeleteLoggerDefinitionRequest {
 
 export namespace DeleteLoggerDefinitionRequest {
   export function isa(o: any): o is DeleteLoggerDefinitionRequest {
-    return _smithy.isa(o, "DeleteLoggerDefinitionRequest");
+    return __isa(o, "DeleteLoggerDefinitionRequest");
   }
 }
 
@@ -1732,7 +1735,7 @@ export interface DeleteLoggerDefinitionResponse extends $MetadataBearer {
 
 export namespace DeleteLoggerDefinitionResponse {
   export function isa(o: any): o is DeleteLoggerDefinitionResponse {
-    return _smithy.isa(o, "DeleteLoggerDefinitionResponse");
+    return __isa(o, "DeleteLoggerDefinitionResponse");
   }
 }
 
@@ -1746,7 +1749,7 @@ export interface DeleteResourceDefinitionRequest {
 
 export namespace DeleteResourceDefinitionRequest {
   export function isa(o: any): o is DeleteResourceDefinitionRequest {
-    return _smithy.isa(o, "DeleteResourceDefinitionRequest");
+    return __isa(o, "DeleteResourceDefinitionRequest");
   }
 }
 
@@ -1756,7 +1759,7 @@ export interface DeleteResourceDefinitionResponse extends $MetadataBearer {
 
 export namespace DeleteResourceDefinitionResponse {
   export function isa(o: any): o is DeleteResourceDefinitionResponse {
-    return _smithy.isa(o, "DeleteResourceDefinitionResponse");
+    return __isa(o, "DeleteResourceDefinitionResponse");
   }
 }
 
@@ -1770,7 +1773,7 @@ export interface DeleteSubscriptionDefinitionRequest {
 
 export namespace DeleteSubscriptionDefinitionRequest {
   export function isa(o: any): o is DeleteSubscriptionDefinitionRequest {
-    return _smithy.isa(o, "DeleteSubscriptionDefinitionRequest");
+    return __isa(o, "DeleteSubscriptionDefinitionRequest");
   }
 }
 
@@ -1780,7 +1783,7 @@ export interface DeleteSubscriptionDefinitionResponse extends $MetadataBearer {
 
 export namespace DeleteSubscriptionDefinitionResponse {
   export function isa(o: any): o is DeleteSubscriptionDefinitionResponse {
-    return _smithy.isa(o, "DeleteSubscriptionDefinitionResponse");
+    return __isa(o, "DeleteSubscriptionDefinitionResponse");
   }
 }
 
@@ -1817,7 +1820,7 @@ export interface Deployment {
 
 export namespace Deployment {
   export function isa(o: any): o is Deployment {
-    return _smithy.isa(o, "Deployment");
+    return __isa(o, "Deployment");
   }
 }
 
@@ -1856,7 +1859,7 @@ export interface Device {
 
 export namespace Device {
   export function isa(o: any): o is Device {
-    return _smithy.isa(o, "Device");
+    return __isa(o, "Device");
   }
 }
 
@@ -1873,7 +1876,7 @@ export interface DeviceDefinitionVersion {
 
 export namespace DeviceDefinitionVersion {
   export function isa(o: any): o is DeviceDefinitionVersion {
-    return _smithy.isa(o, "DeviceDefinitionVersion");
+    return __isa(o, "DeviceDefinitionVersion");
   }
 }
 
@@ -1887,7 +1890,7 @@ export interface DisassociateRoleFromGroupRequest {
 
 export namespace DisassociateRoleFromGroupRequest {
   export function isa(o: any): o is DisassociateRoleFromGroupRequest {
-    return _smithy.isa(o, "DisassociateRoleFromGroupRequest");
+    return __isa(o, "DisassociateRoleFromGroupRequest");
   }
 }
 
@@ -1901,7 +1904,7 @@ export interface DisassociateRoleFromGroupResponse extends $MetadataBearer {
 
 export namespace DisassociateRoleFromGroupResponse {
   export function isa(o: any): o is DisassociateRoleFromGroupResponse {
-    return _smithy.isa(o, "DisassociateRoleFromGroupResponse");
+    return __isa(o, "DisassociateRoleFromGroupResponse");
   }
 }
 
@@ -1911,7 +1914,7 @@ export interface DisassociateServiceRoleFromAccountRequest {
 
 export namespace DisassociateServiceRoleFromAccountRequest {
   export function isa(o: any): o is DisassociateServiceRoleFromAccountRequest {
-    return _smithy.isa(o, "DisassociateServiceRoleFromAccountRequest");
+    return __isa(o, "DisassociateServiceRoleFromAccountRequest");
   }
 }
 
@@ -1926,7 +1929,7 @@ export interface DisassociateServiceRoleFromAccountResponse
 
 export namespace DisassociateServiceRoleFromAccountResponse {
   export function isa(o: any): o is DisassociateServiceRoleFromAccountResponse {
-    return _smithy.isa(o, "DisassociateServiceRoleFromAccountResponse");
+    return __isa(o, "DisassociateServiceRoleFromAccountResponse");
   }
 }
 
@@ -1953,7 +1956,7 @@ export interface ErrorDetail {
 
 export namespace ErrorDetail {
   export function isa(o: any): o is ErrorDetail {
-    return _smithy.isa(o, "ErrorDetail");
+    return __isa(o, "ErrorDetail");
   }
 }
 
@@ -1980,7 +1983,7 @@ export interface Function {
 
 export namespace Function {
   export function isa(o: any): o is Function {
-    return _smithy.isa(o, "Function");
+    return __isa(o, "Function");
   }
 }
 
@@ -2027,7 +2030,7 @@ export interface FunctionConfiguration {
 
 export namespace FunctionConfiguration {
   export function isa(o: any): o is FunctionConfiguration {
-    return _smithy.isa(o, "FunctionConfiguration");
+    return __isa(o, "FunctionConfiguration");
   }
 }
 
@@ -2059,7 +2062,7 @@ export interface FunctionConfigurationEnvironment {
 
 export namespace FunctionConfigurationEnvironment {
   export function isa(o: any): o is FunctionConfigurationEnvironment {
-    return _smithy.isa(o, "FunctionConfigurationEnvironment");
+    return __isa(o, "FunctionConfigurationEnvironment");
   }
 }
 
@@ -2076,7 +2079,7 @@ export interface FunctionDefaultConfig {
 
 export namespace FunctionDefaultConfig {
   export function isa(o: any): o is FunctionDefaultConfig {
-    return _smithy.isa(o, "FunctionDefaultConfig");
+    return __isa(o, "FunctionDefaultConfig");
   }
 }
 
@@ -2098,7 +2101,7 @@ export interface FunctionDefaultExecutionConfig {
 
 export namespace FunctionDefaultExecutionConfig {
   export function isa(o: any): o is FunctionDefaultExecutionConfig {
-    return _smithy.isa(o, "FunctionDefaultExecutionConfig");
+    return __isa(o, "FunctionDefaultExecutionConfig");
   }
 }
 
@@ -2120,7 +2123,7 @@ export interface FunctionDefinitionVersion {
 
 export namespace FunctionDefinitionVersion {
   export function isa(o: any): o is FunctionDefinitionVersion {
-    return _smithy.isa(o, "FunctionDefinitionVersion");
+    return __isa(o, "FunctionDefinitionVersion");
   }
 }
 
@@ -2142,7 +2145,7 @@ export interface FunctionExecutionConfig {
 
 export namespace FunctionExecutionConfig {
   export function isa(o: any): o is FunctionExecutionConfig {
-    return _smithy.isa(o, "FunctionExecutionConfig");
+    return __isa(o, "FunctionExecutionConfig");
   }
 }
 
@@ -2169,7 +2172,7 @@ export interface FunctionRunAsConfig {
 
 export namespace FunctionRunAsConfig {
   export function isa(o: any): o is FunctionRunAsConfig {
-    return _smithy.isa(o, "FunctionRunAsConfig");
+    return __isa(o, "FunctionRunAsConfig");
   }
 }
 
@@ -2183,7 +2186,7 @@ export interface GetAssociatedRoleRequest {
 
 export namespace GetAssociatedRoleRequest {
   export function isa(o: any): o is GetAssociatedRoleRequest {
-    return _smithy.isa(o, "GetAssociatedRoleRequest");
+    return __isa(o, "GetAssociatedRoleRequest");
   }
 }
 
@@ -2202,7 +2205,7 @@ export interface GetAssociatedRoleResponse extends $MetadataBearer {
 
 export namespace GetAssociatedRoleResponse {
   export function isa(o: any): o is GetAssociatedRoleResponse {
-    return _smithy.isa(o, "GetAssociatedRoleResponse");
+    return __isa(o, "GetAssociatedRoleResponse");
   }
 }
 
@@ -2216,7 +2219,7 @@ export interface GetBulkDeploymentStatusRequest {
 
 export namespace GetBulkDeploymentStatusRequest {
   export function isa(o: any): o is GetBulkDeploymentStatusRequest {
-    return _smithy.isa(o, "GetBulkDeploymentStatusRequest");
+    return __isa(o, "GetBulkDeploymentStatusRequest");
   }
 }
 
@@ -2255,7 +2258,7 @@ export interface GetBulkDeploymentStatusResponse extends $MetadataBearer {
 
 export namespace GetBulkDeploymentStatusResponse {
   export function isa(o: any): o is GetBulkDeploymentStatusResponse {
-    return _smithy.isa(o, "GetBulkDeploymentStatusResponse");
+    return __isa(o, "GetBulkDeploymentStatusResponse");
   }
 }
 
@@ -2269,7 +2272,7 @@ export interface GetConnectivityInfoRequest {
 
 export namespace GetConnectivityInfoRequest {
   export function isa(o: any): o is GetConnectivityInfoRequest {
-    return _smithy.isa(o, "GetConnectivityInfoRequest");
+    return __isa(o, "GetConnectivityInfoRequest");
   }
 }
 
@@ -2288,7 +2291,7 @@ export interface GetConnectivityInfoResponse extends $MetadataBearer {
 
 export namespace GetConnectivityInfoResponse {
   export function isa(o: any): o is GetConnectivityInfoResponse {
-    return _smithy.isa(o, "GetConnectivityInfoResponse");
+    return __isa(o, "GetConnectivityInfoResponse");
   }
 }
 
@@ -2302,7 +2305,7 @@ export interface GetConnectorDefinitionRequest {
 
 export namespace GetConnectorDefinitionRequest {
   export function isa(o: any): o is GetConnectorDefinitionRequest {
-    return _smithy.isa(o, "GetConnectorDefinitionRequest");
+    return __isa(o, "GetConnectorDefinitionRequest");
   }
 }
 
@@ -2351,7 +2354,7 @@ export interface GetConnectorDefinitionResponse extends $MetadataBearer {
 
 export namespace GetConnectorDefinitionResponse {
   export function isa(o: any): o is GetConnectorDefinitionResponse {
-    return _smithy.isa(o, "GetConnectorDefinitionResponse");
+    return __isa(o, "GetConnectorDefinitionResponse");
   }
 }
 
@@ -2375,7 +2378,7 @@ export interface GetConnectorDefinitionVersionRequest {
 
 export namespace GetConnectorDefinitionVersionRequest {
   export function isa(o: any): o is GetConnectorDefinitionVersionRequest {
-    return _smithy.isa(o, "GetConnectorDefinitionVersionRequest");
+    return __isa(o, "GetConnectorDefinitionVersionRequest");
   }
 }
 
@@ -2414,7 +2417,7 @@ export interface GetConnectorDefinitionVersionResponse extends $MetadataBearer {
 
 export namespace GetConnectorDefinitionVersionResponse {
   export function isa(o: any): o is GetConnectorDefinitionVersionResponse {
-    return _smithy.isa(o, "GetConnectorDefinitionVersionResponse");
+    return __isa(o, "GetConnectorDefinitionVersionResponse");
   }
 }
 
@@ -2428,7 +2431,7 @@ export interface GetCoreDefinitionRequest {
 
 export namespace GetCoreDefinitionRequest {
   export function isa(o: any): o is GetCoreDefinitionRequest {
-    return _smithy.isa(o, "GetCoreDefinitionRequest");
+    return __isa(o, "GetCoreDefinitionRequest");
   }
 }
 
@@ -2477,7 +2480,7 @@ export interface GetCoreDefinitionResponse extends $MetadataBearer {
 
 export namespace GetCoreDefinitionResponse {
   export function isa(o: any): o is GetCoreDefinitionResponse {
-    return _smithy.isa(o, "GetCoreDefinitionResponse");
+    return __isa(o, "GetCoreDefinitionResponse");
   }
 }
 
@@ -2496,7 +2499,7 @@ export interface GetCoreDefinitionVersionRequest {
 
 export namespace GetCoreDefinitionVersionRequest {
   export function isa(o: any): o is GetCoreDefinitionVersionRequest {
-    return _smithy.isa(o, "GetCoreDefinitionVersionRequest");
+    return __isa(o, "GetCoreDefinitionVersionRequest");
   }
 }
 
@@ -2535,7 +2538,7 @@ export interface GetCoreDefinitionVersionResponse extends $MetadataBearer {
 
 export namespace GetCoreDefinitionVersionResponse {
   export function isa(o: any): o is GetCoreDefinitionVersionResponse {
-    return _smithy.isa(o, "GetCoreDefinitionVersionResponse");
+    return __isa(o, "GetCoreDefinitionVersionResponse");
   }
 }
 
@@ -2554,7 +2557,7 @@ export interface GetDeploymentStatusRequest {
 
 export namespace GetDeploymentStatusRequest {
   export function isa(o: any): o is GetDeploymentStatusRequest {
-    return _smithy.isa(o, "GetDeploymentStatusRequest");
+    return __isa(o, "GetDeploymentStatusRequest");
   }
 }
 
@@ -2588,7 +2591,7 @@ export interface GetDeploymentStatusResponse extends $MetadataBearer {
 
 export namespace GetDeploymentStatusResponse {
   export function isa(o: any): o is GetDeploymentStatusResponse {
-    return _smithy.isa(o, "GetDeploymentStatusResponse");
+    return __isa(o, "GetDeploymentStatusResponse");
   }
 }
 
@@ -2602,7 +2605,7 @@ export interface GetDeviceDefinitionRequest {
 
 export namespace GetDeviceDefinitionRequest {
   export function isa(o: any): o is GetDeviceDefinitionRequest {
-    return _smithy.isa(o, "GetDeviceDefinitionRequest");
+    return __isa(o, "GetDeviceDefinitionRequest");
   }
 }
 
@@ -2651,7 +2654,7 @@ export interface GetDeviceDefinitionResponse extends $MetadataBearer {
 
 export namespace GetDeviceDefinitionResponse {
   export function isa(o: any): o is GetDeviceDefinitionResponse {
-    return _smithy.isa(o, "GetDeviceDefinitionResponse");
+    return __isa(o, "GetDeviceDefinitionResponse");
   }
 }
 
@@ -2675,7 +2678,7 @@ export interface GetDeviceDefinitionVersionRequest {
 
 export namespace GetDeviceDefinitionVersionRequest {
   export function isa(o: any): o is GetDeviceDefinitionVersionRequest {
-    return _smithy.isa(o, "GetDeviceDefinitionVersionRequest");
+    return __isa(o, "GetDeviceDefinitionVersionRequest");
   }
 }
 
@@ -2714,7 +2717,7 @@ export interface GetDeviceDefinitionVersionResponse extends $MetadataBearer {
 
 export namespace GetDeviceDefinitionVersionResponse {
   export function isa(o: any): o is GetDeviceDefinitionVersionResponse {
-    return _smithy.isa(o, "GetDeviceDefinitionVersionResponse");
+    return __isa(o, "GetDeviceDefinitionVersionResponse");
   }
 }
 
@@ -2728,7 +2731,7 @@ export interface GetFunctionDefinitionRequest {
 
 export namespace GetFunctionDefinitionRequest {
   export function isa(o: any): o is GetFunctionDefinitionRequest {
-    return _smithy.isa(o, "GetFunctionDefinitionRequest");
+    return __isa(o, "GetFunctionDefinitionRequest");
   }
 }
 
@@ -2777,7 +2780,7 @@ export interface GetFunctionDefinitionResponse extends $MetadataBearer {
 
 export namespace GetFunctionDefinitionResponse {
   export function isa(o: any): o is GetFunctionDefinitionResponse {
-    return _smithy.isa(o, "GetFunctionDefinitionResponse");
+    return __isa(o, "GetFunctionDefinitionResponse");
   }
 }
 
@@ -2801,7 +2804,7 @@ export interface GetFunctionDefinitionVersionRequest {
 
 export namespace GetFunctionDefinitionVersionRequest {
   export function isa(o: any): o is GetFunctionDefinitionVersionRequest {
-    return _smithy.isa(o, "GetFunctionDefinitionVersionRequest");
+    return __isa(o, "GetFunctionDefinitionVersionRequest");
   }
 }
 
@@ -2840,7 +2843,7 @@ export interface GetFunctionDefinitionVersionResponse extends $MetadataBearer {
 
 export namespace GetFunctionDefinitionVersionResponse {
   export function isa(o: any): o is GetFunctionDefinitionVersionResponse {
-    return _smithy.isa(o, "GetFunctionDefinitionVersionResponse");
+    return __isa(o, "GetFunctionDefinitionVersionResponse");
   }
 }
 
@@ -2859,7 +2862,7 @@ export interface GetGroupCertificateAuthorityRequest {
 
 export namespace GetGroupCertificateAuthorityRequest {
   export function isa(o: any): o is GetGroupCertificateAuthorityRequest {
-    return _smithy.isa(o, "GetGroupCertificateAuthorityRequest");
+    return __isa(o, "GetGroupCertificateAuthorityRequest");
   }
 }
 
@@ -2883,7 +2886,7 @@ export interface GetGroupCertificateAuthorityResponse extends $MetadataBearer {
 
 export namespace GetGroupCertificateAuthorityResponse {
   export function isa(o: any): o is GetGroupCertificateAuthorityResponse {
-    return _smithy.isa(o, "GetGroupCertificateAuthorityResponse");
+    return __isa(o, "GetGroupCertificateAuthorityResponse");
   }
 }
 
@@ -2897,7 +2900,7 @@ export interface GetGroupCertificateConfigurationRequest {
 
 export namespace GetGroupCertificateConfigurationRequest {
   export function isa(o: any): o is GetGroupCertificateConfigurationRequest {
-    return _smithy.isa(o, "GetGroupCertificateConfigurationRequest");
+    return __isa(o, "GetGroupCertificateConfigurationRequest");
   }
 }
 
@@ -2922,7 +2925,7 @@ export interface GetGroupCertificateConfigurationResponse
 
 export namespace GetGroupCertificateConfigurationResponse {
   export function isa(o: any): o is GetGroupCertificateConfigurationResponse {
-    return _smithy.isa(o, "GetGroupCertificateConfigurationResponse");
+    return __isa(o, "GetGroupCertificateConfigurationResponse");
   }
 }
 
@@ -2936,7 +2939,7 @@ export interface GetGroupRequest {
 
 export namespace GetGroupRequest {
   export function isa(o: any): o is GetGroupRequest {
-    return _smithy.isa(o, "GetGroupRequest");
+    return __isa(o, "GetGroupRequest");
   }
 }
 
@@ -2985,7 +2988,7 @@ export interface GetGroupResponse extends $MetadataBearer {
 
 export namespace GetGroupResponse {
   export function isa(o: any): o is GetGroupResponse {
-    return _smithy.isa(o, "GetGroupResponse");
+    return __isa(o, "GetGroupResponse");
   }
 }
 
@@ -3004,7 +3007,7 @@ export interface GetGroupVersionRequest {
 
 export namespace GetGroupVersionRequest {
   export function isa(o: any): o is GetGroupVersionRequest {
-    return _smithy.isa(o, "GetGroupVersionRequest");
+    return __isa(o, "GetGroupVersionRequest");
   }
 }
 
@@ -3038,7 +3041,7 @@ export interface GetGroupVersionResponse extends $MetadataBearer {
 
 export namespace GetGroupVersionResponse {
   export function isa(o: any): o is GetGroupVersionResponse {
-    return _smithy.isa(o, "GetGroupVersionResponse");
+    return __isa(o, "GetGroupVersionResponse");
   }
 }
 
@@ -3052,7 +3055,7 @@ export interface GetLoggerDefinitionRequest {
 
 export namespace GetLoggerDefinitionRequest {
   export function isa(o: any): o is GetLoggerDefinitionRequest {
-    return _smithy.isa(o, "GetLoggerDefinitionRequest");
+    return __isa(o, "GetLoggerDefinitionRequest");
   }
 }
 
@@ -3101,7 +3104,7 @@ export interface GetLoggerDefinitionResponse extends $MetadataBearer {
 
 export namespace GetLoggerDefinitionResponse {
   export function isa(o: any): o is GetLoggerDefinitionResponse {
-    return _smithy.isa(o, "GetLoggerDefinitionResponse");
+    return __isa(o, "GetLoggerDefinitionResponse");
   }
 }
 
@@ -3125,7 +3128,7 @@ export interface GetLoggerDefinitionVersionRequest {
 
 export namespace GetLoggerDefinitionVersionRequest {
   export function isa(o: any): o is GetLoggerDefinitionVersionRequest {
-    return _smithy.isa(o, "GetLoggerDefinitionVersionRequest");
+    return __isa(o, "GetLoggerDefinitionVersionRequest");
   }
 }
 
@@ -3159,7 +3162,7 @@ export interface GetLoggerDefinitionVersionResponse extends $MetadataBearer {
 
 export namespace GetLoggerDefinitionVersionResponse {
   export function isa(o: any): o is GetLoggerDefinitionVersionResponse {
-    return _smithy.isa(o, "GetLoggerDefinitionVersionResponse");
+    return __isa(o, "GetLoggerDefinitionVersionResponse");
   }
 }
 
@@ -3173,7 +3176,7 @@ export interface GetResourceDefinitionRequest {
 
 export namespace GetResourceDefinitionRequest {
   export function isa(o: any): o is GetResourceDefinitionRequest {
-    return _smithy.isa(o, "GetResourceDefinitionRequest");
+    return __isa(o, "GetResourceDefinitionRequest");
   }
 }
 
@@ -3222,7 +3225,7 @@ export interface GetResourceDefinitionResponse extends $MetadataBearer {
 
 export namespace GetResourceDefinitionResponse {
   export function isa(o: any): o is GetResourceDefinitionResponse {
-    return _smithy.isa(o, "GetResourceDefinitionResponse");
+    return __isa(o, "GetResourceDefinitionResponse");
   }
 }
 
@@ -3241,7 +3244,7 @@ export interface GetResourceDefinitionVersionRequest {
 
 export namespace GetResourceDefinitionVersionRequest {
   export function isa(o: any): o is GetResourceDefinitionVersionRequest {
-    return _smithy.isa(o, "GetResourceDefinitionVersionRequest");
+    return __isa(o, "GetResourceDefinitionVersionRequest");
   }
 }
 
@@ -3275,7 +3278,7 @@ export interface GetResourceDefinitionVersionResponse extends $MetadataBearer {
 
 export namespace GetResourceDefinitionVersionResponse {
   export function isa(o: any): o is GetResourceDefinitionVersionResponse {
-    return _smithy.isa(o, "GetResourceDefinitionVersionResponse");
+    return __isa(o, "GetResourceDefinitionVersionResponse");
   }
 }
 
@@ -3285,7 +3288,7 @@ export interface GetServiceRoleForAccountRequest {
 
 export namespace GetServiceRoleForAccountRequest {
   export function isa(o: any): o is GetServiceRoleForAccountRequest {
-    return _smithy.isa(o, "GetServiceRoleForAccountRequest");
+    return __isa(o, "GetServiceRoleForAccountRequest");
   }
 }
 
@@ -3304,7 +3307,7 @@ export interface GetServiceRoleForAccountResponse extends $MetadataBearer {
 
 export namespace GetServiceRoleForAccountResponse {
   export function isa(o: any): o is GetServiceRoleForAccountResponse {
-    return _smithy.isa(o, "GetServiceRoleForAccountResponse");
+    return __isa(o, "GetServiceRoleForAccountResponse");
   }
 }
 
@@ -3318,7 +3321,7 @@ export interface GetSubscriptionDefinitionRequest {
 
 export namespace GetSubscriptionDefinitionRequest {
   export function isa(o: any): o is GetSubscriptionDefinitionRequest {
-    return _smithy.isa(o, "GetSubscriptionDefinitionRequest");
+    return __isa(o, "GetSubscriptionDefinitionRequest");
   }
 }
 
@@ -3367,7 +3370,7 @@ export interface GetSubscriptionDefinitionResponse extends $MetadataBearer {
 
 export namespace GetSubscriptionDefinitionResponse {
   export function isa(o: any): o is GetSubscriptionDefinitionResponse {
-    return _smithy.isa(o, "GetSubscriptionDefinitionResponse");
+    return __isa(o, "GetSubscriptionDefinitionResponse");
   }
 }
 
@@ -3391,7 +3394,7 @@ export interface GetSubscriptionDefinitionVersionRequest {
 
 export namespace GetSubscriptionDefinitionVersionRequest {
   export function isa(o: any): o is GetSubscriptionDefinitionVersionRequest {
-    return _smithy.isa(o, "GetSubscriptionDefinitionVersionRequest");
+    return __isa(o, "GetSubscriptionDefinitionVersionRequest");
   }
 }
 
@@ -3431,7 +3434,7 @@ export interface GetSubscriptionDefinitionVersionResponse
 
 export namespace GetSubscriptionDefinitionVersionResponse {
   export function isa(o: any): o is GetSubscriptionDefinitionVersionResponse {
-    return _smithy.isa(o, "GetSubscriptionDefinitionVersionResponse");
+    return __isa(o, "GetSubscriptionDefinitionVersionResponse");
   }
 }
 
@@ -3453,7 +3456,7 @@ export interface GroupCertificateAuthorityProperties {
 
 export namespace GroupCertificateAuthorityProperties {
   export function isa(o: any): o is GroupCertificateAuthorityProperties {
-    return _smithy.isa(o, "GroupCertificateAuthorityProperties");
+    return __isa(o, "GroupCertificateAuthorityProperties");
   }
 }
 
@@ -3500,7 +3503,7 @@ export interface GroupInformation {
 
 export namespace GroupInformation {
   export function isa(o: any): o is GroupInformation {
-    return _smithy.isa(o, "GroupInformation");
+    return __isa(o, "GroupInformation");
   }
 }
 
@@ -3522,7 +3525,7 @@ export interface GroupOwnerSetting {
 
 export namespace GroupOwnerSetting {
   export function isa(o: any): o is GroupOwnerSetting {
-    return _smithy.isa(o, "GroupOwnerSetting");
+    return __isa(o, "GroupOwnerSetting");
   }
 }
 
@@ -3569,7 +3572,7 @@ export interface GroupVersion {
 
 export namespace GroupVersion {
   export function isa(o: any): o is GroupVersion {
-    return _smithy.isa(o, "GroupVersion");
+    return __isa(o, "GroupVersion");
   }
 }
 
@@ -3577,7 +3580,7 @@ export namespace GroupVersion {
  * General error information.
  */
 export interface InternalServerErrorException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalServerErrorException";
   $fault: "server";
@@ -3594,7 +3597,7 @@ export interface InternalServerErrorException
 
 export namespace InternalServerErrorException {
   export function isa(o: any): o is InternalServerErrorException {
-    return _smithy.isa(o, "InternalServerErrorException");
+    return __isa(o, "InternalServerErrorException");
   }
 }
 
@@ -3618,7 +3621,7 @@ export interface ListBulkDeploymentDetailedReportsRequest {
 
 export namespace ListBulkDeploymentDetailedReportsRequest {
   export function isa(o: any): o is ListBulkDeploymentDetailedReportsRequest {
-    return _smithy.isa(o, "ListBulkDeploymentDetailedReportsRequest");
+    return __isa(o, "ListBulkDeploymentDetailedReportsRequest");
   }
 }
 
@@ -3638,7 +3641,7 @@ export interface ListBulkDeploymentDetailedReportsResponse
 
 export namespace ListBulkDeploymentDetailedReportsResponse {
   export function isa(o: any): o is ListBulkDeploymentDetailedReportsResponse {
-    return _smithy.isa(o, "ListBulkDeploymentDetailedReportsResponse");
+    return __isa(o, "ListBulkDeploymentDetailedReportsResponse");
   }
 }
 
@@ -3657,7 +3660,7 @@ export interface ListBulkDeploymentsRequest {
 
 export namespace ListBulkDeploymentsRequest {
   export function isa(o: any): o is ListBulkDeploymentsRequest {
-    return _smithy.isa(o, "ListBulkDeploymentsRequest");
+    return __isa(o, "ListBulkDeploymentsRequest");
   }
 }
 
@@ -3676,7 +3679,7 @@ export interface ListBulkDeploymentsResponse extends $MetadataBearer {
 
 export namespace ListBulkDeploymentsResponse {
   export function isa(o: any): o is ListBulkDeploymentsResponse {
-    return _smithy.isa(o, "ListBulkDeploymentsResponse");
+    return __isa(o, "ListBulkDeploymentsResponse");
   }
 }
 
@@ -3700,7 +3703,7 @@ export interface ListConnectorDefinitionVersionsRequest {
 
 export namespace ListConnectorDefinitionVersionsRequest {
   export function isa(o: any): o is ListConnectorDefinitionVersionsRequest {
-    return _smithy.isa(o, "ListConnectorDefinitionVersionsRequest");
+    return __isa(o, "ListConnectorDefinitionVersionsRequest");
   }
 }
 
@@ -3720,7 +3723,7 @@ export interface ListConnectorDefinitionVersionsResponse
 
 export namespace ListConnectorDefinitionVersionsResponse {
   export function isa(o: any): o is ListConnectorDefinitionVersionsResponse {
-    return _smithy.isa(o, "ListConnectorDefinitionVersionsResponse");
+    return __isa(o, "ListConnectorDefinitionVersionsResponse");
   }
 }
 
@@ -3739,7 +3742,7 @@ export interface ListConnectorDefinitionsRequest {
 
 export namespace ListConnectorDefinitionsRequest {
   export function isa(o: any): o is ListConnectorDefinitionsRequest {
-    return _smithy.isa(o, "ListConnectorDefinitionsRequest");
+    return __isa(o, "ListConnectorDefinitionsRequest");
   }
 }
 
@@ -3758,7 +3761,7 @@ export interface ListConnectorDefinitionsResponse extends $MetadataBearer {
 
 export namespace ListConnectorDefinitionsResponse {
   export function isa(o: any): o is ListConnectorDefinitionsResponse {
-    return _smithy.isa(o, "ListConnectorDefinitionsResponse");
+    return __isa(o, "ListConnectorDefinitionsResponse");
   }
 }
 
@@ -3782,7 +3785,7 @@ export interface ListCoreDefinitionVersionsRequest {
 
 export namespace ListCoreDefinitionVersionsRequest {
   export function isa(o: any): o is ListCoreDefinitionVersionsRequest {
-    return _smithy.isa(o, "ListCoreDefinitionVersionsRequest");
+    return __isa(o, "ListCoreDefinitionVersionsRequest");
   }
 }
 
@@ -3801,7 +3804,7 @@ export interface ListCoreDefinitionVersionsResponse extends $MetadataBearer {
 
 export namespace ListCoreDefinitionVersionsResponse {
   export function isa(o: any): o is ListCoreDefinitionVersionsResponse {
-    return _smithy.isa(o, "ListCoreDefinitionVersionsResponse");
+    return __isa(o, "ListCoreDefinitionVersionsResponse");
   }
 }
 
@@ -3820,7 +3823,7 @@ export interface ListCoreDefinitionsRequest {
 
 export namespace ListCoreDefinitionsRequest {
   export function isa(o: any): o is ListCoreDefinitionsRequest {
-    return _smithy.isa(o, "ListCoreDefinitionsRequest");
+    return __isa(o, "ListCoreDefinitionsRequest");
   }
 }
 
@@ -3839,7 +3842,7 @@ export interface ListCoreDefinitionsResponse extends $MetadataBearer {
 
 export namespace ListCoreDefinitionsResponse {
   export function isa(o: any): o is ListCoreDefinitionsResponse {
-    return _smithy.isa(o, "ListCoreDefinitionsResponse");
+    return __isa(o, "ListCoreDefinitionsResponse");
   }
 }
 
@@ -3863,7 +3866,7 @@ export interface ListDeploymentsRequest {
 
 export namespace ListDeploymentsRequest {
   export function isa(o: any): o is ListDeploymentsRequest {
-    return _smithy.isa(o, "ListDeploymentsRequest");
+    return __isa(o, "ListDeploymentsRequest");
   }
 }
 
@@ -3882,7 +3885,7 @@ export interface ListDeploymentsResponse extends $MetadataBearer {
 
 export namespace ListDeploymentsResponse {
   export function isa(o: any): o is ListDeploymentsResponse {
-    return _smithy.isa(o, "ListDeploymentsResponse");
+    return __isa(o, "ListDeploymentsResponse");
   }
 }
 
@@ -3906,7 +3909,7 @@ export interface ListDeviceDefinitionVersionsRequest {
 
 export namespace ListDeviceDefinitionVersionsRequest {
   export function isa(o: any): o is ListDeviceDefinitionVersionsRequest {
-    return _smithy.isa(o, "ListDeviceDefinitionVersionsRequest");
+    return __isa(o, "ListDeviceDefinitionVersionsRequest");
   }
 }
 
@@ -3925,7 +3928,7 @@ export interface ListDeviceDefinitionVersionsResponse extends $MetadataBearer {
 
 export namespace ListDeviceDefinitionVersionsResponse {
   export function isa(o: any): o is ListDeviceDefinitionVersionsResponse {
-    return _smithy.isa(o, "ListDeviceDefinitionVersionsResponse");
+    return __isa(o, "ListDeviceDefinitionVersionsResponse");
   }
 }
 
@@ -3944,7 +3947,7 @@ export interface ListDeviceDefinitionsRequest {
 
 export namespace ListDeviceDefinitionsRequest {
   export function isa(o: any): o is ListDeviceDefinitionsRequest {
-    return _smithy.isa(o, "ListDeviceDefinitionsRequest");
+    return __isa(o, "ListDeviceDefinitionsRequest");
   }
 }
 
@@ -3963,7 +3966,7 @@ export interface ListDeviceDefinitionsResponse extends $MetadataBearer {
 
 export namespace ListDeviceDefinitionsResponse {
   export function isa(o: any): o is ListDeviceDefinitionsResponse {
-    return _smithy.isa(o, "ListDeviceDefinitionsResponse");
+    return __isa(o, "ListDeviceDefinitionsResponse");
   }
 }
 
@@ -3987,7 +3990,7 @@ export interface ListFunctionDefinitionVersionsRequest {
 
 export namespace ListFunctionDefinitionVersionsRequest {
   export function isa(o: any): o is ListFunctionDefinitionVersionsRequest {
-    return _smithy.isa(o, "ListFunctionDefinitionVersionsRequest");
+    return __isa(o, "ListFunctionDefinitionVersionsRequest");
   }
 }
 
@@ -4007,7 +4010,7 @@ export interface ListFunctionDefinitionVersionsResponse
 
 export namespace ListFunctionDefinitionVersionsResponse {
   export function isa(o: any): o is ListFunctionDefinitionVersionsResponse {
-    return _smithy.isa(o, "ListFunctionDefinitionVersionsResponse");
+    return __isa(o, "ListFunctionDefinitionVersionsResponse");
   }
 }
 
@@ -4026,7 +4029,7 @@ export interface ListFunctionDefinitionsRequest {
 
 export namespace ListFunctionDefinitionsRequest {
   export function isa(o: any): o is ListFunctionDefinitionsRequest {
-    return _smithy.isa(o, "ListFunctionDefinitionsRequest");
+    return __isa(o, "ListFunctionDefinitionsRequest");
   }
 }
 
@@ -4045,7 +4048,7 @@ export interface ListFunctionDefinitionsResponse extends $MetadataBearer {
 
 export namespace ListFunctionDefinitionsResponse {
   export function isa(o: any): o is ListFunctionDefinitionsResponse {
-    return _smithy.isa(o, "ListFunctionDefinitionsResponse");
+    return __isa(o, "ListFunctionDefinitionsResponse");
   }
 }
 
@@ -4059,7 +4062,7 @@ export interface ListGroupCertificateAuthoritiesRequest {
 
 export namespace ListGroupCertificateAuthoritiesRequest {
   export function isa(o: any): o is ListGroupCertificateAuthoritiesRequest {
-    return _smithy.isa(o, "ListGroupCertificateAuthoritiesRequest");
+    return __isa(o, "ListGroupCertificateAuthoritiesRequest");
   }
 }
 
@@ -4074,7 +4077,7 @@ export interface ListGroupCertificateAuthoritiesResponse
 
 export namespace ListGroupCertificateAuthoritiesResponse {
   export function isa(o: any): o is ListGroupCertificateAuthoritiesResponse {
-    return _smithy.isa(o, "ListGroupCertificateAuthoritiesResponse");
+    return __isa(o, "ListGroupCertificateAuthoritiesResponse");
   }
 }
 
@@ -4098,7 +4101,7 @@ export interface ListGroupVersionsRequest {
 
 export namespace ListGroupVersionsRequest {
   export function isa(o: any): o is ListGroupVersionsRequest {
-    return _smithy.isa(o, "ListGroupVersionsRequest");
+    return __isa(o, "ListGroupVersionsRequest");
   }
 }
 
@@ -4117,7 +4120,7 @@ export interface ListGroupVersionsResponse extends $MetadataBearer {
 
 export namespace ListGroupVersionsResponse {
   export function isa(o: any): o is ListGroupVersionsResponse {
-    return _smithy.isa(o, "ListGroupVersionsResponse");
+    return __isa(o, "ListGroupVersionsResponse");
   }
 }
 
@@ -4136,7 +4139,7 @@ export interface ListGroupsRequest {
 
 export namespace ListGroupsRequest {
   export function isa(o: any): o is ListGroupsRequest {
-    return _smithy.isa(o, "ListGroupsRequest");
+    return __isa(o, "ListGroupsRequest");
   }
 }
 
@@ -4155,7 +4158,7 @@ export interface ListGroupsResponse extends $MetadataBearer {
 
 export namespace ListGroupsResponse {
   export function isa(o: any): o is ListGroupsResponse {
-    return _smithy.isa(o, "ListGroupsResponse");
+    return __isa(o, "ListGroupsResponse");
   }
 }
 
@@ -4179,7 +4182,7 @@ export interface ListLoggerDefinitionVersionsRequest {
 
 export namespace ListLoggerDefinitionVersionsRequest {
   export function isa(o: any): o is ListLoggerDefinitionVersionsRequest {
-    return _smithy.isa(o, "ListLoggerDefinitionVersionsRequest");
+    return __isa(o, "ListLoggerDefinitionVersionsRequest");
   }
 }
 
@@ -4198,7 +4201,7 @@ export interface ListLoggerDefinitionVersionsResponse extends $MetadataBearer {
 
 export namespace ListLoggerDefinitionVersionsResponse {
   export function isa(o: any): o is ListLoggerDefinitionVersionsResponse {
-    return _smithy.isa(o, "ListLoggerDefinitionVersionsResponse");
+    return __isa(o, "ListLoggerDefinitionVersionsResponse");
   }
 }
 
@@ -4217,7 +4220,7 @@ export interface ListLoggerDefinitionsRequest {
 
 export namespace ListLoggerDefinitionsRequest {
   export function isa(o: any): o is ListLoggerDefinitionsRequest {
-    return _smithy.isa(o, "ListLoggerDefinitionsRequest");
+    return __isa(o, "ListLoggerDefinitionsRequest");
   }
 }
 
@@ -4236,7 +4239,7 @@ export interface ListLoggerDefinitionsResponse extends $MetadataBearer {
 
 export namespace ListLoggerDefinitionsResponse {
   export function isa(o: any): o is ListLoggerDefinitionsResponse {
-    return _smithy.isa(o, "ListLoggerDefinitionsResponse");
+    return __isa(o, "ListLoggerDefinitionsResponse");
   }
 }
 
@@ -4260,7 +4263,7 @@ export interface ListResourceDefinitionVersionsRequest {
 
 export namespace ListResourceDefinitionVersionsRequest {
   export function isa(o: any): o is ListResourceDefinitionVersionsRequest {
-    return _smithy.isa(o, "ListResourceDefinitionVersionsRequest");
+    return __isa(o, "ListResourceDefinitionVersionsRequest");
   }
 }
 
@@ -4280,7 +4283,7 @@ export interface ListResourceDefinitionVersionsResponse
 
 export namespace ListResourceDefinitionVersionsResponse {
   export function isa(o: any): o is ListResourceDefinitionVersionsResponse {
-    return _smithy.isa(o, "ListResourceDefinitionVersionsResponse");
+    return __isa(o, "ListResourceDefinitionVersionsResponse");
   }
 }
 
@@ -4299,7 +4302,7 @@ export interface ListResourceDefinitionsRequest {
 
 export namespace ListResourceDefinitionsRequest {
   export function isa(o: any): o is ListResourceDefinitionsRequest {
-    return _smithy.isa(o, "ListResourceDefinitionsRequest");
+    return __isa(o, "ListResourceDefinitionsRequest");
   }
 }
 
@@ -4318,7 +4321,7 @@ export interface ListResourceDefinitionsResponse extends $MetadataBearer {
 
 export namespace ListResourceDefinitionsResponse {
   export function isa(o: any): o is ListResourceDefinitionsResponse {
-    return _smithy.isa(o, "ListResourceDefinitionsResponse");
+    return __isa(o, "ListResourceDefinitionsResponse");
   }
 }
 
@@ -4342,7 +4345,7 @@ export interface ListSubscriptionDefinitionVersionsRequest {
 
 export namespace ListSubscriptionDefinitionVersionsRequest {
   export function isa(o: any): o is ListSubscriptionDefinitionVersionsRequest {
-    return _smithy.isa(o, "ListSubscriptionDefinitionVersionsRequest");
+    return __isa(o, "ListSubscriptionDefinitionVersionsRequest");
   }
 }
 
@@ -4362,7 +4365,7 @@ export interface ListSubscriptionDefinitionVersionsResponse
 
 export namespace ListSubscriptionDefinitionVersionsResponse {
   export function isa(o: any): o is ListSubscriptionDefinitionVersionsResponse {
-    return _smithy.isa(o, "ListSubscriptionDefinitionVersionsResponse");
+    return __isa(o, "ListSubscriptionDefinitionVersionsResponse");
   }
 }
 
@@ -4381,7 +4384,7 @@ export interface ListSubscriptionDefinitionsRequest {
 
 export namespace ListSubscriptionDefinitionsRequest {
   export function isa(o: any): o is ListSubscriptionDefinitionsRequest {
-    return _smithy.isa(o, "ListSubscriptionDefinitionsRequest");
+    return __isa(o, "ListSubscriptionDefinitionsRequest");
   }
 }
 
@@ -4400,7 +4403,7 @@ export interface ListSubscriptionDefinitionsResponse extends $MetadataBearer {
 
 export namespace ListSubscriptionDefinitionsResponse {
   export function isa(o: any): o is ListSubscriptionDefinitionsResponse {
-    return _smithy.isa(o, "ListSubscriptionDefinitionsResponse");
+    return __isa(o, "ListSubscriptionDefinitionsResponse");
   }
 }
 
@@ -4414,7 +4417,7 @@ export interface ListTagsForResourceRequest {
 
 export namespace ListTagsForResourceRequest {
   export function isa(o: any): o is ListTagsForResourceRequest {
-    return _smithy.isa(o, "ListTagsForResourceRequest");
+    return __isa(o, "ListTagsForResourceRequest");
   }
 }
 
@@ -4428,7 +4431,7 @@ export interface ListTagsForResourceResponse extends $MetadataBearer {
 
 export namespace ListTagsForResourceResponse {
   export function isa(o: any): o is ListTagsForResourceResponse {
-    return _smithy.isa(o, "ListTagsForResourceResponse");
+    return __isa(o, "ListTagsForResourceResponse");
   }
 }
 
@@ -4450,7 +4453,7 @@ export interface LocalDeviceResourceData {
 
 export namespace LocalDeviceResourceData {
   export function isa(o: any): o is LocalDeviceResourceData {
-    return _smithy.isa(o, "LocalDeviceResourceData");
+    return __isa(o, "LocalDeviceResourceData");
   }
 }
 
@@ -4477,7 +4480,7 @@ export interface LocalVolumeResourceData {
 
 export namespace LocalVolumeResourceData {
   export function isa(o: any): o is LocalVolumeResourceData {
-    return _smithy.isa(o, "LocalVolumeResourceData");
+    return __isa(o, "LocalVolumeResourceData");
   }
 }
 
@@ -4514,7 +4517,7 @@ export interface Logger {
 
 export namespace Logger {
   export function isa(o: any): o is Logger {
-    return _smithy.isa(o, "Logger");
+    return __isa(o, "Logger");
   }
 }
 
@@ -4536,7 +4539,7 @@ export interface LoggerDefinitionVersion {
 
 export namespace LoggerDefinitionVersion {
   export function isa(o: any): o is LoggerDefinitionVersion {
-    return _smithy.isa(o, "LoggerDefinitionVersion");
+    return __isa(o, "LoggerDefinitionVersion");
   }
 }
 
@@ -4581,7 +4584,7 @@ export interface ResetDeploymentsRequest {
 
 export namespace ResetDeploymentsRequest {
   export function isa(o: any): o is ResetDeploymentsRequest {
-    return _smithy.isa(o, "ResetDeploymentsRequest");
+    return __isa(o, "ResetDeploymentsRequest");
   }
 }
 
@@ -4600,7 +4603,7 @@ export interface ResetDeploymentsResponse extends $MetadataBearer {
 
 export namespace ResetDeploymentsResponse {
   export function isa(o: any): o is ResetDeploymentsResponse {
-    return _smithy.isa(o, "ResetDeploymentsResponse");
+    return __isa(o, "ResetDeploymentsResponse");
   }
 }
 
@@ -4627,7 +4630,7 @@ export interface Resource {
 
 export namespace Resource {
   export function isa(o: any): o is Resource {
-    return _smithy.isa(o, "Resource");
+    return __isa(o, "Resource");
   }
 }
 
@@ -4649,7 +4652,7 @@ export interface ResourceAccessPolicy {
 
 export namespace ResourceAccessPolicy {
   export function isa(o: any): o is ResourceAccessPolicy {
-    return _smithy.isa(o, "ResourceAccessPolicy");
+    return __isa(o, "ResourceAccessPolicy");
   }
 }
 
@@ -4686,7 +4689,7 @@ export interface ResourceDataContainer {
 
 export namespace ResourceDataContainer {
   export function isa(o: any): o is ResourceDataContainer {
-    return _smithy.isa(o, "ResourceDataContainer");
+    return __isa(o, "ResourceDataContainer");
   }
 }
 
@@ -4703,7 +4706,7 @@ export interface ResourceDefinitionVersion {
 
 export namespace ResourceDefinitionVersion {
   export function isa(o: any): o is ResourceDefinitionVersion {
-    return _smithy.isa(o, "ResourceDefinitionVersion");
+    return __isa(o, "ResourceDefinitionVersion");
   }
 }
 
@@ -4725,7 +4728,7 @@ export interface ResourceDownloadOwnerSetting {
 
 export namespace ResourceDownloadOwnerSetting {
   export function isa(o: any): o is ResourceDownloadOwnerSetting {
-    return _smithy.isa(o, "ResourceDownloadOwnerSetting");
+    return __isa(o, "ResourceDownloadOwnerSetting");
   }
 }
 
@@ -4752,7 +4755,7 @@ export interface S3MachineLearningModelResourceData {
 
 export namespace S3MachineLearningModelResourceData {
   export function isa(o: any): o is S3MachineLearningModelResourceData {
-    return _smithy.isa(o, "S3MachineLearningModelResourceData");
+    return __isa(o, "S3MachineLearningModelResourceData");
   }
 }
 
@@ -4779,7 +4782,7 @@ export interface SageMakerMachineLearningModelResourceData {
 
 export namespace SageMakerMachineLearningModelResourceData {
   export function isa(o: any): o is SageMakerMachineLearningModelResourceData {
-    return _smithy.isa(o, "SageMakerMachineLearningModelResourceData");
+    return __isa(o, "SageMakerMachineLearningModelResourceData");
   }
 }
 
@@ -4801,7 +4804,7 @@ export interface SecretsManagerSecretResourceData {
 
 export namespace SecretsManagerSecretResourceData {
   export function isa(o: any): o is SecretsManagerSecretResourceData {
-    return _smithy.isa(o, "SecretsManagerSecretResourceData");
+    return __isa(o, "SecretsManagerSecretResourceData");
   }
 }
 
@@ -4835,7 +4838,7 @@ export interface StartBulkDeploymentRequest {
 
 export namespace StartBulkDeploymentRequest {
   export function isa(o: any): o is StartBulkDeploymentRequest {
-    return _smithy.isa(o, "StartBulkDeploymentRequest");
+    return __isa(o, "StartBulkDeploymentRequest");
   }
 }
 
@@ -4854,7 +4857,7 @@ export interface StartBulkDeploymentResponse extends $MetadataBearer {
 
 export namespace StartBulkDeploymentResponse {
   export function isa(o: any): o is StartBulkDeploymentResponse {
-    return _smithy.isa(o, "StartBulkDeploymentResponse");
+    return __isa(o, "StartBulkDeploymentResponse");
   }
 }
 
@@ -4868,7 +4871,7 @@ export interface StopBulkDeploymentRequest {
 
 export namespace StopBulkDeploymentRequest {
   export function isa(o: any): o is StopBulkDeploymentRequest {
-    return _smithy.isa(o, "StopBulkDeploymentRequest");
+    return __isa(o, "StopBulkDeploymentRequest");
   }
 }
 
@@ -4878,7 +4881,7 @@ export interface StopBulkDeploymentResponse extends $MetadataBearer {
 
 export namespace StopBulkDeploymentResponse {
   export function isa(o: any): o is StopBulkDeploymentResponse {
-    return _smithy.isa(o, "StopBulkDeploymentResponse");
+    return __isa(o, "StopBulkDeploymentResponse");
   }
 }
 
@@ -4910,7 +4913,7 @@ export interface Subscription {
 
 export namespace Subscription {
   export function isa(o: any): o is Subscription {
-    return _smithy.isa(o, "Subscription");
+    return __isa(o, "Subscription");
   }
 }
 
@@ -4927,7 +4930,7 @@ export interface SubscriptionDefinitionVersion {
 
 export namespace SubscriptionDefinitionVersion {
   export function isa(o: any): o is SubscriptionDefinitionVersion {
-    return _smithy.isa(o, "SubscriptionDefinitionVersion");
+    return __isa(o, "SubscriptionDefinitionVersion");
   }
 }
 
@@ -4949,7 +4952,7 @@ export interface TagResourceRequest {
 
 export namespace TagResourceRequest {
   export function isa(o: any): o is TagResourceRequest {
-    return _smithy.isa(o, "TagResourceRequest");
+    return __isa(o, "TagResourceRequest");
   }
 }
 
@@ -4968,7 +4971,7 @@ export interface UntagResourceRequest {
 
 export namespace UntagResourceRequest {
   export function isa(o: any): o is UntagResourceRequest {
-    return _smithy.isa(o, "UntagResourceRequest");
+    return __isa(o, "UntagResourceRequest");
   }
 }
 
@@ -5001,7 +5004,7 @@ export interface UpdateConnectivityInfoRequest {
 
 export namespace UpdateConnectivityInfoRequest {
   export function isa(o: any): o is UpdateConnectivityInfoRequest {
-    return _smithy.isa(o, "UpdateConnectivityInfoRequest");
+    return __isa(o, "UpdateConnectivityInfoRequest");
   }
 }
 
@@ -5020,7 +5023,7 @@ export interface UpdateConnectivityInfoResponse extends $MetadataBearer {
 
 export namespace UpdateConnectivityInfoResponse {
   export function isa(o: any): o is UpdateConnectivityInfoResponse {
-    return _smithy.isa(o, "UpdateConnectivityInfoResponse");
+    return __isa(o, "UpdateConnectivityInfoResponse");
   }
 }
 
@@ -5039,7 +5042,7 @@ export interface UpdateConnectorDefinitionRequest {
 
 export namespace UpdateConnectorDefinitionRequest {
   export function isa(o: any): o is UpdateConnectorDefinitionRequest {
-    return _smithy.isa(o, "UpdateConnectorDefinitionRequest");
+    return __isa(o, "UpdateConnectorDefinitionRequest");
   }
 }
 
@@ -5049,7 +5052,7 @@ export interface UpdateConnectorDefinitionResponse extends $MetadataBearer {
 
 export namespace UpdateConnectorDefinitionResponse {
   export function isa(o: any): o is UpdateConnectorDefinitionResponse {
-    return _smithy.isa(o, "UpdateConnectorDefinitionResponse");
+    return __isa(o, "UpdateConnectorDefinitionResponse");
   }
 }
 
@@ -5068,7 +5071,7 @@ export interface UpdateCoreDefinitionRequest {
 
 export namespace UpdateCoreDefinitionRequest {
   export function isa(o: any): o is UpdateCoreDefinitionRequest {
-    return _smithy.isa(o, "UpdateCoreDefinitionRequest");
+    return __isa(o, "UpdateCoreDefinitionRequest");
   }
 }
 
@@ -5078,7 +5081,7 @@ export interface UpdateCoreDefinitionResponse extends $MetadataBearer {
 
 export namespace UpdateCoreDefinitionResponse {
   export function isa(o: any): o is UpdateCoreDefinitionResponse {
-    return _smithy.isa(o, "UpdateCoreDefinitionResponse");
+    return __isa(o, "UpdateCoreDefinitionResponse");
   }
 }
 
@@ -5097,7 +5100,7 @@ export interface UpdateDeviceDefinitionRequest {
 
 export namespace UpdateDeviceDefinitionRequest {
   export function isa(o: any): o is UpdateDeviceDefinitionRequest {
-    return _smithy.isa(o, "UpdateDeviceDefinitionRequest");
+    return __isa(o, "UpdateDeviceDefinitionRequest");
   }
 }
 
@@ -5107,7 +5110,7 @@ export interface UpdateDeviceDefinitionResponse extends $MetadataBearer {
 
 export namespace UpdateDeviceDefinitionResponse {
   export function isa(o: any): o is UpdateDeviceDefinitionResponse {
-    return _smithy.isa(o, "UpdateDeviceDefinitionResponse");
+    return __isa(o, "UpdateDeviceDefinitionResponse");
   }
 }
 
@@ -5126,7 +5129,7 @@ export interface UpdateFunctionDefinitionRequest {
 
 export namespace UpdateFunctionDefinitionRequest {
   export function isa(o: any): o is UpdateFunctionDefinitionRequest {
-    return _smithy.isa(o, "UpdateFunctionDefinitionRequest");
+    return __isa(o, "UpdateFunctionDefinitionRequest");
   }
 }
 
@@ -5136,7 +5139,7 @@ export interface UpdateFunctionDefinitionResponse extends $MetadataBearer {
 
 export namespace UpdateFunctionDefinitionResponse {
   export function isa(o: any): o is UpdateFunctionDefinitionResponse {
-    return _smithy.isa(o, "UpdateFunctionDefinitionResponse");
+    return __isa(o, "UpdateFunctionDefinitionResponse");
   }
 }
 
@@ -5155,7 +5158,7 @@ export interface UpdateGroupCertificateConfigurationRequest {
 
 export namespace UpdateGroupCertificateConfigurationRequest {
   export function isa(o: any): o is UpdateGroupCertificateConfigurationRequest {
-    return _smithy.isa(o, "UpdateGroupCertificateConfigurationRequest");
+    return __isa(o, "UpdateGroupCertificateConfigurationRequest");
   }
 }
 
@@ -5182,7 +5185,7 @@ export namespace UpdateGroupCertificateConfigurationResponse {
   export function isa(
     o: any
   ): o is UpdateGroupCertificateConfigurationResponse {
-    return _smithy.isa(o, "UpdateGroupCertificateConfigurationResponse");
+    return __isa(o, "UpdateGroupCertificateConfigurationResponse");
   }
 }
 
@@ -5201,7 +5204,7 @@ export interface UpdateGroupRequest {
 
 export namespace UpdateGroupRequest {
   export function isa(o: any): o is UpdateGroupRequest {
-    return _smithy.isa(o, "UpdateGroupRequest");
+    return __isa(o, "UpdateGroupRequest");
   }
 }
 
@@ -5211,7 +5214,7 @@ export interface UpdateGroupResponse extends $MetadataBearer {
 
 export namespace UpdateGroupResponse {
   export function isa(o: any): o is UpdateGroupResponse {
-    return _smithy.isa(o, "UpdateGroupResponse");
+    return __isa(o, "UpdateGroupResponse");
   }
 }
 
@@ -5230,7 +5233,7 @@ export interface UpdateLoggerDefinitionRequest {
 
 export namespace UpdateLoggerDefinitionRequest {
   export function isa(o: any): o is UpdateLoggerDefinitionRequest {
-    return _smithy.isa(o, "UpdateLoggerDefinitionRequest");
+    return __isa(o, "UpdateLoggerDefinitionRequest");
   }
 }
 
@@ -5240,7 +5243,7 @@ export interface UpdateLoggerDefinitionResponse extends $MetadataBearer {
 
 export namespace UpdateLoggerDefinitionResponse {
   export function isa(o: any): o is UpdateLoggerDefinitionResponse {
-    return _smithy.isa(o, "UpdateLoggerDefinitionResponse");
+    return __isa(o, "UpdateLoggerDefinitionResponse");
   }
 }
 
@@ -5259,7 +5262,7 @@ export interface UpdateResourceDefinitionRequest {
 
 export namespace UpdateResourceDefinitionRequest {
   export function isa(o: any): o is UpdateResourceDefinitionRequest {
-    return _smithy.isa(o, "UpdateResourceDefinitionRequest");
+    return __isa(o, "UpdateResourceDefinitionRequest");
   }
 }
 
@@ -5269,7 +5272,7 @@ export interface UpdateResourceDefinitionResponse extends $MetadataBearer {
 
 export namespace UpdateResourceDefinitionResponse {
   export function isa(o: any): o is UpdateResourceDefinitionResponse {
-    return _smithy.isa(o, "UpdateResourceDefinitionResponse");
+    return __isa(o, "UpdateResourceDefinitionResponse");
   }
 }
 
@@ -5288,7 +5291,7 @@ export interface UpdateSubscriptionDefinitionRequest {
 
 export namespace UpdateSubscriptionDefinitionRequest {
   export function isa(o: any): o is UpdateSubscriptionDefinitionRequest {
-    return _smithy.isa(o, "UpdateSubscriptionDefinitionRequest");
+    return __isa(o, "UpdateSubscriptionDefinitionRequest");
   }
 }
 
@@ -5298,7 +5301,7 @@ export interface UpdateSubscriptionDefinitionResponse extends $MetadataBearer {
 
 export namespace UpdateSubscriptionDefinitionResponse {
   export function isa(o: any): o is UpdateSubscriptionDefinitionResponse {
-    return _smithy.isa(o, "UpdateSubscriptionDefinitionResponse");
+    return __isa(o, "UpdateSubscriptionDefinitionResponse");
   }
 }
 
@@ -5344,6 +5347,6 @@ export interface VersionInformation {
 
 export namespace VersionInformation {
   export function isa(o: any): o is VersionInformation {
-    return _smithy.isa(o, "VersionInformation");
+    return __isa(o, "VersionInformation");
   }
 }

--- a/clients/client-greengrass/protocols/Aws_restJson1_1.ts
+++ b/clients/client-greengrass/protocols/Aws_restJson1_1.ts
@@ -406,7 +406,10 @@ import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  extendedEncodeURIComponent as __extendedEncodeURIComponent
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -422,13 +425,13 @@ export async function serializeAws_restJson1_1AssociateRoleToGroupCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/greengrass/groups/{GroupId}/role";
   if (input.GroupId !== undefined) {
-    const labelValue: string = input.GroupId.toString();
+    const labelValue: string = input.GroupId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: GroupId.");
     }
     resolvedPath = resolvedPath.replace(
       "{GroupId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: GroupId.");
@@ -479,7 +482,7 @@ export async function serializeAws_restJson1_1CreateConnectorDefinitionCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.AmznClientToken !== undefined) {
-    headers["X-Amzn-Client-Token"] = input.AmznClientToken.toString();
+    headers["X-Amzn-Client-Token"] = input.AmznClientToken;
   }
   let resolvedPath = "/greengrass/definition/connectors";
   let body: any;
@@ -516,12 +519,12 @@ export async function serializeAws_restJson1_1CreateConnectorDefinitionVersionCo
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.AmznClientToken !== undefined) {
-    headers["X-Amzn-Client-Token"] = input.AmznClientToken.toString();
+    headers["X-Amzn-Client-Token"] = input.AmznClientToken;
   }
   let resolvedPath =
     "/greengrass/definition/connectors/{ConnectorDefinitionId}/versions";
   if (input.ConnectorDefinitionId !== undefined) {
-    const labelValue: string = input.ConnectorDefinitionId.toString();
+    const labelValue: string = input.ConnectorDefinitionId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ConnectorDefinitionId."
@@ -529,7 +532,7 @@ export async function serializeAws_restJson1_1CreateConnectorDefinitionVersionCo
     }
     resolvedPath = resolvedPath.replace(
       "{ConnectorDefinitionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -562,7 +565,7 @@ export async function serializeAws_restJson1_1CreateCoreDefinitionCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.AmznClientToken !== undefined) {
-    headers["X-Amzn-Client-Token"] = input.AmznClientToken.toString();
+    headers["X-Amzn-Client-Token"] = input.AmznClientToken;
   }
   let resolvedPath = "/greengrass/definition/cores";
   let body: any;
@@ -599,11 +602,11 @@ export async function serializeAws_restJson1_1CreateCoreDefinitionVersionCommand
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.AmznClientToken !== undefined) {
-    headers["X-Amzn-Client-Token"] = input.AmznClientToken.toString();
+    headers["X-Amzn-Client-Token"] = input.AmznClientToken;
   }
   let resolvedPath = "/greengrass/definition/cores/{CoreDefinitionId}/versions";
   if (input.CoreDefinitionId !== undefined) {
-    const labelValue: string = input.CoreDefinitionId.toString();
+    const labelValue: string = input.CoreDefinitionId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: CoreDefinitionId."
@@ -611,7 +614,7 @@ export async function serializeAws_restJson1_1CreateCoreDefinitionVersionCommand
     }
     resolvedPath = resolvedPath.replace(
       "{CoreDefinitionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -644,17 +647,17 @@ export async function serializeAws_restJson1_1CreateDeploymentCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.AmznClientToken !== undefined) {
-    headers["X-Amzn-Client-Token"] = input.AmznClientToken.toString();
+    headers["X-Amzn-Client-Token"] = input.AmznClientToken;
   }
   let resolvedPath = "/greengrass/groups/{GroupId}/deployments";
   if (input.GroupId !== undefined) {
-    const labelValue: string = input.GroupId.toString();
+    const labelValue: string = input.GroupId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: GroupId.");
     }
     resolvedPath = resolvedPath.replace(
       "{GroupId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: GroupId.");
@@ -688,7 +691,7 @@ export async function serializeAws_restJson1_1CreateDeviceDefinitionCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.AmznClientToken !== undefined) {
-    headers["X-Amzn-Client-Token"] = input.AmznClientToken.toString();
+    headers["X-Amzn-Client-Token"] = input.AmznClientToken;
   }
   let resolvedPath = "/greengrass/definition/devices";
   let body: any;
@@ -725,12 +728,12 @@ export async function serializeAws_restJson1_1CreateDeviceDefinitionVersionComma
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.AmznClientToken !== undefined) {
-    headers["X-Amzn-Client-Token"] = input.AmznClientToken.toString();
+    headers["X-Amzn-Client-Token"] = input.AmznClientToken;
   }
   let resolvedPath =
     "/greengrass/definition/devices/{DeviceDefinitionId}/versions";
   if (input.DeviceDefinitionId !== undefined) {
-    const labelValue: string = input.DeviceDefinitionId.toString();
+    const labelValue: string = input.DeviceDefinitionId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: DeviceDefinitionId."
@@ -738,7 +741,7 @@ export async function serializeAws_restJson1_1CreateDeviceDefinitionVersionComma
     }
     resolvedPath = resolvedPath.replace(
       "{DeviceDefinitionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -771,7 +774,7 @@ export async function serializeAws_restJson1_1CreateFunctionDefinitionCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.AmznClientToken !== undefined) {
-    headers["X-Amzn-Client-Token"] = input.AmznClientToken.toString();
+    headers["X-Amzn-Client-Token"] = input.AmznClientToken;
   }
   let resolvedPath = "/greengrass/definition/functions";
   let body: any;
@@ -808,12 +811,12 @@ export async function serializeAws_restJson1_1CreateFunctionDefinitionVersionCom
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.AmznClientToken !== undefined) {
-    headers["X-Amzn-Client-Token"] = input.AmznClientToken.toString();
+    headers["X-Amzn-Client-Token"] = input.AmznClientToken;
   }
   let resolvedPath =
     "/greengrass/definition/functions/{FunctionDefinitionId}/versions";
   if (input.FunctionDefinitionId !== undefined) {
-    const labelValue: string = input.FunctionDefinitionId.toString();
+    const labelValue: string = input.FunctionDefinitionId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: FunctionDefinitionId."
@@ -821,7 +824,7 @@ export async function serializeAws_restJson1_1CreateFunctionDefinitionVersionCom
     }
     resolvedPath = resolvedPath.replace(
       "{FunctionDefinitionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -860,7 +863,7 @@ export async function serializeAws_restJson1_1CreateGroupCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.AmznClientToken !== undefined) {
-    headers["X-Amzn-Client-Token"] = input.AmznClientToken.toString();
+    headers["X-Amzn-Client-Token"] = input.AmznClientToken;
   }
   let resolvedPath = "/greengrass/groups";
   let body: any;
@@ -895,17 +898,17 @@ export async function serializeAws_restJson1_1CreateGroupCertificateAuthorityCom
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.AmznClientToken !== undefined) {
-    headers["X-Amzn-Client-Token"] = input.AmznClientToken.toString();
+    headers["X-Amzn-Client-Token"] = input.AmznClientToken;
   }
   let resolvedPath = "/greengrass/groups/{GroupId}/certificateauthorities";
   if (input.GroupId !== undefined) {
-    const labelValue: string = input.GroupId.toString();
+    const labelValue: string = input.GroupId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: GroupId.");
     }
     resolvedPath = resolvedPath.replace(
       "{GroupId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: GroupId.");
@@ -926,17 +929,17 @@ export async function serializeAws_restJson1_1CreateGroupVersionCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.AmznClientToken !== undefined) {
-    headers["X-Amzn-Client-Token"] = input.AmznClientToken.toString();
+    headers["X-Amzn-Client-Token"] = input.AmznClientToken;
   }
   let resolvedPath = "/greengrass/groups/{GroupId}/versions";
   if (input.GroupId !== undefined) {
-    const labelValue: string = input.GroupId.toString();
+    const labelValue: string = input.GroupId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: GroupId.");
     }
     resolvedPath = resolvedPath.replace(
       "{GroupId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: GroupId.");
@@ -986,7 +989,7 @@ export async function serializeAws_restJson1_1CreateLoggerDefinitionCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.AmznClientToken !== undefined) {
-    headers["X-Amzn-Client-Token"] = input.AmznClientToken.toString();
+    headers["X-Amzn-Client-Token"] = input.AmznClientToken;
   }
   let resolvedPath = "/greengrass/definition/loggers";
   let body: any;
@@ -1023,12 +1026,12 @@ export async function serializeAws_restJson1_1CreateLoggerDefinitionVersionComma
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.AmznClientToken !== undefined) {
-    headers["X-Amzn-Client-Token"] = input.AmznClientToken.toString();
+    headers["X-Amzn-Client-Token"] = input.AmznClientToken;
   }
   let resolvedPath =
     "/greengrass/definition/loggers/{LoggerDefinitionId}/versions";
   if (input.LoggerDefinitionId !== undefined) {
-    const labelValue: string = input.LoggerDefinitionId.toString();
+    const labelValue: string = input.LoggerDefinitionId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: LoggerDefinitionId."
@@ -1036,7 +1039,7 @@ export async function serializeAws_restJson1_1CreateLoggerDefinitionVersionComma
     }
     resolvedPath = resolvedPath.replace(
       "{LoggerDefinitionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -1069,7 +1072,7 @@ export async function serializeAws_restJson1_1CreateResourceDefinitionCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.AmznClientToken !== undefined) {
-    headers["X-Amzn-Client-Token"] = input.AmznClientToken.toString();
+    headers["X-Amzn-Client-Token"] = input.AmznClientToken;
   }
   let resolvedPath = "/greengrass/definition/resources";
   let body: any;
@@ -1106,12 +1109,12 @@ export async function serializeAws_restJson1_1CreateResourceDefinitionVersionCom
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.AmznClientToken !== undefined) {
-    headers["X-Amzn-Client-Token"] = input.AmznClientToken.toString();
+    headers["X-Amzn-Client-Token"] = input.AmznClientToken;
   }
   let resolvedPath =
     "/greengrass/definition/resources/{ResourceDefinitionId}/versions";
   if (input.ResourceDefinitionId !== undefined) {
-    const labelValue: string = input.ResourceDefinitionId.toString();
+    const labelValue: string = input.ResourceDefinitionId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ResourceDefinitionId."
@@ -1119,7 +1122,7 @@ export async function serializeAws_restJson1_1CreateResourceDefinitionVersionCom
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceDefinitionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -1152,7 +1155,7 @@ export async function serializeAws_restJson1_1CreateSoftwareUpdateJobCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.AmznClientToken !== undefined) {
-    headers["X-Amzn-Client-Token"] = input.AmznClientToken.toString();
+    headers["X-Amzn-Client-Token"] = input.AmznClientToken;
   }
   let resolvedPath = "/greengrass/updates";
   let body: any;
@@ -1197,7 +1200,7 @@ export async function serializeAws_restJson1_1CreateSubscriptionDefinitionComman
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.AmznClientToken !== undefined) {
-    headers["X-Amzn-Client-Token"] = input.AmznClientToken.toString();
+    headers["X-Amzn-Client-Token"] = input.AmznClientToken;
   }
   let resolvedPath = "/greengrass/definition/subscriptions";
   let body: any;
@@ -1234,12 +1237,12 @@ export async function serializeAws_restJson1_1CreateSubscriptionDefinitionVersio
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.AmznClientToken !== undefined) {
-    headers["X-Amzn-Client-Token"] = input.AmznClientToken.toString();
+    headers["X-Amzn-Client-Token"] = input.AmznClientToken;
   }
   let resolvedPath =
     "/greengrass/definition/subscriptions/{SubscriptionDefinitionId}/versions";
   if (input.SubscriptionDefinitionId !== undefined) {
-    const labelValue: string = input.SubscriptionDefinitionId.toString();
+    const labelValue: string = input.SubscriptionDefinitionId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: SubscriptionDefinitionId."
@@ -1247,7 +1250,7 @@ export async function serializeAws_restJson1_1CreateSubscriptionDefinitionVersio
     }
     resolvedPath = resolvedPath.replace(
       "{SubscriptionDefinitionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -1282,7 +1285,7 @@ export async function serializeAws_restJson1_1DeleteConnectorDefinitionCommand(
   let resolvedPath =
     "/greengrass/definition/connectors/{ConnectorDefinitionId}";
   if (input.ConnectorDefinitionId !== undefined) {
-    const labelValue: string = input.ConnectorDefinitionId.toString();
+    const labelValue: string = input.ConnectorDefinitionId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ConnectorDefinitionId."
@@ -1290,7 +1293,7 @@ export async function serializeAws_restJson1_1DeleteConnectorDefinitionCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ConnectorDefinitionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -1314,7 +1317,7 @@ export async function serializeAws_restJson1_1DeleteCoreDefinitionCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/greengrass/definition/cores/{CoreDefinitionId}";
   if (input.CoreDefinitionId !== undefined) {
-    const labelValue: string = input.CoreDefinitionId.toString();
+    const labelValue: string = input.CoreDefinitionId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: CoreDefinitionId."
@@ -1322,7 +1325,7 @@ export async function serializeAws_restJson1_1DeleteCoreDefinitionCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{CoreDefinitionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -1346,7 +1349,7 @@ export async function serializeAws_restJson1_1DeleteDeviceDefinitionCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/greengrass/definition/devices/{DeviceDefinitionId}";
   if (input.DeviceDefinitionId !== undefined) {
-    const labelValue: string = input.DeviceDefinitionId.toString();
+    const labelValue: string = input.DeviceDefinitionId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: DeviceDefinitionId."
@@ -1354,7 +1357,7 @@ export async function serializeAws_restJson1_1DeleteDeviceDefinitionCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{DeviceDefinitionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -1378,7 +1381,7 @@ export async function serializeAws_restJson1_1DeleteFunctionDefinitionCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/greengrass/definition/functions/{FunctionDefinitionId}";
   if (input.FunctionDefinitionId !== undefined) {
-    const labelValue: string = input.FunctionDefinitionId.toString();
+    const labelValue: string = input.FunctionDefinitionId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: FunctionDefinitionId."
@@ -1386,7 +1389,7 @@ export async function serializeAws_restJson1_1DeleteFunctionDefinitionCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{FunctionDefinitionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -1410,13 +1413,13 @@ export async function serializeAws_restJson1_1DeleteGroupCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/greengrass/groups/{GroupId}";
   if (input.GroupId !== undefined) {
-    const labelValue: string = input.GroupId.toString();
+    const labelValue: string = input.GroupId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: GroupId.");
     }
     resolvedPath = resolvedPath.replace(
       "{GroupId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: GroupId.");
@@ -1438,7 +1441,7 @@ export async function serializeAws_restJson1_1DeleteLoggerDefinitionCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/greengrass/definition/loggers/{LoggerDefinitionId}";
   if (input.LoggerDefinitionId !== undefined) {
-    const labelValue: string = input.LoggerDefinitionId.toString();
+    const labelValue: string = input.LoggerDefinitionId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: LoggerDefinitionId."
@@ -1446,7 +1449,7 @@ export async function serializeAws_restJson1_1DeleteLoggerDefinitionCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{LoggerDefinitionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -1470,7 +1473,7 @@ export async function serializeAws_restJson1_1DeleteResourceDefinitionCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/greengrass/definition/resources/{ResourceDefinitionId}";
   if (input.ResourceDefinitionId !== undefined) {
-    const labelValue: string = input.ResourceDefinitionId.toString();
+    const labelValue: string = input.ResourceDefinitionId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ResourceDefinitionId."
@@ -1478,7 +1481,7 @@ export async function serializeAws_restJson1_1DeleteResourceDefinitionCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceDefinitionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -1503,7 +1506,7 @@ export async function serializeAws_restJson1_1DeleteSubscriptionDefinitionComman
   let resolvedPath =
     "/greengrass/definition/subscriptions/{SubscriptionDefinitionId}";
   if (input.SubscriptionDefinitionId !== undefined) {
-    const labelValue: string = input.SubscriptionDefinitionId.toString();
+    const labelValue: string = input.SubscriptionDefinitionId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: SubscriptionDefinitionId."
@@ -1511,7 +1514,7 @@ export async function serializeAws_restJson1_1DeleteSubscriptionDefinitionComman
     }
     resolvedPath = resolvedPath.replace(
       "{SubscriptionDefinitionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -1535,13 +1538,13 @@ export async function serializeAws_restJson1_1DisassociateRoleFromGroupCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/greengrass/groups/{GroupId}/role";
   if (input.GroupId !== undefined) {
-    const labelValue: string = input.GroupId.toString();
+    const labelValue: string = input.GroupId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: GroupId.");
     }
     resolvedPath = resolvedPath.replace(
       "{GroupId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: GroupId.");
@@ -1579,13 +1582,13 @@ export async function serializeAws_restJson1_1GetAssociatedRoleCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/greengrass/groups/{GroupId}/role";
   if (input.GroupId !== undefined) {
-    const labelValue: string = input.GroupId.toString();
+    const labelValue: string = input.GroupId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: GroupId.");
     }
     resolvedPath = resolvedPath.replace(
       "{GroupId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: GroupId.");
@@ -1607,7 +1610,7 @@ export async function serializeAws_restJson1_1GetBulkDeploymentStatusCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/greengrass/bulk/deployments/{BulkDeploymentId}/status";
   if (input.BulkDeploymentId !== undefined) {
-    const labelValue: string = input.BulkDeploymentId.toString();
+    const labelValue: string = input.BulkDeploymentId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: BulkDeploymentId."
@@ -1615,7 +1618,7 @@ export async function serializeAws_restJson1_1GetBulkDeploymentStatusCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{BulkDeploymentId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -1639,13 +1642,13 @@ export async function serializeAws_restJson1_1GetConnectivityInfoCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/greengrass/things/{ThingName}/connectivityInfo";
   if (input.ThingName !== undefined) {
-    const labelValue: string = input.ThingName.toString();
+    const labelValue: string = input.ThingName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ThingName.");
     }
     resolvedPath = resolvedPath.replace(
       "{ThingName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ThingName.");
@@ -1668,7 +1671,7 @@ export async function serializeAws_restJson1_1GetConnectorDefinitionCommand(
   let resolvedPath =
     "/greengrass/definition/connectors/{ConnectorDefinitionId}";
   if (input.ConnectorDefinitionId !== undefined) {
-    const labelValue: string = input.ConnectorDefinitionId.toString();
+    const labelValue: string = input.ConnectorDefinitionId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ConnectorDefinitionId."
@@ -1676,7 +1679,7 @@ export async function serializeAws_restJson1_1GetConnectorDefinitionCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ConnectorDefinitionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -1701,7 +1704,7 @@ export async function serializeAws_restJson1_1GetConnectorDefinitionVersionComma
   let resolvedPath =
     "/greengrass/definition/connectors/{ConnectorDefinitionId}/versions/{ConnectorDefinitionVersionId}";
   if (input.ConnectorDefinitionId !== undefined) {
-    const labelValue: string = input.ConnectorDefinitionId.toString();
+    const labelValue: string = input.ConnectorDefinitionId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ConnectorDefinitionId."
@@ -1709,7 +1712,7 @@ export async function serializeAws_restJson1_1GetConnectorDefinitionVersionComma
     }
     resolvedPath = resolvedPath.replace(
       "{ConnectorDefinitionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -1717,7 +1720,7 @@ export async function serializeAws_restJson1_1GetConnectorDefinitionVersionComma
     );
   }
   if (input.ConnectorDefinitionVersionId !== undefined) {
-    const labelValue: string = input.ConnectorDefinitionVersionId.toString();
+    const labelValue: string = input.ConnectorDefinitionVersionId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ConnectorDefinitionVersionId."
@@ -1725,7 +1728,7 @@ export async function serializeAws_restJson1_1GetConnectorDefinitionVersionComma
     }
     resolvedPath = resolvedPath.replace(
       "{ConnectorDefinitionVersionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -1734,7 +1737,9 @@ export async function serializeAws_restJson1_1GetConnectorDefinitionVersionComma
   }
   const query: any = {};
   if (input.NextToken !== undefined) {
-    query["NextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("NextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1754,7 +1759,7 @@ export async function serializeAws_restJson1_1GetCoreDefinitionCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/greengrass/definition/cores/{CoreDefinitionId}";
   if (input.CoreDefinitionId !== undefined) {
-    const labelValue: string = input.CoreDefinitionId.toString();
+    const labelValue: string = input.CoreDefinitionId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: CoreDefinitionId."
@@ -1762,7 +1767,7 @@ export async function serializeAws_restJson1_1GetCoreDefinitionCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{CoreDefinitionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -1787,7 +1792,7 @@ export async function serializeAws_restJson1_1GetCoreDefinitionVersionCommand(
   let resolvedPath =
     "/greengrass/definition/cores/{CoreDefinitionId}/versions/{CoreDefinitionVersionId}";
   if (input.CoreDefinitionId !== undefined) {
-    const labelValue: string = input.CoreDefinitionId.toString();
+    const labelValue: string = input.CoreDefinitionId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: CoreDefinitionId."
@@ -1795,7 +1800,7 @@ export async function serializeAws_restJson1_1GetCoreDefinitionVersionCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{CoreDefinitionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -1803,7 +1808,7 @@ export async function serializeAws_restJson1_1GetCoreDefinitionVersionCommand(
     );
   }
   if (input.CoreDefinitionVersionId !== undefined) {
-    const labelValue: string = input.CoreDefinitionVersionId.toString();
+    const labelValue: string = input.CoreDefinitionVersionId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: CoreDefinitionVersionId."
@@ -1811,7 +1816,7 @@ export async function serializeAws_restJson1_1GetCoreDefinitionVersionCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{CoreDefinitionVersionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -1836,7 +1841,7 @@ export async function serializeAws_restJson1_1GetDeploymentStatusCommand(
   let resolvedPath =
     "/greengrass/groups/{GroupId}/deployments/{DeploymentId}/status";
   if (input.DeploymentId !== undefined) {
-    const labelValue: string = input.DeploymentId.toString();
+    const labelValue: string = input.DeploymentId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: DeploymentId."
@@ -1844,19 +1849,19 @@ export async function serializeAws_restJson1_1GetDeploymentStatusCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{DeploymentId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DeploymentId.");
   }
   if (input.GroupId !== undefined) {
-    const labelValue: string = input.GroupId.toString();
+    const labelValue: string = input.GroupId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: GroupId.");
     }
     resolvedPath = resolvedPath.replace(
       "{GroupId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: GroupId.");
@@ -1878,7 +1883,7 @@ export async function serializeAws_restJson1_1GetDeviceDefinitionCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/greengrass/definition/devices/{DeviceDefinitionId}";
   if (input.DeviceDefinitionId !== undefined) {
-    const labelValue: string = input.DeviceDefinitionId.toString();
+    const labelValue: string = input.DeviceDefinitionId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: DeviceDefinitionId."
@@ -1886,7 +1891,7 @@ export async function serializeAws_restJson1_1GetDeviceDefinitionCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{DeviceDefinitionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -1911,7 +1916,7 @@ export async function serializeAws_restJson1_1GetDeviceDefinitionVersionCommand(
   let resolvedPath =
     "/greengrass/definition/devices/{DeviceDefinitionId}/versions/{DeviceDefinitionVersionId}";
   if (input.DeviceDefinitionId !== undefined) {
-    const labelValue: string = input.DeviceDefinitionId.toString();
+    const labelValue: string = input.DeviceDefinitionId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: DeviceDefinitionId."
@@ -1919,7 +1924,7 @@ export async function serializeAws_restJson1_1GetDeviceDefinitionVersionCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{DeviceDefinitionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -1927,7 +1932,7 @@ export async function serializeAws_restJson1_1GetDeviceDefinitionVersionCommand(
     );
   }
   if (input.DeviceDefinitionVersionId !== undefined) {
-    const labelValue: string = input.DeviceDefinitionVersionId.toString();
+    const labelValue: string = input.DeviceDefinitionVersionId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: DeviceDefinitionVersionId."
@@ -1935,7 +1940,7 @@ export async function serializeAws_restJson1_1GetDeviceDefinitionVersionCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{DeviceDefinitionVersionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -1944,7 +1949,9 @@ export async function serializeAws_restJson1_1GetDeviceDefinitionVersionCommand(
   }
   const query: any = {};
   if (input.NextToken !== undefined) {
-    query["NextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("NextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1964,7 +1971,7 @@ export async function serializeAws_restJson1_1GetFunctionDefinitionCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/greengrass/definition/functions/{FunctionDefinitionId}";
   if (input.FunctionDefinitionId !== undefined) {
-    const labelValue: string = input.FunctionDefinitionId.toString();
+    const labelValue: string = input.FunctionDefinitionId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: FunctionDefinitionId."
@@ -1972,7 +1979,7 @@ export async function serializeAws_restJson1_1GetFunctionDefinitionCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{FunctionDefinitionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -1997,7 +2004,7 @@ export async function serializeAws_restJson1_1GetFunctionDefinitionVersionComman
   let resolvedPath =
     "/greengrass/definition/functions/{FunctionDefinitionId}/versions/{FunctionDefinitionVersionId}";
   if (input.FunctionDefinitionId !== undefined) {
-    const labelValue: string = input.FunctionDefinitionId.toString();
+    const labelValue: string = input.FunctionDefinitionId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: FunctionDefinitionId."
@@ -2005,7 +2012,7 @@ export async function serializeAws_restJson1_1GetFunctionDefinitionVersionComman
     }
     resolvedPath = resolvedPath.replace(
       "{FunctionDefinitionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -2013,7 +2020,7 @@ export async function serializeAws_restJson1_1GetFunctionDefinitionVersionComman
     );
   }
   if (input.FunctionDefinitionVersionId !== undefined) {
-    const labelValue: string = input.FunctionDefinitionVersionId.toString();
+    const labelValue: string = input.FunctionDefinitionVersionId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: FunctionDefinitionVersionId."
@@ -2021,7 +2028,7 @@ export async function serializeAws_restJson1_1GetFunctionDefinitionVersionComman
     }
     resolvedPath = resolvedPath.replace(
       "{FunctionDefinitionVersionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -2030,7 +2037,9 @@ export async function serializeAws_restJson1_1GetFunctionDefinitionVersionComman
   }
   const query: any = {};
   if (input.NextToken !== undefined) {
-    query["NextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("NextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2050,13 +2059,13 @@ export async function serializeAws_restJson1_1GetGroupCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/greengrass/groups/{GroupId}";
   if (input.GroupId !== undefined) {
-    const labelValue: string = input.GroupId.toString();
+    const labelValue: string = input.GroupId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: GroupId.");
     }
     resolvedPath = resolvedPath.replace(
       "{GroupId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: GroupId.");
@@ -2079,7 +2088,7 @@ export async function serializeAws_restJson1_1GetGroupCertificateAuthorityComman
   let resolvedPath =
     "/greengrass/groups/{GroupId}/certificateauthorities/{CertificateAuthorityId}";
   if (input.CertificateAuthorityId !== undefined) {
-    const labelValue: string = input.CertificateAuthorityId.toString();
+    const labelValue: string = input.CertificateAuthorityId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: CertificateAuthorityId."
@@ -2087,7 +2096,7 @@ export async function serializeAws_restJson1_1GetGroupCertificateAuthorityComman
     }
     resolvedPath = resolvedPath.replace(
       "{CertificateAuthorityId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -2095,13 +2104,13 @@ export async function serializeAws_restJson1_1GetGroupCertificateAuthorityComman
     );
   }
   if (input.GroupId !== undefined) {
-    const labelValue: string = input.GroupId.toString();
+    const labelValue: string = input.GroupId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: GroupId.");
     }
     resolvedPath = resolvedPath.replace(
       "{GroupId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: GroupId.");
@@ -2124,13 +2133,13 @@ export async function serializeAws_restJson1_1GetGroupCertificateConfigurationCo
   let resolvedPath =
     "/greengrass/groups/{GroupId}/certificateauthorities/configuration/expiry";
   if (input.GroupId !== undefined) {
-    const labelValue: string = input.GroupId.toString();
+    const labelValue: string = input.GroupId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: GroupId.");
     }
     resolvedPath = resolvedPath.replace(
       "{GroupId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: GroupId.");
@@ -2152,19 +2161,19 @@ export async function serializeAws_restJson1_1GetGroupVersionCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/greengrass/groups/{GroupId}/versions/{GroupVersionId}";
   if (input.GroupId !== undefined) {
-    const labelValue: string = input.GroupId.toString();
+    const labelValue: string = input.GroupId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: GroupId.");
     }
     resolvedPath = resolvedPath.replace(
       "{GroupId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: GroupId.");
   }
   if (input.GroupVersionId !== undefined) {
-    const labelValue: string = input.GroupVersionId.toString();
+    const labelValue: string = input.GroupVersionId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: GroupVersionId."
@@ -2172,7 +2181,7 @@ export async function serializeAws_restJson1_1GetGroupVersionCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{GroupVersionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: GroupVersionId.");
@@ -2194,7 +2203,7 @@ export async function serializeAws_restJson1_1GetLoggerDefinitionCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/greengrass/definition/loggers/{LoggerDefinitionId}";
   if (input.LoggerDefinitionId !== undefined) {
-    const labelValue: string = input.LoggerDefinitionId.toString();
+    const labelValue: string = input.LoggerDefinitionId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: LoggerDefinitionId."
@@ -2202,7 +2211,7 @@ export async function serializeAws_restJson1_1GetLoggerDefinitionCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{LoggerDefinitionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -2227,7 +2236,7 @@ export async function serializeAws_restJson1_1GetLoggerDefinitionVersionCommand(
   let resolvedPath =
     "/greengrass/definition/loggers/{LoggerDefinitionId}/versions/{LoggerDefinitionVersionId}";
   if (input.LoggerDefinitionId !== undefined) {
-    const labelValue: string = input.LoggerDefinitionId.toString();
+    const labelValue: string = input.LoggerDefinitionId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: LoggerDefinitionId."
@@ -2235,7 +2244,7 @@ export async function serializeAws_restJson1_1GetLoggerDefinitionVersionCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{LoggerDefinitionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -2243,7 +2252,7 @@ export async function serializeAws_restJson1_1GetLoggerDefinitionVersionCommand(
     );
   }
   if (input.LoggerDefinitionVersionId !== undefined) {
-    const labelValue: string = input.LoggerDefinitionVersionId.toString();
+    const labelValue: string = input.LoggerDefinitionVersionId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: LoggerDefinitionVersionId."
@@ -2251,7 +2260,7 @@ export async function serializeAws_restJson1_1GetLoggerDefinitionVersionCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{LoggerDefinitionVersionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -2260,7 +2269,9 @@ export async function serializeAws_restJson1_1GetLoggerDefinitionVersionCommand(
   }
   const query: any = {};
   if (input.NextToken !== undefined) {
-    query["NextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("NextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2280,7 +2291,7 @@ export async function serializeAws_restJson1_1GetResourceDefinitionCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/greengrass/definition/resources/{ResourceDefinitionId}";
   if (input.ResourceDefinitionId !== undefined) {
-    const labelValue: string = input.ResourceDefinitionId.toString();
+    const labelValue: string = input.ResourceDefinitionId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ResourceDefinitionId."
@@ -2288,7 +2299,7 @@ export async function serializeAws_restJson1_1GetResourceDefinitionCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceDefinitionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -2313,7 +2324,7 @@ export async function serializeAws_restJson1_1GetResourceDefinitionVersionComman
   let resolvedPath =
     "/greengrass/definition/resources/{ResourceDefinitionId}/versions/{ResourceDefinitionVersionId}";
   if (input.ResourceDefinitionId !== undefined) {
-    const labelValue: string = input.ResourceDefinitionId.toString();
+    const labelValue: string = input.ResourceDefinitionId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ResourceDefinitionId."
@@ -2321,7 +2332,7 @@ export async function serializeAws_restJson1_1GetResourceDefinitionVersionComman
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceDefinitionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -2329,7 +2340,7 @@ export async function serializeAws_restJson1_1GetResourceDefinitionVersionComman
     );
   }
   if (input.ResourceDefinitionVersionId !== undefined) {
-    const labelValue: string = input.ResourceDefinitionVersionId.toString();
+    const labelValue: string = input.ResourceDefinitionVersionId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ResourceDefinitionVersionId."
@@ -2337,7 +2348,7 @@ export async function serializeAws_restJson1_1GetResourceDefinitionVersionComman
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceDefinitionVersionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -2378,7 +2389,7 @@ export async function serializeAws_restJson1_1GetSubscriptionDefinitionCommand(
   let resolvedPath =
     "/greengrass/definition/subscriptions/{SubscriptionDefinitionId}";
   if (input.SubscriptionDefinitionId !== undefined) {
-    const labelValue: string = input.SubscriptionDefinitionId.toString();
+    const labelValue: string = input.SubscriptionDefinitionId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: SubscriptionDefinitionId."
@@ -2386,7 +2397,7 @@ export async function serializeAws_restJson1_1GetSubscriptionDefinitionCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{SubscriptionDefinitionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -2411,7 +2422,7 @@ export async function serializeAws_restJson1_1GetSubscriptionDefinitionVersionCo
   let resolvedPath =
     "/greengrass/definition/subscriptions/{SubscriptionDefinitionId}/versions/{SubscriptionDefinitionVersionId}";
   if (input.SubscriptionDefinitionId !== undefined) {
-    const labelValue: string = input.SubscriptionDefinitionId.toString();
+    const labelValue: string = input.SubscriptionDefinitionId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: SubscriptionDefinitionId."
@@ -2419,7 +2430,7 @@ export async function serializeAws_restJson1_1GetSubscriptionDefinitionVersionCo
     }
     resolvedPath = resolvedPath.replace(
       "{SubscriptionDefinitionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -2427,7 +2438,7 @@ export async function serializeAws_restJson1_1GetSubscriptionDefinitionVersionCo
     );
   }
   if (input.SubscriptionDefinitionVersionId !== undefined) {
-    const labelValue: string = input.SubscriptionDefinitionVersionId.toString();
+    const labelValue: string = input.SubscriptionDefinitionVersionId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: SubscriptionDefinitionVersionId."
@@ -2435,7 +2446,7 @@ export async function serializeAws_restJson1_1GetSubscriptionDefinitionVersionCo
     }
     resolvedPath = resolvedPath.replace(
       "{SubscriptionDefinitionVersionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -2444,7 +2455,9 @@ export async function serializeAws_restJson1_1GetSubscriptionDefinitionVersionCo
   }
   const query: any = {};
   if (input.NextToken !== undefined) {
-    query["NextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("NextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2465,7 +2478,7 @@ export async function serializeAws_restJson1_1ListBulkDeploymentDetailedReportsC
   let resolvedPath =
     "/greengrass/bulk/deployments/{BulkDeploymentId}/detailed-reports";
   if (input.BulkDeploymentId !== undefined) {
-    const labelValue: string = input.BulkDeploymentId.toString();
+    const labelValue: string = input.BulkDeploymentId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: BulkDeploymentId."
@@ -2473,7 +2486,7 @@ export async function serializeAws_restJson1_1ListBulkDeploymentDetailedReportsC
     }
     resolvedPath = resolvedPath.replace(
       "{BulkDeploymentId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -2482,10 +2495,14 @@ export async function serializeAws_restJson1_1ListBulkDeploymentDetailedReportsC
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["MaxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("MaxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults);
   }
   if (input.NextToken !== undefined) {
-    query["NextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("NextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2506,10 +2523,14 @@ export async function serializeAws_restJson1_1ListBulkDeploymentsCommand(
   let resolvedPath = "/greengrass/bulk/deployments";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["MaxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("MaxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults);
   }
   if (input.NextToken !== undefined) {
-    query["NextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("NextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2530,7 +2551,7 @@ export async function serializeAws_restJson1_1ListConnectorDefinitionVersionsCom
   let resolvedPath =
     "/greengrass/definition/connectors/{ConnectorDefinitionId}/versions";
   if (input.ConnectorDefinitionId !== undefined) {
-    const labelValue: string = input.ConnectorDefinitionId.toString();
+    const labelValue: string = input.ConnectorDefinitionId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ConnectorDefinitionId."
@@ -2538,7 +2559,7 @@ export async function serializeAws_restJson1_1ListConnectorDefinitionVersionsCom
     }
     resolvedPath = resolvedPath.replace(
       "{ConnectorDefinitionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -2547,10 +2568,14 @@ export async function serializeAws_restJson1_1ListConnectorDefinitionVersionsCom
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["MaxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("MaxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults);
   }
   if (input.NextToken !== undefined) {
-    query["NextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("NextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2571,10 +2596,14 @@ export async function serializeAws_restJson1_1ListConnectorDefinitionsCommand(
   let resolvedPath = "/greengrass/definition/connectors";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["MaxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("MaxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults);
   }
   if (input.NextToken !== undefined) {
-    query["NextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("NextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2594,7 +2623,7 @@ export async function serializeAws_restJson1_1ListCoreDefinitionVersionsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/greengrass/definition/cores/{CoreDefinitionId}/versions";
   if (input.CoreDefinitionId !== undefined) {
-    const labelValue: string = input.CoreDefinitionId.toString();
+    const labelValue: string = input.CoreDefinitionId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: CoreDefinitionId."
@@ -2602,7 +2631,7 @@ export async function serializeAws_restJson1_1ListCoreDefinitionVersionsCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{CoreDefinitionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -2611,10 +2640,14 @@ export async function serializeAws_restJson1_1ListCoreDefinitionVersionsCommand(
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["MaxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("MaxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults);
   }
   if (input.NextToken !== undefined) {
-    query["NextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("NextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2635,10 +2668,14 @@ export async function serializeAws_restJson1_1ListCoreDefinitionsCommand(
   let resolvedPath = "/greengrass/definition/cores";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["MaxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("MaxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults);
   }
   if (input.NextToken !== undefined) {
-    query["NextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("NextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2658,23 +2695,27 @@ export async function serializeAws_restJson1_1ListDeploymentsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/greengrass/groups/{GroupId}/deployments";
   if (input.GroupId !== undefined) {
-    const labelValue: string = input.GroupId.toString();
+    const labelValue: string = input.GroupId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: GroupId.");
     }
     resolvedPath = resolvedPath.replace(
       "{GroupId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: GroupId.");
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["MaxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("MaxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults);
   }
   if (input.NextToken !== undefined) {
-    query["NextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("NextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2695,7 +2736,7 @@ export async function serializeAws_restJson1_1ListDeviceDefinitionVersionsComman
   let resolvedPath =
     "/greengrass/definition/devices/{DeviceDefinitionId}/versions";
   if (input.DeviceDefinitionId !== undefined) {
-    const labelValue: string = input.DeviceDefinitionId.toString();
+    const labelValue: string = input.DeviceDefinitionId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: DeviceDefinitionId."
@@ -2703,7 +2744,7 @@ export async function serializeAws_restJson1_1ListDeviceDefinitionVersionsComman
     }
     resolvedPath = resolvedPath.replace(
       "{DeviceDefinitionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -2712,10 +2753,14 @@ export async function serializeAws_restJson1_1ListDeviceDefinitionVersionsComman
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["MaxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("MaxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults);
   }
   if (input.NextToken !== undefined) {
-    query["NextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("NextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2736,10 +2781,14 @@ export async function serializeAws_restJson1_1ListDeviceDefinitionsCommand(
   let resolvedPath = "/greengrass/definition/devices";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["MaxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("MaxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults);
   }
   if (input.NextToken !== undefined) {
-    query["NextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("NextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2760,7 +2809,7 @@ export async function serializeAws_restJson1_1ListFunctionDefinitionVersionsComm
   let resolvedPath =
     "/greengrass/definition/functions/{FunctionDefinitionId}/versions";
   if (input.FunctionDefinitionId !== undefined) {
-    const labelValue: string = input.FunctionDefinitionId.toString();
+    const labelValue: string = input.FunctionDefinitionId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: FunctionDefinitionId."
@@ -2768,7 +2817,7 @@ export async function serializeAws_restJson1_1ListFunctionDefinitionVersionsComm
     }
     resolvedPath = resolvedPath.replace(
       "{FunctionDefinitionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -2777,10 +2826,14 @@ export async function serializeAws_restJson1_1ListFunctionDefinitionVersionsComm
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["MaxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("MaxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults);
   }
   if (input.NextToken !== undefined) {
-    query["NextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("NextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2801,10 +2854,14 @@ export async function serializeAws_restJson1_1ListFunctionDefinitionsCommand(
   let resolvedPath = "/greengrass/definition/functions";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["MaxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("MaxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults);
   }
   if (input.NextToken !== undefined) {
-    query["NextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("NextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2824,13 +2881,13 @@ export async function serializeAws_restJson1_1ListGroupCertificateAuthoritiesCom
   headers["Content-Type"] = "";
   let resolvedPath = "/greengrass/groups/{GroupId}/certificateauthorities";
   if (input.GroupId !== undefined) {
-    const labelValue: string = input.GroupId.toString();
+    const labelValue: string = input.GroupId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: GroupId.");
     }
     resolvedPath = resolvedPath.replace(
       "{GroupId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: GroupId.");
@@ -2852,23 +2909,27 @@ export async function serializeAws_restJson1_1ListGroupVersionsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/greengrass/groups/{GroupId}/versions";
   if (input.GroupId !== undefined) {
-    const labelValue: string = input.GroupId.toString();
+    const labelValue: string = input.GroupId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: GroupId.");
     }
     resolvedPath = resolvedPath.replace(
       "{GroupId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: GroupId.");
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["MaxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("MaxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults);
   }
   if (input.NextToken !== undefined) {
-    query["NextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("NextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2889,10 +2950,14 @@ export async function serializeAws_restJson1_1ListGroupsCommand(
   let resolvedPath = "/greengrass/groups";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["MaxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("MaxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults);
   }
   if (input.NextToken !== undefined) {
-    query["NextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("NextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2913,7 +2978,7 @@ export async function serializeAws_restJson1_1ListLoggerDefinitionVersionsComman
   let resolvedPath =
     "/greengrass/definition/loggers/{LoggerDefinitionId}/versions";
   if (input.LoggerDefinitionId !== undefined) {
-    const labelValue: string = input.LoggerDefinitionId.toString();
+    const labelValue: string = input.LoggerDefinitionId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: LoggerDefinitionId."
@@ -2921,7 +2986,7 @@ export async function serializeAws_restJson1_1ListLoggerDefinitionVersionsComman
     }
     resolvedPath = resolvedPath.replace(
       "{LoggerDefinitionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -2930,10 +2995,14 @@ export async function serializeAws_restJson1_1ListLoggerDefinitionVersionsComman
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["MaxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("MaxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults);
   }
   if (input.NextToken !== undefined) {
-    query["NextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("NextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2954,10 +3023,14 @@ export async function serializeAws_restJson1_1ListLoggerDefinitionsCommand(
   let resolvedPath = "/greengrass/definition/loggers";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["MaxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("MaxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults);
   }
   if (input.NextToken !== undefined) {
-    query["NextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("NextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2978,7 +3051,7 @@ export async function serializeAws_restJson1_1ListResourceDefinitionVersionsComm
   let resolvedPath =
     "/greengrass/definition/resources/{ResourceDefinitionId}/versions";
   if (input.ResourceDefinitionId !== undefined) {
-    const labelValue: string = input.ResourceDefinitionId.toString();
+    const labelValue: string = input.ResourceDefinitionId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ResourceDefinitionId."
@@ -2986,7 +3059,7 @@ export async function serializeAws_restJson1_1ListResourceDefinitionVersionsComm
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceDefinitionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -2995,10 +3068,14 @@ export async function serializeAws_restJson1_1ListResourceDefinitionVersionsComm
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["MaxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("MaxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults);
   }
   if (input.NextToken !== undefined) {
-    query["NextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("NextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -3019,10 +3096,14 @@ export async function serializeAws_restJson1_1ListResourceDefinitionsCommand(
   let resolvedPath = "/greengrass/definition/resources";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["MaxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("MaxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults);
   }
   if (input.NextToken !== undefined) {
-    query["NextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("NextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -3043,7 +3124,7 @@ export async function serializeAws_restJson1_1ListSubscriptionDefinitionVersions
   let resolvedPath =
     "/greengrass/definition/subscriptions/{SubscriptionDefinitionId}/versions";
   if (input.SubscriptionDefinitionId !== undefined) {
-    const labelValue: string = input.SubscriptionDefinitionId.toString();
+    const labelValue: string = input.SubscriptionDefinitionId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: SubscriptionDefinitionId."
@@ -3051,7 +3132,7 @@ export async function serializeAws_restJson1_1ListSubscriptionDefinitionVersions
     }
     resolvedPath = resolvedPath.replace(
       "{SubscriptionDefinitionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -3060,10 +3141,14 @@ export async function serializeAws_restJson1_1ListSubscriptionDefinitionVersions
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["MaxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("MaxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults);
   }
   if (input.NextToken !== undefined) {
-    query["NextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("NextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -3084,10 +3169,14 @@ export async function serializeAws_restJson1_1ListSubscriptionDefinitionsCommand
   let resolvedPath = "/greengrass/definition/subscriptions";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["MaxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("MaxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults);
   }
   if (input.NextToken !== undefined) {
-    query["NextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("NextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -3107,7 +3196,7 @@ export async function serializeAws_restJson1_1ListTagsForResourceCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/tags/{ResourceArn}";
   if (input.ResourceArn !== undefined) {
-    const labelValue: string = input.ResourceArn.toString();
+    const labelValue: string = input.ResourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ResourceArn."
@@ -3115,7 +3204,7 @@ export async function serializeAws_restJson1_1ListTagsForResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ResourceArn.");
@@ -3136,17 +3225,17 @@ export async function serializeAws_restJson1_1ResetDeploymentsCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.AmznClientToken !== undefined) {
-    headers["X-Amzn-Client-Token"] = input.AmznClientToken.toString();
+    headers["X-Amzn-Client-Token"] = input.AmznClientToken;
   }
   let resolvedPath = "/greengrass/groups/{GroupId}/deployments/$reset";
   if (input.GroupId !== undefined) {
-    const labelValue: string = input.GroupId.toString();
+    const labelValue: string = input.GroupId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: GroupId.");
     }
     resolvedPath = resolvedPath.replace(
       "{GroupId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: GroupId.");
@@ -3174,7 +3263,7 @@ export async function serializeAws_restJson1_1StartBulkDeploymentCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.AmznClientToken !== undefined) {
-    headers["X-Amzn-Client-Token"] = input.AmznClientToken.toString();
+    headers["X-Amzn-Client-Token"] = input.AmznClientToken;
   }
   let resolvedPath = "/greengrass/bulk/deployments";
   let body: any;
@@ -3207,7 +3296,7 @@ export async function serializeAws_restJson1_1StopBulkDeploymentCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/greengrass/bulk/deployments/{BulkDeploymentId}/$stop";
   if (input.BulkDeploymentId !== undefined) {
-    const labelValue: string = input.BulkDeploymentId.toString();
+    const labelValue: string = input.BulkDeploymentId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: BulkDeploymentId."
@@ -3215,7 +3304,7 @@ export async function serializeAws_restJson1_1StopBulkDeploymentCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{BulkDeploymentId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -3239,7 +3328,7 @@ export async function serializeAws_restJson1_1TagResourceCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/tags/{ResourceArn}";
   if (input.ResourceArn !== undefined) {
-    const labelValue: string = input.ResourceArn.toString();
+    const labelValue: string = input.ResourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ResourceArn."
@@ -3247,7 +3336,7 @@ export async function serializeAws_restJson1_1TagResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ResourceArn.");
@@ -3276,7 +3365,7 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/tags/{ResourceArn}";
   if (input.ResourceArn !== undefined) {
-    const labelValue: string = input.ResourceArn.toString();
+    const labelValue: string = input.ResourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ResourceArn."
@@ -3284,14 +3373,16 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ResourceArn.");
   }
   const query: any = {};
   if (input.TagKeys !== undefined) {
-    query["tagKeys"] = input.TagKeys;
+    query[__extendedEncodeURIComponent("tagKeys")] = input.TagKeys.map(entry =>
+      __extendedEncodeURIComponent(entry)
+    );
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -3311,13 +3402,13 @@ export async function serializeAws_restJson1_1UpdateConnectivityInfoCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/greengrass/things/{ThingName}/connectivityInfo";
   if (input.ThingName !== undefined) {
-    const labelValue: string = input.ThingName.toString();
+    const labelValue: string = input.ThingName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ThingName.");
     }
     resolvedPath = resolvedPath.replace(
       "{ThingName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ThingName.");
@@ -3352,7 +3443,7 @@ export async function serializeAws_restJson1_1UpdateConnectorDefinitionCommand(
   let resolvedPath =
     "/greengrass/definition/connectors/{ConnectorDefinitionId}";
   if (input.ConnectorDefinitionId !== undefined) {
-    const labelValue: string = input.ConnectorDefinitionId.toString();
+    const labelValue: string = input.ConnectorDefinitionId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ConnectorDefinitionId."
@@ -3360,7 +3451,7 @@ export async function serializeAws_restJson1_1UpdateConnectorDefinitionCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ConnectorDefinitionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -3391,7 +3482,7 @@ export async function serializeAws_restJson1_1UpdateCoreDefinitionCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/greengrass/definition/cores/{CoreDefinitionId}";
   if (input.CoreDefinitionId !== undefined) {
-    const labelValue: string = input.CoreDefinitionId.toString();
+    const labelValue: string = input.CoreDefinitionId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: CoreDefinitionId."
@@ -3399,7 +3490,7 @@ export async function serializeAws_restJson1_1UpdateCoreDefinitionCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{CoreDefinitionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -3430,7 +3521,7 @@ export async function serializeAws_restJson1_1UpdateDeviceDefinitionCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/greengrass/definition/devices/{DeviceDefinitionId}";
   if (input.DeviceDefinitionId !== undefined) {
-    const labelValue: string = input.DeviceDefinitionId.toString();
+    const labelValue: string = input.DeviceDefinitionId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: DeviceDefinitionId."
@@ -3438,7 +3529,7 @@ export async function serializeAws_restJson1_1UpdateDeviceDefinitionCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{DeviceDefinitionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -3469,7 +3560,7 @@ export async function serializeAws_restJson1_1UpdateFunctionDefinitionCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/greengrass/definition/functions/{FunctionDefinitionId}";
   if (input.FunctionDefinitionId !== undefined) {
-    const labelValue: string = input.FunctionDefinitionId.toString();
+    const labelValue: string = input.FunctionDefinitionId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: FunctionDefinitionId."
@@ -3477,7 +3568,7 @@ export async function serializeAws_restJson1_1UpdateFunctionDefinitionCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{FunctionDefinitionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -3508,13 +3599,13 @@ export async function serializeAws_restJson1_1UpdateGroupCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/greengrass/groups/{GroupId}";
   if (input.GroupId !== undefined) {
-    const labelValue: string = input.GroupId.toString();
+    const labelValue: string = input.GroupId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: GroupId.");
     }
     resolvedPath = resolvedPath.replace(
       "{GroupId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: GroupId.");
@@ -3544,13 +3635,13 @@ export async function serializeAws_restJson1_1UpdateGroupCertificateConfiguratio
   let resolvedPath =
     "/greengrass/groups/{GroupId}/certificateauthorities/configuration/expiry";
   if (input.GroupId !== undefined) {
-    const labelValue: string = input.GroupId.toString();
+    const labelValue: string = input.GroupId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: GroupId.");
     }
     resolvedPath = resolvedPath.replace(
       "{GroupId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: GroupId.");
@@ -3580,7 +3671,7 @@ export async function serializeAws_restJson1_1UpdateLoggerDefinitionCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/greengrass/definition/loggers/{LoggerDefinitionId}";
   if (input.LoggerDefinitionId !== undefined) {
-    const labelValue: string = input.LoggerDefinitionId.toString();
+    const labelValue: string = input.LoggerDefinitionId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: LoggerDefinitionId."
@@ -3588,7 +3679,7 @@ export async function serializeAws_restJson1_1UpdateLoggerDefinitionCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{LoggerDefinitionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -3619,7 +3710,7 @@ export async function serializeAws_restJson1_1UpdateResourceDefinitionCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/greengrass/definition/resources/{ResourceDefinitionId}";
   if (input.ResourceDefinitionId !== undefined) {
-    const labelValue: string = input.ResourceDefinitionId.toString();
+    const labelValue: string = input.ResourceDefinitionId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ResourceDefinitionId."
@@ -3627,7 +3718,7 @@ export async function serializeAws_restJson1_1UpdateResourceDefinitionCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceDefinitionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -3659,7 +3750,7 @@ export async function serializeAws_restJson1_1UpdateSubscriptionDefinitionComman
   let resolvedPath =
     "/greengrass/definition/subscriptions/{SubscriptionDefinitionId}";
   if (input.SubscriptionDefinitionId !== undefined) {
-    const labelValue: string = input.SubscriptionDefinitionId.toString();
+    const labelValue: string = input.SubscriptionDefinitionId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: SubscriptionDefinitionId."
@@ -3667,7 +3758,7 @@ export async function serializeAws_restJson1_1UpdateSubscriptionDefinitionComman
     }
     resolvedPath = resolvedPath.replace(
       "{SubscriptionDefinitionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -5235,6 +5326,7 @@ export async function deserializeAws_restJson1_1DeleteConnectorDefinitionCommand
     $metadata: deserializeMetadata(output),
     __type: "DeleteConnectorDefinitionResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -5286,6 +5378,7 @@ export async function deserializeAws_restJson1_1DeleteCoreDefinitionCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeleteCoreDefinitionResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -5337,6 +5430,7 @@ export async function deserializeAws_restJson1_1DeleteDeviceDefinitionCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeleteDeviceDefinitionResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -5388,6 +5482,7 @@ export async function deserializeAws_restJson1_1DeleteFunctionDefinitionCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeleteFunctionDefinitionResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -5436,6 +5531,7 @@ export async function deserializeAws_restJson1_1DeleteGroupCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeleteGroupResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -5487,6 +5583,7 @@ export async function deserializeAws_restJson1_1DeleteLoggerDefinitionCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeleteLoggerDefinitionResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -5538,6 +5635,7 @@ export async function deserializeAws_restJson1_1DeleteResourceDefinitionCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeleteResourceDefinitionResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -5589,6 +5687,7 @@ export async function deserializeAws_restJson1_1DeleteSubscriptionDefinitionComm
     $metadata: deserializeMetadata(output),
     __type: "DeleteSubscriptionDefinitionResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -8974,6 +9073,7 @@ export async function deserializeAws_restJson1_1StopBulkDeploymentCommand(
     $metadata: deserializeMetadata(output),
     __type: "StopBulkDeploymentResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -9021,6 +9121,7 @@ export async function deserializeAws_restJson1_1TagResourceCommand(
   const contents: TagResourceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -9068,6 +9169,7 @@ export async function deserializeAws_restJson1_1UntagResourceCommand(
   const contents: UntagResourceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -9186,6 +9288,7 @@ export async function deserializeAws_restJson1_1UpdateConnectorDefinitionCommand
     $metadata: deserializeMetadata(output),
     __type: "UpdateConnectorDefinitionResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -9237,6 +9340,7 @@ export async function deserializeAws_restJson1_1UpdateCoreDefinitionCommand(
     $metadata: deserializeMetadata(output),
     __type: "UpdateCoreDefinitionResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -9288,6 +9392,7 @@ export async function deserializeAws_restJson1_1UpdateDeviceDefinitionCommand(
     $metadata: deserializeMetadata(output),
     __type: "UpdateDeviceDefinitionResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -9339,6 +9444,7 @@ export async function deserializeAws_restJson1_1UpdateFunctionDefinitionCommand(
     $metadata: deserializeMetadata(output),
     __type: "UpdateFunctionDefinitionResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -9387,6 +9493,7 @@ export async function deserializeAws_restJson1_1UpdateGroupCommand(
     $metadata: deserializeMetadata(output),
     __type: "UpdateGroupResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -9517,6 +9624,7 @@ export async function deserializeAws_restJson1_1UpdateLoggerDefinitionCommand(
     $metadata: deserializeMetadata(output),
     __type: "UpdateLoggerDefinitionResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -9568,6 +9676,7 @@ export async function deserializeAws_restJson1_1UpdateResourceDefinitionCommand(
     $metadata: deserializeMetadata(output),
     __type: "UpdateResourceDefinitionResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -9619,6 +9728,7 @@ export async function deserializeAws_restJson1_1UpdateSubscriptionDefinitionComm
     $metadata: deserializeMetadata(output),
     __type: "UpdateSubscriptionDefinitionResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 

--- a/clients/client-groundstation/models/index.ts
+++ b/clients/client-groundstation/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -15,7 +18,7 @@ export interface AntennaDownlinkConfig {
 
 export namespace AntennaDownlinkConfig {
   export function isa(o: any): o is AntennaDownlinkConfig {
-    return _smithy.isa(o, "AntennaDownlinkConfig");
+    return __isa(o, "AntennaDownlinkConfig");
   }
 }
 
@@ -42,7 +45,7 @@ export interface AntennaDownlinkDemodDecodeConfig {
 
 export namespace AntennaDownlinkDemodDecodeConfig {
   export function isa(o: any): o is AntennaDownlinkDemodDecodeConfig {
-    return _smithy.isa(o, "AntennaDownlinkDemodDecodeConfig");
+    return __isa(o, "AntennaDownlinkDemodDecodeConfig");
   }
 }
 
@@ -64,7 +67,7 @@ export interface AntennaUplinkConfig {
 
 export namespace AntennaUplinkConfig {
   export function isa(o: any): o is AntennaUplinkConfig {
-    return _smithy.isa(o, "AntennaUplinkConfig");
+    return __isa(o, "AntennaUplinkConfig");
   }
 }
 
@@ -81,7 +84,7 @@ export interface CancelContactRequest {
 
 export namespace CancelContactRequest {
   export function isa(o: any): o is CancelContactRequest {
-    return _smithy.isa(o, "CancelContactRequest");
+    return __isa(o, "CancelContactRequest");
   }
 }
 
@@ -108,7 +111,7 @@ export interface ConfigIdResponse extends $MetadataBearer {
 
 export namespace ConfigIdResponse {
   export function isa(o: any): o is ConfigIdResponse {
-    return _smithy.isa(o, "ConfigIdResponse");
+    return __isa(o, "ConfigIdResponse");
   }
 }
 
@@ -140,7 +143,7 @@ export interface ConfigListItem {
 
 export namespace ConfigListItem {
   export function isa(o: any): o is ConfigListItem {
-    return _smithy.isa(o, "ConfigListItem");
+    return __isa(o, "ConfigListItem");
   }
 }
 
@@ -341,7 +344,7 @@ export interface ContactData {
 
 export namespace ContactData {
   export function isa(o: any): o is ContactData {
-    return _smithy.isa(o, "ContactData");
+    return __isa(o, "ContactData");
   }
 }
 
@@ -358,7 +361,7 @@ export interface ContactIdResponse extends $MetadataBearer {
 
 export namespace ContactIdResponse {
   export function isa(o: any): o is ContactIdResponse {
-    return _smithy.isa(o, "ContactIdResponse");
+    return __isa(o, "ContactIdResponse");
   }
 }
 
@@ -385,7 +388,7 @@ export interface CreateConfigRequest {
 
 export namespace CreateConfigRequest {
   export function isa(o: any): o is CreateConfigRequest {
-    return _smithy.isa(o, "CreateConfigRequest");
+    return __isa(o, "CreateConfigRequest");
   }
 }
 
@@ -407,7 +410,7 @@ export interface CreateDataflowEndpointGroupRequest {
 
 export namespace CreateDataflowEndpointGroupRequest {
   export function isa(o: any): o is CreateDataflowEndpointGroupRequest {
-    return _smithy.isa(o, "CreateDataflowEndpointGroupRequest");
+    return __isa(o, "CreateDataflowEndpointGroupRequest");
   }
 }
 
@@ -455,7 +458,7 @@ export interface CreateMissionProfileRequest {
 
 export namespace CreateMissionProfileRequest {
   export function isa(o: any): o is CreateMissionProfileRequest {
-    return _smithy.isa(o, "CreateMissionProfileRequest");
+    return __isa(o, "CreateMissionProfileRequest");
   }
 }
 
@@ -482,7 +485,7 @@ export interface DataflowEndpoint {
 
 export namespace DataflowEndpoint {
   export function isa(o: any): o is DataflowEndpoint {
-    return _smithy.isa(o, "DataflowEndpoint");
+    return __isa(o, "DataflowEndpoint");
   }
 }
 
@@ -499,7 +502,7 @@ export interface DataflowEndpointConfig {
 
 export namespace DataflowEndpointConfig {
   export function isa(o: any): o is DataflowEndpointConfig {
-    return _smithy.isa(o, "DataflowEndpointConfig");
+    return __isa(o, "DataflowEndpointConfig");
   }
 }
 
@@ -516,7 +519,7 @@ export interface DataflowEndpointGroupIdResponse extends $MetadataBearer {
 
 export namespace DataflowEndpointGroupIdResponse {
   export function isa(o: any): o is DataflowEndpointGroupIdResponse {
-    return _smithy.isa(o, "DataflowEndpointGroupIdResponse");
+    return __isa(o, "DataflowEndpointGroupIdResponse");
   }
 }
 
@@ -538,7 +541,7 @@ export interface DataflowEndpointListItem {
 
 export namespace DataflowEndpointListItem {
   export function isa(o: any): o is DataflowEndpointListItem {
-    return _smithy.isa(o, "DataflowEndpointListItem");
+    return __isa(o, "DataflowEndpointListItem");
   }
 }
 
@@ -555,7 +558,7 @@ export interface DecodeConfig {
 
 export namespace DecodeConfig {
   export function isa(o: any): o is DecodeConfig {
-    return _smithy.isa(o, "DecodeConfig");
+    return __isa(o, "DecodeConfig");
   }
 }
 
@@ -577,7 +580,7 @@ export interface DeleteConfigRequest {
 
 export namespace DeleteConfigRequest {
   export function isa(o: any): o is DeleteConfigRequest {
-    return _smithy.isa(o, "DeleteConfigRequest");
+    return __isa(o, "DeleteConfigRequest");
   }
 }
 
@@ -594,7 +597,7 @@ export interface DeleteDataflowEndpointGroupRequest {
 
 export namespace DeleteDataflowEndpointGroupRequest {
   export function isa(o: any): o is DeleteDataflowEndpointGroupRequest {
-    return _smithy.isa(o, "DeleteDataflowEndpointGroupRequest");
+    return __isa(o, "DeleteDataflowEndpointGroupRequest");
   }
 }
 
@@ -611,7 +614,7 @@ export interface DeleteMissionProfileRequest {
 
 export namespace DeleteMissionProfileRequest {
   export function isa(o: any): o is DeleteMissionProfileRequest {
-    return _smithy.isa(o, "DeleteMissionProfileRequest");
+    return __isa(o, "DeleteMissionProfileRequest");
   }
 }
 
@@ -628,7 +631,7 @@ export interface DemodulationConfig {
 
 export namespace DemodulationConfig {
   export function isa(o: any): o is DemodulationConfig {
-    return _smithy.isa(o, "DemodulationConfig");
+    return __isa(o, "DemodulationConfig");
   }
 }
 
@@ -645,7 +648,7 @@ export interface DescribeContactRequest {
 
 export namespace DescribeContactRequest {
   export function isa(o: any): o is DescribeContactRequest {
-    return _smithy.isa(o, "DescribeContactRequest");
+    return __isa(o, "DescribeContactRequest");
   }
 }
 
@@ -717,7 +720,7 @@ export interface DescribeContactResponse extends $MetadataBearer {
 
 export namespace DescribeContactResponse {
   export function isa(o: any): o is DescribeContactResponse {
-    return _smithy.isa(o, "DescribeContactResponse");
+    return __isa(o, "DescribeContactResponse");
   }
 }
 
@@ -739,7 +742,7 @@ export interface EndpointDetails {
 
 export namespace EndpointDetails {
   export function isa(o: any): o is EndpointDetails {
-    return _smithy.isa(o, "EndpointDetails");
+    return __isa(o, "EndpointDetails");
   }
 }
 
@@ -769,7 +772,7 @@ export interface GetConfigRequest {
 
 export namespace GetConfigRequest {
   export function isa(o: any): o is GetConfigRequest {
-    return _smithy.isa(o, "GetConfigRequest");
+    return __isa(o, "GetConfigRequest");
   }
 }
 
@@ -812,7 +815,7 @@ export interface GetConfigResponse extends $MetadataBearer {
 
 export namespace GetConfigResponse {
   export function isa(o: any): o is GetConfigResponse {
-    return _smithy.isa(o, "GetConfigResponse");
+    return __isa(o, "GetConfigResponse");
   }
 }
 
@@ -829,7 +832,7 @@ export interface GetDataflowEndpointGroupRequest {
 
 export namespace GetDataflowEndpointGroupRequest {
   export function isa(o: any): o is GetDataflowEndpointGroupRequest {
-    return _smithy.isa(o, "GetDataflowEndpointGroupRequest");
+    return __isa(o, "GetDataflowEndpointGroupRequest");
   }
 }
 
@@ -861,7 +864,7 @@ export interface GetDataflowEndpointGroupResponse extends $MetadataBearer {
 
 export namespace GetDataflowEndpointGroupResponse {
   export function isa(o: any): o is GetDataflowEndpointGroupResponse {
-    return _smithy.isa(o, "GetDataflowEndpointGroupResponse");
+    return __isa(o, "GetDataflowEndpointGroupResponse");
   }
 }
 
@@ -878,7 +881,7 @@ export interface GetMissionProfileRequest {
 
 export namespace GetMissionProfileRequest {
   export function isa(o: any): o is GetMissionProfileRequest {
-    return _smithy.isa(o, "GetMissionProfileRequest");
+    return __isa(o, "GetMissionProfileRequest");
   }
 }
 
@@ -941,7 +944,7 @@ export interface GetMissionProfileResponse extends $MetadataBearer {
 
 export namespace GetMissionProfileResponse {
   export function isa(o: any): o is GetMissionProfileResponse {
-    return _smithy.isa(o, "GetMissionProfileResponse");
+    return __isa(o, "GetMissionProfileResponse");
   }
 }
 
@@ -963,7 +966,7 @@ export interface ListConfigsRequest {
 
 export namespace ListConfigsRequest {
   export function isa(o: any): o is ListConfigsRequest {
-    return _smithy.isa(o, "ListConfigsRequest");
+    return __isa(o, "ListConfigsRequest");
   }
 }
 
@@ -985,7 +988,7 @@ export interface ListConfigsResponse extends $MetadataBearer {
 
 export namespace ListConfigsResponse {
   export function isa(o: any): o is ListConfigsResponse {
-    return _smithy.isa(o, "ListConfigsResponse");
+    return __isa(o, "ListConfigsResponse");
   }
 }
 
@@ -1037,7 +1040,7 @@ export interface ListContactsRequest {
 
 export namespace ListContactsRequest {
   export function isa(o: any): o is ListContactsRequest {
-    return _smithy.isa(o, "ListContactsRequest");
+    return __isa(o, "ListContactsRequest");
   }
 }
 
@@ -1059,7 +1062,7 @@ export interface ListContactsResponse extends $MetadataBearer {
 
 export namespace ListContactsResponse {
   export function isa(o: any): o is ListContactsResponse {
-    return _smithy.isa(o, "ListContactsResponse");
+    return __isa(o, "ListContactsResponse");
   }
 }
 
@@ -1081,7 +1084,7 @@ export interface ListDataflowEndpointGroupsRequest {
 
 export namespace ListDataflowEndpointGroupsRequest {
   export function isa(o: any): o is ListDataflowEndpointGroupsRequest {
-    return _smithy.isa(o, "ListDataflowEndpointGroupsRequest");
+    return __isa(o, "ListDataflowEndpointGroupsRequest");
   }
 }
 
@@ -1103,7 +1106,7 @@ export interface ListDataflowEndpointGroupsResponse extends $MetadataBearer {
 
 export namespace ListDataflowEndpointGroupsResponse {
   export function isa(o: any): o is ListDataflowEndpointGroupsResponse {
-    return _smithy.isa(o, "ListDataflowEndpointGroupsResponse");
+    return __isa(o, "ListDataflowEndpointGroupsResponse");
   }
 }
 
@@ -1125,7 +1128,7 @@ export interface ListMissionProfilesRequest {
 
 export namespace ListMissionProfilesRequest {
   export function isa(o: any): o is ListMissionProfilesRequest {
-    return _smithy.isa(o, "ListMissionProfilesRequest");
+    return __isa(o, "ListMissionProfilesRequest");
   }
 }
 
@@ -1147,7 +1150,7 @@ export interface ListMissionProfilesResponse extends $MetadataBearer {
 
 export namespace ListMissionProfilesResponse {
   export function isa(o: any): o is ListMissionProfilesResponse {
-    return _smithy.isa(o, "ListMissionProfilesResponse");
+    return __isa(o, "ListMissionProfilesResponse");
   }
 }
 
@@ -1164,7 +1167,7 @@ export interface MissionProfileIdResponse extends $MetadataBearer {
 
 export namespace MissionProfileIdResponse {
   export function isa(o: any): o is MissionProfileIdResponse {
-    return _smithy.isa(o, "MissionProfileIdResponse");
+    return __isa(o, "MissionProfileIdResponse");
   }
 }
 
@@ -1196,7 +1199,7 @@ export interface MissionProfileListItem {
 
 export namespace MissionProfileListItem {
   export function isa(o: any): o is MissionProfileListItem {
-    return _smithy.isa(o, "MissionProfileListItem");
+    return __isa(o, "MissionProfileListItem");
   }
 }
 
@@ -1238,7 +1241,7 @@ export interface ReserveContactRequest {
 
 export namespace ReserveContactRequest {
   export function isa(o: any): o is ReserveContactRequest {
-    return _smithy.isa(o, "ReserveContactRequest");
+    return __isa(o, "ReserveContactRequest");
   }
 }
 
@@ -1256,7 +1259,7 @@ export interface TrackingConfig {
 
 export namespace TrackingConfig {
   export function isa(o: any): o is TrackingConfig {
-    return _smithy.isa(o, "TrackingConfig");
+    return __isa(o, "TrackingConfig");
   }
 }
 
@@ -1288,7 +1291,7 @@ export interface UpdateConfigRequest {
 
 export namespace UpdateConfigRequest {
   export function isa(o: any): o is UpdateConfigRequest {
-    return _smithy.isa(o, "UpdateConfigRequest");
+    return __isa(o, "UpdateConfigRequest");
   }
 }
 
@@ -1336,7 +1339,7 @@ export interface UpdateMissionProfileRequest {
 
 export namespace UpdateMissionProfileRequest {
   export function isa(o: any): o is UpdateMissionProfileRequest {
-    return _smithy.isa(o, "UpdateMissionProfileRequest");
+    return __isa(o, "UpdateMissionProfileRequest");
   }
 }
 
@@ -1361,7 +1364,7 @@ export interface UplinkEchoConfig {
 
 export namespace UplinkEchoConfig {
   export function isa(o: any): o is UplinkEchoConfig {
-    return _smithy.isa(o, "UplinkEchoConfig");
+    return __isa(o, "UplinkEchoConfig");
   }
 }
 
@@ -1409,7 +1412,7 @@ export enum Criticality {
  * <p>Dependency encountered an error.</p>
  */
 export interface DependencyException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DependencyException";
   $fault: "server";
@@ -1422,7 +1425,7 @@ export interface DependencyException
 
 export namespace DependencyException {
   export function isa(o: any): o is DependencyException {
-    return _smithy.isa(o, "DependencyException");
+    return __isa(o, "DependencyException");
   }
 }
 
@@ -1444,7 +1447,7 @@ export interface Eirp {
 
 export namespace Eirp {
   export function isa(o: any): o is Eirp {
-    return _smithy.isa(o, "Eirp");
+    return __isa(o, "Eirp");
   }
 }
 
@@ -1470,7 +1473,7 @@ export interface Elevation {
 
 export namespace Elevation {
   export function isa(o: any): o is Elevation {
-    return _smithy.isa(o, "Elevation");
+    return __isa(o, "Elevation");
   }
 }
 
@@ -1492,7 +1495,7 @@ export interface Frequency {
 
 export namespace Frequency {
   export function isa(o: any): o is Frequency {
-    return _smithy.isa(o, "Frequency");
+    return __isa(o, "Frequency");
   }
 }
 
@@ -1514,7 +1517,7 @@ export interface FrequencyBandwidth {
 
 export namespace FrequencyBandwidth {
   export function isa(o: any): o is FrequencyBandwidth {
-    return _smithy.isa(o, "FrequencyBandwidth");
+    return __isa(o, "FrequencyBandwidth");
   }
 }
 
@@ -1542,7 +1545,7 @@ export interface GetMinuteUsageRequest {
 
 export namespace GetMinuteUsageRequest {
   export function isa(o: any): o is GetMinuteUsageRequest {
-    return _smithy.isa(o, "GetMinuteUsageRequest");
+    return __isa(o, "GetMinuteUsageRequest");
   }
 }
 
@@ -1579,7 +1582,7 @@ export interface GetMinuteUsageResponse extends $MetadataBearer {
 
 export namespace GetMinuteUsageResponse {
   export function isa(o: any): o is GetMinuteUsageResponse {
-    return _smithy.isa(o, "GetMinuteUsageResponse");
+    return __isa(o, "GetMinuteUsageResponse");
   }
 }
 
@@ -1596,7 +1599,7 @@ export interface GetSatelliteRequest {
 
 export namespace GetSatelliteRequest {
   export function isa(o: any): o is GetSatelliteRequest {
-    return _smithy.isa(o, "GetSatelliteRequest");
+    return __isa(o, "GetSatelliteRequest");
   }
 }
 
@@ -1638,7 +1641,7 @@ export interface GetSatelliteResponse extends $MetadataBearer {
 
 export namespace GetSatelliteResponse {
   export function isa(o: any): o is GetSatelliteResponse {
-    return _smithy.isa(o, "GetSatelliteResponse");
+    return __isa(o, "GetSatelliteResponse");
   }
 }
 
@@ -1665,7 +1668,7 @@ export interface GroundStationData {
 
 export namespace GroundStationData {
   export function isa(o: any): o is GroundStationData {
-    return _smithy.isa(o, "GroundStationData");
+    return __isa(o, "GroundStationData");
   }
 }
 
@@ -1673,7 +1676,7 @@ export namespace GroundStationData {
  * <p>One or more parameters are not valid.</p>
  */
 export interface InvalidParameterException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidParameterException";
   $fault: "client";
@@ -1686,7 +1689,7 @@ export interface InvalidParameterException
 
 export namespace InvalidParameterException {
   export function isa(o: any): o is InvalidParameterException {
-    return _smithy.isa(o, "InvalidParameterException");
+    return __isa(o, "InvalidParameterException");
   }
 }
 
@@ -1708,7 +1711,7 @@ export interface ListGroundStationsRequest {
 
 export namespace ListGroundStationsRequest {
   export function isa(o: any): o is ListGroundStationsRequest {
-    return _smithy.isa(o, "ListGroundStationsRequest");
+    return __isa(o, "ListGroundStationsRequest");
   }
 }
 
@@ -1730,7 +1733,7 @@ export interface ListGroundStationsResponse extends $MetadataBearer {
 
 export namespace ListGroundStationsResponse {
   export function isa(o: any): o is ListGroundStationsResponse {
-    return _smithy.isa(o, "ListGroundStationsResponse");
+    return __isa(o, "ListGroundStationsResponse");
   }
 }
 
@@ -1752,7 +1755,7 @@ export interface ListSatellitesRequest {
 
 export namespace ListSatellitesRequest {
   export function isa(o: any): o is ListSatellitesRequest {
-    return _smithy.isa(o, "ListSatellitesRequest");
+    return __isa(o, "ListSatellitesRequest");
   }
 }
 
@@ -1774,7 +1777,7 @@ export interface ListSatellitesResponse extends $MetadataBearer {
 
 export namespace ListSatellitesResponse {
   export function isa(o: any): o is ListSatellitesResponse {
-    return _smithy.isa(o, "ListSatellitesResponse");
+    return __isa(o, "ListSatellitesResponse");
   }
 }
 
@@ -1791,7 +1794,7 @@ export interface ListTagsForResourceRequest {
 
 export namespace ListTagsForResourceRequest {
   export function isa(o: any): o is ListTagsForResourceRequest {
-    return _smithy.isa(o, "ListTagsForResourceRequest");
+    return __isa(o, "ListTagsForResourceRequest");
   }
 }
 
@@ -1808,7 +1811,7 @@ export interface ListTagsForResourceResponse extends $MetadataBearer {
 
 export namespace ListTagsForResourceResponse {
   export function isa(o: any): o is ListTagsForResourceResponse {
-    return _smithy.isa(o, "ListTagsForResourceResponse");
+    return __isa(o, "ListTagsForResourceResponse");
   }
 }
 
@@ -1822,7 +1825,7 @@ export enum Polarization {
  * <p>Resource was not found.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -1831,7 +1834,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -1858,7 +1861,7 @@ export interface SatelliteListItem {
 
 export namespace SatelliteListItem {
   export function isa(o: any): o is SatelliteListItem {
-    return _smithy.isa(o, "SatelliteListItem");
+    return __isa(o, "SatelliteListItem");
   }
 }
 
@@ -1885,7 +1888,7 @@ export interface SecurityDetails {
 
 export namespace SecurityDetails {
   export function isa(o: any): o is SecurityDetails {
-    return _smithy.isa(o, "SecurityDetails");
+    return __isa(o, "SecurityDetails");
   }
 }
 
@@ -1907,7 +1910,7 @@ export interface SocketAddress {
 
 export namespace SocketAddress {
   export function isa(o: any): o is SocketAddress {
-    return _smithy.isa(o, "SocketAddress");
+    return __isa(o, "SocketAddress");
   }
 }
 
@@ -1934,7 +1937,7 @@ export interface SpectrumConfig {
 
 export namespace SpectrumConfig {
   export function isa(o: any): o is SpectrumConfig {
-    return _smithy.isa(o, "SpectrumConfig");
+    return __isa(o, "SpectrumConfig");
   }
 }
 
@@ -1956,7 +1959,7 @@ export interface TagResourceRequest {
 
 export namespace TagResourceRequest {
   export function isa(o: any): o is TagResourceRequest {
-    return _smithy.isa(o, "TagResourceRequest");
+    return __isa(o, "TagResourceRequest");
   }
 }
 
@@ -1969,7 +1972,7 @@ export interface TagResourceResponse extends $MetadataBearer {
 
 export namespace TagResourceResponse {
   export function isa(o: any): o is TagResourceResponse {
-    return _smithy.isa(o, "TagResourceResponse");
+    return __isa(o, "TagResourceResponse");
   }
 }
 
@@ -1991,7 +1994,7 @@ export interface UntagResourceRequest {
 
 export namespace UntagResourceRequest {
   export function isa(o: any): o is UntagResourceRequest {
-    return _smithy.isa(o, "UntagResourceRequest");
+    return __isa(o, "UntagResourceRequest");
   }
 }
 
@@ -2004,7 +2007,7 @@ export interface UntagResourceResponse extends $MetadataBearer {
 
 export namespace UntagResourceResponse {
   export function isa(o: any): o is UntagResourceResponse {
-    return _smithy.isa(o, "UntagResourceResponse");
+    return __isa(o, "UntagResourceResponse");
   }
 }
 
@@ -2026,6 +2029,6 @@ export interface UplinkSpectrumConfig {
 
 export namespace UplinkSpectrumConfig {
   export function isa(o: any): o is UplinkSpectrumConfig {
-    return _smithy.isa(o, "UplinkSpectrumConfig");
+    return __isa(o, "UplinkSpectrumConfig");
   }
 }

--- a/clients/client-groundstation/protocols/Aws_restJson1_1.ts
+++ b/clients/client-groundstation/protocols/Aws_restJson1_1.ts
@@ -133,7 +133,10 @@ import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  extendedEncodeURIComponent as __extendedEncodeURIComponent
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -149,13 +152,13 @@ export async function serializeAws_restJson1_1CancelContactCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/contact/{contactId}";
   if (input.contactId !== undefined) {
-    const labelValue: string = input.contactId.toString();
+    const labelValue: string = input.contactId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: contactId.");
     }
     resolvedPath = resolvedPath.replace(
       "{contactId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: contactId.");
@@ -285,25 +288,25 @@ export async function serializeAws_restJson1_1DeleteConfigCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/config/{configType}/{configId}";
   if (input.configId !== undefined) {
-    const labelValue: string = input.configId.toString();
+    const labelValue: string = input.configId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: configId.");
     }
     resolvedPath = resolvedPath.replace(
       "{configId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: configId.");
   }
   if (input.configType !== undefined) {
-    const labelValue: string = input.configType.toString();
+    const labelValue: string = input.configType;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: configType.");
     }
     resolvedPath = resolvedPath.replace(
       "{configType}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: configType.");
@@ -325,7 +328,7 @@ export async function serializeAws_restJson1_1DeleteDataflowEndpointGroupCommand
   headers["Content-Type"] = "";
   let resolvedPath = "/dataflowEndpointGroup/{dataflowEndpointGroupId}";
   if (input.dataflowEndpointGroupId !== undefined) {
-    const labelValue: string = input.dataflowEndpointGroupId.toString();
+    const labelValue: string = input.dataflowEndpointGroupId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: dataflowEndpointGroupId."
@@ -333,7 +336,7 @@ export async function serializeAws_restJson1_1DeleteDataflowEndpointGroupCommand
     }
     resolvedPath = resolvedPath.replace(
       "{dataflowEndpointGroupId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -357,7 +360,7 @@ export async function serializeAws_restJson1_1DeleteMissionProfileCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/missionprofile/{missionProfileId}";
   if (input.missionProfileId !== undefined) {
-    const labelValue: string = input.missionProfileId.toString();
+    const labelValue: string = input.missionProfileId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: missionProfileId."
@@ -365,7 +368,7 @@ export async function serializeAws_restJson1_1DeleteMissionProfileCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{missionProfileId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -389,13 +392,13 @@ export async function serializeAws_restJson1_1DescribeContactCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/contact/{contactId}";
   if (input.contactId !== undefined) {
-    const labelValue: string = input.contactId.toString();
+    const labelValue: string = input.contactId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: contactId.");
     }
     resolvedPath = resolvedPath.replace(
       "{contactId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: contactId.");
@@ -417,25 +420,25 @@ export async function serializeAws_restJson1_1GetConfigCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/config/{configType}/{configId}";
   if (input.configId !== undefined) {
-    const labelValue: string = input.configId.toString();
+    const labelValue: string = input.configId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: configId.");
     }
     resolvedPath = resolvedPath.replace(
       "{configId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: configId.");
   }
   if (input.configType !== undefined) {
-    const labelValue: string = input.configType.toString();
+    const labelValue: string = input.configType;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: configType.");
     }
     resolvedPath = resolvedPath.replace(
       "{configType}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: configType.");
@@ -457,7 +460,7 @@ export async function serializeAws_restJson1_1GetDataflowEndpointGroupCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/dataflowEndpointGroup/{dataflowEndpointGroupId}";
   if (input.dataflowEndpointGroupId !== undefined) {
-    const labelValue: string = input.dataflowEndpointGroupId.toString();
+    const labelValue: string = input.dataflowEndpointGroupId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: dataflowEndpointGroupId."
@@ -465,7 +468,7 @@ export async function serializeAws_restJson1_1GetDataflowEndpointGroupCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{dataflowEndpointGroupId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -489,7 +492,7 @@ export async function serializeAws_restJson1_1GetMissionProfileCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/missionprofile/{missionProfileId}";
   if (input.missionProfileId !== undefined) {
-    const labelValue: string = input.missionProfileId.toString();
+    const labelValue: string = input.missionProfileId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: missionProfileId."
@@ -497,7 +500,7 @@ export async function serializeAws_restJson1_1GetMissionProfileCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{missionProfileId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -522,10 +525,14 @@ export async function serializeAws_restJson1_1ListConfigsCommand(
   let resolvedPath = "/config";
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -593,10 +600,14 @@ export async function serializeAws_restJson1_1ListDataflowEndpointGroupsCommand(
   let resolvedPath = "/dataflowEndpointGroup";
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -617,10 +628,14 @@ export async function serializeAws_restJson1_1ListMissionProfilesCommand(
   let resolvedPath = "/missionprofile";
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -678,25 +693,25 @@ export async function serializeAws_restJson1_1UpdateConfigCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/config/{configType}/{configId}";
   if (input.configId !== undefined) {
-    const labelValue: string = input.configId.toString();
+    const labelValue: string = input.configId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: configId.");
     }
     resolvedPath = resolvedPath.replace(
       "{configId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: configId.");
   }
   if (input.configType !== undefined) {
-    const labelValue: string = input.configType.toString();
+    const labelValue: string = input.configType;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: configType.");
     }
     resolvedPath = resolvedPath.replace(
       "{configType}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: configType.");
@@ -731,7 +746,7 @@ export async function serializeAws_restJson1_1UpdateMissionProfileCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/missionprofile/{missionProfileId}";
   if (input.missionProfileId !== undefined) {
-    const labelValue: string = input.missionProfileId.toString();
+    const labelValue: string = input.missionProfileId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: missionProfileId."
@@ -739,7 +754,7 @@ export async function serializeAws_restJson1_1UpdateMissionProfileCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{missionProfileId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -817,7 +832,7 @@ export async function serializeAws_restJson1_1GetSatelliteCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/satellite/{satelliteId}";
   if (input.satelliteId !== undefined) {
-    const labelValue: string = input.satelliteId.toString();
+    const labelValue: string = input.satelliteId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: satelliteId."
@@ -825,7 +840,7 @@ export async function serializeAws_restJson1_1GetSatelliteCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{satelliteId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: satelliteId.");
@@ -848,10 +863,14 @@ export async function serializeAws_restJson1_1ListGroundStationsCommand(
   let resolvedPath = "/groundstation";
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -872,10 +891,14 @@ export async function serializeAws_restJson1_1ListSatellitesCommand(
   let resolvedPath = "/satellite";
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -895,7 +918,7 @@ export async function serializeAws_restJson1_1ListTagsForResourceCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/tags/{resourceArn}";
   if (input.resourceArn !== undefined) {
-    const labelValue: string = input.resourceArn.toString();
+    const labelValue: string = input.resourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: resourceArn."
@@ -903,7 +926,7 @@ export async function serializeAws_restJson1_1ListTagsForResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{resourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: resourceArn.");
@@ -925,7 +948,7 @@ export async function serializeAws_restJson1_1TagResourceCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/tags/{resourceArn}";
   if (input.resourceArn !== undefined) {
-    const labelValue: string = input.resourceArn.toString();
+    const labelValue: string = input.resourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: resourceArn."
@@ -933,7 +956,7 @@ export async function serializeAws_restJson1_1TagResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{resourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: resourceArn.");
@@ -962,7 +985,7 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/tags/{resourceArn}";
   if (input.resourceArn !== undefined) {
-    const labelValue: string = input.resourceArn.toString();
+    const labelValue: string = input.resourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: resourceArn."
@@ -970,14 +993,16 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{resourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: resourceArn.");
   }
   const query: any = {};
   if (input.tagKeys !== undefined) {
-    query["tagKeys"] = input.tagKeys;
+    query[__extendedEncodeURIComponent("tagKeys")] = input.tagKeys.map(entry =>
+      __extendedEncodeURIComponent(entry)
+    );
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2860,6 +2885,7 @@ export async function deserializeAws_restJson1_1TagResourceCommand(
     $metadata: deserializeMetadata(output),
     __type: "TagResourceResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2922,6 +2948,7 @@ export async function deserializeAws_restJson1_1UntagResourceCommand(
     $metadata: deserializeMetadata(output),
     __type: "UntagResourceResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 

--- a/clients/client-guardduty/models/index.ts
+++ b/clients/client-guardduty/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export interface AcceptInvitationRequest {
@@ -21,7 +24,7 @@ export interface AcceptInvitationRequest {
 
 export namespace AcceptInvitationRequest {
   export function isa(o: any): o is AcceptInvitationRequest {
-    return _smithy.isa(o, "AcceptInvitationRequest");
+    return __isa(o, "AcceptInvitationRequest");
   }
 }
 
@@ -31,7 +34,7 @@ export interface AcceptInvitationResponse extends $MetadataBearer {
 
 export namespace AcceptInvitationResponse {
   export function isa(o: any): o is AcceptInvitationResponse {
-    return _smithy.isa(o, "AcceptInvitationResponse");
+    return __isa(o, "AcceptInvitationResponse");
   }
 }
 
@@ -63,7 +66,7 @@ export interface AccessKeyDetails {
 
 export namespace AccessKeyDetails {
   export function isa(o: any): o is AccessKeyDetails {
-    return _smithy.isa(o, "AccessKeyDetails");
+    return __isa(o, "AccessKeyDetails");
   }
 }
 
@@ -85,7 +88,7 @@ export interface AccountDetail {
 
 export namespace AccountDetail {
   export function isa(o: any): o is AccountDetail {
-    return _smithy.isa(o, "AccountDetail");
+    return __isa(o, "AccountDetail");
   }
 }
 
@@ -122,7 +125,7 @@ export interface Action {
 
 export namespace Action {
   export function isa(o: any): o is Action {
-    return _smithy.isa(o, "Action");
+    return __isa(o, "Action");
   }
 }
 
@@ -142,7 +145,7 @@ export interface ArchiveFindingsRequest {
 
 export namespace ArchiveFindingsRequest {
   export function isa(o: any): o is ArchiveFindingsRequest {
-    return _smithy.isa(o, "ArchiveFindingsRequest");
+    return __isa(o, "ArchiveFindingsRequest");
   }
 }
 
@@ -152,7 +155,7 @@ export interface ArchiveFindingsResponse extends $MetadataBearer {
 
 export namespace ArchiveFindingsResponse {
   export function isa(o: any): o is ArchiveFindingsResponse {
-    return _smithy.isa(o, "ArchiveFindingsResponse");
+    return __isa(o, "ArchiveFindingsResponse");
   }
 }
 
@@ -189,7 +192,7 @@ export interface AwsApiCallAction {
 
 export namespace AwsApiCallAction {
   export function isa(o: any): o is AwsApiCallAction {
-    return _smithy.isa(o, "AwsApiCallAction");
+    return __isa(o, "AwsApiCallAction");
   }
 }
 
@@ -197,7 +200,7 @@ export namespace AwsApiCallAction {
  * <p>Bad request exception object.</p>
  */
 export interface BadRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "BadRequestException";
   $fault: "client";
@@ -214,7 +217,7 @@ export interface BadRequestException
 
 export namespace BadRequestException {
   export function isa(o: any): o is BadRequestException {
-    return _smithy.isa(o, "BadRequestException");
+    return __isa(o, "BadRequestException");
   }
 }
 
@@ -231,7 +234,7 @@ export interface City {
 
 export namespace City {
   export function isa(o: any): o is City {
-    return _smithy.isa(o, "City");
+    return __isa(o, "City");
   }
 }
 
@@ -315,7 +318,7 @@ export interface Condition {
 
 export namespace Condition {
   export function isa(o: any): o is Condition {
-    return _smithy.isa(o, "Condition");
+    return __isa(o, "Condition");
   }
 }
 
@@ -337,7 +340,7 @@ export interface Country {
 
 export namespace Country {
   export function isa(o: any): o is Country {
-    return _smithy.isa(o, "Country");
+    return __isa(o, "Country");
   }
 }
 
@@ -366,7 +369,7 @@ export interface CreateDetectorRequest {
 
 export namespace CreateDetectorRequest {
   export function isa(o: any): o is CreateDetectorRequest {
-    return _smithy.isa(o, "CreateDetectorRequest");
+    return __isa(o, "CreateDetectorRequest");
   }
 }
 
@@ -380,7 +383,7 @@ export interface CreateDetectorResponse extends $MetadataBearer {
 
 export namespace CreateDetectorResponse {
   export function isa(o: any): o is CreateDetectorResponse {
-    return _smithy.isa(o, "CreateDetectorResponse");
+    return __isa(o, "CreateDetectorResponse");
   }
 }
 
@@ -431,7 +434,7 @@ export interface CreateFilterRequest {
 
 export namespace CreateFilterRequest {
   export function isa(o: any): o is CreateFilterRequest {
-    return _smithy.isa(o, "CreateFilterRequest");
+    return __isa(o, "CreateFilterRequest");
   }
 }
 
@@ -445,7 +448,7 @@ export interface CreateFilterResponse extends $MetadataBearer {
 
 export namespace CreateFilterResponse {
   export function isa(o: any): o is CreateFilterResponse {
-    return _smithy.isa(o, "CreateFilterResponse");
+    return __isa(o, "CreateFilterResponse");
   }
 }
 
@@ -493,7 +496,7 @@ export interface CreateIPSetRequest {
 
 export namespace CreateIPSetRequest {
   export function isa(o: any): o is CreateIPSetRequest {
-    return _smithy.isa(o, "CreateIPSetRequest");
+    return __isa(o, "CreateIPSetRequest");
   }
 }
 
@@ -507,7 +510,7 @@ export interface CreateIPSetResponse extends $MetadataBearer {
 
 export namespace CreateIPSetResponse {
   export function isa(o: any): o is CreateIPSetResponse {
-    return _smithy.isa(o, "CreateIPSetResponse");
+    return __isa(o, "CreateIPSetResponse");
   }
 }
 
@@ -528,7 +531,7 @@ export interface CreateMembersRequest {
 
 export namespace CreateMembersRequest {
   export function isa(o: any): o is CreateMembersRequest {
-    return _smithy.isa(o, "CreateMembersRequest");
+    return __isa(o, "CreateMembersRequest");
   }
 }
 
@@ -543,7 +546,7 @@ export interface CreateMembersResponse extends $MetadataBearer {
 
 export namespace CreateMembersResponse {
   export function isa(o: any): o is CreateMembersResponse {
-    return _smithy.isa(o, "CreateMembersResponse");
+    return __isa(o, "CreateMembersResponse");
   }
 }
 
@@ -574,7 +577,7 @@ export interface CreatePublishingDestinationRequest {
 
 export namespace CreatePublishingDestinationRequest {
   export function isa(o: any): o is CreatePublishingDestinationRequest {
-    return _smithy.isa(o, "CreatePublishingDestinationRequest");
+    return __isa(o, "CreatePublishingDestinationRequest");
   }
 }
 
@@ -588,7 +591,7 @@ export interface CreatePublishingDestinationResponse extends $MetadataBearer {
 
 export namespace CreatePublishingDestinationResponse {
   export function isa(o: any): o is CreatePublishingDestinationResponse {
-    return _smithy.isa(o, "CreatePublishingDestinationResponse");
+    return __isa(o, "CreatePublishingDestinationResponse");
   }
 }
 
@@ -607,7 +610,7 @@ export interface CreateSampleFindingsRequest {
 
 export namespace CreateSampleFindingsRequest {
   export function isa(o: any): o is CreateSampleFindingsRequest {
-    return _smithy.isa(o, "CreateSampleFindingsRequest");
+    return __isa(o, "CreateSampleFindingsRequest");
   }
 }
 
@@ -617,7 +620,7 @@ export interface CreateSampleFindingsResponse extends $MetadataBearer {
 
 export namespace CreateSampleFindingsResponse {
   export function isa(o: any): o is CreateSampleFindingsResponse {
-    return _smithy.isa(o, "CreateSampleFindingsResponse");
+    return __isa(o, "CreateSampleFindingsResponse");
   }
 }
 
@@ -665,7 +668,7 @@ export interface CreateThreatIntelSetRequest {
 
 export namespace CreateThreatIntelSetRequest {
   export function isa(o: any): o is CreateThreatIntelSetRequest {
-    return _smithy.isa(o, "CreateThreatIntelSetRequest");
+    return __isa(o, "CreateThreatIntelSetRequest");
   }
 }
 
@@ -679,7 +682,7 @@ export interface CreateThreatIntelSetResponse extends $MetadataBearer {
 
 export namespace CreateThreatIntelSetResponse {
   export function isa(o: any): o is CreateThreatIntelSetResponse {
-    return _smithy.isa(o, "CreateThreatIntelSetResponse");
+    return __isa(o, "CreateThreatIntelSetResponse");
   }
 }
 
@@ -694,7 +697,7 @@ export interface DeclineInvitationsRequest {
 
 export namespace DeclineInvitationsRequest {
   export function isa(o: any): o is DeclineInvitationsRequest {
-    return _smithy.isa(o, "DeclineInvitationsRequest");
+    return __isa(o, "DeclineInvitationsRequest");
   }
 }
 
@@ -709,7 +712,7 @@ export interface DeclineInvitationsResponse extends $MetadataBearer {
 
 export namespace DeclineInvitationsResponse {
   export function isa(o: any): o is DeclineInvitationsResponse {
-    return _smithy.isa(o, "DeclineInvitationsResponse");
+    return __isa(o, "DeclineInvitationsResponse");
   }
 }
 
@@ -723,7 +726,7 @@ export interface DeleteDetectorRequest {
 
 export namespace DeleteDetectorRequest {
   export function isa(o: any): o is DeleteDetectorRequest {
-    return _smithy.isa(o, "DeleteDetectorRequest");
+    return __isa(o, "DeleteDetectorRequest");
   }
 }
 
@@ -733,7 +736,7 @@ export interface DeleteDetectorResponse extends $MetadataBearer {
 
 export namespace DeleteDetectorResponse {
   export function isa(o: any): o is DeleteDetectorResponse {
-    return _smithy.isa(o, "DeleteDetectorResponse");
+    return __isa(o, "DeleteDetectorResponse");
   }
 }
 
@@ -752,7 +755,7 @@ export interface DeleteFilterRequest {
 
 export namespace DeleteFilterRequest {
   export function isa(o: any): o is DeleteFilterRequest {
-    return _smithy.isa(o, "DeleteFilterRequest");
+    return __isa(o, "DeleteFilterRequest");
   }
 }
 
@@ -762,7 +765,7 @@ export interface DeleteFilterResponse extends $MetadataBearer {
 
 export namespace DeleteFilterResponse {
   export function isa(o: any): o is DeleteFilterResponse {
-    return _smithy.isa(o, "DeleteFilterResponse");
+    return __isa(o, "DeleteFilterResponse");
   }
 }
 
@@ -781,7 +784,7 @@ export interface DeleteIPSetRequest {
 
 export namespace DeleteIPSetRequest {
   export function isa(o: any): o is DeleteIPSetRequest {
-    return _smithy.isa(o, "DeleteIPSetRequest");
+    return __isa(o, "DeleteIPSetRequest");
   }
 }
 
@@ -791,7 +794,7 @@ export interface DeleteIPSetResponse extends $MetadataBearer {
 
 export namespace DeleteIPSetResponse {
   export function isa(o: any): o is DeleteIPSetResponse {
-    return _smithy.isa(o, "DeleteIPSetResponse");
+    return __isa(o, "DeleteIPSetResponse");
   }
 }
 
@@ -806,7 +809,7 @@ export interface DeleteInvitationsRequest {
 
 export namespace DeleteInvitationsRequest {
   export function isa(o: any): o is DeleteInvitationsRequest {
-    return _smithy.isa(o, "DeleteInvitationsRequest");
+    return __isa(o, "DeleteInvitationsRequest");
   }
 }
 
@@ -821,7 +824,7 @@ export interface DeleteInvitationsResponse extends $MetadataBearer {
 
 export namespace DeleteInvitationsResponse {
   export function isa(o: any): o is DeleteInvitationsResponse {
-    return _smithy.isa(o, "DeleteInvitationsResponse");
+    return __isa(o, "DeleteInvitationsResponse");
   }
 }
 
@@ -841,7 +844,7 @@ export interface DeleteMembersRequest {
 
 export namespace DeleteMembersRequest {
   export function isa(o: any): o is DeleteMembersRequest {
-    return _smithy.isa(o, "DeleteMembersRequest");
+    return __isa(o, "DeleteMembersRequest");
   }
 }
 
@@ -855,7 +858,7 @@ export interface DeleteMembersResponse extends $MetadataBearer {
 
 export namespace DeleteMembersResponse {
   export function isa(o: any): o is DeleteMembersResponse {
-    return _smithy.isa(o, "DeleteMembersResponse");
+    return __isa(o, "DeleteMembersResponse");
   }
 }
 
@@ -874,7 +877,7 @@ export interface DeletePublishingDestinationRequest {
 
 export namespace DeletePublishingDestinationRequest {
   export function isa(o: any): o is DeletePublishingDestinationRequest {
-    return _smithy.isa(o, "DeletePublishingDestinationRequest");
+    return __isa(o, "DeletePublishingDestinationRequest");
   }
 }
 
@@ -884,7 +887,7 @@ export interface DeletePublishingDestinationResponse extends $MetadataBearer {
 
 export namespace DeletePublishingDestinationResponse {
   export function isa(o: any): o is DeletePublishingDestinationResponse {
-    return _smithy.isa(o, "DeletePublishingDestinationResponse");
+    return __isa(o, "DeletePublishingDestinationResponse");
   }
 }
 
@@ -903,7 +906,7 @@ export interface DeleteThreatIntelSetRequest {
 
 export namespace DeleteThreatIntelSetRequest {
   export function isa(o: any): o is DeleteThreatIntelSetRequest {
-    return _smithy.isa(o, "DeleteThreatIntelSetRequest");
+    return __isa(o, "DeleteThreatIntelSetRequest");
   }
 }
 
@@ -913,7 +916,7 @@ export interface DeleteThreatIntelSetResponse extends $MetadataBearer {
 
 export namespace DeleteThreatIntelSetResponse {
   export function isa(o: any): o is DeleteThreatIntelSetResponse {
-    return _smithy.isa(o, "DeleteThreatIntelSetResponse");
+    return __isa(o, "DeleteThreatIntelSetResponse");
   }
 }
 
@@ -933,7 +936,7 @@ export interface DescribePublishingDestinationRequest {
 
 export namespace DescribePublishingDestinationRequest {
   export function isa(o: any): o is DescribePublishingDestinationRequest {
-    return _smithy.isa(o, "DescribePublishingDestinationRequest");
+    return __isa(o, "DescribePublishingDestinationRequest");
   }
 }
 
@@ -969,7 +972,7 @@ export interface DescribePublishingDestinationResponse extends $MetadataBearer {
 
 export namespace DescribePublishingDestinationResponse {
   export function isa(o: any): o is DescribePublishingDestinationResponse {
-    return _smithy.isa(o, "DescribePublishingDestinationResponse");
+    return __isa(o, "DescribePublishingDestinationResponse");
   }
 }
 
@@ -997,7 +1000,7 @@ export interface Destination {
 
 export namespace Destination {
   export function isa(o: any): o is Destination {
-    return _smithy.isa(o, "Destination");
+    return __isa(o, "Destination");
   }
 }
 
@@ -1020,7 +1023,7 @@ export interface DestinationProperties {
 
 export namespace DestinationProperties {
   export function isa(o: any): o is DestinationProperties {
-    return _smithy.isa(o, "DestinationProperties");
+    return __isa(o, "DestinationProperties");
   }
 }
 
@@ -1043,7 +1046,7 @@ export interface DisassociateFromMasterAccountRequest {
 
 export namespace DisassociateFromMasterAccountRequest {
   export function isa(o: any): o is DisassociateFromMasterAccountRequest {
-    return _smithy.isa(o, "DisassociateFromMasterAccountRequest");
+    return __isa(o, "DisassociateFromMasterAccountRequest");
   }
 }
 
@@ -1053,7 +1056,7 @@ export interface DisassociateFromMasterAccountResponse extends $MetadataBearer {
 
 export namespace DisassociateFromMasterAccountResponse {
   export function isa(o: any): o is DisassociateFromMasterAccountResponse {
-    return _smithy.isa(o, "DisassociateFromMasterAccountResponse");
+    return __isa(o, "DisassociateFromMasterAccountResponse");
   }
 }
 
@@ -1074,7 +1077,7 @@ export interface DisassociateMembersRequest {
 
 export namespace DisassociateMembersRequest {
   export function isa(o: any): o is DisassociateMembersRequest {
-    return _smithy.isa(o, "DisassociateMembersRequest");
+    return __isa(o, "DisassociateMembersRequest");
   }
 }
 
@@ -1089,7 +1092,7 @@ export interface DisassociateMembersResponse extends $MetadataBearer {
 
 export namespace DisassociateMembersResponse {
   export function isa(o: any): o is DisassociateMembersResponse {
-    return _smithy.isa(o, "DisassociateMembersResponse");
+    return __isa(o, "DisassociateMembersResponse");
   }
 }
 
@@ -1106,7 +1109,7 @@ export interface DnsRequestAction {
 
 export namespace DnsRequestAction {
   export function isa(o: any): o is DnsRequestAction {
-    return _smithy.isa(o, "DnsRequestAction");
+    return __isa(o, "DnsRequestAction");
   }
 }
 
@@ -1123,7 +1126,7 @@ export interface DomainDetails {
 
 export namespace DomainDetails {
   export function isa(o: any): o is DomainDetails {
-    return _smithy.isa(o, "DomainDetails");
+    return __isa(o, "DomainDetails");
   }
 }
 
@@ -1140,7 +1143,7 @@ export interface Evidence {
 
 export namespace Evidence {
   export function isa(o: any): o is Evidence {
-    return _smithy.isa(o, "Evidence");
+    return __isa(o, "Evidence");
   }
 }
 
@@ -1239,7 +1242,7 @@ export interface Finding {
 
 export namespace Finding {
   export function isa(o: any): o is Finding {
-    return _smithy.isa(o, "Finding");
+    return __isa(o, "Finding");
   }
 }
 
@@ -1257,7 +1260,7 @@ export interface FindingCriteria {
 
 export namespace FindingCriteria {
   export function isa(o: any): o is FindingCriteria {
-    return _smithy.isa(o, "FindingCriteria");
+    return __isa(o, "FindingCriteria");
   }
 }
 
@@ -1284,7 +1287,7 @@ export interface FindingStatistics {
 
 export namespace FindingStatistics {
   export function isa(o: any): o is FindingStatistics {
-    return _smithy.isa(o, "FindingStatistics");
+    return __isa(o, "FindingStatistics");
   }
 }
 
@@ -1306,7 +1309,7 @@ export interface GeoLocation {
 
 export namespace GeoLocation {
   export function isa(o: any): o is GeoLocation {
-    return _smithy.isa(o, "GeoLocation");
+    return __isa(o, "GeoLocation");
   }
 }
 
@@ -1320,7 +1323,7 @@ export interface GetDetectorRequest {
 
 export namespace GetDetectorRequest {
   export function isa(o: any): o is GetDetectorRequest {
-    return _smithy.isa(o, "GetDetectorRequest");
+    return __isa(o, "GetDetectorRequest");
   }
 }
 
@@ -1359,7 +1362,7 @@ export interface GetDetectorResponse extends $MetadataBearer {
 
 export namespace GetDetectorResponse {
   export function isa(o: any): o is GetDetectorResponse {
-    return _smithy.isa(o, "GetDetectorResponse");
+    return __isa(o, "GetDetectorResponse");
   }
 }
 
@@ -1378,7 +1381,7 @@ export interface GetFilterRequest {
 
 export namespace GetFilterRequest {
   export function isa(o: any): o is GetFilterRequest {
-    return _smithy.isa(o, "GetFilterRequest");
+    return __isa(o, "GetFilterRequest");
   }
 }
 
@@ -1418,7 +1421,7 @@ export interface GetFilterResponse extends $MetadataBearer {
 
 export namespace GetFilterResponse {
   export function isa(o: any): o is GetFilterResponse {
-    return _smithy.isa(o, "GetFilterResponse");
+    return __isa(o, "GetFilterResponse");
   }
 }
 
@@ -1443,7 +1446,7 @@ export interface GetFindingsRequest {
 
 export namespace GetFindingsRequest {
   export function isa(o: any): o is GetFindingsRequest {
-    return _smithy.isa(o, "GetFindingsRequest");
+    return __isa(o, "GetFindingsRequest");
   }
 }
 
@@ -1457,7 +1460,7 @@ export interface GetFindingsResponse extends $MetadataBearer {
 
 export namespace GetFindingsResponse {
   export function isa(o: any): o is GetFindingsResponse {
-    return _smithy.isa(o, "GetFindingsResponse");
+    return __isa(o, "GetFindingsResponse");
   }
 }
 
@@ -1482,7 +1485,7 @@ export interface GetFindingsStatisticsRequest {
 
 export namespace GetFindingsStatisticsRequest {
   export function isa(o: any): o is GetFindingsStatisticsRequest {
-    return _smithy.isa(o, "GetFindingsStatisticsRequest");
+    return __isa(o, "GetFindingsStatisticsRequest");
   }
 }
 
@@ -1496,7 +1499,7 @@ export interface GetFindingsStatisticsResponse extends $MetadataBearer {
 
 export namespace GetFindingsStatisticsResponse {
   export function isa(o: any): o is GetFindingsStatisticsResponse {
-    return _smithy.isa(o, "GetFindingsStatisticsResponse");
+    return __isa(o, "GetFindingsStatisticsResponse");
   }
 }
 
@@ -1515,7 +1518,7 @@ export interface GetIPSetRequest {
 
 export namespace GetIPSetRequest {
   export function isa(o: any): o is GetIPSetRequest {
-    return _smithy.isa(o, "GetIPSetRequest");
+    return __isa(o, "GetIPSetRequest");
   }
 }
 
@@ -1550,7 +1553,7 @@ export interface GetIPSetResponse extends $MetadataBearer {
 
 export namespace GetIPSetResponse {
   export function isa(o: any): o is GetIPSetResponse {
-    return _smithy.isa(o, "GetIPSetResponse");
+    return __isa(o, "GetIPSetResponse");
   }
 }
 
@@ -1560,7 +1563,7 @@ export interface GetInvitationsCountRequest {
 
 export namespace GetInvitationsCountRequest {
   export function isa(o: any): o is GetInvitationsCountRequest {
-    return _smithy.isa(o, "GetInvitationsCountRequest");
+    return __isa(o, "GetInvitationsCountRequest");
   }
 }
 
@@ -1574,7 +1577,7 @@ export interface GetInvitationsCountResponse extends $MetadataBearer {
 
 export namespace GetInvitationsCountResponse {
   export function isa(o: any): o is GetInvitationsCountResponse {
-    return _smithy.isa(o, "GetInvitationsCountResponse");
+    return __isa(o, "GetInvitationsCountResponse");
   }
 }
 
@@ -1588,7 +1591,7 @@ export interface GetMasterAccountRequest {
 
 export namespace GetMasterAccountRequest {
   export function isa(o: any): o is GetMasterAccountRequest {
-    return _smithy.isa(o, "GetMasterAccountRequest");
+    return __isa(o, "GetMasterAccountRequest");
   }
 }
 
@@ -1602,7 +1605,7 @@ export interface GetMasterAccountResponse extends $MetadataBearer {
 
 export namespace GetMasterAccountResponse {
   export function isa(o: any): o is GetMasterAccountResponse {
-    return _smithy.isa(o, "GetMasterAccountResponse");
+    return __isa(o, "GetMasterAccountResponse");
   }
 }
 
@@ -1622,7 +1625,7 @@ export interface GetMembersRequest {
 
 export namespace GetMembersRequest {
   export function isa(o: any): o is GetMembersRequest {
-    return _smithy.isa(o, "GetMembersRequest");
+    return __isa(o, "GetMembersRequest");
   }
 }
 
@@ -1642,7 +1645,7 @@ export interface GetMembersResponse extends $MetadataBearer {
 
 export namespace GetMembersResponse {
   export function isa(o: any): o is GetMembersResponse {
-    return _smithy.isa(o, "GetMembersResponse");
+    return __isa(o, "GetMembersResponse");
   }
 }
 
@@ -1661,7 +1664,7 @@ export interface GetThreatIntelSetRequest {
 
 export namespace GetThreatIntelSetRequest {
   export function isa(o: any): o is GetThreatIntelSetRequest {
-    return _smithy.isa(o, "GetThreatIntelSetRequest");
+    return __isa(o, "GetThreatIntelSetRequest");
   }
 }
 
@@ -1697,7 +1700,7 @@ export interface GetThreatIntelSetResponse extends $MetadataBearer {
 
 export namespace GetThreatIntelSetResponse {
   export function isa(o: any): o is GetThreatIntelSetResponse {
-    return _smithy.isa(o, "GetThreatIntelSetResponse");
+    return __isa(o, "GetThreatIntelSetResponse");
   }
 }
 
@@ -1719,7 +1722,7 @@ export interface IamInstanceProfile {
 
 export namespace IamInstanceProfile {
   export function isa(o: any): o is IamInstanceProfile {
-    return _smithy.isa(o, "IamInstanceProfile");
+    return __isa(o, "IamInstanceProfile");
   }
 }
 
@@ -1791,7 +1794,7 @@ export interface InstanceDetails {
 
 export namespace InstanceDetails {
   export function isa(o: any): o is InstanceDetails {
-    return _smithy.isa(o, "InstanceDetails");
+    return __isa(o, "InstanceDetails");
   }
 }
 
@@ -1799,7 +1802,7 @@ export namespace InstanceDetails {
  * <p>Internal server error exception object.</p>
  */
 export interface InternalServerErrorException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalServerErrorException";
   $fault: "server";
@@ -1816,7 +1819,7 @@ export interface InternalServerErrorException
 
 export namespace InternalServerErrorException {
   export function isa(o: any): o is InternalServerErrorException {
-    return _smithy.isa(o, "InternalServerErrorException");
+    return __isa(o, "InternalServerErrorException");
   }
 }
 
@@ -1849,7 +1852,7 @@ export interface Invitation {
 
 export namespace Invitation {
   export function isa(o: any): o is Invitation {
-    return _smithy.isa(o, "Invitation");
+    return __isa(o, "Invitation");
   }
 }
 
@@ -1882,7 +1885,7 @@ export interface InviteMembersRequest {
 
 export namespace InviteMembersRequest {
   export function isa(o: any): o is InviteMembersRequest {
-    return _smithy.isa(o, "InviteMembersRequest");
+    return __isa(o, "InviteMembersRequest");
   }
 }
 
@@ -1897,7 +1900,7 @@ export interface InviteMembersResponse extends $MetadataBearer {
 
 export namespace InviteMembersResponse {
   export function isa(o: any): o is InviteMembersResponse {
-    return _smithy.isa(o, "InviteMembersResponse");
+    return __isa(o, "InviteMembersResponse");
   }
 }
 
@@ -1939,7 +1942,7 @@ export interface ListDetectorsRequest {
 
 export namespace ListDetectorsRequest {
   export function isa(o: any): o is ListDetectorsRequest {
-    return _smithy.isa(o, "ListDetectorsRequest");
+    return __isa(o, "ListDetectorsRequest");
   }
 }
 
@@ -1958,7 +1961,7 @@ export interface ListDetectorsResponse extends $MetadataBearer {
 
 export namespace ListDetectorsResponse {
   export function isa(o: any): o is ListDetectorsResponse {
-    return _smithy.isa(o, "ListDetectorsResponse");
+    return __isa(o, "ListDetectorsResponse");
   }
 }
 
@@ -1986,7 +1989,7 @@ export interface ListFiltersRequest {
 
 export namespace ListFiltersRequest {
   export function isa(o: any): o is ListFiltersRequest {
-    return _smithy.isa(o, "ListFiltersRequest");
+    return __isa(o, "ListFiltersRequest");
   }
 }
 
@@ -2005,7 +2008,7 @@ export interface ListFiltersResponse extends $MetadataBearer {
 
 export namespace ListFiltersResponse {
   export function isa(o: any): o is ListFiltersResponse {
-    return _smithy.isa(o, "ListFiltersResponse");
+    return __isa(o, "ListFiltersResponse");
   }
 }
 
@@ -2200,7 +2203,7 @@ export interface ListFindingsRequest {
 
 export namespace ListFindingsRequest {
   export function isa(o: any): o is ListFindingsRequest {
-    return _smithy.isa(o, "ListFindingsRequest");
+    return __isa(o, "ListFindingsRequest");
   }
 }
 
@@ -2219,7 +2222,7 @@ export interface ListFindingsResponse extends $MetadataBearer {
 
 export namespace ListFindingsResponse {
   export function isa(o: any): o is ListFindingsResponse {
-    return _smithy.isa(o, "ListFindingsResponse");
+    return __isa(o, "ListFindingsResponse");
   }
 }
 
@@ -2247,7 +2250,7 @@ export interface ListIPSetsRequest {
 
 export namespace ListIPSetsRequest {
   export function isa(o: any): o is ListIPSetsRequest {
-    return _smithy.isa(o, "ListIPSetsRequest");
+    return __isa(o, "ListIPSetsRequest");
   }
 }
 
@@ -2266,7 +2269,7 @@ export interface ListIPSetsResponse extends $MetadataBearer {
 
 export namespace ListIPSetsResponse {
   export function isa(o: any): o is ListIPSetsResponse {
-    return _smithy.isa(o, "ListIPSetsResponse");
+    return __isa(o, "ListIPSetsResponse");
   }
 }
 
@@ -2289,7 +2292,7 @@ export interface ListInvitationsRequest {
 
 export namespace ListInvitationsRequest {
   export function isa(o: any): o is ListInvitationsRequest {
-    return _smithy.isa(o, "ListInvitationsRequest");
+    return __isa(o, "ListInvitationsRequest");
   }
 }
 
@@ -2308,7 +2311,7 @@ export interface ListInvitationsResponse extends $MetadataBearer {
 
 export namespace ListInvitationsResponse {
   export function isa(o: any): o is ListInvitationsResponse {
-    return _smithy.isa(o, "ListInvitationsResponse");
+    return __isa(o, "ListInvitationsResponse");
   }
 }
 
@@ -2342,7 +2345,7 @@ export interface ListMembersRequest {
 
 export namespace ListMembersRequest {
   export function isa(o: any): o is ListMembersRequest {
-    return _smithy.isa(o, "ListMembersRequest");
+    return __isa(o, "ListMembersRequest");
   }
 }
 
@@ -2361,7 +2364,7 @@ export interface ListMembersResponse extends $MetadataBearer {
 
 export namespace ListMembersResponse {
   export function isa(o: any): o is ListMembersResponse {
-    return _smithy.isa(o, "ListMembersResponse");
+    return __isa(o, "ListMembersResponse");
   }
 }
 
@@ -2388,7 +2391,7 @@ export interface ListPublishingDestinationsRequest {
 
 export namespace ListPublishingDestinationsRequest {
   export function isa(o: any): o is ListPublishingDestinationsRequest {
-    return _smithy.isa(o, "ListPublishingDestinationsRequest");
+    return __isa(o, "ListPublishingDestinationsRequest");
   }
 }
 
@@ -2411,7 +2414,7 @@ export interface ListPublishingDestinationsResponse extends $MetadataBearer {
 
 export namespace ListPublishingDestinationsResponse {
   export function isa(o: any): o is ListPublishingDestinationsResponse {
-    return _smithy.isa(o, "ListPublishingDestinationsResponse");
+    return __isa(o, "ListPublishingDestinationsResponse");
   }
 }
 
@@ -2425,7 +2428,7 @@ export interface ListTagsForResourceRequest {
 
 export namespace ListTagsForResourceRequest {
   export function isa(o: any): o is ListTagsForResourceRequest {
-    return _smithy.isa(o, "ListTagsForResourceRequest");
+    return __isa(o, "ListTagsForResourceRequest");
   }
 }
 
@@ -2439,7 +2442,7 @@ export interface ListTagsForResourceResponse extends $MetadataBearer {
 
 export namespace ListTagsForResourceResponse {
   export function isa(o: any): o is ListTagsForResourceResponse {
-    return _smithy.isa(o, "ListTagsForResourceResponse");
+    return __isa(o, "ListTagsForResourceResponse");
   }
 }
 
@@ -2467,7 +2470,7 @@ export interface ListThreatIntelSetsRequest {
 
 export namespace ListThreatIntelSetsRequest {
   export function isa(o: any): o is ListThreatIntelSetsRequest {
-    return _smithy.isa(o, "ListThreatIntelSetsRequest");
+    return __isa(o, "ListThreatIntelSetsRequest");
   }
 }
 
@@ -2486,7 +2489,7 @@ export interface ListThreatIntelSetsResponse extends $MetadataBearer {
 
 export namespace ListThreatIntelSetsResponse {
   export function isa(o: any): o is ListThreatIntelSetsResponse {
-    return _smithy.isa(o, "ListThreatIntelSetsResponse");
+    return __isa(o, "ListThreatIntelSetsResponse");
   }
 }
 
@@ -2508,7 +2511,7 @@ export interface LocalPortDetails {
 
 export namespace LocalPortDetails {
   export function isa(o: any): o is LocalPortDetails {
-    return _smithy.isa(o, "LocalPortDetails");
+    return __isa(o, "LocalPortDetails");
   }
 }
 
@@ -2540,7 +2543,7 @@ export interface Master {
 
 export namespace Master {
   export function isa(o: any): o is Master {
-    return _smithy.isa(o, "Master");
+    return __isa(o, "Master");
   }
 }
 
@@ -2587,7 +2590,7 @@ export interface Member {
 
 export namespace Member {
   export function isa(o: any): o is Member {
-    return _smithy.isa(o, "Member");
+    return __isa(o, "Member");
   }
 }
 
@@ -2629,7 +2632,7 @@ export interface NetworkConnectionAction {
 
 export namespace NetworkConnectionAction {
   export function isa(o: any): o is NetworkConnectionAction {
-    return _smithy.isa(o, "NetworkConnectionAction");
+    return __isa(o, "NetworkConnectionAction");
   }
 }
 
@@ -2691,7 +2694,7 @@ export interface NetworkInterface {
 
 export namespace NetworkInterface {
   export function isa(o: any): o is NetworkInterface {
-    return _smithy.isa(o, "NetworkInterface");
+    return __isa(o, "NetworkInterface");
   }
 }
 
@@ -2728,7 +2731,7 @@ export interface Organization {
 
 export namespace Organization {
   export function isa(o: any): o is Organization {
-    return _smithy.isa(o, "Organization");
+    return __isa(o, "Organization");
   }
 }
 
@@ -2750,7 +2753,7 @@ export interface PortProbeAction {
 
 export namespace PortProbeAction {
   export function isa(o: any): o is PortProbeAction {
-    return _smithy.isa(o, "PortProbeAction");
+    return __isa(o, "PortProbeAction");
   }
 }
 
@@ -2772,7 +2775,7 @@ export interface PortProbeDetail {
 
 export namespace PortProbeDetail {
   export function isa(o: any): o is PortProbeDetail {
-    return _smithy.isa(o, "PortProbeDetail");
+    return __isa(o, "PortProbeDetail");
   }
 }
 
@@ -2794,7 +2797,7 @@ export interface PrivateIpAddressDetails {
 
 export namespace PrivateIpAddressDetails {
   export function isa(o: any): o is PrivateIpAddressDetails {
-    return _smithy.isa(o, "PrivateIpAddressDetails");
+    return __isa(o, "PrivateIpAddressDetails");
   }
 }
 
@@ -2816,7 +2819,7 @@ export interface ProductCode {
 
 export namespace ProductCode {
   export function isa(o: any): o is ProductCode {
-    return _smithy.isa(o, "ProductCode");
+    return __isa(o, "ProductCode");
   }
 }
 
@@ -2860,7 +2863,7 @@ export interface RemoteIpDetails {
 
 export namespace RemoteIpDetails {
   export function isa(o: any): o is RemoteIpDetails {
-    return _smithy.isa(o, "RemoteIpDetails");
+    return __isa(o, "RemoteIpDetails");
   }
 }
 
@@ -2882,7 +2885,7 @@ export interface RemotePortDetails {
 
 export namespace RemotePortDetails {
   export function isa(o: any): o is RemotePortDetails {
-    return _smithy.isa(o, "RemotePortDetails");
+    return __isa(o, "RemotePortDetails");
   }
 }
 
@@ -2912,7 +2915,7 @@ export interface Resource {
 
 export namespace Resource {
   export function isa(o: any): o is Resource {
-    return _smithy.isa(o, "Resource");
+    return __isa(o, "Resource");
   }
 }
 
@@ -2934,7 +2937,7 @@ export interface SecurityGroup {
 
 export namespace SecurityGroup {
   export function isa(o: any): o is SecurityGroup {
-    return _smithy.isa(o, "SecurityGroup");
+    return __isa(o, "SecurityGroup");
   }
 }
 
@@ -2998,7 +3001,7 @@ export interface Service {
 
 export namespace Service {
   export function isa(o: any): o is Service {
-    return _smithy.isa(o, "Service");
+    return __isa(o, "Service");
   }
 }
 
@@ -3021,7 +3024,7 @@ export interface SortCriteria {
 
 export namespace SortCriteria {
   export function isa(o: any): o is SortCriteria {
-    return _smithy.isa(o, "SortCriteria");
+    return __isa(o, "SortCriteria");
   }
 }
 
@@ -3040,7 +3043,7 @@ export interface StartMonitoringMembersRequest {
 
 export namespace StartMonitoringMembersRequest {
   export function isa(o: any): o is StartMonitoringMembersRequest {
-    return _smithy.isa(o, "StartMonitoringMembersRequest");
+    return __isa(o, "StartMonitoringMembersRequest");
   }
 }
 
@@ -3055,7 +3058,7 @@ export interface StartMonitoringMembersResponse extends $MetadataBearer {
 
 export namespace StartMonitoringMembersResponse {
   export function isa(o: any): o is StartMonitoringMembersResponse {
-    return _smithy.isa(o, "StartMonitoringMembersResponse");
+    return __isa(o, "StartMonitoringMembersResponse");
   }
 }
 
@@ -3076,7 +3079,7 @@ export interface StopMonitoringMembersRequest {
 
 export namespace StopMonitoringMembersRequest {
   export function isa(o: any): o is StopMonitoringMembersRequest {
-    return _smithy.isa(o, "StopMonitoringMembersRequest");
+    return __isa(o, "StopMonitoringMembersRequest");
   }
 }
 
@@ -3091,7 +3094,7 @@ export interface StopMonitoringMembersResponse extends $MetadataBearer {
 
 export namespace StopMonitoringMembersResponse {
   export function isa(o: any): o is StopMonitoringMembersResponse {
-    return _smithy.isa(o, "StopMonitoringMembersResponse");
+    return __isa(o, "StopMonitoringMembersResponse");
   }
 }
 
@@ -3113,7 +3116,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -3132,7 +3135,7 @@ export interface TagResourceRequest {
 
 export namespace TagResourceRequest {
   export function isa(o: any): o is TagResourceRequest {
-    return _smithy.isa(o, "TagResourceRequest");
+    return __isa(o, "TagResourceRequest");
   }
 }
 
@@ -3142,7 +3145,7 @@ export interface TagResourceResponse extends $MetadataBearer {
 
 export namespace TagResourceResponse {
   export function isa(o: any): o is TagResourceResponse {
-    return _smithy.isa(o, "TagResourceResponse");
+    return __isa(o, "TagResourceResponse");
   }
 }
 
@@ -3185,7 +3188,7 @@ export interface ThreatIntelligenceDetail {
 
 export namespace ThreatIntelligenceDetail {
   export function isa(o: any): o is ThreatIntelligenceDetail {
-    return _smithy.isa(o, "ThreatIntelligenceDetail");
+    return __isa(o, "ThreatIntelligenceDetail");
   }
 }
 
@@ -3204,7 +3207,7 @@ export interface UnarchiveFindingsRequest {
 
 export namespace UnarchiveFindingsRequest {
   export function isa(o: any): o is UnarchiveFindingsRequest {
-    return _smithy.isa(o, "UnarchiveFindingsRequest");
+    return __isa(o, "UnarchiveFindingsRequest");
   }
 }
 
@@ -3214,7 +3217,7 @@ export interface UnarchiveFindingsResponse extends $MetadataBearer {
 
 export namespace UnarchiveFindingsResponse {
   export function isa(o: any): o is UnarchiveFindingsResponse {
-    return _smithy.isa(o, "UnarchiveFindingsResponse");
+    return __isa(o, "UnarchiveFindingsResponse");
   }
 }
 
@@ -3236,7 +3239,7 @@ export interface UnprocessedAccount {
 
 export namespace UnprocessedAccount {
   export function isa(o: any): o is UnprocessedAccount {
-    return _smithy.isa(o, "UnprocessedAccount");
+    return __isa(o, "UnprocessedAccount");
   }
 }
 
@@ -3255,7 +3258,7 @@ export interface UntagResourceRequest {
 
 export namespace UntagResourceRequest {
   export function isa(o: any): o is UntagResourceRequest {
-    return _smithy.isa(o, "UntagResourceRequest");
+    return __isa(o, "UntagResourceRequest");
   }
 }
 
@@ -3265,7 +3268,7 @@ export interface UntagResourceResponse extends $MetadataBearer {
 
 export namespace UntagResourceResponse {
   export function isa(o: any): o is UntagResourceResponse {
-    return _smithy.isa(o, "UntagResourceResponse");
+    return __isa(o, "UntagResourceResponse");
   }
 }
 
@@ -3289,7 +3292,7 @@ export interface UpdateDetectorRequest {
 
 export namespace UpdateDetectorRequest {
   export function isa(o: any): o is UpdateDetectorRequest {
-    return _smithy.isa(o, "UpdateDetectorRequest");
+    return __isa(o, "UpdateDetectorRequest");
   }
 }
 
@@ -3299,7 +3302,7 @@ export interface UpdateDetectorResponse extends $MetadataBearer {
 
 export namespace UpdateDetectorResponse {
   export function isa(o: any): o is UpdateDetectorResponse {
-    return _smithy.isa(o, "UpdateDetectorResponse");
+    return __isa(o, "UpdateDetectorResponse");
   }
 }
 
@@ -3340,7 +3343,7 @@ export interface UpdateFilterRequest {
 
 export namespace UpdateFilterRequest {
   export function isa(o: any): o is UpdateFilterRequest {
-    return _smithy.isa(o, "UpdateFilterRequest");
+    return __isa(o, "UpdateFilterRequest");
   }
 }
 
@@ -3354,7 +3357,7 @@ export interface UpdateFilterResponse extends $MetadataBearer {
 
 export namespace UpdateFilterResponse {
   export function isa(o: any): o is UpdateFilterResponse {
-    return _smithy.isa(o, "UpdateFilterResponse");
+    return __isa(o, "UpdateFilterResponse");
   }
 }
 
@@ -3383,7 +3386,7 @@ export interface UpdateFindingsFeedbackRequest {
 
 export namespace UpdateFindingsFeedbackRequest {
   export function isa(o: any): o is UpdateFindingsFeedbackRequest {
-    return _smithy.isa(o, "UpdateFindingsFeedbackRequest");
+    return __isa(o, "UpdateFindingsFeedbackRequest");
   }
 }
 
@@ -3393,7 +3396,7 @@ export interface UpdateFindingsFeedbackResponse extends $MetadataBearer {
 
 export namespace UpdateFindingsFeedbackResponse {
   export function isa(o: any): o is UpdateFindingsFeedbackResponse {
-    return _smithy.isa(o, "UpdateFindingsFeedbackResponse");
+    return __isa(o, "UpdateFindingsFeedbackResponse");
   }
 }
 
@@ -3428,7 +3431,7 @@ export interface UpdateIPSetRequest {
 
 export namespace UpdateIPSetRequest {
   export function isa(o: any): o is UpdateIPSetRequest {
-    return _smithy.isa(o, "UpdateIPSetRequest");
+    return __isa(o, "UpdateIPSetRequest");
   }
 }
 
@@ -3438,7 +3441,7 @@ export interface UpdateIPSetResponse extends $MetadataBearer {
 
 export namespace UpdateIPSetResponse {
   export function isa(o: any): o is UpdateIPSetResponse {
-    return _smithy.isa(o, "UpdateIPSetResponse");
+    return __isa(o, "UpdateIPSetResponse");
   }
 }
 
@@ -3463,7 +3466,7 @@ export interface UpdatePublishingDestinationRequest {
 
 export namespace UpdatePublishingDestinationRequest {
   export function isa(o: any): o is UpdatePublishingDestinationRequest {
-    return _smithy.isa(o, "UpdatePublishingDestinationRequest");
+    return __isa(o, "UpdatePublishingDestinationRequest");
   }
 }
 
@@ -3473,7 +3476,7 @@ export interface UpdatePublishingDestinationResponse extends $MetadataBearer {
 
 export namespace UpdatePublishingDestinationResponse {
   export function isa(o: any): o is UpdatePublishingDestinationResponse {
-    return _smithy.isa(o, "UpdatePublishingDestinationResponse");
+    return __isa(o, "UpdatePublishingDestinationResponse");
   }
 }
 
@@ -3510,7 +3513,7 @@ export interface UpdateThreatIntelSetRequest {
 
 export namespace UpdateThreatIntelSetRequest {
   export function isa(o: any): o is UpdateThreatIntelSetRequest {
-    return _smithy.isa(o, "UpdateThreatIntelSetRequest");
+    return __isa(o, "UpdateThreatIntelSetRequest");
   }
 }
 
@@ -3520,6 +3523,6 @@ export interface UpdateThreatIntelSetResponse extends $MetadataBearer {
 
 export namespace UpdateThreatIntelSetResponse {
   export function isa(o: any): o is UpdateThreatIntelSetResponse {
-    return _smithy.isa(o, "UpdateThreatIntelSetResponse");
+    return __isa(o, "UpdateThreatIntelSetResponse");
   }
 }

--- a/clients/client-guardduty/protocols/Aws_restJson1_1.ts
+++ b/clients/client-guardduty/protocols/Aws_restJson1_1.ts
@@ -245,7 +245,10 @@ import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  extendedEncodeURIComponent as __extendedEncodeURIComponent
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -262,13 +265,13 @@ export async function serializeAws_restJson1_1AcceptInvitationCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/detector/{DetectorId}/master";
   if (input.DetectorId !== undefined) {
-    const labelValue: string = input.DetectorId.toString();
+    const labelValue: string = input.DetectorId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DetectorId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DetectorId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DetectorId.");
@@ -300,13 +303,13 @@ export async function serializeAws_restJson1_1ArchiveFindingsCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/detector/{DetectorId}/findings/archive";
   if (input.DetectorId !== undefined) {
-    const labelValue: string = input.DetectorId.toString();
+    const labelValue: string = input.DetectorId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DetectorId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DetectorId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DetectorId.");
@@ -373,13 +376,13 @@ export async function serializeAws_restJson1_1CreateFilterCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/detector/{DetectorId}/filter";
   if (input.DetectorId !== undefined) {
-    const labelValue: string = input.DetectorId.toString();
+    const labelValue: string = input.DetectorId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DetectorId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DetectorId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DetectorId.");
@@ -432,13 +435,13 @@ export async function serializeAws_restJson1_1CreateIPSetCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/detector/{DetectorId}/ipset";
   if (input.DetectorId !== undefined) {
-    const labelValue: string = input.DetectorId.toString();
+    const labelValue: string = input.DetectorId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DetectorId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DetectorId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DetectorId.");
@@ -485,13 +488,13 @@ export async function serializeAws_restJson1_1CreateMembersCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/detector/{DetectorId}/member";
   if (input.DetectorId !== undefined) {
-    const labelValue: string = input.DetectorId.toString();
+    const labelValue: string = input.DetectorId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DetectorId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DetectorId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DetectorId.");
@@ -523,13 +526,13 @@ export async function serializeAws_restJson1_1CreatePublishingDestinationCommand
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/detector/{DetectorId}/publishingDestination";
   if (input.DetectorId !== undefined) {
-    const labelValue: string = input.DetectorId.toString();
+    const labelValue: string = input.DetectorId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DetectorId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DetectorId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DetectorId.");
@@ -572,13 +575,13 @@ export async function serializeAws_restJson1_1CreateSampleFindingsCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/detector/{DetectorId}/findings/create";
   if (input.DetectorId !== undefined) {
-    const labelValue: string = input.DetectorId.toString();
+    const labelValue: string = input.DetectorId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DetectorId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DetectorId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DetectorId.");
@@ -610,13 +613,13 @@ export async function serializeAws_restJson1_1CreateThreatIntelSetCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/detector/{DetectorId}/threatintelset";
   if (input.DetectorId !== undefined) {
-    const labelValue: string = input.DetectorId.toString();
+    const labelValue: string = input.DetectorId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DetectorId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DetectorId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DetectorId.");
@@ -689,13 +692,13 @@ export async function serializeAws_restJson1_1DeleteDetectorCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/detector/{DetectorId}";
   if (input.DetectorId !== undefined) {
-    const labelValue: string = input.DetectorId.toString();
+    const labelValue: string = input.DetectorId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DetectorId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DetectorId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DetectorId.");
@@ -717,25 +720,25 @@ export async function serializeAws_restJson1_1DeleteFilterCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/detector/{DetectorId}/filter/{FilterName}";
   if (input.DetectorId !== undefined) {
-    const labelValue: string = input.DetectorId.toString();
+    const labelValue: string = input.DetectorId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DetectorId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DetectorId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DetectorId.");
   }
   if (input.FilterName !== undefined) {
-    const labelValue: string = input.FilterName.toString();
+    const labelValue: string = input.FilterName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: FilterName.");
     }
     resolvedPath = resolvedPath.replace(
       "{FilterName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: FilterName.");
@@ -757,25 +760,25 @@ export async function serializeAws_restJson1_1DeleteIPSetCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/detector/{DetectorId}/ipset/{IpSetId}";
   if (input.DetectorId !== undefined) {
-    const labelValue: string = input.DetectorId.toString();
+    const labelValue: string = input.DetectorId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DetectorId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DetectorId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DetectorId.");
   }
   if (input.IpSetId !== undefined) {
-    const labelValue: string = input.IpSetId.toString();
+    const labelValue: string = input.IpSetId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: IpSetId.");
     }
     resolvedPath = resolvedPath.replace(
       "{IpSetId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: IpSetId.");
@@ -823,13 +826,13 @@ export async function serializeAws_restJson1_1DeleteMembersCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/detector/{DetectorId}/member/delete";
   if (input.DetectorId !== undefined) {
-    const labelValue: string = input.DetectorId.toString();
+    const labelValue: string = input.DetectorId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DetectorId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DetectorId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DetectorId.");
@@ -862,7 +865,7 @@ export async function serializeAws_restJson1_1DeletePublishingDestinationCommand
   let resolvedPath =
     "/detector/{DetectorId}/publishingDestination/{DestinationId}";
   if (input.DestinationId !== undefined) {
-    const labelValue: string = input.DestinationId.toString();
+    const labelValue: string = input.DestinationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: DestinationId."
@@ -870,19 +873,19 @@ export async function serializeAws_restJson1_1DeletePublishingDestinationCommand
     }
     resolvedPath = resolvedPath.replace(
       "{DestinationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DestinationId.");
   }
   if (input.DetectorId !== undefined) {
-    const labelValue: string = input.DetectorId.toString();
+    const labelValue: string = input.DetectorId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DetectorId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DetectorId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DetectorId.");
@@ -904,19 +907,19 @@ export async function serializeAws_restJson1_1DeleteThreatIntelSetCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/detector/{DetectorId}/threatintelset/{ThreatIntelSetId}";
   if (input.DetectorId !== undefined) {
-    const labelValue: string = input.DetectorId.toString();
+    const labelValue: string = input.DetectorId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DetectorId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DetectorId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DetectorId.");
   }
   if (input.ThreatIntelSetId !== undefined) {
-    const labelValue: string = input.ThreatIntelSetId.toString();
+    const labelValue: string = input.ThreatIntelSetId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ThreatIntelSetId."
@@ -924,7 +927,7 @@ export async function serializeAws_restJson1_1DeleteThreatIntelSetCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ThreatIntelSetId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -949,7 +952,7 @@ export async function serializeAws_restJson1_1DescribePublishingDestinationComma
   let resolvedPath =
     "/detector/{DetectorId}/publishingDestination/{DestinationId}";
   if (input.DestinationId !== undefined) {
-    const labelValue: string = input.DestinationId.toString();
+    const labelValue: string = input.DestinationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: DestinationId."
@@ -957,19 +960,19 @@ export async function serializeAws_restJson1_1DescribePublishingDestinationComma
     }
     resolvedPath = resolvedPath.replace(
       "{DestinationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DestinationId.");
   }
   if (input.DetectorId !== undefined) {
-    const labelValue: string = input.DetectorId.toString();
+    const labelValue: string = input.DetectorId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DetectorId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DetectorId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DetectorId.");
@@ -991,13 +994,13 @@ export async function serializeAws_restJson1_1DisassociateFromMasterAccountComma
   headers["Content-Type"] = "";
   let resolvedPath = "/detector/{DetectorId}/master/disassociate";
   if (input.DetectorId !== undefined) {
-    const labelValue: string = input.DetectorId.toString();
+    const labelValue: string = input.DetectorId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DetectorId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DetectorId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DetectorId.");
@@ -1019,13 +1022,13 @@ export async function serializeAws_restJson1_1DisassociateMembersCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/detector/{DetectorId}/member/disassociate";
   if (input.DetectorId !== undefined) {
-    const labelValue: string = input.DetectorId.toString();
+    const labelValue: string = input.DetectorId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DetectorId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DetectorId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DetectorId.");
@@ -1057,13 +1060,13 @@ export async function serializeAws_restJson1_1GetDetectorCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/detector/{DetectorId}";
   if (input.DetectorId !== undefined) {
-    const labelValue: string = input.DetectorId.toString();
+    const labelValue: string = input.DetectorId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DetectorId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DetectorId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DetectorId.");
@@ -1085,25 +1088,25 @@ export async function serializeAws_restJson1_1GetFilterCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/detector/{DetectorId}/filter/{FilterName}";
   if (input.DetectorId !== undefined) {
-    const labelValue: string = input.DetectorId.toString();
+    const labelValue: string = input.DetectorId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DetectorId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DetectorId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DetectorId.");
   }
   if (input.FilterName !== undefined) {
-    const labelValue: string = input.FilterName.toString();
+    const labelValue: string = input.FilterName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: FilterName.");
     }
     resolvedPath = resolvedPath.replace(
       "{FilterName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: FilterName.");
@@ -1125,13 +1128,13 @@ export async function serializeAws_restJson1_1GetFindingsCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/detector/{DetectorId}/findings/get";
   if (input.DetectorId !== undefined) {
-    const labelValue: string = input.DetectorId.toString();
+    const labelValue: string = input.DetectorId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DetectorId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DetectorId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DetectorId.");
@@ -1169,13 +1172,13 @@ export async function serializeAws_restJson1_1GetFindingsStatisticsCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/detector/{DetectorId}/findings/statistics";
   if (input.DetectorId !== undefined) {
-    const labelValue: string = input.DetectorId.toString();
+    const labelValue: string = input.DetectorId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DetectorId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DetectorId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DetectorId.");
@@ -1215,25 +1218,25 @@ export async function serializeAws_restJson1_1GetIPSetCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/detector/{DetectorId}/ipset/{IpSetId}";
   if (input.DetectorId !== undefined) {
-    const labelValue: string = input.DetectorId.toString();
+    const labelValue: string = input.DetectorId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DetectorId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DetectorId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DetectorId.");
   }
   if (input.IpSetId !== undefined) {
-    const labelValue: string = input.IpSetId.toString();
+    const labelValue: string = input.IpSetId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: IpSetId.");
     }
     resolvedPath = resolvedPath.replace(
       "{IpSetId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: IpSetId.");
@@ -1271,13 +1274,13 @@ export async function serializeAws_restJson1_1GetMasterAccountCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/detector/{DetectorId}/master";
   if (input.DetectorId !== undefined) {
-    const labelValue: string = input.DetectorId.toString();
+    const labelValue: string = input.DetectorId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DetectorId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DetectorId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DetectorId.");
@@ -1299,13 +1302,13 @@ export async function serializeAws_restJson1_1GetMembersCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/detector/{DetectorId}/member/get";
   if (input.DetectorId !== undefined) {
-    const labelValue: string = input.DetectorId.toString();
+    const labelValue: string = input.DetectorId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DetectorId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DetectorId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DetectorId.");
@@ -1337,19 +1340,19 @@ export async function serializeAws_restJson1_1GetThreatIntelSetCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/detector/{DetectorId}/threatintelset/{ThreatIntelSetId}";
   if (input.DetectorId !== undefined) {
-    const labelValue: string = input.DetectorId.toString();
+    const labelValue: string = input.DetectorId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DetectorId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DetectorId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DetectorId.");
   }
   if (input.ThreatIntelSetId !== undefined) {
-    const labelValue: string = input.ThreatIntelSetId.toString();
+    const labelValue: string = input.ThreatIntelSetId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ThreatIntelSetId."
@@ -1357,7 +1360,7 @@ export async function serializeAws_restJson1_1GetThreatIntelSetCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ThreatIntelSetId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -1381,13 +1384,13 @@ export async function serializeAws_restJson1_1InviteMembersCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/detector/{DetectorId}/member/invite";
   if (input.DetectorId !== undefined) {
-    const labelValue: string = input.DetectorId.toString();
+    const labelValue: string = input.DetectorId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DetectorId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DetectorId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DetectorId.");
@@ -1426,10 +1429,14 @@ export async function serializeAws_restJson1_1ListDetectorsCommand(
   let resolvedPath = "/detector";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1449,23 +1456,27 @@ export async function serializeAws_restJson1_1ListFiltersCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/detector/{DetectorId}/filter";
   if (input.DetectorId !== undefined) {
-    const labelValue: string = input.DetectorId.toString();
+    const labelValue: string = input.DetectorId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DetectorId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DetectorId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DetectorId.");
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1485,13 +1496,13 @@ export async function serializeAws_restJson1_1ListFindingsCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/detector/{DetectorId}/findings";
   if (input.DetectorId !== undefined) {
-    const labelValue: string = input.DetectorId.toString();
+    const labelValue: string = input.DetectorId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DetectorId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DetectorId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DetectorId.");
@@ -1535,23 +1546,27 @@ export async function serializeAws_restJson1_1ListIPSetsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/detector/{DetectorId}/ipset";
   if (input.DetectorId !== undefined) {
-    const labelValue: string = input.DetectorId.toString();
+    const labelValue: string = input.DetectorId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DetectorId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DetectorId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DetectorId.");
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1572,10 +1587,14 @@ export async function serializeAws_restJson1_1ListInvitationsCommand(
   let resolvedPath = "/invitation";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1595,26 +1614,32 @@ export async function serializeAws_restJson1_1ListMembersCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/detector/{DetectorId}/member";
   if (input.DetectorId !== undefined) {
-    const labelValue: string = input.DetectorId.toString();
+    const labelValue: string = input.DetectorId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DetectorId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DetectorId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DetectorId.");
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   if (input.OnlyAssociated !== undefined) {
-    query["onlyAssociated"] = input.OnlyAssociated.toString();
+    query[
+      __extendedEncodeURIComponent("onlyAssociated")
+    ] = __extendedEncodeURIComponent(input.OnlyAssociated);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1634,23 +1659,27 @@ export async function serializeAws_restJson1_1ListPublishingDestinationsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/detector/{DetectorId}/publishingDestination";
   if (input.DetectorId !== undefined) {
-    const labelValue: string = input.DetectorId.toString();
+    const labelValue: string = input.DetectorId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DetectorId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DetectorId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DetectorId.");
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1670,7 +1699,7 @@ export async function serializeAws_restJson1_1ListTagsForResourceCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/tags/{ResourceArn}";
   if (input.ResourceArn !== undefined) {
-    const labelValue: string = input.ResourceArn.toString();
+    const labelValue: string = input.ResourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ResourceArn."
@@ -1678,7 +1707,7 @@ export async function serializeAws_restJson1_1ListTagsForResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ResourceArn.");
@@ -1700,23 +1729,27 @@ export async function serializeAws_restJson1_1ListThreatIntelSetsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/detector/{DetectorId}/threatintelset";
   if (input.DetectorId !== undefined) {
-    const labelValue: string = input.DetectorId.toString();
+    const labelValue: string = input.DetectorId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DetectorId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DetectorId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DetectorId.");
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1736,13 +1769,13 @@ export async function serializeAws_restJson1_1StartMonitoringMembersCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/detector/{DetectorId}/member/start";
   if (input.DetectorId !== undefined) {
-    const labelValue: string = input.DetectorId.toString();
+    const labelValue: string = input.DetectorId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DetectorId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DetectorId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DetectorId.");
@@ -1774,13 +1807,13 @@ export async function serializeAws_restJson1_1StopMonitoringMembersCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/detector/{DetectorId}/member/stop";
   if (input.DetectorId !== undefined) {
-    const labelValue: string = input.DetectorId.toString();
+    const labelValue: string = input.DetectorId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DetectorId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DetectorId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DetectorId.");
@@ -1812,7 +1845,7 @@ export async function serializeAws_restJson1_1TagResourceCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/tags/{ResourceArn}";
   if (input.ResourceArn !== undefined) {
-    const labelValue: string = input.ResourceArn.toString();
+    const labelValue: string = input.ResourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ResourceArn."
@@ -1820,7 +1853,7 @@ export async function serializeAws_restJson1_1TagResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ResourceArn.");
@@ -1849,13 +1882,13 @@ export async function serializeAws_restJson1_1UnarchiveFindingsCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/detector/{DetectorId}/findings/unarchive";
   if (input.DetectorId !== undefined) {
-    const labelValue: string = input.DetectorId.toString();
+    const labelValue: string = input.DetectorId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DetectorId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DetectorId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DetectorId.");
@@ -1887,7 +1920,7 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/tags/{ResourceArn}";
   if (input.ResourceArn !== undefined) {
-    const labelValue: string = input.ResourceArn.toString();
+    const labelValue: string = input.ResourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ResourceArn."
@@ -1895,14 +1928,16 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ResourceArn.");
   }
   const query: any = {};
   if (input.TagKeys !== undefined) {
-    query["tagKeys"] = input.TagKeys;
+    query[__extendedEncodeURIComponent("tagKeys")] = input.TagKeys.map(entry =>
+      __extendedEncodeURIComponent(entry)
+    );
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1922,13 +1957,13 @@ export async function serializeAws_restJson1_1UpdateDetectorCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/detector/{DetectorId}";
   if (input.DetectorId !== undefined) {
-    const labelValue: string = input.DetectorId.toString();
+    const labelValue: string = input.DetectorId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DetectorId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DetectorId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DetectorId.");
@@ -1960,25 +1995,25 @@ export async function serializeAws_restJson1_1UpdateFilterCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/detector/{DetectorId}/filter/{FilterName}";
   if (input.DetectorId !== undefined) {
-    const labelValue: string = input.DetectorId.toString();
+    const labelValue: string = input.DetectorId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DetectorId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DetectorId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DetectorId.");
   }
   if (input.FilterName !== undefined) {
-    const labelValue: string = input.FilterName.toString();
+    const labelValue: string = input.FilterName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: FilterName.");
     }
     resolvedPath = resolvedPath.replace(
       "{FilterName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: FilterName.");
@@ -2019,13 +2054,13 @@ export async function serializeAws_restJson1_1UpdateFindingsFeedbackCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/detector/{DetectorId}/findings/feedback";
   if (input.DetectorId !== undefined) {
-    const labelValue: string = input.DetectorId.toString();
+    const labelValue: string = input.DetectorId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DetectorId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DetectorId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DetectorId.");
@@ -2063,25 +2098,25 @@ export async function serializeAws_restJson1_1UpdateIPSetCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/detector/{DetectorId}/ipset/{IpSetId}";
   if (input.DetectorId !== undefined) {
-    const labelValue: string = input.DetectorId.toString();
+    const labelValue: string = input.DetectorId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DetectorId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DetectorId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DetectorId.");
   }
   if (input.IpSetId !== undefined) {
-    const labelValue: string = input.IpSetId.toString();
+    const labelValue: string = input.IpSetId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: IpSetId.");
     }
     resolvedPath = resolvedPath.replace(
       "{IpSetId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: IpSetId.");
@@ -2117,7 +2152,7 @@ export async function serializeAws_restJson1_1UpdatePublishingDestinationCommand
   let resolvedPath =
     "/detector/{DetectorId}/publishingDestination/{DestinationId}";
   if (input.DestinationId !== undefined) {
-    const labelValue: string = input.DestinationId.toString();
+    const labelValue: string = input.DestinationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: DestinationId."
@@ -2125,19 +2160,19 @@ export async function serializeAws_restJson1_1UpdatePublishingDestinationCommand
     }
     resolvedPath = resolvedPath.replace(
       "{DestinationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DestinationId.");
   }
   if (input.DetectorId !== undefined) {
-    const labelValue: string = input.DetectorId.toString();
+    const labelValue: string = input.DetectorId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DetectorId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DetectorId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DetectorId.");
@@ -2171,19 +2206,19 @@ export async function serializeAws_restJson1_1UpdateThreatIntelSetCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/detector/{DetectorId}/threatintelset/{ThreatIntelSetId}";
   if (input.DetectorId !== undefined) {
-    const labelValue: string = input.DetectorId.toString();
+    const labelValue: string = input.DetectorId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DetectorId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DetectorId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DetectorId.");
   }
   if (input.ThreatIntelSetId !== undefined) {
-    const labelValue: string = input.ThreatIntelSetId.toString();
+    const labelValue: string = input.ThreatIntelSetId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ThreatIntelSetId."
@@ -2191,7 +2226,7 @@ export async function serializeAws_restJson1_1UpdateThreatIntelSetCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ThreatIntelSetId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -2234,6 +2269,7 @@ export async function deserializeAws_restJson1_1AcceptInvitationCommand(
     $metadata: deserializeMetadata(output),
     __type: "AcceptInvitationResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2292,6 +2328,7 @@ export async function deserializeAws_restJson1_1ArchiveFindingsCommand(
     $metadata: deserializeMetadata(output),
     __type: "ArchiveFindingsResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2662,6 +2699,7 @@ export async function deserializeAws_restJson1_1CreateSampleFindingsCommand(
     $metadata: deserializeMetadata(output),
     __type: "CreateSampleFindingsResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2852,6 +2890,7 @@ export async function deserializeAws_restJson1_1DeleteDetectorCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeleteDetectorResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2907,6 +2946,7 @@ export async function deserializeAws_restJson1_1DeleteFilterCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeleteFilterResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2962,6 +3002,7 @@ export async function deserializeAws_restJson1_1DeleteIPSetCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeleteIPSetResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -3155,6 +3196,7 @@ export async function deserializeAws_restJson1_1DeletePublishingDestinationComma
     $metadata: deserializeMetadata(output),
     __type: "DeletePublishingDestinationResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -3213,6 +3255,7 @@ export async function deserializeAws_restJson1_1DeleteThreatIntelSetCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeleteThreatIntelSetResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -3360,6 +3403,7 @@ export async function deserializeAws_restJson1_1DisassociateFromMasterAccountCom
     $metadata: deserializeMetadata(output),
     __type: "DisassociateFromMasterAccountResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -4939,6 +4983,7 @@ export async function deserializeAws_restJson1_1TagResourceCommand(
     $metadata: deserializeMetadata(output),
     __type: "TagResourceResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -4997,6 +5042,7 @@ export async function deserializeAws_restJson1_1UnarchiveFindingsCommand(
     $metadata: deserializeMetadata(output),
     __type: "UnarchiveFindingsResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -5052,6 +5098,7 @@ export async function deserializeAws_restJson1_1UntagResourceCommand(
     $metadata: deserializeMetadata(output),
     __type: "UntagResourceResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -5110,6 +5157,7 @@ export async function deserializeAws_restJson1_1UpdateDetectorCommand(
     $metadata: deserializeMetadata(output),
     __type: "UpdateDetectorResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -5228,6 +5276,7 @@ export async function deserializeAws_restJson1_1UpdateFindingsFeedbackCommand(
     $metadata: deserializeMetadata(output),
     __type: "UpdateFindingsFeedbackResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -5283,6 +5332,7 @@ export async function deserializeAws_restJson1_1UpdateIPSetCommand(
     $metadata: deserializeMetadata(output),
     __type: "UpdateIPSetResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -5341,6 +5391,7 @@ export async function deserializeAws_restJson1_1UpdatePublishingDestinationComma
     $metadata: deserializeMetadata(output),
     __type: "UpdatePublishingDestinationResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -5399,6 +5450,7 @@ export async function deserializeAws_restJson1_1UpdateThreatIntelSetCommand(
     $metadata: deserializeMetadata(output),
     __type: "UpdateThreatIntelSetResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 

--- a/clients/client-health/models/index.ts
+++ b/clients/client-health/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export enum EntityStatusCode {
@@ -30,7 +33,7 @@ export enum EventTypeCategory {
  *          for the action to complete before trying again. To get the current status, use the <a>DescribeHealthServiceStatusForOrganization</a> operation.</p>
  */
 export interface ConcurrentModificationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ConcurrentModificationException";
   $fault: "client";
@@ -39,7 +42,7 @@ export interface ConcurrentModificationException
 
 export namespace ConcurrentModificationException {
   export function isa(o: any): o is ConcurrentModificationException {
-    return _smithy.isa(o, "ConcurrentModificationException");
+    return __isa(o, "ConcurrentModificationException");
   }
 }
 
@@ -47,7 +50,7 @@ export namespace ConcurrentModificationException {
  * <p>The specified pagination token (<code>nextToken</code>) is not valid.</p>
  */
 export interface InvalidPaginationToken
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidPaginationToken";
   $fault: "client";
@@ -56,16 +59,14 @@ export interface InvalidPaginationToken
 
 export namespace InvalidPaginationToken {
   export function isa(o: any): o is InvalidPaginationToken {
-    return _smithy.isa(o, "InvalidPaginationToken");
+    return __isa(o, "InvalidPaginationToken");
   }
 }
 
 /**
  * <p>The specified locale is not supported.</p>
  */
-export interface UnsupportedLocale
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface UnsupportedLocale extends __SmithyException, $MetadataBearer {
   name: "UnsupportedLocale";
   $fault: "client";
   message?: string;
@@ -73,7 +74,7 @@ export interface UnsupportedLocale
 
 export namespace UnsupportedLocale {
   export function isa(o: any): o is UnsupportedLocale {
-    return _smithy.isa(o, "UnsupportedLocale");
+    return __isa(o, "UnsupportedLocale");
   }
 }
 
@@ -104,7 +105,7 @@ export namespace DescribeAffectedAccountsForOrganizationRequest {
   export function isa(
     o: any
   ): o is DescribeAffectedAccountsForOrganizationRequest {
-    return _smithy.isa(o, "DescribeAffectedAccountsForOrganizationRequest");
+    return __isa(o, "DescribeAffectedAccountsForOrganizationRequest");
   }
 }
 
@@ -129,7 +130,7 @@ export namespace DescribeAffectedAccountsForOrganizationResponse {
   export function isa(
     o: any
   ): o is DescribeAffectedAccountsForOrganizationResponse {
-    return _smithy.isa(o, "DescribeAffectedAccountsForOrganizationResponse");
+    return __isa(o, "DescribeAffectedAccountsForOrganizationResponse");
   }
 }
 
@@ -164,7 +165,7 @@ export namespace DescribeAffectedEntitiesForOrganizationRequest {
   export function isa(
     o: any
   ): o is DescribeAffectedEntitiesForOrganizationRequest {
-    return _smithy.isa(o, "DescribeAffectedEntitiesForOrganizationRequest");
+    return __isa(o, "DescribeAffectedEntitiesForOrganizationRequest");
   }
 }
 
@@ -197,7 +198,7 @@ export namespace DescribeAffectedEntitiesForOrganizationResponse {
   export function isa(
     o: any
   ): o is DescribeAffectedEntitiesForOrganizationResponse {
-    return _smithy.isa(o, "DescribeAffectedEntitiesForOrganizationResponse");
+    return __isa(o, "DescribeAffectedEntitiesForOrganizationResponse");
   }
 }
 
@@ -229,7 +230,7 @@ export interface DescribeAffectedEntitiesRequest {
 
 export namespace DescribeAffectedEntitiesRequest {
   export function isa(o: any): o is DescribeAffectedEntitiesRequest {
-    return _smithy.isa(o, "DescribeAffectedEntitiesRequest");
+    return __isa(o, "DescribeAffectedEntitiesRequest");
   }
 }
 
@@ -251,7 +252,7 @@ export interface DescribeAffectedEntitiesResponse extends $MetadataBearer {
 
 export namespace DescribeAffectedEntitiesResponse {
   export function isa(o: any): o is DescribeAffectedEntitiesResponse {
-    return _smithy.isa(o, "DescribeAffectedEntitiesResponse");
+    return __isa(o, "DescribeAffectedEntitiesResponse");
   }
 }
 
@@ -266,7 +267,7 @@ export interface DescribeEntityAggregatesRequest {
 
 export namespace DescribeEntityAggregatesRequest {
   export function isa(o: any): o is DescribeEntityAggregatesRequest {
-    return _smithy.isa(o, "DescribeEntityAggregatesRequest");
+    return __isa(o, "DescribeEntityAggregatesRequest");
   }
 }
 
@@ -280,7 +281,7 @@ export interface DescribeEntityAggregatesResponse extends $MetadataBearer {
 
 export namespace DescribeEntityAggregatesResponse {
   export function isa(o: any): o is DescribeEntityAggregatesResponse {
-    return _smithy.isa(o, "DescribeEntityAggregatesResponse");
+    return __isa(o, "DescribeEntityAggregatesResponse");
   }
 }
 
@@ -312,7 +313,7 @@ export interface DescribeEventAggregatesRequest {
 
 export namespace DescribeEventAggregatesRequest {
   export function isa(o: any): o is DescribeEventAggregatesRequest {
-    return _smithy.isa(o, "DescribeEventAggregatesRequest");
+    return __isa(o, "DescribeEventAggregatesRequest");
   }
 }
 
@@ -335,7 +336,7 @@ export interface DescribeEventAggregatesResponse extends $MetadataBearer {
 
 export namespace DescribeEventAggregatesResponse {
   export function isa(o: any): o is DescribeEventAggregatesResponse {
-    return _smithy.isa(o, "DescribeEventAggregatesResponse");
+    return __isa(o, "DescribeEventAggregatesResponse");
   }
 }
 
@@ -355,7 +356,7 @@ export interface DescribeEventDetailsForOrganizationRequest {
 
 export namespace DescribeEventDetailsForOrganizationRequest {
   export function isa(o: any): o is DescribeEventDetailsForOrganizationRequest {
-    return _smithy.isa(o, "DescribeEventDetailsForOrganizationRequest");
+    return __isa(o, "DescribeEventDetailsForOrganizationRequest");
   }
 }
 
@@ -377,7 +378,7 @@ export namespace DescribeEventDetailsForOrganizationResponse {
   export function isa(
     o: any
   ): o is DescribeEventDetailsForOrganizationResponse {
-    return _smithy.isa(o, "DescribeEventDetailsForOrganizationResponse");
+    return __isa(o, "DescribeEventDetailsForOrganizationResponse");
   }
 }
 
@@ -397,7 +398,7 @@ export interface DescribeEventDetailsRequest {
 
 export namespace DescribeEventDetailsRequest {
   export function isa(o: any): o is DescribeEventDetailsRequest {
-    return _smithy.isa(o, "DescribeEventDetailsRequest");
+    return __isa(o, "DescribeEventDetailsRequest");
   }
 }
 
@@ -416,7 +417,7 @@ export interface DescribeEventDetailsResponse extends $MetadataBearer {
 
 export namespace DescribeEventDetailsResponse {
   export function isa(o: any): o is DescribeEventDetailsResponse {
-    return _smithy.isa(o, "DescribeEventDetailsResponse");
+    return __isa(o, "DescribeEventDetailsResponse");
   }
 }
 
@@ -448,7 +449,7 @@ export interface DescribeEventTypesRequest {
 
 export namespace DescribeEventTypesRequest {
   export function isa(o: any): o is DescribeEventTypesRequest {
-    return _smithy.isa(o, "DescribeEventTypesRequest");
+    return __isa(o, "DescribeEventTypesRequest");
   }
 }
 
@@ -476,7 +477,7 @@ export interface DescribeEventTypesResponse extends $MetadataBearer {
 
 export namespace DescribeEventTypesResponse {
   export function isa(o: any): o is DescribeEventTypesResponse {
-    return _smithy.isa(o, "DescribeEventTypesResponse");
+    return __isa(o, "DescribeEventTypesResponse");
   }
 }
 
@@ -508,7 +509,7 @@ export interface DescribeEventsForOrganizationRequest {
 
 export namespace DescribeEventsForOrganizationRequest {
   export function isa(o: any): o is DescribeEventsForOrganizationRequest {
-    return _smithy.isa(o, "DescribeEventsForOrganizationRequest");
+    return __isa(o, "DescribeEventsForOrganizationRequest");
   }
 }
 
@@ -530,7 +531,7 @@ export interface DescribeEventsForOrganizationResponse extends $MetadataBearer {
 
 export namespace DescribeEventsForOrganizationResponse {
   export function isa(o: any): o is DescribeEventsForOrganizationResponse {
-    return _smithy.isa(o, "DescribeEventsForOrganizationResponse");
+    return __isa(o, "DescribeEventsForOrganizationResponse");
   }
 }
 
@@ -562,7 +563,7 @@ export interface DescribeEventsRequest {
 
 export namespace DescribeEventsRequest {
   export function isa(o: any): o is DescribeEventsRequest {
-    return _smithy.isa(o, "DescribeEventsRequest");
+    return __isa(o, "DescribeEventsRequest");
   }
 }
 
@@ -584,7 +585,7 @@ export interface DescribeEventsResponse extends $MetadataBearer {
 
 export namespace DescribeEventsResponse {
   export function isa(o: any): o is DescribeEventsResponse {
-    return _smithy.isa(o, "DescribeEventsResponse");
+    return __isa(o, "DescribeEventsResponse");
   }
 }
 
@@ -603,7 +604,7 @@ export namespace DescribeHealthServiceStatusForOrganizationResponse {
   export function isa(
     o: any
   ): o is DescribeHealthServiceStatusForOrganizationResponse {
-    return _smithy.isa(o, "DescribeHealthServiceStatusForOrganizationResponse");
+    return __isa(o, "DescribeHealthServiceStatusForOrganizationResponse");
   }
 }
 
@@ -660,7 +661,7 @@ export interface AffectedEntity {
 
 export namespace AffectedEntity {
   export function isa(o: any): o is AffectedEntity {
-    return _smithy.isa(o, "AffectedEntity");
+    return __isa(o, "AffectedEntity");
   }
 }
 
@@ -689,7 +690,7 @@ export interface DateTimeRange {
 
 export namespace DateTimeRange {
   export function isa(o: any): o is DateTimeRange {
-    return _smithy.isa(o, "DateTimeRange");
+    return __isa(o, "DateTimeRange");
   }
 }
 
@@ -713,7 +714,7 @@ export interface EntityAggregate {
 
 export namespace EntityAggregate {
   export function isa(o: any): o is EntityAggregate {
-    return _smithy.isa(o, "EntityAggregate");
+    return __isa(o, "EntityAggregate");
   }
 }
 
@@ -757,7 +758,7 @@ export interface EntityFilter {
 
 export namespace EntityFilter {
   export function isa(o: any): o is EntityFilter {
-    return _smithy.isa(o, "EntityFilter");
+    return __isa(o, "EntityFilter");
   }
 }
 
@@ -824,7 +825,7 @@ export interface Event {
 
 export namespace Event {
   export function isa(o: any): o is Event {
-    return _smithy.isa(o, "Event");
+    return __isa(o, "Event");
   }
 }
 
@@ -848,7 +849,7 @@ export interface EventAccountFilter {
 
 export namespace EventAccountFilter {
   export function isa(o: any): o is EventAccountFilter {
-    return _smithy.isa(o, "EventAccountFilter");
+    return __isa(o, "EventAccountFilter");
   }
 }
 
@@ -870,7 +871,7 @@ export interface EventAggregate {
 
 export namespace EventAggregate {
   export function isa(o: any): o is EventAggregate {
-    return _smithy.isa(o, "EventAggregate");
+    return __isa(o, "EventAggregate");
   }
 }
 
@@ -888,7 +889,7 @@ export interface EventDescription {
 
 export namespace EventDescription {
   export function isa(o: any): o is EventDescription {
-    return _smithy.isa(o, "EventDescription");
+    return __isa(o, "EventDescription");
   }
 }
 
@@ -917,7 +918,7 @@ export interface EventDetails {
 
 export namespace EventDetails {
   export function isa(o: any): o is EventDetails {
-    return _smithy.isa(o, "EventDetails");
+    return __isa(o, "EventDetails");
   }
 }
 
@@ -947,7 +948,7 @@ export interface EventDetailsErrorItem {
 
 export namespace EventDetailsErrorItem {
   export function isa(o: any): o is EventDetailsErrorItem {
-    return _smithy.isa(o, "EventDetailsErrorItem");
+    return __isa(o, "EventDetailsErrorItem");
   }
 }
 
@@ -1029,7 +1030,7 @@ export interface EventFilter {
 
 export namespace EventFilter {
   export function isa(o: any): o is EventFilter {
-    return _smithy.isa(o, "EventFilter");
+    return __isa(o, "EventFilter");
   }
 }
 
@@ -1061,7 +1062,7 @@ export interface EventType {
 
 export namespace EventType {
   export function isa(o: any): o is EventType {
-    return _smithy.isa(o, "EventType");
+    return __isa(o, "EventType");
   }
 }
 
@@ -1090,7 +1091,7 @@ export interface EventTypeFilter {
 
 export namespace EventTypeFilter {
   export function isa(o: any): o is EventTypeFilter {
-    return _smithy.isa(o, "EventTypeFilter");
+    return __isa(o, "EventTypeFilter");
   }
 }
 
@@ -1127,7 +1128,7 @@ export interface OrganizationAffectedEntitiesErrorItem {
 
 export namespace OrganizationAffectedEntitiesErrorItem {
   export function isa(o: any): o is OrganizationAffectedEntitiesErrorItem {
-    return _smithy.isa(o, "OrganizationAffectedEntitiesErrorItem");
+    return __isa(o, "OrganizationAffectedEntitiesErrorItem");
   }
 }
 
@@ -1189,7 +1190,7 @@ export interface OrganizationEvent {
 
 export namespace OrganizationEvent {
   export function isa(o: any): o is OrganizationEvent {
-    return _smithy.isa(o, "OrganizationEvent");
+    return __isa(o, "OrganizationEvent");
   }
 }
 
@@ -1224,7 +1225,7 @@ export interface OrganizationEventDetails {
 
 export namespace OrganizationEventDetails {
   export function isa(o: any): o is OrganizationEventDetails {
-    return _smithy.isa(o, "OrganizationEventDetails");
+    return __isa(o, "OrganizationEventDetails");
   }
 }
 
@@ -1260,7 +1261,7 @@ export interface OrganizationEventDetailsErrorItem {
 
 export namespace OrganizationEventDetailsErrorItem {
   export function isa(o: any): o is OrganizationEventDetailsErrorItem {
-    return _smithy.isa(o, "OrganizationEventDetailsErrorItem");
+    return __isa(o, "OrganizationEventDetailsErrorItem");
   }
 }
 
@@ -1350,6 +1351,6 @@ export interface OrganizationEventFilter {
 
 export namespace OrganizationEventFilter {
   export function isa(o: any): o is OrganizationEventFilter {
-    return _smithy.isa(o, "OrganizationEventFilter");
+    return __isa(o, "OrganizationEventFilter");
   }
 }

--- a/clients/client-health/protocols/Aws_json1_1.ts
+++ b/clients/client-health/protocols/Aws_json1_1.ts
@@ -996,6 +996,7 @@ export async function deserializeAws_json1_1DisableHealthServiceAccessForOrganiz
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DisableHealthServiceAccessForOrganizationCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1050,6 +1051,7 @@ export async function deserializeAws_json1_1EnableHealthServiceAccessForOrganiza
       context
     );
   }
+  await collectBody(output.body, context);
   const response: EnableHealthServiceAccessForOrganizationCommandOutput = {
     $metadata: deserializeMetadata(output)
   };

--- a/clients/client-iam/models/index.ts
+++ b/clients/client-iam/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -60,7 +63,7 @@ export interface AccessDetail {
 
 export namespace AccessDetail {
   export function isa(o: any): o is AccessDetail {
-    return _smithy.isa(o, "AccessDetail");
+    return __isa(o, "AccessDetail");
   }
 }
 
@@ -105,7 +108,7 @@ export interface AccessKey {
 
 export namespace AccessKey {
   export function isa(o: any): o is AccessKey {
-    return _smithy.isa(o, "AccessKey");
+    return __isa(o, "AccessKey");
   }
 }
 
@@ -176,7 +179,7 @@ export interface AccessKeyLastUsed {
 
 export namespace AccessKeyLastUsed {
   export function isa(o: any): o is AccessKeyLastUsed {
-    return _smithy.isa(o, "AccessKeyLastUsed");
+    return __isa(o, "AccessKeyLastUsed");
   }
 }
 
@@ -211,7 +214,7 @@ export interface AccessKeyMetadata {
 
 export namespace AccessKeyMetadata {
   export function isa(o: any): o is AccessKeyMetadata {
-    return _smithy.isa(o, "AccessKeyMetadata");
+    return __isa(o, "AccessKeyMetadata");
   }
 }
 
@@ -232,7 +235,7 @@ export interface AddClientIDToOpenIDConnectProviderRequest {
 
 export namespace AddClientIDToOpenIDConnectProviderRequest {
   export function isa(o: any): o is AddClientIDToOpenIDConnectProviderRequest {
-    return _smithy.isa(o, "AddClientIDToOpenIDConnectProviderRequest");
+    return __isa(o, "AddClientIDToOpenIDConnectProviderRequest");
   }
 }
 
@@ -255,7 +258,7 @@ export interface AddRoleToInstanceProfileRequest {
 
 export namespace AddRoleToInstanceProfileRequest {
   export function isa(o: any): o is AddRoleToInstanceProfileRequest {
-    return _smithy.isa(o, "AddRoleToInstanceProfileRequest");
+    return __isa(o, "AddRoleToInstanceProfileRequest");
   }
 }
 
@@ -278,7 +281,7 @@ export interface AddUserToGroupRequest {
 
 export namespace AddUserToGroupRequest {
   export function isa(o: any): o is AddUserToGroupRequest {
-    return _smithy.isa(o, "AddUserToGroupRequest");
+    return __isa(o, "AddUserToGroupRequest");
   }
 }
 
@@ -301,7 +304,7 @@ export interface AttachGroupPolicyRequest {
 
 export namespace AttachGroupPolicyRequest {
   export function isa(o: any): o is AttachGroupPolicyRequest {
-    return _smithy.isa(o, "AttachGroupPolicyRequest");
+    return __isa(o, "AttachGroupPolicyRequest");
   }
 }
 
@@ -324,7 +327,7 @@ export interface AttachRolePolicyRequest {
 
 export namespace AttachRolePolicyRequest {
   export function isa(o: any): o is AttachRolePolicyRequest {
-    return _smithy.isa(o, "AttachRolePolicyRequest");
+    return __isa(o, "AttachRolePolicyRequest");
   }
 }
 
@@ -347,7 +350,7 @@ export interface AttachUserPolicyRequest {
 
 export namespace AttachUserPolicyRequest {
   export function isa(o: any): o is AttachUserPolicyRequest {
-    return _smithy.isa(o, "AttachUserPolicyRequest");
+    return __isa(o, "AttachUserPolicyRequest");
   }
 }
 
@@ -375,7 +378,7 @@ export interface AttachedPermissionsBoundary {
 
 export namespace AttachedPermissionsBoundary {
   export function isa(o: any): o is AttachedPermissionsBoundary {
-    return _smithy.isa(o, "AttachedPermissionsBoundary");
+    return __isa(o, "AttachedPermissionsBoundary");
   }
 }
 
@@ -403,7 +406,7 @@ export interface AttachedPolicy {
 
 export namespace AttachedPolicy {
   export function isa(o: any): o is AttachedPolicy {
-    return _smithy.isa(o, "AttachedPolicy");
+    return __isa(o, "AttachedPolicy");
   }
 }
 
@@ -430,7 +433,7 @@ export interface ChangePasswordRequest {
 
 export namespace ChangePasswordRequest {
   export function isa(o: any): o is ChangePasswordRequest {
-    return _smithy.isa(o, "ChangePasswordRequest");
+    return __isa(o, "ChangePasswordRequest");
   }
 }
 
@@ -438,7 +441,7 @@ export namespace ChangePasswordRequest {
  * <p>The request was rejected because multiple requests to change this object were submitted simultaneously. Wait a few minutes and submit your request again.</p>
  */
 export interface ConcurrentModificationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ConcurrentModificationException";
   $fault: "client";
@@ -447,7 +450,7 @@ export interface ConcurrentModificationException
 
 export namespace ConcurrentModificationException {
   export function isa(o: any): o is ConcurrentModificationException {
-    return _smithy.isa(o, "ConcurrentModificationException");
+    return __isa(o, "ConcurrentModificationException");
   }
 }
 
@@ -486,7 +489,7 @@ export interface ContextEntry {
 
 export namespace ContextEntry {
   export function isa(o: any): o is ContextEntry {
-    return _smithy.isa(o, "ContextEntry");
+    return __isa(o, "ContextEntry");
   }
 }
 
@@ -517,7 +520,7 @@ export interface CreateAccessKeyRequest {
 
 export namespace CreateAccessKeyRequest {
   export function isa(o: any): o is CreateAccessKeyRequest {
-    return _smithy.isa(o, "CreateAccessKeyRequest");
+    return __isa(o, "CreateAccessKeyRequest");
   }
 }
 
@@ -535,7 +538,7 @@ export interface CreateAccessKeyResponse extends $MetadataBearer {
 
 export namespace CreateAccessKeyResponse {
   export function isa(o: any): o is CreateAccessKeyResponse {
-    return _smithy.isa(o, "CreateAccessKeyResponse");
+    return __isa(o, "CreateAccessKeyResponse");
   }
 }
 
@@ -552,7 +555,7 @@ export interface CreateAccountAliasRequest {
 
 export namespace CreateAccountAliasRequest {
   export function isa(o: any): o is CreateAccountAliasRequest {
-    return _smithy.isa(o, "CreateAccountAliasRequest");
+    return __isa(o, "CreateAccountAliasRequest");
   }
 }
 
@@ -580,7 +583,7 @@ export interface CreateGroupRequest {
 
 export namespace CreateGroupRequest {
   export function isa(o: any): o is CreateGroupRequest {
-    return _smithy.isa(o, "CreateGroupRequest");
+    return __isa(o, "CreateGroupRequest");
   }
 }
 
@@ -597,7 +600,7 @@ export interface CreateGroupResponse extends $MetadataBearer {
 
 export namespace CreateGroupResponse {
   export function isa(o: any): o is CreateGroupResponse {
-    return _smithy.isa(o, "CreateGroupResponse");
+    return __isa(o, "CreateGroupResponse");
   }
 }
 
@@ -624,7 +627,7 @@ export interface CreateInstanceProfileRequest {
 
 export namespace CreateInstanceProfileRequest {
   export function isa(o: any): o is CreateInstanceProfileRequest {
-    return _smithy.isa(o, "CreateInstanceProfileRequest");
+    return __isa(o, "CreateInstanceProfileRequest");
   }
 }
 
@@ -642,7 +645,7 @@ export interface CreateInstanceProfileResponse extends $MetadataBearer {
 
 export namespace CreateInstanceProfileResponse {
   export function isa(o: any): o is CreateInstanceProfileResponse {
-    return _smithy.isa(o, "CreateInstanceProfileResponse");
+    return __isa(o, "CreateInstanceProfileResponse");
   }
 }
 
@@ -675,7 +678,7 @@ export interface CreateLoginProfileRequest {
 
 export namespace CreateLoginProfileRequest {
   export function isa(o: any): o is CreateLoginProfileRequest {
-    return _smithy.isa(o, "CreateLoginProfileRequest");
+    return __isa(o, "CreateLoginProfileRequest");
   }
 }
 
@@ -693,7 +696,7 @@ export interface CreateLoginProfileResponse extends $MetadataBearer {
 
 export namespace CreateLoginProfileResponse {
   export function isa(o: any): o is CreateLoginProfileResponse {
-    return _smithy.isa(o, "CreateLoginProfileResponse");
+    return __isa(o, "CreateLoginProfileResponse");
   }
 }
 
@@ -745,7 +748,7 @@ export interface CreateOpenIDConnectProviderRequest {
 
 export namespace CreateOpenIDConnectProviderRequest {
   export function isa(o: any): o is CreateOpenIDConnectProviderRequest {
-    return _smithy.isa(o, "CreateOpenIDConnectProviderRequest");
+    return __isa(o, "CreateOpenIDConnectProviderRequest");
   }
 }
 
@@ -764,7 +767,7 @@ export interface CreateOpenIDConnectProviderResponse extends $MetadataBearer {
 
 export namespace CreateOpenIDConnectProviderResponse {
   export function isa(o: any): o is CreateOpenIDConnectProviderResponse {
-    return _smithy.isa(o, "CreateOpenIDConnectProviderResponse");
+    return __isa(o, "CreateOpenIDConnectProviderResponse");
   }
 }
 
@@ -827,7 +830,7 @@ export interface CreatePolicyRequest {
 
 export namespace CreatePolicyRequest {
   export function isa(o: any): o is CreatePolicyRequest {
-    return _smithy.isa(o, "CreatePolicyRequest");
+    return __isa(o, "CreatePolicyRequest");
   }
 }
 
@@ -845,7 +848,7 @@ export interface CreatePolicyResponse extends $MetadataBearer {
 
 export namespace CreatePolicyResponse {
   export function isa(o: any): o is CreatePolicyResponse {
-    return _smithy.isa(o, "CreatePolicyResponse");
+    return __isa(o, "CreatePolicyResponse");
   }
 }
 
@@ -898,7 +901,7 @@ export interface CreatePolicyVersionRequest {
 
 export namespace CreatePolicyVersionRequest {
   export function isa(o: any): o is CreatePolicyVersionRequest {
-    return _smithy.isa(o, "CreatePolicyVersionRequest");
+    return __isa(o, "CreatePolicyVersionRequest");
   }
 }
 
@@ -916,7 +919,7 @@ export interface CreatePolicyVersionResponse extends $MetadataBearer {
 
 export namespace CreatePolicyVersionResponse {
   export function isa(o: any): o is CreatePolicyVersionResponse {
-    return _smithy.isa(o, "CreatePolicyVersionResponse");
+    return __isa(o, "CreatePolicyVersionResponse");
   }
 }
 
@@ -1011,7 +1014,7 @@ export interface CreateRoleRequest {
 
 export namespace CreateRoleRequest {
   export function isa(o: any): o is CreateRoleRequest {
-    return _smithy.isa(o, "CreateRoleRequest");
+    return __isa(o, "CreateRoleRequest");
   }
 }
 
@@ -1028,7 +1031,7 @@ export interface CreateRoleResponse extends $MetadataBearer {
 
 export namespace CreateRoleResponse {
   export function isa(o: any): o is CreateRoleResponse {
-    return _smithy.isa(o, "CreateRoleResponse");
+    return __isa(o, "CreateRoleResponse");
   }
 }
 
@@ -1056,7 +1059,7 @@ export interface CreateSAMLProviderRequest {
 
 export namespace CreateSAMLProviderRequest {
   export function isa(o: any): o is CreateSAMLProviderRequest {
-    return _smithy.isa(o, "CreateSAMLProviderRequest");
+    return __isa(o, "CreateSAMLProviderRequest");
   }
 }
 
@@ -1074,7 +1077,7 @@ export interface CreateSAMLProviderResponse extends $MetadataBearer {
 
 export namespace CreateSAMLProviderResponse {
   export function isa(o: any): o is CreateSAMLProviderResponse {
-    return _smithy.isa(o, "CreateSAMLProviderResponse");
+    return __isa(o, "CreateSAMLProviderResponse");
   }
 }
 
@@ -1112,7 +1115,7 @@ export interface CreateServiceLinkedRoleRequest {
 
 export namespace CreateServiceLinkedRoleRequest {
   export function isa(o: any): o is CreateServiceLinkedRoleRequest {
-    return _smithy.isa(o, "CreateServiceLinkedRoleRequest");
+    return __isa(o, "CreateServiceLinkedRoleRequest");
   }
 }
 
@@ -1127,7 +1130,7 @@ export interface CreateServiceLinkedRoleResponse extends $MetadataBearer {
 
 export namespace CreateServiceLinkedRoleResponse {
   export function isa(o: any): o is CreateServiceLinkedRoleResponse {
-    return _smithy.isa(o, "CreateServiceLinkedRoleResponse");
+    return __isa(o, "CreateServiceLinkedRoleResponse");
   }
 }
 
@@ -1151,7 +1154,7 @@ export interface CreateServiceSpecificCredentialRequest {
 
 export namespace CreateServiceSpecificCredentialRequest {
   export function isa(o: any): o is CreateServiceSpecificCredentialRequest {
-    return _smithy.isa(o, "CreateServiceSpecificCredentialRequest");
+    return __isa(o, "CreateServiceSpecificCredentialRequest");
   }
 }
 
@@ -1171,7 +1174,7 @@ export interface CreateServiceSpecificCredentialResponse
 
 export namespace CreateServiceSpecificCredentialResponse {
   export function isa(o: any): o is CreateServiceSpecificCredentialResponse {
-    return _smithy.isa(o, "CreateServiceSpecificCredentialResponse");
+    return __isa(o, "CreateServiceSpecificCredentialResponse");
   }
 }
 
@@ -1215,7 +1218,7 @@ export interface CreateUserRequest {
 
 export namespace CreateUserRequest {
   export function isa(o: any): o is CreateUserRequest {
-    return _smithy.isa(o, "CreateUserRequest");
+    return __isa(o, "CreateUserRequest");
   }
 }
 
@@ -1232,7 +1235,7 @@ export interface CreateUserResponse extends $MetadataBearer {
 
 export namespace CreateUserResponse {
   export function isa(o: any): o is CreateUserResponse {
-    return _smithy.isa(o, "CreateUserResponse");
+    return __isa(o, "CreateUserResponse");
   }
 }
 
@@ -1260,7 +1263,7 @@ export interface CreateVirtualMFADeviceRequest {
 
 export namespace CreateVirtualMFADeviceRequest {
   export function isa(o: any): o is CreateVirtualMFADeviceRequest {
-    return _smithy.isa(o, "CreateVirtualMFADeviceRequest");
+    return __isa(o, "CreateVirtualMFADeviceRequest");
   }
 }
 
@@ -1278,7 +1281,7 @@ export interface CreateVirtualMFADeviceResponse extends $MetadataBearer {
 
 export namespace CreateVirtualMFADeviceResponse {
   export function isa(o: any): o is CreateVirtualMFADeviceResponse {
-    return _smithy.isa(o, "CreateVirtualMFADeviceResponse");
+    return __isa(o, "CreateVirtualMFADeviceResponse");
   }
 }
 
@@ -1289,7 +1292,7 @@ export namespace CreateVirtualMFADeviceResponse {
  *         <i>IAM User Guide</i>.</p>
  */
 export interface CredentialReportExpiredException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CredentialReportExpiredException";
   $fault: "client";
@@ -1298,7 +1301,7 @@ export interface CredentialReportExpiredException
 
 export namespace CredentialReportExpiredException {
   export function isa(o: any): o is CredentialReportExpiredException {
-    return _smithy.isa(o, "CredentialReportExpiredException");
+    return __isa(o, "CredentialReportExpiredException");
   }
 }
 
@@ -1307,7 +1310,7 @@ export namespace CredentialReportExpiredException {
  *       credential report, use <a>GenerateCredentialReport</a>.</p>
  */
 export interface CredentialReportNotPresentException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CredentialReportNotPresentException";
   $fault: "client";
@@ -1316,7 +1319,7 @@ export interface CredentialReportNotPresentException
 
 export namespace CredentialReportNotPresentException {
   export function isa(o: any): o is CredentialReportNotPresentException {
-    return _smithy.isa(o, "CredentialReportNotPresentException");
+    return __isa(o, "CredentialReportNotPresentException");
   }
 }
 
@@ -1325,7 +1328,7 @@ export namespace CredentialReportNotPresentException {
  *       generated.</p>
  */
 export interface CredentialReportNotReadyException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CredentialReportNotReadyException";
   $fault: "client";
@@ -1334,7 +1337,7 @@ export interface CredentialReportNotReadyException
 
 export namespace CredentialReportNotReadyException {
   export function isa(o: any): o is CredentialReportNotReadyException {
-    return _smithy.isa(o, "CredentialReportNotReadyException");
+    return __isa(o, "CredentialReportNotReadyException");
   }
 }
 
@@ -1359,7 +1362,7 @@ export interface DeactivateMFADeviceRequest {
 
 export namespace DeactivateMFADeviceRequest {
   export function isa(o: any): o is DeactivateMFADeviceRequest {
-    return _smithy.isa(o, "DeactivateMFADeviceRequest");
+    return __isa(o, "DeactivateMFADeviceRequest");
   }
 }
 
@@ -1382,7 +1385,7 @@ export interface DeleteAccessKeyRequest {
 
 export namespace DeleteAccessKeyRequest {
   export function isa(o: any): o is DeleteAccessKeyRequest {
-    return _smithy.isa(o, "DeleteAccessKeyRequest");
+    return __isa(o, "DeleteAccessKeyRequest");
   }
 }
 
@@ -1399,7 +1402,7 @@ export interface DeleteAccountAliasRequest {
 
 export namespace DeleteAccountAliasRequest {
   export function isa(o: any): o is DeleteAccountAliasRequest {
-    return _smithy.isa(o, "DeleteAccountAliasRequest");
+    return __isa(o, "DeleteAccountAliasRequest");
   }
 }
 
@@ -1408,7 +1411,7 @@ export namespace DeleteAccountAliasRequest {
  *       subordinate entities. The error message describes these entities.</p>
  */
 export interface DeleteConflictException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DeleteConflictException";
   $fault: "client";
@@ -1417,7 +1420,7 @@ export interface DeleteConflictException
 
 export namespace DeleteConflictException {
   export function isa(o: any): o is DeleteConflictException {
-    return _smithy.isa(o, "DeleteConflictException");
+    return __isa(o, "DeleteConflictException");
   }
 }
 
@@ -1441,7 +1444,7 @@ export interface DeleteGroupPolicyRequest {
 
 export namespace DeleteGroupPolicyRequest {
   export function isa(o: any): o is DeleteGroupPolicyRequest {
-    return _smithy.isa(o, "DeleteGroupPolicyRequest");
+    return __isa(o, "DeleteGroupPolicyRequest");
   }
 }
 
@@ -1457,7 +1460,7 @@ export interface DeleteGroupRequest {
 
 export namespace DeleteGroupRequest {
   export function isa(o: any): o is DeleteGroupRequest {
-    return _smithy.isa(o, "DeleteGroupRequest");
+    return __isa(o, "DeleteGroupRequest");
   }
 }
 
@@ -1473,7 +1476,7 @@ export interface DeleteInstanceProfileRequest {
 
 export namespace DeleteInstanceProfileRequest {
   export function isa(o: any): o is DeleteInstanceProfileRequest {
-    return _smithy.isa(o, "DeleteInstanceProfileRequest");
+    return __isa(o, "DeleteInstanceProfileRequest");
   }
 }
 
@@ -1489,7 +1492,7 @@ export interface DeleteLoginProfileRequest {
 
 export namespace DeleteLoginProfileRequest {
   export function isa(o: any): o is DeleteLoginProfileRequest {
-    return _smithy.isa(o, "DeleteLoginProfileRequest");
+    return __isa(o, "DeleteLoginProfileRequest");
   }
 }
 
@@ -1504,7 +1507,7 @@ export interface DeleteOpenIDConnectProviderRequest {
 
 export namespace DeleteOpenIDConnectProviderRequest {
   export function isa(o: any): o is DeleteOpenIDConnectProviderRequest {
-    return _smithy.isa(o, "DeleteOpenIDConnectProviderRequest");
+    return __isa(o, "DeleteOpenIDConnectProviderRequest");
   }
 }
 
@@ -1520,7 +1523,7 @@ export interface DeletePolicyRequest {
 
 export namespace DeletePolicyRequest {
   export function isa(o: any): o is DeletePolicyRequest {
-    return _smithy.isa(o, "DeletePolicyRequest");
+    return __isa(o, "DeletePolicyRequest");
   }
 }
 
@@ -1547,7 +1550,7 @@ export interface DeletePolicyVersionRequest {
 
 export namespace DeletePolicyVersionRequest {
   export function isa(o: any): o is DeletePolicyVersionRequest {
-    return _smithy.isa(o, "DeletePolicyVersionRequest");
+    return __isa(o, "DeletePolicyVersionRequest");
   }
 }
 
@@ -1562,7 +1565,7 @@ export interface DeleteRolePermissionsBoundaryRequest {
 
 export namespace DeleteRolePermissionsBoundaryRequest {
   export function isa(o: any): o is DeleteRolePermissionsBoundaryRequest {
-    return _smithy.isa(o, "DeleteRolePermissionsBoundaryRequest");
+    return __isa(o, "DeleteRolePermissionsBoundaryRequest");
   }
 }
 
@@ -1586,7 +1589,7 @@ export interface DeleteRolePolicyRequest {
 
 export namespace DeleteRolePolicyRequest {
   export function isa(o: any): o is DeleteRolePolicyRequest {
-    return _smithy.isa(o, "DeleteRolePolicyRequest");
+    return __isa(o, "DeleteRolePolicyRequest");
   }
 }
 
@@ -1602,7 +1605,7 @@ export interface DeleteRoleRequest {
 
 export namespace DeleteRoleRequest {
   export function isa(o: any): o is DeleteRoleRequest {
-    return _smithy.isa(o, "DeleteRoleRequest");
+    return __isa(o, "DeleteRoleRequest");
   }
 }
 
@@ -1616,7 +1619,7 @@ export interface DeleteSAMLProviderRequest {
 
 export namespace DeleteSAMLProviderRequest {
   export function isa(o: any): o is DeleteSAMLProviderRequest {
-    return _smithy.isa(o, "DeleteSAMLProviderRequest");
+    return __isa(o, "DeleteSAMLProviderRequest");
   }
 }
 
@@ -1639,7 +1642,7 @@ export interface DeleteSSHPublicKeyRequest {
 
 export namespace DeleteSSHPublicKeyRequest {
   export function isa(o: any): o is DeleteSSHPublicKeyRequest {
-    return _smithy.isa(o, "DeleteSSHPublicKeyRequest");
+    return __isa(o, "DeleteSSHPublicKeyRequest");
   }
 }
 
@@ -1655,7 +1658,7 @@ export interface DeleteServerCertificateRequest {
 
 export namespace DeleteServerCertificateRequest {
   export function isa(o: any): o is DeleteServerCertificateRequest {
-    return _smithy.isa(o, "DeleteServerCertificateRequest");
+    return __isa(o, "DeleteServerCertificateRequest");
   }
 }
 
@@ -1669,7 +1672,7 @@ export interface DeleteServiceLinkedRoleRequest {
 
 export namespace DeleteServiceLinkedRoleRequest {
   export function isa(o: any): o is DeleteServiceLinkedRoleRequest {
-    return _smithy.isa(o, "DeleteServiceLinkedRoleRequest");
+    return __isa(o, "DeleteServiceLinkedRoleRequest");
   }
 }
 
@@ -1685,7 +1688,7 @@ export interface DeleteServiceLinkedRoleResponse extends $MetadataBearer {
 
 export namespace DeleteServiceLinkedRoleResponse {
   export function isa(o: any): o is DeleteServiceLinkedRoleResponse {
-    return _smithy.isa(o, "DeleteServiceLinkedRoleResponse");
+    return __isa(o, "DeleteServiceLinkedRoleResponse");
   }
 }
 
@@ -1711,7 +1714,7 @@ export interface DeleteServiceSpecificCredentialRequest {
 
 export namespace DeleteServiceSpecificCredentialRequest {
   export function isa(o: any): o is DeleteServiceSpecificCredentialRequest {
-    return _smithy.isa(o, "DeleteServiceSpecificCredentialRequest");
+    return __isa(o, "DeleteServiceSpecificCredentialRequest");
   }
 }
 
@@ -1734,7 +1737,7 @@ export interface DeleteSigningCertificateRequest {
 
 export namespace DeleteSigningCertificateRequest {
   export function isa(o: any): o is DeleteSigningCertificateRequest {
-    return _smithy.isa(o, "DeleteSigningCertificateRequest");
+    return __isa(o, "DeleteSigningCertificateRequest");
   }
 }
 
@@ -1749,7 +1752,7 @@ export interface DeleteUserPermissionsBoundaryRequest {
 
 export namespace DeleteUserPermissionsBoundaryRequest {
   export function isa(o: any): o is DeleteUserPermissionsBoundaryRequest {
-    return _smithy.isa(o, "DeleteUserPermissionsBoundaryRequest");
+    return __isa(o, "DeleteUserPermissionsBoundaryRequest");
   }
 }
 
@@ -1773,7 +1776,7 @@ export interface DeleteUserPolicyRequest {
 
 export namespace DeleteUserPolicyRequest {
   export function isa(o: any): o is DeleteUserPolicyRequest {
-    return _smithy.isa(o, "DeleteUserPolicyRequest");
+    return __isa(o, "DeleteUserPolicyRequest");
   }
 }
 
@@ -1789,7 +1792,7 @@ export interface DeleteUserRequest {
 
 export namespace DeleteUserRequest {
   export function isa(o: any): o is DeleteUserRequest {
-    return _smithy.isa(o, "DeleteUserRequest");
+    return __isa(o, "DeleteUserRequest");
   }
 }
 
@@ -1807,7 +1810,7 @@ export interface DeleteVirtualMFADeviceRequest {
 
 export namespace DeleteVirtualMFADeviceRequest {
   export function isa(o: any): o is DeleteVirtualMFADeviceRequest {
-    return _smithy.isa(o, "DeleteVirtualMFADeviceRequest");
+    return __isa(o, "DeleteVirtualMFADeviceRequest");
   }
 }
 
@@ -1835,7 +1838,7 @@ export interface DeletionTaskFailureReasonType {
 
 export namespace DeletionTaskFailureReasonType {
   export function isa(o: any): o is DeletionTaskFailureReasonType {
-    return _smithy.isa(o, "DeletionTaskFailureReasonType");
+    return __isa(o, "DeletionTaskFailureReasonType");
   }
 }
 
@@ -1865,7 +1868,7 @@ export interface DetachGroupPolicyRequest {
 
 export namespace DetachGroupPolicyRequest {
   export function isa(o: any): o is DetachGroupPolicyRequest {
-    return _smithy.isa(o, "DetachGroupPolicyRequest");
+    return __isa(o, "DetachGroupPolicyRequest");
   }
 }
 
@@ -1888,7 +1891,7 @@ export interface DetachRolePolicyRequest {
 
 export namespace DetachRolePolicyRequest {
   export function isa(o: any): o is DetachRolePolicyRequest {
-    return _smithy.isa(o, "DetachRolePolicyRequest");
+    return __isa(o, "DetachRolePolicyRequest");
   }
 }
 
@@ -1911,7 +1914,7 @@ export interface DetachUserPolicyRequest {
 
 export namespace DetachUserPolicyRequest {
   export function isa(o: any): o is DetachUserPolicyRequest {
-    return _smithy.isa(o, "DetachUserPolicyRequest");
+    return __isa(o, "DetachUserPolicyRequest");
   }
 }
 
@@ -1920,7 +1923,7 @@ export namespace DetachUserPolicyRequest {
  *       the account.</p>
  */
 export interface DuplicateCertificateException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DuplicateCertificateException";
   $fault: "client";
@@ -1929,7 +1932,7 @@ export interface DuplicateCertificateException
 
 export namespace DuplicateCertificateException {
   export function isa(o: any): o is DuplicateCertificateException {
-    return _smithy.isa(o, "DuplicateCertificateException");
+    return __isa(o, "DuplicateCertificateException");
   }
 }
 
@@ -1938,7 +1941,7 @@ export namespace DuplicateCertificateException {
  *       specified IAM user.</p>
  */
 export interface DuplicateSSHPublicKeyException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DuplicateSSHPublicKeyException";
   $fault: "client";
@@ -1947,7 +1950,7 @@ export interface DuplicateSSHPublicKeyException
 
 export namespace DuplicateSSHPublicKeyException {
   export function isa(o: any): o is DuplicateSSHPublicKeyException {
-    return _smithy.isa(o, "DuplicateSSHPublicKeyException");
+    return __isa(o, "DuplicateSSHPublicKeyException");
   }
 }
 
@@ -1998,7 +2001,7 @@ export interface EnableMFADeviceRequest {
 
 export namespace EnableMFADeviceRequest {
   export function isa(o: any): o is EnableMFADeviceRequest {
-    return _smithy.isa(o, "EnableMFADeviceRequest");
+    return __isa(o, "EnableMFADeviceRequest");
   }
 }
 
@@ -2007,7 +2010,7 @@ export namespace EnableMFADeviceRequest {
  *       exists.</p>
  */
 export interface EntityAlreadyExistsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "EntityAlreadyExistsException";
   $fault: "client";
@@ -2016,7 +2019,7 @@ export interface EntityAlreadyExistsException
 
 export namespace EntityAlreadyExistsException {
   export function isa(o: any): o is EntityAlreadyExistsException {
-    return _smithy.isa(o, "EntityAlreadyExistsException");
+    return __isa(o, "EntityAlreadyExistsException");
   }
 }
 
@@ -2045,7 +2048,7 @@ export interface EntityDetails {
 
 export namespace EntityDetails {
   export function isa(o: any): o is EntityDetails {
-    return _smithy.isa(o, "EntityDetails");
+    return __isa(o, "EntityDetails");
   }
 }
 
@@ -2086,7 +2089,7 @@ export interface EntityInfo {
 
 export namespace EntityInfo {
   export function isa(o: any): o is EntityInfo {
-    return _smithy.isa(o, "EntityInfo");
+    return __isa(o, "EntityInfo");
   }
 }
 
@@ -2097,7 +2100,7 @@ export namespace EntityInfo {
  *       error message describes the entity.</p>
  */
 export interface EntityTemporarilyUnmodifiableException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "EntityTemporarilyUnmodifiableException";
   $fault: "client";
@@ -2106,7 +2109,7 @@ export interface EntityTemporarilyUnmodifiableException
 
 export namespace EntityTemporarilyUnmodifiableException {
   export function isa(o: any): o is EntityTemporarilyUnmodifiableException {
-    return _smithy.isa(o, "EntityTemporarilyUnmodifiableException");
+    return __isa(o, "EntityTemporarilyUnmodifiableException");
   }
 }
 
@@ -2137,7 +2140,7 @@ export interface ErrorDetails {
 
 export namespace ErrorDetails {
   export function isa(o: any): o is ErrorDetails {
-    return _smithy.isa(o, "ErrorDetails");
+    return __isa(o, "ErrorDetails");
   }
 }
 
@@ -2213,7 +2216,7 @@ export interface EvaluationResult {
 
 export namespace EvaluationResult {
   export function isa(o: any): o is EvaluationResult {
-    return _smithy.isa(o, "EvaluationResult");
+    return __isa(o, "EvaluationResult");
   }
 }
 
@@ -2236,7 +2239,7 @@ export interface GenerateCredentialReportResponse extends $MetadataBearer {
 
 export namespace GenerateCredentialReportResponse {
   export function isa(o: any): o is GenerateCredentialReportResponse {
-    return _smithy.isa(o, "GenerateCredentialReportResponse");
+    return __isa(o, "GenerateCredentialReportResponse");
   }
 }
 
@@ -2263,7 +2266,7 @@ export interface GenerateOrganizationsAccessReportRequest {
 
 export namespace GenerateOrganizationsAccessReportRequest {
   export function isa(o: any): o is GenerateOrganizationsAccessReportRequest {
-    return _smithy.isa(o, "GenerateOrganizationsAccessReportRequest");
+    return __isa(o, "GenerateOrganizationsAccessReportRequest");
   }
 }
 
@@ -2278,7 +2281,7 @@ export interface GenerateOrganizationsAccessReportResponse
 
 export namespace GenerateOrganizationsAccessReportResponse {
   export function isa(o: any): o is GenerateOrganizationsAccessReportResponse {
-    return _smithy.isa(o, "GenerateOrganizationsAccessReportResponse");
+    return __isa(o, "GenerateOrganizationsAccessReportResponse");
   }
 }
 
@@ -2294,7 +2297,7 @@ export interface GenerateServiceLastAccessedDetailsRequest {
 
 export namespace GenerateServiceLastAccessedDetailsRequest {
   export function isa(o: any): o is GenerateServiceLastAccessedDetailsRequest {
-    return _smithy.isa(o, "GenerateServiceLastAccessedDetailsRequest");
+    return __isa(o, "GenerateServiceLastAccessedDetailsRequest");
   }
 }
 
@@ -2310,7 +2313,7 @@ export interface GenerateServiceLastAccessedDetailsResponse
 
 export namespace GenerateServiceLastAccessedDetailsResponse {
   export function isa(o: any): o is GenerateServiceLastAccessedDetailsResponse {
-    return _smithy.isa(o, "GenerateServiceLastAccessedDetailsResponse");
+    return __isa(o, "GenerateServiceLastAccessedDetailsResponse");
   }
 }
 
@@ -2326,7 +2329,7 @@ export interface GetAccessKeyLastUsedRequest {
 
 export namespace GetAccessKeyLastUsedRequest {
   export function isa(o: any): o is GetAccessKeyLastUsedRequest {
-    return _smithy.isa(o, "GetAccessKeyLastUsedRequest");
+    return __isa(o, "GetAccessKeyLastUsedRequest");
   }
 }
 
@@ -2351,7 +2354,7 @@ export interface GetAccessKeyLastUsedResponse extends $MetadataBearer {
 
 export namespace GetAccessKeyLastUsedResponse {
   export function isa(o: any): o is GetAccessKeyLastUsedResponse {
-    return _smithy.isa(o, "GetAccessKeyLastUsedResponse");
+    return __isa(o, "GetAccessKeyLastUsedResponse");
   }
 }
 
@@ -2389,7 +2392,7 @@ export interface GetAccountAuthorizationDetailsRequest {
 
 export namespace GetAccountAuthorizationDetailsRequest {
   export function isa(o: any): o is GetAccountAuthorizationDetailsRequest {
-    return _smithy.isa(o, "GetAccountAuthorizationDetailsRequest");
+    return __isa(o, "GetAccountAuthorizationDetailsRequest");
   }
 }
 
@@ -2440,7 +2443,7 @@ export interface GetAccountAuthorizationDetailsResponse
 
 export namespace GetAccountAuthorizationDetailsResponse {
   export function isa(o: any): o is GetAccountAuthorizationDetailsResponse {
-    return _smithy.isa(o, "GetAccountAuthorizationDetailsResponse");
+    return __isa(o, "GetAccountAuthorizationDetailsResponse");
   }
 }
 
@@ -2458,7 +2461,7 @@ export interface GetAccountPasswordPolicyResponse extends $MetadataBearer {
 
 export namespace GetAccountPasswordPolicyResponse {
   export function isa(o: any): o is GetAccountPasswordPolicyResponse {
-    return _smithy.isa(o, "GetAccountPasswordPolicyResponse");
+    return __isa(o, "GetAccountPasswordPolicyResponse");
   }
 }
 
@@ -2477,7 +2480,7 @@ export interface GetAccountSummaryResponse extends $MetadataBearer {
 
 export namespace GetAccountSummaryResponse {
   export function isa(o: any): o is GetAccountSummaryResponse {
-    return _smithy.isa(o, "GetAccountSummaryResponse");
+    return __isa(o, "GetAccountSummaryResponse");
   }
 }
 
@@ -2509,7 +2512,7 @@ export interface GetContextKeysForCustomPolicyRequest {
 
 export namespace GetContextKeysForCustomPolicyRequest {
   export function isa(o: any): o is GetContextKeysForCustomPolicyRequest {
-    return _smithy.isa(o, "GetContextKeysForCustomPolicyRequest");
+    return __isa(o, "GetContextKeysForCustomPolicyRequest");
   }
 }
 
@@ -2526,7 +2529,7 @@ export interface GetContextKeysForPolicyResponse extends $MetadataBearer {
 
 export namespace GetContextKeysForPolicyResponse {
   export function isa(o: any): o is GetContextKeysForPolicyResponse {
-    return _smithy.isa(o, "GetContextKeysForPolicyResponse");
+    return __isa(o, "GetContextKeysForPolicyResponse");
   }
 }
 
@@ -2570,7 +2573,7 @@ export interface GetContextKeysForPrincipalPolicyRequest {
 
 export namespace GetContextKeysForPrincipalPolicyRequest {
   export function isa(o: any): o is GetContextKeysForPrincipalPolicyRequest {
-    return _smithy.isa(o, "GetContextKeysForPrincipalPolicyRequest");
+    return __isa(o, "GetContextKeysForPrincipalPolicyRequest");
   }
 }
 
@@ -2598,7 +2601,7 @@ export interface GetCredentialReportResponse extends $MetadataBearer {
 
 export namespace GetCredentialReportResponse {
   export function isa(o: any): o is GetCredentialReportResponse {
-    return _smithy.isa(o, "GetCredentialReportResponse");
+    return __isa(o, "GetCredentialReportResponse");
   }
 }
 
@@ -2621,7 +2624,7 @@ export interface GetGroupPolicyRequest {
 
 export namespace GetGroupPolicyRequest {
   export function isa(o: any): o is GetGroupPolicyRequest {
-    return _smithy.isa(o, "GetGroupPolicyRequest");
+    return __isa(o, "GetGroupPolicyRequest");
   }
 }
 
@@ -2652,7 +2655,7 @@ export interface GetGroupPolicyResponse extends $MetadataBearer {
 
 export namespace GetGroupPolicyResponse {
   export function isa(o: any): o is GetGroupPolicyResponse {
-    return _smithy.isa(o, "GetGroupPolicyResponse");
+    return __isa(o, "GetGroupPolicyResponse");
   }
 }
 
@@ -2688,7 +2691,7 @@ export interface GetGroupRequest {
 
 export namespace GetGroupRequest {
   export function isa(o: any): o is GetGroupRequest {
-    return _smithy.isa(o, "GetGroupRequest");
+    return __isa(o, "GetGroupRequest");
   }
 }
 
@@ -2727,7 +2730,7 @@ export interface GetGroupResponse extends $MetadataBearer {
 
 export namespace GetGroupResponse {
   export function isa(o: any): o is GetGroupResponse {
-    return _smithy.isa(o, "GetGroupResponse");
+    return __isa(o, "GetGroupResponse");
   }
 }
 
@@ -2743,7 +2746,7 @@ export interface GetInstanceProfileRequest {
 
 export namespace GetInstanceProfileRequest {
   export function isa(o: any): o is GetInstanceProfileRequest {
-    return _smithy.isa(o, "GetInstanceProfileRequest");
+    return __isa(o, "GetInstanceProfileRequest");
   }
 }
 
@@ -2761,7 +2764,7 @@ export interface GetInstanceProfileResponse extends $MetadataBearer {
 
 export namespace GetInstanceProfileResponse {
   export function isa(o: any): o is GetInstanceProfileResponse {
-    return _smithy.isa(o, "GetInstanceProfileResponse");
+    return __isa(o, "GetInstanceProfileResponse");
   }
 }
 
@@ -2777,7 +2780,7 @@ export interface GetLoginProfileRequest {
 
 export namespace GetLoginProfileRequest {
   export function isa(o: any): o is GetLoginProfileRequest {
-    return _smithy.isa(o, "GetLoginProfileRequest");
+    return __isa(o, "GetLoginProfileRequest");
   }
 }
 
@@ -2795,7 +2798,7 @@ export interface GetLoginProfileResponse extends $MetadataBearer {
 
 export namespace GetLoginProfileResponse {
   export function isa(o: any): o is GetLoginProfileResponse {
-    return _smithy.isa(o, "GetLoginProfileResponse");
+    return __isa(o, "GetLoginProfileResponse");
   }
 }
 
@@ -2812,7 +2815,7 @@ export interface GetOpenIDConnectProviderRequest {
 
 export namespace GetOpenIDConnectProviderRequest {
   export function isa(o: any): o is GetOpenIDConnectProviderRequest {
-    return _smithy.isa(o, "GetOpenIDConnectProviderRequest");
+    return __isa(o, "GetOpenIDConnectProviderRequest");
   }
 }
 
@@ -2849,7 +2852,7 @@ export interface GetOpenIDConnectProviderResponse extends $MetadataBearer {
 
 export namespace GetOpenIDConnectProviderResponse {
   export function isa(o: any): o is GetOpenIDConnectProviderResponse {
-    return _smithy.isa(o, "GetOpenIDConnectProviderResponse");
+    return __isa(o, "GetOpenIDConnectProviderResponse");
   }
 }
 
@@ -2890,7 +2893,7 @@ export interface GetOrganizationsAccessReportRequest {
 
 export namespace GetOrganizationsAccessReportRequest {
   export function isa(o: any): o is GetOrganizationsAccessReportRequest {
-    return _smithy.isa(o, "GetOrganizationsAccessReportRequest");
+    return __isa(o, "GetOrganizationsAccessReportRequest");
   }
 }
 
@@ -2959,7 +2962,7 @@ export interface GetOrganizationsAccessReportResponse extends $MetadataBearer {
 
 export namespace GetOrganizationsAccessReportResponse {
   export function isa(o: any): o is GetOrganizationsAccessReportResponse {
-    return _smithy.isa(o, "GetOrganizationsAccessReportResponse");
+    return __isa(o, "GetOrganizationsAccessReportResponse");
   }
 }
 
@@ -2976,7 +2979,7 @@ export interface GetPolicyRequest {
 
 export namespace GetPolicyRequest {
   export function isa(o: any): o is GetPolicyRequest {
-    return _smithy.isa(o, "GetPolicyRequest");
+    return __isa(o, "GetPolicyRequest");
   }
 }
 
@@ -2993,7 +2996,7 @@ export interface GetPolicyResponse extends $MetadataBearer {
 
 export namespace GetPolicyResponse {
   export function isa(o: any): o is GetPolicyResponse {
-    return _smithy.isa(o, "GetPolicyResponse");
+    return __isa(o, "GetPolicyResponse");
   }
 }
 
@@ -3018,7 +3021,7 @@ export interface GetPolicyVersionRequest {
 
 export namespace GetPolicyVersionRequest {
   export function isa(o: any): o is GetPolicyVersionRequest {
-    return _smithy.isa(o, "GetPolicyVersionRequest");
+    return __isa(o, "GetPolicyVersionRequest");
   }
 }
 
@@ -3036,7 +3039,7 @@ export interface GetPolicyVersionResponse extends $MetadataBearer {
 
 export namespace GetPolicyVersionResponse {
   export function isa(o: any): o is GetPolicyVersionResponse {
-    return _smithy.isa(o, "GetPolicyVersionResponse");
+    return __isa(o, "GetPolicyVersionResponse");
   }
 }
 
@@ -3059,7 +3062,7 @@ export interface GetRolePolicyRequest {
 
 export namespace GetRolePolicyRequest {
   export function isa(o: any): o is GetRolePolicyRequest {
-    return _smithy.isa(o, "GetRolePolicyRequest");
+    return __isa(o, "GetRolePolicyRequest");
   }
 }
 
@@ -3090,7 +3093,7 @@ export interface GetRolePolicyResponse extends $MetadataBearer {
 
 export namespace GetRolePolicyResponse {
   export function isa(o: any): o is GetRolePolicyResponse {
-    return _smithy.isa(o, "GetRolePolicyResponse");
+    return __isa(o, "GetRolePolicyResponse");
   }
 }
 
@@ -3106,7 +3109,7 @@ export interface GetRoleRequest {
 
 export namespace GetRoleRequest {
   export function isa(o: any): o is GetRoleRequest {
-    return _smithy.isa(o, "GetRoleRequest");
+    return __isa(o, "GetRoleRequest");
   }
 }
 
@@ -3123,7 +3126,7 @@ export interface GetRoleResponse extends $MetadataBearer {
 
 export namespace GetRoleResponse {
   export function isa(o: any): o is GetRoleResponse {
-    return _smithy.isa(o, "GetRoleResponse");
+    return __isa(o, "GetRoleResponse");
   }
 }
 
@@ -3140,7 +3143,7 @@ export interface GetSAMLProviderRequest {
 
 export namespace GetSAMLProviderRequest {
   export function isa(o: any): o is GetSAMLProviderRequest {
-    return _smithy.isa(o, "GetSAMLProviderRequest");
+    return __isa(o, "GetSAMLProviderRequest");
   }
 }
 
@@ -3168,7 +3171,7 @@ export interface GetSAMLProviderResponse extends $MetadataBearer {
 
 export namespace GetSAMLProviderResponse {
   export function isa(o: any): o is GetSAMLProviderResponse {
-    return _smithy.isa(o, "GetSAMLProviderResponse");
+    return __isa(o, "GetSAMLProviderResponse");
   }
 }
 
@@ -3198,7 +3201,7 @@ export interface GetSSHPublicKeyRequest {
 
 export namespace GetSSHPublicKeyRequest {
   export function isa(o: any): o is GetSSHPublicKeyRequest {
-    return _smithy.isa(o, "GetSSHPublicKeyRequest");
+    return __isa(o, "GetSSHPublicKeyRequest");
   }
 }
 
@@ -3216,7 +3219,7 @@ export interface GetSSHPublicKeyResponse extends $MetadataBearer {
 
 export namespace GetSSHPublicKeyResponse {
   export function isa(o: any): o is GetSSHPublicKeyResponse {
-    return _smithy.isa(o, "GetSSHPublicKeyResponse");
+    return __isa(o, "GetSSHPublicKeyResponse");
   }
 }
 
@@ -3232,7 +3235,7 @@ export interface GetServerCertificateRequest {
 
 export namespace GetServerCertificateRequest {
   export function isa(o: any): o is GetServerCertificateRequest {
-    return _smithy.isa(o, "GetServerCertificateRequest");
+    return __isa(o, "GetServerCertificateRequest");
   }
 }
 
@@ -3250,7 +3253,7 @@ export interface GetServerCertificateResponse extends $MetadataBearer {
 
 export namespace GetServerCertificateResponse {
   export function isa(o: any): o is GetServerCertificateResponse {
-    return _smithy.isa(o, "GetServerCertificateResponse");
+    return __isa(o, "GetServerCertificateResponse");
   }
 }
 
@@ -3284,7 +3287,7 @@ export interface GetServiceLastAccessedDetailsRequest {
 
 export namespace GetServiceLastAccessedDetailsRequest {
   export function isa(o: any): o is GetServiceLastAccessedDetailsRequest {
-    return _smithy.isa(o, "GetServiceLastAccessedDetailsRequest");
+    return __isa(o, "GetServiceLastAccessedDetailsRequest");
   }
 }
 
@@ -3341,7 +3344,7 @@ export interface GetServiceLastAccessedDetailsResponse extends $MetadataBearer {
 
 export namespace GetServiceLastAccessedDetailsResponse {
   export function isa(o: any): o is GetServiceLastAccessedDetailsResponse {
-    return _smithy.isa(o, "GetServiceLastAccessedDetailsResponse");
+    return __isa(o, "GetServiceLastAccessedDetailsResponse");
   }
 }
 
@@ -3391,7 +3394,7 @@ export namespace GetServiceLastAccessedDetailsWithEntitiesRequest {
   export function isa(
     o: any
   ): o is GetServiceLastAccessedDetailsWithEntitiesRequest {
-    return _smithy.isa(o, "GetServiceLastAccessedDetailsWithEntitiesRequest");
+    return __isa(o, "GetServiceLastAccessedDetailsWithEntitiesRequest");
   }
 }
 
@@ -3451,7 +3454,7 @@ export namespace GetServiceLastAccessedDetailsWithEntitiesResponse {
   export function isa(
     o: any
   ): o is GetServiceLastAccessedDetailsWithEntitiesResponse {
-    return _smithy.isa(o, "GetServiceLastAccessedDetailsWithEntitiesResponse");
+    return __isa(o, "GetServiceLastAccessedDetailsWithEntitiesResponse");
   }
 }
 
@@ -3466,7 +3469,7 @@ export interface GetServiceLinkedRoleDeletionStatusRequest {
 
 export namespace GetServiceLinkedRoleDeletionStatusRequest {
   export function isa(o: any): o is GetServiceLinkedRoleDeletionStatusRequest {
-    return _smithy.isa(o, "GetServiceLinkedRoleDeletionStatusRequest");
+    return __isa(o, "GetServiceLinkedRoleDeletionStatusRequest");
   }
 }
 
@@ -3486,7 +3489,7 @@ export interface GetServiceLinkedRoleDeletionStatusResponse
 
 export namespace GetServiceLinkedRoleDeletionStatusResponse {
   export function isa(o: any): o is GetServiceLinkedRoleDeletionStatusResponse {
-    return _smithy.isa(o, "GetServiceLinkedRoleDeletionStatusResponse");
+    return __isa(o, "GetServiceLinkedRoleDeletionStatusResponse");
   }
 }
 
@@ -3509,7 +3512,7 @@ export interface GetUserPolicyRequest {
 
 export namespace GetUserPolicyRequest {
   export function isa(o: any): o is GetUserPolicyRequest {
-    return _smithy.isa(o, "GetUserPolicyRequest");
+    return __isa(o, "GetUserPolicyRequest");
   }
 }
 
@@ -3540,7 +3543,7 @@ export interface GetUserPolicyResponse extends $MetadataBearer {
 
 export namespace GetUserPolicyResponse {
   export function isa(o: any): o is GetUserPolicyResponse {
-    return _smithy.isa(o, "GetUserPolicyResponse");
+    return __isa(o, "GetUserPolicyResponse");
   }
 }
 
@@ -3557,7 +3560,7 @@ export interface GetUserRequest {
 
 export namespace GetUserRequest {
   export function isa(o: any): o is GetUserRequest {
-    return _smithy.isa(o, "GetUserRequest");
+    return __isa(o, "GetUserRequest");
   }
 }
 
@@ -3589,7 +3592,7 @@ export interface GetUserResponse extends $MetadataBearer {
 
 export namespace GetUserResponse {
   export function isa(o: any): o is GetUserResponse {
-    return _smithy.isa(o, "GetUserResponse");
+    return __isa(o, "GetUserResponse");
   }
 }
 
@@ -3650,7 +3653,7 @@ export interface Group {
 
 export namespace Group {
   export function isa(o: any): o is Group {
-    return _smithy.isa(o, "Group");
+    return __isa(o, "Group");
   }
 }
 
@@ -3704,7 +3707,7 @@ export interface GroupDetail {
 
 export namespace GroupDetail {
   export function isa(o: any): o is GroupDetail {
-    return _smithy.isa(o, "GroupDetail");
+    return __isa(o, "GroupDetail");
   }
 }
 
@@ -3773,7 +3776,7 @@ export interface InstanceProfile {
 
 export namespace InstanceProfile {
   export function isa(o: any): o is InstanceProfile {
-    return _smithy.isa(o, "InstanceProfile");
+    return __isa(o, "InstanceProfile");
   }
 }
 
@@ -3782,7 +3785,7 @@ export namespace InstanceProfile {
  *       message describes the specific error.</p>
  */
 export interface InvalidAuthenticationCodeException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidAuthenticationCodeException";
   $fault: "client";
@@ -3791,7 +3794,7 @@ export interface InvalidAuthenticationCodeException
 
 export namespace InvalidAuthenticationCodeException {
   export function isa(o: any): o is InvalidAuthenticationCodeException {
-    return _smithy.isa(o, "InvalidAuthenticationCodeException");
+    return __isa(o, "InvalidAuthenticationCodeException");
   }
 }
 
@@ -3799,7 +3802,7 @@ export namespace InvalidAuthenticationCodeException {
  * <p>The request was rejected because the certificate is invalid.</p>
  */
 export interface InvalidCertificateException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidCertificateException";
   $fault: "client";
@@ -3808,7 +3811,7 @@ export interface InvalidCertificateException
 
 export namespace InvalidCertificateException {
   export function isa(o: any): o is InvalidCertificateException {
-    return _smithy.isa(o, "InvalidCertificateException");
+    return __isa(o, "InvalidCertificateException");
   }
 }
 
@@ -3817,7 +3820,7 @@ export namespace InvalidCertificateException {
  *       input parameter.</p>
  */
 export interface InvalidInputException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidInputException";
   $fault: "client";
@@ -3826,7 +3829,7 @@ export interface InvalidInputException
 
 export namespace InvalidInputException {
   export function isa(o: any): o is InvalidInputException {
-    return _smithy.isa(o, "InvalidInputException");
+    return __isa(o, "InvalidInputException");
   }
 }
 
@@ -3835,7 +3838,7 @@ export namespace InvalidInputException {
  *       invalid.</p>
  */
 export interface InvalidPublicKeyException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidPublicKeyException";
   $fault: "client";
@@ -3844,7 +3847,7 @@ export interface InvalidPublicKeyException
 
 export namespace InvalidPublicKeyException {
   export function isa(o: any): o is InvalidPublicKeyException {
-    return _smithy.isa(o, "InvalidPublicKeyException");
+    return __isa(o, "InvalidPublicKeyException");
   }
 }
 
@@ -3853,7 +3856,7 @@ export namespace InvalidPublicKeyException {
  *       incorrect.</p>
  */
 export interface InvalidUserTypeException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidUserTypeException";
   $fault: "client";
@@ -3862,7 +3865,7 @@ export interface InvalidUserTypeException
 
 export namespace InvalidUserTypeException {
   export function isa(o: any): o is InvalidUserTypeException {
-    return _smithy.isa(o, "InvalidUserTypeException");
+    return __isa(o, "InvalidUserTypeException");
   }
 }
 
@@ -3871,7 +3874,7 @@ export namespace InvalidUserTypeException {
  *       match.</p>
  */
 export interface KeyPairMismatchException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "KeyPairMismatchException";
   $fault: "client";
@@ -3880,7 +3883,7 @@ export interface KeyPairMismatchException
 
 export namespace KeyPairMismatchException {
   export function isa(o: any): o is KeyPairMismatchException {
-    return _smithy.isa(o, "KeyPairMismatchException");
+    return __isa(o, "KeyPairMismatchException");
   }
 }
 
@@ -3889,7 +3892,7 @@ export namespace KeyPairMismatchException {
  *       AWS account limits. The error message describes the limit exceeded.</p>
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -3898,7 +3901,7 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
@@ -3934,7 +3937,7 @@ export interface ListAccessKeysRequest {
 
 export namespace ListAccessKeysRequest {
   export function isa(o: any): o is ListAccessKeysRequest {
-    return _smithy.isa(o, "ListAccessKeysRequest");
+    return __isa(o, "ListAccessKeysRequest");
   }
 }
 
@@ -3969,7 +3972,7 @@ export interface ListAccessKeysResponse extends $MetadataBearer {
 
 export namespace ListAccessKeysResponse {
   export function isa(o: any): o is ListAccessKeysResponse {
-    return _smithy.isa(o, "ListAccessKeysResponse");
+    return __isa(o, "ListAccessKeysResponse");
   }
 }
 
@@ -3998,7 +4001,7 @@ export interface ListAccountAliasesRequest {
 
 export namespace ListAccountAliasesRequest {
   export function isa(o: any): o is ListAccountAliasesRequest {
-    return _smithy.isa(o, "ListAccountAliasesRequest");
+    return __isa(o, "ListAccountAliasesRequest");
   }
 }
 
@@ -4034,7 +4037,7 @@ export interface ListAccountAliasesResponse extends $MetadataBearer {
 
 export namespace ListAccountAliasesResponse {
   export function isa(o: any): o is ListAccountAliasesResponse {
-    return _smithy.isa(o, "ListAccountAliasesResponse");
+    return __isa(o, "ListAccountAliasesResponse");
   }
 }
 
@@ -4080,7 +4083,7 @@ export interface ListAttachedGroupPoliciesRequest {
 
 export namespace ListAttachedGroupPoliciesRequest {
   export function isa(o: any): o is ListAttachedGroupPoliciesRequest {
-    return _smithy.isa(o, "ListAttachedGroupPoliciesRequest");
+    return __isa(o, "ListAttachedGroupPoliciesRequest");
   }
 }
 
@@ -4115,7 +4118,7 @@ export interface ListAttachedGroupPoliciesResponse extends $MetadataBearer {
 
 export namespace ListAttachedGroupPoliciesResponse {
   export function isa(o: any): o is ListAttachedGroupPoliciesResponse {
-    return _smithy.isa(o, "ListAttachedGroupPoliciesResponse");
+    return __isa(o, "ListAttachedGroupPoliciesResponse");
   }
 }
 
@@ -4161,7 +4164,7 @@ export interface ListAttachedRolePoliciesRequest {
 
 export namespace ListAttachedRolePoliciesRequest {
   export function isa(o: any): o is ListAttachedRolePoliciesRequest {
-    return _smithy.isa(o, "ListAttachedRolePoliciesRequest");
+    return __isa(o, "ListAttachedRolePoliciesRequest");
   }
 }
 
@@ -4196,7 +4199,7 @@ export interface ListAttachedRolePoliciesResponse extends $MetadataBearer {
 
 export namespace ListAttachedRolePoliciesResponse {
   export function isa(o: any): o is ListAttachedRolePoliciesResponse {
-    return _smithy.isa(o, "ListAttachedRolePoliciesResponse");
+    return __isa(o, "ListAttachedRolePoliciesResponse");
   }
 }
 
@@ -4242,7 +4245,7 @@ export interface ListAttachedUserPoliciesRequest {
 
 export namespace ListAttachedUserPoliciesRequest {
   export function isa(o: any): o is ListAttachedUserPoliciesRequest {
-    return _smithy.isa(o, "ListAttachedUserPoliciesRequest");
+    return __isa(o, "ListAttachedUserPoliciesRequest");
   }
 }
 
@@ -4277,7 +4280,7 @@ export interface ListAttachedUserPoliciesResponse extends $MetadataBearer {
 
 export namespace ListAttachedUserPoliciesResponse {
   export function isa(o: any): o is ListAttachedUserPoliciesResponse {
-    return _smithy.isa(o, "ListAttachedUserPoliciesResponse");
+    return __isa(o, "ListAttachedUserPoliciesResponse");
   }
 }
 
@@ -4343,7 +4346,7 @@ export interface ListEntitiesForPolicyRequest {
 
 export namespace ListEntitiesForPolicyRequest {
   export function isa(o: any): o is ListEntitiesForPolicyRequest {
-    return _smithy.isa(o, "ListEntitiesForPolicyRequest");
+    return __isa(o, "ListEntitiesForPolicyRequest");
   }
 }
 
@@ -4388,7 +4391,7 @@ export interface ListEntitiesForPolicyResponse extends $MetadataBearer {
 
 export namespace ListEntitiesForPolicyResponse {
   export function isa(o: any): o is ListEntitiesForPolicyResponse {
-    return _smithy.isa(o, "ListEntitiesForPolicyResponse");
+    return __isa(o, "ListEntitiesForPolicyResponse");
   }
 }
 
@@ -4424,7 +4427,7 @@ export interface ListGroupPoliciesRequest {
 
 export namespace ListGroupPoliciesRequest {
   export function isa(o: any): o is ListGroupPoliciesRequest {
-    return _smithy.isa(o, "ListGroupPoliciesRequest");
+    return __isa(o, "ListGroupPoliciesRequest");
   }
 }
 
@@ -4461,7 +4464,7 @@ export interface ListGroupPoliciesResponse extends $MetadataBearer {
 
 export namespace ListGroupPoliciesResponse {
   export function isa(o: any): o is ListGroupPoliciesResponse {
-    return _smithy.isa(o, "ListGroupPoliciesResponse");
+    return __isa(o, "ListGroupPoliciesResponse");
   }
 }
 
@@ -4497,7 +4500,7 @@ export interface ListGroupsForUserRequest {
 
 export namespace ListGroupsForUserRequest {
   export function isa(o: any): o is ListGroupsForUserRequest {
-    return _smithy.isa(o, "ListGroupsForUserRequest");
+    return __isa(o, "ListGroupsForUserRequest");
   }
 }
 
@@ -4532,7 +4535,7 @@ export interface ListGroupsForUserResponse extends $MetadataBearer {
 
 export namespace ListGroupsForUserResponse {
   export function isa(o: any): o is ListGroupsForUserResponse {
-    return _smithy.isa(o, "ListGroupsForUserResponse");
+    return __isa(o, "ListGroupsForUserResponse");
   }
 }
 
@@ -4573,7 +4576,7 @@ export interface ListGroupsRequest {
 
 export namespace ListGroupsRequest {
   export function isa(o: any): o is ListGroupsRequest {
-    return _smithy.isa(o, "ListGroupsRequest");
+    return __isa(o, "ListGroupsRequest");
   }
 }
 
@@ -4607,7 +4610,7 @@ export interface ListGroupsResponse extends $MetadataBearer {
 
 export namespace ListGroupsResponse {
   export function isa(o: any): o is ListGroupsResponse {
-    return _smithy.isa(o, "ListGroupsResponse");
+    return __isa(o, "ListGroupsResponse");
   }
 }
 
@@ -4643,7 +4646,7 @@ export interface ListInstanceProfilesForRoleRequest {
 
 export namespace ListInstanceProfilesForRoleRequest {
   export function isa(o: any): o is ListInstanceProfilesForRoleRequest {
-    return _smithy.isa(o, "ListInstanceProfilesForRoleRequest");
+    return __isa(o, "ListInstanceProfilesForRoleRequest");
   }
 }
 
@@ -4678,7 +4681,7 @@ export interface ListInstanceProfilesForRoleResponse extends $MetadataBearer {
 
 export namespace ListInstanceProfilesForRoleResponse {
   export function isa(o: any): o is ListInstanceProfilesForRoleResponse {
-    return _smithy.isa(o, "ListInstanceProfilesForRoleResponse");
+    return __isa(o, "ListInstanceProfilesForRoleResponse");
   }
 }
 
@@ -4719,7 +4722,7 @@ export interface ListInstanceProfilesRequest {
 
 export namespace ListInstanceProfilesRequest {
   export function isa(o: any): o is ListInstanceProfilesRequest {
-    return _smithy.isa(o, "ListInstanceProfilesRequest");
+    return __isa(o, "ListInstanceProfilesRequest");
   }
 }
 
@@ -4754,7 +4757,7 @@ export interface ListInstanceProfilesResponse extends $MetadataBearer {
 
 export namespace ListInstanceProfilesResponse {
   export function isa(o: any): o is ListInstanceProfilesResponse {
-    return _smithy.isa(o, "ListInstanceProfilesResponse");
+    return __isa(o, "ListInstanceProfilesResponse");
   }
 }
 
@@ -4790,7 +4793,7 @@ export interface ListMFADevicesRequest {
 
 export namespace ListMFADevicesRequest {
   export function isa(o: any): o is ListMFADevicesRequest {
-    return _smithy.isa(o, "ListMFADevicesRequest");
+    return __isa(o, "ListMFADevicesRequest");
   }
 }
 
@@ -4825,7 +4828,7 @@ export interface ListMFADevicesResponse extends $MetadataBearer {
 
 export namespace ListMFADevicesResponse {
   export function isa(o: any): o is ListMFADevicesResponse {
-    return _smithy.isa(o, "ListMFADevicesResponse");
+    return __isa(o, "ListMFADevicesResponse");
   }
 }
 
@@ -4835,7 +4838,7 @@ export interface ListOpenIDConnectProvidersRequest {
 
 export namespace ListOpenIDConnectProvidersRequest {
   export function isa(o: any): o is ListOpenIDConnectProvidersRequest {
-    return _smithy.isa(o, "ListOpenIDConnectProvidersRequest");
+    return __isa(o, "ListOpenIDConnectProvidersRequest");
   }
 }
 
@@ -4853,7 +4856,7 @@ export interface ListOpenIDConnectProvidersResponse extends $MetadataBearer {
 
 export namespace ListOpenIDConnectProvidersResponse {
   export function isa(o: any): o is ListOpenIDConnectProvidersResponse {
-    return _smithy.isa(o, "ListOpenIDConnectProvidersResponse");
+    return __isa(o, "ListOpenIDConnectProvidersResponse");
   }
 }
 
@@ -4885,7 +4888,7 @@ export interface ListPoliciesGrantingServiceAccessEntry {
 
 export namespace ListPoliciesGrantingServiceAccessEntry {
   export function isa(o: any): o is ListPoliciesGrantingServiceAccessEntry {
-    return _smithy.isa(o, "ListPoliciesGrantingServiceAccessEntry");
+    return __isa(o, "ListPoliciesGrantingServiceAccessEntry");
   }
 }
 
@@ -4920,7 +4923,7 @@ export interface ListPoliciesGrantingServiceAccessRequest {
 
 export namespace ListPoliciesGrantingServiceAccessRequest {
   export function isa(o: any): o is ListPoliciesGrantingServiceAccessRequest {
-    return _smithy.isa(o, "ListPoliciesGrantingServiceAccessRequest");
+    return __isa(o, "ListPoliciesGrantingServiceAccessRequest");
   }
 }
 
@@ -4954,7 +4957,7 @@ export interface ListPoliciesGrantingServiceAccessResponse
 
 export namespace ListPoliciesGrantingServiceAccessResponse {
   export function isa(o: any): o is ListPoliciesGrantingServiceAccessResponse {
-    return _smithy.isa(o, "ListPoliciesGrantingServiceAccessResponse");
+    return __isa(o, "ListPoliciesGrantingServiceAccessResponse");
   }
 }
 
@@ -5021,7 +5024,7 @@ export interface ListPoliciesRequest {
 
 export namespace ListPoliciesRequest {
   export function isa(o: any): o is ListPoliciesRequest {
-    return _smithy.isa(o, "ListPoliciesRequest");
+    return __isa(o, "ListPoliciesRequest");
   }
 }
 
@@ -5056,7 +5059,7 @@ export interface ListPoliciesResponse extends $MetadataBearer {
 
 export namespace ListPoliciesResponse {
   export function isa(o: any): o is ListPoliciesResponse {
-    return _smithy.isa(o, "ListPoliciesResponse");
+    return __isa(o, "ListPoliciesResponse");
   }
 }
 
@@ -5093,7 +5096,7 @@ export interface ListPolicyVersionsRequest {
 
 export namespace ListPolicyVersionsRequest {
   export function isa(o: any): o is ListPolicyVersionsRequest {
-    return _smithy.isa(o, "ListPolicyVersionsRequest");
+    return __isa(o, "ListPolicyVersionsRequest");
   }
 }
 
@@ -5130,7 +5133,7 @@ export interface ListPolicyVersionsResponse extends $MetadataBearer {
 
 export namespace ListPolicyVersionsResponse {
   export function isa(o: any): o is ListPolicyVersionsResponse {
-    return _smithy.isa(o, "ListPolicyVersionsResponse");
+    return __isa(o, "ListPolicyVersionsResponse");
   }
 }
 
@@ -5166,7 +5169,7 @@ export interface ListRolePoliciesRequest {
 
 export namespace ListRolePoliciesRequest {
   export function isa(o: any): o is ListRolePoliciesRequest {
-    return _smithy.isa(o, "ListRolePoliciesRequest");
+    return __isa(o, "ListRolePoliciesRequest");
   }
 }
 
@@ -5201,7 +5204,7 @@ export interface ListRolePoliciesResponse extends $MetadataBearer {
 
 export namespace ListRolePoliciesResponse {
   export function isa(o: any): o is ListRolePoliciesResponse {
-    return _smithy.isa(o, "ListRolePoliciesResponse");
+    return __isa(o, "ListRolePoliciesResponse");
   }
 }
 
@@ -5236,7 +5239,7 @@ export interface ListRoleTagsRequest {
 
 export namespace ListRoleTagsRequest {
   export function isa(o: any): o is ListRoleTagsRequest {
-    return _smithy.isa(o, "ListRoleTagsRequest");
+    return __isa(o, "ListRoleTagsRequest");
   }
 }
 
@@ -5267,7 +5270,7 @@ export interface ListRoleTagsResponse extends $MetadataBearer {
 
 export namespace ListRoleTagsResponse {
   export function isa(o: any): o is ListRoleTagsResponse {
-    return _smithy.isa(o, "ListRoleTagsResponse");
+    return __isa(o, "ListRoleTagsResponse");
   }
 }
 
@@ -5308,7 +5311,7 @@ export interface ListRolesRequest {
 
 export namespace ListRolesRequest {
   export function isa(o: any): o is ListRolesRequest {
-    return _smithy.isa(o, "ListRolesRequest");
+    return __isa(o, "ListRolesRequest");
   }
 }
 
@@ -5342,7 +5345,7 @@ export interface ListRolesResponse extends $MetadataBearer {
 
 export namespace ListRolesResponse {
   export function isa(o: any): o is ListRolesResponse {
-    return _smithy.isa(o, "ListRolesResponse");
+    return __isa(o, "ListRolesResponse");
   }
 }
 
@@ -5352,7 +5355,7 @@ export interface ListSAMLProvidersRequest {
 
 export namespace ListSAMLProvidersRequest {
   export function isa(o: any): o is ListSAMLProvidersRequest {
-    return _smithy.isa(o, "ListSAMLProvidersRequest");
+    return __isa(o, "ListSAMLProvidersRequest");
   }
 }
 
@@ -5371,7 +5374,7 @@ export interface ListSAMLProvidersResponse extends $MetadataBearer {
 
 export namespace ListSAMLProvidersResponse {
   export function isa(o: any): o is ListSAMLProvidersResponse {
-    return _smithy.isa(o, "ListSAMLProvidersResponse");
+    return __isa(o, "ListSAMLProvidersResponse");
   }
 }
 
@@ -5409,7 +5412,7 @@ export interface ListSSHPublicKeysRequest {
 
 export namespace ListSSHPublicKeysRequest {
   export function isa(o: any): o is ListSSHPublicKeysRequest {
-    return _smithy.isa(o, "ListSSHPublicKeysRequest");
+    return __isa(o, "ListSSHPublicKeysRequest");
   }
 }
 
@@ -5444,7 +5447,7 @@ export interface ListSSHPublicKeysResponse extends $MetadataBearer {
 
 export namespace ListSSHPublicKeysResponse {
   export function isa(o: any): o is ListSSHPublicKeysResponse {
-    return _smithy.isa(o, "ListSSHPublicKeysResponse");
+    return __isa(o, "ListSSHPublicKeysResponse");
   }
 }
 
@@ -5485,7 +5488,7 @@ export interface ListServerCertificatesRequest {
 
 export namespace ListServerCertificatesRequest {
   export function isa(o: any): o is ListServerCertificatesRequest {
-    return _smithy.isa(o, "ListServerCertificatesRequest");
+    return __isa(o, "ListServerCertificatesRequest");
   }
 }
 
@@ -5520,7 +5523,7 @@ export interface ListServerCertificatesResponse extends $MetadataBearer {
 
 export namespace ListServerCertificatesResponse {
   export function isa(o: any): o is ListServerCertificatesResponse {
-    return _smithy.isa(o, "ListServerCertificatesResponse");
+    return __isa(o, "ListServerCertificatesResponse");
   }
 }
 
@@ -5544,7 +5547,7 @@ export interface ListServiceSpecificCredentialsRequest {
 
 export namespace ListServiceSpecificCredentialsRequest {
   export function isa(o: any): o is ListServiceSpecificCredentialsRequest {
-    return _smithy.isa(o, "ListServiceSpecificCredentialsRequest");
+    return __isa(o, "ListServiceSpecificCredentialsRequest");
   }
 }
 
@@ -5560,7 +5563,7 @@ export interface ListServiceSpecificCredentialsResponse
 
 export namespace ListServiceSpecificCredentialsResponse {
   export function isa(o: any): o is ListServiceSpecificCredentialsResponse {
-    return _smithy.isa(o, "ListServiceSpecificCredentialsResponse");
+    return __isa(o, "ListServiceSpecificCredentialsResponse");
   }
 }
 
@@ -5596,7 +5599,7 @@ export interface ListSigningCertificatesRequest {
 
 export namespace ListSigningCertificatesRequest {
   export function isa(o: any): o is ListSigningCertificatesRequest {
-    return _smithy.isa(o, "ListSigningCertificatesRequest");
+    return __isa(o, "ListSigningCertificatesRequest");
   }
 }
 
@@ -5631,7 +5634,7 @@ export interface ListSigningCertificatesResponse extends $MetadataBearer {
 
 export namespace ListSigningCertificatesResponse {
   export function isa(o: any): o is ListSigningCertificatesResponse {
-    return _smithy.isa(o, "ListSigningCertificatesResponse");
+    return __isa(o, "ListSigningCertificatesResponse");
   }
 }
 
@@ -5667,7 +5670,7 @@ export interface ListUserPoliciesRequest {
 
 export namespace ListUserPoliciesRequest {
   export function isa(o: any): o is ListUserPoliciesRequest {
-    return _smithy.isa(o, "ListUserPoliciesRequest");
+    return __isa(o, "ListUserPoliciesRequest");
   }
 }
 
@@ -5702,7 +5705,7 @@ export interface ListUserPoliciesResponse extends $MetadataBearer {
 
 export namespace ListUserPoliciesResponse {
   export function isa(o: any): o is ListUserPoliciesResponse {
-    return _smithy.isa(o, "ListUserPoliciesResponse");
+    return __isa(o, "ListUserPoliciesResponse");
   }
 }
 
@@ -5737,7 +5740,7 @@ export interface ListUserTagsRequest {
 
 export namespace ListUserTagsRequest {
   export function isa(o: any): o is ListUserTagsRequest {
-    return _smithy.isa(o, "ListUserTagsRequest");
+    return __isa(o, "ListUserTagsRequest");
   }
 }
 
@@ -5768,7 +5771,7 @@ export interface ListUserTagsResponse extends $MetadataBearer {
 
 export namespace ListUserTagsResponse {
   export function isa(o: any): o is ListUserTagsResponse {
-    return _smithy.isa(o, "ListUserTagsResponse");
+    return __isa(o, "ListUserTagsResponse");
   }
 }
 
@@ -5809,7 +5812,7 @@ export interface ListUsersRequest {
 
 export namespace ListUsersRequest {
   export function isa(o: any): o is ListUsersRequest {
-    return _smithy.isa(o, "ListUsersRequest");
+    return __isa(o, "ListUsersRequest");
   }
 }
 
@@ -5843,7 +5846,7 @@ export interface ListUsersResponse extends $MetadataBearer {
 
 export namespace ListUsersResponse {
   export function isa(o: any): o is ListUsersResponse {
-    return _smithy.isa(o, "ListUsersResponse");
+    return __isa(o, "ListUsersResponse");
   }
 }
 
@@ -5879,7 +5882,7 @@ export interface ListVirtualMFADevicesRequest {
 
 export namespace ListVirtualMFADevicesRequest {
   export function isa(o: any): o is ListVirtualMFADevicesRequest {
-    return _smithy.isa(o, "ListVirtualMFADevicesRequest");
+    return __isa(o, "ListVirtualMFADevicesRequest");
   }
 }
 
@@ -5915,7 +5918,7 @@ export interface ListVirtualMFADevicesResponse extends $MetadataBearer {
 
 export namespace ListVirtualMFADevicesResponse {
   export function isa(o: any): o is ListVirtualMFADevicesResponse {
-    return _smithy.isa(o, "ListVirtualMFADevicesResponse");
+    return __isa(o, "ListVirtualMFADevicesResponse");
   }
 }
 
@@ -5944,7 +5947,7 @@ export interface LoginProfile {
 
 export namespace LoginProfile {
   export function isa(o: any): o is LoginProfile {
-    return _smithy.isa(o, "LoginProfile");
+    return __isa(o, "LoginProfile");
   }
 }
 
@@ -5974,7 +5977,7 @@ export interface MFADevice {
 
 export namespace MFADevice {
   export function isa(o: any): o is MFADevice {
-    return _smithy.isa(o, "MFADevice");
+    return __isa(o, "MFADevice");
   }
 }
 
@@ -5983,7 +5986,7 @@ export namespace MFADevice {
  *       message describes the specific error.</p>
  */
 export interface MalformedCertificateException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "MalformedCertificateException";
   $fault: "client";
@@ -5992,7 +5995,7 @@ export interface MalformedCertificateException
 
 export namespace MalformedCertificateException {
   export function isa(o: any): o is MalformedCertificateException {
-    return _smithy.isa(o, "MalformedCertificateException");
+    return __isa(o, "MalformedCertificateException");
   }
 }
 
@@ -6001,7 +6004,7 @@ export namespace MalformedCertificateException {
  *       describes the specific error.</p>
  */
 export interface MalformedPolicyDocumentException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "MalformedPolicyDocumentException";
   $fault: "client";
@@ -6010,7 +6013,7 @@ export interface MalformedPolicyDocumentException
 
 export namespace MalformedPolicyDocumentException {
   export function isa(o: any): o is MalformedPolicyDocumentException {
-    return _smithy.isa(o, "MalformedPolicyDocumentException");
+    return __isa(o, "MalformedPolicyDocumentException");
   }
 }
 
@@ -6105,7 +6108,7 @@ export interface ManagedPolicyDetail {
 
 export namespace ManagedPolicyDetail {
   export function isa(o: any): o is ManagedPolicyDetail {
-    return _smithy.isa(o, "ManagedPolicyDetail");
+    return __isa(o, "ManagedPolicyDetail");
   }
 }
 
@@ -6114,7 +6117,7 @@ export namespace ManagedPolicyDetail {
  *       message describes the resource.</p>
  */
 export interface NoSuchEntityException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "NoSuchEntityException";
   $fault: "client";
@@ -6123,7 +6126,7 @@ export interface NoSuchEntityException
 
 export namespace NoSuchEntityException {
   export function isa(o: any): o is NoSuchEntityException {
-    return _smithy.isa(o, "NoSuchEntityException");
+    return __isa(o, "NoSuchEntityException");
   }
 }
 
@@ -6142,7 +6145,7 @@ export interface OpenIDConnectProviderListEntry {
 
 export namespace OpenIDConnectProviderListEntry {
   export function isa(o: any): o is OpenIDConnectProviderListEntry {
-    return _smithy.isa(o, "OpenIDConnectProviderListEntry");
+    return __isa(o, "OpenIDConnectProviderListEntry");
   }
 }
 
@@ -6160,7 +6163,7 @@ export interface OrganizationsDecisionDetail {
 
 export namespace OrganizationsDecisionDetail {
   export function isa(o: any): o is OrganizationsDecisionDetail {
-    return _smithy.isa(o, "OrganizationsDecisionDetail");
+    return __isa(o, "OrganizationsDecisionDetail");
   }
 }
 
@@ -6227,7 +6230,7 @@ export interface PasswordPolicy {
 
 export namespace PasswordPolicy {
   export function isa(o: any): o is PasswordPolicy {
-    return _smithy.isa(o, "PasswordPolicy");
+    return __isa(o, "PasswordPolicy");
   }
 }
 
@@ -6236,7 +6239,7 @@ export namespace PasswordPolicy {
  *       imposed by the account password policy.</p>
  */
 export interface PasswordPolicyViolationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "PasswordPolicyViolationException";
   $fault: "client";
@@ -6245,7 +6248,7 @@ export interface PasswordPolicyViolationException
 
 export namespace PasswordPolicyViolationException {
   export function isa(o: any): o is PasswordPolicyViolationException {
-    return _smithy.isa(o, "PasswordPolicyViolationException");
+    return __isa(o, "PasswordPolicyViolationException");
   }
 }
 
@@ -6336,7 +6339,7 @@ export interface Policy {
 
 export namespace Policy {
   export function isa(o: any): o is Policy {
-    return _smithy.isa(o, "Policy");
+    return __isa(o, "Policy");
   }
 }
 
@@ -6359,7 +6362,7 @@ export interface PolicyDetail {
 
 export namespace PolicyDetail {
   export function isa(o: any): o is PolicyDetail {
-    return _smithy.isa(o, "PolicyDetail");
+    return __isa(o, "PolicyDetail");
   }
 }
 
@@ -6374,7 +6377,7 @@ export enum PolicyEvaluationDecisionType {
  *       additional detailed message indicates the source of the failure.</p>
  */
 export interface PolicyEvaluationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "PolicyEvaluationException";
   $fault: "server";
@@ -6383,7 +6386,7 @@ export interface PolicyEvaluationException
 
 export namespace PolicyEvaluationException {
   export function isa(o: any): o is PolicyEvaluationException {
-    return _smithy.isa(o, "PolicyEvaluationException");
+    return __isa(o, "PolicyEvaluationException");
   }
 }
 
@@ -6433,7 +6436,7 @@ export interface PolicyGrantingServiceAccess {
 
 export namespace PolicyGrantingServiceAccess {
   export function isa(o: any): o is PolicyGrantingServiceAccess {
-    return _smithy.isa(o, "PolicyGrantingServiceAccess");
+    return __isa(o, "PolicyGrantingServiceAccess");
   }
 }
 
@@ -6460,7 +6463,7 @@ export interface PolicyGroup {
 
 export namespace PolicyGroup {
   export function isa(o: any): o is PolicyGroup {
-    return _smithy.isa(o, "PolicyGroup");
+    return __isa(o, "PolicyGroup");
   }
 }
 
@@ -6469,7 +6472,7 @@ export namespace PolicyGroup {
  *       service-linked role for that service.</p>
  */
 export interface PolicyNotAttachableException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "PolicyNotAttachableException";
   $fault: "client";
@@ -6478,7 +6481,7 @@ export interface PolicyNotAttachableException
 
 export namespace PolicyNotAttachableException {
   export function isa(o: any): o is PolicyNotAttachableException {
-    return _smithy.isa(o, "PolicyNotAttachableException");
+    return __isa(o, "PolicyNotAttachableException");
   }
 }
 
@@ -6505,7 +6508,7 @@ export interface PolicyRole {
 
 export namespace PolicyRole {
   export function isa(o: any): o is PolicyRole {
-    return _smithy.isa(o, "PolicyRole");
+    return __isa(o, "PolicyRole");
   }
 }
 
@@ -6544,7 +6547,7 @@ export interface PolicyUser {
 
 export namespace PolicyUser {
   export function isa(o: any): o is PolicyUser {
-    return _smithy.isa(o, "PolicyUser");
+    return __isa(o, "PolicyUser");
   }
 }
 
@@ -6588,7 +6591,7 @@ export interface PolicyVersion {
 
 export namespace PolicyVersion {
   export function isa(o: any): o is PolicyVersion {
-    return _smithy.isa(o, "PolicyVersion");
+    return __isa(o, "PolicyVersion");
   }
 }
 
@@ -6614,7 +6617,7 @@ export interface Position {
 
 export namespace Position {
   export function isa(o: any): o is Position {
-    return _smithy.isa(o, "Position");
+    return __isa(o, "Position");
   }
 }
 
@@ -6662,7 +6665,7 @@ export interface PutGroupPolicyRequest {
 
 export namespace PutGroupPolicyRequest {
   export function isa(o: any): o is PutGroupPolicyRequest {
-    return _smithy.isa(o, "PutGroupPolicyRequest");
+    return __isa(o, "PutGroupPolicyRequest");
   }
 }
 
@@ -6682,7 +6685,7 @@ export interface PutRolePermissionsBoundaryRequest {
 
 export namespace PutRolePermissionsBoundaryRequest {
   export function isa(o: any): o is PutRolePermissionsBoundaryRequest {
-    return _smithy.isa(o, "PutRolePermissionsBoundaryRequest");
+    return __isa(o, "PutRolePermissionsBoundaryRequest");
   }
 }
 
@@ -6730,7 +6733,7 @@ export interface PutRolePolicyRequest {
 
 export namespace PutRolePolicyRequest {
   export function isa(o: any): o is PutRolePolicyRequest {
-    return _smithy.isa(o, "PutRolePolicyRequest");
+    return __isa(o, "PutRolePolicyRequest");
   }
 }
 
@@ -6750,7 +6753,7 @@ export interface PutUserPermissionsBoundaryRequest {
 
 export namespace PutUserPermissionsBoundaryRequest {
   export function isa(o: any): o is PutUserPermissionsBoundaryRequest {
-    return _smithy.isa(o, "PutUserPermissionsBoundaryRequest");
+    return __isa(o, "PutUserPermissionsBoundaryRequest");
   }
 }
 
@@ -6798,7 +6801,7 @@ export interface PutUserPolicyRequest {
 
 export namespace PutUserPolicyRequest {
   export function isa(o: any): o is PutUserPolicyRequest {
-    return _smithy.isa(o, "PutUserPolicyRequest");
+    return __isa(o, "PutUserPolicyRequest");
   }
 }
 
@@ -6823,7 +6826,7 @@ export namespace RemoveClientIDFromOpenIDConnectProviderRequest {
   export function isa(
     o: any
   ): o is RemoveClientIDFromOpenIDConnectProviderRequest {
-    return _smithy.isa(o, "RemoveClientIDFromOpenIDConnectProviderRequest");
+    return __isa(o, "RemoveClientIDFromOpenIDConnectProviderRequest");
   }
 }
 
@@ -6846,7 +6849,7 @@ export interface RemoveRoleFromInstanceProfileRequest {
 
 export namespace RemoveRoleFromInstanceProfileRequest {
   export function isa(o: any): o is RemoveRoleFromInstanceProfileRequest {
-    return _smithy.isa(o, "RemoveRoleFromInstanceProfileRequest");
+    return __isa(o, "RemoveRoleFromInstanceProfileRequest");
   }
 }
 
@@ -6869,7 +6872,7 @@ export interface RemoveUserFromGroupRequest {
 
 export namespace RemoveUserFromGroupRequest {
   export function isa(o: any): o is RemoveUserFromGroupRequest {
-    return _smithy.isa(o, "RemoveUserFromGroupRequest");
+    return __isa(o, "RemoveUserFromGroupRequest");
   }
 }
 
@@ -6880,7 +6883,7 @@ export type ReportFormatType = "text/csv";
  *     account are already running.</p>
  */
 export interface ReportGenerationLimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ReportGenerationLimitExceededException";
   $fault: "client";
@@ -6889,7 +6892,7 @@ export interface ReportGenerationLimitExceededException
 
 export namespace ReportGenerationLimitExceededException {
   export function isa(o: any): o is ReportGenerationLimitExceededException {
-    return _smithy.isa(o, "ReportGenerationLimitExceededException");
+    return __isa(o, "ReportGenerationLimitExceededException");
   }
 }
 
@@ -6920,7 +6923,7 @@ export interface ResetServiceSpecificCredentialRequest {
 
 export namespace ResetServiceSpecificCredentialRequest {
   export function isa(o: any): o is ResetServiceSpecificCredentialRequest {
-    return _smithy.isa(o, "ResetServiceSpecificCredentialRequest");
+    return __isa(o, "ResetServiceSpecificCredentialRequest");
   }
 }
 
@@ -6940,7 +6943,7 @@ export interface ResetServiceSpecificCredentialResponse
 
 export namespace ResetServiceSpecificCredentialResponse {
   export function isa(o: any): o is ResetServiceSpecificCredentialResponse {
-    return _smithy.isa(o, "ResetServiceSpecificCredentialResponse");
+    return __isa(o, "ResetServiceSpecificCredentialResponse");
   }
 }
 
@@ -6998,7 +7001,7 @@ export interface ResourceSpecificResult {
 
 export namespace ResourceSpecificResult {
   export function isa(o: any): o is ResourceSpecificResult {
-    return _smithy.isa(o, "ResourceSpecificResult");
+    return __isa(o, "ResourceSpecificResult");
   }
 }
 
@@ -7033,7 +7036,7 @@ export interface ResyncMFADeviceRequest {
 
 export namespace ResyncMFADeviceRequest {
   export function isa(o: any): o is ResyncMFADeviceRequest {
-    return _smithy.isa(o, "ResyncMFADeviceRequest");
+    return __isa(o, "ResyncMFADeviceRequest");
   }
 }
 
@@ -7119,7 +7122,7 @@ export interface Role {
 
 export namespace Role {
   export function isa(o: any): o is Role {
-    return _smithy.isa(o, "Role");
+    return __isa(o, "Role");
   }
 }
 
@@ -7209,7 +7212,7 @@ export interface RoleDetail {
 
 export namespace RoleDetail {
   export function isa(o: any): o is RoleDetail {
-    return _smithy.isa(o, "RoleDetail");
+    return __isa(o, "RoleDetail");
   }
 }
 
@@ -7242,7 +7245,7 @@ export interface RoleLastUsed {
 
 export namespace RoleLastUsed {
   export function isa(o: any): o is RoleLastUsed {
-    return _smithy.isa(o, "RoleLastUsed");
+    return __isa(o, "RoleLastUsed");
   }
 }
 
@@ -7266,7 +7269,7 @@ export interface RoleUsageType {
 
 export namespace RoleUsageType {
   export function isa(o: any): o is RoleUsageType {
-    return _smithy.isa(o, "RoleUsageType");
+    return __isa(o, "RoleUsageType");
   }
 }
 
@@ -7293,7 +7296,7 @@ export interface SAMLProviderListEntry {
 
 export namespace SAMLProviderListEntry {
   export function isa(o: any): o is SAMLProviderListEntry {
-    return _smithy.isa(o, "SAMLProviderListEntry");
+    return __isa(o, "SAMLProviderListEntry");
   }
 }
 
@@ -7340,7 +7343,7 @@ export interface SSHPublicKey {
 
 export namespace SSHPublicKey {
   export function isa(o: any): o is SSHPublicKey {
-    return _smithy.isa(o, "SSHPublicKey");
+    return __isa(o, "SSHPublicKey");
   }
 }
 
@@ -7378,7 +7381,7 @@ export interface SSHPublicKeyMetadata {
 
 export namespace SSHPublicKeyMetadata {
   export function isa(o: any): o is SSHPublicKeyMetadata {
-    return _smithy.isa(o, "SSHPublicKeyMetadata");
+    return __isa(o, "SSHPublicKeyMetadata");
   }
 }
 
@@ -7407,7 +7410,7 @@ export interface ServerCertificate {
 
 export namespace ServerCertificate {
   export function isa(o: any): o is ServerCertificate {
-    return _smithy.isa(o, "ServerCertificate");
+    return __isa(o, "ServerCertificate");
   }
 }
 
@@ -7456,7 +7459,7 @@ export interface ServerCertificateMetadata {
 
 export namespace ServerCertificateMetadata {
   export function isa(o: any): o is ServerCertificateMetadata {
-    return _smithy.isa(o, "ServerCertificateMetadata");
+    return __isa(o, "ServerCertificateMetadata");
   }
 }
 
@@ -7465,7 +7468,7 @@ export namespace ServerCertificateMetadata {
  *       failure.</p>
  */
 export interface ServiceFailureException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ServiceFailureException";
   $fault: "server";
@@ -7474,7 +7477,7 @@ export interface ServiceFailureException
 
 export namespace ServiceFailureException {
   export function isa(o: any): o is ServiceFailureException {
-    return _smithy.isa(o, "ServiceFailureException");
+    return __isa(o, "ServiceFailureException");
   }
 }
 
@@ -7528,7 +7531,7 @@ export interface ServiceLastAccessed {
 
 export namespace ServiceLastAccessed {
   export function isa(o: any): o is ServiceLastAccessed {
-    return _smithy.isa(o, "ServiceLastAccessed");
+    return __isa(o, "ServiceLastAccessed");
   }
 }
 
@@ -7536,7 +7539,7 @@ export namespace ServiceLastAccessed {
  * <p>The specified service does not support service-specific credentials.</p>
  */
 export interface ServiceNotSupportedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ServiceNotSupportedException";
   $fault: "client";
@@ -7545,7 +7548,7 @@ export interface ServiceNotSupportedException
 
 export namespace ServiceNotSupportedException {
   export function isa(o: any): o is ServiceNotSupportedException {
-    return _smithy.isa(o, "ServiceNotSupportedException");
+    return __isa(o, "ServiceNotSupportedException");
   }
 }
 
@@ -7597,7 +7600,7 @@ export interface ServiceSpecificCredential {
 
 export namespace ServiceSpecificCredential {
   export function isa(o: any): o is ServiceSpecificCredential {
-    return _smithy.isa(o, "ServiceSpecificCredential");
+    return __isa(o, "ServiceSpecificCredential");
   }
 }
 
@@ -7641,7 +7644,7 @@ export interface ServiceSpecificCredentialMetadata {
 
 export namespace ServiceSpecificCredentialMetadata {
   export function isa(o: any): o is ServiceSpecificCredentialMetadata {
-    return _smithy.isa(o, "ServiceSpecificCredentialMetadata");
+    return __isa(o, "ServiceSpecificCredentialMetadata");
   }
 }
 
@@ -7665,7 +7668,7 @@ export interface SetDefaultPolicyVersionRequest {
 
 export namespace SetDefaultPolicyVersionRequest {
   export function isa(o: any): o is SetDefaultPolicyVersionRequest {
-    return _smithy.isa(o, "SetDefaultPolicyVersionRequest");
+    return __isa(o, "SetDefaultPolicyVersionRequest");
   }
 }
 
@@ -7685,7 +7688,7 @@ export interface SetSecurityTokenServicePreferencesRequest {
 
 export namespace SetSecurityTokenServicePreferencesRequest {
   export function isa(o: any): o is SetSecurityTokenServicePreferencesRequest {
-    return _smithy.isa(o, "SetSecurityTokenServicePreferencesRequest");
+    return __isa(o, "SetSecurityTokenServicePreferencesRequest");
   }
 }
 
@@ -7725,7 +7728,7 @@ export interface SigningCertificate {
 
 export namespace SigningCertificate {
   export function isa(o: any): o is SigningCertificate {
-    return _smithy.isa(o, "SigningCertificate");
+    return __isa(o, "SigningCertificate");
   }
 }
 
@@ -7918,7 +7921,7 @@ export interface SimulateCustomPolicyRequest {
 
 export namespace SimulateCustomPolicyRequest {
   export function isa(o: any): o is SimulateCustomPolicyRequest {
-    return _smithy.isa(o, "SimulateCustomPolicyRequest");
+    return __isa(o, "SimulateCustomPolicyRequest");
   }
 }
 
@@ -7953,7 +7956,7 @@ export interface SimulatePolicyResponse extends $MetadataBearer {
 
 export namespace SimulatePolicyResponse {
   export function isa(o: any): o is SimulatePolicyResponse {
-    return _smithy.isa(o, "SimulatePolicyResponse");
+    return __isa(o, "SimulatePolicyResponse");
   }
 }
 
@@ -8154,7 +8157,7 @@ export interface SimulatePrincipalPolicyRequest {
 
 export namespace SimulatePrincipalPolicyRequest {
   export function isa(o: any): o is SimulatePrincipalPolicyRequest {
-    return _smithy.isa(o, "SimulatePrincipalPolicyRequest");
+    return __isa(o, "SimulatePrincipalPolicyRequest");
   }
 }
 
@@ -8191,7 +8194,7 @@ export interface Statement {
 
 export namespace Statement {
   export function isa(o: any): o is Statement {
-    return _smithy.isa(o, "Statement");
+    return __isa(o, "Statement");
   }
 }
 
@@ -8226,7 +8229,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -8248,7 +8251,7 @@ export interface TagRoleRequest {
 
 export namespace TagRoleRequest {
   export function isa(o: any): o is TagRoleRequest {
-    return _smithy.isa(o, "TagRoleRequest");
+    return __isa(o, "TagRoleRequest");
   }
 }
 
@@ -8270,7 +8273,7 @@ export interface TagUserRequest {
 
 export namespace TagUserRequest {
   export function isa(o: any): o is TagUserRequest {
-    return _smithy.isa(o, "TagUserRequest");
+    return __isa(o, "TagUserRequest");
   }
 }
 
@@ -8281,7 +8284,7 @@ export namespace TagUserRequest {
  *       service.</p>
  */
 export interface UnmodifiableEntityException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UnmodifiableEntityException";
   $fault: "client";
@@ -8290,7 +8293,7 @@ export interface UnmodifiableEntityException
 
 export namespace UnmodifiableEntityException {
   export function isa(o: any): o is UnmodifiableEntityException {
-    return _smithy.isa(o, "UnmodifiableEntityException");
+    return __isa(o, "UnmodifiableEntityException");
   }
 }
 
@@ -8299,7 +8302,7 @@ export namespace UnmodifiableEntityException {
  *       unrecognized.</p>
  */
 export interface UnrecognizedPublicKeyEncodingException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UnrecognizedPublicKeyEncodingException";
   $fault: "client";
@@ -8308,7 +8311,7 @@ export interface UnrecognizedPublicKeyEncodingException
 
 export namespace UnrecognizedPublicKeyEncodingException {
   export function isa(o: any): o is UnrecognizedPublicKeyEncodingException {
-    return _smithy.isa(o, "UnrecognizedPublicKeyEncodingException");
+    return __isa(o, "UnrecognizedPublicKeyEncodingException");
   }
 }
 
@@ -8330,7 +8333,7 @@ export interface UntagRoleRequest {
 
 export namespace UntagRoleRequest {
   export function isa(o: any): o is UntagRoleRequest {
-    return _smithy.isa(o, "UntagRoleRequest");
+    return __isa(o, "UntagRoleRequest");
   }
 }
 
@@ -8352,7 +8355,7 @@ export interface UntagUserRequest {
 
 export namespace UntagUserRequest {
   export function isa(o: any): o is UntagUserRequest {
-    return _smithy.isa(o, "UntagUserRequest");
+    return __isa(o, "UntagUserRequest");
   }
 }
 
@@ -8382,7 +8385,7 @@ export interface UpdateAccessKeyRequest {
 
 export namespace UpdateAccessKeyRequest {
   export function isa(o: any): o is UpdateAccessKeyRequest {
-    return _smithy.isa(o, "UpdateAccessKeyRequest");
+    return __isa(o, "UpdateAccessKeyRequest");
   }
 }
 
@@ -8470,7 +8473,7 @@ export interface UpdateAccountPasswordPolicyRequest {
 
 export namespace UpdateAccountPasswordPolicyRequest {
   export function isa(o: any): o is UpdateAccountPasswordPolicyRequest {
-    return _smithy.isa(o, "UpdateAccountPasswordPolicyRequest");
+    return __isa(o, "UpdateAccountPasswordPolicyRequest");
   }
 }
 
@@ -8511,7 +8514,7 @@ export interface UpdateAssumeRolePolicyRequest {
 
 export namespace UpdateAssumeRolePolicyRequest {
   export function isa(o: any): o is UpdateAssumeRolePolicyRequest {
-    return _smithy.isa(o, "UpdateAssumeRolePolicyRequest");
+    return __isa(o, "UpdateAssumeRolePolicyRequest");
   }
 }
 
@@ -8545,7 +8548,7 @@ export interface UpdateGroupRequest {
 
 export namespace UpdateGroupRequest {
   export function isa(o: any): o is UpdateGroupRequest {
-    return _smithy.isa(o, "UpdateGroupRequest");
+    return __isa(o, "UpdateGroupRequest");
   }
 }
 
@@ -8591,7 +8594,7 @@ export interface UpdateLoginProfileRequest {
 
 export namespace UpdateLoginProfileRequest {
   export function isa(o: any): o is UpdateLoginProfileRequest {
-    return _smithy.isa(o, "UpdateLoginProfileRequest");
+    return __isa(o, "UpdateLoginProfileRequest");
   }
 }
 
@@ -8617,7 +8620,7 @@ export namespace UpdateOpenIDConnectProviderThumbprintRequest {
   export function isa(
     o: any
   ): o is UpdateOpenIDConnectProviderThumbprintRequest {
-    return _smithy.isa(o, "UpdateOpenIDConnectProviderThumbprintRequest");
+    return __isa(o, "UpdateOpenIDConnectProviderThumbprintRequest");
   }
 }
 
@@ -8636,7 +8639,7 @@ export interface UpdateRoleDescriptionRequest {
 
 export namespace UpdateRoleDescriptionRequest {
   export function isa(o: any): o is UpdateRoleDescriptionRequest {
-    return _smithy.isa(o, "UpdateRoleDescriptionRequest");
+    return __isa(o, "UpdateRoleDescriptionRequest");
   }
 }
 
@@ -8650,7 +8653,7 @@ export interface UpdateRoleDescriptionResponse extends $MetadataBearer {
 
 export namespace UpdateRoleDescriptionResponse {
   export function isa(o: any): o is UpdateRoleDescriptionResponse {
-    return _smithy.isa(o, "UpdateRoleDescriptionResponse");
+    return __isa(o, "UpdateRoleDescriptionResponse");
   }
 }
 
@@ -8686,7 +8689,7 @@ export interface UpdateRoleRequest {
 
 export namespace UpdateRoleRequest {
   export function isa(o: any): o is UpdateRoleRequest {
-    return _smithy.isa(o, "UpdateRoleRequest");
+    return __isa(o, "UpdateRoleRequest");
   }
 }
 
@@ -8696,7 +8699,7 @@ export interface UpdateRoleResponse extends $MetadataBearer {
 
 export namespace UpdateRoleResponse {
   export function isa(o: any): o is UpdateRoleResponse {
-    return _smithy.isa(o, "UpdateRoleResponse");
+    return __isa(o, "UpdateRoleResponse");
   }
 }
 
@@ -8721,7 +8724,7 @@ export interface UpdateSAMLProviderRequest {
 
 export namespace UpdateSAMLProviderRequest {
   export function isa(o: any): o is UpdateSAMLProviderRequest {
-    return _smithy.isa(o, "UpdateSAMLProviderRequest");
+    return __isa(o, "UpdateSAMLProviderRequest");
   }
 }
 
@@ -8739,7 +8742,7 @@ export interface UpdateSAMLProviderResponse extends $MetadataBearer {
 
 export namespace UpdateSAMLProviderResponse {
   export function isa(o: any): o is UpdateSAMLProviderResponse {
-    return _smithy.isa(o, "UpdateSAMLProviderResponse");
+    return __isa(o, "UpdateSAMLProviderResponse");
   }
 }
 
@@ -8769,7 +8772,7 @@ export interface UpdateSSHPublicKeyRequest {
 
 export namespace UpdateSSHPublicKeyRequest {
   export function isa(o: any): o is UpdateSSHPublicKeyRequest {
-    return _smithy.isa(o, "UpdateSSHPublicKeyRequest");
+    return __isa(o, "UpdateSSHPublicKeyRequest");
   }
 }
 
@@ -8803,7 +8806,7 @@ export interface UpdateServerCertificateRequest {
 
 export namespace UpdateServerCertificateRequest {
   export function isa(o: any): o is UpdateServerCertificateRequest {
-    return _smithy.isa(o, "UpdateServerCertificateRequest");
+    return __isa(o, "UpdateServerCertificateRequest");
   }
 }
 
@@ -8833,7 +8836,7 @@ export interface UpdateServiceSpecificCredentialRequest {
 
 export namespace UpdateServiceSpecificCredentialRequest {
   export function isa(o: any): o is UpdateServiceSpecificCredentialRequest {
-    return _smithy.isa(o, "UpdateServiceSpecificCredentialRequest");
+    return __isa(o, "UpdateServiceSpecificCredentialRequest");
   }
 }
 
@@ -8863,7 +8866,7 @@ export interface UpdateSigningCertificateRequest {
 
 export namespace UpdateSigningCertificateRequest {
   export function isa(o: any): o is UpdateSigningCertificateRequest {
-    return _smithy.isa(o, "UpdateSigningCertificateRequest");
+    return __isa(o, "UpdateSigningCertificateRequest");
   }
 }
 
@@ -8899,7 +8902,7 @@ export interface UpdateUserRequest {
 
 export namespace UpdateUserRequest {
   export function isa(o: any): o is UpdateUserRequest {
-    return _smithy.isa(o, "UpdateUserRequest");
+    return __isa(o, "UpdateUserRequest");
   }
 }
 
@@ -8938,7 +8941,7 @@ export interface UploadSSHPublicKeyRequest {
 
 export namespace UploadSSHPublicKeyRequest {
   export function isa(o: any): o is UploadSSHPublicKeyRequest {
-    return _smithy.isa(o, "UploadSSHPublicKeyRequest");
+    return __isa(o, "UploadSSHPublicKeyRequest");
   }
 }
 
@@ -8956,7 +8959,7 @@ export interface UploadSSHPublicKeyResponse extends $MetadataBearer {
 
 export namespace UploadSSHPublicKeyResponse {
   export function isa(o: any): o is UploadSSHPublicKeyResponse {
-    return _smithy.isa(o, "UploadSSHPublicKeyResponse");
+    return __isa(o, "UploadSSHPublicKeyResponse");
   }
 }
 
@@ -9054,7 +9057,7 @@ export interface UploadServerCertificateRequest {
 
 export namespace UploadServerCertificateRequest {
   export function isa(o: any): o is UploadServerCertificateRequest {
-    return _smithy.isa(o, "UploadServerCertificateRequest");
+    return __isa(o, "UploadServerCertificateRequest");
   }
 }
 
@@ -9073,7 +9076,7 @@ export interface UploadServerCertificateResponse extends $MetadataBearer {
 
 export namespace UploadServerCertificateResponse {
   export function isa(o: any): o is UploadServerCertificateResponse {
-    return _smithy.isa(o, "UploadServerCertificateResponse");
+    return __isa(o, "UploadServerCertificateResponse");
   }
 }
 
@@ -9110,7 +9113,7 @@ export interface UploadSigningCertificateRequest {
 
 export namespace UploadSigningCertificateRequest {
   export function isa(o: any): o is UploadSigningCertificateRequest {
-    return _smithy.isa(o, "UploadSigningCertificateRequest");
+    return __isa(o, "UploadSigningCertificateRequest");
   }
 }
 
@@ -9128,7 +9131,7 @@ export interface UploadSigningCertificateResponse extends $MetadataBearer {
 
 export namespace UploadSigningCertificateResponse {
   export function isa(o: any): o is UploadSigningCertificateResponse {
-    return _smithy.isa(o, "UploadSigningCertificateResponse");
+    return __isa(o, "UploadSigningCertificateResponse");
   }
 }
 
@@ -9227,7 +9230,7 @@ export interface User {
 
 export namespace User {
   export function isa(o: any): o is User {
-    return _smithy.isa(o, "User");
+    return __isa(o, "User");
   }
 }
 
@@ -9301,7 +9304,7 @@ export interface UserDetail {
 
 export namespace UserDetail {
   export function isa(o: any): o is UserDetail {
-    return _smithy.isa(o, "UserDetail");
+    return __isa(o, "UserDetail");
   }
 }
 
@@ -9343,7 +9346,7 @@ export interface VirtualMFADevice {
 
 export namespace VirtualMFADevice {
   export function isa(o: any): o is VirtualMFADevice {
-    return _smithy.isa(o, "VirtualMFADevice");
+    return __isa(o, "VirtualMFADevice");
   }
 }
 

--- a/clients/client-iam/protocols/Aws_query.ts
+++ b/clients/client-iam/protocols/Aws_query.ts
@@ -3264,6 +3264,7 @@ export async function deserializeAws_queryAddClientIDToOpenIDConnectProviderComm
       context
     );
   }
+  await collectBody(output.body, context);
   const response: AddClientIDToOpenIDConnectProviderCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -3338,6 +3339,7 @@ export async function deserializeAws_queryAddRoleToInstanceProfileCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: AddRoleToInstanceProfileCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -3416,6 +3418,7 @@ export async function deserializeAws_queryAddUserToGroupCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_queryAddUserToGroupCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: AddUserToGroupCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -3480,6 +3483,7 @@ export async function deserializeAws_queryAttachGroupPolicyCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_queryAttachGroupPolicyCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: AttachGroupPolicyCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -3558,6 +3562,7 @@ export async function deserializeAws_queryAttachRolePolicyCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_queryAttachRolePolicyCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: AttachRolePolicyCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -3643,6 +3648,7 @@ export async function deserializeAws_queryAttachUserPolicyCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_queryAttachUserPolicyCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: AttachUserPolicyCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -3721,6 +3727,7 @@ export async function deserializeAws_queryChangePasswordCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_queryChangePasswordCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: ChangePasswordCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -3878,6 +3885,7 @@ export async function deserializeAws_queryCreateAccountAliasCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_queryCreateAccountAliasCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: CreateAccountAliasCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -4933,6 +4941,7 @@ export async function deserializeAws_queryDeactivateMFADeviceCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_queryDeactivateMFADeviceCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeactivateMFADeviceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -5004,6 +5013,7 @@ export async function deserializeAws_queryDeleteAccessKeyCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_queryDeleteAccessKeyCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteAccessKeyCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -5068,6 +5078,7 @@ export async function deserializeAws_queryDeleteAccountAliasCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_queryDeleteAccountAliasCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteAccountAliasCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -5135,6 +5146,7 @@ export async function deserializeAws_queryDeleteAccountPasswordPolicyCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteAccountPasswordPolicyCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -5199,6 +5211,7 @@ export async function deserializeAws_queryDeleteGroupCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_queryDeleteGroupCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteGroupCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -5270,6 +5283,7 @@ export async function deserializeAws_queryDeleteGroupPolicyCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_queryDeleteGroupPolicyCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteGroupPolicyCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -5337,6 +5351,7 @@ export async function deserializeAws_queryDeleteInstanceProfileCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteInstanceProfileCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -5408,6 +5423,7 @@ export async function deserializeAws_queryDeleteLoginProfileCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_queryDeleteLoginProfileCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteLoginProfileCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -5482,6 +5498,7 @@ export async function deserializeAws_queryDeleteOpenIDConnectProviderCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteOpenIDConnectProviderCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -5546,6 +5563,7 @@ export async function deserializeAws_queryDeletePolicyCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_queryDeletePolicyCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeletePolicyCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -5624,6 +5642,7 @@ export async function deserializeAws_queryDeletePolicyVersionCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_queryDeletePolicyVersionCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeletePolicyVersionCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -5702,6 +5721,7 @@ export async function deserializeAws_queryDeleteRoleCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_queryDeleteRoleCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteRoleCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -5790,6 +5810,7 @@ export async function deserializeAws_queryDeleteRolePermissionsBoundaryCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteRolePermissionsBoundaryCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -5854,6 +5875,7 @@ export async function deserializeAws_queryDeleteRolePolicyCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_queryDeleteRolePolicyCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteRolePolicyCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -5925,6 +5947,7 @@ export async function deserializeAws_queryDeleteSAMLProviderCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_queryDeleteSAMLProviderCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteSAMLProviderCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -5996,6 +6019,7 @@ export async function deserializeAws_queryDeleteSSHPublicKeyCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_queryDeleteSSHPublicKeyCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteSSHPublicKeyCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -6049,6 +6073,7 @@ export async function deserializeAws_queryDeleteServerCertificateCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteServerCertificateCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -6198,6 +6223,7 @@ export async function deserializeAws_queryDeleteServiceSpecificCredentialCommand
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteServiceSpecificCredentialCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -6251,6 +6277,7 @@ export async function deserializeAws_queryDeleteSigningCertificateCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteSigningCertificateCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -6315,6 +6342,7 @@ export async function deserializeAws_queryDeleteUserCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_queryDeleteUserCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteUserCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -6396,6 +6424,7 @@ export async function deserializeAws_queryDeleteUserPermissionsBoundaryCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteUserPermissionsBoundaryCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -6453,6 +6482,7 @@ export async function deserializeAws_queryDeleteUserPolicyCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_queryDeleteUserPolicyCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteUserPolicyCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -6520,6 +6550,7 @@ export async function deserializeAws_queryDeleteVirtualMFADeviceCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteVirtualMFADeviceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -6591,6 +6622,7 @@ export async function deserializeAws_queryDetachGroupPolicyCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_queryDetachGroupPolicyCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DetachGroupPolicyCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -6662,6 +6694,7 @@ export async function deserializeAws_queryDetachRolePolicyCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_queryDetachRolePolicyCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DetachRolePolicyCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -6740,6 +6773,7 @@ export async function deserializeAws_queryDetachUserPolicyCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_queryDetachUserPolicyCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DetachUserPolicyCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -6811,6 +6845,7 @@ export async function deserializeAws_queryEnableMFADeviceCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_queryEnableMFADeviceCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: EnableMFADeviceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -10556,6 +10591,7 @@ export async function deserializeAws_queryPutGroupPolicyCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_queryPutGroupPolicyCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: PutGroupPolicyCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -10630,6 +10666,7 @@ export async function deserializeAws_queryPutRolePermissionsBoundaryCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: PutRolePermissionsBoundaryCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -10708,6 +10745,7 @@ export async function deserializeAws_queryPutRolePolicyCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_queryPutRolePolicyCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: PutRolePolicyCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -10789,6 +10827,7 @@ export async function deserializeAws_queryPutUserPermissionsBoundaryCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: PutUserPermissionsBoundaryCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -10860,6 +10899,7 @@ export async function deserializeAws_queryPutUserPolicyCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_queryPutUserPolicyCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: PutUserPolicyCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -10934,6 +10974,7 @@ export async function deserializeAws_queryRemoveClientIDFromOpenIDConnectProvide
       context
     );
   }
+  await collectBody(output.body, context);
   const response: RemoveClientIDFromOpenIDConnectProviderCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -11001,6 +11042,7 @@ export async function deserializeAws_queryRemoveRoleFromInstanceProfileCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: RemoveRoleFromInstanceProfileCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -11072,6 +11114,7 @@ export async function deserializeAws_queryRemoveUserFromGroupCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_queryRemoveUserFromGroupCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: RemoveUserFromGroupCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -11197,6 +11240,7 @@ export async function deserializeAws_queryResyncMFADeviceCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_queryResyncMFADeviceCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: ResyncMFADeviceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -11271,6 +11315,7 @@ export async function deserializeAws_querySetDefaultPolicyVersionCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: SetDefaultPolicyVersionCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -11345,6 +11390,7 @@ export async function deserializeAws_querySetSecurityTokenServicePreferencesComm
       context
     );
   }
+  await collectBody(output.body, context);
   const response: SetSecurityTokenServicePreferencesCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -11538,6 +11584,7 @@ export async function deserializeAws_queryTagRoleCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_queryTagRoleCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: TagRoleCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -11616,6 +11663,7 @@ export async function deserializeAws_queryTagUserCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_queryTagUserCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: TagUserCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -11694,6 +11742,7 @@ export async function deserializeAws_queryUntagRoleCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_queryUntagRoleCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: UntagRoleCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -11758,6 +11807,7 @@ export async function deserializeAws_queryUntagUserCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_queryUntagUserCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: UntagUserCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -11822,6 +11872,7 @@ export async function deserializeAws_queryUpdateAccessKeyCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_queryUpdateAccessKeyCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: UpdateAccessKeyCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -11889,6 +11940,7 @@ export async function deserializeAws_queryUpdateAccountPasswordPolicyCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: UpdateAccountPasswordPolicyCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -11963,6 +12015,7 @@ export async function deserializeAws_queryUpdateAssumeRolePolicyCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: UpdateAssumeRolePolicyCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -12041,6 +12094,7 @@ export async function deserializeAws_queryUpdateGroupCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_queryUpdateGroupCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: UpdateGroupCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -12112,6 +12166,7 @@ export async function deserializeAws_queryUpdateLoginProfileCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_queryUpdateLoginProfileCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: UpdateLoginProfileCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -12193,6 +12248,7 @@ export async function deserializeAws_queryUpdateOpenIDConnectProviderThumbprintC
       context
     );
   }
+  await collectBody(output.body, context);
   const response: UpdateOpenIDConnectProviderThumbprintCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -12483,6 +12539,7 @@ export async function deserializeAws_queryUpdateSSHPublicKeyCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_queryUpdateSSHPublicKeyCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: UpdateSSHPublicKeyCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -12536,6 +12593,7 @@ export async function deserializeAws_queryUpdateServerCertificateCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: UpdateServerCertificateCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -12610,6 +12668,7 @@ export async function deserializeAws_queryUpdateServiceSpecificCredentialCommand
       context
     );
   }
+  await collectBody(output.body, context);
   const response: UpdateServiceSpecificCredentialCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -12663,6 +12722,7 @@ export async function deserializeAws_queryUpdateSigningCertificateCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: UpdateSigningCertificateCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -12727,6 +12787,7 @@ export async function deserializeAws_queryUpdateUserCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_queryUpdateUserCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: UpdateUserCommandOutput = {
     $metadata: deserializeMetadata(output)
   };

--- a/clients/client-imagebuilder/models/index.ts
+++ b/clients/client-imagebuilder/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -34,7 +37,7 @@ export interface Ami {
 
 export namespace Ami {
   export function isa(o: any): o is Ami {
-    return _smithy.isa(o, "Ami");
+    return __isa(o, "Ami");
   }
 }
 
@@ -66,7 +69,7 @@ export interface AmiDistributionConfiguration {
 
 export namespace AmiDistributionConfiguration {
   export function isa(o: any): o is AmiDistributionConfiguration {
-    return _smithy.isa(o, "AmiDistributionConfiguration");
+    return __isa(o, "AmiDistributionConfiguration");
   }
 }
 
@@ -74,7 +77,7 @@ export namespace AmiDistributionConfiguration {
  * <p>You have exceeded the permitted request rate for the specific operation.</p>
  */
 export interface CallRateLimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CallRateLimitExceededException";
   $fault: "client";
@@ -83,7 +86,7 @@ export interface CallRateLimitExceededException
 
 export namespace CallRateLimitExceededException {
   export function isa(o: any): o is CallRateLimitExceededException {
-    return _smithy.isa(o, "CallRateLimitExceededException");
+    return __isa(o, "CallRateLimitExceededException");
   }
 }
 
@@ -102,7 +105,7 @@ export interface CancelImageCreationRequest {
 
 export namespace CancelImageCreationRequest {
   export function isa(o: any): o is CancelImageCreationRequest {
-    return _smithy.isa(o, "CancelImageCreationRequest");
+    return __isa(o, "CancelImageCreationRequest");
   }
 }
 
@@ -126,16 +129,14 @@ export interface CancelImageCreationResponse extends $MetadataBearer {
 
 export namespace CancelImageCreationResponse {
   export function isa(o: any): o is CancelImageCreationResponse {
-    return _smithy.isa(o, "CancelImageCreationResponse");
+    return __isa(o, "CancelImageCreationResponse");
   }
 }
 
 /**
  * <p>These errors are usually caused by a client action, such as using an action or resource on behalf of a user that doesn't have permissions to use the action or resource, or specifying an invalid resource identifier.</p>
  */
-export interface ClientException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface ClientException extends __SmithyException, $MetadataBearer {
   name: "ClientException";
   $fault: "client";
   message?: string;
@@ -143,7 +144,7 @@ export interface ClientException
 
 export namespace ClientException {
   export function isa(o: any): o is ClientException {
-    return _smithy.isa(o, "ClientException");
+    return __isa(o, "ClientException");
   }
 }
 
@@ -220,7 +221,7 @@ export interface Component {
 
 export namespace Component {
   export function isa(o: any): o is Component {
-    return _smithy.isa(o, "Component");
+    return __isa(o, "Component");
   }
 }
 
@@ -237,7 +238,7 @@ export interface ComponentConfiguration {
 
 export namespace ComponentConfiguration {
   export function isa(o: any): o is ComponentConfiguration {
-    return _smithy.isa(o, "ComponentConfiguration");
+    return __isa(o, "ComponentConfiguration");
   }
 }
 
@@ -303,7 +304,7 @@ export interface ComponentSummary {
 
 export namespace ComponentSummary {
   export function isa(o: any): o is ComponentSummary {
-    return _smithy.isa(o, "ComponentSummary");
+    return __isa(o, "ComponentSummary");
   }
 }
 
@@ -360,7 +361,7 @@ export interface ComponentVersion {
 
 export namespace ComponentVersion {
   export function isa(o: any): o is ComponentVersion {
-    return _smithy.isa(o, "ComponentVersion");
+    return __isa(o, "ComponentVersion");
   }
 }
 
@@ -419,7 +420,7 @@ export interface CreateComponentRequest {
 
 export namespace CreateComponentRequest {
   export function isa(o: any): o is CreateComponentRequest {
-    return _smithy.isa(o, "CreateComponentRequest");
+    return __isa(o, "CreateComponentRequest");
   }
 }
 
@@ -443,7 +444,7 @@ export interface CreateComponentResponse extends $MetadataBearer {
 
 export namespace CreateComponentResponse {
   export function isa(o: any): o is CreateComponentResponse {
-    return _smithy.isa(o, "CreateComponentResponse");
+    return __isa(o, "CreateComponentResponse");
   }
 }
 
@@ -477,7 +478,7 @@ export interface CreateDistributionConfigurationRequest {
 
 export namespace CreateDistributionConfigurationRequest {
   export function isa(o: any): o is CreateDistributionConfigurationRequest {
-    return _smithy.isa(o, "CreateDistributionConfigurationRequest");
+    return __isa(o, "CreateDistributionConfigurationRequest");
   }
 }
 
@@ -502,7 +503,7 @@ export interface CreateDistributionConfigurationResponse
 
 export namespace CreateDistributionConfigurationResponse {
   export function isa(o: any): o is CreateDistributionConfigurationResponse {
-    return _smithy.isa(o, "CreateDistributionConfigurationResponse");
+    return __isa(o, "CreateDistributionConfigurationResponse");
   }
 }
 
@@ -561,7 +562,7 @@ export interface CreateImagePipelineRequest {
 
 export namespace CreateImagePipelineRequest {
   export function isa(o: any): o is CreateImagePipelineRequest {
-    return _smithy.isa(o, "CreateImagePipelineRequest");
+    return __isa(o, "CreateImagePipelineRequest");
   }
 }
 
@@ -585,7 +586,7 @@ export interface CreateImagePipelineResponse extends $MetadataBearer {
 
 export namespace CreateImagePipelineResponse {
   export function isa(o: any): o is CreateImagePipelineResponse {
-    return _smithy.isa(o, "CreateImagePipelineResponse");
+    return __isa(o, "CreateImagePipelineResponse");
   }
 }
 
@@ -634,7 +635,7 @@ export interface CreateImageRecipeRequest {
 
 export namespace CreateImageRecipeRequest {
   export function isa(o: any): o is CreateImageRecipeRequest {
-    return _smithy.isa(o, "CreateImageRecipeRequest");
+    return __isa(o, "CreateImageRecipeRequest");
   }
 }
 
@@ -658,7 +659,7 @@ export interface CreateImageRecipeResponse extends $MetadataBearer {
 
 export namespace CreateImageRecipeResponse {
   export function isa(o: any): o is CreateImageRecipeResponse {
-    return _smithy.isa(o, "CreateImageRecipeResponse");
+    return __isa(o, "CreateImageRecipeResponse");
   }
 }
 
@@ -697,7 +698,7 @@ export interface CreateImageRequest {
 
 export namespace CreateImageRequest {
   export function isa(o: any): o is CreateImageRequest {
-    return _smithy.isa(o, "CreateImageRequest");
+    return __isa(o, "CreateImageRequest");
   }
 }
 
@@ -721,7 +722,7 @@ export interface CreateImageResponse extends $MetadataBearer {
 
 export namespace CreateImageResponse {
   export function isa(o: any): o is CreateImageResponse {
-    return _smithy.isa(o, "CreateImageResponse");
+    return __isa(o, "CreateImageResponse");
   }
 }
 
@@ -790,7 +791,7 @@ export interface CreateInfrastructureConfigurationRequest {
 
 export namespace CreateInfrastructureConfigurationRequest {
   export function isa(o: any): o is CreateInfrastructureConfigurationRequest {
-    return _smithy.isa(o, "CreateInfrastructureConfigurationRequest");
+    return __isa(o, "CreateInfrastructureConfigurationRequest");
   }
 }
 
@@ -815,7 +816,7 @@ export interface CreateInfrastructureConfigurationResponse
 
 export namespace CreateInfrastructureConfigurationResponse {
   export function isa(o: any): o is CreateInfrastructureConfigurationResponse {
-    return _smithy.isa(o, "CreateInfrastructureConfigurationResponse");
+    return __isa(o, "CreateInfrastructureConfigurationResponse");
   }
 }
 
@@ -829,7 +830,7 @@ export interface DeleteComponentRequest {
 
 export namespace DeleteComponentRequest {
   export function isa(o: any): o is DeleteComponentRequest {
-    return _smithy.isa(o, "DeleteComponentRequest");
+    return __isa(o, "DeleteComponentRequest");
   }
 }
 
@@ -848,7 +849,7 @@ export interface DeleteComponentResponse extends $MetadataBearer {
 
 export namespace DeleteComponentResponse {
   export function isa(o: any): o is DeleteComponentResponse {
-    return _smithy.isa(o, "DeleteComponentResponse");
+    return __isa(o, "DeleteComponentResponse");
   }
 }
 
@@ -862,7 +863,7 @@ export interface DeleteDistributionConfigurationRequest {
 
 export namespace DeleteDistributionConfigurationRequest {
   export function isa(o: any): o is DeleteDistributionConfigurationRequest {
-    return _smithy.isa(o, "DeleteDistributionConfigurationRequest");
+    return __isa(o, "DeleteDistributionConfigurationRequest");
   }
 }
 
@@ -882,7 +883,7 @@ export interface DeleteDistributionConfigurationResponse
 
 export namespace DeleteDistributionConfigurationResponse {
   export function isa(o: any): o is DeleteDistributionConfigurationResponse {
-    return _smithy.isa(o, "DeleteDistributionConfigurationResponse");
+    return __isa(o, "DeleteDistributionConfigurationResponse");
   }
 }
 
@@ -896,7 +897,7 @@ export interface DeleteImagePipelineRequest {
 
 export namespace DeleteImagePipelineRequest {
   export function isa(o: any): o is DeleteImagePipelineRequest {
-    return _smithy.isa(o, "DeleteImagePipelineRequest");
+    return __isa(o, "DeleteImagePipelineRequest");
   }
 }
 
@@ -915,7 +916,7 @@ export interface DeleteImagePipelineResponse extends $MetadataBearer {
 
 export namespace DeleteImagePipelineResponse {
   export function isa(o: any): o is DeleteImagePipelineResponse {
-    return _smithy.isa(o, "DeleteImagePipelineResponse");
+    return __isa(o, "DeleteImagePipelineResponse");
   }
 }
 
@@ -929,7 +930,7 @@ export interface DeleteImageRecipeRequest {
 
 export namespace DeleteImageRecipeRequest {
   export function isa(o: any): o is DeleteImageRecipeRequest {
-    return _smithy.isa(o, "DeleteImageRecipeRequest");
+    return __isa(o, "DeleteImageRecipeRequest");
   }
 }
 
@@ -948,7 +949,7 @@ export interface DeleteImageRecipeResponse extends $MetadataBearer {
 
 export namespace DeleteImageRecipeResponse {
   export function isa(o: any): o is DeleteImageRecipeResponse {
-    return _smithy.isa(o, "DeleteImageRecipeResponse");
+    return __isa(o, "DeleteImageRecipeResponse");
   }
 }
 
@@ -962,7 +963,7 @@ export interface DeleteImageRequest {
 
 export namespace DeleteImageRequest {
   export function isa(o: any): o is DeleteImageRequest {
-    return _smithy.isa(o, "DeleteImageRequest");
+    return __isa(o, "DeleteImageRequest");
   }
 }
 
@@ -981,7 +982,7 @@ export interface DeleteImageResponse extends $MetadataBearer {
 
 export namespace DeleteImageResponse {
   export function isa(o: any): o is DeleteImageResponse {
-    return _smithy.isa(o, "DeleteImageResponse");
+    return __isa(o, "DeleteImageResponse");
   }
 }
 
@@ -995,7 +996,7 @@ export interface DeleteInfrastructureConfigurationRequest {
 
 export namespace DeleteInfrastructureConfigurationRequest {
   export function isa(o: any): o is DeleteInfrastructureConfigurationRequest {
-    return _smithy.isa(o, "DeleteInfrastructureConfigurationRequest");
+    return __isa(o, "DeleteInfrastructureConfigurationRequest");
   }
 }
 
@@ -1015,7 +1016,7 @@ export interface DeleteInfrastructureConfigurationResponse
 
 export namespace DeleteInfrastructureConfigurationResponse {
   export function isa(o: any): o is DeleteInfrastructureConfigurationResponse {
-    return _smithy.isa(o, "DeleteInfrastructureConfigurationResponse");
+    return __isa(o, "DeleteInfrastructureConfigurationResponse");
   }
 }
 
@@ -1042,7 +1043,7 @@ export interface Distribution {
 
 export namespace Distribution {
   export function isa(o: any): o is Distribution {
-    return _smithy.isa(o, "Distribution");
+    return __isa(o, "Distribution");
   }
 }
 
@@ -1094,7 +1095,7 @@ export interface DistributionConfiguration {
 
 export namespace DistributionConfiguration {
   export function isa(o: any): o is DistributionConfiguration {
-    return _smithy.isa(o, "DistributionConfiguration");
+    return __isa(o, "DistributionConfiguration");
   }
 }
 
@@ -1136,7 +1137,7 @@ export interface DistributionConfigurationSummary {
 
 export namespace DistributionConfigurationSummary {
   export function isa(o: any): o is DistributionConfigurationSummary {
-    return _smithy.isa(o, "DistributionConfigurationSummary");
+    return __isa(o, "DistributionConfigurationSummary");
   }
 }
 
@@ -1183,7 +1184,7 @@ export interface EbsInstanceBlockDeviceSpecification {
 
 export namespace EbsInstanceBlockDeviceSpecification {
   export function isa(o: any): o is EbsInstanceBlockDeviceSpecification {
-    return _smithy.isa(o, "EbsInstanceBlockDeviceSpecification");
+    return __isa(o, "EbsInstanceBlockDeviceSpecification");
   }
 }
 
@@ -1213,16 +1214,14 @@ export interface Filter {
 
 export namespace Filter {
   export function isa(o: any): o is Filter {
-    return _smithy.isa(o, "Filter");
+    return __isa(o, "Filter");
   }
 }
 
 /**
  * <p>You are not authorized to perform the requested operation.</p>
  */
-export interface ForbiddenException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface ForbiddenException extends __SmithyException, $MetadataBearer {
   name: "ForbiddenException";
   $fault: "client";
   message?: string;
@@ -1230,7 +1229,7 @@ export interface ForbiddenException
 
 export namespace ForbiddenException {
   export function isa(o: any): o is ForbiddenException {
-    return _smithy.isa(o, "ForbiddenException");
+    return __isa(o, "ForbiddenException");
   }
 }
 
@@ -1244,7 +1243,7 @@ export interface GetComponentPolicyRequest {
 
 export namespace GetComponentPolicyRequest {
   export function isa(o: any): o is GetComponentPolicyRequest {
-    return _smithy.isa(o, "GetComponentPolicyRequest");
+    return __isa(o, "GetComponentPolicyRequest");
   }
 }
 
@@ -1263,7 +1262,7 @@ export interface GetComponentPolicyResponse extends $MetadataBearer {
 
 export namespace GetComponentPolicyResponse {
   export function isa(o: any): o is GetComponentPolicyResponse {
-    return _smithy.isa(o, "GetComponentPolicyResponse");
+    return __isa(o, "GetComponentPolicyResponse");
   }
 }
 
@@ -1277,7 +1276,7 @@ export interface GetComponentRequest {
 
 export namespace GetComponentRequest {
   export function isa(o: any): o is GetComponentRequest {
-    return _smithy.isa(o, "GetComponentRequest");
+    return __isa(o, "GetComponentRequest");
   }
 }
 
@@ -1296,7 +1295,7 @@ export interface GetComponentResponse extends $MetadataBearer {
 
 export namespace GetComponentResponse {
   export function isa(o: any): o is GetComponentResponse {
-    return _smithy.isa(o, "GetComponentResponse");
+    return __isa(o, "GetComponentResponse");
   }
 }
 
@@ -1310,7 +1309,7 @@ export interface GetDistributionConfigurationRequest {
 
 export namespace GetDistributionConfigurationRequest {
   export function isa(o: any): o is GetDistributionConfigurationRequest {
-    return _smithy.isa(o, "GetDistributionConfigurationRequest");
+    return __isa(o, "GetDistributionConfigurationRequest");
   }
 }
 
@@ -1329,7 +1328,7 @@ export interface GetDistributionConfigurationResponse extends $MetadataBearer {
 
 export namespace GetDistributionConfigurationResponse {
   export function isa(o: any): o is GetDistributionConfigurationResponse {
-    return _smithy.isa(o, "GetDistributionConfigurationResponse");
+    return __isa(o, "GetDistributionConfigurationResponse");
   }
 }
 
@@ -1343,7 +1342,7 @@ export interface GetImagePipelineRequest {
 
 export namespace GetImagePipelineRequest {
   export function isa(o: any): o is GetImagePipelineRequest {
-    return _smithy.isa(o, "GetImagePipelineRequest");
+    return __isa(o, "GetImagePipelineRequest");
   }
 }
 
@@ -1362,7 +1361,7 @@ export interface GetImagePipelineResponse extends $MetadataBearer {
 
 export namespace GetImagePipelineResponse {
   export function isa(o: any): o is GetImagePipelineResponse {
-    return _smithy.isa(o, "GetImagePipelineResponse");
+    return __isa(o, "GetImagePipelineResponse");
   }
 }
 
@@ -1376,7 +1375,7 @@ export interface GetImagePolicyRequest {
 
 export namespace GetImagePolicyRequest {
   export function isa(o: any): o is GetImagePolicyRequest {
-    return _smithy.isa(o, "GetImagePolicyRequest");
+    return __isa(o, "GetImagePolicyRequest");
   }
 }
 
@@ -1395,7 +1394,7 @@ export interface GetImagePolicyResponse extends $MetadataBearer {
 
 export namespace GetImagePolicyResponse {
   export function isa(o: any): o is GetImagePolicyResponse {
-    return _smithy.isa(o, "GetImagePolicyResponse");
+    return __isa(o, "GetImagePolicyResponse");
   }
 }
 
@@ -1409,7 +1408,7 @@ export interface GetImageRecipePolicyRequest {
 
 export namespace GetImageRecipePolicyRequest {
   export function isa(o: any): o is GetImageRecipePolicyRequest {
-    return _smithy.isa(o, "GetImageRecipePolicyRequest");
+    return __isa(o, "GetImageRecipePolicyRequest");
   }
 }
 
@@ -1428,7 +1427,7 @@ export interface GetImageRecipePolicyResponse extends $MetadataBearer {
 
 export namespace GetImageRecipePolicyResponse {
   export function isa(o: any): o is GetImageRecipePolicyResponse {
-    return _smithy.isa(o, "GetImageRecipePolicyResponse");
+    return __isa(o, "GetImageRecipePolicyResponse");
   }
 }
 
@@ -1442,7 +1441,7 @@ export interface GetImageRecipeRequest {
 
 export namespace GetImageRecipeRequest {
   export function isa(o: any): o is GetImageRecipeRequest {
-    return _smithy.isa(o, "GetImageRecipeRequest");
+    return __isa(o, "GetImageRecipeRequest");
   }
 }
 
@@ -1461,7 +1460,7 @@ export interface GetImageRecipeResponse extends $MetadataBearer {
 
 export namespace GetImageRecipeResponse {
   export function isa(o: any): o is GetImageRecipeResponse {
-    return _smithy.isa(o, "GetImageRecipeResponse");
+    return __isa(o, "GetImageRecipeResponse");
   }
 }
 
@@ -1475,7 +1474,7 @@ export interface GetImageRequest {
 
 export namespace GetImageRequest {
   export function isa(o: any): o is GetImageRequest {
-    return _smithy.isa(o, "GetImageRequest");
+    return __isa(o, "GetImageRequest");
   }
 }
 
@@ -1494,7 +1493,7 @@ export interface GetImageResponse extends $MetadataBearer {
 
 export namespace GetImageResponse {
   export function isa(o: any): o is GetImageResponse {
-    return _smithy.isa(o, "GetImageResponse");
+    return __isa(o, "GetImageResponse");
   }
 }
 
@@ -1511,7 +1510,7 @@ export interface GetInfrastructureConfigurationRequest {
 
 export namespace GetInfrastructureConfigurationRequest {
   export function isa(o: any): o is GetInfrastructureConfigurationRequest {
-    return _smithy.isa(o, "GetInfrastructureConfigurationRequest");
+    return __isa(o, "GetInfrastructureConfigurationRequest");
   }
 }
 
@@ -1534,7 +1533,7 @@ export interface GetInfrastructureConfigurationResponse
 
 export namespace GetInfrastructureConfigurationResponse {
   export function isa(o: any): o is GetInfrastructureConfigurationResponse {
-    return _smithy.isa(o, "GetInfrastructureConfigurationResponse");
+    return __isa(o, "GetInfrastructureConfigurationResponse");
   }
 }
 
@@ -1542,7 +1541,7 @@ export namespace GetInfrastructureConfigurationResponse {
  * <p>You have specified an client token for an operation using parameter values that differ from a previous request that used the same client token.</p>
  */
 export interface IdempotentParameterMismatchException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "IdempotentParameterMismatchException";
   $fault: "client";
@@ -1551,7 +1550,7 @@ export interface IdempotentParameterMismatchException
 
 export namespace IdempotentParameterMismatchException {
   export function isa(o: any): o is IdempotentParameterMismatchException {
-    return _smithy.isa(o, "IdempotentParameterMismatchException");
+    return __isa(o, "IdempotentParameterMismatchException");
   }
 }
 
@@ -1633,7 +1632,7 @@ export interface Image {
 
 export namespace Image {
   export function isa(o: any): o is Image {
-    return _smithy.isa(o, "Image");
+    return __isa(o, "Image");
   }
 }
 
@@ -1720,7 +1719,7 @@ export interface ImagePipeline {
 
 export namespace ImagePipeline {
   export function isa(o: any): o is ImagePipeline {
-    return _smithy.isa(o, "ImagePipeline");
+    return __isa(o, "ImagePipeline");
   }
 }
 
@@ -1787,7 +1786,7 @@ export interface ImageRecipe {
 
 export namespace ImageRecipe {
   export function isa(o: any): o is ImageRecipe {
-    return _smithy.isa(o, "ImageRecipe");
+    return __isa(o, "ImageRecipe");
   }
 }
 
@@ -1834,7 +1833,7 @@ export interface ImageRecipeSummary {
 
 export namespace ImageRecipeSummary {
   export function isa(o: any): o is ImageRecipeSummary {
-    return _smithy.isa(o, "ImageRecipeSummary");
+    return __isa(o, "ImageRecipeSummary");
   }
 }
 
@@ -1856,7 +1855,7 @@ export interface ImageState {
 
 export namespace ImageState {
   export function isa(o: any): o is ImageState {
-    return _smithy.isa(o, "ImageState");
+    return __isa(o, "ImageState");
   }
 }
 
@@ -1927,7 +1926,7 @@ export interface ImageSummary {
 
 export namespace ImageSummary {
   export function isa(o: any): o is ImageSummary {
-    return _smithy.isa(o, "ImageSummary");
+    return __isa(o, "ImageSummary");
   }
 }
 
@@ -1949,7 +1948,7 @@ export interface ImageTestsConfiguration {
 
 export namespace ImageTestsConfiguration {
   export function isa(o: any): o is ImageTestsConfiguration {
-    return _smithy.isa(o, "ImageTestsConfiguration");
+    return __isa(o, "ImageTestsConfiguration");
   }
 }
 
@@ -1991,7 +1990,7 @@ export interface ImageVersion {
 
 export namespace ImageVersion {
   export function isa(o: any): o is ImageVersion {
-    return _smithy.isa(o, "ImageVersion");
+    return __isa(o, "ImageVersion");
   }
 }
 
@@ -2060,7 +2059,7 @@ export interface ImportComponentRequest {
 
 export namespace ImportComponentRequest {
   export function isa(o: any): o is ImportComponentRequest {
-    return _smithy.isa(o, "ImportComponentRequest");
+    return __isa(o, "ImportComponentRequest");
   }
 }
 
@@ -2084,7 +2083,7 @@ export interface ImportComponentResponse extends $MetadataBearer {
 
 export namespace ImportComponentResponse {
   export function isa(o: any): o is ImportComponentResponse {
-    return _smithy.isa(o, "ImportComponentResponse");
+    return __isa(o, "ImportComponentResponse");
   }
 }
 
@@ -2166,7 +2165,7 @@ export interface InfrastructureConfiguration {
 
 export namespace InfrastructureConfiguration {
   export function isa(o: any): o is InfrastructureConfiguration {
-    return _smithy.isa(o, "InfrastructureConfiguration");
+    return __isa(o, "InfrastructureConfiguration");
   }
 }
 
@@ -2208,7 +2207,7 @@ export interface InfrastructureConfigurationSummary {
 
 export namespace InfrastructureConfigurationSummary {
   export function isa(o: any): o is InfrastructureConfigurationSummary {
-    return _smithy.isa(o, "InfrastructureConfigurationSummary");
+    return __isa(o, "InfrastructureConfigurationSummary");
   }
 }
 
@@ -2240,7 +2239,7 @@ export interface InstanceBlockDeviceMapping {
 
 export namespace InstanceBlockDeviceMapping {
   export function isa(o: any): o is InstanceBlockDeviceMapping {
-    return _smithy.isa(o, "InstanceBlockDeviceMapping");
+    return __isa(o, "InstanceBlockDeviceMapping");
   }
 }
 
@@ -2248,7 +2247,7 @@ export namespace InstanceBlockDeviceMapping {
  * <p>You have provided an invalid pagination token in your request.</p>
  */
 export interface InvalidPaginationTokenException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidPaginationTokenException";
   $fault: "client";
@@ -2257,7 +2256,7 @@ export interface InvalidPaginationTokenException
 
 export namespace InvalidPaginationTokenException {
   export function isa(o: any): o is InvalidPaginationTokenException {
-    return _smithy.isa(o, "InvalidPaginationTokenException");
+    return __isa(o, "InvalidPaginationTokenException");
   }
 }
 
@@ -2265,7 +2264,7 @@ export namespace InvalidPaginationTokenException {
  * <p>You have specified two or more mutually exclusive parameters. Review the error message for details.</p>
  */
 export interface InvalidParameterCombinationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidParameterCombinationException";
   $fault: "client";
@@ -2274,7 +2273,7 @@ export interface InvalidParameterCombinationException
 
 export namespace InvalidParameterCombinationException {
   export function isa(o: any): o is InvalidParameterCombinationException {
-    return _smithy.isa(o, "InvalidParameterCombinationException");
+    return __isa(o, "InvalidParameterCombinationException");
   }
 }
 
@@ -2282,7 +2281,7 @@ export namespace InvalidParameterCombinationException {
  * <p>The specified parameter is invalid. Review the available parameters for the API request.</p>
  */
 export interface InvalidParameterException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidParameterException";
   $fault: "client";
@@ -2291,7 +2290,7 @@ export interface InvalidParameterException
 
 export namespace InvalidParameterException {
   export function isa(o: any): o is InvalidParameterException {
-    return _smithy.isa(o, "InvalidParameterException");
+    return __isa(o, "InvalidParameterException");
   }
 }
 
@@ -2299,7 +2298,7 @@ export namespace InvalidParameterException {
  * <p>The value that you provided for the specified parameter is invalid.</p>
  */
 export interface InvalidParameterValueException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidParameterValueException";
   $fault: "client";
@@ -2308,7 +2307,7 @@ export interface InvalidParameterValueException
 
 export namespace InvalidParameterValueException {
   export function isa(o: any): o is InvalidParameterValueException {
-    return _smithy.isa(o, "InvalidParameterValueException");
+    return __isa(o, "InvalidParameterValueException");
   }
 }
 
@@ -2316,7 +2315,7 @@ export namespace InvalidParameterValueException {
  * <p>You have made a request for an action that is not supported by the service.</p>
  */
 export interface InvalidRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidRequestException";
   $fault: "client";
@@ -2325,7 +2324,7 @@ export interface InvalidRequestException
 
 export namespace InvalidRequestException {
   export function isa(o: any): o is InvalidRequestException {
-    return _smithy.isa(o, "InvalidRequestException");
+    return __isa(o, "InvalidRequestException");
   }
 }
 
@@ -2333,7 +2332,7 @@ export namespace InvalidRequestException {
  * <p>Your version number is out of bounds or does not follow the required syntax.</p>
  */
 export interface InvalidVersionNumberException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidVersionNumberException";
   $fault: "client";
@@ -2342,7 +2341,7 @@ export interface InvalidVersionNumberException
 
 export namespace InvalidVersionNumberException {
   export function isa(o: any): o is InvalidVersionNumberException {
-    return _smithy.isa(o, "InvalidVersionNumberException");
+    return __isa(o, "InvalidVersionNumberException");
   }
 }
 
@@ -2364,7 +2363,7 @@ export interface LaunchPermissionConfiguration {
 
 export namespace LaunchPermissionConfiguration {
   export function isa(o: any): o is LaunchPermissionConfiguration {
-    return _smithy.isa(o, "LaunchPermissionConfiguration");
+    return __isa(o, "LaunchPermissionConfiguration");
   }
 }
 
@@ -2388,7 +2387,7 @@ export interface ListComponentBuildVersionsRequest {
 
 export namespace ListComponentBuildVersionsRequest {
   export function isa(o: any): o is ListComponentBuildVersionsRequest {
-    return _smithy.isa(o, "ListComponentBuildVersionsRequest");
+    return __isa(o, "ListComponentBuildVersionsRequest");
   }
 }
 
@@ -2412,7 +2411,7 @@ export interface ListComponentBuildVersionsResponse extends $MetadataBearer {
 
 export namespace ListComponentBuildVersionsResponse {
   export function isa(o: any): o is ListComponentBuildVersionsResponse {
-    return _smithy.isa(o, "ListComponentBuildVersionsResponse");
+    return __isa(o, "ListComponentBuildVersionsResponse");
   }
 }
 
@@ -2441,7 +2440,7 @@ export interface ListComponentsRequest {
 
 export namespace ListComponentsRequest {
   export function isa(o: any): o is ListComponentsRequest {
-    return _smithy.isa(o, "ListComponentsRequest");
+    return __isa(o, "ListComponentsRequest");
   }
 }
 
@@ -2465,7 +2464,7 @@ export interface ListComponentsResponse extends $MetadataBearer {
 
 export namespace ListComponentsResponse {
   export function isa(o: any): o is ListComponentsResponse {
-    return _smithy.isa(o, "ListComponentsResponse");
+    return __isa(o, "ListComponentsResponse");
   }
 }
 
@@ -2489,7 +2488,7 @@ export interface ListDistributionConfigurationsRequest {
 
 export namespace ListDistributionConfigurationsRequest {
   export function isa(o: any): o is ListDistributionConfigurationsRequest {
-    return _smithy.isa(o, "ListDistributionConfigurationsRequest");
+    return __isa(o, "ListDistributionConfigurationsRequest");
   }
 }
 
@@ -2516,7 +2515,7 @@ export interface ListDistributionConfigurationsResponse
 
 export namespace ListDistributionConfigurationsResponse {
   export function isa(o: any): o is ListDistributionConfigurationsResponse {
-    return _smithy.isa(o, "ListDistributionConfigurationsResponse");
+    return __isa(o, "ListDistributionConfigurationsResponse");
   }
 }
 
@@ -2545,7 +2544,7 @@ export interface ListImageBuildVersionsRequest {
 
 export namespace ListImageBuildVersionsRequest {
   export function isa(o: any): o is ListImageBuildVersionsRequest {
-    return _smithy.isa(o, "ListImageBuildVersionsRequest");
+    return __isa(o, "ListImageBuildVersionsRequest");
   }
 }
 
@@ -2569,7 +2568,7 @@ export interface ListImageBuildVersionsResponse extends $MetadataBearer {
 
 export namespace ListImageBuildVersionsResponse {
   export function isa(o: any): o is ListImageBuildVersionsResponse {
-    return _smithy.isa(o, "ListImageBuildVersionsResponse");
+    return __isa(o, "ListImageBuildVersionsResponse");
   }
 }
 
@@ -2598,7 +2597,7 @@ export interface ListImagePipelineImagesRequest {
 
 export namespace ListImagePipelineImagesRequest {
   export function isa(o: any): o is ListImagePipelineImagesRequest {
-    return _smithy.isa(o, "ListImagePipelineImagesRequest");
+    return __isa(o, "ListImagePipelineImagesRequest");
   }
 }
 
@@ -2622,7 +2621,7 @@ export interface ListImagePipelineImagesResponse extends $MetadataBearer {
 
 export namespace ListImagePipelineImagesResponse {
   export function isa(o: any): o is ListImagePipelineImagesResponse {
-    return _smithy.isa(o, "ListImagePipelineImagesResponse");
+    return __isa(o, "ListImagePipelineImagesResponse");
   }
 }
 
@@ -2646,7 +2645,7 @@ export interface ListImagePipelinesRequest {
 
 export namespace ListImagePipelinesRequest {
   export function isa(o: any): o is ListImagePipelinesRequest {
-    return _smithy.isa(o, "ListImagePipelinesRequest");
+    return __isa(o, "ListImagePipelinesRequest");
   }
 }
 
@@ -2670,7 +2669,7 @@ export interface ListImagePipelinesResponse extends $MetadataBearer {
 
 export namespace ListImagePipelinesResponse {
   export function isa(o: any): o is ListImagePipelinesResponse {
-    return _smithy.isa(o, "ListImagePipelinesResponse");
+    return __isa(o, "ListImagePipelinesResponse");
   }
 }
 
@@ -2699,7 +2698,7 @@ export interface ListImageRecipesRequest {
 
 export namespace ListImageRecipesRequest {
   export function isa(o: any): o is ListImageRecipesRequest {
-    return _smithy.isa(o, "ListImageRecipesRequest");
+    return __isa(o, "ListImageRecipesRequest");
   }
 }
 
@@ -2723,7 +2722,7 @@ export interface ListImageRecipesResponse extends $MetadataBearer {
 
 export namespace ListImageRecipesResponse {
   export function isa(o: any): o is ListImageRecipesResponse {
-    return _smithy.isa(o, "ListImageRecipesResponse");
+    return __isa(o, "ListImageRecipesResponse");
   }
 }
 
@@ -2752,7 +2751,7 @@ export interface ListImagesRequest {
 
 export namespace ListImagesRequest {
   export function isa(o: any): o is ListImagesRequest {
-    return _smithy.isa(o, "ListImagesRequest");
+    return __isa(o, "ListImagesRequest");
   }
 }
 
@@ -2776,7 +2775,7 @@ export interface ListImagesResponse extends $MetadataBearer {
 
 export namespace ListImagesResponse {
   export function isa(o: any): o is ListImagesResponse {
-    return _smithy.isa(o, "ListImagesResponse");
+    return __isa(o, "ListImagesResponse");
   }
 }
 
@@ -2800,7 +2799,7 @@ export interface ListInfrastructureConfigurationsRequest {
 
 export namespace ListInfrastructureConfigurationsRequest {
   export function isa(o: any): o is ListInfrastructureConfigurationsRequest {
-    return _smithy.isa(o, "ListInfrastructureConfigurationsRequest");
+    return __isa(o, "ListInfrastructureConfigurationsRequest");
   }
 }
 
@@ -2827,7 +2826,7 @@ export interface ListInfrastructureConfigurationsResponse
 
 export namespace ListInfrastructureConfigurationsResponse {
   export function isa(o: any): o is ListInfrastructureConfigurationsResponse {
-    return _smithy.isa(o, "ListInfrastructureConfigurationsResponse");
+    return __isa(o, "ListInfrastructureConfigurationsResponse");
   }
 }
 
@@ -2841,7 +2840,7 @@ export interface ListTagsForResourceRequest {
 
 export namespace ListTagsForResourceRequest {
   export function isa(o: any): o is ListTagsForResourceRequest {
-    return _smithy.isa(o, "ListTagsForResourceRequest");
+    return __isa(o, "ListTagsForResourceRequest");
   }
 }
 
@@ -2855,7 +2854,7 @@ export interface ListTagsForResourceResponse extends $MetadataBearer {
 
 export namespace ListTagsForResourceResponse {
   export function isa(o: any): o is ListTagsForResourceResponse {
-    return _smithy.isa(o, "ListTagsForResourceResponse");
+    return __isa(o, "ListTagsForResourceResponse");
   }
 }
 
@@ -2872,7 +2871,7 @@ export interface Logging {
 
 export namespace Logging {
   export function isa(o: any): o is Logging {
-    return _smithy.isa(o, "Logging");
+    return __isa(o, "Logging");
   }
 }
 
@@ -2889,7 +2888,7 @@ export interface OutputResources {
 
 export namespace OutputResources {
   export function isa(o: any): o is OutputResources {
-    return _smithy.isa(o, "OutputResources");
+    return __isa(o, "OutputResources");
   }
 }
 
@@ -2929,7 +2928,7 @@ export interface PutComponentPolicyRequest {
 
 export namespace PutComponentPolicyRequest {
   export function isa(o: any): o is PutComponentPolicyRequest {
-    return _smithy.isa(o, "PutComponentPolicyRequest");
+    return __isa(o, "PutComponentPolicyRequest");
   }
 }
 
@@ -2948,7 +2947,7 @@ export interface PutComponentPolicyResponse extends $MetadataBearer {
 
 export namespace PutComponentPolicyResponse {
   export function isa(o: any): o is PutComponentPolicyResponse {
-    return _smithy.isa(o, "PutComponentPolicyResponse");
+    return __isa(o, "PutComponentPolicyResponse");
   }
 }
 
@@ -2967,7 +2966,7 @@ export interface PutImagePolicyRequest {
 
 export namespace PutImagePolicyRequest {
   export function isa(o: any): o is PutImagePolicyRequest {
-    return _smithy.isa(o, "PutImagePolicyRequest");
+    return __isa(o, "PutImagePolicyRequest");
   }
 }
 
@@ -2986,7 +2985,7 @@ export interface PutImagePolicyResponse extends $MetadataBearer {
 
 export namespace PutImagePolicyResponse {
   export function isa(o: any): o is PutImagePolicyResponse {
-    return _smithy.isa(o, "PutImagePolicyResponse");
+    return __isa(o, "PutImagePolicyResponse");
   }
 }
 
@@ -3005,7 +3004,7 @@ export interface PutImageRecipePolicyRequest {
 
 export namespace PutImageRecipePolicyRequest {
   export function isa(o: any): o is PutImageRecipePolicyRequest {
-    return _smithy.isa(o, "PutImageRecipePolicyRequest");
+    return __isa(o, "PutImageRecipePolicyRequest");
   }
 }
 
@@ -3024,7 +3023,7 @@ export interface PutImageRecipePolicyResponse extends $MetadataBearer {
 
 export namespace PutImageRecipePolicyResponse {
   export function isa(o: any): o is PutImageRecipePolicyResponse {
-    return _smithy.isa(o, "PutImageRecipePolicyResponse");
+    return __isa(o, "PutImageRecipePolicyResponse");
   }
 }
 
@@ -3032,7 +3031,7 @@ export namespace PutImageRecipePolicyResponse {
  * <p>The resource that you are trying to create already exists.</p>
  */
 export interface ResourceAlreadyExistsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceAlreadyExistsException";
   $fault: "client";
@@ -3041,7 +3040,7 @@ export interface ResourceAlreadyExistsException
 
 export namespace ResourceAlreadyExistsException {
   export function isa(o: any): o is ResourceAlreadyExistsException {
-    return _smithy.isa(o, "ResourceAlreadyExistsException");
+    return __isa(o, "ResourceAlreadyExistsException");
   }
 }
 
@@ -3049,7 +3048,7 @@ export namespace ResourceAlreadyExistsException {
  * <p>You have attempted to mutate or delete a resource with a dependency that is prohibitting this action. See the error message for more details.</p>
  */
 export interface ResourceDependencyException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceDependencyException";
   $fault: "client";
@@ -3058,7 +3057,7 @@ export interface ResourceDependencyException
 
 export namespace ResourceDependencyException {
   export function isa(o: any): o is ResourceDependencyException {
-    return _smithy.isa(o, "ResourceDependencyException");
+    return __isa(o, "ResourceDependencyException");
   }
 }
 
@@ -3066,7 +3065,7 @@ export namespace ResourceDependencyException {
  * <p>The resource that you are trying to operate on is currently in use. Review the message details, and retry later.</p>
  */
 export interface ResourceInUseException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceInUseException";
   $fault: "client";
@@ -3075,7 +3074,7 @@ export interface ResourceInUseException
 
 export namespace ResourceInUseException {
   export function isa(o: any): o is ResourceInUseException {
-    return _smithy.isa(o, "ResourceInUseException");
+    return __isa(o, "ResourceInUseException");
   }
 }
 
@@ -3083,7 +3082,7 @@ export namespace ResourceInUseException {
  * <p>At least one of the resources referenced by your request does not exist.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -3092,7 +3091,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -3114,7 +3113,7 @@ export interface S3Logs {
 
 export namespace S3Logs {
   export function isa(o: any): o is S3Logs {
-    return _smithy.isa(o, "S3Logs");
+    return __isa(o, "S3Logs");
   }
 }
 
@@ -3136,16 +3135,14 @@ export interface Schedule {
 
 export namespace Schedule {
   export function isa(o: any): o is Schedule {
-    return _smithy.isa(o, "Schedule");
+    return __isa(o, "Schedule");
   }
 }
 
 /**
  * <p>This exception is thrown when the service encounters an unrecoverable exception.</p>
  */
-export interface ServiceException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface ServiceException extends __SmithyException, $MetadataBearer {
   name: "ServiceException";
   $fault: "server";
   message?: string;
@@ -3153,7 +3150,7 @@ export interface ServiceException
 
 export namespace ServiceException {
   export function isa(o: any): o is ServiceException {
-    return _smithy.isa(o, "ServiceException");
+    return __isa(o, "ServiceException");
   }
 }
 
@@ -3161,7 +3158,7 @@ export namespace ServiceException {
  * <p>The service is unable to process your request at this time.</p>
  */
 export interface ServiceUnavailableException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ServiceUnavailableException";
   $fault: "server";
@@ -3170,7 +3167,7 @@ export interface ServiceUnavailableException
 
 export namespace ServiceUnavailableException {
   export function isa(o: any): o is ServiceUnavailableException {
-    return _smithy.isa(o, "ServiceUnavailableException");
+    return __isa(o, "ServiceUnavailableException");
   }
 }
 
@@ -3189,7 +3186,7 @@ export interface StartImagePipelineExecutionRequest {
 
 export namespace StartImagePipelineExecutionRequest {
   export function isa(o: any): o is StartImagePipelineExecutionRequest {
-    return _smithy.isa(o, "StartImagePipelineExecutionRequest");
+    return __isa(o, "StartImagePipelineExecutionRequest");
   }
 }
 
@@ -3213,7 +3210,7 @@ export interface StartImagePipelineExecutionResponse extends $MetadataBearer {
 
 export namespace StartImagePipelineExecutionResponse {
   export function isa(o: any): o is StartImagePipelineExecutionResponse {
-    return _smithy.isa(o, "StartImagePipelineExecutionResponse");
+    return __isa(o, "StartImagePipelineExecutionResponse");
   }
 }
 
@@ -3232,7 +3229,7 @@ export interface TagResourceRequest {
 
 export namespace TagResourceRequest {
   export function isa(o: any): o is TagResourceRequest {
-    return _smithy.isa(o, "TagResourceRequest");
+    return __isa(o, "TagResourceRequest");
   }
 }
 
@@ -3242,7 +3239,7 @@ export interface TagResourceResponse extends $MetadataBearer {
 
 export namespace TagResourceResponse {
   export function isa(o: any): o is TagResourceResponse {
-    return _smithy.isa(o, "TagResourceResponse");
+    return __isa(o, "TagResourceResponse");
   }
 }
 
@@ -3261,7 +3258,7 @@ export interface UntagResourceRequest {
 
 export namespace UntagResourceRequest {
   export function isa(o: any): o is UntagResourceRequest {
-    return _smithy.isa(o, "UntagResourceRequest");
+    return __isa(o, "UntagResourceRequest");
   }
 }
 
@@ -3271,7 +3268,7 @@ export interface UntagResourceResponse extends $MetadataBearer {
 
 export namespace UntagResourceResponse {
   export function isa(o: any): o is UntagResourceResponse {
-    return _smithy.isa(o, "UntagResourceResponse");
+    return __isa(o, "UntagResourceResponse");
   }
 }
 
@@ -3300,7 +3297,7 @@ export interface UpdateDistributionConfigurationRequest {
 
 export namespace UpdateDistributionConfigurationRequest {
   export function isa(o: any): o is UpdateDistributionConfigurationRequest {
-    return _smithy.isa(o, "UpdateDistributionConfigurationRequest");
+    return __isa(o, "UpdateDistributionConfigurationRequest");
   }
 }
 
@@ -3325,7 +3322,7 @@ export interface UpdateDistributionConfigurationResponse
 
 export namespace UpdateDistributionConfigurationResponse {
   export function isa(o: any): o is UpdateDistributionConfigurationResponse {
-    return _smithy.isa(o, "UpdateDistributionConfigurationResponse");
+    return __isa(o, "UpdateDistributionConfigurationResponse");
   }
 }
 
@@ -3379,7 +3376,7 @@ export interface UpdateImagePipelineRequest {
 
 export namespace UpdateImagePipelineRequest {
   export function isa(o: any): o is UpdateImagePipelineRequest {
-    return _smithy.isa(o, "UpdateImagePipelineRequest");
+    return __isa(o, "UpdateImagePipelineRequest");
   }
 }
 
@@ -3403,7 +3400,7 @@ export interface UpdateImagePipelineResponse extends $MetadataBearer {
 
 export namespace UpdateImagePipelineResponse {
   export function isa(o: any): o is UpdateImagePipelineResponse {
-    return _smithy.isa(o, "UpdateImagePipelineResponse");
+    return __isa(o, "UpdateImagePipelineResponse");
   }
 }
 
@@ -3467,7 +3464,7 @@ export interface UpdateInfrastructureConfigurationRequest {
 
 export namespace UpdateInfrastructureConfigurationRequest {
   export function isa(o: any): o is UpdateInfrastructureConfigurationRequest {
-    return _smithy.isa(o, "UpdateInfrastructureConfigurationRequest");
+    return __isa(o, "UpdateInfrastructureConfigurationRequest");
   }
 }
 
@@ -3492,6 +3489,6 @@ export interface UpdateInfrastructureConfigurationResponse
 
 export namespace UpdateInfrastructureConfigurationResponse {
   export function isa(o: any): o is UpdateInfrastructureConfigurationResponse {
-    return _smithy.isa(o, "UpdateInfrastructureConfigurationResponse");
+    return __isa(o, "UpdateInfrastructureConfigurationResponse");
   }
 }

--- a/clients/client-imagebuilder/protocols/Aws_restJson1_1.ts
+++ b/clients/client-imagebuilder/protocols/Aws_restJson1_1.ts
@@ -215,7 +215,10 @@ import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  extendedEncodeURIComponent as __extendedEncodeURIComponent
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -590,8 +593,8 @@ export async function serializeAws_restJson1_1DeleteComponentCommand(
   const query: any = {};
   if (input.componentBuildVersionArn !== undefined) {
     query[
-      "componentBuildVersionArn"
-    ] = input.componentBuildVersionArn.toString();
+      __extendedEncodeURIComponent("componentBuildVersionArn")
+    ] = __extendedEncodeURIComponent(input.componentBuildVersionArn);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -613,8 +616,8 @@ export async function serializeAws_restJson1_1DeleteDistributionConfigurationCom
   const query: any = {};
   if (input.distributionConfigurationArn !== undefined) {
     query[
-      "distributionConfigurationArn"
-    ] = input.distributionConfigurationArn.toString();
+      __extendedEncodeURIComponent("distributionConfigurationArn")
+    ] = __extendedEncodeURIComponent(input.distributionConfigurationArn);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -635,7 +638,9 @@ export async function serializeAws_restJson1_1DeleteImageCommand(
   let resolvedPath = "/DeleteImage";
   const query: any = {};
   if (input.imageBuildVersionArn !== undefined) {
-    query["imageBuildVersionArn"] = input.imageBuildVersionArn.toString();
+    query[
+      __extendedEncodeURIComponent("imageBuildVersionArn")
+    ] = __extendedEncodeURIComponent(input.imageBuildVersionArn);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -656,7 +661,9 @@ export async function serializeAws_restJson1_1DeleteImagePipelineCommand(
   let resolvedPath = "/DeleteImagePipeline";
   const query: any = {};
   if (input.imagePipelineArn !== undefined) {
-    query["imagePipelineArn"] = input.imagePipelineArn.toString();
+    query[
+      __extendedEncodeURIComponent("imagePipelineArn")
+    ] = __extendedEncodeURIComponent(input.imagePipelineArn);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -677,7 +684,9 @@ export async function serializeAws_restJson1_1DeleteImageRecipeCommand(
   let resolvedPath = "/DeleteImageRecipe";
   const query: any = {};
   if (input.imageRecipeArn !== undefined) {
-    query["imageRecipeArn"] = input.imageRecipeArn.toString();
+    query[
+      __extendedEncodeURIComponent("imageRecipeArn")
+    ] = __extendedEncodeURIComponent(input.imageRecipeArn);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -699,8 +708,8 @@ export async function serializeAws_restJson1_1DeleteInfrastructureConfigurationC
   const query: any = {};
   if (input.infrastructureConfigurationArn !== undefined) {
     query[
-      "infrastructureConfigurationArn"
-    ] = input.infrastructureConfigurationArn.toString();
+      __extendedEncodeURIComponent("infrastructureConfigurationArn")
+    ] = __extendedEncodeURIComponent(input.infrastructureConfigurationArn);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -722,8 +731,8 @@ export async function serializeAws_restJson1_1GetComponentCommand(
   const query: any = {};
   if (input.componentBuildVersionArn !== undefined) {
     query[
-      "componentBuildVersionArn"
-    ] = input.componentBuildVersionArn.toString();
+      __extendedEncodeURIComponent("componentBuildVersionArn")
+    ] = __extendedEncodeURIComponent(input.componentBuildVersionArn);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -744,7 +753,9 @@ export async function serializeAws_restJson1_1GetComponentPolicyCommand(
   let resolvedPath = "/GetComponentPolicy";
   const query: any = {};
   if (input.componentArn !== undefined) {
-    query["componentArn"] = input.componentArn.toString();
+    query[
+      __extendedEncodeURIComponent("componentArn")
+    ] = __extendedEncodeURIComponent(input.componentArn);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -766,8 +777,8 @@ export async function serializeAws_restJson1_1GetDistributionConfigurationComman
   const query: any = {};
   if (input.distributionConfigurationArn !== undefined) {
     query[
-      "distributionConfigurationArn"
-    ] = input.distributionConfigurationArn.toString();
+      __extendedEncodeURIComponent("distributionConfigurationArn")
+    ] = __extendedEncodeURIComponent(input.distributionConfigurationArn);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -788,7 +799,9 @@ export async function serializeAws_restJson1_1GetImageCommand(
   let resolvedPath = "/GetImage";
   const query: any = {};
   if (input.imageBuildVersionArn !== undefined) {
-    query["imageBuildVersionArn"] = input.imageBuildVersionArn.toString();
+    query[
+      __extendedEncodeURIComponent("imageBuildVersionArn")
+    ] = __extendedEncodeURIComponent(input.imageBuildVersionArn);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -809,7 +822,9 @@ export async function serializeAws_restJson1_1GetImagePipelineCommand(
   let resolvedPath = "/GetImagePipeline";
   const query: any = {};
   if (input.imagePipelineArn !== undefined) {
-    query["imagePipelineArn"] = input.imagePipelineArn.toString();
+    query[
+      __extendedEncodeURIComponent("imagePipelineArn")
+    ] = __extendedEncodeURIComponent(input.imagePipelineArn);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -830,7 +845,9 @@ export async function serializeAws_restJson1_1GetImagePolicyCommand(
   let resolvedPath = "/GetImagePolicy";
   const query: any = {};
   if (input.imageArn !== undefined) {
-    query["imageArn"] = input.imageArn.toString();
+    query[
+      __extendedEncodeURIComponent("imageArn")
+    ] = __extendedEncodeURIComponent(input.imageArn);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -851,7 +868,9 @@ export async function serializeAws_restJson1_1GetImageRecipeCommand(
   let resolvedPath = "/GetImageRecipe";
   const query: any = {};
   if (input.imageRecipeArn !== undefined) {
-    query["imageRecipeArn"] = input.imageRecipeArn.toString();
+    query[
+      __extendedEncodeURIComponent("imageRecipeArn")
+    ] = __extendedEncodeURIComponent(input.imageRecipeArn);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -872,7 +891,9 @@ export async function serializeAws_restJson1_1GetImageRecipePolicyCommand(
   let resolvedPath = "/GetImageRecipePolicy";
   const query: any = {};
   if (input.imageRecipeArn !== undefined) {
-    query["imageRecipeArn"] = input.imageRecipeArn.toString();
+    query[
+      __extendedEncodeURIComponent("imageRecipeArn")
+    ] = __extendedEncodeURIComponent(input.imageRecipeArn);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -894,8 +915,8 @@ export async function serializeAws_restJson1_1GetInfrastructureConfigurationComm
   const query: any = {};
   if (input.infrastructureConfigurationArn !== undefined) {
     query[
-      "infrastructureConfigurationArn"
-    ] = input.infrastructureConfigurationArn.toString();
+      __extendedEncodeURIComponent("infrastructureConfigurationArn")
+    ] = __extendedEncodeURIComponent(input.infrastructureConfigurationArn);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1274,7 +1295,7 @@ export async function serializeAws_restJson1_1ListTagsForResourceCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/tags/{resourceArn}";
   if (input.resourceArn !== undefined) {
-    const labelValue: string = input.resourceArn.toString();
+    const labelValue: string = input.resourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: resourceArn."
@@ -1282,7 +1303,7 @@ export async function serializeAws_restJson1_1ListTagsForResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{resourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: resourceArn.");
@@ -1411,7 +1432,7 @@ export async function serializeAws_restJson1_1TagResourceCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/tags/{resourceArn}";
   if (input.resourceArn !== undefined) {
-    const labelValue: string = input.resourceArn.toString();
+    const labelValue: string = input.resourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: resourceArn."
@@ -1419,7 +1440,7 @@ export async function serializeAws_restJson1_1TagResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{resourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: resourceArn.");
@@ -1448,7 +1469,7 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/tags/{resourceArn}";
   if (input.resourceArn !== undefined) {
-    const labelValue: string = input.resourceArn.toString();
+    const labelValue: string = input.resourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: resourceArn."
@@ -1456,14 +1477,16 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{resourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: resourceArn.");
   }
   const query: any = {};
   if (input.tagKeys !== undefined) {
-    query["tagKeys"] = input.tagKeys;
+    query[__extendedEncodeURIComponent("tagKeys")] = input.tagKeys.map(entry =>
+      __extendedEncodeURIComponent(entry)
+    );
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -5653,6 +5676,7 @@ export async function deserializeAws_restJson1_1TagResourceCommand(
     $metadata: deserializeMetadata(output),
     __type: "TagResourceResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -5715,6 +5739,7 @@ export async function deserializeAws_restJson1_1UntagResourceCommand(
     $metadata: deserializeMetadata(output),
     __type: "UntagResourceResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 

--- a/clients/client-inspector/models/index.ts
+++ b/clients/client-inspector/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export enum AccessDeniedErrorCode {
@@ -16,7 +19,7 @@ export enum AccessDeniedErrorCode {
  * <p>You do not have required permissions to access the requested resource.</p>
  */
 export interface AccessDeniedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AccessDeniedException";
   $fault: "client";
@@ -38,7 +41,7 @@ export interface AccessDeniedException
 
 export namespace AccessDeniedException {
   export function isa(o: any): o is AccessDeniedException {
-    return _smithy.isa(o, "AccessDeniedException");
+    return __isa(o, "AccessDeniedException");
   }
 }
 
@@ -57,7 +60,7 @@ export interface AddAttributesToFindingsRequest {
 
 export namespace AddAttributesToFindingsRequest {
   export function isa(o: any): o is AddAttributesToFindingsRequest {
-    return _smithy.isa(o, "AddAttributesToFindingsRequest");
+    return __isa(o, "AddAttributesToFindingsRequest");
   }
 }
 
@@ -72,7 +75,7 @@ export interface AddAttributesToFindingsResponse extends $MetadataBearer {
 
 export namespace AddAttributesToFindingsResponse {
   export function isa(o: any): o is AddAttributesToFindingsResponse {
-    return _smithy.isa(o, "AddAttributesToFindingsResponse");
+    return __isa(o, "AddAttributesToFindingsResponse");
   }
 }
 
@@ -97,7 +100,7 @@ export interface AgentAlreadyRunningAssessment {
 
 export namespace AgentAlreadyRunningAssessment {
   export function isa(o: any): o is AgentAlreadyRunningAssessment {
-    return _smithy.isa(o, "AgentAlreadyRunningAssessment");
+    return __isa(o, "AgentAlreadyRunningAssessment");
   }
 }
 
@@ -120,7 +123,7 @@ export interface AgentFilter {
 
 export namespace AgentFilter {
   export function isa(o: any): o is AgentFilter {
-    return _smithy.isa(o, "AgentFilter");
+    return __isa(o, "AgentFilter");
   }
 }
 
@@ -191,7 +194,7 @@ export interface AgentPreview {
 
 export namespace AgentPreview {
   export function isa(o: any): o is AgentPreview {
-    return _smithy.isa(o, "AgentPreview");
+    return __isa(o, "AgentPreview");
   }
 }
 
@@ -200,7 +203,7 @@ export namespace AgentPreview {
  *          another assessment run.</p>
  */
 export interface AgentsAlreadyRunningAssessmentException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AgentsAlreadyRunningAssessmentException";
   $fault: "client";
@@ -227,7 +230,7 @@ export interface AgentsAlreadyRunningAssessmentException
 
 export namespace AgentsAlreadyRunningAssessmentException {
   export function isa(o: any): o is AgentsAlreadyRunningAssessmentException {
-    return _smithy.isa(o, "AgentsAlreadyRunningAssessmentException");
+    return __isa(o, "AgentsAlreadyRunningAssessmentException");
   }
 }
 
@@ -321,7 +324,7 @@ export interface AssessmentRun {
 
 export namespace AssessmentRun {
   export function isa(o: any): o is AssessmentRun {
-    return _smithy.isa(o, "AssessmentRun");
+    return __isa(o, "AssessmentRun");
   }
 }
 
@@ -371,7 +374,7 @@ export interface AssessmentRunAgent {
 
 export namespace AssessmentRunAgent {
   export function isa(o: any): o is AssessmentRunAgent {
-    return _smithy.isa(o, "AssessmentRunAgent");
+    return __isa(o, "AssessmentRunAgent");
   }
 }
 
@@ -433,7 +436,7 @@ export interface AssessmentRunFilter {
 
 export namespace AssessmentRunFilter {
   export function isa(o: any): o is AssessmentRunFilter {
-    return _smithy.isa(o, "AssessmentRunFilter");
+    return __isa(o, "AssessmentRunFilter");
   }
 }
 
@@ -442,7 +445,7 @@ export namespace AssessmentRunFilter {
  *          progress.</p>
  */
 export interface AssessmentRunInProgressException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AssessmentRunInProgressException";
   $fault: "client";
@@ -470,7 +473,7 @@ export interface AssessmentRunInProgressException
 
 export namespace AssessmentRunInProgressException {
   export function isa(o: any): o is AssessmentRunInProgressException {
-    return _smithy.isa(o, "AssessmentRunInProgressException");
+    return __isa(o, "AssessmentRunInProgressException");
   }
 }
 
@@ -514,7 +517,7 @@ export interface AssessmentRunNotification {
 
 export namespace AssessmentRunNotification {
   export function isa(o: any): o is AssessmentRunNotification {
-    return _smithy.isa(o, "AssessmentRunNotification");
+    return __isa(o, "AssessmentRunNotification");
   }
 }
 
@@ -560,7 +563,7 @@ export interface AssessmentRunStateChange {
 
 export namespace AssessmentRunStateChange {
   export function isa(o: any): o is AssessmentRunStateChange {
-    return _smithy.isa(o, "AssessmentRunStateChange");
+    return __isa(o, "AssessmentRunStateChange");
   }
 }
 
@@ -599,7 +602,7 @@ export interface AssessmentTarget {
 
 export namespace AssessmentTarget {
   export function isa(o: any): o is AssessmentTarget {
-    return _smithy.isa(o, "AssessmentTarget");
+    return __isa(o, "AssessmentTarget");
   }
 }
 
@@ -619,7 +622,7 @@ export interface AssessmentTargetFilter {
 
 export namespace AssessmentTargetFilter {
   export function isa(o: any): o is AssessmentTargetFilter {
-    return _smithy.isa(o, "AssessmentTargetFilter");
+    return __isa(o, "AssessmentTargetFilter");
   }
 }
 
@@ -684,7 +687,7 @@ export interface AssessmentTemplate {
 
 export namespace AssessmentTemplate {
   export function isa(o: any): o is AssessmentTemplate {
-    return _smithy.isa(o, "AssessmentTemplate");
+    return __isa(o, "AssessmentTemplate");
   }
 }
 
@@ -718,7 +721,7 @@ export interface AssessmentTemplateFilter {
 
 export namespace AssessmentTemplateFilter {
   export function isa(o: any): o is AssessmentTemplateFilter {
-    return _smithy.isa(o, "AssessmentTemplateFilter");
+    return __isa(o, "AssessmentTemplateFilter");
   }
 }
 
@@ -774,7 +777,7 @@ export interface AssetAttributes {
 
 export namespace AssetAttributes {
   export function isa(o: any): o is AssetAttributes {
-    return _smithy.isa(o, "AssetAttributes");
+    return __isa(o, "AssetAttributes");
   }
 }
 
@@ -801,7 +804,7 @@ export interface Attribute {
 
 export namespace Attribute {
   export function isa(o: any): o is Attribute {
-    return _smithy.isa(o, "Attribute");
+    return __isa(o, "Attribute");
   }
 }
 
@@ -823,7 +826,7 @@ export interface CreateAssessmentTargetRequest {
 
 export namespace CreateAssessmentTargetRequest {
   export function isa(o: any): o is CreateAssessmentTargetRequest {
-    return _smithy.isa(o, "CreateAssessmentTargetRequest");
+    return __isa(o, "CreateAssessmentTargetRequest");
   }
 }
 
@@ -837,7 +840,7 @@ export interface CreateAssessmentTargetResponse extends $MetadataBearer {
 
 export namespace CreateAssessmentTargetResponse {
   export function isa(o: any): o is CreateAssessmentTargetResponse {
-    return _smithy.isa(o, "CreateAssessmentTargetResponse");
+    return __isa(o, "CreateAssessmentTargetResponse");
   }
 }
 
@@ -879,7 +882,7 @@ export interface CreateAssessmentTemplateRequest {
 
 export namespace CreateAssessmentTemplateRequest {
   export function isa(o: any): o is CreateAssessmentTemplateRequest {
-    return _smithy.isa(o, "CreateAssessmentTemplateRequest");
+    return __isa(o, "CreateAssessmentTemplateRequest");
   }
 }
 
@@ -893,7 +896,7 @@ export interface CreateAssessmentTemplateResponse extends $MetadataBearer {
 
 export namespace CreateAssessmentTemplateResponse {
   export function isa(o: any): o is CreateAssessmentTemplateResponse {
-    return _smithy.isa(o, "CreateAssessmentTemplateResponse");
+    return __isa(o, "CreateAssessmentTemplateResponse");
   }
 }
 
@@ -908,7 +911,7 @@ export interface CreateExclusionsPreviewRequest {
 
 export namespace CreateExclusionsPreviewRequest {
   export function isa(o: any): o is CreateExclusionsPreviewRequest {
-    return _smithy.isa(o, "CreateExclusionsPreviewRequest");
+    return __isa(o, "CreateExclusionsPreviewRequest");
   }
 }
 
@@ -924,7 +927,7 @@ export interface CreateExclusionsPreviewResponse extends $MetadataBearer {
 
 export namespace CreateExclusionsPreviewResponse {
   export function isa(o: any): o is CreateExclusionsPreviewResponse {
-    return _smithy.isa(o, "CreateExclusionsPreviewResponse");
+    return __isa(o, "CreateExclusionsPreviewResponse");
   }
 }
 
@@ -940,7 +943,7 @@ export interface CreateResourceGroupRequest {
 
 export namespace CreateResourceGroupRequest {
   export function isa(o: any): o is CreateResourceGroupRequest {
-    return _smithy.isa(o, "CreateResourceGroupRequest");
+    return __isa(o, "CreateResourceGroupRequest");
   }
 }
 
@@ -954,7 +957,7 @@ export interface CreateResourceGroupResponse extends $MetadataBearer {
 
 export namespace CreateResourceGroupResponse {
   export function isa(o: any): o is CreateResourceGroupResponse {
-    return _smithy.isa(o, "CreateResourceGroupResponse");
+    return __isa(o, "CreateResourceGroupResponse");
   }
 }
 
@@ -968,7 +971,7 @@ export interface DeleteAssessmentRunRequest {
 
 export namespace DeleteAssessmentRunRequest {
   export function isa(o: any): o is DeleteAssessmentRunRequest {
-    return _smithy.isa(o, "DeleteAssessmentRunRequest");
+    return __isa(o, "DeleteAssessmentRunRequest");
   }
 }
 
@@ -982,7 +985,7 @@ export interface DeleteAssessmentTargetRequest {
 
 export namespace DeleteAssessmentTargetRequest {
   export function isa(o: any): o is DeleteAssessmentTargetRequest {
-    return _smithy.isa(o, "DeleteAssessmentTargetRequest");
+    return __isa(o, "DeleteAssessmentTargetRequest");
   }
 }
 
@@ -996,7 +999,7 @@ export interface DeleteAssessmentTemplateRequest {
 
 export namespace DeleteAssessmentTemplateRequest {
   export function isa(o: any): o is DeleteAssessmentTemplateRequest {
-    return _smithy.isa(o, "DeleteAssessmentTemplateRequest");
+    return __isa(o, "DeleteAssessmentTemplateRequest");
   }
 }
 
@@ -1010,7 +1013,7 @@ export interface DescribeAssessmentRunsRequest {
 
 export namespace DescribeAssessmentRunsRequest {
   export function isa(o: any): o is DescribeAssessmentRunsRequest {
-    return _smithy.isa(o, "DescribeAssessmentRunsRequest");
+    return __isa(o, "DescribeAssessmentRunsRequest");
   }
 }
 
@@ -1030,7 +1033,7 @@ export interface DescribeAssessmentRunsResponse extends $MetadataBearer {
 
 export namespace DescribeAssessmentRunsResponse {
   export function isa(o: any): o is DescribeAssessmentRunsResponse {
-    return _smithy.isa(o, "DescribeAssessmentRunsResponse");
+    return __isa(o, "DescribeAssessmentRunsResponse");
   }
 }
 
@@ -1044,7 +1047,7 @@ export interface DescribeAssessmentTargetsRequest {
 
 export namespace DescribeAssessmentTargetsRequest {
   export function isa(o: any): o is DescribeAssessmentTargetsRequest {
-    return _smithy.isa(o, "DescribeAssessmentTargetsRequest");
+    return __isa(o, "DescribeAssessmentTargetsRequest");
   }
 }
 
@@ -1064,7 +1067,7 @@ export interface DescribeAssessmentTargetsResponse extends $MetadataBearer {
 
 export namespace DescribeAssessmentTargetsResponse {
   export function isa(o: any): o is DescribeAssessmentTargetsResponse {
-    return _smithy.isa(o, "DescribeAssessmentTargetsResponse");
+    return __isa(o, "DescribeAssessmentTargetsResponse");
   }
 }
 
@@ -1075,7 +1078,7 @@ export interface DescribeAssessmentTemplatesRequest {
 
 export namespace DescribeAssessmentTemplatesRequest {
   export function isa(o: any): o is DescribeAssessmentTemplatesRequest {
-    return _smithy.isa(o, "DescribeAssessmentTemplatesRequest");
+    return __isa(o, "DescribeAssessmentTemplatesRequest");
   }
 }
 
@@ -1095,7 +1098,7 @@ export interface DescribeAssessmentTemplatesResponse extends $MetadataBearer {
 
 export namespace DescribeAssessmentTemplatesResponse {
   export function isa(o: any): o is DescribeAssessmentTemplatesResponse {
-    return _smithy.isa(o, "DescribeAssessmentTemplatesResponse");
+    return __isa(o, "DescribeAssessmentTemplatesResponse");
   }
 }
 
@@ -1122,7 +1125,7 @@ export interface DescribeCrossAccountAccessRoleResponse
 
 export namespace DescribeCrossAccountAccessRoleResponse {
   export function isa(o: any): o is DescribeCrossAccountAccessRoleResponse {
-    return _smithy.isa(o, "DescribeCrossAccountAccessRoleResponse");
+    return __isa(o, "DescribeCrossAccountAccessRoleResponse");
   }
 }
 
@@ -1142,7 +1145,7 @@ export interface DescribeExclusionsRequest {
 
 export namespace DescribeExclusionsRequest {
   export function isa(o: any): o is DescribeExclusionsRequest {
-    return _smithy.isa(o, "DescribeExclusionsRequest");
+    return __isa(o, "DescribeExclusionsRequest");
   }
 }
 
@@ -1162,7 +1165,7 @@ export interface DescribeExclusionsResponse extends $MetadataBearer {
 
 export namespace DescribeExclusionsResponse {
   export function isa(o: any): o is DescribeExclusionsResponse {
-    return _smithy.isa(o, "DescribeExclusionsResponse");
+    return __isa(o, "DescribeExclusionsResponse");
   }
 }
 
@@ -1182,7 +1185,7 @@ export interface DescribeFindingsRequest {
 
 export namespace DescribeFindingsRequest {
   export function isa(o: any): o is DescribeFindingsRequest {
-    return _smithy.isa(o, "DescribeFindingsRequest");
+    return __isa(o, "DescribeFindingsRequest");
   }
 }
 
@@ -1202,7 +1205,7 @@ export interface DescribeFindingsResponse extends $MetadataBearer {
 
 export namespace DescribeFindingsResponse {
   export function isa(o: any): o is DescribeFindingsResponse {
-    return _smithy.isa(o, "DescribeFindingsResponse");
+    return __isa(o, "DescribeFindingsResponse");
   }
 }
 
@@ -1216,7 +1219,7 @@ export interface DescribeResourceGroupsRequest {
 
 export namespace DescribeResourceGroupsRequest {
   export function isa(o: any): o is DescribeResourceGroupsRequest {
-    return _smithy.isa(o, "DescribeResourceGroupsRequest");
+    return __isa(o, "DescribeResourceGroupsRequest");
   }
 }
 
@@ -1236,7 +1239,7 @@ export interface DescribeResourceGroupsResponse extends $MetadataBearer {
 
 export namespace DescribeResourceGroupsResponse {
   export function isa(o: any): o is DescribeResourceGroupsResponse {
-    return _smithy.isa(o, "DescribeResourceGroupsResponse");
+    return __isa(o, "DescribeResourceGroupsResponse");
   }
 }
 
@@ -1255,7 +1258,7 @@ export interface DescribeRulesPackagesRequest {
 
 export namespace DescribeRulesPackagesRequest {
   export function isa(o: any): o is DescribeRulesPackagesRequest {
-    return _smithy.isa(o, "DescribeRulesPackagesRequest");
+    return __isa(o, "DescribeRulesPackagesRequest");
   }
 }
 
@@ -1275,7 +1278,7 @@ export interface DescribeRulesPackagesResponse extends $MetadataBearer {
 
 export namespace DescribeRulesPackagesResponse {
   export function isa(o: any): o is DescribeRulesPackagesResponse {
-    return _smithy.isa(o, "DescribeRulesPackagesResponse");
+    return __isa(o, "DescribeRulesPackagesResponse");
   }
 }
 
@@ -1299,7 +1302,7 @@ export interface DurationRange {
 
 export namespace DurationRange {
   export function isa(o: any): o is DurationRange {
-    return _smithy.isa(o, "DurationRange");
+    return __isa(o, "DurationRange");
   }
 }
 
@@ -1322,7 +1325,7 @@ export interface EventSubscription {
 
 export namespace EventSubscription {
   export function isa(o: any): o is EventSubscription {
-    return _smithy.isa(o, "EventSubscription");
+    return __isa(o, "EventSubscription");
   }
 }
 
@@ -1364,7 +1367,7 @@ export interface Exclusion {
 
 export namespace Exclusion {
   export function isa(o: any): o is Exclusion {
-    return _smithy.isa(o, "Exclusion");
+    return __isa(o, "Exclusion");
   }
 }
 
@@ -1402,7 +1405,7 @@ export interface ExclusionPreview {
 
 export namespace ExclusionPreview {
   export function isa(o: any): o is ExclusionPreview {
-    return _smithy.isa(o, "ExclusionPreview");
+    return __isa(o, "ExclusionPreview");
   }
 }
 
@@ -1425,7 +1428,7 @@ export interface FailedItemDetails {
 
 export namespace FailedItemDetails {
   export function isa(o: any): o is FailedItemDetails {
-    return _smithy.isa(o, "FailedItemDetails");
+    return __isa(o, "FailedItemDetails");
   }
 }
 
@@ -1538,7 +1541,7 @@ export interface Finding {
 
 export namespace Finding {
   export function isa(o: any): o is Finding {
-    return _smithy.isa(o, "Finding");
+    return __isa(o, "Finding");
   }
 }
 
@@ -1601,7 +1604,7 @@ export interface FindingFilter {
 
 export namespace FindingFilter {
   export function isa(o: any): o is FindingFilter {
-    return _smithy.isa(o, "FindingFilter");
+    return __isa(o, "FindingFilter");
   }
 }
 
@@ -1629,7 +1632,7 @@ export interface GetAssessmentReportRequest {
 
 export namespace GetAssessmentReportRequest {
   export function isa(o: any): o is GetAssessmentReportRequest {
-    return _smithy.isa(o, "GetAssessmentReportRequest");
+    return __isa(o, "GetAssessmentReportRequest");
   }
 }
 
@@ -1649,7 +1652,7 @@ export interface GetAssessmentReportResponse extends $MetadataBearer {
 
 export namespace GetAssessmentReportResponse {
   export function isa(o: any): o is GetAssessmentReportResponse {
-    return _smithy.isa(o, "GetAssessmentReportResponse");
+    return __isa(o, "GetAssessmentReportResponse");
   }
 }
 
@@ -1689,7 +1692,7 @@ export interface GetExclusionsPreviewRequest {
 
 export namespace GetExclusionsPreviewRequest {
   export function isa(o: any): o is GetExclusionsPreviewRequest {
-    return _smithy.isa(o, "GetExclusionsPreviewRequest");
+    return __isa(o, "GetExclusionsPreviewRequest");
   }
 }
 
@@ -1716,7 +1719,7 @@ export interface GetExclusionsPreviewResponse extends $MetadataBearer {
 
 export namespace GetExclusionsPreviewResponse {
   export function isa(o: any): o is GetExclusionsPreviewResponse {
-    return _smithy.isa(o, "GetExclusionsPreviewResponse");
+    return __isa(o, "GetExclusionsPreviewResponse");
   }
 }
 
@@ -1731,7 +1734,7 @@ export interface GetTelemetryMetadataRequest {
 
 export namespace GetTelemetryMetadataRequest {
   export function isa(o: any): o is GetTelemetryMetadataRequest {
-    return _smithy.isa(o, "GetTelemetryMetadataRequest");
+    return __isa(o, "GetTelemetryMetadataRequest");
   }
 }
 
@@ -1745,7 +1748,7 @@ export interface GetTelemetryMetadataResponse extends $MetadataBearer {
 
 export namespace GetTelemetryMetadataResponse {
   export function isa(o: any): o is GetTelemetryMetadataResponse {
-    return _smithy.isa(o, "GetTelemetryMetadataResponse");
+    return __isa(o, "GetTelemetryMetadataResponse");
   }
 }
 
@@ -1780,16 +1783,14 @@ export interface InspectorServiceAttributes {
 
 export namespace InspectorServiceAttributes {
   export function isa(o: any): o is InspectorServiceAttributes {
-    return _smithy.isa(o, "InspectorServiceAttributes");
+    return __isa(o, "InspectorServiceAttributes");
   }
 }
 
 /**
  * <p>Internal server error.</p>
  */
-export interface InternalException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface InternalException extends __SmithyException, $MetadataBearer {
   name: "InternalException";
   $fault: "server";
   /**
@@ -1805,7 +1806,7 @@ export interface InternalException
 
 export namespace InternalException {
   export function isa(o: any): o is InternalException {
-    return _smithy.isa(o, "InternalException");
+    return __isa(o, "InternalException");
   }
 }
 
@@ -1819,7 +1820,7 @@ export enum InvalidCrossAccountRoleErrorCode {
  *          instances during the assessment run.</p>
  */
 export interface InvalidCrossAccountRoleException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidCrossAccountRoleException";
   $fault: "client";
@@ -1841,7 +1842,7 @@ export interface InvalidCrossAccountRoleException
 
 export namespace InvalidCrossAccountRoleException {
   export function isa(o: any): o is InvalidCrossAccountRoleException {
-    return _smithy.isa(o, "InvalidCrossAccountRoleException");
+    return __isa(o, "InvalidCrossAccountRoleException");
   }
 }
 
@@ -1907,7 +1908,7 @@ export enum InvalidInputErrorCode {
  *          input parameter.</p>
  */
 export interface InvalidInputException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidInputException";
   $fault: "client";
@@ -1929,7 +1930,7 @@ export interface InvalidInputException
 
 export namespace InvalidInputException {
   export function isa(o: any): o is InvalidInputException {
-    return _smithy.isa(o, "InvalidInputException");
+    return __isa(o, "InvalidInputException");
   }
 }
 
@@ -1946,7 +1947,7 @@ export enum LimitExceededErrorCode {
  *          AWS account limits. The error code describes the limit exceeded.</p>
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -1968,7 +1969,7 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
@@ -2006,7 +2007,7 @@ export interface ListAssessmentRunAgentsRequest {
 
 export namespace ListAssessmentRunAgentsRequest {
   export function isa(o: any): o is ListAssessmentRunAgentsRequest {
-    return _smithy.isa(o, "ListAssessmentRunAgentsRequest");
+    return __isa(o, "ListAssessmentRunAgentsRequest");
   }
 }
 
@@ -2027,7 +2028,7 @@ export interface ListAssessmentRunAgentsResponse extends $MetadataBearer {
 
 export namespace ListAssessmentRunAgentsResponse {
   export function isa(o: any): o is ListAssessmentRunAgentsResponse {
-    return _smithy.isa(o, "ListAssessmentRunAgentsResponse");
+    return __isa(o, "ListAssessmentRunAgentsResponse");
   }
 }
 
@@ -2066,7 +2067,7 @@ export interface ListAssessmentRunsRequest {
 
 export namespace ListAssessmentRunsRequest {
   export function isa(o: any): o is ListAssessmentRunsRequest {
-    return _smithy.isa(o, "ListAssessmentRunsRequest");
+    return __isa(o, "ListAssessmentRunsRequest");
   }
 }
 
@@ -2088,7 +2089,7 @@ export interface ListAssessmentRunsResponse extends $MetadataBearer {
 
 export namespace ListAssessmentRunsResponse {
   export function isa(o: any): o is ListAssessmentRunsResponse {
-    return _smithy.isa(o, "ListAssessmentRunsResponse");
+    return __isa(o, "ListAssessmentRunsResponse");
   }
 }
 
@@ -2121,7 +2122,7 @@ export interface ListAssessmentTargetsRequest {
 
 export namespace ListAssessmentTargetsRequest {
   export function isa(o: any): o is ListAssessmentTargetsRequest {
-    return _smithy.isa(o, "ListAssessmentTargetsRequest");
+    return __isa(o, "ListAssessmentTargetsRequest");
   }
 }
 
@@ -2143,7 +2144,7 @@ export interface ListAssessmentTargetsResponse extends $MetadataBearer {
 
 export namespace ListAssessmentTargetsResponse {
   export function isa(o: any): o is ListAssessmentTargetsResponse {
-    return _smithy.isa(o, "ListAssessmentTargetsResponse");
+    return __isa(o, "ListAssessmentTargetsResponse");
   }
 }
 
@@ -2182,7 +2183,7 @@ export interface ListAssessmentTemplatesRequest {
 
 export namespace ListAssessmentTemplatesRequest {
   export function isa(o: any): o is ListAssessmentTemplatesRequest {
-    return _smithy.isa(o, "ListAssessmentTemplatesRequest");
+    return __isa(o, "ListAssessmentTemplatesRequest");
   }
 }
 
@@ -2204,7 +2205,7 @@ export interface ListAssessmentTemplatesResponse extends $MetadataBearer {
 
 export namespace ListAssessmentTemplatesResponse {
   export function isa(o: any): o is ListAssessmentTemplatesResponse {
-    return _smithy.isa(o, "ListAssessmentTemplatesResponse");
+    return __isa(o, "ListAssessmentTemplatesResponse");
   }
 }
 
@@ -2234,7 +2235,7 @@ export interface ListEventSubscriptionsRequest {
 
 export namespace ListEventSubscriptionsRequest {
   export function isa(o: any): o is ListEventSubscriptionsRequest {
-    return _smithy.isa(o, "ListEventSubscriptionsRequest");
+    return __isa(o, "ListEventSubscriptionsRequest");
   }
 }
 
@@ -2255,7 +2256,7 @@ export interface ListEventSubscriptionsResponse extends $MetadataBearer {
 
 export namespace ListEventSubscriptionsResponse {
   export function isa(o: any): o is ListEventSubscriptionsResponse {
-    return _smithy.isa(o, "ListEventSubscriptionsResponse");
+    return __isa(o, "ListEventSubscriptionsResponse");
   }
 }
 
@@ -2284,7 +2285,7 @@ export interface ListExclusionsRequest {
 
 export namespace ListExclusionsRequest {
   export function isa(o: any): o is ListExclusionsRequest {
-    return _smithy.isa(o, "ListExclusionsRequest");
+    return __isa(o, "ListExclusionsRequest");
   }
 }
 
@@ -2306,7 +2307,7 @@ export interface ListExclusionsResponse extends $MetadataBearer {
 
 export namespace ListExclusionsResponse {
   export function isa(o: any): o is ListExclusionsResponse {
-    return _smithy.isa(o, "ListExclusionsResponse");
+    return __isa(o, "ListExclusionsResponse");
   }
 }
 
@@ -2345,7 +2346,7 @@ export interface ListFindingsRequest {
 
 export namespace ListFindingsRequest {
   export function isa(o: any): o is ListFindingsRequest {
-    return _smithy.isa(o, "ListFindingsRequest");
+    return __isa(o, "ListFindingsRequest");
   }
 }
 
@@ -2366,7 +2367,7 @@ export interface ListFindingsResponse extends $MetadataBearer {
 
 export namespace ListFindingsResponse {
   export function isa(o: any): o is ListFindingsResponse {
-    return _smithy.isa(o, "ListFindingsResponse");
+    return __isa(o, "ListFindingsResponse");
   }
 }
 
@@ -2390,7 +2391,7 @@ export interface ListRulesPackagesRequest {
 
 export namespace ListRulesPackagesRequest {
   export function isa(o: any): o is ListRulesPackagesRequest {
-    return _smithy.isa(o, "ListRulesPackagesRequest");
+    return __isa(o, "ListRulesPackagesRequest");
   }
 }
 
@@ -2411,7 +2412,7 @@ export interface ListRulesPackagesResponse extends $MetadataBearer {
 
 export namespace ListRulesPackagesResponse {
   export function isa(o: any): o is ListRulesPackagesResponse {
-    return _smithy.isa(o, "ListRulesPackagesResponse");
+    return __isa(o, "ListRulesPackagesResponse");
   }
 }
 
@@ -2425,7 +2426,7 @@ export interface ListTagsForResourceRequest {
 
 export namespace ListTagsForResourceRequest {
   export function isa(o: any): o is ListTagsForResourceRequest {
-    return _smithy.isa(o, "ListTagsForResourceRequest");
+    return __isa(o, "ListTagsForResourceRequest");
   }
 }
 
@@ -2439,7 +2440,7 @@ export interface ListTagsForResourceResponse extends $MetadataBearer {
 
 export namespace ListTagsForResourceResponse {
   export function isa(o: any): o is ListTagsForResourceResponse {
-    return _smithy.isa(o, "ListTagsForResourceResponse");
+    return __isa(o, "ListTagsForResourceResponse");
   }
 }
 
@@ -2509,7 +2510,7 @@ export interface NetworkInterface {
 
 export namespace NetworkInterface {
   export function isa(o: any): o is NetworkInterface {
-    return _smithy.isa(o, "NetworkInterface");
+    return __isa(o, "NetworkInterface");
   }
 }
 
@@ -2529,7 +2530,7 @@ export enum NoSuchEntityErrorCode {
  *          error code describes the entity.</p>
  */
 export interface NoSuchEntityException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "NoSuchEntityException";
   $fault: "client";
@@ -2551,7 +2552,7 @@ export interface NoSuchEntityException
 
 export namespace NoSuchEntityException {
   export function isa(o: any): o is NoSuchEntityException {
-    return _smithy.isa(o, "NoSuchEntityException");
+    return __isa(o, "NoSuchEntityException");
   }
 }
 
@@ -2580,7 +2581,7 @@ export interface PreviewAgentsRequest {
 
 export namespace PreviewAgentsRequest {
   export function isa(o: any): o is PreviewAgentsRequest {
-    return _smithy.isa(o, "PreviewAgentsRequest");
+    return __isa(o, "PreviewAgentsRequest");
   }
 }
 
@@ -2601,7 +2602,7 @@ export interface PreviewAgentsResponse extends $MetadataBearer {
 
 export namespace PreviewAgentsResponse {
   export function isa(o: any): o is PreviewAgentsResponse {
-    return _smithy.isa(o, "PreviewAgentsResponse");
+    return __isa(o, "PreviewAgentsResponse");
   }
 }
 
@@ -2610,7 +2611,7 @@ export namespace PreviewAgentsResponse {
  *          exclusions preview.</p>
  */
 export interface PreviewGenerationInProgressException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "PreviewGenerationInProgressException";
   $fault: "client";
@@ -2619,7 +2620,7 @@ export interface PreviewGenerationInProgressException
 
 export namespace PreviewGenerationInProgressException {
   export function isa(o: any): o is PreviewGenerationInProgressException {
-    return _smithy.isa(o, "PreviewGenerationInProgressException");
+    return __isa(o, "PreviewGenerationInProgressException");
   }
 }
 
@@ -2648,7 +2649,7 @@ export interface PrivateIp {
 
 export namespace PrivateIp {
   export function isa(o: any): o is PrivateIp {
-    return _smithy.isa(o, "PrivateIp");
+    return __isa(o, "PrivateIp");
   }
 }
 
@@ -2663,7 +2664,7 @@ export interface RegisterCrossAccountAccessRoleRequest {
 
 export namespace RegisterCrossAccountAccessRoleRequest {
   export function isa(o: any): o is RegisterCrossAccountAccessRoleRequest {
-    return _smithy.isa(o, "RegisterCrossAccountAccessRoleRequest");
+    return __isa(o, "RegisterCrossAccountAccessRoleRequest");
   }
 }
 
@@ -2683,7 +2684,7 @@ export interface RemoveAttributesFromFindingsRequest {
 
 export namespace RemoveAttributesFromFindingsRequest {
   export function isa(o: any): o is RemoveAttributesFromFindingsRequest {
-    return _smithy.isa(o, "RemoveAttributesFromFindingsRequest");
+    return __isa(o, "RemoveAttributesFromFindingsRequest");
   }
 }
 
@@ -2698,7 +2699,7 @@ export interface RemoveAttributesFromFindingsResponse extends $MetadataBearer {
 
 export namespace RemoveAttributesFromFindingsResponse {
   export function isa(o: any): o is RemoveAttributesFromFindingsResponse {
-    return _smithy.isa(o, "RemoveAttributesFromFindingsResponse");
+    return __isa(o, "RemoveAttributesFromFindingsResponse");
   }
 }
 
@@ -2745,7 +2746,7 @@ export interface ResourceGroup {
 
 export namespace ResourceGroup {
   export function isa(o: any): o is ResourceGroup {
-    return _smithy.isa(o, "ResourceGroup");
+    return __isa(o, "ResourceGroup");
   }
 }
 
@@ -2768,7 +2769,7 @@ export interface ResourceGroupTag {
 
 export namespace ResourceGroupTag {
   export function isa(o: any): o is ResourceGroupTag {
-    return _smithy.isa(o, "ResourceGroupTag");
+    return __isa(o, "ResourceGroupTag");
   }
 }
 
@@ -2806,7 +2807,7 @@ export interface RulesPackage {
 
 export namespace RulesPackage {
   export function isa(o: any): o is RulesPackage {
-    return _smithy.isa(o, "RulesPackage");
+    return __isa(o, "RulesPackage");
   }
 }
 
@@ -2829,7 +2830,7 @@ export interface Scope {
 
 export namespace Scope {
   export function isa(o: any): o is Scope {
-    return _smithy.isa(o, "Scope");
+    return __isa(o, "Scope");
   }
 }
 
@@ -2858,7 +2859,7 @@ export interface SecurityGroup {
 
 export namespace SecurityGroup {
   export function isa(o: any): o is SecurityGroup {
-    return _smithy.isa(o, "SecurityGroup");
+    return __isa(o, "SecurityGroup");
   }
 }
 
@@ -2866,7 +2867,7 @@ export namespace SecurityGroup {
  * <p>The serice is temporary unavailable.</p>
  */
 export interface ServiceTemporarilyUnavailableException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ServiceTemporarilyUnavailableException";
   $fault: "server";
@@ -2883,7 +2884,7 @@ export interface ServiceTemporarilyUnavailableException
 
 export namespace ServiceTemporarilyUnavailableException {
   export function isa(o: any): o is ServiceTemporarilyUnavailableException {
-    return _smithy.isa(o, "ServiceTemporarilyUnavailableException");
+    return __isa(o, "ServiceTemporarilyUnavailableException");
   }
 }
 
@@ -2903,7 +2904,7 @@ export interface SetTagsForResourceRequest {
 
 export namespace SetTagsForResourceRequest {
   export function isa(o: any): o is SetTagsForResourceRequest {
-    return _smithy.isa(o, "SetTagsForResourceRequest");
+    return __isa(o, "SetTagsForResourceRequest");
   }
 }
 
@@ -2932,7 +2933,7 @@ export interface StartAssessmentRunRequest {
 
 export namespace StartAssessmentRunRequest {
   export function isa(o: any): o is StartAssessmentRunRequest {
-    return _smithy.isa(o, "StartAssessmentRunRequest");
+    return __isa(o, "StartAssessmentRunRequest");
   }
 }
 
@@ -2946,7 +2947,7 @@ export interface StartAssessmentRunResponse extends $MetadataBearer {
 
 export namespace StartAssessmentRunResponse {
   export function isa(o: any): o is StartAssessmentRunResponse {
-    return _smithy.isa(o, "StartAssessmentRunResponse");
+    return __isa(o, "StartAssessmentRunResponse");
   }
 }
 
@@ -2973,7 +2974,7 @@ export interface StopAssessmentRunRequest {
 
 export namespace StopAssessmentRunRequest {
   export function isa(o: any): o is StopAssessmentRunRequest {
-    return _smithy.isa(o, "StopAssessmentRunRequest");
+    return __isa(o, "StopAssessmentRunRequest");
   }
 }
 
@@ -2998,7 +2999,7 @@ export interface SubscribeToEventRequest {
 
 export namespace SubscribeToEventRequest {
   export function isa(o: any): o is SubscribeToEventRequest {
-    return _smithy.isa(o, "SubscribeToEventRequest");
+    return __isa(o, "SubscribeToEventRequest");
   }
 }
 
@@ -3027,7 +3028,7 @@ export interface Subscription {
 
 export namespace Subscription {
   export function isa(o: any): o is Subscription {
-    return _smithy.isa(o, "Subscription");
+    return __isa(o, "Subscription");
   }
 }
 
@@ -3049,7 +3050,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -3078,7 +3079,7 @@ export interface TelemetryMetadata {
 
 export namespace TelemetryMetadata {
   export function isa(o: any): o is TelemetryMetadata {
-    return _smithy.isa(o, "TelemetryMetadata");
+    return __isa(o, "TelemetryMetadata");
   }
 }
 
@@ -3101,7 +3102,7 @@ export interface TimestampRange {
 
 export namespace TimestampRange {
   export function isa(o: any): o is TimestampRange {
-    return _smithy.isa(o, "TimestampRange");
+    return __isa(o, "TimestampRange");
   }
 }
 
@@ -3126,7 +3127,7 @@ export interface UnsubscribeFromEventRequest {
 
 export namespace UnsubscribeFromEventRequest {
   export function isa(o: any): o is UnsubscribeFromEventRequest {
-    return _smithy.isa(o, "UnsubscribeFromEventRequest");
+    return __isa(o, "UnsubscribeFromEventRequest");
   }
 }
 
@@ -3138,7 +3139,7 @@ export namespace UnsubscribeFromEventRequest {
  *          available.</p>
  */
 export interface UnsupportedFeatureException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UnsupportedFeatureException";
   $fault: "client";
@@ -3148,7 +3149,7 @@ export interface UnsupportedFeatureException
 
 export namespace UnsupportedFeatureException {
   export function isa(o: any): o is UnsupportedFeatureException {
-    return _smithy.isa(o, "UnsupportedFeatureException");
+    return __isa(o, "UnsupportedFeatureException");
   }
 }
 
@@ -3173,6 +3174,6 @@ export interface UpdateAssessmentTargetRequest {
 
 export namespace UpdateAssessmentTargetRequest {
   export function isa(o: any): o is UpdateAssessmentTargetRequest {
-    return _smithy.isa(o, "UpdateAssessmentTargetRequest");
+    return __isa(o, "UpdateAssessmentTargetRequest");
   }
 }

--- a/clients/client-inspector/protocols/Aws_json1_1.ts
+++ b/clients/client-inspector/protocols/Aws_json1_1.ts
@@ -1272,6 +1272,7 @@ export async function deserializeAws_json1_1DeleteAssessmentRunCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteAssessmentRunCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1361,6 +1362,7 @@ export async function deserializeAws_json1_1DeleteAssessmentTargetCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteAssessmentTargetCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1450,6 +1452,7 @@ export async function deserializeAws_json1_1DeleteAssessmentTemplateCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteAssessmentTemplateCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -3123,6 +3126,7 @@ export async function deserializeAws_json1_1RegisterCrossAccountAccessRoleComman
       context
     );
   }
+  await collectBody(output.body, context);
   const response: RegisterCrossAccountAccessRoleCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -3295,6 +3299,7 @@ export async function deserializeAws_json1_1SetTagsForResourceCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: SetTagsForResourceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -3482,6 +3487,7 @@ export async function deserializeAws_json1_1StopAssessmentRunCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1StopAssessmentRunCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: StopAssessmentRunCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -3561,6 +3567,7 @@ export async function deserializeAws_json1_1SubscribeToEventCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1SubscribeToEventCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: SubscribeToEventCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -3650,6 +3657,7 @@ export async function deserializeAws_json1_1UnsubscribeFromEventCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: UnsubscribeFromEventCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -3732,6 +3740,7 @@ export async function deserializeAws_json1_1UpdateAssessmentTargetCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: UpdateAssessmentTargetCommandOutput = {
     $metadata: deserializeMetadata(output)
   };

--- a/clients/client-iot-1click-devices-service/models/index.ts
+++ b/clients/client-iot-1click-devices-service/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export interface Attributes {
@@ -7,7 +10,7 @@ export interface Attributes {
 
 export namespace Attributes {
   export function isa(o: any): o is Attributes {
-    return _smithy.isa(o, "Attributes");
+    return __isa(o, "Attributes");
   }
 }
 
@@ -21,7 +24,7 @@ export interface ClaimDevicesByClaimCodeRequest {
 
 export namespace ClaimDevicesByClaimCodeRequest {
   export function isa(o: any): o is ClaimDevicesByClaimCodeRequest {
-    return _smithy.isa(o, "ClaimDevicesByClaimCodeRequest");
+    return __isa(o, "ClaimDevicesByClaimCodeRequest");
   }
 }
 
@@ -41,7 +44,7 @@ export interface ClaimDevicesByClaimCodeResponse extends $MetadataBearer {
 
 export namespace ClaimDevicesByClaimCodeResponse {
   export function isa(o: any): o is ClaimDevicesByClaimCodeResponse {
-    return _smithy.isa(o, "ClaimDevicesByClaimCodeResponse");
+    return __isa(o, "ClaimDevicesByClaimCodeResponse");
   }
 }
 
@@ -55,7 +58,7 @@ export interface DescribeDeviceRequest {
 
 export namespace DescribeDeviceRequest {
   export function isa(o: any): o is DescribeDeviceRequest {
-    return _smithy.isa(o, "DescribeDeviceRequest");
+    return __isa(o, "DescribeDeviceRequest");
   }
 }
 
@@ -69,7 +72,7 @@ export interface DescribeDeviceResponse extends $MetadataBearer {
 
 export namespace DescribeDeviceResponse {
   export function isa(o: any): o is DescribeDeviceResponse {
-    return _smithy.isa(o, "DescribeDeviceResponse");
+    return __isa(o, "DescribeDeviceResponse");
   }
 }
 
@@ -93,7 +96,7 @@ export interface Device {
 
 export namespace Device {
   export function isa(o: any): o is Device {
-    return _smithy.isa(o, "Device");
+    return __isa(o, "Device");
   }
 }
 
@@ -139,7 +142,7 @@ export interface DeviceDescription {
 
 export namespace DeviceDescription {
   export function isa(o: any): o is DeviceDescription {
-    return _smithy.isa(o, "DeviceDescription");
+    return __isa(o, "DeviceDescription");
   }
 }
 
@@ -158,7 +161,7 @@ export interface DeviceEvent {
 
 export namespace DeviceEvent {
   export function isa(o: any): o is DeviceEvent {
-    return _smithy.isa(o, "DeviceEvent");
+    return __isa(o, "DeviceEvent");
   }
 }
 
@@ -177,7 +180,7 @@ export interface DeviceMethod {
 
 export namespace DeviceMethod {
   export function isa(o: any): o is DeviceMethod {
-    return _smithy.isa(o, "DeviceMethod");
+    return __isa(o, "DeviceMethod");
   }
 }
 
@@ -200,7 +203,7 @@ export interface FinalizeDeviceClaimRequest {
 
 export namespace FinalizeDeviceClaimRequest {
   export function isa(o: any): o is FinalizeDeviceClaimRequest {
-    return _smithy.isa(o, "FinalizeDeviceClaimRequest");
+    return __isa(o, "FinalizeDeviceClaimRequest");
   }
 }
 
@@ -214,13 +217,11 @@ export interface FinalizeDeviceClaimResponse extends $MetadataBearer {
 
 export namespace FinalizeDeviceClaimResponse {
   export function isa(o: any): o is FinalizeDeviceClaimResponse {
-    return _smithy.isa(o, "FinalizeDeviceClaimResponse");
+    return __isa(o, "FinalizeDeviceClaimResponse");
   }
 }
 
-export interface ForbiddenException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface ForbiddenException extends __SmithyException, $MetadataBearer {
   name: "ForbiddenException";
   $fault: "client";
   /**
@@ -236,7 +237,7 @@ export interface ForbiddenException
 
 export namespace ForbiddenException {
   export function isa(o: any): o is ForbiddenException {
-    return _smithy.isa(o, "ForbiddenException");
+    return __isa(o, "ForbiddenException");
   }
 }
 
@@ -250,7 +251,7 @@ export interface GetDeviceMethodsRequest {
 
 export namespace GetDeviceMethodsRequest {
   export function isa(o: any): o is GetDeviceMethodsRequest {
-    return _smithy.isa(o, "GetDeviceMethodsRequest");
+    return __isa(o, "GetDeviceMethodsRequest");
   }
 }
 
@@ -264,7 +265,7 @@ export interface GetDeviceMethodsResponse extends $MetadataBearer {
 
 export namespace GetDeviceMethodsResponse {
   export function isa(o: any): o is GetDeviceMethodsResponse {
-    return _smithy.isa(o, "GetDeviceMethodsResponse");
+    return __isa(o, "GetDeviceMethodsResponse");
   }
 }
 
@@ -278,7 +279,7 @@ export interface InitiateDeviceClaimRequest {
 
 export namespace InitiateDeviceClaimRequest {
   export function isa(o: any): o is InitiateDeviceClaimRequest {
-    return _smithy.isa(o, "InitiateDeviceClaimRequest");
+    return __isa(o, "InitiateDeviceClaimRequest");
   }
 }
 
@@ -292,12 +293,12 @@ export interface InitiateDeviceClaimResponse extends $MetadataBearer {
 
 export namespace InitiateDeviceClaimResponse {
   export function isa(o: any): o is InitiateDeviceClaimResponse {
-    return _smithy.isa(o, "InitiateDeviceClaimResponse");
+    return __isa(o, "InitiateDeviceClaimResponse");
   }
 }
 
 export interface InternalFailureException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalFailureException";
   $fault: "server";
@@ -314,12 +315,12 @@ export interface InternalFailureException
 
 export namespace InternalFailureException {
   export function isa(o: any): o is InternalFailureException {
-    return _smithy.isa(o, "InternalFailureException");
+    return __isa(o, "InternalFailureException");
   }
 }
 
 export interface InvalidRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidRequestException";
   $fault: "client";
@@ -336,7 +337,7 @@ export interface InvalidRequestException
 
 export namespace InvalidRequestException {
   export function isa(o: any): o is InvalidRequestException {
-    return _smithy.isa(o, "InvalidRequestException");
+    return __isa(o, "InvalidRequestException");
   }
 }
 
@@ -360,7 +361,7 @@ export interface InvokeDeviceMethodRequest {
 
 export namespace InvokeDeviceMethodRequest {
   export function isa(o: any): o is InvokeDeviceMethodRequest {
-    return _smithy.isa(o, "InvokeDeviceMethodRequest");
+    return __isa(o, "InvokeDeviceMethodRequest");
   }
 }
 
@@ -374,7 +375,7 @@ export interface InvokeDeviceMethodResponse extends $MetadataBearer {
 
 export namespace InvokeDeviceMethodResponse {
   export function isa(o: any): o is InvokeDeviceMethodResponse {
-    return _smithy.isa(o, "InvokeDeviceMethodResponse");
+    return __isa(o, "InvokeDeviceMethodResponse");
   }
 }
 
@@ -413,7 +414,7 @@ export interface ListDeviceEventsRequest {
 
 export namespace ListDeviceEventsRequest {
   export function isa(o: any): o is ListDeviceEventsRequest {
-    return _smithy.isa(o, "ListDeviceEventsRequest");
+    return __isa(o, "ListDeviceEventsRequest");
   }
 }
 
@@ -433,7 +434,7 @@ export interface ListDeviceEventsResponse extends $MetadataBearer {
 
 export namespace ListDeviceEventsResponse {
   export function isa(o: any): o is ListDeviceEventsResponse {
-    return _smithy.isa(o, "ListDeviceEventsResponse");
+    return __isa(o, "ListDeviceEventsResponse");
   }
 }
 
@@ -458,7 +459,7 @@ export interface ListDevicesRequest {
 
 export namespace ListDevicesRequest {
   export function isa(o: any): o is ListDevicesRequest {
-    return _smithy.isa(o, "ListDevicesRequest");
+    return __isa(o, "ListDevicesRequest");
   }
 }
 
@@ -477,7 +478,7 @@ export interface ListDevicesResponse extends $MetadataBearer {
 
 export namespace ListDevicesResponse {
   export function isa(o: any): o is ListDevicesResponse {
-    return _smithy.isa(o, "ListDevicesResponse");
+    return __isa(o, "ListDevicesResponse");
   }
 }
 
@@ -491,7 +492,7 @@ export interface ListTagsForResourceRequest {
 
 export namespace ListTagsForResourceRequest {
   export function isa(o: any): o is ListTagsForResourceRequest {
-    return _smithy.isa(o, "ListTagsForResourceRequest");
+    return __isa(o, "ListTagsForResourceRequest");
   }
 }
 
@@ -509,12 +510,12 @@ export interface ListTagsForResourceResponse extends $MetadataBearer {
 
 export namespace ListTagsForResourceResponse {
   export function isa(o: any): o is ListTagsForResourceResponse {
-    return _smithy.isa(o, "ListTagsForResourceResponse");
+    return __isa(o, "ListTagsForResourceResponse");
   }
 }
 
 export interface PreconditionFailedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "PreconditionFailedException";
   $fault: "client";
@@ -531,12 +532,12 @@ export interface PreconditionFailedException
 
 export namespace PreconditionFailedException {
   export function isa(o: any): o is PreconditionFailedException {
-    return _smithy.isa(o, "PreconditionFailedException");
+    return __isa(o, "PreconditionFailedException");
   }
 }
 
 export interface RangeNotSatisfiableException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "RangeNotSatisfiableException";
   $fault: "client";
@@ -554,12 +555,12 @@ export interface RangeNotSatisfiableException
 
 export namespace RangeNotSatisfiableException {
   export function isa(o: any): o is RangeNotSatisfiableException {
-    return _smithy.isa(o, "RangeNotSatisfiableException");
+    return __isa(o, "RangeNotSatisfiableException");
   }
 }
 
 export interface ResourceConflictException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceConflictException";
   $fault: "client";
@@ -576,12 +577,12 @@ export interface ResourceConflictException
 
 export namespace ResourceConflictException {
   export function isa(o: any): o is ResourceConflictException {
-    return _smithy.isa(o, "ResourceConflictException");
+    return __isa(o, "ResourceConflictException");
   }
 }
 
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -598,7 +599,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -621,7 +622,7 @@ export interface TagResourceRequest {
 
 export namespace TagResourceRequest {
   export function isa(o: any): o is TagResourceRequest {
-    return _smithy.isa(o, "TagResourceRequest");
+    return __isa(o, "TagResourceRequest");
   }
 }
 
@@ -635,7 +636,7 @@ export interface UnclaimDeviceRequest {
 
 export namespace UnclaimDeviceRequest {
   export function isa(o: any): o is UnclaimDeviceRequest {
-    return _smithy.isa(o, "UnclaimDeviceRequest");
+    return __isa(o, "UnclaimDeviceRequest");
   }
 }
 
@@ -649,7 +650,7 @@ export interface UnclaimDeviceResponse extends $MetadataBearer {
 
 export namespace UnclaimDeviceResponse {
   export function isa(o: any): o is UnclaimDeviceResponse {
-    return _smithy.isa(o, "UnclaimDeviceResponse");
+    return __isa(o, "UnclaimDeviceResponse");
   }
 }
 
@@ -668,7 +669,7 @@ export interface UntagResourceRequest {
 
 export namespace UntagResourceRequest {
   export function isa(o: any): o is UntagResourceRequest {
-    return _smithy.isa(o, "UntagResourceRequest");
+    return __isa(o, "UntagResourceRequest");
   }
 }
 
@@ -688,7 +689,7 @@ export interface UpdateDeviceStateRequest {
 
 export namespace UpdateDeviceStateRequest {
   export function isa(o: any): o is UpdateDeviceStateRequest {
-    return _smithy.isa(o, "UpdateDeviceStateRequest");
+    return __isa(o, "UpdateDeviceStateRequest");
   }
 }
 
@@ -698,6 +699,6 @@ export interface UpdateDeviceStateResponse extends $MetadataBearer {
 
 export namespace UpdateDeviceStateResponse {
   export function isa(o: any): o is UpdateDeviceStateResponse {
-    return _smithy.isa(o, "UpdateDeviceStateResponse");
+    return __isa(o, "UpdateDeviceStateResponse");
   }
 }

--- a/clients/client-iot-1click-devices-service/protocols/Aws_restJson1_1.ts
+++ b/clients/client-iot-1click-devices-service/protocols/Aws_restJson1_1.ts
@@ -68,7 +68,10 @@ import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  extendedEncodeURIComponent as __extendedEncodeURIComponent
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -84,13 +87,13 @@ export async function serializeAws_restJson1_1ClaimDevicesByClaimCodeCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/claims/{ClaimCode}";
   if (input.ClaimCode !== undefined) {
-    const labelValue: string = input.ClaimCode.toString();
+    const labelValue: string = input.ClaimCode;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ClaimCode.");
     }
     resolvedPath = resolvedPath.replace(
       "{ClaimCode}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ClaimCode.");
@@ -112,13 +115,13 @@ export async function serializeAws_restJson1_1DescribeDeviceCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/devices/{DeviceId}";
   if (input.DeviceId !== undefined) {
-    const labelValue: string = input.DeviceId.toString();
+    const labelValue: string = input.DeviceId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DeviceId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DeviceId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DeviceId.");
@@ -140,13 +143,13 @@ export async function serializeAws_restJson1_1FinalizeDeviceClaimCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/devices/{DeviceId}/finalize-claim";
   if (input.DeviceId !== undefined) {
-    const labelValue: string = input.DeviceId.toString();
+    const labelValue: string = input.DeviceId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DeviceId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DeviceId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DeviceId.");
@@ -178,13 +181,13 @@ export async function serializeAws_restJson1_1GetDeviceMethodsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/devices/{DeviceId}/methods";
   if (input.DeviceId !== undefined) {
-    const labelValue: string = input.DeviceId.toString();
+    const labelValue: string = input.DeviceId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DeviceId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DeviceId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DeviceId.");
@@ -206,13 +209,13 @@ export async function serializeAws_restJson1_1InitiateDeviceClaimCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/devices/{DeviceId}/initiate-claim";
   if (input.DeviceId !== undefined) {
-    const labelValue: string = input.DeviceId.toString();
+    const labelValue: string = input.DeviceId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DeviceId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DeviceId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DeviceId.");
@@ -234,13 +237,13 @@ export async function serializeAws_restJson1_1InvokeDeviceMethodCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/devices/{DeviceId}/methods";
   if (input.DeviceId !== undefined) {
-    const labelValue: string = input.DeviceId.toString();
+    const labelValue: string = input.DeviceId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DeviceId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DeviceId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DeviceId.");
@@ -275,29 +278,37 @@ export async function serializeAws_restJson1_1ListDeviceEventsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/devices/{DeviceId}/events";
   if (input.DeviceId !== undefined) {
-    const labelValue: string = input.DeviceId.toString();
+    const labelValue: string = input.DeviceId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DeviceId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DeviceId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DeviceId.");
   }
   const query: any = {};
   if (input.FromTimeStamp !== undefined) {
-    query["fromTimeStamp"] = input.FromTimeStamp.toISOString();
+    query[
+      __extendedEncodeURIComponent("fromTimeStamp")
+    ] = __extendedEncodeURIComponent(input.FromTimeStamp.toISOString());
   }
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   if (input.ToTimeStamp !== undefined) {
-    query["toTimeStamp"] = input.ToTimeStamp.toISOString();
+    query[
+      __extendedEncodeURIComponent("toTimeStamp")
+    ] = __extendedEncodeURIComponent(input.ToTimeStamp.toISOString());
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -318,13 +329,19 @@ export async function serializeAws_restJson1_1ListDevicesCommand(
   let resolvedPath = "/devices";
   const query: any = {};
   if (input.DeviceType !== undefined) {
-    query["deviceType"] = input.DeviceType.toString();
+    query[
+      __extendedEncodeURIComponent("deviceType")
+    ] = __extendedEncodeURIComponent(input.DeviceType);
   }
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -344,7 +361,7 @@ export async function serializeAws_restJson1_1ListTagsForResourceCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/tags/{ResourceArn}";
   if (input.ResourceArn !== undefined) {
-    const labelValue: string = input.ResourceArn.toString();
+    const labelValue: string = input.ResourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ResourceArn."
@@ -352,7 +369,7 @@ export async function serializeAws_restJson1_1ListTagsForResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ResourceArn.");
@@ -374,7 +391,7 @@ export async function serializeAws_restJson1_1TagResourceCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/tags/{ResourceArn}";
   if (input.ResourceArn !== undefined) {
-    const labelValue: string = input.ResourceArn.toString();
+    const labelValue: string = input.ResourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ResourceArn."
@@ -382,7 +399,7 @@ export async function serializeAws_restJson1_1TagResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ResourceArn.");
@@ -414,13 +431,13 @@ export async function serializeAws_restJson1_1UnclaimDeviceCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/devices/{DeviceId}/unclaim";
   if (input.DeviceId !== undefined) {
-    const labelValue: string = input.DeviceId.toString();
+    const labelValue: string = input.DeviceId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DeviceId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DeviceId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DeviceId.");
@@ -442,7 +459,7 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/tags/{ResourceArn}";
   if (input.ResourceArn !== undefined) {
-    const labelValue: string = input.ResourceArn.toString();
+    const labelValue: string = input.ResourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ResourceArn."
@@ -450,14 +467,16 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ResourceArn.");
   }
   const query: any = {};
   if (input.TagKeys !== undefined) {
-    query["tagKeys"] = input.TagKeys;
+    query[__extendedEncodeURIComponent("tagKeys")] = input.TagKeys.map(entry =>
+      __extendedEncodeURIComponent(entry)
+    );
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -477,13 +496,13 @@ export async function serializeAws_restJson1_1UpdateDeviceStateCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/devices/{DeviceId}/state";
   if (input.DeviceId !== undefined) {
-    const labelValue: string = input.DeviceId.toString();
+    const labelValue: string = input.DeviceId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DeviceId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DeviceId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DeviceId.");
@@ -1213,6 +1232,7 @@ export async function deserializeAws_restJson1_1TagResourceCommand(
   const contents: TagResourceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -1341,6 +1361,7 @@ export async function deserializeAws_restJson1_1UntagResourceCommand(
   const contents: UntagResourceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -1406,6 +1427,7 @@ export async function deserializeAws_restJson1_1UpdateDeviceStateCommand(
     $metadata: deserializeMetadata(output),
     __type: "UpdateDeviceStateResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 

--- a/clients/client-iot-1click-projects/models/index.ts
+++ b/clients/client-iot-1click-projects/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export interface AssociateDeviceWithPlacementRequest {
@@ -28,7 +31,7 @@ export interface AssociateDeviceWithPlacementRequest {
 
 export namespace AssociateDeviceWithPlacementRequest {
   export function isa(o: any): o is AssociateDeviceWithPlacementRequest {
-    return _smithy.isa(o, "AssociateDeviceWithPlacementRequest");
+    return __isa(o, "AssociateDeviceWithPlacementRequest");
   }
 }
 
@@ -38,7 +41,7 @@ export interface AssociateDeviceWithPlacementResponse extends $MetadataBearer {
 
 export namespace AssociateDeviceWithPlacementResponse {
   export function isa(o: any): o is AssociateDeviceWithPlacementResponse {
-    return _smithy.isa(o, "AssociateDeviceWithPlacementResponse");
+    return __isa(o, "AssociateDeviceWithPlacementResponse");
   }
 }
 
@@ -63,7 +66,7 @@ export interface CreatePlacementRequest {
 
 export namespace CreatePlacementRequest {
   export function isa(o: any): o is CreatePlacementRequest {
-    return _smithy.isa(o, "CreatePlacementRequest");
+    return __isa(o, "CreatePlacementRequest");
   }
 }
 
@@ -73,7 +76,7 @@ export interface CreatePlacementResponse extends $MetadataBearer {
 
 export namespace CreatePlacementResponse {
   export function isa(o: any): o is CreatePlacementResponse {
-    return _smithy.isa(o, "CreatePlacementResponse");
+    return __isa(o, "CreatePlacementResponse");
   }
 }
 
@@ -107,7 +110,7 @@ export interface CreateProjectRequest {
 
 export namespace CreateProjectRequest {
   export function isa(o: any): o is CreateProjectRequest {
-    return _smithy.isa(o, "CreateProjectRequest");
+    return __isa(o, "CreateProjectRequest");
   }
 }
 
@@ -117,7 +120,7 @@ export interface CreateProjectResponse extends $MetadataBearer {
 
 export namespace CreateProjectResponse {
   export function isa(o: any): o is CreateProjectResponse {
-    return _smithy.isa(o, "CreateProjectResponse");
+    return __isa(o, "CreateProjectResponse");
   }
 }
 
@@ -136,7 +139,7 @@ export interface DeletePlacementRequest {
 
 export namespace DeletePlacementRequest {
   export function isa(o: any): o is DeletePlacementRequest {
-    return _smithy.isa(o, "DeletePlacementRequest");
+    return __isa(o, "DeletePlacementRequest");
   }
 }
 
@@ -146,7 +149,7 @@ export interface DeletePlacementResponse extends $MetadataBearer {
 
 export namespace DeletePlacementResponse {
   export function isa(o: any): o is DeletePlacementResponse {
-    return _smithy.isa(o, "DeletePlacementResponse");
+    return __isa(o, "DeletePlacementResponse");
   }
 }
 
@@ -160,7 +163,7 @@ export interface DeleteProjectRequest {
 
 export namespace DeleteProjectRequest {
   export function isa(o: any): o is DeleteProjectRequest {
-    return _smithy.isa(o, "DeleteProjectRequest");
+    return __isa(o, "DeleteProjectRequest");
   }
 }
 
@@ -170,7 +173,7 @@ export interface DeleteProjectResponse extends $MetadataBearer {
 
 export namespace DeleteProjectResponse {
   export function isa(o: any): o is DeleteProjectResponse {
-    return _smithy.isa(o, "DeleteProjectResponse");
+    return __isa(o, "DeleteProjectResponse");
   }
 }
 
@@ -189,7 +192,7 @@ export interface DescribePlacementRequest {
 
 export namespace DescribePlacementRequest {
   export function isa(o: any): o is DescribePlacementRequest {
-    return _smithy.isa(o, "DescribePlacementRequest");
+    return __isa(o, "DescribePlacementRequest");
   }
 }
 
@@ -203,7 +206,7 @@ export interface DescribePlacementResponse extends $MetadataBearer {
 
 export namespace DescribePlacementResponse {
   export function isa(o: any): o is DescribePlacementResponse {
-    return _smithy.isa(o, "DescribePlacementResponse");
+    return __isa(o, "DescribePlacementResponse");
   }
 }
 
@@ -217,7 +220,7 @@ export interface DescribeProjectRequest {
 
 export namespace DescribeProjectRequest {
   export function isa(o: any): o is DescribeProjectRequest {
-    return _smithy.isa(o, "DescribeProjectRequest");
+    return __isa(o, "DescribeProjectRequest");
   }
 }
 
@@ -231,7 +234,7 @@ export interface DescribeProjectResponse extends $MetadataBearer {
 
 export namespace DescribeProjectResponse {
   export function isa(o: any): o is DescribeProjectResponse {
-    return _smithy.isa(o, "DescribeProjectResponse");
+    return __isa(o, "DescribeProjectResponse");
   }
 }
 
@@ -254,7 +257,7 @@ export interface DeviceTemplate {
 
 export namespace DeviceTemplate {
   export function isa(o: any): o is DeviceTemplate {
-    return _smithy.isa(o, "DeviceTemplate");
+    return __isa(o, "DeviceTemplate");
   }
 }
 
@@ -278,7 +281,7 @@ export interface DisassociateDeviceFromPlacementRequest {
 
 export namespace DisassociateDeviceFromPlacementRequest {
   export function isa(o: any): o is DisassociateDeviceFromPlacementRequest {
-    return _smithy.isa(o, "DisassociateDeviceFromPlacementRequest");
+    return __isa(o, "DisassociateDeviceFromPlacementRequest");
   }
 }
 
@@ -289,7 +292,7 @@ export interface DisassociateDeviceFromPlacementResponse
 
 export namespace DisassociateDeviceFromPlacementResponse {
   export function isa(o: any): o is DisassociateDeviceFromPlacementResponse {
-    return _smithy.isa(o, "DisassociateDeviceFromPlacementResponse");
+    return __isa(o, "DisassociateDeviceFromPlacementResponse");
   }
 }
 
@@ -308,7 +311,7 @@ export interface GetDevicesInPlacementRequest {
 
 export namespace GetDevicesInPlacementRequest {
   export function isa(o: any): o is GetDevicesInPlacementRequest {
-    return _smithy.isa(o, "GetDevicesInPlacementRequest");
+    return __isa(o, "GetDevicesInPlacementRequest");
   }
 }
 
@@ -322,7 +325,7 @@ export interface GetDevicesInPlacementResponse extends $MetadataBearer {
 
 export namespace GetDevicesInPlacementResponse {
   export function isa(o: any): o is GetDevicesInPlacementResponse {
-    return _smithy.isa(o, "GetDevicesInPlacementResponse");
+    return __isa(o, "GetDevicesInPlacementResponse");
   }
 }
 
@@ -330,7 +333,7 @@ export namespace GetDevicesInPlacementResponse {
  * <p></p>
  */
 export interface InternalFailureException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalFailureException";
   $fault: "server";
@@ -340,7 +343,7 @@ export interface InternalFailureException
 
 export namespace InternalFailureException {
   export function isa(o: any): o is InternalFailureException {
-    return _smithy.isa(o, "InternalFailureException");
+    return __isa(o, "InternalFailureException");
   }
 }
 
@@ -348,7 +351,7 @@ export namespace InternalFailureException {
  * <p></p>
  */
 export interface InvalidRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidRequestException";
   $fault: "client";
@@ -358,7 +361,7 @@ export interface InvalidRequestException
 
 export namespace InvalidRequestException {
   export function isa(o: any): o is InvalidRequestException {
-    return _smithy.isa(o, "InvalidRequestException");
+    return __isa(o, "InvalidRequestException");
   }
 }
 
@@ -383,7 +386,7 @@ export interface ListPlacementsRequest {
 
 export namespace ListPlacementsRequest {
   export function isa(o: any): o is ListPlacementsRequest {
-    return _smithy.isa(o, "ListPlacementsRequest");
+    return __isa(o, "ListPlacementsRequest");
   }
 }
 
@@ -403,7 +406,7 @@ export interface ListPlacementsResponse extends $MetadataBearer {
 
 export namespace ListPlacementsResponse {
   export function isa(o: any): o is ListPlacementsResponse {
-    return _smithy.isa(o, "ListPlacementsResponse");
+    return __isa(o, "ListPlacementsResponse");
   }
 }
 
@@ -423,7 +426,7 @@ export interface ListProjectsRequest {
 
 export namespace ListProjectsRequest {
   export function isa(o: any): o is ListProjectsRequest {
-    return _smithy.isa(o, "ListProjectsRequest");
+    return __isa(o, "ListProjectsRequest");
   }
 }
 
@@ -443,7 +446,7 @@ export interface ListProjectsResponse extends $MetadataBearer {
 
 export namespace ListProjectsResponse {
   export function isa(o: any): o is ListProjectsResponse {
-    return _smithy.isa(o, "ListProjectsResponse");
+    return __isa(o, "ListProjectsResponse");
   }
 }
 
@@ -457,7 +460,7 @@ export interface ListTagsForResourceRequest {
 
 export namespace ListTagsForResourceRequest {
   export function isa(o: any): o is ListTagsForResourceRequest {
-    return _smithy.isa(o, "ListTagsForResourceRequest");
+    return __isa(o, "ListTagsForResourceRequest");
   }
 }
 
@@ -471,7 +474,7 @@ export interface ListTagsForResourceResponse extends $MetadataBearer {
 
 export namespace ListTagsForResourceResponse {
   export function isa(o: any): o is ListTagsForResourceResponse {
-    return _smithy.isa(o, "ListTagsForResourceResponse");
+    return __isa(o, "ListTagsForResourceResponse");
   }
 }
 
@@ -510,7 +513,7 @@ export interface PlacementDescription {
 
 export namespace PlacementDescription {
   export function isa(o: any): o is PlacementDescription {
-    return _smithy.isa(o, "PlacementDescription");
+    return __isa(o, "PlacementDescription");
   }
 }
 
@@ -544,7 +547,7 @@ export interface PlacementSummary {
 
 export namespace PlacementSummary {
   export function isa(o: any): o is PlacementSummary {
-    return _smithy.isa(o, "PlacementSummary");
+    return __isa(o, "PlacementSummary");
   }
 }
 
@@ -568,7 +571,7 @@ export interface PlacementTemplate {
 
 export namespace PlacementTemplate {
   export function isa(o: any): o is PlacementTemplate {
-    return _smithy.isa(o, "PlacementTemplate");
+    return __isa(o, "PlacementTemplate");
   }
 }
 
@@ -617,7 +620,7 @@ export interface ProjectDescription {
 
 export namespace ProjectDescription {
   export function isa(o: any): o is ProjectDescription {
-    return _smithy.isa(o, "ProjectDescription");
+    return __isa(o, "ProjectDescription");
   }
 }
 
@@ -656,7 +659,7 @@ export interface ProjectSummary {
 
 export namespace ProjectSummary {
   export function isa(o: any): o is ProjectSummary {
-    return _smithy.isa(o, "ProjectSummary");
+    return __isa(o, "ProjectSummary");
   }
 }
 
@@ -664,7 +667,7 @@ export namespace ProjectSummary {
  * <p></p>
  */
 export interface ResourceConflictException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceConflictException";
   $fault: "client";
@@ -674,7 +677,7 @@ export interface ResourceConflictException
 
 export namespace ResourceConflictException {
   export function isa(o: any): o is ResourceConflictException {
-    return _smithy.isa(o, "ResourceConflictException");
+    return __isa(o, "ResourceConflictException");
   }
 }
 
@@ -682,7 +685,7 @@ export namespace ResourceConflictException {
  * <p></p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -692,7 +695,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -712,7 +715,7 @@ export interface TagResourceRequest {
 
 export namespace TagResourceRequest {
   export function isa(o: any): o is TagResourceRequest {
-    return _smithy.isa(o, "TagResourceRequest");
+    return __isa(o, "TagResourceRequest");
   }
 }
 
@@ -722,7 +725,7 @@ export interface TagResourceResponse extends $MetadataBearer {
 
 export namespace TagResourceResponse {
   export function isa(o: any): o is TagResourceResponse {
-    return _smithy.isa(o, "TagResourceResponse");
+    return __isa(o, "TagResourceResponse");
   }
 }
 
@@ -730,7 +733,7 @@ export namespace TagResourceResponse {
  * <p></p>
  */
 export interface TooManyRequestsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyRequestsException";
   $fault: "client";
@@ -740,7 +743,7 @@ export interface TooManyRequestsException
 
 export namespace TooManyRequestsException {
   export function isa(o: any): o is TooManyRequestsException {
-    return _smithy.isa(o, "TooManyRequestsException");
+    return __isa(o, "TooManyRequestsException");
   }
 }
 
@@ -759,7 +762,7 @@ export interface UntagResourceRequest {
 
 export namespace UntagResourceRequest {
   export function isa(o: any): o is UntagResourceRequest {
-    return _smithy.isa(o, "UntagResourceRequest");
+    return __isa(o, "UntagResourceRequest");
   }
 }
 
@@ -769,7 +772,7 @@ export interface UntagResourceResponse extends $MetadataBearer {
 
 export namespace UntagResourceResponse {
   export function isa(o: any): o is UntagResourceResponse {
-    return _smithy.isa(o, "UntagResourceResponse");
+    return __isa(o, "UntagResourceResponse");
   }
 }
 
@@ -794,7 +797,7 @@ export interface UpdatePlacementRequest {
 
 export namespace UpdatePlacementRequest {
   export function isa(o: any): o is UpdatePlacementRequest {
-    return _smithy.isa(o, "UpdatePlacementRequest");
+    return __isa(o, "UpdatePlacementRequest");
   }
 }
 
@@ -804,7 +807,7 @@ export interface UpdatePlacementResponse extends $MetadataBearer {
 
 export namespace UpdatePlacementResponse {
   export function isa(o: any): o is UpdatePlacementResponse {
-    return _smithy.isa(o, "UpdatePlacementResponse");
+    return __isa(o, "UpdatePlacementResponse");
   }
 }
 
@@ -831,7 +834,7 @@ export interface UpdateProjectRequest {
 
 export namespace UpdateProjectRequest {
   export function isa(o: any): o is UpdateProjectRequest {
-    return _smithy.isa(o, "UpdateProjectRequest");
+    return __isa(o, "UpdateProjectRequest");
   }
 }
 
@@ -841,6 +844,6 @@ export interface UpdateProjectResponse extends $MetadataBearer {
 
 export namespace UpdateProjectResponse {
   export function isa(o: any): o is UpdateProjectResponse {
-    return _smithy.isa(o, "UpdateProjectResponse");
+    return __isa(o, "UpdateProjectResponse");
   }
 }

--- a/clients/client-iot-1click-projects/protocols/Aws_restJson1_1.ts
+++ b/clients/client-iot-1click-projects/protocols/Aws_restJson1_1.ts
@@ -79,7 +79,10 @@ import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  extendedEncodeURIComponent as __extendedEncodeURIComponent
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -96,7 +99,7 @@ export async function serializeAws_restJson1_1AssociateDeviceWithPlacementComman
   let resolvedPath =
     "/projects/{projectName}/placements/{placementName}/devices/{deviceTemplateName}";
   if (input.deviceTemplateName !== undefined) {
-    const labelValue: string = input.deviceTemplateName.toString();
+    const labelValue: string = input.deviceTemplateName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: deviceTemplateName."
@@ -104,7 +107,7 @@ export async function serializeAws_restJson1_1AssociateDeviceWithPlacementComman
     }
     resolvedPath = resolvedPath.replace(
       "{deviceTemplateName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -112,7 +115,7 @@ export async function serializeAws_restJson1_1AssociateDeviceWithPlacementComman
     );
   }
   if (input.placementName !== undefined) {
-    const labelValue: string = input.placementName.toString();
+    const labelValue: string = input.placementName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: placementName."
@@ -120,13 +123,13 @@ export async function serializeAws_restJson1_1AssociateDeviceWithPlacementComman
     }
     resolvedPath = resolvedPath.replace(
       "{placementName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: placementName.");
   }
   if (input.projectName !== undefined) {
-    const labelValue: string = input.projectName.toString();
+    const labelValue: string = input.projectName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: projectName."
@@ -134,7 +137,7 @@ export async function serializeAws_restJson1_1AssociateDeviceWithPlacementComman
     }
     resolvedPath = resolvedPath.replace(
       "{projectName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: projectName.");
@@ -163,7 +166,7 @@ export async function serializeAws_restJson1_1CreatePlacementCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/projects/{projectName}/placements";
   if (input.projectName !== undefined) {
-    const labelValue: string = input.projectName.toString();
+    const labelValue: string = input.projectName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: projectName."
@@ -171,7 +174,7 @@ export async function serializeAws_restJson1_1CreatePlacementCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{projectName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: projectName.");
@@ -241,7 +244,7 @@ export async function serializeAws_restJson1_1DeletePlacementCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/projects/{projectName}/placements/{placementName}";
   if (input.placementName !== undefined) {
-    const labelValue: string = input.placementName.toString();
+    const labelValue: string = input.placementName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: placementName."
@@ -249,13 +252,13 @@ export async function serializeAws_restJson1_1DeletePlacementCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{placementName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: placementName.");
   }
   if (input.projectName !== undefined) {
-    const labelValue: string = input.projectName.toString();
+    const labelValue: string = input.projectName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: projectName."
@@ -263,7 +266,7 @@ export async function serializeAws_restJson1_1DeletePlacementCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{projectName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: projectName.");
@@ -285,7 +288,7 @@ export async function serializeAws_restJson1_1DeleteProjectCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/projects/{projectName}";
   if (input.projectName !== undefined) {
-    const labelValue: string = input.projectName.toString();
+    const labelValue: string = input.projectName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: projectName."
@@ -293,7 +296,7 @@ export async function serializeAws_restJson1_1DeleteProjectCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{projectName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: projectName.");
@@ -315,7 +318,7 @@ export async function serializeAws_restJson1_1DescribePlacementCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/projects/{projectName}/placements/{placementName}";
   if (input.placementName !== undefined) {
-    const labelValue: string = input.placementName.toString();
+    const labelValue: string = input.placementName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: placementName."
@@ -323,13 +326,13 @@ export async function serializeAws_restJson1_1DescribePlacementCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{placementName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: placementName.");
   }
   if (input.projectName !== undefined) {
-    const labelValue: string = input.projectName.toString();
+    const labelValue: string = input.projectName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: projectName."
@@ -337,7 +340,7 @@ export async function serializeAws_restJson1_1DescribePlacementCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{projectName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: projectName.");
@@ -359,7 +362,7 @@ export async function serializeAws_restJson1_1DescribeProjectCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/projects/{projectName}";
   if (input.projectName !== undefined) {
-    const labelValue: string = input.projectName.toString();
+    const labelValue: string = input.projectName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: projectName."
@@ -367,7 +370,7 @@ export async function serializeAws_restJson1_1DescribeProjectCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{projectName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: projectName.");
@@ -390,7 +393,7 @@ export async function serializeAws_restJson1_1DisassociateDeviceFromPlacementCom
   let resolvedPath =
     "/projects/{projectName}/placements/{placementName}/devices/{deviceTemplateName}";
   if (input.deviceTemplateName !== undefined) {
-    const labelValue: string = input.deviceTemplateName.toString();
+    const labelValue: string = input.deviceTemplateName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: deviceTemplateName."
@@ -398,7 +401,7 @@ export async function serializeAws_restJson1_1DisassociateDeviceFromPlacementCom
     }
     resolvedPath = resolvedPath.replace(
       "{deviceTemplateName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -406,7 +409,7 @@ export async function serializeAws_restJson1_1DisassociateDeviceFromPlacementCom
     );
   }
   if (input.placementName !== undefined) {
-    const labelValue: string = input.placementName.toString();
+    const labelValue: string = input.placementName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: placementName."
@@ -414,13 +417,13 @@ export async function serializeAws_restJson1_1DisassociateDeviceFromPlacementCom
     }
     resolvedPath = resolvedPath.replace(
       "{placementName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: placementName.");
   }
   if (input.projectName !== undefined) {
-    const labelValue: string = input.projectName.toString();
+    const labelValue: string = input.projectName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: projectName."
@@ -428,7 +431,7 @@ export async function serializeAws_restJson1_1DisassociateDeviceFromPlacementCom
     }
     resolvedPath = resolvedPath.replace(
       "{projectName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: projectName.");
@@ -451,7 +454,7 @@ export async function serializeAws_restJson1_1GetDevicesInPlacementCommand(
   let resolvedPath =
     "/projects/{projectName}/placements/{placementName}/devices";
   if (input.placementName !== undefined) {
-    const labelValue: string = input.placementName.toString();
+    const labelValue: string = input.placementName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: placementName."
@@ -459,13 +462,13 @@ export async function serializeAws_restJson1_1GetDevicesInPlacementCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{placementName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: placementName.");
   }
   if (input.projectName !== undefined) {
-    const labelValue: string = input.projectName.toString();
+    const labelValue: string = input.projectName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: projectName."
@@ -473,7 +476,7 @@ export async function serializeAws_restJson1_1GetDevicesInPlacementCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{projectName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: projectName.");
@@ -495,7 +498,7 @@ export async function serializeAws_restJson1_1ListPlacementsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/projects/{projectName}/placements";
   if (input.projectName !== undefined) {
-    const labelValue: string = input.projectName.toString();
+    const labelValue: string = input.projectName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: projectName."
@@ -503,17 +506,21 @@ export async function serializeAws_restJson1_1ListPlacementsCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{projectName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: projectName.");
   }
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -534,10 +541,14 @@ export async function serializeAws_restJson1_1ListProjectsCommand(
   let resolvedPath = "/projects";
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -557,7 +568,7 @@ export async function serializeAws_restJson1_1ListTagsForResourceCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/tags/{resourceArn}";
   if (input.resourceArn !== undefined) {
-    const labelValue: string = input.resourceArn.toString();
+    const labelValue: string = input.resourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: resourceArn."
@@ -565,7 +576,7 @@ export async function serializeAws_restJson1_1ListTagsForResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{resourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: resourceArn.");
@@ -587,7 +598,7 @@ export async function serializeAws_restJson1_1TagResourceCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/tags/{resourceArn}";
   if (input.resourceArn !== undefined) {
-    const labelValue: string = input.resourceArn.toString();
+    const labelValue: string = input.resourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: resourceArn."
@@ -595,7 +606,7 @@ export async function serializeAws_restJson1_1TagResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{resourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: resourceArn.");
@@ -624,7 +635,7 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/tags/{resourceArn}";
   if (input.resourceArn !== undefined) {
-    const labelValue: string = input.resourceArn.toString();
+    const labelValue: string = input.resourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: resourceArn."
@@ -632,14 +643,16 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{resourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: resourceArn.");
   }
   const query: any = {};
   if (input.tagKeys !== undefined) {
-    query["tagKeys"] = input.tagKeys;
+    query[__extendedEncodeURIComponent("tagKeys")] = input.tagKeys.map(entry =>
+      __extendedEncodeURIComponent(entry)
+    );
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -659,7 +672,7 @@ export async function serializeAws_restJson1_1UpdatePlacementCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/projects/{projectName}/placements/{placementName}";
   if (input.placementName !== undefined) {
-    const labelValue: string = input.placementName.toString();
+    const labelValue: string = input.placementName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: placementName."
@@ -667,13 +680,13 @@ export async function serializeAws_restJson1_1UpdatePlacementCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{placementName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: placementName.");
   }
   if (input.projectName !== undefined) {
-    const labelValue: string = input.projectName.toString();
+    const labelValue: string = input.projectName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: projectName."
@@ -681,7 +694,7 @@ export async function serializeAws_restJson1_1UpdatePlacementCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{projectName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: projectName.");
@@ -713,7 +726,7 @@ export async function serializeAws_restJson1_1UpdateProjectCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/projects/{projectName}";
   if (input.projectName !== undefined) {
-    const labelValue: string = input.projectName.toString();
+    const labelValue: string = input.projectName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: projectName."
@@ -721,7 +734,7 @@ export async function serializeAws_restJson1_1UpdateProjectCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{projectName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: projectName.");
@@ -762,6 +775,7 @@ export async function deserializeAws_restJson1_1AssociateDeviceWithPlacementComm
     $metadata: deserializeMetadata(output),
     __type: "AssociateDeviceWithPlacementResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -834,6 +848,7 @@ export async function deserializeAws_restJson1_1CreatePlacementCommand(
     $metadata: deserializeMetadata(output),
     __type: "CreatePlacementResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -903,6 +918,7 @@ export async function deserializeAws_restJson1_1CreateProjectCommand(
     $metadata: deserializeMetadata(output),
     __type: "CreateProjectResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -968,6 +984,7 @@ export async function deserializeAws_restJson1_1DeletePlacementCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeletePlacementResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -1037,6 +1054,7 @@ export async function deserializeAws_restJson1_1DeleteProjectCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeleteProjectResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -1255,6 +1273,7 @@ export async function deserializeAws_restJson1_1DisassociateDeviceFromPlacementC
     $metadata: deserializeMetadata(output),
     __type: "DisassociateDeviceFromPlacementResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -1611,6 +1630,7 @@ export async function deserializeAws_restJson1_1TagResourceCommand(
     $metadata: deserializeMetadata(output),
     __type: "TagResourceResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -1673,6 +1693,7 @@ export async function deserializeAws_restJson1_1UntagResourceCommand(
     $metadata: deserializeMetadata(output),
     __type: "UntagResourceResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -1738,6 +1759,7 @@ export async function deserializeAws_restJson1_1UpdatePlacementCommand(
     $metadata: deserializeMetadata(output),
     __type: "UpdatePlacementResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -1807,6 +1829,7 @@ export async function deserializeAws_restJson1_1UpdateProjectCommand(
     $metadata: deserializeMetadata(output),
     __type: "UpdateProjectResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 

--- a/clients/client-iot-data-plane/models/index.ts
+++ b/clients/client-iot-data-plane/models/index.ts
@@ -1,11 +1,14 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
  * <p>An unexpected error has occurred.</p>
  */
 export interface InternalFailureException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalFailureException";
   $fault: "server";
@@ -17,7 +20,7 @@ export interface InternalFailureException
 
 export namespace InternalFailureException {
   export function isa(o: any): o is InternalFailureException {
-    return _smithy.isa(o, "InternalFailureException");
+    return __isa(o, "InternalFailureException");
   }
 }
 
@@ -25,7 +28,7 @@ export namespace InternalFailureException {
  * <p>The request is not valid.</p>
  */
 export interface InvalidRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidRequestException";
   $fault: "client";
@@ -37,7 +40,7 @@ export interface InvalidRequestException
 
 export namespace InvalidRequestException {
   export function isa(o: any): o is InvalidRequestException {
-    return _smithy.isa(o, "InvalidRequestException");
+    return __isa(o, "InvalidRequestException");
   }
 }
 
@@ -45,7 +48,7 @@ export namespace InvalidRequestException {
  * <p>The specified resource does not exist.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -57,7 +60,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -65,7 +68,7 @@ export namespace ResourceNotFoundException {
  * <p>The service is temporarily unavailable.</p>
  */
 export interface ServiceUnavailableException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ServiceUnavailableException";
   $fault: "server";
@@ -77,7 +80,7 @@ export interface ServiceUnavailableException
 
 export namespace ServiceUnavailableException {
   export function isa(o: any): o is ServiceUnavailableException {
-    return _smithy.isa(o, "ServiceUnavailableException");
+    return __isa(o, "ServiceUnavailableException");
   }
 }
 
@@ -85,7 +88,7 @@ export namespace ServiceUnavailableException {
  * <p>The rate exceeds the limit.</p>
  */
 export interface ThrottlingException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ThrottlingException";
   $fault: "client";
@@ -97,7 +100,7 @@ export interface ThrottlingException
 
 export namespace ThrottlingException {
   export function isa(o: any): o is ThrottlingException {
-    return _smithy.isa(o, "ThrottlingException");
+    return __isa(o, "ThrottlingException");
   }
 }
 
@@ -105,7 +108,7 @@ export namespace ThrottlingException {
  * <p>You are not authorized to perform this operation.</p>
  */
 export interface UnauthorizedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UnauthorizedException";
   $fault: "client";
@@ -117,7 +120,7 @@ export interface UnauthorizedException
 
 export namespace UnauthorizedException {
   export function isa(o: any): o is UnauthorizedException {
-    return _smithy.isa(o, "UnauthorizedException");
+    return __isa(o, "UnauthorizedException");
   }
 }
 
@@ -125,7 +128,7 @@ export namespace UnauthorizedException {
  * <p>The document encoding is not supported.</p>
  */
 export interface UnsupportedDocumentEncodingException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UnsupportedDocumentEncodingException";
   $fault: "client";
@@ -137,16 +140,14 @@ export interface UnsupportedDocumentEncodingException
 
 export namespace UnsupportedDocumentEncodingException {
   export function isa(o: any): o is UnsupportedDocumentEncodingException {
-    return _smithy.isa(o, "UnsupportedDocumentEncodingException");
+    return __isa(o, "UnsupportedDocumentEncodingException");
   }
 }
 
 /**
  * <p>The specified version does not match the version of the document.</p>
  */
-export interface ConflictException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface ConflictException extends __SmithyException, $MetadataBearer {
   name: "ConflictException";
   $fault: "client";
   /**
@@ -157,7 +158,7 @@ export interface ConflictException
 
 export namespace ConflictException {
   export function isa(o: any): o is ConflictException {
-    return _smithy.isa(o, "ConflictException");
+    return __isa(o, "ConflictException");
   }
 }
 
@@ -174,7 +175,7 @@ export interface DeleteThingShadowRequest {
 
 export namespace DeleteThingShadowRequest {
   export function isa(o: any): o is DeleteThingShadowRequest {
-    return _smithy.isa(o, "DeleteThingShadowRequest");
+    return __isa(o, "DeleteThingShadowRequest");
   }
 }
 
@@ -191,7 +192,7 @@ export interface DeleteThingShadowResponse extends $MetadataBearer {
 
 export namespace DeleteThingShadowResponse {
   export function isa(o: any): o is DeleteThingShadowResponse {
-    return _smithy.isa(o, "DeleteThingShadowResponse");
+    return __isa(o, "DeleteThingShadowResponse");
   }
 }
 
@@ -208,7 +209,7 @@ export interface GetThingShadowRequest {
 
 export namespace GetThingShadowRequest {
   export function isa(o: any): o is GetThingShadowRequest {
-    return _smithy.isa(o, "GetThingShadowRequest");
+    return __isa(o, "GetThingShadowRequest");
   }
 }
 
@@ -225,7 +226,7 @@ export interface GetThingShadowResponse extends $MetadataBearer {
 
 export namespace GetThingShadowResponse {
   export function isa(o: any): o is GetThingShadowResponse {
-    return _smithy.isa(o, "GetThingShadowResponse");
+    return __isa(o, "GetThingShadowResponse");
   }
 }
 
@@ -233,7 +234,7 @@ export namespace GetThingShadowResponse {
  * <p>The specified combination of HTTP verb and URI is not supported.</p>
  */
 export interface MethodNotAllowedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "MethodNotAllowedException";
   $fault: "client";
@@ -245,7 +246,7 @@ export interface MethodNotAllowedException
 
 export namespace MethodNotAllowedException {
   export function isa(o: any): o is MethodNotAllowedException {
-    return _smithy.isa(o, "MethodNotAllowedException");
+    return __isa(o, "MethodNotAllowedException");
   }
 }
 
@@ -272,7 +273,7 @@ export interface PublishRequest {
 
 export namespace PublishRequest {
   export function isa(o: any): o is PublishRequest {
-    return _smithy.isa(o, "PublishRequest");
+    return __isa(o, "PublishRequest");
   }
 }
 
@@ -280,7 +281,7 @@ export namespace PublishRequest {
  * <p>The payload exceeds the maximum size allowed.</p>
  */
 export interface RequestEntityTooLargeException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "RequestEntityTooLargeException";
   $fault: "client";
@@ -292,7 +293,7 @@ export interface RequestEntityTooLargeException
 
 export namespace RequestEntityTooLargeException {
   export function isa(o: any): o is RequestEntityTooLargeException {
-    return _smithy.isa(o, "RequestEntityTooLargeException");
+    return __isa(o, "RequestEntityTooLargeException");
   }
 }
 
@@ -314,7 +315,7 @@ export interface UpdateThingShadowRequest {
 
 export namespace UpdateThingShadowRequest {
   export function isa(o: any): o is UpdateThingShadowRequest {
-    return _smithy.isa(o, "UpdateThingShadowRequest");
+    return __isa(o, "UpdateThingShadowRequest");
   }
 }
 
@@ -331,6 +332,6 @@ export interface UpdateThingShadowResponse extends $MetadataBearer {
 
 export namespace UpdateThingShadowResponse {
   export function isa(o: any): o is UpdateThingShadowResponse {
-    return _smithy.isa(o, "UpdateThingShadowResponse");
+    return __isa(o, "UpdateThingShadowResponse");
   }
 }

--- a/clients/client-iot-data-plane/protocols/Aws_restJson1_1.ts
+++ b/clients/client-iot-data-plane/protocols/Aws_restJson1_1.ts
@@ -30,7 +30,10 @@ import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  extendedEncodeURIComponent as __extendedEncodeURIComponent
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -46,13 +49,13 @@ export async function serializeAws_restJson1_1DeleteThingShadowCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/things/{thingName}/shadow";
   if (input.thingName !== undefined) {
-    const labelValue: string = input.thingName.toString();
+    const labelValue: string = input.thingName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: thingName.");
     }
     resolvedPath = resolvedPath.replace(
       "{thingName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: thingName.");
@@ -74,13 +77,13 @@ export async function serializeAws_restJson1_1GetThingShadowCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/things/{thingName}/shadow";
   if (input.thingName !== undefined) {
-    const labelValue: string = input.thingName.toString();
+    const labelValue: string = input.thingName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: thingName.");
     }
     resolvedPath = resolvedPath.replace(
       "{thingName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: thingName.");
@@ -102,20 +105,22 @@ export async function serializeAws_restJson1_1PublishCommand(
   headers["Content-Type"] = "application/octet-stream";
   let resolvedPath = "/topics/{topic}";
   if (input.topic !== undefined) {
-    const labelValue: string = input.topic.toString();
+    const labelValue: string = input.topic;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: topic.");
     }
     resolvedPath = resolvedPath.replace(
       "{topic}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: topic.");
   }
   const query: any = {};
   if (input.qos !== undefined) {
-    query["qos"] = input.qos.toString();
+    query[__extendedEncodeURIComponent("qos")] = __extendedEncodeURIComponent(
+      input.qos.toString()
+    );
   }
   let body: any;
   if (input.payload !== undefined) {
@@ -140,13 +145,13 @@ export async function serializeAws_restJson1_1UpdateThingShadowCommand(
   headers["Content-Type"] = "application/octet-stream";
   let resolvedPath = "/things/{thingName}/shadow";
   if (input.thingName !== undefined) {
-    const labelValue: string = input.thingName.toString();
+    const labelValue: string = input.thingName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: thingName.");
     }
     resolvedPath = resolvedPath.replace(
       "{thingName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: thingName.");
@@ -381,6 +386,7 @@ export async function deserializeAws_restJson1_1PublishCommand(
   const contents: PublishCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 

--- a/clients/client-iot-events-data/models/index.ts
+++ b/clients/client-iot-events-data/models/index.ts
@@ -1,11 +1,14 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
  * <p>An internal failure occured.</p>
  */
 export interface InternalFailureException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalFailureException";
   $fault: "server";
@@ -17,7 +20,7 @@ export interface InternalFailureException
 
 export namespace InternalFailureException {
   export function isa(o: any): o is InternalFailureException {
-    return _smithy.isa(o, "InternalFailureException");
+    return __isa(o, "InternalFailureException");
   }
 }
 
@@ -25,7 +28,7 @@ export namespace InternalFailureException {
  * <p>The request was invalid.</p>
  */
 export interface InvalidRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidRequestException";
   $fault: "client";
@@ -37,7 +40,7 @@ export interface InvalidRequestException
 
 export namespace InvalidRequestException {
   export function isa(o: any): o is InvalidRequestException {
-    return _smithy.isa(o, "InvalidRequestException");
+    return __isa(o, "InvalidRequestException");
   }
 }
 
@@ -45,7 +48,7 @@ export namespace InvalidRequestException {
  * <p>The resource was not found.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -57,7 +60,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -65,7 +68,7 @@ export namespace ResourceNotFoundException {
  * <p>The service is currently unavailable.</p>
  */
 export interface ServiceUnavailableException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ServiceUnavailableException";
   $fault: "server";
@@ -77,7 +80,7 @@ export interface ServiceUnavailableException
 
 export namespace ServiceUnavailableException {
   export function isa(o: any): o is ServiceUnavailableException {
-    return _smithy.isa(o, "ServiceUnavailableException");
+    return __isa(o, "ServiceUnavailableException");
   }
 }
 
@@ -85,7 +88,7 @@ export namespace ServiceUnavailableException {
  * <p>The request could not be completed due to throttling.</p>
  */
 export interface ThrottlingException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ThrottlingException";
   $fault: "client";
@@ -97,7 +100,7 @@ export interface ThrottlingException
 
 export namespace ThrottlingException {
   export function isa(o: any): o is ThrottlingException {
-    return _smithy.isa(o, "ThrottlingException");
+    return __isa(o, "ThrottlingException");
   }
 }
 
@@ -125,7 +128,7 @@ export interface BatchPutMessageErrorEntry {
 
 export namespace BatchPutMessageErrorEntry {
   export function isa(o: any): o is BatchPutMessageErrorEntry {
-    return _smithy.isa(o, "BatchPutMessageErrorEntry");
+    return __isa(o, "BatchPutMessageErrorEntry");
   }
 }
 
@@ -141,7 +144,7 @@ export interface BatchPutMessageRequest {
 
 export namespace BatchPutMessageRequest {
   export function isa(o: any): o is BatchPutMessageRequest {
-    return _smithy.isa(o, "BatchPutMessageRequest");
+    return __isa(o, "BatchPutMessageRequest");
   }
 }
 
@@ -155,7 +158,7 @@ export interface BatchPutMessageResponse extends $MetadataBearer {
 
 export namespace BatchPutMessageResponse {
   export function isa(o: any): o is BatchPutMessageResponse {
-    return _smithy.isa(o, "BatchPutMessageResponse");
+    return __isa(o, "BatchPutMessageResponse");
   }
 }
 
@@ -183,7 +186,7 @@ export interface BatchUpdateDetectorErrorEntry {
 
 export namespace BatchUpdateDetectorErrorEntry {
   export function isa(o: any): o is BatchUpdateDetectorErrorEntry {
-    return _smithy.isa(o, "BatchUpdateDetectorErrorEntry");
+    return __isa(o, "BatchUpdateDetectorErrorEntry");
   }
 }
 
@@ -197,7 +200,7 @@ export interface BatchUpdateDetectorRequest {
 
 export namespace BatchUpdateDetectorRequest {
   export function isa(o: any): o is BatchUpdateDetectorRequest {
-    return _smithy.isa(o, "BatchUpdateDetectorRequest");
+    return __isa(o, "BatchUpdateDetectorRequest");
   }
 }
 
@@ -212,7 +215,7 @@ export interface BatchUpdateDetectorResponse extends $MetadataBearer {
 
 export namespace BatchUpdateDetectorResponse {
   export function isa(o: any): o is BatchUpdateDetectorResponse {
-    return _smithy.isa(o, "BatchUpdateDetectorResponse");
+    return __isa(o, "BatchUpdateDetectorResponse");
   }
 }
 
@@ -231,7 +234,7 @@ export interface DescribeDetectorRequest {
 
 export namespace DescribeDetectorRequest {
   export function isa(o: any): o is DescribeDetectorRequest {
-    return _smithy.isa(o, "DescribeDetectorRequest");
+    return __isa(o, "DescribeDetectorRequest");
   }
 }
 
@@ -245,7 +248,7 @@ export interface DescribeDetectorResponse extends $MetadataBearer {
 
 export namespace DescribeDetectorResponse {
   export function isa(o: any): o is DescribeDetectorResponse {
-    return _smithy.isa(o, "DescribeDetectorResponse");
+    return __isa(o, "DescribeDetectorResponse");
   }
 }
 
@@ -288,7 +291,7 @@ export interface Detector {
 
 export namespace Detector {
   export function isa(o: any): o is Detector {
-    return _smithy.isa(o, "Detector");
+    return __isa(o, "Detector");
   }
 }
 
@@ -315,7 +318,7 @@ export interface DetectorState {
 
 export namespace DetectorState {
   export function isa(o: any): o is DetectorState {
-    return _smithy.isa(o, "DetectorState");
+    return __isa(o, "DetectorState");
   }
 }
 
@@ -343,7 +346,7 @@ export interface DetectorStateDefinition {
 
 export namespace DetectorStateDefinition {
   export function isa(o: any): o is DetectorStateDefinition {
-    return _smithy.isa(o, "DetectorStateDefinition");
+    return __isa(o, "DetectorStateDefinition");
   }
 }
 
@@ -360,7 +363,7 @@ export interface DetectorStateSummary {
 
 export namespace DetectorStateSummary {
   export function isa(o: any): o is DetectorStateSummary {
-    return _smithy.isa(o, "DetectorStateSummary");
+    return __isa(o, "DetectorStateSummary");
   }
 }
 
@@ -403,7 +406,7 @@ export interface DetectorSummary {
 
 export namespace DetectorSummary {
   export function isa(o: any): o is DetectorSummary {
-    return _smithy.isa(o, "DetectorSummary");
+    return __isa(o, "DetectorSummary");
   }
 }
 
@@ -440,7 +443,7 @@ export interface ListDetectorsRequest {
 
 export namespace ListDetectorsRequest {
   export function isa(o: any): o is ListDetectorsRequest {
-    return _smithy.isa(o, "ListDetectorsRequest");
+    return __isa(o, "ListDetectorsRequest");
   }
 }
 
@@ -460,7 +463,7 @@ export interface ListDetectorsResponse extends $MetadataBearer {
 
 export namespace ListDetectorsResponse {
   export function isa(o: any): o is ListDetectorsResponse {
-    return _smithy.isa(o, "ListDetectorsResponse");
+    return __isa(o, "ListDetectorsResponse");
   }
 }
 
@@ -489,7 +492,7 @@ export interface Message {
 
 export namespace Message {
   export function isa(o: any): o is Message {
-    return _smithy.isa(o, "Message");
+    return __isa(o, "Message");
   }
 }
 
@@ -511,7 +514,7 @@ export interface Timer {
 
 export namespace Timer {
   export function isa(o: any): o is Timer {
-    return _smithy.isa(o, "Timer");
+    return __isa(o, "Timer");
   }
 }
 
@@ -533,7 +536,7 @@ export interface TimerDefinition {
 
 export namespace TimerDefinition {
   export function isa(o: any): o is TimerDefinition {
-    return _smithy.isa(o, "TimerDefinition");
+    return __isa(o, "TimerDefinition");
   }
 }
 
@@ -567,7 +570,7 @@ export interface UpdateDetectorRequest {
 
 export namespace UpdateDetectorRequest {
   export function isa(o: any): o is UpdateDetectorRequest {
-    return _smithy.isa(o, "UpdateDetectorRequest");
+    return __isa(o, "UpdateDetectorRequest");
   }
 }
 
@@ -589,7 +592,7 @@ export interface Variable {
 
 export namespace Variable {
   export function isa(o: any): o is Variable {
-    return _smithy.isa(o, "Variable");
+    return __isa(o, "Variable");
   }
 }
 
@@ -611,6 +614,6 @@ export interface VariableDefinition {
 
 export namespace VariableDefinition {
   export function isa(o: any): o is VariableDefinition {
-    return _smithy.isa(o, "VariableDefinition");
+    return __isa(o, "VariableDefinition");
   }
 }

--- a/clients/client-iot-events-data/protocols/Aws_restJson1_1.ts
+++ b/clients/client-iot-events-data/protocols/Aws_restJson1_1.ts
@@ -38,7 +38,10 @@ import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  extendedEncodeURIComponent as __extendedEncodeURIComponent
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -106,7 +109,7 @@ export async function serializeAws_restJson1_1DescribeDetectorCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/detectors/{detectorModelName}/keyValues";
   if (input.detectorModelName !== undefined) {
-    const labelValue: string = input.detectorModelName.toString();
+    const labelValue: string = input.detectorModelName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: detectorModelName."
@@ -114,7 +117,7 @@ export async function serializeAws_restJson1_1DescribeDetectorCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{detectorModelName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -123,7 +126,9 @@ export async function serializeAws_restJson1_1DescribeDetectorCommand(
   }
   const query: any = {};
   if (input.keyValue !== undefined) {
-    query["keyValue"] = input.keyValue.toString();
+    query[
+      __extendedEncodeURIComponent("keyValue")
+    ] = __extendedEncodeURIComponent(input.keyValue);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -143,7 +148,7 @@ export async function serializeAws_restJson1_1ListDetectorsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/detectors/{detectorModelName}";
   if (input.detectorModelName !== undefined) {
-    const labelValue: string = input.detectorModelName.toString();
+    const labelValue: string = input.detectorModelName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: detectorModelName."
@@ -151,7 +156,7 @@ export async function serializeAws_restJson1_1ListDetectorsCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{detectorModelName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -160,13 +165,19 @@ export async function serializeAws_restJson1_1ListDetectorsCommand(
   }
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   if (input.stateName !== undefined) {
-    query["stateName"] = input.stateName.toString();
+    query[
+      __extendedEncodeURIComponent("stateName")
+    ] = __extendedEncodeURIComponent(input.stateName);
   }
   return new __HttpRequest({
     ...context.endpoint,

--- a/clients/client-iot-events/models/index.ts
+++ b/clients/client-iot-events/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -63,7 +66,7 @@ export interface Action {
 
 export namespace Action {
   export function isa(o: any): o is Action {
-    return _smithy.isa(o, "Action");
+    return __isa(o, "Action");
   }
 }
 
@@ -89,7 +92,7 @@ export interface Attribute {
 
 export namespace Attribute {
   export function isa(o: any): o is Attribute {
-    return _smithy.isa(o, "Attribute");
+    return __isa(o, "Attribute");
   }
 }
 
@@ -106,7 +109,7 @@ export interface ClearTimerAction {
 
 export namespace ClearTimerAction {
   export function isa(o: any): o is ClearTimerAction {
-    return _smithy.isa(o, "ClearTimerAction");
+    return __isa(o, "ClearTimerAction");
   }
 }
 
@@ -153,7 +156,7 @@ export interface CreateDetectorModelRequest {
 
 export namespace CreateDetectorModelRequest {
   export function isa(o: any): o is CreateDetectorModelRequest {
-    return _smithy.isa(o, "CreateDetectorModelRequest");
+    return __isa(o, "CreateDetectorModelRequest");
   }
 }
 
@@ -167,7 +170,7 @@ export interface CreateDetectorModelResponse extends $MetadataBearer {
 
 export namespace CreateDetectorModelResponse {
   export function isa(o: any): o is CreateDetectorModelResponse {
-    return _smithy.isa(o, "CreateDetectorModelResponse");
+    return __isa(o, "CreateDetectorModelResponse");
   }
 }
 
@@ -196,7 +199,7 @@ export interface CreateInputRequest {
 
 export namespace CreateInputRequest {
   export function isa(o: any): o is CreateInputRequest {
-    return _smithy.isa(o, "CreateInputRequest");
+    return __isa(o, "CreateInputRequest");
   }
 }
 
@@ -210,7 +213,7 @@ export interface CreateInputResponse extends $MetadataBearer {
 
 export namespace CreateInputResponse {
   export function isa(o: any): o is CreateInputResponse {
-    return _smithy.isa(o, "CreateInputResponse");
+    return __isa(o, "CreateInputResponse");
   }
 }
 
@@ -224,7 +227,7 @@ export interface DeleteDetectorModelRequest {
 
 export namespace DeleteDetectorModelRequest {
   export function isa(o: any): o is DeleteDetectorModelRequest {
-    return _smithy.isa(o, "DeleteDetectorModelRequest");
+    return __isa(o, "DeleteDetectorModelRequest");
   }
 }
 
@@ -234,7 +237,7 @@ export interface DeleteDetectorModelResponse extends $MetadataBearer {
 
 export namespace DeleteDetectorModelResponse {
   export function isa(o: any): o is DeleteDetectorModelResponse {
-    return _smithy.isa(o, "DeleteDetectorModelResponse");
+    return __isa(o, "DeleteDetectorModelResponse");
   }
 }
 
@@ -248,7 +251,7 @@ export interface DeleteInputRequest {
 
 export namespace DeleteInputRequest {
   export function isa(o: any): o is DeleteInputRequest {
-    return _smithy.isa(o, "DeleteInputRequest");
+    return __isa(o, "DeleteInputRequest");
   }
 }
 
@@ -258,7 +261,7 @@ export interface DeleteInputResponse extends $MetadataBearer {
 
 export namespace DeleteInputResponse {
   export function isa(o: any): o is DeleteInputResponse {
-    return _smithy.isa(o, "DeleteInputResponse");
+    return __isa(o, "DeleteInputResponse");
   }
 }
 
@@ -277,7 +280,7 @@ export interface DescribeDetectorModelRequest {
 
 export namespace DescribeDetectorModelRequest {
   export function isa(o: any): o is DescribeDetectorModelRequest {
-    return _smithy.isa(o, "DescribeDetectorModelRequest");
+    return __isa(o, "DescribeDetectorModelRequest");
   }
 }
 
@@ -291,7 +294,7 @@ export interface DescribeDetectorModelResponse extends $MetadataBearer {
 
 export namespace DescribeDetectorModelResponse {
   export function isa(o: any): o is DescribeDetectorModelResponse {
-    return _smithy.isa(o, "DescribeDetectorModelResponse");
+    return __isa(o, "DescribeDetectorModelResponse");
   }
 }
 
@@ -305,7 +308,7 @@ export interface DescribeInputRequest {
 
 export namespace DescribeInputRequest {
   export function isa(o: any): o is DescribeInputRequest {
-    return _smithy.isa(o, "DescribeInputRequest");
+    return __isa(o, "DescribeInputRequest");
   }
 }
 
@@ -319,7 +322,7 @@ export interface DescribeInputResponse extends $MetadataBearer {
 
 export namespace DescribeInputResponse {
   export function isa(o: any): o is DescribeInputResponse {
-    return _smithy.isa(o, "DescribeInputResponse");
+    return __isa(o, "DescribeInputResponse");
   }
 }
 
@@ -329,7 +332,7 @@ export interface DescribeLoggingOptionsRequest {
 
 export namespace DescribeLoggingOptionsRequest {
   export function isa(o: any): o is DescribeLoggingOptionsRequest {
-    return _smithy.isa(o, "DescribeLoggingOptionsRequest");
+    return __isa(o, "DescribeLoggingOptionsRequest");
   }
 }
 
@@ -343,7 +346,7 @@ export interface DescribeLoggingOptionsResponse extends $MetadataBearer {
 
 export namespace DescribeLoggingOptionsResponse {
   export function isa(o: any): o is DescribeLoggingOptionsResponse {
-    return _smithy.isa(o, "DescribeLoggingOptionsResponse");
+    return __isa(o, "DescribeLoggingOptionsResponse");
   }
 }
 
@@ -366,7 +369,7 @@ export interface DetectorDebugOption {
 
 export namespace DetectorDebugOption {
   export function isa(o: any): o is DetectorDebugOption {
-    return _smithy.isa(o, "DetectorDebugOption");
+    return __isa(o, "DetectorDebugOption");
   }
 }
 
@@ -388,7 +391,7 @@ export interface DetectorModel {
 
 export namespace DetectorModel {
   export function isa(o: any): o is DetectorModel {
-    return _smithy.isa(o, "DetectorModel");
+    return __isa(o, "DetectorModel");
   }
 }
 
@@ -453,7 +456,7 @@ export interface DetectorModelConfiguration {
 
 export namespace DetectorModelConfiguration {
   export function isa(o: any): o is DetectorModelConfiguration {
-    return _smithy.isa(o, "DetectorModelConfiguration");
+    return __isa(o, "DetectorModelConfiguration");
   }
 }
 
@@ -475,7 +478,7 @@ export interface DetectorModelDefinition {
 
 export namespace DetectorModelDefinition {
   export function isa(o: any): o is DetectorModelDefinition {
-    return _smithy.isa(o, "DetectorModelDefinition");
+    return __isa(o, "DetectorModelDefinition");
   }
 }
 
@@ -502,7 +505,7 @@ export interface DetectorModelSummary {
 
 export namespace DetectorModelSummary {
   export function isa(o: any): o is DetectorModelSummary {
-    return _smithy.isa(o, "DetectorModelSummary");
+    return __isa(o, "DetectorModelSummary");
   }
 }
 
@@ -564,7 +567,7 @@ export interface DetectorModelVersionSummary {
 
 export namespace DetectorModelVersionSummary {
   export function isa(o: any): o is DetectorModelVersionSummary {
-    return _smithy.isa(o, "DetectorModelVersionSummary");
+    return __isa(o, "DetectorModelVersionSummary");
   }
 }
 
@@ -599,7 +602,7 @@ export interface Event {
 
 export namespace Event {
   export function isa(o: any): o is Event {
-    return _smithy.isa(o, "Event");
+    return __isa(o, "Event");
   }
 }
 
@@ -624,7 +627,7 @@ export interface FirehoseAction {
 
 export namespace FirehoseAction {
   export function isa(o: any): o is FirehoseAction {
-    return _smithy.isa(o, "FirehoseAction");
+    return __isa(o, "FirehoseAction");
   }
 }
 
@@ -646,7 +649,7 @@ export interface Input {
 
 export namespace Input {
   export function isa(o: any): o is Input {
-    return _smithy.isa(o, "Input");
+    return __isa(o, "Input");
   }
 }
 
@@ -688,7 +691,7 @@ export interface InputConfiguration {
 
 export namespace InputConfiguration {
   export function isa(o: any): o is InputConfiguration {
-    return _smithy.isa(o, "InputConfiguration");
+    return __isa(o, "InputConfiguration");
   }
 }
 
@@ -709,7 +712,7 @@ export interface InputDefinition {
 
 export namespace InputDefinition {
   export function isa(o: any): o is InputDefinition {
-    return _smithy.isa(o, "InputDefinition");
+    return __isa(o, "InputDefinition");
   }
 }
 
@@ -758,7 +761,7 @@ export interface InputSummary {
 
 export namespace InputSummary {
   export function isa(o: any): o is InputSummary {
-    return _smithy.isa(o, "InputSummary");
+    return __isa(o, "InputSummary");
   }
 }
 
@@ -776,7 +779,7 @@ export interface IotEventsAction {
 
 export namespace IotEventsAction {
   export function isa(o: any): o is IotEventsAction {
-    return _smithy.isa(o, "IotEventsAction");
+    return __isa(o, "IotEventsAction");
   }
 }
 
@@ -793,7 +796,7 @@ export interface IotTopicPublishAction {
 
 export namespace IotTopicPublishAction {
   export function isa(o: any): o is IotTopicPublishAction {
-    return _smithy.isa(o, "IotTopicPublishAction");
+    return __isa(o, "IotTopicPublishAction");
   }
 }
 
@@ -811,7 +814,7 @@ export interface LambdaAction {
 
 export namespace LambdaAction {
   export function isa(o: any): o is LambdaAction {
-    return _smithy.isa(o, "LambdaAction");
+    return __isa(o, "LambdaAction");
   }
 }
 
@@ -835,7 +838,7 @@ export interface ListDetectorModelVersionsRequest {
 
 export namespace ListDetectorModelVersionsRequest {
   export function isa(o: any): o is ListDetectorModelVersionsRequest {
-    return _smithy.isa(o, "ListDetectorModelVersionsRequest");
+    return __isa(o, "ListDetectorModelVersionsRequest");
   }
 }
 
@@ -855,7 +858,7 @@ export interface ListDetectorModelVersionsResponse extends $MetadataBearer {
 
 export namespace ListDetectorModelVersionsResponse {
   export function isa(o: any): o is ListDetectorModelVersionsResponse {
-    return _smithy.isa(o, "ListDetectorModelVersionsResponse");
+    return __isa(o, "ListDetectorModelVersionsResponse");
   }
 }
 
@@ -874,7 +877,7 @@ export interface ListDetectorModelsRequest {
 
 export namespace ListDetectorModelsRequest {
   export function isa(o: any): o is ListDetectorModelsRequest {
-    return _smithy.isa(o, "ListDetectorModelsRequest");
+    return __isa(o, "ListDetectorModelsRequest");
   }
 }
 
@@ -894,7 +897,7 @@ export interface ListDetectorModelsResponse extends $MetadataBearer {
 
 export namespace ListDetectorModelsResponse {
   export function isa(o: any): o is ListDetectorModelsResponse {
-    return _smithy.isa(o, "ListDetectorModelsResponse");
+    return __isa(o, "ListDetectorModelsResponse");
   }
 }
 
@@ -913,7 +916,7 @@ export interface ListInputsRequest {
 
 export namespace ListInputsRequest {
   export function isa(o: any): o is ListInputsRequest {
-    return _smithy.isa(o, "ListInputsRequest");
+    return __isa(o, "ListInputsRequest");
   }
 }
 
@@ -933,7 +936,7 @@ export interface ListInputsResponse extends $MetadataBearer {
 
 export namespace ListInputsResponse {
   export function isa(o: any): o is ListInputsResponse {
-    return _smithy.isa(o, "ListInputsResponse");
+    return __isa(o, "ListInputsResponse");
   }
 }
 
@@ -947,7 +950,7 @@ export interface ListTagsForResourceRequest {
 
 export namespace ListTagsForResourceRequest {
   export function isa(o: any): o is ListTagsForResourceRequest {
-    return _smithy.isa(o, "ListTagsForResourceRequest");
+    return __isa(o, "ListTagsForResourceRequest");
   }
 }
 
@@ -961,7 +964,7 @@ export interface ListTagsForResourceResponse extends $MetadataBearer {
 
 export namespace ListTagsForResourceResponse {
   export function isa(o: any): o is ListTagsForResourceResponse {
-    return _smithy.isa(o, "ListTagsForResourceResponse");
+    return __isa(o, "ListTagsForResourceResponse");
   }
 }
 
@@ -1000,7 +1003,7 @@ export interface LoggingOptions {
 
 export namespace LoggingOptions {
   export function isa(o: any): o is LoggingOptions {
-    return _smithy.isa(o, "LoggingOptions");
+    return __isa(o, "LoggingOptions");
   }
 }
 
@@ -1019,7 +1022,7 @@ export interface OnEnterLifecycle {
 
 export namespace OnEnterLifecycle {
   export function isa(o: any): o is OnEnterLifecycle {
-    return _smithy.isa(o, "OnEnterLifecycle");
+    return __isa(o, "OnEnterLifecycle");
   }
 }
 
@@ -1038,7 +1041,7 @@ export interface OnExitLifecycle {
 
 export namespace OnExitLifecycle {
   export function isa(o: any): o is OnExitLifecycle {
-    return _smithy.isa(o, "OnExitLifecycle");
+    return __isa(o, "OnExitLifecycle");
   }
 }
 
@@ -1061,7 +1064,7 @@ export interface OnInputLifecycle {
 
 export namespace OnInputLifecycle {
   export function isa(o: any): o is OnInputLifecycle {
-    return _smithy.isa(o, "OnInputLifecycle");
+    return __isa(o, "OnInputLifecycle");
   }
 }
 
@@ -1075,7 +1078,7 @@ export interface PutLoggingOptionsRequest {
 
 export namespace PutLoggingOptionsRequest {
   export function isa(o: any): o is PutLoggingOptionsRequest {
-    return _smithy.isa(o, "PutLoggingOptionsRequest");
+    return __isa(o, "PutLoggingOptionsRequest");
   }
 }
 
@@ -1092,7 +1095,7 @@ export interface ResetTimerAction {
 
 export namespace ResetTimerAction {
   export function isa(o: any): o is ResetTimerAction {
-    return _smithy.isa(o, "ResetTimerAction");
+    return __isa(o, "ResetTimerAction");
   }
 }
 
@@ -1109,7 +1112,7 @@ export interface SNSTopicPublishAction {
 
 export namespace SNSTopicPublishAction {
   export function isa(o: any): o is SNSTopicPublishAction {
-    return _smithy.isa(o, "SNSTopicPublishAction");
+    return __isa(o, "SNSTopicPublishAction");
   }
 }
 
@@ -1131,7 +1134,7 @@ export interface SetTimerAction {
 
 export namespace SetTimerAction {
   export function isa(o: any): o is SetTimerAction {
-    return _smithy.isa(o, "SetTimerAction");
+    return __isa(o, "SetTimerAction");
   }
 }
 
@@ -1153,7 +1156,7 @@ export interface SetVariableAction {
 
 export namespace SetVariableAction {
   export function isa(o: any): o is SetVariableAction {
-    return _smithy.isa(o, "SetVariableAction");
+    return __isa(o, "SetVariableAction");
   }
 }
 
@@ -1177,7 +1180,7 @@ export interface SqsAction {
 
 export namespace SqsAction {
   export function isa(o: any): o is SqsAction {
-    return _smithy.isa(o, "SqsAction");
+    return __isa(o, "SqsAction");
   }
 }
 
@@ -1212,7 +1215,7 @@ export interface State {
 
 export namespace State {
   export function isa(o: any): o is State {
-    return _smithy.isa(o, "State");
+    return __isa(o, "State");
   }
 }
 
@@ -1234,7 +1237,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -1253,7 +1256,7 @@ export interface TagResourceRequest {
 
 export namespace TagResourceRequest {
   export function isa(o: any): o is TagResourceRequest {
-    return _smithy.isa(o, "TagResourceRequest");
+    return __isa(o, "TagResourceRequest");
   }
 }
 
@@ -1263,7 +1266,7 @@ export interface TagResourceResponse extends $MetadataBearer {
 
 export namespace TagResourceResponse {
   export function isa(o: any): o is TagResourceResponse {
-    return _smithy.isa(o, "TagResourceResponse");
+    return __isa(o, "TagResourceResponse");
   }
 }
 
@@ -1297,7 +1300,7 @@ export interface TransitionEvent {
 
 export namespace TransitionEvent {
   export function isa(o: any): o is TransitionEvent {
-    return _smithy.isa(o, "TransitionEvent");
+    return __isa(o, "TransitionEvent");
   }
 }
 
@@ -1316,7 +1319,7 @@ export interface UntagResourceRequest {
 
 export namespace UntagResourceRequest {
   export function isa(o: any): o is UntagResourceRequest {
-    return _smithy.isa(o, "UntagResourceRequest");
+    return __isa(o, "UntagResourceRequest");
   }
 }
 
@@ -1326,7 +1329,7 @@ export interface UntagResourceResponse extends $MetadataBearer {
 
 export namespace UntagResourceResponse {
   export function isa(o: any): o is UntagResourceResponse {
-    return _smithy.isa(o, "UntagResourceResponse");
+    return __isa(o, "UntagResourceResponse");
   }
 }
 
@@ -1361,7 +1364,7 @@ export interface UpdateDetectorModelRequest {
 
 export namespace UpdateDetectorModelRequest {
   export function isa(o: any): o is UpdateDetectorModelRequest {
-    return _smithy.isa(o, "UpdateDetectorModelRequest");
+    return __isa(o, "UpdateDetectorModelRequest");
   }
 }
 
@@ -1375,7 +1378,7 @@ export interface UpdateDetectorModelResponse extends $MetadataBearer {
 
 export namespace UpdateDetectorModelResponse {
   export function isa(o: any): o is UpdateDetectorModelResponse {
-    return _smithy.isa(o, "UpdateDetectorModelResponse");
+    return __isa(o, "UpdateDetectorModelResponse");
   }
 }
 
@@ -1399,7 +1402,7 @@ export interface UpdateInputRequest {
 
 export namespace UpdateInputRequest {
   export function isa(o: any): o is UpdateInputRequest {
-    return _smithy.isa(o, "UpdateInputRequest");
+    return __isa(o, "UpdateInputRequest");
   }
 }
 
@@ -1413,7 +1416,7 @@ export interface UpdateInputResponse extends $MetadataBearer {
 
 export namespace UpdateInputResponse {
   export function isa(o: any): o is UpdateInputResponse {
-    return _smithy.isa(o, "UpdateInputResponse");
+    return __isa(o, "UpdateInputResponse");
   }
 }
 
@@ -1421,7 +1424,7 @@ export namespace UpdateInputResponse {
  * <p>An internal failure occurred.</p>
  */
 export interface InternalFailureException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalFailureException";
   $fault: "server";
@@ -1433,7 +1436,7 @@ export interface InternalFailureException
 
 export namespace InternalFailureException {
   export function isa(o: any): o is InternalFailureException {
-    return _smithy.isa(o, "InternalFailureException");
+    return __isa(o, "InternalFailureException");
   }
 }
 
@@ -1441,7 +1444,7 @@ export namespace InternalFailureException {
  * <p>The request was invalid.</p>
  */
 export interface InvalidRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidRequestException";
   $fault: "client";
@@ -1453,7 +1456,7 @@ export interface InvalidRequestException
 
 export namespace InvalidRequestException {
   export function isa(o: any): o is InvalidRequestException {
-    return _smithy.isa(o, "InvalidRequestException");
+    return __isa(o, "InvalidRequestException");
   }
 }
 
@@ -1461,7 +1464,7 @@ export namespace InvalidRequestException {
  * <p>A limit was exceeded.</p>
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -1473,7 +1476,7 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
@@ -1481,7 +1484,7 @@ export namespace LimitExceededException {
  * <p>The resource already exists.</p>
  */
 export interface ResourceAlreadyExistsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceAlreadyExistsException";
   $fault: "client";
@@ -1503,7 +1506,7 @@ export interface ResourceAlreadyExistsException
 
 export namespace ResourceAlreadyExistsException {
   export function isa(o: any): o is ResourceAlreadyExistsException {
-    return _smithy.isa(o, "ResourceAlreadyExistsException");
+    return __isa(o, "ResourceAlreadyExistsException");
   }
 }
 
@@ -1511,7 +1514,7 @@ export namespace ResourceAlreadyExistsException {
  * <p>The resource is in use.</p>
  */
 export interface ResourceInUseException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceInUseException";
   $fault: "client";
@@ -1523,7 +1526,7 @@ export interface ResourceInUseException
 
 export namespace ResourceInUseException {
   export function isa(o: any): o is ResourceInUseException {
-    return _smithy.isa(o, "ResourceInUseException");
+    return __isa(o, "ResourceInUseException");
   }
 }
 
@@ -1531,7 +1534,7 @@ export namespace ResourceInUseException {
  * <p>The resource was not found.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -1543,7 +1546,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -1551,7 +1554,7 @@ export namespace ResourceNotFoundException {
  * <p>The service is currently unavailable.</p>
  */
 export interface ServiceUnavailableException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ServiceUnavailableException";
   $fault: "server";
@@ -1563,7 +1566,7 @@ export interface ServiceUnavailableException
 
 export namespace ServiceUnavailableException {
   export function isa(o: any): o is ServiceUnavailableException {
-    return _smithy.isa(o, "ServiceUnavailableException");
+    return __isa(o, "ServiceUnavailableException");
   }
 }
 
@@ -1571,7 +1574,7 @@ export namespace ServiceUnavailableException {
  * <p>The request could not be completed due to throttling.</p>
  */
 export interface ThrottlingException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ThrottlingException";
   $fault: "client";
@@ -1583,7 +1586,7 @@ export interface ThrottlingException
 
 export namespace ThrottlingException {
   export function isa(o: any): o is ThrottlingException {
-    return _smithy.isa(o, "ThrottlingException");
+    return __isa(o, "ThrottlingException");
   }
 }
 
@@ -1591,7 +1594,7 @@ export namespace ThrottlingException {
  * <p>The requested operation is not supported.</p>
  */
 export interface UnsupportedOperationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UnsupportedOperationException";
   $fault: "server";
@@ -1603,6 +1606,6 @@ export interface UnsupportedOperationException
 
 export namespace UnsupportedOperationException {
   export function isa(o: any): o is UnsupportedOperationException {
-    return _smithy.isa(o, "UnsupportedOperationException");
+    return __isa(o, "UnsupportedOperationException");
   }
 }

--- a/clients/client-iot-events/protocols/Aws_restJson1_1.ts
+++ b/clients/client-iot-events/protocols/Aws_restJson1_1.ts
@@ -107,7 +107,10 @@ import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  extendedEncodeURIComponent as __extendedEncodeURIComponent
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -204,7 +207,7 @@ export async function serializeAws_restJson1_1DeleteDetectorModelCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/detector-models/{detectorModelName}";
   if (input.detectorModelName !== undefined) {
-    const labelValue: string = input.detectorModelName.toString();
+    const labelValue: string = input.detectorModelName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: detectorModelName."
@@ -212,7 +215,7 @@ export async function serializeAws_restJson1_1DeleteDetectorModelCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{detectorModelName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -236,13 +239,13 @@ export async function serializeAws_restJson1_1DeleteInputCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/inputs/{inputName}";
   if (input.inputName !== undefined) {
-    const labelValue: string = input.inputName.toString();
+    const labelValue: string = input.inputName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: inputName.");
     }
     resolvedPath = resolvedPath.replace(
       "{inputName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: inputName.");
@@ -264,7 +267,7 @@ export async function serializeAws_restJson1_1DescribeDetectorModelCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/detector-models/{detectorModelName}";
   if (input.detectorModelName !== undefined) {
-    const labelValue: string = input.detectorModelName.toString();
+    const labelValue: string = input.detectorModelName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: detectorModelName."
@@ -272,7 +275,7 @@ export async function serializeAws_restJson1_1DescribeDetectorModelCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{detectorModelName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -281,7 +284,9 @@ export async function serializeAws_restJson1_1DescribeDetectorModelCommand(
   }
   const query: any = {};
   if (input.detectorModelVersion !== undefined) {
-    query["version"] = input.detectorModelVersion.toString();
+    query[
+      __extendedEncodeURIComponent("version")
+    ] = __extendedEncodeURIComponent(input.detectorModelVersion);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -301,13 +306,13 @@ export async function serializeAws_restJson1_1DescribeInputCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/inputs/{inputName}";
   if (input.inputName !== undefined) {
-    const labelValue: string = input.inputName.toString();
+    const labelValue: string = input.inputName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: inputName.");
     }
     resolvedPath = resolvedPath.replace(
       "{inputName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: inputName.");
@@ -345,7 +350,7 @@ export async function serializeAws_restJson1_1ListDetectorModelVersionsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/detector-models/{detectorModelName}/versions";
   if (input.detectorModelName !== undefined) {
-    const labelValue: string = input.detectorModelName.toString();
+    const labelValue: string = input.detectorModelName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: detectorModelName."
@@ -353,7 +358,7 @@ export async function serializeAws_restJson1_1ListDetectorModelVersionsCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{detectorModelName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -362,10 +367,14 @@ export async function serializeAws_restJson1_1ListDetectorModelVersionsCommand(
   }
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -386,10 +395,14 @@ export async function serializeAws_restJson1_1ListDetectorModelsCommand(
   let resolvedPath = "/detector-models";
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -410,10 +423,14 @@ export async function serializeAws_restJson1_1ListInputsCommand(
   let resolvedPath = "/inputs";
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -434,7 +451,9 @@ export async function serializeAws_restJson1_1ListTagsForResourceCommand(
   let resolvedPath = "/tags";
   const query: any = {};
   if (input.resourceArn !== undefined) {
-    query["resourceArn"] = input.resourceArn.toString();
+    query[
+      __extendedEncodeURIComponent("resourceArn")
+    ] = __extendedEncodeURIComponent(input.resourceArn);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -481,7 +500,9 @@ export async function serializeAws_restJson1_1TagResourceCommand(
   let resolvedPath = "/tags";
   const query: any = {};
   if (input.resourceArn !== undefined) {
-    query["resourceArn"] = input.resourceArn.toString();
+    query[
+      __extendedEncodeURIComponent("resourceArn")
+    ] = __extendedEncodeURIComponent(input.resourceArn);
   }
   let body: any;
   const bodyParams: any = {};
@@ -509,10 +530,14 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
   let resolvedPath = "/tags";
   const query: any = {};
   if (input.resourceArn !== undefined) {
-    query["resourceArn"] = input.resourceArn.toString();
+    query[
+      __extendedEncodeURIComponent("resourceArn")
+    ] = __extendedEncodeURIComponent(input.resourceArn);
   }
   if (input.tagKeys !== undefined) {
-    query["tagKeys"] = input.tagKeys;
+    query[__extendedEncodeURIComponent("tagKeys")] = input.tagKeys.map(entry =>
+      __extendedEncodeURIComponent(entry)
+    );
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -532,7 +557,7 @@ export async function serializeAws_restJson1_1UpdateDetectorModelCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/detector-models/{detectorModelName}";
   if (input.detectorModelName !== undefined) {
-    const labelValue: string = input.detectorModelName.toString();
+    const labelValue: string = input.detectorModelName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: detectorModelName."
@@ -540,7 +565,7 @@ export async function serializeAws_restJson1_1UpdateDetectorModelCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{detectorModelName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -585,13 +610,13 @@ export async function serializeAws_restJson1_1UpdateInputCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/inputs/{inputName}";
   if (input.inputName !== undefined) {
-    const labelValue: string = input.inputName.toString();
+    const labelValue: string = input.inputName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: inputName.");
     }
     resolvedPath = resolvedPath.replace(
       "{inputName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: inputName.");
@@ -823,6 +848,7 @@ export async function deserializeAws_restJson1_1DeleteDetectorModelCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeleteDetectorModelResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -906,6 +932,7 @@ export async function deserializeAws_restJson1_1DeleteInputCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeleteInputResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -1599,6 +1626,7 @@ export async function deserializeAws_restJson1_1PutLoggingOptionsCommand(
   const contents: PutLoggingOptionsCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -1682,6 +1710,7 @@ export async function deserializeAws_restJson1_1TagResourceCommand(
     $metadata: deserializeMetadata(output),
     __type: "TagResourceResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -1765,6 +1794,7 @@ export async function deserializeAws_restJson1_1UntagResourceCommand(
     $metadata: deserializeMetadata(output),
     __type: "UntagResourceResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 

--- a/clients/client-iot-jobs-data-plane/models/index.ts
+++ b/clients/client-iot-jobs-data-plane/models/index.ts
@@ -1,11 +1,14 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
  * <p>The certificate is invalid.</p>
  */
 export interface CertificateValidationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CertificateValidationException";
   $fault: "client";
@@ -17,7 +20,7 @@ export interface CertificateValidationException
 
 export namespace CertificateValidationException {
   export function isa(o: any): o is CertificateValidationException {
-    return _smithy.isa(o, "CertificateValidationException");
+    return __isa(o, "CertificateValidationException");
   }
 }
 
@@ -25,7 +28,7 @@ export namespace CertificateValidationException {
  * <p>The contents of the request were invalid. For example, this code is returned when an UpdateJobExecution request contains invalid status details. The message contains details about the error.</p>
  */
 export interface InvalidRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidRequestException";
   $fault: "client";
@@ -37,7 +40,7 @@ export interface InvalidRequestException
 
 export namespace InvalidRequestException {
   export function isa(o: any): o is InvalidRequestException {
-    return _smithy.isa(o, "InvalidRequestException");
+    return __isa(o, "InvalidRequestException");
   }
 }
 
@@ -47,7 +50,7 @@ export namespace InvalidRequestException {
  *          case, the body of the error message also contains the executionState field.</p>
  */
 export interface InvalidStateTransitionException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidStateTransitionException";
   $fault: "client";
@@ -56,7 +59,7 @@ export interface InvalidStateTransitionException
 
 export namespace InvalidStateTransitionException {
   export function isa(o: any): o is InvalidStateTransitionException {
-    return _smithy.isa(o, "InvalidStateTransitionException");
+    return __isa(o, "InvalidStateTransitionException");
   }
 }
 
@@ -64,7 +67,7 @@ export namespace InvalidStateTransitionException {
  * <p>The specified resource does not exist.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -76,7 +79,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -84,7 +87,7 @@ export namespace ResourceNotFoundException {
  * <p>The service is temporarily unavailable.</p>
  */
 export interface ServiceUnavailableException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ServiceUnavailableException";
   $fault: "server";
@@ -96,7 +99,7 @@ export interface ServiceUnavailableException
 
 export namespace ServiceUnavailableException {
   export function isa(o: any): o is ServiceUnavailableException {
-    return _smithy.isa(o, "ServiceUnavailableException");
+    return __isa(o, "ServiceUnavailableException");
   }
 }
 
@@ -104,7 +107,7 @@ export namespace ServiceUnavailableException {
  * <p>The job is in a terminal state.</p>
  */
 export interface TerminalStateException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TerminalStateException";
   $fault: "client";
@@ -113,7 +116,7 @@ export interface TerminalStateException
 
 export namespace TerminalStateException {
   export function isa(o: any): o is TerminalStateException {
-    return _smithy.isa(o, "TerminalStateException");
+    return __isa(o, "TerminalStateException");
   }
 }
 
@@ -132,7 +135,7 @@ export enum JobExecutionStatus {
  * <p>The rate exceeds the limit.</p>
  */
 export interface ThrottlingException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ThrottlingException";
   $fault: "client";
@@ -149,7 +152,7 @@ export interface ThrottlingException
 
 export namespace ThrottlingException {
   export function isa(o: any): o is ThrottlingException {
-    return _smithy.isa(o, "ThrottlingException");
+    return __isa(o, "ThrottlingException");
   }
 }
 
@@ -179,7 +182,7 @@ export interface DescribeJobExecutionRequest {
 
 export namespace DescribeJobExecutionRequest {
   export function isa(o: any): o is DescribeJobExecutionRequest {
-    return _smithy.isa(o, "DescribeJobExecutionRequest");
+    return __isa(o, "DescribeJobExecutionRequest");
   }
 }
 
@@ -193,7 +196,7 @@ export interface DescribeJobExecutionResponse extends $MetadataBearer {
 
 export namespace DescribeJobExecutionResponse {
   export function isa(o: any): o is DescribeJobExecutionResponse {
-    return _smithy.isa(o, "DescribeJobExecutionResponse");
+    return __isa(o, "DescribeJobExecutionResponse");
   }
 }
 
@@ -207,7 +210,7 @@ export interface GetPendingJobExecutionsRequest {
 
 export namespace GetPendingJobExecutionsRequest {
   export function isa(o: any): o is GetPendingJobExecutionsRequest {
-    return _smithy.isa(o, "GetPendingJobExecutionsRequest");
+    return __isa(o, "GetPendingJobExecutionsRequest");
   }
 }
 
@@ -226,7 +229,7 @@ export interface GetPendingJobExecutionsResponse extends $MetadataBearer {
 
 export namespace GetPendingJobExecutionsResponse {
   export function isa(o: any): o is GetPendingJobExecutionsResponse {
-    return _smithy.isa(o, "GetPendingJobExecutionsResponse");
+    return __isa(o, "GetPendingJobExecutionsResponse");
   }
 }
 
@@ -297,7 +300,7 @@ export interface JobExecution {
 
 export namespace JobExecution {
   export function isa(o: any): o is JobExecution {
-    return _smithy.isa(o, "JobExecution");
+    return __isa(o, "JobExecution");
   }
 }
 
@@ -326,7 +329,7 @@ export interface JobExecutionState {
 
 export namespace JobExecutionState {
   export function isa(o: any): o is JobExecutionState {
-    return _smithy.isa(o, "JobExecutionState");
+    return __isa(o, "JobExecutionState");
   }
 }
 
@@ -369,7 +372,7 @@ export interface JobExecutionSummary {
 
 export namespace JobExecutionSummary {
   export function isa(o: any): o is JobExecutionSummary {
-    return _smithy.isa(o, "JobExecutionSummary");
+    return __isa(o, "JobExecutionSummary");
   }
 }
 
@@ -400,7 +403,7 @@ export interface StartNextPendingJobExecutionRequest {
 
 export namespace StartNextPendingJobExecutionRequest {
   export function isa(o: any): o is StartNextPendingJobExecutionRequest {
-    return _smithy.isa(o, "StartNextPendingJobExecutionRequest");
+    return __isa(o, "StartNextPendingJobExecutionRequest");
   }
 }
 
@@ -414,7 +417,7 @@ export interface StartNextPendingJobExecutionResponse extends $MetadataBearer {
 
 export namespace StartNextPendingJobExecutionResponse {
   export function isa(o: any): o is StartNextPendingJobExecutionResponse {
-    return _smithy.isa(o, "StartNextPendingJobExecutionResponse");
+    return __isa(o, "StartNextPendingJobExecutionResponse");
   }
 }
 
@@ -481,7 +484,7 @@ export interface UpdateJobExecutionRequest {
 
 export namespace UpdateJobExecutionRequest {
   export function isa(o: any): o is UpdateJobExecutionRequest {
-    return _smithy.isa(o, "UpdateJobExecutionRequest");
+    return __isa(o, "UpdateJobExecutionRequest");
   }
 }
 
@@ -500,6 +503,6 @@ export interface UpdateJobExecutionResponse extends $MetadataBearer {
 
 export namespace UpdateJobExecutionResponse {
   export function isa(o: any): o is UpdateJobExecutionResponse {
-    return _smithy.isa(o, "UpdateJobExecutionResponse");
+    return __isa(o, "UpdateJobExecutionResponse");
   }
 }

--- a/clients/client-iot-jobs-data-plane/protocols/Aws_restJson1_1.ts
+++ b/clients/client-iot-jobs-data-plane/protocols/Aws_restJson1_1.ts
@@ -30,7 +30,10 @@ import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  extendedEncodeURIComponent as __extendedEncodeURIComponent
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -46,35 +49,39 @@ export async function serializeAws_restJson1_1DescribeJobExecutionCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/things/{thingName}/jobs/{jobId}";
   if (input.jobId !== undefined) {
-    const labelValue: string = input.jobId.toString();
+    const labelValue: string = input.jobId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: jobId.");
     }
     resolvedPath = resolvedPath.replace(
       "{jobId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: jobId.");
   }
   if (input.thingName !== undefined) {
-    const labelValue: string = input.thingName.toString();
+    const labelValue: string = input.thingName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: thingName.");
     }
     resolvedPath = resolvedPath.replace(
       "{thingName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: thingName.");
   }
   const query: any = {};
   if (input.executionNumber !== undefined) {
-    query["executionNumber"] = input.executionNumber.toString();
+    query[
+      __extendedEncodeURIComponent("executionNumber")
+    ] = __extendedEncodeURIComponent(input.executionNumber.toString());
   }
   if (input.includeJobDocument !== undefined) {
-    query["includeJobDocument"] = input.includeJobDocument.toString();
+    query[
+      __extendedEncodeURIComponent("includeJobDocument")
+    ] = __extendedEncodeURIComponent(input.includeJobDocument.toString());
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -94,13 +101,13 @@ export async function serializeAws_restJson1_1GetPendingJobExecutionsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/things/{thingName}/jobs";
   if (input.thingName !== undefined) {
-    const labelValue: string = input.thingName.toString();
+    const labelValue: string = input.thingName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: thingName.");
     }
     resolvedPath = resolvedPath.replace(
       "{thingName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: thingName.");
@@ -122,13 +129,13 @@ export async function serializeAws_restJson1_1StartNextPendingJobExecutionComman
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/things/{thingName}/jobs/$next";
   if (input.thingName !== undefined) {
-    const labelValue: string = input.thingName.toString();
+    const labelValue: string = input.thingName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: thingName.");
     }
     resolvedPath = resolvedPath.replace(
       "{thingName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: thingName.");
@@ -163,25 +170,25 @@ export async function serializeAws_restJson1_1UpdateJobExecutionCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/things/{thingName}/jobs/{jobId}";
   if (input.jobId !== undefined) {
-    const labelValue: string = input.jobId.toString();
+    const labelValue: string = input.jobId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: jobId.");
     }
     resolvedPath = resolvedPath.replace(
       "{jobId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: jobId.");
   }
   if (input.thingName !== undefined) {
-    const labelValue: string = input.thingName.toString();
+    const labelValue: string = input.thingName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: thingName.");
     }
     resolvedPath = resolvedPath.replace(
       "{thingName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: thingName.");

--- a/clients/client-iot/models/index.ts
+++ b/clients/client-iot/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -7,7 +10,7 @@ import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
  *          certificate that has the same subject field and public key.</p>
  */
 export interface CertificateConflictException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CertificateConflictException";
   $fault: "client";
@@ -19,7 +22,7 @@ export interface CertificateConflictException
 
 export namespace CertificateConflictException {
   export function isa(o: any): o is CertificateConflictException {
-    return _smithy.isa(o, "CertificateConflictException");
+    return __isa(o, "CertificateConflictException");
   }
 }
 
@@ -27,7 +30,7 @@ export namespace CertificateConflictException {
  * <p>The certificate operation is not allowed.</p>
  */
 export interface CertificateStateException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CertificateStateException";
   $fault: "client";
@@ -39,7 +42,7 @@ export interface CertificateStateException
 
 export namespace CertificateStateException {
   export function isa(o: any): o is CertificateStateException {
-    return _smithy.isa(o, "CertificateStateException");
+    return __isa(o, "CertificateStateException");
   }
 }
 
@@ -47,7 +50,7 @@ export namespace CertificateStateException {
  * <p>The certificate is invalid.</p>
  */
 export interface CertificateValidationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CertificateValidationException";
   $fault: "client";
@@ -59,7 +62,7 @@ export interface CertificateValidationException
 
 export namespace CertificateValidationException {
   export function isa(o: any): o is CertificateValidationException {
-    return _smithy.isa(o, "CertificateValidationException");
+    return __isa(o, "CertificateValidationException");
   }
 }
 
@@ -76,7 +79,7 @@ export interface Configuration {
 
 export namespace Configuration {
   export function isa(o: any): o is Configuration {
-    return _smithy.isa(o, "Configuration");
+    return __isa(o, "Configuration");
   }
 }
 
@@ -85,7 +88,7 @@ export namespace Configuration {
  *          updates cause a conflict.</p>
  */
 export interface ConflictingResourceUpdateException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ConflictingResourceUpdateException";
   $fault: "client";
@@ -97,7 +100,7 @@ export interface ConflictingResourceUpdateException
 
 export namespace ConflictingResourceUpdateException {
   export function isa(o: any): o is ConflictingResourceUpdateException {
-    return _smithy.isa(o, "ConflictingResourceUpdateException");
+    return __isa(o, "ConflictingResourceUpdateException");
   }
 }
 
@@ -106,7 +109,7 @@ export namespace ConflictingResourceUpdateException {
  *          resources.</p>
  */
 export interface DeleteConflictException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DeleteConflictException";
   $fault: "client";
@@ -118,7 +121,7 @@ export interface DeleteConflictException
 
 export namespace DeleteConflictException {
   export function isa(o: any): o is DeleteConflictException {
-    return _smithy.isa(o, "DeleteConflictException");
+    return __isa(o, "DeleteConflictException");
   }
 }
 
@@ -139,9 +142,7 @@ export enum EventType {
 /**
  * <p>An unexpected error has occurred.</p>
  */
-export interface InternalException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface InternalException extends __SmithyException, $MetadataBearer {
   name: "InternalException";
   $fault: "server";
   /**
@@ -152,7 +153,7 @@ export interface InternalException
 
 export namespace InternalException {
   export function isa(o: any): o is InternalException {
-    return _smithy.isa(o, "InternalException");
+    return __isa(o, "InternalException");
   }
 }
 
@@ -160,7 +161,7 @@ export namespace InternalException {
  * <p>An unexpected error has occurred.</p>
  */
 export interface InternalFailureException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalFailureException";
   $fault: "server";
@@ -172,7 +173,7 @@ export interface InternalFailureException
 
 export namespace InternalFailureException {
   export function isa(o: any): o is InternalFailureException {
-    return _smithy.isa(o, "InternalFailureException");
+    return __isa(o, "InternalFailureException");
   }
 }
 
@@ -180,7 +181,7 @@ export namespace InternalFailureException {
  * <p>The aggregation is invalid.</p>
  */
 export interface InvalidAggregationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidAggregationException";
   $fault: "client";
@@ -189,7 +190,7 @@ export interface InvalidAggregationException
 
 export namespace InvalidAggregationException {
   export function isa(o: any): o is InvalidAggregationException {
-    return _smithy.isa(o, "InvalidAggregationException");
+    return __isa(o, "InvalidAggregationException");
   }
 }
 
@@ -197,7 +198,7 @@ export namespace InvalidAggregationException {
  * <p>The query is invalid.</p>
  */
 export interface InvalidQueryException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidQueryException";
   $fault: "client";
@@ -209,7 +210,7 @@ export interface InvalidQueryException
 
 export namespace InvalidQueryException {
   export function isa(o: any): o is InvalidQueryException {
-    return _smithy.isa(o, "InvalidQueryException");
+    return __isa(o, "InvalidQueryException");
   }
 }
 
@@ -217,7 +218,7 @@ export namespace InvalidQueryException {
  * <p>The request is not valid.</p>
  */
 export interface InvalidRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidRequestException";
   $fault: "client";
@@ -229,7 +230,7 @@ export interface InvalidRequestException
 
 export namespace InvalidRequestException {
   export function isa(o: any): o is InvalidRequestException {
-    return _smithy.isa(o, "InvalidRequestException");
+    return __isa(o, "InvalidRequestException");
   }
 }
 
@@ -237,7 +238,7 @@ export namespace InvalidRequestException {
  * <p>The response is invalid.</p>
  */
 export interface InvalidResponseException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidResponseException";
   $fault: "client";
@@ -249,7 +250,7 @@ export interface InvalidResponseException
 
 export namespace InvalidResponseException {
   export function isa(o: any): o is InvalidResponseException {
-    return _smithy.isa(o, "InvalidResponseException");
+    return __isa(o, "InvalidResponseException");
   }
 }
 
@@ -259,7 +260,7 @@ export namespace InvalidResponseException {
  *          parameter.</p>
  */
 export interface InvalidStateTransitionException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidStateTransitionException";
   $fault: "client";
@@ -271,7 +272,7 @@ export interface InvalidStateTransitionException
 
 export namespace InvalidStateTransitionException {
   export function isa(o: any): o is InvalidStateTransitionException {
-    return _smithy.isa(o, "InvalidStateTransitionException");
+    return __isa(o, "InvalidStateTransitionException");
   }
 }
 
@@ -279,7 +280,7 @@ export namespace InvalidStateTransitionException {
  * <p>A limit has been exceeded.</p>
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -291,7 +292,7 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
@@ -307,7 +308,7 @@ export enum LogLevel {
  * <p>The policy documentation is not valid.</p>
  */
 export interface MalformedPolicyException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "MalformedPolicyException";
   $fault: "client";
@@ -319,7 +320,7 @@ export interface MalformedPolicyException
 
 export namespace MalformedPolicyException {
   export function isa(o: any): o is MalformedPolicyException {
-    return _smithy.isa(o, "MalformedPolicyException");
+    return __isa(o, "MalformedPolicyException");
   }
 }
 
@@ -327,7 +328,7 @@ export namespace MalformedPolicyException {
  * <p>The resource is not configured.</p>
  */
 export interface NotConfiguredException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "NotConfiguredException";
   $fault: "client";
@@ -339,7 +340,7 @@ export interface NotConfiguredException
 
 export namespace NotConfiguredException {
   export function isa(o: any): o is NotConfiguredException {
-    return _smithy.isa(o, "NotConfiguredException");
+    return __isa(o, "NotConfiguredException");
   }
 }
 
@@ -352,7 +353,7 @@ export enum Protocol {
  * <p>The registration code is invalid.</p>
  */
 export interface RegistrationCodeValidationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "RegistrationCodeValidationException";
   $fault: "client";
@@ -364,7 +365,7 @@ export interface RegistrationCodeValidationException
 
 export namespace RegistrationCodeValidationException {
   export function isa(o: any): o is RegistrationCodeValidationException {
-    return _smithy.isa(o, "RegistrationCodeValidationException");
+    return __isa(o, "RegistrationCodeValidationException");
   }
 }
 
@@ -372,7 +373,7 @@ export namespace RegistrationCodeValidationException {
  * <p>The resource already exists.</p>
  */
 export interface ResourceAlreadyExistsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceAlreadyExistsException";
   $fault: "client";
@@ -394,7 +395,7 @@ export interface ResourceAlreadyExistsException
 
 export namespace ResourceAlreadyExistsException {
   export function isa(o: any): o is ResourceAlreadyExistsException {
-    return _smithy.isa(o, "ResourceAlreadyExistsException");
+    return __isa(o, "ResourceAlreadyExistsException");
   }
 }
 
@@ -402,7 +403,7 @@ export namespace ResourceAlreadyExistsException {
  * <p>The specified resource does not exist.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -414,7 +415,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -422,7 +423,7 @@ export namespace ResourceNotFoundException {
  * <p>The resource registration failed.</p>
  */
 export interface ResourceRegistrationFailureException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceRegistrationFailureException";
   $fault: "client";
@@ -434,7 +435,7 @@ export interface ResourceRegistrationFailureException
 
 export namespace ResourceRegistrationFailureException {
   export function isa(o: any): o is ResourceRegistrationFailureException {
-    return _smithy.isa(o, "ResourceRegistrationFailureException");
+    return __isa(o, "ResourceRegistrationFailureException");
   }
 }
 
@@ -442,7 +443,7 @@ export namespace ResourceRegistrationFailureException {
  * <p>The service is temporarily unavailable.</p>
  */
 export interface ServiceUnavailableException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ServiceUnavailableException";
   $fault: "server";
@@ -454,16 +455,14 @@ export interface ServiceUnavailableException
 
 export namespace ServiceUnavailableException {
   export function isa(o: any): o is ServiceUnavailableException {
-    return _smithy.isa(o, "ServiceUnavailableException");
+    return __isa(o, "ServiceUnavailableException");
   }
 }
 
 /**
  * <p>The Rule-SQL expression can't be parsed correctly.</p>
  */
-export interface SqlParseException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface SqlParseException extends __SmithyException, $MetadataBearer {
   name: "SqlParseException";
   $fault: "client";
   /**
@@ -474,7 +473,7 @@ export interface SqlParseException
 
 export namespace SqlParseException {
   export function isa(o: any): o is SqlParseException {
-    return _smithy.isa(o, "SqlParseException");
+    return __isa(o, "SqlParseException");
   }
 }
 
@@ -496,7 +495,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -504,7 +503,7 @@ export namespace Tag {
  * <p>The rate exceeds the limit.</p>
  */
 export interface ThrottlingException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ThrottlingException";
   $fault: "client";
@@ -516,7 +515,7 @@ export interface ThrottlingException
 
 export namespace ThrottlingException {
   export function isa(o: any): o is ThrottlingException {
-    return _smithy.isa(o, "ThrottlingException");
+    return __isa(o, "ThrottlingException");
   }
 }
 
@@ -525,7 +524,7 @@ export namespace ThrottlingException {
  *          complete.</p>
  */
 export interface TransferAlreadyCompletedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TransferAlreadyCompletedException";
   $fault: "client";
@@ -537,7 +536,7 @@ export interface TransferAlreadyCompletedException
 
 export namespace TransferAlreadyCompletedException {
   export function isa(o: any): o is TransferAlreadyCompletedException {
-    return _smithy.isa(o, "TransferAlreadyCompletedException");
+    return __isa(o, "TransferAlreadyCompletedException");
   }
 }
 
@@ -546,7 +545,7 @@ export namespace TransferAlreadyCompletedException {
  *          attached.</p>
  */
 export interface TransferConflictException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TransferConflictException";
   $fault: "client";
@@ -558,7 +557,7 @@ export interface TransferConflictException
 
 export namespace TransferConflictException {
   export function isa(o: any): o is TransferConflictException {
-    return _smithy.isa(o, "TransferConflictException");
+    return __isa(o, "TransferConflictException");
   }
 }
 
@@ -566,7 +565,7 @@ export namespace TransferConflictException {
  * <p>You are not authorized to perform this operation.</p>
  */
 export interface UnauthorizedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UnauthorizedException";
   $fault: "client";
@@ -578,7 +577,7 @@ export interface UnauthorizedException
 
 export namespace UnauthorizedException {
   export function isa(o: any): o is UnauthorizedException {
-    return _smithy.isa(o, "UnauthorizedException");
+    return __isa(o, "UnauthorizedException");
   }
 }
 
@@ -588,7 +587,7 @@ export namespace UnauthorizedException {
  *          system.</p>
  */
 export interface VersionConflictException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "VersionConflictException";
   $fault: "client";
@@ -600,7 +599,7 @@ export interface VersionConflictException
 
 export namespace VersionConflictException {
   export function isa(o: any): o is VersionConflictException {
-    return _smithy.isa(o, "VersionConflictException");
+    return __isa(o, "VersionConflictException");
   }
 }
 
@@ -608,7 +607,7 @@ export namespace VersionConflictException {
  * <p>The number of policy versions exceeds the limit.</p>
  */
 export interface VersionsLimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "VersionsLimitExceededException";
   $fault: "client";
@@ -620,7 +619,7 @@ export interface VersionsLimitExceededException
 
 export namespace VersionsLimitExceededException {
   export function isa(o: any): o is VersionsLimitExceededException {
-    return _smithy.isa(o, "VersionsLimitExceededException");
+    return __isa(o, "VersionsLimitExceededException");
   }
 }
 
@@ -725,7 +724,7 @@ export interface Action {
 
 export namespace Action {
   export function isa(o: any): o is Action {
-    return _smithy.isa(o, "Action");
+    return __isa(o, "Action");
   }
 }
 
@@ -749,7 +748,7 @@ export interface AssetPropertyTimestamp {
 
 export namespace AssetPropertyTimestamp {
   export function isa(o: any): o is AssetPropertyTimestamp {
-    return _smithy.isa(o, "AssetPropertyTimestamp");
+    return __isa(o, "AssetPropertyTimestamp");
   }
 }
 
@@ -777,7 +776,7 @@ export interface AssetPropertyValue {
 
 export namespace AssetPropertyValue {
   export function isa(o: any): o is AssetPropertyValue {
-    return _smithy.isa(o, "AssetPropertyValue");
+    return __isa(o, "AssetPropertyValue");
   }
 }
 
@@ -812,7 +811,7 @@ export interface AssetPropertyVariant {
 
 export namespace AssetPropertyVariant {
   export function isa(o: any): o is AssetPropertyVariant {
-    return _smithy.isa(o, "AssetPropertyVariant");
+    return __isa(o, "AssetPropertyVariant");
   }
 }
 
@@ -856,7 +855,7 @@ export interface CloudwatchAlarmAction {
 
 export namespace CloudwatchAlarmAction {
   export function isa(o: any): o is CloudwatchAlarmAction {
-    return _smithy.isa(o, "CloudwatchAlarmAction");
+    return __isa(o, "CloudwatchAlarmAction");
   }
 }
 
@@ -899,7 +898,7 @@ export interface CloudwatchMetricAction {
 
 export namespace CloudwatchMetricAction {
   export function isa(o: any): o is CloudwatchMetricAction {
-    return _smithy.isa(o, "CloudwatchMetricAction");
+    return __isa(o, "CloudwatchMetricAction");
   }
 }
 
@@ -913,7 +912,7 @@ export interface ConfirmTopicRuleDestinationRequest {
 
 export namespace ConfirmTopicRuleDestinationRequest {
   export function isa(o: any): o is ConfirmTopicRuleDestinationRequest {
-    return _smithy.isa(o, "ConfirmTopicRuleDestinationRequest");
+    return __isa(o, "ConfirmTopicRuleDestinationRequest");
   }
 }
 
@@ -923,7 +922,7 @@ export interface ConfirmTopicRuleDestinationResponse extends $MetadataBearer {
 
 export namespace ConfirmTopicRuleDestinationResponse {
   export function isa(o: any): o is ConfirmTopicRuleDestinationResponse {
-    return _smithy.isa(o, "ConfirmTopicRuleDestinationResponse");
+    return __isa(o, "ConfirmTopicRuleDestinationResponse");
   }
 }
 
@@ -937,7 +936,7 @@ export interface CreateTopicRuleDestinationRequest {
 
 export namespace CreateTopicRuleDestinationRequest {
   export function isa(o: any): o is CreateTopicRuleDestinationRequest {
-    return _smithy.isa(o, "CreateTopicRuleDestinationRequest");
+    return __isa(o, "CreateTopicRuleDestinationRequest");
   }
 }
 
@@ -951,7 +950,7 @@ export interface CreateTopicRuleDestinationResponse extends $MetadataBearer {
 
 export namespace CreateTopicRuleDestinationResponse {
   export function isa(o: any): o is CreateTopicRuleDestinationResponse {
-    return _smithy.isa(o, "CreateTopicRuleDestinationResponse");
+    return __isa(o, "CreateTopicRuleDestinationResponse");
   }
 }
 
@@ -985,7 +984,7 @@ export interface CreateTopicRuleRequest {
 
 export namespace CreateTopicRuleRequest {
   export function isa(o: any): o is CreateTopicRuleRequest {
-    return _smithy.isa(o, "CreateTopicRuleRequest");
+    return __isa(o, "CreateTopicRuleRequest");
   }
 }
 
@@ -999,7 +998,7 @@ export interface DeleteTopicRuleDestinationRequest {
 
 export namespace DeleteTopicRuleDestinationRequest {
   export function isa(o: any): o is DeleteTopicRuleDestinationRequest {
-    return _smithy.isa(o, "DeleteTopicRuleDestinationRequest");
+    return __isa(o, "DeleteTopicRuleDestinationRequest");
   }
 }
 
@@ -1009,7 +1008,7 @@ export interface DeleteTopicRuleDestinationResponse extends $MetadataBearer {
 
 export namespace DeleteTopicRuleDestinationResponse {
   export function isa(o: any): o is DeleteTopicRuleDestinationResponse {
-    return _smithy.isa(o, "DeleteTopicRuleDestinationResponse");
+    return __isa(o, "DeleteTopicRuleDestinationResponse");
   }
 }
 
@@ -1026,7 +1025,7 @@ export interface DeleteTopicRuleRequest {
 
 export namespace DeleteTopicRuleRequest {
   export function isa(o: any): o is DeleteTopicRuleRequest {
-    return _smithy.isa(o, "DeleteTopicRuleRequest");
+    return __isa(o, "DeleteTopicRuleRequest");
   }
 }
 
@@ -1046,7 +1045,7 @@ export interface DeleteV2LoggingLevelRequest {
 
 export namespace DeleteV2LoggingLevelRequest {
   export function isa(o: any): o is DeleteV2LoggingLevelRequest {
-    return _smithy.isa(o, "DeleteV2LoggingLevelRequest");
+    return __isa(o, "DeleteV2LoggingLevelRequest");
   }
 }
 
@@ -1063,7 +1062,7 @@ export interface DisableTopicRuleRequest {
 
 export namespace DisableTopicRuleRequest {
   export function isa(o: any): o is DisableTopicRuleRequest {
-    return _smithy.isa(o, "DisableTopicRuleRequest");
+    return __isa(o, "DisableTopicRuleRequest");
   }
 }
 
@@ -1142,7 +1141,7 @@ export interface DynamoDBAction {
 
 export namespace DynamoDBAction {
   export function isa(o: any): o is DynamoDBAction {
-    return _smithy.isa(o, "DynamoDBAction");
+    return __isa(o, "DynamoDBAction");
   }
 }
 
@@ -1173,7 +1172,7 @@ export interface DynamoDBv2Action {
 
 export namespace DynamoDBv2Action {
   export function isa(o: any): o is DynamoDBv2Action {
-    return _smithy.isa(o, "DynamoDBv2Action");
+    return __isa(o, "DynamoDBv2Action");
   }
 }
 
@@ -1216,7 +1215,7 @@ export interface ElasticsearchAction {
 
 export namespace ElasticsearchAction {
   export function isa(o: any): o is ElasticsearchAction {
-    return _smithy.isa(o, "ElasticsearchAction");
+    return __isa(o, "ElasticsearchAction");
   }
 }
 
@@ -1233,7 +1232,7 @@ export interface EnableTopicRuleRequest {
 
 export namespace EnableTopicRuleRequest {
   export function isa(o: any): o is EnableTopicRuleRequest {
-    return _smithy.isa(o, "EnableTopicRuleRequest");
+    return __isa(o, "EnableTopicRuleRequest");
   }
 }
 
@@ -1262,7 +1261,7 @@ export interface FirehoseAction {
 
 export namespace FirehoseAction {
   export function isa(o: any): o is FirehoseAction {
-    return _smithy.isa(o, "FirehoseAction");
+    return __isa(o, "FirehoseAction");
   }
 }
 
@@ -1275,7 +1274,7 @@ export interface GetLoggingOptionsRequest {
 
 export namespace GetLoggingOptionsRequest {
   export function isa(o: any): o is GetLoggingOptionsRequest {
-    return _smithy.isa(o, "GetLoggingOptionsRequest");
+    return __isa(o, "GetLoggingOptionsRequest");
   }
 }
 
@@ -1297,7 +1296,7 @@ export interface GetLoggingOptionsResponse extends $MetadataBearer {
 
 export namespace GetLoggingOptionsResponse {
   export function isa(o: any): o is GetLoggingOptionsResponse {
-    return _smithy.isa(o, "GetLoggingOptionsResponse");
+    return __isa(o, "GetLoggingOptionsResponse");
   }
 }
 
@@ -1311,7 +1310,7 @@ export interface GetTopicRuleDestinationRequest {
 
 export namespace GetTopicRuleDestinationRequest {
   export function isa(o: any): o is GetTopicRuleDestinationRequest {
-    return _smithy.isa(o, "GetTopicRuleDestinationRequest");
+    return __isa(o, "GetTopicRuleDestinationRequest");
   }
 }
 
@@ -1325,7 +1324,7 @@ export interface GetTopicRuleDestinationResponse extends $MetadataBearer {
 
 export namespace GetTopicRuleDestinationResponse {
   export function isa(o: any): o is GetTopicRuleDestinationResponse {
-    return _smithy.isa(o, "GetTopicRuleDestinationResponse");
+    return __isa(o, "GetTopicRuleDestinationResponse");
   }
 }
 
@@ -1342,7 +1341,7 @@ export interface GetTopicRuleRequest {
 
 export namespace GetTopicRuleRequest {
   export function isa(o: any): o is GetTopicRuleRequest {
-    return _smithy.isa(o, "GetTopicRuleRequest");
+    return __isa(o, "GetTopicRuleRequest");
   }
 }
 
@@ -1364,7 +1363,7 @@ export interface GetTopicRuleResponse extends $MetadataBearer {
 
 export namespace GetTopicRuleResponse {
   export function isa(o: any): o is GetTopicRuleResponse {
-    return _smithy.isa(o, "GetTopicRuleResponse");
+    return __isa(o, "GetTopicRuleResponse");
   }
 }
 
@@ -1374,7 +1373,7 @@ export interface GetV2LoggingOptionsRequest {
 
 export namespace GetV2LoggingOptionsRequest {
   export function isa(o: any): o is GetV2LoggingOptionsRequest {
-    return _smithy.isa(o, "GetV2LoggingOptionsRequest");
+    return __isa(o, "GetV2LoggingOptionsRequest");
   }
 }
 
@@ -1398,7 +1397,7 @@ export interface GetV2LoggingOptionsResponse extends $MetadataBearer {
 
 export namespace GetV2LoggingOptionsResponse {
   export function isa(o: any): o is GetV2LoggingOptionsResponse {
-    return _smithy.isa(o, "GetV2LoggingOptionsResponse");
+    return __isa(o, "GetV2LoggingOptionsResponse");
   }
 }
 
@@ -1437,7 +1436,7 @@ export interface HttpAction {
 
 export namespace HttpAction {
   export function isa(o: any): o is HttpAction {
-    return _smithy.isa(o, "HttpAction");
+    return __isa(o, "HttpAction");
   }
 }
 
@@ -1459,7 +1458,7 @@ export interface HttpActionHeader {
 
 export namespace HttpActionHeader {
   export function isa(o: any): o is HttpActionHeader {
-    return _smithy.isa(o, "HttpActionHeader");
+    return __isa(o, "HttpActionHeader");
   }
 }
 
@@ -1477,7 +1476,7 @@ export interface HttpAuthorization {
 
 export namespace HttpAuthorization {
   export function isa(o: any): o is HttpAuthorization {
-    return _smithy.isa(o, "HttpAuthorization");
+    return __isa(o, "HttpAuthorization");
   }
 }
 
@@ -1495,7 +1494,7 @@ export interface HttpUrlDestinationConfiguration {
 
 export namespace HttpUrlDestinationConfiguration {
   export function isa(o: any): o is HttpUrlDestinationConfiguration {
-    return _smithy.isa(o, "HttpUrlDestinationConfiguration");
+    return __isa(o, "HttpUrlDestinationConfiguration");
   }
 }
 
@@ -1512,7 +1511,7 @@ export interface HttpUrlDestinationProperties {
 
 export namespace HttpUrlDestinationProperties {
   export function isa(o: any): o is HttpUrlDestinationProperties {
-    return _smithy.isa(o, "HttpUrlDestinationProperties");
+    return __isa(o, "HttpUrlDestinationProperties");
   }
 }
 
@@ -1530,7 +1529,7 @@ export interface HttpUrlDestinationSummary {
 
 export namespace HttpUrlDestinationSummary {
   export function isa(o: any): o is HttpUrlDestinationSummary {
-    return _smithy.isa(o, "HttpUrlDestinationSummary");
+    return __isa(o, "HttpUrlDestinationSummary");
   }
 }
 
@@ -1559,7 +1558,7 @@ export interface IotAnalyticsAction {
 
 export namespace IotAnalyticsAction {
   export function isa(o: any): o is IotAnalyticsAction {
-    return _smithy.isa(o, "IotAnalyticsAction");
+    return __isa(o, "IotAnalyticsAction");
   }
 }
 
@@ -1588,7 +1587,7 @@ export interface IotEventsAction {
 
 export namespace IotEventsAction {
   export function isa(o: any): o is IotEventsAction {
-    return _smithy.isa(o, "IotEventsAction");
+    return __isa(o, "IotEventsAction");
   }
 }
 
@@ -1613,7 +1612,7 @@ export interface IotSiteWiseAction {
 
 export namespace IotSiteWiseAction {
   export function isa(o: any): o is IotSiteWiseAction {
-    return _smithy.isa(o, "IotSiteWiseAction");
+    return __isa(o, "IotSiteWiseAction");
   }
 }
 
@@ -1640,7 +1639,7 @@ export interface KinesisAction {
 
 export namespace KinesisAction {
   export function isa(o: any): o is KinesisAction {
-    return _smithy.isa(o, "KinesisAction");
+    return __isa(o, "KinesisAction");
   }
 }
 
@@ -1657,7 +1656,7 @@ export interface LambdaAction {
 
 export namespace LambdaAction {
   export function isa(o: any): o is LambdaAction {
-    return _smithy.isa(o, "LambdaAction");
+    return __isa(o, "LambdaAction");
   }
 }
 
@@ -1676,7 +1675,7 @@ export interface ListTopicRuleDestinationsRequest {
 
 export namespace ListTopicRuleDestinationsRequest {
   export function isa(o: any): o is ListTopicRuleDestinationsRequest {
-    return _smithy.isa(o, "ListTopicRuleDestinationsRequest");
+    return __isa(o, "ListTopicRuleDestinationsRequest");
   }
 }
 
@@ -1695,7 +1694,7 @@ export interface ListTopicRuleDestinationsResponse extends $MetadataBearer {
 
 export namespace ListTopicRuleDestinationsResponse {
   export function isa(o: any): o is ListTopicRuleDestinationsResponse {
-    return _smithy.isa(o, "ListTopicRuleDestinationsResponse");
+    return __isa(o, "ListTopicRuleDestinationsResponse");
   }
 }
 
@@ -1727,7 +1726,7 @@ export interface ListTopicRulesRequest {
 
 export namespace ListTopicRulesRequest {
   export function isa(o: any): o is ListTopicRulesRequest {
-    return _smithy.isa(o, "ListTopicRulesRequest");
+    return __isa(o, "ListTopicRulesRequest");
   }
 }
 
@@ -1749,7 +1748,7 @@ export interface ListTopicRulesResponse extends $MetadataBearer {
 
 export namespace ListTopicRulesResponse {
   export function isa(o: any): o is ListTopicRulesResponse {
-    return _smithy.isa(o, "ListTopicRulesResponse");
+    return __isa(o, "ListTopicRulesResponse");
   }
 }
 
@@ -1774,7 +1773,7 @@ export interface ListV2LoggingLevelsRequest {
 
 export namespace ListV2LoggingLevelsRequest {
   export function isa(o: any): o is ListV2LoggingLevelsRequest {
-    return _smithy.isa(o, "ListV2LoggingLevelsRequest");
+    return __isa(o, "ListV2LoggingLevelsRequest");
   }
 }
 
@@ -1793,7 +1792,7 @@ export interface ListV2LoggingLevelsResponse extends $MetadataBearer {
 
 export namespace ListV2LoggingLevelsResponse {
   export function isa(o: any): o is ListV2LoggingLevelsResponse {
-    return _smithy.isa(o, "ListV2LoggingLevelsResponse");
+    return __isa(o, "ListV2LoggingLevelsResponse");
   }
 }
 
@@ -1815,7 +1814,7 @@ export interface LogTarget {
 
 export namespace LogTarget {
   export function isa(o: any): o is LogTarget {
-    return _smithy.isa(o, "LogTarget");
+    return __isa(o, "LogTarget");
   }
 }
 
@@ -1837,7 +1836,7 @@ export interface LogTargetConfiguration {
 
 export namespace LogTargetConfiguration {
   export function isa(o: any): o is LogTargetConfiguration {
-    return _smithy.isa(o, "LogTargetConfiguration");
+    return __isa(o, "LogTargetConfiguration");
   }
 }
 
@@ -1864,7 +1863,7 @@ export interface LoggingOptionsPayload {
 
 export namespace LoggingOptionsPayload {
   export function isa(o: any): o is LoggingOptionsPayload {
-    return _smithy.isa(o, "LoggingOptionsPayload");
+    return __isa(o, "LoggingOptionsPayload");
   }
 }
 
@@ -1915,7 +1914,7 @@ export interface PutAssetPropertyValueEntry {
 
 export namespace PutAssetPropertyValueEntry {
   export function isa(o: any): o is PutAssetPropertyValueEntry {
-    return _smithy.isa(o, "PutAssetPropertyValueEntry");
+    return __isa(o, "PutAssetPropertyValueEntry");
   }
 }
 
@@ -1933,7 +1932,7 @@ export interface PutItemInput {
 
 export namespace PutItemInput {
   export function isa(o: any): o is PutItemInput {
-    return _smithy.isa(o, "PutItemInput");
+    return __isa(o, "PutItemInput");
   }
 }
 
@@ -1955,7 +1954,7 @@ export interface ReplaceTopicRuleRequest {
 
 export namespace ReplaceTopicRuleRequest {
   export function isa(o: any): o is ReplaceTopicRuleRequest {
-    return _smithy.isa(o, "ReplaceTopicRuleRequest");
+    return __isa(o, "ReplaceTopicRuleRequest");
   }
 }
 
@@ -1983,7 +1982,7 @@ export interface RepublishAction {
 
 export namespace RepublishAction {
   export function isa(o: any): o is RepublishAction {
-    return _smithy.isa(o, "RepublishAction");
+    return __isa(o, "RepublishAction");
   }
 }
 
@@ -2016,7 +2015,7 @@ export interface S3Action {
 
 export namespace S3Action {
   export function isa(o: any): o is S3Action {
-    return _smithy.isa(o, "S3Action");
+    return __isa(o, "S3Action");
   }
 }
 
@@ -2042,7 +2041,7 @@ export interface SalesforceAction {
 
 export namespace SalesforceAction {
   export function isa(o: any): o is SalesforceAction {
-    return _smithy.isa(o, "SalesforceAction");
+    return __isa(o, "SalesforceAction");
   }
 }
 
@@ -2059,7 +2058,7 @@ export interface SetLoggingOptionsRequest {
 
 export namespace SetLoggingOptionsRequest {
   export function isa(o: any): o is SetLoggingOptionsRequest {
-    return _smithy.isa(o, "SetLoggingOptionsRequest");
+    return __isa(o, "SetLoggingOptionsRequest");
   }
 }
 
@@ -2078,7 +2077,7 @@ export interface SetV2LoggingLevelRequest {
 
 export namespace SetV2LoggingLevelRequest {
   export function isa(o: any): o is SetV2LoggingLevelRequest {
-    return _smithy.isa(o, "SetV2LoggingLevelRequest");
+    return __isa(o, "SetV2LoggingLevelRequest");
   }
 }
 
@@ -2102,7 +2101,7 @@ export interface SetV2LoggingOptionsRequest {
 
 export namespace SetV2LoggingOptionsRequest {
   export function isa(o: any): o is SetV2LoggingOptionsRequest {
-    return _smithy.isa(o, "SetV2LoggingOptionsRequest");
+    return __isa(o, "SetV2LoggingOptionsRequest");
   }
 }
 
@@ -2129,7 +2128,7 @@ export interface SigV4Authorization {
 
 export namespace SigV4Authorization {
   export function isa(o: any): o is SigV4Authorization {
-    return _smithy.isa(o, "SigV4Authorization");
+    return __isa(o, "SigV4Authorization");
   }
 }
 
@@ -2159,7 +2158,7 @@ export interface SnsAction {
 
 export namespace SnsAction {
   export function isa(o: any): o is SnsAction {
-    return _smithy.isa(o, "SnsAction");
+    return __isa(o, "SnsAction");
   }
 }
 
@@ -2186,7 +2185,7 @@ export interface SqsAction {
 
 export namespace SqsAction {
   export function isa(o: any): o is SqsAction {
-    return _smithy.isa(o, "SqsAction");
+    return __isa(o, "SqsAction");
   }
 }
 
@@ -2216,7 +2215,7 @@ export interface StepFunctionsAction {
 
 export namespace StepFunctionsAction {
   export function isa(o: any): o is StepFunctionsAction {
-    return _smithy.isa(o, "StepFunctionsAction");
+    return __isa(o, "StepFunctionsAction");
   }
 }
 
@@ -2269,7 +2268,7 @@ export interface TopicRule {
 
 export namespace TopicRule {
   export function isa(o: any): o is TopicRule {
-    return _smithy.isa(o, "TopicRule");
+    return __isa(o, "TopicRule");
   }
 }
 
@@ -2333,7 +2332,7 @@ export interface TopicRuleDestination {
 
 export namespace TopicRuleDestination {
   export function isa(o: any): o is TopicRuleDestination {
-    return _smithy.isa(o, "TopicRuleDestination");
+    return __isa(o, "TopicRuleDestination");
   }
 }
 
@@ -2350,7 +2349,7 @@ export interface TopicRuleDestinationConfiguration {
 
 export namespace TopicRuleDestinationConfiguration {
   export function isa(o: any): o is TopicRuleDestinationConfiguration {
-    return _smithy.isa(o, "TopicRuleDestinationConfiguration");
+    return __isa(o, "TopicRuleDestinationConfiguration");
   }
 }
 
@@ -2420,7 +2419,7 @@ export interface TopicRuleDestinationSummary {
 
 export namespace TopicRuleDestinationSummary {
   export function isa(o: any): o is TopicRuleDestinationSummary {
-    return _smithy.isa(o, "TopicRuleDestinationSummary");
+    return __isa(o, "TopicRuleDestinationSummary");
   }
 }
 
@@ -2457,7 +2456,7 @@ export interface TopicRuleListItem {
 
 export namespace TopicRuleListItem {
   export function isa(o: any): o is TopicRuleListItem {
-    return _smithy.isa(o, "TopicRuleListItem");
+    return __isa(o, "TopicRuleListItem");
   }
 }
 
@@ -2500,7 +2499,7 @@ export interface TopicRulePayload {
 
 export namespace TopicRulePayload {
   export function isa(o: any): o is TopicRulePayload {
-    return _smithy.isa(o, "TopicRulePayload");
+    return __isa(o, "TopicRulePayload");
   }
 }
 
@@ -2550,7 +2549,7 @@ export interface UpdateTopicRuleDestinationRequest {
 
 export namespace UpdateTopicRuleDestinationRequest {
   export function isa(o: any): o is UpdateTopicRuleDestinationRequest {
-    return _smithy.isa(o, "UpdateTopicRuleDestinationRequest");
+    return __isa(o, "UpdateTopicRuleDestinationRequest");
   }
 }
 
@@ -2560,7 +2559,7 @@ export interface UpdateTopicRuleDestinationResponse extends $MetadataBearer {
 
 export namespace UpdateTopicRuleDestinationResponse {
   export function isa(o: any): o is UpdateTopicRuleDestinationResponse {
-    return _smithy.isa(o, "UpdateTopicRuleDestinationResponse");
+    return __isa(o, "UpdateTopicRuleDestinationResponse");
   }
 }
 
@@ -2583,7 +2582,7 @@ export interface AcceptCertificateTransferRequest {
 
 export namespace AcceptCertificateTransferRequest {
   export function isa(o: any): o is AcceptCertificateTransferRequest {
-    return _smithy.isa(o, "AcceptCertificateTransferRequest");
+    return __isa(o, "AcceptCertificateTransferRequest");
   }
 }
 
@@ -2607,7 +2606,7 @@ export interface Allowed {
 
 export namespace Allowed {
   export function isa(o: any): o is Allowed {
-    return _smithy.isa(o, "Allowed");
+    return __isa(o, "Allowed");
   }
 }
 
@@ -2626,7 +2625,7 @@ export interface AttachPolicyRequest {
 
 export namespace AttachPolicyRequest {
   export function isa(o: any): o is AttachPolicyRequest {
-    return _smithy.isa(o, "AttachPolicyRequest");
+    return __isa(o, "AttachPolicyRequest");
   }
 }
 
@@ -2649,7 +2648,7 @@ export interface AttachPrincipalPolicyRequest {
 
 export namespace AttachPrincipalPolicyRequest {
   export function isa(o: any): o is AttachPrincipalPolicyRequest {
-    return _smithy.isa(o, "AttachPrincipalPolicyRequest");
+    return __isa(o, "AttachPrincipalPolicyRequest");
   }
 }
 
@@ -2678,7 +2677,7 @@ export interface AuthInfo {
 
 export namespace AuthInfo {
   export function isa(o: any): o is AuthInfo {
-    return _smithy.isa(o, "AuthInfo");
+    return __isa(o, "AuthInfo");
   }
 }
 
@@ -2717,7 +2716,7 @@ export interface AuthResult {
 
 export namespace AuthResult {
   export function isa(o: any): o is AuthResult {
-    return _smithy.isa(o, "AuthResult");
+    return __isa(o, "AuthResult");
   }
 }
 
@@ -2739,7 +2738,7 @@ export interface AuthorizerConfig {
 
 export namespace AuthorizerConfig {
   export function isa(o: any): o is AuthorizerConfig {
-    return _smithy.isa(o, "AuthorizerConfig");
+    return __isa(o, "AuthorizerConfig");
   }
 }
 
@@ -2797,7 +2796,7 @@ export interface AuthorizerDescription {
 
 export namespace AuthorizerDescription {
   export function isa(o: any): o is AuthorizerDescription {
-    return _smithy.isa(o, "AuthorizerDescription");
+    return __isa(o, "AuthorizerDescription");
   }
 }
 
@@ -2824,7 +2823,7 @@ export interface AuthorizerSummary {
 
 export namespace AuthorizerSummary {
   export function isa(o: any): o is AuthorizerSummary {
-    return _smithy.isa(o, "AuthorizerSummary");
+    return __isa(o, "AuthorizerSummary");
   }
 }
 
@@ -2862,7 +2861,7 @@ export interface CACertificate {
 
 export namespace CACertificate {
   export function isa(o: any): o is CACertificate {
-    return _smithy.isa(o, "CACertificate");
+    return __isa(o, "CACertificate");
   }
 }
 
@@ -2930,7 +2929,7 @@ export interface CACertificateDescription {
 
 export namespace CACertificateDescription {
   export function isa(o: any): o is CACertificateDescription {
-    return _smithy.isa(o, "CACertificateDescription");
+    return __isa(o, "CACertificateDescription");
   }
 }
 
@@ -2953,7 +2952,7 @@ export interface CancelCertificateTransferRequest {
 
 export namespace CancelCertificateTransferRequest {
   export function isa(o: any): o is CancelCertificateTransferRequest {
-    return _smithy.isa(o, "CancelCertificateTransferRequest");
+    return __isa(o, "CancelCertificateTransferRequest");
   }
 }
 
@@ -2987,7 +2986,7 @@ export interface Certificate {
 
 export namespace Certificate {
   export function isa(o: any): o is Certificate {
-    return _smithy.isa(o, "Certificate");
+    return __isa(o, "Certificate");
   }
 }
 
@@ -3064,7 +3063,7 @@ export interface CertificateDescription {
 
 export namespace CertificateDescription {
   export function isa(o: any): o is CertificateDescription {
-    return _smithy.isa(o, "CertificateDescription");
+    return __isa(o, "CertificateDescription");
   }
 }
 
@@ -3095,7 +3094,7 @@ export interface CertificateValidity {
 
 export namespace CertificateValidity {
   export function isa(o: any): o is CertificateValidity {
-    return _smithy.isa(o, "CertificateValidity");
+    return __isa(o, "CertificateValidity");
   }
 }
 
@@ -3105,7 +3104,7 @@ export interface ClearDefaultAuthorizerRequest {
 
 export namespace ClearDefaultAuthorizerRequest {
   export function isa(o: any): o is ClearDefaultAuthorizerRequest {
-    return _smithy.isa(o, "ClearDefaultAuthorizerRequest");
+    return __isa(o, "ClearDefaultAuthorizerRequest");
   }
 }
 
@@ -3115,7 +3114,7 @@ export interface ClearDefaultAuthorizerResponse extends $MetadataBearer {
 
 export namespace ClearDefaultAuthorizerResponse {
   export function isa(o: any): o is ClearDefaultAuthorizerResponse {
-    return _smithy.isa(o, "ClearDefaultAuthorizerResponse");
+    return __isa(o, "ClearDefaultAuthorizerResponse");
   }
 }
 
@@ -3155,7 +3154,7 @@ export interface CreateAuthorizerRequest {
 
 export namespace CreateAuthorizerRequest {
   export function isa(o: any): o is CreateAuthorizerRequest {
-    return _smithy.isa(o, "CreateAuthorizerRequest");
+    return __isa(o, "CreateAuthorizerRequest");
   }
 }
 
@@ -3174,7 +3173,7 @@ export interface CreateAuthorizerResponse extends $MetadataBearer {
 
 export namespace CreateAuthorizerResponse {
   export function isa(o: any): o is CreateAuthorizerResponse {
-    return _smithy.isa(o, "CreateAuthorizerResponse");
+    return __isa(o, "CreateAuthorizerResponse");
   }
 }
 
@@ -3196,7 +3195,7 @@ export interface CreateCertificateFromCsrRequest {
 
 export namespace CreateCertificateFromCsrRequest {
   export function isa(o: any): o is CreateCertificateFromCsrRequest {
-    return _smithy.isa(o, "CreateCertificateFromCsrRequest");
+    return __isa(o, "CreateCertificateFromCsrRequest");
   }
 }
 
@@ -3225,7 +3224,7 @@ export interface CreateCertificateFromCsrResponse extends $MetadataBearer {
 
 export namespace CreateCertificateFromCsrResponse {
   export function isa(o: any): o is CreateCertificateFromCsrResponse {
-    return _smithy.isa(o, "CreateCertificateFromCsrResponse");
+    return __isa(o, "CreateCertificateFromCsrResponse");
   }
 }
 
@@ -3266,7 +3265,7 @@ export interface CreateDomainConfigurationRequest {
 
 export namespace CreateDomainConfigurationRequest {
   export function isa(o: any): o is CreateDomainConfigurationRequest {
-    return _smithy.isa(o, "CreateDomainConfigurationRequest");
+    return __isa(o, "CreateDomainConfigurationRequest");
   }
 }
 
@@ -3285,7 +3284,7 @@ export interface CreateDomainConfigurationResponse extends $MetadataBearer {
 
 export namespace CreateDomainConfigurationResponse {
   export function isa(o: any): o is CreateDomainConfigurationResponse {
-    return _smithy.isa(o, "CreateDomainConfigurationResponse");
+    return __isa(o, "CreateDomainConfigurationResponse");
   }
 }
 
@@ -3302,7 +3301,7 @@ export interface CreateKeysAndCertificateRequest {
 
 export namespace CreateKeysAndCertificateRequest {
   export function isa(o: any): o is CreateKeysAndCertificateRequest {
-    return _smithy.isa(o, "CreateKeysAndCertificateRequest");
+    return __isa(o, "CreateKeysAndCertificateRequest");
   }
 }
 
@@ -3335,7 +3334,7 @@ export interface CreateKeysAndCertificateResponse extends $MetadataBearer {
 
 export namespace CreateKeysAndCertificateResponse {
   export function isa(o: any): o is CreateKeysAndCertificateResponse {
-    return _smithy.isa(o, "CreateKeysAndCertificateResponse");
+    return __isa(o, "CreateKeysAndCertificateResponse");
   }
 }
 
@@ -3358,7 +3357,7 @@ export interface CreatePolicyRequest {
 
 export namespace CreatePolicyRequest {
   export function isa(o: any): o is CreatePolicyRequest {
-    return _smithy.isa(o, "CreatePolicyRequest");
+    return __isa(o, "CreatePolicyRequest");
   }
 }
 
@@ -3390,7 +3389,7 @@ export interface CreatePolicyResponse extends $MetadataBearer {
 
 export namespace CreatePolicyResponse {
   export function isa(o: any): o is CreatePolicyResponse {
-    return _smithy.isa(o, "CreatePolicyResponse");
+    return __isa(o, "CreatePolicyResponse");
   }
 }
 
@@ -3420,7 +3419,7 @@ export interface CreatePolicyVersionRequest {
 
 export namespace CreatePolicyVersionRequest {
   export function isa(o: any): o is CreatePolicyVersionRequest {
-    return _smithy.isa(o, "CreatePolicyVersionRequest");
+    return __isa(o, "CreatePolicyVersionRequest");
   }
 }
 
@@ -3452,7 +3451,7 @@ export interface CreatePolicyVersionResponse extends $MetadataBearer {
 
 export namespace CreatePolicyVersionResponse {
   export function isa(o: any): o is CreatePolicyVersionResponse {
-    return _smithy.isa(o, "CreatePolicyVersionResponse");
+    return __isa(o, "CreatePolicyVersionResponse");
   }
 }
 
@@ -3466,7 +3465,7 @@ export interface CreateProvisioningClaimRequest {
 
 export namespace CreateProvisioningClaimRequest {
   export function isa(o: any): o is CreateProvisioningClaimRequest {
-    return _smithy.isa(o, "CreateProvisioningClaimRequest");
+    return __isa(o, "CreateProvisioningClaimRequest");
   }
 }
 
@@ -3495,7 +3494,7 @@ export interface CreateProvisioningClaimResponse extends $MetadataBearer {
 
 export namespace CreateProvisioningClaimResponse {
   export function isa(o: any): o is CreateProvisioningClaimResponse {
-    return _smithy.isa(o, "CreateProvisioningClaimResponse");
+    return __isa(o, "CreateProvisioningClaimResponse");
   }
 }
 
@@ -3542,7 +3541,7 @@ export interface CreateProvisioningTemplateRequest {
 
 export namespace CreateProvisioningTemplateRequest {
   export function isa(o: any): o is CreateProvisioningTemplateRequest {
-    return _smithy.isa(o, "CreateProvisioningTemplateRequest");
+    return __isa(o, "CreateProvisioningTemplateRequest");
   }
 }
 
@@ -3566,7 +3565,7 @@ export interface CreateProvisioningTemplateResponse extends $MetadataBearer {
 
 export namespace CreateProvisioningTemplateResponse {
   export function isa(o: any): o is CreateProvisioningTemplateResponse {
-    return _smithy.isa(o, "CreateProvisioningTemplateResponse");
+    return __isa(o, "CreateProvisioningTemplateResponse");
   }
 }
 
@@ -3590,7 +3589,7 @@ export interface CreateProvisioningTemplateVersionRequest {
 
 export namespace CreateProvisioningTemplateVersionRequest {
   export function isa(o: any): o is CreateProvisioningTemplateVersionRequest {
-    return _smithy.isa(o, "CreateProvisioningTemplateVersionRequest");
+    return __isa(o, "CreateProvisioningTemplateVersionRequest");
   }
 }
 
@@ -3621,7 +3620,7 @@ export interface CreateProvisioningTemplateVersionResponse
 
 export namespace CreateProvisioningTemplateVersionResponse {
   export function isa(o: any): o is CreateProvisioningTemplateVersionResponse {
-    return _smithy.isa(o, "CreateProvisioningTemplateVersionResponse");
+    return __isa(o, "CreateProvisioningTemplateVersionResponse");
   }
 }
 
@@ -3646,7 +3645,7 @@ export interface CreateRoleAliasRequest {
 
 export namespace CreateRoleAliasRequest {
   export function isa(o: any): o is CreateRoleAliasRequest {
-    return _smithy.isa(o, "CreateRoleAliasRequest");
+    return __isa(o, "CreateRoleAliasRequest");
   }
 }
 
@@ -3665,7 +3664,7 @@ export interface CreateRoleAliasResponse extends $MetadataBearer {
 
 export namespace CreateRoleAliasResponse {
   export function isa(o: any): o is CreateRoleAliasResponse {
-    return _smithy.isa(o, "CreateRoleAliasResponse");
+    return __isa(o, "CreateRoleAliasResponse");
   }
 }
 
@@ -3679,7 +3678,7 @@ export interface DeleteAuthorizerRequest {
 
 export namespace DeleteAuthorizerRequest {
   export function isa(o: any): o is DeleteAuthorizerRequest {
-    return _smithy.isa(o, "DeleteAuthorizerRequest");
+    return __isa(o, "DeleteAuthorizerRequest");
   }
 }
 
@@ -3689,7 +3688,7 @@ export interface DeleteAuthorizerResponse extends $MetadataBearer {
 
 export namespace DeleteAuthorizerResponse {
   export function isa(o: any): o is DeleteAuthorizerResponse {
-    return _smithy.isa(o, "DeleteAuthorizerResponse");
+    return __isa(o, "DeleteAuthorizerResponse");
   }
 }
 
@@ -3707,7 +3706,7 @@ export interface DeleteCACertificateRequest {
 
 export namespace DeleteCACertificateRequest {
   export function isa(o: any): o is DeleteCACertificateRequest {
-    return _smithy.isa(o, "DeleteCACertificateRequest");
+    return __isa(o, "DeleteCACertificateRequest");
   }
 }
 
@@ -3720,7 +3719,7 @@ export interface DeleteCACertificateResponse extends $MetadataBearer {
 
 export namespace DeleteCACertificateResponse {
   export function isa(o: any): o is DeleteCACertificateResponse {
-    return _smithy.isa(o, "DeleteCACertificateResponse");
+    return __isa(o, "DeleteCACertificateResponse");
   }
 }
 
@@ -3744,7 +3743,7 @@ export interface DeleteCertificateRequest {
 
 export namespace DeleteCertificateRequest {
   export function isa(o: any): o is DeleteCertificateRequest {
-    return _smithy.isa(o, "DeleteCertificateRequest");
+    return __isa(o, "DeleteCertificateRequest");
   }
 }
 
@@ -3758,7 +3757,7 @@ export interface DeleteDomainConfigurationRequest {
 
 export namespace DeleteDomainConfigurationRequest {
   export function isa(o: any): o is DeleteDomainConfigurationRequest {
-    return _smithy.isa(o, "DeleteDomainConfigurationRequest");
+    return __isa(o, "DeleteDomainConfigurationRequest");
   }
 }
 
@@ -3768,7 +3767,7 @@ export interface DeleteDomainConfigurationResponse extends $MetadataBearer {
 
 export namespace DeleteDomainConfigurationResponse {
   export function isa(o: any): o is DeleteDomainConfigurationResponse {
-    return _smithy.isa(o, "DeleteDomainConfigurationResponse");
+    return __isa(o, "DeleteDomainConfigurationResponse");
   }
 }
 
@@ -3785,7 +3784,7 @@ export interface DeletePolicyRequest {
 
 export namespace DeletePolicyRequest {
   export function isa(o: any): o is DeletePolicyRequest {
-    return _smithy.isa(o, "DeletePolicyRequest");
+    return __isa(o, "DeletePolicyRequest");
   }
 }
 
@@ -3807,7 +3806,7 @@ export interface DeletePolicyVersionRequest {
 
 export namespace DeletePolicyVersionRequest {
   export function isa(o: any): o is DeletePolicyVersionRequest {
-    return _smithy.isa(o, "DeletePolicyVersionRequest");
+    return __isa(o, "DeletePolicyVersionRequest");
   }
 }
 
@@ -3821,7 +3820,7 @@ export interface DeleteProvisioningTemplateRequest {
 
 export namespace DeleteProvisioningTemplateRequest {
   export function isa(o: any): o is DeleteProvisioningTemplateRequest {
-    return _smithy.isa(o, "DeleteProvisioningTemplateRequest");
+    return __isa(o, "DeleteProvisioningTemplateRequest");
   }
 }
 
@@ -3831,7 +3830,7 @@ export interface DeleteProvisioningTemplateResponse extends $MetadataBearer {
 
 export namespace DeleteProvisioningTemplateResponse {
   export function isa(o: any): o is DeleteProvisioningTemplateResponse {
-    return _smithy.isa(o, "DeleteProvisioningTemplateResponse");
+    return __isa(o, "DeleteProvisioningTemplateResponse");
   }
 }
 
@@ -3850,7 +3849,7 @@ export interface DeleteProvisioningTemplateVersionRequest {
 
 export namespace DeleteProvisioningTemplateVersionRequest {
   export function isa(o: any): o is DeleteProvisioningTemplateVersionRequest {
-    return _smithy.isa(o, "DeleteProvisioningTemplateVersionRequest");
+    return __isa(o, "DeleteProvisioningTemplateVersionRequest");
   }
 }
 
@@ -3861,7 +3860,7 @@ export interface DeleteProvisioningTemplateVersionResponse
 
 export namespace DeleteProvisioningTemplateVersionResponse {
   export function isa(o: any): o is DeleteProvisioningTemplateVersionResponse {
-    return _smithy.isa(o, "DeleteProvisioningTemplateVersionResponse");
+    return __isa(o, "DeleteProvisioningTemplateVersionResponse");
   }
 }
 
@@ -3874,7 +3873,7 @@ export interface DeleteRegistrationCodeRequest {
 
 export namespace DeleteRegistrationCodeRequest {
   export function isa(o: any): o is DeleteRegistrationCodeRequest {
-    return _smithy.isa(o, "DeleteRegistrationCodeRequest");
+    return __isa(o, "DeleteRegistrationCodeRequest");
   }
 }
 
@@ -3887,7 +3886,7 @@ export interface DeleteRegistrationCodeResponse extends $MetadataBearer {
 
 export namespace DeleteRegistrationCodeResponse {
   export function isa(o: any): o is DeleteRegistrationCodeResponse {
-    return _smithy.isa(o, "DeleteRegistrationCodeResponse");
+    return __isa(o, "DeleteRegistrationCodeResponse");
   }
 }
 
@@ -3901,7 +3900,7 @@ export interface DeleteRoleAliasRequest {
 
 export namespace DeleteRoleAliasRequest {
   export function isa(o: any): o is DeleteRoleAliasRequest {
-    return _smithy.isa(o, "DeleteRoleAliasRequest");
+    return __isa(o, "DeleteRoleAliasRequest");
   }
 }
 
@@ -3911,7 +3910,7 @@ export interface DeleteRoleAliasResponse extends $MetadataBearer {
 
 export namespace DeleteRoleAliasResponse {
   export function isa(o: any): o is DeleteRoleAliasResponse {
-    return _smithy.isa(o, "DeleteRoleAliasResponse");
+    return __isa(o, "DeleteRoleAliasResponse");
   }
 }
 
@@ -3935,7 +3934,7 @@ export interface Denied {
 
 export namespace Denied {
   export function isa(o: any): o is Denied {
-    return _smithy.isa(o, "Denied");
+    return __isa(o, "Denied");
   }
 }
 
@@ -3949,7 +3948,7 @@ export interface DescribeAuthorizerRequest {
 
 export namespace DescribeAuthorizerRequest {
   export function isa(o: any): o is DescribeAuthorizerRequest {
-    return _smithy.isa(o, "DescribeAuthorizerRequest");
+    return __isa(o, "DescribeAuthorizerRequest");
   }
 }
 
@@ -3963,7 +3962,7 @@ export interface DescribeAuthorizerResponse extends $MetadataBearer {
 
 export namespace DescribeAuthorizerResponse {
   export function isa(o: any): o is DescribeAuthorizerResponse {
-    return _smithy.isa(o, "DescribeAuthorizerResponse");
+    return __isa(o, "DescribeAuthorizerResponse");
   }
 }
 
@@ -3980,7 +3979,7 @@ export interface DescribeCACertificateRequest {
 
 export namespace DescribeCACertificateRequest {
   export function isa(o: any): o is DescribeCACertificateRequest {
-    return _smithy.isa(o, "DescribeCACertificateRequest");
+    return __isa(o, "DescribeCACertificateRequest");
   }
 }
 
@@ -4002,7 +4001,7 @@ export interface DescribeCACertificateResponse extends $MetadataBearer {
 
 export namespace DescribeCACertificateResponse {
   export function isa(o: any): o is DescribeCACertificateResponse {
-    return _smithy.isa(o, "DescribeCACertificateResponse");
+    return __isa(o, "DescribeCACertificateResponse");
   }
 }
 
@@ -4020,7 +4019,7 @@ export interface DescribeCertificateRequest {
 
 export namespace DescribeCertificateRequest {
   export function isa(o: any): o is DescribeCertificateRequest {
-    return _smithy.isa(o, "DescribeCertificateRequest");
+    return __isa(o, "DescribeCertificateRequest");
   }
 }
 
@@ -4037,7 +4036,7 @@ export interface DescribeCertificateResponse extends $MetadataBearer {
 
 export namespace DescribeCertificateResponse {
   export function isa(o: any): o is DescribeCertificateResponse {
-    return _smithy.isa(o, "DescribeCertificateResponse");
+    return __isa(o, "DescribeCertificateResponse");
   }
 }
 
@@ -4047,7 +4046,7 @@ export interface DescribeDefaultAuthorizerRequest {
 
 export namespace DescribeDefaultAuthorizerRequest {
   export function isa(o: any): o is DescribeDefaultAuthorizerRequest {
-    return _smithy.isa(o, "DescribeDefaultAuthorizerRequest");
+    return __isa(o, "DescribeDefaultAuthorizerRequest");
   }
 }
 
@@ -4061,7 +4060,7 @@ export interface DescribeDefaultAuthorizerResponse extends $MetadataBearer {
 
 export namespace DescribeDefaultAuthorizerResponse {
   export function isa(o: any): o is DescribeDefaultAuthorizerResponse {
-    return _smithy.isa(o, "DescribeDefaultAuthorizerResponse");
+    return __isa(o, "DescribeDefaultAuthorizerResponse");
   }
 }
 
@@ -4075,7 +4074,7 @@ export interface DescribeDomainConfigurationRequest {
 
 export namespace DescribeDomainConfigurationRequest {
   export function isa(o: any): o is DescribeDomainConfigurationRequest {
-    return _smithy.isa(o, "DescribeDomainConfigurationRequest");
+    return __isa(o, "DescribeDomainConfigurationRequest");
   }
 }
 
@@ -4124,7 +4123,7 @@ export interface DescribeDomainConfigurationResponse extends $MetadataBearer {
 
 export namespace DescribeDomainConfigurationResponse {
   export function isa(o: any): o is DescribeDomainConfigurationResponse {
-    return _smithy.isa(o, "DescribeDomainConfigurationResponse");
+    return __isa(o, "DescribeDomainConfigurationResponse");
   }
 }
 
@@ -4167,7 +4166,7 @@ export interface DescribeEndpointRequest {
 
 export namespace DescribeEndpointRequest {
   export function isa(o: any): o is DescribeEndpointRequest {
-    return _smithy.isa(o, "DescribeEndpointRequest");
+    return __isa(o, "DescribeEndpointRequest");
   }
 }
 
@@ -4185,7 +4184,7 @@ export interface DescribeEndpointResponse extends $MetadataBearer {
 
 export namespace DescribeEndpointResponse {
   export function isa(o: any): o is DescribeEndpointResponse {
-    return _smithy.isa(o, "DescribeEndpointResponse");
+    return __isa(o, "DescribeEndpointResponse");
   }
 }
 
@@ -4199,7 +4198,7 @@ export interface DescribeProvisioningTemplateRequest {
 
 export namespace DescribeProvisioningTemplateRequest {
   export function isa(o: any): o is DescribeProvisioningTemplateRequest {
-    return _smithy.isa(o, "DescribeProvisioningTemplateRequest");
+    return __isa(o, "DescribeProvisioningTemplateRequest");
   }
 }
 
@@ -4254,7 +4253,7 @@ export interface DescribeProvisioningTemplateResponse extends $MetadataBearer {
 
 export namespace DescribeProvisioningTemplateResponse {
   export function isa(o: any): o is DescribeProvisioningTemplateResponse {
-    return _smithy.isa(o, "DescribeProvisioningTemplateResponse");
+    return __isa(o, "DescribeProvisioningTemplateResponse");
   }
 }
 
@@ -4273,7 +4272,7 @@ export interface DescribeProvisioningTemplateVersionRequest {
 
 export namespace DescribeProvisioningTemplateVersionRequest {
   export function isa(o: any): o is DescribeProvisioningTemplateVersionRequest {
-    return _smithy.isa(o, "DescribeProvisioningTemplateVersionRequest");
+    return __isa(o, "DescribeProvisioningTemplateVersionRequest");
   }
 }
 
@@ -4305,7 +4304,7 @@ export namespace DescribeProvisioningTemplateVersionResponse {
   export function isa(
     o: any
   ): o is DescribeProvisioningTemplateVersionResponse {
-    return _smithy.isa(o, "DescribeProvisioningTemplateVersionResponse");
+    return __isa(o, "DescribeProvisioningTemplateVersionResponse");
   }
 }
 
@@ -4319,7 +4318,7 @@ export interface DescribeRoleAliasRequest {
 
 export namespace DescribeRoleAliasRequest {
   export function isa(o: any): o is DescribeRoleAliasRequest {
-    return _smithy.isa(o, "DescribeRoleAliasRequest");
+    return __isa(o, "DescribeRoleAliasRequest");
   }
 }
 
@@ -4333,7 +4332,7 @@ export interface DescribeRoleAliasResponse extends $MetadataBearer {
 
 export namespace DescribeRoleAliasResponse {
   export function isa(o: any): o is DescribeRoleAliasResponse {
-    return _smithy.isa(o, "DescribeRoleAliasResponse");
+    return __isa(o, "DescribeRoleAliasResponse");
   }
 }
 
@@ -4352,7 +4351,7 @@ export interface DetachPolicyRequest {
 
 export namespace DetachPolicyRequest {
   export function isa(o: any): o is DetachPolicyRequest {
-    return _smithy.isa(o, "DetachPolicyRequest");
+    return __isa(o, "DetachPolicyRequest");
   }
 }
 
@@ -4376,7 +4375,7 @@ export interface DetachPrincipalPolicyRequest {
 
 export namespace DetachPrincipalPolicyRequest {
   export function isa(o: any): o is DetachPrincipalPolicyRequest {
-    return _smithy.isa(o, "DetachPrincipalPolicyRequest");
+    return __isa(o, "DetachPrincipalPolicyRequest");
   }
 }
 
@@ -4424,7 +4423,7 @@ export interface DomainConfigurationSummary {
 
 export namespace DomainConfigurationSummary {
   export function isa(o: any): o is DomainConfigurationSummary {
-    return _smithy.isa(o, "DomainConfigurationSummary");
+    return __isa(o, "DomainConfigurationSummary");
   }
 }
 
@@ -4457,7 +4456,7 @@ export interface EffectivePolicy {
 
 export namespace EffectivePolicy {
   export function isa(o: any): o is EffectivePolicy {
-    return _smithy.isa(o, "EffectivePolicy");
+    return __isa(o, "EffectivePolicy");
   }
 }
 
@@ -4474,7 +4473,7 @@ export interface ExplicitDeny {
 
 export namespace ExplicitDeny {
   export function isa(o: any): o is ExplicitDeny {
-    return _smithy.isa(o, "ExplicitDeny");
+    return __isa(o, "ExplicitDeny");
   }
 }
 
@@ -4498,7 +4497,7 @@ export interface GetEffectivePoliciesRequest {
 
 export namespace GetEffectivePoliciesRequest {
   export function isa(o: any): o is GetEffectivePoliciesRequest {
-    return _smithy.isa(o, "GetEffectivePoliciesRequest");
+    return __isa(o, "GetEffectivePoliciesRequest");
   }
 }
 
@@ -4512,7 +4511,7 @@ export interface GetEffectivePoliciesResponse extends $MetadataBearer {
 
 export namespace GetEffectivePoliciesResponse {
   export function isa(o: any): o is GetEffectivePoliciesResponse {
-    return _smithy.isa(o, "GetEffectivePoliciesResponse");
+    return __isa(o, "GetEffectivePoliciesResponse");
   }
 }
 
@@ -4529,7 +4528,7 @@ export interface GetPolicyRequest {
 
 export namespace GetPolicyRequest {
   export function isa(o: any): o is GetPolicyRequest {
-    return _smithy.isa(o, "GetPolicyRequest");
+    return __isa(o, "GetPolicyRequest");
   }
 }
 
@@ -4576,7 +4575,7 @@ export interface GetPolicyResponse extends $MetadataBearer {
 
 export namespace GetPolicyResponse {
   export function isa(o: any): o is GetPolicyResponse {
-    return _smithy.isa(o, "GetPolicyResponse");
+    return __isa(o, "GetPolicyResponse");
   }
 }
 
@@ -4598,7 +4597,7 @@ export interface GetPolicyVersionRequest {
 
 export namespace GetPolicyVersionRequest {
   export function isa(o: any): o is GetPolicyVersionRequest {
-    return _smithy.isa(o, "GetPolicyVersionRequest");
+    return __isa(o, "GetPolicyVersionRequest");
   }
 }
 
@@ -4650,7 +4649,7 @@ export interface GetPolicyVersionResponse extends $MetadataBearer {
 
 export namespace GetPolicyVersionResponse {
   export function isa(o: any): o is GetPolicyVersionResponse {
-    return _smithy.isa(o, "GetPolicyVersionResponse");
+    return __isa(o, "GetPolicyVersionResponse");
   }
 }
 
@@ -4663,7 +4662,7 @@ export interface GetRegistrationCodeRequest {
 
 export namespace GetRegistrationCodeRequest {
   export function isa(o: any): o is GetRegistrationCodeRequest {
-    return _smithy.isa(o, "GetRegistrationCodeRequest");
+    return __isa(o, "GetRegistrationCodeRequest");
   }
 }
 
@@ -4680,7 +4679,7 @@ export interface GetRegistrationCodeResponse extends $MetadataBearer {
 
 export namespace GetRegistrationCodeResponse {
   export function isa(o: any): o is GetRegistrationCodeResponse {
-    return _smithy.isa(o, "GetRegistrationCodeResponse");
+    return __isa(o, "GetRegistrationCodeResponse");
   }
 }
 
@@ -4702,7 +4701,7 @@ export interface HttpContext {
 
 export namespace HttpContext {
   export function isa(o: any): o is HttpContext {
-    return _smithy.isa(o, "HttpContext");
+    return __isa(o, "HttpContext");
   }
 }
 
@@ -4721,7 +4720,7 @@ export interface ImplicitDeny {
 
 export namespace ImplicitDeny {
   export function isa(o: any): o is ImplicitDeny {
-    return _smithy.isa(o, "ImplicitDeny");
+    return __isa(o, "ImplicitDeny");
   }
 }
 
@@ -4743,7 +4742,7 @@ export interface KeyPair {
 
 export namespace KeyPair {
   export function isa(o: any): o is KeyPair {
-    return _smithy.isa(o, "KeyPair");
+    return __isa(o, "KeyPair");
   }
 }
 
@@ -4772,7 +4771,7 @@ export interface ListAttachedPoliciesRequest {
 
 export namespace ListAttachedPoliciesRequest {
   export function isa(o: any): o is ListAttachedPoliciesRequest {
-    return _smithy.isa(o, "ListAttachedPoliciesRequest");
+    return __isa(o, "ListAttachedPoliciesRequest");
   }
 }
 
@@ -4792,7 +4791,7 @@ export interface ListAttachedPoliciesResponse extends $MetadataBearer {
 
 export namespace ListAttachedPoliciesResponse {
   export function isa(o: any): o is ListAttachedPoliciesResponse {
-    return _smithy.isa(o, "ListAttachedPoliciesResponse");
+    return __isa(o, "ListAttachedPoliciesResponse");
   }
 }
 
@@ -4821,7 +4820,7 @@ export interface ListAuthorizersRequest {
 
 export namespace ListAuthorizersRequest {
   export function isa(o: any): o is ListAuthorizersRequest {
-    return _smithy.isa(o, "ListAuthorizersRequest");
+    return __isa(o, "ListAuthorizersRequest");
   }
 }
 
@@ -4840,7 +4839,7 @@ export interface ListAuthorizersResponse extends $MetadataBearer {
 
 export namespace ListAuthorizersResponse {
   export function isa(o: any): o is ListAuthorizersResponse {
-    return _smithy.isa(o, "ListAuthorizersResponse");
+    return __isa(o, "ListAuthorizersResponse");
   }
 }
 
@@ -4867,7 +4866,7 @@ export interface ListCACertificatesRequest {
 
 export namespace ListCACertificatesRequest {
   export function isa(o: any): o is ListCACertificatesRequest {
-    return _smithy.isa(o, "ListCACertificatesRequest");
+    return __isa(o, "ListCACertificatesRequest");
   }
 }
 
@@ -4889,7 +4888,7 @@ export interface ListCACertificatesResponse extends $MetadataBearer {
 
 export namespace ListCACertificatesResponse {
   export function isa(o: any): o is ListCACertificatesResponse {
-    return _smithy.isa(o, "ListCACertificatesResponse");
+    return __isa(o, "ListCACertificatesResponse");
   }
 }
 
@@ -4923,7 +4922,7 @@ export interface ListCertificatesByCARequest {
 
 export namespace ListCertificatesByCARequest {
   export function isa(o: any): o is ListCertificatesByCARequest {
-    return _smithy.isa(o, "ListCertificatesByCARequest");
+    return __isa(o, "ListCertificatesByCARequest");
   }
 }
 
@@ -4946,7 +4945,7 @@ export interface ListCertificatesByCAResponse extends $MetadataBearer {
 
 export namespace ListCertificatesByCAResponse {
   export function isa(o: any): o is ListCertificatesByCAResponse {
-    return _smithy.isa(o, "ListCertificatesByCAResponse");
+    return __isa(o, "ListCertificatesByCAResponse");
   }
 }
 
@@ -4974,7 +4973,7 @@ export interface ListCertificatesRequest {
 
 export namespace ListCertificatesRequest {
   export function isa(o: any): o is ListCertificatesRequest {
-    return _smithy.isa(o, "ListCertificatesRequest");
+    return __isa(o, "ListCertificatesRequest");
   }
 }
 
@@ -4997,7 +4996,7 @@ export interface ListCertificatesResponse extends $MetadataBearer {
 
 export namespace ListCertificatesResponse {
   export function isa(o: any): o is ListCertificatesResponse {
-    return _smithy.isa(o, "ListCertificatesResponse");
+    return __isa(o, "ListCertificatesResponse");
   }
 }
 
@@ -5021,7 +5020,7 @@ export interface ListDomainConfigurationsRequest {
 
 export namespace ListDomainConfigurationsRequest {
   export function isa(o: any): o is ListDomainConfigurationsRequest {
-    return _smithy.isa(o, "ListDomainConfigurationsRequest");
+    return __isa(o, "ListDomainConfigurationsRequest");
   }
 }
 
@@ -5040,7 +5039,7 @@ export interface ListDomainConfigurationsResponse extends $MetadataBearer {
 
 export namespace ListDomainConfigurationsResponse {
   export function isa(o: any): o is ListDomainConfigurationsResponse {
-    return _smithy.isa(o, "ListDomainConfigurationsResponse");
+    return __isa(o, "ListDomainConfigurationsResponse");
   }
 }
 
@@ -5068,7 +5067,7 @@ export interface ListOutgoingCertificatesRequest {
 
 export namespace ListOutgoingCertificatesRequest {
   export function isa(o: any): o is ListOutgoingCertificatesRequest {
-    return _smithy.isa(o, "ListOutgoingCertificatesRequest");
+    return __isa(o, "ListOutgoingCertificatesRequest");
   }
 }
 
@@ -5090,7 +5089,7 @@ export interface ListOutgoingCertificatesResponse extends $MetadataBearer {
 
 export namespace ListOutgoingCertificatesResponse {
   export function isa(o: any): o is ListOutgoingCertificatesResponse {
-    return _smithy.isa(o, "ListOutgoingCertificatesResponse");
+    return __isa(o, "ListOutgoingCertificatesResponse");
   }
 }
 
@@ -5118,7 +5117,7 @@ export interface ListPoliciesRequest {
 
 export namespace ListPoliciesRequest {
   export function isa(o: any): o is ListPoliciesRequest {
-    return _smithy.isa(o, "ListPoliciesRequest");
+    return __isa(o, "ListPoliciesRequest");
   }
 }
 
@@ -5141,7 +5140,7 @@ export interface ListPoliciesResponse extends $MetadataBearer {
 
 export namespace ListPoliciesResponse {
   export function isa(o: any): o is ListPoliciesResponse {
-    return _smithy.isa(o, "ListPoliciesResponse");
+    return __isa(o, "ListPoliciesResponse");
   }
 }
 
@@ -5174,7 +5173,7 @@ export interface ListPolicyPrincipalsRequest {
 
 export namespace ListPolicyPrincipalsRequest {
   export function isa(o: any): o is ListPolicyPrincipalsRequest {
-    return _smithy.isa(o, "ListPolicyPrincipalsRequest");
+    return __isa(o, "ListPolicyPrincipalsRequest");
   }
 }
 
@@ -5197,7 +5196,7 @@ export interface ListPolicyPrincipalsResponse extends $MetadataBearer {
 
 export namespace ListPolicyPrincipalsResponse {
   export function isa(o: any): o is ListPolicyPrincipalsResponse {
-    return _smithy.isa(o, "ListPolicyPrincipalsResponse");
+    return __isa(o, "ListPolicyPrincipalsResponse");
   }
 }
 
@@ -5214,7 +5213,7 @@ export interface ListPolicyVersionsRequest {
 
 export namespace ListPolicyVersionsRequest {
   export function isa(o: any): o is ListPolicyVersionsRequest {
-    return _smithy.isa(o, "ListPolicyVersionsRequest");
+    return __isa(o, "ListPolicyVersionsRequest");
   }
 }
 
@@ -5231,7 +5230,7 @@ export interface ListPolicyVersionsResponse extends $MetadataBearer {
 
 export namespace ListPolicyVersionsResponse {
   export function isa(o: any): o is ListPolicyVersionsResponse {
-    return _smithy.isa(o, "ListPolicyVersionsResponse");
+    return __isa(o, "ListPolicyVersionsResponse");
   }
 }
 
@@ -5264,7 +5263,7 @@ export interface ListPrincipalPoliciesRequest {
 
 export namespace ListPrincipalPoliciesRequest {
   export function isa(o: any): o is ListPrincipalPoliciesRequest {
-    return _smithy.isa(o, "ListPrincipalPoliciesRequest");
+    return __isa(o, "ListPrincipalPoliciesRequest");
   }
 }
 
@@ -5287,7 +5286,7 @@ export interface ListPrincipalPoliciesResponse extends $MetadataBearer {
 
 export namespace ListPrincipalPoliciesResponse {
   export function isa(o: any): o is ListPrincipalPoliciesResponse {
-    return _smithy.isa(o, "ListPrincipalPoliciesResponse");
+    return __isa(o, "ListPrincipalPoliciesResponse");
   }
 }
 
@@ -5311,7 +5310,7 @@ export interface ListProvisioningTemplateVersionsRequest {
 
 export namespace ListProvisioningTemplateVersionsRequest {
   export function isa(o: any): o is ListProvisioningTemplateVersionsRequest {
-    return _smithy.isa(o, "ListProvisioningTemplateVersionsRequest");
+    return __isa(o, "ListProvisioningTemplateVersionsRequest");
   }
 }
 
@@ -5331,7 +5330,7 @@ export interface ListProvisioningTemplateVersionsResponse
 
 export namespace ListProvisioningTemplateVersionsResponse {
   export function isa(o: any): o is ListProvisioningTemplateVersionsResponse {
-    return _smithy.isa(o, "ListProvisioningTemplateVersionsResponse");
+    return __isa(o, "ListProvisioningTemplateVersionsResponse");
   }
 }
 
@@ -5350,7 +5349,7 @@ export interface ListProvisioningTemplatesRequest {
 
 export namespace ListProvisioningTemplatesRequest {
   export function isa(o: any): o is ListProvisioningTemplatesRequest {
-    return _smithy.isa(o, "ListProvisioningTemplatesRequest");
+    return __isa(o, "ListProvisioningTemplatesRequest");
   }
 }
 
@@ -5369,7 +5368,7 @@ export interface ListProvisioningTemplatesResponse extends $MetadataBearer {
 
 export namespace ListProvisioningTemplatesResponse {
   export function isa(o: any): o is ListProvisioningTemplatesResponse {
-    return _smithy.isa(o, "ListProvisioningTemplatesResponse");
+    return __isa(o, "ListProvisioningTemplatesResponse");
   }
 }
 
@@ -5393,7 +5392,7 @@ export interface ListRoleAliasesRequest {
 
 export namespace ListRoleAliasesRequest {
   export function isa(o: any): o is ListRoleAliasesRequest {
-    return _smithy.isa(o, "ListRoleAliasesRequest");
+    return __isa(o, "ListRoleAliasesRequest");
   }
 }
 
@@ -5412,7 +5411,7 @@ export interface ListRoleAliasesResponse extends $MetadataBearer {
 
 export namespace ListRoleAliasesResponse {
   export function isa(o: any): o is ListRoleAliasesResponse {
-    return _smithy.isa(o, "ListRoleAliasesResponse");
+    return __isa(o, "ListRoleAliasesResponse");
   }
 }
 
@@ -5436,7 +5435,7 @@ export interface ListTargetsForPolicyRequest {
 
 export namespace ListTargetsForPolicyRequest {
   export function isa(o: any): o is ListTargetsForPolicyRequest {
-    return _smithy.isa(o, "ListTargetsForPolicyRequest");
+    return __isa(o, "ListTargetsForPolicyRequest");
   }
 }
 
@@ -5455,7 +5454,7 @@ export interface ListTargetsForPolicyResponse extends $MetadataBearer {
 
 export namespace ListTargetsForPolicyResponse {
   export function isa(o: any): o is ListTargetsForPolicyResponse {
-    return _smithy.isa(o, "ListTargetsForPolicyResponse");
+    return __isa(o, "ListTargetsForPolicyResponse");
   }
 }
 
@@ -5482,7 +5481,7 @@ export interface MqttContext {
 
 export namespace MqttContext {
   export function isa(o: any): o is MqttContext {
-    return _smithy.isa(o, "MqttContext");
+    return __isa(o, "MqttContext");
   }
 }
 
@@ -5524,7 +5523,7 @@ export interface OutgoingCertificate {
 
 export namespace OutgoingCertificate {
   export function isa(o: any): o is OutgoingCertificate {
-    return _smithy.isa(o, "OutgoingCertificate");
+    return __isa(o, "OutgoingCertificate");
   }
 }
 
@@ -5546,7 +5545,7 @@ export interface Policy {
 
 export namespace Policy {
   export function isa(o: any): o is Policy {
-    return _smithy.isa(o, "Policy");
+    return __isa(o, "Policy");
   }
 }
 
@@ -5573,7 +5572,7 @@ export interface PolicyVersion {
 
 export namespace PolicyVersion {
   export function isa(o: any): o is PolicyVersion {
-    return _smithy.isa(o, "PolicyVersion");
+    return __isa(o, "PolicyVersion");
   }
 }
 
@@ -5615,7 +5614,7 @@ export interface ProvisioningTemplateSummary {
 
 export namespace ProvisioningTemplateSummary {
   export function isa(o: any): o is ProvisioningTemplateSummary {
-    return _smithy.isa(o, "ProvisioningTemplateSummary");
+    return __isa(o, "ProvisioningTemplateSummary");
   }
 }
 
@@ -5643,7 +5642,7 @@ export interface ProvisioningTemplateVersionSummary {
 
 export namespace ProvisioningTemplateVersionSummary {
   export function isa(o: any): o is ProvisioningTemplateVersionSummary {
-    return _smithy.isa(o, "ProvisioningTemplateVersionSummary");
+    return __isa(o, "ProvisioningTemplateVersionSummary");
   }
 }
 
@@ -5681,7 +5680,7 @@ export interface RegisterCACertificateRequest {
 
 export namespace RegisterCACertificateRequest {
   export function isa(o: any): o is RegisterCACertificateRequest {
-    return _smithy.isa(o, "RegisterCACertificateRequest");
+    return __isa(o, "RegisterCACertificateRequest");
   }
 }
 
@@ -5703,7 +5702,7 @@ export interface RegisterCACertificateResponse extends $MetadataBearer {
 
 export namespace RegisterCACertificateResponse {
   export function isa(o: any): o is RegisterCACertificateResponse {
-    return _smithy.isa(o, "RegisterCACertificateResponse");
+    return __isa(o, "RegisterCACertificateResponse");
   }
 }
 
@@ -5735,7 +5734,7 @@ export interface RegisterCertificateRequest {
 
 export namespace RegisterCertificateRequest {
   export function isa(o: any): o is RegisterCertificateRequest {
-    return _smithy.isa(o, "RegisterCertificateRequest");
+    return __isa(o, "RegisterCertificateRequest");
   }
 }
 
@@ -5757,7 +5756,7 @@ export interface RegisterCertificateResponse extends $MetadataBearer {
 
 export namespace RegisterCertificateResponse {
   export function isa(o: any): o is RegisterCertificateResponse {
-    return _smithy.isa(o, "RegisterCertificateResponse");
+    return __isa(o, "RegisterCertificateResponse");
   }
 }
 
@@ -5778,7 +5777,7 @@ export interface RegisterThingRequest {
 
 export namespace RegisterThingRequest {
   export function isa(o: any): o is RegisterThingRequest {
-    return _smithy.isa(o, "RegisterThingRequest");
+    return __isa(o, "RegisterThingRequest");
   }
 }
 
@@ -5797,7 +5796,7 @@ export interface RegisterThingResponse extends $MetadataBearer {
 
 export namespace RegisterThingResponse {
   export function isa(o: any): o is RegisterThingResponse {
-    return _smithy.isa(o, "RegisterThingResponse");
+    return __isa(o, "RegisterThingResponse");
   }
 }
 
@@ -5819,7 +5818,7 @@ export interface RegistrationConfig {
 
 export namespace RegistrationConfig {
   export function isa(o: any): o is RegistrationConfig {
-    return _smithy.isa(o, "RegistrationConfig");
+    return __isa(o, "RegistrationConfig");
   }
 }
 
@@ -5842,7 +5841,7 @@ export interface RejectCertificateTransferRequest {
 
 export namespace RejectCertificateTransferRequest {
   export function isa(o: any): o is RejectCertificateTransferRequest {
-    return _smithy.isa(o, "RejectCertificateTransferRequest");
+    return __isa(o, "RejectCertificateTransferRequest");
   }
 }
 
@@ -5889,7 +5888,7 @@ export interface RoleAliasDescription {
 
 export namespace RoleAliasDescription {
   export function isa(o: any): o is RoleAliasDescription {
-    return _smithy.isa(o, "RoleAliasDescription");
+    return __isa(o, "RoleAliasDescription");
   }
 }
 
@@ -5921,7 +5920,7 @@ export interface ServerCertificateSummary {
 
 export namespace ServerCertificateSummary {
   export function isa(o: any): o is ServerCertificateSummary {
-    return _smithy.isa(o, "ServerCertificateSummary");
+    return __isa(o, "ServerCertificateSummary");
   }
 }
 
@@ -5941,7 +5940,7 @@ export interface SetDefaultAuthorizerRequest {
 
 export namespace SetDefaultAuthorizerRequest {
   export function isa(o: any): o is SetDefaultAuthorizerRequest {
-    return _smithy.isa(o, "SetDefaultAuthorizerRequest");
+    return __isa(o, "SetDefaultAuthorizerRequest");
   }
 }
 
@@ -5960,7 +5959,7 @@ export interface SetDefaultAuthorizerResponse extends $MetadataBearer {
 
 export namespace SetDefaultAuthorizerResponse {
   export function isa(o: any): o is SetDefaultAuthorizerResponse {
-    return _smithy.isa(o, "SetDefaultAuthorizerResponse");
+    return __isa(o, "SetDefaultAuthorizerResponse");
   }
 }
 
@@ -5982,7 +5981,7 @@ export interface SetDefaultPolicyVersionRequest {
 
 export namespace SetDefaultPolicyVersionRequest {
   export function isa(o: any): o is SetDefaultPolicyVersionRequest {
-    return _smithy.isa(o, "SetDefaultPolicyVersionRequest");
+    return __isa(o, "SetDefaultPolicyVersionRequest");
   }
 }
 
@@ -6024,7 +6023,7 @@ export interface TestAuthorizationRequest {
 
 export namespace TestAuthorizationRequest {
   export function isa(o: any): o is TestAuthorizationRequest {
-    return _smithy.isa(o, "TestAuthorizationRequest");
+    return __isa(o, "TestAuthorizationRequest");
   }
 }
 
@@ -6038,7 +6037,7 @@ export interface TestAuthorizationResponse extends $MetadataBearer {
 
 export namespace TestAuthorizationResponse {
   export function isa(o: any): o is TestAuthorizationResponse {
-    return _smithy.isa(o, "TestAuthorizationResponse");
+    return __isa(o, "TestAuthorizationResponse");
   }
 }
 
@@ -6078,7 +6077,7 @@ export interface TestInvokeAuthorizerRequest {
 
 export namespace TestInvokeAuthorizerRequest {
   export function isa(o: any): o is TestInvokeAuthorizerRequest {
-    return _smithy.isa(o, "TestInvokeAuthorizerRequest");
+    return __isa(o, "TestInvokeAuthorizerRequest");
   }
 }
 
@@ -6112,7 +6111,7 @@ export interface TestInvokeAuthorizerResponse extends $MetadataBearer {
 
 export namespace TestInvokeAuthorizerResponse {
   export function isa(o: any): o is TestInvokeAuthorizerResponse {
-    return _smithy.isa(o, "TestInvokeAuthorizerResponse");
+    return __isa(o, "TestInvokeAuthorizerResponse");
   }
 }
 
@@ -6129,7 +6128,7 @@ export interface TlsContext {
 
 export namespace TlsContext {
   export function isa(o: any): o is TlsContext {
-    return _smithy.isa(o, "TlsContext");
+    return __isa(o, "TlsContext");
   }
 }
 
@@ -6157,7 +6156,7 @@ export interface TransferCertificateRequest {
 
 export namespace TransferCertificateRequest {
   export function isa(o: any): o is TransferCertificateRequest {
-    return _smithy.isa(o, "TransferCertificateRequest");
+    return __isa(o, "TransferCertificateRequest");
   }
 }
 
@@ -6174,7 +6173,7 @@ export interface TransferCertificateResponse extends $MetadataBearer {
 
 export namespace TransferCertificateResponse {
   export function isa(o: any): o is TransferCertificateResponse {
-    return _smithy.isa(o, "TransferCertificateResponse");
+    return __isa(o, "TransferCertificateResponse");
   }
 }
 
@@ -6211,7 +6210,7 @@ export interface TransferData {
 
 export namespace TransferData {
   export function isa(o: any): o is TransferData {
-    return _smithy.isa(o, "TransferData");
+    return __isa(o, "TransferData");
   }
 }
 
@@ -6245,7 +6244,7 @@ export interface UpdateAuthorizerRequest {
 
 export namespace UpdateAuthorizerRequest {
   export function isa(o: any): o is UpdateAuthorizerRequest {
-    return _smithy.isa(o, "UpdateAuthorizerRequest");
+    return __isa(o, "UpdateAuthorizerRequest");
   }
 }
 
@@ -6264,7 +6263,7 @@ export interface UpdateAuthorizerResponse extends $MetadataBearer {
 
 export namespace UpdateAuthorizerResponse {
   export function isa(o: any): o is UpdateAuthorizerResponse {
-    return _smithy.isa(o, "UpdateAuthorizerResponse");
+    return __isa(o, "UpdateAuthorizerResponse");
   }
 }
 
@@ -6305,7 +6304,7 @@ export interface UpdateCACertificateRequest {
 
 export namespace UpdateCACertificateRequest {
   export function isa(o: any): o is UpdateCACertificateRequest {
-    return _smithy.isa(o, "UpdateCACertificateRequest");
+    return __isa(o, "UpdateCACertificateRequest");
   }
 }
 
@@ -6335,7 +6334,7 @@ export interface UpdateCertificateRequest {
 
 export namespace UpdateCertificateRequest {
   export function isa(o: any): o is UpdateCertificateRequest {
-    return _smithy.isa(o, "UpdateCertificateRequest");
+    return __isa(o, "UpdateCertificateRequest");
   }
 }
 
@@ -6364,7 +6363,7 @@ export interface UpdateDomainConfigurationRequest {
 
 export namespace UpdateDomainConfigurationRequest {
   export function isa(o: any): o is UpdateDomainConfigurationRequest {
-    return _smithy.isa(o, "UpdateDomainConfigurationRequest");
+    return __isa(o, "UpdateDomainConfigurationRequest");
   }
 }
 
@@ -6383,7 +6382,7 @@ export interface UpdateDomainConfigurationResponse extends $MetadataBearer {
 
 export namespace UpdateDomainConfigurationResponse {
   export function isa(o: any): o is UpdateDomainConfigurationResponse {
-    return _smithy.isa(o, "UpdateDomainConfigurationResponse");
+    return __isa(o, "UpdateDomainConfigurationResponse");
   }
 }
 
@@ -6418,7 +6417,7 @@ export interface UpdateProvisioningTemplateRequest {
 
 export namespace UpdateProvisioningTemplateRequest {
   export function isa(o: any): o is UpdateProvisioningTemplateRequest {
-    return _smithy.isa(o, "UpdateProvisioningTemplateRequest");
+    return __isa(o, "UpdateProvisioningTemplateRequest");
   }
 }
 
@@ -6428,7 +6427,7 @@ export interface UpdateProvisioningTemplateResponse extends $MetadataBearer {
 
 export namespace UpdateProvisioningTemplateResponse {
   export function isa(o: any): o is UpdateProvisioningTemplateResponse {
-    return _smithy.isa(o, "UpdateProvisioningTemplateResponse");
+    return __isa(o, "UpdateProvisioningTemplateResponse");
   }
 }
 
@@ -6452,7 +6451,7 @@ export interface UpdateRoleAliasRequest {
 
 export namespace UpdateRoleAliasRequest {
   export function isa(o: any): o is UpdateRoleAliasRequest {
-    return _smithy.isa(o, "UpdateRoleAliasRequest");
+    return __isa(o, "UpdateRoleAliasRequest");
   }
 }
 
@@ -6471,7 +6470,7 @@ export interface UpdateRoleAliasResponse extends $MetadataBearer {
 
 export namespace UpdateRoleAliasResponse {
   export function isa(o: any): o is UpdateRoleAliasResponse {
-    return _smithy.isa(o, "UpdateRoleAliasResponse");
+    return __isa(o, "UpdateRoleAliasResponse");
   }
 }
 
@@ -6485,7 +6484,7 @@ export interface DescribeIndexRequest {
 
 export namespace DescribeIndexRequest {
   export function isa(o: any): o is DescribeIndexRequest {
-    return _smithy.isa(o, "DescribeIndexRequest");
+    return __isa(o, "DescribeIndexRequest");
   }
 }
 
@@ -6526,7 +6525,7 @@ export interface DescribeIndexResponse extends $MetadataBearer {
 
 export namespace DescribeIndexResponse {
   export function isa(o: any): o is DescribeIndexResponse {
-    return _smithy.isa(o, "DescribeIndexResponse");
+    return __isa(o, "DescribeIndexResponse");
   }
 }
 
@@ -6548,7 +6547,7 @@ export interface Field {
 
 export namespace Field {
   export function isa(o: any): o is Field {
-    return _smithy.isa(o, "Field");
+    return __isa(o, "Field");
   }
 }
 
@@ -6583,7 +6582,7 @@ export interface GetCardinalityRequest {
 
 export namespace GetCardinalityRequest {
   export function isa(o: any): o is GetCardinalityRequest {
-    return _smithy.isa(o, "GetCardinalityRequest");
+    return __isa(o, "GetCardinalityRequest");
   }
 }
 
@@ -6597,7 +6596,7 @@ export interface GetCardinalityResponse extends $MetadataBearer {
 
 export namespace GetCardinalityResponse {
   export function isa(o: any): o is GetCardinalityResponse {
-    return _smithy.isa(o, "GetCardinalityResponse");
+    return __isa(o, "GetCardinalityResponse");
   }
 }
 
@@ -6607,7 +6606,7 @@ export interface GetIndexingConfigurationRequest {
 
 export namespace GetIndexingConfigurationRequest {
   export function isa(o: any): o is GetIndexingConfigurationRequest {
-    return _smithy.isa(o, "GetIndexingConfigurationRequest");
+    return __isa(o, "GetIndexingConfigurationRequest");
   }
 }
 
@@ -6626,7 +6625,7 @@ export interface GetIndexingConfigurationResponse extends $MetadataBearer {
 
 export namespace GetIndexingConfigurationResponse {
   export function isa(o: any): o is GetIndexingConfigurationResponse {
-    return _smithy.isa(o, "GetIndexingConfigurationResponse");
+    return __isa(o, "GetIndexingConfigurationResponse");
   }
 }
 
@@ -6660,7 +6659,7 @@ export interface GetPercentilesRequest {
 
 export namespace GetPercentilesRequest {
   export function isa(o: any): o is GetPercentilesRequest {
-    return _smithy.isa(o, "GetPercentilesRequest");
+    return __isa(o, "GetPercentilesRequest");
   }
 }
 
@@ -6674,7 +6673,7 @@ export interface GetPercentilesResponse extends $MetadataBearer {
 
 export namespace GetPercentilesResponse {
   export function isa(o: any): o is GetPercentilesResponse {
-    return _smithy.isa(o, "GetPercentilesResponse");
+    return __isa(o, "GetPercentilesResponse");
   }
 }
 
@@ -6704,7 +6703,7 @@ export interface GetStatisticsRequest {
 
 export namespace GetStatisticsRequest {
   export function isa(o: any): o is GetStatisticsRequest {
-    return _smithy.isa(o, "GetStatisticsRequest");
+    return __isa(o, "GetStatisticsRequest");
   }
 }
 
@@ -6719,7 +6718,7 @@ export interface GetStatisticsResponse extends $MetadataBearer {
 
 export namespace GetStatisticsResponse {
   export function isa(o: any): o is GetStatisticsResponse {
-    return _smithy.isa(o, "GetStatisticsResponse");
+    return __isa(o, "GetStatisticsResponse");
   }
 }
 
@@ -6727,7 +6726,7 @@ export namespace GetStatisticsResponse {
  * <p>The index is not ready.</p>
  */
 export interface IndexNotReadyException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "IndexNotReadyException";
   $fault: "client";
@@ -6739,7 +6738,7 @@ export interface IndexNotReadyException
 
 export namespace IndexNotReadyException {
   export function isa(o: any): o is IndexNotReadyException {
-    return _smithy.isa(o, "IndexNotReadyException");
+    return __isa(o, "IndexNotReadyException");
   }
 }
 
@@ -6765,7 +6764,7 @@ export interface ListIndicesRequest {
 
 export namespace ListIndicesRequest {
   export function isa(o: any): o is ListIndicesRequest {
-    return _smithy.isa(o, "ListIndicesRequest");
+    return __isa(o, "ListIndicesRequest");
   }
 }
 
@@ -6785,7 +6784,7 @@ export interface ListIndicesResponse extends $MetadataBearer {
 
 export namespace ListIndicesResponse {
   export function isa(o: any): o is ListIndicesResponse {
-    return _smithy.isa(o, "ListIndicesResponse");
+    return __isa(o, "ListIndicesResponse");
   }
 }
 
@@ -6807,7 +6806,7 @@ export interface PercentPair {
 
 export namespace PercentPair {
   export function isa(o: any): o is PercentPair {
-    return _smithy.isa(o, "PercentPair");
+    return __isa(o, "PercentPair");
   }
 }
 
@@ -6842,7 +6841,7 @@ export interface SearchIndexRequest {
 
 export namespace SearchIndexRequest {
   export function isa(o: any): o is SearchIndexRequest {
-    return _smithy.isa(o, "SearchIndexRequest");
+    return __isa(o, "SearchIndexRequest");
   }
 }
 
@@ -6867,7 +6866,7 @@ export interface SearchIndexResponse extends $MetadataBearer {
 
 export namespace SearchIndexResponse {
   export function isa(o: any): o is SearchIndexResponse {
-    return _smithy.isa(o, "SearchIndexResponse");
+    return __isa(o, "SearchIndexResponse");
   }
 }
 
@@ -6920,7 +6919,7 @@ export interface Statistics {
 
 export namespace Statistics {
   export function isa(o: any): o is Statistics {
-    return _smithy.isa(o, "Statistics");
+    return __isa(o, "Statistics");
   }
 }
 
@@ -6944,7 +6943,7 @@ export interface ThingConnectivity {
 
 export namespace ThingConnectivity {
   export function isa(o: any): o is ThingConnectivity {
-    return _smithy.isa(o, "ThingConnectivity");
+    return __isa(o, "ThingConnectivity");
   }
 }
 
@@ -6996,7 +6995,7 @@ export interface ThingDocument {
 
 export namespace ThingDocument {
   export function isa(o: any): o is ThingDocument {
-    return _smithy.isa(o, "ThingDocument");
+    return __isa(o, "ThingDocument");
   }
 }
 
@@ -7033,7 +7032,7 @@ export interface ThingGroupDocument {
 
 export namespace ThingGroupDocument {
   export function isa(o: any): o is ThingGroupDocument {
-    return _smithy.isa(o, "ThingGroupDocument");
+    return __isa(o, "ThingGroupDocument");
   }
 }
 
@@ -7063,7 +7062,7 @@ export interface ThingGroupIndexingConfiguration {
 
 export namespace ThingGroupIndexingConfiguration {
   export function isa(o: any): o is ThingGroupIndexingConfiguration {
-    return _smithy.isa(o, "ThingGroupIndexingConfiguration");
+    return __isa(o, "ThingGroupIndexingConfiguration");
   }
 }
 
@@ -7122,7 +7121,7 @@ export interface ThingIndexingConfiguration {
 
 export namespace ThingIndexingConfiguration {
   export function isa(o: any): o is ThingIndexingConfiguration {
-    return _smithy.isa(o, "ThingIndexingConfiguration");
+    return __isa(o, "ThingIndexingConfiguration");
   }
 }
 
@@ -7147,7 +7146,7 @@ export interface UpdateIndexingConfigurationRequest {
 
 export namespace UpdateIndexingConfigurationRequest {
   export function isa(o: any): o is UpdateIndexingConfigurationRequest {
-    return _smithy.isa(o, "UpdateIndexingConfigurationRequest");
+    return __isa(o, "UpdateIndexingConfigurationRequest");
   }
 }
 
@@ -7157,7 +7156,7 @@ export interface UpdateIndexingConfigurationResponse extends $MetadataBearer {
 
 export namespace UpdateIndexingConfigurationResponse {
   export function isa(o: any): o is UpdateIndexingConfigurationResponse {
-    return _smithy.isa(o, "UpdateIndexingConfigurationResponse");
+    return __isa(o, "UpdateIndexingConfigurationResponse");
   }
 }
 
@@ -7178,7 +7177,7 @@ export interface AbortConfig {
 
 export namespace AbortConfig {
   export function isa(o: any): o is AbortConfig {
-    return _smithy.isa(o, "AbortConfig");
+    return __isa(o, "AbortConfig");
   }
 }
 
@@ -7211,7 +7210,7 @@ export interface AbortCriteria {
 
 export namespace AbortCriteria {
   export function isa(o: any): o is AbortCriteria {
-    return _smithy.isa(o, "AbortCriteria");
+    return __isa(o, "AbortCriteria");
   }
 }
 
@@ -7235,7 +7234,7 @@ export interface AssociateTargetsWithJobRequest {
 
 export namespace AssociateTargetsWithJobRequest {
   export function isa(o: any): o is AssociateTargetsWithJobRequest {
-    return _smithy.isa(o, "AssociateTargetsWithJobRequest");
+    return __isa(o, "AssociateTargetsWithJobRequest");
   }
 }
 
@@ -7259,7 +7258,7 @@ export interface AssociateTargetsWithJobResponse extends $MetadataBearer {
 
 export namespace AssociateTargetsWithJobResponse {
   export function isa(o: any): o is AssociateTargetsWithJobResponse {
-    return _smithy.isa(o, "AssociateTargetsWithJobResponse");
+    return __isa(o, "AssociateTargetsWithJobResponse");
   }
 }
 
@@ -7306,7 +7305,7 @@ export interface CancelJobExecutionRequest {
 
 export namespace CancelJobExecutionRequest {
   export function isa(o: any): o is CancelJobExecutionRequest {
-    return _smithy.isa(o, "CancelJobExecutionRequest");
+    return __isa(o, "CancelJobExecutionRequest");
   }
 }
 
@@ -7340,7 +7339,7 @@ export interface CancelJobRequest {
 
 export namespace CancelJobRequest {
   export function isa(o: any): o is CancelJobRequest {
-    return _smithy.isa(o, "CancelJobRequest");
+    return __isa(o, "CancelJobRequest");
   }
 }
 
@@ -7364,7 +7363,7 @@ export interface CancelJobResponse extends $MetadataBearer {
 
 export namespace CancelJobResponse {
   export function isa(o: any): o is CancelJobResponse {
-    return _smithy.isa(o, "CancelJobResponse");
+    return __isa(o, "CancelJobResponse");
   }
 }
 
@@ -7443,7 +7442,7 @@ export interface CreateJobRequest {
 
 export namespace CreateJobRequest {
   export function isa(o: any): o is CreateJobRequest {
-    return _smithy.isa(o, "CreateJobRequest");
+    return __isa(o, "CreateJobRequest");
   }
 }
 
@@ -7467,7 +7466,7 @@ export interface CreateJobResponse extends $MetadataBearer {
 
 export namespace CreateJobResponse {
   export function isa(o: any): o is CreateJobResponse {
-    return _smithy.isa(o, "CreateJobResponse");
+    return __isa(o, "CreateJobResponse");
   }
 }
 
@@ -7506,7 +7505,7 @@ export interface DeleteJobExecutionRequest {
 
 export namespace DeleteJobExecutionRequest {
   export function isa(o: any): o is DeleteJobExecutionRequest {
-    return _smithy.isa(o, "DeleteJobExecutionRequest");
+    return __isa(o, "DeleteJobExecutionRequest");
   }
 }
 
@@ -7536,7 +7535,7 @@ export interface DeleteJobRequest {
 
 export namespace DeleteJobRequest {
   export function isa(o: any): o is DeleteJobRequest {
-    return _smithy.isa(o, "DeleteJobRequest");
+    return __isa(o, "DeleteJobRequest");
   }
 }
 
@@ -7561,7 +7560,7 @@ export interface DescribeJobExecutionRequest {
 
 export namespace DescribeJobExecutionRequest {
   export function isa(o: any): o is DescribeJobExecutionRequest {
-    return _smithy.isa(o, "DescribeJobExecutionRequest");
+    return __isa(o, "DescribeJobExecutionRequest");
   }
 }
 
@@ -7575,7 +7574,7 @@ export interface DescribeJobExecutionResponse extends $MetadataBearer {
 
 export namespace DescribeJobExecutionResponse {
   export function isa(o: any): o is DescribeJobExecutionResponse {
-    return _smithy.isa(o, "DescribeJobExecutionResponse");
+    return __isa(o, "DescribeJobExecutionResponse");
   }
 }
 
@@ -7589,7 +7588,7 @@ export interface DescribeJobRequest {
 
 export namespace DescribeJobRequest {
   export function isa(o: any): o is DescribeJobRequest {
-    return _smithy.isa(o, "DescribeJobRequest");
+    return __isa(o, "DescribeJobRequest");
   }
 }
 
@@ -7608,7 +7607,7 @@ export interface DescribeJobResponse extends $MetadataBearer {
 
 export namespace DescribeJobResponse {
   export function isa(o: any): o is DescribeJobResponse {
-    return _smithy.isa(o, "DescribeJobResponse");
+    return __isa(o, "DescribeJobResponse");
   }
 }
 
@@ -7637,7 +7636,7 @@ export interface ExponentialRolloutRate {
 
 export namespace ExponentialRolloutRate {
   export function isa(o: any): o is ExponentialRolloutRate {
-    return _smithy.isa(o, "ExponentialRolloutRate");
+    return __isa(o, "ExponentialRolloutRate");
   }
 }
 
@@ -7651,7 +7650,7 @@ export interface GetJobDocumentRequest {
 
 export namespace GetJobDocumentRequest {
   export function isa(o: any): o is GetJobDocumentRequest {
-    return _smithy.isa(o, "GetJobDocumentRequest");
+    return __isa(o, "GetJobDocumentRequest");
   }
 }
 
@@ -7665,7 +7664,7 @@ export interface GetJobDocumentResponse extends $MetadataBearer {
 
 export namespace GetJobDocumentResponse {
   export function isa(o: any): o is GetJobDocumentResponse {
-    return _smithy.isa(o, "GetJobDocumentResponse");
+    return __isa(o, "GetJobDocumentResponse");
   }
 }
 
@@ -7771,7 +7770,7 @@ export interface Job {
 
 export namespace Job {
   export function isa(o: any): o is Job {
-    return _smithy.isa(o, "Job");
+    return __isa(o, "Job");
   }
 }
 
@@ -7846,7 +7845,7 @@ export interface JobExecution {
 
 export namespace JobExecution {
   export function isa(o: any): o is JobExecution {
-    return _smithy.isa(o, "JobExecution");
+    return __isa(o, "JobExecution");
   }
 }
 
@@ -7870,7 +7869,7 @@ export interface JobExecutionStatusDetails {
 
 export namespace JobExecutionStatusDetails {
   export function isa(o: any): o is JobExecutionStatusDetails {
-    return _smithy.isa(o, "JobExecutionStatusDetails");
+    return __isa(o, "JobExecutionStatusDetails");
   }
 }
 
@@ -7909,7 +7908,7 @@ export interface JobExecutionSummary {
 
 export namespace JobExecutionSummary {
   export function isa(o: any): o is JobExecutionSummary {
-    return _smithy.isa(o, "JobExecutionSummary");
+    return __isa(o, "JobExecutionSummary");
   }
 }
 
@@ -7931,7 +7930,7 @@ export interface JobExecutionSummaryForJob {
 
 export namespace JobExecutionSummaryForJob {
   export function isa(o: any): o is JobExecutionSummaryForJob {
-    return _smithy.isa(o, "JobExecutionSummaryForJob");
+    return __isa(o, "JobExecutionSummaryForJob");
   }
 }
 
@@ -7953,7 +7952,7 @@ export interface JobExecutionSummaryForThing {
 
 export namespace JobExecutionSummaryForThing {
   export function isa(o: any): o is JobExecutionSummaryForThing {
-    return _smithy.isa(o, "JobExecutionSummaryForThing");
+    return __isa(o, "JobExecutionSummaryForThing");
   }
 }
 
@@ -7977,7 +7976,7 @@ export interface JobExecutionsRolloutConfig {
 
 export namespace JobExecutionsRolloutConfig {
   export function isa(o: any): o is JobExecutionsRolloutConfig {
-    return _smithy.isa(o, "JobExecutionsRolloutConfig");
+    return __isa(o, "JobExecutionsRolloutConfig");
   }
 }
 
@@ -8035,7 +8034,7 @@ export interface JobProcessDetails {
 
 export namespace JobProcessDetails {
   export function isa(o: any): o is JobProcessDetails {
-    return _smithy.isa(o, "JobProcessDetails");
+    return __isa(o, "JobProcessDetails");
   }
 }
 
@@ -8090,7 +8089,7 @@ export interface JobSummary {
 
 export namespace JobSummary {
   export function isa(o: any): o is JobSummary {
-    return _smithy.isa(o, "JobSummary");
+    return __isa(o, "JobSummary");
   }
 }
 
@@ -8119,7 +8118,7 @@ export interface ListJobExecutionsForJobRequest {
 
 export namespace ListJobExecutionsForJobRequest {
   export function isa(o: any): o is ListJobExecutionsForJobRequest {
-    return _smithy.isa(o, "ListJobExecutionsForJobRequest");
+    return __isa(o, "ListJobExecutionsForJobRequest");
   }
 }
 
@@ -8139,7 +8138,7 @@ export interface ListJobExecutionsForJobResponse extends $MetadataBearer {
 
 export namespace ListJobExecutionsForJobResponse {
   export function isa(o: any): o is ListJobExecutionsForJobResponse {
-    return _smithy.isa(o, "ListJobExecutionsForJobResponse");
+    return __isa(o, "ListJobExecutionsForJobResponse");
   }
 }
 
@@ -8168,7 +8167,7 @@ export interface ListJobExecutionsForThingRequest {
 
 export namespace ListJobExecutionsForThingRequest {
   export function isa(o: any): o is ListJobExecutionsForThingRequest {
-    return _smithy.isa(o, "ListJobExecutionsForThingRequest");
+    return __isa(o, "ListJobExecutionsForThingRequest");
   }
 }
 
@@ -8188,7 +8187,7 @@ export interface ListJobExecutionsForThingResponse extends $MetadataBearer {
 
 export namespace ListJobExecutionsForThingResponse {
   export function isa(o: any): o is ListJobExecutionsForThingResponse {
-    return _smithy.isa(o, "ListJobExecutionsForThingResponse");
+    return __isa(o, "ListJobExecutionsForThingResponse");
   }
 }
 
@@ -8230,7 +8229,7 @@ export interface ListJobsRequest {
 
 export namespace ListJobsRequest {
   export function isa(o: any): o is ListJobsRequest {
-    return _smithy.isa(o, "ListJobsRequest");
+    return __isa(o, "ListJobsRequest");
   }
 }
 
@@ -8250,7 +8249,7 @@ export interface ListJobsResponse extends $MetadataBearer {
 
 export namespace ListJobsResponse {
   export function isa(o: any): o is ListJobsResponse {
-    return _smithy.isa(o, "ListJobsResponse");
+    return __isa(o, "ListJobsResponse");
   }
 }
 
@@ -8274,7 +8273,7 @@ export interface PresignedUrlConfig {
 
 export namespace PresignedUrlConfig {
   export function isa(o: any): o is PresignedUrlConfig {
-    return _smithy.isa(o, "PresignedUrlConfig");
+    return __isa(o, "PresignedUrlConfig");
   }
 }
 
@@ -8296,7 +8295,7 @@ export interface RateIncreaseCriteria {
 
 export namespace RateIncreaseCriteria {
   export function isa(o: any): o is RateIncreaseCriteria {
-    return _smithy.isa(o, "RateIncreaseCriteria");
+    return __isa(o, "RateIncreaseCriteria");
   }
 }
 
@@ -8325,7 +8324,7 @@ export interface TimeoutConfig {
 
 export namespace TimeoutConfig {
   export function isa(o: any): o is TimeoutConfig {
-    return _smithy.isa(o, "TimeoutConfig");
+    return __isa(o, "TimeoutConfig");
   }
 }
 
@@ -8365,7 +8364,7 @@ export interface UpdateJobRequest {
 
 export namespace UpdateJobRequest {
   export function isa(o: any): o is UpdateJobRequest {
-    return _smithy.isa(o, "UpdateJobRequest");
+    return __isa(o, "UpdateJobRequest");
   }
 }
 
@@ -8400,7 +8399,7 @@ export interface AwsJobExecutionsRolloutConfig {
 
 export namespace AwsJobExecutionsRolloutConfig {
   export function isa(o: any): o is AwsJobExecutionsRolloutConfig {
-    return _smithy.isa(o, "AwsJobExecutionsRolloutConfig");
+    return __isa(o, "AwsJobExecutionsRolloutConfig");
   }
 }
 
@@ -8419,7 +8418,7 @@ export interface AwsJobPresignedUrlConfig {
 
 export namespace AwsJobPresignedUrlConfig {
   export function isa(o: any): o is AwsJobPresignedUrlConfig {
-    return _smithy.isa(o, "AwsJobPresignedUrlConfig");
+    return __isa(o, "AwsJobPresignedUrlConfig");
   }
 }
 
@@ -8446,7 +8445,7 @@ export interface CodeSigning {
 
 export namespace CodeSigning {
   export function isa(o: any): o is CodeSigning {
-    return _smithy.isa(o, "CodeSigning");
+    return __isa(o, "CodeSigning");
   }
 }
 
@@ -8468,7 +8467,7 @@ export interface CodeSigningCertificateChain {
 
 export namespace CodeSigningCertificateChain {
   export function isa(o: any): o is CodeSigningCertificateChain {
-    return _smithy.isa(o, "CodeSigningCertificateChain");
+    return __isa(o, "CodeSigningCertificateChain");
   }
 }
 
@@ -8485,7 +8484,7 @@ export interface CodeSigningSignature {
 
 export namespace CodeSigningSignature {
   export function isa(o: any): o is CodeSigningSignature {
-    return _smithy.isa(o, "CodeSigningSignature");
+    return __isa(o, "CodeSigningSignature");
   }
 }
 
@@ -8554,7 +8553,7 @@ export interface CreateOTAUpdateRequest {
 
 export namespace CreateOTAUpdateRequest {
   export function isa(o: any): o is CreateOTAUpdateRequest {
-    return _smithy.isa(o, "CreateOTAUpdateRequest");
+    return __isa(o, "CreateOTAUpdateRequest");
   }
 }
 
@@ -8588,7 +8587,7 @@ export interface CreateOTAUpdateResponse extends $MetadataBearer {
 
 export namespace CreateOTAUpdateResponse {
   export function isa(o: any): o is CreateOTAUpdateResponse {
-    return _smithy.isa(o, "CreateOTAUpdateResponse");
+    return __isa(o, "CreateOTAUpdateResponse");
   }
 }
 
@@ -8620,7 +8619,7 @@ export interface CustomCodeSigning {
 
 export namespace CustomCodeSigning {
   export function isa(o: any): o is CustomCodeSigning {
-    return _smithy.isa(o, "CustomCodeSigning");
+    return __isa(o, "CustomCodeSigning");
   }
 }
 
@@ -8644,7 +8643,7 @@ export interface DeleteOTAUpdateRequest {
 
 export namespace DeleteOTAUpdateRequest {
   export function isa(o: any): o is DeleteOTAUpdateRequest {
-    return _smithy.isa(o, "DeleteOTAUpdateRequest");
+    return __isa(o, "DeleteOTAUpdateRequest");
   }
 }
 
@@ -8654,7 +8653,7 @@ export interface DeleteOTAUpdateResponse extends $MetadataBearer {
 
 export namespace DeleteOTAUpdateResponse {
   export function isa(o: any): o is DeleteOTAUpdateResponse {
-    return _smithy.isa(o, "DeleteOTAUpdateResponse");
+    return __isa(o, "DeleteOTAUpdateResponse");
   }
 }
 
@@ -8671,7 +8670,7 @@ export interface Destination {
 
 export namespace Destination {
   export function isa(o: any): o is Destination {
-    return _smithy.isa(o, "Destination");
+    return __isa(o, "Destination");
   }
 }
 
@@ -8693,7 +8692,7 @@ export interface ErrorInfo {
 
 export namespace ErrorInfo {
   export function isa(o: any): o is ErrorInfo {
-    return _smithy.isa(o, "ErrorInfo");
+    return __isa(o, "ErrorInfo");
   }
 }
 
@@ -8715,7 +8714,7 @@ export interface FileLocation {
 
 export namespace FileLocation {
   export function isa(o: any): o is FileLocation {
-    return _smithy.isa(o, "FileLocation");
+    return __isa(o, "FileLocation");
   }
 }
 
@@ -8729,7 +8728,7 @@ export interface GetOTAUpdateRequest {
 
 export namespace GetOTAUpdateRequest {
   export function isa(o: any): o is GetOTAUpdateRequest {
-    return _smithy.isa(o, "GetOTAUpdateRequest");
+    return __isa(o, "GetOTAUpdateRequest");
   }
 }
 
@@ -8743,7 +8742,7 @@ export interface GetOTAUpdateResponse extends $MetadataBearer {
 
 export namespace GetOTAUpdateResponse {
   export function isa(o: any): o is GetOTAUpdateResponse {
-    return _smithy.isa(o, "GetOTAUpdateResponse");
+    return __isa(o, "GetOTAUpdateResponse");
   }
 }
 
@@ -8767,7 +8766,7 @@ export interface ListOTAUpdatesRequest {
 
 export namespace ListOTAUpdatesRequest {
   export function isa(o: any): o is ListOTAUpdatesRequest {
-    return _smithy.isa(o, "ListOTAUpdatesRequest");
+    return __isa(o, "ListOTAUpdatesRequest");
   }
 }
 
@@ -8786,7 +8785,7 @@ export interface ListOTAUpdatesResponse extends $MetadataBearer {
 
 export namespace ListOTAUpdatesResponse {
   export function isa(o: any): o is ListOTAUpdatesResponse {
-    return _smithy.isa(o, "ListOTAUpdatesResponse");
+    return __isa(o, "ListOTAUpdatesResponse");
   }
 }
 
@@ -8823,7 +8822,7 @@ export interface OTAUpdateFile {
 
 export namespace OTAUpdateFile {
   export function isa(o: any): o is OTAUpdateFile {
-    return _smithy.isa(o, "OTAUpdateFile");
+    return __isa(o, "OTAUpdateFile");
   }
 }
 
@@ -8921,7 +8920,7 @@ export interface OTAUpdateInfo {
 
 export namespace OTAUpdateInfo {
   export function isa(o: any): o is OTAUpdateInfo {
-    return _smithy.isa(o, "OTAUpdateInfo");
+    return __isa(o, "OTAUpdateInfo");
   }
 }
 
@@ -8955,7 +8954,7 @@ export interface OTAUpdateSummary {
 
 export namespace OTAUpdateSummary {
   export function isa(o: any): o is OTAUpdateSummary {
-    return _smithy.isa(o, "OTAUpdateSummary");
+    return __isa(o, "OTAUpdateSummary");
   }
 }
 
@@ -8977,7 +8976,7 @@ export interface S3Destination {
 
 export namespace S3Destination {
   export function isa(o: any): o is S3Destination {
-    return _smithy.isa(o, "S3Destination");
+    return __isa(o, "S3Destination");
   }
 }
 
@@ -9004,7 +9003,7 @@ export interface SigningProfileParameter {
 
 export namespace SigningProfileParameter {
   export function isa(o: any): o is SigningProfileParameter {
-    return _smithy.isa(o, "SigningProfileParameter");
+    return __isa(o, "SigningProfileParameter");
   }
 }
 
@@ -9031,7 +9030,7 @@ export interface StartSigningJobParameter {
 
 export namespace StartSigningJobParameter {
   export function isa(o: any): o is StartSigningJobParameter {
-    return _smithy.isa(o, "StartSigningJobParameter");
+    return __isa(o, "StartSigningJobParameter");
   }
 }
 
@@ -9053,7 +9052,7 @@ export interface _Stream {
 
 export namespace _Stream {
   export function isa(o: any): o is _Stream {
-    return _smithy.isa(o, "Stream");
+    return __isa(o, "Stream");
   }
 }
 
@@ -9082,7 +9081,7 @@ export interface AddThingToBillingGroupRequest {
 
 export namespace AddThingToBillingGroupRequest {
   export function isa(o: any): o is AddThingToBillingGroupRequest {
-    return _smithy.isa(o, "AddThingToBillingGroupRequest");
+    return __isa(o, "AddThingToBillingGroupRequest");
   }
 }
 
@@ -9092,7 +9091,7 @@ export interface AddThingToBillingGroupResponse extends $MetadataBearer {
 
 export namespace AddThingToBillingGroupResponse {
   export function isa(o: any): o is AddThingToBillingGroupResponse {
-    return _smithy.isa(o, "AddThingToBillingGroupResponse");
+    return __isa(o, "AddThingToBillingGroupResponse");
   }
 }
 
@@ -9129,7 +9128,7 @@ export interface AddThingToThingGroupRequest {
 
 export namespace AddThingToThingGroupRequest {
   export function isa(o: any): o is AddThingToThingGroupRequest {
-    return _smithy.isa(o, "AddThingToThingGroupRequest");
+    return __isa(o, "AddThingToThingGroupRequest");
   }
 }
 
@@ -9139,7 +9138,7 @@ export interface AddThingToThingGroupResponse extends $MetadataBearer {
 
 export namespace AddThingToThingGroupResponse {
   export function isa(o: any): o is AddThingToThingGroupResponse {
-    return _smithy.isa(o, "AddThingToThingGroupResponse");
+    return __isa(o, "AddThingToThingGroupResponse");
   }
 }
 
@@ -9162,7 +9161,7 @@ export interface AttachThingPrincipalRequest {
 
 export namespace AttachThingPrincipalRequest {
   export function isa(o: any): o is AttachThingPrincipalRequest {
-    return _smithy.isa(o, "AttachThingPrincipalRequest");
+    return __isa(o, "AttachThingPrincipalRequest");
   }
 }
 
@@ -9175,7 +9174,7 @@ export interface AttachThingPrincipalResponse extends $MetadataBearer {
 
 export namespace AttachThingPrincipalResponse {
   export function isa(o: any): o is AttachThingPrincipalResponse {
-    return _smithy.isa(o, "AttachThingPrincipalResponse");
+    return __isa(o, "AttachThingPrincipalResponse");
   }
 }
 
@@ -9199,7 +9198,7 @@ export interface CreateBillingGroupRequest {
 
 export namespace CreateBillingGroupRequest {
   export function isa(o: any): o is CreateBillingGroupRequest {
-    return _smithy.isa(o, "CreateBillingGroupRequest");
+    return __isa(o, "CreateBillingGroupRequest");
   }
 }
 
@@ -9223,7 +9222,7 @@ export interface CreateBillingGroupResponse extends $MetadataBearer {
 
 export namespace CreateBillingGroupResponse {
   export function isa(o: any): o is CreateBillingGroupResponse {
-    return _smithy.isa(o, "CreateBillingGroupResponse");
+    return __isa(o, "CreateBillingGroupResponse");
   }
 }
 
@@ -9270,7 +9269,7 @@ export interface CreateDynamicThingGroupRequest {
 
 export namespace CreateDynamicThingGroupRequest {
   export function isa(o: any): o is CreateDynamicThingGroupRequest {
-    return _smithy.isa(o, "CreateDynamicThingGroupRequest");
+    return __isa(o, "CreateDynamicThingGroupRequest");
   }
 }
 
@@ -9309,7 +9308,7 @@ export interface CreateDynamicThingGroupResponse extends $MetadataBearer {
 
 export namespace CreateDynamicThingGroupResponse {
   export function isa(o: any): o is CreateDynamicThingGroupResponse {
-    return _smithy.isa(o, "CreateDynamicThingGroupResponse");
+    return __isa(o, "CreateDynamicThingGroupResponse");
   }
 }
 
@@ -9338,7 +9337,7 @@ export interface CreateThingGroupRequest {
 
 export namespace CreateThingGroupRequest {
   export function isa(o: any): o is CreateThingGroupRequest {
-    return _smithy.isa(o, "CreateThingGroupRequest");
+    return __isa(o, "CreateThingGroupRequest");
   }
 }
 
@@ -9362,7 +9361,7 @@ export interface CreateThingGroupResponse extends $MetadataBearer {
 
 export namespace CreateThingGroupResponse {
   export function isa(o: any): o is CreateThingGroupResponse {
-    return _smithy.isa(o, "CreateThingGroupResponse");
+    return __isa(o, "CreateThingGroupResponse");
   }
 }
 
@@ -9398,7 +9397,7 @@ export interface CreateThingRequest {
 
 export namespace CreateThingRequest {
   export function isa(o: any): o is CreateThingRequest {
-    return _smithy.isa(o, "CreateThingRequest");
+    return __isa(o, "CreateThingRequest");
   }
 }
 
@@ -9425,7 +9424,7 @@ export interface CreateThingResponse extends $MetadataBearer {
 
 export namespace CreateThingResponse {
   export function isa(o: any): o is CreateThingResponse {
-    return _smithy.isa(o, "CreateThingResponse");
+    return __isa(o, "CreateThingResponse");
   }
 }
 
@@ -9454,7 +9453,7 @@ export interface CreateThingTypeRequest {
 
 export namespace CreateThingTypeRequest {
   export function isa(o: any): o is CreateThingTypeRequest {
-    return _smithy.isa(o, "CreateThingTypeRequest");
+    return __isa(o, "CreateThingTypeRequest");
   }
 }
 
@@ -9481,7 +9480,7 @@ export interface CreateThingTypeResponse extends $MetadataBearer {
 
 export namespace CreateThingTypeResponse {
   export function isa(o: any): o is CreateThingTypeResponse {
-    return _smithy.isa(o, "CreateThingTypeResponse");
+    return __isa(o, "CreateThingTypeResponse");
   }
 }
 
@@ -9503,7 +9502,7 @@ export interface DeleteBillingGroupRequest {
 
 export namespace DeleteBillingGroupRequest {
   export function isa(o: any): o is DeleteBillingGroupRequest {
-    return _smithy.isa(o, "DeleteBillingGroupRequest");
+    return __isa(o, "DeleteBillingGroupRequest");
   }
 }
 
@@ -9513,7 +9512,7 @@ export interface DeleteBillingGroupResponse extends $MetadataBearer {
 
 export namespace DeleteBillingGroupResponse {
   export function isa(o: any): o is DeleteBillingGroupResponse {
-    return _smithy.isa(o, "DeleteBillingGroupResponse");
+    return __isa(o, "DeleteBillingGroupResponse");
   }
 }
 
@@ -9532,7 +9531,7 @@ export interface DeleteDynamicThingGroupRequest {
 
 export namespace DeleteDynamicThingGroupRequest {
   export function isa(o: any): o is DeleteDynamicThingGroupRequest {
-    return _smithy.isa(o, "DeleteDynamicThingGroupRequest");
+    return __isa(o, "DeleteDynamicThingGroupRequest");
   }
 }
 
@@ -9542,7 +9541,7 @@ export interface DeleteDynamicThingGroupResponse extends $MetadataBearer {
 
 export namespace DeleteDynamicThingGroupResponse {
   export function isa(o: any): o is DeleteDynamicThingGroupResponse {
-    return _smithy.isa(o, "DeleteDynamicThingGroupResponse");
+    return __isa(o, "DeleteDynamicThingGroupResponse");
   }
 }
 
@@ -9561,7 +9560,7 @@ export interface DeleteThingGroupRequest {
 
 export namespace DeleteThingGroupRequest {
   export function isa(o: any): o is DeleteThingGroupRequest {
-    return _smithy.isa(o, "DeleteThingGroupRequest");
+    return __isa(o, "DeleteThingGroupRequest");
   }
 }
 
@@ -9571,7 +9570,7 @@ export interface DeleteThingGroupResponse extends $MetadataBearer {
 
 export namespace DeleteThingGroupResponse {
   export function isa(o: any): o is DeleteThingGroupResponse {
-    return _smithy.isa(o, "DeleteThingGroupResponse");
+    return __isa(o, "DeleteThingGroupResponse");
   }
 }
 
@@ -9596,7 +9595,7 @@ export interface DeleteThingRequest {
 
 export namespace DeleteThingRequest {
   export function isa(o: any): o is DeleteThingRequest {
-    return _smithy.isa(o, "DeleteThingRequest");
+    return __isa(o, "DeleteThingRequest");
   }
 }
 
@@ -9609,7 +9608,7 @@ export interface DeleteThingResponse extends $MetadataBearer {
 
 export namespace DeleteThingResponse {
   export function isa(o: any): o is DeleteThingResponse {
-    return _smithy.isa(o, "DeleteThingResponse");
+    return __isa(o, "DeleteThingResponse");
   }
 }
 
@@ -9626,7 +9625,7 @@ export interface DeleteThingTypeRequest {
 
 export namespace DeleteThingTypeRequest {
   export function isa(o: any): o is DeleteThingTypeRequest {
-    return _smithy.isa(o, "DeleteThingTypeRequest");
+    return __isa(o, "DeleteThingTypeRequest");
   }
 }
 
@@ -9639,7 +9638,7 @@ export interface DeleteThingTypeResponse extends $MetadataBearer {
 
 export namespace DeleteThingTypeResponse {
   export function isa(o: any): o is DeleteThingTypeResponse {
-    return _smithy.isa(o, "DeleteThingTypeResponse");
+    return __isa(o, "DeleteThingTypeResponse");
   }
 }
 
@@ -9662,7 +9661,7 @@ export interface DeprecateThingTypeRequest {
 
 export namespace DeprecateThingTypeRequest {
   export function isa(o: any): o is DeprecateThingTypeRequest {
-    return _smithy.isa(o, "DeprecateThingTypeRequest");
+    return __isa(o, "DeprecateThingTypeRequest");
   }
 }
 
@@ -9675,7 +9674,7 @@ export interface DeprecateThingTypeResponse extends $MetadataBearer {
 
 export namespace DeprecateThingTypeResponse {
   export function isa(o: any): o is DeprecateThingTypeResponse {
-    return _smithy.isa(o, "DeprecateThingTypeResponse");
+    return __isa(o, "DeprecateThingTypeResponse");
   }
 }
 
@@ -9689,7 +9688,7 @@ export interface DescribeBillingGroupRequest {
 
 export namespace DescribeBillingGroupRequest {
   export function isa(o: any): o is DescribeBillingGroupRequest {
-    return _smithy.isa(o, "DescribeBillingGroupRequest");
+    return __isa(o, "DescribeBillingGroupRequest");
   }
 }
 
@@ -9728,7 +9727,7 @@ export interface DescribeBillingGroupResponse extends $MetadataBearer {
 
 export namespace DescribeBillingGroupResponse {
   export function isa(o: any): o is DescribeBillingGroupResponse {
-    return _smithy.isa(o, "DescribeBillingGroupResponse");
+    return __isa(o, "DescribeBillingGroupResponse");
   }
 }
 
@@ -9738,7 +9737,7 @@ export interface DescribeEventConfigurationsRequest {
 
 export namespace DescribeEventConfigurationsRequest {
   export function isa(o: any): o is DescribeEventConfigurationsRequest {
-    return _smithy.isa(o, "DescribeEventConfigurationsRequest");
+    return __isa(o, "DescribeEventConfigurationsRequest");
   }
 }
 
@@ -9762,7 +9761,7 @@ export interface DescribeEventConfigurationsResponse extends $MetadataBearer {
 
 export namespace DescribeEventConfigurationsResponse {
   export function isa(o: any): o is DescribeEventConfigurationsResponse {
-    return _smithy.isa(o, "DescribeEventConfigurationsResponse");
+    return __isa(o, "DescribeEventConfigurationsResponse");
   }
 }
 
@@ -9776,7 +9775,7 @@ export interface DescribeThingGroupRequest {
 
 export namespace DescribeThingGroupRequest {
   export function isa(o: any): o is DescribeThingGroupRequest {
-    return _smithy.isa(o, "DescribeThingGroupRequest");
+    return __isa(o, "DescribeThingGroupRequest");
   }
 }
 
@@ -9835,7 +9834,7 @@ export interface DescribeThingGroupResponse extends $MetadataBearer {
 
 export namespace DescribeThingGroupResponse {
   export function isa(o: any): o is DescribeThingGroupResponse {
-    return _smithy.isa(o, "DescribeThingGroupResponse");
+    return __isa(o, "DescribeThingGroupResponse");
   }
 }
 
@@ -9849,7 +9848,7 @@ export interface DescribeThingRegistrationTaskRequest {
 
 export namespace DescribeThingRegistrationTaskRequest {
   export function isa(o: any): o is DescribeThingRegistrationTaskRequest {
-    return _smithy.isa(o, "DescribeThingRegistrationTaskRequest");
+    return __isa(o, "DescribeThingRegistrationTaskRequest");
   }
 }
 
@@ -9918,7 +9917,7 @@ export interface DescribeThingRegistrationTaskResponse extends $MetadataBearer {
 
 export namespace DescribeThingRegistrationTaskResponse {
   export function isa(o: any): o is DescribeThingRegistrationTaskResponse {
-    return _smithy.isa(o, "DescribeThingRegistrationTaskResponse");
+    return __isa(o, "DescribeThingRegistrationTaskResponse");
   }
 }
 
@@ -9935,7 +9934,7 @@ export interface DescribeThingRequest {
 
 export namespace DescribeThingRequest {
   export function isa(o: any): o is DescribeThingRequest {
-    return _smithy.isa(o, "DescribeThingRequest");
+    return __isa(o, "DescribeThingRequest");
   }
 }
 
@@ -9992,7 +9991,7 @@ export interface DescribeThingResponse extends $MetadataBearer {
 
 export namespace DescribeThingResponse {
   export function isa(o: any): o is DescribeThingResponse {
-    return _smithy.isa(o, "DescribeThingResponse");
+    return __isa(o, "DescribeThingResponse");
   }
 }
 
@@ -10009,7 +10008,7 @@ export interface DescribeThingTypeRequest {
 
 export namespace DescribeThingTypeRequest {
   export function isa(o: any): o is DescribeThingTypeRequest {
-    return _smithy.isa(o, "DescribeThingTypeRequest");
+    return __isa(o, "DescribeThingTypeRequest");
   }
 }
 
@@ -10049,7 +10048,7 @@ export interface DescribeThingTypeResponse extends $MetadataBearer {
 
 export namespace DescribeThingTypeResponse {
   export function isa(o: any): o is DescribeThingTypeResponse {
-    return _smithy.isa(o, "DescribeThingTypeResponse");
+    return __isa(o, "DescribeThingTypeResponse");
   }
 }
 
@@ -10073,7 +10072,7 @@ export interface DetachThingPrincipalRequest {
 
 export namespace DetachThingPrincipalRequest {
   export function isa(o: any): o is DetachThingPrincipalRequest {
-    return _smithy.isa(o, "DetachThingPrincipalRequest");
+    return __isa(o, "DetachThingPrincipalRequest");
   }
 }
 
@@ -10086,7 +10085,7 @@ export interface DetachThingPrincipalResponse extends $MetadataBearer {
 
 export namespace DetachThingPrincipalResponse {
   export function isa(o: any): o is DetachThingPrincipalResponse {
-    return _smithy.isa(o, "DetachThingPrincipalResponse");
+    return __isa(o, "DetachThingPrincipalResponse");
   }
 }
 
@@ -10110,7 +10109,7 @@ export interface ListBillingGroupsRequest {
 
 export namespace ListBillingGroupsRequest {
   export function isa(o: any): o is ListBillingGroupsRequest {
-    return _smithy.isa(o, "ListBillingGroupsRequest");
+    return __isa(o, "ListBillingGroupsRequest");
   }
 }
 
@@ -10129,7 +10128,7 @@ export interface ListBillingGroupsResponse extends $MetadataBearer {
 
 export namespace ListBillingGroupsResponse {
   export function isa(o: any): o is ListBillingGroupsResponse {
-    return _smithy.isa(o, "ListBillingGroupsResponse");
+    return __isa(o, "ListBillingGroupsResponse");
   }
 }
 
@@ -10156,7 +10155,7 @@ export interface ListPrincipalThingsRequest {
 
 export namespace ListPrincipalThingsRequest {
   export function isa(o: any): o is ListPrincipalThingsRequest {
-    return _smithy.isa(o, "ListPrincipalThingsRequest");
+    return __isa(o, "ListPrincipalThingsRequest");
   }
 }
 
@@ -10178,7 +10177,7 @@ export interface ListPrincipalThingsResponse extends $MetadataBearer {
 
 export namespace ListPrincipalThingsResponse {
   export function isa(o: any): o is ListPrincipalThingsResponse {
-    return _smithy.isa(o, "ListPrincipalThingsResponse");
+    return __isa(o, "ListPrincipalThingsResponse");
   }
 }
 
@@ -10197,7 +10196,7 @@ export interface ListTagsForResourceRequest {
 
 export namespace ListTagsForResourceRequest {
   export function isa(o: any): o is ListTagsForResourceRequest {
-    return _smithy.isa(o, "ListTagsForResourceRequest");
+    return __isa(o, "ListTagsForResourceRequest");
   }
 }
 
@@ -10216,7 +10215,7 @@ export interface ListTagsForResourceResponse extends $MetadataBearer {
 
 export namespace ListTagsForResourceResponse {
   export function isa(o: any): o is ListTagsForResourceResponse {
-    return _smithy.isa(o, "ListTagsForResourceResponse");
+    return __isa(o, "ListTagsForResourceResponse");
   }
 }
 
@@ -10240,7 +10239,7 @@ export interface ListThingGroupsForThingRequest {
 
 export namespace ListThingGroupsForThingRequest {
   export function isa(o: any): o is ListThingGroupsForThingRequest {
-    return _smithy.isa(o, "ListThingGroupsForThingRequest");
+    return __isa(o, "ListThingGroupsForThingRequest");
   }
 }
 
@@ -10259,7 +10258,7 @@ export interface ListThingGroupsForThingResponse extends $MetadataBearer {
 
 export namespace ListThingGroupsForThingResponse {
   export function isa(o: any): o is ListThingGroupsForThingResponse {
-    return _smithy.isa(o, "ListThingGroupsForThingResponse");
+    return __isa(o, "ListThingGroupsForThingResponse");
   }
 }
 
@@ -10293,7 +10292,7 @@ export interface ListThingGroupsRequest {
 
 export namespace ListThingGroupsRequest {
   export function isa(o: any): o is ListThingGroupsRequest {
-    return _smithy.isa(o, "ListThingGroupsRequest");
+    return __isa(o, "ListThingGroupsRequest");
   }
 }
 
@@ -10312,7 +10311,7 @@ export interface ListThingGroupsResponse extends $MetadataBearer {
 
 export namespace ListThingGroupsResponse {
   export function isa(o: any): o is ListThingGroupsResponse {
-    return _smithy.isa(o, "ListThingGroupsResponse");
+    return __isa(o, "ListThingGroupsResponse");
   }
 }
 
@@ -10329,7 +10328,7 @@ export interface ListThingPrincipalsRequest {
 
 export namespace ListThingPrincipalsRequest {
   export function isa(o: any): o is ListThingPrincipalsRequest {
-    return _smithy.isa(o, "ListThingPrincipalsRequest");
+    return __isa(o, "ListThingPrincipalsRequest");
   }
 }
 
@@ -10346,7 +10345,7 @@ export interface ListThingPrincipalsResponse extends $MetadataBearer {
 
 export namespace ListThingPrincipalsResponse {
   export function isa(o: any): o is ListThingPrincipalsResponse {
-    return _smithy.isa(o, "ListThingPrincipalsResponse");
+    return __isa(o, "ListThingPrincipalsResponse");
   }
 }
 
@@ -10375,7 +10374,7 @@ export interface ListThingRegistrationTaskReportsRequest {
 
 export namespace ListThingRegistrationTaskReportsRequest {
   export function isa(o: any): o is ListThingRegistrationTaskReportsRequest {
-    return _smithy.isa(o, "ListThingRegistrationTaskReportsRequest");
+    return __isa(o, "ListThingRegistrationTaskReportsRequest");
   }
 }
 
@@ -10400,7 +10399,7 @@ export interface ListThingRegistrationTaskReportsResponse
 
 export namespace ListThingRegistrationTaskReportsResponse {
   export function isa(o: any): o is ListThingRegistrationTaskReportsResponse {
-    return _smithy.isa(o, "ListThingRegistrationTaskReportsResponse");
+    return __isa(o, "ListThingRegistrationTaskReportsResponse");
   }
 }
 
@@ -10424,7 +10423,7 @@ export interface ListThingRegistrationTasksRequest {
 
 export namespace ListThingRegistrationTasksRequest {
   export function isa(o: any): o is ListThingRegistrationTasksRequest {
-    return _smithy.isa(o, "ListThingRegistrationTasksRequest");
+    return __isa(o, "ListThingRegistrationTasksRequest");
   }
 }
 
@@ -10443,7 +10442,7 @@ export interface ListThingRegistrationTasksResponse extends $MetadataBearer {
 
 export namespace ListThingRegistrationTasksResponse {
   export function isa(o: any): o is ListThingRegistrationTasksResponse {
-    return _smithy.isa(o, "ListThingRegistrationTasksResponse");
+    return __isa(o, "ListThingRegistrationTasksResponse");
   }
 }
 
@@ -10470,7 +10469,7 @@ export interface ListThingTypesRequest {
 
 export namespace ListThingTypesRequest {
   export function isa(o: any): o is ListThingTypesRequest {
-    return _smithy.isa(o, "ListThingTypesRequest");
+    return __isa(o, "ListThingTypesRequest");
   }
 }
 
@@ -10493,7 +10492,7 @@ export interface ListThingTypesResponse extends $MetadataBearer {
 
 export namespace ListThingTypesResponse {
   export function isa(o: any): o is ListThingTypesResponse {
-    return _smithy.isa(o, "ListThingTypesResponse");
+    return __isa(o, "ListThingTypesResponse");
   }
 }
 
@@ -10517,7 +10516,7 @@ export interface ListThingsInBillingGroupRequest {
 
 export namespace ListThingsInBillingGroupRequest {
   export function isa(o: any): o is ListThingsInBillingGroupRequest {
-    return _smithy.isa(o, "ListThingsInBillingGroupRequest");
+    return __isa(o, "ListThingsInBillingGroupRequest");
   }
 }
 
@@ -10536,7 +10535,7 @@ export interface ListThingsInBillingGroupResponse extends $MetadataBearer {
 
 export namespace ListThingsInBillingGroupResponse {
   export function isa(o: any): o is ListThingsInBillingGroupResponse {
-    return _smithy.isa(o, "ListThingsInBillingGroupResponse");
+    return __isa(o, "ListThingsInBillingGroupResponse");
   }
 }
 
@@ -10566,7 +10565,7 @@ export interface ListThingsInThingGroupRequest {
 
 export namespace ListThingsInThingGroupRequest {
   export function isa(o: any): o is ListThingsInThingGroupRequest {
-    return _smithy.isa(o, "ListThingsInThingGroupRequest");
+    return __isa(o, "ListThingsInThingGroupRequest");
   }
 }
 
@@ -10585,7 +10584,7 @@ export interface ListThingsInThingGroupResponse extends $MetadataBearer {
 
 export namespace ListThingsInThingGroupResponse {
   export function isa(o: any): o is ListThingsInThingGroupResponse {
-    return _smithy.isa(o, "ListThingsInThingGroupResponse");
+    return __isa(o, "ListThingsInThingGroupResponse");
   }
 }
 
@@ -10622,7 +10621,7 @@ export interface ListThingsRequest {
 
 export namespace ListThingsRequest {
   export function isa(o: any): o is ListThingsRequest {
-    return _smithy.isa(o, "ListThingsRequest");
+    return __isa(o, "ListThingsRequest");
   }
 }
 
@@ -10644,7 +10643,7 @@ export interface ListThingsResponse extends $MetadataBearer {
 
 export namespace ListThingsResponse {
   export function isa(o: any): o is ListThingsResponse {
-    return _smithy.isa(o, "ListThingsResponse");
+    return __isa(o, "ListThingsResponse");
   }
 }
 
@@ -10673,7 +10672,7 @@ export interface RemoveThingFromBillingGroupRequest {
 
 export namespace RemoveThingFromBillingGroupRequest {
   export function isa(o: any): o is RemoveThingFromBillingGroupRequest {
-    return _smithy.isa(o, "RemoveThingFromBillingGroupRequest");
+    return __isa(o, "RemoveThingFromBillingGroupRequest");
   }
 }
 
@@ -10683,7 +10682,7 @@ export interface RemoveThingFromBillingGroupResponse extends $MetadataBearer {
 
 export namespace RemoveThingFromBillingGroupResponse {
   export function isa(o: any): o is RemoveThingFromBillingGroupResponse {
-    return _smithy.isa(o, "RemoveThingFromBillingGroupResponse");
+    return __isa(o, "RemoveThingFromBillingGroupResponse");
   }
 }
 
@@ -10712,7 +10711,7 @@ export interface RemoveThingFromThingGroupRequest {
 
 export namespace RemoveThingFromThingGroupRequest {
   export function isa(o: any): o is RemoveThingFromThingGroupRequest {
-    return _smithy.isa(o, "RemoveThingFromThingGroupRequest");
+    return __isa(o, "RemoveThingFromThingGroupRequest");
   }
 }
 
@@ -10722,7 +10721,7 @@ export interface RemoveThingFromThingGroupResponse extends $MetadataBearer {
 
 export namespace RemoveThingFromThingGroupResponse {
   export function isa(o: any): o is RemoveThingFromThingGroupResponse {
-    return _smithy.isa(o, "RemoveThingFromThingGroupResponse");
+    return __isa(o, "RemoveThingFromThingGroupResponse");
   }
 }
 
@@ -10753,7 +10752,7 @@ export interface StartThingRegistrationTaskRequest {
 
 export namespace StartThingRegistrationTaskRequest {
   export function isa(o: any): o is StartThingRegistrationTaskRequest {
-    return _smithy.isa(o, "StartThingRegistrationTaskRequest");
+    return __isa(o, "StartThingRegistrationTaskRequest");
   }
 }
 
@@ -10767,7 +10766,7 @@ export interface StartThingRegistrationTaskResponse extends $MetadataBearer {
 
 export namespace StartThingRegistrationTaskResponse {
   export function isa(o: any): o is StartThingRegistrationTaskResponse {
-    return _smithy.isa(o, "StartThingRegistrationTaskResponse");
+    return __isa(o, "StartThingRegistrationTaskResponse");
   }
 }
 
@@ -10781,7 +10780,7 @@ export interface StopThingRegistrationTaskRequest {
 
 export namespace StopThingRegistrationTaskRequest {
   export function isa(o: any): o is StopThingRegistrationTaskRequest {
-    return _smithy.isa(o, "StopThingRegistrationTaskRequest");
+    return __isa(o, "StopThingRegistrationTaskRequest");
   }
 }
 
@@ -10791,7 +10790,7 @@ export interface StopThingRegistrationTaskResponse extends $MetadataBearer {
 
 export namespace StopThingRegistrationTaskResponse {
   export function isa(o: any): o is StopThingRegistrationTaskResponse {
-    return _smithy.isa(o, "StopThingRegistrationTaskResponse");
+    return __isa(o, "StopThingRegistrationTaskResponse");
   }
 }
 
@@ -10810,7 +10809,7 @@ export interface TagResourceRequest {
 
 export namespace TagResourceRequest {
   export function isa(o: any): o is TagResourceRequest {
-    return _smithy.isa(o, "TagResourceRequest");
+    return __isa(o, "TagResourceRequest");
   }
 }
 
@@ -10820,7 +10819,7 @@ export interface TagResourceResponse extends $MetadataBearer {
 
 export namespace TagResourceResponse {
   export function isa(o: any): o is TagResourceResponse {
-    return _smithy.isa(o, "TagResourceResponse");
+    return __isa(o, "TagResourceResponse");
   }
 }
 
@@ -10839,7 +10838,7 @@ export interface UntagResourceRequest {
 
 export namespace UntagResourceRequest {
   export function isa(o: any): o is UntagResourceRequest {
-    return _smithy.isa(o, "UntagResourceRequest");
+    return __isa(o, "UntagResourceRequest");
   }
 }
 
@@ -10849,7 +10848,7 @@ export interface UntagResourceResponse extends $MetadataBearer {
 
 export namespace UntagResourceResponse {
   export function isa(o: any): o is UntagResourceResponse {
-    return _smithy.isa(o, "UntagResourceResponse");
+    return __isa(o, "UntagResourceResponse");
   }
 }
 
@@ -10876,7 +10875,7 @@ export interface UpdateBillingGroupRequest {
 
 export namespace UpdateBillingGroupRequest {
   export function isa(o: any): o is UpdateBillingGroupRequest {
-    return _smithy.isa(o, "UpdateBillingGroupRequest");
+    return __isa(o, "UpdateBillingGroupRequest");
   }
 }
 
@@ -10890,7 +10889,7 @@ export interface UpdateBillingGroupResponse extends $MetadataBearer {
 
 export namespace UpdateBillingGroupResponse {
   export function isa(o: any): o is UpdateBillingGroupResponse {
-    return _smithy.isa(o, "UpdateBillingGroupResponse");
+    return __isa(o, "UpdateBillingGroupResponse");
   }
 }
 
@@ -10936,7 +10935,7 @@ export interface UpdateDynamicThingGroupRequest {
 
 export namespace UpdateDynamicThingGroupRequest {
   export function isa(o: any): o is UpdateDynamicThingGroupRequest {
-    return _smithy.isa(o, "UpdateDynamicThingGroupRequest");
+    return __isa(o, "UpdateDynamicThingGroupRequest");
   }
 }
 
@@ -10950,7 +10949,7 @@ export interface UpdateDynamicThingGroupResponse extends $MetadataBearer {
 
 export namespace UpdateDynamicThingGroupResponse {
   export function isa(o: any): o is UpdateDynamicThingGroupResponse {
-    return _smithy.isa(o, "UpdateDynamicThingGroupResponse");
+    return __isa(o, "UpdateDynamicThingGroupResponse");
   }
 }
 
@@ -10964,7 +10963,7 @@ export interface UpdateEventConfigurationsRequest {
 
 export namespace UpdateEventConfigurationsRequest {
   export function isa(o: any): o is UpdateEventConfigurationsRequest {
-    return _smithy.isa(o, "UpdateEventConfigurationsRequest");
+    return __isa(o, "UpdateEventConfigurationsRequest");
   }
 }
 
@@ -10974,7 +10973,7 @@ export interface UpdateEventConfigurationsResponse extends $MetadataBearer {
 
 export namespace UpdateEventConfigurationsResponse {
   export function isa(o: any): o is UpdateEventConfigurationsResponse {
-    return _smithy.isa(o, "UpdateEventConfigurationsResponse");
+    return __isa(o, "UpdateEventConfigurationsResponse");
   }
 }
 
@@ -10999,7 +10998,7 @@ export interface UpdateThingGroupRequest {
 
 export namespace UpdateThingGroupRequest {
   export function isa(o: any): o is UpdateThingGroupRequest {
-    return _smithy.isa(o, "UpdateThingGroupRequest");
+    return __isa(o, "UpdateThingGroupRequest");
   }
 }
 
@@ -11013,7 +11012,7 @@ export interface UpdateThingGroupResponse extends $MetadataBearer {
 
 export namespace UpdateThingGroupResponse {
   export function isa(o: any): o is UpdateThingGroupResponse {
-    return _smithy.isa(o, "UpdateThingGroupResponse");
+    return __isa(o, "UpdateThingGroupResponse");
   }
 }
 
@@ -11045,7 +11044,7 @@ export interface UpdateThingGroupsForThingRequest {
 
 export namespace UpdateThingGroupsForThingRequest {
   export function isa(o: any): o is UpdateThingGroupsForThingRequest {
-    return _smithy.isa(o, "UpdateThingGroupsForThingRequest");
+    return __isa(o, "UpdateThingGroupsForThingRequest");
   }
 }
 
@@ -11055,7 +11054,7 @@ export interface UpdateThingGroupsForThingResponse extends $MetadataBearer {
 
 export namespace UpdateThingGroupsForThingResponse {
   export function isa(o: any): o is UpdateThingGroupsForThingResponse {
-    return _smithy.isa(o, "UpdateThingGroupsForThingResponse");
+    return __isa(o, "UpdateThingGroupsForThingResponse");
   }
 }
 
@@ -11101,7 +11100,7 @@ export interface UpdateThingRequest {
 
 export namespace UpdateThingRequest {
   export function isa(o: any): o is UpdateThingRequest {
-    return _smithy.isa(o, "UpdateThingRequest");
+    return __isa(o, "UpdateThingRequest");
   }
 }
 
@@ -11114,7 +11113,7 @@ export interface UpdateThingResponse extends $MetadataBearer {
 
 export namespace UpdateThingResponse {
   export function isa(o: any): o is UpdateThingResponse {
-    return _smithy.isa(o, "UpdateThingResponse");
+    return __isa(o, "UpdateThingResponse");
   }
 }
 
@@ -11144,7 +11143,7 @@ export interface AttributePayload {
 
 export namespace AttributePayload {
   export function isa(o: any): o is AttributePayload {
-    return _smithy.isa(o, "AttributePayload");
+    return __isa(o, "AttributePayload");
   }
 }
 
@@ -11161,7 +11160,7 @@ export interface BillingGroupMetadata {
 
 export namespace BillingGroupMetadata {
   export function isa(o: any): o is BillingGroupMetadata {
-    return _smithy.isa(o, "BillingGroupMetadata");
+    return __isa(o, "BillingGroupMetadata");
   }
 }
 
@@ -11178,7 +11177,7 @@ export interface BillingGroupProperties {
 
 export namespace BillingGroupProperties {
   export function isa(o: any): o is BillingGroupProperties {
-    return _smithy.isa(o, "BillingGroupProperties");
+    return __isa(o, "BillingGroupProperties");
   }
 }
 
@@ -11206,7 +11205,7 @@ export interface GroupNameAndArn {
 
 export namespace GroupNameAndArn {
   export function isa(o: any): o is GroupNameAndArn {
-    return _smithy.isa(o, "GroupNameAndArn");
+    return __isa(o, "GroupNameAndArn");
   }
 }
 
@@ -11257,7 +11256,7 @@ export interface ThingAttribute {
 
 export namespace ThingAttribute {
   export function isa(o: any): o is ThingAttribute {
-    return _smithy.isa(o, "ThingAttribute");
+    return __isa(o, "ThingAttribute");
   }
 }
 
@@ -11284,7 +11283,7 @@ export interface ThingGroupMetadata {
 
 export namespace ThingGroupMetadata {
   export function isa(o: any): o is ThingGroupMetadata {
-    return _smithy.isa(o, "ThingGroupMetadata");
+    return __isa(o, "ThingGroupMetadata");
   }
 }
 
@@ -11306,7 +11305,7 @@ export interface ThingGroupProperties {
 
 export namespace ThingGroupProperties {
   export function isa(o: any): o is ThingGroupProperties {
-    return _smithy.isa(o, "ThingGroupProperties");
+    return __isa(o, "ThingGroupProperties");
   }
 }
 
@@ -11340,7 +11339,7 @@ export interface ThingTypeDefinition {
 
 export namespace ThingTypeDefinition {
   export function isa(o: any): o is ThingTypeDefinition {
-    return _smithy.isa(o, "ThingTypeDefinition");
+    return __isa(o, "ThingTypeDefinition");
   }
 }
 
@@ -11370,7 +11369,7 @@ export interface ThingTypeMetadata {
 
 export namespace ThingTypeMetadata {
   export function isa(o: any): o is ThingTypeMetadata {
-    return _smithy.isa(o, "ThingTypeMetadata");
+    return __isa(o, "ThingTypeMetadata");
   }
 }
 
@@ -11393,7 +11392,7 @@ export interface ThingTypeProperties {
 
 export namespace ThingTypeProperties {
   export function isa(o: any): o is ThingTypeProperties {
-    return _smithy.isa(o, "ThingTypeProperties");
+    return __isa(o, "ThingTypeProperties");
   }
 }
 
@@ -11412,7 +11411,7 @@ export interface AttachSecurityProfileRequest {
 
 export namespace AttachSecurityProfileRequest {
   export function isa(o: any): o is AttachSecurityProfileRequest {
-    return _smithy.isa(o, "AttachSecurityProfileRequest");
+    return __isa(o, "AttachSecurityProfileRequest");
   }
 }
 
@@ -11422,7 +11421,7 @@ export interface AttachSecurityProfileResponse extends $MetadataBearer {
 
 export namespace AttachSecurityProfileResponse {
   export function isa(o: any): o is AttachSecurityProfileResponse {
-    return _smithy.isa(o, "AttachSecurityProfileResponse");
+    return __isa(o, "AttachSecurityProfileResponse");
   }
 }
 
@@ -11436,7 +11435,7 @@ export interface CancelAuditMitigationActionsTaskRequest {
 
 export namespace CancelAuditMitigationActionsTaskRequest {
   export function isa(o: any): o is CancelAuditMitigationActionsTaskRequest {
-    return _smithy.isa(o, "CancelAuditMitigationActionsTaskRequest");
+    return __isa(o, "CancelAuditMitigationActionsTaskRequest");
   }
 }
 
@@ -11447,7 +11446,7 @@ export interface CancelAuditMitigationActionsTaskResponse
 
 export namespace CancelAuditMitigationActionsTaskResponse {
   export function isa(o: any): o is CancelAuditMitigationActionsTaskResponse {
-    return _smithy.isa(o, "CancelAuditMitigationActionsTaskResponse");
+    return __isa(o, "CancelAuditMitigationActionsTaskResponse");
   }
 }
 
@@ -11462,7 +11461,7 @@ export interface CancelAuditTaskRequest {
 
 export namespace CancelAuditTaskRequest {
   export function isa(o: any): o is CancelAuditTaskRequest {
-    return _smithy.isa(o, "CancelAuditTaskRequest");
+    return __isa(o, "CancelAuditTaskRequest");
   }
 }
 
@@ -11472,7 +11471,7 @@ export interface CancelAuditTaskResponse extends $MetadataBearer {
 
 export namespace CancelAuditTaskResponse {
   export function isa(o: any): o is CancelAuditTaskResponse {
-    return _smithy.isa(o, "CancelAuditTaskResponse");
+    return __isa(o, "CancelAuditTaskResponse");
   }
 }
 
@@ -11501,7 +11500,7 @@ export interface CreateMitigationActionRequest {
 
 export namespace CreateMitigationActionRequest {
   export function isa(o: any): o is CreateMitigationActionRequest {
-    return _smithy.isa(o, "CreateMitigationActionRequest");
+    return __isa(o, "CreateMitigationActionRequest");
   }
 }
 
@@ -11520,7 +11519,7 @@ export interface CreateMitigationActionResponse extends $MetadataBearer {
 
 export namespace CreateMitigationActionResponse {
   export function isa(o: any): o is CreateMitigationActionResponse {
-    return _smithy.isa(o, "CreateMitigationActionResponse");
+    return __isa(o, "CreateMitigationActionResponse");
   }
 }
 
@@ -11569,7 +11568,7 @@ export interface CreateScheduledAuditRequest {
 
 export namespace CreateScheduledAuditRequest {
   export function isa(o: any): o is CreateScheduledAuditRequest {
-    return _smithy.isa(o, "CreateScheduledAuditRequest");
+    return __isa(o, "CreateScheduledAuditRequest");
   }
 }
 
@@ -11583,7 +11582,7 @@ export interface CreateScheduledAuditResponse extends $MetadataBearer {
 
 export namespace CreateScheduledAuditResponse {
   export function isa(o: any): o is CreateScheduledAuditResponse {
-    return _smithy.isa(o, "CreateScheduledAuditResponse");
+    return __isa(o, "CreateScheduledAuditResponse");
   }
 }
 
@@ -11625,7 +11624,7 @@ export interface CreateSecurityProfileRequest {
 
 export namespace CreateSecurityProfileRequest {
   export function isa(o: any): o is CreateSecurityProfileRequest {
-    return _smithy.isa(o, "CreateSecurityProfileRequest");
+    return __isa(o, "CreateSecurityProfileRequest");
   }
 }
 
@@ -11644,7 +11643,7 @@ export interface CreateSecurityProfileResponse extends $MetadataBearer {
 
 export namespace CreateSecurityProfileResponse {
   export function isa(o: any): o is CreateSecurityProfileResponse {
-    return _smithy.isa(o, "CreateSecurityProfileResponse");
+    return __isa(o, "CreateSecurityProfileResponse");
   }
 }
 
@@ -11658,7 +11657,7 @@ export interface DeleteAccountAuditConfigurationRequest {
 
 export namespace DeleteAccountAuditConfigurationRequest {
   export function isa(o: any): o is DeleteAccountAuditConfigurationRequest {
-    return _smithy.isa(o, "DeleteAccountAuditConfigurationRequest");
+    return __isa(o, "DeleteAccountAuditConfigurationRequest");
   }
 }
 
@@ -11669,7 +11668,7 @@ export interface DeleteAccountAuditConfigurationResponse
 
 export namespace DeleteAccountAuditConfigurationResponse {
   export function isa(o: any): o is DeleteAccountAuditConfigurationResponse {
-    return _smithy.isa(o, "DeleteAccountAuditConfigurationResponse");
+    return __isa(o, "DeleteAccountAuditConfigurationResponse");
   }
 }
 
@@ -11683,7 +11682,7 @@ export interface DeleteMitigationActionRequest {
 
 export namespace DeleteMitigationActionRequest {
   export function isa(o: any): o is DeleteMitigationActionRequest {
-    return _smithy.isa(o, "DeleteMitigationActionRequest");
+    return __isa(o, "DeleteMitigationActionRequest");
   }
 }
 
@@ -11693,7 +11692,7 @@ export interface DeleteMitigationActionResponse extends $MetadataBearer {
 
 export namespace DeleteMitigationActionResponse {
   export function isa(o: any): o is DeleteMitigationActionResponse {
-    return _smithy.isa(o, "DeleteMitigationActionResponse");
+    return __isa(o, "DeleteMitigationActionResponse");
   }
 }
 
@@ -11707,7 +11706,7 @@ export interface DeleteScheduledAuditRequest {
 
 export namespace DeleteScheduledAuditRequest {
   export function isa(o: any): o is DeleteScheduledAuditRequest {
-    return _smithy.isa(o, "DeleteScheduledAuditRequest");
+    return __isa(o, "DeleteScheduledAuditRequest");
   }
 }
 
@@ -11717,7 +11716,7 @@ export interface DeleteScheduledAuditResponse extends $MetadataBearer {
 
 export namespace DeleteScheduledAuditResponse {
   export function isa(o: any): o is DeleteScheduledAuditResponse {
-    return _smithy.isa(o, "DeleteScheduledAuditResponse");
+    return __isa(o, "DeleteScheduledAuditResponse");
   }
 }
 
@@ -11738,7 +11737,7 @@ export interface DeleteSecurityProfileRequest {
 
 export namespace DeleteSecurityProfileRequest {
   export function isa(o: any): o is DeleteSecurityProfileRequest {
-    return _smithy.isa(o, "DeleteSecurityProfileRequest");
+    return __isa(o, "DeleteSecurityProfileRequest");
   }
 }
 
@@ -11748,7 +11747,7 @@ export interface DeleteSecurityProfileResponse extends $MetadataBearer {
 
 export namespace DeleteSecurityProfileResponse {
   export function isa(o: any): o is DeleteSecurityProfileResponse {
-    return _smithy.isa(o, "DeleteSecurityProfileResponse");
+    return __isa(o, "DeleteSecurityProfileResponse");
   }
 }
 
@@ -11758,7 +11757,7 @@ export interface DescribeAccountAuditConfigurationRequest {
 
 export namespace DescribeAccountAuditConfigurationRequest {
   export function isa(o: any): o is DescribeAccountAuditConfigurationRequest {
-    return _smithy.isa(o, "DescribeAccountAuditConfigurationRequest");
+    return __isa(o, "DescribeAccountAuditConfigurationRequest");
   }
 }
 
@@ -11790,7 +11789,7 @@ export interface DescribeAccountAuditConfigurationResponse
 
 export namespace DescribeAccountAuditConfigurationResponse {
   export function isa(o: any): o is DescribeAccountAuditConfigurationResponse {
-    return _smithy.isa(o, "DescribeAccountAuditConfigurationResponse");
+    return __isa(o, "DescribeAccountAuditConfigurationResponse");
   }
 }
 
@@ -11804,7 +11803,7 @@ export interface DescribeAuditFindingRequest {
 
 export namespace DescribeAuditFindingRequest {
   export function isa(o: any): o is DescribeAuditFindingRequest {
-    return _smithy.isa(o, "DescribeAuditFindingRequest");
+    return __isa(o, "DescribeAuditFindingRequest");
   }
 }
 
@@ -11818,7 +11817,7 @@ export interface DescribeAuditFindingResponse extends $MetadataBearer {
 
 export namespace DescribeAuditFindingResponse {
   export function isa(o: any): o is DescribeAuditFindingResponse {
-    return _smithy.isa(o, "DescribeAuditFindingResponse");
+    return __isa(o, "DescribeAuditFindingResponse");
   }
 }
 
@@ -11832,7 +11831,7 @@ export interface DescribeAuditMitigationActionsTaskRequest {
 
 export namespace DescribeAuditMitigationActionsTaskRequest {
   export function isa(o: any): o is DescribeAuditMitigationActionsTaskRequest {
-    return _smithy.isa(o, "DescribeAuditMitigationActionsTaskRequest");
+    return __isa(o, "DescribeAuditMitigationActionsTaskRequest");
   }
 }
 
@@ -11877,7 +11876,7 @@ export interface DescribeAuditMitigationActionsTaskResponse
 
 export namespace DescribeAuditMitigationActionsTaskResponse {
   export function isa(o: any): o is DescribeAuditMitigationActionsTaskResponse {
-    return _smithy.isa(o, "DescribeAuditMitigationActionsTaskResponse");
+    return __isa(o, "DescribeAuditMitigationActionsTaskResponse");
   }
 }
 
@@ -11891,7 +11890,7 @@ export interface DescribeAuditTaskRequest {
 
 export namespace DescribeAuditTaskRequest {
   export function isa(o: any): o is DescribeAuditTaskRequest {
-    return _smithy.isa(o, "DescribeAuditTaskRequest");
+    return __isa(o, "DescribeAuditTaskRequest");
   }
 }
 
@@ -11931,7 +11930,7 @@ export interface DescribeAuditTaskResponse extends $MetadataBearer {
 
 export namespace DescribeAuditTaskResponse {
   export function isa(o: any): o is DescribeAuditTaskResponse {
-    return _smithy.isa(o, "DescribeAuditTaskResponse");
+    return __isa(o, "DescribeAuditTaskResponse");
   }
 }
 
@@ -11945,7 +11944,7 @@ export interface DescribeMitigationActionRequest {
 
 export namespace DescribeMitigationActionRequest {
   export function isa(o: any): o is DescribeMitigationActionRequest {
-    return _smithy.isa(o, "DescribeMitigationActionRequest");
+    return __isa(o, "DescribeMitigationActionRequest");
   }
 }
 
@@ -11994,7 +11993,7 @@ export interface DescribeMitigationActionResponse extends $MetadataBearer {
 
 export namespace DescribeMitigationActionResponse {
   export function isa(o: any): o is DescribeMitigationActionResponse {
-    return _smithy.isa(o, "DescribeMitigationActionResponse");
+    return __isa(o, "DescribeMitigationActionResponse");
   }
 }
 
@@ -12008,7 +12007,7 @@ export interface DescribeScheduledAuditRequest {
 
 export namespace DescribeScheduledAuditRequest {
   export function isa(o: any): o is DescribeScheduledAuditRequest {
-    return _smithy.isa(o, "DescribeScheduledAuditRequest");
+    return __isa(o, "DescribeScheduledAuditRequest");
   }
 }
 
@@ -12055,7 +12054,7 @@ export interface DescribeScheduledAuditResponse extends $MetadataBearer {
 
 export namespace DescribeScheduledAuditResponse {
   export function isa(o: any): o is DescribeScheduledAuditResponse {
-    return _smithy.isa(o, "DescribeScheduledAuditResponse");
+    return __isa(o, "DescribeScheduledAuditResponse");
   }
 }
 
@@ -12069,7 +12068,7 @@ export interface DescribeSecurityProfileRequest {
 
 export namespace DescribeSecurityProfileRequest {
   export function isa(o: any): o is DescribeSecurityProfileRequest {
-    return _smithy.isa(o, "DescribeSecurityProfileRequest");
+    return __isa(o, "DescribeSecurityProfileRequest");
   }
 }
 
@@ -12127,7 +12126,7 @@ export interface DescribeSecurityProfileResponse extends $MetadataBearer {
 
 export namespace DescribeSecurityProfileResponse {
   export function isa(o: any): o is DescribeSecurityProfileResponse {
-    return _smithy.isa(o, "DescribeSecurityProfileResponse");
+    return __isa(o, "DescribeSecurityProfileResponse");
   }
 }
 
@@ -12146,7 +12145,7 @@ export interface DetachSecurityProfileRequest {
 
 export namespace DetachSecurityProfileRequest {
   export function isa(o: any): o is DetachSecurityProfileRequest {
-    return _smithy.isa(o, "DetachSecurityProfileRequest");
+    return __isa(o, "DetachSecurityProfileRequest");
   }
 }
 
@@ -12156,7 +12155,7 @@ export interface DetachSecurityProfileResponse extends $MetadataBearer {
 
 export namespace DetachSecurityProfileResponse {
   export function isa(o: any): o is DetachSecurityProfileResponse {
-    return _smithy.isa(o, "DetachSecurityProfileResponse");
+    return __isa(o, "DetachSecurityProfileResponse");
   }
 }
 
@@ -12185,7 +12184,7 @@ export interface ListActiveViolationsRequest {
 
 export namespace ListActiveViolationsRequest {
   export function isa(o: any): o is ListActiveViolationsRequest {
-    return _smithy.isa(o, "ListActiveViolationsRequest");
+    return __isa(o, "ListActiveViolationsRequest");
   }
 }
 
@@ -12205,7 +12204,7 @@ export interface ListActiveViolationsResponse extends $MetadataBearer {
 
 export namespace ListActiveViolationsResponse {
   export function isa(o: any): o is ListActiveViolationsResponse {
-    return _smithy.isa(o, "ListActiveViolationsResponse");
+    return __isa(o, "ListActiveViolationsResponse");
   }
 }
 
@@ -12252,7 +12251,7 @@ export interface ListAuditFindingsRequest {
 
 export namespace ListAuditFindingsRequest {
   export function isa(o: any): o is ListAuditFindingsRequest {
-    return _smithy.isa(o, "ListAuditFindingsRequest");
+    return __isa(o, "ListAuditFindingsRequest");
   }
 }
 
@@ -12272,7 +12271,7 @@ export interface ListAuditFindingsResponse extends $MetadataBearer {
 
 export namespace ListAuditFindingsResponse {
   export function isa(o: any): o is ListAuditFindingsResponse {
-    return _smithy.isa(o, "ListAuditFindingsResponse");
+    return __isa(o, "ListAuditFindingsResponse");
   }
 }
 
@@ -12308,7 +12307,7 @@ export namespace ListAuditMitigationActionsExecutionsRequest {
   export function isa(
     o: any
   ): o is ListAuditMitigationActionsExecutionsRequest {
-    return _smithy.isa(o, "ListAuditMitigationActionsExecutionsRequest");
+    return __isa(o, "ListAuditMitigationActionsExecutionsRequest");
   }
 }
 
@@ -12330,7 +12329,7 @@ export namespace ListAuditMitigationActionsExecutionsResponse {
   export function isa(
     o: any
   ): o is ListAuditMitigationActionsExecutionsResponse {
-    return _smithy.isa(o, "ListAuditMitigationActionsExecutionsResponse");
+    return __isa(o, "ListAuditMitigationActionsExecutionsResponse");
   }
 }
 
@@ -12374,7 +12373,7 @@ export interface ListAuditMitigationActionsTasksRequest {
 
 export namespace ListAuditMitigationActionsTasksRequest {
   export function isa(o: any): o is ListAuditMitigationActionsTasksRequest {
-    return _smithy.isa(o, "ListAuditMitigationActionsTasksRequest");
+    return __isa(o, "ListAuditMitigationActionsTasksRequest");
   }
 }
 
@@ -12394,7 +12393,7 @@ export interface ListAuditMitigationActionsTasksResponse
 
 export namespace ListAuditMitigationActionsTasksResponse {
   export function isa(o: any): o is ListAuditMitigationActionsTasksResponse {
-    return _smithy.isa(o, "ListAuditMitigationActionsTasksResponse");
+    return __isa(o, "ListAuditMitigationActionsTasksResponse");
   }
 }
 
@@ -12437,7 +12436,7 @@ export interface ListAuditTasksRequest {
 
 export namespace ListAuditTasksRequest {
   export function isa(o: any): o is ListAuditTasksRequest {
-    return _smithy.isa(o, "ListAuditTasksRequest");
+    return __isa(o, "ListAuditTasksRequest");
   }
 }
 
@@ -12457,7 +12456,7 @@ export interface ListAuditTasksResponse extends $MetadataBearer {
 
 export namespace ListAuditTasksResponse {
   export function isa(o: any): o is ListAuditTasksResponse {
-    return _smithy.isa(o, "ListAuditTasksResponse");
+    return __isa(o, "ListAuditTasksResponse");
   }
 }
 
@@ -12481,7 +12480,7 @@ export interface ListMitigationActionsRequest {
 
 export namespace ListMitigationActionsRequest {
   export function isa(o: any): o is ListMitigationActionsRequest {
-    return _smithy.isa(o, "ListMitigationActionsRequest");
+    return __isa(o, "ListMitigationActionsRequest");
   }
 }
 
@@ -12500,7 +12499,7 @@ export interface ListMitigationActionsResponse extends $MetadataBearer {
 
 export namespace ListMitigationActionsResponse {
   export function isa(o: any): o is ListMitigationActionsResponse {
-    return _smithy.isa(o, "ListMitigationActionsResponse");
+    return __isa(o, "ListMitigationActionsResponse");
   }
 }
 
@@ -12519,7 +12518,7 @@ export interface ListScheduledAuditsRequest {
 
 export namespace ListScheduledAuditsRequest {
   export function isa(o: any): o is ListScheduledAuditsRequest {
-    return _smithy.isa(o, "ListScheduledAuditsRequest");
+    return __isa(o, "ListScheduledAuditsRequest");
   }
 }
 
@@ -12539,7 +12538,7 @@ export interface ListScheduledAuditsResponse extends $MetadataBearer {
 
 export namespace ListScheduledAuditsResponse {
   export function isa(o: any): o is ListScheduledAuditsResponse {
-    return _smithy.isa(o, "ListScheduledAuditsResponse");
+    return __isa(o, "ListScheduledAuditsResponse");
   }
 }
 
@@ -12568,7 +12567,7 @@ export interface ListSecurityProfilesForTargetRequest {
 
 export namespace ListSecurityProfilesForTargetRequest {
   export function isa(o: any): o is ListSecurityProfilesForTargetRequest {
-    return _smithy.isa(o, "ListSecurityProfilesForTargetRequest");
+    return __isa(o, "ListSecurityProfilesForTargetRequest");
   }
 }
 
@@ -12588,7 +12587,7 @@ export interface ListSecurityProfilesForTargetResponse extends $MetadataBearer {
 
 export namespace ListSecurityProfilesForTargetResponse {
   export function isa(o: any): o is ListSecurityProfilesForTargetResponse {
-    return _smithy.isa(o, "ListSecurityProfilesForTargetResponse");
+    return __isa(o, "ListSecurityProfilesForTargetResponse");
   }
 }
 
@@ -12607,7 +12606,7 @@ export interface ListSecurityProfilesRequest {
 
 export namespace ListSecurityProfilesRequest {
   export function isa(o: any): o is ListSecurityProfilesRequest {
-    return _smithy.isa(o, "ListSecurityProfilesRequest");
+    return __isa(o, "ListSecurityProfilesRequest");
   }
 }
 
@@ -12627,7 +12626,7 @@ export interface ListSecurityProfilesResponse extends $MetadataBearer {
 
 export namespace ListSecurityProfilesResponse {
   export function isa(o: any): o is ListSecurityProfilesResponse {
-    return _smithy.isa(o, "ListSecurityProfilesResponse");
+    return __isa(o, "ListSecurityProfilesResponse");
   }
 }
 
@@ -12651,7 +12650,7 @@ export interface ListTargetsForSecurityProfileRequest {
 
 export namespace ListTargetsForSecurityProfileRequest {
   export function isa(o: any): o is ListTargetsForSecurityProfileRequest {
-    return _smithy.isa(o, "ListTargetsForSecurityProfileRequest");
+    return __isa(o, "ListTargetsForSecurityProfileRequest");
   }
 }
 
@@ -12671,7 +12670,7 @@ export interface ListTargetsForSecurityProfileResponse extends $MetadataBearer {
 
 export namespace ListTargetsForSecurityProfileResponse {
   export function isa(o: any): o is ListTargetsForSecurityProfileResponse {
-    return _smithy.isa(o, "ListTargetsForSecurityProfileResponse");
+    return __isa(o, "ListTargetsForSecurityProfileResponse");
   }
 }
 
@@ -12710,7 +12709,7 @@ export interface ListViolationEventsRequest {
 
 export namespace ListViolationEventsRequest {
   export function isa(o: any): o is ListViolationEventsRequest {
-    return _smithy.isa(o, "ListViolationEventsRequest");
+    return __isa(o, "ListViolationEventsRequest");
   }
 }
 
@@ -12731,7 +12730,7 @@ export interface ListViolationEventsResponse extends $MetadataBearer {
 
 export namespace ListViolationEventsResponse {
   export function isa(o: any): o is ListViolationEventsResponse {
-    return _smithy.isa(o, "ListViolationEventsResponse");
+    return __isa(o, "ListViolationEventsResponse");
   }
 }
 
@@ -12760,7 +12759,7 @@ export interface StartAuditMitigationActionsTaskRequest {
 
 export namespace StartAuditMitigationActionsTaskRequest {
   export function isa(o: any): o is StartAuditMitigationActionsTaskRequest {
-    return _smithy.isa(o, "StartAuditMitigationActionsTaskRequest");
+    return __isa(o, "StartAuditMitigationActionsTaskRequest");
   }
 }
 
@@ -12775,7 +12774,7 @@ export interface StartAuditMitigationActionsTaskResponse
 
 export namespace StartAuditMitigationActionsTaskResponse {
   export function isa(o: any): o is StartAuditMitigationActionsTaskResponse {
-    return _smithy.isa(o, "StartAuditMitigationActionsTaskResponse");
+    return __isa(o, "StartAuditMitigationActionsTaskResponse");
   }
 }
 
@@ -12792,7 +12791,7 @@ export interface StartOnDemandAuditTaskRequest {
 
 export namespace StartOnDemandAuditTaskRequest {
   export function isa(o: any): o is StartOnDemandAuditTaskRequest {
-    return _smithy.isa(o, "StartOnDemandAuditTaskRequest");
+    return __isa(o, "StartOnDemandAuditTaskRequest");
   }
 }
 
@@ -12806,7 +12805,7 @@ export interface StartOnDemandAuditTaskResponse extends $MetadataBearer {
 
 export namespace StartOnDemandAuditTaskResponse {
   export function isa(o: any): o is StartOnDemandAuditTaskResponse {
-    return _smithy.isa(o, "StartOnDemandAuditTaskResponse");
+    return __isa(o, "StartOnDemandAuditTaskResponse");
   }
 }
 
@@ -12842,7 +12841,7 @@ export interface UpdateAccountAuditConfigurationRequest {
 
 export namespace UpdateAccountAuditConfigurationRequest {
   export function isa(o: any): o is UpdateAccountAuditConfigurationRequest {
-    return _smithy.isa(o, "UpdateAccountAuditConfigurationRequest");
+    return __isa(o, "UpdateAccountAuditConfigurationRequest");
   }
 }
 
@@ -12853,7 +12852,7 @@ export interface UpdateAccountAuditConfigurationResponse
 
 export namespace UpdateAccountAuditConfigurationResponse {
   export function isa(o: any): o is UpdateAccountAuditConfigurationResponse {
-    return _smithy.isa(o, "UpdateAccountAuditConfigurationResponse");
+    return __isa(o, "UpdateAccountAuditConfigurationResponse");
   }
 }
 
@@ -12877,7 +12876,7 @@ export interface UpdateMitigationActionRequest {
 
 export namespace UpdateMitigationActionRequest {
   export function isa(o: any): o is UpdateMitigationActionRequest {
-    return _smithy.isa(o, "UpdateMitigationActionRequest");
+    return __isa(o, "UpdateMitigationActionRequest");
   }
 }
 
@@ -12896,7 +12895,7 @@ export interface UpdateMitigationActionResponse extends $MetadataBearer {
 
 export namespace UpdateMitigationActionResponse {
   export function isa(o: any): o is UpdateMitigationActionResponse {
-    return _smithy.isa(o, "UpdateMitigationActionResponse");
+    return __isa(o, "UpdateMitigationActionResponse");
   }
 }
 
@@ -12940,7 +12939,7 @@ export interface UpdateScheduledAuditRequest {
 
 export namespace UpdateScheduledAuditRequest {
   export function isa(o: any): o is UpdateScheduledAuditRequest {
-    return _smithy.isa(o, "UpdateScheduledAuditRequest");
+    return __isa(o, "UpdateScheduledAuditRequest");
   }
 }
 
@@ -12954,7 +12953,7 @@ export interface UpdateScheduledAuditResponse extends $MetadataBearer {
 
 export namespace UpdateScheduledAuditResponse {
   export function isa(o: any): o is UpdateScheduledAuditResponse {
-    return _smithy.isa(o, "UpdateScheduledAuditResponse");
+    return __isa(o, "UpdateScheduledAuditResponse");
   }
 }
 
@@ -13016,7 +13015,7 @@ export interface UpdateSecurityProfileRequest {
 
 export namespace UpdateSecurityProfileRequest {
   export function isa(o: any): o is UpdateSecurityProfileRequest {
-    return _smithy.isa(o, "UpdateSecurityProfileRequest");
+    return __isa(o, "UpdateSecurityProfileRequest");
   }
 }
 
@@ -13072,7 +13071,7 @@ export interface UpdateSecurityProfileResponse extends $MetadataBearer {
 
 export namespace UpdateSecurityProfileResponse {
   export function isa(o: any): o is UpdateSecurityProfileResponse {
-    return _smithy.isa(o, "UpdateSecurityProfileResponse");
+    return __isa(o, "UpdateSecurityProfileResponse");
   }
 }
 
@@ -13086,7 +13085,7 @@ export interface ValidateSecurityProfileBehaviorsRequest {
 
 export namespace ValidateSecurityProfileBehaviorsRequest {
   export function isa(o: any): o is ValidateSecurityProfileBehaviorsRequest {
-    return _smithy.isa(o, "ValidateSecurityProfileBehaviorsRequest");
+    return __isa(o, "ValidateSecurityProfileBehaviorsRequest");
   }
 }
 
@@ -13106,7 +13105,7 @@ export interface ValidateSecurityProfileBehaviorsResponse
 
 export namespace ValidateSecurityProfileBehaviorsResponse {
   export function isa(o: any): o is ValidateSecurityProfileBehaviorsResponse {
-    return _smithy.isa(o, "ValidateSecurityProfileBehaviorsResponse");
+    return __isa(o, "ValidateSecurityProfileBehaviorsResponse");
   }
 }
 
@@ -13128,7 +13127,7 @@ export interface AddThingsToThingGroupParams {
 
 export namespace AddThingsToThingGroupParams {
   export function isa(o: any): o is AddThingsToThingGroupParams {
-    return _smithy.isa(o, "AddThingsToThingGroupParams");
+    return __isa(o, "AddThingsToThingGroupParams");
   }
 }
 
@@ -13158,7 +13157,7 @@ export interface EnableIoTLoggingParams {
 
 export namespace EnableIoTLoggingParams {
   export function isa(o: any): o is EnableIoTLoggingParams {
-    return _smithy.isa(o, "EnableIoTLoggingParams");
+    return __isa(o, "EnableIoTLoggingParams");
   }
 }
 
@@ -13190,7 +13189,7 @@ export interface MitigationAction {
 
 export namespace MitigationAction {
   export function isa(o: any): o is MitigationAction {
-    return _smithy.isa(o, "MitigationAction");
+    return __isa(o, "MitigationAction");
   }
 }
 
@@ -13217,7 +13216,7 @@ export interface MitigationActionIdentifier {
 
 export namespace MitigationActionIdentifier {
   export function isa(o: any): o is MitigationActionIdentifier {
-    return _smithy.isa(o, "MitigationActionIdentifier");
+    return __isa(o, "MitigationActionIdentifier");
   }
 }
 
@@ -13259,7 +13258,7 @@ export interface MitigationActionParams {
 
 export namespace MitigationActionParams {
   export function isa(o: any): o is MitigationActionParams {
-    return _smithy.isa(o, "MitigationActionParams");
+    return __isa(o, "MitigationActionParams");
   }
 }
 
@@ -13289,7 +13288,7 @@ export interface PublishFindingToSnsParams {
 
 export namespace PublishFindingToSnsParams {
   export function isa(o: any): o is PublishFindingToSnsParams {
-    return _smithy.isa(o, "PublishFindingToSnsParams");
+    return __isa(o, "PublishFindingToSnsParams");
   }
 }
 
@@ -13306,7 +13305,7 @@ export interface ReplaceDefaultPolicyVersionParams {
 
 export namespace ReplaceDefaultPolicyVersionParams {
   export function isa(o: any): o is ReplaceDefaultPolicyVersionParams {
-    return _smithy.isa(o, "ReplaceDefaultPolicyVersionParams");
+    return __isa(o, "ReplaceDefaultPolicyVersionParams");
   }
 }
 
@@ -13323,7 +13322,7 @@ export interface UpdateCACertificateParams {
 
 export namespace UpdateCACertificateParams {
   export function isa(o: any): o is UpdateCACertificateParams {
-    return _smithy.isa(o, "UpdateCACertificateParams");
+    return __isa(o, "UpdateCACertificateParams");
   }
 }
 
@@ -13340,7 +13339,7 @@ export interface UpdateDeviceCertificateParams {
 
 export namespace UpdateDeviceCertificateParams {
   export function isa(o: any): o is UpdateDeviceCertificateParams {
-    return _smithy.isa(o, "UpdateDeviceCertificateParams");
+    return __isa(o, "UpdateDeviceCertificateParams");
   }
 }
 
@@ -13357,7 +13356,7 @@ export interface AuditCheckConfiguration {
 
 export namespace AuditCheckConfiguration {
   export function isa(o: any): o is AuditCheckConfiguration {
-    return _smithy.isa(o, "AuditCheckConfiguration");
+    return __isa(o, "AuditCheckConfiguration");
   }
 }
 
@@ -13401,7 +13400,7 @@ export interface AuditCheckDetails {
 
 export namespace AuditCheckDetails {
   export function isa(o: any): o is AuditCheckDetails {
-    return _smithy.isa(o, "AuditCheckDetails");
+    return __isa(o, "AuditCheckDetails");
   }
 }
 
@@ -13474,7 +13473,7 @@ export interface AuditFinding {
 
 export namespace AuditFinding {
   export function isa(o: any): o is AuditFinding {
-    return _smithy.isa(o, "AuditFinding");
+    return __isa(o, "AuditFinding");
   }
 }
 
@@ -13545,7 +13544,7 @@ export interface AuditMitigationActionExecutionMetadata {
 
 export namespace AuditMitigationActionExecutionMetadata {
   export function isa(o: any): o is AuditMitigationActionExecutionMetadata {
-    return _smithy.isa(o, "AuditMitigationActionExecutionMetadata");
+    return __isa(o, "AuditMitigationActionExecutionMetadata");
   }
 }
 
@@ -13581,7 +13580,7 @@ export interface AuditMitigationActionsTaskMetadata {
 
 export namespace AuditMitigationActionsTaskMetadata {
   export function isa(o: any): o is AuditMitigationActionsTaskMetadata {
-    return _smithy.isa(o, "AuditMitigationActionsTaskMetadata");
+    return __isa(o, "AuditMitigationActionsTaskMetadata");
   }
 }
 
@@ -13615,7 +13614,7 @@ export interface AuditMitigationActionsTaskTarget {
 
 export namespace AuditMitigationActionsTaskTarget {
   export function isa(o: any): o is AuditMitigationActionsTaskTarget {
-    return _smithy.isa(o, "AuditMitigationActionsTaskTarget");
+    return __isa(o, "AuditMitigationActionsTaskTarget");
   }
 }
 
@@ -13642,7 +13641,7 @@ export interface AuditNotificationTarget {
 
 export namespace AuditNotificationTarget {
   export function isa(o: any): o is AuditNotificationTarget {
-    return _smithy.isa(o, "AuditNotificationTarget");
+    return __isa(o, "AuditNotificationTarget");
   }
 }
 
@@ -13674,7 +13673,7 @@ export interface AuditTaskMetadata {
 
 export namespace AuditTaskMetadata {
   export function isa(o: any): o is AuditTaskMetadata {
-    return _smithy.isa(o, "AuditTaskMetadata");
+    return __isa(o, "AuditTaskMetadata");
   }
 }
 
@@ -13723,7 +13722,7 @@ export interface NonCompliantResource {
 
 export namespace NonCompliantResource {
   export function isa(o: any): o is NonCompliantResource {
-    return _smithy.isa(o, "NonCompliantResource");
+    return __isa(o, "NonCompliantResource");
   }
 }
 
@@ -13745,7 +13744,7 @@ export interface PolicyVersionIdentifier {
 
 export namespace PolicyVersionIdentifier {
   export function isa(o: any): o is PolicyVersionIdentifier {
-    return _smithy.isa(o, "PolicyVersionIdentifier");
+    return __isa(o, "PolicyVersionIdentifier");
   }
 }
 
@@ -13772,7 +13771,7 @@ export interface RelatedResource {
 
 export namespace RelatedResource {
   export function isa(o: any): o is RelatedResource {
-    return _smithy.isa(o, "RelatedResource");
+    return __isa(o, "RelatedResource");
   }
 }
 
@@ -13824,7 +13823,7 @@ export interface ResourceIdentifier {
 
 export namespace ResourceIdentifier {
   export function isa(o: any): o is ResourceIdentifier {
-    return _smithy.isa(o, "ResourceIdentifier");
+    return __isa(o, "ResourceIdentifier");
   }
 }
 
@@ -13876,7 +13875,7 @@ export interface ScheduledAuditMetadata {
 
 export namespace ScheduledAuditMetadata {
   export function isa(o: any): o is ScheduledAuditMetadata {
-    return _smithy.isa(o, "ScheduledAuditMetadata");
+    return __isa(o, "ScheduledAuditMetadata");
   }
 }
 
@@ -13884,7 +13883,7 @@ export namespace ScheduledAuditMetadata {
  * <p>This exception occurs if you attempt to start a task with the same task-id as an existing task but with a different clientRequestToken.</p>
  */
 export interface TaskAlreadyExistsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TaskAlreadyExistsException";
   $fault: "client";
@@ -13893,7 +13892,7 @@ export interface TaskAlreadyExistsException
 
 export namespace TaskAlreadyExistsException {
   export function isa(o: any): o is TaskAlreadyExistsException {
-    return _smithy.isa(o, "TaskAlreadyExistsException");
+    return __isa(o, "TaskAlreadyExistsException");
   }
 }
 
@@ -13940,7 +13939,7 @@ export interface TaskStatistics {
 
 export namespace TaskStatistics {
   export function isa(o: any): o is TaskStatistics {
-    return _smithy.isa(o, "TaskStatistics");
+    return __isa(o, "TaskStatistics");
   }
 }
 
@@ -13977,7 +13976,7 @@ export interface TaskStatisticsForAuditCheck {
 
 export namespace TaskStatisticsForAuditCheck {
   export function isa(o: any): o is TaskStatisticsForAuditCheck {
-    return _smithy.isa(o, "TaskStatisticsForAuditCheck");
+    return __isa(o, "TaskStatisticsForAuditCheck");
   }
 }
 
@@ -14024,7 +14023,7 @@ export interface ActiveViolation {
 
 export namespace ActiveViolation {
   export function isa(o: any): o is ActiveViolation {
-    return _smithy.isa(o, "ActiveViolation");
+    return __isa(o, "ActiveViolation");
   }
 }
 
@@ -14047,7 +14046,7 @@ export interface AlertTarget {
 
 export namespace AlertTarget {
   export function isa(o: any): o is AlertTarget {
-    return _smithy.isa(o, "AlertTarget");
+    return __isa(o, "AlertTarget");
   }
 }
 
@@ -14079,7 +14078,7 @@ export interface Behavior {
 
 export namespace Behavior {
   export function isa(o: any): o is Behavior {
-    return _smithy.isa(o, "Behavior");
+    return __isa(o, "Behavior");
   }
 }
 
@@ -14131,7 +14130,7 @@ export interface BehaviorCriteria {
 
 export namespace BehaviorCriteria {
   export function isa(o: any): o is BehaviorCriteria {
-    return _smithy.isa(o, "BehaviorCriteria");
+    return __isa(o, "BehaviorCriteria");
   }
 }
 
@@ -14172,7 +14171,7 @@ export interface MetricValue {
 
 export namespace MetricValue {
   export function isa(o: any): o is MetricValue {
-    return _smithy.isa(o, "MetricValue");
+    return __isa(o, "MetricValue");
   }
 }
 
@@ -14194,7 +14193,7 @@ export interface SecurityProfileIdentifier {
 
 export namespace SecurityProfileIdentifier {
   export function isa(o: any): o is SecurityProfileIdentifier {
-    return _smithy.isa(o, "SecurityProfileIdentifier");
+    return __isa(o, "SecurityProfileIdentifier");
   }
 }
 
@@ -14212,7 +14211,7 @@ export interface SecurityProfileTarget {
 
 export namespace SecurityProfileTarget {
   export function isa(o: any): o is SecurityProfileTarget {
-    return _smithy.isa(o, "SecurityProfileTarget");
+    return __isa(o, "SecurityProfileTarget");
   }
 }
 
@@ -14234,7 +14233,7 @@ export interface SecurityProfileTargetMapping {
 
 export namespace SecurityProfileTargetMapping {
   export function isa(o: any): o is SecurityProfileTargetMapping {
-    return _smithy.isa(o, "SecurityProfileTargetMapping");
+    return __isa(o, "SecurityProfileTargetMapping");
   }
 }
 
@@ -14258,7 +14257,7 @@ export interface StatisticalThreshold {
 
 export namespace StatisticalThreshold {
   export function isa(o: any): o is StatisticalThreshold {
-    return _smithy.isa(o, "StatisticalThreshold");
+    return __isa(o, "StatisticalThreshold");
   }
 }
 
@@ -14275,7 +14274,7 @@ export interface ValidationError {
 
 export namespace ValidationError {
   export function isa(o: any): o is ValidationError {
-    return _smithy.isa(o, "ValidationError");
+    return __isa(o, "ValidationError");
   }
 }
 
@@ -14322,7 +14321,7 @@ export interface ViolationEvent {
 
 export namespace ViolationEvent {
   export function isa(o: any): o is ViolationEvent {
-    return _smithy.isa(o, "ViolationEvent");
+    return __isa(o, "ViolationEvent");
   }
 }
 
@@ -14362,7 +14361,7 @@ export interface CreateStreamRequest {
 
 export namespace CreateStreamRequest {
   export function isa(o: any): o is CreateStreamRequest {
-    return _smithy.isa(o, "CreateStreamRequest");
+    return __isa(o, "CreateStreamRequest");
   }
 }
 
@@ -14391,7 +14390,7 @@ export interface CreateStreamResponse extends $MetadataBearer {
 
 export namespace CreateStreamResponse {
   export function isa(o: any): o is CreateStreamResponse {
-    return _smithy.isa(o, "CreateStreamResponse");
+    return __isa(o, "CreateStreamResponse");
   }
 }
 
@@ -14405,7 +14404,7 @@ export interface DeleteStreamRequest {
 
 export namespace DeleteStreamRequest {
   export function isa(o: any): o is DeleteStreamRequest {
-    return _smithy.isa(o, "DeleteStreamRequest");
+    return __isa(o, "DeleteStreamRequest");
   }
 }
 
@@ -14415,7 +14414,7 @@ export interface DeleteStreamResponse extends $MetadataBearer {
 
 export namespace DeleteStreamResponse {
   export function isa(o: any): o is DeleteStreamResponse {
-    return _smithy.isa(o, "DeleteStreamResponse");
+    return __isa(o, "DeleteStreamResponse");
   }
 }
 
@@ -14429,7 +14428,7 @@ export interface DescribeStreamRequest {
 
 export namespace DescribeStreamRequest {
   export function isa(o: any): o is DescribeStreamRequest {
-    return _smithy.isa(o, "DescribeStreamRequest");
+    return __isa(o, "DescribeStreamRequest");
   }
 }
 
@@ -14443,7 +14442,7 @@ export interface DescribeStreamResponse extends $MetadataBearer {
 
 export namespace DescribeStreamResponse {
   export function isa(o: any): o is DescribeStreamResponse {
-    return _smithy.isa(o, "DescribeStreamResponse");
+    return __isa(o, "DescribeStreamResponse");
   }
 }
 
@@ -14467,7 +14466,7 @@ export interface ListStreamsRequest {
 
 export namespace ListStreamsRequest {
   export function isa(o: any): o is ListStreamsRequest {
-    return _smithy.isa(o, "ListStreamsRequest");
+    return __isa(o, "ListStreamsRequest");
   }
 }
 
@@ -14486,7 +14485,7 @@ export interface ListStreamsResponse extends $MetadataBearer {
 
 export namespace ListStreamsResponse {
   export function isa(o: any): o is ListStreamsResponse {
-    return _smithy.isa(o, "ListStreamsResponse");
+    return __isa(o, "ListStreamsResponse");
   }
 }
 
@@ -14508,7 +14507,7 @@ export interface StreamFile {
 
 export namespace StreamFile {
   export function isa(o: any): o is StreamFile {
-    return _smithy.isa(o, "StreamFile");
+    return __isa(o, "StreamFile");
   }
 }
 
@@ -14560,7 +14559,7 @@ export interface StreamInfo {
 
 export namespace StreamInfo {
   export function isa(o: any): o is StreamInfo {
-    return _smithy.isa(o, "StreamInfo");
+    return __isa(o, "StreamInfo");
   }
 }
 
@@ -14592,7 +14591,7 @@ export interface StreamSummary {
 
 export namespace StreamSummary {
   export function isa(o: any): o is StreamSummary {
-    return _smithy.isa(o, "StreamSummary");
+    return __isa(o, "StreamSummary");
   }
 }
 
@@ -14621,7 +14620,7 @@ export interface UpdateStreamRequest {
 
 export namespace UpdateStreamRequest {
   export function isa(o: any): o is UpdateStreamRequest {
-    return _smithy.isa(o, "UpdateStreamRequest");
+    return __isa(o, "UpdateStreamRequest");
   }
 }
 
@@ -14650,7 +14649,7 @@ export interface UpdateStreamResponse extends $MetadataBearer {
 
 export namespace UpdateStreamResponse {
   export function isa(o: any): o is UpdateStreamResponse {
-    return _smithy.isa(o, "UpdateStreamResponse");
+    return __isa(o, "UpdateStreamResponse");
   }
 }
 
@@ -14677,6 +14676,6 @@ export interface S3Location {
 
 export namespace S3Location {
   export function isa(o: any): o is S3Location {
-    return _smithy.isa(o, "S3Location");
+    return __isa(o, "S3Location");
   }
 }

--- a/clients/client-iot/protocols/Aws_restJson1_1.ts
+++ b/clients/client-iot/protocols/Aws_restJson1_1.ts
@@ -996,7 +996,10 @@ import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  extendedEncodeURIComponent as __extendedEncodeURIComponent
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -1013,7 +1016,7 @@ export async function serializeAws_restJson1_1ConfirmTopicRuleDestinationCommand
   headers["Content-Type"] = "";
   let resolvedPath = "/confirmdestination/{confirmationToken+}";
   if (input.confirmationToken !== undefined) {
-    const labelValue: string = input.confirmationToken.toString();
+    const labelValue: string = input.confirmationToken;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: confirmationToken."
@@ -1023,7 +1026,7 @@ export async function serializeAws_restJson1_1ConfirmTopicRuleDestinationCommand
       "{confirmationToken+}",
       labelValue
         .split("/")
-        .map(segment => encodeURIComponent(segment))
+        .map(segment => __extendedEncodeURIComponent(segment))
         .join("/")
     );
   } else {
@@ -1047,17 +1050,17 @@ export async function serializeAws_restJson1_1CreateTopicRuleCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.tags !== undefined) {
-    headers["x-amz-tagging"] = input.tags.toString();
+    headers["x-amz-tagging"] = input.tags;
   }
   let resolvedPath = "/rules/{ruleName}";
   if (input.ruleName !== undefined) {
-    const labelValue: string = input.ruleName.toString();
+    const labelValue: string = input.ruleName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ruleName.");
     }
     resolvedPath = resolvedPath.replace(
       "{ruleName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ruleName.");
@@ -1119,13 +1122,13 @@ export async function serializeAws_restJson1_1DeleteTopicRuleCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/rules/{ruleName}";
   if (input.ruleName !== undefined) {
-    const labelValue: string = input.ruleName.toString();
+    const labelValue: string = input.ruleName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ruleName.");
     }
     resolvedPath = resolvedPath.replace(
       "{ruleName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ruleName.");
@@ -1147,7 +1150,7 @@ export async function serializeAws_restJson1_1DeleteTopicRuleDestinationCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/destinations/{arn+}";
   if (input.arn !== undefined) {
-    const labelValue: string = input.arn.toString();
+    const labelValue: string = input.arn;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: arn.");
     }
@@ -1155,7 +1158,7 @@ export async function serializeAws_restJson1_1DeleteTopicRuleDestinationCommand(
       "{arn+}",
       labelValue
         .split("/")
-        .map(segment => encodeURIComponent(segment))
+        .map(segment => __extendedEncodeURIComponent(segment))
         .join("/")
     );
   } else {
@@ -1179,10 +1182,14 @@ export async function serializeAws_restJson1_1DeleteV2LoggingLevelCommand(
   let resolvedPath = "/v2LoggingLevel";
   const query: any = {};
   if (input.targetName !== undefined) {
-    query["targetName"] = input.targetName.toString();
+    query[
+      __extendedEncodeURIComponent("targetName")
+    ] = __extendedEncodeURIComponent(input.targetName);
   }
   if (input.targetType !== undefined) {
-    query["targetType"] = input.targetType.toString();
+    query[
+      __extendedEncodeURIComponent("targetType")
+    ] = __extendedEncodeURIComponent(input.targetType);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1202,13 +1209,13 @@ export async function serializeAws_restJson1_1DisableTopicRuleCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/rules/{ruleName}/disable";
   if (input.ruleName !== undefined) {
-    const labelValue: string = input.ruleName.toString();
+    const labelValue: string = input.ruleName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ruleName.");
     }
     resolvedPath = resolvedPath.replace(
       "{ruleName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ruleName.");
@@ -1230,13 +1237,13 @@ export async function serializeAws_restJson1_1EnableTopicRuleCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/rules/{ruleName}/enable";
   if (input.ruleName !== undefined) {
-    const labelValue: string = input.ruleName.toString();
+    const labelValue: string = input.ruleName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ruleName.");
     }
     resolvedPath = resolvedPath.replace(
       "{ruleName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ruleName.");
@@ -1274,13 +1281,13 @@ export async function serializeAws_restJson1_1GetTopicRuleCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/rules/{ruleName}";
   if (input.ruleName !== undefined) {
-    const labelValue: string = input.ruleName.toString();
+    const labelValue: string = input.ruleName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ruleName.");
     }
     resolvedPath = resolvedPath.replace(
       "{ruleName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ruleName.");
@@ -1302,7 +1309,7 @@ export async function serializeAws_restJson1_1GetTopicRuleDestinationCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/destinations/{arn+}";
   if (input.arn !== undefined) {
-    const labelValue: string = input.arn.toString();
+    const labelValue: string = input.arn;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: arn.");
     }
@@ -1310,7 +1317,7 @@ export async function serializeAws_restJson1_1GetTopicRuleDestinationCommand(
       "{arn+}",
       labelValue
         .split("/")
-        .map(segment => encodeURIComponent(segment))
+        .map(segment => __extendedEncodeURIComponent(segment))
         .join("/")
     );
   } else {
@@ -1350,10 +1357,14 @@ export async function serializeAws_restJson1_1ListTopicRuleDestinationsCommand(
   let resolvedPath = "/destinations";
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1374,16 +1385,24 @@ export async function serializeAws_restJson1_1ListTopicRulesCommand(
   let resolvedPath = "/rules";
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   if (input.ruleDisabled !== undefined) {
-    query["ruleDisabled"] = input.ruleDisabled.toString();
+    query[
+      __extendedEncodeURIComponent("ruleDisabled")
+    ] = __extendedEncodeURIComponent(input.ruleDisabled.toString());
   }
   if (input.topic !== undefined) {
-    query["topic"] = input.topic.toString();
+    query[__extendedEncodeURIComponent("topic")] = __extendedEncodeURIComponent(
+      input.topic
+    );
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1404,13 +1423,19 @@ export async function serializeAws_restJson1_1ListV2LoggingLevelsCommand(
   let resolvedPath = "/v2LoggingLevel";
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   if (input.targetType !== undefined) {
-    query["targetType"] = input.targetType.toString();
+    query[
+      __extendedEncodeURIComponent("targetType")
+    ] = __extendedEncodeURIComponent(input.targetType);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1430,13 +1455,13 @@ export async function serializeAws_restJson1_1ReplaceTopicRuleCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/rules/{ruleName}";
   if (input.ruleName !== undefined) {
-    const labelValue: string = input.ruleName.toString();
+    const labelValue: string = input.ruleName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ruleName.");
     }
     resolvedPath = resolvedPath.replace(
       "{ruleName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ruleName.");
@@ -1582,7 +1607,7 @@ export async function serializeAws_restJson1_1AcceptCertificateTransferCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/accept-certificate-transfer/{certificateId}";
   if (input.certificateId !== undefined) {
-    const labelValue: string = input.certificateId.toString();
+    const labelValue: string = input.certificateId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: certificateId."
@@ -1590,14 +1615,16 @@ export async function serializeAws_restJson1_1AcceptCertificateTransferCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{certificateId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: certificateId.");
   }
   const query: any = {};
   if (input.setAsActive !== undefined) {
-    query["setAsActive"] = input.setAsActive.toString();
+    query[
+      __extendedEncodeURIComponent("setAsActive")
+    ] = __extendedEncodeURIComponent(input.setAsActive.toString());
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1617,13 +1644,13 @@ export async function serializeAws_restJson1_1AttachPolicyCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/target-policies/{policyName}";
   if (input.policyName !== undefined) {
-    const labelValue: string = input.policyName.toString();
+    const labelValue: string = input.policyName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: policyName.");
     }
     resolvedPath = resolvedPath.replace(
       "{policyName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: policyName.");
@@ -1651,17 +1678,17 @@ export async function serializeAws_restJson1_1AttachPrincipalPolicyCommand(
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.principal !== undefined) {
-    headers["x-amzn-iot-principal"] = input.principal.toString();
+    headers["x-amzn-iot-principal"] = input.principal;
   }
   let resolvedPath = "/principal-policies/{policyName}";
   if (input.policyName !== undefined) {
-    const labelValue: string = input.policyName.toString();
+    const labelValue: string = input.policyName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: policyName.");
     }
     resolvedPath = resolvedPath.replace(
       "{policyName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: policyName.");
@@ -1683,7 +1710,7 @@ export async function serializeAws_restJson1_1CancelCertificateTransferCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/cancel-certificate-transfer/{certificateId}";
   if (input.certificateId !== undefined) {
-    const labelValue: string = input.certificateId.toString();
+    const labelValue: string = input.certificateId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: certificateId."
@@ -1691,7 +1718,7 @@ export async function serializeAws_restJson1_1CancelCertificateTransferCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{certificateId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: certificateId.");
@@ -1729,7 +1756,7 @@ export async function serializeAws_restJson1_1CreateAuthorizerCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/authorizer/{authorizerName}";
   if (input.authorizerName !== undefined) {
-    const labelValue: string = input.authorizerName.toString();
+    const labelValue: string = input.authorizerName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: authorizerName."
@@ -1737,7 +1764,7 @@ export async function serializeAws_restJson1_1CreateAuthorizerCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{authorizerName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: authorizerName.");
@@ -1782,7 +1809,9 @@ export async function serializeAws_restJson1_1CreateCertificateFromCsrCommand(
   let resolvedPath = "/certificates";
   const query: any = {};
   if (input.setAsActive !== undefined) {
-    query["setAsActive"] = input.setAsActive.toString();
+    query[
+      __extendedEncodeURIComponent("setAsActive")
+    ] = __extendedEncodeURIComponent(input.setAsActive.toString());
   }
   let body: any;
   const bodyParams: any = {};
@@ -1809,7 +1838,7 @@ export async function serializeAws_restJson1_1CreateDomainConfigurationCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/domainConfigurations/{domainConfigurationName}";
   if (input.domainConfigurationName !== undefined) {
-    const labelValue: string = input.domainConfigurationName.toString();
+    const labelValue: string = input.domainConfigurationName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: domainConfigurationName."
@@ -1817,7 +1846,7 @@ export async function serializeAws_restJson1_1CreateDomainConfigurationCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{domainConfigurationName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -1869,7 +1898,9 @@ export async function serializeAws_restJson1_1CreateKeysAndCertificateCommand(
   let resolvedPath = "/keys-and-certificate";
   const query: any = {};
   if (input.setAsActive !== undefined) {
-    query["setAsActive"] = input.setAsActive.toString();
+    query[
+      __extendedEncodeURIComponent("setAsActive")
+    ] = __extendedEncodeURIComponent(input.setAsActive.toString());
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1889,13 +1920,13 @@ export async function serializeAws_restJson1_1CreatePolicyCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/policies/{policyName}";
   if (input.policyName !== undefined) {
-    const labelValue: string = input.policyName.toString();
+    const labelValue: string = input.policyName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: policyName.");
     }
     resolvedPath = resolvedPath.replace(
       "{policyName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: policyName.");
@@ -1924,20 +1955,22 @@ export async function serializeAws_restJson1_1CreatePolicyVersionCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/policies/{policyName}/version";
   if (input.policyName !== undefined) {
-    const labelValue: string = input.policyName.toString();
+    const labelValue: string = input.policyName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: policyName.");
     }
     resolvedPath = resolvedPath.replace(
       "{policyName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: policyName.");
   }
   const query: any = {};
   if (input.setAsDefault !== undefined) {
-    query["setAsDefault"] = input.setAsDefault.toString();
+    query[
+      __extendedEncodeURIComponent("setAsDefault")
+    ] = __extendedEncodeURIComponent(input.setAsDefault.toString());
   }
   let body: any;
   const bodyParams: any = {};
@@ -1965,7 +1998,7 @@ export async function serializeAws_restJson1_1CreateProvisioningClaimCommand(
   let resolvedPath =
     "/provisioning-templates/{templateName}/provisioning-claim";
   if (input.templateName !== undefined) {
-    const labelValue: string = input.templateName.toString();
+    const labelValue: string = input.templateName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: templateName."
@@ -1973,7 +2006,7 @@ export async function serializeAws_restJson1_1CreateProvisioningClaimCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{templateName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: templateName.");
@@ -2033,7 +2066,7 @@ export async function serializeAws_restJson1_1CreateProvisioningTemplateVersionC
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/provisioning-templates/{templateName}/versions";
   if (input.templateName !== undefined) {
-    const labelValue: string = input.templateName.toString();
+    const labelValue: string = input.templateName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: templateName."
@@ -2041,14 +2074,16 @@ export async function serializeAws_restJson1_1CreateProvisioningTemplateVersionC
     }
     resolvedPath = resolvedPath.replace(
       "{templateName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: templateName.");
   }
   const query: any = {};
   if (input.setAsDefault !== undefined) {
-    query["setAsDefault"] = input.setAsDefault.toString();
+    query[
+      __extendedEncodeURIComponent("setAsDefault")
+    ] = __extendedEncodeURIComponent(input.setAsDefault.toString());
   }
   let body: any;
   const bodyParams: any = {};
@@ -2075,13 +2110,13 @@ export async function serializeAws_restJson1_1CreateRoleAliasCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/role-aliases/{roleAlias}";
   if (input.roleAlias !== undefined) {
-    const labelValue: string = input.roleAlias.toString();
+    const labelValue: string = input.roleAlias;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: roleAlias.");
     }
     resolvedPath = resolvedPath.replace(
       "{roleAlias}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: roleAlias.");
@@ -2113,7 +2148,7 @@ export async function serializeAws_restJson1_1DeleteAuthorizerCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/authorizer/{authorizerName}";
   if (input.authorizerName !== undefined) {
-    const labelValue: string = input.authorizerName.toString();
+    const labelValue: string = input.authorizerName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: authorizerName."
@@ -2121,7 +2156,7 @@ export async function serializeAws_restJson1_1DeleteAuthorizerCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{authorizerName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: authorizerName.");
@@ -2143,7 +2178,7 @@ export async function serializeAws_restJson1_1DeleteCACertificateCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/cacertificate/{certificateId}";
   if (input.certificateId !== undefined) {
-    const labelValue: string = input.certificateId.toString();
+    const labelValue: string = input.certificateId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: certificateId."
@@ -2151,7 +2186,7 @@ export async function serializeAws_restJson1_1DeleteCACertificateCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{certificateId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: certificateId.");
@@ -2173,7 +2208,7 @@ export async function serializeAws_restJson1_1DeleteCertificateCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/certificates/{certificateId}";
   if (input.certificateId !== undefined) {
-    const labelValue: string = input.certificateId.toString();
+    const labelValue: string = input.certificateId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: certificateId."
@@ -2181,14 +2216,16 @@ export async function serializeAws_restJson1_1DeleteCertificateCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{certificateId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: certificateId.");
   }
   const query: any = {};
   if (input.forceDelete !== undefined) {
-    query["forceDelete"] = input.forceDelete.toString();
+    query[
+      __extendedEncodeURIComponent("forceDelete")
+    ] = __extendedEncodeURIComponent(input.forceDelete.toString());
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2208,7 +2245,7 @@ export async function serializeAws_restJson1_1DeleteDomainConfigurationCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/domainConfigurations/{domainConfigurationName}";
   if (input.domainConfigurationName !== undefined) {
-    const labelValue: string = input.domainConfigurationName.toString();
+    const labelValue: string = input.domainConfigurationName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: domainConfigurationName."
@@ -2216,7 +2253,7 @@ export async function serializeAws_restJson1_1DeleteDomainConfigurationCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{domainConfigurationName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -2240,13 +2277,13 @@ export async function serializeAws_restJson1_1DeletePolicyCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/policies/{policyName}";
   if (input.policyName !== undefined) {
-    const labelValue: string = input.policyName.toString();
+    const labelValue: string = input.policyName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: policyName.");
     }
     resolvedPath = resolvedPath.replace(
       "{policyName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: policyName.");
@@ -2268,19 +2305,19 @@ export async function serializeAws_restJson1_1DeletePolicyVersionCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/policies/{policyName}/version/{policyVersionId}";
   if (input.policyName !== undefined) {
-    const labelValue: string = input.policyName.toString();
+    const labelValue: string = input.policyName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: policyName.");
     }
     resolvedPath = resolvedPath.replace(
       "{policyName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: policyName.");
   }
   if (input.policyVersionId !== undefined) {
-    const labelValue: string = input.policyVersionId.toString();
+    const labelValue: string = input.policyVersionId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: policyVersionId."
@@ -2288,7 +2325,7 @@ export async function serializeAws_restJson1_1DeletePolicyVersionCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{policyVersionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: policyVersionId.");
@@ -2310,7 +2347,7 @@ export async function serializeAws_restJson1_1DeleteProvisioningTemplateCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/provisioning-templates/{templateName}";
   if (input.templateName !== undefined) {
-    const labelValue: string = input.templateName.toString();
+    const labelValue: string = input.templateName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: templateName."
@@ -2318,7 +2355,7 @@ export async function serializeAws_restJson1_1DeleteProvisioningTemplateCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{templateName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: templateName.");
@@ -2341,7 +2378,7 @@ export async function serializeAws_restJson1_1DeleteProvisioningTemplateVersionC
   let resolvedPath =
     "/provisioning-templates/{templateName}/versions/{versionId}";
   if (input.templateName !== undefined) {
-    const labelValue: string = input.templateName.toString();
+    const labelValue: string = input.templateName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: templateName."
@@ -2349,7 +2386,7 @@ export async function serializeAws_restJson1_1DeleteProvisioningTemplateVersionC
     }
     resolvedPath = resolvedPath.replace(
       "{templateName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: templateName.");
@@ -2361,7 +2398,7 @@ export async function serializeAws_restJson1_1DeleteProvisioningTemplateVersionC
     }
     resolvedPath = resolvedPath.replace(
       "{versionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: versionId.");
@@ -2399,13 +2436,13 @@ export async function serializeAws_restJson1_1DeleteRoleAliasCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/role-aliases/{roleAlias}";
   if (input.roleAlias !== undefined) {
-    const labelValue: string = input.roleAlias.toString();
+    const labelValue: string = input.roleAlias;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: roleAlias.");
     }
     resolvedPath = resolvedPath.replace(
       "{roleAlias}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: roleAlias.");
@@ -2427,7 +2464,7 @@ export async function serializeAws_restJson1_1DescribeAuthorizerCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/authorizer/{authorizerName}";
   if (input.authorizerName !== undefined) {
-    const labelValue: string = input.authorizerName.toString();
+    const labelValue: string = input.authorizerName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: authorizerName."
@@ -2435,7 +2472,7 @@ export async function serializeAws_restJson1_1DescribeAuthorizerCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{authorizerName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: authorizerName.");
@@ -2457,7 +2494,7 @@ export async function serializeAws_restJson1_1DescribeCACertificateCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/cacertificate/{certificateId}";
   if (input.certificateId !== undefined) {
-    const labelValue: string = input.certificateId.toString();
+    const labelValue: string = input.certificateId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: certificateId."
@@ -2465,7 +2502,7 @@ export async function serializeAws_restJson1_1DescribeCACertificateCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{certificateId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: certificateId.");
@@ -2487,7 +2524,7 @@ export async function serializeAws_restJson1_1DescribeCertificateCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/certificates/{certificateId}";
   if (input.certificateId !== undefined) {
-    const labelValue: string = input.certificateId.toString();
+    const labelValue: string = input.certificateId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: certificateId."
@@ -2495,7 +2532,7 @@ export async function serializeAws_restJson1_1DescribeCertificateCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{certificateId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: certificateId.");
@@ -2533,7 +2570,7 @@ export async function serializeAws_restJson1_1DescribeDomainConfigurationCommand
   headers["Content-Type"] = "";
   let resolvedPath = "/domainConfigurations/{domainConfigurationName}";
   if (input.domainConfigurationName !== undefined) {
-    const labelValue: string = input.domainConfigurationName.toString();
+    const labelValue: string = input.domainConfigurationName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: domainConfigurationName."
@@ -2541,7 +2578,7 @@ export async function serializeAws_restJson1_1DescribeDomainConfigurationCommand
     }
     resolvedPath = resolvedPath.replace(
       "{domainConfigurationName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -2566,7 +2603,9 @@ export async function serializeAws_restJson1_1DescribeEndpointCommand(
   let resolvedPath = "/endpoint";
   const query: any = {};
   if (input.endpointType !== undefined) {
-    query["endpointType"] = input.endpointType.toString();
+    query[
+      __extendedEncodeURIComponent("endpointType")
+    ] = __extendedEncodeURIComponent(input.endpointType);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2586,7 +2625,7 @@ export async function serializeAws_restJson1_1DescribeProvisioningTemplateComman
   headers["Content-Type"] = "";
   let resolvedPath = "/provisioning-templates/{templateName}";
   if (input.templateName !== undefined) {
-    const labelValue: string = input.templateName.toString();
+    const labelValue: string = input.templateName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: templateName."
@@ -2594,7 +2633,7 @@ export async function serializeAws_restJson1_1DescribeProvisioningTemplateComman
     }
     resolvedPath = resolvedPath.replace(
       "{templateName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: templateName.");
@@ -2617,7 +2656,7 @@ export async function serializeAws_restJson1_1DescribeProvisioningTemplateVersio
   let resolvedPath =
     "/provisioning-templates/{templateName}/versions/{versionId}";
   if (input.templateName !== undefined) {
-    const labelValue: string = input.templateName.toString();
+    const labelValue: string = input.templateName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: templateName."
@@ -2625,7 +2664,7 @@ export async function serializeAws_restJson1_1DescribeProvisioningTemplateVersio
     }
     resolvedPath = resolvedPath.replace(
       "{templateName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: templateName.");
@@ -2637,7 +2676,7 @@ export async function serializeAws_restJson1_1DescribeProvisioningTemplateVersio
     }
     resolvedPath = resolvedPath.replace(
       "{versionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: versionId.");
@@ -2659,13 +2698,13 @@ export async function serializeAws_restJson1_1DescribeRoleAliasCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/role-aliases/{roleAlias}";
   if (input.roleAlias !== undefined) {
-    const labelValue: string = input.roleAlias.toString();
+    const labelValue: string = input.roleAlias;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: roleAlias.");
     }
     resolvedPath = resolvedPath.replace(
       "{roleAlias}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: roleAlias.");
@@ -2687,13 +2726,13 @@ export async function serializeAws_restJson1_1DetachPolicyCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/target-policies/{policyName}";
   if (input.policyName !== undefined) {
-    const labelValue: string = input.policyName.toString();
+    const labelValue: string = input.policyName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: policyName.");
     }
     resolvedPath = resolvedPath.replace(
       "{policyName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: policyName.");
@@ -2721,17 +2760,17 @@ export async function serializeAws_restJson1_1DetachPrincipalPolicyCommand(
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.principal !== undefined) {
-    headers["x-amzn-iot-principal"] = input.principal.toString();
+    headers["x-amzn-iot-principal"] = input.principal;
   }
   let resolvedPath = "/principal-policies/{policyName}";
   if (input.policyName !== undefined) {
-    const labelValue: string = input.policyName.toString();
+    const labelValue: string = input.policyName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: policyName.");
     }
     resolvedPath = resolvedPath.replace(
       "{policyName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: policyName.");
@@ -2754,7 +2793,9 @@ export async function serializeAws_restJson1_1GetEffectivePoliciesCommand(
   let resolvedPath = "/effective-policies";
   const query: any = {};
   if (input.thingName !== undefined) {
-    query["thingName"] = input.thingName.toString();
+    query[
+      __extendedEncodeURIComponent("thingName")
+    ] = __extendedEncodeURIComponent(input.thingName);
   }
   let body: any;
   const bodyParams: any = {};
@@ -2784,13 +2825,13 @@ export async function serializeAws_restJson1_1GetPolicyCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/policies/{policyName}";
   if (input.policyName !== undefined) {
-    const labelValue: string = input.policyName.toString();
+    const labelValue: string = input.policyName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: policyName.");
     }
     resolvedPath = resolvedPath.replace(
       "{policyName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: policyName.");
@@ -2812,19 +2853,19 @@ export async function serializeAws_restJson1_1GetPolicyVersionCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/policies/{policyName}/version/{policyVersionId}";
   if (input.policyName !== undefined) {
-    const labelValue: string = input.policyName.toString();
+    const labelValue: string = input.policyName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: policyName.");
     }
     resolvedPath = resolvedPath.replace(
       "{policyName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: policyName.");
   }
   if (input.policyVersionId !== undefined) {
-    const labelValue: string = input.policyVersionId.toString();
+    const labelValue: string = input.policyVersionId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: policyVersionId."
@@ -2832,7 +2873,7 @@ export async function serializeAws_restJson1_1GetPolicyVersionCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{policyVersionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: policyVersionId.");
@@ -2870,26 +2911,32 @@ export async function serializeAws_restJson1_1ListAttachedPoliciesCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/attached-policies/{target}";
   if (input.target !== undefined) {
-    const labelValue: string = input.target.toString();
+    const labelValue: string = input.target;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: target.");
     }
     resolvedPath = resolvedPath.replace(
       "{target}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: target.");
   }
   const query: any = {};
   if (input.marker !== undefined) {
-    query["marker"] = input.marker.toString();
+    query[
+      __extendedEncodeURIComponent("marker")
+    ] = __extendedEncodeURIComponent(input.marker);
   }
   if (input.pageSize !== undefined) {
-    query["pageSize"] = input.pageSize.toString();
+    query[
+      __extendedEncodeURIComponent("pageSize")
+    ] = __extendedEncodeURIComponent(input.pageSize.toString());
   }
   if (input.recursive !== undefined) {
-    query["recursive"] = input.recursive.toString();
+    query[
+      __extendedEncodeURIComponent("recursive")
+    ] = __extendedEncodeURIComponent(input.recursive.toString());
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2910,16 +2957,24 @@ export async function serializeAws_restJson1_1ListAuthorizersCommand(
   let resolvedPath = "/authorizers";
   const query: any = {};
   if (input.ascendingOrder !== undefined) {
-    query["isAscendingOrder"] = input.ascendingOrder.toString();
+    query[
+      __extendedEncodeURIComponent("isAscendingOrder")
+    ] = __extendedEncodeURIComponent(input.ascendingOrder.toString());
   }
   if (input.marker !== undefined) {
-    query["marker"] = input.marker.toString();
+    query[
+      __extendedEncodeURIComponent("marker")
+    ] = __extendedEncodeURIComponent(input.marker);
   }
   if (input.pageSize !== undefined) {
-    query["pageSize"] = input.pageSize.toString();
+    query[
+      __extendedEncodeURIComponent("pageSize")
+    ] = __extendedEncodeURIComponent(input.pageSize.toString());
   }
   if (input.status !== undefined) {
-    query["status"] = input.status.toString();
+    query[
+      __extendedEncodeURIComponent("status")
+    ] = __extendedEncodeURIComponent(input.status);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2940,13 +2995,19 @@ export async function serializeAws_restJson1_1ListCACertificatesCommand(
   let resolvedPath = "/cacertificates";
   const query: any = {};
   if (input.ascendingOrder !== undefined) {
-    query["isAscendingOrder"] = input.ascendingOrder.toString();
+    query[
+      __extendedEncodeURIComponent("isAscendingOrder")
+    ] = __extendedEncodeURIComponent(input.ascendingOrder.toString());
   }
   if (input.marker !== undefined) {
-    query["marker"] = input.marker.toString();
+    query[
+      __extendedEncodeURIComponent("marker")
+    ] = __extendedEncodeURIComponent(input.marker);
   }
   if (input.pageSize !== undefined) {
-    query["pageSize"] = input.pageSize.toString();
+    query[
+      __extendedEncodeURIComponent("pageSize")
+    ] = __extendedEncodeURIComponent(input.pageSize.toString());
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2967,13 +3028,19 @@ export async function serializeAws_restJson1_1ListCertificatesCommand(
   let resolvedPath = "/certificates";
   const query: any = {};
   if (input.ascendingOrder !== undefined) {
-    query["isAscendingOrder"] = input.ascendingOrder.toString();
+    query[
+      __extendedEncodeURIComponent("isAscendingOrder")
+    ] = __extendedEncodeURIComponent(input.ascendingOrder.toString());
   }
   if (input.marker !== undefined) {
-    query["marker"] = input.marker.toString();
+    query[
+      __extendedEncodeURIComponent("marker")
+    ] = __extendedEncodeURIComponent(input.marker);
   }
   if (input.pageSize !== undefined) {
-    query["pageSize"] = input.pageSize.toString();
+    query[
+      __extendedEncodeURIComponent("pageSize")
+    ] = __extendedEncodeURIComponent(input.pageSize.toString());
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2993,7 +3060,7 @@ export async function serializeAws_restJson1_1ListCertificatesByCACommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/certificates-by-ca/{caCertificateId}";
   if (input.caCertificateId !== undefined) {
-    const labelValue: string = input.caCertificateId.toString();
+    const labelValue: string = input.caCertificateId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: caCertificateId."
@@ -3001,20 +3068,26 @@ export async function serializeAws_restJson1_1ListCertificatesByCACommand(
     }
     resolvedPath = resolvedPath.replace(
       "{caCertificateId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: caCertificateId.");
   }
   const query: any = {};
   if (input.ascendingOrder !== undefined) {
-    query["isAscendingOrder"] = input.ascendingOrder.toString();
+    query[
+      __extendedEncodeURIComponent("isAscendingOrder")
+    ] = __extendedEncodeURIComponent(input.ascendingOrder.toString());
   }
   if (input.marker !== undefined) {
-    query["marker"] = input.marker.toString();
+    query[
+      __extendedEncodeURIComponent("marker")
+    ] = __extendedEncodeURIComponent(input.marker);
   }
   if (input.pageSize !== undefined) {
-    query["pageSize"] = input.pageSize.toString();
+    query[
+      __extendedEncodeURIComponent("pageSize")
+    ] = __extendedEncodeURIComponent(input.pageSize.toString());
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -3035,13 +3108,19 @@ export async function serializeAws_restJson1_1ListDomainConfigurationsCommand(
   let resolvedPath = "/domainConfigurations";
   const query: any = {};
   if (input.marker !== undefined) {
-    query["marker"] = input.marker.toString();
+    query[
+      __extendedEncodeURIComponent("marker")
+    ] = __extendedEncodeURIComponent(input.marker);
   }
   if (input.pageSize !== undefined) {
-    query["pageSize"] = input.pageSize.toString();
+    query[
+      __extendedEncodeURIComponent("pageSize")
+    ] = __extendedEncodeURIComponent(input.pageSize.toString());
   }
   if (input.serviceType !== undefined) {
-    query["serviceType"] = input.serviceType.toString();
+    query[
+      __extendedEncodeURIComponent("serviceType")
+    ] = __extendedEncodeURIComponent(input.serviceType);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -3062,13 +3141,19 @@ export async function serializeAws_restJson1_1ListOutgoingCertificatesCommand(
   let resolvedPath = "/certificates-out-going";
   const query: any = {};
   if (input.ascendingOrder !== undefined) {
-    query["isAscendingOrder"] = input.ascendingOrder.toString();
+    query[
+      __extendedEncodeURIComponent("isAscendingOrder")
+    ] = __extendedEncodeURIComponent(input.ascendingOrder.toString());
   }
   if (input.marker !== undefined) {
-    query["marker"] = input.marker.toString();
+    query[
+      __extendedEncodeURIComponent("marker")
+    ] = __extendedEncodeURIComponent(input.marker);
   }
   if (input.pageSize !== undefined) {
-    query["pageSize"] = input.pageSize.toString();
+    query[
+      __extendedEncodeURIComponent("pageSize")
+    ] = __extendedEncodeURIComponent(input.pageSize.toString());
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -3089,13 +3174,19 @@ export async function serializeAws_restJson1_1ListPoliciesCommand(
   let resolvedPath = "/policies";
   const query: any = {};
   if (input.ascendingOrder !== undefined) {
-    query["isAscendingOrder"] = input.ascendingOrder.toString();
+    query[
+      __extendedEncodeURIComponent("isAscendingOrder")
+    ] = __extendedEncodeURIComponent(input.ascendingOrder.toString());
   }
   if (input.marker !== undefined) {
-    query["marker"] = input.marker.toString();
+    query[
+      __extendedEncodeURIComponent("marker")
+    ] = __extendedEncodeURIComponent(input.marker);
   }
   if (input.pageSize !== undefined) {
-    query["pageSize"] = input.pageSize.toString();
+    query[
+      __extendedEncodeURIComponent("pageSize")
+    ] = __extendedEncodeURIComponent(input.pageSize.toString());
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -3114,18 +3205,24 @@ export async function serializeAws_restJson1_1ListPolicyPrincipalsCommand(
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.policyName !== undefined) {
-    headers["x-amzn-iot-policy"] = input.policyName.toString();
+    headers["x-amzn-iot-policy"] = input.policyName;
   }
   let resolvedPath = "/policy-principals";
   const query: any = {};
   if (input.ascendingOrder !== undefined) {
-    query["isAscendingOrder"] = input.ascendingOrder.toString();
+    query[
+      __extendedEncodeURIComponent("isAscendingOrder")
+    ] = __extendedEncodeURIComponent(input.ascendingOrder.toString());
   }
   if (input.marker !== undefined) {
-    query["marker"] = input.marker.toString();
+    query[
+      __extendedEncodeURIComponent("marker")
+    ] = __extendedEncodeURIComponent(input.marker);
   }
   if (input.pageSize !== undefined) {
-    query["pageSize"] = input.pageSize.toString();
+    query[
+      __extendedEncodeURIComponent("pageSize")
+    ] = __extendedEncodeURIComponent(input.pageSize.toString());
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -3145,13 +3242,13 @@ export async function serializeAws_restJson1_1ListPolicyVersionsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/policies/{policyName}/version";
   if (input.policyName !== undefined) {
-    const labelValue: string = input.policyName.toString();
+    const labelValue: string = input.policyName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: policyName.");
     }
     resolvedPath = resolvedPath.replace(
       "{policyName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: policyName.");
@@ -3172,18 +3269,24 @@ export async function serializeAws_restJson1_1ListPrincipalPoliciesCommand(
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.principal !== undefined) {
-    headers["x-amzn-iot-principal"] = input.principal.toString();
+    headers["x-amzn-iot-principal"] = input.principal;
   }
   let resolvedPath = "/principal-policies";
   const query: any = {};
   if (input.ascendingOrder !== undefined) {
-    query["isAscendingOrder"] = input.ascendingOrder.toString();
+    query[
+      __extendedEncodeURIComponent("isAscendingOrder")
+    ] = __extendedEncodeURIComponent(input.ascendingOrder.toString());
   }
   if (input.marker !== undefined) {
-    query["marker"] = input.marker.toString();
+    query[
+      __extendedEncodeURIComponent("marker")
+    ] = __extendedEncodeURIComponent(input.marker);
   }
   if (input.pageSize !== undefined) {
-    query["pageSize"] = input.pageSize.toString();
+    query[
+      __extendedEncodeURIComponent("pageSize")
+    ] = __extendedEncodeURIComponent(input.pageSize.toString());
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -3203,7 +3306,7 @@ export async function serializeAws_restJson1_1ListProvisioningTemplateVersionsCo
   headers["Content-Type"] = "";
   let resolvedPath = "/provisioning-templates/{templateName}/versions";
   if (input.templateName !== undefined) {
-    const labelValue: string = input.templateName.toString();
+    const labelValue: string = input.templateName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: templateName."
@@ -3211,17 +3314,21 @@ export async function serializeAws_restJson1_1ListProvisioningTemplateVersionsCo
     }
     resolvedPath = resolvedPath.replace(
       "{templateName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: templateName.");
   }
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -3242,10 +3349,14 @@ export async function serializeAws_restJson1_1ListProvisioningTemplatesCommand(
   let resolvedPath = "/provisioning-templates";
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -3266,13 +3377,19 @@ export async function serializeAws_restJson1_1ListRoleAliasesCommand(
   let resolvedPath = "/role-aliases";
   const query: any = {};
   if (input.ascendingOrder !== undefined) {
-    query["isAscendingOrder"] = input.ascendingOrder.toString();
+    query[
+      __extendedEncodeURIComponent("isAscendingOrder")
+    ] = __extendedEncodeURIComponent(input.ascendingOrder.toString());
   }
   if (input.marker !== undefined) {
-    query["marker"] = input.marker.toString();
+    query[
+      __extendedEncodeURIComponent("marker")
+    ] = __extendedEncodeURIComponent(input.marker);
   }
   if (input.pageSize !== undefined) {
-    query["pageSize"] = input.pageSize.toString();
+    query[
+      __extendedEncodeURIComponent("pageSize")
+    ] = __extendedEncodeURIComponent(input.pageSize.toString());
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -3292,23 +3409,27 @@ export async function serializeAws_restJson1_1ListTargetsForPolicyCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/policy-targets/{policyName}";
   if (input.policyName !== undefined) {
-    const labelValue: string = input.policyName.toString();
+    const labelValue: string = input.policyName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: policyName.");
     }
     resolvedPath = resolvedPath.replace(
       "{policyName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: policyName.");
   }
   const query: any = {};
   if (input.marker !== undefined) {
-    query["marker"] = input.marker.toString();
+    query[
+      __extendedEncodeURIComponent("marker")
+    ] = __extendedEncodeURIComponent(input.marker);
   }
   if (input.pageSize !== undefined) {
-    query["pageSize"] = input.pageSize.toString();
+    query[
+      __extendedEncodeURIComponent("pageSize")
+    ] = __extendedEncodeURIComponent(input.pageSize.toString());
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -3329,10 +3450,14 @@ export async function serializeAws_restJson1_1RegisterCACertificateCommand(
   let resolvedPath = "/cacertificate";
   const query: any = {};
   if (input.allowAutoRegistration !== undefined) {
-    query["allowAutoRegistration"] = input.allowAutoRegistration.toString();
+    query[
+      __extendedEncodeURIComponent("allowAutoRegistration")
+    ] = __extendedEncodeURIComponent(input.allowAutoRegistration.toString());
   }
   if (input.setAsActive !== undefined) {
-    query["setAsActive"] = input.setAsActive.toString();
+    query[
+      __extendedEncodeURIComponent("setAsActive")
+    ] = __extendedEncodeURIComponent(input.setAsActive.toString());
   }
   let body: any;
   const bodyParams: any = {};
@@ -3371,7 +3496,9 @@ export async function serializeAws_restJson1_1RegisterCertificateCommand(
   let resolvedPath = "/certificate/register";
   const query: any = {};
   if (input.setAsActive !== undefined) {
-    query["setAsActive"] = input.setAsActive.toString();
+    query[
+      __extendedEncodeURIComponent("setAsActive")
+    ] = __extendedEncodeURIComponent(input.setAsActive.toString());
   }
   let body: any;
   const bodyParams: any = {};
@@ -3433,7 +3560,7 @@ export async function serializeAws_restJson1_1RejectCertificateTransferCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/reject-certificate-transfer/{certificateId}";
   if (input.certificateId !== undefined) {
-    const labelValue: string = input.certificateId.toString();
+    const labelValue: string = input.certificateId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: certificateId."
@@ -3441,7 +3568,7 @@ export async function serializeAws_restJson1_1RejectCertificateTransferCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{certificateId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: certificateId.");
@@ -3493,19 +3620,19 @@ export async function serializeAws_restJson1_1SetDefaultPolicyVersionCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/policies/{policyName}/version/{policyVersionId}";
   if (input.policyName !== undefined) {
-    const labelValue: string = input.policyName.toString();
+    const labelValue: string = input.policyName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: policyName.");
     }
     resolvedPath = resolvedPath.replace(
       "{policyName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: policyName.");
   }
   if (input.policyVersionId !== undefined) {
-    const labelValue: string = input.policyVersionId.toString();
+    const labelValue: string = input.policyVersionId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: policyVersionId."
@@ -3513,7 +3640,7 @@ export async function serializeAws_restJson1_1SetDefaultPolicyVersionCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{policyVersionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: policyVersionId.");
@@ -3536,7 +3663,9 @@ export async function serializeAws_restJson1_1TestAuthorizationCommand(
   let resolvedPath = "/test-authorization";
   const query: any = {};
   if (input.clientId !== undefined) {
-    query["clientId"] = input.clientId.toString();
+    query[
+      __extendedEncodeURIComponent("clientId")
+    ] = __extendedEncodeURIComponent(input.clientId);
   }
   let body: any;
   const bodyParams: any = {};
@@ -3584,7 +3713,7 @@ export async function serializeAws_restJson1_1TestInvokeAuthorizerCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/authorizer/{authorizerName}/test";
   if (input.authorizerName !== undefined) {
-    const labelValue: string = input.authorizerName.toString();
+    const labelValue: string = input.authorizerName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: authorizerName."
@@ -3592,7 +3721,7 @@ export async function serializeAws_restJson1_1TestInvokeAuthorizerCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{authorizerName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: authorizerName.");
@@ -3642,7 +3771,7 @@ export async function serializeAws_restJson1_1TransferCertificateCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/transfer-certificate/{certificateId}";
   if (input.certificateId !== undefined) {
-    const labelValue: string = input.certificateId.toString();
+    const labelValue: string = input.certificateId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: certificateId."
@@ -3650,14 +3779,16 @@ export async function serializeAws_restJson1_1TransferCertificateCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{certificateId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: certificateId.");
   }
   const query: any = {};
   if (input.targetAwsAccount !== undefined) {
-    query["targetAwsAccount"] = input.targetAwsAccount.toString();
+    query[
+      __extendedEncodeURIComponent("targetAwsAccount")
+    ] = __extendedEncodeURIComponent(input.targetAwsAccount);
   }
   let body: any;
   const bodyParams: any = {};
@@ -3684,7 +3815,7 @@ export async function serializeAws_restJson1_1UpdateAuthorizerCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/authorizer/{authorizerName}";
   if (input.authorizerName !== undefined) {
-    const labelValue: string = input.authorizerName.toString();
+    const labelValue: string = input.authorizerName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: authorizerName."
@@ -3692,7 +3823,7 @@ export async function serializeAws_restJson1_1UpdateAuthorizerCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{authorizerName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: authorizerName.");
@@ -3733,7 +3864,7 @@ export async function serializeAws_restJson1_1UpdateCACertificateCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/cacertificate/{certificateId}";
   if (input.certificateId !== undefined) {
-    const labelValue: string = input.certificateId.toString();
+    const labelValue: string = input.certificateId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: certificateId."
@@ -3741,7 +3872,7 @@ export async function serializeAws_restJson1_1UpdateCACertificateCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{certificateId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: certificateId.");
@@ -3749,11 +3880,13 @@ export async function serializeAws_restJson1_1UpdateCACertificateCommand(
   const query: any = {};
   if (input.newAutoRegistrationStatus !== undefined) {
     query[
-      "newAutoRegistrationStatus"
-    ] = input.newAutoRegistrationStatus.toString();
+      __extendedEncodeURIComponent("newAutoRegistrationStatus")
+    ] = __extendedEncodeURIComponent(input.newAutoRegistrationStatus);
   }
   if (input.newStatus !== undefined) {
-    query["newStatus"] = input.newStatus.toString();
+    query[
+      __extendedEncodeURIComponent("newStatus")
+    ] = __extendedEncodeURIComponent(input.newStatus);
   }
   let body: any;
   const bodyParams: any = {};
@@ -3788,7 +3921,7 @@ export async function serializeAws_restJson1_1UpdateCertificateCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/certificates/{certificateId}";
   if (input.certificateId !== undefined) {
-    const labelValue: string = input.certificateId.toString();
+    const labelValue: string = input.certificateId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: certificateId."
@@ -3796,14 +3929,16 @@ export async function serializeAws_restJson1_1UpdateCertificateCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{certificateId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: certificateId.");
   }
   const query: any = {};
   if (input.newStatus !== undefined) {
-    query["newStatus"] = input.newStatus.toString();
+    query[
+      __extendedEncodeURIComponent("newStatus")
+    ] = __extendedEncodeURIComponent(input.newStatus);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -3823,7 +3958,7 @@ export async function serializeAws_restJson1_1UpdateDomainConfigurationCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/domainConfigurations/{domainConfigurationName}";
   if (input.domainConfigurationName !== undefined) {
-    const labelValue: string = input.domainConfigurationName.toString();
+    const labelValue: string = input.domainConfigurationName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: domainConfigurationName."
@@ -3831,7 +3966,7 @@ export async function serializeAws_restJson1_1UpdateDomainConfigurationCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{domainConfigurationName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -3871,7 +4006,7 @@ export async function serializeAws_restJson1_1UpdateProvisioningTemplateCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/provisioning-templates/{templateName}";
   if (input.templateName !== undefined) {
-    const labelValue: string = input.templateName.toString();
+    const labelValue: string = input.templateName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: templateName."
@@ -3879,7 +4014,7 @@ export async function serializeAws_restJson1_1UpdateProvisioningTemplateCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{templateName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: templateName.");
@@ -3917,13 +4052,13 @@ export async function serializeAws_restJson1_1UpdateRoleAliasCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/role-aliases/{roleAlias}";
   if (input.roleAlias !== undefined) {
-    const labelValue: string = input.roleAlias.toString();
+    const labelValue: string = input.roleAlias;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: roleAlias.");
     }
     resolvedPath = resolvedPath.replace(
       "{roleAlias}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: roleAlias.");
@@ -3955,13 +4090,13 @@ export async function serializeAws_restJson1_1DescribeIndexCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/indices/{indexName}";
   if (input.indexName !== undefined) {
-    const labelValue: string = input.indexName.toString();
+    const labelValue: string = input.indexName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: indexName.");
     }
     resolvedPath = resolvedPath.replace(
       "{indexName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: indexName.");
@@ -4102,10 +4237,14 @@ export async function serializeAws_restJson1_1ListIndicesCommand(
   let resolvedPath = "/indices";
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -4196,13 +4335,13 @@ export async function serializeAws_restJson1_1AssociateTargetsWithJobCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/jobs/{jobId}/targets";
   if (input.jobId !== undefined) {
-    const labelValue: string = input.jobId.toString();
+    const labelValue: string = input.jobId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: jobId.");
     }
     resolvedPath = resolvedPath.replace(
       "{jobId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: jobId.");
@@ -4237,20 +4376,22 @@ export async function serializeAws_restJson1_1CancelJobCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/jobs/{jobId}/cancel";
   if (input.jobId !== undefined) {
-    const labelValue: string = input.jobId.toString();
+    const labelValue: string = input.jobId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: jobId.");
     }
     resolvedPath = resolvedPath.replace(
       "{jobId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: jobId.");
   }
   const query: any = {};
   if (input.force !== undefined) {
-    query["force"] = input.force.toString();
+    query[__extendedEncodeURIComponent("force")] = __extendedEncodeURIComponent(
+      input.force.toString()
+    );
   }
   let body: any;
   const bodyParams: any = {};
@@ -4280,32 +4421,34 @@ export async function serializeAws_restJson1_1CancelJobExecutionCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/things/{thingName}/jobs/{jobId}/cancel";
   if (input.jobId !== undefined) {
-    const labelValue: string = input.jobId.toString();
+    const labelValue: string = input.jobId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: jobId.");
     }
     resolvedPath = resolvedPath.replace(
       "{jobId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: jobId.");
   }
   if (input.thingName !== undefined) {
-    const labelValue: string = input.thingName.toString();
+    const labelValue: string = input.thingName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: thingName.");
     }
     resolvedPath = resolvedPath.replace(
       "{thingName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: thingName.");
   }
   const query: any = {};
   if (input.force !== undefined) {
-    query["force"] = input.force.toString();
+    query[__extendedEncodeURIComponent("force")] = __extendedEncodeURIComponent(
+      input.force.toString()
+    );
   }
   let body: any;
   const bodyParams: any = {};
@@ -4338,13 +4481,13 @@ export async function serializeAws_restJson1_1CreateJobCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/jobs/{jobId}";
   if (input.jobId !== undefined) {
-    const labelValue: string = input.jobId.toString();
+    const labelValue: string = input.jobId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: jobId.");
     }
     resolvedPath = resolvedPath.replace(
       "{jobId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: jobId.");
@@ -4419,20 +4562,22 @@ export async function serializeAws_restJson1_1DeleteJobCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/jobs/{jobId}";
   if (input.jobId !== undefined) {
-    const labelValue: string = input.jobId.toString();
+    const labelValue: string = input.jobId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: jobId.");
     }
     resolvedPath = resolvedPath.replace(
       "{jobId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: jobId.");
   }
   const query: any = {};
   if (input.force !== undefined) {
-    query["force"] = input.force.toString();
+    query[__extendedEncodeURIComponent("force")] = __extendedEncodeURIComponent(
+      input.force.toString()
+    );
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -4461,38 +4606,40 @@ export async function serializeAws_restJson1_1DeleteJobExecutionCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{executionNumber}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: executionNumber.");
   }
   if (input.jobId !== undefined) {
-    const labelValue: string = input.jobId.toString();
+    const labelValue: string = input.jobId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: jobId.");
     }
     resolvedPath = resolvedPath.replace(
       "{jobId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: jobId.");
   }
   if (input.thingName !== undefined) {
-    const labelValue: string = input.thingName.toString();
+    const labelValue: string = input.thingName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: thingName.");
     }
     resolvedPath = resolvedPath.replace(
       "{thingName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: thingName.");
   }
   const query: any = {};
   if (input.force !== undefined) {
-    query["force"] = input.force.toString();
+    query[__extendedEncodeURIComponent("force")] = __extendedEncodeURIComponent(
+      input.force.toString()
+    );
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -4512,13 +4659,13 @@ export async function serializeAws_restJson1_1DescribeJobCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/jobs/{jobId}";
   if (input.jobId !== undefined) {
-    const labelValue: string = input.jobId.toString();
+    const labelValue: string = input.jobId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: jobId.");
     }
     resolvedPath = resolvedPath.replace(
       "{jobId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: jobId.");
@@ -4540,32 +4687,34 @@ export async function serializeAws_restJson1_1DescribeJobExecutionCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/things/{thingName}/jobs/{jobId}";
   if (input.jobId !== undefined) {
-    const labelValue: string = input.jobId.toString();
+    const labelValue: string = input.jobId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: jobId.");
     }
     resolvedPath = resolvedPath.replace(
       "{jobId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: jobId.");
   }
   if (input.thingName !== undefined) {
-    const labelValue: string = input.thingName.toString();
+    const labelValue: string = input.thingName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: thingName.");
     }
     resolvedPath = resolvedPath.replace(
       "{thingName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: thingName.");
   }
   const query: any = {};
   if (input.executionNumber !== undefined) {
-    query["executionNumber"] = input.executionNumber.toString();
+    query[
+      __extendedEncodeURIComponent("executionNumber")
+    ] = __extendedEncodeURIComponent(input.executionNumber.toString());
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -4585,13 +4734,13 @@ export async function serializeAws_restJson1_1GetJobDocumentCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/jobs/{jobId}/job-document";
   if (input.jobId !== undefined) {
-    const labelValue: string = input.jobId.toString();
+    const labelValue: string = input.jobId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: jobId.");
     }
     resolvedPath = resolvedPath.replace(
       "{jobId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: jobId.");
@@ -4613,26 +4762,32 @@ export async function serializeAws_restJson1_1ListJobExecutionsForJobCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/jobs/{jobId}/things";
   if (input.jobId !== undefined) {
-    const labelValue: string = input.jobId.toString();
+    const labelValue: string = input.jobId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: jobId.");
     }
     resolvedPath = resolvedPath.replace(
       "{jobId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: jobId.");
   }
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   if (input.status !== undefined) {
-    query["status"] = input.status.toString();
+    query[
+      __extendedEncodeURIComponent("status")
+    ] = __extendedEncodeURIComponent(input.status);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -4652,26 +4807,32 @@ export async function serializeAws_restJson1_1ListJobExecutionsForThingCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/things/{thingName}/jobs";
   if (input.thingName !== undefined) {
-    const labelValue: string = input.thingName.toString();
+    const labelValue: string = input.thingName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: thingName.");
     }
     resolvedPath = resolvedPath.replace(
       "{thingName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: thingName.");
   }
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   if (input.status !== undefined) {
-    query["status"] = input.status.toString();
+    query[
+      __extendedEncodeURIComponent("status")
+    ] = __extendedEncodeURIComponent(input.status);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -4692,22 +4853,34 @@ export async function serializeAws_restJson1_1ListJobsCommand(
   let resolvedPath = "/jobs";
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   if (input.status !== undefined) {
-    query["status"] = input.status.toString();
+    query[
+      __extendedEncodeURIComponent("status")
+    ] = __extendedEncodeURIComponent(input.status);
   }
   if (input.targetSelection !== undefined) {
-    query["targetSelection"] = input.targetSelection.toString();
+    query[
+      __extendedEncodeURIComponent("targetSelection")
+    ] = __extendedEncodeURIComponent(input.targetSelection);
   }
   if (input.thingGroupId !== undefined) {
-    query["thingGroupId"] = input.thingGroupId.toString();
+    query[
+      __extendedEncodeURIComponent("thingGroupId")
+    ] = __extendedEncodeURIComponent(input.thingGroupId);
   }
   if (input.thingGroupName !== undefined) {
-    query["thingGroupName"] = input.thingGroupName.toString();
+    query[
+      __extendedEncodeURIComponent("thingGroupName")
+    ] = __extendedEncodeURIComponent(input.thingGroupName);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -4727,13 +4900,13 @@ export async function serializeAws_restJson1_1UpdateJobCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/jobs/{jobId}";
   if (input.jobId !== undefined) {
-    const labelValue: string = input.jobId.toString();
+    const labelValue: string = input.jobId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: jobId.");
     }
     resolvedPath = resolvedPath.replace(
       "{jobId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: jobId.");
@@ -4790,7 +4963,7 @@ export async function serializeAws_restJson1_1CreateOTAUpdateCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/otaUpdates/{otaUpdateId}";
   if (input.otaUpdateId !== undefined) {
-    const labelValue: string = input.otaUpdateId.toString();
+    const labelValue: string = input.otaUpdateId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: otaUpdateId."
@@ -4798,7 +4971,7 @@ export async function serializeAws_restJson1_1CreateOTAUpdateCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{otaUpdateId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: otaUpdateId.");
@@ -4878,7 +5051,7 @@ export async function serializeAws_restJson1_1DeleteOTAUpdateCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/otaUpdates/{otaUpdateId}";
   if (input.otaUpdateId !== undefined) {
-    const labelValue: string = input.otaUpdateId.toString();
+    const labelValue: string = input.otaUpdateId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: otaUpdateId."
@@ -4886,17 +5059,21 @@ export async function serializeAws_restJson1_1DeleteOTAUpdateCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{otaUpdateId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: otaUpdateId.");
   }
   const query: any = {};
   if (input.deleteStream !== undefined) {
-    query["deleteStream"] = input.deleteStream.toString();
+    query[
+      __extendedEncodeURIComponent("deleteStream")
+    ] = __extendedEncodeURIComponent(input.deleteStream.toString());
   }
   if (input.forceDeleteAWSJob !== undefined) {
-    query["forceDeleteAWSJob"] = input.forceDeleteAWSJob.toString();
+    query[
+      __extendedEncodeURIComponent("forceDeleteAWSJob")
+    ] = __extendedEncodeURIComponent(input.forceDeleteAWSJob.toString());
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -4916,7 +5093,7 @@ export async function serializeAws_restJson1_1GetOTAUpdateCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/otaUpdates/{otaUpdateId}";
   if (input.otaUpdateId !== undefined) {
-    const labelValue: string = input.otaUpdateId.toString();
+    const labelValue: string = input.otaUpdateId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: otaUpdateId."
@@ -4924,7 +5101,7 @@ export async function serializeAws_restJson1_1GetOTAUpdateCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{otaUpdateId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: otaUpdateId.");
@@ -4947,13 +5124,19 @@ export async function serializeAws_restJson1_1ListOTAUpdatesCommand(
   let resolvedPath = "/otaUpdates";
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   if (input.otaUpdateStatus !== undefined) {
-    query["otaUpdateStatus"] = input.otaUpdateStatus.toString();
+    query[
+      __extendedEncodeURIComponent("otaUpdateStatus")
+    ] = __extendedEncodeURIComponent(input.otaUpdateStatus);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -5039,17 +5222,17 @@ export async function serializeAws_restJson1_1AttachThingPrincipalCommand(
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.principal !== undefined) {
-    headers["x-amzn-principal"] = input.principal.toString();
+    headers["x-amzn-principal"] = input.principal;
   }
   let resolvedPath = "/things/{thingName}/principals";
   if (input.thingName !== undefined) {
-    const labelValue: string = input.thingName.toString();
+    const labelValue: string = input.thingName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: thingName.");
     }
     resolvedPath = resolvedPath.replace(
       "{thingName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: thingName.");
@@ -5071,7 +5254,7 @@ export async function serializeAws_restJson1_1CreateBillingGroupCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/billing-groups/{billingGroupName}";
   if (input.billingGroupName !== undefined) {
-    const labelValue: string = input.billingGroupName.toString();
+    const labelValue: string = input.billingGroupName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: billingGroupName."
@@ -5079,7 +5262,7 @@ export async function serializeAws_restJson1_1CreateBillingGroupCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{billingGroupName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -5118,7 +5301,7 @@ export async function serializeAws_restJson1_1CreateDynamicThingGroupCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/dynamic-thing-groups/{thingGroupName}";
   if (input.thingGroupName !== undefined) {
-    const labelValue: string = input.thingGroupName.toString();
+    const labelValue: string = input.thingGroupName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: thingGroupName."
@@ -5126,7 +5309,7 @@ export async function serializeAws_restJson1_1CreateDynamicThingGroupCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{thingGroupName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: thingGroupName.");
@@ -5172,13 +5355,13 @@ export async function serializeAws_restJson1_1CreateThingCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/things/{thingName}";
   if (input.thingName !== undefined) {
-    const labelValue: string = input.thingName.toString();
+    const labelValue: string = input.thingName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: thingName.");
     }
     resolvedPath = resolvedPath.replace(
       "{thingName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: thingName.");
@@ -5216,7 +5399,7 @@ export async function serializeAws_restJson1_1CreateThingGroupCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/thing-groups/{thingGroupName}";
   if (input.thingGroupName !== undefined) {
-    const labelValue: string = input.thingGroupName.toString();
+    const labelValue: string = input.thingGroupName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: thingGroupName."
@@ -5224,7 +5407,7 @@ export async function serializeAws_restJson1_1CreateThingGroupCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{thingGroupName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: thingGroupName.");
@@ -5264,7 +5447,7 @@ export async function serializeAws_restJson1_1CreateThingTypeCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/thing-types/{thingTypeName}";
   if (input.thingTypeName !== undefined) {
-    const labelValue: string = input.thingTypeName.toString();
+    const labelValue: string = input.thingTypeName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: thingTypeName."
@@ -5272,7 +5455,7 @@ export async function serializeAws_restJson1_1CreateThingTypeCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{thingTypeName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: thingTypeName.");
@@ -5309,7 +5492,7 @@ export async function serializeAws_restJson1_1DeleteBillingGroupCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/billing-groups/{billingGroupName}";
   if (input.billingGroupName !== undefined) {
-    const labelValue: string = input.billingGroupName.toString();
+    const labelValue: string = input.billingGroupName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: billingGroupName."
@@ -5317,7 +5500,7 @@ export async function serializeAws_restJson1_1DeleteBillingGroupCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{billingGroupName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -5326,7 +5509,9 @@ export async function serializeAws_restJson1_1DeleteBillingGroupCommand(
   }
   const query: any = {};
   if (input.expectedVersion !== undefined) {
-    query["expectedVersion"] = input.expectedVersion.toString();
+    query[
+      __extendedEncodeURIComponent("expectedVersion")
+    ] = __extendedEncodeURIComponent(input.expectedVersion.toString());
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -5346,7 +5531,7 @@ export async function serializeAws_restJson1_1DeleteDynamicThingGroupCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/dynamic-thing-groups/{thingGroupName}";
   if (input.thingGroupName !== undefined) {
-    const labelValue: string = input.thingGroupName.toString();
+    const labelValue: string = input.thingGroupName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: thingGroupName."
@@ -5354,14 +5539,16 @@ export async function serializeAws_restJson1_1DeleteDynamicThingGroupCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{thingGroupName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: thingGroupName.");
   }
   const query: any = {};
   if (input.expectedVersion !== undefined) {
-    query["expectedVersion"] = input.expectedVersion.toString();
+    query[
+      __extendedEncodeURIComponent("expectedVersion")
+    ] = __extendedEncodeURIComponent(input.expectedVersion.toString());
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -5381,20 +5568,22 @@ export async function serializeAws_restJson1_1DeleteThingCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/things/{thingName}";
   if (input.thingName !== undefined) {
-    const labelValue: string = input.thingName.toString();
+    const labelValue: string = input.thingName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: thingName.");
     }
     resolvedPath = resolvedPath.replace(
       "{thingName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: thingName.");
   }
   const query: any = {};
   if (input.expectedVersion !== undefined) {
-    query["expectedVersion"] = input.expectedVersion.toString();
+    query[
+      __extendedEncodeURIComponent("expectedVersion")
+    ] = __extendedEncodeURIComponent(input.expectedVersion.toString());
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -5414,7 +5603,7 @@ export async function serializeAws_restJson1_1DeleteThingGroupCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/thing-groups/{thingGroupName}";
   if (input.thingGroupName !== undefined) {
-    const labelValue: string = input.thingGroupName.toString();
+    const labelValue: string = input.thingGroupName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: thingGroupName."
@@ -5422,14 +5611,16 @@ export async function serializeAws_restJson1_1DeleteThingGroupCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{thingGroupName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: thingGroupName.");
   }
   const query: any = {};
   if (input.expectedVersion !== undefined) {
-    query["expectedVersion"] = input.expectedVersion.toString();
+    query[
+      __extendedEncodeURIComponent("expectedVersion")
+    ] = __extendedEncodeURIComponent(input.expectedVersion.toString());
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -5449,7 +5640,7 @@ export async function serializeAws_restJson1_1DeleteThingTypeCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/thing-types/{thingTypeName}";
   if (input.thingTypeName !== undefined) {
-    const labelValue: string = input.thingTypeName.toString();
+    const labelValue: string = input.thingTypeName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: thingTypeName."
@@ -5457,7 +5648,7 @@ export async function serializeAws_restJson1_1DeleteThingTypeCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{thingTypeName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: thingTypeName.");
@@ -5479,7 +5670,7 @@ export async function serializeAws_restJson1_1DeprecateThingTypeCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/thing-types/{thingTypeName}/deprecate";
   if (input.thingTypeName !== undefined) {
-    const labelValue: string = input.thingTypeName.toString();
+    const labelValue: string = input.thingTypeName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: thingTypeName."
@@ -5487,7 +5678,7 @@ export async function serializeAws_restJson1_1DeprecateThingTypeCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{thingTypeName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: thingTypeName.");
@@ -5516,7 +5707,7 @@ export async function serializeAws_restJson1_1DescribeBillingGroupCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/billing-groups/{billingGroupName}";
   if (input.billingGroupName !== undefined) {
-    const labelValue: string = input.billingGroupName.toString();
+    const labelValue: string = input.billingGroupName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: billingGroupName."
@@ -5524,7 +5715,7 @@ export async function serializeAws_restJson1_1DescribeBillingGroupCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{billingGroupName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -5564,13 +5755,13 @@ export async function serializeAws_restJson1_1DescribeThingCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/things/{thingName}";
   if (input.thingName !== undefined) {
-    const labelValue: string = input.thingName.toString();
+    const labelValue: string = input.thingName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: thingName.");
     }
     resolvedPath = resolvedPath.replace(
       "{thingName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: thingName.");
@@ -5592,7 +5783,7 @@ export async function serializeAws_restJson1_1DescribeThingGroupCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/thing-groups/{thingGroupName}";
   if (input.thingGroupName !== undefined) {
-    const labelValue: string = input.thingGroupName.toString();
+    const labelValue: string = input.thingGroupName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: thingGroupName."
@@ -5600,7 +5791,7 @@ export async function serializeAws_restJson1_1DescribeThingGroupCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{thingGroupName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: thingGroupName.");
@@ -5622,13 +5813,13 @@ export async function serializeAws_restJson1_1DescribeThingRegistrationTaskComma
   headers["Content-Type"] = "";
   let resolvedPath = "/thing-registration-tasks/{taskId}";
   if (input.taskId !== undefined) {
-    const labelValue: string = input.taskId.toString();
+    const labelValue: string = input.taskId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: taskId.");
     }
     resolvedPath = resolvedPath.replace(
       "{taskId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: taskId.");
@@ -5650,7 +5841,7 @@ export async function serializeAws_restJson1_1DescribeThingTypeCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/thing-types/{thingTypeName}";
   if (input.thingTypeName !== undefined) {
-    const labelValue: string = input.thingTypeName.toString();
+    const labelValue: string = input.thingTypeName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: thingTypeName."
@@ -5658,7 +5849,7 @@ export async function serializeAws_restJson1_1DescribeThingTypeCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{thingTypeName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: thingTypeName.");
@@ -5679,17 +5870,17 @@ export async function serializeAws_restJson1_1DetachThingPrincipalCommand(
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.principal !== undefined) {
-    headers["x-amzn-principal"] = input.principal.toString();
+    headers["x-amzn-principal"] = input.principal;
   }
   let resolvedPath = "/things/{thingName}/principals";
   if (input.thingName !== undefined) {
-    const labelValue: string = input.thingName.toString();
+    const labelValue: string = input.thingName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: thingName.");
     }
     resolvedPath = resolvedPath.replace(
       "{thingName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: thingName.");
@@ -5712,13 +5903,19 @@ export async function serializeAws_restJson1_1ListBillingGroupsCommand(
   let resolvedPath = "/billing-groups";
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.namePrefixFilter !== undefined) {
-    query["namePrefixFilter"] = input.namePrefixFilter.toString();
+    query[
+      __extendedEncodeURIComponent("namePrefixFilter")
+    ] = __extendedEncodeURIComponent(input.namePrefixFilter);
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -5737,15 +5934,19 @@ export async function serializeAws_restJson1_1ListPrincipalThingsCommand(
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.principal !== undefined) {
-    headers["x-amzn-principal"] = input.principal.toString();
+    headers["x-amzn-principal"] = input.principal;
   }
   let resolvedPath = "/principals/things";
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -5766,10 +5967,14 @@ export async function serializeAws_restJson1_1ListTagsForResourceCommand(
   let resolvedPath = "/tags";
   const query: any = {};
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   if (input.resourceArn !== undefined) {
-    query["resourceArn"] = input.resourceArn.toString();
+    query[
+      __extendedEncodeURIComponent("resourceArn")
+    ] = __extendedEncodeURIComponent(input.resourceArn);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -5790,19 +5995,29 @@ export async function serializeAws_restJson1_1ListThingGroupsCommand(
   let resolvedPath = "/thing-groups";
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.namePrefixFilter !== undefined) {
-    query["namePrefixFilter"] = input.namePrefixFilter.toString();
+    query[
+      __extendedEncodeURIComponent("namePrefixFilter")
+    ] = __extendedEncodeURIComponent(input.namePrefixFilter);
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   if (input.parentGroup !== undefined) {
-    query["parentGroup"] = input.parentGroup.toString();
+    query[
+      __extendedEncodeURIComponent("parentGroup")
+    ] = __extendedEncodeURIComponent(input.parentGroup);
   }
   if (input.recursive !== undefined) {
-    query["recursive"] = input.recursive.toString();
+    query[
+      __extendedEncodeURIComponent("recursive")
+    ] = __extendedEncodeURIComponent(input.recursive.toString());
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -5822,23 +6037,27 @@ export async function serializeAws_restJson1_1ListThingGroupsForThingCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/things/{thingName}/thing-groups";
   if (input.thingName !== undefined) {
-    const labelValue: string = input.thingName.toString();
+    const labelValue: string = input.thingName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: thingName.");
     }
     resolvedPath = resolvedPath.replace(
       "{thingName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: thingName.");
   }
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -5858,13 +6077,13 @@ export async function serializeAws_restJson1_1ListThingPrincipalsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/things/{thingName}/principals";
   if (input.thingName !== undefined) {
-    const labelValue: string = input.thingName.toString();
+    const labelValue: string = input.thingName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: thingName.");
     }
     resolvedPath = resolvedPath.replace(
       "{thingName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: thingName.");
@@ -5886,26 +6105,32 @@ export async function serializeAws_restJson1_1ListThingRegistrationTaskReportsCo
   headers["Content-Type"] = "";
   let resolvedPath = "/thing-registration-tasks/{taskId}/reports";
   if (input.taskId !== undefined) {
-    const labelValue: string = input.taskId.toString();
+    const labelValue: string = input.taskId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: taskId.");
     }
     resolvedPath = resolvedPath.replace(
       "{taskId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: taskId.");
   }
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   if (input.reportType !== undefined) {
-    query["reportType"] = input.reportType.toString();
+    query[
+      __extendedEncodeURIComponent("reportType")
+    ] = __extendedEncodeURIComponent(input.reportType);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -5926,13 +6151,19 @@ export async function serializeAws_restJson1_1ListThingRegistrationTasksCommand(
   let resolvedPath = "/thing-registration-tasks";
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   if (input.status !== undefined) {
-    query["status"] = input.status.toString();
+    query[
+      __extendedEncodeURIComponent("status")
+    ] = __extendedEncodeURIComponent(input.status);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -5953,13 +6184,19 @@ export async function serializeAws_restJson1_1ListThingTypesCommand(
   let resolvedPath = "/thing-types";
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   if (input.thingTypeName !== undefined) {
-    query["thingTypeName"] = input.thingTypeName.toString();
+    query[
+      __extendedEncodeURIComponent("thingTypeName")
+    ] = __extendedEncodeURIComponent(input.thingTypeName);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -5980,19 +6217,29 @@ export async function serializeAws_restJson1_1ListThingsCommand(
   let resolvedPath = "/things";
   const query: any = {};
   if (input.attributeName !== undefined) {
-    query["attributeName"] = input.attributeName.toString();
+    query[
+      __extendedEncodeURIComponent("attributeName")
+    ] = __extendedEncodeURIComponent(input.attributeName);
   }
   if (input.attributeValue !== undefined) {
-    query["attributeValue"] = input.attributeValue.toString();
+    query[
+      __extendedEncodeURIComponent("attributeValue")
+    ] = __extendedEncodeURIComponent(input.attributeValue);
   }
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   if (input.thingTypeName !== undefined) {
-    query["thingTypeName"] = input.thingTypeName.toString();
+    query[
+      __extendedEncodeURIComponent("thingTypeName")
+    ] = __extendedEncodeURIComponent(input.thingTypeName);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -6012,7 +6259,7 @@ export async function serializeAws_restJson1_1ListThingsInBillingGroupCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/billing-groups/{billingGroupName}/things";
   if (input.billingGroupName !== undefined) {
-    const labelValue: string = input.billingGroupName.toString();
+    const labelValue: string = input.billingGroupName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: billingGroupName."
@@ -6020,7 +6267,7 @@ export async function serializeAws_restJson1_1ListThingsInBillingGroupCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{billingGroupName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -6029,10 +6276,14 @@ export async function serializeAws_restJson1_1ListThingsInBillingGroupCommand(
   }
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -6052,7 +6303,7 @@ export async function serializeAws_restJson1_1ListThingsInThingGroupCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/thing-groups/{thingGroupName}/things";
   if (input.thingGroupName !== undefined) {
-    const labelValue: string = input.thingGroupName.toString();
+    const labelValue: string = input.thingGroupName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: thingGroupName."
@@ -6060,20 +6311,26 @@ export async function serializeAws_restJson1_1ListThingsInThingGroupCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{thingGroupName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: thingGroupName.");
   }
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   if (input.recursive !== undefined) {
-    query["recursive"] = input.recursive.toString();
+    query[
+      __extendedEncodeURIComponent("recursive")
+    ] = __extendedEncodeURIComponent(input.recursive.toString());
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -6189,13 +6446,13 @@ export async function serializeAws_restJson1_1StopThingRegistrationTaskCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/thing-registration-tasks/{taskId}/cancel";
   if (input.taskId !== undefined) {
-    const labelValue: string = input.taskId.toString();
+    const labelValue: string = input.taskId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: taskId.");
     }
     resolvedPath = resolvedPath.replace(
       "{taskId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: taskId.");
@@ -6272,7 +6529,7 @@ export async function serializeAws_restJson1_1UpdateBillingGroupCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/billing-groups/{billingGroupName}";
   if (input.billingGroupName !== undefined) {
-    const labelValue: string = input.billingGroupName.toString();
+    const labelValue: string = input.billingGroupName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: billingGroupName."
@@ -6280,7 +6537,7 @@ export async function serializeAws_restJson1_1UpdateBillingGroupCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{billingGroupName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -6319,7 +6576,7 @@ export async function serializeAws_restJson1_1UpdateDynamicThingGroupCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/dynamic-thing-groups/{thingGroupName}";
   if (input.thingGroupName !== undefined) {
-    const labelValue: string = input.thingGroupName.toString();
+    const labelValue: string = input.thingGroupName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: thingGroupName."
@@ -6327,7 +6584,7 @@ export async function serializeAws_restJson1_1UpdateDynamicThingGroupCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{thingGroupName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: thingGroupName.");
@@ -6401,13 +6658,13 @@ export async function serializeAws_restJson1_1UpdateThingCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/things/{thingName}";
   if (input.thingName !== undefined) {
-    const labelValue: string = input.thingName.toString();
+    const labelValue: string = input.thingName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: thingName.");
     }
     resolvedPath = resolvedPath.replace(
       "{thingName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: thingName.");
@@ -6448,7 +6705,7 @@ export async function serializeAws_restJson1_1UpdateThingGroupCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/thing-groups/{thingGroupName}";
   if (input.thingGroupName !== undefined) {
-    const labelValue: string = input.thingGroupName.toString();
+    const labelValue: string = input.thingGroupName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: thingGroupName."
@@ -6456,7 +6713,7 @@ export async function serializeAws_restJson1_1UpdateThingGroupCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{thingGroupName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: thingGroupName.");
@@ -6531,7 +6788,7 @@ export async function serializeAws_restJson1_1AttachSecurityProfileCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/security-profiles/{securityProfileName}/targets";
   if (input.securityProfileName !== undefined) {
-    const labelValue: string = input.securityProfileName.toString();
+    const labelValue: string = input.securityProfileName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: securityProfileName."
@@ -6539,7 +6796,7 @@ export async function serializeAws_restJson1_1AttachSecurityProfileCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{securityProfileName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -6549,8 +6806,8 @@ export async function serializeAws_restJson1_1AttachSecurityProfileCommand(
   const query: any = {};
   if (input.securityProfileTargetArn !== undefined) {
     query[
-      "securityProfileTargetArn"
-    ] = input.securityProfileTargetArn.toString();
+      __extendedEncodeURIComponent("securityProfileTargetArn")
+    ] = __extendedEncodeURIComponent(input.securityProfileTargetArn);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -6570,13 +6827,13 @@ export async function serializeAws_restJson1_1CancelAuditMitigationActionsTaskCo
   headers["Content-Type"] = "";
   let resolvedPath = "/audit/mitigationactions/tasks/{taskId}/cancel";
   if (input.taskId !== undefined) {
-    const labelValue: string = input.taskId.toString();
+    const labelValue: string = input.taskId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: taskId.");
     }
     resolvedPath = resolvedPath.replace(
       "{taskId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: taskId.");
@@ -6598,13 +6855,13 @@ export async function serializeAws_restJson1_1CancelAuditTaskCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/audit/tasks/{taskId}/cancel";
   if (input.taskId !== undefined) {
-    const labelValue: string = input.taskId.toString();
+    const labelValue: string = input.taskId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: taskId.");
     }
     resolvedPath = resolvedPath.replace(
       "{taskId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: taskId.");
@@ -6626,13 +6883,13 @@ export async function serializeAws_restJson1_1CreateMitigationActionCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/mitigationactions/actions/{actionName}";
   if (input.actionName !== undefined) {
-    const labelValue: string = input.actionName.toString();
+    const labelValue: string = input.actionName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: actionName.");
     }
     resolvedPath = resolvedPath.replace(
       "{actionName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: actionName.");
@@ -6670,7 +6927,7 @@ export async function serializeAws_restJson1_1CreateScheduledAuditCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/audit/scheduledaudits/{scheduledAuditName}";
   if (input.scheduledAuditName !== undefined) {
-    const labelValue: string = input.scheduledAuditName.toString();
+    const labelValue: string = input.scheduledAuditName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: scheduledAuditName."
@@ -6678,7 +6935,7 @@ export async function serializeAws_restJson1_1CreateScheduledAuditCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{scheduledAuditName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -6726,7 +6983,7 @@ export async function serializeAws_restJson1_1CreateSecurityProfileCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/security-profiles/{securityProfileName}";
   if (input.securityProfileName !== undefined) {
-    const labelValue: string = input.securityProfileName.toString();
+    const labelValue: string = input.securityProfileName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: securityProfileName."
@@ -6734,7 +6991,7 @@ export async function serializeAws_restJson1_1CreateSecurityProfileCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{securityProfileName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -6789,7 +7046,9 @@ export async function serializeAws_restJson1_1DeleteAccountAuditConfigurationCom
   let resolvedPath = "/audit/configuration";
   const query: any = {};
   if (input.deleteScheduledAudits !== undefined) {
-    query["deleteScheduledAudits"] = input.deleteScheduledAudits.toString();
+    query[
+      __extendedEncodeURIComponent("deleteScheduledAudits")
+    ] = __extendedEncodeURIComponent(input.deleteScheduledAudits.toString());
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -6809,13 +7068,13 @@ export async function serializeAws_restJson1_1DeleteMitigationActionCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/mitigationactions/actions/{actionName}";
   if (input.actionName !== undefined) {
-    const labelValue: string = input.actionName.toString();
+    const labelValue: string = input.actionName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: actionName.");
     }
     resolvedPath = resolvedPath.replace(
       "{actionName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: actionName.");
@@ -6837,7 +7096,7 @@ export async function serializeAws_restJson1_1DeleteScheduledAuditCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/audit/scheduledaudits/{scheduledAuditName}";
   if (input.scheduledAuditName !== undefined) {
-    const labelValue: string = input.scheduledAuditName.toString();
+    const labelValue: string = input.scheduledAuditName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: scheduledAuditName."
@@ -6845,7 +7104,7 @@ export async function serializeAws_restJson1_1DeleteScheduledAuditCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{scheduledAuditName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -6869,7 +7128,7 @@ export async function serializeAws_restJson1_1DeleteSecurityProfileCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/security-profiles/{securityProfileName}";
   if (input.securityProfileName !== undefined) {
-    const labelValue: string = input.securityProfileName.toString();
+    const labelValue: string = input.securityProfileName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: securityProfileName."
@@ -6877,7 +7136,7 @@ export async function serializeAws_restJson1_1DeleteSecurityProfileCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{securityProfileName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -6886,7 +7145,9 @@ export async function serializeAws_restJson1_1DeleteSecurityProfileCommand(
   }
   const query: any = {};
   if (input.expectedVersion !== undefined) {
-    query["expectedVersion"] = input.expectedVersion.toString();
+    query[
+      __extendedEncodeURIComponent("expectedVersion")
+    ] = __extendedEncodeURIComponent(input.expectedVersion.toString());
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -6922,13 +7183,13 @@ export async function serializeAws_restJson1_1DescribeAuditFindingCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/audit/findings/{findingId}";
   if (input.findingId !== undefined) {
-    const labelValue: string = input.findingId.toString();
+    const labelValue: string = input.findingId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: findingId.");
     }
     resolvedPath = resolvedPath.replace(
       "{findingId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: findingId.");
@@ -6950,13 +7211,13 @@ export async function serializeAws_restJson1_1DescribeAuditMitigationActionsTask
   headers["Content-Type"] = "";
   let resolvedPath = "/audit/mitigationactions/tasks/{taskId}";
   if (input.taskId !== undefined) {
-    const labelValue: string = input.taskId.toString();
+    const labelValue: string = input.taskId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: taskId.");
     }
     resolvedPath = resolvedPath.replace(
       "{taskId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: taskId.");
@@ -6978,13 +7239,13 @@ export async function serializeAws_restJson1_1DescribeAuditTaskCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/audit/tasks/{taskId}";
   if (input.taskId !== undefined) {
-    const labelValue: string = input.taskId.toString();
+    const labelValue: string = input.taskId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: taskId.");
     }
     resolvedPath = resolvedPath.replace(
       "{taskId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: taskId.");
@@ -7006,13 +7267,13 @@ export async function serializeAws_restJson1_1DescribeMitigationActionCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/mitigationactions/actions/{actionName}";
   if (input.actionName !== undefined) {
-    const labelValue: string = input.actionName.toString();
+    const labelValue: string = input.actionName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: actionName.");
     }
     resolvedPath = resolvedPath.replace(
       "{actionName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: actionName.");
@@ -7034,7 +7295,7 @@ export async function serializeAws_restJson1_1DescribeScheduledAuditCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/audit/scheduledaudits/{scheduledAuditName}";
   if (input.scheduledAuditName !== undefined) {
-    const labelValue: string = input.scheduledAuditName.toString();
+    const labelValue: string = input.scheduledAuditName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: scheduledAuditName."
@@ -7042,7 +7303,7 @@ export async function serializeAws_restJson1_1DescribeScheduledAuditCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{scheduledAuditName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -7066,7 +7327,7 @@ export async function serializeAws_restJson1_1DescribeSecurityProfileCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/security-profiles/{securityProfileName}";
   if (input.securityProfileName !== undefined) {
-    const labelValue: string = input.securityProfileName.toString();
+    const labelValue: string = input.securityProfileName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: securityProfileName."
@@ -7074,7 +7335,7 @@ export async function serializeAws_restJson1_1DescribeSecurityProfileCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{securityProfileName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -7098,7 +7359,7 @@ export async function serializeAws_restJson1_1DetachSecurityProfileCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/security-profiles/{securityProfileName}/targets";
   if (input.securityProfileName !== undefined) {
-    const labelValue: string = input.securityProfileName.toString();
+    const labelValue: string = input.securityProfileName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: securityProfileName."
@@ -7106,7 +7367,7 @@ export async function serializeAws_restJson1_1DetachSecurityProfileCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{securityProfileName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -7116,8 +7377,8 @@ export async function serializeAws_restJson1_1DetachSecurityProfileCommand(
   const query: any = {};
   if (input.securityProfileTargetArn !== undefined) {
     query[
-      "securityProfileTargetArn"
-    ] = input.securityProfileTargetArn.toString();
+      __extendedEncodeURIComponent("securityProfileTargetArn")
+    ] = __extendedEncodeURIComponent(input.securityProfileTargetArn);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -7138,16 +7399,24 @@ export async function serializeAws_restJson1_1ListActiveViolationsCommand(
   let resolvedPath = "/active-violations";
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   if (input.securityProfileName !== undefined) {
-    query["securityProfileName"] = input.securityProfileName.toString();
+    query[
+      __extendedEncodeURIComponent("securityProfileName")
+    ] = __extendedEncodeURIComponent(input.securityProfileName);
   }
   if (input.thingName !== undefined) {
-    query["thingName"] = input.thingName.toString();
+    query[
+      __extendedEncodeURIComponent("thingName")
+    ] = __extendedEncodeURIComponent(input.thingName);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -7214,19 +7483,29 @@ export async function serializeAws_restJson1_1ListAuditMitigationActionsExecutio
   let resolvedPath = "/audit/mitigationactions/executions";
   const query: any = {};
   if (input.actionStatus !== undefined) {
-    query["actionStatus"] = input.actionStatus.toString();
+    query[
+      __extendedEncodeURIComponent("actionStatus")
+    ] = __extendedEncodeURIComponent(input.actionStatus);
   }
   if (input.findingId !== undefined) {
-    query["findingId"] = input.findingId.toString();
+    query[
+      __extendedEncodeURIComponent("findingId")
+    ] = __extendedEncodeURIComponent(input.findingId);
   }
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   if (input.taskId !== undefined) {
-    query["taskId"] = input.taskId.toString();
+    query[
+      __extendedEncodeURIComponent("taskId")
+    ] = __extendedEncodeURIComponent(input.taskId);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -7247,25 +7526,39 @@ export async function serializeAws_restJson1_1ListAuditMitigationActionsTasksCom
   let resolvedPath = "/audit/mitigationactions/tasks";
   const query: any = {};
   if (input.auditTaskId !== undefined) {
-    query["auditTaskId"] = input.auditTaskId.toString();
+    query[
+      __extendedEncodeURIComponent("auditTaskId")
+    ] = __extendedEncodeURIComponent(input.auditTaskId);
   }
   if (input.endTime !== undefined) {
-    query["endTime"] = input.endTime.toISOString();
+    query[
+      __extendedEncodeURIComponent("endTime")
+    ] = __extendedEncodeURIComponent(input.endTime.toISOString());
   }
   if (input.findingId !== undefined) {
-    query["findingId"] = input.findingId.toString();
+    query[
+      __extendedEncodeURIComponent("findingId")
+    ] = __extendedEncodeURIComponent(input.findingId);
   }
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   if (input.startTime !== undefined) {
-    query["startTime"] = input.startTime.toISOString();
+    query[
+      __extendedEncodeURIComponent("startTime")
+    ] = __extendedEncodeURIComponent(input.startTime.toISOString());
   }
   if (input.taskStatus !== undefined) {
-    query["taskStatus"] = input.taskStatus.toString();
+    query[
+      __extendedEncodeURIComponent("taskStatus")
+    ] = __extendedEncodeURIComponent(input.taskStatus);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -7286,22 +7579,34 @@ export async function serializeAws_restJson1_1ListAuditTasksCommand(
   let resolvedPath = "/audit/tasks";
   const query: any = {};
   if (input.endTime !== undefined) {
-    query["endTime"] = input.endTime.toISOString();
+    query[
+      __extendedEncodeURIComponent("endTime")
+    ] = __extendedEncodeURIComponent(input.endTime.toISOString());
   }
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   if (input.startTime !== undefined) {
-    query["startTime"] = input.startTime.toISOString();
+    query[
+      __extendedEncodeURIComponent("startTime")
+    ] = __extendedEncodeURIComponent(input.startTime.toISOString());
   }
   if (input.taskStatus !== undefined) {
-    query["taskStatus"] = input.taskStatus.toString();
+    query[
+      __extendedEncodeURIComponent("taskStatus")
+    ] = __extendedEncodeURIComponent(input.taskStatus);
   }
   if (input.taskType !== undefined) {
-    query["taskType"] = input.taskType.toString();
+    query[
+      __extendedEncodeURIComponent("taskType")
+    ] = __extendedEncodeURIComponent(input.taskType);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -7322,13 +7627,19 @@ export async function serializeAws_restJson1_1ListMitigationActionsCommand(
   let resolvedPath = "/mitigationactions/actions";
   const query: any = {};
   if (input.actionType !== undefined) {
-    query["actionType"] = input.actionType.toString();
+    query[
+      __extendedEncodeURIComponent("actionType")
+    ] = __extendedEncodeURIComponent(input.actionType);
   }
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -7349,10 +7660,14 @@ export async function serializeAws_restJson1_1ListScheduledAuditsCommand(
   let resolvedPath = "/audit/scheduledaudits";
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -7373,10 +7688,14 @@ export async function serializeAws_restJson1_1ListSecurityProfilesCommand(
   let resolvedPath = "/security-profiles";
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -7397,18 +7716,24 @@ export async function serializeAws_restJson1_1ListSecurityProfilesForTargetComma
   let resolvedPath = "/security-profiles-for-target";
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   if (input.recursive !== undefined) {
-    query["recursive"] = input.recursive.toString();
+    query[
+      __extendedEncodeURIComponent("recursive")
+    ] = __extendedEncodeURIComponent(input.recursive.toString());
   }
   if (input.securityProfileTargetArn !== undefined) {
     query[
-      "securityProfileTargetArn"
-    ] = input.securityProfileTargetArn.toString();
+      __extendedEncodeURIComponent("securityProfileTargetArn")
+    ] = __extendedEncodeURIComponent(input.securityProfileTargetArn);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -7428,7 +7753,7 @@ export async function serializeAws_restJson1_1ListTargetsForSecurityProfileComma
   headers["Content-Type"] = "";
   let resolvedPath = "/security-profiles/{securityProfileName}/targets";
   if (input.securityProfileName !== undefined) {
-    const labelValue: string = input.securityProfileName.toString();
+    const labelValue: string = input.securityProfileName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: securityProfileName."
@@ -7436,7 +7761,7 @@ export async function serializeAws_restJson1_1ListTargetsForSecurityProfileComma
     }
     resolvedPath = resolvedPath.replace(
       "{securityProfileName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -7445,10 +7770,14 @@ export async function serializeAws_restJson1_1ListTargetsForSecurityProfileComma
   }
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -7469,22 +7798,34 @@ export async function serializeAws_restJson1_1ListViolationEventsCommand(
   let resolvedPath = "/violation-events";
   const query: any = {};
   if (input.endTime !== undefined) {
-    query["endTime"] = input.endTime.toISOString();
+    query[
+      __extendedEncodeURIComponent("endTime")
+    ] = __extendedEncodeURIComponent(input.endTime.toISOString());
   }
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   if (input.securityProfileName !== undefined) {
-    query["securityProfileName"] = input.securityProfileName.toString();
+    query[
+      __extendedEncodeURIComponent("securityProfileName")
+    ] = __extendedEncodeURIComponent(input.securityProfileName);
   }
   if (input.startTime !== undefined) {
-    query["startTime"] = input.startTime.toISOString();
+    query[
+      __extendedEncodeURIComponent("startTime")
+    ] = __extendedEncodeURIComponent(input.startTime.toISOString());
   }
   if (input.thingName !== undefined) {
-    query["thingName"] = input.thingName.toString();
+    query[
+      __extendedEncodeURIComponent("thingName")
+    ] = __extendedEncodeURIComponent(input.thingName);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -7504,13 +7845,13 @@ export async function serializeAws_restJson1_1StartAuditMitigationActionsTaskCom
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/audit/mitigationactions/tasks/{taskId}";
   if (input.taskId !== undefined) {
-    const labelValue: string = input.taskId.toString();
+    const labelValue: string = input.taskId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: taskId.");
     }
     resolvedPath = resolvedPath.replace(
       "{taskId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: taskId.");
@@ -7625,13 +7966,13 @@ export async function serializeAws_restJson1_1UpdateMitigationActionCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/mitigationactions/actions/{actionName}";
   if (input.actionName !== undefined) {
-    const labelValue: string = input.actionName.toString();
+    const labelValue: string = input.actionName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: actionName.");
     }
     resolvedPath = resolvedPath.replace(
       "{actionName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: actionName.");
@@ -7666,7 +8007,7 @@ export async function serializeAws_restJson1_1UpdateScheduledAuditCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/audit/scheduledaudits/{scheduledAuditName}";
   if (input.scheduledAuditName !== undefined) {
-    const labelValue: string = input.scheduledAuditName.toString();
+    const labelValue: string = input.scheduledAuditName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: scheduledAuditName."
@@ -7674,7 +8015,7 @@ export async function serializeAws_restJson1_1UpdateScheduledAuditCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{scheduledAuditName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -7719,7 +8060,7 @@ export async function serializeAws_restJson1_1UpdateSecurityProfileCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/security-profiles/{securityProfileName}";
   if (input.securityProfileName !== undefined) {
-    const labelValue: string = input.securityProfileName.toString();
+    const labelValue: string = input.securityProfileName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: securityProfileName."
@@ -7727,7 +8068,7 @@ export async function serializeAws_restJson1_1UpdateSecurityProfileCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{securityProfileName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -7736,7 +8077,9 @@ export async function serializeAws_restJson1_1UpdateSecurityProfileCommand(
   }
   const query: any = {};
   if (input.expectedVersion !== undefined) {
-    query["expectedVersion"] = input.expectedVersion.toString();
+    query[
+      __extendedEncodeURIComponent("expectedVersion")
+    ] = __extendedEncodeURIComponent(input.expectedVersion.toString());
   }
   let body: any;
   const bodyParams: any = {};
@@ -7819,13 +8162,13 @@ export async function serializeAws_restJson1_1CreateStreamCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/streams/{streamId}";
   if (input.streamId !== undefined) {
-    const labelValue: string = input.streamId.toString();
+    const labelValue: string = input.streamId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: streamId.");
     }
     resolvedPath = resolvedPath.replace(
       "{streamId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: streamId.");
@@ -7866,13 +8209,13 @@ export async function serializeAws_restJson1_1DeleteStreamCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/streams/{streamId}";
   if (input.streamId !== undefined) {
-    const labelValue: string = input.streamId.toString();
+    const labelValue: string = input.streamId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: streamId.");
     }
     resolvedPath = resolvedPath.replace(
       "{streamId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: streamId.");
@@ -7894,13 +8237,13 @@ export async function serializeAws_restJson1_1DescribeStreamCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/streams/{streamId}";
   if (input.streamId !== undefined) {
-    const labelValue: string = input.streamId.toString();
+    const labelValue: string = input.streamId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: streamId.");
     }
     resolvedPath = resolvedPath.replace(
       "{streamId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: streamId.");
@@ -7923,13 +8266,19 @@ export async function serializeAws_restJson1_1ListStreamsCommand(
   let resolvedPath = "/streams";
   const query: any = {};
   if (input.ascendingOrder !== undefined) {
-    query["isAscendingOrder"] = input.ascendingOrder.toString();
+    query[
+      __extendedEncodeURIComponent("isAscendingOrder")
+    ] = __extendedEncodeURIComponent(input.ascendingOrder.toString());
   }
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -7949,13 +8298,13 @@ export async function serializeAws_restJson1_1UpdateStreamCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/streams/{streamId}";
   if (input.streamId !== undefined) {
-    const labelValue: string = input.streamId.toString();
+    const labelValue: string = input.streamId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: streamId.");
     }
     resolvedPath = resolvedPath.replace(
       "{streamId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: streamId.");
@@ -7999,6 +8348,7 @@ export async function deserializeAws_restJson1_1ConfirmTopicRuleDestinationComma
     $metadata: deserializeMetadata(output),
     __type: "ConfirmTopicRuleDestinationResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -8077,6 +8427,7 @@ export async function deserializeAws_restJson1_1CreateTopicRuleCommand(
   const contents: CreateTopicRuleCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -8252,6 +8603,7 @@ export async function deserializeAws_restJson1_1DeleteTopicRuleCommand(
   const contents: DeleteTopicRuleCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -8331,6 +8683,7 @@ export async function deserializeAws_restJson1_1DeleteTopicRuleDestinationComman
     $metadata: deserializeMetadata(output),
     __type: "DeleteTopicRuleDestinationResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -8409,6 +8762,7 @@ export async function deserializeAws_restJson1_1DeleteV2LoggingLevelCommand(
   const contents: DeleteV2LoggingLevelCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -8473,6 +8827,7 @@ export async function deserializeAws_restJson1_1DisableTopicRuleCommand(
   const contents: DisableTopicRuleCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -8551,6 +8906,7 @@ export async function deserializeAws_restJson1_1EnableTopicRuleCommand(
   const contents: EnableTopicRuleCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -9193,6 +9549,7 @@ export async function deserializeAws_restJson1_1ReplaceTopicRuleCommand(
   const contents: ReplaceTopicRuleCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -9278,6 +9635,7 @@ export async function deserializeAws_restJson1_1SetLoggingOptionsCommand(
   const contents: SetLoggingOptionsCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -9342,6 +9700,7 @@ export async function deserializeAws_restJson1_1SetV2LoggingLevelCommand(
   const contents: SetV2LoggingLevelCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -9413,6 +9772,7 @@ export async function deserializeAws_restJson1_1SetV2LoggingOptionsCommand(
   const contents: SetV2LoggingOptionsCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -9478,6 +9838,7 @@ export async function deserializeAws_restJson1_1UpdateTopicRuleDestinationComman
     $metadata: deserializeMetadata(output),
     __type: "UpdateTopicRuleDestinationResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -9556,6 +9917,7 @@ export async function deserializeAws_restJson1_1AcceptCertificateTransferCommand
   const contents: AcceptCertificateTransferCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -9645,6 +10007,7 @@ export async function deserializeAws_restJson1_1AttachPolicyCommand(
   const contents: AttachPolicyCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -9737,6 +10100,7 @@ export async function deserializeAws_restJson1_1AttachPrincipalPolicyCommand(
   const contents: AttachPrincipalPolicyCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -9829,6 +10193,7 @@ export async function deserializeAws_restJson1_1CancelCertificateTransferCommand
   const contents: CancelCertificateTransferCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -9922,6 +10287,7 @@ export async function deserializeAws_restJson1_1ClearDefaultAuthorizerCommand(
     $metadata: deserializeMetadata(output),
     __type: "ClearDefaultAuthorizerResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -11051,6 +11417,7 @@ export async function deserializeAws_restJson1_1DeleteAuthorizerCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeleteAuthorizerResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -11144,6 +11511,7 @@ export async function deserializeAws_restJson1_1DeleteCACertificateCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeleteCACertificateResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -11236,6 +11604,7 @@ export async function deserializeAws_restJson1_1DeleteCertificateCommand(
   const contents: DeleteCertificateCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -11336,6 +11705,7 @@ export async function deserializeAws_restJson1_1DeleteDomainConfigurationCommand
     $metadata: deserializeMetadata(output),
     __type: "DeleteDomainConfigurationResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -11418,6 +11788,7 @@ export async function deserializeAws_restJson1_1DeletePolicyCommand(
   const contents: DeletePolicyCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -11510,6 +11881,7 @@ export async function deserializeAws_restJson1_1DeletePolicyVersionCommand(
   const contents: DeletePolicyVersionCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -11603,6 +11975,7 @@ export async function deserializeAws_restJson1_1DeleteProvisioningTemplateComman
     $metadata: deserializeMetadata(output),
     __type: "DeleteProvisioningTemplateResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -11689,6 +12062,7 @@ export async function deserializeAws_restJson1_1DeleteProvisioningTemplateVersio
     $metadata: deserializeMetadata(output),
     __type: "DeleteProvisioningTemplateVersionResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -11775,6 +12149,7 @@ export async function deserializeAws_restJson1_1DeleteRegistrationCodeCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeleteRegistrationCodeResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -11854,6 +12229,7 @@ export async function deserializeAws_restJson1_1DeleteRoleAliasCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeleteRoleAliasResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -12862,6 +13238,7 @@ export async function deserializeAws_restJson1_1DetachPolicyCommand(
   const contents: DetachPolicyCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -12947,6 +13324,7 @@ export async function deserializeAws_restJson1_1DetachPrincipalPolicyCommand(
   const contents: DetachPrincipalPolicyCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -15192,6 +15570,7 @@ export async function deserializeAws_restJson1_1RejectCertificateTransferCommand
   const contents: RejectCertificateTransferCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -15386,6 +15765,7 @@ export async function deserializeAws_restJson1_1SetDefaultPolicyVersionCommand(
   const contents: SetDefaultPolicyVersionCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -15905,6 +16285,7 @@ export async function deserializeAws_restJson1_1UpdateCACertificateCommand(
   const contents: UpdateCACertificateCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -15990,6 +16371,7 @@ export async function deserializeAws_restJson1_1UpdateCertificateCommand(
   const contents: UpdateCertificateCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -16191,6 +16573,7 @@ export async function deserializeAws_restJson1_1UpdateProvisioningTemplateComman
     $metadata: deserializeMetadata(output),
     __type: "UpdateProvisioningTemplateResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -17104,6 +17487,7 @@ export async function deserializeAws_restJson1_1UpdateIndexingConfigurationComma
     $metadata: deserializeMetadata(output),
     __type: "UpdateIndexingConfigurationResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -17356,6 +17740,7 @@ export async function deserializeAws_restJson1_1CancelJobExecutionCommand(
   const contents: CancelJobExecutionCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -17534,6 +17919,7 @@ export async function deserializeAws_restJson1_1DeleteJobCommand(
   const contents: DeleteJobCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -17619,6 +18005,7 @@ export async function deserializeAws_restJson1_1DeleteJobExecutionCommand(
   const contents: DeleteJobExecutionCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -18184,6 +18571,7 @@ export async function deserializeAws_restJson1_1UpdateJobCommand(
   const contents: UpdateJobCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -18377,6 +18765,7 @@ export async function deserializeAws_restJson1_1DeleteOTAUpdateCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeleteOTAUpdateResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -18652,6 +19041,7 @@ export async function deserializeAws_restJson1_1AddThingToBillingGroupCommand(
     $metadata: deserializeMetadata(output),
     __type: "AddThingToBillingGroupResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -18724,6 +19114,7 @@ export async function deserializeAws_restJson1_1AddThingToThingGroupCommand(
     $metadata: deserializeMetadata(output),
     __type: "AddThingToThingGroupResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -18796,6 +19187,7 @@ export async function deserializeAws_restJson1_1AttachThingPrincipalCommand(
     $metadata: deserializeMetadata(output),
     __type: "AttachThingPrincipalResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -19372,6 +19764,7 @@ export async function deserializeAws_restJson1_1DeleteBillingGroupCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeleteBillingGroupResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -19444,6 +19837,7 @@ export async function deserializeAws_restJson1_1DeleteDynamicThingGroupCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeleteDynamicThingGroupResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -19513,6 +19907,7 @@ export async function deserializeAws_restJson1_1DeleteThingCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeleteThingResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -19606,6 +20001,7 @@ export async function deserializeAws_restJson1_1DeleteThingGroupCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeleteThingGroupResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -19678,6 +20074,7 @@ export async function deserializeAws_restJson1_1DeleteThingTypeCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeleteThingTypeResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -19764,6 +20161,7 @@ export async function deserializeAws_restJson1_1DeprecateThingTypeCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeprecateThingTypeResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -20531,6 +20929,7 @@ export async function deserializeAws_restJson1_1DetachThingPrincipalCommand(
     $metadata: deserializeMetadata(output),
     __type: "DetachThingPrincipalResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -21640,6 +22039,7 @@ export async function deserializeAws_restJson1_1RemoveThingFromBillingGroupComma
     $metadata: deserializeMetadata(output),
     __type: "RemoveThingFromBillingGroupResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -21712,6 +22112,7 @@ export async function deserializeAws_restJson1_1RemoveThingFromThingGroupCommand
     $metadata: deserializeMetadata(output),
     __type: "RemoveThingFromThingGroupResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -21861,6 +22262,7 @@ export async function deserializeAws_restJson1_1StopThingRegistrationTaskCommand
     $metadata: deserializeMetadata(output),
     __type: "StopThingRegistrationTaskResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -21937,6 +22339,7 @@ export async function deserializeAws_restJson1_1TagResourceCommand(
     $metadata: deserializeMetadata(output),
     __type: "TagResourceResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -22013,6 +22416,7 @@ export async function deserializeAws_restJson1_1UntagResourceCommand(
     $metadata: deserializeMetadata(output),
     __type: "UntagResourceResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -22260,6 +22664,7 @@ export async function deserializeAws_restJson1_1UpdateEventConfigurationsCommand
     $metadata: deserializeMetadata(output),
     __type: "UpdateEventConfigurationsResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -22322,6 +22727,7 @@ export async function deserializeAws_restJson1_1UpdateThingCommand(
     $metadata: deserializeMetadata(output),
     __type: "UpdateThingResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -22499,6 +22905,7 @@ export async function deserializeAws_restJson1_1UpdateThingGroupsForThingCommand
     $metadata: deserializeMetadata(output),
     __type: "UpdateThingGroupsForThingResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -22571,6 +22978,7 @@ export async function deserializeAws_restJson1_1AttachSecurityProfileCommand(
     $metadata: deserializeMetadata(output),
     __type: "AttachSecurityProfileResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -22657,6 +23065,7 @@ export async function deserializeAws_restJson1_1CancelAuditMitigationActionsTask
     $metadata: deserializeMetadata(output),
     __type: "CancelAuditMitigationActionsTaskResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -22729,6 +23138,7 @@ export async function deserializeAws_restJson1_1CancelAuditTaskCommand(
     $metadata: deserializeMetadata(output),
     __type: "CancelAuditTaskResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -23060,6 +23470,7 @@ export async function deserializeAws_restJson1_1DeleteAccountAuditConfigurationC
     $metadata: deserializeMetadata(output),
     __type: "DeleteAccountAuditConfigurationResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -23132,6 +23543,7 @@ export async function deserializeAws_restJson1_1DeleteMitigationActionCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeleteMitigationActionResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -23197,6 +23609,7 @@ export async function deserializeAws_restJson1_1DeleteScheduledAuditCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeleteScheduledAuditResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -23269,6 +23682,7 @@ export async function deserializeAws_restJson1_1DeleteSecurityProfileCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeleteSecurityProfileResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -24071,6 +24485,7 @@ export async function deserializeAws_restJson1_1DetachSecurityProfileCommand(
     $metadata: deserializeMetadata(output),
     __type: "DetachSecurityProfileResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -25181,6 +25596,7 @@ export async function deserializeAws_restJson1_1UpdateAccountAuditConfigurationC
     $metadata: deserializeMetadata(output),
     __type: "UpdateAccountAuditConfigurationResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -25731,6 +26147,7 @@ export async function deserializeAws_restJson1_1DeleteStreamCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeleteStreamResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 

--- a/clients/client-iotanalytics/models/index.ts
+++ b/clients/client-iotanalytics/models/index.ts
@@ -1,11 +1,14 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
  * <p>There was an internal failure.</p>
  */
 export interface InternalFailureException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalFailureException";
   $fault: "server";
@@ -14,7 +17,7 @@ export interface InternalFailureException
 
 export namespace InternalFailureException {
   export function isa(o: any): o is InternalFailureException {
-    return _smithy.isa(o, "InternalFailureException");
+    return __isa(o, "InternalFailureException");
   }
 }
 
@@ -22,7 +25,7 @@ export namespace InternalFailureException {
  * <p>The request was not valid.</p>
  */
 export interface InvalidRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidRequestException";
   $fault: "client";
@@ -31,7 +34,7 @@ export interface InvalidRequestException
 
 export namespace InvalidRequestException {
   export function isa(o: any): o is InvalidRequestException {
-    return _smithy.isa(o, "InvalidRequestException");
+    return __isa(o, "InvalidRequestException");
   }
 }
 
@@ -39,7 +42,7 @@ export namespace InvalidRequestException {
  * <p>The command caused an internal limit to be exceeded.</p>
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -48,7 +51,7 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
@@ -56,7 +59,7 @@ export namespace LimitExceededException {
  * <p>A resource with the same name already exists.</p>
  */
 export interface ResourceAlreadyExistsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceAlreadyExistsException";
   $fault: "client";
@@ -74,7 +77,7 @@ export interface ResourceAlreadyExistsException
 
 export namespace ResourceAlreadyExistsException {
   export function isa(o: any): o is ResourceAlreadyExistsException {
-    return _smithy.isa(o, "ResourceAlreadyExistsException");
+    return __isa(o, "ResourceAlreadyExistsException");
   }
 }
 
@@ -82,7 +85,7 @@ export namespace ResourceAlreadyExistsException {
  * <p>A resource with the specified name could not be found.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -91,7 +94,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -99,7 +102,7 @@ export namespace ResourceNotFoundException {
  * <p>The service is temporarily unavailable.</p>
  */
 export interface ServiceUnavailableException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ServiceUnavailableException";
   $fault: "server";
@@ -108,7 +111,7 @@ export interface ServiceUnavailableException
 
 export namespace ServiceUnavailableException {
   export function isa(o: any): o is ServiceUnavailableException {
-    return _smithy.isa(o, "ServiceUnavailableException");
+    return __isa(o, "ServiceUnavailableException");
   }
 }
 
@@ -116,7 +119,7 @@ export namespace ServiceUnavailableException {
  * <p>The request was denied due to request throttling.</p>
  */
 export interface ThrottlingException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ThrottlingException";
   $fault: "client";
@@ -125,7 +128,7 @@ export interface ThrottlingException
 
 export namespace ThrottlingException {
   export function isa(o: any): o is ThrottlingException {
-    return _smithy.isa(o, "ThrottlingException");
+    return __isa(o, "ThrottlingException");
   }
 }
 
@@ -158,7 +161,7 @@ export interface AddAttributesActivity {
 
 export namespace AddAttributesActivity {
   export function isa(o: any): o is AddAttributesActivity {
-    return _smithy.isa(o, "AddAttributesActivity");
+    return __isa(o, "AddAttributesActivity");
   }
 }
 
@@ -177,7 +180,7 @@ export interface CancelPipelineReprocessingRequest {
 
 export namespace CancelPipelineReprocessingRequest {
   export function isa(o: any): o is CancelPipelineReprocessingRequest {
-    return _smithy.isa(o, "CancelPipelineReprocessingRequest");
+    return __isa(o, "CancelPipelineReprocessingRequest");
   }
 }
 
@@ -187,7 +190,7 @@ export interface CancelPipelineReprocessingResponse extends $MetadataBearer {
 
 export namespace CancelPipelineReprocessingResponse {
   export function isa(o: any): o is CancelPipelineReprocessingResponse {
-    return _smithy.isa(o, "CancelPipelineReprocessingResponse");
+    return __isa(o, "CancelPipelineReprocessingResponse");
   }
 }
 
@@ -237,7 +240,7 @@ export interface Channel {
 
 export namespace Channel {
   export function isa(o: any): o is Channel {
-    return _smithy.isa(o, "Channel");
+    return __isa(o, "Channel");
   }
 }
 
@@ -264,7 +267,7 @@ export interface ChannelActivity {
 
 export namespace ChannelActivity {
   export function isa(o: any): o is ChannelActivity {
-    return _smithy.isa(o, "ChannelActivity");
+    return __isa(o, "ChannelActivity");
   }
 }
 
@@ -281,7 +284,7 @@ export interface ChannelStatistics {
 
 export namespace ChannelStatistics {
   export function isa(o: any): o is ChannelStatistics {
-    return _smithy.isa(o, "ChannelStatistics");
+    return __isa(o, "ChannelStatistics");
   }
 }
 
@@ -315,7 +318,7 @@ export interface ChannelStorage {
 
 export namespace ChannelStorage {
   export function isa(o: any): o is ChannelStorage {
-    return _smithy.isa(o, "ChannelStorage");
+    return __isa(o, "ChannelStorage");
   }
 }
 
@@ -337,7 +340,7 @@ export interface ChannelStorageSummary {
 
 export namespace ChannelStorageSummary {
   export function isa(o: any): o is ChannelStorageSummary {
-    return _smithy.isa(o, "ChannelStorageSummary");
+    return __isa(o, "ChannelStorageSummary");
   }
 }
 
@@ -374,7 +377,7 @@ export interface ChannelSummary {
 
 export namespace ChannelSummary {
   export function isa(o: any): o is ChannelSummary {
-    return _smithy.isa(o, "ChannelSummary");
+    return __isa(o, "ChannelSummary");
   }
 }
 
@@ -417,7 +420,7 @@ export interface ContainerDatasetAction {
 
 export namespace ContainerDatasetAction {
   export function isa(o: any): o is ContainerDatasetAction {
-    return _smithy.isa(o, "ContainerDatasetAction");
+    return __isa(o, "ContainerDatasetAction");
   }
 }
 
@@ -449,7 +452,7 @@ export interface CreateChannelRequest {
 
 export namespace CreateChannelRequest {
   export function isa(o: any): o is CreateChannelRequest {
-    return _smithy.isa(o, "CreateChannelRequest");
+    return __isa(o, "CreateChannelRequest");
   }
 }
 
@@ -473,7 +476,7 @@ export interface CreateChannelResponse extends $MetadataBearer {
 
 export namespace CreateChannelResponse {
   export function isa(o: any): o is CreateChannelResponse {
-    return _smithy.isa(o, "CreateChannelResponse");
+    return __isa(o, "CreateChannelResponse");
   }
 }
 
@@ -487,7 +490,7 @@ export interface CreateDatasetContentRequest {
 
 export namespace CreateDatasetContentRequest {
   export function isa(o: any): o is CreateDatasetContentRequest {
-    return _smithy.isa(o, "CreateDatasetContentRequest");
+    return __isa(o, "CreateDatasetContentRequest");
   }
 }
 
@@ -501,7 +504,7 @@ export interface CreateDatasetContentResponse extends $MetadataBearer {
 
 export namespace CreateDatasetContentResponse {
   export function isa(o: any): o is CreateDatasetContentResponse {
-    return _smithy.isa(o, "CreateDatasetContentResponse");
+    return __isa(o, "CreateDatasetContentResponse");
   }
 }
 
@@ -554,7 +557,7 @@ export interface CreateDatasetRequest {
 
 export namespace CreateDatasetRequest {
   export function isa(o: any): o is CreateDatasetRequest {
-    return _smithy.isa(o, "CreateDatasetRequest");
+    return __isa(o, "CreateDatasetRequest");
   }
 }
 
@@ -578,7 +581,7 @@ export interface CreateDatasetResponse extends $MetadataBearer {
 
 export namespace CreateDatasetResponse {
   export function isa(o: any): o is CreateDatasetResponse {
-    return _smithy.isa(o, "CreateDatasetResponse");
+    return __isa(o, "CreateDatasetResponse");
   }
 }
 
@@ -610,7 +613,7 @@ export interface CreateDatastoreRequest {
 
 export namespace CreateDatastoreRequest {
   export function isa(o: any): o is CreateDatastoreRequest {
-    return _smithy.isa(o, "CreateDatastoreRequest");
+    return __isa(o, "CreateDatastoreRequest");
   }
 }
 
@@ -634,7 +637,7 @@ export interface CreateDatastoreResponse extends $MetadataBearer {
 
 export namespace CreateDatastoreResponse {
   export function isa(o: any): o is CreateDatastoreResponse {
-    return _smithy.isa(o, "CreateDatastoreResponse");
+    return __isa(o, "CreateDatastoreResponse");
   }
 }
 
@@ -675,7 +678,7 @@ export interface CreatePipelineRequest {
 
 export namespace CreatePipelineRequest {
   export function isa(o: any): o is CreatePipelineRequest {
-    return _smithy.isa(o, "CreatePipelineRequest");
+    return __isa(o, "CreatePipelineRequest");
   }
 }
 
@@ -694,7 +697,7 @@ export interface CreatePipelineResponse extends $MetadataBearer {
 
 export namespace CreatePipelineResponse {
   export function isa(o: any): o is CreatePipelineResponse {
-    return _smithy.isa(o, "CreatePipelineResponse");
+    return __isa(o, "CreatePipelineResponse");
   }
 }
 
@@ -725,7 +728,7 @@ export interface CustomerManagedChannelS3Storage {
 
 export namespace CustomerManagedChannelS3Storage {
   export function isa(o: any): o is CustomerManagedChannelS3Storage {
-    return _smithy.isa(o, "CustomerManagedChannelS3Storage");
+    return __isa(o, "CustomerManagedChannelS3Storage");
   }
 }
 
@@ -755,7 +758,7 @@ export interface CustomerManagedChannelS3StorageSummary {
 
 export namespace CustomerManagedChannelS3StorageSummary {
   export function isa(o: any): o is CustomerManagedChannelS3StorageSummary {
-    return _smithy.isa(o, "CustomerManagedChannelS3StorageSummary");
+    return __isa(o, "CustomerManagedChannelS3StorageSummary");
   }
 }
 
@@ -786,7 +789,7 @@ export interface CustomerManagedDatastoreS3Storage {
 
 export namespace CustomerManagedDatastoreS3Storage {
   export function isa(o: any): o is CustomerManagedDatastoreS3Storage {
-    return _smithy.isa(o, "CustomerManagedDatastoreS3Storage");
+    return __isa(o, "CustomerManagedDatastoreS3Storage");
   }
 }
 
@@ -815,7 +818,7 @@ export interface CustomerManagedDatastoreS3StorageSummary {
 
 export namespace CustomerManagedDatastoreS3StorageSummary {
   export function isa(o: any): o is CustomerManagedDatastoreS3StorageSummary {
-    return _smithy.isa(o, "CustomerManagedDatastoreS3StorageSummary");
+    return __isa(o, "CustomerManagedDatastoreS3StorageSummary");
   }
 }
 
@@ -881,7 +884,7 @@ export interface Dataset {
 
 export namespace Dataset {
   export function isa(o: any): o is Dataset {
-    return _smithy.isa(o, "Dataset");
+    return __isa(o, "Dataset");
   }
 }
 
@@ -910,7 +913,7 @@ export interface DatasetAction {
 
 export namespace DatasetAction {
   export function isa(o: any): o is DatasetAction {
-    return _smithy.isa(o, "DatasetAction");
+    return __isa(o, "DatasetAction");
   }
 }
 
@@ -932,7 +935,7 @@ export interface DatasetActionSummary {
 
 export namespace DatasetActionSummary {
   export function isa(o: any): o is DatasetActionSummary {
-    return _smithy.isa(o, "DatasetActionSummary");
+    return __isa(o, "DatasetActionSummary");
   }
 }
 
@@ -959,7 +962,7 @@ export interface DatasetContentDeliveryDestination {
 
 export namespace DatasetContentDeliveryDestination {
   export function isa(o: any): o is DatasetContentDeliveryDestination {
-    return _smithy.isa(o, "DatasetContentDeliveryDestination");
+    return __isa(o, "DatasetContentDeliveryDestination");
   }
 }
 
@@ -981,7 +984,7 @@ export interface DatasetContentDeliveryRule {
 
 export namespace DatasetContentDeliveryRule {
   export function isa(o: any): o is DatasetContentDeliveryRule {
-    return _smithy.isa(o, "DatasetContentDeliveryRule");
+    return __isa(o, "DatasetContentDeliveryRule");
   }
 }
 
@@ -1010,7 +1013,7 @@ export interface DatasetContentStatus {
 
 export namespace DatasetContentStatus {
   export function isa(o: any): o is DatasetContentStatus {
-    return _smithy.isa(o, "DatasetContentStatus");
+    return __isa(o, "DatasetContentStatus");
   }
 }
 
@@ -1047,7 +1050,7 @@ export interface DatasetContentSummary {
 
 export namespace DatasetContentSummary {
   export function isa(o: any): o is DatasetContentSummary {
-    return _smithy.isa(o, "DatasetContentSummary");
+    return __isa(o, "DatasetContentSummary");
   }
 }
 
@@ -1066,7 +1069,7 @@ export interface DatasetContentVersionValue {
 
 export namespace DatasetContentVersionValue {
   export function isa(o: any): o is DatasetContentVersionValue {
-    return _smithy.isa(o, "DatasetContentVersionValue");
+    return __isa(o, "DatasetContentVersionValue");
   }
 }
 
@@ -1088,7 +1091,7 @@ export interface DatasetEntry {
 
 export namespace DatasetEntry {
   export function isa(o: any): o is DatasetEntry {
-    return _smithy.isa(o, "DatasetEntry");
+    return __isa(o, "DatasetEntry");
   }
 }
 
@@ -1138,7 +1141,7 @@ export interface DatasetSummary {
 
 export namespace DatasetSummary {
   export function isa(o: any): o is DatasetSummary {
-    return _smithy.isa(o, "DatasetSummary");
+    return __isa(o, "DatasetSummary");
   }
 }
 
@@ -1161,7 +1164,7 @@ export interface DatasetTrigger {
 
 export namespace DatasetTrigger {
   export function isa(o: any): o is DatasetTrigger {
-    return _smithy.isa(o, "DatasetTrigger");
+    return __isa(o, "DatasetTrigger");
   }
 }
 
@@ -1225,7 +1228,7 @@ export interface Datastore {
 
 export namespace Datastore {
   export function isa(o: any): o is Datastore {
-    return _smithy.isa(o, "Datastore");
+    return __isa(o, "Datastore");
   }
 }
 
@@ -1247,7 +1250,7 @@ export interface DatastoreActivity {
 
 export namespace DatastoreActivity {
   export function isa(o: any): o is DatastoreActivity {
-    return _smithy.isa(o, "DatastoreActivity");
+    return __isa(o, "DatastoreActivity");
   }
 }
 
@@ -1264,7 +1267,7 @@ export interface DatastoreStatistics {
 
 export namespace DatastoreStatistics {
   export function isa(o: any): o is DatastoreStatistics {
-    return _smithy.isa(o, "DatastoreStatistics");
+    return __isa(o, "DatastoreStatistics");
   }
 }
 
@@ -1298,7 +1301,7 @@ export interface DatastoreStorage {
 
 export namespace DatastoreStorage {
   export function isa(o: any): o is DatastoreStorage {
-    return _smithy.isa(o, "DatastoreStorage");
+    return __isa(o, "DatastoreStorage");
   }
 }
 
@@ -1320,7 +1323,7 @@ export interface DatastoreStorageSummary {
 
 export namespace DatastoreStorageSummary {
   export function isa(o: any): o is DatastoreStorageSummary {
-    return _smithy.isa(o, "DatastoreStorageSummary");
+    return __isa(o, "DatastoreStorageSummary");
   }
 }
 
@@ -1357,7 +1360,7 @@ export interface DatastoreSummary {
 
 export namespace DatastoreSummary {
   export function isa(o: any): o is DatastoreSummary {
-    return _smithy.isa(o, "DatastoreSummary");
+    return __isa(o, "DatastoreSummary");
   }
 }
 
@@ -1371,7 +1374,7 @@ export interface DeleteChannelRequest {
 
 export namespace DeleteChannelRequest {
   export function isa(o: any): o is DeleteChannelRequest {
-    return _smithy.isa(o, "DeleteChannelRequest");
+    return __isa(o, "DeleteChannelRequest");
   }
 }
 
@@ -1392,7 +1395,7 @@ export interface DeleteDatasetContentRequest {
 
 export namespace DeleteDatasetContentRequest {
   export function isa(o: any): o is DeleteDatasetContentRequest {
-    return _smithy.isa(o, "DeleteDatasetContentRequest");
+    return __isa(o, "DeleteDatasetContentRequest");
   }
 }
 
@@ -1406,7 +1409,7 @@ export interface DeleteDatasetRequest {
 
 export namespace DeleteDatasetRequest {
   export function isa(o: any): o is DeleteDatasetRequest {
-    return _smithy.isa(o, "DeleteDatasetRequest");
+    return __isa(o, "DeleteDatasetRequest");
   }
 }
 
@@ -1420,7 +1423,7 @@ export interface DeleteDatastoreRequest {
 
 export namespace DeleteDatastoreRequest {
   export function isa(o: any): o is DeleteDatastoreRequest {
-    return _smithy.isa(o, "DeleteDatastoreRequest");
+    return __isa(o, "DeleteDatastoreRequest");
   }
 }
 
@@ -1434,7 +1437,7 @@ export interface DeletePipelineRequest {
 
 export namespace DeletePipelineRequest {
   export function isa(o: any): o is DeletePipelineRequest {
-    return _smithy.isa(o, "DeletePipelineRequest");
+    return __isa(o, "DeletePipelineRequest");
   }
 }
 
@@ -1464,7 +1467,7 @@ export interface DeltaTime {
 
 export namespace DeltaTime {
   export function isa(o: any): o is DeltaTime {
-    return _smithy.isa(o, "DeltaTime");
+    return __isa(o, "DeltaTime");
   }
 }
 
@@ -1484,7 +1487,7 @@ export interface DescribeChannelRequest {
 
 export namespace DescribeChannelRequest {
   export function isa(o: any): o is DescribeChannelRequest {
-    return _smithy.isa(o, "DescribeChannelRequest");
+    return __isa(o, "DescribeChannelRequest");
   }
 }
 
@@ -1504,7 +1507,7 @@ export interface DescribeChannelResponse extends $MetadataBearer {
 
 export namespace DescribeChannelResponse {
   export function isa(o: any): o is DescribeChannelResponse {
-    return _smithy.isa(o, "DescribeChannelResponse");
+    return __isa(o, "DescribeChannelResponse");
   }
 }
 
@@ -1518,7 +1521,7 @@ export interface DescribeDatasetRequest {
 
 export namespace DescribeDatasetRequest {
   export function isa(o: any): o is DescribeDatasetRequest {
-    return _smithy.isa(o, "DescribeDatasetRequest");
+    return __isa(o, "DescribeDatasetRequest");
   }
 }
 
@@ -1532,7 +1535,7 @@ export interface DescribeDatasetResponse extends $MetadataBearer {
 
 export namespace DescribeDatasetResponse {
   export function isa(o: any): o is DescribeDatasetResponse {
-    return _smithy.isa(o, "DescribeDatasetResponse");
+    return __isa(o, "DescribeDatasetResponse");
   }
 }
 
@@ -1552,7 +1555,7 @@ export interface DescribeDatastoreRequest {
 
 export namespace DescribeDatastoreRequest {
   export function isa(o: any): o is DescribeDatastoreRequest {
-    return _smithy.isa(o, "DescribeDatastoreRequest");
+    return __isa(o, "DescribeDatastoreRequest");
   }
 }
 
@@ -1572,7 +1575,7 @@ export interface DescribeDatastoreResponse extends $MetadataBearer {
 
 export namespace DescribeDatastoreResponse {
   export function isa(o: any): o is DescribeDatastoreResponse {
-    return _smithy.isa(o, "DescribeDatastoreResponse");
+    return __isa(o, "DescribeDatastoreResponse");
   }
 }
 
@@ -1582,7 +1585,7 @@ export interface DescribeLoggingOptionsRequest {
 
 export namespace DescribeLoggingOptionsRequest {
   export function isa(o: any): o is DescribeLoggingOptionsRequest {
-    return _smithy.isa(o, "DescribeLoggingOptionsRequest");
+    return __isa(o, "DescribeLoggingOptionsRequest");
   }
 }
 
@@ -1596,7 +1599,7 @@ export interface DescribeLoggingOptionsResponse extends $MetadataBearer {
 
 export namespace DescribeLoggingOptionsResponse {
   export function isa(o: any): o is DescribeLoggingOptionsResponse {
-    return _smithy.isa(o, "DescribeLoggingOptionsResponse");
+    return __isa(o, "DescribeLoggingOptionsResponse");
   }
 }
 
@@ -1610,7 +1613,7 @@ export interface DescribePipelineRequest {
 
 export namespace DescribePipelineRequest {
   export function isa(o: any): o is DescribePipelineRequest {
-    return _smithy.isa(o, "DescribePipelineRequest");
+    return __isa(o, "DescribePipelineRequest");
   }
 }
 
@@ -1625,7 +1628,7 @@ export interface DescribePipelineResponse extends $MetadataBearer {
 
 export namespace DescribePipelineResponse {
   export function isa(o: any): o is DescribePipelineResponse {
-    return _smithy.isa(o, "DescribePipelineResponse");
+    return __isa(o, "DescribePipelineResponse");
   }
 }
 
@@ -1662,7 +1665,7 @@ export interface DeviceRegistryEnrichActivity {
 
 export namespace DeviceRegistryEnrichActivity {
   export function isa(o: any): o is DeviceRegistryEnrichActivity {
-    return _smithy.isa(o, "DeviceRegistryEnrichActivity");
+    return __isa(o, "DeviceRegistryEnrichActivity");
   }
 }
 
@@ -1700,7 +1703,7 @@ export interface DeviceShadowEnrichActivity {
 
 export namespace DeviceShadowEnrichActivity {
   export function isa(o: any): o is DeviceShadowEnrichActivity {
-    return _smithy.isa(o, "DeviceShadowEnrichActivity");
+    return __isa(o, "DeviceShadowEnrichActivity");
   }
 }
 
@@ -1722,7 +1725,7 @@ export interface EstimatedResourceSize {
 
 export namespace EstimatedResourceSize {
   export function isa(o: any): o is EstimatedResourceSize {
-    return _smithy.isa(o, "EstimatedResourceSize");
+    return __isa(o, "EstimatedResourceSize");
   }
 }
 
@@ -1749,7 +1752,7 @@ export interface FilterActivity {
 
 export namespace FilterActivity {
   export function isa(o: any): o is FilterActivity {
-    return _smithy.isa(o, "FilterActivity");
+    return __isa(o, "FilterActivity");
   }
 }
 
@@ -1771,7 +1774,7 @@ export interface GetDatasetContentRequest {
 
 export namespace GetDatasetContentRequest {
   export function isa(o: any): o is GetDatasetContentRequest {
-    return _smithy.isa(o, "GetDatasetContentRequest");
+    return __isa(o, "GetDatasetContentRequest");
   }
 }
 
@@ -1795,7 +1798,7 @@ export interface GetDatasetContentResponse extends $MetadataBearer {
 
 export namespace GetDatasetContentResponse {
   export function isa(o: any): o is GetDatasetContentResponse {
-    return _smithy.isa(o, "GetDatasetContentResponse");
+    return __isa(o, "GetDatasetContentResponse");
   }
 }
 
@@ -1821,7 +1824,7 @@ export interface GlueConfiguration {
 
 export namespace GlueConfiguration {
   export function isa(o: any): o is GlueConfiguration {
-    return _smithy.isa(o, "GlueConfiguration");
+    return __isa(o, "GlueConfiguration");
   }
 }
 
@@ -1844,7 +1847,7 @@ export interface IotEventsDestinationConfiguration {
 
 export namespace IotEventsDestinationConfiguration {
   export function isa(o: any): o is IotEventsDestinationConfiguration {
-    return _smithy.isa(o, "IotEventsDestinationConfiguration");
+    return __isa(o, "IotEventsDestinationConfiguration");
   }
 }
 
@@ -1878,7 +1881,7 @@ export interface LambdaActivity {
 
 export namespace LambdaActivity {
   export function isa(o: any): o is LambdaActivity {
-    return _smithy.isa(o, "LambdaActivity");
+    return __isa(o, "LambdaActivity");
   }
 }
 
@@ -1898,7 +1901,7 @@ export interface ListChannelsRequest {
 
 export namespace ListChannelsRequest {
   export function isa(o: any): o is ListChannelsRequest {
-    return _smithy.isa(o, "ListChannelsRequest");
+    return __isa(o, "ListChannelsRequest");
   }
 }
 
@@ -1918,7 +1921,7 @@ export interface ListChannelsResponse extends $MetadataBearer {
 
 export namespace ListChannelsResponse {
   export function isa(o: any): o is ListChannelsResponse {
-    return _smithy.isa(o, "ListChannelsResponse");
+    return __isa(o, "ListChannelsResponse");
   }
 }
 
@@ -1955,7 +1958,7 @@ export interface ListDatasetContentsRequest {
 
 export namespace ListDatasetContentsRequest {
   export function isa(o: any): o is ListDatasetContentsRequest {
-    return _smithy.isa(o, "ListDatasetContentsRequest");
+    return __isa(o, "ListDatasetContentsRequest");
   }
 }
 
@@ -1975,7 +1978,7 @@ export interface ListDatasetContentsResponse extends $MetadataBearer {
 
 export namespace ListDatasetContentsResponse {
   export function isa(o: any): o is ListDatasetContentsResponse {
-    return _smithy.isa(o, "ListDatasetContentsResponse");
+    return __isa(o, "ListDatasetContentsResponse");
   }
 }
 
@@ -1995,7 +1998,7 @@ export interface ListDatasetsRequest {
 
 export namespace ListDatasetsRequest {
   export function isa(o: any): o is ListDatasetsRequest {
-    return _smithy.isa(o, "ListDatasetsRequest");
+    return __isa(o, "ListDatasetsRequest");
   }
 }
 
@@ -2015,7 +2018,7 @@ export interface ListDatasetsResponse extends $MetadataBearer {
 
 export namespace ListDatasetsResponse {
   export function isa(o: any): o is ListDatasetsResponse {
-    return _smithy.isa(o, "ListDatasetsResponse");
+    return __isa(o, "ListDatasetsResponse");
   }
 }
 
@@ -2035,7 +2038,7 @@ export interface ListDatastoresRequest {
 
 export namespace ListDatastoresRequest {
   export function isa(o: any): o is ListDatastoresRequest {
-    return _smithy.isa(o, "ListDatastoresRequest");
+    return __isa(o, "ListDatastoresRequest");
   }
 }
 
@@ -2055,7 +2058,7 @@ export interface ListDatastoresResponse extends $MetadataBearer {
 
 export namespace ListDatastoresResponse {
   export function isa(o: any): o is ListDatastoresResponse {
-    return _smithy.isa(o, "ListDatastoresResponse");
+    return __isa(o, "ListDatastoresResponse");
   }
 }
 
@@ -2075,7 +2078,7 @@ export interface ListPipelinesRequest {
 
 export namespace ListPipelinesRequest {
   export function isa(o: any): o is ListPipelinesRequest {
-    return _smithy.isa(o, "ListPipelinesRequest");
+    return __isa(o, "ListPipelinesRequest");
   }
 }
 
@@ -2095,7 +2098,7 @@ export interface ListPipelinesResponse extends $MetadataBearer {
 
 export namespace ListPipelinesResponse {
   export function isa(o: any): o is ListPipelinesResponse {
-    return _smithy.isa(o, "ListPipelinesResponse");
+    return __isa(o, "ListPipelinesResponse");
   }
 }
 
@@ -2109,7 +2112,7 @@ export interface ListTagsForResourceRequest {
 
 export namespace ListTagsForResourceRequest {
   export function isa(o: any): o is ListTagsForResourceRequest {
-    return _smithy.isa(o, "ListTagsForResourceRequest");
+    return __isa(o, "ListTagsForResourceRequest");
   }
 }
 
@@ -2123,7 +2126,7 @@ export interface ListTagsForResourceResponse extends $MetadataBearer {
 
 export namespace ListTagsForResourceResponse {
   export function isa(o: any): o is ListTagsForResourceResponse {
-    return _smithy.isa(o, "ListTagsForResourceResponse");
+    return __isa(o, "ListTagsForResourceResponse");
   }
 }
 
@@ -2155,7 +2158,7 @@ export interface LoggingOptions {
 
 export namespace LoggingOptions {
   export function isa(o: any): o is LoggingOptions {
-    return _smithy.isa(o, "LoggingOptions");
+    return __isa(o, "LoggingOptions");
   }
 }
 
@@ -2187,7 +2190,7 @@ export interface MathActivity {
 
 export namespace MathActivity {
   export function isa(o: any): o is MathActivity {
-    return _smithy.isa(o, "MathActivity");
+    return __isa(o, "MathActivity");
   }
 }
 
@@ -2205,7 +2208,7 @@ export interface OutputFileUriValue {
 
 export namespace OutputFileUriValue {
   export function isa(o: any): o is OutputFileUriValue {
-    return _smithy.isa(o, "OutputFileUriValue");
+    return __isa(o, "OutputFileUriValue");
   }
 }
 
@@ -2247,7 +2250,7 @@ export interface Pipeline {
 
 export namespace Pipeline {
   export function isa(o: any): o is Pipeline {
-    return _smithy.isa(o, "Pipeline");
+    return __isa(o, "Pipeline");
   }
 }
 
@@ -2311,7 +2314,7 @@ export interface PipelineActivity {
 
 export namespace PipelineActivity {
   export function isa(o: any): o is PipelineActivity {
-    return _smithy.isa(o, "PipelineActivity");
+    return __isa(o, "PipelineActivity");
   }
 }
 
@@ -2343,7 +2346,7 @@ export interface PipelineSummary {
 
 export namespace PipelineSummary {
   export function isa(o: any): o is PipelineSummary {
-    return _smithy.isa(o, "PipelineSummary");
+    return __isa(o, "PipelineSummary");
   }
 }
 
@@ -2357,7 +2360,7 @@ export interface PutLoggingOptionsRequest {
 
 export namespace PutLoggingOptionsRequest {
   export function isa(o: any): o is PutLoggingOptionsRequest {
-    return _smithy.isa(o, "PutLoggingOptionsRequest");
+    return __isa(o, "PutLoggingOptionsRequest");
   }
 }
 
@@ -2375,7 +2378,7 @@ export interface QueryFilter {
 
 export namespace QueryFilter {
   export function isa(o: any): o is QueryFilter {
-    return _smithy.isa(o, "QueryFilter");
+    return __isa(o, "QueryFilter");
   }
 }
 
@@ -2402,7 +2405,7 @@ export interface RemoveAttributesActivity {
 
 export namespace RemoveAttributesActivity {
   export function isa(o: any): o is RemoveAttributesActivity {
-    return _smithy.isa(o, "RemoveAttributesActivity");
+    return __isa(o, "RemoveAttributesActivity");
   }
 }
 
@@ -2436,7 +2439,7 @@ export interface ReprocessingSummary {
 
 export namespace ReprocessingSummary {
   export function isa(o: any): o is ReprocessingSummary {
-    return _smithy.isa(o, "ReprocessingSummary");
+    return __isa(o, "ReprocessingSummary");
   }
 }
 
@@ -2460,7 +2463,7 @@ export interface ResourceConfiguration {
 
 export namespace ResourceConfiguration {
   export function isa(o: any): o is ResourceConfiguration {
-    return _smithy.isa(o, "ResourceConfiguration");
+    return __isa(o, "ResourceConfiguration");
   }
 }
 
@@ -2482,7 +2485,7 @@ export interface RetentionPeriod {
 
 export namespace RetentionPeriod {
   export function isa(o: any): o is RetentionPeriod {
-    return _smithy.isa(o, "RetentionPeriod");
+    return __isa(o, "RetentionPeriod");
   }
 }
 
@@ -2505,7 +2508,7 @@ export interface RunPipelineActivityRequest {
 
 export namespace RunPipelineActivityRequest {
   export function isa(o: any): o is RunPipelineActivityRequest {
-    return _smithy.isa(o, "RunPipelineActivityRequest");
+    return __isa(o, "RunPipelineActivityRequest");
   }
 }
 
@@ -2526,7 +2529,7 @@ export interface RunPipelineActivityResponse extends $MetadataBearer {
 
 export namespace RunPipelineActivityResponse {
   export function isa(o: any): o is RunPipelineActivityResponse {
-    return _smithy.isa(o, "RunPipelineActivityResponse");
+    return __isa(o, "RunPipelineActivityResponse");
   }
 }
 
@@ -2564,7 +2567,7 @@ export interface S3DestinationConfiguration {
 
 export namespace S3DestinationConfiguration {
   export function isa(o: any): o is S3DestinationConfiguration {
-    return _smithy.isa(o, "S3DestinationConfiguration");
+    return __isa(o, "S3DestinationConfiguration");
   }
 }
 
@@ -2594,7 +2597,7 @@ export interface SampleChannelDataRequest {
 
 export namespace SampleChannelDataRequest {
   export function isa(o: any): o is SampleChannelDataRequest {
-    return _smithy.isa(o, "SampleChannelDataRequest");
+    return __isa(o, "SampleChannelDataRequest");
   }
 }
 
@@ -2609,7 +2612,7 @@ export interface SampleChannelDataResponse extends $MetadataBearer {
 
 export namespace SampleChannelDataResponse {
   export function isa(o: any): o is SampleChannelDataResponse {
-    return _smithy.isa(o, "SampleChannelDataResponse");
+    return __isa(o, "SampleChannelDataResponse");
   }
 }
 
@@ -2628,7 +2631,7 @@ export interface Schedule {
 
 export namespace Schedule {
   export function isa(o: any): o is Schedule {
-    return _smithy.isa(o, "Schedule");
+    return __isa(o, "Schedule");
   }
 }
 
@@ -2656,7 +2659,7 @@ export interface SelectAttributesActivity {
 
 export namespace SelectAttributesActivity {
   export function isa(o: any): o is SelectAttributesActivity {
-    return _smithy.isa(o, "SelectAttributesActivity");
+    return __isa(o, "SelectAttributesActivity");
   }
 }
 
@@ -2671,7 +2674,7 @@ export interface ServiceManagedChannelS3Storage {
 
 export namespace ServiceManagedChannelS3Storage {
   export function isa(o: any): o is ServiceManagedChannelS3Storage {
-    return _smithy.isa(o, "ServiceManagedChannelS3Storage");
+    return __isa(o, "ServiceManagedChannelS3Storage");
   }
 }
 
@@ -2684,7 +2687,7 @@ export interface ServiceManagedChannelS3StorageSummary {
 
 export namespace ServiceManagedChannelS3StorageSummary {
   export function isa(o: any): o is ServiceManagedChannelS3StorageSummary {
-    return _smithy.isa(o, "ServiceManagedChannelS3StorageSummary");
+    return __isa(o, "ServiceManagedChannelS3StorageSummary");
   }
 }
 
@@ -2699,7 +2702,7 @@ export interface ServiceManagedDatastoreS3Storage {
 
 export namespace ServiceManagedDatastoreS3Storage {
   export function isa(o: any): o is ServiceManagedDatastoreS3Storage {
-    return _smithy.isa(o, "ServiceManagedDatastoreS3Storage");
+    return __isa(o, "ServiceManagedDatastoreS3Storage");
   }
 }
 
@@ -2712,7 +2715,7 @@ export interface ServiceManagedDatastoreS3StorageSummary {
 
 export namespace ServiceManagedDatastoreS3StorageSummary {
   export function isa(o: any): o is ServiceManagedDatastoreS3StorageSummary {
-    return _smithy.isa(o, "ServiceManagedDatastoreS3StorageSummary");
+    return __isa(o, "ServiceManagedDatastoreS3StorageSummary");
   }
 }
 
@@ -2734,7 +2737,7 @@ export interface SqlQueryDatasetAction {
 
 export namespace SqlQueryDatasetAction {
   export function isa(o: any): o is SqlQueryDatasetAction {
-    return _smithy.isa(o, "SqlQueryDatasetAction");
+    return __isa(o, "SqlQueryDatasetAction");
   }
 }
 
@@ -2758,7 +2761,7 @@ export interface StartPipelineReprocessingRequest {
 
 export namespace StartPipelineReprocessingRequest {
   export function isa(o: any): o is StartPipelineReprocessingRequest {
-    return _smithy.isa(o, "StartPipelineReprocessingRequest");
+    return __isa(o, "StartPipelineReprocessingRequest");
   }
 }
 
@@ -2772,7 +2775,7 @@ export interface StartPipelineReprocessingResponse extends $MetadataBearer {
 
 export namespace StartPipelineReprocessingResponse {
   export function isa(o: any): o is StartPipelineReprocessingResponse {
-    return _smithy.isa(o, "StartPipelineReprocessingResponse");
+    return __isa(o, "StartPipelineReprocessingResponse");
   }
 }
 
@@ -2794,7 +2797,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -2813,7 +2816,7 @@ export interface TagResourceRequest {
 
 export namespace TagResourceRequest {
   export function isa(o: any): o is TagResourceRequest {
-    return _smithy.isa(o, "TagResourceRequest");
+    return __isa(o, "TagResourceRequest");
   }
 }
 
@@ -2823,7 +2826,7 @@ export interface TagResourceResponse extends $MetadataBearer {
 
 export namespace TagResourceResponse {
   export function isa(o: any): o is TagResourceResponse {
-    return _smithy.isa(o, "TagResourceResponse");
+    return __isa(o, "TagResourceResponse");
   }
 }
 
@@ -2842,7 +2845,7 @@ export interface TriggeringDataset {
 
 export namespace TriggeringDataset {
   export function isa(o: any): o is TriggeringDataset {
-    return _smithy.isa(o, "TriggeringDataset");
+    return __isa(o, "TriggeringDataset");
   }
 }
 
@@ -2861,7 +2864,7 @@ export interface UntagResourceRequest {
 
 export namespace UntagResourceRequest {
   export function isa(o: any): o is UntagResourceRequest {
-    return _smithy.isa(o, "UntagResourceRequest");
+    return __isa(o, "UntagResourceRequest");
   }
 }
 
@@ -2871,7 +2874,7 @@ export interface UntagResourceResponse extends $MetadataBearer {
 
 export namespace UntagResourceResponse {
   export function isa(o: any): o is UntagResourceResponse {
-    return _smithy.isa(o, "UntagResourceResponse");
+    return __isa(o, "UntagResourceResponse");
   }
 }
 
@@ -2898,7 +2901,7 @@ export interface UpdateChannelRequest {
 
 export namespace UpdateChannelRequest {
   export function isa(o: any): o is UpdateChannelRequest {
-    return _smithy.isa(o, "UpdateChannelRequest");
+    return __isa(o, "UpdateChannelRequest");
   }
 }
 
@@ -2941,7 +2944,7 @@ export interface UpdateDatasetRequest {
 
 export namespace UpdateDatasetRequest {
   export function isa(o: any): o is UpdateDatasetRequest {
-    return _smithy.isa(o, "UpdateDatasetRequest");
+    return __isa(o, "UpdateDatasetRequest");
   }
 }
 
@@ -2968,7 +2971,7 @@ export interface UpdateDatastoreRequest {
 
 export namespace UpdateDatastoreRequest {
   export function isa(o: any): o is UpdateDatastoreRequest {
-    return _smithy.isa(o, "UpdateDatastoreRequest");
+    return __isa(o, "UpdateDatastoreRequest");
   }
 }
 
@@ -3004,7 +3007,7 @@ export interface UpdatePipelineRequest {
 
 export namespace UpdatePipelineRequest {
   export function isa(o: any): o is UpdatePipelineRequest {
-    return _smithy.isa(o, "UpdatePipelineRequest");
+    return __isa(o, "UpdatePipelineRequest");
   }
 }
 
@@ -3043,7 +3046,7 @@ export interface Variable {
 
 export namespace Variable {
   export function isa(o: any): o is Variable {
-    return _smithy.isa(o, "Variable");
+    return __isa(o, "Variable");
   }
 }
 
@@ -3065,7 +3068,7 @@ export interface VersioningConfiguration {
 
 export namespace VersioningConfiguration {
   export function isa(o: any): o is VersioningConfiguration {
-    return _smithy.isa(o, "VersioningConfiguration");
+    return __isa(o, "VersioningConfiguration");
   }
 }
 
@@ -3093,7 +3096,7 @@ export interface BatchPutMessageErrorEntry {
 
 export namespace BatchPutMessageErrorEntry {
   export function isa(o: any): o is BatchPutMessageErrorEntry {
-    return _smithy.isa(o, "BatchPutMessageErrorEntry");
+    return __isa(o, "BatchPutMessageErrorEntry");
   }
 }
 
@@ -3139,7 +3142,7 @@ export interface BatchPutMessageRequest {
 
 export namespace BatchPutMessageRequest {
   export function isa(o: any): o is BatchPutMessageRequest {
-    return _smithy.isa(o, "BatchPutMessageRequest");
+    return __isa(o, "BatchPutMessageRequest");
   }
 }
 
@@ -3153,7 +3156,7 @@ export interface BatchPutMessageResponse extends $MetadataBearer {
 
 export namespace BatchPutMessageResponse {
   export function isa(o: any): o is BatchPutMessageResponse {
-    return _smithy.isa(o, "BatchPutMessageResponse");
+    return __isa(o, "BatchPutMessageResponse");
   }
 }
 
@@ -3177,6 +3180,6 @@ export interface Message {
 
 export namespace Message {
   export function isa(o: any): o is Message {
-    return _smithy.isa(o, "Message");
+    return __isa(o, "Message");
   }
 }

--- a/clients/client-iotanalytics/protocols/Aws_restJson1_1.ts
+++ b/clients/client-iotanalytics/protocols/Aws_restJson1_1.ts
@@ -209,7 +209,10 @@ import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  extendedEncodeURIComponent as __extendedEncodeURIComponent
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -225,7 +228,7 @@ export async function serializeAws_restJson1_1CancelPipelineReprocessingCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/pipelines/{pipelineName}/reprocessing/{reprocessingId}";
   if (input.pipelineName !== undefined) {
-    const labelValue: string = input.pipelineName.toString();
+    const labelValue: string = input.pipelineName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: pipelineName."
@@ -233,13 +236,13 @@ export async function serializeAws_restJson1_1CancelPipelineReprocessingCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{pipelineName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: pipelineName.");
   }
   if (input.reprocessingId !== undefined) {
-    const labelValue: string = input.reprocessingId.toString();
+    const labelValue: string = input.reprocessingId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: reprocessingId."
@@ -247,7 +250,7 @@ export async function serializeAws_restJson1_1CancelPipelineReprocessingCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{reprocessingId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: reprocessingId.");
@@ -367,7 +370,7 @@ export async function serializeAws_restJson1_1CreateDatasetContentCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/datasets/{datasetName}/content";
   if (input.datasetName !== undefined) {
-    const labelValue: string = input.datasetName.toString();
+    const labelValue: string = input.datasetName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: datasetName."
@@ -375,7 +378,7 @@ export async function serializeAws_restJson1_1CreateDatasetContentCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{datasetName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: datasetName.");
@@ -469,7 +472,7 @@ export async function serializeAws_restJson1_1DeleteChannelCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/channels/{channelName}";
   if (input.channelName !== undefined) {
-    const labelValue: string = input.channelName.toString();
+    const labelValue: string = input.channelName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: channelName."
@@ -477,7 +480,7 @@ export async function serializeAws_restJson1_1DeleteChannelCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{channelName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: channelName.");
@@ -499,7 +502,7 @@ export async function serializeAws_restJson1_1DeleteDatasetCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/datasets/{datasetName}";
   if (input.datasetName !== undefined) {
-    const labelValue: string = input.datasetName.toString();
+    const labelValue: string = input.datasetName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: datasetName."
@@ -507,7 +510,7 @@ export async function serializeAws_restJson1_1DeleteDatasetCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{datasetName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: datasetName.");
@@ -529,7 +532,7 @@ export async function serializeAws_restJson1_1DeleteDatasetContentCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/datasets/{datasetName}/content";
   if (input.datasetName !== undefined) {
-    const labelValue: string = input.datasetName.toString();
+    const labelValue: string = input.datasetName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: datasetName."
@@ -537,14 +540,16 @@ export async function serializeAws_restJson1_1DeleteDatasetContentCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{datasetName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: datasetName.");
   }
   const query: any = {};
   if (input.versionId !== undefined) {
-    query["versionId"] = input.versionId.toString();
+    query[
+      __extendedEncodeURIComponent("versionId")
+    ] = __extendedEncodeURIComponent(input.versionId);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -564,7 +569,7 @@ export async function serializeAws_restJson1_1DeleteDatastoreCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/datastores/{datastoreName}";
   if (input.datastoreName !== undefined) {
-    const labelValue: string = input.datastoreName.toString();
+    const labelValue: string = input.datastoreName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: datastoreName."
@@ -572,7 +577,7 @@ export async function serializeAws_restJson1_1DeleteDatastoreCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{datastoreName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: datastoreName.");
@@ -594,7 +599,7 @@ export async function serializeAws_restJson1_1DeletePipelineCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/pipelines/{pipelineName}";
   if (input.pipelineName !== undefined) {
-    const labelValue: string = input.pipelineName.toString();
+    const labelValue: string = input.pipelineName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: pipelineName."
@@ -602,7 +607,7 @@ export async function serializeAws_restJson1_1DeletePipelineCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{pipelineName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: pipelineName.");
@@ -624,7 +629,7 @@ export async function serializeAws_restJson1_1DescribeChannelCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/channels/{channelName}";
   if (input.channelName !== undefined) {
-    const labelValue: string = input.channelName.toString();
+    const labelValue: string = input.channelName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: channelName."
@@ -632,14 +637,16 @@ export async function serializeAws_restJson1_1DescribeChannelCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{channelName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: channelName.");
   }
   const query: any = {};
   if (input.includeStatistics !== undefined) {
-    query["includeStatistics"] = input.includeStatistics.toString();
+    query[
+      __extendedEncodeURIComponent("includeStatistics")
+    ] = __extendedEncodeURIComponent(input.includeStatistics.toString());
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -659,7 +666,7 @@ export async function serializeAws_restJson1_1DescribeDatasetCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/datasets/{datasetName}";
   if (input.datasetName !== undefined) {
-    const labelValue: string = input.datasetName.toString();
+    const labelValue: string = input.datasetName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: datasetName."
@@ -667,7 +674,7 @@ export async function serializeAws_restJson1_1DescribeDatasetCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{datasetName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: datasetName.");
@@ -689,7 +696,7 @@ export async function serializeAws_restJson1_1DescribeDatastoreCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/datastores/{datastoreName}";
   if (input.datastoreName !== undefined) {
-    const labelValue: string = input.datastoreName.toString();
+    const labelValue: string = input.datastoreName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: datastoreName."
@@ -697,14 +704,16 @@ export async function serializeAws_restJson1_1DescribeDatastoreCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{datastoreName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: datastoreName.");
   }
   const query: any = {};
   if (input.includeStatistics !== undefined) {
-    query["includeStatistics"] = input.includeStatistics.toString();
+    query[
+      __extendedEncodeURIComponent("includeStatistics")
+    ] = __extendedEncodeURIComponent(input.includeStatistics.toString());
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -740,7 +749,7 @@ export async function serializeAws_restJson1_1DescribePipelineCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/pipelines/{pipelineName}";
   if (input.pipelineName !== undefined) {
-    const labelValue: string = input.pipelineName.toString();
+    const labelValue: string = input.pipelineName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: pipelineName."
@@ -748,7 +757,7 @@ export async function serializeAws_restJson1_1DescribePipelineCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{pipelineName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: pipelineName.");
@@ -770,7 +779,7 @@ export async function serializeAws_restJson1_1GetDatasetContentCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/datasets/{datasetName}/content";
   if (input.datasetName !== undefined) {
-    const labelValue: string = input.datasetName.toString();
+    const labelValue: string = input.datasetName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: datasetName."
@@ -778,14 +787,16 @@ export async function serializeAws_restJson1_1GetDatasetContentCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{datasetName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: datasetName.");
   }
   const query: any = {};
   if (input.versionId !== undefined) {
-    query["versionId"] = input.versionId.toString();
+    query[
+      __extendedEncodeURIComponent("versionId")
+    ] = __extendedEncodeURIComponent(input.versionId);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -806,10 +817,14 @@ export async function serializeAws_restJson1_1ListChannelsCommand(
   let resolvedPath = "/channels";
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -829,7 +844,7 @@ export async function serializeAws_restJson1_1ListDatasetContentsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/datasets/{datasetName}/contents";
   if (input.datasetName !== undefined) {
-    const labelValue: string = input.datasetName.toString();
+    const labelValue: string = input.datasetName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: datasetName."
@@ -837,23 +852,31 @@ export async function serializeAws_restJson1_1ListDatasetContentsCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{datasetName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: datasetName.");
   }
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   if (input.scheduledBefore !== undefined) {
-    query["scheduledBefore"] = input.scheduledBefore.toISOString();
+    query[
+      __extendedEncodeURIComponent("scheduledBefore")
+    ] = __extendedEncodeURIComponent(input.scheduledBefore.toISOString());
   }
   if (input.scheduledOnOrAfter !== undefined) {
-    query["scheduledOnOrAfter"] = input.scheduledOnOrAfter.toISOString();
+    query[
+      __extendedEncodeURIComponent("scheduledOnOrAfter")
+    ] = __extendedEncodeURIComponent(input.scheduledOnOrAfter.toISOString());
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -874,10 +897,14 @@ export async function serializeAws_restJson1_1ListDatasetsCommand(
   let resolvedPath = "/datasets";
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -898,10 +925,14 @@ export async function serializeAws_restJson1_1ListDatastoresCommand(
   let resolvedPath = "/datastores";
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -922,10 +953,14 @@ export async function serializeAws_restJson1_1ListPipelinesCommand(
   let resolvedPath = "/pipelines";
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -946,7 +981,9 @@ export async function serializeAws_restJson1_1ListTagsForResourceCommand(
   let resolvedPath = "/tags";
   const query: any = {};
   if (input.resourceArn !== undefined) {
-    query["resourceArn"] = input.resourceArn.toString();
+    query[
+      __extendedEncodeURIComponent("resourceArn")
+    ] = __extendedEncodeURIComponent(input.resourceArn);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1024,7 +1061,7 @@ export async function serializeAws_restJson1_1SampleChannelDataCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/channels/{channelName}/sample";
   if (input.channelName !== undefined) {
-    const labelValue: string = input.channelName.toString();
+    const labelValue: string = input.channelName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: channelName."
@@ -1032,20 +1069,26 @@ export async function serializeAws_restJson1_1SampleChannelDataCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{channelName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: channelName.");
   }
   const query: any = {};
   if (input.endTime !== undefined) {
-    query["endTime"] = input.endTime.toISOString();
+    query[
+      __extendedEncodeURIComponent("endTime")
+    ] = __extendedEncodeURIComponent(input.endTime.toISOString());
   }
   if (input.maxMessages !== undefined) {
-    query["maxMessages"] = input.maxMessages.toString();
+    query[
+      __extendedEncodeURIComponent("maxMessages")
+    ] = __extendedEncodeURIComponent(input.maxMessages.toString());
   }
   if (input.startTime !== undefined) {
-    query["startTime"] = input.startTime.toISOString();
+    query[
+      __extendedEncodeURIComponent("startTime")
+    ] = __extendedEncodeURIComponent(input.startTime.toISOString());
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1065,7 +1108,7 @@ export async function serializeAws_restJson1_1StartPipelineReprocessingCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/pipelines/{pipelineName}/reprocessing";
   if (input.pipelineName !== undefined) {
-    const labelValue: string = input.pipelineName.toString();
+    const labelValue: string = input.pipelineName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: pipelineName."
@@ -1073,7 +1116,7 @@ export async function serializeAws_restJson1_1StartPipelineReprocessingCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{pipelineName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: pipelineName.");
@@ -1106,7 +1149,9 @@ export async function serializeAws_restJson1_1TagResourceCommand(
   let resolvedPath = "/tags";
   const query: any = {};
   if (input.resourceArn !== undefined) {
-    query["resourceArn"] = input.resourceArn.toString();
+    query[
+      __extendedEncodeURIComponent("resourceArn")
+    ] = __extendedEncodeURIComponent(input.resourceArn);
   }
   let body: any;
   const bodyParams: any = {};
@@ -1134,10 +1179,14 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
   let resolvedPath = "/tags";
   const query: any = {};
   if (input.resourceArn !== undefined) {
-    query["resourceArn"] = input.resourceArn.toString();
+    query[
+      __extendedEncodeURIComponent("resourceArn")
+    ] = __extendedEncodeURIComponent(input.resourceArn);
   }
   if (input.tagKeys !== undefined) {
-    query["tagKeys"] = input.tagKeys;
+    query[__extendedEncodeURIComponent("tagKeys")] = input.tagKeys.map(entry =>
+      __extendedEncodeURIComponent(entry)
+    );
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1157,7 +1206,7 @@ export async function serializeAws_restJson1_1UpdateChannelCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/channels/{channelName}";
   if (input.channelName !== undefined) {
-    const labelValue: string = input.channelName.toString();
+    const labelValue: string = input.channelName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: channelName."
@@ -1165,7 +1214,7 @@ export async function serializeAws_restJson1_1UpdateChannelCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{channelName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: channelName.");
@@ -1203,7 +1252,7 @@ export async function serializeAws_restJson1_1UpdateDatasetCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/datasets/{datasetName}";
   if (input.datasetName !== undefined) {
-    const labelValue: string = input.datasetName.toString();
+    const labelValue: string = input.datasetName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: datasetName."
@@ -1211,7 +1260,7 @@ export async function serializeAws_restJson1_1UpdateDatasetCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{datasetName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: datasetName.");
@@ -1271,7 +1320,7 @@ export async function serializeAws_restJson1_1UpdateDatastoreCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/datastores/{datastoreName}";
   if (input.datastoreName !== undefined) {
-    const labelValue: string = input.datastoreName.toString();
+    const labelValue: string = input.datastoreName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: datastoreName."
@@ -1279,7 +1328,7 @@ export async function serializeAws_restJson1_1UpdateDatastoreCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{datastoreName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: datastoreName.");
@@ -1317,7 +1366,7 @@ export async function serializeAws_restJson1_1UpdatePipelineCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/pipelines/{pipelineName}";
   if (input.pipelineName !== undefined) {
-    const labelValue: string = input.pipelineName.toString();
+    const labelValue: string = input.pipelineName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: pipelineName."
@@ -1325,7 +1374,7 @@ export async function serializeAws_restJson1_1UpdatePipelineCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{pipelineName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: pipelineName.");
@@ -1394,6 +1443,7 @@ export async function deserializeAws_restJson1_1CancelPipelineReprocessingComman
     $metadata: deserializeMetadata(output),
     __type: "CancelPipelineReprocessingResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -1948,6 +1998,7 @@ export async function deserializeAws_restJson1_1DeleteChannelCommand(
   const contents: DeleteChannelCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2023,6 +2074,7 @@ export async function deserializeAws_restJson1_1DeleteDatasetCommand(
   const contents: DeleteDatasetCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2101,6 +2153,7 @@ export async function deserializeAws_restJson1_1DeleteDatasetContentCommand(
   const contents: DeleteDatasetContentCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2179,6 +2232,7 @@ export async function deserializeAws_restJson1_1DeleteDatastoreCommand(
   const contents: DeleteDatastoreCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2257,6 +2311,7 @@ export async function deserializeAws_restJson1_1DeletePipelineCommand(
   const contents: DeletePipelineCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -3391,6 +3446,7 @@ export async function deserializeAws_restJson1_1PutLoggingOptionsCommand(
   const contents: PutLoggingOptionsCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -3722,6 +3778,7 @@ export async function deserializeAws_restJson1_1TagResourceCommand(
     $metadata: deserializeMetadata(output),
     __type: "TagResourceResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -3805,6 +3862,7 @@ export async function deserializeAws_restJson1_1UntagResourceCommand(
     $metadata: deserializeMetadata(output),
     __type: "UntagResourceResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -3887,6 +3945,7 @@ export async function deserializeAws_restJson1_1UpdateChannelCommand(
   const contents: UpdateChannelCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -3962,6 +4021,7 @@ export async function deserializeAws_restJson1_1UpdateDatasetCommand(
   const contents: UpdateDatasetCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -4040,6 +4100,7 @@ export async function deserializeAws_restJson1_1UpdateDatastoreCommand(
   const contents: UpdateDatastoreCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -4118,6 +4179,7 @@ export async function deserializeAws_restJson1_1UpdatePipelineCommand(
   const contents: UpdatePipelineCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 

--- a/clients/client-iotsecuretunneling/models/index.ts
+++ b/clients/client-iotsecuretunneling/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export interface CloseTunnelRequest {
@@ -17,7 +20,7 @@ export interface CloseTunnelRequest {
 
 export namespace CloseTunnelRequest {
   export function isa(o: any): o is CloseTunnelRequest {
-    return _smithy.isa(o, "CloseTunnelRequest");
+    return __isa(o, "CloseTunnelRequest");
   }
 }
 
@@ -27,7 +30,7 @@ export interface CloseTunnelResponse extends $MetadataBearer {
 
 export namespace CloseTunnelResponse {
   export function isa(o: any): o is CloseTunnelResponse {
-    return _smithy.isa(o, "CloseTunnelResponse");
+    return __isa(o, "CloseTunnelResponse");
   }
 }
 
@@ -50,7 +53,7 @@ export interface ConnectionState {
 
 export namespace ConnectionState {
   export function isa(o: any): o is ConnectionState {
-    return _smithy.isa(o, "ConnectionState");
+    return __isa(o, "ConnectionState");
   }
 }
 
@@ -69,7 +72,7 @@ export interface DescribeTunnelRequest {
 
 export namespace DescribeTunnelRequest {
   export function isa(o: any): o is DescribeTunnelRequest {
-    return _smithy.isa(o, "DescribeTunnelRequest");
+    return __isa(o, "DescribeTunnelRequest");
   }
 }
 
@@ -83,7 +86,7 @@ export interface DescribeTunnelResponse extends $MetadataBearer {
 
 export namespace DescribeTunnelResponse {
   export function isa(o: any): o is DescribeTunnelResponse {
-    return _smithy.isa(o, "DescribeTunnelResponse");
+    return __isa(o, "DescribeTunnelResponse");
   }
 }
 
@@ -109,7 +112,7 @@ export interface DestinationConfig {
 
 export namespace DestinationConfig {
   export function isa(o: any): o is DestinationConfig {
-    return _smithy.isa(o, "DestinationConfig");
+    return __isa(o, "DestinationConfig");
   }
 }
 
@@ -117,7 +120,7 @@ export namespace DestinationConfig {
  * <p>Thrown when a tunnel limit is exceeded.</p>
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -126,7 +129,7 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
@@ -140,7 +143,7 @@ export interface ListTagsForResourceRequest {
 
 export namespace ListTagsForResourceRequest {
   export function isa(o: any): o is ListTagsForResourceRequest {
-    return _smithy.isa(o, "ListTagsForResourceRequest");
+    return __isa(o, "ListTagsForResourceRequest");
   }
 }
 
@@ -154,7 +157,7 @@ export interface ListTagsForResourceResponse extends $MetadataBearer {
 
 export namespace ListTagsForResourceResponse {
   export function isa(o: any): o is ListTagsForResourceResponse {
-    return _smithy.isa(o, "ListTagsForResourceResponse");
+    return __isa(o, "ListTagsForResourceResponse");
   }
 }
 
@@ -178,7 +181,7 @@ export interface ListTunnelsRequest {
 
 export namespace ListTunnelsRequest {
   export function isa(o: any): o is ListTunnelsRequest {
-    return _smithy.isa(o, "ListTunnelsRequest");
+    return __isa(o, "ListTunnelsRequest");
   }
 }
 
@@ -197,7 +200,7 @@ export interface ListTunnelsResponse extends $MetadataBearer {
 
 export namespace ListTunnelsResponse {
   export function isa(o: any): o is ListTunnelsResponse {
-    return _smithy.isa(o, "ListTunnelsResponse");
+    return __isa(o, "ListTunnelsResponse");
   }
 }
 
@@ -226,7 +229,7 @@ export interface OpenTunnelRequest {
 
 export namespace OpenTunnelRequest {
   export function isa(o: any): o is OpenTunnelRequest {
-    return _smithy.isa(o, "OpenTunnelRequest");
+    return __isa(o, "OpenTunnelRequest");
   }
 }
 
@@ -259,7 +262,7 @@ export interface OpenTunnelResponse extends $MetadataBearer {
 
 export namespace OpenTunnelResponse {
   export function isa(o: any): o is OpenTunnelResponse {
-    return _smithy.isa(o, "OpenTunnelResponse");
+    return __isa(o, "OpenTunnelResponse");
   }
 }
 
@@ -267,7 +270,7 @@ export namespace OpenTunnelResponse {
  * <p>Thrown when an operation is attempted on a resource that does not exist.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -276,7 +279,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -299,7 +302,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -318,7 +321,7 @@ export interface TagResourceRequest {
 
 export namespace TagResourceRequest {
   export function isa(o: any): o is TagResourceRequest {
-    return _smithy.isa(o, "TagResourceRequest");
+    return __isa(o, "TagResourceRequest");
   }
 }
 
@@ -328,7 +331,7 @@ export interface TagResourceResponse extends $MetadataBearer {
 
 export namespace TagResourceResponse {
   export function isa(o: any): o is TagResourceResponse {
-    return _smithy.isa(o, "TagResourceResponse");
+    return __isa(o, "TagResourceResponse");
   }
 }
 
@@ -347,7 +350,7 @@ export interface TimeoutConfig {
 
 export namespace TimeoutConfig {
   export function isa(o: any): o is TimeoutConfig {
-    return _smithy.isa(o, "TimeoutConfig");
+    return __isa(o, "TimeoutConfig");
   }
 }
 
@@ -418,7 +421,7 @@ export interface Tunnel {
 
 export namespace Tunnel {
   export function isa(o: any): o is Tunnel {
-    return _smithy.isa(o, "Tunnel");
+    return __isa(o, "Tunnel");
   }
 }
 
@@ -467,7 +470,7 @@ export interface TunnelSummary {
 
 export namespace TunnelSummary {
   export function isa(o: any): o is TunnelSummary {
-    return _smithy.isa(o, "TunnelSummary");
+    return __isa(o, "TunnelSummary");
   }
 }
 
@@ -486,7 +489,7 @@ export interface UntagResourceRequest {
 
 export namespace UntagResourceRequest {
   export function isa(o: any): o is UntagResourceRequest {
-    return _smithy.isa(o, "UntagResourceRequest");
+    return __isa(o, "UntagResourceRequest");
   }
 }
 
@@ -496,6 +499,6 @@ export interface UntagResourceResponse extends $MetadataBearer {
 
 export namespace UntagResourceResponse {
   export function isa(o: any): o is UntagResourceResponse {
-    return _smithy.isa(o, "UntagResourceResponse");
+    return __isa(o, "UntagResourceResponse");
   }
 }

--- a/clients/client-iotthingsgraph/models/index.ts
+++ b/clients/client-iotthingsgraph/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export interface AssociateEntityToThingRequest {
@@ -25,7 +28,7 @@ export interface AssociateEntityToThingRequest {
 
 export namespace AssociateEntityToThingRequest {
   export function isa(o: any): o is AssociateEntityToThingRequest {
-    return _smithy.isa(o, "AssociateEntityToThingRequest");
+    return __isa(o, "AssociateEntityToThingRequest");
   }
 }
 
@@ -35,7 +38,7 @@ export interface AssociateEntityToThingResponse extends $MetadataBearer {
 
 export namespace AssociateEntityToThingResponse {
   export function isa(o: any): o is AssociateEntityToThingResponse {
-    return _smithy.isa(o, "AssociateEntityToThingResponse");
+    return __isa(o, "AssociateEntityToThingResponse");
   }
 }
 
@@ -55,7 +58,7 @@ export interface CreateFlowTemplateRequest {
 
 export namespace CreateFlowTemplateRequest {
   export function isa(o: any): o is CreateFlowTemplateRequest {
-    return _smithy.isa(o, "CreateFlowTemplateRequest");
+    return __isa(o, "CreateFlowTemplateRequest");
   }
 }
 
@@ -69,7 +72,7 @@ export interface CreateFlowTemplateResponse extends $MetadataBearer {
 
 export namespace CreateFlowTemplateResponse {
   export function isa(o: any): o is CreateFlowTemplateResponse {
-    return _smithy.isa(o, "CreateFlowTemplateResponse");
+    return __isa(o, "CreateFlowTemplateResponse");
   }
 }
 
@@ -117,7 +120,7 @@ export interface CreateSystemInstanceRequest {
 
 export namespace CreateSystemInstanceRequest {
   export function isa(o: any): o is CreateSystemInstanceRequest {
-    return _smithy.isa(o, "CreateSystemInstanceRequest");
+    return __isa(o, "CreateSystemInstanceRequest");
   }
 }
 
@@ -131,7 +134,7 @@ export interface CreateSystemInstanceResponse extends $MetadataBearer {
 
 export namespace CreateSystemInstanceResponse {
   export function isa(o: any): o is CreateSystemInstanceResponse {
-    return _smithy.isa(o, "CreateSystemInstanceResponse");
+    return __isa(o, "CreateSystemInstanceResponse");
   }
 }
 
@@ -151,7 +154,7 @@ export interface CreateSystemTemplateRequest {
 
 export namespace CreateSystemTemplateRequest {
   export function isa(o: any): o is CreateSystemTemplateRequest {
-    return _smithy.isa(o, "CreateSystemTemplateRequest");
+    return __isa(o, "CreateSystemTemplateRequest");
   }
 }
 
@@ -165,7 +168,7 @@ export interface CreateSystemTemplateResponse extends $MetadataBearer {
 
 export namespace CreateSystemTemplateResponse {
   export function isa(o: any): o is CreateSystemTemplateResponse {
-    return _smithy.isa(o, "CreateSystemTemplateResponse");
+    return __isa(o, "CreateSystemTemplateResponse");
   }
 }
 
@@ -183,7 +186,7 @@ export interface DeleteFlowTemplateRequest {
 
 export namespace DeleteFlowTemplateRequest {
   export function isa(o: any): o is DeleteFlowTemplateRequest {
-    return _smithy.isa(o, "DeleteFlowTemplateRequest");
+    return __isa(o, "DeleteFlowTemplateRequest");
   }
 }
 
@@ -193,7 +196,7 @@ export interface DeleteFlowTemplateResponse extends $MetadataBearer {
 
 export namespace DeleteFlowTemplateResponse {
   export function isa(o: any): o is DeleteFlowTemplateResponse {
-    return _smithy.isa(o, "DeleteFlowTemplateResponse");
+    return __isa(o, "DeleteFlowTemplateResponse");
   }
 }
 
@@ -203,7 +206,7 @@ export interface DeleteNamespaceRequest {
 
 export namespace DeleteNamespaceRequest {
   export function isa(o: any): o is DeleteNamespaceRequest {
-    return _smithy.isa(o, "DeleteNamespaceRequest");
+    return __isa(o, "DeleteNamespaceRequest");
   }
 }
 
@@ -222,7 +225,7 @@ export interface DeleteNamespaceResponse extends $MetadataBearer {
 
 export namespace DeleteNamespaceResponse {
   export function isa(o: any): o is DeleteNamespaceResponse {
-    return _smithy.isa(o, "DeleteNamespaceResponse");
+    return __isa(o, "DeleteNamespaceResponse");
   }
 }
 
@@ -236,7 +239,7 @@ export interface DeleteSystemInstanceRequest {
 
 export namespace DeleteSystemInstanceRequest {
   export function isa(o: any): o is DeleteSystemInstanceRequest {
-    return _smithy.isa(o, "DeleteSystemInstanceRequest");
+    return __isa(o, "DeleteSystemInstanceRequest");
   }
 }
 
@@ -246,7 +249,7 @@ export interface DeleteSystemInstanceResponse extends $MetadataBearer {
 
 export namespace DeleteSystemInstanceResponse {
   export function isa(o: any): o is DeleteSystemInstanceResponse {
-    return _smithy.isa(o, "DeleteSystemInstanceResponse");
+    return __isa(o, "DeleteSystemInstanceResponse");
   }
 }
 
@@ -264,7 +267,7 @@ export interface DeleteSystemTemplateRequest {
 
 export namespace DeleteSystemTemplateRequest {
   export function isa(o: any): o is DeleteSystemTemplateRequest {
-    return _smithy.isa(o, "DeleteSystemTemplateRequest");
+    return __isa(o, "DeleteSystemTemplateRequest");
   }
 }
 
@@ -274,7 +277,7 @@ export interface DeleteSystemTemplateResponse extends $MetadataBearer {
 
 export namespace DeleteSystemTemplateResponse {
   export function isa(o: any): o is DeleteSystemTemplateResponse {
-    return _smithy.isa(o, "DeleteSystemTemplateResponse");
+    return __isa(o, "DeleteSystemTemplateResponse");
   }
 }
 
@@ -292,7 +295,7 @@ export interface DeploySystemInstanceRequest {
 
 export namespace DeploySystemInstanceRequest {
   export function isa(o: any): o is DeploySystemInstanceRequest {
-    return _smithy.isa(o, "DeploySystemInstanceRequest");
+    return __isa(o, "DeploySystemInstanceRequest");
   }
 }
 
@@ -311,7 +314,7 @@ export interface DeploySystemInstanceResponse extends $MetadataBearer {
 
 export namespace DeploySystemInstanceResponse {
   export function isa(o: any): o is DeploySystemInstanceResponse {
-    return _smithy.isa(o, "DeploySystemInstanceResponse");
+    return __isa(o, "DeploySystemInstanceResponse");
   }
 }
 
@@ -329,7 +332,7 @@ export interface DeprecateFlowTemplateRequest {
 
 export namespace DeprecateFlowTemplateRequest {
   export function isa(o: any): o is DeprecateFlowTemplateRequest {
-    return _smithy.isa(o, "DeprecateFlowTemplateRequest");
+    return __isa(o, "DeprecateFlowTemplateRequest");
   }
 }
 
@@ -339,7 +342,7 @@ export interface DeprecateFlowTemplateResponse extends $MetadataBearer {
 
 export namespace DeprecateFlowTemplateResponse {
   export function isa(o: any): o is DeprecateFlowTemplateResponse {
-    return _smithy.isa(o, "DeprecateFlowTemplateResponse");
+    return __isa(o, "DeprecateFlowTemplateResponse");
   }
 }
 
@@ -357,7 +360,7 @@ export interface DeprecateSystemTemplateRequest {
 
 export namespace DeprecateSystemTemplateRequest {
   export function isa(o: any): o is DeprecateSystemTemplateRequest {
-    return _smithy.isa(o, "DeprecateSystemTemplateRequest");
+    return __isa(o, "DeprecateSystemTemplateRequest");
   }
 }
 
@@ -367,7 +370,7 @@ export interface DeprecateSystemTemplateResponse extends $MetadataBearer {
 
 export namespace DeprecateSystemTemplateResponse {
   export function isa(o: any): o is DeprecateSystemTemplateResponse {
-    return _smithy.isa(o, "DeprecateSystemTemplateResponse");
+    return __isa(o, "DeprecateSystemTemplateResponse");
   }
 }
 
@@ -381,7 +384,7 @@ export interface DescribeNamespaceRequest {
 
 export namespace DescribeNamespaceRequest {
   export function isa(o: any): o is DescribeNamespaceRequest {
-    return _smithy.isa(o, "DescribeNamespaceRequest");
+    return __isa(o, "DescribeNamespaceRequest");
   }
 }
 
@@ -415,7 +418,7 @@ export interface DescribeNamespaceResponse extends $MetadataBearer {
 
 export namespace DescribeNamespaceResponse {
   export function isa(o: any): o is DescribeNamespaceResponse {
-    return _smithy.isa(o, "DescribeNamespaceResponse");
+    return __isa(o, "DescribeNamespaceResponse");
   }
 }
 
@@ -434,7 +437,7 @@ export interface DissociateEntityFromThingRequest {
 
 export namespace DissociateEntityFromThingRequest {
   export function isa(o: any): o is DissociateEntityFromThingRequest {
-    return _smithy.isa(o, "DissociateEntityFromThingRequest");
+    return __isa(o, "DissociateEntityFromThingRequest");
   }
 }
 
@@ -444,7 +447,7 @@ export interface DissociateEntityFromThingResponse extends $MetadataBearer {
 
 export namespace DissociateEntityFromThingResponse {
   export function isa(o: any): o is DissociateEntityFromThingResponse {
-    return _smithy.isa(o, "DissociateEntityFromThingResponse");
+    return __isa(o, "DissociateEntityFromThingResponse");
   }
 }
 
@@ -467,7 +470,7 @@ export interface GetEntitiesRequest {
 
 export namespace GetEntitiesRequest {
   export function isa(o: any): o is GetEntitiesRequest {
-    return _smithy.isa(o, "GetEntitiesRequest");
+    return __isa(o, "GetEntitiesRequest");
   }
 }
 
@@ -481,7 +484,7 @@ export interface GetEntitiesResponse extends $MetadataBearer {
 
 export namespace GetEntitiesResponse {
   export function isa(o: any): o is GetEntitiesResponse {
-    return _smithy.isa(o, "GetEntitiesResponse");
+    return __isa(o, "GetEntitiesResponse");
   }
 }
 
@@ -504,7 +507,7 @@ export interface GetFlowTemplateRequest {
 
 export namespace GetFlowTemplateRequest {
   export function isa(o: any): o is GetFlowTemplateRequest {
-    return _smithy.isa(o, "GetFlowTemplateRequest");
+    return __isa(o, "GetFlowTemplateRequest");
   }
 }
 
@@ -518,7 +521,7 @@ export interface GetFlowTemplateResponse extends $MetadataBearer {
 
 export namespace GetFlowTemplateResponse {
   export function isa(o: any): o is GetFlowTemplateResponse {
-    return _smithy.isa(o, "GetFlowTemplateResponse");
+    return __isa(o, "GetFlowTemplateResponse");
   }
 }
 
@@ -546,7 +549,7 @@ export interface GetFlowTemplateRevisionsRequest {
 
 export namespace GetFlowTemplateRevisionsRequest {
   export function isa(o: any): o is GetFlowTemplateRevisionsRequest {
-    return _smithy.isa(o, "GetFlowTemplateRevisionsRequest");
+    return __isa(o, "GetFlowTemplateRevisionsRequest");
   }
 }
 
@@ -565,7 +568,7 @@ export interface GetFlowTemplateRevisionsResponse extends $MetadataBearer {
 
 export namespace GetFlowTemplateRevisionsResponse {
   export function isa(o: any): o is GetFlowTemplateRevisionsResponse {
-    return _smithy.isa(o, "GetFlowTemplateRevisionsResponse");
+    return __isa(o, "GetFlowTemplateRevisionsResponse");
   }
 }
 
@@ -575,7 +578,7 @@ export interface GetNamespaceDeletionStatusRequest {
 
 export namespace GetNamespaceDeletionStatusRequest {
   export function isa(o: any): o is GetNamespaceDeletionStatusRequest {
-    return _smithy.isa(o, "GetNamespaceDeletionStatusRequest");
+    return __isa(o, "GetNamespaceDeletionStatusRequest");
   }
 }
 
@@ -609,7 +612,7 @@ export interface GetNamespaceDeletionStatusResponse extends $MetadataBearer {
 
 export namespace GetNamespaceDeletionStatusResponse {
   export function isa(o: any): o is GetNamespaceDeletionStatusResponse {
-    return _smithy.isa(o, "GetNamespaceDeletionStatusResponse");
+    return __isa(o, "GetNamespaceDeletionStatusResponse");
   }
 }
 
@@ -627,7 +630,7 @@ export interface GetSystemInstanceRequest {
 
 export namespace GetSystemInstanceRequest {
   export function isa(o: any): o is GetSystemInstanceRequest {
-    return _smithy.isa(o, "GetSystemInstanceRequest");
+    return __isa(o, "GetSystemInstanceRequest");
   }
 }
 
@@ -641,7 +644,7 @@ export interface GetSystemInstanceResponse extends $MetadataBearer {
 
 export namespace GetSystemInstanceResponse {
   export function isa(o: any): o is GetSystemInstanceResponse {
-    return _smithy.isa(o, "GetSystemInstanceResponse");
+    return __isa(o, "GetSystemInstanceResponse");
   }
 }
 
@@ -664,7 +667,7 @@ export interface GetSystemTemplateRequest {
 
 export namespace GetSystemTemplateRequest {
   export function isa(o: any): o is GetSystemTemplateRequest {
-    return _smithy.isa(o, "GetSystemTemplateRequest");
+    return __isa(o, "GetSystemTemplateRequest");
   }
 }
 
@@ -678,7 +681,7 @@ export interface GetSystemTemplateResponse extends $MetadataBearer {
 
 export namespace GetSystemTemplateResponse {
   export function isa(o: any): o is GetSystemTemplateResponse {
-    return _smithy.isa(o, "GetSystemTemplateResponse");
+    return __isa(o, "GetSystemTemplateResponse");
   }
 }
 
@@ -706,7 +709,7 @@ export interface GetSystemTemplateRevisionsRequest {
 
 export namespace GetSystemTemplateRevisionsRequest {
   export function isa(o: any): o is GetSystemTemplateRevisionsRequest {
-    return _smithy.isa(o, "GetSystemTemplateRevisionsRequest");
+    return __isa(o, "GetSystemTemplateRevisionsRequest");
   }
 }
 
@@ -725,7 +728,7 @@ export interface GetSystemTemplateRevisionsResponse extends $MetadataBearer {
 
 export namespace GetSystemTemplateRevisionsResponse {
   export function isa(o: any): o is GetSystemTemplateRevisionsResponse {
-    return _smithy.isa(o, "GetSystemTemplateRevisionsResponse");
+    return __isa(o, "GetSystemTemplateRevisionsResponse");
   }
 }
 
@@ -739,7 +742,7 @@ export interface GetUploadStatusRequest {
 
 export namespace GetUploadStatusRequest {
   export function isa(o: any): o is GetUploadStatusRequest {
-    return _smithy.isa(o, "GetUploadStatusRequest");
+    return __isa(o, "GetUploadStatusRequest");
   }
 }
 
@@ -783,7 +786,7 @@ export interface GetUploadStatusResponse extends $MetadataBearer {
 
 export namespace GetUploadStatusResponse {
   export function isa(o: any): o is GetUploadStatusResponse {
-    return _smithy.isa(o, "GetUploadStatusResponse");
+    return __isa(o, "GetUploadStatusResponse");
   }
 }
 
@@ -807,7 +810,7 @@ export interface ListFlowExecutionMessagesRequest {
 
 export namespace ListFlowExecutionMessagesRequest {
   export function isa(o: any): o is ListFlowExecutionMessagesRequest {
-    return _smithy.isa(o, "ListFlowExecutionMessagesRequest");
+    return __isa(o, "ListFlowExecutionMessagesRequest");
   }
 }
 
@@ -826,7 +829,7 @@ export interface ListFlowExecutionMessagesResponse extends $MetadataBearer {
 
 export namespace ListFlowExecutionMessagesResponse {
   export function isa(o: any): o is ListFlowExecutionMessagesResponse {
-    return _smithy.isa(o, "ListFlowExecutionMessagesResponse");
+    return __isa(o, "ListFlowExecutionMessagesResponse");
   }
 }
 
@@ -850,7 +853,7 @@ export interface ListTagsForResourceRequest {
 
 export namespace ListTagsForResourceRequest {
   export function isa(o: any): o is ListTagsForResourceRequest {
-    return _smithy.isa(o, "ListTagsForResourceRequest");
+    return __isa(o, "ListTagsForResourceRequest");
   }
 }
 
@@ -869,7 +872,7 @@ export interface ListTagsForResourceResponse extends $MetadataBearer {
 
 export namespace ListTagsForResourceResponse {
   export function isa(o: any): o is ListTagsForResourceResponse {
-    return _smithy.isa(o, "ListTagsForResourceResponse");
+    return __isa(o, "ListTagsForResourceResponse");
   }
 }
 
@@ -907,7 +910,7 @@ export interface SearchEntitiesRequest {
 
 export namespace SearchEntitiesRequest {
   export function isa(o: any): o is SearchEntitiesRequest {
-    return _smithy.isa(o, "SearchEntitiesRequest");
+    return __isa(o, "SearchEntitiesRequest");
   }
 }
 
@@ -926,7 +929,7 @@ export interface SearchEntitiesResponse extends $MetadataBearer {
 
 export namespace SearchEntitiesResponse {
   export function isa(o: any): o is SearchEntitiesResponse {
-    return _smithy.isa(o, "SearchEntitiesResponse");
+    return __isa(o, "SearchEntitiesResponse");
   }
 }
 
@@ -965,7 +968,7 @@ export interface SearchFlowExecutionsRequest {
 
 export namespace SearchFlowExecutionsRequest {
   export function isa(o: any): o is SearchFlowExecutionsRequest {
-    return _smithy.isa(o, "SearchFlowExecutionsRequest");
+    return __isa(o, "SearchFlowExecutionsRequest");
   }
 }
 
@@ -984,7 +987,7 @@ export interface SearchFlowExecutionsResponse extends $MetadataBearer {
 
 export namespace SearchFlowExecutionsResponse {
   export function isa(o: any): o is SearchFlowExecutionsResponse {
-    return _smithy.isa(o, "SearchFlowExecutionsResponse");
+    return __isa(o, "SearchFlowExecutionsResponse");
   }
 }
 
@@ -1008,7 +1011,7 @@ export interface SearchFlowTemplatesRequest {
 
 export namespace SearchFlowTemplatesRequest {
   export function isa(o: any): o is SearchFlowTemplatesRequest {
-    return _smithy.isa(o, "SearchFlowTemplatesRequest");
+    return __isa(o, "SearchFlowTemplatesRequest");
   }
 }
 
@@ -1027,7 +1030,7 @@ export interface SearchFlowTemplatesResponse extends $MetadataBearer {
 
 export namespace SearchFlowTemplatesResponse {
   export function isa(o: any): o is SearchFlowTemplatesResponse {
-    return _smithy.isa(o, "SearchFlowTemplatesResponse");
+    return __isa(o, "SearchFlowTemplatesResponse");
   }
 }
 
@@ -1053,7 +1056,7 @@ export interface SearchSystemInstancesRequest {
 
 export namespace SearchSystemInstancesRequest {
   export function isa(o: any): o is SearchSystemInstancesRequest {
-    return _smithy.isa(o, "SearchSystemInstancesRequest");
+    return __isa(o, "SearchSystemInstancesRequest");
   }
 }
 
@@ -1072,7 +1075,7 @@ export interface SearchSystemInstancesResponse extends $MetadataBearer {
 
 export namespace SearchSystemInstancesResponse {
   export function isa(o: any): o is SearchSystemInstancesResponse {
-    return _smithy.isa(o, "SearchSystemInstancesResponse");
+    return __isa(o, "SearchSystemInstancesResponse");
   }
 }
 
@@ -1096,7 +1099,7 @@ export interface SearchSystemTemplatesRequest {
 
 export namespace SearchSystemTemplatesRequest {
   export function isa(o: any): o is SearchSystemTemplatesRequest {
-    return _smithy.isa(o, "SearchSystemTemplatesRequest");
+    return __isa(o, "SearchSystemTemplatesRequest");
   }
 }
 
@@ -1115,7 +1118,7 @@ export interface SearchSystemTemplatesResponse extends $MetadataBearer {
 
 export namespace SearchSystemTemplatesResponse {
   export function isa(o: any): o is SearchSystemTemplatesResponse {
-    return _smithy.isa(o, "SearchSystemTemplatesResponse");
+    return __isa(o, "SearchSystemTemplatesResponse");
   }
 }
 
@@ -1148,7 +1151,7 @@ export interface SearchThingsRequest {
 
 export namespace SearchThingsRequest {
   export function isa(o: any): o is SearchThingsRequest {
-    return _smithy.isa(o, "SearchThingsRequest");
+    return __isa(o, "SearchThingsRequest");
   }
 }
 
@@ -1167,7 +1170,7 @@ export interface SearchThingsResponse extends $MetadataBearer {
 
 export namespace SearchThingsResponse {
   export function isa(o: any): o is SearchThingsResponse {
-    return _smithy.isa(o, "SearchThingsResponse");
+    return __isa(o, "SearchThingsResponse");
   }
 }
 
@@ -1186,7 +1189,7 @@ export interface TagResourceRequest {
 
 export namespace TagResourceRequest {
   export function isa(o: any): o is TagResourceRequest {
-    return _smithy.isa(o, "TagResourceRequest");
+    return __isa(o, "TagResourceRequest");
   }
 }
 
@@ -1196,7 +1199,7 @@ export interface TagResourceResponse extends $MetadataBearer {
 
 export namespace TagResourceResponse {
   export function isa(o: any): o is TagResourceResponse {
-    return _smithy.isa(o, "TagResourceResponse");
+    return __isa(o, "TagResourceResponse");
   }
 }
 
@@ -1210,7 +1213,7 @@ export interface UndeploySystemInstanceRequest {
 
 export namespace UndeploySystemInstanceRequest {
   export function isa(o: any): o is UndeploySystemInstanceRequest {
-    return _smithy.isa(o, "UndeploySystemInstanceRequest");
+    return __isa(o, "UndeploySystemInstanceRequest");
   }
 }
 
@@ -1224,7 +1227,7 @@ export interface UndeploySystemInstanceResponse extends $MetadataBearer {
 
 export namespace UndeploySystemInstanceResponse {
   export function isa(o: any): o is UndeploySystemInstanceResponse {
-    return _smithy.isa(o, "UndeploySystemInstanceResponse");
+    return __isa(o, "UndeploySystemInstanceResponse");
   }
 }
 
@@ -1244,7 +1247,7 @@ export interface UntagResourceRequest {
 
 export namespace UntagResourceRequest {
   export function isa(o: any): o is UntagResourceRequest {
-    return _smithy.isa(o, "UntagResourceRequest");
+    return __isa(o, "UntagResourceRequest");
   }
 }
 
@@ -1254,7 +1257,7 @@ export interface UntagResourceResponse extends $MetadataBearer {
 
 export namespace UntagResourceResponse {
   export function isa(o: any): o is UntagResourceResponse {
-    return _smithy.isa(o, "UntagResourceResponse");
+    return __isa(o, "UntagResourceResponse");
   }
 }
 
@@ -1284,7 +1287,7 @@ export interface UpdateFlowTemplateRequest {
 
 export namespace UpdateFlowTemplateRequest {
   export function isa(o: any): o is UpdateFlowTemplateRequest {
-    return _smithy.isa(o, "UpdateFlowTemplateRequest");
+    return __isa(o, "UpdateFlowTemplateRequest");
   }
 }
 
@@ -1298,7 +1301,7 @@ export interface UpdateFlowTemplateResponse extends $MetadataBearer {
 
 export namespace UpdateFlowTemplateResponse {
   export function isa(o: any): o is UpdateFlowTemplateResponse {
-    return _smithy.isa(o, "UpdateFlowTemplateResponse");
+    return __isa(o, "UpdateFlowTemplateResponse");
   }
 }
 
@@ -1327,7 +1330,7 @@ export interface UpdateSystemTemplateRequest {
 
 export namespace UpdateSystemTemplateRequest {
   export function isa(o: any): o is UpdateSystemTemplateRequest {
-    return _smithy.isa(o, "UpdateSystemTemplateRequest");
+    return __isa(o, "UpdateSystemTemplateRequest");
   }
 }
 
@@ -1341,7 +1344,7 @@ export interface UpdateSystemTemplateResponse extends $MetadataBearer {
 
 export namespace UpdateSystemTemplateResponse {
   export function isa(o: any): o is UpdateSystemTemplateResponse {
-    return _smithy.isa(o, "UpdateSystemTemplateResponse");
+    return __isa(o, "UpdateSystemTemplateResponse");
   }
 }
 
@@ -1366,7 +1369,7 @@ export interface UploadEntityDefinitionsRequest {
 
 export namespace UploadEntityDefinitionsRequest {
   export function isa(o: any): o is UploadEntityDefinitionsRequest {
-    return _smithy.isa(o, "UploadEntityDefinitionsRequest");
+    return __isa(o, "UploadEntityDefinitionsRequest");
   }
 }
 
@@ -1380,7 +1383,7 @@ export interface UploadEntityDefinitionsResponse extends $MetadataBearer {
 
 export namespace UploadEntityDefinitionsResponse {
   export function isa(o: any): o is UploadEntityDefinitionsResponse {
-    return _smithy.isa(o, "UploadEntityDefinitionsResponse");
+    return __isa(o, "UploadEntityDefinitionsResponse");
   }
 }
 
@@ -1402,7 +1405,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -1424,7 +1427,7 @@ export interface DefinitionDocument {
 
 export namespace DefinitionDocument {
   export function isa(o: any): o is DefinitionDocument {
-    return _smithy.isa(o, "DefinitionDocument");
+    return __isa(o, "DefinitionDocument");
   }
 }
 
@@ -1436,7 +1439,7 @@ export enum DefinitionLanguage {
  * <p></p>
  */
 export interface InternalFailureException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalFailureException";
   $fault: "server";
@@ -1445,7 +1448,7 @@ export interface InternalFailureException
 
 export namespace InternalFailureException {
   export function isa(o: any): o is InternalFailureException {
-    return _smithy.isa(o, "InternalFailureException");
+    return __isa(o, "InternalFailureException");
   }
 }
 
@@ -1453,7 +1456,7 @@ export namespace InternalFailureException {
  * <p></p>
  */
 export interface InvalidRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidRequestException";
   $fault: "client";
@@ -1462,7 +1465,7 @@ export interface InvalidRequestException
 
 export namespace InvalidRequestException {
   export function isa(o: any): o is InvalidRequestException {
-    return _smithy.isa(o, "InvalidRequestException");
+    return __isa(o, "InvalidRequestException");
   }
 }
 
@@ -1470,7 +1473,7 @@ export namespace InvalidRequestException {
  * <p></p>
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -1479,7 +1482,7 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
@@ -1487,7 +1490,7 @@ export namespace LimitExceededException {
  * <p></p>
  */
 export interface ResourceAlreadyExistsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceAlreadyExistsException";
   $fault: "client";
@@ -1496,7 +1499,7 @@ export interface ResourceAlreadyExistsException
 
 export namespace ResourceAlreadyExistsException {
   export function isa(o: any): o is ResourceAlreadyExistsException {
-    return _smithy.isa(o, "ResourceAlreadyExistsException");
+    return __isa(o, "ResourceAlreadyExistsException");
   }
 }
 
@@ -1504,7 +1507,7 @@ export namespace ResourceAlreadyExistsException {
  * <p></p>
  */
 export interface ResourceInUseException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceInUseException";
   $fault: "client";
@@ -1513,7 +1516,7 @@ export interface ResourceInUseException
 
 export namespace ResourceInUseException {
   export function isa(o: any): o is ResourceInUseException {
-    return _smithy.isa(o, "ResourceInUseException");
+    return __isa(o, "ResourceInUseException");
   }
 }
 
@@ -1521,7 +1524,7 @@ export namespace ResourceInUseException {
  * <p></p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -1530,7 +1533,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -1538,7 +1541,7 @@ export namespace ResourceNotFoundException {
  * <p></p>
  */
 export interface ThrottlingException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ThrottlingException";
   $fault: "client";
@@ -1547,7 +1550,7 @@ export interface ThrottlingException
 
 export namespace ThrottlingException {
   export function isa(o: any): o is ThrottlingException {
-    return _smithy.isa(o, "ThrottlingException");
+    return __isa(o, "ThrottlingException");
   }
 }
 
@@ -1584,7 +1587,7 @@ export interface EntityDescription {
 
 export namespace EntityDescription {
   export function isa(o: any): o is EntityDescription {
-    return _smithy.isa(o, "EntityDescription");
+    return __isa(o, "EntityDescription");
   }
 }
 
@@ -1609,7 +1612,7 @@ export interface EntityFilter {
 
 export namespace EntityFilter {
   export function isa(o: any): o is EntityFilter {
-    return _smithy.isa(o, "EntityFilter");
+    return __isa(o, "EntityFilter");
   }
 }
 
@@ -1661,7 +1664,7 @@ export interface Thing {
 
 export namespace Thing {
   export function isa(o: any): o is Thing {
-    return _smithy.isa(o, "Thing");
+    return __isa(o, "Thing");
   }
 }
 
@@ -1689,7 +1692,7 @@ export interface DependencyRevision {
 
 export namespace DependencyRevision {
   export function isa(o: any): o is DependencyRevision {
-    return _smithy.isa(o, "DependencyRevision");
+    return __isa(o, "DependencyRevision");
   }
 }
 
@@ -1746,7 +1749,7 @@ export interface FlowExecutionMessage {
 
 export namespace FlowExecutionMessage {
   export function isa(o: any): o is FlowExecutionMessage {
-    return _smithy.isa(o, "FlowExecutionMessage");
+    return __isa(o, "FlowExecutionMessage");
   }
 }
 
@@ -1795,7 +1798,7 @@ export interface FlowExecutionSummary {
 
 export namespace FlowExecutionSummary {
   export function isa(o: any): o is FlowExecutionSummary {
-    return _smithy.isa(o, "FlowExecutionSummary");
+    return __isa(o, "FlowExecutionSummary");
   }
 }
 
@@ -1822,7 +1825,7 @@ export interface FlowTemplateDescription {
 
 export namespace FlowTemplateDescription {
   export function isa(o: any): o is FlowTemplateDescription {
-    return _smithy.isa(o, "FlowTemplateDescription");
+    return __isa(o, "FlowTemplateDescription");
   }
 }
 
@@ -1844,7 +1847,7 @@ export interface FlowTemplateFilter {
 
 export namespace FlowTemplateFilter {
   export function isa(o: any): o is FlowTemplateFilter {
-    return _smithy.isa(o, "FlowTemplateFilter");
+    return __isa(o, "FlowTemplateFilter");
   }
 }
 
@@ -1880,7 +1883,7 @@ export interface FlowTemplateSummary {
 
 export namespace FlowTemplateSummary {
   export function isa(o: any): o is FlowTemplateSummary {
-    return _smithy.isa(o, "FlowTemplateSummary");
+    return __isa(o, "FlowTemplateSummary");
   }
 }
 
@@ -1902,7 +1905,7 @@ export interface MetricsConfiguration {
 
 export namespace MetricsConfiguration {
   export function isa(o: any): o is MetricsConfiguration {
-    return _smithy.isa(o, "MetricsConfiguration");
+    return __isa(o, "MetricsConfiguration");
   }
 }
 
@@ -1962,7 +1965,7 @@ export interface SystemInstanceDescription {
 
 export namespace SystemInstanceDescription {
   export function isa(o: any): o is SystemInstanceDescription {
-    return _smithy.isa(o, "SystemInstanceDescription");
+    return __isa(o, "SystemInstanceDescription");
   }
 }
 
@@ -1986,7 +1989,7 @@ export interface SystemInstanceFilter {
 
 export namespace SystemInstanceFilter {
   export function isa(o: any): o is SystemInstanceFilter {
-    return _smithy.isa(o, "SystemInstanceFilter");
+    return __isa(o, "SystemInstanceFilter");
   }
 }
 
@@ -2051,7 +2054,7 @@ export interface SystemInstanceSummary {
 
 export namespace SystemInstanceSummary {
   export function isa(o: any): o is SystemInstanceSummary {
-    return _smithy.isa(o, "SystemInstanceSummary");
+    return __isa(o, "SystemInstanceSummary");
   }
 }
 
@@ -2078,7 +2081,7 @@ export interface SystemTemplateDescription {
 
 export namespace SystemTemplateDescription {
   export function isa(o: any): o is SystemTemplateDescription {
-    return _smithy.isa(o, "SystemTemplateDescription");
+    return __isa(o, "SystemTemplateDescription");
   }
 }
 
@@ -2100,7 +2103,7 @@ export interface SystemTemplateFilter {
 
 export namespace SystemTemplateFilter {
   export function isa(o: any): o is SystemTemplateFilter {
-    return _smithy.isa(o, "SystemTemplateFilter");
+    return __isa(o, "SystemTemplateFilter");
   }
 }
 
@@ -2136,6 +2139,6 @@ export interface SystemTemplateSummary {
 
 export namespace SystemTemplateSummary {
   export function isa(o: any): o is SystemTemplateSummary {
-    return _smithy.isa(o, "SystemTemplateSummary");
+    return __isa(o, "SystemTemplateSummary");
   }
 }

--- a/clients/client-kafka/models/index.ts
+++ b/clients/client-kafka/models/index.ts
@@ -1,11 +1,14 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
  * <p>Returns information about an error.</p>
  */
 export interface BadRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "BadRequestException";
   $fault: "client";
@@ -22,7 +25,7 @@ export interface BadRequestException
 
 export namespace BadRequestException {
   export function isa(o: any): o is BadRequestException {
-    return _smithy.isa(o, "BadRequestException");
+    return __isa(o, "BadRequestException");
   }
 }
 
@@ -48,7 +51,7 @@ export interface BrokerEBSVolumeInfo {
 
 export namespace BrokerEBSVolumeInfo {
   export function isa(o: any): o is BrokerEBSVolumeInfo {
-    return _smithy.isa(o, "BrokerEBSVolumeInfo");
+    return __isa(o, "BrokerEBSVolumeInfo");
   }
 }
 
@@ -87,7 +90,7 @@ export interface BrokerNodeGroupInfo {
 
 export namespace BrokerNodeGroupInfo {
   export function isa(o: any): o is BrokerNodeGroupInfo {
-    return _smithy.isa(o, "BrokerNodeGroupInfo");
+    return __isa(o, "BrokerNodeGroupInfo");
   }
 }
 
@@ -129,7 +132,7 @@ export interface BrokerNodeInfo {
 
 export namespace BrokerNodeInfo {
   export function isa(o: any): o is BrokerNodeInfo {
-    return _smithy.isa(o, "BrokerNodeInfo");
+    return __isa(o, "BrokerNodeInfo");
   }
 }
 
@@ -156,7 +159,7 @@ export interface BrokerSoftwareInfo {
 
 export namespace BrokerSoftwareInfo {
   export function isa(o: any): o is BrokerSoftwareInfo {
-    return _smithy.isa(o, "BrokerSoftwareInfo");
+    return __isa(o, "BrokerSoftwareInfo");
   }
 }
 
@@ -173,7 +176,7 @@ export interface ClientAuthentication {
 
 export namespace ClientAuthentication {
   export function isa(o: any): o is ClientAuthentication {
-    return _smithy.isa(o, "ClientAuthentication");
+    return __isa(o, "ClientAuthentication");
   }
 }
 
@@ -266,7 +269,7 @@ export interface ClusterInfo {
 
 export namespace ClusterInfo {
   export function isa(o: any): o is ClusterInfo {
-    return _smithy.isa(o, "ClusterInfo");
+    return __isa(o, "ClusterInfo");
   }
 }
 
@@ -328,7 +331,7 @@ export interface ClusterOperationInfo {
 
 export namespace ClusterOperationInfo {
   export function isa(o: any): o is ClusterOperationInfo {
-    return _smithy.isa(o, "ClusterOperationInfo");
+    return __isa(o, "ClusterOperationInfo");
   }
 }
 
@@ -378,7 +381,7 @@ export interface Configuration {
 
 export namespace Configuration {
   export function isa(o: any): o is Configuration {
-    return _smithy.isa(o, "Configuration");
+    return __isa(o, "Configuration");
   }
 }
 
@@ -400,7 +403,7 @@ export interface ConfigurationInfo {
 
 export namespace ConfigurationInfo {
   export function isa(o: any): o is ConfigurationInfo {
-    return _smithy.isa(o, "ConfigurationInfo");
+    return __isa(o, "ConfigurationInfo");
   }
 }
 
@@ -427,16 +430,14 @@ export interface ConfigurationRevision {
 
 export namespace ConfigurationRevision {
   export function isa(o: any): o is ConfigurationRevision {
-    return _smithy.isa(o, "ConfigurationRevision");
+    return __isa(o, "ConfigurationRevision");
   }
 }
 
 /**
  * <p>Returns information about an error.</p>
  */
-export interface ConflictException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface ConflictException extends __SmithyException, $MetadataBearer {
   name: "ConflictException";
   $fault: "client";
   /**
@@ -452,7 +453,7 @@ export interface ConflictException
 
 export namespace ConflictException {
   export function isa(o: any): o is ConflictException {
-    return _smithy.isa(o, "ConflictException");
+    return __isa(o, "ConflictException");
   }
 }
 
@@ -511,7 +512,7 @@ export interface CreateClusterRequest {
 
 export namespace CreateClusterRequest {
   export function isa(o: any): o is CreateClusterRequest {
-    return _smithy.isa(o, "CreateClusterRequest");
+    return __isa(o, "CreateClusterRequest");
   }
 }
 
@@ -535,7 +536,7 @@ export interface CreateClusterResponse extends $MetadataBearer {
 
 export namespace CreateClusterResponse {
   export function isa(o: any): o is CreateClusterResponse {
-    return _smithy.isa(o, "CreateClusterResponse");
+    return __isa(o, "CreateClusterResponse");
   }
 }
 
@@ -565,7 +566,7 @@ export interface CreateConfigurationRequest {
 
 export namespace CreateConfigurationRequest {
   export function isa(o: any): o is CreateConfigurationRequest {
-    return _smithy.isa(o, "CreateConfigurationRequest");
+    return __isa(o, "CreateConfigurationRequest");
   }
 }
 
@@ -594,7 +595,7 @@ export interface CreateConfigurationResponse extends $MetadataBearer {
 
 export namespace CreateConfigurationResponse {
   export function isa(o: any): o is CreateConfigurationResponse {
-    return _smithy.isa(o, "CreateConfigurationResponse");
+    return __isa(o, "CreateConfigurationResponse");
   }
 }
 
@@ -613,7 +614,7 @@ export interface DeleteClusterRequest {
 
 export namespace DeleteClusterRequest {
   export function isa(o: any): o is DeleteClusterRequest {
-    return _smithy.isa(o, "DeleteClusterRequest");
+    return __isa(o, "DeleteClusterRequest");
   }
 }
 
@@ -632,7 +633,7 @@ export interface DeleteClusterResponse extends $MetadataBearer {
 
 export namespace DeleteClusterResponse {
   export function isa(o: any): o is DeleteClusterResponse {
-    return _smithy.isa(o, "DeleteClusterResponse");
+    return __isa(o, "DeleteClusterResponse");
   }
 }
 
@@ -646,7 +647,7 @@ export interface DescribeClusterOperationRequest {
 
 export namespace DescribeClusterOperationRequest {
   export function isa(o: any): o is DescribeClusterOperationRequest {
-    return _smithy.isa(o, "DescribeClusterOperationRequest");
+    return __isa(o, "DescribeClusterOperationRequest");
   }
 }
 
@@ -660,7 +661,7 @@ export interface DescribeClusterOperationResponse extends $MetadataBearer {
 
 export namespace DescribeClusterOperationResponse {
   export function isa(o: any): o is DescribeClusterOperationResponse {
-    return _smithy.isa(o, "DescribeClusterOperationResponse");
+    return __isa(o, "DescribeClusterOperationResponse");
   }
 }
 
@@ -674,7 +675,7 @@ export interface DescribeClusterRequest {
 
 export namespace DescribeClusterRequest {
   export function isa(o: any): o is DescribeClusterRequest {
-    return _smithy.isa(o, "DescribeClusterRequest");
+    return __isa(o, "DescribeClusterRequest");
   }
 }
 
@@ -688,7 +689,7 @@ export interface DescribeClusterResponse extends $MetadataBearer {
 
 export namespace DescribeClusterResponse {
   export function isa(o: any): o is DescribeClusterResponse {
-    return _smithy.isa(o, "DescribeClusterResponse");
+    return __isa(o, "DescribeClusterResponse");
   }
 }
 
@@ -702,7 +703,7 @@ export interface DescribeConfigurationRequest {
 
 export namespace DescribeConfigurationRequest {
   export function isa(o: any): o is DescribeConfigurationRequest {
-    return _smithy.isa(o, "DescribeConfigurationRequest");
+    return __isa(o, "DescribeConfigurationRequest");
   }
 }
 
@@ -741,7 +742,7 @@ export interface DescribeConfigurationResponse extends $MetadataBearer {
 
 export namespace DescribeConfigurationResponse {
   export function isa(o: any): o is DescribeConfigurationResponse {
-    return _smithy.isa(o, "DescribeConfigurationResponse");
+    return __isa(o, "DescribeConfigurationResponse");
   }
 }
 
@@ -760,7 +761,7 @@ export interface DescribeConfigurationRevisionRequest {
 
 export namespace DescribeConfigurationRevisionRequest {
   export function isa(o: any): o is DescribeConfigurationRevisionRequest {
-    return _smithy.isa(o, "DescribeConfigurationRevisionRequest");
+    return __isa(o, "DescribeConfigurationRevisionRequest");
   }
 }
 
@@ -795,7 +796,7 @@ export interface DescribeConfigurationRevisionResponse extends $MetadataBearer {
 
 export namespace DescribeConfigurationRevisionResponse {
   export function isa(o: any): o is DescribeConfigurationRevisionResponse {
-    return _smithy.isa(o, "DescribeConfigurationRevisionResponse");
+    return __isa(o, "DescribeConfigurationRevisionResponse");
   }
 }
 
@@ -812,7 +813,7 @@ export interface EBSStorageInfo {
 
 export namespace EBSStorageInfo {
   export function isa(o: any): o is EBSStorageInfo {
-    return _smithy.isa(o, "EBSStorageInfo");
+    return __isa(o, "EBSStorageInfo");
   }
 }
 
@@ -829,7 +830,7 @@ export interface EncryptionAtRest {
 
 export namespace EncryptionAtRest {
   export function isa(o: any): o is EncryptionAtRest {
-    return _smithy.isa(o, "EncryptionAtRest");
+    return __isa(o, "EncryptionAtRest");
   }
 }
 
@@ -859,7 +860,7 @@ export interface EncryptionInTransit {
 
 export namespace EncryptionInTransit {
   export function isa(o: any): o is EncryptionInTransit {
-    return _smithy.isa(o, "EncryptionInTransit");
+    return __isa(o, "EncryptionInTransit");
   }
 }
 
@@ -881,7 +882,7 @@ export interface EncryptionInfo {
 
 export namespace EncryptionInfo {
   export function isa(o: any): o is EncryptionInfo {
-    return _smithy.isa(o, "EncryptionInfo");
+    return __isa(o, "EncryptionInfo");
   }
 }
 
@@ -909,16 +910,14 @@ export interface ErrorInfo {
 
 export namespace ErrorInfo {
   export function isa(o: any): o is ErrorInfo {
-    return _smithy.isa(o, "ErrorInfo");
+    return __isa(o, "ErrorInfo");
   }
 }
 
 /**
  * <p>Returns information about an error.</p>
  */
-export interface ForbiddenException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface ForbiddenException extends __SmithyException, $MetadataBearer {
   name: "ForbiddenException";
   $fault: "client";
   /**
@@ -934,7 +933,7 @@ export interface ForbiddenException
 
 export namespace ForbiddenException {
   export function isa(o: any): o is ForbiddenException {
-    return _smithy.isa(o, "ForbiddenException");
+    return __isa(o, "ForbiddenException");
   }
 }
 
@@ -948,7 +947,7 @@ export interface GetBootstrapBrokersRequest {
 
 export namespace GetBootstrapBrokersRequest {
   export function isa(o: any): o is GetBootstrapBrokersRequest {
-    return _smithy.isa(o, "GetBootstrapBrokersRequest");
+    return __isa(o, "GetBootstrapBrokersRequest");
   }
 }
 
@@ -967,7 +966,7 @@ export interface GetBootstrapBrokersResponse extends $MetadataBearer {
 
 export namespace GetBootstrapBrokersResponse {
   export function isa(o: any): o is GetBootstrapBrokersResponse {
-    return _smithy.isa(o, "GetBootstrapBrokersResponse");
+    return __isa(o, "GetBootstrapBrokersResponse");
   }
 }
 
@@ -975,7 +974,7 @@ export namespace GetBootstrapBrokersResponse {
  * <p>Returns information about an error.</p>
  */
 export interface InternalServerErrorException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalServerErrorException";
   $fault: "server";
@@ -992,7 +991,7 @@ export interface InternalServerErrorException
 
 export namespace InternalServerErrorException {
   export function isa(o: any): o is InternalServerErrorException {
-    return _smithy.isa(o, "InternalServerErrorException");
+    return __isa(o, "InternalServerErrorException");
   }
 }
 
@@ -1009,7 +1008,7 @@ export interface JmxExporter {
 
 export namespace JmxExporter {
   export function isa(o: any): o is JmxExporter {
-    return _smithy.isa(o, "JmxExporter");
+    return __isa(o, "JmxExporter");
   }
 }
 
@@ -1026,7 +1025,7 @@ export interface JmxExporterInfo {
 
 export namespace JmxExporterInfo {
   export function isa(o: any): o is JmxExporterInfo {
-    return _smithy.isa(o, "JmxExporterInfo");
+    return __isa(o, "JmxExporterInfo");
   }
 }
 
@@ -1051,7 +1050,7 @@ export interface ListClusterOperationsRequest {
 
 export namespace ListClusterOperationsRequest {
   export function isa(o: any): o is ListClusterOperationsRequest {
-    return _smithy.isa(o, "ListClusterOperationsRequest");
+    return __isa(o, "ListClusterOperationsRequest");
   }
 }
 
@@ -1070,7 +1069,7 @@ export interface ListClusterOperationsResponse extends $MetadataBearer {
 
 export namespace ListClusterOperationsResponse {
   export function isa(o: any): o is ListClusterOperationsResponse {
-    return _smithy.isa(o, "ListClusterOperationsResponse");
+    return __isa(o, "ListClusterOperationsResponse");
   }
 }
 
@@ -1095,7 +1094,7 @@ export interface ListClustersRequest {
 
 export namespace ListClustersRequest {
   export function isa(o: any): o is ListClustersRequest {
-    return _smithy.isa(o, "ListClustersRequest");
+    return __isa(o, "ListClustersRequest");
   }
 }
 
@@ -1115,7 +1114,7 @@ export interface ListClustersResponse extends $MetadataBearer {
 
 export namespace ListClustersResponse {
   export function isa(o: any): o is ListClustersResponse {
-    return _smithy.isa(o, "ListClustersResponse");
+    return __isa(o, "ListClustersResponse");
   }
 }
 
@@ -1140,7 +1139,7 @@ export interface ListConfigurationRevisionsRequest {
 
 export namespace ListConfigurationRevisionsRequest {
   export function isa(o: any): o is ListConfigurationRevisionsRequest {
-    return _smithy.isa(o, "ListConfigurationRevisionsRequest");
+    return __isa(o, "ListConfigurationRevisionsRequest");
   }
 }
 
@@ -1159,7 +1158,7 @@ export interface ListConfigurationRevisionsResponse extends $MetadataBearer {
 
 export namespace ListConfigurationRevisionsResponse {
   export function isa(o: any): o is ListConfigurationRevisionsResponse {
-    return _smithy.isa(o, "ListConfigurationRevisionsResponse");
+    return __isa(o, "ListConfigurationRevisionsResponse");
   }
 }
 
@@ -1179,7 +1178,7 @@ export interface ListConfigurationsRequest {
 
 export namespace ListConfigurationsRequest {
   export function isa(o: any): o is ListConfigurationsRequest {
-    return _smithy.isa(o, "ListConfigurationsRequest");
+    return __isa(o, "ListConfigurationsRequest");
   }
 }
 
@@ -1199,7 +1198,7 @@ export interface ListConfigurationsResponse extends $MetadataBearer {
 
 export namespace ListConfigurationsResponse {
   export function isa(o: any): o is ListConfigurationsResponse {
-    return _smithy.isa(o, "ListConfigurationsResponse");
+    return __isa(o, "ListConfigurationsResponse");
   }
 }
 
@@ -1224,7 +1223,7 @@ export interface ListNodesRequest {
 
 export namespace ListNodesRequest {
   export function isa(o: any): o is ListNodesRequest {
-    return _smithy.isa(o, "ListNodesRequest");
+    return __isa(o, "ListNodesRequest");
   }
 }
 
@@ -1244,7 +1243,7 @@ export interface ListNodesResponse extends $MetadataBearer {
 
 export namespace ListNodesResponse {
   export function isa(o: any): o is ListNodesResponse {
-    return _smithy.isa(o, "ListNodesResponse");
+    return __isa(o, "ListNodesResponse");
   }
 }
 
@@ -1258,7 +1257,7 @@ export interface ListTagsForResourceRequest {
 
 export namespace ListTagsForResourceRequest {
   export function isa(o: any): o is ListTagsForResourceRequest {
-    return _smithy.isa(o, "ListTagsForResourceRequest");
+    return __isa(o, "ListTagsForResourceRequest");
   }
 }
 
@@ -1272,7 +1271,7 @@ export interface ListTagsForResourceResponse extends $MetadataBearer {
 
 export namespace ListTagsForResourceResponse {
   export function isa(o: any): o is ListTagsForResourceResponse {
-    return _smithy.isa(o, "ListTagsForResourceResponse");
+    return __isa(o, "ListTagsForResourceResponse");
   }
 }
 
@@ -1309,7 +1308,7 @@ export interface MutableClusterInfo {
 
 export namespace MutableClusterInfo {
   export function isa(o: any): o is MutableClusterInfo {
-    return _smithy.isa(o, "MutableClusterInfo");
+    return __isa(o, "MutableClusterInfo");
   }
 }
 
@@ -1326,7 +1325,7 @@ export interface NodeExporter {
 
 export namespace NodeExporter {
   export function isa(o: any): o is NodeExporter {
-    return _smithy.isa(o, "NodeExporter");
+    return __isa(o, "NodeExporter");
   }
 }
 
@@ -1343,7 +1342,7 @@ export interface NodeExporterInfo {
 
 export namespace NodeExporterInfo {
   export function isa(o: any): o is NodeExporterInfo {
-    return _smithy.isa(o, "NodeExporterInfo");
+    return __isa(o, "NodeExporterInfo");
   }
 }
 
@@ -1385,7 +1384,7 @@ export interface NodeInfo {
 
 export namespace NodeInfo {
   export function isa(o: any): o is NodeInfo {
-    return _smithy.isa(o, "NodeInfo");
+    return __isa(o, "NodeInfo");
   }
 }
 
@@ -1396,9 +1395,7 @@ export enum NodeType {
 /**
  * <p>Returns information about an error.</p>
  */
-export interface NotFoundException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface NotFoundException extends __SmithyException, $MetadataBearer {
   name: "NotFoundException";
   $fault: "client";
   /**
@@ -1414,7 +1411,7 @@ export interface NotFoundException
 
 export namespace NotFoundException {
   export function isa(o: any): o is NotFoundException {
-    return _smithy.isa(o, "NotFoundException");
+    return __isa(o, "NotFoundException");
   }
 }
 
@@ -1431,7 +1428,7 @@ export interface OpenMonitoring {
 
 export namespace OpenMonitoring {
   export function isa(o: any): o is OpenMonitoring {
-    return _smithy.isa(o, "OpenMonitoring");
+    return __isa(o, "OpenMonitoring");
   }
 }
 
@@ -1448,7 +1445,7 @@ export interface OpenMonitoringInfo {
 
 export namespace OpenMonitoringInfo {
   export function isa(o: any): o is OpenMonitoringInfo {
-    return _smithy.isa(o, "OpenMonitoringInfo");
+    return __isa(o, "OpenMonitoringInfo");
   }
 }
 
@@ -1470,7 +1467,7 @@ export interface Prometheus {
 
 export namespace Prometheus {
   export function isa(o: any): o is Prometheus {
-    return _smithy.isa(o, "Prometheus");
+    return __isa(o, "Prometheus");
   }
 }
 
@@ -1492,7 +1489,7 @@ export interface PrometheusInfo {
 
 export namespace PrometheusInfo {
   export function isa(o: any): o is PrometheusInfo {
-    return _smithy.isa(o, "PrometheusInfo");
+    return __isa(o, "PrometheusInfo");
   }
 }
 
@@ -1500,7 +1497,7 @@ export namespace PrometheusInfo {
  * <p>Returns information about an error.</p>
  */
 export interface ServiceUnavailableException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ServiceUnavailableException";
   $fault: "server";
@@ -1517,7 +1514,7 @@ export interface ServiceUnavailableException
 
 export namespace ServiceUnavailableException {
   export function isa(o: any): o is ServiceUnavailableException {
-    return _smithy.isa(o, "ServiceUnavailableException");
+    return __isa(o, "ServiceUnavailableException");
   }
 }
 
@@ -1534,7 +1531,7 @@ export interface StorageInfo {
 
 export namespace StorageInfo {
   export function isa(o: any): o is StorageInfo {
-    return _smithy.isa(o, "StorageInfo");
+    return __isa(o, "StorageInfo");
   }
 }
 
@@ -1553,7 +1550,7 @@ export interface TagResourceRequest {
 
 export namespace TagResourceRequest {
   export function isa(o: any): o is TagResourceRequest {
-    return _smithy.isa(o, "TagResourceRequest");
+    return __isa(o, "TagResourceRequest");
   }
 }
 
@@ -1570,7 +1567,7 @@ export interface Tls {
 
 export namespace Tls {
   export function isa(o: any): o is Tls {
-    return _smithy.isa(o, "Tls");
+    return __isa(o, "Tls");
   }
 }
 
@@ -1578,7 +1575,7 @@ export namespace Tls {
  * <p>Returns information about an error.</p>
  */
 export interface TooManyRequestsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyRequestsException";
   $fault: "client";
@@ -1595,7 +1592,7 @@ export interface TooManyRequestsException
 
 export namespace TooManyRequestsException {
   export function isa(o: any): o is TooManyRequestsException {
-    return _smithy.isa(o, "TooManyRequestsException");
+    return __isa(o, "TooManyRequestsException");
   }
 }
 
@@ -1603,7 +1600,7 @@ export namespace TooManyRequestsException {
  * <p>Returns information about an error.</p>
  */
 export interface UnauthorizedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UnauthorizedException";
   $fault: "client";
@@ -1620,7 +1617,7 @@ export interface UnauthorizedException
 
 export namespace UnauthorizedException {
   export function isa(o: any): o is UnauthorizedException {
-    return _smithy.isa(o, "UnauthorizedException");
+    return __isa(o, "UnauthorizedException");
   }
 }
 
@@ -1658,7 +1655,7 @@ export interface UntagResourceRequest {
 
 export namespace UntagResourceRequest {
   export function isa(o: any): o is UntagResourceRequest {
-    return _smithy.isa(o, "UntagResourceRequest");
+    return __isa(o, "UntagResourceRequest");
   }
 }
 
@@ -1682,7 +1679,7 @@ export interface UpdateBrokerCountRequest {
 
 export namespace UpdateBrokerCountRequest {
   export function isa(o: any): o is UpdateBrokerCountRequest {
-    return _smithy.isa(o, "UpdateBrokerCountRequest");
+    return __isa(o, "UpdateBrokerCountRequest");
   }
 }
 
@@ -1701,7 +1698,7 @@ export interface UpdateBrokerCountResponse extends $MetadataBearer {
 
 export namespace UpdateBrokerCountResponse {
   export function isa(o: any): o is UpdateBrokerCountResponse {
-    return _smithy.isa(o, "UpdateBrokerCountResponse");
+    return __isa(o, "UpdateBrokerCountResponse");
   }
 }
 
@@ -1725,7 +1722,7 @@ export interface UpdateBrokerStorageRequest {
 
 export namespace UpdateBrokerStorageRequest {
   export function isa(o: any): o is UpdateBrokerStorageRequest {
-    return _smithy.isa(o, "UpdateBrokerStorageRequest");
+    return __isa(o, "UpdateBrokerStorageRequest");
   }
 }
 
@@ -1744,7 +1741,7 @@ export interface UpdateBrokerStorageResponse extends $MetadataBearer {
 
 export namespace UpdateBrokerStorageResponse {
   export function isa(o: any): o is UpdateBrokerStorageResponse {
-    return _smithy.isa(o, "UpdateBrokerStorageResponse");
+    return __isa(o, "UpdateBrokerStorageResponse");
   }
 }
 
@@ -1768,7 +1765,7 @@ export interface UpdateClusterConfigurationRequest {
 
 export namespace UpdateClusterConfigurationRequest {
   export function isa(o: any): o is UpdateClusterConfigurationRequest {
-    return _smithy.isa(o, "UpdateClusterConfigurationRequest");
+    return __isa(o, "UpdateClusterConfigurationRequest");
   }
 }
 
@@ -1787,7 +1784,7 @@ export interface UpdateClusterConfigurationResponse extends $MetadataBearer {
 
 export namespace UpdateClusterConfigurationResponse {
   export function isa(o: any): o is UpdateClusterConfigurationResponse {
-    return _smithy.isa(o, "UpdateClusterConfigurationResponse");
+    return __isa(o, "UpdateClusterConfigurationResponse");
   }
 }
 
@@ -1819,7 +1816,7 @@ export interface UpdateMonitoringRequest {
 
 export namespace UpdateMonitoringRequest {
   export function isa(o: any): o is UpdateMonitoringRequest {
-    return _smithy.isa(o, "UpdateMonitoringRequest");
+    return __isa(o, "UpdateMonitoringRequest");
   }
 }
 
@@ -1838,7 +1835,7 @@ export interface UpdateMonitoringResponse extends $MetadataBearer {
 
 export namespace UpdateMonitoringResponse {
   export function isa(o: any): o is UpdateMonitoringResponse {
-    return _smithy.isa(o, "UpdateMonitoringResponse");
+    return __isa(o, "UpdateMonitoringResponse");
   }
 }
 
@@ -1875,6 +1872,6 @@ export interface ZookeeperNodeInfo {
 
 export namespace ZookeeperNodeInfo {
   export function isa(o: any): o is ZookeeperNodeInfo {
-    return _smithy.isa(o, "ZookeeperNodeInfo");
+    return __isa(o, "ZookeeperNodeInfo");
   }
 }

--- a/clients/client-kafka/protocols/Aws_restJson1_1.ts
+++ b/clients/client-kafka/protocols/Aws_restJson1_1.ts
@@ -120,7 +120,10 @@ import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  extendedEncodeURIComponent as __extendedEncodeURIComponent
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -245,20 +248,22 @@ export async function serializeAws_restJson1_1DeleteClusterCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/clusters/{ClusterArn}";
   if (input.ClusterArn !== undefined) {
-    const labelValue: string = input.ClusterArn.toString();
+    const labelValue: string = input.ClusterArn;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ClusterArn.");
     }
     resolvedPath = resolvedPath.replace(
       "{ClusterArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ClusterArn.");
   }
   const query: any = {};
   if (input.CurrentVersion !== undefined) {
-    query["currentVersion"] = input.CurrentVersion.toString();
+    query[
+      __extendedEncodeURIComponent("currentVersion")
+    ] = __extendedEncodeURIComponent(input.CurrentVersion);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -278,13 +283,13 @@ export async function serializeAws_restJson1_1DescribeClusterCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/clusters/{ClusterArn}";
   if (input.ClusterArn !== undefined) {
-    const labelValue: string = input.ClusterArn.toString();
+    const labelValue: string = input.ClusterArn;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ClusterArn.");
     }
     resolvedPath = resolvedPath.replace(
       "{ClusterArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ClusterArn.");
@@ -306,7 +311,7 @@ export async function serializeAws_restJson1_1DescribeClusterOperationCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/operations/{ClusterOperationArn}";
   if (input.ClusterOperationArn !== undefined) {
-    const labelValue: string = input.ClusterOperationArn.toString();
+    const labelValue: string = input.ClusterOperationArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ClusterOperationArn."
@@ -314,7 +319,7 @@ export async function serializeAws_restJson1_1DescribeClusterOperationCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ClusterOperationArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -338,13 +343,13 @@ export async function serializeAws_restJson1_1DescribeConfigurationCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/configurations/{Arn}";
   if (input.Arn !== undefined) {
-    const labelValue: string = input.Arn.toString();
+    const labelValue: string = input.Arn;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Arn.");
     }
     resolvedPath = resolvedPath.replace(
       "{Arn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Arn.");
@@ -366,13 +371,13 @@ export async function serializeAws_restJson1_1DescribeConfigurationRevisionComma
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/configurations/{Arn}/revisions/{Revision}";
   if (input.Arn !== undefined) {
-    const labelValue: string = input.Arn.toString();
+    const labelValue: string = input.Arn;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Arn.");
     }
     resolvedPath = resolvedPath.replace(
       "{Arn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Arn.");
@@ -384,7 +389,7 @@ export async function serializeAws_restJson1_1DescribeConfigurationRevisionComma
     }
     resolvedPath = resolvedPath.replace(
       "{Revision}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Revision.");
@@ -406,13 +411,13 @@ export async function serializeAws_restJson1_1GetBootstrapBrokersCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/clusters/{ClusterArn}/bootstrap-brokers";
   if (input.ClusterArn !== undefined) {
-    const labelValue: string = input.ClusterArn.toString();
+    const labelValue: string = input.ClusterArn;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ClusterArn.");
     }
     resolvedPath = resolvedPath.replace(
       "{ClusterArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ClusterArn.");
@@ -434,23 +439,27 @@ export async function serializeAws_restJson1_1ListClusterOperationsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/clusters/{ClusterArn}/operations";
   if (input.ClusterArn !== undefined) {
-    const labelValue: string = input.ClusterArn.toString();
+    const labelValue: string = input.ClusterArn;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ClusterArn.");
     }
     resolvedPath = resolvedPath.replace(
       "{ClusterArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ClusterArn.");
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -471,13 +480,19 @@ export async function serializeAws_restJson1_1ListClustersCommand(
   let resolvedPath = "/v1/clusters";
   const query: any = {};
   if (input.ClusterNameFilter !== undefined) {
-    query["clusterNameFilter"] = input.ClusterNameFilter.toString();
+    query[
+      __extendedEncodeURIComponent("clusterNameFilter")
+    ] = __extendedEncodeURIComponent(input.ClusterNameFilter);
   }
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -497,23 +512,27 @@ export async function serializeAws_restJson1_1ListConfigurationRevisionsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/configurations/{Arn}/revisions";
   if (input.Arn !== undefined) {
-    const labelValue: string = input.Arn.toString();
+    const labelValue: string = input.Arn;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Arn.");
     }
     resolvedPath = resolvedPath.replace(
       "{Arn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Arn.");
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -534,10 +553,14 @@ export async function serializeAws_restJson1_1ListConfigurationsCommand(
   let resolvedPath = "/v1/configurations";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -557,23 +580,27 @@ export async function serializeAws_restJson1_1ListNodesCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/clusters/{ClusterArn}/nodes";
   if (input.ClusterArn !== undefined) {
-    const labelValue: string = input.ClusterArn.toString();
+    const labelValue: string = input.ClusterArn;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ClusterArn.");
     }
     resolvedPath = resolvedPath.replace(
       "{ClusterArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ClusterArn.");
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -593,7 +620,7 @@ export async function serializeAws_restJson1_1ListTagsForResourceCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/tags/{ResourceArn}";
   if (input.ResourceArn !== undefined) {
-    const labelValue: string = input.ResourceArn.toString();
+    const labelValue: string = input.ResourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ResourceArn."
@@ -601,7 +628,7 @@ export async function serializeAws_restJson1_1ListTagsForResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ResourceArn.");
@@ -623,7 +650,7 @@ export async function serializeAws_restJson1_1TagResourceCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v1/tags/{ResourceArn}";
   if (input.ResourceArn !== undefined) {
-    const labelValue: string = input.ResourceArn.toString();
+    const labelValue: string = input.ResourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ResourceArn."
@@ -631,7 +658,7 @@ export async function serializeAws_restJson1_1TagResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ResourceArn.");
@@ -663,7 +690,7 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/tags/{ResourceArn}";
   if (input.ResourceArn !== undefined) {
-    const labelValue: string = input.ResourceArn.toString();
+    const labelValue: string = input.ResourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ResourceArn."
@@ -671,14 +698,16 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ResourceArn.");
   }
   const query: any = {};
   if (input.TagKeys !== undefined) {
-    query["tagKeys"] = input.TagKeys;
+    query[__extendedEncodeURIComponent("tagKeys")] = input.TagKeys.map(entry =>
+      __extendedEncodeURIComponent(entry)
+    );
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -698,13 +727,13 @@ export async function serializeAws_restJson1_1UpdateBrokerCountCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v1/clusters/{ClusterArn}/nodes/count";
   if (input.ClusterArn !== undefined) {
-    const labelValue: string = input.ClusterArn.toString();
+    const labelValue: string = input.ClusterArn;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ClusterArn.");
     }
     resolvedPath = resolvedPath.replace(
       "{ClusterArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ClusterArn.");
@@ -736,13 +765,13 @@ export async function serializeAws_restJson1_1UpdateBrokerStorageCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v1/clusters/{ClusterArn}/nodes/storage";
   if (input.ClusterArn !== undefined) {
-    const labelValue: string = input.ClusterArn.toString();
+    const labelValue: string = input.ClusterArn;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ClusterArn.");
     }
     resolvedPath = resolvedPath.replace(
       "{ClusterArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ClusterArn.");
@@ -779,13 +808,13 @@ export async function serializeAws_restJson1_1UpdateClusterConfigurationCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v1/clusters/{ClusterArn}/configuration";
   if (input.ClusterArn !== undefined) {
-    const labelValue: string = input.ClusterArn.toString();
+    const labelValue: string = input.ClusterArn;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ClusterArn.");
     }
     resolvedPath = resolvedPath.replace(
       "{ClusterArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ClusterArn.");
@@ -820,13 +849,13 @@ export async function serializeAws_restJson1_1UpdateMonitoringCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v1/clusters/{ClusterArn}/monitoring";
   if (input.ClusterArn !== undefined) {
-    const labelValue: string = input.ClusterArn.toString();
+    const labelValue: string = input.ClusterArn;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ClusterArn.");
     }
     resolvedPath = resolvedPath.replace(
       "{ClusterArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ClusterArn.");
@@ -2166,6 +2195,7 @@ export async function deserializeAws_restJson1_1TagResourceCommand(
   const contents: TagResourceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2227,6 +2257,7 @@ export async function deserializeAws_restJson1_1UntagResourceCommand(
   const contents: UntagResourceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 

--- a/clients/client-kendra/models/index.ts
+++ b/clients/client-kendra/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -14,7 +17,7 @@ export interface AccessControlListConfiguration {
 
 export namespace AccessControlListConfiguration {
   export function isa(o: any): o is AccessControlListConfiguration {
-    return _smithy.isa(o, "AccessControlListConfiguration");
+    return __isa(o, "AccessControlListConfiguration");
   }
 }
 
@@ -22,7 +25,7 @@ export namespace AccessControlListConfiguration {
  * <p></p>
  */
 export interface AccessDeniedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AccessDeniedException";
   $fault: "client";
@@ -31,7 +34,7 @@ export interface AccessDeniedException
 
 export namespace AccessDeniedException {
   export function isa(o: any): o is AccessDeniedException {
-    return _smithy.isa(o, "AccessDeniedException");
+    return __isa(o, "AccessDeniedException");
   }
 }
 
@@ -52,7 +55,7 @@ export interface AclConfiguration {
 
 export namespace AclConfiguration {
   export function isa(o: any): o is AclConfiguration {
-    return _smithy.isa(o, "AclConfiguration");
+    return __isa(o, "AclConfiguration");
   }
 }
 
@@ -79,7 +82,7 @@ export interface AdditionalResultAttribute {
 
 export namespace AdditionalResultAttribute {
   export function isa(o: any): o is AdditionalResultAttribute {
-    return _smithy.isa(o, "AdditionalResultAttribute");
+    return __isa(o, "AdditionalResultAttribute");
   }
 }
 
@@ -97,7 +100,7 @@ export interface AdditionalResultAttributeValue {
 
 export namespace AdditionalResultAttributeValue {
   export function isa(o: any): o is AdditionalResultAttributeValue {
-    return _smithy.isa(o, "AdditionalResultAttributeValue");
+    return __isa(o, "AdditionalResultAttributeValue");
   }
 }
 
@@ -167,7 +170,7 @@ export interface AttributeFilter {
 
 export namespace AttributeFilter {
   export function isa(o: any): o is AttributeFilter {
-    return _smithy.isa(o, "AttributeFilter");
+    return __isa(o, "AttributeFilter");
   }
 }
 
@@ -186,7 +189,7 @@ export interface BatchDeleteDocumentRequest {
 
 export namespace BatchDeleteDocumentRequest {
   export function isa(o: any): o is BatchDeleteDocumentRequest {
-    return _smithy.isa(o, "BatchDeleteDocumentRequest");
+    return __isa(o, "BatchDeleteDocumentRequest");
   }
 }
 
@@ -201,7 +204,7 @@ export interface BatchDeleteDocumentResponse extends $MetadataBearer {
 
 export namespace BatchDeleteDocumentResponse {
   export function isa(o: any): o is BatchDeleteDocumentResponse {
-    return _smithy.isa(o, "BatchDeleteDocumentResponse");
+    return __isa(o, "BatchDeleteDocumentResponse");
   }
 }
 
@@ -229,7 +232,7 @@ export interface BatchDeleteDocumentResponseFailedDocument {
 
 export namespace BatchDeleteDocumentResponseFailedDocument {
   export function isa(o: any): o is BatchDeleteDocumentResponseFailedDocument {
-    return _smithy.isa(o, "BatchDeleteDocumentResponseFailedDocument");
+    return __isa(o, "BatchDeleteDocumentResponseFailedDocument");
   }
 }
 
@@ -257,7 +260,7 @@ export interface BatchPutDocumentRequest {
 
 export namespace BatchPutDocumentRequest {
   export function isa(o: any): o is BatchPutDocumentRequest {
-    return _smithy.isa(o, "BatchPutDocumentRequest");
+    return __isa(o, "BatchPutDocumentRequest");
   }
 }
 
@@ -275,7 +278,7 @@ export interface BatchPutDocumentResponse extends $MetadataBearer {
 
 export namespace BatchPutDocumentResponse {
   export function isa(o: any): o is BatchPutDocumentResponse {
-    return _smithy.isa(o, "BatchPutDocumentResponse");
+    return __isa(o, "BatchPutDocumentResponse");
   }
 }
 
@@ -302,7 +305,7 @@ export interface BatchPutDocumentResponseFailedDocument {
 
 export namespace BatchPutDocumentResponseFailedDocument {
   export function isa(o: any): o is BatchPutDocumentResponseFailedDocument {
-    return _smithy.isa(o, "BatchPutDocumentResponseFailedDocument");
+    return __isa(o, "BatchPutDocumentResponseFailedDocument");
   }
 }
 
@@ -326,7 +329,7 @@ export interface ClickFeedback {
 
 export namespace ClickFeedback {
   export function isa(o: any): o is ClickFeedback {
-    return _smithy.isa(o, "ClickFeedback");
+    return __isa(o, "ClickFeedback");
   }
 }
 
@@ -365,16 +368,14 @@ export interface ColumnConfiguration {
 
 export namespace ColumnConfiguration {
   export function isa(o: any): o is ColumnConfiguration {
-    return _smithy.isa(o, "ColumnConfiguration");
+    return __isa(o, "ColumnConfiguration");
   }
 }
 
 /**
  * <p></p>
  */
-export interface ConflictException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface ConflictException extends __SmithyException, $MetadataBearer {
   name: "ConflictException";
   $fault: "client";
   Message?: string;
@@ -382,7 +383,7 @@ export interface ConflictException
 
 export namespace ConflictException {
   export function isa(o: any): o is ConflictException {
-    return _smithy.isa(o, "ConflictException");
+    return __isa(o, "ConflictException");
   }
 }
 
@@ -425,7 +426,7 @@ export interface ConnectionConfiguration {
 
 export namespace ConnectionConfiguration {
   export function isa(o: any): o is ConnectionConfiguration {
-    return _smithy.isa(o, "ConnectionConfiguration");
+    return __isa(o, "ConnectionConfiguration");
   }
 }
 
@@ -483,7 +484,7 @@ export interface CreateDataSourceRequest {
 
 export namespace CreateDataSourceRequest {
   export function isa(o: any): o is CreateDataSourceRequest {
-    return _smithy.isa(o, "CreateDataSourceRequest");
+    return __isa(o, "CreateDataSourceRequest");
   }
 }
 
@@ -497,7 +498,7 @@ export interface CreateDataSourceResponse extends $MetadataBearer {
 
 export namespace CreateDataSourceResponse {
   export function isa(o: any): o is CreateDataSourceResponse {
-    return _smithy.isa(o, "CreateDataSourceResponse");
+    return __isa(o, "CreateDataSourceResponse");
   }
 }
 
@@ -533,7 +534,7 @@ export interface CreateFaqRequest {
 
 export namespace CreateFaqRequest {
   export function isa(o: any): o is CreateFaqRequest {
-    return _smithy.isa(o, "CreateFaqRequest");
+    return __isa(o, "CreateFaqRequest");
   }
 }
 
@@ -547,7 +548,7 @@ export interface CreateFaqResponse extends $MetadataBearer {
 
 export namespace CreateFaqResponse {
   export function isa(o: any): o is CreateFaqResponse {
-    return _smithy.isa(o, "CreateFaqResponse");
+    return __isa(o, "CreateFaqResponse");
   }
 }
 
@@ -579,7 +580,7 @@ export interface CreateIndexRequest {
 
 export namespace CreateIndexRequest {
   export function isa(o: any): o is CreateIndexRequest {
-    return _smithy.isa(o, "CreateIndexRequest");
+    return __isa(o, "CreateIndexRequest");
   }
 }
 
@@ -594,7 +595,7 @@ export interface CreateIndexResponse extends $MetadataBearer {
 
 export namespace CreateIndexResponse {
   export function isa(o: any): o is CreateIndexResponse {
-    return _smithy.isa(o, "CreateIndexResponse");
+    return __isa(o, "CreateIndexResponse");
   }
 }
 
@@ -623,7 +624,7 @@ export interface DataSourceConfiguration {
 
 export namespace DataSourceConfiguration {
   export function isa(o: any): o is DataSourceConfiguration {
-    return _smithy.isa(o, "DataSourceConfiguration");
+    return __isa(o, "DataSourceConfiguration");
   }
 }
 
@@ -674,7 +675,7 @@ export interface DataSourceSummary {
 
 export namespace DataSourceSummary {
   export function isa(o: any): o is DataSourceSummary {
-    return _smithy.isa(o, "DataSourceSummary");
+    return __isa(o, "DataSourceSummary");
   }
 }
 
@@ -729,7 +730,7 @@ export interface DataSourceSyncJob {
 
 export namespace DataSourceSyncJob {
   export function isa(o: any): o is DataSourceSyncJob {
-    return _smithy.isa(o, "DataSourceSyncJob");
+    return __isa(o, "DataSourceSyncJob");
   }
 }
 
@@ -766,7 +767,7 @@ export interface DataSourceToIndexFieldMapping {
 
 export namespace DataSourceToIndexFieldMapping {
   export function isa(o: any): o is DataSourceToIndexFieldMapping {
-    return _smithy.isa(o, "DataSourceToIndexFieldMapping");
+    return __isa(o, "DataSourceToIndexFieldMapping");
   }
 }
 
@@ -797,7 +798,7 @@ export interface DataSourceVpcConfiguration {
 
 export namespace DataSourceVpcConfiguration {
   export function isa(o: any): o is DataSourceVpcConfiguration {
-    return _smithy.isa(o, "DataSourceVpcConfiguration");
+    return __isa(o, "DataSourceVpcConfiguration");
   }
 }
 
@@ -836,7 +837,7 @@ export interface DatabaseConfiguration {
 
 export namespace DatabaseConfiguration {
   export function isa(o: any): o is DatabaseConfiguration {
-    return _smithy.isa(o, "DatabaseConfiguration");
+    return __isa(o, "DatabaseConfiguration");
   }
 }
 
@@ -862,7 +863,7 @@ export interface DeleteFaqRequest {
 
 export namespace DeleteFaqRequest {
   export function isa(o: any): o is DeleteFaqRequest {
-    return _smithy.isa(o, "DeleteFaqRequest");
+    return __isa(o, "DeleteFaqRequest");
   }
 }
 
@@ -876,7 +877,7 @@ export interface DeleteIndexRequest {
 
 export namespace DeleteIndexRequest {
   export function isa(o: any): o is DeleteIndexRequest {
-    return _smithy.isa(o, "DeleteIndexRequest");
+    return __isa(o, "DeleteIndexRequest");
   }
 }
 
@@ -895,7 +896,7 @@ export interface DescribeDataSourceRequest {
 
 export namespace DescribeDataSourceRequest {
   export function isa(o: any): o is DescribeDataSourceRequest {
-    return _smithy.isa(o, "DescribeDataSourceRequest");
+    return __isa(o, "DescribeDataSourceRequest");
   }
 }
 
@@ -971,7 +972,7 @@ export interface DescribeDataSourceResponse extends $MetadataBearer {
 
 export namespace DescribeDataSourceResponse {
   export function isa(o: any): o is DescribeDataSourceResponse {
-    return _smithy.isa(o, "DescribeDataSourceResponse");
+    return __isa(o, "DescribeDataSourceResponse");
   }
 }
 
@@ -990,7 +991,7 @@ export interface DescribeFaqRequest {
 
 export namespace DescribeFaqRequest {
   export function isa(o: any): o is DescribeFaqRequest {
-    return _smithy.isa(o, "DescribeFaqRequest");
+    return __isa(o, "DescribeFaqRequest");
   }
 }
 
@@ -1052,7 +1053,7 @@ export interface DescribeFaqResponse extends $MetadataBearer {
 
 export namespace DescribeFaqResponse {
   export function isa(o: any): o is DescribeFaqResponse {
-    return _smithy.isa(o, "DescribeFaqResponse");
+    return __isa(o, "DescribeFaqResponse");
   }
 }
 
@@ -1066,7 +1067,7 @@ export interface DescribeIndexRequest {
 
 export namespace DescribeIndexRequest {
   export function isa(o: any): o is DescribeIndexRequest {
-    return _smithy.isa(o, "DescribeIndexRequest");
+    return __isa(o, "DescribeIndexRequest");
   }
 }
 
@@ -1136,7 +1137,7 @@ export interface DescribeIndexResponse extends $MetadataBearer {
 
 export namespace DescribeIndexResponse {
   export function isa(o: any): o is DescribeIndexResponse {
-    return _smithy.isa(o, "DescribeIndexResponse");
+    return __isa(o, "DescribeIndexResponse");
   }
 }
 
@@ -1185,7 +1186,7 @@ export interface Document {
 
 export namespace Document {
   export function isa(o: any): o is Document {
-    return _smithy.isa(o, "Document");
+    return __isa(o, "Document");
   }
 }
 
@@ -1207,7 +1208,7 @@ export interface DocumentAttribute {
 
 export namespace DocumentAttribute {
   export function isa(o: any): o is DocumentAttribute {
-    return _smithy.isa(o, "DocumentAttribute");
+    return __isa(o, "DocumentAttribute");
   }
 }
 
@@ -1240,7 +1241,7 @@ export interface DocumentAttributeValue {
 
 export namespace DocumentAttributeValue {
   export function isa(o: any): o is DocumentAttributeValue {
-    return _smithy.isa(o, "DocumentAttributeValue");
+    return __isa(o, "DocumentAttributeValue");
   }
 }
 
@@ -1264,7 +1265,7 @@ export interface DocumentAttributeValueCountPair {
 
 export namespace DocumentAttributeValueCountPair {
   export function isa(o: any): o is DocumentAttributeValueCountPair {
-    return _smithy.isa(o, "DocumentAttributeValueCountPair");
+    return __isa(o, "DocumentAttributeValueCountPair");
   }
 }
 
@@ -1304,7 +1305,7 @@ export interface DocumentMetadataConfiguration {
 
 export namespace DocumentMetadataConfiguration {
   export function isa(o: any): o is DocumentMetadataConfiguration {
-    return _smithy.isa(o, "DocumentMetadataConfiguration");
+    return __isa(o, "DocumentMetadataConfiguration");
   }
 }
 
@@ -1325,7 +1326,7 @@ export interface DocumentsMetadataConfiguration {
 
 export namespace DocumentsMetadataConfiguration {
   export function isa(o: any): o is DocumentsMetadataConfiguration {
-    return _smithy.isa(o, "DocumentsMetadataConfiguration");
+    return __isa(o, "DocumentsMetadataConfiguration");
   }
 }
 
@@ -1347,7 +1348,7 @@ export interface Facet {
 
 export namespace Facet {
   export function isa(o: any): o is Facet {
-    return _smithy.isa(o, "Facet");
+    return __isa(o, "Facet");
   }
 }
 
@@ -1371,7 +1372,7 @@ export interface FacetResult {
 
 export namespace FacetResult {
   export function isa(o: any): o is FacetResult {
-    return _smithy.isa(o, "FacetResult");
+    return __isa(o, "FacetResult");
   }
 }
 
@@ -1389,7 +1390,7 @@ export interface FaqStatistics {
 
 export namespace FaqStatistics {
   export function isa(o: any): o is FaqStatistics {
-    return _smithy.isa(o, "FaqStatistics");
+    return __isa(o, "FaqStatistics");
   }
 }
 
@@ -1436,7 +1437,7 @@ export interface FaqSummary {
 
 export namespace FaqSummary {
   export function isa(o: any): o is FaqSummary {
-    return _smithy.isa(o, "FaqSummary");
+    return __isa(o, "FaqSummary");
   }
 }
 
@@ -1465,7 +1466,7 @@ export interface Highlight {
 
 export namespace Highlight {
   export function isa(o: any): o is Highlight {
-    return _smithy.isa(o, "Highlight");
+    return __isa(o, "Highlight");
   }
 }
 
@@ -1506,7 +1507,7 @@ export interface IndexConfigurationSummary {
 
 export namespace IndexConfigurationSummary {
   export function isa(o: any): o is IndexConfigurationSummary {
-    return _smithy.isa(o, "IndexConfigurationSummary");
+    return __isa(o, "IndexConfigurationSummary");
   }
 }
 
@@ -1529,7 +1530,7 @@ export interface IndexStatistics {
 
 export namespace IndexStatistics {
   export function isa(o: any): o is IndexStatistics {
-    return _smithy.isa(o, "IndexStatistics");
+    return __isa(o, "IndexStatistics");
   }
 }
 
@@ -1545,7 +1546,7 @@ export enum IndexStatus {
  * <p></p>
  */
 export interface InternalServerException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalServerException";
   $fault: "server";
@@ -1554,7 +1555,7 @@ export interface InternalServerException
 
 export namespace InternalServerException {
   export function isa(o: any): o is InternalServerException {
-    return _smithy.isa(o, "InternalServerException");
+    return __isa(o, "InternalServerException");
   }
 }
 
@@ -1597,7 +1598,7 @@ export interface ListDataSourceSyncJobsRequest {
 
 export namespace ListDataSourceSyncJobsRequest {
   export function isa(o: any): o is ListDataSourceSyncJobsRequest {
-    return _smithy.isa(o, "ListDataSourceSyncJobsRequest");
+    return __isa(o, "ListDataSourceSyncJobsRequest");
   }
 }
 
@@ -1620,7 +1621,7 @@ export interface ListDataSourceSyncJobsResponse extends $MetadataBearer {
 
 export namespace ListDataSourceSyncJobsResponse {
   export function isa(o: any): o is ListDataSourceSyncJobsResponse {
-    return _smithy.isa(o, "ListDataSourceSyncJobsResponse");
+    return __isa(o, "ListDataSourceSyncJobsResponse");
   }
 }
 
@@ -1646,7 +1647,7 @@ export interface ListDataSourcesRequest {
 
 export namespace ListDataSourcesRequest {
   export function isa(o: any): o is ListDataSourcesRequest {
-    return _smithy.isa(o, "ListDataSourcesRequest");
+    return __isa(o, "ListDataSourcesRequest");
   }
 }
 
@@ -1666,7 +1667,7 @@ export interface ListDataSourcesResponse extends $MetadataBearer {
 
 export namespace ListDataSourcesResponse {
   export function isa(o: any): o is ListDataSourcesResponse {
-    return _smithy.isa(o, "ListDataSourcesResponse");
+    return __isa(o, "ListDataSourcesResponse");
   }
 }
 
@@ -1692,7 +1693,7 @@ export interface ListFaqsRequest {
 
 export namespace ListFaqsRequest {
   export function isa(o: any): o is ListFaqsRequest {
-    return _smithy.isa(o, "ListFaqsRequest");
+    return __isa(o, "ListFaqsRequest");
   }
 }
 
@@ -1715,7 +1716,7 @@ export interface ListFaqsResponse extends $MetadataBearer {
 
 export namespace ListFaqsResponse {
   export function isa(o: any): o is ListFaqsResponse {
-    return _smithy.isa(o, "ListFaqsResponse");
+    return __isa(o, "ListFaqsResponse");
   }
 }
 
@@ -1736,7 +1737,7 @@ export interface ListIndicesRequest {
 
 export namespace ListIndicesRequest {
   export function isa(o: any): o is ListIndicesRequest {
-    return _smithy.isa(o, "ListIndicesRequest");
+    return __isa(o, "ListIndicesRequest");
   }
 }
 
@@ -1756,7 +1757,7 @@ export interface ListIndicesResponse extends $MetadataBearer {
 
 export namespace ListIndicesResponse {
   export function isa(o: any): o is ListIndicesResponse {
-    return _smithy.isa(o, "ListIndicesResponse");
+    return __isa(o, "ListIndicesResponse");
   }
 }
 
@@ -1788,7 +1789,7 @@ export interface Principal {
 
 export namespace Principal {
   export function isa(o: any): o is Principal {
-    return _smithy.isa(o, "Principal");
+    return __isa(o, "Principal");
   }
 }
 
@@ -1853,7 +1854,7 @@ export interface QueryRequest {
 
 export namespace QueryRequest {
   export function isa(o: any): o is QueryRequest {
-    return _smithy.isa(o, "QueryRequest");
+    return __isa(o, "QueryRequest");
   }
 }
 
@@ -1885,7 +1886,7 @@ export interface QueryResult extends $MetadataBearer {
 
 export namespace QueryResult {
   export function isa(o: any): o is QueryResult {
-    return _smithy.isa(o, "QueryResult");
+    return __isa(o, "QueryResult");
   }
 }
 
@@ -1943,7 +1944,7 @@ export interface QueryResultItem {
 
 export namespace QueryResultItem {
   export function isa(o: any): o is QueryResultItem {
-    return _smithy.isa(o, "QueryResultItem");
+    return __isa(o, "QueryResultItem");
   }
 }
 
@@ -2017,7 +2018,7 @@ export interface Relevance {
 
 export namespace Relevance {
   export function isa(o: any): o is Relevance {
-    return _smithy.isa(o, "Relevance");
+    return __isa(o, "Relevance");
   }
 }
 
@@ -2041,7 +2042,7 @@ export interface RelevanceFeedback {
 
 export namespace RelevanceFeedback {
   export function isa(o: any): o is RelevanceFeedback {
-    return _smithy.isa(o, "RelevanceFeedback");
+    return __isa(o, "RelevanceFeedback");
   }
 }
 
@@ -2054,7 +2055,7 @@ export enum RelevanceType {
  * <p></p>
  */
 export interface ResourceAlreadyExistException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceAlreadyExistException";
   $fault: "client";
@@ -2063,7 +2064,7 @@ export interface ResourceAlreadyExistException
 
 export namespace ResourceAlreadyExistException {
   export function isa(o: any): o is ResourceAlreadyExistException {
-    return _smithy.isa(o, "ResourceAlreadyExistException");
+    return __isa(o, "ResourceAlreadyExistException");
   }
 }
 
@@ -2071,7 +2072,7 @@ export namespace ResourceAlreadyExistException {
  * <p></p>
  */
 export interface ResourceInUseException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceInUseException";
   $fault: "client";
@@ -2080,7 +2081,7 @@ export interface ResourceInUseException
 
 export namespace ResourceInUseException {
   export function isa(o: any): o is ResourceInUseException {
-    return _smithy.isa(o, "ResourceInUseException");
+    return __isa(o, "ResourceInUseException");
   }
 }
 
@@ -2088,7 +2089,7 @@ export namespace ResourceInUseException {
  * <p></p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -2097,7 +2098,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -2105,7 +2106,7 @@ export namespace ResourceNotFoundException {
  * <p></p>
  */
 export interface ResourceUnavailableException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceUnavailableException";
   $fault: "client";
@@ -2114,7 +2115,7 @@ export interface ResourceUnavailableException
 
 export namespace ResourceUnavailableException {
   export function isa(o: any): o is ResourceUnavailableException {
-    return _smithy.isa(o, "ResourceUnavailableException");
+    return __isa(o, "ResourceUnavailableException");
   }
 }
 
@@ -2159,7 +2160,7 @@ export interface S3DataSourceConfiguration {
 
 export namespace S3DataSourceConfiguration {
   export function isa(o: any): o is S3DataSourceConfiguration {
-    return _smithy.isa(o, "S3DataSourceConfiguration");
+    return __isa(o, "S3DataSourceConfiguration");
   }
 }
 
@@ -2181,7 +2182,7 @@ export interface S3Path {
 
 export namespace S3Path {
   export function isa(o: any): o is S3Path {
-    return _smithy.isa(o, "S3Path");
+    return __isa(o, "S3Path");
   }
 }
 
@@ -2213,7 +2214,7 @@ export interface Search {
 
 export namespace Search {
   export function isa(o: any): o is Search {
-    return _smithy.isa(o, "Search");
+    return __isa(o, "Search");
   }
 }
 
@@ -2232,7 +2233,7 @@ export interface ServerSideEncryptionConfiguration {
 
 export namespace ServerSideEncryptionConfiguration {
   export function isa(o: any): o is ServerSideEncryptionConfiguration {
-    return _smithy.isa(o, "ServerSideEncryptionConfiguration");
+    return __isa(o, "ServerSideEncryptionConfiguration");
   }
 }
 
@@ -2240,7 +2241,7 @@ export namespace ServerSideEncryptionConfiguration {
  * <p></p>
  */
 export interface ServiceQuotaExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ServiceQuotaExceededException";
   $fault: "client";
@@ -2249,7 +2250,7 @@ export interface ServiceQuotaExceededException
 
 export namespace ServiceQuotaExceededException {
   export function isa(o: any): o is ServiceQuotaExceededException {
-    return _smithy.isa(o, "ServiceQuotaExceededException");
+    return __isa(o, "ServiceQuotaExceededException");
   }
 }
 
@@ -2308,7 +2309,7 @@ export interface SharePointConfiguration {
 
 export namespace SharePointConfiguration {
   export function isa(o: any): o is SharePointConfiguration {
-    return _smithy.isa(o, "SharePointConfiguration");
+    return __isa(o, "SharePointConfiguration");
   }
 }
 
@@ -2331,7 +2332,7 @@ export interface StartDataSourceSyncJobRequest {
 
 export namespace StartDataSourceSyncJobRequest {
   export function isa(o: any): o is StartDataSourceSyncJobRequest {
-    return _smithy.isa(o, "StartDataSourceSyncJobRequest");
+    return __isa(o, "StartDataSourceSyncJobRequest");
   }
 }
 
@@ -2345,7 +2346,7 @@ export interface StartDataSourceSyncJobResponse extends $MetadataBearer {
 
 export namespace StartDataSourceSyncJobResponse {
   export function isa(o: any): o is StartDataSourceSyncJobResponse {
-    return _smithy.isa(o, "StartDataSourceSyncJobResponse");
+    return __isa(o, "StartDataSourceSyncJobResponse");
   }
 }
 
@@ -2364,7 +2365,7 @@ export interface StopDataSourceSyncJobRequest {
 
 export namespace StopDataSourceSyncJobRequest {
   export function isa(o: any): o is StopDataSourceSyncJobRequest {
-    return _smithy.isa(o, "StopDataSourceSyncJobRequest");
+    return __isa(o, "StopDataSourceSyncJobRequest");
   }
 }
 
@@ -2396,7 +2397,7 @@ export interface SubmitFeedbackRequest {
 
 export namespace SubmitFeedbackRequest {
   export function isa(o: any): o is SubmitFeedbackRequest {
-    return _smithy.isa(o, "SubmitFeedbackRequest");
+    return __isa(o, "SubmitFeedbackRequest");
   }
 }
 
@@ -2413,7 +2414,7 @@ export interface TextDocumentStatistics {
 
 export namespace TextDocumentStatistics {
   export function isa(o: any): o is TextDocumentStatistics {
-    return _smithy.isa(o, "TextDocumentStatistics");
+    return __isa(o, "TextDocumentStatistics");
   }
 }
 
@@ -2435,7 +2436,7 @@ export interface TextWithHighlights {
 
 export namespace TextWithHighlights {
   export function isa(o: any): o is TextWithHighlights {
-    return _smithy.isa(o, "TextWithHighlights");
+    return __isa(o, "TextWithHighlights");
   }
 }
 
@@ -2443,7 +2444,7 @@ export namespace TextWithHighlights {
  * <p></p>
  */
 export interface ThrottlingException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ThrottlingException";
   $fault: "client";
@@ -2452,7 +2453,7 @@ export interface ThrottlingException
 
 export namespace ThrottlingException {
   export function isa(o: any): o is ThrottlingException {
-    return _smithy.isa(o, "ThrottlingException");
+    return __isa(o, "ThrottlingException");
   }
 }
 
@@ -2474,7 +2475,7 @@ export interface TimeRange {
 
 export namespace TimeRange {
   export function isa(o: any): o is TimeRange {
-    return _smithy.isa(o, "TimeRange");
+    return __isa(o, "TimeRange");
   }
 }
 
@@ -2520,7 +2521,7 @@ export interface UpdateDataSourceRequest {
 
 export namespace UpdateDataSourceRequest {
   export function isa(o: any): o is UpdateDataSourceRequest {
-    return _smithy.isa(o, "UpdateDataSourceRequest");
+    return __isa(o, "UpdateDataSourceRequest");
   }
 }
 
@@ -2554,7 +2555,7 @@ export interface UpdateIndexRequest {
 
 export namespace UpdateIndexRequest {
   export function isa(o: any): o is UpdateIndexRequest {
-    return _smithy.isa(o, "UpdateIndexRequest");
+    return __isa(o, "UpdateIndexRequest");
   }
 }
 
@@ -2562,7 +2563,7 @@ export namespace UpdateIndexRequest {
  * <p></p>
  */
 export interface ValidationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ValidationException";
   $fault: "client";
@@ -2571,6 +2572,6 @@ export interface ValidationException
 
 export namespace ValidationException {
   export function isa(o: any): o is ValidationException {
-    return _smithy.isa(o, "ValidationException");
+    return __isa(o, "ValidationException");
   }
 }

--- a/clients/client-kendra/protocols/Aws_json1_1.ts
+++ b/clients/client-kendra/protocols/Aws_json1_1.ts
@@ -933,6 +933,7 @@ export async function deserializeAws_json1_1DeleteFaqCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1DeleteFaqCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteFaqCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1019,6 +1020,7 @@ export async function deserializeAws_json1_1DeleteIndexCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1DeleteIndexCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteIndexCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1900,6 +1902,7 @@ export async function deserializeAws_json1_1StopDataSourceSyncJobCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: StopDataSourceSyncJobCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1979,6 +1982,7 @@ export async function deserializeAws_json1_1SubmitFeedbackCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1SubmitFeedbackCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: SubmitFeedbackCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2065,6 +2069,7 @@ export async function deserializeAws_json1_1UpdateDataSourceCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1UpdateDataSourceCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: UpdateDataSourceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2151,6 +2156,7 @@ export async function deserializeAws_json1_1UpdateIndexCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1UpdateIndexCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: UpdateIndexCommandOutput = {
     $metadata: deserializeMetadata(output)
   };

--- a/clients/client-kinesis-analytics-v2/models/index.ts
+++ b/clients/client-kinesis-analytics-v2/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export interface AddApplicationCloudWatchLoggingOptionRequest {
@@ -23,7 +26,7 @@ export namespace AddApplicationCloudWatchLoggingOptionRequest {
   export function isa(
     o: any
   ): o is AddApplicationCloudWatchLoggingOptionRequest {
-    return _smithy.isa(o, "AddApplicationCloudWatchLoggingOptionRequest");
+    return __isa(o, "AddApplicationCloudWatchLoggingOptionRequest");
   }
 }
 
@@ -54,7 +57,7 @@ export namespace AddApplicationCloudWatchLoggingOptionResponse {
   export function isa(
     o: any
   ): o is AddApplicationCloudWatchLoggingOptionResponse {
-    return _smithy.isa(o, "AddApplicationCloudWatchLoggingOptionResponse");
+    return __isa(o, "AddApplicationCloudWatchLoggingOptionResponse");
   }
 }
 
@@ -90,7 +93,7 @@ export namespace AddApplicationInputProcessingConfigurationRequest {
   export function isa(
     o: any
   ): o is AddApplicationInputProcessingConfigurationRequest {
-    return _smithy.isa(o, "AddApplicationInputProcessingConfigurationRequest");
+    return __isa(o, "AddApplicationInputProcessingConfigurationRequest");
   }
 }
 
@@ -124,7 +127,7 @@ export namespace AddApplicationInputProcessingConfigurationResponse {
   export function isa(
     o: any
   ): o is AddApplicationInputProcessingConfigurationResponse {
-    return _smithy.isa(o, "AddApplicationInputProcessingConfigurationResponse");
+    return __isa(o, "AddApplicationInputProcessingConfigurationResponse");
   }
 }
 
@@ -149,7 +152,7 @@ export interface AddApplicationInputRequest {
 
 export namespace AddApplicationInputRequest {
   export function isa(o: any): o is AddApplicationInputRequest {
-    return _smithy.isa(o, "AddApplicationInputRequest");
+    return __isa(o, "AddApplicationInputRequest");
   }
 }
 
@@ -176,7 +179,7 @@ export interface AddApplicationInputResponse extends $MetadataBearer {
 
 export namespace AddApplicationInputResponse {
   export function isa(o: any): o is AddApplicationInputResponse {
-    return _smithy.isa(o, "AddApplicationInputResponse");
+    return __isa(o, "AddApplicationInputResponse");
   }
 }
 
@@ -206,7 +209,7 @@ export interface AddApplicationOutputRequest {
 
 export namespace AddApplicationOutputRequest {
   export function isa(o: any): o is AddApplicationOutputRequest {
-    return _smithy.isa(o, "AddApplicationOutputRequest");
+    return __isa(o, "AddApplicationOutputRequest");
   }
 }
 
@@ -235,7 +238,7 @@ export interface AddApplicationOutputResponse extends $MetadataBearer {
 
 export namespace AddApplicationOutputResponse {
   export function isa(o: any): o is AddApplicationOutputResponse {
-    return _smithy.isa(o, "AddApplicationOutputResponse");
+    return __isa(o, "AddApplicationOutputResponse");
   }
 }
 
@@ -264,7 +267,7 @@ export interface AddApplicationReferenceDataSourceRequest {
 
 export namespace AddApplicationReferenceDataSourceRequest {
   export function isa(o: any): o is AddApplicationReferenceDataSourceRequest {
-    return _smithy.isa(o, "AddApplicationReferenceDataSourceRequest");
+    return __isa(o, "AddApplicationReferenceDataSourceRequest");
   }
 }
 
@@ -294,7 +297,7 @@ export interface AddApplicationReferenceDataSourceResponse
 
 export namespace AddApplicationReferenceDataSourceResponse {
   export function isa(o: any): o is AddApplicationReferenceDataSourceResponse {
-    return _smithy.isa(o, "AddApplicationReferenceDataSourceResponse");
+    return __isa(o, "AddApplicationReferenceDataSourceResponse");
   }
 }
 
@@ -321,7 +324,7 @@ export interface AddApplicationVpcConfigurationRequest {
 
 export namespace AddApplicationVpcConfigurationRequest {
   export function isa(o: any): o is AddApplicationVpcConfigurationRequest {
-    return _smithy.isa(o, "AddApplicationVpcConfigurationRequest");
+    return __isa(o, "AddApplicationVpcConfigurationRequest");
   }
 }
 
@@ -346,7 +349,7 @@ export interface AddApplicationVpcConfigurationResponse
 
 export namespace AddApplicationVpcConfigurationResponse {
   export function isa(o: any): o is AddApplicationVpcConfigurationResponse {
-    return _smithy.isa(o, "AddApplicationVpcConfigurationResponse");
+    return __isa(o, "AddApplicationVpcConfigurationResponse");
   }
 }
 
@@ -369,7 +372,7 @@ export interface ApplicationCodeConfiguration {
 
 export namespace ApplicationCodeConfiguration {
   export function isa(o: any): o is ApplicationCodeConfiguration {
-    return _smithy.isa(o, "ApplicationCodeConfiguration");
+    return __isa(o, "ApplicationCodeConfiguration");
   }
 }
 
@@ -392,7 +395,7 @@ export interface ApplicationCodeConfigurationDescription {
 
 export namespace ApplicationCodeConfigurationDescription {
   export function isa(o: any): o is ApplicationCodeConfigurationDescription {
-    return _smithy.isa(o, "ApplicationCodeConfigurationDescription");
+    return __isa(o, "ApplicationCodeConfigurationDescription");
   }
 }
 
@@ -415,7 +418,7 @@ export interface ApplicationCodeConfigurationUpdate {
 
 export namespace ApplicationCodeConfigurationUpdate {
   export function isa(o: any): o is ApplicationCodeConfigurationUpdate {
-    return _smithy.isa(o, "ApplicationCodeConfigurationUpdate");
+    return __isa(o, "ApplicationCodeConfigurationUpdate");
   }
 }
 
@@ -460,7 +463,7 @@ export interface ApplicationConfiguration {
 
 export namespace ApplicationConfiguration {
   export function isa(o: any): o is ApplicationConfiguration {
-    return _smithy.isa(o, "ApplicationConfiguration");
+    return __isa(o, "ApplicationConfiguration");
   }
 }
 
@@ -511,7 +514,7 @@ export interface ApplicationConfigurationDescription {
 
 export namespace ApplicationConfigurationDescription {
   export function isa(o: any): o is ApplicationConfigurationDescription {
-    return _smithy.isa(o, "ApplicationConfigurationDescription");
+    return __isa(o, "ApplicationConfigurationDescription");
   }
 }
 
@@ -555,7 +558,7 @@ export interface ApplicationConfigurationUpdate {
 
 export namespace ApplicationConfigurationUpdate {
   export function isa(o: any): o is ApplicationConfigurationUpdate {
-    return _smithy.isa(o, "ApplicationConfigurationUpdate");
+    return __isa(o, "ApplicationConfigurationUpdate");
   }
 }
 
@@ -626,7 +629,7 @@ export interface ApplicationDetail {
 
 export namespace ApplicationDetail {
   export function isa(o: any): o is ApplicationDetail {
-    return _smithy.isa(o, "ApplicationDetail");
+    return __isa(o, "ApplicationDetail");
   }
 }
 
@@ -649,7 +652,7 @@ export interface ApplicationRestoreConfiguration {
 
 export namespace ApplicationRestoreConfiguration {
   export function isa(o: any): o is ApplicationRestoreConfiguration {
-    return _smithy.isa(o, "ApplicationRestoreConfiguration");
+    return __isa(o, "ApplicationRestoreConfiguration");
   }
 }
 
@@ -672,7 +675,7 @@ export interface ApplicationSnapshotConfiguration {
 
 export namespace ApplicationSnapshotConfiguration {
   export function isa(o: any): o is ApplicationSnapshotConfiguration {
-    return _smithy.isa(o, "ApplicationSnapshotConfiguration");
+    return __isa(o, "ApplicationSnapshotConfiguration");
   }
 }
 
@@ -691,7 +694,7 @@ export namespace ApplicationSnapshotConfigurationDescription {
   export function isa(
     o: any
   ): o is ApplicationSnapshotConfigurationDescription {
-    return _smithy.isa(o, "ApplicationSnapshotConfigurationDescription");
+    return __isa(o, "ApplicationSnapshotConfigurationDescription");
   }
 }
 
@@ -708,7 +711,7 @@ export interface ApplicationSnapshotConfigurationUpdate {
 
 export namespace ApplicationSnapshotConfigurationUpdate {
   export function isa(o: any): o is ApplicationSnapshotConfigurationUpdate {
-    return _smithy.isa(o, "ApplicationSnapshotConfigurationUpdate");
+    return __isa(o, "ApplicationSnapshotConfigurationUpdate");
   }
 }
 
@@ -754,7 +757,7 @@ export interface ApplicationSummary {
 
 export namespace ApplicationSummary {
   export function isa(o: any): o is ApplicationSummary {
-    return _smithy.isa(o, "ApplicationSummary");
+    return __isa(o, "ApplicationSummary");
   }
 }
 
@@ -788,7 +791,7 @@ export interface CSVMappingParameters {
 
 export namespace CSVMappingParameters {
   export function isa(o: any): o is CSVMappingParameters {
-    return _smithy.isa(o, "CSVMappingParameters");
+    return __isa(o, "CSVMappingParameters");
   }
 }
 
@@ -861,7 +864,7 @@ export interface CheckpointConfiguration {
 
 export namespace CheckpointConfiguration {
   export function isa(o: any): o is CheckpointConfiguration {
-    return _smithy.isa(o, "CheckpointConfiguration");
+    return __isa(o, "CheckpointConfiguration");
   }
 }
 
@@ -926,7 +929,7 @@ export interface CheckpointConfigurationDescription {
 
 export namespace CheckpointConfigurationDescription {
   export function isa(o: any): o is CheckpointConfigurationDescription {
-    return _smithy.isa(o, "CheckpointConfigurationDescription");
+    return __isa(o, "CheckpointConfigurationDescription");
   }
 }
 
@@ -993,7 +996,7 @@ export interface CheckpointConfigurationUpdate {
 
 export namespace CheckpointConfigurationUpdate {
   export function isa(o: any): o is CheckpointConfigurationUpdate {
-    return _smithy.isa(o, "CheckpointConfigurationUpdate");
+    return __isa(o, "CheckpointConfigurationUpdate");
   }
 }
 
@@ -1011,7 +1014,7 @@ export interface CloudWatchLoggingOption {
 
 export namespace CloudWatchLoggingOption {
   export function isa(o: any): o is CloudWatchLoggingOption {
-    return _smithy.isa(o, "CloudWatchLoggingOption");
+    return __isa(o, "CloudWatchLoggingOption");
   }
 }
 
@@ -1043,7 +1046,7 @@ export interface CloudWatchLoggingOptionDescription {
 
 export namespace CloudWatchLoggingOptionDescription {
   export function isa(o: any): o is CloudWatchLoggingOptionDescription {
-    return _smithy.isa(o, "CloudWatchLoggingOptionDescription");
+    return __isa(o, "CloudWatchLoggingOptionDescription");
   }
 }
 
@@ -1066,7 +1069,7 @@ export interface CloudWatchLoggingOptionUpdate {
 
 export namespace CloudWatchLoggingOptionUpdate {
   export function isa(o: any): o is CloudWatchLoggingOptionUpdate {
-    return _smithy.isa(o, "CloudWatchLoggingOptionUpdate");
+    return __isa(o, "CloudWatchLoggingOptionUpdate");
   }
 }
 
@@ -1094,7 +1097,7 @@ export interface CodeContent {
 
 export namespace CodeContent {
   export function isa(o: any): o is CodeContent {
-    return _smithy.isa(o, "CodeContent");
+    return __isa(o, "CodeContent");
   }
 }
 
@@ -1128,7 +1131,7 @@ export interface CodeContentDescription {
 
 export namespace CodeContentDescription {
   export function isa(o: any): o is CodeContentDescription {
-    return _smithy.isa(o, "CodeContentDescription");
+    return __isa(o, "CodeContentDescription");
   }
 }
 
@@ -1161,7 +1164,7 @@ export interface CodeContentUpdate {
 
 export namespace CodeContentUpdate {
   export function isa(o: any): o is CodeContentUpdate {
-    return _smithy.isa(o, "CodeContentUpdate");
+    return __isa(o, "CodeContentUpdate");
   }
 }
 
@@ -1170,7 +1173,7 @@ export namespace CodeContentUpdate {
  *       error.</p>
  */
 export interface CodeValidationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CodeValidationException";
   $fault: "client";
@@ -1179,7 +1182,7 @@ export interface CodeValidationException
 
 export namespace CodeValidationException {
   export function isa(o: any): o is CodeValidationException {
-    return _smithy.isa(o, "CodeValidationException");
+    return __isa(o, "CodeValidationException");
   }
 }
 
@@ -1189,7 +1192,7 @@ export namespace CodeValidationException {
  *       ID.</p>
  */
 export interface ConcurrentModificationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ConcurrentModificationException";
   $fault: "client";
@@ -1198,7 +1201,7 @@ export interface ConcurrentModificationException
 
 export namespace ConcurrentModificationException {
   export function isa(o: any): o is ConcurrentModificationException {
-    return _smithy.isa(o, "ConcurrentModificationException");
+    return __isa(o, "ConcurrentModificationException");
   }
 }
 
@@ -1251,7 +1254,7 @@ export interface CreateApplicationRequest {
 
 export namespace CreateApplicationRequest {
   export function isa(o: any): o is CreateApplicationRequest {
-    return _smithy.isa(o, "CreateApplicationRequest");
+    return __isa(o, "CreateApplicationRequest");
   }
 }
 
@@ -1266,7 +1269,7 @@ export interface CreateApplicationResponse extends $MetadataBearer {
 
 export namespace CreateApplicationResponse {
   export function isa(o: any): o is CreateApplicationResponse {
-    return _smithy.isa(o, "CreateApplicationResponse");
+    return __isa(o, "CreateApplicationResponse");
   }
 }
 
@@ -1285,7 +1288,7 @@ export interface CreateApplicationSnapshotRequest {
 
 export namespace CreateApplicationSnapshotRequest {
   export function isa(o: any): o is CreateApplicationSnapshotRequest {
-    return _smithy.isa(o, "CreateApplicationSnapshotRequest");
+    return __isa(o, "CreateApplicationSnapshotRequest");
   }
 }
 
@@ -1295,7 +1298,7 @@ export interface CreateApplicationSnapshotResponse extends $MetadataBearer {
 
 export namespace CreateApplicationSnapshotResponse {
   export function isa(o: any): o is CreateApplicationSnapshotResponse {
-    return _smithy.isa(o, "CreateApplicationSnapshotResponse");
+    return __isa(o, "CreateApplicationSnapshotResponse");
   }
 }
 
@@ -1323,7 +1326,7 @@ export namespace DeleteApplicationCloudWatchLoggingOptionRequest {
   export function isa(
     o: any
   ): o is DeleteApplicationCloudWatchLoggingOptionRequest {
-    return _smithy.isa(o, "DeleteApplicationCloudWatchLoggingOptionRequest");
+    return __isa(o, "DeleteApplicationCloudWatchLoggingOptionRequest");
   }
 }
 
@@ -1354,7 +1357,7 @@ export namespace DeleteApplicationCloudWatchLoggingOptionResponse {
   export function isa(
     o: any
   ): o is DeleteApplicationCloudWatchLoggingOptionResponse {
-    return _smithy.isa(o, "DeleteApplicationCloudWatchLoggingOptionResponse");
+    return __isa(o, "DeleteApplicationCloudWatchLoggingOptionResponse");
   }
 }
 
@@ -1385,10 +1388,7 @@ export namespace DeleteApplicationInputProcessingConfigurationRequest {
   export function isa(
     o: any
   ): o is DeleteApplicationInputProcessingConfigurationRequest {
-    return _smithy.isa(
-      o,
-      "DeleteApplicationInputProcessingConfigurationRequest"
-    );
+    return __isa(o, "DeleteApplicationInputProcessingConfigurationRequest");
   }
 }
 
@@ -1410,10 +1410,7 @@ export namespace DeleteApplicationInputProcessingConfigurationResponse {
   export function isa(
     o: any
   ): o is DeleteApplicationInputProcessingConfigurationResponse {
-    return _smithy.isa(
-      o,
-      "DeleteApplicationInputProcessingConfigurationResponse"
-    );
+    return __isa(o, "DeleteApplicationInputProcessingConfigurationResponse");
   }
 }
 
@@ -1445,7 +1442,7 @@ export interface DeleteApplicationOutputRequest {
 
 export namespace DeleteApplicationOutputRequest {
   export function isa(o: any): o is DeleteApplicationOutputRequest {
-    return _smithy.isa(o, "DeleteApplicationOutputRequest");
+    return __isa(o, "DeleteApplicationOutputRequest");
   }
 }
 
@@ -1464,7 +1461,7 @@ export interface DeleteApplicationOutputResponse extends $MetadataBearer {
 
 export namespace DeleteApplicationOutputResponse {
   export function isa(o: any): o is DeleteApplicationOutputResponse {
-    return _smithy.isa(o, "DeleteApplicationOutputResponse");
+    return __isa(o, "DeleteApplicationOutputResponse");
   }
 }
 
@@ -1496,7 +1493,7 @@ export namespace DeleteApplicationReferenceDataSourceRequest {
   export function isa(
     o: any
   ): o is DeleteApplicationReferenceDataSourceRequest {
-    return _smithy.isa(o, "DeleteApplicationReferenceDataSourceRequest");
+    return __isa(o, "DeleteApplicationReferenceDataSourceRequest");
   }
 }
 
@@ -1518,7 +1515,7 @@ export namespace DeleteApplicationReferenceDataSourceResponse {
   export function isa(
     o: any
   ): o is DeleteApplicationReferenceDataSourceResponse {
-    return _smithy.isa(o, "DeleteApplicationReferenceDataSourceResponse");
+    return __isa(o, "DeleteApplicationReferenceDataSourceResponse");
   }
 }
 
@@ -1537,7 +1534,7 @@ export interface DeleteApplicationRequest {
 
 export namespace DeleteApplicationRequest {
   export function isa(o: any): o is DeleteApplicationRequest {
-    return _smithy.isa(o, "DeleteApplicationRequest");
+    return __isa(o, "DeleteApplicationRequest");
   }
 }
 
@@ -1547,7 +1544,7 @@ export interface DeleteApplicationResponse extends $MetadataBearer {
 
 export namespace DeleteApplicationResponse {
   export function isa(o: any): o is DeleteApplicationResponse {
-    return _smithy.isa(o, "DeleteApplicationResponse");
+    return __isa(o, "DeleteApplicationResponse");
   }
 }
 
@@ -1572,7 +1569,7 @@ export interface DeleteApplicationSnapshotRequest {
 
 export namespace DeleteApplicationSnapshotRequest {
   export function isa(o: any): o is DeleteApplicationSnapshotRequest {
-    return _smithy.isa(o, "DeleteApplicationSnapshotRequest");
+    return __isa(o, "DeleteApplicationSnapshotRequest");
   }
 }
 
@@ -1582,7 +1579,7 @@ export interface DeleteApplicationSnapshotResponse extends $MetadataBearer {
 
 export namespace DeleteApplicationSnapshotResponse {
   export function isa(o: any): o is DeleteApplicationSnapshotResponse {
-    return _smithy.isa(o, "DeleteApplicationSnapshotResponse");
+    return __isa(o, "DeleteApplicationSnapshotResponse");
   }
 }
 
@@ -1606,7 +1603,7 @@ export interface DeleteApplicationVpcConfigurationRequest {
 
 export namespace DeleteApplicationVpcConfigurationRequest {
   export function isa(o: any): o is DeleteApplicationVpcConfigurationRequest {
-    return _smithy.isa(o, "DeleteApplicationVpcConfigurationRequest");
+    return __isa(o, "DeleteApplicationVpcConfigurationRequest");
   }
 }
 
@@ -1626,7 +1623,7 @@ export interface DeleteApplicationVpcConfigurationResponse
 
 export namespace DeleteApplicationVpcConfigurationResponse {
   export function isa(o: any): o is DeleteApplicationVpcConfigurationResponse {
-    return _smithy.isa(o, "DeleteApplicationVpcConfigurationResponse");
+    return __isa(o, "DeleteApplicationVpcConfigurationResponse");
   }
 }
 
@@ -1645,7 +1642,7 @@ export interface DescribeApplicationRequest {
 
 export namespace DescribeApplicationRequest {
   export function isa(o: any): o is DescribeApplicationRequest {
-    return _smithy.isa(o, "DescribeApplicationRequest");
+    return __isa(o, "DescribeApplicationRequest");
   }
 }
 
@@ -1660,7 +1657,7 @@ export interface DescribeApplicationResponse extends $MetadataBearer {
 
 export namespace DescribeApplicationResponse {
   export function isa(o: any): o is DescribeApplicationResponse {
-    return _smithy.isa(o, "DescribeApplicationResponse");
+    return __isa(o, "DescribeApplicationResponse");
   }
 }
 
@@ -1679,7 +1676,7 @@ export interface DescribeApplicationSnapshotRequest {
 
 export namespace DescribeApplicationSnapshotRequest {
   export function isa(o: any): o is DescribeApplicationSnapshotRequest {
-    return _smithy.isa(o, "DescribeApplicationSnapshotRequest");
+    return __isa(o, "DescribeApplicationSnapshotRequest");
   }
 }
 
@@ -1693,7 +1690,7 @@ export interface DescribeApplicationSnapshotResponse extends $MetadataBearer {
 
 export namespace DescribeApplicationSnapshotResponse {
   export function isa(o: any): o is DescribeApplicationSnapshotResponse {
-    return _smithy.isa(o, "DescribeApplicationSnapshotResponse");
+    return __isa(o, "DescribeApplicationSnapshotResponse");
   }
 }
 
@@ -1711,7 +1708,7 @@ export interface DestinationSchema {
 
 export namespace DestinationSchema {
   export function isa(o: any): o is DestinationSchema {
-    return _smithy.isa(o, "DestinationSchema");
+    return __isa(o, "DestinationSchema");
   }
 }
 
@@ -1747,7 +1744,7 @@ export interface DiscoverInputSchemaRequest {
 
 export namespace DiscoverInputSchemaRequest {
   export function isa(o: any): o is DiscoverInputSchemaRequest {
-    return _smithy.isa(o, "DiscoverInputSchemaRequest");
+    return __isa(o, "DiscoverInputSchemaRequest");
   }
 }
 
@@ -1779,7 +1776,7 @@ export interface DiscoverInputSchemaResponse extends $MetadataBearer {
 
 export namespace DiscoverInputSchemaResponse {
   export function isa(o: any): o is DiscoverInputSchemaResponse {
-    return _smithy.isa(o, "DiscoverInputSchemaResponse");
+    return __isa(o, "DiscoverInputSchemaResponse");
   }
 }
 
@@ -1797,7 +1794,7 @@ export interface EnvironmentProperties {
 
 export namespace EnvironmentProperties {
   export function isa(o: any): o is EnvironmentProperties {
-    return _smithy.isa(o, "EnvironmentProperties");
+    return __isa(o, "EnvironmentProperties");
   }
 }
 
@@ -1815,7 +1812,7 @@ export interface EnvironmentPropertyDescriptions {
 
 export namespace EnvironmentPropertyDescriptions {
   export function isa(o: any): o is EnvironmentPropertyDescriptions {
-    return _smithy.isa(o, "EnvironmentPropertyDescriptions");
+    return __isa(o, "EnvironmentPropertyDescriptions");
   }
 }
 
@@ -1833,7 +1830,7 @@ export interface EnvironmentPropertyUpdates {
 
 export namespace EnvironmentPropertyUpdates {
   export function isa(o: any): o is EnvironmentPropertyUpdates {
-    return _smithy.isa(o, "EnvironmentPropertyUpdates");
+    return __isa(o, "EnvironmentPropertyUpdates");
   }
 }
 
@@ -1867,7 +1864,7 @@ export interface FlinkApplicationConfiguration {
 
 export namespace FlinkApplicationConfiguration {
   export function isa(o: any): o is FlinkApplicationConfiguration {
-    return _smithy.isa(o, "FlinkApplicationConfiguration");
+    return __isa(o, "FlinkApplicationConfiguration");
   }
 }
 
@@ -1902,7 +1899,7 @@ export interface FlinkApplicationConfigurationDescription {
 
 export namespace FlinkApplicationConfigurationDescription {
   export function isa(o: any): o is FlinkApplicationConfigurationDescription {
-    return _smithy.isa(o, "FlinkApplicationConfigurationDescription");
+    return __isa(o, "FlinkApplicationConfigurationDescription");
   }
 }
 
@@ -1931,7 +1928,7 @@ export interface FlinkApplicationConfigurationUpdate {
 
 export namespace FlinkApplicationConfigurationUpdate {
   export function isa(o: any): o is FlinkApplicationConfigurationUpdate {
-    return _smithy.isa(o, "FlinkApplicationConfigurationUpdate");
+    return __isa(o, "FlinkApplicationConfigurationUpdate");
   }
 }
 
@@ -1953,7 +1950,7 @@ export interface FlinkRunConfiguration {
 
 export namespace FlinkRunConfiguration {
   export function isa(o: any): o is FlinkRunConfiguration {
-    return _smithy.isa(o, "FlinkRunConfiguration");
+    return __isa(o, "FlinkRunConfiguration");
   }
 }
 
@@ -2005,7 +2002,7 @@ export interface Input {
 
 export namespace Input {
   export function isa(o: any): o is Input {
-    return _smithy.isa(o, "Input");
+    return __isa(o, "Input");
   }
 }
 
@@ -2065,7 +2062,7 @@ export interface InputDescription {
 
 export namespace InputDescription {
   export function isa(o: any): o is InputDescription {
-    return _smithy.isa(o, "InputDescription");
+    return __isa(o, "InputDescription");
   }
 }
 
@@ -2088,7 +2085,7 @@ export interface InputLambdaProcessor {
 
 export namespace InputLambdaProcessor {
   export function isa(o: any): o is InputLambdaProcessor {
-    return _smithy.isa(o, "InputLambdaProcessor");
+    return __isa(o, "InputLambdaProcessor");
   }
 }
 
@@ -2122,7 +2119,7 @@ export interface InputLambdaProcessorDescription {
 
 export namespace InputLambdaProcessorDescription {
   export function isa(o: any): o is InputLambdaProcessorDescription {
-    return _smithy.isa(o, "InputLambdaProcessorDescription");
+    return __isa(o, "InputLambdaProcessorDescription");
   }
 }
 
@@ -2146,7 +2143,7 @@ export interface InputLambdaProcessorUpdate {
 
 export namespace InputLambdaProcessorUpdate {
   export function isa(o: any): o is InputLambdaProcessorUpdate {
-    return _smithy.isa(o, "InputLambdaProcessorUpdate");
+    return __isa(o, "InputLambdaProcessorUpdate");
   }
 }
 
@@ -2164,7 +2161,7 @@ export interface InputParallelism {
 
 export namespace InputParallelism {
   export function isa(o: any): o is InputParallelism {
-    return _smithy.isa(o, "InputParallelism");
+    return __isa(o, "InputParallelism");
   }
 }
 
@@ -2182,7 +2179,7 @@ export interface InputParallelismUpdate {
 
 export namespace InputParallelismUpdate {
   export function isa(o: any): o is InputParallelismUpdate {
-    return _smithy.isa(o, "InputParallelismUpdate");
+    return __isa(o, "InputParallelismUpdate");
   }
 }
 
@@ -2202,7 +2199,7 @@ export interface InputProcessingConfiguration {
 
 export namespace InputProcessingConfiguration {
   export function isa(o: any): o is InputProcessingConfiguration {
-    return _smithy.isa(o, "InputProcessingConfiguration");
+    return __isa(o, "InputProcessingConfiguration");
   }
 }
 
@@ -2221,7 +2218,7 @@ export interface InputProcessingConfigurationDescription {
 
 export namespace InputProcessingConfigurationDescription {
   export function isa(o: any): o is InputProcessingConfigurationDescription {
-    return _smithy.isa(o, "InputProcessingConfigurationDescription");
+    return __isa(o, "InputProcessingConfigurationDescription");
   }
 }
 
@@ -2238,7 +2235,7 @@ export interface InputProcessingConfigurationUpdate {
 
 export namespace InputProcessingConfigurationUpdate {
   export function isa(o: any): o is InputProcessingConfigurationUpdate {
-    return _smithy.isa(o, "InputProcessingConfigurationUpdate");
+    return __isa(o, "InputProcessingConfigurationUpdate");
   }
 }
 
@@ -2267,7 +2264,7 @@ export interface InputSchemaUpdate {
 
 export namespace InputSchemaUpdate {
   export function isa(o: any): o is InputSchemaUpdate {
-    return _smithy.isa(o, "InputSchemaUpdate");
+    return __isa(o, "InputSchemaUpdate");
   }
 }
 
@@ -2310,7 +2307,7 @@ export interface InputStartingPositionConfiguration {
 
 export namespace InputStartingPositionConfiguration {
   export function isa(o: any): o is InputStartingPositionConfiguration {
-    return _smithy.isa(o, "InputStartingPositionConfiguration");
+    return __isa(o, "InputStartingPositionConfiguration");
   }
 }
 
@@ -2363,7 +2360,7 @@ export interface InputUpdate {
 
 export namespace InputUpdate {
   export function isa(o: any): o is InputUpdate {
-    return _smithy.isa(o, "InputUpdate");
+    return __isa(o, "InputUpdate");
   }
 }
 
@@ -2371,7 +2368,7 @@ export namespace InputUpdate {
  * <p>The user-provided application configuration is not valid.</p>
  */
 export interface InvalidApplicationConfigurationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidApplicationConfigurationException";
   $fault: "client";
@@ -2380,7 +2377,7 @@ export interface InvalidApplicationConfigurationException
 
 export namespace InvalidApplicationConfigurationException {
   export function isa(o: any): o is InvalidApplicationConfigurationException {
-    return _smithy.isa(o, "InvalidApplicationConfigurationException");
+    return __isa(o, "InvalidApplicationConfigurationException");
   }
 }
 
@@ -2388,7 +2385,7 @@ export namespace InvalidApplicationConfigurationException {
  * <p>The specified input parameter value is not valid.</p>
  */
 export interface InvalidArgumentException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidArgumentException";
   $fault: "client";
@@ -2397,7 +2394,7 @@ export interface InvalidArgumentException
 
 export namespace InvalidArgumentException {
   export function isa(o: any): o is InvalidArgumentException {
-    return _smithy.isa(o, "InvalidArgumentException");
+    return __isa(o, "InvalidArgumentException");
   }
 }
 
@@ -2405,7 +2402,7 @@ export namespace InvalidArgumentException {
  * <p>The request JSON is not valid for the operation.</p>
  */
 export interface InvalidRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidRequestException";
   $fault: "client";
@@ -2414,7 +2411,7 @@ export interface InvalidRequestException
 
 export namespace InvalidRequestException {
   export function isa(o: any): o is InvalidRequestException {
-    return _smithy.isa(o, "InvalidRequestException");
+    return __isa(o, "InvalidRequestException");
   }
 }
 
@@ -2432,7 +2429,7 @@ export interface JSONMappingParameters {
 
 export namespace JSONMappingParameters {
   export function isa(o: any): o is JSONMappingParameters {
-    return _smithy.isa(o, "JSONMappingParameters");
+    return __isa(o, "JSONMappingParameters");
   }
 }
 
@@ -2451,7 +2448,7 @@ export interface KinesisFirehoseInput {
 
 export namespace KinesisFirehoseInput {
   export function isa(o: any): o is KinesisFirehoseInput {
-    return _smithy.isa(o, "KinesisFirehoseInput");
+    return __isa(o, "KinesisFirehoseInput");
   }
 }
 
@@ -2479,7 +2476,7 @@ export interface KinesisFirehoseInputDescription {
 
 export namespace KinesisFirehoseInputDescription {
   export function isa(o: any): o is KinesisFirehoseInputDescription {
-    return _smithy.isa(o, "KinesisFirehoseInputDescription");
+    return __isa(o, "KinesisFirehoseInputDescription");
   }
 }
 
@@ -2498,7 +2495,7 @@ export interface KinesisFirehoseInputUpdate {
 
 export namespace KinesisFirehoseInputUpdate {
   export function isa(o: any): o is KinesisFirehoseInputUpdate {
-    return _smithy.isa(o, "KinesisFirehoseInputUpdate");
+    return __isa(o, "KinesisFirehoseInputUpdate");
   }
 }
 
@@ -2517,7 +2514,7 @@ export interface KinesisFirehoseOutput {
 
 export namespace KinesisFirehoseOutput {
   export function isa(o: any): o is KinesisFirehoseOutput {
-    return _smithy.isa(o, "KinesisFirehoseOutput");
+    return __isa(o, "KinesisFirehoseOutput");
   }
 }
 
@@ -2546,7 +2543,7 @@ export interface KinesisFirehoseOutputDescription {
 
 export namespace KinesisFirehoseOutputDescription {
   export function isa(o: any): o is KinesisFirehoseOutputDescription {
-    return _smithy.isa(o, "KinesisFirehoseOutputDescription");
+    return __isa(o, "KinesisFirehoseOutputDescription");
   }
 }
 
@@ -2565,7 +2562,7 @@ export interface KinesisFirehoseOutputUpdate {
 
 export namespace KinesisFirehoseOutputUpdate {
   export function isa(o: any): o is KinesisFirehoseOutputUpdate {
-    return _smithy.isa(o, "KinesisFirehoseOutputUpdate");
+    return __isa(o, "KinesisFirehoseOutputUpdate");
   }
 }
 
@@ -2583,7 +2580,7 @@ export interface KinesisStreamsInput {
 
 export namespace KinesisStreamsInput {
   export function isa(o: any): o is KinesisStreamsInput {
-    return _smithy.isa(o, "KinesisStreamsInput");
+    return __isa(o, "KinesisStreamsInput");
   }
 }
 
@@ -2612,7 +2609,7 @@ export interface KinesisStreamsInputDescription {
 
 export namespace KinesisStreamsInputDescription {
   export function isa(o: any): o is KinesisStreamsInputDescription {
-    return _smithy.isa(o, "KinesisStreamsInputDescription");
+    return __isa(o, "KinesisStreamsInputDescription");
   }
 }
 
@@ -2631,7 +2628,7 @@ export interface KinesisStreamsInputUpdate {
 
 export namespace KinesisStreamsInputUpdate {
   export function isa(o: any): o is KinesisStreamsInputUpdate {
-    return _smithy.isa(o, "KinesisStreamsInputUpdate");
+    return __isa(o, "KinesisStreamsInputUpdate");
   }
 }
 
@@ -2650,7 +2647,7 @@ export interface KinesisStreamsOutput {
 
 export namespace KinesisStreamsOutput {
   export function isa(o: any): o is KinesisStreamsOutput {
-    return _smithy.isa(o, "KinesisStreamsOutput");
+    return __isa(o, "KinesisStreamsOutput");
   }
 }
 
@@ -2679,7 +2676,7 @@ export interface KinesisStreamsOutputDescription {
 
 export namespace KinesisStreamsOutputDescription {
   export function isa(o: any): o is KinesisStreamsOutputDescription {
-    return _smithy.isa(o, "KinesisStreamsOutputDescription");
+    return __isa(o, "KinesisStreamsOutputDescription");
   }
 }
 
@@ -2699,7 +2696,7 @@ export interface KinesisStreamsOutputUpdate {
 
 export namespace KinesisStreamsOutputUpdate {
   export function isa(o: any): o is KinesisStreamsOutputUpdate {
-    return _smithy.isa(o, "KinesisStreamsOutputUpdate");
+    return __isa(o, "KinesisStreamsOutputUpdate");
   }
 }
 
@@ -2722,7 +2719,7 @@ export interface LambdaOutput {
 
 export namespace LambdaOutput {
   export function isa(o: any): o is LambdaOutput {
-    return _smithy.isa(o, "LambdaOutput");
+    return __isa(o, "LambdaOutput");
   }
 }
 
@@ -2751,7 +2748,7 @@ export interface LambdaOutputDescription {
 
 export namespace LambdaOutputDescription {
   export function isa(o: any): o is LambdaOutputDescription {
-    return _smithy.isa(o, "LambdaOutputDescription");
+    return __isa(o, "LambdaOutputDescription");
   }
 }
 
@@ -2774,7 +2771,7 @@ export interface LambdaOutputUpdate {
 
 export namespace LambdaOutputUpdate {
   export function isa(o: any): o is LambdaOutputUpdate {
-    return _smithy.isa(o, "LambdaOutputUpdate");
+    return __isa(o, "LambdaOutputUpdate");
   }
 }
 
@@ -2782,7 +2779,7 @@ export namespace LambdaOutputUpdate {
  * <p>The number of allowed resources has been exceeded.</p>
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -2791,7 +2788,7 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
@@ -2816,7 +2813,7 @@ export interface ListApplicationSnapshotsRequest {
 
 export namespace ListApplicationSnapshotsRequest {
   export function isa(o: any): o is ListApplicationSnapshotsRequest {
-    return _smithy.isa(o, "ListApplicationSnapshotsRequest");
+    return __isa(o, "ListApplicationSnapshotsRequest");
   }
 }
 
@@ -2835,7 +2832,7 @@ export interface ListApplicationSnapshotsResponse extends $MetadataBearer {
 
 export namespace ListApplicationSnapshotsResponse {
   export function isa(o: any): o is ListApplicationSnapshotsResponse {
-    return _smithy.isa(o, "ListApplicationSnapshotsResponse");
+    return __isa(o, "ListApplicationSnapshotsResponse");
   }
 }
 
@@ -2857,7 +2854,7 @@ export interface ListApplicationsRequest {
 
 export namespace ListApplicationsRequest {
   export function isa(o: any): o is ListApplicationsRequest {
-    return _smithy.isa(o, "ListApplicationsRequest");
+    return __isa(o, "ListApplicationsRequest");
   }
 }
 
@@ -2879,7 +2876,7 @@ export interface ListApplicationsResponse extends $MetadataBearer {
 
 export namespace ListApplicationsResponse {
   export function isa(o: any): o is ListApplicationsResponse {
-    return _smithy.isa(o, "ListApplicationsResponse");
+    return __isa(o, "ListApplicationsResponse");
   }
 }
 
@@ -2893,7 +2890,7 @@ export interface ListTagsForResourceRequest {
 
 export namespace ListTagsForResourceRequest {
   export function isa(o: any): o is ListTagsForResourceRequest {
-    return _smithy.isa(o, "ListTagsForResourceRequest");
+    return __isa(o, "ListTagsForResourceRequest");
   }
 }
 
@@ -2907,7 +2904,7 @@ export interface ListTagsForResourceResponse extends $MetadataBearer {
 
 export namespace ListTagsForResourceResponse {
   export function isa(o: any): o is ListTagsForResourceResponse {
-    return _smithy.isa(o, "ListTagsForResourceResponse");
+    return __isa(o, "ListTagsForResourceResponse");
   }
 }
 
@@ -2940,7 +2937,7 @@ export interface MappingParameters {
 
 export namespace MappingParameters {
   export function isa(o: any): o is MappingParameters {
-    return _smithy.isa(o, "MappingParameters");
+    return __isa(o, "MappingParameters");
   }
 }
 
@@ -2977,7 +2974,7 @@ export interface MonitoringConfiguration {
 
 export namespace MonitoringConfiguration {
   export function isa(o: any): o is MonitoringConfiguration {
-    return _smithy.isa(o, "MonitoringConfiguration");
+    return __isa(o, "MonitoringConfiguration");
   }
 }
 
@@ -3005,7 +3002,7 @@ export interface MonitoringConfigurationDescription {
 
 export namespace MonitoringConfigurationDescription {
   export function isa(o: any): o is MonitoringConfigurationDescription {
-    return _smithy.isa(o, "MonitoringConfigurationDescription");
+    return __isa(o, "MonitoringConfigurationDescription");
   }
 }
 
@@ -3034,7 +3031,7 @@ export interface MonitoringConfigurationUpdate {
 
 export namespace MonitoringConfigurationUpdate {
   export function isa(o: any): o is MonitoringConfigurationUpdate {
-    return _smithy.isa(o, "MonitoringConfigurationUpdate");
+    return __isa(o, "MonitoringConfigurationUpdate");
   }
 }
 
@@ -3078,7 +3075,7 @@ export interface Output {
 
 export namespace Output {
   export function isa(o: any): o is Output {
-    return _smithy.isa(o, "Output");
+    return __isa(o, "Output");
   }
 }
 
@@ -3126,7 +3123,7 @@ export interface OutputDescription {
 
 export namespace OutputDescription {
   export function isa(o: any): o is OutputDescription {
-    return _smithy.isa(o, "OutputDescription");
+    return __isa(o, "OutputDescription");
   }
 }
 
@@ -3173,7 +3170,7 @@ export interface OutputUpdate {
 
 export namespace OutputUpdate {
   export function isa(o: any): o is OutputUpdate {
-    return _smithy.isa(o, "OutputUpdate");
+    return __isa(o, "OutputUpdate");
   }
 }
 
@@ -3216,7 +3213,7 @@ export interface ParallelismConfiguration {
 
 export namespace ParallelismConfiguration {
   export function isa(o: any): o is ParallelismConfiguration {
-    return _smithy.isa(o, "ParallelismConfiguration");
+    return __isa(o, "ParallelismConfiguration");
   }
 }
 
@@ -3263,7 +3260,7 @@ export interface ParallelismConfigurationDescription {
 
 export namespace ParallelismConfigurationDescription {
   export function isa(o: any): o is ParallelismConfigurationDescription {
-    return _smithy.isa(o, "ParallelismConfigurationDescription");
+    return __isa(o, "ParallelismConfigurationDescription");
   }
 }
 
@@ -3302,7 +3299,7 @@ export interface ParallelismConfigurationUpdate {
 
 export namespace ParallelismConfigurationUpdate {
   export function isa(o: any): o is ParallelismConfigurationUpdate {
-    return _smithy.isa(o, "ParallelismConfigurationUpdate");
+    return __isa(o, "ParallelismConfigurationUpdate");
   }
 }
 
@@ -3325,7 +3322,7 @@ export interface PropertyGroup {
 
 export namespace PropertyGroup {
   export function isa(o: any): o is PropertyGroup {
-    return _smithy.isa(o, "PropertyGroup");
+    return __isa(o, "PropertyGroup");
   }
 }
 
@@ -3357,7 +3354,7 @@ export interface RecordColumn {
 
 export namespace RecordColumn {
   export function isa(o: any): o is RecordColumn {
-    return _smithy.isa(o, "RecordColumn");
+    return __isa(o, "RecordColumn");
   }
 }
 
@@ -3383,7 +3380,7 @@ export interface RecordFormat {
 
 export namespace RecordFormat {
   export function isa(o: any): o is RecordFormat {
-    return _smithy.isa(o, "RecordFormat");
+    return __isa(o, "RecordFormat");
   }
 }
 
@@ -3420,7 +3417,7 @@ export interface ReferenceDataSource {
 
 export namespace ReferenceDataSource {
   export function isa(o: any): o is ReferenceDataSource {
-    return _smithy.isa(o, "ReferenceDataSource");
+    return __isa(o, "ReferenceDataSource");
   }
 }
 
@@ -3456,7 +3453,7 @@ export interface ReferenceDataSourceDescription {
 
 export namespace ReferenceDataSourceDescription {
   export function isa(o: any): o is ReferenceDataSourceDescription {
-    return _smithy.isa(o, "ReferenceDataSourceDescription");
+    return __isa(o, "ReferenceDataSourceDescription");
   }
 }
 
@@ -3492,7 +3489,7 @@ export interface ReferenceDataSourceUpdate {
 
 export namespace ReferenceDataSourceUpdate {
   export function isa(o: any): o is ReferenceDataSourceUpdate {
-    return _smithy.isa(o, "ReferenceDataSourceUpdate");
+    return __isa(o, "ReferenceDataSourceUpdate");
   }
 }
 
@@ -3500,7 +3497,7 @@ export namespace ReferenceDataSourceUpdate {
  * <p>The application is not available for this operation.</p>
  */
 export interface ResourceInUseException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceInUseException";
   $fault: "client";
@@ -3509,7 +3506,7 @@ export interface ResourceInUseException
 
 export namespace ResourceInUseException {
   export function isa(o: any): o is ResourceInUseException {
-    return _smithy.isa(o, "ResourceInUseException");
+    return __isa(o, "ResourceInUseException");
   }
 }
 
@@ -3517,7 +3514,7 @@ export namespace ResourceInUseException {
  * <p>Specified application can't be found.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -3526,7 +3523,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -3535,7 +3532,7 @@ export namespace ResourceNotFoundException {
  *       Streams <code>ProvisionedThroughputExceededException</code>. For more information, see <a href="http://docs.aws.amazon.com/kinesis/latest/APIReference/API_GetRecords.html">GetRecords</a> in the Amazon Kinesis Streams API Reference.</p>
  */
 export interface ResourceProvisionedThroughputExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceProvisionedThroughputExceededException";
   $fault: "client";
@@ -3546,7 +3543,7 @@ export namespace ResourceProvisionedThroughputExceededException {
   export function isa(
     o: any
   ): o is ResourceProvisionedThroughputExceededException {
-    return _smithy.isa(o, "ResourceProvisionedThroughputExceededException");
+    return __isa(o, "ResourceProvisionedThroughputExceededException");
   }
 }
 
@@ -3574,7 +3571,7 @@ export interface RunConfiguration {
 
 export namespace RunConfiguration {
   export function isa(o: any): o is RunConfiguration {
-    return _smithy.isa(o, "RunConfiguration");
+    return __isa(o, "RunConfiguration");
   }
 }
 
@@ -3591,7 +3588,7 @@ export interface RunConfigurationDescription {
 
 export namespace RunConfigurationDescription {
   export function isa(o: any): o is RunConfigurationDescription {
-    return _smithy.isa(o, "RunConfigurationDescription");
+    return __isa(o, "RunConfigurationDescription");
   }
 }
 
@@ -3614,7 +3611,7 @@ export interface RunConfigurationUpdate {
 
 export namespace RunConfigurationUpdate {
   export function isa(o: any): o is RunConfigurationUpdate {
-    return _smithy.isa(o, "RunConfigurationUpdate");
+    return __isa(o, "RunConfigurationUpdate");
   }
 }
 
@@ -3648,7 +3645,7 @@ export interface S3ApplicationCodeLocationDescription {
 
 export namespace S3ApplicationCodeLocationDescription {
   export function isa(o: any): o is S3ApplicationCodeLocationDescription {
-    return _smithy.isa(o, "S3ApplicationCodeLocationDescription");
+    return __isa(o, "S3ApplicationCodeLocationDescription");
   }
 }
 
@@ -3672,7 +3669,7 @@ export interface S3Configuration {
 
 export namespace S3Configuration {
   export function isa(o: any): o is S3Configuration {
-    return _smithy.isa(o, "S3Configuration");
+    return __isa(o, "S3Configuration");
   }
 }
 
@@ -3702,7 +3699,7 @@ export interface S3ContentLocation {
 
 export namespace S3ContentLocation {
   export function isa(o: any): o is S3ContentLocation {
-    return _smithy.isa(o, "S3ContentLocation");
+    return __isa(o, "S3ContentLocation");
   }
 }
 
@@ -3730,7 +3727,7 @@ export interface S3ContentLocationUpdate {
 
 export namespace S3ContentLocationUpdate {
   export function isa(o: any): o is S3ContentLocationUpdate {
-    return _smithy.isa(o, "S3ContentLocationUpdate");
+    return __isa(o, "S3ContentLocationUpdate");
   }
 }
 
@@ -3755,7 +3752,7 @@ export interface S3ReferenceDataSource {
 
 export namespace S3ReferenceDataSource {
   export function isa(o: any): o is S3ReferenceDataSource {
-    return _smithy.isa(o, "S3ReferenceDataSource");
+    return __isa(o, "S3ReferenceDataSource");
   }
 }
 
@@ -3789,7 +3786,7 @@ export interface S3ReferenceDataSourceDescription {
 
 export namespace S3ReferenceDataSourceDescription {
   export function isa(o: any): o is S3ReferenceDataSourceDescription {
-    return _smithy.isa(o, "S3ReferenceDataSourceDescription");
+    return __isa(o, "S3ReferenceDataSourceDescription");
   }
 }
 
@@ -3812,7 +3809,7 @@ export interface S3ReferenceDataSourceUpdate {
 
 export namespace S3ReferenceDataSourceUpdate {
   export function isa(o: any): o is S3ReferenceDataSourceUpdate {
-    return _smithy.isa(o, "S3ReferenceDataSourceUpdate");
+    return __isa(o, "S3ReferenceDataSourceUpdate");
   }
 }
 
@@ -3820,7 +3817,7 @@ export namespace S3ReferenceDataSourceUpdate {
  * <p>The service cannot complete the request.</p>
  */
 export interface ServiceUnavailableException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ServiceUnavailableException";
   $fault: "server";
@@ -3829,7 +3826,7 @@ export interface ServiceUnavailableException
 
 export namespace ServiceUnavailableException {
   export function isa(o: any): o is ServiceUnavailableException {
-    return _smithy.isa(o, "ServiceUnavailableException");
+    return __isa(o, "ServiceUnavailableException");
   }
 }
 
@@ -3861,7 +3858,7 @@ export interface SnapshotDetails {
 
 export namespace SnapshotDetails {
   export function isa(o: any): o is SnapshotDetails {
-    return _smithy.isa(o, "SnapshotDetails");
+    return __isa(o, "SnapshotDetails");
   }
 }
 
@@ -3897,7 +3894,7 @@ export interface SourceSchema {
 
 export namespace SourceSchema {
   export function isa(o: any): o is SourceSchema {
-    return _smithy.isa(o, "SourceSchema");
+    return __isa(o, "SourceSchema");
   }
 }
 
@@ -3928,7 +3925,7 @@ export interface SqlApplicationConfiguration {
 
 export namespace SqlApplicationConfiguration {
   export function isa(o: any): o is SqlApplicationConfiguration {
-    return _smithy.isa(o, "SqlApplicationConfiguration");
+    return __isa(o, "SqlApplicationConfiguration");
   }
 }
 
@@ -3959,7 +3956,7 @@ export interface SqlApplicationConfigurationDescription {
 
 export namespace SqlApplicationConfigurationDescription {
   export function isa(o: any): o is SqlApplicationConfigurationDescription {
-    return _smithy.isa(o, "SqlApplicationConfigurationDescription");
+    return __isa(o, "SqlApplicationConfigurationDescription");
   }
 }
 
@@ -3990,7 +3987,7 @@ export interface SqlApplicationConfigurationUpdate {
 
 export namespace SqlApplicationConfigurationUpdate {
   export function isa(o: any): o is SqlApplicationConfigurationUpdate {
-    return _smithy.isa(o, "SqlApplicationConfigurationUpdate");
+    return __isa(o, "SqlApplicationConfigurationUpdate");
   }
 }
 
@@ -4016,7 +4013,7 @@ export interface SqlRunConfiguration {
 
 export namespace SqlRunConfiguration {
   export function isa(o: any): o is SqlRunConfiguration {
-    return _smithy.isa(o, "SqlRunConfiguration");
+    return __isa(o, "SqlRunConfiguration");
   }
 }
 
@@ -4035,7 +4032,7 @@ export interface StartApplicationRequest {
 
 export namespace StartApplicationRequest {
   export function isa(o: any): o is StartApplicationRequest {
-    return _smithy.isa(o, "StartApplicationRequest");
+    return __isa(o, "StartApplicationRequest");
   }
 }
 
@@ -4045,7 +4042,7 @@ export interface StartApplicationResponse extends $MetadataBearer {
 
 export namespace StartApplicationResponse {
   export function isa(o: any): o is StartApplicationResponse {
-    return _smithy.isa(o, "StartApplicationResponse");
+    return __isa(o, "StartApplicationResponse");
   }
 }
 
@@ -4059,7 +4056,7 @@ export interface StopApplicationRequest {
 
 export namespace StopApplicationRequest {
   export function isa(o: any): o is StopApplicationRequest {
-    return _smithy.isa(o, "StopApplicationRequest");
+    return __isa(o, "StopApplicationRequest");
   }
 }
 
@@ -4069,7 +4066,7 @@ export interface StopApplicationResponse extends $MetadataBearer {
 
 export namespace StopApplicationResponse {
   export function isa(o: any): o is StopApplicationResponse {
-    return _smithy.isa(o, "StopApplicationResponse");
+    return __isa(o, "StopApplicationResponse");
   }
 }
 
@@ -4093,7 +4090,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -4112,7 +4109,7 @@ export interface TagResourceRequest {
 
 export namespace TagResourceRequest {
   export function isa(o: any): o is TagResourceRequest {
-    return _smithy.isa(o, "TagResourceRequest");
+    return __isa(o, "TagResourceRequest");
   }
 }
 
@@ -4122,7 +4119,7 @@ export interface TagResourceResponse extends $MetadataBearer {
 
 export namespace TagResourceResponse {
   export function isa(o: any): o is TagResourceResponse {
-    return _smithy.isa(o, "TagResourceResponse");
+    return __isa(o, "TagResourceResponse");
   }
 }
 
@@ -4130,7 +4127,7 @@ export namespace TagResourceResponse {
  * <p>Application created with too many tags, or too many tags added to an application. Note that the maximum number of application tags includes system tags. The maximum number of user-defined application tags is 50.</p>
  */
 export interface TooManyTagsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyTagsException";
   $fault: "client";
@@ -4139,7 +4136,7 @@ export interface TooManyTagsException
 
 export namespace TooManyTagsException {
   export function isa(o: any): o is TooManyTagsException {
-    return _smithy.isa(o, "TooManyTagsException");
+    return __isa(o, "TooManyTagsException");
   }
 }
 
@@ -4148,7 +4145,7 @@ export namespace TooManyTagsException {
  *       the given streaming source.</p>
  */
 export interface UnableToDetectSchemaException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UnableToDetectSchemaException";
   $fault: "client";
@@ -4166,7 +4163,7 @@ export interface UnableToDetectSchemaException
 
 export namespace UnableToDetectSchemaException {
   export function isa(o: any): o is UnableToDetectSchemaException {
-    return _smithy.isa(o, "UnableToDetectSchemaException");
+    return __isa(o, "UnableToDetectSchemaException");
   }
 }
 
@@ -4174,7 +4171,7 @@ export namespace UnableToDetectSchemaException {
  * <p>The request was rejected because a specified parameter is not supported or a specified resource is not valid for this operation. </p>
  */
 export interface UnsupportedOperationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UnsupportedOperationException";
   $fault: "client";
@@ -4183,7 +4180,7 @@ export interface UnsupportedOperationException
 
 export namespace UnsupportedOperationException {
   export function isa(o: any): o is UnsupportedOperationException {
-    return _smithy.isa(o, "UnsupportedOperationException");
+    return __isa(o, "UnsupportedOperationException");
   }
 }
 
@@ -4202,7 +4199,7 @@ export interface UntagResourceRequest {
 
 export namespace UntagResourceRequest {
   export function isa(o: any): o is UntagResourceRequest {
-    return _smithy.isa(o, "UntagResourceRequest");
+    return __isa(o, "UntagResourceRequest");
   }
 }
 
@@ -4212,7 +4209,7 @@ export interface UntagResourceResponse extends $MetadataBearer {
 
 export namespace UntagResourceResponse {
   export function isa(o: any): o is UntagResourceResponse {
-    return _smithy.isa(o, "UntagResourceResponse");
+    return __isa(o, "UntagResourceResponse");
   }
 }
 
@@ -4253,7 +4250,7 @@ export interface UpdateApplicationRequest {
 
 export namespace UpdateApplicationRequest {
   export function isa(o: any): o is UpdateApplicationRequest {
-    return _smithy.isa(o, "UpdateApplicationRequest");
+    return __isa(o, "UpdateApplicationRequest");
   }
 }
 
@@ -4267,7 +4264,7 @@ export interface UpdateApplicationResponse extends $MetadataBearer {
 
 export namespace UpdateApplicationResponse {
   export function isa(o: any): o is UpdateApplicationResponse {
-    return _smithy.isa(o, "UpdateApplicationResponse");
+    return __isa(o, "UpdateApplicationResponse");
   }
 }
 
@@ -4289,7 +4286,7 @@ export interface VpcConfiguration {
 
 export namespace VpcConfiguration {
   export function isa(o: any): o is VpcConfiguration {
-    return _smithy.isa(o, "VpcConfiguration");
+    return __isa(o, "VpcConfiguration");
   }
 }
 
@@ -4321,7 +4318,7 @@ export interface VpcConfigurationDescription {
 
 export namespace VpcConfigurationDescription {
   export function isa(o: any): o is VpcConfigurationDescription {
-    return _smithy.isa(o, "VpcConfigurationDescription");
+    return __isa(o, "VpcConfigurationDescription");
   }
 }
 
@@ -4349,6 +4346,6 @@ export interface VpcConfigurationUpdate {
 
 export namespace VpcConfigurationUpdate {
   export function isa(o: any): o is VpcConfigurationUpdate {
-    return _smithy.isa(o, "VpcConfigurationUpdate");
+    return __isa(o, "VpcConfigurationUpdate");
   }
 }

--- a/clients/client-kinesis-analytics/models/index.ts
+++ b/clients/client-kinesis-analytics/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export interface AddApplicationCloudWatchLoggingOptionRequest {
@@ -25,7 +28,7 @@ export namespace AddApplicationCloudWatchLoggingOptionRequest {
   export function isa(
     o: any
   ): o is AddApplicationCloudWatchLoggingOptionRequest {
-    return _smithy.isa(o, "AddApplicationCloudWatchLoggingOptionRequest");
+    return __isa(o, "AddApplicationCloudWatchLoggingOptionRequest");
   }
 }
 
@@ -38,7 +41,7 @@ export namespace AddApplicationCloudWatchLoggingOptionResponse {
   export function isa(
     o: any
   ): o is AddApplicationCloudWatchLoggingOptionResponse {
-    return _smithy.isa(o, "AddApplicationCloudWatchLoggingOptionResponse");
+    return __isa(o, "AddApplicationCloudWatchLoggingOptionResponse");
   }
 }
 
@@ -72,7 +75,7 @@ export namespace AddApplicationInputProcessingConfigurationRequest {
   export function isa(
     o: any
   ): o is AddApplicationInputProcessingConfigurationRequest {
-    return _smithy.isa(o, "AddApplicationInputProcessingConfigurationRequest");
+    return __isa(o, "AddApplicationInputProcessingConfigurationRequest");
   }
 }
 
@@ -85,7 +88,7 @@ export namespace AddApplicationInputProcessingConfigurationResponse {
   export function isa(
     o: any
   ): o is AddApplicationInputProcessingConfigurationResponse {
-    return _smithy.isa(o, "AddApplicationInputProcessingConfigurationResponse");
+    return __isa(o, "AddApplicationInputProcessingConfigurationResponse");
   }
 }
 
@@ -113,7 +116,7 @@ export interface AddApplicationInputRequest {
 
 export namespace AddApplicationInputRequest {
   export function isa(o: any): o is AddApplicationInputRequest {
-    return _smithy.isa(o, "AddApplicationInputRequest");
+    return __isa(o, "AddApplicationInputRequest");
   }
 }
 
@@ -126,7 +129,7 @@ export interface AddApplicationInputResponse extends $MetadataBearer {
 
 export namespace AddApplicationInputResponse {
   export function isa(o: any): o is AddApplicationInputResponse {
-    return _smithy.isa(o, "AddApplicationInputResponse");
+    return __isa(o, "AddApplicationInputResponse");
   }
 }
 
@@ -159,7 +162,7 @@ export interface AddApplicationOutputRequest {
 
 export namespace AddApplicationOutputRequest {
   export function isa(o: any): o is AddApplicationOutputRequest {
-    return _smithy.isa(o, "AddApplicationOutputRequest");
+    return __isa(o, "AddApplicationOutputRequest");
   }
 }
 
@@ -172,7 +175,7 @@ export interface AddApplicationOutputResponse extends $MetadataBearer {
 
 export namespace AddApplicationOutputResponse {
   export function isa(o: any): o is AddApplicationOutputResponse {
-    return _smithy.isa(o, "AddApplicationOutputResponse");
+    return __isa(o, "AddApplicationOutputResponse");
   }
 }
 
@@ -202,7 +205,7 @@ export interface AddApplicationReferenceDataSourceRequest {
 
 export namespace AddApplicationReferenceDataSourceRequest {
   export function isa(o: any): o is AddApplicationReferenceDataSourceRequest {
-    return _smithy.isa(o, "AddApplicationReferenceDataSourceRequest");
+    return __isa(o, "AddApplicationReferenceDataSourceRequest");
   }
 }
 
@@ -216,7 +219,7 @@ export interface AddApplicationReferenceDataSourceResponse
 
 export namespace AddApplicationReferenceDataSourceResponse {
   export function isa(o: any): o is AddApplicationReferenceDataSourceResponse {
-    return _smithy.isa(o, "AddApplicationReferenceDataSourceResponse");
+    return __isa(o, "AddApplicationReferenceDataSourceResponse");
   }
 }
 
@@ -309,7 +312,7 @@ export interface ApplicationDetail {
 
 export namespace ApplicationDetail {
   export function isa(o: any): o is ApplicationDetail {
-    return _smithy.isa(o, "ApplicationDetail");
+    return __isa(o, "ApplicationDetail");
   }
 }
 
@@ -348,7 +351,7 @@ export interface ApplicationSummary {
 
 export namespace ApplicationSummary {
   export function isa(o: any): o is ApplicationSummary {
-    return _smithy.isa(o, "ApplicationSummary");
+    return __isa(o, "ApplicationSummary");
   }
 }
 
@@ -385,7 +388,7 @@ export interface ApplicationUpdate {
 
 export namespace ApplicationUpdate {
   export function isa(o: any): o is ApplicationUpdate {
-    return _smithy.isa(o, "ApplicationUpdate");
+    return __isa(o, "ApplicationUpdate");
   }
 }
 
@@ -417,7 +420,7 @@ export interface CSVMappingParameters {
 
 export namespace CSVMappingParameters {
   export function isa(o: any): o is CSVMappingParameters {
-    return _smithy.isa(o, "CSVMappingParameters");
+    return __isa(o, "CSVMappingParameters");
   }
 }
 
@@ -442,7 +445,7 @@ export interface CloudWatchLoggingOption {
 
 export namespace CloudWatchLoggingOption {
   export function isa(o: any): o is CloudWatchLoggingOption {
-    return _smithy.isa(o, "CloudWatchLoggingOption");
+    return __isa(o, "CloudWatchLoggingOption");
   }
 }
 
@@ -469,7 +472,7 @@ export interface CloudWatchLoggingOptionDescription {
 
 export namespace CloudWatchLoggingOptionDescription {
   export function isa(o: any): o is CloudWatchLoggingOptionDescription {
-    return _smithy.isa(o, "CloudWatchLoggingOptionDescription");
+    return __isa(o, "CloudWatchLoggingOptionDescription");
   }
 }
 
@@ -496,7 +499,7 @@ export interface CloudWatchLoggingOptionUpdate {
 
 export namespace CloudWatchLoggingOptionUpdate {
   export function isa(o: any): o is CloudWatchLoggingOptionUpdate {
-    return _smithy.isa(o, "CloudWatchLoggingOptionUpdate");
+    return __isa(o, "CloudWatchLoggingOptionUpdate");
   }
 }
 
@@ -504,7 +507,7 @@ export namespace CloudWatchLoggingOptionUpdate {
  * <p>User-provided application code (query) is invalid. This can be a simple syntax error.</p>
  */
 export interface CodeValidationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CodeValidationException";
   $fault: "client";
@@ -516,7 +519,7 @@ export interface CodeValidationException
 
 export namespace CodeValidationException {
   export function isa(o: any): o is CodeValidationException {
-    return _smithy.isa(o, "CodeValidationException");
+    return __isa(o, "CodeValidationException");
   }
 }
 
@@ -524,7 +527,7 @@ export namespace CodeValidationException {
  * <p>Exception thrown as a result of concurrent modification to an application. For example, two individuals attempting to edit the same application at the same time.</p>
  */
 export interface ConcurrentModificationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ConcurrentModificationException";
   $fault: "client";
@@ -536,7 +539,7 @@ export interface ConcurrentModificationException
 
 export namespace ConcurrentModificationException {
   export function isa(o: any): o is ConcurrentModificationException {
-    return _smithy.isa(o, "ConcurrentModificationException");
+    return __isa(o, "ConcurrentModificationException");
   }
 }
 
@@ -614,7 +617,7 @@ export interface CreateApplicationRequest {
 
 export namespace CreateApplicationRequest {
   export function isa(o: any): o is CreateApplicationRequest {
-    return _smithy.isa(o, "CreateApplicationRequest");
+    return __isa(o, "CreateApplicationRequest");
   }
 }
 
@@ -633,7 +636,7 @@ export interface CreateApplicationResponse extends $MetadataBearer {
 
 export namespace CreateApplicationResponse {
   export function isa(o: any): o is CreateApplicationResponse {
-    return _smithy.isa(o, "CreateApplicationResponse");
+    return __isa(o, "CreateApplicationResponse");
   }
 }
 
@@ -660,7 +663,7 @@ export namespace DeleteApplicationCloudWatchLoggingOptionRequest {
   export function isa(
     o: any
   ): o is DeleteApplicationCloudWatchLoggingOptionRequest {
-    return _smithy.isa(o, "DeleteApplicationCloudWatchLoggingOptionRequest");
+    return __isa(o, "DeleteApplicationCloudWatchLoggingOptionRequest");
   }
 }
 
@@ -673,7 +676,7 @@ export namespace DeleteApplicationCloudWatchLoggingOptionResponse {
   export function isa(
     o: any
   ): o is DeleteApplicationCloudWatchLoggingOptionResponse {
-    return _smithy.isa(o, "DeleteApplicationCloudWatchLoggingOptionResponse");
+    return __isa(o, "DeleteApplicationCloudWatchLoggingOptionResponse");
   }
 }
 
@@ -700,10 +703,7 @@ export namespace DeleteApplicationInputProcessingConfigurationRequest {
   export function isa(
     o: any
   ): o is DeleteApplicationInputProcessingConfigurationRequest {
-    return _smithy.isa(
-      o,
-      "DeleteApplicationInputProcessingConfigurationRequest"
-    );
+    return __isa(o, "DeleteApplicationInputProcessingConfigurationRequest");
   }
 }
 
@@ -716,10 +716,7 @@ export namespace DeleteApplicationInputProcessingConfigurationResponse {
   export function isa(
     o: any
   ): o is DeleteApplicationInputProcessingConfigurationResponse {
-    return _smithy.isa(
-      o,
-      "DeleteApplicationInputProcessingConfigurationResponse"
-    );
+    return __isa(o, "DeleteApplicationInputProcessingConfigurationResponse");
   }
 }
 
@@ -757,7 +754,7 @@ export interface DeleteApplicationOutputRequest {
 
 export namespace DeleteApplicationOutputRequest {
   export function isa(o: any): o is DeleteApplicationOutputRequest {
-    return _smithy.isa(o, "DeleteApplicationOutputRequest");
+    return __isa(o, "DeleteApplicationOutputRequest");
   }
 }
 
@@ -770,7 +767,7 @@ export interface DeleteApplicationOutputResponse extends $MetadataBearer {
 
 export namespace DeleteApplicationOutputResponse {
   export function isa(o: any): o is DeleteApplicationOutputResponse {
-    return _smithy.isa(o, "DeleteApplicationOutputResponse");
+    return __isa(o, "DeleteApplicationOutputResponse");
   }
 }
 
@@ -803,7 +800,7 @@ export namespace DeleteApplicationReferenceDataSourceRequest {
   export function isa(
     o: any
   ): o is DeleteApplicationReferenceDataSourceRequest {
-    return _smithy.isa(o, "DeleteApplicationReferenceDataSourceRequest");
+    return __isa(o, "DeleteApplicationReferenceDataSourceRequest");
   }
 }
 
@@ -816,7 +813,7 @@ export namespace DeleteApplicationReferenceDataSourceResponse {
   export function isa(
     o: any
   ): o is DeleteApplicationReferenceDataSourceResponse {
-    return _smithy.isa(o, "DeleteApplicationReferenceDataSourceResponse");
+    return __isa(o, "DeleteApplicationReferenceDataSourceResponse");
   }
 }
 
@@ -840,7 +837,7 @@ export interface DeleteApplicationRequest {
 
 export namespace DeleteApplicationRequest {
   export function isa(o: any): o is DeleteApplicationRequest {
-    return _smithy.isa(o, "DeleteApplicationRequest");
+    return __isa(o, "DeleteApplicationRequest");
   }
 }
 
@@ -853,7 +850,7 @@ export interface DeleteApplicationResponse extends $MetadataBearer {
 
 export namespace DeleteApplicationResponse {
   export function isa(o: any): o is DeleteApplicationResponse {
-    return _smithy.isa(o, "DeleteApplicationResponse");
+    return __isa(o, "DeleteApplicationResponse");
   }
 }
 
@@ -870,7 +867,7 @@ export interface DescribeApplicationRequest {
 
 export namespace DescribeApplicationRequest {
   export function isa(o: any): o is DescribeApplicationRequest {
-    return _smithy.isa(o, "DescribeApplicationRequest");
+    return __isa(o, "DescribeApplicationRequest");
   }
 }
 
@@ -887,7 +884,7 @@ export interface DescribeApplicationResponse extends $MetadataBearer {
 
 export namespace DescribeApplicationResponse {
   export function isa(o: any): o is DescribeApplicationResponse {
-    return _smithy.isa(o, "DescribeApplicationResponse");
+    return __isa(o, "DescribeApplicationResponse");
   }
 }
 
@@ -909,7 +906,7 @@ export interface DestinationSchema {
 
 export namespace DestinationSchema {
   export function isa(o: any): o is DestinationSchema {
-    return _smithy.isa(o, "DestinationSchema");
+    return __isa(o, "DestinationSchema");
   }
 }
 
@@ -944,7 +941,7 @@ export interface DiscoverInputSchemaRequest {
 
 export namespace DiscoverInputSchemaRequest {
   export function isa(o: any): o is DiscoverInputSchemaRequest {
-    return _smithy.isa(o, "DiscoverInputSchemaRequest");
+    return __isa(o, "DiscoverInputSchemaRequest");
   }
 }
 
@@ -976,7 +973,7 @@ export interface DiscoverInputSchemaResponse extends $MetadataBearer {
 
 export namespace DiscoverInputSchemaResponse {
   export function isa(o: any): o is DiscoverInputSchemaResponse {
-    return _smithy.isa(o, "DiscoverInputSchemaResponse");
+    return __isa(o, "DiscoverInputSchemaResponse");
   }
 }
 
@@ -1036,7 +1033,7 @@ export interface Input {
 
 export namespace Input {
   export function isa(o: any): o is Input {
-    return _smithy.isa(o, "Input");
+    return __isa(o, "Input");
   }
 }
 
@@ -1064,7 +1061,7 @@ export interface InputConfiguration {
 
 export namespace InputConfiguration {
   export function isa(o: any): o is InputConfiguration {
-    return _smithy.isa(o, "InputConfiguration");
+    return __isa(o, "InputConfiguration");
   }
 }
 
@@ -1133,7 +1130,7 @@ export interface InputDescription {
 
 export namespace InputDescription {
   export function isa(o: any): o is InputDescription {
-    return _smithy.isa(o, "InputDescription");
+    return __isa(o, "InputDescription");
   }
 }
 
@@ -1162,7 +1159,7 @@ export interface InputLambdaProcessor {
 
 export namespace InputLambdaProcessor {
   export function isa(o: any): o is InputLambdaProcessor {
-    return _smithy.isa(o, "InputLambdaProcessor");
+    return __isa(o, "InputLambdaProcessor");
   }
 }
 
@@ -1186,7 +1183,7 @@ export interface InputLambdaProcessorDescription {
 
 export namespace InputLambdaProcessorDescription {
   export function isa(o: any): o is InputLambdaProcessorDescription {
-    return _smithy.isa(o, "InputLambdaProcessorDescription");
+    return __isa(o, "InputLambdaProcessorDescription");
   }
 }
 
@@ -1214,7 +1211,7 @@ export interface InputLambdaProcessorUpdate {
 
 export namespace InputLambdaProcessorUpdate {
   export function isa(o: any): o is InputLambdaProcessorUpdate {
-    return _smithy.isa(o, "InputLambdaProcessorUpdate");
+    return __isa(o, "InputLambdaProcessorUpdate");
   }
 }
 
@@ -1236,7 +1233,7 @@ export interface InputParallelism {
 
 export namespace InputParallelism {
   export function isa(o: any): o is InputParallelism {
-    return _smithy.isa(o, "InputParallelism");
+    return __isa(o, "InputParallelism");
   }
 }
 
@@ -1254,7 +1251,7 @@ export interface InputParallelismUpdate {
 
 export namespace InputParallelismUpdate {
   export function isa(o: any): o is InputParallelismUpdate {
-    return _smithy.isa(o, "InputParallelismUpdate");
+    return __isa(o, "InputParallelismUpdate");
   }
 }
 
@@ -1275,7 +1272,7 @@ export interface InputProcessingConfiguration {
 
 export namespace InputProcessingConfiguration {
   export function isa(o: any): o is InputProcessingConfiguration {
-    return _smithy.isa(o, "InputProcessingConfiguration");
+    return __isa(o, "InputProcessingConfiguration");
   }
 }
 
@@ -1293,7 +1290,7 @@ export interface InputProcessingConfigurationDescription {
 
 export namespace InputProcessingConfigurationDescription {
   export function isa(o: any): o is InputProcessingConfigurationDescription {
-    return _smithy.isa(o, "InputProcessingConfigurationDescription");
+    return __isa(o, "InputProcessingConfigurationDescription");
   }
 }
 
@@ -1310,7 +1307,7 @@ export interface InputProcessingConfigurationUpdate {
 
 export namespace InputProcessingConfigurationUpdate {
   export function isa(o: any): o is InputProcessingConfigurationUpdate {
-    return _smithy.isa(o, "InputProcessingConfigurationUpdate");
+    return __isa(o, "InputProcessingConfigurationUpdate");
   }
 }
 
@@ -1338,7 +1335,7 @@ export interface InputSchemaUpdate {
 
 export namespace InputSchemaUpdate {
   export function isa(o: any): o is InputSchemaUpdate {
-    return _smithy.isa(o, "InputSchemaUpdate");
+    return __isa(o, "InputSchemaUpdate");
   }
 }
 
@@ -1381,7 +1378,7 @@ export interface InputStartingPositionConfiguration {
 
 export namespace InputStartingPositionConfiguration {
   export function isa(o: any): o is InputStartingPositionConfiguration {
-    return _smithy.isa(o, "InputStartingPositionConfiguration");
+    return __isa(o, "InputStartingPositionConfiguration");
   }
 }
 
@@ -1434,7 +1431,7 @@ export interface InputUpdate {
 
 export namespace InputUpdate {
   export function isa(o: any): o is InputUpdate {
-    return _smithy.isa(o, "InputUpdate");
+    return __isa(o, "InputUpdate");
   }
 }
 
@@ -1442,7 +1439,7 @@ export namespace InputUpdate {
  * <p>User-provided application configuration is not valid.</p>
  */
 export interface InvalidApplicationConfigurationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidApplicationConfigurationException";
   $fault: "client";
@@ -1454,7 +1451,7 @@ export interface InvalidApplicationConfigurationException
 
 export namespace InvalidApplicationConfigurationException {
   export function isa(o: any): o is InvalidApplicationConfigurationException {
-    return _smithy.isa(o, "InvalidApplicationConfigurationException");
+    return __isa(o, "InvalidApplicationConfigurationException");
   }
 }
 
@@ -1462,7 +1459,7 @@ export namespace InvalidApplicationConfigurationException {
  * <p>Specified input parameter value is invalid.</p>
  */
 export interface InvalidArgumentException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidArgumentException";
   $fault: "client";
@@ -1474,7 +1471,7 @@ export interface InvalidArgumentException
 
 export namespace InvalidArgumentException {
   export function isa(o: any): o is InvalidArgumentException {
-    return _smithy.isa(o, "InvalidArgumentException");
+    return __isa(o, "InvalidArgumentException");
   }
 }
 
@@ -1491,7 +1488,7 @@ export interface JSONMappingParameters {
 
 export namespace JSONMappingParameters {
   export function isa(o: any): o is JSONMappingParameters {
-    return _smithy.isa(o, "JSONMappingParameters");
+    return __isa(o, "JSONMappingParameters");
   }
 }
 
@@ -1517,7 +1514,7 @@ export interface KinesisFirehoseInput {
 
 export namespace KinesisFirehoseInput {
   export function isa(o: any): o is KinesisFirehoseInput {
-    return _smithy.isa(o, "KinesisFirehoseInput");
+    return __isa(o, "KinesisFirehoseInput");
   }
 }
 
@@ -1542,7 +1539,7 @@ export interface KinesisFirehoseInputDescription {
 
 export namespace KinesisFirehoseInputDescription {
   export function isa(o: any): o is KinesisFirehoseInputDescription {
-    return _smithy.isa(o, "KinesisFirehoseInputDescription");
+    return __isa(o, "KinesisFirehoseInputDescription");
   }
 }
 
@@ -1567,7 +1564,7 @@ export interface KinesisFirehoseInputUpdate {
 
 export namespace KinesisFirehoseInputUpdate {
   export function isa(o: any): o is KinesisFirehoseInputUpdate {
-    return _smithy.isa(o, "KinesisFirehoseInputUpdate");
+    return __isa(o, "KinesisFirehoseInputUpdate");
   }
 }
 
@@ -1592,7 +1589,7 @@ export interface KinesisFirehoseOutput {
 
 export namespace KinesisFirehoseOutput {
   export function isa(o: any): o is KinesisFirehoseOutput {
-    return _smithy.isa(o, "KinesisFirehoseOutput");
+    return __isa(o, "KinesisFirehoseOutput");
   }
 }
 
@@ -1617,7 +1614,7 @@ export interface KinesisFirehoseOutputDescription {
 
 export namespace KinesisFirehoseOutputDescription {
   export function isa(o: any): o is KinesisFirehoseOutputDescription {
-    return _smithy.isa(o, "KinesisFirehoseOutputDescription");
+    return __isa(o, "KinesisFirehoseOutputDescription");
   }
 }
 
@@ -1645,7 +1642,7 @@ export interface KinesisFirehoseOutputUpdate {
 
 export namespace KinesisFirehoseOutputUpdate {
   export function isa(o: any): o is KinesisFirehoseOutputUpdate {
-    return _smithy.isa(o, "KinesisFirehoseOutputUpdate");
+    return __isa(o, "KinesisFirehoseOutputUpdate");
   }
 }
 
@@ -1669,7 +1666,7 @@ export interface KinesisStreamsInput {
 
 export namespace KinesisStreamsInput {
   export function isa(o: any): o is KinesisStreamsInput {
-    return _smithy.isa(o, "KinesisStreamsInput");
+    return __isa(o, "KinesisStreamsInput");
   }
 }
 
@@ -1694,7 +1691,7 @@ export interface KinesisStreamsInputDescription {
 
 export namespace KinesisStreamsInputDescription {
   export function isa(o: any): o is KinesisStreamsInputDescription {
-    return _smithy.isa(o, "KinesisStreamsInputDescription");
+    return __isa(o, "KinesisStreamsInputDescription");
   }
 }
 
@@ -1717,7 +1714,7 @@ export interface KinesisStreamsInputUpdate {
 
 export namespace KinesisStreamsInputUpdate {
   export function isa(o: any): o is KinesisStreamsInputUpdate {
-    return _smithy.isa(o, "KinesisStreamsInputUpdate");
+    return __isa(o, "KinesisStreamsInputUpdate");
   }
 }
 
@@ -1741,7 +1738,7 @@ export interface KinesisStreamsOutput {
 
 export namespace KinesisStreamsOutput {
   export function isa(o: any): o is KinesisStreamsOutput {
-    return _smithy.isa(o, "KinesisStreamsOutput");
+    return __isa(o, "KinesisStreamsOutput");
   }
 }
 
@@ -1766,7 +1763,7 @@ export interface KinesisStreamsOutputDescription {
 
 export namespace KinesisStreamsOutputDescription {
   export function isa(o: any): o is KinesisStreamsOutputDescription {
-    return _smithy.isa(o, "KinesisStreamsOutputDescription");
+    return __isa(o, "KinesisStreamsOutputDescription");
   }
 }
 
@@ -1793,7 +1790,7 @@ export interface KinesisStreamsOutputUpdate {
 
 export namespace KinesisStreamsOutputUpdate {
   export function isa(o: any): o is KinesisStreamsOutputUpdate {
-    return _smithy.isa(o, "KinesisStreamsOutputUpdate");
+    return __isa(o, "KinesisStreamsOutputUpdate");
   }
 }
 
@@ -1822,7 +1819,7 @@ export interface LambdaOutput {
 
 export namespace LambdaOutput {
   export function isa(o: any): o is LambdaOutput {
-    return _smithy.isa(o, "LambdaOutput");
+    return __isa(o, "LambdaOutput");
   }
 }
 
@@ -1845,7 +1842,7 @@ export interface LambdaOutputDescription {
 
 export namespace LambdaOutputDescription {
   export function isa(o: any): o is LambdaOutputDescription {
-    return _smithy.isa(o, "LambdaOutputDescription");
+    return __isa(o, "LambdaOutputDescription");
   }
 }
 
@@ -1873,7 +1870,7 @@ export interface LambdaOutputUpdate {
 
 export namespace LambdaOutputUpdate {
   export function isa(o: any): o is LambdaOutputUpdate {
-    return _smithy.isa(o, "LambdaOutputUpdate");
+    return __isa(o, "LambdaOutputUpdate");
   }
 }
 
@@ -1881,7 +1878,7 @@ export namespace LambdaOutputUpdate {
  * <p>Exceeded the number of applications allowed.</p>
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -1893,7 +1890,7 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
@@ -1915,7 +1912,7 @@ export interface ListApplicationsRequest {
 
 export namespace ListApplicationsRequest {
   export function isa(o: any): o is ListApplicationsRequest {
-    return _smithy.isa(o, "ListApplicationsRequest");
+    return __isa(o, "ListApplicationsRequest");
   }
 }
 
@@ -1937,7 +1934,7 @@ export interface ListApplicationsResponse extends $MetadataBearer {
 
 export namespace ListApplicationsResponse {
   export function isa(o: any): o is ListApplicationsResponse {
-    return _smithy.isa(o, "ListApplicationsResponse");
+    return __isa(o, "ListApplicationsResponse");
   }
 }
 
@@ -1951,7 +1948,7 @@ export interface ListTagsForResourceRequest {
 
 export namespace ListTagsForResourceRequest {
   export function isa(o: any): o is ListTagsForResourceRequest {
-    return _smithy.isa(o, "ListTagsForResourceRequest");
+    return __isa(o, "ListTagsForResourceRequest");
   }
 }
 
@@ -1965,7 +1962,7 @@ export interface ListTagsForResourceResponse extends $MetadataBearer {
 
 export namespace ListTagsForResourceResponse {
   export function isa(o: any): o is ListTagsForResourceResponse {
-    return _smithy.isa(o, "ListTagsForResourceResponse");
+    return __isa(o, "ListTagsForResourceResponse");
   }
 }
 
@@ -1992,7 +1989,7 @@ export interface MappingParameters {
 
 export namespace MappingParameters {
   export function isa(o: any): o is MappingParameters {
-    return _smithy.isa(o, "MappingParameters");
+    return __isa(o, "MappingParameters");
   }
 }
 
@@ -2041,7 +2038,7 @@ export interface Output {
 
 export namespace Output {
   export function isa(o: any): o is Output {
-    return _smithy.isa(o, "Output");
+    return __isa(o, "Output");
   }
 }
 
@@ -2090,7 +2087,7 @@ export interface OutputDescription {
 
 export namespace OutputDescription {
   export function isa(o: any): o is OutputDescription {
-    return _smithy.isa(o, "OutputDescription");
+    return __isa(o, "OutputDescription");
   }
 }
 
@@ -2138,7 +2135,7 @@ export interface OutputUpdate {
 
 export namespace OutputUpdate {
   export function isa(o: any): o is OutputUpdate {
-    return _smithy.isa(o, "OutputUpdate");
+    return __isa(o, "OutputUpdate");
   }
 }
 
@@ -2168,7 +2165,7 @@ export interface RecordColumn {
 
 export namespace RecordColumn {
   export function isa(o: any): o is RecordColumn {
-    return _smithy.isa(o, "RecordColumn");
+    return __isa(o, "RecordColumn");
   }
 }
 
@@ -2193,7 +2190,7 @@ export interface RecordFormat {
 
 export namespace RecordFormat {
   export function isa(o: any): o is RecordFormat {
-    return _smithy.isa(o, "RecordFormat");
+    return __isa(o, "RecordFormat");
   }
 }
 
@@ -2227,7 +2224,7 @@ export interface ReferenceDataSource {
 
 export namespace ReferenceDataSource {
   export function isa(o: any): o is ReferenceDataSource {
-    return _smithy.isa(o, "ReferenceDataSource");
+    return __isa(o, "ReferenceDataSource");
   }
 }
 
@@ -2263,7 +2260,7 @@ export interface ReferenceDataSourceDescription {
 
 export namespace ReferenceDataSourceDescription {
   export function isa(o: any): o is ReferenceDataSourceDescription {
-    return _smithy.isa(o, "ReferenceDataSourceDescription");
+    return __isa(o, "ReferenceDataSourceDescription");
   }
 }
 
@@ -2296,7 +2293,7 @@ export interface ReferenceDataSourceUpdate {
 
 export namespace ReferenceDataSourceUpdate {
   export function isa(o: any): o is ReferenceDataSourceUpdate {
-    return _smithy.isa(o, "ReferenceDataSourceUpdate");
+    return __isa(o, "ReferenceDataSourceUpdate");
   }
 }
 
@@ -2304,7 +2301,7 @@ export namespace ReferenceDataSourceUpdate {
  * <p>Application is not available for this operation.</p>
  */
 export interface ResourceInUseException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceInUseException";
   $fault: "client";
@@ -2316,7 +2313,7 @@ export interface ResourceInUseException
 
 export namespace ResourceInUseException {
   export function isa(o: any): o is ResourceInUseException {
-    return _smithy.isa(o, "ResourceInUseException");
+    return __isa(o, "ResourceInUseException");
   }
 }
 
@@ -2324,7 +2321,7 @@ export namespace ResourceInUseException {
  * <p>Specified application can't be found.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -2336,7 +2333,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -2348,7 +2345,7 @@ export namespace ResourceNotFoundException {
  *             in the Amazon Kinesis Streams API Reference.</p>
  */
 export interface ResourceProvisionedThroughputExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceProvisionedThroughputExceededException";
   $fault: "client";
@@ -2359,7 +2356,7 @@ export namespace ResourceProvisionedThroughputExceededException {
   export function isa(
     o: any
   ): o is ResourceProvisionedThroughputExceededException {
-    return _smithy.isa(o, "ResourceProvisionedThroughputExceededException");
+    return __isa(o, "ResourceProvisionedThroughputExceededException");
   }
 }
 
@@ -2388,7 +2385,7 @@ export interface S3Configuration {
 
 export namespace S3Configuration {
   export function isa(o: any): o is S3Configuration {
-    return _smithy.isa(o, "S3Configuration");
+    return __isa(o, "S3Configuration");
   }
 }
 
@@ -2418,7 +2415,7 @@ export interface S3ReferenceDataSource {
 
 export namespace S3ReferenceDataSource {
   export function isa(o: any): o is S3ReferenceDataSource {
-    return _smithy.isa(o, "S3ReferenceDataSource");
+    return __isa(o, "S3ReferenceDataSource");
   }
 }
 
@@ -2445,7 +2442,7 @@ export interface S3ReferenceDataSourceDescription {
 
 export namespace S3ReferenceDataSourceDescription {
   export function isa(o: any): o is S3ReferenceDataSourceDescription {
-    return _smithy.isa(o, "S3ReferenceDataSourceDescription");
+    return __isa(o, "S3ReferenceDataSourceDescription");
   }
 }
 
@@ -2472,7 +2469,7 @@ export interface S3ReferenceDataSourceUpdate {
 
 export namespace S3ReferenceDataSourceUpdate {
   export function isa(o: any): o is S3ReferenceDataSourceUpdate {
-    return _smithy.isa(o, "S3ReferenceDataSourceUpdate");
+    return __isa(o, "S3ReferenceDataSourceUpdate");
   }
 }
 
@@ -2480,7 +2477,7 @@ export namespace S3ReferenceDataSourceUpdate {
  * <p>The service is unavailable. Back off and retry the operation. </p>
  */
 export interface ServiceUnavailableException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ServiceUnavailableException";
   $fault: "server";
@@ -2489,7 +2486,7 @@ export interface ServiceUnavailableException
 
 export namespace ServiceUnavailableException {
   export function isa(o: any): o is ServiceUnavailableException {
-    return _smithy.isa(o, "ServiceUnavailableException");
+    return __isa(o, "ServiceUnavailableException");
   }
 }
 
@@ -2516,7 +2513,7 @@ export interface SourceSchema {
 
 export namespace SourceSchema {
   export function isa(o: any): o is SourceSchema {
-    return _smithy.isa(o, "SourceSchema");
+    return __isa(o, "SourceSchema");
   }
 }
 
@@ -2538,7 +2535,7 @@ export interface StartApplicationRequest {
 
 export namespace StartApplicationRequest {
   export function isa(o: any): o is StartApplicationRequest {
-    return _smithy.isa(o, "StartApplicationRequest");
+    return __isa(o, "StartApplicationRequest");
   }
 }
 
@@ -2551,7 +2548,7 @@ export interface StartApplicationResponse extends $MetadataBearer {
 
 export namespace StartApplicationResponse {
   export function isa(o: any): o is StartApplicationResponse {
-    return _smithy.isa(o, "StartApplicationResponse");
+    return __isa(o, "StartApplicationResponse");
   }
 }
 
@@ -2568,7 +2565,7 @@ export interface StopApplicationRequest {
 
 export namespace StopApplicationRequest {
   export function isa(o: any): o is StopApplicationRequest {
-    return _smithy.isa(o, "StopApplicationRequest");
+    return __isa(o, "StopApplicationRequest");
   }
 }
 
@@ -2581,7 +2578,7 @@ export interface StopApplicationResponse extends $MetadataBearer {
 
 export namespace StopApplicationResponse {
   export function isa(o: any): o is StopApplicationResponse {
-    return _smithy.isa(o, "StopApplicationResponse");
+    return __isa(o, "StopApplicationResponse");
   }
 }
 
@@ -2605,7 +2602,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -2624,7 +2621,7 @@ export interface TagResourceRequest {
 
 export namespace TagResourceRequest {
   export function isa(o: any): o is TagResourceRequest {
-    return _smithy.isa(o, "TagResourceRequest");
+    return __isa(o, "TagResourceRequest");
   }
 }
 
@@ -2634,7 +2631,7 @@ export interface TagResourceResponse extends $MetadataBearer {
 
 export namespace TagResourceResponse {
   export function isa(o: any): o is TagResourceResponse {
-    return _smithy.isa(o, "TagResourceResponse");
+    return __isa(o, "TagResourceResponse");
   }
 }
 
@@ -2642,7 +2639,7 @@ export namespace TagResourceResponse {
  * <p>Application created with too many tags, or too many tags added to an application. Note that the maximum number of application tags includes system tags. The maximum number of user-defined application tags is 50.</p>
  */
 export interface TooManyTagsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyTagsException";
   $fault: "client";
@@ -2651,7 +2648,7 @@ export interface TooManyTagsException
 
 export namespace TooManyTagsException {
   export function isa(o: any): o is TooManyTagsException {
-    return _smithy.isa(o, "TooManyTagsException");
+    return __isa(o, "TooManyTagsException");
   }
 }
 
@@ -2660,7 +2657,7 @@ export namespace TooManyTagsException {
  *             the given streaming source.</p>
  */
 export interface UnableToDetectSchemaException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UnableToDetectSchemaException";
   $fault: "client";
@@ -2671,7 +2668,7 @@ export interface UnableToDetectSchemaException
 
 export namespace UnableToDetectSchemaException {
   export function isa(o: any): o is UnableToDetectSchemaException {
-    return _smithy.isa(o, "UnableToDetectSchemaException");
+    return __isa(o, "UnableToDetectSchemaException");
   }
 }
 
@@ -2679,7 +2676,7 @@ export namespace UnableToDetectSchemaException {
  * <p>The request was rejected because a specified parameter is not supported or a specified resource is not valid for this operation. </p>
  */
 export interface UnsupportedOperationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UnsupportedOperationException";
   $fault: "client";
@@ -2688,7 +2685,7 @@ export interface UnsupportedOperationException
 
 export namespace UnsupportedOperationException {
   export function isa(o: any): o is UnsupportedOperationException {
-    return _smithy.isa(o, "UnsupportedOperationException");
+    return __isa(o, "UnsupportedOperationException");
   }
 }
 
@@ -2707,7 +2704,7 @@ export interface UntagResourceRequest {
 
 export namespace UntagResourceRequest {
   export function isa(o: any): o is UntagResourceRequest {
-    return _smithy.isa(o, "UntagResourceRequest");
+    return __isa(o, "UntagResourceRequest");
   }
 }
 
@@ -2717,7 +2714,7 @@ export interface UntagResourceResponse extends $MetadataBearer {
 
 export namespace UntagResourceResponse {
   export function isa(o: any): o is UntagResourceResponse {
-    return _smithy.isa(o, "UntagResourceResponse");
+    return __isa(o, "UntagResourceResponse");
   }
 }
 
@@ -2742,7 +2739,7 @@ export interface UpdateApplicationRequest {
 
 export namespace UpdateApplicationRequest {
   export function isa(o: any): o is UpdateApplicationRequest {
-    return _smithy.isa(o, "UpdateApplicationRequest");
+    return __isa(o, "UpdateApplicationRequest");
   }
 }
 
@@ -2752,6 +2749,6 @@ export interface UpdateApplicationResponse extends $MetadataBearer {
 
 export namespace UpdateApplicationResponse {
   export function isa(o: any): o is UpdateApplicationResponse {
-    return _smithy.isa(o, "UpdateApplicationResponse");
+    return __isa(o, "UpdateApplicationResponse");
   }
 }

--- a/clients/client-kinesis-video-archived-media/models/index.ts
+++ b/clients/client-kinesis-video-archived-media/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export enum ContainerFormat {
@@ -57,7 +60,7 @@ export interface DASHFragmentSelector {
 
 export namespace DASHFragmentSelector {
   export function isa(o: any): o is DASHFragmentSelector {
-    return _smithy.isa(o, "DASHFragmentSelector");
+    return __isa(o, "DASHFragmentSelector");
   }
 }
 
@@ -120,7 +123,7 @@ export interface DASHTimestampRange {
 
 export namespace DASHTimestampRange {
   export function isa(o: any): o is DASHTimestampRange {
-    return _smithy.isa(o, "DASHTimestampRange");
+    return __isa(o, "DASHTimestampRange");
   }
 }
 
@@ -159,7 +162,7 @@ export interface Fragment {
 
 export namespace Fragment {
   export function isa(o: any): o is Fragment {
-    return _smithy.isa(o, "Fragment");
+    return __isa(o, "Fragment");
   }
 }
 
@@ -200,7 +203,7 @@ export interface FragmentSelector {
 
 export namespace FragmentSelector {
   export function isa(o: any): o is FragmentSelector {
-    return _smithy.isa(o, "FragmentSelector");
+    return __isa(o, "FragmentSelector");
   }
 }
 
@@ -365,7 +368,7 @@ export interface GetDASHStreamingSessionURLInput {
 
 export namespace GetDASHStreamingSessionURLInput {
   export function isa(o: any): o is GetDASHStreamingSessionURLInput {
-    return _smithy.isa(o, "GetDASHStreamingSessionURLInput");
+    return __isa(o, "GetDASHStreamingSessionURLInput");
   }
 }
 
@@ -380,7 +383,7 @@ export interface GetDASHStreamingSessionURLOutput extends $MetadataBearer {
 
 export namespace GetDASHStreamingSessionURLOutput {
   export function isa(o: any): o is GetDASHStreamingSessionURLOutput {
-    return _smithy.isa(o, "GetDASHStreamingSessionURLOutput");
+    return __isa(o, "GetDASHStreamingSessionURLOutput");
   }
 }
 
@@ -581,7 +584,7 @@ export interface GetHLSStreamingSessionURLInput {
 
 export namespace GetHLSStreamingSessionURLInput {
   export function isa(o: any): o is GetHLSStreamingSessionURLInput {
-    return _smithy.isa(o, "GetHLSStreamingSessionURLInput");
+    return __isa(o, "GetHLSStreamingSessionURLInput");
   }
 }
 
@@ -596,7 +599,7 @@ export interface GetHLSStreamingSessionURLOutput extends $MetadataBearer {
 
 export namespace GetHLSStreamingSessionURLOutput {
   export function isa(o: any): o is GetHLSStreamingSessionURLOutput {
-    return _smithy.isa(o, "GetHLSStreamingSessionURLOutput");
+    return __isa(o, "GetHLSStreamingSessionURLOutput");
   }
 }
 
@@ -616,7 +619,7 @@ export interface GetMediaForFragmentListInput {
 
 export namespace GetMediaForFragmentListInput {
   export function isa(o: any): o is GetMediaForFragmentListInput {
-    return _smithy.isa(o, "GetMediaForFragmentListInput");
+    return __isa(o, "GetMediaForFragmentListInput");
   }
 }
 
@@ -667,7 +670,7 @@ export interface GetMediaForFragmentListOutput extends $MetadataBearer {
 
 export namespace GetMediaForFragmentListOutput {
   export function isa(o: any): o is GetMediaForFragmentListOutput {
-    return _smithy.isa(o, "GetMediaForFragmentListOutput");
+    return __isa(o, "GetMediaForFragmentListOutput");
   }
 }
 
@@ -723,7 +726,7 @@ export interface HLSFragmentSelector {
 
 export namespace HLSFragmentSelector {
   export function isa(o: any): o is HLSFragmentSelector {
-    return _smithy.isa(o, "HLSFragmentSelector");
+    return __isa(o, "HLSFragmentSelector");
   }
 }
 
@@ -785,7 +788,7 @@ export interface HLSTimestampRange {
 
 export namespace HLSTimestampRange {
   export function isa(o: any): o is HLSTimestampRange {
-    return _smithy.isa(o, "HLSTimestampRange");
+    return __isa(o, "HLSTimestampRange");
   }
 }
 
@@ -818,7 +821,7 @@ export interface ListFragmentsInput {
 
 export namespace ListFragmentsInput {
   export function isa(o: any): o is ListFragmentsInput {
-    return _smithy.isa(o, "ListFragmentsInput");
+    return __isa(o, "ListFragmentsInput");
   }
 }
 
@@ -840,7 +843,7 @@ export interface ListFragmentsOutput extends $MetadataBearer {
 
 export namespace ListFragmentsOutput {
   export function isa(o: any): o is ListFragmentsOutput {
-    return _smithy.isa(o, "ListFragmentsOutput");
+    return __isa(o, "ListFragmentsOutput");
   }
 }
 
@@ -863,7 +866,7 @@ export interface TimestampRange {
 
 export namespace TimestampRange {
   export function isa(o: any): o is TimestampRange {
-    return _smithy.isa(o, "TimestampRange");
+    return __isa(o, "TimestampRange");
   }
 }
 
@@ -872,7 +875,7 @@ export namespace TimestampRange {
  *             allowed client calls. Try making the call later.</p>
  */
 export interface ClientLimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ClientLimitExceededException";
   $fault: "client";
@@ -881,7 +884,7 @@ export interface ClientLimitExceededException
 
 export namespace ClientLimitExceededException {
   export function isa(o: any): o is ClientLimitExceededException {
-    return _smithy.isa(o, "ClientLimitExceededException");
+    return __isa(o, "ClientLimitExceededException");
   }
 }
 
@@ -890,7 +893,7 @@ export namespace ClientLimitExceededException {
  *             used.</p>
  */
 export interface InvalidArgumentException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidArgumentException";
   $fault: "client";
@@ -899,7 +902,7 @@ export interface InvalidArgumentException
 
 export namespace InvalidArgumentException {
   export function isa(o: any): o is InvalidArgumentException {
-    return _smithy.isa(o, "InvalidArgumentException");
+    return __isa(o, "InvalidArgumentException");
   }
 }
 
@@ -908,7 +911,7 @@ export namespace InvalidArgumentException {
  *             for this operation.</p>
  */
 export interface InvalidCodecPrivateDataException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidCodecPrivateDataException";
   $fault: "client";
@@ -917,7 +920,7 @@ export interface InvalidCodecPrivateDataException
 
 export namespace InvalidCodecPrivateDataException {
   export function isa(o: any): o is InvalidCodecPrivateDataException {
-    return _smithy.isa(o, "InvalidCodecPrivateDataException");
+    return __isa(o, "InvalidCodecPrivateDataException");
   }
 }
 
@@ -925,7 +928,7 @@ export namespace InvalidCodecPrivateDataException {
  * <p>No codec private data was found in at least one of tracks of the video stream.</p>
  */
 export interface MissingCodecPrivateDataException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "MissingCodecPrivateDataException";
   $fault: "client";
@@ -934,7 +937,7 @@ export interface MissingCodecPrivateDataException
 
 export namespace MissingCodecPrivateDataException {
   export function isa(o: any): o is MissingCodecPrivateDataException {
-    return _smithy.isa(o, "MissingCodecPrivateDataException");
+    return __isa(o, "MissingCodecPrivateDataException");
   }
 }
 
@@ -943,7 +946,7 @@ export namespace MissingCodecPrivateDataException {
  *             a <code>DataRetentionInHours</code> of 0). </p>
  */
 export interface NoDataRetentionException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "NoDataRetentionException";
   $fault: "client";
@@ -952,7 +955,7 @@ export interface NoDataRetentionException
 
 export namespace NoDataRetentionException {
   export function isa(o: any): o is NoDataRetentionException {
-    return _smithy.isa(o, "NoDataRetentionException");
+    return __isa(o, "NoDataRetentionException");
   }
 }
 
@@ -961,7 +964,7 @@ export namespace NoDataRetentionException {
  *             stream, or the token has expired.</p>
  */
 export interface NotAuthorizedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "NotAuthorizedException";
   $fault: "client";
@@ -970,7 +973,7 @@ export interface NotAuthorizedException
 
 export namespace NotAuthorizedException {
   export function isa(o: any): o is NotAuthorizedException {
-    return _smithy.isa(o, "NotAuthorizedException");
+    return __isa(o, "NotAuthorizedException");
   }
 }
 
@@ -987,7 +990,7 @@ export namespace NotAuthorizedException {
  *             seconds.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -996,7 +999,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -1007,7 +1010,7 @@ export namespace ResourceNotFoundException {
  *             the codec ID for track 2 should be <code>A_AAC</code>.</p>
  */
 export interface UnsupportedStreamMediaTypeException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UnsupportedStreamMediaTypeException";
   $fault: "client";
@@ -1016,6 +1019,6 @@ export interface UnsupportedStreamMediaTypeException
 
 export namespace UnsupportedStreamMediaTypeException {
   export function isa(o: any): o is UnsupportedStreamMediaTypeException {
-    return _smithy.isa(o, "UnsupportedStreamMediaTypeException");
+    return __isa(o, "UnsupportedStreamMediaTypeException");
   }
 }

--- a/clients/client-kinesis-video-media/models/index.ts
+++ b/clients/client-kinesis-video-media/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export interface GetMediaInput {
@@ -24,7 +27,7 @@ export interface GetMediaInput {
 
 export namespace GetMediaInput {
   export function isa(o: any): o is GetMediaInput {
-    return _smithy.isa(o, "GetMediaInput");
+    return __isa(o, "GetMediaInput");
   }
 }
 
@@ -110,7 +113,7 @@ export interface GetMediaOutput extends $MetadataBearer {
 
 export namespace GetMediaOutput {
   export function isa(o: any): o is GetMediaOutput {
-    return _smithy.isa(o, "GetMediaOutput");
+    return __isa(o, "GetMediaOutput");
   }
 }
 
@@ -191,7 +194,7 @@ export interface StartSelector {
 
 export namespace StartSelector {
   export function isa(o: any): o is StartSelector {
-    return _smithy.isa(o, "StartSelector");
+    return __isa(o, "StartSelector");
   }
 }
 
@@ -209,7 +212,7 @@ export enum StartSelectorType {
  *       allowed client calls. Try making the call later.</p>
  */
 export interface ClientLimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ClientLimitExceededException";
   $fault: "client";
@@ -218,7 +221,7 @@ export interface ClientLimitExceededException
 
 export namespace ClientLimitExceededException {
   export function isa(o: any): o is ClientLimitExceededException {
-    return _smithy.isa(o, "ClientLimitExceededException");
+    return __isa(o, "ClientLimitExceededException");
   }
 }
 
@@ -227,7 +230,7 @@ export namespace ClientLimitExceededException {
  *       allowed client connections.</p>
  */
 export interface ConnectionLimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ConnectionLimitExceededException";
   $fault: "client";
@@ -236,7 +239,7 @@ export interface ConnectionLimitExceededException
 
 export namespace ConnectionLimitExceededException {
   export function isa(o: any): o is ConnectionLimitExceededException {
-    return _smithy.isa(o, "ConnectionLimitExceededException");
+    return __isa(o, "ConnectionLimitExceededException");
   }
 }
 
@@ -244,7 +247,7 @@ export namespace ConnectionLimitExceededException {
  * <p>The value for this input parameter is invalid.</p>
  */
 export interface InvalidArgumentException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidArgumentException";
   $fault: "client";
@@ -253,7 +256,7 @@ export interface InvalidArgumentException
 
 export namespace InvalidArgumentException {
   export function isa(o: any): o is InvalidArgumentException {
-    return _smithy.isa(o, "InvalidArgumentException");
+    return __isa(o, "InvalidArgumentException");
   }
 }
 
@@ -264,7 +267,7 @@ export namespace InvalidArgumentException {
  *         <code>GetMedia</code> call. </p>
  */
 export interface InvalidEndpointException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidEndpointException";
   $fault: "client";
@@ -273,7 +276,7 @@ export interface InvalidEndpointException
 
 export namespace InvalidEndpointException {
   export function isa(o: any): o is InvalidEndpointException {
-    return _smithy.isa(o, "InvalidEndpointException");
+    return __isa(o, "InvalidEndpointException");
   }
 }
 
@@ -282,7 +285,7 @@ export namespace InvalidEndpointException {
  *       stream, or the token has expired.</p>
  */
 export interface NotAuthorizedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "NotAuthorizedException";
   $fault: "client";
@@ -291,7 +294,7 @@ export interface NotAuthorizedException
 
 export namespace NotAuthorizedException {
   export function isa(o: any): o is NotAuthorizedException {
-    return _smithy.isa(o, "NotAuthorizedException");
+    return __isa(o, "NotAuthorizedException");
   }
 }
 
@@ -299,7 +302,7 @@ export namespace NotAuthorizedException {
  * <p>Status Code: 404, The stream with the given name does not exist.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -308,6 +311,6 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }

--- a/clients/client-kinesis-video-signaling/models/index.ts
+++ b/clients/client-kinesis-video-signaling/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -6,7 +9,7 @@ import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
  *             calls. Try making the call later.</p>
  */
 export interface ClientLimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ClientLimitExceededException";
   $fault: "client";
@@ -15,7 +18,7 @@ export interface ClientLimitExceededException
 
 export namespace ClientLimitExceededException {
   export function isa(o: any): o is ClientLimitExceededException {
-    return _smithy.isa(o, "ClientLimitExceededException");
+    return __isa(o, "ClientLimitExceededException");
   }
 }
 
@@ -23,7 +26,7 @@ export namespace ClientLimitExceededException {
  * <p>The value for this input parameter is invalid.</p>
  */
 export interface InvalidArgumentException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidArgumentException";
   $fault: "client";
@@ -32,7 +35,7 @@ export interface InvalidArgumentException
 
 export namespace InvalidArgumentException {
   export function isa(o: any): o is InvalidArgumentException {
-    return _smithy.isa(o, "InvalidArgumentException");
+    return __isa(o, "InvalidArgumentException");
   }
 }
 
@@ -40,7 +43,7 @@ export namespace InvalidArgumentException {
  * <p>The caller is not authorized to perform this operation.</p>
  */
 export interface NotAuthorizedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "NotAuthorizedException";
   $fault: "client";
@@ -49,7 +52,7 @@ export interface NotAuthorizedException
 
 export namespace NotAuthorizedException {
   export function isa(o: any): o is NotAuthorizedException {
-    return _smithy.isa(o, "NotAuthorizedException");
+    return __isa(o, "NotAuthorizedException");
   }
 }
 
@@ -57,7 +60,7 @@ export namespace NotAuthorizedException {
  * <p>The specified resource is not found.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -66,7 +69,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -97,7 +100,7 @@ export interface GetIceServerConfigRequest {
 
 export namespace GetIceServerConfigRequest {
   export function isa(o: any): o is GetIceServerConfigRequest {
-    return _smithy.isa(o, "GetIceServerConfigRequest");
+    return __isa(o, "GetIceServerConfigRequest");
   }
 }
 
@@ -111,7 +114,7 @@ export interface GetIceServerConfigResponse extends $MetadataBearer {
 
 export namespace GetIceServerConfigResponse {
   export function isa(o: any): o is GetIceServerConfigResponse {
-    return _smithy.isa(o, "GetIceServerConfigResponse");
+    return __isa(o, "GetIceServerConfigResponse");
   }
 }
 
@@ -145,7 +148,7 @@ export interface IceServer {
 
 export namespace IceServer {
   export function isa(o: any): o is IceServer {
-    return _smithy.isa(o, "IceServer");
+    return __isa(o, "IceServer");
   }
 }
 
@@ -153,7 +156,7 @@ export namespace IceServer {
  * <p>The specified client is invalid.</p>
  */
 export interface InvalidClientException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidClientException";
   $fault: "client";
@@ -162,7 +165,7 @@ export interface InvalidClientException
 
 export namespace InvalidClientException {
   export function isa(o: any): o is InvalidClientException {
-    return _smithy.isa(o, "InvalidClientException");
+    return __isa(o, "InvalidClientException");
   }
 }
 
@@ -187,7 +190,7 @@ export interface SendAlexaOfferToMasterRequest {
 
 export namespace SendAlexaOfferToMasterRequest {
   export function isa(o: any): o is SendAlexaOfferToMasterRequest {
-    return _smithy.isa(o, "SendAlexaOfferToMasterRequest");
+    return __isa(o, "SendAlexaOfferToMasterRequest");
   }
 }
 
@@ -201,7 +204,7 @@ export interface SendAlexaOfferToMasterResponse extends $MetadataBearer {
 
 export namespace SendAlexaOfferToMasterResponse {
   export function isa(o: any): o is SendAlexaOfferToMasterResponse {
-    return _smithy.isa(o, "SendAlexaOfferToMasterResponse");
+    return __isa(o, "SendAlexaOfferToMasterResponse");
   }
 }
 
@@ -215,7 +218,7 @@ export enum Service {
  *             messages.</p>
  */
 export interface SessionExpiredException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "SessionExpiredException";
   $fault: "client";
@@ -224,6 +227,6 @@ export interface SessionExpiredException
 
 export namespace SessionExpiredException {
   export function isa(o: any): o is SessionExpiredException {
-    return _smithy.isa(o, "SessionExpiredException");
+    return __isa(o, "SessionExpiredException");
   }
 }

--- a/clients/client-kinesis-video/models/index.ts
+++ b/clients/client-kinesis-video/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export enum APIName {
@@ -14,7 +17,7 @@ export enum APIName {
  * <p>You do not have required permissions to perform this operation.</p>
  */
 export interface AccessDeniedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AccessDeniedException";
   $fault: "client";
@@ -23,7 +26,7 @@ export interface AccessDeniedException
 
 export namespace AccessDeniedException {
   export function isa(o: any): o is AccessDeniedException {
-    return _smithy.isa(o, "AccessDeniedException");
+    return __isa(o, "AccessDeniedException");
   }
 }
 
@@ -32,7 +35,7 @@ export namespace AccessDeniedException {
  *             in this region.</p>
  */
 export interface AccountChannelLimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AccountChannelLimitExceededException";
   $fault: "client";
@@ -41,7 +44,7 @@ export interface AccountChannelLimitExceededException
 
 export namespace AccountChannelLimitExceededException {
   export function isa(o: any): o is AccountChannelLimitExceededException {
-    return _smithy.isa(o, "AccountChannelLimitExceededException");
+    return __isa(o, "AccountChannelLimitExceededException");
   }
 }
 
@@ -49,7 +52,7 @@ export namespace AccountChannelLimitExceededException {
  * <p>The number of streams created for the account is too high.</p>
  */
 export interface AccountStreamLimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AccountStreamLimitExceededException";
   $fault: "client";
@@ -58,7 +61,7 @@ export interface AccountStreamLimitExceededException
 
 export namespace AccountStreamLimitExceededException {
   export function isa(o: any): o is AccountStreamLimitExceededException {
-    return _smithy.isa(o, "AccountStreamLimitExceededException");
+    return __isa(o, "AccountStreamLimitExceededException");
   }
 }
 
@@ -106,7 +109,7 @@ export interface ChannelInfo {
 
 export namespace ChannelInfo {
   export function isa(o: any): o is ChannelInfo {
-    return _smithy.isa(o, "ChannelInfo");
+    return __isa(o, "ChannelInfo");
   }
 }
 
@@ -132,7 +135,7 @@ export interface ChannelNameCondition {
 
 export namespace ChannelNameCondition {
   export function isa(o: any): o is ChannelNameCondition {
-    return _smithy.isa(o, "ChannelNameCondition");
+    return __isa(o, "ChannelNameCondition");
   }
 }
 
@@ -155,7 +158,7 @@ export enum ChannelType {
  *             allowed client calls. Try making the call later.</p>
  */
 export interface ClientLimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ClientLimitExceededException";
   $fault: "client";
@@ -164,7 +167,7 @@ export interface ClientLimitExceededException
 
 export namespace ClientLimitExceededException {
   export function isa(o: any): o is ClientLimitExceededException {
-    return _smithy.isa(o, "ClientLimitExceededException");
+    return __isa(o, "ClientLimitExceededException");
   }
 }
 
@@ -200,7 +203,7 @@ export interface CreateSignalingChannelInput {
 
 export namespace CreateSignalingChannelInput {
   export function isa(o: any): o is CreateSignalingChannelInput {
-    return _smithy.isa(o, "CreateSignalingChannelInput");
+    return __isa(o, "CreateSignalingChannelInput");
   }
 }
 
@@ -214,7 +217,7 @@ export interface CreateSignalingChannelOutput extends $MetadataBearer {
 
 export namespace CreateSignalingChannelOutput {
   export function isa(o: any): o is CreateSignalingChannelOutput {
-    return _smithy.isa(o, "CreateSignalingChannelOutput");
+    return __isa(o, "CreateSignalingChannelOutput");
   }
 }
 
@@ -277,7 +280,7 @@ export interface CreateStreamInput {
 
 export namespace CreateStreamInput {
   export function isa(o: any): o is CreateStreamInput {
-    return _smithy.isa(o, "CreateStreamInput");
+    return __isa(o, "CreateStreamInput");
   }
 }
 
@@ -291,7 +294,7 @@ export interface CreateStreamOutput extends $MetadataBearer {
 
 export namespace CreateStreamOutput {
   export function isa(o: any): o is CreateStreamOutput {
-    return _smithy.isa(o, "CreateStreamOutput");
+    return __isa(o, "CreateStreamOutput");
   }
 }
 
@@ -312,7 +315,7 @@ export interface DeleteSignalingChannelInput {
 
 export namespace DeleteSignalingChannelInput {
   export function isa(o: any): o is DeleteSignalingChannelInput {
-    return _smithy.isa(o, "DeleteSignalingChannelInput");
+    return __isa(o, "DeleteSignalingChannelInput");
   }
 }
 
@@ -322,7 +325,7 @@ export interface DeleteSignalingChannelOutput extends $MetadataBearer {
 
 export namespace DeleteSignalingChannelOutput {
   export function isa(o: any): o is DeleteSignalingChannelOutput {
-    return _smithy.isa(o, "DeleteSignalingChannelOutput");
+    return __isa(o, "DeleteSignalingChannelOutput");
   }
 }
 
@@ -345,7 +348,7 @@ export interface DeleteStreamInput {
 
 export namespace DeleteStreamInput {
   export function isa(o: any): o is DeleteStreamInput {
-    return _smithy.isa(o, "DeleteStreamInput");
+    return __isa(o, "DeleteStreamInput");
   }
 }
 
@@ -355,7 +358,7 @@ export interface DeleteStreamOutput extends $MetadataBearer {
 
 export namespace DeleteStreamOutput {
   export function isa(o: any): o is DeleteStreamOutput {
-    return _smithy.isa(o, "DeleteStreamOutput");
+    return __isa(o, "DeleteStreamOutput");
   }
 }
 
@@ -374,7 +377,7 @@ export interface DescribeSignalingChannelInput {
 
 export namespace DescribeSignalingChannelInput {
   export function isa(o: any): o is DescribeSignalingChannelInput {
-    return _smithy.isa(o, "DescribeSignalingChannelInput");
+    return __isa(o, "DescribeSignalingChannelInput");
   }
 }
 
@@ -389,7 +392,7 @@ export interface DescribeSignalingChannelOutput extends $MetadataBearer {
 
 export namespace DescribeSignalingChannelOutput {
   export function isa(o: any): o is DescribeSignalingChannelOutput {
-    return _smithy.isa(o, "DescribeSignalingChannelOutput");
+    return __isa(o, "DescribeSignalingChannelOutput");
   }
 }
 
@@ -408,7 +411,7 @@ export interface DescribeStreamInput {
 
 export namespace DescribeStreamInput {
   export function isa(o: any): o is DescribeStreamInput {
-    return _smithy.isa(o, "DescribeStreamInput");
+    return __isa(o, "DescribeStreamInput");
   }
 }
 
@@ -422,7 +425,7 @@ export interface DescribeStreamOutput extends $MetadataBearer {
 
 export namespace DescribeStreamOutput {
   export function isa(o: any): o is DescribeStreamOutput {
-    return _smithy.isa(o, "DescribeStreamOutput");
+    return __isa(o, "DescribeStreamOutput");
   }
 }
 
@@ -431,7 +434,7 @@ export namespace DescribeStreamOutput {
  *             </p>
  */
 export interface DeviceStreamLimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DeviceStreamLimitExceededException";
   $fault: "client";
@@ -440,7 +443,7 @@ export interface DeviceStreamLimitExceededException
 
 export namespace DeviceStreamLimitExceededException {
   export function isa(o: any): o is DeviceStreamLimitExceededException {
-    return _smithy.isa(o, "DeviceStreamLimitExceededException");
+    return __isa(o, "DeviceStreamLimitExceededException");
   }
 }
 
@@ -467,7 +470,7 @@ export interface GetDataEndpointInput {
 
 export namespace GetDataEndpointInput {
   export function isa(o: any): o is GetDataEndpointInput {
-    return _smithy.isa(o, "GetDataEndpointInput");
+    return __isa(o, "GetDataEndpointInput");
   }
 }
 
@@ -482,7 +485,7 @@ export interface GetDataEndpointOutput extends $MetadataBearer {
 
 export namespace GetDataEndpointOutput {
   export function isa(o: any): o is GetDataEndpointOutput {
-    return _smithy.isa(o, "GetDataEndpointOutput");
+    return __isa(o, "GetDataEndpointOutput");
   }
 }
 
@@ -502,7 +505,7 @@ export interface GetSignalingChannelEndpointInput {
 
 export namespace GetSignalingChannelEndpointInput {
   export function isa(o: any): o is GetSignalingChannelEndpointInput {
-    return _smithy.isa(o, "GetSignalingChannelEndpointInput");
+    return __isa(o, "GetSignalingChannelEndpointInput");
   }
 }
 
@@ -516,7 +519,7 @@ export interface GetSignalingChannelEndpointOutput extends $MetadataBearer {
 
 export namespace GetSignalingChannelEndpointOutput {
   export function isa(o: any): o is GetSignalingChannelEndpointOutput {
-    return _smithy.isa(o, "GetSignalingChannelEndpointOutput");
+    return __isa(o, "GetSignalingChannelEndpointOutput");
   }
 }
 
@@ -524,7 +527,7 @@ export namespace GetSignalingChannelEndpointOutput {
  * <p>The value for this input parameter is invalid.</p>
  */
 export interface InvalidArgumentException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidArgumentException";
   $fault: "client";
@@ -533,7 +536,7 @@ export interface InvalidArgumentException
 
 export namespace InvalidArgumentException {
   export function isa(o: any): o is InvalidArgumentException {
-    return _smithy.isa(o, "InvalidArgumentException");
+    return __isa(o, "InvalidArgumentException");
   }
 }
 
@@ -541,7 +544,7 @@ export namespace InvalidArgumentException {
  * <p>Not implemented.</p>
  */
 export interface InvalidDeviceException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidDeviceException";
   $fault: "client";
@@ -550,7 +553,7 @@ export interface InvalidDeviceException
 
 export namespace InvalidDeviceException {
   export function isa(o: any): o is InvalidDeviceException {
-    return _smithy.isa(o, "InvalidDeviceException");
+    return __isa(o, "InvalidDeviceException");
   }
 }
 
@@ -558,7 +561,7 @@ export namespace InvalidDeviceException {
  * <p>The format of the <code>StreamARN</code> is invalid.</p>
  */
 export interface InvalidResourceFormatException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidResourceFormatException";
   $fault: "client";
@@ -567,7 +570,7 @@ export interface InvalidResourceFormatException
 
 export namespace InvalidResourceFormatException {
   export function isa(o: any): o is InvalidResourceFormatException {
-    return _smithy.isa(o, "InvalidResourceFormatException");
+    return __isa(o, "InvalidResourceFormatException");
   }
 }
 
@@ -593,7 +596,7 @@ export interface ListSignalingChannelsInput {
 
 export namespace ListSignalingChannelsInput {
   export function isa(o: any): o is ListSignalingChannelsInput {
-    return _smithy.isa(o, "ListSignalingChannelsInput");
+    return __isa(o, "ListSignalingChannelsInput");
   }
 }
 
@@ -613,7 +616,7 @@ export interface ListSignalingChannelsOutput extends $MetadataBearer {
 
 export namespace ListSignalingChannelsOutput {
   export function isa(o: any): o is ListSignalingChannelsOutput {
-    return _smithy.isa(o, "ListSignalingChannelsOutput");
+    return __isa(o, "ListSignalingChannelsOutput");
   }
 }
 
@@ -641,7 +644,7 @@ export interface ListStreamsInput {
 
 export namespace ListStreamsInput {
   export function isa(o: any): o is ListStreamsInput {
-    return _smithy.isa(o, "ListStreamsInput");
+    return __isa(o, "ListStreamsInput");
   }
 }
 
@@ -661,7 +664,7 @@ export interface ListStreamsOutput extends $MetadataBearer {
 
 export namespace ListStreamsOutput {
   export function isa(o: any): o is ListStreamsOutput {
-    return _smithy.isa(o, "ListStreamsOutput");
+    return __isa(o, "ListStreamsOutput");
   }
 }
 
@@ -682,7 +685,7 @@ export interface ListTagsForResourceInput {
 
 export namespace ListTagsForResourceInput {
   export function isa(o: any): o is ListTagsForResourceInput {
-    return _smithy.isa(o, "ListTagsForResourceInput");
+    return __isa(o, "ListTagsForResourceInput");
   }
 }
 
@@ -703,7 +706,7 @@ export interface ListTagsForResourceOutput extends $MetadataBearer {
 
 export namespace ListTagsForResourceOutput {
   export function isa(o: any): o is ListTagsForResourceOutput {
-    return _smithy.isa(o, "ListTagsForResourceOutput");
+    return __isa(o, "ListTagsForResourceOutput");
   }
 }
 
@@ -730,7 +733,7 @@ export interface ListTagsForStreamInput {
 
 export namespace ListTagsForStreamInput {
   export function isa(o: any): o is ListTagsForStreamInput {
-    return _smithy.isa(o, "ListTagsForStreamInput");
+    return __isa(o, "ListTagsForStreamInput");
   }
 }
 
@@ -751,7 +754,7 @@ export interface ListTagsForStreamOutput extends $MetadataBearer {
 
 export namespace ListTagsForStreamOutput {
   export function isa(o: any): o is ListTagsForStreamOutput {
-    return _smithy.isa(o, "ListTagsForStreamOutput");
+    return __isa(o, "ListTagsForStreamOutput");
   }
 }
 
@@ -759,7 +762,7 @@ export namespace ListTagsForStreamOutput {
  * <p>The caller is not authorized to perform this operation.</p>
  */
 export interface NotAuthorizedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "NotAuthorizedException";
   $fault: "client";
@@ -768,7 +771,7 @@ export interface NotAuthorizedException
 
 export namespace NotAuthorizedException {
   export function isa(o: any): o is NotAuthorizedException {
-    return _smithy.isa(o, "NotAuthorizedException");
+    return __isa(o, "NotAuthorizedException");
   }
 }
 
@@ -793,7 +796,7 @@ export interface ResourceEndpointListItem {
 
 export namespace ResourceEndpointListItem {
   export function isa(o: any): o is ResourceEndpointListItem {
-    return _smithy.isa(o, "ResourceEndpointListItem");
+    return __isa(o, "ResourceEndpointListItem");
   }
 }
 
@@ -801,7 +804,7 @@ export namespace ResourceEndpointListItem {
  * <p>The stream is currently not available for this operation.</p>
  */
 export interface ResourceInUseException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceInUseException";
   $fault: "client";
@@ -810,7 +813,7 @@ export interface ResourceInUseException
 
 export namespace ResourceInUseException {
   export function isa(o: any): o is ResourceInUseException {
-    return _smithy.isa(o, "ResourceInUseException");
+    return __isa(o, "ResourceInUseException");
   }
 }
 
@@ -818,7 +821,7 @@ export namespace ResourceInUseException {
  * <p>Amazon Kinesis Video Streams can't find the stream that you specified.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -827,7 +830,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -858,7 +861,7 @@ export interface SingleMasterChannelEndpointConfiguration {
 
 export namespace SingleMasterChannelEndpointConfiguration {
   export function isa(o: any): o is SingleMasterChannelEndpointConfiguration {
-    return _smithy.isa(o, "SingleMasterChannelEndpointConfiguration");
+    return __isa(o, "SingleMasterChannelEndpointConfiguration");
   }
 }
 
@@ -877,7 +880,7 @@ export interface SingleMasterConfiguration {
 
 export namespace SingleMasterConfiguration {
   export function isa(o: any): o is SingleMasterConfiguration {
-    return _smithy.isa(o, "SingleMasterConfiguration");
+    return __isa(o, "SingleMasterConfiguration");
   }
 }
 
@@ -942,7 +945,7 @@ export interface StreamInfo {
 
 export namespace StreamInfo {
   export function isa(o: any): o is StreamInfo {
-    return _smithy.isa(o, "StreamInfo");
+    return __isa(o, "StreamInfo");
   }
 }
 
@@ -968,7 +971,7 @@ export interface StreamNameCondition {
 
 export namespace StreamNameCondition {
   export function isa(o: any): o is StreamNameCondition {
-    return _smithy.isa(o, "StreamNameCondition");
+    return __isa(o, "StreamNameCondition");
   }
 }
 
@@ -990,7 +993,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -1010,7 +1013,7 @@ export interface TagResourceInput {
 
 export namespace TagResourceInput {
   export function isa(o: any): o is TagResourceInput {
-    return _smithy.isa(o, "TagResourceInput");
+    return __isa(o, "TagResourceInput");
   }
 }
 
@@ -1020,7 +1023,7 @@ export interface TagResourceOutput extends $MetadataBearer {
 
 export namespace TagResourceOutput {
   export function isa(o: any): o is TagResourceOutput {
-    return _smithy.isa(o, "TagResourceOutput");
+    return __isa(o, "TagResourceOutput");
   }
 }
 
@@ -1046,7 +1049,7 @@ export interface TagStreamInput {
 
 export namespace TagStreamInput {
   export function isa(o: any): o is TagStreamInput {
-    return _smithy.isa(o, "TagStreamInput");
+    return __isa(o, "TagStreamInput");
   }
 }
 
@@ -1056,7 +1059,7 @@ export interface TagStreamOutput extends $MetadataBearer {
 
 export namespace TagStreamOutput {
   export function isa(o: any): o is TagStreamOutput {
-    return _smithy.isa(o, "TagStreamOutput");
+    return __isa(o, "TagStreamOutput");
   }
 }
 
@@ -1065,7 +1068,7 @@ export namespace TagStreamOutput {
  *             Kinesis video streams support up to 50 tags. </p>
  */
 export interface TagsPerResourceExceededLimitException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TagsPerResourceExceededLimitException";
   $fault: "client";
@@ -1074,7 +1077,7 @@ export interface TagsPerResourceExceededLimitException
 
 export namespace TagsPerResourceExceededLimitException {
   export function isa(o: any): o is TagsPerResourceExceededLimitException {
-    return _smithy.isa(o, "TagsPerResourceExceededLimitException");
+    return __isa(o, "TagsPerResourceExceededLimitException");
   }
 }
 
@@ -1093,7 +1096,7 @@ export interface UntagResourceInput {
 
 export namespace UntagResourceInput {
   export function isa(o: any): o is UntagResourceInput {
-    return _smithy.isa(o, "UntagResourceInput");
+    return __isa(o, "UntagResourceInput");
   }
 }
 
@@ -1103,7 +1106,7 @@ export interface UntagResourceOutput extends $MetadataBearer {
 
 export namespace UntagResourceOutput {
   export function isa(o: any): o is UntagResourceOutput {
-    return _smithy.isa(o, "UntagResourceOutput");
+    return __isa(o, "UntagResourceOutput");
   }
 }
 
@@ -1128,7 +1131,7 @@ export interface UntagStreamInput {
 
 export namespace UntagStreamInput {
   export function isa(o: any): o is UntagStreamInput {
-    return _smithy.isa(o, "UntagStreamInput");
+    return __isa(o, "UntagStreamInput");
   }
 }
 
@@ -1138,7 +1141,7 @@ export interface UntagStreamOutput extends $MetadataBearer {
 
 export namespace UntagStreamOutput {
   export function isa(o: any): o is UntagStreamOutput {
-    return _smithy.isa(o, "UntagStreamOutput");
+    return __isa(o, "UntagStreamOutput");
   }
 }
 
@@ -1176,7 +1179,7 @@ export interface UpdateDataRetentionInput {
 
 export namespace UpdateDataRetentionInput {
   export function isa(o: any): o is UpdateDataRetentionInput {
-    return _smithy.isa(o, "UpdateDataRetentionInput");
+    return __isa(o, "UpdateDataRetentionInput");
   }
 }
 
@@ -1191,7 +1194,7 @@ export interface UpdateDataRetentionOutput extends $MetadataBearer {
 
 export namespace UpdateDataRetentionOutput {
   export function isa(o: any): o is UpdateDataRetentionOutput {
-    return _smithy.isa(o, "UpdateDataRetentionOutput");
+    return __isa(o, "UpdateDataRetentionOutput");
   }
 }
 
@@ -1216,7 +1219,7 @@ export interface UpdateSignalingChannelInput {
 
 export namespace UpdateSignalingChannelInput {
   export function isa(o: any): o is UpdateSignalingChannelInput {
-    return _smithy.isa(o, "UpdateSignalingChannelInput");
+    return __isa(o, "UpdateSignalingChannelInput");
   }
 }
 
@@ -1226,7 +1229,7 @@ export interface UpdateSignalingChannelOutput extends $MetadataBearer {
 
 export namespace UpdateSignalingChannelOutput {
   export function isa(o: any): o is UpdateSignalingChannelOutput {
-    return _smithy.isa(o, "UpdateSignalingChannelOutput");
+    return __isa(o, "UpdateSignalingChannelOutput");
   }
 }
 
@@ -1273,7 +1276,7 @@ export interface UpdateStreamInput {
 
 export namespace UpdateStreamInput {
   export function isa(o: any): o is UpdateStreamInput {
-    return _smithy.isa(o, "UpdateStreamInput");
+    return __isa(o, "UpdateStreamInput");
   }
 }
 
@@ -1283,7 +1286,7 @@ export interface UpdateStreamOutput extends $MetadataBearer {
 
 export namespace UpdateStreamOutput {
   export function isa(o: any): o is UpdateStreamOutput {
-    return _smithy.isa(o, "UpdateStreamOutput");
+    return __isa(o, "UpdateStreamOutput");
   }
 }
 
@@ -1293,7 +1296,7 @@ export namespace UpdateStreamOutput {
  *             API.</p>
  */
 export interface VersionMismatchException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "VersionMismatchException";
   $fault: "client";
@@ -1302,6 +1305,6 @@ export interface VersionMismatchException
 
 export namespace VersionMismatchException {
   export function isa(o: any): o is VersionMismatchException {
-    return _smithy.isa(o, "VersionMismatchException");
+    return __isa(o, "VersionMismatchException");
   }
 }

--- a/clients/client-kinesis-video/protocols/Aws_restJson1_1.ts
+++ b/clients/client-kinesis-video/protocols/Aws_restJson1_1.ts
@@ -901,6 +901,7 @@ export async function deserializeAws_restJson1_1DeleteSignalingChannelCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeleteSignalingChannelOutput"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -977,6 +978,7 @@ export async function deserializeAws_restJson1_1DeleteStreamCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeleteStreamOutput"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -1693,6 +1695,7 @@ export async function deserializeAws_restJson1_1TagResourceCommand(
     $metadata: deserializeMetadata(output),
     __type: "TagResourceOutput"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -1769,6 +1772,7 @@ export async function deserializeAws_restJson1_1TagStreamCommand(
     $metadata: deserializeMetadata(output),
     __type: "TagStreamOutput"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -1852,6 +1856,7 @@ export async function deserializeAws_restJson1_1UntagResourceCommand(
     $metadata: deserializeMetadata(output),
     __type: "UntagResourceOutput"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -1921,6 +1926,7 @@ export async function deserializeAws_restJson1_1UntagStreamCommand(
     $metadata: deserializeMetadata(output),
     __type: "UntagStreamOutput"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2000,6 +2006,7 @@ export async function deserializeAws_restJson1_1UpdateDataRetentionCommand(
     $metadata: deserializeMetadata(output),
     __type: "UpdateDataRetentionOutput"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2086,6 +2093,7 @@ export async function deserializeAws_restJson1_1UpdateSignalingChannelCommand(
     $metadata: deserializeMetadata(output),
     __type: "UpdateSignalingChannelOutput"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2169,6 +2177,7 @@ export async function deserializeAws_restJson1_1UpdateStreamCommand(
     $metadata: deserializeMetadata(output),
     __type: "UpdateStreamOutput"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 

--- a/clients/client-kinesis/models/index.ts
+++ b/clients/client-kinesis/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -19,7 +22,7 @@ export interface AddTagsToStreamInput {
 
 export namespace AddTagsToStreamInput {
   export function isa(o: any): o is AddTagsToStreamInput {
-    return _smithy.isa(o, "AddTagsToStreamInput");
+    return __isa(o, "AddTagsToStreamInput");
   }
 }
 
@@ -55,7 +58,7 @@ export interface Consumer {
 
 export namespace Consumer {
   export function isa(o: any): o is Consumer {
-    return _smithy.isa(o, "Consumer");
+    return __isa(o, "Consumer");
   }
 }
 
@@ -97,7 +100,7 @@ export interface ConsumerDescription {
 
 export namespace ConsumerDescription {
   export function isa(o: any): o is ConsumerDescription {
-    return _smithy.isa(o, "ConsumerDescription");
+    return __isa(o, "ConsumerDescription");
   }
 }
 
@@ -129,7 +132,7 @@ export interface CreateStreamInput {
 
 export namespace CreateStreamInput {
   export function isa(o: any): o is CreateStreamInput {
-    return _smithy.isa(o, "CreateStreamInput");
+    return __isa(o, "CreateStreamInput");
   }
 }
 
@@ -151,7 +154,7 @@ export interface DecreaseStreamRetentionPeriodInput {
 
 export namespace DecreaseStreamRetentionPeriodInput {
   export function isa(o: any): o is DecreaseStreamRetentionPeriodInput {
-    return _smithy.isa(o, "DecreaseStreamRetentionPeriodInput");
+    return __isa(o, "DecreaseStreamRetentionPeriodInput");
   }
 }
 
@@ -175,7 +178,7 @@ export interface DeleteStreamInput {
 
 export namespace DeleteStreamInput {
   export function isa(o: any): o is DeleteStreamInput {
-    return _smithy.isa(o, "DeleteStreamInput");
+    return __isa(o, "DeleteStreamInput");
   }
 }
 
@@ -204,7 +207,7 @@ export interface DeregisterStreamConsumerInput {
 
 export namespace DeregisterStreamConsumerInput {
   export function isa(o: any): o is DeregisterStreamConsumerInput {
-    return _smithy.isa(o, "DeregisterStreamConsumerInput");
+    return __isa(o, "DeregisterStreamConsumerInput");
   }
 }
 
@@ -214,7 +217,7 @@ export interface DescribeLimitsInput {
 
 export namespace DescribeLimitsInput {
   export function isa(o: any): o is DescribeLimitsInput {
-    return _smithy.isa(o, "DescribeLimitsInput");
+    return __isa(o, "DescribeLimitsInput");
   }
 }
 
@@ -233,7 +236,7 @@ export interface DescribeLimitsOutput extends $MetadataBearer {
 
 export namespace DescribeLimitsOutput {
   export function isa(o: any): o is DescribeLimitsOutput {
-    return _smithy.isa(o, "DescribeLimitsOutput");
+    return __isa(o, "DescribeLimitsOutput");
   }
 }
 
@@ -258,7 +261,7 @@ export interface DescribeStreamConsumerInput {
 
 export namespace DescribeStreamConsumerInput {
   export function isa(o: any): o is DescribeStreamConsumerInput {
-    return _smithy.isa(o, "DescribeStreamConsumerInput");
+    return __isa(o, "DescribeStreamConsumerInput");
   }
 }
 
@@ -272,7 +275,7 @@ export interface DescribeStreamConsumerOutput extends $MetadataBearer {
 
 export namespace DescribeStreamConsumerOutput {
   export function isa(o: any): o is DescribeStreamConsumerOutput {
-    return _smithy.isa(o, "DescribeStreamConsumerOutput");
+    return __isa(o, "DescribeStreamConsumerOutput");
   }
 }
 
@@ -300,7 +303,7 @@ export interface DescribeStreamInput {
 
 export namespace DescribeStreamInput {
   export function isa(o: any): o is DescribeStreamInput {
-    return _smithy.isa(o, "DescribeStreamInput");
+    return __isa(o, "DescribeStreamInput");
   }
 }
 
@@ -319,7 +322,7 @@ export interface DescribeStreamOutput extends $MetadataBearer {
 
 export namespace DescribeStreamOutput {
   export function isa(o: any): o is DescribeStreamOutput {
-    return _smithy.isa(o, "DescribeStreamOutput");
+    return __isa(o, "DescribeStreamOutput");
   }
 }
 
@@ -333,7 +336,7 @@ export interface DescribeStreamSummaryInput {
 
 export namespace DescribeStreamSummaryInput {
   export function isa(o: any): o is DescribeStreamSummaryInput {
-    return _smithy.isa(o, "DescribeStreamSummaryInput");
+    return __isa(o, "DescribeStreamSummaryInput");
   }
 }
 
@@ -347,7 +350,7 @@ export interface DescribeStreamSummaryOutput extends $MetadataBearer {
 
 export namespace DescribeStreamSummaryOutput {
   export function isa(o: any): o is DescribeStreamSummaryOutput {
-    return _smithy.isa(o, "DescribeStreamSummaryOutput");
+    return __isa(o, "DescribeStreamSummaryOutput");
   }
 }
 
@@ -417,7 +420,7 @@ export interface DisableEnhancedMonitoringInput {
 
 export namespace DisableEnhancedMonitoringInput {
   export function isa(o: any): o is DisableEnhancedMonitoringInput {
-    return _smithy.isa(o, "DisableEnhancedMonitoringInput");
+    return __isa(o, "DisableEnhancedMonitoringInput");
   }
 }
 
@@ -486,7 +489,7 @@ export interface EnableEnhancedMonitoringInput {
 
 export namespace EnableEnhancedMonitoringInput {
   export function isa(o: any): o is EnableEnhancedMonitoringInput {
-    return _smithy.isa(o, "EnableEnhancedMonitoringInput");
+    return __isa(o, "EnableEnhancedMonitoringInput");
   }
 }
 
@@ -555,7 +558,7 @@ export interface EnhancedMetrics {
 
 export namespace EnhancedMetrics {
   export function isa(o: any): o is EnhancedMetrics {
-    return _smithy.isa(o, "EnhancedMetrics");
+    return __isa(o, "EnhancedMetrics");
   }
 }
 
@@ -583,7 +586,7 @@ export interface EnhancedMonitoringOutput extends $MetadataBearer {
 
 export namespace EnhancedMonitoringOutput {
   export function isa(o: any): o is EnhancedMonitoringOutput {
-    return _smithy.isa(o, "EnhancedMonitoringOutput");
+    return __isa(o, "EnhancedMonitoringOutput");
   }
 }
 
@@ -591,7 +594,7 @@ export namespace EnhancedMonitoringOutput {
  * <p>The provided iterator exceeds the maximum age allowed.</p>
  */
 export interface ExpiredIteratorException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ExpiredIteratorException";
   $fault: "client";
@@ -603,7 +606,7 @@ export interface ExpiredIteratorException
 
 export namespace ExpiredIteratorException {
   export function isa(o: any): o is ExpiredIteratorException {
-    return _smithy.isa(o, "ExpiredIteratorException");
+    return __isa(o, "ExpiredIteratorException");
   }
 }
 
@@ -611,7 +614,7 @@ export namespace ExpiredIteratorException {
  * <p>The pagination token passed to the operation is expired.</p>
  */
 export interface ExpiredNextTokenException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ExpiredNextTokenException";
   $fault: "client";
@@ -620,7 +623,7 @@ export interface ExpiredNextTokenException
 
 export namespace ExpiredNextTokenException {
   export function isa(o: any): o is ExpiredNextTokenException {
-    return _smithy.isa(o, "ExpiredNextTokenException");
+    return __isa(o, "ExpiredNextTokenException");
   }
 }
 
@@ -644,7 +647,7 @@ export interface GetRecordsInput {
 
 export namespace GetRecordsInput {
   export function isa(o: any): o is GetRecordsInput {
-    return _smithy.isa(o, "GetRecordsInput");
+    return __isa(o, "GetRecordsInput");
   }
 }
 
@@ -676,7 +679,7 @@ export interface GetRecordsOutput extends $MetadataBearer {
 
 export namespace GetRecordsOutput {
   export function isa(o: any): o is GetRecordsOutput {
-    return _smithy.isa(o, "GetRecordsOutput");
+    return __isa(o, "GetRecordsOutput");
   }
 }
 
@@ -740,7 +743,7 @@ export interface GetShardIteratorInput {
 
 export namespace GetShardIteratorInput {
   export function isa(o: any): o is GetShardIteratorInput {
-    return _smithy.isa(o, "GetShardIteratorInput");
+    return __isa(o, "GetShardIteratorInput");
   }
 }
 
@@ -757,7 +760,7 @@ export interface GetShardIteratorOutput extends $MetadataBearer {
 
 export namespace GetShardIteratorOutput {
   export function isa(o: any): o is GetShardIteratorOutput {
-    return _smithy.isa(o, "GetShardIteratorOutput");
+    return __isa(o, "GetShardIteratorOutput");
   }
 }
 
@@ -779,7 +782,7 @@ export interface HashKeyRange {
 
 export namespace HashKeyRange {
   export function isa(o: any): o is HashKeyRange {
-    return _smithy.isa(o, "HashKeyRange");
+    return __isa(o, "HashKeyRange");
   }
 }
 
@@ -801,11 +804,11 @@ export interface IncreaseStreamRetentionPeriodInput {
 
 export namespace IncreaseStreamRetentionPeriodInput {
   export function isa(o: any): o is IncreaseStreamRetentionPeriodInput {
-    return _smithy.isa(o, "IncreaseStreamRetentionPeriodInput");
+    return __isa(o, "IncreaseStreamRetentionPeriodInput");
   }
 }
 
-export interface InternalFailureException extends _smithy.SmithyException {
+export interface InternalFailureException extends __SmithyException {
   name: "InternalFailureException";
   $fault: "server";
   message?: string;
@@ -813,7 +816,7 @@ export interface InternalFailureException extends _smithy.SmithyException {
 
 export namespace InternalFailureException {
   export function isa(o: any): o is InternalFailureException {
-    return _smithy.isa(o, "InternalFailureException");
+    return __isa(o, "InternalFailureException");
   }
 }
 
@@ -821,7 +824,7 @@ export namespace InternalFailureException {
  * <p>A specified parameter exceeds its restrictions, is not supported, or can't be used. For more information, see the returned message.</p>
  */
 export interface InvalidArgumentException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidArgumentException";
   $fault: "client";
@@ -833,7 +836,7 @@ export interface InvalidArgumentException
 
 export namespace InvalidArgumentException {
   export function isa(o: any): o is InvalidArgumentException {
-    return _smithy.isa(o, "InvalidArgumentException");
+    return __isa(o, "InvalidArgumentException");
   }
 }
 
@@ -841,7 +844,7 @@ export namespace InvalidArgumentException {
  * <p>The ciphertext references a key that doesn't exist or that you don't have access to.</p>
  */
 export interface KMSAccessDeniedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "KMSAccessDeniedException";
   $fault: "client";
@@ -853,7 +856,7 @@ export interface KMSAccessDeniedException
 
 export namespace KMSAccessDeniedException {
   export function isa(o: any): o is KMSAccessDeniedException {
-    return _smithy.isa(o, "KMSAccessDeniedException");
+    return __isa(o, "KMSAccessDeniedException");
   }
 }
 
@@ -862,7 +865,7 @@ export namespace KMSAccessDeniedException {
  *             enabled.</p>
  */
 export interface KMSDisabledException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "KMSDisabledException";
   $fault: "client";
@@ -874,7 +877,7 @@ export interface KMSDisabledException
 
 export namespace KMSDisabledException {
   export function isa(o: any): o is KMSDisabledException {
-    return _smithy.isa(o, "KMSDisabledException");
+    return __isa(o, "KMSDisabledException");
   }
 }
 
@@ -884,7 +887,7 @@ export namespace KMSDisabledException {
  *             <i>AWS Key Management Service Developer Guide</i>.</p>
  */
 export interface KMSInvalidStateException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "KMSInvalidStateException";
   $fault: "client";
@@ -896,7 +899,7 @@ export interface KMSInvalidStateException
 
 export namespace KMSInvalidStateException {
   export function isa(o: any): o is KMSInvalidStateException {
-    return _smithy.isa(o, "KMSInvalidStateException");
+    return __isa(o, "KMSInvalidStateException");
   }
 }
 
@@ -905,7 +908,7 @@ export namespace KMSInvalidStateException {
  *             found.</p>
  */
 export interface KMSNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "KMSNotFoundException";
   $fault: "client";
@@ -917,16 +920,14 @@ export interface KMSNotFoundException
 
 export namespace KMSNotFoundException {
   export function isa(o: any): o is KMSNotFoundException {
-    return _smithy.isa(o, "KMSNotFoundException");
+    return __isa(o, "KMSNotFoundException");
   }
 }
 
 /**
  * <p>The AWS access key ID needs a subscription for the service.</p>
  */
-export interface KMSOptInRequired
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface KMSOptInRequired extends __SmithyException, $MetadataBearer {
   name: "KMSOptInRequired";
   $fault: "client";
   /**
@@ -937,7 +938,7 @@ export interface KMSOptInRequired
 
 export namespace KMSOptInRequired {
   export function isa(o: any): o is KMSOptInRequired {
-    return _smithy.isa(o, "KMSOptInRequired");
+    return __isa(o, "KMSOptInRequired");
   }
 }
 
@@ -946,7 +947,7 @@ export namespace KMSOptInRequired {
  *             <i>AWS Key Management Service Developer Guide</i>.</p>
  */
 export interface KMSThrottlingException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "KMSThrottlingException";
   $fault: "client";
@@ -958,7 +959,7 @@ export interface KMSThrottlingException
 
 export namespace KMSThrottlingException {
   export function isa(o: any): o is KMSThrottlingException {
-    return _smithy.isa(o, "KMSThrottlingException");
+    return __isa(o, "KMSThrottlingException");
   }
 }
 
@@ -966,7 +967,7 @@ export namespace KMSThrottlingException {
  * <p>The requested resource exceeds the maximum number allowed, or the number of concurrent stream requests exceeds the maximum number allowed. </p>
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -978,7 +979,7 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
@@ -1048,7 +1049,7 @@ export interface ListShardsInput {
 
 export namespace ListShardsInput {
   export function isa(o: any): o is ListShardsInput {
-    return _smithy.isa(o, "ListShardsInput");
+    return __isa(o, "ListShardsInput");
   }
 }
 
@@ -1080,7 +1081,7 @@ export interface ListShardsOutput extends $MetadataBearer {
 
 export namespace ListShardsOutput {
   export function isa(o: any): o is ListShardsOutput {
-    return _smithy.isa(o, "ListShardsOutput");
+    return __isa(o, "ListShardsOutput");
   }
 }
 
@@ -1135,7 +1136,7 @@ export interface ListStreamConsumersInput {
 
 export namespace ListStreamConsumersInput {
   export function isa(o: any): o is ListStreamConsumersInput {
-    return _smithy.isa(o, "ListStreamConsumersInput");
+    return __isa(o, "ListStreamConsumersInput");
   }
 }
 
@@ -1166,7 +1167,7 @@ export interface ListStreamConsumersOutput extends $MetadataBearer {
 
 export namespace ListStreamConsumersOutput {
   export function isa(o: any): o is ListStreamConsumersOutput {
-    return _smithy.isa(o, "ListStreamConsumersOutput");
+    return __isa(o, "ListStreamConsumersOutput");
   }
 }
 
@@ -1188,7 +1189,7 @@ export interface ListStreamsInput {
 
 export namespace ListStreamsInput {
   export function isa(o: any): o is ListStreamsInput {
-    return _smithy.isa(o, "ListStreamsInput");
+    return __isa(o, "ListStreamsInput");
   }
 }
 
@@ -1211,7 +1212,7 @@ export interface ListStreamsOutput extends $MetadataBearer {
 
 export namespace ListStreamsOutput {
   export function isa(o: any): o is ListStreamsOutput {
-    return _smithy.isa(o, "ListStreamsOutput");
+    return __isa(o, "ListStreamsOutput");
   }
 }
 
@@ -1243,7 +1244,7 @@ export interface ListTagsForStreamInput {
 
 export namespace ListTagsForStreamInput {
   export function isa(o: any): o is ListTagsForStreamInput {
-    return _smithy.isa(o, "ListTagsForStreamInput");
+    return __isa(o, "ListTagsForStreamInput");
   }
 }
 
@@ -1267,7 +1268,7 @@ export interface ListTagsForStreamOutput extends $MetadataBearer {
 
 export namespace ListTagsForStreamOutput {
   export function isa(o: any): o is ListTagsForStreamOutput {
-    return _smithy.isa(o, "ListTagsForStreamOutput");
+    return __isa(o, "ListTagsForStreamOutput");
   }
 }
 
@@ -1294,7 +1295,7 @@ export interface MergeShardsInput {
 
 export namespace MergeShardsInput {
   export function isa(o: any): o is MergeShardsInput {
-    return _smithy.isa(o, "MergeShardsInput");
+    return __isa(o, "MergeShardsInput");
   }
 }
 
@@ -1318,7 +1319,7 @@ export enum MetricsName {
  *             Reference</i>.</p>
  */
 export interface ProvisionedThroughputExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ProvisionedThroughputExceededException";
   $fault: "client";
@@ -1330,7 +1331,7 @@ export interface ProvisionedThroughputExceededException
 
 export namespace ProvisionedThroughputExceededException {
   export function isa(o: any): o is ProvisionedThroughputExceededException {
-    return _smithy.isa(o, "ProvisionedThroughputExceededException");
+    return __isa(o, "ProvisionedThroughputExceededException");
   }
 }
 
@@ -1377,7 +1378,7 @@ export interface PutRecordInput {
 
 export namespace PutRecordInput {
   export function isa(o: any): o is PutRecordInput {
-    return _smithy.isa(o, "PutRecordInput");
+    return __isa(o, "PutRecordInput");
   }
 }
 
@@ -1415,7 +1416,7 @@ export interface PutRecordOutput extends $MetadataBearer {
 
 export namespace PutRecordOutput {
   export function isa(o: any): o is PutRecordOutput {
-    return _smithy.isa(o, "PutRecordOutput");
+    return __isa(o, "PutRecordOutput");
   }
 }
 
@@ -1437,7 +1438,7 @@ export interface PutRecordsInput {
 
 export namespace PutRecordsInput {
   export function isa(o: any): o is PutRecordsInput {
-    return _smithy.isa(o, "PutRecordsInput");
+    return __isa(o, "PutRecordsInput");
   }
 }
 
@@ -1480,7 +1481,7 @@ export interface PutRecordsOutput extends $MetadataBearer {
 
 export namespace PutRecordsOutput {
   export function isa(o: any): o is PutRecordsOutput {
-    return _smithy.isa(o, "PutRecordsOutput");
+    return __isa(o, "PutRecordsOutput");
   }
 }
 
@@ -1513,7 +1514,7 @@ export interface PutRecordsRequestEntry {
 
 export namespace PutRecordsRequestEntry {
   export function isa(o: any): o is PutRecordsRequestEntry {
-    return _smithy.isa(o, "PutRecordsRequestEntry");
+    return __isa(o, "PutRecordsRequestEntry");
   }
 }
 
@@ -1554,7 +1555,7 @@ export interface PutRecordsResultEntry {
 
 export namespace PutRecordsResultEntry {
   export function isa(o: any): o is PutRecordsResultEntry {
-    return _smithy.isa(o, "PutRecordsResultEntry");
+    return __isa(o, "PutRecordsResultEntry");
   }
 }
 
@@ -1606,7 +1607,7 @@ export interface _Record {
 
 export namespace _Record {
   export function isa(o: any): o is _Record {
-    return _smithy.isa(o, "Record");
+    return __isa(o, "Record");
   }
 }
 
@@ -1626,7 +1627,7 @@ export interface RegisterStreamConsumerInput {
 
 export namespace RegisterStreamConsumerInput {
   export function isa(o: any): o is RegisterStreamConsumerInput {
-    return _smithy.isa(o, "RegisterStreamConsumerInput");
+    return __isa(o, "RegisterStreamConsumerInput");
   }
 }
 
@@ -1641,7 +1642,7 @@ export interface RegisterStreamConsumerOutput extends $MetadataBearer {
 
 export namespace RegisterStreamConsumerOutput {
   export function isa(o: any): o is RegisterStreamConsumerOutput {
-    return _smithy.isa(o, "RegisterStreamConsumerOutput");
+    return __isa(o, "RegisterStreamConsumerOutput");
   }
 }
 
@@ -1663,7 +1664,7 @@ export interface RemoveTagsFromStreamInput {
 
 export namespace RemoveTagsFromStreamInput {
   export function isa(o: any): o is RemoveTagsFromStreamInput {
-    return _smithy.isa(o, "RemoveTagsFromStreamInput");
+    return __isa(o, "RemoveTagsFromStreamInput");
   }
 }
 
@@ -1672,7 +1673,7 @@ export namespace RemoveTagsFromStreamInput {
  *             resource must be in the <code>ACTIVE</code> state.</p>
  */
 export interface ResourceInUseException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceInUseException";
   $fault: "client";
@@ -1684,7 +1685,7 @@ export interface ResourceInUseException
 
 export namespace ResourceInUseException {
   export function isa(o: any): o is ResourceInUseException {
-    return _smithy.isa(o, "ResourceInUseException");
+    return __isa(o, "ResourceInUseException");
   }
 }
 
@@ -1692,7 +1693,7 @@ export namespace ResourceInUseException {
  * <p>The requested resource could not be found. The stream might not be specified correctly.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -1704,7 +1705,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -1731,7 +1732,7 @@ export interface SequenceNumberRange {
 
 export namespace SequenceNumberRange {
   export function isa(o: any): o is SequenceNumberRange {
-    return _smithy.isa(o, "SequenceNumberRange");
+    return __isa(o, "SequenceNumberRange");
   }
 }
 
@@ -1768,7 +1769,7 @@ export interface Shard {
 
 export namespace Shard {
   export function isa(o: any): o is Shard {
-    return _smithy.isa(o, "Shard");
+    return __isa(o, "Shard");
   }
 }
 
@@ -1809,7 +1810,7 @@ export interface SplitShardInput {
 
 export namespace SplitShardInput {
   export function isa(o: any): o is SplitShardInput {
-    return _smithy.isa(o, "SplitShardInput");
+    return __isa(o, "SplitShardInput");
   }
 }
 
@@ -1861,7 +1862,7 @@ export interface StartStreamEncryptionInput {
 
 export namespace StartStreamEncryptionInput {
   export function isa(o: any): o is StartStreamEncryptionInput {
-    return _smithy.isa(o, "StartStreamEncryptionInput");
+    return __isa(o, "StartStreamEncryptionInput");
   }
 }
 
@@ -1874,7 +1875,7 @@ export interface StartingPosition {
 
 export namespace StartingPosition {
   export function isa(o: any): o is StartingPosition {
-    return _smithy.isa(o, "StartingPosition");
+    return __isa(o, "StartingPosition");
   }
 }
 
@@ -1926,7 +1927,7 @@ export interface StopStreamEncryptionInput {
 
 export namespace StopStreamEncryptionInput {
   export function isa(o: any): o is StopStreamEncryptionInput {
-    return _smithy.isa(o, "StopStreamEncryptionInput");
+    return __isa(o, "StopStreamEncryptionInput");
   }
 }
 
@@ -2052,7 +2053,7 @@ export interface StreamDescription {
 
 export namespace StreamDescription {
   export function isa(o: any): o is StreamDescription {
-    return _smithy.isa(o, "StreamDescription");
+    return __isa(o, "StreamDescription");
   }
 }
 
@@ -2180,7 +2181,7 @@ export interface StreamDescriptionSummary {
 
 export namespace StreamDescriptionSummary {
   export function isa(o: any): o is StreamDescriptionSummary {
-    return _smithy.isa(o, "StreamDescriptionSummary");
+    return __isa(o, "StreamDescriptionSummary");
   }
 }
 
@@ -2215,7 +2216,7 @@ export interface SubscribeToShardEvent {
 
 export namespace SubscribeToShardEvent {
   export function isa(o: any): o is SubscribeToShardEvent {
-    return _smithy.isa(o, "SubscribeToShardEvent");
+    return __isa(o, "SubscribeToShardEvent");
   }
 }
 
@@ -2471,7 +2472,7 @@ export interface SubscribeToShardInput {
 
 export namespace SubscribeToShardInput {
   export function isa(o: any): o is SubscribeToShardInput {
-    return _smithy.isa(o, "SubscribeToShardInput");
+    return __isa(o, "SubscribeToShardInput");
   }
 }
 
@@ -2485,7 +2486,7 @@ export interface SubscribeToShardOutput extends $MetadataBearer {
 
 export namespace SubscribeToShardOutput {
   export function isa(o: any): o is SubscribeToShardOutput {
-    return _smithy.isa(o, "SubscribeToShardOutput");
+    return __isa(o, "SubscribeToShardOutput");
   }
 }
 
@@ -2507,7 +2508,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -2531,7 +2532,7 @@ export interface UpdateShardCountInput {
 
 export namespace UpdateShardCountInput {
   export function isa(o: any): o is UpdateShardCountInput {
-    return _smithy.isa(o, "UpdateShardCountInput");
+    return __isa(o, "UpdateShardCountInput");
   }
 }
 
@@ -2555,6 +2556,6 @@ export interface UpdateShardCountOutput extends $MetadataBearer {
 
 export namespace UpdateShardCountOutput {
   export function isa(o: any): o is UpdateShardCountOutput {
-    return _smithy.isa(o, "UpdateShardCountOutput");
+    return __isa(o, "UpdateShardCountOutput");
   }
 }

--- a/clients/client-kinesis/protocols/Aws_json1_1.ts
+++ b/clients/client-kinesis/protocols/Aws_json1_1.ts
@@ -580,6 +580,7 @@ export async function deserializeAws_json1_1AddTagsToStreamCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1AddTagsToStreamCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: AddTagsToStreamCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -652,6 +653,7 @@ export async function deserializeAws_json1_1CreateStreamCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1CreateStreamCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: CreateStreamCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -720,6 +722,7 @@ export async function deserializeAws_json1_1DecreaseStreamRetentionPeriodCommand
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DecreaseStreamRetentionPeriodCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -792,6 +795,7 @@ export async function deserializeAws_json1_1DeleteStreamCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1DeleteStreamCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteStreamCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -860,6 +864,7 @@ export async function deserializeAws_json1_1DeregisterStreamConsumerCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeregisterStreamConsumerCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1535,6 +1540,7 @@ export async function deserializeAws_json1_1IncreaseStreamRetentionPeriodCommand
       context
     );
   }
+  await collectBody(output.body, context);
   const response: IncreaseStreamRetentionPeriodCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1904,6 +1910,7 @@ export async function deserializeAws_json1_1MergeShardsCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1MergeShardsCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: MergeShardsCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2283,6 +2290,7 @@ export async function deserializeAws_json1_1RemoveTagsFromStreamCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: RemoveTagsFromStreamCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2355,6 +2363,7 @@ export async function deserializeAws_json1_1SplitShardCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1SplitShardCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: SplitShardCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2430,6 +2439,7 @@ export async function deserializeAws_json1_1StartStreamEncryptionCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: StartStreamEncryptionCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2547,6 +2557,7 @@ export async function deserializeAws_json1_1StopStreamEncryptionCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: StopStreamEncryptionCommandOutput = {
     $metadata: deserializeMetadata(output)
   };

--- a/clients/client-kms/models/index.ts
+++ b/clients/client-kms/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export enum AlgorithmSpec {
@@ -30,7 +33,7 @@ export interface AliasListEntry {
 
 export namespace AliasListEntry {
   export function isa(o: any): o is AliasListEntry {
-    return _smithy.isa(o, "AliasListEntry");
+    return __isa(o, "AliasListEntry");
   }
 }
 
@@ -39,7 +42,7 @@ export namespace AliasListEntry {
  *       exists.</p>
  */
 export interface AlreadyExistsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AlreadyExistsException";
   $fault: "client";
@@ -48,7 +51,7 @@ export interface AlreadyExistsException
 
 export namespace AlreadyExistsException {
   export function isa(o: any): o is AlreadyExistsException {
-    return _smithy.isa(o, "AlreadyExistsException");
+    return __isa(o, "AlreadyExistsException");
   }
 }
 
@@ -76,7 +79,7 @@ export interface CancelKeyDeletionRequest {
 
 export namespace CancelKeyDeletionRequest {
   export function isa(o: any): o is CancelKeyDeletionRequest {
-    return _smithy.isa(o, "CancelKeyDeletionRequest");
+    return __isa(o, "CancelKeyDeletionRequest");
   }
 }
 
@@ -90,7 +93,7 @@ export interface CancelKeyDeletionResponse extends $MetadataBearer {
 
 export namespace CancelKeyDeletionResponse {
   export function isa(o: any): o is CancelKeyDeletionResponse {
-    return _smithy.isa(o, "CancelKeyDeletionResponse");
+    return __isa(o, "CancelKeyDeletionResponse");
   }
 }
 
@@ -102,7 +105,7 @@ export namespace CancelKeyDeletionResponse {
  *       cluster certificate of a cluster, use the <a href="https://docs.aws.amazon.com/cloudhsm/latest/APIReference/API_DescribeClusters.html">DescribeClusters</a> operation.</p>
  */
 export interface CloudHsmClusterInUseException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CloudHsmClusterInUseException";
   $fault: "client";
@@ -111,7 +114,7 @@ export interface CloudHsmClusterInUseException
 
 export namespace CloudHsmClusterInUseException {
   export function isa(o: any): o is CloudHsmClusterInUseException {
-    return _smithy.isa(o, "CloudHsmClusterInUseException");
+    return __isa(o, "CloudHsmClusterInUseException");
   }
 }
 
@@ -151,7 +154,7 @@ export namespace CloudHsmClusterInUseException {
  *             </i>. </p>
  */
 export interface CloudHsmClusterInvalidConfigurationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CloudHsmClusterInvalidConfigurationException";
   $fault: "client";
@@ -162,7 +165,7 @@ export namespace CloudHsmClusterInvalidConfigurationException {
   export function isa(
     o: any
   ): o is CloudHsmClusterInvalidConfigurationException {
-    return _smithy.isa(o, "CloudHsmClusterInvalidConfigurationException");
+    return __isa(o, "CloudHsmClusterInvalidConfigurationException");
   }
 }
 
@@ -172,7 +175,7 @@ export namespace CloudHsmClusterInvalidConfigurationException {
  *       detailed instructions, see <a href="https://docs.aws.amazon.com/cloudhsm/latest/userguide/getting-started.html">Getting Started</a> in the <i>AWS CloudHSM User Guide</i>.</p>
  */
 export interface CloudHsmClusterNotActiveException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CloudHsmClusterNotActiveException";
   $fault: "client";
@@ -181,7 +184,7 @@ export interface CloudHsmClusterNotActiveException
 
 export namespace CloudHsmClusterNotActiveException {
   export function isa(o: any): o is CloudHsmClusterNotActiveException {
-    return _smithy.isa(o, "CloudHsmClusterNotActiveException");
+    return __isa(o, "CloudHsmClusterNotActiveException");
   }
 }
 
@@ -190,7 +193,7 @@ export namespace CloudHsmClusterNotActiveException {
  *       cluster ID. Retry the request with a different cluster ID.</p>
  */
 export interface CloudHsmClusterNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CloudHsmClusterNotFoundException";
   $fault: "client";
@@ -199,7 +202,7 @@ export interface CloudHsmClusterNotFoundException
 
 export namespace CloudHsmClusterNotFoundException {
   export function isa(o: any): o is CloudHsmClusterNotFoundException {
-    return _smithy.isa(o, "CloudHsmClusterNotFoundException");
+    return __isa(o, "CloudHsmClusterNotFoundException");
   }
 }
 
@@ -214,7 +217,7 @@ export namespace CloudHsmClusterNotFoundException {
  *       cluster certificate of a cluster, use the <a href="https://docs.aws.amazon.com/cloudhsm/latest/APIReference/API_DescribeClusters.html">DescribeClusters</a> operation.</p>
  */
 export interface CloudHsmClusterNotRelatedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CloudHsmClusterNotRelatedException";
   $fault: "client";
@@ -223,7 +226,7 @@ export interface CloudHsmClusterNotRelatedException
 
 export namespace CloudHsmClusterNotRelatedException {
   export function isa(o: any): o is CloudHsmClusterNotRelatedException {
-    return _smithy.isa(o, "CloudHsmClusterNotRelatedException");
+    return __isa(o, "CloudHsmClusterNotRelatedException");
   }
 }
 
@@ -238,7 +241,7 @@ export interface ConnectCustomKeyStoreRequest {
 
 export namespace ConnectCustomKeyStoreRequest {
   export function isa(o: any): o is ConnectCustomKeyStoreRequest {
-    return _smithy.isa(o, "ConnectCustomKeyStoreRequest");
+    return __isa(o, "ConnectCustomKeyStoreRequest");
   }
 }
 
@@ -248,7 +251,7 @@ export interface ConnectCustomKeyStoreResponse extends $MetadataBearer {
 
 export namespace ConnectCustomKeyStoreResponse {
   export function isa(o: any): o is ConnectCustomKeyStoreResponse {
-    return _smithy.isa(o, "ConnectCustomKeyStoreResponse");
+    return __isa(o, "ConnectCustomKeyStoreResponse");
   }
 }
 
@@ -292,7 +295,7 @@ export interface CreateAliasRequest {
 
 export namespace CreateAliasRequest {
   export function isa(o: any): o is CreateAliasRequest {
-    return _smithy.isa(o, "CreateAliasRequest");
+    return __isa(o, "CreateAliasRequest");
   }
 }
 
@@ -331,7 +334,7 @@ export interface CreateCustomKeyStoreRequest {
 
 export namespace CreateCustomKeyStoreRequest {
   export function isa(o: any): o is CreateCustomKeyStoreRequest {
-    return _smithy.isa(o, "CreateCustomKeyStoreRequest");
+    return __isa(o, "CreateCustomKeyStoreRequest");
   }
 }
 
@@ -345,7 +348,7 @@ export interface CreateCustomKeyStoreResponse extends $MetadataBearer {
 
 export namespace CreateCustomKeyStoreResponse {
   export function isa(o: any): o is CreateCustomKeyStoreResponse {
-    return _smithy.isa(o, "CreateCustomKeyStoreResponse");
+    return __isa(o, "CreateCustomKeyStoreResponse");
   }
 }
 
@@ -432,7 +435,7 @@ export interface CreateGrantRequest {
 
 export namespace CreateGrantRequest {
   export function isa(o: any): o is CreateGrantRequest {
-    return _smithy.isa(o, "CreateGrantRequest");
+    return __isa(o, "CreateGrantRequest");
   }
 }
 
@@ -455,7 +458,7 @@ export interface CreateGrantResponse extends $MetadataBearer {
 
 export namespace CreateGrantResponse {
   export function isa(o: any): o is CreateGrantResponse {
-    return _smithy.isa(o, "CreateGrantResponse");
+    return __isa(o, "CreateGrantResponse");
   }
 }
 
@@ -658,7 +661,7 @@ export interface CreateKeyRequest {
 
 export namespace CreateKeyRequest {
   export function isa(o: any): o is CreateKeyRequest {
-    return _smithy.isa(o, "CreateKeyRequest");
+    return __isa(o, "CreateKeyRequest");
   }
 }
 
@@ -672,7 +675,7 @@ export interface CreateKeyResponse extends $MetadataBearer {
 
 export namespace CreateKeyResponse {
   export function isa(o: any): o is CreateKeyResponse {
-    return _smithy.isa(o, "CreateKeyResponse");
+    return __isa(o, "CreateKeyResponse");
   }
 }
 
@@ -682,7 +685,7 @@ export namespace CreateKeyResponse {
  *       can delete the custom key store.</p>
  */
 export interface CustomKeyStoreHasCMKsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CustomKeyStoreHasCMKsException";
   $fault: "client";
@@ -691,7 +694,7 @@ export interface CustomKeyStoreHasCMKsException
 
 export namespace CustomKeyStoreHasCMKsException {
   export function isa(o: any): o is CustomKeyStoreHasCMKsException {
-    return _smithy.isa(o, "CustomKeyStoreHasCMKsException");
+    return __isa(o, "CustomKeyStoreHasCMKsException");
   }
 }
 
@@ -719,7 +722,7 @@ export namespace CustomKeyStoreHasCMKsException {
  *          </ul>
  */
 export interface CustomKeyStoreInvalidStateException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CustomKeyStoreInvalidStateException";
   $fault: "client";
@@ -728,7 +731,7 @@ export interface CustomKeyStoreInvalidStateException
 
 export namespace CustomKeyStoreInvalidStateException {
   export function isa(o: any): o is CustomKeyStoreInvalidStateException {
-    return _smithy.isa(o, "CustomKeyStoreInvalidStateException");
+    return __isa(o, "CustomKeyStoreInvalidStateException");
   }
 }
 
@@ -738,7 +741,7 @@ export namespace CustomKeyStoreInvalidStateException {
  *       unique in the account.</p>
  */
 export interface CustomKeyStoreNameInUseException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CustomKeyStoreNameInUseException";
   $fault: "client";
@@ -747,7 +750,7 @@ export interface CustomKeyStoreNameInUseException
 
 export namespace CustomKeyStoreNameInUseException {
   export function isa(o: any): o is CustomKeyStoreNameInUseException {
-    return _smithy.isa(o, "CustomKeyStoreNameInUseException");
+    return __isa(o, "CustomKeyStoreNameInUseException");
   }
 }
 
@@ -756,7 +759,7 @@ export namespace CustomKeyStoreNameInUseException {
  *       key store name or ID.</p>
  */
 export interface CustomKeyStoreNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CustomKeyStoreNotFoundException";
   $fault: "client";
@@ -765,7 +768,7 @@ export interface CustomKeyStoreNotFoundException
 
 export namespace CustomKeyStoreNotFoundException {
   export function isa(o: any): o is CustomKeyStoreNotFoundException {
-    return _smithy.isa(o, "CustomKeyStoreNotFoundException");
+    return __isa(o, "CustomKeyStoreNotFoundException");
   }
 }
 
@@ -877,7 +880,7 @@ export interface CustomKeyStoresListEntry {
 
 export namespace CustomKeyStoresListEntry {
   export function isa(o: any): o is CustomKeyStoresListEntry {
-    return _smithy.isa(o, "CustomKeyStoresListEntry");
+    return __isa(o, "CustomKeyStoresListEntry");
   }
 }
 
@@ -977,7 +980,7 @@ export interface DecryptRequest {
 
 export namespace DecryptRequest {
   export function isa(o: any): o is DecryptRequest {
-    return _smithy.isa(o, "DecryptRequest");
+    return __isa(o, "DecryptRequest");
   }
 }
 
@@ -1001,7 +1004,7 @@ export interface DecryptResponse extends $MetadataBearer {
 
 export namespace DecryptResponse {
   export function isa(o: any): o is DecryptResponse {
-    return _smithy.isa(o, "DecryptResponse");
+    return __isa(o, "DecryptResponse");
   }
 }
 
@@ -1016,7 +1019,7 @@ export interface DeleteAliasRequest {
 
 export namespace DeleteAliasRequest {
   export function isa(o: any): o is DeleteAliasRequest {
-    return _smithy.isa(o, "DeleteAliasRequest");
+    return __isa(o, "DeleteAliasRequest");
   }
 }
 
@@ -1030,7 +1033,7 @@ export interface DeleteCustomKeyStoreRequest {
 
 export namespace DeleteCustomKeyStoreRequest {
   export function isa(o: any): o is DeleteCustomKeyStoreRequest {
-    return _smithy.isa(o, "DeleteCustomKeyStoreRequest");
+    return __isa(o, "DeleteCustomKeyStoreRequest");
   }
 }
 
@@ -1040,7 +1043,7 @@ export interface DeleteCustomKeyStoreResponse extends $MetadataBearer {
 
 export namespace DeleteCustomKeyStoreResponse {
   export function isa(o: any): o is DeleteCustomKeyStoreResponse {
-    return _smithy.isa(o, "DeleteCustomKeyStoreResponse");
+    return __isa(o, "DeleteCustomKeyStoreResponse");
   }
 }
 
@@ -1068,7 +1071,7 @@ export interface DeleteImportedKeyMaterialRequest {
 
 export namespace DeleteImportedKeyMaterialRequest {
   export function isa(o: any): o is DeleteImportedKeyMaterialRequest {
-    return _smithy.isa(o, "DeleteImportedKeyMaterialRequest");
+    return __isa(o, "DeleteImportedKeyMaterialRequest");
   }
 }
 
@@ -1077,7 +1080,7 @@ export namespace DeleteImportedKeyMaterialRequest {
  *       retried.</p>
  */
 export interface DependencyTimeoutException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DependencyTimeoutException";
   $fault: "server";
@@ -1086,7 +1089,7 @@ export interface DependencyTimeoutException
 
 export namespace DependencyTimeoutException {
   export function isa(o: any): o is DependencyTimeoutException {
-    return _smithy.isa(o, "DependencyTimeoutException");
+    return __isa(o, "DependencyTimeoutException");
   }
 }
 
@@ -1128,7 +1131,7 @@ export interface DescribeCustomKeyStoresRequest {
 
 export namespace DescribeCustomKeyStoresRequest {
   export function isa(o: any): o is DescribeCustomKeyStoresRequest {
-    return _smithy.isa(o, "DescribeCustomKeyStoresRequest");
+    return __isa(o, "DescribeCustomKeyStoresRequest");
   }
 }
 
@@ -1156,7 +1159,7 @@ export interface DescribeCustomKeyStoresResponse extends $MetadataBearer {
 
 export namespace DescribeCustomKeyStoresResponse {
   export function isa(o: any): o is DescribeCustomKeyStoresResponse {
-    return _smithy.isa(o, "DescribeCustomKeyStoresResponse");
+    return __isa(o, "DescribeCustomKeyStoresResponse");
   }
 }
 
@@ -1202,7 +1205,7 @@ export interface DescribeKeyRequest {
 
 export namespace DescribeKeyRequest {
   export function isa(o: any): o is DescribeKeyRequest {
-    return _smithy.isa(o, "DescribeKeyRequest");
+    return __isa(o, "DescribeKeyRequest");
   }
 }
 
@@ -1216,7 +1219,7 @@ export interface DescribeKeyResponse extends $MetadataBearer {
 
 export namespace DescribeKeyResponse {
   export function isa(o: any): o is DescribeKeyResponse {
-    return _smithy.isa(o, "DescribeKeyResponse");
+    return __isa(o, "DescribeKeyResponse");
   }
 }
 
@@ -1243,7 +1246,7 @@ export interface DisableKeyRequest {
 
 export namespace DisableKeyRequest {
   export function isa(o: any): o is DisableKeyRequest {
-    return _smithy.isa(o, "DisableKeyRequest");
+    return __isa(o, "DisableKeyRequest");
   }
 }
 
@@ -1272,16 +1275,14 @@ export interface DisableKeyRotationRequest {
 
 export namespace DisableKeyRotationRequest {
   export function isa(o: any): o is DisableKeyRotationRequest {
-    return _smithy.isa(o, "DisableKeyRotationRequest");
+    return __isa(o, "DisableKeyRotationRequest");
   }
 }
 
 /**
  * <p>The request was rejected because the specified CMK is not enabled.</p>
  */
-export interface DisabledException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface DisabledException extends __SmithyException, $MetadataBearer {
   name: "DisabledException";
   $fault: "client";
   message?: string;
@@ -1289,7 +1290,7 @@ export interface DisabledException
 
 export namespace DisabledException {
   export function isa(o: any): o is DisabledException {
-    return _smithy.isa(o, "DisabledException");
+    return __isa(o, "DisabledException");
   }
 }
 
@@ -1303,7 +1304,7 @@ export interface DisconnectCustomKeyStoreRequest {
 
 export namespace DisconnectCustomKeyStoreRequest {
   export function isa(o: any): o is DisconnectCustomKeyStoreRequest {
-    return _smithy.isa(o, "DisconnectCustomKeyStoreRequest");
+    return __isa(o, "DisconnectCustomKeyStoreRequest");
   }
 }
 
@@ -1313,7 +1314,7 @@ export interface DisconnectCustomKeyStoreResponse extends $MetadataBearer {
 
 export namespace DisconnectCustomKeyStoreResponse {
   export function isa(o: any): o is DisconnectCustomKeyStoreResponse {
-    return _smithy.isa(o, "DisconnectCustomKeyStoreResponse");
+    return __isa(o, "DisconnectCustomKeyStoreResponse");
   }
 }
 
@@ -1340,7 +1341,7 @@ export interface EnableKeyRequest {
 
 export namespace EnableKeyRequest {
   export function isa(o: any): o is EnableKeyRequest {
-    return _smithy.isa(o, "EnableKeyRequest");
+    return __isa(o, "EnableKeyRequest");
   }
 }
 
@@ -1368,7 +1369,7 @@ export interface EnableKeyRotationRequest {
 
 export namespace EnableKeyRotationRequest {
   export function isa(o: any): o is EnableKeyRotationRequest {
-    return _smithy.isa(o, "EnableKeyRotationRequest");
+    return __isa(o, "EnableKeyRotationRequest");
   }
 }
 
@@ -1434,7 +1435,7 @@ export interface EncryptRequest {
 
 export namespace EncryptRequest {
   export function isa(o: any): o is EncryptRequest {
-    return _smithy.isa(o, "EncryptRequest");
+    return __isa(o, "EncryptRequest");
   }
 }
 
@@ -1458,7 +1459,7 @@ export interface EncryptResponse extends $MetadataBearer {
 
 export namespace EncryptResponse {
   export function isa(o: any): o is EncryptResponse {
-    return _smithy.isa(o, "EncryptResponse");
+    return __isa(o, "EncryptResponse");
   }
 }
 
@@ -1478,7 +1479,7 @@ export enum ExpirationModelType {
  *       public key to encrypt the key material, and then try the request again.</p>
  */
 export interface ExpiredImportTokenException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ExpiredImportTokenException";
   $fault: "client";
@@ -1487,7 +1488,7 @@ export interface ExpiredImportTokenException
 
 export namespace ExpiredImportTokenException {
   export function isa(o: any): o is ExpiredImportTokenException {
-    return _smithy.isa(o, "ExpiredImportTokenException");
+    return __isa(o, "ExpiredImportTokenException");
   }
 }
 
@@ -1546,7 +1547,7 @@ export interface GenerateDataKeyPairRequest {
 
 export namespace GenerateDataKeyPairRequest {
   export function isa(o: any): o is GenerateDataKeyPairRequest {
-    return _smithy.isa(o, "GenerateDataKeyPairRequest");
+    return __isa(o, "GenerateDataKeyPairRequest");
   }
 }
 
@@ -1580,7 +1581,7 @@ export interface GenerateDataKeyPairResponse extends $MetadataBearer {
 
 export namespace GenerateDataKeyPairResponse {
   export function isa(o: any): o is GenerateDataKeyPairResponse {
-    return _smithy.isa(o, "GenerateDataKeyPairResponse");
+    return __isa(o, "GenerateDataKeyPairResponse");
   }
 }
 
@@ -1641,7 +1642,7 @@ export interface GenerateDataKeyPairWithoutPlaintextRequest {
 
 export namespace GenerateDataKeyPairWithoutPlaintextRequest {
   export function isa(o: any): o is GenerateDataKeyPairWithoutPlaintextRequest {
-    return _smithy.isa(o, "GenerateDataKeyPairWithoutPlaintextRequest");
+    return __isa(o, "GenerateDataKeyPairWithoutPlaintextRequest");
   }
 }
 
@@ -1696,7 +1697,7 @@ export namespace GenerateDataKeyPairWithoutPlaintextResponse {
   export function isa(
     o: any
   ): o is GenerateDataKeyPairWithoutPlaintextResponse {
-    return _smithy.isa(o, "GenerateDataKeyPairWithoutPlaintextResponse");
+    return __isa(o, "GenerateDataKeyPairWithoutPlaintextResponse");
   }
 }
 
@@ -1765,7 +1766,7 @@ export interface GenerateDataKeyRequest {
 
 export namespace GenerateDataKeyRequest {
   export function isa(o: any): o is GenerateDataKeyRequest {
-    return _smithy.isa(o, "GenerateDataKeyRequest");
+    return __isa(o, "GenerateDataKeyRequest");
   }
 }
 
@@ -1790,7 +1791,7 @@ export interface GenerateDataKeyResponse extends $MetadataBearer {
 
 export namespace GenerateDataKeyResponse {
   export function isa(o: any): o is GenerateDataKeyResponse {
-    return _smithy.isa(o, "GenerateDataKeyResponse");
+    return __isa(o, "GenerateDataKeyResponse");
   }
 }
 
@@ -1855,7 +1856,7 @@ export interface GenerateDataKeyWithoutPlaintextRequest {
 
 export namespace GenerateDataKeyWithoutPlaintextRequest {
   export function isa(o: any): o is GenerateDataKeyWithoutPlaintextRequest {
-    return _smithy.isa(o, "GenerateDataKeyWithoutPlaintextRequest");
+    return __isa(o, "GenerateDataKeyWithoutPlaintextRequest");
   }
 }
 
@@ -1875,7 +1876,7 @@ export interface GenerateDataKeyWithoutPlaintextResponse
 
 export namespace GenerateDataKeyWithoutPlaintextResponse {
   export function isa(o: any): o is GenerateDataKeyWithoutPlaintextResponse {
-    return _smithy.isa(o, "GenerateDataKeyWithoutPlaintextResponse");
+    return __isa(o, "GenerateDataKeyWithoutPlaintextResponse");
   }
 }
 
@@ -1895,7 +1896,7 @@ export interface GenerateRandomRequest {
 
 export namespace GenerateRandomRequest {
   export function isa(o: any): o is GenerateRandomRequest {
-    return _smithy.isa(o, "GenerateRandomRequest");
+    return __isa(o, "GenerateRandomRequest");
   }
 }
 
@@ -1909,7 +1910,7 @@ export interface GenerateRandomResponse extends $MetadataBearer {
 
 export namespace GenerateRandomResponse {
   export function isa(o: any): o is GenerateRandomResponse {
-    return _smithy.isa(o, "GenerateRandomResponse");
+    return __isa(o, "GenerateRandomResponse");
   }
 }
 
@@ -1942,7 +1943,7 @@ export interface GetKeyPolicyRequest {
 
 export namespace GetKeyPolicyRequest {
   export function isa(o: any): o is GetKeyPolicyRequest {
-    return _smithy.isa(o, "GetKeyPolicyRequest");
+    return __isa(o, "GetKeyPolicyRequest");
   }
 }
 
@@ -1956,7 +1957,7 @@ export interface GetKeyPolicyResponse extends $MetadataBearer {
 
 export namespace GetKeyPolicyResponse {
   export function isa(o: any): o is GetKeyPolicyResponse {
-    return _smithy.isa(o, "GetKeyPolicyResponse");
+    return __isa(o, "GetKeyPolicyResponse");
   }
 }
 
@@ -1984,7 +1985,7 @@ export interface GetKeyRotationStatusRequest {
 
 export namespace GetKeyRotationStatusRequest {
   export function isa(o: any): o is GetKeyRotationStatusRequest {
-    return _smithy.isa(o, "GetKeyRotationStatusRequest");
+    return __isa(o, "GetKeyRotationStatusRequest");
   }
 }
 
@@ -1998,7 +1999,7 @@ export interface GetKeyRotationStatusResponse extends $MetadataBearer {
 
 export namespace GetKeyRotationStatusResponse {
   export function isa(o: any): o is GetKeyRotationStatusResponse {
-    return _smithy.isa(o, "GetKeyRotationStatusResponse");
+    return __isa(o, "GetKeyRotationStatusResponse");
   }
 }
 
@@ -2038,7 +2039,7 @@ export interface GetParametersForImportRequest {
 
 export namespace GetParametersForImportRequest {
   export function isa(o: any): o is GetParametersForImportRequest {
-    return _smithy.isa(o, "GetParametersForImportRequest");
+    return __isa(o, "GetParametersForImportRequest");
   }
 }
 
@@ -2072,7 +2073,7 @@ export interface GetParametersForImportResponse extends $MetadataBearer {
 
 export namespace GetParametersForImportResponse {
   export function isa(o: any): o is GetParametersForImportResponse {
-    return _smithy.isa(o, "GetParametersForImportResponse");
+    return __isa(o, "GetParametersForImportResponse");
   }
 }
 
@@ -2115,7 +2116,7 @@ export interface GetPublicKeyRequest {
 
 export namespace GetPublicKeyRequest {
   export function isa(o: any): o is GetPublicKeyRequest {
-    return _smithy.isa(o, "GetPublicKeyRequest");
+    return __isa(o, "GetPublicKeyRequest");
   }
 }
 
@@ -2167,7 +2168,7 @@ export interface GetPublicKeyResponse extends $MetadataBearer {
 
 export namespace GetPublicKeyResponse {
   export function isa(o: any): o is GetPublicKeyResponse {
-    return _smithy.isa(o, "GetPublicKeyResponse");
+    return __isa(o, "GetPublicKeyResponse");
   }
 }
 
@@ -2238,7 +2239,7 @@ export interface GrantConstraints {
 
 export namespace GrantConstraints {
   export function isa(o: any): o is GrantConstraints {
-    return _smithy.isa(o, "GrantConstraints");
+    return __isa(o, "GrantConstraints");
   }
 }
 
@@ -2296,7 +2297,7 @@ export interface GrantListEntry {
 
 export namespace GrantListEntry {
   export function isa(o: any): o is GrantListEntry {
-    return _smithy.isa(o, "GrantListEntry");
+    return __isa(o, "GrantListEntry");
   }
 }
 
@@ -2372,7 +2373,7 @@ export interface ImportKeyMaterialRequest {
 
 export namespace ImportKeyMaterialRequest {
   export function isa(o: any): o is ImportKeyMaterialRequest {
-    return _smithy.isa(o, "ImportKeyMaterialRequest");
+    return __isa(o, "ImportKeyMaterialRequest");
   }
 }
 
@@ -2382,7 +2383,7 @@ export interface ImportKeyMaterialResponse extends $MetadataBearer {
 
 export namespace ImportKeyMaterialResponse {
   export function isa(o: any): o is ImportKeyMaterialResponse {
-    return _smithy.isa(o, "ImportKeyMaterialResponse");
+    return __isa(o, "ImportKeyMaterialResponse");
   }
 }
 
@@ -2393,7 +2394,7 @@ export namespace ImportKeyMaterialResponse {
  *       the ciphertext.</p>
  */
 export interface IncorrectKeyException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "IncorrectKeyException";
   $fault: "client";
@@ -2402,7 +2403,7 @@ export interface IncorrectKeyException
 
 export namespace IncorrectKeyException {
   export function isa(o: any): o is IncorrectKeyException {
-    return _smithy.isa(o, "IncorrectKeyException");
+    return __isa(o, "IncorrectKeyException");
   }
 }
 
@@ -2412,7 +2413,7 @@ export namespace IncorrectKeyException {
  *       (CMK).</p>
  */
 export interface IncorrectKeyMaterialException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "IncorrectKeyMaterialException";
   $fault: "client";
@@ -2421,7 +2422,7 @@ export interface IncorrectKeyMaterialException
 
 export namespace IncorrectKeyMaterialException {
   export function isa(o: any): o is IncorrectKeyMaterialException {
-    return _smithy.isa(o, "IncorrectKeyMaterialException");
+    return __isa(o, "IncorrectKeyMaterialException");
   }
 }
 
@@ -2432,7 +2433,7 @@ export namespace IncorrectKeyMaterialException {
  *         <code>customerCA.crt</code> file.</p>
  */
 export interface IncorrectTrustAnchorException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "IncorrectTrustAnchorException";
   $fault: "client";
@@ -2441,7 +2442,7 @@ export interface IncorrectTrustAnchorException
 
 export namespace IncorrectTrustAnchorException {
   export function isa(o: any): o is IncorrectTrustAnchorException {
-    return _smithy.isa(o, "IncorrectTrustAnchorException");
+    return __isa(o, "IncorrectTrustAnchorException");
   }
 }
 
@@ -2449,7 +2450,7 @@ export namespace IncorrectTrustAnchorException {
  * <p>The request was rejected because the specified alias name is not valid.</p>
  */
 export interface InvalidAliasNameException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidAliasNameException";
   $fault: "client";
@@ -2458,7 +2459,7 @@ export interface InvalidAliasNameException
 
 export namespace InvalidAliasNameException {
   export function isa(o: any): o is InvalidAliasNameException {
-    return _smithy.isa(o, "InvalidAliasNameException");
+    return __isa(o, "InvalidAliasNameException");
   }
 }
 
@@ -2467,7 +2468,7 @@ export namespace InvalidAliasNameException {
  *       valid.</p>
  */
 export interface InvalidArnException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidArnException";
   $fault: "client";
@@ -2476,7 +2477,7 @@ export interface InvalidArnException
 
 export namespace InvalidArnException {
   export function isa(o: any): o is InvalidArnException {
-    return _smithy.isa(o, "InvalidArnException");
+    return __isa(o, "InvalidArnException");
   }
 }
 
@@ -2489,7 +2490,7 @@ export namespace InvalidArnException {
  *       AWS KMS could not decrypt the encrypted (wrapped) key material. </p>
  */
 export interface InvalidCiphertextException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidCiphertextException";
   $fault: "client";
@@ -2498,7 +2499,7 @@ export interface InvalidCiphertextException
 
 export namespace InvalidCiphertextException {
   export function isa(o: any): o is InvalidCiphertextException {
-    return _smithy.isa(o, "InvalidCiphertextException");
+    return __isa(o, "InvalidCiphertextException");
   }
 }
 
@@ -2506,7 +2507,7 @@ export namespace InvalidCiphertextException {
  * <p>The request was rejected because the specified <code>GrantId</code> is not valid.</p>
  */
 export interface InvalidGrantIdException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidGrantIdException";
   $fault: "client";
@@ -2515,7 +2516,7 @@ export interface InvalidGrantIdException
 
 export namespace InvalidGrantIdException {
   export function isa(o: any): o is InvalidGrantIdException {
-    return _smithy.isa(o, "InvalidGrantIdException");
+    return __isa(o, "InvalidGrantIdException");
   }
 }
 
@@ -2523,7 +2524,7 @@ export namespace InvalidGrantIdException {
  * <p>The request was rejected because the specified grant token is not valid.</p>
  */
 export interface InvalidGrantTokenException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidGrantTokenException";
   $fault: "client";
@@ -2532,7 +2533,7 @@ export interface InvalidGrantTokenException
 
 export namespace InvalidGrantTokenException {
   export function isa(o: any): o is InvalidGrantTokenException {
-    return _smithy.isa(o, "InvalidGrantTokenException");
+    return __isa(o, "InvalidGrantTokenException");
   }
 }
 
@@ -2541,7 +2542,7 @@ export namespace InvalidGrantTokenException {
  *       with a different customer master key (CMK).</p>
  */
 export interface InvalidImportTokenException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidImportTokenException";
   $fault: "client";
@@ -2550,7 +2551,7 @@ export interface InvalidImportTokenException
 
 export namespace InvalidImportTokenException {
   export function isa(o: any): o is InvalidImportTokenException {
-    return _smithy.isa(o, "InvalidImportTokenException");
+    return __isa(o, "InvalidImportTokenException");
   }
 }
 
@@ -2574,7 +2575,7 @@ export namespace InvalidImportTokenException {
  *          <p>To find the encryption or signing algorithms supported for a particular CMK, use the <a>DescribeKey</a> operation.</p>
  */
 export interface InvalidKeyUsageException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidKeyUsageException";
   $fault: "client";
@@ -2583,7 +2584,7 @@ export interface InvalidKeyUsageException
 
 export namespace InvalidKeyUsageException {
   export function isa(o: any): o is InvalidKeyUsageException {
-    return _smithy.isa(o, "InvalidKeyUsageException");
+    return __isa(o, "InvalidKeyUsageException");
   }
 }
 
@@ -2592,7 +2593,7 @@ export namespace InvalidKeyUsageException {
  *       begin is not valid.</p>
  */
 export interface InvalidMarkerException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidMarkerException";
   $fault: "client";
@@ -2601,7 +2602,7 @@ export interface InvalidMarkerException
 
 export namespace InvalidMarkerException {
   export function isa(o: any): o is InvalidMarkerException {
-    return _smithy.isa(o, "InvalidMarkerException");
+    return __isa(o, "InvalidMarkerException");
   }
 }
 
@@ -2610,7 +2611,7 @@ export namespace InvalidMarkerException {
  *       retried.</p>
  */
 export interface KMSInternalException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "KMSInternalException";
   $fault: "server";
@@ -2619,7 +2620,7 @@ export interface KMSInternalException
 
 export namespace KMSInternalException {
   export function isa(o: any): o is KMSInternalException {
-    return _smithy.isa(o, "KMSInternalException");
+    return __isa(o, "KMSInternalException");
   }
 }
 
@@ -2629,7 +2630,7 @@ export namespace KMSInternalException {
  *       message with the specified CMK and signing algorithm.</p>
  */
 export interface KMSInvalidSignatureException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "KMSInvalidSignatureException";
   $fault: "client";
@@ -2638,7 +2639,7 @@ export interface KMSInvalidSignatureException
 
 export namespace KMSInvalidSignatureException {
   export function isa(o: any): o is KMSInvalidSignatureException {
-    return _smithy.isa(o, "KMSInvalidSignatureException");
+    return __isa(o, "KMSInvalidSignatureException");
   }
 }
 
@@ -2651,7 +2652,7 @@ export namespace KMSInvalidSignatureException {
  *             </i>.</p>
  */
 export interface KMSInvalidStateException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "KMSInvalidStateException";
   $fault: "client";
@@ -2660,7 +2661,7 @@ export interface KMSInvalidStateException
 
 export namespace KMSInvalidStateException {
   export function isa(o: any): o is KMSInvalidStateException {
-    return _smithy.isa(o, "KMSInvalidStateException");
+    return __isa(o, "KMSInvalidStateException");
   }
 }
 
@@ -2682,7 +2683,7 @@ export interface KeyListEntry {
 
 export namespace KeyListEntry {
   export function isa(o: any): o is KeyListEntry {
-    return _smithy.isa(o, "KeyListEntry");
+    return __isa(o, "KeyListEntry");
   }
 }
 
@@ -2816,7 +2817,7 @@ export interface KeyMetadata {
 
 export namespace KeyMetadata {
   export function isa(o: any): o is KeyMetadata {
-    return _smithy.isa(o, "KeyMetadata");
+    return __isa(o, "KeyMetadata");
   }
 }
 
@@ -2833,7 +2834,7 @@ export enum KeyState {
  *       request.</p>
  */
 export interface KeyUnavailableException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "KeyUnavailableException";
   $fault: "server";
@@ -2842,7 +2843,7 @@ export interface KeyUnavailableException
 
 export namespace KeyUnavailableException {
   export function isa(o: any): o is KeyUnavailableException {
-    return _smithy.isa(o, "KeyUnavailableException");
+    return __isa(o, "KeyUnavailableException");
   }
 }
 
@@ -2856,7 +2857,7 @@ export enum KeyUsageType {
  *       <i>AWS Key Management Service Developer Guide</i>.</p>
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -2865,7 +2866,7 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
@@ -2899,7 +2900,7 @@ export interface ListAliasesRequest {
 
 export namespace ListAliasesRequest {
   export function isa(o: any): o is ListAliasesRequest {
-    return _smithy.isa(o, "ListAliasesRequest");
+    return __isa(o, "ListAliasesRequest");
   }
 }
 
@@ -2927,7 +2928,7 @@ export interface ListAliasesResponse extends $MetadataBearer {
 
 export namespace ListAliasesResponse {
   export function isa(o: any): o is ListAliasesResponse {
-    return _smithy.isa(o, "ListAliasesResponse");
+    return __isa(o, "ListAliasesResponse");
   }
 }
 
@@ -2971,7 +2972,7 @@ export interface ListGrantsRequest {
 
 export namespace ListGrantsRequest {
   export function isa(o: any): o is ListGrantsRequest {
-    return _smithy.isa(o, "ListGrantsRequest");
+    return __isa(o, "ListGrantsRequest");
   }
 }
 
@@ -2999,7 +3000,7 @@ export interface ListGrantsResponse extends $MetadataBearer {
 
 export namespace ListGrantsResponse {
   export function isa(o: any): o is ListGrantsResponse {
-    return _smithy.isa(o, "ListGrantsResponse");
+    return __isa(o, "ListGrantsResponse");
   }
 }
 
@@ -3043,7 +3044,7 @@ export interface ListKeyPoliciesRequest {
 
 export namespace ListKeyPoliciesRequest {
   export function isa(o: any): o is ListKeyPoliciesRequest {
-    return _smithy.isa(o, "ListKeyPoliciesRequest");
+    return __isa(o, "ListKeyPoliciesRequest");
   }
 }
 
@@ -3071,7 +3072,7 @@ export interface ListKeyPoliciesResponse extends $MetadataBearer {
 
 export namespace ListKeyPoliciesResponse {
   export function isa(o: any): o is ListKeyPoliciesResponse {
-    return _smithy.isa(o, "ListKeyPoliciesResponse");
+    return __isa(o, "ListKeyPoliciesResponse");
   }
 }
 
@@ -3096,7 +3097,7 @@ export interface ListKeysRequest {
 
 export namespace ListKeysRequest {
   export function isa(o: any): o is ListKeysRequest {
-    return _smithy.isa(o, "ListKeysRequest");
+    return __isa(o, "ListKeysRequest");
   }
 }
 
@@ -3124,7 +3125,7 @@ export interface ListKeysResponse extends $MetadataBearer {
 
 export namespace ListKeysResponse {
   export function isa(o: any): o is ListKeysResponse {
-    return _smithy.isa(o, "ListKeysResponse");
+    return __isa(o, "ListKeysResponse");
   }
 }
 
@@ -3169,7 +3170,7 @@ export interface ListResourceTagsRequest {
 
 export namespace ListResourceTagsRequest {
   export function isa(o: any): o is ListResourceTagsRequest {
-    return _smithy.isa(o, "ListResourceTagsRequest");
+    return __isa(o, "ListResourceTagsRequest");
   }
 }
 
@@ -3198,7 +3199,7 @@ export interface ListResourceTagsResponse extends $MetadataBearer {
 
 export namespace ListResourceTagsResponse {
   export function isa(o: any): o is ListResourceTagsResponse {
-    return _smithy.isa(o, "ListResourceTagsResponse");
+    return __isa(o, "ListResourceTagsResponse");
   }
 }
 
@@ -3233,7 +3234,7 @@ export interface ListRetirableGrantsRequest {
 
 export namespace ListRetirableGrantsRequest {
   export function isa(o: any): o is ListRetirableGrantsRequest {
-    return _smithy.isa(o, "ListRetirableGrantsRequest");
+    return __isa(o, "ListRetirableGrantsRequest");
   }
 }
 
@@ -3242,7 +3243,7 @@ export namespace ListRetirableGrantsRequest {
  *       correct.</p>
  */
 export interface MalformedPolicyDocumentException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "MalformedPolicyDocumentException";
   $fault: "client";
@@ -3251,7 +3252,7 @@ export interface MalformedPolicyDocumentException
 
 export namespace MalformedPolicyDocumentException {
   export function isa(o: any): o is MalformedPolicyDocumentException {
-    return _smithy.isa(o, "MalformedPolicyDocumentException");
+    return __isa(o, "MalformedPolicyDocumentException");
   }
 }
 
@@ -3264,9 +3265,7 @@ export enum MessageType {
  * <p>The request was rejected because the specified entity or resource could not be
  *       found.</p>
  */
-export interface NotFoundException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface NotFoundException extends __SmithyException, $MetadataBearer {
   name: "NotFoundException";
   $fault: "client";
   message?: string;
@@ -3274,7 +3273,7 @@ export interface NotFoundException
 
 export namespace NotFoundException {
   export function isa(o: any): o is NotFoundException {
-    return _smithy.isa(o, "NotFoundException");
+    return __isa(o, "NotFoundException");
   }
 }
 
@@ -3348,7 +3347,7 @@ export interface PutKeyPolicyRequest {
 
 export namespace PutKeyPolicyRequest {
   export function isa(o: any): o is PutKeyPolicyRequest {
-    return _smithy.isa(o, "PutKeyPolicyRequest");
+    return __isa(o, "PutKeyPolicyRequest");
   }
 }
 
@@ -3474,7 +3473,7 @@ export interface ReEncryptRequest {
 
 export namespace ReEncryptRequest {
   export function isa(o: any): o is ReEncryptRequest {
-    return _smithy.isa(o, "ReEncryptRequest");
+    return __isa(o, "ReEncryptRequest");
   }
 }
 
@@ -3509,7 +3508,7 @@ export interface ReEncryptResponse extends $MetadataBearer {
 
 export namespace ReEncryptResponse {
   export function isa(o: any): o is ReEncryptResponse {
-    return _smithy.isa(o, "ReEncryptResponse");
+    return __isa(o, "ReEncryptResponse");
   }
 }
 
@@ -3542,7 +3541,7 @@ export interface RetireGrantRequest {
 
 export namespace RetireGrantRequest {
   export function isa(o: any): o is RetireGrantRequest {
-    return _smithy.isa(o, "RetireGrantRequest");
+    return __isa(o, "RetireGrantRequest");
   }
 }
 
@@ -3576,7 +3575,7 @@ export interface RevokeGrantRequest {
 
 export namespace RevokeGrantRequest {
   export function isa(o: any): o is RevokeGrantRequest {
-    return _smithy.isa(o, "RevokeGrantRequest");
+    return __isa(o, "RevokeGrantRequest");
   }
 }
 
@@ -3612,7 +3611,7 @@ export interface ScheduleKeyDeletionRequest {
 
 export namespace ScheduleKeyDeletionRequest {
   export function isa(o: any): o is ScheduleKeyDeletionRequest {
-    return _smithy.isa(o, "ScheduleKeyDeletionRequest");
+    return __isa(o, "ScheduleKeyDeletionRequest");
   }
 }
 
@@ -3632,7 +3631,7 @@ export interface ScheduleKeyDeletionResponse extends $MetadataBearer {
 
 export namespace ScheduleKeyDeletionResponse {
   export function isa(o: any): o is ScheduleKeyDeletionResponse {
-    return _smithy.isa(o, "ScheduleKeyDeletionResponse");
+    return __isa(o, "ScheduleKeyDeletionResponse");
   }
 }
 
@@ -3699,7 +3698,7 @@ export interface SignRequest {
 
 export namespace SignRequest {
   export function isa(o: any): o is SignRequest {
-    return _smithy.isa(o, "SignRequest");
+    return __isa(o, "SignRequest");
   }
 }
 
@@ -3724,7 +3723,7 @@ export interface SignResponse extends $MetadataBearer {
 
 export namespace SignResponse {
   export function isa(o: any): o is SignResponse {
-    return _smithy.isa(o, "SignResponse");
+    return __isa(o, "SignResponse");
   }
 }
 
@@ -3761,14 +3760,14 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
 /**
  * <p>The request was rejected because one or more tags are not valid.</p>
  */
-export interface TagException extends _smithy.SmithyException, $MetadataBearer {
+export interface TagException extends __SmithyException, $MetadataBearer {
   name: "TagException";
   $fault: "client";
   message?: string;
@@ -3776,7 +3775,7 @@ export interface TagException extends _smithy.SmithyException, $MetadataBearer {
 
 export namespace TagException {
   export function isa(o: any): o is TagException {
-    return _smithy.isa(o, "TagException");
+    return __isa(o, "TagException");
   }
 }
 
@@ -3808,7 +3807,7 @@ export interface TagResourceRequest {
 
 export namespace TagResourceRequest {
   export function isa(o: any): o is TagResourceRequest {
-    return _smithy.isa(o, "TagResourceRequest");
+    return __isa(o, "TagResourceRequest");
   }
 }
 
@@ -3817,7 +3816,7 @@ export namespace TagResourceRequest {
  *       resource is not valid for this operation.</p>
  */
 export interface UnsupportedOperationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UnsupportedOperationException";
   $fault: "client";
@@ -3826,7 +3825,7 @@ export interface UnsupportedOperationException
 
 export namespace UnsupportedOperationException {
   export function isa(o: any): o is UnsupportedOperationException {
-    return _smithy.isa(o, "UnsupportedOperationException");
+    return __isa(o, "UnsupportedOperationException");
   }
 }
 
@@ -3859,7 +3858,7 @@ export interface UntagResourceRequest {
 
 export namespace UntagResourceRequest {
   export function isa(o: any): o is UntagResourceRequest {
-    return _smithy.isa(o, "UntagResourceRequest");
+    return __isa(o, "UntagResourceRequest");
   }
 }
 
@@ -3899,7 +3898,7 @@ export interface UpdateAliasRequest {
 
 export namespace UpdateAliasRequest {
   export function isa(o: any): o is UpdateAliasRequest {
-    return _smithy.isa(o, "UpdateAliasRequest");
+    return __isa(o, "UpdateAliasRequest");
   }
 }
 
@@ -3939,7 +3938,7 @@ export interface UpdateCustomKeyStoreRequest {
 
 export namespace UpdateCustomKeyStoreRequest {
   export function isa(o: any): o is UpdateCustomKeyStoreRequest {
-    return _smithy.isa(o, "UpdateCustomKeyStoreRequest");
+    return __isa(o, "UpdateCustomKeyStoreRequest");
   }
 }
 
@@ -3949,7 +3948,7 @@ export interface UpdateCustomKeyStoreResponse extends $MetadataBearer {
 
 export namespace UpdateCustomKeyStoreResponse {
   export function isa(o: any): o is UpdateCustomKeyStoreResponse {
-    return _smithy.isa(o, "UpdateCustomKeyStoreResponse");
+    return __isa(o, "UpdateCustomKeyStoreResponse");
   }
 }
 
@@ -3981,7 +3980,7 @@ export interface UpdateKeyDescriptionRequest {
 
 export namespace UpdateKeyDescriptionRequest {
   export function isa(o: any): o is UpdateKeyDescriptionRequest {
-    return _smithy.isa(o, "UpdateKeyDescriptionRequest");
+    return __isa(o, "UpdateKeyDescriptionRequest");
   }
 }
 
@@ -4059,7 +4058,7 @@ export interface VerifyRequest {
 
 export namespace VerifyRequest {
   export function isa(o: any): o is VerifyRequest {
-    return _smithy.isa(o, "VerifyRequest");
+    return __isa(o, "VerifyRequest");
   }
 }
 
@@ -4087,7 +4086,7 @@ export interface VerifyResponse extends $MetadataBearer {
 
 export namespace VerifyResponse {
   export function isa(o: any): o is VerifyResponse {
-    return _smithy.isa(o, "VerifyResponse");
+    return __isa(o, "VerifyResponse");
   }
 }
 

--- a/clients/client-kms/protocols/Aws_json1_1.ts
+++ b/clients/client-kms/protocols/Aws_json1_1.ts
@@ -1101,6 +1101,7 @@ export async function deserializeAws_json1_1CreateAliasCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1CreateAliasCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: CreateAliasCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1638,6 +1639,7 @@ export async function deserializeAws_json1_1DeleteAliasCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1DeleteAliasCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteAliasCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1793,6 +1795,7 @@ export async function deserializeAws_json1_1DeleteImportedKeyMaterialCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteImportedKeyMaterialCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2025,6 +2028,7 @@ export async function deserializeAws_json1_1DisableKeyCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1DisableKeyCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DisableKeyCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2107,6 +2111,7 @@ export async function deserializeAws_json1_1DisableKeyRotationCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DisableKeyRotationCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2276,6 +2281,7 @@ export async function deserializeAws_json1_1EnableKeyCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1EnableKeyCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: EnableKeyCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2362,6 +2368,7 @@ export async function deserializeAws_json1_1EnableKeyRotationCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1EnableKeyRotationCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: EnableKeyRotationCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -4078,6 +4085,7 @@ export async function deserializeAws_json1_1PutKeyPolicyCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1PutKeyPolicyCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: PutKeyPolicyCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -4297,6 +4305,7 @@ export async function deserializeAws_json1_1RetireGrantCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1RetireGrantCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: RetireGrantCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -4390,6 +4399,7 @@ export async function deserializeAws_json1_1RevokeGrantCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1RevokeGrantCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: RevokeGrantCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -4668,6 +4678,7 @@ export async function deserializeAws_json1_1TagResourceCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1TagResourceCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: TagResourceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -4754,6 +4765,7 @@ export async function deserializeAws_json1_1UntagResourceCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1UntagResourceCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: UntagResourceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -4833,6 +4845,7 @@ export async function deserializeAws_json1_1UpdateAliasCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1UpdateAliasCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: UpdateAliasCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -5016,6 +5029,7 @@ export async function deserializeAws_json1_1UpdateKeyDescriptionCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: UpdateKeyDescriptionCommandOutput = {
     $metadata: deserializeMetadata(output)
   };

--- a/clients/client-lakeformation/models/index.ts
+++ b/clients/client-lakeformation/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export interface BatchGrantPermissionsRequest {
@@ -16,7 +19,7 @@ export interface BatchGrantPermissionsRequest {
 
 export namespace BatchGrantPermissionsRequest {
   export function isa(o: any): o is BatchGrantPermissionsRequest {
-    return _smithy.isa(o, "BatchGrantPermissionsRequest");
+    return __isa(o, "BatchGrantPermissionsRequest");
   }
 }
 
@@ -30,7 +33,7 @@ export interface BatchGrantPermissionsResponse extends $MetadataBearer {
 
 export namespace BatchGrantPermissionsResponse {
   export function isa(o: any): o is BatchGrantPermissionsResponse {
-    return _smithy.isa(o, "BatchGrantPermissionsResponse");
+    return __isa(o, "BatchGrantPermissionsResponse");
   }
 }
 
@@ -52,7 +55,7 @@ export interface BatchPermissionsFailureEntry {
 
 export namespace BatchPermissionsFailureEntry {
   export function isa(o: any): o is BatchPermissionsFailureEntry {
-    return _smithy.isa(o, "BatchPermissionsFailureEntry");
+    return __isa(o, "BatchPermissionsFailureEntry");
   }
 }
 
@@ -89,7 +92,7 @@ export interface BatchPermissionsRequestEntry {
 
 export namespace BatchPermissionsRequestEntry {
   export function isa(o: any): o is BatchPermissionsRequestEntry {
-    return _smithy.isa(o, "BatchPermissionsRequestEntry");
+    return __isa(o, "BatchPermissionsRequestEntry");
   }
 }
 
@@ -108,7 +111,7 @@ export interface BatchRevokePermissionsRequest {
 
 export namespace BatchRevokePermissionsRequest {
   export function isa(o: any): o is BatchRevokePermissionsRequest {
-    return _smithy.isa(o, "BatchRevokePermissionsRequest");
+    return __isa(o, "BatchRevokePermissionsRequest");
   }
 }
 
@@ -122,7 +125,7 @@ export interface BatchRevokePermissionsResponse extends $MetadataBearer {
 
 export namespace BatchRevokePermissionsResponse {
   export function isa(o: any): o is BatchRevokePermissionsResponse {
-    return _smithy.isa(o, "BatchRevokePermissionsResponse");
+    return __isa(o, "BatchRevokePermissionsResponse");
   }
 }
 
@@ -135,7 +138,7 @@ export interface CatalogResource {
 
 export namespace CatalogResource {
   export function isa(o: any): o is CatalogResource {
-    return _smithy.isa(o, "CatalogResource");
+    return __isa(o, "CatalogResource");
   }
 }
 
@@ -152,7 +155,7 @@ export interface ColumnWildcard {
 
 export namespace ColumnWildcard {
   export function isa(o: any): o is ColumnWildcard {
-    return _smithy.isa(o, "ColumnWildcard");
+    return __isa(o, "ColumnWildcard");
   }
 }
 
@@ -169,7 +172,7 @@ export interface DataLakePrincipal {
 
 export namespace DataLakePrincipal {
   export function isa(o: any): o is DataLakePrincipal {
-    return _smithy.isa(o, "DataLakePrincipal");
+    return __isa(o, "DataLakePrincipal");
   }
 }
 
@@ -203,7 +206,7 @@ export interface DataLakeSettings {
 
 export namespace DataLakeSettings {
   export function isa(o: any): o is DataLakeSettings {
-    return _smithy.isa(o, "DataLakeSettings");
+    return __isa(o, "DataLakeSettings");
   }
 }
 
@@ -220,7 +223,7 @@ export interface DataLocationResource {
 
 export namespace DataLocationResource {
   export function isa(o: any): o is DataLocationResource {
-    return _smithy.isa(o, "DataLocationResource");
+    return __isa(o, "DataLocationResource");
   }
 }
 
@@ -237,7 +240,7 @@ export interface DatabaseResource {
 
 export namespace DatabaseResource {
   export function isa(o: any): o is DatabaseResource {
-    return _smithy.isa(o, "DatabaseResource");
+    return __isa(o, "DatabaseResource");
   }
 }
 
@@ -251,7 +254,7 @@ export interface DeregisterResourceRequest {
 
 export namespace DeregisterResourceRequest {
   export function isa(o: any): o is DeregisterResourceRequest {
-    return _smithy.isa(o, "DeregisterResourceRequest");
+    return __isa(o, "DeregisterResourceRequest");
   }
 }
 
@@ -261,7 +264,7 @@ export interface DeregisterResourceResponse extends $MetadataBearer {
 
 export namespace DeregisterResourceResponse {
   export function isa(o: any): o is DeregisterResourceResponse {
-    return _smithy.isa(o, "DeregisterResourceResponse");
+    return __isa(o, "DeregisterResourceResponse");
   }
 }
 
@@ -275,7 +278,7 @@ export interface DescribeResourceRequest {
 
 export namespace DescribeResourceRequest {
   export function isa(o: any): o is DescribeResourceRequest {
-    return _smithy.isa(o, "DescribeResourceRequest");
+    return __isa(o, "DescribeResourceRequest");
   }
 }
 
@@ -289,7 +292,7 @@ export interface DescribeResourceResponse extends $MetadataBearer {
 
 export namespace DescribeResourceResponse {
   export function isa(o: any): o is DescribeResourceResponse {
-    return _smithy.isa(o, "DescribeResourceResponse");
+    return __isa(o, "DescribeResourceResponse");
   }
 }
 
@@ -303,7 +306,7 @@ export interface GetDataLakeSettingsRequest {
 
 export namespace GetDataLakeSettingsRequest {
   export function isa(o: any): o is GetDataLakeSettingsRequest {
-    return _smithy.isa(o, "GetDataLakeSettingsRequest");
+    return __isa(o, "GetDataLakeSettingsRequest");
   }
 }
 
@@ -317,7 +320,7 @@ export interface GetDataLakeSettingsResponse extends $MetadataBearer {
 
 export namespace GetDataLakeSettingsResponse {
   export function isa(o: any): o is GetDataLakeSettingsResponse {
-    return _smithy.isa(o, "GetDataLakeSettingsResponse");
+    return __isa(o, "GetDataLakeSettingsResponse");
   }
 }
 
@@ -346,7 +349,7 @@ export interface GetEffectivePermissionsForPathRequest {
 
 export namespace GetEffectivePermissionsForPathRequest {
   export function isa(o: any): o is GetEffectivePermissionsForPathRequest {
-    return _smithy.isa(o, "GetEffectivePermissionsForPathRequest");
+    return __isa(o, "GetEffectivePermissionsForPathRequest");
   }
 }
 
@@ -366,7 +369,7 @@ export interface GetEffectivePermissionsForPathResponse
 
 export namespace GetEffectivePermissionsForPathResponse {
   export function isa(o: any): o is GetEffectivePermissionsForPathResponse {
-    return _smithy.isa(o, "GetEffectivePermissionsForPathResponse");
+    return __isa(o, "GetEffectivePermissionsForPathResponse");
   }
 }
 
@@ -401,7 +404,7 @@ export interface GrantPermissionsRequest {
 
 export namespace GrantPermissionsRequest {
   export function isa(o: any): o is GrantPermissionsRequest {
-    return _smithy.isa(o, "GrantPermissionsRequest");
+    return __isa(o, "GrantPermissionsRequest");
   }
 }
 
@@ -411,7 +414,7 @@ export interface GrantPermissionsResponse extends $MetadataBearer {
 
 export namespace GrantPermissionsResponse {
   export function isa(o: any): o is GrantPermissionsResponse {
-    return _smithy.isa(o, "GrantPermissionsResponse");
+    return __isa(o, "GrantPermissionsResponse");
   }
 }
 
@@ -451,7 +454,7 @@ export interface ListPermissionsRequest {
 
 export namespace ListPermissionsRequest {
   export function isa(o: any): o is ListPermissionsRequest {
-    return _smithy.isa(o, "ListPermissionsRequest");
+    return __isa(o, "ListPermissionsRequest");
   }
 }
 
@@ -470,7 +473,7 @@ export interface ListPermissionsResponse extends $MetadataBearer {
 
 export namespace ListPermissionsResponse {
   export function isa(o: any): o is ListPermissionsResponse {
-    return _smithy.isa(o, "ListPermissionsResponse");
+    return __isa(o, "ListPermissionsResponse");
   }
 }
 
@@ -494,7 +497,7 @@ export interface ListResourcesRequest {
 
 export namespace ListResourcesRequest {
   export function isa(o: any): o is ListResourcesRequest {
-    return _smithy.isa(o, "ListResourcesRequest");
+    return __isa(o, "ListResourcesRequest");
   }
 }
 
@@ -513,7 +516,7 @@ export interface ListResourcesResponse extends $MetadataBearer {
 
 export namespace ListResourcesResponse {
   export function isa(o: any): o is ListResourcesResponse {
-    return _smithy.isa(o, "ListResourcesResponse");
+    return __isa(o, "ListResourcesResponse");
   }
 }
 
@@ -547,7 +550,7 @@ export interface PrincipalPermissions {
 
 export namespace PrincipalPermissions {
   export function isa(o: any): o is PrincipalPermissions {
-    return _smithy.isa(o, "PrincipalPermissions");
+    return __isa(o, "PrincipalPermissions");
   }
 }
 
@@ -579,7 +582,7 @@ export interface PrincipalResourcePermissions {
 
 export namespace PrincipalResourcePermissions {
   export function isa(o: any): o is PrincipalResourcePermissions {
-    return _smithy.isa(o, "PrincipalResourcePermissions");
+    return __isa(o, "PrincipalResourcePermissions");
   }
 }
 
@@ -598,7 +601,7 @@ export interface PutDataLakeSettingsRequest {
 
 export namespace PutDataLakeSettingsRequest {
   export function isa(o: any): o is PutDataLakeSettingsRequest {
-    return _smithy.isa(o, "PutDataLakeSettingsRequest");
+    return __isa(o, "PutDataLakeSettingsRequest");
   }
 }
 
@@ -608,7 +611,7 @@ export interface PutDataLakeSettingsResponse extends $MetadataBearer {
 
 export namespace PutDataLakeSettingsResponse {
   export function isa(o: any): o is PutDataLakeSettingsResponse {
-    return _smithy.isa(o, "PutDataLakeSettingsResponse");
+    return __isa(o, "PutDataLakeSettingsResponse");
   }
 }
 
@@ -632,7 +635,7 @@ export interface RegisterResourceRequest {
 
 export namespace RegisterResourceRequest {
   export function isa(o: any): o is RegisterResourceRequest {
-    return _smithy.isa(o, "RegisterResourceRequest");
+    return __isa(o, "RegisterResourceRequest");
   }
 }
 
@@ -642,7 +645,7 @@ export interface RegisterResourceResponse extends $MetadataBearer {
 
 export namespace RegisterResourceResponse {
   export function isa(o: any): o is RegisterResourceResponse {
-    return _smithy.isa(o, "RegisterResourceResponse");
+    return __isa(o, "RegisterResourceResponse");
   }
 }
 
@@ -679,7 +682,7 @@ export interface Resource {
 
 export namespace Resource {
   export function isa(o: any): o is Resource {
-    return _smithy.isa(o, "Resource");
+    return __isa(o, "Resource");
   }
 }
 
@@ -714,7 +717,7 @@ export interface RevokePermissionsRequest {
 
 export namespace RevokePermissionsRequest {
   export function isa(o: any): o is RevokePermissionsRequest {
-    return _smithy.isa(o, "RevokePermissionsRequest");
+    return __isa(o, "RevokePermissionsRequest");
   }
 }
 
@@ -724,7 +727,7 @@ export interface RevokePermissionsResponse extends $MetadataBearer {
 
 export namespace RevokePermissionsResponse {
   export function isa(o: any): o is RevokePermissionsResponse {
-    return _smithy.isa(o, "RevokePermissionsResponse");
+    return __isa(o, "RevokePermissionsResponse");
   }
 }
 
@@ -746,7 +749,7 @@ export interface TableResource {
 
 export namespace TableResource {
   export function isa(o: any): o is TableResource {
-    return _smithy.isa(o, "TableResource");
+    return __isa(o, "TableResource");
   }
 }
 
@@ -779,7 +782,7 @@ export interface TableWithColumnsResource {
 
 export namespace TableWithColumnsResource {
   export function isa(o: any): o is TableWithColumnsResource {
-    return _smithy.isa(o, "TableWithColumnsResource");
+    return __isa(o, "TableWithColumnsResource");
   }
 }
 
@@ -798,7 +801,7 @@ export interface UpdateResourceRequest {
 
 export namespace UpdateResourceRequest {
   export function isa(o: any): o is UpdateResourceRequest {
-    return _smithy.isa(o, "UpdateResourceRequest");
+    return __isa(o, "UpdateResourceRequest");
   }
 }
 
@@ -808,7 +811,7 @@ export interface UpdateResourceResponse extends $MetadataBearer {
 
 export namespace UpdateResourceResponse {
   export function isa(o: any): o is UpdateResourceResponse {
-    return _smithy.isa(o, "UpdateResourceResponse");
+    return __isa(o, "UpdateResourceResponse");
   }
 }
 
@@ -816,7 +819,7 @@ export namespace UpdateResourceResponse {
  * <p>A resource to be created or added already exists.</p>
  */
 export interface AlreadyExistsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AlreadyExistsException";
   $fault: "client";
@@ -828,7 +831,7 @@ export interface AlreadyExistsException
 
 export namespace AlreadyExistsException {
   export function isa(o: any): o is AlreadyExistsException {
-    return _smithy.isa(o, "AlreadyExistsException");
+    return __isa(o, "AlreadyExistsException");
   }
 }
 
@@ -836,7 +839,7 @@ export namespace AlreadyExistsException {
  * <p>Two processes are trying to modify a resource simultaneously.</p>
  */
 export interface ConcurrentModificationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ConcurrentModificationException";
   $fault: "client";
@@ -848,7 +851,7 @@ export interface ConcurrentModificationException
 
 export namespace ConcurrentModificationException {
   export function isa(o: any): o is ConcurrentModificationException {
-    return _smithy.isa(o, "ConcurrentModificationException");
+    return __isa(o, "ConcurrentModificationException");
   }
 }
 
@@ -856,7 +859,7 @@ export namespace ConcurrentModificationException {
  * <p>A specified entity does not exist</p>
  */
 export interface EntityNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "EntityNotFoundException";
   $fault: "client";
@@ -868,7 +871,7 @@ export interface EntityNotFoundException
 
 export namespace EntityNotFoundException {
   export function isa(o: any): o is EntityNotFoundException {
-    return _smithy.isa(o, "EntityNotFoundException");
+    return __isa(o, "EntityNotFoundException");
   }
 }
 
@@ -890,7 +893,7 @@ export interface ErrorDetail {
 
 export namespace ErrorDetail {
   export function isa(o: any): o is ErrorDetail {
-    return _smithy.isa(o, "ErrorDetail");
+    return __isa(o, "ErrorDetail");
   }
 }
 
@@ -898,7 +901,7 @@ export namespace ErrorDetail {
  * <p>An internal service error occurred.</p>
  */
 export interface InternalServiceException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalServiceException";
   $fault: "server";
@@ -910,7 +913,7 @@ export interface InternalServiceException
 
 export namespace InternalServiceException {
   export function isa(o: any): o is InternalServiceException {
-    return _smithy.isa(o, "InternalServiceException");
+    return __isa(o, "InternalServiceException");
   }
 }
 
@@ -918,7 +921,7 @@ export namespace InternalServiceException {
  * <p>The input provided was not valid.</p>
  */
 export interface InvalidInputException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidInputException";
   $fault: "client";
@@ -930,7 +933,7 @@ export interface InvalidInputException
 
 export namespace InvalidInputException {
   export function isa(o: any): o is InvalidInputException {
-    return _smithy.isa(o, "InvalidInputException");
+    return __isa(o, "InvalidInputException");
   }
 }
 
@@ -938,7 +941,7 @@ export namespace InvalidInputException {
  * <p>The operation timed out.</p>
  */
 export interface OperationTimeoutException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "OperationTimeoutException";
   $fault: "client";
@@ -950,7 +953,7 @@ export interface OperationTimeoutException
 
 export namespace OperationTimeoutException {
   export function isa(o: any): o is OperationTimeoutException {
-    return _smithy.isa(o, "OperationTimeoutException");
+    return __isa(o, "OperationTimeoutException");
   }
 }
 
@@ -997,7 +1000,7 @@ export interface FilterCondition {
 
 export namespace FilterCondition {
   export function isa(o: any): o is FilterCondition {
-    return _smithy.isa(o, "FilterCondition");
+    return __isa(o, "FilterCondition");
   }
 }
 
@@ -1024,6 +1027,6 @@ export interface ResourceInfo {
 
 export namespace ResourceInfo {
   export function isa(o: any): o is ResourceInfo {
-    return _smithy.isa(o, "ResourceInfo");
+    return __isa(o, "ResourceInfo");
   }
 }

--- a/clients/client-lambda/models/index.ts
+++ b/clients/client-lambda/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -36,7 +39,7 @@ export interface AccountLimit {
 
 export namespace AccountLimit {
   export function isa(o: any): o is AccountLimit {
-    return _smithy.isa(o, "AccountLimit");
+    return __isa(o, "AccountLimit");
   }
 }
 
@@ -58,7 +61,7 @@ export interface AccountUsage {
 
 export namespace AccountUsage {
   export function isa(o: any): o is AccountUsage {
-    return _smithy.isa(o, "AccountUsage");
+    return __isa(o, "AccountUsage");
   }
 }
 
@@ -104,7 +107,7 @@ export interface AddLayerVersionPermissionRequest {
 
 export namespace AddLayerVersionPermissionRequest {
   export function isa(o: any): o is AddLayerVersionPermissionRequest {
-    return _smithy.isa(o, "AddLayerVersionPermissionRequest");
+    return __isa(o, "AddLayerVersionPermissionRequest");
   }
 }
 
@@ -123,7 +126,7 @@ export interface AddLayerVersionPermissionResponse extends $MetadataBearer {
 
 export namespace AddLayerVersionPermissionResponse {
   export function isa(o: any): o is AddLayerVersionPermissionResponse {
-    return _smithy.isa(o, "AddLayerVersionPermissionResponse");
+    return __isa(o, "AddLayerVersionPermissionResponse");
   }
 }
 
@@ -203,7 +206,7 @@ export interface AddPermissionRequest {
 
 export namespace AddPermissionRequest {
   export function isa(o: any): o is AddPermissionRequest {
-    return _smithy.isa(o, "AddPermissionRequest");
+    return __isa(o, "AddPermissionRequest");
   }
 }
 
@@ -217,7 +220,7 @@ export interface AddPermissionResponse extends $MetadataBearer {
 
 export namespace AddPermissionResponse {
   export function isa(o: any): o is AddPermissionResponse {
-    return _smithy.isa(o, "AddPermissionResponse");
+    return __isa(o, "AddPermissionResponse");
   }
 }
 
@@ -260,7 +263,7 @@ export interface AliasConfiguration extends $MetadataBearer {
 
 export namespace AliasConfiguration {
   export function isa(o: any): o is AliasConfiguration {
-    return _smithy.isa(o, "AliasConfiguration");
+    return __isa(o, "AliasConfiguration");
   }
 }
 
@@ -277,7 +280,7 @@ export interface AliasRoutingConfiguration {
 
 export namespace AliasRoutingConfiguration {
   export function isa(o: any): o is AliasRoutingConfiguration {
-    return _smithy.isa(o, "AliasRoutingConfiguration");
+    return __isa(o, "AliasRoutingConfiguration");
   }
 }
 
@@ -286,7 +289,7 @@ export namespace AliasRoutingConfiguration {
  *          </p>
  */
 export interface CodeStorageExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CodeStorageExceededException";
   $fault: "client";
@@ -300,7 +303,7 @@ export interface CodeStorageExceededException
 
 export namespace CodeStorageExceededException {
   export function isa(o: any): o is CodeStorageExceededException {
-    return _smithy.isa(o, "CodeStorageExceededException");
+    return __isa(o, "CodeStorageExceededException");
   }
 }
 
@@ -314,7 +317,7 @@ export interface Concurrency extends $MetadataBearer {
 
 export namespace Concurrency {
   export function isa(o: any): o is Concurrency {
-    return _smithy.isa(o, "Concurrency");
+    return __isa(o, "Concurrency");
   }
 }
 
@@ -368,7 +371,7 @@ export interface CreateAliasRequest {
 
 export namespace CreateAliasRequest {
   export function isa(o: any): o is CreateAliasRequest {
-    return _smithy.isa(o, "CreateAliasRequest");
+    return __isa(o, "CreateAliasRequest");
   }
 }
 
@@ -490,7 +493,7 @@ export interface CreateEventSourceMappingRequest {
 
 export namespace CreateEventSourceMappingRequest {
   export function isa(o: any): o is CreateEventSourceMappingRequest {
-    return _smithy.isa(o, "CreateEventSourceMappingRequest");
+    return __isa(o, "CreateEventSourceMappingRequest");
   }
 }
 
@@ -609,7 +612,7 @@ export interface CreateFunctionRequest {
 
 export namespace CreateFunctionRequest {
   export function isa(o: any): o is CreateFunctionRequest {
-    return _smithy.isa(o, "CreateFunctionRequest");
+    return __isa(o, "CreateFunctionRequest");
   }
 }
 
@@ -627,7 +630,7 @@ export interface DeadLetterConfig {
 
 export namespace DeadLetterConfig {
   export function isa(o: any): o is DeadLetterConfig {
-    return _smithy.isa(o, "DeadLetterConfig");
+    return __isa(o, "DeadLetterConfig");
   }
 }
 
@@ -665,7 +668,7 @@ export interface DeleteAliasRequest {
 
 export namespace DeleteAliasRequest {
   export function isa(o: any): o is DeleteAliasRequest {
-    return _smithy.isa(o, "DeleteAliasRequest");
+    return __isa(o, "DeleteAliasRequest");
   }
 }
 
@@ -679,7 +682,7 @@ export interface DeleteEventSourceMappingRequest {
 
 export namespace DeleteEventSourceMappingRequest {
   export function isa(o: any): o is DeleteEventSourceMappingRequest {
-    return _smithy.isa(o, "DeleteEventSourceMappingRequest");
+    return __isa(o, "DeleteEventSourceMappingRequest");
   }
 }
 
@@ -712,7 +715,7 @@ export interface DeleteFunctionConcurrencyRequest {
 
 export namespace DeleteFunctionConcurrencyRequest {
   export function isa(o: any): o is DeleteFunctionConcurrencyRequest {
-    return _smithy.isa(o, "DeleteFunctionConcurrencyRequest");
+    return __isa(o, "DeleteFunctionConcurrencyRequest");
   }
 }
 
@@ -750,7 +753,7 @@ export interface DeleteFunctionEventInvokeConfigRequest {
 
 export namespace DeleteFunctionEventInvokeConfigRequest {
   export function isa(o: any): o is DeleteFunctionEventInvokeConfigRequest {
-    return _smithy.isa(o, "DeleteFunctionEventInvokeConfigRequest");
+    return __isa(o, "DeleteFunctionEventInvokeConfigRequest");
   }
 }
 
@@ -788,7 +791,7 @@ export interface DeleteFunctionRequest {
 
 export namespace DeleteFunctionRequest {
   export function isa(o: any): o is DeleteFunctionRequest {
-    return _smithy.isa(o, "DeleteFunctionRequest");
+    return __isa(o, "DeleteFunctionRequest");
   }
 }
 
@@ -807,7 +810,7 @@ export interface DeleteLayerVersionRequest {
 
 export namespace DeleteLayerVersionRequest {
   export function isa(o: any): o is DeleteLayerVersionRequest {
-    return _smithy.isa(o, "DeleteLayerVersionRequest");
+    return __isa(o, "DeleteLayerVersionRequest");
   }
 }
 
@@ -845,7 +848,7 @@ export interface DeleteProvisionedConcurrencyConfigRequest {
 
 export namespace DeleteProvisionedConcurrencyConfigRequest {
   export function isa(o: any): o is DeleteProvisionedConcurrencyConfigRequest {
-    return _smithy.isa(o, "DeleteProvisionedConcurrencyConfigRequest");
+    return __isa(o, "DeleteProvisionedConcurrencyConfigRequest");
   }
 }
 
@@ -867,7 +870,7 @@ export interface DestinationConfig {
 
 export namespace DestinationConfig {
   export function isa(o: any): o is DestinationConfig {
-    return _smithy.isa(o, "DestinationConfig");
+    return __isa(o, "DestinationConfig");
   }
 }
 
@@ -875,7 +878,7 @@ export namespace DestinationConfig {
  * <p>Need additional permissions to configure VPC settings.</p>
  */
 export interface EC2AccessDeniedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "EC2AccessDeniedException";
   $fault: "server";
@@ -885,7 +888,7 @@ export interface EC2AccessDeniedException
 
 export namespace EC2AccessDeniedException {
   export function isa(o: any): o is EC2AccessDeniedException {
-    return _smithy.isa(o, "EC2AccessDeniedException");
+    return __isa(o, "EC2AccessDeniedException");
   }
 }
 
@@ -894,7 +897,7 @@ export namespace EC2AccessDeniedException {
  *       for the Lambda function.</p>
  */
 export interface EC2ThrottledException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "EC2ThrottledException";
   $fault: "server";
@@ -904,7 +907,7 @@ export interface EC2ThrottledException
 
 export namespace EC2ThrottledException {
   export function isa(o: any): o is EC2ThrottledException {
-    return _smithy.isa(o, "EC2ThrottledException");
+    return __isa(o, "EC2ThrottledException");
   }
 }
 
@@ -912,7 +915,7 @@ export namespace EC2ThrottledException {
  * <p>AWS Lambda received an unexpected EC2 client exception while setting up for the Lambda function.</p>
  */
 export interface EC2UnexpectedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "EC2UnexpectedException";
   $fault: "server";
@@ -923,7 +926,7 @@ export interface EC2UnexpectedException
 
 export namespace EC2UnexpectedException {
   export function isa(o: any): o is EC2UnexpectedException {
-    return _smithy.isa(o, "EC2UnexpectedException");
+    return __isa(o, "EC2UnexpectedException");
   }
 }
 
@@ -932,7 +935,7 @@ export namespace EC2UnexpectedException {
  *       function configuration, because the limit for network interfaces has been reached.</p>
  */
 export interface ENILimitReachedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ENILimitReachedException";
   $fault: "server";
@@ -942,7 +945,7 @@ export interface ENILimitReachedException
 
 export namespace ENILimitReachedException {
   export function isa(o: any): o is ENILimitReachedException {
-    return _smithy.isa(o, "ENILimitReachedException");
+    return __isa(o, "ENILimitReachedException");
   }
 }
 
@@ -959,7 +962,7 @@ export interface Environment {
 
 export namespace Environment {
   export function isa(o: any): o is Environment {
-    return _smithy.isa(o, "Environment");
+    return __isa(o, "Environment");
   }
 }
 
@@ -981,7 +984,7 @@ export interface EnvironmentError {
 
 export namespace EnvironmentError {
   export function isa(o: any): o is EnvironmentError {
-    return _smithy.isa(o, "EnvironmentError");
+    return __isa(o, "EnvironmentError");
   }
 }
 
@@ -1004,7 +1007,7 @@ export interface EnvironmentResponse {
 
 export namespace EnvironmentResponse {
   export function isa(o: any): o is EnvironmentResponse {
-    return _smithy.isa(o, "EnvironmentResponse");
+    return __isa(o, "EnvironmentResponse");
   }
 }
 
@@ -1090,7 +1093,7 @@ export interface EventSourceMappingConfiguration extends $MetadataBearer {
 
 export namespace EventSourceMappingConfiguration {
   export function isa(o: any): o is EventSourceMappingConfiguration {
-    return _smithy.isa(o, "EventSourceMappingConfiguration");
+    return __isa(o, "EventSourceMappingConfiguration");
   }
 }
 
@@ -1130,7 +1133,7 @@ export interface FunctionCode {
 
 export namespace FunctionCode {
   export function isa(o: any): o is FunctionCode {
-    return _smithy.isa(o, "FunctionCode");
+    return __isa(o, "FunctionCode");
   }
 }
 
@@ -1152,7 +1155,7 @@ export interface FunctionCodeLocation {
 
 export namespace FunctionCodeLocation {
   export function isa(o: any): o is FunctionCodeLocation {
-    return _smithy.isa(o, "FunctionCodeLocation");
+    return __isa(o, "FunctionCodeLocation");
   }
 }
 
@@ -1299,7 +1302,7 @@ export interface FunctionConfiguration extends $MetadataBearer {
 
 export namespace FunctionConfiguration {
   export function isa(o: any): o is FunctionConfiguration {
-    return _smithy.isa(o, "FunctionConfiguration");
+    return __isa(o, "FunctionConfiguration");
   }
 }
 
@@ -1354,7 +1357,7 @@ export interface FunctionEventInvokeConfig extends $MetadataBearer {
 
 export namespace FunctionEventInvokeConfig {
   export function isa(o: any): o is FunctionEventInvokeConfig {
-    return _smithy.isa(o, "FunctionEventInvokeConfig");
+    return __isa(o, "FunctionEventInvokeConfig");
   }
 }
 
@@ -1368,7 +1371,7 @@ export interface GetAccountSettingsRequest {
 
 export namespace GetAccountSettingsRequest {
   export function isa(o: any): o is GetAccountSettingsRequest {
-    return _smithy.isa(o, "GetAccountSettingsRequest");
+    return __isa(o, "GetAccountSettingsRequest");
   }
 }
 
@@ -1387,7 +1390,7 @@ export interface GetAccountSettingsResponse extends $MetadataBearer {
 
 export namespace GetAccountSettingsResponse {
   export function isa(o: any): o is GetAccountSettingsResponse {
-    return _smithy.isa(o, "GetAccountSettingsResponse");
+    return __isa(o, "GetAccountSettingsResponse");
   }
 }
 
@@ -1425,7 +1428,7 @@ export interface GetAliasRequest {
 
 export namespace GetAliasRequest {
   export function isa(o: any): o is GetAliasRequest {
-    return _smithy.isa(o, "GetAliasRequest");
+    return __isa(o, "GetAliasRequest");
   }
 }
 
@@ -1439,7 +1442,7 @@ export interface GetEventSourceMappingRequest {
 
 export namespace GetEventSourceMappingRequest {
   export function isa(o: any): o is GetEventSourceMappingRequest {
-    return _smithy.isa(o, "GetEventSourceMappingRequest");
+    return __isa(o, "GetEventSourceMappingRequest");
   }
 }
 
@@ -1472,7 +1475,7 @@ export interface GetFunctionConcurrencyRequest {
 
 export namespace GetFunctionConcurrencyRequest {
   export function isa(o: any): o is GetFunctionConcurrencyRequest {
-    return _smithy.isa(o, "GetFunctionConcurrencyRequest");
+    return __isa(o, "GetFunctionConcurrencyRequest");
   }
 }
 
@@ -1486,7 +1489,7 @@ export interface GetFunctionConcurrencyResponse extends $MetadataBearer {
 
 export namespace GetFunctionConcurrencyResponse {
   export function isa(o: any): o is GetFunctionConcurrencyResponse {
-    return _smithy.isa(o, "GetFunctionConcurrencyResponse");
+    return __isa(o, "GetFunctionConcurrencyResponse");
   }
 }
 
@@ -1524,7 +1527,7 @@ export interface GetFunctionConfigurationRequest {
 
 export namespace GetFunctionConfigurationRequest {
   export function isa(o: any): o is GetFunctionConfigurationRequest {
-    return _smithy.isa(o, "GetFunctionConfigurationRequest");
+    return __isa(o, "GetFunctionConfigurationRequest");
   }
 }
 
@@ -1562,7 +1565,7 @@ export interface GetFunctionEventInvokeConfigRequest {
 
 export namespace GetFunctionEventInvokeConfigRequest {
   export function isa(o: any): o is GetFunctionEventInvokeConfigRequest {
-    return _smithy.isa(o, "GetFunctionEventInvokeConfigRequest");
+    return __isa(o, "GetFunctionEventInvokeConfigRequest");
   }
 }
 
@@ -1600,7 +1603,7 @@ export interface GetFunctionRequest {
 
 export namespace GetFunctionRequest {
   export function isa(o: any): o is GetFunctionRequest {
-    return _smithy.isa(o, "GetFunctionRequest");
+    return __isa(o, "GetFunctionRequest");
   }
 }
 
@@ -1630,7 +1633,7 @@ export interface GetFunctionResponse extends $MetadataBearer {
 
 export namespace GetFunctionResponse {
   export function isa(o: any): o is GetFunctionResponse {
-    return _smithy.isa(o, "GetFunctionResponse");
+    return __isa(o, "GetFunctionResponse");
   }
 }
 
@@ -1644,7 +1647,7 @@ export interface GetLayerVersionByArnRequest {
 
 export namespace GetLayerVersionByArnRequest {
   export function isa(o: any): o is GetLayerVersionByArnRequest {
-    return _smithy.isa(o, "GetLayerVersionByArnRequest");
+    return __isa(o, "GetLayerVersionByArnRequest");
   }
 }
 
@@ -1663,7 +1666,7 @@ export interface GetLayerVersionPolicyRequest {
 
 export namespace GetLayerVersionPolicyRequest {
   export function isa(o: any): o is GetLayerVersionPolicyRequest {
-    return _smithy.isa(o, "GetLayerVersionPolicyRequest");
+    return __isa(o, "GetLayerVersionPolicyRequest");
   }
 }
 
@@ -1682,7 +1685,7 @@ export interface GetLayerVersionPolicyResponse extends $MetadataBearer {
 
 export namespace GetLayerVersionPolicyResponse {
   export function isa(o: any): o is GetLayerVersionPolicyResponse {
-    return _smithy.isa(o, "GetLayerVersionPolicyResponse");
+    return __isa(o, "GetLayerVersionPolicyResponse");
   }
 }
 
@@ -1701,7 +1704,7 @@ export interface GetLayerVersionRequest {
 
 export namespace GetLayerVersionRequest {
   export function isa(o: any): o is GetLayerVersionRequest {
-    return _smithy.isa(o, "GetLayerVersionRequest");
+    return __isa(o, "GetLayerVersionRequest");
   }
 }
 
@@ -1750,7 +1753,7 @@ export interface GetLayerVersionResponse extends $MetadataBearer {
 
 export namespace GetLayerVersionResponse {
   export function isa(o: any): o is GetLayerVersionResponse {
-    return _smithy.isa(o, "GetLayerVersionResponse");
+    return __isa(o, "GetLayerVersionResponse");
   }
 }
 
@@ -1788,7 +1791,7 @@ export interface GetPolicyRequest {
 
 export namespace GetPolicyRequest {
   export function isa(o: any): o is GetPolicyRequest {
-    return _smithy.isa(o, "GetPolicyRequest");
+    return __isa(o, "GetPolicyRequest");
   }
 }
 
@@ -1807,7 +1810,7 @@ export interface GetPolicyResponse extends $MetadataBearer {
 
 export namespace GetPolicyResponse {
   export function isa(o: any): o is GetPolicyResponse {
-    return _smithy.isa(o, "GetPolicyResponse");
+    return __isa(o, "GetPolicyResponse");
   }
 }
 
@@ -1845,7 +1848,7 @@ export interface GetProvisionedConcurrencyConfigRequest {
 
 export namespace GetProvisionedConcurrencyConfigRequest {
   export function isa(o: any): o is GetProvisionedConcurrencyConfigRequest {
-    return _smithy.isa(o, "GetProvisionedConcurrencyConfigRequest");
+    return __isa(o, "GetProvisionedConcurrencyConfigRequest");
   }
 }
 
@@ -1885,7 +1888,7 @@ export interface GetProvisionedConcurrencyConfigResponse
 
 export namespace GetProvisionedConcurrencyConfigResponse {
   export function isa(o: any): o is GetProvisionedConcurrencyConfigResponse {
-    return _smithy.isa(o, "GetProvisionedConcurrencyConfigResponse");
+    return __isa(o, "GetProvisionedConcurrencyConfigResponse");
   }
 }
 
@@ -1893,7 +1896,7 @@ export namespace GetProvisionedConcurrencyConfigResponse {
  * <p>One of the parameters in the request is invalid.</p>
  */
 export interface InvalidParameterValueException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidParameterValueException";
   $fault: "client";
@@ -1910,7 +1913,7 @@ export interface InvalidParameterValueException
 
 export namespace InvalidParameterValueException {
   export function isa(o: any): o is InvalidParameterValueException {
-    return _smithy.isa(o, "InvalidParameterValueException");
+    return __isa(o, "InvalidParameterValueException");
   }
 }
 
@@ -1918,7 +1921,7 @@ export namespace InvalidParameterValueException {
  * <p>The request body could not be parsed as JSON.</p>
  */
 export interface InvalidRequestContentException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidRequestContentException";
   $fault: "client";
@@ -1935,7 +1938,7 @@ export interface InvalidRequestContentException
 
 export namespace InvalidRequestContentException {
   export function isa(o: any): o is InvalidRequestContentException {
-    return _smithy.isa(o, "InvalidRequestContentException");
+    return __isa(o, "InvalidRequestContentException");
   }
 }
 
@@ -1943,7 +1946,7 @@ export namespace InvalidRequestContentException {
  * <p>The runtime or runtime version specified is not supported.</p>
  */
 export interface InvalidRuntimeException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidRuntimeException";
   $fault: "server";
@@ -1953,7 +1956,7 @@ export interface InvalidRuntimeException
 
 export namespace InvalidRuntimeException {
   export function isa(o: any): o is InvalidRuntimeException {
-    return _smithy.isa(o, "InvalidRuntimeException");
+    return __isa(o, "InvalidRuntimeException");
   }
 }
 
@@ -1961,7 +1964,7 @@ export namespace InvalidRuntimeException {
  * <p>The Security Group ID provided in the Lambda function VPC configuration is invalid.</p>
  */
 export interface InvalidSecurityGroupIDException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidSecurityGroupIDException";
   $fault: "server";
@@ -1971,7 +1974,7 @@ export interface InvalidSecurityGroupIDException
 
 export namespace InvalidSecurityGroupIDException {
   export function isa(o: any): o is InvalidSecurityGroupIDException {
-    return _smithy.isa(o, "InvalidSecurityGroupIDException");
+    return __isa(o, "InvalidSecurityGroupIDException");
   }
 }
 
@@ -1979,7 +1982,7 @@ export namespace InvalidSecurityGroupIDException {
  * <p>The Subnet ID provided in the Lambda function VPC configuration is invalid.</p>
  */
 export interface InvalidSubnetIDException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidSubnetIDException";
   $fault: "server";
@@ -1989,7 +1992,7 @@ export interface InvalidSubnetIDException
 
 export namespace InvalidSubnetIDException {
   export function isa(o: any): o is InvalidSubnetIDException {
-    return _smithy.isa(o, "InvalidSubnetIDException");
+    return __isa(o, "InvalidSubnetIDException");
   }
 }
 
@@ -1997,7 +2000,7 @@ export namespace InvalidSubnetIDException {
  * <p>AWS Lambda could not unzip the deployment package.</p>
  */
 export interface InvalidZipFileException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidZipFileException";
   $fault: "server";
@@ -2007,7 +2010,7 @@ export interface InvalidZipFileException
 
 export namespace InvalidZipFileException {
   export function isa(o: any): o is InvalidZipFileException {
-    return _smithy.isa(o, "InvalidZipFileException");
+    return __isa(o, "InvalidZipFileException");
   }
 }
 
@@ -2084,7 +2087,7 @@ export interface InvocationRequest {
 
 export namespace InvocationRequest {
   export function isa(o: any): o is InvocationRequest {
-    return _smithy.isa(o, "InvocationRequest");
+    return __isa(o, "InvocationRequest");
   }
 }
 
@@ -2115,7 +2118,7 @@ export interface InvocationResponse extends $MetadataBearer {
 
 export namespace InvocationResponse {
   export function isa(o: any): o is InvocationResponse {
-    return _smithy.isa(o, "InvocationResponse");
+    return __isa(o, "InvocationResponse");
   }
 }
 
@@ -2159,7 +2162,7 @@ export interface InvokeAsyncRequest {
 
 export namespace InvokeAsyncRequest {
   export function isa(o: any): o is InvokeAsyncRequest {
-    return _smithy.isa(o, "InvokeAsyncRequest");
+    return __isa(o, "InvokeAsyncRequest");
   }
 }
 
@@ -2172,7 +2175,7 @@ export interface InvokeAsyncResponse extends $MetadataBearer {
 
 export namespace InvokeAsyncResponse {
   export function isa(o: any): o is InvokeAsyncResponse {
-    return _smithy.isa(o, "InvokeAsyncResponse");
+    return __isa(o, "InvokeAsyncResponse");
   }
 }
 
@@ -2181,7 +2184,7 @@ export namespace InvokeAsyncResponse {
  *       function's KMS permissions.</p>
  */
 export interface KMSAccessDeniedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "KMSAccessDeniedException";
   $fault: "server";
@@ -2191,7 +2194,7 @@ export interface KMSAccessDeniedException
 
 export namespace KMSAccessDeniedException {
   export function isa(o: any): o is KMSAccessDeniedException {
-    return _smithy.isa(o, "KMSAccessDeniedException");
+    return __isa(o, "KMSAccessDeniedException");
   }
 }
 
@@ -2200,7 +2203,7 @@ export namespace KMSAccessDeniedException {
  *       function's KMS key settings.</p>
  */
 export interface KMSDisabledException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "KMSDisabledException";
   $fault: "server";
@@ -2210,7 +2213,7 @@ export interface KMSDisabledException
 
 export namespace KMSDisabledException {
   export function isa(o: any): o is KMSDisabledException {
-    return _smithy.isa(o, "KMSDisabledException");
+    return __isa(o, "KMSDisabledException");
   }
 }
 
@@ -2219,7 +2222,7 @@ export namespace KMSDisabledException {
  *       Decrypt. Check the function's KMS key settings.</p>
  */
 export interface KMSInvalidStateException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "KMSInvalidStateException";
   $fault: "server";
@@ -2229,7 +2232,7 @@ export interface KMSInvalidStateException
 
 export namespace KMSInvalidStateException {
   export function isa(o: any): o is KMSInvalidStateException {
-    return _smithy.isa(o, "KMSInvalidStateException");
+    return __isa(o, "KMSInvalidStateException");
   }
 }
 
@@ -2238,7 +2241,7 @@ export namespace KMSInvalidStateException {
  *       KMS key settings. </p>
  */
 export interface KMSNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "KMSNotFoundException";
   $fault: "server";
@@ -2248,7 +2251,7 @@ export interface KMSNotFoundException
 
 export namespace KMSNotFoundException {
   export function isa(o: any): o is KMSNotFoundException {
-    return _smithy.isa(o, "KMSNotFoundException");
+    return __isa(o, "KMSNotFoundException");
   }
 }
 
@@ -2287,7 +2290,7 @@ export interface Layer {
 
 export namespace Layer {
   export function isa(o: any): o is Layer {
-    return _smithy.isa(o, "Layer");
+    return __isa(o, "Layer");
   }
 }
 
@@ -2322,7 +2325,7 @@ export interface LayerVersionContentInput {
 
 export namespace LayerVersionContentInput {
   export function isa(o: any): o is LayerVersionContentInput {
-    return _smithy.isa(o, "LayerVersionContentInput");
+    return __isa(o, "LayerVersionContentInput");
   }
 }
 
@@ -2350,7 +2353,7 @@ export interface LayerVersionContentOutput {
 
 export namespace LayerVersionContentOutput {
   export function isa(o: any): o is LayerVersionContentOutput {
-    return _smithy.isa(o, "LayerVersionContentOutput");
+    return __isa(o, "LayerVersionContentOutput");
   }
 }
 
@@ -2393,7 +2396,7 @@ export interface LayerVersionsListItem {
 
 export namespace LayerVersionsListItem {
   export function isa(o: any): o is LayerVersionsListItem {
-    return _smithy.isa(o, "LayerVersionsListItem");
+    return __isa(o, "LayerVersionsListItem");
   }
 }
 
@@ -2421,7 +2424,7 @@ export interface LayersListItem {
 
 export namespace LayersListItem {
   export function isa(o: any): o is LayersListItem {
-    return _smithy.isa(o, "LayersListItem");
+    return __isa(o, "LayersListItem");
   }
 }
 
@@ -2469,7 +2472,7 @@ export interface ListAliasesRequest {
 
 export namespace ListAliasesRequest {
   export function isa(o: any): o is ListAliasesRequest {
-    return _smithy.isa(o, "ListAliasesRequest");
+    return __isa(o, "ListAliasesRequest");
   }
 }
 
@@ -2488,7 +2491,7 @@ export interface ListAliasesResponse extends $MetadataBearer {
 
 export namespace ListAliasesResponse {
   export function isa(o: any): o is ListAliasesResponse {
-    return _smithy.isa(o, "ListAliasesResponse");
+    return __isa(o, "ListAliasesResponse");
   }
 }
 
@@ -2554,7 +2557,7 @@ export interface ListEventSourceMappingsRequest {
 
 export namespace ListEventSourceMappingsRequest {
   export function isa(o: any): o is ListEventSourceMappingsRequest {
-    return _smithy.isa(o, "ListEventSourceMappingsRequest");
+    return __isa(o, "ListEventSourceMappingsRequest");
   }
 }
 
@@ -2573,7 +2576,7 @@ export interface ListEventSourceMappingsResponse extends $MetadataBearer {
 
 export namespace ListEventSourceMappingsResponse {
   export function isa(o: any): o is ListEventSourceMappingsResponse {
-    return _smithy.isa(o, "ListEventSourceMappingsResponse");
+    return __isa(o, "ListEventSourceMappingsResponse");
   }
 }
 
@@ -2616,7 +2619,7 @@ export interface ListFunctionEventInvokeConfigsRequest {
 
 export namespace ListFunctionEventInvokeConfigsRequest {
   export function isa(o: any): o is ListFunctionEventInvokeConfigsRequest {
-    return _smithy.isa(o, "ListFunctionEventInvokeConfigsRequest");
+    return __isa(o, "ListFunctionEventInvokeConfigsRequest");
   }
 }
 
@@ -2636,7 +2639,7 @@ export interface ListFunctionEventInvokeConfigsResponse
 
 export namespace ListFunctionEventInvokeConfigsResponse {
   export function isa(o: any): o is ListFunctionEventInvokeConfigsResponse {
-    return _smithy.isa(o, "ListFunctionEventInvokeConfigsResponse");
+    return __isa(o, "ListFunctionEventInvokeConfigsResponse");
   }
 }
 
@@ -2667,7 +2670,7 @@ export interface ListFunctionsRequest {
 
 export namespace ListFunctionsRequest {
   export function isa(o: any): o is ListFunctionsRequest {
-    return _smithy.isa(o, "ListFunctionsRequest");
+    return __isa(o, "ListFunctionsRequest");
   }
 }
 
@@ -2689,7 +2692,7 @@ export interface ListFunctionsResponse extends $MetadataBearer {
 
 export namespace ListFunctionsResponse {
   export function isa(o: any): o is ListFunctionsResponse {
-    return _smithy.isa(o, "ListFunctionsResponse");
+    return __isa(o, "ListFunctionsResponse");
   }
 }
 
@@ -2718,7 +2721,7 @@ export interface ListLayerVersionsRequest {
 
 export namespace ListLayerVersionsRequest {
   export function isa(o: any): o is ListLayerVersionsRequest {
-    return _smithy.isa(o, "ListLayerVersionsRequest");
+    return __isa(o, "ListLayerVersionsRequest");
   }
 }
 
@@ -2737,7 +2740,7 @@ export interface ListLayerVersionsResponse extends $MetadataBearer {
 
 export namespace ListLayerVersionsResponse {
   export function isa(o: any): o is ListLayerVersionsResponse {
-    return _smithy.isa(o, "ListLayerVersionsResponse");
+    return __isa(o, "ListLayerVersionsResponse");
   }
 }
 
@@ -2761,7 +2764,7 @@ export interface ListLayersRequest {
 
 export namespace ListLayersRequest {
   export function isa(o: any): o is ListLayersRequest {
-    return _smithy.isa(o, "ListLayersRequest");
+    return __isa(o, "ListLayersRequest");
   }
 }
 
@@ -2780,7 +2783,7 @@ export interface ListLayersResponse extends $MetadataBearer {
 
 export namespace ListLayersResponse {
   export function isa(o: any): o is ListLayersResponse {
-    return _smithy.isa(o, "ListLayersResponse");
+    return __isa(o, "ListLayersResponse");
   }
 }
 
@@ -2823,7 +2826,7 @@ export interface ListProvisionedConcurrencyConfigsRequest {
 
 export namespace ListProvisionedConcurrencyConfigsRequest {
   export function isa(o: any): o is ListProvisionedConcurrencyConfigsRequest {
-    return _smithy.isa(o, "ListProvisionedConcurrencyConfigsRequest");
+    return __isa(o, "ListProvisionedConcurrencyConfigsRequest");
   }
 }
 
@@ -2843,7 +2846,7 @@ export interface ListProvisionedConcurrencyConfigsResponse
 
 export namespace ListProvisionedConcurrencyConfigsResponse {
   export function isa(o: any): o is ListProvisionedConcurrencyConfigsResponse {
-    return _smithy.isa(o, "ListProvisionedConcurrencyConfigsResponse");
+    return __isa(o, "ListProvisionedConcurrencyConfigsResponse");
   }
 }
 
@@ -2857,7 +2860,7 @@ export interface ListTagsRequest {
 
 export namespace ListTagsRequest {
   export function isa(o: any): o is ListTagsRequest {
-    return _smithy.isa(o, "ListTagsRequest");
+    return __isa(o, "ListTagsRequest");
   }
 }
 
@@ -2871,7 +2874,7 @@ export interface ListTagsResponse extends $MetadataBearer {
 
 export namespace ListTagsResponse {
   export function isa(o: any): o is ListTagsResponse {
-    return _smithy.isa(o, "ListTagsResponse");
+    return __isa(o, "ListTagsResponse");
   }
 }
 
@@ -2914,7 +2917,7 @@ export interface ListVersionsByFunctionRequest {
 
 export namespace ListVersionsByFunctionRequest {
   export function isa(o: any): o is ListVersionsByFunctionRequest {
-    return _smithy.isa(o, "ListVersionsByFunctionRequest");
+    return __isa(o, "ListVersionsByFunctionRequest");
   }
 }
 
@@ -2933,7 +2936,7 @@ export interface ListVersionsByFunctionResponse extends $MetadataBearer {
 
 export namespace ListVersionsByFunctionResponse {
   export function isa(o: any): o is ListVersionsByFunctionResponse {
-    return _smithy.isa(o, "ListVersionsByFunctionResponse");
+    return __isa(o, "ListVersionsByFunctionResponse");
   }
 }
 
@@ -2955,7 +2958,7 @@ export interface OnFailure {
 
 export namespace OnFailure {
   export function isa(o: any): o is OnFailure {
-    return _smithy.isa(o, "OnFailure");
+    return __isa(o, "OnFailure");
   }
 }
 
@@ -2972,7 +2975,7 @@ export interface OnSuccess {
 
 export namespace OnSuccess {
   export function isa(o: any): o is OnSuccess {
-    return _smithy.isa(o, "OnSuccess");
+    return __isa(o, "OnSuccess");
   }
 }
 
@@ -2981,7 +2984,7 @@ export namespace OnSuccess {
  *          </p>
  */
 export interface PolicyLengthExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "PolicyLengthExceededException";
   $fault: "client";
@@ -2991,7 +2994,7 @@ export interface PolicyLengthExceededException
 
 export namespace PolicyLengthExceededException {
   export function isa(o: any): o is PolicyLengthExceededException {
-    return _smithy.isa(o, "PolicyLengthExceededException");
+    return __isa(o, "PolicyLengthExceededException");
   }
 }
 
@@ -3001,7 +3004,7 @@ export namespace PolicyLengthExceededException {
  *       resource.</p>
  */
 export interface PreconditionFailedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "PreconditionFailedException";
   $fault: "client";
@@ -3018,7 +3021,7 @@ export interface PreconditionFailedException
 
 export namespace PreconditionFailedException {
   export function isa(o: any): o is PreconditionFailedException {
-    return _smithy.isa(o, "PreconditionFailedException");
+    return __isa(o, "PreconditionFailedException");
   }
 }
 
@@ -3065,7 +3068,7 @@ export interface ProvisionedConcurrencyConfigListItem {
 
 export namespace ProvisionedConcurrencyConfigListItem {
   export function isa(o: any): o is ProvisionedConcurrencyConfigListItem {
-    return _smithy.isa(o, "ProvisionedConcurrencyConfigListItem");
+    return __isa(o, "ProvisionedConcurrencyConfigListItem");
   }
 }
 
@@ -3073,7 +3076,7 @@ export namespace ProvisionedConcurrencyConfigListItem {
  * <p>The specified configuration does not exist.</p>
  */
 export interface ProvisionedConcurrencyConfigNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ProvisionedConcurrencyConfigNotFoundException";
   $fault: "client";
@@ -3085,7 +3088,7 @@ export namespace ProvisionedConcurrencyConfigNotFoundException {
   export function isa(
     o: any
   ): o is ProvisionedConcurrencyConfigNotFoundException {
-    return _smithy.isa(o, "ProvisionedConcurrencyConfigNotFoundException");
+    return __isa(o, "ProvisionedConcurrencyConfigNotFoundException");
   }
 }
 
@@ -3139,7 +3142,7 @@ export interface PublishLayerVersionRequest {
 
 export namespace PublishLayerVersionRequest {
   export function isa(o: any): o is PublishLayerVersionRequest {
-    return _smithy.isa(o, "PublishLayerVersionRequest");
+    return __isa(o, "PublishLayerVersionRequest");
   }
 }
 
@@ -3188,7 +3191,7 @@ export interface PublishLayerVersionResponse extends $MetadataBearer {
 
 export namespace PublishLayerVersionResponse {
   export function isa(o: any): o is PublishLayerVersionResponse {
-    return _smithy.isa(o, "PublishLayerVersionResponse");
+    return __isa(o, "PublishLayerVersionResponse");
   }
 }
 
@@ -3239,7 +3242,7 @@ export interface PublishVersionRequest {
 
 export namespace PublishVersionRequest {
   export function isa(o: any): o is PublishVersionRequest {
-    return _smithy.isa(o, "PublishVersionRequest");
+    return __isa(o, "PublishVersionRequest");
   }
 }
 
@@ -3277,7 +3280,7 @@ export interface PutFunctionConcurrencyRequest {
 
 export namespace PutFunctionConcurrencyRequest {
   export function isa(o: any): o is PutFunctionConcurrencyRequest {
-    return _smithy.isa(o, "PutFunctionConcurrencyRequest");
+    return __isa(o, "PutFunctionConcurrencyRequest");
   }
 }
 
@@ -3351,7 +3354,7 @@ export interface PutFunctionEventInvokeConfigRequest {
 
 export namespace PutFunctionEventInvokeConfigRequest {
   export function isa(o: any): o is PutFunctionEventInvokeConfigRequest {
-    return _smithy.isa(o, "PutFunctionEventInvokeConfigRequest");
+    return __isa(o, "PutFunctionEventInvokeConfigRequest");
   }
 }
 
@@ -3394,7 +3397,7 @@ export interface PutProvisionedConcurrencyConfigRequest {
 
 export namespace PutProvisionedConcurrencyConfigRequest {
   export function isa(o: any): o is PutProvisionedConcurrencyConfigRequest {
-    return _smithy.isa(o, "PutProvisionedConcurrencyConfigRequest");
+    return __isa(o, "PutProvisionedConcurrencyConfigRequest");
   }
 }
 
@@ -3434,7 +3437,7 @@ export interface PutProvisionedConcurrencyConfigResponse
 
 export namespace PutProvisionedConcurrencyConfigResponse {
   export function isa(o: any): o is PutProvisionedConcurrencyConfigResponse {
-    return _smithy.isa(o, "PutProvisionedConcurrencyConfigResponse");
+    return __isa(o, "PutProvisionedConcurrencyConfigResponse");
   }
 }
 
@@ -3464,7 +3467,7 @@ export interface RemoveLayerVersionPermissionRequest {
 
 export namespace RemoveLayerVersionPermissionRequest {
   export function isa(o: any): o is RemoveLayerVersionPermissionRequest {
-    return _smithy.isa(o, "RemoveLayerVersionPermissionRequest");
+    return __isa(o, "RemoveLayerVersionPermissionRequest");
   }
 }
 
@@ -3513,7 +3516,7 @@ export interface RemovePermissionRequest {
 
 export namespace RemovePermissionRequest {
   export function isa(o: any): o is RemovePermissionRequest {
-    return _smithy.isa(o, "RemovePermissionRequest");
+    return __isa(o, "RemovePermissionRequest");
   }
 }
 
@@ -3522,7 +3525,7 @@ export namespace RemovePermissionRequest {
  *         <a href="https://docs.aws.amazon.com/lambda/latest/dg/limits.html">Limits</a>. </p>
  */
 export interface RequestTooLargeException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "RequestTooLargeException";
   $fault: "client";
@@ -3532,7 +3535,7 @@ export interface RequestTooLargeException
 
 export namespace RequestTooLargeException {
   export function isa(o: any): o is RequestTooLargeException {
-    return _smithy.isa(o, "RequestTooLargeException");
+    return __isa(o, "RequestTooLargeException");
   }
 }
 
@@ -3540,7 +3543,7 @@ export namespace RequestTooLargeException {
  * <p>The resource already exists, or another operation is in progress.</p>
  */
 export interface ResourceConflictException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceConflictException";
   $fault: "client";
@@ -3557,7 +3560,7 @@ export interface ResourceConflictException
 
 export namespace ResourceConflictException {
   export function isa(o: any): o is ResourceConflictException {
-    return _smithy.isa(o, "ResourceConflictException");
+    return __isa(o, "ResourceConflictException");
   }
 }
 
@@ -3566,7 +3569,7 @@ export namespace ResourceConflictException {
  *       Mapping in CREATING, or tried to delete a EventSource mapping currently in the UPDATING state. </p>
  */
 export interface ResourceInUseException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceInUseException";
   $fault: "client";
@@ -3576,7 +3579,7 @@ export interface ResourceInUseException
 
 export namespace ResourceInUseException {
   export function isa(o: any): o is ResourceInUseException {
-    return _smithy.isa(o, "ResourceInUseException");
+    return __isa(o, "ResourceInUseException");
   }
 }
 
@@ -3584,7 +3587,7 @@ export namespace ResourceInUseException {
  * <p>The resource specified in the request does not exist.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -3594,7 +3597,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -3603,7 +3606,7 @@ export namespace ResourceNotFoundException {
  *       reestablish and try again.</p>
  */
 export interface ResourceNotReadyException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotReadyException";
   $fault: "server";
@@ -3620,7 +3623,7 @@ export interface ResourceNotReadyException
 
 export namespace ResourceNotReadyException {
   export function isa(o: any): o is ResourceNotReadyException {
-    return _smithy.isa(o, "ResourceNotReadyException");
+    return __isa(o, "ResourceNotReadyException");
   }
 }
 
@@ -3649,9 +3652,7 @@ export enum Runtime {
 /**
  * <p>The AWS Lambda service encountered an internal error.</p>
  */
-export interface ServiceException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface ServiceException extends __SmithyException, $MetadataBearer {
   name: "ServiceException";
   $fault: "server";
   Message?: string;
@@ -3660,7 +3661,7 @@ export interface ServiceException
 
 export namespace ServiceException {
   export function isa(o: any): o is ServiceException {
-    return _smithy.isa(o, "ServiceException");
+    return __isa(o, "ServiceException");
   }
 }
 
@@ -3689,7 +3690,7 @@ export enum StateReasonCode {
  *       has no available IP addresses.</p>
  */
 export interface SubnetIPAddressLimitReachedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "SubnetIPAddressLimitReachedException";
   $fault: "server";
@@ -3699,7 +3700,7 @@ export interface SubnetIPAddressLimitReachedException
 
 export namespace SubnetIPAddressLimitReachedException {
   export function isa(o: any): o is SubnetIPAddressLimitReachedException {
-    return _smithy.isa(o, "SubnetIPAddressLimitReachedException");
+    return __isa(o, "SubnetIPAddressLimitReachedException");
   }
 }
 
@@ -3718,7 +3719,7 @@ export interface TagResourceRequest {
 
 export namespace TagResourceRequest {
   export function isa(o: any): o is TagResourceRequest {
-    return _smithy.isa(o, "TagResourceRequest");
+    return __isa(o, "TagResourceRequest");
   }
 }
 
@@ -3734,7 +3735,7 @@ export enum ThrottleReason {
  * <p>The request throughput limit was exceeded.</p>
  */
 export interface TooManyRequestsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyRequestsException";
   $fault: "client";
@@ -3749,7 +3750,7 @@ export interface TooManyRequestsException
 
 export namespace TooManyRequestsException {
   export function isa(o: any): o is TooManyRequestsException {
-    return _smithy.isa(o, "TooManyRequestsException");
+    return __isa(o, "TooManyRequestsException");
   }
 }
 
@@ -3767,7 +3768,7 @@ export interface TracingConfig {
 
 export namespace TracingConfig {
   export function isa(o: any): o is TracingConfig {
-    return _smithy.isa(o, "TracingConfig");
+    return __isa(o, "TracingConfig");
   }
 }
 
@@ -3784,7 +3785,7 @@ export interface TracingConfigResponse {
 
 export namespace TracingConfigResponse {
   export function isa(o: any): o is TracingConfigResponse {
-    return _smithy.isa(o, "TracingConfigResponse");
+    return __isa(o, "TracingConfigResponse");
   }
 }
 
@@ -3797,7 +3798,7 @@ export enum TracingMode {
  * <p>The content type of the <code>Invoke</code> request body is not JSON.</p>
  */
 export interface UnsupportedMediaTypeException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UnsupportedMediaTypeException";
   $fault: "client";
@@ -3807,7 +3808,7 @@ export interface UnsupportedMediaTypeException
 
 export namespace UnsupportedMediaTypeException {
   export function isa(o: any): o is UnsupportedMediaTypeException {
-    return _smithy.isa(o, "UnsupportedMediaTypeException");
+    return __isa(o, "UnsupportedMediaTypeException");
   }
 }
 
@@ -3826,7 +3827,7 @@ export interface UntagResourceRequest {
 
 export namespace UntagResourceRequest {
   export function isa(o: any): o is UntagResourceRequest {
-    return _smithy.isa(o, "UntagResourceRequest");
+    return __isa(o, "UntagResourceRequest");
   }
 }
 
@@ -3886,7 +3887,7 @@ export interface UpdateAliasRequest {
 
 export namespace UpdateAliasRequest {
   export function isa(o: any): o is UpdateAliasRequest {
-    return _smithy.isa(o, "UpdateAliasRequest");
+    return __isa(o, "UpdateAliasRequest");
   }
 }
 
@@ -3982,7 +3983,7 @@ export interface UpdateEventSourceMappingRequest {
 
 export namespace UpdateEventSourceMappingRequest {
   export function isa(o: any): o is UpdateEventSourceMappingRequest {
-    return _smithy.isa(o, "UpdateEventSourceMappingRequest");
+    return __isa(o, "UpdateEventSourceMappingRequest");
   }
 }
 
@@ -4054,7 +4055,7 @@ export interface UpdateFunctionCodeRequest {
 
 export namespace UpdateFunctionCodeRequest {
   export function isa(o: any): o is UpdateFunctionCodeRequest {
-    return _smithy.isa(o, "UpdateFunctionCodeRequest");
+    return __isa(o, "UpdateFunctionCodeRequest");
   }
 }
 
@@ -4163,7 +4164,7 @@ export interface UpdateFunctionConfigurationRequest {
 
 export namespace UpdateFunctionConfigurationRequest {
   export function isa(o: any): o is UpdateFunctionConfigurationRequest {
-    return _smithy.isa(o, "UpdateFunctionConfigurationRequest");
+    return __isa(o, "UpdateFunctionConfigurationRequest");
   }
 }
 
@@ -4237,7 +4238,7 @@ export interface UpdateFunctionEventInvokeConfigRequest {
 
 export namespace UpdateFunctionEventInvokeConfigRequest {
   export function isa(o: any): o is UpdateFunctionEventInvokeConfigRequest {
-    return _smithy.isa(o, "UpdateFunctionEventInvokeConfigRequest");
+    return __isa(o, "UpdateFunctionEventInvokeConfigRequest");
   }
 }
 
@@ -4259,7 +4260,7 @@ export interface VpcConfig {
 
 export namespace VpcConfig {
   export function isa(o: any): o is VpcConfig {
-    return _smithy.isa(o, "VpcConfig");
+    return __isa(o, "VpcConfig");
   }
 }
 
@@ -4286,6 +4287,6 @@ export interface VpcConfigResponse {
 
 export namespace VpcConfigResponse {
   export function isa(o: any): o is VpcConfigResponse {
-    return _smithy.isa(o, "VpcConfigResponse");
+    return __isa(o, "VpcConfigResponse");
   }
 }

--- a/clients/client-lambda/protocols/Aws_restJson1_1.ts
+++ b/clients/client-lambda/protocols/Aws_restJson1_1.ts
@@ -255,7 +255,10 @@ import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  extendedEncodeURIComponent as __extendedEncodeURIComponent
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -272,13 +275,13 @@ export async function serializeAws_restJson1_1AddLayerVersionPermissionCommand(
   let resolvedPath =
     "/2018-10-31/layers/{LayerName}/versions/{VersionNumber}/policy";
   if (input.LayerName !== undefined) {
-    const labelValue: string = input.LayerName.toString();
+    const labelValue: string = input.LayerName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: LayerName.");
     }
     resolvedPath = resolvedPath.replace(
       "{LayerName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: LayerName.");
@@ -292,14 +295,16 @@ export async function serializeAws_restJson1_1AddLayerVersionPermissionCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{VersionNumber}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: VersionNumber.");
   }
   const query: any = {};
   if (input.RevisionId !== undefined) {
-    query["RevisionId"] = input.RevisionId.toString();
+    query[
+      __extendedEncodeURIComponent("RevisionId")
+    ] = __extendedEncodeURIComponent(input.RevisionId);
   }
   let body: any;
   const bodyParams: any = {};
@@ -335,7 +340,7 @@ export async function serializeAws_restJson1_1AddPermissionCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/2015-03-31/functions/{FunctionName}/policy";
   if (input.FunctionName !== undefined) {
-    const labelValue: string = input.FunctionName.toString();
+    const labelValue: string = input.FunctionName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: FunctionName."
@@ -343,14 +348,16 @@ export async function serializeAws_restJson1_1AddPermissionCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{FunctionName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: FunctionName.");
   }
   const query: any = {};
   if (input.Qualifier !== undefined) {
-    query["Qualifier"] = input.Qualifier.toString();
+    query[
+      __extendedEncodeURIComponent("Qualifier")
+    ] = __extendedEncodeURIComponent(input.Qualifier);
   }
   let body: any;
   const bodyParams: any = {};
@@ -395,7 +402,7 @@ export async function serializeAws_restJson1_1CreateAliasCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/2015-03-31/functions/{FunctionName}/aliases";
   if (input.FunctionName !== undefined) {
-    const labelValue: string = input.FunctionName.toString();
+    const labelValue: string = input.FunctionName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: FunctionName."
@@ -403,7 +410,7 @@ export async function serializeAws_restJson1_1CreateAliasCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{FunctionName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: FunctionName.");
@@ -594,7 +601,7 @@ export async function serializeAws_restJson1_1DeleteAliasCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/2015-03-31/functions/{FunctionName}/aliases/{Name}";
   if (input.FunctionName !== undefined) {
-    const labelValue: string = input.FunctionName.toString();
+    const labelValue: string = input.FunctionName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: FunctionName."
@@ -602,19 +609,19 @@ export async function serializeAws_restJson1_1DeleteAliasCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{FunctionName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: FunctionName.");
   }
   if (input.Name !== undefined) {
-    const labelValue: string = input.Name.toString();
+    const labelValue: string = input.Name;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Name.");
     }
     resolvedPath = resolvedPath.replace(
       "{Name}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Name.");
@@ -636,13 +643,13 @@ export async function serializeAws_restJson1_1DeleteEventSourceMappingCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/2015-03-31/event-source-mappings/{UUID}";
   if (input.UUID !== undefined) {
-    const labelValue: string = input.UUID.toString();
+    const labelValue: string = input.UUID;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: UUID.");
     }
     resolvedPath = resolvedPath.replace(
       "{UUID}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: UUID.");
@@ -664,7 +671,7 @@ export async function serializeAws_restJson1_1DeleteFunctionCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/2015-03-31/functions/{FunctionName}";
   if (input.FunctionName !== undefined) {
-    const labelValue: string = input.FunctionName.toString();
+    const labelValue: string = input.FunctionName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: FunctionName."
@@ -672,14 +679,16 @@ export async function serializeAws_restJson1_1DeleteFunctionCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{FunctionName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: FunctionName.");
   }
   const query: any = {};
   if (input.Qualifier !== undefined) {
-    query["Qualifier"] = input.Qualifier.toString();
+    query[
+      __extendedEncodeURIComponent("Qualifier")
+    ] = __extendedEncodeURIComponent(input.Qualifier);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -699,7 +708,7 @@ export async function serializeAws_restJson1_1DeleteFunctionConcurrencyCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/2017-10-31/functions/{FunctionName}/concurrency";
   if (input.FunctionName !== undefined) {
-    const labelValue: string = input.FunctionName.toString();
+    const labelValue: string = input.FunctionName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: FunctionName."
@@ -707,7 +716,7 @@ export async function serializeAws_restJson1_1DeleteFunctionConcurrencyCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{FunctionName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: FunctionName.");
@@ -729,7 +738,7 @@ export async function serializeAws_restJson1_1DeleteFunctionEventInvokeConfigCom
   headers["Content-Type"] = "";
   let resolvedPath = "/2019-09-25/functions/{FunctionName}/event-invoke-config";
   if (input.FunctionName !== undefined) {
-    const labelValue: string = input.FunctionName.toString();
+    const labelValue: string = input.FunctionName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: FunctionName."
@@ -737,14 +746,16 @@ export async function serializeAws_restJson1_1DeleteFunctionEventInvokeConfigCom
     }
     resolvedPath = resolvedPath.replace(
       "{FunctionName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: FunctionName.");
   }
   const query: any = {};
   if (input.Qualifier !== undefined) {
-    query["Qualifier"] = input.Qualifier.toString();
+    query[
+      __extendedEncodeURIComponent("Qualifier")
+    ] = __extendedEncodeURIComponent(input.Qualifier);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -764,13 +775,13 @@ export async function serializeAws_restJson1_1DeleteLayerVersionCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/2018-10-31/layers/{LayerName}/versions/{VersionNumber}";
   if (input.LayerName !== undefined) {
-    const labelValue: string = input.LayerName.toString();
+    const labelValue: string = input.LayerName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: LayerName.");
     }
     resolvedPath = resolvedPath.replace(
       "{LayerName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: LayerName.");
@@ -784,7 +795,7 @@ export async function serializeAws_restJson1_1DeleteLayerVersionCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{VersionNumber}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: VersionNumber.");
@@ -807,7 +818,7 @@ export async function serializeAws_restJson1_1DeleteProvisionedConcurrencyConfig
   let resolvedPath =
     "/2019-09-30/functions/{FunctionName}/provisioned-concurrency";
   if (input.FunctionName !== undefined) {
-    const labelValue: string = input.FunctionName.toString();
+    const labelValue: string = input.FunctionName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: FunctionName."
@@ -815,14 +826,16 @@ export async function serializeAws_restJson1_1DeleteProvisionedConcurrencyConfig
     }
     resolvedPath = resolvedPath.replace(
       "{FunctionName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: FunctionName.");
   }
   const query: any = {};
   if (input.Qualifier !== undefined) {
-    query["Qualifier"] = input.Qualifier.toString();
+    query[
+      __extendedEncodeURIComponent("Qualifier")
+    ] = __extendedEncodeURIComponent(input.Qualifier);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -858,7 +871,7 @@ export async function serializeAws_restJson1_1GetAliasCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/2015-03-31/functions/{FunctionName}/aliases/{Name}";
   if (input.FunctionName !== undefined) {
-    const labelValue: string = input.FunctionName.toString();
+    const labelValue: string = input.FunctionName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: FunctionName."
@@ -866,19 +879,19 @@ export async function serializeAws_restJson1_1GetAliasCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{FunctionName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: FunctionName.");
   }
   if (input.Name !== undefined) {
-    const labelValue: string = input.Name.toString();
+    const labelValue: string = input.Name;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Name.");
     }
     resolvedPath = resolvedPath.replace(
       "{Name}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Name.");
@@ -900,13 +913,13 @@ export async function serializeAws_restJson1_1GetEventSourceMappingCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/2015-03-31/event-source-mappings/{UUID}";
   if (input.UUID !== undefined) {
-    const labelValue: string = input.UUID.toString();
+    const labelValue: string = input.UUID;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: UUID.");
     }
     resolvedPath = resolvedPath.replace(
       "{UUID}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: UUID.");
@@ -928,7 +941,7 @@ export async function serializeAws_restJson1_1GetFunctionCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/2015-03-31/functions/{FunctionName}";
   if (input.FunctionName !== undefined) {
-    const labelValue: string = input.FunctionName.toString();
+    const labelValue: string = input.FunctionName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: FunctionName."
@@ -936,14 +949,16 @@ export async function serializeAws_restJson1_1GetFunctionCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{FunctionName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: FunctionName.");
   }
   const query: any = {};
   if (input.Qualifier !== undefined) {
-    query["Qualifier"] = input.Qualifier.toString();
+    query[
+      __extendedEncodeURIComponent("Qualifier")
+    ] = __extendedEncodeURIComponent(input.Qualifier);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -963,7 +978,7 @@ export async function serializeAws_restJson1_1GetFunctionConcurrencyCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/2019-09-30/functions/{FunctionName}/concurrency";
   if (input.FunctionName !== undefined) {
-    const labelValue: string = input.FunctionName.toString();
+    const labelValue: string = input.FunctionName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: FunctionName."
@@ -971,7 +986,7 @@ export async function serializeAws_restJson1_1GetFunctionConcurrencyCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{FunctionName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: FunctionName.");
@@ -993,7 +1008,7 @@ export async function serializeAws_restJson1_1GetFunctionConfigurationCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/2015-03-31/functions/{FunctionName}/configuration";
   if (input.FunctionName !== undefined) {
-    const labelValue: string = input.FunctionName.toString();
+    const labelValue: string = input.FunctionName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: FunctionName."
@@ -1001,14 +1016,16 @@ export async function serializeAws_restJson1_1GetFunctionConfigurationCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{FunctionName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: FunctionName.");
   }
   const query: any = {};
   if (input.Qualifier !== undefined) {
-    query["Qualifier"] = input.Qualifier.toString();
+    query[
+      __extendedEncodeURIComponent("Qualifier")
+    ] = __extendedEncodeURIComponent(input.Qualifier);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1028,7 +1045,7 @@ export async function serializeAws_restJson1_1GetFunctionEventInvokeConfigComman
   headers["Content-Type"] = "";
   let resolvedPath = "/2019-09-25/functions/{FunctionName}/event-invoke-config";
   if (input.FunctionName !== undefined) {
-    const labelValue: string = input.FunctionName.toString();
+    const labelValue: string = input.FunctionName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: FunctionName."
@@ -1036,14 +1053,16 @@ export async function serializeAws_restJson1_1GetFunctionEventInvokeConfigComman
     }
     resolvedPath = resolvedPath.replace(
       "{FunctionName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: FunctionName.");
   }
   const query: any = {};
   if (input.Qualifier !== undefined) {
-    query["Qualifier"] = input.Qualifier.toString();
+    query[
+      __extendedEncodeURIComponent("Qualifier")
+    ] = __extendedEncodeURIComponent(input.Qualifier);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1063,13 +1082,13 @@ export async function serializeAws_restJson1_1GetLayerVersionCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/2018-10-31/layers/{LayerName}/versions/{VersionNumber}";
   if (input.LayerName !== undefined) {
-    const labelValue: string = input.LayerName.toString();
+    const labelValue: string = input.LayerName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: LayerName.");
     }
     resolvedPath = resolvedPath.replace(
       "{LayerName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: LayerName.");
@@ -1083,7 +1102,7 @@ export async function serializeAws_restJson1_1GetLayerVersionCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{VersionNumber}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: VersionNumber.");
@@ -1108,7 +1127,9 @@ export async function serializeAws_restJson1_1GetLayerVersionByArnCommand(
     find: "LayerVersion"
   };
   if (input.Arn !== undefined) {
-    query["Arn"] = input.Arn.toString();
+    query[__extendedEncodeURIComponent("Arn")] = __extendedEncodeURIComponent(
+      input.Arn
+    );
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1129,13 +1150,13 @@ export async function serializeAws_restJson1_1GetLayerVersionPolicyCommand(
   let resolvedPath =
     "/2018-10-31/layers/{LayerName}/versions/{VersionNumber}/policy";
   if (input.LayerName !== undefined) {
-    const labelValue: string = input.LayerName.toString();
+    const labelValue: string = input.LayerName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: LayerName.");
     }
     resolvedPath = resolvedPath.replace(
       "{LayerName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: LayerName.");
@@ -1149,7 +1170,7 @@ export async function serializeAws_restJson1_1GetLayerVersionPolicyCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{VersionNumber}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: VersionNumber.");
@@ -1171,7 +1192,7 @@ export async function serializeAws_restJson1_1GetPolicyCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/2015-03-31/functions/{FunctionName}/policy";
   if (input.FunctionName !== undefined) {
-    const labelValue: string = input.FunctionName.toString();
+    const labelValue: string = input.FunctionName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: FunctionName."
@@ -1179,14 +1200,16 @@ export async function serializeAws_restJson1_1GetPolicyCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{FunctionName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: FunctionName.");
   }
   const query: any = {};
   if (input.Qualifier !== undefined) {
-    query["Qualifier"] = input.Qualifier.toString();
+    query[
+      __extendedEncodeURIComponent("Qualifier")
+    ] = __extendedEncodeURIComponent(input.Qualifier);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1207,7 +1230,7 @@ export async function serializeAws_restJson1_1GetProvisionedConcurrencyConfigCom
   let resolvedPath =
     "/2019-09-30/functions/{FunctionName}/provisioned-concurrency";
   if (input.FunctionName !== undefined) {
-    const labelValue: string = input.FunctionName.toString();
+    const labelValue: string = input.FunctionName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: FunctionName."
@@ -1215,14 +1238,16 @@ export async function serializeAws_restJson1_1GetProvisionedConcurrencyConfigCom
     }
     resolvedPath = resolvedPath.replace(
       "{FunctionName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: FunctionName.");
   }
   const query: any = {};
   if (input.Qualifier !== undefined) {
-    query["Qualifier"] = input.Qualifier.toString();
+    query[
+      __extendedEncodeURIComponent("Qualifier")
+    ] = __extendedEncodeURIComponent(input.Qualifier);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1241,17 +1266,17 @@ export async function serializeAws_restJson1_1InvokeCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/octet-stream";
   if (input.ClientContext !== undefined) {
-    headers["X-Amz-Client-Context"] = input.ClientContext.toString();
+    headers["X-Amz-Client-Context"] = input.ClientContext;
   }
   if (input.InvocationType !== undefined) {
-    headers["X-Amz-Invocation-Type"] = input.InvocationType.toString();
+    headers["X-Amz-Invocation-Type"] = input.InvocationType;
   }
   if (input.LogType !== undefined) {
-    headers["X-Amz-Log-Type"] = input.LogType.toString();
+    headers["X-Amz-Log-Type"] = input.LogType;
   }
   let resolvedPath = "/2015-03-31/functions/{FunctionName}/invocations";
   if (input.FunctionName !== undefined) {
-    const labelValue: string = input.FunctionName.toString();
+    const labelValue: string = input.FunctionName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: FunctionName."
@@ -1259,14 +1284,16 @@ export async function serializeAws_restJson1_1InvokeCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{FunctionName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: FunctionName.");
   }
   const query: any = {};
   if (input.Qualifier !== undefined) {
-    query["Qualifier"] = input.Qualifier.toString();
+    query[
+      __extendedEncodeURIComponent("Qualifier")
+    ] = __extendedEncodeURIComponent(input.Qualifier);
   }
   let body: any;
   if (input.Payload !== undefined) {
@@ -1291,7 +1318,7 @@ export async function serializeAws_restJson1_1InvokeAsyncCommand(
   headers["Content-Type"] = "application/octet-stream";
   let resolvedPath = "/2014-11-13/functions/{FunctionName}/invoke-async";
   if (input.FunctionName !== undefined) {
-    const labelValue: string = input.FunctionName.toString();
+    const labelValue: string = input.FunctionName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: FunctionName."
@@ -1299,7 +1326,7 @@ export async function serializeAws_restJson1_1InvokeAsyncCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{FunctionName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: FunctionName.");
@@ -1326,7 +1353,7 @@ export async function serializeAws_restJson1_1ListAliasesCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/2015-03-31/functions/{FunctionName}/aliases";
   if (input.FunctionName !== undefined) {
-    const labelValue: string = input.FunctionName.toString();
+    const labelValue: string = input.FunctionName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: FunctionName."
@@ -1334,20 +1361,26 @@ export async function serializeAws_restJson1_1ListAliasesCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{FunctionName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: FunctionName.");
   }
   const query: any = {};
   if (input.FunctionVersion !== undefined) {
-    query["FunctionVersion"] = input.FunctionVersion.toString();
+    query[
+      __extendedEncodeURIComponent("FunctionVersion")
+    ] = __extendedEncodeURIComponent(input.FunctionVersion);
   }
   if (input.Marker !== undefined) {
-    query["Marker"] = input.Marker.toString();
+    query[
+      __extendedEncodeURIComponent("Marker")
+    ] = __extendedEncodeURIComponent(input.Marker);
   }
   if (input.MaxItems !== undefined) {
-    query["MaxItems"] = input.MaxItems.toString();
+    query[
+      __extendedEncodeURIComponent("MaxItems")
+    ] = __extendedEncodeURIComponent(input.MaxItems.toString());
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1368,16 +1401,24 @@ export async function serializeAws_restJson1_1ListEventSourceMappingsCommand(
   let resolvedPath = "/2015-03-31/event-source-mappings";
   const query: any = {};
   if (input.EventSourceArn !== undefined) {
-    query["EventSourceArn"] = input.EventSourceArn.toString();
+    query[
+      __extendedEncodeURIComponent("EventSourceArn")
+    ] = __extendedEncodeURIComponent(input.EventSourceArn);
   }
   if (input.FunctionName !== undefined) {
-    query["FunctionName"] = input.FunctionName.toString();
+    query[
+      __extendedEncodeURIComponent("FunctionName")
+    ] = __extendedEncodeURIComponent(input.FunctionName);
   }
   if (input.Marker !== undefined) {
-    query["Marker"] = input.Marker.toString();
+    query[
+      __extendedEncodeURIComponent("Marker")
+    ] = __extendedEncodeURIComponent(input.Marker);
   }
   if (input.MaxItems !== undefined) {
-    query["MaxItems"] = input.MaxItems.toString();
+    query[
+      __extendedEncodeURIComponent("MaxItems")
+    ] = __extendedEncodeURIComponent(input.MaxItems.toString());
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1398,7 +1439,7 @@ export async function serializeAws_restJson1_1ListFunctionEventInvokeConfigsComm
   let resolvedPath =
     "/2019-09-25/functions/{FunctionName}/event-invoke-config/list";
   if (input.FunctionName !== undefined) {
-    const labelValue: string = input.FunctionName.toString();
+    const labelValue: string = input.FunctionName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: FunctionName."
@@ -1406,17 +1447,21 @@ export async function serializeAws_restJson1_1ListFunctionEventInvokeConfigsComm
     }
     resolvedPath = resolvedPath.replace(
       "{FunctionName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: FunctionName.");
   }
   const query: any = {};
   if (input.Marker !== undefined) {
-    query["Marker"] = input.Marker.toString();
+    query[
+      __extendedEncodeURIComponent("Marker")
+    ] = __extendedEncodeURIComponent(input.Marker);
   }
   if (input.MaxItems !== undefined) {
-    query["MaxItems"] = input.MaxItems.toString();
+    query[
+      __extendedEncodeURIComponent("MaxItems")
+    ] = __extendedEncodeURIComponent(input.MaxItems.toString());
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1437,16 +1482,24 @@ export async function serializeAws_restJson1_1ListFunctionsCommand(
   let resolvedPath = "/2015-03-31/functions";
   const query: any = {};
   if (input.FunctionVersion !== undefined) {
-    query["FunctionVersion"] = input.FunctionVersion.toString();
+    query[
+      __extendedEncodeURIComponent("FunctionVersion")
+    ] = __extendedEncodeURIComponent(input.FunctionVersion);
   }
   if (input.Marker !== undefined) {
-    query["Marker"] = input.Marker.toString();
+    query[
+      __extendedEncodeURIComponent("Marker")
+    ] = __extendedEncodeURIComponent(input.Marker);
   }
   if (input.MasterRegion !== undefined) {
-    query["MasterRegion"] = input.MasterRegion.toString();
+    query[
+      __extendedEncodeURIComponent("MasterRegion")
+    ] = __extendedEncodeURIComponent(input.MasterRegion);
   }
   if (input.MaxItems !== undefined) {
-    query["MaxItems"] = input.MaxItems.toString();
+    query[
+      __extendedEncodeURIComponent("MaxItems")
+    ] = __extendedEncodeURIComponent(input.MaxItems.toString());
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1466,26 +1519,32 @@ export async function serializeAws_restJson1_1ListLayerVersionsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/2018-10-31/layers/{LayerName}/versions";
   if (input.LayerName !== undefined) {
-    const labelValue: string = input.LayerName.toString();
+    const labelValue: string = input.LayerName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: LayerName.");
     }
     resolvedPath = resolvedPath.replace(
       "{LayerName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: LayerName.");
   }
   const query: any = {};
   if (input.CompatibleRuntime !== undefined) {
-    query["CompatibleRuntime"] = input.CompatibleRuntime.toString();
+    query[
+      __extendedEncodeURIComponent("CompatibleRuntime")
+    ] = __extendedEncodeURIComponent(input.CompatibleRuntime);
   }
   if (input.Marker !== undefined) {
-    query["Marker"] = input.Marker.toString();
+    query[
+      __extendedEncodeURIComponent("Marker")
+    ] = __extendedEncodeURIComponent(input.Marker);
   }
   if (input.MaxItems !== undefined) {
-    query["MaxItems"] = input.MaxItems.toString();
+    query[
+      __extendedEncodeURIComponent("MaxItems")
+    ] = __extendedEncodeURIComponent(input.MaxItems.toString());
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1506,13 +1565,19 @@ export async function serializeAws_restJson1_1ListLayersCommand(
   let resolvedPath = "/2018-10-31/layers";
   const query: any = {};
   if (input.CompatibleRuntime !== undefined) {
-    query["CompatibleRuntime"] = input.CompatibleRuntime.toString();
+    query[
+      __extendedEncodeURIComponent("CompatibleRuntime")
+    ] = __extendedEncodeURIComponent(input.CompatibleRuntime);
   }
   if (input.Marker !== undefined) {
-    query["Marker"] = input.Marker.toString();
+    query[
+      __extendedEncodeURIComponent("Marker")
+    ] = __extendedEncodeURIComponent(input.Marker);
   }
   if (input.MaxItems !== undefined) {
-    query["MaxItems"] = input.MaxItems.toString();
+    query[
+      __extendedEncodeURIComponent("MaxItems")
+    ] = __extendedEncodeURIComponent(input.MaxItems.toString());
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1533,7 +1598,7 @@ export async function serializeAws_restJson1_1ListProvisionedConcurrencyConfigsC
   let resolvedPath =
     "/2019-09-30/functions/{FunctionName}/provisioned-concurrency";
   if (input.FunctionName !== undefined) {
-    const labelValue: string = input.FunctionName.toString();
+    const labelValue: string = input.FunctionName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: FunctionName."
@@ -1541,7 +1606,7 @@ export async function serializeAws_restJson1_1ListProvisionedConcurrencyConfigsC
     }
     resolvedPath = resolvedPath.replace(
       "{FunctionName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: FunctionName.");
@@ -1550,10 +1615,14 @@ export async function serializeAws_restJson1_1ListProvisionedConcurrencyConfigsC
     List: "ALL"
   };
   if (input.Marker !== undefined) {
-    query["Marker"] = input.Marker.toString();
+    query[
+      __extendedEncodeURIComponent("Marker")
+    ] = __extendedEncodeURIComponent(input.Marker);
   }
   if (input.MaxItems !== undefined) {
-    query["MaxItems"] = input.MaxItems.toString();
+    query[
+      __extendedEncodeURIComponent("MaxItems")
+    ] = __extendedEncodeURIComponent(input.MaxItems.toString());
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1573,13 +1642,13 @@ export async function serializeAws_restJson1_1ListTagsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/2017-03-31/tags/{Resource}";
   if (input.Resource !== undefined) {
-    const labelValue: string = input.Resource.toString();
+    const labelValue: string = input.Resource;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Resource.");
     }
     resolvedPath = resolvedPath.replace(
       "{Resource}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Resource.");
@@ -1601,7 +1670,7 @@ export async function serializeAws_restJson1_1ListVersionsByFunctionCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/2015-03-31/functions/{FunctionName}/versions";
   if (input.FunctionName !== undefined) {
-    const labelValue: string = input.FunctionName.toString();
+    const labelValue: string = input.FunctionName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: FunctionName."
@@ -1609,17 +1678,21 @@ export async function serializeAws_restJson1_1ListVersionsByFunctionCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{FunctionName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: FunctionName.");
   }
   const query: any = {};
   if (input.Marker !== undefined) {
-    query["Marker"] = input.Marker.toString();
+    query[
+      __extendedEncodeURIComponent("Marker")
+    ] = __extendedEncodeURIComponent(input.Marker);
   }
   if (input.MaxItems !== undefined) {
-    query["MaxItems"] = input.MaxItems.toString();
+    query[
+      __extendedEncodeURIComponent("MaxItems")
+    ] = __extendedEncodeURIComponent(input.MaxItems.toString());
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1639,13 +1712,13 @@ export async function serializeAws_restJson1_1PublishLayerVersionCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/2018-10-31/layers/{LayerName}/versions";
   if (input.LayerName !== undefined) {
-    const labelValue: string = input.LayerName.toString();
+    const labelValue: string = input.LayerName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: LayerName.");
     }
     resolvedPath = resolvedPath.replace(
       "{LayerName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: LayerName.");
@@ -1691,7 +1764,7 @@ export async function serializeAws_restJson1_1PublishVersionCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/2015-03-31/functions/{FunctionName}/versions";
   if (input.FunctionName !== undefined) {
-    const labelValue: string = input.FunctionName.toString();
+    const labelValue: string = input.FunctionName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: FunctionName."
@@ -1699,7 +1772,7 @@ export async function serializeAws_restJson1_1PublishVersionCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{FunctionName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: FunctionName.");
@@ -1734,7 +1807,7 @@ export async function serializeAws_restJson1_1PutFunctionConcurrencyCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/2017-10-31/functions/{FunctionName}/concurrency";
   if (input.FunctionName !== undefined) {
-    const labelValue: string = input.FunctionName.toString();
+    const labelValue: string = input.FunctionName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: FunctionName."
@@ -1742,7 +1815,7 @@ export async function serializeAws_restJson1_1PutFunctionConcurrencyCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{FunctionName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: FunctionName.");
@@ -1772,7 +1845,7 @@ export async function serializeAws_restJson1_1PutFunctionEventInvokeConfigComman
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/2019-09-25/functions/{FunctionName}/event-invoke-config";
   if (input.FunctionName !== undefined) {
-    const labelValue: string = input.FunctionName.toString();
+    const labelValue: string = input.FunctionName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: FunctionName."
@@ -1780,14 +1853,16 @@ export async function serializeAws_restJson1_1PutFunctionEventInvokeConfigComman
     }
     resolvedPath = resolvedPath.replace(
       "{FunctionName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: FunctionName.");
   }
   const query: any = {};
   if (input.Qualifier !== undefined) {
-    query["Qualifier"] = input.Qualifier.toString();
+    query[
+      __extendedEncodeURIComponent("Qualifier")
+    ] = __extendedEncodeURIComponent(input.Qualifier);
   }
   let body: any;
   const bodyParams: any = {};
@@ -1824,7 +1899,7 @@ export async function serializeAws_restJson1_1PutProvisionedConcurrencyConfigCom
   let resolvedPath =
     "/2019-09-30/functions/{FunctionName}/provisioned-concurrency";
   if (input.FunctionName !== undefined) {
-    const labelValue: string = input.FunctionName.toString();
+    const labelValue: string = input.FunctionName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: FunctionName."
@@ -1832,14 +1907,16 @@ export async function serializeAws_restJson1_1PutProvisionedConcurrencyConfigCom
     }
     resolvedPath = resolvedPath.replace(
       "{FunctionName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: FunctionName.");
   }
   const query: any = {};
   if (input.Qualifier !== undefined) {
-    query["Qualifier"] = input.Qualifier.toString();
+    query[
+      __extendedEncodeURIComponent("Qualifier")
+    ] = __extendedEncodeURIComponent(input.Qualifier);
   }
   let body: any;
   const bodyParams: any = {};
@@ -1868,19 +1945,19 @@ export async function serializeAws_restJson1_1RemoveLayerVersionPermissionComman
   let resolvedPath =
     "/2018-10-31/layers/{LayerName}/versions/{VersionNumber}/policy/{StatementId}";
   if (input.LayerName !== undefined) {
-    const labelValue: string = input.LayerName.toString();
+    const labelValue: string = input.LayerName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: LayerName.");
     }
     resolvedPath = resolvedPath.replace(
       "{LayerName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: LayerName.");
   }
   if (input.StatementId !== undefined) {
-    const labelValue: string = input.StatementId.toString();
+    const labelValue: string = input.StatementId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: StatementId."
@@ -1888,7 +1965,7 @@ export async function serializeAws_restJson1_1RemoveLayerVersionPermissionComman
     }
     resolvedPath = resolvedPath.replace(
       "{StatementId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: StatementId.");
@@ -1902,14 +1979,16 @@ export async function serializeAws_restJson1_1RemoveLayerVersionPermissionComman
     }
     resolvedPath = resolvedPath.replace(
       "{VersionNumber}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: VersionNumber.");
   }
   const query: any = {};
   if (input.RevisionId !== undefined) {
-    query["RevisionId"] = input.RevisionId.toString();
+    query[
+      __extendedEncodeURIComponent("RevisionId")
+    ] = __extendedEncodeURIComponent(input.RevisionId);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1930,7 +2009,7 @@ export async function serializeAws_restJson1_1RemovePermissionCommand(
   let resolvedPath =
     "/2015-03-31/functions/{FunctionName}/policy/{StatementId}";
   if (input.FunctionName !== undefined) {
-    const labelValue: string = input.FunctionName.toString();
+    const labelValue: string = input.FunctionName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: FunctionName."
@@ -1938,13 +2017,13 @@ export async function serializeAws_restJson1_1RemovePermissionCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{FunctionName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: FunctionName.");
   }
   if (input.StatementId !== undefined) {
-    const labelValue: string = input.StatementId.toString();
+    const labelValue: string = input.StatementId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: StatementId."
@@ -1952,17 +2031,21 @@ export async function serializeAws_restJson1_1RemovePermissionCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{StatementId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: StatementId.");
   }
   const query: any = {};
   if (input.Qualifier !== undefined) {
-    query["Qualifier"] = input.Qualifier.toString();
+    query[
+      __extendedEncodeURIComponent("Qualifier")
+    ] = __extendedEncodeURIComponent(input.Qualifier);
   }
   if (input.RevisionId !== undefined) {
-    query["RevisionId"] = input.RevisionId.toString();
+    query[
+      __extendedEncodeURIComponent("RevisionId")
+    ] = __extendedEncodeURIComponent(input.RevisionId);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1982,13 +2065,13 @@ export async function serializeAws_restJson1_1TagResourceCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/2017-03-31/tags/{Resource}";
   if (input.Resource !== undefined) {
-    const labelValue: string = input.Resource.toString();
+    const labelValue: string = input.Resource;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Resource.");
     }
     resolvedPath = resolvedPath.replace(
       "{Resource}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Resource.");
@@ -2017,20 +2100,22 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/2017-03-31/tags/{Resource}";
   if (input.Resource !== undefined) {
-    const labelValue: string = input.Resource.toString();
+    const labelValue: string = input.Resource;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Resource.");
     }
     resolvedPath = resolvedPath.replace(
       "{Resource}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Resource.");
   }
   const query: any = {};
   if (input.TagKeys !== undefined) {
-    query["tagKeys"] = input.TagKeys;
+    query[__extendedEncodeURIComponent("tagKeys")] = input.TagKeys.map(entry =>
+      __extendedEncodeURIComponent(entry)
+    );
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2050,7 +2135,7 @@ export async function serializeAws_restJson1_1UpdateAliasCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/2015-03-31/functions/{FunctionName}/aliases/{Name}";
   if (input.FunctionName !== undefined) {
-    const labelValue: string = input.FunctionName.toString();
+    const labelValue: string = input.FunctionName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: FunctionName."
@@ -2058,19 +2143,19 @@ export async function serializeAws_restJson1_1UpdateAliasCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{FunctionName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: FunctionName.");
   }
   if (input.Name !== undefined) {
-    const labelValue: string = input.Name.toString();
+    const labelValue: string = input.Name;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Name.");
     }
     resolvedPath = resolvedPath.replace(
       "{Name}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Name.");
@@ -2113,13 +2198,13 @@ export async function serializeAws_restJson1_1UpdateEventSourceMappingCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/2015-03-31/event-source-mappings/{UUID}";
   if (input.UUID !== undefined) {
-    const labelValue: string = input.UUID.toString();
+    const labelValue: string = input.UUID;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: UUID.");
     }
     resolvedPath = resolvedPath.replace(
       "{UUID}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: UUID.");
@@ -2176,7 +2261,7 @@ export async function serializeAws_restJson1_1UpdateFunctionCodeCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/2015-03-31/functions/{FunctionName}/code";
   if (input.FunctionName !== undefined) {
-    const labelValue: string = input.FunctionName.toString();
+    const labelValue: string = input.FunctionName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: FunctionName."
@@ -2184,7 +2269,7 @@ export async function serializeAws_restJson1_1UpdateFunctionCodeCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{FunctionName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: FunctionName.");
@@ -2231,7 +2316,7 @@ export async function serializeAws_restJson1_1UpdateFunctionConfigurationCommand
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/2015-03-31/functions/{FunctionName}/configuration";
   if (input.FunctionName !== undefined) {
-    const labelValue: string = input.FunctionName.toString();
+    const labelValue: string = input.FunctionName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: FunctionName."
@@ -2239,7 +2324,7 @@ export async function serializeAws_restJson1_1UpdateFunctionConfigurationCommand
     }
     resolvedPath = resolvedPath.replace(
       "{FunctionName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: FunctionName.");
@@ -2319,7 +2404,7 @@ export async function serializeAws_restJson1_1UpdateFunctionEventInvokeConfigCom
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/2019-09-25/functions/{FunctionName}/event-invoke-config";
   if (input.FunctionName !== undefined) {
-    const labelValue: string = input.FunctionName.toString();
+    const labelValue: string = input.FunctionName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: FunctionName."
@@ -2327,14 +2412,16 @@ export async function serializeAws_restJson1_1UpdateFunctionEventInvokeConfigCom
     }
     resolvedPath = resolvedPath.replace(
       "{FunctionName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: FunctionName.");
   }
   const query: any = {};
   if (input.Qualifier !== undefined) {
-    query["Qualifier"] = input.Qualifier.toString();
+    query[
+      __extendedEncodeURIComponent("Qualifier")
+    ] = __extendedEncodeURIComponent(input.Qualifier);
   }
   let body: any;
   const bodyParams: any = {};
@@ -3046,6 +3133,7 @@ export async function deserializeAws_restJson1_1DeleteAliasCommand(
   const contents: DeleteAliasCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -3278,6 +3366,7 @@ export async function deserializeAws_restJson1_1DeleteFunctionCommand(
   const contents: DeleteFunctionCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -3356,6 +3445,7 @@ export async function deserializeAws_restJson1_1DeleteFunctionConcurrencyCommand
   const contents: DeleteFunctionConcurrencyCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -3434,6 +3524,7 @@ export async function deserializeAws_restJson1_1DeleteFunctionEventInvokeConfigC
   const contents: DeleteFunctionEventInvokeConfigCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -3505,6 +3596,7 @@ export async function deserializeAws_restJson1_1DeleteLayerVersionCommand(
   const contents: DeleteLayerVersionCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -3562,6 +3654,7 @@ export async function deserializeAws_restJson1_1DeleteProvisionedConcurrencyConf
   const contents: DeleteProvisionedConcurrencyConfigCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -5150,6 +5243,7 @@ export async function deserializeAws_restJson1_1InvokeAsyncCommand(
     $metadata: deserializeMetadata(output),
     __type: "InvokeAsyncResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -6605,6 +6699,7 @@ export async function deserializeAws_restJson1_1RemoveLayerVersionPermissionComm
   const contents: RemoveLayerVersionPermissionCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -6683,6 +6778,7 @@ export async function deserializeAws_restJson1_1RemovePermissionCommand(
   const contents: RemovePermissionCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -6758,6 +6854,7 @@ export async function deserializeAws_restJson1_1TagResourceCommand(
   const contents: TagResourceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -6833,6 +6930,7 @@ export async function deserializeAws_restJson1_1UntagResourceCommand(
   const contents: UntagResourceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 

--- a/clients/client-lex-model-building-service/models/index.ts
+++ b/clients/client-lex-model-building-service/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -6,7 +9,7 @@ import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
  *       missing. Check the field values, and try again.</p>
  */
 export interface BadRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "BadRequestException";
   $fault: "client";
@@ -15,16 +18,14 @@ export interface BadRequestException
 
 export namespace BadRequestException {
   export function isa(o: any): o is BadRequestException {
-    return _smithy.isa(o, "BadRequestException");
+    return __isa(o, "BadRequestException");
   }
 }
 
 /**
  * <p> There was a conflict processing the request. Try your request again. </p>
  */
-export interface ConflictException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface ConflictException extends __SmithyException, $MetadataBearer {
   name: "ConflictException";
   $fault: "client";
   message?: string;
@@ -32,7 +33,7 @@ export interface ConflictException
 
 export namespace ConflictException {
   export function isa(o: any): o is ConflictException {
-    return _smithy.isa(o, "ConflictException");
+    return __isa(o, "ConflictException");
   }
 }
 
@@ -40,7 +41,7 @@ export namespace ConflictException {
  * <p>An internal Amazon Lex error occurred. Try your request again.</p>
  */
 export interface InternalFailureException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalFailureException";
   $fault: "server";
@@ -49,7 +50,7 @@ export interface InternalFailureException
 
 export namespace InternalFailureException {
   export function isa(o: any): o is InternalFailureException {
-    return _smithy.isa(o, "InternalFailureException");
+    return __isa(o, "InternalFailureException");
   }
 }
 
@@ -57,7 +58,7 @@ export namespace InternalFailureException {
  * <p>The request exceeded a limit. Try your request again.</p>
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -67,7 +68,7 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
@@ -75,9 +76,7 @@ export namespace LimitExceededException {
  * <p>The resource specified in the request was not found. Check the resource and try
  *       again.</p>
  */
-export interface NotFoundException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface NotFoundException extends __SmithyException, $MetadataBearer {
   name: "NotFoundException";
   $fault: "client";
   message?: string;
@@ -85,7 +84,7 @@ export interface NotFoundException
 
 export namespace NotFoundException {
   export function isa(o: any): o is NotFoundException {
-    return _smithy.isa(o, "NotFoundException");
+    return __isa(o, "NotFoundException");
   }
 }
 
@@ -94,7 +93,7 @@ export namespace NotFoundException {
  *       in the request. Check the resource's checksum and try again.</p>
  */
 export interface PreconditionFailedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "PreconditionFailedException";
   $fault: "client";
@@ -103,7 +102,7 @@ export interface PreconditionFailedException
 
 export namespace PreconditionFailedException {
   export function isa(o: any): o is PreconditionFailedException {
-    return _smithy.isa(o, "PreconditionFailedException");
+    return __isa(o, "PreconditionFailedException");
   }
 }
 
@@ -156,7 +155,7 @@ export interface BotAliasMetadata {
 
 export namespace BotAliasMetadata {
   export function isa(o: any): o is BotAliasMetadata {
-    return _smithy.isa(o, "BotAliasMetadata");
+    return __isa(o, "BotAliasMetadata");
   }
 }
 
@@ -237,7 +236,7 @@ export interface BotChannelAssociation {
 
 export namespace BotChannelAssociation {
   export function isa(o: any): o is BotChannelAssociation {
-    return _smithy.isa(o, "BotChannelAssociation");
+    return __isa(o, "BotChannelAssociation");
   }
 }
 
@@ -281,7 +280,7 @@ export interface BotMetadata {
 
 export namespace BotMetadata {
   export function isa(o: any): o is BotMetadata {
-    return _smithy.isa(o, "BotMetadata");
+    return __isa(o, "BotMetadata");
   }
 }
 
@@ -304,7 +303,7 @@ export interface BuiltinIntentMetadata {
 
 export namespace BuiltinIntentMetadata {
   export function isa(o: any): o is BuiltinIntentMetadata {
-    return _smithy.isa(o, "BuiltinIntentMetadata");
+    return __isa(o, "BuiltinIntentMetadata");
   }
 }
 
@@ -321,7 +320,7 @@ export interface BuiltinIntentSlot {
 
 export namespace BuiltinIntentSlot {
   export function isa(o: any): o is BuiltinIntentSlot {
-    return _smithy.isa(o, "BuiltinIntentSlot");
+    return __isa(o, "BuiltinIntentSlot");
   }
 }
 
@@ -344,7 +343,7 @@ export interface BuiltinSlotTypeMetadata {
 
 export namespace BuiltinSlotTypeMetadata {
   export function isa(o: any): o is BuiltinSlotTypeMetadata {
-    return _smithy.isa(o, "BuiltinSlotTypeMetadata");
+    return __isa(o, "BuiltinSlotTypeMetadata");
   }
 }
 
@@ -381,7 +380,7 @@ export interface CodeHook {
 
 export namespace CodeHook {
   export function isa(o: any): o is CodeHook {
-    return _smithy.isa(o, "CodeHook");
+    return __isa(o, "CodeHook");
   }
 }
 
@@ -414,7 +413,7 @@ export interface ConversationLogsRequest {
 
 export namespace ConversationLogsRequest {
   export function isa(o: any): o is ConversationLogsRequest {
-    return _smithy.isa(o, "ConversationLogsRequest");
+    return __isa(o, "ConversationLogsRequest");
   }
 }
 
@@ -437,7 +436,7 @@ export interface ConversationLogsResponse {
 
 export namespace ConversationLogsResponse {
   export function isa(o: any): o is ConversationLogsResponse {
-    return _smithy.isa(o, "ConversationLogsResponse");
+    return __isa(o, "ConversationLogsResponse");
   }
 }
 
@@ -461,7 +460,7 @@ export interface CreateBotVersionRequest {
 
 export namespace CreateBotVersionRequest {
   export function isa(o: any): o is CreateBotVersionRequest {
-    return _smithy.isa(o, "CreateBotVersionRequest");
+    return __isa(o, "CreateBotVersionRequest");
   }
 }
 
@@ -578,7 +577,7 @@ export interface CreateBotVersionResponse extends $MetadataBearer {
 
 export namespace CreateBotVersionResponse {
   export function isa(o: any): o is CreateBotVersionResponse {
-    return _smithy.isa(o, "CreateBotVersionResponse");
+    return __isa(o, "CreateBotVersionResponse");
   }
 }
 
@@ -602,7 +601,7 @@ export interface CreateIntentVersionRequest {
 
 export namespace CreateIntentVersionRequest {
   export function isa(o: any): o is CreateIntentVersionRequest {
-    return _smithy.isa(o, "CreateIntentVersionRequest");
+    return __isa(o, "CreateIntentVersionRequest");
   }
 }
 
@@ -691,7 +690,7 @@ export interface CreateIntentVersionResponse extends $MetadataBearer {
 
 export namespace CreateIntentVersionResponse {
   export function isa(o: any): o is CreateIntentVersionResponse {
-    return _smithy.isa(o, "CreateIntentVersionResponse");
+    return __isa(o, "CreateIntentVersionResponse");
   }
 }
 
@@ -715,7 +714,7 @@ export interface CreateSlotTypeVersionRequest {
 
 export namespace CreateSlotTypeVersionRequest {
   export function isa(o: any): o is CreateSlotTypeVersionRequest {
-    return _smithy.isa(o, "CreateSlotTypeVersionRequest");
+    return __isa(o, "CreateSlotTypeVersionRequest");
   }
 }
 
@@ -767,7 +766,7 @@ export interface CreateSlotTypeVersionResponse extends $MetadataBearer {
 
 export namespace CreateSlotTypeVersionResponse {
   export function isa(o: any): o is CreateSlotTypeVersionResponse {
-    return _smithy.isa(o, "CreateSlotTypeVersionResponse");
+    return __isa(o, "CreateSlotTypeVersionResponse");
   }
 }
 
@@ -786,7 +785,7 @@ export interface DeleteBotAliasRequest {
 
 export namespace DeleteBotAliasRequest {
   export function isa(o: any): o is DeleteBotAliasRequest {
-    return _smithy.isa(o, "DeleteBotAliasRequest");
+    return __isa(o, "DeleteBotAliasRequest");
   }
 }
 
@@ -811,7 +810,7 @@ export interface DeleteBotChannelAssociationRequest {
 
 export namespace DeleteBotChannelAssociationRequest {
   export function isa(o: any): o is DeleteBotChannelAssociationRequest {
-    return _smithy.isa(o, "DeleteBotChannelAssociationRequest");
+    return __isa(o, "DeleteBotChannelAssociationRequest");
   }
 }
 
@@ -825,7 +824,7 @@ export interface DeleteBotRequest {
 
 export namespace DeleteBotRequest {
   export function isa(o: any): o is DeleteBotRequest {
-    return _smithy.isa(o, "DeleteBotRequest");
+    return __isa(o, "DeleteBotRequest");
   }
 }
 
@@ -846,7 +845,7 @@ export interface DeleteBotVersionRequest {
 
 export namespace DeleteBotVersionRequest {
   export function isa(o: any): o is DeleteBotVersionRequest {
-    return _smithy.isa(o, "DeleteBotVersionRequest");
+    return __isa(o, "DeleteBotVersionRequest");
   }
 }
 
@@ -860,7 +859,7 @@ export interface DeleteIntentRequest {
 
 export namespace DeleteIntentRequest {
   export function isa(o: any): o is DeleteIntentRequest {
-    return _smithy.isa(o, "DeleteIntentRequest");
+    return __isa(o, "DeleteIntentRequest");
   }
 }
 
@@ -880,7 +879,7 @@ export interface DeleteIntentVersionRequest {
 
 export namespace DeleteIntentVersionRequest {
   export function isa(o: any): o is DeleteIntentVersionRequest {
-    return _smithy.isa(o, "DeleteIntentVersionRequest");
+    return __isa(o, "DeleteIntentVersionRequest");
   }
 }
 
@@ -894,7 +893,7 @@ export interface DeleteSlotTypeRequest {
 
 export namespace DeleteSlotTypeRequest {
   export function isa(o: any): o is DeleteSlotTypeRequest {
-    return _smithy.isa(o, "DeleteSlotTypeRequest");
+    return __isa(o, "DeleteSlotTypeRequest");
   }
 }
 
@@ -914,7 +913,7 @@ export interface DeleteSlotTypeVersionRequest {
 
 export namespace DeleteSlotTypeVersionRequest {
   export function isa(o: any): o is DeleteSlotTypeVersionRequest {
-    return _smithy.isa(o, "DeleteSlotTypeVersionRequest");
+    return __isa(o, "DeleteSlotTypeVersionRequest");
   }
 }
 
@@ -935,7 +934,7 @@ export interface DeleteUtterancesRequest {
 
 export namespace DeleteUtterancesRequest {
   export function isa(o: any): o is DeleteUtterancesRequest {
-    return _smithy.isa(o, "DeleteUtterancesRequest");
+    return __isa(o, "DeleteUtterancesRequest");
   }
 }
 
@@ -976,7 +975,7 @@ export interface EnumerationValue {
 
 export namespace EnumerationValue {
   export function isa(o: any): o is EnumerationValue {
-    return _smithy.isa(o, "EnumerationValue");
+    return __isa(o, "EnumerationValue");
   }
 }
 
@@ -1012,7 +1011,7 @@ export interface FollowUpPrompt {
 
 export namespace FollowUpPrompt {
   export function isa(o: any): o is FollowUpPrompt {
-    return _smithy.isa(o, "FollowUpPrompt");
+    return __isa(o, "FollowUpPrompt");
   }
 }
 
@@ -1054,7 +1053,7 @@ export interface FulfillmentActivity {
 
 export namespace FulfillmentActivity {
   export function isa(o: any): o is FulfillmentActivity {
-    return _smithy.isa(o, "FulfillmentActivity");
+    return __isa(o, "FulfillmentActivity");
   }
 }
 
@@ -1078,7 +1077,7 @@ export interface GetBotAliasRequest {
 
 export namespace GetBotAliasRequest {
   export function isa(o: any): o is GetBotAliasRequest {
-    return _smithy.isa(o, "GetBotAliasRequest");
+    return __isa(o, "GetBotAliasRequest");
   }
 }
 
@@ -1128,7 +1127,7 @@ export interface GetBotAliasResponse extends $MetadataBearer {
 
 export namespace GetBotAliasResponse {
   export function isa(o: any): o is GetBotAliasResponse {
-    return _smithy.isa(o, "GetBotAliasResponse");
+    return __isa(o, "GetBotAliasResponse");
   }
 }
 
@@ -1161,7 +1160,7 @@ export interface GetBotAliasesRequest {
 
 export namespace GetBotAliasesRequest {
   export function isa(o: any): o is GetBotAliasesRequest {
-    return _smithy.isa(o, "GetBotAliasesRequest");
+    return __isa(o, "GetBotAliasesRequest");
   }
 }
 
@@ -1183,7 +1182,7 @@ export interface GetBotAliasesResponse extends $MetadataBearer {
 
 export namespace GetBotAliasesResponse {
   export function isa(o: any): o is GetBotAliasesResponse {
-    return _smithy.isa(o, "GetBotAliasesResponse");
+    return __isa(o, "GetBotAliasesResponse");
   }
 }
 
@@ -1209,7 +1208,7 @@ export interface GetBotChannelAssociationRequest {
 
 export namespace GetBotChannelAssociationRequest {
   export function isa(o: any): o is GetBotChannelAssociationRequest {
-    return _smithy.isa(o, "GetBotChannelAssociationRequest");
+    return __isa(o, "GetBotChannelAssociationRequest");
   }
 }
 
@@ -1281,7 +1280,7 @@ export interface GetBotChannelAssociationResponse extends $MetadataBearer {
 
 export namespace GetBotChannelAssociationResponse {
   export function isa(o: any): o is GetBotChannelAssociationResponse {
-    return _smithy.isa(o, "GetBotChannelAssociationResponse");
+    return __isa(o, "GetBotChannelAssociationResponse");
   }
 }
 
@@ -1322,7 +1321,7 @@ export interface GetBotChannelAssociationsRequest {
 
 export namespace GetBotChannelAssociationsRequest {
   export function isa(o: any): o is GetBotChannelAssociationsRequest {
-    return _smithy.isa(o, "GetBotChannelAssociationsRequest");
+    return __isa(o, "GetBotChannelAssociationsRequest");
   }
 }
 
@@ -1344,7 +1343,7 @@ export interface GetBotChannelAssociationsResponse extends $MetadataBearer {
 
 export namespace GetBotChannelAssociationsResponse {
   export function isa(o: any): o is GetBotChannelAssociationsResponse {
-    return _smithy.isa(o, "GetBotChannelAssociationsResponse");
+    return __isa(o, "GetBotChannelAssociationsResponse");
   }
 }
 
@@ -1363,7 +1362,7 @@ export interface GetBotRequest {
 
 export namespace GetBotRequest {
   export function isa(o: any): o is GetBotRequest {
-    return _smithy.isa(o, "GetBotRequest");
+    return __isa(o, "GetBotRequest");
   }
 }
 
@@ -1488,7 +1487,7 @@ export interface GetBotResponse extends $MetadataBearer {
 
 export namespace GetBotResponse {
   export function isa(o: any): o is GetBotResponse {
-    return _smithy.isa(o, "GetBotResponse");
+    return __isa(o, "GetBotResponse");
   }
 }
 
@@ -1515,7 +1514,7 @@ export interface GetBotVersionsRequest {
 
 export namespace GetBotVersionsRequest {
   export function isa(o: any): o is GetBotVersionsRequest {
-    return _smithy.isa(o, "GetBotVersionsRequest");
+    return __isa(o, "GetBotVersionsRequest");
   }
 }
 
@@ -1537,7 +1536,7 @@ export interface GetBotVersionsResponse extends $MetadataBearer {
 
 export namespace GetBotVersionsResponse {
   export function isa(o: any): o is GetBotVersionsResponse {
-    return _smithy.isa(o, "GetBotVersionsResponse");
+    return __isa(o, "GetBotVersionsResponse");
   }
 }
 
@@ -1565,7 +1564,7 @@ export interface GetBotsRequest {
 
 export namespace GetBotsRequest {
   export function isa(o: any): o is GetBotsRequest {
-    return _smithy.isa(o, "GetBotsRequest");
+    return __isa(o, "GetBotsRequest");
   }
 }
 
@@ -1585,7 +1584,7 @@ export interface GetBotsResponse extends $MetadataBearer {
 
 export namespace GetBotsResponse {
   export function isa(o: any): o is GetBotsResponse {
-    return _smithy.isa(o, "GetBotsResponse");
+    return __isa(o, "GetBotsResponse");
   }
 }
 
@@ -1600,7 +1599,7 @@ export interface GetBuiltinIntentRequest {
 
 export namespace GetBuiltinIntentRequest {
   export function isa(o: any): o is GetBuiltinIntentRequest {
-    return _smithy.isa(o, "GetBuiltinIntentRequest");
+    return __isa(o, "GetBuiltinIntentRequest");
   }
 }
 
@@ -1625,7 +1624,7 @@ export interface GetBuiltinIntentResponse extends $MetadataBearer {
 
 export namespace GetBuiltinIntentResponse {
   export function isa(o: any): o is GetBuiltinIntentResponse {
-    return _smithy.isa(o, "GetBuiltinIntentResponse");
+    return __isa(o, "GetBuiltinIntentResponse");
   }
 }
 
@@ -1658,7 +1657,7 @@ export interface GetBuiltinIntentsRequest {
 
 export namespace GetBuiltinIntentsRequest {
   export function isa(o: any): o is GetBuiltinIntentsRequest {
-    return _smithy.isa(o, "GetBuiltinIntentsRequest");
+    return __isa(o, "GetBuiltinIntentsRequest");
   }
 }
 
@@ -1680,7 +1679,7 @@ export interface GetBuiltinIntentsResponse extends $MetadataBearer {
 
 export namespace GetBuiltinIntentsResponse {
   export function isa(o: any): o is GetBuiltinIntentsResponse {
-    return _smithy.isa(o, "GetBuiltinIntentsResponse");
+    return __isa(o, "GetBuiltinIntentsResponse");
   }
 }
 
@@ -1714,7 +1713,7 @@ export interface GetBuiltinSlotTypesRequest {
 
 export namespace GetBuiltinSlotTypesRequest {
   export function isa(o: any): o is GetBuiltinSlotTypesRequest {
-    return _smithy.isa(o, "GetBuiltinSlotTypesRequest");
+    return __isa(o, "GetBuiltinSlotTypesRequest");
   }
 }
 
@@ -1735,7 +1734,7 @@ export interface GetBuiltinSlotTypesResponse extends $MetadataBearer {
 
 export namespace GetBuiltinSlotTypesResponse {
   export function isa(o: any): o is GetBuiltinSlotTypesResponse {
-    return _smithy.isa(o, "GetBuiltinSlotTypesResponse");
+    return __isa(o, "GetBuiltinSlotTypesResponse");
   }
 }
 
@@ -1764,7 +1763,7 @@ export interface GetExportRequest {
 
 export namespace GetExportRequest {
   export function isa(o: any): o is GetExportRequest {
-    return _smithy.isa(o, "GetExportRequest");
+    return __isa(o, "GetExportRequest");
   }
 }
 
@@ -1825,7 +1824,7 @@ export interface GetExportResponse extends $MetadataBearer {
 
 export namespace GetExportResponse {
   export function isa(o: any): o is GetExportResponse {
-    return _smithy.isa(o, "GetExportResponse");
+    return __isa(o, "GetExportResponse");
   }
 }
 
@@ -1839,7 +1838,7 @@ export interface GetImportRequest {
 
 export namespace GetImportRequest {
   export function isa(o: any): o is GetImportRequest {
-    return _smithy.isa(o, "GetImportRequest");
+    return __isa(o, "GetImportRequest");
   }
 }
 
@@ -1885,7 +1884,7 @@ export interface GetImportResponse extends $MetadataBearer {
 
 export namespace GetImportResponse {
   export function isa(o: any): o is GetImportResponse {
-    return _smithy.isa(o, "GetImportResponse");
+    return __isa(o, "GetImportResponse");
   }
 }
 
@@ -1904,7 +1903,7 @@ export interface GetIntentRequest {
 
 export namespace GetIntentRequest {
   export function isa(o: any): o is GetIntentRequest {
-    return _smithy.isa(o, "GetIntentRequest");
+    return __isa(o, "GetIntentRequest");
   }
 }
 
@@ -1994,7 +1993,7 @@ export interface GetIntentResponse extends $MetadataBearer {
 
 export namespace GetIntentResponse {
   export function isa(o: any): o is GetIntentResponse {
-    return _smithy.isa(o, "GetIntentResponse");
+    return __isa(o, "GetIntentResponse");
   }
 }
 
@@ -2021,7 +2020,7 @@ export interface GetIntentVersionsRequest {
 
 export namespace GetIntentVersionsRequest {
   export function isa(o: any): o is GetIntentVersionsRequest {
-    return _smithy.isa(o, "GetIntentVersionsRequest");
+    return __isa(o, "GetIntentVersionsRequest");
   }
 }
 
@@ -2043,7 +2042,7 @@ export interface GetIntentVersionsResponse extends $MetadataBearer {
 
 export namespace GetIntentVersionsResponse {
   export function isa(o: any): o is GetIntentVersionsResponse {
-    return _smithy.isa(o, "GetIntentVersionsResponse");
+    return __isa(o, "GetIntentVersionsResponse");
   }
 }
 
@@ -2070,7 +2069,7 @@ export interface GetIntentsRequest {
 
 export namespace GetIntentsRequest {
   export function isa(o: any): o is GetIntentsRequest {
-    return _smithy.isa(o, "GetIntentsRequest");
+    return __isa(o, "GetIntentsRequest");
   }
 }
 
@@ -2090,7 +2089,7 @@ export interface GetIntentsResponse extends $MetadataBearer {
 
 export namespace GetIntentsResponse {
   export function isa(o: any): o is GetIntentsResponse {
-    return _smithy.isa(o, "GetIntentsResponse");
+    return __isa(o, "GetIntentsResponse");
   }
 }
 
@@ -2109,7 +2108,7 @@ export interface GetSlotTypeRequest {
 
 export namespace GetSlotTypeRequest {
   export function isa(o: any): o is GetSlotTypeRequest {
-    return _smithy.isa(o, "GetSlotTypeRequest");
+    return __isa(o, "GetSlotTypeRequest");
   }
 }
 
@@ -2161,7 +2160,7 @@ export interface GetSlotTypeResponse extends $MetadataBearer {
 
 export namespace GetSlotTypeResponse {
   export function isa(o: any): o is GetSlotTypeResponse {
-    return _smithy.isa(o, "GetSlotTypeResponse");
+    return __isa(o, "GetSlotTypeResponse");
   }
 }
 
@@ -2188,7 +2187,7 @@ export interface GetSlotTypeVersionsRequest {
 
 export namespace GetSlotTypeVersionsRequest {
   export function isa(o: any): o is GetSlotTypeVersionsRequest {
-    return _smithy.isa(o, "GetSlotTypeVersionsRequest");
+    return __isa(o, "GetSlotTypeVersionsRequest");
   }
 }
 
@@ -2210,7 +2209,7 @@ export interface GetSlotTypeVersionsResponse extends $MetadataBearer {
 
 export namespace GetSlotTypeVersionsResponse {
   export function isa(o: any): o is GetSlotTypeVersionsResponse {
-    return _smithy.isa(o, "GetSlotTypeVersionsResponse");
+    return __isa(o, "GetSlotTypeVersionsResponse");
   }
 }
 
@@ -2238,7 +2237,7 @@ export interface GetSlotTypesRequest {
 
 export namespace GetSlotTypesRequest {
   export function isa(o: any): o is GetSlotTypesRequest {
-    return _smithy.isa(o, "GetSlotTypesRequest");
+    return __isa(o, "GetSlotTypesRequest");
   }
 }
 
@@ -2259,7 +2258,7 @@ export interface GetSlotTypesResponse extends $MetadataBearer {
 
 export namespace GetSlotTypesResponse {
   export function isa(o: any): o is GetSlotTypesResponse {
-    return _smithy.isa(o, "GetSlotTypesResponse");
+    return __isa(o, "GetSlotTypesResponse");
   }
 }
 
@@ -2285,7 +2284,7 @@ export interface GetUtterancesViewRequest {
 
 export namespace GetUtterancesViewRequest {
   export function isa(o: any): o is GetUtterancesViewRequest {
-    return _smithy.isa(o, "GetUtterancesViewRequest");
+    return __isa(o, "GetUtterancesViewRequest");
   }
 }
 
@@ -2306,7 +2305,7 @@ export interface GetUtterancesViewResponse extends $MetadataBearer {
 
 export namespace GetUtterancesViewResponse {
   export function isa(o: any): o is GetUtterancesViewResponse {
-    return _smithy.isa(o, "GetUtterancesViewResponse");
+    return __isa(o, "GetUtterancesViewResponse");
   }
 }
 
@@ -2334,7 +2333,7 @@ export interface Intent {
 
 export namespace Intent {
   export function isa(o: any): o is Intent {
-    return _smithy.isa(o, "Intent");
+    return __isa(o, "Intent");
   }
 }
 
@@ -2372,7 +2371,7 @@ export interface IntentMetadata {
 
 export namespace IntentMetadata {
   export function isa(o: any): o is IntentMetadata {
-    return _smithy.isa(o, "IntentMetadata");
+    return __isa(o, "IntentMetadata");
   }
 }
 
@@ -2415,7 +2414,7 @@ export interface LogSettingsRequest {
 
 export namespace LogSettingsRequest {
   export function isa(o: any): o is LogSettingsRequest {
-    return _smithy.isa(o, "LogSettingsRequest");
+    return __isa(o, "LogSettingsRequest");
   }
 }
 
@@ -2456,7 +2455,7 @@ export interface LogSettingsResponse {
 
 export namespace LogSettingsResponse {
   export function isa(o: any): o is LogSettingsResponse {
-    return _smithy.isa(o, "LogSettingsResponse");
+    return __isa(o, "LogSettingsResponse");
   }
 }
 
@@ -2494,7 +2493,7 @@ export interface Message {
 
 export namespace Message {
   export function isa(o: any): o is Message {
-    return _smithy.isa(o, "Message");
+    return __isa(o, "Message");
   }
 }
 
@@ -2538,7 +2537,7 @@ export interface Prompt {
 
 export namespace Prompt {
   export function isa(o: any): o is Prompt {
-    return _smithy.isa(o, "Prompt");
+    return __isa(o, "Prompt");
   }
 }
 
@@ -2583,7 +2582,7 @@ export interface PutBotAliasRequest {
 
 export namespace PutBotAliasRequest {
   export function isa(o: any): o is PutBotAliasRequest {
-    return _smithy.isa(o, "PutBotAliasRequest");
+    return __isa(o, "PutBotAliasRequest");
   }
 }
 
@@ -2633,7 +2632,7 @@ export interface PutBotAliasResponse extends $MetadataBearer {
 
 export namespace PutBotAliasResponse {
   export function isa(o: any): o is PutBotAliasResponse {
-    return _smithy.isa(o, "PutBotAliasResponse");
+    return __isa(o, "PutBotAliasResponse");
   }
 }
 
@@ -2802,7 +2801,7 @@ export interface PutBotRequest {
 
 export namespace PutBotRequest {
   export function isa(o: any): o is PutBotRequest {
-    return _smithy.isa(o, "PutBotRequest");
+    return __isa(o, "PutBotRequest");
   }
 }
 
@@ -2938,7 +2937,7 @@ export interface PutBotResponse extends $MetadataBearer {
 
 export namespace PutBotResponse {
   export function isa(o: any): o is PutBotResponse {
-    return _smithy.isa(o, "PutBotResponse");
+    return __isa(o, "PutBotResponse");
   }
 }
 
@@ -3089,7 +3088,7 @@ export interface PutIntentRequest {
 
 export namespace PutIntentRequest {
   export function isa(o: any): o is PutIntentRequest {
-    return _smithy.isa(o, "PutIntentRequest");
+    return __isa(o, "PutIntentRequest");
   }
 }
 
@@ -3189,7 +3188,7 @@ export interface PutIntentResponse extends $MetadataBearer {
 
 export namespace PutIntentResponse {
   export function isa(o: any): o is PutIntentResponse {
-    return _smithy.isa(o, "PutIntentResponse");
+    return __isa(o, "PutIntentResponse");
   }
 }
 
@@ -3265,7 +3264,7 @@ export interface PutSlotTypeRequest {
 
 export namespace PutSlotTypeRequest {
   export function isa(o: any): o is PutSlotTypeRequest {
-    return _smithy.isa(o, "PutSlotTypeRequest");
+    return __isa(o, "PutSlotTypeRequest");
   }
 }
 
@@ -3326,7 +3325,7 @@ export interface PutSlotTypeResponse extends $MetadataBearer {
 
 export namespace PutSlotTypeResponse {
   export function isa(o: any): o is PutSlotTypeResponse {
-    return _smithy.isa(o, "PutSlotTypeResponse");
+    return __isa(o, "PutSlotTypeResponse");
   }
 }
 
@@ -3353,7 +3352,7 @@ export enum ReferenceType {
  *          </p>
  */
 export interface ResourceInUseException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceInUseException";
   $fault: "client";
@@ -3369,7 +3368,7 @@ export interface ResourceInUseException
 
 export namespace ResourceInUseException {
   export function isa(o: any): o is ResourceInUseException {
-    return _smithy.isa(o, "ResourceInUseException");
+    return __isa(o, "ResourceInUseException");
   }
 }
 
@@ -3395,7 +3394,7 @@ export interface ResourceReference {
 
 export namespace ResourceReference {
   export function isa(o: any): o is ResourceReference {
-    return _smithy.isa(o, "ResourceReference");
+    return __isa(o, "ResourceReference");
   }
 }
 
@@ -3475,7 +3474,7 @@ export interface Slot {
 
 export namespace Slot {
   export function isa(o: any): o is Slot {
-    return _smithy.isa(o, "Slot");
+    return __isa(o, "Slot");
   }
 }
 
@@ -3518,7 +3517,7 @@ export interface SlotTypeMetadata {
 
 export namespace SlotTypeMetadata {
   export function isa(o: any): o is SlotTypeMetadata {
-    return _smithy.isa(o, "SlotTypeMetadata");
+    return __isa(o, "SlotTypeMetadata");
   }
 }
 
@@ -3570,7 +3569,7 @@ export interface StartImportRequest {
 
 export namespace StartImportRequest {
   export function isa(o: any): o is StartImportRequest {
-    return _smithy.isa(o, "StartImportRequest");
+    return __isa(o, "StartImportRequest");
   }
 }
 
@@ -3610,7 +3609,7 @@ export interface StartImportResponse extends $MetadataBearer {
 
 export namespace StartImportResponse {
   export function isa(o: any): o is StartImportResponse {
-    return _smithy.isa(o, "StartImportResponse");
+    return __isa(o, "StartImportResponse");
   }
 }
 
@@ -3635,7 +3634,7 @@ export interface Statement {
 
 export namespace Statement {
   export function isa(o: any): o is Statement {
-    return _smithy.isa(o, "Statement");
+    return __isa(o, "Statement");
   }
 }
 
@@ -3686,7 +3685,7 @@ export interface UtteranceData {
 
 export namespace UtteranceData {
   export function isa(o: any): o is UtteranceData {
-    return _smithy.isa(o, "UtteranceData");
+    return __isa(o, "UtteranceData");
   }
 }
 
@@ -3710,6 +3709,6 @@ export interface UtteranceList {
 
 export namespace UtteranceList {
   export function isa(o: any): o is UtteranceList {
-    return _smithy.isa(o, "UtteranceList");
+    return __isa(o, "UtteranceList");
   }
 }

--- a/clients/client-lex-model-building-service/protocols/Aws_restJson1_1.ts
+++ b/clients/client-lex-model-building-service/protocols/Aws_restJson1_1.ts
@@ -180,7 +180,10 @@ import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  extendedEncodeURIComponent as __extendedEncodeURIComponent
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -196,13 +199,13 @@ export async function serializeAws_restJson1_1CreateBotVersionCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/bots/{name}/versions";
   if (input.name !== undefined) {
-    const labelValue: string = input.name.toString();
+    const labelValue: string = input.name;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: name.");
     }
     resolvedPath = resolvedPath.replace(
       "{name}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: name.");
@@ -231,13 +234,13 @@ export async function serializeAws_restJson1_1CreateIntentVersionCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/intents/{name}/versions";
   if (input.name !== undefined) {
-    const labelValue: string = input.name.toString();
+    const labelValue: string = input.name;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: name.");
     }
     resolvedPath = resolvedPath.replace(
       "{name}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: name.");
@@ -266,13 +269,13 @@ export async function serializeAws_restJson1_1CreateSlotTypeVersionCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/slottypes/{name}/versions";
   if (input.name !== undefined) {
-    const labelValue: string = input.name.toString();
+    const labelValue: string = input.name;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: name.");
     }
     resolvedPath = resolvedPath.replace(
       "{name}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: name.");
@@ -301,13 +304,13 @@ export async function serializeAws_restJson1_1DeleteBotCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/bots/{name}";
   if (input.name !== undefined) {
-    const labelValue: string = input.name.toString();
+    const labelValue: string = input.name;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: name.");
     }
     resolvedPath = resolvedPath.replace(
       "{name}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: name.");
@@ -329,25 +332,25 @@ export async function serializeAws_restJson1_1DeleteBotAliasCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/bots/{botName}/aliases/{name}";
   if (input.botName !== undefined) {
-    const labelValue: string = input.botName.toString();
+    const labelValue: string = input.botName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: botName.");
     }
     resolvedPath = resolvedPath.replace(
       "{botName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: botName.");
   }
   if (input.name !== undefined) {
-    const labelValue: string = input.name.toString();
+    const labelValue: string = input.name;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: name.");
     }
     resolvedPath = resolvedPath.replace(
       "{name}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: name.");
@@ -369,37 +372,37 @@ export async function serializeAws_restJson1_1DeleteBotChannelAssociationCommand
   headers["Content-Type"] = "";
   let resolvedPath = "/bots/{botName}/aliases/{botAlias}/channels/{name}";
   if (input.botAlias !== undefined) {
-    const labelValue: string = input.botAlias.toString();
+    const labelValue: string = input.botAlias;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: botAlias.");
     }
     resolvedPath = resolvedPath.replace(
       "{botAlias}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: botAlias.");
   }
   if (input.botName !== undefined) {
-    const labelValue: string = input.botName.toString();
+    const labelValue: string = input.botName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: botName.");
     }
     resolvedPath = resolvedPath.replace(
       "{botName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: botName.");
   }
   if (input.name !== undefined) {
-    const labelValue: string = input.name.toString();
+    const labelValue: string = input.name;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: name.");
     }
     resolvedPath = resolvedPath.replace(
       "{name}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: name.");
@@ -421,25 +424,25 @@ export async function serializeAws_restJson1_1DeleteBotVersionCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/bots/{name}/versions/{version}";
   if (input.name !== undefined) {
-    const labelValue: string = input.name.toString();
+    const labelValue: string = input.name;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: name.");
     }
     resolvedPath = resolvedPath.replace(
       "{name}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: name.");
   }
   if (input.version !== undefined) {
-    const labelValue: string = input.version.toString();
+    const labelValue: string = input.version;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: version.");
     }
     resolvedPath = resolvedPath.replace(
       "{version}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: version.");
@@ -461,13 +464,13 @@ export async function serializeAws_restJson1_1DeleteIntentCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/intents/{name}";
   if (input.name !== undefined) {
-    const labelValue: string = input.name.toString();
+    const labelValue: string = input.name;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: name.");
     }
     resolvedPath = resolvedPath.replace(
       "{name}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: name.");
@@ -489,25 +492,25 @@ export async function serializeAws_restJson1_1DeleteIntentVersionCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/intents/{name}/versions/{version}";
   if (input.name !== undefined) {
-    const labelValue: string = input.name.toString();
+    const labelValue: string = input.name;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: name.");
     }
     resolvedPath = resolvedPath.replace(
       "{name}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: name.");
   }
   if (input.version !== undefined) {
-    const labelValue: string = input.version.toString();
+    const labelValue: string = input.version;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: version.");
     }
     resolvedPath = resolvedPath.replace(
       "{version}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: version.");
@@ -529,13 +532,13 @@ export async function serializeAws_restJson1_1DeleteSlotTypeCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/slottypes/{name}";
   if (input.name !== undefined) {
-    const labelValue: string = input.name.toString();
+    const labelValue: string = input.name;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: name.");
     }
     resolvedPath = resolvedPath.replace(
       "{name}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: name.");
@@ -557,25 +560,25 @@ export async function serializeAws_restJson1_1DeleteSlotTypeVersionCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/slottypes/{name}/version/{version}";
   if (input.name !== undefined) {
-    const labelValue: string = input.name.toString();
+    const labelValue: string = input.name;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: name.");
     }
     resolvedPath = resolvedPath.replace(
       "{name}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: name.");
   }
   if (input.version !== undefined) {
-    const labelValue: string = input.version.toString();
+    const labelValue: string = input.version;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: version.");
     }
     resolvedPath = resolvedPath.replace(
       "{version}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: version.");
@@ -597,25 +600,25 @@ export async function serializeAws_restJson1_1DeleteUtterancesCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/bots/{botName}/utterances/{userId}";
   if (input.botName !== undefined) {
-    const labelValue: string = input.botName.toString();
+    const labelValue: string = input.botName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: botName.");
     }
     resolvedPath = resolvedPath.replace(
       "{botName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: botName.");
   }
   if (input.userId !== undefined) {
-    const labelValue: string = input.userId.toString();
+    const labelValue: string = input.userId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: userId.");
     }
     resolvedPath = resolvedPath.replace(
       "{userId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: userId.");
@@ -637,19 +640,19 @@ export async function serializeAws_restJson1_1GetBotCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/bots/{name}/versions/{versionOrAlias}";
   if (input.name !== undefined) {
-    const labelValue: string = input.name.toString();
+    const labelValue: string = input.name;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: name.");
     }
     resolvedPath = resolvedPath.replace(
       "{name}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: name.");
   }
   if (input.versionOrAlias !== undefined) {
-    const labelValue: string = input.versionOrAlias.toString();
+    const labelValue: string = input.versionOrAlias;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: versionOrAlias."
@@ -657,7 +660,7 @@ export async function serializeAws_restJson1_1GetBotCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{versionOrAlias}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: versionOrAlias.");
@@ -679,25 +682,25 @@ export async function serializeAws_restJson1_1GetBotAliasCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/bots/{botName}/aliases/{name}";
   if (input.botName !== undefined) {
-    const labelValue: string = input.botName.toString();
+    const labelValue: string = input.botName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: botName.");
     }
     resolvedPath = resolvedPath.replace(
       "{botName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: botName.");
   }
   if (input.name !== undefined) {
-    const labelValue: string = input.name.toString();
+    const labelValue: string = input.name;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: name.");
     }
     resolvedPath = resolvedPath.replace(
       "{name}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: name.");
@@ -719,26 +722,32 @@ export async function serializeAws_restJson1_1GetBotAliasesCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/bots/{botName}/aliases";
   if (input.botName !== undefined) {
-    const labelValue: string = input.botName.toString();
+    const labelValue: string = input.botName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: botName.");
     }
     resolvedPath = resolvedPath.replace(
       "{botName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: botName.");
   }
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nameContains !== undefined) {
-    query["nameContains"] = input.nameContains.toString();
+    query[
+      __extendedEncodeURIComponent("nameContains")
+    ] = __extendedEncodeURIComponent(input.nameContains);
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -758,37 +767,37 @@ export async function serializeAws_restJson1_1GetBotChannelAssociationCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/bots/{botName}/aliases/{botAlias}/channels/{name}";
   if (input.botAlias !== undefined) {
-    const labelValue: string = input.botAlias.toString();
+    const labelValue: string = input.botAlias;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: botAlias.");
     }
     resolvedPath = resolvedPath.replace(
       "{botAlias}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: botAlias.");
   }
   if (input.botName !== undefined) {
-    const labelValue: string = input.botName.toString();
+    const labelValue: string = input.botName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: botName.");
     }
     resolvedPath = resolvedPath.replace(
       "{botName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: botName.");
   }
   if (input.name !== undefined) {
-    const labelValue: string = input.name.toString();
+    const labelValue: string = input.name;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: name.");
     }
     resolvedPath = resolvedPath.replace(
       "{name}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: name.");
@@ -810,38 +819,44 @@ export async function serializeAws_restJson1_1GetBotChannelAssociationsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/bots/{botName}/aliases/{botAlias}/channels";
   if (input.botAlias !== undefined) {
-    const labelValue: string = input.botAlias.toString();
+    const labelValue: string = input.botAlias;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: botAlias.");
     }
     resolvedPath = resolvedPath.replace(
       "{botAlias}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: botAlias.");
   }
   if (input.botName !== undefined) {
-    const labelValue: string = input.botName.toString();
+    const labelValue: string = input.botName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: botName.");
     }
     resolvedPath = resolvedPath.replace(
       "{botName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: botName.");
   }
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nameContains !== undefined) {
-    query["nameContains"] = input.nameContains.toString();
+    query[
+      __extendedEncodeURIComponent("nameContains")
+    ] = __extendedEncodeURIComponent(input.nameContains);
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -861,23 +876,27 @@ export async function serializeAws_restJson1_1GetBotVersionsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/bots/{name}/versions";
   if (input.name !== undefined) {
-    const labelValue: string = input.name.toString();
+    const labelValue: string = input.name;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: name.");
     }
     resolvedPath = resolvedPath.replace(
       "{name}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: name.");
   }
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -898,13 +917,19 @@ export async function serializeAws_restJson1_1GetBotsCommand(
   let resolvedPath = "/bots";
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nameContains !== undefined) {
-    query["nameContains"] = input.nameContains.toString();
+    query[
+      __extendedEncodeURIComponent("nameContains")
+    ] = __extendedEncodeURIComponent(input.nameContains);
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -924,13 +949,13 @@ export async function serializeAws_restJson1_1GetBuiltinIntentCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/builtins/intents/{signature}";
   if (input.signature !== undefined) {
-    const labelValue: string = input.signature.toString();
+    const labelValue: string = input.signature;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: signature.");
     }
     resolvedPath = resolvedPath.replace(
       "{signature}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: signature.");
@@ -953,16 +978,24 @@ export async function serializeAws_restJson1_1GetBuiltinIntentsCommand(
   let resolvedPath = "/builtins/intents";
   const query: any = {};
   if (input.locale !== undefined) {
-    query["locale"] = input.locale.toString();
+    query[
+      __extendedEncodeURIComponent("locale")
+    ] = __extendedEncodeURIComponent(input.locale);
   }
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   if (input.signatureContains !== undefined) {
-    query["signatureContains"] = input.signatureContains.toString();
+    query[
+      __extendedEncodeURIComponent("signatureContains")
+    ] = __extendedEncodeURIComponent(input.signatureContains);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -983,16 +1016,24 @@ export async function serializeAws_restJson1_1GetBuiltinSlotTypesCommand(
   let resolvedPath = "/builtins/slottypes";
   const query: any = {};
   if (input.locale !== undefined) {
-    query["locale"] = input.locale.toString();
+    query[
+      __extendedEncodeURIComponent("locale")
+    ] = __extendedEncodeURIComponent(input.locale);
   }
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   if (input.signatureContains !== undefined) {
-    query["signatureContains"] = input.signatureContains.toString();
+    query[
+      __extendedEncodeURIComponent("signatureContains")
+    ] = __extendedEncodeURIComponent(input.signatureContains);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1013,16 +1054,24 @@ export async function serializeAws_restJson1_1GetExportCommand(
   let resolvedPath = "/exports";
   const query: any = {};
   if (input.exportType !== undefined) {
-    query["exportType"] = input.exportType.toString();
+    query[
+      __extendedEncodeURIComponent("exportType")
+    ] = __extendedEncodeURIComponent(input.exportType);
   }
   if (input.name !== undefined) {
-    query["name"] = input.name.toString();
+    query[__extendedEncodeURIComponent("name")] = __extendedEncodeURIComponent(
+      input.name
+    );
   }
   if (input.resourceType !== undefined) {
-    query["resourceType"] = input.resourceType.toString();
+    query[
+      __extendedEncodeURIComponent("resourceType")
+    ] = __extendedEncodeURIComponent(input.resourceType);
   }
   if (input.version !== undefined) {
-    query["version"] = input.version.toString();
+    query[
+      __extendedEncodeURIComponent("version")
+    ] = __extendedEncodeURIComponent(input.version);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1042,13 +1091,13 @@ export async function serializeAws_restJson1_1GetImportCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/imports/{importId}";
   if (input.importId !== undefined) {
-    const labelValue: string = input.importId.toString();
+    const labelValue: string = input.importId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: importId.");
     }
     resolvedPath = resolvedPath.replace(
       "{importId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: importId.");
@@ -1070,25 +1119,25 @@ export async function serializeAws_restJson1_1GetIntentCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/intents/{name}/versions/{version}";
   if (input.name !== undefined) {
-    const labelValue: string = input.name.toString();
+    const labelValue: string = input.name;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: name.");
     }
     resolvedPath = resolvedPath.replace(
       "{name}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: name.");
   }
   if (input.version !== undefined) {
-    const labelValue: string = input.version.toString();
+    const labelValue: string = input.version;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: version.");
     }
     resolvedPath = resolvedPath.replace(
       "{version}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: version.");
@@ -1110,23 +1159,27 @@ export async function serializeAws_restJson1_1GetIntentVersionsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/intents/{name}/versions";
   if (input.name !== undefined) {
-    const labelValue: string = input.name.toString();
+    const labelValue: string = input.name;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: name.");
     }
     resolvedPath = resolvedPath.replace(
       "{name}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: name.");
   }
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1147,13 +1200,19 @@ export async function serializeAws_restJson1_1GetIntentsCommand(
   let resolvedPath = "/intents";
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nameContains !== undefined) {
-    query["nameContains"] = input.nameContains.toString();
+    query[
+      __extendedEncodeURIComponent("nameContains")
+    ] = __extendedEncodeURIComponent(input.nameContains);
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1173,25 +1232,25 @@ export async function serializeAws_restJson1_1GetSlotTypeCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/slottypes/{name}/versions/{version}";
   if (input.name !== undefined) {
-    const labelValue: string = input.name.toString();
+    const labelValue: string = input.name;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: name.");
     }
     resolvedPath = resolvedPath.replace(
       "{name}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: name.");
   }
   if (input.version !== undefined) {
-    const labelValue: string = input.version.toString();
+    const labelValue: string = input.version;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: version.");
     }
     resolvedPath = resolvedPath.replace(
       "{version}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: version.");
@@ -1213,23 +1272,27 @@ export async function serializeAws_restJson1_1GetSlotTypeVersionsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/slottypes/{name}/versions";
   if (input.name !== undefined) {
-    const labelValue: string = input.name.toString();
+    const labelValue: string = input.name;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: name.");
     }
     resolvedPath = resolvedPath.replace(
       "{name}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: name.");
   }
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1250,13 +1313,19 @@ export async function serializeAws_restJson1_1GetSlotTypesCommand(
   let resolvedPath = "/slottypes";
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nameContains !== undefined) {
-    query["nameContains"] = input.nameContains.toString();
+    query[
+      __extendedEncodeURIComponent("nameContains")
+    ] = __extendedEncodeURIComponent(input.nameContains);
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1276,13 +1345,13 @@ export async function serializeAws_restJson1_1GetUtterancesViewCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/bots/{botName}/utterances";
   if (input.botName !== undefined) {
-    const labelValue: string = input.botName.toString();
+    const labelValue: string = input.botName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: botName.");
     }
     resolvedPath = resolvedPath.replace(
       "{botName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: botName.");
@@ -1291,10 +1360,14 @@ export async function serializeAws_restJson1_1GetUtterancesViewCommand(
     view: "aggregation"
   };
   if (input.botVersions !== undefined) {
-    query["bot_versions"] = input.botVersions;
+    query[
+      __extendedEncodeURIComponent("bot_versions")
+    ] = input.botVersions.map(entry => __extendedEncodeURIComponent(entry));
   }
   if (input.statusType !== undefined) {
-    query["status_type"] = input.statusType.toString();
+    query[
+      __extendedEncodeURIComponent("status_type")
+    ] = __extendedEncodeURIComponent(input.statusType);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1314,13 +1387,13 @@ export async function serializeAws_restJson1_1PutBotCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/bots/{name}/versions/$LATEST";
   if (input.name !== undefined) {
-    const labelValue: string = input.name.toString();
+    const labelValue: string = input.name;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: name.");
     }
     resolvedPath = resolvedPath.replace(
       "{name}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: name.");
@@ -1391,25 +1464,25 @@ export async function serializeAws_restJson1_1PutBotAliasCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/bots/{botName}/aliases/{name}";
   if (input.botName !== undefined) {
-    const labelValue: string = input.botName.toString();
+    const labelValue: string = input.botName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: botName.");
     }
     resolvedPath = resolvedPath.replace(
       "{botName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: botName.");
   }
   if (input.name !== undefined) {
-    const labelValue: string = input.name.toString();
+    const labelValue: string = input.name;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: name.");
     }
     resolvedPath = resolvedPath.replace(
       "{name}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: name.");
@@ -1452,13 +1525,13 @@ export async function serializeAws_restJson1_1PutIntentCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/intents/{name}/versions/$LATEST";
   if (input.name !== undefined) {
-    const labelValue: string = input.name.toString();
+    const labelValue: string = input.name;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: name.");
     }
     resolvedPath = resolvedPath.replace(
       "{name}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: name.");
@@ -1548,13 +1621,13 @@ export async function serializeAws_restJson1_1PutSlotTypeCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/slottypes/{name}/versions/$LATEST";
   if (input.name !== undefined) {
-    const labelValue: string = input.name.toString();
+    const labelValue: string = input.name;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: name.");
     }
     resolvedPath = resolvedPath.replace(
       "{name}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: name.");
@@ -2109,6 +2182,7 @@ export async function deserializeAws_restJson1_1DeleteBotCommand(
   const contents: DeleteBotCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2194,6 +2268,7 @@ export async function deserializeAws_restJson1_1DeleteBotAliasCommand(
   const contents: DeleteBotAliasCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2279,6 +2354,7 @@ export async function deserializeAws_restJson1_1DeleteBotChannelAssociationComma
   const contents: DeleteBotChannelAssociationCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2357,6 +2433,7 @@ export async function deserializeAws_restJson1_1DeleteBotVersionCommand(
   const contents: DeleteBotVersionCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2439,6 +2516,7 @@ export async function deserializeAws_restJson1_1DeleteIntentCommand(
   const contents: DeleteIntentCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2524,6 +2602,7 @@ export async function deserializeAws_restJson1_1DeleteIntentVersionCommand(
   const contents: DeleteIntentVersionCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2609,6 +2688,7 @@ export async function deserializeAws_restJson1_1DeleteSlotTypeCommand(
   const contents: DeleteSlotTypeCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2694,6 +2774,7 @@ export async function deserializeAws_restJson1_1DeleteSlotTypeVersionCommand(
   const contents: DeleteSlotTypeVersionCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2779,6 +2860,7 @@ export async function deserializeAws_restJson1_1DeleteUtterancesCommand(
   const contents: DeleteUtterancesCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 

--- a/clients/client-lex-runtime-service/models/index.ts
+++ b/clients/client-lex-runtime-service/models/index.ts
@@ -1,4 +1,8 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  LazyJsonString as __LazyJsonString,
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -6,7 +10,7 @@ import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
  *       failed, is still in progress, or contains unbuilt changes. </p>
  */
 export interface BadRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "BadRequestException";
   $fault: "client";
@@ -15,16 +19,14 @@ export interface BadRequestException
 
 export namespace BadRequestException {
   export function isa(o: any): o is BadRequestException {
-    return _smithy.isa(o, "BadRequestException");
+    return __isa(o, "BadRequestException");
   }
 }
 
 /**
  * <p> Two clients are using the same AWS account, Amazon Lex bot, and user ID. </p>
  */
-export interface ConflictException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface ConflictException extends __SmithyException, $MetadataBearer {
   name: "ConflictException";
   $fault: "client";
   message?: string;
@@ -32,7 +34,7 @@ export interface ConflictException
 
 export namespace ConflictException {
   export function isa(o: any): o is ConflictException {
-    return _smithy.isa(o, "ConflictException");
+    return __isa(o, "ConflictException");
   }
 }
 
@@ -40,7 +42,7 @@ export namespace ConflictException {
  * <p>Internal service error. Retry the call.</p>
  */
 export interface InternalFailureException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalFailureException";
   $fault: "server";
@@ -49,7 +51,7 @@ export interface InternalFailureException
 
 export namespace InternalFailureException {
   export function isa(o: any): o is InternalFailureException {
-    return _smithy.isa(o, "InternalFailureException");
+    return __isa(o, "InternalFailureException");
   }
 }
 
@@ -57,7 +59,7 @@ export namespace InternalFailureException {
  * <p>Exceeded a limit.</p>
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -67,7 +69,7 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
@@ -75,7 +77,7 @@ export namespace LimitExceededException {
  * <p>The accept header in the request does not have a valid value.</p>
  */
 export interface NotAcceptableException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "NotAcceptableException";
   $fault: "client";
@@ -84,7 +86,7 @@ export interface NotAcceptableException
 
 export namespace NotAcceptableException {
   export function isa(o: any): o is NotAcceptableException {
-    return _smithy.isa(o, "NotAcceptableException");
+    return __isa(o, "NotAcceptableException");
   }
 }
 
@@ -92,9 +94,7 @@ export namespace NotAcceptableException {
  * <p>The resource (such as the Amazon Lex bot or an alias) that is referred to is not
  *       found.</p>
  */
-export interface NotFoundException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface NotFoundException extends __SmithyException, $MetadataBearer {
   name: "NotFoundException";
   $fault: "client";
   message?: string;
@@ -102,7 +102,7 @@ export interface NotFoundException
 
 export namespace NotFoundException {
   export function isa(o: any): o is NotFoundException {
-    return _smithy.isa(o, "NotFoundException");
+    return __isa(o, "NotFoundException");
   }
 }
 
@@ -110,7 +110,7 @@ export namespace NotFoundException {
  * <p>The input speech is too long.</p>
  */
 export interface RequestTimeoutException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "RequestTimeoutException";
   $fault: "client";
@@ -119,7 +119,7 @@ export interface RequestTimeoutException
 
 export namespace RequestTimeoutException {
   export function isa(o: any): o is RequestTimeoutException {
-    return _smithy.isa(o, "RequestTimeoutException");
+    return __isa(o, "RequestTimeoutException");
   }
 }
 
@@ -127,7 +127,7 @@ export namespace RequestTimeoutException {
  * <p>The Content-Type header (<code>PostContent</code> API) has an invalid value. </p>
  */
 export interface UnsupportedMediaTypeException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UnsupportedMediaTypeException";
   $fault: "client";
@@ -136,7 +136,7 @@ export interface UnsupportedMediaTypeException
 
 export namespace UnsupportedMediaTypeException {
   export function isa(o: any): o is UnsupportedMediaTypeException {
-    return _smithy.isa(o, "UnsupportedMediaTypeException");
+    return __isa(o, "UnsupportedMediaTypeException");
   }
 }
 
@@ -145,7 +145,7 @@ export namespace UnsupportedMediaTypeException {
  *       AWS Lambda) failed with an internal service error.</p>
  */
 export interface BadGatewayException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "BadGatewayException";
   $fault: "server";
@@ -154,7 +154,7 @@ export interface BadGatewayException
 
 export namespace BadGatewayException {
   export function isa(o: any): o is BadGatewayException {
-    return _smithy.isa(o, "BadGatewayException");
+    return __isa(o, "BadGatewayException");
   }
 }
 
@@ -184,7 +184,7 @@ export interface DeleteSessionRequest {
 
 export namespace DeleteSessionRequest {
   export function isa(o: any): o is DeleteSessionRequest {
-    return _smithy.isa(o, "DeleteSessionRequest");
+    return __isa(o, "DeleteSessionRequest");
   }
 }
 
@@ -213,7 +213,7 @@ export interface DeleteSessionResponse extends $MetadataBearer {
 
 export namespace DeleteSessionResponse {
   export function isa(o: any): o is DeleteSessionResponse {
-    return _smithy.isa(o, "DeleteSessionResponse");
+    return __isa(o, "DeleteSessionResponse");
   }
 }
 
@@ -233,7 +233,7 @@ export namespace DeleteSessionResponse {
  *          </ul>
  */
 export interface DependencyFailedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DependencyFailedException";
   $fault: "client";
@@ -242,7 +242,7 @@ export interface DependencyFailedException
 
 export namespace DependencyFailedException {
   export function isa(o: any): o is DependencyFailedException {
-    return _smithy.isa(o, "DependencyFailedException");
+    return __isa(o, "DependencyFailedException");
   }
 }
 
@@ -358,7 +358,7 @@ export interface DialogAction {
 
 export namespace DialogAction {
   export function isa(o: any): o is DialogAction {
-    return _smithy.isa(o, "DialogAction");
+    return __isa(o, "DialogAction");
   }
 }
 
@@ -414,7 +414,7 @@ export interface GetSessionRequest {
 
 export namespace GetSessionRequest {
   export function isa(o: any): o is GetSessionRequest {
-    return _smithy.isa(o, "GetSessionRequest");
+    return __isa(o, "GetSessionRequest");
   }
 }
 
@@ -449,7 +449,7 @@ export interface GetSessionResponse extends $MetadataBearer {
 
 export namespace GetSessionResponse {
   export function isa(o: any): o is GetSessionResponse {
-    return _smithy.isa(o, "GetSessionResponse");
+    return __isa(o, "GetSessionResponse");
   }
 }
 
@@ -563,7 +563,7 @@ export interface IntentSummary {
 
 export namespace IntentSummary {
   export function isa(o: any): o is IntentSummary {
-    return _smithy.isa(o, "IntentSummary");
+    return __isa(o, "IntentSummary");
   }
 }
 
@@ -571,7 +571,7 @@ export namespace IntentSummary {
  * <p>This exception is not used.</p>
  */
 export interface LoopDetectedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LoopDetectedException";
   $fault: "server";
@@ -580,7 +580,7 @@ export interface LoopDetectedException
 
 export namespace LoopDetectedException {
   export function isa(o: any): o is LoopDetectedException {
-    return _smithy.isa(o, "LoopDetectedException");
+    return __isa(o, "LoopDetectedException");
   }
 }
 
@@ -708,7 +708,7 @@ export interface PostContentRequest {
    *          <p>For more information, see <a href="https://docs.aws.amazon.com/lex/latest/dg/context-mgmt.html#context-mgmt-request-attribs">Setting Request
    *         Attributes</a>.</p>
    */
-  requestAttributes?: string;
+  requestAttributes?: __LazyJsonString | string;
 
   /**
    * <p>You pass this value as the <code>x-amz-lex-session-attributes</code> HTTP header.</p>
@@ -719,7 +719,7 @@ export interface PostContentRequest {
    *          <p>For more information, see <a href="https://docs.aws.amazon.com/lex/latest/dg/context-mgmt.html#context-mgmt-session-attribs">Setting Session
    *         Attributes</a>.</p>
    */
-  sessionAttributes?: string;
+  sessionAttributes?: __LazyJsonString | string;
 
   /**
    * <p>The ID of the client application user. Amazon Lex uses this to identify a user's conversation
@@ -753,7 +753,7 @@ export interface PostContentRequest {
 
 export namespace PostContentRequest {
   export function isa(o: any): o is PostContentRequest {
-    return _smithy.isa(o, "PostContentRequest");
+    return __isa(o, "PostContentRequest");
   }
 }
 
@@ -892,7 +892,7 @@ export interface PostContentResponse extends $MetadataBearer {
   /**
    * <p> Map of key/value pairs representing the session-specific context information. </p>
    */
-  sessionAttributes?: string;
+  sessionAttributes?: __LazyJsonString | string;
 
   /**
    * <p>The unique identifier for the session.</p>
@@ -917,12 +917,12 @@ export interface PostContentResponse extends $MetadataBearer {
    *       there is no resolution list, null. If you don't specify a <code>valueSelectionStrategy</code>,
    *       the default is <code>ORIGINAL_VALUE</code>.</p>
    */
-  slots?: string;
+  slots?: __LazyJsonString | string;
 }
 
 export namespace PostContentResponse {
   export function isa(o: any): o is PostContentResponse {
-    return _smithy.isa(o, "PostContentResponse");
+    return __isa(o, "PostContentResponse");
   }
 }
 
@@ -991,7 +991,7 @@ export interface PostTextRequest {
 
 export namespace PostTextRequest {
   export function isa(o: any): o is PostTextRequest {
-    return _smithy.isa(o, "PostTextRequest");
+    return __isa(o, "PostTextRequest");
   }
 }
 
@@ -1142,7 +1142,7 @@ export interface PostTextResponse extends $MetadataBearer {
 
 export namespace PostTextResponse {
   export function isa(o: any): o is PostTextResponse {
-    return _smithy.isa(o, "PostTextResponse");
+    return __isa(o, "PostTextResponse");
   }
 }
 
@@ -1258,7 +1258,7 @@ export interface PutSessionRequest {
 
 export namespace PutSessionRequest {
   export function isa(o: any): o is PutSessionRequest {
-    return _smithy.isa(o, "PutSessionRequest");
+    return __isa(o, "PutSessionRequest");
   }
 }
 
@@ -1349,7 +1349,7 @@ export interface PutSessionResponse extends $MetadataBearer {
   /**
    * <p>Map of key/value pairs representing session-specific context information.</p>
    */
-  sessionAttributes?: string;
+  sessionAttributes?: __LazyJsonString | string;
 
   /**
    * <p>A unique identifier for the session.</p>
@@ -1374,12 +1374,12 @@ export interface PutSessionResponse extends $MetadataBearer {
    *       there is no resolution list, null. If you don't specify a <code>valueSelectionStrategy</code>
    *       the default is <code>ORIGINAL_VALUE</code>. </p>
    */
-  slots?: string;
+  slots?: __LazyJsonString | string;
 }
 
 export namespace PutSessionResponse {
   export function isa(o: any): o is PutSessionResponse {
-    return _smithy.isa(o, "PutSessionResponse");
+    return __isa(o, "PutSessionResponse");
   }
 }
 
@@ -1403,7 +1403,7 @@ export interface SentimentResponse {
 
 export namespace SentimentResponse {
   export function isa(o: any): o is SentimentResponse {
-    return _smithy.isa(o, "SentimentResponse");
+    return __isa(o, "SentimentResponse");
   }
 }
 
@@ -1426,7 +1426,7 @@ export interface Button {
 
 export namespace Button {
   export function isa(o: any): o is Button {
-    return _smithy.isa(o, "Button");
+    return __isa(o, "Button");
   }
 }
 
@@ -1468,7 +1468,7 @@ export interface GenericAttachment {
 
 export namespace GenericAttachment {
   export function isa(o: any): o is GenericAttachment {
-    return _smithy.isa(o, "GenericAttachment");
+    return __isa(o, "GenericAttachment");
   }
 }
 
@@ -1498,6 +1498,6 @@ export interface ResponseCard {
 
 export namespace ResponseCard {
   export function isa(o: any): o is ResponseCard {
-    return _smithy.isa(o, "ResponseCard");
+    return __isa(o, "ResponseCard");
   }
 }

--- a/clients/client-lex-runtime-service/protocols/Aws_restJson1_1.ts
+++ b/clients/client-lex-runtime-service/protocols/Aws_restJson1_1.ts
@@ -41,7 +41,11 @@ import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  LazyJsonString as __LazyJsonString,
+  SmithyException as __SmithyException,
+  extendedEncodeURIComponent as __extendedEncodeURIComponent
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -57,37 +61,37 @@ export async function serializeAws_restJson1_1DeleteSessionCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/bot/{botName}/alias/{botAlias}/user/{userId}/session";
   if (input.botAlias !== undefined) {
-    const labelValue: string = input.botAlias.toString();
+    const labelValue: string = input.botAlias;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: botAlias.");
     }
     resolvedPath = resolvedPath.replace(
       "{botAlias}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: botAlias.");
   }
   if (input.botName !== undefined) {
-    const labelValue: string = input.botName.toString();
+    const labelValue: string = input.botName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: botName.");
     }
     resolvedPath = resolvedPath.replace(
       "{botName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: botName.");
   }
   if (input.userId !== undefined) {
-    const labelValue: string = input.userId.toString();
+    const labelValue: string = input.userId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: userId.");
     }
     resolvedPath = resolvedPath.replace(
       "{userId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: userId.");
@@ -109,44 +113,46 @@ export async function serializeAws_restJson1_1GetSessionCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/bot/{botName}/alias/{botAlias}/user/{userId}/session";
   if (input.botAlias !== undefined) {
-    const labelValue: string = input.botAlias.toString();
+    const labelValue: string = input.botAlias;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: botAlias.");
     }
     resolvedPath = resolvedPath.replace(
       "{botAlias}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: botAlias.");
   }
   if (input.botName !== undefined) {
-    const labelValue: string = input.botName.toString();
+    const labelValue: string = input.botName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: botName.");
     }
     resolvedPath = resolvedPath.replace(
       "{botName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: botName.");
   }
   if (input.userId !== undefined) {
-    const labelValue: string = input.userId.toString();
+    const labelValue: string = input.userId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: userId.");
     }
     resolvedPath = resolvedPath.replace(
       "{userId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: userId.");
   }
   const query: any = {};
   if (input.checkpointLabelFilter !== undefined) {
-    query["checkpointLabelFilter"] = input.checkpointLabelFilter.toString();
+    query[
+      __extendedEncodeURIComponent("checkpointLabelFilter")
+    ] = __extendedEncodeURIComponent(input.checkpointLabelFilter);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -166,54 +172,54 @@ export async function serializeAws_restJson1_1PostContentCommand(
   headers["Content-Type"] = "application/octet-stream";
   headers["x-amz-content-sha256"] = "UNSIGNED_PAYLOAD";
   if (input.accept !== undefined) {
-    headers["Accept"] = input.accept.toString();
+    headers["Accept"] = input.accept;
   }
   if (input.contentType !== undefined) {
-    headers["Content-Type"] = input.contentType.toString();
+    headers["Content-Type"] = input.contentType;
   }
   if (input.requestAttributes !== undefined) {
-    headers[
-      "x-amz-lex-request-attributes"
-    ] = input.requestAttributes.toString();
+    headers["x-amz-lex-request-attributes"] = __LazyJsonString.fromObject(
+      input.requestAttributes
+    );
   }
   if (input.sessionAttributes !== undefined) {
-    headers[
-      "x-amz-lex-session-attributes"
-    ] = input.sessionAttributes.toString();
+    headers["x-amz-lex-session-attributes"] = __LazyJsonString.fromObject(
+      input.sessionAttributes
+    );
   }
   let resolvedPath = "/bot/{botName}/alias/{botAlias}/user/{userId}/content";
   if (input.botAlias !== undefined) {
-    const labelValue: string = input.botAlias.toString();
+    const labelValue: string = input.botAlias;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: botAlias.");
     }
     resolvedPath = resolvedPath.replace(
       "{botAlias}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: botAlias.");
   }
   if (input.botName !== undefined) {
-    const labelValue: string = input.botName.toString();
+    const labelValue: string = input.botName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: botName.");
     }
     resolvedPath = resolvedPath.replace(
       "{botName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: botName.");
   }
   if (input.userId !== undefined) {
-    const labelValue: string = input.userId.toString();
+    const labelValue: string = input.userId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: userId.");
     }
     resolvedPath = resolvedPath.replace(
       "{userId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: userId.");
@@ -240,37 +246,37 @@ export async function serializeAws_restJson1_1PostTextCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/bot/{botName}/alias/{botAlias}/user/{userId}/text";
   if (input.botAlias !== undefined) {
-    const labelValue: string = input.botAlias.toString();
+    const labelValue: string = input.botAlias;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: botAlias.");
     }
     resolvedPath = resolvedPath.replace(
       "{botAlias}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: botAlias.");
   }
   if (input.botName !== undefined) {
-    const labelValue: string = input.botName.toString();
+    const labelValue: string = input.botName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: botName.");
     }
     resolvedPath = resolvedPath.replace(
       "{botName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: botName.");
   }
   if (input.userId !== undefined) {
-    const labelValue: string = input.userId.toString();
+    const labelValue: string = input.userId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: userId.");
     }
     resolvedPath = resolvedPath.replace(
       "{userId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: userId.");
@@ -310,41 +316,41 @@ export async function serializeAws_restJson1_1PutSessionCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.accept !== undefined) {
-    headers["Accept"] = input.accept.toString();
+    headers["Accept"] = input.accept;
   }
   let resolvedPath = "/bot/{botName}/alias/{botAlias}/user/{userId}/session";
   if (input.botAlias !== undefined) {
-    const labelValue: string = input.botAlias.toString();
+    const labelValue: string = input.botAlias;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: botAlias.");
     }
     resolvedPath = resolvedPath.replace(
       "{botAlias}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: botAlias.");
   }
   if (input.botName !== undefined) {
-    const labelValue: string = input.botName.toString();
+    const labelValue: string = input.botName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: botName.");
     }
     resolvedPath = resolvedPath.replace(
       "{botName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: botName.");
   }
   if (input.userId !== undefined) {
-    const labelValue: string = input.userId.toString();
+    const labelValue: string = input.userId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: userId.");
     }
     resolvedPath = resolvedPath.replace(
       "{userId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: userId.");
@@ -618,7 +624,9 @@ export async function deserializeAws_restJson1_1PostContentCommand(
     contents.sentimentResponse = output.headers["x-amz-lex-sentiment"];
   }
   if (output.headers["x-amz-lex-session-attributes"] !== undefined) {
-    contents.sessionAttributes = output.headers["x-amz-lex-session-attributes"];
+    contents.sessionAttributes = new __LazyJsonString(
+      output.headers["x-amz-lex-session-attributes"]
+    );
   }
   if (output.headers["x-amz-lex-session-id"] !== undefined) {
     contents.sessionId = output.headers["x-amz-lex-session-id"];
@@ -627,7 +635,7 @@ export async function deserializeAws_restJson1_1PostContentCommand(
     contents.slotToElicit = output.headers["x-amz-lex-slot-to-elicit"];
   }
   if (output.headers["x-amz-lex-slots"] !== undefined) {
-    contents.slots = output.headers["x-amz-lex-slots"];
+    contents.slots = new __LazyJsonString(output.headers["x-amz-lex-slots"]);
   }
   const data: any = output.body;
   contents.audioStream = data;
@@ -922,7 +930,9 @@ export async function deserializeAws_restJson1_1PutSessionCommand(
     contents.messageFormat = output.headers["x-amz-lex-message-format"];
   }
   if (output.headers["x-amz-lex-session-attributes"] !== undefined) {
-    contents.sessionAttributes = output.headers["x-amz-lex-session-attributes"];
+    contents.sessionAttributes = new __LazyJsonString(
+      output.headers["x-amz-lex-session-attributes"]
+    );
   }
   if (output.headers["x-amz-lex-session-id"] !== undefined) {
     contents.sessionId = output.headers["x-amz-lex-session-id"];
@@ -931,7 +941,7 @@ export async function deserializeAws_restJson1_1PutSessionCommand(
     contents.slotToElicit = output.headers["x-amz-lex-slot-to-elicit"];
   }
   if (output.headers["x-amz-lex-slots"] !== undefined) {
-    contents.slots = output.headers["x-amz-lex-slots"];
+    contents.slots = new __LazyJsonString(output.headers["x-amz-lex-slots"]);
   }
   const data: any = output.body;
   contents.audioStream = data;

--- a/clients/client-license-manager/models/index.ts
+++ b/clients/client-license-manager/models/index.ts
@@ -1,11 +1,14 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
  * <p>Access to resource denied.</p>
  */
 export interface AccessDeniedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AccessDeniedException";
   $fault: "client";
@@ -14,7 +17,7 @@ export interface AccessDeniedException
 
 export namespace AccessDeniedException {
   export function isa(o: any): o is AccessDeniedException {
-    return _smithy.isa(o, "AccessDeniedException");
+    return __isa(o, "AccessDeniedException");
   }
 }
 
@@ -23,7 +26,7 @@ export namespace AccessDeniedException {
  *          policy associated with this account.</p>
  */
 export interface AuthorizationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AuthorizationException";
   $fault: "client";
@@ -32,7 +35,7 @@ export interface AuthorizationException
 
 export namespace AuthorizationException {
   export function isa(o: any): o is AuthorizationException {
-    return _smithy.isa(o, "AuthorizationException");
+    return __isa(o, "AuthorizationException");
   }
 }
 
@@ -49,7 +52,7 @@ export interface AutomatedDiscoveryInformation {
 
 export namespace AutomatedDiscoveryInformation {
   export function isa(o: any): o is AutomatedDiscoveryInformation {
-    return _smithy.isa(o, "AutomatedDiscoveryInformation");
+    return __isa(o, "AutomatedDiscoveryInformation");
   }
 }
 
@@ -71,7 +74,7 @@ export interface ConsumedLicenseSummary {
 
 export namespace ConsumedLicenseSummary {
   export function isa(o: any): o is ConsumedLicenseSummary {
-    return _smithy.isa(o, "ConsumedLicenseSummary");
+    return __isa(o, "ConsumedLicenseSummary");
   }
 }
 
@@ -146,7 +149,7 @@ export interface CreateLicenseConfigurationRequest {
 
 export namespace CreateLicenseConfigurationRequest {
   export function isa(o: any): o is CreateLicenseConfigurationRequest {
-    return _smithy.isa(o, "CreateLicenseConfigurationRequest");
+    return __isa(o, "CreateLicenseConfigurationRequest");
   }
 }
 
@@ -160,7 +163,7 @@ export interface CreateLicenseConfigurationResponse extends $MetadataBearer {
 
 export namespace CreateLicenseConfigurationResponse {
   export function isa(o: any): o is CreateLicenseConfigurationResponse {
-    return _smithy.isa(o, "CreateLicenseConfigurationResponse");
+    return __isa(o, "CreateLicenseConfigurationResponse");
   }
 }
 
@@ -174,7 +177,7 @@ export interface DeleteLicenseConfigurationRequest {
 
 export namespace DeleteLicenseConfigurationRequest {
   export function isa(o: any): o is DeleteLicenseConfigurationRequest {
-    return _smithy.isa(o, "DeleteLicenseConfigurationRequest");
+    return __isa(o, "DeleteLicenseConfigurationRequest");
   }
 }
 
@@ -184,7 +187,7 @@ export interface DeleteLicenseConfigurationResponse extends $MetadataBearer {
 
 export namespace DeleteLicenseConfigurationResponse {
   export function isa(o: any): o is DeleteLicenseConfigurationResponse {
-    return _smithy.isa(o, "DeleteLicenseConfigurationResponse");
+    return __isa(o, "DeleteLicenseConfigurationResponse");
   }
 }
 
@@ -192,7 +195,7 @@ export namespace DeleteLicenseConfigurationResponse {
  * <p>A dependency required to run the API is missing.</p>
  */
 export interface FailedDependencyException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "FailedDependencyException";
   $fault: "client";
@@ -201,7 +204,7 @@ export interface FailedDependencyException
 
 export namespace FailedDependencyException {
   export function isa(o: any): o is FailedDependencyException {
-    return _smithy.isa(o, "FailedDependencyException");
+    return __isa(o, "FailedDependencyException");
   }
 }
 
@@ -225,7 +228,7 @@ export interface Filter {
 
 export namespace Filter {
   export function isa(o: any): o is Filter {
-    return _smithy.isa(o, "Filter");
+    return __isa(o, "Filter");
   }
 }
 
@@ -233,7 +236,7 @@ export namespace Filter {
  * <p>The request uses too many filters or too many filter values.</p>
  */
 export interface FilterLimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "FilterLimitExceededException";
   $fault: "client";
@@ -242,7 +245,7 @@ export interface FilterLimitExceededException
 
 export namespace FilterLimitExceededException {
   export function isa(o: any): o is FilterLimitExceededException {
-    return _smithy.isa(o, "FilterLimitExceededException");
+    return __isa(o, "FilterLimitExceededException");
   }
 }
 
@@ -256,7 +259,7 @@ export interface GetLicenseConfigurationRequest {
 
 export namespace GetLicenseConfigurationRequest {
   export function isa(o: any): o is GetLicenseConfigurationRequest {
-    return _smithy.isa(o, "GetLicenseConfigurationRequest");
+    return __isa(o, "GetLicenseConfigurationRequest");
   }
 }
 
@@ -345,7 +348,7 @@ export interface GetLicenseConfigurationResponse extends $MetadataBearer {
 
 export namespace GetLicenseConfigurationResponse {
   export function isa(o: any): o is GetLicenseConfigurationResponse {
-    return _smithy.isa(o, "GetLicenseConfigurationResponse");
+    return __isa(o, "GetLicenseConfigurationResponse");
   }
 }
 
@@ -355,7 +358,7 @@ export interface GetServiceSettingsRequest {
 
 export namespace GetServiceSettingsRequest {
   export function isa(o: any): o is GetServiceSettingsRequest {
-    return _smithy.isa(o, "GetServiceSettingsRequest");
+    return __isa(o, "GetServiceSettingsRequest");
   }
 }
 
@@ -392,7 +395,7 @@ export interface GetServiceSettingsResponse extends $MetadataBearer {
 
 export namespace GetServiceSettingsResponse {
   export function isa(o: any): o is GetServiceSettingsResponse {
-    return _smithy.isa(o, "GetServiceSettingsResponse");
+    return __isa(o, "GetServiceSettingsResponse");
   }
 }
 
@@ -400,7 +403,7 @@ export namespace GetServiceSettingsResponse {
  * <p>One or more parameter values are not valid.</p>
  */
 export interface InvalidParameterValueException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidParameterValueException";
   $fault: "client";
@@ -409,7 +412,7 @@ export interface InvalidParameterValueException
 
 export namespace InvalidParameterValueException {
   export function isa(o: any): o is InvalidParameterValueException {
-    return _smithy.isa(o, "InvalidParameterValueException");
+    return __isa(o, "InvalidParameterValueException");
   }
 }
 
@@ -419,7 +422,7 @@ export namespace InvalidParameterValueException {
  *          down.</p>
  */
 export interface InvalidResourceStateException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidResourceStateException";
   $fault: "client";
@@ -428,7 +431,7 @@ export interface InvalidResourceStateException
 
 export namespace InvalidResourceStateException {
   export function isa(o: any): o is InvalidResourceStateException {
-    return _smithy.isa(o, "InvalidResourceStateException");
+    return __isa(o, "InvalidResourceStateException");
   }
 }
 
@@ -455,7 +458,7 @@ export interface InventoryFilter {
 
 export namespace InventoryFilter {
   export function isa(o: any): o is InventoryFilter {
-    return _smithy.isa(o, "InventoryFilter");
+    return __isa(o, "InventoryFilter");
   }
 }
 
@@ -553,7 +556,7 @@ export interface LicenseConfiguration {
 
 export namespace LicenseConfiguration {
   export function isa(o: any): o is LicenseConfiguration {
-    return _smithy.isa(o, "LicenseConfiguration");
+    return __isa(o, "LicenseConfiguration");
   }
 }
 
@@ -585,7 +588,7 @@ export interface LicenseConfigurationAssociation {
 
 export namespace LicenseConfigurationAssociation {
   export function isa(o: any): o is LicenseConfigurationAssociation {
-    return _smithy.isa(o, "LicenseConfigurationAssociation");
+    return __isa(o, "LicenseConfigurationAssociation");
   }
 }
 
@@ -632,7 +635,7 @@ export interface LicenseConfigurationUsage {
 
 export namespace LicenseConfigurationUsage {
   export function isa(o: any): o is LicenseConfigurationUsage {
-    return _smithy.isa(o, "LicenseConfigurationUsage");
+    return __isa(o, "LicenseConfigurationUsage");
   }
 }
 
@@ -691,7 +694,7 @@ export interface LicenseOperationFailure {
 
 export namespace LicenseOperationFailure {
   export function isa(o: any): o is LicenseOperationFailure {
-    return _smithy.isa(o, "LicenseOperationFailure");
+    return __isa(o, "LicenseOperationFailure");
   }
 }
 
@@ -708,7 +711,7 @@ export interface LicenseSpecification {
 
 export namespace LicenseSpecification {
   export function isa(o: any): o is LicenseSpecification {
-    return _smithy.isa(o, "LicenseSpecification");
+    return __isa(o, "LicenseSpecification");
   }
 }
 
@@ -716,7 +719,7 @@ export namespace LicenseSpecification {
  * <p>You do not have enough licenses available to support a new resource launch.</p>
  */
 export interface LicenseUsageException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LicenseUsageException";
   $fault: "client";
@@ -725,7 +728,7 @@ export interface LicenseUsageException
 
 export namespace LicenseUsageException {
   export function isa(o: any): o is LicenseUsageException {
-    return _smithy.isa(o, "LicenseUsageException");
+    return __isa(o, "LicenseUsageException");
   }
 }
 
@@ -751,7 +754,7 @@ export namespace ListAssociationsForLicenseConfigurationRequest {
   export function isa(
     o: any
   ): o is ListAssociationsForLicenseConfigurationRequest {
-    return _smithy.isa(o, "ListAssociationsForLicenseConfigurationRequest");
+    return __isa(o, "ListAssociationsForLicenseConfigurationRequest");
   }
 }
 
@@ -773,7 +776,7 @@ export namespace ListAssociationsForLicenseConfigurationResponse {
   export function isa(
     o: any
   ): o is ListAssociationsForLicenseConfigurationResponse {
-    return _smithy.isa(o, "ListAssociationsForLicenseConfigurationResponse");
+    return __isa(o, "ListAssociationsForLicenseConfigurationResponse");
   }
 }
 
@@ -799,10 +802,7 @@ export namespace ListFailuresForLicenseConfigurationOperationsRequest {
   export function isa(
     o: any
   ): o is ListFailuresForLicenseConfigurationOperationsRequest {
-    return _smithy.isa(
-      o,
-      "ListFailuresForLicenseConfigurationOperationsRequest"
-    );
+    return __isa(o, "ListFailuresForLicenseConfigurationOperationsRequest");
   }
 }
 
@@ -824,10 +824,7 @@ export namespace ListFailuresForLicenseConfigurationOperationsResponse {
   export function isa(
     o: any
   ): o is ListFailuresForLicenseConfigurationOperationsResponse {
-    return _smithy.isa(
-      o,
-      "ListFailuresForLicenseConfigurationOperationsResponse"
-    );
+    return __isa(o, "ListFailuresForLicenseConfigurationOperationsResponse");
   }
 }
 
@@ -874,7 +871,7 @@ export interface ListLicenseConfigurationsRequest {
 
 export namespace ListLicenseConfigurationsRequest {
   export function isa(o: any): o is ListLicenseConfigurationsRequest {
-    return _smithy.isa(o, "ListLicenseConfigurationsRequest");
+    return __isa(o, "ListLicenseConfigurationsRequest");
   }
 }
 
@@ -893,7 +890,7 @@ export interface ListLicenseConfigurationsResponse extends $MetadataBearer {
 
 export namespace ListLicenseConfigurationsResponse {
   export function isa(o: any): o is ListLicenseConfigurationsResponse {
-    return _smithy.isa(o, "ListLicenseConfigurationsResponse");
+    return __isa(o, "ListLicenseConfigurationsResponse");
   }
 }
 
@@ -919,7 +916,7 @@ export namespace ListLicenseSpecificationsForResourceRequest {
   export function isa(
     o: any
   ): o is ListLicenseSpecificationsForResourceRequest {
-    return _smithy.isa(o, "ListLicenseSpecificationsForResourceRequest");
+    return __isa(o, "ListLicenseSpecificationsForResourceRequest");
   }
 }
 
@@ -941,7 +938,7 @@ export namespace ListLicenseSpecificationsForResourceResponse {
   export function isa(
     o: any
   ): o is ListLicenseSpecificationsForResourceResponse {
-    return _smithy.isa(o, "ListLicenseSpecificationsForResourceResponse");
+    return __isa(o, "ListLicenseSpecificationsForResourceResponse");
   }
 }
 
@@ -997,7 +994,7 @@ export interface ListResourceInventoryRequest {
 
 export namespace ListResourceInventoryRequest {
   export function isa(o: any): o is ListResourceInventoryRequest {
-    return _smithy.isa(o, "ListResourceInventoryRequest");
+    return __isa(o, "ListResourceInventoryRequest");
   }
 }
 
@@ -1016,7 +1013,7 @@ export interface ListResourceInventoryResponse extends $MetadataBearer {
 
 export namespace ListResourceInventoryResponse {
   export function isa(o: any): o is ListResourceInventoryResponse {
-    return _smithy.isa(o, "ListResourceInventoryResponse");
+    return __isa(o, "ListResourceInventoryResponse");
   }
 }
 
@@ -1030,7 +1027,7 @@ export interface ListTagsForResourceRequest {
 
 export namespace ListTagsForResourceRequest {
   export function isa(o: any): o is ListTagsForResourceRequest {
-    return _smithy.isa(o, "ListTagsForResourceRequest");
+    return __isa(o, "ListTagsForResourceRequest");
   }
 }
 
@@ -1044,7 +1041,7 @@ export interface ListTagsForResourceResponse extends $MetadataBearer {
 
 export namespace ListTagsForResourceResponse {
   export function isa(o: any): o is ListTagsForResourceResponse {
-    return _smithy.isa(o, "ListTagsForResourceResponse");
+    return __isa(o, "ListTagsForResourceResponse");
   }
 }
 
@@ -1091,7 +1088,7 @@ export interface ListUsageForLicenseConfigurationRequest {
 
 export namespace ListUsageForLicenseConfigurationRequest {
   export function isa(o: any): o is ListUsageForLicenseConfigurationRequest {
-    return _smithy.isa(o, "ListUsageForLicenseConfigurationRequest");
+    return __isa(o, "ListUsageForLicenseConfigurationRequest");
   }
 }
 
@@ -1111,7 +1108,7 @@ export interface ListUsageForLicenseConfigurationResponse
 
 export namespace ListUsageForLicenseConfigurationResponse {
   export function isa(o: any): o is ListUsageForLicenseConfigurationResponse {
-    return _smithy.isa(o, "ListUsageForLicenseConfigurationResponse");
+    return __isa(o, "ListUsageForLicenseConfigurationResponse");
   }
 }
 
@@ -1133,7 +1130,7 @@ export interface ManagedResourceSummary {
 
 export namespace ManagedResourceSummary {
   export function isa(o: any): o is ManagedResourceSummary {
-    return _smithy.isa(o, "ManagedResourceSummary");
+    return __isa(o, "ManagedResourceSummary");
   }
 }
 
@@ -1155,7 +1152,7 @@ export interface Metadata {
 
 export namespace Metadata {
   export function isa(o: any): o is Metadata {
-    return _smithy.isa(o, "Metadata");
+    return __isa(o, "Metadata");
   }
 }
 
@@ -1172,7 +1169,7 @@ export interface OrganizationConfiguration {
 
 export namespace OrganizationConfiguration {
   export function isa(o: any): o is OrganizationConfiguration {
-    return _smithy.isa(o, "OrganizationConfiguration");
+    return __isa(o, "OrganizationConfiguration");
   }
 }
 
@@ -1231,7 +1228,7 @@ export interface ProductInformation {
 
 export namespace ProductInformation {
   export function isa(o: any): o is ProductInformation {
-    return _smithy.isa(o, "ProductInformation");
+    return __isa(o, "ProductInformation");
   }
 }
 
@@ -1258,7 +1255,7 @@ export interface ProductInformationFilter {
 
 export namespace ProductInformationFilter {
   export function isa(o: any): o is ProductInformationFilter {
-    return _smithy.isa(o, "ProductInformationFilter");
+    return __isa(o, "ProductInformationFilter");
   }
 }
 
@@ -1266,7 +1263,7 @@ export namespace ProductInformationFilter {
  * <p>Too many requests have been submitted. Try again after a brief wait.</p>
  */
 export interface RateLimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "RateLimitExceededException";
   $fault: "client";
@@ -1275,7 +1272,7 @@ export interface RateLimitExceededException
 
 export namespace RateLimitExceededException {
   export function isa(o: any): o is RateLimitExceededException {
-    return _smithy.isa(o, "RateLimitExceededException");
+    return __isa(o, "RateLimitExceededException");
   }
 }
 
@@ -1317,7 +1314,7 @@ export interface ResourceInventory {
 
 export namespace ResourceInventory {
   export function isa(o: any): o is ResourceInventory {
-    return _smithy.isa(o, "ResourceInventory");
+    return __isa(o, "ResourceInventory");
   }
 }
 
@@ -1325,7 +1322,7 @@ export namespace ResourceInventory {
  * <p>Your resource limits have been exceeded.</p>
  */
 export interface ResourceLimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceLimitExceededException";
   $fault: "client";
@@ -1334,7 +1331,7 @@ export interface ResourceLimitExceededException
 
 export namespace ResourceLimitExceededException {
   export function isa(o: any): o is ResourceLimitExceededException {
-    return _smithy.isa(o, "ResourceLimitExceededException");
+    return __isa(o, "ResourceLimitExceededException");
   }
 }
 
@@ -1350,7 +1347,7 @@ export enum ResourceType {
  * <p>The server experienced an internal error. Try again.</p>
  */
 export interface ServerInternalException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ServerInternalException";
   $fault: "server";
@@ -1359,7 +1356,7 @@ export interface ServerInternalException
 
 export namespace ServerInternalException {
   export function isa(o: any): o is ServerInternalException {
-    return _smithy.isa(o, "ServerInternalException");
+    return __isa(o, "ServerInternalException");
   }
 }
 
@@ -1381,7 +1378,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -1400,7 +1397,7 @@ export interface TagResourceRequest {
 
 export namespace TagResourceRequest {
   export function isa(o: any): o is TagResourceRequest {
-    return _smithy.isa(o, "TagResourceRequest");
+    return __isa(o, "TagResourceRequest");
   }
 }
 
@@ -1410,7 +1407,7 @@ export interface TagResourceResponse extends $MetadataBearer {
 
 export namespace TagResourceResponse {
   export function isa(o: any): o is TagResourceResponse {
-    return _smithy.isa(o, "TagResourceResponse");
+    return __isa(o, "TagResourceResponse");
   }
 }
 
@@ -1429,7 +1426,7 @@ export interface UntagResourceRequest {
 
 export namespace UntagResourceRequest {
   export function isa(o: any): o is UntagResourceRequest {
-    return _smithy.isa(o, "UntagResourceRequest");
+    return __isa(o, "UntagResourceRequest");
   }
 }
 
@@ -1439,7 +1436,7 @@ export interface UntagResourceResponse extends $MetadataBearer {
 
 export namespace UntagResourceResponse {
   export function isa(o: any): o is UntagResourceResponse {
-    return _smithy.isa(o, "UntagResourceResponse");
+    return __isa(o, "UntagResourceResponse");
   }
 }
 
@@ -1488,7 +1485,7 @@ export interface UpdateLicenseConfigurationRequest {
 
 export namespace UpdateLicenseConfigurationRequest {
   export function isa(o: any): o is UpdateLicenseConfigurationRequest {
-    return _smithy.isa(o, "UpdateLicenseConfigurationRequest");
+    return __isa(o, "UpdateLicenseConfigurationRequest");
   }
 }
 
@@ -1498,7 +1495,7 @@ export interface UpdateLicenseConfigurationResponse extends $MetadataBearer {
 
 export namespace UpdateLicenseConfigurationResponse {
   export function isa(o: any): o is UpdateLicenseConfigurationResponse {
-    return _smithy.isa(o, "UpdateLicenseConfigurationResponse");
+    return __isa(o, "UpdateLicenseConfigurationResponse");
   }
 }
 
@@ -1524,7 +1521,7 @@ export namespace UpdateLicenseSpecificationsForResourceRequest {
   export function isa(
     o: any
   ): o is UpdateLicenseSpecificationsForResourceRequest {
-    return _smithy.isa(o, "UpdateLicenseSpecificationsForResourceRequest");
+    return __isa(o, "UpdateLicenseSpecificationsForResourceRequest");
   }
 }
 
@@ -1537,7 +1534,7 @@ export namespace UpdateLicenseSpecificationsForResourceResponse {
   export function isa(
     o: any
   ): o is UpdateLicenseSpecificationsForResourceResponse {
-    return _smithy.isa(o, "UpdateLicenseSpecificationsForResourceResponse");
+    return __isa(o, "UpdateLicenseSpecificationsForResourceResponse");
   }
 }
 
@@ -1566,7 +1563,7 @@ export interface UpdateServiceSettingsRequest {
 
 export namespace UpdateServiceSettingsRequest {
   export function isa(o: any): o is UpdateServiceSettingsRequest {
-    return _smithy.isa(o, "UpdateServiceSettingsRequest");
+    return __isa(o, "UpdateServiceSettingsRequest");
   }
 }
 
@@ -1576,6 +1573,6 @@ export interface UpdateServiceSettingsResponse extends $MetadataBearer {
 
 export namespace UpdateServiceSettingsResponse {
   export function isa(o: any): o is UpdateServiceSettingsResponse {
-    return _smithy.isa(o, "UpdateServiceSettingsResponse");
+    return __isa(o, "UpdateServiceSettingsResponse");
   }
 }

--- a/clients/client-lightsail/models/index.ts
+++ b/clients/client-lightsail/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -6,7 +9,7 @@ import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
  *       credentials to access a resource.</p>
  */
 export interface AccessDeniedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AccessDeniedException";
   $fault: "client";
@@ -18,7 +21,7 @@ export interface AccessDeniedException
 
 export namespace AccessDeniedException {
   export function isa(o: any): o is AccessDeniedException {
-    return _smithy.isa(o, "AccessDeniedException");
+    return __isa(o, "AccessDeniedException");
   }
 }
 
@@ -32,7 +35,7 @@ export enum AccessDirection {
  *       state.</p>
  */
 export interface AccountSetupInProgressException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AccountSetupInProgressException";
   $fault: "client";
@@ -44,7 +47,7 @@ export interface AccountSetupInProgressException
 
 export namespace AccountSetupInProgressException {
   export function isa(o: any): o is AccountSetupInProgressException {
-    return _smithy.isa(o, "AccountSetupInProgressException");
+    return __isa(o, "AccountSetupInProgressException");
   }
 }
 
@@ -84,7 +87,7 @@ export interface AddOn {
 
 export namespace AddOn {
   export function isa(o: any): o is AddOn {
-    return _smithy.isa(o, "AddOn");
+    return __isa(o, "AddOn");
   }
 }
 
@@ -113,7 +116,7 @@ export interface AddOnRequest {
 
 export namespace AddOnRequest {
   export function isa(o: any): o is AddOnRequest {
-    return _smithy.isa(o, "AddOnRequest");
+    return __isa(o, "AddOnRequest");
   }
 }
 
@@ -131,7 +134,7 @@ export interface AllocateStaticIpRequest {
 
 export namespace AllocateStaticIpRequest {
   export function isa(o: any): o is AllocateStaticIpRequest {
-    return _smithy.isa(o, "AllocateStaticIpRequest");
+    return __isa(o, "AllocateStaticIpRequest");
   }
 }
 
@@ -146,7 +149,7 @@ export interface AllocateStaticIpResult extends $MetadataBearer {
 
 export namespace AllocateStaticIpResult {
   export function isa(o: any): o is AllocateStaticIpResult {
-    return _smithy.isa(o, "AllocateStaticIpResult");
+    return __isa(o, "AllocateStaticIpResult");
   }
 }
 
@@ -171,7 +174,7 @@ export interface AttachDiskRequest {
 
 export namespace AttachDiskRequest {
   export function isa(o: any): o is AttachDiskRequest {
-    return _smithy.isa(o, "AttachDiskRequest");
+    return __isa(o, "AttachDiskRequest");
   }
 }
 
@@ -185,7 +188,7 @@ export interface AttachDiskResult extends $MetadataBearer {
 
 export namespace AttachDiskResult {
   export function isa(o: any): o is AttachDiskResult {
-    return _smithy.isa(o, "AttachDiskResult");
+    return __isa(o, "AttachDiskResult");
   }
 }
 
@@ -210,7 +213,7 @@ export interface AttachInstancesToLoadBalancerRequest {
 
 export namespace AttachInstancesToLoadBalancerRequest {
   export function isa(o: any): o is AttachInstancesToLoadBalancerRequest {
-    return _smithy.isa(o, "AttachInstancesToLoadBalancerRequest");
+    return __isa(o, "AttachInstancesToLoadBalancerRequest");
   }
 }
 
@@ -224,7 +227,7 @@ export interface AttachInstancesToLoadBalancerResult extends $MetadataBearer {
 
 export namespace AttachInstancesToLoadBalancerResult {
   export function isa(o: any): o is AttachInstancesToLoadBalancerResult {
-    return _smithy.isa(o, "AttachInstancesToLoadBalancerResult");
+    return __isa(o, "AttachInstancesToLoadBalancerResult");
   }
 }
 
@@ -244,7 +247,7 @@ export interface AttachLoadBalancerTlsCertificateRequest {
 
 export namespace AttachLoadBalancerTlsCertificateRequest {
   export function isa(o: any): o is AttachLoadBalancerTlsCertificateRequest {
-    return _smithy.isa(o, "AttachLoadBalancerTlsCertificateRequest");
+    return __isa(o, "AttachLoadBalancerTlsCertificateRequest");
   }
 }
 
@@ -261,7 +264,7 @@ export interface AttachLoadBalancerTlsCertificateResult
 
 export namespace AttachLoadBalancerTlsCertificateResult {
   export function isa(o: any): o is AttachLoadBalancerTlsCertificateResult {
-    return _smithy.isa(o, "AttachLoadBalancerTlsCertificateResult");
+    return __isa(o, "AttachLoadBalancerTlsCertificateResult");
   }
 }
 
@@ -280,7 +283,7 @@ export interface AttachStaticIpRequest {
 
 export namespace AttachStaticIpRequest {
   export function isa(o: any): o is AttachStaticIpRequest {
-    return _smithy.isa(o, "AttachStaticIpRequest");
+    return __isa(o, "AttachStaticIpRequest");
   }
 }
 
@@ -294,7 +297,7 @@ export interface AttachStaticIpResult extends $MetadataBearer {
 
 export namespace AttachStaticIpResult {
   export function isa(o: any): o is AttachStaticIpResult {
-    return _smithy.isa(o, "AttachStaticIpResult");
+    return __isa(o, "AttachStaticIpResult");
   }
 }
 
@@ -317,7 +320,7 @@ export interface AttachedDisk {
 
 export namespace AttachedDisk {
   export function isa(o: any): o is AttachedDisk {
-    return _smithy.isa(o, "AttachedDisk");
+    return __isa(o, "AttachedDisk");
   }
 }
 
@@ -379,7 +382,7 @@ export interface AutoSnapshotAddOnRequest {
 
 export namespace AutoSnapshotAddOnRequest {
   export function isa(o: any): o is AutoSnapshotAddOnRequest {
-    return _smithy.isa(o, "AutoSnapshotAddOnRequest");
+    return __isa(o, "AutoSnapshotAddOnRequest");
   }
 }
 
@@ -412,7 +415,7 @@ export interface AutoSnapshotDetails {
 
 export namespace AutoSnapshotDetails {
   export function isa(o: any): o is AutoSnapshotDetails {
-    return _smithy.isa(o, "AutoSnapshotDetails");
+    return __isa(o, "AutoSnapshotDetails");
   }
 }
 
@@ -442,7 +445,7 @@ export interface AvailabilityZone {
 
 export namespace AvailabilityZone {
   export function isa(o: any): o is AvailabilityZone {
-    return _smithy.isa(o, "AvailabilityZone");
+    return __isa(o, "AvailabilityZone");
   }
 }
 
@@ -523,7 +526,7 @@ export interface Blueprint {
 
 export namespace Blueprint {
   export function isa(o: any): o is Blueprint {
-    return _smithy.isa(o, "Blueprint");
+    return __isa(o, "Blueprint");
   }
 }
 
@@ -603,7 +606,7 @@ export interface Bundle {
 
 export namespace Bundle {
   export function isa(o: any): o is Bundle {
-    return _smithy.isa(o, "Bundle");
+    return __isa(o, "Bundle");
   }
 }
 
@@ -623,7 +626,7 @@ export interface CloseInstancePublicPortsRequest {
 
 export namespace CloseInstancePublicPortsRequest {
   export function isa(o: any): o is CloseInstancePublicPortsRequest {
-    return _smithy.isa(o, "CloseInstancePublicPortsRequest");
+    return __isa(o, "CloseInstancePublicPortsRequest");
   }
 }
 
@@ -637,7 +640,7 @@ export interface CloseInstancePublicPortsResult extends $MetadataBearer {
 
 export namespace CloseInstancePublicPortsResult {
   export function isa(o: any): o is CloseInstancePublicPortsResult {
-    return _smithy.isa(o, "CloseInstancePublicPortsResult");
+    return __isa(o, "CloseInstancePublicPortsResult");
   }
 }
 
@@ -695,7 +698,7 @@ export interface CloudFormationStackRecord {
 
 export namespace CloudFormationStackRecord {
   export function isa(o: any): o is CloudFormationStackRecord {
-    return _smithy.isa(o, "CloudFormationStackRecord");
+    return __isa(o, "CloudFormationStackRecord");
   }
 }
 
@@ -723,7 +726,7 @@ export interface CloudFormationStackRecordSourceInfo {
 
 export namespace CloudFormationStackRecordSourceInfo {
   export function isa(o: any): o is CloudFormationStackRecordSourceInfo {
-    return _smithy.isa(o, "CloudFormationStackRecordSourceInfo");
+    return __isa(o, "CloudFormationStackRecordSourceInfo");
   }
 }
 
@@ -810,7 +813,7 @@ export interface CopySnapshotRequest {
 
 export namespace CopySnapshotRequest {
   export function isa(o: any): o is CopySnapshotRequest {
-    return _smithy.isa(o, "CopySnapshotRequest");
+    return __isa(o, "CopySnapshotRequest");
   }
 }
 
@@ -824,7 +827,7 @@ export interface CopySnapshotResult extends $MetadataBearer {
 
 export namespace CopySnapshotResult {
   export function isa(o: any): o is CopySnapshotResult {
-    return _smithy.isa(o, "CopySnapshotResult");
+    return __isa(o, "CopySnapshotResult");
   }
 }
 
@@ -840,7 +843,7 @@ export interface CreateCloudFormationStackRequest {
 
 export namespace CreateCloudFormationStackRequest {
   export function isa(o: any): o is CreateCloudFormationStackRequest {
-    return _smithy.isa(o, "CreateCloudFormationStackRequest");
+    return __isa(o, "CreateCloudFormationStackRequest");
   }
 }
 
@@ -854,7 +857,7 @@ export interface CreateCloudFormationStackResult extends $MetadataBearer {
 
 export namespace CreateCloudFormationStackResult {
   export function isa(o: any): o is CreateCloudFormationStackResult {
-    return _smithy.isa(o, "CreateCloudFormationStackResult");
+    return __isa(o, "CreateCloudFormationStackResult");
   }
 }
 
@@ -964,7 +967,7 @@ export interface CreateDiskFromSnapshotRequest {
 
 export namespace CreateDiskFromSnapshotRequest {
   export function isa(o: any): o is CreateDiskFromSnapshotRequest {
-    return _smithy.isa(o, "CreateDiskFromSnapshotRequest");
+    return __isa(o, "CreateDiskFromSnapshotRequest");
   }
 }
 
@@ -978,7 +981,7 @@ export interface CreateDiskFromSnapshotResult extends $MetadataBearer {
 
 export namespace CreateDiskFromSnapshotResult {
   export function isa(o: any): o is CreateDiskFromSnapshotResult {
-    return _smithy.isa(o, "CreateDiskFromSnapshotResult");
+    return __isa(o, "CreateDiskFromSnapshotResult");
   }
 }
 
@@ -1018,7 +1021,7 @@ export interface CreateDiskRequest {
 
 export namespace CreateDiskRequest {
   export function isa(o: any): o is CreateDiskRequest {
-    return _smithy.isa(o, "CreateDiskRequest");
+    return __isa(o, "CreateDiskRequest");
   }
 }
 
@@ -1032,7 +1035,7 @@ export interface CreateDiskResult extends $MetadataBearer {
 
 export namespace CreateDiskResult {
   export function isa(o: any): o is CreateDiskResult {
-    return _smithy.isa(o, "CreateDiskResult");
+    return __isa(o, "CreateDiskResult");
   }
 }
 
@@ -1075,7 +1078,7 @@ export interface CreateDiskSnapshotRequest {
 
 export namespace CreateDiskSnapshotRequest {
   export function isa(o: any): o is CreateDiskSnapshotRequest {
-    return _smithy.isa(o, "CreateDiskSnapshotRequest");
+    return __isa(o, "CreateDiskSnapshotRequest");
   }
 }
 
@@ -1089,7 +1092,7 @@ export interface CreateDiskSnapshotResult extends $MetadataBearer {
 
 export namespace CreateDiskSnapshotResult {
   export function isa(o: any): o is CreateDiskSnapshotResult {
-    return _smithy.isa(o, "CreateDiskSnapshotResult");
+    return __isa(o, "CreateDiskSnapshotResult");
   }
 }
 
@@ -1110,7 +1113,7 @@ export interface CreateDomainEntryRequest {
 
 export namespace CreateDomainEntryRequest {
   export function isa(o: any): o is CreateDomainEntryRequest {
-    return _smithy.isa(o, "CreateDomainEntryRequest");
+    return __isa(o, "CreateDomainEntryRequest");
   }
 }
 
@@ -1124,7 +1127,7 @@ export interface CreateDomainEntryResult extends $MetadataBearer {
 
 export namespace CreateDomainEntryResult {
   export function isa(o: any): o is CreateDomainEntryResult {
-    return _smithy.isa(o, "CreateDomainEntryResult");
+    return __isa(o, "CreateDomainEntryResult");
   }
 }
 
@@ -1151,7 +1154,7 @@ export interface CreateDomainRequest {
 
 export namespace CreateDomainRequest {
   export function isa(o: any): o is CreateDomainRequest {
-    return _smithy.isa(o, "CreateDomainRequest");
+    return __isa(o, "CreateDomainRequest");
   }
 }
 
@@ -1166,7 +1169,7 @@ export interface CreateDomainResult extends $MetadataBearer {
 
 export namespace CreateDomainResult {
   export function isa(o: any): o is CreateDomainResult {
-    return _smithy.isa(o, "CreateDomainResult");
+    return __isa(o, "CreateDomainResult");
   }
 }
 
@@ -1192,7 +1195,7 @@ export interface CreateInstanceSnapshotRequest {
 
 export namespace CreateInstanceSnapshotRequest {
   export function isa(o: any): o is CreateInstanceSnapshotRequest {
-    return _smithy.isa(o, "CreateInstanceSnapshotRequest");
+    return __isa(o, "CreateInstanceSnapshotRequest");
   }
 }
 
@@ -1207,7 +1210,7 @@ export interface CreateInstanceSnapshotResult extends $MetadataBearer {
 
 export namespace CreateInstanceSnapshotResult {
   export function isa(o: any): o is CreateInstanceSnapshotResult {
-    return _smithy.isa(o, "CreateInstanceSnapshotResult");
+    return __isa(o, "CreateInstanceSnapshotResult");
   }
 }
 
@@ -1343,7 +1346,7 @@ export interface CreateInstancesFromSnapshotRequest {
 
 export namespace CreateInstancesFromSnapshotRequest {
   export function isa(o: any): o is CreateInstancesFromSnapshotRequest {
-    return _smithy.isa(o, "CreateInstancesFromSnapshotRequest");
+    return __isa(o, "CreateInstancesFromSnapshotRequest");
   }
 }
 
@@ -1358,7 +1361,7 @@ export interface CreateInstancesFromSnapshotResult extends $MetadataBearer {
 
 export namespace CreateInstancesFromSnapshotResult {
   export function isa(o: any): o is CreateInstancesFromSnapshotResult {
-    return _smithy.isa(o, "CreateInstancesFromSnapshotResult");
+    return __isa(o, "CreateInstancesFromSnapshotResult");
   }
 }
 
@@ -1442,7 +1445,7 @@ export interface CreateInstancesRequest {
 
 export namespace CreateInstancesRequest {
   export function isa(o: any): o is CreateInstancesRequest {
-    return _smithy.isa(o, "CreateInstancesRequest");
+    return __isa(o, "CreateInstancesRequest");
   }
 }
 
@@ -1457,7 +1460,7 @@ export interface CreateInstancesResult extends $MetadataBearer {
 
 export namespace CreateInstancesResult {
   export function isa(o: any): o is CreateInstancesResult {
-    return _smithy.isa(o, "CreateInstancesResult");
+    return __isa(o, "CreateInstancesResult");
   }
 }
 
@@ -1478,7 +1481,7 @@ export interface CreateKeyPairRequest {
 
 export namespace CreateKeyPairRequest {
   export function isa(o: any): o is CreateKeyPairRequest {
-    return _smithy.isa(o, "CreateKeyPairRequest");
+    return __isa(o, "CreateKeyPairRequest");
   }
 }
 
@@ -1509,7 +1512,7 @@ export interface CreateKeyPairResult extends $MetadataBearer {
 
 export namespace CreateKeyPairResult {
   export function isa(o: any): o is CreateKeyPairResult {
-    return _smithy.isa(o, "CreateKeyPairResult");
+    return __isa(o, "CreateKeyPairResult");
   }
 }
 
@@ -1566,7 +1569,7 @@ export interface CreateLoadBalancerRequest {
 
 export namespace CreateLoadBalancerRequest {
   export function isa(o: any): o is CreateLoadBalancerRequest {
-    return _smithy.isa(o, "CreateLoadBalancerRequest");
+    return __isa(o, "CreateLoadBalancerRequest");
   }
 }
 
@@ -1580,7 +1583,7 @@ export interface CreateLoadBalancerResult extends $MetadataBearer {
 
 export namespace CreateLoadBalancerResult {
   export function isa(o: any): o is CreateLoadBalancerResult {
-    return _smithy.isa(o, "CreateLoadBalancerResult");
+    return __isa(o, "CreateLoadBalancerResult");
   }
 }
 
@@ -1624,7 +1627,7 @@ export interface CreateLoadBalancerTlsCertificateRequest {
 
 export namespace CreateLoadBalancerTlsCertificateRequest {
   export function isa(o: any): o is CreateLoadBalancerTlsCertificateRequest {
-    return _smithy.isa(o, "CreateLoadBalancerTlsCertificateRequest");
+    return __isa(o, "CreateLoadBalancerTlsCertificateRequest");
   }
 }
 
@@ -1639,7 +1642,7 @@ export interface CreateLoadBalancerTlsCertificateResult
 
 export namespace CreateLoadBalancerTlsCertificateResult {
   export function isa(o: any): o is CreateLoadBalancerTlsCertificateResult {
-    return _smithy.isa(o, "CreateLoadBalancerTlsCertificateResult");
+    return __isa(o, "CreateLoadBalancerTlsCertificateResult");
   }
 }
 
@@ -1742,7 +1745,7 @@ export namespace CreateRelationalDatabaseFromSnapshotRequest {
   export function isa(
     o: any
   ): o is CreateRelationalDatabaseFromSnapshotRequest {
-    return _smithy.isa(o, "CreateRelationalDatabaseFromSnapshotRequest");
+    return __isa(o, "CreateRelationalDatabaseFromSnapshotRequest");
   }
 }
 
@@ -1758,7 +1761,7 @@ export interface CreateRelationalDatabaseFromSnapshotResult
 
 export namespace CreateRelationalDatabaseFromSnapshotResult {
   export function isa(o: any): o is CreateRelationalDatabaseFromSnapshotResult {
-    return _smithy.isa(o, "CreateRelationalDatabaseFromSnapshotResult");
+    return __isa(o, "CreateRelationalDatabaseFromSnapshotResult");
   }
 }
 
@@ -1919,7 +1922,7 @@ export interface CreateRelationalDatabaseRequest {
 
 export namespace CreateRelationalDatabaseRequest {
   export function isa(o: any): o is CreateRelationalDatabaseRequest {
-    return _smithy.isa(o, "CreateRelationalDatabaseRequest");
+    return __isa(o, "CreateRelationalDatabaseRequest");
   }
 }
 
@@ -1933,7 +1936,7 @@ export interface CreateRelationalDatabaseResult extends $MetadataBearer {
 
 export namespace CreateRelationalDatabaseResult {
   export function isa(o: any): o is CreateRelationalDatabaseResult {
-    return _smithy.isa(o, "CreateRelationalDatabaseResult");
+    return __isa(o, "CreateRelationalDatabaseResult");
   }
 }
 
@@ -1968,7 +1971,7 @@ export interface CreateRelationalDatabaseSnapshotRequest {
 
 export namespace CreateRelationalDatabaseSnapshotRequest {
   export function isa(o: any): o is CreateRelationalDatabaseSnapshotRequest {
-    return _smithy.isa(o, "CreateRelationalDatabaseSnapshotRequest");
+    return __isa(o, "CreateRelationalDatabaseSnapshotRequest");
   }
 }
 
@@ -1984,7 +1987,7 @@ export interface CreateRelationalDatabaseSnapshotResult
 
 export namespace CreateRelationalDatabaseSnapshotResult {
   export function isa(o: any): o is CreateRelationalDatabaseSnapshotResult {
-    return _smithy.isa(o, "CreateRelationalDatabaseSnapshotResult");
+    return __isa(o, "CreateRelationalDatabaseSnapshotResult");
   }
 }
 
@@ -2006,7 +2009,7 @@ export interface DeleteAutoSnapshotRequest {
 
 export namespace DeleteAutoSnapshotRequest {
   export function isa(o: any): o is DeleteAutoSnapshotRequest {
-    return _smithy.isa(o, "DeleteAutoSnapshotRequest");
+    return __isa(o, "DeleteAutoSnapshotRequest");
   }
 }
 
@@ -2020,7 +2023,7 @@ export interface DeleteAutoSnapshotResult extends $MetadataBearer {
 
 export namespace DeleteAutoSnapshotResult {
   export function isa(o: any): o is DeleteAutoSnapshotResult {
-    return _smithy.isa(o, "DeleteAutoSnapshotResult");
+    return __isa(o, "DeleteAutoSnapshotResult");
   }
 }
 
@@ -2039,7 +2042,7 @@ export interface DeleteDiskRequest {
 
 export namespace DeleteDiskRequest {
   export function isa(o: any): o is DeleteDiskRequest {
-    return _smithy.isa(o, "DeleteDiskRequest");
+    return __isa(o, "DeleteDiskRequest");
   }
 }
 
@@ -2053,7 +2056,7 @@ export interface DeleteDiskResult extends $MetadataBearer {
 
 export namespace DeleteDiskResult {
   export function isa(o: any): o is DeleteDiskResult {
-    return _smithy.isa(o, "DeleteDiskResult");
+    return __isa(o, "DeleteDiskResult");
   }
 }
 
@@ -2068,7 +2071,7 @@ export interface DeleteDiskSnapshotRequest {
 
 export namespace DeleteDiskSnapshotRequest {
   export function isa(o: any): o is DeleteDiskSnapshotRequest {
-    return _smithy.isa(o, "DeleteDiskSnapshotRequest");
+    return __isa(o, "DeleteDiskSnapshotRequest");
   }
 }
 
@@ -2082,7 +2085,7 @@ export interface DeleteDiskSnapshotResult extends $MetadataBearer {
 
 export namespace DeleteDiskSnapshotResult {
   export function isa(o: any): o is DeleteDiskSnapshotResult {
-    return _smithy.isa(o, "DeleteDiskSnapshotResult");
+    return __isa(o, "DeleteDiskSnapshotResult");
   }
 }
 
@@ -2101,7 +2104,7 @@ export interface DeleteDomainEntryRequest {
 
 export namespace DeleteDomainEntryRequest {
   export function isa(o: any): o is DeleteDomainEntryRequest {
-    return _smithy.isa(o, "DeleteDomainEntryRequest");
+    return __isa(o, "DeleteDomainEntryRequest");
   }
 }
 
@@ -2116,7 +2119,7 @@ export interface DeleteDomainEntryResult extends $MetadataBearer {
 
 export namespace DeleteDomainEntryResult {
   export function isa(o: any): o is DeleteDomainEntryResult {
-    return _smithy.isa(o, "DeleteDomainEntryResult");
+    return __isa(o, "DeleteDomainEntryResult");
   }
 }
 
@@ -2130,7 +2133,7 @@ export interface DeleteDomainRequest {
 
 export namespace DeleteDomainRequest {
   export function isa(o: any): o is DeleteDomainRequest {
-    return _smithy.isa(o, "DeleteDomainRequest");
+    return __isa(o, "DeleteDomainRequest");
   }
 }
 
@@ -2145,7 +2148,7 @@ export interface DeleteDomainResult extends $MetadataBearer {
 
 export namespace DeleteDomainResult {
   export function isa(o: any): o is DeleteDomainResult {
-    return _smithy.isa(o, "DeleteDomainResult");
+    return __isa(o, "DeleteDomainResult");
   }
 }
 
@@ -2164,7 +2167,7 @@ export interface DeleteInstanceRequest {
 
 export namespace DeleteInstanceRequest {
   export function isa(o: any): o is DeleteInstanceRequest {
-    return _smithy.isa(o, "DeleteInstanceRequest");
+    return __isa(o, "DeleteInstanceRequest");
   }
 }
 
@@ -2179,7 +2182,7 @@ export interface DeleteInstanceResult extends $MetadataBearer {
 
 export namespace DeleteInstanceResult {
   export function isa(o: any): o is DeleteInstanceResult {
-    return _smithy.isa(o, "DeleteInstanceResult");
+    return __isa(o, "DeleteInstanceResult");
   }
 }
 
@@ -2193,7 +2196,7 @@ export interface DeleteInstanceSnapshotRequest {
 
 export namespace DeleteInstanceSnapshotRequest {
   export function isa(o: any): o is DeleteInstanceSnapshotRequest {
-    return _smithy.isa(o, "DeleteInstanceSnapshotRequest");
+    return __isa(o, "DeleteInstanceSnapshotRequest");
   }
 }
 
@@ -2208,7 +2211,7 @@ export interface DeleteInstanceSnapshotResult extends $MetadataBearer {
 
 export namespace DeleteInstanceSnapshotResult {
   export function isa(o: any): o is DeleteInstanceSnapshotResult {
-    return _smithy.isa(o, "DeleteInstanceSnapshotResult");
+    return __isa(o, "DeleteInstanceSnapshotResult");
   }
 }
 
@@ -2222,7 +2225,7 @@ export interface DeleteKeyPairRequest {
 
 export namespace DeleteKeyPairRequest {
   export function isa(o: any): o is DeleteKeyPairRequest {
-    return _smithy.isa(o, "DeleteKeyPairRequest");
+    return __isa(o, "DeleteKeyPairRequest");
   }
 }
 
@@ -2237,7 +2240,7 @@ export interface DeleteKeyPairResult extends $MetadataBearer {
 
 export namespace DeleteKeyPairResult {
   export function isa(o: any): o is DeleteKeyPairResult {
-    return _smithy.isa(o, "DeleteKeyPairResult");
+    return __isa(o, "DeleteKeyPairResult");
   }
 }
 
@@ -2251,7 +2254,7 @@ export interface DeleteKnownHostKeysRequest {
 
 export namespace DeleteKnownHostKeysRequest {
   export function isa(o: any): o is DeleteKnownHostKeysRequest {
-    return _smithy.isa(o, "DeleteKnownHostKeysRequest");
+    return __isa(o, "DeleteKnownHostKeysRequest");
   }
 }
 
@@ -2265,7 +2268,7 @@ export interface DeleteKnownHostKeysResult extends $MetadataBearer {
 
 export namespace DeleteKnownHostKeysResult {
   export function isa(o: any): o is DeleteKnownHostKeysResult {
-    return _smithy.isa(o, "DeleteKnownHostKeysResult");
+    return __isa(o, "DeleteKnownHostKeysResult");
   }
 }
 
@@ -2279,7 +2282,7 @@ export interface DeleteLoadBalancerRequest {
 
 export namespace DeleteLoadBalancerRequest {
   export function isa(o: any): o is DeleteLoadBalancerRequest {
-    return _smithy.isa(o, "DeleteLoadBalancerRequest");
+    return __isa(o, "DeleteLoadBalancerRequest");
   }
 }
 
@@ -2293,7 +2296,7 @@ export interface DeleteLoadBalancerResult extends $MetadataBearer {
 
 export namespace DeleteLoadBalancerResult {
   export function isa(o: any): o is DeleteLoadBalancerResult {
-    return _smithy.isa(o, "DeleteLoadBalancerResult");
+    return __isa(o, "DeleteLoadBalancerResult");
   }
 }
 
@@ -2320,7 +2323,7 @@ export interface DeleteLoadBalancerTlsCertificateRequest {
 
 export namespace DeleteLoadBalancerTlsCertificateRequest {
   export function isa(o: any): o is DeleteLoadBalancerTlsCertificateRequest {
-    return _smithy.isa(o, "DeleteLoadBalancerTlsCertificateRequest");
+    return __isa(o, "DeleteLoadBalancerTlsCertificateRequest");
   }
 }
 
@@ -2335,7 +2338,7 @@ export interface DeleteLoadBalancerTlsCertificateResult
 
 export namespace DeleteLoadBalancerTlsCertificateResult {
   export function isa(o: any): o is DeleteLoadBalancerTlsCertificateResult {
-    return _smithy.isa(o, "DeleteLoadBalancerTlsCertificateResult");
+    return __isa(o, "DeleteLoadBalancerTlsCertificateResult");
   }
 }
 
@@ -2380,7 +2383,7 @@ export interface DeleteRelationalDatabaseRequest {
 
 export namespace DeleteRelationalDatabaseRequest {
   export function isa(o: any): o is DeleteRelationalDatabaseRequest {
-    return _smithy.isa(o, "DeleteRelationalDatabaseRequest");
+    return __isa(o, "DeleteRelationalDatabaseRequest");
   }
 }
 
@@ -2394,7 +2397,7 @@ export interface DeleteRelationalDatabaseResult extends $MetadataBearer {
 
 export namespace DeleteRelationalDatabaseResult {
   export function isa(o: any): o is DeleteRelationalDatabaseResult {
-    return _smithy.isa(o, "DeleteRelationalDatabaseResult");
+    return __isa(o, "DeleteRelationalDatabaseResult");
   }
 }
 
@@ -2408,7 +2411,7 @@ export interface DeleteRelationalDatabaseSnapshotRequest {
 
 export namespace DeleteRelationalDatabaseSnapshotRequest {
   export function isa(o: any): o is DeleteRelationalDatabaseSnapshotRequest {
-    return _smithy.isa(o, "DeleteRelationalDatabaseSnapshotRequest");
+    return __isa(o, "DeleteRelationalDatabaseSnapshotRequest");
   }
 }
 
@@ -2424,7 +2427,7 @@ export interface DeleteRelationalDatabaseSnapshotResult
 
 export namespace DeleteRelationalDatabaseSnapshotResult {
   export function isa(o: any): o is DeleteRelationalDatabaseSnapshotResult {
-    return _smithy.isa(o, "DeleteRelationalDatabaseSnapshotResult");
+    return __isa(o, "DeleteRelationalDatabaseSnapshotResult");
   }
 }
 
@@ -2446,7 +2449,7 @@ export interface DestinationInfo {
 
 export namespace DestinationInfo {
   export function isa(o: any): o is DestinationInfo {
-    return _smithy.isa(o, "DestinationInfo");
+    return __isa(o, "DestinationInfo");
   }
 }
 
@@ -2461,7 +2464,7 @@ export interface DetachDiskRequest {
 
 export namespace DetachDiskRequest {
   export function isa(o: any): o is DetachDiskRequest {
-    return _smithy.isa(o, "DetachDiskRequest");
+    return __isa(o, "DetachDiskRequest");
   }
 }
 
@@ -2475,7 +2478,7 @@ export interface DetachDiskResult extends $MetadataBearer {
 
 export namespace DetachDiskResult {
   export function isa(o: any): o is DetachDiskResult {
-    return _smithy.isa(o, "DetachDiskResult");
+    return __isa(o, "DetachDiskResult");
   }
 }
 
@@ -2495,7 +2498,7 @@ export interface DetachInstancesFromLoadBalancerRequest {
 
 export namespace DetachInstancesFromLoadBalancerRequest {
   export function isa(o: any): o is DetachInstancesFromLoadBalancerRequest {
-    return _smithy.isa(o, "DetachInstancesFromLoadBalancerRequest");
+    return __isa(o, "DetachInstancesFromLoadBalancerRequest");
   }
 }
 
@@ -2509,7 +2512,7 @@ export interface DetachInstancesFromLoadBalancerResult extends $MetadataBearer {
 
 export namespace DetachInstancesFromLoadBalancerResult {
   export function isa(o: any): o is DetachInstancesFromLoadBalancerResult {
-    return _smithy.isa(o, "DetachInstancesFromLoadBalancerResult");
+    return __isa(o, "DetachInstancesFromLoadBalancerResult");
   }
 }
 
@@ -2523,7 +2526,7 @@ export interface DetachStaticIpRequest {
 
 export namespace DetachStaticIpRequest {
   export function isa(o: any): o is DetachStaticIpRequest {
-    return _smithy.isa(o, "DetachStaticIpRequest");
+    return __isa(o, "DetachStaticIpRequest");
   }
 }
 
@@ -2538,7 +2541,7 @@ export interface DetachStaticIpResult extends $MetadataBearer {
 
 export namespace DetachStaticIpResult {
   export function isa(o: any): o is DetachStaticIpResult {
-    return _smithy.isa(o, "DetachStaticIpResult");
+    return __isa(o, "DetachStaticIpResult");
   }
 }
 
@@ -2557,7 +2560,7 @@ export interface DisableAddOnRequest {
 
 export namespace DisableAddOnRequest {
   export function isa(o: any): o is DisableAddOnRequest {
-    return _smithy.isa(o, "DisableAddOnRequest");
+    return __isa(o, "DisableAddOnRequest");
   }
 }
 
@@ -2571,7 +2574,7 @@ export interface DisableAddOnResult extends $MetadataBearer {
 
 export namespace DisableAddOnResult {
   export function isa(o: any): o is DisableAddOnResult {
-    return _smithy.isa(o, "DisableAddOnResult");
+    return __isa(o, "DisableAddOnResult");
   }
 }
 
@@ -2682,7 +2685,7 @@ export interface Disk {
 
 export namespace Disk {
   export function isa(o: any): o is Disk {
-    return _smithy.isa(o, "Disk");
+    return __isa(o, "Disk");
   }
 }
 
@@ -2715,7 +2718,7 @@ export interface DiskInfo {
 
 export namespace DiskInfo {
   export function isa(o: any): o is DiskInfo {
-    return _smithy.isa(o, "DiskInfo");
+    return __isa(o, "DiskInfo");
   }
 }
 
@@ -2738,7 +2741,7 @@ export interface DiskMap {
 
 export namespace DiskMap {
   export function isa(o: any): o is DiskMap {
-    return _smithy.isa(o, "DiskMap");
+    return __isa(o, "DiskMap");
   }
 }
 
@@ -2833,7 +2836,7 @@ export interface DiskSnapshot {
 
 export namespace DiskSnapshot {
   export function isa(o: any): o is DiskSnapshot {
-    return _smithy.isa(o, "DiskSnapshot");
+    return __isa(o, "DiskSnapshot");
   }
 }
 
@@ -2850,7 +2853,7 @@ export interface DiskSnapshotInfo {
 
 export namespace DiskSnapshotInfo {
   export function isa(o: any): o is DiskSnapshotInfo {
-    return _smithy.isa(o, "DiskSnapshotInfo");
+    return __isa(o, "DiskSnapshotInfo");
   }
 }
 
@@ -2922,7 +2925,7 @@ export interface Domain {
 
 export namespace Domain {
   export function isa(o: any): o is Domain {
-    return _smithy.isa(o, "Domain");
+    return __isa(o, "Domain");
   }
 }
 
@@ -3014,7 +3017,7 @@ export interface DomainEntry {
 
 export namespace DomainEntry {
   export function isa(o: any): o is DomainEntry {
-    return _smithy.isa(o, "DomainEntry");
+    return __isa(o, "DomainEntry");
   }
 }
 
@@ -3024,7 +3027,7 @@ export interface DownloadDefaultKeyPairRequest {
 
 export namespace DownloadDefaultKeyPairRequest {
   export function isa(o: any): o is DownloadDefaultKeyPairRequest {
-    return _smithy.isa(o, "DownloadDefaultKeyPairRequest");
+    return __isa(o, "DownloadDefaultKeyPairRequest");
   }
 }
 
@@ -3043,7 +3046,7 @@ export interface DownloadDefaultKeyPairResult extends $MetadataBearer {
 
 export namespace DownloadDefaultKeyPairResult {
   export function isa(o: any): o is DownloadDefaultKeyPairResult {
-    return _smithy.isa(o, "DownloadDefaultKeyPairResult");
+    return __isa(o, "DownloadDefaultKeyPairResult");
   }
 }
 
@@ -3062,7 +3065,7 @@ export interface EnableAddOnRequest {
 
 export namespace EnableAddOnRequest {
   export function isa(o: any): o is EnableAddOnRequest {
-    return _smithy.isa(o, "EnableAddOnRequest");
+    return __isa(o, "EnableAddOnRequest");
   }
 }
 
@@ -3076,7 +3079,7 @@ export interface EnableAddOnResult extends $MetadataBearer {
 
 export namespace EnableAddOnResult {
   export function isa(o: any): o is EnableAddOnResult {
-    return _smithy.isa(o, "EnableAddOnResult");
+    return __isa(o, "EnableAddOnResult");
   }
 }
 
@@ -3128,7 +3131,7 @@ export interface ExportSnapshotRecord {
 
 export namespace ExportSnapshotRecord {
   export function isa(o: any): o is ExportSnapshotRecord {
-    return _smithy.isa(o, "ExportSnapshotRecord");
+    return __isa(o, "ExportSnapshotRecord");
   }
 }
 
@@ -3181,7 +3184,7 @@ export interface ExportSnapshotRecordSourceInfo {
 
 export namespace ExportSnapshotRecordSourceInfo {
   export function isa(o: any): o is ExportSnapshotRecordSourceInfo {
-    return _smithy.isa(o, "ExportSnapshotRecordSourceInfo");
+    return __isa(o, "ExportSnapshotRecordSourceInfo");
   }
 }
 
@@ -3200,7 +3203,7 @@ export interface ExportSnapshotRequest {
 
 export namespace ExportSnapshotRequest {
   export function isa(o: any): o is ExportSnapshotRequest {
-    return _smithy.isa(o, "ExportSnapshotRequest");
+    return __isa(o, "ExportSnapshotRequest");
   }
 }
 
@@ -3214,7 +3217,7 @@ export interface ExportSnapshotResult extends $MetadataBearer {
 
 export namespace ExportSnapshotResult {
   export function isa(o: any): o is ExportSnapshotResult {
-    return _smithy.isa(o, "ExportSnapshotResult");
+    return __isa(o, "ExportSnapshotResult");
   }
 }
 
@@ -3228,7 +3231,7 @@ export interface GetActiveNamesRequest {
 
 export namespace GetActiveNamesRequest {
   export function isa(o: any): o is GetActiveNamesRequest {
-    return _smithy.isa(o, "GetActiveNamesRequest");
+    return __isa(o, "GetActiveNamesRequest");
   }
 }
 
@@ -3248,7 +3251,7 @@ export interface GetActiveNamesResult extends $MetadataBearer {
 
 export namespace GetActiveNamesResult {
   export function isa(o: any): o is GetActiveNamesResult {
-    return _smithy.isa(o, "GetActiveNamesResult");
+    return __isa(o, "GetActiveNamesResult");
   }
 }
 
@@ -3263,7 +3266,7 @@ export interface GetAutoSnapshotsRequest {
 
 export namespace GetAutoSnapshotsRequest {
   export function isa(o: any): o is GetAutoSnapshotsRequest {
-    return _smithy.isa(o, "GetAutoSnapshotsRequest");
+    return __isa(o, "GetAutoSnapshotsRequest");
   }
 }
 
@@ -3288,7 +3291,7 @@ export interface GetAutoSnapshotsResult extends $MetadataBearer {
 
 export namespace GetAutoSnapshotsResult {
   export function isa(o: any): o is GetAutoSnapshotsResult {
-    return _smithy.isa(o, "GetAutoSnapshotsResult");
+    return __isa(o, "GetAutoSnapshotsResult");
   }
 }
 
@@ -3309,7 +3312,7 @@ export interface GetBlueprintsRequest {
 
 export namespace GetBlueprintsRequest {
   export function isa(o: any): o is GetBlueprintsRequest {
-    return _smithy.isa(o, "GetBlueprintsRequest");
+    return __isa(o, "GetBlueprintsRequest");
   }
 }
 
@@ -3330,7 +3333,7 @@ export interface GetBlueprintsResult extends $MetadataBearer {
 
 export namespace GetBlueprintsResult {
   export function isa(o: any): o is GetBlueprintsResult {
-    return _smithy.isa(o, "GetBlueprintsResult");
+    return __isa(o, "GetBlueprintsResult");
   }
 }
 
@@ -3351,7 +3354,7 @@ export interface GetBundlesRequest {
 
 export namespace GetBundlesRequest {
   export function isa(o: any): o is GetBundlesRequest {
-    return _smithy.isa(o, "GetBundlesRequest");
+    return __isa(o, "GetBundlesRequest");
   }
 }
 
@@ -3372,7 +3375,7 @@ export interface GetBundlesResult extends $MetadataBearer {
 
 export namespace GetBundlesResult {
   export function isa(o: any): o is GetBundlesResult {
-    return _smithy.isa(o, "GetBundlesResult");
+    return __isa(o, "GetBundlesResult");
   }
 }
 
@@ -3387,7 +3390,7 @@ export interface GetCloudFormationStackRecordsRequest {
 
 export namespace GetCloudFormationStackRecordsRequest {
   export function isa(o: any): o is GetCloudFormationStackRecordsRequest {
-    return _smithy.isa(o, "GetCloudFormationStackRecordsRequest");
+    return __isa(o, "GetCloudFormationStackRecordsRequest");
   }
 }
 
@@ -3407,7 +3410,7 @@ export interface GetCloudFormationStackRecordsResult extends $MetadataBearer {
 
 export namespace GetCloudFormationStackRecordsResult {
   export function isa(o: any): o is GetCloudFormationStackRecordsResult {
-    return _smithy.isa(o, "GetCloudFormationStackRecordsResult");
+    return __isa(o, "GetCloudFormationStackRecordsResult");
   }
 }
 
@@ -3421,7 +3424,7 @@ export interface GetDiskRequest {
 
 export namespace GetDiskRequest {
   export function isa(o: any): o is GetDiskRequest {
-    return _smithy.isa(o, "GetDiskRequest");
+    return __isa(o, "GetDiskRequest");
   }
 }
 
@@ -3435,7 +3438,7 @@ export interface GetDiskResult extends $MetadataBearer {
 
 export namespace GetDiskResult {
   export function isa(o: any): o is GetDiskResult {
-    return _smithy.isa(o, "GetDiskResult");
+    return __isa(o, "GetDiskResult");
   }
 }
 
@@ -3449,7 +3452,7 @@ export interface GetDiskSnapshotRequest {
 
 export namespace GetDiskSnapshotRequest {
   export function isa(o: any): o is GetDiskSnapshotRequest {
-    return _smithy.isa(o, "GetDiskSnapshotRequest");
+    return __isa(o, "GetDiskSnapshotRequest");
   }
 }
 
@@ -3463,7 +3466,7 @@ export interface GetDiskSnapshotResult extends $MetadataBearer {
 
 export namespace GetDiskSnapshotResult {
   export function isa(o: any): o is GetDiskSnapshotResult {
-    return _smithy.isa(o, "GetDiskSnapshotResult");
+    return __isa(o, "GetDiskSnapshotResult");
   }
 }
 
@@ -3478,7 +3481,7 @@ export interface GetDiskSnapshotsRequest {
 
 export namespace GetDiskSnapshotsRequest {
   export function isa(o: any): o is GetDiskSnapshotsRequest {
-    return _smithy.isa(o, "GetDiskSnapshotsRequest");
+    return __isa(o, "GetDiskSnapshotsRequest");
   }
 }
 
@@ -3499,7 +3502,7 @@ export interface GetDiskSnapshotsResult extends $MetadataBearer {
 
 export namespace GetDiskSnapshotsResult {
   export function isa(o: any): o is GetDiskSnapshotsResult {
-    return _smithy.isa(o, "GetDiskSnapshotsResult");
+    return __isa(o, "GetDiskSnapshotsResult");
   }
 }
 
@@ -3514,7 +3517,7 @@ export interface GetDisksRequest {
 
 export namespace GetDisksRequest {
   export function isa(o: any): o is GetDisksRequest {
-    return _smithy.isa(o, "GetDisksRequest");
+    return __isa(o, "GetDisksRequest");
   }
 }
 
@@ -3534,7 +3537,7 @@ export interface GetDisksResult extends $MetadataBearer {
 
 export namespace GetDisksResult {
   export function isa(o: any): o is GetDisksResult {
-    return _smithy.isa(o, "GetDisksResult");
+    return __isa(o, "GetDisksResult");
   }
 }
 
@@ -3548,7 +3551,7 @@ export interface GetDomainRequest {
 
 export namespace GetDomainRequest {
   export function isa(o: any): o is GetDomainRequest {
-    return _smithy.isa(o, "GetDomainRequest");
+    return __isa(o, "GetDomainRequest");
   }
 }
 
@@ -3563,7 +3566,7 @@ export interface GetDomainResult extends $MetadataBearer {
 
 export namespace GetDomainResult {
   export function isa(o: any): o is GetDomainResult {
-    return _smithy.isa(o, "GetDomainResult");
+    return __isa(o, "GetDomainResult");
   }
 }
 
@@ -3578,7 +3581,7 @@ export interface GetDomainsRequest {
 
 export namespace GetDomainsRequest {
   export function isa(o: any): o is GetDomainsRequest {
-    return _smithy.isa(o, "GetDomainsRequest");
+    return __isa(o, "GetDomainsRequest");
   }
 }
 
@@ -3599,7 +3602,7 @@ export interface GetDomainsResult extends $MetadataBearer {
 
 export namespace GetDomainsResult {
   export function isa(o: any): o is GetDomainsResult {
-    return _smithy.isa(o, "GetDomainsResult");
+    return __isa(o, "GetDomainsResult");
   }
 }
 
@@ -3614,7 +3617,7 @@ export interface GetExportSnapshotRecordsRequest {
 
 export namespace GetExportSnapshotRecordsRequest {
   export function isa(o: any): o is GetExportSnapshotRecordsRequest {
-    return _smithy.isa(o, "GetExportSnapshotRecordsRequest");
+    return __isa(o, "GetExportSnapshotRecordsRequest");
   }
 }
 
@@ -3634,7 +3637,7 @@ export interface GetExportSnapshotRecordsResult extends $MetadataBearer {
 
 export namespace GetExportSnapshotRecordsResult {
   export function isa(o: any): o is GetExportSnapshotRecordsResult {
-    return _smithy.isa(o, "GetExportSnapshotRecordsResult");
+    return __isa(o, "GetExportSnapshotRecordsResult");
   }
 }
 
@@ -3654,7 +3657,7 @@ export interface GetInstanceAccessDetailsRequest {
 
 export namespace GetInstanceAccessDetailsRequest {
   export function isa(o: any): o is GetInstanceAccessDetailsRequest {
-    return _smithy.isa(o, "GetInstanceAccessDetailsRequest");
+    return __isa(o, "GetInstanceAccessDetailsRequest");
   }
 }
 
@@ -3669,7 +3672,7 @@ export interface GetInstanceAccessDetailsResult extends $MetadataBearer {
 
 export namespace GetInstanceAccessDetailsResult {
   export function isa(o: any): o is GetInstanceAccessDetailsResult {
-    return _smithy.isa(o, "GetInstanceAccessDetailsResult");
+    return __isa(o, "GetInstanceAccessDetailsResult");
   }
 }
 
@@ -3713,7 +3716,7 @@ export interface GetInstanceMetricDataRequest {
 
 export namespace GetInstanceMetricDataRequest {
   export function isa(o: any): o is GetInstanceMetricDataRequest {
-    return _smithy.isa(o, "GetInstanceMetricDataRequest");
+    return __isa(o, "GetInstanceMetricDataRequest");
   }
 }
 
@@ -3733,7 +3736,7 @@ export interface GetInstanceMetricDataResult extends $MetadataBearer {
 
 export namespace GetInstanceMetricDataResult {
   export function isa(o: any): o is GetInstanceMetricDataResult {
-    return _smithy.isa(o, "GetInstanceMetricDataResult");
+    return __isa(o, "GetInstanceMetricDataResult");
   }
 }
 
@@ -3747,7 +3750,7 @@ export interface GetInstancePortStatesRequest {
 
 export namespace GetInstancePortStatesRequest {
   export function isa(o: any): o is GetInstancePortStatesRequest {
-    return _smithy.isa(o, "GetInstancePortStatesRequest");
+    return __isa(o, "GetInstancePortStatesRequest");
   }
 }
 
@@ -3761,7 +3764,7 @@ export interface GetInstancePortStatesResult extends $MetadataBearer {
 
 export namespace GetInstancePortStatesResult {
   export function isa(o: any): o is GetInstancePortStatesResult {
-    return _smithy.isa(o, "GetInstancePortStatesResult");
+    return __isa(o, "GetInstancePortStatesResult");
   }
 }
 
@@ -3775,7 +3778,7 @@ export interface GetInstanceRequest {
 
 export namespace GetInstanceRequest {
   export function isa(o: any): o is GetInstanceRequest {
-    return _smithy.isa(o, "GetInstanceRequest");
+    return __isa(o, "GetInstanceRequest");
   }
 }
 
@@ -3790,7 +3793,7 @@ export interface GetInstanceResult extends $MetadataBearer {
 
 export namespace GetInstanceResult {
   export function isa(o: any): o is GetInstanceResult {
-    return _smithy.isa(o, "GetInstanceResult");
+    return __isa(o, "GetInstanceResult");
   }
 }
 
@@ -3804,7 +3807,7 @@ export interface GetInstanceSnapshotRequest {
 
 export namespace GetInstanceSnapshotRequest {
   export function isa(o: any): o is GetInstanceSnapshotRequest {
-    return _smithy.isa(o, "GetInstanceSnapshotRequest");
+    return __isa(o, "GetInstanceSnapshotRequest");
   }
 }
 
@@ -3819,7 +3822,7 @@ export interface GetInstanceSnapshotResult extends $MetadataBearer {
 
 export namespace GetInstanceSnapshotResult {
   export function isa(o: any): o is GetInstanceSnapshotResult {
-    return _smithy.isa(o, "GetInstanceSnapshotResult");
+    return __isa(o, "GetInstanceSnapshotResult");
   }
 }
 
@@ -3834,7 +3837,7 @@ export interface GetInstanceSnapshotsRequest {
 
 export namespace GetInstanceSnapshotsRequest {
   export function isa(o: any): o is GetInstanceSnapshotsRequest {
-    return _smithy.isa(o, "GetInstanceSnapshotsRequest");
+    return __isa(o, "GetInstanceSnapshotsRequest");
   }
 }
 
@@ -3855,7 +3858,7 @@ export interface GetInstanceSnapshotsResult extends $MetadataBearer {
 
 export namespace GetInstanceSnapshotsResult {
   export function isa(o: any): o is GetInstanceSnapshotsResult {
-    return _smithy.isa(o, "GetInstanceSnapshotsResult");
+    return __isa(o, "GetInstanceSnapshotsResult");
   }
 }
 
@@ -3869,7 +3872,7 @@ export interface GetInstanceStateRequest {
 
 export namespace GetInstanceStateRequest {
   export function isa(o: any): o is GetInstanceStateRequest {
-    return _smithy.isa(o, "GetInstanceStateRequest");
+    return __isa(o, "GetInstanceStateRequest");
   }
 }
 
@@ -3883,7 +3886,7 @@ export interface GetInstanceStateResult extends $MetadataBearer {
 
 export namespace GetInstanceStateResult {
   export function isa(o: any): o is GetInstanceStateResult {
-    return _smithy.isa(o, "GetInstanceStateResult");
+    return __isa(o, "GetInstanceStateResult");
   }
 }
 
@@ -3898,7 +3901,7 @@ export interface GetInstancesRequest {
 
 export namespace GetInstancesRequest {
   export function isa(o: any): o is GetInstancesRequest {
-    return _smithy.isa(o, "GetInstancesRequest");
+    return __isa(o, "GetInstancesRequest");
   }
 }
 
@@ -3918,7 +3921,7 @@ export interface GetInstancesResult extends $MetadataBearer {
 
 export namespace GetInstancesResult {
   export function isa(o: any): o is GetInstancesResult {
-    return _smithy.isa(o, "GetInstancesResult");
+    return __isa(o, "GetInstancesResult");
   }
 }
 
@@ -3932,7 +3935,7 @@ export interface GetKeyPairRequest {
 
 export namespace GetKeyPairRequest {
   export function isa(o: any): o is GetKeyPairRequest {
-    return _smithy.isa(o, "GetKeyPairRequest");
+    return __isa(o, "GetKeyPairRequest");
   }
 }
 
@@ -3946,7 +3949,7 @@ export interface GetKeyPairResult extends $MetadataBearer {
 
 export namespace GetKeyPairResult {
   export function isa(o: any): o is GetKeyPairResult {
-    return _smithy.isa(o, "GetKeyPairResult");
+    return __isa(o, "GetKeyPairResult");
   }
 }
 
@@ -3961,7 +3964,7 @@ export interface GetKeyPairsRequest {
 
 export namespace GetKeyPairsRequest {
   export function isa(o: any): o is GetKeyPairsRequest {
-    return _smithy.isa(o, "GetKeyPairsRequest");
+    return __isa(o, "GetKeyPairsRequest");
   }
 }
 
@@ -3981,7 +3984,7 @@ export interface GetKeyPairsResult extends $MetadataBearer {
 
 export namespace GetKeyPairsResult {
   export function isa(o: any): o is GetKeyPairsResult {
-    return _smithy.isa(o, "GetKeyPairsResult");
+    return __isa(o, "GetKeyPairsResult");
   }
 }
 
@@ -4210,7 +4213,7 @@ export interface GetLoadBalancerMetricDataRequest {
 
 export namespace GetLoadBalancerMetricDataRequest {
   export function isa(o: any): o is GetLoadBalancerMetricDataRequest {
-    return _smithy.isa(o, "GetLoadBalancerMetricDataRequest");
+    return __isa(o, "GetLoadBalancerMetricDataRequest");
   }
 }
 
@@ -4370,7 +4373,7 @@ export interface GetLoadBalancerMetricDataResult extends $MetadataBearer {
 
 export namespace GetLoadBalancerMetricDataResult {
   export function isa(o: any): o is GetLoadBalancerMetricDataResult {
-    return _smithy.isa(o, "GetLoadBalancerMetricDataResult");
+    return __isa(o, "GetLoadBalancerMetricDataResult");
   }
 }
 
@@ -4384,7 +4387,7 @@ export interface GetLoadBalancerRequest {
 
 export namespace GetLoadBalancerRequest {
   export function isa(o: any): o is GetLoadBalancerRequest {
-    return _smithy.isa(o, "GetLoadBalancerRequest");
+    return __isa(o, "GetLoadBalancerRequest");
   }
 }
 
@@ -4398,7 +4401,7 @@ export interface GetLoadBalancerResult extends $MetadataBearer {
 
 export namespace GetLoadBalancerResult {
   export function isa(o: any): o is GetLoadBalancerResult {
-    return _smithy.isa(o, "GetLoadBalancerResult");
+    return __isa(o, "GetLoadBalancerResult");
   }
 }
 
@@ -4412,7 +4415,7 @@ export interface GetLoadBalancerTlsCertificatesRequest {
 
 export namespace GetLoadBalancerTlsCertificatesRequest {
   export function isa(o: any): o is GetLoadBalancerTlsCertificatesRequest {
-    return _smithy.isa(o, "GetLoadBalancerTlsCertificatesRequest");
+    return __isa(o, "GetLoadBalancerTlsCertificatesRequest");
   }
 }
 
@@ -4427,7 +4430,7 @@ export interface GetLoadBalancerTlsCertificatesResult extends $MetadataBearer {
 
 export namespace GetLoadBalancerTlsCertificatesResult {
   export function isa(o: any): o is GetLoadBalancerTlsCertificatesResult {
-    return _smithy.isa(o, "GetLoadBalancerTlsCertificatesResult");
+    return __isa(o, "GetLoadBalancerTlsCertificatesResult");
   }
 }
 
@@ -4441,7 +4444,7 @@ export interface GetLoadBalancersRequest {
 
 export namespace GetLoadBalancersRequest {
   export function isa(o: any): o is GetLoadBalancersRequest {
-    return _smithy.isa(o, "GetLoadBalancersRequest");
+    return __isa(o, "GetLoadBalancersRequest");
   }
 }
 
@@ -4461,7 +4464,7 @@ export interface GetLoadBalancersResult extends $MetadataBearer {
 
 export namespace GetLoadBalancersResult {
   export function isa(o: any): o is GetLoadBalancersResult {
-    return _smithy.isa(o, "GetLoadBalancersResult");
+    return __isa(o, "GetLoadBalancersResult");
   }
 }
 
@@ -4475,7 +4478,7 @@ export interface GetOperationRequest {
 
 export namespace GetOperationRequest {
   export function isa(o: any): o is GetOperationRequest {
-    return _smithy.isa(o, "GetOperationRequest");
+    return __isa(o, "GetOperationRequest");
   }
 }
 
@@ -4490,7 +4493,7 @@ export interface GetOperationResult extends $MetadataBearer {
 
 export namespace GetOperationResult {
   export function isa(o: any): o is GetOperationResult {
-    return _smithy.isa(o, "GetOperationResult");
+    return __isa(o, "GetOperationResult");
   }
 }
 
@@ -4510,7 +4513,7 @@ export interface GetOperationsForResourceRequest {
 
 export namespace GetOperationsForResourceRequest {
   export function isa(o: any): o is GetOperationsForResourceRequest {
-    return _smithy.isa(o, "GetOperationsForResourceRequest");
+    return __isa(o, "GetOperationsForResourceRequest");
   }
 }
 
@@ -4541,7 +4544,7 @@ export interface GetOperationsForResourceResult extends $MetadataBearer {
 
 export namespace GetOperationsForResourceResult {
   export function isa(o: any): o is GetOperationsForResourceResult {
-    return _smithy.isa(o, "GetOperationsForResourceResult");
+    return __isa(o, "GetOperationsForResourceResult");
   }
 }
 
@@ -4556,7 +4559,7 @@ export interface GetOperationsRequest {
 
 export namespace GetOperationsRequest {
   export function isa(o: any): o is GetOperationsRequest {
-    return _smithy.isa(o, "GetOperationsRequest");
+    return __isa(o, "GetOperationsRequest");
   }
 }
 
@@ -4577,7 +4580,7 @@ export interface GetOperationsResult extends $MetadataBearer {
 
 export namespace GetOperationsResult {
   export function isa(o: any): o is GetOperationsResult {
-    return _smithy.isa(o, "GetOperationsResult");
+    return __isa(o, "GetOperationsResult");
   }
 }
 
@@ -4600,7 +4603,7 @@ export interface GetRegionsRequest {
 
 export namespace GetRegionsRequest {
   export function isa(o: any): o is GetRegionsRequest {
-    return _smithy.isa(o, "GetRegionsRequest");
+    return __isa(o, "GetRegionsRequest");
   }
 }
 
@@ -4615,7 +4618,7 @@ export interface GetRegionsResult extends $MetadataBearer {
 
 export namespace GetRegionsResult {
   export function isa(o: any): o is GetRegionsResult {
-    return _smithy.isa(o, "GetRegionsResult");
+    return __isa(o, "GetRegionsResult");
   }
 }
 
@@ -4630,7 +4633,7 @@ export interface GetRelationalDatabaseBlueprintsRequest {
 
 export namespace GetRelationalDatabaseBlueprintsRequest {
   export function isa(o: any): o is GetRelationalDatabaseBlueprintsRequest {
-    return _smithy.isa(o, "GetRelationalDatabaseBlueprintsRequest");
+    return __isa(o, "GetRelationalDatabaseBlueprintsRequest");
   }
 }
 
@@ -4651,7 +4654,7 @@ export interface GetRelationalDatabaseBlueprintsResult extends $MetadataBearer {
 
 export namespace GetRelationalDatabaseBlueprintsResult {
   export function isa(o: any): o is GetRelationalDatabaseBlueprintsResult {
-    return _smithy.isa(o, "GetRelationalDatabaseBlueprintsResult");
+    return __isa(o, "GetRelationalDatabaseBlueprintsResult");
   }
 }
 
@@ -4666,7 +4669,7 @@ export interface GetRelationalDatabaseBundlesRequest {
 
 export namespace GetRelationalDatabaseBundlesRequest {
   export function isa(o: any): o is GetRelationalDatabaseBundlesRequest {
-    return _smithy.isa(o, "GetRelationalDatabaseBundlesRequest");
+    return __isa(o, "GetRelationalDatabaseBundlesRequest");
   }
 }
 
@@ -4687,7 +4690,7 @@ export interface GetRelationalDatabaseBundlesResult extends $MetadataBearer {
 
 export namespace GetRelationalDatabaseBundlesResult {
   export function isa(o: any): o is GetRelationalDatabaseBundlesResult {
-    return _smithy.isa(o, "GetRelationalDatabaseBundlesResult");
+    return __isa(o, "GetRelationalDatabaseBundlesResult");
   }
 }
 
@@ -4716,7 +4719,7 @@ export interface GetRelationalDatabaseEventsRequest {
 
 export namespace GetRelationalDatabaseEventsRequest {
   export function isa(o: any): o is GetRelationalDatabaseEventsRequest {
-    return _smithy.isa(o, "GetRelationalDatabaseEventsRequest");
+    return __isa(o, "GetRelationalDatabaseEventsRequest");
   }
 }
 
@@ -4737,7 +4740,7 @@ export interface GetRelationalDatabaseEventsResult extends $MetadataBearer {
 
 export namespace GetRelationalDatabaseEventsResult {
   export function isa(o: any): o is GetRelationalDatabaseEventsResult {
-    return _smithy.isa(o, "GetRelationalDatabaseEventsResult");
+    return __isa(o, "GetRelationalDatabaseEventsResult");
   }
 }
 
@@ -4808,7 +4811,7 @@ export interface GetRelationalDatabaseLogEventsRequest {
 
 export namespace GetRelationalDatabaseLogEventsRequest {
   export function isa(o: any): o is GetRelationalDatabaseLogEventsRequest {
-    return _smithy.isa(o, "GetRelationalDatabaseLogEventsRequest");
+    return __isa(o, "GetRelationalDatabaseLogEventsRequest");
   }
 }
 
@@ -4835,7 +4838,7 @@ export interface GetRelationalDatabaseLogEventsResult extends $MetadataBearer {
 
 export namespace GetRelationalDatabaseLogEventsResult {
   export function isa(o: any): o is GetRelationalDatabaseLogEventsResult {
-    return _smithy.isa(o, "GetRelationalDatabaseLogEventsResult");
+    return __isa(o, "GetRelationalDatabaseLogEventsResult");
   }
 }
 
@@ -4849,7 +4852,7 @@ export interface GetRelationalDatabaseLogStreamsRequest {
 
 export namespace GetRelationalDatabaseLogStreamsRequest {
   export function isa(o: any): o is GetRelationalDatabaseLogStreamsRequest {
-    return _smithy.isa(o, "GetRelationalDatabaseLogStreamsRequest");
+    return __isa(o, "GetRelationalDatabaseLogStreamsRequest");
   }
 }
 
@@ -4864,7 +4867,7 @@ export interface GetRelationalDatabaseLogStreamsResult extends $MetadataBearer {
 
 export namespace GetRelationalDatabaseLogStreamsResult {
   export function isa(o: any): o is GetRelationalDatabaseLogStreamsResult {
-    return _smithy.isa(o, "GetRelationalDatabaseLogStreamsResult");
+    return __isa(o, "GetRelationalDatabaseLogStreamsResult");
   }
 }
 
@@ -4892,7 +4895,7 @@ export namespace GetRelationalDatabaseMasterUserPasswordRequest {
   export function isa(
     o: any
   ): o is GetRelationalDatabaseMasterUserPasswordRequest {
-    return _smithy.isa(o, "GetRelationalDatabaseMasterUserPasswordRequest");
+    return __isa(o, "GetRelationalDatabaseMasterUserPasswordRequest");
   }
 }
 
@@ -4915,7 +4918,7 @@ export namespace GetRelationalDatabaseMasterUserPasswordResult {
   export function isa(
     o: any
   ): o is GetRelationalDatabaseMasterUserPasswordResult {
-    return _smithy.isa(o, "GetRelationalDatabaseMasterUserPasswordResult");
+    return __isa(o, "GetRelationalDatabaseMasterUserPasswordResult");
   }
 }
 
@@ -4983,7 +4986,7 @@ export interface GetRelationalDatabaseMetricDataRequest {
 
 export namespace GetRelationalDatabaseMetricDataRequest {
   export function isa(o: any): o is GetRelationalDatabaseMetricDataRequest {
-    return _smithy.isa(o, "GetRelationalDatabaseMetricDataRequest");
+    return __isa(o, "GetRelationalDatabaseMetricDataRequest");
   }
 }
 
@@ -5003,7 +5006,7 @@ export interface GetRelationalDatabaseMetricDataResult extends $MetadataBearer {
 
 export namespace GetRelationalDatabaseMetricDataResult {
   export function isa(o: any): o is GetRelationalDatabaseMetricDataResult {
-    return _smithy.isa(o, "GetRelationalDatabaseMetricDataResult");
+    return __isa(o, "GetRelationalDatabaseMetricDataResult");
   }
 }
 
@@ -5023,7 +5026,7 @@ export interface GetRelationalDatabaseParametersRequest {
 
 export namespace GetRelationalDatabaseParametersRequest {
   export function isa(o: any): o is GetRelationalDatabaseParametersRequest {
-    return _smithy.isa(o, "GetRelationalDatabaseParametersRequest");
+    return __isa(o, "GetRelationalDatabaseParametersRequest");
   }
 }
 
@@ -5044,7 +5047,7 @@ export interface GetRelationalDatabaseParametersResult extends $MetadataBearer {
 
 export namespace GetRelationalDatabaseParametersResult {
   export function isa(o: any): o is GetRelationalDatabaseParametersResult {
-    return _smithy.isa(o, "GetRelationalDatabaseParametersResult");
+    return __isa(o, "GetRelationalDatabaseParametersResult");
   }
 }
 
@@ -5058,7 +5061,7 @@ export interface GetRelationalDatabaseRequest {
 
 export namespace GetRelationalDatabaseRequest {
   export function isa(o: any): o is GetRelationalDatabaseRequest {
-    return _smithy.isa(o, "GetRelationalDatabaseRequest");
+    return __isa(o, "GetRelationalDatabaseRequest");
   }
 }
 
@@ -5072,7 +5075,7 @@ export interface GetRelationalDatabaseResult extends $MetadataBearer {
 
 export namespace GetRelationalDatabaseResult {
   export function isa(o: any): o is GetRelationalDatabaseResult {
-    return _smithy.isa(o, "GetRelationalDatabaseResult");
+    return __isa(o, "GetRelationalDatabaseResult");
   }
 }
 
@@ -5086,7 +5089,7 @@ export interface GetRelationalDatabaseSnapshotRequest {
 
 export namespace GetRelationalDatabaseSnapshotRequest {
   export function isa(o: any): o is GetRelationalDatabaseSnapshotRequest {
-    return _smithy.isa(o, "GetRelationalDatabaseSnapshotRequest");
+    return __isa(o, "GetRelationalDatabaseSnapshotRequest");
   }
 }
 
@@ -5100,7 +5103,7 @@ export interface GetRelationalDatabaseSnapshotResult extends $MetadataBearer {
 
 export namespace GetRelationalDatabaseSnapshotResult {
   export function isa(o: any): o is GetRelationalDatabaseSnapshotResult {
-    return _smithy.isa(o, "GetRelationalDatabaseSnapshotResult");
+    return __isa(o, "GetRelationalDatabaseSnapshotResult");
   }
 }
 
@@ -5115,7 +5118,7 @@ export interface GetRelationalDatabaseSnapshotsRequest {
 
 export namespace GetRelationalDatabaseSnapshotsRequest {
   export function isa(o: any): o is GetRelationalDatabaseSnapshotsRequest {
-    return _smithy.isa(o, "GetRelationalDatabaseSnapshotsRequest");
+    return __isa(o, "GetRelationalDatabaseSnapshotsRequest");
   }
 }
 
@@ -5136,7 +5139,7 @@ export interface GetRelationalDatabaseSnapshotsResult extends $MetadataBearer {
 
 export namespace GetRelationalDatabaseSnapshotsResult {
   export function isa(o: any): o is GetRelationalDatabaseSnapshotsResult {
-    return _smithy.isa(o, "GetRelationalDatabaseSnapshotsResult");
+    return __isa(o, "GetRelationalDatabaseSnapshotsResult");
   }
 }
 
@@ -5151,7 +5154,7 @@ export interface GetRelationalDatabasesRequest {
 
 export namespace GetRelationalDatabasesRequest {
   export function isa(o: any): o is GetRelationalDatabasesRequest {
-    return _smithy.isa(o, "GetRelationalDatabasesRequest");
+    return __isa(o, "GetRelationalDatabasesRequest");
   }
 }
 
@@ -5171,7 +5174,7 @@ export interface GetRelationalDatabasesResult extends $MetadataBearer {
 
 export namespace GetRelationalDatabasesResult {
   export function isa(o: any): o is GetRelationalDatabasesResult {
-    return _smithy.isa(o, "GetRelationalDatabasesResult");
+    return __isa(o, "GetRelationalDatabasesResult");
   }
 }
 
@@ -5185,7 +5188,7 @@ export interface GetStaticIpRequest {
 
 export namespace GetStaticIpRequest {
   export function isa(o: any): o is GetStaticIpRequest {
-    return _smithy.isa(o, "GetStaticIpRequest");
+    return __isa(o, "GetStaticIpRequest");
   }
 }
 
@@ -5200,7 +5203,7 @@ export interface GetStaticIpResult extends $MetadataBearer {
 
 export namespace GetStaticIpResult {
   export function isa(o: any): o is GetStaticIpResult {
-    return _smithy.isa(o, "GetStaticIpResult");
+    return __isa(o, "GetStaticIpResult");
   }
 }
 
@@ -5215,7 +5218,7 @@ export interface GetStaticIpsRequest {
 
 export namespace GetStaticIpsRequest {
   export function isa(o: any): o is GetStaticIpsRequest {
-    return _smithy.isa(o, "GetStaticIpsRequest");
+    return __isa(o, "GetStaticIpsRequest");
   }
 }
 
@@ -5236,7 +5239,7 @@ export interface GetStaticIpsResult extends $MetadataBearer {
 
 export namespace GetStaticIpsResult {
   export function isa(o: any): o is GetStaticIpsResult {
-    return _smithy.isa(o, "GetStaticIpsResult");
+    return __isa(o, "GetStaticIpsResult");
   }
 }
 
@@ -5316,7 +5319,7 @@ export interface HostKeyAttributes {
 
 export namespace HostKeyAttributes {
   export function isa(o: any): o is HostKeyAttributes {
-    return _smithy.isa(o, "HostKeyAttributes");
+    return __isa(o, "HostKeyAttributes");
   }
 }
 
@@ -5335,7 +5338,7 @@ export interface ImportKeyPairRequest {
 
 export namespace ImportKeyPairRequest {
   export function isa(o: any): o is ImportKeyPairRequest {
-    return _smithy.isa(o, "ImportKeyPairRequest");
+    return __isa(o, "ImportKeyPairRequest");
   }
 }
 
@@ -5350,7 +5353,7 @@ export interface ImportKeyPairResult extends $MetadataBearer {
 
 export namespace ImportKeyPairResult {
   export function isa(o: any): o is ImportKeyPairResult {
-    return _smithy.isa(o, "ImportKeyPairResult");
+    return __isa(o, "ImportKeyPairResult");
   }
 }
 
@@ -5472,7 +5475,7 @@ export interface Instance {
 
 export namespace Instance {
   export function isa(o: any): o is Instance {
-    return _smithy.isa(o, "Instance");
+    return __isa(o, "Instance");
   }
 }
 
@@ -5551,7 +5554,7 @@ export interface InstanceAccessDetails {
 
 export namespace InstanceAccessDetails {
   export function isa(o: any): o is InstanceAccessDetails {
-    return _smithy.isa(o, "InstanceAccessDetails");
+    return __isa(o, "InstanceAccessDetails");
   }
 }
 
@@ -5618,7 +5621,7 @@ export interface InstanceEntry {
 
 export namespace InstanceEntry {
   export function isa(o: any): o is InstanceEntry {
-    return _smithy.isa(o, "InstanceEntry");
+    return __isa(o, "InstanceEntry");
   }
 }
 
@@ -5645,7 +5648,7 @@ export interface InstanceHardware {
 
 export namespace InstanceHardware {
   export function isa(o: any): o is InstanceHardware {
-    return _smithy.isa(o, "InstanceHardware");
+    return __isa(o, "InstanceHardware");
   }
 }
 
@@ -5814,7 +5817,7 @@ export interface InstanceHealthSummary {
 
 export namespace InstanceHealthSummary {
   export function isa(o: any): o is InstanceHealthSummary {
-    return _smithy.isa(o, "InstanceHealthSummary");
+    return __isa(o, "InstanceHealthSummary");
   }
 }
 
@@ -5846,7 +5849,7 @@ export interface InstanceNetworking {
 
 export namespace InstanceNetworking {
   export function isa(o: any): o is InstanceNetworking {
-    return _smithy.isa(o, "InstanceNetworking");
+    return __isa(o, "InstanceNetworking");
   }
 }
 
@@ -5923,7 +5926,7 @@ export interface InstancePortInfo {
 
 export namespace InstancePortInfo {
   export function isa(o: any): o is InstancePortInfo {
-    return _smithy.isa(o, "InstancePortInfo");
+    return __isa(o, "InstancePortInfo");
   }
 }
 
@@ -5980,7 +5983,7 @@ export interface InstancePortState {
 
 export namespace InstancePortState {
   export function isa(o: any): o is InstancePortState {
-    return _smithy.isa(o, "InstancePortState");
+    return __isa(o, "InstancePortState");
   }
 }
 
@@ -6085,7 +6088,7 @@ export interface InstanceSnapshot {
 
 export namespace InstanceSnapshot {
   export function isa(o: any): o is InstanceSnapshot {
-    return _smithy.isa(o, "InstanceSnapshot");
+    return __isa(o, "InstanceSnapshot");
   }
 }
 
@@ -6114,7 +6117,7 @@ export interface InstanceSnapshotInfo {
 
 export namespace InstanceSnapshotInfo {
   export function isa(o: any): o is InstanceSnapshotInfo {
-    return _smithy.isa(o, "InstanceSnapshotInfo");
+    return __isa(o, "InstanceSnapshotInfo");
   }
 }
 
@@ -6144,7 +6147,7 @@ export interface InstanceState {
 
 export namespace InstanceState {
   export function isa(o: any): o is InstanceState {
-    return _smithy.isa(o, "InstanceState");
+    return __isa(o, "InstanceState");
   }
 }
 
@@ -6158,7 +6161,7 @@ export namespace InstanceState {
  *          </note>
  */
 export interface InvalidInputException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidInputException";
   $fault: "client";
@@ -6170,7 +6173,7 @@ export interface InvalidInputException
 
 export namespace InvalidInputException {
   export function isa(o: any): o is InvalidInputException {
-    return _smithy.isa(o, "InvalidInputException");
+    return __isa(o, "InvalidInputException");
   }
 }
 
@@ -6180,7 +6183,7 @@ export interface IsVpcPeeredRequest {
 
 export namespace IsVpcPeeredRequest {
   export function isa(o: any): o is IsVpcPeeredRequest {
-    return _smithy.isa(o, "IsVpcPeeredRequest");
+    return __isa(o, "IsVpcPeeredRequest");
   }
 }
 
@@ -6195,7 +6198,7 @@ export interface IsVpcPeeredResult extends $MetadataBearer {
 
 export namespace IsVpcPeeredResult {
   export function isa(o: any): o is IsVpcPeeredResult {
-    return _smithy.isa(o, "IsVpcPeeredResult");
+    return __isa(o, "IsVpcPeeredResult");
   }
 }
 
@@ -6253,7 +6256,7 @@ export interface KeyPair {
 
 export namespace KeyPair {
   export function isa(o: any): o is KeyPair {
-    return _smithy.isa(o, "KeyPair");
+    return __isa(o, "KeyPair");
   }
 }
 
@@ -6359,7 +6362,7 @@ export interface LoadBalancer {
 
 export namespace LoadBalancer {
   export function isa(o: any): o is LoadBalancer {
-    return _smithy.isa(o, "LoadBalancer");
+    return __isa(o, "LoadBalancer");
   }
 }
 
@@ -6617,7 +6620,7 @@ export interface LoadBalancerTlsCertificate {
 
 export namespace LoadBalancerTlsCertificate {
   export function isa(o: any): o is LoadBalancerTlsCertificate {
-    return _smithy.isa(o, "LoadBalancerTlsCertificate");
+    return __isa(o, "LoadBalancerTlsCertificate");
   }
 }
 
@@ -6648,7 +6651,7 @@ export namespace LoadBalancerTlsCertificateDomainValidationOption {
   export function isa(
     o: any
   ): o is LoadBalancerTlsCertificateDomainValidationOption {
-    return _smithy.isa(o, "LoadBalancerTlsCertificateDomainValidationOption");
+    return __isa(o, "LoadBalancerTlsCertificateDomainValidationOption");
   }
 }
 
@@ -6690,7 +6693,7 @@ export namespace LoadBalancerTlsCertificateDomainValidationRecord {
   export function isa(
     o: any
   ): o is LoadBalancerTlsCertificateDomainValidationRecord {
-    return _smithy.isa(o, "LoadBalancerTlsCertificateDomainValidationRecord");
+    return __isa(o, "LoadBalancerTlsCertificateDomainValidationRecord");
   }
 }
 
@@ -6733,7 +6736,7 @@ export interface LoadBalancerTlsCertificateRenewalSummary {
 
 export namespace LoadBalancerTlsCertificateRenewalSummary {
   export function isa(o: any): o is LoadBalancerTlsCertificateRenewalSummary {
-    return _smithy.isa(o, "LoadBalancerTlsCertificateRenewalSummary");
+    return __isa(o, "LoadBalancerTlsCertificateRenewalSummary");
   }
 }
 
@@ -6780,7 +6783,7 @@ export interface LoadBalancerTlsCertificateSummary {
 
 export namespace LoadBalancerTlsCertificateSummary {
   export function isa(o: any): o is LoadBalancerTlsCertificateSummary {
-    return _smithy.isa(o, "LoadBalancerTlsCertificateSummary");
+    return __isa(o, "LoadBalancerTlsCertificateSummary");
   }
 }
 
@@ -6802,7 +6805,7 @@ export interface LogEvent {
 
 export namespace LogEvent {
   export function isa(o: any): o is LogEvent {
-    return _smithy.isa(o, "LogEvent");
+    return __isa(o, "LogEvent");
   }
 }
 
@@ -6849,7 +6852,7 @@ export interface MetricDatapoint {
 
 export namespace MetricDatapoint {
   export function isa(o: any): o is MetricDatapoint {
-    return _smithy.isa(o, "MetricDatapoint");
+    return __isa(o, "MetricDatapoint");
   }
 }
 
@@ -6905,7 +6908,7 @@ export interface MonthlyTransfer {
 
 export namespace MonthlyTransfer {
   export function isa(o: any): o is MonthlyTransfer {
-    return _smithy.isa(o, "MonthlyTransfer");
+    return __isa(o, "MonthlyTransfer");
   }
 }
 
@@ -6918,9 +6921,7 @@ export enum NetworkProtocol {
 /**
  * <p>Lightsail throws this exception when it cannot find a resource.</p>
  */
-export interface NotFoundException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface NotFoundException extends __SmithyException, $MetadataBearer {
   name: "NotFoundException";
   $fault: "client";
   code?: string;
@@ -6931,7 +6932,7 @@ export interface NotFoundException
 
 export namespace NotFoundException {
   export function isa(o: any): o is NotFoundException {
-    return _smithy.isa(o, "NotFoundException");
+    return __isa(o, "NotFoundException");
   }
 }
 
@@ -6950,7 +6951,7 @@ export interface OpenInstancePublicPortsRequest {
 
 export namespace OpenInstancePublicPortsRequest {
   export function isa(o: any): o is OpenInstancePublicPortsRequest {
-    return _smithy.isa(o, "OpenInstancePublicPortsRequest");
+    return __isa(o, "OpenInstancePublicPortsRequest");
   }
 }
 
@@ -6965,7 +6966,7 @@ export interface OpenInstancePublicPortsResult extends $MetadataBearer {
 
 export namespace OpenInstancePublicPortsResult {
   export function isa(o: any): o is OpenInstancePublicPortsResult {
-    return _smithy.isa(o, "OpenInstancePublicPortsResult");
+    return __isa(o, "OpenInstancePublicPortsResult");
   }
 }
 
@@ -7039,7 +7040,7 @@ export interface Operation {
 
 export namespace Operation {
   export function isa(o: any): o is Operation {
-    return _smithy.isa(o, "Operation");
+    return __isa(o, "Operation");
   }
 }
 
@@ -7047,7 +7048,7 @@ export namespace Operation {
  * <p>Lightsail throws this exception when an operation fails to execute.</p>
  */
 export interface OperationFailureException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "OperationFailureException";
   $fault: "client";
@@ -7059,7 +7060,7 @@ export interface OperationFailureException
 
 export namespace OperationFailureException {
   export function isa(o: any): o is OperationFailureException {
-    return _smithy.isa(o, "OperationFailureException");
+    return __isa(o, "OperationFailureException");
   }
 }
 
@@ -7156,7 +7157,7 @@ export interface PasswordData {
 
 export namespace PasswordData {
   export function isa(o: any): o is PasswordData {
-    return _smithy.isa(o, "PasswordData");
+    return __isa(o, "PasswordData");
   }
 }
 
@@ -7166,7 +7167,7 @@ export interface PeerVpcRequest {
 
 export namespace PeerVpcRequest {
   export function isa(o: any): o is PeerVpcRequest {
-    return _smithy.isa(o, "PeerVpcRequest");
+    return __isa(o, "PeerVpcRequest");
   }
 }
 
@@ -7181,7 +7182,7 @@ export interface PeerVpcResult extends $MetadataBearer {
 
 export namespace PeerVpcResult {
   export function isa(o: any): o is PeerVpcResult {
-    return _smithy.isa(o, "PeerVpcResult");
+    return __isa(o, "PeerVpcResult");
   }
 }
 
@@ -7208,7 +7209,7 @@ export interface PendingMaintenanceAction {
 
 export namespace PendingMaintenanceAction {
   export function isa(o: any): o is PendingMaintenanceAction {
-    return _smithy.isa(o, "PendingMaintenanceAction");
+    return __isa(o, "PendingMaintenanceAction");
   }
 }
 
@@ -7235,7 +7236,7 @@ export interface PendingModifiedRelationalDatabaseValues {
 
 export namespace PendingModifiedRelationalDatabaseValues {
   export function isa(o: any): o is PendingModifiedRelationalDatabaseValues {
-    return _smithy.isa(o, "PendingModifiedRelationalDatabaseValues");
+    return __isa(o, "PendingModifiedRelationalDatabaseValues");
   }
 }
 
@@ -7268,7 +7269,7 @@ export interface PortInfo {
 
 export namespace PortInfo {
   export function isa(o: any): o is PortInfo {
-    return _smithy.isa(o, "PortInfo");
+    return __isa(o, "PortInfo");
   }
 }
 
@@ -7299,7 +7300,7 @@ export interface PutInstancePublicPortsRequest {
 
 export namespace PutInstancePublicPortsRequest {
   export function isa(o: any): o is PutInstancePublicPortsRequest {
-    return _smithy.isa(o, "PutInstancePublicPortsRequest");
+    return __isa(o, "PutInstancePublicPortsRequest");
   }
 }
 
@@ -7313,7 +7314,7 @@ export interface PutInstancePublicPortsResult extends $MetadataBearer {
 
 export namespace PutInstancePublicPortsResult {
   export function isa(o: any): o is PutInstancePublicPortsResult {
-    return _smithy.isa(o, "PutInstancePublicPortsResult");
+    return __isa(o, "PutInstancePublicPortsResult");
   }
 }
 
@@ -7327,7 +7328,7 @@ export interface RebootInstanceRequest {
 
 export namespace RebootInstanceRequest {
   export function isa(o: any): o is RebootInstanceRequest {
-    return _smithy.isa(o, "RebootInstanceRequest");
+    return __isa(o, "RebootInstanceRequest");
   }
 }
 
@@ -7342,7 +7343,7 @@ export interface RebootInstanceResult extends $MetadataBearer {
 
 export namespace RebootInstanceResult {
   export function isa(o: any): o is RebootInstanceResult {
-    return _smithy.isa(o, "RebootInstanceResult");
+    return __isa(o, "RebootInstanceResult");
   }
 }
 
@@ -7356,7 +7357,7 @@ export interface RebootRelationalDatabaseRequest {
 
 export namespace RebootRelationalDatabaseRequest {
   export function isa(o: any): o is RebootRelationalDatabaseRequest {
-    return _smithy.isa(o, "RebootRelationalDatabaseRequest");
+    return __isa(o, "RebootRelationalDatabaseRequest");
   }
 }
 
@@ -7370,7 +7371,7 @@ export interface RebootRelationalDatabaseResult extends $MetadataBearer {
 
 export namespace RebootRelationalDatabaseResult {
   export function isa(o: any): o is RebootRelationalDatabaseResult {
-    return _smithy.isa(o, "RebootRelationalDatabaseResult");
+    return __isa(o, "RebootRelationalDatabaseResult");
   }
 }
 
@@ -7421,7 +7422,7 @@ export interface Region {
 
 export namespace Region {
   export function isa(o: any): o is Region {
-    return _smithy.isa(o, "Region");
+    return __isa(o, "Region");
   }
 }
 
@@ -7596,7 +7597,7 @@ export interface RelationalDatabase {
 
 export namespace RelationalDatabase {
   export function isa(o: any): o is RelationalDatabase {
-    return _smithy.isa(o, "RelationalDatabase");
+    return __isa(o, "RelationalDatabase");
   }
 }
 
@@ -7642,7 +7643,7 @@ export interface RelationalDatabaseBlueprint {
 
 export namespace RelationalDatabaseBlueprint {
   export function isa(o: any): o is RelationalDatabaseBlueprint {
-    return _smithy.isa(o, "RelationalDatabaseBlueprint");
+    return __isa(o, "RelationalDatabaseBlueprint");
   }
 }
 
@@ -7701,7 +7702,7 @@ export interface RelationalDatabaseBundle {
 
 export namespace RelationalDatabaseBundle {
   export function isa(o: any): o is RelationalDatabaseBundle {
-    return _smithy.isa(o, "RelationalDatabaseBundle");
+    return __isa(o, "RelationalDatabaseBundle");
   }
 }
 
@@ -7723,7 +7724,7 @@ export interface RelationalDatabaseEndpoint {
 
 export namespace RelationalDatabaseEndpoint {
   export function isa(o: any): o is RelationalDatabaseEndpoint {
-    return _smithy.isa(o, "RelationalDatabaseEndpoint");
+    return __isa(o, "RelationalDatabaseEndpoint");
   }
 }
 
@@ -7759,7 +7760,7 @@ export interface RelationalDatabaseEvent {
 
 export namespace RelationalDatabaseEvent {
   export function isa(o: any): o is RelationalDatabaseEvent {
-    return _smithy.isa(o, "RelationalDatabaseEvent");
+    return __isa(o, "RelationalDatabaseEvent");
   }
 }
 
@@ -7786,7 +7787,7 @@ export interface RelationalDatabaseHardware {
 
 export namespace RelationalDatabaseHardware {
   export function isa(o: any): o is RelationalDatabaseHardware {
-    return _smithy.isa(o, "RelationalDatabaseHardware");
+    return __isa(o, "RelationalDatabaseHardware");
   }
 }
 
@@ -7848,7 +7849,7 @@ export interface RelationalDatabaseParameter {
 
 export namespace RelationalDatabaseParameter {
   export function isa(o: any): o is RelationalDatabaseParameter {
-    return _smithy.isa(o, "RelationalDatabaseParameter");
+    return __isa(o, "RelationalDatabaseParameter");
   }
 }
 
@@ -7949,7 +7950,7 @@ export interface RelationalDatabaseSnapshot {
 
 export namespace RelationalDatabaseSnapshot {
   export function isa(o: any): o is RelationalDatabaseSnapshot {
-    return _smithy.isa(o, "RelationalDatabaseSnapshot");
+    return __isa(o, "RelationalDatabaseSnapshot");
   }
 }
 
@@ -7963,7 +7964,7 @@ export interface ReleaseStaticIpRequest {
 
 export namespace ReleaseStaticIpRequest {
   export function isa(o: any): o is ReleaseStaticIpRequest {
-    return _smithy.isa(o, "ReleaseStaticIpRequest");
+    return __isa(o, "ReleaseStaticIpRequest");
   }
 }
 
@@ -7978,7 +7979,7 @@ export interface ReleaseStaticIpResult extends $MetadataBearer {
 
 export namespace ReleaseStaticIpResult {
   export function isa(o: any): o is ReleaseStaticIpResult {
-    return _smithy.isa(o, "ReleaseStaticIpResult");
+    return __isa(o, "ReleaseStaticIpResult");
   }
 }
 
@@ -8001,7 +8002,7 @@ export interface ResourceLocation {
 
 export namespace ResourceLocation {
   export function isa(o: any): o is ResourceLocation {
-    return _smithy.isa(o, "ResourceLocation");
+    return __isa(o, "ResourceLocation");
   }
 }
 
@@ -8025,9 +8026,7 @@ export enum ResourceType {
 /**
  * <p>A general service exception.</p>
  */
-export interface ServiceException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface ServiceException extends __SmithyException, $MetadataBearer {
   name: "ServiceException";
   $fault: "server";
   code?: string;
@@ -8038,7 +8037,7 @@ export interface ServiceException
 
 export namespace ServiceException {
   export function isa(o: any): o is ServiceException {
-    return _smithy.isa(o, "ServiceException");
+    return __isa(o, "ServiceException");
   }
 }
 
@@ -8052,7 +8051,7 @@ export interface StartInstanceRequest {
 
 export namespace StartInstanceRequest {
   export function isa(o: any): o is StartInstanceRequest {
-    return _smithy.isa(o, "StartInstanceRequest");
+    return __isa(o, "StartInstanceRequest");
   }
 }
 
@@ -8067,7 +8066,7 @@ export interface StartInstanceResult extends $MetadataBearer {
 
 export namespace StartInstanceResult {
   export function isa(o: any): o is StartInstanceResult {
-    return _smithy.isa(o, "StartInstanceResult");
+    return __isa(o, "StartInstanceResult");
   }
 }
 
@@ -8081,7 +8080,7 @@ export interface StartRelationalDatabaseRequest {
 
 export namespace StartRelationalDatabaseRequest {
   export function isa(o: any): o is StartRelationalDatabaseRequest {
-    return _smithy.isa(o, "StartRelationalDatabaseRequest");
+    return __isa(o, "StartRelationalDatabaseRequest");
   }
 }
 
@@ -8095,7 +8094,7 @@ export interface StartRelationalDatabaseResult extends $MetadataBearer {
 
 export namespace StartRelationalDatabaseResult {
   export function isa(o: any): o is StartRelationalDatabaseResult {
-    return _smithy.isa(o, "StartRelationalDatabaseResult");
+    return __isa(o, "StartRelationalDatabaseResult");
   }
 }
 
@@ -8157,7 +8156,7 @@ export interface StaticIp {
 
 export namespace StaticIp {
   export function isa(o: any): o is StaticIp {
-    return _smithy.isa(o, "StaticIp");
+    return __isa(o, "StaticIp");
   }
 }
 
@@ -8182,7 +8181,7 @@ export interface StopInstanceRequest {
 
 export namespace StopInstanceRequest {
   export function isa(o: any): o is StopInstanceRequest {
-    return _smithy.isa(o, "StopInstanceRequest");
+    return __isa(o, "StopInstanceRequest");
   }
 }
 
@@ -8197,7 +8196,7 @@ export interface StopInstanceResult extends $MetadataBearer {
 
 export namespace StopInstanceResult {
   export function isa(o: any): o is StopInstanceResult {
-    return _smithy.isa(o, "StopInstanceResult");
+    return __isa(o, "StopInstanceResult");
   }
 }
 
@@ -8217,7 +8216,7 @@ export interface StopRelationalDatabaseRequest {
 
 export namespace StopRelationalDatabaseRequest {
   export function isa(o: any): o is StopRelationalDatabaseRequest {
-    return _smithy.isa(o, "StopRelationalDatabaseRequest");
+    return __isa(o, "StopRelationalDatabaseRequest");
   }
 }
 
@@ -8231,7 +8230,7 @@ export interface StopRelationalDatabaseResult extends $MetadataBearer {
 
 export namespace StopRelationalDatabaseResult {
   export function isa(o: any): o is StopRelationalDatabaseResult {
-    return _smithy.isa(o, "StopRelationalDatabaseResult");
+    return __isa(o, "StopRelationalDatabaseResult");
   }
 }
 
@@ -8259,7 +8258,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -8283,7 +8282,7 @@ export interface TagResourceRequest {
 
 export namespace TagResourceRequest {
   export function isa(o: any): o is TagResourceRequest {
-    return _smithy.isa(o, "TagResourceRequest");
+    return __isa(o, "TagResourceRequest");
   }
 }
 
@@ -8297,7 +8296,7 @@ export interface TagResourceResult extends $MetadataBearer {
 
 export namespace TagResourceResult {
   export function isa(o: any): o is TagResourceResult {
-    return _smithy.isa(o, "TagResourceResult");
+    return __isa(o, "TagResourceResult");
   }
 }
 
@@ -8305,7 +8304,7 @@ export namespace TagResourceResult {
  * <p>Lightsail throws this exception when the user has not been authenticated.</p>
  */
 export interface UnauthenticatedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UnauthenticatedException";
   $fault: "client";
@@ -8317,7 +8316,7 @@ export interface UnauthenticatedException
 
 export namespace UnauthenticatedException {
   export function isa(o: any): o is UnauthenticatedException {
-    return _smithy.isa(o, "UnauthenticatedException");
+    return __isa(o, "UnauthenticatedException");
   }
 }
 
@@ -8327,7 +8326,7 @@ export interface UnpeerVpcRequest {
 
 export namespace UnpeerVpcRequest {
   export function isa(o: any): o is UnpeerVpcRequest {
-    return _smithy.isa(o, "UnpeerVpcRequest");
+    return __isa(o, "UnpeerVpcRequest");
   }
 }
 
@@ -8342,7 +8341,7 @@ export interface UnpeerVpcResult extends $MetadataBearer {
 
 export namespace UnpeerVpcResult {
   export function isa(o: any): o is UnpeerVpcResult {
-    return _smithy.isa(o, "UnpeerVpcResult");
+    return __isa(o, "UnpeerVpcResult");
   }
 }
 
@@ -8366,7 +8365,7 @@ export interface UntagResourceRequest {
 
 export namespace UntagResourceRequest {
   export function isa(o: any): o is UntagResourceRequest {
-    return _smithy.isa(o, "UntagResourceRequest");
+    return __isa(o, "UntagResourceRequest");
   }
 }
 
@@ -8380,7 +8379,7 @@ export interface UntagResourceResult extends $MetadataBearer {
 
 export namespace UntagResourceResult {
   export function isa(o: any): o is UntagResourceResult {
-    return _smithy.isa(o, "UntagResourceResult");
+    return __isa(o, "UntagResourceResult");
   }
 }
 
@@ -8399,7 +8398,7 @@ export interface UpdateDomainEntryRequest {
 
 export namespace UpdateDomainEntryRequest {
   export function isa(o: any): o is UpdateDomainEntryRequest {
-    return _smithy.isa(o, "UpdateDomainEntryRequest");
+    return __isa(o, "UpdateDomainEntryRequest");
   }
 }
 
@@ -8414,7 +8413,7 @@ export interface UpdateDomainEntryResult extends $MetadataBearer {
 
 export namespace UpdateDomainEntryResult {
   export function isa(o: any): o is UpdateDomainEntryResult {
-    return _smithy.isa(o, "UpdateDomainEntryResult");
+    return __isa(o, "UpdateDomainEntryResult");
   }
 }
 
@@ -8439,7 +8438,7 @@ export interface UpdateLoadBalancerAttributeRequest {
 
 export namespace UpdateLoadBalancerAttributeRequest {
   export function isa(o: any): o is UpdateLoadBalancerAttributeRequest {
-    return _smithy.isa(o, "UpdateLoadBalancerAttributeRequest");
+    return __isa(o, "UpdateLoadBalancerAttributeRequest");
   }
 }
 
@@ -8453,7 +8452,7 @@ export interface UpdateLoadBalancerAttributeResult extends $MetadataBearer {
 
 export namespace UpdateLoadBalancerAttributeResult {
   export function isa(o: any): o is UpdateLoadBalancerAttributeResult {
-    return _smithy.isa(o, "UpdateLoadBalancerAttributeResult");
+    return __isa(o, "UpdateLoadBalancerAttributeResult");
   }
 }
 
@@ -8472,7 +8471,7 @@ export interface UpdateRelationalDatabaseParametersRequest {
 
 export namespace UpdateRelationalDatabaseParametersRequest {
   export function isa(o: any): o is UpdateRelationalDatabaseParametersRequest {
-    return _smithy.isa(o, "UpdateRelationalDatabaseParametersRequest");
+    return __isa(o, "UpdateRelationalDatabaseParametersRequest");
   }
 }
 
@@ -8488,7 +8487,7 @@ export interface UpdateRelationalDatabaseParametersResult
 
 export namespace UpdateRelationalDatabaseParametersResult {
   export function isa(o: any): o is UpdateRelationalDatabaseParametersResult {
-    return _smithy.isa(o, "UpdateRelationalDatabaseParametersResult");
+    return __isa(o, "UpdateRelationalDatabaseParametersResult");
   }
 }
 
@@ -8606,7 +8605,7 @@ export interface UpdateRelationalDatabaseRequest {
 
 export namespace UpdateRelationalDatabaseRequest {
   export function isa(o: any): o is UpdateRelationalDatabaseRequest {
-    return _smithy.isa(o, "UpdateRelationalDatabaseRequest");
+    return __isa(o, "UpdateRelationalDatabaseRequest");
   }
 }
 
@@ -8620,6 +8619,6 @@ export interface UpdateRelationalDatabaseResult extends $MetadataBearer {
 
 export namespace UpdateRelationalDatabaseResult {
   export function isa(o: any): o is UpdateRelationalDatabaseResult {
-    return _smithy.isa(o, "UpdateRelationalDatabaseResult");
+    return __isa(o, "UpdateRelationalDatabaseResult");
   }
 }

--- a/clients/client-machine-learning/models/index.ts
+++ b/clients/client-machine-learning/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export interface AddTagsInput {
@@ -21,7 +24,7 @@ export interface AddTagsInput {
 
 export namespace AddTagsInput {
   export function isa(o: any): o is AddTagsInput {
-    return _smithy.isa(o, "AddTagsInput");
+    return __isa(o, "AddTagsInput");
   }
 }
 
@@ -43,7 +46,7 @@ export interface AddTagsOutput extends $MetadataBearer {
 
 export namespace AddTagsOutput {
   export function isa(o: any): o is AddTagsOutput {
-    return _smithy.isa(o, "AddTagsOutput");
+    return __isa(o, "AddTagsOutput");
   }
 }
 
@@ -165,7 +168,7 @@ export interface BatchPrediction {
 
 export namespace BatchPrediction {
   export function isa(o: any): o is BatchPrediction {
-    return _smithy.isa(o, "BatchPrediction");
+    return __isa(o, "BatchPrediction");
   }
 }
 
@@ -212,7 +215,7 @@ export interface CreateBatchPredictionInput {
 
 export namespace CreateBatchPredictionInput {
   export function isa(o: any): o is CreateBatchPredictionInput {
-    return _smithy.isa(o, "CreateBatchPredictionInput");
+    return __isa(o, "CreateBatchPredictionInput");
   }
 }
 
@@ -233,7 +236,7 @@ export interface CreateBatchPredictionOutput extends $MetadataBearer {
 
 export namespace CreateBatchPredictionOutput {
   export function isa(o: any): o is CreateBatchPredictionOutput {
-    return _smithy.isa(o, "CreateBatchPredictionOutput");
+    return __isa(o, "CreateBatchPredictionOutput");
   }
 }
 
@@ -320,7 +323,7 @@ export interface CreateDataSourceFromRDSInput {
 
 export namespace CreateDataSourceFromRDSInput {
   export function isa(o: any): o is CreateDataSourceFromRDSInput {
-    return _smithy.isa(o, "CreateDataSourceFromRDSInput");
+    return __isa(o, "CreateDataSourceFromRDSInput");
   }
 }
 
@@ -344,7 +347,7 @@ export interface CreateDataSourceFromRDSOutput extends $MetadataBearer {
 
 export namespace CreateDataSourceFromRDSOutput {
   export function isa(o: any): o is CreateDataSourceFromRDSOutput {
-    return _smithy.isa(o, "CreateDataSourceFromRDSOutput");
+    return __isa(o, "CreateDataSourceFromRDSOutput");
   }
 }
 
@@ -430,7 +433,7 @@ export interface CreateDataSourceFromRedshiftInput {
 
 export namespace CreateDataSourceFromRedshiftInput {
   export function isa(o: any): o is CreateDataSourceFromRedshiftInput {
-    return _smithy.isa(o, "CreateDataSourceFromRedshiftInput");
+    return __isa(o, "CreateDataSourceFromRedshiftInput");
   }
 }
 
@@ -451,7 +454,7 @@ export interface CreateDataSourceFromRedshiftOutput extends $MetadataBearer {
 
 export namespace CreateDataSourceFromRedshiftOutput {
   export function isa(o: any): o is CreateDataSourceFromRedshiftOutput {
-    return _smithy.isa(o, "CreateDataSourceFromRedshiftOutput");
+    return __isa(o, "CreateDataSourceFromRedshiftOutput");
   }
 }
 
@@ -499,7 +502,7 @@ export interface CreateDataSourceFromS3Input {
 
 export namespace CreateDataSourceFromS3Input {
   export function isa(o: any): o is CreateDataSourceFromS3Input {
-    return _smithy.isa(o, "CreateDataSourceFromS3Input");
+    return __isa(o, "CreateDataSourceFromS3Input");
   }
 }
 
@@ -520,7 +523,7 @@ export interface CreateDataSourceFromS3Output extends $MetadataBearer {
 
 export namespace CreateDataSourceFromS3Output {
   export function isa(o: any): o is CreateDataSourceFromS3Output {
-    return _smithy.isa(o, "CreateDataSourceFromS3Output");
+    return __isa(o, "CreateDataSourceFromS3Output");
   }
 }
 
@@ -551,7 +554,7 @@ export interface CreateEvaluationInput {
 
 export namespace CreateEvaluationInput {
   export function isa(o: any): o is CreateEvaluationInput {
-    return _smithy.isa(o, "CreateEvaluationInput");
+    return __isa(o, "CreateEvaluationInput");
   }
 }
 
@@ -574,7 +577,7 @@ export interface CreateEvaluationOutput extends $MetadataBearer {
 
 export namespace CreateEvaluationOutput {
   export function isa(o: any): o is CreateEvaluationOutput {
-    return _smithy.isa(o, "CreateEvaluationOutput");
+    return __isa(o, "CreateEvaluationOutput");
   }
 }
 
@@ -675,7 +678,7 @@ export interface CreateMLModelInput {
 
 export namespace CreateMLModelInput {
   export function isa(o: any): o is CreateMLModelInput {
-    return _smithy.isa(o, "CreateMLModelInput");
+    return __isa(o, "CreateMLModelInput");
   }
 }
 
@@ -697,7 +700,7 @@ export interface CreateMLModelOutput extends $MetadataBearer {
 
 export namespace CreateMLModelOutput {
   export function isa(o: any): o is CreateMLModelOutput {
-    return _smithy.isa(o, "CreateMLModelOutput");
+    return __isa(o, "CreateMLModelOutput");
   }
 }
 
@@ -711,7 +714,7 @@ export interface CreateRealtimeEndpointInput {
 
 export namespace CreateRealtimeEndpointInput {
   export function isa(o: any): o is CreateRealtimeEndpointInput {
-    return _smithy.isa(o, "CreateRealtimeEndpointInput");
+    return __isa(o, "CreateRealtimeEndpointInput");
   }
 }
 
@@ -738,7 +741,7 @@ export interface CreateRealtimeEndpointOutput extends $MetadataBearer {
 
 export namespace CreateRealtimeEndpointOutput {
   export function isa(o: any): o is CreateRealtimeEndpointOutput {
-    return _smithy.isa(o, "CreateRealtimeEndpointOutput");
+    return __isa(o, "CreateRealtimeEndpointOutput");
   }
 }
 
@@ -862,7 +865,7 @@ export interface DataSource {
 
 export namespace DataSource {
   export function isa(o: any): o is DataSource {
-    return _smithy.isa(o, "DataSource");
+    return __isa(o, "DataSource");
   }
 }
 
@@ -885,7 +888,7 @@ export interface DeleteBatchPredictionInput {
 
 export namespace DeleteBatchPredictionInput {
   export function isa(o: any): o is DeleteBatchPredictionInput {
-    return _smithy.isa(o, "DeleteBatchPredictionInput");
+    return __isa(o, "DeleteBatchPredictionInput");
   }
 }
 
@@ -904,7 +907,7 @@ export interface DeleteBatchPredictionOutput extends $MetadataBearer {
 
 export namespace DeleteBatchPredictionOutput {
   export function isa(o: any): o is DeleteBatchPredictionOutput {
-    return _smithy.isa(o, "DeleteBatchPredictionOutput");
+    return __isa(o, "DeleteBatchPredictionOutput");
   }
 }
 
@@ -918,7 +921,7 @@ export interface DeleteDataSourceInput {
 
 export namespace DeleteDataSourceInput {
   export function isa(o: any): o is DeleteDataSourceInput {
-    return _smithy.isa(o, "DeleteDataSourceInput");
+    return __isa(o, "DeleteDataSourceInput");
   }
 }
 
@@ -935,7 +938,7 @@ export interface DeleteDataSourceOutput extends $MetadataBearer {
 
 export namespace DeleteDataSourceOutput {
   export function isa(o: any): o is DeleteDataSourceOutput {
-    return _smithy.isa(o, "DeleteDataSourceOutput");
+    return __isa(o, "DeleteDataSourceOutput");
   }
 }
 
@@ -949,7 +952,7 @@ export interface DeleteEvaluationInput {
 
 export namespace DeleteEvaluationInput {
   export function isa(o: any): o is DeleteEvaluationInput {
-    return _smithy.isa(o, "DeleteEvaluationInput");
+    return __isa(o, "DeleteEvaluationInput");
   }
 }
 
@@ -968,7 +971,7 @@ export interface DeleteEvaluationOutput extends $MetadataBearer {
 
 export namespace DeleteEvaluationOutput {
   export function isa(o: any): o is DeleteEvaluationOutput {
-    return _smithy.isa(o, "DeleteEvaluationOutput");
+    return __isa(o, "DeleteEvaluationOutput");
   }
 }
 
@@ -982,7 +985,7 @@ export interface DeleteMLModelInput {
 
 export namespace DeleteMLModelInput {
   export function isa(o: any): o is DeleteMLModelInput {
-    return _smithy.isa(o, "DeleteMLModelInput");
+    return __isa(o, "DeleteMLModelInput");
   }
 }
 
@@ -1001,7 +1004,7 @@ export interface DeleteMLModelOutput extends $MetadataBearer {
 
 export namespace DeleteMLModelOutput {
   export function isa(o: any): o is DeleteMLModelOutput {
-    return _smithy.isa(o, "DeleteMLModelOutput");
+    return __isa(o, "DeleteMLModelOutput");
   }
 }
 
@@ -1015,7 +1018,7 @@ export interface DeleteRealtimeEndpointInput {
 
 export namespace DeleteRealtimeEndpointInput {
   export function isa(o: any): o is DeleteRealtimeEndpointInput {
-    return _smithy.isa(o, "DeleteRealtimeEndpointInput");
+    return __isa(o, "DeleteRealtimeEndpointInput");
   }
 }
 
@@ -1040,7 +1043,7 @@ export interface DeleteRealtimeEndpointOutput extends $MetadataBearer {
 
 export namespace DeleteRealtimeEndpointOutput {
   export function isa(o: any): o is DeleteRealtimeEndpointOutput {
-    return _smithy.isa(o, "DeleteRealtimeEndpointOutput");
+    return __isa(o, "DeleteRealtimeEndpointOutput");
   }
 }
 
@@ -1064,7 +1067,7 @@ export interface DeleteTagsInput {
 
 export namespace DeleteTagsInput {
   export function isa(o: any): o is DeleteTagsInput {
-    return _smithy.isa(o, "DeleteTagsInput");
+    return __isa(o, "DeleteTagsInput");
   }
 }
 
@@ -1086,7 +1089,7 @@ export interface DeleteTagsOutput extends $MetadataBearer {
 
 export namespace DeleteTagsOutput {
   export function isa(o: any): o is DeleteTagsOutput {
-    return _smithy.isa(o, "DeleteTagsOutput");
+    return __isa(o, "DeleteTagsOutput");
   }
 }
 
@@ -1214,7 +1217,7 @@ export interface DescribeBatchPredictionsInput {
 
 export namespace DescribeBatchPredictionsInput {
   export function isa(o: any): o is DescribeBatchPredictionsInput {
-    return _smithy.isa(o, "DescribeBatchPredictionsInput");
+    return __isa(o, "DescribeBatchPredictionsInput");
   }
 }
 
@@ -1237,7 +1240,7 @@ export interface DescribeBatchPredictionsOutput extends $MetadataBearer {
 
 export namespace DescribeBatchPredictionsOutput {
   export function isa(o: any): o is DescribeBatchPredictionsOutput {
-    return _smithy.isa(o, "DescribeBatchPredictionsOutput");
+    return __isa(o, "DescribeBatchPredictionsOutput");
   }
 }
 
@@ -1356,7 +1359,7 @@ export interface DescribeDataSourcesInput {
 
 export namespace DescribeDataSourcesInput {
   export function isa(o: any): o is DescribeDataSourcesInput {
-    return _smithy.isa(o, "DescribeDataSourcesInput");
+    return __isa(o, "DescribeDataSourcesInput");
   }
 }
 
@@ -1379,7 +1382,7 @@ export interface DescribeDataSourcesOutput extends $MetadataBearer {
 
 export namespace DescribeDataSourcesOutput {
   export function isa(o: any): o is DescribeDataSourcesOutput {
-    return _smithy.isa(o, "DescribeDataSourcesOutput");
+    return __isa(o, "DescribeDataSourcesOutput");
   }
 }
 
@@ -1507,7 +1510,7 @@ export interface DescribeEvaluationsInput {
 
 export namespace DescribeEvaluationsInput {
   export function isa(o: any): o is DescribeEvaluationsInput {
-    return _smithy.isa(o, "DescribeEvaluationsInput");
+    return __isa(o, "DescribeEvaluationsInput");
   }
 }
 
@@ -1530,7 +1533,7 @@ export interface DescribeEvaluationsOutput extends $MetadataBearer {
 
 export namespace DescribeEvaluationsOutput {
   export function isa(o: any): o is DescribeEvaluationsOutput {
-    return _smithy.isa(o, "DescribeEvaluationsOutput");
+    return __isa(o, "DescribeEvaluationsOutput");
   }
 }
 
@@ -1666,7 +1669,7 @@ export interface DescribeMLModelsInput {
 
 export namespace DescribeMLModelsInput {
   export function isa(o: any): o is DescribeMLModelsInput {
-    return _smithy.isa(o, "DescribeMLModelsInput");
+    return __isa(o, "DescribeMLModelsInput");
   }
 }
 
@@ -1688,7 +1691,7 @@ export interface DescribeMLModelsOutput extends $MetadataBearer {
 
 export namespace DescribeMLModelsOutput {
   export function isa(o: any): o is DescribeMLModelsOutput {
-    return _smithy.isa(o, "DescribeMLModelsOutput");
+    return __isa(o, "DescribeMLModelsOutput");
   }
 }
 
@@ -1707,7 +1710,7 @@ export interface DescribeTagsInput {
 
 export namespace DescribeTagsInput {
   export function isa(o: any): o is DescribeTagsInput {
-    return _smithy.isa(o, "DescribeTagsInput");
+    return __isa(o, "DescribeTagsInput");
   }
 }
 
@@ -1734,7 +1737,7 @@ export interface DescribeTagsOutput extends $MetadataBearer {
 
 export namespace DescribeTagsOutput {
   export function isa(o: any): o is DescribeTagsOutput {
-    return _smithy.isa(o, "DescribeTagsOutput");
+    return __isa(o, "DescribeTagsOutput");
   }
 }
 
@@ -1869,7 +1872,7 @@ export interface Evaluation {
 
 export namespace Evaluation {
   export function isa(o: any): o is Evaluation {
-    return _smithy.isa(o, "Evaluation");
+    return __isa(o, "Evaluation");
   }
 }
 
@@ -1894,7 +1897,7 @@ export interface GetBatchPredictionInput {
 
 export namespace GetBatchPredictionInput {
   export function isa(o: any): o is GetBatchPredictionInput {
-    return _smithy.isa(o, "GetBatchPredictionInput");
+    return __isa(o, "GetBatchPredictionInput");
   }
 }
 
@@ -2015,7 +2018,7 @@ export interface GetBatchPredictionOutput extends $MetadataBearer {
 
 export namespace GetBatchPredictionOutput {
   export function isa(o: any): o is GetBatchPredictionOutput {
-    return _smithy.isa(o, "GetBatchPredictionOutput");
+    return __isa(o, "GetBatchPredictionOutput");
   }
 }
 
@@ -2036,7 +2039,7 @@ export interface GetDataSourceInput {
 
 export namespace GetDataSourceInput {
   export function isa(o: any): o is GetDataSourceInput {
-    return _smithy.isa(o, "GetDataSourceInput");
+    return __isa(o, "GetDataSourceInput");
   }
 }
 
@@ -2175,7 +2178,7 @@ export interface GetDataSourceOutput extends $MetadataBearer {
 
 export namespace GetDataSourceOutput {
   export function isa(o: any): o is GetDataSourceOutput {
-    return _smithy.isa(o, "GetDataSourceOutput");
+    return __isa(o, "GetDataSourceOutput");
   }
 }
 
@@ -2189,7 +2192,7 @@ export interface GetEvaluationInput {
 
 export namespace GetEvaluationInput {
   export function isa(o: any): o is GetEvaluationInput {
-    return _smithy.isa(o, "GetEvaluationInput");
+    return __isa(o, "GetEvaluationInput");
   }
 }
 
@@ -2313,7 +2316,7 @@ export interface GetEvaluationOutput extends $MetadataBearer {
 
 export namespace GetEvaluationOutput {
   export function isa(o: any): o is GetEvaluationOutput {
-    return _smithy.isa(o, "GetEvaluationOutput");
+    return __isa(o, "GetEvaluationOutput");
   }
 }
 
@@ -2334,7 +2337,7 @@ export interface GetMLModelInput {
 
 export namespace GetMLModelInput {
   export function isa(o: any): o is GetMLModelInput {
-    return _smithy.isa(o, "GetMLModelInput");
+    return __isa(o, "GetMLModelInput");
   }
 }
 
@@ -2543,7 +2546,7 @@ export interface GetMLModelOutput extends $MetadataBearer {
 
 export namespace GetMLModelOutput {
   export function isa(o: any): o is GetMLModelOutput {
-    return _smithy.isa(o, "GetMLModelOutput");
+    return __isa(o, "GetMLModelOutput");
   }
 }
 
@@ -2551,7 +2554,7 @@ export namespace GetMLModelOutput {
  * <p>A second request to use or change an object was not allowed. This can result from retrying a request using a parameter that was not present in the original request.</p>
  */
 export interface IdempotentParameterMismatchException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "IdempotentParameterMismatchException";
   $fault: "client";
@@ -2561,7 +2564,7 @@ export interface IdempotentParameterMismatchException
 
 export namespace IdempotentParameterMismatchException {
   export function isa(o: any): o is IdempotentParameterMismatchException {
-    return _smithy.isa(o, "IdempotentParameterMismatchException");
+    return __isa(o, "IdempotentParameterMismatchException");
   }
 }
 
@@ -2569,7 +2572,7 @@ export namespace IdempotentParameterMismatchException {
  * <p>An error on the server occurred when trying to process a request.</p>
  */
 export interface InternalServerException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalServerException";
   $fault: "server";
@@ -2579,7 +2582,7 @@ export interface InternalServerException
 
 export namespace InternalServerException {
   export function isa(o: any): o is InternalServerException {
-    return _smithy.isa(o, "InternalServerException");
+    return __isa(o, "InternalServerException");
   }
 }
 
@@ -2587,7 +2590,7 @@ export namespace InternalServerException {
  * <p>An error on the client occurred. Typically, the cause is an invalid input value.</p>
  */
 export interface InvalidInputException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidInputException";
   $fault: "client";
@@ -2597,7 +2600,7 @@ export interface InvalidInputException
 
 export namespace InvalidInputException {
   export function isa(o: any): o is InvalidInputException {
-    return _smithy.isa(o, "InvalidInputException");
+    return __isa(o, "InvalidInputException");
   }
 }
 
@@ -2605,7 +2608,7 @@ export namespace InvalidInputException {
  * <p>A submitted tag is invalid.</p>
  */
 export interface InvalidTagException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidTagException";
   $fault: "client";
@@ -2614,7 +2617,7 @@ export interface InvalidTagException
 
 export namespace InvalidTagException {
   export function isa(o: any): o is InvalidTagException {
-    return _smithy.isa(o, "InvalidTagException");
+    return __isa(o, "InvalidTagException");
   }
 }
 
@@ -2622,7 +2625,7 @@ export namespace InvalidTagException {
  * <p>The subscriber exceeded the maximum number of operations. This exception can occur when listing objects such as <code>DataSource</code>.</p>
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -2632,7 +2635,7 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
@@ -2831,7 +2834,7 @@ export interface MLModel {
 
 export namespace MLModel {
   export function isa(o: any): o is MLModel {
-    return _smithy.isa(o, "MLModel");
+    return __isa(o, "MLModel");
   }
 }
 
@@ -2882,7 +2885,7 @@ export interface PerformanceMetrics {
 
 export namespace PerformanceMetrics {
   export function isa(o: any): o is PerformanceMetrics {
-    return _smithy.isa(o, "PerformanceMetrics");
+    return __isa(o, "PerformanceMetrics");
   }
 }
 
@@ -2906,7 +2909,7 @@ export interface PredictInput {
 
 export namespace PredictInput {
   export function isa(o: any): o is PredictInput {
-    return _smithy.isa(o, "PredictInput");
+    return __isa(o, "PredictInput");
   }
 }
 
@@ -2947,7 +2950,7 @@ export interface PredictOutput extends $MetadataBearer {
 
 export namespace PredictOutput {
   export function isa(o: any): o is PredictOutput {
-    return _smithy.isa(o, "PredictOutput");
+    return __isa(o, "PredictOutput");
   }
 }
 
@@ -3008,7 +3011,7 @@ export interface Prediction {
 
 export namespace Prediction {
   export function isa(o: any): o is Prediction {
-    return _smithy.isa(o, "Prediction");
+    return __isa(o, "Prediction");
   }
 }
 
@@ -3016,7 +3019,7 @@ export namespace Prediction {
  * <p>The exception is thrown when a predict request is made to an unmounted <code>MLModel</code>.</p>
  */
 export interface PredictorNotMountedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "PredictorNotMountedException";
   $fault: "client";
@@ -3025,7 +3028,7 @@ export interface PredictorNotMountedException
 
 export namespace PredictorNotMountedException {
   export function isa(o: any): o is PredictorNotMountedException {
-    return _smithy.isa(o, "PredictorNotMountedException");
+    return __isa(o, "PredictorNotMountedException");
   }
 }
 
@@ -3195,7 +3198,7 @@ export interface RDSDataSpec {
 
 export namespace RDSDataSpec {
   export function isa(o: any): o is RDSDataSpec {
-    return _smithy.isa(o, "RDSDataSpec");
+    return __isa(o, "RDSDataSpec");
   }
 }
 
@@ -3217,7 +3220,7 @@ export interface RDSDatabase {
 
 export namespace RDSDatabase {
   export function isa(o: any): o is RDSDatabase {
-    return _smithy.isa(o, "RDSDatabase");
+    return __isa(o, "RDSDatabase");
   }
 }
 
@@ -3241,7 +3244,7 @@ export interface RDSDatabaseCredentials {
 
 export namespace RDSDatabaseCredentials {
   export function isa(o: any): o is RDSDatabaseCredentials {
-    return _smithy.isa(o, "RDSDatabaseCredentials");
+    return __isa(o, "RDSDatabaseCredentials");
   }
 }
 
@@ -3284,7 +3287,7 @@ export interface RDSMetadata {
 
 export namespace RDSMetadata {
   export function isa(o: any): o is RDSMetadata {
-    return _smithy.isa(o, "RDSMetadata");
+    return __isa(o, "RDSMetadata");
   }
 }
 
@@ -3332,7 +3335,7 @@ export interface RealtimeEndpointInfo {
 
 export namespace RealtimeEndpointInfo {
   export function isa(o: any): o is RealtimeEndpointInfo {
-    return _smithy.isa(o, "RealtimeEndpointInfo");
+    return __isa(o, "RealtimeEndpointInfo");
   }
 }
 
@@ -3488,7 +3491,7 @@ export interface RedshiftDataSpec {
 
 export namespace RedshiftDataSpec {
   export function isa(o: any): o is RedshiftDataSpec {
-    return _smithy.isa(o, "RedshiftDataSpec");
+    return __isa(o, "RedshiftDataSpec");
   }
 }
 
@@ -3510,7 +3513,7 @@ export interface RedshiftDatabase {
 
 export namespace RedshiftDatabase {
   export function isa(o: any): o is RedshiftDatabase {
-    return _smithy.isa(o, "RedshiftDatabase");
+    return __isa(o, "RedshiftDatabase");
   }
 }
 
@@ -3534,7 +3537,7 @@ export interface RedshiftDatabaseCredentials {
 
 export namespace RedshiftDatabaseCredentials {
   export function isa(o: any): o is RedshiftDatabaseCredentials {
-    return _smithy.isa(o, "RedshiftDatabaseCredentials");
+    return __isa(o, "RedshiftDatabaseCredentials");
   }
 }
 
@@ -3562,7 +3565,7 @@ export interface RedshiftMetadata {
 
 export namespace RedshiftMetadata {
   export function isa(o: any): o is RedshiftMetadata {
-    return _smithy.isa(o, "RedshiftMetadata");
+    return __isa(o, "RedshiftMetadata");
   }
 }
 
@@ -3570,7 +3573,7 @@ export namespace RedshiftMetadata {
  * <p>A specified resource cannot be located.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -3580,7 +3583,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -3715,7 +3718,7 @@ export interface S3DataSpec {
 
 export namespace S3DataSpec {
   export function isa(o: any): o is S3DataSpec {
-    return _smithy.isa(o, "S3DataSpec");
+    return __isa(o, "S3DataSpec");
   }
 }
 
@@ -3742,7 +3745,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -3750,7 +3753,7 @@ export namespace Tag {
  * <p>The limit in the number of tags has been exceeded.</p>
  */
 export interface TagLimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TagLimitExceededException";
   $fault: "client";
@@ -3759,7 +3762,7 @@ export interface TagLimitExceededException
 
 export namespace TagLimitExceededException {
   export function isa(o: any): o is TagLimitExceededException {
-    return _smithy.isa(o, "TagLimitExceededException");
+    return __isa(o, "TagLimitExceededException");
   }
 }
 
@@ -3785,7 +3788,7 @@ export interface UpdateBatchPredictionInput {
 
 export namespace UpdateBatchPredictionInput {
   export function isa(o: any): o is UpdateBatchPredictionInput {
-    return _smithy.isa(o, "UpdateBatchPredictionInput");
+    return __isa(o, "UpdateBatchPredictionInput");
   }
 }
 
@@ -3804,7 +3807,7 @@ export interface UpdateBatchPredictionOutput extends $MetadataBearer {
 
 export namespace UpdateBatchPredictionOutput {
   export function isa(o: any): o is UpdateBatchPredictionOutput {
-    return _smithy.isa(o, "UpdateBatchPredictionOutput");
+    return __isa(o, "UpdateBatchPredictionOutput");
   }
 }
 
@@ -3823,7 +3826,7 @@ export interface UpdateDataSourceInput {
 
 export namespace UpdateDataSourceInput {
   export function isa(o: any): o is UpdateDataSourceInput {
-    return _smithy.isa(o, "UpdateDataSourceInput");
+    return __isa(o, "UpdateDataSourceInput");
   }
 }
 
@@ -3842,7 +3845,7 @@ export interface UpdateDataSourceOutput extends $MetadataBearer {
 
 export namespace UpdateDataSourceOutput {
   export function isa(o: any): o is UpdateDataSourceOutput {
-    return _smithy.isa(o, "UpdateDataSourceOutput");
+    return __isa(o, "UpdateDataSourceOutput");
   }
 }
 
@@ -3861,7 +3864,7 @@ export interface UpdateEvaluationInput {
 
 export namespace UpdateEvaluationInput {
   export function isa(o: any): o is UpdateEvaluationInput {
-    return _smithy.isa(o, "UpdateEvaluationInput");
+    return __isa(o, "UpdateEvaluationInput");
   }
 }
 
@@ -3880,7 +3883,7 @@ export interface UpdateEvaluationOutput extends $MetadataBearer {
 
 export namespace UpdateEvaluationOutput {
   export function isa(o: any): o is UpdateEvaluationOutput {
-    return _smithy.isa(o, "UpdateEvaluationOutput");
+    return __isa(o, "UpdateEvaluationOutput");
   }
 }
 
@@ -3905,7 +3908,7 @@ export interface UpdateMLModelInput {
 
 export namespace UpdateMLModelInput {
   export function isa(o: any): o is UpdateMLModelInput {
-    return _smithy.isa(o, "UpdateMLModelInput");
+    return __isa(o, "UpdateMLModelInput");
   }
 }
 
@@ -3924,6 +3927,6 @@ export interface UpdateMLModelOutput extends $MetadataBearer {
 
 export namespace UpdateMLModelOutput {
   export function isa(o: any): o is UpdateMLModelOutput {
-    return _smithy.isa(o, "UpdateMLModelOutput");
+    return __isa(o, "UpdateMLModelOutput");
   }
 }

--- a/clients/client-macie/models/index.ts
+++ b/clients/client-macie/models/index.ts
@@ -1,11 +1,14 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
  * <p>You do not have required permissions to access the requested resource.</p>
  */
 export interface AccessDeniedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AccessDeniedException";
   $fault: "client";
@@ -18,7 +21,7 @@ export interface AccessDeniedException
 
 export namespace AccessDeniedException {
   export function isa(o: any): o is AccessDeniedException {
-    return _smithy.isa(o, "AccessDeniedException");
+    return __isa(o, "AccessDeniedException");
   }
 }
 
@@ -33,7 +36,7 @@ export interface AssociateMemberAccountRequest {
 
 export namespace AssociateMemberAccountRequest {
   export function isa(o: any): o is AssociateMemberAccountRequest {
-    return _smithy.isa(o, "AssociateMemberAccountRequest");
+    return __isa(o, "AssociateMemberAccountRequest");
   }
 }
 
@@ -54,7 +57,7 @@ export interface AssociateS3ResourcesRequest {
 
 export namespace AssociateS3ResourcesRequest {
   export function isa(o: any): o is AssociateS3ResourcesRequest {
-    return _smithy.isa(o, "AssociateS3ResourcesRequest");
+    return __isa(o, "AssociateS3ResourcesRequest");
   }
 }
 
@@ -69,7 +72,7 @@ export interface AssociateS3ResourcesResult extends $MetadataBearer {
 
 export namespace AssociateS3ResourcesResult {
   export function isa(o: any): o is AssociateS3ResourcesResult {
-    return _smithy.isa(o, "AssociateS3ResourcesResult");
+    return __isa(o, "AssociateS3ResourcesResult");
   }
 }
 
@@ -95,7 +98,7 @@ export interface ClassificationType {
 
 export namespace ClassificationType {
   export function isa(o: any): o is ClassificationType {
-    return _smithy.isa(o, "ClassificationType");
+    return __isa(o, "ClassificationType");
   }
 }
 
@@ -121,7 +124,7 @@ export interface ClassificationTypeUpdate {
 
 export namespace ClassificationTypeUpdate {
   export function isa(o: any): o is ClassificationTypeUpdate {
-    return _smithy.isa(o, "ClassificationTypeUpdate");
+    return __isa(o, "ClassificationTypeUpdate");
   }
 }
 
@@ -135,7 +138,7 @@ export interface DisassociateMemberAccountRequest {
 
 export namespace DisassociateMemberAccountRequest {
   export function isa(o: any): o is DisassociateMemberAccountRequest {
-    return _smithy.isa(o, "DisassociateMemberAccountRequest");
+    return __isa(o, "DisassociateMemberAccountRequest");
   }
 }
 
@@ -156,7 +159,7 @@ export interface DisassociateS3ResourcesRequest {
 
 export namespace DisassociateS3ResourcesRequest {
   export function isa(o: any): o is DisassociateS3ResourcesRequest {
-    return _smithy.isa(o, "DisassociateS3ResourcesRequest");
+    return __isa(o, "DisassociateS3ResourcesRequest");
   }
 }
 
@@ -171,7 +174,7 @@ export interface DisassociateS3ResourcesResult extends $MetadataBearer {
 
 export namespace DisassociateS3ResourcesResult {
   export function isa(o: any): o is DisassociateS3ResourcesResult {
-    return _smithy.isa(o, "DisassociateS3ResourcesResult");
+    return __isa(o, "DisassociateS3ResourcesResult");
   }
 }
 
@@ -198,16 +201,14 @@ export interface FailedS3Resource {
 
 export namespace FailedS3Resource {
   export function isa(o: any): o is FailedS3Resource {
-    return _smithy.isa(o, "FailedS3Resource");
+    return __isa(o, "FailedS3Resource");
   }
 }
 
 /**
  * <p>Internal server error.</p>
  */
-export interface InternalException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface InternalException extends __SmithyException, $MetadataBearer {
   name: "InternalException";
   $fault: "server";
   /**
@@ -220,7 +221,7 @@ export interface InternalException
 
 export namespace InternalException {
   export function isa(o: any): o is InternalException {
-    return _smithy.isa(o, "InternalException");
+    return __isa(o, "InternalException");
   }
 }
 
@@ -229,7 +230,7 @@ export namespace InternalException {
  *       input parameter. </p>
  */
 export interface InvalidInputException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidInputException";
   $fault: "client";
@@ -248,7 +249,7 @@ export interface InvalidInputException
 
 export namespace InvalidInputException {
   export function isa(o: any): o is InvalidInputException {
-    return _smithy.isa(o, "InvalidInputException");
+    return __isa(o, "InvalidInputException");
   }
 }
 
@@ -257,7 +258,7 @@ export namespace InvalidInputException {
  *       AWS account limits. The error code describes the limit exceeded. </p>
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -275,7 +276,7 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
@@ -298,7 +299,7 @@ export interface ListMemberAccountsRequest {
 
 export namespace ListMemberAccountsRequest {
   export function isa(o: any): o is ListMemberAccountsRequest {
-    return _smithy.isa(o, "ListMemberAccountsRequest");
+    return __isa(o, "ListMemberAccountsRequest");
   }
 }
 
@@ -321,7 +322,7 @@ export interface ListMemberAccountsResult extends $MetadataBearer {
 
 export namespace ListMemberAccountsResult {
   export function isa(o: any): o is ListMemberAccountsResult {
-    return _smithy.isa(o, "ListMemberAccountsResult");
+    return __isa(o, "ListMemberAccountsResult");
   }
 }
 
@@ -349,7 +350,7 @@ export interface ListS3ResourcesRequest {
 
 export namespace ListS3ResourcesRequest {
   export function isa(o: any): o is ListS3ResourcesRequest {
-    return _smithy.isa(o, "ListS3ResourcesRequest");
+    return __isa(o, "ListS3ResourcesRequest");
   }
 }
 
@@ -371,7 +372,7 @@ export interface ListS3ResourcesResult extends $MetadataBearer {
 
 export namespace ListS3ResourcesResult {
   export function isa(o: any): o is ListS3ResourcesResult {
-    return _smithy.isa(o, "ListS3ResourcesResult");
+    return __isa(o, "ListS3ResourcesResult");
   }
 }
 
@@ -388,7 +389,7 @@ export interface MemberAccount {
 
 export namespace MemberAccount {
   export function isa(o: any): o is MemberAccount {
-    return _smithy.isa(o, "MemberAccount");
+    return __isa(o, "MemberAccount");
   }
 }
 
@@ -421,7 +422,7 @@ export interface S3Resource {
 
 export namespace S3Resource {
   export function isa(o: any): o is S3Resource {
-    return _smithy.isa(o, "S3Resource");
+    return __isa(o, "S3Resource");
   }
 }
 
@@ -451,7 +452,7 @@ export interface S3ResourceClassification {
 
 export namespace S3ResourceClassification {
   export function isa(o: any): o is S3ResourceClassification {
-    return _smithy.isa(o, "S3ResourceClassification");
+    return __isa(o, "S3ResourceClassification");
   }
 }
 
@@ -480,7 +481,7 @@ export interface S3ResourceClassificationUpdate {
 
 export namespace S3ResourceClassificationUpdate {
   export function isa(o: any): o is S3ResourceClassificationUpdate {
-    return _smithy.isa(o, "S3ResourceClassificationUpdate");
+    return __isa(o, "S3ResourceClassificationUpdate");
   }
 }
 
@@ -500,7 +501,7 @@ export interface UpdateS3ResourcesRequest {
 
 export namespace UpdateS3ResourcesRequest {
   export function isa(o: any): o is UpdateS3ResourcesRequest {
-    return _smithy.isa(o, "UpdateS3ResourcesRequest");
+    return __isa(o, "UpdateS3ResourcesRequest");
   }
 }
 
@@ -515,6 +516,6 @@ export interface UpdateS3ResourcesResult extends $MetadataBearer {
 
 export namespace UpdateS3ResourcesResult {
   export function isa(o: any): o is UpdateS3ResourcesResult {
-    return _smithy.isa(o, "UpdateS3ResourcesResult");
+    return __isa(o, "UpdateS3ResourcesResult");
   }
 }

--- a/clients/client-macie/protocols/Aws_json1_1.ts
+++ b/clients/client-macie/protocols/Aws_json1_1.ts
@@ -172,6 +172,7 @@ export async function deserializeAws_json1_1AssociateMemberAccountCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: AssociateMemberAccountCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -320,6 +321,7 @@ export async function deserializeAws_json1_1DisassociateMemberAccountCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DisassociateMemberAccountCommandOutput = {
     $metadata: deserializeMetadata(output)
   };

--- a/clients/client-managedblockchain/models/index.ts
+++ b/clients/client-managedblockchain/models/index.ts
@@ -1,11 +1,14 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
  * <p>You do not have sufficient access to perform this action.</p>
  */
 export interface AccessDeniedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AccessDeniedException";
   $fault: "client";
@@ -13,7 +16,7 @@ export interface AccessDeniedException
 
 export namespace AccessDeniedException {
   export function isa(o: any): o is AccessDeniedException {
-    return _smithy.isa(o, "AccessDeniedException");
+    return __isa(o, "AccessDeniedException");
   }
 }
 
@@ -40,7 +43,7 @@ export interface ApprovalThresholdPolicy {
 
 export namespace ApprovalThresholdPolicy {
   export function isa(o: any): o is ApprovalThresholdPolicy {
-    return _smithy.isa(o, "ApprovalThresholdPolicy");
+    return __isa(o, "ApprovalThresholdPolicy");
   }
 }
 
@@ -69,7 +72,7 @@ export interface CreateMemberInput {
 
 export namespace CreateMemberInput {
   export function isa(o: any): o is CreateMemberInput {
-    return _smithy.isa(o, "CreateMemberInput");
+    return __isa(o, "CreateMemberInput");
   }
 }
 
@@ -83,7 +86,7 @@ export interface CreateMemberOutput extends $MetadataBearer {
 
 export namespace CreateMemberOutput {
   export function isa(o: any): o is CreateMemberOutput {
-    return _smithy.isa(o, "CreateMemberOutput");
+    return __isa(o, "CreateMemberOutput");
   }
 }
 
@@ -136,7 +139,7 @@ export interface CreateNetworkInput {
 
 export namespace CreateNetworkInput {
   export function isa(o: any): o is CreateNetworkInput {
-    return _smithy.isa(o, "CreateNetworkInput");
+    return __isa(o, "CreateNetworkInput");
   }
 }
 
@@ -155,7 +158,7 @@ export interface CreateNetworkOutput extends $MetadataBearer {
 
 export namespace CreateNetworkOutput {
   export function isa(o: any): o is CreateNetworkOutput {
-    return _smithy.isa(o, "CreateNetworkOutput");
+    return __isa(o, "CreateNetworkOutput");
   }
 }
 
@@ -184,7 +187,7 @@ export interface CreateNodeInput {
 
 export namespace CreateNodeInput {
   export function isa(o: any): o is CreateNodeInput {
-    return _smithy.isa(o, "CreateNodeInput");
+    return __isa(o, "CreateNodeInput");
   }
 }
 
@@ -198,7 +201,7 @@ export interface CreateNodeOutput extends $MetadataBearer {
 
 export namespace CreateNodeOutput {
   export function isa(o: any): o is CreateNodeOutput {
-    return _smithy.isa(o, "CreateNodeOutput");
+    return __isa(o, "CreateNodeOutput");
   }
 }
 
@@ -233,7 +236,7 @@ export interface CreateProposalInput {
 
 export namespace CreateProposalInput {
   export function isa(o: any): o is CreateProposalInput {
-    return _smithy.isa(o, "CreateProposalInput");
+    return __isa(o, "CreateProposalInput");
   }
 }
 
@@ -247,7 +250,7 @@ export interface CreateProposalOutput extends $MetadataBearer {
 
 export namespace CreateProposalOutput {
   export function isa(o: any): o is CreateProposalOutput {
-    return _smithy.isa(o, "CreateProposalOutput");
+    return __isa(o, "CreateProposalOutput");
   }
 }
 
@@ -266,7 +269,7 @@ export interface DeleteMemberInput {
 
 export namespace DeleteMemberInput {
   export function isa(o: any): o is DeleteMemberInput {
-    return _smithy.isa(o, "DeleteMemberInput");
+    return __isa(o, "DeleteMemberInput");
   }
 }
 
@@ -276,7 +279,7 @@ export interface DeleteMemberOutput extends $MetadataBearer {
 
 export namespace DeleteMemberOutput {
   export function isa(o: any): o is DeleteMemberOutput {
-    return _smithy.isa(o, "DeleteMemberOutput");
+    return __isa(o, "DeleteMemberOutput");
   }
 }
 
@@ -300,7 +303,7 @@ export interface DeleteNodeInput {
 
 export namespace DeleteNodeInput {
   export function isa(o: any): o is DeleteNodeInput {
-    return _smithy.isa(o, "DeleteNodeInput");
+    return __isa(o, "DeleteNodeInput");
   }
 }
 
@@ -310,7 +313,7 @@ export interface DeleteNodeOutput extends $MetadataBearer {
 
 export namespace DeleteNodeOutput {
   export function isa(o: any): o is DeleteNodeOutput {
-    return _smithy.isa(o, "DeleteNodeOutput");
+    return __isa(o, "DeleteNodeOutput");
   }
 }
 
@@ -338,7 +341,7 @@ export interface GetMemberInput {
 
 export namespace GetMemberInput {
   export function isa(o: any): o is GetMemberInput {
-    return _smithy.isa(o, "GetMemberInput");
+    return __isa(o, "GetMemberInput");
   }
 }
 
@@ -352,7 +355,7 @@ export interface GetMemberOutput extends $MetadataBearer {
 
 export namespace GetMemberOutput {
   export function isa(o: any): o is GetMemberOutput {
-    return _smithy.isa(o, "GetMemberOutput");
+    return __isa(o, "GetMemberOutput");
   }
 }
 
@@ -366,7 +369,7 @@ export interface GetNetworkInput {
 
 export namespace GetNetworkInput {
   export function isa(o: any): o is GetNetworkInput {
-    return _smithy.isa(o, "GetNetworkInput");
+    return __isa(o, "GetNetworkInput");
   }
 }
 
@@ -380,7 +383,7 @@ export interface GetNetworkOutput extends $MetadataBearer {
 
 export namespace GetNetworkOutput {
   export function isa(o: any): o is GetNetworkOutput {
-    return _smithy.isa(o, "GetNetworkOutput");
+    return __isa(o, "GetNetworkOutput");
   }
 }
 
@@ -404,7 +407,7 @@ export interface GetNodeInput {
 
 export namespace GetNodeInput {
   export function isa(o: any): o is GetNodeInput {
-    return _smithy.isa(o, "GetNodeInput");
+    return __isa(o, "GetNodeInput");
   }
 }
 
@@ -418,7 +421,7 @@ export interface GetNodeOutput extends $MetadataBearer {
 
 export namespace GetNodeOutput {
   export function isa(o: any): o is GetNodeOutput {
-    return _smithy.isa(o, "GetNodeOutput");
+    return __isa(o, "GetNodeOutput");
   }
 }
 
@@ -437,7 +440,7 @@ export interface GetProposalInput {
 
 export namespace GetProposalInput {
   export function isa(o: any): o is GetProposalInput {
-    return _smithy.isa(o, "GetProposalInput");
+    return __isa(o, "GetProposalInput");
   }
 }
 
@@ -451,7 +454,7 @@ export interface GetProposalOutput extends $MetadataBearer {
 
 export namespace GetProposalOutput {
   export function isa(o: any): o is GetProposalOutput {
-    return _smithy.isa(o, "GetProposalOutput");
+    return __isa(o, "GetProposalOutput");
   }
 }
 
@@ -459,7 +462,7 @@ export namespace GetProposalOutput {
  * <p></p>
  */
 export interface IllegalActionException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "IllegalActionException";
   $fault: "client";
@@ -468,7 +471,7 @@ export interface IllegalActionException
 
 export namespace IllegalActionException {
   export function isa(o: any): o is IllegalActionException {
-    return _smithy.isa(o, "IllegalActionException");
+    return __isa(o, "IllegalActionException");
   }
 }
 
@@ -476,7 +479,7 @@ export namespace IllegalActionException {
  * <p>The request processing has failed because of an unknown error, exception or failure.</p>
  */
 export interface InternalServiceErrorException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalServiceErrorException";
   $fault: "server";
@@ -484,7 +487,7 @@ export interface InternalServiceErrorException
 
 export namespace InternalServiceErrorException {
   export function isa(o: any): o is InternalServiceErrorException {
-    return _smithy.isa(o, "InternalServiceErrorException");
+    return __isa(o, "InternalServiceErrorException");
   }
 }
 
@@ -492,7 +495,7 @@ export namespace InternalServiceErrorException {
  * <p>The action or operation requested is invalid. Verify that the action is typed correctly.</p>
  */
 export interface InvalidRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidRequestException";
   $fault: "client";
@@ -501,7 +504,7 @@ export interface InvalidRequestException
 
 export namespace InvalidRequestException {
   export function isa(o: any): o is InvalidRequestException {
-    return _smithy.isa(o, "InvalidRequestException");
+    return __isa(o, "InvalidRequestException");
   }
 }
 
@@ -560,7 +563,7 @@ export interface Invitation {
 
 export namespace Invitation {
   export function isa(o: any): o is Invitation {
-    return _smithy.isa(o, "Invitation");
+    return __isa(o, "Invitation");
   }
 }
 
@@ -585,7 +588,7 @@ export interface InviteAction {
 
 export namespace InviteAction {
   export function isa(o: any): o is InviteAction {
-    return _smithy.isa(o, "InviteAction");
+    return __isa(o, "InviteAction");
   }
 }
 
@@ -604,7 +607,7 @@ export interface ListInvitationsInput {
 
 export namespace ListInvitationsInput {
   export function isa(o: any): o is ListInvitationsInput {
-    return _smithy.isa(o, "ListInvitationsInput");
+    return __isa(o, "ListInvitationsInput");
   }
 }
 
@@ -623,7 +626,7 @@ export interface ListInvitationsOutput extends $MetadataBearer {
 
 export namespace ListInvitationsOutput {
   export function isa(o: any): o is ListInvitationsOutput {
-    return _smithy.isa(o, "ListInvitationsOutput");
+    return __isa(o, "ListInvitationsOutput");
   }
 }
 
@@ -664,7 +667,7 @@ export interface ListMembersInput {
 
 export namespace ListMembersInput {
   export function isa(o: any): o is ListMembersInput {
-    return _smithy.isa(o, "ListMembersInput");
+    return __isa(o, "ListMembersInput");
   }
 }
 
@@ -683,7 +686,7 @@ export interface ListMembersOutput extends $MetadataBearer {
 
 export namespace ListMembersOutput {
   export function isa(o: any): o is ListMembersOutput {
-    return _smithy.isa(o, "ListMembersOutput");
+    return __isa(o, "ListMembersOutput");
   }
 }
 
@@ -717,7 +720,7 @@ export interface ListNetworksInput {
 
 export namespace ListNetworksInput {
   export function isa(o: any): o is ListNetworksInput {
-    return _smithy.isa(o, "ListNetworksInput");
+    return __isa(o, "ListNetworksInput");
   }
 }
 
@@ -736,7 +739,7 @@ export interface ListNetworksOutput extends $MetadataBearer {
 
 export namespace ListNetworksOutput {
   export function isa(o: any): o is ListNetworksOutput {
-    return _smithy.isa(o, "ListNetworksOutput");
+    return __isa(o, "ListNetworksOutput");
   }
 }
 
@@ -770,7 +773,7 @@ export interface ListNodesInput {
 
 export namespace ListNodesInput {
   export function isa(o: any): o is ListNodesInput {
-    return _smithy.isa(o, "ListNodesInput");
+    return __isa(o, "ListNodesInput");
   }
 }
 
@@ -789,7 +792,7 @@ export interface ListNodesOutput extends $MetadataBearer {
 
 export namespace ListNodesOutput {
   export function isa(o: any): o is ListNodesOutput {
-    return _smithy.isa(o, "ListNodesOutput");
+    return __isa(o, "ListNodesOutput");
   }
 }
 
@@ -826,7 +829,7 @@ export interface ListProposalVotesInput {
 
 export namespace ListProposalVotesInput {
   export function isa(o: any): o is ListProposalVotesInput {
-    return _smithy.isa(o, "ListProposalVotesInput");
+    return __isa(o, "ListProposalVotesInput");
   }
 }
 
@@ -849,7 +852,7 @@ export interface ListProposalVotesOutput extends $MetadataBearer {
 
 export namespace ListProposalVotesOutput {
   export function isa(o: any): o is ListProposalVotesOutput {
-    return _smithy.isa(o, "ListProposalVotesOutput");
+    return __isa(o, "ListProposalVotesOutput");
   }
 }
 
@@ -879,7 +882,7 @@ export interface ListProposalsInput {
 
 export namespace ListProposalsInput {
   export function isa(o: any): o is ListProposalsInput {
-    return _smithy.isa(o, "ListProposalsInput");
+    return __isa(o, "ListProposalsInput");
   }
 }
 
@@ -898,7 +901,7 @@ export interface ListProposalsOutput extends $MetadataBearer {
 
 export namespace ListProposalsOutput {
   export function isa(o: any): o is ListProposalsOutput {
-    return _smithy.isa(o, "ListProposalsOutput");
+    return __isa(o, "ListProposalsOutput");
   }
 }
 
@@ -969,7 +972,7 @@ export interface Member {
 
 export namespace Member {
   export function isa(o: any): o is Member {
-    return _smithy.isa(o, "Member");
+    return __isa(o, "Member");
   }
 }
 
@@ -996,7 +999,7 @@ export interface MemberConfiguration {
 
 export namespace MemberConfiguration {
   export function isa(o: any): o is MemberConfiguration {
-    return _smithy.isa(o, "MemberConfiguration");
+    return __isa(o, "MemberConfiguration");
   }
 }
 
@@ -1018,7 +1021,7 @@ export interface MemberFabricAttributes {
 
 export namespace MemberFabricAttributes {
   export function isa(o: any): o is MemberFabricAttributes {
-    return _smithy.isa(o, "MemberFabricAttributes");
+    return __isa(o, "MemberFabricAttributes");
   }
 }
 
@@ -1040,7 +1043,7 @@ export interface MemberFabricConfiguration {
 
 export namespace MemberFabricConfiguration {
   export function isa(o: any): o is MemberFabricConfiguration {
-    return _smithy.isa(o, "MemberFabricConfiguration");
+    return __isa(o, "MemberFabricConfiguration");
   }
 }
 
@@ -1057,7 +1060,7 @@ export interface MemberFrameworkAttributes {
 
 export namespace MemberFrameworkAttributes {
   export function isa(o: any): o is MemberFrameworkAttributes {
-    return _smithy.isa(o, "MemberFrameworkAttributes");
+    return __isa(o, "MemberFrameworkAttributes");
   }
 }
 
@@ -1074,7 +1077,7 @@ export interface MemberFrameworkConfiguration {
 
 export namespace MemberFrameworkConfiguration {
   export function isa(o: any): o is MemberFrameworkConfiguration {
-    return _smithy.isa(o, "MemberFrameworkConfiguration");
+    return __isa(o, "MemberFrameworkConfiguration");
   }
 }
 
@@ -1148,7 +1151,7 @@ export interface MemberSummary {
 
 export namespace MemberSummary {
   export function isa(o: any): o is MemberSummary {
-    return _smithy.isa(o, "MemberSummary");
+    return __isa(o, "MemberSummary");
   }
 }
 
@@ -1210,7 +1213,7 @@ export interface Network {
 
 export namespace Network {
   export function isa(o: any): o is Network {
-    return _smithy.isa(o, "Network");
+    return __isa(o, "Network");
   }
 }
 
@@ -1232,7 +1235,7 @@ export interface NetworkFabricAttributes {
 
 export namespace NetworkFabricAttributes {
   export function isa(o: any): o is NetworkFabricAttributes {
-    return _smithy.isa(o, "NetworkFabricAttributes");
+    return __isa(o, "NetworkFabricAttributes");
   }
 }
 
@@ -1249,7 +1252,7 @@ export interface NetworkFabricConfiguration {
 
 export namespace NetworkFabricConfiguration {
   export function isa(o: any): o is NetworkFabricConfiguration {
-    return _smithy.isa(o, "NetworkFabricConfiguration");
+    return __isa(o, "NetworkFabricConfiguration");
   }
 }
 
@@ -1266,7 +1269,7 @@ export interface NetworkFrameworkAttributes {
 
 export namespace NetworkFrameworkAttributes {
   export function isa(o: any): o is NetworkFrameworkAttributes {
-    return _smithy.isa(o, "NetworkFrameworkAttributes");
+    return __isa(o, "NetworkFrameworkAttributes");
   }
 }
 
@@ -1287,7 +1290,7 @@ export interface NetworkFrameworkConfiguration {
 
 export namespace NetworkFrameworkConfiguration {
   export function isa(o: any): o is NetworkFrameworkConfiguration {
-    return _smithy.isa(o, "NetworkFrameworkConfiguration");
+    return __isa(o, "NetworkFrameworkConfiguration");
   }
 }
 
@@ -1342,7 +1345,7 @@ export interface NetworkSummary {
 
 export namespace NetworkSummary {
   export function isa(o: any): o is NetworkSummary {
-    return _smithy.isa(o, "NetworkSummary");
+    return __isa(o, "NetworkSummary");
   }
 }
 
@@ -1394,7 +1397,7 @@ export interface Node {
 
 export namespace Node {
   export function isa(o: any): o is Node {
-    return _smithy.isa(o, "Node");
+    return __isa(o, "Node");
   }
 }
 
@@ -1416,7 +1419,7 @@ export interface NodeConfiguration {
 
 export namespace NodeConfiguration {
   export function isa(o: any): o is NodeConfiguration {
-    return _smithy.isa(o, "NodeConfiguration");
+    return __isa(o, "NodeConfiguration");
   }
 }
 
@@ -1438,7 +1441,7 @@ export interface NodeFabricAttributes {
 
 export namespace NodeFabricAttributes {
   export function isa(o: any): o is NodeFabricAttributes {
-    return _smithy.isa(o, "NodeFabricAttributes");
+    return __isa(o, "NodeFabricAttributes");
   }
 }
 
@@ -1455,7 +1458,7 @@ export interface NodeFrameworkAttributes {
 
 export namespace NodeFrameworkAttributes {
   export function isa(o: any): o is NodeFrameworkAttributes {
-    return _smithy.isa(o, "NodeFrameworkAttributes");
+    return __isa(o, "NodeFrameworkAttributes");
   }
 }
 
@@ -1501,7 +1504,7 @@ export interface NodeSummary {
 
 export namespace NodeSummary {
   export function isa(o: any): o is NodeSummary {
-    return _smithy.isa(o, "NodeSummary");
+    return __isa(o, "NodeSummary");
   }
 }
 
@@ -1605,7 +1608,7 @@ export interface Proposal {
 
 export namespace Proposal {
   export function isa(o: any): o is Proposal {
-    return _smithy.isa(o, "Proposal");
+    return __isa(o, "Proposal");
   }
 }
 
@@ -1633,7 +1636,7 @@ export interface ProposalActions {
 
 export namespace ProposalActions {
   export function isa(o: any): o is ProposalActions {
-    return _smithy.isa(o, "ProposalActions");
+    return __isa(o, "ProposalActions");
   }
 }
 
@@ -1722,7 +1725,7 @@ export interface ProposalSummary {
 
 export namespace ProposalSummary {
   export function isa(o: any): o is ProposalSummary {
-    return _smithy.isa(o, "ProposalSummary");
+    return __isa(o, "ProposalSummary");
   }
 }
 
@@ -1736,7 +1739,7 @@ export interface RejectInvitationInput {
 
 export namespace RejectInvitationInput {
   export function isa(o: any): o is RejectInvitationInput {
-    return _smithy.isa(o, "RejectInvitationInput");
+    return __isa(o, "RejectInvitationInput");
   }
 }
 
@@ -1746,7 +1749,7 @@ export interface RejectInvitationOutput extends $MetadataBearer {
 
 export namespace RejectInvitationOutput {
   export function isa(o: any): o is RejectInvitationOutput {
-    return _smithy.isa(o, "RejectInvitationOutput");
+    return __isa(o, "RejectInvitationOutput");
   }
 }
 
@@ -1763,7 +1766,7 @@ export interface RemoveAction {
 
 export namespace RemoveAction {
   export function isa(o: any): o is RemoveAction {
-    return _smithy.isa(o, "RemoveAction");
+    return __isa(o, "RemoveAction");
   }
 }
 
@@ -1771,7 +1774,7 @@ export namespace RemoveAction {
  * <p>A resource request is issued for a resource that already exists.</p>
  */
 export interface ResourceAlreadyExistsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceAlreadyExistsException";
   $fault: "client";
@@ -1780,7 +1783,7 @@ export interface ResourceAlreadyExistsException
 
 export namespace ResourceAlreadyExistsException {
   export function isa(o: any): o is ResourceAlreadyExistsException {
-    return _smithy.isa(o, "ResourceAlreadyExistsException");
+    return __isa(o, "ResourceAlreadyExistsException");
   }
 }
 
@@ -1788,7 +1791,7 @@ export namespace ResourceAlreadyExistsException {
  * <p>The maximum number of resources of that type already exist. Ensure the resources requested are within the boundaries of the service edition and your account limits.</p>
  */
 export interface ResourceLimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceLimitExceededException";
   $fault: "client";
@@ -1797,7 +1800,7 @@ export interface ResourceLimitExceededException
 
 export namespace ResourceLimitExceededException {
   export function isa(o: any): o is ResourceLimitExceededException {
-    return _smithy.isa(o, "ResourceLimitExceededException");
+    return __isa(o, "ResourceLimitExceededException");
   }
 }
 
@@ -1805,7 +1808,7 @@ export namespace ResourceLimitExceededException {
  * <p>A requested resource does not exist on the network. It may have been deleted or referenced inaccurately.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -1814,7 +1817,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -1822,7 +1825,7 @@ export namespace ResourceNotFoundException {
  * <p>The requested resource exists but is not in a status that can complete the operation.</p>
  */
 export interface ResourceNotReadyException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotReadyException";
   $fault: "client";
@@ -1831,7 +1834,7 @@ export interface ResourceNotReadyException
 
 export namespace ResourceNotReadyException {
   export function isa(o: any): o is ResourceNotReadyException {
-    return _smithy.isa(o, "ResourceNotReadyException");
+    return __isa(o, "ResourceNotReadyException");
   }
 }
 
@@ -1844,7 +1847,7 @@ export enum ThresholdComparator {
  * <p>The request or operation could not be performed because a service is throttling requests. The most common source of throttling errors is launching EC2 instances such that your service limit for EC2 instances is exceeded. Request a limit increase or delete unused resources if possible.</p>
  */
 export interface ThrottlingException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ThrottlingException";
   $fault: "client";
@@ -1852,7 +1855,7 @@ export interface ThrottlingException
 
 export namespace ThrottlingException {
   export function isa(o: any): o is ThrottlingException {
-    return _smithy.isa(o, "ThrottlingException");
+    return __isa(o, "ThrottlingException");
   }
 }
 
@@ -1888,7 +1891,7 @@ export interface VoteOnProposalInput {
 
 export namespace VoteOnProposalInput {
   export function isa(o: any): o is VoteOnProposalInput {
-    return _smithy.isa(o, "VoteOnProposalInput");
+    return __isa(o, "VoteOnProposalInput");
   }
 }
 
@@ -1898,7 +1901,7 @@ export interface VoteOnProposalOutput extends $MetadataBearer {
 
 export namespace VoteOnProposalOutput {
   export function isa(o: any): o is VoteOnProposalOutput {
-    return _smithy.isa(o, "VoteOnProposalOutput");
+    return __isa(o, "VoteOnProposalOutput");
   }
 }
 
@@ -1933,7 +1936,7 @@ export interface VoteSummary {
 
 export namespace VoteSummary {
   export function isa(o: any): o is VoteSummary {
-    return _smithy.isa(o, "VoteSummary");
+    return __isa(o, "VoteSummary");
   }
 }
 
@@ -1957,6 +1960,6 @@ export interface VotingPolicy {
 
 export namespace VotingPolicy {
   export function isa(o: any): o is VotingPolicy {
-    return _smithy.isa(o, "VotingPolicy");
+    return __isa(o, "VotingPolicy");
   }
 }

--- a/clients/client-managedblockchain/protocols/Aws_restJson1_1.ts
+++ b/clients/client-managedblockchain/protocols/Aws_restJson1_1.ts
@@ -112,7 +112,10 @@ import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  extendedEncodeURIComponent as __extendedEncodeURIComponent
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -129,13 +132,13 @@ export async function serializeAws_restJson1_1CreateMemberCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/networks/{NetworkId}/members";
   if (input.NetworkId !== undefined) {
-    const labelValue: string = input.NetworkId.toString();
+    const labelValue: string = input.NetworkId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: NetworkId.");
     }
     resolvedPath = resolvedPath.replace(
       "{NetworkId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: NetworkId.");
@@ -238,25 +241,25 @@ export async function serializeAws_restJson1_1CreateNodeCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/networks/{NetworkId}/members/{MemberId}/nodes";
   if (input.MemberId !== undefined) {
-    const labelValue: string = input.MemberId.toString();
+    const labelValue: string = input.MemberId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: MemberId.");
     }
     resolvedPath = resolvedPath.replace(
       "{MemberId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: MemberId.");
   }
   if (input.NetworkId !== undefined) {
-    const labelValue: string = input.NetworkId.toString();
+    const labelValue: string = input.NetworkId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: NetworkId.");
     }
     resolvedPath = resolvedPath.replace(
       "{NetworkId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: NetworkId.");
@@ -294,13 +297,13 @@ export async function serializeAws_restJson1_1CreateProposalCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/networks/{NetworkId}/proposals";
   if (input.NetworkId !== undefined) {
-    const labelValue: string = input.NetworkId.toString();
+    const labelValue: string = input.NetworkId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: NetworkId.");
     }
     resolvedPath = resolvedPath.replace(
       "{NetworkId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: NetworkId.");
@@ -344,25 +347,25 @@ export async function serializeAws_restJson1_1DeleteMemberCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/networks/{NetworkId}/members/{MemberId}";
   if (input.MemberId !== undefined) {
-    const labelValue: string = input.MemberId.toString();
+    const labelValue: string = input.MemberId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: MemberId.");
     }
     resolvedPath = resolvedPath.replace(
       "{MemberId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: MemberId.");
   }
   if (input.NetworkId !== undefined) {
-    const labelValue: string = input.NetworkId.toString();
+    const labelValue: string = input.NetworkId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: NetworkId.");
     }
     resolvedPath = resolvedPath.replace(
       "{NetworkId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: NetworkId.");
@@ -384,37 +387,37 @@ export async function serializeAws_restJson1_1DeleteNodeCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/networks/{NetworkId}/members/{MemberId}/nodes/{NodeId}";
   if (input.MemberId !== undefined) {
-    const labelValue: string = input.MemberId.toString();
+    const labelValue: string = input.MemberId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: MemberId.");
     }
     resolvedPath = resolvedPath.replace(
       "{MemberId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: MemberId.");
   }
   if (input.NetworkId !== undefined) {
-    const labelValue: string = input.NetworkId.toString();
+    const labelValue: string = input.NetworkId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: NetworkId.");
     }
     resolvedPath = resolvedPath.replace(
       "{NetworkId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: NetworkId.");
   }
   if (input.NodeId !== undefined) {
-    const labelValue: string = input.NodeId.toString();
+    const labelValue: string = input.NodeId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: NodeId.");
     }
     resolvedPath = resolvedPath.replace(
       "{NodeId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: NodeId.");
@@ -436,25 +439,25 @@ export async function serializeAws_restJson1_1GetMemberCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/networks/{NetworkId}/members/{MemberId}";
   if (input.MemberId !== undefined) {
-    const labelValue: string = input.MemberId.toString();
+    const labelValue: string = input.MemberId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: MemberId.");
     }
     resolvedPath = resolvedPath.replace(
       "{MemberId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: MemberId.");
   }
   if (input.NetworkId !== undefined) {
-    const labelValue: string = input.NetworkId.toString();
+    const labelValue: string = input.NetworkId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: NetworkId.");
     }
     resolvedPath = resolvedPath.replace(
       "{NetworkId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: NetworkId.");
@@ -476,13 +479,13 @@ export async function serializeAws_restJson1_1GetNetworkCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/networks/{NetworkId}";
   if (input.NetworkId !== undefined) {
-    const labelValue: string = input.NetworkId.toString();
+    const labelValue: string = input.NetworkId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: NetworkId.");
     }
     resolvedPath = resolvedPath.replace(
       "{NetworkId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: NetworkId.");
@@ -504,37 +507,37 @@ export async function serializeAws_restJson1_1GetNodeCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/networks/{NetworkId}/members/{MemberId}/nodes/{NodeId}";
   if (input.MemberId !== undefined) {
-    const labelValue: string = input.MemberId.toString();
+    const labelValue: string = input.MemberId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: MemberId.");
     }
     resolvedPath = resolvedPath.replace(
       "{MemberId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: MemberId.");
   }
   if (input.NetworkId !== undefined) {
-    const labelValue: string = input.NetworkId.toString();
+    const labelValue: string = input.NetworkId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: NetworkId.");
     }
     resolvedPath = resolvedPath.replace(
       "{NetworkId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: NetworkId.");
   }
   if (input.NodeId !== undefined) {
-    const labelValue: string = input.NodeId.toString();
+    const labelValue: string = input.NodeId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: NodeId.");
     }
     resolvedPath = resolvedPath.replace(
       "{NodeId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: NodeId.");
@@ -556,25 +559,25 @@ export async function serializeAws_restJson1_1GetProposalCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/networks/{NetworkId}/proposals/{ProposalId}";
   if (input.NetworkId !== undefined) {
-    const labelValue: string = input.NetworkId.toString();
+    const labelValue: string = input.NetworkId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: NetworkId.");
     }
     resolvedPath = resolvedPath.replace(
       "{NetworkId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: NetworkId.");
   }
   if (input.ProposalId !== undefined) {
-    const labelValue: string = input.ProposalId.toString();
+    const labelValue: string = input.ProposalId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ProposalId.");
     }
     resolvedPath = resolvedPath.replace(
       "{ProposalId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ProposalId.");
@@ -597,10 +600,14 @@ export async function serializeAws_restJson1_1ListInvitationsCommand(
   let resolvedPath = "/invitations";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -620,32 +627,42 @@ export async function serializeAws_restJson1_1ListMembersCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/networks/{NetworkId}/members";
   if (input.NetworkId !== undefined) {
-    const labelValue: string = input.NetworkId.toString();
+    const labelValue: string = input.NetworkId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: NetworkId.");
     }
     resolvedPath = resolvedPath.replace(
       "{NetworkId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: NetworkId.");
   }
   const query: any = {};
   if (input.IsOwned !== undefined) {
-    query["isOwned"] = input.IsOwned.toString();
+    query[
+      __extendedEncodeURIComponent("isOwned")
+    ] = __extendedEncodeURIComponent(input.IsOwned.toString());
   }
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.Name !== undefined) {
-    query["name"] = input.Name.toString();
+    query[__extendedEncodeURIComponent("name")] = __extendedEncodeURIComponent(
+      input.Name
+    );
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   if (input.Status !== undefined) {
-    query["status"] = input.Status.toString();
+    query[
+      __extendedEncodeURIComponent("status")
+    ] = __extendedEncodeURIComponent(input.Status);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -666,19 +683,29 @@ export async function serializeAws_restJson1_1ListNetworksCommand(
   let resolvedPath = "/networks";
   const query: any = {};
   if (input.Framework !== undefined) {
-    query["framework"] = input.Framework.toString();
+    query[
+      __extendedEncodeURIComponent("framework")
+    ] = __extendedEncodeURIComponent(input.Framework);
   }
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.Name !== undefined) {
-    query["name"] = input.Name.toString();
+    query[__extendedEncodeURIComponent("name")] = __extendedEncodeURIComponent(
+      input.Name
+    );
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   if (input.Status !== undefined) {
-    query["status"] = input.Status.toString();
+    query[
+      __extendedEncodeURIComponent("status")
+    ] = __extendedEncodeURIComponent(input.Status);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -698,38 +725,44 @@ export async function serializeAws_restJson1_1ListNodesCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/networks/{NetworkId}/members/{MemberId}/nodes";
   if (input.MemberId !== undefined) {
-    const labelValue: string = input.MemberId.toString();
+    const labelValue: string = input.MemberId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: MemberId.");
     }
     resolvedPath = resolvedPath.replace(
       "{MemberId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: MemberId.");
   }
   if (input.NetworkId !== undefined) {
-    const labelValue: string = input.NetworkId.toString();
+    const labelValue: string = input.NetworkId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: NetworkId.");
     }
     resolvedPath = resolvedPath.replace(
       "{NetworkId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: NetworkId.");
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   if (input.Status !== undefined) {
-    query["status"] = input.Status.toString();
+    query[
+      __extendedEncodeURIComponent("status")
+    ] = __extendedEncodeURIComponent(input.Status);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -749,35 +782,39 @@ export async function serializeAws_restJson1_1ListProposalVotesCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/networks/{NetworkId}/proposals/{ProposalId}/votes";
   if (input.NetworkId !== undefined) {
-    const labelValue: string = input.NetworkId.toString();
+    const labelValue: string = input.NetworkId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: NetworkId.");
     }
     resolvedPath = resolvedPath.replace(
       "{NetworkId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: NetworkId.");
   }
   if (input.ProposalId !== undefined) {
-    const labelValue: string = input.ProposalId.toString();
+    const labelValue: string = input.ProposalId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ProposalId.");
     }
     resolvedPath = resolvedPath.replace(
       "{ProposalId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ProposalId.");
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -797,23 +834,27 @@ export async function serializeAws_restJson1_1ListProposalsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/networks/{NetworkId}/proposals";
   if (input.NetworkId !== undefined) {
-    const labelValue: string = input.NetworkId.toString();
+    const labelValue: string = input.NetworkId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: NetworkId.");
     }
     resolvedPath = resolvedPath.replace(
       "{NetworkId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: NetworkId.");
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -833,7 +874,7 @@ export async function serializeAws_restJson1_1RejectInvitationCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/invitations/{InvitationId}";
   if (input.InvitationId !== undefined) {
-    const labelValue: string = input.InvitationId.toString();
+    const labelValue: string = input.InvitationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: InvitationId."
@@ -841,7 +882,7 @@ export async function serializeAws_restJson1_1RejectInvitationCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{InvitationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: InvitationId.");
@@ -863,25 +904,25 @@ export async function serializeAws_restJson1_1VoteOnProposalCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/networks/{NetworkId}/proposals/{ProposalId}/votes";
   if (input.NetworkId !== undefined) {
-    const labelValue: string = input.NetworkId.toString();
+    const labelValue: string = input.NetworkId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: NetworkId.");
     }
     resolvedPath = resolvedPath.replace(
       "{NetworkId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: NetworkId.");
   }
   if (input.ProposalId !== undefined) {
-    const labelValue: string = input.ProposalId.toString();
+    const labelValue: string = input.ProposalId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ProposalId.");
     }
     resolvedPath = resolvedPath.replace(
       "{ProposalId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ProposalId.");
@@ -1303,6 +1344,7 @@ export async function deserializeAws_restJson1_1DeleteMemberCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeleteMemberOutput"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -1386,6 +1428,7 @@ export async function deserializeAws_restJson1_1DeleteNodeCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeleteNodeOutput"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2312,6 +2355,7 @@ export async function deserializeAws_restJson1_1RejectInvitationCommand(
     $metadata: deserializeMetadata(output),
     __type: "RejectInvitationOutput"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2398,6 +2442,7 @@ export async function deserializeAws_restJson1_1VoteOnProposalCommand(
     $metadata: deserializeMetadata(output),
     __type: "VoteOnProposalOutput"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2479,6 +2524,7 @@ const deserializeAws_restJson1_1AccessDeniedExceptionResponse = async (
     $fault: "client",
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return contents;
 };
 
@@ -2508,6 +2554,7 @@ const deserializeAws_restJson1_1InternalServiceErrorExceptionResponse = async (
     $fault: "server",
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return contents;
 };
 
@@ -2605,6 +2652,7 @@ const deserializeAws_restJson1_1ThrottlingExceptionResponse = async (
     $fault: "client",
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return contents;
 };
 

--- a/clients/client-marketplace-catalog/models/index.ts
+++ b/clients/client-marketplace-catalog/models/index.ts
@@ -1,11 +1,14 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
  * <p>Access is denied.</p>
  */
 export interface AccessDeniedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AccessDeniedException";
   $fault: "client";
@@ -14,7 +17,7 @@ export interface AccessDeniedException
 
 export namespace AccessDeniedException {
   export function isa(o: any): o is AccessDeniedException {
-    return _smithy.isa(o, "AccessDeniedException");
+    return __isa(o, "AccessDeniedException");
   }
 }
 
@@ -35,7 +38,7 @@ export interface CancelChangeSetRequest {
 
 export namespace CancelChangeSetRequest {
   export function isa(o: any): o is CancelChangeSetRequest {
-    return _smithy.isa(o, "CancelChangeSetRequest");
+    return __isa(o, "CancelChangeSetRequest");
   }
 }
 
@@ -54,7 +57,7 @@ export interface CancelChangeSetResponse extends $MetadataBearer {
 
 export namespace CancelChangeSetResponse {
   export function isa(o: any): o is CancelChangeSetResponse {
-    return _smithy.isa(o, "CancelChangeSetResponse");
+    return __isa(o, "CancelChangeSetResponse");
   }
 }
 
@@ -85,7 +88,7 @@ export interface Change {
 
 export namespace Change {
   export function isa(o: any): o is Change {
-    return _smithy.isa(o, "Change");
+    return __isa(o, "Change");
   }
 }
 
@@ -137,7 +140,7 @@ export interface ChangeSetSummaryListItem {
 
 export namespace ChangeSetSummaryListItem {
   export function isa(o: any): o is ChangeSetSummaryListItem {
-    return _smithy.isa(o, "ChangeSetSummaryListItem");
+    return __isa(o, "ChangeSetSummaryListItem");
   }
 }
 
@@ -173,7 +176,7 @@ export interface ChangeSummary {
 
 export namespace ChangeSummary {
   export function isa(o: any): o is ChangeSummary {
-    return _smithy.isa(o, "ChangeSummary");
+    return __isa(o, "ChangeSummary");
   }
 }
 
@@ -195,7 +198,7 @@ export interface DescribeChangeSetRequest {
 
 export namespace DescribeChangeSetRequest {
   export function isa(o: any): o is DescribeChangeSetRequest {
-    return _smithy.isa(o, "DescribeChangeSetRequest");
+    return __isa(o, "DescribeChangeSetRequest");
   }
 }
 
@@ -250,7 +253,7 @@ export interface DescribeChangeSetResponse extends $MetadataBearer {
 
 export namespace DescribeChangeSetResponse {
   export function isa(o: any): o is DescribeChangeSetResponse {
-    return _smithy.isa(o, "DescribeChangeSetResponse");
+    return __isa(o, "DescribeChangeSetResponse");
   }
 }
 
@@ -271,7 +274,7 @@ export interface DescribeEntityRequest {
 
 export namespace DescribeEntityRequest {
   export function isa(o: any): o is DescribeEntityRequest {
-    return _smithy.isa(o, "DescribeEntityRequest");
+    return __isa(o, "DescribeEntityRequest");
   }
 }
 
@@ -308,7 +311,7 @@ export interface DescribeEntityResponse extends $MetadataBearer {
 
 export namespace DescribeEntityResponse {
   export function isa(o: any): o is DescribeEntityResponse {
-    return _smithy.isa(o, "DescribeEntityResponse");
+    return __isa(o, "DescribeEntityResponse");
   }
 }
 
@@ -331,7 +334,7 @@ export interface Entity {
 
 export namespace Entity {
   export function isa(o: any): o is Entity {
-    return _smithy.isa(o, "Entity");
+    return __isa(o, "Entity");
   }
 }
 
@@ -380,7 +383,7 @@ export interface EntitySummary {
 
 export namespace EntitySummary {
   export function isa(o: any): o is EntitySummary {
-    return _smithy.isa(o, "EntitySummary");
+    return __isa(o, "EntitySummary");
   }
 }
 
@@ -402,7 +405,7 @@ export interface ErrorDetail {
 
 export namespace ErrorDetail {
   export function isa(o: any): o is ErrorDetail {
-    return _smithy.isa(o, "ErrorDetail");
+    return __isa(o, "ErrorDetail");
   }
 }
 
@@ -470,7 +473,7 @@ export interface Filter {
 
 export namespace Filter {
   export function isa(o: any): o is Filter {
-    return _smithy.isa(o, "Filter");
+    return __isa(o, "Filter");
   }
 }
 
@@ -478,7 +481,7 @@ export namespace Filter {
  * <p>There was an internal service exception.</p>
  */
 export interface InternalServiceException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalServiceException";
   $fault: "server";
@@ -487,7 +490,7 @@ export interface InternalServiceException
 
 export namespace InternalServiceException {
   export function isa(o: any): o is InternalServiceException {
-    return _smithy.isa(o, "InternalServiceException");
+    return __isa(o, "InternalServiceException");
   }
 }
 
@@ -526,7 +529,7 @@ export interface ListChangeSetsRequest {
 
 export namespace ListChangeSetsRequest {
   export function isa(o: any): o is ListChangeSetsRequest {
-    return _smithy.isa(o, "ListChangeSetsRequest");
+    return __isa(o, "ListChangeSetsRequest");
   }
 }
 
@@ -545,7 +548,7 @@ export interface ListChangeSetsResponse extends $MetadataBearer {
 
 export namespace ListChangeSetsResponse {
   export function isa(o: any): o is ListChangeSetsResponse {
-    return _smithy.isa(o, "ListChangeSetsResponse");
+    return __isa(o, "ListChangeSetsResponse");
   }
 }
 
@@ -588,7 +591,7 @@ export interface ListEntitiesRequest {
 
 export namespace ListEntitiesRequest {
   export function isa(o: any): o is ListEntitiesRequest {
-    return _smithy.isa(o, "ListEntitiesRequest");
+    return __isa(o, "ListEntitiesRequest");
   }
 }
 
@@ -607,7 +610,7 @@ export interface ListEntitiesResponse extends $MetadataBearer {
 
 export namespace ListEntitiesResponse {
   export function isa(o: any): o is ListEntitiesResponse {
-    return _smithy.isa(o, "ListEntitiesResponse");
+    return __isa(o, "ListEntitiesResponse");
   }
 }
 
@@ -615,7 +618,7 @@ export namespace ListEntitiesResponse {
  * <p>The resource is currently in use.</p>
  */
 export interface ResourceInUseException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceInUseException";
   $fault: "client";
@@ -624,7 +627,7 @@ export interface ResourceInUseException
 
 export namespace ResourceInUseException {
   export function isa(o: any): o is ResourceInUseException {
-    return _smithy.isa(o, "ResourceInUseException");
+    return __isa(o, "ResourceInUseException");
   }
 }
 
@@ -632,7 +635,7 @@ export namespace ResourceInUseException {
  * <p>The specified resource wasn't found.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -641,7 +644,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -649,7 +652,7 @@ export namespace ResourceNotFoundException {
  * <p>Currently, the specified resource is not supported.</p>
  */
 export interface ResourceNotSupportedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotSupportedException";
   $fault: "client";
@@ -658,7 +661,7 @@ export interface ResourceNotSupportedException
 
 export namespace ResourceNotSupportedException {
   export function isa(o: any): o is ResourceNotSupportedException {
-    return _smithy.isa(o, "ResourceNotSupportedException");
+    return __isa(o, "ResourceNotSupportedException");
   }
 }
 
@@ -666,7 +669,7 @@ export namespace ResourceNotSupportedException {
  * <p>The maximum number of open requests per account has been exceeded.</p>
  */
 export interface ServiceQuotaExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ServiceQuotaExceededException";
   $fault: "client";
@@ -675,7 +678,7 @@ export interface ServiceQuotaExceededException
 
 export namespace ServiceQuotaExceededException {
   export function isa(o: any): o is ServiceQuotaExceededException {
-    return _smithy.isa(o, "ServiceQuotaExceededException");
+    return __isa(o, "ServiceQuotaExceededException");
   }
 }
 
@@ -704,7 +707,7 @@ export interface Sort {
 
 export namespace Sort {
   export function isa(o: any): o is Sort {
-    return _smithy.isa(o, "Sort");
+    return __isa(o, "Sort");
   }
 }
 
@@ -740,7 +743,7 @@ export interface StartChangeSetRequest {
 
 export namespace StartChangeSetRequest {
   export function isa(o: any): o is StartChangeSetRequest {
-    return _smithy.isa(o, "StartChangeSetRequest");
+    return __isa(o, "StartChangeSetRequest");
   }
 }
 
@@ -759,7 +762,7 @@ export interface StartChangeSetResponse extends $MetadataBearer {
 
 export namespace StartChangeSetResponse {
   export function isa(o: any): o is StartChangeSetResponse {
-    return _smithy.isa(o, "StartChangeSetResponse");
+    return __isa(o, "StartChangeSetResponse");
   }
 }
 
@@ -767,7 +770,7 @@ export namespace StartChangeSetResponse {
  * <p>Too many requests.</p>
  */
 export interface ThrottlingException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ThrottlingException";
   $fault: "client";
@@ -776,7 +779,7 @@ export interface ThrottlingException
 
 export namespace ThrottlingException {
   export function isa(o: any): o is ThrottlingException {
-    return _smithy.isa(o, "ThrottlingException");
+    return __isa(o, "ThrottlingException");
   }
 }
 
@@ -784,7 +787,7 @@ export namespace ThrottlingException {
  * <p>An error occurred during validation.</p>
  */
 export interface ValidationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ValidationException";
   $fault: "client";
@@ -793,6 +796,6 @@ export interface ValidationException
 
 export namespace ValidationException {
   export function isa(o: any): o is ValidationException {
-    return _smithy.isa(o, "ValidationException");
+    return __isa(o, "ValidationException");
   }
 }

--- a/clients/client-marketplace-catalog/protocols/Aws_restJson1_1.ts
+++ b/clients/client-marketplace-catalog/protocols/Aws_restJson1_1.ts
@@ -44,7 +44,10 @@ import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  extendedEncodeURIComponent as __extendedEncodeURIComponent
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -61,10 +64,14 @@ export async function serializeAws_restJson1_1CancelChangeSetCommand(
   let resolvedPath = "/CancelChangeSet";
   const query: any = {};
   if (input.Catalog !== undefined) {
-    query["catalog"] = input.Catalog.toString();
+    query[
+      __extendedEncodeURIComponent("catalog")
+    ] = __extendedEncodeURIComponent(input.Catalog);
   }
   if (input.ChangeSetId !== undefined) {
-    query["changeSetId"] = input.ChangeSetId.toString();
+    query[
+      __extendedEncodeURIComponent("changeSetId")
+    ] = __extendedEncodeURIComponent(input.ChangeSetId);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -85,10 +92,14 @@ export async function serializeAws_restJson1_1DescribeChangeSetCommand(
   let resolvedPath = "/DescribeChangeSet";
   const query: any = {};
   if (input.Catalog !== undefined) {
-    query["catalog"] = input.Catalog.toString();
+    query[
+      __extendedEncodeURIComponent("catalog")
+    ] = __extendedEncodeURIComponent(input.Catalog);
   }
   if (input.ChangeSetId !== undefined) {
-    query["changeSetId"] = input.ChangeSetId.toString();
+    query[
+      __extendedEncodeURIComponent("changeSetId")
+    ] = __extendedEncodeURIComponent(input.ChangeSetId);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -109,10 +120,14 @@ export async function serializeAws_restJson1_1DescribeEntityCommand(
   let resolvedPath = "/DescribeEntity";
   const query: any = {};
   if (input.Catalog !== undefined) {
-    query["catalog"] = input.Catalog.toString();
+    query[
+      __extendedEncodeURIComponent("catalog")
+    ] = __extendedEncodeURIComponent(input.Catalog);
   }
   if (input.EntityId !== undefined) {
-    query["entityId"] = input.EntityId.toString();
+    query[
+      __extendedEncodeURIComponent("entityId")
+    ] = __extendedEncodeURIComponent(input.EntityId);
   }
   return new __HttpRequest({
     ...context.endpoint,

--- a/clients/client-marketplace-commerce-analytics/models/index.ts
+++ b/clients/client-marketplace-commerce-analytics/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export enum DataSetType {
@@ -172,7 +175,7 @@ export interface GenerateDataSetRequest {
 
 export namespace GenerateDataSetRequest {
   export function isa(o: any): o is GenerateDataSetRequest {
-    return _smithy.isa(o, "GenerateDataSetRequest");
+    return __isa(o, "GenerateDataSetRequest");
   }
 }
 
@@ -190,7 +193,7 @@ export interface GenerateDataSetResult extends $MetadataBearer {
 
 export namespace GenerateDataSetResult {
   export function isa(o: any): o is GenerateDataSetResult {
-    return _smithy.isa(o, "GenerateDataSetResult");
+    return __isa(o, "GenerateDataSetResult");
   }
 }
 
@@ -198,7 +201,7 @@ export namespace GenerateDataSetResult {
  * This exception is thrown when an internal service error occurs.
  */
 export interface MarketplaceCommerceAnalyticsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "MarketplaceCommerceAnalyticsException";
   $fault: "server";
@@ -210,7 +213,7 @@ export interface MarketplaceCommerceAnalyticsException
 
 export namespace MarketplaceCommerceAnalyticsException {
   export function isa(o: any): o is MarketplaceCommerceAnalyticsException {
-    return _smithy.isa(o, "MarketplaceCommerceAnalyticsException");
+    return __isa(o, "MarketplaceCommerceAnalyticsException");
   }
 }
 
@@ -275,7 +278,7 @@ export interface StartSupportDataExportRequest {
 
 export namespace StartSupportDataExportRequest {
   export function isa(o: any): o is StartSupportDataExportRequest {
-    return _smithy.isa(o, "StartSupportDataExportRequest");
+    return __isa(o, "StartSupportDataExportRequest");
   }
 }
 
@@ -293,7 +296,7 @@ export interface StartSupportDataExportResult extends $MetadataBearer {
 
 export namespace StartSupportDataExportResult {
   export function isa(o: any): o is StartSupportDataExportResult {
-    return _smithy.isa(o, "StartSupportDataExportResult");
+    return __isa(o, "StartSupportDataExportResult");
   }
 }
 

--- a/clients/client-marketplace-entitlement-service/models/index.ts
+++ b/clients/client-marketplace-entitlement-service/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -45,7 +48,7 @@ export interface Entitlement {
 
 export namespace Entitlement {
   export function isa(o: any): o is Entitlement {
-    return _smithy.isa(o, "Entitlement");
+    return __isa(o, "Entitlement");
   }
 }
 
@@ -82,7 +85,7 @@ export interface EntitlementValue {
 
 export namespace EntitlementValue {
   export function isa(o: any): o is EntitlementValue {
-    return _smithy.isa(o, "EntitlementValue");
+    return __isa(o, "EntitlementValue");
   }
 }
 
@@ -126,7 +129,7 @@ export interface GetEntitlementsRequest {
 
 export namespace GetEntitlementsRequest {
   export function isa(o: any): o is GetEntitlementsRequest {
-    return _smithy.isa(o, "GetEntitlementsRequest");
+    return __isa(o, "GetEntitlementsRequest");
   }
 }
 
@@ -152,7 +155,7 @@ export interface GetEntitlementsResult extends $MetadataBearer {
 
 export namespace GetEntitlementsResult {
   export function isa(o: any): o is GetEntitlementsResult {
-    return _smithy.isa(o, "GetEntitlementsResult");
+    return __isa(o, "GetEntitlementsResult");
   }
 }
 
@@ -161,7 +164,7 @@ export namespace GetEntitlementsResult {
  *    message with details on the AWS forums.</p>
  */
 export interface InternalServiceErrorException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalServiceErrorException";
   $fault: "server";
@@ -170,7 +173,7 @@ export interface InternalServiceErrorException
 
 export namespace InternalServiceErrorException {
   export function isa(o: any): o is InternalServiceErrorException {
-    return _smithy.isa(o, "InternalServiceErrorException");
+    return __isa(o, "InternalServiceErrorException");
   }
 }
 
@@ -178,7 +181,7 @@ export namespace InternalServiceErrorException {
  * <p>One or more parameters in your request was invalid.</p>
  */
 export interface InvalidParameterException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidParameterException";
   $fault: "client";
@@ -187,7 +190,7 @@ export interface InvalidParameterException
 
 export namespace InvalidParameterException {
   export function isa(o: any): o is InvalidParameterException {
-    return _smithy.isa(o, "InvalidParameterException");
+    return __isa(o, "InvalidParameterException");
   }
 }
 
@@ -195,7 +198,7 @@ export namespace InvalidParameterException {
  * <p>The calls to the GetEntitlements API are throttled.</p>
  */
 export interface ThrottlingException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ThrottlingException";
   $fault: "client";
@@ -204,6 +207,6 @@ export interface ThrottlingException
 
 export namespace ThrottlingException {
   export function isa(o: any): o is ThrottlingException {
-    return _smithy.isa(o, "ThrottlingException");
+    return __isa(o, "ThrottlingException");
   }
 }

--- a/clients/client-marketplace-metering/models/index.ts
+++ b/clients/client-marketplace-metering/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -23,7 +26,7 @@ export interface BatchMeterUsageRequest {
 
 export namespace BatchMeterUsageRequest {
   export function isa(o: any): o is BatchMeterUsageRequest {
-    return _smithy.isa(o, "BatchMeterUsageRequest");
+    return __isa(o, "BatchMeterUsageRequest");
   }
 }
 
@@ -49,7 +52,7 @@ export interface BatchMeterUsageResult extends $MetadataBearer {
 
 export namespace BatchMeterUsageResult {
   export function isa(o: any): o is BatchMeterUsageResult {
-    return _smithy.isa(o, "BatchMeterUsageResult");
+    return __isa(o, "BatchMeterUsageResult");
   }
 }
 
@@ -58,7 +61,7 @@ export namespace BatchMeterUsageResult {
  *             product.</p>
  */
 export interface CustomerNotEntitledException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CustomerNotEntitledException";
   $fault: "client";
@@ -67,7 +70,7 @@ export interface CustomerNotEntitledException
 
 export namespace CustomerNotEntitledException {
   export function isa(o: any): o is CustomerNotEntitledException {
-    return _smithy.isa(o, "CustomerNotEntitledException");
+    return __isa(o, "CustomerNotEntitledException");
   }
 }
 
@@ -75,7 +78,7 @@ export namespace CustomerNotEntitledException {
  * <p>The API is disabled in the Region.</p>
  */
 export interface DisabledApiException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DisabledApiException";
   $fault: "client";
@@ -84,7 +87,7 @@ export interface DisabledApiException
 
 export namespace DisabledApiException {
   export function isa(o: any): o is DisabledApiException {
-    return _smithy.isa(o, "DisabledApiException");
+    return __isa(o, "DisabledApiException");
   }
 }
 
@@ -94,7 +97,7 @@ export namespace DisabledApiException {
  *             usageQuantity.</p>
  */
 export interface DuplicateRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DuplicateRequestException";
   $fault: "client";
@@ -103,7 +106,7 @@ export interface DuplicateRequestException
 
 export namespace DuplicateRequestException {
   export function isa(o: any): o is DuplicateRequestException {
-    return _smithy.isa(o, "DuplicateRequestException");
+    return __isa(o, "DuplicateRequestException");
   }
 }
 
@@ -115,7 +118,7 @@ export namespace DuplicateRequestException {
  *             by the buyer's browser.</p>
  */
 export interface ExpiredTokenException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ExpiredTokenException";
   $fault: "client";
@@ -124,7 +127,7 @@ export interface ExpiredTokenException
 
 export namespace ExpiredTokenException {
   export function isa(o: any): o is ExpiredTokenException {
-    return _smithy.isa(o, "ExpiredTokenException");
+    return __isa(o, "ExpiredTokenException");
   }
 }
 
@@ -133,7 +136,7 @@ export namespace ExpiredTokenException {
  *             message with details on the AWS forums.</p>
  */
 export interface InternalServiceErrorException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalServiceErrorException";
   $fault: "server";
@@ -142,7 +145,7 @@ export interface InternalServiceErrorException
 
 export namespace InternalServiceErrorException {
   export function isa(o: any): o is InternalServiceErrorException {
-    return _smithy.isa(o, "InternalServiceErrorException");
+    return __isa(o, "InternalServiceErrorException");
   }
 }
 
@@ -150,7 +153,7 @@ export namespace InternalServiceErrorException {
  * <p>You have metered usage for a CustomerIdentifier that does not exist.</p>
  */
 export interface InvalidCustomerIdentifierException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidCustomerIdentifierException";
   $fault: "client";
@@ -159,7 +162,7 @@ export interface InvalidCustomerIdentifierException
 
 export namespace InvalidCustomerIdentifierException {
   export function isa(o: any): o is InvalidCustomerIdentifierException {
-    return _smithy.isa(o, "InvalidCustomerIdentifierException");
+    return __isa(o, "InvalidCustomerIdentifierException");
   }
 }
 
@@ -169,7 +172,7 @@ export namespace InvalidCustomerIdentifierException {
  *             resource must match.</p>
  */
 export interface InvalidEndpointRegionException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidEndpointRegionException";
   $fault: "client";
@@ -178,7 +181,7 @@ export interface InvalidEndpointRegionException
 
 export namespace InvalidEndpointRegionException {
   export function isa(o: any): o is InvalidEndpointRegionException {
-    return _smithy.isa(o, "InvalidEndpointRegionException");
+    return __isa(o, "InvalidEndpointRegionException");
   }
 }
 
@@ -187,7 +190,7 @@ export namespace InvalidEndpointRegionException {
  *             product.</p>
  */
 export interface InvalidProductCodeException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidProductCodeException";
   $fault: "client";
@@ -196,7 +199,7 @@ export interface InvalidProductCodeException
 
 export namespace InvalidProductCodeException {
   export function isa(o: any): o is InvalidProductCodeException {
-    return _smithy.isa(o, "InvalidProductCodeException");
+    return __isa(o, "InvalidProductCodeException");
   }
 }
 
@@ -204,7 +207,7 @@ export namespace InvalidProductCodeException {
  * <p>Public Key version is invalid.</p>
  */
 export interface InvalidPublicKeyVersionException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidPublicKeyVersionException";
   $fault: "client";
@@ -213,7 +216,7 @@ export interface InvalidPublicKeyVersionException
 
 export namespace InvalidPublicKeyVersionException {
   export function isa(o: any): o is InvalidPublicKeyVersionException {
-    return _smithy.isa(o, "InvalidPublicKeyVersionException");
+    return __isa(o, "InvalidPublicKeyVersionException");
   }
 }
 
@@ -223,7 +226,7 @@ export namespace InvalidPublicKeyVersionException {
  *             calling RegisterUsage.</p>
  */
 export interface InvalidRegionException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidRegionException";
   $fault: "client";
@@ -232,7 +235,7 @@ export interface InvalidRegionException
 
 export namespace InvalidRegionException {
   export function isa(o: any): o is InvalidRegionException {
-    return _smithy.isa(o, "InvalidRegionException");
+    return __isa(o, "InvalidRegionException");
   }
 }
 
@@ -240,7 +243,7 @@ export namespace InvalidRegionException {
  * <p>Registration token is invalid.</p>
  */
 export interface InvalidTokenException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidTokenException";
   $fault: "client";
@@ -249,7 +252,7 @@ export interface InvalidTokenException
 
 export namespace InvalidTokenException {
   export function isa(o: any): o is InvalidTokenException {
-    return _smithy.isa(o, "InvalidTokenException");
+    return __isa(o, "InvalidTokenException");
   }
 }
 
@@ -258,7 +261,7 @@ export namespace InvalidTokenException {
  *             products.</p>
  */
 export interface InvalidUsageDimensionException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidUsageDimensionException";
   $fault: "client";
@@ -267,7 +270,7 @@ export interface InvalidUsageDimensionException
 
 export namespace InvalidUsageDimensionException {
   export function isa(o: any): o is InvalidUsageDimensionException {
-    return _smithy.isa(o, "InvalidUsageDimensionException");
+    return __isa(o, "InvalidUsageDimensionException");
   }
 }
 
@@ -310,7 +313,7 @@ export interface MeterUsageRequest {
 
 export namespace MeterUsageRequest {
   export function isa(o: any): o is MeterUsageRequest {
-    return _smithy.isa(o, "MeterUsageRequest");
+    return __isa(o, "MeterUsageRequest");
   }
 }
 
@@ -324,7 +327,7 @@ export interface MeterUsageResult extends $MetadataBearer {
 
 export namespace MeterUsageResult {
   export function isa(o: any): o is MeterUsageResult {
-    return _smithy.isa(o, "MeterUsageResult");
+    return __isa(o, "MeterUsageResult");
   }
 }
 
@@ -333,7 +336,7 @@ export namespace MeterUsageResult {
  *             Currently, only Amazon ECS is supported.</p>
  */
 export interface PlatformNotSupportedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "PlatformNotSupportedException";
   $fault: "client";
@@ -342,7 +345,7 @@ export interface PlatformNotSupportedException
 
 export namespace PlatformNotSupportedException {
   export function isa(o: any): o is PlatformNotSupportedException {
-    return _smithy.isa(o, "PlatformNotSupportedException");
+    return __isa(o, "PlatformNotSupportedException");
   }
 }
 
@@ -369,7 +372,7 @@ export interface RegisterUsageRequest {
 
 export namespace RegisterUsageRequest {
   export function isa(o: any): o is RegisterUsageRequest {
-    return _smithy.isa(o, "RegisterUsageRequest");
+    return __isa(o, "RegisterUsageRequest");
   }
 }
 
@@ -388,7 +391,7 @@ export interface RegisterUsageResult extends $MetadataBearer {
 
 export namespace RegisterUsageResult {
   export function isa(o: any): o is RegisterUsageResult {
-    return _smithy.isa(o, "RegisterUsageResult");
+    return __isa(o, "RegisterUsageResult");
   }
 }
 
@@ -407,7 +410,7 @@ export interface ResolveCustomerRequest {
 
 export namespace ResolveCustomerRequest {
   export function isa(o: any): o is ResolveCustomerRequest {
-    return _smithy.isa(o, "ResolveCustomerRequest");
+    return __isa(o, "ResolveCustomerRequest");
   }
 }
 
@@ -434,7 +437,7 @@ export interface ResolveCustomerResult extends $MetadataBearer {
 
 export namespace ResolveCustomerResult {
   export function isa(o: any): o is ResolveCustomerResult {
-    return _smithy.isa(o, "ResolveCustomerResult");
+    return __isa(o, "ResolveCustomerResult");
   }
 }
 
@@ -442,7 +445,7 @@ export namespace ResolveCustomerResult {
  * <p>The calls to the API are throttled.</p>
  */
 export interface ThrottlingException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ThrottlingException";
   $fault: "client";
@@ -451,7 +454,7 @@ export interface ThrottlingException
 
 export namespace ThrottlingException {
   export function isa(o: any): o is ThrottlingException {
-    return _smithy.isa(o, "ThrottlingException");
+    return __isa(o, "ThrottlingException");
   }
 }
 
@@ -459,7 +462,7 @@ export namespace ThrottlingException {
  * <p>The timestamp value passed in the meterUsage() is out of allowed range.</p>
  */
 export interface TimestampOutOfBoundsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TimestampOutOfBoundsException";
   $fault: "client";
@@ -468,7 +471,7 @@ export interface TimestampOutOfBoundsException
 
 export namespace TimestampOutOfBoundsException {
   export function isa(o: any): o is TimestampOutOfBoundsException {
-    return _smithy.isa(o, "TimestampOutOfBoundsException");
+    return __isa(o, "TimestampOutOfBoundsException");
   }
 }
 
@@ -509,7 +512,7 @@ export interface UsageRecord {
 
 export namespace UsageRecord {
   export function isa(o: any): o is UsageRecord {
-    return _smithy.isa(o, "UsageRecord");
+    return __isa(o, "UsageRecord");
   }
 }
 
@@ -558,7 +561,7 @@ export interface UsageRecordResult {
 
 export namespace UsageRecordResult {
   export function isa(o: any): o is UsageRecordResult {
-    return _smithy.isa(o, "UsageRecordResult");
+    return __isa(o, "UsageRecordResult");
   }
 }
 

--- a/clients/client-mediaconnect/models/index.ts
+++ b/clients/client-mediaconnect/models/index.ts
@@ -1,11 +1,14 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
  * Exception raised by AWS Elemental MediaConnect. See the error message and documentation for the operation for more information on the cause of this exception.
  */
 export interface AddFlowOutputs420Exception
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AddFlowOutputs420Exception";
   $fault: "client";
@@ -17,7 +20,7 @@ export interface AddFlowOutputs420Exception
 
 export namespace AddFlowOutputs420Exception {
   export function isa(o: any): o is AddFlowOutputs420Exception {
-    return _smithy.isa(o, "AddFlowOutputs420Exception");
+    return __isa(o, "AddFlowOutputs420Exception");
   }
 }
 
@@ -39,7 +42,7 @@ export interface AddFlowOutputsRequest {
 
 export namespace AddFlowOutputsRequest {
   export function isa(o: any): o is AddFlowOutputsRequest {
-    return _smithy.isa(o, "AddFlowOutputsRequest");
+    return __isa(o, "AddFlowOutputsRequest");
   }
 }
 
@@ -58,7 +61,7 @@ export interface AddFlowOutputsResponse extends $MetadataBearer {
 
 export namespace AddFlowOutputsResponse {
   export function isa(o: any): o is AddFlowOutputsResponse {
-    return _smithy.isa(o, "AddFlowOutputsResponse");
+    return __isa(o, "AddFlowOutputsResponse");
   }
 }
 
@@ -125,7 +128,7 @@ export interface AddOutputRequest {
 
 export namespace AddOutputRequest {
   export function isa(o: any): o is AddOutputRequest {
-    return _smithy.isa(o, "AddOutputRequest");
+    return __isa(o, "AddOutputRequest");
   }
 }
 
@@ -139,7 +142,7 @@ export enum Algorithm {
  * Exception raised by AWS Elemental MediaConnect. See the error message and documentation for the operation for more information on the cause of this exception.
  */
 export interface BadRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "BadRequestException";
   $fault: "client";
@@ -151,7 +154,7 @@ export interface BadRequestException
 
 export namespace BadRequestException {
   export function isa(o: any): o is BadRequestException {
-    return _smithy.isa(o, "BadRequestException");
+    return __isa(o, "BadRequestException");
   }
 }
 
@@ -159,7 +162,7 @@ export namespace BadRequestException {
  * Exception raised by AWS Elemental MediaConnect. See the error message and documentation for the operation for more information on the cause of this exception.
  */
 export interface CreateFlow420Exception
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CreateFlow420Exception";
   $fault: "client";
@@ -171,7 +174,7 @@ export interface CreateFlow420Exception
 
 export namespace CreateFlow420Exception {
   export function isa(o: any): o is CreateFlow420Exception {
-    return _smithy.isa(o, "CreateFlow420Exception");
+    return __isa(o, "CreateFlow420Exception");
   }
 }
 
@@ -208,7 +211,7 @@ export interface CreateFlowRequest {
 
 export namespace CreateFlowRequest {
   export function isa(o: any): o is CreateFlowRequest {
-    return _smithy.isa(o, "CreateFlowRequest");
+    return __isa(o, "CreateFlowRequest");
   }
 }
 
@@ -222,7 +225,7 @@ export interface CreateFlowResponse extends $MetadataBearer {
 
 export namespace CreateFlowResponse {
   export function isa(o: any): o is CreateFlowResponse {
-    return _smithy.isa(o, "CreateFlowResponse");
+    return __isa(o, "CreateFlowResponse");
   }
 }
 
@@ -236,7 +239,7 @@ export interface DeleteFlowRequest {
 
 export namespace DeleteFlowRequest {
   export function isa(o: any): o is DeleteFlowRequest {
-    return _smithy.isa(o, "DeleteFlowRequest");
+    return __isa(o, "DeleteFlowRequest");
   }
 }
 
@@ -255,7 +258,7 @@ export interface DeleteFlowResponse extends $MetadataBearer {
 
 export namespace DeleteFlowResponse {
   export function isa(o: any): o is DeleteFlowResponse {
-    return _smithy.isa(o, "DeleteFlowResponse");
+    return __isa(o, "DeleteFlowResponse");
   }
 }
 
@@ -269,7 +272,7 @@ export interface DescribeFlowRequest {
 
 export namespace DescribeFlowRequest {
   export function isa(o: any): o is DescribeFlowRequest {
-    return _smithy.isa(o, "DescribeFlowRequest");
+    return __isa(o, "DescribeFlowRequest");
   }
 }
 
@@ -288,7 +291,7 @@ export interface DescribeFlowResponse extends $MetadataBearer {
 
 export namespace DescribeFlowResponse {
   export function isa(o: any): o is DescribeFlowResponse {
-    return _smithy.isa(o, "DescribeFlowResponse");
+    return __isa(o, "DescribeFlowResponse");
   }
 }
 
@@ -345,7 +348,7 @@ export interface Encryption {
 
 export namespace Encryption {
   export function isa(o: any): o is Encryption {
-    return _smithy.isa(o, "Encryption");
+    return __isa(o, "Encryption");
   }
 }
 
@@ -387,7 +390,7 @@ export interface Entitlement {
 
 export namespace Entitlement {
   export function isa(o: any): o is Entitlement {
-    return _smithy.isa(o, "Entitlement");
+    return __isa(o, "Entitlement");
   }
 }
 
@@ -444,16 +447,14 @@ export interface Flow {
 
 export namespace Flow {
   export function isa(o: any): o is Flow {
-    return _smithy.isa(o, "Flow");
+    return __isa(o, "Flow");
   }
 }
 
 /**
  * Exception raised by AWS Elemental MediaConnect. See the error message and documentation for the operation for more information on the cause of this exception.
  */
-export interface ForbiddenException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface ForbiddenException extends __SmithyException, $MetadataBearer {
   name: "ForbiddenException";
   $fault: "client";
   /**
@@ -464,7 +465,7 @@ export interface ForbiddenException
 
 export namespace ForbiddenException {
   export function isa(o: any): o is ForbiddenException {
-    return _smithy.isa(o, "ForbiddenException");
+    return __isa(o, "ForbiddenException");
   }
 }
 
@@ -501,7 +502,7 @@ export interface GrantEntitlementRequest {
 
 export namespace GrantEntitlementRequest {
   export function isa(o: any): o is GrantEntitlementRequest {
-    return _smithy.isa(o, "GrantEntitlementRequest");
+    return __isa(o, "GrantEntitlementRequest");
   }
 }
 
@@ -509,7 +510,7 @@ export namespace GrantEntitlementRequest {
  * Exception raised by AWS Elemental MediaConnect. See the error message and documentation for the operation for more information on the cause of this exception.
  */
 export interface GrantFlowEntitlements420Exception
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "GrantFlowEntitlements420Exception";
   $fault: "client";
@@ -521,7 +522,7 @@ export interface GrantFlowEntitlements420Exception
 
 export namespace GrantFlowEntitlements420Exception {
   export function isa(o: any): o is GrantFlowEntitlements420Exception {
-    return _smithy.isa(o, "GrantFlowEntitlements420Exception");
+    return __isa(o, "GrantFlowEntitlements420Exception");
   }
 }
 
@@ -543,7 +544,7 @@ export interface GrantFlowEntitlementsRequest {
 
 export namespace GrantFlowEntitlementsRequest {
   export function isa(o: any): o is GrantFlowEntitlementsRequest {
-    return _smithy.isa(o, "GrantFlowEntitlementsRequest");
+    return __isa(o, "GrantFlowEntitlementsRequest");
   }
 }
 
@@ -562,7 +563,7 @@ export interface GrantFlowEntitlementsResponse extends $MetadataBearer {
 
 export namespace GrantFlowEntitlementsResponse {
   export function isa(o: any): o is GrantFlowEntitlementsResponse {
-    return _smithy.isa(o, "GrantFlowEntitlementsResponse");
+    return __isa(o, "GrantFlowEntitlementsResponse");
   }
 }
 
@@ -570,7 +571,7 @@ export namespace GrantFlowEntitlementsResponse {
  * Exception raised by AWS Elemental MediaConnect. See the error message and documentation for the operation for more information on the cause of this exception.
  */
 export interface InternalServerErrorException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalServerErrorException";
   $fault: "server";
@@ -582,7 +583,7 @@ export interface InternalServerErrorException
 
 export namespace InternalServerErrorException {
   export function isa(o: any): o is InternalServerErrorException {
-    return _smithy.isa(o, "InternalServerErrorException");
+    return __isa(o, "InternalServerErrorException");
   }
 }
 
@@ -606,7 +607,7 @@ export interface ListEntitlementsRequest {
 
 export namespace ListEntitlementsRequest {
   export function isa(o: any): o is ListEntitlementsRequest {
-    return _smithy.isa(o, "ListEntitlementsRequest");
+    return __isa(o, "ListEntitlementsRequest");
   }
 }
 
@@ -625,7 +626,7 @@ export interface ListEntitlementsResponse extends $MetadataBearer {
 
 export namespace ListEntitlementsResponse {
   export function isa(o: any): o is ListEntitlementsResponse {
-    return _smithy.isa(o, "ListEntitlementsResponse");
+    return __isa(o, "ListEntitlementsResponse");
   }
 }
 
@@ -644,7 +645,7 @@ export interface ListFlowsRequest {
 
 export namespace ListFlowsRequest {
   export function isa(o: any): o is ListFlowsRequest {
-    return _smithy.isa(o, "ListFlowsRequest");
+    return __isa(o, "ListFlowsRequest");
   }
 }
 
@@ -663,7 +664,7 @@ export interface ListFlowsResponse extends $MetadataBearer {
 
 export namespace ListFlowsResponse {
   export function isa(o: any): o is ListFlowsResponse {
-    return _smithy.isa(o, "ListFlowsResponse");
+    return __isa(o, "ListFlowsResponse");
   }
 }
 
@@ -677,7 +678,7 @@ export interface ListTagsForResourceRequest {
 
 export namespace ListTagsForResourceRequest {
   export function isa(o: any): o is ListTagsForResourceRequest {
-    return _smithy.isa(o, "ListTagsForResourceRequest");
+    return __isa(o, "ListTagsForResourceRequest");
   }
 }
 
@@ -691,7 +692,7 @@ export interface ListTagsForResourceResponse extends $MetadataBearer {
 
 export namespace ListTagsForResourceResponse {
   export function isa(o: any): o is ListTagsForResourceResponse {
-    return _smithy.isa(o, "ListTagsForResourceResponse");
+    return __isa(o, "ListTagsForResourceResponse");
   }
 }
 
@@ -718,7 +719,7 @@ export interface ListedEntitlement {
 
 export namespace ListedEntitlement {
   export function isa(o: any): o is ListedEntitlement {
-    return _smithy.isa(o, "ListedEntitlement");
+    return __isa(o, "ListedEntitlement");
   }
 }
 
@@ -760,7 +761,7 @@ export interface ListedFlow {
 
 export namespace ListedFlow {
   export function isa(o: any): o is ListedFlow {
-    return _smithy.isa(o, "ListedFlow");
+    return __isa(o, "ListedFlow");
   }
 }
 
@@ -777,16 +778,14 @@ export interface Messages {
 
 export namespace Messages {
   export function isa(o: any): o is Messages {
-    return _smithy.isa(o, "Messages");
+    return __isa(o, "Messages");
   }
 }
 
 /**
  * Exception raised by AWS Elemental MediaConnect. See the error message and documentation for the operation for more information on the cause of this exception.
  */
-export interface NotFoundException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface NotFoundException extends __SmithyException, $MetadataBearer {
   name: "NotFoundException";
   $fault: "client";
   /**
@@ -797,7 +796,7 @@ export interface NotFoundException
 
 export namespace NotFoundException {
   export function isa(o: any): o is NotFoundException {
-    return _smithy.isa(o, "NotFoundException");
+    return __isa(o, "NotFoundException");
   }
 }
 
@@ -859,7 +858,7 @@ export interface Output {
 
 export namespace Output {
   export function isa(o: any): o is Output {
-    return _smithy.isa(o, "Output");
+    return __isa(o, "Output");
   }
 }
 
@@ -886,7 +885,7 @@ export interface RemoveFlowOutputRequest {
 
 export namespace RemoveFlowOutputRequest {
   export function isa(o: any): o is RemoveFlowOutputRequest {
-    return _smithy.isa(o, "RemoveFlowOutputRequest");
+    return __isa(o, "RemoveFlowOutputRequest");
   }
 }
 
@@ -905,7 +904,7 @@ export interface RemoveFlowOutputResponse extends $MetadataBearer {
 
 export namespace RemoveFlowOutputResponse {
   export function isa(o: any): o is RemoveFlowOutputResponse {
-    return _smithy.isa(o, "RemoveFlowOutputResponse");
+    return __isa(o, "RemoveFlowOutputResponse");
   }
 }
 
@@ -924,7 +923,7 @@ export interface RevokeFlowEntitlementRequest {
 
 export namespace RevokeFlowEntitlementRequest {
   export function isa(o: any): o is RevokeFlowEntitlementRequest {
-    return _smithy.isa(o, "RevokeFlowEntitlementRequest");
+    return __isa(o, "RevokeFlowEntitlementRequest");
   }
 }
 
@@ -943,7 +942,7 @@ export interface RevokeFlowEntitlementResponse extends $MetadataBearer {
 
 export namespace RevokeFlowEntitlementResponse {
   export function isa(o: any): o is RevokeFlowEntitlementResponse {
-    return _smithy.isa(o, "RevokeFlowEntitlementResponse");
+    return __isa(o, "RevokeFlowEntitlementResponse");
   }
 }
 
@@ -951,7 +950,7 @@ export namespace RevokeFlowEntitlementResponse {
  * Exception raised by AWS Elemental MediaConnect. See the error message and documentation for the operation for more information on the cause of this exception.
  */
 export interface ServiceUnavailableException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ServiceUnavailableException";
   $fault: "server";
@@ -963,7 +962,7 @@ export interface ServiceUnavailableException
 
 export namespace ServiceUnavailableException {
   export function isa(o: any): o is ServiceUnavailableException {
-    return _smithy.isa(o, "ServiceUnavailableException");
+    return __isa(o, "ServiceUnavailableException");
   }
 }
 
@@ -1025,7 +1024,7 @@ export interface SetSourceRequest {
 
 export namespace SetSourceRequest {
   export function isa(o: any): o is SetSourceRequest {
-    return _smithy.isa(o, "SetSourceRequest");
+    return __isa(o, "SetSourceRequest");
   }
 }
 
@@ -1087,7 +1086,7 @@ export interface Source {
 
 export namespace Source {
   export function isa(o: any): o is Source {
-    return _smithy.isa(o, "Source");
+    return __isa(o, "Source");
   }
 }
 
@@ -1106,7 +1105,7 @@ export interface StartFlowRequest {
 
 export namespace StartFlowRequest {
   export function isa(o: any): o is StartFlowRequest {
-    return _smithy.isa(o, "StartFlowRequest");
+    return __isa(o, "StartFlowRequest");
   }
 }
 
@@ -1125,7 +1124,7 @@ export interface StartFlowResponse extends $MetadataBearer {
 
 export namespace StartFlowResponse {
   export function isa(o: any): o is StartFlowResponse {
-    return _smithy.isa(o, "StartFlowResponse");
+    return __isa(o, "StartFlowResponse");
   }
 }
 
@@ -1149,7 +1148,7 @@ export interface StopFlowRequest {
 
 export namespace StopFlowRequest {
   export function isa(o: any): o is StopFlowRequest {
-    return _smithy.isa(o, "StopFlowRequest");
+    return __isa(o, "StopFlowRequest");
   }
 }
 
@@ -1168,7 +1167,7 @@ export interface StopFlowResponse extends $MetadataBearer {
 
 export namespace StopFlowResponse {
   export function isa(o: any): o is StopFlowResponse {
-    return _smithy.isa(o, "StopFlowResponse");
+    return __isa(o, "StopFlowResponse");
   }
 }
 
@@ -1190,7 +1189,7 @@ export interface TagResourceRequest {
 
 export namespace TagResourceRequest {
   export function isa(o: any): o is TagResourceRequest {
-    return _smithy.isa(o, "TagResourceRequest");
+    return __isa(o, "TagResourceRequest");
   }
 }
 
@@ -1198,7 +1197,7 @@ export namespace TagResourceRequest {
  * Exception raised by AWS Elemental MediaConnect. See the error message and documentation for the operation for more information on the cause of this exception.
  */
 export interface TooManyRequestsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyRequestsException";
   $fault: "client";
@@ -1210,7 +1209,7 @@ export interface TooManyRequestsException
 
 export namespace TooManyRequestsException {
   export function isa(o: any): o is TooManyRequestsException {
-    return _smithy.isa(o, "TooManyRequestsException");
+    return __isa(o, "TooManyRequestsException");
   }
 }
 
@@ -1257,7 +1256,7 @@ export interface Transport {
 
 export namespace Transport {
   export function isa(o: any): o is Transport {
-    return _smithy.isa(o, "Transport");
+    return __isa(o, "Transport");
   }
 }
 
@@ -1276,7 +1275,7 @@ export interface UntagResourceRequest {
 
 export namespace UntagResourceRequest {
   export function isa(o: any): o is UntagResourceRequest {
-    return _smithy.isa(o, "UntagResourceRequest");
+    return __isa(o, "UntagResourceRequest");
   }
 }
 
@@ -1333,7 +1332,7 @@ export interface UpdateEncryption {
 
 export namespace UpdateEncryption {
   export function isa(o: any): o is UpdateEncryption {
-    return _smithy.isa(o, "UpdateEncryption");
+    return __isa(o, "UpdateEncryption");
   }
 }
 
@@ -1370,7 +1369,7 @@ export interface UpdateFlowEntitlementRequest {
 
 export namespace UpdateFlowEntitlementRequest {
   export function isa(o: any): o is UpdateFlowEntitlementRequest {
-    return _smithy.isa(o, "UpdateFlowEntitlementRequest");
+    return __isa(o, "UpdateFlowEntitlementRequest");
   }
 }
 
@@ -1389,7 +1388,7 @@ export interface UpdateFlowEntitlementResponse extends $MetadataBearer {
 
 export namespace UpdateFlowEntitlementResponse {
   export function isa(o: any): o is UpdateFlowEntitlementResponse {
-    return _smithy.isa(o, "UpdateFlowEntitlementResponse");
+    return __isa(o, "UpdateFlowEntitlementResponse");
   }
 }
 
@@ -1461,7 +1460,7 @@ export interface UpdateFlowOutputRequest {
 
 export namespace UpdateFlowOutputRequest {
   export function isa(o: any): o is UpdateFlowOutputRequest {
-    return _smithy.isa(o, "UpdateFlowOutputRequest");
+    return __isa(o, "UpdateFlowOutputRequest");
   }
 }
 
@@ -1480,7 +1479,7 @@ export interface UpdateFlowOutputResponse extends $MetadataBearer {
 
 export namespace UpdateFlowOutputResponse {
   export function isa(o: any): o is UpdateFlowOutputResponse {
-    return _smithy.isa(o, "UpdateFlowOutputResponse");
+    return __isa(o, "UpdateFlowOutputResponse");
   }
 }
 
@@ -1547,7 +1546,7 @@ export interface UpdateFlowSourceRequest {
 
 export namespace UpdateFlowSourceRequest {
   export function isa(o: any): o is UpdateFlowSourceRequest {
-    return _smithy.isa(o, "UpdateFlowSourceRequest");
+    return __isa(o, "UpdateFlowSourceRequest");
   }
 }
 
@@ -1566,6 +1565,6 @@ export interface UpdateFlowSourceResponse extends $MetadataBearer {
 
 export namespace UpdateFlowSourceResponse {
   export function isa(o: any): o is UpdateFlowSourceResponse {
-    return _smithy.isa(o, "UpdateFlowSourceResponse");
+    return __isa(o, "UpdateFlowSourceResponse");
   }
 }

--- a/clients/client-mediaconnect/protocols/Aws_restJson1_1.ts
+++ b/clients/client-mediaconnect/protocols/Aws_restJson1_1.ts
@@ -94,7 +94,10 @@ import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  extendedEncodeURIComponent as __extendedEncodeURIComponent
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -110,13 +113,13 @@ export async function serializeAws_restJson1_1AddFlowOutputsCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v1/flows/{FlowArn}/outputs";
   if (input.FlowArn !== undefined) {
-    const labelValue: string = input.FlowArn.toString();
+    const labelValue: string = input.FlowArn;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: FlowArn.");
     }
     resolvedPath = resolvedPath.replace(
       "{FlowArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: FlowArn.");
@@ -194,13 +197,13 @@ export async function serializeAws_restJson1_1DeleteFlowCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/flows/{FlowArn}";
   if (input.FlowArn !== undefined) {
-    const labelValue: string = input.FlowArn.toString();
+    const labelValue: string = input.FlowArn;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: FlowArn.");
     }
     resolvedPath = resolvedPath.replace(
       "{FlowArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: FlowArn.");
@@ -222,13 +225,13 @@ export async function serializeAws_restJson1_1DescribeFlowCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/flows/{FlowArn}";
   if (input.FlowArn !== undefined) {
-    const labelValue: string = input.FlowArn.toString();
+    const labelValue: string = input.FlowArn;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: FlowArn.");
     }
     resolvedPath = resolvedPath.replace(
       "{FlowArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: FlowArn.");
@@ -250,13 +253,13 @@ export async function serializeAws_restJson1_1GrantFlowEntitlementsCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v1/flows/{FlowArn}/entitlements";
   if (input.FlowArn !== undefined) {
-    const labelValue: string = input.FlowArn.toString();
+    const labelValue: string = input.FlowArn;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: FlowArn.");
     }
     resolvedPath = resolvedPath.replace(
       "{FlowArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: FlowArn.");
@@ -291,10 +294,14 @@ export async function serializeAws_restJson1_1ListEntitlementsCommand(
   let resolvedPath = "/v1/entitlements";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -315,10 +322,14 @@ export async function serializeAws_restJson1_1ListFlowsCommand(
   let resolvedPath = "/v1/flows";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -338,7 +349,7 @@ export async function serializeAws_restJson1_1ListTagsForResourceCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/tags/{ResourceArn}";
   if (input.ResourceArn !== undefined) {
-    const labelValue: string = input.ResourceArn.toString();
+    const labelValue: string = input.ResourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ResourceArn."
@@ -346,7 +357,7 @@ export async function serializeAws_restJson1_1ListTagsForResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ResourceArn.");
@@ -368,25 +379,25 @@ export async function serializeAws_restJson1_1RemoveFlowOutputCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/flows/{FlowArn}/outputs/{OutputArn}";
   if (input.FlowArn !== undefined) {
-    const labelValue: string = input.FlowArn.toString();
+    const labelValue: string = input.FlowArn;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: FlowArn.");
     }
     resolvedPath = resolvedPath.replace(
       "{FlowArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: FlowArn.");
   }
   if (input.OutputArn !== undefined) {
-    const labelValue: string = input.OutputArn.toString();
+    const labelValue: string = input.OutputArn;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: OutputArn.");
     }
     resolvedPath = resolvedPath.replace(
       "{OutputArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: OutputArn.");
@@ -408,7 +419,7 @@ export async function serializeAws_restJson1_1RevokeFlowEntitlementCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/flows/{FlowArn}/entitlements/{EntitlementArn}";
   if (input.EntitlementArn !== undefined) {
-    const labelValue: string = input.EntitlementArn.toString();
+    const labelValue: string = input.EntitlementArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: EntitlementArn."
@@ -416,19 +427,19 @@ export async function serializeAws_restJson1_1RevokeFlowEntitlementCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{EntitlementArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: EntitlementArn.");
   }
   if (input.FlowArn !== undefined) {
-    const labelValue: string = input.FlowArn.toString();
+    const labelValue: string = input.FlowArn;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: FlowArn.");
     }
     resolvedPath = resolvedPath.replace(
       "{FlowArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: FlowArn.");
@@ -450,13 +461,13 @@ export async function serializeAws_restJson1_1StartFlowCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/flows/start/{FlowArn}";
   if (input.FlowArn !== undefined) {
-    const labelValue: string = input.FlowArn.toString();
+    const labelValue: string = input.FlowArn;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: FlowArn.");
     }
     resolvedPath = resolvedPath.replace(
       "{FlowArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: FlowArn.");
@@ -478,13 +489,13 @@ export async function serializeAws_restJson1_1StopFlowCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/flows/stop/{FlowArn}";
   if (input.FlowArn !== undefined) {
-    const labelValue: string = input.FlowArn.toString();
+    const labelValue: string = input.FlowArn;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: FlowArn.");
     }
     resolvedPath = resolvedPath.replace(
       "{FlowArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: FlowArn.");
@@ -506,7 +517,7 @@ export async function serializeAws_restJson1_1TagResourceCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/tags/{ResourceArn}";
   if (input.ResourceArn !== undefined) {
-    const labelValue: string = input.ResourceArn.toString();
+    const labelValue: string = input.ResourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ResourceArn."
@@ -514,7 +525,7 @@ export async function serializeAws_restJson1_1TagResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ResourceArn.");
@@ -546,7 +557,7 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/tags/{ResourceArn}";
   if (input.ResourceArn !== undefined) {
-    const labelValue: string = input.ResourceArn.toString();
+    const labelValue: string = input.ResourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ResourceArn."
@@ -554,14 +565,16 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ResourceArn.");
   }
   const query: any = {};
   if (input.TagKeys !== undefined) {
-    query["tagKeys"] = input.TagKeys;
+    query[__extendedEncodeURIComponent("tagKeys")] = input.TagKeys.map(entry =>
+      __extendedEncodeURIComponent(entry)
+    );
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -581,7 +594,7 @@ export async function serializeAws_restJson1_1UpdateFlowEntitlementCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v1/flows/{FlowArn}/entitlements/{EntitlementArn}";
   if (input.EntitlementArn !== undefined) {
-    const labelValue: string = input.EntitlementArn.toString();
+    const labelValue: string = input.EntitlementArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: EntitlementArn."
@@ -589,19 +602,19 @@ export async function serializeAws_restJson1_1UpdateFlowEntitlementCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{EntitlementArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: EntitlementArn.");
   }
   if (input.FlowArn !== undefined) {
-    const labelValue: string = input.FlowArn.toString();
+    const labelValue: string = input.FlowArn;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: FlowArn.");
     }
     resolvedPath = resolvedPath.replace(
       "{FlowArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: FlowArn.");
@@ -642,25 +655,25 @@ export async function serializeAws_restJson1_1UpdateFlowOutputCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v1/flows/{FlowArn}/outputs/{OutputArn}";
   if (input.FlowArn !== undefined) {
-    const labelValue: string = input.FlowArn.toString();
+    const labelValue: string = input.FlowArn;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: FlowArn.");
     }
     resolvedPath = resolvedPath.replace(
       "{FlowArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: FlowArn.");
   }
   if (input.OutputArn !== undefined) {
-    const labelValue: string = input.OutputArn.toString();
+    const labelValue: string = input.OutputArn;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: OutputArn.");
     }
     resolvedPath = resolvedPath.replace(
       "{OutputArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: OutputArn.");
@@ -722,25 +735,25 @@ export async function serializeAws_restJson1_1UpdateFlowSourceCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v1/flows/{FlowArn}/source/{SourceArn}";
   if (input.FlowArn !== undefined) {
-    const labelValue: string = input.FlowArn.toString();
+    const labelValue: string = input.FlowArn;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: FlowArn.");
     }
     resolvedPath = resolvedPath.replace(
       "{FlowArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: FlowArn.");
   }
   if (input.SourceArn !== undefined) {
-    const labelValue: string = input.SourceArn.toString();
+    const labelValue: string = input.SourceArn;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: SourceArn.");
     }
     resolvedPath = resolvedPath.replace(
       "{SourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: SourceArn.");
@@ -1895,6 +1908,7 @@ export async function deserializeAws_restJson1_1TagResourceCommand(
   const contents: TagResourceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -1956,6 +1970,7 @@ export async function deserializeAws_restJson1_1UntagResourceCommand(
   const contents: UntagResourceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 

--- a/clients/client-mediaconvert/models/index.ts
+++ b/clients/client-mediaconvert/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export enum AacAudioDescriptionBroadcasterMix {
@@ -83,7 +86,7 @@ export interface AacSettings {
 
 export namespace AacSettings {
   export function isa(o: any): o is AacSettings {
-    return _smithy.isa(o, "AacSettings");
+    return __isa(o, "AacSettings");
   }
 }
 
@@ -180,7 +183,7 @@ export interface Ac3Settings {
 
 export namespace Ac3Settings {
   export function isa(o: any): o is Ac3Settings {
-    return _smithy.isa(o, "Ac3Settings");
+    return __isa(o, "Ac3Settings");
   }
 }
 
@@ -203,7 +206,7 @@ export interface AccelerationSettings {
 
 export namespace AccelerationSettings {
   export function isa(o: any): o is AccelerationSettings {
-    return _smithy.isa(o, "AccelerationSettings");
+    return __isa(o, "AccelerationSettings");
   }
 }
 
@@ -243,7 +246,7 @@ export interface AiffSettings {
 
 export namespace AiffSettings {
   export function isa(o: any): o is AiffSettings {
-    return _smithy.isa(o, "AiffSettings");
+    return __isa(o, "AiffSettings");
   }
 }
 
@@ -280,7 +283,7 @@ export interface AncillarySourceSettings {
 
 export namespace AncillarySourceSettings {
   export function isa(o: any): o is AncillarySourceSettings {
-    return _smithy.isa(o, "AncillarySourceSettings");
+    return __isa(o, "AncillarySourceSettings");
   }
 }
 
@@ -304,7 +307,7 @@ export interface AssociateCertificateRequest {
 
 export namespace AssociateCertificateRequest {
   export function isa(o: any): o is AssociateCertificateRequest {
-    return _smithy.isa(o, "AssociateCertificateRequest");
+    return __isa(o, "AssociateCertificateRequest");
   }
 }
 
@@ -314,7 +317,7 @@ export interface AssociateCertificateResponse extends $MetadataBearer {
 
 export namespace AssociateCertificateResponse {
   export function isa(o: any): o is AssociateCertificateResponse {
-    return _smithy.isa(o, "AssociateCertificateResponse");
+    return __isa(o, "AssociateCertificateResponse");
   }
 }
 
@@ -383,7 +386,7 @@ export interface AudioCodecSettings {
 
 export namespace AudioCodecSettings {
   export function isa(o: any): o is AudioCodecSettings {
-    return _smithy.isa(o, "AudioCodecSettings");
+    return __isa(o, "AudioCodecSettings");
   }
 }
 
@@ -450,7 +453,7 @@ export interface AudioDescription {
 
 export namespace AudioDescription {
   export function isa(o: any): o is AudioDescription {
-    return _smithy.isa(o, "AudioDescription");
+    return __isa(o, "AudioDescription");
   }
 }
 
@@ -519,7 +522,7 @@ export interface AudioNormalizationSettings {
 
 export namespace AudioNormalizationSettings {
   export function isa(o: any): o is AudioNormalizationSettings {
-    return _smithy.isa(o, "AudioNormalizationSettings");
+    return __isa(o, "AudioNormalizationSettings");
   }
 }
 
@@ -581,7 +584,7 @@ export interface AudioSelector {
 
 export namespace AudioSelector {
   export function isa(o: any): o is AudioSelector {
-    return _smithy.isa(o, "AudioSelector");
+    return __isa(o, "AudioSelector");
   }
 }
 
@@ -598,7 +601,7 @@ export interface AudioSelectorGroup {
 
 export namespace AudioSelectorGroup {
   export function isa(o: any): o is AudioSelectorGroup {
-    return _smithy.isa(o, "AudioSelectorGroup");
+    return __isa(o, "AudioSelectorGroup");
   }
 }
 
@@ -626,7 +629,7 @@ export interface AvailBlanking {
 
 export namespace AvailBlanking {
   export function isa(o: any): o is AvailBlanking {
-    return _smithy.isa(o, "AvailBlanking");
+    return __isa(o, "AvailBlanking");
   }
 }
 
@@ -634,7 +637,7 @@ export namespace AvailBlanking {
  * The service can't process your request because of a problem in the request. Please check your request form and syntax.
  */
 export interface BadRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "BadRequestException";
   $fault: "client";
@@ -643,7 +646,7 @@ export interface BadRequestException
 
 export namespace BadRequestException {
   export function isa(o: any): o is BadRequestException {
-    return _smithy.isa(o, "BadRequestException");
+    return __isa(o, "BadRequestException");
   }
 }
 
@@ -751,7 +754,7 @@ export interface BurninDestinationSettings {
 
 export namespace BurninDestinationSettings {
   export function isa(o: any): o is BurninDestinationSettings {
-    return _smithy.isa(o, "BurninDestinationSettings");
+    return __isa(o, "BurninDestinationSettings");
   }
 }
 
@@ -805,7 +808,7 @@ export interface CancelJobRequest {
 
 export namespace CancelJobRequest {
   export function isa(o: any): o is CancelJobRequest {
-    return _smithy.isa(o, "CancelJobRequest");
+    return __isa(o, "CancelJobRequest");
   }
 }
 
@@ -815,7 +818,7 @@ export interface CancelJobResponse extends $MetadataBearer {
 
 export namespace CancelJobResponse {
   export function isa(o: any): o is CancelJobResponse {
-    return _smithy.isa(o, "CancelJobResponse");
+    return __isa(o, "CancelJobResponse");
   }
 }
 
@@ -852,7 +855,7 @@ export interface CaptionDescription {
 
 export namespace CaptionDescription {
   export function isa(o: any): o is CaptionDescription {
-    return _smithy.isa(o, "CaptionDescription");
+    return __isa(o, "CaptionDescription");
   }
 }
 
@@ -884,7 +887,7 @@ export interface CaptionDescriptionPreset {
 
 export namespace CaptionDescriptionPreset {
   export function isa(o: any): o is CaptionDescriptionPreset {
-    return _smithy.isa(o, "CaptionDescriptionPreset");
+    return __isa(o, "CaptionDescriptionPreset");
   }
 }
 
@@ -936,7 +939,7 @@ export interface CaptionDestinationSettings {
 
 export namespace CaptionDestinationSettings {
   export function isa(o: any): o is CaptionDestinationSettings {
-    return _smithy.isa(o, "CaptionDestinationSettings");
+    return __isa(o, "CaptionDestinationSettings");
   }
 }
 
@@ -978,7 +981,7 @@ export interface CaptionSelector {
 
 export namespace CaptionSelector {
   export function isa(o: any): o is CaptionSelector {
-    return _smithy.isa(o, "CaptionSelector");
+    return __isa(o, "CaptionSelector");
   }
 }
 
@@ -1025,7 +1028,7 @@ export interface CaptionSourceSettings {
 
 export namespace CaptionSourceSettings {
   export function isa(o: any): o is CaptionSourceSettings {
-    return _smithy.isa(o, "CaptionSourceSettings");
+    return __isa(o, "CaptionSourceSettings");
   }
 }
 
@@ -1057,7 +1060,7 @@ export interface ChannelMapping {
 
 export namespace ChannelMapping {
   export function isa(o: any): o is ChannelMapping {
-    return _smithy.isa(o, "ChannelMapping");
+    return __isa(o, "ChannelMapping");
   }
 }
 
@@ -1079,7 +1082,7 @@ export interface CmafAdditionalManifest {
 
 export namespace CmafAdditionalManifest {
   export function isa(o: any): o is CmafAdditionalManifest {
-    return _smithy.isa(o, "CmafAdditionalManifest");
+    return __isa(o, "CmafAdditionalManifest");
   }
 }
 
@@ -1131,7 +1134,7 @@ export interface CmafEncryptionSettings {
 
 export namespace CmafEncryptionSettings {
   export function isa(o: any): o is CmafEncryptionSettings {
-    return _smithy.isa(o, "CmafEncryptionSettings");
+    return __isa(o, "CmafEncryptionSettings");
   }
 }
 
@@ -1245,7 +1248,7 @@ export interface CmafGroupSettings {
 
 export namespace CmafGroupSettings {
   export function isa(o: any): o is CmafGroupSettings {
-    return _smithy.isa(o, "CmafGroupSettings");
+    return __isa(o, "CmafGroupSettings");
   }
 }
 
@@ -1327,7 +1330,7 @@ export interface CmfcSettings {
 
 export namespace CmfcSettings {
   export function isa(o: any): o is CmfcSettings {
-    return _smithy.isa(o, "CmfcSettings");
+    return __isa(o, "CmfcSettings");
   }
 }
 
@@ -1369,7 +1372,7 @@ export interface ColorCorrector {
 
 export namespace ColorCorrector {
   export function isa(o: any): o is ColorCorrector {
-    return _smithy.isa(o, "ColorCorrector");
+    return __isa(o, "ColorCorrector");
   }
 }
 
@@ -1406,9 +1409,7 @@ export enum Commitment {
 /**
  * The service couldn't complete your request because there is a conflict with the current state of the resource.
  */
-export interface ConflictException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface ConflictException extends __SmithyException, $MetadataBearer {
   name: "ConflictException";
   $fault: "client";
   Message?: string;
@@ -1416,7 +1417,7 @@ export interface ConflictException
 
 export namespace ConflictException {
   export function isa(o: any): o is ConflictException {
-    return _smithy.isa(o, "ConflictException");
+    return __isa(o, "ConflictException");
   }
 }
 
@@ -1468,7 +1469,7 @@ export interface ContainerSettings {
 
 export namespace ContainerSettings {
   export function isa(o: any): o is ContainerSettings {
-    return _smithy.isa(o, "ContainerSettings");
+    return __isa(o, "ContainerSettings");
   }
 }
 
@@ -1550,7 +1551,7 @@ export interface CreateJobRequest {
 
 export namespace CreateJobRequest {
   export function isa(o: any): o is CreateJobRequest {
-    return _smithy.isa(o, "CreateJobRequest");
+    return __isa(o, "CreateJobRequest");
   }
 }
 
@@ -1564,7 +1565,7 @@ export interface CreateJobResponse extends $MetadataBearer {
 
 export namespace CreateJobResponse {
   export function isa(o: any): o is CreateJobResponse {
-    return _smithy.isa(o, "CreateJobResponse");
+    return __isa(o, "CreateJobResponse");
   }
 }
 
@@ -1618,7 +1619,7 @@ export interface CreateJobTemplateRequest {
 
 export namespace CreateJobTemplateRequest {
   export function isa(o: any): o is CreateJobTemplateRequest {
-    return _smithy.isa(o, "CreateJobTemplateRequest");
+    return __isa(o, "CreateJobTemplateRequest");
   }
 }
 
@@ -1632,7 +1633,7 @@ export interface CreateJobTemplateResponse extends $MetadataBearer {
 
 export namespace CreateJobTemplateResponse {
   export function isa(o: any): o is CreateJobTemplateResponse {
-    return _smithy.isa(o, "CreateJobTemplateResponse");
+    return __isa(o, "CreateJobTemplateResponse");
   }
 }
 
@@ -1666,7 +1667,7 @@ export interface CreatePresetRequest {
 
 export namespace CreatePresetRequest {
   export function isa(o: any): o is CreatePresetRequest {
-    return _smithy.isa(o, "CreatePresetRequest");
+    return __isa(o, "CreatePresetRequest");
   }
 }
 
@@ -1680,7 +1681,7 @@ export interface CreatePresetResponse extends $MetadataBearer {
 
 export namespace CreatePresetResponse {
   export function isa(o: any): o is CreatePresetResponse {
-    return _smithy.isa(o, "CreatePresetResponse");
+    return __isa(o, "CreatePresetResponse");
   }
 }
 
@@ -1719,7 +1720,7 @@ export interface CreateQueueRequest {
 
 export namespace CreateQueueRequest {
   export function isa(o: any): o is CreateQueueRequest {
-    return _smithy.isa(o, "CreateQueueRequest");
+    return __isa(o, "CreateQueueRequest");
   }
 }
 
@@ -1733,7 +1734,7 @@ export interface CreateQueueResponse extends $MetadataBearer {
 
 export namespace CreateQueueResponse {
   export function isa(o: any): o is CreateQueueResponse {
-    return _smithy.isa(o, "CreateQueueResponse");
+    return __isa(o, "CreateQueueResponse");
   }
 }
 
@@ -1755,7 +1756,7 @@ export interface DashAdditionalManifest {
 
 export namespace DashAdditionalManifest {
   export function isa(o: any): o is DashAdditionalManifest {
-    return _smithy.isa(o, "DashAdditionalManifest");
+    return __isa(o, "DashAdditionalManifest");
   }
 }
 
@@ -1777,7 +1778,7 @@ export interface DashIsoEncryptionSettings {
 
 export namespace DashIsoEncryptionSettings {
   export function isa(o: any): o is DashIsoEncryptionSettings {
-    return _smithy.isa(o, "DashIsoEncryptionSettings");
+    return __isa(o, "DashIsoEncryptionSettings");
   }
 }
 
@@ -1851,7 +1852,7 @@ export interface DashIsoGroupSettings {
 
 export namespace DashIsoGroupSettings {
   export function isa(o: any): o is DashIsoGroupSettings {
-    return _smithy.isa(o, "DashIsoGroupSettings");
+    return __isa(o, "DashIsoGroupSettings");
   }
 }
 
@@ -1916,7 +1917,7 @@ export interface Deinterlacer {
 
 export namespace Deinterlacer {
   export function isa(o: any): o is Deinterlacer {
-    return _smithy.isa(o, "Deinterlacer");
+    return __isa(o, "Deinterlacer");
   }
 }
 
@@ -1941,7 +1942,7 @@ export interface DeleteJobTemplateRequest {
 
 export namespace DeleteJobTemplateRequest {
   export function isa(o: any): o is DeleteJobTemplateRequest {
-    return _smithy.isa(o, "DeleteJobTemplateRequest");
+    return __isa(o, "DeleteJobTemplateRequest");
   }
 }
 
@@ -1951,7 +1952,7 @@ export interface DeleteJobTemplateResponse extends $MetadataBearer {
 
 export namespace DeleteJobTemplateResponse {
   export function isa(o: any): o is DeleteJobTemplateResponse {
-    return _smithy.isa(o, "DeleteJobTemplateResponse");
+    return __isa(o, "DeleteJobTemplateResponse");
   }
 }
 
@@ -1965,7 +1966,7 @@ export interface DeletePresetRequest {
 
 export namespace DeletePresetRequest {
   export function isa(o: any): o is DeletePresetRequest {
-    return _smithy.isa(o, "DeletePresetRequest");
+    return __isa(o, "DeletePresetRequest");
   }
 }
 
@@ -1975,7 +1976,7 @@ export interface DeletePresetResponse extends $MetadataBearer {
 
 export namespace DeletePresetResponse {
   export function isa(o: any): o is DeletePresetResponse {
-    return _smithy.isa(o, "DeletePresetResponse");
+    return __isa(o, "DeletePresetResponse");
   }
 }
 
@@ -1989,7 +1990,7 @@ export interface DeleteQueueRequest {
 
 export namespace DeleteQueueRequest {
   export function isa(o: any): o is DeleteQueueRequest {
-    return _smithy.isa(o, "DeleteQueueRequest");
+    return __isa(o, "DeleteQueueRequest");
   }
 }
 
@@ -1999,7 +2000,7 @@ export interface DeleteQueueResponse extends $MetadataBearer {
 
 export namespace DeleteQueueResponse {
   export function isa(o: any): o is DeleteQueueResponse {
-    return _smithy.isa(o, "DeleteQueueResponse");
+    return __isa(o, "DeleteQueueResponse");
   }
 }
 
@@ -2031,7 +2032,7 @@ export interface DescribeEndpointsRequest {
 
 export namespace DescribeEndpointsRequest {
   export function isa(o: any): o is DescribeEndpointsRequest {
-    return _smithy.isa(o, "DescribeEndpointsRequest");
+    return __isa(o, "DescribeEndpointsRequest");
   }
 }
 
@@ -2050,7 +2051,7 @@ export interface DescribeEndpointsResponse extends $MetadataBearer {
 
 export namespace DescribeEndpointsResponse {
   export function isa(o: any): o is DescribeEndpointsResponse {
-    return _smithy.isa(o, "DescribeEndpointsResponse");
+    return __isa(o, "DescribeEndpointsResponse");
   }
 }
 
@@ -2067,7 +2068,7 @@ export interface DestinationSettings {
 
 export namespace DestinationSettings {
   export function isa(o: any): o is DestinationSettings {
-    return _smithy.isa(o, "DestinationSettings");
+    return __isa(o, "DestinationSettings");
   }
 }
 
@@ -2081,7 +2082,7 @@ export interface DisassociateCertificateRequest {
 
 export namespace DisassociateCertificateRequest {
   export function isa(o: any): o is DisassociateCertificateRequest {
-    return _smithy.isa(o, "DisassociateCertificateRequest");
+    return __isa(o, "DisassociateCertificateRequest");
   }
 }
 
@@ -2091,7 +2092,7 @@ export interface DisassociateCertificateResponse extends $MetadataBearer {
 
 export namespace DisassociateCertificateResponse {
   export function isa(o: any): o is DisassociateCertificateResponse {
-    return _smithy.isa(o, "DisassociateCertificateResponse");
+    return __isa(o, "DisassociateCertificateResponse");
   }
 }
 
@@ -2118,7 +2119,7 @@ export interface DolbyVision {
 
 export namespace DolbyVision {
   export function isa(o: any): o is DolbyVision {
-    return _smithy.isa(o, "DolbyVision");
+    return __isa(o, "DolbyVision");
   }
 }
 
@@ -2140,7 +2141,7 @@ export interface DolbyVisionLevel6Metadata {
 
 export namespace DolbyVisionLevel6Metadata {
   export function isa(o: any): o is DolbyVisionLevel6Metadata {
-    return _smithy.isa(o, "DolbyVisionLevel6Metadata");
+    return __isa(o, "DolbyVisionLevel6Metadata");
   }
 }
 
@@ -2182,7 +2183,7 @@ export interface DvbNitSettings {
 
 export namespace DvbNitSettings {
   export function isa(o: any): o is DvbNitSettings {
-    return _smithy.isa(o, "DvbNitSettings");
+    return __isa(o, "DvbNitSettings");
   }
 }
 
@@ -2214,7 +2215,7 @@ export interface DvbSdtSettings {
 
 export namespace DvbSdtSettings {
   export function isa(o: any): o is DvbSdtSettings {
-    return _smithy.isa(o, "DvbSdtSettings");
+    return __isa(o, "DvbSdtSettings");
   }
 }
 
@@ -2320,7 +2321,7 @@ export interface DvbSubDestinationSettings {
 
 export namespace DvbSubDestinationSettings {
   export function isa(o: any): o is DvbSubDestinationSettings {
-    return _smithy.isa(o, "DvbSubDestinationSettings");
+    return __isa(o, "DvbSubDestinationSettings");
   }
 }
 
@@ -2337,7 +2338,7 @@ export interface DvbSubSourceSettings {
 
 export namespace DvbSubSourceSettings {
   export function isa(o: any): o is DvbSubSourceSettings {
-    return _smithy.isa(o, "DvbSubSourceSettings");
+    return __isa(o, "DvbSubSourceSettings");
   }
 }
 
@@ -2399,7 +2400,7 @@ export interface DvbTdtSettings {
 
 export namespace DvbTdtSettings {
   export function isa(o: any): o is DvbTdtSettings {
-    return _smithy.isa(o, "DvbTdtSettings");
+    return __isa(o, "DvbTdtSettings");
   }
 }
 
@@ -2529,7 +2530,7 @@ export interface Eac3AtmosSettings {
 
 export namespace Eac3AtmosSettings {
   export function isa(o: any): o is Eac3AtmosSettings {
-    return _smithy.isa(o, "Eac3AtmosSettings");
+    return __isa(o, "Eac3AtmosSettings");
   }
 }
 
@@ -2726,7 +2727,7 @@ export interface Eac3Settings {
 
 export namespace Eac3Settings {
   export function isa(o: any): o is Eac3Settings {
-    return _smithy.isa(o, "Eac3Settings");
+    return __isa(o, "Eac3Settings");
   }
 }
 
@@ -2772,7 +2773,7 @@ export interface EmbeddedDestinationSettings {
 
 export namespace EmbeddedDestinationSettings {
   export function isa(o: any): o is EmbeddedDestinationSettings {
-    return _smithy.isa(o, "EmbeddedDestinationSettings");
+    return __isa(o, "EmbeddedDestinationSettings");
   }
 }
 
@@ -2804,7 +2805,7 @@ export interface EmbeddedSourceSettings {
 
 export namespace EmbeddedSourceSettings {
   export function isa(o: any): o is EmbeddedSourceSettings {
-    return _smithy.isa(o, "EmbeddedSourceSettings");
+    return __isa(o, "EmbeddedSourceSettings");
   }
 }
 
@@ -2826,7 +2827,7 @@ export interface Endpoint {
 
 export namespace Endpoint {
   export function isa(o: any): o is Endpoint {
-    return _smithy.isa(o, "Endpoint");
+    return __isa(o, "Endpoint");
   }
 }
 
@@ -2843,7 +2844,7 @@ export interface EsamManifestConfirmConditionNotification {
 
 export namespace EsamManifestConfirmConditionNotification {
   export function isa(o: any): o is EsamManifestConfirmConditionNotification {
-    return _smithy.isa(o, "EsamManifestConfirmConditionNotification");
+    return __isa(o, "EsamManifestConfirmConditionNotification");
   }
 }
 
@@ -2870,7 +2871,7 @@ export interface EsamSettings {
 
 export namespace EsamSettings {
   export function isa(o: any): o is EsamSettings {
-    return _smithy.isa(o, "EsamSettings");
+    return __isa(o, "EsamSettings");
   }
 }
 
@@ -2887,7 +2888,7 @@ export interface EsamSignalProcessingNotification {
 
 export namespace EsamSignalProcessingNotification {
   export function isa(o: any): o is EsamSignalProcessingNotification {
-    return _smithy.isa(o, "EsamSignalProcessingNotification");
+    return __isa(o, "EsamSignalProcessingNotification");
   }
 }
 
@@ -2909,7 +2910,7 @@ export interface F4vSettings {
 
 export namespace F4vSettings {
   export function isa(o: any): o is F4vSettings {
-    return _smithy.isa(o, "F4vSettings");
+    return __isa(o, "F4vSettings");
   }
 }
 
@@ -2931,7 +2932,7 @@ export interface FileGroupSettings {
 
 export namespace FileGroupSettings {
   export function isa(o: any): o is FileGroupSettings {
-    return _smithy.isa(o, "FileGroupSettings");
+    return __isa(o, "FileGroupSettings");
   }
 }
 
@@ -2963,7 +2964,7 @@ export interface FileSourceSettings {
 
 export namespace FileSourceSettings {
   export function isa(o: any): o is FileSourceSettings {
-    return _smithy.isa(o, "FileSourceSettings");
+    return __isa(o, "FileSourceSettings");
   }
 }
 
@@ -2976,9 +2977,7 @@ export enum FontScript {
 /**
  * You don't have permissions for this action with the credentials you sent.
  */
-export interface ForbiddenException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface ForbiddenException extends __SmithyException, $MetadataBearer {
   name: "ForbiddenException";
   $fault: "client";
   Message?: string;
@@ -2986,7 +2985,7 @@ export interface ForbiddenException
 
 export namespace ForbiddenException {
   export function isa(o: any): o is ForbiddenException {
-    return _smithy.isa(o, "ForbiddenException");
+    return __isa(o, "ForbiddenException");
   }
 }
 
@@ -3018,7 +3017,7 @@ export interface FrameCaptureSettings {
 
 export namespace FrameCaptureSettings {
   export function isa(o: any): o is FrameCaptureSettings {
-    return _smithy.isa(o, "FrameCaptureSettings");
+    return __isa(o, "FrameCaptureSettings");
   }
 }
 
@@ -3032,7 +3031,7 @@ export interface GetJobRequest {
 
 export namespace GetJobRequest {
   export function isa(o: any): o is GetJobRequest {
-    return _smithy.isa(o, "GetJobRequest");
+    return __isa(o, "GetJobRequest");
   }
 }
 
@@ -3046,7 +3045,7 @@ export interface GetJobResponse extends $MetadataBearer {
 
 export namespace GetJobResponse {
   export function isa(o: any): o is GetJobResponse {
-    return _smithy.isa(o, "GetJobResponse");
+    return __isa(o, "GetJobResponse");
   }
 }
 
@@ -3060,7 +3059,7 @@ export interface GetJobTemplateRequest {
 
 export namespace GetJobTemplateRequest {
   export function isa(o: any): o is GetJobTemplateRequest {
-    return _smithy.isa(o, "GetJobTemplateRequest");
+    return __isa(o, "GetJobTemplateRequest");
   }
 }
 
@@ -3074,7 +3073,7 @@ export interface GetJobTemplateResponse extends $MetadataBearer {
 
 export namespace GetJobTemplateResponse {
   export function isa(o: any): o is GetJobTemplateResponse {
-    return _smithy.isa(o, "GetJobTemplateResponse");
+    return __isa(o, "GetJobTemplateResponse");
   }
 }
 
@@ -3088,7 +3087,7 @@ export interface GetPresetRequest {
 
 export namespace GetPresetRequest {
   export function isa(o: any): o is GetPresetRequest {
-    return _smithy.isa(o, "GetPresetRequest");
+    return __isa(o, "GetPresetRequest");
   }
 }
 
@@ -3102,7 +3101,7 @@ export interface GetPresetResponse extends $MetadataBearer {
 
 export namespace GetPresetResponse {
   export function isa(o: any): o is GetPresetResponse {
-    return _smithy.isa(o, "GetPresetResponse");
+    return __isa(o, "GetPresetResponse");
   }
 }
 
@@ -3116,7 +3115,7 @@ export interface GetQueueRequest {
 
 export namespace GetQueueRequest {
   export function isa(o: any): o is GetQueueRequest {
-    return _smithy.isa(o, "GetQueueRequest");
+    return __isa(o, "GetQueueRequest");
   }
 }
 
@@ -3130,7 +3129,7 @@ export interface GetQueueResponse extends $MetadataBearer {
 
 export namespace GetQueueResponse {
   export function isa(o: any): o is GetQueueResponse {
-    return _smithy.isa(o, "GetQueueResponse");
+    return __isa(o, "GetQueueResponse");
   }
 }
 
@@ -3249,7 +3248,7 @@ export interface H264QvbrSettings {
 
 export namespace H264QvbrSettings {
   export function isa(o: any): o is H264QvbrSettings {
-    return _smithy.isa(o, "H264QvbrSettings");
+    return __isa(o, "H264QvbrSettings");
   }
 }
 
@@ -3475,7 +3474,7 @@ export interface H264Settings {
 
 export namespace H264Settings {
   export function isa(o: any): o is H264Settings {
-    return _smithy.isa(o, "H264Settings");
+    return __isa(o, "H264Settings");
   }
 }
 
@@ -3619,7 +3618,7 @@ export interface H265QvbrSettings {
 
 export namespace H265QvbrSettings {
   export function isa(o: any): o is H265QvbrSettings {
-    return _smithy.isa(o, "H265QvbrSettings");
+    return __isa(o, "H265QvbrSettings");
   }
 }
 
@@ -3844,7 +3843,7 @@ export interface H265Settings {
 
 export namespace H265Settings {
   export function isa(o: any): o is H265Settings {
-    return _smithy.isa(o, "H265Settings");
+    return __isa(o, "H265Settings");
   }
 }
 
@@ -3957,7 +3956,7 @@ export interface Hdr10Metadata {
 
 export namespace Hdr10Metadata {
   export function isa(o: any): o is Hdr10Metadata {
-    return _smithy.isa(o, "Hdr10Metadata");
+    return __isa(o, "Hdr10Metadata");
   }
 }
 
@@ -3984,7 +3983,7 @@ export interface HlsAdditionalManifest {
 
 export namespace HlsAdditionalManifest {
   export function isa(o: any): o is HlsAdditionalManifest {
-    return _smithy.isa(o, "HlsAdditionalManifest");
+    return __isa(o, "HlsAdditionalManifest");
   }
 }
 
@@ -4028,7 +4027,7 @@ export interface HlsCaptionLanguageMapping {
 
 export namespace HlsCaptionLanguageMapping {
   export function isa(o: any): o is HlsCaptionLanguageMapping {
-    return _smithy.isa(o, "HlsCaptionLanguageMapping");
+    return __isa(o, "HlsCaptionLanguageMapping");
   }
 }
 
@@ -4096,7 +4095,7 @@ export interface HlsEncryptionSettings {
 
 export namespace HlsEncryptionSettings {
   export function isa(o: any): o is HlsEncryptionSettings {
-    return _smithy.isa(o, "HlsEncryptionSettings");
+    return __isa(o, "HlsEncryptionSettings");
   }
 }
 
@@ -4238,7 +4237,7 @@ export interface HlsGroupSettings {
 
 export namespace HlsGroupSettings {
   export function isa(o: any): o is HlsGroupSettings {
-    return _smithy.isa(o, "HlsGroupSettings");
+    return __isa(o, "HlsGroupSettings");
   }
 }
 
@@ -4325,7 +4324,7 @@ export interface HlsSettings {
 
 export namespace HlsSettings {
   export function isa(o: any): o is HlsSettings {
-    return _smithy.isa(o, "HlsSettings");
+    return __isa(o, "HlsSettings");
   }
 }
 
@@ -4358,7 +4357,7 @@ export interface Id3Insertion {
 
 export namespace Id3Insertion {
   export function isa(o: any): o is Id3Insertion {
-    return _smithy.isa(o, "Id3Insertion");
+    return __isa(o, "Id3Insertion");
   }
 }
 
@@ -4375,7 +4374,7 @@ export interface ImageInserter {
 
 export namespace ImageInserter {
   export function isa(o: any): o is ImageInserter {
-    return _smithy.isa(o, "ImageInserter");
+    return __isa(o, "ImageInserter");
   }
 }
 
@@ -4392,7 +4391,7 @@ export interface ImscDestinationSettings {
 
 export namespace ImscDestinationSettings {
   export function isa(o: any): o is ImscDestinationSettings {
-    return _smithy.isa(o, "ImscDestinationSettings");
+    return __isa(o, "ImscDestinationSettings");
   }
 }
 
@@ -4504,7 +4503,7 @@ export interface Input {
 
 export namespace Input {
   export function isa(o: any): o is Input {
-    return _smithy.isa(o, "Input");
+    return __isa(o, "Input");
   }
 }
 
@@ -4526,7 +4525,7 @@ export interface InputClipping {
 
 export namespace InputClipping {
   export function isa(o: any): o is InputClipping {
-    return _smithy.isa(o, "InputClipping");
+    return __isa(o, "InputClipping");
   }
 }
 
@@ -4563,7 +4562,7 @@ export interface InputDecryptionSettings {
 
 export namespace InputDecryptionSettings {
   export function isa(o: any): o is InputDecryptionSettings {
-    return _smithy.isa(o, "InputDecryptionSettings");
+    return __isa(o, "InputDecryptionSettings");
   }
 }
 
@@ -4679,7 +4678,7 @@ export interface InputTemplate {
 
 export namespace InputTemplate {
   export function isa(o: any): o is InputTemplate {
-    return _smithy.isa(o, "InputTemplate");
+    return __isa(o, "InputTemplate");
   }
 }
 
@@ -4752,7 +4751,7 @@ export interface InsertableImage {
 
 export namespace InsertableImage {
   export function isa(o: any): o is InsertableImage {
-    return _smithy.isa(o, "InsertableImage");
+    return __isa(o, "InsertableImage");
   }
 }
 
@@ -4760,7 +4759,7 @@ export namespace InsertableImage {
  * The service encountered an unexpected condition and can't fulfill your request.
  */
 export interface InternalServerErrorException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalServerErrorException";
   $fault: "server";
@@ -4769,7 +4768,7 @@ export interface InternalServerErrorException
 
 export namespace InternalServerErrorException {
   export function isa(o: any): o is InternalServerErrorException {
-    return _smithy.isa(o, "InternalServerErrorException");
+    return __isa(o, "InternalServerErrorException");
   }
 }
 
@@ -4896,7 +4895,7 @@ export interface Job {
 
 export namespace Job {
   export function isa(o: any): o is Job {
-    return _smithy.isa(o, "Job");
+    return __isa(o, "Job");
   }
 }
 
@@ -4918,7 +4917,7 @@ export interface JobMessages {
 
 export namespace JobMessages {
   export function isa(o: any): o is JobMessages {
-    return _smithy.isa(o, "JobMessages");
+    return __isa(o, "JobMessages");
   }
 }
 
@@ -4981,7 +4980,7 @@ export interface JobSettings {
 
 export namespace JobSettings {
   export function isa(o: any): o is JobSettings {
-    return _smithy.isa(o, "JobSettings");
+    return __isa(o, "JobSettings");
   }
 }
 
@@ -5061,7 +5060,7 @@ export interface JobTemplate {
 
 export namespace JobTemplate {
   export function isa(o: any): o is JobTemplate {
-    return _smithy.isa(o, "JobTemplate");
+    return __isa(o, "JobTemplate");
   }
 }
 
@@ -5124,7 +5123,7 @@ export interface JobTemplateSettings {
 
 export namespace JobTemplateSettings {
   export function isa(o: any): o is JobTemplateSettings {
-    return _smithy.isa(o, "JobTemplateSettings");
+    return __isa(o, "JobTemplateSettings");
   }
 }
 
@@ -5352,7 +5351,7 @@ export interface ListJobTemplatesRequest {
 
 export namespace ListJobTemplatesRequest {
   export function isa(o: any): o is ListJobTemplatesRequest {
-    return _smithy.isa(o, "ListJobTemplatesRequest");
+    return __isa(o, "ListJobTemplatesRequest");
   }
 }
 
@@ -5371,7 +5370,7 @@ export interface ListJobTemplatesResponse extends $MetadataBearer {
 
 export namespace ListJobTemplatesResponse {
   export function isa(o: any): o is ListJobTemplatesResponse {
-    return _smithy.isa(o, "ListJobTemplatesResponse");
+    return __isa(o, "ListJobTemplatesResponse");
   }
 }
 
@@ -5405,7 +5404,7 @@ export interface ListJobsRequest {
 
 export namespace ListJobsRequest {
   export function isa(o: any): o is ListJobsRequest {
-    return _smithy.isa(o, "ListJobsRequest");
+    return __isa(o, "ListJobsRequest");
   }
 }
 
@@ -5424,7 +5423,7 @@ export interface ListJobsResponse extends $MetadataBearer {
 
 export namespace ListJobsResponse {
   export function isa(o: any): o is ListJobsResponse {
-    return _smithy.isa(o, "ListJobsResponse");
+    return __isa(o, "ListJobsResponse");
   }
 }
 
@@ -5458,7 +5457,7 @@ export interface ListPresetsRequest {
 
 export namespace ListPresetsRequest {
   export function isa(o: any): o is ListPresetsRequest {
-    return _smithy.isa(o, "ListPresetsRequest");
+    return __isa(o, "ListPresetsRequest");
   }
 }
 
@@ -5477,7 +5476,7 @@ export interface ListPresetsResponse extends $MetadataBearer {
 
 export namespace ListPresetsResponse {
   export function isa(o: any): o is ListPresetsResponse {
-    return _smithy.isa(o, "ListPresetsResponse");
+    return __isa(o, "ListPresetsResponse");
   }
 }
 
@@ -5506,7 +5505,7 @@ export interface ListQueuesRequest {
 
 export namespace ListQueuesRequest {
   export function isa(o: any): o is ListQueuesRequest {
-    return _smithy.isa(o, "ListQueuesRequest");
+    return __isa(o, "ListQueuesRequest");
   }
 }
 
@@ -5525,7 +5524,7 @@ export interface ListQueuesResponse extends $MetadataBearer {
 
 export namespace ListQueuesResponse {
   export function isa(o: any): o is ListQueuesResponse {
-    return _smithy.isa(o, "ListQueuesResponse");
+    return __isa(o, "ListQueuesResponse");
   }
 }
 
@@ -5539,7 +5538,7 @@ export interface ListTagsForResourceRequest {
 
 export namespace ListTagsForResourceRequest {
   export function isa(o: any): o is ListTagsForResourceRequest {
-    return _smithy.isa(o, "ListTagsForResourceRequest");
+    return __isa(o, "ListTagsForResourceRequest");
   }
 }
 
@@ -5553,7 +5552,7 @@ export interface ListTagsForResourceResponse extends $MetadataBearer {
 
 export namespace ListTagsForResourceResponse {
   export function isa(o: any): o is ListTagsForResourceResponse {
-    return _smithy.isa(o, "ListTagsForResourceResponse");
+    return __isa(o, "ListTagsForResourceResponse");
   }
 }
 
@@ -5615,7 +5614,7 @@ export interface M2tsScte35Esam {
 
 export namespace M2tsScte35Esam {
   export function isa(o: any): o is M2tsScte35Esam {
-    return _smithy.isa(o, "M2tsScte35Esam");
+    return __isa(o, "M2tsScte35Esam");
   }
 }
 
@@ -5826,7 +5825,7 @@ export interface M2tsSettings {
 
 export namespace M2tsSettings {
   export function isa(o: any): o is M2tsSettings {
-    return _smithy.isa(o, "M2tsSettings");
+    return __isa(o, "M2tsSettings");
   }
 }
 
@@ -5933,7 +5932,7 @@ export interface M3u8Settings {
 
 export namespace M3u8Settings {
   export function isa(o: any): o is M3u8Settings {
-    return _smithy.isa(o, "M3u8Settings");
+    return __isa(o, "M3u8Settings");
   }
 }
 
@@ -5975,7 +5974,7 @@ export interface MotionImageInserter {
 
 export namespace MotionImageInserter {
   export function isa(o: any): o is MotionImageInserter {
-    return _smithy.isa(o, "MotionImageInserter");
+    return __isa(o, "MotionImageInserter");
   }
 }
 
@@ -5997,7 +5996,7 @@ export interface MotionImageInsertionFramerate {
 
 export namespace MotionImageInsertionFramerate {
   export function isa(o: any): o is MotionImageInsertionFramerate {
-    return _smithy.isa(o, "MotionImageInsertionFramerate");
+    return __isa(o, "MotionImageInsertionFramerate");
   }
 }
 
@@ -6024,7 +6023,7 @@ export interface MotionImageInsertionOffset {
 
 export namespace MotionImageInsertionOffset {
   export function isa(o: any): o is MotionImageInsertionOffset {
-    return _smithy.isa(o, "MotionImageInsertionOffset");
+    return __isa(o, "MotionImageInsertionOffset");
   }
 }
 
@@ -6091,7 +6090,7 @@ export interface MovSettings {
 
 export namespace MovSettings {
   export function isa(o: any): o is MovSettings {
-    return _smithy.isa(o, "MovSettings");
+    return __isa(o, "MovSettings");
   }
 }
 
@@ -6118,7 +6117,7 @@ export interface Mp2Settings {
 
 export namespace Mp2Settings {
   export function isa(o: any): o is Mp2Settings {
-    return _smithy.isa(o, "Mp2Settings");
+    return __isa(o, "Mp2Settings");
   }
 }
 
@@ -6160,7 +6159,7 @@ export interface Mp3Settings {
 
 export namespace Mp3Settings {
   export function isa(o: any): o is Mp3Settings {
-    return _smithy.isa(o, "Mp3Settings");
+    return __isa(o, "Mp3Settings");
   }
 }
 
@@ -6212,7 +6211,7 @@ export interface Mp4Settings {
 
 export namespace Mp4Settings {
   export function isa(o: any): o is Mp4Settings {
-    return _smithy.isa(o, "Mp4Settings");
+    return __isa(o, "Mp4Settings");
   }
 }
 
@@ -6254,7 +6253,7 @@ export interface MpdSettings {
 
 export namespace MpdSettings {
   export function isa(o: any): o is MpdSettings {
-    return _smithy.isa(o, "MpdSettings");
+    return __isa(o, "MpdSettings");
   }
 }
 
@@ -6499,7 +6498,7 @@ export interface Mpeg2Settings {
 
 export namespace Mpeg2Settings {
   export function isa(o: any): o is Mpeg2Settings {
-    return _smithy.isa(o, "Mpeg2Settings");
+    return __isa(o, "Mpeg2Settings");
   }
 }
 
@@ -6547,7 +6546,7 @@ export interface MsSmoothAdditionalManifest {
 
 export namespace MsSmoothAdditionalManifest {
   export function isa(o: any): o is MsSmoothAdditionalManifest {
-    return _smithy.isa(o, "MsSmoothAdditionalManifest");
+    return __isa(o, "MsSmoothAdditionalManifest");
   }
 }
 
@@ -6569,7 +6568,7 @@ export interface MsSmoothEncryptionSettings {
 
 export namespace MsSmoothEncryptionSettings {
   export function isa(o: any): o is MsSmoothEncryptionSettings {
-    return _smithy.isa(o, "MsSmoothEncryptionSettings");
+    return __isa(o, "MsSmoothEncryptionSettings");
   }
 }
 
@@ -6616,7 +6615,7 @@ export interface MsSmoothGroupSettings {
 
 export namespace MsSmoothGroupSettings {
   export function isa(o: any): o is MsSmoothGroupSettings {
-    return _smithy.isa(o, "MsSmoothGroupSettings");
+    return __isa(o, "MsSmoothGroupSettings");
   }
 }
 
@@ -6643,7 +6642,7 @@ export interface NielsenConfiguration {
 
 export namespace NielsenConfiguration {
   export function isa(o: any): o is NielsenConfiguration {
-    return _smithy.isa(o, "NielsenConfiguration");
+    return __isa(o, "NielsenConfiguration");
   }
 }
 
@@ -6675,7 +6674,7 @@ export interface NoiseReducer {
 
 export namespace NoiseReducer {
   export function isa(o: any): o is NoiseReducer {
-    return _smithy.isa(o, "NoiseReducer");
+    return __isa(o, "NoiseReducer");
   }
 }
 
@@ -6703,7 +6702,7 @@ export interface NoiseReducerFilterSettings {
 
 export namespace NoiseReducerFilterSettings {
   export function isa(o: any): o is NoiseReducerFilterSettings {
-    return _smithy.isa(o, "NoiseReducerFilterSettings");
+    return __isa(o, "NoiseReducerFilterSettings");
   }
 }
 
@@ -6730,7 +6729,7 @@ export interface NoiseReducerSpatialFilterSettings {
 
 export namespace NoiseReducerSpatialFilterSettings {
   export function isa(o: any): o is NoiseReducerSpatialFilterSettings {
-    return _smithy.isa(o, "NoiseReducerSpatialFilterSettings");
+    return __isa(o, "NoiseReducerSpatialFilterSettings");
   }
 }
 
@@ -6757,16 +6756,14 @@ export interface NoiseReducerTemporalFilterSettings {
 
 export namespace NoiseReducerTemporalFilterSettings {
   export function isa(o: any): o is NoiseReducerTemporalFilterSettings {
-    return _smithy.isa(o, "NoiseReducerTemporalFilterSettings");
+    return __isa(o, "NoiseReducerTemporalFilterSettings");
   }
 }
 
 /**
  * The resource you requested doesn't exist.
  */
-export interface NotFoundException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface NotFoundException extends __SmithyException, $MetadataBearer {
   name: "NotFoundException";
   $fault: "client";
   Message?: string;
@@ -6774,7 +6771,7 @@ export interface NotFoundException
 
 export namespace NotFoundException {
   export function isa(o: any): o is NotFoundException {
-    return _smithy.isa(o, "NotFoundException");
+    return __isa(o, "NotFoundException");
   }
 }
 
@@ -6831,7 +6828,7 @@ export interface Output {
 
 export namespace Output {
   export function isa(o: any): o is Output {
-    return _smithy.isa(o, "Output");
+    return __isa(o, "Output");
   }
 }
 
@@ -6848,7 +6845,7 @@ export interface OutputChannelMapping {
 
 export namespace OutputChannelMapping {
   export function isa(o: any): o is OutputChannelMapping {
-    return _smithy.isa(o, "OutputChannelMapping");
+    return __isa(o, "OutputChannelMapping");
   }
 }
 
@@ -6870,7 +6867,7 @@ export interface OutputDetail {
 
 export namespace OutputDetail {
   export function isa(o: any): o is OutputDetail {
-    return _smithy.isa(o, "OutputDetail");
+    return __isa(o, "OutputDetail");
   }
 }
 
@@ -6902,7 +6899,7 @@ export interface OutputGroup {
 
 export namespace OutputGroup {
   export function isa(o: any): o is OutputGroup {
-    return _smithy.isa(o, "OutputGroup");
+    return __isa(o, "OutputGroup");
   }
 }
 
@@ -6919,7 +6916,7 @@ export interface OutputGroupDetail {
 
 export namespace OutputGroupDetail {
   export function isa(o: any): o is OutputGroupDetail {
-    return _smithy.isa(o, "OutputGroupDetail");
+    return __isa(o, "OutputGroupDetail");
   }
 }
 
@@ -6961,7 +6958,7 @@ export interface OutputGroupSettings {
 
 export namespace OutputGroupSettings {
   export function isa(o: any): o is OutputGroupSettings {
-    return _smithy.isa(o, "OutputGroupSettings");
+    return __isa(o, "OutputGroupSettings");
   }
 }
 
@@ -6993,7 +6990,7 @@ export interface OutputSettings {
 
 export namespace OutputSettings {
   export function isa(o: any): o is OutputSettings {
-    return _smithy.isa(o, "OutputSettings");
+    return __isa(o, "OutputSettings");
   }
 }
 
@@ -7045,7 +7042,7 @@ export interface Preset {
 
 export namespace Preset {
   export function isa(o: any): o is Preset {
-    return _smithy.isa(o, "Preset");
+    return __isa(o, "Preset");
   }
 }
 
@@ -7083,7 +7080,7 @@ export interface PresetSettings {
 
 export namespace PresetSettings {
   export function isa(o: any): o is PresetSettings {
-    return _smithy.isa(o, "PresetSettings");
+    return __isa(o, "PresetSettings");
   }
 }
 
@@ -7187,7 +7184,7 @@ export interface ProresSettings {
 
 export namespace ProresSettings {
   export function isa(o: any): o is ProresSettings {
-    return _smithy.isa(o, "ProresSettings");
+    return __isa(o, "ProresSettings");
   }
 }
 
@@ -7264,7 +7261,7 @@ export interface Queue {
 
 export namespace Queue {
   export function isa(o: any): o is Queue {
-    return _smithy.isa(o, "Queue");
+    return __isa(o, "Queue");
   }
 }
 
@@ -7306,7 +7303,7 @@ export interface Rectangle {
 
 export namespace Rectangle {
   export function isa(o: any): o is Rectangle {
-    return _smithy.isa(o, "Rectangle");
+    return __isa(o, "Rectangle");
   }
 }
 
@@ -7333,7 +7330,7 @@ export interface RemixSettings {
 
 export namespace RemixSettings {
   export function isa(o: any): o is RemixSettings {
-    return _smithy.isa(o, "RemixSettings");
+    return __isa(o, "RemixSettings");
   }
 }
 
@@ -7380,7 +7377,7 @@ export interface ReservationPlan {
 
 export namespace ReservationPlan {
   export function isa(o: any): o is ReservationPlan {
-    return _smithy.isa(o, "ReservationPlan");
+    return __isa(o, "ReservationPlan");
   }
 }
 
@@ -7407,7 +7404,7 @@ export interface ReservationPlanSettings {
 
 export namespace ReservationPlanSettings {
   export function isa(o: any): o is ReservationPlanSettings {
-    return _smithy.isa(o, "ReservationPlanSettings");
+    return __isa(o, "ReservationPlanSettings");
   }
 }
 
@@ -7434,7 +7431,7 @@ export interface ResourceTags {
 
 export namespace ResourceTags {
   export function isa(o: any): o is ResourceTags {
-    return _smithy.isa(o, "ResourceTags");
+    return __isa(o, "ResourceTags");
   }
 }
 
@@ -7457,7 +7454,7 @@ export interface S3DestinationAccessControl {
 
 export namespace S3DestinationAccessControl {
   export function isa(o: any): o is S3DestinationAccessControl {
-    return _smithy.isa(o, "S3DestinationAccessControl");
+    return __isa(o, "S3DestinationAccessControl");
   }
 }
 
@@ -7479,7 +7476,7 @@ export interface S3DestinationSettings {
 
 export namespace S3DestinationSettings {
   export function isa(o: any): o is S3DestinationSettings {
-    return _smithy.isa(o, "S3DestinationSettings");
+    return __isa(o, "S3DestinationSettings");
   }
 }
 
@@ -7501,7 +7498,7 @@ export interface S3EncryptionSettings {
 
 export namespace S3EncryptionSettings {
   export function isa(o: any): o is S3EncryptionSettings {
-    return _smithy.isa(o, "S3EncryptionSettings");
+    return __isa(o, "S3EncryptionSettings");
   }
 }
 
@@ -7543,7 +7540,7 @@ export interface SccDestinationSettings {
 
 export namespace SccDestinationSettings {
   export function isa(o: any): o is SccDestinationSettings {
-    return _smithy.isa(o, "SccDestinationSettings");
+    return __isa(o, "SccDestinationSettings");
   }
 }
 
@@ -7581,7 +7578,7 @@ export interface SpekeKeyProvider {
 
 export namespace SpekeKeyProvider {
   export function isa(o: any): o is SpekeKeyProvider {
-    return _smithy.isa(o, "SpekeKeyProvider");
+    return __isa(o, "SpekeKeyProvider");
   }
 }
 
@@ -7618,7 +7615,7 @@ export interface SpekeKeyProviderCmaf {
 
 export namespace SpekeKeyProviderCmaf {
   export function isa(o: any): o is SpekeKeyProviderCmaf {
-    return _smithy.isa(o, "SpekeKeyProviderCmaf");
+    return __isa(o, "SpekeKeyProviderCmaf");
   }
 }
 
@@ -7650,7 +7647,7 @@ export interface StaticKeyProvider {
 
 export namespace StaticKeyProvider {
   export function isa(o: any): o is StaticKeyProvider {
-    return _smithy.isa(o, "StaticKeyProvider");
+    return __isa(o, "StaticKeyProvider");
   }
 }
 
@@ -7687,7 +7684,7 @@ export interface TagResourceRequest {
 
 export namespace TagResourceRequest {
   export function isa(o: any): o is TagResourceRequest {
-    return _smithy.isa(o, "TagResourceRequest");
+    return __isa(o, "TagResourceRequest");
   }
 }
 
@@ -7697,7 +7694,7 @@ export interface TagResourceResponse extends $MetadataBearer {
 
 export namespace TagResourceResponse {
   export function isa(o: any): o is TagResourceResponse {
-    return _smithy.isa(o, "TagResourceResponse");
+    return __isa(o, "TagResourceResponse");
   }
 }
 
@@ -7719,7 +7716,7 @@ export interface TeletextDestinationSettings {
 
 export namespace TeletextDestinationSettings {
   export function isa(o: any): o is TeletextDestinationSettings {
-    return _smithy.isa(o, "TeletextDestinationSettings");
+    return __isa(o, "TeletextDestinationSettings");
   }
 }
 
@@ -7744,7 +7741,7 @@ export interface TeletextSourceSettings {
 
 export namespace TeletextSourceSettings {
   export function isa(o: any): o is TeletextSourceSettings {
-    return _smithy.isa(o, "TeletextSourceSettings");
+    return __isa(o, "TeletextSourceSettings");
   }
 }
 
@@ -7771,7 +7768,7 @@ export interface TimecodeBurnin {
 
 export namespace TimecodeBurnin {
   export function isa(o: any): o is TimecodeBurnin {
-    return _smithy.isa(o, "TimecodeBurnin");
+    return __isa(o, "TimecodeBurnin");
   }
 }
 
@@ -7815,7 +7812,7 @@ export interface TimecodeConfig {
 
 export namespace TimecodeConfig {
   export function isa(o: any): o is TimecodeConfig {
-    return _smithy.isa(o, "TimecodeConfig");
+    return __isa(o, "TimecodeConfig");
   }
 }
 
@@ -7843,7 +7840,7 @@ export interface TimedMetadataInsertion {
 
 export namespace TimedMetadataInsertion {
   export function isa(o: any): o is TimedMetadataInsertion {
-    return _smithy.isa(o, "TimedMetadataInsertion");
+    return __isa(o, "TimedMetadataInsertion");
   }
 }
 
@@ -7870,7 +7867,7 @@ export interface Timing {
 
 export namespace Timing {
   export function isa(o: any): o is Timing {
-    return _smithy.isa(o, "Timing");
+    return __isa(o, "Timing");
   }
 }
 
@@ -7878,7 +7875,7 @@ export namespace Timing {
  * Too many requests have been sent in too short of a time. The service limits the rate at which it will accept requests.
  */
 export interface TooManyRequestsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyRequestsException";
   $fault: "client";
@@ -7887,7 +7884,7 @@ export interface TooManyRequestsException
 
 export namespace TooManyRequestsException {
   export function isa(o: any): o is TooManyRequestsException {
-    return _smithy.isa(o, "TooManyRequestsException");
+    return __isa(o, "TooManyRequestsException");
   }
 }
 
@@ -7904,7 +7901,7 @@ export interface TrackSourceSettings {
 
 export namespace TrackSourceSettings {
   export function isa(o: any): o is TrackSourceSettings {
-    return _smithy.isa(o, "TrackSourceSettings");
+    return __isa(o, "TrackSourceSettings");
   }
 }
 
@@ -7921,7 +7918,7 @@ export interface TtmlDestinationSettings {
 
 export namespace TtmlDestinationSettings {
   export function isa(o: any): o is TtmlDestinationSettings {
-    return _smithy.isa(o, "TtmlDestinationSettings");
+    return __isa(o, "TtmlDestinationSettings");
   }
 }
 
@@ -7950,7 +7947,7 @@ export interface UntagResourceRequest {
 
 export namespace UntagResourceRequest {
   export function isa(o: any): o is UntagResourceRequest {
-    return _smithy.isa(o, "UntagResourceRequest");
+    return __isa(o, "UntagResourceRequest");
   }
 }
 
@@ -7960,7 +7957,7 @@ export interface UntagResourceResponse extends $MetadataBearer {
 
 export namespace UntagResourceResponse {
   export function isa(o: any): o is UntagResourceResponse {
-    return _smithy.isa(o, "UntagResourceResponse");
+    return __isa(o, "UntagResourceResponse");
   }
 }
 
@@ -8009,7 +8006,7 @@ export interface UpdateJobTemplateRequest {
 
 export namespace UpdateJobTemplateRequest {
   export function isa(o: any): o is UpdateJobTemplateRequest {
-    return _smithy.isa(o, "UpdateJobTemplateRequest");
+    return __isa(o, "UpdateJobTemplateRequest");
   }
 }
 
@@ -8023,7 +8020,7 @@ export interface UpdateJobTemplateResponse extends $MetadataBearer {
 
 export namespace UpdateJobTemplateResponse {
   export function isa(o: any): o is UpdateJobTemplateResponse {
-    return _smithy.isa(o, "UpdateJobTemplateResponse");
+    return __isa(o, "UpdateJobTemplateResponse");
   }
 }
 
@@ -8052,7 +8049,7 @@ export interface UpdatePresetRequest {
 
 export namespace UpdatePresetRequest {
   export function isa(o: any): o is UpdatePresetRequest {
-    return _smithy.isa(o, "UpdatePresetRequest");
+    return __isa(o, "UpdatePresetRequest");
   }
 }
 
@@ -8066,7 +8063,7 @@ export interface UpdatePresetResponse extends $MetadataBearer {
 
 export namespace UpdatePresetResponse {
   export function isa(o: any): o is UpdatePresetResponse {
-    return _smithy.isa(o, "UpdatePresetResponse");
+    return __isa(o, "UpdatePresetResponse");
   }
 }
 
@@ -8095,7 +8092,7 @@ export interface UpdateQueueRequest {
 
 export namespace UpdateQueueRequest {
   export function isa(o: any): o is UpdateQueueRequest {
-    return _smithy.isa(o, "UpdateQueueRequest");
+    return __isa(o, "UpdateQueueRequest");
   }
 }
 
@@ -8109,7 +8106,7 @@ export interface UpdateQueueResponse extends $MetadataBearer {
 
 export namespace UpdateQueueResponse {
   export function isa(o: any): o is UpdateQueueResponse {
-    return _smithy.isa(o, "UpdateQueueResponse");
+    return __isa(o, "UpdateQueueResponse");
   }
 }
 
@@ -8159,7 +8156,7 @@ export interface VideoCodecSettings {
 
 export namespace VideoCodecSettings {
   export function isa(o: any): o is VideoCodecSettings {
-    return _smithy.isa(o, "VideoCodecSettings");
+    return __isa(o, "VideoCodecSettings");
   }
 }
 
@@ -8246,7 +8243,7 @@ export interface VideoDescription {
 
 export namespace VideoDescription {
   export function isa(o: any): o is VideoDescription {
-    return _smithy.isa(o, "VideoDescription");
+    return __isa(o, "VideoDescription");
   }
 }
 
@@ -8268,7 +8265,7 @@ export interface VideoDetail {
 
 export namespace VideoDetail {
   export function isa(o: any): o is VideoDetail {
-    return _smithy.isa(o, "VideoDetail");
+    return __isa(o, "VideoDetail");
   }
 }
 
@@ -8310,7 +8307,7 @@ export interface VideoPreprocessor {
 
 export namespace VideoPreprocessor {
   export function isa(o: any): o is VideoPreprocessor {
-    return _smithy.isa(o, "VideoPreprocessor");
+    return __isa(o, "VideoPreprocessor");
   }
 }
 
@@ -8357,7 +8354,7 @@ export interface VideoSelector {
 
 export namespace VideoSelector {
   export function isa(o: any): o is VideoSelector {
-    return _smithy.isa(o, "VideoSelector");
+    return __isa(o, "VideoSelector");
   }
 }
 
@@ -8399,6 +8396,6 @@ export interface WavSettings {
 
 export namespace WavSettings {
   export function isa(o: any): o is WavSettings {
-    return _smithy.isa(o, "WavSettings");
+    return __isa(o, "WavSettings");
   }
 }

--- a/clients/client-mediaconvert/protocols/Aws_restJson1_1.ts
+++ b/clients/client-mediaconvert/protocols/Aws_restJson1_1.ts
@@ -240,7 +240,10 @@ import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  extendedEncodeURIComponent as __extendedEncodeURIComponent
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -280,11 +283,14 @@ export async function serializeAws_restJson1_1CancelJobCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/2017-08-29/jobs/{Id}";
   if (input.Id !== undefined) {
-    const labelValue: string = input.Id.toString();
+    const labelValue: string = input.Id;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Id.");
     }
-    resolvedPath = resolvedPath.replace("{Id}", encodeURIComponent(labelValue));
+    resolvedPath = resolvedPath.replace(
+      "{Id}",
+      __extendedEncodeURIComponent(labelValue)
+    );
   } else {
     throw new Error("No value provided for input HTTP label: Id.");
   }
@@ -523,13 +529,13 @@ export async function serializeAws_restJson1_1DeleteJobTemplateCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/2017-08-29/jobTemplates/{Name}";
   if (input.Name !== undefined) {
-    const labelValue: string = input.Name.toString();
+    const labelValue: string = input.Name;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Name.");
     }
     resolvedPath = resolvedPath.replace(
       "{Name}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Name.");
@@ -551,13 +557,13 @@ export async function serializeAws_restJson1_1DeletePresetCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/2017-08-29/presets/{Name}";
   if (input.Name !== undefined) {
-    const labelValue: string = input.Name.toString();
+    const labelValue: string = input.Name;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Name.");
     }
     resolvedPath = resolvedPath.replace(
       "{Name}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Name.");
@@ -579,13 +585,13 @@ export async function serializeAws_restJson1_1DeleteQueueCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/2017-08-29/queues/{Name}";
   if (input.Name !== undefined) {
-    const labelValue: string = input.Name.toString();
+    const labelValue: string = input.Name;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Name.");
     }
     resolvedPath = resolvedPath.replace(
       "{Name}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Name.");
@@ -636,13 +642,13 @@ export async function serializeAws_restJson1_1DisassociateCertificateCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/2017-08-29/certificates/{Arn}";
   if (input.Arn !== undefined) {
-    const labelValue: string = input.Arn.toString();
+    const labelValue: string = input.Arn;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Arn.");
     }
     resolvedPath = resolvedPath.replace(
       "{Arn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Arn.");
@@ -664,11 +670,14 @@ export async function serializeAws_restJson1_1GetJobCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/2017-08-29/jobs/{Id}";
   if (input.Id !== undefined) {
-    const labelValue: string = input.Id.toString();
+    const labelValue: string = input.Id;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Id.");
     }
-    resolvedPath = resolvedPath.replace("{Id}", encodeURIComponent(labelValue));
+    resolvedPath = resolvedPath.replace(
+      "{Id}",
+      __extendedEncodeURIComponent(labelValue)
+    );
   } else {
     throw new Error("No value provided for input HTTP label: Id.");
   }
@@ -689,13 +698,13 @@ export async function serializeAws_restJson1_1GetJobTemplateCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/2017-08-29/jobTemplates/{Name}";
   if (input.Name !== undefined) {
-    const labelValue: string = input.Name.toString();
+    const labelValue: string = input.Name;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Name.");
     }
     resolvedPath = resolvedPath.replace(
       "{Name}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Name.");
@@ -717,13 +726,13 @@ export async function serializeAws_restJson1_1GetPresetCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/2017-08-29/presets/{Name}";
   if (input.Name !== undefined) {
-    const labelValue: string = input.Name.toString();
+    const labelValue: string = input.Name;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Name.");
     }
     resolvedPath = resolvedPath.replace(
       "{Name}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Name.");
@@ -745,13 +754,13 @@ export async function serializeAws_restJson1_1GetQueueCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/2017-08-29/queues/{Name}";
   if (input.Name !== undefined) {
-    const labelValue: string = input.Name.toString();
+    const labelValue: string = input.Name;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Name.");
     }
     resolvedPath = resolvedPath.replace(
       "{Name}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Name.");
@@ -774,19 +783,29 @@ export async function serializeAws_restJson1_1ListJobTemplatesCommand(
   let resolvedPath = "/2017-08-29/jobTemplates";
   const query: any = {};
   if (input.Category !== undefined) {
-    query["category"] = input.Category.toString();
+    query[
+      __extendedEncodeURIComponent("category")
+    ] = __extendedEncodeURIComponent(input.Category);
   }
   if (input.ListBy !== undefined) {
-    query["listBy"] = input.ListBy.toString();
+    query[
+      __extendedEncodeURIComponent("listBy")
+    ] = __extendedEncodeURIComponent(input.ListBy);
   }
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   if (input.Order !== undefined) {
-    query["order"] = input.Order.toString();
+    query[__extendedEncodeURIComponent("order")] = __extendedEncodeURIComponent(
+      input.Order
+    );
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -807,19 +826,29 @@ export async function serializeAws_restJson1_1ListJobsCommand(
   let resolvedPath = "/2017-08-29/jobs";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   if (input.Order !== undefined) {
-    query["order"] = input.Order.toString();
+    query[__extendedEncodeURIComponent("order")] = __extendedEncodeURIComponent(
+      input.Order
+    );
   }
   if (input.Queue !== undefined) {
-    query["queue"] = input.Queue.toString();
+    query[__extendedEncodeURIComponent("queue")] = __extendedEncodeURIComponent(
+      input.Queue
+    );
   }
   if (input.Status !== undefined) {
-    query["status"] = input.Status.toString();
+    query[
+      __extendedEncodeURIComponent("status")
+    ] = __extendedEncodeURIComponent(input.Status);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -840,19 +869,29 @@ export async function serializeAws_restJson1_1ListPresetsCommand(
   let resolvedPath = "/2017-08-29/presets";
   const query: any = {};
   if (input.Category !== undefined) {
-    query["category"] = input.Category.toString();
+    query[
+      __extendedEncodeURIComponent("category")
+    ] = __extendedEncodeURIComponent(input.Category);
   }
   if (input.ListBy !== undefined) {
-    query["listBy"] = input.ListBy.toString();
+    query[
+      __extendedEncodeURIComponent("listBy")
+    ] = __extendedEncodeURIComponent(input.ListBy);
   }
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   if (input.Order !== undefined) {
-    query["order"] = input.Order.toString();
+    query[__extendedEncodeURIComponent("order")] = __extendedEncodeURIComponent(
+      input.Order
+    );
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -873,16 +912,24 @@ export async function serializeAws_restJson1_1ListQueuesCommand(
   let resolvedPath = "/2017-08-29/queues";
   const query: any = {};
   if (input.ListBy !== undefined) {
-    query["listBy"] = input.ListBy.toString();
+    query[
+      __extendedEncodeURIComponent("listBy")
+    ] = __extendedEncodeURIComponent(input.ListBy);
   }
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   if (input.Order !== undefined) {
-    query["order"] = input.Order.toString();
+    query[__extendedEncodeURIComponent("order")] = __extendedEncodeURIComponent(
+      input.Order
+    );
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -902,13 +949,13 @@ export async function serializeAws_restJson1_1ListTagsForResourceCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/2017-08-29/tags/{Arn}";
   if (input.Arn !== undefined) {
-    const labelValue: string = input.Arn.toString();
+    const labelValue: string = input.Arn;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Arn.");
     }
     resolvedPath = resolvedPath.replace(
       "{Arn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Arn.");
@@ -959,13 +1006,13 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/2017-08-29/tags/{Arn}";
   if (input.Arn !== undefined) {
-    const labelValue: string = input.Arn.toString();
+    const labelValue: string = input.Arn;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Arn.");
     }
     resolvedPath = resolvedPath.replace(
       "{Arn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Arn.");
@@ -997,13 +1044,13 @@ export async function serializeAws_restJson1_1UpdateJobTemplateCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/2017-08-29/jobTemplates/{Name}";
   if (input.Name !== undefined) {
-    const labelValue: string = input.Name.toString();
+    const labelValue: string = input.Name;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Name.");
     }
     resolvedPath = resolvedPath.replace(
       "{Name}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Name.");
@@ -1058,13 +1105,13 @@ export async function serializeAws_restJson1_1UpdatePresetCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/2017-08-29/presets/{Name}";
   if (input.Name !== undefined) {
-    const labelValue: string = input.Name.toString();
+    const labelValue: string = input.Name;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Name.");
     }
     resolvedPath = resolvedPath.replace(
       "{Name}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Name.");
@@ -1102,13 +1149,13 @@ export async function serializeAws_restJson1_1UpdateQueueCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/2017-08-29/queues/{Name}";
   if (input.Name !== undefined) {
-    const labelValue: string = input.Name.toString();
+    const labelValue: string = input.Name;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Name.");
     }
     resolvedPath = resolvedPath.replace(
       "{Name}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Name.");
@@ -1154,6 +1201,7 @@ export async function deserializeAws_restJson1_1AssociateCertificateCommand(
     $metadata: deserializeMetadata(output),
     __type: "AssociateCertificateResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -1237,6 +1285,7 @@ export async function deserializeAws_restJson1_1CancelJobCommand(
     $metadata: deserializeMetadata(output),
     __type: "CancelJobResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -1681,6 +1730,7 @@ export async function deserializeAws_restJson1_1DeleteJobTemplateCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeleteJobTemplateResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -1764,6 +1814,7 @@ export async function deserializeAws_restJson1_1DeletePresetCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeletePresetResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -1847,6 +1898,7 @@ export async function deserializeAws_restJson1_1DeleteQueueCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeleteQueueResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2031,6 +2083,7 @@ export async function deserializeAws_restJson1_1DisassociateCertificateCommand(
     $metadata: deserializeMetadata(output),
     __type: "DisassociateCertificateResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2946,6 +2999,7 @@ export async function deserializeAws_restJson1_1TagResourceCommand(
     $metadata: deserializeMetadata(output),
     __type: "TagResourceResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -3029,6 +3083,7 @@ export async function deserializeAws_restJson1_1UntagResourceCommand(
     $metadata: deserializeMetadata(output),
     __type: "UntagResourceResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 

--- a/clients/client-medialive/models/index.ts
+++ b/clients/client-medialive/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export enum AacCodingMode {
@@ -85,7 +88,7 @@ export interface AacSettings {
 
 export namespace AacSettings {
   export function isa(o: any): o is AacSettings {
-    return _smithy.isa(o, "AacSettings");
+    return __isa(o, "AacSettings");
   }
 }
 
@@ -177,7 +180,7 @@ export interface Ac3Settings {
 
 export namespace Ac3Settings {
   export function isa(o: any): o is Ac3Settings {
-    return _smithy.isa(o, "Ac3Settings");
+    return __isa(o, "Ac3Settings");
   }
 }
 
@@ -200,7 +203,7 @@ export interface ArchiveContainerSettings {
 
 export namespace ArchiveContainerSettings {
   export function isa(o: any): o is ArchiveContainerSettings {
-    return _smithy.isa(o, "ArchiveContainerSettings");
+    return __isa(o, "ArchiveContainerSettings");
   }
 }
 
@@ -222,7 +225,7 @@ export interface ArchiveGroupSettings {
 
 export namespace ArchiveGroupSettings {
   export function isa(o: any): o is ArchiveGroupSettings {
-    return _smithy.isa(o, "ArchiveGroupSettings");
+    return __isa(o, "ArchiveGroupSettings");
   }
 }
 
@@ -249,7 +252,7 @@ export interface ArchiveOutputSettings {
 
 export namespace ArchiveOutputSettings {
   export function isa(o: any): o is ArchiveOutputSettings {
-    return _smithy.isa(o, "ArchiveOutputSettings");
+    return __isa(o, "ArchiveOutputSettings");
   }
 }
 
@@ -262,7 +265,7 @@ export interface AribDestinationSettings {
 
 export namespace AribDestinationSettings {
   export function isa(o: any): o is AribDestinationSettings {
-    return _smithy.isa(o, "AribDestinationSettings");
+    return __isa(o, "AribDestinationSettings");
   }
 }
 
@@ -275,7 +278,7 @@ export interface AribSourceSettings {
 
 export namespace AribSourceSettings {
   export function isa(o: any): o is AribSourceSettings {
-    return _smithy.isa(o, "AribSourceSettings");
+    return __isa(o, "AribSourceSettings");
   }
 }
 
@@ -297,7 +300,7 @@ export interface AudioChannelMapping {
 
 export namespace AudioChannelMapping {
   export function isa(o: any): o is AudioChannelMapping {
-    return _smithy.isa(o, "AudioChannelMapping");
+    return __isa(o, "AudioChannelMapping");
   }
 }
 
@@ -334,7 +337,7 @@ export interface AudioCodecSettings {
 
 export namespace AudioCodecSettings {
   export function isa(o: any): o is AudioCodecSettings {
-    return _smithy.isa(o, "AudioCodecSettings");
+    return __isa(o, "AudioCodecSettings");
   }
 }
 
@@ -399,7 +402,7 @@ export interface AudioDescription {
 
 export namespace AudioDescription {
   export function isa(o: any): o is AudioDescription {
-    return _smithy.isa(o, "AudioDescription");
+    return __isa(o, "AudioDescription");
   }
 }
 
@@ -431,7 +434,7 @@ export interface AudioLanguageSelection {
 
 export namespace AudioLanguageSelection {
   export function isa(o: any): o is AudioLanguageSelection {
-    return _smithy.isa(o, "AudioLanguageSelection");
+    return __isa(o, "AudioLanguageSelection");
   }
 }
 
@@ -472,7 +475,7 @@ export interface AudioNormalizationSettings {
 
 export namespace AudioNormalizationSettings {
   export function isa(o: any): o is AudioNormalizationSettings {
-    return _smithy.isa(o, "AudioNormalizationSettings");
+    return __isa(o, "AudioNormalizationSettings");
   }
 }
 
@@ -523,7 +526,7 @@ export interface AudioOnlyHlsSettings {
 
 export namespace AudioOnlyHlsSettings {
   export function isa(o: any): o is AudioOnlyHlsSettings {
-    return _smithy.isa(o, "AudioOnlyHlsSettings");
+    return __isa(o, "AudioOnlyHlsSettings");
   }
 }
 
@@ -547,7 +550,7 @@ export interface AudioPidSelection {
 
 export namespace AudioPidSelection {
   export function isa(o: any): o is AudioPidSelection {
-    return _smithy.isa(o, "AudioPidSelection");
+    return __isa(o, "AudioPidSelection");
   }
 }
 
@@ -569,7 +572,7 @@ export interface AudioSelector {
 
 export namespace AudioSelector {
   export function isa(o: any): o is AudioSelector {
-    return _smithy.isa(o, "AudioSelector");
+    return __isa(o, "AudioSelector");
   }
 }
 
@@ -591,7 +594,7 @@ export interface AudioSelectorSettings {
 
 export namespace AudioSelectorSettings {
   export function isa(o: any): o is AudioSelectorSettings {
-    return _smithy.isa(o, "AudioSelectorSettings");
+    return __isa(o, "AudioSelectorSettings");
   }
 }
 
@@ -625,7 +628,7 @@ export interface AvailBlanking {
 
 export namespace AvailBlanking {
   export function isa(o: any): o is AvailBlanking {
-    return _smithy.isa(o, "AvailBlanking");
+    return __isa(o, "AvailBlanking");
   }
 }
 
@@ -647,7 +650,7 @@ export interface AvailConfiguration {
 
 export namespace AvailConfiguration {
   export function isa(o: any): o is AvailConfiguration {
-    return _smithy.isa(o, "AvailConfiguration");
+    return __isa(o, "AvailConfiguration");
   }
 }
 
@@ -669,7 +672,7 @@ export interface AvailSettings {
 
 export namespace AvailSettings {
   export function isa(o: any): o is AvailSettings {
-    return _smithy.isa(o, "AvailSettings");
+    return __isa(o, "AvailSettings");
   }
 }
 
@@ -677,7 +680,7 @@ export namespace AvailSettings {
  * Placeholder documentation for BadGatewayException
  */
 export interface BadGatewayException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "BadGatewayException";
   $fault: "server";
@@ -689,7 +692,7 @@ export interface BadGatewayException
 
 export namespace BadGatewayException {
   export function isa(o: any): o is BadGatewayException {
-    return _smithy.isa(o, "BadGatewayException");
+    return __isa(o, "BadGatewayException");
   }
 }
 
@@ -697,7 +700,7 @@ export namespace BadGatewayException {
  * Placeholder documentation for BadRequestException
  */
 export interface BadRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "BadRequestException";
   $fault: "client";
@@ -709,7 +712,7 @@ export interface BadRequestException
 
 export namespace BadRequestException {
   export function isa(o: any): o is BadRequestException {
-    return _smithy.isa(o, "BadRequestException");
+    return __isa(o, "BadRequestException");
   }
 }
 
@@ -726,7 +729,7 @@ export interface BatchScheduleActionCreateRequest {
 
 export namespace BatchScheduleActionCreateRequest {
   export function isa(o: any): o is BatchScheduleActionCreateRequest {
-    return _smithy.isa(o, "BatchScheduleActionCreateRequest");
+    return __isa(o, "BatchScheduleActionCreateRequest");
   }
 }
 
@@ -743,7 +746,7 @@ export interface BatchScheduleActionCreateResult {
 
 export namespace BatchScheduleActionCreateResult {
   export function isa(o: any): o is BatchScheduleActionCreateResult {
-    return _smithy.isa(o, "BatchScheduleActionCreateResult");
+    return __isa(o, "BatchScheduleActionCreateResult");
   }
 }
 
@@ -760,7 +763,7 @@ export interface BatchScheduleActionDeleteRequest {
 
 export namespace BatchScheduleActionDeleteRequest {
   export function isa(o: any): o is BatchScheduleActionDeleteRequest {
-    return _smithy.isa(o, "BatchScheduleActionDeleteRequest");
+    return __isa(o, "BatchScheduleActionDeleteRequest");
   }
 }
 
@@ -777,7 +780,7 @@ export interface BatchScheduleActionDeleteResult {
 
 export namespace BatchScheduleActionDeleteResult {
   export function isa(o: any): o is BatchScheduleActionDeleteResult {
-    return _smithy.isa(o, "BatchScheduleActionDeleteResult");
+    return __isa(o, "BatchScheduleActionDeleteResult");
   }
 }
 
@@ -804,7 +807,7 @@ export interface BatchUpdateScheduleRequest {
 
 export namespace BatchUpdateScheduleRequest {
   export function isa(o: any): o is BatchUpdateScheduleRequest {
-    return _smithy.isa(o, "BatchUpdateScheduleRequest");
+    return __isa(o, "BatchUpdateScheduleRequest");
   }
 }
 
@@ -826,7 +829,7 @@ export interface BatchUpdateScheduleResponse extends $MetadataBearer {
 
 export namespace BatchUpdateScheduleResponse {
   export function isa(o: any): o is BatchUpdateScheduleResponse {
-    return _smithy.isa(o, "BatchUpdateScheduleResponse");
+    return __isa(o, "BatchUpdateScheduleResponse");
   }
 }
 
@@ -863,7 +866,7 @@ export interface BlackoutSlate {
 
 export namespace BlackoutSlate {
   export function isa(o: any): o is BlackoutSlate {
-    return _smithy.isa(o, "BlackoutSlate");
+    return __isa(o, "BlackoutSlate");
   }
 }
 
@@ -982,7 +985,7 @@ export interface BurnInDestinationSettings {
 
 export namespace BurnInDestinationSettings {
   export function isa(o: any): o is BurnInDestinationSettings {
-    return _smithy.isa(o, "BurnInDestinationSettings");
+    return __isa(o, "BurnInDestinationSettings");
   }
 }
 
@@ -1048,7 +1051,7 @@ export interface CaptionDescription {
 
 export namespace CaptionDescription {
   export function isa(o: any): o is CaptionDescription {
-    return _smithy.isa(o, "CaptionDescription");
+    return __isa(o, "CaptionDescription");
   }
 }
 
@@ -1120,7 +1123,7 @@ export interface CaptionDestinationSettings {
 
 export namespace CaptionDestinationSettings {
   export function isa(o: any): o is CaptionDestinationSettings {
-    return _smithy.isa(o, "CaptionDestinationSettings");
+    return __isa(o, "CaptionDestinationSettings");
   }
 }
 
@@ -1147,7 +1150,7 @@ export interface CaptionLanguageMapping {
 
 export namespace CaptionLanguageMapping {
   export function isa(o: any): o is CaptionLanguageMapping {
-    return _smithy.isa(o, "CaptionLanguageMapping");
+    return __isa(o, "CaptionLanguageMapping");
   }
 }
 
@@ -1174,7 +1177,7 @@ export interface CaptionSelector {
 
 export namespace CaptionSelector {
   export function isa(o: any): o is CaptionSelector {
-    return _smithy.isa(o, "CaptionSelector");
+    return __isa(o, "CaptionSelector");
   }
 }
 
@@ -1216,7 +1219,7 @@ export interface CaptionSelectorSettings {
 
 export namespace CaptionSelectorSettings {
   export function isa(o: any): o is CaptionSelectorSettings {
-    return _smithy.isa(o, "CaptionSelectorSettings");
+    return __isa(o, "CaptionSelectorSettings");
   }
 }
 
@@ -1305,7 +1308,7 @@ export interface Channel {
 
 export namespace Channel {
   export function isa(o: any): o is Channel {
-    return _smithy.isa(o, "Channel");
+    return __isa(o, "Channel");
   }
 }
 
@@ -1327,7 +1330,7 @@ export interface ChannelEgressEndpoint {
 
 export namespace ChannelEgressEndpoint {
   export function isa(o: any): o is ChannelEgressEndpoint {
-    return _smithy.isa(o, "ChannelEgressEndpoint");
+    return __isa(o, "ChannelEgressEndpoint");
   }
 }
 
@@ -1420,7 +1423,7 @@ export interface ChannelSummary {
 
 export namespace ChannelSummary {
   export function isa(o: any): o is ChannelSummary {
-    return _smithy.isa(o, "ChannelSummary");
+    return __isa(o, "ChannelSummary");
   }
 }
 
@@ -1433,16 +1436,14 @@ export interface ColorSpacePassthroughSettings {
 
 export namespace ColorSpacePassthroughSettings {
   export function isa(o: any): o is ColorSpacePassthroughSettings {
-    return _smithy.isa(o, "ColorSpacePassthroughSettings");
+    return __isa(o, "ColorSpacePassthroughSettings");
   }
 }
 
 /**
  * Placeholder documentation for ConflictException
  */
-export interface ConflictException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface ConflictException extends __SmithyException, $MetadataBearer {
   name: "ConflictException";
   $fault: "client";
   /**
@@ -1453,7 +1454,7 @@ export interface ConflictException
 
 export namespace ConflictException {
   export function isa(o: any): o is ConflictException {
-    return _smithy.isa(o, "ConflictException");
+    return __isa(o, "ConflictException");
   }
 }
 
@@ -1521,7 +1522,7 @@ export interface CreateChannelRequest {
 
 export namespace CreateChannelRequest {
   export function isa(o: any): o is CreateChannelRequest {
-    return _smithy.isa(o, "CreateChannelRequest");
+    return __isa(o, "CreateChannelRequest");
   }
 }
 
@@ -1538,7 +1539,7 @@ export interface CreateChannelResponse extends $MetadataBearer {
 
 export namespace CreateChannelResponse {
   export function isa(o: any): o is CreateChannelResponse {
-    return _smithy.isa(o, "CreateChannelResponse");
+    return __isa(o, "CreateChannelResponse");
   }
 }
 
@@ -1608,7 +1609,7 @@ export interface CreateInputRequest {
 
 export namespace CreateInputRequest {
   export function isa(o: any): o is CreateInputRequest {
-    return _smithy.isa(o, "CreateInputRequest");
+    return __isa(o, "CreateInputRequest");
   }
 }
 
@@ -1625,7 +1626,7 @@ export interface CreateInputResponse extends $MetadataBearer {
 
 export namespace CreateInputResponse {
   export function isa(o: any): o is CreateInputResponse {
-    return _smithy.isa(o, "CreateInputResponse");
+    return __isa(o, "CreateInputResponse");
   }
 }
 
@@ -1647,7 +1648,7 @@ export interface CreateInputSecurityGroupRequest {
 
 export namespace CreateInputSecurityGroupRequest {
   export function isa(o: any): o is CreateInputSecurityGroupRequest {
-    return _smithy.isa(o, "CreateInputSecurityGroupRequest");
+    return __isa(o, "CreateInputSecurityGroupRequest");
   }
 }
 
@@ -1664,7 +1665,7 @@ export interface CreateInputSecurityGroupResponse extends $MetadataBearer {
 
 export namespace CreateInputSecurityGroupResponse {
   export function isa(o: any): o is CreateInputSecurityGroupResponse {
-    return _smithy.isa(o, "CreateInputSecurityGroupResponse");
+    return __isa(o, "CreateInputSecurityGroupResponse");
   }
 }
 
@@ -1697,7 +1698,7 @@ export interface CreateMultiplexProgramRequest {
 
 export namespace CreateMultiplexProgramRequest {
   export function isa(o: any): o is CreateMultiplexProgramRequest {
-    return _smithy.isa(o, "CreateMultiplexProgramRequest");
+    return __isa(o, "CreateMultiplexProgramRequest");
   }
 }
 
@@ -1714,7 +1715,7 @@ export interface CreateMultiplexProgramResponse extends $MetadataBearer {
 
 export namespace CreateMultiplexProgramResponse {
   export function isa(o: any): o is CreateMultiplexProgramResponse {
-    return _smithy.isa(o, "CreateMultiplexProgramResponse");
+    return __isa(o, "CreateMultiplexProgramResponse");
   }
 }
 
@@ -1752,7 +1753,7 @@ export interface CreateMultiplexRequest {
 
 export namespace CreateMultiplexRequest {
   export function isa(o: any): o is CreateMultiplexRequest {
-    return _smithy.isa(o, "CreateMultiplexRequest");
+    return __isa(o, "CreateMultiplexRequest");
   }
 }
 
@@ -1769,7 +1770,7 @@ export interface CreateMultiplexResponse extends $MetadataBearer {
 
 export namespace CreateMultiplexResponse {
   export function isa(o: any): o is CreateMultiplexResponse {
-    return _smithy.isa(o, "CreateMultiplexResponse");
+    return __isa(o, "CreateMultiplexResponse");
   }
 }
 
@@ -1791,7 +1792,7 @@ export interface CreateTagsRequest {
 
 export namespace CreateTagsRequest {
   export function isa(o: any): o is CreateTagsRequest {
-    return _smithy.isa(o, "CreateTagsRequest");
+    return __isa(o, "CreateTagsRequest");
   }
 }
 
@@ -1808,7 +1809,7 @@ export interface DeleteChannelRequest {
 
 export namespace DeleteChannelRequest {
   export function isa(o: any): o is DeleteChannelRequest {
-    return _smithy.isa(o, "DeleteChannelRequest");
+    return __isa(o, "DeleteChannelRequest");
   }
 }
 
@@ -1897,7 +1898,7 @@ export interface DeleteChannelResponse extends $MetadataBearer {
 
 export namespace DeleteChannelResponse {
   export function isa(o: any): o is DeleteChannelResponse {
-    return _smithy.isa(o, "DeleteChannelResponse");
+    return __isa(o, "DeleteChannelResponse");
   }
 }
 
@@ -1914,7 +1915,7 @@ export interface DeleteInputRequest {
 
 export namespace DeleteInputRequest {
   export function isa(o: any): o is DeleteInputRequest {
-    return _smithy.isa(o, "DeleteInputRequest");
+    return __isa(o, "DeleteInputRequest");
   }
 }
 
@@ -1927,7 +1928,7 @@ export interface DeleteInputResponse extends $MetadataBearer {
 
 export namespace DeleteInputResponse {
   export function isa(o: any): o is DeleteInputResponse {
-    return _smithy.isa(o, "DeleteInputResponse");
+    return __isa(o, "DeleteInputResponse");
   }
 }
 
@@ -1944,7 +1945,7 @@ export interface DeleteInputSecurityGroupRequest {
 
 export namespace DeleteInputSecurityGroupRequest {
   export function isa(o: any): o is DeleteInputSecurityGroupRequest {
-    return _smithy.isa(o, "DeleteInputSecurityGroupRequest");
+    return __isa(o, "DeleteInputSecurityGroupRequest");
   }
 }
 
@@ -1957,7 +1958,7 @@ export interface DeleteInputSecurityGroupResponse extends $MetadataBearer {
 
 export namespace DeleteInputSecurityGroupResponse {
   export function isa(o: any): o is DeleteInputSecurityGroupResponse {
-    return _smithy.isa(o, "DeleteInputSecurityGroupResponse");
+    return __isa(o, "DeleteInputSecurityGroupResponse");
   }
 }
 
@@ -1979,7 +1980,7 @@ export interface DeleteMultiplexProgramRequest {
 
 export namespace DeleteMultiplexProgramRequest {
   export function isa(o: any): o is DeleteMultiplexProgramRequest {
-    return _smithy.isa(o, "DeleteMultiplexProgramRequest");
+    return __isa(o, "DeleteMultiplexProgramRequest");
   }
 }
 
@@ -2011,7 +2012,7 @@ export interface DeleteMultiplexProgramResponse extends $MetadataBearer {
 
 export namespace DeleteMultiplexProgramResponse {
   export function isa(o: any): o is DeleteMultiplexProgramResponse {
-    return _smithy.isa(o, "DeleteMultiplexProgramResponse");
+    return __isa(o, "DeleteMultiplexProgramResponse");
   }
 }
 
@@ -2028,7 +2029,7 @@ export interface DeleteMultiplexRequest {
 
 export namespace DeleteMultiplexRequest {
   export function isa(o: any): o is DeleteMultiplexRequest {
-    return _smithy.isa(o, "DeleteMultiplexRequest");
+    return __isa(o, "DeleteMultiplexRequest");
   }
 }
 
@@ -2090,7 +2091,7 @@ export interface DeleteMultiplexResponse extends $MetadataBearer {
 
 export namespace DeleteMultiplexResponse {
   export function isa(o: any): o is DeleteMultiplexResponse {
-    return _smithy.isa(o, "DeleteMultiplexResponse");
+    return __isa(o, "DeleteMultiplexResponse");
   }
 }
 
@@ -2107,7 +2108,7 @@ export interface DeleteReservationRequest {
 
 export namespace DeleteReservationRequest {
   export function isa(o: any): o is DeleteReservationRequest {
-    return _smithy.isa(o, "DeleteReservationRequest");
+    return __isa(o, "DeleteReservationRequest");
   }
 }
 
@@ -2209,7 +2210,7 @@ export interface DeleteReservationResponse extends $MetadataBearer {
 
 export namespace DeleteReservationResponse {
   export function isa(o: any): o is DeleteReservationResponse {
-    return _smithy.isa(o, "DeleteReservationResponse");
+    return __isa(o, "DeleteReservationResponse");
   }
 }
 
@@ -2226,7 +2227,7 @@ export interface DeleteScheduleRequest {
 
 export namespace DeleteScheduleRequest {
   export function isa(o: any): o is DeleteScheduleRequest {
-    return _smithy.isa(o, "DeleteScheduleRequest");
+    return __isa(o, "DeleteScheduleRequest");
   }
 }
 
@@ -2239,7 +2240,7 @@ export interface DeleteScheduleResponse extends $MetadataBearer {
 
 export namespace DeleteScheduleResponse {
   export function isa(o: any): o is DeleteScheduleResponse {
-    return _smithy.isa(o, "DeleteScheduleResponse");
+    return __isa(o, "DeleteScheduleResponse");
   }
 }
 
@@ -2261,7 +2262,7 @@ export interface DeleteTagsRequest {
 
 export namespace DeleteTagsRequest {
   export function isa(o: any): o is DeleteTagsRequest {
-    return _smithy.isa(o, "DeleteTagsRequest");
+    return __isa(o, "DeleteTagsRequest");
   }
 }
 
@@ -2278,7 +2279,7 @@ export interface DescribeChannelRequest {
 
 export namespace DescribeChannelRequest {
   export function isa(o: any): o is DescribeChannelRequest {
-    return _smithy.isa(o, "DescribeChannelRequest");
+    return __isa(o, "DescribeChannelRequest");
   }
 }
 
@@ -2367,7 +2368,7 @@ export interface DescribeChannelResponse extends $MetadataBearer {
 
 export namespace DescribeChannelResponse {
   export function isa(o: any): o is DescribeChannelResponse {
-    return _smithy.isa(o, "DescribeChannelResponse");
+    return __isa(o, "DescribeChannelResponse");
   }
 }
 
@@ -2384,7 +2385,7 @@ export interface DescribeInputRequest {
 
 export namespace DescribeInputRequest {
   export function isa(o: any): o is DescribeInputRequest {
-    return _smithy.isa(o, "DescribeInputRequest");
+    return __isa(o, "DescribeInputRequest");
   }
 }
 
@@ -2468,7 +2469,7 @@ export interface DescribeInputResponse extends $MetadataBearer {
 
 export namespace DescribeInputResponse {
   export function isa(o: any): o is DescribeInputResponse {
-    return _smithy.isa(o, "DescribeInputResponse");
+    return __isa(o, "DescribeInputResponse");
   }
 }
 
@@ -2485,7 +2486,7 @@ export interface DescribeInputSecurityGroupRequest {
 
 export namespace DescribeInputSecurityGroupRequest {
   export function isa(o: any): o is DescribeInputSecurityGroupRequest {
-    return _smithy.isa(o, "DescribeInputSecurityGroupRequest");
+    return __isa(o, "DescribeInputSecurityGroupRequest");
   }
 }
 
@@ -2527,7 +2528,7 @@ export interface DescribeInputSecurityGroupResponse extends $MetadataBearer {
 
 export namespace DescribeInputSecurityGroupResponse {
   export function isa(o: any): o is DescribeInputSecurityGroupResponse {
-    return _smithy.isa(o, "DescribeInputSecurityGroupResponse");
+    return __isa(o, "DescribeInputSecurityGroupResponse");
   }
 }
 
@@ -2549,7 +2550,7 @@ export interface DescribeMultiplexProgramRequest {
 
 export namespace DescribeMultiplexProgramRequest {
   export function isa(o: any): o is DescribeMultiplexProgramRequest {
-    return _smithy.isa(o, "DescribeMultiplexProgramRequest");
+    return __isa(o, "DescribeMultiplexProgramRequest");
   }
 }
 
@@ -2581,7 +2582,7 @@ export interface DescribeMultiplexProgramResponse extends $MetadataBearer {
 
 export namespace DescribeMultiplexProgramResponse {
   export function isa(o: any): o is DescribeMultiplexProgramResponse {
-    return _smithy.isa(o, "DescribeMultiplexProgramResponse");
+    return __isa(o, "DescribeMultiplexProgramResponse");
   }
 }
 
@@ -2598,7 +2599,7 @@ export interface DescribeMultiplexRequest {
 
 export namespace DescribeMultiplexRequest {
   export function isa(o: any): o is DescribeMultiplexRequest {
-    return _smithy.isa(o, "DescribeMultiplexRequest");
+    return __isa(o, "DescribeMultiplexRequest");
   }
 }
 
@@ -2660,7 +2661,7 @@ export interface DescribeMultiplexResponse extends $MetadataBearer {
 
 export namespace DescribeMultiplexResponse {
   export function isa(o: any): o is DescribeMultiplexResponse {
-    return _smithy.isa(o, "DescribeMultiplexResponse");
+    return __isa(o, "DescribeMultiplexResponse");
   }
 }
 
@@ -2677,7 +2678,7 @@ export interface DescribeOfferingRequest {
 
 export namespace DescribeOfferingRequest {
   export function isa(o: any): o is DescribeOfferingRequest {
-    return _smithy.isa(o, "DescribeOfferingRequest");
+    return __isa(o, "DescribeOfferingRequest");
   }
 }
 
@@ -2744,7 +2745,7 @@ export interface DescribeOfferingResponse extends $MetadataBearer {
 
 export namespace DescribeOfferingResponse {
   export function isa(o: any): o is DescribeOfferingResponse {
-    return _smithy.isa(o, "DescribeOfferingResponse");
+    return __isa(o, "DescribeOfferingResponse");
   }
 }
 
@@ -2761,7 +2762,7 @@ export interface DescribeReservationRequest {
 
 export namespace DescribeReservationRequest {
   export function isa(o: any): o is DescribeReservationRequest {
-    return _smithy.isa(o, "DescribeReservationRequest");
+    return __isa(o, "DescribeReservationRequest");
   }
 }
 
@@ -2863,7 +2864,7 @@ export interface DescribeReservationResponse extends $MetadataBearer {
 
 export namespace DescribeReservationResponse {
   export function isa(o: any): o is DescribeReservationResponse {
-    return _smithy.isa(o, "DescribeReservationResponse");
+    return __isa(o, "DescribeReservationResponse");
   }
 }
 
@@ -2890,7 +2891,7 @@ export interface DescribeScheduleRequest {
 
 export namespace DescribeScheduleRequest {
   export function isa(o: any): o is DescribeScheduleRequest {
-    return _smithy.isa(o, "DescribeScheduleRequest");
+    return __isa(o, "DescribeScheduleRequest");
   }
 }
 
@@ -2912,7 +2913,7 @@ export interface DescribeScheduleResponse extends $MetadataBearer {
 
 export namespace DescribeScheduleResponse {
   export function isa(o: any): o is DescribeScheduleResponse {
-    return _smithy.isa(o, "DescribeScheduleResponse");
+    return __isa(o, "DescribeScheduleResponse");
   }
 }
 
@@ -2939,7 +2940,7 @@ export interface DvbNitSettings {
 
 export namespace DvbNitSettings {
   export function isa(o: any): o is DvbNitSettings {
-    return _smithy.isa(o, "DvbNitSettings");
+    return __isa(o, "DvbNitSettings");
   }
 }
 
@@ -2978,7 +2979,7 @@ export interface DvbSdtSettings {
 
 export namespace DvbSdtSettings {
   export function isa(o: any): o is DvbSdtSettings {
-    return _smithy.isa(o, "DvbSdtSettings");
+    return __isa(o, "DvbSdtSettings");
   }
 }
 
@@ -3105,7 +3106,7 @@ export interface DvbSubDestinationSettings {
 
 export namespace DvbSubDestinationSettings {
   export function isa(o: any): o is DvbSubDestinationSettings {
-    return _smithy.isa(o, "DvbSubDestinationSettings");
+    return __isa(o, "DvbSubDestinationSettings");
   }
 }
 
@@ -3133,7 +3134,7 @@ export interface DvbSubSourceSettings {
 
 export namespace DvbSubSourceSettings {
   export function isa(o: any): o is DvbSubSourceSettings {
-    return _smithy.isa(o, "DvbSubSourceSettings");
+    return __isa(o, "DvbSubSourceSettings");
   }
 }
 
@@ -3150,7 +3151,7 @@ export interface DvbTdtSettings {
 
 export namespace DvbTdtSettings {
   export function isa(o: any): o is DvbTdtSettings {
-    return _smithy.isa(o, "DvbTdtSettings");
+    return __isa(o, "DvbTdtSettings");
   }
 }
 
@@ -3329,7 +3330,7 @@ export interface Eac3Settings {
 
 export namespace Eac3Settings {
   export function isa(o: any): o is Eac3Settings {
-    return _smithy.isa(o, "Eac3Settings");
+    return __isa(o, "Eac3Settings");
   }
 }
 
@@ -3366,7 +3367,7 @@ export interface EmbeddedDestinationSettings {
 
 export namespace EmbeddedDestinationSettings {
   export function isa(o: any): o is EmbeddedDestinationSettings {
-    return _smithy.isa(o, "EmbeddedDestinationSettings");
+    return __isa(o, "EmbeddedDestinationSettings");
   }
 }
 
@@ -3379,7 +3380,7 @@ export interface EmbeddedPlusScte20DestinationSettings {
 
 export namespace EmbeddedPlusScte20DestinationSettings {
   export function isa(o: any): o is EmbeddedPlusScte20DestinationSettings {
-    return _smithy.isa(o, "EmbeddedPlusScte20DestinationSettings");
+    return __isa(o, "EmbeddedPlusScte20DestinationSettings");
   }
 }
 
@@ -3416,7 +3417,7 @@ export interface EmbeddedSourceSettings {
 
 export namespace EmbeddedSourceSettings {
   export function isa(o: any): o is EmbeddedSourceSettings {
-    return _smithy.isa(o, "EmbeddedSourceSettings");
+    return __isa(o, "EmbeddedSourceSettings");
   }
 }
 
@@ -3478,7 +3479,7 @@ export interface EncoderSettings {
 
 export namespace EncoderSettings {
   export function isa(o: any): o is EncoderSettings {
-    return _smithy.isa(o, "EncoderSettings");
+    return __isa(o, "EncoderSettings");
   }
 }
 
@@ -3510,7 +3511,7 @@ export interface FecOutputSettings {
 
 export namespace FecOutputSettings {
   export function isa(o: any): o is FecOutputSettings {
-    return _smithy.isa(o, "FecOutputSettings");
+    return __isa(o, "FecOutputSettings");
   }
 }
 
@@ -3541,7 +3542,7 @@ export interface FixedModeScheduleActionStartSettings {
 
 export namespace FixedModeScheduleActionStartSettings {
   export function isa(o: any): o is FixedModeScheduleActionStartSettings {
-    return _smithy.isa(o, "FixedModeScheduleActionStartSettings");
+    return __isa(o, "FixedModeScheduleActionStartSettings");
   }
 }
 
@@ -3558,7 +3559,7 @@ export interface Fmp4HlsSettings {
 
 export namespace Fmp4HlsSettings {
   export function isa(o: any): o is Fmp4HlsSettings {
-    return _smithy.isa(o, "Fmp4HlsSettings");
+    return __isa(o, "Fmp4HlsSettings");
   }
 }
 
@@ -3580,7 +3581,7 @@ export interface FollowModeScheduleActionStartSettings {
 
 export namespace FollowModeScheduleActionStartSettings {
   export function isa(o: any): o is FollowModeScheduleActionStartSettings {
-    return _smithy.isa(o, "FollowModeScheduleActionStartSettings");
+    return __isa(o, "FollowModeScheduleActionStartSettings");
   }
 }
 
@@ -3592,9 +3593,7 @@ export enum FollowPoint {
 /**
  * Placeholder documentation for ForbiddenException
  */
-export interface ForbiddenException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface ForbiddenException extends __SmithyException, $MetadataBearer {
   name: "ForbiddenException";
   $fault: "client";
   /**
@@ -3605,7 +3604,7 @@ export interface ForbiddenException
 
 export namespace ForbiddenException {
   export function isa(o: any): o is ForbiddenException {
-    return _smithy.isa(o, "ForbiddenException");
+    return __isa(o, "ForbiddenException");
   }
 }
 
@@ -3622,7 +3621,7 @@ export interface FrameCaptureGroupSettings {
 
 export namespace FrameCaptureGroupSettings {
   export function isa(o: any): o is FrameCaptureGroupSettings {
-    return _smithy.isa(o, "FrameCaptureGroupSettings");
+    return __isa(o, "FrameCaptureGroupSettings");
   }
 }
 
@@ -3644,7 +3643,7 @@ export interface FrameCaptureOutputSettings {
 
 export namespace FrameCaptureOutputSettings {
   export function isa(o: any): o is FrameCaptureOutputSettings {
-    return _smithy.isa(o, "FrameCaptureOutputSettings");
+    return __isa(o, "FrameCaptureOutputSettings");
   }
 }
 
@@ -3666,7 +3665,7 @@ export interface FrameCaptureSettings {
 
 export namespace FrameCaptureSettings {
   export function isa(o: any): o is FrameCaptureSettings {
-    return _smithy.isa(o, "FrameCaptureSettings");
+    return __isa(o, "FrameCaptureSettings");
   }
 }
 
@@ -3674,7 +3673,7 @@ export namespace FrameCaptureSettings {
  * Placeholder documentation for GatewayTimeoutException
  */
 export interface GatewayTimeoutException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "GatewayTimeoutException";
   $fault: "server";
@@ -3686,7 +3685,7 @@ export interface GatewayTimeoutException
 
 export namespace GatewayTimeoutException {
   export function isa(o: any): o is GatewayTimeoutException {
-    return _smithy.isa(o, "GatewayTimeoutException");
+    return __isa(o, "GatewayTimeoutException");
   }
 }
 
@@ -3731,7 +3730,7 @@ export interface GlobalConfiguration {
 
 export namespace GlobalConfiguration {
   export function isa(o: any): o is GlobalConfiguration {
-    return _smithy.isa(o, "GlobalConfiguration");
+    return __isa(o, "GlobalConfiguration");
   }
 }
 
@@ -3792,7 +3791,7 @@ export interface H264ColorSpaceSettings {
 
 export namespace H264ColorSpaceSettings {
   export function isa(o: any): o is H264ColorSpaceSettings {
-    return _smithy.isa(o, "H264ColorSpaceSettings");
+    return __isa(o, "H264ColorSpaceSettings");
   }
 }
 
@@ -4102,7 +4101,7 @@ export interface H264Settings {
 
 export namespace H264Settings {
   export function isa(o: any): o is H264Settings {
-    return _smithy.isa(o, "H264Settings");
+    return __isa(o, "H264Settings");
   }
 }
 
@@ -4178,7 +4177,7 @@ export interface H265ColorSpaceSettings {
 
 export namespace H265ColorSpaceSettings {
   export function isa(o: any): o is H265ColorSpaceSettings {
-    return _smithy.isa(o, "H265ColorSpaceSettings");
+    return __isa(o, "H265ColorSpaceSettings");
   }
 }
 
@@ -4397,7 +4396,7 @@ export interface H265Settings {
 
 export namespace H265Settings {
   export function isa(o: any): o is H265Settings {
-    return _smithy.isa(o, "H265Settings");
+    return __isa(o, "H265Settings");
   }
 }
 
@@ -4433,7 +4432,7 @@ export interface Hdr10Settings {
 
 export namespace Hdr10Settings {
   export function isa(o: any): o is Hdr10Settings {
-    return _smithy.isa(o, "Hdr10Settings");
+    return __isa(o, "Hdr10Settings");
   }
 }
 
@@ -4491,7 +4490,7 @@ export interface HlsAkamaiSettings {
 
 export namespace HlsAkamaiSettings {
   export function isa(o: any): o is HlsAkamaiSettings {
-    return _smithy.isa(o, "HlsAkamaiSettings");
+    return __isa(o, "HlsAkamaiSettings");
   }
 }
 
@@ -4523,7 +4522,7 @@ export interface HlsBasicPutSettings {
 
 export namespace HlsBasicPutSettings {
   export function isa(o: any): o is HlsBasicPutSettings {
-    return _smithy.isa(o, "HlsBasicPutSettings");
+    return __isa(o, "HlsBasicPutSettings");
   }
 }
 
@@ -4561,7 +4560,7 @@ export interface HlsCdnSettings {
 
 export namespace HlsCdnSettings {
   export function isa(o: any): o is HlsCdnSettings {
-    return _smithy.isa(o, "HlsCdnSettings");
+    return __isa(o, "HlsCdnSettings");
   }
 }
 
@@ -4812,7 +4811,7 @@ export interface HlsGroupSettings {
 
 export namespace HlsGroupSettings {
   export function isa(o: any): o is HlsGroupSettings {
-    return _smithy.isa(o, "HlsGroupSettings");
+    return __isa(o, "HlsGroupSettings");
   }
 }
 
@@ -4834,7 +4833,7 @@ export interface HlsId3SegmentTaggingScheduleActionSettings {
 
 export namespace HlsId3SegmentTaggingScheduleActionSettings {
   export function isa(o: any): o is HlsId3SegmentTaggingScheduleActionSettings {
-    return _smithy.isa(o, "HlsId3SegmentTaggingScheduleActionSettings");
+    return __isa(o, "HlsId3SegmentTaggingScheduleActionSettings");
   }
 }
 
@@ -4871,7 +4870,7 @@ export interface HlsInputSettings {
 
 export namespace HlsInputSettings {
   export function isa(o: any): o is HlsInputSettings {
-    return _smithy.isa(o, "HlsInputSettings");
+    return __isa(o, "HlsInputSettings");
   }
 }
 
@@ -4928,7 +4927,7 @@ export interface HlsMediaStoreSettings {
 
 export namespace HlsMediaStoreSettings {
   export function isa(o: any): o is HlsMediaStoreSettings {
-    return _smithy.isa(o, "HlsMediaStoreSettings");
+    return __isa(o, "HlsMediaStoreSettings");
   }
 }
 
@@ -4975,7 +4974,7 @@ export interface HlsOutputSettings {
 
 export namespace HlsOutputSettings {
   export function isa(o: any): o is HlsOutputSettings {
-    return _smithy.isa(o, "HlsOutputSettings");
+    return __isa(o, "HlsOutputSettings");
   }
 }
 
@@ -5017,7 +5016,7 @@ export interface HlsSettings {
 
 export namespace HlsSettings {
   export function isa(o: any): o is HlsSettings {
-    return _smithy.isa(o, "HlsSettings");
+    return __isa(o, "HlsSettings");
   }
 }
 
@@ -5045,7 +5044,7 @@ export interface HlsTimedMetadataScheduleActionSettings {
 
 export namespace HlsTimedMetadataScheduleActionSettings {
   export function isa(o: any): o is HlsTimedMetadataScheduleActionSettings {
-    return _smithy.isa(o, "HlsTimedMetadataScheduleActionSettings");
+    return __isa(o, "HlsTimedMetadataScheduleActionSettings");
   }
 }
 
@@ -5092,7 +5091,7 @@ export interface HlsWebdavSettings {
 
 export namespace HlsWebdavSettings {
   export function isa(o: any): o is HlsWebdavSettings {
-    return _smithy.isa(o, "HlsWebdavSettings");
+    return __isa(o, "HlsWebdavSettings");
   }
 }
 
@@ -5110,7 +5109,7 @@ export interface ImmediateModeScheduleActionStartSettings {
 
 export namespace ImmediateModeScheduleActionStartSettings {
   export function isa(o: any): o is ImmediateModeScheduleActionStartSettings {
-    return _smithy.isa(o, "ImmediateModeScheduleActionStartSettings");
+    return __isa(o, "ImmediateModeScheduleActionStartSettings");
   }
 }
 
@@ -5194,7 +5193,7 @@ export interface Input {
 
 export namespace Input {
   export function isa(o: any): o is Input {
-    return _smithy.isa(o, "Input");
+    return __isa(o, "Input");
   }
 }
 
@@ -5221,7 +5220,7 @@ export interface InputAttachment {
 
 export namespace InputAttachment {
   export function isa(o: any): o is InputAttachment {
-    return _smithy.isa(o, "InputAttachment");
+    return __isa(o, "InputAttachment");
   }
 }
 
@@ -5243,7 +5242,7 @@ export interface InputChannelLevel {
 
 export namespace InputChannelLevel {
   export function isa(o: any): o is InputChannelLevel {
-    return _smithy.isa(o, "InputChannelLevel");
+    return __isa(o, "InputChannelLevel");
   }
 }
 
@@ -5275,7 +5274,7 @@ export interface InputClippingSettings {
 
 export namespace InputClippingSettings {
   export function isa(o: any): o is InputClippingSettings {
-    return _smithy.isa(o, "InputClippingSettings");
+    return __isa(o, "InputClippingSettings");
   }
 }
 
@@ -5325,7 +5324,7 @@ export interface InputDestination {
 
 export namespace InputDestination {
   export function isa(o: any): o is InputDestination {
-    return _smithy.isa(o, "InputDestination");
+    return __isa(o, "InputDestination");
   }
 }
 
@@ -5343,7 +5342,7 @@ export interface InputDestinationRequest {
 
 export namespace InputDestinationRequest {
   export function isa(o: any): o is InputDestinationRequest {
-    return _smithy.isa(o, "InputDestinationRequest");
+    return __isa(o, "InputDestinationRequest");
   }
 }
 
@@ -5365,7 +5364,7 @@ export interface InputDestinationVpc {
 
 export namespace InputDestinationVpc {
   export function isa(o: any): o is InputDestinationVpc {
-    return _smithy.isa(o, "InputDestinationVpc");
+    return __isa(o, "InputDestinationVpc");
   }
 }
 
@@ -5398,7 +5397,7 @@ export interface InputLocation {
 
 export namespace InputLocation {
   export function isa(o: any): o is InputLocation {
-    return _smithy.isa(o, "InputLocation");
+    return __isa(o, "InputLocation");
   }
 }
 
@@ -5456,7 +5455,7 @@ export interface InputLossBehavior {
 
 export namespace InputLossBehavior {
   export function isa(o: any): o is InputLossBehavior {
-    return _smithy.isa(o, "InputLossBehavior");
+    return __isa(o, "InputLossBehavior");
   }
 }
 
@@ -5515,7 +5514,7 @@ export interface InputSecurityGroup {
 
 export namespace InputSecurityGroup {
   export function isa(o: any): o is InputSecurityGroup {
-    return _smithy.isa(o, "InputSecurityGroup");
+    return __isa(o, "InputSecurityGroup");
   }
 }
 
@@ -5582,7 +5581,7 @@ export interface InputSettings {
 
 export namespace InputSettings {
   export function isa(o: any): o is InputSettings {
-    return _smithy.isa(o, "InputSettings");
+    return __isa(o, "InputSettings");
   }
 }
 
@@ -5610,7 +5609,7 @@ export interface InputSource {
 
 export namespace InputSource {
   export function isa(o: any): o is InputSource {
-    return _smithy.isa(o, "InputSource");
+    return __isa(o, "InputSource");
   }
 }
 
@@ -5643,7 +5642,7 @@ export interface InputSourceRequest {
 
 export namespace InputSourceRequest {
   export function isa(o: any): o is InputSourceRequest {
-    return _smithy.isa(o, "InputSourceRequest");
+    return __isa(o, "InputSourceRequest");
   }
 }
 
@@ -5675,7 +5674,7 @@ export interface InputSpecification {
 
 export namespace InputSpecification {
   export function isa(o: any): o is InputSpecification {
-    return _smithy.isa(o, "InputSpecification");
+    return __isa(o, "InputSpecification");
   }
 }
 
@@ -5710,7 +5709,7 @@ export interface InputSwitchScheduleActionSettings {
 
 export namespace InputSwitchScheduleActionSettings {
   export function isa(o: any): o is InputSwitchScheduleActionSettings {
-    return _smithy.isa(o, "InputSwitchScheduleActionSettings");
+    return __isa(o, "InputSwitchScheduleActionSettings");
   }
 }
 
@@ -5752,7 +5751,7 @@ export interface InputVpcRequest {
 
 export namespace InputVpcRequest {
   export function isa(o: any): o is InputVpcRequest {
-    return _smithy.isa(o, "InputVpcRequest");
+    return __isa(o, "InputVpcRequest");
   }
 }
 
@@ -5769,7 +5768,7 @@ export interface InputWhitelistRule {
 
 export namespace InputWhitelistRule {
   export function isa(o: any): o is InputWhitelistRule {
-    return _smithy.isa(o, "InputWhitelistRule");
+    return __isa(o, "InputWhitelistRule");
   }
 }
 
@@ -5786,7 +5785,7 @@ export interface InputWhitelistRuleCidr {
 
 export namespace InputWhitelistRuleCidr {
   export function isa(o: any): o is InputWhitelistRuleCidr {
-    return _smithy.isa(o, "InputWhitelistRuleCidr");
+    return __isa(o, "InputWhitelistRuleCidr");
   }
 }
 
@@ -5794,7 +5793,7 @@ export namespace InputWhitelistRuleCidr {
  * Placeholder documentation for InternalServerErrorException
  */
 export interface InternalServerErrorException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalServerErrorException";
   $fault: "server";
@@ -5806,7 +5805,7 @@ export interface InternalServerErrorException
 
 export namespace InternalServerErrorException {
   export function isa(o: any): o is InternalServerErrorException {
-    return _smithy.isa(o, "InternalServerErrorException");
+    return __isa(o, "InternalServerErrorException");
   }
 }
 
@@ -5823,7 +5822,7 @@ export interface KeyProviderSettings {
 
 export namespace KeyProviderSettings {
   export function isa(o: any): o is KeyProviderSettings {
-    return _smithy.isa(o, "KeyProviderSettings");
+    return __isa(o, "KeyProviderSettings");
   }
 }
 
@@ -5850,7 +5849,7 @@ export interface ListChannelsRequest {
 
 export namespace ListChannelsRequest {
   export function isa(o: any): o is ListChannelsRequest {
-    return _smithy.isa(o, "ListChannelsRequest");
+    return __isa(o, "ListChannelsRequest");
   }
 }
 
@@ -5872,7 +5871,7 @@ export interface ListChannelsResponse extends $MetadataBearer {
 
 export namespace ListChannelsResponse {
   export function isa(o: any): o is ListChannelsResponse {
-    return _smithy.isa(o, "ListChannelsResponse");
+    return __isa(o, "ListChannelsResponse");
   }
 }
 
@@ -5894,7 +5893,7 @@ export interface ListInputSecurityGroupsRequest {
 
 export namespace ListInputSecurityGroupsRequest {
   export function isa(o: any): o is ListInputSecurityGroupsRequest {
-    return _smithy.isa(o, "ListInputSecurityGroupsRequest");
+    return __isa(o, "ListInputSecurityGroupsRequest");
   }
 }
 
@@ -5916,7 +5915,7 @@ export interface ListInputSecurityGroupsResponse extends $MetadataBearer {
 
 export namespace ListInputSecurityGroupsResponse {
   export function isa(o: any): o is ListInputSecurityGroupsResponse {
-    return _smithy.isa(o, "ListInputSecurityGroupsResponse");
+    return __isa(o, "ListInputSecurityGroupsResponse");
   }
 }
 
@@ -5938,7 +5937,7 @@ export interface ListInputsRequest {
 
 export namespace ListInputsRequest {
   export function isa(o: any): o is ListInputsRequest {
-    return _smithy.isa(o, "ListInputsRequest");
+    return __isa(o, "ListInputsRequest");
   }
 }
 
@@ -5960,7 +5959,7 @@ export interface ListInputsResponse extends $MetadataBearer {
 
 export namespace ListInputsResponse {
   export function isa(o: any): o is ListInputsResponse {
-    return _smithy.isa(o, "ListInputsResponse");
+    return __isa(o, "ListInputsResponse");
   }
 }
 
@@ -5987,7 +5986,7 @@ export interface ListMultiplexProgramsRequest {
 
 export namespace ListMultiplexProgramsRequest {
   export function isa(o: any): o is ListMultiplexProgramsRequest {
-    return _smithy.isa(o, "ListMultiplexProgramsRequest");
+    return __isa(o, "ListMultiplexProgramsRequest");
   }
 }
 
@@ -6009,7 +6008,7 @@ export interface ListMultiplexProgramsResponse extends $MetadataBearer {
 
 export namespace ListMultiplexProgramsResponse {
   export function isa(o: any): o is ListMultiplexProgramsResponse {
-    return _smithy.isa(o, "ListMultiplexProgramsResponse");
+    return __isa(o, "ListMultiplexProgramsResponse");
   }
 }
 
@@ -6031,7 +6030,7 @@ export interface ListMultiplexesRequest {
 
 export namespace ListMultiplexesRequest {
   export function isa(o: any): o is ListMultiplexesRequest {
-    return _smithy.isa(o, "ListMultiplexesRequest");
+    return __isa(o, "ListMultiplexesRequest");
   }
 }
 
@@ -6053,7 +6052,7 @@ export interface ListMultiplexesResponse extends $MetadataBearer {
 
 export namespace ListMultiplexesResponse {
   export function isa(o: any): o is ListMultiplexesResponse {
-    return _smithy.isa(o, "ListMultiplexesResponse");
+    return __isa(o, "ListMultiplexesResponse");
   }
 }
 
@@ -6125,7 +6124,7 @@ export interface ListOfferingsRequest {
 
 export namespace ListOfferingsRequest {
   export function isa(o: any): o is ListOfferingsRequest {
-    return _smithy.isa(o, "ListOfferingsRequest");
+    return __isa(o, "ListOfferingsRequest");
   }
 }
 
@@ -6147,7 +6146,7 @@ export interface ListOfferingsResponse extends $MetadataBearer {
 
 export namespace ListOfferingsResponse {
   export function isa(o: any): o is ListOfferingsResponse {
-    return _smithy.isa(o, "ListOfferingsResponse");
+    return __isa(o, "ListOfferingsResponse");
   }
 }
 
@@ -6209,7 +6208,7 @@ export interface ListReservationsRequest {
 
 export namespace ListReservationsRequest {
   export function isa(o: any): o is ListReservationsRequest {
-    return _smithy.isa(o, "ListReservationsRequest");
+    return __isa(o, "ListReservationsRequest");
   }
 }
 
@@ -6231,7 +6230,7 @@ export interface ListReservationsResponse extends $MetadataBearer {
 
 export namespace ListReservationsResponse {
   export function isa(o: any): o is ListReservationsResponse {
-    return _smithy.isa(o, "ListReservationsResponse");
+    return __isa(o, "ListReservationsResponse");
   }
 }
 
@@ -6248,7 +6247,7 @@ export interface ListTagsForResourceRequest {
 
 export namespace ListTagsForResourceRequest {
   export function isa(o: any): o is ListTagsForResourceRequest {
-    return _smithy.isa(o, "ListTagsForResourceRequest");
+    return __isa(o, "ListTagsForResourceRequest");
   }
 }
 
@@ -6265,7 +6264,7 @@ export interface ListTagsForResourceResponse extends $MetadataBearer {
 
 export namespace ListTagsForResourceResponse {
   export function isa(o: any): o is ListTagsForResourceResponse {
-    return _smithy.isa(o, "ListTagsForResourceResponse");
+    return __isa(o, "ListTagsForResourceResponse");
   }
 }
 
@@ -6618,7 +6617,7 @@ export interface M2tsSettings {
 
 export namespace M2tsSettings {
   export function isa(o: any): o is M2tsSettings {
-    return _smithy.isa(o, "M2tsSettings");
+    return __isa(o, "M2tsSettings");
   }
 }
 
@@ -6735,7 +6734,7 @@ export interface M3u8Settings {
 
 export namespace M3u8Settings {
   export function isa(o: any): o is M3u8Settings {
-    return _smithy.isa(o, "M3u8Settings");
+    return __isa(o, "M3u8Settings");
   }
 }
 
@@ -6757,7 +6756,7 @@ export interface MediaConnectFlow {
 
 export namespace MediaConnectFlow {
   export function isa(o: any): o is MediaConnectFlow {
-    return _smithy.isa(o, "MediaConnectFlow");
+    return __isa(o, "MediaConnectFlow");
   }
 }
 
@@ -6774,7 +6773,7 @@ export interface MediaConnectFlowRequest {
 
 export namespace MediaConnectFlowRequest {
   export function isa(o: any): o is MediaConnectFlowRequest {
-    return _smithy.isa(o, "MediaConnectFlowRequest");
+    return __isa(o, "MediaConnectFlowRequest");
   }
 }
 
@@ -6791,7 +6790,7 @@ export interface MediaPackageGroupSettings {
 
 export namespace MediaPackageGroupSettings {
   export function isa(o: any): o is MediaPackageGroupSettings {
-    return _smithy.isa(o, "MediaPackageGroupSettings");
+    return __isa(o, "MediaPackageGroupSettings");
   }
 }
 
@@ -6808,7 +6807,7 @@ export interface MediaPackageOutputDestinationSettings {
 
 export namespace MediaPackageOutputDestinationSettings {
   export function isa(o: any): o is MediaPackageOutputDestinationSettings {
-    return _smithy.isa(o, "MediaPackageOutputDestinationSettings");
+    return __isa(o, "MediaPackageOutputDestinationSettings");
   }
 }
 
@@ -6821,7 +6820,7 @@ export interface MediaPackageOutputSettings {
 
 export namespace MediaPackageOutputSettings {
   export function isa(o: any): o is MediaPackageOutputSettings {
-    return _smithy.isa(o, "MediaPackageOutputSettings");
+    return __isa(o, "MediaPackageOutputSettings");
   }
 }
 
@@ -6853,7 +6852,7 @@ export interface Mp2Settings {
 
 export namespace Mp2Settings {
   export function isa(o: any): o is Mp2Settings {
-    return _smithy.isa(o, "Mp2Settings");
+    return __isa(o, "Mp2Settings");
   }
 }
 
@@ -6969,7 +6968,7 @@ export interface MsSmoothGroupSettings {
 
 export namespace MsSmoothGroupSettings {
   export function isa(o: any): o is MsSmoothGroupSettings {
-    return _smithy.isa(o, "MsSmoothGroupSettings");
+    return __isa(o, "MsSmoothGroupSettings");
   }
 }
 
@@ -6997,7 +6996,7 @@ export interface MsSmoothOutputSettings {
 
 export namespace MsSmoothOutputSettings {
   export function isa(o: any): o is MsSmoothOutputSettings {
-    return _smithy.isa(o, "MsSmoothOutputSettings");
+    return __isa(o, "MsSmoothOutputSettings");
   }
 }
 
@@ -7059,7 +7058,7 @@ export interface Multiplex {
 
 export namespace Multiplex {
   export function isa(o: any): o is Multiplex {
-    return _smithy.isa(o, "Multiplex");
+    return __isa(o, "Multiplex");
   }
 }
 
@@ -7072,7 +7071,7 @@ export interface MultiplexGroupSettings {
 
 export namespace MultiplexGroupSettings {
   export function isa(o: any): o is MultiplexGroupSettings {
-    return _smithy.isa(o, "MultiplexGroupSettings");
+    return __isa(o, "MultiplexGroupSettings");
   }
 }
 
@@ -7091,7 +7090,7 @@ export namespace MultiplexMediaConnectOutputDestinationSettings {
   export function isa(
     o: any
   ): o is MultiplexMediaConnectOutputDestinationSettings {
-    return _smithy.isa(o, "MultiplexMediaConnectOutputDestinationSettings");
+    return __isa(o, "MultiplexMediaConnectOutputDestinationSettings");
   }
 }
 
@@ -7108,7 +7107,7 @@ export interface MultiplexOutputDestination {
 
 export namespace MultiplexOutputDestination {
   export function isa(o: any): o is MultiplexOutputDestination {
-    return _smithy.isa(o, "MultiplexOutputDestination");
+    return __isa(o, "MultiplexOutputDestination");
   }
 }
 
@@ -7125,7 +7124,7 @@ export interface MultiplexOutputSettings {
 
 export namespace MultiplexOutputSettings {
   export function isa(o: any): o is MultiplexOutputSettings {
-    return _smithy.isa(o, "MultiplexOutputSettings");
+    return __isa(o, "MultiplexOutputSettings");
   }
 }
 
@@ -7157,7 +7156,7 @@ export interface MultiplexProgram {
 
 export namespace MultiplexProgram {
   export function isa(o: any): o is MultiplexProgram {
-    return _smithy.isa(o, "MultiplexProgram");
+    return __isa(o, "MultiplexProgram");
   }
 }
 
@@ -7180,7 +7179,7 @@ export interface MultiplexProgramChannelDestinationSettings {
 
 export namespace MultiplexProgramChannelDestinationSettings {
   export function isa(o: any): o is MultiplexProgramChannelDestinationSettings {
-    return _smithy.isa(o, "MultiplexProgramChannelDestinationSettings");
+    return __isa(o, "MultiplexProgramChannelDestinationSettings");
   }
 }
 
@@ -7257,7 +7256,7 @@ export interface MultiplexProgramPacketIdentifiersMap {
 
 export namespace MultiplexProgramPacketIdentifiersMap {
   export function isa(o: any): o is MultiplexProgramPacketIdentifiersMap {
-    return _smithy.isa(o, "MultiplexProgramPacketIdentifiersMap");
+    return __isa(o, "MultiplexProgramPacketIdentifiersMap");
   }
 }
 
@@ -7279,7 +7278,7 @@ export interface MultiplexProgramServiceDescriptor {
 
 export namespace MultiplexProgramServiceDescriptor {
   export function isa(o: any): o is MultiplexProgramServiceDescriptor {
-    return _smithy.isa(o, "MultiplexProgramServiceDescriptor");
+    return __isa(o, "MultiplexProgramServiceDescriptor");
   }
 }
 
@@ -7306,7 +7305,7 @@ export interface MultiplexProgramSettings {
 
 export namespace MultiplexProgramSettings {
   export function isa(o: any): o is MultiplexProgramSettings {
-    return _smithy.isa(o, "MultiplexProgramSettings");
+    return __isa(o, "MultiplexProgramSettings");
   }
 }
 
@@ -7328,7 +7327,7 @@ export interface MultiplexProgramSummary {
 
 export namespace MultiplexProgramSummary {
   export function isa(o: any): o is MultiplexProgramSummary {
-    return _smithy.isa(o, "MultiplexProgramSummary");
+    return __isa(o, "MultiplexProgramSummary");
   }
 }
 
@@ -7360,7 +7359,7 @@ export interface MultiplexSettings {
 
 export namespace MultiplexSettings {
   export function isa(o: any): o is MultiplexSettings {
-    return _smithy.isa(o, "MultiplexSettings");
+    return __isa(o, "MultiplexSettings");
   }
 }
 
@@ -7377,7 +7376,7 @@ export interface MultiplexSettingsSummary {
 
 export namespace MultiplexSettingsSummary {
   export function isa(o: any): o is MultiplexSettingsSummary {
-    return _smithy.isa(o, "MultiplexSettingsSummary");
+    return __isa(o, "MultiplexSettingsSummary");
   }
 }
 
@@ -7411,7 +7410,7 @@ export interface MultiplexStatmuxVideoSettings {
 
 export namespace MultiplexStatmuxVideoSettings {
   export function isa(o: any): o is MultiplexStatmuxVideoSettings {
-    return _smithy.isa(o, "MultiplexStatmuxVideoSettings");
+    return __isa(o, "MultiplexStatmuxVideoSettings");
   }
 }
 
@@ -7468,7 +7467,7 @@ export interface MultiplexSummary {
 
 export namespace MultiplexSummary {
   export function isa(o: any): o is MultiplexSummary {
-    return _smithy.isa(o, "MultiplexSummary");
+    return __isa(o, "MultiplexSummary");
   }
 }
 
@@ -7492,7 +7491,7 @@ export interface MultiplexVideoSettings {
 
 export namespace MultiplexVideoSettings {
   export function isa(o: any): o is MultiplexVideoSettings {
-    return _smithy.isa(o, "MultiplexVideoSettings");
+    return __isa(o, "MultiplexVideoSettings");
   }
 }
 
@@ -7519,7 +7518,7 @@ export interface NetworkInputSettings {
 
 export namespace NetworkInputSettings {
   export function isa(o: any): o is NetworkInputSettings {
-    return _smithy.isa(o, "NetworkInputSettings");
+    return __isa(o, "NetworkInputSettings");
   }
 }
 
@@ -7541,7 +7540,7 @@ export interface NielsenConfiguration {
 
 export namespace NielsenConfiguration {
   export function isa(o: any): o is NielsenConfiguration {
-    return _smithy.isa(o, "NielsenConfiguration");
+    return __isa(o, "NielsenConfiguration");
   }
 }
 
@@ -7553,9 +7552,7 @@ export enum NielsenPcmToId3TaggingState {
 /**
  * Placeholder documentation for NotFoundException
  */
-export interface NotFoundException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface NotFoundException extends __SmithyException, $MetadataBearer {
   name: "NotFoundException";
   $fault: "client";
   /**
@@ -7566,7 +7563,7 @@ export interface NotFoundException
 
 export namespace NotFoundException {
   export function isa(o: any): o is NotFoundException {
-    return _smithy.isa(o, "NotFoundException");
+    return __isa(o, "NotFoundException");
   }
 }
 
@@ -7633,7 +7630,7 @@ export interface Offering {
 
 export namespace Offering {
   export function isa(o: any): o is Offering {
-    return _smithy.isa(o, "Offering");
+    return __isa(o, "Offering");
   }
 }
 
@@ -7678,7 +7675,7 @@ export interface Output {
 
 export namespace Output {
   export function isa(o: any): o is Output {
-    return _smithy.isa(o, "Output");
+    return __isa(o, "Output");
   }
 }
 
@@ -7710,7 +7707,7 @@ export interface OutputDestination {
 
 export namespace OutputDestination {
   export function isa(o: any): o is OutputDestination {
-    return _smithy.isa(o, "OutputDestination");
+    return __isa(o, "OutputDestination");
   }
 }
 
@@ -7742,7 +7739,7 @@ export interface OutputDestinationSettings {
 
 export namespace OutputDestinationSettings {
   export function isa(o: any): o is OutputDestinationSettings {
-    return _smithy.isa(o, "OutputDestinationSettings");
+    return __isa(o, "OutputDestinationSettings");
   }
 }
 
@@ -7769,7 +7766,7 @@ export interface OutputGroup {
 
 export namespace OutputGroup {
   export function isa(o: any): o is OutputGroup {
-    return _smithy.isa(o, "OutputGroup");
+    return __isa(o, "OutputGroup");
   }
 }
 
@@ -7821,7 +7818,7 @@ export interface OutputGroupSettings {
 
 export namespace OutputGroupSettings {
   export function isa(o: any): o is OutputGroupSettings {
-    return _smithy.isa(o, "OutputGroupSettings");
+    return __isa(o, "OutputGroupSettings");
   }
 }
 
@@ -7838,7 +7835,7 @@ export interface OutputLocationRef {
 
 export namespace OutputLocationRef {
   export function isa(o: any): o is OutputLocationRef {
-    return _smithy.isa(o, "OutputLocationRef");
+    return __isa(o, "OutputLocationRef");
   }
 }
 
@@ -7890,7 +7887,7 @@ export interface OutputSettings {
 
 export namespace OutputSettings {
   export function isa(o: any): o is OutputSettings {
-    return _smithy.isa(o, "OutputSettings");
+    return __isa(o, "OutputSettings");
   }
 }
 
@@ -7903,7 +7900,7 @@ export interface PassThroughSettings {
 
 export namespace PassThroughSettings {
   export function isa(o: any): o is PassThroughSettings {
-    return _smithy.isa(o, "PassThroughSettings");
+    return __isa(o, "PassThroughSettings");
   }
 }
 
@@ -7920,7 +7917,7 @@ export interface PauseStateScheduleActionSettings {
 
 export namespace PauseStateScheduleActionSettings {
   export function isa(o: any): o is PauseStateScheduleActionSettings {
-    return _smithy.isa(o, "PauseStateScheduleActionSettings");
+    return __isa(o, "PauseStateScheduleActionSettings");
   }
 }
 
@@ -7947,7 +7944,7 @@ export interface PipelineDetail {
 
 export namespace PipelineDetail {
   export function isa(o: any): o is PipelineDetail {
-    return _smithy.isa(o, "PipelineDetail");
+    return __isa(o, "PipelineDetail");
   }
 }
 
@@ -7969,7 +7966,7 @@ export interface PipelinePauseStateSettings {
 
 export namespace PipelinePauseStateSettings {
   export function isa(o: any): o is PipelinePauseStateSettings {
-    return _smithy.isa(o, "PipelinePauseStateSettings");
+    return __isa(o, "PipelinePauseStateSettings");
   }
 }
 
@@ -8011,7 +8008,7 @@ export interface PurchaseOfferingRequest {
 
 export namespace PurchaseOfferingRequest {
   export function isa(o: any): o is PurchaseOfferingRequest {
-    return _smithy.isa(o, "PurchaseOfferingRequest");
+    return __isa(o, "PurchaseOfferingRequest");
   }
 }
 
@@ -8028,7 +8025,7 @@ export interface PurchaseOfferingResponse extends $MetadataBearer {
 
 export namespace PurchaseOfferingResponse {
   export function isa(o: any): o is PurchaseOfferingResponse {
-    return _smithy.isa(o, "PurchaseOfferingResponse");
+    return __isa(o, "PurchaseOfferingResponse");
   }
 }
 
@@ -8041,7 +8038,7 @@ export interface Rec601Settings {
 
 export namespace Rec601Settings {
   export function isa(o: any): o is Rec601Settings {
-    return _smithy.isa(o, "Rec601Settings");
+    return __isa(o, "Rec601Settings");
   }
 }
 
@@ -8054,7 +8051,7 @@ export interface Rec709Settings {
 
 export namespace Rec709Settings {
   export function isa(o: any): o is Rec709Settings {
-    return _smithy.isa(o, "Rec709Settings");
+    return __isa(o, "Rec709Settings");
   }
 }
 
@@ -8082,7 +8079,7 @@ export interface RemixSettings {
 
 export namespace RemixSettings {
   export function isa(o: any): o is RemixSettings {
-    return _smithy.isa(o, "RemixSettings");
+    return __isa(o, "RemixSettings");
   }
 }
 
@@ -8184,7 +8181,7 @@ export interface Reservation {
 
 export namespace Reservation {
   export function isa(o: any): o is Reservation {
-    return _smithy.isa(o, "Reservation");
+    return __isa(o, "Reservation");
   }
 }
 
@@ -8261,7 +8258,7 @@ export interface ReservationResourceSpecification {
 
 export namespace ReservationResourceSpecification {
   export function isa(o: any): o is ReservationResourceSpecification {
-    return _smithy.isa(o, "ReservationResourceSpecification");
+    return __isa(o, "ReservationResourceSpecification");
   }
 }
 
@@ -8310,7 +8307,7 @@ export interface RtmpCaptionInfoDestinationSettings {
 
 export namespace RtmpCaptionInfoDestinationSettings {
   export function isa(o: any): o is RtmpCaptionInfoDestinationSettings {
-    return _smithy.isa(o, "RtmpCaptionInfoDestinationSettings");
+    return __isa(o, "RtmpCaptionInfoDestinationSettings");
   }
 }
 
@@ -8355,7 +8352,7 @@ export interface RtmpGroupSettings {
 
 export namespace RtmpGroupSettings {
   export function isa(o: any): o is RtmpGroupSettings {
-    return _smithy.isa(o, "RtmpGroupSettings");
+    return __isa(o, "RtmpGroupSettings");
   }
 }
 
@@ -8392,7 +8389,7 @@ export interface RtmpOutputSettings {
 
 export namespace RtmpOutputSettings {
   export function isa(o: any): o is RtmpOutputSettings {
-    return _smithy.isa(o, "RtmpOutputSettings");
+    return __isa(o, "RtmpOutputSettings");
   }
 }
 
@@ -8419,7 +8416,7 @@ export interface ScheduleAction {
 
 export namespace ScheduleAction {
   export function isa(o: any): o is ScheduleAction {
-    return _smithy.isa(o, "ScheduleAction");
+    return __isa(o, "ScheduleAction");
   }
 }
 
@@ -8476,7 +8473,7 @@ export interface ScheduleActionSettings {
 
 export namespace ScheduleActionSettings {
   export function isa(o: any): o is ScheduleActionSettings {
-    return _smithy.isa(o, "ScheduleActionSettings");
+    return __isa(o, "ScheduleActionSettings");
   }
 }
 
@@ -8503,7 +8500,7 @@ export interface ScheduleActionStartSettings {
 
 export namespace ScheduleActionStartSettings {
   export function isa(o: any): o is ScheduleActionStartSettings {
-    return _smithy.isa(o, "ScheduleActionStartSettings");
+    return __isa(o, "ScheduleActionStartSettings");
   }
 }
 
@@ -8521,7 +8518,7 @@ export interface Scte20PlusEmbeddedDestinationSettings {
 
 export namespace Scte20PlusEmbeddedDestinationSettings {
   export function isa(o: any): o is Scte20PlusEmbeddedDestinationSettings {
-    return _smithy.isa(o, "Scte20PlusEmbeddedDestinationSettings");
+    return __isa(o, "Scte20PlusEmbeddedDestinationSettings");
   }
 }
 
@@ -8543,7 +8540,7 @@ export interface Scte20SourceSettings {
 
 export namespace Scte20SourceSettings {
   export function isa(o: any): o is Scte20SourceSettings {
-    return _smithy.isa(o, "Scte20SourceSettings");
+    return __isa(o, "Scte20SourceSettings");
   }
 }
 
@@ -8556,7 +8553,7 @@ export interface Scte27DestinationSettings {
 
 export namespace Scte27DestinationSettings {
   export function isa(o: any): o is Scte27DestinationSettings {
-    return _smithy.isa(o, "Scte27DestinationSettings");
+    return __isa(o, "Scte27DestinationSettings");
   }
 }
 
@@ -8577,7 +8574,7 @@ export interface Scte27SourceSettings {
 
 export namespace Scte27SourceSettings {
   export function isa(o: any): o is Scte27SourceSettings {
-    return _smithy.isa(o, "Scte27SourceSettings");
+    return __isa(o, "Scte27SourceSettings");
   }
 }
 
@@ -8624,7 +8621,7 @@ export interface Scte35DeliveryRestrictions {
 
 export namespace Scte35DeliveryRestrictions {
   export function isa(o: any): o is Scte35DeliveryRestrictions {
-    return _smithy.isa(o, "Scte35DeliveryRestrictions");
+    return __isa(o, "Scte35DeliveryRestrictions");
   }
 }
 
@@ -8641,7 +8638,7 @@ export interface Scte35Descriptor {
 
 export namespace Scte35Descriptor {
   export function isa(o: any): o is Scte35Descriptor {
-    return _smithy.isa(o, "Scte35Descriptor");
+    return __isa(o, "Scte35Descriptor");
   }
 }
 
@@ -8660,7 +8657,7 @@ export interface Scte35DescriptorSettings {
 
 export namespace Scte35DescriptorSettings {
   export function isa(o: any): o is Scte35DescriptorSettings {
-    return _smithy.isa(o, "Scte35DescriptorSettings");
+    return __isa(o, "Scte35DescriptorSettings");
   }
 }
 
@@ -8691,7 +8688,7 @@ export namespace Scte35ReturnToNetworkScheduleActionSettings {
   export function isa(
     o: any
   ): o is Scte35ReturnToNetworkScheduleActionSettings {
-    return _smithy.isa(o, "Scte35ReturnToNetworkScheduleActionSettings");
+    return __isa(o, "Scte35ReturnToNetworkScheduleActionSettings");
   }
 }
 
@@ -8766,7 +8763,7 @@ export interface Scte35SegmentationDescriptor {
 
 export namespace Scte35SegmentationDescriptor {
   export function isa(o: any): o is Scte35SegmentationDescriptor {
-    return _smithy.isa(o, "Scte35SegmentationDescriptor");
+    return __isa(o, "Scte35SegmentationDescriptor");
   }
 }
 
@@ -8797,7 +8794,7 @@ export interface Scte35SpliceInsert {
 
 export namespace Scte35SpliceInsert {
   export function isa(o: any): o is Scte35SpliceInsert {
-    return _smithy.isa(o, "Scte35SpliceInsert");
+    return __isa(o, "Scte35SpliceInsert");
   }
 }
 
@@ -8824,7 +8821,7 @@ export interface Scte35SpliceInsertScheduleActionSettings {
 
 export namespace Scte35SpliceInsertScheduleActionSettings {
   export function isa(o: any): o is Scte35SpliceInsertScheduleActionSettings {
-    return _smithy.isa(o, "Scte35SpliceInsertScheduleActionSettings");
+    return __isa(o, "Scte35SpliceInsertScheduleActionSettings");
   }
 }
 
@@ -8856,7 +8853,7 @@ export interface Scte35TimeSignalApos {
 
 export namespace Scte35TimeSignalApos {
   export function isa(o: any): o is Scte35TimeSignalApos {
-    return _smithy.isa(o, "Scte35TimeSignalApos");
+    return __isa(o, "Scte35TimeSignalApos");
   }
 }
 
@@ -8873,7 +8870,7 @@ export interface Scte35TimeSignalScheduleActionSettings {
 
 export namespace Scte35TimeSignalScheduleActionSettings {
   export function isa(o: any): o is Scte35TimeSignalScheduleActionSettings {
-    return _smithy.isa(o, "Scte35TimeSignalScheduleActionSettings");
+    return __isa(o, "Scte35TimeSignalScheduleActionSettings");
   }
 }
 
@@ -8932,7 +8929,7 @@ export interface SmpteTtDestinationSettings {
 
 export namespace SmpteTtDestinationSettings {
   export function isa(o: any): o is SmpteTtDestinationSettings {
-    return _smithy.isa(o, "SmpteTtDestinationSettings");
+    return __isa(o, "SmpteTtDestinationSettings");
   }
 }
 
@@ -8954,7 +8951,7 @@ export interface StandardHlsSettings {
 
 export namespace StandardHlsSettings {
   export function isa(o: any): o is StandardHlsSettings {
-    return _smithy.isa(o, "StandardHlsSettings");
+    return __isa(o, "StandardHlsSettings");
   }
 }
 
@@ -8971,7 +8968,7 @@ export interface StartChannelRequest {
 
 export namespace StartChannelRequest {
   export function isa(o: any): o is StartChannelRequest {
-    return _smithy.isa(o, "StartChannelRequest");
+    return __isa(o, "StartChannelRequest");
   }
 }
 
@@ -9060,7 +9057,7 @@ export interface StartChannelResponse extends $MetadataBearer {
 
 export namespace StartChannelResponse {
   export function isa(o: any): o is StartChannelResponse {
-    return _smithy.isa(o, "StartChannelResponse");
+    return __isa(o, "StartChannelResponse");
   }
 }
 
@@ -9077,7 +9074,7 @@ export interface StartMultiplexRequest {
 
 export namespace StartMultiplexRequest {
   export function isa(o: any): o is StartMultiplexRequest {
-    return _smithy.isa(o, "StartMultiplexRequest");
+    return __isa(o, "StartMultiplexRequest");
   }
 }
 
@@ -9139,7 +9136,7 @@ export interface StartMultiplexResponse extends $MetadataBearer {
 
 export namespace StartMultiplexResponse {
   export function isa(o: any): o is StartMultiplexResponse {
-    return _smithy.isa(o, "StartMultiplexResponse");
+    return __isa(o, "StartMultiplexResponse");
   }
 }
 
@@ -9156,7 +9153,7 @@ export interface StartTimecode {
 
 export namespace StartTimecode {
   export function isa(o: any): o is StartTimecode {
-    return _smithy.isa(o, "StartTimecode");
+    return __isa(o, "StartTimecode");
   }
 }
 
@@ -9218,7 +9215,7 @@ export interface StaticImageActivateScheduleActionSettings {
 
 export namespace StaticImageActivateScheduleActionSettings {
   export function isa(o: any): o is StaticImageActivateScheduleActionSettings {
-    return _smithy.isa(o, "StaticImageActivateScheduleActionSettings");
+    return __isa(o, "StaticImageActivateScheduleActionSettings");
   }
 }
 
@@ -9242,7 +9239,7 @@ export namespace StaticImageDeactivateScheduleActionSettings {
   export function isa(
     o: any
   ): o is StaticImageDeactivateScheduleActionSettings {
-    return _smithy.isa(o, "StaticImageDeactivateScheduleActionSettings");
+    return __isa(o, "StaticImageDeactivateScheduleActionSettings");
   }
 }
 
@@ -9264,7 +9261,7 @@ export interface StaticKeySettings {
 
 export namespace StaticKeySettings {
   export function isa(o: any): o is StaticKeySettings {
-    return _smithy.isa(o, "StaticKeySettings");
+    return __isa(o, "StaticKeySettings");
   }
 }
 
@@ -9281,7 +9278,7 @@ export interface StopChannelRequest {
 
 export namespace StopChannelRequest {
   export function isa(o: any): o is StopChannelRequest {
-    return _smithy.isa(o, "StopChannelRequest");
+    return __isa(o, "StopChannelRequest");
   }
 }
 
@@ -9370,7 +9367,7 @@ export interface StopChannelResponse extends $MetadataBearer {
 
 export namespace StopChannelResponse {
   export function isa(o: any): o is StopChannelResponse {
-    return _smithy.isa(o, "StopChannelResponse");
+    return __isa(o, "StopChannelResponse");
   }
 }
 
@@ -9387,7 +9384,7 @@ export interface StopMultiplexRequest {
 
 export namespace StopMultiplexRequest {
   export function isa(o: any): o is StopMultiplexRequest {
-    return _smithy.isa(o, "StopMultiplexRequest");
+    return __isa(o, "StopMultiplexRequest");
   }
 }
 
@@ -9449,7 +9446,7 @@ export interface StopMultiplexResponse extends $MetadataBearer {
 
 export namespace StopMultiplexResponse {
   export function isa(o: any): o is StopMultiplexResponse {
-    return _smithy.isa(o, "StopMultiplexResponse");
+    return __isa(o, "StopMultiplexResponse");
   }
 }
 
@@ -9471,7 +9468,7 @@ export interface StopTimecode {
 
 export namespace StopTimecode {
   export function isa(o: any): o is StopTimecode {
-    return _smithy.isa(o, "StopTimecode");
+    return __isa(o, "StopTimecode");
   }
 }
 
@@ -9484,7 +9481,7 @@ export interface TeletextDestinationSettings {
 
 export namespace TeletextDestinationSettings {
   export function isa(o: any): o is TeletextDestinationSettings {
-    return _smithy.isa(o, "TeletextDestinationSettings");
+    return __isa(o, "TeletextDestinationSettings");
   }
 }
 
@@ -9501,7 +9498,7 @@ export interface TeletextSourceSettings {
 
 export namespace TeletextSourceSettings {
   export function isa(o: any): o is TeletextSourceSettings {
-    return _smithy.isa(o, "TeletextSourceSettings");
+    return __isa(o, "TeletextSourceSettings");
   }
 }
 
@@ -9526,7 +9523,7 @@ export interface TimecodeConfig {
 
 export namespace TimecodeConfig {
   export function isa(o: any): o is TimecodeConfig {
-    return _smithy.isa(o, "TimecodeConfig");
+    return __isa(o, "TimecodeConfig");
   }
 }
 
@@ -9540,7 +9537,7 @@ export enum TimecodeConfigSource {
  * Placeholder documentation for TooManyRequestsException
  */
 export interface TooManyRequestsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyRequestsException";
   $fault: "client";
@@ -9552,7 +9549,7 @@ export interface TooManyRequestsException
 
 export namespace TooManyRequestsException {
   export function isa(o: any): o is TooManyRequestsException {
-    return _smithy.isa(o, "TooManyRequestsException");
+    return __isa(o, "TooManyRequestsException");
   }
 }
 
@@ -9569,7 +9566,7 @@ export interface TtmlDestinationSettings {
 
 export namespace TtmlDestinationSettings {
   export function isa(o: any): o is TtmlDestinationSettings {
-    return _smithy.isa(o, "TtmlDestinationSettings");
+    return __isa(o, "TtmlDestinationSettings");
   }
 }
 
@@ -9591,7 +9588,7 @@ export interface UdpContainerSettings {
 
 export namespace UdpContainerSettings {
   export function isa(o: any): o is UdpContainerSettings {
-    return _smithy.isa(o, "UdpContainerSettings");
+    return __isa(o, "UdpContainerSettings");
   }
 }
 
@@ -9618,7 +9615,7 @@ export interface UdpGroupSettings {
 
 export namespace UdpGroupSettings {
   export function isa(o: any): o is UdpGroupSettings {
-    return _smithy.isa(o, "UdpGroupSettings");
+    return __isa(o, "UdpGroupSettings");
   }
 }
 
@@ -9650,7 +9647,7 @@ export interface UdpOutputSettings {
 
 export namespace UdpOutputSettings {
   export function isa(o: any): o is UdpOutputSettings {
-    return _smithy.isa(o, "UdpOutputSettings");
+    return __isa(o, "UdpOutputSettings");
   }
 }
 
@@ -9664,7 +9661,7 @@ export enum UdpTimedMetadataId3Frame {
  * Placeholder documentation for UnprocessableEntityException
  */
 export interface UnprocessableEntityException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UnprocessableEntityException";
   $fault: "client";
@@ -9681,7 +9678,7 @@ export interface UnprocessableEntityException
 
 export namespace UnprocessableEntityException {
   export function isa(o: any): o is UnprocessableEntityException {
-    return _smithy.isa(o, "UnprocessableEntityException");
+    return __isa(o, "UnprocessableEntityException");
   }
 }
 
@@ -9708,7 +9705,7 @@ export interface UpdateChannelClassRequest {
 
 export namespace UpdateChannelClassRequest {
   export function isa(o: any): o is UpdateChannelClassRequest {
-    return _smithy.isa(o, "UpdateChannelClassRequest");
+    return __isa(o, "UpdateChannelClassRequest");
   }
 }
 
@@ -9725,7 +9722,7 @@ export interface UpdateChannelClassResponse extends $MetadataBearer {
 
 export namespace UpdateChannelClassResponse {
   export function isa(o: any): o is UpdateChannelClassResponse {
-    return _smithy.isa(o, "UpdateChannelClassResponse");
+    return __isa(o, "UpdateChannelClassResponse");
   }
 }
 
@@ -9777,7 +9774,7 @@ export interface UpdateChannelRequest {
 
 export namespace UpdateChannelRequest {
   export function isa(o: any): o is UpdateChannelRequest {
-    return _smithy.isa(o, "UpdateChannelRequest");
+    return __isa(o, "UpdateChannelRequest");
   }
 }
 
@@ -9794,7 +9791,7 @@ export interface UpdateChannelResponse extends $MetadataBearer {
 
 export namespace UpdateChannelResponse {
   export function isa(o: any): o is UpdateChannelResponse {
-    return _smithy.isa(o, "UpdateChannelResponse");
+    return __isa(o, "UpdateChannelResponse");
   }
 }
 
@@ -9845,7 +9842,7 @@ export interface UpdateInputRequest {
 
 export namespace UpdateInputRequest {
   export function isa(o: any): o is UpdateInputRequest {
-    return _smithy.isa(o, "UpdateInputRequest");
+    return __isa(o, "UpdateInputRequest");
   }
 }
 
@@ -9862,7 +9859,7 @@ export interface UpdateInputResponse extends $MetadataBearer {
 
 export namespace UpdateInputResponse {
   export function isa(o: any): o is UpdateInputResponse {
-    return _smithy.isa(o, "UpdateInputResponse");
+    return __isa(o, "UpdateInputResponse");
   }
 }
 
@@ -9889,7 +9886,7 @@ export interface UpdateInputSecurityGroupRequest {
 
 export namespace UpdateInputSecurityGroupRequest {
   export function isa(o: any): o is UpdateInputSecurityGroupRequest {
-    return _smithy.isa(o, "UpdateInputSecurityGroupRequest");
+    return __isa(o, "UpdateInputSecurityGroupRequest");
   }
 }
 
@@ -9906,7 +9903,7 @@ export interface UpdateInputSecurityGroupResponse extends $MetadataBearer {
 
 export namespace UpdateInputSecurityGroupResponse {
   export function isa(o: any): o is UpdateInputSecurityGroupResponse {
-    return _smithy.isa(o, "UpdateInputSecurityGroupResponse");
+    return __isa(o, "UpdateInputSecurityGroupResponse");
   }
 }
 
@@ -9933,7 +9930,7 @@ export interface UpdateMultiplexProgramRequest {
 
 export namespace UpdateMultiplexProgramRequest {
   export function isa(o: any): o is UpdateMultiplexProgramRequest {
-    return _smithy.isa(o, "UpdateMultiplexProgramRequest");
+    return __isa(o, "UpdateMultiplexProgramRequest");
   }
 }
 
@@ -9950,7 +9947,7 @@ export interface UpdateMultiplexProgramResponse extends $MetadataBearer {
 
 export namespace UpdateMultiplexProgramResponse {
   export function isa(o: any): o is UpdateMultiplexProgramResponse {
-    return _smithy.isa(o, "UpdateMultiplexProgramResponse");
+    return __isa(o, "UpdateMultiplexProgramResponse");
   }
 }
 
@@ -9977,7 +9974,7 @@ export interface UpdateMultiplexRequest {
 
 export namespace UpdateMultiplexRequest {
   export function isa(o: any): o is UpdateMultiplexRequest {
-    return _smithy.isa(o, "UpdateMultiplexRequest");
+    return __isa(o, "UpdateMultiplexRequest");
   }
 }
 
@@ -9994,7 +9991,7 @@ export interface UpdateMultiplexResponse extends $MetadataBearer {
 
 export namespace UpdateMultiplexResponse {
   export function isa(o: any): o is UpdateMultiplexResponse {
-    return _smithy.isa(o, "UpdateMultiplexResponse");
+    return __isa(o, "UpdateMultiplexResponse");
   }
 }
 
@@ -10016,7 +10013,7 @@ export interface UpdateReservationRequest {
 
 export namespace UpdateReservationRequest {
   export function isa(o: any): o is UpdateReservationRequest {
-    return _smithy.isa(o, "UpdateReservationRequest");
+    return __isa(o, "UpdateReservationRequest");
   }
 }
 
@@ -10033,7 +10030,7 @@ export interface UpdateReservationResponse extends $MetadataBearer {
 
 export namespace UpdateReservationResponse {
   export function isa(o: any): o is UpdateReservationResponse {
-    return _smithy.isa(o, "UpdateReservationResponse");
+    return __isa(o, "UpdateReservationResponse");
   }
 }
 
@@ -10055,7 +10052,7 @@ export interface ValidationError {
 
 export namespace ValidationError {
   export function isa(o: any): o is ValidationError {
-    return _smithy.isa(o, "ValidationError");
+    return __isa(o, "ValidationError");
   }
 }
 
@@ -10082,7 +10079,7 @@ export interface VideoCodecSettings {
 
 export namespace VideoCodecSettings {
   export function isa(o: any): o is VideoCodecSettings {
-    return _smithy.isa(o, "VideoCodecSettings");
+    return __isa(o, "VideoCodecSettings");
   }
 }
 
@@ -10129,7 +10126,7 @@ export interface VideoDescription {
 
 export namespace VideoDescription {
   export function isa(o: any): o is VideoDescription {
-    return _smithy.isa(o, "VideoDescription");
+    return __isa(o, "VideoDescription");
   }
 }
 
@@ -10167,7 +10164,7 @@ export interface VideoSelector {
 
 export namespace VideoSelector {
   export function isa(o: any): o is VideoSelector {
-    return _smithy.isa(o, "VideoSelector");
+    return __isa(o, "VideoSelector");
   }
 }
 
@@ -10195,7 +10192,7 @@ export interface VideoSelectorPid {
 
 export namespace VideoSelectorPid {
   export function isa(o: any): o is VideoSelectorPid {
-    return _smithy.isa(o, "VideoSelectorPid");
+    return __isa(o, "VideoSelectorPid");
   }
 }
 
@@ -10212,7 +10209,7 @@ export interface VideoSelectorProgramId {
 
 export namespace VideoSelectorProgramId {
   export function isa(o: any): o is VideoSelectorProgramId {
-    return _smithy.isa(o, "VideoSelectorProgramId");
+    return __isa(o, "VideoSelectorProgramId");
   }
 }
 
@@ -10234,7 +10231,7 @@ export interface VideoSelectorSettings {
 
 export namespace VideoSelectorSettings {
   export function isa(o: any): o is VideoSelectorSettings {
-    return _smithy.isa(o, "VideoSelectorSettings");
+    return __isa(o, "VideoSelectorSettings");
   }
 }
 
@@ -10247,6 +10244,6 @@ export interface WebvttDestinationSettings {
 
 export namespace WebvttDestinationSettings {
   export function isa(o: any): o is WebvttDestinationSettings {
-    return _smithy.isa(o, "WebvttDestinationSettings");
+    return __isa(o, "WebvttDestinationSettings");
   }
 }

--- a/clients/client-medialive/protocols/Aws_restJson1_1.ts
+++ b/clients/client-medialive/protocols/Aws_restJson1_1.ts
@@ -360,7 +360,10 @@ import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  extendedEncodeURIComponent as __extendedEncodeURIComponent
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -377,13 +380,13 @@ export async function serializeAws_restJson1_1BatchUpdateScheduleCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/prod/channels/{ChannelId}/schedule";
   if (input.ChannelId !== undefined) {
-    const labelValue: string = input.ChannelId.toString();
+    const labelValue: string = input.ChannelId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ChannelId.");
     }
     resolvedPath = resolvedPath.replace(
       "{ChannelId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ChannelId.");
@@ -648,7 +651,7 @@ export async function serializeAws_restJson1_1CreateMultiplexProgramCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/prod/multiplexes/{MultiplexId}/programs";
   if (input.MultiplexId !== undefined) {
-    const labelValue: string = input.MultiplexId.toString();
+    const labelValue: string = input.MultiplexId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: MultiplexId."
@@ -656,7 +659,7 @@ export async function serializeAws_restJson1_1CreateMultiplexProgramCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{MultiplexId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: MultiplexId.");
@@ -699,7 +702,7 @@ export async function serializeAws_restJson1_1CreateTagsCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/prod/tags/{ResourceArn}";
   if (input.ResourceArn !== undefined) {
-    const labelValue: string = input.ResourceArn.toString();
+    const labelValue: string = input.ResourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ResourceArn."
@@ -707,7 +710,7 @@ export async function serializeAws_restJson1_1CreateTagsCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ResourceArn.");
@@ -736,13 +739,13 @@ export async function serializeAws_restJson1_1DeleteChannelCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/prod/channels/{ChannelId}";
   if (input.ChannelId !== undefined) {
-    const labelValue: string = input.ChannelId.toString();
+    const labelValue: string = input.ChannelId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ChannelId.");
     }
     resolvedPath = resolvedPath.replace(
       "{ChannelId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ChannelId.");
@@ -764,13 +767,13 @@ export async function serializeAws_restJson1_1DeleteInputCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/prod/inputs/{InputId}";
   if (input.InputId !== undefined) {
-    const labelValue: string = input.InputId.toString();
+    const labelValue: string = input.InputId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: InputId.");
     }
     resolvedPath = resolvedPath.replace(
       "{InputId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: InputId.");
@@ -792,7 +795,7 @@ export async function serializeAws_restJson1_1DeleteInputSecurityGroupCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/prod/inputSecurityGroups/{InputSecurityGroupId}";
   if (input.InputSecurityGroupId !== undefined) {
-    const labelValue: string = input.InputSecurityGroupId.toString();
+    const labelValue: string = input.InputSecurityGroupId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: InputSecurityGroupId."
@@ -800,7 +803,7 @@ export async function serializeAws_restJson1_1DeleteInputSecurityGroupCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{InputSecurityGroupId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -824,7 +827,7 @@ export async function serializeAws_restJson1_1DeleteMultiplexCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/prod/multiplexes/{MultiplexId}";
   if (input.MultiplexId !== undefined) {
-    const labelValue: string = input.MultiplexId.toString();
+    const labelValue: string = input.MultiplexId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: MultiplexId."
@@ -832,7 +835,7 @@ export async function serializeAws_restJson1_1DeleteMultiplexCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{MultiplexId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: MultiplexId.");
@@ -854,7 +857,7 @@ export async function serializeAws_restJson1_1DeleteMultiplexProgramCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/prod/multiplexes/{MultiplexId}/programs/{ProgramName}";
   if (input.MultiplexId !== undefined) {
-    const labelValue: string = input.MultiplexId.toString();
+    const labelValue: string = input.MultiplexId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: MultiplexId."
@@ -862,13 +865,13 @@ export async function serializeAws_restJson1_1DeleteMultiplexProgramCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{MultiplexId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: MultiplexId.");
   }
   if (input.ProgramName !== undefined) {
-    const labelValue: string = input.ProgramName.toString();
+    const labelValue: string = input.ProgramName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ProgramName."
@@ -876,7 +879,7 @@ export async function serializeAws_restJson1_1DeleteMultiplexProgramCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ProgramName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ProgramName.");
@@ -898,7 +901,7 @@ export async function serializeAws_restJson1_1DeleteReservationCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/prod/reservations/{ReservationId}";
   if (input.ReservationId !== undefined) {
-    const labelValue: string = input.ReservationId.toString();
+    const labelValue: string = input.ReservationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ReservationId."
@@ -906,7 +909,7 @@ export async function serializeAws_restJson1_1DeleteReservationCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ReservationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ReservationId.");
@@ -928,13 +931,13 @@ export async function serializeAws_restJson1_1DeleteScheduleCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/prod/channels/{ChannelId}/schedule";
   if (input.ChannelId !== undefined) {
-    const labelValue: string = input.ChannelId.toString();
+    const labelValue: string = input.ChannelId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ChannelId.");
     }
     resolvedPath = resolvedPath.replace(
       "{ChannelId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ChannelId.");
@@ -956,7 +959,7 @@ export async function serializeAws_restJson1_1DeleteTagsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/prod/tags/{ResourceArn}";
   if (input.ResourceArn !== undefined) {
-    const labelValue: string = input.ResourceArn.toString();
+    const labelValue: string = input.ResourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ResourceArn."
@@ -964,14 +967,16 @@ export async function serializeAws_restJson1_1DeleteTagsCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ResourceArn.");
   }
   const query: any = {};
   if (input.TagKeys !== undefined) {
-    query["tagKeys"] = input.TagKeys;
+    query[__extendedEncodeURIComponent("tagKeys")] = input.TagKeys.map(entry =>
+      __extendedEncodeURIComponent(entry)
+    );
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -991,13 +996,13 @@ export async function serializeAws_restJson1_1DescribeChannelCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/prod/channels/{ChannelId}";
   if (input.ChannelId !== undefined) {
-    const labelValue: string = input.ChannelId.toString();
+    const labelValue: string = input.ChannelId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ChannelId.");
     }
     resolvedPath = resolvedPath.replace(
       "{ChannelId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ChannelId.");
@@ -1019,13 +1024,13 @@ export async function serializeAws_restJson1_1DescribeInputCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/prod/inputs/{InputId}";
   if (input.InputId !== undefined) {
-    const labelValue: string = input.InputId.toString();
+    const labelValue: string = input.InputId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: InputId.");
     }
     resolvedPath = resolvedPath.replace(
       "{InputId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: InputId.");
@@ -1047,7 +1052,7 @@ export async function serializeAws_restJson1_1DescribeInputSecurityGroupCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/prod/inputSecurityGroups/{InputSecurityGroupId}";
   if (input.InputSecurityGroupId !== undefined) {
-    const labelValue: string = input.InputSecurityGroupId.toString();
+    const labelValue: string = input.InputSecurityGroupId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: InputSecurityGroupId."
@@ -1055,7 +1060,7 @@ export async function serializeAws_restJson1_1DescribeInputSecurityGroupCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{InputSecurityGroupId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -1079,7 +1084,7 @@ export async function serializeAws_restJson1_1DescribeMultiplexCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/prod/multiplexes/{MultiplexId}";
   if (input.MultiplexId !== undefined) {
-    const labelValue: string = input.MultiplexId.toString();
+    const labelValue: string = input.MultiplexId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: MultiplexId."
@@ -1087,7 +1092,7 @@ export async function serializeAws_restJson1_1DescribeMultiplexCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{MultiplexId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: MultiplexId.");
@@ -1109,7 +1114,7 @@ export async function serializeAws_restJson1_1DescribeMultiplexProgramCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/prod/multiplexes/{MultiplexId}/programs/{ProgramName}";
   if (input.MultiplexId !== undefined) {
-    const labelValue: string = input.MultiplexId.toString();
+    const labelValue: string = input.MultiplexId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: MultiplexId."
@@ -1117,13 +1122,13 @@ export async function serializeAws_restJson1_1DescribeMultiplexProgramCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{MultiplexId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: MultiplexId.");
   }
   if (input.ProgramName !== undefined) {
-    const labelValue: string = input.ProgramName.toString();
+    const labelValue: string = input.ProgramName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ProgramName."
@@ -1131,7 +1136,7 @@ export async function serializeAws_restJson1_1DescribeMultiplexProgramCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ProgramName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ProgramName.");
@@ -1153,13 +1158,13 @@ export async function serializeAws_restJson1_1DescribeOfferingCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/prod/offerings/{OfferingId}";
   if (input.OfferingId !== undefined) {
-    const labelValue: string = input.OfferingId.toString();
+    const labelValue: string = input.OfferingId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: OfferingId.");
     }
     resolvedPath = resolvedPath.replace(
       "{OfferingId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: OfferingId.");
@@ -1181,7 +1186,7 @@ export async function serializeAws_restJson1_1DescribeReservationCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/prod/reservations/{ReservationId}";
   if (input.ReservationId !== undefined) {
-    const labelValue: string = input.ReservationId.toString();
+    const labelValue: string = input.ReservationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ReservationId."
@@ -1189,7 +1194,7 @@ export async function serializeAws_restJson1_1DescribeReservationCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ReservationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ReservationId.");
@@ -1211,23 +1216,27 @@ export async function serializeAws_restJson1_1DescribeScheduleCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/prod/channels/{ChannelId}/schedule";
   if (input.ChannelId !== undefined) {
-    const labelValue: string = input.ChannelId.toString();
+    const labelValue: string = input.ChannelId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ChannelId.");
     }
     resolvedPath = resolvedPath.replace(
       "{ChannelId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ChannelId.");
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1248,10 +1257,14 @@ export async function serializeAws_restJson1_1ListChannelsCommand(
   let resolvedPath = "/prod/channels";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1272,10 +1285,14 @@ export async function serializeAws_restJson1_1ListInputSecurityGroupsCommand(
   let resolvedPath = "/prod/inputSecurityGroups";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1296,10 +1313,14 @@ export async function serializeAws_restJson1_1ListInputsCommand(
   let resolvedPath = "/prod/inputs";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1319,7 +1340,7 @@ export async function serializeAws_restJson1_1ListMultiplexProgramsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/prod/multiplexes/{MultiplexId}/programs";
   if (input.MultiplexId !== undefined) {
-    const labelValue: string = input.MultiplexId.toString();
+    const labelValue: string = input.MultiplexId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: MultiplexId."
@@ -1327,17 +1348,21 @@ export async function serializeAws_restJson1_1ListMultiplexProgramsCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{MultiplexId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: MultiplexId.");
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1358,10 +1383,14 @@ export async function serializeAws_restJson1_1ListMultiplexesCommand(
   let resolvedPath = "/prod/multiplexes";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1382,40 +1411,64 @@ export async function serializeAws_restJson1_1ListOfferingsCommand(
   let resolvedPath = "/prod/offerings";
   const query: any = {};
   if (input.ChannelClass !== undefined) {
-    query["channelClass"] = input.ChannelClass.toString();
+    query[
+      __extendedEncodeURIComponent("channelClass")
+    ] = __extendedEncodeURIComponent(input.ChannelClass);
   }
   if (input.ChannelConfiguration !== undefined) {
-    query["channelConfiguration"] = input.ChannelConfiguration.toString();
+    query[
+      __extendedEncodeURIComponent("channelConfiguration")
+    ] = __extendedEncodeURIComponent(input.ChannelConfiguration);
   }
   if (input.Codec !== undefined) {
-    query["codec"] = input.Codec.toString();
+    query[__extendedEncodeURIComponent("codec")] = __extendedEncodeURIComponent(
+      input.Codec
+    );
   }
   if (input.Duration !== undefined) {
-    query["duration"] = input.Duration.toString();
+    query[
+      __extendedEncodeURIComponent("duration")
+    ] = __extendedEncodeURIComponent(input.Duration);
   }
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.MaximumBitrate !== undefined) {
-    query["maximumBitrate"] = input.MaximumBitrate.toString();
+    query[
+      __extendedEncodeURIComponent("maximumBitrate")
+    ] = __extendedEncodeURIComponent(input.MaximumBitrate);
   }
   if (input.MaximumFramerate !== undefined) {
-    query["maximumFramerate"] = input.MaximumFramerate.toString();
+    query[
+      __extendedEncodeURIComponent("maximumFramerate")
+    ] = __extendedEncodeURIComponent(input.MaximumFramerate);
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   if (input.Resolution !== undefined) {
-    query["resolution"] = input.Resolution.toString();
+    query[
+      __extendedEncodeURIComponent("resolution")
+    ] = __extendedEncodeURIComponent(input.Resolution);
   }
   if (input.ResourceType !== undefined) {
-    query["resourceType"] = input.ResourceType.toString();
+    query[
+      __extendedEncodeURIComponent("resourceType")
+    ] = __extendedEncodeURIComponent(input.ResourceType);
   }
   if (input.SpecialFeature !== undefined) {
-    query["specialFeature"] = input.SpecialFeature.toString();
+    query[
+      __extendedEncodeURIComponent("specialFeature")
+    ] = __extendedEncodeURIComponent(input.SpecialFeature);
   }
   if (input.VideoQuality !== undefined) {
-    query["videoQuality"] = input.VideoQuality.toString();
+    query[
+      __extendedEncodeURIComponent("videoQuality")
+    ] = __extendedEncodeURIComponent(input.VideoQuality);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1436,34 +1489,54 @@ export async function serializeAws_restJson1_1ListReservationsCommand(
   let resolvedPath = "/prod/reservations";
   const query: any = {};
   if (input.ChannelClass !== undefined) {
-    query["channelClass"] = input.ChannelClass.toString();
+    query[
+      __extendedEncodeURIComponent("channelClass")
+    ] = __extendedEncodeURIComponent(input.ChannelClass);
   }
   if (input.Codec !== undefined) {
-    query["codec"] = input.Codec.toString();
+    query[__extendedEncodeURIComponent("codec")] = __extendedEncodeURIComponent(
+      input.Codec
+    );
   }
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.MaximumBitrate !== undefined) {
-    query["maximumBitrate"] = input.MaximumBitrate.toString();
+    query[
+      __extendedEncodeURIComponent("maximumBitrate")
+    ] = __extendedEncodeURIComponent(input.MaximumBitrate);
   }
   if (input.MaximumFramerate !== undefined) {
-    query["maximumFramerate"] = input.MaximumFramerate.toString();
+    query[
+      __extendedEncodeURIComponent("maximumFramerate")
+    ] = __extendedEncodeURIComponent(input.MaximumFramerate);
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   if (input.Resolution !== undefined) {
-    query["resolution"] = input.Resolution.toString();
+    query[
+      __extendedEncodeURIComponent("resolution")
+    ] = __extendedEncodeURIComponent(input.Resolution);
   }
   if (input.ResourceType !== undefined) {
-    query["resourceType"] = input.ResourceType.toString();
+    query[
+      __extendedEncodeURIComponent("resourceType")
+    ] = __extendedEncodeURIComponent(input.ResourceType);
   }
   if (input.SpecialFeature !== undefined) {
-    query["specialFeature"] = input.SpecialFeature.toString();
+    query[
+      __extendedEncodeURIComponent("specialFeature")
+    ] = __extendedEncodeURIComponent(input.SpecialFeature);
   }
   if (input.VideoQuality !== undefined) {
-    query["videoQuality"] = input.VideoQuality.toString();
+    query[
+      __extendedEncodeURIComponent("videoQuality")
+    ] = __extendedEncodeURIComponent(input.VideoQuality);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1483,7 +1556,7 @@ export async function serializeAws_restJson1_1ListTagsForResourceCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/prod/tags/{ResourceArn}";
   if (input.ResourceArn !== undefined) {
-    const labelValue: string = input.ResourceArn.toString();
+    const labelValue: string = input.ResourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ResourceArn."
@@ -1491,7 +1564,7 @@ export async function serializeAws_restJson1_1ListTagsForResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ResourceArn.");
@@ -1513,13 +1586,13 @@ export async function serializeAws_restJson1_1PurchaseOfferingCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/prod/offerings/{OfferingId}/purchase";
   if (input.OfferingId !== undefined) {
-    const labelValue: string = input.OfferingId.toString();
+    const labelValue: string = input.OfferingId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: OfferingId.");
     }
     resolvedPath = resolvedPath.replace(
       "{OfferingId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: OfferingId.");
@@ -1563,13 +1636,13 @@ export async function serializeAws_restJson1_1StartChannelCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/prod/channels/{ChannelId}/start";
   if (input.ChannelId !== undefined) {
-    const labelValue: string = input.ChannelId.toString();
+    const labelValue: string = input.ChannelId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ChannelId.");
     }
     resolvedPath = resolvedPath.replace(
       "{ChannelId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ChannelId.");
@@ -1591,7 +1664,7 @@ export async function serializeAws_restJson1_1StartMultiplexCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/prod/multiplexes/{MultiplexId}/start";
   if (input.MultiplexId !== undefined) {
-    const labelValue: string = input.MultiplexId.toString();
+    const labelValue: string = input.MultiplexId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: MultiplexId."
@@ -1599,7 +1672,7 @@ export async function serializeAws_restJson1_1StartMultiplexCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{MultiplexId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: MultiplexId.");
@@ -1621,13 +1694,13 @@ export async function serializeAws_restJson1_1StopChannelCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/prod/channels/{ChannelId}/stop";
   if (input.ChannelId !== undefined) {
-    const labelValue: string = input.ChannelId.toString();
+    const labelValue: string = input.ChannelId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ChannelId.");
     }
     resolvedPath = resolvedPath.replace(
       "{ChannelId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ChannelId.");
@@ -1649,7 +1722,7 @@ export async function serializeAws_restJson1_1StopMultiplexCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/prod/multiplexes/{MultiplexId}/stop";
   if (input.MultiplexId !== undefined) {
-    const labelValue: string = input.MultiplexId.toString();
+    const labelValue: string = input.MultiplexId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: MultiplexId."
@@ -1657,7 +1730,7 @@ export async function serializeAws_restJson1_1StopMultiplexCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{MultiplexId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: MultiplexId.");
@@ -1679,13 +1752,13 @@ export async function serializeAws_restJson1_1UpdateChannelCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/prod/channels/{ChannelId}";
   if (input.ChannelId !== undefined) {
-    const labelValue: string = input.ChannelId.toString();
+    const labelValue: string = input.ChannelId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ChannelId.");
     }
     resolvedPath = resolvedPath.replace(
       "{ChannelId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ChannelId.");
@@ -1750,13 +1823,13 @@ export async function serializeAws_restJson1_1UpdateChannelClassCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/prod/channels/{ChannelId}/channelClass";
   if (input.ChannelId !== undefined) {
-    const labelValue: string = input.ChannelId.toString();
+    const labelValue: string = input.ChannelId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ChannelId.");
     }
     resolvedPath = resolvedPath.replace(
       "{ChannelId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ChannelId.");
@@ -1793,13 +1866,13 @@ export async function serializeAws_restJson1_1UpdateInputCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/prod/inputs/{InputId}";
   if (input.InputId !== undefined) {
-    const labelValue: string = input.InputId.toString();
+    const labelValue: string = input.InputId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: InputId.");
     }
     resolvedPath = resolvedPath.replace(
       "{InputId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: InputId.");
@@ -1861,7 +1934,7 @@ export async function serializeAws_restJson1_1UpdateInputSecurityGroupCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/prod/inputSecurityGroups/{InputSecurityGroupId}";
   if (input.InputSecurityGroupId !== undefined) {
-    const labelValue: string = input.InputSecurityGroupId.toString();
+    const labelValue: string = input.InputSecurityGroupId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: InputSecurityGroupId."
@@ -1869,7 +1942,7 @@ export async function serializeAws_restJson1_1UpdateInputSecurityGroupCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{InputSecurityGroupId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -1908,7 +1981,7 @@ export async function serializeAws_restJson1_1UpdateMultiplexCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/prod/multiplexes/{MultiplexId}";
   if (input.MultiplexId !== undefined) {
-    const labelValue: string = input.MultiplexId.toString();
+    const labelValue: string = input.MultiplexId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: MultiplexId."
@@ -1916,7 +1989,7 @@ export async function serializeAws_restJson1_1UpdateMultiplexCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{MultiplexId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: MultiplexId.");
@@ -1951,7 +2024,7 @@ export async function serializeAws_restJson1_1UpdateMultiplexProgramCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/prod/multiplexes/{MultiplexId}/programs/{ProgramName}";
   if (input.MultiplexId !== undefined) {
-    const labelValue: string = input.MultiplexId.toString();
+    const labelValue: string = input.MultiplexId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: MultiplexId."
@@ -1959,13 +2032,13 @@ export async function serializeAws_restJson1_1UpdateMultiplexProgramCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{MultiplexId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: MultiplexId.");
   }
   if (input.ProgramName !== undefined) {
-    const labelValue: string = input.ProgramName.toString();
+    const labelValue: string = input.ProgramName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ProgramName."
@@ -1973,7 +2046,7 @@ export async function serializeAws_restJson1_1UpdateMultiplexProgramCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ProgramName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ProgramName.");
@@ -2007,7 +2080,7 @@ export async function serializeAws_restJson1_1UpdateReservationCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/prod/reservations/{ReservationId}";
   if (input.ReservationId !== undefined) {
-    const labelValue: string = input.ReservationId.toString();
+    const labelValue: string = input.ReservationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ReservationId."
@@ -2015,7 +2088,7 @@ export async function serializeAws_restJson1_1UpdateReservationCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ReservationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ReservationId.");
@@ -2661,6 +2734,7 @@ export async function deserializeAws_restJson1_1CreateTagsCommand(
   const contents: CreateTagsCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2912,6 +2986,7 @@ export async function deserializeAws_restJson1_1DeleteInputCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeleteInputResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -3012,6 +3087,7 @@ export async function deserializeAws_restJson1_1DeleteInputSecurityGroupCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeleteInputSecurityGroupResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -3569,6 +3645,7 @@ export async function deserializeAws_restJson1_1DeleteScheduleCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeleteScheduleResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -3658,6 +3735,7 @@ export async function deserializeAws_restJson1_1DeleteTagsCommand(
   const contents: DeleteTagsCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 

--- a/clients/client-mediapackage-vod/models/index.ts
+++ b/clients/client-mediapackage-vod/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export enum AdMarkers {
@@ -50,7 +53,7 @@ export interface AssetShallow {
 
 export namespace AssetShallow {
   export function isa(o: any): o is AssetShallow {
-    return _smithy.isa(o, "AssetShallow");
+    return __isa(o, "AssetShallow");
   }
 }
 
@@ -67,7 +70,7 @@ export interface CmafEncryption {
 
 export namespace CmafEncryption {
   export function isa(o: any): o is CmafEncryption {
-    return _smithy.isa(o, "CmafEncryption");
+    return __isa(o, "CmafEncryption");
   }
 }
 
@@ -95,7 +98,7 @@ export interface CmafPackage {
 
 export namespace CmafPackage {
   export function isa(o: any): o is CmafPackage {
-    return _smithy.isa(o, "CmafPackage");
+    return __isa(o, "CmafPackage");
   }
 }
 
@@ -132,7 +135,7 @@ export interface CreateAssetRequest {
 
 export namespace CreateAssetRequest {
   export function isa(o: any): o is CreateAssetRequest {
-    return _smithy.isa(o, "CreateAssetRequest");
+    return __isa(o, "CreateAssetRequest");
   }
 }
 
@@ -181,7 +184,7 @@ export interface CreateAssetResponse extends $MetadataBearer {
 
 export namespace CreateAssetResponse {
   export function isa(o: any): o is CreateAssetResponse {
-    return _smithy.isa(o, "CreateAssetResponse");
+    return __isa(o, "CreateAssetResponse");
   }
 }
 
@@ -223,7 +226,7 @@ export interface CreatePackagingConfigurationRequest {
 
 export namespace CreatePackagingConfigurationRequest {
   export function isa(o: any): o is CreatePackagingConfigurationRequest {
-    return _smithy.isa(o, "CreatePackagingConfigurationRequest");
+    return __isa(o, "CreatePackagingConfigurationRequest");
   }
 }
 
@@ -267,7 +270,7 @@ export interface CreatePackagingConfigurationResponse extends $MetadataBearer {
 
 export namespace CreatePackagingConfigurationResponse {
   export function isa(o: any): o is CreatePackagingConfigurationResponse {
-    return _smithy.isa(o, "CreatePackagingConfigurationResponse");
+    return __isa(o, "CreatePackagingConfigurationResponse");
   }
 }
 
@@ -284,7 +287,7 @@ export interface CreatePackagingGroupRequest {
 
 export namespace CreatePackagingGroupRequest {
   export function isa(o: any): o is CreatePackagingGroupRequest {
-    return _smithy.isa(o, "CreatePackagingGroupRequest");
+    return __isa(o, "CreatePackagingGroupRequest");
   }
 }
 
@@ -308,7 +311,7 @@ export interface CreatePackagingGroupResponse extends $MetadataBearer {
 
 export namespace CreatePackagingGroupResponse {
   export function isa(o: any): o is CreatePackagingGroupResponse {
-    return _smithy.isa(o, "CreatePackagingGroupResponse");
+    return __isa(o, "CreatePackagingGroupResponse");
   }
 }
 
@@ -325,7 +328,7 @@ export interface DashEncryption {
 
 export namespace DashEncryption {
   export function isa(o: any): o is DashEncryption {
-    return _smithy.isa(o, "DashEncryption");
+    return __isa(o, "DashEncryption");
   }
 }
 
@@ -357,7 +360,7 @@ export interface DashManifest {
 
 export namespace DashManifest {
   export function isa(o: any): o is DashManifest {
-    return _smithy.isa(o, "DashManifest");
+    return __isa(o, "DashManifest");
   }
 }
 
@@ -385,7 +388,7 @@ export interface DashPackage {
 
 export namespace DashPackage {
   export function isa(o: any): o is DashPackage {
-    return _smithy.isa(o, "DashPackage");
+    return __isa(o, "DashPackage");
   }
 }
 
@@ -399,7 +402,7 @@ export interface DeleteAssetRequest {
 
 export namespace DeleteAssetRequest {
   export function isa(o: any): o is DeleteAssetRequest {
-    return _smithy.isa(o, "DeleteAssetRequest");
+    return __isa(o, "DeleteAssetRequest");
   }
 }
 
@@ -409,7 +412,7 @@ export interface DeleteAssetResponse extends $MetadataBearer {
 
 export namespace DeleteAssetResponse {
   export function isa(o: any): o is DeleteAssetResponse {
-    return _smithy.isa(o, "DeleteAssetResponse");
+    return __isa(o, "DeleteAssetResponse");
   }
 }
 
@@ -423,7 +426,7 @@ export interface DeletePackagingConfigurationRequest {
 
 export namespace DeletePackagingConfigurationRequest {
   export function isa(o: any): o is DeletePackagingConfigurationRequest {
-    return _smithy.isa(o, "DeletePackagingConfigurationRequest");
+    return __isa(o, "DeletePackagingConfigurationRequest");
   }
 }
 
@@ -433,7 +436,7 @@ export interface DeletePackagingConfigurationResponse extends $MetadataBearer {
 
 export namespace DeletePackagingConfigurationResponse {
   export function isa(o: any): o is DeletePackagingConfigurationResponse {
-    return _smithy.isa(o, "DeletePackagingConfigurationResponse");
+    return __isa(o, "DeletePackagingConfigurationResponse");
   }
 }
 
@@ -447,7 +450,7 @@ export interface DeletePackagingGroupRequest {
 
 export namespace DeletePackagingGroupRequest {
   export function isa(o: any): o is DeletePackagingGroupRequest {
-    return _smithy.isa(o, "DeletePackagingGroupRequest");
+    return __isa(o, "DeletePackagingGroupRequest");
   }
 }
 
@@ -457,7 +460,7 @@ export interface DeletePackagingGroupResponse extends $MetadataBearer {
 
 export namespace DeletePackagingGroupResponse {
   export function isa(o: any): o is DeletePackagingGroupResponse {
-    return _smithy.isa(o, "DeletePackagingGroupResponse");
+    return __isa(o, "DeletePackagingGroupResponse");
   }
 }
 
@@ -471,7 +474,7 @@ export interface DescribeAssetRequest {
 
 export namespace DescribeAssetRequest {
   export function isa(o: any): o is DescribeAssetRequest {
-    return _smithy.isa(o, "DescribeAssetRequest");
+    return __isa(o, "DescribeAssetRequest");
   }
 }
 
@@ -520,7 +523,7 @@ export interface DescribeAssetResponse extends $MetadataBearer {
 
 export namespace DescribeAssetResponse {
   export function isa(o: any): o is DescribeAssetResponse {
-    return _smithy.isa(o, "DescribeAssetResponse");
+    return __isa(o, "DescribeAssetResponse");
   }
 }
 
@@ -534,7 +537,7 @@ export interface DescribePackagingConfigurationRequest {
 
 export namespace DescribePackagingConfigurationRequest {
   export function isa(o: any): o is DescribePackagingConfigurationRequest {
-    return _smithy.isa(o, "DescribePackagingConfigurationRequest");
+    return __isa(o, "DescribePackagingConfigurationRequest");
   }
 }
 
@@ -579,7 +582,7 @@ export interface DescribePackagingConfigurationResponse
 
 export namespace DescribePackagingConfigurationResponse {
   export function isa(o: any): o is DescribePackagingConfigurationResponse {
-    return _smithy.isa(o, "DescribePackagingConfigurationResponse");
+    return __isa(o, "DescribePackagingConfigurationResponse");
   }
 }
 
@@ -593,7 +596,7 @@ export interface DescribePackagingGroupRequest {
 
 export namespace DescribePackagingGroupRequest {
   export function isa(o: any): o is DescribePackagingGroupRequest {
-    return _smithy.isa(o, "DescribePackagingGroupRequest");
+    return __isa(o, "DescribePackagingGroupRequest");
   }
 }
 
@@ -617,7 +620,7 @@ export interface DescribePackagingGroupResponse extends $MetadataBearer {
 
 export namespace DescribePackagingGroupResponse {
   export function isa(o: any): o is DescribePackagingGroupResponse {
-    return _smithy.isa(o, "DescribePackagingGroupResponse");
+    return __isa(o, "DescribePackagingGroupResponse");
   }
 }
 
@@ -639,7 +642,7 @@ export interface EgressEndpoint {
 
 export namespace EgressEndpoint {
   export function isa(o: any): o is EgressEndpoint {
-    return _smithy.isa(o, "EgressEndpoint");
+    return __isa(o, "EgressEndpoint");
   }
 }
 
@@ -651,9 +654,7 @@ export enum EncryptionMethod {
 /**
  * The client is not authorized to access the requested resource.
  */
-export interface ForbiddenException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface ForbiddenException extends __SmithyException, $MetadataBearer {
   name: "ForbiddenException";
   $fault: "client";
   Message?: string;
@@ -661,7 +662,7 @@ export interface ForbiddenException
 
 export namespace ForbiddenException {
   export function isa(o: any): o is ForbiddenException {
-    return _smithy.isa(o, "ForbiddenException");
+    return __isa(o, "ForbiddenException");
   }
 }
 
@@ -689,7 +690,7 @@ export interface HlsEncryption {
 
 export namespace HlsEncryption {
   export function isa(o: any): o is HlsEncryption {
-    return _smithy.isa(o, "HlsEncryption");
+    return __isa(o, "HlsEncryption");
   }
 }
 
@@ -744,7 +745,7 @@ export interface HlsManifest {
 
 export namespace HlsManifest {
   export function isa(o: any): o is HlsManifest {
-    return _smithy.isa(o, "HlsManifest");
+    return __isa(o, "HlsManifest");
   }
 }
 
@@ -777,7 +778,7 @@ export interface HlsPackage {
 
 export namespace HlsPackage {
   export function isa(o: any): o is HlsPackage {
-    return _smithy.isa(o, "HlsPackage");
+    return __isa(o, "HlsPackage");
   }
 }
 
@@ -785,7 +786,7 @@ export namespace HlsPackage {
  * An unexpected error occurred.
  */
 export interface InternalServerErrorException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalServerErrorException";
   $fault: "server";
@@ -794,7 +795,7 @@ export interface InternalServerErrorException
 
 export namespace InternalServerErrorException {
   export function isa(o: any): o is InternalServerErrorException {
-    return _smithy.isa(o, "InternalServerErrorException");
+    return __isa(o, "InternalServerErrorException");
   }
 }
 
@@ -818,7 +819,7 @@ export interface ListAssetsRequest {
 
 export namespace ListAssetsRequest {
   export function isa(o: any): o is ListAssetsRequest {
-    return _smithy.isa(o, "ListAssetsRequest");
+    return __isa(o, "ListAssetsRequest");
   }
 }
 
@@ -837,7 +838,7 @@ export interface ListAssetsResponse extends $MetadataBearer {
 
 export namespace ListAssetsResponse {
   export function isa(o: any): o is ListAssetsResponse {
-    return _smithy.isa(o, "ListAssetsResponse");
+    return __isa(o, "ListAssetsResponse");
   }
 }
 
@@ -861,7 +862,7 @@ export interface ListPackagingConfigurationsRequest {
 
 export namespace ListPackagingConfigurationsRequest {
   export function isa(o: any): o is ListPackagingConfigurationsRequest {
-    return _smithy.isa(o, "ListPackagingConfigurationsRequest");
+    return __isa(o, "ListPackagingConfigurationsRequest");
   }
 }
 
@@ -880,7 +881,7 @@ export interface ListPackagingConfigurationsResponse extends $MetadataBearer {
 
 export namespace ListPackagingConfigurationsResponse {
   export function isa(o: any): o is ListPackagingConfigurationsResponse {
-    return _smithy.isa(o, "ListPackagingConfigurationsResponse");
+    return __isa(o, "ListPackagingConfigurationsResponse");
   }
 }
 
@@ -899,7 +900,7 @@ export interface ListPackagingGroupsRequest {
 
 export namespace ListPackagingGroupsRequest {
   export function isa(o: any): o is ListPackagingGroupsRequest {
-    return _smithy.isa(o, "ListPackagingGroupsRequest");
+    return __isa(o, "ListPackagingGroupsRequest");
   }
 }
 
@@ -918,7 +919,7 @@ export interface ListPackagingGroupsResponse extends $MetadataBearer {
 
 export namespace ListPackagingGroupsResponse {
   export function isa(o: any): o is ListPackagingGroupsResponse {
-    return _smithy.isa(o, "ListPackagingGroupsResponse");
+    return __isa(o, "ListPackagingGroupsResponse");
   }
 }
 
@@ -935,7 +936,7 @@ export interface MssEncryption {
 
 export namespace MssEncryption {
   export function isa(o: any): o is MssEncryption {
-    return _smithy.isa(o, "MssEncryption");
+    return __isa(o, "MssEncryption");
   }
 }
 
@@ -957,7 +958,7 @@ export interface MssManifest {
 
 export namespace MssManifest {
   export function isa(o: any): o is MssManifest {
-    return _smithy.isa(o, "MssManifest");
+    return __isa(o, "MssManifest");
   }
 }
 
@@ -984,16 +985,14 @@ export interface MssPackage {
 
 export namespace MssPackage {
   export function isa(o: any): o is MssPackage {
-    return _smithy.isa(o, "MssPackage");
+    return __isa(o, "MssPackage");
   }
 }
 
 /**
  * The requested resource does not exist.
  */
-export interface NotFoundException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface NotFoundException extends __SmithyException, $MetadataBearer {
   name: "NotFoundException";
   $fault: "client";
   Message?: string;
@@ -1001,7 +1000,7 @@ export interface NotFoundException
 
 export namespace NotFoundException {
   export function isa(o: any): o is NotFoundException {
-    return _smithy.isa(o, "NotFoundException");
+    return __isa(o, "NotFoundException");
   }
 }
 
@@ -1048,7 +1047,7 @@ export interface PackagingConfiguration {
 
 export namespace PackagingConfiguration {
   export function isa(o: any): o is PackagingConfiguration {
-    return _smithy.isa(o, "PackagingConfiguration");
+    return __isa(o, "PackagingConfiguration");
   }
 }
 
@@ -1075,7 +1074,7 @@ export interface PackagingGroup {
 
 export namespace PackagingGroup {
   export function isa(o: any): o is PackagingGroup {
-    return _smithy.isa(o, "PackagingGroup");
+    return __isa(o, "PackagingGroup");
   }
 }
 
@@ -1088,7 +1087,7 @@ export enum Profile {
  * An unexpected error occurred.
  */
 export interface ServiceUnavailableException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ServiceUnavailableException";
   $fault: "server";
@@ -1097,7 +1096,7 @@ export interface ServiceUnavailableException
 
 export namespace ServiceUnavailableException {
   export function isa(o: any): o is ServiceUnavailableException {
-    return _smithy.isa(o, "ServiceUnavailableException");
+    return __isa(o, "ServiceUnavailableException");
   }
 }
 
@@ -1125,7 +1124,7 @@ export interface SpekeKeyProvider {
 
 export namespace SpekeKeyProvider {
   export function isa(o: any): o is SpekeKeyProvider {
-    return _smithy.isa(o, "SpekeKeyProvider");
+    return __isa(o, "SpekeKeyProvider");
   }
 }
 
@@ -1158,7 +1157,7 @@ export interface StreamSelection {
 
 export namespace StreamSelection {
   export function isa(o: any): o is StreamSelection {
-    return _smithy.isa(o, "StreamSelection");
+    return __isa(o, "StreamSelection");
   }
 }
 
@@ -1166,7 +1165,7 @@ export namespace StreamSelection {
  * The client has exceeded their resource or throttling limits.
  */
 export interface TooManyRequestsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyRequestsException";
   $fault: "client";
@@ -1175,7 +1174,7 @@ export interface TooManyRequestsException
 
 export namespace TooManyRequestsException {
   export function isa(o: any): o is TooManyRequestsException {
-    return _smithy.isa(o, "TooManyRequestsException");
+    return __isa(o, "TooManyRequestsException");
   }
 }
 
@@ -1183,7 +1182,7 @@ export namespace TooManyRequestsException {
  * The parameters sent in the request are not valid.
  */
 export interface UnprocessableEntityException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UnprocessableEntityException";
   $fault: "client";
@@ -1192,6 +1191,6 @@ export interface UnprocessableEntityException
 
 export namespace UnprocessableEntityException {
   export function isa(o: any): o is UnprocessableEntityException {
-    return _smithy.isa(o, "UnprocessableEntityException");
+    return __isa(o, "UnprocessableEntityException");
   }
 }

--- a/clients/client-mediapackage-vod/protocols/Aws_restJson1_1.ts
+++ b/clients/client-mediapackage-vod/protocols/Aws_restJson1_1.ts
@@ -75,7 +75,10 @@ import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  extendedEncodeURIComponent as __extendedEncodeURIComponent
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -199,11 +202,14 @@ export async function serializeAws_restJson1_1DeleteAssetCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/assets/{Id}";
   if (input.Id !== undefined) {
-    const labelValue: string = input.Id.toString();
+    const labelValue: string = input.Id;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Id.");
     }
-    resolvedPath = resolvedPath.replace("{Id}", encodeURIComponent(labelValue));
+    resolvedPath = resolvedPath.replace(
+      "{Id}",
+      __extendedEncodeURIComponent(labelValue)
+    );
   } else {
     throw new Error("No value provided for input HTTP label: Id.");
   }
@@ -224,11 +230,14 @@ export async function serializeAws_restJson1_1DeletePackagingConfigurationComman
   headers["Content-Type"] = "";
   let resolvedPath = "/packaging_configurations/{Id}";
   if (input.Id !== undefined) {
-    const labelValue: string = input.Id.toString();
+    const labelValue: string = input.Id;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Id.");
     }
-    resolvedPath = resolvedPath.replace("{Id}", encodeURIComponent(labelValue));
+    resolvedPath = resolvedPath.replace(
+      "{Id}",
+      __extendedEncodeURIComponent(labelValue)
+    );
   } else {
     throw new Error("No value provided for input HTTP label: Id.");
   }
@@ -249,11 +258,14 @@ export async function serializeAws_restJson1_1DeletePackagingGroupCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/packaging_groups/{Id}";
   if (input.Id !== undefined) {
-    const labelValue: string = input.Id.toString();
+    const labelValue: string = input.Id;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Id.");
     }
-    resolvedPath = resolvedPath.replace("{Id}", encodeURIComponent(labelValue));
+    resolvedPath = resolvedPath.replace(
+      "{Id}",
+      __extendedEncodeURIComponent(labelValue)
+    );
   } else {
     throw new Error("No value provided for input HTTP label: Id.");
   }
@@ -274,11 +286,14 @@ export async function serializeAws_restJson1_1DescribeAssetCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/assets/{Id}";
   if (input.Id !== undefined) {
-    const labelValue: string = input.Id.toString();
+    const labelValue: string = input.Id;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Id.");
     }
-    resolvedPath = resolvedPath.replace("{Id}", encodeURIComponent(labelValue));
+    resolvedPath = resolvedPath.replace(
+      "{Id}",
+      __extendedEncodeURIComponent(labelValue)
+    );
   } else {
     throw new Error("No value provided for input HTTP label: Id.");
   }
@@ -299,11 +314,14 @@ export async function serializeAws_restJson1_1DescribePackagingConfigurationComm
   headers["Content-Type"] = "";
   let resolvedPath = "/packaging_configurations/{Id}";
   if (input.Id !== undefined) {
-    const labelValue: string = input.Id.toString();
+    const labelValue: string = input.Id;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Id.");
     }
-    resolvedPath = resolvedPath.replace("{Id}", encodeURIComponent(labelValue));
+    resolvedPath = resolvedPath.replace(
+      "{Id}",
+      __extendedEncodeURIComponent(labelValue)
+    );
   } else {
     throw new Error("No value provided for input HTTP label: Id.");
   }
@@ -324,11 +342,14 @@ export async function serializeAws_restJson1_1DescribePackagingGroupCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/packaging_groups/{Id}";
   if (input.Id !== undefined) {
-    const labelValue: string = input.Id.toString();
+    const labelValue: string = input.Id;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Id.");
     }
-    resolvedPath = resolvedPath.replace("{Id}", encodeURIComponent(labelValue));
+    resolvedPath = resolvedPath.replace(
+      "{Id}",
+      __extendedEncodeURIComponent(labelValue)
+    );
   } else {
     throw new Error("No value provided for input HTTP label: Id.");
   }
@@ -350,13 +371,19 @@ export async function serializeAws_restJson1_1ListAssetsCommand(
   let resolvedPath = "/assets";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   if (input.PackagingGroupId !== undefined) {
-    query["packagingGroupId"] = input.PackagingGroupId.toString();
+    query[
+      __extendedEncodeURIComponent("packagingGroupId")
+    ] = __extendedEncodeURIComponent(input.PackagingGroupId);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -377,13 +404,19 @@ export async function serializeAws_restJson1_1ListPackagingConfigurationsCommand
   let resolvedPath = "/packaging_configurations";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   if (input.PackagingGroupId !== undefined) {
-    query["packagingGroupId"] = input.PackagingGroupId.toString();
+    query[
+      __extendedEncodeURIComponent("packagingGroupId")
+    ] = __extendedEncodeURIComponent(input.PackagingGroupId);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -404,10 +437,14 @@ export async function serializeAws_restJson1_1ListPackagingGroupsCommand(
   let resolvedPath = "/packaging_groups";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -775,6 +812,7 @@ export async function deserializeAws_restJson1_1DeleteAssetCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeleteAssetResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -861,6 +899,7 @@ export async function deserializeAws_restJson1_1DeletePackagingConfigurationComm
     $metadata: deserializeMetadata(output),
     __type: "DeletePackagingConfigurationResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -947,6 +986,7 @@ export async function deserializeAws_restJson1_1DeletePackagingGroupCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeletePackagingGroupResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 

--- a/clients/client-mediapackage/models/index.ts
+++ b/clients/client-mediapackage/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export enum AdMarkers {
@@ -32,7 +35,7 @@ export interface Authorization {
 
 export namespace Authorization {
   export function isa(o: any): o is Authorization {
-    return _smithy.isa(o, "Authorization");
+    return __isa(o, "Authorization");
   }
 }
 
@@ -69,7 +72,7 @@ export interface Channel {
 
 export namespace Channel {
   export function isa(o: any): o is Channel {
-    return _smithy.isa(o, "Channel");
+    return __isa(o, "Channel");
   }
 }
 
@@ -91,7 +94,7 @@ export interface CmafEncryption {
 
 export namespace CmafEncryption {
   export function isa(o: any): o is CmafEncryption {
-    return _smithy.isa(o, "CmafEncryption");
+    return __isa(o, "CmafEncryption");
   }
 }
 
@@ -129,7 +132,7 @@ export interface CmafPackage {
 
 export namespace CmafPackage {
   export function isa(o: any): o is CmafPackage {
-    return _smithy.isa(o, "CmafPackage");
+    return __isa(o, "CmafPackage");
   }
 }
 
@@ -167,7 +170,7 @@ export interface CmafPackageCreateOrUpdateParameters {
 
 export namespace CmafPackageCreateOrUpdateParameters {
   export function isa(o: any): o is CmafPackageCreateOrUpdateParameters {
-    return _smithy.isa(o, "CmafPackageCreateOrUpdateParameters");
+    return __isa(o, "CmafPackageCreateOrUpdateParameters");
   }
 }
 
@@ -195,7 +198,7 @@ export interface CreateChannelRequest {
 
 export namespace CreateChannelRequest {
   export function isa(o: any): o is CreateChannelRequest {
-    return _smithy.isa(o, "CreateChannelRequest");
+    return __isa(o, "CreateChannelRequest");
   }
 }
 
@@ -229,7 +232,7 @@ export interface CreateChannelResponse extends $MetadataBearer {
 
 export namespace CreateChannelResponse {
   export function isa(o: any): o is CreateChannelResponse {
-    return _smithy.isa(o, "CreateChannelResponse");
+    return __isa(o, "CreateChannelResponse");
   }
 }
 
@@ -268,7 +271,7 @@ export interface CreateHarvestJobRequest {
 
 export namespace CreateHarvestJobRequest {
   export function isa(o: any): o is CreateHarvestJobRequest {
-    return _smithy.isa(o, "CreateHarvestJobRequest");
+    return __isa(o, "CreateHarvestJobRequest");
   }
 }
 
@@ -326,7 +329,7 @@ export interface CreateHarvestJobResponse extends $MetadataBearer {
 
 export namespace CreateHarvestJobResponse {
   export function isa(o: any): o is CreateHarvestJobResponse {
-    return _smithy.isa(o, "CreateHarvestJobResponse");
+    return __isa(o, "CreateHarvestJobResponse");
   }
 }
 
@@ -414,7 +417,7 @@ export interface CreateOriginEndpointRequest {
 
 export namespace CreateOriginEndpointRequest {
   export function isa(o: any): o is CreateOriginEndpointRequest {
-    return _smithy.isa(o, "CreateOriginEndpointRequest");
+    return __isa(o, "CreateOriginEndpointRequest");
   }
 }
 
@@ -507,7 +510,7 @@ export interface CreateOriginEndpointResponse extends $MetadataBearer {
 
 export namespace CreateOriginEndpointResponse {
   export function isa(o: any): o is CreateOriginEndpointResponse {
-    return _smithy.isa(o, "CreateOriginEndpointResponse");
+    return __isa(o, "CreateOriginEndpointResponse");
   }
 }
 
@@ -529,7 +532,7 @@ export interface DashEncryption {
 
 export namespace DashEncryption {
   export function isa(o: any): o is DashEncryption {
-    return _smithy.isa(o, "DashEncryption");
+    return __isa(o, "DashEncryption");
   }
 }
 
@@ -619,7 +622,7 @@ export interface DashPackage {
 
 export namespace DashPackage {
   export function isa(o: any): o is DashPackage {
-    return _smithy.isa(o, "DashPackage");
+    return __isa(o, "DashPackage");
   }
 }
 
@@ -633,7 +636,7 @@ export interface DeleteChannelRequest {
 
 export namespace DeleteChannelRequest {
   export function isa(o: any): o is DeleteChannelRequest {
-    return _smithy.isa(o, "DeleteChannelRequest");
+    return __isa(o, "DeleteChannelRequest");
   }
 }
 
@@ -643,7 +646,7 @@ export interface DeleteChannelResponse extends $MetadataBearer {
 
 export namespace DeleteChannelResponse {
   export function isa(o: any): o is DeleteChannelResponse {
-    return _smithy.isa(o, "DeleteChannelResponse");
+    return __isa(o, "DeleteChannelResponse");
   }
 }
 
@@ -657,7 +660,7 @@ export interface DeleteOriginEndpointRequest {
 
 export namespace DeleteOriginEndpointRequest {
   export function isa(o: any): o is DeleteOriginEndpointRequest {
-    return _smithy.isa(o, "DeleteOriginEndpointRequest");
+    return __isa(o, "DeleteOriginEndpointRequest");
   }
 }
 
@@ -667,7 +670,7 @@ export interface DeleteOriginEndpointResponse extends $MetadataBearer {
 
 export namespace DeleteOriginEndpointResponse {
   export function isa(o: any): o is DeleteOriginEndpointResponse {
-    return _smithy.isa(o, "DeleteOriginEndpointResponse");
+    return __isa(o, "DeleteOriginEndpointResponse");
   }
 }
 
@@ -681,7 +684,7 @@ export interface DescribeChannelRequest {
 
 export namespace DescribeChannelRequest {
   export function isa(o: any): o is DescribeChannelRequest {
-    return _smithy.isa(o, "DescribeChannelRequest");
+    return __isa(o, "DescribeChannelRequest");
   }
 }
 
@@ -715,7 +718,7 @@ export interface DescribeChannelResponse extends $MetadataBearer {
 
 export namespace DescribeChannelResponse {
   export function isa(o: any): o is DescribeChannelResponse {
-    return _smithy.isa(o, "DescribeChannelResponse");
+    return __isa(o, "DescribeChannelResponse");
   }
 }
 
@@ -729,7 +732,7 @@ export interface DescribeHarvestJobRequest {
 
 export namespace DescribeHarvestJobRequest {
   export function isa(o: any): o is DescribeHarvestJobRequest {
-    return _smithy.isa(o, "DescribeHarvestJobRequest");
+    return __isa(o, "DescribeHarvestJobRequest");
   }
 }
 
@@ -787,7 +790,7 @@ export interface DescribeHarvestJobResponse extends $MetadataBearer {
 
 export namespace DescribeHarvestJobResponse {
   export function isa(o: any): o is DescribeHarvestJobResponse {
-    return _smithy.isa(o, "DescribeHarvestJobResponse");
+    return __isa(o, "DescribeHarvestJobResponse");
   }
 }
 
@@ -801,7 +804,7 @@ export interface DescribeOriginEndpointRequest {
 
 export namespace DescribeOriginEndpointRequest {
   export function isa(o: any): o is DescribeOriginEndpointRequest {
-    return _smithy.isa(o, "DescribeOriginEndpointRequest");
+    return __isa(o, "DescribeOriginEndpointRequest");
   }
 }
 
@@ -894,7 +897,7 @@ export interface DescribeOriginEndpointResponse extends $MetadataBearer {
 
 export namespace DescribeOriginEndpointResponse {
   export function isa(o: any): o is DescribeOriginEndpointResponse {
-    return _smithy.isa(o, "DescribeOriginEndpointResponse");
+    return __isa(o, "DescribeOriginEndpointResponse");
   }
 }
 
@@ -906,9 +909,7 @@ export enum EncryptionMethod {
 /**
  * The client is not authorized to access the requested resource.
  */
-export interface ForbiddenException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface ForbiddenException extends __SmithyException, $MetadataBearer {
   name: "ForbiddenException";
   $fault: "client";
   Message?: string;
@@ -916,7 +917,7 @@ export interface ForbiddenException
 
 export namespace ForbiddenException {
   export function isa(o: any): o is ForbiddenException {
-    return _smithy.isa(o, "ForbiddenException");
+    return __isa(o, "ForbiddenException");
   }
 }
 
@@ -977,7 +978,7 @@ export interface HarvestJob {
 
 export namespace HarvestJob {
   export function isa(o: any): o is HarvestJob {
-    return _smithy.isa(o, "HarvestJob");
+    return __isa(o, "HarvestJob");
   }
 }
 
@@ -1015,7 +1016,7 @@ export interface HlsEncryption {
 
 export namespace HlsEncryption {
   export function isa(o: any): o is HlsEncryption {
-    return _smithy.isa(o, "HlsEncryption");
+    return __isa(o, "HlsEncryption");
   }
 }
 
@@ -1032,7 +1033,7 @@ export interface HlsIngest {
 
 export namespace HlsIngest {
   export function isa(o: any): o is HlsIngest {
-    return _smithy.isa(o, "HlsIngest");
+    return __isa(o, "HlsIngest");
   }
 }
 
@@ -1099,7 +1100,7 @@ export interface HlsManifest {
 
 export namespace HlsManifest {
   export function isa(o: any): o is HlsManifest {
-    return _smithy.isa(o, "HlsManifest");
+    return __isa(o, "HlsManifest");
   }
 }
 
@@ -1180,7 +1181,7 @@ export interface HlsManifestCreateOrUpdateParameters {
 
 export namespace HlsManifestCreateOrUpdateParameters {
   export function isa(o: any): o is HlsManifestCreateOrUpdateParameters {
-    return _smithy.isa(o, "HlsManifestCreateOrUpdateParameters");
+    return __isa(o, "HlsManifestCreateOrUpdateParameters");
   }
 }
 
@@ -1272,7 +1273,7 @@ export interface HlsPackage {
 
 export namespace HlsPackage {
   export function isa(o: any): o is HlsPackage {
-    return _smithy.isa(o, "HlsPackage");
+    return __isa(o, "HlsPackage");
   }
 }
 
@@ -1304,7 +1305,7 @@ export interface IngestEndpoint {
 
 export namespace IngestEndpoint {
   export function isa(o: any): o is IngestEndpoint {
-    return _smithy.isa(o, "IngestEndpoint");
+    return __isa(o, "IngestEndpoint");
   }
 }
 
@@ -1312,7 +1313,7 @@ export namespace IngestEndpoint {
  * An unexpected error occurred.
  */
 export interface InternalServerErrorException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalServerErrorException";
   $fault: "server";
@@ -1321,7 +1322,7 @@ export interface InternalServerErrorException
 
 export namespace InternalServerErrorException {
   export function isa(o: any): o is InternalServerErrorException {
-    return _smithy.isa(o, "InternalServerErrorException");
+    return __isa(o, "InternalServerErrorException");
   }
 }
 
@@ -1340,7 +1341,7 @@ export interface ListChannelsRequest {
 
 export namespace ListChannelsRequest {
   export function isa(o: any): o is ListChannelsRequest {
-    return _smithy.isa(o, "ListChannelsRequest");
+    return __isa(o, "ListChannelsRequest");
   }
 }
 
@@ -1359,7 +1360,7 @@ export interface ListChannelsResponse extends $MetadataBearer {
 
 export namespace ListChannelsResponse {
   export function isa(o: any): o is ListChannelsResponse {
-    return _smithy.isa(o, "ListChannelsResponse");
+    return __isa(o, "ListChannelsResponse");
   }
 }
 
@@ -1388,7 +1389,7 @@ export interface ListHarvestJobsRequest {
 
 export namespace ListHarvestJobsRequest {
   export function isa(o: any): o is ListHarvestJobsRequest {
-    return _smithy.isa(o, "ListHarvestJobsRequest");
+    return __isa(o, "ListHarvestJobsRequest");
   }
 }
 
@@ -1407,7 +1408,7 @@ export interface ListHarvestJobsResponse extends $MetadataBearer {
 
 export namespace ListHarvestJobsResponse {
   export function isa(o: any): o is ListHarvestJobsResponse {
-    return _smithy.isa(o, "ListHarvestJobsResponse");
+    return __isa(o, "ListHarvestJobsResponse");
   }
 }
 
@@ -1431,7 +1432,7 @@ export interface ListOriginEndpointsRequest {
 
 export namespace ListOriginEndpointsRequest {
   export function isa(o: any): o is ListOriginEndpointsRequest {
-    return _smithy.isa(o, "ListOriginEndpointsRequest");
+    return __isa(o, "ListOriginEndpointsRequest");
   }
 }
 
@@ -1450,7 +1451,7 @@ export interface ListOriginEndpointsResponse extends $MetadataBearer {
 
 export namespace ListOriginEndpointsResponse {
   export function isa(o: any): o is ListOriginEndpointsResponse {
-    return _smithy.isa(o, "ListOriginEndpointsResponse");
+    return __isa(o, "ListOriginEndpointsResponse");
   }
 }
 
@@ -1461,7 +1462,7 @@ export interface ListTagsForResourceRequest {
 
 export namespace ListTagsForResourceRequest {
   export function isa(o: any): o is ListTagsForResourceRequest {
-    return _smithy.isa(o, "ListTagsForResourceRequest");
+    return __isa(o, "ListTagsForResourceRequest");
   }
 }
 
@@ -1472,7 +1473,7 @@ export interface ListTagsForResourceResponse extends $MetadataBearer {
 
 export namespace ListTagsForResourceResponse {
   export function isa(o: any): o is ListTagsForResourceResponse {
-    return _smithy.isa(o, "ListTagsForResourceResponse");
+    return __isa(o, "ListTagsForResourceResponse");
   }
 }
 
@@ -1494,7 +1495,7 @@ export interface MssEncryption {
 
 export namespace MssEncryption {
   export function isa(o: any): o is MssEncryption {
-    return _smithy.isa(o, "MssEncryption");
+    return __isa(o, "MssEncryption");
   }
 }
 
@@ -1526,16 +1527,14 @@ export interface MssPackage {
 
 export namespace MssPackage {
   export function isa(o: any): o is MssPackage {
-    return _smithy.isa(o, "MssPackage");
+    return __isa(o, "MssPackage");
   }
 }
 
 /**
  * The requested resource does not exist.
  */
-export interface NotFoundException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface NotFoundException extends __SmithyException, $MetadataBearer {
   name: "NotFoundException";
   $fault: "client";
   Message?: string;
@@ -1543,7 +1542,7 @@ export interface NotFoundException
 
 export namespace NotFoundException {
   export function isa(o: any): o is NotFoundException {
-    return _smithy.isa(o, "NotFoundException");
+    return __isa(o, "NotFoundException");
   }
 }
 
@@ -1639,7 +1638,7 @@ export interface OriginEndpoint {
 
 export namespace OriginEndpoint {
   export function isa(o: any): o is OriginEndpoint {
-    return _smithy.isa(o, "OriginEndpoint");
+    return __isa(o, "OriginEndpoint");
   }
 }
 
@@ -1669,7 +1668,7 @@ export interface RotateChannelCredentialsRequest {
 
 export namespace RotateChannelCredentialsRequest {
   export function isa(o: any): o is RotateChannelCredentialsRequest {
-    return _smithy.isa(o, "RotateChannelCredentialsRequest");
+    return __isa(o, "RotateChannelCredentialsRequest");
   }
 }
 
@@ -1703,7 +1702,7 @@ export interface RotateChannelCredentialsResponse extends $MetadataBearer {
 
 export namespace RotateChannelCredentialsResponse {
   export function isa(o: any): o is RotateChannelCredentialsResponse {
-    return _smithy.isa(o, "RotateChannelCredentialsResponse");
+    return __isa(o, "RotateChannelCredentialsResponse");
   }
 }
 
@@ -1722,7 +1721,7 @@ export interface RotateIngestEndpointCredentialsRequest {
 
 export namespace RotateIngestEndpointCredentialsRequest {
   export function isa(o: any): o is RotateIngestEndpointCredentialsRequest {
-    return _smithy.isa(o, "RotateIngestEndpointCredentialsRequest");
+    return __isa(o, "RotateIngestEndpointCredentialsRequest");
   }
 }
 
@@ -1757,7 +1756,7 @@ export interface RotateIngestEndpointCredentialsResponse
 
 export namespace RotateIngestEndpointCredentialsResponse {
   export function isa(o: any): o is RotateIngestEndpointCredentialsResponse {
-    return _smithy.isa(o, "RotateIngestEndpointCredentialsResponse");
+    return __isa(o, "RotateIngestEndpointCredentialsResponse");
   }
 }
 
@@ -1784,7 +1783,7 @@ export interface S3Destination {
 
 export namespace S3Destination {
   export function isa(o: any): o is S3Destination {
-    return _smithy.isa(o, "S3Destination");
+    return __isa(o, "S3Destination");
   }
 }
 
@@ -1798,7 +1797,7 @@ export enum SegmentTemplateFormat {
  * An unexpected error occurred.
  */
 export interface ServiceUnavailableException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ServiceUnavailableException";
   $fault: "server";
@@ -1807,7 +1806,7 @@ export interface ServiceUnavailableException
 
 export namespace ServiceUnavailableException {
   export function isa(o: any): o is ServiceUnavailableException {
-    return _smithy.isa(o, "ServiceUnavailableException");
+    return __isa(o, "ServiceUnavailableException");
   }
 }
 
@@ -1847,7 +1846,7 @@ export interface SpekeKeyProvider {
 
 export namespace SpekeKeyProvider {
   export function isa(o: any): o is SpekeKeyProvider {
-    return _smithy.isa(o, "SpekeKeyProvider");
+    return __isa(o, "SpekeKeyProvider");
   }
 }
 
@@ -1886,7 +1885,7 @@ export interface StreamSelection {
 
 export namespace StreamSelection {
   export function isa(o: any): o is StreamSelection {
-    return _smithy.isa(o, "StreamSelection");
+    return __isa(o, "StreamSelection");
   }
 }
 
@@ -1898,7 +1897,7 @@ export interface TagResourceRequest {
 
 export namespace TagResourceRequest {
   export function isa(o: any): o is TagResourceRequest {
-    return _smithy.isa(o, "TagResourceRequest");
+    return __isa(o, "TagResourceRequest");
   }
 }
 
@@ -1906,7 +1905,7 @@ export namespace TagResourceRequest {
  * The client has exceeded their resource or throttling limits.
  */
 export interface TooManyRequestsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyRequestsException";
   $fault: "client";
@@ -1915,7 +1914,7 @@ export interface TooManyRequestsException
 
 export namespace TooManyRequestsException {
   export function isa(o: any): o is TooManyRequestsException {
-    return _smithy.isa(o, "TooManyRequestsException");
+    return __isa(o, "TooManyRequestsException");
   }
 }
 
@@ -1923,7 +1922,7 @@ export namespace TooManyRequestsException {
  * The parameters sent in the request are not valid.
  */
 export interface UnprocessableEntityException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UnprocessableEntityException";
   $fault: "client";
@@ -1932,7 +1931,7 @@ export interface UnprocessableEntityException
 
 export namespace UnprocessableEntityException {
   export function isa(o: any): o is UnprocessableEntityException {
-    return _smithy.isa(o, "UnprocessableEntityException");
+    return __isa(o, "UnprocessableEntityException");
   }
 }
 
@@ -1947,7 +1946,7 @@ export interface UntagResourceRequest {
 
 export namespace UntagResourceRequest {
   export function isa(o: any): o is UntagResourceRequest {
-    return _smithy.isa(o, "UntagResourceRequest");
+    return __isa(o, "UntagResourceRequest");
   }
 }
 
@@ -1969,7 +1968,7 @@ export interface UpdateChannelRequest {
 
 export namespace UpdateChannelRequest {
   export function isa(o: any): o is UpdateChannelRequest {
-    return _smithy.isa(o, "UpdateChannelRequest");
+    return __isa(o, "UpdateChannelRequest");
   }
 }
 
@@ -2003,7 +2002,7 @@ export interface UpdateChannelResponse extends $MetadataBearer {
 
 export namespace UpdateChannelResponse {
   export function isa(o: any): o is UpdateChannelResponse {
-    return _smithy.isa(o, "UpdateChannelResponse");
+    return __isa(o, "UpdateChannelResponse");
   }
 }
 
@@ -2079,7 +2078,7 @@ export interface UpdateOriginEndpointRequest {
 
 export namespace UpdateOriginEndpointRequest {
   export function isa(o: any): o is UpdateOriginEndpointRequest {
-    return _smithy.isa(o, "UpdateOriginEndpointRequest");
+    return __isa(o, "UpdateOriginEndpointRequest");
   }
 }
 
@@ -2172,7 +2171,7 @@ export interface UpdateOriginEndpointResponse extends $MetadataBearer {
 
 export namespace UpdateOriginEndpointResponse {
   export function isa(o: any): o is UpdateOriginEndpointResponse {
-    return _smithy.isa(o, "UpdateOriginEndpointResponse");
+    return __isa(o, "UpdateOriginEndpointResponse");
   }
 }
 

--- a/clients/client-mediapackage/protocols/Aws_restJson1_1.ts
+++ b/clients/client-mediapackage/protocols/Aws_restJson1_1.ts
@@ -104,7 +104,10 @@ import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  extendedEncodeURIComponent as __extendedEncodeURIComponent
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -269,11 +272,14 @@ export async function serializeAws_restJson1_1DeleteChannelCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/channels/{Id}";
   if (input.Id !== undefined) {
-    const labelValue: string = input.Id.toString();
+    const labelValue: string = input.Id;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Id.");
     }
-    resolvedPath = resolvedPath.replace("{Id}", encodeURIComponent(labelValue));
+    resolvedPath = resolvedPath.replace(
+      "{Id}",
+      __extendedEncodeURIComponent(labelValue)
+    );
   } else {
     throw new Error("No value provided for input HTTP label: Id.");
   }
@@ -294,11 +300,14 @@ export async function serializeAws_restJson1_1DeleteOriginEndpointCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/origin_endpoints/{Id}";
   if (input.Id !== undefined) {
-    const labelValue: string = input.Id.toString();
+    const labelValue: string = input.Id;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Id.");
     }
-    resolvedPath = resolvedPath.replace("{Id}", encodeURIComponent(labelValue));
+    resolvedPath = resolvedPath.replace(
+      "{Id}",
+      __extendedEncodeURIComponent(labelValue)
+    );
   } else {
     throw new Error("No value provided for input HTTP label: Id.");
   }
@@ -319,11 +328,14 @@ export async function serializeAws_restJson1_1DescribeChannelCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/channels/{Id}";
   if (input.Id !== undefined) {
-    const labelValue: string = input.Id.toString();
+    const labelValue: string = input.Id;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Id.");
     }
-    resolvedPath = resolvedPath.replace("{Id}", encodeURIComponent(labelValue));
+    resolvedPath = resolvedPath.replace(
+      "{Id}",
+      __extendedEncodeURIComponent(labelValue)
+    );
   } else {
     throw new Error("No value provided for input HTTP label: Id.");
   }
@@ -344,11 +356,14 @@ export async function serializeAws_restJson1_1DescribeHarvestJobCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/harvest_jobs/{Id}";
   if (input.Id !== undefined) {
-    const labelValue: string = input.Id.toString();
+    const labelValue: string = input.Id;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Id.");
     }
-    resolvedPath = resolvedPath.replace("{Id}", encodeURIComponent(labelValue));
+    resolvedPath = resolvedPath.replace(
+      "{Id}",
+      __extendedEncodeURIComponent(labelValue)
+    );
   } else {
     throw new Error("No value provided for input HTTP label: Id.");
   }
@@ -369,11 +384,14 @@ export async function serializeAws_restJson1_1DescribeOriginEndpointCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/origin_endpoints/{Id}";
   if (input.Id !== undefined) {
-    const labelValue: string = input.Id.toString();
+    const labelValue: string = input.Id;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Id.");
     }
-    resolvedPath = resolvedPath.replace("{Id}", encodeURIComponent(labelValue));
+    resolvedPath = resolvedPath.replace(
+      "{Id}",
+      __extendedEncodeURIComponent(labelValue)
+    );
   } else {
     throw new Error("No value provided for input HTTP label: Id.");
   }
@@ -395,10 +413,14 @@ export async function serializeAws_restJson1_1ListChannelsCommand(
   let resolvedPath = "/channels";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -419,16 +441,24 @@ export async function serializeAws_restJson1_1ListHarvestJobsCommand(
   let resolvedPath = "/harvest_jobs";
   const query: any = {};
   if (input.IncludeChannelId !== undefined) {
-    query["includeChannelId"] = input.IncludeChannelId.toString();
+    query[
+      __extendedEncodeURIComponent("includeChannelId")
+    ] = __extendedEncodeURIComponent(input.IncludeChannelId);
   }
   if (input.IncludeStatus !== undefined) {
-    query["includeStatus"] = input.IncludeStatus.toString();
+    query[
+      __extendedEncodeURIComponent("includeStatus")
+    ] = __extendedEncodeURIComponent(input.IncludeStatus);
   }
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -449,13 +479,19 @@ export async function serializeAws_restJson1_1ListOriginEndpointsCommand(
   let resolvedPath = "/origin_endpoints";
   const query: any = {};
   if (input.ChannelId !== undefined) {
-    query["channelId"] = input.ChannelId.toString();
+    query[
+      __extendedEncodeURIComponent("channelId")
+    ] = __extendedEncodeURIComponent(input.ChannelId);
   }
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -475,7 +511,7 @@ export async function serializeAws_restJson1_1ListTagsForResourceCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/tags/{ResourceArn}";
   if (input.ResourceArn !== undefined) {
-    const labelValue: string = input.ResourceArn.toString();
+    const labelValue: string = input.ResourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ResourceArn."
@@ -483,7 +519,7 @@ export async function serializeAws_restJson1_1ListTagsForResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ResourceArn.");
@@ -505,11 +541,14 @@ export async function serializeAws_restJson1_1RotateChannelCredentialsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/channels/{Id}/credentials";
   if (input.Id !== undefined) {
-    const labelValue: string = input.Id.toString();
+    const labelValue: string = input.Id;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Id.");
     }
-    resolvedPath = resolvedPath.replace("{Id}", encodeURIComponent(labelValue));
+    resolvedPath = resolvedPath.replace(
+      "{Id}",
+      __extendedEncodeURIComponent(labelValue)
+    );
   } else {
     throw new Error("No value provided for input HTTP label: Id.");
   }
@@ -531,16 +570,19 @@ export async function serializeAws_restJson1_1RotateIngestEndpointCredentialsCom
   let resolvedPath =
     "/channels/{Id}/ingest_endpoints/{IngestEndpointId}/credentials";
   if (input.Id !== undefined) {
-    const labelValue: string = input.Id.toString();
+    const labelValue: string = input.Id;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Id.");
     }
-    resolvedPath = resolvedPath.replace("{Id}", encodeURIComponent(labelValue));
+    resolvedPath = resolvedPath.replace(
+      "{Id}",
+      __extendedEncodeURIComponent(labelValue)
+    );
   } else {
     throw new Error("No value provided for input HTTP label: Id.");
   }
   if (input.IngestEndpointId !== undefined) {
-    const labelValue: string = input.IngestEndpointId.toString();
+    const labelValue: string = input.IngestEndpointId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: IngestEndpointId."
@@ -548,7 +590,7 @@ export async function serializeAws_restJson1_1RotateIngestEndpointCredentialsCom
     }
     resolvedPath = resolvedPath.replace(
       "{IngestEndpointId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -572,7 +614,7 @@ export async function serializeAws_restJson1_1TagResourceCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/tags/{ResourceArn}";
   if (input.ResourceArn !== undefined) {
-    const labelValue: string = input.ResourceArn.toString();
+    const labelValue: string = input.ResourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ResourceArn."
@@ -580,7 +622,7 @@ export async function serializeAws_restJson1_1TagResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ResourceArn.");
@@ -612,7 +654,7 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/tags/{ResourceArn}";
   if (input.ResourceArn !== undefined) {
-    const labelValue: string = input.ResourceArn.toString();
+    const labelValue: string = input.ResourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ResourceArn."
@@ -620,14 +662,16 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ResourceArn.");
   }
   const query: any = {};
   if (input.TagKeys !== undefined) {
-    query["tagKeys"] = input.TagKeys;
+    query[__extendedEncodeURIComponent("tagKeys")] = input.TagKeys.map(entry =>
+      __extendedEncodeURIComponent(entry)
+    );
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -647,11 +691,14 @@ export async function serializeAws_restJson1_1UpdateChannelCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/channels/{Id}";
   if (input.Id !== undefined) {
-    const labelValue: string = input.Id.toString();
+    const labelValue: string = input.Id;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Id.");
     }
-    resolvedPath = resolvedPath.replace("{Id}", encodeURIComponent(labelValue));
+    resolvedPath = resolvedPath.replace(
+      "{Id}",
+      __extendedEncodeURIComponent(labelValue)
+    );
   } else {
     throw new Error("No value provided for input HTTP label: Id.");
   }
@@ -679,11 +726,14 @@ export async function serializeAws_restJson1_1UpdateOriginEndpointCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/origin_endpoints/{Id}";
   if (input.Id !== undefined) {
-    const labelValue: string = input.Id.toString();
+    const labelValue: string = input.Id;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Id.");
     }
-    resolvedPath = resolvedPath.replace("{Id}", encodeURIComponent(labelValue));
+    resolvedPath = resolvedPath.replace(
+      "{Id}",
+      __extendedEncodeURIComponent(labelValue)
+    );
   } else {
     throw new Error("No value provided for input HTTP label: Id.");
   }
@@ -1169,6 +1219,7 @@ export async function deserializeAws_restJson1_1DeleteChannelCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeleteChannelResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -1255,6 +1306,7 @@ export async function deserializeAws_restJson1_1DeleteOriginEndpointCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeleteOriginEndpointResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2308,6 +2360,7 @@ export async function deserializeAws_restJson1_1TagResourceCommand(
   const contents: TagResourceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2348,6 +2401,7 @@ export async function deserializeAws_restJson1_1UntagResourceCommand(
   const contents: UntagResourceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 

--- a/clients/client-mediastore-data/models/index.ts
+++ b/clients/client-mediastore-data/models/index.ts
@@ -1,11 +1,14 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
  * <p>The specified container was not found for the specified account.</p>
  */
 export interface ContainerNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ContainerNotFoundException";
   $fault: "client";
@@ -14,7 +17,7 @@ export interface ContainerNotFoundException
 
 export namespace ContainerNotFoundException {
   export function isa(o: any): o is ContainerNotFoundException {
-    return _smithy.isa(o, "ContainerNotFoundException");
+    return __isa(o, "ContainerNotFoundException");
   }
 }
 
@@ -29,7 +32,7 @@ export interface DeleteObjectRequest {
 
 export namespace DeleteObjectRequest {
   export function isa(o: any): o is DeleteObjectRequest {
-    return _smithy.isa(o, "DeleteObjectRequest");
+    return __isa(o, "DeleteObjectRequest");
   }
 }
 
@@ -39,7 +42,7 @@ export interface DeleteObjectResponse extends $MetadataBearer {
 
 export namespace DeleteObjectResponse {
   export function isa(o: any): o is DeleteObjectResponse {
-    return _smithy.isa(o, "DeleteObjectResponse");
+    return __isa(o, "DeleteObjectResponse");
   }
 }
 
@@ -54,7 +57,7 @@ export interface DescribeObjectRequest {
 
 export namespace DescribeObjectRequest {
   export function isa(o: any): o is DescribeObjectRequest {
-    return _smithy.isa(o, "DescribeObjectRequest");
+    return __isa(o, "DescribeObjectRequest");
   }
 }
 
@@ -90,7 +93,7 @@ export interface DescribeObjectResponse extends $MetadataBearer {
 
 export namespace DescribeObjectResponse {
   export function isa(o: any): o is DescribeObjectResponse {
-    return _smithy.isa(o, "DescribeObjectResponse");
+    return __isa(o, "DescribeObjectResponse");
   }
 }
 
@@ -127,7 +130,7 @@ export interface GetObjectRequest {
 
 export namespace GetObjectRequest {
   export function isa(o: any): o is GetObjectRequest {
-    return _smithy.isa(o, "GetObjectRequest");
+    return __isa(o, "GetObjectRequest");
   }
 }
 
@@ -173,7 +176,7 @@ export interface GetObjectResponse extends $MetadataBearer {
 
 export namespace GetObjectResponse {
   export function isa(o: any): o is GetObjectResponse {
-    return _smithy.isa(o, "GetObjectResponse");
+    return __isa(o, "GetObjectResponse");
   }
 }
 
@@ -181,7 +184,7 @@ export namespace GetObjectResponse {
  * <p>The service is temporarily unavailable.</p>
  */
 export interface InternalServerError
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalServerError";
   $fault: "server";
@@ -190,7 +193,7 @@ export interface InternalServerError
 
 export namespace InternalServerError {
   export function isa(o: any): o is InternalServerError {
-    return _smithy.isa(o, "InternalServerError");
+    return __isa(o, "InternalServerError");
   }
 }
 
@@ -232,7 +235,7 @@ export interface Item {
 
 export namespace Item {
   export function isa(o: any): o is Item {
-    return _smithy.isa(o, "Item");
+    return __isa(o, "Item");
   }
 }
 
@@ -274,7 +277,7 @@ export interface ListItemsRequest {
 
 export namespace ListItemsRequest {
   export function isa(o: any): o is ListItemsRequest {
-    return _smithy.isa(o, "ListItemsRequest");
+    return __isa(o, "ListItemsRequest");
   }
 }
 
@@ -297,7 +300,7 @@ export interface ListItemsResponse extends $MetadataBearer {
 
 export namespace ListItemsResponse {
   export function isa(o: any): o is ListItemsResponse {
-    return _smithy.isa(o, "ListItemsResponse");
+    return __isa(o, "ListItemsResponse");
   }
 }
 
@@ -305,7 +308,7 @@ export namespace ListItemsResponse {
  * <p>Could not perform an operation on an object that does not exist.</p>
  */
 export interface ObjectNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ObjectNotFoundException";
   $fault: "client";
@@ -314,7 +317,7 @@ export interface ObjectNotFoundException
 
 export namespace ObjectNotFoundException {
   export function isa(o: any): o is ObjectNotFoundException {
-    return _smithy.isa(o, "ObjectNotFoundException");
+    return __isa(o, "ObjectNotFoundException");
   }
 }
 
@@ -369,7 +372,7 @@ export interface PutObjectRequest {
 
 export namespace PutObjectRequest {
   export function isa(o: any): o is PutObjectRequest {
-    return _smithy.isa(o, "PutObjectRequest");
+    return __isa(o, "PutObjectRequest");
   }
 }
 
@@ -394,7 +397,7 @@ export interface PutObjectResponse extends $MetadataBearer {
 
 export namespace PutObjectResponse {
   export function isa(o: any): o is PutObjectResponse {
-    return _smithy.isa(o, "PutObjectResponse");
+    return __isa(o, "PutObjectResponse");
   }
 }
 
@@ -402,7 +405,7 @@ export namespace PutObjectResponse {
  * <p>The requested content range is not valid.</p>
  */
 export interface RequestedRangeNotSatisfiableException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "RequestedRangeNotSatisfiableException";
   $fault: "client";
@@ -411,7 +414,7 @@ export interface RequestedRangeNotSatisfiableException
 
 export namespace RequestedRangeNotSatisfiableException {
   export function isa(o: any): o is RequestedRangeNotSatisfiableException {
-    return _smithy.isa(o, "RequestedRangeNotSatisfiableException");
+    return __isa(o, "RequestedRangeNotSatisfiableException");
   }
 }
 

--- a/clients/client-mediastore-data/protocols/Aws_restJson1_1.ts
+++ b/clients/client-mediastore-data/protocols/Aws_restJson1_1.ts
@@ -29,7 +29,10 @@ import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  extendedEncodeURIComponent as __extendedEncodeURIComponent
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -45,7 +48,7 @@ export async function serializeAws_restJson1_1DeleteObjectCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/{Path+}";
   if (input.Path !== undefined) {
-    const labelValue: string = input.Path.toString();
+    const labelValue: string = input.Path;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Path.");
     }
@@ -53,7 +56,7 @@ export async function serializeAws_restJson1_1DeleteObjectCommand(
       "{Path+}",
       labelValue
         .split("/")
-        .map(segment => encodeURIComponent(segment))
+        .map(segment => __extendedEncodeURIComponent(segment))
         .join("/")
     );
   } else {
@@ -76,7 +79,7 @@ export async function serializeAws_restJson1_1DescribeObjectCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/{Path+}";
   if (input.Path !== undefined) {
-    const labelValue: string = input.Path.toString();
+    const labelValue: string = input.Path;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Path.");
     }
@@ -84,7 +87,7 @@ export async function serializeAws_restJson1_1DescribeObjectCommand(
       "{Path+}",
       labelValue
         .split("/")
-        .map(segment => encodeURIComponent(segment))
+        .map(segment => __extendedEncodeURIComponent(segment))
         .join("/")
     );
   } else {
@@ -106,11 +109,11 @@ export async function serializeAws_restJson1_1GetObjectCommand(
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.Range !== undefined) {
-    headers["Range"] = input.Range.toString();
+    headers["Range"] = input.Range;
   }
   let resolvedPath = "/{Path+}";
   if (input.Path !== undefined) {
-    const labelValue: string = input.Path.toString();
+    const labelValue: string = input.Path;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Path.");
     }
@@ -118,7 +121,7 @@ export async function serializeAws_restJson1_1GetObjectCommand(
       "{Path+}",
       labelValue
         .split("/")
-        .map(segment => encodeURIComponent(segment))
+        .map(segment => __extendedEncodeURIComponent(segment))
         .join("/")
     );
   } else {
@@ -142,13 +145,19 @@ export async function serializeAws_restJson1_1ListItemsCommand(
   let resolvedPath = "/";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["MaxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("MaxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["NextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("NextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   if (input.Path !== undefined) {
-    query["Path"] = input.Path.toString();
+    query[__extendedEncodeURIComponent("Path")] = __extendedEncodeURIComponent(
+      input.Path
+    );
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -168,17 +177,17 @@ export async function serializeAws_restJson1_1PutObjectCommand(
   headers["Content-Type"] = "application/octet-stream";
   headers["x-amz-content-sha256"] = "UNSIGNED_PAYLOAD";
   if (input.CacheControl !== undefined) {
-    headers["Cache-Control"] = input.CacheControl.toString();
+    headers["Cache-Control"] = input.CacheControl;
   }
   if (input.ContentType !== undefined) {
-    headers["Content-Type"] = input.ContentType.toString();
+    headers["Content-Type"] = input.ContentType;
   }
   if (input.StorageClass !== undefined) {
-    headers["x-amz-storage-class"] = input.StorageClass.toString();
+    headers["x-amz-storage-class"] = input.StorageClass;
   }
   let resolvedPath = "/{Path+}";
   if (input.Path !== undefined) {
-    const labelValue: string = input.Path.toString();
+    const labelValue: string = input.Path;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Path.");
     }
@@ -186,7 +195,7 @@ export async function serializeAws_restJson1_1PutObjectCommand(
       "{Path+}",
       labelValue
         .split("/")
-        .map(segment => encodeURIComponent(segment))
+        .map(segment => __extendedEncodeURIComponent(segment))
         .join("/")
     );
   } else {
@@ -217,6 +226,7 @@ export async function deserializeAws_restJson1_1DeleteObjectCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeleteObjectResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -302,6 +312,7 @@ export async function deserializeAws_restJson1_1DescribeObjectCommand(
   if (output.headers["last-modified"] !== undefined) {
     contents.LastModified = new Date(output.headers["last-modified"]);
   }
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 

--- a/clients/client-mediastore/models/index.ts
+++ b/clients/client-mediastore/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -49,7 +52,7 @@ export interface Container {
 
 export namespace Container {
   export function isa(o: any): o is Container {
-    return _smithy.isa(o, "Container");
+    return __isa(o, "Container");
   }
 }
 
@@ -58,7 +61,7 @@ export namespace Container {
  *          updated.</p>
  */
 export interface ContainerInUseException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ContainerInUseException";
   $fault: "client";
@@ -67,7 +70,7 @@ export interface ContainerInUseException
 
 export namespace ContainerInUseException {
   export function isa(o: any): o is ContainerInUseException {
-    return _smithy.isa(o, "ContainerInUseException");
+    return __isa(o, "ContainerInUseException");
   }
 }
 
@@ -75,7 +78,7 @@ export namespace ContainerInUseException {
  * <p>The container that you specified in the request does not exist.</p>
  */
 export interface ContainerNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ContainerNotFoundException";
   $fault: "client";
@@ -84,7 +87,7 @@ export interface ContainerNotFoundException
 
 export namespace ContainerNotFoundException {
   export function isa(o: any): o is ContainerNotFoundException {
-    return _smithy.isa(o, "ContainerNotFoundException");
+    return __isa(o, "ContainerNotFoundException");
   }
 }
 
@@ -98,7 +101,7 @@ export enum ContainerStatus {
  * <p>The CORS policy that you specified in the request does not exist.</p>
  */
 export interface CorsPolicyNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CorsPolicyNotFoundException";
   $fault: "client";
@@ -107,7 +110,7 @@ export interface CorsPolicyNotFoundException
 
 export namespace CorsPolicyNotFoundException {
   export function isa(o: any): o is CorsPolicyNotFoundException {
-    return _smithy.isa(o, "CorsPolicyNotFoundException");
+    return __isa(o, "CorsPolicyNotFoundException");
   }
 }
 
@@ -162,7 +165,7 @@ export interface CorsRule {
 
 export namespace CorsRule {
   export function isa(o: any): o is CorsRule {
-    return _smithy.isa(o, "CorsRule");
+    return __isa(o, "CorsRule");
   }
 }
 
@@ -186,7 +189,7 @@ export interface CreateContainerInput {
 
 export namespace CreateContainerInput {
   export function isa(o: any): o is CreateContainerInput {
-    return _smithy.isa(o, "CreateContainerInput");
+    return __isa(o, "CreateContainerInput");
   }
 }
 
@@ -211,7 +214,7 @@ export interface CreateContainerOutput extends $MetadataBearer {
 
 export namespace CreateContainerOutput {
   export function isa(o: any): o is CreateContainerOutput {
-    return _smithy.isa(o, "CreateContainerOutput");
+    return __isa(o, "CreateContainerOutput");
   }
 }
 
@@ -225,7 +228,7 @@ export interface DeleteContainerInput {
 
 export namespace DeleteContainerInput {
   export function isa(o: any): o is DeleteContainerInput {
-    return _smithy.isa(o, "DeleteContainerInput");
+    return __isa(o, "DeleteContainerInput");
   }
 }
 
@@ -235,7 +238,7 @@ export interface DeleteContainerOutput extends $MetadataBearer {
 
 export namespace DeleteContainerOutput {
   export function isa(o: any): o is DeleteContainerOutput {
-    return _smithy.isa(o, "DeleteContainerOutput");
+    return __isa(o, "DeleteContainerOutput");
   }
 }
 
@@ -249,7 +252,7 @@ export interface DeleteContainerPolicyInput {
 
 export namespace DeleteContainerPolicyInput {
   export function isa(o: any): o is DeleteContainerPolicyInput {
-    return _smithy.isa(o, "DeleteContainerPolicyInput");
+    return __isa(o, "DeleteContainerPolicyInput");
   }
 }
 
@@ -259,7 +262,7 @@ export interface DeleteContainerPolicyOutput extends $MetadataBearer {
 
 export namespace DeleteContainerPolicyOutput {
   export function isa(o: any): o is DeleteContainerPolicyOutput {
-    return _smithy.isa(o, "DeleteContainerPolicyOutput");
+    return __isa(o, "DeleteContainerPolicyOutput");
   }
 }
 
@@ -273,7 +276,7 @@ export interface DeleteCorsPolicyInput {
 
 export namespace DeleteCorsPolicyInput {
   export function isa(o: any): o is DeleteCorsPolicyInput {
-    return _smithy.isa(o, "DeleteCorsPolicyInput");
+    return __isa(o, "DeleteCorsPolicyInput");
   }
 }
 
@@ -283,7 +286,7 @@ export interface DeleteCorsPolicyOutput extends $MetadataBearer {
 
 export namespace DeleteCorsPolicyOutput {
   export function isa(o: any): o is DeleteCorsPolicyOutput {
-    return _smithy.isa(o, "DeleteCorsPolicyOutput");
+    return __isa(o, "DeleteCorsPolicyOutput");
   }
 }
 
@@ -297,7 +300,7 @@ export interface DeleteLifecyclePolicyInput {
 
 export namespace DeleteLifecyclePolicyInput {
   export function isa(o: any): o is DeleteLifecyclePolicyInput {
-    return _smithy.isa(o, "DeleteLifecyclePolicyInput");
+    return __isa(o, "DeleteLifecyclePolicyInput");
   }
 }
 
@@ -307,7 +310,7 @@ export interface DeleteLifecyclePolicyOutput extends $MetadataBearer {
 
 export namespace DeleteLifecyclePolicyOutput {
   export function isa(o: any): o is DeleteLifecyclePolicyOutput {
-    return _smithy.isa(o, "DeleteLifecyclePolicyOutput");
+    return __isa(o, "DeleteLifecyclePolicyOutput");
   }
 }
 
@@ -321,7 +324,7 @@ export interface DescribeContainerInput {
 
 export namespace DescribeContainerInput {
   export function isa(o: any): o is DescribeContainerInput {
-    return _smithy.isa(o, "DescribeContainerInput");
+    return __isa(o, "DescribeContainerInput");
   }
 }
 
@@ -335,7 +338,7 @@ export interface DescribeContainerOutput extends $MetadataBearer {
 
 export namespace DescribeContainerOutput {
   export function isa(o: any): o is DescribeContainerOutput {
-    return _smithy.isa(o, "DescribeContainerOutput");
+    return __isa(o, "DescribeContainerOutput");
   }
 }
 
@@ -349,7 +352,7 @@ export interface GetContainerPolicyInput {
 
 export namespace GetContainerPolicyInput {
   export function isa(o: any): o is GetContainerPolicyInput {
-    return _smithy.isa(o, "GetContainerPolicyInput");
+    return __isa(o, "GetContainerPolicyInput");
   }
 }
 
@@ -363,7 +366,7 @@ export interface GetContainerPolicyOutput extends $MetadataBearer {
 
 export namespace GetContainerPolicyOutput {
   export function isa(o: any): o is GetContainerPolicyOutput {
-    return _smithy.isa(o, "GetContainerPolicyOutput");
+    return __isa(o, "GetContainerPolicyOutput");
   }
 }
 
@@ -377,7 +380,7 @@ export interface GetCorsPolicyInput {
 
 export namespace GetCorsPolicyInput {
   export function isa(o: any): o is GetCorsPolicyInput {
-    return _smithy.isa(o, "GetCorsPolicyInput");
+    return __isa(o, "GetCorsPolicyInput");
   }
 }
 
@@ -391,7 +394,7 @@ export interface GetCorsPolicyOutput extends $MetadataBearer {
 
 export namespace GetCorsPolicyOutput {
   export function isa(o: any): o is GetCorsPolicyOutput {
-    return _smithy.isa(o, "GetCorsPolicyOutput");
+    return __isa(o, "GetCorsPolicyOutput");
   }
 }
 
@@ -405,7 +408,7 @@ export interface GetLifecyclePolicyInput {
 
 export namespace GetLifecyclePolicyInput {
   export function isa(o: any): o is GetLifecyclePolicyInput {
-    return _smithy.isa(o, "GetLifecyclePolicyInput");
+    return __isa(o, "GetLifecyclePolicyInput");
   }
 }
 
@@ -419,7 +422,7 @@ export interface GetLifecyclePolicyOutput extends $MetadataBearer {
 
 export namespace GetLifecyclePolicyOutput {
   export function isa(o: any): o is GetLifecyclePolicyOutput {
-    return _smithy.isa(o, "GetLifecyclePolicyOutput");
+    return __isa(o, "GetLifecyclePolicyOutput");
   }
 }
 
@@ -427,7 +430,7 @@ export namespace GetLifecyclePolicyOutput {
  * <p>The service is temporarily unavailable.</p>
  */
 export interface InternalServerError
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalServerError";
   $fault: "server";
@@ -436,7 +439,7 @@ export interface InternalServerError
 
 export namespace InternalServerError {
   export function isa(o: any): o is InternalServerError {
-    return _smithy.isa(o, "InternalServerError");
+    return __isa(o, "InternalServerError");
   }
 }
 
@@ -444,7 +447,7 @@ export namespace InternalServerError {
  * <p>A service limit has been exceeded.</p>
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -453,7 +456,7 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
@@ -475,7 +478,7 @@ export interface ListContainersInput {
 
 export namespace ListContainersInput {
   export function isa(o: any): o is ListContainersInput {
-    return _smithy.isa(o, "ListContainersInput");
+    return __isa(o, "ListContainersInput");
   }
 }
 
@@ -497,7 +500,7 @@ export interface ListContainersOutput extends $MetadataBearer {
 
 export namespace ListContainersOutput {
   export function isa(o: any): o is ListContainersOutput {
-    return _smithy.isa(o, "ListContainersOutput");
+    return __isa(o, "ListContainersOutput");
   }
 }
 
@@ -511,7 +514,7 @@ export interface ListTagsForResourceInput {
 
 export namespace ListTagsForResourceInput {
   export function isa(o: any): o is ListTagsForResourceInput {
-    return _smithy.isa(o, "ListTagsForResourceInput");
+    return __isa(o, "ListTagsForResourceInput");
   }
 }
 
@@ -525,7 +528,7 @@ export interface ListTagsForResourceOutput extends $MetadataBearer {
 
 export namespace ListTagsForResourceOutput {
   export function isa(o: any): o is ListTagsForResourceOutput {
-    return _smithy.isa(o, "ListTagsForResourceOutput");
+    return __isa(o, "ListTagsForResourceOutput");
   }
 }
 
@@ -540,7 +543,7 @@ export enum MethodName {
  * <p>The policy that you specified in the request does not exist.</p>
  */
 export interface PolicyNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "PolicyNotFoundException";
   $fault: "client";
@@ -549,7 +552,7 @@ export interface PolicyNotFoundException
 
 export namespace PolicyNotFoundException {
   export function isa(o: any): o is PolicyNotFoundException {
-    return _smithy.isa(o, "PolicyNotFoundException");
+    return __isa(o, "PolicyNotFoundException");
   }
 }
 
@@ -577,7 +580,7 @@ export interface PutContainerPolicyInput {
 
 export namespace PutContainerPolicyInput {
   export function isa(o: any): o is PutContainerPolicyInput {
-    return _smithy.isa(o, "PutContainerPolicyInput");
+    return __isa(o, "PutContainerPolicyInput");
   }
 }
 
@@ -587,7 +590,7 @@ export interface PutContainerPolicyOutput extends $MetadataBearer {
 
 export namespace PutContainerPolicyOutput {
   export function isa(o: any): o is PutContainerPolicyOutput {
-    return _smithy.isa(o, "PutContainerPolicyOutput");
+    return __isa(o, "PutContainerPolicyOutput");
   }
 }
 
@@ -606,7 +609,7 @@ export interface PutCorsPolicyInput {
 
 export namespace PutCorsPolicyInput {
   export function isa(o: any): o is PutCorsPolicyInput {
-    return _smithy.isa(o, "PutCorsPolicyInput");
+    return __isa(o, "PutCorsPolicyInput");
   }
 }
 
@@ -616,7 +619,7 @@ export interface PutCorsPolicyOutput extends $MetadataBearer {
 
 export namespace PutCorsPolicyOutput {
   export function isa(o: any): o is PutCorsPolicyOutput {
-    return _smithy.isa(o, "PutCorsPolicyOutput");
+    return __isa(o, "PutCorsPolicyOutput");
   }
 }
 
@@ -635,7 +638,7 @@ export interface PutLifecyclePolicyInput {
 
 export namespace PutLifecyclePolicyInput {
   export function isa(o: any): o is PutLifecyclePolicyInput {
-    return _smithy.isa(o, "PutLifecyclePolicyInput");
+    return __isa(o, "PutLifecyclePolicyInput");
   }
 }
 
@@ -645,7 +648,7 @@ export interface PutLifecyclePolicyOutput extends $MetadataBearer {
 
 export namespace PutLifecyclePolicyOutput {
   export function isa(o: any): o is PutLifecyclePolicyOutput {
-    return _smithy.isa(o, "PutLifecyclePolicyOutput");
+    return __isa(o, "PutLifecyclePolicyOutput");
   }
 }
 
@@ -659,7 +662,7 @@ export interface StartAccessLoggingInput {
 
 export namespace StartAccessLoggingInput {
   export function isa(o: any): o is StartAccessLoggingInput {
-    return _smithy.isa(o, "StartAccessLoggingInput");
+    return __isa(o, "StartAccessLoggingInput");
   }
 }
 
@@ -669,7 +672,7 @@ export interface StartAccessLoggingOutput extends $MetadataBearer {
 
 export namespace StartAccessLoggingOutput {
   export function isa(o: any): o is StartAccessLoggingOutput {
-    return _smithy.isa(o, "StartAccessLoggingOutput");
+    return __isa(o, "StartAccessLoggingOutput");
   }
 }
 
@@ -683,7 +686,7 @@ export interface StopAccessLoggingInput {
 
 export namespace StopAccessLoggingInput {
   export function isa(o: any): o is StopAccessLoggingInput {
-    return _smithy.isa(o, "StopAccessLoggingInput");
+    return __isa(o, "StopAccessLoggingInput");
   }
 }
 
@@ -693,7 +696,7 @@ export interface StopAccessLoggingOutput extends $MetadataBearer {
 
 export namespace StopAccessLoggingOutput {
   export function isa(o: any): o is StopAccessLoggingOutput {
-    return _smithy.isa(o, "StopAccessLoggingOutput");
+    return __isa(o, "StopAccessLoggingOutput");
   }
 }
 
@@ -720,7 +723,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -742,7 +745,7 @@ export interface TagResourceInput {
 
 export namespace TagResourceInput {
   export function isa(o: any): o is TagResourceInput {
-    return _smithy.isa(o, "TagResourceInput");
+    return __isa(o, "TagResourceInput");
   }
 }
 
@@ -752,7 +755,7 @@ export interface TagResourceOutput extends $MetadataBearer {
 
 export namespace TagResourceOutput {
   export function isa(o: any): o is TagResourceOutput {
-    return _smithy.isa(o, "TagResourceOutput");
+    return __isa(o, "TagResourceOutput");
   }
 }
 
@@ -773,7 +776,7 @@ export interface UntagResourceInput {
 
 export namespace UntagResourceInput {
   export function isa(o: any): o is UntagResourceInput {
-    return _smithy.isa(o, "UntagResourceInput");
+    return __isa(o, "UntagResourceInput");
   }
 }
 
@@ -783,6 +786,6 @@ export interface UntagResourceOutput extends $MetadataBearer {
 
 export namespace UntagResourceOutput {
   export function isa(o: any): o is UntagResourceOutput {
-    return _smithy.isa(o, "UntagResourceOutput");
+    return __isa(o, "UntagResourceOutput");
   }
 }

--- a/clients/client-mediatailor/models/index.ts
+++ b/clients/client-mediatailor/models/index.ts
@@ -1,11 +1,14 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
  * <p>Invalid request parameters.</p>
  */
 export interface BadRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "BadRequestException";
   $fault: "client";
@@ -14,7 +17,7 @@ export interface BadRequestException
 
 export namespace BadRequestException {
   export function isa(o: any): o is BadRequestException {
-    return _smithy.isa(o, "BadRequestException");
+    return __isa(o, "BadRequestException");
   }
 }
 
@@ -36,7 +39,7 @@ export interface CdnConfiguration {
 
 export namespace CdnConfiguration {
   export function isa(o: any): o is CdnConfiguration {
-    return _smithy.isa(o, "CdnConfiguration");
+    return __isa(o, "CdnConfiguration");
   }
 }
 
@@ -63,7 +66,7 @@ export interface DashConfiguration {
 
 export namespace DashConfiguration {
   export function isa(o: any): o is DashConfiguration {
-    return _smithy.isa(o, "DashConfiguration");
+    return __isa(o, "DashConfiguration");
   }
 }
 
@@ -85,7 +88,7 @@ export interface DashConfigurationForPut {
 
 export namespace DashConfigurationForPut {
   export function isa(o: any): o is DashConfigurationForPut {
-    return _smithy.isa(o, "DashConfigurationForPut");
+    return __isa(o, "DashConfigurationForPut");
   }
 }
 
@@ -99,7 +102,7 @@ export interface DeletePlaybackConfigurationRequest {
 
 export namespace DeletePlaybackConfigurationRequest {
   export function isa(o: any): o is DeletePlaybackConfigurationRequest {
-    return _smithy.isa(o, "DeletePlaybackConfigurationRequest");
+    return __isa(o, "DeletePlaybackConfigurationRequest");
   }
 }
 
@@ -109,7 +112,7 @@ export interface DeletePlaybackConfigurationResponse extends $MetadataBearer {
 
 export namespace DeletePlaybackConfigurationResponse {
   export function isa(o: any): o is DeletePlaybackConfigurationResponse {
-    return _smithy.isa(o, "DeletePlaybackConfigurationResponse");
+    return __isa(o, "DeletePlaybackConfigurationResponse");
   }
 }
 
@@ -123,7 +126,7 @@ export interface GetPlaybackConfigurationRequest {
 
 export namespace GetPlaybackConfigurationRequest {
   export function isa(o: any): o is GetPlaybackConfigurationRequest {
-    return _smithy.isa(o, "GetPlaybackConfigurationRequest");
+    return __isa(o, "GetPlaybackConfigurationRequest");
   }
 }
 
@@ -197,7 +200,7 @@ export interface GetPlaybackConfigurationResponse extends $MetadataBearer {
 
 export namespace GetPlaybackConfigurationResponse {
   export function isa(o: any): o is GetPlaybackConfigurationResponse {
-    return _smithy.isa(o, "GetPlaybackConfigurationResponse");
+    return __isa(o, "GetPlaybackConfigurationResponse");
   }
 }
 
@@ -214,7 +217,7 @@ export interface HlsConfiguration {
 
 export namespace HlsConfiguration {
   export function isa(o: any): o is HlsConfiguration {
-    return _smithy.isa(o, "HlsConfiguration");
+    return __isa(o, "HlsConfiguration");
   }
 }
 
@@ -233,7 +236,7 @@ export interface ListPlaybackConfigurationsRequest {
 
 export namespace ListPlaybackConfigurationsRequest {
   export function isa(o: any): o is ListPlaybackConfigurationsRequest {
-    return _smithy.isa(o, "ListPlaybackConfigurationsRequest");
+    return __isa(o, "ListPlaybackConfigurationsRequest");
   }
 }
 
@@ -252,7 +255,7 @@ export interface ListPlaybackConfigurationsResponse extends $MetadataBearer {
 
 export namespace ListPlaybackConfigurationsResponse {
   export function isa(o: any): o is ListPlaybackConfigurationsResponse {
-    return _smithy.isa(o, "ListPlaybackConfigurationsResponse");
+    return __isa(o, "ListPlaybackConfigurationsResponse");
   }
 }
 
@@ -266,7 +269,7 @@ export interface ListTagsForResourceRequest {
 
 export namespace ListTagsForResourceRequest {
   export function isa(o: any): o is ListTagsForResourceRequest {
-    return _smithy.isa(o, "ListTagsForResourceRequest");
+    return __isa(o, "ListTagsForResourceRequest");
   }
 }
 
@@ -285,7 +288,7 @@ export interface ListTagsForResourceResponse extends $MetadataBearer {
 
 export namespace ListTagsForResourceResponse {
   export function isa(o: any): o is ListTagsForResourceResponse {
-    return _smithy.isa(o, "ListTagsForResourceResponse");
+    return __isa(o, "ListTagsForResourceResponse");
   }
 }
 
@@ -307,7 +310,7 @@ export interface LivePreRollConfiguration {
 
 export namespace LivePreRollConfiguration {
   export function isa(o: any): o is LivePreRollConfiguration {
-    return _smithy.isa(o, "LivePreRollConfiguration");
+    return __isa(o, "LivePreRollConfiguration");
   }
 }
 
@@ -384,7 +387,7 @@ export interface PlaybackConfiguration {
 
 export namespace PlaybackConfiguration {
   export function isa(o: any): o is PlaybackConfiguration {
-    return _smithy.isa(o, "PlaybackConfiguration");
+    return __isa(o, "PlaybackConfiguration");
   }
 }
 
@@ -438,7 +441,7 @@ export interface PutPlaybackConfigurationRequest {
 
 export namespace PutPlaybackConfigurationRequest {
   export function isa(o: any): o is PutPlaybackConfigurationRequest {
-    return _smithy.isa(o, "PutPlaybackConfigurationRequest");
+    return __isa(o, "PutPlaybackConfigurationRequest");
   }
 }
 
@@ -512,7 +515,7 @@ export interface PutPlaybackConfigurationResponse extends $MetadataBearer {
 
 export namespace PutPlaybackConfigurationResponse {
   export function isa(o: any): o is PutPlaybackConfigurationResponse {
-    return _smithy.isa(o, "PutPlaybackConfigurationResponse");
+    return __isa(o, "PutPlaybackConfigurationResponse");
   }
 }
 
@@ -536,7 +539,7 @@ export interface TagResourceRequest {
 
 export namespace TagResourceRequest {
   export function isa(o: any): o is TagResourceRequest {
-    return _smithy.isa(o, "TagResourceRequest");
+    return __isa(o, "TagResourceRequest");
   }
 }
 
@@ -555,6 +558,6 @@ export interface UntagResourceRequest {
 
 export namespace UntagResourceRequest {
   export function isa(o: any): o is UntagResourceRequest {
-    return _smithy.isa(o, "UntagResourceRequest");
+    return __isa(o, "UntagResourceRequest");
   }
 }

--- a/clients/client-mediatailor/protocols/Aws_restJson1_1.ts
+++ b/clients/client-mediatailor/protocols/Aws_restJson1_1.ts
@@ -39,7 +39,10 @@ import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  extendedEncodeURIComponent as __extendedEncodeURIComponent
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -55,13 +58,13 @@ export async function serializeAws_restJson1_1DeletePlaybackConfigurationCommand
   headers["Content-Type"] = "";
   let resolvedPath = "/playbackConfiguration/{Name}";
   if (input.Name !== undefined) {
-    const labelValue: string = input.Name.toString();
+    const labelValue: string = input.Name;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Name.");
     }
     resolvedPath = resolvedPath.replace(
       "{Name}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Name.");
@@ -83,13 +86,13 @@ export async function serializeAws_restJson1_1GetPlaybackConfigurationCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/playbackConfiguration/{Name}";
   if (input.Name !== undefined) {
-    const labelValue: string = input.Name.toString();
+    const labelValue: string = input.Name;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Name.");
     }
     resolvedPath = resolvedPath.replace(
       "{Name}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Name.");
@@ -112,10 +115,14 @@ export async function serializeAws_restJson1_1ListPlaybackConfigurationsCommand(
   let resolvedPath = "/playbackConfigurations";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["MaxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("MaxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["NextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("NextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -135,7 +142,7 @@ export async function serializeAws_restJson1_1ListTagsForResourceCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/tags/{ResourceArn}";
   if (input.ResourceArn !== undefined) {
-    const labelValue: string = input.ResourceArn.toString();
+    const labelValue: string = input.ResourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ResourceArn."
@@ -143,7 +150,7 @@ export async function serializeAws_restJson1_1ListTagsForResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ResourceArn.");
@@ -228,7 +235,7 @@ export async function serializeAws_restJson1_1TagResourceCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/tags/{ResourceArn}";
   if (input.ResourceArn !== undefined) {
-    const labelValue: string = input.ResourceArn.toString();
+    const labelValue: string = input.ResourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ResourceArn."
@@ -236,7 +243,7 @@ export async function serializeAws_restJson1_1TagResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ResourceArn.");
@@ -268,7 +275,7 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/tags/{ResourceArn}";
   if (input.ResourceArn !== undefined) {
-    const labelValue: string = input.ResourceArn.toString();
+    const labelValue: string = input.ResourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ResourceArn."
@@ -276,14 +283,16 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ResourceArn.");
   }
   const query: any = {};
   if (input.TagKeys !== undefined) {
-    query["tagKeys"] = input.TagKeys;
+    query[__extendedEncodeURIComponent("tagKeys")] = input.TagKeys.map(entry =>
+      __extendedEncodeURIComponent(entry)
+    );
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -309,6 +318,7 @@ export async function deserializeAws_restJson1_1DeletePlaybackConfigurationComma
     $metadata: deserializeMetadata(output),
     __type: "DeletePlaybackConfigurationResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -732,6 +742,7 @@ export async function deserializeAws_restJson1_1TagResourceCommand(
   const contents: TagResourceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -779,6 +790,7 @@ export async function deserializeAws_restJson1_1UntagResourceCommand(
   const contents: UntagResourceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 

--- a/clients/client-migration-hub/models/index.ts
+++ b/clients/client-migration-hub/models/index.ts
@@ -1,11 +1,14 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
  * <p>You do not have sufficient access to perform this action.</p>
  */
 export interface AccessDeniedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AccessDeniedException";
   $fault: "client";
@@ -14,7 +17,7 @@ export interface AccessDeniedException
 
 export namespace AccessDeniedException {
   export function isa(o: any): o is AccessDeniedException {
-    return _smithy.isa(o, "AccessDeniedException");
+    return __isa(o, "AccessDeniedException");
   }
 }
 
@@ -43,7 +46,7 @@ export interface ApplicationState {
 
 export namespace ApplicationState {
   export function isa(o: any): o is ApplicationState {
-    return _smithy.isa(o, "ApplicationState");
+    return __isa(o, "ApplicationState");
   }
 }
 
@@ -82,7 +85,7 @@ export interface AssociateCreatedArtifactRequest {
 
 export namespace AssociateCreatedArtifactRequest {
   export function isa(o: any): o is AssociateCreatedArtifactRequest {
-    return _smithy.isa(o, "AssociateCreatedArtifactRequest");
+    return __isa(o, "AssociateCreatedArtifactRequest");
   }
 }
 
@@ -92,7 +95,7 @@ export interface AssociateCreatedArtifactResult extends $MetadataBearer {
 
 export namespace AssociateCreatedArtifactResult {
   export function isa(o: any): o is AssociateCreatedArtifactResult {
-    return _smithy.isa(o, "AssociateCreatedArtifactResult");
+    return __isa(o, "AssociateCreatedArtifactResult");
   }
 }
 
@@ -124,7 +127,7 @@ export interface AssociateDiscoveredResourceRequest {
 
 export namespace AssociateDiscoveredResourceRequest {
   export function isa(o: any): o is AssociateDiscoveredResourceRequest {
-    return _smithy.isa(o, "AssociateDiscoveredResourceRequest");
+    return __isa(o, "AssociateDiscoveredResourceRequest");
   }
 }
 
@@ -134,7 +137,7 @@ export interface AssociateDiscoveredResourceResult extends $MetadataBearer {
 
 export namespace AssociateDiscoveredResourceResult {
   export function isa(o: any): o is AssociateDiscoveredResourceResult {
-    return _smithy.isa(o, "AssociateDiscoveredResourceResult");
+    return __isa(o, "AssociateDiscoveredResourceResult");
   }
 }
 
@@ -156,7 +159,7 @@ export interface CreateProgressUpdateStreamRequest {
 
 export namespace CreateProgressUpdateStreamRequest {
   export function isa(o: any): o is CreateProgressUpdateStreamRequest {
-    return _smithy.isa(o, "CreateProgressUpdateStreamRequest");
+    return __isa(o, "CreateProgressUpdateStreamRequest");
   }
 }
 
@@ -166,7 +169,7 @@ export interface CreateProgressUpdateStreamResult extends $MetadataBearer {
 
 export namespace CreateProgressUpdateStreamResult {
   export function isa(o: any): o is CreateProgressUpdateStreamResult {
-    return _smithy.isa(o, "CreateProgressUpdateStreamResult");
+    return __isa(o, "CreateProgressUpdateStreamResult");
   }
 }
 
@@ -190,7 +193,7 @@ export interface CreatedArtifact {
 
 export namespace CreatedArtifact {
   export function isa(o: any): o is CreatedArtifact {
-    return _smithy.isa(o, "CreatedArtifact");
+    return __isa(o, "CreatedArtifact");
   }
 }
 
@@ -212,7 +215,7 @@ export interface DeleteProgressUpdateStreamRequest {
 
 export namespace DeleteProgressUpdateStreamRequest {
   export function isa(o: any): o is DeleteProgressUpdateStreamRequest {
-    return _smithy.isa(o, "DeleteProgressUpdateStreamRequest");
+    return __isa(o, "DeleteProgressUpdateStreamRequest");
   }
 }
 
@@ -222,7 +225,7 @@ export interface DeleteProgressUpdateStreamResult extends $MetadataBearer {
 
 export namespace DeleteProgressUpdateStreamResult {
   export function isa(o: any): o is DeleteProgressUpdateStreamResult {
-    return _smithy.isa(o, "DeleteProgressUpdateStreamResult");
+    return __isa(o, "DeleteProgressUpdateStreamResult");
   }
 }
 
@@ -237,7 +240,7 @@ export interface DescribeApplicationStateRequest {
 
 export namespace DescribeApplicationStateRequest {
   export function isa(o: any): o is DescribeApplicationStateRequest {
-    return _smithy.isa(o, "DescribeApplicationStateRequest");
+    return __isa(o, "DescribeApplicationStateRequest");
   }
 }
 
@@ -256,7 +259,7 @@ export interface DescribeApplicationStateResult extends $MetadataBearer {
 
 export namespace DescribeApplicationStateResult {
   export function isa(o: any): o is DescribeApplicationStateResult {
-    return _smithy.isa(o, "DescribeApplicationStateResult");
+    return __isa(o, "DescribeApplicationStateResult");
   }
 }
 
@@ -277,7 +280,7 @@ export interface DescribeMigrationTaskRequest {
 
 export namespace DescribeMigrationTaskRequest {
   export function isa(o: any): o is DescribeMigrationTaskRequest {
-    return _smithy.isa(o, "DescribeMigrationTaskRequest");
+    return __isa(o, "DescribeMigrationTaskRequest");
   }
 }
 
@@ -291,7 +294,7 @@ export interface DescribeMigrationTaskResult extends $MetadataBearer {
 
 export namespace DescribeMigrationTaskResult {
   export function isa(o: any): o is DescribeMigrationTaskResult {
-    return _smithy.isa(o, "DescribeMigrationTaskResult");
+    return __isa(o, "DescribeMigrationTaskResult");
   }
 }
 
@@ -324,7 +327,7 @@ export interface DisassociateCreatedArtifactRequest {
 
 export namespace DisassociateCreatedArtifactRequest {
   export function isa(o: any): o is DisassociateCreatedArtifactRequest {
-    return _smithy.isa(o, "DisassociateCreatedArtifactRequest");
+    return __isa(o, "DisassociateCreatedArtifactRequest");
   }
 }
 
@@ -334,7 +337,7 @@ export interface DisassociateCreatedArtifactResult extends $MetadataBearer {
 
 export namespace DisassociateCreatedArtifactResult {
   export function isa(o: any): o is DisassociateCreatedArtifactResult {
-    return _smithy.isa(o, "DisassociateCreatedArtifactResult");
+    return __isa(o, "DisassociateCreatedArtifactResult");
   }
 }
 
@@ -367,7 +370,7 @@ export interface DisassociateDiscoveredResourceRequest {
 
 export namespace DisassociateDiscoveredResourceRequest {
   export function isa(o: any): o is DisassociateDiscoveredResourceRequest {
-    return _smithy.isa(o, "DisassociateDiscoveredResourceRequest");
+    return __isa(o, "DisassociateDiscoveredResourceRequest");
   }
 }
 
@@ -377,7 +380,7 @@ export interface DisassociateDiscoveredResourceResult extends $MetadataBearer {
 
 export namespace DisassociateDiscoveredResourceResult {
   export function isa(o: any): o is DisassociateDiscoveredResourceResult {
-    return _smithy.isa(o, "DisassociateDiscoveredResourceResult");
+    return __isa(o, "DisassociateDiscoveredResourceResult");
   }
 }
 
@@ -401,7 +404,7 @@ export interface DiscoveredResource {
 
 export namespace DiscoveredResource {
   export function isa(o: any): o is DiscoveredResource {
-    return _smithy.isa(o, "DiscoveredResource");
+    return __isa(o, "DiscoveredResource");
   }
 }
 
@@ -409,9 +412,7 @@ export namespace DiscoveredResource {
  * <p>Exception raised to indicate a successfully authorized action when the
  *             <code>DryRun</code> flag is set to "true".</p>
  */
-export interface DryRunOperation
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface DryRunOperation extends __SmithyException, $MetadataBearer {
   name: "DryRunOperation";
   $fault: "client";
   Message?: string;
@@ -419,7 +420,7 @@ export interface DryRunOperation
 
 export namespace DryRunOperation {
   export function isa(o: any): o is DryRunOperation {
-    return _smithy.isa(o, "DryRunOperation");
+    return __isa(o, "DryRunOperation");
   }
 }
 
@@ -427,7 +428,7 @@ export namespace DryRunOperation {
  * <p>The home region is not set. Set the home region to continue.</p>
  */
 export interface HomeRegionNotSetException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "HomeRegionNotSetException";
   $fault: "client";
@@ -436,7 +437,7 @@ export interface HomeRegionNotSetException
 
 export namespace HomeRegionNotSetException {
   export function isa(o: any): o is HomeRegionNotSetException {
-    return _smithy.isa(o, "HomeRegionNotSetException");
+    return __isa(o, "HomeRegionNotSetException");
   }
 }
 
@@ -463,7 +464,7 @@ export interface ImportMigrationTaskRequest {
 
 export namespace ImportMigrationTaskRequest {
   export function isa(o: any): o is ImportMigrationTaskRequest {
-    return _smithy.isa(o, "ImportMigrationTaskRequest");
+    return __isa(o, "ImportMigrationTaskRequest");
   }
 }
 
@@ -473,7 +474,7 @@ export interface ImportMigrationTaskResult extends $MetadataBearer {
 
 export namespace ImportMigrationTaskResult {
   export function isa(o: any): o is ImportMigrationTaskResult {
-    return _smithy.isa(o, "ImportMigrationTaskResult");
+    return __isa(o, "ImportMigrationTaskResult");
   }
 }
 
@@ -482,7 +483,7 @@ export namespace ImportMigrationTaskResult {
  *          encountered.</p>
  */
 export interface InternalServerError
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalServerError";
   $fault: "server";
@@ -491,7 +492,7 @@ export interface InternalServerError
 
 export namespace InternalServerError {
   export function isa(o: any): o is InternalServerError {
-    return _smithy.isa(o, "InternalServerError");
+    return __isa(o, "InternalServerError");
   }
 }
 
@@ -500,7 +501,7 @@ export namespace InternalServerError {
  *          the wrong format or data type.</p>
  */
 export interface InvalidInputException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidInputException";
   $fault: "client";
@@ -509,7 +510,7 @@ export interface InvalidInputException
 
 export namespace InvalidInputException {
   export function isa(o: any): o is InvalidInputException {
-    return _smithy.isa(o, "InvalidInputException");
+    return __isa(o, "InvalidInputException");
   }
 }
 
@@ -536,7 +537,7 @@ export interface ListApplicationStatesRequest {
 
 export namespace ListApplicationStatesRequest {
   export function isa(o: any): o is ListApplicationStatesRequest {
-    return _smithy.isa(o, "ListApplicationStatesRequest");
+    return __isa(o, "ListApplicationStatesRequest");
   }
 }
 
@@ -557,7 +558,7 @@ export interface ListApplicationStatesResult extends $MetadataBearer {
 
 export namespace ListApplicationStatesResult {
   export function isa(o: any): o is ListApplicationStatesResult {
-    return _smithy.isa(o, "ListApplicationStatesResult");
+    return __isa(o, "ListApplicationStatesResult");
   }
 }
 
@@ -590,7 +591,7 @@ export interface ListCreatedArtifactsRequest {
 
 export namespace ListCreatedArtifactsRequest {
   export function isa(o: any): o is ListCreatedArtifactsRequest {
-    return _smithy.isa(o, "ListCreatedArtifactsRequest");
+    return __isa(o, "ListCreatedArtifactsRequest");
   }
 }
 
@@ -611,7 +612,7 @@ export interface ListCreatedArtifactsResult extends $MetadataBearer {
 
 export namespace ListCreatedArtifactsResult {
   export function isa(o: any): o is ListCreatedArtifactsResult {
-    return _smithy.isa(o, "ListCreatedArtifactsResult");
+    return __isa(o, "ListCreatedArtifactsResult");
   }
 }
 
@@ -644,7 +645,7 @@ export interface ListDiscoveredResourcesRequest {
 
 export namespace ListDiscoveredResourcesRequest {
   export function isa(o: any): o is ListDiscoveredResourcesRequest {
-    return _smithy.isa(o, "ListDiscoveredResourcesRequest");
+    return __isa(o, "ListDiscoveredResourcesRequest");
   }
 }
 
@@ -664,7 +665,7 @@ export interface ListDiscoveredResourcesResult extends $MetadataBearer {
 
 export namespace ListDiscoveredResourcesResult {
   export function isa(o: any): o is ListDiscoveredResourcesResult {
-    return _smithy.isa(o, "ListDiscoveredResourcesResult");
+    return __isa(o, "ListDiscoveredResourcesResult");
   }
 }
 
@@ -690,7 +691,7 @@ export interface ListMigrationTasksRequest {
 
 export namespace ListMigrationTasksRequest {
   export function isa(o: any): o is ListMigrationTasksRequest {
-    return _smithy.isa(o, "ListMigrationTasksRequest");
+    return __isa(o, "ListMigrationTasksRequest");
   }
 }
 
@@ -712,7 +713,7 @@ export interface ListMigrationTasksResult extends $MetadataBearer {
 
 export namespace ListMigrationTasksResult {
   export function isa(o: any): o is ListMigrationTasksResult {
-    return _smithy.isa(o, "ListMigrationTasksResult");
+    return __isa(o, "ListMigrationTasksResult");
   }
 }
 
@@ -733,7 +734,7 @@ export interface ListProgressUpdateStreamsRequest {
 
 export namespace ListProgressUpdateStreamsRequest {
   export function isa(o: any): o is ListProgressUpdateStreamsRequest {
-    return _smithy.isa(o, "ListProgressUpdateStreamsRequest");
+    return __isa(o, "ListProgressUpdateStreamsRequest");
   }
 }
 
@@ -754,7 +755,7 @@ export interface ListProgressUpdateStreamsResult extends $MetadataBearer {
 
 export namespace ListProgressUpdateStreamsResult {
   export function isa(o: any): o is ListProgressUpdateStreamsResult {
-    return _smithy.isa(o, "ListProgressUpdateStreamsResult");
+    return __isa(o, "ListProgressUpdateStreamsResult");
   }
 }
 
@@ -794,7 +795,7 @@ export interface MigrationTask {
 
 export namespace MigrationTask {
   export function isa(o: any): o is MigrationTask {
-    return _smithy.isa(o, "MigrationTask");
+    return __isa(o, "MigrationTask");
   }
 }
 
@@ -841,7 +842,7 @@ export interface MigrationTaskSummary {
 
 export namespace MigrationTaskSummary {
   export function isa(o: any): o is MigrationTaskSummary {
-    return _smithy.isa(o, "MigrationTaskSummary");
+    return __isa(o, "MigrationTaskSummary");
   }
 }
 
@@ -872,7 +873,7 @@ export interface NotifyApplicationStateRequest {
 
 export namespace NotifyApplicationStateRequest {
   export function isa(o: any): o is NotifyApplicationStateRequest {
-    return _smithy.isa(o, "NotifyApplicationStateRequest");
+    return __isa(o, "NotifyApplicationStateRequest");
   }
 }
 
@@ -882,7 +883,7 @@ export interface NotifyApplicationStateResult extends $MetadataBearer {
 
 export namespace NotifyApplicationStateResult {
   export function isa(o: any): o is NotifyApplicationStateResult {
-    return _smithy.isa(o, "NotifyApplicationStateResult");
+    return __isa(o, "NotifyApplicationStateResult");
   }
 }
 
@@ -926,7 +927,7 @@ export interface NotifyMigrationTaskStateRequest {
 
 export namespace NotifyMigrationTaskStateRequest {
   export function isa(o: any): o is NotifyMigrationTaskStateRequest {
-    return _smithy.isa(o, "NotifyMigrationTaskStateRequest");
+    return __isa(o, "NotifyMigrationTaskStateRequest");
   }
 }
 
@@ -936,7 +937,7 @@ export interface NotifyMigrationTaskStateResult extends $MetadataBearer {
 
 export namespace NotifyMigrationTaskStateResult {
   export function isa(o: any): o is NotifyMigrationTaskStateResult {
-    return _smithy.isa(o, "NotifyMigrationTaskStateResult");
+    return __isa(o, "NotifyMigrationTaskStateResult");
   }
 }
 
@@ -946,7 +947,7 @@ export namespace NotifyMigrationTaskStateResult {
  *             <code>migrationhub-discovery</code> role is missing or not configured correctly.</p>
  */
 export interface PolicyErrorException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "PolicyErrorException";
   $fault: "client";
@@ -955,7 +956,7 @@ export interface PolicyErrorException
 
 export namespace PolicyErrorException {
   export function isa(o: any): o is PolicyErrorException {
-    return _smithy.isa(o, "PolicyErrorException");
+    return __isa(o, "PolicyErrorException");
   }
 }
 
@@ -975,7 +976,7 @@ export interface ProgressUpdateStreamSummary {
 
 export namespace ProgressUpdateStreamSummary {
   export function isa(o: any): o is ProgressUpdateStreamSummary {
-    return _smithy.isa(o, "ProgressUpdateStreamSummary");
+    return __isa(o, "ProgressUpdateStreamSummary");
   }
 }
 
@@ -1034,7 +1035,7 @@ export interface PutResourceAttributesRequest {
 
 export namespace PutResourceAttributesRequest {
   export function isa(o: any): o is PutResourceAttributesRequest {
-    return _smithy.isa(o, "PutResourceAttributesRequest");
+    return __isa(o, "PutResourceAttributesRequest");
   }
 }
 
@@ -1044,7 +1045,7 @@ export interface PutResourceAttributesResult extends $MetadataBearer {
 
 export namespace PutResourceAttributesResult {
   export function isa(o: any): o is PutResourceAttributesResult {
-    return _smithy.isa(o, "PutResourceAttributesResult");
+    return __isa(o, "PutResourceAttributesResult");
   }
 }
 
@@ -1102,7 +1103,7 @@ export interface ResourceAttribute {
 
 export namespace ResourceAttribute {
   export function isa(o: any): o is ResourceAttribute {
-    return _smithy.isa(o, "ResourceAttribute");
+    return __isa(o, "ResourceAttribute");
   }
 }
 
@@ -1125,7 +1126,7 @@ export enum ResourceAttributeType {
  *          Discovery Service (Application Discovery Service) or in Migration Hub's repository.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -1134,7 +1135,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -1143,7 +1144,7 @@ export namespace ResourceNotFoundException {
  *          encountered.</p>
  */
 export interface ServiceUnavailableException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ServiceUnavailableException";
   $fault: "server";
@@ -1152,7 +1153,7 @@ export interface ServiceUnavailableException
 
 export namespace ServiceUnavailableException {
   export function isa(o: any): o is ServiceUnavailableException {
-    return _smithy.isa(o, "ServiceUnavailableException");
+    return __isa(o, "ServiceUnavailableException");
   }
 }
 
@@ -1188,7 +1189,7 @@ export interface Task {
 
 export namespace Task {
   export function isa(o: any): o is Task {
-    return _smithy.isa(o, "Task");
+    return __isa(o, "Task");
   }
 }
 
@@ -1197,7 +1198,7 @@ export namespace Task {
  *          flag is set to "true".</p>
  */
 export interface UnauthorizedOperation
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UnauthorizedOperation";
   $fault: "client";
@@ -1206,6 +1207,6 @@ export interface UnauthorizedOperation
 
 export namespace UnauthorizedOperation {
   export function isa(o: any): o is UnauthorizedOperation {
-    return _smithy.isa(o, "UnauthorizedOperation");
+    return __isa(o, "UnauthorizedOperation");
   }
 }

--- a/clients/client-migrationhub-config/models/index.ts
+++ b/clients/client-migrationhub-config/models/index.ts
@@ -1,11 +1,14 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
  * <p>You do not have sufficient access to perform this action.</p>
  */
 export interface AccessDeniedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AccessDeniedException";
   $fault: "client";
@@ -14,7 +17,7 @@ export interface AccessDeniedException
 
 export namespace AccessDeniedException {
   export function isa(o: any): o is AccessDeniedException {
-    return _smithy.isa(o, "AccessDeniedException");
+    return __isa(o, "AccessDeniedException");
   }
 }
 
@@ -39,7 +42,7 @@ export interface CreateHomeRegionControlRequest {
 
 export namespace CreateHomeRegionControlRequest {
   export function isa(o: any): o is CreateHomeRegionControlRequest {
-    return _smithy.isa(o, "CreateHomeRegionControlRequest");
+    return __isa(o, "CreateHomeRegionControlRequest");
   }
 }
 
@@ -54,7 +57,7 @@ export interface CreateHomeRegionControlResult extends $MetadataBearer {
 
 export namespace CreateHomeRegionControlResult {
   export function isa(o: any): o is CreateHomeRegionControlResult {
-    return _smithy.isa(o, "CreateHomeRegionControlResult");
+    return __isa(o, "CreateHomeRegionControlResult");
   }
 }
 
@@ -92,7 +95,7 @@ export interface DescribeHomeRegionControlsRequest {
 
 export namespace DescribeHomeRegionControlsRequest {
   export function isa(o: any): o is DescribeHomeRegionControlsRequest {
-    return _smithy.isa(o, "DescribeHomeRegionControlsRequest");
+    return __isa(o, "DescribeHomeRegionControlsRequest");
   }
 }
 
@@ -113,7 +116,7 @@ export interface DescribeHomeRegionControlsResult extends $MetadataBearer {
 
 export namespace DescribeHomeRegionControlsResult {
   export function isa(o: any): o is DescribeHomeRegionControlsResult {
-    return _smithy.isa(o, "DescribeHomeRegionControlsResult");
+    return __isa(o, "DescribeHomeRegionControlsResult");
   }
 }
 
@@ -121,9 +124,7 @@ export namespace DescribeHomeRegionControlsResult {
  * <p>Exception raised to indicate that authorization of an action was successful, when the
  *         <code>DryRun</code> flag is set to true.</p>
  */
-export interface DryRunOperation
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface DryRunOperation extends __SmithyException, $MetadataBearer {
   name: "DryRunOperation";
   $fault: "client";
   Message?: string;
@@ -131,7 +132,7 @@ export interface DryRunOperation
 
 export namespace DryRunOperation {
   export function isa(o: any): o is DryRunOperation {
-    return _smithy.isa(o, "DryRunOperation");
+    return __isa(o, "DryRunOperation");
   }
 }
 
@@ -141,7 +142,7 @@ export interface GetHomeRegionRequest {
 
 export namespace GetHomeRegionRequest {
   export function isa(o: any): o is GetHomeRegionRequest {
-    return _smithy.isa(o, "GetHomeRegionRequest");
+    return __isa(o, "GetHomeRegionRequest");
   }
 }
 
@@ -155,7 +156,7 @@ export interface GetHomeRegionResult extends $MetadataBearer {
 
 export namespace GetHomeRegionResult {
   export function isa(o: any): o is GetHomeRegionResult {
-    return _smithy.isa(o, "GetHomeRegionResult");
+    return __isa(o, "GetHomeRegionResult");
   }
 }
 
@@ -194,7 +195,7 @@ export interface HomeRegionControl {
 
 export namespace HomeRegionControl {
   export function isa(o: any): o is HomeRegionControl {
-    return _smithy.isa(o, "HomeRegionControl");
+    return __isa(o, "HomeRegionControl");
   }
 }
 
@@ -203,7 +204,7 @@ export namespace HomeRegionControl {
  *       encountered.</p>
  */
 export interface InternalServerError
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalServerError";
   $fault: "server";
@@ -212,7 +213,7 @@ export interface InternalServerError
 
 export namespace InternalServerError {
   export function isa(o: any): o is InternalServerError {
-    return _smithy.isa(o, "InternalServerError");
+    return __isa(o, "InternalServerError");
   }
 }
 
@@ -221,7 +222,7 @@ export namespace InternalServerError {
  *       wrong format or data type.</p>
  */
 export interface InvalidInputException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidInputException";
   $fault: "client";
@@ -230,7 +231,7 @@ export interface InvalidInputException
 
 export namespace InvalidInputException {
   export function isa(o: any): o is InvalidInputException {
-    return _smithy.isa(o, "InvalidInputException");
+    return __isa(o, "InvalidInputException");
   }
 }
 
@@ -238,7 +239,7 @@ export namespace InvalidInputException {
  * <p>Exception raised when a request fails due to temporary unavailability of the service.</p>
  */
 export interface ServiceUnavailableException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ServiceUnavailableException";
   $fault: "server";
@@ -247,7 +248,7 @@ export interface ServiceUnavailableException
 
 export namespace ServiceUnavailableException {
   export function isa(o: any): o is ServiceUnavailableException {
-    return _smithy.isa(o, "ServiceUnavailableException");
+    return __isa(o, "ServiceUnavailableException");
   }
 }
 
@@ -271,7 +272,7 @@ export interface Target {
 
 export namespace Target {
   export function isa(o: any): o is Target {
-    return _smithy.isa(o, "Target");
+    return __isa(o, "Target");
   }
 }
 

--- a/clients/client-mobile/models/index.ts
+++ b/clients/client-mobile/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -7,7 +10,7 @@ import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
  *         </p>
  */
 export interface AccountActionRequiredException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AccountActionRequiredException";
   $fault: "client";
@@ -21,7 +24,7 @@ export interface AccountActionRequiredException
 
 export namespace AccountActionRequiredException {
   export function isa(o: any): o is AccountActionRequiredException {
-    return _smithy.isa(o, "AccountActionRequiredException");
+    return __isa(o, "AccountActionRequiredException");
   }
 }
 
@@ -32,7 +35,7 @@ export namespace AccountActionRequiredException {
  *         </p>
  */
 export interface BadRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "BadRequestException";
   $fault: "client";
@@ -46,7 +49,7 @@ export interface BadRequestException
 
 export namespace BadRequestException {
   export function isa(o: any): o is BadRequestException {
-    return _smithy.isa(o, "BadRequestException");
+    return __isa(o, "BadRequestException");
   }
 }
 
@@ -102,7 +105,7 @@ export interface BundleDetails {
 
 export namespace BundleDetails {
   export function isa(o: any): o is BundleDetails {
-    return _smithy.isa(o, "BundleDetails");
+    return __isa(o, "BundleDetails");
   }
 }
 
@@ -147,7 +150,7 @@ export interface CreateProjectRequest {
 
 export namespace CreateProjectRequest {
   export function isa(o: any): o is CreateProjectRequest {
-    return _smithy.isa(o, "CreateProjectRequest");
+    return __isa(o, "CreateProjectRequest");
   }
 }
 
@@ -168,7 +171,7 @@ export interface CreateProjectResult extends $MetadataBearer {
 
 export namespace CreateProjectResult {
   export function isa(o: any): o is CreateProjectResult {
-    return _smithy.isa(o, "CreateProjectResult");
+    return __isa(o, "CreateProjectResult");
   }
 }
 
@@ -189,7 +192,7 @@ export interface DeleteProjectRequest {
 
 export namespace DeleteProjectRequest {
   export function isa(o: any): o is DeleteProjectRequest {
-    return _smithy.isa(o, "DeleteProjectRequest");
+    return __isa(o, "DeleteProjectRequest");
   }
 }
 
@@ -218,7 +221,7 @@ export interface DeleteProjectResult extends $MetadataBearer {
 
 export namespace DeleteProjectResult {
   export function isa(o: any): o is DeleteProjectResult {
-    return _smithy.isa(o, "DeleteProjectResult");
+    return __isa(o, "DeleteProjectResult");
   }
 }
 
@@ -239,7 +242,7 @@ export interface DescribeBundleRequest {
 
 export namespace DescribeBundleRequest {
   export function isa(o: any): o is DescribeBundleRequest {
-    return _smithy.isa(o, "DescribeBundleRequest");
+    return __isa(o, "DescribeBundleRequest");
   }
 }
 
@@ -260,7 +263,7 @@ export interface DescribeBundleResult extends $MetadataBearer {
 
 export namespace DescribeBundleResult {
   export function isa(o: any): o is DescribeBundleResult {
-    return _smithy.isa(o, "DescribeBundleResult");
+    return __isa(o, "DescribeBundleResult");
   }
 }
 
@@ -288,7 +291,7 @@ export interface DescribeProjectRequest {
 
 export namespace DescribeProjectRequest {
   export function isa(o: any): o is DescribeProjectRequest {
-    return _smithy.isa(o, "DescribeProjectRequest");
+    return __isa(o, "DescribeProjectRequest");
   }
 }
 
@@ -309,7 +312,7 @@ export interface DescribeProjectResult extends $MetadataBearer {
 
 export namespace DescribeProjectResult {
   export function isa(o: any): o is DescribeProjectResult {
-    return _smithy.isa(o, "DescribeProjectResult");
+    return __isa(o, "DescribeProjectResult");
   }
 }
 
@@ -345,7 +348,7 @@ export interface ExportBundleRequest {
 
 export namespace ExportBundleRequest {
   export function isa(o: any): o is ExportBundleRequest {
-    return _smithy.isa(o, "ExportBundleRequest");
+    return __isa(o, "ExportBundleRequest");
   }
 }
 
@@ -370,7 +373,7 @@ export interface ExportBundleResult extends $MetadataBearer {
 
 export namespace ExportBundleResult {
   export function isa(o: any): o is ExportBundleResult {
-    return _smithy.isa(o, "ExportBundleResult");
+    return __isa(o, "ExportBundleResult");
   }
 }
 
@@ -391,7 +394,7 @@ export interface ExportProjectRequest {
 
 export namespace ExportProjectRequest {
   export function isa(o: any): o is ExportProjectRequest {
-    return _smithy.isa(o, "ExportProjectRequest");
+    return __isa(o, "ExportProjectRequest");
   }
 }
 
@@ -432,7 +435,7 @@ export interface ExportProjectResult extends $MetadataBearer {
 
 export namespace ExportProjectResult {
   export function isa(o: any): o is ExportProjectResult {
-    return _smithy.isa(o, "ExportProjectResult");
+    return __isa(o, "ExportProjectResult");
   }
 }
 
@@ -443,7 +446,7 @@ export namespace ExportProjectResult {
  *         </p>
  */
 export interface InternalFailureException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalFailureException";
   $fault: "server";
@@ -457,7 +460,7 @@ export interface InternalFailureException
 
 export namespace InternalFailureException {
   export function isa(o: any): o is InternalFailureException {
-    return _smithy.isa(o, "InternalFailureException");
+    return __isa(o, "InternalFailureException");
   }
 }
 
@@ -470,7 +473,7 @@ export namespace InternalFailureException {
  *         </p>
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -491,7 +494,7 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
@@ -521,7 +524,7 @@ export interface ListBundlesRequest {
 
 export namespace ListBundlesRequest {
   export function isa(o: any): o is ListBundlesRequest {
-    return _smithy.isa(o, "ListBundlesRequest");
+    return __isa(o, "ListBundlesRequest");
   }
 }
 
@@ -550,7 +553,7 @@ export interface ListBundlesResult extends $MetadataBearer {
 
 export namespace ListBundlesResult {
   export function isa(o: any): o is ListBundlesResult {
-    return _smithy.isa(o, "ListBundlesResult");
+    return __isa(o, "ListBundlesResult");
   }
 }
 
@@ -580,7 +583,7 @@ export interface ListProjectsRequest {
 
 export namespace ListProjectsRequest {
   export function isa(o: any): o is ListProjectsRequest {
-    return _smithy.isa(o, "ListProjectsRequest");
+    return __isa(o, "ListProjectsRequest");
   }
 }
 
@@ -610,7 +613,7 @@ export interface ListProjectsResult extends $MetadataBearer {
 
 export namespace ListProjectsResult {
   export function isa(o: any): o is ListProjectsResult {
-    return _smithy.isa(o, "ListProjectsResult");
+    return __isa(o, "ListProjectsResult");
   }
 }
 
@@ -619,9 +622,7 @@ export namespace ListProjectsResult {
  *             No entity can be found with the specified identifier.
  *         </p>
  */
-export interface NotFoundException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface NotFoundException extends __SmithyException, $MetadataBearer {
   name: "NotFoundException";
   $fault: "client";
   /**
@@ -634,7 +635,7 @@ export interface NotFoundException
 
 export namespace NotFoundException {
   export function isa(o: any): o is NotFoundException {
-    return _smithy.isa(o, "NotFoundException");
+    return __isa(o, "NotFoundException");
   }
 }
 
@@ -714,7 +715,7 @@ export interface ProjectDetails {
 
 export namespace ProjectDetails {
   export function isa(o: any): o is ProjectDetails {
-    return _smithy.isa(o, "ProjectDetails");
+    return __isa(o, "ProjectDetails");
   }
 }
 
@@ -748,7 +749,7 @@ export interface ProjectSummary {
 
 export namespace ProjectSummary {
   export function isa(o: any): o is ProjectSummary {
-    return _smithy.isa(o, "ProjectSummary");
+    return __isa(o, "ProjectSummary");
   }
 }
 
@@ -797,7 +798,7 @@ export interface Resource {
 
 export namespace Resource {
   export function isa(o: any): o is Resource {
-    return _smithy.isa(o, "Resource");
+    return __isa(o, "Resource");
   }
 }
 
@@ -808,7 +809,7 @@ export namespace Resource {
  *         </p>
  */
 export interface ServiceUnavailableException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ServiceUnavailableException";
   $fault: "server";
@@ -829,7 +830,7 @@ export interface ServiceUnavailableException
 
 export namespace ServiceUnavailableException {
   export function isa(o: any): o is ServiceUnavailableException {
-    return _smithy.isa(o, "ServiceUnavailableException");
+    return __isa(o, "ServiceUnavailableException");
   }
 }
 
@@ -840,7 +841,7 @@ export namespace ServiceUnavailableException {
  *         </p>
  */
 export interface TooManyRequestsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyRequestsException";
   $fault: "client";
@@ -861,7 +862,7 @@ export interface TooManyRequestsException
 
 export namespace TooManyRequestsException {
   export function isa(o: any): o is TooManyRequestsException {
-    return _smithy.isa(o, "TooManyRequestsException");
+    return __isa(o, "TooManyRequestsException");
   }
 }
 
@@ -871,7 +872,7 @@ export namespace TooManyRequestsException {
  *         </p>
  */
 export interface UnauthorizedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UnauthorizedException";
   $fault: "client";
@@ -885,7 +886,7 @@ export interface UnauthorizedException
 
 export namespace UnauthorizedException {
   export function isa(o: any): o is UnauthorizedException {
-    return _smithy.isa(o, "UnauthorizedException");
+    return __isa(o, "UnauthorizedException");
   }
 }
 
@@ -915,7 +916,7 @@ export interface UpdateProjectRequest {
 
 export namespace UpdateProjectRequest {
   export function isa(o: any): o is UpdateProjectRequest {
-    return _smithy.isa(o, "UpdateProjectRequest");
+    return __isa(o, "UpdateProjectRequest");
   }
 }
 
@@ -936,6 +937,6 @@ export interface UpdateProjectResult extends $MetadataBearer {
 
 export namespace UpdateProjectResult {
   export function isa(o: any): o is UpdateProjectResult {
-    return _smithy.isa(o, "UpdateProjectResult");
+    return __isa(o, "UpdateProjectResult");
   }
 }

--- a/clients/client-mobile/protocols/Aws_restJson1_1.ts
+++ b/clients/client-mobile/protocols/Aws_restJson1_1.ts
@@ -53,7 +53,10 @@ import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  extendedEncodeURIComponent as __extendedEncodeURIComponent
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -70,13 +73,19 @@ export async function serializeAws_restJson1_1CreateProjectCommand(
   let resolvedPath = "/projects";
   const query: any = {};
   if (input.name !== undefined) {
-    query["name"] = input.name.toString();
+    query[__extendedEncodeURIComponent("name")] = __extendedEncodeURIComponent(
+      input.name
+    );
   }
   if (input.region !== undefined) {
-    query["region"] = input.region.toString();
+    query[
+      __extendedEncodeURIComponent("region")
+    ] = __extendedEncodeURIComponent(input.region);
   }
   if (input.snapshotId !== undefined) {
-    query["snapshotId"] = input.snapshotId.toString();
+    query[
+      __extendedEncodeURIComponent("snapshotId")
+    ] = __extendedEncodeURIComponent(input.snapshotId);
   }
   let body: any;
   if (input.contents !== undefined) {
@@ -101,13 +110,13 @@ export async function serializeAws_restJson1_1DeleteProjectCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/projects/{projectId}";
   if (input.projectId !== undefined) {
-    const labelValue: string = input.projectId.toString();
+    const labelValue: string = input.projectId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: projectId.");
     }
     resolvedPath = resolvedPath.replace(
       "{projectId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: projectId.");
@@ -129,13 +138,13 @@ export async function serializeAws_restJson1_1DescribeBundleCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/bundles/{bundleId}";
   if (input.bundleId !== undefined) {
-    const labelValue: string = input.bundleId.toString();
+    const labelValue: string = input.bundleId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: bundleId.");
     }
     resolvedPath = resolvedPath.replace(
       "{bundleId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: bundleId.");
@@ -158,10 +167,14 @@ export async function serializeAws_restJson1_1DescribeProjectCommand(
   let resolvedPath = "/project";
   const query: any = {};
   if (input.projectId !== undefined) {
-    query["projectId"] = input.projectId.toString();
+    query[
+      __extendedEncodeURIComponent("projectId")
+    ] = __extendedEncodeURIComponent(input.projectId);
   }
   if (input.syncFromResources !== undefined) {
-    query["syncFromResources"] = input.syncFromResources.toString();
+    query[
+      __extendedEncodeURIComponent("syncFromResources")
+    ] = __extendedEncodeURIComponent(input.syncFromResources.toString());
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -181,23 +194,27 @@ export async function serializeAws_restJson1_1ExportBundleCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/bundles/{bundleId}";
   if (input.bundleId !== undefined) {
-    const labelValue: string = input.bundleId.toString();
+    const labelValue: string = input.bundleId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: bundleId.");
     }
     resolvedPath = resolvedPath.replace(
       "{bundleId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: bundleId.");
   }
   const query: any = {};
   if (input.platform !== undefined) {
-    query["platform"] = input.platform.toString();
+    query[
+      __extendedEncodeURIComponent("platform")
+    ] = __extendedEncodeURIComponent(input.platform);
   }
   if (input.projectId !== undefined) {
-    query["projectId"] = input.projectId.toString();
+    query[
+      __extendedEncodeURIComponent("projectId")
+    ] = __extendedEncodeURIComponent(input.projectId);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -217,13 +234,13 @@ export async function serializeAws_restJson1_1ExportProjectCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/exports/{projectId}";
   if (input.projectId !== undefined) {
-    const labelValue: string = input.projectId.toString();
+    const labelValue: string = input.projectId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: projectId.");
     }
     resolvedPath = resolvedPath.replace(
       "{projectId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: projectId.");
@@ -246,10 +263,14 @@ export async function serializeAws_restJson1_1ListBundlesCommand(
   let resolvedPath = "/bundles";
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -270,10 +291,14 @@ export async function serializeAws_restJson1_1ListProjectsCommand(
   let resolvedPath = "/projects";
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -294,7 +319,9 @@ export async function serializeAws_restJson1_1UpdateProjectCommand(
   let resolvedPath = "/update";
   const query: any = {};
   if (input.projectId !== undefined) {
-    query["projectId"] = input.projectId.toString();
+    query[
+      __extendedEncodeURIComponent("projectId")
+    ] = __extendedEncodeURIComponent(input.projectId);
   }
   let body: any;
   if (input.contents !== undefined) {

--- a/clients/client-mq/models/index.ts
+++ b/clients/client-mq/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -14,7 +17,7 @@ export interface AvailabilityZone {
 
 export namespace AvailabilityZone {
   export function isa(o: any): o is AvailabilityZone {
-    return _smithy.isa(o, "AvailabilityZone");
+    return __isa(o, "AvailabilityZone");
   }
 }
 
@@ -22,7 +25,7 @@ export namespace AvailabilityZone {
  * Returns information about an error.
  */
 export interface BadRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "BadRequestException";
   $fault: "client";
@@ -39,7 +42,7 @@ export interface BadRequestException
 
 export namespace BadRequestException {
   export function isa(o: any): o is BadRequestException {
-    return _smithy.isa(o, "BadRequestException");
+    return __isa(o, "BadRequestException");
   }
 }
 
@@ -61,7 +64,7 @@ export interface BrokerEngineType {
 
 export namespace BrokerEngineType {
   export function isa(o: any): o is BrokerEngineType {
-    return _smithy.isa(o, "BrokerEngineType");
+    return __isa(o, "BrokerEngineType");
   }
 }
 
@@ -88,7 +91,7 @@ export interface BrokerInstance {
 
 export namespace BrokerInstance {
   export function isa(o: any): o is BrokerInstance {
-    return _smithy.isa(o, "BrokerInstance");
+    return __isa(o, "BrokerInstance");
   }
 }
 
@@ -130,7 +133,7 @@ export interface BrokerInstanceOption {
 
 export namespace BrokerInstanceOption {
   export function isa(o: any): o is BrokerInstanceOption {
-    return _smithy.isa(o, "BrokerInstanceOption");
+    return __isa(o, "BrokerInstanceOption");
   }
 }
 
@@ -190,7 +193,7 @@ export interface BrokerSummary {
 
 export namespace BrokerSummary {
   export function isa(o: any): o is BrokerSummary {
-    return _smithy.isa(o, "BrokerSummary");
+    return __isa(o, "BrokerSummary");
   }
 }
 
@@ -253,7 +256,7 @@ export interface Configuration {
 
 export namespace Configuration {
   export function isa(o: any): o is Configuration {
-    return _smithy.isa(o, "Configuration");
+    return __isa(o, "Configuration");
   }
 }
 
@@ -275,7 +278,7 @@ export interface ConfigurationId {
 
 export namespace ConfigurationId {
   export function isa(o: any): o is ConfigurationId {
-    return _smithy.isa(o, "ConfigurationId");
+    return __isa(o, "ConfigurationId");
   }
 }
 
@@ -302,7 +305,7 @@ export interface ConfigurationRevision {
 
 export namespace ConfigurationRevision {
   export function isa(o: any): o is ConfigurationRevision {
-    return _smithy.isa(o, "ConfigurationRevision");
+    return __isa(o, "ConfigurationRevision");
   }
 }
 
@@ -329,16 +332,14 @@ export interface Configurations {
 
 export namespace Configurations {
   export function isa(o: any): o is Configurations {
-    return _smithy.isa(o, "Configurations");
+    return __isa(o, "Configurations");
   }
 }
 
 /**
  * Returns information about an error.
  */
-export interface ConflictException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface ConflictException extends __SmithyException, $MetadataBearer {
   name: "ConflictException";
   $fault: "client";
   /**
@@ -354,7 +355,7 @@ export interface ConflictException
 
 export namespace ConflictException {
   export function isa(o: any): o is ConflictException {
-    return _smithy.isa(o, "ConflictException");
+    return __isa(o, "ConflictException");
   }
 }
 
@@ -451,7 +452,7 @@ export interface CreateBrokerRequest {
 
 export namespace CreateBrokerRequest {
   export function isa(o: any): o is CreateBrokerRequest {
-    return _smithy.isa(o, "CreateBrokerRequest");
+    return __isa(o, "CreateBrokerRequest");
   }
 }
 
@@ -470,7 +471,7 @@ export interface CreateBrokerResponse extends $MetadataBearer {
 
 export namespace CreateBrokerResponse {
   export function isa(o: any): o is CreateBrokerResponse {
-    return _smithy.isa(o, "CreateBrokerResponse");
+    return __isa(o, "CreateBrokerResponse");
   }
 }
 
@@ -502,7 +503,7 @@ export interface CreateConfigurationRequest {
 
 export namespace CreateConfigurationRequest {
   export function isa(o: any): o is CreateConfigurationRequest {
-    return _smithy.isa(o, "CreateConfigurationRequest");
+    return __isa(o, "CreateConfigurationRequest");
   }
 }
 
@@ -536,7 +537,7 @@ export interface CreateConfigurationResponse extends $MetadataBearer {
 
 export namespace CreateConfigurationResponse {
   export function isa(o: any): o is CreateConfigurationResponse {
-    return _smithy.isa(o, "CreateConfigurationResponse");
+    return __isa(o, "CreateConfigurationResponse");
   }
 }
 
@@ -558,7 +559,7 @@ export interface CreateTagsRequest {
 
 export namespace CreateTagsRequest {
   export function isa(o: any): o is CreateTagsRequest {
-    return _smithy.isa(o, "CreateTagsRequest");
+    return __isa(o, "CreateTagsRequest");
   }
 }
 
@@ -595,7 +596,7 @@ export interface CreateUserRequest {
 
 export namespace CreateUserRequest {
   export function isa(o: any): o is CreateUserRequest {
-    return _smithy.isa(o, "CreateUserRequest");
+    return __isa(o, "CreateUserRequest");
   }
 }
 
@@ -605,7 +606,7 @@ export interface CreateUserResponse extends $MetadataBearer {
 
 export namespace CreateUserResponse {
   export function isa(o: any): o is CreateUserResponse {
-    return _smithy.isa(o, "CreateUserResponse");
+    return __isa(o, "CreateUserResponse");
   }
 }
 
@@ -629,7 +630,7 @@ export interface DeleteBrokerRequest {
 
 export namespace DeleteBrokerRequest {
   export function isa(o: any): o is DeleteBrokerRequest {
-    return _smithy.isa(o, "DeleteBrokerRequest");
+    return __isa(o, "DeleteBrokerRequest");
   }
 }
 
@@ -643,7 +644,7 @@ export interface DeleteBrokerResponse extends $MetadataBearer {
 
 export namespace DeleteBrokerResponse {
   export function isa(o: any): o is DeleteBrokerResponse {
-    return _smithy.isa(o, "DeleteBrokerResponse");
+    return __isa(o, "DeleteBrokerResponse");
   }
 }
 
@@ -662,7 +663,7 @@ export interface DeleteTagsRequest {
 
 export namespace DeleteTagsRequest {
   export function isa(o: any): o is DeleteTagsRequest {
-    return _smithy.isa(o, "DeleteTagsRequest");
+    return __isa(o, "DeleteTagsRequest");
   }
 }
 
@@ -681,7 +682,7 @@ export interface DeleteUserRequest {
 
 export namespace DeleteUserRequest {
   export function isa(o: any): o is DeleteUserRequest {
-    return _smithy.isa(o, "DeleteUserRequest");
+    return __isa(o, "DeleteUserRequest");
   }
 }
 
@@ -691,7 +692,7 @@ export interface DeleteUserResponse extends $MetadataBearer {
 
 export namespace DeleteUserResponse {
   export function isa(o: any): o is DeleteUserResponse {
-    return _smithy.isa(o, "DeleteUserResponse");
+    return __isa(o, "DeleteUserResponse");
   }
 }
 
@@ -720,7 +721,7 @@ export interface DescribeBrokerEngineTypesRequest {
 
 export namespace DescribeBrokerEngineTypesRequest {
   export function isa(o: any): o is DescribeBrokerEngineTypesRequest {
-    return _smithy.isa(o, "DescribeBrokerEngineTypesRequest");
+    return __isa(o, "DescribeBrokerEngineTypesRequest");
   }
 }
 
@@ -744,7 +745,7 @@ export interface DescribeBrokerEngineTypesResponse extends $MetadataBearer {
 
 export namespace DescribeBrokerEngineTypesResponse {
   export function isa(o: any): o is DescribeBrokerEngineTypesResponse {
-    return _smithy.isa(o, "DescribeBrokerEngineTypesResponse");
+    return __isa(o, "DescribeBrokerEngineTypesResponse");
   }
 }
 
@@ -778,7 +779,7 @@ export interface DescribeBrokerInstanceOptionsRequest {
 
 export namespace DescribeBrokerInstanceOptionsRequest {
   export function isa(o: any): o is DescribeBrokerInstanceOptionsRequest {
-    return _smithy.isa(o, "DescribeBrokerInstanceOptionsRequest");
+    return __isa(o, "DescribeBrokerInstanceOptionsRequest");
   }
 }
 
@@ -802,7 +803,7 @@ export interface DescribeBrokerInstanceOptionsResponse extends $MetadataBearer {
 
 export namespace DescribeBrokerInstanceOptionsResponse {
   export function isa(o: any): o is DescribeBrokerInstanceOptionsResponse {
-    return _smithy.isa(o, "DescribeBrokerInstanceOptionsResponse");
+    return __isa(o, "DescribeBrokerInstanceOptionsResponse");
   }
 }
 
@@ -816,7 +817,7 @@ export interface DescribeBrokerRequest {
 
 export namespace DescribeBrokerRequest {
   export function isa(o: any): o is DescribeBrokerRequest {
-    return _smithy.isa(o, "DescribeBrokerRequest");
+    return __isa(o, "DescribeBrokerRequest");
   }
 }
 
@@ -945,7 +946,7 @@ export interface DescribeBrokerResponse extends $MetadataBearer {
 
 export namespace DescribeBrokerResponse {
   export function isa(o: any): o is DescribeBrokerResponse {
-    return _smithy.isa(o, "DescribeBrokerResponse");
+    return __isa(o, "DescribeBrokerResponse");
   }
 }
 
@@ -959,7 +960,7 @@ export interface DescribeConfigurationRequest {
 
 export namespace DescribeConfigurationRequest {
   export function isa(o: any): o is DescribeConfigurationRequest {
-    return _smithy.isa(o, "DescribeConfigurationRequest");
+    return __isa(o, "DescribeConfigurationRequest");
   }
 }
 
@@ -1013,7 +1014,7 @@ export interface DescribeConfigurationResponse extends $MetadataBearer {
 
 export namespace DescribeConfigurationResponse {
   export function isa(o: any): o is DescribeConfigurationResponse {
-    return _smithy.isa(o, "DescribeConfigurationResponse");
+    return __isa(o, "DescribeConfigurationResponse");
   }
 }
 
@@ -1032,7 +1033,7 @@ export interface DescribeConfigurationRevisionRequest {
 
 export namespace DescribeConfigurationRevisionRequest {
   export function isa(o: any): o is DescribeConfigurationRevisionRequest {
-    return _smithy.isa(o, "DescribeConfigurationRevisionRequest");
+    return __isa(o, "DescribeConfigurationRevisionRequest");
   }
 }
 
@@ -1061,7 +1062,7 @@ export interface DescribeConfigurationRevisionResponse extends $MetadataBearer {
 
 export namespace DescribeConfigurationRevisionResponse {
   export function isa(o: any): o is DescribeConfigurationRevisionResponse {
-    return _smithy.isa(o, "DescribeConfigurationRevisionResponse");
+    return __isa(o, "DescribeConfigurationRevisionResponse");
   }
 }
 
@@ -1080,7 +1081,7 @@ export interface DescribeUserRequest {
 
 export namespace DescribeUserRequest {
   export function isa(o: any): o is DescribeUserRequest {
-    return _smithy.isa(o, "DescribeUserRequest");
+    return __isa(o, "DescribeUserRequest");
   }
 }
 
@@ -1114,7 +1115,7 @@ export interface DescribeUserResponse extends $MetadataBearer {
 
 export namespace DescribeUserResponse {
   export function isa(o: any): o is DescribeUserResponse {
-    return _smithy.isa(o, "DescribeUserResponse");
+    return __isa(o, "DescribeUserResponse");
   }
 }
 
@@ -1136,7 +1137,7 @@ export interface EncryptionOptions {
 
 export namespace EncryptionOptions {
   export function isa(o: any): o is EncryptionOptions {
-    return _smithy.isa(o, "EncryptionOptions");
+    return __isa(o, "EncryptionOptions");
   }
 }
 
@@ -1157,16 +1158,14 @@ export interface EngineVersion {
 
 export namespace EngineVersion {
   export function isa(o: any): o is EngineVersion {
-    return _smithy.isa(o, "EngineVersion");
+    return __isa(o, "EngineVersion");
   }
 }
 
 /**
  * Returns information about an error.
  */
-export interface ForbiddenException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface ForbiddenException extends __SmithyException, $MetadataBearer {
   name: "ForbiddenException";
   $fault: "client";
   /**
@@ -1182,7 +1181,7 @@ export interface ForbiddenException
 
 export namespace ForbiddenException {
   export function isa(o: any): o is ForbiddenException {
-    return _smithy.isa(o, "ForbiddenException");
+    return __isa(o, "ForbiddenException");
   }
 }
 
@@ -1190,7 +1189,7 @@ export namespace ForbiddenException {
  * Returns information about an error.
  */
 export interface InternalServerErrorException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalServerErrorException";
   $fault: "server";
@@ -1207,7 +1206,7 @@ export interface InternalServerErrorException
 
 export namespace InternalServerErrorException {
   export function isa(o: any): o is InternalServerErrorException {
-    return _smithy.isa(o, "InternalServerErrorException");
+    return __isa(o, "InternalServerErrorException");
   }
 }
 
@@ -1226,7 +1225,7 @@ export interface ListBrokersRequest {
 
 export namespace ListBrokersRequest {
   export function isa(o: any): o is ListBrokersRequest {
-    return _smithy.isa(o, "ListBrokersRequest");
+    return __isa(o, "ListBrokersRequest");
   }
 }
 
@@ -1245,7 +1244,7 @@ export interface ListBrokersResponse extends $MetadataBearer {
 
 export namespace ListBrokersResponse {
   export function isa(o: any): o is ListBrokersResponse {
-    return _smithy.isa(o, "ListBrokersResponse");
+    return __isa(o, "ListBrokersResponse");
   }
 }
 
@@ -1269,7 +1268,7 @@ export interface ListConfigurationRevisionsRequest {
 
 export namespace ListConfigurationRevisionsRequest {
   export function isa(o: any): o is ListConfigurationRevisionsRequest {
-    return _smithy.isa(o, "ListConfigurationRevisionsRequest");
+    return __isa(o, "ListConfigurationRevisionsRequest");
   }
 }
 
@@ -1298,7 +1297,7 @@ export interface ListConfigurationRevisionsResponse extends $MetadataBearer {
 
 export namespace ListConfigurationRevisionsResponse {
   export function isa(o: any): o is ListConfigurationRevisionsResponse {
-    return _smithy.isa(o, "ListConfigurationRevisionsResponse");
+    return __isa(o, "ListConfigurationRevisionsResponse");
   }
 }
 
@@ -1317,7 +1316,7 @@ export interface ListConfigurationsRequest {
 
 export namespace ListConfigurationsRequest {
   export function isa(o: any): o is ListConfigurationsRequest {
-    return _smithy.isa(o, "ListConfigurationsRequest");
+    return __isa(o, "ListConfigurationsRequest");
   }
 }
 
@@ -1341,7 +1340,7 @@ export interface ListConfigurationsResponse extends $MetadataBearer {
 
 export namespace ListConfigurationsResponse {
   export function isa(o: any): o is ListConfigurationsResponse {
-    return _smithy.isa(o, "ListConfigurationsResponse");
+    return __isa(o, "ListConfigurationsResponse");
   }
 }
 
@@ -1355,7 +1354,7 @@ export interface ListTagsRequest {
 
 export namespace ListTagsRequest {
   export function isa(o: any): o is ListTagsRequest {
-    return _smithy.isa(o, "ListTagsRequest");
+    return __isa(o, "ListTagsRequest");
   }
 }
 
@@ -1369,7 +1368,7 @@ export interface ListTagsResponse extends $MetadataBearer {
 
 export namespace ListTagsResponse {
   export function isa(o: any): o is ListTagsResponse {
-    return _smithy.isa(o, "ListTagsResponse");
+    return __isa(o, "ListTagsResponse");
   }
 }
 
@@ -1393,7 +1392,7 @@ export interface ListUsersRequest {
 
 export namespace ListUsersRequest {
   export function isa(o: any): o is ListUsersRequest {
-    return _smithy.isa(o, "ListUsersRequest");
+    return __isa(o, "ListUsersRequest");
   }
 }
 
@@ -1422,7 +1421,7 @@ export interface ListUsersResponse extends $MetadataBearer {
 
 export namespace ListUsersResponse {
   export function isa(o: any): o is ListUsersResponse {
-    return _smithy.isa(o, "ListUsersResponse");
+    return __isa(o, "ListUsersResponse");
   }
 }
 
@@ -1444,7 +1443,7 @@ export interface Logs {
 
 export namespace Logs {
   export function isa(o: any): o is Logs {
-    return _smithy.isa(o, "Logs");
+    return __isa(o, "Logs");
   }
 }
 
@@ -1481,16 +1480,14 @@ export interface LogsSummary {
 
 export namespace LogsSummary {
   export function isa(o: any): o is LogsSummary {
-    return _smithy.isa(o, "LogsSummary");
+    return __isa(o, "LogsSummary");
   }
 }
 
 /**
  * Returns information about an error.
  */
-export interface NotFoundException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface NotFoundException extends __SmithyException, $MetadataBearer {
   name: "NotFoundException";
   $fault: "client";
   /**
@@ -1506,7 +1503,7 @@ export interface NotFoundException
 
 export namespace NotFoundException {
   export function isa(o: any): o is NotFoundException {
-    return _smithy.isa(o, "NotFoundException");
+    return __isa(o, "NotFoundException");
   }
 }
 
@@ -1528,7 +1525,7 @@ export interface PendingLogs {
 
 export namespace PendingLogs {
   export function isa(o: any): o is PendingLogs {
-    return _smithy.isa(o, "PendingLogs");
+    return __isa(o, "PendingLogs");
   }
 }
 
@@ -1542,7 +1539,7 @@ export interface RebootBrokerRequest {
 
 export namespace RebootBrokerRequest {
   export function isa(o: any): o is RebootBrokerRequest {
-    return _smithy.isa(o, "RebootBrokerRequest");
+    return __isa(o, "RebootBrokerRequest");
   }
 }
 
@@ -1552,7 +1549,7 @@ export interface RebootBrokerResponse extends $MetadataBearer {
 
 export namespace RebootBrokerResponse {
   export function isa(o: any): o is RebootBrokerResponse {
-    return _smithy.isa(o, "RebootBrokerResponse");
+    return __isa(o, "RebootBrokerResponse");
   }
 }
 
@@ -1579,7 +1576,7 @@ export interface SanitizationWarning {
 
 export namespace SanitizationWarning {
   export function isa(o: any): o is SanitizationWarning {
-    return _smithy.isa(o, "SanitizationWarning");
+    return __isa(o, "SanitizationWarning");
   }
 }
 
@@ -1593,7 +1590,7 @@ export enum SanitizationWarningReason {
  * Returns information about an error.
  */
 export interface UnauthorizedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UnauthorizedException";
   $fault: "client";
@@ -1610,7 +1607,7 @@ export interface UnauthorizedException
 
 export namespace UnauthorizedException {
   export function isa(o: any): o is UnauthorizedException {
-    return _smithy.isa(o, "UnauthorizedException");
+    return __isa(o, "UnauthorizedException");
   }
 }
 
@@ -1657,7 +1654,7 @@ export interface UpdateBrokerRequest {
 
 export namespace UpdateBrokerRequest {
   export function isa(o: any): o is UpdateBrokerRequest {
-    return _smithy.isa(o, "UpdateBrokerRequest");
+    return __isa(o, "UpdateBrokerRequest");
   }
 }
 
@@ -1701,7 +1698,7 @@ export interface UpdateBrokerResponse extends $MetadataBearer {
 
 export namespace UpdateBrokerResponse {
   export function isa(o: any): o is UpdateBrokerResponse {
-    return _smithy.isa(o, "UpdateBrokerResponse");
+    return __isa(o, "UpdateBrokerResponse");
   }
 }
 
@@ -1728,7 +1725,7 @@ export interface UpdateConfigurationRequest {
 
 export namespace UpdateConfigurationRequest {
   export function isa(o: any): o is UpdateConfigurationRequest {
-    return _smithy.isa(o, "UpdateConfigurationRequest");
+    return __isa(o, "UpdateConfigurationRequest");
   }
 }
 
@@ -1767,7 +1764,7 @@ export interface UpdateConfigurationResponse extends $MetadataBearer {
 
 export namespace UpdateConfigurationResponse {
   export function isa(o: any): o is UpdateConfigurationResponse {
-    return _smithy.isa(o, "UpdateConfigurationResponse");
+    return __isa(o, "UpdateConfigurationResponse");
   }
 }
 
@@ -1804,7 +1801,7 @@ export interface UpdateUserRequest {
 
 export namespace UpdateUserRequest {
   export function isa(o: any): o is UpdateUserRequest {
-    return _smithy.isa(o, "UpdateUserRequest");
+    return __isa(o, "UpdateUserRequest");
   }
 }
 
@@ -1814,7 +1811,7 @@ export interface UpdateUserResponse extends $MetadataBearer {
 
 export namespace UpdateUserResponse {
   export function isa(o: any): o is UpdateUserResponse {
-    return _smithy.isa(o, "UpdateUserResponse");
+    return __isa(o, "UpdateUserResponse");
   }
 }
 
@@ -1846,7 +1843,7 @@ export interface User {
 
 export namespace User {
   export function isa(o: any): o is User {
-    return _smithy.isa(o, "User");
+    return __isa(o, "User");
   }
 }
 
@@ -1873,7 +1870,7 @@ export interface UserPendingChanges {
 
 export namespace UserPendingChanges {
   export function isa(o: any): o is UserPendingChanges {
-    return _smithy.isa(o, "UserPendingChanges");
+    return __isa(o, "UserPendingChanges");
   }
 }
 
@@ -1895,7 +1892,7 @@ export interface UserSummary {
 
 export namespace UserSummary {
   export function isa(o: any): o is UserSummary {
-    return _smithy.isa(o, "UserSummary");
+    return __isa(o, "UserSummary");
   }
 }
 
@@ -1922,6 +1919,6 @@ export interface WeeklyStartTime {
 
 export namespace WeeklyStartTime {
   export function isa(o: any): o is WeeklyStartTime {
-    return _smithy.isa(o, "WeeklyStartTime");
+    return __isa(o, "WeeklyStartTime");
   }
 }

--- a/clients/client-mq/protocols/Aws_restJson1_1.ts
+++ b/clients/client-mq/protocols/Aws_restJson1_1.ts
@@ -118,7 +118,10 @@ import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  extendedEncodeURIComponent as __extendedEncodeURIComponent
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -267,7 +270,7 @@ export async function serializeAws_restJson1_1CreateTagsCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v1/tags/{ResourceArn}";
   if (input.ResourceArn !== undefined) {
-    const labelValue: string = input.ResourceArn.toString();
+    const labelValue: string = input.ResourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ResourceArn."
@@ -275,7 +278,7 @@ export async function serializeAws_restJson1_1CreateTagsCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ResourceArn.");
@@ -307,25 +310,25 @@ export async function serializeAws_restJson1_1CreateUserCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v1/brokers/{BrokerId}/users/{Username}";
   if (input.BrokerId !== undefined) {
-    const labelValue: string = input.BrokerId.toString();
+    const labelValue: string = input.BrokerId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: BrokerId.");
     }
     resolvedPath = resolvedPath.replace(
       "{BrokerId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: BrokerId.");
   }
   if (input.Username !== undefined) {
-    const labelValue: string = input.Username.toString();
+    const labelValue: string = input.Username;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Username.");
     }
     resolvedPath = resolvedPath.replace(
       "{Username}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Username.");
@@ -363,13 +366,13 @@ export async function serializeAws_restJson1_1DeleteBrokerCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/brokers/{BrokerId}";
   if (input.BrokerId !== undefined) {
-    const labelValue: string = input.BrokerId.toString();
+    const labelValue: string = input.BrokerId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: BrokerId.");
     }
     resolvedPath = resolvedPath.replace(
       "{BrokerId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: BrokerId.");
@@ -391,7 +394,7 @@ export async function serializeAws_restJson1_1DeleteTagsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/tags/{ResourceArn}";
   if (input.ResourceArn !== undefined) {
-    const labelValue: string = input.ResourceArn.toString();
+    const labelValue: string = input.ResourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ResourceArn."
@@ -399,14 +402,16 @@ export async function serializeAws_restJson1_1DeleteTagsCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ResourceArn.");
   }
   const query: any = {};
   if (input.TagKeys !== undefined) {
-    query["tagKeys"] = input.TagKeys;
+    query[__extendedEncodeURIComponent("tagKeys")] = input.TagKeys.map(entry =>
+      __extendedEncodeURIComponent(entry)
+    );
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -426,25 +431,25 @@ export async function serializeAws_restJson1_1DeleteUserCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/brokers/{BrokerId}/users/{Username}";
   if (input.BrokerId !== undefined) {
-    const labelValue: string = input.BrokerId.toString();
+    const labelValue: string = input.BrokerId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: BrokerId.");
     }
     resolvedPath = resolvedPath.replace(
       "{BrokerId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: BrokerId.");
   }
   if (input.Username !== undefined) {
-    const labelValue: string = input.Username.toString();
+    const labelValue: string = input.Username;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Username.");
     }
     resolvedPath = resolvedPath.replace(
       "{Username}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Username.");
@@ -466,13 +471,13 @@ export async function serializeAws_restJson1_1DescribeBrokerCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/brokers/{BrokerId}";
   if (input.BrokerId !== undefined) {
-    const labelValue: string = input.BrokerId.toString();
+    const labelValue: string = input.BrokerId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: BrokerId.");
     }
     resolvedPath = resolvedPath.replace(
       "{BrokerId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: BrokerId.");
@@ -495,13 +500,19 @@ export async function serializeAws_restJson1_1DescribeBrokerEngineTypesCommand(
   let resolvedPath = "/v1/broker-engine-types";
   const query: any = {};
   if (input.EngineType !== undefined) {
-    query["engineType"] = input.EngineType.toString();
+    query[
+      __extendedEncodeURIComponent("engineType")
+    ] = __extendedEncodeURIComponent(input.EngineType);
   }
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -522,19 +533,29 @@ export async function serializeAws_restJson1_1DescribeBrokerInstanceOptionsComma
   let resolvedPath = "/v1/broker-instance-options";
   const query: any = {};
   if (input.EngineType !== undefined) {
-    query["engineType"] = input.EngineType.toString();
+    query[
+      __extendedEncodeURIComponent("engineType")
+    ] = __extendedEncodeURIComponent(input.EngineType);
   }
   if (input.HostInstanceType !== undefined) {
-    query["hostInstanceType"] = input.HostInstanceType.toString();
+    query[
+      __extendedEncodeURIComponent("hostInstanceType")
+    ] = __extendedEncodeURIComponent(input.HostInstanceType);
   }
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   if (input.StorageType !== undefined) {
-    query["storageType"] = input.StorageType.toString();
+    query[
+      __extendedEncodeURIComponent("storageType")
+    ] = __extendedEncodeURIComponent(input.StorageType);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -554,7 +575,7 @@ export async function serializeAws_restJson1_1DescribeConfigurationCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/configurations/{ConfigurationId}";
   if (input.ConfigurationId !== undefined) {
-    const labelValue: string = input.ConfigurationId.toString();
+    const labelValue: string = input.ConfigurationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ConfigurationId."
@@ -562,7 +583,7 @@ export async function serializeAws_restJson1_1DescribeConfigurationCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ConfigurationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ConfigurationId.");
@@ -585,7 +606,7 @@ export async function serializeAws_restJson1_1DescribeConfigurationRevisionComma
   let resolvedPath =
     "/v1/configurations/{ConfigurationId}/revisions/{ConfigurationRevision}";
   if (input.ConfigurationId !== undefined) {
-    const labelValue: string = input.ConfigurationId.toString();
+    const labelValue: string = input.ConfigurationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ConfigurationId."
@@ -593,13 +614,13 @@ export async function serializeAws_restJson1_1DescribeConfigurationRevisionComma
     }
     resolvedPath = resolvedPath.replace(
       "{ConfigurationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ConfigurationId.");
   }
   if (input.ConfigurationRevision !== undefined) {
-    const labelValue: string = input.ConfigurationRevision.toString();
+    const labelValue: string = input.ConfigurationRevision;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ConfigurationRevision."
@@ -607,7 +628,7 @@ export async function serializeAws_restJson1_1DescribeConfigurationRevisionComma
     }
     resolvedPath = resolvedPath.replace(
       "{ConfigurationRevision}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -631,25 +652,25 @@ export async function serializeAws_restJson1_1DescribeUserCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/brokers/{BrokerId}/users/{Username}";
   if (input.BrokerId !== undefined) {
-    const labelValue: string = input.BrokerId.toString();
+    const labelValue: string = input.BrokerId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: BrokerId.");
     }
     resolvedPath = resolvedPath.replace(
       "{BrokerId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: BrokerId.");
   }
   if (input.Username !== undefined) {
-    const labelValue: string = input.Username.toString();
+    const labelValue: string = input.Username;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Username.");
     }
     resolvedPath = resolvedPath.replace(
       "{Username}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Username.");
@@ -672,10 +693,14 @@ export async function serializeAws_restJson1_1ListBrokersCommand(
   let resolvedPath = "/v1/brokers";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -695,7 +720,7 @@ export async function serializeAws_restJson1_1ListConfigurationRevisionsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/configurations/{ConfigurationId}/revisions";
   if (input.ConfigurationId !== undefined) {
-    const labelValue: string = input.ConfigurationId.toString();
+    const labelValue: string = input.ConfigurationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ConfigurationId."
@@ -703,17 +728,21 @@ export async function serializeAws_restJson1_1ListConfigurationRevisionsCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ConfigurationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ConfigurationId.");
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -734,10 +763,14 @@ export async function serializeAws_restJson1_1ListConfigurationsCommand(
   let resolvedPath = "/v1/configurations";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -757,7 +790,7 @@ export async function serializeAws_restJson1_1ListTagsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/tags/{ResourceArn}";
   if (input.ResourceArn !== undefined) {
-    const labelValue: string = input.ResourceArn.toString();
+    const labelValue: string = input.ResourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ResourceArn."
@@ -765,7 +798,7 @@ export async function serializeAws_restJson1_1ListTagsCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ResourceArn.");
@@ -787,23 +820,27 @@ export async function serializeAws_restJson1_1ListUsersCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/brokers/{BrokerId}/users";
   if (input.BrokerId !== undefined) {
-    const labelValue: string = input.BrokerId.toString();
+    const labelValue: string = input.BrokerId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: BrokerId.");
     }
     resolvedPath = resolvedPath.replace(
       "{BrokerId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: BrokerId.");
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -823,13 +860,13 @@ export async function serializeAws_restJson1_1RebootBrokerCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/brokers/{BrokerId}/reboot";
   if (input.BrokerId !== undefined) {
-    const labelValue: string = input.BrokerId.toString();
+    const labelValue: string = input.BrokerId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: BrokerId.");
     }
     resolvedPath = resolvedPath.replace(
       "{BrokerId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: BrokerId.");
@@ -851,13 +888,13 @@ export async function serializeAws_restJson1_1UpdateBrokerCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v1/brokers/{BrokerId}";
   if (input.BrokerId !== undefined) {
-    const labelValue: string = input.BrokerId.toString();
+    const labelValue: string = input.BrokerId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: BrokerId.");
     }
     resolvedPath = resolvedPath.replace(
       "{BrokerId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: BrokerId.");
@@ -907,7 +944,7 @@ export async function serializeAws_restJson1_1UpdateConfigurationCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v1/configurations/{ConfigurationId}";
   if (input.ConfigurationId !== undefined) {
-    const labelValue: string = input.ConfigurationId.toString();
+    const labelValue: string = input.ConfigurationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ConfigurationId."
@@ -915,7 +952,7 @@ export async function serializeAws_restJson1_1UpdateConfigurationCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ConfigurationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ConfigurationId.");
@@ -947,25 +984,25 @@ export async function serializeAws_restJson1_1UpdateUserCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v1/brokers/{BrokerId}/users/{Username}";
   if (input.BrokerId !== undefined) {
-    const labelValue: string = input.BrokerId.toString();
+    const labelValue: string = input.BrokerId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: BrokerId.");
     }
     resolvedPath = resolvedPath.replace(
       "{BrokerId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: BrokerId.");
   }
   if (input.Username !== undefined) {
-    const labelValue: string = input.Username.toString();
+    const labelValue: string = input.Username;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Username.");
     }
     resolvedPath = resolvedPath.replace(
       "{Username}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Username.");
@@ -1186,6 +1223,7 @@ export async function deserializeAws_restJson1_1CreateTagsCommand(
   const contents: CreateTagsCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -1255,6 +1293,7 @@ export async function deserializeAws_restJson1_1CreateUserCommand(
     $metadata: deserializeMetadata(output),
     __type: "CreateUserResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -1404,6 +1443,7 @@ export async function deserializeAws_restJson1_1DeleteTagsCommand(
   const contents: DeleteTagsCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -1473,6 +1513,7 @@ export async function deserializeAws_restJson1_1DeleteUserCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeleteUserResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2634,6 +2675,7 @@ export async function deserializeAws_restJson1_1RebootBrokerCommand(
     $metadata: deserializeMetadata(output),
     __type: "RebootBrokerResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2927,6 +2969,7 @@ export async function deserializeAws_restJson1_1UpdateUserCommand(
     $metadata: deserializeMetadata(output),
     __type: "UpdateUserResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 

--- a/clients/client-mturk/models/index.ts
+++ b/clients/client-mturk/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export interface AcceptQualificationRequestRequest {
@@ -19,7 +22,7 @@ export interface AcceptQualificationRequestRequest {
 
 export namespace AcceptQualificationRequestRequest {
   export function isa(o: any): o is AcceptQualificationRequestRequest {
-    return _smithy.isa(o, "AcceptQualificationRequestRequest");
+    return __isa(o, "AcceptQualificationRequestRequest");
   }
 }
 
@@ -29,7 +32,7 @@ export interface AcceptQualificationRequestResponse extends $MetadataBearer {
 
 export namespace AcceptQualificationRequestResponse {
   export function isa(o: any): o is AcceptQualificationRequestResponse {
-    return _smithy.isa(o, "AcceptQualificationRequestResponse");
+    return __isa(o, "AcceptQualificationRequestResponse");
   }
 }
 
@@ -59,7 +62,7 @@ export interface ApproveAssignmentRequest {
 
 export namespace ApproveAssignmentRequest {
   export function isa(o: any): o is ApproveAssignmentRequest {
-    return _smithy.isa(o, "ApproveAssignmentRequest");
+    return __isa(o, "ApproveAssignmentRequest");
   }
 }
 
@@ -69,7 +72,7 @@ export interface ApproveAssignmentResponse extends $MetadataBearer {
 
 export namespace ApproveAssignmentResponse {
   export function isa(o: any): o is ApproveAssignmentResponse {
-    return _smithy.isa(o, "ApproveAssignmentResponse");
+    return __isa(o, "ApproveAssignmentResponse");
   }
 }
 
@@ -164,7 +167,7 @@ export interface Assignment {
 
 export namespace Assignment {
   export function isa(o: any): o is Assignment {
-    return _smithy.isa(o, "Assignment");
+    return __isa(o, "Assignment");
   }
 }
 
@@ -206,7 +209,7 @@ export interface AssociateQualificationWithWorkerRequest {
 
 export namespace AssociateQualificationWithWorkerRequest {
   export function isa(o: any): o is AssociateQualificationWithWorkerRequest {
-    return _smithy.isa(o, "AssociateQualificationWithWorkerRequest");
+    return __isa(o, "AssociateQualificationWithWorkerRequest");
   }
 }
 
@@ -217,7 +220,7 @@ export interface AssociateQualificationWithWorkerResponse
 
 export namespace AssociateQualificationWithWorkerResponse {
   export function isa(o: any): o is AssociateQualificationWithWorkerResponse {
-    return _smithy.isa(o, "AssociateQualificationWithWorkerResponse");
+    return __isa(o, "AssociateQualificationWithWorkerResponse");
   }
 }
 
@@ -254,7 +257,7 @@ export interface BonusPayment {
 
 export namespace BonusPayment {
   export function isa(o: any): o is BonusPayment {
-    return _smithy.isa(o, "BonusPayment");
+    return __isa(o, "BonusPayment");
   }
 }
 
@@ -298,7 +301,7 @@ export interface CreateAdditionalAssignmentsForHITRequest {
 
 export namespace CreateAdditionalAssignmentsForHITRequest {
   export function isa(o: any): o is CreateAdditionalAssignmentsForHITRequest {
-    return _smithy.isa(o, "CreateAdditionalAssignmentsForHITRequest");
+    return __isa(o, "CreateAdditionalAssignmentsForHITRequest");
   }
 }
 
@@ -309,7 +312,7 @@ export interface CreateAdditionalAssignmentsForHITResponse
 
 export namespace CreateAdditionalAssignmentsForHITResponse {
   export function isa(o: any): o is CreateAdditionalAssignmentsForHITResponse {
-    return _smithy.isa(o, "CreateAdditionalAssignmentsForHITResponse");
+    return __isa(o, "CreateAdditionalAssignmentsForHITResponse");
   }
 }
 
@@ -487,7 +490,7 @@ export interface CreateHITRequest {
 
 export namespace CreateHITRequest {
   export function isa(o: any): o is CreateHITRequest {
-    return _smithy.isa(o, "CreateHITRequest");
+    return __isa(o, "CreateHITRequest");
   }
 }
 
@@ -504,7 +507,7 @@ export interface CreateHITResponse extends $MetadataBearer {
 
 export namespace CreateHITResponse {
   export function isa(o: any): o is CreateHITResponse {
-    return _smithy.isa(o, "CreateHITResponse");
+    return __isa(o, "CreateHITResponse");
   }
 }
 
@@ -579,7 +582,7 @@ export interface CreateHITTypeRequest {
 
 export namespace CreateHITTypeRequest {
   export function isa(o: any): o is CreateHITTypeRequest {
-    return _smithy.isa(o, "CreateHITTypeRequest");
+    return __isa(o, "CreateHITTypeRequest");
   }
 }
 
@@ -593,7 +596,7 @@ export interface CreateHITTypeResponse extends $MetadataBearer {
 
 export namespace CreateHITTypeResponse {
   export function isa(o: any): o is CreateHITTypeResponse {
-    return _smithy.isa(o, "CreateHITTypeResponse");
+    return __isa(o, "CreateHITTypeResponse");
   }
 }
 
@@ -710,7 +713,7 @@ export interface CreateHITWithHITTypeRequest {
 
 export namespace CreateHITWithHITTypeRequest {
   export function isa(o: any): o is CreateHITWithHITTypeRequest {
-    return _smithy.isa(o, "CreateHITWithHITTypeRequest");
+    return __isa(o, "CreateHITWithHITTypeRequest");
   }
 }
 
@@ -727,7 +730,7 @@ export interface CreateHITWithHITTypeResponse extends $MetadataBearer {
 
 export namespace CreateHITWithHITTypeResponse {
   export function isa(o: any): o is CreateHITWithHITTypeResponse {
-    return _smithy.isa(o, "CreateHITWithHITTypeResponse");
+    return __isa(o, "CreateHITWithHITTypeResponse");
   }
 }
 
@@ -826,7 +829,7 @@ export interface CreateQualificationTypeRequest {
 
 export namespace CreateQualificationTypeRequest {
   export function isa(o: any): o is CreateQualificationTypeRequest {
-    return _smithy.isa(o, "CreateQualificationTypeRequest");
+    return __isa(o, "CreateQualificationTypeRequest");
   }
 }
 
@@ -841,7 +844,7 @@ export interface CreateQualificationTypeResponse extends $MetadataBearer {
 
 export namespace CreateQualificationTypeResponse {
   export function isa(o: any): o is CreateQualificationTypeResponse {
-    return _smithy.isa(o, "CreateQualificationTypeResponse");
+    return __isa(o, "CreateQualificationTypeResponse");
   }
 }
 
@@ -860,7 +863,7 @@ export interface CreateWorkerBlockRequest {
 
 export namespace CreateWorkerBlockRequest {
   export function isa(o: any): o is CreateWorkerBlockRequest {
-    return _smithy.isa(o, "CreateWorkerBlockRequest");
+    return __isa(o, "CreateWorkerBlockRequest");
   }
 }
 
@@ -870,7 +873,7 @@ export interface CreateWorkerBlockResponse extends $MetadataBearer {
 
 export namespace CreateWorkerBlockResponse {
   export function isa(o: any): o is CreateWorkerBlockResponse {
-    return _smithy.isa(o, "CreateWorkerBlockResponse");
+    return __isa(o, "CreateWorkerBlockResponse");
   }
 }
 
@@ -884,7 +887,7 @@ export interface DeleteHITRequest {
 
 export namespace DeleteHITRequest {
   export function isa(o: any): o is DeleteHITRequest {
-    return _smithy.isa(o, "DeleteHITRequest");
+    return __isa(o, "DeleteHITRequest");
   }
 }
 
@@ -894,7 +897,7 @@ export interface DeleteHITResponse extends $MetadataBearer {
 
 export namespace DeleteHITResponse {
   export function isa(o: any): o is DeleteHITResponse {
-    return _smithy.isa(o, "DeleteHITResponse");
+    return __isa(o, "DeleteHITResponse");
   }
 }
 
@@ -908,7 +911,7 @@ export interface DeleteQualificationTypeRequest {
 
 export namespace DeleteQualificationTypeRequest {
   export function isa(o: any): o is DeleteQualificationTypeRequest {
-    return _smithy.isa(o, "DeleteQualificationTypeRequest");
+    return __isa(o, "DeleteQualificationTypeRequest");
   }
 }
 
@@ -918,7 +921,7 @@ export interface DeleteQualificationTypeResponse extends $MetadataBearer {
 
 export namespace DeleteQualificationTypeResponse {
   export function isa(o: any): o is DeleteQualificationTypeResponse {
-    return _smithy.isa(o, "DeleteQualificationTypeResponse");
+    return __isa(o, "DeleteQualificationTypeResponse");
   }
 }
 
@@ -937,7 +940,7 @@ export interface DeleteWorkerBlockRequest {
 
 export namespace DeleteWorkerBlockRequest {
   export function isa(o: any): o is DeleteWorkerBlockRequest {
-    return _smithy.isa(o, "DeleteWorkerBlockRequest");
+    return __isa(o, "DeleteWorkerBlockRequest");
   }
 }
 
@@ -947,7 +950,7 @@ export interface DeleteWorkerBlockResponse extends $MetadataBearer {
 
 export namespace DeleteWorkerBlockResponse {
   export function isa(o: any): o is DeleteWorkerBlockResponse {
-    return _smithy.isa(o, "DeleteWorkerBlockResponse");
+    return __isa(o, "DeleteWorkerBlockResponse");
   }
 }
 
@@ -971,7 +974,7 @@ export interface DisassociateQualificationFromWorkerRequest {
 
 export namespace DisassociateQualificationFromWorkerRequest {
   export function isa(o: any): o is DisassociateQualificationFromWorkerRequest {
-    return _smithy.isa(o, "DisassociateQualificationFromWorkerRequest");
+    return __isa(o, "DisassociateQualificationFromWorkerRequest");
   }
 }
 
@@ -984,7 +987,7 @@ export namespace DisassociateQualificationFromWorkerResponse {
   export function isa(
     o: any
   ): o is DisassociateQualificationFromWorkerResponse {
-    return _smithy.isa(o, "DisassociateQualificationFromWorkerResponse");
+    return __isa(o, "DisassociateQualificationFromWorkerResponse");
   }
 }
 
@@ -1009,7 +1012,7 @@ export interface GetAccountBalanceRequest {
 
 export namespace GetAccountBalanceRequest {
   export function isa(o: any): o is GetAccountBalanceRequest {
-    return _smithy.isa(o, "GetAccountBalanceRequest");
+    return __isa(o, "GetAccountBalanceRequest");
   }
 }
 
@@ -1028,7 +1031,7 @@ export interface GetAccountBalanceResponse extends $MetadataBearer {
 
 export namespace GetAccountBalanceResponse {
   export function isa(o: any): o is GetAccountBalanceResponse {
-    return _smithy.isa(o, "GetAccountBalanceResponse");
+    return __isa(o, "GetAccountBalanceResponse");
   }
 }
 
@@ -1042,7 +1045,7 @@ export interface GetAssignmentRequest {
 
 export namespace GetAssignmentRequest {
   export function isa(o: any): o is GetAssignmentRequest {
-    return _smithy.isa(o, "GetAssignmentRequest");
+    return __isa(o, "GetAssignmentRequest");
   }
 }
 
@@ -1064,7 +1067,7 @@ export interface GetAssignmentResponse extends $MetadataBearer {
 
 export namespace GetAssignmentResponse {
   export function isa(o: any): o is GetAssignmentResponse {
-    return _smithy.isa(o, "GetAssignmentResponse");
+    return __isa(o, "GetAssignmentResponse");
   }
 }
 
@@ -1085,7 +1088,7 @@ export interface GetFileUploadURLRequest {
 
 export namespace GetFileUploadURLRequest {
   export function isa(o: any): o is GetFileUploadURLRequest {
-    return _smithy.isa(o, "GetFileUploadURLRequest");
+    return __isa(o, "GetFileUploadURLRequest");
   }
 }
 
@@ -1101,7 +1104,7 @@ export interface GetFileUploadURLResponse extends $MetadataBearer {
 
 export namespace GetFileUploadURLResponse {
   export function isa(o: any): o is GetFileUploadURLResponse {
-    return _smithy.isa(o, "GetFileUploadURLResponse");
+    return __isa(o, "GetFileUploadURLResponse");
   }
 }
 
@@ -1115,7 +1118,7 @@ export interface GetHITRequest {
 
 export namespace GetHITRequest {
   export function isa(o: any): o is GetHITRequest {
-    return _smithy.isa(o, "GetHITRequest");
+    return __isa(o, "GetHITRequest");
   }
 }
 
@@ -1129,7 +1132,7 @@ export interface GetHITResponse extends $MetadataBearer {
 
 export namespace GetHITResponse {
   export function isa(o: any): o is GetHITResponse {
-    return _smithy.isa(o, "GetHITResponse");
+    return __isa(o, "GetHITResponse");
   }
 }
 
@@ -1148,7 +1151,7 @@ export interface GetQualificationScoreRequest {
 
 export namespace GetQualificationScoreRequest {
   export function isa(o: any): o is GetQualificationScoreRequest {
-    return _smithy.isa(o, "GetQualificationScoreRequest");
+    return __isa(o, "GetQualificationScoreRequest");
   }
 }
 
@@ -1165,7 +1168,7 @@ export interface GetQualificationScoreResponse extends $MetadataBearer {
 
 export namespace GetQualificationScoreResponse {
   export function isa(o: any): o is GetQualificationScoreResponse {
-    return _smithy.isa(o, "GetQualificationScoreResponse");
+    return __isa(o, "GetQualificationScoreResponse");
   }
 }
 
@@ -1179,7 +1182,7 @@ export interface GetQualificationTypeRequest {
 
 export namespace GetQualificationTypeRequest {
   export function isa(o: any): o is GetQualificationTypeRequest {
-    return _smithy.isa(o, "GetQualificationTypeRequest");
+    return __isa(o, "GetQualificationTypeRequest");
   }
 }
 
@@ -1193,7 +1196,7 @@ export interface GetQualificationTypeResponse extends $MetadataBearer {
 
 export namespace GetQualificationTypeResponse {
   export function isa(o: any): o is GetQualificationTypeResponse {
-    return _smithy.isa(o, "GetQualificationTypeResponse");
+    return __isa(o, "GetQualificationTypeResponse");
   }
 }
 
@@ -1340,7 +1343,7 @@ export interface HIT {
 
 export namespace HIT {
   export function isa(o: any): o is HIT {
-    return _smithy.isa(o, "HIT");
+    return __isa(o, "HIT");
   }
 }
 
@@ -1375,7 +1378,7 @@ export interface HITLayoutParameter {
 
 export namespace HITLayoutParameter {
   export function isa(o: any): o is HITLayoutParameter {
-    return _smithy.isa(o, "HITLayoutParameter");
+    return __isa(o, "HITLayoutParameter");
   }
 }
 
@@ -1416,7 +1419,7 @@ export interface ListAssignmentsForHITRequest {
 
 export namespace ListAssignmentsForHITRequest {
   export function isa(o: any): o is ListAssignmentsForHITRequest {
-    return _smithy.isa(o, "ListAssignmentsForHITRequest");
+    return __isa(o, "ListAssignmentsForHITRequest");
   }
 }
 
@@ -1446,7 +1449,7 @@ export interface ListAssignmentsForHITResponse extends $MetadataBearer {
 
 export namespace ListAssignmentsForHITResponse {
   export function isa(o: any): o is ListAssignmentsForHITResponse {
-    return _smithy.isa(o, "ListAssignmentsForHITResponse");
+    return __isa(o, "ListAssignmentsForHITResponse");
   }
 }
 
@@ -1477,7 +1480,7 @@ export interface ListBonusPaymentsRequest {
 
 export namespace ListBonusPaymentsRequest {
   export function isa(o: any): o is ListBonusPaymentsRequest {
-    return _smithy.isa(o, "ListBonusPaymentsRequest");
+    return __isa(o, "ListBonusPaymentsRequest");
   }
 }
 
@@ -1509,7 +1512,7 @@ export interface ListBonusPaymentsResponse extends $MetadataBearer {
 
 export namespace ListBonusPaymentsResponse {
   export function isa(o: any): o is ListBonusPaymentsResponse {
-    return _smithy.isa(o, "ListBonusPaymentsResponse");
+    return __isa(o, "ListBonusPaymentsResponse");
   }
 }
 
@@ -1537,7 +1540,7 @@ export interface ListHITsForQualificationTypeRequest {
 
 export namespace ListHITsForQualificationTypeRequest {
   export function isa(o: any): o is ListHITsForQualificationTypeRequest {
-    return _smithy.isa(o, "ListHITsForQualificationTypeRequest");
+    return __isa(o, "ListHITsForQualificationTypeRequest");
   }
 }
 
@@ -1565,7 +1568,7 @@ export interface ListHITsForQualificationTypeResponse extends $MetadataBearer {
 
 export namespace ListHITsForQualificationTypeResponse {
   export function isa(o: any): o is ListHITsForQualificationTypeResponse {
-    return _smithy.isa(o, "ListHITsForQualificationTypeResponse");
+    return __isa(o, "ListHITsForQualificationTypeResponse");
   }
 }
 
@@ -1580,7 +1583,7 @@ export interface ListHITsRequest {
 
 export namespace ListHITsRequest {
   export function isa(o: any): o is ListHITsRequest {
-    return _smithy.isa(o, "ListHITsRequest");
+    return __isa(o, "ListHITsRequest");
   }
 }
 
@@ -1608,7 +1611,7 @@ export interface ListHITsResponse extends $MetadataBearer {
 
 export namespace ListHITsResponse {
   export function isa(o: any): o is ListHITsResponse {
-    return _smithy.isa(o, "ListHITsResponse");
+    return __isa(o, "ListHITsResponse");
   }
 }
 
@@ -1636,7 +1639,7 @@ export interface ListQualificationRequestsRequest {
 
 export namespace ListQualificationRequestsRequest {
   export function isa(o: any): o is ListQualificationRequestsRequest {
-    return _smithy.isa(o, "ListQualificationRequestsRequest");
+    return __isa(o, "ListQualificationRequestsRequest");
   }
 }
 
@@ -1667,7 +1670,7 @@ export interface ListQualificationRequestsResponse extends $MetadataBearer {
 
 export namespace ListQualificationRequestsResponse {
   export function isa(o: any): o is ListQualificationRequestsResponse {
-    return _smithy.isa(o, "ListQualificationRequestsResponse");
+    return __isa(o, "ListQualificationRequestsResponse");
   }
 }
 
@@ -1717,7 +1720,7 @@ export interface ListQualificationTypesRequest {
 
 export namespace ListQualificationTypesRequest {
   export function isa(o: any): o is ListQualificationTypesRequest {
-    return _smithy.isa(o, "ListQualificationTypesRequest");
+    return __isa(o, "ListQualificationTypesRequest");
   }
 }
 
@@ -1749,7 +1752,7 @@ export interface ListQualificationTypesResponse extends $MetadataBearer {
 
 export namespace ListQualificationTypesResponse {
   export function isa(o: any): o is ListQualificationTypesResponse {
-    return _smithy.isa(o, "ListQualificationTypesResponse");
+    return __isa(o, "ListQualificationTypesResponse");
   }
 }
 
@@ -1797,7 +1800,7 @@ export interface ListReviewPolicyResultsForHITRequest {
 
 export namespace ListReviewPolicyResultsForHITRequest {
   export function isa(o: any): o is ListReviewPolicyResultsForHITRequest {
-    return _smithy.isa(o, "ListReviewPolicyResultsForHITRequest");
+    return __isa(o, "ListReviewPolicyResultsForHITRequest");
   }
 }
 
@@ -1845,7 +1848,7 @@ export interface ListReviewPolicyResultsForHITResponse extends $MetadataBearer {
 
 export namespace ListReviewPolicyResultsForHITResponse {
   export function isa(o: any): o is ListReviewPolicyResultsForHITResponse {
-    return _smithy.isa(o, "ListReviewPolicyResultsForHITResponse");
+    return __isa(o, "ListReviewPolicyResultsForHITResponse");
   }
 }
 
@@ -1882,7 +1885,7 @@ export interface ListReviewableHITsRequest {
 
 export namespace ListReviewableHITsRequest {
   export function isa(o: any): o is ListReviewableHITsRequest {
-    return _smithy.isa(o, "ListReviewableHITsRequest");
+    return __isa(o, "ListReviewableHITsRequest");
   }
 }
 
@@ -1911,7 +1914,7 @@ export interface ListReviewableHITsResponse extends $MetadataBearer {
 
 export namespace ListReviewableHITsResponse {
   export function isa(o: any): o is ListReviewableHITsResponse {
-    return _smithy.isa(o, "ListReviewableHITsResponse");
+    return __isa(o, "ListReviewableHITsResponse");
   }
 }
 
@@ -1926,7 +1929,7 @@ export interface ListWorkerBlocksRequest {
 
 export namespace ListWorkerBlocksRequest {
   export function isa(o: any): o is ListWorkerBlocksRequest {
-    return _smithy.isa(o, "ListWorkerBlocksRequest");
+    return __isa(o, "ListWorkerBlocksRequest");
   }
 }
 
@@ -1956,7 +1959,7 @@ export interface ListWorkerBlocksResponse extends $MetadataBearer {
 
 export namespace ListWorkerBlocksResponse {
   export function isa(o: any): o is ListWorkerBlocksResponse {
-    return _smithy.isa(o, "ListWorkerBlocksResponse");
+    return __isa(o, "ListWorkerBlocksResponse");
   }
 }
 
@@ -1991,7 +1994,7 @@ export interface ListWorkersWithQualificationTypeRequest {
 
 export namespace ListWorkersWithQualificationTypeRequest {
   export function isa(o: any): o is ListWorkersWithQualificationTypeRequest {
-    return _smithy.isa(o, "ListWorkersWithQualificationTypeRequest");
+    return __isa(o, "ListWorkersWithQualificationTypeRequest");
   }
 }
 
@@ -2022,7 +2025,7 @@ export interface ListWorkersWithQualificationTypeResponse
 
 export namespace ListWorkersWithQualificationTypeResponse {
   export function isa(o: any): o is ListWorkersWithQualificationTypeResponse {
-    return _smithy.isa(o, "ListWorkersWithQualificationTypeResponse");
+    return __isa(o, "ListWorkersWithQualificationTypeResponse");
   }
 }
 
@@ -2049,7 +2052,7 @@ export interface Locale {
 
 export namespace Locale {
   export function isa(o: any): o is Locale {
-    return _smithy.isa(o, "Locale");
+    return __isa(o, "Locale");
   }
 }
 
@@ -2104,7 +2107,7 @@ export interface NotificationSpecification {
 
 export namespace NotificationSpecification {
   export function isa(o: any): o is NotificationSpecification {
-    return _smithy.isa(o, "NotificationSpecification");
+    return __isa(o, "NotificationSpecification");
   }
 }
 
@@ -2147,7 +2150,7 @@ export interface NotifyWorkersFailureStatus {
 
 export namespace NotifyWorkersFailureStatus {
   export function isa(o: any): o is NotifyWorkersFailureStatus {
-    return _smithy.isa(o, "NotifyWorkersFailureStatus");
+    return __isa(o, "NotifyWorkersFailureStatus");
   }
 }
 
@@ -2175,7 +2178,7 @@ export interface NotifyWorkersRequest {
 
 export namespace NotifyWorkersRequest {
   export function isa(o: any): o is NotifyWorkersRequest {
-    return _smithy.isa(o, "NotifyWorkersRequest");
+    return __isa(o, "NotifyWorkersRequest");
   }
 }
 
@@ -2192,7 +2195,7 @@ export interface NotifyWorkersResponse extends $MetadataBearer {
 
 export namespace NotifyWorkersResponse {
   export function isa(o: any): o is NotifyWorkersResponse {
-    return _smithy.isa(o, "NotifyWorkersResponse");
+    return __isa(o, "NotifyWorkersResponse");
   }
 }
 
@@ -2222,7 +2225,7 @@ export interface ParameterMapEntry {
 
 export namespace ParameterMapEntry {
   export function isa(o: any): o is ParameterMapEntry {
-    return _smithy.isa(o, "ParameterMapEntry");
+    return __isa(o, "ParameterMapEntry");
   }
 }
 
@@ -2252,7 +2255,7 @@ export interface PolicyParameter {
 
 export namespace PolicyParameter {
   export function isa(o: any): o is PolicyParameter {
-    return _smithy.isa(o, "PolicyParameter");
+    return __isa(o, "PolicyParameter");
   }
 }
 
@@ -2303,7 +2306,7 @@ export interface Qualification {
 
 export namespace Qualification {
   export function isa(o: any): o is Qualification {
-    return _smithy.isa(o, "Qualification");
+    return __isa(o, "Qualification");
   }
 }
 
@@ -2364,7 +2367,7 @@ export interface QualificationRequest {
 
 export namespace QualificationRequest {
   export function isa(o: any): o is QualificationRequest {
-    return _smithy.isa(o, "QualificationRequest");
+    return __isa(o, "QualificationRequest");
   }
 }
 
@@ -2462,7 +2465,7 @@ export interface QualificationRequirement {
 
 export namespace QualificationRequirement {
   export function isa(o: any): o is QualificationRequirement {
-    return _smithy.isa(o, "QualificationRequirement");
+    return __isa(o, "QualificationRequirement");
   }
 }
 
@@ -2588,7 +2591,7 @@ export interface QualificationType {
 
 export namespace QualificationType {
   export function isa(o: any): o is QualificationType {
-    return _smithy.isa(o, "QualificationType");
+    return __isa(o, "QualificationType");
   }
 }
 
@@ -2616,7 +2619,7 @@ export interface RejectAssignmentRequest {
 
 export namespace RejectAssignmentRequest {
   export function isa(o: any): o is RejectAssignmentRequest {
-    return _smithy.isa(o, "RejectAssignmentRequest");
+    return __isa(o, "RejectAssignmentRequest");
   }
 }
 
@@ -2626,7 +2629,7 @@ export interface RejectAssignmentResponse extends $MetadataBearer {
 
 export namespace RejectAssignmentResponse {
   export function isa(o: any): o is RejectAssignmentResponse {
-    return _smithy.isa(o, "RejectAssignmentResponse");
+    return __isa(o, "RejectAssignmentResponse");
   }
 }
 
@@ -2650,7 +2653,7 @@ export interface RejectQualificationRequestRequest {
 
 export namespace RejectQualificationRequestRequest {
   export function isa(o: any): o is RejectQualificationRequestRequest {
-    return _smithy.isa(o, "RejectQualificationRequestRequest");
+    return __isa(o, "RejectQualificationRequestRequest");
   }
 }
 
@@ -2660,7 +2663,7 @@ export interface RejectQualificationRequestResponse extends $MetadataBearer {
 
 export namespace RejectQualificationRequestResponse {
   export function isa(o: any): o is RejectQualificationRequestResponse {
-    return _smithy.isa(o, "RejectQualificationRequestResponse");
+    return __isa(o, "RejectQualificationRequestResponse");
   }
 }
 
@@ -2720,7 +2723,7 @@ export interface ReviewActionDetail {
 
 export namespace ReviewActionDetail {
   export function isa(o: any): o is ReviewActionDetail {
-    return _smithy.isa(o, "ReviewActionDetail");
+    return __isa(o, "ReviewActionDetail");
   }
 }
 
@@ -2753,7 +2756,7 @@ export interface ReviewPolicy {
 
 export namespace ReviewPolicy {
   export function isa(o: any): o is ReviewPolicy {
-    return _smithy.isa(o, "ReviewPolicy");
+    return __isa(o, "ReviewPolicy");
   }
 }
 
@@ -2786,7 +2789,7 @@ export interface ReviewReport {
 
 export namespace ReviewReport {
   export function isa(o: any): o is ReviewReport {
-    return _smithy.isa(o, "ReviewReport");
+    return __isa(o, "ReviewReport");
   }
 }
 
@@ -2846,7 +2849,7 @@ export interface ReviewResultDetail {
 
 export namespace ReviewResultDetail {
   export function isa(o: any): o is ReviewResultDetail {
-    return _smithy.isa(o, "ReviewResultDetail");
+    return __isa(o, "ReviewResultDetail");
   }
 }
 
@@ -2895,7 +2898,7 @@ export interface SendBonusRequest {
 
 export namespace SendBonusRequest {
   export function isa(o: any): o is SendBonusRequest {
-    return _smithy.isa(o, "SendBonusRequest");
+    return __isa(o, "SendBonusRequest");
   }
 }
 
@@ -2905,7 +2908,7 @@ export interface SendBonusResponse extends $MetadataBearer {
 
 export namespace SendBonusResponse {
   export function isa(o: any): o is SendBonusResponse {
-    return _smithy.isa(o, "SendBonusResponse");
+    return __isa(o, "SendBonusResponse");
   }
 }
 
@@ -2933,7 +2936,7 @@ export interface SendTestEventNotificationRequest {
 
 export namespace SendTestEventNotificationRequest {
   export function isa(o: any): o is SendTestEventNotificationRequest {
-    return _smithy.isa(o, "SendTestEventNotificationRequest");
+    return __isa(o, "SendTestEventNotificationRequest");
   }
 }
 
@@ -2943,7 +2946,7 @@ export interface SendTestEventNotificationResponse extends $MetadataBearer {
 
 export namespace SendTestEventNotificationResponse {
   export function isa(o: any): o is SendTestEventNotificationResponse {
-    return _smithy.isa(o, "SendTestEventNotificationResponse");
+    return __isa(o, "SendTestEventNotificationResponse");
   }
 }
 
@@ -2966,7 +2969,7 @@ export interface UpdateExpirationForHITRequest {
 
 export namespace UpdateExpirationForHITRequest {
   export function isa(o: any): o is UpdateExpirationForHITRequest {
-    return _smithy.isa(o, "UpdateExpirationForHITRequest");
+    return __isa(o, "UpdateExpirationForHITRequest");
   }
 }
 
@@ -2976,7 +2979,7 @@ export interface UpdateExpirationForHITResponse extends $MetadataBearer {
 
 export namespace UpdateExpirationForHITResponse {
   export function isa(o: any): o is UpdateExpirationForHITResponse {
-    return _smithy.isa(o, "UpdateExpirationForHITResponse");
+    return __isa(o, "UpdateExpirationForHITResponse");
   }
 }
 
@@ -3011,7 +3014,7 @@ export interface UpdateHITReviewStatusRequest {
 
 export namespace UpdateHITReviewStatusRequest {
   export function isa(o: any): o is UpdateHITReviewStatusRequest {
-    return _smithy.isa(o, "UpdateHITReviewStatusRequest");
+    return __isa(o, "UpdateHITReviewStatusRequest");
   }
 }
 
@@ -3021,7 +3024,7 @@ export interface UpdateHITReviewStatusResponse extends $MetadataBearer {
 
 export namespace UpdateHITReviewStatusResponse {
   export function isa(o: any): o is UpdateHITReviewStatusResponse {
-    return _smithy.isa(o, "UpdateHITReviewStatusResponse");
+    return __isa(o, "UpdateHITReviewStatusResponse");
   }
 }
 
@@ -3040,7 +3043,7 @@ export interface UpdateHITTypeOfHITRequest {
 
 export namespace UpdateHITTypeOfHITRequest {
   export function isa(o: any): o is UpdateHITTypeOfHITRequest {
-    return _smithy.isa(o, "UpdateHITTypeOfHITRequest");
+    return __isa(o, "UpdateHITTypeOfHITRequest");
   }
 }
 
@@ -3050,7 +3053,7 @@ export interface UpdateHITTypeOfHITResponse extends $MetadataBearer {
 
 export namespace UpdateHITTypeOfHITResponse {
   export function isa(o: any): o is UpdateHITTypeOfHITResponse {
-    return _smithy.isa(o, "UpdateHITTypeOfHITResponse");
+    return __isa(o, "UpdateHITTypeOfHITResponse");
   }
 }
 
@@ -3083,7 +3086,7 @@ export interface UpdateNotificationSettingsRequest {
 
 export namespace UpdateNotificationSettingsRequest {
   export function isa(o: any): o is UpdateNotificationSettingsRequest {
-    return _smithy.isa(o, "UpdateNotificationSettingsRequest");
+    return __isa(o, "UpdateNotificationSettingsRequest");
   }
 }
 
@@ -3093,7 +3096,7 @@ export interface UpdateNotificationSettingsResponse extends $MetadataBearer {
 
 export namespace UpdateNotificationSettingsResponse {
   export function isa(o: any): o is UpdateNotificationSettingsResponse {
-    return _smithy.isa(o, "UpdateNotificationSettingsResponse");
+    return __isa(o, "UpdateNotificationSettingsResponse");
   }
 }
 
@@ -3157,7 +3160,7 @@ export interface UpdateQualificationTypeRequest {
 
 export namespace UpdateQualificationTypeRequest {
   export function isa(o: any): o is UpdateQualificationTypeRequest {
-    return _smithy.isa(o, "UpdateQualificationTypeRequest");
+    return __isa(o, "UpdateQualificationTypeRequest");
   }
 }
 
@@ -3171,7 +3174,7 @@ export interface UpdateQualificationTypeResponse extends $MetadataBearer {
 
 export namespace UpdateQualificationTypeResponse {
   export function isa(o: any): o is UpdateQualificationTypeResponse {
-    return _smithy.isa(o, "UpdateQualificationTypeResponse");
+    return __isa(o, "UpdateQualificationTypeResponse");
   }
 }
 
@@ -3197,14 +3200,14 @@ export interface WorkerBlock {
 
 export namespace WorkerBlock {
   export function isa(o: any): o is WorkerBlock {
-    return _smithy.isa(o, "WorkerBlock");
+    return __isa(o, "WorkerBlock");
   }
 }
 
 /**
  * <p>Your request is invalid.</p>
  */
-export interface RequestError extends _smithy.SmithyException, $MetadataBearer {
+export interface RequestError extends __SmithyException, $MetadataBearer {
   name: "RequestError";
   $fault: "client";
   Message?: string;
@@ -3213,14 +3216,14 @@ export interface RequestError extends _smithy.SmithyException, $MetadataBearer {
 
 export namespace RequestError {
   export function isa(o: any): o is RequestError {
-    return _smithy.isa(o, "RequestError");
+    return __isa(o, "RequestError");
   }
 }
 
 /**
  * <p>Amazon Mechanical Turk is temporarily unable to process your request. Try your call again.</p>
  */
-export interface ServiceFault extends _smithy.SmithyException, $MetadataBearer {
+export interface ServiceFault extends __SmithyException, $MetadataBearer {
   name: "ServiceFault";
   $fault: "server";
   Message?: string;
@@ -3229,6 +3232,6 @@ export interface ServiceFault extends _smithy.SmithyException, $MetadataBearer {
 
 export namespace ServiceFault {
   export function isa(o: any): o is ServiceFault {
-    return _smithy.isa(o, "ServiceFault");
+    return __isa(o, "ServiceFault");
   }
 }

--- a/clients/client-neptune/models/index.ts
+++ b/clients/client-neptune/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -6,7 +9,7 @@ import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
  *          <p>Neptune may not also be authorized via IAM to perform necessary actions on your behalf.</p>
  */
 export interface AuthorizationNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AuthorizationNotFoundFault";
   $fault: "client";
@@ -18,7 +21,7 @@ export interface AuthorizationNotFoundFault
 
 export namespace AuthorizationNotFoundFault {
   export function isa(o: any): o is AuthorizationNotFoundFault {
-    return _smithy.isa(o, "AuthorizationNotFoundFault");
+    return __isa(o, "AuthorizationNotFoundFault");
   }
 }
 
@@ -27,7 +30,7 @@ export namespace AuthorizationNotFoundFault {
  *             <i>CertificateIdentifier</i> does not refer to an existing certificate.</p>
  */
 export interface CertificateNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CertificateNotFoundFault";
   $fault: "client";
@@ -39,7 +42,7 @@ export interface CertificateNotFoundFault
 
 export namespace CertificateNotFoundFault {
   export function isa(o: any): o is CertificateNotFoundFault {
-    return _smithy.isa(o, "CertificateNotFoundFault");
+    return __isa(o, "CertificateNotFoundFault");
   }
 }
 
@@ -47,7 +50,7 @@ export namespace CertificateNotFoundFault {
  * <p>User already has a DB cluster with the given identifier.</p>
  */
 export interface DBClusterAlreadyExistsFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBClusterAlreadyExistsFault";
   $fault: "client";
@@ -59,7 +62,7 @@ export interface DBClusterAlreadyExistsFault
 
 export namespace DBClusterAlreadyExistsFault {
   export function isa(o: any): o is DBClusterAlreadyExistsFault {
-    return _smithy.isa(o, "DBClusterAlreadyExistsFault");
+    return __isa(o, "DBClusterAlreadyExistsFault");
   }
 }
 
@@ -68,7 +71,7 @@ export namespace DBClusterAlreadyExistsFault {
  *             <i>DBClusterIdentifier</i> does not refer to an existing DB cluster.</p>
  */
 export interface DBClusterNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBClusterNotFoundFault";
   $fault: "client";
@@ -80,7 +83,7 @@ export interface DBClusterNotFoundFault
 
 export namespace DBClusterNotFoundFault {
   export function isa(o: any): o is DBClusterNotFoundFault {
-    return _smithy.isa(o, "DBClusterNotFoundFault");
+    return __isa(o, "DBClusterNotFoundFault");
   }
 }
 
@@ -90,7 +93,7 @@ export namespace DBClusterNotFoundFault {
  *       existing DB Cluster parameter group.</p>
  */
 export interface DBClusterParameterGroupNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBClusterParameterGroupNotFoundFault";
   $fault: "client";
@@ -102,7 +105,7 @@ export interface DBClusterParameterGroupNotFoundFault
 
 export namespace DBClusterParameterGroupNotFoundFault {
   export function isa(o: any): o is DBClusterParameterGroupNotFoundFault {
-    return _smithy.isa(o, "DBClusterParameterGroupNotFoundFault");
+    return __isa(o, "DBClusterParameterGroupNotFoundFault");
   }
 }
 
@@ -110,7 +113,7 @@ export namespace DBClusterParameterGroupNotFoundFault {
  * <p>User attempted to create a new DB cluster and the user has already reached the maximum allowed DB cluster quota.</p>
  */
 export interface DBClusterQuotaExceededFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBClusterQuotaExceededFault";
   $fault: "client";
@@ -122,7 +125,7 @@ export interface DBClusterQuotaExceededFault
 
 export namespace DBClusterQuotaExceededFault {
   export function isa(o: any): o is DBClusterQuotaExceededFault {
-    return _smithy.isa(o, "DBClusterQuotaExceededFault");
+    return __isa(o, "DBClusterQuotaExceededFault");
   }
 }
 
@@ -130,7 +133,7 @@ export namespace DBClusterQuotaExceededFault {
  * <p>The specified IAM role Amazon Resource Name (ARN) is already associated with the specified DB cluster.</p>
  */
 export interface DBClusterRoleAlreadyExistsFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBClusterRoleAlreadyExistsFault";
   $fault: "client";
@@ -142,7 +145,7 @@ export interface DBClusterRoleAlreadyExistsFault
 
 export namespace DBClusterRoleAlreadyExistsFault {
   export function isa(o: any): o is DBClusterRoleAlreadyExistsFault {
-    return _smithy.isa(o, "DBClusterRoleAlreadyExistsFault");
+    return __isa(o, "DBClusterRoleAlreadyExistsFault");
   }
 }
 
@@ -150,7 +153,7 @@ export namespace DBClusterRoleAlreadyExistsFault {
  * <p>The specified IAM role Amazon Resource Name (ARN) is not associated with the specified DB cluster.</p>
  */
 export interface DBClusterRoleNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBClusterRoleNotFoundFault";
   $fault: "client";
@@ -162,7 +165,7 @@ export interface DBClusterRoleNotFoundFault
 
 export namespace DBClusterRoleNotFoundFault {
   export function isa(o: any): o is DBClusterRoleNotFoundFault {
-    return _smithy.isa(o, "DBClusterRoleNotFoundFault");
+    return __isa(o, "DBClusterRoleNotFoundFault");
   }
 }
 
@@ -170,7 +173,7 @@ export namespace DBClusterRoleNotFoundFault {
  * <p>You have exceeded the maximum number of IAM roles that can be associated with the specified DB cluster.</p>
  */
 export interface DBClusterRoleQuotaExceededFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBClusterRoleQuotaExceededFault";
   $fault: "client";
@@ -182,7 +185,7 @@ export interface DBClusterRoleQuotaExceededFault
 
 export namespace DBClusterRoleQuotaExceededFault {
   export function isa(o: any): o is DBClusterRoleQuotaExceededFault {
-    return _smithy.isa(o, "DBClusterRoleQuotaExceededFault");
+    return __isa(o, "DBClusterRoleQuotaExceededFault");
   }
 }
 
@@ -190,7 +193,7 @@ export namespace DBClusterRoleQuotaExceededFault {
  * <p>User already has a DB cluster snapshot with the given identifier.</p>
  */
 export interface DBClusterSnapshotAlreadyExistsFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBClusterSnapshotAlreadyExistsFault";
   $fault: "client";
@@ -202,7 +205,7 @@ export interface DBClusterSnapshotAlreadyExistsFault
 
 export namespace DBClusterSnapshotAlreadyExistsFault {
   export function isa(o: any): o is DBClusterSnapshotAlreadyExistsFault {
-    return _smithy.isa(o, "DBClusterSnapshotAlreadyExistsFault");
+    return __isa(o, "DBClusterSnapshotAlreadyExistsFault");
   }
 }
 
@@ -212,7 +215,7 @@ export namespace DBClusterSnapshotAlreadyExistsFault {
  *       DB cluster snapshot.</p>
  */
 export interface DBClusterSnapshotNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBClusterSnapshotNotFoundFault";
   $fault: "client";
@@ -224,7 +227,7 @@ export interface DBClusterSnapshotNotFoundFault
 
 export namespace DBClusterSnapshotNotFoundFault {
   export function isa(o: any): o is DBClusterSnapshotNotFoundFault {
-    return _smithy.isa(o, "DBClusterSnapshotNotFoundFault");
+    return __isa(o, "DBClusterSnapshotNotFoundFault");
   }
 }
 
@@ -232,7 +235,7 @@ export namespace DBClusterSnapshotNotFoundFault {
  * <p>User already has a DB instance with the given identifier.</p>
  */
 export interface DBInstanceAlreadyExistsFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBInstanceAlreadyExistsFault";
   $fault: "client";
@@ -244,7 +247,7 @@ export interface DBInstanceAlreadyExistsFault
 
 export namespace DBInstanceAlreadyExistsFault {
   export function isa(o: any): o is DBInstanceAlreadyExistsFault {
-    return _smithy.isa(o, "DBInstanceAlreadyExistsFault");
+    return __isa(o, "DBInstanceAlreadyExistsFault");
   }
 }
 
@@ -253,7 +256,7 @@ export namespace DBInstanceAlreadyExistsFault {
  *             <i>DBInstanceIdentifier</i> does not refer to an existing DB instance.</p>
  */
 export interface DBInstanceNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBInstanceNotFoundFault";
   $fault: "client";
@@ -265,7 +268,7 @@ export interface DBInstanceNotFoundFault
 
 export namespace DBInstanceNotFoundFault {
   export function isa(o: any): o is DBInstanceNotFoundFault {
-    return _smithy.isa(o, "DBInstanceNotFoundFault");
+    return __isa(o, "DBInstanceNotFoundFault");
   }
 }
 
@@ -273,7 +276,7 @@ export namespace DBInstanceNotFoundFault {
  * <p>A DB parameter group with the same name exists.</p>
  */
 export interface DBParameterGroupAlreadyExistsFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBParameterGroupAlreadyExistsFault";
   $fault: "client";
@@ -285,7 +288,7 @@ export interface DBParameterGroupAlreadyExistsFault
 
 export namespace DBParameterGroupAlreadyExistsFault {
   export function isa(o: any): o is DBParameterGroupAlreadyExistsFault {
-    return _smithy.isa(o, "DBParameterGroupAlreadyExistsFault");
+    return __isa(o, "DBParameterGroupAlreadyExistsFault");
   }
 }
 
@@ -295,7 +298,7 @@ export namespace DBParameterGroupAlreadyExistsFault {
  *       existing DB parameter group.</p>
  */
 export interface DBParameterGroupNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBParameterGroupNotFoundFault";
   $fault: "client";
@@ -307,7 +310,7 @@ export interface DBParameterGroupNotFoundFault
 
 export namespace DBParameterGroupNotFoundFault {
   export function isa(o: any): o is DBParameterGroupNotFoundFault {
-    return _smithy.isa(o, "DBParameterGroupNotFoundFault");
+    return __isa(o, "DBParameterGroupNotFoundFault");
   }
 }
 
@@ -315,7 +318,7 @@ export namespace DBParameterGroupNotFoundFault {
  * <p>Request would result in user exceeding the allowed number of DB parameter groups.</p>
  */
 export interface DBParameterGroupQuotaExceededFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBParameterGroupQuotaExceededFault";
   $fault: "client";
@@ -327,7 +330,7 @@ export interface DBParameterGroupQuotaExceededFault
 
 export namespace DBParameterGroupQuotaExceededFault {
   export function isa(o: any): o is DBParameterGroupQuotaExceededFault {
-    return _smithy.isa(o, "DBParameterGroupQuotaExceededFault");
+    return __isa(o, "DBParameterGroupQuotaExceededFault");
   }
 }
 
@@ -337,7 +340,7 @@ export namespace DBParameterGroupQuotaExceededFault {
  *       to an existing DB security group.</p>
  */
 export interface DBSecurityGroupNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBSecurityGroupNotFoundFault";
   $fault: "client";
@@ -349,7 +352,7 @@ export interface DBSecurityGroupNotFoundFault
 
 export namespace DBSecurityGroupNotFoundFault {
   export function isa(o: any): o is DBSecurityGroupNotFoundFault {
-    return _smithy.isa(o, "DBSecurityGroupNotFoundFault");
+    return __isa(o, "DBSecurityGroupNotFoundFault");
   }
 }
 
@@ -358,7 +361,7 @@ export namespace DBSecurityGroupNotFoundFault {
  *             <i>DBSnapshotIdentifier</i> is already used by an existing snapshot.</p>
  */
 export interface DBSnapshotAlreadyExistsFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBSnapshotAlreadyExistsFault";
   $fault: "client";
@@ -370,7 +373,7 @@ export interface DBSnapshotAlreadyExistsFault
 
 export namespace DBSnapshotAlreadyExistsFault {
   export function isa(o: any): o is DBSnapshotAlreadyExistsFault {
-    return _smithy.isa(o, "DBSnapshotAlreadyExistsFault");
+    return __isa(o, "DBSnapshotAlreadyExistsFault");
   }
 }
 
@@ -379,7 +382,7 @@ export namespace DBSnapshotAlreadyExistsFault {
  *             <i>DBSnapshotIdentifier</i> does not refer to an existing DB snapshot.</p>
  */
 export interface DBSnapshotNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBSnapshotNotFoundFault";
   $fault: "client";
@@ -391,7 +394,7 @@ export interface DBSnapshotNotFoundFault
 
 export namespace DBSnapshotNotFoundFault {
   export function isa(o: any): o is DBSnapshotNotFoundFault {
-    return _smithy.isa(o, "DBSnapshotNotFoundFault");
+    return __isa(o, "DBSnapshotNotFoundFault");
   }
 }
 
@@ -400,7 +403,7 @@ export namespace DBSnapshotNotFoundFault {
  *             <i>DBSubnetGroupName</i> is already used by an existing DB subnet group.</p>
  */
 export interface DBSubnetGroupAlreadyExistsFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBSubnetGroupAlreadyExistsFault";
   $fault: "client";
@@ -412,7 +415,7 @@ export interface DBSubnetGroupAlreadyExistsFault
 
 export namespace DBSubnetGroupAlreadyExistsFault {
   export function isa(o: any): o is DBSubnetGroupAlreadyExistsFault {
-    return _smithy.isa(o, "DBSubnetGroupAlreadyExistsFault");
+    return __isa(o, "DBSubnetGroupAlreadyExistsFault");
   }
 }
 
@@ -421,7 +424,7 @@ export namespace DBSubnetGroupAlreadyExistsFault {
  *       Zones unless there is only one Availability Zone.</p>
  */
 export interface DBSubnetGroupDoesNotCoverEnoughAZs
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBSubnetGroupDoesNotCoverEnoughAZs";
   $fault: "client";
@@ -433,7 +436,7 @@ export interface DBSubnetGroupDoesNotCoverEnoughAZs
 
 export namespace DBSubnetGroupDoesNotCoverEnoughAZs {
   export function isa(o: any): o is DBSubnetGroupDoesNotCoverEnoughAZs {
-    return _smithy.isa(o, "DBSubnetGroupDoesNotCoverEnoughAZs");
+    return __isa(o, "DBSubnetGroupDoesNotCoverEnoughAZs");
   }
 }
 
@@ -443,7 +446,7 @@ export namespace DBSubnetGroupDoesNotCoverEnoughAZs {
  *       existing DB subnet group.</p>
  */
 export interface DBSubnetGroupNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBSubnetGroupNotFoundFault";
   $fault: "client";
@@ -455,7 +458,7 @@ export interface DBSubnetGroupNotFoundFault
 
 export namespace DBSubnetGroupNotFoundFault {
   export function isa(o: any): o is DBSubnetGroupNotFoundFault {
-    return _smithy.isa(o, "DBSubnetGroupNotFoundFault");
+    return __isa(o, "DBSubnetGroupNotFoundFault");
   }
 }
 
@@ -463,7 +466,7 @@ export namespace DBSubnetGroupNotFoundFault {
  * <p>Request would result in user exceeding the allowed number of DB subnet groups.</p>
  */
 export interface DBSubnetGroupQuotaExceededFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBSubnetGroupQuotaExceededFault";
   $fault: "client";
@@ -475,7 +478,7 @@ export interface DBSubnetGroupQuotaExceededFault
 
 export namespace DBSubnetGroupQuotaExceededFault {
   export function isa(o: any): o is DBSubnetGroupQuotaExceededFault {
-    return _smithy.isa(o, "DBSubnetGroupQuotaExceededFault");
+    return __isa(o, "DBSubnetGroupQuotaExceededFault");
   }
 }
 
@@ -483,7 +486,7 @@ export namespace DBSubnetGroupQuotaExceededFault {
  * <p>Request would result in user exceeding the allowed number of subnets in a DB subnet groups.</p>
  */
 export interface DBSubnetQuotaExceededFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBSubnetQuotaExceededFault";
   $fault: "client";
@@ -495,7 +498,7 @@ export interface DBSubnetQuotaExceededFault
 
 export namespace DBSubnetQuotaExceededFault {
   export function isa(o: any): o is DBSubnetQuotaExceededFault {
-    return _smithy.isa(o, "DBSubnetQuotaExceededFault");
+    return __isa(o, "DBSubnetQuotaExceededFault");
   }
 }
 
@@ -503,7 +506,7 @@ export namespace DBSubnetQuotaExceededFault {
  * <p>The DB upgrade failed because a resource the DB depends on could not be modified.</p>
  */
 export interface DBUpgradeDependencyFailureFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBUpgradeDependencyFailureFault";
   $fault: "client";
@@ -515,7 +518,7 @@ export interface DBUpgradeDependencyFailureFault
 
 export namespace DBUpgradeDependencyFailureFault {
   export function isa(o: any): o is DBUpgradeDependencyFailureFault {
-    return _smithy.isa(o, "DBUpgradeDependencyFailureFault");
+    return __isa(o, "DBUpgradeDependencyFailureFault");
   }
 }
 
@@ -524,7 +527,7 @@ export namespace DBUpgradeDependencyFailureFault {
  *             <i>Domain</i> does not refer to an existing Active Directory Domain.</p>
  */
 export interface DomainNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DomainNotFoundFault";
   $fault: "client";
@@ -536,7 +539,7 @@ export interface DomainNotFoundFault
 
 export namespace DomainNotFoundFault {
   export function isa(o: any): o is DomainNotFoundFault {
-    return _smithy.isa(o, "DomainNotFoundFault");
+    return __isa(o, "DomainNotFoundFault");
   }
 }
 
@@ -544,7 +547,7 @@ export namespace DomainNotFoundFault {
  * <p>You have exceeded the number of events you can subscribe to.</p>
  */
 export interface EventSubscriptionQuotaExceededFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "EventSubscriptionQuotaExceededFault";
   $fault: "client";
@@ -556,7 +559,7 @@ export interface EventSubscriptionQuotaExceededFault
 
 export namespace EventSubscriptionQuotaExceededFault {
   export function isa(o: any): o is EventSubscriptionQuotaExceededFault {
-    return _smithy.isa(o, "EventSubscriptionQuotaExceededFault");
+    return __isa(o, "EventSubscriptionQuotaExceededFault");
   }
 }
 
@@ -564,7 +567,7 @@ export namespace EventSubscriptionQuotaExceededFault {
  * <p>Request would result in user exceeding the allowed number of DB instances.</p>
  */
 export interface InstanceQuotaExceededFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InstanceQuotaExceededFault";
   $fault: "client";
@@ -576,7 +579,7 @@ export interface InstanceQuotaExceededFault
 
 export namespace InstanceQuotaExceededFault {
   export function isa(o: any): o is InstanceQuotaExceededFault {
-    return _smithy.isa(o, "InstanceQuotaExceededFault");
+    return __isa(o, "InstanceQuotaExceededFault");
   }
 }
 
@@ -584,7 +587,7 @@ export namespace InstanceQuotaExceededFault {
  * <p>The DB cluster does not have enough capacity for the current operation.</p>
  */
 export interface InsufficientDBClusterCapacityFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InsufficientDBClusterCapacityFault";
   $fault: "client";
@@ -596,7 +599,7 @@ export interface InsufficientDBClusterCapacityFault
 
 export namespace InsufficientDBClusterCapacityFault {
   export function isa(o: any): o is InsufficientDBClusterCapacityFault {
-    return _smithy.isa(o, "InsufficientDBClusterCapacityFault");
+    return __isa(o, "InsufficientDBClusterCapacityFault");
   }
 }
 
@@ -604,7 +607,7 @@ export namespace InsufficientDBClusterCapacityFault {
  * <p>Specified DB instance class is not available in the specified Availability Zone.</p>
  */
 export interface InsufficientDBInstanceCapacityFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InsufficientDBInstanceCapacityFault";
   $fault: "client";
@@ -616,7 +619,7 @@ export interface InsufficientDBInstanceCapacityFault
 
 export namespace InsufficientDBInstanceCapacityFault {
   export function isa(o: any): o is InsufficientDBInstanceCapacityFault {
-    return _smithy.isa(o, "InsufficientDBInstanceCapacityFault");
+    return __isa(o, "InsufficientDBInstanceCapacityFault");
   }
 }
 
@@ -626,7 +629,7 @@ export namespace InsufficientDBInstanceCapacityFault {
  *        Availability Zones that have more storage available.</p>
  */
 export interface InsufficientStorageClusterCapacityFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InsufficientStorageClusterCapacityFault";
   $fault: "client";
@@ -638,7 +641,7 @@ export interface InsufficientStorageClusterCapacityFault
 
 export namespace InsufficientStorageClusterCapacityFault {
   export function isa(o: any): o is InsufficientStorageClusterCapacityFault {
-    return _smithy.isa(o, "InsufficientStorageClusterCapacityFault");
+    return __isa(o, "InsufficientStorageClusterCapacityFault");
   }
 }
 
@@ -646,7 +649,7 @@ export namespace InsufficientStorageClusterCapacityFault {
  * <p>The supplied value is not a valid DB cluster snapshot state.</p>
  */
 export interface InvalidDBClusterSnapshotStateFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidDBClusterSnapshotStateFault";
   $fault: "client";
@@ -658,7 +661,7 @@ export interface InvalidDBClusterSnapshotStateFault
 
 export namespace InvalidDBClusterSnapshotStateFault {
   export function isa(o: any): o is InvalidDBClusterSnapshotStateFault {
-    return _smithy.isa(o, "InvalidDBClusterSnapshotStateFault");
+    return __isa(o, "InvalidDBClusterSnapshotStateFault");
   }
 }
 
@@ -666,7 +669,7 @@ export namespace InvalidDBClusterSnapshotStateFault {
  * <p>The DB cluster is not in a valid state.</p>
  */
 export interface InvalidDBClusterStateFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidDBClusterStateFault";
   $fault: "client";
@@ -678,7 +681,7 @@ export interface InvalidDBClusterStateFault
 
 export namespace InvalidDBClusterStateFault {
   export function isa(o: any): o is InvalidDBClusterStateFault {
-    return _smithy.isa(o, "InvalidDBClusterStateFault");
+    return __isa(o, "InvalidDBClusterStateFault");
   }
 }
 
@@ -686,7 +689,7 @@ export namespace InvalidDBClusterStateFault {
  * <p>The specified DB instance is not in the <i>available</i> state.</p>
  */
 export interface InvalidDBInstanceStateFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidDBInstanceStateFault";
   $fault: "client";
@@ -698,7 +701,7 @@ export interface InvalidDBInstanceStateFault
 
 export namespace InvalidDBInstanceStateFault {
   export function isa(o: any): o is InvalidDBInstanceStateFault {
-    return _smithy.isa(o, "InvalidDBInstanceStateFault");
+    return __isa(o, "InvalidDBInstanceStateFault");
   }
 }
 
@@ -707,7 +710,7 @@ export namespace InvalidDBInstanceStateFault {
  *       delete the parameter group, you cannot delete it when the parameter group is in this state.</p>
  */
 export interface InvalidDBParameterGroupStateFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidDBParameterGroupStateFault";
   $fault: "client";
@@ -719,7 +722,7 @@ export interface InvalidDBParameterGroupStateFault
 
 export namespace InvalidDBParameterGroupStateFault {
   export function isa(o: any): o is InvalidDBParameterGroupStateFault {
-    return _smithy.isa(o, "InvalidDBParameterGroupStateFault");
+    return __isa(o, "InvalidDBParameterGroupStateFault");
   }
 }
 
@@ -727,7 +730,7 @@ export namespace InvalidDBParameterGroupStateFault {
  * <p>The state of the DB security group does not allow deletion.</p>
  */
 export interface InvalidDBSecurityGroupStateFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidDBSecurityGroupStateFault";
   $fault: "client";
@@ -739,7 +742,7 @@ export interface InvalidDBSecurityGroupStateFault
 
 export namespace InvalidDBSecurityGroupStateFault {
   export function isa(o: any): o is InvalidDBSecurityGroupStateFault {
-    return _smithy.isa(o, "InvalidDBSecurityGroupStateFault");
+    return __isa(o, "InvalidDBSecurityGroupStateFault");
   }
 }
 
@@ -747,7 +750,7 @@ export namespace InvalidDBSecurityGroupStateFault {
  * <p>The state of the DB snapshot does not allow deletion.</p>
  */
 export interface InvalidDBSnapshotStateFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidDBSnapshotStateFault";
   $fault: "client";
@@ -759,7 +762,7 @@ export interface InvalidDBSnapshotStateFault
 
 export namespace InvalidDBSnapshotStateFault {
   export function isa(o: any): o is InvalidDBSnapshotStateFault {
-    return _smithy.isa(o, "InvalidDBSnapshotStateFault");
+    return __isa(o, "InvalidDBSnapshotStateFault");
   }
 }
 
@@ -767,7 +770,7 @@ export namespace InvalidDBSnapshotStateFault {
  * <p>The DB subnet group cannot be deleted because it is in use.</p>
  */
 export interface InvalidDBSubnetGroupStateFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidDBSubnetGroupStateFault";
   $fault: "client";
@@ -779,7 +782,7 @@ export interface InvalidDBSubnetGroupStateFault
 
 export namespace InvalidDBSubnetGroupStateFault {
   export function isa(o: any): o is InvalidDBSubnetGroupStateFault {
-    return _smithy.isa(o, "InvalidDBSubnetGroupStateFault");
+    return __isa(o, "InvalidDBSubnetGroupStateFault");
   }
 }
 
@@ -787,7 +790,7 @@ export namespace InvalidDBSubnetGroupStateFault {
  * <p>The DB subnet is not in the <i>available</i> state.</p>
  */
 export interface InvalidDBSubnetStateFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidDBSubnetStateFault";
   $fault: "client";
@@ -799,7 +802,7 @@ export interface InvalidDBSubnetStateFault
 
 export namespace InvalidDBSubnetStateFault {
   export function isa(o: any): o is InvalidDBSubnetStateFault {
-    return _smithy.isa(o, "InvalidDBSubnetStateFault");
+    return __isa(o, "InvalidDBSubnetStateFault");
   }
 }
 
@@ -807,7 +810,7 @@ export namespace InvalidDBSubnetStateFault {
  * <p>The event subscription is in an invalid state.</p>
  */
 export interface InvalidEventSubscriptionStateFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidEventSubscriptionStateFault";
   $fault: "client";
@@ -819,7 +822,7 @@ export interface InvalidEventSubscriptionStateFault
 
 export namespace InvalidEventSubscriptionStateFault {
   export function isa(o: any): o is InvalidEventSubscriptionStateFault {
-    return _smithy.isa(o, "InvalidEventSubscriptionStateFault");
+    return __isa(o, "InvalidEventSubscriptionStateFault");
   }
 }
 
@@ -827,7 +830,7 @@ export namespace InvalidEventSubscriptionStateFault {
  * <p>Cannot restore from vpc backup to non-vpc DB instance.</p>
  */
 export interface InvalidRestoreFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidRestoreFault";
   $fault: "client";
@@ -839,7 +842,7 @@ export interface InvalidRestoreFault
 
 export namespace InvalidRestoreFault {
   export function isa(o: any): o is InvalidRestoreFault {
-    return _smithy.isa(o, "InvalidRestoreFault");
+    return __isa(o, "InvalidRestoreFault");
   }
 }
 
@@ -847,9 +850,7 @@ export namespace InvalidRestoreFault {
  * <p>The requested subnet is invalid, or multiple subnets were requested that are
  *       not all in a common VPC.</p>
  */
-export interface InvalidSubnet
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface InvalidSubnet extends __SmithyException, $MetadataBearer {
   name: "InvalidSubnet";
   $fault: "client";
   /**
@@ -860,7 +861,7 @@ export interface InvalidSubnet
 
 export namespace InvalidSubnet {
   export function isa(o: any): o is InvalidSubnet {
-    return _smithy.isa(o, "InvalidSubnet");
+    return __isa(o, "InvalidSubnet");
   }
 }
 
@@ -869,7 +870,7 @@ export namespace InvalidSubnet {
  *       because users' change.</p>
  */
 export interface InvalidVPCNetworkStateFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidVPCNetworkStateFault";
   $fault: "client";
@@ -881,7 +882,7 @@ export interface InvalidVPCNetworkStateFault
 
 export namespace InvalidVPCNetworkStateFault {
   export function isa(o: any): o is InvalidVPCNetworkStateFault {
-    return _smithy.isa(o, "InvalidVPCNetworkStateFault");
+    return __isa(o, "InvalidVPCNetworkStateFault");
   }
 }
 
@@ -889,7 +890,7 @@ export namespace InvalidVPCNetworkStateFault {
  * <p>Error accessing KMS key.</p>
  */
 export interface KMSKeyNotAccessibleFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "KMSKeyNotAccessibleFault";
   $fault: "client";
@@ -901,7 +902,7 @@ export interface KMSKeyNotAccessibleFault
 
 export namespace KMSKeyNotAccessibleFault {
   export function isa(o: any): o is KMSKeyNotAccessibleFault {
-    return _smithy.isa(o, "KMSKeyNotAccessibleFault");
+    return __isa(o, "KMSKeyNotAccessibleFault");
   }
 }
 
@@ -909,7 +910,7 @@ export namespace KMSKeyNotAccessibleFault {
  * <p>The designated option group could not be found.</p>
  */
 export interface OptionGroupNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "OptionGroupNotFoundFault";
   $fault: "client";
@@ -921,7 +922,7 @@ export interface OptionGroupNotFoundFault
 
 export namespace OptionGroupNotFoundFault {
   export function isa(o: any): o is OptionGroupNotFoundFault {
-    return _smithy.isa(o, "OptionGroupNotFoundFault");
+    return __isa(o, "OptionGroupNotFoundFault");
   }
 }
 
@@ -929,7 +930,7 @@ export namespace OptionGroupNotFoundFault {
  * <p>Provisioned IOPS not available in the specified Availability Zone.</p>
  */
 export interface ProvisionedIopsNotAvailableInAZFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ProvisionedIopsNotAvailableInAZFault";
   $fault: "client";
@@ -941,7 +942,7 @@ export interface ProvisionedIopsNotAvailableInAZFault
 
 export namespace ProvisionedIopsNotAvailableInAZFault {
   export function isa(o: any): o is ProvisionedIopsNotAvailableInAZFault {
-    return _smithy.isa(o, "ProvisionedIopsNotAvailableInAZFault");
+    return __isa(o, "ProvisionedIopsNotAvailableInAZFault");
   }
 }
 
@@ -949,7 +950,7 @@ export namespace ProvisionedIopsNotAvailableInAZFault {
  * <p>The specified resource ID was not found.</p>
  */
 export interface ResourceNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundFault";
   $fault: "client";
@@ -961,7 +962,7 @@ export interface ResourceNotFoundFault
 
 export namespace ResourceNotFoundFault {
   export function isa(o: any): o is ResourceNotFoundFault {
-    return _smithy.isa(o, "ResourceNotFoundFault");
+    return __isa(o, "ResourceNotFoundFault");
   }
 }
 
@@ -969,7 +970,7 @@ export namespace ResourceNotFoundFault {
  * <p>The SNS topic is invalid.</p>
  */
 export interface SNSInvalidTopicFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "SNSInvalidTopicFault";
   $fault: "client";
@@ -981,7 +982,7 @@ export interface SNSInvalidTopicFault
 
 export namespace SNSInvalidTopicFault {
   export function isa(o: any): o is SNSInvalidTopicFault {
-    return _smithy.isa(o, "SNSInvalidTopicFault");
+    return __isa(o, "SNSInvalidTopicFault");
   }
 }
 
@@ -989,7 +990,7 @@ export namespace SNSInvalidTopicFault {
  * <p>There is no SNS authorization.</p>
  */
 export interface SNSNoAuthorizationFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "SNSNoAuthorizationFault";
   $fault: "client";
@@ -1001,7 +1002,7 @@ export interface SNSNoAuthorizationFault
 
 export namespace SNSNoAuthorizationFault {
   export function isa(o: any): o is SNSNoAuthorizationFault {
-    return _smithy.isa(o, "SNSNoAuthorizationFault");
+    return __isa(o, "SNSNoAuthorizationFault");
   }
 }
 
@@ -1009,7 +1010,7 @@ export namespace SNSNoAuthorizationFault {
  * <p>The ARN of the SNS topic could not be found.</p>
  */
 export interface SNSTopicArnNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "SNSTopicArnNotFoundFault";
   $fault: "client";
@@ -1021,7 +1022,7 @@ export interface SNSTopicArnNotFoundFault
 
 export namespace SNSTopicArnNotFoundFault {
   export function isa(o: any): o is SNSTopicArnNotFoundFault {
-    return _smithy.isa(o, "SNSTopicArnNotFoundFault");
+    return __isa(o, "SNSTopicArnNotFoundFault");
   }
 }
 
@@ -1029,7 +1030,7 @@ export namespace SNSTopicArnNotFoundFault {
  * <p>You have exceeded the maximum number of accounts that you can share a manual DB snapshot with.</p>
  */
 export interface SharedSnapshotQuotaExceededFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "SharedSnapshotQuotaExceededFault";
   $fault: "client";
@@ -1041,7 +1042,7 @@ export interface SharedSnapshotQuotaExceededFault
 
 export namespace SharedSnapshotQuotaExceededFault {
   export function isa(o: any): o is SharedSnapshotQuotaExceededFault {
-    return _smithy.isa(o, "SharedSnapshotQuotaExceededFault");
+    return __isa(o, "SharedSnapshotQuotaExceededFault");
   }
 }
 
@@ -1049,7 +1050,7 @@ export namespace SharedSnapshotQuotaExceededFault {
  * <p>Request would result in user exceeding the allowed number of DB snapshots.</p>
  */
 export interface SnapshotQuotaExceededFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "SnapshotQuotaExceededFault";
   $fault: "client";
@@ -1061,7 +1062,7 @@ export interface SnapshotQuotaExceededFault
 
 export namespace SnapshotQuotaExceededFault {
   export function isa(o: any): o is SnapshotQuotaExceededFault {
-    return _smithy.isa(o, "SnapshotQuotaExceededFault");
+    return __isa(o, "SnapshotQuotaExceededFault");
   }
 }
 
@@ -1069,7 +1070,7 @@ export namespace SnapshotQuotaExceededFault {
  * <p>The source could not be found.</p>
  */
 export interface SourceNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "SourceNotFoundFault";
   $fault: "client";
@@ -1081,7 +1082,7 @@ export interface SourceNotFoundFault
 
 export namespace SourceNotFoundFault {
   export function isa(o: any): o is SourceNotFoundFault {
-    return _smithy.isa(o, "SourceNotFoundFault");
+    return __isa(o, "SourceNotFoundFault");
   }
 }
 
@@ -1089,7 +1090,7 @@ export namespace SourceNotFoundFault {
  * <p>Request would result in user exceeding the allowed amount of storage available across all DB instances.</p>
  */
 export interface StorageQuotaExceededFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "StorageQuotaExceededFault";
   $fault: "client";
@@ -1101,7 +1102,7 @@ export interface StorageQuotaExceededFault
 
 export namespace StorageQuotaExceededFault {
   export function isa(o: any): o is StorageQuotaExceededFault {
-    return _smithy.isa(o, "StorageQuotaExceededFault");
+    return __isa(o, "StorageQuotaExceededFault");
   }
 }
 
@@ -1110,7 +1111,7 @@ export namespace StorageQuotaExceededFault {
  *             <i>StorageType</i> specified cannot be associated with the DB Instance.</p>
  */
 export interface StorageTypeNotSupportedFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "StorageTypeNotSupportedFault";
   $fault: "client";
@@ -1122,16 +1123,14 @@ export interface StorageTypeNotSupportedFault
 
 export namespace StorageTypeNotSupportedFault {
   export function isa(o: any): o is StorageTypeNotSupportedFault {
-    return _smithy.isa(o, "StorageTypeNotSupportedFault");
+    return __isa(o, "StorageTypeNotSupportedFault");
   }
 }
 
 /**
  * <p>The DB subnet is already in use in the Availability Zone.</p>
  */
-export interface SubnetAlreadyInUse
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface SubnetAlreadyInUse extends __SmithyException, $MetadataBearer {
   name: "SubnetAlreadyInUse";
   $fault: "client";
   /**
@@ -1142,7 +1141,7 @@ export interface SubnetAlreadyInUse
 
 export namespace SubnetAlreadyInUse {
   export function isa(o: any): o is SubnetAlreadyInUse {
-    return _smithy.isa(o, "SubnetAlreadyInUse");
+    return __isa(o, "SubnetAlreadyInUse");
   }
 }
 
@@ -1150,7 +1149,7 @@ export namespace SubnetAlreadyInUse {
  * <p>This subscription already exists.</p>
  */
 export interface SubscriptionAlreadyExistFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "SubscriptionAlreadyExistFault";
   $fault: "client";
@@ -1162,7 +1161,7 @@ export interface SubscriptionAlreadyExistFault
 
 export namespace SubscriptionAlreadyExistFault {
   export function isa(o: any): o is SubscriptionAlreadyExistFault {
-    return _smithy.isa(o, "SubscriptionAlreadyExistFault");
+    return __isa(o, "SubscriptionAlreadyExistFault");
   }
 }
 
@@ -1170,7 +1169,7 @@ export namespace SubscriptionAlreadyExistFault {
  * <p>The designated subscription category could not be found.</p>
  */
 export interface SubscriptionCategoryNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "SubscriptionCategoryNotFoundFault";
   $fault: "client";
@@ -1182,7 +1181,7 @@ export interface SubscriptionCategoryNotFoundFault
 
 export namespace SubscriptionCategoryNotFoundFault {
   export function isa(o: any): o is SubscriptionCategoryNotFoundFault {
-    return _smithy.isa(o, "SubscriptionCategoryNotFoundFault");
+    return __isa(o, "SubscriptionCategoryNotFoundFault");
   }
 }
 
@@ -1190,7 +1189,7 @@ export namespace SubscriptionCategoryNotFoundFault {
  * <p>The designated subscription could not be found.</p>
  */
 export interface SubscriptionNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "SubscriptionNotFoundFault";
   $fault: "client";
@@ -1202,7 +1201,7 @@ export interface SubscriptionNotFoundFault
 
 export namespace SubscriptionNotFoundFault {
   export function isa(o: any): o is SubscriptionNotFoundFault {
-    return _smithy.isa(o, "SubscriptionNotFoundFault");
+    return __isa(o, "SubscriptionNotFoundFault");
   }
 }
 
@@ -1222,7 +1221,7 @@ export interface AddRoleToDBClusterMessage {
 
 export namespace AddRoleToDBClusterMessage {
   export function isa(o: any): o is AddRoleToDBClusterMessage {
-    return _smithy.isa(o, "AddRoleToDBClusterMessage");
+    return __isa(o, "AddRoleToDBClusterMessage");
   }
 }
 
@@ -1261,7 +1260,7 @@ export interface AddSourceIdentifierToSubscriptionMessage {
 
 export namespace AddSourceIdentifierToSubscriptionMessage {
   export function isa(o: any): o is AddSourceIdentifierToSubscriptionMessage {
-    return _smithy.isa(o, "AddSourceIdentifierToSubscriptionMessage");
+    return __isa(o, "AddSourceIdentifierToSubscriptionMessage");
   }
 }
 
@@ -1276,7 +1275,7 @@ export interface AddSourceIdentifierToSubscriptionResult
 
 export namespace AddSourceIdentifierToSubscriptionResult {
   export function isa(o: any): o is AddSourceIdentifierToSubscriptionResult {
-    return _smithy.isa(o, "AddSourceIdentifierToSubscriptionResult");
+    return __isa(o, "AddSourceIdentifierToSubscriptionResult");
   }
 }
 
@@ -1297,7 +1296,7 @@ export interface AddTagsToResourceMessage {
 
 export namespace AddTagsToResourceMessage {
   export function isa(o: any): o is AddTagsToResourceMessage {
-    return _smithy.isa(o, "AddTagsToResourceMessage");
+    return __isa(o, "AddTagsToResourceMessage");
   }
 }
 
@@ -1345,7 +1344,7 @@ export interface ApplyPendingMaintenanceActionMessage {
 
 export namespace ApplyPendingMaintenanceActionMessage {
   export function isa(o: any): o is ApplyPendingMaintenanceActionMessage {
-    return _smithy.isa(o, "ApplyPendingMaintenanceActionMessage");
+    return __isa(o, "ApplyPendingMaintenanceActionMessage");
   }
 }
 
@@ -1359,7 +1358,7 @@ export interface ApplyPendingMaintenanceActionResult extends $MetadataBearer {
 
 export namespace ApplyPendingMaintenanceActionResult {
   export function isa(o: any): o is ApplyPendingMaintenanceActionResult {
-    return _smithy.isa(o, "ApplyPendingMaintenanceActionResult");
+    return __isa(o, "ApplyPendingMaintenanceActionResult");
   }
 }
 
@@ -1376,7 +1375,7 @@ export interface AvailabilityZone {
 
 export namespace AvailabilityZone {
   export function isa(o: any): o is AvailabilityZone {
-    return _smithy.isa(o, "AvailabilityZone");
+    return __isa(o, "AvailabilityZone");
   }
 }
 
@@ -1398,7 +1397,7 @@ export interface CharacterSet {
 
 export namespace CharacterSet {
   export function isa(o: any): o is CharacterSet {
-    return _smithy.isa(o, "CharacterSet");
+    return __isa(o, "CharacterSet");
   }
 }
 
@@ -1424,7 +1423,7 @@ export interface CloudwatchLogsExportConfiguration {
 
 export namespace CloudwatchLogsExportConfiguration {
   export function isa(o: any): o is CloudwatchLogsExportConfiguration {
-    return _smithy.isa(o, "CloudwatchLogsExportConfiguration");
+    return __isa(o, "CloudwatchLogsExportConfiguration");
   }
 }
 
@@ -1488,7 +1487,7 @@ export interface CopyDBClusterParameterGroupMessage {
 
 export namespace CopyDBClusterParameterGroupMessage {
   export function isa(o: any): o is CopyDBClusterParameterGroupMessage {
-    return _smithy.isa(o, "CopyDBClusterParameterGroupMessage");
+    return __isa(o, "CopyDBClusterParameterGroupMessage");
   }
 }
 
@@ -1503,7 +1502,7 @@ export interface CopyDBClusterParameterGroupResult extends $MetadataBearer {
 
 export namespace CopyDBClusterParameterGroupResult {
   export function isa(o: any): o is CopyDBClusterParameterGroupResult {
-    return _smithy.isa(o, "CopyDBClusterParameterGroupResult");
+    return __isa(o, "CopyDBClusterParameterGroupResult");
   }
 }
 
@@ -1586,7 +1585,7 @@ export interface CopyDBClusterSnapshotMessage {
 
 export namespace CopyDBClusterSnapshotMessage {
   export function isa(o: any): o is CopyDBClusterSnapshotMessage {
-    return _smithy.isa(o, "CopyDBClusterSnapshotMessage");
+    return __isa(o, "CopyDBClusterSnapshotMessage");
   }
 }
 
@@ -1601,7 +1600,7 @@ export interface CopyDBClusterSnapshotResult extends $MetadataBearer {
 
 export namespace CopyDBClusterSnapshotResult {
   export function isa(o: any): o is CopyDBClusterSnapshotResult {
-    return _smithy.isa(o, "CopyDBClusterSnapshotResult");
+    return __isa(o, "CopyDBClusterSnapshotResult");
   }
 }
 
@@ -1662,7 +1661,7 @@ export interface CopyDBParameterGroupMessage {
 
 export namespace CopyDBParameterGroupMessage {
   export function isa(o: any): o is CopyDBParameterGroupMessage {
-    return _smithy.isa(o, "CopyDBParameterGroupMessage");
+    return __isa(o, "CopyDBParameterGroupMessage");
   }
 }
 
@@ -1677,7 +1676,7 @@ export interface CopyDBParameterGroupResult extends $MetadataBearer {
 
 export namespace CopyDBParameterGroupResult {
   export function isa(o: any): o is CopyDBParameterGroupResult {
-    return _smithy.isa(o, "CopyDBParameterGroupResult");
+    return __isa(o, "CopyDBParameterGroupResult");
   }
 }
 
@@ -1924,7 +1923,7 @@ export interface CreateDBClusterMessage {
 
 export namespace CreateDBClusterMessage {
   export function isa(o: any): o is CreateDBClusterMessage {
-    return _smithy.isa(o, "CreateDBClusterMessage");
+    return __isa(o, "CreateDBClusterMessage");
   }
 }
 
@@ -1965,7 +1964,7 @@ export interface CreateDBClusterParameterGroupMessage {
 
 export namespace CreateDBClusterParameterGroupMessage {
   export function isa(o: any): o is CreateDBClusterParameterGroupMessage {
-    return _smithy.isa(o, "CreateDBClusterParameterGroupMessage");
+    return __isa(o, "CreateDBClusterParameterGroupMessage");
   }
 }
 
@@ -1980,7 +1979,7 @@ export interface CreateDBClusterParameterGroupResult extends $MetadataBearer {
 
 export namespace CreateDBClusterParameterGroupResult {
   export function isa(o: any): o is CreateDBClusterParameterGroupResult {
-    return _smithy.isa(o, "CreateDBClusterParameterGroupResult");
+    return __isa(o, "CreateDBClusterParameterGroupResult");
   }
 }
 
@@ -1995,7 +1994,7 @@ export interface CreateDBClusterResult extends $MetadataBearer {
 
 export namespace CreateDBClusterResult {
   export function isa(o: any): o is CreateDBClusterResult {
-    return _smithy.isa(o, "CreateDBClusterResult");
+    return __isa(o, "CreateDBClusterResult");
   }
 }
 
@@ -2043,7 +2042,7 @@ export interface CreateDBClusterSnapshotMessage {
 
 export namespace CreateDBClusterSnapshotMessage {
   export function isa(o: any): o is CreateDBClusterSnapshotMessage {
-    return _smithy.isa(o, "CreateDBClusterSnapshotMessage");
+    return __isa(o, "CreateDBClusterSnapshotMessage");
   }
 }
 
@@ -2058,7 +2057,7 @@ export interface CreateDBClusterSnapshotResult extends $MetadataBearer {
 
 export namespace CreateDBClusterSnapshotResult {
   export function isa(o: any): o is CreateDBClusterSnapshotResult {
-    return _smithy.isa(o, "CreateDBClusterSnapshotResult");
+    return __isa(o, "CreateDBClusterSnapshotResult");
   }
 }
 
@@ -2414,7 +2413,7 @@ export interface CreateDBInstanceMessage {
 
 export namespace CreateDBInstanceMessage {
   export function isa(o: any): o is CreateDBInstanceMessage {
-    return _smithy.isa(o, "CreateDBInstanceMessage");
+    return __isa(o, "CreateDBInstanceMessage");
   }
 }
 
@@ -2429,7 +2428,7 @@ export interface CreateDBInstanceResult extends $MetadataBearer {
 
 export namespace CreateDBInstanceResult {
   export function isa(o: any): o is CreateDBInstanceResult {
-    return _smithy.isa(o, "CreateDBInstanceResult");
+    return __isa(o, "CreateDBInstanceResult");
   }
 }
 
@@ -2475,7 +2474,7 @@ export interface CreateDBParameterGroupMessage {
 
 export namespace CreateDBParameterGroupMessage {
   export function isa(o: any): o is CreateDBParameterGroupMessage {
-    return _smithy.isa(o, "CreateDBParameterGroupMessage");
+    return __isa(o, "CreateDBParameterGroupMessage");
   }
 }
 
@@ -2490,7 +2489,7 @@ export interface CreateDBParameterGroupResult extends $MetadataBearer {
 
 export namespace CreateDBParameterGroupResult {
   export function isa(o: any): o is CreateDBParameterGroupResult {
-    return _smithy.isa(o, "CreateDBParameterGroupResult");
+    return __isa(o, "CreateDBParameterGroupResult");
   }
 }
 
@@ -2523,7 +2522,7 @@ export interface CreateDBSubnetGroupMessage {
 
 export namespace CreateDBSubnetGroupMessage {
   export function isa(o: any): o is CreateDBSubnetGroupMessage {
-    return _smithy.isa(o, "CreateDBSubnetGroupMessage");
+    return __isa(o, "CreateDBSubnetGroupMessage");
   }
 }
 
@@ -2538,7 +2537,7 @@ export interface CreateDBSubnetGroupResult extends $MetadataBearer {
 
 export namespace CreateDBSubnetGroupResult {
   export function isa(o: any): o is CreateDBSubnetGroupResult {
-    return _smithy.isa(o, "CreateDBSubnetGroupResult");
+    return __isa(o, "CreateDBSubnetGroupResult");
   }
 }
 
@@ -2619,7 +2618,7 @@ export interface CreateEventSubscriptionMessage {
 
 export namespace CreateEventSubscriptionMessage {
   export function isa(o: any): o is CreateEventSubscriptionMessage {
-    return _smithy.isa(o, "CreateEventSubscriptionMessage");
+    return __isa(o, "CreateEventSubscriptionMessage");
   }
 }
 
@@ -2633,7 +2632,7 @@ export interface CreateEventSubscriptionResult extends $MetadataBearer {
 
 export namespace CreateEventSubscriptionResult {
   export function isa(o: any): o is CreateEventSubscriptionResult {
-    return _smithy.isa(o, "CreateEventSubscriptionResult");
+    return __isa(o, "CreateEventSubscriptionResult");
   }
 }
 
@@ -2862,7 +2861,7 @@ export interface DBCluster {
 
 export namespace DBCluster {
   export function isa(o: any): o is DBCluster {
-    return _smithy.isa(o, "DBCluster");
+    return __isa(o, "DBCluster");
   }
 }
 
@@ -2897,7 +2896,7 @@ export interface DBClusterMember {
 
 export namespace DBClusterMember {
   export function isa(o: any): o is DBClusterMember {
-    return _smithy.isa(o, "DBClusterMember");
+    return __isa(o, "DBClusterMember");
   }
 }
 
@@ -2916,7 +2915,7 @@ export interface DBClusterMessage extends $MetadataBearer {
 
 export namespace DBClusterMessage {
   export function isa(o: any): o is DBClusterMessage {
-    return _smithy.isa(o, "DBClusterMessage");
+    return __isa(o, "DBClusterMessage");
   }
 }
 
@@ -2938,7 +2937,7 @@ export interface DBClusterOptionGroupStatus {
 
 export namespace DBClusterOptionGroupStatus {
   export function isa(o: any): o is DBClusterOptionGroupStatus {
-    return _smithy.isa(o, "DBClusterOptionGroupStatus");
+    return __isa(o, "DBClusterOptionGroupStatus");
   }
 }
 
@@ -2972,7 +2971,7 @@ export interface DBClusterParameterGroup {
 
 export namespace DBClusterParameterGroup {
   export function isa(o: any): o is DBClusterParameterGroup {
-    return _smithy.isa(o, "DBClusterParameterGroup");
+    return __isa(o, "DBClusterParameterGroup");
   }
 }
 
@@ -2993,7 +2992,7 @@ export interface DBClusterParameterGroupDetails extends $MetadataBearer {
 
 export namespace DBClusterParameterGroupDetails {
   export function isa(o: any): o is DBClusterParameterGroupDetails {
-    return _smithy.isa(o, "DBClusterParameterGroupDetails");
+    return __isa(o, "DBClusterParameterGroupDetails");
   }
 }
 
@@ -3022,7 +3021,7 @@ export interface DBClusterParameterGroupNameMessage extends $MetadataBearer {
 
 export namespace DBClusterParameterGroupNameMessage {
   export function isa(o: any): o is DBClusterParameterGroupNameMessage {
-    return _smithy.isa(o, "DBClusterParameterGroupNameMessage");
+    return __isa(o, "DBClusterParameterGroupNameMessage");
   }
 }
 
@@ -3044,7 +3043,7 @@ export interface DBClusterParameterGroupsMessage extends $MetadataBearer {
 
 export namespace DBClusterParameterGroupsMessage {
   export function isa(o: any): o is DBClusterParameterGroupsMessage {
-    return _smithy.isa(o, "DBClusterParameterGroupsMessage");
+    return __isa(o, "DBClusterParameterGroupsMessage");
   }
 }
 
@@ -3087,7 +3086,7 @@ export interface DBClusterRole {
 
 export namespace DBClusterRole {
   export function isa(o: any): o is DBClusterRole {
-    return _smithy.isa(o, "DBClusterRole");
+    return __isa(o, "DBClusterRole");
   }
 }
 
@@ -3207,7 +3206,7 @@ export interface DBClusterSnapshot {
 
 export namespace DBClusterSnapshot {
   export function isa(o: any): o is DBClusterSnapshot {
-    return _smithy.isa(o, "DBClusterSnapshot");
+    return __isa(o, "DBClusterSnapshot");
   }
 }
 
@@ -3238,7 +3237,7 @@ export interface DBClusterSnapshotAttribute {
 
 export namespace DBClusterSnapshotAttribute {
   export function isa(o: any): o is DBClusterSnapshotAttribute {
-    return _smithy.isa(o, "DBClusterSnapshotAttribute");
+    return __isa(o, "DBClusterSnapshotAttribute");
   }
 }
 
@@ -3262,7 +3261,7 @@ export interface DBClusterSnapshotAttributesResult {
 
 export namespace DBClusterSnapshotAttributesResult {
   export function isa(o: any): o is DBClusterSnapshotAttributesResult {
-    return _smithy.isa(o, "DBClusterSnapshotAttributesResult");
+    return __isa(o, "DBClusterSnapshotAttributesResult");
   }
 }
 
@@ -3283,7 +3282,7 @@ export interface DBClusterSnapshotMessage extends $MetadataBearer {
 
 export namespace DBClusterSnapshotMessage {
   export function isa(o: any): o is DBClusterSnapshotMessage {
-    return _smithy.isa(o, "DBClusterSnapshotMessage");
+    return __isa(o, "DBClusterSnapshotMessage");
   }
 }
 
@@ -3362,7 +3361,7 @@ export interface DBEngineVersion {
 
 export namespace DBEngineVersion {
   export function isa(o: any): o is DBEngineVersion {
-    return _smithy.isa(o, "DBEngineVersion");
+    return __isa(o, "DBEngineVersion");
   }
 }
 
@@ -3383,7 +3382,7 @@ export interface DBEngineVersionMessage extends $MetadataBearer {
 
 export namespace DBEngineVersionMessage {
   export function isa(o: any): o is DBEngineVersionMessage {
-    return _smithy.isa(o, "DBEngineVersionMessage");
+    return __isa(o, "DBEngineVersionMessage");
   }
 }
 
@@ -3695,7 +3694,7 @@ export interface DBInstance {
 
 export namespace DBInstance {
   export function isa(o: any): o is DBInstance {
-    return _smithy.isa(o, "DBInstance");
+    return __isa(o, "DBInstance");
   }
 }
 
@@ -3716,7 +3715,7 @@ export interface DBInstanceMessage extends $MetadataBearer {
 
 export namespace DBInstanceMessage {
   export function isa(o: any): o is DBInstanceMessage {
-    return _smithy.isa(o, "DBInstanceMessage");
+    return __isa(o, "DBInstanceMessage");
   }
 }
 
@@ -3751,7 +3750,7 @@ export interface DBInstanceStatusInfo {
 
 export namespace DBInstanceStatusInfo {
   export function isa(o: any): o is DBInstanceStatusInfo {
-    return _smithy.isa(o, "DBInstanceStatusInfo");
+    return __isa(o, "DBInstanceStatusInfo");
   }
 }
 
@@ -3785,7 +3784,7 @@ export interface DBParameterGroup {
 
 export namespace DBParameterGroup {
   export function isa(o: any): o is DBParameterGroup {
-    return _smithy.isa(o, "DBParameterGroup");
+    return __isa(o, "DBParameterGroup");
   }
 }
 
@@ -3806,7 +3805,7 @@ export interface DBParameterGroupDetails extends $MetadataBearer {
 
 export namespace DBParameterGroupDetails {
   export function isa(o: any): o is DBParameterGroupDetails {
-    return _smithy.isa(o, "DBParameterGroupDetails");
+    return __isa(o, "DBParameterGroupDetails");
   }
 }
 
@@ -3820,7 +3819,7 @@ export interface DBParameterGroupNameMessage extends $MetadataBearer {
 
 export namespace DBParameterGroupNameMessage {
   export function isa(o: any): o is DBParameterGroupNameMessage {
-    return _smithy.isa(o, "DBParameterGroupNameMessage");
+    return __isa(o, "DBParameterGroupNameMessage");
   }
 }
 
@@ -3865,7 +3864,7 @@ export interface DBParameterGroupStatus {
 
 export namespace DBParameterGroupStatus {
   export function isa(o: any): o is DBParameterGroupStatus {
-    return _smithy.isa(o, "DBParameterGroupStatus");
+    return __isa(o, "DBParameterGroupStatus");
   }
 }
 
@@ -3886,7 +3885,7 @@ export interface DBParameterGroupsMessage extends $MetadataBearer {
 
 export namespace DBParameterGroupsMessage {
   export function isa(o: any): o is DBParameterGroupsMessage {
-    return _smithy.isa(o, "DBParameterGroupsMessage");
+    return __isa(o, "DBParameterGroupsMessage");
   }
 }
 
@@ -3908,7 +3907,7 @@ export interface DBSecurityGroupMembership {
 
 export namespace DBSecurityGroupMembership {
   export function isa(o: any): o is DBSecurityGroupMembership {
-    return _smithy.isa(o, "DBSecurityGroupMembership");
+    return __isa(o, "DBSecurityGroupMembership");
   }
 }
 
@@ -3951,7 +3950,7 @@ export interface DBSubnetGroup {
 
 export namespace DBSubnetGroup {
   export function isa(o: any): o is DBSubnetGroup {
-    return _smithy.isa(o, "DBSubnetGroup");
+    return __isa(o, "DBSubnetGroup");
   }
 }
 
@@ -3972,7 +3971,7 @@ export interface DBSubnetGroupMessage extends $MetadataBearer {
 
 export namespace DBSubnetGroupMessage {
   export function isa(o: any): o is DBSubnetGroupMessage {
-    return _smithy.isa(o, "DBSubnetGroupMessage");
+    return __isa(o, "DBSubnetGroupMessage");
   }
 }
 
@@ -4029,7 +4028,7 @@ export interface DeleteDBClusterMessage {
 
 export namespace DeleteDBClusterMessage {
   export function isa(o: any): o is DeleteDBClusterMessage {
-    return _smithy.isa(o, "DeleteDBClusterMessage");
+    return __isa(o, "DeleteDBClusterMessage");
   }
 }
 
@@ -4055,7 +4054,7 @@ export interface DeleteDBClusterParameterGroupMessage {
 
 export namespace DeleteDBClusterParameterGroupMessage {
   export function isa(o: any): o is DeleteDBClusterParameterGroupMessage {
-    return _smithy.isa(o, "DeleteDBClusterParameterGroupMessage");
+    return __isa(o, "DeleteDBClusterParameterGroupMessage");
   }
 }
 
@@ -4070,7 +4069,7 @@ export interface DeleteDBClusterResult extends $MetadataBearer {
 
 export namespace DeleteDBClusterResult {
   export function isa(o: any): o is DeleteDBClusterResult {
-    return _smithy.isa(o, "DeleteDBClusterResult");
+    return __isa(o, "DeleteDBClusterResult");
   }
 }
 
@@ -4086,7 +4085,7 @@ export interface DeleteDBClusterSnapshotMessage {
 
 export namespace DeleteDBClusterSnapshotMessage {
   export function isa(o: any): o is DeleteDBClusterSnapshotMessage {
-    return _smithy.isa(o, "DeleteDBClusterSnapshotMessage");
+    return __isa(o, "DeleteDBClusterSnapshotMessage");
   }
 }
 
@@ -4101,7 +4100,7 @@ export interface DeleteDBClusterSnapshotResult extends $MetadataBearer {
 
 export namespace DeleteDBClusterSnapshotResult {
   export function isa(o: any): o is DeleteDBClusterSnapshotResult {
-    return _smithy.isa(o, "DeleteDBClusterSnapshotResult");
+    return __isa(o, "DeleteDBClusterSnapshotResult");
   }
 }
 
@@ -4164,7 +4163,7 @@ export interface DeleteDBInstanceMessage {
 
 export namespace DeleteDBInstanceMessage {
   export function isa(o: any): o is DeleteDBInstanceMessage {
-    return _smithy.isa(o, "DeleteDBInstanceMessage");
+    return __isa(o, "DeleteDBInstanceMessage");
   }
 }
 
@@ -4179,7 +4178,7 @@ export interface DeleteDBInstanceResult extends $MetadataBearer {
 
 export namespace DeleteDBInstanceResult {
   export function isa(o: any): o is DeleteDBInstanceResult {
-    return _smithy.isa(o, "DeleteDBInstanceResult");
+    return __isa(o, "DeleteDBInstanceResult");
   }
 }
 
@@ -4205,7 +4204,7 @@ export interface DeleteDBParameterGroupMessage {
 
 export namespace DeleteDBParameterGroupMessage {
   export function isa(o: any): o is DeleteDBParameterGroupMessage {
-    return _smithy.isa(o, "DeleteDBParameterGroupMessage");
+    return __isa(o, "DeleteDBParameterGroupMessage");
   }
 }
 
@@ -4226,7 +4225,7 @@ export interface DeleteDBSubnetGroupMessage {
 
 export namespace DeleteDBSubnetGroupMessage {
   export function isa(o: any): o is DeleteDBSubnetGroupMessage {
-    return _smithy.isa(o, "DeleteDBSubnetGroupMessage");
+    return __isa(o, "DeleteDBSubnetGroupMessage");
   }
 }
 
@@ -4240,7 +4239,7 @@ export interface DeleteEventSubscriptionMessage {
 
 export namespace DeleteEventSubscriptionMessage {
   export function isa(o: any): o is DeleteEventSubscriptionMessage {
-    return _smithy.isa(o, "DeleteEventSubscriptionMessage");
+    return __isa(o, "DeleteEventSubscriptionMessage");
   }
 }
 
@@ -4254,7 +4253,7 @@ export interface DeleteEventSubscriptionResult extends $MetadataBearer {
 
 export namespace DeleteEventSubscriptionResult {
   export function isa(o: any): o is DeleteEventSubscriptionResult {
-    return _smithy.isa(o, "DeleteEventSubscriptionResult");
+    return __isa(o, "DeleteEventSubscriptionResult");
   }
 }
 
@@ -4296,7 +4295,7 @@ export interface DescribeDBClusterParameterGroupsMessage {
 
 export namespace DescribeDBClusterParameterGroupsMessage {
   export function isa(o: any): o is DescribeDBClusterParameterGroupsMessage {
-    return _smithy.isa(o, "DescribeDBClusterParameterGroupsMessage");
+    return __isa(o, "DescribeDBClusterParameterGroupsMessage");
   }
 }
 
@@ -4344,7 +4343,7 @@ export interface DescribeDBClusterParametersMessage {
 
 export namespace DescribeDBClusterParametersMessage {
   export function isa(o: any): o is DescribeDBClusterParametersMessage {
-    return _smithy.isa(o, "DescribeDBClusterParametersMessage");
+    return __isa(o, "DescribeDBClusterParametersMessage");
   }
 }
 
@@ -4358,7 +4357,7 @@ export interface DescribeDBClusterSnapshotAttributesMessage {
 
 export namespace DescribeDBClusterSnapshotAttributesMessage {
   export function isa(o: any): o is DescribeDBClusterSnapshotAttributesMessage {
-    return _smithy.isa(o, "DescribeDBClusterSnapshotAttributesMessage");
+    return __isa(o, "DescribeDBClusterSnapshotAttributesMessage");
   }
 }
 
@@ -4375,7 +4374,7 @@ export interface DescribeDBClusterSnapshotAttributesResult
 
 export namespace DescribeDBClusterSnapshotAttributesResult {
   export function isa(o: any): o is DescribeDBClusterSnapshotAttributesResult {
-    return _smithy.isa(o, "DescribeDBClusterSnapshotAttributesResult");
+    return __isa(o, "DescribeDBClusterSnapshotAttributesResult");
   }
 }
 
@@ -4492,7 +4491,7 @@ export interface DescribeDBClusterSnapshotsMessage {
 
 export namespace DescribeDBClusterSnapshotsMessage {
   export function isa(o: any): o is DescribeDBClusterSnapshotsMessage {
-    return _smithy.isa(o, "DescribeDBClusterSnapshotsMessage");
+    return __isa(o, "DescribeDBClusterSnapshotsMessage");
   }
 }
 
@@ -4543,7 +4542,7 @@ export interface DescribeDBClustersMessage {
 
 export namespace DescribeDBClustersMessage {
   export function isa(o: any): o is DescribeDBClustersMessage {
-    return _smithy.isa(o, "DescribeDBClustersMessage");
+    return __isa(o, "DescribeDBClustersMessage");
   }
 }
 
@@ -4616,7 +4615,7 @@ export interface DescribeDBEngineVersionsMessage {
 
 export namespace DescribeDBEngineVersionsMessage {
   export function isa(o: any): o is DescribeDBEngineVersionsMessage {
-    return _smithy.isa(o, "DescribeDBEngineVersionsMessage");
+    return __isa(o, "DescribeDBEngineVersionsMessage");
   }
 }
 
@@ -4673,7 +4672,7 @@ export interface DescribeDBInstancesMessage {
 
 export namespace DescribeDBInstancesMessage {
   export function isa(o: any): o is DescribeDBInstancesMessage {
-    return _smithy.isa(o, "DescribeDBInstancesMessage");
+    return __isa(o, "DescribeDBInstancesMessage");
   }
 }
 
@@ -4714,7 +4713,7 @@ export interface DescribeDBParameterGroupsMessage {
 
 export namespace DescribeDBParameterGroupsMessage {
   export function isa(o: any): o is DescribeDBParameterGroupsMessage {
-    return _smithy.isa(o, "DescribeDBParameterGroupsMessage");
+    return __isa(o, "DescribeDBParameterGroupsMessage");
   }
 }
 
@@ -4763,7 +4762,7 @@ export interface DescribeDBParametersMessage {
 
 export namespace DescribeDBParametersMessage {
   export function isa(o: any): o is DescribeDBParametersMessage {
-    return _smithy.isa(o, "DescribeDBParametersMessage");
+    return __isa(o, "DescribeDBParametersMessage");
   }
 }
 
@@ -4798,7 +4797,7 @@ export interface DescribeDBSubnetGroupsMessage {
 
 export namespace DescribeDBSubnetGroupsMessage {
   export function isa(o: any): o is DescribeDBSubnetGroupsMessage {
-    return _smithy.isa(o, "DescribeDBSubnetGroupsMessage");
+    return __isa(o, "DescribeDBSubnetGroupsMessage");
   }
 }
 
@@ -4837,7 +4836,7 @@ export namespace DescribeEngineDefaultClusterParametersMessage {
   export function isa(
     o: any
   ): o is DescribeEngineDefaultClusterParametersMessage {
-    return _smithy.isa(o, "DescribeEngineDefaultClusterParametersMessage");
+    return __isa(o, "DescribeEngineDefaultClusterParametersMessage");
   }
 }
 
@@ -4854,7 +4853,7 @@ export namespace DescribeEngineDefaultClusterParametersResult {
   export function isa(
     o: any
   ): o is DescribeEngineDefaultClusterParametersResult {
-    return _smithy.isa(o, "DescribeEngineDefaultClusterParametersResult");
+    return __isa(o, "DescribeEngineDefaultClusterParametersResult");
   }
 }
 
@@ -4890,7 +4889,7 @@ export interface DescribeEngineDefaultParametersMessage {
 
 export namespace DescribeEngineDefaultParametersMessage {
   export function isa(o: any): o is DescribeEngineDefaultParametersMessage {
-    return _smithy.isa(o, "DescribeEngineDefaultParametersMessage");
+    return __isa(o, "DescribeEngineDefaultParametersMessage");
   }
 }
 
@@ -4904,7 +4903,7 @@ export interface DescribeEngineDefaultParametersResult extends $MetadataBearer {
 
 export namespace DescribeEngineDefaultParametersResult {
   export function isa(o: any): o is DescribeEngineDefaultParametersResult {
-    return _smithy.isa(o, "DescribeEngineDefaultParametersResult");
+    return __isa(o, "DescribeEngineDefaultParametersResult");
   }
 }
 
@@ -4924,7 +4923,7 @@ export interface DescribeEventCategoriesMessage {
 
 export namespace DescribeEventCategoriesMessage {
   export function isa(o: any): o is DescribeEventCategoriesMessage {
-    return _smithy.isa(o, "DescribeEventCategoriesMessage");
+    return __isa(o, "DescribeEventCategoriesMessage");
   }
 }
 
@@ -4959,7 +4958,7 @@ export interface DescribeEventSubscriptionsMessage {
 
 export namespace DescribeEventSubscriptionsMessage {
   export function isa(o: any): o is DescribeEventSubscriptionsMessage {
-    return _smithy.isa(o, "DescribeEventSubscriptionsMessage");
+    return __isa(o, "DescribeEventSubscriptionsMessage");
   }
 }
 
@@ -5054,7 +5053,7 @@ export interface DescribeEventsMessage {
 
 export namespace DescribeEventsMessage {
   export function isa(o: any): o is DescribeEventsMessage {
-    return _smithy.isa(o, "DescribeEventsMessage");
+    return __isa(o, "DescribeEventsMessage");
   }
 }
 
@@ -5113,7 +5112,7 @@ export interface DescribeOrderableDBInstanceOptionsMessage {
 
 export namespace DescribeOrderableDBInstanceOptionsMessage {
   export function isa(o: any): o is DescribeOrderableDBInstanceOptionsMessage {
-    return _smithy.isa(o, "DescribeOrderableDBInstanceOptionsMessage");
+    return __isa(o, "DescribeOrderableDBInstanceOptionsMessage");
   }
 }
 
@@ -5165,7 +5164,7 @@ export interface DescribePendingMaintenanceActionsMessage {
 
 export namespace DescribePendingMaintenanceActionsMessage {
   export function isa(o: any): o is DescribePendingMaintenanceActionsMessage {
-    return _smithy.isa(o, "DescribePendingMaintenanceActionsMessage");
+    return __isa(o, "DescribePendingMaintenanceActionsMessage");
   }
 }
 
@@ -5181,7 +5180,7 @@ export namespace DescribeValidDBInstanceModificationsMessage {
   export function isa(
     o: any
   ): o is DescribeValidDBInstanceModificationsMessage {
-    return _smithy.isa(o, "DescribeValidDBInstanceModificationsMessage");
+    return __isa(o, "DescribeValidDBInstanceModificationsMessage");
   }
 }
 
@@ -5199,7 +5198,7 @@ export interface DescribeValidDBInstanceModificationsResult
 
 export namespace DescribeValidDBInstanceModificationsResult {
   export function isa(o: any): o is DescribeValidDBInstanceModificationsResult {
-    return _smithy.isa(o, "DescribeValidDBInstanceModificationsResult");
+    return __isa(o, "DescribeValidDBInstanceModificationsResult");
   }
 }
 
@@ -5232,7 +5231,7 @@ export interface DomainMembership {
 
 export namespace DomainMembership {
   export function isa(o: any): o is DomainMembership {
-    return _smithy.isa(o, "DomainMembership");
+    return __isa(o, "DomainMembership");
   }
 }
 
@@ -5254,7 +5253,7 @@ export interface DoubleRange {
 
 export namespace DoubleRange {
   export function isa(o: any): o is DoubleRange {
-    return _smithy.isa(o, "DoubleRange");
+    return __isa(o, "DoubleRange");
   }
 }
 
@@ -5281,7 +5280,7 @@ export interface Endpoint {
 
 export namespace Endpoint {
   export function isa(o: any): o is Endpoint {
-    return _smithy.isa(o, "Endpoint");
+    return __isa(o, "Endpoint");
   }
 }
 
@@ -5311,7 +5310,7 @@ export interface EngineDefaults {
 
 export namespace EngineDefaults {
   export function isa(o: any): o is EngineDefaults {
-    return _smithy.isa(o, "EngineDefaults");
+    return __isa(o, "EngineDefaults");
   }
 }
 
@@ -5354,7 +5353,7 @@ export interface Event {
 
 export namespace Event {
   export function isa(o: any): o is Event {
-    return _smithy.isa(o, "Event");
+    return __isa(o, "Event");
   }
 }
 
@@ -5376,7 +5375,7 @@ export interface EventCategoriesMap {
 
 export namespace EventCategoriesMap {
   export function isa(o: any): o is EventCategoriesMap {
-    return _smithy.isa(o, "EventCategoriesMap");
+    return __isa(o, "EventCategoriesMap");
   }
 }
 
@@ -5390,7 +5389,7 @@ export interface EventCategoriesMessage extends $MetadataBearer {
 
 export namespace EventCategoriesMessage {
   export function isa(o: any): o is EventCategoriesMessage {
-    return _smithy.isa(o, "EventCategoriesMessage");
+    return __isa(o, "EventCategoriesMessage");
   }
 }
 
@@ -5459,7 +5458,7 @@ export interface EventSubscription {
 
 export namespace EventSubscription {
   export function isa(o: any): o is EventSubscription {
-    return _smithy.isa(o, "EventSubscription");
+    return __isa(o, "EventSubscription");
   }
 }
 
@@ -5480,7 +5479,7 @@ export interface EventSubscriptionsMessage extends $MetadataBearer {
 
 export namespace EventSubscriptionsMessage {
   export function isa(o: any): o is EventSubscriptionsMessage {
-    return _smithy.isa(o, "EventSubscriptionsMessage");
+    return __isa(o, "EventSubscriptionsMessage");
   }
 }
 
@@ -5501,7 +5500,7 @@ export interface EventsMessage extends $MetadataBearer {
 
 export namespace EventsMessage {
   export function isa(o: any): o is EventsMessage {
-    return _smithy.isa(o, "EventsMessage");
+    return __isa(o, "EventsMessage");
   }
 }
 
@@ -5529,7 +5528,7 @@ export interface FailoverDBClusterMessage {
 
 export namespace FailoverDBClusterMessage {
   export function isa(o: any): o is FailoverDBClusterMessage {
-    return _smithy.isa(o, "FailoverDBClusterMessage");
+    return __isa(o, "FailoverDBClusterMessage");
   }
 }
 
@@ -5544,7 +5543,7 @@ export interface FailoverDBClusterResult extends $MetadataBearer {
 
 export namespace FailoverDBClusterResult {
   export function isa(o: any): o is FailoverDBClusterResult {
-    return _smithy.isa(o, "FailoverDBClusterResult");
+    return __isa(o, "FailoverDBClusterResult");
   }
 }
 
@@ -5566,7 +5565,7 @@ export interface Filter {
 
 export namespace Filter {
   export function isa(o: any): o is Filter {
-    return _smithy.isa(o, "Filter");
+    return __isa(o, "Filter");
   }
 }
 
@@ -5587,7 +5586,7 @@ export interface ListTagsForResourceMessage {
 
 export namespace ListTagsForResourceMessage {
   export function isa(o: any): o is ListTagsForResourceMessage {
-    return _smithy.isa(o, "ListTagsForResourceMessage");
+    return __isa(o, "ListTagsForResourceMessage");
   }
 }
 
@@ -5758,7 +5757,7 @@ export interface ModifyDBClusterMessage {
 
 export namespace ModifyDBClusterMessage {
   export function isa(o: any): o is ModifyDBClusterMessage {
-    return _smithy.isa(o, "ModifyDBClusterMessage");
+    return __isa(o, "ModifyDBClusterMessage");
   }
 }
 
@@ -5777,7 +5776,7 @@ export interface ModifyDBClusterParameterGroupMessage {
 
 export namespace ModifyDBClusterParameterGroupMessage {
   export function isa(o: any): o is ModifyDBClusterParameterGroupMessage {
-    return _smithy.isa(o, "ModifyDBClusterParameterGroupMessage");
+    return __isa(o, "ModifyDBClusterParameterGroupMessage");
   }
 }
 
@@ -5792,7 +5791,7 @@ export interface ModifyDBClusterResult extends $MetadataBearer {
 
 export namespace ModifyDBClusterResult {
   export function isa(o: any): o is ModifyDBClusterResult {
-    return _smithy.isa(o, "ModifyDBClusterResult");
+    return __isa(o, "ModifyDBClusterResult");
   }
 }
 
@@ -5835,7 +5834,7 @@ export interface ModifyDBClusterSnapshotAttributeMessage {
 
 export namespace ModifyDBClusterSnapshotAttributeMessage {
   export function isa(o: any): o is ModifyDBClusterSnapshotAttributeMessage {
-    return _smithy.isa(o, "ModifyDBClusterSnapshotAttributeMessage");
+    return __isa(o, "ModifyDBClusterSnapshotAttributeMessage");
   }
 }
 
@@ -5852,7 +5851,7 @@ export interface ModifyDBClusterSnapshotAttributeResult
 
 export namespace ModifyDBClusterSnapshotAttributeResult {
   export function isa(o: any): o is ModifyDBClusterSnapshotAttributeResult {
-    return _smithy.isa(o, "ModifyDBClusterSnapshotAttributeResult");
+    return __isa(o, "ModifyDBClusterSnapshotAttributeResult");
   }
 }
 
@@ -6195,7 +6194,7 @@ export interface ModifyDBInstanceMessage {
 
 export namespace ModifyDBInstanceMessage {
   export function isa(o: any): o is ModifyDBInstanceMessage {
-    return _smithy.isa(o, "ModifyDBInstanceMessage");
+    return __isa(o, "ModifyDBInstanceMessage");
   }
 }
 
@@ -6210,7 +6209,7 @@ export interface ModifyDBInstanceResult extends $MetadataBearer {
 
 export namespace ModifyDBInstanceResult {
   export function isa(o: any): o is ModifyDBInstanceResult {
-    return _smithy.isa(o, "ModifyDBInstanceResult");
+    return __isa(o, "ModifyDBInstanceResult");
   }
 }
 
@@ -6244,7 +6243,7 @@ export interface ModifyDBParameterGroupMessage {
 
 export namespace ModifyDBParameterGroupMessage {
   export function isa(o: any): o is ModifyDBParameterGroupMessage {
-    return _smithy.isa(o, "ModifyDBParameterGroupMessage");
+    return __isa(o, "ModifyDBParameterGroupMessage");
   }
 }
 
@@ -6272,7 +6271,7 @@ export interface ModifyDBSubnetGroupMessage {
 
 export namespace ModifyDBSubnetGroupMessage {
   export function isa(o: any): o is ModifyDBSubnetGroupMessage {
-    return _smithy.isa(o, "ModifyDBSubnetGroupMessage");
+    return __isa(o, "ModifyDBSubnetGroupMessage");
   }
 }
 
@@ -6287,7 +6286,7 @@ export interface ModifyDBSubnetGroupResult extends $MetadataBearer {
 
 export namespace ModifyDBSubnetGroupResult {
   export function isa(o: any): o is ModifyDBSubnetGroupResult {
-    return _smithy.isa(o, "ModifyDBSubnetGroupResult");
+    return __isa(o, "ModifyDBSubnetGroupResult");
   }
 }
 
@@ -6329,7 +6328,7 @@ export interface ModifyEventSubscriptionMessage {
 
 export namespace ModifyEventSubscriptionMessage {
   export function isa(o: any): o is ModifyEventSubscriptionMessage {
-    return _smithy.isa(o, "ModifyEventSubscriptionMessage");
+    return __isa(o, "ModifyEventSubscriptionMessage");
   }
 }
 
@@ -6343,7 +6342,7 @@ export interface ModifyEventSubscriptionResult extends $MetadataBearer {
 
 export namespace ModifyEventSubscriptionResult {
   export function isa(o: any): o is ModifyEventSubscriptionResult {
-    return _smithy.isa(o, "ModifyEventSubscriptionResult");
+    return __isa(o, "ModifyEventSubscriptionResult");
   }
 }
 
@@ -6368,7 +6367,7 @@ export interface OptionGroupMembership {
 
 export namespace OptionGroupMembership {
   export function isa(o: any): o is OptionGroupMembership {
-    return _smithy.isa(o, "OptionGroupMembership");
+    return __isa(o, "OptionGroupMembership");
   }
 }
 
@@ -6484,7 +6483,7 @@ export interface OrderableDBInstanceOption {
 
 export namespace OrderableDBInstanceOption {
   export function isa(o: any): o is OrderableDBInstanceOption {
-    return _smithy.isa(o, "OrderableDBInstanceOption");
+    return __isa(o, "OrderableDBInstanceOption");
   }
 }
 
@@ -6506,7 +6505,7 @@ export interface OrderableDBInstanceOptionsMessage extends $MetadataBearer {
 
 export namespace OrderableDBInstanceOptionsMessage {
   export function isa(o: any): o is OrderableDBInstanceOptionsMessage {
-    return _smithy.isa(o, "OrderableDBInstanceOptionsMessage");
+    return __isa(o, "OrderableDBInstanceOptionsMessage");
   }
 }
 
@@ -6570,7 +6569,7 @@ export interface Parameter {
 
 export namespace Parameter {
   export function isa(o: any): o is Parameter {
-    return _smithy.isa(o, "Parameter");
+    return __isa(o, "Parameter");
   }
 }
 
@@ -6595,7 +6594,7 @@ export interface PendingCloudwatchLogsExports {
 
 export namespace PendingCloudwatchLogsExports {
   export function isa(o: any): o is PendingCloudwatchLogsExports {
-    return _smithy.isa(o, "PendingCloudwatchLogsExports");
+    return __isa(o, "PendingCloudwatchLogsExports");
   }
 }
 
@@ -6645,7 +6644,7 @@ export interface PendingMaintenanceAction {
 
 export namespace PendingMaintenanceAction {
   export function isa(o: any): o is PendingMaintenanceAction {
-    return _smithy.isa(o, "PendingMaintenanceAction");
+    return __isa(o, "PendingMaintenanceAction");
   }
 }
 
@@ -6667,7 +6666,7 @@ export interface PendingMaintenanceActionsMessage extends $MetadataBearer {
 
 export namespace PendingMaintenanceActionsMessage {
   export function isa(o: any): o is PendingMaintenanceActionsMessage {
-    return _smithy.isa(o, "PendingMaintenanceActionsMessage");
+    return __isa(o, "PendingMaintenanceActionsMessage");
   }
 }
 
@@ -6759,7 +6758,7 @@ export interface PendingModifiedValues {
 
 export namespace PendingModifiedValues {
   export function isa(o: any): o is PendingModifiedValues {
-    return _smithy.isa(o, "PendingModifiedValues");
+    return __isa(o, "PendingModifiedValues");
   }
 }
 
@@ -6773,7 +6772,7 @@ export interface PromoteReadReplicaDBClusterMessage {
 
 export namespace PromoteReadReplicaDBClusterMessage {
   export function isa(o: any): o is PromoteReadReplicaDBClusterMessage {
-    return _smithy.isa(o, "PromoteReadReplicaDBClusterMessage");
+    return __isa(o, "PromoteReadReplicaDBClusterMessage");
   }
 }
 
@@ -6788,7 +6787,7 @@ export interface PromoteReadReplicaDBClusterResult extends $MetadataBearer {
 
 export namespace PromoteReadReplicaDBClusterResult {
   export function isa(o: any): o is PromoteReadReplicaDBClusterResult {
-    return _smithy.isa(o, "PromoteReadReplicaDBClusterResult");
+    return __isa(o, "PromoteReadReplicaDBClusterResult");
   }
 }
 
@@ -6818,7 +6817,7 @@ export interface Range {
 
 export namespace Range {
   export function isa(o: any): o is Range {
-    return _smithy.isa(o, "Range");
+    return __isa(o, "Range");
   }
 }
 
@@ -6845,7 +6844,7 @@ export interface RebootDBInstanceMessage {
 
 export namespace RebootDBInstanceMessage {
   export function isa(o: any): o is RebootDBInstanceMessage {
-    return _smithy.isa(o, "RebootDBInstanceMessage");
+    return __isa(o, "RebootDBInstanceMessage");
   }
 }
 
@@ -6860,7 +6859,7 @@ export interface RebootDBInstanceResult extends $MetadataBearer {
 
 export namespace RebootDBInstanceResult {
   export function isa(o: any): o is RebootDBInstanceResult {
-    return _smithy.isa(o, "RebootDBInstanceResult");
+    return __isa(o, "RebootDBInstanceResult");
   }
 }
 
@@ -6880,7 +6879,7 @@ export interface RemoveRoleFromDBClusterMessage {
 
 export namespace RemoveRoleFromDBClusterMessage {
   export function isa(o: any): o is RemoveRoleFromDBClusterMessage {
-    return _smithy.isa(o, "RemoveRoleFromDBClusterMessage");
+    return __isa(o, "RemoveRoleFromDBClusterMessage");
   }
 }
 
@@ -6903,7 +6902,7 @@ export namespace RemoveSourceIdentifierFromSubscriptionMessage {
   export function isa(
     o: any
   ): o is RemoveSourceIdentifierFromSubscriptionMessage {
-    return _smithy.isa(o, "RemoveSourceIdentifierFromSubscriptionMessage");
+    return __isa(o, "RemoveSourceIdentifierFromSubscriptionMessage");
   }
 }
 
@@ -6920,7 +6919,7 @@ export namespace RemoveSourceIdentifierFromSubscriptionResult {
   export function isa(
     o: any
   ): o is RemoveSourceIdentifierFromSubscriptionResult {
-    return _smithy.isa(o, "RemoveSourceIdentifierFromSubscriptionResult");
+    return __isa(o, "RemoveSourceIdentifierFromSubscriptionResult");
   }
 }
 
@@ -6941,7 +6940,7 @@ export interface RemoveTagsFromResourceMessage {
 
 export namespace RemoveTagsFromResourceMessage {
   export function isa(o: any): o is RemoveTagsFromResourceMessage {
-    return _smithy.isa(o, "RemoveTagsFromResourceMessage");
+    return __isa(o, "RemoveTagsFromResourceMessage");
   }
 }
 
@@ -6970,7 +6969,7 @@ export interface ResetDBClusterParameterGroupMessage {
 
 export namespace ResetDBClusterParameterGroupMessage {
   export function isa(o: any): o is ResetDBClusterParameterGroupMessage {
-    return _smithy.isa(o, "ResetDBClusterParameterGroupMessage");
+    return __isa(o, "ResetDBClusterParameterGroupMessage");
   }
 }
 
@@ -7008,7 +7007,7 @@ export interface ResetDBParameterGroupMessage {
 
 export namespace ResetDBParameterGroupMessage {
   export function isa(o: any): o is ResetDBParameterGroupMessage {
-    return _smithy.isa(o, "ResetDBParameterGroupMessage");
+    return __isa(o, "ResetDBParameterGroupMessage");
   }
 }
 
@@ -7031,7 +7030,7 @@ export interface ResourcePendingMaintenanceActions {
 
 export namespace ResourcePendingMaintenanceActions {
   export function isa(o: any): o is ResourcePendingMaintenanceActions {
-    return _smithy.isa(o, "ResourcePendingMaintenanceActions");
+    return __isa(o, "ResourcePendingMaintenanceActions");
   }
 }
 
@@ -7184,7 +7183,7 @@ export interface RestoreDBClusterFromSnapshotMessage {
 
 export namespace RestoreDBClusterFromSnapshotMessage {
   export function isa(o: any): o is RestoreDBClusterFromSnapshotMessage {
-    return _smithy.isa(o, "RestoreDBClusterFromSnapshotMessage");
+    return __isa(o, "RestoreDBClusterFromSnapshotMessage");
   }
 }
 
@@ -7199,7 +7198,7 @@ export interface RestoreDBClusterFromSnapshotResult extends $MetadataBearer {
 
 export namespace RestoreDBClusterFromSnapshotResult {
   export function isa(o: any): o is RestoreDBClusterFromSnapshotResult {
-    return _smithy.isa(o, "RestoreDBClusterFromSnapshotResult");
+    return __isa(o, "RestoreDBClusterFromSnapshotResult");
   }
 }
 
@@ -7383,7 +7382,7 @@ export interface RestoreDBClusterToPointInTimeMessage {
 
 export namespace RestoreDBClusterToPointInTimeMessage {
   export function isa(o: any): o is RestoreDBClusterToPointInTimeMessage {
-    return _smithy.isa(o, "RestoreDBClusterToPointInTimeMessage");
+    return __isa(o, "RestoreDBClusterToPointInTimeMessage");
   }
 }
 
@@ -7398,7 +7397,7 @@ export interface RestoreDBClusterToPointInTimeResult extends $MetadataBearer {
 
 export namespace RestoreDBClusterToPointInTimeResult {
   export function isa(o: any): o is RestoreDBClusterToPointInTimeResult {
-    return _smithy.isa(o, "RestoreDBClusterToPointInTimeResult");
+    return __isa(o, "RestoreDBClusterToPointInTimeResult");
   }
 }
 
@@ -7434,7 +7433,7 @@ export interface Subnet {
 
 export namespace Subnet {
   export function isa(o: any): o is Subnet {
-    return _smithy.isa(o, "Subnet");
+    return __isa(o, "Subnet");
   }
 }
 
@@ -7462,7 +7461,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -7476,7 +7475,7 @@ export interface TagListMessage extends $MetadataBearer {
 
 export namespace TagListMessage {
   export function isa(o: any): o is TagListMessage {
-    return _smithy.isa(o, "TagListMessage");
+    return __isa(o, "TagListMessage");
   }
 }
 
@@ -7493,7 +7492,7 @@ export interface Timezone {
 
 export namespace Timezone {
   export function isa(o: any): o is Timezone {
-    return _smithy.isa(o, "Timezone");
+    return __isa(o, "Timezone");
   }
 }
 
@@ -7531,7 +7530,7 @@ export interface UpgradeTarget {
 
 export namespace UpgradeTarget {
   export function isa(o: any): o is UpgradeTarget {
-    return _smithy.isa(o, "UpgradeTarget");
+    return __isa(o, "UpgradeTarget");
   }
 }
 
@@ -7551,7 +7550,7 @@ export interface ValidDBInstanceModificationsMessage {
 
 export namespace ValidDBInstanceModificationsMessage {
   export function isa(o: any): o is ValidDBInstanceModificationsMessage {
-    return _smithy.isa(o, "ValidDBInstanceModificationsMessage");
+    return __isa(o, "ValidDBInstanceModificationsMessage");
   }
 }
 
@@ -7586,7 +7585,7 @@ export interface ValidStorageOptions {
 
 export namespace ValidStorageOptions {
   export function isa(o: any): o is ValidStorageOptions {
-    return _smithy.isa(o, "ValidStorageOptions");
+    return __isa(o, "ValidStorageOptions");
   }
 }
 
@@ -7609,6 +7608,6 @@ export interface VpcSecurityGroupMembership {
 
 export namespace VpcSecurityGroupMembership {
   export function isa(o: any): o is VpcSecurityGroupMembership {
-    return _smithy.isa(o, "VpcSecurityGroupMembership");
+    return __isa(o, "VpcSecurityGroupMembership");
   }
 }

--- a/clients/client-neptune/protocols/Aws_query.ts
+++ b/clients/client-neptune/protocols/Aws_query.ts
@@ -1483,6 +1483,7 @@ export async function deserializeAws_queryAddRoleToDBClusterCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_queryAddRoleToDBClusterCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: AddRoleToDBClusterCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1622,6 +1623,7 @@ export async function deserializeAws_queryAddTagsToResourceCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_queryAddTagsToResourceCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: AddTagsToResourceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2829,6 +2831,7 @@ export async function deserializeAws_queryDeleteDBClusterParameterGroupCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteDBClusterParameterGroupCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -3043,6 +3046,7 @@ export async function deserializeAws_queryDeleteDBParameterGroupCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteDBParameterGroupCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -3100,6 +3104,7 @@ export async function deserializeAws_queryDeleteDBSubnetGroupCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_queryDeleteDBSubnetGroupCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteDBSubnetGroupCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -5250,6 +5255,7 @@ export async function deserializeAws_queryRemoveRoleFromDBClusterCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: RemoveRoleFromDBClusterCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -5385,6 +5391,7 @@ export async function deserializeAws_queryRemoveTagsFromResourceCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: RemoveTagsFromResourceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };

--- a/clients/client-networkmanager/models/index.ts
+++ b/clients/client-networkmanager/models/index.ts
@@ -1,11 +1,14 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
  * <p>You do not have sufficient access to perform this action.</p>
  */
 export interface AccessDeniedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AccessDeniedException";
   $fault: "client";
@@ -14,7 +17,7 @@ export interface AccessDeniedException
 
 export namespace AccessDeniedException {
   export function isa(o: any): o is AccessDeniedException {
-    return _smithy.isa(o, "AccessDeniedException");
+    return __isa(o, "AccessDeniedException");
   }
 }
 
@@ -44,7 +47,7 @@ export interface AssociateCustomerGatewayRequest {
 
 export namespace AssociateCustomerGatewayRequest {
   export function isa(o: any): o is AssociateCustomerGatewayRequest {
-    return _smithy.isa(o, "AssociateCustomerGatewayRequest");
+    return __isa(o, "AssociateCustomerGatewayRequest");
   }
 }
 
@@ -58,7 +61,7 @@ export interface AssociateCustomerGatewayResponse extends $MetadataBearer {
 
 export namespace AssociateCustomerGatewayResponse {
   export function isa(o: any): o is AssociateCustomerGatewayResponse {
-    return _smithy.isa(o, "AssociateCustomerGatewayResponse");
+    return __isa(o, "AssociateCustomerGatewayResponse");
   }
 }
 
@@ -82,7 +85,7 @@ export interface AssociateLinkRequest {
 
 export namespace AssociateLinkRequest {
   export function isa(o: any): o is AssociateLinkRequest {
-    return _smithy.isa(o, "AssociateLinkRequest");
+    return __isa(o, "AssociateLinkRequest");
   }
 }
 
@@ -96,7 +99,7 @@ export interface AssociateLinkResponse extends $MetadataBearer {
 
 export namespace AssociateLinkResponse {
   export function isa(o: any): o is AssociateLinkResponse {
-    return _smithy.isa(o, "AssociateLinkResponse");
+    return __isa(o, "AssociateLinkResponse");
   }
 }
 
@@ -118,7 +121,7 @@ export interface Bandwidth {
 
 export namespace Bandwidth {
   export function isa(o: any): o is Bandwidth {
-    return _smithy.isa(o, "Bandwidth");
+    return __isa(o, "Bandwidth");
   }
 }
 
@@ -126,9 +129,7 @@ export namespace Bandwidth {
  * <p>There was a conflict processing the request. Updating or deleting the resource can
  *             cause an inconsistent state.</p>
  */
-export interface ConflictException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface ConflictException extends __SmithyException, $MetadataBearer {
   name: "ConflictException";
   $fault: "client";
   Message: string | undefined;
@@ -145,7 +146,7 @@ export interface ConflictException
 
 export namespace ConflictException {
   export function isa(o: any): o is ConflictException {
-    return _smithy.isa(o, "ConflictException");
+    return __isa(o, "ConflictException");
   }
 }
 
@@ -203,7 +204,7 @@ export interface CreateDeviceRequest {
 
 export namespace CreateDeviceRequest {
   export function isa(o: any): o is CreateDeviceRequest {
-    return _smithy.isa(o, "CreateDeviceRequest");
+    return __isa(o, "CreateDeviceRequest");
   }
 }
 
@@ -217,7 +218,7 @@ export interface CreateDeviceResponse extends $MetadataBearer {
 
 export namespace CreateDeviceResponse {
   export function isa(o: any): o is CreateDeviceResponse {
-    return _smithy.isa(o, "CreateDeviceResponse");
+    return __isa(o, "CreateDeviceResponse");
   }
 }
 
@@ -237,7 +238,7 @@ export interface CreateGlobalNetworkRequest {
 
 export namespace CreateGlobalNetworkRequest {
   export function isa(o: any): o is CreateGlobalNetworkRequest {
-    return _smithy.isa(o, "CreateGlobalNetworkRequest");
+    return __isa(o, "CreateGlobalNetworkRequest");
   }
 }
 
@@ -251,7 +252,7 @@ export interface CreateGlobalNetworkResponse extends $MetadataBearer {
 
 export namespace CreateGlobalNetworkResponse {
   export function isa(o: any): o is CreateGlobalNetworkResponse {
-    return _smithy.isa(o, "CreateGlobalNetworkResponse");
+    return __isa(o, "CreateGlobalNetworkResponse");
   }
 }
 
@@ -300,7 +301,7 @@ export interface CreateLinkRequest {
 
 export namespace CreateLinkRequest {
   export function isa(o: any): o is CreateLinkRequest {
-    return _smithy.isa(o, "CreateLinkRequest");
+    return __isa(o, "CreateLinkRequest");
   }
 }
 
@@ -314,7 +315,7 @@ export interface CreateLinkResponse extends $MetadataBearer {
 
 export namespace CreateLinkResponse {
   export function isa(o: any): o is CreateLinkResponse {
-    return _smithy.isa(o, "CreateLinkResponse");
+    return __isa(o, "CreateLinkResponse");
   }
 }
 
@@ -358,7 +359,7 @@ export interface CreateSiteRequest {
 
 export namespace CreateSiteRequest {
   export function isa(o: any): o is CreateSiteRequest {
-    return _smithy.isa(o, "CreateSiteRequest");
+    return __isa(o, "CreateSiteRequest");
   }
 }
 
@@ -372,7 +373,7 @@ export interface CreateSiteResponse extends $MetadataBearer {
 
 export namespace CreateSiteResponse {
   export function isa(o: any): o is CreateSiteResponse {
-    return _smithy.isa(o, "CreateSiteResponse");
+    return __isa(o, "CreateSiteResponse");
   }
 }
 
@@ -409,7 +410,7 @@ export interface CustomerGatewayAssociation {
 
 export namespace CustomerGatewayAssociation {
   export function isa(o: any): o is CustomerGatewayAssociation {
-    return _smithy.isa(o, "CustomerGatewayAssociation");
+    return __isa(o, "CustomerGatewayAssociation");
   }
 }
 
@@ -435,7 +436,7 @@ export interface DeleteDeviceRequest {
 
 export namespace DeleteDeviceRequest {
   export function isa(o: any): o is DeleteDeviceRequest {
-    return _smithy.isa(o, "DeleteDeviceRequest");
+    return __isa(o, "DeleteDeviceRequest");
   }
 }
 
@@ -449,7 +450,7 @@ export interface DeleteDeviceResponse extends $MetadataBearer {
 
 export namespace DeleteDeviceResponse {
   export function isa(o: any): o is DeleteDeviceResponse {
-    return _smithy.isa(o, "DeleteDeviceResponse");
+    return __isa(o, "DeleteDeviceResponse");
   }
 }
 
@@ -463,7 +464,7 @@ export interface DeleteGlobalNetworkRequest {
 
 export namespace DeleteGlobalNetworkRequest {
   export function isa(o: any): o is DeleteGlobalNetworkRequest {
-    return _smithy.isa(o, "DeleteGlobalNetworkRequest");
+    return __isa(o, "DeleteGlobalNetworkRequest");
   }
 }
 
@@ -477,7 +478,7 @@ export interface DeleteGlobalNetworkResponse extends $MetadataBearer {
 
 export namespace DeleteGlobalNetworkResponse {
   export function isa(o: any): o is DeleteGlobalNetworkResponse {
-    return _smithy.isa(o, "DeleteGlobalNetworkResponse");
+    return __isa(o, "DeleteGlobalNetworkResponse");
   }
 }
 
@@ -496,7 +497,7 @@ export interface DeleteLinkRequest {
 
 export namespace DeleteLinkRequest {
   export function isa(o: any): o is DeleteLinkRequest {
-    return _smithy.isa(o, "DeleteLinkRequest");
+    return __isa(o, "DeleteLinkRequest");
   }
 }
 
@@ -510,7 +511,7 @@ export interface DeleteLinkResponse extends $MetadataBearer {
 
 export namespace DeleteLinkResponse {
   export function isa(o: any): o is DeleteLinkResponse {
-    return _smithy.isa(o, "DeleteLinkResponse");
+    return __isa(o, "DeleteLinkResponse");
   }
 }
 
@@ -529,7 +530,7 @@ export interface DeleteSiteRequest {
 
 export namespace DeleteSiteRequest {
   export function isa(o: any): o is DeleteSiteRequest {
-    return _smithy.isa(o, "DeleteSiteRequest");
+    return __isa(o, "DeleteSiteRequest");
   }
 }
 
@@ -543,7 +544,7 @@ export interface DeleteSiteResponse extends $MetadataBearer {
 
 export namespace DeleteSiteResponse {
   export function isa(o: any): o is DeleteSiteResponse {
-    return _smithy.isa(o, "DeleteSiteResponse");
+    return __isa(o, "DeleteSiteResponse");
   }
 }
 
@@ -562,7 +563,7 @@ export interface DeregisterTransitGatewayRequest {
 
 export namespace DeregisterTransitGatewayRequest {
   export function isa(o: any): o is DeregisterTransitGatewayRequest {
-    return _smithy.isa(o, "DeregisterTransitGatewayRequest");
+    return __isa(o, "DeregisterTransitGatewayRequest");
   }
 }
 
@@ -576,7 +577,7 @@ export interface DeregisterTransitGatewayResponse extends $MetadataBearer {
 
 export namespace DeregisterTransitGatewayResponse {
   export function isa(o: any): o is DeregisterTransitGatewayResponse {
-    return _smithy.isa(o, "DeregisterTransitGatewayResponse");
+    return __isa(o, "DeregisterTransitGatewayResponse");
   }
 }
 
@@ -600,7 +601,7 @@ export interface DescribeGlobalNetworksRequest {
 
 export namespace DescribeGlobalNetworksRequest {
   export function isa(o: any): o is DescribeGlobalNetworksRequest {
-    return _smithy.isa(o, "DescribeGlobalNetworksRequest");
+    return __isa(o, "DescribeGlobalNetworksRequest");
   }
 }
 
@@ -619,7 +620,7 @@ export interface DescribeGlobalNetworksResponse extends $MetadataBearer {
 
 export namespace DescribeGlobalNetworksResponse {
   export function isa(o: any): o is DescribeGlobalNetworksResponse {
-    return _smithy.isa(o, "DescribeGlobalNetworksResponse");
+    return __isa(o, "DescribeGlobalNetworksResponse");
   }
 }
 
@@ -696,7 +697,7 @@ export interface Device {
 
 export namespace Device {
   export function isa(o: any): o is Device {
-    return _smithy.isa(o, "Device");
+    return __isa(o, "Device");
   }
 }
 
@@ -723,7 +724,7 @@ export interface DisassociateCustomerGatewayRequest {
 
 export namespace DisassociateCustomerGatewayRequest {
   export function isa(o: any): o is DisassociateCustomerGatewayRequest {
-    return _smithy.isa(o, "DisassociateCustomerGatewayRequest");
+    return __isa(o, "DisassociateCustomerGatewayRequest");
   }
 }
 
@@ -737,7 +738,7 @@ export interface DisassociateCustomerGatewayResponse extends $MetadataBearer {
 
 export namespace DisassociateCustomerGatewayResponse {
   export function isa(o: any): o is DisassociateCustomerGatewayResponse {
-    return _smithy.isa(o, "DisassociateCustomerGatewayResponse");
+    return __isa(o, "DisassociateCustomerGatewayResponse");
   }
 }
 
@@ -761,7 +762,7 @@ export interface DisassociateLinkRequest {
 
 export namespace DisassociateLinkRequest {
   export function isa(o: any): o is DisassociateLinkRequest {
-    return _smithy.isa(o, "DisassociateLinkRequest");
+    return __isa(o, "DisassociateLinkRequest");
   }
 }
 
@@ -775,7 +776,7 @@ export interface DisassociateLinkResponse extends $MetadataBearer {
 
 export namespace DisassociateLinkResponse {
   export function isa(o: any): o is DisassociateLinkResponse {
-    return _smithy.isa(o, "DisassociateLinkResponse");
+    return __isa(o, "DisassociateLinkResponse");
   }
 }
 
@@ -805,7 +806,7 @@ export interface GetCustomerGatewayAssociationsRequest {
 
 export namespace GetCustomerGatewayAssociationsRequest {
   export function isa(o: any): o is GetCustomerGatewayAssociationsRequest {
-    return _smithy.isa(o, "GetCustomerGatewayAssociationsRequest");
+    return __isa(o, "GetCustomerGatewayAssociationsRequest");
   }
 }
 
@@ -825,7 +826,7 @@ export interface GetCustomerGatewayAssociationsResponse
 
 export namespace GetCustomerGatewayAssociationsResponse {
   export function isa(o: any): o is GetCustomerGatewayAssociationsResponse {
-    return _smithy.isa(o, "GetCustomerGatewayAssociationsResponse");
+    return __isa(o, "GetCustomerGatewayAssociationsResponse");
   }
 }
 
@@ -859,7 +860,7 @@ export interface GetDevicesRequest {
 
 export namespace GetDevicesRequest {
   export function isa(o: any): o is GetDevicesRequest {
-    return _smithy.isa(o, "GetDevicesRequest");
+    return __isa(o, "GetDevicesRequest");
   }
 }
 
@@ -878,7 +879,7 @@ export interface GetDevicesResponse extends $MetadataBearer {
 
 export namespace GetDevicesResponse {
   export function isa(o: any): o is GetDevicesResponse {
-    return _smithy.isa(o, "GetDevicesResponse");
+    return __isa(o, "GetDevicesResponse");
   }
 }
 
@@ -912,7 +913,7 @@ export interface GetLinkAssociationsRequest {
 
 export namespace GetLinkAssociationsRequest {
   export function isa(o: any): o is GetLinkAssociationsRequest {
-    return _smithy.isa(o, "GetLinkAssociationsRequest");
+    return __isa(o, "GetLinkAssociationsRequest");
   }
 }
 
@@ -931,7 +932,7 @@ export interface GetLinkAssociationsResponse extends $MetadataBearer {
 
 export namespace GetLinkAssociationsResponse {
   export function isa(o: any): o is GetLinkAssociationsResponse {
-    return _smithy.isa(o, "GetLinkAssociationsResponse");
+    return __isa(o, "GetLinkAssociationsResponse");
   }
 }
 
@@ -975,7 +976,7 @@ export interface GetLinksRequest {
 
 export namespace GetLinksRequest {
   export function isa(o: any): o is GetLinksRequest {
-    return _smithy.isa(o, "GetLinksRequest");
+    return __isa(o, "GetLinksRequest");
   }
 }
 
@@ -994,7 +995,7 @@ export interface GetLinksResponse extends $MetadataBearer {
 
 export namespace GetLinksResponse {
   export function isa(o: any): o is GetLinksResponse {
-    return _smithy.isa(o, "GetLinksResponse");
+    return __isa(o, "GetLinksResponse");
   }
 }
 
@@ -1023,7 +1024,7 @@ export interface GetSitesRequest {
 
 export namespace GetSitesRequest {
   export function isa(o: any): o is GetSitesRequest {
-    return _smithy.isa(o, "GetSitesRequest");
+    return __isa(o, "GetSitesRequest");
   }
 }
 
@@ -1042,7 +1043,7 @@ export interface GetSitesResponse extends $MetadataBearer {
 
 export namespace GetSitesResponse {
   export function isa(o: any): o is GetSitesResponse {
-    return _smithy.isa(o, "GetSitesResponse");
+    return __isa(o, "GetSitesResponse");
   }
 }
 
@@ -1072,7 +1073,7 @@ export interface GetTransitGatewayRegistrationsRequest {
 
 export namespace GetTransitGatewayRegistrationsRequest {
   export function isa(o: any): o is GetTransitGatewayRegistrationsRequest {
-    return _smithy.isa(o, "GetTransitGatewayRegistrationsRequest");
+    return __isa(o, "GetTransitGatewayRegistrationsRequest");
   }
 }
 
@@ -1092,7 +1093,7 @@ export interface GetTransitGatewayRegistrationsResponse
 
 export namespace GetTransitGatewayRegistrationsResponse {
   export function isa(o: any): o is GetTransitGatewayRegistrationsResponse {
-    return _smithy.isa(o, "GetTransitGatewayRegistrationsResponse");
+    return __isa(o, "GetTransitGatewayRegistrationsResponse");
   }
 }
 
@@ -1134,7 +1135,7 @@ export interface GlobalNetwork {
 
 export namespace GlobalNetwork {
   export function isa(o: any): o is GlobalNetwork {
-    return _smithy.isa(o, "GlobalNetwork");
+    return __isa(o, "GlobalNetwork");
   }
 }
 
@@ -1149,7 +1150,7 @@ export enum GlobalNetworkState {
  * <p>The request has failed due to an internal error.</p>
  */
 export interface InternalServerException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalServerException";
   $fault: "server";
@@ -1162,7 +1163,7 @@ export interface InternalServerException
 
 export namespace InternalServerException {
   export function isa(o: any): o is InternalServerException {
-    return _smithy.isa(o, "InternalServerException");
+    return __isa(o, "InternalServerException");
   }
 }
 
@@ -1229,7 +1230,7 @@ export interface Link {
 
 export namespace Link {
   export function isa(o: any): o is Link {
-    return _smithy.isa(o, "Link");
+    return __isa(o, "Link");
   }
 }
 
@@ -1261,7 +1262,7 @@ export interface LinkAssociation {
 
 export namespace LinkAssociation {
   export function isa(o: any): o is LinkAssociation {
-    return _smithy.isa(o, "LinkAssociation");
+    return __isa(o, "LinkAssociation");
   }
 }
 
@@ -1289,7 +1290,7 @@ export interface ListTagsForResourceRequest {
 
 export namespace ListTagsForResourceRequest {
   export function isa(o: any): o is ListTagsForResourceRequest {
-    return _smithy.isa(o, "ListTagsForResourceRequest");
+    return __isa(o, "ListTagsForResourceRequest");
   }
 }
 
@@ -1303,7 +1304,7 @@ export interface ListTagsForResourceResponse extends $MetadataBearer {
 
 export namespace ListTagsForResourceResponse {
   export function isa(o: any): o is ListTagsForResourceResponse {
-    return _smithy.isa(o, "ListTagsForResourceResponse");
+    return __isa(o, "ListTagsForResourceResponse");
   }
 }
 
@@ -1330,7 +1331,7 @@ export interface Location {
 
 export namespace Location {
   export function isa(o: any): o is Location {
-    return _smithy.isa(o, "Location");
+    return __isa(o, "Location");
   }
 }
 
@@ -1350,7 +1351,7 @@ export interface RegisterTransitGatewayRequest {
 
 export namespace RegisterTransitGatewayRequest {
   export function isa(o: any): o is RegisterTransitGatewayRequest {
-    return _smithy.isa(o, "RegisterTransitGatewayRequest");
+    return __isa(o, "RegisterTransitGatewayRequest");
   }
 }
 
@@ -1364,7 +1365,7 @@ export interface RegisterTransitGatewayResponse extends $MetadataBearer {
 
 export namespace RegisterTransitGatewayResponse {
   export function isa(o: any): o is RegisterTransitGatewayResponse {
-    return _smithy.isa(o, "RegisterTransitGatewayResponse");
+    return __isa(o, "RegisterTransitGatewayResponse");
   }
 }
 
@@ -1372,7 +1373,7 @@ export namespace RegisterTransitGatewayResponse {
  * <p>The specified resource could not be found.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -1390,7 +1391,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -1398,7 +1399,7 @@ export namespace ResourceNotFoundException {
  * <p>A service limit was exceeded.</p>
  */
 export interface ServiceQuotaExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ServiceQuotaExceededException";
   $fault: "client";
@@ -1430,7 +1431,7 @@ export interface ServiceQuotaExceededException
 
 export namespace ServiceQuotaExceededException {
   export function isa(o: any): o is ServiceQuotaExceededException {
-    return _smithy.isa(o, "ServiceQuotaExceededException");
+    return __isa(o, "ServiceQuotaExceededException");
   }
 }
 
@@ -1482,7 +1483,7 @@ export interface Site {
 
 export namespace Site {
   export function isa(o: any): o is Site {
-    return _smithy.isa(o, "Site");
+    return __isa(o, "Site");
   }
 }
 
@@ -1513,7 +1514,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -1532,7 +1533,7 @@ export interface TagResourceRequest {
 
 export namespace TagResourceRequest {
   export function isa(o: any): o is TagResourceRequest {
-    return _smithy.isa(o, "TagResourceRequest");
+    return __isa(o, "TagResourceRequest");
   }
 }
 
@@ -1542,7 +1543,7 @@ export interface TagResourceResponse extends $MetadataBearer {
 
 export namespace TagResourceResponse {
   export function isa(o: any): o is TagResourceResponse {
-    return _smithy.isa(o, "TagResourceResponse");
+    return __isa(o, "TagResourceResponse");
   }
 }
 
@@ -1550,7 +1551,7 @@ export namespace TagResourceResponse {
  * <p>The request was denied due to request throttling.</p>
  */
 export interface ThrottlingException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ThrottlingException";
   $fault: "client";
@@ -1563,7 +1564,7 @@ export interface ThrottlingException
 
 export namespace ThrottlingException {
   export function isa(o: any): o is ThrottlingException {
-    return _smithy.isa(o, "ThrottlingException");
+    return __isa(o, "ThrottlingException");
   }
 }
 
@@ -1590,7 +1591,7 @@ export interface TransitGatewayRegistration {
 
 export namespace TransitGatewayRegistration {
   export function isa(o: any): o is TransitGatewayRegistration {
-    return _smithy.isa(o, "TransitGatewayRegistration");
+    return __isa(o, "TransitGatewayRegistration");
   }
 }
 
@@ -1620,7 +1621,7 @@ export interface TransitGatewayRegistrationStateReason {
 
 export namespace TransitGatewayRegistrationStateReason {
   export function isa(o: any): o is TransitGatewayRegistrationStateReason {
-    return _smithy.isa(o, "TransitGatewayRegistrationStateReason");
+    return __isa(o, "TransitGatewayRegistrationStateReason");
   }
 }
 
@@ -1639,7 +1640,7 @@ export interface UntagResourceRequest {
 
 export namespace UntagResourceRequest {
   export function isa(o: any): o is UntagResourceRequest {
-    return _smithy.isa(o, "UntagResourceRequest");
+    return __isa(o, "UntagResourceRequest");
   }
 }
 
@@ -1649,7 +1650,7 @@ export interface UntagResourceResponse extends $MetadataBearer {
 
 export namespace UntagResourceResponse {
   export function isa(o: any): o is UntagResourceResponse {
-    return _smithy.isa(o, "UntagResourceResponse");
+    return __isa(o, "UntagResourceResponse");
   }
 }
 
@@ -1707,7 +1708,7 @@ export interface UpdateDeviceRequest {
 
 export namespace UpdateDeviceRequest {
   export function isa(o: any): o is UpdateDeviceRequest {
-    return _smithy.isa(o, "UpdateDeviceRequest");
+    return __isa(o, "UpdateDeviceRequest");
   }
 }
 
@@ -1721,7 +1722,7 @@ export interface UpdateDeviceResponse extends $MetadataBearer {
 
 export namespace UpdateDeviceResponse {
   export function isa(o: any): o is UpdateDeviceResponse {
-    return _smithy.isa(o, "UpdateDeviceResponse");
+    return __isa(o, "UpdateDeviceResponse");
   }
 }
 
@@ -1741,7 +1742,7 @@ export interface UpdateGlobalNetworkRequest {
 
 export namespace UpdateGlobalNetworkRequest {
   export function isa(o: any): o is UpdateGlobalNetworkRequest {
-    return _smithy.isa(o, "UpdateGlobalNetworkRequest");
+    return __isa(o, "UpdateGlobalNetworkRequest");
   }
 }
 
@@ -1755,7 +1756,7 @@ export interface UpdateGlobalNetworkResponse extends $MetadataBearer {
 
 export namespace UpdateGlobalNetworkResponse {
   export function isa(o: any): o is UpdateGlobalNetworkResponse {
-    return _smithy.isa(o, "UpdateGlobalNetworkResponse");
+    return __isa(o, "UpdateGlobalNetworkResponse");
   }
 }
 
@@ -1797,7 +1798,7 @@ export interface UpdateLinkRequest {
 
 export namespace UpdateLinkRequest {
   export function isa(o: any): o is UpdateLinkRequest {
-    return _smithy.isa(o, "UpdateLinkRequest");
+    return __isa(o, "UpdateLinkRequest");
   }
 }
 
@@ -1811,7 +1812,7 @@ export interface UpdateLinkResponse extends $MetadataBearer {
 
 export namespace UpdateLinkResponse {
   export function isa(o: any): o is UpdateLinkResponse {
-    return _smithy.isa(o, "UpdateLinkResponse");
+    return __isa(o, "UpdateLinkResponse");
   }
 }
 
@@ -1855,7 +1856,7 @@ export interface UpdateSiteRequest {
 
 export namespace UpdateSiteRequest {
   export function isa(o: any): o is UpdateSiteRequest {
-    return _smithy.isa(o, "UpdateSiteRequest");
+    return __isa(o, "UpdateSiteRequest");
   }
 }
 
@@ -1869,7 +1870,7 @@ export interface UpdateSiteResponse extends $MetadataBearer {
 
 export namespace UpdateSiteResponse {
   export function isa(o: any): o is UpdateSiteResponse {
-    return _smithy.isa(o, "UpdateSiteResponse");
+    return __isa(o, "UpdateSiteResponse");
   }
 }
 
@@ -1877,7 +1878,7 @@ export namespace UpdateSiteResponse {
  * <p>The input fails to satisfy the constraints.</p>
  */
 export interface ValidationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ValidationException";
   $fault: "client";
@@ -1895,7 +1896,7 @@ export interface ValidationException
 
 export namespace ValidationException {
   export function isa(o: any): o is ValidationException {
-    return _smithy.isa(o, "ValidationException");
+    return __isa(o, "ValidationException");
   }
 }
 
@@ -1917,7 +1918,7 @@ export interface ValidationExceptionField {
 
 export namespace ValidationExceptionField {
   export function isa(o: any): o is ValidationExceptionField {
-    return _smithy.isa(o, "ValidationExceptionField");
+    return __isa(o, "ValidationExceptionField");
   }
 }
 

--- a/clients/client-networkmanager/protocols/Aws_restJson1_1.ts
+++ b/clients/client-networkmanager/protocols/Aws_restJson1_1.ts
@@ -135,7 +135,10 @@ import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  extendedEncodeURIComponent as __extendedEncodeURIComponent
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -152,7 +155,7 @@ export async function serializeAws_restJson1_1AssociateCustomerGatewayCommand(
   let resolvedPath =
     "/global-networks/{GlobalNetworkId}/customer-gateway-associations";
   if (input.GlobalNetworkId !== undefined) {
-    const labelValue: string = input.GlobalNetworkId.toString();
+    const labelValue: string = input.GlobalNetworkId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: GlobalNetworkId."
@@ -160,7 +163,7 @@ export async function serializeAws_restJson1_1AssociateCustomerGatewayCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{GlobalNetworkId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: GlobalNetworkId.");
@@ -195,7 +198,7 @@ export async function serializeAws_restJson1_1AssociateLinkCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/global-networks/{GlobalNetworkId}/link-associations";
   if (input.GlobalNetworkId !== undefined) {
-    const labelValue: string = input.GlobalNetworkId.toString();
+    const labelValue: string = input.GlobalNetworkId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: GlobalNetworkId."
@@ -203,7 +206,7 @@ export async function serializeAws_restJson1_1AssociateLinkCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{GlobalNetworkId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: GlobalNetworkId.");
@@ -235,7 +238,7 @@ export async function serializeAws_restJson1_1CreateDeviceCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/global-networks/{GlobalNetworkId}/devices";
   if (input.GlobalNetworkId !== undefined) {
-    const labelValue: string = input.GlobalNetworkId.toString();
+    const labelValue: string = input.GlobalNetworkId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: GlobalNetworkId."
@@ -243,7 +246,7 @@ export async function serializeAws_restJson1_1CreateDeviceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{GlobalNetworkId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: GlobalNetworkId.");
@@ -322,7 +325,7 @@ export async function serializeAws_restJson1_1CreateLinkCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/global-networks/{GlobalNetworkId}/links";
   if (input.GlobalNetworkId !== undefined) {
-    const labelValue: string = input.GlobalNetworkId.toString();
+    const labelValue: string = input.GlobalNetworkId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: GlobalNetworkId."
@@ -330,7 +333,7 @@ export async function serializeAws_restJson1_1CreateLinkCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{GlobalNetworkId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: GlobalNetworkId.");
@@ -377,7 +380,7 @@ export async function serializeAws_restJson1_1CreateSiteCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/global-networks/{GlobalNetworkId}/sites";
   if (input.GlobalNetworkId !== undefined) {
-    const labelValue: string = input.GlobalNetworkId.toString();
+    const labelValue: string = input.GlobalNetworkId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: GlobalNetworkId."
@@ -385,7 +388,7 @@ export async function serializeAws_restJson1_1CreateSiteCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{GlobalNetworkId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: GlobalNetworkId.");
@@ -423,19 +426,19 @@ export async function serializeAws_restJson1_1DeleteDeviceCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/global-networks/{GlobalNetworkId}/devices/{DeviceId}";
   if (input.DeviceId !== undefined) {
-    const labelValue: string = input.DeviceId.toString();
+    const labelValue: string = input.DeviceId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DeviceId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DeviceId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DeviceId.");
   }
   if (input.GlobalNetworkId !== undefined) {
-    const labelValue: string = input.GlobalNetworkId.toString();
+    const labelValue: string = input.GlobalNetworkId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: GlobalNetworkId."
@@ -443,7 +446,7 @@ export async function serializeAws_restJson1_1DeleteDeviceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{GlobalNetworkId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: GlobalNetworkId.");
@@ -465,7 +468,7 @@ export async function serializeAws_restJson1_1DeleteGlobalNetworkCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/global-networks/{GlobalNetworkId}";
   if (input.GlobalNetworkId !== undefined) {
-    const labelValue: string = input.GlobalNetworkId.toString();
+    const labelValue: string = input.GlobalNetworkId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: GlobalNetworkId."
@@ -473,7 +476,7 @@ export async function serializeAws_restJson1_1DeleteGlobalNetworkCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{GlobalNetworkId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: GlobalNetworkId.");
@@ -495,7 +498,7 @@ export async function serializeAws_restJson1_1DeleteLinkCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/global-networks/{GlobalNetworkId}/links/{LinkId}";
   if (input.GlobalNetworkId !== undefined) {
-    const labelValue: string = input.GlobalNetworkId.toString();
+    const labelValue: string = input.GlobalNetworkId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: GlobalNetworkId."
@@ -503,19 +506,19 @@ export async function serializeAws_restJson1_1DeleteLinkCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{GlobalNetworkId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: GlobalNetworkId.");
   }
   if (input.LinkId !== undefined) {
-    const labelValue: string = input.LinkId.toString();
+    const labelValue: string = input.LinkId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: LinkId.");
     }
     resolvedPath = resolvedPath.replace(
       "{LinkId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: LinkId.");
@@ -537,7 +540,7 @@ export async function serializeAws_restJson1_1DeleteSiteCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/global-networks/{GlobalNetworkId}/sites/{SiteId}";
   if (input.GlobalNetworkId !== undefined) {
-    const labelValue: string = input.GlobalNetworkId.toString();
+    const labelValue: string = input.GlobalNetworkId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: GlobalNetworkId."
@@ -545,19 +548,19 @@ export async function serializeAws_restJson1_1DeleteSiteCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{GlobalNetworkId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: GlobalNetworkId.");
   }
   if (input.SiteId !== undefined) {
-    const labelValue: string = input.SiteId.toString();
+    const labelValue: string = input.SiteId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: SiteId.");
     }
     resolvedPath = resolvedPath.replace(
       "{SiteId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: SiteId.");
@@ -580,7 +583,7 @@ export async function serializeAws_restJson1_1DeregisterTransitGatewayCommand(
   let resolvedPath =
     "/global-networks/{GlobalNetworkId}/transit-gateway-registrations/{TransitGatewayArn}";
   if (input.GlobalNetworkId !== undefined) {
-    const labelValue: string = input.GlobalNetworkId.toString();
+    const labelValue: string = input.GlobalNetworkId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: GlobalNetworkId."
@@ -588,13 +591,13 @@ export async function serializeAws_restJson1_1DeregisterTransitGatewayCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{GlobalNetworkId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: GlobalNetworkId.");
   }
   if (input.TransitGatewayArn !== undefined) {
-    const labelValue: string = input.TransitGatewayArn.toString();
+    const labelValue: string = input.TransitGatewayArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: TransitGatewayArn."
@@ -602,7 +605,7 @@ export async function serializeAws_restJson1_1DeregisterTransitGatewayCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{TransitGatewayArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -627,13 +630,21 @@ export async function serializeAws_restJson1_1DescribeGlobalNetworksCommand(
   let resolvedPath = "/global-networks";
   const query: any = {};
   if (input.GlobalNetworkIds !== undefined) {
-    query["globalNetworkIds"] = input.GlobalNetworkIds;
+    query[
+      __extendedEncodeURIComponent("globalNetworkIds")
+    ] = input.GlobalNetworkIds.map(entry =>
+      __extendedEncodeURIComponent(entry)
+    );
   }
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -654,7 +665,7 @@ export async function serializeAws_restJson1_1DisassociateCustomerGatewayCommand
   let resolvedPath =
     "/global-networks/{GlobalNetworkId}/customer-gateway-associations/{CustomerGatewayArn}";
   if (input.CustomerGatewayArn !== undefined) {
-    const labelValue: string = input.CustomerGatewayArn.toString();
+    const labelValue: string = input.CustomerGatewayArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: CustomerGatewayArn."
@@ -662,7 +673,7 @@ export async function serializeAws_restJson1_1DisassociateCustomerGatewayCommand
     }
     resolvedPath = resolvedPath.replace(
       "{CustomerGatewayArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -670,7 +681,7 @@ export async function serializeAws_restJson1_1DisassociateCustomerGatewayCommand
     );
   }
   if (input.GlobalNetworkId !== undefined) {
-    const labelValue: string = input.GlobalNetworkId.toString();
+    const labelValue: string = input.GlobalNetworkId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: GlobalNetworkId."
@@ -678,7 +689,7 @@ export async function serializeAws_restJson1_1DisassociateCustomerGatewayCommand
     }
     resolvedPath = resolvedPath.replace(
       "{GlobalNetworkId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: GlobalNetworkId.");
@@ -700,7 +711,7 @@ export async function serializeAws_restJson1_1DisassociateLinkCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/global-networks/{GlobalNetworkId}/link-associations";
   if (input.GlobalNetworkId !== undefined) {
-    const labelValue: string = input.GlobalNetworkId.toString();
+    const labelValue: string = input.GlobalNetworkId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: GlobalNetworkId."
@@ -708,17 +719,21 @@ export async function serializeAws_restJson1_1DisassociateLinkCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{GlobalNetworkId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: GlobalNetworkId.");
   }
   const query: any = {};
   if (input.DeviceId !== undefined) {
-    query["deviceId"] = input.DeviceId.toString();
+    query[
+      __extendedEncodeURIComponent("deviceId")
+    ] = __extendedEncodeURIComponent(input.DeviceId);
   }
   if (input.LinkId !== undefined) {
-    query["linkId"] = input.LinkId.toString();
+    query[
+      __extendedEncodeURIComponent("linkId")
+    ] = __extendedEncodeURIComponent(input.LinkId);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -739,7 +754,7 @@ export async function serializeAws_restJson1_1GetCustomerGatewayAssociationsComm
   let resolvedPath =
     "/global-networks/{GlobalNetworkId}/customer-gateway-associations";
   if (input.GlobalNetworkId !== undefined) {
-    const labelValue: string = input.GlobalNetworkId.toString();
+    const labelValue: string = input.GlobalNetworkId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: GlobalNetworkId."
@@ -747,20 +762,28 @@ export async function serializeAws_restJson1_1GetCustomerGatewayAssociationsComm
     }
     resolvedPath = resolvedPath.replace(
       "{GlobalNetworkId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: GlobalNetworkId.");
   }
   const query: any = {};
   if (input.CustomerGatewayArns !== undefined) {
-    query["customerGatewayArns"] = input.CustomerGatewayArns;
+    query[
+      __extendedEncodeURIComponent("customerGatewayArns")
+    ] = input.CustomerGatewayArns.map(entry =>
+      __extendedEncodeURIComponent(entry)
+    );
   }
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -780,7 +803,7 @@ export async function serializeAws_restJson1_1GetDevicesCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/global-networks/{GlobalNetworkId}/devices";
   if (input.GlobalNetworkId !== undefined) {
-    const labelValue: string = input.GlobalNetworkId.toString();
+    const labelValue: string = input.GlobalNetworkId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: GlobalNetworkId."
@@ -788,23 +811,31 @@ export async function serializeAws_restJson1_1GetDevicesCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{GlobalNetworkId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: GlobalNetworkId.");
   }
   const query: any = {};
   if (input.DeviceIds !== undefined) {
-    query["deviceIds"] = input.DeviceIds;
+    query[
+      __extendedEncodeURIComponent("deviceIds")
+    ] = input.DeviceIds.map(entry => __extendedEncodeURIComponent(entry));
   }
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   if (input.SiteId !== undefined) {
-    query["siteId"] = input.SiteId.toString();
+    query[
+      __extendedEncodeURIComponent("siteId")
+    ] = __extendedEncodeURIComponent(input.SiteId);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -824,7 +855,7 @@ export async function serializeAws_restJson1_1GetLinkAssociationsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/global-networks/{GlobalNetworkId}/link-associations";
   if (input.GlobalNetworkId !== undefined) {
-    const labelValue: string = input.GlobalNetworkId.toString();
+    const labelValue: string = input.GlobalNetworkId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: GlobalNetworkId."
@@ -832,23 +863,31 @@ export async function serializeAws_restJson1_1GetLinkAssociationsCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{GlobalNetworkId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: GlobalNetworkId.");
   }
   const query: any = {};
   if (input.DeviceId !== undefined) {
-    query["deviceId"] = input.DeviceId.toString();
+    query[
+      __extendedEncodeURIComponent("deviceId")
+    ] = __extendedEncodeURIComponent(input.DeviceId);
   }
   if (input.LinkId !== undefined) {
-    query["linkId"] = input.LinkId.toString();
+    query[
+      __extendedEncodeURIComponent("linkId")
+    ] = __extendedEncodeURIComponent(input.LinkId);
   }
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -868,7 +907,7 @@ export async function serializeAws_restJson1_1GetLinksCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/global-networks/{GlobalNetworkId}/links";
   if (input.GlobalNetworkId !== undefined) {
-    const labelValue: string = input.GlobalNetworkId.toString();
+    const labelValue: string = input.GlobalNetworkId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: GlobalNetworkId."
@@ -876,29 +915,41 @@ export async function serializeAws_restJson1_1GetLinksCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{GlobalNetworkId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: GlobalNetworkId.");
   }
   const query: any = {};
   if (input.LinkIds !== undefined) {
-    query["linkIds"] = input.LinkIds;
+    query[__extendedEncodeURIComponent("linkIds")] = input.LinkIds.map(entry =>
+      __extendedEncodeURIComponent(entry)
+    );
   }
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   if (input.Provider !== undefined) {
-    query["provider"] = input.Provider.toString();
+    query[
+      __extendedEncodeURIComponent("provider")
+    ] = __extendedEncodeURIComponent(input.Provider);
   }
   if (input.SiteId !== undefined) {
-    query["siteId"] = input.SiteId.toString();
+    query[
+      __extendedEncodeURIComponent("siteId")
+    ] = __extendedEncodeURIComponent(input.SiteId);
   }
   if (input.Type !== undefined) {
-    query["type"] = input.Type.toString();
+    query[__extendedEncodeURIComponent("type")] = __extendedEncodeURIComponent(
+      input.Type
+    );
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -918,7 +969,7 @@ export async function serializeAws_restJson1_1GetSitesCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/global-networks/{GlobalNetworkId}/sites";
   if (input.GlobalNetworkId !== undefined) {
-    const labelValue: string = input.GlobalNetworkId.toString();
+    const labelValue: string = input.GlobalNetworkId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: GlobalNetworkId."
@@ -926,20 +977,26 @@ export async function serializeAws_restJson1_1GetSitesCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{GlobalNetworkId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: GlobalNetworkId.");
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   if (input.SiteIds !== undefined) {
-    query["siteIds"] = input.SiteIds;
+    query[__extendedEncodeURIComponent("siteIds")] = input.SiteIds.map(entry =>
+      __extendedEncodeURIComponent(entry)
+    );
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -960,7 +1017,7 @@ export async function serializeAws_restJson1_1GetTransitGatewayRegistrationsComm
   let resolvedPath =
     "/global-networks/{GlobalNetworkId}/transit-gateway-registrations";
   if (input.GlobalNetworkId !== undefined) {
-    const labelValue: string = input.GlobalNetworkId.toString();
+    const labelValue: string = input.GlobalNetworkId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: GlobalNetworkId."
@@ -968,20 +1025,28 @@ export async function serializeAws_restJson1_1GetTransitGatewayRegistrationsComm
     }
     resolvedPath = resolvedPath.replace(
       "{GlobalNetworkId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: GlobalNetworkId.");
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   if (input.TransitGatewayArns !== undefined) {
-    query["transitGatewayArns"] = input.TransitGatewayArns;
+    query[
+      __extendedEncodeURIComponent("transitGatewayArns")
+    ] = input.TransitGatewayArns.map(entry =>
+      __extendedEncodeURIComponent(entry)
+    );
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1001,7 +1066,7 @@ export async function serializeAws_restJson1_1ListTagsForResourceCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/tags/{ResourceArn}";
   if (input.ResourceArn !== undefined) {
-    const labelValue: string = input.ResourceArn.toString();
+    const labelValue: string = input.ResourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ResourceArn."
@@ -1009,7 +1074,7 @@ export async function serializeAws_restJson1_1ListTagsForResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ResourceArn.");
@@ -1032,7 +1097,7 @@ export async function serializeAws_restJson1_1RegisterTransitGatewayCommand(
   let resolvedPath =
     "/global-networks/{GlobalNetworkId}/transit-gateway-registrations";
   if (input.GlobalNetworkId !== undefined) {
-    const labelValue: string = input.GlobalNetworkId.toString();
+    const labelValue: string = input.GlobalNetworkId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: GlobalNetworkId."
@@ -1040,7 +1105,7 @@ export async function serializeAws_restJson1_1RegisterTransitGatewayCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{GlobalNetworkId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: GlobalNetworkId.");
@@ -1069,7 +1134,7 @@ export async function serializeAws_restJson1_1TagResourceCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/tags/{ResourceArn}";
   if (input.ResourceArn !== undefined) {
-    const labelValue: string = input.ResourceArn.toString();
+    const labelValue: string = input.ResourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ResourceArn."
@@ -1077,7 +1142,7 @@ export async function serializeAws_restJson1_1TagResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ResourceArn.");
@@ -1106,7 +1171,7 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/tags/{ResourceArn}";
   if (input.ResourceArn !== undefined) {
-    const labelValue: string = input.ResourceArn.toString();
+    const labelValue: string = input.ResourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ResourceArn."
@@ -1114,14 +1179,16 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ResourceArn.");
   }
   const query: any = {};
   if (input.TagKeys !== undefined) {
-    query["tagKeys"] = input.TagKeys;
+    query[__extendedEncodeURIComponent("tagKeys")] = input.TagKeys.map(entry =>
+      __extendedEncodeURIComponent(entry)
+    );
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1141,19 +1208,19 @@ export async function serializeAws_restJson1_1UpdateDeviceCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/global-networks/{GlobalNetworkId}/devices/{DeviceId}";
   if (input.DeviceId !== undefined) {
-    const labelValue: string = input.DeviceId.toString();
+    const labelValue: string = input.DeviceId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DeviceId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DeviceId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DeviceId.");
   }
   if (input.GlobalNetworkId !== undefined) {
-    const labelValue: string = input.GlobalNetworkId.toString();
+    const labelValue: string = input.GlobalNetworkId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: GlobalNetworkId."
@@ -1161,7 +1228,7 @@ export async function serializeAws_restJson1_1UpdateDeviceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{GlobalNetworkId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: GlobalNetworkId.");
@@ -1211,7 +1278,7 @@ export async function serializeAws_restJson1_1UpdateGlobalNetworkCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/global-networks/{GlobalNetworkId}";
   if (input.GlobalNetworkId !== undefined) {
-    const labelValue: string = input.GlobalNetworkId.toString();
+    const labelValue: string = input.GlobalNetworkId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: GlobalNetworkId."
@@ -1219,7 +1286,7 @@ export async function serializeAws_restJson1_1UpdateGlobalNetworkCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{GlobalNetworkId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: GlobalNetworkId.");
@@ -1248,7 +1315,7 @@ export async function serializeAws_restJson1_1UpdateLinkCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/global-networks/{GlobalNetworkId}/links/{LinkId}";
   if (input.GlobalNetworkId !== undefined) {
-    const labelValue: string = input.GlobalNetworkId.toString();
+    const labelValue: string = input.GlobalNetworkId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: GlobalNetworkId."
@@ -1256,19 +1323,19 @@ export async function serializeAws_restJson1_1UpdateLinkCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{GlobalNetworkId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: GlobalNetworkId.");
   }
   if (input.LinkId !== undefined) {
-    const labelValue: string = input.LinkId.toString();
+    const labelValue: string = input.LinkId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: LinkId.");
     }
     resolvedPath = resolvedPath.replace(
       "{LinkId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: LinkId.");
@@ -1309,7 +1376,7 @@ export async function serializeAws_restJson1_1UpdateSiteCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/global-networks/{GlobalNetworkId}/sites/{SiteId}";
   if (input.GlobalNetworkId !== undefined) {
-    const labelValue: string = input.GlobalNetworkId.toString();
+    const labelValue: string = input.GlobalNetworkId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: GlobalNetworkId."
@@ -1317,19 +1384,19 @@ export async function serializeAws_restJson1_1UpdateSiteCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{GlobalNetworkId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: GlobalNetworkId.");
   }
   if (input.SiteId !== undefined) {
-    const labelValue: string = input.SiteId.toString();
+    const labelValue: string = input.SiteId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: SiteId.");
     }
     resolvedPath = resolvedPath.replace(
       "{SiteId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: SiteId.");
@@ -3410,6 +3477,7 @@ export async function deserializeAws_restJson1_1TagResourceCommand(
     $metadata: deserializeMetadata(output),
     __type: "TagResourceResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -3500,6 +3568,7 @@ export async function deserializeAws_restJson1_1UntagResourceCommand(
     $metadata: deserializeMetadata(output),
     __type: "UntagResourceResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 

--- a/clients/client-opsworks/models/index.ts
+++ b/clients/client-opsworks/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -19,7 +22,7 @@ export interface AgentVersion {
 
 export namespace AgentVersion {
   export function isa(o: any): o is AgentVersion {
-    return _smithy.isa(o, "AgentVersion");
+    return __isa(o, "AgentVersion");
   }
 }
 
@@ -108,7 +111,7 @@ export interface App {
 
 export namespace App {
   export function isa(o: any): o is App {
-    return _smithy.isa(o, "App");
+    return __isa(o, "App");
   }
 }
 
@@ -144,7 +147,7 @@ export interface AssignInstanceRequest {
 
 export namespace AssignInstanceRequest {
   export function isa(o: any): o is AssignInstanceRequest {
-    return _smithy.isa(o, "AssignInstanceRequest");
+    return __isa(o, "AssignInstanceRequest");
   }
 }
 
@@ -163,7 +166,7 @@ export interface AssignVolumeRequest {
 
 export namespace AssignVolumeRequest {
   export function isa(o: any): o is AssignVolumeRequest {
-    return _smithy.isa(o, "AssignVolumeRequest");
+    return __isa(o, "AssignVolumeRequest");
   }
 }
 
@@ -182,7 +185,7 @@ export interface AssociateElasticIpRequest {
 
 export namespace AssociateElasticIpRequest {
   export function isa(o: any): o is AssociateElasticIpRequest {
-    return _smithy.isa(o, "AssociateElasticIpRequest");
+    return __isa(o, "AssociateElasticIpRequest");
   }
 }
 
@@ -201,7 +204,7 @@ export interface AttachElasticLoadBalancerRequest {
 
 export namespace AttachElasticLoadBalancerRequest {
   export function isa(o: any): o is AttachElasticLoadBalancerRequest {
-    return _smithy.isa(o, "AttachElasticLoadBalancerRequest");
+    return __isa(o, "AttachElasticLoadBalancerRequest");
   }
 }
 
@@ -260,7 +263,7 @@ export interface AutoScalingThresholds {
 
 export namespace AutoScalingThresholds {
   export function isa(o: any): o is AutoScalingThresholds {
-    return _smithy.isa(o, "AutoScalingThresholds");
+    return __isa(o, "AutoScalingThresholds");
   }
 }
 
@@ -297,7 +300,7 @@ export interface BlockDeviceMapping {
 
 export namespace BlockDeviceMapping {
   export function isa(o: any): o is BlockDeviceMapping {
-    return _smithy.isa(o, "BlockDeviceMapping");
+    return __isa(o, "BlockDeviceMapping");
   }
 }
 
@@ -319,7 +322,7 @@ export interface ChefConfiguration {
 
 export namespace ChefConfiguration {
   export function isa(o: any): o is ChefConfiguration {
-    return _smithy.isa(o, "ChefConfiguration");
+    return __isa(o, "ChefConfiguration");
   }
 }
 
@@ -628,7 +631,7 @@ export interface CloneStackRequest {
 
 export namespace CloneStackRequest {
   export function isa(o: any): o is CloneStackRequest {
-    return _smithy.isa(o, "CloneStackRequest");
+    return __isa(o, "CloneStackRequest");
   }
 }
 
@@ -645,7 +648,7 @@ export interface CloneStackResult extends $MetadataBearer {
 
 export namespace CloneStackResult {
   export function isa(o: any): o is CloneStackResult {
-    return _smithy.isa(o, "CloneStackResult");
+    return __isa(o, "CloneStackResult");
   }
 }
 
@@ -667,7 +670,7 @@ export interface CloudWatchLogsConfiguration {
 
 export namespace CloudWatchLogsConfiguration {
   export function isa(o: any): o is CloudWatchLogsConfiguration {
-    return _smithy.isa(o, "CloudWatchLogsConfiguration");
+    return __isa(o, "CloudWatchLogsConfiguration");
   }
 }
 
@@ -847,7 +850,7 @@ export interface CloudWatchLogsLogStream {
 
 export namespace CloudWatchLogsLogStream {
   export function isa(o: any): o is CloudWatchLogsLogStream {
-    return _smithy.isa(o, "CloudWatchLogsLogStream");
+    return __isa(o, "CloudWatchLogsLogStream");
   }
 }
 
@@ -987,7 +990,7 @@ export interface Command {
 
 export namespace Command {
   export function isa(o: any): o is Command {
-    return _smithy.isa(o, "Command");
+    return __isa(o, "Command");
   }
 }
 
@@ -1067,7 +1070,7 @@ export interface CreateAppRequest {
 
 export namespace CreateAppRequest {
   export function isa(o: any): o is CreateAppRequest {
-    return _smithy.isa(o, "CreateAppRequest");
+    return __isa(o, "CreateAppRequest");
   }
 }
 
@@ -1084,7 +1087,7 @@ export interface CreateAppResult extends $MetadataBearer {
 
 export namespace CreateAppResult {
   export function isa(o: any): o is CreateAppResult {
-    return _smithy.isa(o, "CreateAppResult");
+    return __isa(o, "CreateAppResult");
   }
 }
 
@@ -1135,7 +1138,7 @@ export interface CreateDeploymentRequest {
 
 export namespace CreateDeploymentRequest {
   export function isa(o: any): o is CreateDeploymentRequest {
-    return _smithy.isa(o, "CreateDeploymentRequest");
+    return __isa(o, "CreateDeploymentRequest");
   }
 }
 
@@ -1152,7 +1155,7 @@ export interface CreateDeploymentResult extends $MetadataBearer {
 
 export namespace CreateDeploymentResult {
   export function isa(o: any): o is CreateDeploymentResult {
-    return _smithy.isa(o, "CreateDeploymentResult");
+    return __isa(o, "CreateDeploymentResult");
   }
 }
 
@@ -1325,7 +1328,7 @@ export interface CreateInstanceRequest {
 
 export namespace CreateInstanceRequest {
   export function isa(o: any): o is CreateInstanceRequest {
-    return _smithy.isa(o, "CreateInstanceRequest");
+    return __isa(o, "CreateInstanceRequest");
   }
 }
 
@@ -1342,7 +1345,7 @@ export interface CreateInstanceResult extends $MetadataBearer {
 
 export namespace CreateInstanceResult {
   export function isa(o: any): o is CreateInstanceResult {
-    return _smithy.isa(o, "CreateInstanceResult");
+    return __isa(o, "CreateInstanceResult");
   }
 }
 
@@ -1463,7 +1466,7 @@ export interface CreateLayerRequest {
 
 export namespace CreateLayerRequest {
   export function isa(o: any): o is CreateLayerRequest {
-    return _smithy.isa(o, "CreateLayerRequest");
+    return __isa(o, "CreateLayerRequest");
   }
 }
 
@@ -1480,7 +1483,7 @@ export interface CreateLayerResult extends $MetadataBearer {
 
 export namespace CreateLayerResult {
   export function isa(o: any): o is CreateLayerResult {
-    return _smithy.isa(o, "CreateLayerResult");
+    return __isa(o, "CreateLayerResult");
   }
 }
 
@@ -1786,7 +1789,7 @@ export interface CreateStackRequest {
 
 export namespace CreateStackRequest {
   export function isa(o: any): o is CreateStackRequest {
-    return _smithy.isa(o, "CreateStackRequest");
+    return __isa(o, "CreateStackRequest");
   }
 }
 
@@ -1804,7 +1807,7 @@ export interface CreateStackResult extends $MetadataBearer {
 
 export namespace CreateStackResult {
   export function isa(o: any): o is CreateStackResult {
-    return _smithy.isa(o, "CreateStackResult");
+    return __isa(o, "CreateStackResult");
   }
 }
 
@@ -1838,7 +1841,7 @@ export interface CreateUserProfileRequest {
 
 export namespace CreateUserProfileRequest {
   export function isa(o: any): o is CreateUserProfileRequest {
-    return _smithy.isa(o, "CreateUserProfileRequest");
+    return __isa(o, "CreateUserProfileRequest");
   }
 }
 
@@ -1855,7 +1858,7 @@ export interface CreateUserProfileResult extends $MetadataBearer {
 
 export namespace CreateUserProfileResult {
   export function isa(o: any): o is CreateUserProfileResult {
-    return _smithy.isa(o, "CreateUserProfileResult");
+    return __isa(o, "CreateUserProfileResult");
   }
 }
 
@@ -1883,7 +1886,7 @@ export interface DataSource {
 
 export namespace DataSource {
   export function isa(o: any): o is DataSource {
-    return _smithy.isa(o, "DataSource");
+    return __isa(o, "DataSource");
   }
 }
 
@@ -1897,7 +1900,7 @@ export interface DeleteAppRequest {
 
 export namespace DeleteAppRequest {
   export function isa(o: any): o is DeleteAppRequest {
-    return _smithy.isa(o, "DeleteAppRequest");
+    return __isa(o, "DeleteAppRequest");
   }
 }
 
@@ -1921,7 +1924,7 @@ export interface DeleteInstanceRequest {
 
 export namespace DeleteInstanceRequest {
   export function isa(o: any): o is DeleteInstanceRequest {
-    return _smithy.isa(o, "DeleteInstanceRequest");
+    return __isa(o, "DeleteInstanceRequest");
   }
 }
 
@@ -1935,7 +1938,7 @@ export interface DeleteLayerRequest {
 
 export namespace DeleteLayerRequest {
   export function isa(o: any): o is DeleteLayerRequest {
-    return _smithy.isa(o, "DeleteLayerRequest");
+    return __isa(o, "DeleteLayerRequest");
   }
 }
 
@@ -1949,7 +1952,7 @@ export interface DeleteStackRequest {
 
 export namespace DeleteStackRequest {
   export function isa(o: any): o is DeleteStackRequest {
-    return _smithy.isa(o, "DeleteStackRequest");
+    return __isa(o, "DeleteStackRequest");
   }
 }
 
@@ -1963,7 +1966,7 @@ export interface DeleteUserProfileRequest {
 
 export namespace DeleteUserProfileRequest {
   export function isa(o: any): o is DeleteUserProfileRequest {
-    return _smithy.isa(o, "DeleteUserProfileRequest");
+    return __isa(o, "DeleteUserProfileRequest");
   }
 }
 
@@ -2051,7 +2054,7 @@ export interface Deployment {
 
 export namespace Deployment {
   export function isa(o: any): o is Deployment {
-    return _smithy.isa(o, "Deployment");
+    return __isa(o, "Deployment");
   }
 }
 
@@ -2153,7 +2156,7 @@ export interface DeploymentCommand {
 
 export namespace DeploymentCommand {
   export function isa(o: any): o is DeploymentCommand {
-    return _smithy.isa(o, "DeploymentCommand");
+    return __isa(o, "DeploymentCommand");
   }
 }
 
@@ -2181,7 +2184,7 @@ export interface DeregisterEcsClusterRequest {
 
 export namespace DeregisterEcsClusterRequest {
   export function isa(o: any): o is DeregisterEcsClusterRequest {
-    return _smithy.isa(o, "DeregisterEcsClusterRequest");
+    return __isa(o, "DeregisterEcsClusterRequest");
   }
 }
 
@@ -2195,7 +2198,7 @@ export interface DeregisterElasticIpRequest {
 
 export namespace DeregisterElasticIpRequest {
   export function isa(o: any): o is DeregisterElasticIpRequest {
-    return _smithy.isa(o, "DeregisterElasticIpRequest");
+    return __isa(o, "DeregisterElasticIpRequest");
   }
 }
 
@@ -2209,7 +2212,7 @@ export interface DeregisterInstanceRequest {
 
 export namespace DeregisterInstanceRequest {
   export function isa(o: any): o is DeregisterInstanceRequest {
-    return _smithy.isa(o, "DeregisterInstanceRequest");
+    return __isa(o, "DeregisterInstanceRequest");
   }
 }
 
@@ -2223,7 +2226,7 @@ export interface DeregisterRdsDbInstanceRequest {
 
 export namespace DeregisterRdsDbInstanceRequest {
   export function isa(o: any): o is DeregisterRdsDbInstanceRequest {
-    return _smithy.isa(o, "DeregisterRdsDbInstanceRequest");
+    return __isa(o, "DeregisterRdsDbInstanceRequest");
   }
 }
 
@@ -2237,7 +2240,7 @@ export interface DeregisterVolumeRequest {
 
 export namespace DeregisterVolumeRequest {
   export function isa(o: any): o is DeregisterVolumeRequest {
-    return _smithy.isa(o, "DeregisterVolumeRequest");
+    return __isa(o, "DeregisterVolumeRequest");
   }
 }
 
@@ -2256,7 +2259,7 @@ export interface DescribeAgentVersionsRequest {
 
 export namespace DescribeAgentVersionsRequest {
   export function isa(o: any): o is DescribeAgentVersionsRequest {
-    return _smithy.isa(o, "DescribeAgentVersionsRequest");
+    return __isa(o, "DescribeAgentVersionsRequest");
   }
 }
 
@@ -2273,7 +2276,7 @@ export interface DescribeAgentVersionsResult extends $MetadataBearer {
 
 export namespace DescribeAgentVersionsResult {
   export function isa(o: any): o is DescribeAgentVersionsResult {
-    return _smithy.isa(o, "DescribeAgentVersionsResult");
+    return __isa(o, "DescribeAgentVersionsResult");
   }
 }
 
@@ -2295,7 +2298,7 @@ export interface DescribeAppsRequest {
 
 export namespace DescribeAppsRequest {
   export function isa(o: any): o is DescribeAppsRequest {
-    return _smithy.isa(o, "DescribeAppsRequest");
+    return __isa(o, "DescribeAppsRequest");
   }
 }
 
@@ -2312,7 +2315,7 @@ export interface DescribeAppsResult extends $MetadataBearer {
 
 export namespace DescribeAppsResult {
   export function isa(o: any): o is DescribeAppsResult {
-    return _smithy.isa(o, "DescribeAppsResult");
+    return __isa(o, "DescribeAppsResult");
   }
 }
 
@@ -2340,7 +2343,7 @@ export interface DescribeCommandsRequest {
 
 export namespace DescribeCommandsRequest {
   export function isa(o: any): o is DescribeCommandsRequest {
-    return _smithy.isa(o, "DescribeCommandsRequest");
+    return __isa(o, "DescribeCommandsRequest");
   }
 }
 
@@ -2357,7 +2360,7 @@ export interface DescribeCommandsResult extends $MetadataBearer {
 
 export namespace DescribeCommandsResult {
   export function isa(o: any): o is DescribeCommandsResult {
-    return _smithy.isa(o, "DescribeCommandsResult");
+    return __isa(o, "DescribeCommandsResult");
   }
 }
 
@@ -2385,7 +2388,7 @@ export interface DescribeDeploymentsRequest {
 
 export namespace DescribeDeploymentsRequest {
   export function isa(o: any): o is DescribeDeploymentsRequest {
-    return _smithy.isa(o, "DescribeDeploymentsRequest");
+    return __isa(o, "DescribeDeploymentsRequest");
   }
 }
 
@@ -2402,7 +2405,7 @@ export interface DescribeDeploymentsResult extends $MetadataBearer {
 
 export namespace DescribeDeploymentsResult {
   export function isa(o: any): o is DescribeDeploymentsResult {
-    return _smithy.isa(o, "DescribeDeploymentsResult");
+    return __isa(o, "DescribeDeploymentsResult");
   }
 }
 
@@ -2440,7 +2443,7 @@ export interface DescribeEcsClustersRequest {
 
 export namespace DescribeEcsClustersRequest {
   export function isa(o: any): o is DescribeEcsClustersRequest {
-    return _smithy.isa(o, "DescribeEcsClustersRequest");
+    return __isa(o, "DescribeEcsClustersRequest");
   }
 }
 
@@ -2465,7 +2468,7 @@ export interface DescribeEcsClustersResult extends $MetadataBearer {
 
 export namespace DescribeEcsClustersResult {
   export function isa(o: any): o is DescribeEcsClustersResult {
-    return _smithy.isa(o, "DescribeEcsClustersResult");
+    return __isa(o, "DescribeEcsClustersResult");
   }
 }
 
@@ -2493,7 +2496,7 @@ export interface DescribeElasticIpsRequest {
 
 export namespace DescribeElasticIpsRequest {
   export function isa(o: any): o is DescribeElasticIpsRequest {
-    return _smithy.isa(o, "DescribeElasticIpsRequest");
+    return __isa(o, "DescribeElasticIpsRequest");
   }
 }
 
@@ -2510,7 +2513,7 @@ export interface DescribeElasticIpsResult extends $MetadataBearer {
 
 export namespace DescribeElasticIpsResult {
   export function isa(o: any): o is DescribeElasticIpsResult {
-    return _smithy.isa(o, "DescribeElasticIpsResult");
+    return __isa(o, "DescribeElasticIpsResult");
   }
 }
 
@@ -2529,7 +2532,7 @@ export interface DescribeElasticLoadBalancersRequest {
 
 export namespace DescribeElasticLoadBalancersRequest {
   export function isa(o: any): o is DescribeElasticLoadBalancersRequest {
-    return _smithy.isa(o, "DescribeElasticLoadBalancersRequest");
+    return __isa(o, "DescribeElasticLoadBalancersRequest");
   }
 }
 
@@ -2547,7 +2550,7 @@ export interface DescribeElasticLoadBalancersResult extends $MetadataBearer {
 
 export namespace DescribeElasticLoadBalancersResult {
   export function isa(o: any): o is DescribeElasticLoadBalancersResult {
-    return _smithy.isa(o, "DescribeElasticLoadBalancersResult");
+    return __isa(o, "DescribeElasticLoadBalancersResult");
   }
 }
 
@@ -2575,7 +2578,7 @@ export interface DescribeInstancesRequest {
 
 export namespace DescribeInstancesRequest {
   export function isa(o: any): o is DescribeInstancesRequest {
-    return _smithy.isa(o, "DescribeInstancesRequest");
+    return __isa(o, "DescribeInstancesRequest");
   }
 }
 
@@ -2592,7 +2595,7 @@ export interface DescribeInstancesResult extends $MetadataBearer {
 
 export namespace DescribeInstancesResult {
   export function isa(o: any): o is DescribeInstancesResult {
-    return _smithy.isa(o, "DescribeInstancesResult");
+    return __isa(o, "DescribeInstancesResult");
   }
 }
 
@@ -2612,7 +2615,7 @@ export interface DescribeLayersRequest {
 
 export namespace DescribeLayersRequest {
   export function isa(o: any): o is DescribeLayersRequest {
-    return _smithy.isa(o, "DescribeLayersRequest");
+    return __isa(o, "DescribeLayersRequest");
   }
 }
 
@@ -2629,7 +2632,7 @@ export interface DescribeLayersResult extends $MetadataBearer {
 
 export namespace DescribeLayersResult {
   export function isa(o: any): o is DescribeLayersResult {
-    return _smithy.isa(o, "DescribeLayersResult");
+    return __isa(o, "DescribeLayersResult");
   }
 }
 
@@ -2643,7 +2646,7 @@ export interface DescribeLoadBasedAutoScalingRequest {
 
 export namespace DescribeLoadBasedAutoScalingRequest {
   export function isa(o: any): o is DescribeLoadBasedAutoScalingRequest {
-    return _smithy.isa(o, "DescribeLoadBasedAutoScalingRequest");
+    return __isa(o, "DescribeLoadBasedAutoScalingRequest");
   }
 }
 
@@ -2661,7 +2664,7 @@ export interface DescribeLoadBasedAutoScalingResult extends $MetadataBearer {
 
 export namespace DescribeLoadBasedAutoScalingResult {
   export function isa(o: any): o is DescribeLoadBasedAutoScalingResult {
-    return _smithy.isa(o, "DescribeLoadBasedAutoScalingResult");
+    return __isa(o, "DescribeLoadBasedAutoScalingResult");
   }
 }
 
@@ -2678,7 +2681,7 @@ export interface DescribeMyUserProfileResult extends $MetadataBearer {
 
 export namespace DescribeMyUserProfileResult {
   export function isa(o: any): o is DescribeMyUserProfileResult {
-    return _smithy.isa(o, "DescribeMyUserProfileResult");
+    return __isa(o, "DescribeMyUserProfileResult");
   }
 }
 
@@ -2695,7 +2698,7 @@ export interface DescribeOperatingSystemsResponse extends $MetadataBearer {
 
 export namespace DescribeOperatingSystemsResponse {
   export function isa(o: any): o is DescribeOperatingSystemsResponse {
-    return _smithy.isa(o, "DescribeOperatingSystemsResponse");
+    return __isa(o, "DescribeOperatingSystemsResponse");
   }
 }
 
@@ -2715,7 +2718,7 @@ export interface DescribePermissionsRequest {
 
 export namespace DescribePermissionsRequest {
   export function isa(o: any): o is DescribePermissionsRequest {
-    return _smithy.isa(o, "DescribePermissionsRequest");
+    return __isa(o, "DescribePermissionsRequest");
   }
 }
 
@@ -2746,7 +2749,7 @@ export interface DescribePermissionsResult extends $MetadataBearer {
 
 export namespace DescribePermissionsResult {
   export function isa(o: any): o is DescribePermissionsResult {
-    return _smithy.isa(o, "DescribePermissionsResult");
+    return __isa(o, "DescribePermissionsResult");
   }
 }
 
@@ -2773,7 +2776,7 @@ export interface DescribeRaidArraysRequest {
 
 export namespace DescribeRaidArraysRequest {
   export function isa(o: any): o is DescribeRaidArraysRequest {
-    return _smithy.isa(o, "DescribeRaidArraysRequest");
+    return __isa(o, "DescribeRaidArraysRequest");
   }
 }
 
@@ -2790,7 +2793,7 @@ export interface DescribeRaidArraysResult extends $MetadataBearer {
 
 export namespace DescribeRaidArraysResult {
   export function isa(o: any): o is DescribeRaidArraysResult {
-    return _smithy.isa(o, "DescribeRaidArraysResult");
+    return __isa(o, "DescribeRaidArraysResult");
   }
 }
 
@@ -2809,7 +2812,7 @@ export interface DescribeRdsDbInstancesRequest {
 
 export namespace DescribeRdsDbInstancesRequest {
   export function isa(o: any): o is DescribeRdsDbInstancesRequest {
-    return _smithy.isa(o, "DescribeRdsDbInstancesRequest");
+    return __isa(o, "DescribeRdsDbInstancesRequest");
   }
 }
 
@@ -2826,7 +2829,7 @@ export interface DescribeRdsDbInstancesResult extends $MetadataBearer {
 
 export namespace DescribeRdsDbInstancesResult {
   export function isa(o: any): o is DescribeRdsDbInstancesResult {
-    return _smithy.isa(o, "DescribeRdsDbInstancesResult");
+    return __isa(o, "DescribeRdsDbInstancesResult");
   }
 }
 
@@ -2854,7 +2857,7 @@ export interface DescribeServiceErrorsRequest {
 
 export namespace DescribeServiceErrorsRequest {
   export function isa(o: any): o is DescribeServiceErrorsRequest {
-    return _smithy.isa(o, "DescribeServiceErrorsRequest");
+    return __isa(o, "DescribeServiceErrorsRequest");
   }
 }
 
@@ -2871,7 +2874,7 @@ export interface DescribeServiceErrorsResult extends $MetadataBearer {
 
 export namespace DescribeServiceErrorsResult {
   export function isa(o: any): o is DescribeServiceErrorsResult {
-    return _smithy.isa(o, "DescribeServiceErrorsResult");
+    return __isa(o, "DescribeServiceErrorsResult");
   }
 }
 
@@ -2885,7 +2888,7 @@ export interface DescribeStackProvisioningParametersRequest {
 
 export namespace DescribeStackProvisioningParametersRequest {
   export function isa(o: any): o is DescribeStackProvisioningParametersRequest {
-    return _smithy.isa(o, "DescribeStackProvisioningParametersRequest");
+    return __isa(o, "DescribeStackProvisioningParametersRequest");
   }
 }
 
@@ -2908,7 +2911,7 @@ export interface DescribeStackProvisioningParametersResult
 
 export namespace DescribeStackProvisioningParametersResult {
   export function isa(o: any): o is DescribeStackProvisioningParametersResult {
-    return _smithy.isa(o, "DescribeStackProvisioningParametersResult");
+    return __isa(o, "DescribeStackProvisioningParametersResult");
   }
 }
 
@@ -2922,7 +2925,7 @@ export interface DescribeStackSummaryRequest {
 
 export namespace DescribeStackSummaryRequest {
   export function isa(o: any): o is DescribeStackSummaryRequest {
-    return _smithy.isa(o, "DescribeStackSummaryRequest");
+    return __isa(o, "DescribeStackSummaryRequest");
   }
 }
 
@@ -2939,7 +2942,7 @@ export interface DescribeStackSummaryResult extends $MetadataBearer {
 
 export namespace DescribeStackSummaryResult {
   export function isa(o: any): o is DescribeStackSummaryResult {
-    return _smithy.isa(o, "DescribeStackSummaryResult");
+    return __isa(o, "DescribeStackSummaryResult");
   }
 }
 
@@ -2954,7 +2957,7 @@ export interface DescribeStacksRequest {
 
 export namespace DescribeStacksRequest {
   export function isa(o: any): o is DescribeStacksRequest {
-    return _smithy.isa(o, "DescribeStacksRequest");
+    return __isa(o, "DescribeStacksRequest");
   }
 }
 
@@ -2971,7 +2974,7 @@ export interface DescribeStacksResult extends $MetadataBearer {
 
 export namespace DescribeStacksResult {
   export function isa(o: any): o is DescribeStacksResult {
-    return _smithy.isa(o, "DescribeStacksResult");
+    return __isa(o, "DescribeStacksResult");
   }
 }
 
@@ -2985,7 +2988,7 @@ export interface DescribeTimeBasedAutoScalingRequest {
 
 export namespace DescribeTimeBasedAutoScalingRequest {
   export function isa(o: any): o is DescribeTimeBasedAutoScalingRequest {
-    return _smithy.isa(o, "DescribeTimeBasedAutoScalingRequest");
+    return __isa(o, "DescribeTimeBasedAutoScalingRequest");
   }
 }
 
@@ -3003,7 +3006,7 @@ export interface DescribeTimeBasedAutoScalingResult extends $MetadataBearer {
 
 export namespace DescribeTimeBasedAutoScalingResult {
   export function isa(o: any): o is DescribeTimeBasedAutoScalingResult {
-    return _smithy.isa(o, "DescribeTimeBasedAutoScalingResult");
+    return __isa(o, "DescribeTimeBasedAutoScalingResult");
   }
 }
 
@@ -3017,7 +3020,7 @@ export interface DescribeUserProfilesRequest {
 
 export namespace DescribeUserProfilesRequest {
   export function isa(o: any): o is DescribeUserProfilesRequest {
-    return _smithy.isa(o, "DescribeUserProfilesRequest");
+    return __isa(o, "DescribeUserProfilesRequest");
   }
 }
 
@@ -3034,7 +3037,7 @@ export interface DescribeUserProfilesResult extends $MetadataBearer {
 
 export namespace DescribeUserProfilesResult {
   export function isa(o: any): o is DescribeUserProfilesResult {
-    return _smithy.isa(o, "DescribeUserProfilesResult");
+    return __isa(o, "DescribeUserProfilesResult");
   }
 }
 
@@ -3067,7 +3070,7 @@ export interface DescribeVolumesRequest {
 
 export namespace DescribeVolumesRequest {
   export function isa(o: any): o is DescribeVolumesRequest {
-    return _smithy.isa(o, "DescribeVolumesRequest");
+    return __isa(o, "DescribeVolumesRequest");
   }
 }
 
@@ -3084,7 +3087,7 @@ export interface DescribeVolumesResult extends $MetadataBearer {
 
 export namespace DescribeVolumesResult {
   export function isa(o: any): o is DescribeVolumesResult {
-    return _smithy.isa(o, "DescribeVolumesResult");
+    return __isa(o, "DescribeVolumesResult");
   }
 }
 
@@ -3103,7 +3106,7 @@ export interface DetachElasticLoadBalancerRequest {
 
 export namespace DetachElasticLoadBalancerRequest {
   export function isa(o: any): o is DetachElasticLoadBalancerRequest {
-    return _smithy.isa(o, "DetachElasticLoadBalancerRequest");
+    return __isa(o, "DetachElasticLoadBalancerRequest");
   }
 }
 
@@ -3117,7 +3120,7 @@ export interface DisassociateElasticIpRequest {
 
 export namespace DisassociateElasticIpRequest {
   export function isa(o: any): o is DisassociateElasticIpRequest {
-    return _smithy.isa(o, "DisassociateElasticIpRequest");
+    return __isa(o, "DisassociateElasticIpRequest");
   }
 }
 
@@ -3160,7 +3163,7 @@ export interface EbsBlockDevice {
 
 export namespace EbsBlockDevice {
   export function isa(o: any): o is EbsBlockDevice {
-    return _smithy.isa(o, "EbsBlockDevice");
+    return __isa(o, "EbsBlockDevice");
   }
 }
 
@@ -3192,7 +3195,7 @@ export interface EcsCluster {
 
 export namespace EcsCluster {
   export function isa(o: any): o is EcsCluster {
-    return _smithy.isa(o, "EcsCluster");
+    return __isa(o, "EcsCluster");
   }
 }
 
@@ -3229,7 +3232,7 @@ export interface ElasticIp {
 
 export namespace ElasticIp {
   export function isa(o: any): o is ElasticIp {
-    return _smithy.isa(o, "ElasticIp");
+    return __isa(o, "ElasticIp");
   }
 }
 
@@ -3286,7 +3289,7 @@ export interface ElasticLoadBalancer {
 
 export namespace ElasticLoadBalancer {
   export function isa(o: any): o is ElasticLoadBalancer {
-    return _smithy.isa(o, "ElasticLoadBalancer");
+    return __isa(o, "ElasticLoadBalancer");
   }
 }
 
@@ -3316,7 +3319,7 @@ export interface EnvironmentVariable {
 
 export namespace EnvironmentVariable {
   export function isa(o: any): o is EnvironmentVariable {
-    return _smithy.isa(o, "EnvironmentVariable");
+    return __isa(o, "EnvironmentVariable");
   }
 }
 
@@ -3330,7 +3333,7 @@ export interface GetHostnameSuggestionRequest {
 
 export namespace GetHostnameSuggestionRequest {
   export function isa(o: any): o is GetHostnameSuggestionRequest {
-    return _smithy.isa(o, "GetHostnameSuggestionRequest");
+    return __isa(o, "GetHostnameSuggestionRequest");
   }
 }
 
@@ -3352,7 +3355,7 @@ export interface GetHostnameSuggestionResult extends $MetadataBearer {
 
 export namespace GetHostnameSuggestionResult {
   export function isa(o: any): o is GetHostnameSuggestionResult {
-    return _smithy.isa(o, "GetHostnameSuggestionResult");
+    return __isa(o, "GetHostnameSuggestionResult");
   }
 }
 
@@ -3371,7 +3374,7 @@ export interface GrantAccessRequest {
 
 export namespace GrantAccessRequest {
   export function isa(o: any): o is GrantAccessRequest {
-    return _smithy.isa(o, "GrantAccessRequest");
+    return __isa(o, "GrantAccessRequest");
   }
 }
 
@@ -3389,7 +3392,7 @@ export interface GrantAccessResult extends $MetadataBearer {
 
 export namespace GrantAccessResult {
   export function isa(o: any): o is GrantAccessResult {
-    return _smithy.isa(o, "GrantAccessResult");
+    return __isa(o, "GrantAccessResult");
   }
 }
 
@@ -3700,7 +3703,7 @@ export interface Instance {
 
 export namespace Instance {
   export function isa(o: any): o is Instance {
-    return _smithy.isa(o, "Instance");
+    return __isa(o, "Instance");
   }
 }
 
@@ -3723,7 +3726,7 @@ export interface InstanceIdentity {
 
 export namespace InstanceIdentity {
   export function isa(o: any): o is InstanceIdentity {
-    return _smithy.isa(o, "InstanceIdentity");
+    return __isa(o, "InstanceIdentity");
   }
 }
 
@@ -3835,7 +3838,7 @@ export interface InstancesCount {
 
 export namespace InstancesCount {
   export function isa(o: any): o is InstancesCount {
-    return _smithy.isa(o, "InstancesCount");
+    return __isa(o, "InstancesCount");
   }
 }
 
@@ -3989,7 +3992,7 @@ export interface Layer {
 
 export namespace Layer {
   export function isa(o: any): o is Layer {
-    return _smithy.isa(o, "Layer");
+    return __isa(o, "Layer");
   }
 }
 
@@ -4048,7 +4051,7 @@ export interface LifecycleEventConfiguration {
 
 export namespace LifecycleEventConfiguration {
   export function isa(o: any): o is LifecycleEventConfiguration {
-    return _smithy.isa(o, "LifecycleEventConfiguration");
+    return __isa(o, "LifecycleEventConfiguration");
   }
 }
 
@@ -4074,7 +4077,7 @@ export interface ListTagsRequest {
 
 export namespace ListTagsRequest {
   export function isa(o: any): o is ListTagsRequest {
-    return _smithy.isa(o, "ListTagsRequest");
+    return __isa(o, "ListTagsRequest");
   }
 }
 
@@ -4100,7 +4103,7 @@ export interface ListTagsResult extends $MetadataBearer {
 
 export namespace ListTagsResult {
   export function isa(o: any): o is ListTagsResult {
-    return _smithy.isa(o, "ListTagsResult");
+    return __isa(o, "ListTagsResult");
   }
 }
 
@@ -4134,7 +4137,7 @@ export interface LoadBasedAutoScalingConfiguration {
 
 export namespace LoadBasedAutoScalingConfiguration {
   export function isa(o: any): o is LoadBasedAutoScalingConfiguration {
-    return _smithy.isa(o, "LoadBasedAutoScalingConfiguration");
+    return __isa(o, "LoadBasedAutoScalingConfiguration");
   }
 }
 
@@ -4181,7 +4184,7 @@ export interface OperatingSystem {
 
 export namespace OperatingSystem {
   export function isa(o: any): o is OperatingSystem {
-    return _smithy.isa(o, "OperatingSystem");
+    return __isa(o, "OperatingSystem");
   }
 }
 
@@ -4203,7 +4206,7 @@ export interface OperatingSystemConfigurationManager {
 
 export namespace OperatingSystemConfigurationManager {
   export function isa(o: any): o is OperatingSystemConfigurationManager {
-    return _smithy.isa(o, "OperatingSystemConfigurationManager");
+    return __isa(o, "OperatingSystemConfigurationManager");
   }
 }
 
@@ -4271,7 +4274,7 @@ export interface Permission {
 
 export namespace Permission {
   export function isa(o: any): o is Permission {
-    return _smithy.isa(o, "Permission");
+    return __isa(o, "Permission");
   }
 }
 
@@ -4348,7 +4351,7 @@ export interface RaidArray {
 
 export namespace RaidArray {
   export function isa(o: any): o is RaidArray {
-    return _smithy.isa(o, "RaidArray");
+    return __isa(o, "RaidArray");
   }
 }
 
@@ -4407,7 +4410,7 @@ export interface RdsDbInstance {
 
 export namespace RdsDbInstance {
   export function isa(o: any): o is RdsDbInstance {
-    return _smithy.isa(o, "RdsDbInstance");
+    return __isa(o, "RdsDbInstance");
   }
 }
 
@@ -4421,7 +4424,7 @@ export interface RebootInstanceRequest {
 
 export namespace RebootInstanceRequest {
   export function isa(o: any): o is RebootInstanceRequest {
-    return _smithy.isa(o, "RebootInstanceRequest");
+    return __isa(o, "RebootInstanceRequest");
   }
 }
 
@@ -4466,7 +4469,7 @@ export interface Recipes {
 
 export namespace Recipes {
   export function isa(o: any): o is Recipes {
-    return _smithy.isa(o, "Recipes");
+    return __isa(o, "Recipes");
   }
 }
 
@@ -4485,7 +4488,7 @@ export interface RegisterEcsClusterRequest {
 
 export namespace RegisterEcsClusterRequest {
   export function isa(o: any): o is RegisterEcsClusterRequest {
-    return _smithy.isa(o, "RegisterEcsClusterRequest");
+    return __isa(o, "RegisterEcsClusterRequest");
   }
 }
 
@@ -4502,7 +4505,7 @@ export interface RegisterEcsClusterResult extends $MetadataBearer {
 
 export namespace RegisterEcsClusterResult {
   export function isa(o: any): o is RegisterEcsClusterResult {
-    return _smithy.isa(o, "RegisterEcsClusterResult");
+    return __isa(o, "RegisterEcsClusterResult");
   }
 }
 
@@ -4521,7 +4524,7 @@ export interface RegisterElasticIpRequest {
 
 export namespace RegisterElasticIpRequest {
   export function isa(o: any): o is RegisterElasticIpRequest {
-    return _smithy.isa(o, "RegisterElasticIpRequest");
+    return __isa(o, "RegisterElasticIpRequest");
   }
 }
 
@@ -4538,7 +4541,7 @@ export interface RegisterElasticIpResult extends $MetadataBearer {
 
 export namespace RegisterElasticIpResult {
   export function isa(o: any): o is RegisterElasticIpResult {
-    return _smithy.isa(o, "RegisterElasticIpResult");
+    return __isa(o, "RegisterElasticIpResult");
   }
 }
 
@@ -4582,7 +4585,7 @@ export interface RegisterInstanceRequest {
 
 export namespace RegisterInstanceRequest {
   export function isa(o: any): o is RegisterInstanceRequest {
-    return _smithy.isa(o, "RegisterInstanceRequest");
+    return __isa(o, "RegisterInstanceRequest");
   }
 }
 
@@ -4599,7 +4602,7 @@ export interface RegisterInstanceResult extends $MetadataBearer {
 
 export namespace RegisterInstanceResult {
   export function isa(o: any): o is RegisterInstanceResult {
-    return _smithy.isa(o, "RegisterInstanceResult");
+    return __isa(o, "RegisterInstanceResult");
   }
 }
 
@@ -4628,7 +4631,7 @@ export interface RegisterRdsDbInstanceRequest {
 
 export namespace RegisterRdsDbInstanceRequest {
   export function isa(o: any): o is RegisterRdsDbInstanceRequest {
-    return _smithy.isa(o, "RegisterRdsDbInstanceRequest");
+    return __isa(o, "RegisterRdsDbInstanceRequest");
   }
 }
 
@@ -4647,7 +4650,7 @@ export interface RegisterVolumeRequest {
 
 export namespace RegisterVolumeRequest {
   export function isa(o: any): o is RegisterVolumeRequest {
-    return _smithy.isa(o, "RegisterVolumeRequest");
+    return __isa(o, "RegisterVolumeRequest");
   }
 }
 
@@ -4664,7 +4667,7 @@ export interface RegisterVolumeResult extends $MetadataBearer {
 
 export namespace RegisterVolumeResult {
   export function isa(o: any): o is RegisterVolumeResult {
-    return _smithy.isa(o, "RegisterVolumeResult");
+    return __isa(o, "RegisterVolumeResult");
   }
 }
 
@@ -4691,7 +4694,7 @@ export interface ReportedOs {
 
 export namespace ReportedOs {
   export function isa(o: any): o is ReportedOs {
-    return _smithy.isa(o, "ReportedOs");
+    return __isa(o, "ReportedOs");
   }
 }
 
@@ -4699,7 +4702,7 @@ export namespace ReportedOs {
  * <p>Indicates that a resource was not found.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -4711,7 +4714,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -4745,7 +4748,7 @@ export interface SelfUserProfile {
 
 export namespace SelfUserProfile {
   export function isa(o: any): o is SelfUserProfile {
-    return _smithy.isa(o, "SelfUserProfile");
+    return __isa(o, "SelfUserProfile");
   }
 }
 
@@ -4787,7 +4790,7 @@ export interface ServiceError {
 
 export namespace ServiceError {
   export function isa(o: any): o is ServiceError {
-    return _smithy.isa(o, "ServiceError");
+    return __isa(o, "ServiceError");
   }
 }
 
@@ -4820,7 +4823,7 @@ export interface SetLoadBasedAutoScalingRequest {
 
 export namespace SetLoadBasedAutoScalingRequest {
   export function isa(o: any): o is SetLoadBasedAutoScalingRequest {
-    return _smithy.isa(o, "SetLoadBasedAutoScalingRequest");
+    return __isa(o, "SetLoadBasedAutoScalingRequest");
   }
 }
 
@@ -4882,7 +4885,7 @@ export interface SetPermissionRequest {
 
 export namespace SetPermissionRequest {
   export function isa(o: any): o is SetPermissionRequest {
-    return _smithy.isa(o, "SetPermissionRequest");
+    return __isa(o, "SetPermissionRequest");
   }
 }
 
@@ -4901,7 +4904,7 @@ export interface SetTimeBasedAutoScalingRequest {
 
 export namespace SetTimeBasedAutoScalingRequest {
   export function isa(o: any): o is SetTimeBasedAutoScalingRequest {
-    return _smithy.isa(o, "SetTimeBasedAutoScalingRequest");
+    return __isa(o, "SetTimeBasedAutoScalingRequest");
   }
 }
 
@@ -4924,7 +4927,7 @@ export interface ShutdownEventConfiguration {
 
 export namespace ShutdownEventConfiguration {
   export function isa(o: any): o is ShutdownEventConfiguration {
-    return _smithy.isa(o, "ShutdownEventConfiguration");
+    return __isa(o, "ShutdownEventConfiguration");
   }
 }
 
@@ -4991,7 +4994,7 @@ export interface Source {
 
 export namespace Source {
   export function isa(o: any): o is Source {
-    return _smithy.isa(o, "Source");
+    return __isa(o, "Source");
   }
 }
 
@@ -5020,7 +5023,7 @@ export interface SslConfiguration {
 
 export namespace SslConfiguration {
   export function isa(o: any): o is SslConfiguration {
-    return _smithy.isa(o, "SslConfiguration");
+    return __isa(o, "SslConfiguration");
   }
 }
 
@@ -5154,7 +5157,7 @@ export interface Stack {
 
 export namespace Stack {
   export function isa(o: any): o is Stack {
-    return _smithy.isa(o, "Stack");
+    return __isa(o, "Stack");
   }
 }
 
@@ -5178,7 +5181,7 @@ export interface StackConfigurationManager {
 
 export namespace StackConfigurationManager {
   export function isa(o: any): o is StackConfigurationManager {
-    return _smithy.isa(o, "StackConfigurationManager");
+    return __isa(o, "StackConfigurationManager");
   }
 }
 
@@ -5220,7 +5223,7 @@ export interface StackSummary {
 
 export namespace StackSummary {
   export function isa(o: any): o is StackSummary {
-    return _smithy.isa(o, "StackSummary");
+    return __isa(o, "StackSummary");
   }
 }
 
@@ -5234,7 +5237,7 @@ export interface StartInstanceRequest {
 
 export namespace StartInstanceRequest {
   export function isa(o: any): o is StartInstanceRequest {
-    return _smithy.isa(o, "StartInstanceRequest");
+    return __isa(o, "StartInstanceRequest");
   }
 }
 
@@ -5248,7 +5251,7 @@ export interface StartStackRequest {
 
 export namespace StartStackRequest {
   export function isa(o: any): o is StartStackRequest {
-    return _smithy.isa(o, "StartStackRequest");
+    return __isa(o, "StartStackRequest");
   }
 }
 
@@ -5269,7 +5272,7 @@ export interface StopInstanceRequest {
 
 export namespace StopInstanceRequest {
   export function isa(o: any): o is StopInstanceRequest {
-    return _smithy.isa(o, "StopInstanceRequest");
+    return __isa(o, "StopInstanceRequest");
   }
 }
 
@@ -5283,7 +5286,7 @@ export interface StopStackRequest {
 
 export namespace StopStackRequest {
   export function isa(o: any): o is StopStackRequest {
-    return _smithy.isa(o, "StopStackRequest");
+    return __isa(o, "StopStackRequest");
   }
 }
 
@@ -5321,7 +5324,7 @@ export interface TagResourceRequest {
 
 export namespace TagResourceRequest {
   export function isa(o: any): o is TagResourceRequest {
-    return _smithy.isa(o, "TagResourceRequest");
+    return __isa(o, "TagResourceRequest");
   }
 }
 
@@ -5353,7 +5356,7 @@ export interface TemporaryCredential {
 
 export namespace TemporaryCredential {
   export function isa(o: any): o is TemporaryCredential {
-    return _smithy.isa(o, "TemporaryCredential");
+    return __isa(o, "TemporaryCredential");
   }
 }
 
@@ -5375,7 +5378,7 @@ export interface TimeBasedAutoScalingConfiguration {
 
 export namespace TimeBasedAutoScalingConfiguration {
   export function isa(o: any): o is TimeBasedAutoScalingConfiguration {
-    return _smithy.isa(o, "TimeBasedAutoScalingConfiguration");
+    return __isa(o, "TimeBasedAutoScalingConfiguration");
   }
 }
 
@@ -5389,7 +5392,7 @@ export interface UnassignInstanceRequest {
 
 export namespace UnassignInstanceRequest {
   export function isa(o: any): o is UnassignInstanceRequest {
-    return _smithy.isa(o, "UnassignInstanceRequest");
+    return __isa(o, "UnassignInstanceRequest");
   }
 }
 
@@ -5403,7 +5406,7 @@ export interface UnassignVolumeRequest {
 
 export namespace UnassignVolumeRequest {
   export function isa(o: any): o is UnassignVolumeRequest {
-    return _smithy.isa(o, "UnassignVolumeRequest");
+    return __isa(o, "UnassignVolumeRequest");
   }
 }
 
@@ -5422,7 +5425,7 @@ export interface UntagResourceRequest {
 
 export namespace UntagResourceRequest {
   export function isa(o: any): o is UntagResourceRequest {
-    return _smithy.isa(o, "UntagResourceRequest");
+    return __isa(o, "UntagResourceRequest");
   }
 }
 
@@ -5494,7 +5497,7 @@ export interface UpdateAppRequest {
 
 export namespace UpdateAppRequest {
   export function isa(o: any): o is UpdateAppRequest {
-    return _smithy.isa(o, "UpdateAppRequest");
+    return __isa(o, "UpdateAppRequest");
   }
 }
 
@@ -5513,7 +5516,7 @@ export interface UpdateElasticIpRequest {
 
 export namespace UpdateElasticIpRequest {
   export function isa(o: any): o is UpdateElasticIpRequest {
-    return _smithy.isa(o, "UpdateElasticIpRequest");
+    return __isa(o, "UpdateElasticIpRequest");
   }
 }
 
@@ -5650,7 +5653,7 @@ export interface UpdateInstanceRequest {
 
 export namespace UpdateInstanceRequest {
   export function isa(o: any): o is UpdateInstanceRequest {
-    return _smithy.isa(o, "UpdateInstanceRequest");
+    return __isa(o, "UpdateInstanceRequest");
   }
 }
 
@@ -5765,7 +5768,7 @@ export interface UpdateLayerRequest {
 
 export namespace UpdateLayerRequest {
   export function isa(o: any): o is UpdateLayerRequest {
-    return _smithy.isa(o, "UpdateLayerRequest");
+    return __isa(o, "UpdateLayerRequest");
   }
 }
 
@@ -5779,7 +5782,7 @@ export interface UpdateMyUserProfileRequest {
 
 export namespace UpdateMyUserProfileRequest {
   export function isa(o: any): o is UpdateMyUserProfileRequest {
-    return _smithy.isa(o, "UpdateMyUserProfileRequest");
+    return __isa(o, "UpdateMyUserProfileRequest");
   }
 }
 
@@ -5803,7 +5806,7 @@ export interface UpdateRdsDbInstanceRequest {
 
 export namespace UpdateRdsDbInstanceRequest {
   export function isa(o: any): o is UpdateRdsDbInstanceRequest {
-    return _smithy.isa(o, "UpdateRdsDbInstanceRequest");
+    return __isa(o, "UpdateRdsDbInstanceRequest");
   }
 }
 
@@ -6053,7 +6056,7 @@ export interface UpdateStackRequest {
 
 export namespace UpdateStackRequest {
   export function isa(o: any): o is UpdateStackRequest {
-    return _smithy.isa(o, "UpdateStackRequest");
+    return __isa(o, "UpdateStackRequest");
   }
 }
 
@@ -6087,7 +6090,7 @@ export interface UpdateUserProfileRequest {
 
 export namespace UpdateUserProfileRequest {
   export function isa(o: any): o is UpdateUserProfileRequest {
-    return _smithy.isa(o, "UpdateUserProfileRequest");
+    return __isa(o, "UpdateUserProfileRequest");
   }
 }
 
@@ -6111,7 +6114,7 @@ export interface UpdateVolumeRequest {
 
 export namespace UpdateVolumeRequest {
   export function isa(o: any): o is UpdateVolumeRequest {
-    return _smithy.isa(o, "UpdateVolumeRequest");
+    return __isa(o, "UpdateVolumeRequest");
   }
 }
 
@@ -6150,7 +6153,7 @@ export interface UserProfile {
 
 export namespace UserProfile {
   export function isa(o: any): o is UserProfile {
-    return _smithy.isa(o, "UserProfile");
+    return __isa(o, "UserProfile");
   }
 }
 
@@ -6158,7 +6161,7 @@ export namespace UserProfile {
  * <p>Indicates that a request was not valid.</p>
  */
 export interface ValidationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ValidationException";
   $fault: "client";
@@ -6170,7 +6173,7 @@ export interface ValidationException
 
 export namespace ValidationException {
   export function isa(o: any): o is ValidationException {
-    return _smithy.isa(o, "ValidationException");
+    return __isa(o, "ValidationException");
   }
 }
 
@@ -6278,7 +6281,7 @@ export interface Volume {
 
 export namespace Volume {
   export function isa(o: any): o is Volume {
-    return _smithy.isa(o, "Volume");
+    return __isa(o, "Volume");
   }
 }
 
@@ -6349,7 +6352,7 @@ export interface VolumeConfiguration {
 
 export namespace VolumeConfiguration {
   export function isa(o: any): o is VolumeConfiguration {
-    return _smithy.isa(o, "VolumeConfiguration");
+    return __isa(o, "VolumeConfiguration");
   }
 }
 
@@ -6411,6 +6414,6 @@ export interface WeeklyAutoScalingSchedule {
 
 export namespace WeeklyAutoScalingSchedule {
   export function isa(o: any): o is WeeklyAutoScalingSchedule {
-    return _smithy.isa(o, "WeeklyAutoScalingSchedule");
+    return __isa(o, "WeeklyAutoScalingSchedule");
   }
 }

--- a/clients/client-opsworks/protocols/Aws_json1_1.ts
+++ b/clients/client-opsworks/protocols/Aws_json1_1.ts
@@ -1471,6 +1471,7 @@ export async function deserializeAws_json1_1AssignInstanceCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1AssignInstanceCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: AssignInstanceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1529,6 +1530,7 @@ export async function deserializeAws_json1_1AssignVolumeCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1AssignVolumeCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: AssignVolumeCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1590,6 +1592,7 @@ export async function deserializeAws_json1_1AssociateElasticIpCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: AssociateElasticIpCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1651,6 +1654,7 @@ export async function deserializeAws_json1_1AttachElasticLoadBalancerCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: AttachElasticLoadBalancerCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2136,6 +2140,7 @@ export async function deserializeAws_json1_1DeleteAppCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1DeleteAppCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteAppCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2194,6 +2199,7 @@ export async function deserializeAws_json1_1DeleteInstanceCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1DeleteInstanceCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteInstanceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2252,6 +2258,7 @@ export async function deserializeAws_json1_1DeleteLayerCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1DeleteLayerCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteLayerCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2310,6 +2317,7 @@ export async function deserializeAws_json1_1DeleteStackCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1DeleteStackCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteStackCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2368,6 +2376,7 @@ export async function deserializeAws_json1_1DeleteUserProfileCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1DeleteUserProfileCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteUserProfileCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2429,6 +2438,7 @@ export async function deserializeAws_json1_1DeregisterEcsClusterCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeregisterEcsClusterCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2490,6 +2500,7 @@ export async function deserializeAws_json1_1DeregisterElasticIpCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeregisterElasticIpCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2551,6 +2562,7 @@ export async function deserializeAws_json1_1DeregisterInstanceCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeregisterInstanceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2612,6 +2624,7 @@ export async function deserializeAws_json1_1DeregisterRdsDbInstanceCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeregisterRdsDbInstanceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2670,6 +2683,7 @@ export async function deserializeAws_json1_1DeregisterVolumeCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1DeregisterVolumeCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeregisterVolumeCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -4152,6 +4166,7 @@ export async function deserializeAws_json1_1DetachElasticLoadBalancerCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DetachElasticLoadBalancerCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -4206,6 +4221,7 @@ export async function deserializeAws_json1_1DisassociateElasticIpCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DisassociateElasticIpCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -4456,6 +4472,7 @@ export async function deserializeAws_json1_1RebootInstanceCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1RebootInstanceCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: RebootInstanceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -4709,6 +4726,7 @@ export async function deserializeAws_json1_1RegisterRdsDbInstanceCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: RegisterRdsDbInstanceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -4833,6 +4851,7 @@ export async function deserializeAws_json1_1SetLoadBasedAutoScalingCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: SetLoadBasedAutoScalingCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -4891,6 +4910,7 @@ export async function deserializeAws_json1_1SetPermissionCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1SetPermissionCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: SetPermissionCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -4952,6 +4972,7 @@ export async function deserializeAws_json1_1SetTimeBasedAutoScalingCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: SetTimeBasedAutoScalingCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -5010,6 +5031,7 @@ export async function deserializeAws_json1_1StartInstanceCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1StartInstanceCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: StartInstanceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -5068,6 +5090,7 @@ export async function deserializeAws_json1_1StartStackCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1StartStackCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: StartStackCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -5126,6 +5149,7 @@ export async function deserializeAws_json1_1StopInstanceCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1StopInstanceCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: StopInstanceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -5184,6 +5208,7 @@ export async function deserializeAws_json1_1StopStackCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1StopStackCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: StopStackCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -5242,6 +5267,7 @@ export async function deserializeAws_json1_1TagResourceCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1TagResourceCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: TagResourceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -5300,6 +5326,7 @@ export async function deserializeAws_json1_1UnassignInstanceCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1UnassignInstanceCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: UnassignInstanceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -5358,6 +5385,7 @@ export async function deserializeAws_json1_1UnassignVolumeCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1UnassignVolumeCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: UnassignVolumeCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -5416,6 +5444,7 @@ export async function deserializeAws_json1_1UntagResourceCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1UntagResourceCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: UntagResourceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -5474,6 +5503,7 @@ export async function deserializeAws_json1_1UpdateAppCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1UpdateAppCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: UpdateAppCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -5532,6 +5562,7 @@ export async function deserializeAws_json1_1UpdateElasticIpCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1UpdateElasticIpCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: UpdateElasticIpCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -5590,6 +5621,7 @@ export async function deserializeAws_json1_1UpdateInstanceCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1UpdateInstanceCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: UpdateInstanceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -5648,6 +5680,7 @@ export async function deserializeAws_json1_1UpdateLayerCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1UpdateLayerCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: UpdateLayerCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -5709,6 +5742,7 @@ export async function deserializeAws_json1_1UpdateMyUserProfileCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: UpdateMyUserProfileCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -5763,6 +5797,7 @@ export async function deserializeAws_json1_1UpdateRdsDbInstanceCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: UpdateRdsDbInstanceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -5821,6 +5856,7 @@ export async function deserializeAws_json1_1UpdateStackCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1UpdateStackCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: UpdateStackCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -5879,6 +5915,7 @@ export async function deserializeAws_json1_1UpdateUserProfileCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1UpdateUserProfileCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: UpdateUserProfileCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -5937,6 +5974,7 @@ export async function deserializeAws_json1_1UpdateVolumeCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1UpdateVolumeCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: UpdateVolumeCommandOutput = {
     $metadata: deserializeMetadata(output)
   };

--- a/clients/client-opsworkscm/models/index.ts
+++ b/clients/client-opsworkscm/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -44,7 +47,7 @@ export interface AccountAttribute {
 
 export namespace AccountAttribute {
   export function isa(o: any): o is AccountAttribute {
-    return _smithy.isa(o, "AccountAttribute");
+    return __isa(o, "AccountAttribute");
   }
 }
 
@@ -98,7 +101,7 @@ export interface AssociateNodeRequest {
 
 export namespace AssociateNodeRequest {
   export function isa(o: any): o is AssociateNodeRequest {
-    return _smithy.isa(o, "AssociateNodeRequest");
+    return __isa(o, "AssociateNodeRequest");
   }
 }
 
@@ -113,7 +116,7 @@ export interface AssociateNodeResponse extends $MetadataBearer {
 
 export namespace AssociateNodeResponse {
   export function isa(o: any): o is AssociateNodeResponse {
-    return _smithy.isa(o, "AssociateNodeResponse");
+    return __isa(o, "AssociateNodeResponse");
   }
 }
 
@@ -293,7 +296,7 @@ export interface Backup {
 
 export namespace Backup {
   export function isa(o: any): o is Backup {
-    return _smithy.isa(o, "Backup");
+    return __isa(o, "Backup");
   }
 }
 
@@ -351,7 +354,7 @@ export interface CreateBackupRequest {
 
 export namespace CreateBackupRequest {
   export function isa(o: any): o is CreateBackupRequest {
-    return _smithy.isa(o, "CreateBackupRequest");
+    return __isa(o, "CreateBackupRequest");
   }
 }
 
@@ -365,7 +368,7 @@ export interface CreateBackupResponse extends $MetadataBearer {
 
 export namespace CreateBackupResponse {
   export function isa(o: any): o is CreateBackupResponse {
-    return _smithy.isa(o, "CreateBackupResponse");
+    return __isa(o, "CreateBackupResponse");
   }
 }
 
@@ -644,7 +647,7 @@ export interface CreateServerRequest {
 
 export namespace CreateServerRequest {
   export function isa(o: any): o is CreateServerRequest {
-    return _smithy.isa(o, "CreateServerRequest");
+    return __isa(o, "CreateServerRequest");
   }
 }
 
@@ -659,7 +662,7 @@ export interface CreateServerResponse extends $MetadataBearer {
 
 export namespace CreateServerResponse {
   export function isa(o: any): o is CreateServerResponse {
-    return _smithy.isa(o, "CreateServerResponse");
+    return __isa(o, "CreateServerResponse");
   }
 }
 
@@ -675,7 +678,7 @@ export interface DeleteBackupRequest {
 
 export namespace DeleteBackupRequest {
   export function isa(o: any): o is DeleteBackupRequest {
-    return _smithy.isa(o, "DeleteBackupRequest");
+    return __isa(o, "DeleteBackupRequest");
   }
 }
 
@@ -685,7 +688,7 @@ export interface DeleteBackupResponse extends $MetadataBearer {
 
 export namespace DeleteBackupResponse {
   export function isa(o: any): o is DeleteBackupResponse {
-    return _smithy.isa(o, "DeleteBackupResponse");
+    return __isa(o, "DeleteBackupResponse");
   }
 }
 
@@ -699,7 +702,7 @@ export interface DeleteServerRequest {
 
 export namespace DeleteServerRequest {
   export function isa(o: any): o is DeleteServerRequest {
-    return _smithy.isa(o, "DeleteServerRequest");
+    return __isa(o, "DeleteServerRequest");
   }
 }
 
@@ -709,7 +712,7 @@ export interface DeleteServerResponse extends $MetadataBearer {
 
 export namespace DeleteServerResponse {
   export function isa(o: any): o is DeleteServerResponse {
-    return _smithy.isa(o, "DeleteServerResponse");
+    return __isa(o, "DeleteServerResponse");
   }
 }
 
@@ -719,7 +722,7 @@ export interface DescribeAccountAttributesRequest {
 
 export namespace DescribeAccountAttributesRequest {
   export function isa(o: any): o is DescribeAccountAttributesRequest {
-    return _smithy.isa(o, "DescribeAccountAttributesRequest");
+    return __isa(o, "DescribeAccountAttributesRequest");
   }
 }
 
@@ -735,7 +738,7 @@ export interface DescribeAccountAttributesResponse extends $MetadataBearer {
 
 export namespace DescribeAccountAttributesResponse {
   export function isa(o: any): o is DescribeAccountAttributesResponse {
-    return _smithy.isa(o, "DescribeAccountAttributesResponse");
+    return __isa(o, "DescribeAccountAttributesResponse");
   }
 }
 
@@ -766,7 +769,7 @@ export interface DescribeBackupsRequest {
 
 export namespace DescribeBackupsRequest {
   export function isa(o: any): o is DescribeBackupsRequest {
-    return _smithy.isa(o, "DescribeBackupsRequest");
+    return __isa(o, "DescribeBackupsRequest");
   }
 }
 
@@ -786,7 +789,7 @@ export interface DescribeBackupsResponse extends $MetadataBearer {
 
 export namespace DescribeBackupsResponse {
   export function isa(o: any): o is DescribeBackupsResponse {
-    return _smithy.isa(o, "DescribeBackupsResponse");
+    return __isa(o, "DescribeBackupsResponse");
   }
 }
 
@@ -821,7 +824,7 @@ export interface DescribeEventsRequest {
 
 export namespace DescribeEventsRequest {
   export function isa(o: any): o is DescribeEventsRequest {
-    return _smithy.isa(o, "DescribeEventsRequest");
+    return __isa(o, "DescribeEventsRequest");
   }
 }
 
@@ -848,7 +851,7 @@ export interface DescribeEventsResponse extends $MetadataBearer {
 
 export namespace DescribeEventsResponse {
   export function isa(o: any): o is DescribeEventsResponse {
-    return _smithy.isa(o, "DescribeEventsResponse");
+    return __isa(o, "DescribeEventsResponse");
   }
 }
 
@@ -869,7 +872,7 @@ export interface DescribeNodeAssociationStatusRequest {
 
 export namespace DescribeNodeAssociationStatusRequest {
   export function isa(o: any): o is DescribeNodeAssociationStatusRequest {
-    return _smithy.isa(o, "DescribeNodeAssociationStatusRequest");
+    return __isa(o, "DescribeNodeAssociationStatusRequest");
   }
 }
 
@@ -911,7 +914,7 @@ export interface DescribeNodeAssociationStatusResponse extends $MetadataBearer {
 
 export namespace DescribeNodeAssociationStatusResponse {
   export function isa(o: any): o is DescribeNodeAssociationStatusResponse {
-    return _smithy.isa(o, "DescribeNodeAssociationStatusResponse");
+    return __isa(o, "DescribeNodeAssociationStatusResponse");
   }
 }
 
@@ -937,7 +940,7 @@ export interface DescribeServersRequest {
 
 export namespace DescribeServersRequest {
   export function isa(o: any): o is DescribeServersRequest {
-    return _smithy.isa(o, "DescribeServersRequest");
+    return __isa(o, "DescribeServersRequest");
   }
 }
 
@@ -963,7 +966,7 @@ export interface DescribeServersResponse extends $MetadataBearer {
 
 export namespace DescribeServersResponse {
   export function isa(o: any): o is DescribeServersResponse {
-    return _smithy.isa(o, "DescribeServersResponse");
+    return __isa(o, "DescribeServersResponse");
   }
 }
 
@@ -1002,7 +1005,7 @@ export interface DisassociateNodeRequest {
 
 export namespace DisassociateNodeRequest {
   export function isa(o: any): o is DisassociateNodeRequest {
-    return _smithy.isa(o, "DisassociateNodeRequest");
+    return __isa(o, "DisassociateNodeRequest");
   }
 }
 
@@ -1019,7 +1022,7 @@ export interface DisassociateNodeResponse extends $MetadataBearer {
 
 export namespace DisassociateNodeResponse {
   export function isa(o: any): o is DisassociateNodeResponse {
-    return _smithy.isa(o, "DisassociateNodeResponse");
+    return __isa(o, "DisassociateNodeResponse");
   }
 }
 
@@ -1044,7 +1047,7 @@ export interface EngineAttribute {
 
 export namespace EngineAttribute {
   export function isa(o: any): o is EngineAttribute {
-    return _smithy.isa(o, "EngineAttribute");
+    return __isa(o, "EngineAttribute");
   }
 }
 
@@ -1094,7 +1097,7 @@ export interface ExportServerEngineAttributeRequest {
 
 export namespace ExportServerEngineAttributeRequest {
   export function isa(o: any): o is ExportServerEngineAttributeRequest {
-    return _smithy.isa(o, "ExportServerEngineAttributeRequest");
+    return __isa(o, "ExportServerEngineAttributeRequest");
   }
 }
 
@@ -1113,7 +1116,7 @@ export interface ExportServerEngineAttributeResponse extends $MetadataBearer {
 
 export namespace ExportServerEngineAttributeResponse {
   export function isa(o: any): o is ExportServerEngineAttributeResponse {
-    return _smithy.isa(o, "ExportServerEngineAttributeResponse");
+    return __isa(o, "ExportServerEngineAttributeResponse");
   }
 }
 
@@ -1122,7 +1125,7 @@ export namespace ExportServerEngineAttributeResponse {
  *     </p>
  */
 export interface InvalidNextTokenException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidNextTokenException";
   $fault: "client";
@@ -1135,7 +1138,7 @@ export interface InvalidNextTokenException
 
 export namespace InvalidNextTokenException {
   export function isa(o: any): o is InvalidNextTokenException {
-    return _smithy.isa(o, "InvalidNextTokenException");
+    return __isa(o, "InvalidNextTokenException");
   }
 }
 
@@ -1144,7 +1147,7 @@ export namespace InvalidNextTokenException {
  *     </p>
  */
 export interface InvalidStateException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidStateException";
   $fault: "client";
@@ -1158,7 +1161,7 @@ export interface InvalidStateException
 
 export namespace InvalidStateException {
   export function isa(o: any): o is InvalidStateException {
-    return _smithy.isa(o, "InvalidStateException");
+    return __isa(o, "InvalidStateException");
   }
 }
 
@@ -1167,7 +1170,7 @@ export namespace InvalidStateException {
  *     </p>
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -1180,7 +1183,7 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
@@ -1214,7 +1217,7 @@ export interface ListTagsForResourceRequest {
 
 export namespace ListTagsForResourceRequest {
   export function isa(o: any): o is ListTagsForResourceRequest {
-    return _smithy.isa(o, "ListTagsForResourceRequest");
+    return __isa(o, "ListTagsForResourceRequest");
   }
 }
 
@@ -1233,7 +1236,7 @@ export interface ListTagsForResourceResponse extends $MetadataBearer {
 
 export namespace ListTagsForResourceResponse {
   export function isa(o: any): o is ListTagsForResourceResponse {
-    return _smithy.isa(o, "ListTagsForResourceResponse");
+    return __isa(o, "ListTagsForResourceResponse");
   }
 }
 
@@ -1253,7 +1256,7 @@ export enum NodeAssociationStatus {
  *     </p>
  */
 export interface ResourceAlreadyExistsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceAlreadyExistsException";
   $fault: "client";
@@ -1266,7 +1269,7 @@ export interface ResourceAlreadyExistsException
 
 export namespace ResourceAlreadyExistsException {
   export function isa(o: any): o is ResourceAlreadyExistsException {
-    return _smithy.isa(o, "ResourceAlreadyExistsException");
+    return __isa(o, "ResourceAlreadyExistsException");
   }
 }
 
@@ -1275,7 +1278,7 @@ export namespace ResourceAlreadyExistsException {
  *     </p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -1288,7 +1291,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -1324,7 +1327,7 @@ export interface RestoreServerRequest {
 
 export namespace RestoreServerRequest {
   export function isa(o: any): o is RestoreServerRequest {
-    return _smithy.isa(o, "RestoreServerRequest");
+    return __isa(o, "RestoreServerRequest");
   }
 }
 
@@ -1334,7 +1337,7 @@ export interface RestoreServerResponse extends $MetadataBearer {
 
 export namespace RestoreServerResponse {
   export function isa(o: any): o is RestoreServerResponse {
-    return _smithy.isa(o, "RestoreServerResponse");
+    return __isa(o, "RestoreServerResponse");
   }
 }
 
@@ -1538,7 +1541,7 @@ export interface Server {
 
 export namespace Server {
   export function isa(o: any): o is Server {
-    return _smithy.isa(o, "Server");
+    return __isa(o, "Server");
   }
 }
 
@@ -1573,7 +1576,7 @@ export interface ServerEvent {
 
 export namespace ServerEvent {
   export function isa(o: any): o is ServerEvent {
-    return _smithy.isa(o, "ServerEvent");
+    return __isa(o, "ServerEvent");
   }
 }
 
@@ -1609,7 +1612,7 @@ export interface StartMaintenanceRequest {
 
 export namespace StartMaintenanceRequest {
   export function isa(o: any): o is StartMaintenanceRequest {
-    return _smithy.isa(o, "StartMaintenanceRequest");
+    return __isa(o, "StartMaintenanceRequest");
   }
 }
 
@@ -1624,7 +1627,7 @@ export interface StartMaintenanceResponse extends $MetadataBearer {
 
 export namespace StartMaintenanceResponse {
   export function isa(o: any): o is StartMaintenanceResponse {
-    return _smithy.isa(o, "StartMaintenanceResponse");
+    return __isa(o, "StartMaintenanceResponse");
   }
 }
 
@@ -1652,7 +1655,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -1691,7 +1694,7 @@ export interface TagResourceRequest {
 
 export namespace TagResourceRequest {
   export function isa(o: any): o is TagResourceRequest {
-    return _smithy.isa(o, "TagResourceRequest");
+    return __isa(o, "TagResourceRequest");
   }
 }
 
@@ -1701,7 +1704,7 @@ export interface TagResourceResponse extends $MetadataBearer {
 
 export namespace TagResourceResponse {
   export function isa(o: any): o is TagResourceResponse {
-    return _smithy.isa(o, "TagResourceResponse");
+    return __isa(o, "TagResourceResponse");
   }
 }
 
@@ -1721,7 +1724,7 @@ export interface UntagResourceRequest {
 
 export namespace UntagResourceRequest {
   export function isa(o: any): o is UntagResourceRequest {
-    return _smithy.isa(o, "UntagResourceRequest");
+    return __isa(o, "UntagResourceRequest");
   }
 }
 
@@ -1731,7 +1734,7 @@ export interface UntagResourceResponse extends $MetadataBearer {
 
 export namespace UntagResourceResponse {
   export function isa(o: any): o is UntagResourceResponse {
-    return _smithy.isa(o, "UntagResourceResponse");
+    return __isa(o, "UntagResourceResponse");
   }
 }
 
@@ -1758,7 +1761,7 @@ export interface UpdateServerEngineAttributesRequest {
 
 export namespace UpdateServerEngineAttributesRequest {
   export function isa(o: any): o is UpdateServerEngineAttributesRequest {
-    return _smithy.isa(o, "UpdateServerEngineAttributesRequest");
+    return __isa(o, "UpdateServerEngineAttributesRequest");
   }
 }
 
@@ -1773,7 +1776,7 @@ export interface UpdateServerEngineAttributesResponse extends $MetadataBearer {
 
 export namespace UpdateServerEngineAttributesResponse {
   export function isa(o: any): o is UpdateServerEngineAttributesResponse {
-    return _smithy.isa(o, "UpdateServerEngineAttributesResponse");
+    return __isa(o, "UpdateServerEngineAttributesResponse");
   }
 }
 
@@ -1822,7 +1825,7 @@ export interface UpdateServerRequest {
 
 export namespace UpdateServerRequest {
   export function isa(o: any): o is UpdateServerRequest {
-    return _smithy.isa(o, "UpdateServerRequest");
+    return __isa(o, "UpdateServerRequest");
   }
 }
 
@@ -1837,7 +1840,7 @@ export interface UpdateServerResponse extends $MetadataBearer {
 
 export namespace UpdateServerResponse {
   export function isa(o: any): o is UpdateServerResponse {
-    return _smithy.isa(o, "UpdateServerResponse");
+    return __isa(o, "UpdateServerResponse");
   }
 }
 
@@ -1846,7 +1849,7 @@ export namespace UpdateServerResponse {
  *     </p>
  */
 export interface ValidationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ValidationException";
   $fault: "client";
@@ -1859,6 +1862,6 @@ export interface ValidationException
 
 export namespace ValidationException {
   export function isa(o: any): o is ValidationException {
-    return _smithy.isa(o, "ValidationException");
+    return __isa(o, "ValidationException");
   }
 }

--- a/clients/client-organizations/models/index.ts
+++ b/clients/client-organizations/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -6,7 +9,7 @@ import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
  *       credentials of an account that belongs to an organization.</p>
  */
 export interface AWSOrganizationsNotInUseException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AWSOrganizationsNotInUseException";
   $fault: "client";
@@ -15,7 +18,7 @@ export interface AWSOrganizationsNotInUseException
 
 export namespace AWSOrganizationsNotInUseException {
   export function isa(o: any): o is AWSOrganizationsNotInUseException {
-    return _smithy.isa(o, "AWSOrganizationsNotInUseException");
+    return __isa(o, "AWSOrganizationsNotInUseException");
   }
 }
 
@@ -31,7 +34,7 @@ export interface AcceptHandshakeRequest {
 
 export namespace AcceptHandshakeRequest {
   export function isa(o: any): o is AcceptHandshakeRequest {
-    return _smithy.isa(o, "AcceptHandshakeRequest");
+    return __isa(o, "AcceptHandshakeRequest");
   }
 }
 
@@ -45,7 +48,7 @@ export interface AcceptHandshakeResponse extends $MetadataBearer {
 
 export namespace AcceptHandshakeResponse {
   export function isa(o: any): o is AcceptHandshakeResponse {
-    return _smithy.isa(o, "AcceptHandshakeResponse");
+    return __isa(o, "AcceptHandshakeResponse");
   }
 }
 
@@ -57,7 +60,7 @@ export namespace AcceptHandshakeResponse {
  *          </p>
  */
 export interface AccessDeniedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AccessDeniedException";
   $fault: "client";
@@ -66,7 +69,7 @@ export interface AccessDeniedException
 
 export namespace AccessDeniedException {
   export function isa(o: any): o is AccessDeniedException {
-    return _smithy.isa(o, "AccessDeniedException");
+    return __isa(o, "AccessDeniedException");
   }
 }
 
@@ -77,7 +80,7 @@ export namespace AccessDeniedException {
  *       permission.</p>
  */
 export interface AccessDeniedForDependencyException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AccessDeniedForDependencyException";
   $fault: "client";
@@ -87,7 +90,7 @@ export interface AccessDeniedForDependencyException
 
 export namespace AccessDeniedForDependencyException {
   export function isa(o: any): o is AccessDeniedForDependencyException {
-    return _smithy.isa(o, "AccessDeniedForDependencyException");
+    return __isa(o, "AccessDeniedForDependencyException");
   }
 }
 
@@ -147,7 +150,7 @@ export interface Account {
 
 export namespace Account {
   export function isa(o: any): o is Account {
-    return _smithy.isa(o, "Account");
+    return __isa(o, "Account");
   }
 }
 
@@ -162,7 +165,7 @@ export enum AccountJoinedMethod {
  *       organization.</p>
  */
 export interface AccountNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AccountNotFoundException";
   $fault: "client";
@@ -171,7 +174,7 @@ export interface AccountNotFoundException
 
 export namespace AccountNotFoundException {
   export function isa(o: any): o is AccountNotFoundException {
-    return _smithy.isa(o, "AccountNotFoundException");
+    return __isa(o, "AccountNotFoundException");
   }
 }
 
@@ -182,7 +185,7 @@ export namespace AccountNotFoundException {
  *          </p>
  */
 export interface AccountOwnerNotVerifiedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AccountOwnerNotVerifiedException";
   $fault: "client";
@@ -191,7 +194,7 @@ export interface AccountOwnerNotVerifiedException
 
 export namespace AccountOwnerNotVerifiedException {
   export function isa(o: any): o is AccountOwnerNotVerifiedException {
-    return _smithy.isa(o, "AccountOwnerNotVerifiedException");
+    return __isa(o, "AccountOwnerNotVerifiedException");
   }
 }
 
@@ -212,7 +215,7 @@ export enum ActionType {
  *       organization at a time.</p>
  */
 export interface AlreadyInOrganizationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AlreadyInOrganizationException";
   $fault: "client";
@@ -221,7 +224,7 @@ export interface AlreadyInOrganizationException
 
 export namespace AlreadyInOrganizationException {
   export function isa(o: any): o is AlreadyInOrganizationException {
-    return _smithy.isa(o, "AlreadyInOrganizationException");
+    return __isa(o, "AlreadyInOrganizationException");
   }
 }
 
@@ -264,7 +267,7 @@ export interface AttachPolicyRequest {
 
 export namespace AttachPolicyRequest {
   export function isa(o: any): o is AttachPolicyRequest {
-    return _smithy.isa(o, "AttachPolicyRequest");
+    return __isa(o, "AttachPolicyRequest");
   }
 }
 
@@ -281,7 +284,7 @@ export interface CancelHandshakeRequest {
 
 export namespace CancelHandshakeRequest {
   export function isa(o: any): o is CancelHandshakeRequest {
-    return _smithy.isa(o, "CancelHandshakeRequest");
+    return __isa(o, "CancelHandshakeRequest");
   }
 }
 
@@ -295,7 +298,7 @@ export interface CancelHandshakeResponse extends $MetadataBearer {
 
 export namespace CancelHandshakeResponse {
   export function isa(o: any): o is CancelHandshakeResponse {
-    return _smithy.isa(o, "CancelHandshakeResponse");
+    return __isa(o, "CancelHandshakeResponse");
   }
 }
 
@@ -329,7 +332,7 @@ export interface Child {
 
 export namespace Child {
   export function isa(o: any): o is Child {
-    return _smithy.isa(o, "Child");
+    return __isa(o, "Child");
   }
 }
 
@@ -338,7 +341,7 @@ export namespace Child {
  *       that you specified.</p>
  */
 export interface ChildNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ChildNotFoundException";
   $fault: "client";
@@ -347,7 +350,7 @@ export interface ChildNotFoundException
 
 export namespace ChildNotFoundException {
   export function isa(o: any): o is ChildNotFoundException {
-    return _smithy.isa(o, "ChildNotFoundException");
+    return __isa(o, "ChildNotFoundException");
   }
 }
 
@@ -361,7 +364,7 @@ export enum ChildType {
  *       later.</p>
  */
 export interface ConcurrentModificationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ConcurrentModificationException";
   $fault: "client";
@@ -370,7 +373,7 @@ export interface ConcurrentModificationException
 
 export namespace ConcurrentModificationException {
   export function isa(o: any): o is ConcurrentModificationException {
-    return _smithy.isa(o, "ConcurrentModificationException");
+    return __isa(o, "ConcurrentModificationException");
   }
 }
 
@@ -499,7 +502,7 @@ export namespace ConcurrentModificationException {
  *          </ul>
  */
 export interface ConstraintViolationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ConstraintViolationException";
   $fault: "client";
@@ -509,7 +512,7 @@ export interface ConstraintViolationException
 
 export namespace ConstraintViolationException {
   export function isa(o: any): o is ConstraintViolationException {
-    return _smithy.isa(o, "ConstraintViolationException");
+    return __isa(o, "ConstraintViolationException");
   }
 }
 
@@ -598,7 +601,7 @@ export interface CreateAccountRequest {
 
 export namespace CreateAccountRequest {
   export function isa(o: any): o is CreateAccountRequest {
-    return _smithy.isa(o, "CreateAccountRequest");
+    return __isa(o, "CreateAccountRequest");
   }
 }
 
@@ -618,7 +621,7 @@ export interface CreateAccountResponse extends $MetadataBearer {
 
 export namespace CreateAccountResponse {
   export function isa(o: any): o is CreateAccountResponse {
-    return _smithy.isa(o, "CreateAccountResponse");
+    return __isa(o, "CreateAccountResponse");
   }
 }
 
@@ -710,7 +713,7 @@ export interface CreateAccountStatus {
 
 export namespace CreateAccountStatus {
   export function isa(o: any): o is CreateAccountStatus {
-    return _smithy.isa(o, "CreateAccountStatus");
+    return __isa(o, "CreateAccountStatus");
   }
 }
 
@@ -719,7 +722,7 @@ export namespace CreateAccountStatus {
  *       you specified.</p>
  */
 export interface CreateAccountStatusNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CreateAccountStatusNotFoundException";
   $fault: "client";
@@ -728,7 +731,7 @@ export interface CreateAccountStatusNotFoundException
 
 export namespace CreateAccountStatusNotFoundException {
   export function isa(o: any): o is CreateAccountStatusNotFoundException {
-    return _smithy.isa(o, "CreateAccountStatusNotFoundException");
+    return __isa(o, "CreateAccountStatusNotFoundException");
   }
 }
 
@@ -787,7 +790,7 @@ export interface CreateGovCloudAccountRequest {
 
 export namespace CreateGovCloudAccountRequest {
   export function isa(o: any): o is CreateGovCloudAccountRequest {
-    return _smithy.isa(o, "CreateGovCloudAccountRequest");
+    return __isa(o, "CreateGovCloudAccountRequest");
   }
 }
 
@@ -802,7 +805,7 @@ export interface CreateGovCloudAccountResponse extends $MetadataBearer {
 
 export namespace CreateGovCloudAccountResponse {
   export function isa(o: any): o is CreateGovCloudAccountResponse {
-    return _smithy.isa(o, "CreateGovCloudAccountResponse");
+    return __isa(o, "CreateGovCloudAccountResponse");
   }
 }
 
@@ -836,7 +839,7 @@ export interface CreateOrganizationRequest {
 
 export namespace CreateOrganizationRequest {
   export function isa(o: any): o is CreateOrganizationRequest {
-    return _smithy.isa(o, "CreateOrganizationRequest");
+    return __isa(o, "CreateOrganizationRequest");
   }
 }
 
@@ -850,7 +853,7 @@ export interface CreateOrganizationResponse extends $MetadataBearer {
 
 export namespace CreateOrganizationResponse {
   export function isa(o: any): o is CreateOrganizationResponse {
-    return _smithy.isa(o, "CreateOrganizationResponse");
+    return __isa(o, "CreateOrganizationResponse");
   }
 }
 
@@ -885,7 +888,7 @@ export interface CreateOrganizationalUnitRequest {
 
 export namespace CreateOrganizationalUnitRequest {
   export function isa(o: any): o is CreateOrganizationalUnitRequest {
-    return _smithy.isa(o, "CreateOrganizationalUnitRequest");
+    return __isa(o, "CreateOrganizationalUnitRequest");
   }
 }
 
@@ -899,7 +902,7 @@ export interface CreateOrganizationalUnitResponse extends $MetadataBearer {
 
 export namespace CreateOrganizationalUnitResponse {
   export function isa(o: any): o is CreateOrganizationalUnitResponse {
-    return _smithy.isa(o, "CreateOrganizationalUnitResponse");
+    return __isa(o, "CreateOrganizationalUnitResponse");
   }
 }
 
@@ -936,7 +939,7 @@ export interface CreatePolicyRequest {
 
 export namespace CreatePolicyRequest {
   export function isa(o: any): o is CreatePolicyRequest {
-    return _smithy.isa(o, "CreatePolicyRequest");
+    return __isa(o, "CreatePolicyRequest");
   }
 }
 
@@ -950,7 +953,7 @@ export interface CreatePolicyResponse extends $MetadataBearer {
 
 export namespace CreatePolicyResponse {
   export function isa(o: any): o is CreatePolicyResponse {
-    return _smithy.isa(o, "CreatePolicyResponse");
+    return __isa(o, "CreatePolicyResponse");
   }
 }
 
@@ -967,7 +970,7 @@ export interface DeclineHandshakeRequest {
 
 export namespace DeclineHandshakeRequest {
   export function isa(o: any): o is DeclineHandshakeRequest {
-    return _smithy.isa(o, "DeclineHandshakeRequest");
+    return __isa(o, "DeclineHandshakeRequest");
   }
 }
 
@@ -982,7 +985,7 @@ export interface DeclineHandshakeResponse extends $MetadataBearer {
 
 export namespace DeclineHandshakeResponse {
   export function isa(o: any): o is DeclineHandshakeResponse {
-    return _smithy.isa(o, "DeclineHandshakeResponse");
+    return __isa(o, "DeclineHandshakeResponse");
   }
 }
 
@@ -1001,7 +1004,7 @@ export interface DeleteOrganizationalUnitRequest {
 
 export namespace DeleteOrganizationalUnitRequest {
   export function isa(o: any): o is DeleteOrganizationalUnitRequest {
-    return _smithy.isa(o, "DeleteOrganizationalUnitRequest");
+    return __isa(o, "DeleteOrganizationalUnitRequest");
   }
 }
 
@@ -1019,7 +1022,7 @@ export interface DeletePolicyRequest {
 
 export namespace DeletePolicyRequest {
   export function isa(o: any): o is DeletePolicyRequest {
-    return _smithy.isa(o, "DeletePolicyRequest");
+    return __isa(o, "DeletePolicyRequest");
   }
 }
 
@@ -1037,7 +1040,7 @@ export interface DescribeAccountRequest {
 
 export namespace DescribeAccountRequest {
   export function isa(o: any): o is DescribeAccountRequest {
-    return _smithy.isa(o, "DescribeAccountRequest");
+    return __isa(o, "DescribeAccountRequest");
   }
 }
 
@@ -1051,7 +1054,7 @@ export interface DescribeAccountResponse extends $MetadataBearer {
 
 export namespace DescribeAccountResponse {
   export function isa(o: any): o is DescribeAccountResponse {
-    return _smithy.isa(o, "DescribeAccountResponse");
+    return __isa(o, "DescribeAccountResponse");
   }
 }
 
@@ -1069,7 +1072,7 @@ export interface DescribeCreateAccountStatusRequest {
 
 export namespace DescribeCreateAccountStatusRequest {
   export function isa(o: any): o is DescribeCreateAccountStatusRequest {
-    return _smithy.isa(o, "DescribeCreateAccountStatusRequest");
+    return __isa(o, "DescribeCreateAccountStatusRequest");
   }
 }
 
@@ -1083,7 +1086,7 @@ export interface DescribeCreateAccountStatusResponse extends $MetadataBearer {
 
 export namespace DescribeCreateAccountStatusResponse {
   export function isa(o: any): o is DescribeCreateAccountStatusResponse {
-    return _smithy.isa(o, "DescribeCreateAccountStatusResponse");
+    return __isa(o, "DescribeCreateAccountStatusResponse");
   }
 }
 
@@ -1103,7 +1106,7 @@ export interface DescribeEffectivePolicyRequest {
 
 export namespace DescribeEffectivePolicyRequest {
   export function isa(o: any): o is DescribeEffectivePolicyRequest {
-    return _smithy.isa(o, "DescribeEffectivePolicyRequest");
+    return __isa(o, "DescribeEffectivePolicyRequest");
   }
 }
 
@@ -1117,7 +1120,7 @@ export interface DescribeEffectivePolicyResponse extends $MetadataBearer {
 
 export namespace DescribeEffectivePolicyResponse {
   export function isa(o: any): o is DescribeEffectivePolicyResponse {
-    return _smithy.isa(o, "DescribeEffectivePolicyResponse");
+    return __isa(o, "DescribeEffectivePolicyResponse");
   }
 }
 
@@ -1135,7 +1138,7 @@ export interface DescribeHandshakeRequest {
 
 export namespace DescribeHandshakeRequest {
   export function isa(o: any): o is DescribeHandshakeRequest {
-    return _smithy.isa(o, "DescribeHandshakeRequest");
+    return __isa(o, "DescribeHandshakeRequest");
   }
 }
 
@@ -1149,7 +1152,7 @@ export interface DescribeHandshakeResponse extends $MetadataBearer {
 
 export namespace DescribeHandshakeResponse {
   export function isa(o: any): o is DescribeHandshakeResponse {
-    return _smithy.isa(o, "DescribeHandshakeResponse");
+    return __isa(o, "DescribeHandshakeResponse");
   }
 }
 
@@ -1163,7 +1166,7 @@ export interface DescribeOrganizationResponse extends $MetadataBearer {
 
 export namespace DescribeOrganizationResponse {
   export function isa(o: any): o is DescribeOrganizationResponse {
-    return _smithy.isa(o, "DescribeOrganizationResponse");
+    return __isa(o, "DescribeOrganizationResponse");
   }
 }
 
@@ -1182,7 +1185,7 @@ export interface DescribeOrganizationalUnitRequest {
 
 export namespace DescribeOrganizationalUnitRequest {
   export function isa(o: any): o is DescribeOrganizationalUnitRequest {
-    return _smithy.isa(o, "DescribeOrganizationalUnitRequest");
+    return __isa(o, "DescribeOrganizationalUnitRequest");
   }
 }
 
@@ -1196,7 +1199,7 @@ export interface DescribeOrganizationalUnitResponse extends $MetadataBearer {
 
 export namespace DescribeOrganizationalUnitResponse {
   export function isa(o: any): o is DescribeOrganizationalUnitResponse {
-    return _smithy.isa(o, "DescribeOrganizationalUnitResponse");
+    return __isa(o, "DescribeOrganizationalUnitResponse");
   }
 }
 
@@ -1214,7 +1217,7 @@ export interface DescribePolicyRequest {
 
 export namespace DescribePolicyRequest {
   export function isa(o: any): o is DescribePolicyRequest {
-    return _smithy.isa(o, "DescribePolicyRequest");
+    return __isa(o, "DescribePolicyRequest");
   }
 }
 
@@ -1228,7 +1231,7 @@ export interface DescribePolicyResponse extends $MetadataBearer {
 
 export namespace DescribePolicyResponse {
   export function isa(o: any): o is DescribePolicyResponse {
-    return _smithy.isa(o, "DescribePolicyResponse");
+    return __isa(o, "DescribePolicyResponse");
   }
 }
 
@@ -1237,7 +1240,7 @@ export namespace DescribePolicyResponse {
  *       you specified.</p>
  */
 export interface DestinationParentNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DestinationParentNotFoundException";
   $fault: "client";
@@ -1246,7 +1249,7 @@ export interface DestinationParentNotFoundException
 
 export namespace DestinationParentNotFoundException {
   export function isa(o: any): o is DestinationParentNotFoundException {
-    return _smithy.isa(o, "DestinationParentNotFoundException");
+    return __isa(o, "DestinationParentNotFoundException");
   }
 }
 
@@ -1289,7 +1292,7 @@ export interface DetachPolicyRequest {
 
 export namespace DetachPolicyRequest {
   export function isa(o: any): o is DetachPolicyRequest {
-    return _smithy.isa(o, "DetachPolicyRequest");
+    return __isa(o, "DetachPolicyRequest");
   }
 }
 
@@ -1306,7 +1309,7 @@ export interface DisableAWSServiceAccessRequest {
 
 export namespace DisableAWSServiceAccessRequest {
   export function isa(o: any): o is DisableAWSServiceAccessRequest {
-    return _smithy.isa(o, "DisableAWSServiceAccessRequest");
+    return __isa(o, "DisableAWSServiceAccessRequest");
   }
 }
 
@@ -1328,7 +1331,7 @@ export interface DisablePolicyTypeRequest {
 
 export namespace DisablePolicyTypeRequest {
   export function isa(o: any): o is DisablePolicyTypeRequest {
-    return _smithy.isa(o, "DisablePolicyTypeRequest");
+    return __isa(o, "DisablePolicyTypeRequest");
   }
 }
 
@@ -1342,7 +1345,7 @@ export interface DisablePolicyTypeResponse extends $MetadataBearer {
 
 export namespace DisablePolicyTypeResponse {
   export function isa(o: any): o is DisablePolicyTypeResponse {
-    return _smithy.isa(o, "DisablePolicyTypeResponse");
+    return __isa(o, "DisablePolicyTypeResponse");
   }
 }
 
@@ -1350,7 +1353,7 @@ export namespace DisablePolicyTypeResponse {
  * <p>That account is already present in the specified destination.</p>
  */
 export interface DuplicateAccountException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DuplicateAccountException";
   $fault: "client";
@@ -1359,7 +1362,7 @@ export interface DuplicateAccountException
 
 export namespace DuplicateAccountException {
   export function isa(o: any): o is DuplicateAccountException {
-    return _smithy.isa(o, "DuplicateAccountException");
+    return __isa(o, "DuplicateAccountException");
   }
 }
 
@@ -1370,7 +1373,7 @@ export namespace DuplicateAccountException {
  *       existing handshakes that might be considered duplicates are canceled or declined.</p>
  */
 export interface DuplicateHandshakeException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DuplicateHandshakeException";
   $fault: "client";
@@ -1379,7 +1382,7 @@ export interface DuplicateHandshakeException
 
 export namespace DuplicateHandshakeException {
   export function isa(o: any): o is DuplicateHandshakeException {
-    return _smithy.isa(o, "DuplicateHandshakeException");
+    return __isa(o, "DuplicateHandshakeException");
   }
 }
 
@@ -1387,7 +1390,7 @@ export namespace DuplicateHandshakeException {
  * <p>An OU with the same name already exists.</p>
  */
 export interface DuplicateOrganizationalUnitException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DuplicateOrganizationalUnitException";
   $fault: "client";
@@ -1396,7 +1399,7 @@ export interface DuplicateOrganizationalUnitException
 
 export namespace DuplicateOrganizationalUnitException {
   export function isa(o: any): o is DuplicateOrganizationalUnitException {
-    return _smithy.isa(o, "DuplicateOrganizationalUnitException");
+    return __isa(o, "DuplicateOrganizationalUnitException");
   }
 }
 
@@ -1404,7 +1407,7 @@ export namespace DuplicateOrganizationalUnitException {
  * <p>The selected policy is already attached to the specified target.</p>
  */
 export interface DuplicatePolicyAttachmentException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DuplicatePolicyAttachmentException";
   $fault: "client";
@@ -1413,7 +1416,7 @@ export interface DuplicatePolicyAttachmentException
 
 export namespace DuplicatePolicyAttachmentException {
   export function isa(o: any): o is DuplicatePolicyAttachmentException {
-    return _smithy.isa(o, "DuplicatePolicyAttachmentException");
+    return __isa(o, "DuplicatePolicyAttachmentException");
   }
 }
 
@@ -1421,7 +1424,7 @@ export namespace DuplicatePolicyAttachmentException {
  * <p>A policy with the same name already exists.</p>
  */
 export interface DuplicatePolicyException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DuplicatePolicyException";
   $fault: "client";
@@ -1430,7 +1433,7 @@ export interface DuplicatePolicyException
 
 export namespace DuplicatePolicyException {
   export function isa(o: any): o is DuplicatePolicyException {
-    return _smithy.isa(o, "DuplicatePolicyException");
+    return __isa(o, "DuplicatePolicyException");
   }
 }
 
@@ -1464,7 +1467,7 @@ export interface EffectivePolicy {
 
 export namespace EffectivePolicy {
   export function isa(o: any): o is EffectivePolicy {
-    return _smithy.isa(o, "EffectivePolicy");
+    return __isa(o, "EffectivePolicy");
   }
 }
 
@@ -1475,7 +1478,7 @@ export namespace EffectivePolicy {
  *       account. </p>
  */
 export interface EffectivePolicyNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "EffectivePolicyNotFoundException";
   $fault: "client";
@@ -1484,7 +1487,7 @@ export interface EffectivePolicyNotFoundException
 
 export namespace EffectivePolicyNotFoundException {
   export function isa(o: any): o is EffectivePolicyNotFoundException {
-    return _smithy.isa(o, "EffectivePolicyNotFoundException");
+    return __isa(o, "EffectivePolicyNotFoundException");
   }
 }
 
@@ -1505,7 +1508,7 @@ export interface EnableAWSServiceAccessRequest {
 
 export namespace EnableAWSServiceAccessRequest {
   export function isa(o: any): o is EnableAWSServiceAccessRequest {
-    return _smithy.isa(o, "EnableAWSServiceAccessRequest");
+    return __isa(o, "EnableAWSServiceAccessRequest");
   }
 }
 
@@ -1515,7 +1518,7 @@ export interface EnableAllFeaturesRequest {
 
 export namespace EnableAllFeaturesRequest {
   export function isa(o: any): o is EnableAllFeaturesRequest {
-    return _smithy.isa(o, "EnableAllFeaturesRequest");
+    return __isa(o, "EnableAllFeaturesRequest");
   }
 }
 
@@ -1530,7 +1533,7 @@ export interface EnableAllFeaturesResponse extends $MetadataBearer {
 
 export namespace EnableAllFeaturesResponse {
   export function isa(o: any): o is EnableAllFeaturesResponse {
-    return _smithy.isa(o, "EnableAllFeaturesResponse");
+    return __isa(o, "EnableAllFeaturesResponse");
   }
 }
 
@@ -1552,7 +1555,7 @@ export interface EnablePolicyTypeRequest {
 
 export namespace EnablePolicyTypeRequest {
   export function isa(o: any): o is EnablePolicyTypeRequest {
-    return _smithy.isa(o, "EnablePolicyTypeRequest");
+    return __isa(o, "EnablePolicyTypeRequest");
   }
 }
 
@@ -1566,7 +1569,7 @@ export interface EnablePolicyTypeResponse extends $MetadataBearer {
 
 export namespace EnablePolicyTypeResponse {
   export function isa(o: any): o is EnablePolicyTypeResponse {
-    return _smithy.isa(o, "EnablePolicyTypeResponse");
+    return __isa(o, "EnablePolicyTypeResponse");
   }
 }
 
@@ -1591,7 +1594,7 @@ export interface EnabledServicePrincipal {
 
 export namespace EnabledServicePrincipal {
   export function isa(o: any): o is EnabledServicePrincipal {
-    return _smithy.isa(o, "EnabledServicePrincipal");
+    return __isa(o, "EnabledServicePrincipal");
   }
 }
 
@@ -1602,7 +1605,7 @@ export namespace EnabledServicePrincipal {
  *       Support</a>.</p>
  */
 export interface FinalizingOrganizationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "FinalizingOrganizationException";
   $fault: "client";
@@ -1611,7 +1614,7 @@ export interface FinalizingOrganizationException
 
 export namespace FinalizingOrganizationException {
   export function isa(o: any): o is FinalizingOrganizationException {
-    return _smithy.isa(o, "FinalizingOrganizationException");
+    return __isa(o, "FinalizingOrganizationException");
   }
 }
 
@@ -1739,7 +1742,7 @@ export interface Handshake {
 
 export namespace Handshake {
   export function isa(o: any): o is Handshake {
-    return _smithy.isa(o, "Handshake");
+    return __isa(o, "Handshake");
   }
 }
 
@@ -1748,7 +1751,7 @@ export namespace Handshake {
  *       handshake that was already accepted.</p>
  */
 export interface HandshakeAlreadyInStateException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "HandshakeAlreadyInStateException";
   $fault: "client";
@@ -1757,7 +1760,7 @@ export interface HandshakeAlreadyInStateException
 
 export namespace HandshakeAlreadyInStateException {
   export function isa(o: any): o is HandshakeAlreadyInStateException {
-    return _smithy.isa(o, "HandshakeAlreadyInStateException");
+    return __isa(o, "HandshakeAlreadyInStateException");
   }
 }
 
@@ -1812,7 +1815,7 @@ export namespace HandshakeAlreadyInStateException {
  *          </ul>
  */
 export interface HandshakeConstraintViolationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "HandshakeConstraintViolationException";
   $fault: "client";
@@ -1822,7 +1825,7 @@ export interface HandshakeConstraintViolationException
 
 export namespace HandshakeConstraintViolationException {
   export function isa(o: any): o is HandshakeConstraintViolationException {
-    return _smithy.isa(o, "HandshakeConstraintViolationException");
+    return __isa(o, "HandshakeConstraintViolationException");
   }
 }
 
@@ -1862,7 +1865,7 @@ export interface HandshakeFilter {
 
 export namespace HandshakeFilter {
   export function isa(o: any): o is HandshakeFilter {
-    return _smithy.isa(o, "HandshakeFilter");
+    return __isa(o, "HandshakeFilter");
   }
 }
 
@@ -1870,7 +1873,7 @@ export namespace HandshakeFilter {
  * <p>We can't find a handshake with the <code>HandshakeId</code> that you specified.</p>
  */
 export interface HandshakeNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "HandshakeNotFoundException";
   $fault: "client";
@@ -1879,7 +1882,7 @@ export interface HandshakeNotFoundException
 
 export namespace HandshakeNotFoundException {
   export function isa(o: any): o is HandshakeNotFoundException {
-    return _smithy.isa(o, "HandshakeNotFoundException");
+    return __isa(o, "HandshakeNotFoundException");
   }
 }
 
@@ -1903,7 +1906,7 @@ export interface HandshakeParty {
 
 export namespace HandshakeParty {
   export function isa(o: any): o is HandshakeParty {
-    return _smithy.isa(o, "HandshakeParty");
+    return __isa(o, "HandshakeParty");
   }
 }
 
@@ -1969,7 +1972,7 @@ export interface HandshakeResource {
 
 export namespace HandshakeResource {
   export function isa(o: any): o is HandshakeResource {
-    return _smithy.isa(o, "HandshakeResource");
+    return __isa(o, "HandshakeResource");
   }
 }
 
@@ -2004,7 +2007,7 @@ export enum IAMUserAccessToBilling {
  *       declined.</p>
  */
 export interface InvalidHandshakeTransitionException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidHandshakeTransitionException";
   $fault: "client";
@@ -2013,7 +2016,7 @@ export interface InvalidHandshakeTransitionException
 
 export namespace InvalidHandshakeTransitionException {
   export function isa(o: any): o is InvalidHandshakeTransitionException {
-    return _smithy.isa(o, "InvalidHandshakeTransitionException");
+    return __isa(o, "InvalidHandshakeTransitionException");
   }
 }
 
@@ -2105,7 +2108,7 @@ export namespace InvalidHandshakeTransitionException {
  *          </ul>
  */
 export interface InvalidInputException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidInputException";
   $fault: "client";
@@ -2115,7 +2118,7 @@ export interface InvalidInputException
 
 export namespace InvalidInputException {
   export function isa(o: any): o is InvalidInputException {
-    return _smithy.isa(o, "InvalidInputException");
+    return __isa(o, "InvalidInputException");
   }
 }
 
@@ -2178,7 +2181,7 @@ export interface InviteAccountToOrganizationRequest {
 
 export namespace InviteAccountToOrganizationRequest {
   export function isa(o: any): o is InviteAccountToOrganizationRequest {
-    return _smithy.isa(o, "InviteAccountToOrganizationRequest");
+    return __isa(o, "InviteAccountToOrganizationRequest");
   }
 }
 
@@ -2193,7 +2196,7 @@ export interface InviteAccountToOrganizationResponse extends $MetadataBearer {
 
 export namespace InviteAccountToOrganizationResponse {
   export function isa(o: any): o is InviteAccountToOrganizationResponse {
-    return _smithy.isa(o, "InviteAccountToOrganizationResponse");
+    return __isa(o, "InviteAccountToOrganizationResponse");
   }
 }
 
@@ -2222,7 +2225,7 @@ export interface ListAWSServiceAccessForOrganizationRequest {
 
 export namespace ListAWSServiceAccessForOrganizationRequest {
   export function isa(o: any): o is ListAWSServiceAccessForOrganizationRequest {
-    return _smithy.isa(o, "ListAWSServiceAccessForOrganizationRequest");
+    return __isa(o, "ListAWSServiceAccessForOrganizationRequest");
   }
 }
 
@@ -2250,7 +2253,7 @@ export namespace ListAWSServiceAccessForOrganizationResponse {
   export function isa(
     o: any
   ): o is ListAWSServiceAccessForOrganizationResponse {
-    return _smithy.isa(o, "ListAWSServiceAccessForOrganizationResponse");
+    return __isa(o, "ListAWSServiceAccessForOrganizationResponse");
   }
 }
 
@@ -2285,7 +2288,7 @@ export interface ListAccountsForParentRequest {
 
 export namespace ListAccountsForParentRequest {
   export function isa(o: any): o is ListAccountsForParentRequest {
-    return _smithy.isa(o, "ListAccountsForParentRequest");
+    return __isa(o, "ListAccountsForParentRequest");
   }
 }
 
@@ -2308,7 +2311,7 @@ export interface ListAccountsForParentResponse extends $MetadataBearer {
 
 export namespace ListAccountsForParentResponse {
   export function isa(o: any): o is ListAccountsForParentResponse {
-    return _smithy.isa(o, "ListAccountsForParentResponse");
+    return __isa(o, "ListAccountsForParentResponse");
   }
 }
 
@@ -2337,7 +2340,7 @@ export interface ListAccountsRequest {
 
 export namespace ListAccountsRequest {
   export function isa(o: any): o is ListAccountsRequest {
-    return _smithy.isa(o, "ListAccountsRequest");
+    return __isa(o, "ListAccountsRequest");
   }
 }
 
@@ -2360,7 +2363,7 @@ export interface ListAccountsResponse extends $MetadataBearer {
 
 export namespace ListAccountsResponse {
   export function isa(o: any): o is ListAccountsResponse {
-    return _smithy.isa(o, "ListAccountsResponse");
+    return __isa(o, "ListAccountsResponse");
   }
 }
 
@@ -2415,7 +2418,7 @@ export interface ListChildrenRequest {
 
 export namespace ListChildrenRequest {
   export function isa(o: any): o is ListChildrenRequest {
-    return _smithy.isa(o, "ListChildrenRequest");
+    return __isa(o, "ListChildrenRequest");
   }
 }
 
@@ -2438,7 +2441,7 @@ export interface ListChildrenResponse extends $MetadataBearer {
 
 export namespace ListChildrenResponse {
   export function isa(o: any): o is ListChildrenResponse {
-    return _smithy.isa(o, "ListChildrenResponse");
+    return __isa(o, "ListChildrenResponse");
   }
 }
 
@@ -2473,7 +2476,7 @@ export interface ListCreateAccountStatusRequest {
 
 export namespace ListCreateAccountStatusRequest {
   export function isa(o: any): o is ListCreateAccountStatusRequest {
-    return _smithy.isa(o, "ListCreateAccountStatusRequest");
+    return __isa(o, "ListCreateAccountStatusRequest");
   }
 }
 
@@ -2497,7 +2500,7 @@ export interface ListCreateAccountStatusResponse extends $MetadataBearer {
 
 export namespace ListCreateAccountStatusResponse {
   export function isa(o: any): o is ListCreateAccountStatusResponse {
-    return _smithy.isa(o, "ListCreateAccountStatusResponse");
+    return __isa(o, "ListCreateAccountStatusResponse");
   }
 }
 
@@ -2537,7 +2540,7 @@ export interface ListHandshakesForAccountRequest {
 
 export namespace ListHandshakesForAccountRequest {
   export function isa(o: any): o is ListHandshakesForAccountRequest {
-    return _smithy.isa(o, "ListHandshakesForAccountRequest");
+    return __isa(o, "ListHandshakesForAccountRequest");
   }
 }
 
@@ -2561,7 +2564,7 @@ export interface ListHandshakesForAccountResponse extends $MetadataBearer {
 
 export namespace ListHandshakesForAccountResponse {
   export function isa(o: any): o is ListHandshakesForAccountResponse {
-    return _smithy.isa(o, "ListHandshakesForAccountResponse");
+    return __isa(o, "ListHandshakesForAccountResponse");
   }
 }
 
@@ -2601,7 +2604,7 @@ export interface ListHandshakesForOrganizationRequest {
 
 export namespace ListHandshakesForOrganizationRequest {
   export function isa(o: any): o is ListHandshakesForOrganizationRequest {
-    return _smithy.isa(o, "ListHandshakesForOrganizationRequest");
+    return __isa(o, "ListHandshakesForOrganizationRequest");
   }
 }
 
@@ -2625,7 +2628,7 @@ export interface ListHandshakesForOrganizationResponse extends $MetadataBearer {
 
 export namespace ListHandshakesForOrganizationResponse {
   export function isa(o: any): o is ListHandshakesForOrganizationResponse {
-    return _smithy.isa(o, "ListHandshakesForOrganizationResponse");
+    return __isa(o, "ListHandshakesForOrganizationResponse");
   }
 }
 
@@ -2674,7 +2677,7 @@ export interface ListOrganizationalUnitsForParentRequest {
 
 export namespace ListOrganizationalUnitsForParentRequest {
   export function isa(o: any): o is ListOrganizationalUnitsForParentRequest {
-    return _smithy.isa(o, "ListOrganizationalUnitsForParentRequest");
+    return __isa(o, "ListOrganizationalUnitsForParentRequest");
   }
 }
 
@@ -2698,7 +2701,7 @@ export interface ListOrganizationalUnitsForParentResponse
 
 export namespace ListOrganizationalUnitsForParentResponse {
   export function isa(o: any): o is ListOrganizationalUnitsForParentResponse {
-    return _smithy.isa(o, "ListOrganizationalUnitsForParentResponse");
+    return __isa(o, "ListOrganizationalUnitsForParentResponse");
   }
 }
 
@@ -2747,7 +2750,7 @@ export interface ListParentsRequest {
 
 export namespace ListParentsRequest {
   export function isa(o: any): o is ListParentsRequest {
-    return _smithy.isa(o, "ListParentsRequest");
+    return __isa(o, "ListParentsRequest");
   }
 }
 
@@ -2770,7 +2773,7 @@ export interface ListParentsResponse extends $MetadataBearer {
 
 export namespace ListParentsResponse {
   export function isa(o: any): o is ListParentsResponse {
-    return _smithy.isa(o, "ListParentsResponse");
+    return __isa(o, "ListParentsResponse");
   }
 }
 
@@ -2829,7 +2832,7 @@ export interface ListPoliciesForTargetRequest {
 
 export namespace ListPoliciesForTargetRequest {
   export function isa(o: any): o is ListPoliciesForTargetRequest {
-    return _smithy.isa(o, "ListPoliciesForTargetRequest");
+    return __isa(o, "ListPoliciesForTargetRequest");
   }
 }
 
@@ -2852,7 +2855,7 @@ export interface ListPoliciesForTargetResponse extends $MetadataBearer {
 
 export namespace ListPoliciesForTargetResponse {
   export function isa(o: any): o is ListPoliciesForTargetResponse {
-    return _smithy.isa(o, "ListPoliciesForTargetResponse");
+    return __isa(o, "ListPoliciesForTargetResponse");
   }
 }
 
@@ -2886,7 +2889,7 @@ export interface ListPoliciesRequest {
 
 export namespace ListPoliciesRequest {
   export function isa(o: any): o is ListPoliciesRequest {
-    return _smithy.isa(o, "ListPoliciesRequest");
+    return __isa(o, "ListPoliciesRequest");
   }
 }
 
@@ -2910,7 +2913,7 @@ export interface ListPoliciesResponse extends $MetadataBearer {
 
 export namespace ListPoliciesResponse {
   export function isa(o: any): o is ListPoliciesResponse {
-    return _smithy.isa(o, "ListPoliciesResponse");
+    return __isa(o, "ListPoliciesResponse");
   }
 }
 
@@ -2939,7 +2942,7 @@ export interface ListRootsRequest {
 
 export namespace ListRootsRequest {
   export function isa(o: any): o is ListRootsRequest {
-    return _smithy.isa(o, "ListRootsRequest");
+    return __isa(o, "ListRootsRequest");
   }
 }
 
@@ -2962,7 +2965,7 @@ export interface ListRootsResponse extends $MetadataBearer {
 
 export namespace ListRootsResponse {
   export function isa(o: any): o is ListRootsResponse {
-    return _smithy.isa(o, "ListRootsResponse");
+    return __isa(o, "ListRootsResponse");
   }
 }
 
@@ -2984,7 +2987,7 @@ export interface ListTagsForResourceRequest {
 
 export namespace ListTagsForResourceRequest {
   export function isa(o: any): o is ListTagsForResourceRequest {
-    return _smithy.isa(o, "ListTagsForResourceRequest");
+    return __isa(o, "ListTagsForResourceRequest");
   }
 }
 
@@ -3007,7 +3010,7 @@ export interface ListTagsForResourceResponse extends $MetadataBearer {
 
 export namespace ListTagsForResourceResponse {
   export function isa(o: any): o is ListTagsForResourceResponse {
-    return _smithy.isa(o, "ListTagsForResourceResponse");
+    return __isa(o, "ListTagsForResourceResponse");
   }
 }
 
@@ -3043,7 +3046,7 @@ export interface ListTargetsForPolicyRequest {
 
 export namespace ListTargetsForPolicyRequest {
   export function isa(o: any): o is ListTargetsForPolicyRequest {
-    return _smithy.isa(o, "ListTargetsForPolicyRequest");
+    return __isa(o, "ListTargetsForPolicyRequest");
   }
 }
 
@@ -3067,7 +3070,7 @@ export interface ListTargetsForPolicyResponse extends $MetadataBearer {
 
 export namespace ListTargetsForPolicyResponse {
   export function isa(o: any): o is ListTargetsForPolicyResponse {
-    return _smithy.isa(o, "ListTargetsForPolicyResponse");
+    return __isa(o, "ListTargetsForPolicyResponse");
   }
 }
 
@@ -3079,7 +3082,7 @@ export namespace ListTargetsForPolicyResponse {
  *          </p>
  */
 export interface MalformedPolicyDocumentException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "MalformedPolicyDocumentException";
   $fault: "client";
@@ -3088,7 +3091,7 @@ export interface MalformedPolicyDocumentException
 
 export namespace MalformedPolicyDocumentException {
   export function isa(o: any): o is MalformedPolicyDocumentException {
-    return _smithy.isa(o, "MalformedPolicyDocumentException");
+    return __isa(o, "MalformedPolicyDocumentException");
   }
 }
 
@@ -3098,7 +3101,7 @@ export namespace MalformedPolicyDocumentException {
  *       organization of the master account.</p>
  */
 export interface MasterCannotLeaveOrganizationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "MasterCannotLeaveOrganizationException";
   $fault: "client";
@@ -3107,7 +3110,7 @@ export interface MasterCannotLeaveOrganizationException
 
 export namespace MasterCannotLeaveOrganizationException {
   export function isa(o: any): o is MasterCannotLeaveOrganizationException {
-    return _smithy.isa(o, "MasterCannotLeaveOrganizationException");
+    return __isa(o, "MasterCannotLeaveOrganizationException");
   }
 }
 
@@ -3165,7 +3168,7 @@ export interface MoveAccountRequest {
 
 export namespace MoveAccountRequest {
   export function isa(o: any): o is MoveAccountRequest {
-    return _smithy.isa(o, "MoveAccountRequest");
+    return __isa(o, "MoveAccountRequest");
   }
 }
 
@@ -3236,7 +3239,7 @@ export interface Organization {
 
 export namespace Organization {
   export function isa(o: any): o is Organization {
-    return _smithy.isa(o, "Organization");
+    return __isa(o, "Organization");
   }
 }
 
@@ -3250,7 +3253,7 @@ export enum OrganizationFeatureSet {
  *       accounts except the master account, delete all OUs, and delete all policies.</p>
  */
 export interface OrganizationNotEmptyException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "OrganizationNotEmptyException";
   $fault: "client";
@@ -3259,7 +3262,7 @@ export interface OrganizationNotEmptyException
 
 export namespace OrganizationNotEmptyException {
   export function isa(o: any): o is OrganizationNotEmptyException {
-    return _smithy.isa(o, "OrganizationNotEmptyException");
+    return __isa(o, "OrganizationNotEmptyException");
   }
 }
 
@@ -3297,7 +3300,7 @@ export interface OrganizationalUnit {
 
 export namespace OrganizationalUnit {
   export function isa(o: any): o is OrganizationalUnit {
-    return _smithy.isa(o, "OrganizationalUnit");
+    return __isa(o, "OrganizationalUnit");
   }
 }
 
@@ -3306,7 +3309,7 @@ export namespace OrganizationalUnit {
  *       all child OUs, and try the operation again.</p>
  */
 export interface OrganizationalUnitNotEmptyException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "OrganizationalUnitNotEmptyException";
   $fault: "client";
@@ -3315,7 +3318,7 @@ export interface OrganizationalUnitNotEmptyException
 
 export namespace OrganizationalUnitNotEmptyException {
   export function isa(o: any): o is OrganizationalUnitNotEmptyException {
-    return _smithy.isa(o, "OrganizationalUnitNotEmptyException");
+    return __isa(o, "OrganizationalUnitNotEmptyException");
   }
 }
 
@@ -3323,7 +3326,7 @@ export namespace OrganizationalUnitNotEmptyException {
  * <p>We can't find an OU with the <code>OrganizationalUnitId</code> that you specified.</p>
  */
 export interface OrganizationalUnitNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "OrganizationalUnitNotFoundException";
   $fault: "client";
@@ -3332,7 +3335,7 @@ export interface OrganizationalUnitNotFoundException
 
 export namespace OrganizationalUnitNotFoundException {
   export function isa(o: any): o is OrganizationalUnitNotFoundException {
-    return _smithy.isa(o, "OrganizationalUnitNotFoundException");
+    return __isa(o, "OrganizationalUnitNotFoundException");
   }
 }
 
@@ -3368,7 +3371,7 @@ export interface Parent {
 
 export namespace Parent {
   export function isa(o: any): o is Parent {
-    return _smithy.isa(o, "Parent");
+    return __isa(o, "Parent");
   }
 }
 
@@ -3376,7 +3379,7 @@ export namespace Parent {
  * <p>We can't find a root or OU with the <code>ParentId</code> that you specified.</p>
  */
 export interface ParentNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ParentNotFoundException";
   $fault: "client";
@@ -3385,7 +3388,7 @@ export interface ParentNotFoundException
 
 export namespace ParentNotFoundException {
   export function isa(o: any): o is ParentNotFoundException {
-    return _smithy.isa(o, "ParentNotFoundException");
+    return __isa(o, "ParentNotFoundException");
   }
 }
 
@@ -3413,7 +3416,7 @@ export interface Policy {
 
 export namespace Policy {
   export function isa(o: any): o is Policy {
-    return _smithy.isa(o, "Policy");
+    return __isa(o, "Policy");
   }
 }
 
@@ -3422,7 +3425,7 @@ export namespace Policy {
  *       the operation again later. </p>
  */
 export interface PolicyChangesInProgressException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "PolicyChangesInProgressException";
   $fault: "client";
@@ -3431,7 +3434,7 @@ export interface PolicyChangesInProgressException
 
 export namespace PolicyChangesInProgressException {
   export function isa(o: any): o is PolicyChangesInProgressException {
-    return _smithy.isa(o, "PolicyChangesInProgressException");
+    return __isa(o, "PolicyChangesInProgressException");
   }
 }
 
@@ -3440,7 +3443,7 @@ export namespace PolicyChangesInProgressException {
  *       and accounts before performing this operation.</p>
  */
 export interface PolicyInUseException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "PolicyInUseException";
   $fault: "client";
@@ -3449,7 +3452,7 @@ export interface PolicyInUseException
 
 export namespace PolicyInUseException {
   export function isa(o: any): o is PolicyInUseException {
-    return _smithy.isa(o, "PolicyInUseException");
+    return __isa(o, "PolicyInUseException");
   }
 }
 
@@ -3457,7 +3460,7 @@ export namespace PolicyInUseException {
  * <p>The policy isn't attached to the specified target in the specified root.</p>
  */
 export interface PolicyNotAttachedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "PolicyNotAttachedException";
   $fault: "client";
@@ -3466,7 +3469,7 @@ export interface PolicyNotAttachedException
 
 export namespace PolicyNotAttachedException {
   export function isa(o: any): o is PolicyNotAttachedException {
-    return _smithy.isa(o, "PolicyNotAttachedException");
+    return __isa(o, "PolicyNotAttachedException");
   }
 }
 
@@ -3474,7 +3477,7 @@ export namespace PolicyNotAttachedException {
  * <p>We can't find a policy with the <code>PolicyId</code> that you specified.</p>
  */
 export interface PolicyNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "PolicyNotFoundException";
   $fault: "client";
@@ -3483,7 +3486,7 @@ export interface PolicyNotFoundException
 
 export namespace PolicyNotFoundException {
   export function isa(o: any): o is PolicyNotFoundException {
-    return _smithy.isa(o, "PolicyNotFoundException");
+    return __isa(o, "PolicyNotFoundException");
   }
 }
 
@@ -3535,7 +3538,7 @@ export interface PolicySummary {
 
 export namespace PolicySummary {
   export function isa(o: any): o is PolicySummary {
-    return _smithy.isa(o, "PolicySummary");
+    return __isa(o, "PolicySummary");
   }
 }
 
@@ -3588,7 +3591,7 @@ export interface PolicyTargetSummary {
 
 export namespace PolicyTargetSummary {
   export function isa(o: any): o is PolicyTargetSummary {
-    return _smithy.isa(o, "PolicyTargetSummary");
+    return __isa(o, "PolicyTargetSummary");
   }
 }
 
@@ -3601,7 +3604,7 @@ export enum PolicyType {
  * <p>The specified policy type is already enabled in the specified root.</p>
  */
 export interface PolicyTypeAlreadyEnabledException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "PolicyTypeAlreadyEnabledException";
   $fault: "client";
@@ -3610,7 +3613,7 @@ export interface PolicyTypeAlreadyEnabledException
 
 export namespace PolicyTypeAlreadyEnabledException {
   export function isa(o: any): o is PolicyTypeAlreadyEnabledException {
-    return _smithy.isa(o, "PolicyTypeAlreadyEnabledException");
+    return __isa(o, "PolicyTypeAlreadyEnabledException");
   }
 }
 
@@ -3622,7 +3625,7 @@ export namespace PolicyTypeAlreadyEnabledException {
  *          </p>
  */
 export interface PolicyTypeNotAvailableForOrganizationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "PolicyTypeNotAvailableForOrganizationException";
   $fault: "client";
@@ -3633,7 +3636,7 @@ export namespace PolicyTypeNotAvailableForOrganizationException {
   export function isa(
     o: any
   ): o is PolicyTypeNotAvailableForOrganizationException {
-    return _smithy.isa(o, "PolicyTypeNotAvailableForOrganizationException");
+    return __isa(o, "PolicyTypeNotAvailableForOrganizationException");
   }
 }
 
@@ -3645,7 +3648,7 @@ export namespace PolicyTypeNotAvailableForOrganizationException {
  *          </p>
  */
 export interface PolicyTypeNotEnabledException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "PolicyTypeNotEnabledException";
   $fault: "client";
@@ -3654,7 +3657,7 @@ export interface PolicyTypeNotEnabledException
 
 export namespace PolicyTypeNotEnabledException {
   export function isa(o: any): o is PolicyTypeNotEnabledException {
-    return _smithy.isa(o, "PolicyTypeNotEnabledException");
+    return __isa(o, "PolicyTypeNotEnabledException");
   }
 }
 
@@ -3684,7 +3687,7 @@ export interface PolicyTypeSummary {
 
 export namespace PolicyTypeSummary {
   export function isa(o: any): o is PolicyTypeSummary {
-    return _smithy.isa(o, "PolicyTypeSummary");
+    return __isa(o, "PolicyTypeSummary");
   }
 }
 
@@ -3701,7 +3704,7 @@ export interface RemoveAccountFromOrganizationRequest {
 
 export namespace RemoveAccountFromOrganizationRequest {
   export function isa(o: any): o is RemoveAccountFromOrganizationRequest {
-    return _smithy.isa(o, "RemoveAccountFromOrganizationRequest");
+    return __isa(o, "RemoveAccountFromOrganizationRequest");
   }
 }
 
@@ -3750,7 +3753,7 @@ export interface Root {
 
 export namespace Root {
   export function isa(o: any): o is Root {
-    return _smithy.isa(o, "Root");
+    return __isa(o, "Root");
   }
 }
 
@@ -3758,7 +3761,7 @@ export namespace Root {
  * <p>We can't find a root with the <code>RootId</code> that you specified.</p>
  */
 export interface RootNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "RootNotFoundException";
   $fault: "client";
@@ -3767,7 +3770,7 @@ export interface RootNotFoundException
 
 export namespace RootNotFoundException {
   export function isa(o: any): o is RootNotFoundException {
-    return _smithy.isa(o, "RootNotFoundException");
+    return __isa(o, "RootNotFoundException");
   }
 }
 
@@ -3775,9 +3778,7 @@ export namespace RootNotFoundException {
  * <p>AWS Organizations can't complete your request because of an internal service error. Try again
  *       later.</p>
  */
-export interface ServiceException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface ServiceException extends __SmithyException, $MetadataBearer {
   name: "ServiceException";
   $fault: "server";
   Message?: string;
@@ -3785,7 +3786,7 @@ export interface ServiceException
 
 export namespace ServiceException {
   export function isa(o: any): o is ServiceException {
-    return _smithy.isa(o, "ServiceException");
+    return __isa(o, "ServiceException");
   }
 }
 
@@ -3794,7 +3795,7 @@ export namespace ServiceException {
  *       specified.</p>
  */
 export interface SourceParentNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "SourceParentNotFoundException";
   $fault: "client";
@@ -3803,7 +3804,7 @@ export interface SourceParentNotFoundException
 
 export namespace SourceParentNotFoundException {
   export function isa(o: any): o is SourceParentNotFoundException {
-    return _smithy.isa(o, "SourceParentNotFoundException");
+    return __isa(o, "SourceParentNotFoundException");
   }
 }
 
@@ -3827,7 +3828,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -3847,7 +3848,7 @@ export interface TagResourceRequest {
 
 export namespace TagResourceRequest {
   export function isa(o: any): o is TagResourceRequest {
-    return _smithy.isa(o, "TagResourceRequest");
+    return __isa(o, "TagResourceRequest");
   }
 }
 
@@ -3856,7 +3857,7 @@ export namespace TagResourceRequest {
  *       specified.</p>
  */
 export interface TargetNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TargetNotFoundException";
   $fault: "client";
@@ -3865,7 +3866,7 @@ export interface TargetNotFoundException
 
 export namespace TargetNotFoundException {
   export function isa(o: any): o is TargetNotFoundException {
-    return _smithy.isa(o, "TargetNotFoundException");
+    return __isa(o, "TargetNotFoundException");
   }
 }
 
@@ -3883,7 +3884,7 @@ export enum TargetType {
  *          </p>
  */
 export interface TooManyRequestsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyRequestsException";
   $fault: "client";
@@ -3893,7 +3894,7 @@ export interface TooManyRequestsException
 
 export namespace TooManyRequestsException {
   export function isa(o: any): o is TooManyRequestsException {
-    return _smithy.isa(o, "TooManyRequestsException");
+    return __isa(o, "TooManyRequestsException");
   }
 }
 
@@ -3901,7 +3902,7 @@ export namespace TooManyRequestsException {
  * <p>This action isn't available in the current Region.</p>
  */
 export interface UnsupportedAPIEndpointException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UnsupportedAPIEndpointException";
   $fault: "client";
@@ -3910,7 +3911,7 @@ export interface UnsupportedAPIEndpointException
 
 export namespace UnsupportedAPIEndpointException {
   export function isa(o: any): o is UnsupportedAPIEndpointException {
-    return _smithy.isa(o, "UnsupportedAPIEndpointException");
+    return __isa(o, "UnsupportedAPIEndpointException");
   }
 }
 
@@ -3929,7 +3930,7 @@ export interface UntagResourceRequest {
 
 export namespace UntagResourceRequest {
   export function isa(o: any): o is UntagResourceRequest {
-    return _smithy.isa(o, "UntagResourceRequest");
+    return __isa(o, "UntagResourceRequest");
   }
 }
 
@@ -3956,7 +3957,7 @@ export interface UpdateOrganizationalUnitRequest {
 
 export namespace UpdateOrganizationalUnitRequest {
   export function isa(o: any): o is UpdateOrganizationalUnitRequest {
-    return _smithy.isa(o, "UpdateOrganizationalUnitRequest");
+    return __isa(o, "UpdateOrganizationalUnitRequest");
   }
 }
 
@@ -3971,7 +3972,7 @@ export interface UpdateOrganizationalUnitResponse extends $MetadataBearer {
 
 export namespace UpdateOrganizationalUnitResponse {
   export function isa(o: any): o is UpdateOrganizationalUnitResponse {
-    return _smithy.isa(o, "UpdateOrganizationalUnitResponse");
+    return __isa(o, "UpdateOrganizationalUnitResponse");
   }
 }
 
@@ -4008,7 +4009,7 @@ export interface UpdatePolicyRequest {
 
 export namespace UpdatePolicyRequest {
   export function isa(o: any): o is UpdatePolicyRequest {
-    return _smithy.isa(o, "UpdatePolicyRequest");
+    return __isa(o, "UpdatePolicyRequest");
   }
 }
 
@@ -4023,6 +4024,6 @@ export interface UpdatePolicyResponse extends $MetadataBearer {
 
 export namespace UpdatePolicyResponse {
   export function isa(o: any): o is UpdatePolicyResponse {
-    return _smithy.isa(o, "UpdatePolicyResponse");
+    return __isa(o, "UpdatePolicyResponse");
   }
 }

--- a/clients/client-organizations/protocols/Aws_json1_1.ts
+++ b/clients/client-organizations/protocols/Aws_json1_1.ts
@@ -1126,6 +1126,7 @@ export async function deserializeAws_json1_1AttachPolicyCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1AttachPolicyCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: AttachPolicyCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2053,6 +2054,7 @@ export async function deserializeAws_json1_1DeleteOrganizationCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteOrganizationCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2149,6 +2151,7 @@ export async function deserializeAws_json1_1DeleteOrganizationalUnitCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteOrganizationalUnitCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2249,6 +2252,7 @@ export async function deserializeAws_json1_1DeletePolicyCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1DeletePolicyCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeletePolicyCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -3042,6 +3046,7 @@ export async function deserializeAws_json1_1DetachPolicyCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1DetachPolicyCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DetachPolicyCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -3173,6 +3178,7 @@ export async function deserializeAws_json1_1DisableAWSServiceAccessCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DisableAWSServiceAccessCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -3395,6 +3401,7 @@ export async function deserializeAws_json1_1EnableAWSServiceAccessCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: EnableAWSServiceAccessCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -3844,6 +3851,7 @@ export async function deserializeAws_json1_1LeaveOrganizationCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1LeaveOrganizationCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: LeaveOrganizationCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -5260,6 +5268,7 @@ export async function deserializeAws_json1_1MoveAccountCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1MoveAccountCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: MoveAccountCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -5377,6 +5386,7 @@ export async function deserializeAws_json1_1RemoveAccountFromOrganizationCommand
       context
     );
   }
+  await collectBody(output.body, context);
   const response: RemoveAccountFromOrganizationCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -5484,6 +5494,7 @@ export async function deserializeAws_json1_1TagResourceCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1TagResourceCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: TagResourceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -5584,6 +5595,7 @@ export async function deserializeAws_json1_1UntagResourceCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1UntagResourceCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: UntagResourceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };

--- a/clients/client-outposts/models/index.ts
+++ b/clients/client-outposts/models/index.ts
@@ -1,11 +1,14 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
  * <p>You do not have permission to perform this operation.</p>
  */
 export interface AccessDeniedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AccessDeniedException";
   $fault: "client";
@@ -14,7 +17,7 @@ export interface AccessDeniedException
 
 export namespace AccessDeniedException {
   export function isa(o: any): o is AccessDeniedException {
-    return _smithy.isa(o, "AccessDeniedException");
+    return __isa(o, "AccessDeniedException");
   }
 }
 
@@ -48,7 +51,7 @@ export interface CreateOutpostInput {
 
 export namespace CreateOutpostInput {
   export function isa(o: any): o is CreateOutpostInput {
-    return _smithy.isa(o, "CreateOutpostInput");
+    return __isa(o, "CreateOutpostInput");
   }
 }
 
@@ -62,7 +65,7 @@ export interface CreateOutpostOutput extends $MetadataBearer {
 
 export namespace CreateOutpostOutput {
   export function isa(o: any): o is CreateOutpostOutput {
-    return _smithy.isa(o, "CreateOutpostOutput");
+    return __isa(o, "CreateOutpostOutput");
   }
 }
 
@@ -76,7 +79,7 @@ export interface GetOutpostInput {
 
 export namespace GetOutpostInput {
   export function isa(o: any): o is GetOutpostInput {
-    return _smithy.isa(o, "GetOutpostInput");
+    return __isa(o, "GetOutpostInput");
   }
 }
 
@@ -100,7 +103,7 @@ export interface GetOutpostInstanceTypesInput {
 
 export namespace GetOutpostInstanceTypesInput {
   export function isa(o: any): o is GetOutpostInstanceTypesInput {
-    return _smithy.isa(o, "GetOutpostInstanceTypesInput");
+    return __isa(o, "GetOutpostInstanceTypesInput");
   }
 }
 
@@ -129,7 +132,7 @@ export interface GetOutpostInstanceTypesOutput extends $MetadataBearer {
 
 export namespace GetOutpostInstanceTypesOutput {
   export function isa(o: any): o is GetOutpostInstanceTypesOutput {
-    return _smithy.isa(o, "GetOutpostInstanceTypesOutput");
+    return __isa(o, "GetOutpostInstanceTypesOutput");
   }
 }
 
@@ -143,7 +146,7 @@ export interface GetOutpostOutput extends $MetadataBearer {
 
 export namespace GetOutpostOutput {
   export function isa(o: any): o is GetOutpostOutput {
-    return _smithy.isa(o, "GetOutpostOutput");
+    return __isa(o, "GetOutpostOutput");
   }
 }
 
@@ -160,7 +163,7 @@ export interface InstanceTypeItem {
 
 export namespace InstanceTypeItem {
   export function isa(o: any): o is InstanceTypeItem {
-    return _smithy.isa(o, "InstanceTypeItem");
+    return __isa(o, "InstanceTypeItem");
   }
 }
 
@@ -168,7 +171,7 @@ export namespace InstanceTypeItem {
  * <p>An internal error has occurred.</p>
  */
 export interface InternalServerException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalServerException";
   $fault: "server";
@@ -177,7 +180,7 @@ export interface InternalServerException
 
 export namespace InternalServerException {
   export function isa(o: any): o is InternalServerException {
-    return _smithy.isa(o, "InternalServerException");
+    return __isa(o, "InternalServerException");
   }
 }
 
@@ -196,7 +199,7 @@ export interface ListOutpostsInput {
 
 export namespace ListOutpostsInput {
   export function isa(o: any): o is ListOutpostsInput {
-    return _smithy.isa(o, "ListOutpostsInput");
+    return __isa(o, "ListOutpostsInput");
   }
 }
 
@@ -215,7 +218,7 @@ export interface ListOutpostsOutput extends $MetadataBearer {
 
 export namespace ListOutpostsOutput {
   export function isa(o: any): o is ListOutpostsOutput {
-    return _smithy.isa(o, "ListOutpostsOutput");
+    return __isa(o, "ListOutpostsOutput");
   }
 }
 
@@ -234,7 +237,7 @@ export interface ListSitesInput {
 
 export namespace ListSitesInput {
   export function isa(o: any): o is ListSitesInput {
-    return _smithy.isa(o, "ListSitesInput");
+    return __isa(o, "ListSitesInput");
   }
 }
 
@@ -253,16 +256,14 @@ export interface ListSitesOutput extends $MetadataBearer {
 
 export namespace ListSitesOutput {
   export function isa(o: any): o is ListSitesOutput {
-    return _smithy.isa(o, "ListSitesOutput");
+    return __isa(o, "ListSitesOutput");
   }
 }
 
 /**
  * <p>The specified request is not valid.</p>
  */
-export interface NotFoundException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface NotFoundException extends __SmithyException, $MetadataBearer {
   name: "NotFoundException";
   $fault: "client";
   Message?: string;
@@ -270,7 +271,7 @@ export interface NotFoundException
 
 export namespace NotFoundException {
   export function isa(o: any): o is NotFoundException {
-    return _smithy.isa(o, "NotFoundException");
+    return __isa(o, "NotFoundException");
   }
 }
 
@@ -327,7 +328,7 @@ export interface Outpost {
 
 export namespace Outpost {
   export function isa(o: any): o is Outpost {
-    return _smithy.isa(o, "Outpost");
+    return __isa(o, "Outpost");
   }
 }
 
@@ -335,7 +336,7 @@ export namespace Outpost {
  * <p>You have exceeded a service quota.</p>
  */
 export interface ServiceQuotaExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ServiceQuotaExceededException";
   $fault: "client";
@@ -344,7 +345,7 @@ export interface ServiceQuotaExceededException
 
 export namespace ServiceQuotaExceededException {
   export function isa(o: any): o is ServiceQuotaExceededException {
-    return _smithy.isa(o, "ServiceQuotaExceededException");
+    return __isa(o, "ServiceQuotaExceededException");
   }
 }
 
@@ -376,7 +377,7 @@ export interface Site {
 
 export namespace Site {
   export function isa(o: any): o is Site {
-    return _smithy.isa(o, "Site");
+    return __isa(o, "Site");
   }
 }
 
@@ -384,7 +385,7 @@ export namespace Site {
  * <p>A parameter is not valid.</p>
  */
 export interface ValidationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ValidationException";
   $fault: "client";
@@ -393,6 +394,6 @@ export interface ValidationException
 
 export namespace ValidationException {
   export function isa(o: any): o is ValidationException {
-    return _smithy.isa(o, "ValidationException");
+    return __isa(o, "ValidationException");
   }
 }

--- a/clients/client-outposts/protocols/Aws_restJson1_1.ts
+++ b/clients/client-outposts/protocols/Aws_restJson1_1.ts
@@ -32,7 +32,10 @@ import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  extendedEncodeURIComponent as __extendedEncodeURIComponent
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -83,13 +86,13 @@ export async function serializeAws_restJson1_1GetOutpostCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/outposts/{OutpostId}";
   if (input.OutpostId !== undefined) {
-    const labelValue: string = input.OutpostId.toString();
+    const labelValue: string = input.OutpostId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: OutpostId.");
     }
     resolvedPath = resolvedPath.replace(
       "{OutpostId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: OutpostId.");
@@ -111,23 +114,27 @@ export async function serializeAws_restJson1_1GetOutpostInstanceTypesCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/outposts/{OutpostId}/instanceTypes";
   if (input.OutpostId !== undefined) {
-    const labelValue: string = input.OutpostId.toString();
+    const labelValue: string = input.OutpostId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: OutpostId.");
     }
     resolvedPath = resolvedPath.replace(
       "{OutpostId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: OutpostId.");
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["MaxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("MaxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["NextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("NextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -148,10 +155,14 @@ export async function serializeAws_restJson1_1ListOutpostsCommand(
   let resolvedPath = "/outposts";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["MaxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("MaxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["NextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("NextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -172,10 +183,14 @@ export async function serializeAws_restJson1_1ListSitesCommand(
   let resolvedPath = "/sites";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["MaxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("MaxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["NextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("NextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,

--- a/clients/client-personalize-events/models/index.ts
+++ b/clients/client-personalize-events/models/index.ts
@@ -1,4 +1,8 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  LazyJsonString as __LazyJsonString,
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -42,7 +46,7 @@ export interface Event {
    *       <code>eventValue</code> being the rating. The <code>numberOfRatings</code> would match the
    *       'NUMBER_OF_RATINGS' field defined in the Interactions schema.</p>
    */
-  properties: string | undefined;
+  properties: __LazyJsonString | string | undefined;
 
   /**
    * <p>The timestamp on the client side when the event occurred.</p>
@@ -52,7 +56,7 @@ export interface Event {
 
 export namespace Event {
   export function isa(o: any): o is Event {
-    return _smithy.isa(o, "Event");
+    return __isa(o, "Event");
   }
 }
 
@@ -83,7 +87,7 @@ export interface PutEventsRequest {
 
 export namespace PutEventsRequest {
   export function isa(o: any): o is PutEventsRequest {
-    return _smithy.isa(o, "PutEventsRequest");
+    return __isa(o, "PutEventsRequest");
   }
 }
 
@@ -91,7 +95,7 @@ export namespace PutEventsRequest {
  * <p>Provide a valid value for the field or parameter.</p>
  */
 export interface InvalidInputException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidInputException";
   $fault: "client";
@@ -100,6 +104,6 @@ export interface InvalidInputException
 
 export namespace InvalidInputException {
   export function isa(o: any): o is InvalidInputException {
-    return _smithy.isa(o, "InvalidInputException");
+    return __isa(o, "InvalidInputException");
   }
 }

--- a/clients/client-personalize-events/protocols/Aws_restJson1_1.ts
+++ b/clients/client-personalize-events/protocols/Aws_restJson1_1.ts
@@ -7,7 +7,10 @@ import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  LazyJsonString as __LazyJsonString,
+  SmithyException as __SmithyException
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -60,6 +63,7 @@ export async function deserializeAws_restJson1_1PutEventsCommand(
   const contents: PutEventsCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -126,7 +130,7 @@ const serializeAws_restJson1_1Event = (
     bodyParams["eventType"] = input.eventType;
   }
   if (input.properties !== undefined) {
-    bodyParams["properties"] = input.properties;
+    bodyParams["properties"] = __LazyJsonString.fromObject(input.properties);
   }
   if (input.sentAt !== undefined) {
     bodyParams["sentAt"] = Math.round(input.sentAt.getTime() / 1000);

--- a/clients/client-personalize-runtime/models/index.ts
+++ b/clients/client-personalize-runtime/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export interface GetPersonalizedRankingRequest {
@@ -31,7 +34,7 @@ export interface GetPersonalizedRankingRequest {
 
 export namespace GetPersonalizedRankingRequest {
   export function isa(o: any): o is GetPersonalizedRankingRequest {
-    return _smithy.isa(o, "GetPersonalizedRankingRequest");
+    return __isa(o, "GetPersonalizedRankingRequest");
   }
 }
 
@@ -45,7 +48,7 @@ export interface GetPersonalizedRankingResponse extends $MetadataBearer {
 
 export namespace GetPersonalizedRankingResponse {
   export function isa(o: any): o is GetPersonalizedRankingResponse {
-    return _smithy.isa(o, "GetPersonalizedRankingResponse");
+    return __isa(o, "GetPersonalizedRankingResponse");
   }
 }
 
@@ -84,7 +87,7 @@ export interface GetRecommendationsRequest {
 
 export namespace GetRecommendationsRequest {
   export function isa(o: any): o is GetRecommendationsRequest {
-    return _smithy.isa(o, "GetRecommendationsRequest");
+    return __isa(o, "GetRecommendationsRequest");
   }
 }
 
@@ -99,7 +102,7 @@ export interface GetRecommendationsResponse extends $MetadataBearer {
 
 export namespace GetRecommendationsResponse {
   export function isa(o: any): o is GetRecommendationsResponse {
-    return _smithy.isa(o, "GetRecommendationsResponse");
+    return __isa(o, "GetRecommendationsResponse");
   }
 }
 
@@ -118,7 +121,7 @@ export interface PredictedItem {
 
 export namespace PredictedItem {
   export function isa(o: any): o is PredictedItem {
-    return _smithy.isa(o, "PredictedItem");
+    return __isa(o, "PredictedItem");
   }
 }
 
@@ -126,7 +129,7 @@ export namespace PredictedItem {
  * <p>Provide a valid value for the field or parameter.</p>
  */
 export interface InvalidInputException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidInputException";
   $fault: "client";
@@ -135,7 +138,7 @@ export interface InvalidInputException
 
 export namespace InvalidInputException {
   export function isa(o: any): o is InvalidInputException {
-    return _smithy.isa(o, "InvalidInputException");
+    return __isa(o, "InvalidInputException");
   }
 }
 
@@ -143,7 +146,7 @@ export namespace InvalidInputException {
  * <p>The specified resource does not exist.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -152,6 +155,6 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }

--- a/clients/client-personalize/models/index.ts
+++ b/clients/client-personalize/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -61,7 +64,7 @@ export interface Algorithm {
 
 export namespace Algorithm {
   export function isa(o: any): o is Algorithm {
-    return _smithy.isa(o, "Algorithm");
+    return __isa(o, "Algorithm");
   }
 }
 
@@ -83,7 +86,7 @@ export interface AlgorithmImage {
 
 export namespace AlgorithmImage {
   export function isa(o: any): o is AlgorithmImage {
-    return _smithy.isa(o, "AlgorithmImage");
+    return __isa(o, "AlgorithmImage");
   }
 }
 
@@ -108,7 +111,7 @@ export interface AutoMLConfig {
 
 export namespace AutoMLConfig {
   export function isa(o: any): o is AutoMLConfig {
-    return _smithy.isa(o, "AutoMLConfig");
+    return __isa(o, "AutoMLConfig");
   }
 }
 
@@ -127,7 +130,7 @@ export interface AutoMLResult {
 
 export namespace AutoMLResult {
   export function isa(o: any): o is AutoMLResult {
-    return _smithy.isa(o, "AutoMLResult");
+    return __isa(o, "AutoMLResult");
   }
 }
 
@@ -211,7 +214,7 @@ export interface BatchInferenceJob {
 
 export namespace BatchInferenceJob {
   export function isa(o: any): o is BatchInferenceJob {
-    return _smithy.isa(o, "BatchInferenceJob");
+    return __isa(o, "BatchInferenceJob");
   }
 }
 
@@ -229,7 +232,7 @@ export interface BatchInferenceJobInput {
 
 export namespace BatchInferenceJobInput {
   export function isa(o: any): o is BatchInferenceJobInput {
-    return _smithy.isa(o, "BatchInferenceJobInput");
+    return __isa(o, "BatchInferenceJobInput");
   }
 }
 
@@ -246,7 +249,7 @@ export interface BatchInferenceJobOutput {
 
 export namespace BatchInferenceJobOutput {
   export function isa(o: any): o is BatchInferenceJobOutput {
-    return _smithy.isa(o, "BatchInferenceJobOutput");
+    return __isa(o, "BatchInferenceJobOutput");
   }
 }
 
@@ -303,7 +306,7 @@ export interface BatchInferenceJobSummary {
 
 export namespace BatchInferenceJobSummary {
   export function isa(o: any): o is BatchInferenceJobSummary {
-    return _smithy.isa(o, "BatchInferenceJobSummary");
+    return __isa(o, "BatchInferenceJobSummary");
   }
 }
 
@@ -371,7 +374,7 @@ export interface Campaign {
 
 export namespace Campaign {
   export function isa(o: any): o is Campaign {
-    return _smithy.isa(o, "Campaign");
+    return __isa(o, "Campaign");
   }
 }
 
@@ -423,7 +426,7 @@ export interface CampaignSummary {
 
 export namespace CampaignSummary {
   export function isa(o: any): o is CampaignSummary {
-    return _smithy.isa(o, "CampaignSummary");
+    return __isa(o, "CampaignSummary");
   }
 }
 
@@ -476,7 +479,7 @@ export interface CampaignUpdateSummary {
 
 export namespace CampaignUpdateSummary {
   export function isa(o: any): o is CampaignUpdateSummary {
-    return _smithy.isa(o, "CampaignUpdateSummary");
+    return __isa(o, "CampaignUpdateSummary");
   }
 }
 
@@ -498,7 +501,7 @@ export interface CategoricalHyperParameterRange {
 
 export namespace CategoricalHyperParameterRange {
   export function isa(o: any): o is CategoricalHyperParameterRange {
-    return _smithy.isa(o, "CategoricalHyperParameterRange");
+    return __isa(o, "CategoricalHyperParameterRange");
   }
 }
 
@@ -525,7 +528,7 @@ export interface ContinuousHyperParameterRange {
 
 export namespace ContinuousHyperParameterRange {
   export function isa(o: any): o is ContinuousHyperParameterRange {
-    return _smithy.isa(o, "ContinuousHyperParameterRange");
+    return __isa(o, "ContinuousHyperParameterRange");
   }
 }
 
@@ -567,7 +570,7 @@ export interface CreateBatchInferenceJobRequest {
 
 export namespace CreateBatchInferenceJobRequest {
   export function isa(o: any): o is CreateBatchInferenceJobRequest {
-    return _smithy.isa(o, "CreateBatchInferenceJobRequest");
+    return __isa(o, "CreateBatchInferenceJobRequest");
   }
 }
 
@@ -581,7 +584,7 @@ export interface CreateBatchInferenceJobResponse extends $MetadataBearer {
 
 export namespace CreateBatchInferenceJobResponse {
   export function isa(o: any): o is CreateBatchInferenceJobResponse {
-    return _smithy.isa(o, "CreateBatchInferenceJobResponse");
+    return __isa(o, "CreateBatchInferenceJobResponse");
   }
 }
 
@@ -606,7 +609,7 @@ export interface CreateCampaignRequest {
 
 export namespace CreateCampaignRequest {
   export function isa(o: any): o is CreateCampaignRequest {
-    return _smithy.isa(o, "CreateCampaignRequest");
+    return __isa(o, "CreateCampaignRequest");
   }
 }
 
@@ -620,7 +623,7 @@ export interface CreateCampaignResponse extends $MetadataBearer {
 
 export namespace CreateCampaignResponse {
   export function isa(o: any): o is CreateCampaignResponse {
-    return _smithy.isa(o, "CreateCampaignResponse");
+    return __isa(o, "CreateCampaignResponse");
   }
 }
 
@@ -645,7 +648,7 @@ export interface CreateDatasetGroupRequest {
 
 export namespace CreateDatasetGroupRequest {
   export function isa(o: any): o is CreateDatasetGroupRequest {
-    return _smithy.isa(o, "CreateDatasetGroupRequest");
+    return __isa(o, "CreateDatasetGroupRequest");
   }
 }
 
@@ -659,7 +662,7 @@ export interface CreateDatasetGroupResponse extends $MetadataBearer {
 
 export namespace CreateDatasetGroupResponse {
   export function isa(o: any): o is CreateDatasetGroupResponse {
-    return _smithy.isa(o, "CreateDatasetGroupResponse");
+    return __isa(o, "CreateDatasetGroupResponse");
   }
 }
 
@@ -688,7 +691,7 @@ export interface CreateDatasetImportJobRequest {
 
 export namespace CreateDatasetImportJobRequest {
   export function isa(o: any): o is CreateDatasetImportJobRequest {
-    return _smithy.isa(o, "CreateDatasetImportJobRequest");
+    return __isa(o, "CreateDatasetImportJobRequest");
   }
 }
 
@@ -702,7 +705,7 @@ export interface CreateDatasetImportJobResponse extends $MetadataBearer {
 
 export namespace CreateDatasetImportJobResponse {
   export function isa(o: any): o is CreateDatasetImportJobResponse {
-    return _smithy.isa(o, "CreateDatasetImportJobResponse");
+    return __isa(o, "CreateDatasetImportJobResponse");
   }
 }
 
@@ -744,7 +747,7 @@ export interface CreateDatasetRequest {
 
 export namespace CreateDatasetRequest {
   export function isa(o: any): o is CreateDatasetRequest {
-    return _smithy.isa(o, "CreateDatasetRequest");
+    return __isa(o, "CreateDatasetRequest");
   }
 }
 
@@ -758,7 +761,7 @@ export interface CreateDatasetResponse extends $MetadataBearer {
 
 export namespace CreateDatasetResponse {
   export function isa(o: any): o is CreateDatasetResponse {
-    return _smithy.isa(o, "CreateDatasetResponse");
+    return __isa(o, "CreateDatasetResponse");
   }
 }
 
@@ -777,7 +780,7 @@ export interface CreateEventTrackerRequest {
 
 export namespace CreateEventTrackerRequest {
   export function isa(o: any): o is CreateEventTrackerRequest {
-    return _smithy.isa(o, "CreateEventTrackerRequest");
+    return __isa(o, "CreateEventTrackerRequest");
   }
 }
 
@@ -797,7 +800,7 @@ export interface CreateEventTrackerResponse extends $MetadataBearer {
 
 export namespace CreateEventTrackerResponse {
   export function isa(o: any): o is CreateEventTrackerResponse {
-    return _smithy.isa(o, "CreateEventTrackerResponse");
+    return __isa(o, "CreateEventTrackerResponse");
   }
 }
 
@@ -816,7 +819,7 @@ export interface CreateSchemaRequest {
 
 export namespace CreateSchemaRequest {
   export function isa(o: any): o is CreateSchemaRequest {
-    return _smithy.isa(o, "CreateSchemaRequest");
+    return __isa(o, "CreateSchemaRequest");
   }
 }
 
@@ -830,7 +833,7 @@ export interface CreateSchemaResponse extends $MetadataBearer {
 
 export namespace CreateSchemaResponse {
   export function isa(o: any): o is CreateSchemaResponse {
-    return _smithy.isa(o, "CreateSchemaResponse");
+    return __isa(o, "CreateSchemaResponse");
   }
 }
 
@@ -888,7 +891,7 @@ export interface CreateSolutionRequest {
 
 export namespace CreateSolutionRequest {
   export function isa(o: any): o is CreateSolutionRequest {
-    return _smithy.isa(o, "CreateSolutionRequest");
+    return __isa(o, "CreateSolutionRequest");
   }
 }
 
@@ -902,7 +905,7 @@ export interface CreateSolutionResponse extends $MetadataBearer {
 
 export namespace CreateSolutionResponse {
   export function isa(o: any): o is CreateSolutionResponse {
-    return _smithy.isa(o, "CreateSolutionResponse");
+    return __isa(o, "CreateSolutionResponse");
   }
 }
 
@@ -931,7 +934,7 @@ export interface CreateSolutionVersionRequest {
 
 export namespace CreateSolutionVersionRequest {
   export function isa(o: any): o is CreateSolutionVersionRequest {
-    return _smithy.isa(o, "CreateSolutionVersionRequest");
+    return __isa(o, "CreateSolutionVersionRequest");
   }
 }
 
@@ -945,7 +948,7 @@ export interface CreateSolutionVersionResponse extends $MetadataBearer {
 
 export namespace CreateSolutionVersionResponse {
   export function isa(o: any): o is CreateSolutionVersionResponse {
-    return _smithy.isa(o, "CreateSolutionVersionResponse");
+    return __isa(o, "CreateSolutionVersionResponse");
   }
 }
 
@@ -966,7 +969,7 @@ export interface DataSource {
 
 export namespace DataSource {
   export function isa(o: any): o is DataSource {
-    return _smithy.isa(o, "DataSource");
+    return __isa(o, "DataSource");
   }
 }
 
@@ -1038,7 +1041,7 @@ export interface Dataset {
 
 export namespace Dataset {
   export function isa(o: any): o is Dataset {
-    return _smithy.isa(o, "Dataset");
+    return __isa(o, "Dataset");
   }
 }
 
@@ -1105,7 +1108,7 @@ export interface DatasetGroup {
 
 export namespace DatasetGroup {
   export function isa(o: any): o is DatasetGroup {
-    return _smithy.isa(o, "DatasetGroup");
+    return __isa(o, "DatasetGroup");
   }
 }
 
@@ -1157,7 +1160,7 @@ export interface DatasetGroupSummary {
 
 export namespace DatasetGroupSummary {
   export function isa(o: any): o is DatasetGroupSummary {
-    return _smithy.isa(o, "DatasetGroupSummary");
+    return __isa(o, "DatasetGroupSummary");
   }
 }
 
@@ -1228,7 +1231,7 @@ export interface DatasetImportJob {
 
 export namespace DatasetImportJob {
   export function isa(o: any): o is DatasetImportJob {
-    return _smithy.isa(o, "DatasetImportJob");
+    return __isa(o, "DatasetImportJob");
   }
 }
 
@@ -1277,7 +1280,7 @@ export interface DatasetImportJobSummary {
 
 export namespace DatasetImportJobSummary {
   export function isa(o: any): o is DatasetImportJobSummary {
-    return _smithy.isa(o, "DatasetImportJobSummary");
+    return __isa(o, "DatasetImportJobSummary");
   }
 }
 
@@ -1315,7 +1318,7 @@ export interface DatasetSchema {
 
 export namespace DatasetSchema {
   export function isa(o: any): o is DatasetSchema {
-    return _smithy.isa(o, "DatasetSchema");
+    return __isa(o, "DatasetSchema");
   }
 }
 
@@ -1348,7 +1351,7 @@ export interface DatasetSchemaSummary {
 
 export namespace DatasetSchemaSummary {
   export function isa(o: any): o is DatasetSchemaSummary {
-    return _smithy.isa(o, "DatasetSchemaSummary");
+    return __isa(o, "DatasetSchemaSummary");
   }
 }
 
@@ -1414,7 +1417,7 @@ export interface DatasetSummary {
 
 export namespace DatasetSummary {
   export function isa(o: any): o is DatasetSummary {
-    return _smithy.isa(o, "DatasetSummary");
+    return __isa(o, "DatasetSummary");
   }
 }
 
@@ -1443,7 +1446,7 @@ export interface DefaultCategoricalHyperParameterRange {
 
 export namespace DefaultCategoricalHyperParameterRange {
   export function isa(o: any): o is DefaultCategoricalHyperParameterRange {
-    return _smithy.isa(o, "DefaultCategoricalHyperParameterRange");
+    return __isa(o, "DefaultCategoricalHyperParameterRange");
   }
 }
 
@@ -1477,7 +1480,7 @@ export interface DefaultContinuousHyperParameterRange {
 
 export namespace DefaultContinuousHyperParameterRange {
   export function isa(o: any): o is DefaultContinuousHyperParameterRange {
-    return _smithy.isa(o, "DefaultContinuousHyperParameterRange");
+    return __isa(o, "DefaultContinuousHyperParameterRange");
   }
 }
 
@@ -1507,7 +1510,7 @@ export interface DefaultHyperParameterRanges {
 
 export namespace DefaultHyperParameterRanges {
   export function isa(o: any): o is DefaultHyperParameterRanges {
-    return _smithy.isa(o, "DefaultHyperParameterRanges");
+    return __isa(o, "DefaultHyperParameterRanges");
   }
 }
 
@@ -1541,7 +1544,7 @@ export interface DefaultIntegerHyperParameterRange {
 
 export namespace DefaultIntegerHyperParameterRange {
   export function isa(o: any): o is DefaultIntegerHyperParameterRange {
-    return _smithy.isa(o, "DefaultIntegerHyperParameterRange");
+    return __isa(o, "DefaultIntegerHyperParameterRange");
   }
 }
 
@@ -1555,7 +1558,7 @@ export interface DeleteCampaignRequest {
 
 export namespace DeleteCampaignRequest {
   export function isa(o: any): o is DeleteCampaignRequest {
-    return _smithy.isa(o, "DeleteCampaignRequest");
+    return __isa(o, "DeleteCampaignRequest");
   }
 }
 
@@ -1569,7 +1572,7 @@ export interface DeleteDatasetGroupRequest {
 
 export namespace DeleteDatasetGroupRequest {
   export function isa(o: any): o is DeleteDatasetGroupRequest {
-    return _smithy.isa(o, "DeleteDatasetGroupRequest");
+    return __isa(o, "DeleteDatasetGroupRequest");
   }
 }
 
@@ -1583,7 +1586,7 @@ export interface DeleteDatasetRequest {
 
 export namespace DeleteDatasetRequest {
   export function isa(o: any): o is DeleteDatasetRequest {
-    return _smithy.isa(o, "DeleteDatasetRequest");
+    return __isa(o, "DeleteDatasetRequest");
   }
 }
 
@@ -1597,7 +1600,7 @@ export interface DeleteEventTrackerRequest {
 
 export namespace DeleteEventTrackerRequest {
   export function isa(o: any): o is DeleteEventTrackerRequest {
-    return _smithy.isa(o, "DeleteEventTrackerRequest");
+    return __isa(o, "DeleteEventTrackerRequest");
   }
 }
 
@@ -1611,7 +1614,7 @@ export interface DeleteSchemaRequest {
 
 export namespace DeleteSchemaRequest {
   export function isa(o: any): o is DeleteSchemaRequest {
-    return _smithy.isa(o, "DeleteSchemaRequest");
+    return __isa(o, "DeleteSchemaRequest");
   }
 }
 
@@ -1625,7 +1628,7 @@ export interface DeleteSolutionRequest {
 
 export namespace DeleteSolutionRequest {
   export function isa(o: any): o is DeleteSolutionRequest {
-    return _smithy.isa(o, "DeleteSolutionRequest");
+    return __isa(o, "DeleteSolutionRequest");
   }
 }
 
@@ -1639,7 +1642,7 @@ export interface DescribeAlgorithmRequest {
 
 export namespace DescribeAlgorithmRequest {
   export function isa(o: any): o is DescribeAlgorithmRequest {
-    return _smithy.isa(o, "DescribeAlgorithmRequest");
+    return __isa(o, "DescribeAlgorithmRequest");
   }
 }
 
@@ -1653,7 +1656,7 @@ export interface DescribeAlgorithmResponse extends $MetadataBearer {
 
 export namespace DescribeAlgorithmResponse {
   export function isa(o: any): o is DescribeAlgorithmResponse {
-    return _smithy.isa(o, "DescribeAlgorithmResponse");
+    return __isa(o, "DescribeAlgorithmResponse");
   }
 }
 
@@ -1667,7 +1670,7 @@ export interface DescribeBatchInferenceJobRequest {
 
 export namespace DescribeBatchInferenceJobRequest {
   export function isa(o: any): o is DescribeBatchInferenceJobRequest {
-    return _smithy.isa(o, "DescribeBatchInferenceJobRequest");
+    return __isa(o, "DescribeBatchInferenceJobRequest");
   }
 }
 
@@ -1681,7 +1684,7 @@ export interface DescribeBatchInferenceJobResponse extends $MetadataBearer {
 
 export namespace DescribeBatchInferenceJobResponse {
   export function isa(o: any): o is DescribeBatchInferenceJobResponse {
-    return _smithy.isa(o, "DescribeBatchInferenceJobResponse");
+    return __isa(o, "DescribeBatchInferenceJobResponse");
   }
 }
 
@@ -1695,7 +1698,7 @@ export interface DescribeCampaignRequest {
 
 export namespace DescribeCampaignRequest {
   export function isa(o: any): o is DescribeCampaignRequest {
-    return _smithy.isa(o, "DescribeCampaignRequest");
+    return __isa(o, "DescribeCampaignRequest");
   }
 }
 
@@ -1709,7 +1712,7 @@ export interface DescribeCampaignResponse extends $MetadataBearer {
 
 export namespace DescribeCampaignResponse {
   export function isa(o: any): o is DescribeCampaignResponse {
-    return _smithy.isa(o, "DescribeCampaignResponse");
+    return __isa(o, "DescribeCampaignResponse");
   }
 }
 
@@ -1723,7 +1726,7 @@ export interface DescribeDatasetGroupRequest {
 
 export namespace DescribeDatasetGroupRequest {
   export function isa(o: any): o is DescribeDatasetGroupRequest {
-    return _smithy.isa(o, "DescribeDatasetGroupRequest");
+    return __isa(o, "DescribeDatasetGroupRequest");
   }
 }
 
@@ -1737,7 +1740,7 @@ export interface DescribeDatasetGroupResponse extends $MetadataBearer {
 
 export namespace DescribeDatasetGroupResponse {
   export function isa(o: any): o is DescribeDatasetGroupResponse {
-    return _smithy.isa(o, "DescribeDatasetGroupResponse");
+    return __isa(o, "DescribeDatasetGroupResponse");
   }
 }
 
@@ -1751,7 +1754,7 @@ export interface DescribeDatasetImportJobRequest {
 
 export namespace DescribeDatasetImportJobRequest {
   export function isa(o: any): o is DescribeDatasetImportJobRequest {
-    return _smithy.isa(o, "DescribeDatasetImportJobRequest");
+    return __isa(o, "DescribeDatasetImportJobRequest");
   }
 }
 
@@ -1780,7 +1783,7 @@ export interface DescribeDatasetImportJobResponse extends $MetadataBearer {
 
 export namespace DescribeDatasetImportJobResponse {
   export function isa(o: any): o is DescribeDatasetImportJobResponse {
-    return _smithy.isa(o, "DescribeDatasetImportJobResponse");
+    return __isa(o, "DescribeDatasetImportJobResponse");
   }
 }
 
@@ -1794,7 +1797,7 @@ export interface DescribeDatasetRequest {
 
 export namespace DescribeDatasetRequest {
   export function isa(o: any): o is DescribeDatasetRequest {
-    return _smithy.isa(o, "DescribeDatasetRequest");
+    return __isa(o, "DescribeDatasetRequest");
   }
 }
 
@@ -1808,7 +1811,7 @@ export interface DescribeDatasetResponse extends $MetadataBearer {
 
 export namespace DescribeDatasetResponse {
   export function isa(o: any): o is DescribeDatasetResponse {
-    return _smithy.isa(o, "DescribeDatasetResponse");
+    return __isa(o, "DescribeDatasetResponse");
   }
 }
 
@@ -1822,7 +1825,7 @@ export interface DescribeEventTrackerRequest {
 
 export namespace DescribeEventTrackerRequest {
   export function isa(o: any): o is DescribeEventTrackerRequest {
-    return _smithy.isa(o, "DescribeEventTrackerRequest");
+    return __isa(o, "DescribeEventTrackerRequest");
   }
 }
 
@@ -1836,7 +1839,7 @@ export interface DescribeEventTrackerResponse extends $MetadataBearer {
 
 export namespace DescribeEventTrackerResponse {
   export function isa(o: any): o is DescribeEventTrackerResponse {
-    return _smithy.isa(o, "DescribeEventTrackerResponse");
+    return __isa(o, "DescribeEventTrackerResponse");
   }
 }
 
@@ -1850,7 +1853,7 @@ export interface DescribeFeatureTransformationRequest {
 
 export namespace DescribeFeatureTransformationRequest {
   export function isa(o: any): o is DescribeFeatureTransformationRequest {
-    return _smithy.isa(o, "DescribeFeatureTransformationRequest");
+    return __isa(o, "DescribeFeatureTransformationRequest");
   }
 }
 
@@ -1864,7 +1867,7 @@ export interface DescribeFeatureTransformationResponse extends $MetadataBearer {
 
 export namespace DescribeFeatureTransformationResponse {
   export function isa(o: any): o is DescribeFeatureTransformationResponse {
-    return _smithy.isa(o, "DescribeFeatureTransformationResponse");
+    return __isa(o, "DescribeFeatureTransformationResponse");
   }
 }
 
@@ -1878,7 +1881,7 @@ export interface DescribeRecipeRequest {
 
 export namespace DescribeRecipeRequest {
   export function isa(o: any): o is DescribeRecipeRequest {
-    return _smithy.isa(o, "DescribeRecipeRequest");
+    return __isa(o, "DescribeRecipeRequest");
   }
 }
 
@@ -1892,7 +1895,7 @@ export interface DescribeRecipeResponse extends $MetadataBearer {
 
 export namespace DescribeRecipeResponse {
   export function isa(o: any): o is DescribeRecipeResponse {
-    return _smithy.isa(o, "DescribeRecipeResponse");
+    return __isa(o, "DescribeRecipeResponse");
   }
 }
 
@@ -1906,7 +1909,7 @@ export interface DescribeSchemaRequest {
 
 export namespace DescribeSchemaRequest {
   export function isa(o: any): o is DescribeSchemaRequest {
-    return _smithy.isa(o, "DescribeSchemaRequest");
+    return __isa(o, "DescribeSchemaRequest");
   }
 }
 
@@ -1920,7 +1923,7 @@ export interface DescribeSchemaResponse extends $MetadataBearer {
 
 export namespace DescribeSchemaResponse {
   export function isa(o: any): o is DescribeSchemaResponse {
-    return _smithy.isa(o, "DescribeSchemaResponse");
+    return __isa(o, "DescribeSchemaResponse");
   }
 }
 
@@ -1934,7 +1937,7 @@ export interface DescribeSolutionRequest {
 
 export namespace DescribeSolutionRequest {
   export function isa(o: any): o is DescribeSolutionRequest {
-    return _smithy.isa(o, "DescribeSolutionRequest");
+    return __isa(o, "DescribeSolutionRequest");
   }
 }
 
@@ -1948,7 +1951,7 @@ export interface DescribeSolutionResponse extends $MetadataBearer {
 
 export namespace DescribeSolutionResponse {
   export function isa(o: any): o is DescribeSolutionResponse {
-    return _smithy.isa(o, "DescribeSolutionResponse");
+    return __isa(o, "DescribeSolutionResponse");
   }
 }
 
@@ -1962,7 +1965,7 @@ export interface DescribeSolutionVersionRequest {
 
 export namespace DescribeSolutionVersionRequest {
   export function isa(o: any): o is DescribeSolutionVersionRequest {
-    return _smithy.isa(o, "DescribeSolutionVersionRequest");
+    return __isa(o, "DescribeSolutionVersionRequest");
   }
 }
 
@@ -1976,7 +1979,7 @@ export interface DescribeSolutionVersionResponse extends $MetadataBearer {
 
 export namespace DescribeSolutionVersionResponse {
   export function isa(o: any): o is DescribeSolutionVersionResponse {
-    return _smithy.isa(o, "DescribeSolutionVersionResponse");
+    return __isa(o, "DescribeSolutionVersionResponse");
   }
 }
 
@@ -2038,7 +2041,7 @@ export interface EventTracker {
 
 export namespace EventTracker {
   export function isa(o: any): o is EventTracker {
-    return _smithy.isa(o, "EventTracker");
+    return __isa(o, "EventTracker");
   }
 }
 
@@ -2085,7 +2088,7 @@ export interface EventTrackerSummary {
 
 export namespace EventTrackerSummary {
   export function isa(o: any): o is EventTrackerSummary {
-    return _smithy.isa(o, "EventTrackerSummary");
+    return __isa(o, "EventTrackerSummary");
   }
 }
 
@@ -2134,7 +2137,7 @@ export interface FeatureTransformation {
 
 export namespace FeatureTransformation {
   export function isa(o: any): o is FeatureTransformation {
-    return _smithy.isa(o, "FeatureTransformation");
+    return __isa(o, "FeatureTransformation");
   }
 }
 
@@ -2148,7 +2151,7 @@ export interface GetSolutionMetricsRequest {
 
 export namespace GetSolutionMetricsRequest {
   export function isa(o: any): o is GetSolutionMetricsRequest {
-    return _smithy.isa(o, "GetSolutionMetricsRequest");
+    return __isa(o, "GetSolutionMetricsRequest");
   }
 }
 
@@ -2167,7 +2170,7 @@ export interface GetSolutionMetricsResponse extends $MetadataBearer {
 
 export namespace GetSolutionMetricsResponse {
   export function isa(o: any): o is GetSolutionMetricsResponse {
-    return _smithy.isa(o, "GetSolutionMetricsResponse");
+    return __isa(o, "GetSolutionMetricsResponse");
   }
 }
 
@@ -2195,7 +2198,7 @@ export interface HPOConfig {
 
 export namespace HPOConfig {
   export function isa(o: any): o is HPOConfig {
-    return _smithy.isa(o, "HPOConfig");
+    return __isa(o, "HPOConfig");
   }
 }
 
@@ -2222,7 +2225,7 @@ export interface HPOObjective {
 
 export namespace HPOObjective {
   export function isa(o: any): o is HPOObjective {
-    return _smithy.isa(o, "HPOObjective");
+    return __isa(o, "HPOObjective");
   }
 }
 
@@ -2254,7 +2257,7 @@ export interface HPOResourceConfig {
 
 export namespace HPOResourceConfig {
   export function isa(o: any): o is HPOResourceConfig {
-    return _smithy.isa(o, "HPOResourceConfig");
+    return __isa(o, "HPOResourceConfig");
   }
 }
 
@@ -2282,7 +2285,7 @@ export interface HyperParameterRanges {
 
 export namespace HyperParameterRanges {
   export function isa(o: any): o is HyperParameterRanges {
-    return _smithy.isa(o, "HyperParameterRanges");
+    return __isa(o, "HyperParameterRanges");
   }
 }
 
@@ -2309,7 +2312,7 @@ export interface IntegerHyperParameterRange {
 
 export namespace IntegerHyperParameterRange {
   export function isa(o: any): o is IntegerHyperParameterRange {
-    return _smithy.isa(o, "IntegerHyperParameterRange");
+    return __isa(o, "IntegerHyperParameterRange");
   }
 }
 
@@ -2335,7 +2338,7 @@ export interface ListBatchInferenceJobsRequest {
 
 export namespace ListBatchInferenceJobsRequest {
   export function isa(o: any): o is ListBatchInferenceJobsRequest {
-    return _smithy.isa(o, "ListBatchInferenceJobsRequest");
+    return __isa(o, "ListBatchInferenceJobsRequest");
   }
 }
 
@@ -2355,7 +2358,7 @@ export interface ListBatchInferenceJobsResponse extends $MetadataBearer {
 
 export namespace ListBatchInferenceJobsResponse {
   export function isa(o: any): o is ListBatchInferenceJobsResponse {
-    return _smithy.isa(o, "ListBatchInferenceJobsResponse");
+    return __isa(o, "ListBatchInferenceJobsResponse");
   }
 }
 
@@ -2381,7 +2384,7 @@ export interface ListCampaignsRequest {
 
 export namespace ListCampaignsRequest {
   export function isa(o: any): o is ListCampaignsRequest {
-    return _smithy.isa(o, "ListCampaignsRequest");
+    return __isa(o, "ListCampaignsRequest");
   }
 }
 
@@ -2400,7 +2403,7 @@ export interface ListCampaignsResponse extends $MetadataBearer {
 
 export namespace ListCampaignsResponse {
   export function isa(o: any): o is ListCampaignsResponse {
-    return _smithy.isa(o, "ListCampaignsResponse");
+    return __isa(o, "ListCampaignsResponse");
   }
 }
 
@@ -2420,7 +2423,7 @@ export interface ListDatasetGroupsRequest {
 
 export namespace ListDatasetGroupsRequest {
   export function isa(o: any): o is ListDatasetGroupsRequest {
-    return _smithy.isa(o, "ListDatasetGroupsRequest");
+    return __isa(o, "ListDatasetGroupsRequest");
   }
 }
 
@@ -2439,7 +2442,7 @@ export interface ListDatasetGroupsResponse extends $MetadataBearer {
 
 export namespace ListDatasetGroupsResponse {
   export function isa(o: any): o is ListDatasetGroupsResponse {
-    return _smithy.isa(o, "ListDatasetGroupsResponse");
+    return __isa(o, "ListDatasetGroupsResponse");
   }
 }
 
@@ -2464,7 +2467,7 @@ export interface ListDatasetImportJobsRequest {
 
 export namespace ListDatasetImportJobsRequest {
   export function isa(o: any): o is ListDatasetImportJobsRequest {
-    return _smithy.isa(o, "ListDatasetImportJobsRequest");
+    return __isa(o, "ListDatasetImportJobsRequest");
   }
 }
 
@@ -2483,7 +2486,7 @@ export interface ListDatasetImportJobsResponse extends $MetadataBearer {
 
 export namespace ListDatasetImportJobsResponse {
   export function isa(o: any): o is ListDatasetImportJobsResponse {
-    return _smithy.isa(o, "ListDatasetImportJobsResponse");
+    return __isa(o, "ListDatasetImportJobsResponse");
   }
 }
 
@@ -2509,7 +2512,7 @@ export interface ListDatasetsRequest {
 
 export namespace ListDatasetsRequest {
   export function isa(o: any): o is ListDatasetsRequest {
-    return _smithy.isa(o, "ListDatasetsRequest");
+    return __isa(o, "ListDatasetsRequest");
   }
 }
 
@@ -2528,7 +2531,7 @@ export interface ListDatasetsResponse extends $MetadataBearer {
 
 export namespace ListDatasetsResponse {
   export function isa(o: any): o is ListDatasetsResponse {
-    return _smithy.isa(o, "ListDatasetsResponse");
+    return __isa(o, "ListDatasetsResponse");
   }
 }
 
@@ -2553,7 +2556,7 @@ export interface ListEventTrackersRequest {
 
 export namespace ListEventTrackersRequest {
   export function isa(o: any): o is ListEventTrackersRequest {
-    return _smithy.isa(o, "ListEventTrackersRequest");
+    return __isa(o, "ListEventTrackersRequest");
   }
 }
 
@@ -2572,7 +2575,7 @@ export interface ListEventTrackersResponse extends $MetadataBearer {
 
 export namespace ListEventTrackersResponse {
   export function isa(o: any): o is ListEventTrackersResponse {
-    return _smithy.isa(o, "ListEventTrackersResponse");
+    return __isa(o, "ListEventTrackersResponse");
   }
 }
 
@@ -2597,7 +2600,7 @@ export interface ListRecipesRequest {
 
 export namespace ListRecipesRequest {
   export function isa(o: any): o is ListRecipesRequest {
-    return _smithy.isa(o, "ListRecipesRequest");
+    return __isa(o, "ListRecipesRequest");
   }
 }
 
@@ -2616,7 +2619,7 @@ export interface ListRecipesResponse extends $MetadataBearer {
 
 export namespace ListRecipesResponse {
   export function isa(o: any): o is ListRecipesResponse {
-    return _smithy.isa(o, "ListRecipesResponse");
+    return __isa(o, "ListRecipesResponse");
   }
 }
 
@@ -2636,7 +2639,7 @@ export interface ListSchemasRequest {
 
 export namespace ListSchemasRequest {
   export function isa(o: any): o is ListSchemasRequest {
-    return _smithy.isa(o, "ListSchemasRequest");
+    return __isa(o, "ListSchemasRequest");
   }
 }
 
@@ -2655,7 +2658,7 @@ export interface ListSchemasResponse extends $MetadataBearer {
 
 export namespace ListSchemasResponse {
   export function isa(o: any): o is ListSchemasResponse {
-    return _smithy.isa(o, "ListSchemasResponse");
+    return __isa(o, "ListSchemasResponse");
   }
 }
 
@@ -2680,7 +2683,7 @@ export interface ListSolutionVersionsRequest {
 
 export namespace ListSolutionVersionsRequest {
   export function isa(o: any): o is ListSolutionVersionsRequest {
-    return _smithy.isa(o, "ListSolutionVersionsRequest");
+    return __isa(o, "ListSolutionVersionsRequest");
   }
 }
 
@@ -2699,7 +2702,7 @@ export interface ListSolutionVersionsResponse extends $MetadataBearer {
 
 export namespace ListSolutionVersionsResponse {
   export function isa(o: any): o is ListSolutionVersionsResponse {
-    return _smithy.isa(o, "ListSolutionVersionsResponse");
+    return __isa(o, "ListSolutionVersionsResponse");
   }
 }
 
@@ -2724,7 +2727,7 @@ export interface ListSolutionsRequest {
 
 export namespace ListSolutionsRequest {
   export function isa(o: any): o is ListSolutionsRequest {
-    return _smithy.isa(o, "ListSolutionsRequest");
+    return __isa(o, "ListSolutionsRequest");
   }
 }
 
@@ -2743,7 +2746,7 @@ export interface ListSolutionsResponse extends $MetadataBearer {
 
 export namespace ListSolutionsResponse {
   export function isa(o: any): o is ListSolutionsResponse {
-    return _smithy.isa(o, "ListSolutionsResponse");
+    return __isa(o, "ListSolutionsResponse");
   }
 }
 
@@ -2814,7 +2817,7 @@ export interface Recipe {
 
 export namespace Recipe {
   export function isa(o: any): o is Recipe {
-    return _smithy.isa(o, "Recipe");
+    return __isa(o, "Recipe");
   }
 }
 
@@ -2856,7 +2859,7 @@ export interface RecipeSummary {
 
 export namespace RecipeSummary {
   export function isa(o: any): o is RecipeSummary {
-    return _smithy.isa(o, "RecipeSummary");
+    return __isa(o, "RecipeSummary");
   }
 }
 
@@ -2879,7 +2882,7 @@ export interface S3DataConfig {
 
 export namespace S3DataConfig {
   export function isa(o: any): o is S3DataConfig {
-    return _smithy.isa(o, "S3DataConfig");
+    return __isa(o, "S3DataConfig");
   }
 }
 
@@ -2969,7 +2972,7 @@ export interface Solution {
 
 export namespace Solution {
   export function isa(o: any): o is Solution {
-    return _smithy.isa(o, "Solution");
+    return __isa(o, "Solution");
   }
 }
 
@@ -3008,7 +3011,7 @@ export interface SolutionConfig {
 
 export namespace SolutionConfig {
   export function isa(o: any): o is SolutionConfig {
-    return _smithy.isa(o, "SolutionConfig");
+    return __isa(o, "SolutionConfig");
   }
 }
 
@@ -3055,7 +3058,7 @@ export interface SolutionSummary {
 
 export namespace SolutionSummary {
   export function isa(o: any): o is SolutionSummary {
-    return _smithy.isa(o, "SolutionSummary");
+    return __isa(o, "SolutionSummary");
   }
 }
 
@@ -3168,7 +3171,7 @@ export interface SolutionVersion {
 
 export namespace SolutionVersion {
   export function isa(o: any): o is SolutionVersion {
-    return _smithy.isa(o, "SolutionVersion");
+    return __isa(o, "SolutionVersion");
   }
 }
 
@@ -3212,7 +3215,7 @@ export interface SolutionVersionSummary {
 
 export namespace SolutionVersionSummary {
   export function isa(o: any): o is SolutionVersionSummary {
-    return _smithy.isa(o, "SolutionVersionSummary");
+    return __isa(o, "SolutionVersionSummary");
   }
 }
 
@@ -3242,7 +3245,7 @@ export interface UpdateCampaignRequest {
 
 export namespace UpdateCampaignRequest {
   export function isa(o: any): o is UpdateCampaignRequest {
-    return _smithy.isa(o, "UpdateCampaignRequest");
+    return __isa(o, "UpdateCampaignRequest");
   }
 }
 
@@ -3256,7 +3259,7 @@ export interface UpdateCampaignResponse extends $MetadataBearer {
 
 export namespace UpdateCampaignResponse {
   export function isa(o: any): o is UpdateCampaignResponse {
-    return _smithy.isa(o, "UpdateCampaignResponse");
+    return __isa(o, "UpdateCampaignResponse");
   }
 }
 
@@ -3264,7 +3267,7 @@ export namespace UpdateCampaignResponse {
  * <p>Provide a valid value for the field or parameter.</p>
  */
 export interface InvalidInputException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidInputException";
   $fault: "client";
@@ -3273,7 +3276,7 @@ export interface InvalidInputException
 
 export namespace InvalidInputException {
   export function isa(o: any): o is InvalidInputException {
-    return _smithy.isa(o, "InvalidInputException");
+    return __isa(o, "InvalidInputException");
   }
 }
 
@@ -3281,7 +3284,7 @@ export namespace InvalidInputException {
  * <p>The token is not valid.</p>
  */
 export interface InvalidNextTokenException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidNextTokenException";
   $fault: "client";
@@ -3290,7 +3293,7 @@ export interface InvalidNextTokenException
 
 export namespace InvalidNextTokenException {
   export function isa(o: any): o is InvalidNextTokenException {
-    return _smithy.isa(o, "InvalidNextTokenException");
+    return __isa(o, "InvalidNextTokenException");
   }
 }
 
@@ -3298,7 +3301,7 @@ export namespace InvalidNextTokenException {
  * <p>The limit on the number of requests per second has been exceeded.</p>
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -3307,7 +3310,7 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
@@ -3315,7 +3318,7 @@ export namespace LimitExceededException {
  * <p>The specified resource already exists.</p>
  */
 export interface ResourceAlreadyExistsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceAlreadyExistsException";
   $fault: "client";
@@ -3324,7 +3327,7 @@ export interface ResourceAlreadyExistsException
 
 export namespace ResourceAlreadyExistsException {
   export function isa(o: any): o is ResourceAlreadyExistsException {
-    return _smithy.isa(o, "ResourceAlreadyExistsException");
+    return __isa(o, "ResourceAlreadyExistsException");
   }
 }
 
@@ -3332,7 +3335,7 @@ export namespace ResourceAlreadyExistsException {
  * <p>The specified resource is in use.</p>
  */
 export interface ResourceInUseException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceInUseException";
   $fault: "client";
@@ -3341,7 +3344,7 @@ export interface ResourceInUseException
 
 export namespace ResourceInUseException {
   export function isa(o: any): o is ResourceInUseException {
-    return _smithy.isa(o, "ResourceInUseException");
+    return __isa(o, "ResourceInUseException");
   }
 }
 
@@ -3349,7 +3352,7 @@ export namespace ResourceInUseException {
  * <p>Could not find the specified resource.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -3358,6 +3361,6 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }

--- a/clients/client-personalize/protocols/Aws_json1_1.ts
+++ b/clients/client-personalize/protocols/Aws_json1_1.ts
@@ -1573,6 +1573,7 @@ export async function deserializeAws_json1_1DeleteCampaignCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1DeleteCampaignCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteCampaignCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1638,6 +1639,7 @@ export async function deserializeAws_json1_1DeleteDatasetCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1DeleteDatasetCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteDatasetCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1706,6 +1708,7 @@ export async function deserializeAws_json1_1DeleteDatasetGroupCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteDatasetGroupCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1774,6 +1777,7 @@ export async function deserializeAws_json1_1DeleteEventTrackerCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteEventTrackerCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1839,6 +1843,7 @@ export async function deserializeAws_json1_1DeleteSchemaCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1DeleteSchemaCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteSchemaCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1904,6 +1909,7 @@ export async function deserializeAws_json1_1DeleteSolutionCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1DeleteSolutionCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteSolutionCommandOutput = {
     $metadata: deserializeMetadata(output)
   };

--- a/clients/client-pi/models/index.ts
+++ b/clients/client-pi/models/index.ts
@@ -1,11 +1,14 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
  * <p>The request failed due to an unknown error.</p>
  */
 export interface InternalServiceError
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalServiceError";
   $fault: "server";
@@ -14,7 +17,7 @@ export interface InternalServiceError
 
 export namespace InternalServiceError {
   export function isa(o: any): o is InternalServiceError {
-    return _smithy.isa(o, "InternalServiceError");
+    return __isa(o, "InternalServiceError");
   }
 }
 
@@ -22,7 +25,7 @@ export namespace InternalServiceError {
  * <p>One of the arguments provided is invalid for this request.</p>
  */
 export interface InvalidArgumentException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidArgumentException";
   $fault: "client";
@@ -31,7 +34,7 @@ export interface InvalidArgumentException
 
 export namespace InvalidArgumentException {
   export function isa(o: any): o is InvalidArgumentException {
-    return _smithy.isa(o, "InvalidArgumentException");
+    return __isa(o, "InvalidArgumentException");
   }
 }
 
@@ -39,7 +42,7 @@ export namespace InvalidArgumentException {
  * <p>The user is not authorized to perform this request.</p>
  */
 export interface NotAuthorizedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "NotAuthorizedException";
   $fault: "client";
@@ -48,7 +51,7 @@ export interface NotAuthorizedException
 
 export namespace NotAuthorizedException {
   export function isa(o: any): o is NotAuthorizedException {
-    return _smithy.isa(o, "NotAuthorizedException");
+    return __isa(o, "NotAuthorizedException");
   }
 }
 
@@ -74,7 +77,7 @@ export interface DataPoint {
 
 export namespace DataPoint {
   export function isa(o: any): o is DataPoint {
-    return _smithy.isa(o, "DataPoint");
+    return __isa(o, "DataPoint");
   }
 }
 
@@ -214,7 +217,7 @@ export interface DescribeDimensionKeysRequest {
 
 export namespace DescribeDimensionKeysRequest {
   export function isa(o: any): o is DescribeDimensionKeysRequest {
-    return _smithy.isa(o, "DescribeDimensionKeysRequest");
+    return __isa(o, "DescribeDimensionKeysRequest");
   }
 }
 
@@ -254,7 +257,7 @@ export interface DescribeDimensionKeysResponse extends $MetadataBearer {
 
 export namespace DescribeDimensionKeysResponse {
   export function isa(o: any): o is DescribeDimensionKeysResponse {
-    return _smithy.isa(o, "DescribeDimensionKeysResponse");
+    return __isa(o, "DescribeDimensionKeysResponse");
   }
 }
 
@@ -364,7 +367,7 @@ export interface DimensionGroup {
 
 export namespace DimensionGroup {
   export function isa(o: any): o is DimensionGroup {
-    return _smithy.isa(o, "DimensionGroup");
+    return __isa(o, "DimensionGroup");
   }
 }
 
@@ -392,7 +395,7 @@ export interface DimensionKeyDescription {
 
 export namespace DimensionKeyDescription {
   export function isa(o: any): o is DimensionKeyDescription {
-    return _smithy.isa(o, "DimensionKeyDescription");
+    return __isa(o, "DimensionKeyDescription");
   }
 }
 
@@ -488,7 +491,7 @@ export interface GetResourceMetricsRequest {
 
 export namespace GetResourceMetricsRequest {
   export function isa(o: any): o is GetResourceMetricsRequest {
-    return _smithy.isa(o, "GetResourceMetricsRequest");
+    return __isa(o, "GetResourceMetricsRequest");
   }
 }
 
@@ -533,7 +536,7 @@ export interface GetResourceMetricsResponse extends $MetadataBearer {
 
 export namespace GetResourceMetricsResponse {
   export function isa(o: any): o is GetResourceMetricsResponse {
-    return _smithy.isa(o, "GetResourceMetricsResponse");
+    return __isa(o, "GetResourceMetricsResponse");
   }
 }
 
@@ -556,7 +559,7 @@ export interface MetricKeyDataPoints {
 
 export namespace MetricKeyDataPoints {
   export function isa(o: any): o is MetricKeyDataPoints {
-    return _smithy.isa(o, "MetricKeyDataPoints");
+    return __isa(o, "MetricKeyDataPoints");
   }
 }
 
@@ -611,7 +614,7 @@ export interface MetricQuery {
 
 export namespace MetricQuery {
   export function isa(o: any): o is MetricQuery {
-    return _smithy.isa(o, "MetricQuery");
+    return __isa(o, "MetricQuery");
   }
 }
 
@@ -630,7 +633,7 @@ export interface ResponsePartitionKey {
 
 export namespace ResponsePartitionKey {
   export function isa(o: any): o is ResponsePartitionKey {
-    return _smithy.isa(o, "ResponsePartitionKey");
+    return __isa(o, "ResponsePartitionKey");
   }
 }
 
@@ -666,6 +669,6 @@ export interface ResponseResourceMetricKey {
 
 export namespace ResponseResourceMetricKey {
   export function isa(o: any): o is ResponseResourceMetricKey {
-    return _smithy.isa(o, "ResponseResourceMetricKey");
+    return __isa(o, "ResponseResourceMetricKey");
   }
 }

--- a/clients/client-pinpoint-email/models/index.ts
+++ b/clients/client-pinpoint-email/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -55,7 +58,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -64,7 +67,7 @@ export namespace Tag {
  *             permanently restricted.</p>
  */
 export interface AccountSuspendedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AccountSuspendedException";
   $fault: "client";
@@ -73,7 +76,7 @@ export interface AccountSuspendedException
 
 export namespace AccountSuspendedException {
   export function isa(o: any): o is AccountSuspendedException {
-    return _smithy.isa(o, "AccountSuspendedException");
+    return __isa(o, "AccountSuspendedException");
   }
 }
 
@@ -81,7 +84,7 @@ export namespace AccountSuspendedException {
  * <p>The resource specified in your request already exists.</p>
  */
 export interface AlreadyExistsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AlreadyExistsException";
   $fault: "client";
@@ -90,7 +93,7 @@ export interface AlreadyExistsException
 
 export namespace AlreadyExistsException {
   export function isa(o: any): o is AlreadyExistsException {
-    return _smithy.isa(o, "AlreadyExistsException");
+    return __isa(o, "AlreadyExistsException");
   }
 }
 
@@ -98,7 +101,7 @@ export namespace AlreadyExistsException {
  * <p>The input you provided is invalid.</p>
  */
 export interface BadRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "BadRequestException";
   $fault: "client";
@@ -107,7 +110,7 @@ export interface BadRequestException
 
 export namespace BadRequestException {
   export function isa(o: any): o is BadRequestException {
-    return _smithy.isa(o, "BadRequestException");
+    return __isa(o, "BadRequestException");
   }
 }
 
@@ -141,7 +144,7 @@ export interface BlacklistEntry {
 
 export namespace BlacklistEntry {
   export function isa(o: any): o is BlacklistEntry {
-    return _smithy.isa(o, "BlacklistEntry");
+    return __isa(o, "BlacklistEntry");
   }
 }
 
@@ -167,7 +170,7 @@ export interface Body {
 
 export namespace Body {
   export function isa(o: any): o is Body {
-    return _smithy.isa(o, "Body");
+    return __isa(o, "Body");
   }
 }
 
@@ -186,7 +189,7 @@ export interface CloudWatchDestination {
 
 export namespace CloudWatchDestination {
   export function isa(o: any): o is CloudWatchDestination {
-    return _smithy.isa(o, "CloudWatchDestination");
+    return __isa(o, "CloudWatchDestination");
   }
 }
 
@@ -239,7 +242,7 @@ export interface CloudWatchDimensionConfiguration {
 
 export namespace CloudWatchDimensionConfiguration {
   export function isa(o: any): o is CloudWatchDimensionConfiguration {
-    return _smithy.isa(o, "CloudWatchDimensionConfiguration");
+    return __isa(o, "CloudWatchDimensionConfiguration");
   }
 }
 
@@ -247,7 +250,7 @@ export namespace CloudWatchDimensionConfiguration {
  * <p>The resource is being modified by another operation or thread.</p>
  */
 export interface ConcurrentModificationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ConcurrentModificationException";
   $fault: "server";
@@ -256,7 +259,7 @@ export interface ConcurrentModificationException
 
 export namespace ConcurrentModificationException {
   export function isa(o: any): o is ConcurrentModificationException {
-    return _smithy.isa(o, "ConcurrentModificationException");
+    return __isa(o, "ConcurrentModificationException");
   }
 }
 
@@ -282,7 +285,7 @@ export interface Content {
 
 export namespace Content {
   export function isa(o: any): o is Content {
-    return _smithy.isa(o, "Content");
+    return __isa(o, "Content");
   }
 }
 
@@ -311,7 +314,7 @@ export namespace CreateConfigurationSetEventDestinationRequest {
   export function isa(
     o: any
   ): o is CreateConfigurationSetEventDestinationRequest {
-    return _smithy.isa(o, "CreateConfigurationSetEventDestinationRequest");
+    return __isa(o, "CreateConfigurationSetEventDestinationRequest");
   }
 }
 
@@ -328,7 +331,7 @@ export namespace CreateConfigurationSetEventDestinationResponse {
   export function isa(
     o: any
   ): o is CreateConfigurationSetEventDestinationResponse {
-    return _smithy.isa(o, "CreateConfigurationSetEventDestinationResponse");
+    return __isa(o, "CreateConfigurationSetEventDestinationResponse");
   }
 }
 
@@ -375,7 +378,7 @@ export interface CreateConfigurationSetRequest {
 
 export namespace CreateConfigurationSetRequest {
   export function isa(o: any): o is CreateConfigurationSetRequest {
-    return _smithy.isa(o, "CreateConfigurationSetRequest");
+    return __isa(o, "CreateConfigurationSetRequest");
   }
 }
 
@@ -389,7 +392,7 @@ export interface CreateConfigurationSetResponse extends $MetadataBearer {
 
 export namespace CreateConfigurationSetResponse {
   export function isa(o: any): o is CreateConfigurationSetResponse {
-    return _smithy.isa(o, "CreateConfigurationSetResponse");
+    return __isa(o, "CreateConfigurationSetResponse");
   }
 }
 
@@ -412,7 +415,7 @@ export interface CreateDedicatedIpPoolRequest {
 
 export namespace CreateDedicatedIpPoolRequest {
   export function isa(o: any): o is CreateDedicatedIpPoolRequest {
-    return _smithy.isa(o, "CreateDedicatedIpPoolRequest");
+    return __isa(o, "CreateDedicatedIpPoolRequest");
   }
 }
 
@@ -426,7 +429,7 @@ export interface CreateDedicatedIpPoolResponse extends $MetadataBearer {
 
 export namespace CreateDedicatedIpPoolResponse {
   export function isa(o: any): o is CreateDedicatedIpPoolResponse {
-    return _smithy.isa(o, "CreateDedicatedIpPoolResponse");
+    return __isa(o, "CreateDedicatedIpPoolResponse");
   }
 }
 
@@ -466,7 +469,7 @@ export interface CreateDeliverabilityTestReportRequest {
 
 export namespace CreateDeliverabilityTestReportRequest {
   export function isa(o: any): o is CreateDeliverabilityTestReportRequest {
-    return _smithy.isa(o, "CreateDeliverabilityTestReportRequest");
+    return __isa(o, "CreateDeliverabilityTestReportRequest");
   }
 }
 
@@ -492,7 +495,7 @@ export interface CreateDeliverabilityTestReportResponse
 
 export namespace CreateDeliverabilityTestReportResponse {
   export function isa(o: any): o is CreateDeliverabilityTestReportResponse {
-    return _smithy.isa(o, "CreateDeliverabilityTestReportResponse");
+    return __isa(o, "CreateDeliverabilityTestReportResponse");
   }
 }
 
@@ -516,7 +519,7 @@ export interface CreateEmailIdentityRequest {
 
 export namespace CreateEmailIdentityRequest {
   export function isa(o: any): o is CreateEmailIdentityRequest {
-    return _smithy.isa(o, "CreateEmailIdentityRequest");
+    return __isa(o, "CreateEmailIdentityRequest");
   }
 }
 
@@ -550,7 +553,7 @@ export interface CreateEmailIdentityResponse extends $MetadataBearer {
 
 export namespace CreateEmailIdentityResponse {
   export function isa(o: any): o is CreateEmailIdentityResponse {
-    return _smithy.isa(o, "CreateEmailIdentityResponse");
+    return __isa(o, "CreateEmailIdentityResponse");
   }
 }
 
@@ -580,7 +583,7 @@ export interface DailyVolume {
 
 export namespace DailyVolume {
   export function isa(o: any): o is DailyVolume {
-    return _smithy.isa(o, "DailyVolume");
+    return __isa(o, "DailyVolume");
   }
 }
 
@@ -628,7 +631,7 @@ export interface DedicatedIp {
 
 export namespace DedicatedIp {
   export function isa(o: any): o is DedicatedIp {
-    return _smithy.isa(o, "DedicatedIp");
+    return __isa(o, "DedicatedIp");
   }
 }
 
@@ -653,7 +656,7 @@ export namespace DeleteConfigurationSetEventDestinationRequest {
   export function isa(
     o: any
   ): o is DeleteConfigurationSetEventDestinationRequest {
-    return _smithy.isa(o, "DeleteConfigurationSetEventDestinationRequest");
+    return __isa(o, "DeleteConfigurationSetEventDestinationRequest");
   }
 }
 
@@ -670,7 +673,7 @@ export namespace DeleteConfigurationSetEventDestinationResponse {
   export function isa(
     o: any
   ): o is DeleteConfigurationSetEventDestinationResponse {
-    return _smithy.isa(o, "DeleteConfigurationSetEventDestinationResponse");
+    return __isa(o, "DeleteConfigurationSetEventDestinationResponse");
   }
 }
 
@@ -687,7 +690,7 @@ export interface DeleteConfigurationSetRequest {
 
 export namespace DeleteConfigurationSetRequest {
   export function isa(o: any): o is DeleteConfigurationSetRequest {
-    return _smithy.isa(o, "DeleteConfigurationSetRequest");
+    return __isa(o, "DeleteConfigurationSetRequest");
   }
 }
 
@@ -701,7 +704,7 @@ export interface DeleteConfigurationSetResponse extends $MetadataBearer {
 
 export namespace DeleteConfigurationSetResponse {
   export function isa(o: any): o is DeleteConfigurationSetResponse {
-    return _smithy.isa(o, "DeleteConfigurationSetResponse");
+    return __isa(o, "DeleteConfigurationSetResponse");
   }
 }
 
@@ -718,7 +721,7 @@ export interface DeleteDedicatedIpPoolRequest {
 
 export namespace DeleteDedicatedIpPoolRequest {
   export function isa(o: any): o is DeleteDedicatedIpPoolRequest {
-    return _smithy.isa(o, "DeleteDedicatedIpPoolRequest");
+    return __isa(o, "DeleteDedicatedIpPoolRequest");
   }
 }
 
@@ -732,7 +735,7 @@ export interface DeleteDedicatedIpPoolResponse extends $MetadataBearer {
 
 export namespace DeleteDedicatedIpPoolResponse {
   export function isa(o: any): o is DeleteDedicatedIpPoolResponse {
-    return _smithy.isa(o, "DeleteDedicatedIpPoolResponse");
+    return __isa(o, "DeleteDedicatedIpPoolResponse");
   }
 }
 
@@ -752,7 +755,7 @@ export interface DeleteEmailIdentityRequest {
 
 export namespace DeleteEmailIdentityRequest {
   export function isa(o: any): o is DeleteEmailIdentityRequest {
-    return _smithy.isa(o, "DeleteEmailIdentityRequest");
+    return __isa(o, "DeleteEmailIdentityRequest");
   }
 }
 
@@ -766,7 +769,7 @@ export interface DeleteEmailIdentityResponse extends $MetadataBearer {
 
 export namespace DeleteEmailIdentityResponse {
   export function isa(o: any): o is DeleteEmailIdentityResponse {
-    return _smithy.isa(o, "DeleteEmailIdentityResponse");
+    return __isa(o, "DeleteEmailIdentityResponse");
   }
 }
 
@@ -817,7 +820,7 @@ export interface DeliverabilityTestReport {
 
 export namespace DeliverabilityTestReport {
   export function isa(o: any): o is DeliverabilityTestReport {
-    return _smithy.isa(o, "DeliverabilityTestReport");
+    return __isa(o, "DeliverabilityTestReport");
   }
 }
 
@@ -848,7 +851,7 @@ export interface DeliveryOptions {
 
 export namespace DeliveryOptions {
   export function isa(o: any): o is DeliveryOptions {
-    return _smithy.isa(o, "DeliveryOptions");
+    return __isa(o, "DeliveryOptions");
   }
 }
 
@@ -878,7 +881,7 @@ export interface Destination {
 
 export namespace Destination {
   export function isa(o: any): o is Destination {
-    return _smithy.isa(o, "Destination");
+    return __isa(o, "Destination");
   }
 }
 
@@ -948,7 +951,7 @@ export interface DkimAttributes {
 
 export namespace DkimAttributes {
   export function isa(o: any): o is DkimAttributes {
-    return _smithy.isa(o, "DkimAttributes");
+    return __isa(o, "DkimAttributes");
   }
 }
 
@@ -1056,7 +1059,7 @@ export interface DomainDeliverabilityCampaign {
 
 export namespace DomainDeliverabilityCampaign {
   export function isa(o: any): o is DomainDeliverabilityCampaign {
-    return _smithy.isa(o, "DomainDeliverabilityCampaign");
+    return __isa(o, "DomainDeliverabilityCampaign");
   }
 }
 
@@ -1089,7 +1092,7 @@ export interface DomainDeliverabilityTrackingOption {
 
 export namespace DomainDeliverabilityTrackingOption {
   export function isa(o: any): o is DomainDeliverabilityTrackingOption {
-    return _smithy.isa(o, "DomainDeliverabilityTrackingOption");
+    return __isa(o, "DomainDeliverabilityTrackingOption");
   }
 }
 
@@ -1131,7 +1134,7 @@ export interface DomainIspPlacement {
 
 export namespace DomainIspPlacement {
   export function isa(o: any): o is DomainIspPlacement {
-    return _smithy.isa(o, "DomainIspPlacement");
+    return __isa(o, "DomainIspPlacement");
   }
 }
 
@@ -1190,7 +1193,7 @@ export interface EmailContent {
 
 export namespace EmailContent {
   export function isa(o: any): o is EmailContent {
-    return _smithy.isa(o, "EmailContent");
+    return __isa(o, "EmailContent");
   }
 }
 
@@ -1250,7 +1253,7 @@ export interface EventDestination {
 
 export namespace EventDestination {
   export function isa(o: any): o is EventDestination {
-    return _smithy.isa(o, "EventDestination");
+    return __isa(o, "EventDestination");
   }
 }
 
@@ -1305,7 +1308,7 @@ export interface EventDestinationDefinition {
 
 export namespace EventDestinationDefinition {
   export function isa(o: any): o is EventDestinationDefinition {
-    return _smithy.isa(o, "EventDestinationDefinition");
+    return __isa(o, "EventDestinationDefinition");
   }
 }
 
@@ -1330,7 +1333,7 @@ export interface GetAccountRequest {
 
 export namespace GetAccountRequest {
   export function isa(o: any): o is GetAccountRequest {
-    return _smithy.isa(o, "GetAccountRequest");
+    return __isa(o, "GetAccountRequest");
   }
 }
 
@@ -1401,7 +1404,7 @@ export interface GetAccountResponse extends $MetadataBearer {
 
 export namespace GetAccountResponse {
   export function isa(o: any): o is GetAccountResponse {
-    return _smithy.isa(o, "GetAccountResponse");
+    return __isa(o, "GetAccountResponse");
   }
 }
 
@@ -1421,7 +1424,7 @@ export interface GetBlacklistReportsRequest {
 
 export namespace GetBlacklistReportsRequest {
   export function isa(o: any): o is GetBlacklistReportsRequest {
-    return _smithy.isa(o, "GetBlacklistReportsRequest");
+    return __isa(o, "GetBlacklistReportsRequest");
   }
 }
 
@@ -1439,7 +1442,7 @@ export interface GetBlacklistReportsResponse extends $MetadataBearer {
 
 export namespace GetBlacklistReportsResponse {
   export function isa(o: any): o is GetBlacklistReportsResponse {
-    return _smithy.isa(o, "GetBlacklistReportsResponse");
+    return __isa(o, "GetBlacklistReportsResponse");
   }
 }
 
@@ -1459,7 +1462,7 @@ export namespace GetConfigurationSetEventDestinationsRequest {
   export function isa(
     o: any
   ): o is GetConfigurationSetEventDestinationsRequest {
-    return _smithy.isa(o, "GetConfigurationSetEventDestinationsRequest");
+    return __isa(o, "GetConfigurationSetEventDestinationsRequest");
   }
 }
 
@@ -1480,7 +1483,7 @@ export namespace GetConfigurationSetEventDestinationsResponse {
   export function isa(
     o: any
   ): o is GetConfigurationSetEventDestinationsResponse {
-    return _smithy.isa(o, "GetConfigurationSetEventDestinationsResponse");
+    return __isa(o, "GetConfigurationSetEventDestinationsResponse");
   }
 }
 
@@ -1498,7 +1501,7 @@ export interface GetConfigurationSetRequest {
 
 export namespace GetConfigurationSetRequest {
   export function isa(o: any): o is GetConfigurationSetRequest {
-    return _smithy.isa(o, "GetConfigurationSetRequest");
+    return __isa(o, "GetConfigurationSetRequest");
   }
 }
 
@@ -1545,7 +1548,7 @@ export interface GetConfigurationSetResponse extends $MetadataBearer {
 
 export namespace GetConfigurationSetResponse {
   export function isa(o: any): o is GetConfigurationSetResponse {
-    return _smithy.isa(o, "GetConfigurationSetResponse");
+    return __isa(o, "GetConfigurationSetResponse");
   }
 }
 
@@ -1563,7 +1566,7 @@ export interface GetDedicatedIpRequest {
 
 export namespace GetDedicatedIpRequest {
   export function isa(o: any): o is GetDedicatedIpRequest {
-    return _smithy.isa(o, "GetDedicatedIpRequest");
+    return __isa(o, "GetDedicatedIpRequest");
   }
 }
 
@@ -1580,7 +1583,7 @@ export interface GetDedicatedIpResponse extends $MetadataBearer {
 
 export namespace GetDedicatedIpResponse {
   export function isa(o: any): o is GetDedicatedIpResponse {
-    return _smithy.isa(o, "GetDedicatedIpResponse");
+    return __isa(o, "GetDedicatedIpResponse");
   }
 }
 
@@ -1611,7 +1614,7 @@ export interface GetDedicatedIpsRequest {
 
 export namespace GetDedicatedIpsRequest {
   export function isa(o: any): o is GetDedicatedIpsRequest {
-    return _smithy.isa(o, "GetDedicatedIpsRequest");
+    return __isa(o, "GetDedicatedIpsRequest");
   }
 }
 
@@ -1637,7 +1640,7 @@ export interface GetDedicatedIpsResponse extends $MetadataBearer {
 
 export namespace GetDedicatedIpsResponse {
   export function isa(o: any): o is GetDedicatedIpsResponse {
-    return _smithy.isa(o, "GetDedicatedIpsResponse");
+    return __isa(o, "GetDedicatedIpsResponse");
   }
 }
 
@@ -1656,7 +1659,7 @@ export interface GetDeliverabilityDashboardOptionsRequest {
 
 export namespace GetDeliverabilityDashboardOptionsRequest {
   export function isa(o: any): o is GetDeliverabilityDashboardOptionsRequest {
-    return _smithy.isa(o, "GetDeliverabilityDashboardOptionsRequest");
+    return __isa(o, "GetDeliverabilityDashboardOptionsRequest");
   }
 }
 
@@ -1706,7 +1709,7 @@ export interface GetDeliverabilityDashboardOptionsResponse
 
 export namespace GetDeliverabilityDashboardOptionsResponse {
   export function isa(o: any): o is GetDeliverabilityDashboardOptionsResponse {
-    return _smithy.isa(o, "GetDeliverabilityDashboardOptionsResponse");
+    return __isa(o, "GetDeliverabilityDashboardOptionsResponse");
   }
 }
 
@@ -1723,7 +1726,7 @@ export interface GetDeliverabilityTestReportRequest {
 
 export namespace GetDeliverabilityTestReportRequest {
   export function isa(o: any): o is GetDeliverabilityTestReportRequest {
-    return _smithy.isa(o, "GetDeliverabilityTestReportRequest");
+    return __isa(o, "GetDeliverabilityTestReportRequest");
   }
 }
 
@@ -1765,7 +1768,7 @@ export interface GetDeliverabilityTestReportResponse extends $MetadataBearer {
 
 export namespace GetDeliverabilityTestReportResponse {
   export function isa(o: any): o is GetDeliverabilityTestReportResponse {
-    return _smithy.isa(o, "GetDeliverabilityTestReportResponse");
+    return __isa(o, "GetDeliverabilityTestReportResponse");
   }
 }
 
@@ -1788,7 +1791,7 @@ export interface GetDomainDeliverabilityCampaignRequest {
 
 export namespace GetDomainDeliverabilityCampaignRequest {
   export function isa(o: any): o is GetDomainDeliverabilityCampaignRequest {
-    return _smithy.isa(o, "GetDomainDeliverabilityCampaignRequest");
+    return __isa(o, "GetDomainDeliverabilityCampaignRequest");
   }
 }
 
@@ -1809,7 +1812,7 @@ export interface GetDomainDeliverabilityCampaignResponse
 
 export namespace GetDomainDeliverabilityCampaignResponse {
   export function isa(o: any): o is GetDomainDeliverabilityCampaignResponse {
-    return _smithy.isa(o, "GetDomainDeliverabilityCampaignResponse");
+    return __isa(o, "GetDomainDeliverabilityCampaignResponse");
   }
 }
 
@@ -1839,7 +1842,7 @@ export interface GetDomainStatisticsReportRequest {
 
 export namespace GetDomainStatisticsReportRequest {
   export function isa(o: any): o is GetDomainStatisticsReportRequest {
-    return _smithy.isa(o, "GetDomainStatisticsReportRequest");
+    return __isa(o, "GetDomainStatisticsReportRequest");
   }
 }
 
@@ -1866,7 +1869,7 @@ export interface GetDomainStatisticsReportResponse extends $MetadataBearer {
 
 export namespace GetDomainStatisticsReportResponse {
   export function isa(o: any): o is GetDomainStatisticsReportResponse {
-    return _smithy.isa(o, "GetDomainStatisticsReportResponse");
+    return __isa(o, "GetDomainStatisticsReportResponse");
   }
 }
 
@@ -1883,7 +1886,7 @@ export interface GetEmailIdentityRequest {
 
 export namespace GetEmailIdentityRequest {
   export function isa(o: any): o is GetEmailIdentityRequest {
-    return _smithy.isa(o, "GetEmailIdentityRequest");
+    return __isa(o, "GetEmailIdentityRequest");
   }
 }
 
@@ -1939,7 +1942,7 @@ export interface GetEmailIdentityResponse extends $MetadataBearer {
 
 export namespace GetEmailIdentityResponse {
   export function isa(o: any): o is GetEmailIdentityResponse {
-    return _smithy.isa(o, "GetEmailIdentityResponse");
+    return __isa(o, "GetEmailIdentityResponse");
   }
 }
 
@@ -1984,7 +1987,7 @@ export interface IdentityInfo {
 
 export namespace IdentityInfo {
   export function isa(o: any): o is IdentityInfo {
-    return _smithy.isa(o, "IdentityInfo");
+    return __isa(o, "IdentityInfo");
   }
 }
 
@@ -2016,7 +2019,7 @@ export interface InboxPlacementTrackingOption {
 
 export namespace InboxPlacementTrackingOption {
   export function isa(o: any): o is InboxPlacementTrackingOption {
-    return _smithy.isa(o, "InboxPlacementTrackingOption");
+    return __isa(o, "InboxPlacementTrackingOption");
   }
 }
 
@@ -2039,7 +2042,7 @@ export interface IspPlacement {
 
 export namespace IspPlacement {
   export function isa(o: any): o is IspPlacement {
-    return _smithy.isa(o, "IspPlacement");
+    return __isa(o, "IspPlacement");
   }
 }
 
@@ -2064,7 +2067,7 @@ export interface KinesisFirehoseDestination {
 
 export namespace KinesisFirehoseDestination {
   export function isa(o: any): o is KinesisFirehoseDestination {
-    return _smithy.isa(o, "KinesisFirehoseDestination");
+    return __isa(o, "KinesisFirehoseDestination");
   }
 }
 
@@ -2072,7 +2075,7 @@ export namespace KinesisFirehoseDestination {
  * <p>There are too many instances of the specified resource type.</p>
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -2081,7 +2084,7 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
@@ -2108,7 +2111,7 @@ export interface ListConfigurationSetsRequest {
 
 export namespace ListConfigurationSetsRequest {
   export function isa(o: any): o is ListConfigurationSetsRequest {
-    return _smithy.isa(o, "ListConfigurationSetsRequest");
+    return __isa(o, "ListConfigurationSetsRequest");
   }
 }
 
@@ -2134,7 +2137,7 @@ export interface ListConfigurationSetsResponse extends $MetadataBearer {
 
 export namespace ListConfigurationSetsResponse {
   export function isa(o: any): o is ListConfigurationSetsResponse {
-    return _smithy.isa(o, "ListConfigurationSetsResponse");
+    return __isa(o, "ListConfigurationSetsResponse");
   }
 }
 
@@ -2160,7 +2163,7 @@ export interface ListDedicatedIpPoolsRequest {
 
 export namespace ListDedicatedIpPoolsRequest {
   export function isa(o: any): o is ListDedicatedIpPoolsRequest {
-    return _smithy.isa(o, "ListDedicatedIpPoolsRequest");
+    return __isa(o, "ListDedicatedIpPoolsRequest");
   }
 }
 
@@ -2185,7 +2188,7 @@ export interface ListDedicatedIpPoolsResponse extends $MetadataBearer {
 
 export namespace ListDedicatedIpPoolsResponse {
   export function isa(o: any): o is ListDedicatedIpPoolsResponse {
-    return _smithy.isa(o, "ListDedicatedIpPoolsResponse");
+    return __isa(o, "ListDedicatedIpPoolsResponse");
   }
 }
 
@@ -2213,7 +2216,7 @@ export interface ListDeliverabilityTestReportsRequest {
 
 export namespace ListDeliverabilityTestReportsRequest {
   export function isa(o: any): o is ListDeliverabilityTestReportsRequest {
-    return _smithy.isa(o, "ListDeliverabilityTestReportsRequest");
+    return __isa(o, "ListDeliverabilityTestReportsRequest");
   }
 }
 
@@ -2238,7 +2241,7 @@ export interface ListDeliverabilityTestReportsResponse extends $MetadataBearer {
 
 export namespace ListDeliverabilityTestReportsResponse {
   export function isa(o: any): o is ListDeliverabilityTestReportsResponse {
-    return _smithy.isa(o, "ListDeliverabilityTestReportsResponse");
+    return __isa(o, "ListDeliverabilityTestReportsResponse");
   }
 }
 
@@ -2287,7 +2290,7 @@ export interface ListDomainDeliverabilityCampaignsRequest {
 
 export namespace ListDomainDeliverabilityCampaignsRequest {
   export function isa(o: any): o is ListDomainDeliverabilityCampaignsRequest {
-    return _smithy.isa(o, "ListDomainDeliverabilityCampaignsRequest");
+    return __isa(o, "ListDomainDeliverabilityCampaignsRequest");
   }
 }
 
@@ -2318,7 +2321,7 @@ export interface ListDomainDeliverabilityCampaignsResponse
 
 export namespace ListDomainDeliverabilityCampaignsResponse {
   export function isa(o: any): o is ListDomainDeliverabilityCampaignsResponse {
-    return _smithy.isa(o, "ListDomainDeliverabilityCampaignsResponse");
+    return __isa(o, "ListDomainDeliverabilityCampaignsResponse");
   }
 }
 
@@ -2347,7 +2350,7 @@ export interface ListEmailIdentitiesRequest {
 
 export namespace ListEmailIdentitiesRequest {
   export function isa(o: any): o is ListEmailIdentitiesRequest {
-    return _smithy.isa(o, "ListEmailIdentitiesRequest");
+    return __isa(o, "ListEmailIdentitiesRequest");
   }
 }
 
@@ -2374,7 +2377,7 @@ export interface ListEmailIdentitiesResponse extends $MetadataBearer {
 
 export namespace ListEmailIdentitiesResponse {
   export function isa(o: any): o is ListEmailIdentitiesResponse {
-    return _smithy.isa(o, "ListEmailIdentitiesResponse");
+    return __isa(o, "ListEmailIdentitiesResponse");
   }
 }
 
@@ -2389,7 +2392,7 @@ export interface ListTagsForResourceRequest {
 
 export namespace ListTagsForResourceRequest {
   export function isa(o: any): o is ListTagsForResourceRequest {
-    return _smithy.isa(o, "ListTagsForResourceRequest");
+    return __isa(o, "ListTagsForResourceRequest");
   }
 }
 
@@ -2405,7 +2408,7 @@ export interface ListTagsForResourceResponse extends $MetadataBearer {
 
 export namespace ListTagsForResourceResponse {
   export function isa(o: any): o is ListTagsForResourceResponse {
-    return _smithy.isa(o, "ListTagsForResourceResponse");
+    return __isa(o, "ListTagsForResourceResponse");
   }
 }
 
@@ -2461,7 +2464,7 @@ export interface MailFromAttributes {
 
 export namespace MailFromAttributes {
   export function isa(o: any): o is MailFromAttributes {
-    return _smithy.isa(o, "MailFromAttributes");
+    return __isa(o, "MailFromAttributes");
   }
 }
 
@@ -2469,7 +2472,7 @@ export namespace MailFromAttributes {
  * <p>The message can't be sent because the sending domain isn't verified.</p>
  */
 export interface MailFromDomainNotVerifiedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "MailFromDomainNotVerifiedException";
   $fault: "client";
@@ -2478,7 +2481,7 @@ export interface MailFromDomainNotVerifiedException
 
 export namespace MailFromDomainNotVerifiedException {
   export function isa(o: any): o is MailFromDomainNotVerifiedException {
-    return _smithy.isa(o, "MailFromDomainNotVerifiedException");
+    return __isa(o, "MailFromDomainNotVerifiedException");
   }
 }
 
@@ -2511,16 +2514,14 @@ export interface Message {
 
 export namespace Message {
   export function isa(o: any): o is Message {
-    return _smithy.isa(o, "Message");
+    return __isa(o, "Message");
   }
 }
 
 /**
  * <p>The message can't be sent because it contains invalid content.</p>
  */
-export interface MessageRejected
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface MessageRejected extends __SmithyException, $MetadataBearer {
   name: "MessageRejected";
   $fault: "client";
   message?: string;
@@ -2528,7 +2529,7 @@ export interface MessageRejected
 
 export namespace MessageRejected {
   export function isa(o: any): o is MessageRejected {
-    return _smithy.isa(o, "MessageRejected");
+    return __isa(o, "MessageRejected");
   }
 }
 
@@ -2572,16 +2573,14 @@ export interface MessageTag {
 
 export namespace MessageTag {
   export function isa(o: any): o is MessageTag {
-    return _smithy.isa(o, "MessageTag");
+    return __isa(o, "MessageTag");
   }
 }
 
 /**
  * <p>The resource you attempted to access doesn't exist.</p>
  */
-export interface NotFoundException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface NotFoundException extends __SmithyException, $MetadataBearer {
   name: "NotFoundException";
   $fault: "client";
   message?: string;
@@ -2589,7 +2588,7 @@ export interface NotFoundException
 
 export namespace NotFoundException {
   export function isa(o: any): o is NotFoundException {
-    return _smithy.isa(o, "NotFoundException");
+    return __isa(o, "NotFoundException");
   }
 }
 
@@ -2620,7 +2619,7 @@ export interface OverallVolume {
 
 export namespace OverallVolume {
   export function isa(o: any): o is OverallVolume {
-    return _smithy.isa(o, "OverallVolume");
+    return __isa(o, "OverallVolume");
   }
 }
 
@@ -2640,7 +2639,7 @@ export interface PinpointDestination {
 
 export namespace PinpointDestination {
   export function isa(o: any): o is PinpointDestination {
-    return _smithy.isa(o, "PinpointDestination");
+    return __isa(o, "PinpointDestination");
   }
 }
 
@@ -2681,7 +2680,7 @@ export interface PlacementStatistics {
 
 export namespace PlacementStatistics {
   export function isa(o: any): o is PlacementStatistics {
-    return _smithy.isa(o, "PlacementStatistics");
+    return __isa(o, "PlacementStatistics");
   }
 }
 
@@ -2703,7 +2702,7 @@ export namespace PutAccountDedicatedIpWarmupAttributesRequest {
   export function isa(
     o: any
   ): o is PutAccountDedicatedIpWarmupAttributesRequest {
-    return _smithy.isa(o, "PutAccountDedicatedIpWarmupAttributesRequest");
+    return __isa(o, "PutAccountDedicatedIpWarmupAttributesRequest");
   }
 }
 
@@ -2720,7 +2719,7 @@ export namespace PutAccountDedicatedIpWarmupAttributesResponse {
   export function isa(
     o: any
   ): o is PutAccountDedicatedIpWarmupAttributesResponse {
-    return _smithy.isa(o, "PutAccountDedicatedIpWarmupAttributesResponse");
+    return __isa(o, "PutAccountDedicatedIpWarmupAttributesResponse");
   }
 }
 
@@ -2742,7 +2741,7 @@ export interface PutAccountSendingAttributesRequest {
 
 export namespace PutAccountSendingAttributesRequest {
   export function isa(o: any): o is PutAccountSendingAttributesRequest {
-    return _smithy.isa(o, "PutAccountSendingAttributesRequest");
+    return __isa(o, "PutAccountSendingAttributesRequest");
   }
 }
 
@@ -2756,7 +2755,7 @@ export interface PutAccountSendingAttributesResponse extends $MetadataBearer {
 
 export namespace PutAccountSendingAttributesResponse {
   export function isa(o: any): o is PutAccountSendingAttributesResponse {
-    return _smithy.isa(o, "PutAccountSendingAttributesResponse");
+    return __isa(o, "PutAccountSendingAttributesResponse");
   }
 }
 
@@ -2788,7 +2787,7 @@ export interface PutConfigurationSetDeliveryOptionsRequest {
 
 export namespace PutConfigurationSetDeliveryOptionsRequest {
   export function isa(o: any): o is PutConfigurationSetDeliveryOptionsRequest {
-    return _smithy.isa(o, "PutConfigurationSetDeliveryOptionsRequest");
+    return __isa(o, "PutConfigurationSetDeliveryOptionsRequest");
   }
 }
 
@@ -2803,7 +2802,7 @@ export interface PutConfigurationSetDeliveryOptionsResponse
 
 export namespace PutConfigurationSetDeliveryOptionsResponse {
   export function isa(o: any): o is PutConfigurationSetDeliveryOptionsResponse {
-    return _smithy.isa(o, "PutConfigurationSetDeliveryOptionsResponse");
+    return __isa(o, "PutConfigurationSetDeliveryOptionsResponse");
   }
 }
 
@@ -2831,7 +2830,7 @@ export namespace PutConfigurationSetReputationOptionsRequest {
   export function isa(
     o: any
   ): o is PutConfigurationSetReputationOptionsRequest {
-    return _smithy.isa(o, "PutConfigurationSetReputationOptionsRequest");
+    return __isa(o, "PutConfigurationSetReputationOptionsRequest");
   }
 }
 
@@ -2848,7 +2847,7 @@ export namespace PutConfigurationSetReputationOptionsResponse {
   export function isa(
     o: any
   ): o is PutConfigurationSetReputationOptionsResponse {
-    return _smithy.isa(o, "PutConfigurationSetReputationOptionsResponse");
+    return __isa(o, "PutConfigurationSetReputationOptionsResponse");
   }
 }
 
@@ -2873,7 +2872,7 @@ export interface PutConfigurationSetSendingOptionsRequest {
 
 export namespace PutConfigurationSetSendingOptionsRequest {
   export function isa(o: any): o is PutConfigurationSetSendingOptionsRequest {
-    return _smithy.isa(o, "PutConfigurationSetSendingOptionsRequest");
+    return __isa(o, "PutConfigurationSetSendingOptionsRequest");
   }
 }
 
@@ -2888,7 +2887,7 @@ export interface PutConfigurationSetSendingOptionsResponse
 
 export namespace PutConfigurationSetSendingOptionsResponse {
   export function isa(o: any): o is PutConfigurationSetSendingOptionsResponse {
-    return _smithy.isa(o, "PutConfigurationSetSendingOptionsResponse");
+    return __isa(o, "PutConfigurationSetSendingOptionsResponse");
   }
 }
 
@@ -2912,7 +2911,7 @@ export interface PutConfigurationSetTrackingOptionsRequest {
 
 export namespace PutConfigurationSetTrackingOptionsRequest {
   export function isa(o: any): o is PutConfigurationSetTrackingOptionsRequest {
-    return _smithy.isa(o, "PutConfigurationSetTrackingOptionsRequest");
+    return __isa(o, "PutConfigurationSetTrackingOptionsRequest");
   }
 }
 
@@ -2927,7 +2926,7 @@ export interface PutConfigurationSetTrackingOptionsResponse
 
 export namespace PutConfigurationSetTrackingOptionsResponse {
   export function isa(o: any): o is PutConfigurationSetTrackingOptionsResponse {
-    return _smithy.isa(o, "PutConfigurationSetTrackingOptionsResponse");
+    return __isa(o, "PutConfigurationSetTrackingOptionsResponse");
   }
 }
 
@@ -2951,7 +2950,7 @@ export interface PutDedicatedIpInPoolRequest {
 
 export namespace PutDedicatedIpInPoolRequest {
   export function isa(o: any): o is PutDedicatedIpInPoolRequest {
-    return _smithy.isa(o, "PutDedicatedIpInPoolRequest");
+    return __isa(o, "PutDedicatedIpInPoolRequest");
   }
 }
 
@@ -2965,7 +2964,7 @@ export interface PutDedicatedIpInPoolResponse extends $MetadataBearer {
 
 export namespace PutDedicatedIpInPoolResponse {
   export function isa(o: any): o is PutDedicatedIpInPoolResponse {
-    return _smithy.isa(o, "PutDedicatedIpInPoolResponse");
+    return __isa(o, "PutDedicatedIpInPoolResponse");
   }
 }
 
@@ -2989,7 +2988,7 @@ export interface PutDedicatedIpWarmupAttributesRequest {
 
 export namespace PutDedicatedIpWarmupAttributesRequest {
   export function isa(o: any): o is PutDedicatedIpWarmupAttributesRequest {
-    return _smithy.isa(o, "PutDedicatedIpWarmupAttributesRequest");
+    return __isa(o, "PutDedicatedIpWarmupAttributesRequest");
   }
 }
 
@@ -3004,7 +3003,7 @@ export interface PutDedicatedIpWarmupAttributesResponse
 
 export namespace PutDedicatedIpWarmupAttributesResponse {
   export function isa(o: any): o is PutDedicatedIpWarmupAttributesResponse {
-    return _smithy.isa(o, "PutDedicatedIpWarmupAttributesResponse");
+    return __isa(o, "PutDedicatedIpWarmupAttributesResponse");
   }
 }
 
@@ -3034,7 +3033,7 @@ export interface PutDeliverabilityDashboardOptionRequest {
 
 export namespace PutDeliverabilityDashboardOptionRequest {
   export function isa(o: any): o is PutDeliverabilityDashboardOptionRequest {
-    return _smithy.isa(o, "PutDeliverabilityDashboardOptionRequest");
+    return __isa(o, "PutDeliverabilityDashboardOptionRequest");
   }
 }
 
@@ -3049,7 +3048,7 @@ export interface PutDeliverabilityDashboardOptionResponse
 
 export namespace PutDeliverabilityDashboardOptionResponse {
   export function isa(o: any): o is PutDeliverabilityDashboardOptionResponse {
-    return _smithy.isa(o, "PutDeliverabilityDashboardOptionResponse");
+    return __isa(o, "PutDeliverabilityDashboardOptionResponse");
   }
 }
 
@@ -3075,7 +3074,7 @@ export interface PutEmailIdentityDkimAttributesRequest {
 
 export namespace PutEmailIdentityDkimAttributesRequest {
   export function isa(o: any): o is PutEmailIdentityDkimAttributesRequest {
-    return _smithy.isa(o, "PutEmailIdentityDkimAttributesRequest");
+    return __isa(o, "PutEmailIdentityDkimAttributesRequest");
   }
 }
 
@@ -3090,7 +3089,7 @@ export interface PutEmailIdentityDkimAttributesResponse
 
 export namespace PutEmailIdentityDkimAttributesResponse {
   export function isa(o: any): o is PutEmailIdentityDkimAttributesResponse {
-    return _smithy.isa(o, "PutEmailIdentityDkimAttributesResponse");
+    return __isa(o, "PutEmailIdentityDkimAttributesResponse");
   }
 }
 
@@ -3122,7 +3121,7 @@ export interface PutEmailIdentityFeedbackAttributesRequest {
 
 export namespace PutEmailIdentityFeedbackAttributesRequest {
   export function isa(o: any): o is PutEmailIdentityFeedbackAttributesRequest {
-    return _smithy.isa(o, "PutEmailIdentityFeedbackAttributesRequest");
+    return __isa(o, "PutEmailIdentityFeedbackAttributesRequest");
   }
 }
 
@@ -3137,7 +3136,7 @@ export interface PutEmailIdentityFeedbackAttributesResponse
 
 export namespace PutEmailIdentityFeedbackAttributesResponse {
   export function isa(o: any): o is PutEmailIdentityFeedbackAttributesResponse {
-    return _smithy.isa(o, "PutEmailIdentityFeedbackAttributesResponse");
+    return __isa(o, "PutEmailIdentityFeedbackAttributesResponse");
   }
 }
 
@@ -3185,7 +3184,7 @@ export interface PutEmailIdentityMailFromAttributesRequest {
 
 export namespace PutEmailIdentityMailFromAttributesRequest {
   export function isa(o: any): o is PutEmailIdentityMailFromAttributesRequest {
-    return _smithy.isa(o, "PutEmailIdentityMailFromAttributesRequest");
+    return __isa(o, "PutEmailIdentityMailFromAttributesRequest");
   }
 }
 
@@ -3200,7 +3199,7 @@ export interface PutEmailIdentityMailFromAttributesResponse
 
 export namespace PutEmailIdentityMailFromAttributesResponse {
   export function isa(o: any): o is PutEmailIdentityMailFromAttributesResponse {
-    return _smithy.isa(o, "PutEmailIdentityMailFromAttributesResponse");
+    return __isa(o, "PutEmailIdentityMailFromAttributesResponse");
   }
 }
 
@@ -3245,7 +3244,7 @@ export interface RawMessage {
 
 export namespace RawMessage {
   export function isa(o: any): o is RawMessage {
-    return _smithy.isa(o, "RawMessage");
+    return __isa(o, "RawMessage");
   }
 }
 
@@ -3272,7 +3271,7 @@ export interface ReputationOptions {
 
 export namespace ReputationOptions {
   export function isa(o: any): o is ReputationOptions {
-    return _smithy.isa(o, "ReputationOptions");
+    return __isa(o, "ReputationOptions");
   }
 }
 
@@ -3325,7 +3324,7 @@ export interface SendEmailRequest {
 
 export namespace SendEmailRequest {
   export function isa(o: any): o is SendEmailRequest {
-    return _smithy.isa(o, "SendEmailRequest");
+    return __isa(o, "SendEmailRequest");
   }
 }
 
@@ -3349,7 +3348,7 @@ export interface SendEmailResponse extends $MetadataBearer {
 
 export namespace SendEmailResponse {
   export function isa(o: any): o is SendEmailResponse {
-    return _smithy.isa(o, "SendEmailResponse");
+    return __isa(o, "SendEmailResponse");
   }
 }
 
@@ -3382,7 +3381,7 @@ export interface SendQuota {
 
 export namespace SendQuota {
   export function isa(o: any): o is SendQuota {
-    return _smithy.isa(o, "SendQuota");
+    return __isa(o, "SendQuota");
   }
 }
 
@@ -3401,7 +3400,7 @@ export interface SendingOptions {
 
 export namespace SendingOptions {
   export function isa(o: any): o is SendingOptions {
-    return _smithy.isa(o, "SendingOptions");
+    return __isa(o, "SendingOptions");
   }
 }
 
@@ -3410,7 +3409,7 @@ export namespace SendingOptions {
  *             paused.</p>
  */
 export interface SendingPausedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "SendingPausedException";
   $fault: "client";
@@ -3419,7 +3418,7 @@ export interface SendingPausedException
 
 export namespace SendingPausedException {
   export function isa(o: any): o is SendingPausedException {
-    return _smithy.isa(o, "SendingPausedException");
+    return __isa(o, "SendingPausedException");
   }
 }
 
@@ -3439,7 +3438,7 @@ export interface SnsDestination {
 
 export namespace SnsDestination {
   export function isa(o: any): o is SnsDestination {
-    return _smithy.isa(o, "SnsDestination");
+    return __isa(o, "SnsDestination");
   }
 }
 
@@ -3462,7 +3461,7 @@ export interface TagResourceRequest {
 
 export namespace TagResourceRequest {
   export function isa(o: any): o is TagResourceRequest {
-    return _smithy.isa(o, "TagResourceRequest");
+    return __isa(o, "TagResourceRequest");
   }
 }
 
@@ -3472,7 +3471,7 @@ export interface TagResourceResponse extends $MetadataBearer {
 
 export namespace TagResourceResponse {
   export function isa(o: any): o is TagResourceResponse {
-    return _smithy.isa(o, "TagResourceResponse");
+    return __isa(o, "TagResourceResponse");
   }
 }
 
@@ -3491,7 +3490,7 @@ export interface Template {
 
 export namespace Template {
   export function isa(o: any): o is Template {
-    return _smithy.isa(o, "Template");
+    return __isa(o, "Template");
   }
 }
 
@@ -3504,7 +3503,7 @@ export enum TlsPolicy {
  * <p>Too many requests have been made to the operation.</p>
  */
 export interface TooManyRequestsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyRequestsException";
   $fault: "client";
@@ -3513,7 +3512,7 @@ export interface TooManyRequestsException
 
 export namespace TooManyRequestsException {
   export function isa(o: any): o is TooManyRequestsException {
-    return _smithy.isa(o, "TooManyRequestsException");
+    return __isa(o, "TooManyRequestsException");
   }
 }
 
@@ -3536,7 +3535,7 @@ export interface TrackingOptions {
 
 export namespace TrackingOptions {
   export function isa(o: any): o is TrackingOptions {
-    return _smithy.isa(o, "TrackingOptions");
+    return __isa(o, "TrackingOptions");
   }
 }
 
@@ -3562,7 +3561,7 @@ export interface UntagResourceRequest {
 
 export namespace UntagResourceRequest {
   export function isa(o: any): o is UntagResourceRequest {
-    return _smithy.isa(o, "UntagResourceRequest");
+    return __isa(o, "UntagResourceRequest");
   }
 }
 
@@ -3572,7 +3571,7 @@ export interface UntagResourceResponse extends $MetadataBearer {
 
 export namespace UntagResourceResponse {
   export function isa(o: any): o is UntagResourceResponse {
-    return _smithy.isa(o, "UntagResourceResponse");
+    return __isa(o, "UntagResourceResponse");
   }
 }
 
@@ -3603,7 +3602,7 @@ export namespace UpdateConfigurationSetEventDestinationRequest {
   export function isa(
     o: any
   ): o is UpdateConfigurationSetEventDestinationRequest {
-    return _smithy.isa(o, "UpdateConfigurationSetEventDestinationRequest");
+    return __isa(o, "UpdateConfigurationSetEventDestinationRequest");
   }
 }
 
@@ -3620,7 +3619,7 @@ export namespace UpdateConfigurationSetEventDestinationResponse {
   export function isa(
     o: any
   ): o is UpdateConfigurationSetEventDestinationResponse {
-    return _smithy.isa(o, "UpdateConfigurationSetEventDestinationResponse");
+    return __isa(o, "UpdateConfigurationSetEventDestinationResponse");
   }
 }
 
@@ -3656,7 +3655,7 @@ export interface VolumeStatistics {
 
 export namespace VolumeStatistics {
   export function isa(o: any): o is VolumeStatistics {
-    return _smithy.isa(o, "VolumeStatistics");
+    return __isa(o, "VolumeStatistics");
   }
 }
 

--- a/clients/client-pinpoint-email/protocols/Aws_restJson1_1.ts
+++ b/clients/client-pinpoint-email/protocols/Aws_restJson1_1.ts
@@ -219,7 +219,10 @@ import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  extendedEncodeURIComponent as __extendedEncodeURIComponent
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -286,7 +289,7 @@ export async function serializeAws_restJson1_1CreateConfigurationSetEventDestina
   let resolvedPath =
     "/v1/email/configuration-sets/{ConfigurationSetName}/event-destinations";
   if (input.ConfigurationSetName !== undefined) {
-    const labelValue: string = input.ConfigurationSetName.toString();
+    const labelValue: string = input.ConfigurationSetName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ConfigurationSetName."
@@ -294,7 +297,7 @@ export async function serializeAws_restJson1_1CreateConfigurationSetEventDestina
     }
     resolvedPath = resolvedPath.replace(
       "{ConfigurationSetName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -420,7 +423,7 @@ export async function serializeAws_restJson1_1DeleteConfigurationSetCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/email/configuration-sets/{ConfigurationSetName}";
   if (input.ConfigurationSetName !== undefined) {
-    const labelValue: string = input.ConfigurationSetName.toString();
+    const labelValue: string = input.ConfigurationSetName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ConfigurationSetName."
@@ -428,7 +431,7 @@ export async function serializeAws_restJson1_1DeleteConfigurationSetCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ConfigurationSetName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -453,7 +456,7 @@ export async function serializeAws_restJson1_1DeleteConfigurationSetEventDestina
   let resolvedPath =
     "/v1/email/configuration-sets/{ConfigurationSetName}/event-destinations/{EventDestinationName}";
   if (input.ConfigurationSetName !== undefined) {
-    const labelValue: string = input.ConfigurationSetName.toString();
+    const labelValue: string = input.ConfigurationSetName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ConfigurationSetName."
@@ -461,7 +464,7 @@ export async function serializeAws_restJson1_1DeleteConfigurationSetEventDestina
     }
     resolvedPath = resolvedPath.replace(
       "{ConfigurationSetName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -469,7 +472,7 @@ export async function serializeAws_restJson1_1DeleteConfigurationSetEventDestina
     );
   }
   if (input.EventDestinationName !== undefined) {
-    const labelValue: string = input.EventDestinationName.toString();
+    const labelValue: string = input.EventDestinationName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: EventDestinationName."
@@ -477,7 +480,7 @@ export async function serializeAws_restJson1_1DeleteConfigurationSetEventDestina
     }
     resolvedPath = resolvedPath.replace(
       "{EventDestinationName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -501,13 +504,13 @@ export async function serializeAws_restJson1_1DeleteDedicatedIpPoolCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/email/dedicated-ip-pools/{PoolName}";
   if (input.PoolName !== undefined) {
-    const labelValue: string = input.PoolName.toString();
+    const labelValue: string = input.PoolName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: PoolName.");
     }
     resolvedPath = resolvedPath.replace(
       "{PoolName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: PoolName.");
@@ -529,7 +532,7 @@ export async function serializeAws_restJson1_1DeleteEmailIdentityCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/email/identities/{EmailIdentity}";
   if (input.EmailIdentity !== undefined) {
-    const labelValue: string = input.EmailIdentity.toString();
+    const labelValue: string = input.EmailIdentity;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: EmailIdentity."
@@ -537,7 +540,7 @@ export async function serializeAws_restJson1_1DeleteEmailIdentityCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{EmailIdentity}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: EmailIdentity.");
@@ -576,7 +579,11 @@ export async function serializeAws_restJson1_1GetBlacklistReportsCommand(
   let resolvedPath = "/v1/email/deliverability-dashboard/blacklist-report";
   const query: any = {};
   if (input.BlacklistItemNames !== undefined) {
-    query["BlacklistItemNames"] = input.BlacklistItemNames;
+    query[
+      __extendedEncodeURIComponent("BlacklistItemNames")
+    ] = input.BlacklistItemNames.map(entry =>
+      __extendedEncodeURIComponent(entry)
+    );
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -596,7 +603,7 @@ export async function serializeAws_restJson1_1GetConfigurationSetCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/email/configuration-sets/{ConfigurationSetName}";
   if (input.ConfigurationSetName !== undefined) {
-    const labelValue: string = input.ConfigurationSetName.toString();
+    const labelValue: string = input.ConfigurationSetName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ConfigurationSetName."
@@ -604,7 +611,7 @@ export async function serializeAws_restJson1_1GetConfigurationSetCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ConfigurationSetName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -629,7 +636,7 @@ export async function serializeAws_restJson1_1GetConfigurationSetEventDestinatio
   let resolvedPath =
     "/v1/email/configuration-sets/{ConfigurationSetName}/event-destinations";
   if (input.ConfigurationSetName !== undefined) {
-    const labelValue: string = input.ConfigurationSetName.toString();
+    const labelValue: string = input.ConfigurationSetName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ConfigurationSetName."
@@ -637,7 +644,7 @@ export async function serializeAws_restJson1_1GetConfigurationSetEventDestinatio
     }
     resolvedPath = resolvedPath.replace(
       "{ConfigurationSetName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -661,11 +668,14 @@ export async function serializeAws_restJson1_1GetDedicatedIpCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/email/dedicated-ips/{Ip}";
   if (input.Ip !== undefined) {
-    const labelValue: string = input.Ip.toString();
+    const labelValue: string = input.Ip;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Ip.");
     }
-    resolvedPath = resolvedPath.replace("{Ip}", encodeURIComponent(labelValue));
+    resolvedPath = resolvedPath.replace(
+      "{Ip}",
+      __extendedEncodeURIComponent(labelValue)
+    );
   } else {
     throw new Error("No value provided for input HTTP label: Ip.");
   }
@@ -687,13 +697,19 @@ export async function serializeAws_restJson1_1GetDedicatedIpsCommand(
   let resolvedPath = "/v1/email/dedicated-ips";
   const query: any = {};
   if (input.NextToken !== undefined) {
-    query["NextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("NextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   if (input.PageSize !== undefined) {
-    query["PageSize"] = input.PageSize.toString();
+    query[
+      __extendedEncodeURIComponent("PageSize")
+    ] = __extendedEncodeURIComponent(input.PageSize.toString());
   }
   if (input.PoolName !== undefined) {
-    query["PoolName"] = input.PoolName.toString();
+    query[
+      __extendedEncodeURIComponent("PoolName")
+    ] = __extendedEncodeURIComponent(input.PoolName);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -730,13 +746,13 @@ export async function serializeAws_restJson1_1GetDeliverabilityTestReportCommand
   let resolvedPath =
     "/v1/email/deliverability-dashboard/test-reports/{ReportId}";
   if (input.ReportId !== undefined) {
-    const labelValue: string = input.ReportId.toString();
+    const labelValue: string = input.ReportId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ReportId.");
     }
     resolvedPath = resolvedPath.replace(
       "{ReportId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ReportId.");
@@ -759,13 +775,13 @@ export async function serializeAws_restJson1_1GetDomainDeliverabilityCampaignCom
   let resolvedPath =
     "/v1/email/deliverability-dashboard/campaigns/{CampaignId}";
   if (input.CampaignId !== undefined) {
-    const labelValue: string = input.CampaignId.toString();
+    const labelValue: string = input.CampaignId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: CampaignId.");
     }
     resolvedPath = resolvedPath.replace(
       "{CampaignId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: CampaignId.");
@@ -788,23 +804,27 @@ export async function serializeAws_restJson1_1GetDomainStatisticsReportCommand(
   let resolvedPath =
     "/v1/email/deliverability-dashboard/statistics-report/{Domain}";
   if (input.Domain !== undefined) {
-    const labelValue: string = input.Domain.toString();
+    const labelValue: string = input.Domain;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Domain.");
     }
     resolvedPath = resolvedPath.replace(
       "{Domain}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Domain.");
   }
   const query: any = {};
   if (input.EndDate !== undefined) {
-    query["EndDate"] = input.EndDate.toISOString();
+    query[
+      __extendedEncodeURIComponent("EndDate")
+    ] = __extendedEncodeURIComponent(input.EndDate.toISOString());
   }
   if (input.StartDate !== undefined) {
-    query["StartDate"] = input.StartDate.toISOString();
+    query[
+      __extendedEncodeURIComponent("StartDate")
+    ] = __extendedEncodeURIComponent(input.StartDate.toISOString());
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -824,7 +844,7 @@ export async function serializeAws_restJson1_1GetEmailIdentityCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/email/identities/{EmailIdentity}";
   if (input.EmailIdentity !== undefined) {
-    const labelValue: string = input.EmailIdentity.toString();
+    const labelValue: string = input.EmailIdentity;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: EmailIdentity."
@@ -832,7 +852,7 @@ export async function serializeAws_restJson1_1GetEmailIdentityCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{EmailIdentity}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: EmailIdentity.");
@@ -855,10 +875,14 @@ export async function serializeAws_restJson1_1ListConfigurationSetsCommand(
   let resolvedPath = "/v1/email/configuration-sets";
   const query: any = {};
   if (input.NextToken !== undefined) {
-    query["NextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("NextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   if (input.PageSize !== undefined) {
-    query["PageSize"] = input.PageSize.toString();
+    query[
+      __extendedEncodeURIComponent("PageSize")
+    ] = __extendedEncodeURIComponent(input.PageSize.toString());
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -879,10 +903,14 @@ export async function serializeAws_restJson1_1ListDedicatedIpPoolsCommand(
   let resolvedPath = "/v1/email/dedicated-ip-pools";
   const query: any = {};
   if (input.NextToken !== undefined) {
-    query["NextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("NextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   if (input.PageSize !== undefined) {
-    query["PageSize"] = input.PageSize.toString();
+    query[
+      __extendedEncodeURIComponent("PageSize")
+    ] = __extendedEncodeURIComponent(input.PageSize.toString());
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -903,10 +931,14 @@ export async function serializeAws_restJson1_1ListDeliverabilityTestReportsComma
   let resolvedPath = "/v1/email/deliverability-dashboard/test-reports";
   const query: any = {};
   if (input.NextToken !== undefined) {
-    query["NextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("NextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   if (input.PageSize !== undefined) {
-    query["PageSize"] = input.PageSize.toString();
+    query[
+      __extendedEncodeURIComponent("PageSize")
+    ] = __extendedEncodeURIComponent(input.PageSize.toString());
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -927,7 +959,7 @@ export async function serializeAws_restJson1_1ListDomainDeliverabilityCampaignsC
   let resolvedPath =
     "/v1/email/deliverability-dashboard/domains/{SubscribedDomain}/campaigns";
   if (input.SubscribedDomain !== undefined) {
-    const labelValue: string = input.SubscribedDomain.toString();
+    const labelValue: string = input.SubscribedDomain;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: SubscribedDomain."
@@ -935,7 +967,7 @@ export async function serializeAws_restJson1_1ListDomainDeliverabilityCampaignsC
     }
     resolvedPath = resolvedPath.replace(
       "{SubscribedDomain}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -944,16 +976,24 @@ export async function serializeAws_restJson1_1ListDomainDeliverabilityCampaignsC
   }
   const query: any = {};
   if (input.EndDate !== undefined) {
-    query["EndDate"] = input.EndDate.toISOString();
+    query[
+      __extendedEncodeURIComponent("EndDate")
+    ] = __extendedEncodeURIComponent(input.EndDate.toISOString());
   }
   if (input.NextToken !== undefined) {
-    query["NextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("NextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   if (input.PageSize !== undefined) {
-    query["PageSize"] = input.PageSize.toString();
+    query[
+      __extendedEncodeURIComponent("PageSize")
+    ] = __extendedEncodeURIComponent(input.PageSize.toString());
   }
   if (input.StartDate !== undefined) {
-    query["StartDate"] = input.StartDate.toISOString();
+    query[
+      __extendedEncodeURIComponent("StartDate")
+    ] = __extendedEncodeURIComponent(input.StartDate.toISOString());
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -974,10 +1014,14 @@ export async function serializeAws_restJson1_1ListEmailIdentitiesCommand(
   let resolvedPath = "/v1/email/identities";
   const query: any = {};
   if (input.NextToken !== undefined) {
-    query["NextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("NextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   if (input.PageSize !== undefined) {
-    query["PageSize"] = input.PageSize.toString();
+    query[
+      __extendedEncodeURIComponent("PageSize")
+    ] = __extendedEncodeURIComponent(input.PageSize.toString());
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -998,7 +1042,9 @@ export async function serializeAws_restJson1_1ListTagsForResourceCommand(
   let resolvedPath = "/v1/email/tags";
   const query: any = {};
   if (input.ResourceArn !== undefined) {
-    query["ResourceArn"] = input.ResourceArn.toString();
+    query[
+      __extendedEncodeURIComponent("ResourceArn")
+    ] = __extendedEncodeURIComponent(input.ResourceArn);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1065,7 +1111,7 @@ export async function serializeAws_restJson1_1PutConfigurationSetDeliveryOptions
   let resolvedPath =
     "/v1/email/configuration-sets/{ConfigurationSetName}/delivery-options";
   if (input.ConfigurationSetName !== undefined) {
-    const labelValue: string = input.ConfigurationSetName.toString();
+    const labelValue: string = input.ConfigurationSetName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ConfigurationSetName."
@@ -1073,7 +1119,7 @@ export async function serializeAws_restJson1_1PutConfigurationSetDeliveryOptions
     }
     resolvedPath = resolvedPath.replace(
       "{ConfigurationSetName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -1108,7 +1154,7 @@ export async function serializeAws_restJson1_1PutConfigurationSetReputationOptio
   let resolvedPath =
     "/v1/email/configuration-sets/{ConfigurationSetName}/reputation-options";
   if (input.ConfigurationSetName !== undefined) {
-    const labelValue: string = input.ConfigurationSetName.toString();
+    const labelValue: string = input.ConfigurationSetName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ConfigurationSetName."
@@ -1116,7 +1162,7 @@ export async function serializeAws_restJson1_1PutConfigurationSetReputationOptio
     }
     resolvedPath = resolvedPath.replace(
       "{ConfigurationSetName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -1148,7 +1194,7 @@ export async function serializeAws_restJson1_1PutConfigurationSetSendingOptionsC
   let resolvedPath =
     "/v1/email/configuration-sets/{ConfigurationSetName}/sending";
   if (input.ConfigurationSetName !== undefined) {
-    const labelValue: string = input.ConfigurationSetName.toString();
+    const labelValue: string = input.ConfigurationSetName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ConfigurationSetName."
@@ -1156,7 +1202,7 @@ export async function serializeAws_restJson1_1PutConfigurationSetSendingOptionsC
     }
     resolvedPath = resolvedPath.replace(
       "{ConfigurationSetName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -1188,7 +1234,7 @@ export async function serializeAws_restJson1_1PutConfigurationSetTrackingOptions
   let resolvedPath =
     "/v1/email/configuration-sets/{ConfigurationSetName}/tracking-options";
   if (input.ConfigurationSetName !== undefined) {
-    const labelValue: string = input.ConfigurationSetName.toString();
+    const labelValue: string = input.ConfigurationSetName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ConfigurationSetName."
@@ -1196,7 +1242,7 @@ export async function serializeAws_restJson1_1PutConfigurationSetTrackingOptions
     }
     resolvedPath = resolvedPath.replace(
       "{ConfigurationSetName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -1227,11 +1273,14 @@ export async function serializeAws_restJson1_1PutDedicatedIpInPoolCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v1/email/dedicated-ips/{Ip}/pool";
   if (input.Ip !== undefined) {
-    const labelValue: string = input.Ip.toString();
+    const labelValue: string = input.Ip;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Ip.");
     }
-    resolvedPath = resolvedPath.replace("{Ip}", encodeURIComponent(labelValue));
+    resolvedPath = resolvedPath.replace(
+      "{Ip}",
+      __extendedEncodeURIComponent(labelValue)
+    );
   } else {
     throw new Error("No value provided for input HTTP label: Ip.");
   }
@@ -1259,11 +1308,14 @@ export async function serializeAws_restJson1_1PutDedicatedIpWarmupAttributesComm
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v1/email/dedicated-ips/{Ip}/warmup";
   if (input.Ip !== undefined) {
-    const labelValue: string = input.Ip.toString();
+    const labelValue: string = input.Ip;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Ip.");
     }
-    resolvedPath = resolvedPath.replace("{Ip}", encodeURIComponent(labelValue));
+    resolvedPath = resolvedPath.replace(
+      "{Ip}",
+      __extendedEncodeURIComponent(labelValue)
+    );
   } else {
     throw new Error("No value provided for input HTTP label: Ip.");
   }
@@ -1322,7 +1374,7 @@ export async function serializeAws_restJson1_1PutEmailIdentityDkimAttributesComm
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v1/email/identities/{EmailIdentity}/dkim";
   if (input.EmailIdentity !== undefined) {
-    const labelValue: string = input.EmailIdentity.toString();
+    const labelValue: string = input.EmailIdentity;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: EmailIdentity."
@@ -1330,7 +1382,7 @@ export async function serializeAws_restJson1_1PutEmailIdentityDkimAttributesComm
     }
     resolvedPath = resolvedPath.replace(
       "{EmailIdentity}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: EmailIdentity.");
@@ -1359,7 +1411,7 @@ export async function serializeAws_restJson1_1PutEmailIdentityFeedbackAttributes
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v1/email/identities/{EmailIdentity}/feedback";
   if (input.EmailIdentity !== undefined) {
-    const labelValue: string = input.EmailIdentity.toString();
+    const labelValue: string = input.EmailIdentity;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: EmailIdentity."
@@ -1367,7 +1419,7 @@ export async function serializeAws_restJson1_1PutEmailIdentityFeedbackAttributes
     }
     resolvedPath = resolvedPath.replace(
       "{EmailIdentity}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: EmailIdentity.");
@@ -1396,7 +1448,7 @@ export async function serializeAws_restJson1_1PutEmailIdentityMailFromAttributes
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v1/email/identities/{EmailIdentity}/mail-from";
   if (input.EmailIdentity !== undefined) {
-    const labelValue: string = input.EmailIdentity.toString();
+    const labelValue: string = input.EmailIdentity;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: EmailIdentity."
@@ -1404,7 +1456,7 @@ export async function serializeAws_restJson1_1PutEmailIdentityMailFromAttributes
     }
     resolvedPath = resolvedPath.replace(
       "{EmailIdentity}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: EmailIdentity.");
@@ -1517,10 +1569,14 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
   let resolvedPath = "/v1/email/tags";
   const query: any = {};
   if (input.ResourceArn !== undefined) {
-    query["ResourceArn"] = input.ResourceArn.toString();
+    query[
+      __extendedEncodeURIComponent("ResourceArn")
+    ] = __extendedEncodeURIComponent(input.ResourceArn);
   }
   if (input.TagKeys !== undefined) {
-    query["TagKeys"] = input.TagKeys;
+    query[__extendedEncodeURIComponent("TagKeys")] = input.TagKeys.map(entry =>
+      __extendedEncodeURIComponent(entry)
+    );
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1541,7 +1597,7 @@ export async function serializeAws_restJson1_1UpdateConfigurationSetEventDestina
   let resolvedPath =
     "/v1/email/configuration-sets/{ConfigurationSetName}/event-destinations/{EventDestinationName}";
   if (input.ConfigurationSetName !== undefined) {
-    const labelValue: string = input.ConfigurationSetName.toString();
+    const labelValue: string = input.ConfigurationSetName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ConfigurationSetName."
@@ -1549,7 +1605,7 @@ export async function serializeAws_restJson1_1UpdateConfigurationSetEventDestina
     }
     resolvedPath = resolvedPath.replace(
       "{ConfigurationSetName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -1557,7 +1613,7 @@ export async function serializeAws_restJson1_1UpdateConfigurationSetEventDestina
     );
   }
   if (input.EventDestinationName !== undefined) {
-    const labelValue: string = input.EventDestinationName.toString();
+    const labelValue: string = input.EventDestinationName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: EventDestinationName."
@@ -1565,7 +1621,7 @@ export async function serializeAws_restJson1_1UpdateConfigurationSetEventDestina
     }
     resolvedPath = resolvedPath.replace(
       "{EventDestinationName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -1607,6 +1663,7 @@ export async function deserializeAws_restJson1_1CreateConfigurationSetCommand(
     $metadata: deserializeMetadata(output),
     __type: "CreateConfigurationSetResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -1693,6 +1750,7 @@ export async function deserializeAws_restJson1_1CreateConfigurationSetEventDesti
     $metadata: deserializeMetadata(output),
     __type: "CreateConfigurationSetEventDestinationResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -1772,6 +1830,7 @@ export async function deserializeAws_restJson1_1CreateDedicatedIpPoolCommand(
     $metadata: deserializeMetadata(output),
     __type: "CreateDedicatedIpPoolResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2061,6 +2120,7 @@ export async function deserializeAws_restJson1_1DeleteConfigurationSetCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeleteConfigurationSetResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2133,6 +2193,7 @@ export async function deserializeAws_restJson1_1DeleteConfigurationSetEventDesti
     $metadata: deserializeMetadata(output),
     __type: "DeleteConfigurationSetEventDestinationResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2198,6 +2259,7 @@ export async function deserializeAws_restJson1_1DeleteDedicatedIpPoolCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeleteDedicatedIpPoolResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2270,6 +2332,7 @@ export async function deserializeAws_restJson1_1DeleteEmailIdentityCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeleteEmailIdentityResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -3730,6 +3793,7 @@ export async function deserializeAws_restJson1_1PutAccountDedicatedIpWarmupAttri
     $metadata: deserializeMetadata(output),
     __type: "PutAccountDedicatedIpWarmupAttributesResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -3788,6 +3852,7 @@ export async function deserializeAws_restJson1_1PutAccountSendingAttributesComma
     $metadata: deserializeMetadata(output),
     __type: "PutAccountSendingAttributesResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -3846,6 +3911,7 @@ export async function deserializeAws_restJson1_1PutConfigurationSetDeliveryOptio
     $metadata: deserializeMetadata(output),
     __type: "PutConfigurationSetDeliveryOptionsResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -3911,6 +3977,7 @@ export async function deserializeAws_restJson1_1PutConfigurationSetReputationOpt
     $metadata: deserializeMetadata(output),
     __type: "PutConfigurationSetReputationOptionsResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -3976,6 +4043,7 @@ export async function deserializeAws_restJson1_1PutConfigurationSetSendingOption
     $metadata: deserializeMetadata(output),
     __type: "PutConfigurationSetSendingOptionsResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -4041,6 +4109,7 @@ export async function deserializeAws_restJson1_1PutConfigurationSetTrackingOptio
     $metadata: deserializeMetadata(output),
     __type: "PutConfigurationSetTrackingOptionsResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -4106,6 +4175,7 @@ export async function deserializeAws_restJson1_1PutDedicatedIpInPoolCommand(
     $metadata: deserializeMetadata(output),
     __type: "PutDedicatedIpInPoolResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -4171,6 +4241,7 @@ export async function deserializeAws_restJson1_1PutDedicatedIpWarmupAttributesCo
     $metadata: deserializeMetadata(output),
     __type: "PutDedicatedIpWarmupAttributesResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -4236,6 +4307,7 @@ export async function deserializeAws_restJson1_1PutDeliverabilityDashboardOption
     $metadata: deserializeMetadata(output),
     __type: "PutDeliverabilityDashboardOptionResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -4315,6 +4387,7 @@ export async function deserializeAws_restJson1_1PutEmailIdentityDkimAttributesCo
     $metadata: deserializeMetadata(output),
     __type: "PutEmailIdentityDkimAttributesResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -4380,6 +4453,7 @@ export async function deserializeAws_restJson1_1PutEmailIdentityFeedbackAttribut
     $metadata: deserializeMetadata(output),
     __type: "PutEmailIdentityFeedbackAttributesResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -4445,6 +4519,7 @@ export async function deserializeAws_restJson1_1PutEmailIdentityMailFromAttribut
     $metadata: deserializeMetadata(output),
     __type: "PutEmailIdentityMailFromAttributesResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -4609,6 +4684,7 @@ export async function deserializeAws_restJson1_1TagResourceCommand(
     $metadata: deserializeMetadata(output),
     __type: "TagResourceResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -4678,6 +4754,7 @@ export async function deserializeAws_restJson1_1UntagResourceCommand(
     $metadata: deserializeMetadata(output),
     __type: "UntagResourceResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -4750,6 +4827,7 @@ export async function deserializeAws_restJson1_1UpdateConfigurationSetEventDesti
     $metadata: deserializeMetadata(output),
     __type: "UpdateConfigurationSetEventDestinationResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 

--- a/clients/client-pinpoint-sms-voice/models/index.ts
+++ b/clients/client-pinpoint-sms-voice/models/index.ts
@@ -1,11 +1,14 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
  * The resource specified in your request already exists.
  */
 export interface AlreadyExistsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AlreadyExistsException";
   $fault: "client";
@@ -14,7 +17,7 @@ export interface AlreadyExistsException
 
 export namespace AlreadyExistsException {
   export function isa(o: any): o is AlreadyExistsException {
-    return _smithy.isa(o, "AlreadyExistsException");
+    return __isa(o, "AlreadyExistsException");
   }
 }
 
@@ -22,7 +25,7 @@ export namespace AlreadyExistsException {
  * The input you provided is invalid.
  */
 export interface BadRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "BadRequestException";
   $fault: "client";
@@ -31,7 +34,7 @@ export interface BadRequestException
 
 export namespace BadRequestException {
   export function isa(o: any): o is BadRequestException {
-    return _smithy.isa(o, "BadRequestException");
+    return __isa(o, "BadRequestException");
   }
 }
 
@@ -48,7 +51,7 @@ export interface CallInstructionsMessageType {
 
 export namespace CallInstructionsMessageType {
   export function isa(o: any): o is CallInstructionsMessageType {
-    return _smithy.isa(o, "CallInstructionsMessageType");
+    return __isa(o, "CallInstructionsMessageType");
   }
 }
 
@@ -70,7 +73,7 @@ export interface CloudWatchLogsDestination {
 
 export namespace CloudWatchLogsDestination {
   export function isa(o: any): o is CloudWatchLogsDestination {
-    return _smithy.isa(o, "CloudWatchLogsDestination");
+    return __isa(o, "CloudWatchLogsDestination");
   }
 }
 
@@ -99,7 +102,7 @@ export namespace CreateConfigurationSetEventDestinationRequest {
   export function isa(
     o: any
   ): o is CreateConfigurationSetEventDestinationRequest {
-    return _smithy.isa(o, "CreateConfigurationSetEventDestinationRequest");
+    return __isa(o, "CreateConfigurationSetEventDestinationRequest");
   }
 }
 
@@ -115,7 +118,7 @@ export namespace CreateConfigurationSetEventDestinationResponse {
   export function isa(
     o: any
   ): o is CreateConfigurationSetEventDestinationResponse {
-    return _smithy.isa(o, "CreateConfigurationSetEventDestinationResponse");
+    return __isa(o, "CreateConfigurationSetEventDestinationResponse");
   }
 }
 
@@ -132,7 +135,7 @@ export interface CreateConfigurationSetRequest {
 
 export namespace CreateConfigurationSetRequest {
   export function isa(o: any): o is CreateConfigurationSetRequest {
-    return _smithy.isa(o, "CreateConfigurationSetRequest");
+    return __isa(o, "CreateConfigurationSetRequest");
   }
 }
 
@@ -145,7 +148,7 @@ export interface CreateConfigurationSetResponse extends $MetadataBearer {
 
 export namespace CreateConfigurationSetResponse {
   export function isa(o: any): o is CreateConfigurationSetResponse {
-    return _smithy.isa(o, "CreateConfigurationSetResponse");
+    return __isa(o, "CreateConfigurationSetResponse");
   }
 }
 
@@ -166,7 +169,7 @@ export namespace DeleteConfigurationSetEventDestinationRequest {
   export function isa(
     o: any
   ): o is DeleteConfigurationSetEventDestinationRequest {
-    return _smithy.isa(o, "DeleteConfigurationSetEventDestinationRequest");
+    return __isa(o, "DeleteConfigurationSetEventDestinationRequest");
   }
 }
 
@@ -182,7 +185,7 @@ export namespace DeleteConfigurationSetEventDestinationResponse {
   export function isa(
     o: any
   ): o is DeleteConfigurationSetEventDestinationResponse {
-    return _smithy.isa(o, "DeleteConfigurationSetEventDestinationResponse");
+    return __isa(o, "DeleteConfigurationSetEventDestinationResponse");
   }
 }
 
@@ -196,7 +199,7 @@ export interface DeleteConfigurationSetRequest {
 
 export namespace DeleteConfigurationSetRequest {
   export function isa(o: any): o is DeleteConfigurationSetRequest {
-    return _smithy.isa(o, "DeleteConfigurationSetRequest");
+    return __isa(o, "DeleteConfigurationSetRequest");
   }
 }
 
@@ -209,7 +212,7 @@ export interface DeleteConfigurationSetResponse extends $MetadataBearer {
 
 export namespace DeleteConfigurationSetResponse {
   export function isa(o: any): o is DeleteConfigurationSetResponse {
-    return _smithy.isa(o, "DeleteConfigurationSetResponse");
+    return __isa(o, "DeleteConfigurationSetResponse");
   }
 }
 
@@ -251,7 +254,7 @@ export interface EventDestination {
 
 export namespace EventDestination {
   export function isa(o: any): o is EventDestination {
-    return _smithy.isa(o, "EventDestination");
+    return __isa(o, "EventDestination");
   }
 }
 
@@ -288,7 +291,7 @@ export interface EventDestinationDefinition {
 
 export namespace EventDestinationDefinition {
   export function isa(o: any): o is EventDestinationDefinition {
-    return _smithy.isa(o, "EventDestinationDefinition");
+    return __isa(o, "EventDestinationDefinition");
   }
 }
 
@@ -314,7 +317,7 @@ export namespace GetConfigurationSetEventDestinationsRequest {
   export function isa(
     o: any
   ): o is GetConfigurationSetEventDestinationsRequest {
-    return _smithy.isa(o, "GetConfigurationSetEventDestinationsRequest");
+    return __isa(o, "GetConfigurationSetEventDestinationsRequest");
   }
 }
 
@@ -334,7 +337,7 @@ export namespace GetConfigurationSetEventDestinationsResponse {
   export function isa(
     o: any
   ): o is GetConfigurationSetEventDestinationsResponse {
-    return _smithy.isa(o, "GetConfigurationSetEventDestinationsResponse");
+    return __isa(o, "GetConfigurationSetEventDestinationsResponse");
   }
 }
 
@@ -342,7 +345,7 @@ export namespace GetConfigurationSetEventDestinationsResponse {
  * The API encountered an unexpected error and couldn't complete the request. You might be able to successfully issue the request again in the future.
  */
 export interface InternalServiceErrorException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalServiceErrorException";
   $fault: "server";
@@ -351,7 +354,7 @@ export interface InternalServiceErrorException
 
 export namespace InternalServiceErrorException {
   export function isa(o: any): o is InternalServiceErrorException {
-    return _smithy.isa(o, "InternalServiceErrorException");
+    return __isa(o, "InternalServiceErrorException");
   }
 }
 
@@ -373,7 +376,7 @@ export interface KinesisFirehoseDestination {
 
 export namespace KinesisFirehoseDestination {
   export function isa(o: any): o is KinesisFirehoseDestination {
-    return _smithy.isa(o, "KinesisFirehoseDestination");
+    return __isa(o, "KinesisFirehoseDestination");
   }
 }
 
@@ -381,7 +384,7 @@ export namespace KinesisFirehoseDestination {
  * There are too many instances of the specified resource type.
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -390,7 +393,7 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
@@ -409,7 +412,7 @@ export interface ListConfigurationSetsRequest {
 
 export namespace ListConfigurationSetsRequest {
   export function isa(o: any): o is ListConfigurationSetsRequest {
-    return _smithy.isa(o, "ListConfigurationSetsRequest");
+    return __isa(o, "ListConfigurationSetsRequest");
   }
 }
 
@@ -431,16 +434,14 @@ export interface ListConfigurationSetsResponse extends $MetadataBearer {
 
 export namespace ListConfigurationSetsResponse {
   export function isa(o: any): o is ListConfigurationSetsResponse {
-    return _smithy.isa(o, "ListConfigurationSetsResponse");
+    return __isa(o, "ListConfigurationSetsResponse");
   }
 }
 
 /**
  * The resource you attempted to access doesn't exist.
  */
-export interface NotFoundException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface NotFoundException extends __SmithyException, $MetadataBearer {
   name: "NotFoundException";
   $fault: "client";
   Message?: string;
@@ -448,7 +449,7 @@ export interface NotFoundException
 
 export namespace NotFoundException {
   export function isa(o: any): o is NotFoundException {
-    return _smithy.isa(o, "NotFoundException");
+    return __isa(o, "NotFoundException");
   }
 }
 
@@ -475,7 +476,7 @@ export interface PlainTextMessageType {
 
 export namespace PlainTextMessageType {
   export function isa(o: any): o is PlainTextMessageType {
-    return _smithy.isa(o, "PlainTextMessageType");
+    return __isa(o, "PlainTextMessageType");
   }
 }
 
@@ -502,7 +503,7 @@ export interface SSMLMessageType {
 
 export namespace SSMLMessageType {
   export function isa(o: any): o is SSMLMessageType {
-    return _smithy.isa(o, "SSMLMessageType");
+    return __isa(o, "SSMLMessageType");
   }
 }
 
@@ -539,7 +540,7 @@ export interface SendVoiceMessageRequest {
 
 export namespace SendVoiceMessageRequest {
   export function isa(o: any): o is SendVoiceMessageRequest {
-    return _smithy.isa(o, "SendVoiceMessageRequest");
+    return __isa(o, "SendVoiceMessageRequest");
   }
 }
 
@@ -556,7 +557,7 @@ export interface SendVoiceMessageResponse extends $MetadataBearer {
 
 export namespace SendVoiceMessageResponse {
   export function isa(o: any): o is SendVoiceMessageResponse {
-    return _smithy.isa(o, "SendVoiceMessageResponse");
+    return __isa(o, "SendVoiceMessageResponse");
   }
 }
 
@@ -573,7 +574,7 @@ export interface SnsDestination {
 
 export namespace SnsDestination {
   export function isa(o: any): o is SnsDestination {
-    return _smithy.isa(o, "SnsDestination");
+    return __isa(o, "SnsDestination");
   }
 }
 
@@ -581,7 +582,7 @@ export namespace SnsDestination {
  * You've issued too many requests to the resource. Wait a few minutes, and then try again.
  */
 export interface TooManyRequestsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyRequestsException";
   $fault: "client";
@@ -590,7 +591,7 @@ export interface TooManyRequestsException
 
 export namespace TooManyRequestsException {
   export function isa(o: any): o is TooManyRequestsException {
-    return _smithy.isa(o, "TooManyRequestsException");
+    return __isa(o, "TooManyRequestsException");
   }
 }
 
@@ -619,7 +620,7 @@ export namespace UpdateConfigurationSetEventDestinationRequest {
   export function isa(
     o: any
   ): o is UpdateConfigurationSetEventDestinationRequest {
-    return _smithy.isa(o, "UpdateConfigurationSetEventDestinationRequest");
+    return __isa(o, "UpdateConfigurationSetEventDestinationRequest");
   }
 }
 
@@ -635,7 +636,7 @@ export namespace UpdateConfigurationSetEventDestinationResponse {
   export function isa(
     o: any
   ): o is UpdateConfigurationSetEventDestinationResponse {
-    return _smithy.isa(o, "UpdateConfigurationSetEventDestinationResponse");
+    return __isa(o, "UpdateConfigurationSetEventDestinationResponse");
   }
 }
 
@@ -662,6 +663,6 @@ export interface VoiceMessageContent {
 
 export namespace VoiceMessageContent {
   export function isa(o: any): o is VoiceMessageContent {
-    return _smithy.isa(o, "VoiceMessageContent");
+    return __isa(o, "VoiceMessageContent");
   }
 }

--- a/clients/client-pinpoint-sms-voice/protocols/Aws_restJson1_1.ts
+++ b/clients/client-pinpoint-sms-voice/protocols/Aws_restJson1_1.ts
@@ -52,7 +52,10 @@ import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  extendedEncodeURIComponent as __extendedEncodeURIComponent
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -92,7 +95,7 @@ export async function serializeAws_restJson1_1CreateConfigurationSetEventDestina
   let resolvedPath =
     "/v1/sms-voice/configuration-sets/{ConfigurationSetName}/event-destinations";
   if (input.ConfigurationSetName !== undefined) {
-    const labelValue: string = input.ConfigurationSetName.toString();
+    const labelValue: string = input.ConfigurationSetName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ConfigurationSetName."
@@ -100,7 +103,7 @@ export async function serializeAws_restJson1_1CreateConfigurationSetEventDestina
     }
     resolvedPath = resolvedPath.replace(
       "{ConfigurationSetName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -139,7 +142,7 @@ export async function serializeAws_restJson1_1DeleteConfigurationSetCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/sms-voice/configuration-sets/{ConfigurationSetName}";
   if (input.ConfigurationSetName !== undefined) {
-    const labelValue: string = input.ConfigurationSetName.toString();
+    const labelValue: string = input.ConfigurationSetName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ConfigurationSetName."
@@ -147,7 +150,7 @@ export async function serializeAws_restJson1_1DeleteConfigurationSetCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ConfigurationSetName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -172,7 +175,7 @@ export async function serializeAws_restJson1_1DeleteConfigurationSetEventDestina
   let resolvedPath =
     "/v1/sms-voice/configuration-sets/{ConfigurationSetName}/event-destinations/{EventDestinationName}";
   if (input.ConfigurationSetName !== undefined) {
-    const labelValue: string = input.ConfigurationSetName.toString();
+    const labelValue: string = input.ConfigurationSetName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ConfigurationSetName."
@@ -180,7 +183,7 @@ export async function serializeAws_restJson1_1DeleteConfigurationSetEventDestina
     }
     resolvedPath = resolvedPath.replace(
       "{ConfigurationSetName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -188,7 +191,7 @@ export async function serializeAws_restJson1_1DeleteConfigurationSetEventDestina
     );
   }
   if (input.EventDestinationName !== undefined) {
-    const labelValue: string = input.EventDestinationName.toString();
+    const labelValue: string = input.EventDestinationName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: EventDestinationName."
@@ -196,7 +199,7 @@ export async function serializeAws_restJson1_1DeleteConfigurationSetEventDestina
     }
     resolvedPath = resolvedPath.replace(
       "{EventDestinationName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -221,7 +224,7 @@ export async function serializeAws_restJson1_1GetConfigurationSetEventDestinatio
   let resolvedPath =
     "/v1/sms-voice/configuration-sets/{ConfigurationSetName}/event-destinations";
   if (input.ConfigurationSetName !== undefined) {
-    const labelValue: string = input.ConfigurationSetName.toString();
+    const labelValue: string = input.ConfigurationSetName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ConfigurationSetName."
@@ -229,7 +232,7 @@ export async function serializeAws_restJson1_1GetConfigurationSetEventDestinatio
     }
     resolvedPath = resolvedPath.replace(
       "{ConfigurationSetName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -254,10 +257,14 @@ export async function serializeAws_restJson1_1ListConfigurationSetsCommand(
   let resolvedPath = "/v1/sms-voice/configuration-sets";
   const query: any = {};
   if (input.NextToken !== undefined) {
-    query["NextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("NextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   if (input.PageSize !== undefined) {
-    query["PageSize"] = input.PageSize.toString();
+    query[
+      __extendedEncodeURIComponent("PageSize")
+    ] = __extendedEncodeURIComponent(input.PageSize);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -316,7 +323,7 @@ export async function serializeAws_restJson1_1UpdateConfigurationSetEventDestina
   let resolvedPath =
     "/v1/sms-voice/configuration-sets/{ConfigurationSetName}/event-destinations/{EventDestinationName}";
   if (input.ConfigurationSetName !== undefined) {
-    const labelValue: string = input.ConfigurationSetName.toString();
+    const labelValue: string = input.ConfigurationSetName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ConfigurationSetName."
@@ -324,7 +331,7 @@ export async function serializeAws_restJson1_1UpdateConfigurationSetEventDestina
     }
     resolvedPath = resolvedPath.replace(
       "{ConfigurationSetName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -332,7 +339,7 @@ export async function serializeAws_restJson1_1UpdateConfigurationSetEventDestina
     );
   }
   if (input.EventDestinationName !== undefined) {
-    const labelValue: string = input.EventDestinationName.toString();
+    const labelValue: string = input.EventDestinationName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: EventDestinationName."
@@ -340,7 +347,7 @@ export async function serializeAws_restJson1_1UpdateConfigurationSetEventDestina
     }
     resolvedPath = resolvedPath.replace(
       "{EventDestinationName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -382,6 +389,7 @@ export async function deserializeAws_restJson1_1CreateConfigurationSetCommand(
     $metadata: deserializeMetadata(output),
     __type: "CreateConfigurationSetResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -461,6 +469,7 @@ export async function deserializeAws_restJson1_1CreateConfigurationSetEventDesti
     $metadata: deserializeMetadata(output),
     __type: "CreateConfigurationSetEventDestinationResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -547,6 +556,7 @@ export async function deserializeAws_restJson1_1DeleteConfigurationSetCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeleteConfigurationSetResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -619,6 +629,7 @@ export async function deserializeAws_restJson1_1DeleteConfigurationSetEventDesti
     $metadata: deserializeMetadata(output),
     __type: "DeleteConfigurationSetEventDestinationResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -918,6 +929,7 @@ export async function deserializeAws_restJson1_1UpdateConfigurationSetEventDesti
     $metadata: deserializeMetadata(output),
     __type: "UpdateConfigurationSetEventDestinationResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 

--- a/clients/client-pinpoint/models/index.ts
+++ b/clients/client-pinpoint/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -24,7 +27,7 @@ export interface ADMChannelRequest {
 
 export namespace ADMChannelRequest {
   export function isa(o: any): o is ADMChannelRequest {
-    return _smithy.isa(o, "ADMChannelRequest");
+    return __isa(o, "ADMChannelRequest");
   }
 }
 
@@ -86,7 +89,7 @@ export interface ADMChannelResponse {
 
 export namespace ADMChannelResponse {
   export function isa(o: any): o is ADMChannelResponse {
-    return _smithy.isa(o, "ADMChannelResponse");
+    return __isa(o, "ADMChannelResponse");
   }
 }
 
@@ -178,7 +181,7 @@ export interface ADMMessage {
 
 export namespace ADMMessage {
   export function isa(o: any): o is ADMMessage {
-    return _smithy.isa(o, "ADMMessage");
+    return __isa(o, "ADMMessage");
   }
 }
 
@@ -230,7 +233,7 @@ export interface APNSChannelRequest {
 
 export namespace APNSChannelRequest {
   export function isa(o: any): o is APNSChannelRequest {
-    return _smithy.isa(o, "APNSChannelRequest");
+    return __isa(o, "APNSChannelRequest");
   }
 }
 
@@ -302,7 +305,7 @@ export interface APNSChannelResponse {
 
 export namespace APNSChannelResponse {
   export function isa(o: any): o is APNSChannelResponse {
-    return _smithy.isa(o, "APNSChannelResponse");
+    return __isa(o, "APNSChannelResponse");
   }
 }
 
@@ -404,7 +407,7 @@ export interface APNSMessage {
 
 export namespace APNSMessage {
   export function isa(o: any): o is APNSMessage {
-    return _smithy.isa(o, "APNSMessage");
+    return __isa(o, "APNSMessage");
   }
 }
 
@@ -451,7 +454,7 @@ export interface APNSPushNotificationTemplate {
 
 export namespace APNSPushNotificationTemplate {
   export function isa(o: any): o is APNSPushNotificationTemplate {
-    return _smithy.isa(o, "APNSPushNotificationTemplate");
+    return __isa(o, "APNSPushNotificationTemplate");
   }
 }
 
@@ -503,7 +506,7 @@ export interface APNSSandboxChannelRequest {
 
 export namespace APNSSandboxChannelRequest {
   export function isa(o: any): o is APNSSandboxChannelRequest {
-    return _smithy.isa(o, "APNSSandboxChannelRequest");
+    return __isa(o, "APNSSandboxChannelRequest");
   }
 }
 
@@ -575,7 +578,7 @@ export interface APNSSandboxChannelResponse {
 
 export namespace APNSSandboxChannelResponse {
   export function isa(o: any): o is APNSSandboxChannelResponse {
-    return _smithy.isa(o, "APNSSandboxChannelResponse");
+    return __isa(o, "APNSSandboxChannelResponse");
   }
 }
 
@@ -627,7 +630,7 @@ export interface APNSVoipChannelRequest {
 
 export namespace APNSVoipChannelRequest {
   export function isa(o: any): o is APNSVoipChannelRequest {
-    return _smithy.isa(o, "APNSVoipChannelRequest");
+    return __isa(o, "APNSVoipChannelRequest");
   }
 }
 
@@ -699,7 +702,7 @@ export interface APNSVoipChannelResponse {
 
 export namespace APNSVoipChannelResponse {
   export function isa(o: any): o is APNSVoipChannelResponse {
-    return _smithy.isa(o, "APNSVoipChannelResponse");
+    return __isa(o, "APNSVoipChannelResponse");
   }
 }
 
@@ -751,7 +754,7 @@ export interface APNSVoipSandboxChannelRequest {
 
 export namespace APNSVoipSandboxChannelRequest {
   export function isa(o: any): o is APNSVoipSandboxChannelRequest {
-    return _smithy.isa(o, "APNSVoipSandboxChannelRequest");
+    return __isa(o, "APNSVoipSandboxChannelRequest");
   }
 }
 
@@ -823,7 +826,7 @@ export interface APNSVoipSandboxChannelResponse {
 
 export namespace APNSVoipSandboxChannelResponse {
   export function isa(o: any): o is APNSVoipSandboxChannelResponse {
-    return _smithy.isa(o, "APNSVoipSandboxChannelResponse");
+    return __isa(o, "APNSVoipSandboxChannelResponse");
   }
 }
 
@@ -851,7 +854,7 @@ export interface ActivitiesResponse {
 
 export namespace ActivitiesResponse {
   export function isa(o: any): o is ActivitiesResponse {
-    return _smithy.isa(o, "ActivitiesResponse");
+    return __isa(o, "ActivitiesResponse");
   }
 }
 
@@ -898,7 +901,7 @@ export interface Activity {
 
 export namespace Activity {
   export function isa(o: any): o is Activity {
-    return _smithy.isa(o, "Activity");
+    return __isa(o, "Activity");
   }
 }
 
@@ -975,7 +978,7 @@ export interface ActivityResponse {
 
 export namespace ActivityResponse {
   export function isa(o: any): o is ActivityResponse {
-    return _smithy.isa(o, "ActivityResponse");
+    return __isa(o, "ActivityResponse");
   }
 }
 
@@ -1017,7 +1020,7 @@ export interface AddressConfiguration {
 
 export namespace AddressConfiguration {
   export function isa(o: any): o is AddressConfiguration {
-    return _smithy.isa(o, "AddressConfiguration");
+    return __isa(o, "AddressConfiguration");
   }
 }
 
@@ -1074,7 +1077,7 @@ export interface AndroidPushNotificationTemplate {
 
 export namespace AndroidPushNotificationTemplate {
   export function isa(o: any): o is AndroidPushNotificationTemplate {
-    return _smithy.isa(o, "AndroidPushNotificationTemplate");
+    return __isa(o, "AndroidPushNotificationTemplate");
   }
 }
 
@@ -1116,7 +1119,7 @@ export interface ApplicationDateRangeKpiResponse {
 
 export namespace ApplicationDateRangeKpiResponse {
   export function isa(o: any): o is ApplicationDateRangeKpiResponse {
-    return _smithy.isa(o, "ApplicationDateRangeKpiResponse");
+    return __isa(o, "ApplicationDateRangeKpiResponse");
   }
 }
 
@@ -1148,7 +1151,7 @@ export interface ApplicationResponse {
 
 export namespace ApplicationResponse {
   export function isa(o: any): o is ApplicationResponse {
-    return _smithy.isa(o, "ApplicationResponse");
+    return __isa(o, "ApplicationResponse");
   }
 }
 
@@ -1185,7 +1188,7 @@ export interface ApplicationSettingsResource {
 
 export namespace ApplicationSettingsResource {
   export function isa(o: any): o is ApplicationSettingsResource {
-    return _smithy.isa(o, "ApplicationSettingsResource");
+    return __isa(o, "ApplicationSettingsResource");
   }
 }
 
@@ -1207,7 +1210,7 @@ export interface ApplicationsResponse {
 
 export namespace ApplicationsResponse {
   export function isa(o: any): o is ApplicationsResponse {
-    return _smithy.isa(o, "ApplicationsResponse");
+    return __isa(o, "ApplicationsResponse");
   }
 }
 
@@ -1229,7 +1232,7 @@ export interface AttributeDimension {
 
 export namespace AttributeDimension {
   export function isa(o: any): o is AttributeDimension {
-    return _smithy.isa(o, "AttributeDimension");
+    return __isa(o, "AttributeDimension");
   }
 }
 
@@ -1261,7 +1264,7 @@ export interface AttributesResource {
 
 export namespace AttributesResource {
   export function isa(o: any): o is AttributesResource {
-    return _smithy.isa(o, "AttributesResource");
+    return __isa(o, "AttributesResource");
   }
 }
 
@@ -1269,7 +1272,7 @@ export namespace AttributesResource {
  * <p>Provides information about an API request or response.</p>
  */
 export interface BadRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "BadRequestException";
   $fault: "client";
@@ -1286,7 +1289,7 @@ export interface BadRequestException
 
 export namespace BadRequestException {
   export function isa(o: any): o is BadRequestException {
-    return _smithy.isa(o, "BadRequestException");
+    return __isa(o, "BadRequestException");
   }
 }
 
@@ -1313,7 +1316,7 @@ export interface BaiduChannelRequest {
 
 export namespace BaiduChannelRequest {
   export function isa(o: any): o is BaiduChannelRequest {
-    return _smithy.isa(o, "BaiduChannelRequest");
+    return __isa(o, "BaiduChannelRequest");
   }
 }
 
@@ -1380,7 +1383,7 @@ export interface BaiduChannelResponse {
 
 export namespace BaiduChannelResponse {
   export function isa(o: any): o is BaiduChannelResponse {
-    return _smithy.isa(o, "BaiduChannelResponse");
+    return __isa(o, "BaiduChannelResponse");
   }
 }
 
@@ -1462,7 +1465,7 @@ export interface BaiduMessage {
 
 export namespace BaiduMessage {
   export function isa(o: any): o is BaiduMessage {
-    return _smithy.isa(o, "BaiduMessage");
+    return __isa(o, "BaiduMessage");
   }
 }
 
@@ -1479,7 +1482,7 @@ export interface BaseKpiResult {
 
 export namespace BaseKpiResult {
   export function isa(o: any): o is BaseKpiResult {
-    return _smithy.isa(o, "BaseKpiResult");
+    return __isa(o, "BaseKpiResult");
   }
 }
 
@@ -1526,7 +1529,7 @@ export interface CampaignDateRangeKpiResponse {
 
 export namespace CampaignDateRangeKpiResponse {
   export function isa(o: any): o is CampaignDateRangeKpiResponse {
-    return _smithy.isa(o, "CampaignDateRangeKpiResponse");
+    return __isa(o, "CampaignDateRangeKpiResponse");
   }
 }
 
@@ -1558,7 +1561,7 @@ export interface CampaignEmailMessage {
 
 export namespace CampaignEmailMessage {
   export function isa(o: any): o is CampaignEmailMessage {
-    return _smithy.isa(o, "CampaignEmailMessage");
+    return __isa(o, "CampaignEmailMessage");
   }
 }
 
@@ -1580,7 +1583,7 @@ export interface CampaignEventFilter {
 
 export namespace CampaignEventFilter {
   export function isa(o: any): o is CampaignEventFilter {
-    return _smithy.isa(o, "CampaignEventFilter");
+    return __isa(o, "CampaignEventFilter");
   }
 }
 
@@ -1607,7 +1610,7 @@ export interface CampaignHook {
 
 export namespace CampaignHook {
   export function isa(o: any): o is CampaignHook {
-    return _smithy.isa(o, "CampaignHook");
+    return __isa(o, "CampaignHook");
   }
 }
 
@@ -1639,7 +1642,7 @@ export interface CampaignLimits {
 
 export namespace CampaignLimits {
   export function isa(o: any): o is CampaignLimits {
-    return _smithy.isa(o, "CampaignLimits");
+    return __isa(o, "CampaignLimits");
   }
 }
 
@@ -1766,7 +1769,7 @@ export interface CampaignResponse {
 
 export namespace CampaignResponse {
   export function isa(o: any): o is CampaignResponse {
-    return _smithy.isa(o, "CampaignResponse");
+    return __isa(o, "CampaignResponse");
   }
 }
 
@@ -1793,7 +1796,7 @@ export interface CampaignSmsMessage {
 
 export namespace CampaignSmsMessage {
   export function isa(o: any): o is CampaignSmsMessage {
-    return _smithy.isa(o, "CampaignSmsMessage");
+    return __isa(o, "CampaignSmsMessage");
   }
 }
 
@@ -1810,7 +1813,7 @@ export interface CampaignState {
 
 export namespace CampaignState {
   export function isa(o: any): o is CampaignState {
-    return _smithy.isa(o, "CampaignState");
+    return __isa(o, "CampaignState");
   }
 }
 
@@ -1841,7 +1844,7 @@ export interface CampaignsResponse {
 
 export namespace CampaignsResponse {
   export function isa(o: any): o is CampaignsResponse {
-    return _smithy.isa(o, "CampaignsResponse");
+    return __isa(o, "CampaignsResponse");
   }
 }
 
@@ -1898,7 +1901,7 @@ export interface ChannelResponse {
 
 export namespace ChannelResponse {
   export function isa(o: any): o is ChannelResponse {
-    return _smithy.isa(o, "ChannelResponse");
+    return __isa(o, "ChannelResponse");
   }
 }
 
@@ -1929,7 +1932,7 @@ export interface ChannelsResponse {
 
 export namespace ChannelsResponse {
   export function isa(o: any): o is ChannelsResponse {
-    return _smithy.isa(o, "ChannelsResponse");
+    return __isa(o, "ChannelsResponse");
   }
 }
 
@@ -1951,7 +1954,7 @@ export interface Condition {
 
 export namespace Condition {
   export function isa(o: any): o is Condition {
-    return _smithy.isa(o, "Condition");
+    return __isa(o, "Condition");
   }
 }
 
@@ -1983,7 +1986,7 @@ export interface ConditionalSplitActivity {
 
 export namespace ConditionalSplitActivity {
   export function isa(o: any): o is ConditionalSplitActivity {
-    return _smithy.isa(o, "ConditionalSplitActivity");
+    return __isa(o, "ConditionalSplitActivity");
   }
 }
 
@@ -1997,7 +2000,7 @@ export interface CreateAppRequest {
 
 export namespace CreateAppRequest {
   export function isa(o: any): o is CreateAppRequest {
-    return _smithy.isa(o, "CreateAppRequest");
+    return __isa(o, "CreateAppRequest");
   }
 }
 
@@ -2011,7 +2014,7 @@ export interface CreateAppResponse extends $MetadataBearer {
 
 export namespace CreateAppResponse {
   export function isa(o: any): o is CreateAppResponse {
-    return _smithy.isa(o, "CreateAppResponse");
+    return __isa(o, "CreateAppResponse");
   }
 }
 
@@ -2033,7 +2036,7 @@ export interface CreateApplicationRequest {
 
 export namespace CreateApplicationRequest {
   export function isa(o: any): o is CreateApplicationRequest {
-    return _smithy.isa(o, "CreateApplicationRequest");
+    return __isa(o, "CreateApplicationRequest");
   }
 }
 
@@ -2052,7 +2055,7 @@ export interface CreateCampaignRequest {
 
 export namespace CreateCampaignRequest {
   export function isa(o: any): o is CreateCampaignRequest {
-    return _smithy.isa(o, "CreateCampaignRequest");
+    return __isa(o, "CreateCampaignRequest");
   }
 }
 
@@ -2066,7 +2069,7 @@ export interface CreateCampaignResponse extends $MetadataBearer {
 
 export namespace CreateCampaignResponse {
   export function isa(o: any): o is CreateCampaignResponse {
-    return _smithy.isa(o, "CreateCampaignResponse");
+    return __isa(o, "CreateCampaignResponse");
   }
 }
 
@@ -2085,7 +2088,7 @@ export interface CreateEmailTemplateRequest {
 
 export namespace CreateEmailTemplateRequest {
   export function isa(o: any): o is CreateEmailTemplateRequest {
-    return _smithy.isa(o, "CreateEmailTemplateRequest");
+    return __isa(o, "CreateEmailTemplateRequest");
   }
 }
 
@@ -2099,7 +2102,7 @@ export interface CreateEmailTemplateResponse extends $MetadataBearer {
 
 export namespace CreateEmailTemplateResponse {
   export function isa(o: any): o is CreateEmailTemplateResponse {
-    return _smithy.isa(o, "CreateEmailTemplateResponse");
+    return __isa(o, "CreateEmailTemplateResponse");
   }
 }
 
@@ -2118,7 +2121,7 @@ export interface CreateExportJobRequest {
 
 export namespace CreateExportJobRequest {
   export function isa(o: any): o is CreateExportJobRequest {
-    return _smithy.isa(o, "CreateExportJobRequest");
+    return __isa(o, "CreateExportJobRequest");
   }
 }
 
@@ -2132,7 +2135,7 @@ export interface CreateExportJobResponse extends $MetadataBearer {
 
 export namespace CreateExportJobResponse {
   export function isa(o: any): o is CreateExportJobResponse {
-    return _smithy.isa(o, "CreateExportJobResponse");
+    return __isa(o, "CreateExportJobResponse");
   }
 }
 
@@ -2151,7 +2154,7 @@ export interface CreateImportJobRequest {
 
 export namespace CreateImportJobRequest {
   export function isa(o: any): o is CreateImportJobRequest {
-    return _smithy.isa(o, "CreateImportJobRequest");
+    return __isa(o, "CreateImportJobRequest");
   }
 }
 
@@ -2165,7 +2168,7 @@ export interface CreateImportJobResponse extends $MetadataBearer {
 
 export namespace CreateImportJobResponse {
   export function isa(o: any): o is CreateImportJobResponse {
-    return _smithy.isa(o, "CreateImportJobResponse");
+    return __isa(o, "CreateImportJobResponse");
   }
 }
 
@@ -2184,7 +2187,7 @@ export interface CreateJourneyRequest {
 
 export namespace CreateJourneyRequest {
   export function isa(o: any): o is CreateJourneyRequest {
-    return _smithy.isa(o, "CreateJourneyRequest");
+    return __isa(o, "CreateJourneyRequest");
   }
 }
 
@@ -2198,7 +2201,7 @@ export interface CreateJourneyResponse extends $MetadataBearer {
 
 export namespace CreateJourneyResponse {
   export function isa(o: any): o is CreateJourneyResponse {
-    return _smithy.isa(o, "CreateJourneyResponse");
+    return __isa(o, "CreateJourneyResponse");
   }
 }
 
@@ -2217,7 +2220,7 @@ export interface CreatePushTemplateRequest {
 
 export namespace CreatePushTemplateRequest {
   export function isa(o: any): o is CreatePushTemplateRequest {
-    return _smithy.isa(o, "CreatePushTemplateRequest");
+    return __isa(o, "CreatePushTemplateRequest");
   }
 }
 
@@ -2231,7 +2234,7 @@ export interface CreatePushTemplateResponse extends $MetadataBearer {
 
 export namespace CreatePushTemplateResponse {
   export function isa(o: any): o is CreatePushTemplateResponse {
-    return _smithy.isa(o, "CreatePushTemplateResponse");
+    return __isa(o, "CreatePushTemplateResponse");
   }
 }
 
@@ -2250,7 +2253,7 @@ export interface CreateSegmentRequest {
 
 export namespace CreateSegmentRequest {
   export function isa(o: any): o is CreateSegmentRequest {
-    return _smithy.isa(o, "CreateSegmentRequest");
+    return __isa(o, "CreateSegmentRequest");
   }
 }
 
@@ -2264,7 +2267,7 @@ export interface CreateSegmentResponse extends $MetadataBearer {
 
 export namespace CreateSegmentResponse {
   export function isa(o: any): o is CreateSegmentResponse {
-    return _smithy.isa(o, "CreateSegmentResponse");
+    return __isa(o, "CreateSegmentResponse");
   }
 }
 
@@ -2283,7 +2286,7 @@ export interface CreateSmsTemplateRequest {
 
 export namespace CreateSmsTemplateRequest {
   export function isa(o: any): o is CreateSmsTemplateRequest {
-    return _smithy.isa(o, "CreateSmsTemplateRequest");
+    return __isa(o, "CreateSmsTemplateRequest");
   }
 }
 
@@ -2297,7 +2300,7 @@ export interface CreateSmsTemplateResponse extends $MetadataBearer {
 
 export namespace CreateSmsTemplateResponse {
   export function isa(o: any): o is CreateSmsTemplateResponse {
-    return _smithy.isa(o, "CreateSmsTemplateResponse");
+    return __isa(o, "CreateSmsTemplateResponse");
   }
 }
 
@@ -2324,7 +2327,7 @@ export interface CreateTemplateMessageBody {
 
 export namespace CreateTemplateMessageBody {
   export function isa(o: any): o is CreateTemplateMessageBody {
-    return _smithy.isa(o, "CreateTemplateMessageBody");
+    return __isa(o, "CreateTemplateMessageBody");
   }
 }
 
@@ -2343,7 +2346,7 @@ export interface CreateVoiceTemplateRequest {
 
 export namespace CreateVoiceTemplateRequest {
   export function isa(o: any): o is CreateVoiceTemplateRequest {
-    return _smithy.isa(o, "CreateVoiceTemplateRequest");
+    return __isa(o, "CreateVoiceTemplateRequest");
   }
 }
 
@@ -2357,7 +2360,7 @@ export interface CreateVoiceTemplateResponse extends $MetadataBearer {
 
 export namespace CreateVoiceTemplateResponse {
   export function isa(o: any): o is CreateVoiceTemplateResponse {
-    return _smithy.isa(o, "CreateVoiceTemplateResponse");
+    return __isa(o, "CreateVoiceTemplateResponse");
   }
 }
 
@@ -2379,7 +2382,7 @@ export interface DefaultMessage {
 
 export namespace DefaultMessage {
   export function isa(o: any): o is DefaultMessage {
-    return _smithy.isa(o, "DefaultMessage");
+    return __isa(o, "DefaultMessage");
   }
 }
 
@@ -2426,7 +2429,7 @@ export interface DefaultPushNotificationMessage {
 
 export namespace DefaultPushNotificationMessage {
   export function isa(o: any): o is DefaultPushNotificationMessage {
-    return _smithy.isa(o, "DefaultPushNotificationMessage");
+    return __isa(o, "DefaultPushNotificationMessage");
   }
 }
 
@@ -2463,7 +2466,7 @@ export interface DefaultPushNotificationTemplate {
 
 export namespace DefaultPushNotificationTemplate {
   export function isa(o: any): o is DefaultPushNotificationTemplate {
-    return _smithy.isa(o, "DefaultPushNotificationTemplate");
+    return __isa(o, "DefaultPushNotificationTemplate");
   }
 }
 
@@ -2477,7 +2480,7 @@ export interface DeleteAdmChannelRequest {
 
 export namespace DeleteAdmChannelRequest {
   export function isa(o: any): o is DeleteAdmChannelRequest {
-    return _smithy.isa(o, "DeleteAdmChannelRequest");
+    return __isa(o, "DeleteAdmChannelRequest");
   }
 }
 
@@ -2491,7 +2494,7 @@ export interface DeleteAdmChannelResponse extends $MetadataBearer {
 
 export namespace DeleteAdmChannelResponse {
   export function isa(o: any): o is DeleteAdmChannelResponse {
-    return _smithy.isa(o, "DeleteAdmChannelResponse");
+    return __isa(o, "DeleteAdmChannelResponse");
   }
 }
 
@@ -2505,7 +2508,7 @@ export interface DeleteApnsChannelRequest {
 
 export namespace DeleteApnsChannelRequest {
   export function isa(o: any): o is DeleteApnsChannelRequest {
-    return _smithy.isa(o, "DeleteApnsChannelRequest");
+    return __isa(o, "DeleteApnsChannelRequest");
   }
 }
 
@@ -2519,7 +2522,7 @@ export interface DeleteApnsChannelResponse extends $MetadataBearer {
 
 export namespace DeleteApnsChannelResponse {
   export function isa(o: any): o is DeleteApnsChannelResponse {
-    return _smithy.isa(o, "DeleteApnsChannelResponse");
+    return __isa(o, "DeleteApnsChannelResponse");
   }
 }
 
@@ -2533,7 +2536,7 @@ export interface DeleteApnsSandboxChannelRequest {
 
 export namespace DeleteApnsSandboxChannelRequest {
   export function isa(o: any): o is DeleteApnsSandboxChannelRequest {
-    return _smithy.isa(o, "DeleteApnsSandboxChannelRequest");
+    return __isa(o, "DeleteApnsSandboxChannelRequest");
   }
 }
 
@@ -2547,7 +2550,7 @@ export interface DeleteApnsSandboxChannelResponse extends $MetadataBearer {
 
 export namespace DeleteApnsSandboxChannelResponse {
   export function isa(o: any): o is DeleteApnsSandboxChannelResponse {
-    return _smithy.isa(o, "DeleteApnsSandboxChannelResponse");
+    return __isa(o, "DeleteApnsSandboxChannelResponse");
   }
 }
 
@@ -2561,7 +2564,7 @@ export interface DeleteApnsVoipChannelRequest {
 
 export namespace DeleteApnsVoipChannelRequest {
   export function isa(o: any): o is DeleteApnsVoipChannelRequest {
-    return _smithy.isa(o, "DeleteApnsVoipChannelRequest");
+    return __isa(o, "DeleteApnsVoipChannelRequest");
   }
 }
 
@@ -2575,7 +2578,7 @@ export interface DeleteApnsVoipChannelResponse extends $MetadataBearer {
 
 export namespace DeleteApnsVoipChannelResponse {
   export function isa(o: any): o is DeleteApnsVoipChannelResponse {
-    return _smithy.isa(o, "DeleteApnsVoipChannelResponse");
+    return __isa(o, "DeleteApnsVoipChannelResponse");
   }
 }
 
@@ -2589,7 +2592,7 @@ export interface DeleteApnsVoipSandboxChannelRequest {
 
 export namespace DeleteApnsVoipSandboxChannelRequest {
   export function isa(o: any): o is DeleteApnsVoipSandboxChannelRequest {
-    return _smithy.isa(o, "DeleteApnsVoipSandboxChannelRequest");
+    return __isa(o, "DeleteApnsVoipSandboxChannelRequest");
   }
 }
 
@@ -2603,7 +2606,7 @@ export interface DeleteApnsVoipSandboxChannelResponse extends $MetadataBearer {
 
 export namespace DeleteApnsVoipSandboxChannelResponse {
   export function isa(o: any): o is DeleteApnsVoipSandboxChannelResponse {
-    return _smithy.isa(o, "DeleteApnsVoipSandboxChannelResponse");
+    return __isa(o, "DeleteApnsVoipSandboxChannelResponse");
   }
 }
 
@@ -2617,7 +2620,7 @@ export interface DeleteAppRequest {
 
 export namespace DeleteAppRequest {
   export function isa(o: any): o is DeleteAppRequest {
-    return _smithy.isa(o, "DeleteAppRequest");
+    return __isa(o, "DeleteAppRequest");
   }
 }
 
@@ -2631,7 +2634,7 @@ export interface DeleteAppResponse extends $MetadataBearer {
 
 export namespace DeleteAppResponse {
   export function isa(o: any): o is DeleteAppResponse {
-    return _smithy.isa(o, "DeleteAppResponse");
+    return __isa(o, "DeleteAppResponse");
   }
 }
 
@@ -2645,7 +2648,7 @@ export interface DeleteBaiduChannelRequest {
 
 export namespace DeleteBaiduChannelRequest {
   export function isa(o: any): o is DeleteBaiduChannelRequest {
-    return _smithy.isa(o, "DeleteBaiduChannelRequest");
+    return __isa(o, "DeleteBaiduChannelRequest");
   }
 }
 
@@ -2659,7 +2662,7 @@ export interface DeleteBaiduChannelResponse extends $MetadataBearer {
 
 export namespace DeleteBaiduChannelResponse {
   export function isa(o: any): o is DeleteBaiduChannelResponse {
-    return _smithy.isa(o, "DeleteBaiduChannelResponse");
+    return __isa(o, "DeleteBaiduChannelResponse");
   }
 }
 
@@ -2678,7 +2681,7 @@ export interface DeleteCampaignRequest {
 
 export namespace DeleteCampaignRequest {
   export function isa(o: any): o is DeleteCampaignRequest {
-    return _smithy.isa(o, "DeleteCampaignRequest");
+    return __isa(o, "DeleteCampaignRequest");
   }
 }
 
@@ -2692,7 +2695,7 @@ export interface DeleteCampaignResponse extends $MetadataBearer {
 
 export namespace DeleteCampaignResponse {
   export function isa(o: any): o is DeleteCampaignResponse {
-    return _smithy.isa(o, "DeleteCampaignResponse");
+    return __isa(o, "DeleteCampaignResponse");
   }
 }
 
@@ -2706,7 +2709,7 @@ export interface DeleteEmailChannelRequest {
 
 export namespace DeleteEmailChannelRequest {
   export function isa(o: any): o is DeleteEmailChannelRequest {
-    return _smithy.isa(o, "DeleteEmailChannelRequest");
+    return __isa(o, "DeleteEmailChannelRequest");
   }
 }
 
@@ -2720,7 +2723,7 @@ export interface DeleteEmailChannelResponse extends $MetadataBearer {
 
 export namespace DeleteEmailChannelResponse {
   export function isa(o: any): o is DeleteEmailChannelResponse {
-    return _smithy.isa(o, "DeleteEmailChannelResponse");
+    return __isa(o, "DeleteEmailChannelResponse");
   }
 }
 
@@ -2739,7 +2742,7 @@ export interface DeleteEmailTemplateRequest {
 
 export namespace DeleteEmailTemplateRequest {
   export function isa(o: any): o is DeleteEmailTemplateRequest {
-    return _smithy.isa(o, "DeleteEmailTemplateRequest");
+    return __isa(o, "DeleteEmailTemplateRequest");
   }
 }
 
@@ -2753,7 +2756,7 @@ export interface DeleteEmailTemplateResponse extends $MetadataBearer {
 
 export namespace DeleteEmailTemplateResponse {
   export function isa(o: any): o is DeleteEmailTemplateResponse {
-    return _smithy.isa(o, "DeleteEmailTemplateResponse");
+    return __isa(o, "DeleteEmailTemplateResponse");
   }
 }
 
@@ -2772,7 +2775,7 @@ export interface DeleteEndpointRequest {
 
 export namespace DeleteEndpointRequest {
   export function isa(o: any): o is DeleteEndpointRequest {
-    return _smithy.isa(o, "DeleteEndpointRequest");
+    return __isa(o, "DeleteEndpointRequest");
   }
 }
 
@@ -2786,7 +2789,7 @@ export interface DeleteEndpointResponse extends $MetadataBearer {
 
 export namespace DeleteEndpointResponse {
   export function isa(o: any): o is DeleteEndpointResponse {
-    return _smithy.isa(o, "DeleteEndpointResponse");
+    return __isa(o, "DeleteEndpointResponse");
   }
 }
 
@@ -2800,7 +2803,7 @@ export interface DeleteEventStreamRequest {
 
 export namespace DeleteEventStreamRequest {
   export function isa(o: any): o is DeleteEventStreamRequest {
-    return _smithy.isa(o, "DeleteEventStreamRequest");
+    return __isa(o, "DeleteEventStreamRequest");
   }
 }
 
@@ -2814,7 +2817,7 @@ export interface DeleteEventStreamResponse extends $MetadataBearer {
 
 export namespace DeleteEventStreamResponse {
   export function isa(o: any): o is DeleteEventStreamResponse {
-    return _smithy.isa(o, "DeleteEventStreamResponse");
+    return __isa(o, "DeleteEventStreamResponse");
   }
 }
 
@@ -2828,7 +2831,7 @@ export interface DeleteGcmChannelRequest {
 
 export namespace DeleteGcmChannelRequest {
   export function isa(o: any): o is DeleteGcmChannelRequest {
-    return _smithy.isa(o, "DeleteGcmChannelRequest");
+    return __isa(o, "DeleteGcmChannelRequest");
   }
 }
 
@@ -2842,7 +2845,7 @@ export interface DeleteGcmChannelResponse extends $MetadataBearer {
 
 export namespace DeleteGcmChannelResponse {
   export function isa(o: any): o is DeleteGcmChannelResponse {
-    return _smithy.isa(o, "DeleteGcmChannelResponse");
+    return __isa(o, "DeleteGcmChannelResponse");
   }
 }
 
@@ -2861,7 +2864,7 @@ export interface DeleteJourneyRequest {
 
 export namespace DeleteJourneyRequest {
   export function isa(o: any): o is DeleteJourneyRequest {
-    return _smithy.isa(o, "DeleteJourneyRequest");
+    return __isa(o, "DeleteJourneyRequest");
   }
 }
 
@@ -2875,7 +2878,7 @@ export interface DeleteJourneyResponse extends $MetadataBearer {
 
 export namespace DeleteJourneyResponse {
   export function isa(o: any): o is DeleteJourneyResponse {
-    return _smithy.isa(o, "DeleteJourneyResponse");
+    return __isa(o, "DeleteJourneyResponse");
   }
 }
 
@@ -2894,7 +2897,7 @@ export interface DeletePushTemplateRequest {
 
 export namespace DeletePushTemplateRequest {
   export function isa(o: any): o is DeletePushTemplateRequest {
-    return _smithy.isa(o, "DeletePushTemplateRequest");
+    return __isa(o, "DeletePushTemplateRequest");
   }
 }
 
@@ -2908,7 +2911,7 @@ export interface DeletePushTemplateResponse extends $MetadataBearer {
 
 export namespace DeletePushTemplateResponse {
   export function isa(o: any): o is DeletePushTemplateResponse {
-    return _smithy.isa(o, "DeletePushTemplateResponse");
+    return __isa(o, "DeletePushTemplateResponse");
   }
 }
 
@@ -2927,7 +2930,7 @@ export interface DeleteSegmentRequest {
 
 export namespace DeleteSegmentRequest {
   export function isa(o: any): o is DeleteSegmentRequest {
-    return _smithy.isa(o, "DeleteSegmentRequest");
+    return __isa(o, "DeleteSegmentRequest");
   }
 }
 
@@ -2941,7 +2944,7 @@ export interface DeleteSegmentResponse extends $MetadataBearer {
 
 export namespace DeleteSegmentResponse {
   export function isa(o: any): o is DeleteSegmentResponse {
-    return _smithy.isa(o, "DeleteSegmentResponse");
+    return __isa(o, "DeleteSegmentResponse");
   }
 }
 
@@ -2955,7 +2958,7 @@ export interface DeleteSmsChannelRequest {
 
 export namespace DeleteSmsChannelRequest {
   export function isa(o: any): o is DeleteSmsChannelRequest {
-    return _smithy.isa(o, "DeleteSmsChannelRequest");
+    return __isa(o, "DeleteSmsChannelRequest");
   }
 }
 
@@ -2969,7 +2972,7 @@ export interface DeleteSmsChannelResponse extends $MetadataBearer {
 
 export namespace DeleteSmsChannelResponse {
   export function isa(o: any): o is DeleteSmsChannelResponse {
-    return _smithy.isa(o, "DeleteSmsChannelResponse");
+    return __isa(o, "DeleteSmsChannelResponse");
   }
 }
 
@@ -2988,7 +2991,7 @@ export interface DeleteSmsTemplateRequest {
 
 export namespace DeleteSmsTemplateRequest {
   export function isa(o: any): o is DeleteSmsTemplateRequest {
-    return _smithy.isa(o, "DeleteSmsTemplateRequest");
+    return __isa(o, "DeleteSmsTemplateRequest");
   }
 }
 
@@ -3002,7 +3005,7 @@ export interface DeleteSmsTemplateResponse extends $MetadataBearer {
 
 export namespace DeleteSmsTemplateResponse {
   export function isa(o: any): o is DeleteSmsTemplateResponse {
-    return _smithy.isa(o, "DeleteSmsTemplateResponse");
+    return __isa(o, "DeleteSmsTemplateResponse");
   }
 }
 
@@ -3021,7 +3024,7 @@ export interface DeleteUserEndpointsRequest {
 
 export namespace DeleteUserEndpointsRequest {
   export function isa(o: any): o is DeleteUserEndpointsRequest {
-    return _smithy.isa(o, "DeleteUserEndpointsRequest");
+    return __isa(o, "DeleteUserEndpointsRequest");
   }
 }
 
@@ -3035,7 +3038,7 @@ export interface DeleteUserEndpointsResponse extends $MetadataBearer {
 
 export namespace DeleteUserEndpointsResponse {
   export function isa(o: any): o is DeleteUserEndpointsResponse {
-    return _smithy.isa(o, "DeleteUserEndpointsResponse");
+    return __isa(o, "DeleteUserEndpointsResponse");
   }
 }
 
@@ -3049,7 +3052,7 @@ export interface DeleteVoiceChannelRequest {
 
 export namespace DeleteVoiceChannelRequest {
   export function isa(o: any): o is DeleteVoiceChannelRequest {
-    return _smithy.isa(o, "DeleteVoiceChannelRequest");
+    return __isa(o, "DeleteVoiceChannelRequest");
   }
 }
 
@@ -3063,7 +3066,7 @@ export interface DeleteVoiceChannelResponse extends $MetadataBearer {
 
 export namespace DeleteVoiceChannelResponse {
   export function isa(o: any): o is DeleteVoiceChannelResponse {
-    return _smithy.isa(o, "DeleteVoiceChannelResponse");
+    return __isa(o, "DeleteVoiceChannelResponse");
   }
 }
 
@@ -3082,7 +3085,7 @@ export interface DeleteVoiceTemplateRequest {
 
 export namespace DeleteVoiceTemplateRequest {
   export function isa(o: any): o is DeleteVoiceTemplateRequest {
-    return _smithy.isa(o, "DeleteVoiceTemplateRequest");
+    return __isa(o, "DeleteVoiceTemplateRequest");
   }
 }
 
@@ -3096,7 +3099,7 @@ export interface DeleteVoiceTemplateResponse extends $MetadataBearer {
 
 export namespace DeleteVoiceTemplateResponse {
   export function isa(o: any): o is DeleteVoiceTemplateResponse {
-    return _smithy.isa(o, "DeleteVoiceTemplateResponse");
+    return __isa(o, "DeleteVoiceTemplateResponse");
   }
 }
 
@@ -3168,7 +3171,7 @@ export interface DirectMessageConfiguration {
 
 export namespace DirectMessageConfiguration {
   export function isa(o: any): o is DirectMessageConfiguration {
-    return _smithy.isa(o, "DirectMessageConfiguration");
+    return __isa(o, "DirectMessageConfiguration");
   }
 }
 
@@ -3212,7 +3215,7 @@ export interface EmailChannelRequest {
 
 export namespace EmailChannelRequest {
   export function isa(o: any): o is EmailChannelRequest {
-    return _smithy.isa(o, "EmailChannelRequest");
+    return __isa(o, "EmailChannelRequest");
   }
 }
 
@@ -3299,7 +3302,7 @@ export interface EmailChannelResponse {
 
 export namespace EmailChannelResponse {
   export function isa(o: any): o is EmailChannelResponse {
-    return _smithy.isa(o, "EmailChannelResponse");
+    return __isa(o, "EmailChannelResponse");
   }
 }
 
@@ -3346,7 +3349,7 @@ export interface EmailMessage {
 
 export namespace EmailMessage {
   export function isa(o: any): o is EmailMessage {
-    return _smithy.isa(o, "EmailMessage");
+    return __isa(o, "EmailMessage");
   }
 }
 
@@ -3378,7 +3381,7 @@ export interface EmailMessageActivity {
 
 export namespace EmailMessageActivity {
   export function isa(o: any): o is EmailMessageActivity {
-    return _smithy.isa(o, "EmailMessageActivity");
+    return __isa(o, "EmailMessageActivity");
   }
 }
 
@@ -3420,7 +3423,7 @@ export interface EmailTemplateRequest {
 
 export namespace EmailTemplateRequest {
   export function isa(o: any): o is EmailTemplateRequest {
-    return _smithy.isa(o, "EmailTemplateRequest");
+    return __isa(o, "EmailTemplateRequest");
   }
 }
 
@@ -3492,7 +3495,7 @@ export interface EmailTemplateResponse {
 
 export namespace EmailTemplateResponse {
   export function isa(o: any): o is EmailTemplateResponse {
-    return _smithy.isa(o, "EmailTemplateResponse");
+    return __isa(o, "EmailTemplateResponse");
   }
 }
 
@@ -3564,7 +3567,7 @@ export interface EndpointBatchItem {
 
 export namespace EndpointBatchItem {
   export function isa(o: any): o is EndpointBatchItem {
-    return _smithy.isa(o, "EndpointBatchItem");
+    return __isa(o, "EndpointBatchItem");
   }
 }
 
@@ -3581,7 +3584,7 @@ export interface EndpointBatchRequest {
 
 export namespace EndpointBatchRequest {
   export function isa(o: any): o is EndpointBatchRequest {
-    return _smithy.isa(o, "EndpointBatchRequest");
+    return __isa(o, "EndpointBatchRequest");
   }
 }
 
@@ -3633,7 +3636,7 @@ export interface EndpointDemographic {
 
 export namespace EndpointDemographic {
   export function isa(o: any): o is EndpointDemographic {
-    return _smithy.isa(o, "EndpointDemographic");
+    return __isa(o, "EndpointDemographic");
   }
 }
 
@@ -3655,7 +3658,7 @@ export interface EndpointItemResponse {
 
 export namespace EndpointItemResponse {
   export function isa(o: any): o is EndpointItemResponse {
-    return _smithy.isa(o, "EndpointItemResponse");
+    return __isa(o, "EndpointItemResponse");
   }
 }
 
@@ -3697,7 +3700,7 @@ export interface EndpointLocation {
 
 export namespace EndpointLocation {
   export function isa(o: any): o is EndpointLocation {
-    return _smithy.isa(o, "EndpointLocation");
+    return __isa(o, "EndpointLocation");
   }
 }
 
@@ -3739,7 +3742,7 @@ export interface EndpointMessageResult {
 
 export namespace EndpointMessageResult {
   export function isa(o: any): o is EndpointMessageResult {
-    return _smithy.isa(o, "EndpointMessageResult");
+    return __isa(o, "EndpointMessageResult");
   }
 }
 
@@ -3806,7 +3809,7 @@ export interface EndpointRequest {
 
 export namespace EndpointRequest {
   export function isa(o: any): o is EndpointRequest {
-    return _smithy.isa(o, "EndpointRequest");
+    return __isa(o, "EndpointRequest");
   }
 }
 
@@ -3893,7 +3896,7 @@ export interface EndpointResponse {
 
 export namespace EndpointResponse {
   export function isa(o: any): o is EndpointResponse {
-    return _smithy.isa(o, "EndpointResponse");
+    return __isa(o, "EndpointResponse");
   }
 }
 
@@ -3930,7 +3933,7 @@ export interface EndpointSendConfiguration {
 
 export namespace EndpointSendConfiguration {
   export function isa(o: any): o is EndpointSendConfiguration {
-    return _smithy.isa(o, "EndpointSendConfiguration");
+    return __isa(o, "EndpointSendConfiguration");
   }
 }
 
@@ -3952,7 +3955,7 @@ export interface EndpointUser {
 
 export namespace EndpointUser {
   export function isa(o: any): o is EndpointUser {
-    return _smithy.isa(o, "EndpointUser");
+    return __isa(o, "EndpointUser");
   }
 }
 
@@ -3969,7 +3972,7 @@ export interface EndpointsResponse {
 
 export namespace EndpointsResponse {
   export function isa(o: any): o is EndpointsResponse {
-    return _smithy.isa(o, "EndpointsResponse");
+    return __isa(o, "EndpointsResponse");
   }
 }
 
@@ -4031,7 +4034,7 @@ export interface Event {
 
 export namespace Event {
   export function isa(o: any): o is Event {
-    return _smithy.isa(o, "Event");
+    return __isa(o, "Event");
   }
 }
 
@@ -4053,7 +4056,7 @@ export interface EventCondition {
 
 export namespace EventCondition {
   export function isa(o: any): o is EventCondition {
-    return _smithy.isa(o, "EventCondition");
+    return __isa(o, "EventCondition");
   }
 }
 
@@ -4080,7 +4083,7 @@ export interface EventDimensions {
 
 export namespace EventDimensions {
   export function isa(o: any): o is EventDimensions {
-    return _smithy.isa(o, "EventDimensions");
+    return __isa(o, "EventDimensions");
   }
 }
 
@@ -4102,7 +4105,7 @@ export interface EventItemResponse {
 
 export namespace EventItemResponse {
   export function isa(o: any): o is EventItemResponse {
-    return _smithy.isa(o, "EventItemResponse");
+    return __isa(o, "EventItemResponse");
   }
 }
 
@@ -4146,7 +4149,7 @@ export interface EventStream {
 
 export namespace EventStream {
   export function isa(o: any): o is EventStream {
-    return _smithy.isa(o, "EventStream");
+    return __isa(o, "EventStream");
   }
 }
 
@@ -4168,7 +4171,7 @@ export interface EventsBatch {
 
 export namespace EventsBatch {
   export function isa(o: any): o is EventsBatch {
-    return _smithy.isa(o, "EventsBatch");
+    return __isa(o, "EventsBatch");
   }
 }
 
@@ -4185,7 +4188,7 @@ export interface EventsRequest {
 
 export namespace EventsRequest {
   export function isa(o: any): o is EventsRequest {
-    return _smithy.isa(o, "EventsRequest");
+    return __isa(o, "EventsRequest");
   }
 }
 
@@ -4202,7 +4205,7 @@ export interface EventsResponse {
 
 export namespace EventsResponse {
   export function isa(o: any): o is EventsResponse {
-    return _smithy.isa(o, "EventsResponse");
+    return __isa(o, "EventsResponse");
   }
 }
 
@@ -4234,7 +4237,7 @@ export interface ExportJobRequest {
 
 export namespace ExportJobRequest {
   export function isa(o: any): o is ExportJobRequest {
-    return _smithy.isa(o, "ExportJobRequest");
+    return __isa(o, "ExportJobRequest");
   }
 }
 
@@ -4266,7 +4269,7 @@ export interface ExportJobResource {
 
 export namespace ExportJobResource {
   export function isa(o: any): o is ExportJobResource {
-    return _smithy.isa(o, "ExportJobResource");
+    return __isa(o, "ExportJobResource");
   }
 }
 
@@ -4343,7 +4346,7 @@ export interface ExportJobResponse {
 
 export namespace ExportJobResponse {
   export function isa(o: any): o is ExportJobResponse {
-    return _smithy.isa(o, "ExportJobResponse");
+    return __isa(o, "ExportJobResponse");
   }
 }
 
@@ -4365,7 +4368,7 @@ export interface ExportJobsResponse {
 
 export namespace ExportJobsResponse {
   export function isa(o: any): o is ExportJobsResponse {
-    return _smithy.isa(o, "ExportJobsResponse");
+    return __isa(o, "ExportJobsResponse");
   }
 }
 
@@ -4377,9 +4380,7 @@ export enum FilterType {
 /**
  * <p>Provides information about an API request or response.</p>
  */
-export interface ForbiddenException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface ForbiddenException extends __SmithyException, $MetadataBearer {
   name: "ForbiddenException";
   $fault: "client";
   /**
@@ -4395,7 +4396,7 @@ export interface ForbiddenException
 
 export namespace ForbiddenException {
   export function isa(o: any): o is ForbiddenException {
-    return _smithy.isa(o, "ForbiddenException");
+    return __isa(o, "ForbiddenException");
   }
 }
 
@@ -4431,7 +4432,7 @@ export interface GCMChannelRequest {
 
 export namespace GCMChannelRequest {
   export function isa(o: any): o is GCMChannelRequest {
-    return _smithy.isa(o, "GCMChannelRequest");
+    return __isa(o, "GCMChannelRequest");
   }
 }
 
@@ -4498,7 +4499,7 @@ export interface GCMChannelResponse {
 
 export namespace GCMChannelResponse {
   export function isa(o: any): o is GCMChannelResponse {
-    return _smithy.isa(o, "GCMChannelResponse");
+    return __isa(o, "GCMChannelResponse");
   }
 }
 
@@ -4595,7 +4596,7 @@ export interface GCMMessage {
 
 export namespace GCMMessage {
   export function isa(o: any): o is GCMMessage {
-    return _smithy.isa(o, "GCMMessage");
+    return __isa(o, "GCMMessage");
   }
 }
 
@@ -4617,7 +4618,7 @@ export interface GPSCoordinates {
 
 export namespace GPSCoordinates {
   export function isa(o: any): o is GPSCoordinates {
-    return _smithy.isa(o, "GPSCoordinates");
+    return __isa(o, "GPSCoordinates");
   }
 }
 
@@ -4639,7 +4640,7 @@ export interface GPSPointDimension {
 
 export namespace GPSPointDimension {
   export function isa(o: any): o is GPSPointDimension {
-    return _smithy.isa(o, "GPSPointDimension");
+    return __isa(o, "GPSPointDimension");
   }
 }
 
@@ -4653,7 +4654,7 @@ export interface GetAdmChannelRequest {
 
 export namespace GetAdmChannelRequest {
   export function isa(o: any): o is GetAdmChannelRequest {
-    return _smithy.isa(o, "GetAdmChannelRequest");
+    return __isa(o, "GetAdmChannelRequest");
   }
 }
 
@@ -4667,7 +4668,7 @@ export interface GetAdmChannelResponse extends $MetadataBearer {
 
 export namespace GetAdmChannelResponse {
   export function isa(o: any): o is GetAdmChannelResponse {
-    return _smithy.isa(o, "GetAdmChannelResponse");
+    return __isa(o, "GetAdmChannelResponse");
   }
 }
 
@@ -4681,7 +4682,7 @@ export interface GetApnsChannelRequest {
 
 export namespace GetApnsChannelRequest {
   export function isa(o: any): o is GetApnsChannelRequest {
-    return _smithy.isa(o, "GetApnsChannelRequest");
+    return __isa(o, "GetApnsChannelRequest");
   }
 }
 
@@ -4695,7 +4696,7 @@ export interface GetApnsChannelResponse extends $MetadataBearer {
 
 export namespace GetApnsChannelResponse {
   export function isa(o: any): o is GetApnsChannelResponse {
-    return _smithy.isa(o, "GetApnsChannelResponse");
+    return __isa(o, "GetApnsChannelResponse");
   }
 }
 
@@ -4709,7 +4710,7 @@ export interface GetApnsSandboxChannelRequest {
 
 export namespace GetApnsSandboxChannelRequest {
   export function isa(o: any): o is GetApnsSandboxChannelRequest {
-    return _smithy.isa(o, "GetApnsSandboxChannelRequest");
+    return __isa(o, "GetApnsSandboxChannelRequest");
   }
 }
 
@@ -4723,7 +4724,7 @@ export interface GetApnsSandboxChannelResponse extends $MetadataBearer {
 
 export namespace GetApnsSandboxChannelResponse {
   export function isa(o: any): o is GetApnsSandboxChannelResponse {
-    return _smithy.isa(o, "GetApnsSandboxChannelResponse");
+    return __isa(o, "GetApnsSandboxChannelResponse");
   }
 }
 
@@ -4737,7 +4738,7 @@ export interface GetApnsVoipChannelRequest {
 
 export namespace GetApnsVoipChannelRequest {
   export function isa(o: any): o is GetApnsVoipChannelRequest {
-    return _smithy.isa(o, "GetApnsVoipChannelRequest");
+    return __isa(o, "GetApnsVoipChannelRequest");
   }
 }
 
@@ -4751,7 +4752,7 @@ export interface GetApnsVoipChannelResponse extends $MetadataBearer {
 
 export namespace GetApnsVoipChannelResponse {
   export function isa(o: any): o is GetApnsVoipChannelResponse {
-    return _smithy.isa(o, "GetApnsVoipChannelResponse");
+    return __isa(o, "GetApnsVoipChannelResponse");
   }
 }
 
@@ -4765,7 +4766,7 @@ export interface GetApnsVoipSandboxChannelRequest {
 
 export namespace GetApnsVoipSandboxChannelRequest {
   export function isa(o: any): o is GetApnsVoipSandboxChannelRequest {
-    return _smithy.isa(o, "GetApnsVoipSandboxChannelRequest");
+    return __isa(o, "GetApnsVoipSandboxChannelRequest");
   }
 }
 
@@ -4779,7 +4780,7 @@ export interface GetApnsVoipSandboxChannelResponse extends $MetadataBearer {
 
 export namespace GetApnsVoipSandboxChannelResponse {
   export function isa(o: any): o is GetApnsVoipSandboxChannelResponse {
-    return _smithy.isa(o, "GetApnsVoipSandboxChannelResponse");
+    return __isa(o, "GetApnsVoipSandboxChannelResponse");
   }
 }
 
@@ -4793,7 +4794,7 @@ export interface GetAppRequest {
 
 export namespace GetAppRequest {
   export function isa(o: any): o is GetAppRequest {
-    return _smithy.isa(o, "GetAppRequest");
+    return __isa(o, "GetAppRequest");
   }
 }
 
@@ -4807,7 +4808,7 @@ export interface GetAppResponse extends $MetadataBearer {
 
 export namespace GetAppResponse {
   export function isa(o: any): o is GetAppResponse {
-    return _smithy.isa(o, "GetAppResponse");
+    return __isa(o, "GetAppResponse");
   }
 }
 
@@ -4846,7 +4847,7 @@ export interface GetApplicationDateRangeKpiRequest {
 
 export namespace GetApplicationDateRangeKpiRequest {
   export function isa(o: any): o is GetApplicationDateRangeKpiRequest {
-    return _smithy.isa(o, "GetApplicationDateRangeKpiRequest");
+    return __isa(o, "GetApplicationDateRangeKpiRequest");
   }
 }
 
@@ -4860,7 +4861,7 @@ export interface GetApplicationDateRangeKpiResponse extends $MetadataBearer {
 
 export namespace GetApplicationDateRangeKpiResponse {
   export function isa(o: any): o is GetApplicationDateRangeKpiResponse {
-    return _smithy.isa(o, "GetApplicationDateRangeKpiResponse");
+    return __isa(o, "GetApplicationDateRangeKpiResponse");
   }
 }
 
@@ -4874,7 +4875,7 @@ export interface GetApplicationSettingsRequest {
 
 export namespace GetApplicationSettingsRequest {
   export function isa(o: any): o is GetApplicationSettingsRequest {
-    return _smithy.isa(o, "GetApplicationSettingsRequest");
+    return __isa(o, "GetApplicationSettingsRequest");
   }
 }
 
@@ -4888,7 +4889,7 @@ export interface GetApplicationSettingsResponse extends $MetadataBearer {
 
 export namespace GetApplicationSettingsResponse {
   export function isa(o: any): o is GetApplicationSettingsResponse {
-    return _smithy.isa(o, "GetApplicationSettingsResponse");
+    return __isa(o, "GetApplicationSettingsResponse");
   }
 }
 
@@ -4907,7 +4908,7 @@ export interface GetAppsRequest {
 
 export namespace GetAppsRequest {
   export function isa(o: any): o is GetAppsRequest {
-    return _smithy.isa(o, "GetAppsRequest");
+    return __isa(o, "GetAppsRequest");
   }
 }
 
@@ -4921,7 +4922,7 @@ export interface GetAppsResponse extends $MetadataBearer {
 
 export namespace GetAppsResponse {
   export function isa(o: any): o is GetAppsResponse {
-    return _smithy.isa(o, "GetAppsResponse");
+    return __isa(o, "GetAppsResponse");
   }
 }
 
@@ -4935,7 +4936,7 @@ export interface GetBaiduChannelRequest {
 
 export namespace GetBaiduChannelRequest {
   export function isa(o: any): o is GetBaiduChannelRequest {
-    return _smithy.isa(o, "GetBaiduChannelRequest");
+    return __isa(o, "GetBaiduChannelRequest");
   }
 }
 
@@ -4949,7 +4950,7 @@ export interface GetBaiduChannelResponse extends $MetadataBearer {
 
 export namespace GetBaiduChannelResponse {
   export function isa(o: any): o is GetBaiduChannelResponse {
-    return _smithy.isa(o, "GetBaiduChannelResponse");
+    return __isa(o, "GetBaiduChannelResponse");
   }
 }
 
@@ -4978,7 +4979,7 @@ export interface GetCampaignActivitiesRequest {
 
 export namespace GetCampaignActivitiesRequest {
   export function isa(o: any): o is GetCampaignActivitiesRequest {
-    return _smithy.isa(o, "GetCampaignActivitiesRequest");
+    return __isa(o, "GetCampaignActivitiesRequest");
   }
 }
 
@@ -4992,7 +4993,7 @@ export interface GetCampaignActivitiesResponse extends $MetadataBearer {
 
 export namespace GetCampaignActivitiesResponse {
   export function isa(o: any): o is GetCampaignActivitiesResponse {
-    return _smithy.isa(o, "GetCampaignActivitiesResponse");
+    return __isa(o, "GetCampaignActivitiesResponse");
   }
 }
 
@@ -5036,7 +5037,7 @@ export interface GetCampaignDateRangeKpiRequest {
 
 export namespace GetCampaignDateRangeKpiRequest {
   export function isa(o: any): o is GetCampaignDateRangeKpiRequest {
-    return _smithy.isa(o, "GetCampaignDateRangeKpiRequest");
+    return __isa(o, "GetCampaignDateRangeKpiRequest");
   }
 }
 
@@ -5050,7 +5051,7 @@ export interface GetCampaignDateRangeKpiResponse extends $MetadataBearer {
 
 export namespace GetCampaignDateRangeKpiResponse {
   export function isa(o: any): o is GetCampaignDateRangeKpiResponse {
-    return _smithy.isa(o, "GetCampaignDateRangeKpiResponse");
+    return __isa(o, "GetCampaignDateRangeKpiResponse");
   }
 }
 
@@ -5069,7 +5070,7 @@ export interface GetCampaignRequest {
 
 export namespace GetCampaignRequest {
   export function isa(o: any): o is GetCampaignRequest {
-    return _smithy.isa(o, "GetCampaignRequest");
+    return __isa(o, "GetCampaignRequest");
   }
 }
 
@@ -5083,7 +5084,7 @@ export interface GetCampaignResponse extends $MetadataBearer {
 
 export namespace GetCampaignResponse {
   export function isa(o: any): o is GetCampaignResponse {
-    return _smithy.isa(o, "GetCampaignResponse");
+    return __isa(o, "GetCampaignResponse");
   }
 }
 
@@ -5107,7 +5108,7 @@ export interface GetCampaignVersionRequest {
 
 export namespace GetCampaignVersionRequest {
   export function isa(o: any): o is GetCampaignVersionRequest {
-    return _smithy.isa(o, "GetCampaignVersionRequest");
+    return __isa(o, "GetCampaignVersionRequest");
   }
 }
 
@@ -5121,7 +5122,7 @@ export interface GetCampaignVersionResponse extends $MetadataBearer {
 
 export namespace GetCampaignVersionResponse {
   export function isa(o: any): o is GetCampaignVersionResponse {
-    return _smithy.isa(o, "GetCampaignVersionResponse");
+    return __isa(o, "GetCampaignVersionResponse");
   }
 }
 
@@ -5150,7 +5151,7 @@ export interface GetCampaignVersionsRequest {
 
 export namespace GetCampaignVersionsRequest {
   export function isa(o: any): o is GetCampaignVersionsRequest {
-    return _smithy.isa(o, "GetCampaignVersionsRequest");
+    return __isa(o, "GetCampaignVersionsRequest");
   }
 }
 
@@ -5164,7 +5165,7 @@ export interface GetCampaignVersionsResponse extends $MetadataBearer {
 
 export namespace GetCampaignVersionsResponse {
   export function isa(o: any): o is GetCampaignVersionsResponse {
-    return _smithy.isa(o, "GetCampaignVersionsResponse");
+    return __isa(o, "GetCampaignVersionsResponse");
   }
 }
 
@@ -5188,7 +5189,7 @@ export interface GetCampaignsRequest {
 
 export namespace GetCampaignsRequest {
   export function isa(o: any): o is GetCampaignsRequest {
-    return _smithy.isa(o, "GetCampaignsRequest");
+    return __isa(o, "GetCampaignsRequest");
   }
 }
 
@@ -5202,7 +5203,7 @@ export interface GetCampaignsResponse extends $MetadataBearer {
 
 export namespace GetCampaignsResponse {
   export function isa(o: any): o is GetCampaignsResponse {
-    return _smithy.isa(o, "GetCampaignsResponse");
+    return __isa(o, "GetCampaignsResponse");
   }
 }
 
@@ -5216,7 +5217,7 @@ export interface GetChannelsRequest {
 
 export namespace GetChannelsRequest {
   export function isa(o: any): o is GetChannelsRequest {
-    return _smithy.isa(o, "GetChannelsRequest");
+    return __isa(o, "GetChannelsRequest");
   }
 }
 
@@ -5230,7 +5231,7 @@ export interface GetChannelsResponse extends $MetadataBearer {
 
 export namespace GetChannelsResponse {
   export function isa(o: any): o is GetChannelsResponse {
-    return _smithy.isa(o, "GetChannelsResponse");
+    return __isa(o, "GetChannelsResponse");
   }
 }
 
@@ -5244,7 +5245,7 @@ export interface GetEmailChannelRequest {
 
 export namespace GetEmailChannelRequest {
   export function isa(o: any): o is GetEmailChannelRequest {
-    return _smithy.isa(o, "GetEmailChannelRequest");
+    return __isa(o, "GetEmailChannelRequest");
   }
 }
 
@@ -5258,7 +5259,7 @@ export interface GetEmailChannelResponse extends $MetadataBearer {
 
 export namespace GetEmailChannelResponse {
   export function isa(o: any): o is GetEmailChannelResponse {
-    return _smithy.isa(o, "GetEmailChannelResponse");
+    return __isa(o, "GetEmailChannelResponse");
   }
 }
 
@@ -5277,7 +5278,7 @@ export interface GetEmailTemplateRequest {
 
 export namespace GetEmailTemplateRequest {
   export function isa(o: any): o is GetEmailTemplateRequest {
-    return _smithy.isa(o, "GetEmailTemplateRequest");
+    return __isa(o, "GetEmailTemplateRequest");
   }
 }
 
@@ -5291,7 +5292,7 @@ export interface GetEmailTemplateResponse extends $MetadataBearer {
 
 export namespace GetEmailTemplateResponse {
   export function isa(o: any): o is GetEmailTemplateResponse {
-    return _smithy.isa(o, "GetEmailTemplateResponse");
+    return __isa(o, "GetEmailTemplateResponse");
   }
 }
 
@@ -5310,7 +5311,7 @@ export interface GetEndpointRequest {
 
 export namespace GetEndpointRequest {
   export function isa(o: any): o is GetEndpointRequest {
-    return _smithy.isa(o, "GetEndpointRequest");
+    return __isa(o, "GetEndpointRequest");
   }
 }
 
@@ -5324,7 +5325,7 @@ export interface GetEndpointResponse extends $MetadataBearer {
 
 export namespace GetEndpointResponse {
   export function isa(o: any): o is GetEndpointResponse {
-    return _smithy.isa(o, "GetEndpointResponse");
+    return __isa(o, "GetEndpointResponse");
   }
 }
 
@@ -5338,7 +5339,7 @@ export interface GetEventStreamRequest {
 
 export namespace GetEventStreamRequest {
   export function isa(o: any): o is GetEventStreamRequest {
-    return _smithy.isa(o, "GetEventStreamRequest");
+    return __isa(o, "GetEventStreamRequest");
   }
 }
 
@@ -5352,7 +5353,7 @@ export interface GetEventStreamResponse extends $MetadataBearer {
 
 export namespace GetEventStreamResponse {
   export function isa(o: any): o is GetEventStreamResponse {
-    return _smithy.isa(o, "GetEventStreamResponse");
+    return __isa(o, "GetEventStreamResponse");
   }
 }
 
@@ -5371,7 +5372,7 @@ export interface GetExportJobRequest {
 
 export namespace GetExportJobRequest {
   export function isa(o: any): o is GetExportJobRequest {
-    return _smithy.isa(o, "GetExportJobRequest");
+    return __isa(o, "GetExportJobRequest");
   }
 }
 
@@ -5385,7 +5386,7 @@ export interface GetExportJobResponse extends $MetadataBearer {
 
 export namespace GetExportJobResponse {
   export function isa(o: any): o is GetExportJobResponse {
-    return _smithy.isa(o, "GetExportJobResponse");
+    return __isa(o, "GetExportJobResponse");
   }
 }
 
@@ -5409,7 +5410,7 @@ export interface GetExportJobsRequest {
 
 export namespace GetExportJobsRequest {
   export function isa(o: any): o is GetExportJobsRequest {
-    return _smithy.isa(o, "GetExportJobsRequest");
+    return __isa(o, "GetExportJobsRequest");
   }
 }
 
@@ -5423,7 +5424,7 @@ export interface GetExportJobsResponse extends $MetadataBearer {
 
 export namespace GetExportJobsResponse {
   export function isa(o: any): o is GetExportJobsResponse {
-    return _smithy.isa(o, "GetExportJobsResponse");
+    return __isa(o, "GetExportJobsResponse");
   }
 }
 
@@ -5437,7 +5438,7 @@ export interface GetGcmChannelRequest {
 
 export namespace GetGcmChannelRequest {
   export function isa(o: any): o is GetGcmChannelRequest {
-    return _smithy.isa(o, "GetGcmChannelRequest");
+    return __isa(o, "GetGcmChannelRequest");
   }
 }
 
@@ -5451,7 +5452,7 @@ export interface GetGcmChannelResponse extends $MetadataBearer {
 
 export namespace GetGcmChannelResponse {
   export function isa(o: any): o is GetGcmChannelResponse {
-    return _smithy.isa(o, "GetGcmChannelResponse");
+    return __isa(o, "GetGcmChannelResponse");
   }
 }
 
@@ -5470,7 +5471,7 @@ export interface GetImportJobRequest {
 
 export namespace GetImportJobRequest {
   export function isa(o: any): o is GetImportJobRequest {
-    return _smithy.isa(o, "GetImportJobRequest");
+    return __isa(o, "GetImportJobRequest");
   }
 }
 
@@ -5484,7 +5485,7 @@ export interface GetImportJobResponse extends $MetadataBearer {
 
 export namespace GetImportJobResponse {
   export function isa(o: any): o is GetImportJobResponse {
-    return _smithy.isa(o, "GetImportJobResponse");
+    return __isa(o, "GetImportJobResponse");
   }
 }
 
@@ -5508,7 +5509,7 @@ export interface GetImportJobsRequest {
 
 export namespace GetImportJobsRequest {
   export function isa(o: any): o is GetImportJobsRequest {
-    return _smithy.isa(o, "GetImportJobsRequest");
+    return __isa(o, "GetImportJobsRequest");
   }
 }
 
@@ -5522,7 +5523,7 @@ export interface GetImportJobsResponse extends $MetadataBearer {
 
 export namespace GetImportJobsResponse {
   export function isa(o: any): o is GetImportJobsResponse {
-    return _smithy.isa(o, "GetImportJobsResponse");
+    return __isa(o, "GetImportJobsResponse");
   }
 }
 
@@ -5566,7 +5567,7 @@ export interface GetJourneyDateRangeKpiRequest {
 
 export namespace GetJourneyDateRangeKpiRequest {
   export function isa(o: any): o is GetJourneyDateRangeKpiRequest {
-    return _smithy.isa(o, "GetJourneyDateRangeKpiRequest");
+    return __isa(o, "GetJourneyDateRangeKpiRequest");
   }
 }
 
@@ -5580,7 +5581,7 @@ export interface GetJourneyDateRangeKpiResponse extends $MetadataBearer {
 
 export namespace GetJourneyDateRangeKpiResponse {
   export function isa(o: any): o is GetJourneyDateRangeKpiResponse {
-    return _smithy.isa(o, "GetJourneyDateRangeKpiResponse");
+    return __isa(o, "GetJourneyDateRangeKpiResponse");
   }
 }
 
@@ -5614,7 +5615,7 @@ export interface GetJourneyExecutionActivityMetricsRequest {
 
 export namespace GetJourneyExecutionActivityMetricsRequest {
   export function isa(o: any): o is GetJourneyExecutionActivityMetricsRequest {
-    return _smithy.isa(o, "GetJourneyExecutionActivityMetricsRequest");
+    return __isa(o, "GetJourneyExecutionActivityMetricsRequest");
   }
 }
 
@@ -5631,7 +5632,7 @@ export interface GetJourneyExecutionActivityMetricsResponse
 
 export namespace GetJourneyExecutionActivityMetricsResponse {
   export function isa(o: any): o is GetJourneyExecutionActivityMetricsResponse {
-    return _smithy.isa(o, "GetJourneyExecutionActivityMetricsResponse");
+    return __isa(o, "GetJourneyExecutionActivityMetricsResponse");
   }
 }
 
@@ -5660,7 +5661,7 @@ export interface GetJourneyExecutionMetricsRequest {
 
 export namespace GetJourneyExecutionMetricsRequest {
   export function isa(o: any): o is GetJourneyExecutionMetricsRequest {
-    return _smithy.isa(o, "GetJourneyExecutionMetricsRequest");
+    return __isa(o, "GetJourneyExecutionMetricsRequest");
   }
 }
 
@@ -5674,7 +5675,7 @@ export interface GetJourneyExecutionMetricsResponse extends $MetadataBearer {
 
 export namespace GetJourneyExecutionMetricsResponse {
   export function isa(o: any): o is GetJourneyExecutionMetricsResponse {
-    return _smithy.isa(o, "GetJourneyExecutionMetricsResponse");
+    return __isa(o, "GetJourneyExecutionMetricsResponse");
   }
 }
 
@@ -5693,7 +5694,7 @@ export interface GetJourneyRequest {
 
 export namespace GetJourneyRequest {
   export function isa(o: any): o is GetJourneyRequest {
-    return _smithy.isa(o, "GetJourneyRequest");
+    return __isa(o, "GetJourneyRequest");
   }
 }
 
@@ -5707,7 +5708,7 @@ export interface GetJourneyResponse extends $MetadataBearer {
 
 export namespace GetJourneyResponse {
   export function isa(o: any): o is GetJourneyResponse {
-    return _smithy.isa(o, "GetJourneyResponse");
+    return __isa(o, "GetJourneyResponse");
   }
 }
 
@@ -5726,7 +5727,7 @@ export interface GetPushTemplateRequest {
 
 export namespace GetPushTemplateRequest {
   export function isa(o: any): o is GetPushTemplateRequest {
-    return _smithy.isa(o, "GetPushTemplateRequest");
+    return __isa(o, "GetPushTemplateRequest");
   }
 }
 
@@ -5742,7 +5743,7 @@ export interface GetPushTemplateResponse extends $MetadataBearer {
 
 export namespace GetPushTemplateResponse {
   export function isa(o: any): o is GetPushTemplateResponse {
-    return _smithy.isa(o, "GetPushTemplateResponse");
+    return __isa(o, "GetPushTemplateResponse");
   }
 }
 
@@ -5771,7 +5772,7 @@ export interface GetSegmentExportJobsRequest {
 
 export namespace GetSegmentExportJobsRequest {
   export function isa(o: any): o is GetSegmentExportJobsRequest {
-    return _smithy.isa(o, "GetSegmentExportJobsRequest");
+    return __isa(o, "GetSegmentExportJobsRequest");
   }
 }
 
@@ -5785,7 +5786,7 @@ export interface GetSegmentExportJobsResponse extends $MetadataBearer {
 
 export namespace GetSegmentExportJobsResponse {
   export function isa(o: any): o is GetSegmentExportJobsResponse {
-    return _smithy.isa(o, "GetSegmentExportJobsResponse");
+    return __isa(o, "GetSegmentExportJobsResponse");
   }
 }
 
@@ -5814,7 +5815,7 @@ export interface GetSegmentImportJobsRequest {
 
 export namespace GetSegmentImportJobsRequest {
   export function isa(o: any): o is GetSegmentImportJobsRequest {
-    return _smithy.isa(o, "GetSegmentImportJobsRequest");
+    return __isa(o, "GetSegmentImportJobsRequest");
   }
 }
 
@@ -5828,7 +5829,7 @@ export interface GetSegmentImportJobsResponse extends $MetadataBearer {
 
 export namespace GetSegmentImportJobsResponse {
   export function isa(o: any): o is GetSegmentImportJobsResponse {
-    return _smithy.isa(o, "GetSegmentImportJobsResponse");
+    return __isa(o, "GetSegmentImportJobsResponse");
   }
 }
 
@@ -5847,7 +5848,7 @@ export interface GetSegmentRequest {
 
 export namespace GetSegmentRequest {
   export function isa(o: any): o is GetSegmentRequest {
-    return _smithy.isa(o, "GetSegmentRequest");
+    return __isa(o, "GetSegmentRequest");
   }
 }
 
@@ -5861,7 +5862,7 @@ export interface GetSegmentResponse extends $MetadataBearer {
 
 export namespace GetSegmentResponse {
   export function isa(o: any): o is GetSegmentResponse {
-    return _smithy.isa(o, "GetSegmentResponse");
+    return __isa(o, "GetSegmentResponse");
   }
 }
 
@@ -5885,7 +5886,7 @@ export interface GetSegmentVersionRequest {
 
 export namespace GetSegmentVersionRequest {
   export function isa(o: any): o is GetSegmentVersionRequest {
-    return _smithy.isa(o, "GetSegmentVersionRequest");
+    return __isa(o, "GetSegmentVersionRequest");
   }
 }
 
@@ -5899,7 +5900,7 @@ export interface GetSegmentVersionResponse extends $MetadataBearer {
 
 export namespace GetSegmentVersionResponse {
   export function isa(o: any): o is GetSegmentVersionResponse {
-    return _smithy.isa(o, "GetSegmentVersionResponse");
+    return __isa(o, "GetSegmentVersionResponse");
   }
 }
 
@@ -5928,7 +5929,7 @@ export interface GetSegmentVersionsRequest {
 
 export namespace GetSegmentVersionsRequest {
   export function isa(o: any): o is GetSegmentVersionsRequest {
-    return _smithy.isa(o, "GetSegmentVersionsRequest");
+    return __isa(o, "GetSegmentVersionsRequest");
   }
 }
 
@@ -5942,7 +5943,7 @@ export interface GetSegmentVersionsResponse extends $MetadataBearer {
 
 export namespace GetSegmentVersionsResponse {
   export function isa(o: any): o is GetSegmentVersionsResponse {
-    return _smithy.isa(o, "GetSegmentVersionsResponse");
+    return __isa(o, "GetSegmentVersionsResponse");
   }
 }
 
@@ -5966,7 +5967,7 @@ export interface GetSegmentsRequest {
 
 export namespace GetSegmentsRequest {
   export function isa(o: any): o is GetSegmentsRequest {
-    return _smithy.isa(o, "GetSegmentsRequest");
+    return __isa(o, "GetSegmentsRequest");
   }
 }
 
@@ -5980,7 +5981,7 @@ export interface GetSegmentsResponse extends $MetadataBearer {
 
 export namespace GetSegmentsResponse {
   export function isa(o: any): o is GetSegmentsResponse {
-    return _smithy.isa(o, "GetSegmentsResponse");
+    return __isa(o, "GetSegmentsResponse");
   }
 }
 
@@ -5994,7 +5995,7 @@ export interface GetSmsChannelRequest {
 
 export namespace GetSmsChannelRequest {
   export function isa(o: any): o is GetSmsChannelRequest {
-    return _smithy.isa(o, "GetSmsChannelRequest");
+    return __isa(o, "GetSmsChannelRequest");
   }
 }
 
@@ -6008,7 +6009,7 @@ export interface GetSmsChannelResponse extends $MetadataBearer {
 
 export namespace GetSmsChannelResponse {
   export function isa(o: any): o is GetSmsChannelResponse {
-    return _smithy.isa(o, "GetSmsChannelResponse");
+    return __isa(o, "GetSmsChannelResponse");
   }
 }
 
@@ -6027,7 +6028,7 @@ export interface GetSmsTemplateRequest {
 
 export namespace GetSmsTemplateRequest {
   export function isa(o: any): o is GetSmsTemplateRequest {
-    return _smithy.isa(o, "GetSmsTemplateRequest");
+    return __isa(o, "GetSmsTemplateRequest");
   }
 }
 
@@ -6041,7 +6042,7 @@ export interface GetSmsTemplateResponse extends $MetadataBearer {
 
 export namespace GetSmsTemplateResponse {
   export function isa(o: any): o is GetSmsTemplateResponse {
-    return _smithy.isa(o, "GetSmsTemplateResponse");
+    return __isa(o, "GetSmsTemplateResponse");
   }
 }
 
@@ -6060,7 +6061,7 @@ export interface GetUserEndpointsRequest {
 
 export namespace GetUserEndpointsRequest {
   export function isa(o: any): o is GetUserEndpointsRequest {
-    return _smithy.isa(o, "GetUserEndpointsRequest");
+    return __isa(o, "GetUserEndpointsRequest");
   }
 }
 
@@ -6074,7 +6075,7 @@ export interface GetUserEndpointsResponse extends $MetadataBearer {
 
 export namespace GetUserEndpointsResponse {
   export function isa(o: any): o is GetUserEndpointsResponse {
-    return _smithy.isa(o, "GetUserEndpointsResponse");
+    return __isa(o, "GetUserEndpointsResponse");
   }
 }
 
@@ -6088,7 +6089,7 @@ export interface GetVoiceChannelRequest {
 
 export namespace GetVoiceChannelRequest {
   export function isa(o: any): o is GetVoiceChannelRequest {
-    return _smithy.isa(o, "GetVoiceChannelRequest");
+    return __isa(o, "GetVoiceChannelRequest");
   }
 }
 
@@ -6102,7 +6103,7 @@ export interface GetVoiceChannelResponse extends $MetadataBearer {
 
 export namespace GetVoiceChannelResponse {
   export function isa(o: any): o is GetVoiceChannelResponse {
-    return _smithy.isa(o, "GetVoiceChannelResponse");
+    return __isa(o, "GetVoiceChannelResponse");
   }
 }
 
@@ -6121,7 +6122,7 @@ export interface GetVoiceTemplateRequest {
 
 export namespace GetVoiceTemplateRequest {
   export function isa(o: any): o is GetVoiceTemplateRequest {
-    return _smithy.isa(o, "GetVoiceTemplateRequest");
+    return __isa(o, "GetVoiceTemplateRequest");
   }
 }
 
@@ -6135,7 +6136,7 @@ export interface GetVoiceTemplateResponse extends $MetadataBearer {
 
 export namespace GetVoiceTemplateResponse {
   export function isa(o: any): o is GetVoiceTemplateResponse {
-    return _smithy.isa(o, "GetVoiceTemplateResponse");
+    return __isa(o, "GetVoiceTemplateResponse");
   }
 }
 
@@ -6157,7 +6158,7 @@ export interface HoldoutActivity {
 
 export namespace HoldoutActivity {
   export function isa(o: any): o is HoldoutActivity {
-    return _smithy.isa(o, "HoldoutActivity");
+    return __isa(o, "HoldoutActivity");
   }
 }
 
@@ -6209,7 +6210,7 @@ export interface ImportJobRequest {
 
 export namespace ImportJobRequest {
   export function isa(o: any): o is ImportJobRequest {
-    return _smithy.isa(o, "ImportJobRequest");
+    return __isa(o, "ImportJobRequest");
   }
 }
 
@@ -6261,7 +6262,7 @@ export interface ImportJobResource {
 
 export namespace ImportJobResource {
   export function isa(o: any): o is ImportJobResource {
-    return _smithy.isa(o, "ImportJobResource");
+    return __isa(o, "ImportJobResource");
   }
 }
 
@@ -6338,7 +6339,7 @@ export interface ImportJobResponse {
 
 export namespace ImportJobResponse {
   export function isa(o: any): o is ImportJobResponse {
-    return _smithy.isa(o, "ImportJobResponse");
+    return __isa(o, "ImportJobResponse");
   }
 }
 
@@ -6360,7 +6361,7 @@ export interface ImportJobsResponse {
 
 export namespace ImportJobsResponse {
   export function isa(o: any): o is ImportJobsResponse {
-    return _smithy.isa(o, "ImportJobsResponse");
+    return __isa(o, "ImportJobsResponse");
   }
 }
 
@@ -6374,7 +6375,7 @@ export enum Include {
  * <p>Provides information about an API request or response.</p>
  */
 export interface InternalServerErrorException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalServerErrorException";
   $fault: "server";
@@ -6391,7 +6392,7 @@ export interface InternalServerErrorException
 
 export namespace InternalServerErrorException {
   export function isa(o: any): o is InternalServerErrorException {
-    return _smithy.isa(o, "InternalServerErrorException");
+    return __isa(o, "InternalServerErrorException");
   }
 }
 
@@ -6413,7 +6414,7 @@ export interface ItemResponse {
 
 export namespace ItemResponse {
   export function isa(o: any): o is ItemResponse {
-    return _smithy.isa(o, "ItemResponse");
+    return __isa(o, "ItemResponse");
   }
 }
 
@@ -6472,7 +6473,7 @@ export interface JourneyDateRangeKpiResponse {
 
 export namespace JourneyDateRangeKpiResponse {
   export function isa(o: any): o is JourneyDateRangeKpiResponse {
-    return _smithy.isa(o, "JourneyDateRangeKpiResponse");
+    return __isa(o, "JourneyDateRangeKpiResponse");
   }
 }
 
@@ -6489,7 +6490,7 @@ export interface JourneyEmailMessage {
 
 export namespace JourneyEmailMessage {
   export function isa(o: any): o is JourneyEmailMessage {
-    return _smithy.isa(o, "JourneyEmailMessage");
+    return __isa(o, "JourneyEmailMessage");
   }
 }
 
@@ -6531,7 +6532,7 @@ export interface JourneyExecutionActivityMetricsResponse {
 
 export namespace JourneyExecutionActivityMetricsResponse {
   export function isa(o: any): o is JourneyExecutionActivityMetricsResponse {
-    return _smithy.isa(o, "JourneyExecutionActivityMetricsResponse");
+    return __isa(o, "JourneyExecutionActivityMetricsResponse");
   }
 }
 
@@ -6563,7 +6564,7 @@ export interface JourneyExecutionMetricsResponse {
 
 export namespace JourneyExecutionMetricsResponse {
   export function isa(o: any): o is JourneyExecutionMetricsResponse {
-    return _smithy.isa(o, "JourneyExecutionMetricsResponse");
+    return __isa(o, "JourneyExecutionMetricsResponse");
   }
 }
 
@@ -6590,7 +6591,7 @@ export interface JourneyLimits {
 
 export namespace JourneyLimits {
   export function isa(o: any): o is JourneyLimits {
-    return _smithy.isa(o, "JourneyLimits");
+    return __isa(o, "JourneyLimits");
   }
 }
 
@@ -6677,7 +6678,7 @@ export interface JourneyResponse {
 
 export namespace JourneyResponse {
   export function isa(o: any): o is JourneyResponse {
-    return _smithy.isa(o, "JourneyResponse");
+    return __isa(o, "JourneyResponse");
   }
 }
 
@@ -6709,7 +6710,7 @@ export interface JourneySchedule {
 
 export namespace JourneySchedule {
   export function isa(o: any): o is JourneySchedule {
-    return _smithy.isa(o, "JourneySchedule");
+    return __isa(o, "JourneySchedule");
   }
 }
 
@@ -6726,7 +6727,7 @@ export interface JourneyStateRequest {
 
 export namespace JourneyStateRequest {
   export function isa(o: any): o is JourneyStateRequest {
-    return _smithy.isa(o, "JourneyStateRequest");
+    return __isa(o, "JourneyStateRequest");
   }
 }
 
@@ -6748,7 +6749,7 @@ export interface JourneysResponse {
 
 export namespace JourneysResponse {
   export function isa(o: any): o is JourneysResponse {
-    return _smithy.isa(o, "JourneysResponse");
+    return __isa(o, "JourneysResponse");
   }
 }
 
@@ -6772,7 +6773,7 @@ export interface ListJourneysRequest {
 
 export namespace ListJourneysRequest {
   export function isa(o: any): o is ListJourneysRequest {
-    return _smithy.isa(o, "ListJourneysRequest");
+    return __isa(o, "ListJourneysRequest");
   }
 }
 
@@ -6786,7 +6787,7 @@ export interface ListJourneysResponse extends $MetadataBearer {
 
 export namespace ListJourneysResponse {
   export function isa(o: any): o is ListJourneysResponse {
-    return _smithy.isa(o, "ListJourneysResponse");
+    return __isa(o, "ListJourneysResponse");
   }
 }
 
@@ -6800,7 +6801,7 @@ export interface ListTagsForResourceRequest {
 
 export namespace ListTagsForResourceRequest {
   export function isa(o: any): o is ListTagsForResourceRequest {
-    return _smithy.isa(o, "ListTagsForResourceRequest");
+    return __isa(o, "ListTagsForResourceRequest");
   }
 }
 
@@ -6814,7 +6815,7 @@ export interface ListTagsForResourceResponse extends $MetadataBearer {
 
 export namespace ListTagsForResourceResponse {
   export function isa(o: any): o is ListTagsForResourceResponse {
-    return _smithy.isa(o, "ListTagsForResourceResponse");
+    return __isa(o, "ListTagsForResourceResponse");
   }
 }
 
@@ -6843,7 +6844,7 @@ export interface ListTemplateVersionsRequest {
 
 export namespace ListTemplateVersionsRequest {
   export function isa(o: any): o is ListTemplateVersionsRequest {
-    return _smithy.isa(o, "ListTemplateVersionsRequest");
+    return __isa(o, "ListTemplateVersionsRequest");
   }
 }
 
@@ -6857,7 +6858,7 @@ export interface ListTemplateVersionsResponse extends $MetadataBearer {
 
 export namespace ListTemplateVersionsResponse {
   export function isa(o: any): o is ListTemplateVersionsResponse {
-    return _smithy.isa(o, "ListTemplateVersionsResponse");
+    return __isa(o, "ListTemplateVersionsResponse");
   }
 }
 
@@ -6886,7 +6887,7 @@ export interface ListTemplatesRequest {
 
 export namespace ListTemplatesRequest {
   export function isa(o: any): o is ListTemplatesRequest {
-    return _smithy.isa(o, "ListTemplatesRequest");
+    return __isa(o, "ListTemplatesRequest");
   }
 }
 
@@ -6900,7 +6901,7 @@ export interface ListTemplatesResponse extends $MetadataBearer {
 
 export namespace ListTemplatesResponse {
   export function isa(o: any): o is ListTemplatesResponse {
-    return _smithy.isa(o, "ListTemplatesResponse");
+    return __isa(o, "ListTemplatesResponse");
   }
 }
 
@@ -6972,7 +6973,7 @@ export interface Message {
 
 export namespace Message {
   export function isa(o: any): o is Message {
-    return _smithy.isa(o, "Message");
+    return __isa(o, "Message");
   }
 }
 
@@ -6994,7 +6995,7 @@ export interface MessageBody {
 
 export namespace MessageBody {
   export function isa(o: any): o is MessageBody {
-    return _smithy.isa(o, "MessageBody");
+    return __isa(o, "MessageBody");
   }
 }
 
@@ -7041,7 +7042,7 @@ export interface MessageConfiguration {
 
 export namespace MessageConfiguration {
   export function isa(o: any): o is MessageConfiguration {
-    return _smithy.isa(o, "MessageConfiguration");
+    return __isa(o, "MessageConfiguration");
   }
 }
 
@@ -7083,7 +7084,7 @@ export interface MessageRequest {
 
 export namespace MessageRequest {
   export function isa(o: any): o is MessageRequest {
-    return _smithy.isa(o, "MessageRequest");
+    return __isa(o, "MessageRequest");
   }
 }
 
@@ -7115,7 +7116,7 @@ export interface MessageResponse {
 
 export namespace MessageResponse {
   export function isa(o: any): o is MessageResponse {
-    return _smithy.isa(o, "MessageResponse");
+    return __isa(o, "MessageResponse");
   }
 }
 
@@ -7152,7 +7153,7 @@ export interface MessageResult {
 
 export namespace MessageResult {
   export function isa(o: any): o is MessageResult {
-    return _smithy.isa(o, "MessageResult");
+    return __isa(o, "MessageResult");
   }
 }
 
@@ -7165,7 +7166,7 @@ export enum MessageType {
  * <p>Provides information about an API request or response.</p>
  */
 export interface MethodNotAllowedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "MethodNotAllowedException";
   $fault: "client";
@@ -7182,7 +7183,7 @@ export interface MethodNotAllowedException
 
 export namespace MethodNotAllowedException {
   export function isa(o: any): o is MethodNotAllowedException {
-    return _smithy.isa(o, "MethodNotAllowedException");
+    return __isa(o, "MethodNotAllowedException");
   }
 }
 
@@ -7204,7 +7205,7 @@ export interface MetricDimension {
 
 export namespace MetricDimension {
   export function isa(o: any): o is MetricDimension {
-    return _smithy.isa(o, "MetricDimension");
+    return __isa(o, "MetricDimension");
   }
 }
 
@@ -7231,7 +7232,7 @@ export interface MultiConditionalBranch {
 
 export namespace MultiConditionalBranch {
   export function isa(o: any): o is MultiConditionalBranch {
-    return _smithy.isa(o, "MultiConditionalBranch");
+    return __isa(o, "MultiConditionalBranch");
   }
 }
 
@@ -7258,16 +7259,14 @@ export interface MultiConditionalSplitActivity {
 
 export namespace MultiConditionalSplitActivity {
   export function isa(o: any): o is MultiConditionalSplitActivity {
-    return _smithy.isa(o, "MultiConditionalSplitActivity");
+    return __isa(o, "MultiConditionalSplitActivity");
   }
 }
 
 /**
  * <p>Provides information about an API request or response.</p>
  */
-export interface NotFoundException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface NotFoundException extends __SmithyException, $MetadataBearer {
   name: "NotFoundException";
   $fault: "client";
   /**
@@ -7283,7 +7282,7 @@ export interface NotFoundException
 
 export namespace NotFoundException {
   export function isa(o: any): o is NotFoundException {
-    return _smithy.isa(o, "NotFoundException");
+    return __isa(o, "NotFoundException");
   }
 }
 
@@ -7305,7 +7304,7 @@ export interface NumberValidateRequest {
 
 export namespace NumberValidateRequest {
   export function isa(o: any): o is NumberValidateRequest {
-    return _smithy.isa(o, "NumberValidateRequest");
+    return __isa(o, "NumberValidateRequest");
   }
 }
 
@@ -7388,7 +7387,7 @@ export interface NumberValidateResponse {
 
 export namespace NumberValidateResponse {
   export function isa(o: any): o is NumberValidateResponse {
-    return _smithy.isa(o, "NumberValidateResponse");
+    return __isa(o, "NumberValidateResponse");
   }
 }
 
@@ -7407,7 +7406,7 @@ export interface PhoneNumberValidateRequest {
 
 export namespace PhoneNumberValidateRequest {
   export function isa(o: any): o is PhoneNumberValidateRequest {
-    return _smithy.isa(o, "PhoneNumberValidateRequest");
+    return __isa(o, "PhoneNumberValidateRequest");
   }
 }
 
@@ -7421,7 +7420,7 @@ export interface PhoneNumberValidateResponse extends $MetadataBearer {
 
 export namespace PhoneNumberValidateResponse {
   export function isa(o: any): o is PhoneNumberValidateResponse {
-    return _smithy.isa(o, "PhoneNumberValidateResponse");
+    return __isa(o, "PhoneNumberValidateResponse");
   }
 }
 
@@ -7488,7 +7487,7 @@ export interface PublicEndpoint {
 
 export namespace PublicEndpoint {
   export function isa(o: any): o is PublicEndpoint {
-    return _smithy.isa(o, "PublicEndpoint");
+    return __isa(o, "PublicEndpoint");
   }
 }
 
@@ -7540,7 +7539,7 @@ export interface PushNotificationTemplateRequest {
 
 export namespace PushNotificationTemplateRequest {
   export function isa(o: any): o is PushNotificationTemplateRequest {
-    return _smithy.isa(o, "PushNotificationTemplateRequest");
+    return __isa(o, "PushNotificationTemplateRequest");
   }
 }
 
@@ -7622,7 +7621,7 @@ export interface PushNotificationTemplateResponse {
 
 export namespace PushNotificationTemplateResponse {
   export function isa(o: any): o is PushNotificationTemplateResponse {
-    return _smithy.isa(o, "PushNotificationTemplateResponse");
+    return __isa(o, "PushNotificationTemplateResponse");
   }
 }
 
@@ -7641,7 +7640,7 @@ export interface PutEventStreamRequest {
 
 export namespace PutEventStreamRequest {
   export function isa(o: any): o is PutEventStreamRequest {
-    return _smithy.isa(o, "PutEventStreamRequest");
+    return __isa(o, "PutEventStreamRequest");
   }
 }
 
@@ -7655,7 +7654,7 @@ export interface PutEventStreamResponse extends $MetadataBearer {
 
 export namespace PutEventStreamResponse {
   export function isa(o: any): o is PutEventStreamResponse {
-    return _smithy.isa(o, "PutEventStreamResponse");
+    return __isa(o, "PutEventStreamResponse");
   }
 }
 
@@ -7674,7 +7673,7 @@ export interface PutEventsRequest {
 
 export namespace PutEventsRequest {
   export function isa(o: any): o is PutEventsRequest {
-    return _smithy.isa(o, "PutEventsRequest");
+    return __isa(o, "PutEventsRequest");
   }
 }
 
@@ -7688,7 +7687,7 @@ export interface PutEventsResponse extends $MetadataBearer {
 
 export namespace PutEventsResponse {
   export function isa(o: any): o is PutEventsResponse {
-    return _smithy.isa(o, "PutEventsResponse");
+    return __isa(o, "PutEventsResponse");
   }
 }
 
@@ -7710,7 +7709,7 @@ export interface QuietTime {
 
 export namespace QuietTime {
   export function isa(o: any): o is QuietTime {
-    return _smithy.isa(o, "QuietTime");
+    return __isa(o, "QuietTime");
   }
 }
 
@@ -7727,7 +7726,7 @@ export interface RandomSplitActivity {
 
 export namespace RandomSplitActivity {
   export function isa(o: any): o is RandomSplitActivity {
-    return _smithy.isa(o, "RandomSplitActivity");
+    return __isa(o, "RandomSplitActivity");
   }
 }
 
@@ -7749,7 +7748,7 @@ export interface RandomSplitEntry {
 
 export namespace RandomSplitEntry {
   export function isa(o: any): o is RandomSplitEntry {
-    return _smithy.isa(o, "RandomSplitEntry");
+    return __isa(o, "RandomSplitEntry");
   }
 }
 
@@ -7766,7 +7765,7 @@ export interface RawEmail {
 
 export namespace RawEmail {
   export function isa(o: any): o is RawEmail {
-    return _smithy.isa(o, "RawEmail");
+    return __isa(o, "RawEmail");
   }
 }
 
@@ -7788,7 +7787,7 @@ export interface RecencyDimension {
 
 export namespace RecencyDimension {
   export function isa(o: any): o is RecencyDimension {
-    return _smithy.isa(o, "RecencyDimension");
+    return __isa(o, "RecencyDimension");
   }
 }
 
@@ -7817,7 +7816,7 @@ export interface RemoveAttributesRequest {
 
 export namespace RemoveAttributesRequest {
   export function isa(o: any): o is RemoveAttributesRequest {
-    return _smithy.isa(o, "RemoveAttributesRequest");
+    return __isa(o, "RemoveAttributesRequest");
   }
 }
 
@@ -7831,7 +7830,7 @@ export interface RemoveAttributesResponse extends $MetadataBearer {
 
 export namespace RemoveAttributesResponse {
   export function isa(o: any): o is RemoveAttributesResponse {
-    return _smithy.isa(o, "RemoveAttributesResponse");
+    return __isa(o, "RemoveAttributesResponse");
   }
 }
 
@@ -7853,7 +7852,7 @@ export interface ResultRow {
 
 export namespace ResultRow {
   export function isa(o: any): o is ResultRow {
-    return _smithy.isa(o, "ResultRow");
+    return __isa(o, "ResultRow");
   }
 }
 
@@ -7880,7 +7879,7 @@ export interface ResultRowValue {
 
 export namespace ResultRowValue {
   export function isa(o: any): o is ResultRowValue {
-    return _smithy.isa(o, "ResultRowValue");
+    return __isa(o, "ResultRowValue");
   }
 }
 
@@ -7907,7 +7906,7 @@ export interface SMSChannelRequest {
 
 export namespace SMSChannelRequest {
   export function isa(o: any): o is SMSChannelRequest {
-    return _smithy.isa(o, "SMSChannelRequest");
+    return __isa(o, "SMSChannelRequest");
   }
 }
 
@@ -7989,7 +7988,7 @@ export interface SMSChannelResponse {
 
 export namespace SMSChannelResponse {
   export function isa(o: any): o is SMSChannelResponse {
-    return _smithy.isa(o, "SMSChannelResponse");
+    return __isa(o, "SMSChannelResponse");
   }
 }
 
@@ -8031,7 +8030,7 @@ export interface SMSMessage {
 
 export namespace SMSMessage {
   export function isa(o: any): o is SMSMessage {
-    return _smithy.isa(o, "SMSMessage");
+    return __isa(o, "SMSMessage");
   }
 }
 
@@ -8063,7 +8062,7 @@ export interface SMSTemplateRequest {
 
 export namespace SMSTemplateRequest {
   export function isa(o: any): o is SMSTemplateRequest {
-    return _smithy.isa(o, "SMSTemplateRequest");
+    return __isa(o, "SMSTemplateRequest");
   }
 }
 
@@ -8125,7 +8124,7 @@ export interface SMSTemplateResponse {
 
 export namespace SMSTemplateResponse {
   export function isa(o: any): o is SMSTemplateResponse {
-    return _smithy.isa(o, "SMSTemplateResponse");
+    return __isa(o, "SMSTemplateResponse");
   }
 }
 
@@ -8175,7 +8174,7 @@ export interface Schedule {
 
 export namespace Schedule {
   export function isa(o: any): o is Schedule {
-    return _smithy.isa(o, "Schedule");
+    return __isa(o, "Schedule");
   }
 }
 
@@ -8192,7 +8191,7 @@ export interface SegmentBehaviors {
 
 export namespace SegmentBehaviors {
   export function isa(o: any): o is SegmentBehaviors {
-    return _smithy.isa(o, "SegmentBehaviors");
+    return __isa(o, "SegmentBehaviors");
   }
 }
 
@@ -8209,7 +8208,7 @@ export interface SegmentCondition {
 
 export namespace SegmentCondition {
   export function isa(o: any): o is SegmentCondition {
-    return _smithy.isa(o, "SegmentCondition");
+    return __isa(o, "SegmentCondition");
   }
 }
 
@@ -8251,7 +8250,7 @@ export interface SegmentDemographics {
 
 export namespace SegmentDemographics {
   export function isa(o: any): o is SegmentDemographics {
-    return _smithy.isa(o, "SegmentDemographics");
+    return __isa(o, "SegmentDemographics");
   }
 }
 
@@ -8293,7 +8292,7 @@ export interface SegmentDimensions {
 
 export namespace SegmentDimensions {
   export function isa(o: any): o is SegmentDimensions {
-    return _smithy.isa(o, "SegmentDimensions");
+    return __isa(o, "SegmentDimensions");
   }
 }
 
@@ -8325,7 +8324,7 @@ export interface SegmentGroup {
 
 export namespace SegmentGroup {
   export function isa(o: any): o is SegmentGroup {
-    return _smithy.isa(o, "SegmentGroup");
+    return __isa(o, "SegmentGroup");
   }
 }
 
@@ -8347,7 +8346,7 @@ export interface SegmentGroupList {
 
 export namespace SegmentGroupList {
   export function isa(o: any): o is SegmentGroupList {
-    return _smithy.isa(o, "SegmentGroupList");
+    return __isa(o, "SegmentGroupList");
   }
 }
 
@@ -8389,7 +8388,7 @@ export interface SegmentImportResource {
 
 export namespace SegmentImportResource {
   export function isa(o: any): o is SegmentImportResource {
-    return _smithy.isa(o, "SegmentImportResource");
+    return __isa(o, "SegmentImportResource");
   }
 }
 
@@ -8411,7 +8410,7 @@ export interface SegmentLocation {
 
 export namespace SegmentLocation {
   export function isa(o: any): o is SegmentLocation {
-    return _smithy.isa(o, "SegmentLocation");
+    return __isa(o, "SegmentLocation");
   }
 }
 
@@ -8433,7 +8432,7 @@ export interface SegmentReference {
 
 export namespace SegmentReference {
   export function isa(o: any): o is SegmentReference {
-    return _smithy.isa(o, "SegmentReference");
+    return __isa(o, "SegmentReference");
   }
 }
 
@@ -8505,7 +8504,7 @@ export interface SegmentResponse {
 
 export namespace SegmentResponse {
   export function isa(o: any): o is SegmentResponse {
-    return _smithy.isa(o, "SegmentResponse");
+    return __isa(o, "SegmentResponse");
   }
 }
 
@@ -8532,7 +8531,7 @@ export interface SegmentsResponse {
 
 export namespace SegmentsResponse {
   export function isa(o: any): o is SegmentsResponse {
-    return _smithy.isa(o, "SegmentsResponse");
+    return __isa(o, "SegmentsResponse");
   }
 }
 
@@ -8551,7 +8550,7 @@ export interface SendMessagesRequest {
 
 export namespace SendMessagesRequest {
   export function isa(o: any): o is SendMessagesRequest {
-    return _smithy.isa(o, "SendMessagesRequest");
+    return __isa(o, "SendMessagesRequest");
   }
 }
 
@@ -8565,7 +8564,7 @@ export interface SendMessagesResponse extends $MetadataBearer {
 
 export namespace SendMessagesResponse {
   export function isa(o: any): o is SendMessagesResponse {
-    return _smithy.isa(o, "SendMessagesResponse");
+    return __isa(o, "SendMessagesResponse");
   }
 }
 
@@ -8602,7 +8601,7 @@ export interface SendUsersMessageRequest {
 
 export namespace SendUsersMessageRequest {
   export function isa(o: any): o is SendUsersMessageRequest {
-    return _smithy.isa(o, "SendUsersMessageRequest");
+    return __isa(o, "SendUsersMessageRequest");
   }
 }
 
@@ -8629,7 +8628,7 @@ export interface SendUsersMessageResponse {
 
 export namespace SendUsersMessageResponse {
   export function isa(o: any): o is SendUsersMessageResponse {
-    return _smithy.isa(o, "SendUsersMessageResponse");
+    return __isa(o, "SendUsersMessageResponse");
   }
 }
 
@@ -8648,7 +8647,7 @@ export interface SendUsersMessagesRequest {
 
 export namespace SendUsersMessagesRequest {
   export function isa(o: any): o is SendUsersMessagesRequest {
-    return _smithy.isa(o, "SendUsersMessagesRequest");
+    return __isa(o, "SendUsersMessagesRequest");
   }
 }
 
@@ -8662,7 +8661,7 @@ export interface SendUsersMessagesResponse extends $MetadataBearer {
 
 export namespace SendUsersMessagesResponse {
   export function isa(o: any): o is SendUsersMessagesResponse {
-    return _smithy.isa(o, "SendUsersMessagesResponse");
+    return __isa(o, "SendUsersMessagesResponse");
   }
 }
 
@@ -8694,7 +8693,7 @@ export interface Session {
 
 export namespace Session {
   export function isa(o: any): o is Session {
-    return _smithy.isa(o, "Session");
+    return __isa(o, "Session");
   }
 }
 
@@ -8716,7 +8715,7 @@ export interface SetDimension {
 
 export namespace SetDimension {
   export function isa(o: any): o is SetDimension {
-    return _smithy.isa(o, "SetDimension");
+    return __isa(o, "SetDimension");
   }
 }
 
@@ -8743,7 +8742,7 @@ export interface SimpleCondition {
 
 export namespace SimpleCondition {
   export function isa(o: any): o is SimpleCondition {
-    return _smithy.isa(o, "SimpleCondition");
+    return __isa(o, "SimpleCondition");
   }
 }
 
@@ -8770,7 +8769,7 @@ export interface SimpleEmail {
 
 export namespace SimpleEmail {
   export function isa(o: any): o is SimpleEmail {
-    return _smithy.isa(o, "SimpleEmail");
+    return __isa(o, "SimpleEmail");
   }
 }
 
@@ -8792,7 +8791,7 @@ export interface SimpleEmailPart {
 
 export namespace SimpleEmailPart {
   export function isa(o: any): o is SimpleEmailPart {
-    return _smithy.isa(o, "SimpleEmailPart");
+    return __isa(o, "SimpleEmailPart");
   }
 }
 
@@ -8820,7 +8819,7 @@ export interface StartCondition {
 
 export namespace StartCondition {
   export function isa(o: any): o is StartCondition {
-    return _smithy.isa(o, "StartCondition");
+    return __isa(o, "StartCondition");
   }
 }
 
@@ -8847,7 +8846,7 @@ export interface TagResourceRequest {
 
 export namespace TagResourceRequest {
   export function isa(o: any): o is TagResourceRequest {
-    return _smithy.isa(o, "TagResourceRequest");
+    return __isa(o, "TagResourceRequest");
   }
 }
 
@@ -8864,7 +8863,7 @@ export interface TagsModel {
 
 export namespace TagsModel {
   export function isa(o: any): o is TagsModel {
-    return _smithy.isa(o, "TagsModel");
+    return __isa(o, "TagsModel");
   }
 }
 
@@ -8886,7 +8885,7 @@ export interface Template {
 
 export namespace Template {
   export function isa(o: any): o is Template {
-    return _smithy.isa(o, "Template");
+    return __isa(o, "Template");
   }
 }
 
@@ -8903,7 +8902,7 @@ export interface TemplateActiveVersionRequest {
 
 export namespace TemplateActiveVersionRequest {
   export function isa(o: any): o is TemplateActiveVersionRequest {
-    return _smithy.isa(o, "TemplateActiveVersionRequest");
+    return __isa(o, "TemplateActiveVersionRequest");
   }
 }
 
@@ -8935,7 +8934,7 @@ export interface TemplateConfiguration {
 
 export namespace TemplateConfiguration {
   export function isa(o: any): o is TemplateConfiguration {
-    return _smithy.isa(o, "TemplateConfiguration");
+    return __isa(o, "TemplateConfiguration");
   }
 }
 
@@ -8992,7 +8991,7 @@ export interface TemplateResponse {
 
 export namespace TemplateResponse {
   export function isa(o: any): o is TemplateResponse {
-    return _smithy.isa(o, "TemplateResponse");
+    return __isa(o, "TemplateResponse");
   }
 }
 
@@ -9046,7 +9045,7 @@ export interface TemplateVersionResponse {
 
 export namespace TemplateVersionResponse {
   export function isa(o: any): o is TemplateVersionResponse {
-    return _smithy.isa(o, "TemplateVersionResponse");
+    return __isa(o, "TemplateVersionResponse");
   }
 }
 
@@ -9078,7 +9077,7 @@ export interface TemplateVersionsResponse {
 
 export namespace TemplateVersionsResponse {
   export function isa(o: any): o is TemplateVersionsResponse {
-    return _smithy.isa(o, "TemplateVersionsResponse");
+    return __isa(o, "TemplateVersionsResponse");
   }
 }
 
@@ -9100,7 +9099,7 @@ export interface TemplatesResponse {
 
 export namespace TemplatesResponse {
   export function isa(o: any): o is TemplatesResponse {
-    return _smithy.isa(o, "TemplatesResponse");
+    return __isa(o, "TemplatesResponse");
   }
 }
 
@@ -9108,7 +9107,7 @@ export namespace TemplatesResponse {
  * <p>Provides information about an API request or response.</p>
  */
 export interface TooManyRequestsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyRequestsException";
   $fault: "client";
@@ -9125,7 +9124,7 @@ export interface TooManyRequestsException
 
 export namespace TooManyRequestsException {
   export function isa(o: any): o is TooManyRequestsException {
-    return _smithy.isa(o, "TooManyRequestsException");
+    return __isa(o, "TooManyRequestsException");
   }
 }
 
@@ -9177,7 +9176,7 @@ export interface TreatmentResource {
 
 export namespace TreatmentResource {
   export function isa(o: any): o is TreatmentResource {
-    return _smithy.isa(o, "TreatmentResource");
+    return __isa(o, "TreatmentResource");
   }
 }
 
@@ -9202,7 +9201,7 @@ export interface UntagResourceRequest {
 
 export namespace UntagResourceRequest {
   export function isa(o: any): o is UntagResourceRequest {
-    return _smithy.isa(o, "UntagResourceRequest");
+    return __isa(o, "UntagResourceRequest");
   }
 }
 
@@ -9221,7 +9220,7 @@ export interface UpdateAdmChannelRequest {
 
 export namespace UpdateAdmChannelRequest {
   export function isa(o: any): o is UpdateAdmChannelRequest {
-    return _smithy.isa(o, "UpdateAdmChannelRequest");
+    return __isa(o, "UpdateAdmChannelRequest");
   }
 }
 
@@ -9235,7 +9234,7 @@ export interface UpdateAdmChannelResponse extends $MetadataBearer {
 
 export namespace UpdateAdmChannelResponse {
   export function isa(o: any): o is UpdateAdmChannelResponse {
-    return _smithy.isa(o, "UpdateAdmChannelResponse");
+    return __isa(o, "UpdateAdmChannelResponse");
   }
 }
 
@@ -9254,7 +9253,7 @@ export interface UpdateApnsChannelRequest {
 
 export namespace UpdateApnsChannelRequest {
   export function isa(o: any): o is UpdateApnsChannelRequest {
-    return _smithy.isa(o, "UpdateApnsChannelRequest");
+    return __isa(o, "UpdateApnsChannelRequest");
   }
 }
 
@@ -9268,7 +9267,7 @@ export interface UpdateApnsChannelResponse extends $MetadataBearer {
 
 export namespace UpdateApnsChannelResponse {
   export function isa(o: any): o is UpdateApnsChannelResponse {
-    return _smithy.isa(o, "UpdateApnsChannelResponse");
+    return __isa(o, "UpdateApnsChannelResponse");
   }
 }
 
@@ -9287,7 +9286,7 @@ export interface UpdateApnsSandboxChannelRequest {
 
 export namespace UpdateApnsSandboxChannelRequest {
   export function isa(o: any): o is UpdateApnsSandboxChannelRequest {
-    return _smithy.isa(o, "UpdateApnsSandboxChannelRequest");
+    return __isa(o, "UpdateApnsSandboxChannelRequest");
   }
 }
 
@@ -9301,7 +9300,7 @@ export interface UpdateApnsSandboxChannelResponse extends $MetadataBearer {
 
 export namespace UpdateApnsSandboxChannelResponse {
   export function isa(o: any): o is UpdateApnsSandboxChannelResponse {
-    return _smithy.isa(o, "UpdateApnsSandboxChannelResponse");
+    return __isa(o, "UpdateApnsSandboxChannelResponse");
   }
 }
 
@@ -9320,7 +9319,7 @@ export interface UpdateApnsVoipChannelRequest {
 
 export namespace UpdateApnsVoipChannelRequest {
   export function isa(o: any): o is UpdateApnsVoipChannelRequest {
-    return _smithy.isa(o, "UpdateApnsVoipChannelRequest");
+    return __isa(o, "UpdateApnsVoipChannelRequest");
   }
 }
 
@@ -9334,7 +9333,7 @@ export interface UpdateApnsVoipChannelResponse extends $MetadataBearer {
 
 export namespace UpdateApnsVoipChannelResponse {
   export function isa(o: any): o is UpdateApnsVoipChannelResponse {
-    return _smithy.isa(o, "UpdateApnsVoipChannelResponse");
+    return __isa(o, "UpdateApnsVoipChannelResponse");
   }
 }
 
@@ -9353,7 +9352,7 @@ export interface UpdateApnsVoipSandboxChannelRequest {
 
 export namespace UpdateApnsVoipSandboxChannelRequest {
   export function isa(o: any): o is UpdateApnsVoipSandboxChannelRequest {
-    return _smithy.isa(o, "UpdateApnsVoipSandboxChannelRequest");
+    return __isa(o, "UpdateApnsVoipSandboxChannelRequest");
   }
 }
 
@@ -9367,7 +9366,7 @@ export interface UpdateApnsVoipSandboxChannelResponse extends $MetadataBearer {
 
 export namespace UpdateApnsVoipSandboxChannelResponse {
   export function isa(o: any): o is UpdateApnsVoipSandboxChannelResponse {
-    return _smithy.isa(o, "UpdateApnsVoipSandboxChannelResponse");
+    return __isa(o, "UpdateApnsVoipSandboxChannelResponse");
   }
 }
 
@@ -9386,7 +9385,7 @@ export interface UpdateApplicationSettingsRequest {
 
 export namespace UpdateApplicationSettingsRequest {
   export function isa(o: any): o is UpdateApplicationSettingsRequest {
-    return _smithy.isa(o, "UpdateApplicationSettingsRequest");
+    return __isa(o, "UpdateApplicationSettingsRequest");
   }
 }
 
@@ -9400,7 +9399,7 @@ export interface UpdateApplicationSettingsResponse extends $MetadataBearer {
 
 export namespace UpdateApplicationSettingsResponse {
   export function isa(o: any): o is UpdateApplicationSettingsResponse {
-    return _smithy.isa(o, "UpdateApplicationSettingsResponse");
+    return __isa(o, "UpdateApplicationSettingsResponse");
   }
 }
 
@@ -9417,7 +9416,7 @@ export interface UpdateAttributesRequest {
 
 export namespace UpdateAttributesRequest {
   export function isa(o: any): o is UpdateAttributesRequest {
-    return _smithy.isa(o, "UpdateAttributesRequest");
+    return __isa(o, "UpdateAttributesRequest");
   }
 }
 
@@ -9436,7 +9435,7 @@ export interface UpdateBaiduChannelRequest {
 
 export namespace UpdateBaiduChannelRequest {
   export function isa(o: any): o is UpdateBaiduChannelRequest {
-    return _smithy.isa(o, "UpdateBaiduChannelRequest");
+    return __isa(o, "UpdateBaiduChannelRequest");
   }
 }
 
@@ -9450,7 +9449,7 @@ export interface UpdateBaiduChannelResponse extends $MetadataBearer {
 
 export namespace UpdateBaiduChannelResponse {
   export function isa(o: any): o is UpdateBaiduChannelResponse {
-    return _smithy.isa(o, "UpdateBaiduChannelResponse");
+    return __isa(o, "UpdateBaiduChannelResponse");
   }
 }
 
@@ -9474,7 +9473,7 @@ export interface UpdateCampaignRequest {
 
 export namespace UpdateCampaignRequest {
   export function isa(o: any): o is UpdateCampaignRequest {
-    return _smithy.isa(o, "UpdateCampaignRequest");
+    return __isa(o, "UpdateCampaignRequest");
   }
 }
 
@@ -9488,7 +9487,7 @@ export interface UpdateCampaignResponse extends $MetadataBearer {
 
 export namespace UpdateCampaignResponse {
   export function isa(o: any): o is UpdateCampaignResponse {
-    return _smithy.isa(o, "UpdateCampaignResponse");
+    return __isa(o, "UpdateCampaignResponse");
   }
 }
 
@@ -9507,7 +9506,7 @@ export interface UpdateEmailChannelRequest {
 
 export namespace UpdateEmailChannelRequest {
   export function isa(o: any): o is UpdateEmailChannelRequest {
-    return _smithy.isa(o, "UpdateEmailChannelRequest");
+    return __isa(o, "UpdateEmailChannelRequest");
   }
 }
 
@@ -9521,7 +9520,7 @@ export interface UpdateEmailChannelResponse extends $MetadataBearer {
 
 export namespace UpdateEmailChannelResponse {
   export function isa(o: any): o is UpdateEmailChannelResponse {
-    return _smithy.isa(o, "UpdateEmailChannelResponse");
+    return __isa(o, "UpdateEmailChannelResponse");
   }
 }
 
@@ -9550,7 +9549,7 @@ export interface UpdateEmailTemplateRequest {
 
 export namespace UpdateEmailTemplateRequest {
   export function isa(o: any): o is UpdateEmailTemplateRequest {
-    return _smithy.isa(o, "UpdateEmailTemplateRequest");
+    return __isa(o, "UpdateEmailTemplateRequest");
   }
 }
 
@@ -9564,7 +9563,7 @@ export interface UpdateEmailTemplateResponse extends $MetadataBearer {
 
 export namespace UpdateEmailTemplateResponse {
   export function isa(o: any): o is UpdateEmailTemplateResponse {
-    return _smithy.isa(o, "UpdateEmailTemplateResponse");
+    return __isa(o, "UpdateEmailTemplateResponse");
   }
 }
 
@@ -9588,7 +9587,7 @@ export interface UpdateEndpointRequest {
 
 export namespace UpdateEndpointRequest {
   export function isa(o: any): o is UpdateEndpointRequest {
-    return _smithy.isa(o, "UpdateEndpointRequest");
+    return __isa(o, "UpdateEndpointRequest");
   }
 }
 
@@ -9602,7 +9601,7 @@ export interface UpdateEndpointResponse extends $MetadataBearer {
 
 export namespace UpdateEndpointResponse {
   export function isa(o: any): o is UpdateEndpointResponse {
-    return _smithy.isa(o, "UpdateEndpointResponse");
+    return __isa(o, "UpdateEndpointResponse");
   }
 }
 
@@ -9621,7 +9620,7 @@ export interface UpdateEndpointsBatchRequest {
 
 export namespace UpdateEndpointsBatchRequest {
   export function isa(o: any): o is UpdateEndpointsBatchRequest {
-    return _smithy.isa(o, "UpdateEndpointsBatchRequest");
+    return __isa(o, "UpdateEndpointsBatchRequest");
   }
 }
 
@@ -9635,7 +9634,7 @@ export interface UpdateEndpointsBatchResponse extends $MetadataBearer {
 
 export namespace UpdateEndpointsBatchResponse {
   export function isa(o: any): o is UpdateEndpointsBatchResponse {
-    return _smithy.isa(o, "UpdateEndpointsBatchResponse");
+    return __isa(o, "UpdateEndpointsBatchResponse");
   }
 }
 
@@ -9654,7 +9653,7 @@ export interface UpdateGcmChannelRequest {
 
 export namespace UpdateGcmChannelRequest {
   export function isa(o: any): o is UpdateGcmChannelRequest {
-    return _smithy.isa(o, "UpdateGcmChannelRequest");
+    return __isa(o, "UpdateGcmChannelRequest");
   }
 }
 
@@ -9668,7 +9667,7 @@ export interface UpdateGcmChannelResponse extends $MetadataBearer {
 
 export namespace UpdateGcmChannelResponse {
   export function isa(o: any): o is UpdateGcmChannelResponse {
-    return _smithy.isa(o, "UpdateGcmChannelResponse");
+    return __isa(o, "UpdateGcmChannelResponse");
   }
 }
 
@@ -9692,7 +9691,7 @@ export interface UpdateJourneyRequest {
 
 export namespace UpdateJourneyRequest {
   export function isa(o: any): o is UpdateJourneyRequest {
-    return _smithy.isa(o, "UpdateJourneyRequest");
+    return __isa(o, "UpdateJourneyRequest");
   }
 }
 
@@ -9706,7 +9705,7 @@ export interface UpdateJourneyResponse extends $MetadataBearer {
 
 export namespace UpdateJourneyResponse {
   export function isa(o: any): o is UpdateJourneyResponse {
-    return _smithy.isa(o, "UpdateJourneyResponse");
+    return __isa(o, "UpdateJourneyResponse");
   }
 }
 
@@ -9730,7 +9729,7 @@ export interface UpdateJourneyStateRequest {
 
 export namespace UpdateJourneyStateRequest {
   export function isa(o: any): o is UpdateJourneyStateRequest {
-    return _smithy.isa(o, "UpdateJourneyStateRequest");
+    return __isa(o, "UpdateJourneyStateRequest");
   }
 }
 
@@ -9744,7 +9743,7 @@ export interface UpdateJourneyStateResponse extends $MetadataBearer {
 
 export namespace UpdateJourneyStateResponse {
   export function isa(o: any): o is UpdateJourneyStateResponse {
-    return _smithy.isa(o, "UpdateJourneyStateResponse");
+    return __isa(o, "UpdateJourneyStateResponse");
   }
 }
 
@@ -9773,7 +9772,7 @@ export interface UpdatePushTemplateRequest {
 
 export namespace UpdatePushTemplateRequest {
   export function isa(o: any): o is UpdatePushTemplateRequest {
-    return _smithy.isa(o, "UpdatePushTemplateRequest");
+    return __isa(o, "UpdatePushTemplateRequest");
   }
 }
 
@@ -9787,7 +9786,7 @@ export interface UpdatePushTemplateResponse extends $MetadataBearer {
 
 export namespace UpdatePushTemplateResponse {
   export function isa(o: any): o is UpdatePushTemplateResponse {
-    return _smithy.isa(o, "UpdatePushTemplateResponse");
+    return __isa(o, "UpdatePushTemplateResponse");
   }
 }
 
@@ -9811,7 +9810,7 @@ export interface UpdateSegmentRequest {
 
 export namespace UpdateSegmentRequest {
   export function isa(o: any): o is UpdateSegmentRequest {
-    return _smithy.isa(o, "UpdateSegmentRequest");
+    return __isa(o, "UpdateSegmentRequest");
   }
 }
 
@@ -9825,7 +9824,7 @@ export interface UpdateSegmentResponse extends $MetadataBearer {
 
 export namespace UpdateSegmentResponse {
   export function isa(o: any): o is UpdateSegmentResponse {
-    return _smithy.isa(o, "UpdateSegmentResponse");
+    return __isa(o, "UpdateSegmentResponse");
   }
 }
 
@@ -9844,7 +9843,7 @@ export interface UpdateSmsChannelRequest {
 
 export namespace UpdateSmsChannelRequest {
   export function isa(o: any): o is UpdateSmsChannelRequest {
-    return _smithy.isa(o, "UpdateSmsChannelRequest");
+    return __isa(o, "UpdateSmsChannelRequest");
   }
 }
 
@@ -9858,7 +9857,7 @@ export interface UpdateSmsChannelResponse extends $MetadataBearer {
 
 export namespace UpdateSmsChannelResponse {
   export function isa(o: any): o is UpdateSmsChannelResponse {
-    return _smithy.isa(o, "UpdateSmsChannelResponse");
+    return __isa(o, "UpdateSmsChannelResponse");
   }
 }
 
@@ -9887,7 +9886,7 @@ export interface UpdateSmsTemplateRequest {
 
 export namespace UpdateSmsTemplateRequest {
   export function isa(o: any): o is UpdateSmsTemplateRequest {
-    return _smithy.isa(o, "UpdateSmsTemplateRequest");
+    return __isa(o, "UpdateSmsTemplateRequest");
   }
 }
 
@@ -9901,7 +9900,7 @@ export interface UpdateSmsTemplateResponse extends $MetadataBearer {
 
 export namespace UpdateSmsTemplateResponse {
   export function isa(o: any): o is UpdateSmsTemplateResponse {
-    return _smithy.isa(o, "UpdateSmsTemplateResponse");
+    return __isa(o, "UpdateSmsTemplateResponse");
   }
 }
 
@@ -9925,7 +9924,7 @@ export interface UpdateTemplateActiveVersionRequest {
 
 export namespace UpdateTemplateActiveVersionRequest {
   export function isa(o: any): o is UpdateTemplateActiveVersionRequest {
-    return _smithy.isa(o, "UpdateTemplateActiveVersionRequest");
+    return __isa(o, "UpdateTemplateActiveVersionRequest");
   }
 }
 
@@ -9939,7 +9938,7 @@ export interface UpdateTemplateActiveVersionResponse extends $MetadataBearer {
 
 export namespace UpdateTemplateActiveVersionResponse {
   export function isa(o: any): o is UpdateTemplateActiveVersionResponse {
-    return _smithy.isa(o, "UpdateTemplateActiveVersionResponse");
+    return __isa(o, "UpdateTemplateActiveVersionResponse");
   }
 }
 
@@ -9958,7 +9957,7 @@ export interface UpdateVoiceChannelRequest {
 
 export namespace UpdateVoiceChannelRequest {
   export function isa(o: any): o is UpdateVoiceChannelRequest {
-    return _smithy.isa(o, "UpdateVoiceChannelRequest");
+    return __isa(o, "UpdateVoiceChannelRequest");
   }
 }
 
@@ -9972,7 +9971,7 @@ export interface UpdateVoiceChannelResponse extends $MetadataBearer {
 
 export namespace UpdateVoiceChannelResponse {
   export function isa(o: any): o is UpdateVoiceChannelResponse {
-    return _smithy.isa(o, "UpdateVoiceChannelResponse");
+    return __isa(o, "UpdateVoiceChannelResponse");
   }
 }
 
@@ -10001,7 +10000,7 @@ export interface UpdateVoiceTemplateRequest {
 
 export namespace UpdateVoiceTemplateRequest {
   export function isa(o: any): o is UpdateVoiceTemplateRequest {
-    return _smithy.isa(o, "UpdateVoiceTemplateRequest");
+    return __isa(o, "UpdateVoiceTemplateRequest");
   }
 }
 
@@ -10015,7 +10014,7 @@ export interface UpdateVoiceTemplateResponse extends $MetadataBearer {
 
 export namespace UpdateVoiceTemplateResponse {
   export function isa(o: any): o is UpdateVoiceTemplateResponse {
-    return _smithy.isa(o, "UpdateVoiceTemplateResponse");
+    return __isa(o, "UpdateVoiceTemplateResponse");
   }
 }
 
@@ -10032,7 +10031,7 @@ export interface VoiceChannelRequest {
 
 export namespace VoiceChannelRequest {
   export function isa(o: any): o is VoiceChannelRequest {
-    return _smithy.isa(o, "VoiceChannelRequest");
+    return __isa(o, "VoiceChannelRequest");
   }
 }
 
@@ -10094,7 +10093,7 @@ export interface VoiceChannelResponse {
 
 export namespace VoiceChannelResponse {
   export function isa(o: any): o is VoiceChannelResponse {
-    return _smithy.isa(o, "VoiceChannelResponse");
+    return __isa(o, "VoiceChannelResponse");
   }
 }
 
@@ -10131,7 +10130,7 @@ export interface VoiceMessage {
 
 export namespace VoiceMessage {
   export function isa(o: any): o is VoiceMessage {
-    return _smithy.isa(o, "VoiceMessage");
+    return __isa(o, "VoiceMessage");
   }
 }
 
@@ -10173,7 +10172,7 @@ export interface VoiceTemplateRequest {
 
 export namespace VoiceTemplateRequest {
   export function isa(o: any): o is VoiceTemplateRequest {
-    return _smithy.isa(o, "VoiceTemplateRequest");
+    return __isa(o, "VoiceTemplateRequest");
   }
 }
 
@@ -10245,7 +10244,7 @@ export interface VoiceTemplateResponse {
 
 export namespace VoiceTemplateResponse {
   export function isa(o: any): o is VoiceTemplateResponse {
-    return _smithy.isa(o, "VoiceTemplateResponse");
+    return __isa(o, "VoiceTemplateResponse");
   }
 }
 
@@ -10267,7 +10266,7 @@ export interface WaitActivity {
 
 export namespace WaitActivity {
   export function isa(o: any): o is WaitActivity {
-    return _smithy.isa(o, "WaitActivity");
+    return __isa(o, "WaitActivity");
   }
 }
 
@@ -10289,7 +10288,7 @@ export interface WaitTime {
 
 export namespace WaitTime {
   export function isa(o: any): o is WaitTime {
-    return _smithy.isa(o, "WaitTime");
+    return __isa(o, "WaitTime");
   }
 }
 
@@ -10321,7 +10320,7 @@ export interface WriteApplicationSettingsRequest {
 
 export namespace WriteApplicationSettingsRequest {
   export function isa(o: any): o is WriteApplicationSettingsRequest {
-    return _smithy.isa(o, "WriteApplicationSettingsRequest");
+    return __isa(o, "WriteApplicationSettingsRequest");
   }
 }
 
@@ -10408,7 +10407,7 @@ export interface WriteCampaignRequest {
 
 export namespace WriteCampaignRequest {
   export function isa(o: any): o is WriteCampaignRequest {
-    return _smithy.isa(o, "WriteCampaignRequest");
+    return __isa(o, "WriteCampaignRequest");
   }
 }
 
@@ -10432,7 +10431,7 @@ export interface WriteEventStream {
 
 export namespace WriteEventStream {
   export function isa(o: any): o is WriteEventStream {
-    return _smithy.isa(o, "WriteEventStream");
+    return __isa(o, "WriteEventStream");
   }
 }
 
@@ -10504,7 +10503,7 @@ export interface WriteJourneyRequest {
 
 export namespace WriteJourneyRequest {
   export function isa(o: any): o is WriteJourneyRequest {
-    return _smithy.isa(o, "WriteJourneyRequest");
+    return __isa(o, "WriteJourneyRequest");
   }
 }
 
@@ -10536,7 +10535,7 @@ export interface WriteSegmentRequest {
 
 export namespace WriteSegmentRequest {
   export function isa(o: any): o is WriteSegmentRequest {
-    return _smithy.isa(o, "WriteSegmentRequest");
+    return __isa(o, "WriteSegmentRequest");
   }
 }
 
@@ -10578,6 +10577,6 @@ export interface WriteTreatmentResource {
 
 export namespace WriteTreatmentResource {
   export function isa(o: any): o is WriteTreatmentResource {
-    return _smithy.isa(o, "WriteTreatmentResource");
+    return __isa(o, "WriteTreatmentResource");
   }
 }

--- a/clients/client-pinpoint/protocols/Aws_restJson1_1.ts
+++ b/clients/client-pinpoint/protocols/Aws_restJson1_1.ts
@@ -603,7 +603,10 @@ import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  extendedEncodeURIComponent as __extendedEncodeURIComponent
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -647,7 +650,7 @@ export async function serializeAws_restJson1_1CreateCampaignCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v1/apps/{ApplicationId}/campaigns";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -655,7 +658,7 @@ export async function serializeAws_restJson1_1CreateCampaignCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
@@ -689,7 +692,7 @@ export async function serializeAws_restJson1_1CreateEmailTemplateCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v1/templates/{TemplateName}/email";
   if (input.TemplateName !== undefined) {
-    const labelValue: string = input.TemplateName.toString();
+    const labelValue: string = input.TemplateName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: TemplateName."
@@ -697,7 +700,7 @@ export async function serializeAws_restJson1_1CreateEmailTemplateCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{TemplateName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: TemplateName.");
@@ -731,7 +734,7 @@ export async function serializeAws_restJson1_1CreateExportJobCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v1/apps/{ApplicationId}/jobs/export";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -739,7 +742,7 @@ export async function serializeAws_restJson1_1CreateExportJobCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
@@ -773,7 +776,7 @@ export async function serializeAws_restJson1_1CreateImportJobCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v1/apps/{ApplicationId}/jobs/import";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -781,7 +784,7 @@ export async function serializeAws_restJson1_1CreateImportJobCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
@@ -815,7 +818,7 @@ export async function serializeAws_restJson1_1CreateJourneyCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v1/apps/{ApplicationId}/journeys";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -823,7 +826,7 @@ export async function serializeAws_restJson1_1CreateJourneyCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
@@ -857,7 +860,7 @@ export async function serializeAws_restJson1_1CreatePushTemplateCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v1/templates/{TemplateName}/push";
   if (input.TemplateName !== undefined) {
-    const labelValue: string = input.TemplateName.toString();
+    const labelValue: string = input.TemplateName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: TemplateName."
@@ -865,7 +868,7 @@ export async function serializeAws_restJson1_1CreatePushTemplateCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{TemplateName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: TemplateName.");
@@ -899,7 +902,7 @@ export async function serializeAws_restJson1_1CreateSegmentCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v1/apps/{ApplicationId}/segments";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -907,7 +910,7 @@ export async function serializeAws_restJson1_1CreateSegmentCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
@@ -941,7 +944,7 @@ export async function serializeAws_restJson1_1CreateSmsTemplateCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v1/templates/{TemplateName}/sms";
   if (input.TemplateName !== undefined) {
-    const labelValue: string = input.TemplateName.toString();
+    const labelValue: string = input.TemplateName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: TemplateName."
@@ -949,7 +952,7 @@ export async function serializeAws_restJson1_1CreateSmsTemplateCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{TemplateName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: TemplateName.");
@@ -983,7 +986,7 @@ export async function serializeAws_restJson1_1CreateVoiceTemplateCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v1/templates/{TemplateName}/voice";
   if (input.TemplateName !== undefined) {
-    const labelValue: string = input.TemplateName.toString();
+    const labelValue: string = input.TemplateName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: TemplateName."
@@ -991,7 +994,7 @@ export async function serializeAws_restJson1_1CreateVoiceTemplateCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{TemplateName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: TemplateName.");
@@ -1025,7 +1028,7 @@ export async function serializeAws_restJson1_1DeleteAdmChannelCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/apps/{ApplicationId}/channels/adm";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -1033,7 +1036,7 @@ export async function serializeAws_restJson1_1DeleteAdmChannelCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
@@ -1055,7 +1058,7 @@ export async function serializeAws_restJson1_1DeleteApnsChannelCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/apps/{ApplicationId}/channels/apns";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -1063,7 +1066,7 @@ export async function serializeAws_restJson1_1DeleteApnsChannelCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
@@ -1085,7 +1088,7 @@ export async function serializeAws_restJson1_1DeleteApnsSandboxChannelCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/apps/{ApplicationId}/channels/apns_sandbox";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -1093,7 +1096,7 @@ export async function serializeAws_restJson1_1DeleteApnsSandboxChannelCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
@@ -1115,7 +1118,7 @@ export async function serializeAws_restJson1_1DeleteApnsVoipChannelCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/apps/{ApplicationId}/channels/apns_voip";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -1123,7 +1126,7 @@ export async function serializeAws_restJson1_1DeleteApnsVoipChannelCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
@@ -1145,7 +1148,7 @@ export async function serializeAws_restJson1_1DeleteApnsVoipSandboxChannelComman
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/apps/{ApplicationId}/channels/apns_voip_sandbox";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -1153,7 +1156,7 @@ export async function serializeAws_restJson1_1DeleteApnsVoipSandboxChannelComman
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
@@ -1175,7 +1178,7 @@ export async function serializeAws_restJson1_1DeleteAppCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/apps/{ApplicationId}";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -1183,7 +1186,7 @@ export async function serializeAws_restJson1_1DeleteAppCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
@@ -1205,7 +1208,7 @@ export async function serializeAws_restJson1_1DeleteBaiduChannelCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/apps/{ApplicationId}/channels/baidu";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -1213,7 +1216,7 @@ export async function serializeAws_restJson1_1DeleteBaiduChannelCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
@@ -1235,7 +1238,7 @@ export async function serializeAws_restJson1_1DeleteCampaignCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/apps/{ApplicationId}/campaigns/{CampaignId}";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -1243,19 +1246,19 @@ export async function serializeAws_restJson1_1DeleteCampaignCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
   }
   if (input.CampaignId !== undefined) {
-    const labelValue: string = input.CampaignId.toString();
+    const labelValue: string = input.CampaignId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: CampaignId.");
     }
     resolvedPath = resolvedPath.replace(
       "{CampaignId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: CampaignId.");
@@ -1277,7 +1280,7 @@ export async function serializeAws_restJson1_1DeleteEmailChannelCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/apps/{ApplicationId}/channels/email";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -1285,7 +1288,7 @@ export async function serializeAws_restJson1_1DeleteEmailChannelCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
@@ -1307,7 +1310,7 @@ export async function serializeAws_restJson1_1DeleteEmailTemplateCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/templates/{TemplateName}/email";
   if (input.TemplateName !== undefined) {
-    const labelValue: string = input.TemplateName.toString();
+    const labelValue: string = input.TemplateName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: TemplateName."
@@ -1315,14 +1318,16 @@ export async function serializeAws_restJson1_1DeleteEmailTemplateCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{TemplateName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: TemplateName.");
   }
   const query: any = {};
   if (input.Version !== undefined) {
-    query["version"] = input.Version.toString();
+    query[
+      __extendedEncodeURIComponent("version")
+    ] = __extendedEncodeURIComponent(input.Version);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1342,7 +1347,7 @@ export async function serializeAws_restJson1_1DeleteEndpointCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/apps/{ApplicationId}/endpoints/{EndpointId}";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -1350,19 +1355,19 @@ export async function serializeAws_restJson1_1DeleteEndpointCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
   }
   if (input.EndpointId !== undefined) {
-    const labelValue: string = input.EndpointId.toString();
+    const labelValue: string = input.EndpointId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: EndpointId.");
     }
     resolvedPath = resolvedPath.replace(
       "{EndpointId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: EndpointId.");
@@ -1384,7 +1389,7 @@ export async function serializeAws_restJson1_1DeleteEventStreamCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/apps/{ApplicationId}/eventstream";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -1392,7 +1397,7 @@ export async function serializeAws_restJson1_1DeleteEventStreamCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
@@ -1414,7 +1419,7 @@ export async function serializeAws_restJson1_1DeleteGcmChannelCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/apps/{ApplicationId}/channels/gcm";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -1422,7 +1427,7 @@ export async function serializeAws_restJson1_1DeleteGcmChannelCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
@@ -1444,7 +1449,7 @@ export async function serializeAws_restJson1_1DeleteJourneyCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/apps/{ApplicationId}/journeys/{JourneyId}";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -1452,19 +1457,19 @@ export async function serializeAws_restJson1_1DeleteJourneyCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
   }
   if (input.JourneyId !== undefined) {
-    const labelValue: string = input.JourneyId.toString();
+    const labelValue: string = input.JourneyId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: JourneyId.");
     }
     resolvedPath = resolvedPath.replace(
       "{JourneyId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: JourneyId.");
@@ -1486,7 +1491,7 @@ export async function serializeAws_restJson1_1DeletePushTemplateCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/templates/{TemplateName}/push";
   if (input.TemplateName !== undefined) {
-    const labelValue: string = input.TemplateName.toString();
+    const labelValue: string = input.TemplateName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: TemplateName."
@@ -1494,14 +1499,16 @@ export async function serializeAws_restJson1_1DeletePushTemplateCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{TemplateName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: TemplateName.");
   }
   const query: any = {};
   if (input.Version !== undefined) {
-    query["version"] = input.Version.toString();
+    query[
+      __extendedEncodeURIComponent("version")
+    ] = __extendedEncodeURIComponent(input.Version);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1521,7 +1528,7 @@ export async function serializeAws_restJson1_1DeleteSegmentCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/apps/{ApplicationId}/segments/{SegmentId}";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -1529,19 +1536,19 @@ export async function serializeAws_restJson1_1DeleteSegmentCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
   }
   if (input.SegmentId !== undefined) {
-    const labelValue: string = input.SegmentId.toString();
+    const labelValue: string = input.SegmentId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: SegmentId.");
     }
     resolvedPath = resolvedPath.replace(
       "{SegmentId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: SegmentId.");
@@ -1563,7 +1570,7 @@ export async function serializeAws_restJson1_1DeleteSmsChannelCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/apps/{ApplicationId}/channels/sms";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -1571,7 +1578,7 @@ export async function serializeAws_restJson1_1DeleteSmsChannelCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
@@ -1593,7 +1600,7 @@ export async function serializeAws_restJson1_1DeleteSmsTemplateCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/templates/{TemplateName}/sms";
   if (input.TemplateName !== undefined) {
-    const labelValue: string = input.TemplateName.toString();
+    const labelValue: string = input.TemplateName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: TemplateName."
@@ -1601,14 +1608,16 @@ export async function serializeAws_restJson1_1DeleteSmsTemplateCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{TemplateName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: TemplateName.");
   }
   const query: any = {};
   if (input.Version !== undefined) {
-    query["version"] = input.Version.toString();
+    query[
+      __extendedEncodeURIComponent("version")
+    ] = __extendedEncodeURIComponent(input.Version);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1628,7 +1637,7 @@ export async function serializeAws_restJson1_1DeleteUserEndpointsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/apps/{ApplicationId}/users/{UserId}";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -1636,19 +1645,19 @@ export async function serializeAws_restJson1_1DeleteUserEndpointsCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
   }
   if (input.UserId !== undefined) {
-    const labelValue: string = input.UserId.toString();
+    const labelValue: string = input.UserId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: UserId.");
     }
     resolvedPath = resolvedPath.replace(
       "{UserId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: UserId.");
@@ -1670,7 +1679,7 @@ export async function serializeAws_restJson1_1DeleteVoiceChannelCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/apps/{ApplicationId}/channels/voice";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -1678,7 +1687,7 @@ export async function serializeAws_restJson1_1DeleteVoiceChannelCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
@@ -1700,7 +1709,7 @@ export async function serializeAws_restJson1_1DeleteVoiceTemplateCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/templates/{TemplateName}/voice";
   if (input.TemplateName !== undefined) {
-    const labelValue: string = input.TemplateName.toString();
+    const labelValue: string = input.TemplateName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: TemplateName."
@@ -1708,14 +1717,16 @@ export async function serializeAws_restJson1_1DeleteVoiceTemplateCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{TemplateName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: TemplateName.");
   }
   const query: any = {};
   if (input.Version !== undefined) {
-    query["version"] = input.Version.toString();
+    query[
+      __extendedEncodeURIComponent("version")
+    ] = __extendedEncodeURIComponent(input.Version);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1735,7 +1746,7 @@ export async function serializeAws_restJson1_1GetAdmChannelCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/apps/{ApplicationId}/channels/adm";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -1743,7 +1754,7 @@ export async function serializeAws_restJson1_1GetAdmChannelCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
@@ -1765,7 +1776,7 @@ export async function serializeAws_restJson1_1GetApnsChannelCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/apps/{ApplicationId}/channels/apns";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -1773,7 +1784,7 @@ export async function serializeAws_restJson1_1GetApnsChannelCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
@@ -1795,7 +1806,7 @@ export async function serializeAws_restJson1_1GetApnsSandboxChannelCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/apps/{ApplicationId}/channels/apns_sandbox";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -1803,7 +1814,7 @@ export async function serializeAws_restJson1_1GetApnsSandboxChannelCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
@@ -1825,7 +1836,7 @@ export async function serializeAws_restJson1_1GetApnsVoipChannelCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/apps/{ApplicationId}/channels/apns_voip";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -1833,7 +1844,7 @@ export async function serializeAws_restJson1_1GetApnsVoipChannelCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
@@ -1855,7 +1866,7 @@ export async function serializeAws_restJson1_1GetApnsVoipSandboxChannelCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/apps/{ApplicationId}/channels/apns_voip_sandbox";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -1863,7 +1874,7 @@ export async function serializeAws_restJson1_1GetApnsVoipSandboxChannelCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
@@ -1885,7 +1896,7 @@ export async function serializeAws_restJson1_1GetAppCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/apps/{ApplicationId}";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -1893,7 +1904,7 @@ export async function serializeAws_restJson1_1GetAppCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
@@ -1915,7 +1926,7 @@ export async function serializeAws_restJson1_1GetApplicationDateRangeKpiCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/apps/{ApplicationId}/kpis/daterange/{KpiName}";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -1923,35 +1934,43 @@ export async function serializeAws_restJson1_1GetApplicationDateRangeKpiCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
   }
   if (input.KpiName !== undefined) {
-    const labelValue: string = input.KpiName.toString();
+    const labelValue: string = input.KpiName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: KpiName.");
     }
     resolvedPath = resolvedPath.replace(
       "{KpiName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: KpiName.");
   }
   const query: any = {};
   if (input.EndTime !== undefined) {
-    query["end-time"] = input.EndTime.toISOString();
+    query[
+      __extendedEncodeURIComponent("end-time")
+    ] = __extendedEncodeURIComponent(input.EndTime.toISOString());
   }
   if (input.NextToken !== undefined) {
-    query["next-token"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("next-token")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   if (input.PageSize !== undefined) {
-    query["page-size"] = input.PageSize.toString();
+    query[
+      __extendedEncodeURIComponent("page-size")
+    ] = __extendedEncodeURIComponent(input.PageSize);
   }
   if (input.StartTime !== undefined) {
-    query["start-time"] = input.StartTime.toISOString();
+    query[
+      __extendedEncodeURIComponent("start-time")
+    ] = __extendedEncodeURIComponent(input.StartTime.toISOString());
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1971,7 +1990,7 @@ export async function serializeAws_restJson1_1GetApplicationSettingsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/apps/{ApplicationId}/settings";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -1979,7 +1998,7 @@ export async function serializeAws_restJson1_1GetApplicationSettingsCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
@@ -2002,10 +2021,14 @@ export async function serializeAws_restJson1_1GetAppsCommand(
   let resolvedPath = "/v1/apps";
   const query: any = {};
   if (input.PageSize !== undefined) {
-    query["page-size"] = input.PageSize.toString();
+    query[
+      __extendedEncodeURIComponent("page-size")
+    ] = __extendedEncodeURIComponent(input.PageSize);
   }
   if (input.Token !== undefined) {
-    query["token"] = input.Token.toString();
+    query[__extendedEncodeURIComponent("token")] = __extendedEncodeURIComponent(
+      input.Token
+    );
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2025,7 +2048,7 @@ export async function serializeAws_restJson1_1GetBaiduChannelCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/apps/{ApplicationId}/channels/baidu";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -2033,7 +2056,7 @@ export async function serializeAws_restJson1_1GetBaiduChannelCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
@@ -2055,7 +2078,7 @@ export async function serializeAws_restJson1_1GetCampaignCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/apps/{ApplicationId}/campaigns/{CampaignId}";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -2063,19 +2086,19 @@ export async function serializeAws_restJson1_1GetCampaignCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
   }
   if (input.CampaignId !== undefined) {
-    const labelValue: string = input.CampaignId.toString();
+    const labelValue: string = input.CampaignId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: CampaignId.");
     }
     resolvedPath = resolvedPath.replace(
       "{CampaignId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: CampaignId.");
@@ -2098,7 +2121,7 @@ export async function serializeAws_restJson1_1GetCampaignActivitiesCommand(
   let resolvedPath =
     "/v1/apps/{ApplicationId}/campaigns/{CampaignId}/activities";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -2106,29 +2129,33 @@ export async function serializeAws_restJson1_1GetCampaignActivitiesCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
   }
   if (input.CampaignId !== undefined) {
-    const labelValue: string = input.CampaignId.toString();
+    const labelValue: string = input.CampaignId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: CampaignId.");
     }
     resolvedPath = resolvedPath.replace(
       "{CampaignId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: CampaignId.");
   }
   const query: any = {};
   if (input.PageSize !== undefined) {
-    query["page-size"] = input.PageSize.toString();
+    query[
+      __extendedEncodeURIComponent("page-size")
+    ] = __extendedEncodeURIComponent(input.PageSize);
   }
   if (input.Token !== undefined) {
-    query["token"] = input.Token.toString();
+    query[__extendedEncodeURIComponent("token")] = __extendedEncodeURIComponent(
+      input.Token
+    );
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2149,7 +2176,7 @@ export async function serializeAws_restJson1_1GetCampaignDateRangeKpiCommand(
   let resolvedPath =
     "/v1/apps/{ApplicationId}/campaigns/{CampaignId}/kpis/daterange/{KpiName}";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -2157,47 +2184,55 @@ export async function serializeAws_restJson1_1GetCampaignDateRangeKpiCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
   }
   if (input.CampaignId !== undefined) {
-    const labelValue: string = input.CampaignId.toString();
+    const labelValue: string = input.CampaignId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: CampaignId.");
     }
     resolvedPath = resolvedPath.replace(
       "{CampaignId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: CampaignId.");
   }
   if (input.KpiName !== undefined) {
-    const labelValue: string = input.KpiName.toString();
+    const labelValue: string = input.KpiName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: KpiName.");
     }
     resolvedPath = resolvedPath.replace(
       "{KpiName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: KpiName.");
   }
   const query: any = {};
   if (input.EndTime !== undefined) {
-    query["end-time"] = input.EndTime.toISOString();
+    query[
+      __extendedEncodeURIComponent("end-time")
+    ] = __extendedEncodeURIComponent(input.EndTime.toISOString());
   }
   if (input.NextToken !== undefined) {
-    query["next-token"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("next-token")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   if (input.PageSize !== undefined) {
-    query["page-size"] = input.PageSize.toString();
+    query[
+      __extendedEncodeURIComponent("page-size")
+    ] = __extendedEncodeURIComponent(input.PageSize);
   }
   if (input.StartTime !== undefined) {
-    query["start-time"] = input.StartTime.toISOString();
+    query[
+      __extendedEncodeURIComponent("start-time")
+    ] = __extendedEncodeURIComponent(input.StartTime.toISOString());
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2218,7 +2253,7 @@ export async function serializeAws_restJson1_1GetCampaignVersionCommand(
   let resolvedPath =
     "/v1/apps/{ApplicationId}/campaigns/{CampaignId}/versions/{Version}";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -2226,31 +2261,31 @@ export async function serializeAws_restJson1_1GetCampaignVersionCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
   }
   if (input.CampaignId !== undefined) {
-    const labelValue: string = input.CampaignId.toString();
+    const labelValue: string = input.CampaignId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: CampaignId.");
     }
     resolvedPath = resolvedPath.replace(
       "{CampaignId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: CampaignId.");
   }
   if (input.Version !== undefined) {
-    const labelValue: string = input.Version.toString();
+    const labelValue: string = input.Version;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Version.");
     }
     resolvedPath = resolvedPath.replace(
       "{Version}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Version.");
@@ -2272,7 +2307,7 @@ export async function serializeAws_restJson1_1GetCampaignVersionsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/apps/{ApplicationId}/campaigns/{CampaignId}/versions";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -2280,29 +2315,33 @@ export async function serializeAws_restJson1_1GetCampaignVersionsCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
   }
   if (input.CampaignId !== undefined) {
-    const labelValue: string = input.CampaignId.toString();
+    const labelValue: string = input.CampaignId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: CampaignId.");
     }
     resolvedPath = resolvedPath.replace(
       "{CampaignId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: CampaignId.");
   }
   const query: any = {};
   if (input.PageSize !== undefined) {
-    query["page-size"] = input.PageSize.toString();
+    query[
+      __extendedEncodeURIComponent("page-size")
+    ] = __extendedEncodeURIComponent(input.PageSize);
   }
   if (input.Token !== undefined) {
-    query["token"] = input.Token.toString();
+    query[__extendedEncodeURIComponent("token")] = __extendedEncodeURIComponent(
+      input.Token
+    );
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2322,7 +2361,7 @@ export async function serializeAws_restJson1_1GetCampaignsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/apps/{ApplicationId}/campaigns";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -2330,17 +2369,21 @@ export async function serializeAws_restJson1_1GetCampaignsCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
   }
   const query: any = {};
   if (input.PageSize !== undefined) {
-    query["page-size"] = input.PageSize.toString();
+    query[
+      __extendedEncodeURIComponent("page-size")
+    ] = __extendedEncodeURIComponent(input.PageSize);
   }
   if (input.Token !== undefined) {
-    query["token"] = input.Token.toString();
+    query[__extendedEncodeURIComponent("token")] = __extendedEncodeURIComponent(
+      input.Token
+    );
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2360,7 +2403,7 @@ export async function serializeAws_restJson1_1GetChannelsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/apps/{ApplicationId}/channels";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -2368,7 +2411,7 @@ export async function serializeAws_restJson1_1GetChannelsCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
@@ -2390,7 +2433,7 @@ export async function serializeAws_restJson1_1GetEmailChannelCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/apps/{ApplicationId}/channels/email";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -2398,7 +2441,7 @@ export async function serializeAws_restJson1_1GetEmailChannelCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
@@ -2420,7 +2463,7 @@ export async function serializeAws_restJson1_1GetEmailTemplateCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/templates/{TemplateName}/email";
   if (input.TemplateName !== undefined) {
-    const labelValue: string = input.TemplateName.toString();
+    const labelValue: string = input.TemplateName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: TemplateName."
@@ -2428,14 +2471,16 @@ export async function serializeAws_restJson1_1GetEmailTemplateCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{TemplateName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: TemplateName.");
   }
   const query: any = {};
   if (input.Version !== undefined) {
-    query["version"] = input.Version.toString();
+    query[
+      __extendedEncodeURIComponent("version")
+    ] = __extendedEncodeURIComponent(input.Version);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2455,7 +2500,7 @@ export async function serializeAws_restJson1_1GetEndpointCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/apps/{ApplicationId}/endpoints/{EndpointId}";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -2463,19 +2508,19 @@ export async function serializeAws_restJson1_1GetEndpointCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
   }
   if (input.EndpointId !== undefined) {
-    const labelValue: string = input.EndpointId.toString();
+    const labelValue: string = input.EndpointId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: EndpointId.");
     }
     resolvedPath = resolvedPath.replace(
       "{EndpointId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: EndpointId.");
@@ -2497,7 +2542,7 @@ export async function serializeAws_restJson1_1GetEventStreamCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/apps/{ApplicationId}/eventstream";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -2505,7 +2550,7 @@ export async function serializeAws_restJson1_1GetEventStreamCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
@@ -2527,7 +2572,7 @@ export async function serializeAws_restJson1_1GetExportJobCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/apps/{ApplicationId}/jobs/export/{JobId}";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -2535,19 +2580,19 @@ export async function serializeAws_restJson1_1GetExportJobCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
   }
   if (input.JobId !== undefined) {
-    const labelValue: string = input.JobId.toString();
+    const labelValue: string = input.JobId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: JobId.");
     }
     resolvedPath = resolvedPath.replace(
       "{JobId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: JobId.");
@@ -2569,7 +2614,7 @@ export async function serializeAws_restJson1_1GetExportJobsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/apps/{ApplicationId}/jobs/export";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -2577,17 +2622,21 @@ export async function serializeAws_restJson1_1GetExportJobsCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
   }
   const query: any = {};
   if (input.PageSize !== undefined) {
-    query["page-size"] = input.PageSize.toString();
+    query[
+      __extendedEncodeURIComponent("page-size")
+    ] = __extendedEncodeURIComponent(input.PageSize);
   }
   if (input.Token !== undefined) {
-    query["token"] = input.Token.toString();
+    query[__extendedEncodeURIComponent("token")] = __extendedEncodeURIComponent(
+      input.Token
+    );
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2607,7 +2656,7 @@ export async function serializeAws_restJson1_1GetGcmChannelCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/apps/{ApplicationId}/channels/gcm";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -2615,7 +2664,7 @@ export async function serializeAws_restJson1_1GetGcmChannelCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
@@ -2637,7 +2686,7 @@ export async function serializeAws_restJson1_1GetImportJobCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/apps/{ApplicationId}/jobs/import/{JobId}";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -2645,19 +2694,19 @@ export async function serializeAws_restJson1_1GetImportJobCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
   }
   if (input.JobId !== undefined) {
-    const labelValue: string = input.JobId.toString();
+    const labelValue: string = input.JobId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: JobId.");
     }
     resolvedPath = resolvedPath.replace(
       "{JobId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: JobId.");
@@ -2679,7 +2728,7 @@ export async function serializeAws_restJson1_1GetImportJobsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/apps/{ApplicationId}/jobs/import";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -2687,17 +2736,21 @@ export async function serializeAws_restJson1_1GetImportJobsCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
   }
   const query: any = {};
   if (input.PageSize !== undefined) {
-    query["page-size"] = input.PageSize.toString();
+    query[
+      __extendedEncodeURIComponent("page-size")
+    ] = __extendedEncodeURIComponent(input.PageSize);
   }
   if (input.Token !== undefined) {
-    query["token"] = input.Token.toString();
+    query[__extendedEncodeURIComponent("token")] = __extendedEncodeURIComponent(
+      input.Token
+    );
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2717,7 +2770,7 @@ export async function serializeAws_restJson1_1GetJourneyCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/apps/{ApplicationId}/journeys/{JourneyId}";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -2725,19 +2778,19 @@ export async function serializeAws_restJson1_1GetJourneyCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
   }
   if (input.JourneyId !== undefined) {
-    const labelValue: string = input.JourneyId.toString();
+    const labelValue: string = input.JourneyId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: JourneyId.");
     }
     resolvedPath = resolvedPath.replace(
       "{JourneyId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: JourneyId.");
@@ -2760,7 +2813,7 @@ export async function serializeAws_restJson1_1GetJourneyDateRangeKpiCommand(
   let resolvedPath =
     "/v1/apps/{ApplicationId}/journeys/{JourneyId}/kpis/daterange/{KpiName}";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -2768,47 +2821,55 @@ export async function serializeAws_restJson1_1GetJourneyDateRangeKpiCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
   }
   if (input.JourneyId !== undefined) {
-    const labelValue: string = input.JourneyId.toString();
+    const labelValue: string = input.JourneyId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: JourneyId.");
     }
     resolvedPath = resolvedPath.replace(
       "{JourneyId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: JourneyId.");
   }
   if (input.KpiName !== undefined) {
-    const labelValue: string = input.KpiName.toString();
+    const labelValue: string = input.KpiName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: KpiName.");
     }
     resolvedPath = resolvedPath.replace(
       "{KpiName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: KpiName.");
   }
   const query: any = {};
   if (input.EndTime !== undefined) {
-    query["end-time"] = input.EndTime.toISOString();
+    query[
+      __extendedEncodeURIComponent("end-time")
+    ] = __extendedEncodeURIComponent(input.EndTime.toISOString());
   }
   if (input.NextToken !== undefined) {
-    query["next-token"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("next-token")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   if (input.PageSize !== undefined) {
-    query["page-size"] = input.PageSize.toString();
+    query[
+      __extendedEncodeURIComponent("page-size")
+    ] = __extendedEncodeURIComponent(input.PageSize);
   }
   if (input.StartTime !== undefined) {
-    query["start-time"] = input.StartTime.toISOString();
+    query[
+      __extendedEncodeURIComponent("start-time")
+    ] = __extendedEncodeURIComponent(input.StartTime.toISOString());
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2829,7 +2890,7 @@ export async function serializeAws_restJson1_1GetJourneyExecutionActivityMetrics
   let resolvedPath =
     "/v1/apps/{ApplicationId}/journeys/{JourneyId}/activities/{JourneyActivityId}/execution-metrics";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -2837,13 +2898,13 @@ export async function serializeAws_restJson1_1GetJourneyExecutionActivityMetrics
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
   }
   if (input.JourneyActivityId !== undefined) {
-    const labelValue: string = input.JourneyActivityId.toString();
+    const labelValue: string = input.JourneyActivityId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: JourneyActivityId."
@@ -2851,7 +2912,7 @@ export async function serializeAws_restJson1_1GetJourneyExecutionActivityMetrics
     }
     resolvedPath = resolvedPath.replace(
       "{JourneyActivityId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -2859,23 +2920,27 @@ export async function serializeAws_restJson1_1GetJourneyExecutionActivityMetrics
     );
   }
   if (input.JourneyId !== undefined) {
-    const labelValue: string = input.JourneyId.toString();
+    const labelValue: string = input.JourneyId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: JourneyId.");
     }
     resolvedPath = resolvedPath.replace(
       "{JourneyId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: JourneyId.");
   }
   const query: any = {};
   if (input.NextToken !== undefined) {
-    query["next-token"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("next-token")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   if (input.PageSize !== undefined) {
-    query["page-size"] = input.PageSize.toString();
+    query[
+      __extendedEncodeURIComponent("page-size")
+    ] = __extendedEncodeURIComponent(input.PageSize);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2896,7 +2961,7 @@ export async function serializeAws_restJson1_1GetJourneyExecutionMetricsCommand(
   let resolvedPath =
     "/v1/apps/{ApplicationId}/journeys/{JourneyId}/execution-metrics";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -2904,29 +2969,33 @@ export async function serializeAws_restJson1_1GetJourneyExecutionMetricsCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
   }
   if (input.JourneyId !== undefined) {
-    const labelValue: string = input.JourneyId.toString();
+    const labelValue: string = input.JourneyId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: JourneyId.");
     }
     resolvedPath = resolvedPath.replace(
       "{JourneyId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: JourneyId.");
   }
   const query: any = {};
   if (input.NextToken !== undefined) {
-    query["next-token"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("next-token")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   if (input.PageSize !== undefined) {
-    query["page-size"] = input.PageSize.toString();
+    query[
+      __extendedEncodeURIComponent("page-size")
+    ] = __extendedEncodeURIComponent(input.PageSize);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2946,7 +3015,7 @@ export async function serializeAws_restJson1_1GetPushTemplateCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/templates/{TemplateName}/push";
   if (input.TemplateName !== undefined) {
-    const labelValue: string = input.TemplateName.toString();
+    const labelValue: string = input.TemplateName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: TemplateName."
@@ -2954,14 +3023,16 @@ export async function serializeAws_restJson1_1GetPushTemplateCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{TemplateName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: TemplateName.");
   }
   const query: any = {};
   if (input.Version !== undefined) {
-    query["version"] = input.Version.toString();
+    query[
+      __extendedEncodeURIComponent("version")
+    ] = __extendedEncodeURIComponent(input.Version);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2981,7 +3052,7 @@ export async function serializeAws_restJson1_1GetSegmentCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/apps/{ApplicationId}/segments/{SegmentId}";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -2989,19 +3060,19 @@ export async function serializeAws_restJson1_1GetSegmentCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
   }
   if (input.SegmentId !== undefined) {
-    const labelValue: string = input.SegmentId.toString();
+    const labelValue: string = input.SegmentId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: SegmentId.");
     }
     resolvedPath = resolvedPath.replace(
       "{SegmentId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: SegmentId.");
@@ -3024,7 +3095,7 @@ export async function serializeAws_restJson1_1GetSegmentExportJobsCommand(
   let resolvedPath =
     "/v1/apps/{ApplicationId}/segments/{SegmentId}/jobs/export";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -3032,29 +3103,33 @@ export async function serializeAws_restJson1_1GetSegmentExportJobsCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
   }
   if (input.SegmentId !== undefined) {
-    const labelValue: string = input.SegmentId.toString();
+    const labelValue: string = input.SegmentId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: SegmentId.");
     }
     resolvedPath = resolvedPath.replace(
       "{SegmentId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: SegmentId.");
   }
   const query: any = {};
   if (input.PageSize !== undefined) {
-    query["page-size"] = input.PageSize.toString();
+    query[
+      __extendedEncodeURIComponent("page-size")
+    ] = __extendedEncodeURIComponent(input.PageSize);
   }
   if (input.Token !== undefined) {
-    query["token"] = input.Token.toString();
+    query[__extendedEncodeURIComponent("token")] = __extendedEncodeURIComponent(
+      input.Token
+    );
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -3075,7 +3150,7 @@ export async function serializeAws_restJson1_1GetSegmentImportJobsCommand(
   let resolvedPath =
     "/v1/apps/{ApplicationId}/segments/{SegmentId}/jobs/import";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -3083,29 +3158,33 @@ export async function serializeAws_restJson1_1GetSegmentImportJobsCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
   }
   if (input.SegmentId !== undefined) {
-    const labelValue: string = input.SegmentId.toString();
+    const labelValue: string = input.SegmentId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: SegmentId.");
     }
     resolvedPath = resolvedPath.replace(
       "{SegmentId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: SegmentId.");
   }
   const query: any = {};
   if (input.PageSize !== undefined) {
-    query["page-size"] = input.PageSize.toString();
+    query[
+      __extendedEncodeURIComponent("page-size")
+    ] = __extendedEncodeURIComponent(input.PageSize);
   }
   if (input.Token !== undefined) {
-    query["token"] = input.Token.toString();
+    query[__extendedEncodeURIComponent("token")] = __extendedEncodeURIComponent(
+      input.Token
+    );
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -3126,7 +3205,7 @@ export async function serializeAws_restJson1_1GetSegmentVersionCommand(
   let resolvedPath =
     "/v1/apps/{ApplicationId}/segments/{SegmentId}/versions/{Version}";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -3134,31 +3213,31 @@ export async function serializeAws_restJson1_1GetSegmentVersionCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
   }
   if (input.SegmentId !== undefined) {
-    const labelValue: string = input.SegmentId.toString();
+    const labelValue: string = input.SegmentId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: SegmentId.");
     }
     resolvedPath = resolvedPath.replace(
       "{SegmentId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: SegmentId.");
   }
   if (input.Version !== undefined) {
-    const labelValue: string = input.Version.toString();
+    const labelValue: string = input.Version;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Version.");
     }
     resolvedPath = resolvedPath.replace(
       "{Version}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Version.");
@@ -3180,7 +3259,7 @@ export async function serializeAws_restJson1_1GetSegmentVersionsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/apps/{ApplicationId}/segments/{SegmentId}/versions";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -3188,29 +3267,33 @@ export async function serializeAws_restJson1_1GetSegmentVersionsCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
   }
   if (input.SegmentId !== undefined) {
-    const labelValue: string = input.SegmentId.toString();
+    const labelValue: string = input.SegmentId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: SegmentId.");
     }
     resolvedPath = resolvedPath.replace(
       "{SegmentId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: SegmentId.");
   }
   const query: any = {};
   if (input.PageSize !== undefined) {
-    query["page-size"] = input.PageSize.toString();
+    query[
+      __extendedEncodeURIComponent("page-size")
+    ] = __extendedEncodeURIComponent(input.PageSize);
   }
   if (input.Token !== undefined) {
-    query["token"] = input.Token.toString();
+    query[__extendedEncodeURIComponent("token")] = __extendedEncodeURIComponent(
+      input.Token
+    );
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -3230,7 +3313,7 @@ export async function serializeAws_restJson1_1GetSegmentsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/apps/{ApplicationId}/segments";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -3238,17 +3321,21 @@ export async function serializeAws_restJson1_1GetSegmentsCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
   }
   const query: any = {};
   if (input.PageSize !== undefined) {
-    query["page-size"] = input.PageSize.toString();
+    query[
+      __extendedEncodeURIComponent("page-size")
+    ] = __extendedEncodeURIComponent(input.PageSize);
   }
   if (input.Token !== undefined) {
-    query["token"] = input.Token.toString();
+    query[__extendedEncodeURIComponent("token")] = __extendedEncodeURIComponent(
+      input.Token
+    );
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -3268,7 +3355,7 @@ export async function serializeAws_restJson1_1GetSmsChannelCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/apps/{ApplicationId}/channels/sms";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -3276,7 +3363,7 @@ export async function serializeAws_restJson1_1GetSmsChannelCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
@@ -3298,7 +3385,7 @@ export async function serializeAws_restJson1_1GetSmsTemplateCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/templates/{TemplateName}/sms";
   if (input.TemplateName !== undefined) {
-    const labelValue: string = input.TemplateName.toString();
+    const labelValue: string = input.TemplateName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: TemplateName."
@@ -3306,14 +3393,16 @@ export async function serializeAws_restJson1_1GetSmsTemplateCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{TemplateName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: TemplateName.");
   }
   const query: any = {};
   if (input.Version !== undefined) {
-    query["version"] = input.Version.toString();
+    query[
+      __extendedEncodeURIComponent("version")
+    ] = __extendedEncodeURIComponent(input.Version);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -3333,7 +3422,7 @@ export async function serializeAws_restJson1_1GetUserEndpointsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/apps/{ApplicationId}/users/{UserId}";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -3341,19 +3430,19 @@ export async function serializeAws_restJson1_1GetUserEndpointsCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
   }
   if (input.UserId !== undefined) {
-    const labelValue: string = input.UserId.toString();
+    const labelValue: string = input.UserId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: UserId.");
     }
     resolvedPath = resolvedPath.replace(
       "{UserId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: UserId.");
@@ -3375,7 +3464,7 @@ export async function serializeAws_restJson1_1GetVoiceChannelCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/apps/{ApplicationId}/channels/voice";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -3383,7 +3472,7 @@ export async function serializeAws_restJson1_1GetVoiceChannelCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
@@ -3405,7 +3494,7 @@ export async function serializeAws_restJson1_1GetVoiceTemplateCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/templates/{TemplateName}/voice";
   if (input.TemplateName !== undefined) {
-    const labelValue: string = input.TemplateName.toString();
+    const labelValue: string = input.TemplateName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: TemplateName."
@@ -3413,14 +3502,16 @@ export async function serializeAws_restJson1_1GetVoiceTemplateCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{TemplateName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: TemplateName.");
   }
   const query: any = {};
   if (input.Version !== undefined) {
-    query["version"] = input.Version.toString();
+    query[
+      __extendedEncodeURIComponent("version")
+    ] = __extendedEncodeURIComponent(input.Version);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -3440,7 +3531,7 @@ export async function serializeAws_restJson1_1ListJourneysCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/apps/{ApplicationId}/journeys";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -3448,17 +3539,21 @@ export async function serializeAws_restJson1_1ListJourneysCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
   }
   const query: any = {};
   if (input.PageSize !== undefined) {
-    query["page-size"] = input.PageSize.toString();
+    query[
+      __extendedEncodeURIComponent("page-size")
+    ] = __extendedEncodeURIComponent(input.PageSize);
   }
   if (input.Token !== undefined) {
-    query["token"] = input.Token.toString();
+    query[__extendedEncodeURIComponent("token")] = __extendedEncodeURIComponent(
+      input.Token
+    );
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -3478,7 +3573,7 @@ export async function serializeAws_restJson1_1ListTagsForResourceCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/tags/{ResourceArn}";
   if (input.ResourceArn !== undefined) {
-    const labelValue: string = input.ResourceArn.toString();
+    const labelValue: string = input.ResourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ResourceArn."
@@ -3486,7 +3581,7 @@ export async function serializeAws_restJson1_1ListTagsForResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ResourceArn.");
@@ -3508,7 +3603,7 @@ export async function serializeAws_restJson1_1ListTemplateVersionsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/templates/{TemplateName}/{TemplateType}/versions";
   if (input.TemplateName !== undefined) {
-    const labelValue: string = input.TemplateName.toString();
+    const labelValue: string = input.TemplateName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: TemplateName."
@@ -3516,13 +3611,13 @@ export async function serializeAws_restJson1_1ListTemplateVersionsCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{TemplateName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: TemplateName.");
   }
   if (input.TemplateType !== undefined) {
-    const labelValue: string = input.TemplateType.toString();
+    const labelValue: string = input.TemplateType;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: TemplateType."
@@ -3530,17 +3625,21 @@ export async function serializeAws_restJson1_1ListTemplateVersionsCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{TemplateType}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: TemplateType.");
   }
   const query: any = {};
   if (input.NextToken !== undefined) {
-    query["next-token"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("next-token")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   if (input.PageSize !== undefined) {
-    query["page-size"] = input.PageSize.toString();
+    query[
+      __extendedEncodeURIComponent("page-size")
+    ] = __extendedEncodeURIComponent(input.PageSize);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -3561,16 +3660,24 @@ export async function serializeAws_restJson1_1ListTemplatesCommand(
   let resolvedPath = "/v1/templates";
   const query: any = {};
   if (input.NextToken !== undefined) {
-    query["next-token"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("next-token")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   if (input.PageSize !== undefined) {
-    query["page-size"] = input.PageSize.toString();
+    query[
+      __extendedEncodeURIComponent("page-size")
+    ] = __extendedEncodeURIComponent(input.PageSize);
   }
   if (input.Prefix !== undefined) {
-    query["prefix"] = input.Prefix.toString();
+    query[
+      __extendedEncodeURIComponent("prefix")
+    ] = __extendedEncodeURIComponent(input.Prefix);
   }
   if (input.TemplateType !== undefined) {
-    query["template-type"] = input.TemplateType.toString();
+    query[
+      __extendedEncodeURIComponent("template-type")
+    ] = __extendedEncodeURIComponent(input.TemplateType);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -3618,7 +3725,7 @@ export async function serializeAws_restJson1_1PutEventStreamCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v1/apps/{ApplicationId}/eventstream";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -3626,7 +3733,7 @@ export async function serializeAws_restJson1_1PutEventStreamCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
@@ -3660,7 +3767,7 @@ export async function serializeAws_restJson1_1PutEventsCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v1/apps/{ApplicationId}/events";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -3668,7 +3775,7 @@ export async function serializeAws_restJson1_1PutEventsCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
@@ -3699,7 +3806,7 @@ export async function serializeAws_restJson1_1RemoveAttributesCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v1/apps/{ApplicationId}/attributes/{AttributeType}";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -3707,13 +3814,13 @@ export async function serializeAws_restJson1_1RemoveAttributesCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
   }
   if (input.AttributeType !== undefined) {
-    const labelValue: string = input.AttributeType.toString();
+    const labelValue: string = input.AttributeType;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: AttributeType."
@@ -3721,7 +3828,7 @@ export async function serializeAws_restJson1_1RemoveAttributesCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{AttributeType}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AttributeType.");
@@ -3755,7 +3862,7 @@ export async function serializeAws_restJson1_1SendMessagesCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v1/apps/{ApplicationId}/messages";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -3763,7 +3870,7 @@ export async function serializeAws_restJson1_1SendMessagesCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
@@ -3797,7 +3904,7 @@ export async function serializeAws_restJson1_1SendUsersMessagesCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v1/apps/{ApplicationId}/users-messages";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -3805,7 +3912,7 @@ export async function serializeAws_restJson1_1SendUsersMessagesCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
@@ -3839,7 +3946,7 @@ export async function serializeAws_restJson1_1TagResourceCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v1/tags/{ResourceArn}";
   if (input.ResourceArn !== undefined) {
-    const labelValue: string = input.ResourceArn.toString();
+    const labelValue: string = input.ResourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ResourceArn."
@@ -3847,7 +3954,7 @@ export async function serializeAws_restJson1_1TagResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ResourceArn.");
@@ -3878,7 +3985,7 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/tags/{ResourceArn}";
   if (input.ResourceArn !== undefined) {
-    const labelValue: string = input.ResourceArn.toString();
+    const labelValue: string = input.ResourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ResourceArn."
@@ -3886,14 +3993,16 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ResourceArn.");
   }
   const query: any = {};
   if (input.TagKeys !== undefined) {
-    query["tagKeys"] = input.TagKeys;
+    query[__extendedEncodeURIComponent("tagKeys")] = input.TagKeys.map(entry =>
+      __extendedEncodeURIComponent(entry)
+    );
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -3913,7 +4022,7 @@ export async function serializeAws_restJson1_1UpdateAdmChannelCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v1/apps/{ApplicationId}/channels/adm";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -3921,7 +4030,7 @@ export async function serializeAws_restJson1_1UpdateAdmChannelCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
@@ -3955,7 +4064,7 @@ export async function serializeAws_restJson1_1UpdateApnsChannelCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v1/apps/{ApplicationId}/channels/apns";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -3963,7 +4072,7 @@ export async function serializeAws_restJson1_1UpdateApnsChannelCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
@@ -3997,7 +4106,7 @@ export async function serializeAws_restJson1_1UpdateApnsSandboxChannelCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v1/apps/{ApplicationId}/channels/apns_sandbox";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -4005,7 +4114,7 @@ export async function serializeAws_restJson1_1UpdateApnsSandboxChannelCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
@@ -4039,7 +4148,7 @@ export async function serializeAws_restJson1_1UpdateApnsVoipChannelCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v1/apps/{ApplicationId}/channels/apns_voip";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -4047,7 +4156,7 @@ export async function serializeAws_restJson1_1UpdateApnsVoipChannelCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
@@ -4081,7 +4190,7 @@ export async function serializeAws_restJson1_1UpdateApnsVoipSandboxChannelComman
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v1/apps/{ApplicationId}/channels/apns_voip_sandbox";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -4089,7 +4198,7 @@ export async function serializeAws_restJson1_1UpdateApnsVoipSandboxChannelComman
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
@@ -4123,7 +4232,7 @@ export async function serializeAws_restJson1_1UpdateApplicationSettingsCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v1/apps/{ApplicationId}/settings";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -4131,7 +4240,7 @@ export async function serializeAws_restJson1_1UpdateApplicationSettingsCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
@@ -4165,7 +4274,7 @@ export async function serializeAws_restJson1_1UpdateBaiduChannelCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v1/apps/{ApplicationId}/channels/baidu";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -4173,7 +4282,7 @@ export async function serializeAws_restJson1_1UpdateBaiduChannelCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
@@ -4207,7 +4316,7 @@ export async function serializeAws_restJson1_1UpdateCampaignCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v1/apps/{ApplicationId}/campaigns/{CampaignId}";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -4215,19 +4324,19 @@ export async function serializeAws_restJson1_1UpdateCampaignCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
   }
   if (input.CampaignId !== undefined) {
-    const labelValue: string = input.CampaignId.toString();
+    const labelValue: string = input.CampaignId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: CampaignId.");
     }
     resolvedPath = resolvedPath.replace(
       "{CampaignId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: CampaignId.");
@@ -4261,7 +4370,7 @@ export async function serializeAws_restJson1_1UpdateEmailChannelCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v1/apps/{ApplicationId}/channels/email";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -4269,7 +4378,7 @@ export async function serializeAws_restJson1_1UpdateEmailChannelCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
@@ -4303,7 +4412,7 @@ export async function serializeAws_restJson1_1UpdateEmailTemplateCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v1/templates/{TemplateName}/email";
   if (input.TemplateName !== undefined) {
-    const labelValue: string = input.TemplateName.toString();
+    const labelValue: string = input.TemplateName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: TemplateName."
@@ -4311,17 +4420,21 @@ export async function serializeAws_restJson1_1UpdateEmailTemplateCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{TemplateName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: TemplateName.");
   }
   const query: any = {};
   if (input.CreateNewVersion !== undefined) {
-    query["create-new-version"] = input.CreateNewVersion.toString();
+    query[
+      __extendedEncodeURIComponent("create-new-version")
+    ] = __extendedEncodeURIComponent(input.CreateNewVersion.toString());
   }
   if (input.Version !== undefined) {
-    query["version"] = input.Version.toString();
+    query[
+      __extendedEncodeURIComponent("version")
+    ] = __extendedEncodeURIComponent(input.Version);
   }
   let body: any;
   if (input.EmailTemplateRequest !== undefined) {
@@ -4353,7 +4466,7 @@ export async function serializeAws_restJson1_1UpdateEndpointCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v1/apps/{ApplicationId}/endpoints/{EndpointId}";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -4361,19 +4474,19 @@ export async function serializeAws_restJson1_1UpdateEndpointCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
   }
   if (input.EndpointId !== undefined) {
-    const labelValue: string = input.EndpointId.toString();
+    const labelValue: string = input.EndpointId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: EndpointId.");
     }
     resolvedPath = resolvedPath.replace(
       "{EndpointId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: EndpointId.");
@@ -4407,7 +4520,7 @@ export async function serializeAws_restJson1_1UpdateEndpointsBatchCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v1/apps/{ApplicationId}/endpoints";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -4415,7 +4528,7 @@ export async function serializeAws_restJson1_1UpdateEndpointsBatchCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
@@ -4449,7 +4562,7 @@ export async function serializeAws_restJson1_1UpdateGcmChannelCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v1/apps/{ApplicationId}/channels/gcm";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -4457,7 +4570,7 @@ export async function serializeAws_restJson1_1UpdateGcmChannelCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
@@ -4491,7 +4604,7 @@ export async function serializeAws_restJson1_1UpdateJourneyCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v1/apps/{ApplicationId}/journeys/{JourneyId}";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -4499,19 +4612,19 @@ export async function serializeAws_restJson1_1UpdateJourneyCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
   }
   if (input.JourneyId !== undefined) {
-    const labelValue: string = input.JourneyId.toString();
+    const labelValue: string = input.JourneyId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: JourneyId.");
     }
     resolvedPath = resolvedPath.replace(
       "{JourneyId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: JourneyId.");
@@ -4545,7 +4658,7 @@ export async function serializeAws_restJson1_1UpdateJourneyStateCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v1/apps/{ApplicationId}/journeys/{JourneyId}/state";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -4553,19 +4666,19 @@ export async function serializeAws_restJson1_1UpdateJourneyStateCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
   }
   if (input.JourneyId !== undefined) {
-    const labelValue: string = input.JourneyId.toString();
+    const labelValue: string = input.JourneyId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: JourneyId.");
     }
     resolvedPath = resolvedPath.replace(
       "{JourneyId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: JourneyId.");
@@ -4599,7 +4712,7 @@ export async function serializeAws_restJson1_1UpdatePushTemplateCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v1/templates/{TemplateName}/push";
   if (input.TemplateName !== undefined) {
-    const labelValue: string = input.TemplateName.toString();
+    const labelValue: string = input.TemplateName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: TemplateName."
@@ -4607,17 +4720,21 @@ export async function serializeAws_restJson1_1UpdatePushTemplateCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{TemplateName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: TemplateName.");
   }
   const query: any = {};
   if (input.CreateNewVersion !== undefined) {
-    query["create-new-version"] = input.CreateNewVersion.toString();
+    query[
+      __extendedEncodeURIComponent("create-new-version")
+    ] = __extendedEncodeURIComponent(input.CreateNewVersion.toString());
   }
   if (input.Version !== undefined) {
-    query["version"] = input.Version.toString();
+    query[
+      __extendedEncodeURIComponent("version")
+    ] = __extendedEncodeURIComponent(input.Version);
   }
   let body: any;
   if (input.PushNotificationTemplateRequest !== undefined) {
@@ -4649,7 +4766,7 @@ export async function serializeAws_restJson1_1UpdateSegmentCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v1/apps/{ApplicationId}/segments/{SegmentId}";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -4657,19 +4774,19 @@ export async function serializeAws_restJson1_1UpdateSegmentCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
   }
   if (input.SegmentId !== undefined) {
-    const labelValue: string = input.SegmentId.toString();
+    const labelValue: string = input.SegmentId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: SegmentId.");
     }
     resolvedPath = resolvedPath.replace(
       "{SegmentId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: SegmentId.");
@@ -4703,7 +4820,7 @@ export async function serializeAws_restJson1_1UpdateSmsChannelCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v1/apps/{ApplicationId}/channels/sms";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -4711,7 +4828,7 @@ export async function serializeAws_restJson1_1UpdateSmsChannelCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
@@ -4745,7 +4862,7 @@ export async function serializeAws_restJson1_1UpdateSmsTemplateCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v1/templates/{TemplateName}/sms";
   if (input.TemplateName !== undefined) {
-    const labelValue: string = input.TemplateName.toString();
+    const labelValue: string = input.TemplateName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: TemplateName."
@@ -4753,17 +4870,21 @@ export async function serializeAws_restJson1_1UpdateSmsTemplateCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{TemplateName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: TemplateName.");
   }
   const query: any = {};
   if (input.CreateNewVersion !== undefined) {
-    query["create-new-version"] = input.CreateNewVersion.toString();
+    query[
+      __extendedEncodeURIComponent("create-new-version")
+    ] = __extendedEncodeURIComponent(input.CreateNewVersion.toString());
   }
   if (input.Version !== undefined) {
-    query["version"] = input.Version.toString();
+    query[
+      __extendedEncodeURIComponent("version")
+    ] = __extendedEncodeURIComponent(input.Version);
   }
   let body: any;
   if (input.SMSTemplateRequest !== undefined) {
@@ -4796,7 +4917,7 @@ export async function serializeAws_restJson1_1UpdateTemplateActiveVersionCommand
   let resolvedPath =
     "/v1/templates/{TemplateName}/{TemplateType}/active-version";
   if (input.TemplateName !== undefined) {
-    const labelValue: string = input.TemplateName.toString();
+    const labelValue: string = input.TemplateName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: TemplateName."
@@ -4804,13 +4925,13 @@ export async function serializeAws_restJson1_1UpdateTemplateActiveVersionCommand
     }
     resolvedPath = resolvedPath.replace(
       "{TemplateName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: TemplateName.");
   }
   if (input.TemplateType !== undefined) {
-    const labelValue: string = input.TemplateType.toString();
+    const labelValue: string = input.TemplateType;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: TemplateType."
@@ -4818,7 +4939,7 @@ export async function serializeAws_restJson1_1UpdateTemplateActiveVersionCommand
     }
     resolvedPath = resolvedPath.replace(
       "{TemplateType}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: TemplateType.");
@@ -4852,7 +4973,7 @@ export async function serializeAws_restJson1_1UpdateVoiceChannelCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v1/apps/{ApplicationId}/channels/voice";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -4860,7 +4981,7 @@ export async function serializeAws_restJson1_1UpdateVoiceChannelCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
@@ -4894,7 +5015,7 @@ export async function serializeAws_restJson1_1UpdateVoiceTemplateCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v1/templates/{TemplateName}/voice";
   if (input.TemplateName !== undefined) {
-    const labelValue: string = input.TemplateName.toString();
+    const labelValue: string = input.TemplateName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: TemplateName."
@@ -4902,17 +5023,21 @@ export async function serializeAws_restJson1_1UpdateVoiceTemplateCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{TemplateName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: TemplateName.");
   }
   const query: any = {};
   if (input.CreateNewVersion !== undefined) {
-    query["create-new-version"] = input.CreateNewVersion.toString();
+    query[
+      __extendedEncodeURIComponent("create-new-version")
+    ] = __extendedEncodeURIComponent(input.CreateNewVersion.toString());
   }
   if (input.Version !== undefined) {
-    query["version"] = input.Version.toString();
+    query[
+      __extendedEncodeURIComponent("version")
+    ] = __extendedEncodeURIComponent(input.Version);
   }
   let body: any;
   if (input.VoiceTemplateRequest !== undefined) {
@@ -12403,6 +12528,7 @@ export async function deserializeAws_restJson1_1TagResourceCommand(
   const contents: TagResourceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -12443,6 +12569,7 @@ export async function deserializeAws_restJson1_1UntagResourceCommand(
   const contents: UntagResourceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 

--- a/clients/client-polly/models/index.ts
+++ b/clients/client-polly/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export interface DeleteLexiconInput {
@@ -12,7 +15,7 @@ export interface DeleteLexiconInput {
 
 export namespace DeleteLexiconInput {
   export function isa(o: any): o is DeleteLexiconInput {
-    return _smithy.isa(o, "DeleteLexiconInput");
+    return __isa(o, "DeleteLexiconInput");
   }
 }
 
@@ -22,7 +25,7 @@ export interface DeleteLexiconOutput extends $MetadataBearer {
 
 export namespace DeleteLexiconOutput {
   export function isa(o: any): o is DeleteLexiconOutput {
-    return _smithy.isa(o, "DeleteLexiconOutput");
+    return __isa(o, "DeleteLexiconOutput");
   }
 }
 
@@ -60,7 +63,7 @@ export interface DescribeVoicesInput {
 
 export namespace DescribeVoicesInput {
   export function isa(o: any): o is DescribeVoicesInput {
-    return _smithy.isa(o, "DescribeVoicesInput");
+    return __isa(o, "DescribeVoicesInput");
   }
 }
 
@@ -81,7 +84,7 @@ export interface DescribeVoicesOutput extends $MetadataBearer {
 
 export namespace DescribeVoicesOutput {
   export function isa(o: any): o is DescribeVoicesOutput {
-    return _smithy.isa(o, "DescribeVoicesOutput");
+    return __isa(o, "DescribeVoicesOutput");
   }
 }
 
@@ -95,7 +98,7 @@ export enum Engine {
  *       and restart the operation.</p>
  */
 export interface EngineNotSupportedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "EngineNotSupportedException";
   $fault: "client";
@@ -104,7 +107,7 @@ export interface EngineNotSupportedException
 
 export namespace EngineNotSupportedException {
   export function isa(o: any): o is EngineNotSupportedException {
-    return _smithy.isa(o, "EngineNotSupportedException");
+    return __isa(o, "EngineNotSupportedException");
   }
 }
 
@@ -120,7 +123,7 @@ export interface GetLexiconInput {
 
 export namespace GetLexiconInput {
   export function isa(o: any): o is GetLexiconInput {
-    return _smithy.isa(o, "GetLexiconInput");
+    return __isa(o, "GetLexiconInput");
   }
 }
 
@@ -141,7 +144,7 @@ export interface GetLexiconOutput extends $MetadataBearer {
 
 export namespace GetLexiconOutput {
   export function isa(o: any): o is GetLexiconOutput {
-    return _smithy.isa(o, "GetLexiconOutput");
+    return __isa(o, "GetLexiconOutput");
   }
 }
 
@@ -155,7 +158,7 @@ export interface GetSpeechSynthesisTaskInput {
 
 export namespace GetSpeechSynthesisTaskInput {
   export function isa(o: any): o is GetSpeechSynthesisTaskInput {
-    return _smithy.isa(o, "GetSpeechSynthesisTaskInput");
+    return __isa(o, "GetSpeechSynthesisTaskInput");
   }
 }
 
@@ -170,7 +173,7 @@ export interface GetSpeechSynthesisTaskOutput extends $MetadataBearer {
 
 export namespace GetSpeechSynthesisTaskOutput {
   export function isa(o: any): o is GetSpeechSynthesisTaskOutput {
-    return _smithy.isa(o, "GetSpeechSynthesisTaskOutput");
+    return __isa(o, "GetSpeechSynthesisTaskOutput");
   }
 }
 
@@ -179,7 +182,7 @@ export namespace GetSpeechSynthesisTaskOutput {
  *       Verify that the lexicon's name is spelled correctly, and then try again.</p>
  */
 export interface InvalidLexiconException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidLexiconException";
   $fault: "client";
@@ -188,7 +191,7 @@ export interface InvalidLexiconException
 
 export namespace InvalidLexiconException {
   export function isa(o: any): o is InvalidLexiconException {
-    return _smithy.isa(o, "InvalidLexiconException");
+    return __isa(o, "InvalidLexiconException");
   }
 }
 
@@ -197,7 +200,7 @@ export namespace InvalidLexiconException {
  *       Verify that it's spelled correctly, and then try again.</p>
  */
 export interface InvalidNextTokenException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidNextTokenException";
   $fault: "client";
@@ -206,7 +209,7 @@ export interface InvalidNextTokenException
 
 export namespace InvalidNextTokenException {
   export function isa(o: any): o is InvalidNextTokenException {
-    return _smithy.isa(o, "InvalidNextTokenException");
+    return __isa(o, "InvalidNextTokenException");
   }
 }
 
@@ -215,7 +218,7 @@ export namespace InvalidNextTokenException {
  *       naming requirements and try again.</p>
  */
 export interface InvalidS3BucketException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidS3BucketException";
   $fault: "client";
@@ -224,7 +227,7 @@ export interface InvalidS3BucketException
 
 export namespace InvalidS3BucketException {
   export function isa(o: any): o is InvalidS3BucketException {
-    return _smithy.isa(o, "InvalidS3BucketException");
+    return __isa(o, "InvalidS3BucketException");
   }
 }
 
@@ -232,7 +235,7 @@ export namespace InvalidS3BucketException {
  * <p>The provided Amazon S3 key prefix is invalid. Please provide a valid S3 object key name.</p>
  */
 export interface InvalidS3KeyException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidS3KeyException";
   $fault: "client";
@@ -241,7 +244,7 @@ export interface InvalidS3KeyException
 
 export namespace InvalidS3KeyException {
   export function isa(o: any): o is InvalidS3KeyException {
-    return _smithy.isa(o, "InvalidS3KeyException");
+    return __isa(o, "InvalidS3KeyException");
   }
 }
 
@@ -249,7 +252,7 @@ export namespace InvalidS3KeyException {
  * <p>The specified sample rate is not valid.</p>
  */
 export interface InvalidSampleRateException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidSampleRateException";
   $fault: "client";
@@ -258,7 +261,7 @@ export interface InvalidSampleRateException
 
 export namespace InvalidSampleRateException {
   export function isa(o: any): o is InvalidSampleRateException {
-    return _smithy.isa(o, "InvalidSampleRateException");
+    return __isa(o, "InvalidSampleRateException");
   }
 }
 
@@ -266,7 +269,7 @@ export namespace InvalidSampleRateException {
  * <p>The provided SNS topic ARN is invalid. Please provide a valid SNS topic ARN and try again.</p>
  */
 export interface InvalidSnsTopicArnException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidSnsTopicArnException";
   $fault: "client";
@@ -275,7 +278,7 @@ export interface InvalidSnsTopicArnException
 
 export namespace InvalidSnsTopicArnException {
   export function isa(o: any): o is InvalidSnsTopicArnException {
-    return _smithy.isa(o, "InvalidSnsTopicArnException");
+    return __isa(o, "InvalidSnsTopicArnException");
   }
 }
 
@@ -284,7 +287,7 @@ export namespace InvalidSnsTopicArnException {
  *       Verify the SSML syntax, spelling of tags and values, and then try again.</p>
  */
 export interface InvalidSsmlException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidSsmlException";
   $fault: "client";
@@ -293,7 +296,7 @@ export interface InvalidSsmlException
 
 export namespace InvalidSsmlException {
   export function isa(o: any): o is InvalidSsmlException {
-    return _smithy.isa(o, "InvalidSsmlException");
+    return __isa(o, "InvalidSsmlException");
   }
 }
 
@@ -301,7 +304,7 @@ export namespace InvalidSsmlException {
  * <p>The provided Task ID is not valid. Please provide a valid Task ID and try again.</p>
  */
 export interface InvalidTaskIdException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidTaskIdException";
   $fault: "client";
@@ -310,7 +313,7 @@ export interface InvalidTaskIdException
 
 export namespace InvalidTaskIdException {
   export function isa(o: any): o is InvalidTaskIdException {
-    return _smithy.isa(o, "InvalidTaskIdException");
+    return __isa(o, "InvalidTaskIdException");
   }
 }
 
@@ -349,7 +352,7 @@ export type LanguageCode =
  * <p>The language specified is not currently supported by Amazon Polly in this capacity.</p>
  */
 export interface LanguageNotSupportedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LanguageNotSupportedException";
   $fault: "client";
@@ -358,7 +361,7 @@ export interface LanguageNotSupportedException
 
 export namespace LanguageNotSupportedException {
   export function isa(o: any): o is LanguageNotSupportedException {
-    return _smithy.isa(o, "LanguageNotSupportedException");
+    return __isa(o, "LanguageNotSupportedException");
   }
 }
 
@@ -382,7 +385,7 @@ export interface Lexicon {
 
 export namespace Lexicon {
   export function isa(o: any): o is Lexicon {
-    return _smithy.isa(o, "Lexicon");
+    return __isa(o, "Lexicon");
   }
 }
 
@@ -430,7 +433,7 @@ export interface LexiconAttributes {
 
 export namespace LexiconAttributes {
   export function isa(o: any): o is LexiconAttributes {
-    return _smithy.isa(o, "LexiconAttributes");
+    return __isa(o, "LexiconAttributes");
   }
 }
 
@@ -452,7 +455,7 @@ export interface LexiconDescription {
 
 export namespace LexiconDescription {
   export function isa(o: any): o is LexiconDescription {
-    return _smithy.isa(o, "LexiconDescription");
+    return __isa(o, "LexiconDescription");
   }
 }
 
@@ -464,7 +467,7 @@ export namespace LexiconDescription {
  *       and that you spelled its name is spelled correctly. Then try again.</p>
  */
 export interface LexiconNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LexiconNotFoundException";
   $fault: "client";
@@ -473,7 +476,7 @@ export interface LexiconNotFoundException
 
 export namespace LexiconNotFoundException {
   export function isa(o: any): o is LexiconNotFoundException {
-    return _smithy.isa(o, "LexiconNotFoundException");
+    return __isa(o, "LexiconNotFoundException");
   }
 }
 
@@ -481,7 +484,7 @@ export namespace LexiconNotFoundException {
  * <p>The maximum size of the specified lexicon would be exceeded by this operation.</p>
  */
 export interface LexiconSizeExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LexiconSizeExceededException";
   $fault: "client";
@@ -490,7 +493,7 @@ export interface LexiconSizeExceededException
 
 export namespace LexiconSizeExceededException {
   export function isa(o: any): o is LexiconSizeExceededException {
-    return _smithy.isa(o, "LexiconSizeExceededException");
+    return __isa(o, "LexiconSizeExceededException");
   }
 }
 
@@ -506,7 +509,7 @@ export interface ListLexiconsInput {
 
 export namespace ListLexiconsInput {
   export function isa(o: any): o is ListLexiconsInput {
-    return _smithy.isa(o, "ListLexiconsInput");
+    return __isa(o, "ListLexiconsInput");
   }
 }
 
@@ -527,7 +530,7 @@ export interface ListLexiconsOutput extends $MetadataBearer {
 
 export namespace ListLexiconsOutput {
   export function isa(o: any): o is ListLexiconsOutput {
-    return _smithy.isa(o, "ListLexiconsOutput");
+    return __isa(o, "ListLexiconsOutput");
   }
 }
 
@@ -552,7 +555,7 @@ export interface ListSpeechSynthesisTasksInput {
 
 export namespace ListSpeechSynthesisTasksInput {
   export function isa(o: any): o is ListSpeechSynthesisTasksInput {
-    return _smithy.isa(o, "ListSpeechSynthesisTasksInput");
+    return __isa(o, "ListSpeechSynthesisTasksInput");
   }
 }
 
@@ -573,7 +576,7 @@ export interface ListSpeechSynthesisTasksOutput extends $MetadataBearer {
 
 export namespace ListSpeechSynthesisTasksOutput {
   export function isa(o: any): o is ListSpeechSynthesisTasksOutput {
-    return _smithy.isa(o, "ListSpeechSynthesisTasksOutput");
+    return __isa(o, "ListSpeechSynthesisTasksOutput");
   }
 }
 
@@ -582,7 +585,7 @@ export namespace ListSpeechSynthesisTasksOutput {
  *       Speech marks are only available for content in <code>json</code> format.</p>
  */
 export interface MarksNotSupportedForFormatException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "MarksNotSupportedForFormatException";
   $fault: "client";
@@ -591,7 +594,7 @@ export interface MarksNotSupportedForFormatException
 
 export namespace MarksNotSupportedForFormatException {
   export function isa(o: any): o is MarksNotSupportedForFormatException {
-    return _smithy.isa(o, "MarksNotSupportedForFormatException");
+    return __isa(o, "MarksNotSupportedForFormatException");
   }
 }
 
@@ -599,7 +602,7 @@ export namespace MarksNotSupportedForFormatException {
  * <p>The maximum size of the lexeme would be exceeded by this operation.</p>
  */
 export interface MaxLexemeLengthExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "MaxLexemeLengthExceededException";
   $fault: "client";
@@ -608,7 +611,7 @@ export interface MaxLexemeLengthExceededException
 
 export namespace MaxLexemeLengthExceededException {
   export function isa(o: any): o is MaxLexemeLengthExceededException {
-    return _smithy.isa(o, "MaxLexemeLengthExceededException");
+    return __isa(o, "MaxLexemeLengthExceededException");
   }
 }
 
@@ -616,7 +619,7 @@ export namespace MaxLexemeLengthExceededException {
  * <p>The maximum number of lexicons would be exceeded by this operation.</p>
  */
 export interface MaxLexiconsNumberExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "MaxLexiconsNumberExceededException";
   $fault: "client";
@@ -625,7 +628,7 @@ export interface MaxLexiconsNumberExceededException
 
 export namespace MaxLexiconsNumberExceededException {
   export function isa(o: any): o is MaxLexiconsNumberExceededException {
-    return _smithy.isa(o, "MaxLexiconsNumberExceededException");
+    return __isa(o, "MaxLexiconsNumberExceededException");
   }
 }
 
@@ -654,7 +657,7 @@ export interface PutLexiconInput {
 
 export namespace PutLexiconInput {
   export function isa(o: any): o is PutLexiconInput {
-    return _smithy.isa(o, "PutLexiconInput");
+    return __isa(o, "PutLexiconInput");
   }
 }
 
@@ -664,7 +667,7 @@ export interface PutLexiconOutput extends $MetadataBearer {
 
 export namespace PutLexiconOutput {
   export function isa(o: any): o is PutLexiconOutput {
-    return _smithy.isa(o, "PutLexiconOutput");
+    return __isa(o, "PutLexiconOutput");
   }
 }
 
@@ -672,7 +675,7 @@ export namespace PutLexiconOutput {
  * <p>An unknown condition has caused a service failure.</p>
  */
 export interface ServiceFailureException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ServiceFailureException";
   $fault: "server";
@@ -681,7 +684,7 @@ export interface ServiceFailureException
 
 export namespace ServiceFailureException {
   export function isa(o: any): o is ServiceFailureException {
-    return _smithy.isa(o, "ServiceFailureException");
+    return __isa(o, "ServiceFailureException");
   }
 }
 
@@ -696,7 +699,7 @@ export enum SpeechMarkType {
  * <p>SSML speech marks are not supported for plain text-type input.</p>
  */
 export interface SsmlMarksNotSupportedForTextTypeException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "SsmlMarksNotSupportedForTextTypeException";
   $fault: "client";
@@ -705,7 +708,7 @@ export interface SsmlMarksNotSupportedForTextTypeException
 
 export namespace SsmlMarksNotSupportedForTextTypeException {
   export function isa(o: any): o is SsmlMarksNotSupportedForTextTypeException {
-    return _smithy.isa(o, "SsmlMarksNotSupportedForTextTypeException");
+    return __isa(o, "SsmlMarksNotSupportedForTextTypeException");
   }
 }
 
@@ -787,7 +790,7 @@ export interface StartSpeechSynthesisTaskInput {
 
 export namespace StartSpeechSynthesisTaskInput {
   export function isa(o: any): o is StartSpeechSynthesisTaskInput {
-    return _smithy.isa(o, "StartSpeechSynthesisTaskInput");
+    return __isa(o, "StartSpeechSynthesisTaskInput");
   }
 }
 
@@ -801,7 +804,7 @@ export interface StartSpeechSynthesisTaskOutput extends $MetadataBearer {
 
 export namespace StartSpeechSynthesisTaskOutput {
   export function isa(o: any): o is StartSpeechSynthesisTaskOutput {
-    return _smithy.isa(o, "StartSpeechSynthesisTaskOutput");
+    return __isa(o, "StartSpeechSynthesisTaskOutput");
   }
 }
 
@@ -902,7 +905,7 @@ export interface SynthesisTask {
 
 export namespace SynthesisTask {
   export function isa(o: any): o is SynthesisTask {
-    return _smithy.isa(o, "SynthesisTask");
+    return __isa(o, "SynthesisTask");
   }
 }
 
@@ -910,7 +913,7 @@ export namespace SynthesisTask {
  * <p>The Speech Synthesis task with requested Task ID cannot be found.</p>
  */
 export interface SynthesisTaskNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "SynthesisTaskNotFoundException";
   $fault: "client";
@@ -919,7 +922,7 @@ export interface SynthesisTaskNotFoundException
 
 export namespace SynthesisTaskNotFoundException {
   export function isa(o: any): o is SynthesisTaskNotFoundException {
-    return _smithy.isa(o, "SynthesisTaskNotFoundException");
+    return __isa(o, "SynthesisTaskNotFoundException");
   }
 }
 
@@ -997,7 +1000,7 @@ export interface SynthesizeSpeechInput {
 
 export namespace SynthesizeSpeechInput {
   export function isa(o: any): o is SynthesizeSpeechInput {
-    return _smithy.isa(o, "SynthesizeSpeechInput");
+    return __isa(o, "SynthesizeSpeechInput");
   }
 }
 
@@ -1052,7 +1055,7 @@ export interface SynthesizeSpeechOutput extends $MetadataBearer {
 
 export namespace SynthesizeSpeechOutput {
   export function isa(o: any): o is SynthesizeSpeechOutput {
-    return _smithy.isa(o, "SynthesizeSpeechOutput");
+    return __isa(o, "SynthesizeSpeechOutput");
   }
 }
 
@@ -1070,7 +1073,7 @@ export enum TaskStatus {
  *       SSML tags are not counted as billed characters.</p>
  */
 export interface TextLengthExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TextLengthExceededException";
   $fault: "client";
@@ -1079,7 +1082,7 @@ export interface TextLengthExceededException
 
 export namespace TextLengthExceededException {
   export function isa(o: any): o is TextLengthExceededException {
-    return _smithy.isa(o, "TextLengthExceededException");
+    return __isa(o, "TextLengthExceededException");
   }
 }
 
@@ -1093,7 +1096,7 @@ export enum TextType {
  *       Valid values are <code>x-sampa</code> and <code>ipa</code>.</p>
  */
 export interface UnsupportedPlsAlphabetException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UnsupportedPlsAlphabetException";
   $fault: "client";
@@ -1102,7 +1105,7 @@ export interface UnsupportedPlsAlphabetException
 
 export namespace UnsupportedPlsAlphabetException {
   export function isa(o: any): o is UnsupportedPlsAlphabetException {
-    return _smithy.isa(o, "UnsupportedPlsAlphabetException");
+    return __isa(o, "UnsupportedPlsAlphabetException");
   }
 }
 
@@ -1111,7 +1114,7 @@ export namespace UnsupportedPlsAlphabetException {
  *       supported languages, see <a href="https://docs.aws.amazon.com/polly/latest/dg/API_LexiconAttributes.html">Lexicon Attributes</a>.</p>
  */
 export interface UnsupportedPlsLanguageException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UnsupportedPlsLanguageException";
   $fault: "client";
@@ -1120,7 +1123,7 @@ export interface UnsupportedPlsLanguageException
 
 export namespace UnsupportedPlsLanguageException {
   export function isa(o: any): o is UnsupportedPlsLanguageException {
-    return _smithy.isa(o, "UnsupportedPlsLanguageException");
+    return __isa(o, "UnsupportedPlsLanguageException");
   }
 }
 
@@ -1172,7 +1175,7 @@ export interface Voice {
 
 export namespace Voice {
   export function isa(o: any): o is Voice {
-    return _smithy.isa(o, "Voice");
+    return __isa(o, "Voice");
   }
 }
 

--- a/clients/client-polly/protocols/Aws_restJson1_1.ts
+++ b/clients/client-polly/protocols/Aws_restJson1_1.ts
@@ -69,7 +69,10 @@ import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  extendedEncodeURIComponent as __extendedEncodeURIComponent
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -85,13 +88,13 @@ export async function serializeAws_restJson1_1DeleteLexiconCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/lexicons/{Name}";
   if (input.Name !== undefined) {
-    const labelValue: string = input.Name.toString();
+    const labelValue: string = input.Name;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Name.");
     }
     resolvedPath = resolvedPath.replace(
       "{Name}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Name.");
@@ -114,18 +117,26 @@ export async function serializeAws_restJson1_1DescribeVoicesCommand(
   let resolvedPath = "/v1/voices";
   const query: any = {};
   if (input.Engine !== undefined) {
-    query["Engine"] = input.Engine.toString();
+    query[
+      __extendedEncodeURIComponent("Engine")
+    ] = __extendedEncodeURIComponent(input.Engine);
   }
   if (input.IncludeAdditionalLanguageCodes !== undefined) {
     query[
-      "IncludeAdditionalLanguageCodes"
-    ] = input.IncludeAdditionalLanguageCodes.toString();
+      __extendedEncodeURIComponent("IncludeAdditionalLanguageCodes")
+    ] = __extendedEncodeURIComponent(
+      input.IncludeAdditionalLanguageCodes.toString()
+    );
   }
   if (input.LanguageCode !== undefined) {
-    query["LanguageCode"] = input.LanguageCode.toString();
+    query[
+      __extendedEncodeURIComponent("LanguageCode")
+    ] = __extendedEncodeURIComponent(input.LanguageCode);
   }
   if (input.NextToken !== undefined) {
-    query["NextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("NextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -145,13 +156,13 @@ export async function serializeAws_restJson1_1GetLexiconCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/lexicons/{Name}";
   if (input.Name !== undefined) {
-    const labelValue: string = input.Name.toString();
+    const labelValue: string = input.Name;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Name.");
     }
     resolvedPath = resolvedPath.replace(
       "{Name}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Name.");
@@ -173,13 +184,13 @@ export async function serializeAws_restJson1_1GetSpeechSynthesisTaskCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/synthesisTasks/{TaskId}";
   if (input.TaskId !== undefined) {
-    const labelValue: string = input.TaskId.toString();
+    const labelValue: string = input.TaskId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: TaskId.");
     }
     resolvedPath = resolvedPath.replace(
       "{TaskId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: TaskId.");
@@ -202,7 +213,9 @@ export async function serializeAws_restJson1_1ListLexiconsCommand(
   let resolvedPath = "/v1/lexicons";
   const query: any = {};
   if (input.NextToken !== undefined) {
-    query["NextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("NextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -223,13 +236,19 @@ export async function serializeAws_restJson1_1ListSpeechSynthesisTasksCommand(
   let resolvedPath = "/v1/synthesisTasks";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["MaxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("MaxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["NextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("NextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   if (input.Status !== undefined) {
-    query["Status"] = input.Status.toString();
+    query[
+      __extendedEncodeURIComponent("Status")
+    ] = __extendedEncodeURIComponent(input.Status);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -249,13 +268,13 @@ export async function serializeAws_restJson1_1PutLexiconCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v1/lexicons/{Name}";
   if (input.Name !== undefined) {
-    const labelValue: string = input.Name.toString();
+    const labelValue: string = input.Name;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Name.");
     }
     resolvedPath = resolvedPath.replace(
       "{Name}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Name.");
@@ -402,6 +421,7 @@ export async function deserializeAws_restJson1_1DeleteLexiconCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeleteLexiconOutput"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -801,6 +821,7 @@ export async function deserializeAws_restJson1_1PutLexiconCommand(
     $metadata: deserializeMetadata(output),
     __type: "PutLexiconOutput"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 

--- a/clients/client-pricing/models/index.ts
+++ b/clients/client-pricing/models/index.ts
@@ -1,4 +1,8 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  LazyJsonString as __LazyJsonString,
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -16,7 +20,7 @@ export interface AttributeValue {
 
 export namespace AttributeValue {
   export function isa(o: any): o is AttributeValue {
-    return _smithy.isa(o, "AttributeValue");
+    return __isa(o, "AttributeValue");
   }
 }
 
@@ -50,7 +54,7 @@ export interface DescribeServicesRequest {
 
 export namespace DescribeServicesRequest {
   export function isa(o: any): o is DescribeServicesRequest {
-    return _smithy.isa(o, "DescribeServicesRequest");
+    return __isa(o, "DescribeServicesRequest");
   }
 }
 
@@ -74,7 +78,7 @@ export interface DescribeServicesResponse extends $MetadataBearer {
 
 export namespace DescribeServicesResponse {
   export function isa(o: any): o is DescribeServicesResponse {
-    return _smithy.isa(o, "DescribeServicesResponse");
+    return __isa(o, "DescribeServicesResponse");
   }
 }
 
@@ -82,7 +86,7 @@ export namespace DescribeServicesResponse {
  * <p>The pagination token expired. Try again without a pagination token.</p>
  */
 export interface ExpiredNextTokenException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ExpiredNextTokenException";
   $fault: "client";
@@ -91,7 +95,7 @@ export interface ExpiredNextTokenException
 
 export namespace ExpiredNextTokenException {
   export function isa(o: any): o is ExpiredNextTokenException {
-    return _smithy.isa(o, "ExpiredNextTokenException");
+    return __isa(o, "ExpiredNextTokenException");
   }
 }
 
@@ -130,7 +134,7 @@ export interface Filter {
 
 export namespace Filter {
   export function isa(o: any): o is Filter {
-    return _smithy.isa(o, "Filter");
+    return __isa(o, "Filter");
   }
 }
 
@@ -164,7 +168,7 @@ export interface GetAttributeValuesRequest {
 
 export namespace GetAttributeValuesRequest {
   export function isa(o: any): o is GetAttributeValuesRequest {
-    return _smithy.isa(o, "GetAttributeValuesRequest");
+    return __isa(o, "GetAttributeValuesRequest");
   }
 }
 
@@ -185,7 +189,7 @@ export interface GetAttributeValuesResponse extends $MetadataBearer {
 
 export namespace GetAttributeValuesResponse {
   export function isa(o: any): o is GetAttributeValuesResponse {
-    return _smithy.isa(o, "GetAttributeValuesResponse");
+    return __isa(o, "GetAttributeValuesResponse");
   }
 }
 
@@ -222,7 +226,7 @@ export interface GetProductsRequest {
 
 export namespace GetProductsRequest {
   export function isa(o: any): o is GetProductsRequest {
-    return _smithy.isa(o, "GetProductsRequest");
+    return __isa(o, "GetProductsRequest");
   }
 }
 
@@ -242,12 +246,12 @@ export interface GetProductsResponse extends $MetadataBearer {
    * <p>The list of products that match your filters. The list contains both the product metadata and
    *          the price information.</p>
    */
-  PriceList?: Array<string>;
+  PriceList?: Array<__LazyJsonString | string>;
 }
 
 export namespace GetProductsResponse {
   export function isa(o: any): o is GetProductsResponse {
-    return _smithy.isa(o, "GetProductsResponse");
+    return __isa(o, "GetProductsResponse");
   }
 }
 
@@ -255,7 +259,7 @@ export namespace GetProductsResponse {
  * <p>An error on the server occurred during the processing of your request. Try again later.</p>
  */
 export interface InternalErrorException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalErrorException";
   $fault: "server";
@@ -264,7 +268,7 @@ export interface InternalErrorException
 
 export namespace InternalErrorException {
   export function isa(o: any): o is InternalErrorException {
-    return _smithy.isa(o, "InternalErrorException");
+    return __isa(o, "InternalErrorException");
   }
 }
 
@@ -272,7 +276,7 @@ export namespace InternalErrorException {
  * <p>The pagination token is invalid. Try again without a pagination token.</p>
  */
 export interface InvalidNextTokenException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidNextTokenException";
   $fault: "client";
@@ -281,7 +285,7 @@ export interface InvalidNextTokenException
 
 export namespace InvalidNextTokenException {
   export function isa(o: any): o is InvalidNextTokenException {
-    return _smithy.isa(o, "InvalidNextTokenException");
+    return __isa(o, "InvalidNextTokenException");
   }
 }
 
@@ -289,7 +293,7 @@ export namespace InvalidNextTokenException {
  * <p>One or more parameters had an invalid value.</p>
  */
 export interface InvalidParameterException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidParameterException";
   $fault: "client";
@@ -298,16 +302,14 @@ export interface InvalidParameterException
 
 export namespace InvalidParameterException {
   export function isa(o: any): o is InvalidParameterException {
-    return _smithy.isa(o, "InvalidParameterException");
+    return __isa(o, "InvalidParameterException");
   }
 }
 
 /**
  * <p>The requested resource can't be found.</p>
  */
-export interface NotFoundException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface NotFoundException extends __SmithyException, $MetadataBearer {
   name: "NotFoundException";
   $fault: "client";
   Message?: string;
@@ -315,7 +317,7 @@ export interface NotFoundException
 
 export namespace NotFoundException {
   export function isa(o: any): o is NotFoundException {
-    return _smithy.isa(o, "NotFoundException");
+    return __isa(o, "NotFoundException");
   }
 }
 
@@ -337,6 +339,6 @@ export interface Service {
 
 export namespace Service {
   export function isa(o: any): o is Service {
-    return _smithy.isa(o, "Service");
+    return __isa(o, "Service");
   }
 }

--- a/clients/client-pricing/protocols/Aws_json1_1.ts
+++ b/clients/client-pricing/protocols/Aws_json1_1.ts
@@ -30,7 +30,10 @@ import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  LazyJsonString as __LazyJsonString,
+  SmithyException as __SmithyException
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -685,8 +688,8 @@ const deserializeAws_json1_1NotFoundException = (
 const deserializeAws_json1_1PriceList = (
   output: any,
   context: __SerdeContext
-): Array<string> => {
-  return (output || []).map((entry: any) => entry);
+): Array<__LazyJsonString | string> => {
+  return (output || []).map((entry: any) => new __LazyJsonString(entry));
 };
 
 const deserializeAws_json1_1Service = (

--- a/clients/client-qldb-session/models/index.ts
+++ b/clients/client-qldb-session/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -10,7 +13,7 @@ export interface AbortTransactionRequest {
 
 export namespace AbortTransactionRequest {
   export function isa(o: any): o is AbortTransactionRequest {
-    return _smithy.isa(o, "AbortTransactionRequest");
+    return __isa(o, "AbortTransactionRequest");
   }
 }
 
@@ -23,7 +26,7 @@ export interface AbortTransactionResult {
 
 export namespace AbortTransactionResult {
   export function isa(o: any): o is AbortTransactionResult {
-    return _smithy.isa(o, "AbortTransactionResult");
+    return __isa(o, "AbortTransactionResult");
   }
 }
 
@@ -31,7 +34,7 @@ export namespace AbortTransactionResult {
  * <p>Returned if the request is malformed or contains an error such as an invalid parameter value or a missing required parameter.</p>
  */
 export interface BadRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "BadRequestException";
   $fault: "client";
@@ -41,7 +44,7 @@ export interface BadRequestException
 
 export namespace BadRequestException {
   export function isa(o: any): o is BadRequestException {
-    return _smithy.isa(o, "BadRequestException");
+    return __isa(o, "BadRequestException");
   }
 }
 
@@ -66,7 +69,7 @@ export interface CommitTransactionRequest {
 
 export namespace CommitTransactionRequest {
   export function isa(o: any): o is CommitTransactionRequest {
-    return _smithy.isa(o, "CommitTransactionRequest");
+    return __isa(o, "CommitTransactionRequest");
   }
 }
 
@@ -88,7 +91,7 @@ export interface CommitTransactionResult {
 
 export namespace CommitTransactionResult {
   export function isa(o: any): o is CommitTransactionResult {
-    return _smithy.isa(o, "CommitTransactionResult");
+    return __isa(o, "CommitTransactionResult");
   }
 }
 
@@ -101,7 +104,7 @@ export interface EndSessionRequest {
 
 export namespace EndSessionRequest {
   export function isa(o: any): o is EndSessionRequest {
-    return _smithy.isa(o, "EndSessionRequest");
+    return __isa(o, "EndSessionRequest");
   }
 }
 
@@ -114,7 +117,7 @@ export interface EndSessionResult {
 
 export namespace EndSessionResult {
   export function isa(o: any): o is EndSessionResult {
-    return _smithy.isa(o, "EndSessionResult");
+    return __isa(o, "EndSessionResult");
   }
 }
 
@@ -141,7 +144,7 @@ export interface ExecuteStatementRequest {
 
 export namespace ExecuteStatementRequest {
   export function isa(o: any): o is ExecuteStatementRequest {
-    return _smithy.isa(o, "ExecuteStatementRequest");
+    return __isa(o, "ExecuteStatementRequest");
   }
 }
 
@@ -158,7 +161,7 @@ export interface ExecuteStatementResult {
 
 export namespace ExecuteStatementResult {
   export function isa(o: any): o is ExecuteStatementResult {
-    return _smithy.isa(o, "ExecuteStatementResult");
+    return __isa(o, "ExecuteStatementResult");
   }
 }
 
@@ -180,7 +183,7 @@ export interface FetchPageRequest {
 
 export namespace FetchPageRequest {
   export function isa(o: any): o is FetchPageRequest {
-    return _smithy.isa(o, "FetchPageRequest");
+    return __isa(o, "FetchPageRequest");
   }
 }
 
@@ -197,7 +200,7 @@ export interface FetchPageResult {
 
 export namespace FetchPageResult {
   export function isa(o: any): o is FetchPageResult {
-    return _smithy.isa(o, "FetchPageResult");
+    return __isa(o, "FetchPageResult");
   }
 }
 
@@ -205,7 +208,7 @@ export namespace FetchPageResult {
  * <p>Returned if the session doesn't exist anymore because it timed-out or expired.</p>
  */
 export interface InvalidSessionException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidSessionException";
   $fault: "client";
@@ -215,7 +218,7 @@ export interface InvalidSessionException
 
 export namespace InvalidSessionException {
   export function isa(o: any): o is InvalidSessionException {
-    return _smithy.isa(o, "InvalidSessionException");
+    return __isa(o, "InvalidSessionException");
   }
 }
 
@@ -223,7 +226,7 @@ export namespace InvalidSessionException {
  * <p>Returned if a resource limit such as number of active sessions is exceeded.</p>
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -232,7 +235,7 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
@@ -240,7 +243,7 @@ export namespace LimitExceededException {
  * <p>Returned when a transaction cannot be written to the journal due to a failure in the verification phase of Optimistic Concurrency Control.</p>
  */
 export interface OccConflictException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "OccConflictException";
   $fault: "client";
@@ -249,7 +252,7 @@ export interface OccConflictException
 
 export namespace OccConflictException {
   export function isa(o: any): o is OccConflictException {
-    return _smithy.isa(o, "OccConflictException");
+    return __isa(o, "OccConflictException");
   }
 }
 
@@ -271,7 +274,7 @@ export interface Page {
 
 export namespace Page {
   export function isa(o: any): o is Page {
-    return _smithy.isa(o, "Page");
+    return __isa(o, "Page");
   }
 }
 
@@ -279,7 +282,7 @@ export namespace Page {
  * <p>Returned when the rate of requests exceeds the allowed throughput.</p>
  */
 export interface RateExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "RateExceededException";
   $fault: "client";
@@ -288,7 +291,7 @@ export interface RateExceededException
 
 export namespace RateExceededException {
   export function isa(o: any): o is RateExceededException {
-    return _smithy.isa(o, "RateExceededException");
+    return __isa(o, "RateExceededException");
   }
 }
 
@@ -340,7 +343,7 @@ export interface SendCommandRequest {
 
 export namespace SendCommandRequest {
   export function isa(o: any): o is SendCommandRequest {
-    return _smithy.isa(o, "SendCommandRequest");
+    return __isa(o, "SendCommandRequest");
   }
 }
 
@@ -385,7 +388,7 @@ export interface SendCommandResult extends $MetadataBearer {
 
 export namespace SendCommandResult {
   export function isa(o: any): o is SendCommandResult {
-    return _smithy.isa(o, "SendCommandResult");
+    return __isa(o, "SendCommandResult");
   }
 }
 
@@ -402,7 +405,7 @@ export interface StartSessionRequest {
 
 export namespace StartSessionRequest {
   export function isa(o: any): o is StartSessionRequest {
-    return _smithy.isa(o, "StartSessionRequest");
+    return __isa(o, "StartSessionRequest");
   }
 }
 
@@ -420,7 +423,7 @@ export interface StartSessionResult {
 
 export namespace StartSessionResult {
   export function isa(o: any): o is StartSessionResult {
-    return _smithy.isa(o, "StartSessionResult");
+    return __isa(o, "StartSessionResult");
   }
 }
 
@@ -433,7 +436,7 @@ export interface StartTransactionRequest {
 
 export namespace StartTransactionRequest {
   export function isa(o: any): o is StartTransactionRequest {
-    return _smithy.isa(o, "StartTransactionRequest");
+    return __isa(o, "StartTransactionRequest");
   }
 }
 
@@ -450,7 +453,7 @@ export interface StartTransactionResult {
 
 export namespace StartTransactionResult {
   export function isa(o: any): o is StartTransactionResult {
-    return _smithy.isa(o, "StartTransactionResult");
+    return __isa(o, "StartTransactionResult");
   }
 }
 
@@ -472,6 +475,6 @@ export interface ValueHolder {
 
 export namespace ValueHolder {
   export function isa(o: any): o is ValueHolder {
-    return _smithy.isa(o, "ValueHolder");
+    return __isa(o, "ValueHolder");
   }
 }

--- a/clients/client-qldb/models/index.ts
+++ b/clients/client-qldb/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export interface CreateLedgerRequest {
@@ -33,7 +36,7 @@ export interface CreateLedgerRequest {
 
 export namespace CreateLedgerRequest {
   export function isa(o: any): o is CreateLedgerRequest {
-    return _smithy.isa(o, "CreateLedgerRequest");
+    return __isa(o, "CreateLedgerRequest");
   }
 }
 
@@ -73,7 +76,7 @@ export interface CreateLedgerResponse extends $MetadataBearer {
 
 export namespace CreateLedgerResponse {
   export function isa(o: any): o is CreateLedgerResponse {
-    return _smithy.isa(o, "CreateLedgerResponse");
+    return __isa(o, "CreateLedgerResponse");
   }
 }
 
@@ -87,7 +90,7 @@ export interface DeleteLedgerRequest {
 
 export namespace DeleteLedgerRequest {
   export function isa(o: any): o is DeleteLedgerRequest {
-    return _smithy.isa(o, "DeleteLedgerRequest");
+    return __isa(o, "DeleteLedgerRequest");
   }
 }
 
@@ -106,7 +109,7 @@ export interface DescribeJournalS3ExportRequest {
 
 export namespace DescribeJournalS3ExportRequest {
   export function isa(o: any): o is DescribeJournalS3ExportRequest {
-    return _smithy.isa(o, "DescribeJournalS3ExportRequest");
+    return __isa(o, "DescribeJournalS3ExportRequest");
   }
 }
 
@@ -121,7 +124,7 @@ export interface DescribeJournalS3ExportResponse extends $MetadataBearer {
 
 export namespace DescribeJournalS3ExportResponse {
   export function isa(o: any): o is DescribeJournalS3ExportResponse {
-    return _smithy.isa(o, "DescribeJournalS3ExportResponse");
+    return __isa(o, "DescribeJournalS3ExportResponse");
   }
 }
 
@@ -135,7 +138,7 @@ export interface DescribeLedgerRequest {
 
 export namespace DescribeLedgerRequest {
   export function isa(o: any): o is DescribeLedgerRequest {
-    return _smithy.isa(o, "DescribeLedgerRequest");
+    return __isa(o, "DescribeLedgerRequest");
   }
 }
 
@@ -175,7 +178,7 @@ export interface DescribeLedgerResponse extends $MetadataBearer {
 
 export namespace DescribeLedgerResponse {
   export function isa(o: any): o is DescribeLedgerResponse {
-    return _smithy.isa(o, "DescribeLedgerResponse");
+    return __isa(o, "DescribeLedgerResponse");
   }
 }
 
@@ -236,7 +239,7 @@ export interface ExportJournalToS3Request {
 
 export namespace ExportJournalToS3Request {
   export function isa(o: any): o is ExportJournalToS3Request {
-    return _smithy.isa(o, "ExportJournalToS3Request");
+    return __isa(o, "ExportJournalToS3Request");
   }
 }
 
@@ -252,7 +255,7 @@ export interface ExportJournalToS3Response extends $MetadataBearer {
 
 export namespace ExportJournalToS3Response {
   export function isa(o: any): o is ExportJournalToS3Response {
-    return _smithy.isa(o, "ExportJournalToS3Response");
+    return __isa(o, "ExportJournalToS3Response");
   }
 }
 
@@ -289,7 +292,7 @@ export interface GetBlockRequest {
 
 export namespace GetBlockRequest {
   export function isa(o: any): o is GetBlockRequest {
-    return _smithy.isa(o, "GetBlockRequest");
+    return __isa(o, "GetBlockRequest");
   }
 }
 
@@ -310,7 +313,7 @@ export interface GetBlockResponse extends $MetadataBearer {
 
 export namespace GetBlockResponse {
   export function isa(o: any): o is GetBlockResponse {
-    return _smithy.isa(o, "GetBlockResponse");
+    return __isa(o, "GetBlockResponse");
   }
 }
 
@@ -324,7 +327,7 @@ export interface GetDigestRequest {
 
 export namespace GetDigestRequest {
   export function isa(o: any): o is GetDigestRequest {
-    return _smithy.isa(o, "GetDigestRequest");
+    return __isa(o, "GetDigestRequest");
   }
 }
 
@@ -346,7 +349,7 @@ export interface GetDigestResponse extends $MetadataBearer {
 
 export namespace GetDigestResponse {
   export function isa(o: any): o is GetDigestResponse {
-    return _smithy.isa(o, "GetDigestResponse");
+    return __isa(o, "GetDigestResponse");
   }
 }
 
@@ -382,7 +385,7 @@ export interface GetRevisionRequest {
 
 export namespace GetRevisionRequest {
   export function isa(o: any): o is GetRevisionRequest {
-    return _smithy.isa(o, "GetRevisionRequest");
+    return __isa(o, "GetRevisionRequest");
   }
 }
 
@@ -403,7 +406,7 @@ export interface GetRevisionResponse extends $MetadataBearer {
 
 export namespace GetRevisionResponse {
   export function isa(o: any): o is GetRevisionResponse {
-    return _smithy.isa(o, "GetRevisionResponse");
+    return __isa(o, "GetRevisionResponse");
   }
 }
 
@@ -411,7 +414,7 @@ export namespace GetRevisionResponse {
  * <p>One or more parameters in the request aren't valid.</p>
  */
 export interface InvalidParameterException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidParameterException";
   $fault: "client";
@@ -424,7 +427,7 @@ export interface InvalidParameterException
 
 export namespace InvalidParameterException {
   export function isa(o: any): o is InvalidParameterException {
-    return _smithy.isa(o, "InvalidParameterException");
+    return __isa(o, "InvalidParameterException");
   }
 }
 
@@ -491,7 +494,7 @@ export interface JournalS3ExportDescription {
 
 export namespace JournalS3ExportDescription {
   export function isa(o: any): o is JournalS3ExportDescription {
-    return _smithy.isa(o, "JournalS3ExportDescription");
+    return __isa(o, "JournalS3ExportDescription");
   }
 }
 
@@ -526,7 +529,7 @@ export interface LedgerSummary {
 
 export namespace LedgerSummary {
   export function isa(o: any): o is LedgerSummary {
-    return _smithy.isa(o, "LedgerSummary");
+    return __isa(o, "LedgerSummary");
   }
 }
 
@@ -534,7 +537,7 @@ export namespace LedgerSummary {
  * <p>You have reached the limit on the maximum number of resources allowed.</p>
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -547,7 +550,7 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
@@ -576,7 +579,7 @@ export interface ListJournalS3ExportsForLedgerRequest {
 
 export namespace ListJournalS3ExportsForLedgerRequest {
   export function isa(o: any): o is ListJournalS3ExportsForLedgerRequest {
-    return _smithy.isa(o, "ListJournalS3ExportsForLedgerRequest");
+    return __isa(o, "ListJournalS3ExportsForLedgerRequest");
   }
 }
 
@@ -607,7 +610,7 @@ export interface ListJournalS3ExportsForLedgerResponse extends $MetadataBearer {
 
 export namespace ListJournalS3ExportsForLedgerResponse {
   export function isa(o: any): o is ListJournalS3ExportsForLedgerResponse {
-    return _smithy.isa(o, "ListJournalS3ExportsForLedgerResponse");
+    return __isa(o, "ListJournalS3ExportsForLedgerResponse");
   }
 }
 
@@ -630,7 +633,7 @@ export interface ListJournalS3ExportsRequest {
 
 export namespace ListJournalS3ExportsRequest {
   export function isa(o: any): o is ListJournalS3ExportsRequest {
-    return _smithy.isa(o, "ListJournalS3ExportsRequest");
+    return __isa(o, "ListJournalS3ExportsRequest");
   }
 }
 
@@ -661,7 +664,7 @@ export interface ListJournalS3ExportsResponse extends $MetadataBearer {
 
 export namespace ListJournalS3ExportsResponse {
   export function isa(o: any): o is ListJournalS3ExportsResponse {
-    return _smithy.isa(o, "ListJournalS3ExportsResponse");
+    return __isa(o, "ListJournalS3ExportsResponse");
   }
 }
 
@@ -683,7 +686,7 @@ export interface ListLedgersRequest {
 
 export namespace ListLedgersRequest {
   export function isa(o: any): o is ListLedgersRequest {
-    return _smithy.isa(o, "ListLedgersRequest");
+    return __isa(o, "ListLedgersRequest");
   }
 }
 
@@ -714,7 +717,7 @@ export interface ListLedgersResponse extends $MetadataBearer {
 
 export namespace ListLedgersResponse {
   export function isa(o: any): o is ListLedgersResponse {
-    return _smithy.isa(o, "ListLedgersResponse");
+    return __isa(o, "ListLedgersResponse");
   }
 }
 
@@ -731,7 +734,7 @@ export interface ListTagsForResourceRequest {
 
 export namespace ListTagsForResourceRequest {
   export function isa(o: any): o is ListTagsForResourceRequest {
-    return _smithy.isa(o, "ListTagsForResourceRequest");
+    return __isa(o, "ListTagsForResourceRequest");
   }
 }
 
@@ -745,7 +748,7 @@ export interface ListTagsForResourceResponse extends $MetadataBearer {
 
 export namespace ListTagsForResourceResponse {
   export function isa(o: any): o is ListTagsForResourceResponse {
-    return _smithy.isa(o, "ListTagsForResourceResponse");
+    return __isa(o, "ListTagsForResourceResponse");
   }
 }
 
@@ -757,7 +760,7 @@ export enum PermissionsMode {
  * <p>The specified resource already exists.</p>
  */
 export interface ResourceAlreadyExistsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceAlreadyExistsException";
   $fault: "client";
@@ -775,7 +778,7 @@ export interface ResourceAlreadyExistsException
 
 export namespace ResourceAlreadyExistsException {
   export function isa(o: any): o is ResourceAlreadyExistsException {
-    return _smithy.isa(o, "ResourceAlreadyExistsException");
+    return __isa(o, "ResourceAlreadyExistsException");
   }
 }
 
@@ -783,7 +786,7 @@ export namespace ResourceAlreadyExistsException {
  * <p>The specified resource can't be modified at this time.</p>
  */
 export interface ResourceInUseException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceInUseException";
   $fault: "client";
@@ -801,7 +804,7 @@ export interface ResourceInUseException
 
 export namespace ResourceInUseException {
   export function isa(o: any): o is ResourceInUseException {
-    return _smithy.isa(o, "ResourceInUseException");
+    return __isa(o, "ResourceInUseException");
   }
 }
 
@@ -809,7 +812,7 @@ export namespace ResourceInUseException {
  * <p>The specified resource doesn't exist.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -827,7 +830,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -835,7 +838,7 @@ export namespace ResourceNotFoundException {
  * <p>The operation failed because a condition wasn't satisfied in advance.</p>
  */
 export interface ResourcePreconditionNotMetException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourcePreconditionNotMetException";
   $fault: "client";
@@ -853,7 +856,7 @@ export interface ResourcePreconditionNotMetException
 
 export namespace ResourcePreconditionNotMetException {
   export function isa(o: any): o is ResourcePreconditionNotMetException {
-    return _smithy.isa(o, "ResourcePreconditionNotMetException");
+    return __isa(o, "ResourcePreconditionNotMetException");
   }
 }
 
@@ -885,7 +888,7 @@ export interface S3EncryptionConfiguration {
 
 export namespace S3EncryptionConfiguration {
   export function isa(o: any): o is S3EncryptionConfiguration {
-    return _smithy.isa(o, "S3EncryptionConfiguration");
+    return __isa(o, "S3EncryptionConfiguration");
   }
 }
 
@@ -939,7 +942,7 @@ export interface S3ExportConfiguration {
 
 export namespace S3ExportConfiguration {
   export function isa(o: any): o is S3ExportConfiguration {
-    return _smithy.isa(o, "S3ExportConfiguration");
+    return __isa(o, "S3ExportConfiguration");
   }
 }
 
@@ -969,7 +972,7 @@ export interface TagResourceRequest {
 
 export namespace TagResourceRequest {
   export function isa(o: any): o is TagResourceRequest {
-    return _smithy.isa(o, "TagResourceRequest");
+    return __isa(o, "TagResourceRequest");
   }
 }
 
@@ -979,7 +982,7 @@ export interface TagResourceResponse extends $MetadataBearer {
 
 export namespace TagResourceResponse {
   export function isa(o: any): o is TagResourceResponse {
-    return _smithy.isa(o, "TagResourceResponse");
+    return __isa(o, "TagResourceResponse");
   }
 }
 
@@ -1002,7 +1005,7 @@ export interface UntagResourceRequest {
 
 export namespace UntagResourceRequest {
   export function isa(o: any): o is UntagResourceRequest {
-    return _smithy.isa(o, "UntagResourceRequest");
+    return __isa(o, "UntagResourceRequest");
   }
 }
 
@@ -1012,7 +1015,7 @@ export interface UntagResourceResponse extends $MetadataBearer {
 
 export namespace UntagResourceResponse {
   export function isa(o: any): o is UntagResourceResponse {
-    return _smithy.isa(o, "UntagResourceResponse");
+    return __isa(o, "UntagResourceResponse");
   }
 }
 
@@ -1036,7 +1039,7 @@ export interface UpdateLedgerRequest {
 
 export namespace UpdateLedgerRequest {
   export function isa(o: any): o is UpdateLedgerRequest {
-    return _smithy.isa(o, "UpdateLedgerRequest");
+    return __isa(o, "UpdateLedgerRequest");
   }
 }
 
@@ -1076,7 +1079,7 @@ export interface UpdateLedgerResponse extends $MetadataBearer {
 
 export namespace UpdateLedgerResponse {
   export function isa(o: any): o is UpdateLedgerResponse {
-    return _smithy.isa(o, "UpdateLedgerResponse");
+    return __isa(o, "UpdateLedgerResponse");
   }
 }
 
@@ -1093,6 +1096,6 @@ export interface ValueHolder {
 
 export namespace ValueHolder {
   export function isa(o: any): o is ValueHolder {
-    return _smithy.isa(o, "ValueHolder");
+    return __isa(o, "ValueHolder");
   }
 }

--- a/clients/client-qldb/protocols/Aws_restJson1_1.ts
+++ b/clients/client-qldb/protocols/Aws_restJson1_1.ts
@@ -75,7 +75,10 @@ import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  extendedEncodeURIComponent as __extendedEncodeURIComponent
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -123,13 +126,13 @@ export async function serializeAws_restJson1_1DeleteLedgerCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/ledgers/{Name}";
   if (input.Name !== undefined) {
-    const labelValue: string = input.Name.toString();
+    const labelValue: string = input.Name;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Name.");
     }
     resolvedPath = resolvedPath.replace(
       "{Name}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Name.");
@@ -151,25 +154,25 @@ export async function serializeAws_restJson1_1DescribeJournalS3ExportCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/ledgers/{Name}/journal-s3-exports/{ExportId}";
   if (input.ExportId !== undefined) {
-    const labelValue: string = input.ExportId.toString();
+    const labelValue: string = input.ExportId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ExportId.");
     }
     resolvedPath = resolvedPath.replace(
       "{ExportId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ExportId.");
   }
   if (input.Name !== undefined) {
-    const labelValue: string = input.Name.toString();
+    const labelValue: string = input.Name;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Name.");
     }
     resolvedPath = resolvedPath.replace(
       "{Name}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Name.");
@@ -191,13 +194,13 @@ export async function serializeAws_restJson1_1DescribeLedgerCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/ledgers/{Name}";
   if (input.Name !== undefined) {
-    const labelValue: string = input.Name.toString();
+    const labelValue: string = input.Name;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Name.");
     }
     resolvedPath = resolvedPath.replace(
       "{Name}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Name.");
@@ -219,13 +222,13 @@ export async function serializeAws_restJson1_1ExportJournalToS3Command(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/ledgers/{Name}/journal-s3-exports";
   if (input.Name !== undefined) {
-    const labelValue: string = input.Name.toString();
+    const labelValue: string = input.Name;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Name.");
     }
     resolvedPath = resolvedPath.replace(
       "{Name}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Name.");
@@ -272,13 +275,13 @@ export async function serializeAws_restJson1_1GetBlockCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/ledgers/{Name}/block";
   if (input.Name !== undefined) {
-    const labelValue: string = input.Name.toString();
+    const labelValue: string = input.Name;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Name.");
     }
     resolvedPath = resolvedPath.replace(
       "{Name}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Name.");
@@ -316,13 +319,13 @@ export async function serializeAws_restJson1_1GetDigestCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/ledgers/{Name}/digest";
   if (input.Name !== undefined) {
-    const labelValue: string = input.Name.toString();
+    const labelValue: string = input.Name;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Name.");
     }
     resolvedPath = resolvedPath.replace(
       "{Name}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Name.");
@@ -344,13 +347,13 @@ export async function serializeAws_restJson1_1GetRevisionCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/ledgers/{Name}/revision";
   if (input.Name !== undefined) {
-    const labelValue: string = input.Name.toString();
+    const labelValue: string = input.Name;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Name.");
     }
     resolvedPath = resolvedPath.replace(
       "{Name}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Name.");
@@ -392,10 +395,14 @@ export async function serializeAws_restJson1_1ListJournalS3ExportsCommand(
   let resolvedPath = "/journal-s3-exports";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["max_results"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("max_results")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["next_token"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("next_token")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -415,23 +422,27 @@ export async function serializeAws_restJson1_1ListJournalS3ExportsForLedgerComma
   headers["Content-Type"] = "";
   let resolvedPath = "/ledgers/{Name}/journal-s3-exports";
   if (input.Name !== undefined) {
-    const labelValue: string = input.Name.toString();
+    const labelValue: string = input.Name;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Name.");
     }
     resolvedPath = resolvedPath.replace(
       "{Name}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Name.");
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["max_results"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("max_results")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["next_token"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("next_token")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -452,10 +463,14 @@ export async function serializeAws_restJson1_1ListLedgersCommand(
   let resolvedPath = "/ledgers";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["max_results"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("max_results")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["next_token"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("next_token")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -475,7 +490,7 @@ export async function serializeAws_restJson1_1ListTagsForResourceCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/tags/{ResourceArn}";
   if (input.ResourceArn !== undefined) {
-    const labelValue: string = input.ResourceArn.toString();
+    const labelValue: string = input.ResourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ResourceArn."
@@ -483,7 +498,7 @@ export async function serializeAws_restJson1_1ListTagsForResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ResourceArn.");
@@ -505,7 +520,7 @@ export async function serializeAws_restJson1_1TagResourceCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/tags/{ResourceArn}";
   if (input.ResourceArn !== undefined) {
-    const labelValue: string = input.ResourceArn.toString();
+    const labelValue: string = input.ResourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ResourceArn."
@@ -513,7 +528,7 @@ export async function serializeAws_restJson1_1TagResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ResourceArn.");
@@ -542,7 +557,7 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/tags/{ResourceArn}";
   if (input.ResourceArn !== undefined) {
-    const labelValue: string = input.ResourceArn.toString();
+    const labelValue: string = input.ResourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ResourceArn."
@@ -550,14 +565,16 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ResourceArn.");
   }
   const query: any = {};
   if (input.TagKeys !== undefined) {
-    query["tagKeys"] = input.TagKeys;
+    query[__extendedEncodeURIComponent("tagKeys")] = input.TagKeys.map(entry =>
+      __extendedEncodeURIComponent(entry)
+    );
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -577,13 +594,13 @@ export async function serializeAws_restJson1_1UpdateLedgerCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/ledgers/{Name}";
   if (input.Name !== undefined) {
-    const labelValue: string = input.Name.toString();
+    const labelValue: string = input.Name;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Name.");
     }
     resolvedPath = resolvedPath.replace(
       "{Name}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Name.");
@@ -709,6 +726,7 @@ export async function deserializeAws_restJson1_1DeleteLedgerCommand(
   const contents: DeleteLedgerCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -1431,6 +1449,7 @@ export async function deserializeAws_restJson1_1TagResourceCommand(
     $metadata: deserializeMetadata(output),
     __type: "TagResourceResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -1486,6 +1505,7 @@ export async function deserializeAws_restJson1_1UntagResourceCommand(
     $metadata: deserializeMetadata(output),
     __type: "UntagResourceResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 

--- a/clients/client-quicksight/models/index.ts
+++ b/clients/client-quicksight/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -19,7 +22,7 @@ export interface ActiveIAMPolicyAssignment {
 
 export namespace ActiveIAMPolicyAssignment {
   export function isa(o: any): o is ActiveIAMPolicyAssignment {
-    return _smithy.isa(o, "ActiveIAMPolicyAssignment");
+    return __isa(o, "ActiveIAMPolicyAssignment");
   }
 }
 
@@ -36,7 +39,7 @@ export interface AdHocFilteringOption {
 
 export namespace AdHocFilteringOption {
   export function isa(o: any): o is AdHocFilteringOption {
-    return _smithy.isa(o, "AdHocFilteringOption");
+    return __isa(o, "AdHocFilteringOption");
   }
 }
 
@@ -53,7 +56,7 @@ export interface AmazonElasticsearchParameters {
 
 export namespace AmazonElasticsearchParameters {
   export function isa(o: any): o is AmazonElasticsearchParameters {
-    return _smithy.isa(o, "AmazonElasticsearchParameters");
+    return __isa(o, "AmazonElasticsearchParameters");
   }
 }
 
@@ -76,7 +79,7 @@ export interface AthenaParameters {
 
 export namespace AthenaParameters {
   export function isa(o: any): o is AthenaParameters {
-    return _smithy.isa(o, "AthenaParameters");
+    return __isa(o, "AthenaParameters");
   }
 }
 
@@ -103,7 +106,7 @@ export interface AuroraParameters {
 
 export namespace AuroraParameters {
   export function isa(o: any): o is AuroraParameters {
-    return _smithy.isa(o, "AuroraParameters");
+    return __isa(o, "AuroraParameters");
   }
 }
 
@@ -130,7 +133,7 @@ export interface AuroraPostgreSqlParameters {
 
 export namespace AuroraPostgreSqlParameters {
   export function isa(o: any): o is AuroraPostgreSqlParameters {
-    return _smithy.isa(o, "AuroraPostgreSqlParameters");
+    return __isa(o, "AuroraPostgreSqlParameters");
   }
 }
 
@@ -147,7 +150,7 @@ export interface AwsIotAnalyticsParameters {
 
 export namespace AwsIotAnalyticsParameters {
   export function isa(o: any): o is AwsIotAnalyticsParameters {
-    return _smithy.isa(o, "AwsIotAnalyticsParameters");
+    return __isa(o, "AwsIotAnalyticsParameters");
   }
 }
 
@@ -176,7 +179,7 @@ export interface CalculatedColumn {
 
 export namespace CalculatedColumn {
   export function isa(o: any): o is CalculatedColumn {
-    return _smithy.isa(o, "CalculatedColumn");
+    return __isa(o, "CalculatedColumn");
   }
 }
 
@@ -200,7 +203,7 @@ export interface CancelIngestionRequest {
 
 export namespace CancelIngestionRequest {
   export function isa(o: any): o is CancelIngestionRequest {
-    return _smithy.isa(o, "CancelIngestionRequest");
+    return __isa(o, "CancelIngestionRequest");
   }
 }
 
@@ -224,7 +227,7 @@ export interface CancelIngestionResponse extends $MetadataBearer {
 
 export namespace CancelIngestionResponse {
   export function isa(o: any): o is CancelIngestionResponse {
-    return _smithy.isa(o, "CancelIngestionResponse");
+    return __isa(o, "CancelIngestionResponse");
   }
 }
 
@@ -252,7 +255,7 @@ export interface CastColumnTypeOperation {
 
 export namespace CastColumnTypeOperation {
   export function isa(o: any): o is CastColumnTypeOperation {
-    return _smithy.isa(o, "CastColumnTypeOperation");
+    return __isa(o, "CastColumnTypeOperation");
   }
 }
 
@@ -271,7 +274,7 @@ export interface ColumnGroup {
 
 export namespace ColumnGroup {
   export function isa(o: any): o is ColumnGroup {
-    return _smithy.isa(o, "ColumnGroup");
+    return __isa(o, "ColumnGroup");
   }
 }
 
@@ -288,7 +291,7 @@ export interface ColumnGroupColumnSchema {
 
 export namespace ColumnGroupColumnSchema {
   export function isa(o: any): o is ColumnGroupColumnSchema {
-    return _smithy.isa(o, "ColumnGroupColumnSchema");
+    return __isa(o, "ColumnGroupColumnSchema");
   }
 }
 
@@ -310,7 +313,7 @@ export interface ColumnGroupSchema {
 
 export namespace ColumnGroupSchema {
   export function isa(o: any): o is ColumnGroupSchema {
-    return _smithy.isa(o, "ColumnGroupSchema");
+    return __isa(o, "ColumnGroupSchema");
   }
 }
 
@@ -337,7 +340,7 @@ export interface ColumnSchema {
 
 export namespace ColumnSchema {
   export function isa(o: any): o is ColumnSchema {
-    return _smithy.isa(o, "ColumnSchema");
+    return __isa(o, "ColumnSchema");
   }
 }
 
@@ -356,7 +359,7 @@ export interface ColumnTag {
 
 export namespace ColumnTag {
   export function isa(o: any): o is ColumnTag {
-    return _smithy.isa(o, "ColumnTag");
+    return __isa(o, "ColumnTag");
   }
 }
 
@@ -365,7 +368,7 @@ export namespace ColumnTag {
  * 			before a new update can be applied.</p>
  */
 export interface ConcurrentUpdatingException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ConcurrentUpdatingException";
   $fault: "server";
@@ -375,7 +378,7 @@ export interface ConcurrentUpdatingException
 
 export namespace ConcurrentUpdatingException {
   export function isa(o: any): o is ConcurrentUpdatingException {
-    return _smithy.isa(o, "ConcurrentUpdatingException");
+    return __isa(o, "ConcurrentUpdatingException");
   }
 }
 
@@ -393,7 +396,7 @@ export interface CreateColumnsOperation {
 
 export namespace CreateColumnsOperation {
   export function isa(o: any): o is CreateColumnsOperation {
-    return _smithy.isa(o, "CreateColumnsOperation");
+    return __isa(o, "CreateColumnsOperation");
   }
 }
 
@@ -483,7 +486,7 @@ export interface CreateDashboardRequest {
 
 export namespace CreateDashboardRequest {
   export function isa(o: any): o is CreateDashboardRequest {
-    return _smithy.isa(o, "CreateDashboardRequest");
+    return __isa(o, "CreateDashboardRequest");
   }
 }
 
@@ -518,7 +521,7 @@ export interface CreateDashboardResponse extends $MetadataBearer {
 
 export namespace CreateDashboardResponse {
   export function isa(o: any): o is CreateDashboardResponse {
-    return _smithy.isa(o, "CreateDashboardResponse");
+    return __isa(o, "CreateDashboardResponse");
   }
 }
 
@@ -577,7 +580,7 @@ export interface CreateDataSetRequest {
 
 export namespace CreateDataSetRequest {
   export function isa(o: any): o is CreateDataSetRequest {
-    return _smithy.isa(o, "CreateDataSetRequest");
+    return __isa(o, "CreateDataSetRequest");
   }
 }
 
@@ -613,7 +616,7 @@ export interface CreateDataSetResponse extends $MetadataBearer {
 
 export namespace CreateDataSetResponse {
   export function isa(o: any): o is CreateDataSetResponse {
-    return _smithy.isa(o, "CreateDataSetResponse");
+    return __isa(o, "CreateDataSetResponse");
   }
 }
 
@@ -678,7 +681,7 @@ export interface CreateDataSourceRequest {
 
 export namespace CreateDataSourceRequest {
   export function isa(o: any): o is CreateDataSourceRequest {
-    return _smithy.isa(o, "CreateDataSourceRequest");
+    return __isa(o, "CreateDataSourceRequest");
   }
 }
 
@@ -707,7 +710,7 @@ export interface CreateDataSourceResponse extends $MetadataBearer {
 
 export namespace CreateDataSourceResponse {
   export function isa(o: any): o is CreateDataSourceResponse {
-    return _smithy.isa(o, "CreateDataSourceResponse");
+    return __isa(o, "CreateDataSourceResponse");
   }
 }
 
@@ -737,7 +740,7 @@ export interface CreateGroupMembershipRequest {
 
 export namespace CreateGroupMembershipRequest {
   export function isa(o: any): o is CreateGroupMembershipRequest {
-    return _smithy.isa(o, "CreateGroupMembershipRequest");
+    return __isa(o, "CreateGroupMembershipRequest");
   }
 }
 
@@ -756,7 +759,7 @@ export interface CreateGroupMembershipResponse extends $MetadataBearer {
 
 export namespace CreateGroupMembershipResponse {
   export function isa(o: any): o is CreateGroupMembershipResponse {
-    return _smithy.isa(o, "CreateGroupMembershipResponse");
+    return __isa(o, "CreateGroupMembershipResponse");
   }
 }
 
@@ -789,7 +792,7 @@ export interface CreateGroupRequest {
 
 export namespace CreateGroupRequest {
   export function isa(o: any): o is CreateGroupRequest {
-    return _smithy.isa(o, "CreateGroupRequest");
+    return __isa(o, "CreateGroupRequest");
   }
 }
 
@@ -811,7 +814,7 @@ export interface CreateGroupResponse extends $MetadataBearer {
 
 export namespace CreateGroupResponse {
   export function isa(o: any): o is CreateGroupResponse {
-    return _smithy.isa(o, "CreateGroupResponse");
+    return __isa(o, "CreateGroupResponse");
   }
 }
 
@@ -868,7 +871,7 @@ export interface CreateIAMPolicyAssignmentRequest {
 
 export namespace CreateIAMPolicyAssignmentRequest {
   export function isa(o: any): o is CreateIAMPolicyAssignmentRequest {
-    return _smithy.isa(o, "CreateIAMPolicyAssignmentRequest");
+    return __isa(o, "CreateIAMPolicyAssignmentRequest");
   }
 }
 
@@ -923,7 +926,7 @@ export interface CreateIAMPolicyAssignmentResponse extends $MetadataBearer {
 
 export namespace CreateIAMPolicyAssignmentResponse {
   export function isa(o: any): o is CreateIAMPolicyAssignmentResponse {
-    return _smithy.isa(o, "CreateIAMPolicyAssignmentResponse");
+    return __isa(o, "CreateIAMPolicyAssignmentResponse");
   }
 }
 
@@ -947,7 +950,7 @@ export interface CreateIngestionRequest {
 
 export namespace CreateIngestionRequest {
   export function isa(o: any): o is CreateIngestionRequest {
-    return _smithy.isa(o, "CreateIngestionRequest");
+    return __isa(o, "CreateIngestionRequest");
   }
 }
 
@@ -976,7 +979,7 @@ export interface CreateIngestionResponse extends $MetadataBearer {
 
 export namespace CreateIngestionResponse {
   export function isa(o: any): o is CreateIngestionResponse {
-    return _smithy.isa(o, "CreateIngestionResponse");
+    return __isa(o, "CreateIngestionResponse");
   }
 }
 
@@ -1007,7 +1010,7 @@ export interface CreateTemplateAliasRequest {
 
 export namespace CreateTemplateAliasRequest {
   export function isa(o: any): o is CreateTemplateAliasRequest {
-    return _smithy.isa(o, "CreateTemplateAliasRequest");
+    return __isa(o, "CreateTemplateAliasRequest");
   }
 }
 
@@ -1026,7 +1029,7 @@ export interface CreateTemplateAliasResponse extends $MetadataBearer {
 
 export namespace CreateTemplateAliasResponse {
   export function isa(o: any): o is CreateTemplateAliasResponse {
-    return _smithy.isa(o, "CreateTemplateAliasResponse");
+    return __isa(o, "CreateTemplateAliasResponse");
   }
 }
 
@@ -1077,7 +1080,7 @@ export interface CreateTemplateRequest {
 
 export namespace CreateTemplateRequest {
   export function isa(o: any): o is CreateTemplateRequest {
-    return _smithy.isa(o, "CreateTemplateRequest");
+    return __isa(o, "CreateTemplateRequest");
   }
 }
 
@@ -1112,7 +1115,7 @@ export interface CreateTemplateResponse extends $MetadataBearer {
 
 export namespace CreateTemplateResponse {
   export function isa(o: any): o is CreateTemplateResponse {
-    return _smithy.isa(o, "CreateTemplateResponse");
+    return __isa(o, "CreateTemplateResponse");
   }
 }
 
@@ -1134,7 +1137,7 @@ export interface CredentialPair {
 
 export namespace CredentialPair {
   export function isa(o: any): o is CredentialPair {
-    return _smithy.isa(o, "CredentialPair");
+    return __isa(o, "CredentialPair");
   }
 }
 
@@ -1166,7 +1169,7 @@ export interface CustomSql {
 
 export namespace CustomSql {
   export function isa(o: any): o is CustomSql {
-    return _smithy.isa(o, "CustomSql");
+    return __isa(o, "CustomSql");
   }
 }
 
@@ -1213,7 +1216,7 @@ export interface Dashboard {
 
 export namespace Dashboard {
   export function isa(o: any): o is Dashboard {
-    return _smithy.isa(o, "Dashboard");
+    return __isa(o, "Dashboard");
   }
 }
 
@@ -1240,7 +1243,7 @@ export interface DashboardError {
 
 export namespace DashboardError {
   export function isa(o: any): o is DashboardError {
-    return _smithy.isa(o, "DashboardError");
+    return __isa(o, "DashboardError");
   }
 }
 
@@ -1278,7 +1281,7 @@ export interface DashboardPublishOptions {
 
 export namespace DashboardPublishOptions {
   export function isa(o: any): o is DashboardPublishOptions {
-    return _smithy.isa(o, "DashboardPublishOptions");
+    return __isa(o, "DashboardPublishOptions");
   }
 }
 
@@ -1295,7 +1298,7 @@ export interface DashboardSourceEntity {
 
 export namespace DashboardSourceEntity {
   export function isa(o: any): o is DashboardSourceEntity {
-    return _smithy.isa(o, "DashboardSourceEntity");
+    return __isa(o, "DashboardSourceEntity");
   }
 }
 
@@ -1317,7 +1320,7 @@ export interface DashboardSourceTemplate {
 
 export namespace DashboardSourceTemplate {
   export function isa(o: any): o is DashboardSourceTemplate {
-    return _smithy.isa(o, "DashboardSourceTemplate");
+    return __isa(o, "DashboardSourceTemplate");
   }
 }
 
@@ -1364,7 +1367,7 @@ export interface DashboardSummary {
 
 export namespace DashboardSummary {
   export function isa(o: any): o is DashboardSummary {
-    return _smithy.isa(o, "DashboardSummary");
+    return __isa(o, "DashboardSummary");
   }
 }
 
@@ -1416,7 +1419,7 @@ export interface DashboardVersion {
 
 export namespace DashboardVersion {
   export function isa(o: any): o is DashboardVersion {
-    return _smithy.isa(o, "DashboardVersion");
+    return __isa(o, "DashboardVersion");
   }
 }
 
@@ -1458,7 +1461,7 @@ export interface DashboardVersionSummary {
 
 export namespace DashboardVersionSummary {
   export function isa(o: any): o is DashboardVersionSummary {
-    return _smithy.isa(o, "DashboardVersionSummary");
+    return __isa(o, "DashboardVersionSummary");
   }
 }
 
@@ -1534,7 +1537,7 @@ export interface DataSet {
 
 export namespace DataSet {
   export function isa(o: any): o is DataSet {
-    return _smithy.isa(o, "DataSet");
+    return __isa(o, "DataSet");
   }
 }
 
@@ -1561,7 +1564,7 @@ export interface DataSetConfiguration {
 
 export namespace DataSetConfiguration {
   export function isa(o: any): o is DataSetConfiguration {
-    return _smithy.isa(o, "DataSetConfiguration");
+    return __isa(o, "DataSetConfiguration");
   }
 }
 
@@ -1588,7 +1591,7 @@ export interface DataSetReference {
 
 export namespace DataSetReference {
   export function isa(o: any): o is DataSetReference {
-    return _smithy.isa(o, "DataSetReference");
+    return __isa(o, "DataSetReference");
   }
 }
 
@@ -1605,7 +1608,7 @@ export interface DataSetSchema {
 
 export namespace DataSetSchema {
   export function isa(o: any): o is DataSetSchema {
-    return _smithy.isa(o, "DataSetSchema");
+    return __isa(o, "DataSetSchema");
   }
 }
 
@@ -1652,7 +1655,7 @@ export interface DataSetSummary {
 
 export namespace DataSetSummary {
   export function isa(o: any): o is DataSetSummary {
-    return _smithy.isa(o, "DataSetSummary");
+    return __isa(o, "DataSetSummary");
   }
 }
 
@@ -1724,7 +1727,7 @@ export interface DataSource {
 
 export namespace DataSource {
   export function isa(o: any): o is DataSource {
-    return _smithy.isa(o, "DataSource");
+    return __isa(o, "DataSource");
   }
 }
 
@@ -1741,7 +1744,7 @@ export interface DataSourceCredentials {
 
 export namespace DataSourceCredentials {
   export function isa(o: any): o is DataSourceCredentials {
-    return _smithy.isa(o, "DataSourceCredentials");
+    return __isa(o, "DataSourceCredentials");
   }
 }
 
@@ -1763,7 +1766,7 @@ export interface DataSourceErrorInfo {
 
 export namespace DataSourceErrorInfo {
   export function isa(o: any): o is DataSourceErrorInfo {
-    return _smithy.isa(o, "DataSourceErrorInfo");
+    return __isa(o, "DataSourceErrorInfo");
   }
 }
 
@@ -1881,7 +1884,7 @@ export interface DataSourceParameters {
 
 export namespace DataSourceParameters {
   export function isa(o: any): o is DataSourceParameters {
-    return _smithy.isa(o, "DataSourceParameters");
+    return __isa(o, "DataSourceParameters");
   }
 }
 
@@ -1927,7 +1930,7 @@ export interface DateTimeParameter {
 
 export namespace DateTimeParameter {
   export function isa(o: any): o is DateTimeParameter {
-    return _smithy.isa(o, "DateTimeParameter");
+    return __isa(o, "DateTimeParameter");
   }
 }
 
@@ -1949,7 +1952,7 @@ export interface DecimalParameter {
 
 export namespace DecimalParameter {
   export function isa(o: any): o is DecimalParameter {
-    return _smithy.isa(o, "DecimalParameter");
+    return __isa(o, "DecimalParameter");
   }
 }
 
@@ -1974,7 +1977,7 @@ export interface DeleteDashboardRequest {
 
 export namespace DeleteDashboardRequest {
   export function isa(o: any): o is DeleteDashboardRequest {
-    return _smithy.isa(o, "DeleteDashboardRequest");
+    return __isa(o, "DeleteDashboardRequest");
   }
 }
 
@@ -1998,7 +2001,7 @@ export interface DeleteDashboardResponse extends $MetadataBearer {
 
 export namespace DeleteDashboardResponse {
   export function isa(o: any): o is DeleteDashboardResponse {
-    return _smithy.isa(o, "DeleteDashboardResponse");
+    return __isa(o, "DeleteDashboardResponse");
   }
 }
 
@@ -2017,7 +2020,7 @@ export interface DeleteDataSetRequest {
 
 export namespace DeleteDataSetRequest {
   export function isa(o: any): o is DeleteDataSetRequest {
-    return _smithy.isa(o, "DeleteDataSetRequest");
+    return __isa(o, "DeleteDataSetRequest");
   }
 }
 
@@ -2041,7 +2044,7 @@ export interface DeleteDataSetResponse extends $MetadataBearer {
 
 export namespace DeleteDataSetResponse {
   export function isa(o: any): o is DeleteDataSetResponse {
-    return _smithy.isa(o, "DeleteDataSetResponse");
+    return __isa(o, "DeleteDataSetResponse");
   }
 }
 
@@ -2060,7 +2063,7 @@ export interface DeleteDataSourceRequest {
 
 export namespace DeleteDataSourceRequest {
   export function isa(o: any): o is DeleteDataSourceRequest {
-    return _smithy.isa(o, "DeleteDataSourceRequest");
+    return __isa(o, "DeleteDataSourceRequest");
   }
 }
 
@@ -2084,7 +2087,7 @@ export interface DeleteDataSourceResponse extends $MetadataBearer {
 
 export namespace DeleteDataSourceResponse {
   export function isa(o: any): o is DeleteDataSourceResponse {
-    return _smithy.isa(o, "DeleteDataSourceResponse");
+    return __isa(o, "DeleteDataSourceResponse");
   }
 }
 
@@ -2114,7 +2117,7 @@ export interface DeleteGroupMembershipRequest {
 
 export namespace DeleteGroupMembershipRequest {
   export function isa(o: any): o is DeleteGroupMembershipRequest {
-    return _smithy.isa(o, "DeleteGroupMembershipRequest");
+    return __isa(o, "DeleteGroupMembershipRequest");
   }
 }
 
@@ -2128,7 +2131,7 @@ export interface DeleteGroupMembershipResponse extends $MetadataBearer {
 
 export namespace DeleteGroupMembershipResponse {
   export function isa(o: any): o is DeleteGroupMembershipResponse {
-    return _smithy.isa(o, "DeleteGroupMembershipResponse");
+    return __isa(o, "DeleteGroupMembershipResponse");
   }
 }
 
@@ -2153,7 +2156,7 @@ export interface DeleteGroupRequest {
 
 export namespace DeleteGroupRequest {
   export function isa(o: any): o is DeleteGroupRequest {
-    return _smithy.isa(o, "DeleteGroupRequest");
+    return __isa(o, "DeleteGroupRequest");
   }
 }
 
@@ -2167,7 +2170,7 @@ export interface DeleteGroupResponse extends $MetadataBearer {
 
 export namespace DeleteGroupResponse {
   export function isa(o: any): o is DeleteGroupResponse {
-    return _smithy.isa(o, "DeleteGroupResponse");
+    return __isa(o, "DeleteGroupResponse");
   }
 }
 
@@ -2191,7 +2194,7 @@ export interface DeleteIAMPolicyAssignmentRequest {
 
 export namespace DeleteIAMPolicyAssignmentRequest {
   export function isa(o: any): o is DeleteIAMPolicyAssignmentRequest {
-    return _smithy.isa(o, "DeleteIAMPolicyAssignmentRequest");
+    return __isa(o, "DeleteIAMPolicyAssignmentRequest");
   }
 }
 
@@ -2210,7 +2213,7 @@ export interface DeleteIAMPolicyAssignmentResponse extends $MetadataBearer {
 
 export namespace DeleteIAMPolicyAssignmentResponse {
   export function isa(o: any): o is DeleteIAMPolicyAssignmentResponse {
-    return _smithy.isa(o, "DeleteIAMPolicyAssignmentResponse");
+    return __isa(o, "DeleteIAMPolicyAssignmentResponse");
   }
 }
 
@@ -2237,7 +2240,7 @@ export interface DeleteTemplateAliasRequest {
 
 export namespace DeleteTemplateAliasRequest {
   export function isa(o: any): o is DeleteTemplateAliasRequest {
-    return _smithy.isa(o, "DeleteTemplateAliasRequest");
+    return __isa(o, "DeleteTemplateAliasRequest");
   }
 }
 
@@ -2266,7 +2269,7 @@ export interface DeleteTemplateAliasResponse extends $MetadataBearer {
 
 export namespace DeleteTemplateAliasResponse {
   export function isa(o: any): o is DeleteTemplateAliasResponse {
-    return _smithy.isa(o, "DeleteTemplateAliasResponse");
+    return __isa(o, "DeleteTemplateAliasResponse");
   }
 }
 
@@ -2292,7 +2295,7 @@ export interface DeleteTemplateRequest {
 
 export namespace DeleteTemplateRequest {
   export function isa(o: any): o is DeleteTemplateRequest {
-    return _smithy.isa(o, "DeleteTemplateRequest");
+    return __isa(o, "DeleteTemplateRequest");
   }
 }
 
@@ -2316,7 +2319,7 @@ export interface DeleteTemplateResponse extends $MetadataBearer {
 
 export namespace DeleteTemplateResponse {
   export function isa(o: any): o is DeleteTemplateResponse {
-    return _smithy.isa(o, "DeleteTemplateResponse");
+    return __isa(o, "DeleteTemplateResponse");
   }
 }
 
@@ -2344,7 +2347,7 @@ export interface DeleteUserByPrincipalIdRequest {
 
 export namespace DeleteUserByPrincipalIdRequest {
   export function isa(o: any): o is DeleteUserByPrincipalIdRequest {
-    return _smithy.isa(o, "DeleteUserByPrincipalIdRequest");
+    return __isa(o, "DeleteUserByPrincipalIdRequest");
   }
 }
 
@@ -2358,7 +2361,7 @@ export interface DeleteUserByPrincipalIdResponse extends $MetadataBearer {
 
 export namespace DeleteUserByPrincipalIdResponse {
   export function isa(o: any): o is DeleteUserByPrincipalIdResponse {
-    return _smithy.isa(o, "DeleteUserByPrincipalIdResponse");
+    return __isa(o, "DeleteUserByPrincipalIdResponse");
   }
 }
 
@@ -2383,7 +2386,7 @@ export interface DeleteUserRequest {
 
 export namespace DeleteUserRequest {
   export function isa(o: any): o is DeleteUserRequest {
-    return _smithy.isa(o, "DeleteUserRequest");
+    return __isa(o, "DeleteUserRequest");
   }
 }
 
@@ -2397,7 +2400,7 @@ export interface DeleteUserResponse extends $MetadataBearer {
 
 export namespace DeleteUserResponse {
   export function isa(o: any): o is DeleteUserResponse {
-    return _smithy.isa(o, "DeleteUserResponse");
+    return __isa(o, "DeleteUserResponse");
   }
 }
 
@@ -2417,7 +2420,7 @@ export interface DescribeDashboardPermissionsRequest {
 
 export namespace DescribeDashboardPermissionsRequest {
   export function isa(o: any): o is DescribeDashboardPermissionsRequest {
-    return _smithy.isa(o, "DescribeDashboardPermissionsRequest");
+    return __isa(o, "DescribeDashboardPermissionsRequest");
   }
 }
 
@@ -2446,7 +2449,7 @@ export interface DescribeDashboardPermissionsResponse extends $MetadataBearer {
 
 export namespace DescribeDashboardPermissionsResponse {
   export function isa(o: any): o is DescribeDashboardPermissionsResponse {
-    return _smithy.isa(o, "DescribeDashboardPermissionsResponse");
+    return __isa(o, "DescribeDashboardPermissionsResponse");
   }
 }
 
@@ -2476,7 +2479,7 @@ export interface DescribeDashboardRequest {
 
 export namespace DescribeDashboardRequest {
   export function isa(o: any): o is DescribeDashboardRequest {
-    return _smithy.isa(o, "DescribeDashboardRequest");
+    return __isa(o, "DescribeDashboardRequest");
   }
 }
 
@@ -2495,7 +2498,7 @@ export interface DescribeDashboardResponse extends $MetadataBearer {
 
 export namespace DescribeDashboardResponse {
   export function isa(o: any): o is DescribeDashboardResponse {
-    return _smithy.isa(o, "DescribeDashboardResponse");
+    return __isa(o, "DescribeDashboardResponse");
   }
 }
 
@@ -2514,7 +2517,7 @@ export interface DescribeDataSetPermissionsRequest {
 
 export namespace DescribeDataSetPermissionsRequest {
   export function isa(o: any): o is DescribeDataSetPermissionsRequest {
-    return _smithy.isa(o, "DescribeDataSetPermissionsRequest");
+    return __isa(o, "DescribeDataSetPermissionsRequest");
   }
 }
 
@@ -2543,7 +2546,7 @@ export interface DescribeDataSetPermissionsResponse extends $MetadataBearer {
 
 export namespace DescribeDataSetPermissionsResponse {
   export function isa(o: any): o is DescribeDataSetPermissionsResponse {
-    return _smithy.isa(o, "DescribeDataSetPermissionsResponse");
+    return __isa(o, "DescribeDataSetPermissionsResponse");
   }
 }
 
@@ -2562,7 +2565,7 @@ export interface DescribeDataSetRequest {
 
 export namespace DescribeDataSetRequest {
   export function isa(o: any): o is DescribeDataSetRequest {
-    return _smithy.isa(o, "DescribeDataSetRequest");
+    return __isa(o, "DescribeDataSetRequest");
   }
 }
 
@@ -2581,7 +2584,7 @@ export interface DescribeDataSetResponse extends $MetadataBearer {
 
 export namespace DescribeDataSetResponse {
   export function isa(o: any): o is DescribeDataSetResponse {
-    return _smithy.isa(o, "DescribeDataSetResponse");
+    return __isa(o, "DescribeDataSetResponse");
   }
 }
 
@@ -2600,7 +2603,7 @@ export interface DescribeDataSourcePermissionsRequest {
 
 export namespace DescribeDataSourcePermissionsRequest {
   export function isa(o: any): o is DescribeDataSourcePermissionsRequest {
-    return _smithy.isa(o, "DescribeDataSourcePermissionsRequest");
+    return __isa(o, "DescribeDataSourcePermissionsRequest");
   }
 }
 
@@ -2629,7 +2632,7 @@ export interface DescribeDataSourcePermissionsResponse extends $MetadataBearer {
 
 export namespace DescribeDataSourcePermissionsResponse {
   export function isa(o: any): o is DescribeDataSourcePermissionsResponse {
-    return _smithy.isa(o, "DescribeDataSourcePermissionsResponse");
+    return __isa(o, "DescribeDataSourcePermissionsResponse");
   }
 }
 
@@ -2648,7 +2651,7 @@ export interface DescribeDataSourceRequest {
 
 export namespace DescribeDataSourceRequest {
   export function isa(o: any): o is DescribeDataSourceRequest {
-    return _smithy.isa(o, "DescribeDataSourceRequest");
+    return __isa(o, "DescribeDataSourceRequest");
   }
 }
 
@@ -2667,7 +2670,7 @@ export interface DescribeDataSourceResponse extends $MetadataBearer {
 
 export namespace DescribeDataSourceResponse {
   export function isa(o: any): o is DescribeDataSourceResponse {
-    return _smithy.isa(o, "DescribeDataSourceResponse");
+    return __isa(o, "DescribeDataSourceResponse");
   }
 }
 
@@ -2692,7 +2695,7 @@ export interface DescribeGroupRequest {
 
 export namespace DescribeGroupRequest {
   export function isa(o: any): o is DescribeGroupRequest {
-    return _smithy.isa(o, "DescribeGroupRequest");
+    return __isa(o, "DescribeGroupRequest");
   }
 }
 
@@ -2711,7 +2714,7 @@ export interface DescribeGroupResponse extends $MetadataBearer {
 
 export namespace DescribeGroupResponse {
   export function isa(o: any): o is DescribeGroupResponse {
-    return _smithy.isa(o, "DescribeGroupResponse");
+    return __isa(o, "DescribeGroupResponse");
   }
 }
 
@@ -2735,7 +2738,7 @@ export interface DescribeIAMPolicyAssignmentRequest {
 
 export namespace DescribeIAMPolicyAssignmentRequest {
   export function isa(o: any): o is DescribeIAMPolicyAssignmentRequest {
-    return _smithy.isa(o, "DescribeIAMPolicyAssignmentRequest");
+    return __isa(o, "DescribeIAMPolicyAssignmentRequest");
   }
 }
 
@@ -2754,7 +2757,7 @@ export interface DescribeIAMPolicyAssignmentResponse extends $MetadataBearer {
 
 export namespace DescribeIAMPolicyAssignmentResponse {
   export function isa(o: any): o is DescribeIAMPolicyAssignmentResponse {
-    return _smithy.isa(o, "DescribeIAMPolicyAssignmentResponse");
+    return __isa(o, "DescribeIAMPolicyAssignmentResponse");
   }
 }
 
@@ -2778,7 +2781,7 @@ export interface DescribeIngestionRequest {
 
 export namespace DescribeIngestionRequest {
   export function isa(o: any): o is DescribeIngestionRequest {
-    return _smithy.isa(o, "DescribeIngestionRequest");
+    return __isa(o, "DescribeIngestionRequest");
   }
 }
 
@@ -2797,7 +2800,7 @@ export interface DescribeIngestionResponse extends $MetadataBearer {
 
 export namespace DescribeIngestionResponse {
   export function isa(o: any): o is DescribeIngestionResponse {
-    return _smithy.isa(o, "DescribeIngestionResponse");
+    return __isa(o, "DescribeIngestionResponse");
   }
 }
 
@@ -2827,7 +2830,7 @@ export interface DescribeTemplateAliasRequest {
 
 export namespace DescribeTemplateAliasRequest {
   export function isa(o: any): o is DescribeTemplateAliasRequest {
-    return _smithy.isa(o, "DescribeTemplateAliasRequest");
+    return __isa(o, "DescribeTemplateAliasRequest");
   }
 }
 
@@ -2846,7 +2849,7 @@ export interface DescribeTemplateAliasResponse extends $MetadataBearer {
 
 export namespace DescribeTemplateAliasResponse {
   export function isa(o: any): o is DescribeTemplateAliasResponse {
-    return _smithy.isa(o, "DescribeTemplateAliasResponse");
+    return __isa(o, "DescribeTemplateAliasResponse");
   }
 }
 
@@ -2865,7 +2868,7 @@ export interface DescribeTemplatePermissionsRequest {
 
 export namespace DescribeTemplatePermissionsRequest {
   export function isa(o: any): o is DescribeTemplatePermissionsRequest {
-    return _smithy.isa(o, "DescribeTemplatePermissionsRequest");
+    return __isa(o, "DescribeTemplatePermissionsRequest");
   }
 }
 
@@ -2894,7 +2897,7 @@ export interface DescribeTemplatePermissionsResponse extends $MetadataBearer {
 
 export namespace DescribeTemplatePermissionsResponse {
   export function isa(o: any): o is DescribeTemplatePermissionsResponse {
-    return _smithy.isa(o, "DescribeTemplatePermissionsResponse");
+    return __isa(o, "DescribeTemplatePermissionsResponse");
   }
 }
 
@@ -2927,7 +2930,7 @@ export interface DescribeTemplateRequest {
 
 export namespace DescribeTemplateRequest {
   export function isa(o: any): o is DescribeTemplateRequest {
-    return _smithy.isa(o, "DescribeTemplateRequest");
+    return __isa(o, "DescribeTemplateRequest");
   }
 }
 
@@ -2941,7 +2944,7 @@ export interface DescribeTemplateResponse extends $MetadataBearer {
 
 export namespace DescribeTemplateResponse {
   export function isa(o: any): o is DescribeTemplateResponse {
-    return _smithy.isa(o, "DescribeTemplateResponse");
+    return __isa(o, "DescribeTemplateResponse");
   }
 }
 
@@ -2966,7 +2969,7 @@ export interface DescribeUserRequest {
 
 export namespace DescribeUserRequest {
   export function isa(o: any): o is DescribeUserRequest {
-    return _smithy.isa(o, "DescribeUserRequest");
+    return __isa(o, "DescribeUserRequest");
   }
 }
 
@@ -2985,7 +2988,7 @@ export interface DescribeUserResponse extends $MetadataBearer {
 
 export namespace DescribeUserResponse {
   export function isa(o: any): o is DescribeUserResponse {
-    return _smithy.isa(o, "DescribeUserResponse");
+    return __isa(o, "DescribeUserResponse");
   }
 }
 
@@ -2994,7 +2997,7 @@ export namespace DescribeUserResponse {
  * 			added to the approved list by an Amazon QuickSight admin.</p>
  */
 export interface DomainNotWhitelistedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DomainNotWhitelistedException";
   $fault: "client";
@@ -3007,7 +3010,7 @@ export interface DomainNotWhitelistedException
 
 export namespace DomainNotWhitelistedException {
   export function isa(o: any): o is DomainNotWhitelistedException {
-    return _smithy.isa(o, "DomainNotWhitelistedException");
+    return __isa(o, "DomainNotWhitelistedException");
   }
 }
 
@@ -3029,7 +3032,7 @@ export interface ErrorInfo {
 
 export namespace ErrorInfo {
   export function isa(o: any): o is ErrorInfo {
-    return _smithy.isa(o, "ErrorInfo");
+    return __isa(o, "ErrorInfo");
   }
 }
 
@@ -3046,7 +3049,7 @@ export interface ExportToCSVOption {
 
 export namespace ExportToCSVOption {
   export function isa(o: any): o is ExportToCSVOption {
-    return _smithy.isa(o, "ExportToCSVOption");
+    return __isa(o, "ExportToCSVOption");
   }
 }
 
@@ -3073,7 +3076,7 @@ export interface FilterOperation {
 
 export namespace FilterOperation {
   export function isa(o: any): o is FilterOperation {
-    return _smithy.isa(o, "FilterOperation");
+    return __isa(o, "FilterOperation");
   }
 }
 
@@ -3100,7 +3103,7 @@ export interface GeoSpatialColumnGroup {
 
 export namespace GeoSpatialColumnGroup {
   export function isa(o: any): o is GeoSpatialColumnGroup {
-    return _smithy.isa(o, "GeoSpatialColumnGroup");
+    return __isa(o, "GeoSpatialColumnGroup");
   }
 }
 
@@ -3174,7 +3177,7 @@ export interface GetDashboardEmbedUrlRequest {
 
 export namespace GetDashboardEmbedUrlRequest {
   export function isa(o: any): o is GetDashboardEmbedUrlRequest {
-    return _smithy.isa(o, "GetDashboardEmbedUrlRequest");
+    return __isa(o, "GetDashboardEmbedUrlRequest");
   }
 }
 
@@ -3195,7 +3198,7 @@ export interface GetDashboardEmbedUrlResponse extends $MetadataBearer {
 
 export namespace GetDashboardEmbedUrlResponse {
   export function isa(o: any): o is GetDashboardEmbedUrlResponse {
-    return _smithy.isa(o, "GetDashboardEmbedUrlResponse");
+    return __isa(o, "GetDashboardEmbedUrlResponse");
   }
 }
 
@@ -3229,7 +3232,7 @@ export interface Group {
 
 export namespace Group {
   export function isa(o: any): o is Group {
-    return _smithy.isa(o, "Group");
+    return __isa(o, "Group");
   }
 }
 
@@ -3252,7 +3255,7 @@ export interface GroupMember {
 
 export namespace GroupMember {
   export function isa(o: any): o is GroupMember {
-    return _smithy.isa(o, "GroupMember");
+    return __isa(o, "GroupMember");
   }
 }
 
@@ -3294,7 +3297,7 @@ export interface IAMPolicyAssignment {
 
 export namespace IAMPolicyAssignment {
   export function isa(o: any): o is IAMPolicyAssignment {
-    return _smithy.isa(o, "IAMPolicyAssignment");
+    return __isa(o, "IAMPolicyAssignment");
   }
 }
 
@@ -3316,7 +3319,7 @@ export interface IAMPolicyAssignmentSummary {
 
 export namespace IAMPolicyAssignmentSummary {
   export function isa(o: any): o is IAMPolicyAssignmentSummary {
-    return _smithy.isa(o, "IAMPolicyAssignmentSummary");
+    return __isa(o, "IAMPolicyAssignmentSummary");
   }
 }
 
@@ -3325,7 +3328,7 @@ export namespace IAMPolicyAssignmentSummary {
  * 				<code>IAM</code> and <code>QUICKSIGHT</code>.</p>
  */
 export interface IdentityTypeNotSupportedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "IdentityTypeNotSupportedException";
   $fault: "client";
@@ -3338,7 +3341,7 @@ export interface IdentityTypeNotSupportedException
 
 export namespace IdentityTypeNotSupportedException {
   export function isa(o: any): o is IdentityTypeNotSupportedException {
-    return _smithy.isa(o, "IdentityTypeNotSupportedException");
+    return __isa(o, "IdentityTypeNotSupportedException");
   }
 }
 
@@ -3405,7 +3408,7 @@ export interface Ingestion {
 
 export namespace Ingestion {
   export function isa(o: any): o is Ingestion {
-    return _smithy.isa(o, "Ingestion");
+    return __isa(o, "Ingestion");
   }
 }
 
@@ -3491,7 +3494,7 @@ export interface InputColumn {
 
 export namespace InputColumn {
   export function isa(o: any): o is InputColumn {
-    return _smithy.isa(o, "InputColumn");
+    return __isa(o, "InputColumn");
   }
 }
 
@@ -3523,7 +3526,7 @@ export interface IntegerParameter {
 
 export namespace IntegerParameter {
   export function isa(o: any): o is IntegerParameter {
-    return _smithy.isa(o, "IntegerParameter");
+    return __isa(o, "IntegerParameter");
   }
 }
 
@@ -3540,7 +3543,7 @@ export interface JiraParameters {
 
 export namespace JiraParameters {
   export function isa(o: any): o is JiraParameters {
-    return _smithy.isa(o, "JiraParameters");
+    return __isa(o, "JiraParameters");
   }
 }
 
@@ -3572,7 +3575,7 @@ export interface JoinInstruction {
 
 export namespace JoinInstruction {
   export function isa(o: any): o is JoinInstruction {
-    return _smithy.isa(o, "JoinInstruction");
+    return __isa(o, "JoinInstruction");
   }
 }
 
@@ -3609,7 +3612,7 @@ export interface ListDashboardVersionsRequest {
 
 export namespace ListDashboardVersionsRequest {
   export function isa(o: any): o is ListDashboardVersionsRequest {
-    return _smithy.isa(o, "ListDashboardVersionsRequest");
+    return __isa(o, "ListDashboardVersionsRequest");
   }
 }
 
@@ -3633,7 +3636,7 @@ export interface ListDashboardVersionsResponse extends $MetadataBearer {
 
 export namespace ListDashboardVersionsResponse {
   export function isa(o: any): o is ListDashboardVersionsResponse {
-    return _smithy.isa(o, "ListDashboardVersionsResponse");
+    return __isa(o, "ListDashboardVersionsResponse");
   }
 }
 
@@ -3657,7 +3660,7 @@ export interface ListDashboardsRequest {
 
 export namespace ListDashboardsRequest {
   export function isa(o: any): o is ListDashboardsRequest {
-    return _smithy.isa(o, "ListDashboardsRequest");
+    return __isa(o, "ListDashboardsRequest");
   }
 }
 
@@ -3682,7 +3685,7 @@ export interface ListDashboardsResponse extends $MetadataBearer {
 
 export namespace ListDashboardsResponse {
   export function isa(o: any): o is ListDashboardsResponse {
-    return _smithy.isa(o, "ListDashboardsResponse");
+    return __isa(o, "ListDashboardsResponse");
   }
 }
 
@@ -3706,7 +3709,7 @@ export interface ListDataSetsRequest {
 
 export namespace ListDataSetsRequest {
   export function isa(o: any): o is ListDataSetsRequest {
-    return _smithy.isa(o, "ListDataSetsRequest");
+    return __isa(o, "ListDataSetsRequest");
   }
 }
 
@@ -3730,7 +3733,7 @@ export interface ListDataSetsResponse extends $MetadataBearer {
 
 export namespace ListDataSetsResponse {
   export function isa(o: any): o is ListDataSetsResponse {
-    return _smithy.isa(o, "ListDataSetsResponse");
+    return __isa(o, "ListDataSetsResponse");
   }
 }
 
@@ -3754,7 +3757,7 @@ export interface ListDataSourcesRequest {
 
 export namespace ListDataSourcesRequest {
   export function isa(o: any): o is ListDataSourcesRequest {
-    return _smithy.isa(o, "ListDataSourcesRequest");
+    return __isa(o, "ListDataSourcesRequest");
   }
 }
 
@@ -3778,7 +3781,7 @@ export interface ListDataSourcesResponse extends $MetadataBearer {
 
 export namespace ListDataSourcesResponse {
   export function isa(o: any): o is ListDataSourcesResponse {
-    return _smithy.isa(o, "ListDataSourcesResponse");
+    return __isa(o, "ListDataSourcesResponse");
   }
 }
 
@@ -3813,7 +3816,7 @@ export interface ListGroupMembershipsRequest {
 
 export namespace ListGroupMembershipsRequest {
   export function isa(o: any): o is ListGroupMembershipsRequest {
-    return _smithy.isa(o, "ListGroupMembershipsRequest");
+    return __isa(o, "ListGroupMembershipsRequest");
   }
 }
 
@@ -3837,7 +3840,7 @@ export interface ListGroupMembershipsResponse extends $MetadataBearer {
 
 export namespace ListGroupMembershipsResponse {
   export function isa(o: any): o is ListGroupMembershipsResponse {
-    return _smithy.isa(o, "ListGroupMembershipsResponse");
+    return __isa(o, "ListGroupMembershipsResponse");
   }
 }
 
@@ -3867,7 +3870,7 @@ export interface ListGroupsRequest {
 
 export namespace ListGroupsRequest {
   export function isa(o: any): o is ListGroupsRequest {
-    return _smithy.isa(o, "ListGroupsRequest");
+    return __isa(o, "ListGroupsRequest");
   }
 }
 
@@ -3891,7 +3894,7 @@ export interface ListGroupsResponse extends $MetadataBearer {
 
 export namespace ListGroupsResponse {
   export function isa(o: any): o is ListGroupsResponse {
-    return _smithy.isa(o, "ListGroupsResponse");
+    return __isa(o, "ListGroupsResponse");
   }
 }
 
@@ -3925,7 +3928,7 @@ export interface ListIAMPolicyAssignmentsForUserRequest {
 
 export namespace ListIAMPolicyAssignmentsForUserRequest {
   export function isa(o: any): o is ListIAMPolicyAssignmentsForUserRequest {
-    return _smithy.isa(o, "ListIAMPolicyAssignmentsForUserRequest");
+    return __isa(o, "ListIAMPolicyAssignmentsForUserRequest");
   }
 }
 
@@ -3950,7 +3953,7 @@ export interface ListIAMPolicyAssignmentsForUserResponse
 
 export namespace ListIAMPolicyAssignmentsForUserResponse {
   export function isa(o: any): o is ListIAMPolicyAssignmentsForUserResponse {
-    return _smithy.isa(o, "ListIAMPolicyAssignmentsForUserResponse");
+    return __isa(o, "ListIAMPolicyAssignmentsForUserResponse");
   }
 }
 
@@ -3984,7 +3987,7 @@ export interface ListIAMPolicyAssignmentsRequest {
 
 export namespace ListIAMPolicyAssignmentsRequest {
   export function isa(o: any): o is ListIAMPolicyAssignmentsRequest {
-    return _smithy.isa(o, "ListIAMPolicyAssignmentsRequest");
+    return __isa(o, "ListIAMPolicyAssignmentsRequest");
   }
 }
 
@@ -4008,7 +4011,7 @@ export interface ListIAMPolicyAssignmentsResponse extends $MetadataBearer {
 
 export namespace ListIAMPolicyAssignmentsResponse {
   export function isa(o: any): o is ListIAMPolicyAssignmentsResponse {
-    return _smithy.isa(o, "ListIAMPolicyAssignmentsResponse");
+    return __isa(o, "ListIAMPolicyAssignmentsResponse");
   }
 }
 
@@ -4037,7 +4040,7 @@ export interface ListIngestionsRequest {
 
 export namespace ListIngestionsRequest {
   export function isa(o: any): o is ListIngestionsRequest {
-    return _smithy.isa(o, "ListIngestionsRequest");
+    return __isa(o, "ListIngestionsRequest");
   }
 }
 
@@ -4061,7 +4064,7 @@ export interface ListIngestionsResponse extends $MetadataBearer {
 
 export namespace ListIngestionsResponse {
   export function isa(o: any): o is ListIngestionsResponse {
-    return _smithy.isa(o, "ListIngestionsResponse");
+    return __isa(o, "ListIngestionsResponse");
   }
 }
 
@@ -4075,7 +4078,7 @@ export interface ListTagsForResourceRequest {
 
 export namespace ListTagsForResourceRequest {
   export function isa(o: any): o is ListTagsForResourceRequest {
-    return _smithy.isa(o, "ListTagsForResourceRequest");
+    return __isa(o, "ListTagsForResourceRequest");
   }
 }
 
@@ -4095,7 +4098,7 @@ export interface ListTagsForResourceResponse extends $MetadataBearer {
 
 export namespace ListTagsForResourceResponse {
   export function isa(o: any): o is ListTagsForResourceResponse {
-    return _smithy.isa(o, "ListTagsForResourceResponse");
+    return __isa(o, "ListTagsForResourceResponse");
   }
 }
 
@@ -4124,7 +4127,7 @@ export interface ListTemplateAliasesRequest {
 
 export namespace ListTemplateAliasesRequest {
   export function isa(o: any): o is ListTemplateAliasesRequest {
-    return _smithy.isa(o, "ListTemplateAliasesRequest");
+    return __isa(o, "ListTemplateAliasesRequest");
   }
 }
 
@@ -4148,7 +4151,7 @@ export interface ListTemplateAliasesResponse extends $MetadataBearer {
 
 export namespace ListTemplateAliasesResponse {
   export function isa(o: any): o is ListTemplateAliasesResponse {
-    return _smithy.isa(o, "ListTemplateAliasesResponse");
+    return __isa(o, "ListTemplateAliasesResponse");
   }
 }
 
@@ -4177,7 +4180,7 @@ export interface ListTemplateVersionsRequest {
 
 export namespace ListTemplateVersionsRequest {
   export function isa(o: any): o is ListTemplateVersionsRequest {
-    return _smithy.isa(o, "ListTemplateVersionsRequest");
+    return __isa(o, "ListTemplateVersionsRequest");
   }
 }
 
@@ -4201,7 +4204,7 @@ export interface ListTemplateVersionsResponse extends $MetadataBearer {
 
 export namespace ListTemplateVersionsResponse {
   export function isa(o: any): o is ListTemplateVersionsResponse {
-    return _smithy.isa(o, "ListTemplateVersionsResponse");
+    return __isa(o, "ListTemplateVersionsResponse");
   }
 }
 
@@ -4225,7 +4228,7 @@ export interface ListTemplatesRequest {
 
 export namespace ListTemplatesRequest {
   export function isa(o: any): o is ListTemplatesRequest {
-    return _smithy.isa(o, "ListTemplatesRequest");
+    return __isa(o, "ListTemplatesRequest");
   }
 }
 
@@ -4249,7 +4252,7 @@ export interface ListTemplatesResponse extends $MetadataBearer {
 
 export namespace ListTemplatesResponse {
   export function isa(o: any): o is ListTemplatesResponse {
-    return _smithy.isa(o, "ListTemplatesResponse");
+    return __isa(o, "ListTemplatesResponse");
   }
 }
 
@@ -4284,7 +4287,7 @@ export interface ListUserGroupsRequest {
 
 export namespace ListUserGroupsRequest {
   export function isa(o: any): o is ListUserGroupsRequest {
-    return _smithy.isa(o, "ListUserGroupsRequest");
+    return __isa(o, "ListUserGroupsRequest");
   }
 }
 
@@ -4308,7 +4311,7 @@ export interface ListUserGroupsResponse extends $MetadataBearer {
 
 export namespace ListUserGroupsResponse {
   export function isa(o: any): o is ListUserGroupsResponse {
-    return _smithy.isa(o, "ListUserGroupsResponse");
+    return __isa(o, "ListUserGroupsResponse");
   }
 }
 
@@ -4338,7 +4341,7 @@ export interface ListUsersRequest {
 
 export namespace ListUsersRequest {
   export function isa(o: any): o is ListUsersRequest {
-    return _smithy.isa(o, "ListUsersRequest");
+    return __isa(o, "ListUsersRequest");
   }
 }
 
@@ -4362,7 +4365,7 @@ export interface ListUsersResponse extends $MetadataBearer {
 
 export namespace ListUsersResponse {
   export function isa(o: any): o is ListUsersResponse {
-    return _smithy.isa(o, "ListUsersResponse");
+    return __isa(o, "ListUsersResponse");
   }
 }
 
@@ -4392,7 +4395,7 @@ export interface LogicalTable {
 
 export namespace LogicalTable {
   export function isa(o: any): o is LogicalTable {
-    return _smithy.isa(o, "LogicalTable");
+    return __isa(o, "LogicalTable");
   }
 }
 
@@ -4415,7 +4418,7 @@ export interface LogicalTableSource {
 
 export namespace LogicalTableSource {
   export function isa(o: any): o is LogicalTableSource {
-    return _smithy.isa(o, "LogicalTableSource");
+    return __isa(o, "LogicalTableSource");
   }
 }
 
@@ -4437,7 +4440,7 @@ export interface ManifestFileLocation {
 
 export namespace ManifestFileLocation {
   export function isa(o: any): o is ManifestFileLocation {
-    return _smithy.isa(o, "ManifestFileLocation");
+    return __isa(o, "ManifestFileLocation");
   }
 }
 
@@ -4464,7 +4467,7 @@ export interface MariaDbParameters {
 
 export namespace MariaDbParameters {
   export function isa(o: any): o is MariaDbParameters {
-    return _smithy.isa(o, "MariaDbParameters");
+    return __isa(o, "MariaDbParameters");
   }
 }
 
@@ -4491,7 +4494,7 @@ export interface MySqlParameters {
 
 export namespace MySqlParameters {
   export function isa(o: any): o is MySqlParameters {
-    return _smithy.isa(o, "MySqlParameters");
+    return __isa(o, "MySqlParameters");
   }
 }
 
@@ -4513,7 +4516,7 @@ export interface OutputColumn {
 
 export namespace OutputColumn {
   export function isa(o: any): o is OutputColumn {
-    return _smithy.isa(o, "OutputColumn");
+    return __isa(o, "OutputColumn");
   }
 }
 
@@ -4545,7 +4548,7 @@ export interface _Parameters {
 
 export namespace _Parameters {
   export function isa(o: any): o is _Parameters {
-    return _smithy.isa(o, "Parameters");
+    return __isa(o, "Parameters");
   }
 }
 
@@ -4574,7 +4577,7 @@ export interface PhysicalTable {
 
 export namespace PhysicalTable {
   export function isa(o: any): o is PhysicalTable {
-    return _smithy.isa(o, "PhysicalTable");
+    return __isa(o, "PhysicalTable");
   }
 }
 
@@ -4601,7 +4604,7 @@ export interface PostgreSqlParameters {
 
 export namespace PostgreSqlParameters {
   export function isa(o: any): o is PostgreSqlParameters {
-    return _smithy.isa(o, "PostgreSqlParameters");
+    return __isa(o, "PostgreSqlParameters");
   }
 }
 
@@ -4628,7 +4631,7 @@ export interface PrestoParameters {
 
 export namespace PrestoParameters {
   export function isa(o: any): o is PrestoParameters {
-    return _smithy.isa(o, "PrestoParameters");
+    return __isa(o, "PrestoParameters");
   }
 }
 
@@ -4646,7 +4649,7 @@ export interface ProjectOperation {
 
 export namespace ProjectOperation {
   export function isa(o: any): o is ProjectOperation {
-    return _smithy.isa(o, "ProjectOperation");
+    return __isa(o, "ProjectOperation");
   }
 }
 
@@ -4669,7 +4672,7 @@ export interface QueueInfo {
 
 export namespace QueueInfo {
   export function isa(o: any): o is QueueInfo {
-    return _smithy.isa(o, "QueueInfo");
+    return __isa(o, "QueueInfo");
   }
 }
 
@@ -4679,7 +4682,7 @@ export namespace QueueInfo {
  * 				<code>DeleteUser</code>, <code>DescribeUser</code>, and so on.</p>
  */
 export interface QuickSightUserNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "QuickSightUserNotFoundException";
   $fault: "client";
@@ -4692,7 +4695,7 @@ export interface QuickSightUserNotFoundException
 
 export namespace QuickSightUserNotFoundException {
   export function isa(o: any): o is QuickSightUserNotFoundException {
-    return _smithy.isa(o, "QuickSightUserNotFoundException");
+    return __isa(o, "QuickSightUserNotFoundException");
   }
 }
 
@@ -4714,7 +4717,7 @@ export interface RdsParameters {
 
 export namespace RdsParameters {
   export function isa(o: any): o is RdsParameters {
-    return _smithy.isa(o, "RdsParameters");
+    return __isa(o, "RdsParameters");
   }
 }
 
@@ -4750,7 +4753,7 @@ export interface RedshiftParameters {
 
 export namespace RedshiftParameters {
   export function isa(o: any): o is RedshiftParameters {
-    return _smithy.isa(o, "RedshiftParameters");
+    return __isa(o, "RedshiftParameters");
   }
 }
 
@@ -4848,7 +4851,7 @@ export interface RegisterUserRequest {
 
 export namespace RegisterUserRequest {
   export function isa(o: any): o is RegisterUserRequest {
-    return _smithy.isa(o, "RegisterUserRequest");
+    return __isa(o, "RegisterUserRequest");
   }
 }
 
@@ -4873,7 +4876,7 @@ export interface RegisterUserResponse extends $MetadataBearer {
 
 export namespace RegisterUserResponse {
   export function isa(o: any): o is RegisterUserResponse {
-    return _smithy.isa(o, "RegisterUserResponse");
+    return __isa(o, "RegisterUserResponse");
   }
 }
 
@@ -4905,7 +4908,7 @@ export interface RelationalTable {
 
 export namespace RelationalTable {
   export function isa(o: any): o is RelationalTable {
-    return _smithy.isa(o, "RelationalTable");
+    return __isa(o, "RelationalTable");
   }
 }
 
@@ -4927,7 +4930,7 @@ export interface RenameColumnOperation {
 
 export namespace RenameColumnOperation {
   export function isa(o: any): o is RenameColumnOperation {
-    return _smithy.isa(o, "RenameColumnOperation");
+    return __isa(o, "RenameColumnOperation");
   }
 }
 
@@ -4949,7 +4952,7 @@ export interface RowInfo {
 
 export namespace RowInfo {
   export function isa(o: any): o is RowInfo {
-    return _smithy.isa(o, "RowInfo");
+    return __isa(o, "RowInfo");
   }
 }
 
@@ -4971,7 +4974,7 @@ export interface RowLevelPermissionDataSet {
 
 export namespace RowLevelPermissionDataSet {
   export function isa(o: any): o is RowLevelPermissionDataSet {
-    return _smithy.isa(o, "RowLevelPermissionDataSet");
+    return __isa(o, "RowLevelPermissionDataSet");
   }
 }
 
@@ -4994,7 +4997,7 @@ export interface S3Parameters {
 
 export namespace S3Parameters {
   export function isa(o: any): o is S3Parameters {
-    return _smithy.isa(o, "S3Parameters");
+    return __isa(o, "S3Parameters");
   }
 }
 
@@ -5021,7 +5024,7 @@ export interface S3Source {
 
 export namespace S3Source {
   export function isa(o: any): o is S3Source {
-    return _smithy.isa(o, "S3Source");
+    return __isa(o, "S3Source");
   }
 }
 
@@ -5038,7 +5041,7 @@ export interface ServiceNowParameters {
 
 export namespace ServiceNowParameters {
   export function isa(o: any): o is ServiceNowParameters {
-    return _smithy.isa(o, "ServiceNowParameters");
+    return __isa(o, "ServiceNowParameters");
   }
 }
 
@@ -5047,7 +5050,7 @@ export namespace ServiceNowParameters {
  * 			lifetime must be 15-600 minutes.</p>
  */
 export interface SessionLifetimeInMinutesInvalidException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "SessionLifetimeInMinutesInvalidException";
   $fault: "client";
@@ -5060,7 +5063,7 @@ export interface SessionLifetimeInMinutesInvalidException
 
 export namespace SessionLifetimeInMinutesInvalidException {
   export function isa(o: any): o is SessionLifetimeInMinutesInvalidException {
-    return _smithy.isa(o, "SessionLifetimeInMinutesInvalidException");
+    return __isa(o, "SessionLifetimeInMinutesInvalidException");
   }
 }
 
@@ -5077,7 +5080,7 @@ export interface SheetControlsOption {
 
 export namespace SheetControlsOption {
   export function isa(o: any): o is SheetControlsOption {
-    return _smithy.isa(o, "SheetControlsOption");
+    return __isa(o, "SheetControlsOption");
   }
 }
 
@@ -5104,7 +5107,7 @@ export interface SnowflakeParameters {
 
 export namespace SnowflakeParameters {
   export function isa(o: any): o is SnowflakeParameters {
-    return _smithy.isa(o, "SnowflakeParameters");
+    return __isa(o, "SnowflakeParameters");
   }
 }
 
@@ -5126,7 +5129,7 @@ export interface SparkParameters {
 
 export namespace SparkParameters {
   export function isa(o: any): o is SparkParameters {
-    return _smithy.isa(o, "SparkParameters");
+    return __isa(o, "SparkParameters");
   }
 }
 
@@ -5153,7 +5156,7 @@ export interface SqlServerParameters {
 
 export namespace SqlServerParameters {
   export function isa(o: any): o is SqlServerParameters {
-    return _smithy.isa(o, "SqlServerParameters");
+    return __isa(o, "SqlServerParameters");
   }
 }
 
@@ -5171,7 +5174,7 @@ export interface SslProperties {
 
 export namespace SslProperties {
   export function isa(o: any): o is SslProperties {
-    return _smithy.isa(o, "SslProperties");
+    return __isa(o, "SslProperties");
   }
 }
 
@@ -5193,7 +5196,7 @@ export interface StringParameter {
 
 export namespace StringParameter {
   export function isa(o: any): o is StringParameter {
-    return _smithy.isa(o, "StringParameter");
+    return __isa(o, "StringParameter");
   }
 }
 
@@ -5218,7 +5221,7 @@ export interface TagColumnOperation {
 
 export namespace TagColumnOperation {
   export function isa(o: any): o is TagColumnOperation {
-    return _smithy.isa(o, "TagColumnOperation");
+    return __isa(o, "TagColumnOperation");
   }
 }
 
@@ -5237,7 +5240,7 @@ export interface TagResourceRequest {
 
 export namespace TagResourceRequest {
   export function isa(o: any): o is TagResourceRequest {
-    return _smithy.isa(o, "TagResourceRequest");
+    return __isa(o, "TagResourceRequest");
   }
 }
 
@@ -5251,7 +5254,7 @@ export interface TagResourceResponse extends $MetadataBearer {
 
 export namespace TagResourceResponse {
   export function isa(o: any): o is TagResourceResponse {
-    return _smithy.isa(o, "TagResourceResponse");
+    return __isa(o, "TagResourceResponse");
   }
 }
 
@@ -5300,7 +5303,7 @@ export interface Template {
 
 export namespace Template {
   export function isa(o: any): o is Template {
-    return _smithy.isa(o, "Template");
+    return __isa(o, "Template");
   }
 }
 
@@ -5327,7 +5330,7 @@ export interface TemplateAlias {
 
 export namespace TemplateAlias {
   export function isa(o: any): o is TemplateAlias {
-    return _smithy.isa(o, "TemplateAlias");
+    return __isa(o, "TemplateAlias");
   }
 }
 
@@ -5349,7 +5352,7 @@ export interface TemplateError {
 
 export namespace TemplateError {
   export function isa(o: any): o is TemplateError {
-    return _smithy.isa(o, "TemplateError");
+    return __isa(o, "TemplateError");
   }
 }
 
@@ -5377,7 +5380,7 @@ export interface TemplateSourceAnalysis {
 
 export namespace TemplateSourceAnalysis {
   export function isa(o: any): o is TemplateSourceAnalysis {
-    return _smithy.isa(o, "TemplateSourceAnalysis");
+    return __isa(o, "TemplateSourceAnalysis");
   }
 }
 
@@ -5399,7 +5402,7 @@ export interface TemplateSourceEntity {
 
 export namespace TemplateSourceEntity {
   export function isa(o: any): o is TemplateSourceEntity {
-    return _smithy.isa(o, "TemplateSourceEntity");
+    return __isa(o, "TemplateSourceEntity");
   }
 }
 
@@ -5416,7 +5419,7 @@ export interface TemplateSourceTemplate {
 
 export namespace TemplateSourceTemplate {
   export function isa(o: any): o is TemplateSourceTemplate {
-    return _smithy.isa(o, "TemplateSourceTemplate");
+    return __isa(o, "TemplateSourceTemplate");
   }
 }
 
@@ -5458,7 +5461,7 @@ export interface TemplateSummary {
 
 export namespace TemplateSummary {
   export function isa(o: any): o is TemplateSummary {
-    return _smithy.isa(o, "TemplateSummary");
+    return __isa(o, "TemplateSummary");
   }
 }
 
@@ -5508,7 +5511,7 @@ export interface TemplateVersion {
 
 export namespace TemplateVersion {
   export function isa(o: any): o is TemplateVersion {
-    return _smithy.isa(o, "TemplateVersion");
+    return __isa(o, "TemplateVersion");
   }
 }
 
@@ -5545,7 +5548,7 @@ export interface TemplateVersionSummary {
 
 export namespace TemplateVersionSummary {
   export function isa(o: any): o is TemplateVersionSummary {
-    return _smithy.isa(o, "TemplateVersionSummary");
+    return __isa(o, "TemplateVersionSummary");
   }
 }
 
@@ -5572,7 +5575,7 @@ export interface TeradataParameters {
 
 export namespace TeradataParameters {
   export function isa(o: any): o is TeradataParameters {
-    return _smithy.isa(o, "TeradataParameters");
+    return __isa(o, "TeradataParameters");
   }
 }
 
@@ -5622,7 +5625,7 @@ export interface TransformOperation {
 
 export namespace TransformOperation {
   export function isa(o: any): o is TransformOperation {
-    return _smithy.isa(o, "TransformOperation");
+    return __isa(o, "TransformOperation");
   }
 }
 
@@ -5644,7 +5647,7 @@ export interface TwitterParameters {
 
 export namespace TwitterParameters {
   export function isa(o: any): o is TwitterParameters {
-    return _smithy.isa(o, "TwitterParameters");
+    return __isa(o, "TwitterParameters");
   }
 }
 
@@ -5663,7 +5666,7 @@ export interface UntagResourceRequest {
 
 export namespace UntagResourceRequest {
   export function isa(o: any): o is UntagResourceRequest {
-    return _smithy.isa(o, "UntagResourceRequest");
+    return __isa(o, "UntagResourceRequest");
   }
 }
 
@@ -5677,7 +5680,7 @@ export interface UntagResourceResponse extends $MetadataBearer {
 
 export namespace UntagResourceResponse {
   export function isa(o: any): o is UntagResourceResponse {
-    return _smithy.isa(o, "UntagResourceResponse");
+    return __isa(o, "UntagResourceResponse");
   }
 }
 
@@ -5707,7 +5710,7 @@ export interface UpdateDashboardPermissionsRequest {
 
 export namespace UpdateDashboardPermissionsRequest {
   export function isa(o: any): o is UpdateDashboardPermissionsRequest {
-    return _smithy.isa(o, "UpdateDashboardPermissionsRequest");
+    return __isa(o, "UpdateDashboardPermissionsRequest");
   }
 }
 
@@ -5736,7 +5739,7 @@ export interface UpdateDashboardPermissionsResponse extends $MetadataBearer {
 
 export namespace UpdateDashboardPermissionsResponse {
   export function isa(o: any): o is UpdateDashboardPermissionsResponse {
-    return _smithy.isa(o, "UpdateDashboardPermissionsResponse");
+    return __isa(o, "UpdateDashboardPermissionsResponse");
   }
 }
 
@@ -5760,7 +5763,7 @@ export interface UpdateDashboardPublishedVersionRequest {
 
 export namespace UpdateDashboardPublishedVersionRequest {
   export function isa(o: any): o is UpdateDashboardPublishedVersionRequest {
-    return _smithy.isa(o, "UpdateDashboardPublishedVersionRequest");
+    return __isa(o, "UpdateDashboardPublishedVersionRequest");
   }
 }
 
@@ -5785,7 +5788,7 @@ export interface UpdateDashboardPublishedVersionResponse
 
 export namespace UpdateDashboardPublishedVersionResponse {
   export function isa(o: any): o is UpdateDashboardPublishedVersionResponse {
-    return _smithy.isa(o, "UpdateDashboardPublishedVersionResponse");
+    return __isa(o, "UpdateDashboardPublishedVersionResponse");
   }
 }
 
@@ -5857,7 +5860,7 @@ export interface UpdateDashboardRequest {
 
 export namespace UpdateDashboardRequest {
   export function isa(o: any): o is UpdateDashboardRequest {
-    return _smithy.isa(o, "UpdateDashboardRequest");
+    return __isa(o, "UpdateDashboardRequest");
   }
 }
 
@@ -5896,7 +5899,7 @@ export interface UpdateDashboardResponse extends $MetadataBearer {
 
 export namespace UpdateDashboardResponse {
   export function isa(o: any): o is UpdateDashboardResponse {
-    return _smithy.isa(o, "UpdateDashboardResponse");
+    return __isa(o, "UpdateDashboardResponse");
   }
 }
 
@@ -5926,7 +5929,7 @@ export interface UpdateDataSetPermissionsRequest {
 
 export namespace UpdateDataSetPermissionsRequest {
   export function isa(o: any): o is UpdateDataSetPermissionsRequest {
-    return _smithy.isa(o, "UpdateDataSetPermissionsRequest");
+    return __isa(o, "UpdateDataSetPermissionsRequest");
   }
 }
 
@@ -5951,7 +5954,7 @@ export interface UpdateDataSetPermissionsResponse extends $MetadataBearer {
 
 export namespace UpdateDataSetPermissionsResponse {
   export function isa(o: any): o is UpdateDataSetPermissionsResponse {
-    return _smithy.isa(o, "UpdateDataSetPermissionsResponse");
+    return __isa(o, "UpdateDataSetPermissionsResponse");
   }
 }
 
@@ -6001,7 +6004,7 @@ export interface UpdateDataSetRequest {
 
 export namespace UpdateDataSetRequest {
   export function isa(o: any): o is UpdateDataSetRequest {
-    return _smithy.isa(o, "UpdateDataSetRequest");
+    return __isa(o, "UpdateDataSetRequest");
   }
 }
 
@@ -6037,7 +6040,7 @@ export interface UpdateDataSetResponse extends $MetadataBearer {
 
 export namespace UpdateDataSetResponse {
   export function isa(o: any): o is UpdateDataSetResponse {
-    return _smithy.isa(o, "UpdateDataSetResponse");
+    return __isa(o, "UpdateDataSetResponse");
   }
 }
 
@@ -6066,7 +6069,7 @@ export interface UpdateDataSourcePermissionsRequest {
 
 export namespace UpdateDataSourcePermissionsRequest {
   export function isa(o: any): o is UpdateDataSourcePermissionsRequest {
-    return _smithy.isa(o, "UpdateDataSourcePermissionsRequest");
+    return __isa(o, "UpdateDataSourcePermissionsRequest");
   }
 }
 
@@ -6090,7 +6093,7 @@ export interface UpdateDataSourcePermissionsResponse extends $MetadataBearer {
 
 export namespace UpdateDataSourcePermissionsResponse {
   export function isa(o: any): o is UpdateDataSourcePermissionsResponse {
-    return _smithy.isa(o, "UpdateDataSourcePermissionsResponse");
+    return __isa(o, "UpdateDataSourcePermissionsResponse");
   }
 }
 
@@ -6137,7 +6140,7 @@ export interface UpdateDataSourceRequest {
 
 export namespace UpdateDataSourceRequest {
   export function isa(o: any): o is UpdateDataSourceRequest {
-    return _smithy.isa(o, "UpdateDataSourceRequest");
+    return __isa(o, "UpdateDataSourceRequest");
   }
 }
 
@@ -6166,7 +6169,7 @@ export interface UpdateDataSourceResponse extends $MetadataBearer {
 
 export namespace UpdateDataSourceResponse {
   export function isa(o: any): o is UpdateDataSourceResponse {
-    return _smithy.isa(o, "UpdateDataSourceResponse");
+    return __isa(o, "UpdateDataSourceResponse");
   }
 }
 
@@ -6196,7 +6199,7 @@ export interface UpdateGroupRequest {
 
 export namespace UpdateGroupRequest {
   export function isa(o: any): o is UpdateGroupRequest {
-    return _smithy.isa(o, "UpdateGroupRequest");
+    return __isa(o, "UpdateGroupRequest");
   }
 }
 
@@ -6215,7 +6218,7 @@ export interface UpdateGroupResponse extends $MetadataBearer {
 
 export namespace UpdateGroupResponse {
   export function isa(o: any): o is UpdateGroupResponse {
-    return _smithy.isa(o, "UpdateGroupResponse");
+    return __isa(o, "UpdateGroupResponse");
   }
 }
 
@@ -6271,7 +6274,7 @@ export interface UpdateIAMPolicyAssignmentRequest {
 
 export namespace UpdateIAMPolicyAssignmentRequest {
   export function isa(o: any): o is UpdateIAMPolicyAssignmentRequest {
-    return _smithy.isa(o, "UpdateIAMPolicyAssignmentRequest");
+    return __isa(o, "UpdateIAMPolicyAssignmentRequest");
   }
 }
 
@@ -6327,7 +6330,7 @@ export interface UpdateIAMPolicyAssignmentResponse extends $MetadataBearer {
 
 export namespace UpdateIAMPolicyAssignmentResponse {
   export function isa(o: any): o is UpdateIAMPolicyAssignmentResponse {
-    return _smithy.isa(o, "UpdateIAMPolicyAssignmentResponse");
+    return __isa(o, "UpdateIAMPolicyAssignmentResponse");
   }
 }
 
@@ -6359,7 +6362,7 @@ export interface UpdateTemplateAliasRequest {
 
 export namespace UpdateTemplateAliasRequest {
   export function isa(o: any): o is UpdateTemplateAliasRequest {
-    return _smithy.isa(o, "UpdateTemplateAliasRequest");
+    return __isa(o, "UpdateTemplateAliasRequest");
   }
 }
 
@@ -6378,7 +6381,7 @@ export interface UpdateTemplateAliasResponse extends $MetadataBearer {
 
 export namespace UpdateTemplateAliasResponse {
   export function isa(o: any): o is UpdateTemplateAliasResponse {
-    return _smithy.isa(o, "UpdateTemplateAliasResponse");
+    return __isa(o, "UpdateTemplateAliasResponse");
   }
 }
 
@@ -6407,7 +6410,7 @@ export interface UpdateTemplatePermissionsRequest {
 
 export namespace UpdateTemplatePermissionsRequest {
   export function isa(o: any): o is UpdateTemplatePermissionsRequest {
-    return _smithy.isa(o, "UpdateTemplatePermissionsRequest");
+    return __isa(o, "UpdateTemplatePermissionsRequest");
   }
 }
 
@@ -6436,7 +6439,7 @@ export interface UpdateTemplatePermissionsResponse extends $MetadataBearer {
 
 export namespace UpdateTemplatePermissionsResponse {
   export function isa(o: any): o is UpdateTemplatePermissionsResponse {
-    return _smithy.isa(o, "UpdateTemplatePermissionsResponse");
+    return __isa(o, "UpdateTemplatePermissionsResponse");
   }
 }
 
@@ -6474,7 +6477,7 @@ export interface UpdateTemplateRequest {
 
 export namespace UpdateTemplateRequest {
   export function isa(o: any): o is UpdateTemplateRequest {
-    return _smithy.isa(o, "UpdateTemplateRequest");
+    return __isa(o, "UpdateTemplateRequest");
   }
 }
 
@@ -6508,7 +6511,7 @@ export interface UpdateTemplateResponse extends $MetadataBearer {
 
 export namespace UpdateTemplateResponse {
   export function isa(o: any): o is UpdateTemplateResponse {
-    return _smithy.isa(o, "UpdateTemplateResponse");
+    return __isa(o, "UpdateTemplateResponse");
   }
 }
 
@@ -6560,7 +6563,7 @@ export interface UpdateUserRequest {
 
 export namespace UpdateUserRequest {
   export function isa(o: any): o is UpdateUserRequest {
-    return _smithy.isa(o, "UpdateUserRequest");
+    return __isa(o, "UpdateUserRequest");
   }
 }
 
@@ -6579,7 +6582,7 @@ export interface UpdateUserResponse extends $MetadataBearer {
 
 export namespace UpdateUserResponse {
   export function isa(o: any): o is UpdateUserResponse {
-    return _smithy.isa(o, "UpdateUserResponse");
+    return __isa(o, "UpdateUserResponse");
   }
 }
 
@@ -6616,7 +6619,7 @@ export interface UploadSettings {
 
 export namespace UploadSettings {
   export function isa(o: any): o is UploadSettings {
-    return _smithy.isa(o, "UploadSettings");
+    return __isa(o, "UploadSettings");
   }
 }
 
@@ -6693,7 +6696,7 @@ export interface User {
 
 export namespace User {
   export function isa(o: any): o is User {
-    return _smithy.isa(o, "User");
+    return __isa(o, "User");
   }
 }
 
@@ -6718,7 +6721,7 @@ export interface VpcConnectionProperties {
 
 export namespace VpcConnectionProperties {
   export function isa(o: any): o is VpcConnectionProperties {
-    return _smithy.isa(o, "VpcConnectionProperties");
+    return __isa(o, "VpcConnectionProperties");
   }
 }
 
@@ -6729,7 +6732,7 @@ export namespace VpcConnectionProperties {
  * 			correct permissions, and that you are using the correct access keys.</p>
  */
 export interface AccessDeniedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AccessDeniedException";
   $fault: "client";
@@ -6742,7 +6745,7 @@ export interface AccessDeniedException
 
 export namespace AccessDeniedException {
   export function isa(o: any): o is AccessDeniedException {
-    return _smithy.isa(o, "AccessDeniedException");
+    return __isa(o, "AccessDeniedException");
   }
 }
 
@@ -6756,9 +6759,7 @@ export enum ColumnDataType {
 /**
  * <p>Updating or deleting a resource can cause an inconsistent state.</p>
  */
-export interface ConflictException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface ConflictException extends __SmithyException, $MetadataBearer {
   name: "ConflictException";
   $fault: "client";
   Message?: string;
@@ -6770,7 +6771,7 @@ export interface ConflictException
 
 export namespace ConflictException {
   export function isa(o: any): o is ConflictException {
-    return _smithy.isa(o, "ConflictException");
+    return __isa(o, "ConflictException");
   }
 }
 
@@ -6795,7 +6796,7 @@ export enum IdentityType {
  * <p>An internal failure occurred.</p>
  */
 export interface InternalFailureException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalFailureException";
   $fault: "server";
@@ -6808,7 +6809,7 @@ export interface InternalFailureException
 
 export namespace InternalFailureException {
   export function isa(o: any): o is InternalFailureException {
-    return _smithy.isa(o, "InternalFailureException");
+    return __isa(o, "InternalFailureException");
   }
 }
 
@@ -6816,7 +6817,7 @@ export namespace InternalFailureException {
  * <p>The <code>NextToken</code> value isn't valid.</p>
  */
 export interface InvalidNextTokenException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidNextTokenException";
   $fault: "client";
@@ -6829,7 +6830,7 @@ export interface InvalidNextTokenException
 
 export namespace InvalidNextTokenException {
   export function isa(o: any): o is InvalidNextTokenException {
-    return _smithy.isa(o, "InvalidNextTokenException");
+    return __isa(o, "InvalidNextTokenException");
   }
 }
 
@@ -6837,7 +6838,7 @@ export namespace InvalidNextTokenException {
  * <p>One or more parameters has a value that isn't valid.</p>
  */
 export interface InvalidParameterValueException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidParameterValueException";
   $fault: "client";
@@ -6850,7 +6851,7 @@ export interface InvalidParameterValueException
 
 export namespace InvalidParameterValueException {
   export function isa(o: any): o is InvalidParameterValueException {
-    return _smithy.isa(o, "InvalidParameterValueException");
+    return __isa(o, "InvalidParameterValueException");
   }
 }
 
@@ -6858,7 +6859,7 @@ export namespace InvalidParameterValueException {
  * <p>A limit is exceeded.</p>
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -6876,7 +6877,7 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
@@ -6884,7 +6885,7 @@ export namespace LimitExceededException {
  * <p>One or more preconditions aren't met.</p>
  */
 export interface PreconditionNotMetException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "PreconditionNotMetException";
   $fault: "client";
@@ -6897,7 +6898,7 @@ export interface PreconditionNotMetException
 
 export namespace PreconditionNotMetException {
   export function isa(o: any): o is PreconditionNotMetException {
-    return _smithy.isa(o, "PreconditionNotMetException");
+    return __isa(o, "PreconditionNotMetException");
   }
 }
 
@@ -6905,7 +6906,7 @@ export namespace PreconditionNotMetException {
  * <p>The resource specified already exists. </p>
  */
 export interface ResourceExistsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceExistsException";
   $fault: "client";
@@ -6923,7 +6924,7 @@ export interface ResourceExistsException
 
 export namespace ResourceExistsException {
   export function isa(o: any): o is ResourceExistsException {
-    return _smithy.isa(o, "ResourceExistsException");
+    return __isa(o, "ResourceExistsException");
   }
 }
 
@@ -6931,7 +6932,7 @@ export namespace ResourceExistsException {
  * <p>One or more resources can't be found.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -6949,7 +6950,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -6974,7 +6975,7 @@ export interface ResourcePermission {
 
 export namespace ResourcePermission {
   export function isa(o: any): o is ResourcePermission {
-    return _smithy.isa(o, "ResourcePermission");
+    return __isa(o, "ResourcePermission");
   }
 }
 
@@ -6991,7 +6992,7 @@ export enum ResourceStatus {
  * <p>This resource is currently unavailable.</p>
  */
 export interface ResourceUnavailableException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceUnavailableException";
   $fault: "server";
@@ -7009,7 +7010,7 @@ export interface ResourceUnavailableException
 
 export namespace ResourceUnavailableException {
   export function isa(o: any): o is ResourceUnavailableException {
-    return _smithy.isa(o, "ResourceUnavailableException");
+    return __isa(o, "ResourceUnavailableException");
   }
 }
 
@@ -7032,7 +7033,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -7040,7 +7041,7 @@ export namespace Tag {
  * <p>Access is throttled.</p>
  */
 export interface ThrottlingException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ThrottlingException";
   $fault: "client";
@@ -7053,7 +7054,7 @@ export interface ThrottlingException
 
 export namespace ThrottlingException {
   export function isa(o: any): o is ThrottlingException {
-    return _smithy.isa(o, "ThrottlingException");
+    return __isa(o, "ThrottlingException");
   }
 }
 
@@ -7064,7 +7065,7 @@ export namespace ThrottlingException {
  * 			capability is available in every edition.</p>
  */
 export interface UnsupportedUserEditionException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UnsupportedUserEditionException";
   $fault: "client";
@@ -7077,6 +7078,6 @@ export interface UnsupportedUserEditionException
 
 export namespace UnsupportedUserEditionException {
   export function isa(o: any): o is UnsupportedUserEditionException {
-    return _smithy.isa(o, "UnsupportedUserEditionException");
+    return __isa(o, "UnsupportedUserEditionException");
   }
 }

--- a/clients/client-quicksight/protocols/Aws_restJson1_1.ts
+++ b/clients/client-quicksight/protocols/Aws_restJson1_1.ts
@@ -375,7 +375,10 @@ import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  extendedEncodeURIComponent as __extendedEncodeURIComponent
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -392,7 +395,7 @@ export async function serializeAws_restJson1_1CancelIngestionCommand(
   let resolvedPath =
     "/accounts/{AwsAccountId}/data-sets/{DataSetId}/ingestions/{IngestionId}";
   if (input.AwsAccountId !== undefined) {
-    const labelValue: string = input.AwsAccountId.toString();
+    const labelValue: string = input.AwsAccountId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: AwsAccountId."
@@ -400,25 +403,25 @@ export async function serializeAws_restJson1_1CancelIngestionCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{AwsAccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AwsAccountId.");
   }
   if (input.DataSetId !== undefined) {
-    const labelValue: string = input.DataSetId.toString();
+    const labelValue: string = input.DataSetId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DataSetId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DataSetId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DataSetId.");
   }
   if (input.IngestionId !== undefined) {
-    const labelValue: string = input.IngestionId.toString();
+    const labelValue: string = input.IngestionId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: IngestionId."
@@ -426,7 +429,7 @@ export async function serializeAws_restJson1_1CancelIngestionCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{IngestionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: IngestionId.");
@@ -448,7 +451,7 @@ export async function serializeAws_restJson1_1CreateDashboardCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/accounts/{AwsAccountId}/dashboards/{DashboardId}";
   if (input.AwsAccountId !== undefined) {
-    const labelValue: string = input.AwsAccountId.toString();
+    const labelValue: string = input.AwsAccountId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: AwsAccountId."
@@ -456,13 +459,13 @@ export async function serializeAws_restJson1_1CreateDashboardCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{AwsAccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AwsAccountId.");
   }
   if (input.DashboardId !== undefined) {
-    const labelValue: string = input.DashboardId.toString();
+    const labelValue: string = input.DashboardId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: DashboardId."
@@ -470,7 +473,7 @@ export async function serializeAws_restJson1_1CreateDashboardCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{DashboardId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DashboardId.");
@@ -531,7 +534,7 @@ export async function serializeAws_restJson1_1CreateDataSetCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/accounts/{AwsAccountId}/data-sets";
   if (input.AwsAccountId !== undefined) {
-    const labelValue: string = input.AwsAccountId.toString();
+    const labelValue: string = input.AwsAccountId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: AwsAccountId."
@@ -539,7 +542,7 @@ export async function serializeAws_restJson1_1CreateDataSetCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{AwsAccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AwsAccountId.");
@@ -609,7 +612,7 @@ export async function serializeAws_restJson1_1CreateDataSourceCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/accounts/{AwsAccountId}/data-sources";
   if (input.AwsAccountId !== undefined) {
-    const labelValue: string = input.AwsAccountId.toString();
+    const labelValue: string = input.AwsAccountId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: AwsAccountId."
@@ -617,7 +620,7 @@ export async function serializeAws_restJson1_1CreateDataSourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{AwsAccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AwsAccountId.");
@@ -689,7 +692,7 @@ export async function serializeAws_restJson1_1CreateGroupCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/accounts/{AwsAccountId}/namespaces/{Namespace}/groups";
   if (input.AwsAccountId !== undefined) {
-    const labelValue: string = input.AwsAccountId.toString();
+    const labelValue: string = input.AwsAccountId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: AwsAccountId."
@@ -697,19 +700,19 @@ export async function serializeAws_restJson1_1CreateGroupCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{AwsAccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AwsAccountId.");
   }
   if (input.Namespace !== undefined) {
-    const labelValue: string = input.Namespace.toString();
+    const labelValue: string = input.Namespace;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Namespace.");
     }
     resolvedPath = resolvedPath.replace(
       "{Namespace}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Namespace.");
@@ -742,7 +745,7 @@ export async function serializeAws_restJson1_1CreateGroupMembershipCommand(
   let resolvedPath =
     "/accounts/{AwsAccountId}/namespaces/{Namespace}/groups/{GroupName}/members/{MemberName}";
   if (input.AwsAccountId !== undefined) {
-    const labelValue: string = input.AwsAccountId.toString();
+    const labelValue: string = input.AwsAccountId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: AwsAccountId."
@@ -750,43 +753,43 @@ export async function serializeAws_restJson1_1CreateGroupMembershipCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{AwsAccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AwsAccountId.");
   }
   if (input.GroupName !== undefined) {
-    const labelValue: string = input.GroupName.toString();
+    const labelValue: string = input.GroupName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: GroupName.");
     }
     resolvedPath = resolvedPath.replace(
       "{GroupName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: GroupName.");
   }
   if (input.MemberName !== undefined) {
-    const labelValue: string = input.MemberName.toString();
+    const labelValue: string = input.MemberName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: MemberName.");
     }
     resolvedPath = resolvedPath.replace(
       "{MemberName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: MemberName.");
   }
   if (input.Namespace !== undefined) {
-    const labelValue: string = input.Namespace.toString();
+    const labelValue: string = input.Namespace;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Namespace.");
     }
     resolvedPath = resolvedPath.replace(
       "{Namespace}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Namespace.");
@@ -809,7 +812,7 @@ export async function serializeAws_restJson1_1CreateIAMPolicyAssignmentCommand(
   let resolvedPath =
     "/accounts/{AwsAccountId}/namespaces/{Namespace}/iam-policy-assignments";
   if (input.AwsAccountId !== undefined) {
-    const labelValue: string = input.AwsAccountId.toString();
+    const labelValue: string = input.AwsAccountId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: AwsAccountId."
@@ -817,19 +820,19 @@ export async function serializeAws_restJson1_1CreateIAMPolicyAssignmentCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{AwsAccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AwsAccountId.");
   }
   if (input.Namespace !== undefined) {
-    const labelValue: string = input.Namespace.toString();
+    const labelValue: string = input.Namespace;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Namespace.");
     }
     resolvedPath = resolvedPath.replace(
       "{Namespace}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Namespace.");
@@ -871,7 +874,7 @@ export async function serializeAws_restJson1_1CreateIngestionCommand(
   let resolvedPath =
     "/accounts/{AwsAccountId}/data-sets/{DataSetId}/ingestions/{IngestionId}";
   if (input.AwsAccountId !== undefined) {
-    const labelValue: string = input.AwsAccountId.toString();
+    const labelValue: string = input.AwsAccountId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: AwsAccountId."
@@ -879,25 +882,25 @@ export async function serializeAws_restJson1_1CreateIngestionCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{AwsAccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AwsAccountId.");
   }
   if (input.DataSetId !== undefined) {
-    const labelValue: string = input.DataSetId.toString();
+    const labelValue: string = input.DataSetId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DataSetId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DataSetId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DataSetId.");
   }
   if (input.IngestionId !== undefined) {
-    const labelValue: string = input.IngestionId.toString();
+    const labelValue: string = input.IngestionId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: IngestionId."
@@ -905,7 +908,7 @@ export async function serializeAws_restJson1_1CreateIngestionCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{IngestionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: IngestionId.");
@@ -927,7 +930,7 @@ export async function serializeAws_restJson1_1CreateTemplateCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/accounts/{AwsAccountId}/templates/{TemplateId}";
   if (input.AwsAccountId !== undefined) {
-    const labelValue: string = input.AwsAccountId.toString();
+    const labelValue: string = input.AwsAccountId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: AwsAccountId."
@@ -935,19 +938,19 @@ export async function serializeAws_restJson1_1CreateTemplateCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{AwsAccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AwsAccountId.");
   }
   if (input.TemplateId !== undefined) {
-    const labelValue: string = input.TemplateId.toString();
+    const labelValue: string = input.TemplateId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: TemplateId.");
     }
     resolvedPath = resolvedPath.replace(
       "{TemplateId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: TemplateId.");
@@ -995,19 +998,19 @@ export async function serializeAws_restJson1_1CreateTemplateAliasCommand(
   let resolvedPath =
     "/accounts/{AwsAccountId}/templates/{TemplateId}/aliases/{AliasName}";
   if (input.AliasName !== undefined) {
-    const labelValue: string = input.AliasName.toString();
+    const labelValue: string = input.AliasName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: AliasName.");
     }
     resolvedPath = resolvedPath.replace(
       "{AliasName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AliasName.");
   }
   if (input.AwsAccountId !== undefined) {
-    const labelValue: string = input.AwsAccountId.toString();
+    const labelValue: string = input.AwsAccountId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: AwsAccountId."
@@ -1015,19 +1018,19 @@ export async function serializeAws_restJson1_1CreateTemplateAliasCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{AwsAccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AwsAccountId.");
   }
   if (input.TemplateId !== undefined) {
-    const labelValue: string = input.TemplateId.toString();
+    const labelValue: string = input.TemplateId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: TemplateId.");
     }
     resolvedPath = resolvedPath.replace(
       "{TemplateId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: TemplateId.");
@@ -1056,7 +1059,7 @@ export async function serializeAws_restJson1_1DeleteDashboardCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/accounts/{AwsAccountId}/dashboards/{DashboardId}";
   if (input.AwsAccountId !== undefined) {
-    const labelValue: string = input.AwsAccountId.toString();
+    const labelValue: string = input.AwsAccountId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: AwsAccountId."
@@ -1064,13 +1067,13 @@ export async function serializeAws_restJson1_1DeleteDashboardCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{AwsAccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AwsAccountId.");
   }
   if (input.DashboardId !== undefined) {
-    const labelValue: string = input.DashboardId.toString();
+    const labelValue: string = input.DashboardId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: DashboardId."
@@ -1078,14 +1081,16 @@ export async function serializeAws_restJson1_1DeleteDashboardCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{DashboardId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DashboardId.");
   }
   const query: any = {};
   if (input.VersionNumber !== undefined) {
-    query["version-number"] = input.VersionNumber.toString();
+    query[
+      __extendedEncodeURIComponent("version-number")
+    ] = __extendedEncodeURIComponent(input.VersionNumber.toString());
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1105,7 +1110,7 @@ export async function serializeAws_restJson1_1DeleteDataSetCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/accounts/{AwsAccountId}/data-sets/{DataSetId}";
   if (input.AwsAccountId !== undefined) {
-    const labelValue: string = input.AwsAccountId.toString();
+    const labelValue: string = input.AwsAccountId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: AwsAccountId."
@@ -1113,19 +1118,19 @@ export async function serializeAws_restJson1_1DeleteDataSetCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{AwsAccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AwsAccountId.");
   }
   if (input.DataSetId !== undefined) {
-    const labelValue: string = input.DataSetId.toString();
+    const labelValue: string = input.DataSetId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DataSetId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DataSetId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DataSetId.");
@@ -1147,7 +1152,7 @@ export async function serializeAws_restJson1_1DeleteDataSourceCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/accounts/{AwsAccountId}/data-sources/{DataSourceId}";
   if (input.AwsAccountId !== undefined) {
-    const labelValue: string = input.AwsAccountId.toString();
+    const labelValue: string = input.AwsAccountId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: AwsAccountId."
@@ -1155,13 +1160,13 @@ export async function serializeAws_restJson1_1DeleteDataSourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{AwsAccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AwsAccountId.");
   }
   if (input.DataSourceId !== undefined) {
-    const labelValue: string = input.DataSourceId.toString();
+    const labelValue: string = input.DataSourceId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: DataSourceId."
@@ -1169,7 +1174,7 @@ export async function serializeAws_restJson1_1DeleteDataSourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{DataSourceId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DataSourceId.");
@@ -1192,7 +1197,7 @@ export async function serializeAws_restJson1_1DeleteGroupCommand(
   let resolvedPath =
     "/accounts/{AwsAccountId}/namespaces/{Namespace}/groups/{GroupName}";
   if (input.AwsAccountId !== undefined) {
-    const labelValue: string = input.AwsAccountId.toString();
+    const labelValue: string = input.AwsAccountId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: AwsAccountId."
@@ -1200,31 +1205,31 @@ export async function serializeAws_restJson1_1DeleteGroupCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{AwsAccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AwsAccountId.");
   }
   if (input.GroupName !== undefined) {
-    const labelValue: string = input.GroupName.toString();
+    const labelValue: string = input.GroupName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: GroupName.");
     }
     resolvedPath = resolvedPath.replace(
       "{GroupName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: GroupName.");
   }
   if (input.Namespace !== undefined) {
-    const labelValue: string = input.Namespace.toString();
+    const labelValue: string = input.Namespace;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Namespace.");
     }
     resolvedPath = resolvedPath.replace(
       "{Namespace}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Namespace.");
@@ -1247,7 +1252,7 @@ export async function serializeAws_restJson1_1DeleteGroupMembershipCommand(
   let resolvedPath =
     "/accounts/{AwsAccountId}/namespaces/{Namespace}/groups/{GroupName}/members/{MemberName}";
   if (input.AwsAccountId !== undefined) {
-    const labelValue: string = input.AwsAccountId.toString();
+    const labelValue: string = input.AwsAccountId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: AwsAccountId."
@@ -1255,43 +1260,43 @@ export async function serializeAws_restJson1_1DeleteGroupMembershipCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{AwsAccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AwsAccountId.");
   }
   if (input.GroupName !== undefined) {
-    const labelValue: string = input.GroupName.toString();
+    const labelValue: string = input.GroupName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: GroupName.");
     }
     resolvedPath = resolvedPath.replace(
       "{GroupName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: GroupName.");
   }
   if (input.MemberName !== undefined) {
-    const labelValue: string = input.MemberName.toString();
+    const labelValue: string = input.MemberName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: MemberName.");
     }
     resolvedPath = resolvedPath.replace(
       "{MemberName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: MemberName.");
   }
   if (input.Namespace !== undefined) {
-    const labelValue: string = input.Namespace.toString();
+    const labelValue: string = input.Namespace;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Namespace.");
     }
     resolvedPath = resolvedPath.replace(
       "{Namespace}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Namespace.");
@@ -1314,7 +1319,7 @@ export async function serializeAws_restJson1_1DeleteIAMPolicyAssignmentCommand(
   let resolvedPath =
     "/accounts/{AwsAccountId}/namespace/{Namespace}/iam-policy-assignments/{AssignmentName}";
   if (input.AssignmentName !== undefined) {
-    const labelValue: string = input.AssignmentName.toString();
+    const labelValue: string = input.AssignmentName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: AssignmentName."
@@ -1322,13 +1327,13 @@ export async function serializeAws_restJson1_1DeleteIAMPolicyAssignmentCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{AssignmentName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AssignmentName.");
   }
   if (input.AwsAccountId !== undefined) {
-    const labelValue: string = input.AwsAccountId.toString();
+    const labelValue: string = input.AwsAccountId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: AwsAccountId."
@@ -1336,19 +1341,19 @@ export async function serializeAws_restJson1_1DeleteIAMPolicyAssignmentCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{AwsAccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AwsAccountId.");
   }
   if (input.Namespace !== undefined) {
-    const labelValue: string = input.Namespace.toString();
+    const labelValue: string = input.Namespace;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Namespace.");
     }
     resolvedPath = resolvedPath.replace(
       "{Namespace}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Namespace.");
@@ -1370,7 +1375,7 @@ export async function serializeAws_restJson1_1DeleteTemplateCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/accounts/{AwsAccountId}/templates/{TemplateId}";
   if (input.AwsAccountId !== undefined) {
-    const labelValue: string = input.AwsAccountId.toString();
+    const labelValue: string = input.AwsAccountId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: AwsAccountId."
@@ -1378,26 +1383,28 @@ export async function serializeAws_restJson1_1DeleteTemplateCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{AwsAccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AwsAccountId.");
   }
   if (input.TemplateId !== undefined) {
-    const labelValue: string = input.TemplateId.toString();
+    const labelValue: string = input.TemplateId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: TemplateId.");
     }
     resolvedPath = resolvedPath.replace(
       "{TemplateId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: TemplateId.");
   }
   const query: any = {};
   if (input.VersionNumber !== undefined) {
-    query["version-number"] = input.VersionNumber.toString();
+    query[
+      __extendedEncodeURIComponent("version-number")
+    ] = __extendedEncodeURIComponent(input.VersionNumber.toString());
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1418,19 +1425,19 @@ export async function serializeAws_restJson1_1DeleteTemplateAliasCommand(
   let resolvedPath =
     "/accounts/{AwsAccountId}/templates/{TemplateId}/aliases/{AliasName}";
   if (input.AliasName !== undefined) {
-    const labelValue: string = input.AliasName.toString();
+    const labelValue: string = input.AliasName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: AliasName.");
     }
     resolvedPath = resolvedPath.replace(
       "{AliasName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AliasName.");
   }
   if (input.AwsAccountId !== undefined) {
-    const labelValue: string = input.AwsAccountId.toString();
+    const labelValue: string = input.AwsAccountId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: AwsAccountId."
@@ -1438,19 +1445,19 @@ export async function serializeAws_restJson1_1DeleteTemplateAliasCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{AwsAccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AwsAccountId.");
   }
   if (input.TemplateId !== undefined) {
-    const labelValue: string = input.TemplateId.toString();
+    const labelValue: string = input.TemplateId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: TemplateId.");
     }
     resolvedPath = resolvedPath.replace(
       "{TemplateId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: TemplateId.");
@@ -1473,7 +1480,7 @@ export async function serializeAws_restJson1_1DeleteUserCommand(
   let resolvedPath =
     "/accounts/{AwsAccountId}/namespaces/{Namespace}/users/{UserName}";
   if (input.AwsAccountId !== undefined) {
-    const labelValue: string = input.AwsAccountId.toString();
+    const labelValue: string = input.AwsAccountId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: AwsAccountId."
@@ -1481,31 +1488,31 @@ export async function serializeAws_restJson1_1DeleteUserCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{AwsAccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AwsAccountId.");
   }
   if (input.Namespace !== undefined) {
-    const labelValue: string = input.Namespace.toString();
+    const labelValue: string = input.Namespace;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Namespace.");
     }
     resolvedPath = resolvedPath.replace(
       "{Namespace}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Namespace.");
   }
   if (input.UserName !== undefined) {
-    const labelValue: string = input.UserName.toString();
+    const labelValue: string = input.UserName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: UserName.");
     }
     resolvedPath = resolvedPath.replace(
       "{UserName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: UserName.");
@@ -1528,7 +1535,7 @@ export async function serializeAws_restJson1_1DeleteUserByPrincipalIdCommand(
   let resolvedPath =
     "/accounts/{AwsAccountId}/namespaces/{Namespace}/user-principals/{PrincipalId}";
   if (input.AwsAccountId !== undefined) {
-    const labelValue: string = input.AwsAccountId.toString();
+    const labelValue: string = input.AwsAccountId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: AwsAccountId."
@@ -1536,25 +1543,25 @@ export async function serializeAws_restJson1_1DeleteUserByPrincipalIdCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{AwsAccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AwsAccountId.");
   }
   if (input.Namespace !== undefined) {
-    const labelValue: string = input.Namespace.toString();
+    const labelValue: string = input.Namespace;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Namespace.");
     }
     resolvedPath = resolvedPath.replace(
       "{Namespace}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Namespace.");
   }
   if (input.PrincipalId !== undefined) {
-    const labelValue: string = input.PrincipalId.toString();
+    const labelValue: string = input.PrincipalId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: PrincipalId."
@@ -1562,7 +1569,7 @@ export async function serializeAws_restJson1_1DeleteUserByPrincipalIdCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{PrincipalId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: PrincipalId.");
@@ -1584,7 +1591,7 @@ export async function serializeAws_restJson1_1DescribeDashboardCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/accounts/{AwsAccountId}/dashboards/{DashboardId}";
   if (input.AwsAccountId !== undefined) {
-    const labelValue: string = input.AwsAccountId.toString();
+    const labelValue: string = input.AwsAccountId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: AwsAccountId."
@@ -1592,13 +1599,13 @@ export async function serializeAws_restJson1_1DescribeDashboardCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{AwsAccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AwsAccountId.");
   }
   if (input.DashboardId !== undefined) {
-    const labelValue: string = input.DashboardId.toString();
+    const labelValue: string = input.DashboardId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: DashboardId."
@@ -1606,17 +1613,21 @@ export async function serializeAws_restJson1_1DescribeDashboardCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{DashboardId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DashboardId.");
   }
   const query: any = {};
   if (input.AliasName !== undefined) {
-    query["alias-name"] = input.AliasName.toString();
+    query[
+      __extendedEncodeURIComponent("alias-name")
+    ] = __extendedEncodeURIComponent(input.AliasName);
   }
   if (input.VersionNumber !== undefined) {
-    query["version-number"] = input.VersionNumber.toString();
+    query[
+      __extendedEncodeURIComponent("version-number")
+    ] = __extendedEncodeURIComponent(input.VersionNumber.toString());
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1637,7 +1648,7 @@ export async function serializeAws_restJson1_1DescribeDashboardPermissionsComman
   let resolvedPath =
     "/accounts/{AwsAccountId}/dashboards/{DashboardId}/permissions";
   if (input.AwsAccountId !== undefined) {
-    const labelValue: string = input.AwsAccountId.toString();
+    const labelValue: string = input.AwsAccountId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: AwsAccountId."
@@ -1645,13 +1656,13 @@ export async function serializeAws_restJson1_1DescribeDashboardPermissionsComman
     }
     resolvedPath = resolvedPath.replace(
       "{AwsAccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AwsAccountId.");
   }
   if (input.DashboardId !== undefined) {
-    const labelValue: string = input.DashboardId.toString();
+    const labelValue: string = input.DashboardId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: DashboardId."
@@ -1659,7 +1670,7 @@ export async function serializeAws_restJson1_1DescribeDashboardPermissionsComman
     }
     resolvedPath = resolvedPath.replace(
       "{DashboardId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DashboardId.");
@@ -1681,7 +1692,7 @@ export async function serializeAws_restJson1_1DescribeDataSetCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/accounts/{AwsAccountId}/data-sets/{DataSetId}";
   if (input.AwsAccountId !== undefined) {
-    const labelValue: string = input.AwsAccountId.toString();
+    const labelValue: string = input.AwsAccountId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: AwsAccountId."
@@ -1689,19 +1700,19 @@ export async function serializeAws_restJson1_1DescribeDataSetCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{AwsAccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AwsAccountId.");
   }
   if (input.DataSetId !== undefined) {
-    const labelValue: string = input.DataSetId.toString();
+    const labelValue: string = input.DataSetId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DataSetId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DataSetId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DataSetId.");
@@ -1724,7 +1735,7 @@ export async function serializeAws_restJson1_1DescribeDataSetPermissionsCommand(
   let resolvedPath =
     "/accounts/{AwsAccountId}/data-sets/{DataSetId}/permissions";
   if (input.AwsAccountId !== undefined) {
-    const labelValue: string = input.AwsAccountId.toString();
+    const labelValue: string = input.AwsAccountId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: AwsAccountId."
@@ -1732,19 +1743,19 @@ export async function serializeAws_restJson1_1DescribeDataSetPermissionsCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{AwsAccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AwsAccountId.");
   }
   if (input.DataSetId !== undefined) {
-    const labelValue: string = input.DataSetId.toString();
+    const labelValue: string = input.DataSetId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DataSetId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DataSetId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DataSetId.");
@@ -1766,7 +1777,7 @@ export async function serializeAws_restJson1_1DescribeDataSourceCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/accounts/{AwsAccountId}/data-sources/{DataSourceId}";
   if (input.AwsAccountId !== undefined) {
-    const labelValue: string = input.AwsAccountId.toString();
+    const labelValue: string = input.AwsAccountId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: AwsAccountId."
@@ -1774,13 +1785,13 @@ export async function serializeAws_restJson1_1DescribeDataSourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{AwsAccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AwsAccountId.");
   }
   if (input.DataSourceId !== undefined) {
-    const labelValue: string = input.DataSourceId.toString();
+    const labelValue: string = input.DataSourceId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: DataSourceId."
@@ -1788,7 +1799,7 @@ export async function serializeAws_restJson1_1DescribeDataSourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{DataSourceId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DataSourceId.");
@@ -1811,7 +1822,7 @@ export async function serializeAws_restJson1_1DescribeDataSourcePermissionsComma
   let resolvedPath =
     "/accounts/{AwsAccountId}/data-sources/{DataSourceId}/permissions";
   if (input.AwsAccountId !== undefined) {
-    const labelValue: string = input.AwsAccountId.toString();
+    const labelValue: string = input.AwsAccountId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: AwsAccountId."
@@ -1819,13 +1830,13 @@ export async function serializeAws_restJson1_1DescribeDataSourcePermissionsComma
     }
     resolvedPath = resolvedPath.replace(
       "{AwsAccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AwsAccountId.");
   }
   if (input.DataSourceId !== undefined) {
-    const labelValue: string = input.DataSourceId.toString();
+    const labelValue: string = input.DataSourceId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: DataSourceId."
@@ -1833,7 +1844,7 @@ export async function serializeAws_restJson1_1DescribeDataSourcePermissionsComma
     }
     resolvedPath = resolvedPath.replace(
       "{DataSourceId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DataSourceId.");
@@ -1856,7 +1867,7 @@ export async function serializeAws_restJson1_1DescribeGroupCommand(
   let resolvedPath =
     "/accounts/{AwsAccountId}/namespaces/{Namespace}/groups/{GroupName}";
   if (input.AwsAccountId !== undefined) {
-    const labelValue: string = input.AwsAccountId.toString();
+    const labelValue: string = input.AwsAccountId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: AwsAccountId."
@@ -1864,31 +1875,31 @@ export async function serializeAws_restJson1_1DescribeGroupCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{AwsAccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AwsAccountId.");
   }
   if (input.GroupName !== undefined) {
-    const labelValue: string = input.GroupName.toString();
+    const labelValue: string = input.GroupName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: GroupName.");
     }
     resolvedPath = resolvedPath.replace(
       "{GroupName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: GroupName.");
   }
   if (input.Namespace !== undefined) {
-    const labelValue: string = input.Namespace.toString();
+    const labelValue: string = input.Namespace;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Namespace.");
     }
     resolvedPath = resolvedPath.replace(
       "{Namespace}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Namespace.");
@@ -1911,7 +1922,7 @@ export async function serializeAws_restJson1_1DescribeIAMPolicyAssignmentCommand
   let resolvedPath =
     "/accounts/{AwsAccountId}/namespaces/{Namespace}/iam-policy-assignments/{AssignmentName}";
   if (input.AssignmentName !== undefined) {
-    const labelValue: string = input.AssignmentName.toString();
+    const labelValue: string = input.AssignmentName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: AssignmentName."
@@ -1919,13 +1930,13 @@ export async function serializeAws_restJson1_1DescribeIAMPolicyAssignmentCommand
     }
     resolvedPath = resolvedPath.replace(
       "{AssignmentName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AssignmentName.");
   }
   if (input.AwsAccountId !== undefined) {
-    const labelValue: string = input.AwsAccountId.toString();
+    const labelValue: string = input.AwsAccountId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: AwsAccountId."
@@ -1933,19 +1944,19 @@ export async function serializeAws_restJson1_1DescribeIAMPolicyAssignmentCommand
     }
     resolvedPath = resolvedPath.replace(
       "{AwsAccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AwsAccountId.");
   }
   if (input.Namespace !== undefined) {
-    const labelValue: string = input.Namespace.toString();
+    const labelValue: string = input.Namespace;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Namespace.");
     }
     resolvedPath = resolvedPath.replace(
       "{Namespace}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Namespace.");
@@ -1968,7 +1979,7 @@ export async function serializeAws_restJson1_1DescribeIngestionCommand(
   let resolvedPath =
     "/accounts/{AwsAccountId}/data-sets/{DataSetId}/ingestions/{IngestionId}";
   if (input.AwsAccountId !== undefined) {
-    const labelValue: string = input.AwsAccountId.toString();
+    const labelValue: string = input.AwsAccountId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: AwsAccountId."
@@ -1976,25 +1987,25 @@ export async function serializeAws_restJson1_1DescribeIngestionCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{AwsAccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AwsAccountId.");
   }
   if (input.DataSetId !== undefined) {
-    const labelValue: string = input.DataSetId.toString();
+    const labelValue: string = input.DataSetId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DataSetId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DataSetId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DataSetId.");
   }
   if (input.IngestionId !== undefined) {
-    const labelValue: string = input.IngestionId.toString();
+    const labelValue: string = input.IngestionId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: IngestionId."
@@ -2002,7 +2013,7 @@ export async function serializeAws_restJson1_1DescribeIngestionCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{IngestionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: IngestionId.");
@@ -2024,7 +2035,7 @@ export async function serializeAws_restJson1_1DescribeTemplateCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/accounts/{AwsAccountId}/templates/{TemplateId}";
   if (input.AwsAccountId !== undefined) {
-    const labelValue: string = input.AwsAccountId.toString();
+    const labelValue: string = input.AwsAccountId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: AwsAccountId."
@@ -2032,29 +2043,33 @@ export async function serializeAws_restJson1_1DescribeTemplateCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{AwsAccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AwsAccountId.");
   }
   if (input.TemplateId !== undefined) {
-    const labelValue: string = input.TemplateId.toString();
+    const labelValue: string = input.TemplateId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: TemplateId.");
     }
     resolvedPath = resolvedPath.replace(
       "{TemplateId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: TemplateId.");
   }
   const query: any = {};
   if (input.AliasName !== undefined) {
-    query["alias-name"] = input.AliasName.toString();
+    query[
+      __extendedEncodeURIComponent("alias-name")
+    ] = __extendedEncodeURIComponent(input.AliasName);
   }
   if (input.VersionNumber !== undefined) {
-    query["version-number"] = input.VersionNumber.toString();
+    query[
+      __extendedEncodeURIComponent("version-number")
+    ] = __extendedEncodeURIComponent(input.VersionNumber.toString());
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2075,19 +2090,19 @@ export async function serializeAws_restJson1_1DescribeTemplateAliasCommand(
   let resolvedPath =
     "/accounts/{AwsAccountId}/templates/{TemplateId}/aliases/{AliasName}";
   if (input.AliasName !== undefined) {
-    const labelValue: string = input.AliasName.toString();
+    const labelValue: string = input.AliasName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: AliasName.");
     }
     resolvedPath = resolvedPath.replace(
       "{AliasName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AliasName.");
   }
   if (input.AwsAccountId !== undefined) {
-    const labelValue: string = input.AwsAccountId.toString();
+    const labelValue: string = input.AwsAccountId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: AwsAccountId."
@@ -2095,19 +2110,19 @@ export async function serializeAws_restJson1_1DescribeTemplateAliasCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{AwsAccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AwsAccountId.");
   }
   if (input.TemplateId !== undefined) {
-    const labelValue: string = input.TemplateId.toString();
+    const labelValue: string = input.TemplateId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: TemplateId.");
     }
     resolvedPath = resolvedPath.replace(
       "{TemplateId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: TemplateId.");
@@ -2130,7 +2145,7 @@ export async function serializeAws_restJson1_1DescribeTemplatePermissionsCommand
   let resolvedPath =
     "/accounts/{AwsAccountId}/templates/{TemplateId}/permissions";
   if (input.AwsAccountId !== undefined) {
-    const labelValue: string = input.AwsAccountId.toString();
+    const labelValue: string = input.AwsAccountId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: AwsAccountId."
@@ -2138,19 +2153,19 @@ export async function serializeAws_restJson1_1DescribeTemplatePermissionsCommand
     }
     resolvedPath = resolvedPath.replace(
       "{AwsAccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AwsAccountId.");
   }
   if (input.TemplateId !== undefined) {
-    const labelValue: string = input.TemplateId.toString();
+    const labelValue: string = input.TemplateId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: TemplateId.");
     }
     resolvedPath = resolvedPath.replace(
       "{TemplateId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: TemplateId.");
@@ -2173,7 +2188,7 @@ export async function serializeAws_restJson1_1DescribeUserCommand(
   let resolvedPath =
     "/accounts/{AwsAccountId}/namespaces/{Namespace}/users/{UserName}";
   if (input.AwsAccountId !== undefined) {
-    const labelValue: string = input.AwsAccountId.toString();
+    const labelValue: string = input.AwsAccountId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: AwsAccountId."
@@ -2181,31 +2196,31 @@ export async function serializeAws_restJson1_1DescribeUserCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{AwsAccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AwsAccountId.");
   }
   if (input.Namespace !== undefined) {
-    const labelValue: string = input.Namespace.toString();
+    const labelValue: string = input.Namespace;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Namespace.");
     }
     resolvedPath = resolvedPath.replace(
       "{Namespace}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Namespace.");
   }
   if (input.UserName !== undefined) {
-    const labelValue: string = input.UserName.toString();
+    const labelValue: string = input.UserName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: UserName.");
     }
     resolvedPath = resolvedPath.replace(
       "{UserName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: UserName.");
@@ -2228,7 +2243,7 @@ export async function serializeAws_restJson1_1GetDashboardEmbedUrlCommand(
   let resolvedPath =
     "/accounts/{AwsAccountId}/dashboards/{DashboardId}/embed-url";
   if (input.AwsAccountId !== undefined) {
-    const labelValue: string = input.AwsAccountId.toString();
+    const labelValue: string = input.AwsAccountId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: AwsAccountId."
@@ -2236,13 +2251,13 @@ export async function serializeAws_restJson1_1GetDashboardEmbedUrlCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{AwsAccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AwsAccountId.");
   }
   if (input.DashboardId !== undefined) {
-    const labelValue: string = input.DashboardId.toString();
+    const labelValue: string = input.DashboardId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: DashboardId."
@@ -2250,26 +2265,36 @@ export async function serializeAws_restJson1_1GetDashboardEmbedUrlCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{DashboardId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DashboardId.");
   }
   const query: any = {};
   if (input.IdentityType !== undefined) {
-    query["creds-type"] = input.IdentityType.toString();
+    query[
+      __extendedEncodeURIComponent("creds-type")
+    ] = __extendedEncodeURIComponent(input.IdentityType);
   }
   if (input.ResetDisabled !== undefined) {
-    query["reset-disabled"] = input.ResetDisabled.toString();
+    query[
+      __extendedEncodeURIComponent("reset-disabled")
+    ] = __extendedEncodeURIComponent(input.ResetDisabled.toString());
   }
   if (input.SessionLifetimeInMinutes !== undefined) {
-    query["session-lifetime"] = input.SessionLifetimeInMinutes.toString();
+    query[
+      __extendedEncodeURIComponent("session-lifetime")
+    ] = __extendedEncodeURIComponent(input.SessionLifetimeInMinutes.toString());
   }
   if (input.UndoRedoDisabled !== undefined) {
-    query["undo-redo-disabled"] = input.UndoRedoDisabled.toString();
+    query[
+      __extendedEncodeURIComponent("undo-redo-disabled")
+    ] = __extendedEncodeURIComponent(input.UndoRedoDisabled.toString());
   }
   if (input.UserArn !== undefined) {
-    query["user-arn"] = input.UserArn.toString();
+    query[
+      __extendedEncodeURIComponent("user-arn")
+    ] = __extendedEncodeURIComponent(input.UserArn);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2290,7 +2315,7 @@ export async function serializeAws_restJson1_1ListDashboardVersionsCommand(
   let resolvedPath =
     "/accounts/{AwsAccountId}/dashboards/{DashboardId}/versions";
   if (input.AwsAccountId !== undefined) {
-    const labelValue: string = input.AwsAccountId.toString();
+    const labelValue: string = input.AwsAccountId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: AwsAccountId."
@@ -2298,13 +2323,13 @@ export async function serializeAws_restJson1_1ListDashboardVersionsCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{AwsAccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AwsAccountId.");
   }
   if (input.DashboardId !== undefined) {
-    const labelValue: string = input.DashboardId.toString();
+    const labelValue: string = input.DashboardId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: DashboardId."
@@ -2312,17 +2337,21 @@ export async function serializeAws_restJson1_1ListDashboardVersionsCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{DashboardId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DashboardId.");
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["max-results"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("max-results")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["next-token"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("next-token")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2342,7 +2371,7 @@ export async function serializeAws_restJson1_1ListDashboardsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/accounts/{AwsAccountId}/dashboards";
   if (input.AwsAccountId !== undefined) {
-    const labelValue: string = input.AwsAccountId.toString();
+    const labelValue: string = input.AwsAccountId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: AwsAccountId."
@@ -2350,17 +2379,21 @@ export async function serializeAws_restJson1_1ListDashboardsCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{AwsAccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AwsAccountId.");
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["max-results"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("max-results")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["next-token"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("next-token")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2380,7 +2413,7 @@ export async function serializeAws_restJson1_1ListDataSetsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/accounts/{AwsAccountId}/data-sets";
   if (input.AwsAccountId !== undefined) {
-    const labelValue: string = input.AwsAccountId.toString();
+    const labelValue: string = input.AwsAccountId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: AwsAccountId."
@@ -2388,17 +2421,21 @@ export async function serializeAws_restJson1_1ListDataSetsCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{AwsAccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AwsAccountId.");
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["max-results"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("max-results")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["next-token"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("next-token")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2418,7 +2455,7 @@ export async function serializeAws_restJson1_1ListDataSourcesCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/accounts/{AwsAccountId}/data-sources";
   if (input.AwsAccountId !== undefined) {
-    const labelValue: string = input.AwsAccountId.toString();
+    const labelValue: string = input.AwsAccountId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: AwsAccountId."
@@ -2426,17 +2463,21 @@ export async function serializeAws_restJson1_1ListDataSourcesCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{AwsAccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AwsAccountId.");
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["max-results"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("max-results")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["next-token"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("next-token")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2457,7 +2498,7 @@ export async function serializeAws_restJson1_1ListGroupMembershipsCommand(
   let resolvedPath =
     "/accounts/{AwsAccountId}/namespaces/{Namespace}/groups/{GroupName}/members";
   if (input.AwsAccountId !== undefined) {
-    const labelValue: string = input.AwsAccountId.toString();
+    const labelValue: string = input.AwsAccountId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: AwsAccountId."
@@ -2465,41 +2506,45 @@ export async function serializeAws_restJson1_1ListGroupMembershipsCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{AwsAccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AwsAccountId.");
   }
   if (input.GroupName !== undefined) {
-    const labelValue: string = input.GroupName.toString();
+    const labelValue: string = input.GroupName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: GroupName.");
     }
     resolvedPath = resolvedPath.replace(
       "{GroupName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: GroupName.");
   }
   if (input.Namespace !== undefined) {
-    const labelValue: string = input.Namespace.toString();
+    const labelValue: string = input.Namespace;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Namespace.");
     }
     resolvedPath = resolvedPath.replace(
       "{Namespace}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Namespace.");
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["max-results"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("max-results")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["next-token"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("next-token")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2519,7 +2564,7 @@ export async function serializeAws_restJson1_1ListGroupsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/accounts/{AwsAccountId}/namespaces/{Namespace}/groups";
   if (input.AwsAccountId !== undefined) {
-    const labelValue: string = input.AwsAccountId.toString();
+    const labelValue: string = input.AwsAccountId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: AwsAccountId."
@@ -2527,29 +2572,33 @@ export async function serializeAws_restJson1_1ListGroupsCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{AwsAccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AwsAccountId.");
   }
   if (input.Namespace !== undefined) {
-    const labelValue: string = input.Namespace.toString();
+    const labelValue: string = input.Namespace;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Namespace.");
     }
     resolvedPath = resolvedPath.replace(
       "{Namespace}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Namespace.");
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["max-results"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("max-results")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["next-token"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("next-token")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2570,7 +2619,7 @@ export async function serializeAws_restJson1_1ListIAMPolicyAssignmentsCommand(
   let resolvedPath =
     "/accounts/{AwsAccountId}/namespaces/{Namespace}/iam-policy-assignments";
   if (input.AwsAccountId !== undefined) {
-    const labelValue: string = input.AwsAccountId.toString();
+    const labelValue: string = input.AwsAccountId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: AwsAccountId."
@@ -2578,29 +2627,33 @@ export async function serializeAws_restJson1_1ListIAMPolicyAssignmentsCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{AwsAccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AwsAccountId.");
   }
   if (input.Namespace !== undefined) {
-    const labelValue: string = input.Namespace.toString();
+    const labelValue: string = input.Namespace;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Namespace.");
     }
     resolvedPath = resolvedPath.replace(
       "{Namespace}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Namespace.");
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["max-results"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("max-results")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["next-token"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("next-token")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   let body: any;
   const bodyParams: any = {};
@@ -2628,7 +2681,7 @@ export async function serializeAws_restJson1_1ListIAMPolicyAssignmentsForUserCom
   let resolvedPath =
     "/accounts/{AwsAccountId}/namespaces/{Namespace}/users/{UserName}/iam-policy-assignments";
   if (input.AwsAccountId !== undefined) {
-    const labelValue: string = input.AwsAccountId.toString();
+    const labelValue: string = input.AwsAccountId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: AwsAccountId."
@@ -2636,41 +2689,45 @@ export async function serializeAws_restJson1_1ListIAMPolicyAssignmentsForUserCom
     }
     resolvedPath = resolvedPath.replace(
       "{AwsAccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AwsAccountId.");
   }
   if (input.Namespace !== undefined) {
-    const labelValue: string = input.Namespace.toString();
+    const labelValue: string = input.Namespace;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Namespace.");
     }
     resolvedPath = resolvedPath.replace(
       "{Namespace}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Namespace.");
   }
   if (input.UserName !== undefined) {
-    const labelValue: string = input.UserName.toString();
+    const labelValue: string = input.UserName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: UserName.");
     }
     resolvedPath = resolvedPath.replace(
       "{UserName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: UserName.");
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["max-results"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("max-results")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["next-token"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("next-token")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2691,7 +2748,7 @@ export async function serializeAws_restJson1_1ListIngestionsCommand(
   let resolvedPath =
     "/accounts/{AwsAccountId}/data-sets/{DataSetId}/ingestions";
   if (input.AwsAccountId !== undefined) {
-    const labelValue: string = input.AwsAccountId.toString();
+    const labelValue: string = input.AwsAccountId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: AwsAccountId."
@@ -2699,29 +2756,33 @@ export async function serializeAws_restJson1_1ListIngestionsCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{AwsAccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AwsAccountId.");
   }
   if (input.DataSetId !== undefined) {
-    const labelValue: string = input.DataSetId.toString();
+    const labelValue: string = input.DataSetId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DataSetId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DataSetId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DataSetId.");
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["max-results"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("max-results")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["next-token"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("next-token")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2741,7 +2802,7 @@ export async function serializeAws_restJson1_1ListTagsForResourceCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/resources/{ResourceArn}/tags";
   if (input.ResourceArn !== undefined) {
-    const labelValue: string = input.ResourceArn.toString();
+    const labelValue: string = input.ResourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ResourceArn."
@@ -2749,7 +2810,7 @@ export async function serializeAws_restJson1_1ListTagsForResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ResourceArn.");
@@ -2771,7 +2832,7 @@ export async function serializeAws_restJson1_1ListTemplateAliasesCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/accounts/{AwsAccountId}/templates/{TemplateId}/aliases";
   if (input.AwsAccountId !== undefined) {
-    const labelValue: string = input.AwsAccountId.toString();
+    const labelValue: string = input.AwsAccountId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: AwsAccountId."
@@ -2779,29 +2840,33 @@ export async function serializeAws_restJson1_1ListTemplateAliasesCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{AwsAccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AwsAccountId.");
   }
   if (input.TemplateId !== undefined) {
-    const labelValue: string = input.TemplateId.toString();
+    const labelValue: string = input.TemplateId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: TemplateId.");
     }
     resolvedPath = resolvedPath.replace(
       "{TemplateId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: TemplateId.");
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["max-result"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("max-result")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["next-token"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("next-token")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2821,7 +2886,7 @@ export async function serializeAws_restJson1_1ListTemplateVersionsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/accounts/{AwsAccountId}/templates/{TemplateId}/versions";
   if (input.AwsAccountId !== undefined) {
-    const labelValue: string = input.AwsAccountId.toString();
+    const labelValue: string = input.AwsAccountId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: AwsAccountId."
@@ -2829,29 +2894,33 @@ export async function serializeAws_restJson1_1ListTemplateVersionsCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{AwsAccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AwsAccountId.");
   }
   if (input.TemplateId !== undefined) {
-    const labelValue: string = input.TemplateId.toString();
+    const labelValue: string = input.TemplateId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: TemplateId.");
     }
     resolvedPath = resolvedPath.replace(
       "{TemplateId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: TemplateId.");
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["max-results"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("max-results")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["next-token"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("next-token")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2871,7 +2940,7 @@ export async function serializeAws_restJson1_1ListTemplatesCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/accounts/{AwsAccountId}/templates";
   if (input.AwsAccountId !== undefined) {
-    const labelValue: string = input.AwsAccountId.toString();
+    const labelValue: string = input.AwsAccountId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: AwsAccountId."
@@ -2879,17 +2948,21 @@ export async function serializeAws_restJson1_1ListTemplatesCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{AwsAccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AwsAccountId.");
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["max-result"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("max-result")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["next-token"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("next-token")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2910,7 +2983,7 @@ export async function serializeAws_restJson1_1ListUserGroupsCommand(
   let resolvedPath =
     "/accounts/{AwsAccountId}/namespaces/{Namespace}/users/{UserName}/groups";
   if (input.AwsAccountId !== undefined) {
-    const labelValue: string = input.AwsAccountId.toString();
+    const labelValue: string = input.AwsAccountId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: AwsAccountId."
@@ -2918,41 +2991,45 @@ export async function serializeAws_restJson1_1ListUserGroupsCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{AwsAccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AwsAccountId.");
   }
   if (input.Namespace !== undefined) {
-    const labelValue: string = input.Namespace.toString();
+    const labelValue: string = input.Namespace;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Namespace.");
     }
     resolvedPath = resolvedPath.replace(
       "{Namespace}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Namespace.");
   }
   if (input.UserName !== undefined) {
-    const labelValue: string = input.UserName.toString();
+    const labelValue: string = input.UserName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: UserName.");
     }
     resolvedPath = resolvedPath.replace(
       "{UserName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: UserName.");
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["max-results"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("max-results")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["next-token"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("next-token")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2972,7 +3049,7 @@ export async function serializeAws_restJson1_1ListUsersCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/accounts/{AwsAccountId}/namespaces/{Namespace}/users";
   if (input.AwsAccountId !== undefined) {
-    const labelValue: string = input.AwsAccountId.toString();
+    const labelValue: string = input.AwsAccountId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: AwsAccountId."
@@ -2980,29 +3057,33 @@ export async function serializeAws_restJson1_1ListUsersCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{AwsAccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AwsAccountId.");
   }
   if (input.Namespace !== undefined) {
-    const labelValue: string = input.Namespace.toString();
+    const labelValue: string = input.Namespace;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Namespace.");
     }
     resolvedPath = resolvedPath.replace(
       "{Namespace}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Namespace.");
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["max-results"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("max-results")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["next-token"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("next-token")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -3022,7 +3103,7 @@ export async function serializeAws_restJson1_1RegisterUserCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/accounts/{AwsAccountId}/namespaces/{Namespace}/users";
   if (input.AwsAccountId !== undefined) {
-    const labelValue: string = input.AwsAccountId.toString();
+    const labelValue: string = input.AwsAccountId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: AwsAccountId."
@@ -3030,19 +3111,19 @@ export async function serializeAws_restJson1_1RegisterUserCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{AwsAccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AwsAccountId.");
   }
   if (input.Namespace !== undefined) {
-    const labelValue: string = input.Namespace.toString();
+    const labelValue: string = input.Namespace;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Namespace.");
     }
     resolvedPath = resolvedPath.replace(
       "{Namespace}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Namespace.");
@@ -3086,7 +3167,7 @@ export async function serializeAws_restJson1_1TagResourceCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/resources/{ResourceArn}/tags";
   if (input.ResourceArn !== undefined) {
-    const labelValue: string = input.ResourceArn.toString();
+    const labelValue: string = input.ResourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ResourceArn."
@@ -3094,7 +3175,7 @@ export async function serializeAws_restJson1_1TagResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ResourceArn.");
@@ -3123,7 +3204,7 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/resources/{ResourceArn}/tags";
   if (input.ResourceArn !== undefined) {
-    const labelValue: string = input.ResourceArn.toString();
+    const labelValue: string = input.ResourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ResourceArn."
@@ -3131,14 +3212,16 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ResourceArn.");
   }
   const query: any = {};
   if (input.TagKeys !== undefined) {
-    query["keys"] = input.TagKeys;
+    query[__extendedEncodeURIComponent("keys")] = input.TagKeys.map(entry =>
+      __extendedEncodeURIComponent(entry)
+    );
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -3158,7 +3241,7 @@ export async function serializeAws_restJson1_1UpdateDashboardCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/accounts/{AwsAccountId}/dashboards/{DashboardId}";
   if (input.AwsAccountId !== undefined) {
-    const labelValue: string = input.AwsAccountId.toString();
+    const labelValue: string = input.AwsAccountId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: AwsAccountId."
@@ -3166,13 +3249,13 @@ export async function serializeAws_restJson1_1UpdateDashboardCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{AwsAccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AwsAccountId.");
   }
   if (input.DashboardId !== undefined) {
-    const labelValue: string = input.DashboardId.toString();
+    const labelValue: string = input.DashboardId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: DashboardId."
@@ -3180,7 +3263,7 @@ export async function serializeAws_restJson1_1UpdateDashboardCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{DashboardId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DashboardId.");
@@ -3233,7 +3316,7 @@ export async function serializeAws_restJson1_1UpdateDashboardPermissionsCommand(
   let resolvedPath =
     "/accounts/{AwsAccountId}/dashboards/{DashboardId}/permissions";
   if (input.AwsAccountId !== undefined) {
-    const labelValue: string = input.AwsAccountId.toString();
+    const labelValue: string = input.AwsAccountId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: AwsAccountId."
@@ -3241,13 +3324,13 @@ export async function serializeAws_restJson1_1UpdateDashboardPermissionsCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{AwsAccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AwsAccountId.");
   }
   if (input.DashboardId !== undefined) {
-    const labelValue: string = input.DashboardId.toString();
+    const labelValue: string = input.DashboardId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: DashboardId."
@@ -3255,7 +3338,7 @@ export async function serializeAws_restJson1_1UpdateDashboardPermissionsCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{DashboardId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DashboardId.");
@@ -3298,7 +3381,7 @@ export async function serializeAws_restJson1_1UpdateDashboardPublishedVersionCom
   let resolvedPath =
     "/accounts/{AwsAccountId}/dashboards/{DashboardId}/versions/{VersionNumber}";
   if (input.AwsAccountId !== undefined) {
-    const labelValue: string = input.AwsAccountId.toString();
+    const labelValue: string = input.AwsAccountId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: AwsAccountId."
@@ -3306,13 +3389,13 @@ export async function serializeAws_restJson1_1UpdateDashboardPublishedVersionCom
     }
     resolvedPath = resolvedPath.replace(
       "{AwsAccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AwsAccountId.");
   }
   if (input.DashboardId !== undefined) {
-    const labelValue: string = input.DashboardId.toString();
+    const labelValue: string = input.DashboardId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: DashboardId."
@@ -3320,7 +3403,7 @@ export async function serializeAws_restJson1_1UpdateDashboardPublishedVersionCom
     }
     resolvedPath = resolvedPath.replace(
       "{DashboardId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DashboardId.");
@@ -3334,7 +3417,7 @@ export async function serializeAws_restJson1_1UpdateDashboardPublishedVersionCom
     }
     resolvedPath = resolvedPath.replace(
       "{VersionNumber}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: VersionNumber.");
@@ -3356,7 +3439,7 @@ export async function serializeAws_restJson1_1UpdateDataSetCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/accounts/{AwsAccountId}/data-sets/{DataSetId}";
   if (input.AwsAccountId !== undefined) {
-    const labelValue: string = input.AwsAccountId.toString();
+    const labelValue: string = input.AwsAccountId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: AwsAccountId."
@@ -3364,19 +3447,19 @@ export async function serializeAws_restJson1_1UpdateDataSetCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{AwsAccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AwsAccountId.");
   }
   if (input.DataSetId !== undefined) {
-    const labelValue: string = input.DataSetId.toString();
+    const labelValue: string = input.DataSetId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DataSetId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DataSetId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DataSetId.");
@@ -3435,7 +3518,7 @@ export async function serializeAws_restJson1_1UpdateDataSetPermissionsCommand(
   let resolvedPath =
     "/accounts/{AwsAccountId}/data-sets/{DataSetId}/permissions";
   if (input.AwsAccountId !== undefined) {
-    const labelValue: string = input.AwsAccountId.toString();
+    const labelValue: string = input.AwsAccountId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: AwsAccountId."
@@ -3443,19 +3526,19 @@ export async function serializeAws_restJson1_1UpdateDataSetPermissionsCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{AwsAccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AwsAccountId.");
   }
   if (input.DataSetId !== undefined) {
-    const labelValue: string = input.DataSetId.toString();
+    const labelValue: string = input.DataSetId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DataSetId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DataSetId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DataSetId.");
@@ -3497,7 +3580,7 @@ export async function serializeAws_restJson1_1UpdateDataSourceCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/accounts/{AwsAccountId}/data-sources/{DataSourceId}";
   if (input.AwsAccountId !== undefined) {
-    const labelValue: string = input.AwsAccountId.toString();
+    const labelValue: string = input.AwsAccountId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: AwsAccountId."
@@ -3505,13 +3588,13 @@ export async function serializeAws_restJson1_1UpdateDataSourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{AwsAccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AwsAccountId.");
   }
   if (input.DataSourceId !== undefined) {
-    const labelValue: string = input.DataSourceId.toString();
+    const labelValue: string = input.DataSourceId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: DataSourceId."
@@ -3519,7 +3602,7 @@ export async function serializeAws_restJson1_1UpdateDataSourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{DataSourceId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DataSourceId.");
@@ -3577,7 +3660,7 @@ export async function serializeAws_restJson1_1UpdateDataSourcePermissionsCommand
   let resolvedPath =
     "/accounts/{AwsAccountId}/data-sources/{DataSourceId}/permissions";
   if (input.AwsAccountId !== undefined) {
-    const labelValue: string = input.AwsAccountId.toString();
+    const labelValue: string = input.AwsAccountId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: AwsAccountId."
@@ -3585,13 +3668,13 @@ export async function serializeAws_restJson1_1UpdateDataSourcePermissionsCommand
     }
     resolvedPath = resolvedPath.replace(
       "{AwsAccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AwsAccountId.");
   }
   if (input.DataSourceId !== undefined) {
-    const labelValue: string = input.DataSourceId.toString();
+    const labelValue: string = input.DataSourceId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: DataSourceId."
@@ -3599,7 +3682,7 @@ export async function serializeAws_restJson1_1UpdateDataSourcePermissionsCommand
     }
     resolvedPath = resolvedPath.replace(
       "{DataSourceId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DataSourceId.");
@@ -3642,7 +3725,7 @@ export async function serializeAws_restJson1_1UpdateGroupCommand(
   let resolvedPath =
     "/accounts/{AwsAccountId}/namespaces/{Namespace}/groups/{GroupName}";
   if (input.AwsAccountId !== undefined) {
-    const labelValue: string = input.AwsAccountId.toString();
+    const labelValue: string = input.AwsAccountId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: AwsAccountId."
@@ -3650,31 +3733,31 @@ export async function serializeAws_restJson1_1UpdateGroupCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{AwsAccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AwsAccountId.");
   }
   if (input.GroupName !== undefined) {
-    const labelValue: string = input.GroupName.toString();
+    const labelValue: string = input.GroupName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: GroupName.");
     }
     resolvedPath = resolvedPath.replace(
       "{GroupName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: GroupName.");
   }
   if (input.Namespace !== undefined) {
-    const labelValue: string = input.Namespace.toString();
+    const labelValue: string = input.Namespace;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Namespace.");
     }
     resolvedPath = resolvedPath.replace(
       "{Namespace}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Namespace.");
@@ -3704,7 +3787,7 @@ export async function serializeAws_restJson1_1UpdateIAMPolicyAssignmentCommand(
   let resolvedPath =
     "/accounts/{AwsAccountId}/namespaces/{Namespace}/iam-policy-assignments/{AssignmentName}";
   if (input.AssignmentName !== undefined) {
-    const labelValue: string = input.AssignmentName.toString();
+    const labelValue: string = input.AssignmentName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: AssignmentName."
@@ -3712,13 +3795,13 @@ export async function serializeAws_restJson1_1UpdateIAMPolicyAssignmentCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{AssignmentName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AssignmentName.");
   }
   if (input.AwsAccountId !== undefined) {
-    const labelValue: string = input.AwsAccountId.toString();
+    const labelValue: string = input.AwsAccountId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: AwsAccountId."
@@ -3726,19 +3809,19 @@ export async function serializeAws_restJson1_1UpdateIAMPolicyAssignmentCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{AwsAccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AwsAccountId.");
   }
   if (input.Namespace !== undefined) {
-    const labelValue: string = input.Namespace.toString();
+    const labelValue: string = input.Namespace;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Namespace.");
     }
     resolvedPath = resolvedPath.replace(
       "{Namespace}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Namespace.");
@@ -3776,7 +3859,7 @@ export async function serializeAws_restJson1_1UpdateTemplateCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/accounts/{AwsAccountId}/templates/{TemplateId}";
   if (input.AwsAccountId !== undefined) {
-    const labelValue: string = input.AwsAccountId.toString();
+    const labelValue: string = input.AwsAccountId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: AwsAccountId."
@@ -3784,19 +3867,19 @@ export async function serializeAws_restJson1_1UpdateTemplateCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{AwsAccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AwsAccountId.");
   }
   if (input.TemplateId !== undefined) {
-    const labelValue: string = input.TemplateId.toString();
+    const labelValue: string = input.TemplateId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: TemplateId.");
     }
     resolvedPath = resolvedPath.replace(
       "{TemplateId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: TemplateId.");
@@ -3835,19 +3918,19 @@ export async function serializeAws_restJson1_1UpdateTemplateAliasCommand(
   let resolvedPath =
     "/accounts/{AwsAccountId}/templates/{TemplateId}/aliases/{AliasName}";
   if (input.AliasName !== undefined) {
-    const labelValue: string = input.AliasName.toString();
+    const labelValue: string = input.AliasName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: AliasName.");
     }
     resolvedPath = resolvedPath.replace(
       "{AliasName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AliasName.");
   }
   if (input.AwsAccountId !== undefined) {
-    const labelValue: string = input.AwsAccountId.toString();
+    const labelValue: string = input.AwsAccountId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: AwsAccountId."
@@ -3855,19 +3938,19 @@ export async function serializeAws_restJson1_1UpdateTemplateAliasCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{AwsAccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AwsAccountId.");
   }
   if (input.TemplateId !== undefined) {
-    const labelValue: string = input.TemplateId.toString();
+    const labelValue: string = input.TemplateId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: TemplateId.");
     }
     resolvedPath = resolvedPath.replace(
       "{TemplateId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: TemplateId.");
@@ -3897,7 +3980,7 @@ export async function serializeAws_restJson1_1UpdateTemplatePermissionsCommand(
   let resolvedPath =
     "/accounts/{AwsAccountId}/templates/{TemplateId}/permissions";
   if (input.AwsAccountId !== undefined) {
-    const labelValue: string = input.AwsAccountId.toString();
+    const labelValue: string = input.AwsAccountId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: AwsAccountId."
@@ -3905,19 +3988,19 @@ export async function serializeAws_restJson1_1UpdateTemplatePermissionsCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{AwsAccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AwsAccountId.");
   }
   if (input.TemplateId !== undefined) {
-    const labelValue: string = input.TemplateId.toString();
+    const labelValue: string = input.TemplateId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: TemplateId.");
     }
     resolvedPath = resolvedPath.replace(
       "{TemplateId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: TemplateId.");
@@ -3960,7 +4043,7 @@ export async function serializeAws_restJson1_1UpdateUserCommand(
   let resolvedPath =
     "/accounts/{AwsAccountId}/namespaces/{Namespace}/users/{UserName}";
   if (input.AwsAccountId !== undefined) {
-    const labelValue: string = input.AwsAccountId.toString();
+    const labelValue: string = input.AwsAccountId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: AwsAccountId."
@@ -3968,31 +4051,31 @@ export async function serializeAws_restJson1_1UpdateUserCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{AwsAccountId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: AwsAccountId.");
   }
   if (input.Namespace !== undefined) {
-    const labelValue: string = input.Namespace.toString();
+    const labelValue: string = input.Namespace;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Namespace.");
     }
     resolvedPath = resolvedPath.replace(
       "{Namespace}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Namespace.");
   }
   if (input.UserName !== undefined) {
-    const labelValue: string = input.UserName.toString();
+    const labelValue: string = input.UserName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: UserName.");
     }
     resolvedPath = resolvedPath.replace(
       "{UserName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: UserName.");

--- a/clients/client-ram/models/index.ts
+++ b/clients/client-ram/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export interface AcceptResourceShareInvitationRequest {
@@ -16,7 +19,7 @@ export interface AcceptResourceShareInvitationRequest {
 
 export namespace AcceptResourceShareInvitationRequest {
   export function isa(o: any): o is AcceptResourceShareInvitationRequest {
-    return _smithy.isa(o, "AcceptResourceShareInvitationRequest");
+    return __isa(o, "AcceptResourceShareInvitationRequest");
   }
 }
 
@@ -35,7 +38,7 @@ export interface AcceptResourceShareInvitationResponse extends $MetadataBearer {
 
 export namespace AcceptResourceShareInvitationResponse {
   export function isa(o: any): o is AcceptResourceShareInvitationResponse {
-    return _smithy.isa(o, "AcceptResourceShareInvitationResponse");
+    return __isa(o, "AcceptResourceShareInvitationResponse");
   }
 }
 
@@ -66,7 +69,7 @@ export interface AssociateResourceSharePermissionRequest {
 
 export namespace AssociateResourceSharePermissionRequest {
   export function isa(o: any): o is AssociateResourceSharePermissionRequest {
-    return _smithy.isa(o, "AssociateResourceSharePermissionRequest");
+    return __isa(o, "AssociateResourceSharePermissionRequest");
   }
 }
 
@@ -86,7 +89,7 @@ export interface AssociateResourceSharePermissionResponse
 
 export namespace AssociateResourceSharePermissionResponse {
   export function isa(o: any): o is AssociateResourceSharePermissionResponse {
-    return _smithy.isa(o, "AssociateResourceSharePermissionResponse");
+    return __isa(o, "AssociateResourceSharePermissionResponse");
   }
 }
 
@@ -115,7 +118,7 @@ export interface AssociateResourceShareRequest {
 
 export namespace AssociateResourceShareRequest {
   export function isa(o: any): o is AssociateResourceShareRequest {
-    return _smithy.isa(o, "AssociateResourceShareRequest");
+    return __isa(o, "AssociateResourceShareRequest");
   }
 }
 
@@ -134,7 +137,7 @@ export interface AssociateResourceShareResponse extends $MetadataBearer {
 
 export namespace AssociateResourceShareResponse {
   export function isa(o: any): o is AssociateResourceShareResponse {
-    return _smithy.isa(o, "AssociateResourceShareResponse");
+    return __isa(o, "AssociateResourceShareResponse");
   }
 }
 
@@ -181,7 +184,7 @@ export interface CreateResourceShareRequest {
 
 export namespace CreateResourceShareRequest {
   export function isa(o: any): o is CreateResourceShareRequest {
-    return _smithy.isa(o, "CreateResourceShareRequest");
+    return __isa(o, "CreateResourceShareRequest");
   }
 }
 
@@ -200,7 +203,7 @@ export interface CreateResourceShareResponse extends $MetadataBearer {
 
 export namespace CreateResourceShareResponse {
   export function isa(o: any): o is CreateResourceShareResponse {
-    return _smithy.isa(o, "CreateResourceShareResponse");
+    return __isa(o, "CreateResourceShareResponse");
   }
 }
 
@@ -219,7 +222,7 @@ export interface DeleteResourceShareRequest {
 
 export namespace DeleteResourceShareRequest {
   export function isa(o: any): o is DeleteResourceShareRequest {
-    return _smithy.isa(o, "DeleteResourceShareRequest");
+    return __isa(o, "DeleteResourceShareRequest");
   }
 }
 
@@ -238,7 +241,7 @@ export interface DeleteResourceShareResponse extends $MetadataBearer {
 
 export namespace DeleteResourceShareResponse {
   export function isa(o: any): o is DeleteResourceShareResponse {
-    return _smithy.isa(o, "DeleteResourceShareResponse");
+    return __isa(o, "DeleteResourceShareResponse");
   }
 }
 
@@ -262,7 +265,7 @@ export interface DisassociateResourceSharePermissionRequest {
 
 export namespace DisassociateResourceSharePermissionRequest {
   export function isa(o: any): o is DisassociateResourceSharePermissionRequest {
-    return _smithy.isa(o, "DisassociateResourceSharePermissionRequest");
+    return __isa(o, "DisassociateResourceSharePermissionRequest");
   }
 }
 
@@ -284,7 +287,7 @@ export namespace DisassociateResourceSharePermissionResponse {
   export function isa(
     o: any
   ): o is DisassociateResourceSharePermissionResponse {
-    return _smithy.isa(o, "DisassociateResourceSharePermissionResponse");
+    return __isa(o, "DisassociateResourceSharePermissionResponse");
   }
 }
 
@@ -313,7 +316,7 @@ export interface DisassociateResourceShareRequest {
 
 export namespace DisassociateResourceShareRequest {
   export function isa(o: any): o is DisassociateResourceShareRequest {
-    return _smithy.isa(o, "DisassociateResourceShareRequest");
+    return __isa(o, "DisassociateResourceShareRequest");
   }
 }
 
@@ -332,7 +335,7 @@ export interface DisassociateResourceShareResponse extends $MetadataBearer {
 
 export namespace DisassociateResourceShareResponse {
   export function isa(o: any): o is DisassociateResourceShareResponse {
-    return _smithy.isa(o, "DisassociateResourceShareResponse");
+    return __isa(o, "DisassociateResourceShareResponse");
   }
 }
 
@@ -342,7 +345,7 @@ export interface EnableSharingWithAwsOrganizationRequest {
 
 export namespace EnableSharingWithAwsOrganizationRequest {
   export function isa(o: any): o is EnableSharingWithAwsOrganizationRequest {
-    return _smithy.isa(o, "EnableSharingWithAwsOrganizationRequest");
+    return __isa(o, "EnableSharingWithAwsOrganizationRequest");
   }
 }
 
@@ -357,7 +360,7 @@ export interface EnableSharingWithAwsOrganizationResponse
 
 export namespace EnableSharingWithAwsOrganizationResponse {
   export function isa(o: any): o is EnableSharingWithAwsOrganizationResponse {
-    return _smithy.isa(o, "EnableSharingWithAwsOrganizationResponse");
+    return __isa(o, "EnableSharingWithAwsOrganizationResponse");
   }
 }
 
@@ -376,7 +379,7 @@ export interface GetPermissionRequest {
 
 export namespace GetPermissionRequest {
   export function isa(o: any): o is GetPermissionRequest {
-    return _smithy.isa(o, "GetPermissionRequest");
+    return __isa(o, "GetPermissionRequest");
   }
 }
 
@@ -390,7 +393,7 @@ export interface GetPermissionResponse extends $MetadataBearer {
 
 export namespace GetPermissionResponse {
   export function isa(o: any): o is GetPermissionResponse {
-    return _smithy.isa(o, "GetPermissionResponse");
+    return __isa(o, "GetPermissionResponse");
   }
 }
 
@@ -420,7 +423,7 @@ export interface GetResourcePoliciesRequest {
 
 export namespace GetResourcePoliciesRequest {
   export function isa(o: any): o is GetResourcePoliciesRequest {
-    return _smithy.isa(o, "GetResourcePoliciesRequest");
+    return __isa(o, "GetResourcePoliciesRequest");
   }
 }
 
@@ -439,7 +442,7 @@ export interface GetResourcePoliciesResponse extends $MetadataBearer {
 
 export namespace GetResourcePoliciesResponse {
   export function isa(o: any): o is GetResourcePoliciesResponse {
-    return _smithy.isa(o, "GetResourcePoliciesResponse");
+    return __isa(o, "GetResourcePoliciesResponse");
   }
 }
 
@@ -488,7 +491,7 @@ export interface GetResourceShareAssociationsRequest {
 
 export namespace GetResourceShareAssociationsRequest {
   export function isa(o: any): o is GetResourceShareAssociationsRequest {
-    return _smithy.isa(o, "GetResourceShareAssociationsRequest");
+    return __isa(o, "GetResourceShareAssociationsRequest");
   }
 }
 
@@ -507,7 +510,7 @@ export interface GetResourceShareAssociationsResponse extends $MetadataBearer {
 
 export namespace GetResourceShareAssociationsResponse {
   export function isa(o: any): o is GetResourceShareAssociationsResponse {
-    return _smithy.isa(o, "GetResourceShareAssociationsResponse");
+    return __isa(o, "GetResourceShareAssociationsResponse");
   }
 }
 
@@ -537,7 +540,7 @@ export interface GetResourceShareInvitationsRequest {
 
 export namespace GetResourceShareInvitationsRequest {
   export function isa(o: any): o is GetResourceShareInvitationsRequest {
-    return _smithy.isa(o, "GetResourceShareInvitationsRequest");
+    return __isa(o, "GetResourceShareInvitationsRequest");
   }
 }
 
@@ -556,7 +559,7 @@ export interface GetResourceShareInvitationsResponse extends $MetadataBearer {
 
 export namespace GetResourceShareInvitationsResponse {
   export function isa(o: any): o is GetResourceShareInvitationsResponse {
-    return _smithy.isa(o, "GetResourceShareInvitationsResponse");
+    return __isa(o, "GetResourceShareInvitationsResponse");
   }
 }
 
@@ -601,7 +604,7 @@ export interface GetResourceSharesRequest {
 
 export namespace GetResourceSharesRequest {
   export function isa(o: any): o is GetResourceSharesRequest {
-    return _smithy.isa(o, "GetResourceSharesRequest");
+    return __isa(o, "GetResourceSharesRequest");
   }
 }
 
@@ -620,7 +623,7 @@ export interface GetResourceSharesResponse extends $MetadataBearer {
 
 export namespace GetResourceSharesResponse {
   export function isa(o: any): o is GetResourceSharesResponse {
-    return _smithy.isa(o, "GetResourceSharesResponse");
+    return __isa(o, "GetResourceSharesResponse");
   }
 }
 
@@ -629,7 +632,7 @@ export namespace GetResourceSharesResponse {
  *         the other input parameters is different from the previous call to the operation.</p>
  */
 export interface IdempotentParameterMismatchException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "IdempotentParameterMismatchException";
   $fault: "client";
@@ -638,7 +641,7 @@ export interface IdempotentParameterMismatchException
 
 export namespace IdempotentParameterMismatchException {
   export function isa(o: any): o is IdempotentParameterMismatchException {
-    return _smithy.isa(o, "IdempotentParameterMismatchException");
+    return __isa(o, "IdempotentParameterMismatchException");
   }
 }
 
@@ -646,7 +649,7 @@ export namespace IdempotentParameterMismatchException {
  * <p>A client token is not valid.</p>
  */
 export interface InvalidClientTokenException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidClientTokenException";
   $fault: "client";
@@ -655,7 +658,7 @@ export interface InvalidClientTokenException
 
 export namespace InvalidClientTokenException {
   export function isa(o: any): o is InvalidClientTokenException {
-    return _smithy.isa(o, "InvalidClientTokenException");
+    return __isa(o, "InvalidClientTokenException");
   }
 }
 
@@ -663,7 +666,7 @@ export namespace InvalidClientTokenException {
  * <p>The specified value for MaxResults is not valid.</p>
  */
 export interface InvalidMaxResultsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidMaxResultsException";
   $fault: "client";
@@ -672,7 +675,7 @@ export interface InvalidMaxResultsException
 
 export namespace InvalidMaxResultsException {
   export function isa(o: any): o is InvalidMaxResultsException {
-    return _smithy.isa(o, "InvalidMaxResultsException");
+    return __isa(o, "InvalidMaxResultsException");
   }
 }
 
@@ -680,7 +683,7 @@ export namespace InvalidMaxResultsException {
  * <p>The specified value for NextToken is not valid.</p>
  */
 export interface InvalidNextTokenException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidNextTokenException";
   $fault: "client";
@@ -689,7 +692,7 @@ export interface InvalidNextTokenException
 
 export namespace InvalidNextTokenException {
   export function isa(o: any): o is InvalidNextTokenException {
-    return _smithy.isa(o, "InvalidNextTokenException");
+    return __isa(o, "InvalidNextTokenException");
   }
 }
 
@@ -697,7 +700,7 @@ export namespace InvalidNextTokenException {
  * <p>A parameter is not valid.</p>
  */
 export interface InvalidParameterException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidParameterException";
   $fault: "client";
@@ -706,7 +709,7 @@ export interface InvalidParameterException
 
 export namespace InvalidParameterException {
   export function isa(o: any): o is InvalidParameterException {
-    return _smithy.isa(o, "InvalidParameterException");
+    return __isa(o, "InvalidParameterException");
   }
 }
 
@@ -714,7 +717,7 @@ export namespace InvalidParameterException {
  * <p>The specified resource type is not valid.</p>
  */
 export interface InvalidResourceTypeException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidResourceTypeException";
   $fault: "client";
@@ -723,7 +726,7 @@ export interface InvalidResourceTypeException
 
 export namespace InvalidResourceTypeException {
   export function isa(o: any): o is InvalidResourceTypeException {
-    return _smithy.isa(o, "InvalidResourceTypeException");
+    return __isa(o, "InvalidResourceTypeException");
   }
 }
 
@@ -731,7 +734,7 @@ export namespace InvalidResourceTypeException {
  * <p>The requested state transition is not valid.</p>
  */
 export interface InvalidStateTransitionException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidStateTransitionException";
   $fault: "client";
@@ -740,7 +743,7 @@ export interface InvalidStateTransitionException
 
 export namespace InvalidStateTransitionException {
   export function isa(o: any): o is InvalidStateTransitionException {
-    return _smithy.isa(o, "InvalidStateTransitionException");
+    return __isa(o, "InvalidStateTransitionException");
   }
 }
 
@@ -765,7 +768,7 @@ export interface ListPendingInvitationResourcesRequest {
 
 export namespace ListPendingInvitationResourcesRequest {
   export function isa(o: any): o is ListPendingInvitationResourcesRequest {
-    return _smithy.isa(o, "ListPendingInvitationResourcesRequest");
+    return __isa(o, "ListPendingInvitationResourcesRequest");
   }
 }
 
@@ -785,7 +788,7 @@ export interface ListPendingInvitationResourcesResponse
 
 export namespace ListPendingInvitationResourcesResponse {
   export function isa(o: any): o is ListPendingInvitationResourcesResponse {
-    return _smithy.isa(o, "ListPendingInvitationResourcesResponse");
+    return __isa(o, "ListPendingInvitationResourcesResponse");
   }
 }
 
@@ -811,7 +814,7 @@ export interface ListPermissionsRequest {
 
 export namespace ListPermissionsRequest {
   export function isa(o: any): o is ListPermissionsRequest {
-    return _smithy.isa(o, "ListPermissionsRequest");
+    return __isa(o, "ListPermissionsRequest");
   }
 }
 
@@ -830,7 +833,7 @@ export interface ListPermissionsResponse extends $MetadataBearer {
 
 export namespace ListPermissionsResponse {
   export function isa(o: any): o is ListPermissionsResponse {
-    return _smithy.isa(o, "ListPermissionsResponse");
+    return __isa(o, "ListPermissionsResponse");
   }
 }
 
@@ -881,7 +884,7 @@ export interface ListPrincipalsRequest {
 
 export namespace ListPrincipalsRequest {
   export function isa(o: any): o is ListPrincipalsRequest {
-    return _smithy.isa(o, "ListPrincipalsRequest");
+    return __isa(o, "ListPrincipalsRequest");
   }
 }
 
@@ -900,7 +903,7 @@ export interface ListPrincipalsResponse extends $MetadataBearer {
 
 export namespace ListPrincipalsResponse {
   export function isa(o: any): o is ListPrincipalsResponse {
-    return _smithy.isa(o, "ListPrincipalsResponse");
+    return __isa(o, "ListPrincipalsResponse");
   }
 }
 
@@ -925,7 +928,7 @@ export interface ListResourceSharePermissionsRequest {
 
 export namespace ListResourceSharePermissionsRequest {
   export function isa(o: any): o is ListResourceSharePermissionsRequest {
-    return _smithy.isa(o, "ListResourceSharePermissionsRequest");
+    return __isa(o, "ListResourceSharePermissionsRequest");
   }
 }
 
@@ -944,7 +947,7 @@ export interface ListResourceSharePermissionsResponse extends $MetadataBearer {
 
 export namespace ListResourceSharePermissionsResponse {
   export function isa(o: any): o is ListResourceSharePermissionsResponse {
-    return _smithy.isa(o, "ListResourceSharePermissionsResponse");
+    return __isa(o, "ListResourceSharePermissionsResponse");
   }
 }
 
@@ -995,7 +998,7 @@ export interface ListResourcesRequest {
 
 export namespace ListResourcesRequest {
   export function isa(o: any): o is ListResourcesRequest {
-    return _smithy.isa(o, "ListResourcesRequest");
+    return __isa(o, "ListResourcesRequest");
   }
 }
 
@@ -1014,7 +1017,7 @@ export interface ListResourcesResponse extends $MetadataBearer {
 
 export namespace ListResourcesResponse {
   export function isa(o: any): o is ListResourcesResponse {
-    return _smithy.isa(o, "ListResourcesResponse");
+    return __isa(o, "ListResourcesResponse");
   }
 }
 
@@ -1022,7 +1025,7 @@ export namespace ListResourcesResponse {
  * <p>The format of an Amazon Resource Name (ARN) is not valid.</p>
  */
 export interface MalformedArnException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "MalformedArnException";
   $fault: "client";
@@ -1031,7 +1034,7 @@ export interface MalformedArnException
 
 export namespace MalformedArnException {
   export function isa(o: any): o is MalformedArnException {
-    return _smithy.isa(o, "MalformedArnException");
+    return __isa(o, "MalformedArnException");
   }
 }
 
@@ -1039,7 +1042,7 @@ export namespace MalformedArnException {
  * <p>A required input parameter is missing.</p>
  */
 export interface MissingRequiredParameterException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "MissingRequiredParameterException";
   $fault: "client";
@@ -1048,7 +1051,7 @@ export interface MissingRequiredParameterException
 
 export namespace MissingRequiredParameterException {
   export function isa(o: any): o is MissingRequiredParameterException {
-    return _smithy.isa(o, "MissingRequiredParameterException");
+    return __isa(o, "MissingRequiredParameterException");
   }
 }
 
@@ -1056,7 +1059,7 @@ export namespace MissingRequiredParameterException {
  * <p>The requested operation is not permitted.</p>
  */
 export interface OperationNotPermittedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "OperationNotPermittedException";
   $fault: "client";
@@ -1065,7 +1068,7 @@ export interface OperationNotPermittedException
 
 export namespace OperationNotPermittedException {
   export function isa(o: any): o is OperationNotPermittedException {
-    return _smithy.isa(o, "OperationNotPermittedException");
+    return __isa(o, "OperationNotPermittedException");
   }
 }
 
@@ -1102,7 +1105,7 @@ export interface Principal {
 
 export namespace Principal {
   export function isa(o: any): o is Principal {
-    return _smithy.isa(o, "Principal");
+    return __isa(o, "Principal");
   }
 }
 
@@ -1118,7 +1121,7 @@ export namespace PromoteResourceShareCreatedFromPolicyRequest {
   export function isa(
     o: any
   ): o is PromoteResourceShareCreatedFromPolicyRequest {
-    return _smithy.isa(o, "PromoteResourceShareCreatedFromPolicyRequest");
+    return __isa(o, "PromoteResourceShareCreatedFromPolicyRequest");
   }
 }
 
@@ -1135,7 +1138,7 @@ export namespace PromoteResourceShareCreatedFromPolicyResponse {
   export function isa(
     o: any
   ): o is PromoteResourceShareCreatedFromPolicyResponse {
-    return _smithy.isa(o, "PromoteResourceShareCreatedFromPolicyResponse");
+    return __isa(o, "PromoteResourceShareCreatedFromPolicyResponse");
   }
 }
 
@@ -1154,7 +1157,7 @@ export interface RejectResourceShareInvitationRequest {
 
 export namespace RejectResourceShareInvitationRequest {
   export function isa(o: any): o is RejectResourceShareInvitationRequest {
-    return _smithy.isa(o, "RejectResourceShareInvitationRequest");
+    return __isa(o, "RejectResourceShareInvitationRequest");
   }
 }
 
@@ -1173,7 +1176,7 @@ export interface RejectResourceShareInvitationResponse extends $MetadataBearer {
 
 export namespace RejectResourceShareInvitationResponse {
   export function isa(o: any): o is RejectResourceShareInvitationResponse {
-    return _smithy.isa(o, "RejectResourceShareInvitationResponse");
+    return __isa(o, "RejectResourceShareInvitationResponse");
   }
 }
 
@@ -1226,7 +1229,7 @@ export interface Resource {
 
 export namespace Resource {
   export function isa(o: any): o is Resource {
-    return _smithy.isa(o, "Resource");
+    return __isa(o, "Resource");
   }
 }
 
@@ -1234,7 +1237,7 @@ export namespace Resource {
  * <p>An Amazon Resource Name (ARN) was not found.</p>
  */
 export interface ResourceArnNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceArnNotFoundException";
   $fault: "client";
@@ -1243,7 +1246,7 @@ export interface ResourceArnNotFoundException
 
 export namespace ResourceArnNotFoundException {
   export function isa(o: any): o is ResourceArnNotFoundException {
-    return _smithy.isa(o, "ResourceArnNotFoundException");
+    return __isa(o, "ResourceArnNotFoundException");
   }
 }
 
@@ -1331,7 +1334,7 @@ export interface ResourceShare {
 
 export namespace ResourceShare {
   export function isa(o: any): o is ResourceShare {
-    return _smithy.isa(o, "ResourceShare");
+    return __isa(o, "ResourceShare");
   }
 }
 
@@ -1390,7 +1393,7 @@ export interface ResourceShareAssociation {
 
 export namespace ResourceShareAssociation {
   export function isa(o: any): o is ResourceShareAssociation {
-    return _smithy.isa(o, "ResourceShareAssociation");
+    return __isa(o, "ResourceShareAssociation");
   }
 }
 
@@ -1458,7 +1461,7 @@ export interface ResourceShareInvitation {
 
 export namespace ResourceShareInvitation {
   export function isa(o: any): o is ResourceShareInvitation {
-    return _smithy.isa(o, "ResourceShareInvitation");
+    return __isa(o, "ResourceShareInvitation");
   }
 }
 
@@ -1466,7 +1469,7 @@ export namespace ResourceShareInvitation {
  * <p>The invitation was already accepted.</p>
  */
 export interface ResourceShareInvitationAlreadyAcceptedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceShareInvitationAlreadyAcceptedException";
   $fault: "client";
@@ -1477,7 +1480,7 @@ export namespace ResourceShareInvitationAlreadyAcceptedException {
   export function isa(
     o: any
   ): o is ResourceShareInvitationAlreadyAcceptedException {
-    return _smithy.isa(o, "ResourceShareInvitationAlreadyAcceptedException");
+    return __isa(o, "ResourceShareInvitationAlreadyAcceptedException");
   }
 }
 
@@ -1485,7 +1488,7 @@ export namespace ResourceShareInvitationAlreadyAcceptedException {
  * <p>The invitation was already rejected.</p>
  */
 export interface ResourceShareInvitationAlreadyRejectedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceShareInvitationAlreadyRejectedException";
   $fault: "client";
@@ -1496,7 +1499,7 @@ export namespace ResourceShareInvitationAlreadyRejectedException {
   export function isa(
     o: any
   ): o is ResourceShareInvitationAlreadyRejectedException {
-    return _smithy.isa(o, "ResourceShareInvitationAlreadyRejectedException");
+    return __isa(o, "ResourceShareInvitationAlreadyRejectedException");
   }
 }
 
@@ -1504,7 +1507,7 @@ export namespace ResourceShareInvitationAlreadyRejectedException {
  * <p>The Amazon Resource Name (ARN) for an invitation was not found.</p>
  */
 export interface ResourceShareInvitationArnNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceShareInvitationArnNotFoundException";
   $fault: "client";
@@ -1515,7 +1518,7 @@ export namespace ResourceShareInvitationArnNotFoundException {
   export function isa(
     o: any
   ): o is ResourceShareInvitationArnNotFoundException {
-    return _smithy.isa(o, "ResourceShareInvitationArnNotFoundException");
+    return __isa(o, "ResourceShareInvitationArnNotFoundException");
   }
 }
 
@@ -1523,7 +1526,7 @@ export namespace ResourceShareInvitationArnNotFoundException {
  * <p>The invitation is expired.</p>
  */
 export interface ResourceShareInvitationExpiredException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceShareInvitationExpiredException";
   $fault: "client";
@@ -1532,7 +1535,7 @@ export interface ResourceShareInvitationExpiredException
 
 export namespace ResourceShareInvitationExpiredException {
   export function isa(o: any): o is ResourceShareInvitationExpiredException {
-    return _smithy.isa(o, "ResourceShareInvitationExpiredException");
+    return __isa(o, "ResourceShareInvitationExpiredException");
   }
 }
 
@@ -1546,7 +1549,7 @@ export type ResourceShareInvitationStatus =
  * <p>The requested resource share exceeds the limit for your account.</p>
  */
 export interface ResourceShareLimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceShareLimitExceededException";
   $fault: "client";
@@ -1555,7 +1558,7 @@ export interface ResourceShareLimitExceededException
 
 export namespace ResourceShareLimitExceededException {
   export function isa(o: any): o is ResourceShareLimitExceededException {
-    return _smithy.isa(o, "ResourceShareLimitExceededException");
+    return __isa(o, "ResourceShareLimitExceededException");
   }
 }
 
@@ -1610,7 +1613,7 @@ export interface ResourceSharePermissionDetail {
 
 export namespace ResourceSharePermissionDetail {
   export function isa(o: any): o is ResourceSharePermissionDetail {
-    return _smithy.isa(o, "ResourceSharePermissionDetail");
+    return __isa(o, "ResourceSharePermissionDetail");
   }
 }
 
@@ -1662,7 +1665,7 @@ export interface ResourceSharePermissionSummary {
 
 export namespace ResourceSharePermissionSummary {
   export function isa(o: any): o is ResourceSharePermissionSummary {
-    return _smithy.isa(o, "ResourceSharePermissionSummary");
+    return __isa(o, "ResourceSharePermissionSummary");
   }
 }
 
@@ -1684,7 +1687,7 @@ export type ResourceStatus =
  * <p>The service could not respond to the request due to an internal problem.</p>
  */
 export interface ServerInternalException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ServerInternalException";
   $fault: "server";
@@ -1693,7 +1696,7 @@ export interface ServerInternalException
 
 export namespace ServerInternalException {
   export function isa(o: any): o is ServerInternalException {
-    return _smithy.isa(o, "ServerInternalException");
+    return __isa(o, "ServerInternalException");
   }
 }
 
@@ -1701,7 +1704,7 @@ export namespace ServerInternalException {
  * <p>The service is not available.</p>
  */
 export interface ServiceUnavailableException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ServiceUnavailableException";
   $fault: "server";
@@ -1710,7 +1713,7 @@ export interface ServiceUnavailableException
 
 export namespace ServiceUnavailableException {
   export function isa(o: any): o is ServiceUnavailableException {
-    return _smithy.isa(o, "ServiceUnavailableException");
+    return __isa(o, "ServiceUnavailableException");
   }
 }
 
@@ -1732,7 +1735,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -1754,7 +1757,7 @@ export interface TagFilter {
 
 export namespace TagFilter {
   export function isa(o: any): o is TagFilter {
-    return _smithy.isa(o, "TagFilter");
+    return __isa(o, "TagFilter");
   }
 }
 
@@ -1762,7 +1765,7 @@ export namespace TagFilter {
  * <p>The requested tags exceed the limit for your account.</p>
  */
 export interface TagLimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TagLimitExceededException";
   $fault: "client";
@@ -1771,7 +1774,7 @@ export interface TagLimitExceededException
 
 export namespace TagLimitExceededException {
   export function isa(o: any): o is TagLimitExceededException {
-    return _smithy.isa(o, "TagLimitExceededException");
+    return __isa(o, "TagLimitExceededException");
   }
 }
 
@@ -1779,7 +1782,7 @@ export namespace TagLimitExceededException {
  * <p>The specified tag is a reserved word and cannot be used.</p>
  */
 export interface TagPolicyViolationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TagPolicyViolationException";
   $fault: "client";
@@ -1788,7 +1791,7 @@ export interface TagPolicyViolationException
 
 export namespace TagPolicyViolationException {
   export function isa(o: any): o is TagPolicyViolationException {
-    return _smithy.isa(o, "TagPolicyViolationException");
+    return __isa(o, "TagPolicyViolationException");
   }
 }
 
@@ -1807,7 +1810,7 @@ export interface TagResourceRequest {
 
 export namespace TagResourceRequest {
   export function isa(o: any): o is TagResourceRequest {
-    return _smithy.isa(o, "TagResourceRequest");
+    return __isa(o, "TagResourceRequest");
   }
 }
 
@@ -1817,7 +1820,7 @@ export interface TagResourceResponse extends $MetadataBearer {
 
 export namespace TagResourceResponse {
   export function isa(o: any): o is TagResourceResponse {
-    return _smithy.isa(o, "TagResourceResponse");
+    return __isa(o, "TagResourceResponse");
   }
 }
 
@@ -1825,7 +1828,7 @@ export namespace TagResourceResponse {
  * <p>A specified resource was not found.</p>
  */
 export interface UnknownResourceException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UnknownResourceException";
   $fault: "client";
@@ -1834,7 +1837,7 @@ export interface UnknownResourceException
 
 export namespace UnknownResourceException {
   export function isa(o: any): o is UnknownResourceException {
-    return _smithy.isa(o, "UnknownResourceException");
+    return __isa(o, "UnknownResourceException");
   }
 }
 
@@ -1853,7 +1856,7 @@ export interface UntagResourceRequest {
 
 export namespace UntagResourceRequest {
   export function isa(o: any): o is UntagResourceRequest {
-    return _smithy.isa(o, "UntagResourceRequest");
+    return __isa(o, "UntagResourceRequest");
   }
 }
 
@@ -1863,7 +1866,7 @@ export interface UntagResourceResponse extends $MetadataBearer {
 
 export namespace UntagResourceResponse {
   export function isa(o: any): o is UntagResourceResponse {
-    return _smithy.isa(o, "UntagResourceResponse");
+    return __isa(o, "UntagResourceResponse");
   }
 }
 
@@ -1892,7 +1895,7 @@ export interface UpdateResourceShareRequest {
 
 export namespace UpdateResourceShareRequest {
   export function isa(o: any): o is UpdateResourceShareRequest {
-    return _smithy.isa(o, "UpdateResourceShareRequest");
+    return __isa(o, "UpdateResourceShareRequest");
   }
 }
 
@@ -1911,6 +1914,6 @@ export interface UpdateResourceShareResponse extends $MetadataBearer {
 
 export namespace UpdateResourceShareResponse {
   export function isa(o: any): o is UpdateResourceShareResponse {
-    return _smithy.isa(o, "UpdateResourceShareResponse");
+    return __isa(o, "UpdateResourceShareResponse");
   }
 }

--- a/clients/client-ram/protocols/Aws_restJson1_1.ts
+++ b/clients/client-ram/protocols/Aws_restJson1_1.ts
@@ -126,7 +126,10 @@ import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  extendedEncodeURIComponent as __extendedEncodeURIComponent
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -289,10 +292,14 @@ export async function serializeAws_restJson1_1DeleteResourceShareCommand(
   let resolvedPath = "/deleteresourceshare";
   const query: any = {};
   if (input.clientToken !== undefined) {
-    query["clientToken"] = input.clientToken.toString();
+    query[
+      __extendedEncodeURIComponent("clientToken")
+    ] = __extendedEncodeURIComponent(input.clientToken);
   }
   if (input.resourceShareArn !== undefined) {
-    query["resourceShareArn"] = input.resourceShareArn.toString();
+    query[
+      __extendedEncodeURIComponent("resourceShareArn")
+    ] = __extendedEncodeURIComponent(input.resourceShareArn);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -779,7 +786,9 @@ export async function serializeAws_restJson1_1PromoteResourceShareCreatedFromPol
   let resolvedPath = "/promoteresourcesharecreatedfrompolicy";
   const query: any = {};
   if (input.resourceShareArn !== undefined) {
-    query["resourceShareArn"] = input.resourceShareArn.toString();
+    query[
+      __extendedEncodeURIComponent("resourceShareArn")
+    ] = __extendedEncodeURIComponent(input.resourceShareArn);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -3056,6 +3065,7 @@ export async function deserializeAws_restJson1_1TagResourceCommand(
     $metadata: deserializeMetadata(output),
     __type: "TagResourceResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -3146,6 +3156,7 @@ export async function deserializeAws_restJson1_1UntagResourceCommand(
     $metadata: deserializeMetadata(output),
     __type: "UntagResourceResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 

--- a/clients/client-rds-data/models/index.ts
+++ b/clients/client-rds-data/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -106,7 +109,7 @@ export namespace ArrayValue {
  * <p>There is an error in the call or in a SQL statement.</p>
  */
 export interface BadRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "BadRequestException";
   $fault: "client";
@@ -118,7 +121,7 @@ export interface BadRequestException
 
 export namespace BadRequestException {
   export function isa(o: any): o is BadRequestException {
-    return _smithy.isa(o, "BadRequestException");
+    return __isa(o, "BadRequestException");
   }
 }
 
@@ -170,7 +173,7 @@ export interface BatchExecuteStatementRequest {
 
 export namespace BatchExecuteStatementRequest {
   export function isa(o: any): o is BatchExecuteStatementRequest {
-    return _smithy.isa(o, "BatchExecuteStatementRequest");
+    return __isa(o, "BatchExecuteStatementRequest");
   }
 }
 
@@ -188,7 +191,7 @@ export interface BatchExecuteStatementResponse extends $MetadataBearer {
 
 export namespace BatchExecuteStatementResponse {
   export function isa(o: any): o is BatchExecuteStatementResponse {
-    return _smithy.isa(o, "BatchExecuteStatementResponse");
+    return __isa(o, "BatchExecuteStatementResponse");
   }
 }
 
@@ -221,7 +224,7 @@ export interface BeginTransactionRequest {
 
 export namespace BeginTransactionRequest {
   export function isa(o: any): o is BeginTransactionRequest {
-    return _smithy.isa(o, "BeginTransactionRequest");
+    return __isa(o, "BeginTransactionRequest");
   }
 }
 
@@ -239,7 +242,7 @@ export interface BeginTransactionResponse extends $MetadataBearer {
 
 export namespace BeginTransactionResponse {
   export function isa(o: any): o is BeginTransactionResponse {
-    return _smithy.isa(o, "BeginTransactionResponse");
+    return __isa(o, "BeginTransactionResponse");
   }
 }
 
@@ -321,7 +324,7 @@ export interface ColumnMetadata {
 
 export namespace ColumnMetadata {
   export function isa(o: any): o is ColumnMetadata {
-    return _smithy.isa(o, "ColumnMetadata");
+    return __isa(o, "ColumnMetadata");
   }
 }
 
@@ -348,7 +351,7 @@ export interface CommitTransactionRequest {
 
 export namespace CommitTransactionRequest {
   export function isa(o: any): o is CommitTransactionRequest {
-    return _smithy.isa(o, "CommitTransactionRequest");
+    return __isa(o, "CommitTransactionRequest");
   }
 }
 
@@ -365,7 +368,7 @@ export interface CommitTransactionResponse extends $MetadataBearer {
 
 export namespace CommitTransactionResponse {
   export function isa(o: any): o is CommitTransactionResponse {
-    return _smithy.isa(o, "CommitTransactionResponse");
+    return __isa(o, "CommitTransactionResponse");
   }
 }
 
@@ -406,7 +409,7 @@ export interface ExecuteSqlRequest {
 
 export namespace ExecuteSqlRequest {
   export function isa(o: any): o is ExecuteSqlRequest {
-    return _smithy.isa(o, "ExecuteSqlRequest");
+    return __isa(o, "ExecuteSqlRequest");
   }
 }
 
@@ -424,7 +427,7 @@ export interface ExecuteSqlResponse extends $MetadataBearer {
 
 export namespace ExecuteSqlResponse {
   export function isa(o: any): o is ExecuteSqlResponse {
-    return _smithy.isa(o, "ExecuteSqlResponse");
+    return __isa(o, "ExecuteSqlResponse");
   }
 }
 
@@ -492,7 +495,7 @@ export interface ExecuteStatementRequest {
 
 export namespace ExecuteStatementRequest {
   export function isa(o: any): o is ExecuteStatementRequest {
-    return _smithy.isa(o, "ExecuteStatementRequest");
+    return __isa(o, "ExecuteStatementRequest");
   }
 }
 
@@ -525,7 +528,7 @@ export interface ExecuteStatementResponse extends $MetadataBearer {
 
 export namespace ExecuteStatementResponse {
   export function isa(o: any): o is ExecuteStatementResponse {
-    return _smithy.isa(o, "ExecuteStatementResponse");
+    return __isa(o, "ExecuteStatementResponse");
   }
 }
 
@@ -678,9 +681,7 @@ export namespace Field {
 /**
  * <p>There are insufficient privileges to make the call.</p>
  */
-export interface ForbiddenException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface ForbiddenException extends __SmithyException, $MetadataBearer {
   name: "ForbiddenException";
   $fault: "client";
   /**
@@ -691,7 +692,7 @@ export interface ForbiddenException
 
 export namespace ForbiddenException {
   export function isa(o: any): o is ForbiddenException {
-    return _smithy.isa(o, "ForbiddenException");
+    return __isa(o, "ForbiddenException");
   }
 }
 
@@ -699,7 +700,7 @@ export namespace ForbiddenException {
  * <p>An internal error occurred.</p>
  */
 export interface InternalServerErrorException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalServerErrorException";
   $fault: "server";
@@ -707,16 +708,14 @@ export interface InternalServerErrorException
 
 export namespace InternalServerErrorException {
   export function isa(o: any): o is InternalServerErrorException {
-    return _smithy.isa(o, "InternalServerErrorException");
+    return __isa(o, "InternalServerErrorException");
   }
 }
 
 /**
  * <p>The <code>resourceArn</code>, <code>secretArn</code>, or <code>transactionId</code> value can't be found.</p>
  */
-export interface NotFoundException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface NotFoundException extends __SmithyException, $MetadataBearer {
   name: "NotFoundException";
   $fault: "client";
   /**
@@ -727,7 +726,7 @@ export interface NotFoundException
 
 export namespace NotFoundException {
   export function isa(o: any): o is NotFoundException {
-    return _smithy.isa(o, "NotFoundException");
+    return __isa(o, "NotFoundException");
   }
 }
 
@@ -744,7 +743,7 @@ export interface _Record {
 
 export namespace _Record {
   export function isa(o: any): o is _Record {
-    return _smithy.isa(o, "Record");
+    return __isa(o, "Record");
   }
 }
 
@@ -766,7 +765,7 @@ export interface ResultFrame {
 
 export namespace ResultFrame {
   export function isa(o: any): o is ResultFrame {
-    return _smithy.isa(o, "ResultFrame");
+    return __isa(o, "ResultFrame");
   }
 }
 
@@ -788,7 +787,7 @@ export interface ResultSetMetadata {
 
 export namespace ResultSetMetadata {
   export function isa(o: any): o is ResultSetMetadata {
-    return _smithy.isa(o, "ResultSetMetadata");
+    return __isa(o, "ResultSetMetadata");
   }
 }
 
@@ -816,7 +815,7 @@ export interface RollbackTransactionRequest {
 
 export namespace RollbackTransactionRequest {
   export function isa(o: any): o is RollbackTransactionRequest {
-    return _smithy.isa(o, "RollbackTransactionRequest");
+    return __isa(o, "RollbackTransactionRequest");
   }
 }
 
@@ -834,7 +833,7 @@ export interface RollbackTransactionResponse extends $MetadataBearer {
 
 export namespace RollbackTransactionResponse {
   export function isa(o: any): o is RollbackTransactionResponse {
-    return _smithy.isa(o, "RollbackTransactionResponse");
+    return __isa(o, "RollbackTransactionResponse");
   }
 }
 
@@ -843,7 +842,7 @@ export namespace RollbackTransactionResponse {
  *             available.</p>
  */
 export interface ServiceUnavailableError
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ServiceUnavailableError";
   $fault: "server";
@@ -851,7 +850,7 @@ export interface ServiceUnavailableError
 
 export namespace ServiceUnavailableError {
   export function isa(o: any): o is ServiceUnavailableError {
-    return _smithy.isa(o, "ServiceUnavailableError");
+    return __isa(o, "ServiceUnavailableError");
   }
 }
 
@@ -873,7 +872,7 @@ export interface SqlParameter {
 
 export namespace SqlParameter {
   export function isa(o: any): o is SqlParameter {
-    return _smithy.isa(o, "SqlParameter");
+    return __isa(o, "SqlParameter");
   }
 }
 
@@ -895,7 +894,7 @@ export interface SqlStatementResult {
 
 export namespace SqlStatementResult {
   export function isa(o: any): o is SqlStatementResult {
-    return _smithy.isa(o, "SqlStatementResult");
+    return __isa(o, "SqlStatementResult");
   }
 }
 
@@ -903,7 +902,7 @@ export namespace SqlStatementResult {
  * <p>The execution of the SQL statement timed out.</p>
  */
 export interface StatementTimeoutException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "StatementTimeoutException";
   $fault: "client";
@@ -920,7 +919,7 @@ export interface StatementTimeoutException
 
 export namespace StatementTimeoutException {
   export function isa(o: any): o is StatementTimeoutException {
-    return _smithy.isa(o, "StatementTimeoutException");
+    return __isa(o, "StatementTimeoutException");
   }
 }
 
@@ -937,7 +936,7 @@ export interface StructValue {
 
 export namespace StructValue {
   export function isa(o: any): o is StructValue {
-    return _smithy.isa(o, "StructValue");
+    return __isa(o, "StructValue");
   }
 }
 
@@ -954,7 +953,7 @@ export interface UpdateResult {
 
 export namespace UpdateResult {
   export function isa(o: any): o is UpdateResult {
-    return _smithy.isa(o, "UpdateResult");
+    return __isa(o, "UpdateResult");
   }
 }
 

--- a/clients/client-rds-data/protocols/Aws_restJson1_1.ts
+++ b/clients/client-rds-data/protocols/Aws_restJson1_1.ts
@@ -842,6 +842,7 @@ const deserializeAws_restJson1_1InternalServerErrorExceptionResponse = async (
     $fault: "server",
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return contents;
 };
 
@@ -871,6 +872,7 @@ const deserializeAws_restJson1_1ServiceUnavailableErrorResponse = async (
     $fault: "server",
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return contents;
 };
 

--- a/clients/client-rds/models/index.ts
+++ b/clients/client-rds/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -6,7 +9,7 @@ import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
  *             the specified DB security group.</p>
  */
 export interface AuthorizationAlreadyExistsFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AuthorizationAlreadyExistsFault";
   $fault: "client";
@@ -15,7 +18,7 @@ export interface AuthorizationAlreadyExistsFault
 
 export namespace AuthorizationAlreadyExistsFault {
   export function isa(o: any): o is AuthorizationAlreadyExistsFault {
-    return _smithy.isa(o, "AuthorizationAlreadyExistsFault");
+    return __isa(o, "AuthorizationAlreadyExistsFault");
   }
 }
 
@@ -26,7 +29,7 @@ export namespace AuthorizationAlreadyExistsFault {
  *             behalf.</p>
  */
 export interface AuthorizationNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AuthorizationNotFoundFault";
   $fault: "client";
@@ -35,7 +38,7 @@ export interface AuthorizationNotFoundFault
 
 export namespace AuthorizationNotFoundFault {
   export function isa(o: any): o is AuthorizationNotFoundFault {
-    return _smithy.isa(o, "AuthorizationNotFoundFault");
+    return __isa(o, "AuthorizationNotFoundFault");
   }
 }
 
@@ -43,7 +46,7 @@ export namespace AuthorizationNotFoundFault {
  * <p>The DB security group authorization quota has been reached.</p>
  */
 export interface AuthorizationQuotaExceededFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AuthorizationQuotaExceededFault";
   $fault: "client";
@@ -52,12 +55,12 @@ export interface AuthorizationQuotaExceededFault
 
 export namespace AuthorizationQuotaExceededFault {
   export function isa(o: any): o is AuthorizationQuotaExceededFault {
-    return _smithy.isa(o, "AuthorizationQuotaExceededFault");
+    return __isa(o, "AuthorizationQuotaExceededFault");
   }
 }
 
 export interface BackupPolicyNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "BackupPolicyNotFoundFault";
   $fault: "client";
@@ -66,7 +69,7 @@ export interface BackupPolicyNotFoundFault
 
 export namespace BackupPolicyNotFoundFault {
   export function isa(o: any): o is BackupPolicyNotFoundFault {
-    return _smithy.isa(o, "BackupPolicyNotFoundFault");
+    return __isa(o, "BackupPolicyNotFoundFault");
   }
 }
 
@@ -77,7 +80,7 @@ export namespace BackupPolicyNotFoundFault {
  *         </p>
  */
 export interface CertificateNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CertificateNotFoundFault";
   $fault: "client";
@@ -86,7 +89,7 @@ export interface CertificateNotFoundFault
 
 export namespace CertificateNotFoundFault {
   export function isa(o: any): o is CertificateNotFoundFault {
-    return _smithy.isa(o, "CertificateNotFoundFault");
+    return __isa(o, "CertificateNotFoundFault");
   }
 }
 
@@ -96,7 +99,7 @@ export namespace CertificateNotFoundFault {
  *             Availability Zone.</p>
  */
 export interface CustomAvailabilityZoneAlreadyExistsFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CustomAvailabilityZoneAlreadyExistsFault";
   $fault: "client";
@@ -105,7 +108,7 @@ export interface CustomAvailabilityZoneAlreadyExistsFault
 
 export namespace CustomAvailabilityZoneAlreadyExistsFault {
   export function isa(o: any): o is CustomAvailabilityZoneAlreadyExistsFault {
-    return _smithy.isa(o, "CustomAvailabilityZoneAlreadyExistsFault");
+    return __isa(o, "CustomAvailabilityZoneAlreadyExistsFault");
   }
 }
 
@@ -115,7 +118,7 @@ export namespace CustomAvailabilityZoneAlreadyExistsFault {
  *             Availability Zone identifier.</p>
  */
 export interface CustomAvailabilityZoneNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CustomAvailabilityZoneNotFoundFault";
   $fault: "client";
@@ -124,7 +127,7 @@ export interface CustomAvailabilityZoneNotFoundFault
 
 export namespace CustomAvailabilityZoneNotFoundFault {
   export function isa(o: any): o is CustomAvailabilityZoneNotFoundFault {
-    return _smithy.isa(o, "CustomAvailabilityZoneNotFoundFault");
+    return __isa(o, "CustomAvailabilityZoneNotFoundFault");
   }
 }
 
@@ -132,7 +135,7 @@ export namespace CustomAvailabilityZoneNotFoundFault {
  * <p>You have exceeded the maximum number of custom Availability Zones.</p>
  */
 export interface CustomAvailabilityZoneQuotaExceededFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CustomAvailabilityZoneQuotaExceededFault";
   $fault: "client";
@@ -141,7 +144,7 @@ export interface CustomAvailabilityZoneQuotaExceededFault
 
 export namespace CustomAvailabilityZoneQuotaExceededFault {
   export function isa(o: any): o is CustomAvailabilityZoneQuotaExceededFault {
-    return _smithy.isa(o, "CustomAvailabilityZoneQuotaExceededFault");
+    return __isa(o, "CustomAvailabilityZoneQuotaExceededFault");
   }
 }
 
@@ -149,7 +152,7 @@ export namespace CustomAvailabilityZoneQuotaExceededFault {
  * <p>The user already has a DB cluster with the given identifier.</p>
  */
 export interface DBClusterAlreadyExistsFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBClusterAlreadyExistsFault";
   $fault: "client";
@@ -158,7 +161,7 @@ export interface DBClusterAlreadyExistsFault
 
 export namespace DBClusterAlreadyExistsFault {
   export function isa(o: any): o is DBClusterAlreadyExistsFault {
-    return _smithy.isa(o, "DBClusterAlreadyExistsFault");
+    return __isa(o, "DBClusterAlreadyExistsFault");
   }
 }
 
@@ -167,7 +170,7 @@ export namespace DBClusterAlreadyExistsFault {
  *             <code>BacktrackIdentifier</code> doesn't refer to an existing backtrack. </p>
  */
 export interface DBClusterBacktrackNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBClusterBacktrackNotFoundFault";
   $fault: "client";
@@ -176,7 +179,7 @@ export interface DBClusterBacktrackNotFoundFault
 
 export namespace DBClusterBacktrackNotFoundFault {
   export function isa(o: any): o is DBClusterBacktrackNotFoundFault {
-    return _smithy.isa(o, "DBClusterBacktrackNotFoundFault");
+    return __isa(o, "DBClusterBacktrackNotFoundFault");
   }
 }
 
@@ -184,7 +187,7 @@ export namespace DBClusterBacktrackNotFoundFault {
  * <p>The specified custom endpoint can't be created because it already exists.</p>
  */
 export interface DBClusterEndpointAlreadyExistsFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBClusterEndpointAlreadyExistsFault";
   $fault: "client";
@@ -193,7 +196,7 @@ export interface DBClusterEndpointAlreadyExistsFault
 
 export namespace DBClusterEndpointAlreadyExistsFault {
   export function isa(o: any): o is DBClusterEndpointAlreadyExistsFault {
-    return _smithy.isa(o, "DBClusterEndpointAlreadyExistsFault");
+    return __isa(o, "DBClusterEndpointAlreadyExistsFault");
   }
 }
 
@@ -201,7 +204,7 @@ export namespace DBClusterEndpointAlreadyExistsFault {
  * <p>The specified custom endpoint doesn't exist.</p>
  */
 export interface DBClusterEndpointNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBClusterEndpointNotFoundFault";
   $fault: "client";
@@ -210,7 +213,7 @@ export interface DBClusterEndpointNotFoundFault
 
 export namespace DBClusterEndpointNotFoundFault {
   export function isa(o: any): o is DBClusterEndpointNotFoundFault {
-    return _smithy.isa(o, "DBClusterEndpointNotFoundFault");
+    return __isa(o, "DBClusterEndpointNotFoundFault");
   }
 }
 
@@ -218,7 +221,7 @@ export namespace DBClusterEndpointNotFoundFault {
  * <p>The cluster already has the maximum number of custom endpoints.</p>
  */
 export interface DBClusterEndpointQuotaExceededFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBClusterEndpointQuotaExceededFault";
   $fault: "client";
@@ -227,7 +230,7 @@ export interface DBClusterEndpointQuotaExceededFault
 
 export namespace DBClusterEndpointQuotaExceededFault {
   export function isa(o: any): o is DBClusterEndpointQuotaExceededFault {
-    return _smithy.isa(o, "DBClusterEndpointQuotaExceededFault");
+    return __isa(o, "DBClusterEndpointQuotaExceededFault");
   }
 }
 
@@ -237,7 +240,7 @@ export namespace DBClusterEndpointQuotaExceededFault {
  *         </p>
  */
 export interface DBClusterNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBClusterNotFoundFault";
   $fault: "client";
@@ -246,7 +249,7 @@ export interface DBClusterNotFoundFault
 
 export namespace DBClusterNotFoundFault {
   export function isa(o: any): o is DBClusterNotFoundFault {
-    return _smithy.isa(o, "DBClusterNotFoundFault");
+    return __isa(o, "DBClusterNotFoundFault");
   }
 }
 
@@ -256,7 +259,7 @@ export namespace DBClusterNotFoundFault {
  *             cluster parameter group. </p>
  */
 export interface DBClusterParameterGroupNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBClusterParameterGroupNotFoundFault";
   $fault: "client";
@@ -265,7 +268,7 @@ export interface DBClusterParameterGroupNotFoundFault
 
 export namespace DBClusterParameterGroupNotFoundFault {
   export function isa(o: any): o is DBClusterParameterGroupNotFoundFault {
-    return _smithy.isa(o, "DBClusterParameterGroupNotFoundFault");
+    return __isa(o, "DBClusterParameterGroupNotFoundFault");
   }
 }
 
@@ -274,7 +277,7 @@ export namespace DBClusterParameterGroupNotFoundFault {
  *             maximum allowed DB cluster quota.</p>
  */
 export interface DBClusterQuotaExceededFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBClusterQuotaExceededFault";
   $fault: "client";
@@ -283,7 +286,7 @@ export interface DBClusterQuotaExceededFault
 
 export namespace DBClusterQuotaExceededFault {
   export function isa(o: any): o is DBClusterQuotaExceededFault {
-    return _smithy.isa(o, "DBClusterQuotaExceededFault");
+    return __isa(o, "DBClusterQuotaExceededFault");
   }
 }
 
@@ -291,7 +294,7 @@ export namespace DBClusterQuotaExceededFault {
  * <p>The specified IAM role Amazon Resource Name (ARN) is already associated with the specified DB cluster.</p>
  */
 export interface DBClusterRoleAlreadyExistsFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBClusterRoleAlreadyExistsFault";
   $fault: "client";
@@ -300,7 +303,7 @@ export interface DBClusterRoleAlreadyExistsFault
 
 export namespace DBClusterRoleAlreadyExistsFault {
   export function isa(o: any): o is DBClusterRoleAlreadyExistsFault {
-    return _smithy.isa(o, "DBClusterRoleAlreadyExistsFault");
+    return __isa(o, "DBClusterRoleAlreadyExistsFault");
   }
 }
 
@@ -308,7 +311,7 @@ export namespace DBClusterRoleAlreadyExistsFault {
  * <p>The specified IAM role Amazon Resource Name (ARN) isn't associated with the specified DB cluster.</p>
  */
 export interface DBClusterRoleNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBClusterRoleNotFoundFault";
   $fault: "client";
@@ -317,7 +320,7 @@ export interface DBClusterRoleNotFoundFault
 
 export namespace DBClusterRoleNotFoundFault {
   export function isa(o: any): o is DBClusterRoleNotFoundFault {
-    return _smithy.isa(o, "DBClusterRoleNotFoundFault");
+    return __isa(o, "DBClusterRoleNotFoundFault");
   }
 }
 
@@ -325,7 +328,7 @@ export namespace DBClusterRoleNotFoundFault {
  * <p>You have exceeded the maximum number of IAM roles that can be associated with the specified DB cluster.</p>
  */
 export interface DBClusterRoleQuotaExceededFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBClusterRoleQuotaExceededFault";
   $fault: "client";
@@ -334,7 +337,7 @@ export interface DBClusterRoleQuotaExceededFault
 
 export namespace DBClusterRoleQuotaExceededFault {
   export function isa(o: any): o is DBClusterRoleQuotaExceededFault {
-    return _smithy.isa(o, "DBClusterRoleQuotaExceededFault");
+    return __isa(o, "DBClusterRoleQuotaExceededFault");
   }
 }
 
@@ -342,7 +345,7 @@ export namespace DBClusterRoleQuotaExceededFault {
  * <p>The user already has a DB cluster snapshot with the given identifier.</p>
  */
 export interface DBClusterSnapshotAlreadyExistsFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBClusterSnapshotAlreadyExistsFault";
   $fault: "client";
@@ -351,7 +354,7 @@ export interface DBClusterSnapshotAlreadyExistsFault
 
 export namespace DBClusterSnapshotAlreadyExistsFault {
   export function isa(o: any): o is DBClusterSnapshotAlreadyExistsFault {
-    return _smithy.isa(o, "DBClusterSnapshotAlreadyExistsFault");
+    return __isa(o, "DBClusterSnapshotAlreadyExistsFault");
   }
 }
 
@@ -361,7 +364,7 @@ export namespace DBClusterSnapshotAlreadyExistsFault {
  *         </p>
  */
 export interface DBClusterSnapshotNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBClusterSnapshotNotFoundFault";
   $fault: "client";
@@ -370,7 +373,7 @@ export interface DBClusterSnapshotNotFoundFault
 
 export namespace DBClusterSnapshotNotFoundFault {
   export function isa(o: any): o is DBClusterSnapshotNotFoundFault {
-    return _smithy.isa(o, "DBClusterSnapshotNotFoundFault");
+    return __isa(o, "DBClusterSnapshotNotFoundFault");
   }
 }
 
@@ -378,7 +381,7 @@ export namespace DBClusterSnapshotNotFoundFault {
  * <p>The user already has a DB instance with the given identifier.</p>
  */
 export interface DBInstanceAlreadyExistsFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBInstanceAlreadyExistsFault";
   $fault: "client";
@@ -387,7 +390,7 @@ export interface DBInstanceAlreadyExistsFault
 
 export namespace DBInstanceAlreadyExistsFault {
   export function isa(o: any): o is DBInstanceAlreadyExistsFault {
-    return _smithy.isa(o, "DBInstanceAlreadyExistsFault");
+    return __isa(o, "DBInstanceAlreadyExistsFault");
   }
 }
 
@@ -395,7 +398,7 @@ export namespace DBInstanceAlreadyExistsFault {
  * <p>No automated backup for this DB instance was found.</p>
  */
 export interface DBInstanceAutomatedBackupNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBInstanceAutomatedBackupNotFoundFault";
   $fault: "client";
@@ -404,7 +407,7 @@ export interface DBInstanceAutomatedBackupNotFoundFault
 
 export namespace DBInstanceAutomatedBackupNotFoundFault {
   export function isa(o: any): o is DBInstanceAutomatedBackupNotFoundFault {
-    return _smithy.isa(o, "DBInstanceAutomatedBackupNotFoundFault");
+    return __isa(o, "DBInstanceAutomatedBackupNotFoundFault");
   }
 }
 
@@ -414,7 +417,7 @@ export namespace DBInstanceAutomatedBackupNotFoundFault {
  *             quota is the same as your DB Instance quota.</p>
  */
 export interface DBInstanceAutomatedBackupQuotaExceededFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBInstanceAutomatedBackupQuotaExceededFault";
   $fault: "client";
@@ -425,7 +428,7 @@ export namespace DBInstanceAutomatedBackupQuotaExceededFault {
   export function isa(
     o: any
   ): o is DBInstanceAutomatedBackupQuotaExceededFault {
-    return _smithy.isa(o, "DBInstanceAutomatedBackupQuotaExceededFault");
+    return __isa(o, "DBInstanceAutomatedBackupQuotaExceededFault");
   }
 }
 
@@ -435,7 +438,7 @@ export namespace DBInstanceAutomatedBackupQuotaExceededFault {
  *         </p>
  */
 export interface DBInstanceNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBInstanceNotFoundFault";
   $fault: "client";
@@ -444,7 +447,7 @@ export interface DBInstanceNotFoundFault
 
 export namespace DBInstanceNotFoundFault {
   export function isa(o: any): o is DBInstanceNotFoundFault {
-    return _smithy.isa(o, "DBInstanceNotFoundFault");
+    return __isa(o, "DBInstanceNotFoundFault");
   }
 }
 
@@ -452,7 +455,7 @@ export namespace DBInstanceNotFoundFault {
  * <p>The specified <code>RoleArn</code> or <code>FeatureName</code> value is already associated with the DB instance.</p>
  */
 export interface DBInstanceRoleAlreadyExistsFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBInstanceRoleAlreadyExistsFault";
   $fault: "client";
@@ -461,7 +464,7 @@ export interface DBInstanceRoleAlreadyExistsFault
 
 export namespace DBInstanceRoleAlreadyExistsFault {
   export function isa(o: any): o is DBInstanceRoleAlreadyExistsFault {
-    return _smithy.isa(o, "DBInstanceRoleAlreadyExistsFault");
+    return __isa(o, "DBInstanceRoleAlreadyExistsFault");
   }
 }
 
@@ -470,7 +473,7 @@ export namespace DBInstanceRoleAlreadyExistsFault {
  *             the DB instance.</p>
  */
 export interface DBInstanceRoleNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBInstanceRoleNotFoundFault";
   $fault: "client";
@@ -479,7 +482,7 @@ export interface DBInstanceRoleNotFoundFault
 
 export namespace DBInstanceRoleNotFoundFault {
   export function isa(o: any): o is DBInstanceRoleNotFoundFault {
-    return _smithy.isa(o, "DBInstanceRoleNotFoundFault");
+    return __isa(o, "DBInstanceRoleNotFoundFault");
   }
 }
 
@@ -487,7 +490,7 @@ export namespace DBInstanceRoleNotFoundFault {
  * <p>You can't associate any more AWS Identity and Access Management (IAM) roles with the DB instance because the quota has been reached.</p>
  */
 export interface DBInstanceRoleQuotaExceededFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBInstanceRoleQuotaExceededFault";
   $fault: "client";
@@ -496,7 +499,7 @@ export interface DBInstanceRoleQuotaExceededFault
 
 export namespace DBInstanceRoleQuotaExceededFault {
   export function isa(o: any): o is DBInstanceRoleQuotaExceededFault {
-    return _smithy.isa(o, "DBInstanceRoleQuotaExceededFault");
+    return __isa(o, "DBInstanceRoleQuotaExceededFault");
   }
 }
 
@@ -505,7 +508,7 @@ export namespace DBInstanceRoleQuotaExceededFault {
  *             <code>LogFileName</code> doesn't refer to an existing DB log file.</p>
  */
 export interface DBLogFileNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBLogFileNotFoundFault";
   $fault: "client";
@@ -514,7 +517,7 @@ export interface DBLogFileNotFoundFault
 
 export namespace DBLogFileNotFoundFault {
   export function isa(o: any): o is DBLogFileNotFoundFault {
-    return _smithy.isa(o, "DBLogFileNotFoundFault");
+    return __isa(o, "DBLogFileNotFoundFault");
   }
 }
 
@@ -522,7 +525,7 @@ export namespace DBLogFileNotFoundFault {
  * <p>A DB parameter group with the same name exists.</p>
  */
 export interface DBParameterGroupAlreadyExistsFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBParameterGroupAlreadyExistsFault";
   $fault: "client";
@@ -531,7 +534,7 @@ export interface DBParameterGroupAlreadyExistsFault
 
 export namespace DBParameterGroupAlreadyExistsFault {
   export function isa(o: any): o is DBParameterGroupAlreadyExistsFault {
-    return _smithy.isa(o, "DBParameterGroupAlreadyExistsFault");
+    return __isa(o, "DBParameterGroupAlreadyExistsFault");
   }
 }
 
@@ -542,7 +545,7 @@ export namespace DBParameterGroupAlreadyExistsFault {
  *         </p>
  */
 export interface DBParameterGroupNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBParameterGroupNotFoundFault";
   $fault: "client";
@@ -551,7 +554,7 @@ export interface DBParameterGroupNotFoundFault
 
 export namespace DBParameterGroupNotFoundFault {
   export function isa(o: any): o is DBParameterGroupNotFoundFault {
-    return _smithy.isa(o, "DBParameterGroupNotFoundFault");
+    return __isa(o, "DBParameterGroupNotFoundFault");
   }
 }
 
@@ -560,7 +563,7 @@ export namespace DBParameterGroupNotFoundFault {
  *             groups.</p>
  */
 export interface DBParameterGroupQuotaExceededFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBParameterGroupQuotaExceededFault";
   $fault: "client";
@@ -569,7 +572,7 @@ export interface DBParameterGroupQuotaExceededFault
 
 export namespace DBParameterGroupQuotaExceededFault {
   export function isa(o: any): o is DBParameterGroupQuotaExceededFault {
-    return _smithy.isa(o, "DBParameterGroupQuotaExceededFault");
+    return __isa(o, "DBParameterGroupQuotaExceededFault");
   }
 }
 
@@ -577,7 +580,7 @@ export namespace DBParameterGroupQuotaExceededFault {
  * <p>The specified proxy name must be unique for all proxies owned by your AWS account in the specified AWS Region.</p>
  */
 export interface DBProxyAlreadyExistsFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBProxyAlreadyExistsFault";
   $fault: "client";
@@ -586,7 +589,7 @@ export interface DBProxyAlreadyExistsFault
 
 export namespace DBProxyAlreadyExistsFault {
   export function isa(o: any): o is DBProxyAlreadyExistsFault {
-    return _smithy.isa(o, "DBProxyAlreadyExistsFault");
+    return __isa(o, "DBProxyAlreadyExistsFault");
   }
 }
 
@@ -594,7 +597,7 @@ export namespace DBProxyAlreadyExistsFault {
  * <p>The specified proxy name doesn't correspond to a proxy owned by your AWS accoutn in the specified AWS Region.</p>
  */
 export interface DBProxyNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBProxyNotFoundFault";
   $fault: "client";
@@ -603,7 +606,7 @@ export interface DBProxyNotFoundFault
 
 export namespace DBProxyNotFoundFault {
   export function isa(o: any): o is DBProxyNotFoundFault {
-    return _smithy.isa(o, "DBProxyNotFoundFault");
+    return __isa(o, "DBProxyNotFoundFault");
   }
 }
 
@@ -611,7 +614,7 @@ export namespace DBProxyNotFoundFault {
  * <p>Your AWS account already has the maximum number of proxies in the specified AWS Region.</p>
  */
 export interface DBProxyQuotaExceededFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBProxyQuotaExceededFault";
   $fault: "client";
@@ -620,7 +623,7 @@ export interface DBProxyQuotaExceededFault
 
 export namespace DBProxyQuotaExceededFault {
   export function isa(o: any): o is DBProxyQuotaExceededFault {
-    return _smithy.isa(o, "DBProxyQuotaExceededFault");
+    return __isa(o, "DBProxyQuotaExceededFault");
   }
 }
 
@@ -628,7 +631,7 @@ export namespace DBProxyQuotaExceededFault {
  * <p>The proxy is already associated with the specified RDS DB instance or Aurora DB cluster.</p>
  */
 export interface DBProxyTargetAlreadyRegisteredFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBProxyTargetAlreadyRegisteredFault";
   $fault: "client";
@@ -637,7 +640,7 @@ export interface DBProxyTargetAlreadyRegisteredFault
 
 export namespace DBProxyTargetAlreadyRegisteredFault {
   export function isa(o: any): o is DBProxyTargetAlreadyRegisteredFault {
-    return _smithy.isa(o, "DBProxyTargetAlreadyRegisteredFault");
+    return __isa(o, "DBProxyTargetAlreadyRegisteredFault");
   }
 }
 
@@ -645,7 +648,7 @@ export namespace DBProxyTargetAlreadyRegisteredFault {
  * <p>The specified target group isn't available for a proxy owned by your AWS account in the specified AWS Region.</p>
  */
 export interface DBProxyTargetGroupNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBProxyTargetGroupNotFoundFault";
   $fault: "client";
@@ -654,7 +657,7 @@ export interface DBProxyTargetGroupNotFoundFault
 
 export namespace DBProxyTargetGroupNotFoundFault {
   export function isa(o: any): o is DBProxyTargetGroupNotFoundFault {
-    return _smithy.isa(o, "DBProxyTargetGroupNotFoundFault");
+    return __isa(o, "DBProxyTargetGroupNotFoundFault");
   }
 }
 
@@ -662,7 +665,7 @@ export namespace DBProxyTargetGroupNotFoundFault {
  * <p>The specified RDS DB instance or Aurora DB cluster isn't available for a proxy owned by your AWS account in the specified AWS Region.</p>
  */
 export interface DBProxyTargetNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBProxyTargetNotFoundFault";
   $fault: "client";
@@ -671,7 +674,7 @@ export interface DBProxyTargetNotFoundFault
 
 export namespace DBProxyTargetNotFoundFault {
   export function isa(o: any): o is DBProxyTargetNotFoundFault {
-    return _smithy.isa(o, "DBProxyTargetNotFoundFault");
+    return __isa(o, "DBProxyTargetNotFoundFault");
   }
 }
 
@@ -682,7 +685,7 @@ export namespace DBProxyTargetNotFoundFault {
  *         </p>
  */
 export interface DBSecurityGroupAlreadyExistsFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBSecurityGroupAlreadyExistsFault";
   $fault: "client";
@@ -691,7 +694,7 @@ export interface DBSecurityGroupAlreadyExistsFault
 
 export namespace DBSecurityGroupAlreadyExistsFault {
   export function isa(o: any): o is DBSecurityGroupAlreadyExistsFault {
-    return _smithy.isa(o, "DBSecurityGroupAlreadyExistsFault");
+    return __isa(o, "DBSecurityGroupAlreadyExistsFault");
   }
 }
 
@@ -701,7 +704,7 @@ export namespace DBSecurityGroupAlreadyExistsFault {
  *         </p>
  */
 export interface DBSecurityGroupNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBSecurityGroupNotFoundFault";
   $fault: "client";
@@ -710,7 +713,7 @@ export interface DBSecurityGroupNotFoundFault
 
 export namespace DBSecurityGroupNotFoundFault {
   export function isa(o: any): o is DBSecurityGroupNotFoundFault {
-    return _smithy.isa(o, "DBSecurityGroupNotFoundFault");
+    return __isa(o, "DBSecurityGroupNotFoundFault");
   }
 }
 
@@ -718,7 +721,7 @@ export namespace DBSecurityGroupNotFoundFault {
  * <p>A DB security group isn't allowed for this action.</p>
  */
 export interface DBSecurityGroupNotSupportedFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBSecurityGroupNotSupportedFault";
   $fault: "client";
@@ -727,7 +730,7 @@ export interface DBSecurityGroupNotSupportedFault
 
 export namespace DBSecurityGroupNotSupportedFault {
   export function isa(o: any): o is DBSecurityGroupNotSupportedFault {
-    return _smithy.isa(o, "DBSecurityGroupNotSupportedFault");
+    return __isa(o, "DBSecurityGroupNotSupportedFault");
   }
 }
 
@@ -736,7 +739,7 @@ export namespace DBSecurityGroupNotSupportedFault {
  *             groups.</p>
  */
 export interface DBSecurityGroupQuotaExceededFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBSecurityGroupQuotaExceededFault";
   $fault: "client";
@@ -745,7 +748,7 @@ export interface DBSecurityGroupQuotaExceededFault
 
 export namespace DBSecurityGroupQuotaExceededFault {
   export function isa(o: any): o is DBSecurityGroupQuotaExceededFault {
-    return _smithy.isa(o, "DBSecurityGroupQuotaExceededFault");
+    return __isa(o, "DBSecurityGroupQuotaExceededFault");
   }
 }
 
@@ -755,7 +758,7 @@ export namespace DBSecurityGroupQuotaExceededFault {
  *         </p>
  */
 export interface DBSnapshotAlreadyExistsFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBSnapshotAlreadyExistsFault";
   $fault: "client";
@@ -764,7 +767,7 @@ export interface DBSnapshotAlreadyExistsFault
 
 export namespace DBSnapshotAlreadyExistsFault {
   export function isa(o: any): o is DBSnapshotAlreadyExistsFault {
-    return _smithy.isa(o, "DBSnapshotAlreadyExistsFault");
+    return __isa(o, "DBSnapshotAlreadyExistsFault");
   }
 }
 
@@ -774,7 +777,7 @@ export namespace DBSnapshotAlreadyExistsFault {
  *         </p>
  */
 export interface DBSnapshotNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBSnapshotNotFoundFault";
   $fault: "client";
@@ -783,7 +786,7 @@ export interface DBSnapshotNotFoundFault
 
 export namespace DBSnapshotNotFoundFault {
   export function isa(o: any): o is DBSnapshotNotFoundFault {
-    return _smithy.isa(o, "DBSnapshotNotFoundFault");
+    return __isa(o, "DBSnapshotNotFoundFault");
   }
 }
 
@@ -793,7 +796,7 @@ export namespace DBSnapshotNotFoundFault {
  *         </p>
  */
 export interface DBSubnetGroupAlreadyExistsFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBSubnetGroupAlreadyExistsFault";
   $fault: "client";
@@ -802,7 +805,7 @@ export interface DBSubnetGroupAlreadyExistsFault
 
 export namespace DBSubnetGroupAlreadyExistsFault {
   export function isa(o: any): o is DBSubnetGroupAlreadyExistsFault {
-    return _smithy.isa(o, "DBSubnetGroupAlreadyExistsFault");
+    return __isa(o, "DBSubnetGroupAlreadyExistsFault");
   }
 }
 
@@ -810,7 +813,7 @@ export namespace DBSubnetGroupAlreadyExistsFault {
  * <p>Subnets in the DB subnet group should cover at least two Availability Zones unless there is only one Availability Zone.</p>
  */
 export interface DBSubnetGroupDoesNotCoverEnoughAZs
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBSubnetGroupDoesNotCoverEnoughAZs";
   $fault: "client";
@@ -819,7 +822,7 @@ export interface DBSubnetGroupDoesNotCoverEnoughAZs
 
 export namespace DBSubnetGroupDoesNotCoverEnoughAZs {
   export function isa(o: any): o is DBSubnetGroupDoesNotCoverEnoughAZs {
-    return _smithy.isa(o, "DBSubnetGroupDoesNotCoverEnoughAZs");
+    return __isa(o, "DBSubnetGroupDoesNotCoverEnoughAZs");
   }
 }
 
@@ -828,7 +831,7 @@ export namespace DBSubnetGroupDoesNotCoverEnoughAZs {
  *             in the same region as the source instance.</p>
  */
 export interface DBSubnetGroupNotAllowedFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBSubnetGroupNotAllowedFault";
   $fault: "client";
@@ -837,7 +840,7 @@ export interface DBSubnetGroupNotAllowedFault
 
 export namespace DBSubnetGroupNotAllowedFault {
   export function isa(o: any): o is DBSubnetGroupNotAllowedFault {
-    return _smithy.isa(o, "DBSubnetGroupNotAllowedFault");
+    return __isa(o, "DBSubnetGroupNotAllowedFault");
   }
 }
 
@@ -847,7 +850,7 @@ export namespace DBSubnetGroupNotAllowedFault {
  *         </p>
  */
 export interface DBSubnetGroupNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBSubnetGroupNotFoundFault";
   $fault: "client";
@@ -856,7 +859,7 @@ export interface DBSubnetGroupNotFoundFault
 
 export namespace DBSubnetGroupNotFoundFault {
   export function isa(o: any): o is DBSubnetGroupNotFoundFault {
-    return _smithy.isa(o, "DBSubnetGroupNotFoundFault");
+    return __isa(o, "DBSubnetGroupNotFoundFault");
   }
 }
 
@@ -865,7 +868,7 @@ export namespace DBSubnetGroupNotFoundFault {
  *             groups.</p>
  */
 export interface DBSubnetGroupQuotaExceededFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBSubnetGroupQuotaExceededFault";
   $fault: "client";
@@ -874,7 +877,7 @@ export interface DBSubnetGroupQuotaExceededFault
 
 export namespace DBSubnetGroupQuotaExceededFault {
   export function isa(o: any): o is DBSubnetGroupQuotaExceededFault {
-    return _smithy.isa(o, "DBSubnetGroupQuotaExceededFault");
+    return __isa(o, "DBSubnetGroupQuotaExceededFault");
   }
 }
 
@@ -883,7 +886,7 @@ export namespace DBSubnetGroupQuotaExceededFault {
  *             DB subnet groups.</p>
  */
 export interface DBSubnetQuotaExceededFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBSubnetQuotaExceededFault";
   $fault: "client";
@@ -892,7 +895,7 @@ export interface DBSubnetQuotaExceededFault
 
 export namespace DBSubnetQuotaExceededFault {
   export function isa(o: any): o is DBSubnetQuotaExceededFault {
-    return _smithy.isa(o, "DBSubnetQuotaExceededFault");
+    return __isa(o, "DBSubnetQuotaExceededFault");
   }
 }
 
@@ -901,7 +904,7 @@ export namespace DBSubnetQuotaExceededFault {
  *             modified.</p>
  */
 export interface DBUpgradeDependencyFailureFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DBUpgradeDependencyFailureFault";
   $fault: "client";
@@ -910,7 +913,7 @@ export interface DBUpgradeDependencyFailureFault
 
 export namespace DBUpgradeDependencyFailureFault {
   export function isa(o: any): o is DBUpgradeDependencyFailureFault {
-    return _smithy.isa(o, "DBUpgradeDependencyFailureFault");
+    return __isa(o, "DBUpgradeDependencyFailureFault");
   }
 }
 
@@ -920,7 +923,7 @@ export namespace DBUpgradeDependencyFailureFault {
  *         </p>
  */
 export interface DomainNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DomainNotFoundFault";
   $fault: "client";
@@ -929,7 +932,7 @@ export interface DomainNotFoundFault
 
 export namespace DomainNotFoundFault {
   export function isa(o: any): o is DomainNotFoundFault {
-    return _smithy.isa(o, "DomainNotFoundFault");
+    return __isa(o, "DomainNotFoundFault");
   }
 }
 
@@ -937,7 +940,7 @@ export namespace DomainNotFoundFault {
  * <p>You have reached the maximum number of event subscriptions.</p>
  */
 export interface EventSubscriptionQuotaExceededFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "EventSubscriptionQuotaExceededFault";
   $fault: "client";
@@ -946,7 +949,7 @@ export interface EventSubscriptionQuotaExceededFault
 
 export namespace EventSubscriptionQuotaExceededFault {
   export function isa(o: any): o is EventSubscriptionQuotaExceededFault {
-    return _smithy.isa(o, "EventSubscriptionQuotaExceededFault");
+    return __isa(o, "EventSubscriptionQuotaExceededFault");
   }
 }
 
@@ -954,7 +957,7 @@ export namespace EventSubscriptionQuotaExceededFault {
  * <p></p>
  */
 export interface GlobalClusterAlreadyExistsFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "GlobalClusterAlreadyExistsFault";
   $fault: "client";
@@ -963,7 +966,7 @@ export interface GlobalClusterAlreadyExistsFault
 
 export namespace GlobalClusterAlreadyExistsFault {
   export function isa(o: any): o is GlobalClusterAlreadyExistsFault {
-    return _smithy.isa(o, "GlobalClusterAlreadyExistsFault");
+    return __isa(o, "GlobalClusterAlreadyExistsFault");
   }
 }
 
@@ -971,7 +974,7 @@ export namespace GlobalClusterAlreadyExistsFault {
  * <p></p>
  */
 export interface GlobalClusterNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "GlobalClusterNotFoundFault";
   $fault: "client";
@@ -980,7 +983,7 @@ export interface GlobalClusterNotFoundFault
 
 export namespace GlobalClusterNotFoundFault {
   export function isa(o: any): o is GlobalClusterNotFoundFault {
-    return _smithy.isa(o, "GlobalClusterNotFoundFault");
+    return __isa(o, "GlobalClusterNotFoundFault");
   }
 }
 
@@ -988,7 +991,7 @@ export namespace GlobalClusterNotFoundFault {
  * <p></p>
  */
 export interface GlobalClusterQuotaExceededFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "GlobalClusterQuotaExceededFault";
   $fault: "client";
@@ -997,7 +1000,7 @@ export interface GlobalClusterQuotaExceededFault
 
 export namespace GlobalClusterQuotaExceededFault {
   export function isa(o: any): o is GlobalClusterQuotaExceededFault {
-    return _smithy.isa(o, "GlobalClusterQuotaExceededFault");
+    return __isa(o, "GlobalClusterQuotaExceededFault");
   }
 }
 
@@ -1005,7 +1008,7 @@ export namespace GlobalClusterQuotaExceededFault {
  * <p>The specified installation medium has already been imported.</p>
  */
 export interface InstallationMediaAlreadyExistsFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InstallationMediaAlreadyExistsFault";
   $fault: "client";
@@ -1014,7 +1017,7 @@ export interface InstallationMediaAlreadyExistsFault
 
 export namespace InstallationMediaAlreadyExistsFault {
   export function isa(o: any): o is InstallationMediaAlreadyExistsFault {
-    return _smithy.isa(o, "InstallationMediaAlreadyExistsFault");
+    return __isa(o, "InstallationMediaAlreadyExistsFault");
   }
 }
 
@@ -1023,7 +1026,7 @@ export namespace InstallationMediaAlreadyExistsFault {
  *             <code>InstallationMediaID</code> doesn't refer to an existing installation medium.</p>
  */
 export interface InstallationMediaNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InstallationMediaNotFoundFault";
   $fault: "client";
@@ -1032,7 +1035,7 @@ export interface InstallationMediaNotFoundFault
 
 export namespace InstallationMediaNotFoundFault {
   export function isa(o: any): o is InstallationMediaNotFoundFault {
-    return _smithy.isa(o, "InstallationMediaNotFoundFault");
+    return __isa(o, "InstallationMediaNotFoundFault");
   }
 }
 
@@ -1041,7 +1044,7 @@ export namespace InstallationMediaNotFoundFault {
  *             instances.</p>
  */
 export interface InstanceQuotaExceededFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InstanceQuotaExceededFault";
   $fault: "client";
@@ -1050,7 +1053,7 @@ export interface InstanceQuotaExceededFault
 
 export namespace InstanceQuotaExceededFault {
   export function isa(o: any): o is InstanceQuotaExceededFault {
-    return _smithy.isa(o, "InstanceQuotaExceededFault");
+    return __isa(o, "InstanceQuotaExceededFault");
   }
 }
 
@@ -1058,7 +1061,7 @@ export namespace InstanceQuotaExceededFault {
  * <p>The DB cluster doesn't have enough capacity for the current operation.</p>
  */
 export interface InsufficientDBClusterCapacityFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InsufficientDBClusterCapacityFault";
   $fault: "client";
@@ -1067,7 +1070,7 @@ export interface InsufficientDBClusterCapacityFault
 
 export namespace InsufficientDBClusterCapacityFault {
   export function isa(o: any): o is InsufficientDBClusterCapacityFault {
-    return _smithy.isa(o, "InsufficientDBClusterCapacityFault");
+    return __isa(o, "InsufficientDBClusterCapacityFault");
   }
 }
 
@@ -1076,7 +1079,7 @@ export namespace InsufficientDBClusterCapacityFault {
  *             Zone.</p>
  */
 export interface InsufficientDBInstanceCapacityFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InsufficientDBInstanceCapacityFault";
   $fault: "client";
@@ -1085,7 +1088,7 @@ export interface InsufficientDBInstanceCapacityFault
 
 export namespace InsufficientDBInstanceCapacityFault {
   export function isa(o: any): o is InsufficientDBInstanceCapacityFault {
-    return _smithy.isa(o, "InsufficientDBInstanceCapacityFault");
+    return __isa(o, "InsufficientDBInstanceCapacityFault");
   }
 }
 
@@ -1095,7 +1098,7 @@ export namespace InsufficientDBInstanceCapacityFault {
  *             that have more storage available.</p>
  */
 export interface InsufficientStorageClusterCapacityFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InsufficientStorageClusterCapacityFault";
   $fault: "client";
@@ -1104,7 +1107,7 @@ export interface InsufficientStorageClusterCapacityFault
 
 export namespace InsufficientStorageClusterCapacityFault {
   export function isa(o: any): o is InsufficientStorageClusterCapacityFault {
-    return _smithy.isa(o, "InsufficientStorageClusterCapacityFault");
+    return __isa(o, "InsufficientStorageClusterCapacityFault");
   }
 }
 
@@ -1115,7 +1118,7 @@ export namespace InsufficientStorageClusterCapacityFault {
  *             <code>32</code>, <code>64</code>, <code>128</code>, and <code>256</code>.</p>
  */
 export interface InvalidDBClusterCapacityFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidDBClusterCapacityFault";
   $fault: "client";
@@ -1124,7 +1127,7 @@ export interface InvalidDBClusterCapacityFault
 
 export namespace InvalidDBClusterCapacityFault {
   export function isa(o: any): o is InvalidDBClusterCapacityFault {
-    return _smithy.isa(o, "InvalidDBClusterCapacityFault");
+    return __isa(o, "InvalidDBClusterCapacityFault");
   }
 }
 
@@ -1132,7 +1135,7 @@ export namespace InvalidDBClusterCapacityFault {
  * <p>The requested operation can't be performed on the endpoint while the endpoint is in this state.</p>
  */
 export interface InvalidDBClusterEndpointStateFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidDBClusterEndpointStateFault";
   $fault: "client";
@@ -1141,7 +1144,7 @@ export interface InvalidDBClusterEndpointStateFault
 
 export namespace InvalidDBClusterEndpointStateFault {
   export function isa(o: any): o is InvalidDBClusterEndpointStateFault {
-    return _smithy.isa(o, "InvalidDBClusterEndpointStateFault");
+    return __isa(o, "InvalidDBClusterEndpointStateFault");
   }
 }
 
@@ -1149,7 +1152,7 @@ export namespace InvalidDBClusterEndpointStateFault {
  * <p>The supplied value isn't a valid DB cluster snapshot state.</p>
  */
 export interface InvalidDBClusterSnapshotStateFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidDBClusterSnapshotStateFault";
   $fault: "client";
@@ -1158,7 +1161,7 @@ export interface InvalidDBClusterSnapshotStateFault
 
 export namespace InvalidDBClusterSnapshotStateFault {
   export function isa(o: any): o is InvalidDBClusterSnapshotStateFault {
-    return _smithy.isa(o, "InvalidDBClusterSnapshotStateFault");
+    return __isa(o, "InvalidDBClusterSnapshotStateFault");
   }
 }
 
@@ -1166,7 +1169,7 @@ export namespace InvalidDBClusterSnapshotStateFault {
  * <p>The requested operation can't be performed while the cluster is in this state.</p>
  */
 export interface InvalidDBClusterStateFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidDBClusterStateFault";
   $fault: "client";
@@ -1175,7 +1178,7 @@ export interface InvalidDBClusterStateFault
 
 export namespace InvalidDBClusterStateFault {
   export function isa(o: any): o is InvalidDBClusterStateFault {
-    return _smithy.isa(o, "InvalidDBClusterStateFault");
+    return __isa(o, "InvalidDBClusterStateFault");
   }
 }
 
@@ -1184,7 +1187,7 @@ export namespace InvalidDBClusterStateFault {
  *     	    For example, this automated backup is associated with an active instance. </p>
  */
 export interface InvalidDBInstanceAutomatedBackupStateFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidDBInstanceAutomatedBackupStateFault";
   $fault: "client";
@@ -1193,7 +1196,7 @@ export interface InvalidDBInstanceAutomatedBackupStateFault
 
 export namespace InvalidDBInstanceAutomatedBackupStateFault {
   export function isa(o: any): o is InvalidDBInstanceAutomatedBackupStateFault {
-    return _smithy.isa(o, "InvalidDBInstanceAutomatedBackupStateFault");
+    return __isa(o, "InvalidDBInstanceAutomatedBackupStateFault");
   }
 }
 
@@ -1201,7 +1204,7 @@ export namespace InvalidDBInstanceAutomatedBackupStateFault {
  * <p>The DB instance isn't in a valid state.</p>
  */
 export interface InvalidDBInstanceStateFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidDBInstanceStateFault";
   $fault: "client";
@@ -1210,7 +1213,7 @@ export interface InvalidDBInstanceStateFault
 
 export namespace InvalidDBInstanceStateFault {
   export function isa(o: any): o is InvalidDBInstanceStateFault {
-    return _smithy.isa(o, "InvalidDBInstanceStateFault");
+    return __isa(o, "InvalidDBInstanceStateFault");
   }
 }
 
@@ -1220,7 +1223,7 @@ export namespace InvalidDBInstanceStateFault {
  *             this state.</p>
  */
 export interface InvalidDBParameterGroupStateFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidDBParameterGroupStateFault";
   $fault: "client";
@@ -1229,7 +1232,7 @@ export interface InvalidDBParameterGroupStateFault
 
 export namespace InvalidDBParameterGroupStateFault {
   export function isa(o: any): o is InvalidDBParameterGroupStateFault {
-    return _smithy.isa(o, "InvalidDBParameterGroupStateFault");
+    return __isa(o, "InvalidDBParameterGroupStateFault");
   }
 }
 
@@ -1237,7 +1240,7 @@ export namespace InvalidDBParameterGroupStateFault {
  * <p>The requested operation can't be performed while the proxy is in this state.</p>
  */
 export interface InvalidDBProxyStateFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidDBProxyStateFault";
   $fault: "client";
@@ -1246,7 +1249,7 @@ export interface InvalidDBProxyStateFault
 
 export namespace InvalidDBProxyStateFault {
   export function isa(o: any): o is InvalidDBProxyStateFault {
-    return _smithy.isa(o, "InvalidDBProxyStateFault");
+    return __isa(o, "InvalidDBProxyStateFault");
   }
 }
 
@@ -1254,7 +1257,7 @@ export namespace InvalidDBProxyStateFault {
  * <p>The state of the DB security group doesn't allow deletion.</p>
  */
 export interface InvalidDBSecurityGroupStateFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidDBSecurityGroupStateFault";
   $fault: "client";
@@ -1263,7 +1266,7 @@ export interface InvalidDBSecurityGroupStateFault
 
 export namespace InvalidDBSecurityGroupStateFault {
   export function isa(o: any): o is InvalidDBSecurityGroupStateFault {
-    return _smithy.isa(o, "InvalidDBSecurityGroupStateFault");
+    return __isa(o, "InvalidDBSecurityGroupStateFault");
   }
 }
 
@@ -1271,7 +1274,7 @@ export namespace InvalidDBSecurityGroupStateFault {
  * <p>The state of the DB snapshot doesn't allow deletion.</p>
  */
 export interface InvalidDBSnapshotStateFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidDBSnapshotStateFault";
   $fault: "client";
@@ -1280,7 +1283,7 @@ export interface InvalidDBSnapshotStateFault
 
 export namespace InvalidDBSnapshotStateFault {
   export function isa(o: any): o is InvalidDBSnapshotStateFault {
-    return _smithy.isa(o, "InvalidDBSnapshotStateFault");
+    return __isa(o, "InvalidDBSnapshotStateFault");
   }
 }
 
@@ -1289,7 +1292,7 @@ export namespace InvalidDBSnapshotStateFault {
  *             cross-region read replica of the same source instance.</p>
  */
 export interface InvalidDBSubnetGroupFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidDBSubnetGroupFault";
   $fault: "client";
@@ -1298,7 +1301,7 @@ export interface InvalidDBSubnetGroupFault
 
 export namespace InvalidDBSubnetGroupFault {
   export function isa(o: any): o is InvalidDBSubnetGroupFault {
-    return _smithy.isa(o, "InvalidDBSubnetGroupFault");
+    return __isa(o, "InvalidDBSubnetGroupFault");
   }
 }
 
@@ -1306,7 +1309,7 @@ export namespace InvalidDBSubnetGroupFault {
  * <p>The DB subnet group cannot be deleted because it's in use.</p>
  */
 export interface InvalidDBSubnetGroupStateFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidDBSubnetGroupStateFault";
   $fault: "client";
@@ -1315,7 +1318,7 @@ export interface InvalidDBSubnetGroupStateFault
 
 export namespace InvalidDBSubnetGroupStateFault {
   export function isa(o: any): o is InvalidDBSubnetGroupStateFault {
-    return _smithy.isa(o, "InvalidDBSubnetGroupStateFault");
+    return __isa(o, "InvalidDBSubnetGroupStateFault");
   }
 }
 
@@ -1325,7 +1328,7 @@ export namespace InvalidDBSubnetGroupStateFault {
  *         </p>
  */
 export interface InvalidDBSubnetStateFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidDBSubnetStateFault";
   $fault: "client";
@@ -1334,7 +1337,7 @@ export interface InvalidDBSubnetStateFault
 
 export namespace InvalidDBSubnetStateFault {
   export function isa(o: any): o is InvalidDBSubnetStateFault {
-    return _smithy.isa(o, "InvalidDBSubnetStateFault");
+    return __isa(o, "InvalidDBSubnetStateFault");
   }
 }
 
@@ -1342,7 +1345,7 @@ export namespace InvalidDBSubnetStateFault {
  * <p>This error can occur if someone else is modifying a subscription. You should retry the action.</p>
  */
 export interface InvalidEventSubscriptionStateFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidEventSubscriptionStateFault";
   $fault: "client";
@@ -1351,7 +1354,7 @@ export interface InvalidEventSubscriptionStateFault
 
 export namespace InvalidEventSubscriptionStateFault {
   export function isa(o: any): o is InvalidEventSubscriptionStateFault {
-    return _smithy.isa(o, "InvalidEventSubscriptionStateFault");
+    return __isa(o, "InvalidEventSubscriptionStateFault");
   }
 }
 
@@ -1359,7 +1362,7 @@ export namespace InvalidEventSubscriptionStateFault {
  * <p></p>
  */
 export interface InvalidGlobalClusterStateFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidGlobalClusterStateFault";
   $fault: "client";
@@ -1368,7 +1371,7 @@ export interface InvalidGlobalClusterStateFault
 
 export namespace InvalidGlobalClusterStateFault {
   export function isa(o: any): o is InvalidGlobalClusterStateFault {
-    return _smithy.isa(o, "InvalidGlobalClusterStateFault");
+    return __isa(o, "InvalidGlobalClusterStateFault");
   }
 }
 
@@ -1378,7 +1381,7 @@ export namespace InvalidGlobalClusterStateFault {
  *         </p>
  */
 export interface InvalidOptionGroupStateFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidOptionGroupStateFault";
   $fault: "client";
@@ -1387,7 +1390,7 @@ export interface InvalidOptionGroupStateFault
 
 export namespace InvalidOptionGroupStateFault {
   export function isa(o: any): o is InvalidOptionGroupStateFault {
-    return _smithy.isa(o, "InvalidOptionGroupStateFault");
+    return __isa(o, "InvalidOptionGroupStateFault");
   }
 }
 
@@ -1395,7 +1398,7 @@ export namespace InvalidOptionGroupStateFault {
  * <p>Cannot restore from VPC backup to non-VPC DB instance.</p>
  */
 export interface InvalidRestoreFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidRestoreFault";
   $fault: "client";
@@ -1404,7 +1407,7 @@ export interface InvalidRestoreFault
 
 export namespace InvalidRestoreFault {
   export function isa(o: any): o is InvalidRestoreFault {
-    return _smithy.isa(o, "InvalidRestoreFault");
+    return __isa(o, "InvalidRestoreFault");
   }
 }
 
@@ -1413,7 +1416,7 @@ export namespace InvalidRestoreFault {
  *             authorized to access the specified Amazon S3 bucket. Verify the <b>SourceS3BucketName</b> and <b>S3IngestionRoleArn</b> values and try again.</p>
  */
 export interface InvalidS3BucketFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidS3BucketFault";
   $fault: "client";
@@ -1422,16 +1425,14 @@ export interface InvalidS3BucketFault
 
 export namespace InvalidS3BucketFault {
   export function isa(o: any): o is InvalidS3BucketFault {
-    return _smithy.isa(o, "InvalidS3BucketFault");
+    return __isa(o, "InvalidS3BucketFault");
   }
 }
 
 /**
  * <p>The requested subnet is invalid, or multiple subnets were requested that are not all in a common VPC.</p>
  */
-export interface InvalidSubnet
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface InvalidSubnet extends __SmithyException, $MetadataBearer {
   name: "InvalidSubnet";
   $fault: "client";
   message?: string;
@@ -1439,7 +1440,7 @@ export interface InvalidSubnet
 
 export namespace InvalidSubnet {
   export function isa(o: any): o is InvalidSubnet {
-    return _smithy.isa(o, "InvalidSubnet");
+    return __isa(o, "InvalidSubnet");
   }
 }
 
@@ -1448,7 +1449,7 @@ export namespace InvalidSubnet {
  *             created because of users' change.</p>
  */
 export interface InvalidVPCNetworkStateFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidVPCNetworkStateFault";
   $fault: "client";
@@ -1457,7 +1458,7 @@ export interface InvalidVPCNetworkStateFault
 
 export namespace InvalidVPCNetworkStateFault {
   export function isa(o: any): o is InvalidVPCNetworkStateFault {
-    return _smithy.isa(o, "InvalidVPCNetworkStateFault");
+    return __isa(o, "InvalidVPCNetworkStateFault");
   }
 }
 
@@ -1465,7 +1466,7 @@ export namespace InvalidVPCNetworkStateFault {
  * <p>An error occurred accessing an AWS KMS key.</p>
  */
 export interface KMSKeyNotAccessibleFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "KMSKeyNotAccessibleFault";
   $fault: "client";
@@ -1474,7 +1475,7 @@ export interface KMSKeyNotAccessibleFault
 
 export namespace KMSKeyNotAccessibleFault {
   export function isa(o: any): o is KMSKeyNotAccessibleFault {
-    return _smithy.isa(o, "KMSKeyNotAccessibleFault");
+    return __isa(o, "KMSKeyNotAccessibleFault");
   }
 }
 
@@ -1482,7 +1483,7 @@ export namespace KMSKeyNotAccessibleFault {
  * <p>The option group you are trying to create already exists.</p>
  */
 export interface OptionGroupAlreadyExistsFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "OptionGroupAlreadyExistsFault";
   $fault: "client";
@@ -1491,7 +1492,7 @@ export interface OptionGroupAlreadyExistsFault
 
 export namespace OptionGroupAlreadyExistsFault {
   export function isa(o: any): o is OptionGroupAlreadyExistsFault {
-    return _smithy.isa(o, "OptionGroupAlreadyExistsFault");
+    return __isa(o, "OptionGroupAlreadyExistsFault");
   }
 }
 
@@ -1499,7 +1500,7 @@ export namespace OptionGroupAlreadyExistsFault {
  * <p>The specified option group could not be found.</p>
  */
 export interface OptionGroupNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "OptionGroupNotFoundFault";
   $fault: "client";
@@ -1508,7 +1509,7 @@ export interface OptionGroupNotFoundFault
 
 export namespace OptionGroupNotFoundFault {
   export function isa(o: any): o is OptionGroupNotFoundFault {
-    return _smithy.isa(o, "OptionGroupNotFoundFault");
+    return __isa(o, "OptionGroupNotFoundFault");
   }
 }
 
@@ -1516,7 +1517,7 @@ export namespace OptionGroupNotFoundFault {
  * <p>The quota of 20 option groups was exceeded for this AWS account.</p>
  */
 export interface OptionGroupQuotaExceededFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "OptionGroupQuotaExceededFault";
   $fault: "client";
@@ -1525,7 +1526,7 @@ export interface OptionGroupQuotaExceededFault
 
 export namespace OptionGroupQuotaExceededFault {
   export function isa(o: any): o is OptionGroupQuotaExceededFault {
-    return _smithy.isa(o, "OptionGroupQuotaExceededFault");
+    return __isa(o, "OptionGroupQuotaExceededFault");
   }
 }
 
@@ -1537,7 +1538,7 @@ export namespace OptionGroupQuotaExceededFault {
  *         </p>
  */
 export interface PointInTimeRestoreNotEnabledFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "PointInTimeRestoreNotEnabledFault";
   $fault: "client";
@@ -1546,7 +1547,7 @@ export interface PointInTimeRestoreNotEnabledFault
 
 export namespace PointInTimeRestoreNotEnabledFault {
   export function isa(o: any): o is PointInTimeRestoreNotEnabledFault {
-    return _smithy.isa(o, "PointInTimeRestoreNotEnabledFault");
+    return __isa(o, "PointInTimeRestoreNotEnabledFault");
   }
 }
 
@@ -1554,7 +1555,7 @@ export namespace PointInTimeRestoreNotEnabledFault {
  * <p>Provisioned IOPS not available in the specified Availability Zone.</p>
  */
 export interface ProvisionedIopsNotAvailableInAZFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ProvisionedIopsNotAvailableInAZFault";
   $fault: "client";
@@ -1563,7 +1564,7 @@ export interface ProvisionedIopsNotAvailableInAZFault
 
 export namespace ProvisionedIopsNotAvailableInAZFault {
   export function isa(o: any): o is ProvisionedIopsNotAvailableInAZFault {
-    return _smithy.isa(o, "ProvisionedIopsNotAvailableInAZFault");
+    return __isa(o, "ProvisionedIopsNotAvailableInAZFault");
   }
 }
 
@@ -1571,7 +1572,7 @@ export namespace ProvisionedIopsNotAvailableInAZFault {
  * <p>User already has a reservation with the given identifier.</p>
  */
 export interface ReservedDBInstanceAlreadyExistsFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ReservedDBInstanceAlreadyExistsFault";
   $fault: "client";
@@ -1580,7 +1581,7 @@ export interface ReservedDBInstanceAlreadyExistsFault
 
 export namespace ReservedDBInstanceAlreadyExistsFault {
   export function isa(o: any): o is ReservedDBInstanceAlreadyExistsFault {
-    return _smithy.isa(o, "ReservedDBInstanceAlreadyExistsFault");
+    return __isa(o, "ReservedDBInstanceAlreadyExistsFault");
   }
 }
 
@@ -1588,7 +1589,7 @@ export namespace ReservedDBInstanceAlreadyExistsFault {
  * <p>The specified reserved DB Instance not found.</p>
  */
 export interface ReservedDBInstanceNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ReservedDBInstanceNotFoundFault";
   $fault: "client";
@@ -1597,7 +1598,7 @@ export interface ReservedDBInstanceNotFoundFault
 
 export namespace ReservedDBInstanceNotFoundFault {
   export function isa(o: any): o is ReservedDBInstanceNotFoundFault {
-    return _smithy.isa(o, "ReservedDBInstanceNotFoundFault");
+    return __isa(o, "ReservedDBInstanceNotFoundFault");
   }
 }
 
@@ -1605,7 +1606,7 @@ export namespace ReservedDBInstanceNotFoundFault {
  * <p>Request would exceed the user's DB Instance quota.</p>
  */
 export interface ReservedDBInstanceQuotaExceededFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ReservedDBInstanceQuotaExceededFault";
   $fault: "client";
@@ -1614,7 +1615,7 @@ export interface ReservedDBInstanceQuotaExceededFault
 
 export namespace ReservedDBInstanceQuotaExceededFault {
   export function isa(o: any): o is ReservedDBInstanceQuotaExceededFault {
-    return _smithy.isa(o, "ReservedDBInstanceQuotaExceededFault");
+    return __isa(o, "ReservedDBInstanceQuotaExceededFault");
   }
 }
 
@@ -1622,7 +1623,7 @@ export namespace ReservedDBInstanceQuotaExceededFault {
  * <p>Specified offering does not exist.</p>
  */
 export interface ReservedDBInstancesOfferingNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ReservedDBInstancesOfferingNotFoundFault";
   $fault: "client";
@@ -1631,7 +1632,7 @@ export interface ReservedDBInstancesOfferingNotFoundFault
 
 export namespace ReservedDBInstancesOfferingNotFoundFault {
   export function isa(o: any): o is ReservedDBInstancesOfferingNotFoundFault {
-    return _smithy.isa(o, "ReservedDBInstancesOfferingNotFoundFault");
+    return __isa(o, "ReservedDBInstancesOfferingNotFoundFault");
   }
 }
 
@@ -1639,7 +1640,7 @@ export namespace ReservedDBInstancesOfferingNotFoundFault {
  * <p>The specified resource ID was not found.</p>
  */
 export interface ResourceNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundFault";
   $fault: "client";
@@ -1648,7 +1649,7 @@ export interface ResourceNotFoundFault
 
 export namespace ResourceNotFoundFault {
   export function isa(o: any): o is ResourceNotFoundFault {
-    return _smithy.isa(o, "ResourceNotFoundFault");
+    return __isa(o, "ResourceNotFoundFault");
   }
 }
 
@@ -1656,7 +1657,7 @@ export namespace ResourceNotFoundFault {
  * <p>SNS has responded that there is a problem with the SND topic specified.</p>
  */
 export interface SNSInvalidTopicFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "SNSInvalidTopicFault";
   $fault: "client";
@@ -1665,7 +1666,7 @@ export interface SNSInvalidTopicFault
 
 export namespace SNSInvalidTopicFault {
   export function isa(o: any): o is SNSInvalidTopicFault {
-    return _smithy.isa(o, "SNSInvalidTopicFault");
+    return __isa(o, "SNSInvalidTopicFault");
   }
 }
 
@@ -1673,7 +1674,7 @@ export namespace SNSInvalidTopicFault {
  * <p>You do not have permission to publish to the SNS topic ARN.</p>
  */
 export interface SNSNoAuthorizationFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "SNSNoAuthorizationFault";
   $fault: "client";
@@ -1682,7 +1683,7 @@ export interface SNSNoAuthorizationFault
 
 export namespace SNSNoAuthorizationFault {
   export function isa(o: any): o is SNSNoAuthorizationFault {
-    return _smithy.isa(o, "SNSNoAuthorizationFault");
+    return __isa(o, "SNSNoAuthorizationFault");
   }
 }
 
@@ -1690,7 +1691,7 @@ export namespace SNSNoAuthorizationFault {
  * <p>The SNS topic ARN does not exist.</p>
  */
 export interface SNSTopicArnNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "SNSTopicArnNotFoundFault";
   $fault: "client";
@@ -1699,7 +1700,7 @@ export interface SNSTopicArnNotFoundFault
 
 export namespace SNSTopicArnNotFoundFault {
   export function isa(o: any): o is SNSTopicArnNotFoundFault {
-    return _smithy.isa(o, "SNSTopicArnNotFoundFault");
+    return __isa(o, "SNSTopicArnNotFoundFault");
   }
 }
 
@@ -1707,7 +1708,7 @@ export namespace SNSTopicArnNotFoundFault {
  * <p>You have exceeded the maximum number of accounts that you can share a manual DB snapshot with.</p>
  */
 export interface SharedSnapshotQuotaExceededFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "SharedSnapshotQuotaExceededFault";
   $fault: "client";
@@ -1716,7 +1717,7 @@ export interface SharedSnapshotQuotaExceededFault
 
 export namespace SharedSnapshotQuotaExceededFault {
   export function isa(o: any): o is SharedSnapshotQuotaExceededFault {
-    return _smithy.isa(o, "SharedSnapshotQuotaExceededFault");
+    return __isa(o, "SharedSnapshotQuotaExceededFault");
   }
 }
 
@@ -1725,7 +1726,7 @@ export namespace SharedSnapshotQuotaExceededFault {
  *             snapshots.</p>
  */
 export interface SnapshotQuotaExceededFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "SnapshotQuotaExceededFault";
   $fault: "client";
@@ -1734,7 +1735,7 @@ export interface SnapshotQuotaExceededFault
 
 export namespace SnapshotQuotaExceededFault {
   export function isa(o: any): o is SnapshotQuotaExceededFault {
-    return _smithy.isa(o, "SnapshotQuotaExceededFault");
+    return __isa(o, "SnapshotQuotaExceededFault");
   }
 }
 
@@ -1742,7 +1743,7 @@ export namespace SnapshotQuotaExceededFault {
  * <p>The requested source could not be found.</p>
  */
 export interface SourceNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "SourceNotFoundFault";
   $fault: "client";
@@ -1751,7 +1752,7 @@ export interface SourceNotFoundFault
 
 export namespace SourceNotFoundFault {
   export function isa(o: any): o is SourceNotFoundFault {
-    return _smithy.isa(o, "SourceNotFoundFault");
+    return __isa(o, "SourceNotFoundFault");
   }
 }
 
@@ -1760,7 +1761,7 @@ export namespace SourceNotFoundFault {
  *             available across all DB instances.</p>
  */
 export interface StorageQuotaExceededFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "StorageQuotaExceededFault";
   $fault: "client";
@@ -1769,7 +1770,7 @@ export interface StorageQuotaExceededFault
 
 export namespace StorageQuotaExceededFault {
   export function isa(o: any): o is StorageQuotaExceededFault {
-    return _smithy.isa(o, "StorageQuotaExceededFault");
+    return __isa(o, "StorageQuotaExceededFault");
   }
 }
 
@@ -1778,7 +1779,7 @@ export namespace StorageQuotaExceededFault {
  *             with the DB instance. </p>
  */
 export interface StorageTypeNotSupportedFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "StorageTypeNotSupportedFault";
   $fault: "client";
@@ -1787,16 +1788,14 @@ export interface StorageTypeNotSupportedFault
 
 export namespace StorageTypeNotSupportedFault {
   export function isa(o: any): o is StorageTypeNotSupportedFault {
-    return _smithy.isa(o, "StorageTypeNotSupportedFault");
+    return __isa(o, "StorageTypeNotSupportedFault");
   }
 }
 
 /**
  * <p>The DB subnet is already in use in the Availability Zone.</p>
  */
-export interface SubnetAlreadyInUse
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface SubnetAlreadyInUse extends __SmithyException, $MetadataBearer {
   name: "SubnetAlreadyInUse";
   $fault: "client";
   message?: string;
@@ -1804,7 +1803,7 @@ export interface SubnetAlreadyInUse
 
 export namespace SubnetAlreadyInUse {
   export function isa(o: any): o is SubnetAlreadyInUse {
-    return _smithy.isa(o, "SubnetAlreadyInUse");
+    return __isa(o, "SubnetAlreadyInUse");
   }
 }
 
@@ -1812,7 +1811,7 @@ export namespace SubnetAlreadyInUse {
  * <p>The supplied subscription name already exists.</p>
  */
 export interface SubscriptionAlreadyExistFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "SubscriptionAlreadyExistFault";
   $fault: "client";
@@ -1821,7 +1820,7 @@ export interface SubscriptionAlreadyExistFault
 
 export namespace SubscriptionAlreadyExistFault {
   export function isa(o: any): o is SubscriptionAlreadyExistFault {
-    return _smithy.isa(o, "SubscriptionAlreadyExistFault");
+    return __isa(o, "SubscriptionAlreadyExistFault");
   }
 }
 
@@ -1829,7 +1828,7 @@ export namespace SubscriptionAlreadyExistFault {
  * <p>The supplied category does not exist.</p>
  */
 export interface SubscriptionCategoryNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "SubscriptionCategoryNotFoundFault";
   $fault: "client";
@@ -1838,7 +1837,7 @@ export interface SubscriptionCategoryNotFoundFault
 
 export namespace SubscriptionCategoryNotFoundFault {
   export function isa(o: any): o is SubscriptionCategoryNotFoundFault {
-    return _smithy.isa(o, "SubscriptionCategoryNotFoundFault");
+    return __isa(o, "SubscriptionCategoryNotFoundFault");
   }
 }
 
@@ -1846,7 +1845,7 @@ export namespace SubscriptionCategoryNotFoundFault {
  * <p>The subscription name does not exist.</p>
  */
 export interface SubscriptionNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "SubscriptionNotFoundFault";
   $fault: "client";
@@ -1855,7 +1854,7 @@ export interface SubscriptionNotFoundFault
 
 export namespace SubscriptionNotFoundFault {
   export function isa(o: any): o is SubscriptionNotFoundFault {
-    return _smithy.isa(o, "SubscriptionNotFoundFault");
+    return __isa(o, "SubscriptionNotFoundFault");
   }
 }
 
@@ -1873,7 +1872,7 @@ export interface AccountAttributesMessage extends $MetadataBearer {
 
 export namespace AccountAttributesMessage {
   export function isa(o: any): o is AccountAttributesMessage {
-    return _smithy.isa(o, "AccountAttributesMessage");
+    return __isa(o, "AccountAttributesMessage");
   }
 }
 
@@ -2003,7 +2002,7 @@ export interface AccountQuota {
 
 export namespace AccountQuota {
   export function isa(o: any): o is AccountQuota {
-    return _smithy.isa(o, "AccountQuota");
+    return __isa(o, "AccountQuota");
   }
 }
 
@@ -2037,7 +2036,7 @@ export interface AddRoleToDBClusterMessage {
 
 export namespace AddRoleToDBClusterMessage {
   export function isa(o: any): o is AddRoleToDBClusterMessage {
-    return _smithy.isa(o, "AddRoleToDBClusterMessage");
+    return __isa(o, "AddRoleToDBClusterMessage");
   }
 }
 
@@ -2064,7 +2063,7 @@ export interface AddRoleToDBInstanceMessage {
 
 export namespace AddRoleToDBInstanceMessage {
   export function isa(o: any): o is AddRoleToDBInstanceMessage {
-    return _smithy.isa(o, "AddRoleToDBInstanceMessage");
+    return __isa(o, "AddRoleToDBInstanceMessage");
   }
 }
 
@@ -2101,7 +2100,7 @@ export interface AddSourceIdentifierToSubscriptionMessage {
 
 export namespace AddSourceIdentifierToSubscriptionMessage {
   export function isa(o: any): o is AddSourceIdentifierToSubscriptionMessage {
-    return _smithy.isa(o, "AddSourceIdentifierToSubscriptionMessage");
+    return __isa(o, "AddSourceIdentifierToSubscriptionMessage");
   }
 }
 
@@ -2116,7 +2115,7 @@ export interface AddSourceIdentifierToSubscriptionResult
 
 export namespace AddSourceIdentifierToSubscriptionResult {
   export function isa(o: any): o is AddSourceIdentifierToSubscriptionResult {
-    return _smithy.isa(o, "AddSourceIdentifierToSubscriptionResult");
+    return __isa(o, "AddSourceIdentifierToSubscriptionResult");
   }
 }
 
@@ -2141,7 +2140,7 @@ export interface AddTagsToResourceMessage {
 
 export namespace AddTagsToResourceMessage {
   export function isa(o: any): o is AddTagsToResourceMessage {
-    return _smithy.isa(o, "AddTagsToResourceMessage");
+    return __isa(o, "AddTagsToResourceMessage");
   }
 }
 
@@ -2195,7 +2194,7 @@ export interface ApplyPendingMaintenanceActionMessage {
 
 export namespace ApplyPendingMaintenanceActionMessage {
   export function isa(o: any): o is ApplyPendingMaintenanceActionMessage {
-    return _smithy.isa(o, "ApplyPendingMaintenanceActionMessage");
+    return __isa(o, "ApplyPendingMaintenanceActionMessage");
   }
 }
 
@@ -2209,7 +2208,7 @@ export interface ApplyPendingMaintenanceActionResult extends $MetadataBearer {
 
 export namespace ApplyPendingMaintenanceActionResult {
   export function isa(o: any): o is ApplyPendingMaintenanceActionResult {
-    return _smithy.isa(o, "ApplyPendingMaintenanceActionResult");
+    return __isa(o, "ApplyPendingMaintenanceActionResult");
   }
 }
 
@@ -2265,7 +2264,7 @@ export interface AuthorizeDBSecurityGroupIngressMessage {
 
 export namespace AuthorizeDBSecurityGroupIngressMessage {
   export function isa(o: any): o is AuthorizeDBSecurityGroupIngressMessage {
-    return _smithy.isa(o, "AuthorizeDBSecurityGroupIngressMessage");
+    return __isa(o, "AuthorizeDBSecurityGroupIngressMessage");
   }
 }
 
@@ -2283,7 +2282,7 @@ export interface AuthorizeDBSecurityGroupIngressResult extends $MetadataBearer {
 
 export namespace AuthorizeDBSecurityGroupIngressResult {
   export function isa(o: any): o is AuthorizeDBSecurityGroupIngressResult {
-    return _smithy.isa(o, "AuthorizeDBSecurityGroupIngressResult");
+    return __isa(o, "AuthorizeDBSecurityGroupIngressResult");
   }
 }
 
@@ -2302,7 +2301,7 @@ export interface AvailabilityZone {
 
 export namespace AvailabilityZone {
   export function isa(o: any): o is AvailabilityZone {
-    return _smithy.isa(o, "AvailabilityZone");
+    return __isa(o, "AvailabilityZone");
   }
 }
 
@@ -2334,7 +2333,7 @@ export interface AvailableProcessorFeature {
 
 export namespace AvailableProcessorFeature {
   export function isa(o: any): o is AvailableProcessorFeature {
-    return _smithy.isa(o, "AvailableProcessorFeature");
+    return __isa(o, "AvailableProcessorFeature");
   }
 }
 
@@ -2403,7 +2402,7 @@ export interface BacktrackDBClusterMessage {
 
 export namespace BacktrackDBClusterMessage {
   export function isa(o: any): o is BacktrackDBClusterMessage {
-    return _smithy.isa(o, "BacktrackDBClusterMessage");
+    return __isa(o, "BacktrackDBClusterMessage");
   }
 }
 
@@ -2456,7 +2455,7 @@ export interface Certificate {
 
 export namespace Certificate {
   export function isa(o: any): o is Certificate {
-    return _smithy.isa(o, "Certificate");
+    return __isa(o, "Certificate");
   }
 }
 
@@ -2484,7 +2483,7 @@ export interface CertificateMessage extends $MetadataBearer {
 
 export namespace CertificateMessage {
   export function isa(o: any): o is CertificateMessage {
-    return _smithy.isa(o, "CertificateMessage");
+    return __isa(o, "CertificateMessage");
   }
 }
 
@@ -2508,7 +2507,7 @@ export interface CharacterSet {
 
 export namespace CharacterSet {
   export function isa(o: any): o is CharacterSet {
-    return _smithy.isa(o, "CharacterSet");
+    return __isa(o, "CharacterSet");
   }
 }
 
@@ -2535,7 +2534,7 @@ export interface CloudwatchLogsExportConfiguration {
 
 export namespace CloudwatchLogsExportConfiguration {
   export function isa(o: any): o is CloudwatchLogsExportConfiguration {
-    return _smithy.isa(o, "CloudwatchLogsExportConfiguration");
+    return __isa(o, "CloudwatchLogsExportConfiguration");
   }
 }
 
@@ -2601,7 +2600,7 @@ export interface ConnectionPoolConfiguration {
 
 export namespace ConnectionPoolConfiguration {
   export function isa(o: any): o is ConnectionPoolConfiguration {
-    return _smithy.isa(o, "ConnectionPoolConfiguration");
+    return __isa(o, "ConnectionPoolConfiguration");
   }
 }
 
@@ -2659,7 +2658,7 @@ export interface ConnectionPoolConfigurationInfo {
 
 export namespace ConnectionPoolConfigurationInfo {
   export function isa(o: any): o is ConnectionPoolConfigurationInfo {
-    return _smithy.isa(o, "ConnectionPoolConfigurationInfo");
+    return __isa(o, "ConnectionPoolConfigurationInfo");
   }
 }
 
@@ -2728,7 +2727,7 @@ export interface CopyDBClusterParameterGroupMessage {
 
 export namespace CopyDBClusterParameterGroupMessage {
   export function isa(o: any): o is CopyDBClusterParameterGroupMessage {
-    return _smithy.isa(o, "CopyDBClusterParameterGroupMessage");
+    return __isa(o, "CopyDBClusterParameterGroupMessage");
   }
 }
 
@@ -2745,7 +2744,7 @@ export interface CopyDBClusterParameterGroupResult extends $MetadataBearer {
 
 export namespace CopyDBClusterParameterGroupResult {
   export function isa(o: any): o is CopyDBClusterParameterGroupResult {
-    return _smithy.isa(o, "CopyDBClusterParameterGroupResult");
+    return __isa(o, "CopyDBClusterParameterGroupResult");
   }
 }
 
@@ -2875,7 +2874,7 @@ export interface CopyDBClusterSnapshotMessage {
 
 export namespace CopyDBClusterSnapshotMessage {
   export function isa(o: any): o is CopyDBClusterSnapshotMessage {
-    return _smithy.isa(o, "CopyDBClusterSnapshotMessage");
+    return __isa(o, "CopyDBClusterSnapshotMessage");
   }
 }
 
@@ -2893,7 +2892,7 @@ export interface CopyDBClusterSnapshotResult extends $MetadataBearer {
 
 export namespace CopyDBClusterSnapshotResult {
   export function isa(o: any): o is CopyDBClusterSnapshotResult {
-    return _smithy.isa(o, "CopyDBClusterSnapshotResult");
+    return __isa(o, "CopyDBClusterSnapshotResult");
   }
 }
 
@@ -2960,7 +2959,7 @@ export interface CopyDBParameterGroupMessage {
 
 export namespace CopyDBParameterGroupMessage {
   export function isa(o: any): o is CopyDBParameterGroupMessage {
-    return _smithy.isa(o, "CopyDBParameterGroupMessage");
+    return __isa(o, "CopyDBParameterGroupMessage");
   }
 }
 
@@ -2977,7 +2976,7 @@ export interface CopyDBParameterGroupResult extends $MetadataBearer {
 
 export namespace CopyDBParameterGroupResult {
   export function isa(o: any): o is CopyDBParameterGroupResult {
-    return _smithy.isa(o, "CopyDBParameterGroupResult");
+    return __isa(o, "CopyDBParameterGroupResult");
   }
 }
 
@@ -3161,7 +3160,7 @@ export interface CopyDBSnapshotMessage {
 
 export namespace CopyDBSnapshotMessage {
   export function isa(o: any): o is CopyDBSnapshotMessage {
-    return _smithy.isa(o, "CopyDBSnapshotMessage");
+    return __isa(o, "CopyDBSnapshotMessage");
   }
 }
 
@@ -3179,7 +3178,7 @@ export interface CopyDBSnapshotResult extends $MetadataBearer {
 
 export namespace CopyDBSnapshotResult {
   export function isa(o: any): o is CopyDBSnapshotResult {
-    return _smithy.isa(o, "CopyDBSnapshotResult");
+    return __isa(o, "CopyDBSnapshotResult");
   }
 }
 
@@ -3250,7 +3249,7 @@ export interface CopyOptionGroupMessage {
 
 export namespace CopyOptionGroupMessage {
   export function isa(o: any): o is CopyOptionGroupMessage {
-    return _smithy.isa(o, "CopyOptionGroupMessage");
+    return __isa(o, "CopyOptionGroupMessage");
   }
 }
 
@@ -3264,7 +3263,7 @@ export interface CopyOptionGroupResult extends $MetadataBearer {
 
 export namespace CopyOptionGroupResult {
   export function isa(o: any): o is CopyOptionGroupResult {
-    return _smithy.isa(o, "CopyOptionGroupResult");
+    return __isa(o, "CopyOptionGroupResult");
   }
 }
 
@@ -3299,7 +3298,7 @@ export interface CreateCustomAvailabilityZoneMessage {
 
 export namespace CreateCustomAvailabilityZoneMessage {
   export function isa(o: any): o is CreateCustomAvailabilityZoneMessage {
-    return _smithy.isa(o, "CreateCustomAvailabilityZoneMessage");
+    return __isa(o, "CreateCustomAvailabilityZoneMessage");
   }
 }
 
@@ -3318,7 +3317,7 @@ export interface CreateCustomAvailabilityZoneResult extends $MetadataBearer {
 
 export namespace CreateCustomAvailabilityZoneResult {
   export function isa(o: any): o is CreateCustomAvailabilityZoneResult {
-    return _smithy.isa(o, "CreateCustomAvailabilityZoneResult");
+    return __isa(o, "CreateCustomAvailabilityZoneResult");
   }
 }
 
@@ -3360,7 +3359,7 @@ export interface CreateDBClusterEndpointMessage {
 
 export namespace CreateDBClusterEndpointMessage {
   export function isa(o: any): o is CreateDBClusterEndpointMessage {
-    return _smithy.isa(o, "CreateDBClusterEndpointMessage");
+    return __isa(o, "CreateDBClusterEndpointMessage");
   }
 }
 
@@ -3752,7 +3751,7 @@ export interface CreateDBClusterMessage {
 
 export namespace CreateDBClusterMessage {
   export function isa(o: any): o is CreateDBClusterMessage {
-    return _smithy.isa(o, "CreateDBClusterMessage");
+    return __isa(o, "CreateDBClusterMessage");
   }
 }
 
@@ -3804,7 +3803,7 @@ export interface CreateDBClusterParameterGroupMessage {
 
 export namespace CreateDBClusterParameterGroupMessage {
   export function isa(o: any): o is CreateDBClusterParameterGroupMessage {
-    return _smithy.isa(o, "CreateDBClusterParameterGroupMessage");
+    return __isa(o, "CreateDBClusterParameterGroupMessage");
   }
 }
 
@@ -3821,7 +3820,7 @@ export interface CreateDBClusterParameterGroupResult extends $MetadataBearer {
 
 export namespace CreateDBClusterParameterGroupResult {
   export function isa(o: any): o is CreateDBClusterParameterGroupResult {
-    return _smithy.isa(o, "CreateDBClusterParameterGroupResult");
+    return __isa(o, "CreateDBClusterParameterGroupResult");
   }
 }
 
@@ -3839,7 +3838,7 @@ export interface CreateDBClusterResult extends $MetadataBearer {
 
 export namespace CreateDBClusterResult {
   export function isa(o: any): o is CreateDBClusterResult {
-    return _smithy.isa(o, "CreateDBClusterResult");
+    return __isa(o, "CreateDBClusterResult");
   }
 }
 
@@ -3888,7 +3887,7 @@ export interface CreateDBClusterSnapshotMessage {
 
 export namespace CreateDBClusterSnapshotMessage {
   export function isa(o: any): o is CreateDBClusterSnapshotMessage {
-    return _smithy.isa(o, "CreateDBClusterSnapshotMessage");
+    return __isa(o, "CreateDBClusterSnapshotMessage");
   }
 }
 
@@ -3906,7 +3905,7 @@ export interface CreateDBClusterSnapshotResult extends $MetadataBearer {
 
 export namespace CreateDBClusterSnapshotResult {
   export function isa(o: any): o is CreateDBClusterSnapshotResult {
-    return _smithy.isa(o, "CreateDBClusterSnapshotResult");
+    return __isa(o, "CreateDBClusterSnapshotResult");
   }
 }
 
@@ -4945,7 +4944,7 @@ export interface CreateDBInstanceMessage {
 
 export namespace CreateDBInstanceMessage {
   export function isa(o: any): o is CreateDBInstanceMessage {
-    return _smithy.isa(o, "CreateDBInstanceMessage");
+    return __isa(o, "CreateDBInstanceMessage");
   }
 }
 
@@ -5329,7 +5328,7 @@ export interface CreateDBInstanceReadReplicaMessage {
 
 export namespace CreateDBInstanceReadReplicaMessage {
   export function isa(o: any): o is CreateDBInstanceReadReplicaMessage {
-    return _smithy.isa(o, "CreateDBInstanceReadReplicaMessage");
+    return __isa(o, "CreateDBInstanceReadReplicaMessage");
   }
 }
 
@@ -5346,7 +5345,7 @@ export interface CreateDBInstanceReadReplicaResult extends $MetadataBearer {
 
 export namespace CreateDBInstanceReadReplicaResult {
   export function isa(o: any): o is CreateDBInstanceReadReplicaResult {
-    return _smithy.isa(o, "CreateDBInstanceReadReplicaResult");
+    return __isa(o, "CreateDBInstanceReadReplicaResult");
   }
 }
 
@@ -5363,7 +5362,7 @@ export interface CreateDBInstanceResult extends $MetadataBearer {
 
 export namespace CreateDBInstanceResult {
   export function isa(o: any): o is CreateDBInstanceResult {
-    return _smithy.isa(o, "CreateDBInstanceResult");
+    return __isa(o, "CreateDBInstanceResult");
   }
 }
 
@@ -5417,7 +5416,7 @@ export interface CreateDBParameterGroupMessage {
 
 export namespace CreateDBParameterGroupMessage {
   export function isa(o: any): o is CreateDBParameterGroupMessage {
-    return _smithy.isa(o, "CreateDBParameterGroupMessage");
+    return __isa(o, "CreateDBParameterGroupMessage");
   }
 }
 
@@ -5434,7 +5433,7 @@ export interface CreateDBParameterGroupResult extends $MetadataBearer {
 
 export namespace CreateDBParameterGroupResult {
   export function isa(o: any): o is CreateDBParameterGroupResult {
-    return _smithy.isa(o, "CreateDBParameterGroupResult");
+    return __isa(o, "CreateDBParameterGroupResult");
   }
 }
 
@@ -5502,7 +5501,7 @@ export interface CreateDBProxyRequest {
 
 export namespace CreateDBProxyRequest {
   export function isa(o: any): o is CreateDBProxyRequest {
-    return _smithy.isa(o, "CreateDBProxyRequest");
+    return __isa(o, "CreateDBProxyRequest");
   }
 }
 
@@ -5516,7 +5515,7 @@ export interface CreateDBProxyResponse extends $MetadataBearer {
 
 export namespace CreateDBProxyResponse {
   export function isa(o: any): o is CreateDBProxyResponse {
-    return _smithy.isa(o, "CreateDBProxyResponse");
+    return __isa(o, "CreateDBProxyResponse");
   }
 }
 
@@ -5560,7 +5559,7 @@ export interface CreateDBSecurityGroupMessage {
 
 export namespace CreateDBSecurityGroupMessage {
   export function isa(o: any): o is CreateDBSecurityGroupMessage {
-    return _smithy.isa(o, "CreateDBSecurityGroupMessage");
+    return __isa(o, "CreateDBSecurityGroupMessage");
   }
 }
 
@@ -5578,7 +5577,7 @@ export interface CreateDBSecurityGroupResult extends $MetadataBearer {
 
 export namespace CreateDBSecurityGroupResult {
   export function isa(o: any): o is CreateDBSecurityGroupResult {
-    return _smithy.isa(o, "CreateDBSecurityGroupResult");
+    return __isa(o, "CreateDBSecurityGroupResult");
   }
 }
 
@@ -5630,7 +5629,7 @@ export interface CreateDBSnapshotMessage {
 
 export namespace CreateDBSnapshotMessage {
   export function isa(o: any): o is CreateDBSnapshotMessage {
-    return _smithy.isa(o, "CreateDBSnapshotMessage");
+    return __isa(o, "CreateDBSnapshotMessage");
   }
 }
 
@@ -5648,7 +5647,7 @@ export interface CreateDBSnapshotResult extends $MetadataBearer {
 
 export namespace CreateDBSnapshotResult {
   export function isa(o: any): o is CreateDBSnapshotResult {
-    return _smithy.isa(o, "CreateDBSnapshotResult");
+    return __isa(o, "CreateDBSnapshotResult");
   }
 }
 
@@ -5683,7 +5682,7 @@ export interface CreateDBSubnetGroupMessage {
 
 export namespace CreateDBSubnetGroupMessage {
   export function isa(o: any): o is CreateDBSubnetGroupMessage {
-    return _smithy.isa(o, "CreateDBSubnetGroupMessage");
+    return __isa(o, "CreateDBSubnetGroupMessage");
   }
 }
 
@@ -5701,7 +5700,7 @@ export interface CreateDBSubnetGroupResult extends $MetadataBearer {
 
 export namespace CreateDBSubnetGroupResult {
   export function isa(o: any): o is CreateDBSubnetGroupResult {
-    return _smithy.isa(o, "CreateDBSubnetGroupResult");
+    return __isa(o, "CreateDBSubnetGroupResult");
   }
 }
 
@@ -5780,7 +5779,7 @@ export interface CreateEventSubscriptionMessage {
 
 export namespace CreateEventSubscriptionMessage {
   export function isa(o: any): o is CreateEventSubscriptionMessage {
-    return _smithy.isa(o, "CreateEventSubscriptionMessage");
+    return __isa(o, "CreateEventSubscriptionMessage");
   }
 }
 
@@ -5794,7 +5793,7 @@ export interface CreateEventSubscriptionResult extends $MetadataBearer {
 
 export namespace CreateEventSubscriptionResult {
   export function isa(o: any): o is CreateEventSubscriptionResult {
-    return _smithy.isa(o, "CreateEventSubscriptionResult");
+    return __isa(o, "CreateEventSubscriptionResult");
   }
 }
 
@@ -5849,7 +5848,7 @@ export interface CreateGlobalClusterMessage {
 
 export namespace CreateGlobalClusterMessage {
   export function isa(o: any): o is CreateGlobalClusterMessage {
-    return _smithy.isa(o, "CreateGlobalClusterMessage");
+    return __isa(o, "CreateGlobalClusterMessage");
   }
 }
 
@@ -5863,7 +5862,7 @@ export interface CreateGlobalClusterResult extends $MetadataBearer {
 
 export namespace CreateGlobalClusterResult {
   export function isa(o: any): o is CreateGlobalClusterResult {
-    return _smithy.isa(o, "CreateGlobalClusterResult");
+    return __isa(o, "CreateGlobalClusterResult");
   }
 }
 
@@ -5914,7 +5913,7 @@ export interface CreateOptionGroupMessage {
 
 export namespace CreateOptionGroupMessage {
   export function isa(o: any): o is CreateOptionGroupMessage {
-    return _smithy.isa(o, "CreateOptionGroupMessage");
+    return __isa(o, "CreateOptionGroupMessage");
   }
 }
 
@@ -5928,7 +5927,7 @@ export interface CreateOptionGroupResult extends $MetadataBearer {
 
 export namespace CreateOptionGroupResult {
   export function isa(o: any): o is CreateOptionGroupResult {
-    return _smithy.isa(o, "CreateOptionGroupResult");
+    return __isa(o, "CreateOptionGroupResult");
   }
 }
 
@@ -5967,7 +5966,7 @@ export interface CustomAvailabilityZone {
 
 export namespace CustomAvailabilityZone {
   export function isa(o: any): o is CustomAvailabilityZone {
-    return _smithy.isa(o, "CustomAvailabilityZone");
+    return __isa(o, "CustomAvailabilityZone");
   }
 }
 
@@ -5990,7 +5989,7 @@ export interface CustomAvailabilityZoneMessage extends $MetadataBearer {
 
 export namespace CustomAvailabilityZoneMessage {
   export function isa(o: any): o is CustomAvailabilityZoneMessage {
-    return _smithy.isa(o, "CustomAvailabilityZoneMessage");
+    return __isa(o, "CustomAvailabilityZoneMessage");
   }
 }
 
@@ -6296,7 +6295,7 @@ export interface DBCluster {
 
 export namespace DBCluster {
   export function isa(o: any): o is DBCluster {
-    return _smithy.isa(o, "DBCluster");
+    return __isa(o, "DBCluster");
   }
 }
 
@@ -6357,7 +6356,7 @@ export interface DBClusterBacktrack extends $MetadataBearer {
 
 export namespace DBClusterBacktrack {
   export function isa(o: any): o is DBClusterBacktrack {
-    return _smithy.isa(o, "DBClusterBacktrack");
+    return __isa(o, "DBClusterBacktrack");
   }
 }
 
@@ -6379,7 +6378,7 @@ export interface DBClusterBacktrackMessage extends $MetadataBearer {
 
 export namespace DBClusterBacktrackMessage {
   export function isa(o: any): o is DBClusterBacktrackMessage {
-    return _smithy.isa(o, "DBClusterBacktrackMessage");
+    return __isa(o, "DBClusterBacktrackMessage");
   }
 }
 
@@ -6415,7 +6414,7 @@ export interface DBClusterCapacityInfo extends $MetadataBearer {
 
 export namespace DBClusterCapacityInfo {
   export function isa(o: any): o is DBClusterCapacityInfo {
-    return _smithy.isa(o, "DBClusterCapacityInfo");
+    return __isa(o, "DBClusterCapacityInfo");
   }
 }
 
@@ -6506,7 +6505,7 @@ export interface DBClusterEndpoint extends $MetadataBearer {
 
 export namespace DBClusterEndpoint {
   export function isa(o: any): o is DBClusterEndpoint {
-    return _smithy.isa(o, "DBClusterEndpoint");
+    return __isa(o, "DBClusterEndpoint");
   }
 }
 
@@ -6531,7 +6530,7 @@ export interface DBClusterEndpointMessage extends $MetadataBearer {
 
 export namespace DBClusterEndpointMessage {
   export function isa(o: any): o is DBClusterEndpointMessage {
-    return _smithy.isa(o, "DBClusterEndpointMessage");
+    return __isa(o, "DBClusterEndpointMessage");
   }
 }
 
@@ -6567,7 +6566,7 @@ export interface DBClusterMember {
 
 export namespace DBClusterMember {
   export function isa(o: any): o is DBClusterMember {
-    return _smithy.isa(o, "DBClusterMember");
+    return __isa(o, "DBClusterMember");
   }
 }
 
@@ -6589,7 +6588,7 @@ export interface DBClusterMessage extends $MetadataBearer {
 
 export namespace DBClusterMessage {
   export function isa(o: any): o is DBClusterMessage {
-    return _smithy.isa(o, "DBClusterMessage");
+    return __isa(o, "DBClusterMessage");
   }
 }
 
@@ -6611,7 +6610,7 @@ export interface DBClusterOptionGroupStatus {
 
 export namespace DBClusterOptionGroupStatus {
   export function isa(o: any): o is DBClusterOptionGroupStatus {
-    return _smithy.isa(o, "DBClusterOptionGroupStatus");
+    return __isa(o, "DBClusterOptionGroupStatus");
   }
 }
 
@@ -6646,7 +6645,7 @@ export interface DBClusterParameterGroup {
 
 export namespace DBClusterParameterGroup {
   export function isa(o: any): o is DBClusterParameterGroup {
-    return _smithy.isa(o, "DBClusterParameterGroup");
+    return __isa(o, "DBClusterParameterGroup");
   }
 }
 
@@ -6674,7 +6673,7 @@ export interface DBClusterParameterGroupDetails extends $MetadataBearer {
 
 export namespace DBClusterParameterGroupDetails {
   export function isa(o: any): o is DBClusterParameterGroupDetails {
-    return _smithy.isa(o, "DBClusterParameterGroupDetails");
+    return __isa(o, "DBClusterParameterGroupDetails");
   }
 }
 
@@ -6706,7 +6705,7 @@ export interface DBClusterParameterGroupNameMessage extends $MetadataBearer {
 
 export namespace DBClusterParameterGroupNameMessage {
   export function isa(o: any): o is DBClusterParameterGroupNameMessage {
-    return _smithy.isa(o, "DBClusterParameterGroupNameMessage");
+    return __isa(o, "DBClusterParameterGroupNameMessage");
   }
 }
 
@@ -6734,7 +6733,7 @@ export interface DBClusterParameterGroupsMessage extends $MetadataBearer {
 
 export namespace DBClusterParameterGroupsMessage {
   export function isa(o: any): o is DBClusterParameterGroupsMessage {
-    return _smithy.isa(o, "DBClusterParameterGroupsMessage");
+    return __isa(o, "DBClusterParameterGroupsMessage");
   }
 }
 
@@ -6780,7 +6779,7 @@ export interface DBClusterRole {
 
 export namespace DBClusterRole {
   export function isa(o: any): o is DBClusterRole {
-    return _smithy.isa(o, "DBClusterRole");
+    return __isa(o, "DBClusterRole");
   }
 }
 
@@ -6897,7 +6896,7 @@ export interface DBClusterSnapshot {
 
 export namespace DBClusterSnapshot {
   export function isa(o: any): o is DBClusterSnapshot {
-    return _smithy.isa(o, "DBClusterSnapshot");
+    return __isa(o, "DBClusterSnapshot");
   }
 }
 
@@ -6930,7 +6929,7 @@ export interface DBClusterSnapshotAttribute {
 
 export namespace DBClusterSnapshotAttribute {
   export function isa(o: any): o is DBClusterSnapshotAttribute {
-    return _smithy.isa(o, "DBClusterSnapshotAttribute");
+    return __isa(o, "DBClusterSnapshotAttribute");
   }
 }
 
@@ -6956,7 +6955,7 @@ export interface DBClusterSnapshotAttributesResult {
 
 export namespace DBClusterSnapshotAttributesResult {
   export function isa(o: any): o is DBClusterSnapshotAttributesResult {
-    return _smithy.isa(o, "DBClusterSnapshotAttributesResult");
+    return __isa(o, "DBClusterSnapshotAttributesResult");
   }
 }
 
@@ -6986,7 +6985,7 @@ export interface DBClusterSnapshotMessage extends $MetadataBearer {
 
 export namespace DBClusterSnapshotMessage {
   export function isa(o: any): o is DBClusterSnapshotMessage {
-    return _smithy.isa(o, "DBClusterSnapshotMessage");
+    return __isa(o, "DBClusterSnapshotMessage");
   }
 }
 
@@ -7091,7 +7090,7 @@ export interface DBEngineVersion {
 
 export namespace DBEngineVersion {
   export function isa(o: any): o is DBEngineVersion {
-    return _smithy.isa(o, "DBEngineVersion");
+    return __isa(o, "DBEngineVersion");
   }
 }
 
@@ -7122,7 +7121,7 @@ export interface DBEngineVersionMessage extends $MetadataBearer {
 
 export namespace DBEngineVersionMessage {
   export function isa(o: any): o is DBEngineVersionMessage {
-    return _smithy.isa(o, "DBEngineVersionMessage");
+    return __isa(o, "DBEngineVersionMessage");
   }
 }
 
@@ -7491,7 +7490,7 @@ export interface DBInstance {
 
 export namespace DBInstance {
   export function isa(o: any): o is DBInstance {
-    return _smithy.isa(o, "DBInstance");
+    return __isa(o, "DBInstance");
   }
 }
 
@@ -7648,7 +7647,7 @@ export interface DBInstanceAutomatedBackup {
 
 export namespace DBInstanceAutomatedBackup {
   export function isa(o: any): o is DBInstanceAutomatedBackup {
-    return _smithy.isa(o, "DBInstanceAutomatedBackup");
+    return __isa(o, "DBInstanceAutomatedBackup");
   }
 }
 
@@ -7679,7 +7678,7 @@ export interface DBInstanceAutomatedBackupMessage extends $MetadataBearer {
 
 export namespace DBInstanceAutomatedBackupMessage {
   export function isa(o: any): o is DBInstanceAutomatedBackupMessage {
-    return _smithy.isa(o, "DBInstanceAutomatedBackupMessage");
+    return __isa(o, "DBInstanceAutomatedBackupMessage");
   }
 }
 
@@ -7710,7 +7709,7 @@ export interface DBInstanceMessage extends $MetadataBearer {
 
 export namespace DBInstanceMessage {
   export function isa(o: any): o is DBInstanceMessage {
-    return _smithy.isa(o, "DBInstanceMessage");
+    return __isa(o, "DBInstanceMessage");
   }
 }
 
@@ -7757,7 +7756,7 @@ export interface DBInstanceRole {
 
 export namespace DBInstanceRole {
   export function isa(o: any): o is DBInstanceRole {
-    return _smithy.isa(o, "DBInstanceRole");
+    return __isa(o, "DBInstanceRole");
   }
 }
 
@@ -7790,7 +7789,7 @@ export interface DBInstanceStatusInfo {
 
 export namespace DBInstanceStatusInfo {
   export function isa(o: any): o is DBInstanceStatusInfo {
-    return _smithy.isa(o, "DBInstanceStatusInfo");
+    return __isa(o, "DBInstanceStatusInfo");
   }
 }
 
@@ -7825,7 +7824,7 @@ export interface DBParameterGroup {
 
 export namespace DBParameterGroup {
   export function isa(o: any): o is DBParameterGroup {
-    return _smithy.isa(o, "DBParameterGroup");
+    return __isa(o, "DBParameterGroup");
   }
 }
 
@@ -7856,7 +7855,7 @@ export interface DBParameterGroupDetails extends $MetadataBearer {
 
 export namespace DBParameterGroupDetails {
   export function isa(o: any): o is DBParameterGroupDetails {
-    return _smithy.isa(o, "DBParameterGroupDetails");
+    return __isa(o, "DBParameterGroupDetails");
   }
 }
 
@@ -7876,7 +7875,7 @@ export interface DBParameterGroupNameMessage extends $MetadataBearer {
 
 export namespace DBParameterGroupNameMessage {
   export function isa(o: any): o is DBParameterGroupNameMessage {
-    return _smithy.isa(o, "DBParameterGroupNameMessage");
+    return __isa(o, "DBParameterGroupNameMessage");
   }
 }
 
@@ -7931,7 +7930,7 @@ export interface DBParameterGroupStatus {
 
 export namespace DBParameterGroupStatus {
   export function isa(o: any): o is DBParameterGroupStatus {
-    return _smithy.isa(o, "DBParameterGroupStatus");
+    return __isa(o, "DBParameterGroupStatus");
   }
 }
 
@@ -7962,7 +7961,7 @@ export interface DBParameterGroupsMessage extends $MetadataBearer {
 
 export namespace DBParameterGroupsMessage {
   export function isa(o: any): o is DBParameterGroupsMessage {
-    return _smithy.isa(o, "DBParameterGroupsMessage");
+    return __isa(o, "DBParameterGroupsMessage");
   }
 }
 
@@ -8063,7 +8062,7 @@ export interface DBProxy {
 
 export namespace DBProxy {
   export function isa(o: any): o is DBProxy {
-    return _smithy.isa(o, "DBProxy");
+    return __isa(o, "DBProxy");
   }
 }
 
@@ -8121,7 +8120,7 @@ export interface DBProxyTarget {
 
 export namespace DBProxyTarget {
   export function isa(o: any): o is DBProxyTarget {
-    return _smithy.isa(o, "DBProxyTarget");
+    return __isa(o, "DBProxyTarget");
   }
 }
 
@@ -8183,7 +8182,7 @@ export interface DBProxyTargetGroup {
 
 export namespace DBProxyTargetGroup {
   export function isa(o: any): o is DBProxyTargetGroup {
-    return _smithy.isa(o, "DBProxyTargetGroup");
+    return __isa(o, "DBProxyTargetGroup");
   }
 }
 
@@ -8238,7 +8237,7 @@ export interface DBSecurityGroup {
 
 export namespace DBSecurityGroup {
   export function isa(o: any): o is DBSecurityGroup {
-    return _smithy.isa(o, "DBSecurityGroup");
+    return __isa(o, "DBSecurityGroup");
   }
 }
 
@@ -8282,7 +8281,7 @@ export interface DBSecurityGroupMembership {
 
 export namespace DBSecurityGroupMembership {
   export function isa(o: any): o is DBSecurityGroupMembership {
-    return _smithy.isa(o, "DBSecurityGroupMembership");
+    return __isa(o, "DBSecurityGroupMembership");
   }
 }
 
@@ -8313,7 +8312,7 @@ export interface DBSecurityGroupMessage extends $MetadataBearer {
 
 export namespace DBSecurityGroupMessage {
   export function isa(o: any): o is DBSecurityGroupMessage {
-    return _smithy.isa(o, "DBSecurityGroupMessage");
+    return __isa(o, "DBSecurityGroupMessage");
   }
 }
 
@@ -8479,7 +8478,7 @@ export interface DBSnapshot {
 
 export namespace DBSnapshot {
   export function isa(o: any): o is DBSnapshot {
-    return _smithy.isa(o, "DBSnapshot");
+    return __isa(o, "DBSnapshot");
   }
 }
 
@@ -8512,7 +8511,7 @@ export interface DBSnapshotAttribute {
 
 export namespace DBSnapshotAttribute {
   export function isa(o: any): o is DBSnapshotAttribute {
-    return _smithy.isa(o, "DBSnapshotAttribute");
+    return __isa(o, "DBSnapshotAttribute");
   }
 }
 
@@ -8538,7 +8537,7 @@ export interface DBSnapshotAttributesResult {
 
 export namespace DBSnapshotAttributesResult {
   export function isa(o: any): o is DBSnapshotAttributesResult {
-    return _smithy.isa(o, "DBSnapshotAttributesResult");
+    return __isa(o, "DBSnapshotAttributesResult");
   }
 }
 
@@ -8569,7 +8568,7 @@ export interface DBSnapshotMessage extends $MetadataBearer {
 
 export namespace DBSnapshotMessage {
   export function isa(o: any): o is DBSnapshotMessage {
-    return _smithy.isa(o, "DBSnapshotMessage");
+    return __isa(o, "DBSnapshotMessage");
   }
 }
 
@@ -8617,7 +8616,7 @@ export interface DBSubnetGroup {
 
 export namespace DBSubnetGroup {
   export function isa(o: any): o is DBSubnetGroup {
-    return _smithy.isa(o, "DBSubnetGroup");
+    return __isa(o, "DBSubnetGroup");
   }
 }
 
@@ -8648,7 +8647,7 @@ export interface DBSubnetGroupMessage extends $MetadataBearer {
 
 export namespace DBSubnetGroupMessage {
   export function isa(o: any): o is DBSubnetGroupMessage {
-    return _smithy.isa(o, "DBSubnetGroupMessage");
+    return __isa(o, "DBSubnetGroupMessage");
   }
 }
 
@@ -8662,7 +8661,7 @@ export interface DeleteCustomAvailabilityZoneMessage {
 
 export namespace DeleteCustomAvailabilityZoneMessage {
   export function isa(o: any): o is DeleteCustomAvailabilityZoneMessage {
-    return _smithy.isa(o, "DeleteCustomAvailabilityZoneMessage");
+    return __isa(o, "DeleteCustomAvailabilityZoneMessage");
   }
 }
 
@@ -8681,7 +8680,7 @@ export interface DeleteCustomAvailabilityZoneResult extends $MetadataBearer {
 
 export namespace DeleteCustomAvailabilityZoneResult {
   export function isa(o: any): o is DeleteCustomAvailabilityZoneResult {
-    return _smithy.isa(o, "DeleteCustomAvailabilityZoneResult");
+    return __isa(o, "DeleteCustomAvailabilityZoneResult");
   }
 }
 
@@ -8695,7 +8694,7 @@ export interface DeleteDBClusterEndpointMessage {
 
 export namespace DeleteDBClusterEndpointMessage {
   export function isa(o: any): o is DeleteDBClusterEndpointMessage {
-    return _smithy.isa(o, "DeleteDBClusterEndpointMessage");
+    return __isa(o, "DeleteDBClusterEndpointMessage");
   }
 }
 
@@ -8754,7 +8753,7 @@ export interface DeleteDBClusterMessage {
 
 export namespace DeleteDBClusterMessage {
   export function isa(o: any): o is DeleteDBClusterMessage {
-    return _smithy.isa(o, "DeleteDBClusterMessage");
+    return __isa(o, "DeleteDBClusterMessage");
   }
 }
 
@@ -8783,7 +8782,7 @@ export interface DeleteDBClusterParameterGroupMessage {
 
 export namespace DeleteDBClusterParameterGroupMessage {
   export function isa(o: any): o is DeleteDBClusterParameterGroupMessage {
-    return _smithy.isa(o, "DeleteDBClusterParameterGroupMessage");
+    return __isa(o, "DeleteDBClusterParameterGroupMessage");
   }
 }
 
@@ -8801,7 +8800,7 @@ export interface DeleteDBClusterResult extends $MetadataBearer {
 
 export namespace DeleteDBClusterResult {
   export function isa(o: any): o is DeleteDBClusterResult {
-    return _smithy.isa(o, "DeleteDBClusterResult");
+    return __isa(o, "DeleteDBClusterResult");
   }
 }
 
@@ -8819,7 +8818,7 @@ export interface DeleteDBClusterSnapshotMessage {
 
 export namespace DeleteDBClusterSnapshotMessage {
   export function isa(o: any): o is DeleteDBClusterSnapshotMessage {
-    return _smithy.isa(o, "DeleteDBClusterSnapshotMessage");
+    return __isa(o, "DeleteDBClusterSnapshotMessage");
   }
 }
 
@@ -8837,7 +8836,7 @@ export interface DeleteDBClusterSnapshotResult extends $MetadataBearer {
 
 export namespace DeleteDBClusterSnapshotResult {
   export function isa(o: any): o is DeleteDBClusterSnapshotResult {
-    return _smithy.isa(o, "DeleteDBClusterSnapshotResult");
+    return __isa(o, "DeleteDBClusterSnapshotResult");
   }
 }
 
@@ -8854,7 +8853,7 @@ export interface DeleteDBInstanceAutomatedBackupMessage {
 
 export namespace DeleteDBInstanceAutomatedBackupMessage {
   export function isa(o: any): o is DeleteDBInstanceAutomatedBackupMessage {
-    return _smithy.isa(o, "DeleteDBInstanceAutomatedBackupMessage");
+    return __isa(o, "DeleteDBInstanceAutomatedBackupMessage");
   }
 }
 
@@ -8870,7 +8869,7 @@ export interface DeleteDBInstanceAutomatedBackupResult extends $MetadataBearer {
 
 export namespace DeleteDBInstanceAutomatedBackupResult {
   export function isa(o: any): o is DeleteDBInstanceAutomatedBackupResult {
-    return _smithy.isa(o, "DeleteDBInstanceAutomatedBackupResult");
+    return __isa(o, "DeleteDBInstanceAutomatedBackupResult");
   }
 }
 
@@ -8938,7 +8937,7 @@ export interface DeleteDBInstanceMessage {
 
 export namespace DeleteDBInstanceMessage {
   export function isa(o: any): o is DeleteDBInstanceMessage {
-    return _smithy.isa(o, "DeleteDBInstanceMessage");
+    return __isa(o, "DeleteDBInstanceMessage");
   }
 }
 
@@ -8955,7 +8954,7 @@ export interface DeleteDBInstanceResult extends $MetadataBearer {
 
 export namespace DeleteDBInstanceResult {
   export function isa(o: any): o is DeleteDBInstanceResult {
-    return _smithy.isa(o, "DeleteDBInstanceResult");
+    return __isa(o, "DeleteDBInstanceResult");
   }
 }
 
@@ -8984,7 +8983,7 @@ export interface DeleteDBParameterGroupMessage {
 
 export namespace DeleteDBParameterGroupMessage {
   export function isa(o: any): o is DeleteDBParameterGroupMessage {
-    return _smithy.isa(o, "DeleteDBParameterGroupMessage");
+    return __isa(o, "DeleteDBParameterGroupMessage");
   }
 }
 
@@ -8998,7 +8997,7 @@ export interface DeleteDBProxyRequest {
 
 export namespace DeleteDBProxyRequest {
   export function isa(o: any): o is DeleteDBProxyRequest {
-    return _smithy.isa(o, "DeleteDBProxyRequest");
+    return __isa(o, "DeleteDBProxyRequest");
   }
 }
 
@@ -9012,7 +9011,7 @@ export interface DeleteDBProxyResponse extends $MetadataBearer {
 
 export namespace DeleteDBProxyResponse {
   export function isa(o: any): o is DeleteDBProxyResponse {
-    return _smithy.isa(o, "DeleteDBProxyResponse");
+    return __isa(o, "DeleteDBProxyResponse");
   }
 }
 
@@ -9047,7 +9046,7 @@ export interface DeleteDBSecurityGroupMessage {
 
 export namespace DeleteDBSecurityGroupMessage {
   export function isa(o: any): o is DeleteDBSecurityGroupMessage {
-    return _smithy.isa(o, "DeleteDBSecurityGroupMessage");
+    return __isa(o, "DeleteDBSecurityGroupMessage");
   }
 }
 
@@ -9065,7 +9064,7 @@ export interface DeleteDBSnapshotMessage {
 
 export namespace DeleteDBSnapshotMessage {
   export function isa(o: any): o is DeleteDBSnapshotMessage {
-    return _smithy.isa(o, "DeleteDBSnapshotMessage");
+    return __isa(o, "DeleteDBSnapshotMessage");
   }
 }
 
@@ -9083,7 +9082,7 @@ export interface DeleteDBSnapshotResult extends $MetadataBearer {
 
 export namespace DeleteDBSnapshotResult {
   export function isa(o: any): o is DeleteDBSnapshotResult {
-    return _smithy.isa(o, "DeleteDBSnapshotResult");
+    return __isa(o, "DeleteDBSnapshotResult");
   }
 }
 
@@ -9107,7 +9106,7 @@ export interface DeleteDBSubnetGroupMessage {
 
 export namespace DeleteDBSubnetGroupMessage {
   export function isa(o: any): o is DeleteDBSubnetGroupMessage {
-    return _smithy.isa(o, "DeleteDBSubnetGroupMessage");
+    return __isa(o, "DeleteDBSubnetGroupMessage");
   }
 }
 
@@ -9124,7 +9123,7 @@ export interface DeleteEventSubscriptionMessage {
 
 export namespace DeleteEventSubscriptionMessage {
   export function isa(o: any): o is DeleteEventSubscriptionMessage {
-    return _smithy.isa(o, "DeleteEventSubscriptionMessage");
+    return __isa(o, "DeleteEventSubscriptionMessage");
   }
 }
 
@@ -9138,7 +9137,7 @@ export interface DeleteEventSubscriptionResult extends $MetadataBearer {
 
 export namespace DeleteEventSubscriptionResult {
   export function isa(o: any): o is DeleteEventSubscriptionResult {
-    return _smithy.isa(o, "DeleteEventSubscriptionResult");
+    return __isa(o, "DeleteEventSubscriptionResult");
   }
 }
 
@@ -9154,7 +9153,7 @@ export interface DeleteGlobalClusterMessage {
 
 export namespace DeleteGlobalClusterMessage {
   export function isa(o: any): o is DeleteGlobalClusterMessage {
-    return _smithy.isa(o, "DeleteGlobalClusterMessage");
+    return __isa(o, "DeleteGlobalClusterMessage");
   }
 }
 
@@ -9168,7 +9167,7 @@ export interface DeleteGlobalClusterResult extends $MetadataBearer {
 
 export namespace DeleteGlobalClusterResult {
   export function isa(o: any): o is DeleteGlobalClusterResult {
-    return _smithy.isa(o, "DeleteGlobalClusterResult");
+    return __isa(o, "DeleteGlobalClusterResult");
   }
 }
 
@@ -9182,7 +9181,7 @@ export interface DeleteInstallationMediaMessage {
 
 export namespace DeleteInstallationMediaMessage {
   export function isa(o: any): o is DeleteInstallationMediaMessage {
-    return _smithy.isa(o, "DeleteInstallationMediaMessage");
+    return __isa(o, "DeleteInstallationMediaMessage");
   }
 }
 
@@ -9202,7 +9201,7 @@ export interface DeleteOptionGroupMessage {
 
 export namespace DeleteOptionGroupMessage {
   export function isa(o: any): o is DeleteOptionGroupMessage {
-    return _smithy.isa(o, "DeleteOptionGroupMessage");
+    return __isa(o, "DeleteOptionGroupMessage");
   }
 }
 
@@ -9231,7 +9230,7 @@ export interface DeregisterDBProxyTargetsRequest {
 
 export namespace DeregisterDBProxyTargetsRequest {
   export function isa(o: any): o is DeregisterDBProxyTargetsRequest {
-    return _smithy.isa(o, "DeregisterDBProxyTargetsRequest");
+    return __isa(o, "DeregisterDBProxyTargetsRequest");
   }
 }
 
@@ -9241,7 +9240,7 @@ export interface DeregisterDBProxyTargetsResponse extends $MetadataBearer {
 
 export namespace DeregisterDBProxyTargetsResponse {
   export function isa(o: any): o is DeregisterDBProxyTargetsResponse {
-    return _smithy.isa(o, "DeregisterDBProxyTargetsResponse");
+    return __isa(o, "DeregisterDBProxyTargetsResponse");
   }
 }
 
@@ -9254,7 +9253,7 @@ export interface DescribeAccountAttributesMessage {
 
 export namespace DescribeAccountAttributesMessage {
   export function isa(o: any): o is DescribeAccountAttributesMessage {
-    return _smithy.isa(o, "DescribeAccountAttributesMessage");
+    return __isa(o, "DescribeAccountAttributesMessage");
   }
 }
 
@@ -9304,7 +9303,7 @@ export interface DescribeCertificatesMessage {
 
 export namespace DescribeCertificatesMessage {
   export function isa(o: any): o is DescribeCertificatesMessage {
-    return _smithy.isa(o, "DescribeCertificatesMessage");
+    return __isa(o, "DescribeCertificatesMessage");
   }
 }
 
@@ -9341,7 +9340,7 @@ export interface DescribeCustomAvailabilityZonesMessage {
 
 export namespace DescribeCustomAvailabilityZonesMessage {
   export function isa(o: any): o is DescribeCustomAvailabilityZonesMessage {
-    return _smithy.isa(o, "DescribeCustomAvailabilityZonesMessage");
+    return __isa(o, "DescribeCustomAvailabilityZonesMessage");
   }
 }
 
@@ -9451,7 +9450,7 @@ export interface DescribeDBClusterBacktracksMessage {
 
 export namespace DescribeDBClusterBacktracksMessage {
   export function isa(o: any): o is DescribeDBClusterBacktracksMessage {
-    return _smithy.isa(o, "DescribeDBClusterBacktracksMessage");
+    return __isa(o, "DescribeDBClusterBacktracksMessage");
   }
 }
 
@@ -9503,7 +9502,7 @@ export interface DescribeDBClusterEndpointsMessage {
 
 export namespace DescribeDBClusterEndpointsMessage {
   export function isa(o: any): o is DescribeDBClusterEndpointsMessage {
-    return _smithy.isa(o, "DescribeDBClusterEndpointsMessage");
+    return __isa(o, "DescribeDBClusterEndpointsMessage");
   }
 }
 
@@ -9553,7 +9552,7 @@ export interface DescribeDBClusterParameterGroupsMessage {
 
 export namespace DescribeDBClusterParameterGroupsMessage {
   export function isa(o: any): o is DescribeDBClusterParameterGroupsMessage {
-    return _smithy.isa(o, "DescribeDBClusterParameterGroupsMessage");
+    return __isa(o, "DescribeDBClusterParameterGroupsMessage");
   }
 }
 
@@ -9612,7 +9611,7 @@ export interface DescribeDBClusterParametersMessage {
 
 export namespace DescribeDBClusterParametersMessage {
   export function isa(o: any): o is DescribeDBClusterParametersMessage {
-    return _smithy.isa(o, "DescribeDBClusterParametersMessage");
+    return __isa(o, "DescribeDBClusterParametersMessage");
   }
 }
 
@@ -9629,7 +9628,7 @@ export interface DescribeDBClusterSnapshotAttributesMessage {
 
 export namespace DescribeDBClusterSnapshotAttributesMessage {
   export function isa(o: any): o is DescribeDBClusterSnapshotAttributesMessage {
-    return _smithy.isa(o, "DescribeDBClusterSnapshotAttributesMessage");
+    return __isa(o, "DescribeDBClusterSnapshotAttributesMessage");
   }
 }
 
@@ -9648,7 +9647,7 @@ export interface DescribeDBClusterSnapshotAttributesResult
 
 export namespace DescribeDBClusterSnapshotAttributesResult {
   export function isa(o: any): o is DescribeDBClusterSnapshotAttributesResult {
-    return _smithy.isa(o, "DescribeDBClusterSnapshotAttributesResult");
+    return __isa(o, "DescribeDBClusterSnapshotAttributesResult");
   }
 }
 
@@ -9786,7 +9785,7 @@ export interface DescribeDBClusterSnapshotsMessage {
 
 export namespace DescribeDBClusterSnapshotsMessage {
   export function isa(o: any): o is DescribeDBClusterSnapshotsMessage {
-    return _smithy.isa(o, "DescribeDBClusterSnapshotsMessage");
+    return __isa(o, "DescribeDBClusterSnapshotsMessage");
   }
 }
 
@@ -9849,7 +9848,7 @@ export interface DescribeDBClustersMessage {
 
 export namespace DescribeDBClustersMessage {
   export function isa(o: any): o is DescribeDBClustersMessage {
-    return _smithy.isa(o, "DescribeDBClustersMessage");
+    return __isa(o, "DescribeDBClustersMessage");
   }
 }
 
@@ -9933,7 +9932,7 @@ export interface DescribeDBEngineVersionsMessage {
 
 export namespace DescribeDBEngineVersionsMessage {
   export function isa(o: any): o is DescribeDBEngineVersionsMessage {
-    return _smithy.isa(o, "DescribeDBEngineVersionsMessage");
+    return __isa(o, "DescribeDBEngineVersionsMessage");
   }
 }
 
@@ -10012,7 +10011,7 @@ export interface DescribeDBInstanceAutomatedBackupsMessage {
 
 export namespace DescribeDBInstanceAutomatedBackupsMessage {
   export function isa(o: any): o is DescribeDBInstanceAutomatedBackupsMessage {
-    return _smithy.isa(o, "DescribeDBInstanceAutomatedBackupsMessage");
+    return __isa(o, "DescribeDBInstanceAutomatedBackupsMessage");
   }
 }
 
@@ -10093,7 +10092,7 @@ export interface DescribeDBInstancesMessage {
 
 export namespace DescribeDBInstancesMessage {
   export function isa(o: any): o is DescribeDBInstancesMessage {
-    return _smithy.isa(o, "DescribeDBInstancesMessage");
+    return __isa(o, "DescribeDBInstancesMessage");
   }
 }
 
@@ -10120,7 +10119,7 @@ export interface DescribeDBLogFilesDetails {
 
 export namespace DescribeDBLogFilesDetails {
   export function isa(o: any): o is DescribeDBLogFilesDetails {
-    return _smithy.isa(o, "DescribeDBLogFilesDetails");
+    return __isa(o, "DescribeDBLogFilesDetails");
   }
 }
 
@@ -10173,7 +10172,7 @@ export interface DescribeDBLogFilesMessage {
 
 export namespace DescribeDBLogFilesMessage {
   export function isa(o: any): o is DescribeDBLogFilesMessage {
-    return _smithy.isa(o, "DescribeDBLogFilesMessage");
+    return __isa(o, "DescribeDBLogFilesMessage");
   }
 }
 
@@ -10197,7 +10196,7 @@ export interface DescribeDBLogFilesResponse extends $MetadataBearer {
 
 export namespace DescribeDBLogFilesResponse {
   export function isa(o: any): o is DescribeDBLogFilesResponse {
-    return _smithy.isa(o, "DescribeDBLogFilesResponse");
+    return __isa(o, "DescribeDBLogFilesResponse");
   }
 }
 
@@ -10248,7 +10247,7 @@ export interface DescribeDBParameterGroupsMessage {
 
 export namespace DescribeDBParameterGroupsMessage {
   export function isa(o: any): o is DescribeDBParameterGroupsMessage {
-    return _smithy.isa(o, "DescribeDBParameterGroupsMessage");
+    return __isa(o, "DescribeDBParameterGroupsMessage");
   }
 }
 
@@ -10304,7 +10303,7 @@ export interface DescribeDBParametersMessage {
 
 export namespace DescribeDBParametersMessage {
   export function isa(o: any): o is DescribeDBParametersMessage {
-    return _smithy.isa(o, "DescribeDBParametersMessage");
+    return __isa(o, "DescribeDBParametersMessage");
   }
 }
 
@@ -10341,7 +10340,7 @@ export interface DescribeDBProxiesRequest {
 
 export namespace DescribeDBProxiesRequest {
   export function isa(o: any): o is DescribeDBProxiesRequest {
-    return _smithy.isa(o, "DescribeDBProxiesRequest");
+    return __isa(o, "DescribeDBProxiesRequest");
   }
 }
 
@@ -10364,7 +10363,7 @@ export interface DescribeDBProxiesResponse extends $MetadataBearer {
 
 export namespace DescribeDBProxiesResponse {
   export function isa(o: any): o is DescribeDBProxiesResponse {
-    return _smithy.isa(o, "DescribeDBProxiesResponse");
+    return __isa(o, "DescribeDBProxiesResponse");
   }
 }
 
@@ -10409,7 +10408,7 @@ export interface DescribeDBProxyTargetGroupsRequest {
 
 export namespace DescribeDBProxyTargetGroupsRequest {
   export function isa(o: any): o is DescribeDBProxyTargetGroupsRequest {
-    return _smithy.isa(o, "DescribeDBProxyTargetGroupsRequest");
+    return __isa(o, "DescribeDBProxyTargetGroupsRequest");
   }
 }
 
@@ -10432,7 +10431,7 @@ export interface DescribeDBProxyTargetGroupsResponse extends $MetadataBearer {
 
 export namespace DescribeDBProxyTargetGroupsResponse {
   export function isa(o: any): o is DescribeDBProxyTargetGroupsResponse {
-    return _smithy.isa(o, "DescribeDBProxyTargetGroupsResponse");
+    return __isa(o, "DescribeDBProxyTargetGroupsResponse");
   }
 }
 
@@ -10477,7 +10476,7 @@ export interface DescribeDBProxyTargetsRequest {
 
 export namespace DescribeDBProxyTargetsRequest {
   export function isa(o: any): o is DescribeDBProxyTargetsRequest {
-    return _smithy.isa(o, "DescribeDBProxyTargetsRequest");
+    return __isa(o, "DescribeDBProxyTargetsRequest");
   }
 }
 
@@ -10500,7 +10499,7 @@ export interface DescribeDBProxyTargetsResponse extends $MetadataBearer {
 
 export namespace DescribeDBProxyTargetsResponse {
   export function isa(o: any): o is DescribeDBProxyTargetsResponse {
-    return _smithy.isa(o, "DescribeDBProxyTargetsResponse");
+    return __isa(o, "DescribeDBProxyTargetsResponse");
   }
 }
 
@@ -10545,7 +10544,7 @@ export interface DescribeDBSecurityGroupsMessage {
 
 export namespace DescribeDBSecurityGroupsMessage {
   export function isa(o: any): o is DescribeDBSecurityGroupsMessage {
-    return _smithy.isa(o, "DescribeDBSecurityGroupsMessage");
+    return __isa(o, "DescribeDBSecurityGroupsMessage");
   }
 }
 
@@ -10562,7 +10561,7 @@ export interface DescribeDBSnapshotAttributesMessage {
 
 export namespace DescribeDBSnapshotAttributesMessage {
   export function isa(o: any): o is DescribeDBSnapshotAttributesMessage {
-    return _smithy.isa(o, "DescribeDBSnapshotAttributesMessage");
+    return __isa(o, "DescribeDBSnapshotAttributesMessage");
   }
 }
 
@@ -10580,7 +10579,7 @@ export interface DescribeDBSnapshotAttributesResult extends $MetadataBearer {
 
 export namespace DescribeDBSnapshotAttributesResult {
   export function isa(o: any): o is DescribeDBSnapshotAttributesResult {
-    return _smithy.isa(o, "DescribeDBSnapshotAttributesResult");
+    return __isa(o, "DescribeDBSnapshotAttributesResult");
   }
 }
 
@@ -10739,7 +10738,7 @@ export interface DescribeDBSnapshotsMessage {
 
 export namespace DescribeDBSnapshotsMessage {
   export function isa(o: any): o is DescribeDBSnapshotsMessage {
-    return _smithy.isa(o, "DescribeDBSnapshotsMessage");
+    return __isa(o, "DescribeDBSnapshotsMessage");
   }
 }
 
@@ -10783,7 +10782,7 @@ export interface DescribeDBSubnetGroupsMessage {
 
 export namespace DescribeDBSubnetGroupsMessage {
   export function isa(o: any): o is DescribeDBSubnetGroupsMessage {
-    return _smithy.isa(o, "DescribeDBSubnetGroupsMessage");
+    return __isa(o, "DescribeDBSubnetGroupsMessage");
   }
 }
 
@@ -10829,7 +10828,7 @@ export namespace DescribeEngineDefaultClusterParametersMessage {
   export function isa(
     o: any
   ): o is DescribeEngineDefaultClusterParametersMessage {
-    return _smithy.isa(o, "DescribeEngineDefaultClusterParametersMessage");
+    return __isa(o, "DescribeEngineDefaultClusterParametersMessage");
   }
 }
 
@@ -10848,7 +10847,7 @@ export namespace DescribeEngineDefaultClusterParametersResult {
   export function isa(
     o: any
   ): o is DescribeEngineDefaultClusterParametersResult {
-    return _smithy.isa(o, "DescribeEngineDefaultClusterParametersResult");
+    return __isa(o, "DescribeEngineDefaultClusterParametersResult");
   }
 }
 
@@ -10892,7 +10891,7 @@ export interface DescribeEngineDefaultParametersMessage {
 
 export namespace DescribeEngineDefaultParametersMessage {
   export function isa(o: any): o is DescribeEngineDefaultParametersMessage {
-    return _smithy.isa(o, "DescribeEngineDefaultParametersMessage");
+    return __isa(o, "DescribeEngineDefaultParametersMessage");
   }
 }
 
@@ -10908,7 +10907,7 @@ export interface DescribeEngineDefaultParametersResult extends $MetadataBearer {
 
 export namespace DescribeEngineDefaultParametersResult {
   export function isa(o: any): o is DescribeEngineDefaultParametersResult {
-    return _smithy.isa(o, "DescribeEngineDefaultParametersResult");
+    return __isa(o, "DescribeEngineDefaultParametersResult");
   }
 }
 
@@ -10931,7 +10930,7 @@ export interface DescribeEventCategoriesMessage {
 
 export namespace DescribeEventCategoriesMessage {
   export function isa(o: any): o is DescribeEventCategoriesMessage {
-    return _smithy.isa(o, "DescribeEventCategoriesMessage");
+    return __isa(o, "DescribeEventCategoriesMessage");
   }
 }
 
@@ -10976,7 +10975,7 @@ export interface DescribeEventSubscriptionsMessage {
 
 export namespace DescribeEventSubscriptionsMessage {
   export function isa(o: any): o is DescribeEventSubscriptionsMessage {
-    return _smithy.isa(o, "DescribeEventSubscriptionsMessage");
+    return __isa(o, "DescribeEventSubscriptionsMessage");
   }
 }
 
@@ -11078,7 +11077,7 @@ export interface DescribeEventsMessage {
 
 export namespace DescribeEventsMessage {
   export function isa(o: any): o is DescribeEventsMessage {
-    return _smithy.isa(o, "DescribeEventsMessage");
+    return __isa(o, "DescribeEventsMessage");
   }
 }
 
@@ -11134,7 +11133,7 @@ export interface DescribeGlobalClustersMessage {
 
 export namespace DescribeGlobalClustersMessage {
   export function isa(o: any): o is DescribeGlobalClustersMessage {
-    return _smithy.isa(o, "DescribeGlobalClustersMessage");
+    return __isa(o, "DescribeGlobalClustersMessage");
   }
 }
 
@@ -11183,7 +11182,7 @@ export interface DescribeInstallationMediaMessage {
 
 export namespace DescribeInstallationMediaMessage {
   export function isa(o: any): o is DescribeInstallationMediaMessage {
-    return _smithy.isa(o, "DescribeInstallationMediaMessage");
+    return __isa(o, "DescribeInstallationMediaMessage");
   }
 }
 
@@ -11230,7 +11229,7 @@ export interface DescribeOptionGroupOptionsMessage {
 
 export namespace DescribeOptionGroupOptionsMessage {
   export function isa(o: any): o is DescribeOptionGroupOptionsMessage {
-    return _smithy.isa(o, "DescribeOptionGroupOptionsMessage");
+    return __isa(o, "DescribeOptionGroupOptionsMessage");
   }
 }
 
@@ -11284,7 +11283,7 @@ export interface DescribeOptionGroupsMessage {
 
 export namespace DescribeOptionGroupsMessage {
   export function isa(o: any): o is DescribeOptionGroupsMessage {
-    return _smithy.isa(o, "DescribeOptionGroupsMessage");
+    return __isa(o, "DescribeOptionGroupsMessage");
   }
 }
 
@@ -11349,7 +11348,7 @@ export interface DescribeOrderableDBInstanceOptionsMessage {
 
 export namespace DescribeOrderableDBInstanceOptionsMessage {
   export function isa(o: any): o is DescribeOrderableDBInstanceOptionsMessage {
-    return _smithy.isa(o, "DescribeOrderableDBInstanceOptionsMessage");
+    return __isa(o, "DescribeOrderableDBInstanceOptionsMessage");
   }
 }
 
@@ -11409,7 +11408,7 @@ export interface DescribePendingMaintenanceActionsMessage {
 
 export namespace DescribePendingMaintenanceActionsMessage {
   export function isa(o: any): o is DescribePendingMaintenanceActionsMessage {
-    return _smithy.isa(o, "DescribePendingMaintenanceActionsMessage");
+    return __isa(o, "DescribePendingMaintenanceActionsMessage");
   }
 }
 
@@ -11494,7 +11493,7 @@ export interface DescribeReservedDBInstancesMessage {
 
 export namespace DescribeReservedDBInstancesMessage {
   export function isa(o: any): o is DescribeReservedDBInstancesMessage {
-    return _smithy.isa(o, "DescribeReservedDBInstancesMessage");
+    return __isa(o, "DescribeReservedDBInstancesMessage");
   }
 }
 
@@ -11573,7 +11572,7 @@ export namespace DescribeReservedDBInstancesOfferingsMessage {
   export function isa(
     o: any
   ): o is DescribeReservedDBInstancesOfferingsMessage {
-    return _smithy.isa(o, "DescribeReservedDBInstancesOfferingsMessage");
+    return __isa(o, "DescribeReservedDBInstancesOfferingsMessage");
   }
 }
 
@@ -11617,7 +11616,7 @@ export interface DescribeSourceRegionsMessage {
 
 export namespace DescribeSourceRegionsMessage {
   export function isa(o: any): o is DescribeSourceRegionsMessage {
-    return _smithy.isa(o, "DescribeSourceRegionsMessage");
+    return __isa(o, "DescribeSourceRegionsMessage");
   }
 }
 
@@ -11637,7 +11636,7 @@ export namespace DescribeValidDBInstanceModificationsMessage {
   export function isa(
     o: any
   ): o is DescribeValidDBInstanceModificationsMessage {
-    return _smithy.isa(o, "DescribeValidDBInstanceModificationsMessage");
+    return __isa(o, "DescribeValidDBInstanceModificationsMessage");
   }
 }
 
@@ -11657,7 +11656,7 @@ export interface DescribeValidDBInstanceModificationsResult
 
 export namespace DescribeValidDBInstanceModificationsResult {
   export function isa(o: any): o is DescribeValidDBInstanceModificationsResult {
-    return _smithy.isa(o, "DescribeValidDBInstanceModificationsResult");
+    return __isa(o, "DescribeValidDBInstanceModificationsResult");
   }
 }
 
@@ -11689,7 +11688,7 @@ export interface DomainMembership {
 
 export namespace DomainMembership {
   export function isa(o: any): o is DomainMembership {
-    return _smithy.isa(o, "DomainMembership");
+    return __isa(o, "DomainMembership");
   }
 }
 
@@ -11711,7 +11710,7 @@ export interface DoubleRange {
 
 export namespace DoubleRange {
   export function isa(o: any): o is DoubleRange {
-    return _smithy.isa(o, "DoubleRange");
+    return __isa(o, "DoubleRange");
   }
 }
 
@@ -11738,7 +11737,7 @@ export interface DownloadDBLogFilePortionDetails extends $MetadataBearer {
 
 export namespace DownloadDBLogFilePortionDetails {
   export function isa(o: any): o is DownloadDBLogFilePortionDetails {
-    return _smithy.isa(o, "DownloadDBLogFilePortionDetails");
+    return __isa(o, "DownloadDBLogFilePortionDetails");
   }
 }
 
@@ -11800,7 +11799,7 @@ export interface DownloadDBLogFilePortionMessage {
 
 export namespace DownloadDBLogFilePortionMessage {
   export function isa(o: any): o is DownloadDBLogFilePortionMessage {
-    return _smithy.isa(o, "DownloadDBLogFilePortionMessage");
+    return __isa(o, "DownloadDBLogFilePortionMessage");
   }
 }
 
@@ -11852,7 +11851,7 @@ export interface EC2SecurityGroup {
 
 export namespace EC2SecurityGroup {
   export function isa(o: any): o is EC2SecurityGroup {
-    return _smithy.isa(o, "EC2SecurityGroup");
+    return __isa(o, "EC2SecurityGroup");
   }
 }
 
@@ -11899,7 +11898,7 @@ export interface Endpoint {
 
 export namespace Endpoint {
   export function isa(o: any): o is Endpoint {
-    return _smithy.isa(o, "Endpoint");
+    return __isa(o, "Endpoint");
   }
 }
 
@@ -11934,7 +11933,7 @@ export interface EngineDefaults {
 
 export namespace EngineDefaults {
   export function isa(o: any): o is EngineDefaults {
-    return _smithy.isa(o, "EngineDefaults");
+    return __isa(o, "EngineDefaults");
   }
 }
 
@@ -11982,7 +11981,7 @@ export interface Event {
 
 export namespace Event {
   export function isa(o: any): o is Event {
-    return _smithy.isa(o, "Event");
+    return __isa(o, "Event");
   }
 }
 
@@ -12004,7 +12003,7 @@ export interface EventCategoriesMap {
 
 export namespace EventCategoriesMap {
   export function isa(o: any): o is EventCategoriesMap {
-    return _smithy.isa(o, "EventCategoriesMap");
+    return __isa(o, "EventCategoriesMap");
   }
 }
 
@@ -12021,7 +12020,7 @@ export interface EventCategoriesMessage extends $MetadataBearer {
 
 export namespace EventCategoriesMessage {
   export function isa(o: any): o is EventCategoriesMessage {
-    return _smithy.isa(o, "EventCategoriesMessage");
+    return __isa(o, "EventCategoriesMessage");
   }
 }
 
@@ -12086,7 +12085,7 @@ export interface EventSubscription {
 
 export namespace EventSubscription {
   export function isa(o: any): o is EventSubscription {
-    return _smithy.isa(o, "EventSubscription");
+    return __isa(o, "EventSubscription");
   }
 }
 
@@ -12114,7 +12113,7 @@ export interface EventSubscriptionsMessage extends $MetadataBearer {
 
 export namespace EventSubscriptionsMessage {
   export function isa(o: any): o is EventSubscriptionsMessage {
-    return _smithy.isa(o, "EventSubscriptionsMessage");
+    return __isa(o, "EventSubscriptionsMessage");
   }
 }
 
@@ -12146,7 +12145,7 @@ export interface EventsMessage extends $MetadataBearer {
 
 export namespace EventsMessage {
   export function isa(o: any): o is EventsMessage {
-    return _smithy.isa(o, "EventsMessage");
+    return __isa(o, "EventsMessage");
   }
 }
 
@@ -12176,7 +12175,7 @@ export interface FailoverDBClusterMessage {
 
 export namespace FailoverDBClusterMessage {
   export function isa(o: any): o is FailoverDBClusterMessage {
-    return _smithy.isa(o, "FailoverDBClusterMessage");
+    return __isa(o, "FailoverDBClusterMessage");
   }
 }
 
@@ -12194,7 +12193,7 @@ export interface FailoverDBClusterResult extends $MetadataBearer {
 
 export namespace FailoverDBClusterResult {
   export function isa(o: any): o is FailoverDBClusterResult {
-    return _smithy.isa(o, "FailoverDBClusterResult");
+    return __isa(o, "FailoverDBClusterResult");
   }
 }
 
@@ -12250,7 +12249,7 @@ export interface Filter {
 
 export namespace Filter {
   export function isa(o: any): o is Filter {
-    return _smithy.isa(o, "Filter");
+    return __isa(o, "Filter");
   }
 }
 
@@ -12329,7 +12328,7 @@ export interface GlobalCluster {
 
 export namespace GlobalCluster {
   export function isa(o: any): o is GlobalCluster {
-    return _smithy.isa(o, "GlobalCluster");
+    return __isa(o, "GlobalCluster");
   }
 }
 
@@ -12368,7 +12367,7 @@ export interface GlobalClusterMember {
 
 export namespace GlobalClusterMember {
   export function isa(o: any): o is GlobalClusterMember {
-    return _smithy.isa(o, "GlobalClusterMember");
+    return __isa(o, "GlobalClusterMember");
   }
 }
 
@@ -12393,7 +12392,7 @@ export interface GlobalClustersMessage extends $MetadataBearer {
 
 export namespace GlobalClustersMessage {
   export function isa(o: any): o is GlobalClustersMessage {
-    return _smithy.isa(o, "GlobalClustersMessage");
+    return __isa(o, "GlobalClustersMessage");
   }
 }
 
@@ -12422,7 +12421,7 @@ export interface IPRange {
 
 export namespace IPRange {
   export function isa(o: any): o is IPRange {
-    return _smithy.isa(o, "IPRange");
+    return __isa(o, "IPRange");
   }
 }
 
@@ -12502,7 +12501,7 @@ export interface ImportInstallationMediaMessage {
 
 export namespace ImportInstallationMediaMessage {
   export function isa(o: any): o is ImportInstallationMediaMessage {
-    return _smithy.isa(o, "ImportInstallationMediaMessage");
+    return __isa(o, "ImportInstallationMediaMessage");
   }
 }
 
@@ -12555,7 +12554,7 @@ export interface InstallationMedia extends $MetadataBearer {
 
 export namespace InstallationMedia {
   export function isa(o: any): o is InstallationMedia {
-    return _smithy.isa(o, "InstallationMedia");
+    return __isa(o, "InstallationMedia");
   }
 }
 
@@ -12574,7 +12573,7 @@ export interface InstallationMediaFailureCause {
 
 export namespace InstallationMediaFailureCause {
   export function isa(o: any): o is InstallationMediaFailureCause {
-    return _smithy.isa(o, "InstallationMediaFailureCause");
+    return __isa(o, "InstallationMediaFailureCause");
   }
 }
 
@@ -12597,7 +12596,7 @@ export interface InstallationMediaMessage extends $MetadataBearer {
 
 export namespace InstallationMediaMessage {
   export function isa(o: any): o is InstallationMediaMessage {
-    return _smithy.isa(o, "InstallationMediaMessage");
+    return __isa(o, "InstallationMediaMessage");
   }
 }
 
@@ -12622,7 +12621,7 @@ export interface ListTagsForResourceMessage {
 
 export namespace ListTagsForResourceMessage {
   export function isa(o: any): o is ListTagsForResourceMessage {
-    return _smithy.isa(o, "ListTagsForResourceMessage");
+    return __isa(o, "ListTagsForResourceMessage");
   }
 }
 
@@ -12644,7 +12643,7 @@ export interface MinimumEngineVersionPerAllowedValue {
 
 export namespace MinimumEngineVersionPerAllowedValue {
   export function isa(o: any): o is MinimumEngineVersionPerAllowedValue {
-    return _smithy.isa(o, "MinimumEngineVersionPerAllowedValue");
+    return __isa(o, "MinimumEngineVersionPerAllowedValue");
   }
 }
 
@@ -12667,7 +12666,7 @@ export interface ModifyCertificatesMessage {
 
 export namespace ModifyCertificatesMessage {
   export function isa(o: any): o is ModifyCertificatesMessage {
-    return _smithy.isa(o, "ModifyCertificatesMessage");
+    return __isa(o, "ModifyCertificatesMessage");
   }
 }
 
@@ -12681,7 +12680,7 @@ export interface ModifyCertificatesResult extends $MetadataBearer {
 
 export namespace ModifyCertificatesResult {
   export function isa(o: any): o is ModifyCertificatesResult {
-    return _smithy.isa(o, "ModifyCertificatesResult");
+    return __isa(o, "ModifyCertificatesResult");
   }
 }
 
@@ -12737,7 +12736,7 @@ export interface ModifyCurrentDBClusterCapacityMessage {
 
 export namespace ModifyCurrentDBClusterCapacityMessage {
   export function isa(o: any): o is ModifyCurrentDBClusterCapacityMessage {
-    return _smithy.isa(o, "ModifyCurrentDBClusterCapacityMessage");
+    return __isa(o, "ModifyCurrentDBClusterCapacityMessage");
   }
 }
 
@@ -12768,7 +12767,7 @@ export interface ModifyDBClusterEndpointMessage {
 
 export namespace ModifyDBClusterEndpointMessage {
   export function isa(o: any): o is ModifyDBClusterEndpointMessage {
-    return _smithy.isa(o, "ModifyDBClusterEndpointMessage");
+    return __isa(o, "ModifyDBClusterEndpointMessage");
   }
 }
 
@@ -13021,7 +13020,7 @@ export interface ModifyDBClusterMessage {
 
 export namespace ModifyDBClusterMessage {
   export function isa(o: any): o is ModifyDBClusterMessage {
-    return _smithy.isa(o, "ModifyDBClusterMessage");
+    return __isa(o, "ModifyDBClusterMessage");
   }
 }
 
@@ -13043,7 +13042,7 @@ export interface ModifyDBClusterParameterGroupMessage {
 
 export namespace ModifyDBClusterParameterGroupMessage {
   export function isa(o: any): o is ModifyDBClusterParameterGroupMessage {
-    return _smithy.isa(o, "ModifyDBClusterParameterGroupMessage");
+    return __isa(o, "ModifyDBClusterParameterGroupMessage");
   }
 }
 
@@ -13061,7 +13060,7 @@ export interface ModifyDBClusterResult extends $MetadataBearer {
 
 export namespace ModifyDBClusterResult {
   export function isa(o: any): o is ModifyDBClusterResult {
-    return _smithy.isa(o, "ModifyDBClusterResult");
+    return __isa(o, "ModifyDBClusterResult");
   }
 }
 
@@ -13106,7 +13105,7 @@ export interface ModifyDBClusterSnapshotAttributeMessage {
 
 export namespace ModifyDBClusterSnapshotAttributeMessage {
   export function isa(o: any): o is ModifyDBClusterSnapshotAttributeMessage {
-    return _smithy.isa(o, "ModifyDBClusterSnapshotAttributeMessage");
+    return __isa(o, "ModifyDBClusterSnapshotAttributeMessage");
   }
 }
 
@@ -13125,7 +13124,7 @@ export interface ModifyDBClusterSnapshotAttributeResult
 
 export namespace ModifyDBClusterSnapshotAttributeResult {
   export function isa(o: any): o is ModifyDBClusterSnapshotAttributeResult {
-    return _smithy.isa(o, "ModifyDBClusterSnapshotAttributeResult");
+    return __isa(o, "ModifyDBClusterSnapshotAttributeResult");
   }
 }
 
@@ -13772,7 +13771,7 @@ export interface ModifyDBInstanceMessage {
 
 export namespace ModifyDBInstanceMessage {
   export function isa(o: any): o is ModifyDBInstanceMessage {
-    return _smithy.isa(o, "ModifyDBInstanceMessage");
+    return __isa(o, "ModifyDBInstanceMessage");
   }
 }
 
@@ -13789,7 +13788,7 @@ export interface ModifyDBInstanceResult extends $MetadataBearer {
 
 export namespace ModifyDBInstanceResult {
   export function isa(o: any): o is ModifyDBInstanceResult {
-    return _smithy.isa(o, "ModifyDBInstanceResult");
+    return __isa(o, "ModifyDBInstanceResult");
   }
 }
 
@@ -13822,7 +13821,7 @@ export interface ModifyDBParameterGroupMessage {
 
 export namespace ModifyDBParameterGroupMessage {
   export function isa(o: any): o is ModifyDBParameterGroupMessage {
-    return _smithy.isa(o, "ModifyDBParameterGroupMessage");
+    return __isa(o, "ModifyDBParameterGroupMessage");
   }
 }
 
@@ -13879,7 +13878,7 @@ export interface ModifyDBProxyRequest {
 
 export namespace ModifyDBProxyRequest {
   export function isa(o: any): o is ModifyDBProxyRequest {
-    return _smithy.isa(o, "ModifyDBProxyRequest");
+    return __isa(o, "ModifyDBProxyRequest");
   }
 }
 
@@ -13893,7 +13892,7 @@ export interface ModifyDBProxyResponse extends $MetadataBearer {
 
 export namespace ModifyDBProxyResponse {
   export function isa(o: any): o is ModifyDBProxyResponse {
-    return _smithy.isa(o, "ModifyDBProxyResponse");
+    return __isa(o, "ModifyDBProxyResponse");
   }
 }
 
@@ -13922,7 +13921,7 @@ export interface ModifyDBProxyTargetGroupRequest {
 
 export namespace ModifyDBProxyTargetGroupRequest {
   export function isa(o: any): o is ModifyDBProxyTargetGroupRequest {
-    return _smithy.isa(o, "ModifyDBProxyTargetGroupRequest");
+    return __isa(o, "ModifyDBProxyTargetGroupRequest");
   }
 }
 
@@ -13936,7 +13935,7 @@ export interface ModifyDBProxyTargetGroupResponse extends $MetadataBearer {
 
 export namespace ModifyDBProxyTargetGroupResponse {
   export function isa(o: any): o is ModifyDBProxyTargetGroupResponse {
-    return _smithy.isa(o, "ModifyDBProxyTargetGroupResponse");
+    return __isa(o, "ModifyDBProxyTargetGroupResponse");
   }
 }
 
@@ -13981,7 +13980,7 @@ export interface ModifyDBSnapshotAttributeMessage {
 
 export namespace ModifyDBSnapshotAttributeMessage {
   export function isa(o: any): o is ModifyDBSnapshotAttributeMessage {
-    return _smithy.isa(o, "ModifyDBSnapshotAttributeMessage");
+    return __isa(o, "ModifyDBSnapshotAttributeMessage");
   }
 }
 
@@ -13999,7 +13998,7 @@ export interface ModifyDBSnapshotAttributeResult extends $MetadataBearer {
 
 export namespace ModifyDBSnapshotAttributeResult {
   export function isa(o: any): o is ModifyDBSnapshotAttributeResult {
-    return _smithy.isa(o, "ModifyDBSnapshotAttributeResult");
+    return __isa(o, "ModifyDBSnapshotAttributeResult");
   }
 }
 
@@ -14073,7 +14072,7 @@ export interface ModifyDBSnapshotMessage {
 
 export namespace ModifyDBSnapshotMessage {
   export function isa(o: any): o is ModifyDBSnapshotMessage {
-    return _smithy.isa(o, "ModifyDBSnapshotMessage");
+    return __isa(o, "ModifyDBSnapshotMessage");
   }
 }
 
@@ -14091,7 +14090,7 @@ export interface ModifyDBSnapshotResult extends $MetadataBearer {
 
 export namespace ModifyDBSnapshotResult {
   export function isa(o: any): o is ModifyDBSnapshotResult {
-    return _smithy.isa(o, "ModifyDBSnapshotResult");
+    return __isa(o, "ModifyDBSnapshotResult");
   }
 }
 
@@ -14123,7 +14122,7 @@ export interface ModifyDBSubnetGroupMessage {
 
 export namespace ModifyDBSubnetGroupMessage {
   export function isa(o: any): o is ModifyDBSubnetGroupMessage {
-    return _smithy.isa(o, "ModifyDBSubnetGroupMessage");
+    return __isa(o, "ModifyDBSubnetGroupMessage");
   }
 }
 
@@ -14141,7 +14140,7 @@ export interface ModifyDBSubnetGroupResult extends $MetadataBearer {
 
 export namespace ModifyDBSubnetGroupResult {
   export function isa(o: any): o is ModifyDBSubnetGroupResult {
-    return _smithy.isa(o, "ModifyDBSubnetGroupResult");
+    return __isa(o, "ModifyDBSubnetGroupResult");
   }
 }
 
@@ -14185,7 +14184,7 @@ export interface ModifyEventSubscriptionMessage {
 
 export namespace ModifyEventSubscriptionMessage {
   export function isa(o: any): o is ModifyEventSubscriptionMessage {
-    return _smithy.isa(o, "ModifyEventSubscriptionMessage");
+    return __isa(o, "ModifyEventSubscriptionMessage");
   }
 }
 
@@ -14199,7 +14198,7 @@ export interface ModifyEventSubscriptionResult extends $MetadataBearer {
 
 export namespace ModifyEventSubscriptionResult {
   export function isa(o: any): o is ModifyEventSubscriptionResult {
-    return _smithy.isa(o, "ModifyEventSubscriptionResult");
+    return __isa(o, "ModifyEventSubscriptionResult");
   }
 }
 
@@ -14251,7 +14250,7 @@ export interface ModifyGlobalClusterMessage {
 
 export namespace ModifyGlobalClusterMessage {
   export function isa(o: any): o is ModifyGlobalClusterMessage {
-    return _smithy.isa(o, "ModifyGlobalClusterMessage");
+    return __isa(o, "ModifyGlobalClusterMessage");
   }
 }
 
@@ -14265,7 +14264,7 @@ export interface ModifyGlobalClusterResult extends $MetadataBearer {
 
 export namespace ModifyGlobalClusterResult {
   export function isa(o: any): o is ModifyGlobalClusterResult {
-    return _smithy.isa(o, "ModifyGlobalClusterResult");
+    return __isa(o, "ModifyGlobalClusterResult");
   }
 }
 
@@ -14298,7 +14297,7 @@ export interface ModifyOptionGroupMessage {
 
 export namespace ModifyOptionGroupMessage {
   export function isa(o: any): o is ModifyOptionGroupMessage {
-    return _smithy.isa(o, "ModifyOptionGroupMessage");
+    return __isa(o, "ModifyOptionGroupMessage");
   }
 }
 
@@ -14312,7 +14311,7 @@ export interface ModifyOptionGroupResult extends $MetadataBearer {
 
 export namespace ModifyOptionGroupResult {
   export function isa(o: any): o is ModifyOptionGroupResult {
-    return _smithy.isa(o, "ModifyOptionGroupResult");
+    return __isa(o, "ModifyOptionGroupResult");
   }
 }
 
@@ -14369,7 +14368,7 @@ export interface Option {
 
 export namespace Option {
   export function isa(o: any): o is Option {
-    return _smithy.isa(o, "Option");
+    return __isa(o, "Option");
   }
 }
 
@@ -14411,7 +14410,7 @@ export interface OptionConfiguration {
 
 export namespace OptionConfiguration {
   export function isa(o: any): o is OptionConfiguration {
-    return _smithy.isa(o, "OptionConfiguration");
+    return __isa(o, "OptionConfiguration");
   }
 }
 
@@ -14471,7 +14470,7 @@ export interface OptionGroup {
 
 export namespace OptionGroup {
   export function isa(o: any): o is OptionGroup {
-    return _smithy.isa(o, "OptionGroup");
+    return __isa(o, "OptionGroup");
   }
 }
 
@@ -14502,7 +14501,7 @@ export interface OptionGroupMembership {
 
 export namespace OptionGroupMembership {
   export function isa(o: any): o is OptionGroupMembership {
-    return _smithy.isa(o, "OptionGroupMembership");
+    return __isa(o, "OptionGroupMembership");
   }
 }
 
@@ -14601,7 +14600,7 @@ export interface OptionGroupOption {
 
 export namespace OptionGroupOption {
   export function isa(o: any): o is OptionGroupOption {
-    return _smithy.isa(o, "OptionGroupOption");
+    return __isa(o, "OptionGroupOption");
   }
 }
 
@@ -14655,7 +14654,7 @@ export interface OptionGroupOptionSetting {
 
 export namespace OptionGroupOptionSetting {
   export function isa(o: any): o is OptionGroupOptionSetting {
-    return _smithy.isa(o, "OptionGroupOptionSetting");
+    return __isa(o, "OptionGroupOptionSetting");
   }
 }
 
@@ -14680,7 +14679,7 @@ export interface OptionGroupOptionsMessage extends $MetadataBearer {
 
 export namespace OptionGroupOptionsMessage {
   export function isa(o: any): o is OptionGroupOptionsMessage {
-    return _smithy.isa(o, "OptionGroupOptionsMessage");
+    return __isa(o, "OptionGroupOptionsMessage");
   }
 }
 
@@ -14706,7 +14705,7 @@ export interface OptionGroups extends $MetadataBearer {
 
 export namespace OptionGroups {
   export function isa(o: any): o is OptionGroups {
-    return _smithy.isa(o, "OptionGroups");
+    return __isa(o, "OptionGroups");
   }
 }
 
@@ -14763,7 +14762,7 @@ export interface OptionSetting {
 
 export namespace OptionSetting {
   export function isa(o: any): o is OptionSetting {
-    return _smithy.isa(o, "OptionSetting");
+    return __isa(o, "OptionSetting");
   }
 }
 
@@ -14786,7 +14785,7 @@ export interface OptionVersion {
 
 export namespace OptionVersion {
   export function isa(o: any): o is OptionVersion {
-    return _smithy.isa(o, "OptionVersion");
+    return __isa(o, "OptionVersion");
   }
 }
 
@@ -14921,7 +14920,7 @@ export interface OrderableDBInstanceOption {
 
 export namespace OrderableDBInstanceOption {
   export function isa(o: any): o is OrderableDBInstanceOption {
-    return _smithy.isa(o, "OrderableDBInstanceOption");
+    return __isa(o, "OrderableDBInstanceOption");
   }
 }
 
@@ -14952,7 +14951,7 @@ export interface OrderableDBInstanceOptionsMessage extends $MetadataBearer {
 
 export namespace OrderableDBInstanceOptionsMessage {
   export function isa(o: any): o is OrderableDBInstanceOptionsMessage {
-    return _smithy.isa(o, "OrderableDBInstanceOptionsMessage");
+    return __isa(o, "OrderableDBInstanceOptionsMessage");
   }
 }
 
@@ -15028,7 +15027,7 @@ export interface Parameter {
 
 export namespace Parameter {
   export function isa(o: any): o is Parameter {
-    return _smithy.isa(o, "Parameter");
+    return __isa(o, "Parameter");
   }
 }
 
@@ -15050,7 +15049,7 @@ export interface PendingCloudwatchLogsExports {
 
 export namespace PendingCloudwatchLogsExports {
   export function isa(o: any): o is PendingCloudwatchLogsExports {
-    return _smithy.isa(o, "PendingCloudwatchLogsExports");
+    return __isa(o, "PendingCloudwatchLogsExports");
   }
 }
 
@@ -15103,7 +15102,7 @@ export interface PendingMaintenanceAction {
 
 export namespace PendingMaintenanceAction {
   export function isa(o: any): o is PendingMaintenanceAction {
-    return _smithy.isa(o, "PendingMaintenanceAction");
+    return __isa(o, "PendingMaintenanceAction");
   }
 }
 
@@ -15131,7 +15130,7 @@ export interface PendingMaintenanceActionsMessage extends $MetadataBearer {
 
 export namespace PendingMaintenanceActionsMessage {
   export function isa(o: any): o is PendingMaintenanceActionsMessage {
-    return _smithy.isa(o, "PendingMaintenanceActionsMessage");
+    return __isa(o, "PendingMaintenanceActionsMessage");
   }
 }
 
@@ -15234,7 +15233,7 @@ export interface PendingModifiedValues {
 
 export namespace PendingModifiedValues {
   export function isa(o: any): o is PendingModifiedValues {
-    return _smithy.isa(o, "PendingModifiedValues");
+    return __isa(o, "PendingModifiedValues");
   }
 }
 
@@ -15313,7 +15312,7 @@ export interface ProcessorFeature {
 
 export namespace ProcessorFeature {
   export function isa(o: any): o is ProcessorFeature {
-    return _smithy.isa(o, "ProcessorFeature");
+    return __isa(o, "ProcessorFeature");
   }
 }
 
@@ -15340,7 +15339,7 @@ export interface PromoteReadReplicaDBClusterMessage {
 
 export namespace PromoteReadReplicaDBClusterMessage {
   export function isa(o: any): o is PromoteReadReplicaDBClusterMessage {
-    return _smithy.isa(o, "PromoteReadReplicaDBClusterMessage");
+    return __isa(o, "PromoteReadReplicaDBClusterMessage");
   }
 }
 
@@ -15358,7 +15357,7 @@ export interface PromoteReadReplicaDBClusterResult extends $MetadataBearer {
 
 export namespace PromoteReadReplicaDBClusterResult {
   export function isa(o: any): o is PromoteReadReplicaDBClusterResult {
-    return _smithy.isa(o, "PromoteReadReplicaDBClusterResult");
+    return __isa(o, "PromoteReadReplicaDBClusterResult");
   }
 }
 
@@ -15429,7 +15428,7 @@ export interface PromoteReadReplicaMessage {
 
 export namespace PromoteReadReplicaMessage {
   export function isa(o: any): o is PromoteReadReplicaMessage {
-    return _smithy.isa(o, "PromoteReadReplicaMessage");
+    return __isa(o, "PromoteReadReplicaMessage");
   }
 }
 
@@ -15446,7 +15445,7 @@ export interface PromoteReadReplicaResult extends $MetadataBearer {
 
 export namespace PromoteReadReplicaResult {
   export function isa(o: any): o is PromoteReadReplicaResult {
-    return _smithy.isa(o, "PromoteReadReplicaResult");
+    return __isa(o, "PromoteReadReplicaResult");
   }
 }
 
@@ -15484,7 +15483,7 @@ export interface PurchaseReservedDBInstancesOfferingMessage {
 
 export namespace PurchaseReservedDBInstancesOfferingMessage {
   export function isa(o: any): o is PurchaseReservedDBInstancesOfferingMessage {
-    return _smithy.isa(o, "PurchaseReservedDBInstancesOfferingMessage");
+    return __isa(o, "PurchaseReservedDBInstancesOfferingMessage");
   }
 }
 
@@ -15503,7 +15502,7 @@ export interface PurchaseReservedDBInstancesOfferingResult
 
 export namespace PurchaseReservedDBInstancesOfferingResult {
   export function isa(o: any): o is PurchaseReservedDBInstancesOfferingResult {
-    return _smithy.isa(o, "PurchaseReservedDBInstancesOfferingResult");
+    return __isa(o, "PurchaseReservedDBInstancesOfferingResult");
   }
 }
 
@@ -15537,7 +15536,7 @@ export interface Range {
 
 export namespace Range {
   export function isa(o: any): o is Range {
-    return _smithy.isa(o, "Range");
+    return __isa(o, "Range");
   }
 }
 
@@ -15568,7 +15567,7 @@ export interface RebootDBInstanceMessage {
 
 export namespace RebootDBInstanceMessage {
   export function isa(o: any): o is RebootDBInstanceMessage {
-    return _smithy.isa(o, "RebootDBInstanceMessage");
+    return __isa(o, "RebootDBInstanceMessage");
   }
 }
 
@@ -15585,7 +15584,7 @@ export interface RebootDBInstanceResult extends $MetadataBearer {
 
 export namespace RebootDBInstanceResult {
   export function isa(o: any): o is RebootDBInstanceResult {
-    return _smithy.isa(o, "RebootDBInstanceResult");
+    return __isa(o, "RebootDBInstanceResult");
   }
 }
 
@@ -15610,7 +15609,7 @@ export interface RecurringCharge {
 
 export namespace RecurringCharge {
   export function isa(o: any): o is RecurringCharge {
-    return _smithy.isa(o, "RecurringCharge");
+    return __isa(o, "RecurringCharge");
   }
 }
 
@@ -15639,7 +15638,7 @@ export interface RegisterDBProxyTargetsRequest {
 
 export namespace RegisterDBProxyTargetsRequest {
   export function isa(o: any): o is RegisterDBProxyTargetsRequest {
-    return _smithy.isa(o, "RegisterDBProxyTargetsRequest");
+    return __isa(o, "RegisterDBProxyTargetsRequest");
   }
 }
 
@@ -15653,7 +15652,7 @@ export interface RegisterDBProxyTargetsResponse extends $MetadataBearer {
 
 export namespace RegisterDBProxyTargetsResponse {
   export function isa(o: any): o is RegisterDBProxyTargetsResponse {
-    return _smithy.isa(o, "RegisterDBProxyTargetsResponse");
+    return __isa(o, "RegisterDBProxyTargetsResponse");
   }
 }
 
@@ -15676,7 +15675,7 @@ export interface RemoveFromGlobalClusterMessage {
 
 export namespace RemoveFromGlobalClusterMessage {
   export function isa(o: any): o is RemoveFromGlobalClusterMessage {
-    return _smithy.isa(o, "RemoveFromGlobalClusterMessage");
+    return __isa(o, "RemoveFromGlobalClusterMessage");
   }
 }
 
@@ -15690,7 +15689,7 @@ export interface RemoveFromGlobalClusterResult extends $MetadataBearer {
 
 export namespace RemoveFromGlobalClusterResult {
   export function isa(o: any): o is RemoveFromGlobalClusterResult {
-    return _smithy.isa(o, "RemoveFromGlobalClusterResult");
+    return __isa(o, "RemoveFromGlobalClusterResult");
   }
 }
 
@@ -15716,7 +15715,7 @@ export interface RemoveRoleFromDBClusterMessage {
 
 export namespace RemoveRoleFromDBClusterMessage {
   export function isa(o: any): o is RemoveRoleFromDBClusterMessage {
-    return _smithy.isa(o, "RemoveRoleFromDBClusterMessage");
+    return __isa(o, "RemoveRoleFromDBClusterMessage");
   }
 }
 
@@ -15743,7 +15742,7 @@ export interface RemoveRoleFromDBInstanceMessage {
 
 export namespace RemoveRoleFromDBInstanceMessage {
   export function isa(o: any): o is RemoveRoleFromDBInstanceMessage {
-    return _smithy.isa(o, "RemoveRoleFromDBInstanceMessage");
+    return __isa(o, "RemoveRoleFromDBInstanceMessage");
   }
 }
 
@@ -15770,7 +15769,7 @@ export namespace RemoveSourceIdentifierFromSubscriptionMessage {
   export function isa(
     o: any
   ): o is RemoveSourceIdentifierFromSubscriptionMessage {
-    return _smithy.isa(o, "RemoveSourceIdentifierFromSubscriptionMessage");
+    return __isa(o, "RemoveSourceIdentifierFromSubscriptionMessage");
   }
 }
 
@@ -15787,7 +15786,7 @@ export namespace RemoveSourceIdentifierFromSubscriptionResult {
   export function isa(
     o: any
   ): o is RemoveSourceIdentifierFromSubscriptionResult {
-    return _smithy.isa(o, "RemoveSourceIdentifierFromSubscriptionResult");
+    return __isa(o, "RemoveSourceIdentifierFromSubscriptionResult");
   }
 }
 
@@ -15813,7 +15812,7 @@ export interface RemoveTagsFromResourceMessage {
 
 export namespace RemoveTagsFromResourceMessage {
   export function isa(o: any): o is RemoveTagsFromResourceMessage {
-    return _smithy.isa(o, "RemoveTagsFromResourceMessage");
+    return __isa(o, "RemoveTagsFromResourceMessage");
   }
 }
 
@@ -15912,7 +15911,7 @@ export interface ReservedDBInstance {
 
 export namespace ReservedDBInstance {
   export function isa(o: any): o is ReservedDBInstance {
-    return _smithy.isa(o, "ReservedDBInstance");
+    return __isa(o, "ReservedDBInstance");
   }
 }
 
@@ -15941,7 +15940,7 @@ export interface ReservedDBInstanceMessage extends $MetadataBearer {
 
 export namespace ReservedDBInstanceMessage {
   export function isa(o: any): o is ReservedDBInstanceMessage {
-    return _smithy.isa(o, "ReservedDBInstanceMessage");
+    return __isa(o, "ReservedDBInstanceMessage");
   }
 }
 
@@ -16005,7 +16004,7 @@ export interface ReservedDBInstancesOffering {
 
 export namespace ReservedDBInstancesOffering {
   export function isa(o: any): o is ReservedDBInstancesOffering {
-    return _smithy.isa(o, "ReservedDBInstancesOffering");
+    return __isa(o, "ReservedDBInstancesOffering");
   }
 }
 
@@ -16034,7 +16033,7 @@ export interface ReservedDBInstancesOfferingMessage extends $MetadataBearer {
 
 export namespace ReservedDBInstancesOfferingMessage {
   export function isa(o: any): o is ReservedDBInstancesOfferingMessage {
-    return _smithy.isa(o, "ReservedDBInstancesOfferingMessage");
+    return __isa(o, "ReservedDBInstancesOfferingMessage");
   }
 }
 
@@ -16064,7 +16063,7 @@ export interface ResetDBClusterParameterGroupMessage {
 
 export namespace ResetDBClusterParameterGroupMessage {
   export function isa(o: any): o is ResetDBClusterParameterGroupMessage {
-    return _smithy.isa(o, "ResetDBClusterParameterGroupMessage");
+    return __isa(o, "ResetDBClusterParameterGroupMessage");
   }
 }
 
@@ -16125,7 +16124,7 @@ export interface ResetDBParameterGroupMessage {
 
 export namespace ResetDBParameterGroupMessage {
   export function isa(o: any): o is ResetDBParameterGroupMessage {
-    return _smithy.isa(o, "ResetDBParameterGroupMessage");
+    return __isa(o, "ResetDBParameterGroupMessage");
   }
 }
 
@@ -16147,7 +16146,7 @@ export interface ResourcePendingMaintenanceActions {
 
 export namespace ResourcePendingMaintenanceActions {
   export function isa(o: any): o is ResourcePendingMaintenanceActions {
-    return _smithy.isa(o, "ResourcePendingMaintenanceActions");
+    return __isa(o, "ResourcePendingMaintenanceActions");
   }
 }
 
@@ -16448,7 +16447,7 @@ export interface RestoreDBClusterFromS3Message {
 
 export namespace RestoreDBClusterFromS3Message {
   export function isa(o: any): o is RestoreDBClusterFromS3Message {
-    return _smithy.isa(o, "RestoreDBClusterFromS3Message");
+    return __isa(o, "RestoreDBClusterFromS3Message");
   }
 }
 
@@ -16466,7 +16465,7 @@ export interface RestoreDBClusterFromS3Result extends $MetadataBearer {
 
 export namespace RestoreDBClusterFromS3Result {
   export function isa(o: any): o is RestoreDBClusterFromS3Result {
-    return _smithy.isa(o, "RestoreDBClusterFromS3Result");
+    return __isa(o, "RestoreDBClusterFromS3Result");
   }
 }
 
@@ -16693,7 +16692,7 @@ export interface RestoreDBClusterFromSnapshotMessage {
 
 export namespace RestoreDBClusterFromSnapshotMessage {
   export function isa(o: any): o is RestoreDBClusterFromSnapshotMessage {
-    return _smithy.isa(o, "RestoreDBClusterFromSnapshotMessage");
+    return __isa(o, "RestoreDBClusterFromSnapshotMessage");
   }
 }
 
@@ -16711,7 +16710,7 @@ export interface RestoreDBClusterFromSnapshotResult extends $MetadataBearer {
 
 export namespace RestoreDBClusterFromSnapshotResult {
   export function isa(o: any): o is RestoreDBClusterFromSnapshotResult {
-    return _smithy.isa(o, "RestoreDBClusterFromSnapshotResult");
+    return __isa(o, "RestoreDBClusterFromSnapshotResult");
   }
 }
 
@@ -16923,7 +16922,7 @@ export interface RestoreDBClusterToPointInTimeMessage {
 
 export namespace RestoreDBClusterToPointInTimeMessage {
   export function isa(o: any): o is RestoreDBClusterToPointInTimeMessage {
-    return _smithy.isa(o, "RestoreDBClusterToPointInTimeMessage");
+    return __isa(o, "RestoreDBClusterToPointInTimeMessage");
   }
 }
 
@@ -16941,7 +16940,7 @@ export interface RestoreDBClusterToPointInTimeResult extends $MetadataBearer {
 
 export namespace RestoreDBClusterToPointInTimeResult {
   export function isa(o: any): o is RestoreDBClusterToPointInTimeResult {
-    return _smithy.isa(o, "RestoreDBClusterToPointInTimeResult");
+    return __isa(o, "RestoreDBClusterToPointInTimeResult");
   }
 }
 
@@ -17278,7 +17277,7 @@ export interface RestoreDBInstanceFromDBSnapshotMessage {
 
 export namespace RestoreDBInstanceFromDBSnapshotMessage {
   export function isa(o: any): o is RestoreDBInstanceFromDBSnapshotMessage {
-    return _smithy.isa(o, "RestoreDBInstanceFromDBSnapshotMessage");
+    return __isa(o, "RestoreDBInstanceFromDBSnapshotMessage");
   }
 }
 
@@ -17295,7 +17294,7 @@ export interface RestoreDBInstanceFromDBSnapshotResult extends $MetadataBearer {
 
 export namespace RestoreDBInstanceFromDBSnapshotResult {
   export function isa(o: any): o is RestoreDBInstanceFromDBSnapshotResult {
-    return _smithy.isa(o, "RestoreDBInstanceFromDBSnapshotResult");
+    return __isa(o, "RestoreDBInstanceFromDBSnapshotResult");
   }
 }
 
@@ -17746,7 +17745,7 @@ export interface RestoreDBInstanceFromS3Message {
 
 export namespace RestoreDBInstanceFromS3Message {
   export function isa(o: any): o is RestoreDBInstanceFromS3Message {
-    return _smithy.isa(o, "RestoreDBInstanceFromS3Message");
+    return __isa(o, "RestoreDBInstanceFromS3Message");
   }
 }
 
@@ -17763,7 +17762,7 @@ export interface RestoreDBInstanceFromS3Result extends $MetadataBearer {
 
 export namespace RestoreDBInstanceFromS3Result {
   export function isa(o: any): o is RestoreDBInstanceFromS3Result {
-    return _smithy.isa(o, "RestoreDBInstanceFromS3Result");
+    return __isa(o, "RestoreDBInstanceFromS3Result");
   }
 }
 
@@ -18120,7 +18119,7 @@ export interface RestoreDBInstanceToPointInTimeMessage {
 
 export namespace RestoreDBInstanceToPointInTimeMessage {
   export function isa(o: any): o is RestoreDBInstanceToPointInTimeMessage {
-    return _smithy.isa(o, "RestoreDBInstanceToPointInTimeMessage");
+    return __isa(o, "RestoreDBInstanceToPointInTimeMessage");
   }
 }
 
@@ -18137,7 +18136,7 @@ export interface RestoreDBInstanceToPointInTimeResult extends $MetadataBearer {
 
 export namespace RestoreDBInstanceToPointInTimeResult {
   export function isa(o: any): o is RestoreDBInstanceToPointInTimeResult {
-    return _smithy.isa(o, "RestoreDBInstanceToPointInTimeResult");
+    return __isa(o, "RestoreDBInstanceToPointInTimeResult");
   }
 }
 
@@ -18159,7 +18158,7 @@ export interface RestoreWindow {
 
 export namespace RestoreWindow {
   export function isa(o: any): o is RestoreWindow {
-    return _smithy.isa(o, "RestoreWindow");
+    return __isa(o, "RestoreWindow");
   }
 }
 
@@ -18215,7 +18214,7 @@ export interface RevokeDBSecurityGroupIngressMessage {
 
 export namespace RevokeDBSecurityGroupIngressMessage {
   export function isa(o: any): o is RevokeDBSecurityGroupIngressMessage {
-    return _smithy.isa(o, "RevokeDBSecurityGroupIngressMessage");
+    return __isa(o, "RevokeDBSecurityGroupIngressMessage");
   }
 }
 
@@ -18233,7 +18232,7 @@ export interface RevokeDBSecurityGroupIngressResult extends $MetadataBearer {
 
 export namespace RevokeDBSecurityGroupIngressResult {
   export function isa(o: any): o is RevokeDBSecurityGroupIngressResult {
-    return _smithy.isa(o, "RevokeDBSecurityGroupIngressResult");
+    return __isa(o, "RevokeDBSecurityGroupIngressResult");
   }
 }
 
@@ -18293,7 +18292,7 @@ export interface ScalingConfiguration {
 
 export namespace ScalingConfiguration {
   export function isa(o: any): o is ScalingConfiguration {
-    return _smithy.isa(o, "ScalingConfiguration");
+    return __isa(o, "ScalingConfiguration");
   }
 }
 
@@ -18338,7 +18337,7 @@ export interface ScalingConfigurationInfo {
 
 export namespace ScalingConfigurationInfo {
   export function isa(o: any): o is ScalingConfigurationInfo {
-    return _smithy.isa(o, "ScalingConfigurationInfo");
+    return __isa(o, "ScalingConfigurationInfo");
   }
 }
 
@@ -18365,7 +18364,7 @@ export interface SourceRegion {
 
 export namespace SourceRegion {
   export function isa(o: any): o is SourceRegion {
-    return _smithy.isa(o, "SourceRegion");
+    return __isa(o, "SourceRegion");
   }
 }
 
@@ -18392,7 +18391,7 @@ export interface SourceRegionMessage extends $MetadataBearer {
 
 export namespace SourceRegionMessage {
   export function isa(o: any): o is SourceRegionMessage {
-    return _smithy.isa(o, "SourceRegionMessage");
+    return __isa(o, "SourceRegionMessage");
   }
 }
 
@@ -18435,7 +18434,7 @@ export interface StartActivityStreamRequest {
 
 export namespace StartActivityStreamRequest {
   export function isa(o: any): o is StartActivityStreamRequest {
-    return _smithy.isa(o, "StartActivityStreamRequest");
+    return __isa(o, "StartActivityStreamRequest");
   }
 }
 
@@ -18470,7 +18469,7 @@ export interface StartActivityStreamResponse extends $MetadataBearer {
 
 export namespace StartActivityStreamResponse {
   export function isa(o: any): o is StartActivityStreamResponse {
-    return _smithy.isa(o, "StartActivityStreamResponse");
+    return __isa(o, "StartActivityStreamResponse");
   }
 }
 
@@ -18485,7 +18484,7 @@ export interface StartDBClusterMessage {
 
 export namespace StartDBClusterMessage {
   export function isa(o: any): o is StartDBClusterMessage {
-    return _smithy.isa(o, "StartDBClusterMessage");
+    return __isa(o, "StartDBClusterMessage");
   }
 }
 
@@ -18503,7 +18502,7 @@ export interface StartDBClusterResult extends $MetadataBearer {
 
 export namespace StartDBClusterResult {
   export function isa(o: any): o is StartDBClusterResult {
-    return _smithy.isa(o, "StartDBClusterResult");
+    return __isa(o, "StartDBClusterResult");
   }
 }
 
@@ -18519,7 +18518,7 @@ export interface StartDBInstanceMessage {
 
 export namespace StartDBInstanceMessage {
   export function isa(o: any): o is StartDBInstanceMessage {
-    return _smithy.isa(o, "StartDBInstanceMessage");
+    return __isa(o, "StartDBInstanceMessage");
   }
 }
 
@@ -18536,7 +18535,7 @@ export interface StartDBInstanceResult extends $MetadataBearer {
 
 export namespace StartDBInstanceResult {
   export function isa(o: any): o is StartDBInstanceResult {
-    return _smithy.isa(o, "StartDBInstanceResult");
+    return __isa(o, "StartDBInstanceResult");
   }
 }
 
@@ -18558,7 +18557,7 @@ export interface StopActivityStreamRequest {
 
 export namespace StopActivityStreamRequest {
   export function isa(o: any): o is StopActivityStreamRequest {
-    return _smithy.isa(o, "StopActivityStreamRequest");
+    return __isa(o, "StopActivityStreamRequest");
   }
 }
 
@@ -18582,7 +18581,7 @@ export interface StopActivityStreamResponse extends $MetadataBearer {
 
 export namespace StopActivityStreamResponse {
   export function isa(o: any): o is StopActivityStreamResponse {
-    return _smithy.isa(o, "StopActivityStreamResponse");
+    return __isa(o, "StopActivityStreamResponse");
   }
 }
 
@@ -18597,7 +18596,7 @@ export interface StopDBClusterMessage {
 
 export namespace StopDBClusterMessage {
   export function isa(o: any): o is StopDBClusterMessage {
-    return _smithy.isa(o, "StopDBClusterMessage");
+    return __isa(o, "StopDBClusterMessage");
   }
 }
 
@@ -18615,7 +18614,7 @@ export interface StopDBClusterResult extends $MetadataBearer {
 
 export namespace StopDBClusterResult {
   export function isa(o: any): o is StopDBClusterResult {
-    return _smithy.isa(o, "StopDBClusterResult");
+    return __isa(o, "StopDBClusterResult");
   }
 }
 
@@ -18638,7 +18637,7 @@ export interface StopDBInstanceMessage {
 
 export namespace StopDBInstanceMessage {
   export function isa(o: any): o is StopDBInstanceMessage {
-    return _smithy.isa(o, "StopDBInstanceMessage");
+    return __isa(o, "StopDBInstanceMessage");
   }
 }
 
@@ -18655,7 +18654,7 @@ export interface StopDBInstanceResult extends $MetadataBearer {
 
 export namespace StopDBInstanceResult {
   export function isa(o: any): o is StopDBInstanceResult {
-    return _smithy.isa(o, "StopDBInstanceResult");
+    return __isa(o, "StopDBInstanceResult");
   }
 }
 
@@ -18686,7 +18685,7 @@ export interface Subnet {
 
 export namespace Subnet {
   export function isa(o: any): o is Subnet {
-    return _smithy.isa(o, "Subnet");
+    return __isa(o, "Subnet");
   }
 }
 
@@ -18708,7 +18707,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -18725,7 +18724,7 @@ export interface TagListMessage extends $MetadataBearer {
 
 export namespace TagListMessage {
   export function isa(o: any): o is TagListMessage {
-    return _smithy.isa(o, "TagListMessage");
+    return __isa(o, "TagListMessage");
   }
 }
 
@@ -18756,7 +18755,7 @@ export interface Timezone {
 
 export namespace Timezone {
   export function isa(o: any): o is Timezone {
-    return _smithy.isa(o, "Timezone");
+    return __isa(o, "Timezone");
   }
 }
 
@@ -18793,7 +18792,7 @@ export interface UpgradeTarget {
 
 export namespace UpgradeTarget {
   export function isa(o: any): o is UpgradeTarget {
-    return _smithy.isa(o, "UpgradeTarget");
+    return __isa(o, "UpgradeTarget");
   }
 }
 
@@ -18835,7 +18834,7 @@ export interface UserAuthConfig {
 
 export namespace UserAuthConfig {
   export function isa(o: any): o is UserAuthConfig {
-    return _smithy.isa(o, "UserAuthConfig");
+    return __isa(o, "UserAuthConfig");
   }
 }
 
@@ -18877,7 +18876,7 @@ export interface UserAuthConfigInfo {
 
 export namespace UserAuthConfigInfo {
   export function isa(o: any): o is UserAuthConfigInfo {
-    return _smithy.isa(o, "UserAuthConfigInfo");
+    return __isa(o, "UserAuthConfigInfo");
   }
 }
 
@@ -18906,7 +18905,7 @@ export interface ValidDBInstanceModificationsMessage {
 
 export namespace ValidDBInstanceModificationsMessage {
   export function isa(o: any): o is ValidDBInstanceModificationsMessage {
-    return _smithy.isa(o, "ValidDBInstanceModificationsMessage");
+    return __isa(o, "ValidDBInstanceModificationsMessage");
   }
 }
 
@@ -18955,7 +18954,7 @@ export interface ValidStorageOptions {
 
 export namespace ValidStorageOptions {
   export function isa(o: any): o is ValidStorageOptions {
-    return _smithy.isa(o, "ValidStorageOptions");
+    return __isa(o, "ValidStorageOptions");
   }
 }
 
@@ -18977,7 +18976,7 @@ export interface VpcSecurityGroupMembership {
 
 export namespace VpcSecurityGroupMembership {
   export function isa(o: any): o is VpcSecurityGroupMembership {
-    return _smithy.isa(o, "VpcSecurityGroupMembership");
+    return __isa(o, "VpcSecurityGroupMembership");
   }
 }
 
@@ -19024,6 +19023,6 @@ export interface VpnDetails {
 
 export namespace VpnDetails {
   export function isa(o: any): o is VpnDetails {
-    return _smithy.isa(o, "VpnDetails");
+    return __isa(o, "VpnDetails");
   }
 }

--- a/clients/client-rds/protocols/Aws_query.ts
+++ b/clients/client-rds/protocols/Aws_query.ts
@@ -3225,6 +3225,7 @@ export async function deserializeAws_queryAddRoleToDBClusterCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_queryAddRoleToDBClusterCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: AddRoleToDBClusterCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -3296,6 +3297,7 @@ export async function deserializeAws_queryAddRoleToDBInstanceCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_queryAddRoleToDBInstanceCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: AddRoleToDBInstanceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -3435,6 +3437,7 @@ export async function deserializeAws_queryAddTagsToResourceCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_queryAddTagsToResourceCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: AddTagsToResourceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -5860,6 +5863,7 @@ export async function deserializeAws_queryDeleteDBClusterParameterGroupCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteDBClusterParameterGroupCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -6149,6 +6153,7 @@ export async function deserializeAws_queryDeleteDBParameterGroupCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteDBParameterGroupCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -6274,6 +6279,7 @@ export async function deserializeAws_queryDeleteDBSecurityGroupCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteDBSecurityGroupCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -6396,6 +6402,7 @@ export async function deserializeAws_queryDeleteDBSubnetGroupCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_queryDeleteDBSubnetGroupCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteDBSubnetGroupCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -6654,6 +6661,7 @@ export async function deserializeAws_queryDeleteOptionGroupCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_queryDeleteOptionGroupCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteOptionGroupCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -11108,6 +11116,7 @@ export async function deserializeAws_queryRemoveRoleFromDBClusterCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: RemoveRoleFromDBClusterCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -11175,6 +11184,7 @@ export async function deserializeAws_queryRemoveRoleFromDBInstanceCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: RemoveRoleFromDBInstanceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -11310,6 +11320,7 @@ export async function deserializeAws_queryRemoveTagsFromResourceCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: RemoveTagsFromResourceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };

--- a/clients/client-redshift/models/index.ts
+++ b/clients/client-redshift/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -6,7 +9,7 @@ import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
  *             snapshot.</p>
  */
 export interface AccessToSnapshotDeniedFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AccessToSnapshotDeniedFault";
   $fault: "client";
@@ -15,7 +18,7 @@ export interface AccessToSnapshotDeniedFault
 
 export namespace AccessToSnapshotDeniedFault {
   export function isa(o: any): o is AccessToSnapshotDeniedFault {
-    return _smithy.isa(o, "AccessToSnapshotDeniedFault");
+    return __isa(o, "AccessToSnapshotDeniedFault");
   }
 }
 
@@ -24,7 +27,7 @@ export namespace AccessToSnapshotDeniedFault {
  *             specified cluster security group.</p>
  */
 export interface AuthorizationAlreadyExistsFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AuthorizationAlreadyExistsFault";
   $fault: "client";
@@ -33,7 +36,7 @@ export interface AuthorizationAlreadyExistsFault
 
 export namespace AuthorizationAlreadyExistsFault {
   export function isa(o: any): o is AuthorizationAlreadyExistsFault {
-    return _smithy.isa(o, "AuthorizationAlreadyExistsFault");
+    return __isa(o, "AuthorizationAlreadyExistsFault");
   }
 }
 
@@ -42,7 +45,7 @@ export namespace AuthorizationAlreadyExistsFault {
  *             specified cluster security group.</p>
  */
 export interface AuthorizationNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AuthorizationNotFoundFault";
   $fault: "client";
@@ -51,7 +54,7 @@ export interface AuthorizationNotFoundFault
 
 export namespace AuthorizationNotFoundFault {
   export function isa(o: any): o is AuthorizationNotFoundFault {
-    return _smithy.isa(o, "AuthorizationNotFoundFault");
+    return __isa(o, "AuthorizationNotFoundFault");
   }
 }
 
@@ -59,7 +62,7 @@ export namespace AuthorizationNotFoundFault {
  * <p>The authorization quota for the cluster security group has been reached.</p>
  */
 export interface AuthorizationQuotaExceededFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AuthorizationQuotaExceededFault";
   $fault: "client";
@@ -68,7 +71,7 @@ export interface AuthorizationQuotaExceededFault
 
 export namespace AuthorizationQuotaExceededFault {
   export function isa(o: any): o is AuthorizationQuotaExceededFault {
-    return _smithy.isa(o, "AuthorizationQuotaExceededFault");
+    return __isa(o, "AuthorizationQuotaExceededFault");
   }
 }
 
@@ -77,7 +80,7 @@ export namespace AuthorizationQuotaExceededFault {
  *             100. </p>
  */
 export interface BatchDeleteRequestSizeExceededFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "BatchDeleteRequestSizeExceededFault";
   $fault: "client";
@@ -86,7 +89,7 @@ export interface BatchDeleteRequestSizeExceededFault
 
 export namespace BatchDeleteRequestSizeExceededFault {
   export function isa(o: any): o is BatchDeleteRequestSizeExceededFault {
-    return _smithy.isa(o, "BatchDeleteRequestSizeExceededFault");
+    return __isa(o, "BatchDeleteRequestSizeExceededFault");
   }
 }
 
@@ -95,7 +98,7 @@ export namespace BatchDeleteRequestSizeExceededFault {
  *         </p>
  */
 export interface BatchModifyClusterSnapshotsLimitExceededFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "BatchModifyClusterSnapshotsLimitExceededFault";
   $fault: "client";
@@ -106,7 +109,7 @@ export namespace BatchModifyClusterSnapshotsLimitExceededFault {
   export function isa(
     o: any
   ): o is BatchModifyClusterSnapshotsLimitExceededFault {
-    return _smithy.isa(o, "BatchModifyClusterSnapshotsLimitExceededFault");
+    return __isa(o, "BatchModifyClusterSnapshotsLimitExceededFault");
   }
 }
 
@@ -114,7 +117,7 @@ export namespace BatchModifyClusterSnapshotsLimitExceededFault {
  * <p>Could not find the specified S3 bucket.</p>
  */
 export interface BucketNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "BucketNotFoundFault";
   $fault: "client";
@@ -123,7 +126,7 @@ export interface BucketNotFoundFault
 
 export namespace BucketNotFoundFault {
   export function isa(o: any): o is BucketNotFoundFault {
-    return _smithy.isa(o, "BucketNotFoundFault");
+    return __isa(o, "BucketNotFoundFault");
   }
 }
 
@@ -131,7 +134,7 @@ export namespace BucketNotFoundFault {
  * <p>The account already has a cluster with the given identifier.</p>
  */
 export interface ClusterAlreadyExistsFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ClusterAlreadyExistsFault";
   $fault: "client";
@@ -140,7 +143,7 @@ export interface ClusterAlreadyExistsFault
 
 export namespace ClusterAlreadyExistsFault {
   export function isa(o: any): o is ClusterAlreadyExistsFault {
-    return _smithy.isa(o, "ClusterAlreadyExistsFault");
+    return __isa(o, "ClusterAlreadyExistsFault");
   }
 }
 
@@ -149,7 +152,7 @@ export namespace ClusterAlreadyExistsFault {
  *         </p>
  */
 export interface ClusterNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ClusterNotFoundFault";
   $fault: "client";
@@ -158,7 +161,7 @@ export interface ClusterNotFoundFault
 
 export namespace ClusterNotFoundFault {
   export function isa(o: any): o is ClusterNotFoundFault {
-    return _smithy.isa(o, "ClusterNotFoundFault");
+    return __isa(o, "ClusterNotFoundFault");
   }
 }
 
@@ -166,7 +169,7 @@ export namespace ClusterNotFoundFault {
  * <p>Cluster is already on the latest database revision.</p>
  */
 export interface ClusterOnLatestRevisionFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ClusterOnLatestRevisionFault";
   $fault: "client";
@@ -175,7 +178,7 @@ export interface ClusterOnLatestRevisionFault
 
 export namespace ClusterOnLatestRevisionFault {
   export function isa(o: any): o is ClusterOnLatestRevisionFault {
-    return _smithy.isa(o, "ClusterOnLatestRevisionFault");
+    return __isa(o, "ClusterOnLatestRevisionFault");
   }
 }
 
@@ -183,7 +186,7 @@ export namespace ClusterOnLatestRevisionFault {
  * <p>A cluster parameter group with the same name already exists.</p>
  */
 export interface ClusterParameterGroupAlreadyExistsFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ClusterParameterGroupAlreadyExistsFault";
   $fault: "client";
@@ -192,7 +195,7 @@ export interface ClusterParameterGroupAlreadyExistsFault
 
 export namespace ClusterParameterGroupAlreadyExistsFault {
   export function isa(o: any): o is ClusterParameterGroupAlreadyExistsFault {
-    return _smithy.isa(o, "ClusterParameterGroupAlreadyExistsFault");
+    return __isa(o, "ClusterParameterGroupAlreadyExistsFault");
   }
 }
 
@@ -200,7 +203,7 @@ export namespace ClusterParameterGroupAlreadyExistsFault {
  * <p>The parameter group name does not refer to an existing parameter group.</p>
  */
 export interface ClusterParameterGroupNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ClusterParameterGroupNotFoundFault";
   $fault: "client";
@@ -209,7 +212,7 @@ export interface ClusterParameterGroupNotFoundFault
 
 export namespace ClusterParameterGroupNotFoundFault {
   export function isa(o: any): o is ClusterParameterGroupNotFoundFault {
-    return _smithy.isa(o, "ClusterParameterGroupNotFoundFault");
+    return __isa(o, "ClusterParameterGroupNotFoundFault");
   }
 }
 
@@ -221,7 +224,7 @@ export namespace ClusterParameterGroupNotFoundFault {
  * </p>
  */
 export interface ClusterParameterGroupQuotaExceededFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ClusterParameterGroupQuotaExceededFault";
   $fault: "client";
@@ -230,7 +233,7 @@ export interface ClusterParameterGroupQuotaExceededFault
 
 export namespace ClusterParameterGroupQuotaExceededFault {
   export function isa(o: any): o is ClusterParameterGroupQuotaExceededFault {
-    return _smithy.isa(o, "ClusterParameterGroupQuotaExceededFault");
+    return __isa(o, "ClusterParameterGroupQuotaExceededFault");
   }
 }
 
@@ -242,7 +245,7 @@ export namespace ClusterParameterGroupQuotaExceededFault {
  * </p>
  */
 export interface ClusterQuotaExceededFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ClusterQuotaExceededFault";
   $fault: "client";
@@ -251,7 +254,7 @@ export interface ClusterQuotaExceededFault
 
 export namespace ClusterQuotaExceededFault {
   export function isa(o: any): o is ClusterQuotaExceededFault {
-    return _smithy.isa(o, "ClusterQuotaExceededFault");
+    return __isa(o, "ClusterQuotaExceededFault");
   }
 }
 
@@ -259,7 +262,7 @@ export namespace ClusterQuotaExceededFault {
  * <p>A cluster security group with the same name already exists.</p>
  */
 export interface ClusterSecurityGroupAlreadyExistsFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ClusterSecurityGroupAlreadyExistsFault";
   $fault: "client";
@@ -268,7 +271,7 @@ export interface ClusterSecurityGroupAlreadyExistsFault
 
 export namespace ClusterSecurityGroupAlreadyExistsFault {
   export function isa(o: any): o is ClusterSecurityGroupAlreadyExistsFault {
-    return _smithy.isa(o, "ClusterSecurityGroupAlreadyExistsFault");
+    return __isa(o, "ClusterSecurityGroupAlreadyExistsFault");
   }
 }
 
@@ -277,7 +280,7 @@ export namespace ClusterSecurityGroupAlreadyExistsFault {
  *             group.</p>
  */
 export interface ClusterSecurityGroupNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ClusterSecurityGroupNotFoundFault";
   $fault: "client";
@@ -286,7 +289,7 @@ export interface ClusterSecurityGroupNotFoundFault
 
 export namespace ClusterSecurityGroupNotFoundFault {
   export function isa(o: any): o is ClusterSecurityGroupNotFoundFault {
-    return _smithy.isa(o, "ClusterSecurityGroupNotFoundFault");
+    return __isa(o, "ClusterSecurityGroupNotFoundFault");
   }
 }
 
@@ -298,7 +301,7 @@ export namespace ClusterSecurityGroupNotFoundFault {
  * </p>
  */
 export interface ClusterSecurityGroupQuotaExceededFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ClusterSecurityGroupQuotaExceededFault";
   $fault: "client";
@@ -307,7 +310,7 @@ export interface ClusterSecurityGroupQuotaExceededFault
 
 export namespace ClusterSecurityGroupQuotaExceededFault {
   export function isa(o: any): o is ClusterSecurityGroupQuotaExceededFault {
-    return _smithy.isa(o, "ClusterSecurityGroupQuotaExceededFault");
+    return __isa(o, "ClusterSecurityGroupQuotaExceededFault");
   }
 }
 
@@ -316,7 +319,7 @@ export namespace ClusterSecurityGroupQuotaExceededFault {
  *             snapshot.</p>
  */
 export interface ClusterSnapshotAlreadyExistsFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ClusterSnapshotAlreadyExistsFault";
   $fault: "client";
@@ -325,7 +328,7 @@ export interface ClusterSnapshotAlreadyExistsFault
 
 export namespace ClusterSnapshotAlreadyExistsFault {
   export function isa(o: any): o is ClusterSnapshotAlreadyExistsFault {
-    return _smithy.isa(o, "ClusterSnapshotAlreadyExistsFault");
+    return __isa(o, "ClusterSnapshotAlreadyExistsFault");
   }
 }
 
@@ -333,7 +336,7 @@ export namespace ClusterSnapshotAlreadyExistsFault {
  * <p>The snapshot identifier does not refer to an existing cluster snapshot.</p>
  */
 export interface ClusterSnapshotNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ClusterSnapshotNotFoundFault";
   $fault: "client";
@@ -342,7 +345,7 @@ export interface ClusterSnapshotNotFoundFault
 
 export namespace ClusterSnapshotNotFoundFault {
   export function isa(o: any): o is ClusterSnapshotNotFoundFault {
-    return _smithy.isa(o, "ClusterSnapshotNotFoundFault");
+    return __isa(o, "ClusterSnapshotNotFoundFault");
   }
 }
 
@@ -351,7 +354,7 @@ export namespace ClusterSnapshotNotFoundFault {
  *             snapshots.</p>
  */
 export interface ClusterSnapshotQuotaExceededFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ClusterSnapshotQuotaExceededFault";
   $fault: "client";
@@ -360,7 +363,7 @@ export interface ClusterSnapshotQuotaExceededFault
 
 export namespace ClusterSnapshotQuotaExceededFault {
   export function isa(o: any): o is ClusterSnapshotQuotaExceededFault {
-    return _smithy.isa(o, "ClusterSnapshotQuotaExceededFault");
+    return __isa(o, "ClusterSnapshotQuotaExceededFault");
   }
 }
 
@@ -369,7 +372,7 @@ export namespace ClusterSnapshotQuotaExceededFault {
  *             cluster subnet group. </p>
  */
 export interface ClusterSubnetGroupAlreadyExistsFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ClusterSubnetGroupAlreadyExistsFault";
   $fault: "client";
@@ -378,7 +381,7 @@ export interface ClusterSubnetGroupAlreadyExistsFault
 
 export namespace ClusterSubnetGroupAlreadyExistsFault {
   export function isa(o: any): o is ClusterSubnetGroupAlreadyExistsFault {
-    return _smithy.isa(o, "ClusterSubnetGroupAlreadyExistsFault");
+    return __isa(o, "ClusterSubnetGroupAlreadyExistsFault");
   }
 }
 
@@ -387,7 +390,7 @@ export namespace ClusterSubnetGroupAlreadyExistsFault {
  *             group.</p>
  */
 export interface ClusterSubnetGroupNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ClusterSubnetGroupNotFoundFault";
   $fault: "client";
@@ -396,7 +399,7 @@ export interface ClusterSubnetGroupNotFoundFault
 
 export namespace ClusterSubnetGroupNotFoundFault {
   export function isa(o: any): o is ClusterSubnetGroupNotFoundFault {
-    return _smithy.isa(o, "ClusterSubnetGroupNotFoundFault");
+    return __isa(o, "ClusterSubnetGroupNotFoundFault");
   }
 }
 
@@ -408,7 +411,7 @@ export namespace ClusterSubnetGroupNotFoundFault {
  * </p>
  */
 export interface ClusterSubnetGroupQuotaExceededFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ClusterSubnetGroupQuotaExceededFault";
   $fault: "client";
@@ -417,7 +420,7 @@ export interface ClusterSubnetGroupQuotaExceededFault
 
 export namespace ClusterSubnetGroupQuotaExceededFault {
   export function isa(o: any): o is ClusterSubnetGroupQuotaExceededFault {
-    return _smithy.isa(o, "ClusterSubnetGroupQuotaExceededFault");
+    return __isa(o, "ClusterSubnetGroupQuotaExceededFault");
   }
 }
 
@@ -429,7 +432,7 @@ export namespace ClusterSubnetGroupQuotaExceededFault {
  * </p>
  */
 export interface ClusterSubnetQuotaExceededFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ClusterSubnetQuotaExceededFault";
   $fault: "client";
@@ -438,7 +441,7 @@ export interface ClusterSubnetQuotaExceededFault
 
 export namespace ClusterSubnetQuotaExceededFault {
   export function isa(o: any): o is ClusterSubnetQuotaExceededFault {
-    return _smithy.isa(o, "ClusterSubnetQuotaExceededFault");
+    return __isa(o, "ClusterSubnetQuotaExceededFault");
   }
 }
 
@@ -447,7 +450,7 @@ export namespace ClusterSubnetQuotaExceededFault {
  *             again.</p>
  */
 export interface CopyToRegionDisabledFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CopyToRegionDisabledFault";
   $fault: "client";
@@ -456,7 +459,7 @@ export interface CopyToRegionDisabledFault
 
 export namespace CopyToRegionDisabledFault {
   export function isa(o: any): o is CopyToRegionDisabledFault {
-    return _smithy.isa(o, "CopyToRegionDisabledFault");
+    return __isa(o, "CopyToRegionDisabledFault");
   }
 }
 
@@ -465,7 +468,7 @@ export namespace CopyToRegionDisabledFault {
  *             made by Amazon Redshift on your behalf. Wait and retry the request.</p>
  */
 export interface DependentServiceRequestThrottlingFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DependentServiceRequestThrottlingFault";
   $fault: "client";
@@ -474,7 +477,7 @@ export interface DependentServiceRequestThrottlingFault
 
 export namespace DependentServiceRequestThrottlingFault {
   export function isa(o: any): o is DependentServiceRequestThrottlingFault {
-    return _smithy.isa(o, "DependentServiceRequestThrottlingFault");
+    return __isa(o, "DependentServiceRequestThrottlingFault");
   }
 }
 
@@ -483,7 +486,7 @@ export namespace DependentServiceRequestThrottlingFault {
  *             temporarily unavailable. Wait 30 to 60 seconds and try again.</p>
  */
 export interface DependentServiceUnavailableFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DependentServiceUnavailableFault";
   $fault: "client";
@@ -492,7 +495,7 @@ export interface DependentServiceUnavailableFault
 
 export namespace DependentServiceUnavailableFault {
   export function isa(o: any): o is DependentServiceUnavailableFault {
-    return _smithy.isa(o, "DependentServiceUnavailableFault");
+    return __isa(o, "DependentServiceUnavailableFault");
   }
 }
 
@@ -504,7 +507,7 @@ export namespace DependentServiceUnavailableFault {
  * </p>
  */
 export interface EventSubscriptionQuotaExceededFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "EventSubscriptionQuotaExceededFault";
   $fault: "client";
@@ -513,7 +516,7 @@ export interface EventSubscriptionQuotaExceededFault
 
 export namespace EventSubscriptionQuotaExceededFault {
   export function isa(o: any): o is EventSubscriptionQuotaExceededFault {
-    return _smithy.isa(o, "EventSubscriptionQuotaExceededFault");
+    return __isa(o, "EventSubscriptionQuotaExceededFault");
   }
 }
 
@@ -522,7 +525,7 @@ export namespace EventSubscriptionQuotaExceededFault {
  *             identifier.</p>
  */
 export interface HsmClientCertificateAlreadyExistsFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "HsmClientCertificateAlreadyExistsFault";
   $fault: "client";
@@ -531,7 +534,7 @@ export interface HsmClientCertificateAlreadyExistsFault
 
 export namespace HsmClientCertificateAlreadyExistsFault {
   export function isa(o: any): o is HsmClientCertificateAlreadyExistsFault {
-    return _smithy.isa(o, "HsmClientCertificateAlreadyExistsFault");
+    return __isa(o, "HsmClientCertificateAlreadyExistsFault");
   }
 }
 
@@ -540,7 +543,7 @@ export namespace HsmClientCertificateAlreadyExistsFault {
  *             identifier.</p>
  */
 export interface HsmClientCertificateNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "HsmClientCertificateNotFoundFault";
   $fault: "client";
@@ -549,7 +552,7 @@ export interface HsmClientCertificateNotFoundFault
 
 export namespace HsmClientCertificateNotFoundFault {
   export function isa(o: any): o is HsmClientCertificateNotFoundFault {
-    return _smithy.isa(o, "HsmClientCertificateNotFoundFault");
+    return __isa(o, "HsmClientCertificateNotFoundFault");
   }
 }
 
@@ -560,7 +563,7 @@ export namespace HsmClientCertificateNotFoundFault {
  * </p>
  */
 export interface HsmClientCertificateQuotaExceededFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "HsmClientCertificateQuotaExceededFault";
   $fault: "client";
@@ -569,7 +572,7 @@ export interface HsmClientCertificateQuotaExceededFault
 
 export namespace HsmClientCertificateQuotaExceededFault {
   export function isa(o: any): o is HsmClientCertificateQuotaExceededFault {
-    return _smithy.isa(o, "HsmClientCertificateQuotaExceededFault");
+    return __isa(o, "HsmClientCertificateQuotaExceededFault");
   }
 }
 
@@ -578,7 +581,7 @@ export namespace HsmClientCertificateQuotaExceededFault {
  *             identifier.</p>
  */
 export interface HsmConfigurationAlreadyExistsFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "HsmConfigurationAlreadyExistsFault";
   $fault: "client";
@@ -587,7 +590,7 @@ export interface HsmConfigurationAlreadyExistsFault
 
 export namespace HsmConfigurationAlreadyExistsFault {
   export function isa(o: any): o is HsmConfigurationAlreadyExistsFault {
-    return _smithy.isa(o, "HsmConfigurationAlreadyExistsFault");
+    return __isa(o, "HsmConfigurationAlreadyExistsFault");
   }
 }
 
@@ -595,7 +598,7 @@ export namespace HsmConfigurationAlreadyExistsFault {
  * <p>There is no Amazon Redshift HSM configuration with the specified identifier.</p>
  */
 export interface HsmConfigurationNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "HsmConfigurationNotFoundFault";
   $fault: "client";
@@ -604,7 +607,7 @@ export interface HsmConfigurationNotFoundFault
 
 export namespace HsmConfigurationNotFoundFault {
   export function isa(o: any): o is HsmConfigurationNotFoundFault {
-    return _smithy.isa(o, "HsmConfigurationNotFoundFault");
+    return __isa(o, "HsmConfigurationNotFoundFault");
   }
 }
 
@@ -615,7 +618,7 @@ export namespace HsmConfigurationNotFoundFault {
  * </p>
  */
 export interface HsmConfigurationQuotaExceededFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "HsmConfigurationQuotaExceededFault";
   $fault: "client";
@@ -624,7 +627,7 @@ export interface HsmConfigurationQuotaExceededFault
 
 export namespace HsmConfigurationQuotaExceededFault {
   export function isa(o: any): o is HsmConfigurationQuotaExceededFault {
-    return _smithy.isa(o, "HsmConfigurationQuotaExceededFault");
+    return __isa(o, "HsmConfigurationQuotaExceededFault");
   }
 }
 
@@ -633,7 +636,7 @@ export namespace HsmConfigurationQuotaExceededFault {
  *             current table restore requests to complete before making a new request.</p>
  */
 export interface InProgressTableRestoreQuotaExceededFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InProgressTableRestoreQuotaExceededFault";
   $fault: "client";
@@ -642,7 +645,7 @@ export interface InProgressTableRestoreQuotaExceededFault
 
 export namespace InProgressTableRestoreQuotaExceededFault {
   export function isa(o: any): o is InProgressTableRestoreQuotaExceededFault {
-    return _smithy.isa(o, "InProgressTableRestoreQuotaExceededFault");
+    return __isa(o, "InProgressTableRestoreQuotaExceededFault");
   }
 }
 
@@ -650,7 +653,7 @@ export namespace InProgressTableRestoreQuotaExceededFault {
  * <p>The specified options are incompatible.</p>
  */
 export interface IncompatibleOrderableOptions
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "IncompatibleOrderableOptions";
   $fault: "client";
@@ -659,7 +662,7 @@ export interface IncompatibleOrderableOptions
 
 export namespace IncompatibleOrderableOptions {
   export function isa(o: any): o is IncompatibleOrderableOptions {
-    return _smithy.isa(o, "IncompatibleOrderableOptions");
+    return __isa(o, "IncompatibleOrderableOptions");
   }
 }
 
@@ -668,7 +671,7 @@ export namespace IncompatibleOrderableOptions {
  *             cluster.</p>
  */
 export interface InsufficientClusterCapacityFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InsufficientClusterCapacityFault";
   $fault: "client";
@@ -677,7 +680,7 @@ export interface InsufficientClusterCapacityFault
 
 export namespace InsufficientClusterCapacityFault {
   export function isa(o: any): o is InsufficientClusterCapacityFault {
-    return _smithy.isa(o, "InsufficientClusterCapacityFault");
+    return __isa(o, "InsufficientClusterCapacityFault");
   }
 }
 
@@ -686,7 +689,7 @@ export namespace InsufficientClusterCapacityFault {
  *             specified when enabling logging.</p>
  */
 export interface InsufficientS3BucketPolicyFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InsufficientS3BucketPolicyFault";
   $fault: "client";
@@ -695,7 +698,7 @@ export interface InsufficientS3BucketPolicyFault
 
 export namespace InsufficientS3BucketPolicyFault {
   export function isa(o: any): o is InsufficientS3BucketPolicyFault {
-    return _smithy.isa(o, "InsufficientS3BucketPolicyFault");
+    return __isa(o, "InsufficientS3BucketPolicyFault");
   }
 }
 
@@ -705,7 +708,7 @@ export namespace InsufficientS3BucketPolicyFault {
  *             again.</p>
  */
 export interface InvalidClusterParameterGroupStateFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidClusterParameterGroupStateFault";
   $fault: "client";
@@ -714,7 +717,7 @@ export interface InvalidClusterParameterGroupStateFault
 
 export namespace InvalidClusterParameterGroupStateFault {
   export function isa(o: any): o is InvalidClusterParameterGroupStateFault {
-    return _smithy.isa(o, "InvalidClusterParameterGroupStateFault");
+    return __isa(o, "InvalidClusterParameterGroupStateFault");
   }
 }
 
@@ -722,7 +725,7 @@ export namespace InvalidClusterParameterGroupStateFault {
  * <p>The state of the cluster security group is not <code>available</code>. </p>
  */
 export interface InvalidClusterSecurityGroupStateFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidClusterSecurityGroupStateFault";
   $fault: "client";
@@ -731,7 +734,7 @@ export interface InvalidClusterSecurityGroupStateFault
 
 export namespace InvalidClusterSecurityGroupStateFault {
   export function isa(o: any): o is InvalidClusterSecurityGroupStateFault {
-    return _smithy.isa(o, "InvalidClusterSecurityGroupStateFault");
+    return __isa(o, "InvalidClusterSecurityGroupStateFault");
   }
 }
 
@@ -739,7 +742,7 @@ export namespace InvalidClusterSecurityGroupStateFault {
  * <p>The cluster snapshot schedule state is not valid.</p>
  */
 export interface InvalidClusterSnapshotScheduleStateFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidClusterSnapshotScheduleStateFault";
   $fault: "client";
@@ -748,7 +751,7 @@ export interface InvalidClusterSnapshotScheduleStateFault
 
 export namespace InvalidClusterSnapshotScheduleStateFault {
   export function isa(o: any): o is InvalidClusterSnapshotScheduleStateFault {
-    return _smithy.isa(o, "InvalidClusterSnapshotScheduleStateFault");
+    return __isa(o, "InvalidClusterSnapshotScheduleStateFault");
   }
 }
 
@@ -757,7 +760,7 @@ export namespace InvalidClusterSnapshotScheduleStateFault {
  *             accounts are authorized to access the snapshot. </p>
  */
 export interface InvalidClusterSnapshotStateFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidClusterSnapshotStateFault";
   $fault: "client";
@@ -766,7 +769,7 @@ export interface InvalidClusterSnapshotStateFault
 
 export namespace InvalidClusterSnapshotStateFault {
   export function isa(o: any): o is InvalidClusterSnapshotStateFault {
-    return _smithy.isa(o, "InvalidClusterSnapshotStateFault");
+    return __isa(o, "InvalidClusterSnapshotStateFault");
   }
 }
 
@@ -774,7 +777,7 @@ export namespace InvalidClusterSnapshotStateFault {
  * <p>The specified cluster is not in the <code>available</code> state. </p>
  */
 export interface InvalidClusterStateFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidClusterStateFault";
   $fault: "client";
@@ -783,7 +786,7 @@ export interface InvalidClusterStateFault
 
 export namespace InvalidClusterStateFault {
   export function isa(o: any): o is InvalidClusterStateFault {
-    return _smithy.isa(o, "InvalidClusterStateFault");
+    return __isa(o, "InvalidClusterStateFault");
   }
 }
 
@@ -791,7 +794,7 @@ export namespace InvalidClusterStateFault {
  * <p>The cluster subnet group cannot be deleted because it is in use.</p>
  */
 export interface InvalidClusterSubnetGroupStateFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidClusterSubnetGroupStateFault";
   $fault: "client";
@@ -800,7 +803,7 @@ export interface InvalidClusterSubnetGroupStateFault
 
 export namespace InvalidClusterSubnetGroupStateFault {
   export function isa(o: any): o is InvalidClusterSubnetGroupStateFault {
-    return _smithy.isa(o, "InvalidClusterSubnetGroupStateFault");
+    return __isa(o, "InvalidClusterSubnetGroupStateFault");
   }
 }
 
@@ -808,7 +811,7 @@ export namespace InvalidClusterSubnetGroupStateFault {
  * <p>The state of the subnet is invalid.</p>
  */
 export interface InvalidClusterSubnetStateFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidClusterSubnetStateFault";
   $fault: "client";
@@ -817,7 +820,7 @@ export interface InvalidClusterSubnetStateFault
 
 export namespace InvalidClusterSubnetStateFault {
   export function isa(o: any): o is InvalidClusterSubnetStateFault {
-    return _smithy.isa(o, "InvalidClusterSubnetStateFault");
+    return __isa(o, "InvalidClusterSubnetStateFault");
   }
 }
 
@@ -825,7 +828,7 @@ export namespace InvalidClusterSubnetStateFault {
  * <p>The provided cluster track name is not valid.</p>
  */
 export interface InvalidClusterTrackFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidClusterTrackFault";
   $fault: "client";
@@ -834,7 +837,7 @@ export interface InvalidClusterTrackFault
 
 export namespace InvalidClusterTrackFault {
   export function isa(o: any): o is InvalidClusterTrackFault {
-    return _smithy.isa(o, "InvalidClusterTrackFault");
+    return __isa(o, "InvalidClusterTrackFault");
   }
 }
 
@@ -842,7 +845,7 @@ export namespace InvalidClusterTrackFault {
  * <p>The Elastic IP (EIP) is invalid or cannot be found.</p>
  */
 export interface InvalidElasticIpFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidElasticIpFault";
   $fault: "client";
@@ -851,7 +854,7 @@ export interface InvalidElasticIpFault
 
 export namespace InvalidElasticIpFault {
   export function isa(o: any): o is InvalidElasticIpFault {
-    return _smithy.isa(o, "InvalidElasticIpFault");
+    return __isa(o, "InvalidElasticIpFault");
   }
 }
 
@@ -860,7 +863,7 @@ export namespace InvalidElasticIpFault {
  *             it is still in use by one or more Amazon Redshift clusters.</p>
  */
 export interface InvalidHsmClientCertificateStateFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidHsmClientCertificateStateFault";
   $fault: "client";
@@ -869,7 +872,7 @@ export interface InvalidHsmClientCertificateStateFault
 
 export namespace InvalidHsmClientCertificateStateFault {
   export function isa(o: any): o is InvalidHsmClientCertificateStateFault {
-    return _smithy.isa(o, "InvalidHsmClientCertificateStateFault");
+    return __isa(o, "InvalidHsmClientCertificateStateFault");
   }
 }
 
@@ -878,7 +881,7 @@ export namespace InvalidHsmClientCertificateStateFault {
  *             is still in use by one or more Amazon Redshift clusters.</p>
  */
 export interface InvalidHsmConfigurationStateFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidHsmConfigurationStateFault";
   $fault: "client";
@@ -887,7 +890,7 @@ export interface InvalidHsmConfigurationStateFault
 
 export namespace InvalidHsmConfigurationStateFault {
   export function isa(o: any): o is InvalidHsmConfigurationStateFault {
-    return _smithy.isa(o, "InvalidHsmConfigurationStateFault");
+    return __isa(o, "InvalidHsmConfigurationStateFault");
   }
 }
 
@@ -895,7 +898,7 @@ export namespace InvalidHsmConfigurationStateFault {
  * <p>Indicates that the Reserved Node being exchanged is not in an active state.</p>
  */
 export interface InvalidReservedNodeStateFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidReservedNodeStateFault";
   $fault: "client";
@@ -904,7 +907,7 @@ export interface InvalidReservedNodeStateFault
 
 export namespace InvalidReservedNodeStateFault {
   export function isa(o: any): o is InvalidReservedNodeStateFault {
-    return _smithy.isa(o, "InvalidReservedNodeStateFault");
+    return __isa(o, "InvalidReservedNodeStateFault");
   }
 }
 
@@ -912,7 +915,7 @@ export namespace InvalidReservedNodeStateFault {
  * <p>The restore is invalid.</p>
  */
 export interface InvalidRestoreFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidRestoreFault";
   $fault: "client";
@@ -921,7 +924,7 @@ export interface InvalidRestoreFault
 
 export namespace InvalidRestoreFault {
   export function isa(o: any): o is InvalidRestoreFault {
-    return _smithy.isa(o, "InvalidRestoreFault");
+    return __isa(o, "InvalidRestoreFault");
   }
 }
 
@@ -930,7 +933,7 @@ export namespace InvalidRestoreFault {
  *         <p>The value must be either -1 or an integer between 1 and 3,653.</p>
  */
 export interface InvalidRetentionPeriodFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidRetentionPeriodFault";
   $fault: "client";
@@ -939,7 +942,7 @@ export interface InvalidRetentionPeriodFault
 
 export namespace InvalidRetentionPeriodFault {
   export function isa(o: any): o is InvalidRetentionPeriodFault {
-    return _smithy.isa(o, "InvalidRetentionPeriodFault");
+    return __isa(o, "InvalidRetentionPeriodFault");
   }
 }
 
@@ -950,7 +953,7 @@ export namespace InvalidRetentionPeriodFault {
  *             Developer Guide.</p>
  */
 export interface InvalidS3BucketNameFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidS3BucketNameFault";
   $fault: "client";
@@ -959,7 +962,7 @@ export interface InvalidS3BucketNameFault
 
 export namespace InvalidS3BucketNameFault {
   export function isa(o: any): o is InvalidS3BucketNameFault {
-    return _smithy.isa(o, "InvalidS3BucketNameFault");
+    return __isa(o, "InvalidS3BucketNameFault");
   }
 }
 
@@ -968,7 +971,7 @@ export namespace InvalidS3BucketNameFault {
  *             documented constraints.</p>
  */
 export interface InvalidS3KeyPrefixFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidS3KeyPrefixFault";
   $fault: "client";
@@ -977,7 +980,7 @@ export interface InvalidS3KeyPrefixFault
 
 export namespace InvalidS3KeyPrefixFault {
   export function isa(o: any): o is InvalidS3KeyPrefixFault {
-    return _smithy.isa(o, "InvalidS3KeyPrefixFault");
+    return __isa(o, "InvalidS3KeyPrefixFault");
   }
 }
 
@@ -985,7 +988,7 @@ export namespace InvalidS3KeyPrefixFault {
  * <p>The schedule you submitted isn't valid.</p>
  */
 export interface InvalidScheduleFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidScheduleFault";
   $fault: "client";
@@ -994,7 +997,7 @@ export interface InvalidScheduleFault
 
 export namespace InvalidScheduleFault {
   export function isa(o: any): o is InvalidScheduleFault {
-    return _smithy.isa(o, "InvalidScheduleFault");
+    return __isa(o, "InvalidScheduleFault");
   }
 }
 
@@ -1002,7 +1005,7 @@ export namespace InvalidScheduleFault {
  * <p>The scheduled action is not valid. </p>
  */
 export interface InvalidScheduledActionFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidScheduledActionFault";
   $fault: "client";
@@ -1011,7 +1014,7 @@ export interface InvalidScheduledActionFault
 
 export namespace InvalidScheduledActionFault {
   export function isa(o: any): o is InvalidScheduledActionFault {
-    return _smithy.isa(o, "InvalidScheduledActionFault");
+    return __isa(o, "InvalidScheduledActionFault");
   }
 }
 
@@ -1020,7 +1023,7 @@ export namespace InvalidScheduledActionFault {
  *             clusters.</p>
  */
 export interface InvalidSnapshotCopyGrantStateFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidSnapshotCopyGrantStateFault";
   $fault: "client";
@@ -1029,7 +1032,7 @@ export interface InvalidSnapshotCopyGrantStateFault
 
 export namespace InvalidSnapshotCopyGrantStateFault {
   export function isa(o: any): o is InvalidSnapshotCopyGrantStateFault {
-    return _smithy.isa(o, "InvalidSnapshotCopyGrantStateFault");
+    return __isa(o, "InvalidSnapshotCopyGrantStateFault");
   }
 }
 
@@ -1037,9 +1040,7 @@ export namespace InvalidSnapshotCopyGrantStateFault {
  * <p>The requested subnet is not valid, or not all of the subnets are in the same
  *             VPC.</p>
  */
-export interface InvalidSubnet
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface InvalidSubnet extends __SmithyException, $MetadataBearer {
   name: "InvalidSubnet";
   $fault: "client";
   message?: string;
@@ -1047,7 +1048,7 @@ export interface InvalidSubnet
 
 export namespace InvalidSubnet {
   export function isa(o: any): o is InvalidSubnet {
-    return _smithy.isa(o, "InvalidSubnet");
+    return __isa(o, "InvalidSubnet");
   }
 }
 
@@ -1056,7 +1057,7 @@ export namespace InvalidSubnet {
  *             subscription request is already in progress.</p>
  */
 export interface InvalidSubscriptionStateFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidSubscriptionStateFault";
   $fault: "client";
@@ -1065,7 +1066,7 @@ export interface InvalidSubscriptionStateFault
 
 export namespace InvalidSubscriptionStateFault {
   export function isa(o: any): o is InvalidSubscriptionStateFault {
-    return _smithy.isa(o, "InvalidSubscriptionStateFault");
+    return __isa(o, "InvalidSubscriptionStateFault");
   }
 }
 
@@ -1075,7 +1076,7 @@ export namespace InvalidSubscriptionStateFault {
  *             combination of these, doesn't exist in the snapshot.</p>
  */
 export interface InvalidTableRestoreArgumentFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidTableRestoreArgumentFault";
   $fault: "client";
@@ -1084,16 +1085,14 @@ export interface InvalidTableRestoreArgumentFault
 
 export namespace InvalidTableRestoreArgumentFault {
   export function isa(o: any): o is InvalidTableRestoreArgumentFault {
-    return _smithy.isa(o, "InvalidTableRestoreArgumentFault");
+    return __isa(o, "InvalidTableRestoreArgumentFault");
   }
 }
 
 /**
  * <p>The tag is invalid.</p>
  */
-export interface InvalidTagFault
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface InvalidTagFault extends __SmithyException, $MetadataBearer {
   name: "InvalidTagFault";
   $fault: "client";
   message?: string;
@@ -1101,7 +1100,7 @@ export interface InvalidTagFault
 
 export namespace InvalidTagFault {
   export function isa(o: any): o is InvalidTagFault {
-    return _smithy.isa(o, "InvalidTagFault");
+    return __isa(o, "InvalidTagFault");
   }
 }
 
@@ -1109,7 +1108,7 @@ export namespace InvalidTagFault {
  * <p>The cluster subnet group does not cover all Availability Zones.</p>
  */
 export interface InvalidVPCNetworkStateFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidVPCNetworkStateFault";
   $fault: "client";
@@ -1118,16 +1117,14 @@ export interface InvalidVPCNetworkStateFault
 
 export namespace InvalidVPCNetworkStateFault {
   export function isa(o: any): o is InvalidVPCNetworkStateFault {
-    return _smithy.isa(o, "InvalidVPCNetworkStateFault");
+    return __isa(o, "InvalidVPCNetworkStateFault");
   }
 }
 
 /**
  * <p>The encryption key has exceeded its grant limit in AWS KMS.</p>
  */
-export interface LimitExceededFault
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface LimitExceededFault extends __SmithyException, $MetadataBearer {
   name: "LimitExceededFault";
   $fault: "client";
   message?: string;
@@ -1135,7 +1132,7 @@ export interface LimitExceededFault
 
 export namespace LimitExceededFault {
   export function isa(o: any): o is LimitExceededFault {
-    return _smithy.isa(o, "LimitExceededFault");
+    return __isa(o, "LimitExceededFault");
   }
 }
 
@@ -1143,7 +1140,7 @@ export namespace LimitExceededFault {
  * <p>The operation would exceed the number of nodes allowed for a cluster.</p>
  */
 export interface NumberOfNodesPerClusterLimitExceededFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "NumberOfNodesPerClusterLimitExceededFault";
   $fault: "client";
@@ -1152,7 +1149,7 @@ export interface NumberOfNodesPerClusterLimitExceededFault
 
 export namespace NumberOfNodesPerClusterLimitExceededFault {
   export function isa(o: any): o is NumberOfNodesPerClusterLimitExceededFault {
-    return _smithy.isa(o, "NumberOfNodesPerClusterLimitExceededFault");
+    return __isa(o, "NumberOfNodesPerClusterLimitExceededFault");
   }
 }
 
@@ -1164,7 +1161,7 @@ export namespace NumberOfNodesPerClusterLimitExceededFault {
  * </p>
  */
 export interface NumberOfNodesQuotaExceededFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "NumberOfNodesQuotaExceededFault";
   $fault: "client";
@@ -1173,7 +1170,7 @@ export interface NumberOfNodesQuotaExceededFault
 
 export namespace NumberOfNodesQuotaExceededFault {
   export function isa(o: any): o is NumberOfNodesQuotaExceededFault {
-    return _smithy.isa(o, "NumberOfNodesQuotaExceededFault");
+    return __isa(o, "NumberOfNodesQuotaExceededFault");
   }
 }
 
@@ -1181,7 +1178,7 @@ export namespace NumberOfNodesQuotaExceededFault {
  * <p>User already has a reservation with the given identifier.</p>
  */
 export interface ReservedNodeAlreadyExistsFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ReservedNodeAlreadyExistsFault";
   $fault: "client";
@@ -1190,7 +1187,7 @@ export interface ReservedNodeAlreadyExistsFault
 
 export namespace ReservedNodeAlreadyExistsFault {
   export function isa(o: any): o is ReservedNodeAlreadyExistsFault {
-    return _smithy.isa(o, "ReservedNodeAlreadyExistsFault");
+    return __isa(o, "ReservedNodeAlreadyExistsFault");
   }
 }
 
@@ -1198,7 +1195,7 @@ export namespace ReservedNodeAlreadyExistsFault {
  * <p>Indicates that the reserved node has already been exchanged.</p>
  */
 export interface ReservedNodeAlreadyMigratedFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ReservedNodeAlreadyMigratedFault";
   $fault: "client";
@@ -1207,7 +1204,7 @@ export interface ReservedNodeAlreadyMigratedFault
 
 export namespace ReservedNodeAlreadyMigratedFault {
   export function isa(o: any): o is ReservedNodeAlreadyMigratedFault {
-    return _smithy.isa(o, "ReservedNodeAlreadyMigratedFault");
+    return __isa(o, "ReservedNodeAlreadyMigratedFault");
   }
 }
 
@@ -1215,7 +1212,7 @@ export namespace ReservedNodeAlreadyMigratedFault {
  * <p>The specified reserved compute node not found.</p>
  */
 export interface ReservedNodeNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ReservedNodeNotFoundFault";
   $fault: "client";
@@ -1224,7 +1221,7 @@ export interface ReservedNodeNotFoundFault
 
 export namespace ReservedNodeNotFoundFault {
   export function isa(o: any): o is ReservedNodeNotFoundFault {
-    return _smithy.isa(o, "ReservedNodeNotFoundFault");
+    return __isa(o, "ReservedNodeNotFoundFault");
   }
 }
 
@@ -1232,7 +1229,7 @@ export namespace ReservedNodeNotFoundFault {
  * <p>Specified offering does not exist.</p>
  */
 export interface ReservedNodeOfferingNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ReservedNodeOfferingNotFoundFault";
   $fault: "client";
@@ -1241,7 +1238,7 @@ export interface ReservedNodeOfferingNotFoundFault
 
 export namespace ReservedNodeOfferingNotFoundFault {
   export function isa(o: any): o is ReservedNodeOfferingNotFoundFault {
-    return _smithy.isa(o, "ReservedNodeOfferingNotFoundFault");
+    return __isa(o, "ReservedNodeOfferingNotFoundFault");
   }
 }
 
@@ -1252,7 +1249,7 @@ export namespace ReservedNodeOfferingNotFoundFault {
  * </p>
  */
 export interface ReservedNodeQuotaExceededFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ReservedNodeQuotaExceededFault";
   $fault: "client";
@@ -1261,7 +1258,7 @@ export interface ReservedNodeQuotaExceededFault
 
 export namespace ReservedNodeQuotaExceededFault {
   export function isa(o: any): o is ReservedNodeQuotaExceededFault {
-    return _smithy.isa(o, "ReservedNodeQuotaExceededFault");
+    return __isa(o, "ReservedNodeQuotaExceededFault");
   }
 }
 
@@ -1269,7 +1266,7 @@ export namespace ReservedNodeQuotaExceededFault {
  * <p>A resize operation for the specified cluster is not found.</p>
  */
 export interface ResizeNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResizeNotFoundFault";
   $fault: "client";
@@ -1278,7 +1275,7 @@ export interface ResizeNotFoundFault
 
 export namespace ResizeNotFoundFault {
   export function isa(o: any): o is ResizeNotFoundFault {
-    return _smithy.isa(o, "ResizeNotFoundFault");
+    return __isa(o, "ResizeNotFoundFault");
   }
 }
 
@@ -1286,7 +1283,7 @@ export namespace ResizeNotFoundFault {
  * <p>The resource could not be found.</p>
  */
 export interface ResourceNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundFault";
   $fault: "client";
@@ -1295,7 +1292,7 @@ export interface ResourceNotFoundFault
 
 export namespace ResourceNotFoundFault {
   export function isa(o: any): o is ResourceNotFoundFault {
-    return _smithy.isa(o, "ResourceNotFoundFault");
+    return __isa(o, "ResourceNotFoundFault");
   }
 }
 
@@ -1304,7 +1301,7 @@ export namespace ResourceNotFoundFault {
  *             topic.</p>
  */
 export interface SNSInvalidTopicFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "SNSInvalidTopicFault";
   $fault: "client";
@@ -1313,7 +1310,7 @@ export interface SNSInvalidTopicFault
 
 export namespace SNSInvalidTopicFault {
   export function isa(o: any): o is SNSInvalidTopicFault {
-    return _smithy.isa(o, "SNSInvalidTopicFault");
+    return __isa(o, "SNSInvalidTopicFault");
   }
 }
 
@@ -1321,7 +1318,7 @@ export namespace SNSInvalidTopicFault {
  * <p>You do not have permission to publish to the specified Amazon SNS topic.</p>
  */
 export interface SNSNoAuthorizationFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "SNSNoAuthorizationFault";
   $fault: "client";
@@ -1330,7 +1327,7 @@ export interface SNSNoAuthorizationFault
 
 export namespace SNSNoAuthorizationFault {
   export function isa(o: any): o is SNSNoAuthorizationFault {
-    return _smithy.isa(o, "SNSNoAuthorizationFault");
+    return __isa(o, "SNSNoAuthorizationFault");
   }
 }
 
@@ -1339,7 +1336,7 @@ export namespace SNSNoAuthorizationFault {
  *             exist.</p>
  */
 export interface SNSTopicArnNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "SNSTopicArnNotFoundFault";
   $fault: "client";
@@ -1348,7 +1345,7 @@ export interface SNSTopicArnNotFoundFault
 
 export namespace SNSTopicArnNotFoundFault {
   export function isa(o: any): o is SNSTopicArnNotFoundFault {
-    return _smithy.isa(o, "SNSTopicArnNotFoundFault");
+    return __isa(o, "SNSTopicArnNotFoundFault");
   }
 }
 
@@ -1356,7 +1353,7 @@ export namespace SNSTopicArnNotFoundFault {
  * <p>The definition you submitted is not supported.</p>
  */
 export interface ScheduleDefinitionTypeUnsupportedFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ScheduleDefinitionTypeUnsupportedFault";
   $fault: "client";
@@ -1365,7 +1362,7 @@ export interface ScheduleDefinitionTypeUnsupportedFault
 
 export namespace ScheduleDefinitionTypeUnsupportedFault {
   export function isa(o: any): o is ScheduleDefinitionTypeUnsupportedFault {
-    return _smithy.isa(o, "ScheduleDefinitionTypeUnsupportedFault");
+    return __isa(o, "ScheduleDefinitionTypeUnsupportedFault");
   }
 }
 
@@ -1373,7 +1370,7 @@ export namespace ScheduleDefinitionTypeUnsupportedFault {
  * <p>The scheduled action already exists. </p>
  */
 export interface ScheduledActionAlreadyExistsFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ScheduledActionAlreadyExistsFault";
   $fault: "client";
@@ -1382,7 +1379,7 @@ export interface ScheduledActionAlreadyExistsFault
 
 export namespace ScheduledActionAlreadyExistsFault {
   export function isa(o: any): o is ScheduledActionAlreadyExistsFault {
-    return _smithy.isa(o, "ScheduledActionAlreadyExistsFault");
+    return __isa(o, "ScheduledActionAlreadyExistsFault");
   }
 }
 
@@ -1390,7 +1387,7 @@ export namespace ScheduledActionAlreadyExistsFault {
  * <p>The scheduled action cannot be found. </p>
  */
 export interface ScheduledActionNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ScheduledActionNotFoundFault";
   $fault: "client";
@@ -1399,7 +1396,7 @@ export interface ScheduledActionNotFoundFault
 
 export namespace ScheduledActionNotFoundFault {
   export function isa(o: any): o is ScheduledActionNotFoundFault {
-    return _smithy.isa(o, "ScheduledActionNotFoundFault");
+    return __isa(o, "ScheduledActionNotFoundFault");
   }
 }
 
@@ -1407,7 +1404,7 @@ export namespace ScheduledActionNotFoundFault {
  * <p>The quota for scheduled actions exceeded. </p>
  */
 export interface ScheduledActionQuotaExceededFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ScheduledActionQuotaExceededFault";
   $fault: "client";
@@ -1416,7 +1413,7 @@ export interface ScheduledActionQuotaExceededFault
 
 export namespace ScheduledActionQuotaExceededFault {
   export function isa(o: any): o is ScheduledActionQuotaExceededFault {
-    return _smithy.isa(o, "ScheduledActionQuotaExceededFault");
+    return __isa(o, "ScheduledActionQuotaExceededFault");
   }
 }
 
@@ -1424,7 +1421,7 @@ export namespace ScheduledActionQuotaExceededFault {
  * <p>The action type specified for a scheduled action is not supported. </p>
  */
 export interface ScheduledActionTypeUnsupportedFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ScheduledActionTypeUnsupportedFault";
   $fault: "client";
@@ -1433,7 +1430,7 @@ export interface ScheduledActionTypeUnsupportedFault
 
 export namespace ScheduledActionTypeUnsupportedFault {
   export function isa(o: any): o is ScheduledActionTypeUnsupportedFault {
-    return _smithy.isa(o, "ScheduledActionTypeUnsupportedFault");
+    return __isa(o, "ScheduledActionTypeUnsupportedFault");
   }
 }
 
@@ -1441,7 +1438,7 @@ export namespace ScheduledActionTypeUnsupportedFault {
  * <p>The cluster already has cross-region snapshot copy disabled.</p>
  */
 export interface SnapshotCopyAlreadyDisabledFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "SnapshotCopyAlreadyDisabledFault";
   $fault: "client";
@@ -1450,7 +1447,7 @@ export interface SnapshotCopyAlreadyDisabledFault
 
 export namespace SnapshotCopyAlreadyDisabledFault {
   export function isa(o: any): o is SnapshotCopyAlreadyDisabledFault {
-    return _smithy.isa(o, "SnapshotCopyAlreadyDisabledFault");
+    return __isa(o, "SnapshotCopyAlreadyDisabledFault");
   }
 }
 
@@ -1458,7 +1455,7 @@ export namespace SnapshotCopyAlreadyDisabledFault {
  * <p>The cluster already has cross-region snapshot copy enabled.</p>
  */
 export interface SnapshotCopyAlreadyEnabledFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "SnapshotCopyAlreadyEnabledFault";
   $fault: "client";
@@ -1467,7 +1464,7 @@ export interface SnapshotCopyAlreadyEnabledFault
 
 export namespace SnapshotCopyAlreadyEnabledFault {
   export function isa(o: any): o is SnapshotCopyAlreadyEnabledFault {
-    return _smithy.isa(o, "SnapshotCopyAlreadyEnabledFault");
+    return __isa(o, "SnapshotCopyAlreadyEnabledFault");
   }
 }
 
@@ -1476,7 +1473,7 @@ export namespace SnapshotCopyAlreadyEnabledFault {
  *             again.</p>
  */
 export interface SnapshotCopyDisabledFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "SnapshotCopyDisabledFault";
   $fault: "client";
@@ -1485,7 +1482,7 @@ export interface SnapshotCopyDisabledFault
 
 export namespace SnapshotCopyDisabledFault {
   export function isa(o: any): o is SnapshotCopyDisabledFault {
-    return _smithy.isa(o, "SnapshotCopyDisabledFault");
+    return __isa(o, "SnapshotCopyDisabledFault");
   }
 }
 
@@ -1494,7 +1491,7 @@ export namespace SnapshotCopyDisabledFault {
  *             exists.</p>
  */
 export interface SnapshotCopyGrantAlreadyExistsFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "SnapshotCopyGrantAlreadyExistsFault";
   $fault: "client";
@@ -1503,7 +1500,7 @@ export interface SnapshotCopyGrantAlreadyExistsFault
 
 export namespace SnapshotCopyGrantAlreadyExistsFault {
   export function isa(o: any): o is SnapshotCopyGrantAlreadyExistsFault {
-    return _smithy.isa(o, "SnapshotCopyGrantAlreadyExistsFault");
+    return __isa(o, "SnapshotCopyGrantAlreadyExistsFault");
   }
 }
 
@@ -1512,7 +1509,7 @@ export namespace SnapshotCopyGrantAlreadyExistsFault {
  *             correctly and that the grant exists in the destination region.</p>
  */
 export interface SnapshotCopyGrantNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "SnapshotCopyGrantNotFoundFault";
   $fault: "client";
@@ -1521,7 +1518,7 @@ export interface SnapshotCopyGrantNotFoundFault
 
 export namespace SnapshotCopyGrantNotFoundFault {
   export function isa(o: any): o is SnapshotCopyGrantNotFoundFault {
-    return _smithy.isa(o, "SnapshotCopyGrantNotFoundFault");
+    return __isa(o, "SnapshotCopyGrantNotFoundFault");
   }
 }
 
@@ -1530,7 +1527,7 @@ export namespace SnapshotCopyGrantNotFoundFault {
  *             region.</p>
  */
 export interface SnapshotCopyGrantQuotaExceededFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "SnapshotCopyGrantQuotaExceededFault";
   $fault: "client";
@@ -1539,7 +1536,7 @@ export interface SnapshotCopyGrantQuotaExceededFault
 
 export namespace SnapshotCopyGrantQuotaExceededFault {
   export function isa(o: any): o is SnapshotCopyGrantQuotaExceededFault {
-    return _smithy.isa(o, "SnapshotCopyGrantQuotaExceededFault");
+    return __isa(o, "SnapshotCopyGrantQuotaExceededFault");
   }
 }
 
@@ -1547,7 +1544,7 @@ export namespace SnapshotCopyGrantQuotaExceededFault {
  * <p>The specified snapshot schedule already exists. </p>
  */
 export interface SnapshotScheduleAlreadyExistsFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "SnapshotScheduleAlreadyExistsFault";
   $fault: "client";
@@ -1556,7 +1553,7 @@ export interface SnapshotScheduleAlreadyExistsFault
 
 export namespace SnapshotScheduleAlreadyExistsFault {
   export function isa(o: any): o is SnapshotScheduleAlreadyExistsFault {
-    return _smithy.isa(o, "SnapshotScheduleAlreadyExistsFault");
+    return __isa(o, "SnapshotScheduleAlreadyExistsFault");
   }
 }
 
@@ -1564,7 +1561,7 @@ export namespace SnapshotScheduleAlreadyExistsFault {
  * <p>We could not find the specified snapshot schedule. </p>
  */
 export interface SnapshotScheduleNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "SnapshotScheduleNotFoundFault";
   $fault: "client";
@@ -1573,7 +1570,7 @@ export interface SnapshotScheduleNotFoundFault
 
 export namespace SnapshotScheduleNotFoundFault {
   export function isa(o: any): o is SnapshotScheduleNotFoundFault {
-    return _smithy.isa(o, "SnapshotScheduleNotFoundFault");
+    return __isa(o, "SnapshotScheduleNotFoundFault");
   }
 }
 
@@ -1581,7 +1578,7 @@ export namespace SnapshotScheduleNotFoundFault {
  * <p>You have exceeded the quota of snapshot schedules. </p>
  */
 export interface SnapshotScheduleQuotaExceededFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "SnapshotScheduleQuotaExceededFault";
   $fault: "client";
@@ -1590,7 +1587,7 @@ export interface SnapshotScheduleQuotaExceededFault
 
 export namespace SnapshotScheduleQuotaExceededFault {
   export function isa(o: any): o is SnapshotScheduleQuotaExceededFault {
-    return _smithy.isa(o, "SnapshotScheduleQuotaExceededFault");
+    return __isa(o, "SnapshotScheduleQuotaExceededFault");
   }
 }
 
@@ -1598,7 +1595,7 @@ export namespace SnapshotScheduleQuotaExceededFault {
  * <p>The specified snapshot schedule is already being updated.</p>
  */
 export interface SnapshotScheduleUpdateInProgressFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "SnapshotScheduleUpdateInProgressFault";
   $fault: "client";
@@ -1607,7 +1604,7 @@ export interface SnapshotScheduleUpdateInProgressFault
 
 export namespace SnapshotScheduleUpdateInProgressFault {
   export function isa(o: any): o is SnapshotScheduleUpdateInProgressFault {
-    return _smithy.isa(o, "SnapshotScheduleUpdateInProgressFault");
+    return __isa(o, "SnapshotScheduleUpdateInProgressFault");
   }
 }
 
@@ -1615,7 +1612,7 @@ export namespace SnapshotScheduleUpdateInProgressFault {
  * <p>The specified Amazon Redshift event source could not be found.</p>
  */
 export interface SourceNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "SourceNotFoundFault";
   $fault: "client";
@@ -1624,16 +1621,14 @@ export interface SourceNotFoundFault
 
 export namespace SourceNotFoundFault {
   export function isa(o: any): o is SourceNotFoundFault {
-    return _smithy.isa(o, "SourceNotFoundFault");
+    return __isa(o, "SourceNotFoundFault");
   }
 }
 
 /**
  * <p>A specified subnet is already in use by another cluster.</p>
  */
-export interface SubnetAlreadyInUse
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface SubnetAlreadyInUse extends __SmithyException, $MetadataBearer {
   name: "SubnetAlreadyInUse";
   $fault: "client";
   message?: string;
@@ -1641,7 +1636,7 @@ export interface SubnetAlreadyInUse
 
 export namespace SubnetAlreadyInUse {
   export function isa(o: any): o is SubnetAlreadyInUse {
-    return _smithy.isa(o, "SubnetAlreadyInUse");
+    return __isa(o, "SubnetAlreadyInUse");
   }
 }
 
@@ -1650,7 +1645,7 @@ export namespace SubnetAlreadyInUse {
  *             name.</p>
  */
 export interface SubscriptionAlreadyExistFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "SubscriptionAlreadyExistFault";
   $fault: "client";
@@ -1659,7 +1654,7 @@ export interface SubscriptionAlreadyExistFault
 
 export namespace SubscriptionAlreadyExistFault {
   export function isa(o: any): o is SubscriptionAlreadyExistFault {
-    return _smithy.isa(o, "SubscriptionAlreadyExistFault");
+    return __isa(o, "SubscriptionAlreadyExistFault");
   }
 }
 
@@ -1669,7 +1664,7 @@ export namespace SubscriptionAlreadyExistFault {
  *             values are Configuration, Management, Monitoring, and Security.</p>
  */
 export interface SubscriptionCategoryNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "SubscriptionCategoryNotFoundFault";
   $fault: "client";
@@ -1678,7 +1673,7 @@ export interface SubscriptionCategoryNotFoundFault
 
 export namespace SubscriptionCategoryNotFoundFault {
   export function isa(o: any): o is SubscriptionCategoryNotFoundFault {
-    return _smithy.isa(o, "SubscriptionCategoryNotFoundFault");
+    return __isa(o, "SubscriptionCategoryNotFoundFault");
   }
 }
 
@@ -1686,7 +1681,7 @@ export namespace SubscriptionCategoryNotFoundFault {
  * <p>An Amazon Redshift event with the specified event ID does not exist.</p>
  */
 export interface SubscriptionEventIdNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "SubscriptionEventIdNotFoundFault";
   $fault: "client";
@@ -1695,7 +1690,7 @@ export interface SubscriptionEventIdNotFoundFault
 
 export namespace SubscriptionEventIdNotFoundFault {
   export function isa(o: any): o is SubscriptionEventIdNotFoundFault {
-    return _smithy.isa(o, "SubscriptionEventIdNotFoundFault");
+    return __isa(o, "SubscriptionEventIdNotFoundFault");
   }
 }
 
@@ -1704,7 +1699,7 @@ export namespace SubscriptionEventIdNotFoundFault {
  *             exist.</p>
  */
 export interface SubscriptionNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "SubscriptionNotFoundFault";
   $fault: "client";
@@ -1713,7 +1708,7 @@ export interface SubscriptionNotFoundFault
 
 export namespace SubscriptionNotFoundFault {
   export function isa(o: any): o is SubscriptionNotFoundFault {
-    return _smithy.isa(o, "SubscriptionNotFoundFault");
+    return __isa(o, "SubscriptionNotFoundFault");
   }
 }
 
@@ -1723,7 +1718,7 @@ export namespace SubscriptionNotFoundFault {
  *             values are ERROR and INFO.</p>
  */
 export interface SubscriptionSeverityNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "SubscriptionSeverityNotFoundFault";
   $fault: "client";
@@ -1732,7 +1727,7 @@ export interface SubscriptionSeverityNotFoundFault
 
 export namespace SubscriptionSeverityNotFoundFault {
   export function isa(o: any): o is SubscriptionSeverityNotFoundFault {
-    return _smithy.isa(o, "SubscriptionSeverityNotFoundFault");
+    return __isa(o, "SubscriptionSeverityNotFoundFault");
   }
 }
 
@@ -1741,7 +1736,7 @@ export namespace SubscriptionSeverityNotFoundFault {
  *             node type. </p>
  */
 export interface TableLimitExceededFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TableLimitExceededFault";
   $fault: "client";
@@ -1750,7 +1745,7 @@ export interface TableLimitExceededFault
 
 export namespace TableLimitExceededFault {
   export function isa(o: any): o is TableLimitExceededFault {
-    return _smithy.isa(o, "TableLimitExceededFault");
+    return __isa(o, "TableLimitExceededFault");
   }
 }
 
@@ -1758,7 +1753,7 @@ export namespace TableLimitExceededFault {
  * <p>The specified <code>TableRestoreRequestId</code> value was not found.</p>
  */
 export interface TableRestoreNotFoundFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TableRestoreNotFoundFault";
   $fault: "client";
@@ -1767,7 +1762,7 @@ export interface TableRestoreNotFoundFault
 
 export namespace TableRestoreNotFoundFault {
   export function isa(o: any): o is TableRestoreNotFoundFault {
-    return _smithy.isa(o, "TableRestoreNotFoundFault");
+    return __isa(o, "TableRestoreNotFoundFault");
   }
 }
 
@@ -1775,7 +1770,7 @@ export namespace TableRestoreNotFoundFault {
  * <p>You have exceeded the number of tags allowed.</p>
  */
 export interface TagLimitExceededFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TagLimitExceededFault";
   $fault: "client";
@@ -1784,7 +1779,7 @@ export interface TagLimitExceededFault
 
 export namespace TagLimitExceededFault {
   export function isa(o: any): o is TagLimitExceededFault {
-    return _smithy.isa(o, "TagLimitExceededFault");
+    return __isa(o, "TagLimitExceededFault");
   }
 }
 
@@ -1792,7 +1787,7 @@ export namespace TagLimitExceededFault {
  * <p>Your account is not authorized to perform the requested operation.</p>
  */
 export interface UnauthorizedOperation
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UnauthorizedOperation";
   $fault: "client";
@@ -1801,7 +1796,7 @@ export interface UnauthorizedOperation
 
 export namespace UnauthorizedOperation {
   export function isa(o: any): o is UnauthorizedOperation {
-    return _smithy.isa(o, "UnauthorizedOperation");
+    return __isa(o, "UnauthorizedOperation");
   }
 }
 
@@ -1809,7 +1804,7 @@ export namespace UnauthorizedOperation {
  * <p>The specified region is incorrect or does not exist.</p>
  */
 export interface UnknownSnapshotCopyRegionFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UnknownSnapshotCopyRegionFault";
   $fault: "client";
@@ -1818,7 +1813,7 @@ export interface UnknownSnapshotCopyRegionFault
 
 export namespace UnknownSnapshotCopyRegionFault {
   export function isa(o: any): o is UnknownSnapshotCopyRegionFault {
-    return _smithy.isa(o, "UnknownSnapshotCopyRegionFault");
+    return __isa(o, "UnknownSnapshotCopyRegionFault");
   }
 }
 
@@ -1826,7 +1821,7 @@ export namespace UnknownSnapshotCopyRegionFault {
  * <p>The requested operation isn't supported.</p>
  */
 export interface UnsupportedOperationFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UnsupportedOperationFault";
   $fault: "client";
@@ -1835,7 +1830,7 @@ export interface UnsupportedOperationFault
 
 export namespace UnsupportedOperationFault {
   export function isa(o: any): o is UnsupportedOperationFault {
-    return _smithy.isa(o, "UnsupportedOperationFault");
+    return __isa(o, "UnsupportedOperationFault");
   }
 }
 
@@ -1843,7 +1838,7 @@ export namespace UnsupportedOperationFault {
  * <p>A request option was specified that is not supported.</p>
  */
 export interface UnsupportedOptionFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UnsupportedOptionFault";
   $fault: "client";
@@ -1852,7 +1847,7 @@ export interface UnsupportedOptionFault
 
 export namespace UnsupportedOptionFault {
   export function isa(o: any): o is UnsupportedOptionFault {
-    return _smithy.isa(o, "UnsupportedOptionFault");
+    return __isa(o, "UnsupportedOptionFault");
   }
 }
 
@@ -1874,7 +1869,7 @@ export interface AcceptReservedNodeExchangeInputMessage {
 
 export namespace AcceptReservedNodeExchangeInputMessage {
   export function isa(o: any): o is AcceptReservedNodeExchangeInputMessage {
-    return _smithy.isa(o, "AcceptReservedNodeExchangeInputMessage");
+    return __isa(o, "AcceptReservedNodeExchangeInputMessage");
   }
 }
 
@@ -1889,7 +1884,7 @@ export interface AcceptReservedNodeExchangeOutputMessage
 
 export namespace AcceptReservedNodeExchangeOutputMessage {
   export function isa(o: any): o is AcceptReservedNodeExchangeOutputMessage {
-    return _smithy.isa(o, "AcceptReservedNodeExchangeOutputMessage");
+    return __isa(o, "AcceptReservedNodeExchangeOutputMessage");
   }
 }
 
@@ -1911,7 +1906,7 @@ export interface AccountAttribute {
 
 export namespace AccountAttribute {
   export function isa(o: any): o is AccountAttribute {
-    return _smithy.isa(o, "AccountAttribute");
+    return __isa(o, "AccountAttribute");
   }
 }
 
@@ -1925,7 +1920,7 @@ export interface AccountAttributeList extends $MetadataBearer {
 
 export namespace AccountAttributeList {
   export function isa(o: any): o is AccountAttributeList {
-    return _smithy.isa(o, "AccountAttributeList");
+    return __isa(o, "AccountAttributeList");
   }
 }
 
@@ -1949,7 +1944,7 @@ export interface AccountWithRestoreAccess {
 
 export namespace AccountWithRestoreAccess {
   export function isa(o: any): o is AccountWithRestoreAccess {
-    return _smithy.isa(o, "AccountWithRestoreAccess");
+    return __isa(o, "AccountWithRestoreAccess");
   }
 }
 
@@ -1971,7 +1966,7 @@ export interface AttributeValueTarget {
 
 export namespace AttributeValueTarget {
   export function isa(o: any): o is AttributeValueTarget {
-    return _smithy.isa(o, "AttributeValueTarget");
+    return __isa(o, "AttributeValueTarget");
   }
 }
 
@@ -2009,7 +2004,7 @@ export namespace AuthorizeClusterSecurityGroupIngressMessage {
   export function isa(
     o: any
   ): o is AuthorizeClusterSecurityGroupIngressMessage {
-    return _smithy.isa(o, "AuthorizeClusterSecurityGroupIngressMessage");
+    return __isa(o, "AuthorizeClusterSecurityGroupIngressMessage");
   }
 }
 
@@ -2024,7 +2019,7 @@ export interface AuthorizeClusterSecurityGroupIngressResult
 
 export namespace AuthorizeClusterSecurityGroupIngressResult {
   export function isa(o: any): o is AuthorizeClusterSecurityGroupIngressResult {
-    return _smithy.isa(o, "AuthorizeClusterSecurityGroupIngressResult");
+    return __isa(o, "AuthorizeClusterSecurityGroupIngressResult");
   }
 }
 
@@ -2055,7 +2050,7 @@ export interface AuthorizeSnapshotAccessMessage {
 
 export namespace AuthorizeSnapshotAccessMessage {
   export function isa(o: any): o is AuthorizeSnapshotAccessMessage {
-    return _smithy.isa(o, "AuthorizeSnapshotAccessMessage");
+    return __isa(o, "AuthorizeSnapshotAccessMessage");
   }
 }
 
@@ -2069,7 +2064,7 @@ export interface AuthorizeSnapshotAccessResult extends $MetadataBearer {
 
 export namespace AuthorizeSnapshotAccessResult {
   export function isa(o: any): o is AuthorizeSnapshotAccessResult {
-    return _smithy.isa(o, "AuthorizeSnapshotAccessResult");
+    return __isa(o, "AuthorizeSnapshotAccessResult");
   }
 }
 
@@ -2091,7 +2086,7 @@ export interface AvailabilityZone {
 
 export namespace AvailabilityZone {
   export function isa(o: any): o is AvailabilityZone {
-    return _smithy.isa(o, "AvailabilityZone");
+    return __isa(o, "AvailabilityZone");
   }
 }
 
@@ -2105,7 +2100,7 @@ export interface BatchDeleteClusterSnapshotsRequest {
 
 export namespace BatchDeleteClusterSnapshotsRequest {
   export function isa(o: any): o is BatchDeleteClusterSnapshotsRequest {
-    return _smithy.isa(o, "BatchDeleteClusterSnapshotsRequest");
+    return __isa(o, "BatchDeleteClusterSnapshotsRequest");
   }
 }
 
@@ -2124,7 +2119,7 @@ export interface BatchDeleteClusterSnapshotsResult extends $MetadataBearer {
 
 export namespace BatchDeleteClusterSnapshotsResult {
   export function isa(o: any): o is BatchDeleteClusterSnapshotsResult {
-    return _smithy.isa(o, "BatchDeleteClusterSnapshotsResult");
+    return __isa(o, "BatchDeleteClusterSnapshotsResult");
   }
 }
 
@@ -2154,7 +2149,7 @@ export interface BatchModifyClusterSnapshotsMessage {
 
 export namespace BatchModifyClusterSnapshotsMessage {
   export function isa(o: any): o is BatchModifyClusterSnapshotsMessage {
-    return _smithy.isa(o, "BatchModifyClusterSnapshotsMessage");
+    return __isa(o, "BatchModifyClusterSnapshotsMessage");
   }
 }
 
@@ -2174,7 +2169,7 @@ export interface BatchModifyClusterSnapshotsOutputMessage
 
 export namespace BatchModifyClusterSnapshotsOutputMessage {
   export function isa(o: any): o is BatchModifyClusterSnapshotsOutputMessage {
-    return _smithy.isa(o, "BatchModifyClusterSnapshotsOutputMessage");
+    return __isa(o, "BatchModifyClusterSnapshotsOutputMessage");
   }
 }
 
@@ -2189,7 +2184,7 @@ export interface CancelResizeMessage {
 
 export namespace CancelResizeMessage {
   export function isa(o: any): o is CancelResizeMessage {
-    return _smithy.isa(o, "CancelResizeMessage");
+    return __isa(o, "CancelResizeMessage");
   }
 }
 
@@ -2597,7 +2592,7 @@ export interface Cluster {
 
 export namespace Cluster {
   export function isa(o: any): o is Cluster {
-    return _smithy.isa(o, "Cluster");
+    return __isa(o, "Cluster");
   }
 }
 
@@ -2619,7 +2614,7 @@ export interface ClusterAssociatedToSchedule {
 
 export namespace ClusterAssociatedToSchedule {
   export function isa(o: any): o is ClusterAssociatedToSchedule {
-    return _smithy.isa(o, "ClusterAssociatedToSchedule");
+    return __isa(o, "ClusterAssociatedToSchedule");
   }
 }
 
@@ -2653,7 +2648,7 @@ export interface ClusterCredentials extends $MetadataBearer {
 
 export namespace ClusterCredentials {
   export function isa(o: any): o is ClusterCredentials {
-    return _smithy.isa(o, "ClusterCredentials");
+    return __isa(o, "ClusterCredentials");
   }
 }
 
@@ -2686,7 +2681,7 @@ export interface ClusterDbRevision {
 
 export namespace ClusterDbRevision {
   export function isa(o: any): o is ClusterDbRevision {
-    return _smithy.isa(o, "ClusterDbRevision");
+    return __isa(o, "ClusterDbRevision");
   }
 }
 
@@ -2708,7 +2703,7 @@ export interface ClusterDbRevisionsMessage extends $MetadataBearer {
 
 export namespace ClusterDbRevisionsMessage {
   export function isa(o: any): o is ClusterDbRevisionsMessage {
-    return _smithy.isa(o, "ClusterDbRevisionsMessage");
+    return __isa(o, "ClusterDbRevisionsMessage");
   }
 }
 
@@ -2750,7 +2745,7 @@ export interface ClusterIamRole {
 
 export namespace ClusterIamRole {
   export function isa(o: any): o is ClusterIamRole {
-    return _smithy.isa(o, "ClusterIamRole");
+    return __isa(o, "ClusterIamRole");
   }
 }
 
@@ -2777,7 +2772,7 @@ export interface ClusterNode {
 
 export namespace ClusterNode {
   export function isa(o: any): o is ClusterNode {
-    return _smithy.isa(o, "ClusterNode");
+    return __isa(o, "ClusterNode");
   }
 }
 
@@ -2810,7 +2805,7 @@ export interface ClusterParameterGroup {
 
 export namespace ClusterParameterGroup {
   export function isa(o: any): o is ClusterParameterGroup {
-    return _smithy.isa(o, "ClusterParameterGroup");
+    return __isa(o, "ClusterParameterGroup");
   }
 }
 
@@ -2838,7 +2833,7 @@ export interface ClusterParameterGroupDetails extends $MetadataBearer {
 
 export namespace ClusterParameterGroupDetails {
   export function isa(o: any): o is ClusterParameterGroupDetails {
-    return _smithy.isa(o, "ClusterParameterGroupDetails");
+    return __isa(o, "ClusterParameterGroupDetails");
   }
 }
 
@@ -2862,7 +2857,7 @@ export interface ClusterParameterGroupNameMessage extends $MetadataBearer {
 
 export namespace ClusterParameterGroupNameMessage {
   export function isa(o: any): o is ClusterParameterGroupNameMessage {
-    return _smithy.isa(o, "ClusterParameterGroupNameMessage");
+    return __isa(o, "ClusterParameterGroupNameMessage");
   }
 }
 
@@ -2893,7 +2888,7 @@ export interface ClusterParameterGroupStatus {
 
 export namespace ClusterParameterGroupStatus {
   export function isa(o: any): o is ClusterParameterGroupStatus {
-    return _smithy.isa(o, "ClusterParameterGroupStatus");
+    return __isa(o, "ClusterParameterGroupStatus");
   }
 }
 
@@ -2921,7 +2916,7 @@ export interface ClusterParameterGroupsMessage extends $MetadataBearer {
 
 export namespace ClusterParameterGroupsMessage {
   export function isa(o: any): o is ClusterParameterGroupsMessage {
-    return _smithy.isa(o, "ClusterParameterGroupsMessage");
+    return __isa(o, "ClusterParameterGroupsMessage");
   }
 }
 
@@ -2989,7 +2984,7 @@ export interface ClusterParameterStatus {
 
 export namespace ClusterParameterStatus {
   export function isa(o: any): o is ClusterParameterStatus {
-    return _smithy.isa(o, "ClusterParameterStatus");
+    return __isa(o, "ClusterParameterStatus");
   }
 }
 
@@ -3029,7 +3024,7 @@ export interface ClusterSecurityGroup {
 
 export namespace ClusterSecurityGroup {
   export function isa(o: any): o is ClusterSecurityGroup {
-    return _smithy.isa(o, "ClusterSecurityGroup");
+    return __isa(o, "ClusterSecurityGroup");
   }
 }
 
@@ -3051,7 +3046,7 @@ export interface ClusterSecurityGroupMembership {
 
 export namespace ClusterSecurityGroupMembership {
   export function isa(o: any): o is ClusterSecurityGroupMembership {
-    return _smithy.isa(o, "ClusterSecurityGroupMembership");
+    return __isa(o, "ClusterSecurityGroupMembership");
   }
 }
 
@@ -3077,7 +3072,7 @@ export interface ClusterSecurityGroupMessage extends $MetadataBearer {
 
 export namespace ClusterSecurityGroupMessage {
   export function isa(o: any): o is ClusterSecurityGroupMessage {
-    return _smithy.isa(o, "ClusterSecurityGroupMessage");
+    return __isa(o, "ClusterSecurityGroupMessage");
   }
 }
 
@@ -3115,7 +3110,7 @@ export interface ClusterSnapshotCopyStatus {
 
 export namespace ClusterSnapshotCopyStatus {
   export function isa(o: any): o is ClusterSnapshotCopyStatus {
-    return _smithy.isa(o, "ClusterSnapshotCopyStatus");
+    return __isa(o, "ClusterSnapshotCopyStatus");
   }
 }
 
@@ -3158,7 +3153,7 @@ export interface ClusterSubnetGroup {
 
 export namespace ClusterSubnetGroup {
   export function isa(o: any): o is ClusterSubnetGroup {
-    return _smithy.isa(o, "ClusterSubnetGroup");
+    return __isa(o, "ClusterSubnetGroup");
   }
 }
 
@@ -3185,7 +3180,7 @@ export interface ClusterSubnetGroupMessage extends $MetadataBearer {
 
 export namespace ClusterSubnetGroupMessage {
   export function isa(o: any): o is ClusterSubnetGroupMessage {
-    return _smithy.isa(o, "ClusterSubnetGroupMessage");
+    return __isa(o, "ClusterSubnetGroupMessage");
   }
 }
 
@@ -3213,7 +3208,7 @@ export interface ClusterVersion {
 
 export namespace ClusterVersion {
   export function isa(o: any): o is ClusterVersion {
-    return _smithy.isa(o, "ClusterVersion");
+    return __isa(o, "ClusterVersion");
   }
 }
 
@@ -3240,7 +3235,7 @@ export interface ClusterVersionsMessage extends $MetadataBearer {
 
 export namespace ClusterVersionsMessage {
   export function isa(o: any): o is ClusterVersionsMessage {
-    return _smithy.isa(o, "ClusterVersionsMessage");
+    return __isa(o, "ClusterVersionsMessage");
   }
 }
 
@@ -3267,7 +3262,7 @@ export interface ClustersMessage extends $MetadataBearer {
 
 export namespace ClustersMessage {
   export function isa(o: any): o is ClustersMessage {
-    return _smithy.isa(o, "ClustersMessage");
+    return __isa(o, "ClustersMessage");
   }
 }
 
@@ -3335,7 +3330,7 @@ export interface CopyClusterSnapshotMessage {
 
 export namespace CopyClusterSnapshotMessage {
   export function isa(o: any): o is CopyClusterSnapshotMessage {
-    return _smithy.isa(o, "CopyClusterSnapshotMessage");
+    return __isa(o, "CopyClusterSnapshotMessage");
   }
 }
 
@@ -3349,7 +3344,7 @@ export interface CopyClusterSnapshotResult extends $MetadataBearer {
 
 export namespace CopyClusterSnapshotResult {
   export function isa(o: any): o is CopyClusterSnapshotResult {
-    return _smithy.isa(o, "CopyClusterSnapshotResult");
+    return __isa(o, "CopyClusterSnapshotResult");
   }
 }
 
@@ -3706,7 +3701,7 @@ export interface CreateClusterMessage {
 
 export namespace CreateClusterMessage {
   export function isa(o: any): o is CreateClusterMessage {
-    return _smithy.isa(o, "CreateClusterMessage");
+    return __isa(o, "CreateClusterMessage");
   }
 }
 
@@ -3762,7 +3757,7 @@ export interface CreateClusterParameterGroupMessage {
 
 export namespace CreateClusterParameterGroupMessage {
   export function isa(o: any): o is CreateClusterParameterGroupMessage {
-    return _smithy.isa(o, "CreateClusterParameterGroupMessage");
+    return __isa(o, "CreateClusterParameterGroupMessage");
   }
 }
 
@@ -3776,7 +3771,7 @@ export interface CreateClusterParameterGroupResult extends $MetadataBearer {
 
 export namespace CreateClusterParameterGroupResult {
   export function isa(o: any): o is CreateClusterParameterGroupResult {
-    return _smithy.isa(o, "CreateClusterParameterGroupResult");
+    return __isa(o, "CreateClusterParameterGroupResult");
   }
 }
 
@@ -3790,7 +3785,7 @@ export interface CreateClusterResult extends $MetadataBearer {
 
 export namespace CreateClusterResult {
   export function isa(o: any): o is CreateClusterResult {
-    return _smithy.isa(o, "CreateClusterResult");
+    return __isa(o, "CreateClusterResult");
   }
 }
 
@@ -3833,7 +3828,7 @@ export interface CreateClusterSecurityGroupMessage {
 
 export namespace CreateClusterSecurityGroupMessage {
   export function isa(o: any): o is CreateClusterSecurityGroupMessage {
-    return _smithy.isa(o, "CreateClusterSecurityGroupMessage");
+    return __isa(o, "CreateClusterSecurityGroupMessage");
   }
 }
 
@@ -3847,7 +3842,7 @@ export interface CreateClusterSecurityGroupResult extends $MetadataBearer {
 
 export namespace CreateClusterSecurityGroupResult {
   export function isa(o: any): o is CreateClusterSecurityGroupResult {
-    return _smithy.isa(o, "CreateClusterSecurityGroupResult");
+    return __isa(o, "CreateClusterSecurityGroupResult");
   }
 }
 
@@ -3902,7 +3897,7 @@ export interface CreateClusterSnapshotMessage {
 
 export namespace CreateClusterSnapshotMessage {
   export function isa(o: any): o is CreateClusterSnapshotMessage {
-    return _smithy.isa(o, "CreateClusterSnapshotMessage");
+    return __isa(o, "CreateClusterSnapshotMessage");
   }
 }
 
@@ -3916,7 +3911,7 @@ export interface CreateClusterSnapshotResult extends $MetadataBearer {
 
 export namespace CreateClusterSnapshotResult {
   export function isa(o: any): o is CreateClusterSnapshotResult {
-    return _smithy.isa(o, "CreateClusterSnapshotResult");
+    return __isa(o, "CreateClusterSnapshotResult");
   }
 }
 
@@ -3965,7 +3960,7 @@ export interface CreateClusterSubnetGroupMessage {
 
 export namespace CreateClusterSubnetGroupMessage {
   export function isa(o: any): o is CreateClusterSubnetGroupMessage {
-    return _smithy.isa(o, "CreateClusterSubnetGroupMessage");
+    return __isa(o, "CreateClusterSubnetGroupMessage");
   }
 }
 
@@ -3979,7 +3974,7 @@ export interface CreateClusterSubnetGroupResult extends $MetadataBearer {
 
 export namespace CreateClusterSubnetGroupResult {
   export function isa(o: any): o is CreateClusterSubnetGroupResult {
-    return _smithy.isa(o, "CreateClusterSubnetGroupResult");
+    return __isa(o, "CreateClusterSubnetGroupResult");
   }
 }
 
@@ -4063,7 +4058,7 @@ export interface CreateEventSubscriptionMessage {
 
 export namespace CreateEventSubscriptionMessage {
   export function isa(o: any): o is CreateEventSubscriptionMessage {
-    return _smithy.isa(o, "CreateEventSubscriptionMessage");
+    return __isa(o, "CreateEventSubscriptionMessage");
   }
 }
 
@@ -4077,7 +4072,7 @@ export interface CreateEventSubscriptionResult extends $MetadataBearer {
 
 export namespace CreateEventSubscriptionResult {
   export function isa(o: any): o is CreateEventSubscriptionResult {
-    return _smithy.isa(o, "CreateEventSubscriptionResult");
+    return __isa(o, "CreateEventSubscriptionResult");
   }
 }
 
@@ -4100,7 +4095,7 @@ export interface CreateHsmClientCertificateMessage {
 
 export namespace CreateHsmClientCertificateMessage {
   export function isa(o: any): o is CreateHsmClientCertificateMessage {
-    return _smithy.isa(o, "CreateHsmClientCertificateMessage");
+    return __isa(o, "CreateHsmClientCertificateMessage");
   }
 }
 
@@ -4116,7 +4111,7 @@ export interface CreateHsmClientCertificateResult extends $MetadataBearer {
 
 export namespace CreateHsmClientCertificateResult {
   export function isa(o: any): o is CreateHsmClientCertificateResult {
-    return _smithy.isa(o, "CreateHsmClientCertificateResult");
+    return __isa(o, "CreateHsmClientCertificateResult");
   }
 }
 
@@ -4165,7 +4160,7 @@ export interface CreateHsmConfigurationMessage {
 
 export namespace CreateHsmConfigurationMessage {
   export function isa(o: any): o is CreateHsmConfigurationMessage {
-    return _smithy.isa(o, "CreateHsmConfigurationMessage");
+    return __isa(o, "CreateHsmConfigurationMessage");
   }
 }
 
@@ -4181,7 +4176,7 @@ export interface CreateHsmConfigurationResult extends $MetadataBearer {
 
 export namespace CreateHsmConfigurationResult {
   export function isa(o: any): o is CreateHsmConfigurationResult {
-    return _smithy.isa(o, "CreateHsmConfigurationResult");
+    return __isa(o, "CreateHsmConfigurationResult");
   }
 }
 
@@ -4239,7 +4234,7 @@ export interface CreateScheduledActionMessage {
 
 export namespace CreateScheduledActionMessage {
   export function isa(o: any): o is CreateScheduledActionMessage {
-    return _smithy.isa(o, "CreateScheduledActionMessage");
+    return __isa(o, "CreateScheduledActionMessage");
   }
 }
 
@@ -4286,7 +4281,7 @@ export interface CreateSnapshotCopyGrantMessage {
 
 export namespace CreateSnapshotCopyGrantMessage {
   export function isa(o: any): o is CreateSnapshotCopyGrantMessage {
-    return _smithy.isa(o, "CreateSnapshotCopyGrantMessage");
+    return __isa(o, "CreateSnapshotCopyGrantMessage");
   }
 }
 
@@ -4307,7 +4302,7 @@ export interface CreateSnapshotCopyGrantResult extends $MetadataBearer {
 
 export namespace CreateSnapshotCopyGrantResult {
   export function isa(o: any): o is CreateSnapshotCopyGrantResult {
-    return _smithy.isa(o, "CreateSnapshotCopyGrantResult");
+    return __isa(o, "CreateSnapshotCopyGrantResult");
   }
 }
 
@@ -4348,7 +4343,7 @@ export interface CreateSnapshotScheduleMessage {
 
 export namespace CreateSnapshotScheduleMessage {
   export function isa(o: any): o is CreateSnapshotScheduleMessage {
-    return _smithy.isa(o, "CreateSnapshotScheduleMessage");
+    return __isa(o, "CreateSnapshotScheduleMessage");
   }
 }
 
@@ -4376,7 +4371,7 @@ export interface CreateTagsMessage {
 
 export namespace CreateTagsMessage {
   export function isa(o: any): o is CreateTagsMessage {
-    return _smithy.isa(o, "CreateTagsMessage");
+    return __isa(o, "CreateTagsMessage");
   }
 }
 
@@ -4395,7 +4390,7 @@ export interface CustomerStorageMessage extends $MetadataBearer {
 
 export namespace CustomerStorageMessage {
   export function isa(o: any): o is CustomerStorageMessage {
-    return _smithy.isa(o, "CustomerStorageMessage");
+    return __isa(o, "CustomerStorageMessage");
   }
 }
 
@@ -4439,7 +4434,7 @@ export interface DataTransferProgress {
 
 export namespace DataTransferProgress {
   export function isa(o: any): o is DataTransferProgress {
-    return _smithy.isa(o, "DataTransferProgress");
+    return __isa(o, "DataTransferProgress");
   }
 }
 
@@ -4471,7 +4466,7 @@ export interface DefaultClusterParameters {
 
 export namespace DefaultClusterParameters {
   export function isa(o: any): o is DefaultClusterParameters {
-    return _smithy.isa(o, "DefaultClusterParameters");
+    return __isa(o, "DefaultClusterParameters");
   }
 }
 
@@ -4498,7 +4493,7 @@ export interface DeferredMaintenanceWindow {
 
 export namespace DeferredMaintenanceWindow {
   export function isa(o: any): o is DeferredMaintenanceWindow {
-    return _smithy.isa(o, "DeferredMaintenanceWindow");
+    return __isa(o, "DeferredMaintenanceWindow");
   }
 }
 
@@ -4572,7 +4567,7 @@ export interface DeleteClusterMessage {
 
 export namespace DeleteClusterMessage {
   export function isa(o: any): o is DeleteClusterMessage {
-    return _smithy.isa(o, "DeleteClusterMessage");
+    return __isa(o, "DeleteClusterMessage");
   }
 }
 
@@ -4598,7 +4593,7 @@ export interface DeleteClusterParameterGroupMessage {
 
 export namespace DeleteClusterParameterGroupMessage {
   export function isa(o: any): o is DeleteClusterParameterGroupMessage {
-    return _smithy.isa(o, "DeleteClusterParameterGroupMessage");
+    return __isa(o, "DeleteClusterParameterGroupMessage");
   }
 }
 
@@ -4612,7 +4607,7 @@ export interface DeleteClusterResult extends $MetadataBearer {
 
 export namespace DeleteClusterResult {
   export function isa(o: any): o is DeleteClusterResult {
-    return _smithy.isa(o, "DeleteClusterResult");
+    return __isa(o, "DeleteClusterResult");
   }
 }
 
@@ -4629,7 +4624,7 @@ export interface DeleteClusterSecurityGroupMessage {
 
 export namespace DeleteClusterSecurityGroupMessage {
   export function isa(o: any): o is DeleteClusterSecurityGroupMessage {
-    return _smithy.isa(o, "DeleteClusterSecurityGroupMessage");
+    return __isa(o, "DeleteClusterSecurityGroupMessage");
   }
 }
 
@@ -4657,7 +4652,7 @@ export interface DeleteClusterSnapshotMessage {
 
 export namespace DeleteClusterSnapshotMessage {
   export function isa(o: any): o is DeleteClusterSnapshotMessage {
-    return _smithy.isa(o, "DeleteClusterSnapshotMessage");
+    return __isa(o, "DeleteClusterSnapshotMessage");
   }
 }
 
@@ -4671,7 +4666,7 @@ export interface DeleteClusterSnapshotResult extends $MetadataBearer {
 
 export namespace DeleteClusterSnapshotResult {
   export function isa(o: any): o is DeleteClusterSnapshotResult {
-    return _smithy.isa(o, "DeleteClusterSnapshotResult");
+    return __isa(o, "DeleteClusterSnapshotResult");
   }
 }
 
@@ -4688,7 +4683,7 @@ export interface DeleteClusterSubnetGroupMessage {
 
 export namespace DeleteClusterSubnetGroupMessage {
   export function isa(o: any): o is DeleteClusterSubnetGroupMessage {
-    return _smithy.isa(o, "DeleteClusterSubnetGroupMessage");
+    return __isa(o, "DeleteClusterSubnetGroupMessage");
   }
 }
 
@@ -4705,7 +4700,7 @@ export interface DeleteEventSubscriptionMessage {
 
 export namespace DeleteEventSubscriptionMessage {
   export function isa(o: any): o is DeleteEventSubscriptionMessage {
-    return _smithy.isa(o, "DeleteEventSubscriptionMessage");
+    return __isa(o, "DeleteEventSubscriptionMessage");
   }
 }
 
@@ -4722,7 +4717,7 @@ export interface DeleteHsmClientCertificateMessage {
 
 export namespace DeleteHsmClientCertificateMessage {
   export function isa(o: any): o is DeleteHsmClientCertificateMessage {
-    return _smithy.isa(o, "DeleteHsmClientCertificateMessage");
+    return __isa(o, "DeleteHsmClientCertificateMessage");
   }
 }
 
@@ -4739,7 +4734,7 @@ export interface DeleteHsmConfigurationMessage {
 
 export namespace DeleteHsmConfigurationMessage {
   export function isa(o: any): o is DeleteHsmConfigurationMessage {
-    return _smithy.isa(o, "DeleteHsmConfigurationMessage");
+    return __isa(o, "DeleteHsmConfigurationMessage");
   }
 }
 
@@ -4753,7 +4748,7 @@ export interface DeleteScheduledActionMessage {
 
 export namespace DeleteScheduledActionMessage {
   export function isa(o: any): o is DeleteScheduledActionMessage {
-    return _smithy.isa(o, "DeleteScheduledActionMessage");
+    return __isa(o, "DeleteScheduledActionMessage");
   }
 }
 
@@ -4770,7 +4765,7 @@ export interface DeleteSnapshotCopyGrantMessage {
 
 export namespace DeleteSnapshotCopyGrantMessage {
   export function isa(o: any): o is DeleteSnapshotCopyGrantMessage {
-    return _smithy.isa(o, "DeleteSnapshotCopyGrantMessage");
+    return __isa(o, "DeleteSnapshotCopyGrantMessage");
   }
 }
 
@@ -4784,7 +4779,7 @@ export interface DeleteSnapshotScheduleMessage {
 
 export namespace DeleteSnapshotScheduleMessage {
   export function isa(o: any): o is DeleteSnapshotScheduleMessage {
-    return _smithy.isa(o, "DeleteSnapshotScheduleMessage");
+    return __isa(o, "DeleteSnapshotScheduleMessage");
   }
 }
 
@@ -4807,7 +4802,7 @@ export interface DeleteTagsMessage {
 
 export namespace DeleteTagsMessage {
   export function isa(o: any): o is DeleteTagsMessage {
-    return _smithy.isa(o, "DeleteTagsMessage");
+    return __isa(o, "DeleteTagsMessage");
   }
 }
 
@@ -4821,7 +4816,7 @@ export interface DescribeAccountAttributesMessage {
 
 export namespace DescribeAccountAttributesMessage {
   export function isa(o: any): o is DescribeAccountAttributesMessage {
-    return _smithy.isa(o, "DescribeAccountAttributesMessage");
+    return __isa(o, "DescribeAccountAttributesMessage");
   }
 }
 
@@ -4860,7 +4855,7 @@ export interface DescribeClusterDbRevisionsMessage {
 
 export namespace DescribeClusterDbRevisionsMessage {
   export function isa(o: any): o is DescribeClusterDbRevisionsMessage {
-    return _smithy.isa(o, "DescribeClusterDbRevisionsMessage");
+    return __isa(o, "DescribeClusterDbRevisionsMessage");
   }
 }
 
@@ -4920,7 +4915,7 @@ export interface DescribeClusterParameterGroupsMessage {
 
 export namespace DescribeClusterParameterGroupsMessage {
   export function isa(o: any): o is DescribeClusterParameterGroupsMessage {
-    return _smithy.isa(o, "DescribeClusterParameterGroupsMessage");
+    return __isa(o, "DescribeClusterParameterGroupsMessage");
   }
 }
 
@@ -4968,7 +4963,7 @@ export interface DescribeClusterParametersMessage {
 
 export namespace DescribeClusterParametersMessage {
   export function isa(o: any): o is DescribeClusterParametersMessage {
-    return _smithy.isa(o, "DescribeClusterParametersMessage");
+    return __isa(o, "DescribeClusterParametersMessage");
   }
 }
 
@@ -5030,7 +5025,7 @@ export interface DescribeClusterSecurityGroupsMessage {
 
 export namespace DescribeClusterSecurityGroupsMessage {
   export function isa(o: any): o is DescribeClusterSecurityGroupsMessage {
-    return _smithy.isa(o, "DescribeClusterSecurityGroupsMessage");
+    return __isa(o, "DescribeClusterSecurityGroupsMessage");
   }
 }
 
@@ -5164,7 +5159,7 @@ export interface DescribeClusterSnapshotsMessage {
 
 export namespace DescribeClusterSnapshotsMessage {
   export function isa(o: any): o is DescribeClusterSnapshotsMessage {
-    return _smithy.isa(o, "DescribeClusterSnapshotsMessage");
+    return __isa(o, "DescribeClusterSnapshotsMessage");
   }
 }
 
@@ -5222,7 +5217,7 @@ export interface DescribeClusterSubnetGroupsMessage {
 
 export namespace DescribeClusterSubnetGroupsMessage {
   export function isa(o: any): o is DescribeClusterSubnetGroupsMessage {
-    return _smithy.isa(o, "DescribeClusterSubnetGroupsMessage");
+    return __isa(o, "DescribeClusterSubnetGroupsMessage");
   }
 }
 
@@ -5251,7 +5246,7 @@ export interface DescribeClusterTracksMessage {
 
 export namespace DescribeClusterTracksMessage {
   export function isa(o: any): o is DescribeClusterTracksMessage {
-    return _smithy.isa(o, "DescribeClusterTracksMessage");
+    return __isa(o, "DescribeClusterTracksMessage");
   }
 }
 
@@ -5309,7 +5304,7 @@ export interface DescribeClusterVersionsMessage {
 
 export namespace DescribeClusterVersionsMessage {
   export function isa(o: any): o is DescribeClusterVersionsMessage {
-    return _smithy.isa(o, "DescribeClusterVersionsMessage");
+    return __isa(o, "DescribeClusterVersionsMessage");
   }
 }
 
@@ -5369,7 +5364,7 @@ export interface DescribeClustersMessage {
 
 export namespace DescribeClustersMessage {
   export function isa(o: any): o is DescribeClustersMessage {
-    return _smithy.isa(o, "DescribeClustersMessage");
+    return __isa(o, "DescribeClustersMessage");
   }
 }
 
@@ -5407,7 +5402,7 @@ export interface DescribeDefaultClusterParametersMessage {
 
 export namespace DescribeDefaultClusterParametersMessage {
   export function isa(o: any): o is DescribeDefaultClusterParametersMessage {
-    return _smithy.isa(o, "DescribeDefaultClusterParametersMessage");
+    return __isa(o, "DescribeDefaultClusterParametersMessage");
   }
 }
 
@@ -5422,7 +5417,7 @@ export interface DescribeDefaultClusterParametersResult
 
 export namespace DescribeDefaultClusterParametersResult {
   export function isa(o: any): o is DescribeDefaultClusterParametersResult {
-    return _smithy.isa(o, "DescribeDefaultClusterParametersResult");
+    return __isa(o, "DescribeDefaultClusterParametersResult");
   }
 }
 
@@ -5441,7 +5436,7 @@ export interface DescribeEventCategoriesMessage {
 
 export namespace DescribeEventCategoriesMessage {
   export function isa(o: any): o is DescribeEventCategoriesMessage {
-    return _smithy.isa(o, "DescribeEventCategoriesMessage");
+    return __isa(o, "DescribeEventCategoriesMessage");
   }
 }
 
@@ -5500,7 +5495,7 @@ export interface DescribeEventSubscriptionsMessage {
 
 export namespace DescribeEventSubscriptionsMessage {
   export function isa(o: any): o is DescribeEventSubscriptionsMessage {
-    return _smithy.isa(o, "DescribeEventSubscriptionsMessage");
+    return __isa(o, "DescribeEventSubscriptionsMessage");
   }
 }
 
@@ -5617,7 +5612,7 @@ export interface DescribeEventsMessage {
 
 export namespace DescribeEventsMessage {
   export function isa(o: any): o is DescribeEventsMessage {
-    return _smithy.isa(o, "DescribeEventsMessage");
+    return __isa(o, "DescribeEventsMessage");
   }
 }
 
@@ -5677,7 +5672,7 @@ export interface DescribeHsmClientCertificatesMessage {
 
 export namespace DescribeHsmClientCertificatesMessage {
   export function isa(o: any): o is DescribeHsmClientCertificatesMessage {
-    return _smithy.isa(o, "DescribeHsmClientCertificatesMessage");
+    return __isa(o, "DescribeHsmClientCertificatesMessage");
   }
 }
 
@@ -5737,7 +5732,7 @@ export interface DescribeHsmConfigurationsMessage {
 
 export namespace DescribeHsmConfigurationsMessage {
   export function isa(o: any): o is DescribeHsmConfigurationsMessage {
-    return _smithy.isa(o, "DescribeHsmConfigurationsMessage");
+    return __isa(o, "DescribeHsmConfigurationsMessage");
   }
 }
 
@@ -5756,7 +5751,7 @@ export interface DescribeLoggingStatusMessage {
 
 export namespace DescribeLoggingStatusMessage {
   export function isa(o: any): o is DescribeLoggingStatusMessage {
-    return _smithy.isa(o, "DescribeLoggingStatusMessage");
+    return __isa(o, "DescribeLoggingStatusMessage");
   }
 }
 
@@ -5816,7 +5811,7 @@ export interface DescribeNodeConfigurationOptionsMessage {
 
 export namespace DescribeNodeConfigurationOptionsMessage {
   export function isa(o: any): o is DescribeNodeConfigurationOptionsMessage {
-    return _smithy.isa(o, "DescribeNodeConfigurationOptionsMessage");
+    return __isa(o, "DescribeNodeConfigurationOptionsMessage");
   }
 }
 
@@ -5863,7 +5858,7 @@ export interface DescribeOrderableClusterOptionsMessage {
 
 export namespace DescribeOrderableClusterOptionsMessage {
   export function isa(o: any): o is DescribeOrderableClusterOptionsMessage {
-    return _smithy.isa(o, "DescribeOrderableClusterOptionsMessage");
+    return __isa(o, "DescribeOrderableClusterOptionsMessage");
   }
 }
 
@@ -5901,7 +5896,7 @@ export interface DescribeReservedNodeOfferingsMessage {
 
 export namespace DescribeReservedNodeOfferingsMessage {
   export function isa(o: any): o is DescribeReservedNodeOfferingsMessage {
-    return _smithy.isa(o, "DescribeReservedNodeOfferingsMessage");
+    return __isa(o, "DescribeReservedNodeOfferingsMessage");
   }
 }
 
@@ -5939,7 +5934,7 @@ export interface DescribeReservedNodesMessage {
 
 export namespace DescribeReservedNodesMessage {
   export function isa(o: any): o is DescribeReservedNodesMessage {
-    return _smithy.isa(o, "DescribeReservedNodesMessage");
+    return __isa(o, "DescribeReservedNodesMessage");
   }
 }
 
@@ -5959,7 +5954,7 @@ export interface DescribeResizeMessage {
 
 export namespace DescribeResizeMessage {
   export function isa(o: any): o is DescribeResizeMessage {
-    return _smithy.isa(o, "DescribeResizeMessage");
+    return __isa(o, "DescribeResizeMessage");
   }
 }
 
@@ -6022,7 +6017,7 @@ export interface DescribeScheduledActionsMessage {
 
 export namespace DescribeScheduledActionsMessage {
   export function isa(o: any): o is DescribeScheduledActionsMessage {
-    return _smithy.isa(o, "DescribeScheduledActionsMessage");
+    return __isa(o, "DescribeScheduledActionsMessage");
   }
 }
 
@@ -6079,7 +6074,7 @@ export interface DescribeSnapshotCopyGrantsMessage {
 
 export namespace DescribeSnapshotCopyGrantsMessage {
   export function isa(o: any): o is DescribeSnapshotCopyGrantsMessage {
-    return _smithy.isa(o, "DescribeSnapshotCopyGrantsMessage");
+    return __isa(o, "DescribeSnapshotCopyGrantsMessage");
   }
 }
 
@@ -6127,7 +6122,7 @@ export interface DescribeSnapshotSchedulesMessage {
 
 export namespace DescribeSnapshotSchedulesMessage {
   export function isa(o: any): o is DescribeSnapshotSchedulesMessage {
-    return _smithy.isa(o, "DescribeSnapshotSchedulesMessage");
+    return __isa(o, "DescribeSnapshotSchedulesMessage");
   }
 }
 
@@ -6151,7 +6146,7 @@ export interface DescribeSnapshotSchedulesOutputMessage
 
 export namespace DescribeSnapshotSchedulesOutputMessage {
   export function isa(o: any): o is DescribeSnapshotSchedulesOutputMessage {
-    return _smithy.isa(o, "DescribeSnapshotSchedulesOutputMessage");
+    return __isa(o, "DescribeSnapshotSchedulesOutputMessage");
   }
 }
 
@@ -6191,7 +6186,7 @@ export interface DescribeTableRestoreStatusMessage {
 
 export namespace DescribeTableRestoreStatusMessage {
   export function isa(o: any): o is DescribeTableRestoreStatusMessage {
-    return _smithy.isa(o, "DescribeTableRestoreStatusMessage");
+    return __isa(o, "DescribeTableRestoreStatusMessage");
   }
 }
 
@@ -6285,7 +6280,7 @@ export interface DescribeTagsMessage {
 
 export namespace DescribeTagsMessage {
   export function isa(o: any): o is DescribeTagsMessage {
-    return _smithy.isa(o, "DescribeTagsMessage");
+    return __isa(o, "DescribeTagsMessage");
   }
 }
 
@@ -6304,7 +6299,7 @@ export interface DisableLoggingMessage {
 
 export namespace DisableLoggingMessage {
   export function isa(o: any): o is DisableLoggingMessage {
-    return _smithy.isa(o, "DisableLoggingMessage");
+    return __isa(o, "DisableLoggingMessage");
   }
 }
 
@@ -6324,7 +6319,7 @@ export interface DisableSnapshotCopyMessage {
 
 export namespace DisableSnapshotCopyMessage {
   export function isa(o: any): o is DisableSnapshotCopyMessage {
-    return _smithy.isa(o, "DisableSnapshotCopyMessage");
+    return __isa(o, "DisableSnapshotCopyMessage");
   }
 }
 
@@ -6338,7 +6333,7 @@ export interface DisableSnapshotCopyResult extends $MetadataBearer {
 
 export namespace DisableSnapshotCopyResult {
   export function isa(o: any): o is DisableSnapshotCopyResult {
-    return _smithy.isa(o, "DisableSnapshotCopyResult");
+    return __isa(o, "DisableSnapshotCopyResult");
   }
 }
 
@@ -6371,7 +6366,7 @@ export interface EC2SecurityGroup {
 
 export namespace EC2SecurityGroup {
   export function isa(o: any): o is EC2SecurityGroup {
-    return _smithy.isa(o, "EC2SecurityGroup");
+    return __isa(o, "EC2SecurityGroup");
   }
 }
 
@@ -6393,7 +6388,7 @@ export interface ElasticIpStatus {
 
 export namespace ElasticIpStatus {
   export function isa(o: any): o is ElasticIpStatus {
-    return _smithy.isa(o, "ElasticIpStatus");
+    return __isa(o, "ElasticIpStatus");
   }
 }
 
@@ -6458,7 +6453,7 @@ export interface EnableLoggingMessage {
 
 export namespace EnableLoggingMessage {
   export function isa(o: any): o is EnableLoggingMessage {
-    return _smithy.isa(o, "EnableLoggingMessage");
+    return __isa(o, "EnableLoggingMessage");
   }
 }
 
@@ -6507,7 +6502,7 @@ export interface EnableSnapshotCopyMessage {
 
 export namespace EnableSnapshotCopyMessage {
   export function isa(o: any): o is EnableSnapshotCopyMessage {
-    return _smithy.isa(o, "EnableSnapshotCopyMessage");
+    return __isa(o, "EnableSnapshotCopyMessage");
   }
 }
 
@@ -6521,7 +6516,7 @@ export interface EnableSnapshotCopyResult extends $MetadataBearer {
 
 export namespace EnableSnapshotCopyResult {
   export function isa(o: any): o is EnableSnapshotCopyResult {
-    return _smithy.isa(o, "EnableSnapshotCopyResult");
+    return __isa(o, "EnableSnapshotCopyResult");
   }
 }
 
@@ -6543,7 +6538,7 @@ export interface Endpoint {
 
 export namespace Endpoint {
   export function isa(o: any): o is Endpoint {
-    return _smithy.isa(o, "Endpoint");
+    return __isa(o, "Endpoint");
   }
 }
 
@@ -6592,7 +6587,7 @@ export interface Event {
 
 export namespace Event {
   export function isa(o: any): o is Event {
-    return _smithy.isa(o, "Event");
+    return __isa(o, "Event");
   }
 }
 
@@ -6615,7 +6610,7 @@ export interface EventCategoriesMap {
 
 export namespace EventCategoriesMap {
   export function isa(o: any): o is EventCategoriesMap {
-    return _smithy.isa(o, "EventCategoriesMap");
+    return __isa(o, "EventCategoriesMap");
   }
 }
 
@@ -6632,7 +6627,7 @@ export interface EventCategoriesMessage extends $MetadataBearer {
 
 export namespace EventCategoriesMessage {
   export function isa(o: any): o is EventCategoriesMessage {
-    return _smithy.isa(o, "EventCategoriesMessage");
+    return __isa(o, "EventCategoriesMessage");
   }
 }
 
@@ -6665,7 +6660,7 @@ export interface EventInfoMap {
 
 export namespace EventInfoMap {
   export function isa(o: any): o is EventInfoMap {
-    return _smithy.isa(o, "EventInfoMap");
+    return __isa(o, "EventInfoMap");
   }
 }
 
@@ -6755,7 +6750,7 @@ export interface EventSubscription {
 
 export namespace EventSubscription {
   export function isa(o: any): o is EventSubscription {
-    return _smithy.isa(o, "EventSubscription");
+    return __isa(o, "EventSubscription");
   }
 }
 
@@ -6781,7 +6776,7 @@ export interface EventSubscriptionsMessage extends $MetadataBearer {
 
 export namespace EventSubscriptionsMessage {
   export function isa(o: any): o is EventSubscriptionsMessage {
-    return _smithy.isa(o, "EventSubscriptionsMessage");
+    return __isa(o, "EventSubscriptionsMessage");
   }
 }
 
@@ -6807,7 +6802,7 @@ export interface EventsMessage extends $MetadataBearer {
 
 export namespace EventsMessage {
   export function isa(o: any): o is EventsMessage {
-    return _smithy.isa(o, "EventsMessage");
+    return __isa(o, "EventsMessage");
   }
 }
 
@@ -6928,7 +6923,7 @@ export interface GetClusterCredentialsMessage {
 
 export namespace GetClusterCredentialsMessage {
   export function isa(o: any): o is GetClusterCredentialsMessage {
-    return _smithy.isa(o, "GetClusterCredentialsMessage");
+    return __isa(o, "GetClusterCredentialsMessage");
   }
 }
 
@@ -6960,7 +6955,7 @@ export namespace GetReservedNodeExchangeOfferingsInputMessage {
   export function isa(
     o: any
   ): o is GetReservedNodeExchangeOfferingsInputMessage {
-    return _smithy.isa(o, "GetReservedNodeExchangeOfferingsInputMessage");
+    return __isa(o, "GetReservedNodeExchangeOfferingsInputMessage");
   }
 }
 
@@ -6987,7 +6982,7 @@ export namespace GetReservedNodeExchangeOfferingsOutputMessage {
   export function isa(
     o: any
   ): o is GetReservedNodeExchangeOfferingsOutputMessage {
-    return _smithy.isa(o, "GetReservedNodeExchangeOfferingsOutputMessage");
+    return __isa(o, "GetReservedNodeExchangeOfferingsOutputMessage");
   }
 }
 
@@ -7017,7 +7012,7 @@ export interface HsmClientCertificate {
 
 export namespace HsmClientCertificate {
   export function isa(o: any): o is HsmClientCertificate {
-    return _smithy.isa(o, "HsmClientCertificate");
+    return __isa(o, "HsmClientCertificate");
   }
 }
 
@@ -7044,7 +7039,7 @@ export interface HsmClientCertificateMessage extends $MetadataBearer {
 
 export namespace HsmClientCertificateMessage {
   export function isa(o: any): o is HsmClientCertificateMessage {
-    return _smithy.isa(o, "HsmClientCertificateMessage");
+    return __isa(o, "HsmClientCertificateMessage");
   }
 }
 
@@ -7084,7 +7079,7 @@ export interface HsmConfiguration {
 
 export namespace HsmConfiguration {
   export function isa(o: any): o is HsmConfiguration {
-    return _smithy.isa(o, "HsmConfiguration");
+    return __isa(o, "HsmConfiguration");
   }
 }
 
@@ -7110,7 +7105,7 @@ export interface HsmConfigurationMessage extends $MetadataBearer {
 
 export namespace HsmConfigurationMessage {
   export function isa(o: any): o is HsmConfigurationMessage {
-    return _smithy.isa(o, "HsmConfigurationMessage");
+    return __isa(o, "HsmConfigurationMessage");
   }
 }
 
@@ -7141,7 +7136,7 @@ export interface HsmStatus {
 
 export namespace HsmStatus {
   export function isa(o: any): o is HsmStatus {
-    return _smithy.isa(o, "HsmStatus");
+    return __isa(o, "HsmStatus");
   }
 }
 
@@ -7168,7 +7163,7 @@ export interface IPRange {
 
 export namespace IPRange {
   export function isa(o: any): o is IPRange {
-    return _smithy.isa(o, "IPRange");
+    return __isa(o, "IPRange");
   }
 }
 
@@ -7211,7 +7206,7 @@ export interface LoggingStatus extends $MetadataBearer {
 
 export namespace LoggingStatus {
   export function isa(o: any): o is LoggingStatus {
-    return _smithy.isa(o, "LoggingStatus");
+    return __isa(o, "LoggingStatus");
   }
 }
 
@@ -7244,7 +7239,7 @@ export interface MaintenanceTrack {
 
 export namespace MaintenanceTrack {
   export function isa(o: any): o is MaintenanceTrack {
-    return _smithy.isa(o, "MaintenanceTrack");
+    return __isa(o, "MaintenanceTrack");
   }
 }
 
@@ -7271,7 +7266,7 @@ export interface ModifyClusterDbRevisionMessage {
 
 export namespace ModifyClusterDbRevisionMessage {
   export function isa(o: any): o is ModifyClusterDbRevisionMessage {
-    return _smithy.isa(o, "ModifyClusterDbRevisionMessage");
+    return __isa(o, "ModifyClusterDbRevisionMessage");
   }
 }
 
@@ -7285,7 +7280,7 @@ export interface ModifyClusterDbRevisionResult extends $MetadataBearer {
 
 export namespace ModifyClusterDbRevisionResult {
   export function isa(o: any): o is ModifyClusterDbRevisionResult {
-    return _smithy.isa(o, "ModifyClusterDbRevisionResult");
+    return __isa(o, "ModifyClusterDbRevisionResult");
   }
 }
 
@@ -7316,7 +7311,7 @@ export interface ModifyClusterIamRolesMessage {
 
 export namespace ModifyClusterIamRolesMessage {
   export function isa(o: any): o is ModifyClusterIamRolesMessage {
-    return _smithy.isa(o, "ModifyClusterIamRolesMessage");
+    return __isa(o, "ModifyClusterIamRolesMessage");
   }
 }
 
@@ -7330,7 +7325,7 @@ export interface ModifyClusterIamRolesResult extends $MetadataBearer {
 
 export namespace ModifyClusterIamRolesResult {
   export function isa(o: any): o is ModifyClusterIamRolesResult {
-    return _smithy.isa(o, "ModifyClusterIamRolesResult");
+    return __isa(o, "ModifyClusterIamRolesResult");
   }
 }
 
@@ -7371,7 +7366,7 @@ export interface ModifyClusterMaintenanceMessage {
 
 export namespace ModifyClusterMaintenanceMessage {
   export function isa(o: any): o is ModifyClusterMaintenanceMessage {
-    return _smithy.isa(o, "ModifyClusterMaintenanceMessage");
+    return __isa(o, "ModifyClusterMaintenanceMessage");
   }
 }
 
@@ -7385,7 +7380,7 @@ export interface ModifyClusterMaintenanceResult extends $MetadataBearer {
 
 export namespace ModifyClusterMaintenanceResult {
   export function isa(o: any): o is ModifyClusterMaintenanceResult {
-    return _smithy.isa(o, "ModifyClusterMaintenanceResult");
+    return __isa(o, "ModifyClusterMaintenanceResult");
   }
 }
 
@@ -7658,7 +7653,7 @@ export interface ModifyClusterMessage {
 
 export namespace ModifyClusterMessage {
   export function isa(o: any): o is ModifyClusterMessage {
-    return _smithy.isa(o, "ModifyClusterMessage");
+    return __isa(o, "ModifyClusterMessage");
   }
 }
 
@@ -7685,7 +7680,7 @@ export interface ModifyClusterParameterGroupMessage {
 
 export namespace ModifyClusterParameterGroupMessage {
   export function isa(o: any): o is ModifyClusterParameterGroupMessage {
-    return _smithy.isa(o, "ModifyClusterParameterGroupMessage");
+    return __isa(o, "ModifyClusterParameterGroupMessage");
   }
 }
 
@@ -7699,7 +7694,7 @@ export interface ModifyClusterResult extends $MetadataBearer {
 
 export namespace ModifyClusterResult {
   export function isa(o: any): o is ModifyClusterResult {
-    return _smithy.isa(o, "ModifyClusterResult");
+    return __isa(o, "ModifyClusterResult");
   }
 }
 
@@ -7728,7 +7723,7 @@ export interface ModifyClusterSnapshotMessage {
 
 export namespace ModifyClusterSnapshotMessage {
   export function isa(o: any): o is ModifyClusterSnapshotMessage {
-    return _smithy.isa(o, "ModifyClusterSnapshotMessage");
+    return __isa(o, "ModifyClusterSnapshotMessage");
   }
 }
 
@@ -7742,7 +7737,7 @@ export interface ModifyClusterSnapshotResult extends $MetadataBearer {
 
 export namespace ModifyClusterSnapshotResult {
   export function isa(o: any): o is ModifyClusterSnapshotResult {
-    return _smithy.isa(o, "ModifyClusterSnapshotResult");
+    return __isa(o, "ModifyClusterSnapshotResult");
   }
 }
 
@@ -7769,7 +7764,7 @@ export interface ModifyClusterSnapshotScheduleMessage {
 
 export namespace ModifyClusterSnapshotScheduleMessage {
   export function isa(o: any): o is ModifyClusterSnapshotScheduleMessage {
-    return _smithy.isa(o, "ModifyClusterSnapshotScheduleMessage");
+    return __isa(o, "ModifyClusterSnapshotScheduleMessage");
   }
 }
 
@@ -7797,7 +7792,7 @@ export interface ModifyClusterSubnetGroupMessage {
 
 export namespace ModifyClusterSubnetGroupMessage {
   export function isa(o: any): o is ModifyClusterSubnetGroupMessage {
-    return _smithy.isa(o, "ModifyClusterSubnetGroupMessage");
+    return __isa(o, "ModifyClusterSubnetGroupMessage");
   }
 }
 
@@ -7811,7 +7806,7 @@ export interface ModifyClusterSubnetGroupResult extends $MetadataBearer {
 
 export namespace ModifyClusterSubnetGroupResult {
   export function isa(o: any): o is ModifyClusterSubnetGroupResult {
-    return _smithy.isa(o, "ModifyClusterSubnetGroupResult");
+    return __isa(o, "ModifyClusterSubnetGroupResult");
   }
 }
 
@@ -7874,7 +7869,7 @@ export interface ModifyEventSubscriptionMessage {
 
 export namespace ModifyEventSubscriptionMessage {
   export function isa(o: any): o is ModifyEventSubscriptionMessage {
-    return _smithy.isa(o, "ModifyEventSubscriptionMessage");
+    return __isa(o, "ModifyEventSubscriptionMessage");
   }
 }
 
@@ -7888,7 +7883,7 @@ export interface ModifyEventSubscriptionResult extends $MetadataBearer {
 
 export namespace ModifyEventSubscriptionResult {
   export function isa(o: any): o is ModifyEventSubscriptionResult {
-    return _smithy.isa(o, "ModifyEventSubscriptionResult");
+    return __isa(o, "ModifyEventSubscriptionResult");
   }
 }
 
@@ -7942,7 +7937,7 @@ export interface ModifyScheduledActionMessage {
 
 export namespace ModifyScheduledActionMessage {
   export function isa(o: any): o is ModifyScheduledActionMessage {
-    return _smithy.isa(o, "ModifyScheduledActionMessage");
+    return __isa(o, "ModifyScheduledActionMessage");
   }
 }
 
@@ -7987,7 +7982,7 @@ export interface ModifySnapshotCopyRetentionPeriodMessage {
 
 export namespace ModifySnapshotCopyRetentionPeriodMessage {
   export function isa(o: any): o is ModifySnapshotCopyRetentionPeriodMessage {
-    return _smithy.isa(o, "ModifySnapshotCopyRetentionPeriodMessage");
+    return __isa(o, "ModifySnapshotCopyRetentionPeriodMessage");
   }
 }
 
@@ -8002,7 +7997,7 @@ export interface ModifySnapshotCopyRetentionPeriodResult
 
 export namespace ModifySnapshotCopyRetentionPeriodResult {
   export function isa(o: any): o is ModifySnapshotCopyRetentionPeriodResult {
-    return _smithy.isa(o, "ModifySnapshotCopyRetentionPeriodResult");
+    return __isa(o, "ModifySnapshotCopyRetentionPeriodResult");
   }
 }
 
@@ -8022,7 +8017,7 @@ export interface ModifySnapshotScheduleMessage {
 
 export namespace ModifySnapshotScheduleMessage {
   export function isa(o: any): o is ModifySnapshotScheduleMessage {
-    return _smithy.isa(o, "ModifySnapshotScheduleMessage");
+    return __isa(o, "ModifySnapshotScheduleMessage");
   }
 }
 
@@ -8054,7 +8049,7 @@ export interface NodeConfigurationOption {
 
 export namespace NodeConfigurationOption {
   export function isa(o: any): o is NodeConfigurationOption {
-    return _smithy.isa(o, "NodeConfigurationOption");
+    return __isa(o, "NodeConfigurationOption");
   }
 }
 
@@ -8088,7 +8083,7 @@ export interface NodeConfigurationOptionsFilter {
 
 export namespace NodeConfigurationOptionsFilter {
   export function isa(o: any): o is NodeConfigurationOptionsFilter {
-    return _smithy.isa(o, "NodeConfigurationOptionsFilter");
+    return __isa(o, "NodeConfigurationOptionsFilter");
   }
 }
 
@@ -8118,7 +8113,7 @@ export interface NodeConfigurationOptionsMessage extends $MetadataBearer {
 
 export namespace NodeConfigurationOptionsMessage {
   export function isa(o: any): o is NodeConfigurationOptionsMessage {
-    return _smithy.isa(o, "NodeConfigurationOptionsMessage");
+    return __isa(o, "NodeConfigurationOptionsMessage");
   }
 }
 
@@ -8160,7 +8155,7 @@ export interface OrderableClusterOption {
 
 export namespace OrderableClusterOption {
   export function isa(o: any): o is OrderableClusterOption {
-    return _smithy.isa(o, "OrderableClusterOption");
+    return __isa(o, "OrderableClusterOption");
   }
 }
 
@@ -8188,7 +8183,7 @@ export interface OrderableClusterOptionsMessage extends $MetadataBearer {
 
 export namespace OrderableClusterOptionsMessage {
   export function isa(o: any): o is OrderableClusterOptionsMessage {
-    return _smithy.isa(o, "OrderableClusterOptionsMessage");
+    return __isa(o, "OrderableClusterOptionsMessage");
   }
 }
 
@@ -8251,7 +8246,7 @@ export interface Parameter {
 
 export namespace Parameter {
   export function isa(o: any): o is Parameter {
-    return _smithy.isa(o, "Parameter");
+    return __isa(o, "Parameter");
   }
 }
 
@@ -8331,7 +8326,7 @@ export interface PendingModifiedValues {
 
 export namespace PendingModifiedValues {
   export function isa(o: any): o is PendingModifiedValues {
-    return _smithy.isa(o, "PendingModifiedValues");
+    return __isa(o, "PendingModifiedValues");
   }
 }
 
@@ -8355,7 +8350,7 @@ export interface PurchaseReservedNodeOfferingMessage {
 
 export namespace PurchaseReservedNodeOfferingMessage {
   export function isa(o: any): o is PurchaseReservedNodeOfferingMessage {
-    return _smithy.isa(o, "PurchaseReservedNodeOfferingMessage");
+    return __isa(o, "PurchaseReservedNodeOfferingMessage");
   }
 }
 
@@ -8370,7 +8365,7 @@ export interface PurchaseReservedNodeOfferingResult extends $MetadataBearer {
 
 export namespace PurchaseReservedNodeOfferingResult {
   export function isa(o: any): o is PurchaseReservedNodeOfferingResult {
-    return _smithy.isa(o, "PurchaseReservedNodeOfferingResult");
+    return __isa(o, "PurchaseReservedNodeOfferingResult");
   }
 }
 
@@ -8387,7 +8382,7 @@ export interface RebootClusterMessage {
 
 export namespace RebootClusterMessage {
   export function isa(o: any): o is RebootClusterMessage {
-    return _smithy.isa(o, "RebootClusterMessage");
+    return __isa(o, "RebootClusterMessage");
   }
 }
 
@@ -8401,7 +8396,7 @@ export interface RebootClusterResult extends $MetadataBearer {
 
 export namespace RebootClusterResult {
   export function isa(o: any): o is RebootClusterResult {
-    return _smithy.isa(o, "RebootClusterResult");
+    return __isa(o, "RebootClusterResult");
   }
 }
 
@@ -8424,7 +8419,7 @@ export interface RecurringCharge {
 
 export namespace RecurringCharge {
   export function isa(o: any): o is RecurringCharge {
-    return _smithy.isa(o, "RecurringCharge");
+    return __isa(o, "RecurringCharge");
   }
 }
 
@@ -8525,7 +8520,7 @@ export interface ReservedNode {
 
 export namespace ReservedNode {
   export function isa(o: any): o is ReservedNode {
-    return _smithy.isa(o, "ReservedNode");
+    return __isa(o, "ReservedNode");
   }
 }
 
@@ -8587,7 +8582,7 @@ export interface ReservedNodeOffering {
 
 export namespace ReservedNodeOffering {
   export function isa(o: any): o is ReservedNodeOffering {
-    return _smithy.isa(o, "ReservedNodeOffering");
+    return __isa(o, "ReservedNodeOffering");
   }
 }
 
@@ -8615,7 +8610,7 @@ export interface ReservedNodeOfferingsMessage extends $MetadataBearer {
 
 export namespace ReservedNodeOfferingsMessage {
   export function isa(o: any): o is ReservedNodeOfferingsMessage {
-    return _smithy.isa(o, "ReservedNodeOfferingsMessage");
+    return __isa(o, "ReservedNodeOfferingsMessage");
   }
 }
 
@@ -8641,7 +8636,7 @@ export interface ReservedNodesMessage extends $MetadataBearer {
 
 export namespace ReservedNodesMessage {
   export function isa(o: any): o is ReservedNodesMessage {
-    return _smithy.isa(o, "ReservedNodesMessage");
+    return __isa(o, "ReservedNodesMessage");
   }
 }
 
@@ -8674,7 +8669,7 @@ export interface ResetClusterParameterGroupMessage {
 
 export namespace ResetClusterParameterGroupMessage {
   export function isa(o: any): o is ResetClusterParameterGroupMessage {
-    return _smithy.isa(o, "ResetClusterParameterGroupMessage");
+    return __isa(o, "ResetClusterParameterGroupMessage");
   }
 }
 
@@ -8710,7 +8705,7 @@ export interface ResizeClusterMessage {
 
 export namespace ResizeClusterMessage {
   export function isa(o: any): o is ResizeClusterMessage {
-    return _smithy.isa(o, "ResizeClusterMessage");
+    return __isa(o, "ResizeClusterMessage");
   }
 }
 
@@ -8724,7 +8719,7 @@ export interface ResizeClusterResult extends $MetadataBearer {
 
 export namespace ResizeClusterResult {
   export function isa(o: any): o is ResizeClusterResult {
-    return _smithy.isa(o, "ResizeClusterResult");
+    return __isa(o, "ResizeClusterResult");
   }
 }
 
@@ -8746,7 +8741,7 @@ export interface ResizeInfo {
 
 export namespace ResizeInfo {
   export function isa(o: any): o is ResizeInfo {
-    return _smithy.isa(o, "ResizeInfo");
+    return __isa(o, "ResizeInfo");
   }
 }
 
@@ -8864,7 +8859,7 @@ export interface ResizeProgressMessage extends $MetadataBearer {
 
 export namespace ResizeProgressMessage {
   export function isa(o: any): o is ResizeProgressMessage {
-    return _smithy.isa(o, "ResizeProgressMessage");
+    return __isa(o, "ResizeProgressMessage");
   }
 }
 
@@ -9103,7 +9098,7 @@ export interface RestoreFromClusterSnapshotMessage {
 
 export namespace RestoreFromClusterSnapshotMessage {
   export function isa(o: any): o is RestoreFromClusterSnapshotMessage {
-    return _smithy.isa(o, "RestoreFromClusterSnapshotMessage");
+    return __isa(o, "RestoreFromClusterSnapshotMessage");
   }
 }
 
@@ -9117,7 +9112,7 @@ export interface RestoreFromClusterSnapshotResult extends $MetadataBearer {
 
 export namespace RestoreFromClusterSnapshotResult {
   export function isa(o: any): o is RestoreFromClusterSnapshotResult {
-    return _smithy.isa(o, "RestoreFromClusterSnapshotResult");
+    return __isa(o, "RestoreFromClusterSnapshotResult");
   }
 }
 
@@ -9169,7 +9164,7 @@ export interface RestoreStatus {
 
 export namespace RestoreStatus {
   export function isa(o: any): o is RestoreStatus {
-    return _smithy.isa(o, "RestoreStatus");
+    return __isa(o, "RestoreStatus");
   }
 }
 
@@ -9225,7 +9220,7 @@ export interface RestoreTableFromClusterSnapshotMessage {
 
 export namespace RestoreTableFromClusterSnapshotMessage {
   export function isa(o: any): o is RestoreTableFromClusterSnapshotMessage {
-    return _smithy.isa(o, "RestoreTableFromClusterSnapshotMessage");
+    return __isa(o, "RestoreTableFromClusterSnapshotMessage");
   }
 }
 
@@ -9240,7 +9235,7 @@ export interface RestoreTableFromClusterSnapshotResult extends $MetadataBearer {
 
 export namespace RestoreTableFromClusterSnapshotResult {
   export function isa(o: any): o is RestoreTableFromClusterSnapshotResult {
-    return _smithy.isa(o, "RestoreTableFromClusterSnapshotResult");
+    return __isa(o, "RestoreTableFromClusterSnapshotResult");
   }
 }
 
@@ -9269,7 +9264,7 @@ export interface RevisionTarget {
 
 export namespace RevisionTarget {
   export function isa(o: any): o is RevisionTarget {
-    return _smithy.isa(o, "RevisionTarget");
+    return __isa(o, "RevisionTarget");
   }
 }
 
@@ -9312,7 +9307,7 @@ export interface RevokeClusterSecurityGroupIngressMessage {
 
 export namespace RevokeClusterSecurityGroupIngressMessage {
   export function isa(o: any): o is RevokeClusterSecurityGroupIngressMessage {
-    return _smithy.isa(o, "RevokeClusterSecurityGroupIngressMessage");
+    return __isa(o, "RevokeClusterSecurityGroupIngressMessage");
   }
 }
 
@@ -9327,7 +9322,7 @@ export interface RevokeClusterSecurityGroupIngressResult
 
 export namespace RevokeClusterSecurityGroupIngressResult {
   export function isa(o: any): o is RevokeClusterSecurityGroupIngressResult {
-    return _smithy.isa(o, "RevokeClusterSecurityGroupIngressResult");
+    return __isa(o, "RevokeClusterSecurityGroupIngressResult");
   }
 }
 
@@ -9357,7 +9352,7 @@ export interface RevokeSnapshotAccessMessage {
 
 export namespace RevokeSnapshotAccessMessage {
   export function isa(o: any): o is RevokeSnapshotAccessMessage {
-    return _smithy.isa(o, "RevokeSnapshotAccessMessage");
+    return __isa(o, "RevokeSnapshotAccessMessage");
   }
 }
 
@@ -9371,7 +9366,7 @@ export interface RevokeSnapshotAccessResult extends $MetadataBearer {
 
 export namespace RevokeSnapshotAccessResult {
   export function isa(o: any): o is RevokeSnapshotAccessResult {
-    return _smithy.isa(o, "RevokeSnapshotAccessResult");
+    return __isa(o, "RevokeSnapshotAccessResult");
   }
 }
 
@@ -9391,7 +9386,7 @@ export interface RotateEncryptionKeyMessage {
 
 export namespace RotateEncryptionKeyMessage {
   export function isa(o: any): o is RotateEncryptionKeyMessage {
-    return _smithy.isa(o, "RotateEncryptionKeyMessage");
+    return __isa(o, "RotateEncryptionKeyMessage");
   }
 }
 
@@ -9405,7 +9400,7 @@ export interface RotateEncryptionKeyResult extends $MetadataBearer {
 
 export namespace RotateEncryptionKeyResult {
   export function isa(o: any): o is RotateEncryptionKeyResult {
-    return _smithy.isa(o, "RotateEncryptionKeyResult");
+    return __isa(o, "RotateEncryptionKeyResult");
   }
 }
 
@@ -9479,7 +9474,7 @@ export interface ScheduledAction extends $MetadataBearer {
 
 export namespace ScheduledAction {
   export function isa(o: any): o is ScheduledAction {
-    return _smithy.isa(o, "ScheduledAction");
+    return __isa(o, "ScheduledAction");
   }
 }
 
@@ -9501,7 +9496,7 @@ export interface ScheduledActionFilter {
 
 export namespace ScheduledActionFilter {
   export function isa(o: any): o is ScheduledActionFilter {
-    return _smithy.isa(o, "ScheduledActionFilter");
+    return __isa(o, "ScheduledActionFilter");
   }
 }
 
@@ -9528,7 +9523,7 @@ export interface ScheduledActionType {
 
 export namespace ScheduledActionType {
   export function isa(o: any): o is ScheduledActionType {
-    return _smithy.isa(o, "ScheduledActionType");
+    return __isa(o, "ScheduledActionType");
   }
 }
 
@@ -9556,7 +9551,7 @@ export interface ScheduledActionsMessage extends $MetadataBearer {
 
 export namespace ScheduledActionsMessage {
   export function isa(o: any): o is ScheduledActionsMessage {
-    return _smithy.isa(o, "ScheduledActionsMessage");
+    return __isa(o, "ScheduledActionsMessage");
   }
 }
 
@@ -9772,7 +9767,7 @@ export interface Snapshot {
 
 export namespace Snapshot {
   export function isa(o: any): o is Snapshot {
-    return _smithy.isa(o, "Snapshot");
+    return __isa(o, "Snapshot");
   }
 }
 
@@ -9813,7 +9808,7 @@ export interface SnapshotCopyGrant {
 
 export namespace SnapshotCopyGrant {
   export function isa(o: any): o is SnapshotCopyGrant {
-    return _smithy.isa(o, "SnapshotCopyGrant");
+    return __isa(o, "SnapshotCopyGrant");
   }
 }
 
@@ -9841,7 +9836,7 @@ export interface SnapshotCopyGrantMessage extends $MetadataBearer {
 
 export namespace SnapshotCopyGrantMessage {
   export function isa(o: any): o is SnapshotCopyGrantMessage {
-    return _smithy.isa(o, "SnapshotCopyGrantMessage");
+    return __isa(o, "SnapshotCopyGrantMessage");
   }
 }
 
@@ -9873,7 +9868,7 @@ export interface SnapshotErrorMessage {
 
 export namespace SnapshotErrorMessage {
   export function isa(o: any): o is SnapshotErrorMessage {
-    return _smithy.isa(o, "SnapshotErrorMessage");
+    return __isa(o, "SnapshotErrorMessage");
   }
 }
 
@@ -9900,7 +9895,7 @@ export interface SnapshotMessage extends $MetadataBearer {
 
 export namespace SnapshotMessage {
   export function isa(o: any): o is SnapshotMessage {
-    return _smithy.isa(o, "SnapshotMessage");
+    return __isa(o, "SnapshotMessage");
   }
 }
 
@@ -9948,7 +9943,7 @@ export interface SnapshotSchedule extends $MetadataBearer {
 
 export namespace SnapshotSchedule {
   export function isa(o: any): o is SnapshotSchedule {
-    return _smithy.isa(o, "SnapshotSchedule");
+    return __isa(o, "SnapshotSchedule");
   }
 }
 
@@ -9970,7 +9965,7 @@ export interface SnapshotSortingEntity {
 
 export namespace SnapshotSortingEntity {
   export function isa(o: any): o is SnapshotSortingEntity {
-    return _smithy.isa(o, "SnapshotSortingEntity");
+    return __isa(o, "SnapshotSortingEntity");
   }
 }
 
@@ -10009,7 +10004,7 @@ export interface Subnet {
 
 export namespace Subnet {
   export function isa(o: any): o is Subnet {
-    return _smithy.isa(o, "Subnet");
+    return __isa(o, "Subnet");
   }
 }
 
@@ -10026,7 +10021,7 @@ export interface SupportedOperation {
 
 export namespace SupportedOperation {
   export function isa(o: any): o is SupportedOperation {
-    return _smithy.isa(o, "SupportedOperation");
+    return __isa(o, "SupportedOperation");
   }
 }
 
@@ -10043,7 +10038,7 @@ export interface SupportedPlatform {
 
 export namespace SupportedPlatform {
   export function isa(o: any): o is SupportedPlatform {
-    return _smithy.isa(o, "SupportedPlatform");
+    return __isa(o, "SupportedPlatform");
   }
 }
 
@@ -10133,7 +10128,7 @@ export interface TableRestoreStatus {
 
 export namespace TableRestoreStatus {
   export function isa(o: any): o is TableRestoreStatus {
-    return _smithy.isa(o, "TableRestoreStatus");
+    return __isa(o, "TableRestoreStatus");
   }
 }
 
@@ -10155,7 +10150,7 @@ export interface TableRestoreStatusMessage extends $MetadataBearer {
 
 export namespace TableRestoreStatusMessage {
   export function isa(o: any): o is TableRestoreStatusMessage {
-    return _smithy.isa(o, "TableRestoreStatusMessage");
+    return __isa(o, "TableRestoreStatusMessage");
   }
 }
 
@@ -10184,7 +10179,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -10244,7 +10239,7 @@ export interface TaggedResource {
 
 export namespace TaggedResource {
   export function isa(o: any): o is TaggedResource {
-    return _smithy.isa(o, "TaggedResource");
+    return __isa(o, "TaggedResource");
   }
 }
 
@@ -10270,7 +10265,7 @@ export interface TaggedResourceListMessage extends $MetadataBearer {
 
 export namespace TaggedResourceListMessage {
   export function isa(o: any): o is TaggedResourceListMessage {
-    return _smithy.isa(o, "TaggedResourceListMessage");
+    return __isa(o, "TaggedResourceListMessage");
   }
 }
 
@@ -10292,7 +10287,7 @@ export interface TrackListMessage extends $MetadataBearer {
 
 export namespace TrackListMessage {
   export function isa(o: any): o is TrackListMessage {
-    return _smithy.isa(o, "TrackListMessage");
+    return __isa(o, "TrackListMessage");
   }
 }
 
@@ -10319,7 +10314,7 @@ export interface UpdateTarget {
 
 export namespace UpdateTarget {
   export function isa(o: any): o is UpdateTarget {
-    return _smithy.isa(o, "UpdateTarget");
+    return __isa(o, "UpdateTarget");
   }
 }
 
@@ -10341,6 +10336,6 @@ export interface VpcSecurityGroupMembership {
 
 export namespace VpcSecurityGroupMembership {
   export function isa(o: any): o is VpcSecurityGroupMembership {
-    return _smithy.isa(o, "VpcSecurityGroupMembership");
+    return __isa(o, "VpcSecurityGroupMembership");
   }
 }

--- a/clients/client-redshift/protocols/Aws_query.ts
+++ b/clients/client-redshift/protocols/Aws_query.ts
@@ -3986,6 +3986,7 @@ export async function deserializeAws_queryCreateTagsCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_queryCreateTagsCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: CreateTagsCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -4139,6 +4140,7 @@ export async function deserializeAws_queryDeleteClusterParameterGroupCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteClusterParameterGroupCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -4199,6 +4201,7 @@ export async function deserializeAws_queryDeleteClusterSecurityGroupCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteClusterSecurityGroupCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -4327,6 +4330,7 @@ export async function deserializeAws_queryDeleteClusterSubnetGroupCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteClusterSubnetGroupCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -4394,6 +4398,7 @@ export async function deserializeAws_queryDeleteEventSubscriptionCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteEventSubscriptionCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -4454,6 +4459,7 @@ export async function deserializeAws_queryDeleteHsmClientCertificateCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteHsmClientCertificateCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -4514,6 +4520,7 @@ export async function deserializeAws_queryDeleteHsmConfigurationCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteHsmConfigurationCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -4574,6 +4581,7 @@ export async function deserializeAws_queryDeleteScheduledActionCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteScheduledActionCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -4634,6 +4642,7 @@ export async function deserializeAws_queryDeleteSnapshotCopyGrantCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteSnapshotCopyGrantCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -4694,6 +4703,7 @@ export async function deserializeAws_queryDeleteSnapshotScheduleCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteSnapshotScheduleCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -4751,6 +4761,7 @@ export async function deserializeAws_queryDeleteTagsCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_queryDeleteTagsCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteTagsCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -7648,6 +7659,7 @@ export async function deserializeAws_queryModifyClusterSnapshotScheduleCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: ModifyClusterSnapshotScheduleCommandOutput = {
     $metadata: deserializeMetadata(output)
   };

--- a/clients/client-rekognition/models/index.ts
+++ b/clients/client-rekognition/models/index.ts
@@ -1,11 +1,15 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  LazyJsonString as __LazyJsonString,
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
  * <p>You are not authorized to perform the action.</p>
  */
 export interface AccessDeniedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AccessDeniedException";
   $fault: "client";
@@ -16,7 +20,7 @@ export interface AccessDeniedException
 
 export namespace AccessDeniedException {
   export function isa(o: any): o is AccessDeniedException {
-    return _smithy.isa(o, "AccessDeniedException");
+    return __isa(o, "AccessDeniedException");
   }
 }
 
@@ -41,7 +45,7 @@ export interface AgeRange {
 
 export namespace AgeRange {
   export function isa(o: any): o is AgeRange {
-    return _smithy.isa(o, "AgeRange");
+    return __isa(o, "AgeRange");
   }
 }
 
@@ -60,7 +64,7 @@ export interface Asset {
 
 export namespace Asset {
   export function isa(o: any): o is Asset {
-    return _smithy.isa(o, "Asset");
+    return __isa(o, "Asset");
   }
 }
 
@@ -88,7 +92,7 @@ export interface Beard {
 
 export namespace Beard {
   export function isa(o: any): o is Beard {
-    return _smithy.isa(o, "Beard");
+    return __isa(o, "Beard");
   }
 }
 
@@ -137,7 +141,7 @@ export interface BoundingBox {
 
 export namespace BoundingBox {
   export function isa(o: any): o is BoundingBox {
-    return _smithy.isa(o, "BoundingBox");
+    return __isa(o, "BoundingBox");
   }
 }
 
@@ -177,7 +181,7 @@ export interface Celebrity {
 
 export namespace Celebrity {
   export function isa(o: any): o is Celebrity {
-    return _smithy.isa(o, "Celebrity");
+    return __isa(o, "Celebrity");
   }
 }
 
@@ -219,7 +223,7 @@ export interface CelebrityDetail {
 
 export namespace CelebrityDetail {
   export function isa(o: any): o is CelebrityDetail {
-    return _smithy.isa(o, "CelebrityDetail");
+    return __isa(o, "CelebrityDetail");
   }
 }
 
@@ -242,7 +246,7 @@ export interface CelebrityRecognition {
 
 export namespace CelebrityRecognition {
   export function isa(o: any): o is CelebrityRecognition {
-    return _smithy.isa(o, "CelebrityRecognition");
+    return __isa(o, "CelebrityRecognition");
   }
 }
 
@@ -273,7 +277,7 @@ export interface CompareFacesMatch {
 
 export namespace CompareFacesMatch {
   export function isa(o: any): o is CompareFacesMatch {
-    return _smithy.isa(o, "CompareFacesMatch");
+    return __isa(o, "CompareFacesMatch");
   }
 }
 
@@ -325,7 +329,7 @@ export interface CompareFacesRequest {
 
 export namespace CompareFacesRequest {
   export function isa(o: any): o is CompareFacesRequest {
-    return _smithy.isa(o, "CompareFacesRequest");
+    return __isa(o, "CompareFacesRequest");
   }
 }
 
@@ -381,7 +385,7 @@ export interface CompareFacesResponse extends $MetadataBearer {
 
 export namespace CompareFacesResponse {
   export function isa(o: any): o is CompareFacesResponse {
-    return _smithy.isa(o, "CompareFacesResponse");
+    return __isa(o, "CompareFacesResponse");
   }
 }
 
@@ -419,7 +423,7 @@ export interface ComparedFace {
 
 export namespace ComparedFace {
   export function isa(o: any): o is ComparedFace {
-    return _smithy.isa(o, "ComparedFace");
+    return __isa(o, "ComparedFace");
   }
 }
 
@@ -444,7 +448,7 @@ export interface ComparedSourceImageFace {
 
 export namespace ComparedSourceImageFace {
   export function isa(o: any): o is ComparedSourceImageFace {
-    return _smithy.isa(o, "ComparedSourceImageFace");
+    return __isa(o, "ComparedSourceImageFace");
   }
 }
 
@@ -471,7 +475,7 @@ export interface ContentModerationDetection {
 
 export namespace ContentModerationDetection {
   export function isa(o: any): o is ContentModerationDetection {
-    return _smithy.isa(o, "ContentModerationDetection");
+    return __isa(o, "ContentModerationDetection");
   }
 }
 
@@ -490,7 +494,7 @@ export interface CreateCollectionRequest {
 
 export namespace CreateCollectionRequest {
   export function isa(o: any): o is CreateCollectionRequest {
-    return _smithy.isa(o, "CreateCollectionRequest");
+    return __isa(o, "CreateCollectionRequest");
   }
 }
 
@@ -515,7 +519,7 @@ export interface CreateCollectionResponse extends $MetadataBearer {
 
 export namespace CreateCollectionResponse {
   export function isa(o: any): o is CreateCollectionResponse {
-    return _smithy.isa(o, "CreateCollectionResponse");
+    return __isa(o, "CreateCollectionResponse");
   }
 }
 
@@ -529,7 +533,7 @@ export interface CreateProjectRequest {
 
 export namespace CreateProjectRequest {
   export function isa(o: any): o is CreateProjectRequest {
-    return _smithy.isa(o, "CreateProjectRequest");
+    return __isa(o, "CreateProjectRequest");
   }
 }
 
@@ -544,7 +548,7 @@ export interface CreateProjectResponse extends $MetadataBearer {
 
 export namespace CreateProjectResponse {
   export function isa(o: any): o is CreateProjectResponse {
-    return _smithy.isa(o, "CreateProjectResponse");
+    return __isa(o, "CreateProjectResponse");
   }
 }
 
@@ -579,7 +583,7 @@ export interface CreateProjectVersionRequest {
 
 export namespace CreateProjectVersionRequest {
   export function isa(o: any): o is CreateProjectVersionRequest {
-    return _smithy.isa(o, "CreateProjectVersionRequest");
+    return __isa(o, "CreateProjectVersionRequest");
   }
 }
 
@@ -594,7 +598,7 @@ export interface CreateProjectVersionResponse extends $MetadataBearer {
 
 export namespace CreateProjectVersionResponse {
   export function isa(o: any): o is CreateProjectVersionResponse {
-    return _smithy.isa(o, "CreateProjectVersionResponse");
+    return __isa(o, "CreateProjectVersionResponse");
   }
 }
 
@@ -632,7 +636,7 @@ export interface CreateStreamProcessorRequest {
 
 export namespace CreateStreamProcessorRequest {
   export function isa(o: any): o is CreateStreamProcessorRequest {
-    return _smithy.isa(o, "CreateStreamProcessorRequest");
+    return __isa(o, "CreateStreamProcessorRequest");
   }
 }
 
@@ -646,7 +650,7 @@ export interface CreateStreamProcessorResponse extends $MetadataBearer {
 
 export namespace CreateStreamProcessorResponse {
   export function isa(o: any): o is CreateStreamProcessorResponse {
-    return _smithy.isa(o, "CreateStreamProcessorResponse");
+    return __isa(o, "CreateStreamProcessorResponse");
   }
 }
 
@@ -676,7 +680,7 @@ export interface CustomLabel {
 
 export namespace CustomLabel {
   export function isa(o: any): o is CustomLabel {
-    return _smithy.isa(o, "CustomLabel");
+    return __isa(o, "CustomLabel");
   }
 }
 
@@ -690,7 +694,7 @@ export interface DeleteCollectionRequest {
 
 export namespace DeleteCollectionRequest {
   export function isa(o: any): o is DeleteCollectionRequest {
-    return _smithy.isa(o, "DeleteCollectionRequest");
+    return __isa(o, "DeleteCollectionRequest");
   }
 }
 
@@ -704,7 +708,7 @@ export interface DeleteCollectionResponse extends $MetadataBearer {
 
 export namespace DeleteCollectionResponse {
   export function isa(o: any): o is DeleteCollectionResponse {
-    return _smithy.isa(o, "DeleteCollectionResponse");
+    return __isa(o, "DeleteCollectionResponse");
   }
 }
 
@@ -723,7 +727,7 @@ export interface DeleteFacesRequest {
 
 export namespace DeleteFacesRequest {
   export function isa(o: any): o is DeleteFacesRequest {
-    return _smithy.isa(o, "DeleteFacesRequest");
+    return __isa(o, "DeleteFacesRequest");
   }
 }
 
@@ -737,7 +741,7 @@ export interface DeleteFacesResponse extends $MetadataBearer {
 
 export namespace DeleteFacesResponse {
   export function isa(o: any): o is DeleteFacesResponse {
-    return _smithy.isa(o, "DeleteFacesResponse");
+    return __isa(o, "DeleteFacesResponse");
   }
 }
 
@@ -751,7 +755,7 @@ export interface DeleteStreamProcessorRequest {
 
 export namespace DeleteStreamProcessorRequest {
   export function isa(o: any): o is DeleteStreamProcessorRequest {
-    return _smithy.isa(o, "DeleteStreamProcessorRequest");
+    return __isa(o, "DeleteStreamProcessorRequest");
   }
 }
 
@@ -761,7 +765,7 @@ export interface DeleteStreamProcessorResponse extends $MetadataBearer {
 
 export namespace DeleteStreamProcessorResponse {
   export function isa(o: any): o is DeleteStreamProcessorResponse {
-    return _smithy.isa(o, "DeleteStreamProcessorResponse");
+    return __isa(o, "DeleteStreamProcessorResponse");
   }
 }
 
@@ -775,7 +779,7 @@ export interface DescribeCollectionRequest {
 
 export namespace DescribeCollectionRequest {
   export function isa(o: any): o is DescribeCollectionRequest {
-    return _smithy.isa(o, "DescribeCollectionRequest");
+    return __isa(o, "DescribeCollectionRequest");
   }
 }
 
@@ -809,7 +813,7 @@ export interface DescribeCollectionResponse extends $MetadataBearer {
 
 export namespace DescribeCollectionResponse {
   export function isa(o: any): o is DescribeCollectionResponse {
-    return _smithy.isa(o, "DescribeCollectionResponse");
+    return __isa(o, "DescribeCollectionResponse");
   }
 }
 
@@ -843,7 +847,7 @@ export interface DescribeProjectVersionsRequest {
 
 export namespace DescribeProjectVersionsRequest {
   export function isa(o: any): o is DescribeProjectVersionsRequest {
-    return _smithy.isa(o, "DescribeProjectVersionsRequest");
+    return __isa(o, "DescribeProjectVersionsRequest");
   }
 }
 
@@ -865,7 +869,7 @@ export interface DescribeProjectVersionsResponse extends $MetadataBearer {
 
 export namespace DescribeProjectVersionsResponse {
   export function isa(o: any): o is DescribeProjectVersionsResponse {
-    return _smithy.isa(o, "DescribeProjectVersionsResponse");
+    return __isa(o, "DescribeProjectVersionsResponse");
   }
 }
 
@@ -888,7 +892,7 @@ export interface DescribeProjectsRequest {
 
 export namespace DescribeProjectsRequest {
   export function isa(o: any): o is DescribeProjectsRequest {
-    return _smithy.isa(o, "DescribeProjectsRequest");
+    return __isa(o, "DescribeProjectsRequest");
   }
 }
 
@@ -909,7 +913,7 @@ export interface DescribeProjectsResponse extends $MetadataBearer {
 
 export namespace DescribeProjectsResponse {
   export function isa(o: any): o is DescribeProjectsResponse {
-    return _smithy.isa(o, "DescribeProjectsResponse");
+    return __isa(o, "DescribeProjectsResponse");
   }
 }
 
@@ -923,7 +927,7 @@ export interface DescribeStreamProcessorRequest {
 
 export namespace DescribeStreamProcessorRequest {
   export function isa(o: any): o is DescribeStreamProcessorRequest {
-    return _smithy.isa(o, "DescribeStreamProcessorRequest");
+    return __isa(o, "DescribeStreamProcessorRequest");
   }
 }
 
@@ -985,7 +989,7 @@ export interface DescribeStreamProcessorResponse extends $MetadataBearer {
 
 export namespace DescribeStreamProcessorResponse {
   export function isa(o: any): o is DescribeStreamProcessorResponse {
-    return _smithy.isa(o, "DescribeStreamProcessorResponse");
+    return __isa(o, "DescribeStreamProcessorResponse");
   }
 }
 
@@ -1040,7 +1044,7 @@ export interface DetectCustomLabelsRequest {
 
 export namespace DetectCustomLabelsRequest {
   export function isa(o: any): o is DetectCustomLabelsRequest {
-    return _smithy.isa(o, "DetectCustomLabelsRequest");
+    return __isa(o, "DetectCustomLabelsRequest");
   }
 }
 
@@ -1054,7 +1058,7 @@ export interface DetectCustomLabelsResponse extends $MetadataBearer {
 
 export namespace DetectCustomLabelsResponse {
   export function isa(o: any): o is DetectCustomLabelsResponse {
-    return _smithy.isa(o, "DetectCustomLabelsResponse");
+    return __isa(o, "DetectCustomLabelsResponse");
   }
 }
 
@@ -1084,7 +1088,7 @@ export interface DetectFacesRequest {
 
 export namespace DetectFacesRequest {
   export function isa(o: any): o is DetectFacesRequest {
-    return _smithy.isa(o, "DetectFacesRequest");
+    return __isa(o, "DetectFacesRequest");
   }
 }
 
@@ -1112,7 +1116,7 @@ export interface DetectFacesResponse extends $MetadataBearer {
 
 export namespace DetectFacesResponse {
   export function isa(o: any): o is DetectFacesResponse {
-    return _smithy.isa(o, "DetectFacesResponse");
+    return __isa(o, "DetectFacesResponse");
   }
 }
 
@@ -1145,7 +1149,7 @@ export interface DetectLabelsRequest {
 
 export namespace DetectLabelsRequest {
   export function isa(o: any): o is DetectLabelsRequest {
-    return _smithy.isa(o, "DetectLabelsRequest");
+    return __isa(o, "DetectLabelsRequest");
   }
 }
 
@@ -1178,7 +1182,7 @@ export interface DetectLabelsResponse extends $MetadataBearer {
 
 export namespace DetectLabelsResponse {
   export function isa(o: any): o is DetectLabelsResponse {
-    return _smithy.isa(o, "DetectLabelsResponse");
+    return __isa(o, "DetectLabelsResponse");
   }
 }
 
@@ -1211,7 +1215,7 @@ export interface DetectModerationLabelsRequest {
 
 export namespace DetectModerationLabelsRequest {
   export function isa(o: any): o is DetectModerationLabelsRequest {
-    return _smithy.isa(o, "DetectModerationLabelsRequest");
+    return __isa(o, "DetectModerationLabelsRequest");
   }
 }
 
@@ -1236,7 +1240,7 @@ export interface DetectModerationLabelsResponse extends $MetadataBearer {
 
 export namespace DetectModerationLabelsResponse {
   export function isa(o: any): o is DetectModerationLabelsResponse {
-    return _smithy.isa(o, "DetectModerationLabelsResponse");
+    return __isa(o, "DetectModerationLabelsResponse");
   }
 }
 
@@ -1254,7 +1258,7 @@ export interface DetectTextRequest {
 
 export namespace DetectTextRequest {
   export function isa(o: any): o is DetectTextRequest {
-    return _smithy.isa(o, "DetectTextRequest");
+    return __isa(o, "DetectTextRequest");
   }
 }
 
@@ -1268,7 +1272,7 @@ export interface DetectTextResponse extends $MetadataBearer {
 
 export namespace DetectTextResponse {
   export function isa(o: any): o is DetectTextResponse {
-    return _smithy.isa(o, "DetectTextResponse");
+    return __isa(o, "DetectTextResponse");
   }
 }
 
@@ -1293,7 +1297,7 @@ export interface Emotion {
 
 export namespace Emotion {
   export function isa(o: any): o is Emotion {
-    return _smithy.isa(o, "Emotion");
+    return __isa(o, "Emotion");
   }
 }
 
@@ -1330,7 +1334,7 @@ export interface EvaluationResult {
 
 export namespace EvaluationResult {
   export function isa(o: any): o is EvaluationResult {
-    return _smithy.isa(o, "EvaluationResult");
+    return __isa(o, "EvaluationResult");
   }
 }
 
@@ -1353,7 +1357,7 @@ export interface EyeOpen {
 
 export namespace EyeOpen {
   export function isa(o: any): o is EyeOpen {
-    return _smithy.isa(o, "EyeOpen");
+    return __isa(o, "EyeOpen");
   }
 }
 
@@ -1376,7 +1380,7 @@ export interface Eyeglasses {
 
 export namespace Eyeglasses {
   export function isa(o: any): o is Eyeglasses {
-    return _smithy.isa(o, "Eyeglasses");
+    return __isa(o, "Eyeglasses");
   }
 }
 
@@ -1415,7 +1419,7 @@ export interface Face {
 
 export namespace Face {
   export function isa(o: any): o is Face {
-    return _smithy.isa(o, "Face");
+    return __isa(o, "Face");
   }
 }
 
@@ -1542,7 +1546,7 @@ export interface FaceDetail {
 
 export namespace FaceDetail {
   export function isa(o: any): o is FaceDetail {
-    return _smithy.isa(o, "FaceDetail");
+    return __isa(o, "FaceDetail");
   }
 }
 
@@ -1564,7 +1568,7 @@ export interface FaceDetection {
 
 export namespace FaceDetection {
   export function isa(o: any): o is FaceDetection {
-    return _smithy.isa(o, "FaceDetection");
+    return __isa(o, "FaceDetection");
   }
 }
 
@@ -1588,7 +1592,7 @@ export interface FaceMatch {
 
 export namespace FaceMatch {
   export function isa(o: any): o is FaceMatch {
-    return _smithy.isa(o, "FaceMatch");
+    return __isa(o, "FaceMatch");
   }
 }
 
@@ -1612,7 +1616,7 @@ export interface FaceRecord {
 
 export namespace FaceRecord {
   export function isa(o: any): o is FaceRecord {
-    return _smithy.isa(o, "FaceRecord");
+    return __isa(o, "FaceRecord");
   }
 }
 
@@ -1636,7 +1640,7 @@ export interface FaceSearchSettings {
 
 export namespace FaceSearchSettings {
   export function isa(o: any): o is FaceSearchSettings {
-    return _smithy.isa(o, "FaceSearchSettings");
+    return __isa(o, "FaceSearchSettings");
   }
 }
 
@@ -1675,7 +1679,7 @@ export interface Gender {
 
 export namespace Gender {
   export function isa(o: any): o is Gender {
-    return _smithy.isa(o, "Gender");
+    return __isa(o, "Gender");
   }
 }
 
@@ -1704,7 +1708,7 @@ export interface Geometry {
 
 export namespace Geometry {
   export function isa(o: any): o is Geometry {
-    return _smithy.isa(o, "Geometry");
+    return __isa(o, "Geometry");
   }
 }
 
@@ -1719,7 +1723,7 @@ export interface GetCelebrityInfoRequest {
 
 export namespace GetCelebrityInfoRequest {
   export function isa(o: any): o is GetCelebrityInfoRequest {
-    return _smithy.isa(o, "GetCelebrityInfoRequest");
+    return __isa(o, "GetCelebrityInfoRequest");
   }
 }
 
@@ -1738,7 +1742,7 @@ export interface GetCelebrityInfoResponse extends $MetadataBearer {
 
 export namespace GetCelebrityInfoResponse {
   export function isa(o: any): o is GetCelebrityInfoResponse {
-    return _smithy.isa(o, "GetCelebrityInfoResponse");
+    return __isa(o, "GetCelebrityInfoResponse");
   }
 }
 
@@ -1772,7 +1776,7 @@ export interface GetCelebrityRecognitionRequest {
 
 export namespace GetCelebrityRecognitionRequest {
   export function isa(o: any): o is GetCelebrityRecognitionRequest {
-    return _smithy.isa(o, "GetCelebrityRecognitionRequest");
+    return __isa(o, "GetCelebrityRecognitionRequest");
   }
 }
 
@@ -1808,7 +1812,7 @@ export interface GetCelebrityRecognitionResponse extends $MetadataBearer {
 
 export namespace GetCelebrityRecognitionResponse {
   export function isa(o: any): o is GetCelebrityRecognitionResponse {
-    return _smithy.isa(o, "GetCelebrityRecognitionResponse");
+    return __isa(o, "GetCelebrityRecognitionResponse");
   }
 }
 
@@ -1846,7 +1850,7 @@ export interface GetContentModerationRequest {
 
 export namespace GetContentModerationRequest {
   export function isa(o: any): o is GetContentModerationRequest {
-    return _smithy.isa(o, "GetContentModerationRequest");
+    return __isa(o, "GetContentModerationRequest");
   }
 }
 
@@ -1887,7 +1891,7 @@ export interface GetContentModerationResponse extends $MetadataBearer {
 
 export namespace GetContentModerationResponse {
   export function isa(o: any): o is GetContentModerationResponse {
-    return _smithy.isa(o, "GetContentModerationResponse");
+    return __isa(o, "GetContentModerationResponse");
   }
 }
 
@@ -1914,7 +1918,7 @@ export interface GetFaceDetectionRequest {
 
 export namespace GetFaceDetectionRequest {
   export function isa(o: any): o is GetFaceDetectionRequest {
-    return _smithy.isa(o, "GetFaceDetectionRequest");
+    return __isa(o, "GetFaceDetectionRequest");
   }
 }
 
@@ -1950,7 +1954,7 @@ export interface GetFaceDetectionResponse extends $MetadataBearer {
 
 export namespace GetFaceDetectionResponse {
   export function isa(o: any): o is GetFaceDetectionResponse {
-    return _smithy.isa(o, "GetFaceDetectionResponse");
+    return __isa(o, "GetFaceDetectionResponse");
   }
 }
 
@@ -1983,7 +1987,7 @@ export interface GetFaceSearchRequest {
 
 export namespace GetFaceSearchRequest {
   export function isa(o: any): o is GetFaceSearchRequest {
-    return _smithy.isa(o, "GetFaceSearchRequest");
+    return __isa(o, "GetFaceSearchRequest");
   }
 }
 
@@ -2024,7 +2028,7 @@ export interface GetFaceSearchResponse extends $MetadataBearer {
 
 export namespace GetFaceSearchResponse {
   export function isa(o: any): o is GetFaceSearchResponse {
-    return _smithy.isa(o, "GetFaceSearchResponse");
+    return __isa(o, "GetFaceSearchResponse");
   }
 }
 
@@ -2061,7 +2065,7 @@ export interface GetLabelDetectionRequest {
 
 export namespace GetLabelDetectionRequest {
   export function isa(o: any): o is GetLabelDetectionRequest {
-    return _smithy.isa(o, "GetLabelDetectionRequest");
+    return __isa(o, "GetLabelDetectionRequest");
   }
 }
 
@@ -2103,7 +2107,7 @@ export interface GetLabelDetectionResponse extends $MetadataBearer {
 
 export namespace GetLabelDetectionResponse {
   export function isa(o: any): o is GetLabelDetectionResponse {
-    return _smithy.isa(o, "GetLabelDetectionResponse");
+    return __isa(o, "GetLabelDetectionResponse");
   }
 }
 
@@ -2139,7 +2143,7 @@ export interface GetPersonTrackingRequest {
 
 export namespace GetPersonTrackingRequest {
   export function isa(o: any): o is GetPersonTrackingRequest {
-    return _smithy.isa(o, "GetPersonTrackingRequest");
+    return __isa(o, "GetPersonTrackingRequest");
   }
 }
 
@@ -2175,7 +2179,7 @@ export interface GetPersonTrackingResponse extends $MetadataBearer {
 
 export namespace GetPersonTrackingResponse {
   export function isa(o: any): o is GetPersonTrackingResponse {
-    return _smithy.isa(o, "GetPersonTrackingResponse");
+    return __isa(o, "GetPersonTrackingResponse");
   }
 }
 
@@ -2198,7 +2202,7 @@ export interface GroundTruthManifest {
 
 export namespace GroundTruthManifest {
   export function isa(o: any): o is GroundTruthManifest {
-    return _smithy.isa(o, "GroundTruthManifest");
+    return __isa(o, "GroundTruthManifest");
   }
 }
 
@@ -2212,7 +2216,7 @@ export interface HumanLoopActivationOutput {
    * <p>Shows the result of condition evaluations, including those conditions which activated a
    *       human review.</p>
    */
-  HumanLoopActivationConditionsEvaluationResults?: string;
+  HumanLoopActivationConditionsEvaluationResults?: __LazyJsonString | string;
 
   /**
    * <p>Shows if and why human review was needed.</p>
@@ -2227,7 +2231,7 @@ export interface HumanLoopActivationOutput {
 
 export namespace HumanLoopActivationOutput {
   export function isa(o: any): o is HumanLoopActivationOutput {
-    return _smithy.isa(o, "HumanLoopActivationOutput");
+    return __isa(o, "HumanLoopActivationOutput");
   }
 }
 
@@ -2255,7 +2259,7 @@ export interface HumanLoopConfig {
 
 export namespace HumanLoopConfig {
   export function isa(o: any): o is HumanLoopConfig {
-    return _smithy.isa(o, "HumanLoopConfig");
+    return __isa(o, "HumanLoopConfig");
   }
 }
 
@@ -2273,7 +2277,7 @@ export interface HumanLoopDataAttributes {
 
 export namespace HumanLoopDataAttributes {
   export function isa(o: any): o is HumanLoopDataAttributes {
-    return _smithy.isa(o, "HumanLoopDataAttributes");
+    return __isa(o, "HumanLoopDataAttributes");
   }
 }
 
@@ -2281,7 +2285,7 @@ export namespace HumanLoopDataAttributes {
  * <p>The number of in-progress human reviews you have has exceeded the number allowed.</p>
  */
 export interface HumanLoopQuotaExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "HumanLoopQuotaExceededException";
   $fault: "client";
@@ -2295,7 +2299,7 @@ export interface HumanLoopQuotaExceededException
 
 export namespace HumanLoopQuotaExceededException {
   export function isa(o: any): o is HumanLoopQuotaExceededException {
-    return _smithy.isa(o, "HumanLoopQuotaExceededException");
+    return __isa(o, "HumanLoopQuotaExceededException");
   }
 }
 
@@ -2304,7 +2308,7 @@ export namespace HumanLoopQuotaExceededException {
  *         parameters is different from the previous call to the operation.</p>
  */
 export interface IdempotentParameterMismatchException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "IdempotentParameterMismatchException";
   $fault: "client";
@@ -2315,7 +2319,7 @@ export interface IdempotentParameterMismatchException
 
 export namespace IdempotentParameterMismatchException {
   export function isa(o: any): o is IdempotentParameterMismatchException {
-    return _smithy.isa(o, "IdempotentParameterMismatchException");
+    return __isa(o, "IdempotentParameterMismatchException");
   }
 }
 
@@ -2359,7 +2363,7 @@ export interface Image {
 
 export namespace Image {
   export function isa(o: any): o is Image {
-    return _smithy.isa(o, "Image");
+    return __isa(o, "Image");
   }
 }
 
@@ -2383,7 +2387,7 @@ export interface ImageQuality {
 
 export namespace ImageQuality {
   export function isa(o: any): o is ImageQuality {
-    return _smithy.isa(o, "ImageQuality");
+    return __isa(o, "ImageQuality");
   }
 }
 
@@ -2392,7 +2396,7 @@ export namespace ImageQuality {
  *       Limits in Amazon Rekognition in the Amazon Rekognition Developer Guide. </p>
  */
 export interface ImageTooLargeException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ImageTooLargeException";
   $fault: "client";
@@ -2403,7 +2407,7 @@ export interface ImageTooLargeException
 
 export namespace ImageTooLargeException {
   export function isa(o: any): o is ImageTooLargeException {
-    return _smithy.isa(o, "ImageTooLargeException");
+    return __isa(o, "ImageTooLargeException");
   }
 }
 
@@ -2478,7 +2482,7 @@ export interface IndexFacesRequest {
 
 export namespace IndexFacesRequest {
   export function isa(o: any): o is IndexFacesRequest {
-    return _smithy.isa(o, "IndexFacesRequest");
+    return __isa(o, "IndexFacesRequest");
   }
 }
 
@@ -2539,7 +2543,7 @@ export interface IndexFacesResponse extends $MetadataBearer {
 
 export namespace IndexFacesResponse {
   export function isa(o: any): o is IndexFacesResponse {
-    return _smithy.isa(o, "IndexFacesResponse");
+    return __isa(o, "IndexFacesResponse");
   }
 }
 
@@ -2562,7 +2566,7 @@ export interface Instance {
 
 export namespace Instance {
   export function isa(o: any): o is Instance {
-    return _smithy.isa(o, "Instance");
+    return __isa(o, "Instance");
   }
 }
 
@@ -2570,7 +2574,7 @@ export namespace Instance {
  * <p>Amazon Rekognition experienced a service issue. Try your call again.</p>
  */
 export interface InternalServerError
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalServerError";
   $fault: "server";
@@ -2581,7 +2585,7 @@ export interface InternalServerError
 
 export namespace InternalServerError {
   export function isa(o: any): o is InternalServerError {
-    return _smithy.isa(o, "InternalServerError");
+    return __isa(o, "InternalServerError");
   }
 }
 
@@ -2589,7 +2593,7 @@ export namespace InternalServerError {
  * <p>The provided image format is not supported. </p>
  */
 export interface InvalidImageFormatException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidImageFormatException";
   $fault: "client";
@@ -2600,7 +2604,7 @@ export interface InvalidImageFormatException
 
 export namespace InvalidImageFormatException {
   export function isa(o: any): o is InvalidImageFormatException {
-    return _smithy.isa(o, "InvalidImageFormatException");
+    return __isa(o, "InvalidImageFormatException");
   }
 }
 
@@ -2608,7 +2612,7 @@ export namespace InvalidImageFormatException {
  * <p>Pagination token in the request is not valid.</p>
  */
 export interface InvalidPaginationTokenException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidPaginationTokenException";
   $fault: "client";
@@ -2619,7 +2623,7 @@ export interface InvalidPaginationTokenException
 
 export namespace InvalidPaginationTokenException {
   export function isa(o: any): o is InvalidPaginationTokenException {
-    return _smithy.isa(o, "InvalidPaginationTokenException");
+    return __isa(o, "InvalidPaginationTokenException");
   }
 }
 
@@ -2628,7 +2632,7 @@ export namespace InvalidPaginationTokenException {
  *       operation again.</p>
  */
 export interface InvalidParameterException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidParameterException";
   $fault: "client";
@@ -2639,7 +2643,7 @@ export interface InvalidParameterException
 
 export namespace InvalidParameterException {
   export function isa(o: any): o is InvalidParameterException {
-    return _smithy.isa(o, "InvalidParameterException");
+    return __isa(o, "InvalidParameterException");
   }
 }
 
@@ -2647,7 +2651,7 @@ export namespace InvalidParameterException {
  * <p>Amazon Rekognition is unable to access the S3 object specified in the request.</p>
  */
 export interface InvalidS3ObjectException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidS3ObjectException";
   $fault: "client";
@@ -2658,7 +2662,7 @@ export interface InvalidS3ObjectException
 
 export namespace InvalidS3ObjectException {
   export function isa(o: any): o is InvalidS3ObjectException {
-    return _smithy.isa(o, "InvalidS3ObjectException");
+    return __isa(o, "InvalidS3ObjectException");
   }
 }
 
@@ -2676,7 +2680,7 @@ export interface KinesisDataStream {
 
 export namespace KinesisDataStream {
   export function isa(o: any): o is KinesisDataStream {
-    return _smithy.isa(o, "KinesisDataStream");
+    return __isa(o, "KinesisDataStream");
   }
 }
 
@@ -2694,7 +2698,7 @@ export interface KinesisVideoStream {
 
 export namespace KinesisVideoStream {
   export function isa(o: any): o is KinesisVideoStream {
-    return _smithy.isa(o, "KinesisVideoStream");
+    return __isa(o, "KinesisVideoStream");
   }
 }
 
@@ -2730,7 +2734,7 @@ export interface Label {
 
 export namespace Label {
   export function isa(o: any): o is Label {
-    return _smithy.isa(o, "Label");
+    return __isa(o, "Label");
   }
 }
 
@@ -2752,7 +2756,7 @@ export interface LabelDetection {
 
 export namespace LabelDetection {
   export function isa(o: any): o is LabelDetection {
-    return _smithy.isa(o, "LabelDetection");
+    return __isa(o, "LabelDetection");
   }
 }
 
@@ -2788,7 +2792,7 @@ export interface Landmark {
 
 export namespace Landmark {
   export function isa(o: any): o is Landmark {
-    return _smithy.isa(o, "Landmark");
+    return __isa(o, "Landmark");
   }
 }
 
@@ -2831,7 +2835,7 @@ export enum LandmarkType {
  *             the number of concurrently running jobs is below the Amazon Rekognition service limit.  </p>
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -2842,7 +2846,7 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
@@ -2861,7 +2865,7 @@ export interface ListCollectionsRequest {
 
 export namespace ListCollectionsRequest {
   export function isa(o: any): o is ListCollectionsRequest {
-    return _smithy.isa(o, "ListCollectionsRequest");
+    return __isa(o, "ListCollectionsRequest");
   }
 }
 
@@ -2888,7 +2892,7 @@ export interface ListCollectionsResponse extends $MetadataBearer {
 
 export namespace ListCollectionsResponse {
   export function isa(o: any): o is ListCollectionsResponse {
-    return _smithy.isa(o, "ListCollectionsResponse");
+    return __isa(o, "ListCollectionsResponse");
   }
 }
 
@@ -2914,7 +2918,7 @@ export interface ListFacesRequest {
 
 export namespace ListFacesRequest {
   export function isa(o: any): o is ListFacesRequest {
-    return _smithy.isa(o, "ListFacesRequest");
+    return __isa(o, "ListFacesRequest");
   }
 }
 
@@ -2939,7 +2943,7 @@ export interface ListFacesResponse extends $MetadataBearer {
 
 export namespace ListFacesResponse {
   export function isa(o: any): o is ListFacesResponse {
-    return _smithy.isa(o, "ListFacesResponse");
+    return __isa(o, "ListFacesResponse");
   }
 }
 
@@ -2959,7 +2963,7 @@ export interface ListStreamProcessorsRequest {
 
 export namespace ListStreamProcessorsRequest {
   export function isa(o: any): o is ListStreamProcessorsRequest {
-    return _smithy.isa(o, "ListStreamProcessorsRequest");
+    return __isa(o, "ListStreamProcessorsRequest");
   }
 }
 
@@ -2979,7 +2983,7 @@ export interface ListStreamProcessorsResponse extends $MetadataBearer {
 
 export namespace ListStreamProcessorsResponse {
   export function isa(o: any): o is ListStreamProcessorsResponse {
-    return _smithy.isa(o, "ListStreamProcessorsResponse");
+    return __isa(o, "ListStreamProcessorsResponse");
   }
 }
 
@@ -3013,7 +3017,7 @@ export interface ModerationLabel {
 
 export namespace ModerationLabel {
   export function isa(o: any): o is ModerationLabel {
-    return _smithy.isa(o, "ModerationLabel");
+    return __isa(o, "ModerationLabel");
   }
 }
 
@@ -3036,7 +3040,7 @@ export interface MouthOpen {
 
 export namespace MouthOpen {
   export function isa(o: any): o is MouthOpen {
-    return _smithy.isa(o, "MouthOpen");
+    return __isa(o, "MouthOpen");
   }
 }
 
@@ -3059,7 +3063,7 @@ export interface Mustache {
 
 export namespace Mustache {
   export function isa(o: any): o is Mustache {
-    return _smithy.isa(o, "Mustache");
+    return __isa(o, "Mustache");
   }
 }
 
@@ -3082,7 +3086,7 @@ export interface NotificationChannel {
 
 export namespace NotificationChannel {
   export function isa(o: any): o is NotificationChannel {
-    return _smithy.isa(o, "NotificationChannel");
+    return __isa(o, "NotificationChannel");
   }
 }
 
@@ -3111,7 +3115,7 @@ export interface OutputConfig {
 
 export namespace OutputConfig {
   export function isa(o: any): o is OutputConfig {
-    return _smithy.isa(o, "OutputConfig");
+    return __isa(o, "OutputConfig");
   }
 }
 
@@ -3128,7 +3132,7 @@ export interface Parent {
 
 export namespace Parent {
   export function isa(o: any): o is Parent {
-    return _smithy.isa(o, "Parent");
+    return __isa(o, "Parent");
   }
 }
 
@@ -3155,7 +3159,7 @@ export interface PersonDetail {
 
 export namespace PersonDetail {
   export function isa(o: any): o is PersonDetail {
-    return _smithy.isa(o, "PersonDetail");
+    return __isa(o, "PersonDetail");
   }
 }
 
@@ -3181,7 +3185,7 @@ export interface PersonDetection {
 
 export namespace PersonDetection {
   export function isa(o: any): o is PersonDetection {
-    return _smithy.isa(o, "PersonDetection");
+    return __isa(o, "PersonDetection");
   }
 }
 
@@ -3211,7 +3215,7 @@ export interface PersonMatch {
 
 export namespace PersonMatch {
   export function isa(o: any): o is PersonMatch {
-    return _smithy.isa(o, "PersonMatch");
+    return __isa(o, "PersonMatch");
   }
 }
 
@@ -3245,7 +3249,7 @@ export interface Point {
 
 export namespace Point {
   export function isa(o: any): o is Point {
-    return _smithy.isa(o, "Point");
+    return __isa(o, "Point");
   }
 }
 
@@ -3272,7 +3276,7 @@ export interface Pose {
 
 export namespace Pose {
   export function isa(o: any): o is Pose {
-    return _smithy.isa(o, "Pose");
+    return __isa(o, "Pose");
   }
 }
 
@@ -3299,7 +3303,7 @@ export interface ProjectDescription {
 
 export namespace ProjectDescription {
   export function isa(o: any): o is ProjectDescription {
-    return _smithy.isa(o, "ProjectDescription");
+    return __isa(o, "ProjectDescription");
   }
 }
 
@@ -3374,7 +3378,7 @@ export interface ProjectVersionDescription {
 
 export namespace ProjectVersionDescription {
   export function isa(o: any): o is ProjectVersionDescription {
-    return _smithy.isa(o, "ProjectVersionDescription");
+    return __isa(o, "ProjectVersionDescription");
   }
 }
 
@@ -3395,7 +3399,7 @@ export enum ProjectVersionStatus {
  *       limit, contact Amazon Rekognition.</p>
  */
 export interface ProvisionedThroughputExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ProvisionedThroughputExceededException";
   $fault: "client";
@@ -3406,7 +3410,7 @@ export interface ProvisionedThroughputExceededException
 
 export namespace ProvisionedThroughputExceededException {
   export function isa(o: any): o is ProvisionedThroughputExceededException {
-    return _smithy.isa(o, "ProvisionedThroughputExceededException");
+    return __isa(o, "ProvisionedThroughputExceededException");
   }
 }
 
@@ -3442,7 +3446,7 @@ export interface RecognizeCelebritiesRequest {
 
 export namespace RecognizeCelebritiesRequest {
   export function isa(o: any): o is RecognizeCelebritiesRequest {
-    return _smithy.isa(o, "RecognizeCelebritiesRequest");
+    return __isa(o, "RecognizeCelebritiesRequest");
   }
 }
 
@@ -3478,7 +3482,7 @@ export interface RecognizeCelebritiesResponse extends $MetadataBearer {
 
 export namespace RecognizeCelebritiesResponse {
   export function isa(o: any): o is RecognizeCelebritiesResponse {
-    return _smithy.isa(o, "RecognizeCelebritiesResponse");
+    return __isa(o, "RecognizeCelebritiesResponse");
   }
 }
 
@@ -3486,7 +3490,7 @@ export namespace RecognizeCelebritiesResponse {
  * <p>A collection with the specified ID already exists.</p>
  */
 export interface ResourceAlreadyExistsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceAlreadyExistsException";
   $fault: "client";
@@ -3497,7 +3501,7 @@ export interface ResourceAlreadyExistsException
 
 export namespace ResourceAlreadyExistsException {
   export function isa(o: any): o is ResourceAlreadyExistsException {
-    return _smithy.isa(o, "ResourceAlreadyExistsException");
+    return __isa(o, "ResourceAlreadyExistsException");
   }
 }
 
@@ -3505,7 +3509,7 @@ export namespace ResourceAlreadyExistsException {
  * <p></p>
  */
 export interface ResourceInUseException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceInUseException";
   $fault: "client";
@@ -3516,7 +3520,7 @@ export interface ResourceInUseException
 
 export namespace ResourceInUseException {
   export function isa(o: any): o is ResourceInUseException {
-    return _smithy.isa(o, "ResourceInUseException");
+    return __isa(o, "ResourceInUseException");
   }
 }
 
@@ -3524,7 +3528,7 @@ export namespace ResourceInUseException {
  * <p>The collection specified in the request cannot be found.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -3535,7 +3539,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -3545,7 +3549,7 @@ export namespace ResourceNotFoundException {
  *          model version that isn't deployed. </p>
  */
 export interface ResourceNotReadyException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotReadyException";
   $fault: "client";
@@ -3556,7 +3560,7 @@ export interface ResourceNotReadyException
 
 export namespace ResourceNotReadyException {
   export function isa(o: any): o is ResourceNotReadyException {
-    return _smithy.isa(o, "ResourceNotReadyException");
+    return __isa(o, "ResourceNotReadyException");
   }
 }
 
@@ -3589,7 +3593,7 @@ export interface S3Object {
 
 export namespace S3Object {
   export function isa(o: any): o is S3Object {
-    return _smithy.isa(o, "S3Object");
+    return __isa(o, "S3Object");
   }
 }
 
@@ -3643,7 +3647,7 @@ export interface SearchFacesByImageRequest {
 
 export namespace SearchFacesByImageRequest {
   export function isa(o: any): o is SearchFacesByImageRequest {
-    return _smithy.isa(o, "SearchFacesByImageRequest");
+    return __isa(o, "SearchFacesByImageRequest");
   }
 }
 
@@ -3675,7 +3679,7 @@ export interface SearchFacesByImageResponse extends $MetadataBearer {
 
 export namespace SearchFacesByImageResponse {
   export function isa(o: any): o is SearchFacesByImageResponse {
-    return _smithy.isa(o, "SearchFacesByImageResponse");
+    return __isa(o, "SearchFacesByImageResponse");
   }
 }
 
@@ -3708,7 +3712,7 @@ export interface SearchFacesRequest {
 
 export namespace SearchFacesRequest {
   export function isa(o: any): o is SearchFacesRequest {
-    return _smithy.isa(o, "SearchFacesRequest");
+    return __isa(o, "SearchFacesRequest");
   }
 }
 
@@ -3733,7 +3737,7 @@ export interface SearchFacesResponse extends $MetadataBearer {
 
 export namespace SearchFacesResponse {
   export function isa(o: any): o is SearchFacesResponse {
-    return _smithy.isa(o, "SearchFacesResponse");
+    return __isa(o, "SearchFacesResponse");
   }
 }
 
@@ -3756,7 +3760,7 @@ export interface Smile {
 
 export namespace Smile {
   export function isa(o: any): o is Smile {
-    return _smithy.isa(o, "Smile");
+    return __isa(o, "Smile");
   }
 }
 
@@ -3790,7 +3794,7 @@ export interface StartCelebrityRecognitionRequest {
 
 export namespace StartCelebrityRecognitionRequest {
   export function isa(o: any): o is StartCelebrityRecognitionRequest {
-    return _smithy.isa(o, "StartCelebrityRecognitionRequest");
+    return __isa(o, "StartCelebrityRecognitionRequest");
   }
 }
 
@@ -3805,7 +3809,7 @@ export interface StartCelebrityRecognitionResponse extends $MetadataBearer {
 
 export namespace StartCelebrityRecognitionResponse {
   export function isa(o: any): o is StartCelebrityRecognitionResponse {
-    return _smithy.isa(o, "StartCelebrityRecognitionResponse");
+    return __isa(o, "StartCelebrityRecognitionResponse");
   }
 }
 
@@ -3848,7 +3852,7 @@ export interface StartContentModerationRequest {
 
 export namespace StartContentModerationRequest {
   export function isa(o: any): o is StartContentModerationRequest {
-    return _smithy.isa(o, "StartContentModerationRequest");
+    return __isa(o, "StartContentModerationRequest");
   }
 }
 
@@ -3863,7 +3867,7 @@ export interface StartContentModerationResponse extends $MetadataBearer {
 
 export namespace StartContentModerationResponse {
   export function isa(o: any): o is StartContentModerationResponse {
-    return _smithy.isa(o, "StartContentModerationResponse");
+    return __isa(o, "StartContentModerationResponse");
   }
 }
 
@@ -3906,7 +3910,7 @@ export interface StartFaceDetectionRequest {
 
 export namespace StartFaceDetectionRequest {
   export function isa(o: any): o is StartFaceDetectionRequest {
-    return _smithy.isa(o, "StartFaceDetectionRequest");
+    return __isa(o, "StartFaceDetectionRequest");
   }
 }
 
@@ -3921,7 +3925,7 @@ export interface StartFaceDetectionResponse extends $MetadataBearer {
 
 export namespace StartFaceDetectionResponse {
   export function isa(o: any): o is StartFaceDetectionResponse {
-    return _smithy.isa(o, "StartFaceDetectionResponse");
+    return __isa(o, "StartFaceDetectionResponse");
   }
 }
 
@@ -3964,7 +3968,7 @@ export interface StartFaceSearchRequest {
 
 export namespace StartFaceSearchRequest {
   export function isa(o: any): o is StartFaceSearchRequest {
-    return _smithy.isa(o, "StartFaceSearchRequest");
+    return __isa(o, "StartFaceSearchRequest");
   }
 }
 
@@ -3978,7 +3982,7 @@ export interface StartFaceSearchResponse extends $MetadataBearer {
 
 export namespace StartFaceSearchResponse {
   export function isa(o: any): o is StartFaceSearchResponse {
-    return _smithy.isa(o, "StartFaceSearchResponse");
+    return __isa(o, "StartFaceSearchResponse");
   }
 }
 
@@ -4022,7 +4026,7 @@ export interface StartLabelDetectionRequest {
 
 export namespace StartLabelDetectionRequest {
   export function isa(o: any): o is StartLabelDetectionRequest {
-    return _smithy.isa(o, "StartLabelDetectionRequest");
+    return __isa(o, "StartLabelDetectionRequest");
   }
 }
 
@@ -4037,7 +4041,7 @@ export interface StartLabelDetectionResponse extends $MetadataBearer {
 
 export namespace StartLabelDetectionResponse {
   export function isa(o: any): o is StartLabelDetectionResponse {
-    return _smithy.isa(o, "StartLabelDetectionResponse");
+    return __isa(o, "StartLabelDetectionResponse");
   }
 }
 
@@ -4071,7 +4075,7 @@ export interface StartPersonTrackingRequest {
 
 export namespace StartPersonTrackingRequest {
   export function isa(o: any): o is StartPersonTrackingRequest {
-    return _smithy.isa(o, "StartPersonTrackingRequest");
+    return __isa(o, "StartPersonTrackingRequest");
   }
 }
 
@@ -4086,7 +4090,7 @@ export interface StartPersonTrackingResponse extends $MetadataBearer {
 
 export namespace StartPersonTrackingResponse {
   export function isa(o: any): o is StartPersonTrackingResponse {
-    return _smithy.isa(o, "StartPersonTrackingResponse");
+    return __isa(o, "StartPersonTrackingResponse");
   }
 }
 
@@ -4109,7 +4113,7 @@ export interface StartProjectVersionRequest {
 
 export namespace StartProjectVersionRequest {
   export function isa(o: any): o is StartProjectVersionRequest {
-    return _smithy.isa(o, "StartProjectVersionRequest");
+    return __isa(o, "StartProjectVersionRequest");
   }
 }
 
@@ -4123,7 +4127,7 @@ export interface StartProjectVersionResponse extends $MetadataBearer {
 
 export namespace StartProjectVersionResponse {
   export function isa(o: any): o is StartProjectVersionResponse {
-    return _smithy.isa(o, "StartProjectVersionResponse");
+    return __isa(o, "StartProjectVersionResponse");
   }
 }
 
@@ -4137,7 +4141,7 @@ export interface StartStreamProcessorRequest {
 
 export namespace StartStreamProcessorRequest {
   export function isa(o: any): o is StartStreamProcessorRequest {
-    return _smithy.isa(o, "StartStreamProcessorRequest");
+    return __isa(o, "StartStreamProcessorRequest");
   }
 }
 
@@ -4147,7 +4151,7 @@ export interface StartStreamProcessorResponse extends $MetadataBearer {
 
 export namespace StartStreamProcessorResponse {
   export function isa(o: any): o is StartStreamProcessorResponse {
-    return _smithy.isa(o, "StartStreamProcessorResponse");
+    return __isa(o, "StartStreamProcessorResponse");
   }
 }
 
@@ -4162,7 +4166,7 @@ export interface StopProjectVersionRequest {
 
 export namespace StopProjectVersionRequest {
   export function isa(o: any): o is StopProjectVersionRequest {
-    return _smithy.isa(o, "StopProjectVersionRequest");
+    return __isa(o, "StopProjectVersionRequest");
   }
 }
 
@@ -4176,7 +4180,7 @@ export interface StopProjectVersionResponse extends $MetadataBearer {
 
 export namespace StopProjectVersionResponse {
   export function isa(o: any): o is StopProjectVersionResponse {
-    return _smithy.isa(o, "StopProjectVersionResponse");
+    return __isa(o, "StopProjectVersionResponse");
   }
 }
 
@@ -4190,7 +4194,7 @@ export interface StopStreamProcessorRequest {
 
 export namespace StopStreamProcessorRequest {
   export function isa(o: any): o is StopStreamProcessorRequest {
-    return _smithy.isa(o, "StopStreamProcessorRequest");
+    return __isa(o, "StopStreamProcessorRequest");
   }
 }
 
@@ -4200,7 +4204,7 @@ export interface StopStreamProcessorResponse extends $MetadataBearer {
 
 export namespace StopStreamProcessorResponse {
   export function isa(o: any): o is StopStreamProcessorResponse {
-    return _smithy.isa(o, "StopStreamProcessorResponse");
+    return __isa(o, "StopStreamProcessorResponse");
   }
 }
 
@@ -4225,7 +4229,7 @@ export interface StreamProcessor {
 
 export namespace StreamProcessor {
   export function isa(o: any): o is StreamProcessor {
-    return _smithy.isa(o, "StreamProcessor");
+    return __isa(o, "StreamProcessor");
   }
 }
 
@@ -4242,7 +4246,7 @@ export interface StreamProcessorInput {
 
 export namespace StreamProcessorInput {
   export function isa(o: any): o is StreamProcessorInput {
-    return _smithy.isa(o, "StreamProcessorInput");
+    return __isa(o, "StreamProcessorInput");
   }
 }
 
@@ -4260,7 +4264,7 @@ export interface StreamProcessorOutput {
 
 export namespace StreamProcessorOutput {
   export function isa(o: any): o is StreamProcessorOutput {
-    return _smithy.isa(o, "StreamProcessorOutput");
+    return __isa(o, "StreamProcessorOutput");
   }
 }
 
@@ -4277,7 +4281,7 @@ export interface StreamProcessorSettings {
 
 export namespace StreamProcessorSettings {
   export function isa(o: any): o is StreamProcessorSettings {
-    return _smithy.isa(o, "StreamProcessorSettings");
+    return __isa(o, "StreamProcessorSettings");
   }
 }
 
@@ -4312,7 +4316,7 @@ export interface Summary {
 
 export namespace Summary {
   export function isa(o: any): o is Summary {
-    return _smithy.isa(o, "Summary");
+    return __isa(o, "Summary");
   }
 }
 
@@ -4335,7 +4339,7 @@ export interface Sunglasses {
 
 export namespace Sunglasses {
   export function isa(o: any): o is Sunglasses {
-    return _smithy.isa(o, "Sunglasses");
+    return __isa(o, "Sunglasses");
   }
 }
 
@@ -4358,7 +4362,7 @@ export interface TestingData {
 
 export namespace TestingData {
   export function isa(o: any): o is TestingData {
-    return _smithy.isa(o, "TestingData");
+    return __isa(o, "TestingData");
   }
 }
 
@@ -4381,7 +4385,7 @@ export interface TestingDataResult {
 
 export namespace TestingDataResult {
   export function isa(o: any): o is TestingDataResult {
-    return _smithy.isa(o, "TestingDataResult");
+    return __isa(o, "TestingDataResult");
   }
 }
 
@@ -4437,7 +4441,7 @@ export interface TextDetection {
 
 export namespace TextDetection {
   export function isa(o: any): o is TextDetection {
-    return _smithy.isa(o, "TextDetection");
+    return __isa(o, "TextDetection");
   }
 }
 
@@ -4450,7 +4454,7 @@ export enum TextTypes {
  * <p>Amazon Rekognition is temporarily unable to process the request. Try your call again.</p>
  */
 export interface ThrottlingException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ThrottlingException";
   $fault: "server";
@@ -4461,7 +4465,7 @@ export interface ThrottlingException
 
 export namespace ThrottlingException {
   export function isa(o: any): o is ThrottlingException {
-    return _smithy.isa(o, "ThrottlingException");
+    return __isa(o, "ThrottlingException");
   }
 }
 
@@ -4478,7 +4482,7 @@ export interface TrainingData {
 
 export namespace TrainingData {
   export function isa(o: any): o is TrainingData {
-    return _smithy.isa(o, "TrainingData");
+    return __isa(o, "TrainingData");
   }
 }
 
@@ -4500,7 +4504,7 @@ export interface TrainingDataResult {
 
 export namespace TrainingDataResult {
   export function isa(o: any): o is TrainingDataResult {
-    return _smithy.isa(o, "TrainingDataResult");
+    return __isa(o, "TrainingDataResult");
   }
 }
 
@@ -4547,7 +4551,7 @@ export interface UnindexedFace {
 
 export namespace UnindexedFace {
   export function isa(o: any): o is UnindexedFace {
-    return _smithy.isa(o, "UnindexedFace");
+    return __isa(o, "UnindexedFace");
   }
 }
 
@@ -4565,7 +4569,7 @@ export interface Video {
 
 export namespace Video {
   export function isa(o: any): o is Video {
-    return _smithy.isa(o, "Video");
+    return __isa(o, "Video");
   }
 }
 
@@ -4614,7 +4618,7 @@ export interface VideoMetadata {
 
 export namespace VideoMetadata {
   export function isa(o: any): o is VideoMetadata {
-    return _smithy.isa(o, "VideoMetadata");
+    return __isa(o, "VideoMetadata");
   }
 }
 
@@ -4623,7 +4627,7 @@ export namespace VideoMetadata {
  *         The maximum duration is 2 hours. </p>
  */
 export interface VideoTooLargeException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "VideoTooLargeException";
   $fault: "client";
@@ -4634,6 +4638,6 @@ export interface VideoTooLargeException
 
 export namespace VideoTooLargeException {
   export function isa(o: any): o is VideoTooLargeException {
-    return _smithy.isa(o, "VideoTooLargeException");
+    return __isa(o, "VideoTooLargeException");
   }
 }

--- a/clients/client-rekognition/protocols/Aws_json1_1.ts
+++ b/clients/client-rekognition/protocols/Aws_json1_1.ts
@@ -335,7 +335,10 @@ import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  LazyJsonString as __LazyJsonString,
+  SmithyException as __SmithyException
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -7990,8 +7993,9 @@ const deserializeAws_json1_1HumanLoopActivationOutput = (
     output.HumanLoopActivationConditionsEvaluationResults !== undefined &&
     output.HumanLoopActivationConditionsEvaluationResults !== null
   ) {
-    contents.HumanLoopActivationConditionsEvaluationResults =
-      output.HumanLoopActivationConditionsEvaluationResults;
+    contents.HumanLoopActivationConditionsEvaluationResults = new __LazyJsonString(
+      output.HumanLoopActivationConditionsEvaluationResults
+    );
   }
   if (
     output.HumanLoopActivationReasons !== undefined &&

--- a/clients/client-resource-groups-tagging-api/models/index.ts
+++ b/clients/client-resource-groups-tagging-api/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -26,7 +29,7 @@ export interface ComplianceDetails {
 
 export namespace ComplianceDetails {
   export function isa(o: any): o is ComplianceDetails {
-    return _smithy.isa(o, "ComplianceDetails");
+    return __isa(o, "ComplianceDetails");
   }
 }
 
@@ -35,7 +38,7 @@ export namespace ComplianceDetails {
  *             again later.</p>
  */
 export interface ConcurrentModificationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ConcurrentModificationException";
   $fault: "client";
@@ -44,7 +47,7 @@ export interface ConcurrentModificationException
 
 export namespace ConcurrentModificationException {
   export function isa(o: any): o is ConcurrentModificationException {
-    return _smithy.isa(o, "ConcurrentModificationException");
+    return __isa(o, "ConcurrentModificationException");
   }
 }
 
@@ -71,7 +74,7 @@ export namespace ConcurrentModificationException {
  *          </ul>
  */
 export interface ConstraintViolationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ConstraintViolationException";
   $fault: "client";
@@ -80,7 +83,7 @@ export interface ConstraintViolationException
 
 export namespace ConstraintViolationException {
   export function isa(o: any): o is ConstraintViolationException {
-    return _smithy.isa(o, "ConstraintViolationException");
+    return __isa(o, "ConstraintViolationException");
   }
 }
 
@@ -90,7 +93,7 @@ export interface DescribeReportCreationInput {
 
 export namespace DescribeReportCreationInput {
   export function isa(o: any): o is DescribeReportCreationInput {
-    return _smithy.isa(o, "DescribeReportCreationInput");
+    return __isa(o, "DescribeReportCreationInput");
   }
 }
 
@@ -141,7 +144,7 @@ export interface DescribeReportCreationOutput extends $MetadataBearer {
 
 export namespace DescribeReportCreationOutput {
   export function isa(o: any): o is DescribeReportCreationOutput {
-    return _smithy.isa(o, "DescribeReportCreationOutput");
+    return __isa(o, "DescribeReportCreationOutput");
   }
 }
 
@@ -176,7 +179,7 @@ export interface FailureInfo {
 
 export namespace FailureInfo {
   export function isa(o: any): o is FailureInfo {
-    return _smithy.isa(o, "FailureInfo");
+    return __isa(o, "FailureInfo");
   }
 }
 
@@ -249,7 +252,7 @@ export interface GetComplianceSummaryInput {
 
 export namespace GetComplianceSummaryInput {
   export function isa(o: any): o is GetComplianceSummaryInput {
-    return _smithy.isa(o, "GetComplianceSummaryInput");
+    return __isa(o, "GetComplianceSummaryInput");
   }
 }
 
@@ -270,7 +273,7 @@ export interface GetComplianceSummaryOutput extends $MetadataBearer {
 
 export namespace GetComplianceSummaryOutput {
   export function isa(o: any): o is GetComplianceSummaryOutput {
-    return _smithy.isa(o, "GetComplianceSummaryOutput");
+    return __isa(o, "GetComplianceSummaryOutput");
   }
 }
 
@@ -409,7 +412,7 @@ export interface GetResourcesInput {
 
 export namespace GetResourcesInput {
   export function isa(o: any): o is GetResourcesInput {
-    return _smithy.isa(o, "GetResourcesInput");
+    return __isa(o, "GetResourcesInput");
   }
 }
 
@@ -430,7 +433,7 @@ export interface GetResourcesOutput extends $MetadataBearer {
 
 export namespace GetResourcesOutput {
   export function isa(o: any): o is GetResourcesOutput {
-    return _smithy.isa(o, "GetResourcesOutput");
+    return __isa(o, "GetResourcesOutput");
   }
 }
 
@@ -447,7 +450,7 @@ export interface GetTagKeysInput {
 
 export namespace GetTagKeysInput {
   export function isa(o: any): o is GetTagKeysInput {
-    return _smithy.isa(o, "GetTagKeysInput");
+    return __isa(o, "GetTagKeysInput");
   }
 }
 
@@ -468,7 +471,7 @@ export interface GetTagKeysOutput extends $MetadataBearer {
 
 export namespace GetTagKeysOutput {
   export function isa(o: any): o is GetTagKeysOutput {
-    return _smithy.isa(o, "GetTagKeysOutput");
+    return __isa(o, "GetTagKeysOutput");
   }
 }
 
@@ -491,7 +494,7 @@ export interface GetTagValuesInput {
 
 export namespace GetTagValuesInput {
   export function isa(o: any): o is GetTagValuesInput {
-    return _smithy.isa(o, "GetTagValuesInput");
+    return __isa(o, "GetTagValuesInput");
   }
 }
 
@@ -512,7 +515,7 @@ export interface GetTagValuesOutput extends $MetadataBearer {
 
 export namespace GetTagValuesOutput {
   export function isa(o: any): o is GetTagValuesOutput {
-    return _smithy.isa(o, "GetTagValuesOutput");
+    return __isa(o, "GetTagValuesOutput");
   }
 }
 
@@ -527,7 +530,7 @@ export enum GroupByAttribute {
  *             can retry the request.</p>
  */
 export interface InternalServiceException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalServiceException";
   $fault: "server";
@@ -536,7 +539,7 @@ export interface InternalServiceException
 
 export namespace InternalServiceException {
   export function isa(o: any): o is InternalServiceException {
-    return _smithy.isa(o, "InternalServiceException");
+    return __isa(o, "InternalServiceException");
   }
 }
 
@@ -564,7 +567,7 @@ export namespace InternalServiceException {
  *          </ul>
  */
 export interface InvalidParameterException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidParameterException";
   $fault: "client";
@@ -573,7 +576,7 @@ export interface InvalidParameterException
 
 export namespace InvalidParameterException {
   export function isa(o: any): o is InvalidParameterException {
-    return _smithy.isa(o, "InvalidParameterException");
+    return __isa(o, "InvalidParameterException");
   }
 }
 
@@ -582,7 +585,7 @@ export namespace InvalidParameterException {
  *             denied because the specified <code>PaginationToken</code> has expired.</p>
  */
 export interface PaginationTokenExpiredException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "PaginationTokenExpiredException";
   $fault: "client";
@@ -591,7 +594,7 @@ export interface PaginationTokenExpiredException
 
 export namespace PaginationTokenExpiredException {
   export function isa(o: any): o is PaginationTokenExpiredException {
-    return _smithy.isa(o, "PaginationTokenExpiredException");
+    return __isa(o, "PaginationTokenExpiredException");
   }
 }
 
@@ -620,7 +623,7 @@ export interface ResourceTagMapping {
 
 export namespace ResourceTagMapping {
   export function isa(o: any): o is ResourceTagMapping {
-    return _smithy.isa(o, "ResourceTagMapping");
+    return __isa(o, "ResourceTagMapping");
   }
 }
 
@@ -639,7 +642,7 @@ export interface StartReportCreationInput {
 
 export namespace StartReportCreationInput {
   export function isa(o: any): o is StartReportCreationInput {
-    return _smithy.isa(o, "StartReportCreationInput");
+    return __isa(o, "StartReportCreationInput");
   }
 }
 
@@ -649,7 +652,7 @@ export interface StartReportCreationOutput extends $MetadataBearer {
 
 export namespace StartReportCreationOutput {
   export function isa(o: any): o is StartReportCreationOutput {
-    return _smithy.isa(o, "StartReportCreationOutput");
+    return __isa(o, "StartReportCreationOutput");
   }
 }
 
@@ -692,7 +695,7 @@ export interface Summary {
 
 export namespace Summary {
   export function isa(o: any): o is Summary {
-    return _smithy.isa(o, "Summary");
+    return __isa(o, "Summary");
   }
 }
 
@@ -717,7 +720,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -740,7 +743,7 @@ export interface TagFilter {
 
 export namespace TagFilter {
   export function isa(o: any): o is TagFilter {
-    return _smithy.isa(o, "TagFilter");
+    return __isa(o, "TagFilter");
   }
 }
 
@@ -764,7 +767,7 @@ export interface TagResourcesInput {
 
 export namespace TagResourcesInput {
   export function isa(o: any): o is TagResourcesInput {
-    return _smithy.isa(o, "TagResourcesInput");
+    return __isa(o, "TagResourcesInput");
   }
 }
 
@@ -779,7 +782,7 @@ export interface TagResourcesOutput extends $MetadataBearer {
 
 export namespace TagResourcesOutput {
   export function isa(o: any): o is TagResourcesOutput {
-    return _smithy.isa(o, "TagResourcesOutput");
+    return __isa(o, "TagResourcesOutput");
   }
 }
 
@@ -792,9 +795,7 @@ export enum TargetIdType {
 /**
  * <p>The request was denied to limit the frequency of submitted requests.</p>
  */
-export interface ThrottledException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface ThrottledException extends __SmithyException, $MetadataBearer {
   name: "ThrottledException";
   $fault: "client";
   Message?: string;
@@ -802,7 +803,7 @@ export interface ThrottledException
 
 export namespace ThrottledException {
   export function isa(o: any): o is ThrottledException {
-    return _smithy.isa(o, "ThrottledException");
+    return __isa(o, "ThrottledException");
   }
 }
 
@@ -825,7 +826,7 @@ export interface UntagResourcesInput {
 
 export namespace UntagResourcesInput {
   export function isa(o: any): o is UntagResourcesInput {
-    return _smithy.isa(o, "UntagResourcesInput");
+    return __isa(o, "UntagResourcesInput");
   }
 }
 
@@ -840,6 +841,6 @@ export interface UntagResourcesOutput extends $MetadataBearer {
 
 export namespace UntagResourcesOutput {
   export function isa(o: any): o is UntagResourcesOutput {
-    return _smithy.isa(o, "UntagResourcesOutput");
+    return __isa(o, "UntagResourcesOutput");
   }
 }

--- a/clients/client-resource-groups/models/index.ts
+++ b/clients/client-resource-groups/models/index.ts
@@ -1,11 +1,14 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
  * <p>The request does not comply with validation rules that are defined for the request parameters.</p>
  */
 export interface BadRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "BadRequestException";
   $fault: "client";
@@ -14,7 +17,7 @@ export interface BadRequestException
 
 export namespace BadRequestException {
   export function isa(o: any): o is BadRequestException {
-    return _smithy.isa(o, "BadRequestException");
+    return __isa(o, "BadRequestException");
   }
 }
 
@@ -47,7 +50,7 @@ export interface CreateGroupInput {
 
 export namespace CreateGroupInput {
   export function isa(o: any): o is CreateGroupInput {
-    return _smithy.isa(o, "CreateGroupInput");
+    return __isa(o, "CreateGroupInput");
   }
 }
 
@@ -71,7 +74,7 @@ export interface CreateGroupOutput extends $MetadataBearer {
 
 export namespace CreateGroupOutput {
   export function isa(o: any): o is CreateGroupOutput {
-    return _smithy.isa(o, "CreateGroupOutput");
+    return __isa(o, "CreateGroupOutput");
   }
 }
 
@@ -85,7 +88,7 @@ export interface DeleteGroupInput {
 
 export namespace DeleteGroupInput {
   export function isa(o: any): o is DeleteGroupInput {
-    return _smithy.isa(o, "DeleteGroupInput");
+    return __isa(o, "DeleteGroupInput");
   }
 }
 
@@ -99,16 +102,14 @@ export interface DeleteGroupOutput extends $MetadataBearer {
 
 export namespace DeleteGroupOutput {
   export function isa(o: any): o is DeleteGroupOutput {
-    return _smithy.isa(o, "DeleteGroupOutput");
+    return __isa(o, "DeleteGroupOutput");
   }
 }
 
 /**
  * <p>The caller is not authorized to make the request.</p>
  */
-export interface ForbiddenException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface ForbiddenException extends __SmithyException, $MetadataBearer {
   name: "ForbiddenException";
   $fault: "client";
   Message?: string;
@@ -116,7 +117,7 @@ export interface ForbiddenException
 
 export namespace ForbiddenException {
   export function isa(o: any): o is ForbiddenException {
-    return _smithy.isa(o, "ForbiddenException");
+    return __isa(o, "ForbiddenException");
   }
 }
 
@@ -130,7 +131,7 @@ export interface GetGroupInput {
 
 export namespace GetGroupInput {
   export function isa(o: any): o is GetGroupInput {
-    return _smithy.isa(o, "GetGroupInput");
+    return __isa(o, "GetGroupInput");
   }
 }
 
@@ -144,7 +145,7 @@ export interface GetGroupOutput extends $MetadataBearer {
 
 export namespace GetGroupOutput {
   export function isa(o: any): o is GetGroupOutput {
-    return _smithy.isa(o, "GetGroupOutput");
+    return __isa(o, "GetGroupOutput");
   }
 }
 
@@ -158,7 +159,7 @@ export interface GetGroupQueryInput {
 
 export namespace GetGroupQueryInput {
   export function isa(o: any): o is GetGroupQueryInput {
-    return _smithy.isa(o, "GetGroupQueryInput");
+    return __isa(o, "GetGroupQueryInput");
   }
 }
 
@@ -172,7 +173,7 @@ export interface GetGroupQueryOutput extends $MetadataBearer {
 
 export namespace GetGroupQueryOutput {
   export function isa(o: any): o is GetGroupQueryOutput {
-    return _smithy.isa(o, "GetGroupQueryOutput");
+    return __isa(o, "GetGroupQueryOutput");
   }
 }
 
@@ -186,7 +187,7 @@ export interface GetTagsInput {
 
 export namespace GetTagsInput {
   export function isa(o: any): o is GetTagsInput {
-    return _smithy.isa(o, "GetTagsInput");
+    return __isa(o, "GetTagsInput");
   }
 }
 
@@ -205,7 +206,7 @@ export interface GetTagsOutput extends $MetadataBearer {
 
 export namespace GetTagsOutput {
   export function isa(o: any): o is GetTagsOutput {
-    return _smithy.isa(o, "GetTagsOutput");
+    return __isa(o, "GetTagsOutput");
   }
 }
 
@@ -232,7 +233,7 @@ export interface Group {
 
 export namespace Group {
   export function isa(o: any): o is Group {
-    return _smithy.isa(o, "Group");
+    return __isa(o, "Group");
   }
 }
 
@@ -254,7 +255,7 @@ export interface GroupFilter {
 
 export namespace GroupFilter {
   export function isa(o: any): o is GroupFilter {
-    return _smithy.isa(o, "GroupFilter");
+    return __isa(o, "GroupFilter");
   }
 }
 
@@ -280,7 +281,7 @@ export interface GroupIdentifier {
 
 export namespace GroupIdentifier {
   export function isa(o: any): o is GroupIdentifier {
-    return _smithy.isa(o, "GroupIdentifier");
+    return __isa(o, "GroupIdentifier");
   }
 }
 
@@ -302,7 +303,7 @@ export interface GroupQuery {
 
 export namespace GroupQuery {
   export function isa(o: any): o is GroupQuery {
-    return _smithy.isa(o, "GroupQuery");
+    return __isa(o, "GroupQuery");
   }
 }
 
@@ -310,7 +311,7 @@ export namespace GroupQuery {
  * <p>An internal error occurred while processing the request.</p>
  */
 export interface InternalServerErrorException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalServerErrorException";
   $fault: "server";
@@ -319,7 +320,7 @@ export interface InternalServerErrorException
 
 export namespace InternalServerErrorException {
   export function isa(o: any): o is InternalServerErrorException {
-    return _smithy.isa(o, "InternalServerErrorException");
+    return __isa(o, "InternalServerErrorException");
   }
 }
 
@@ -355,7 +356,7 @@ export interface ListGroupResourcesInput {
 
 export namespace ListGroupResourcesInput {
   export function isa(o: any): o is ListGroupResourcesInput {
-    return _smithy.isa(o, "ListGroupResourcesInput");
+    return __isa(o, "ListGroupResourcesInput");
   }
 }
 
@@ -381,7 +382,7 @@ export interface ListGroupResourcesOutput extends $MetadataBearer {
 
 export namespace ListGroupResourcesOutput {
   export function isa(o: any): o is ListGroupResourcesOutput {
-    return _smithy.isa(o, "ListGroupResourcesOutput");
+    return __isa(o, "ListGroupResourcesOutput");
   }
 }
 
@@ -412,7 +413,7 @@ export interface ListGroupsInput {
 
 export namespace ListGroupsInput {
   export function isa(o: any): o is ListGroupsInput {
-    return _smithy.isa(o, "ListGroupsInput");
+    return __isa(o, "ListGroupsInput");
   }
 }
 
@@ -436,7 +437,7 @@ export interface ListGroupsOutput extends $MetadataBearer {
 
 export namespace ListGroupsOutput {
   export function isa(o: any): o is ListGroupsOutput {
-    return _smithy.isa(o, "ListGroupsOutput");
+    return __isa(o, "ListGroupsOutput");
   }
 }
 
@@ -444,7 +445,7 @@ export namespace ListGroupsOutput {
  * <p>The request uses an HTTP method which is not allowed for the specified resource.</p>
  */
 export interface MethodNotAllowedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "MethodNotAllowedException";
   $fault: "client";
@@ -453,16 +454,14 @@ export interface MethodNotAllowedException
 
 export namespace MethodNotAllowedException {
   export function isa(o: any): o is MethodNotAllowedException {
-    return _smithy.isa(o, "MethodNotAllowedException");
+    return __isa(o, "MethodNotAllowedException");
   }
 }
 
 /**
  * <p>One or more resources specified in the request do not exist.</p>
  */
-export interface NotFoundException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface NotFoundException extends __SmithyException, $MetadataBearer {
   name: "NotFoundException";
   $fault: "client";
   Message?: string;
@@ -470,7 +469,7 @@ export interface NotFoundException
 
 export namespace NotFoundException {
   export function isa(o: any): o is NotFoundException {
-    return _smithy.isa(o, "NotFoundException");
+    return __isa(o, "NotFoundException");
   }
 }
 
@@ -501,7 +500,7 @@ export interface QueryError {
 
 export namespace QueryError {
   export function isa(o: any): o is QueryError {
-    return _smithy.isa(o, "QueryError");
+    return __isa(o, "QueryError");
   }
 }
 
@@ -533,7 +532,7 @@ export interface ResourceFilter {
 
 export namespace ResourceFilter {
   export function isa(o: any): o is ResourceFilter {
-    return _smithy.isa(o, "ResourceFilter");
+    return __isa(o, "ResourceFilter");
   }
 }
 
@@ -559,7 +558,7 @@ export interface ResourceIdentifier {
 
 export namespace ResourceIdentifier {
   export function isa(o: any): o is ResourceIdentifier {
-    return _smithy.isa(o, "ResourceIdentifier");
+    return __isa(o, "ResourceIdentifier");
   }
 }
 
@@ -614,7 +613,7 @@ export interface ResourceQuery {
 
 export namespace ResourceQuery {
   export function isa(o: any): o is ResourceQuery {
-    return _smithy.isa(o, "ResourceQuery");
+    return __isa(o, "ResourceQuery");
   }
 }
 
@@ -639,7 +638,7 @@ export interface SearchResourcesInput {
 
 export namespace SearchResourcesInput {
   export function isa(o: any): o is SearchResourcesInput {
-    return _smithy.isa(o, "SearchResourcesInput");
+    return __isa(o, "SearchResourcesInput");
   }
 }
 
@@ -666,7 +665,7 @@ export interface SearchResourcesOutput extends $MetadataBearer {
 
 export namespace SearchResourcesOutput {
   export function isa(o: any): o is SearchResourcesOutput {
-    return _smithy.isa(o, "SearchResourcesOutput");
+    return __isa(o, "SearchResourcesOutput");
   }
 }
 
@@ -686,7 +685,7 @@ export interface TagInput {
 
 export namespace TagInput {
   export function isa(o: any): o is TagInput {
-    return _smithy.isa(o, "TagInput");
+    return __isa(o, "TagInput");
   }
 }
 
@@ -705,7 +704,7 @@ export interface TagOutput extends $MetadataBearer {
 
 export namespace TagOutput {
   export function isa(o: any): o is TagOutput {
-    return _smithy.isa(o, "TagOutput");
+    return __isa(o, "TagOutput");
   }
 }
 
@@ -713,7 +712,7 @@ export namespace TagOutput {
  * <p>The caller has exceeded throttling limits.</p>
  */
 export interface TooManyRequestsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyRequestsException";
   $fault: "client";
@@ -722,7 +721,7 @@ export interface TooManyRequestsException
 
 export namespace TooManyRequestsException {
   export function isa(o: any): o is TooManyRequestsException {
-    return _smithy.isa(o, "TooManyRequestsException");
+    return __isa(o, "TooManyRequestsException");
   }
 }
 
@@ -730,7 +729,7 @@ export namespace TooManyRequestsException {
  * <p>The request has not been applied because it lacks valid authentication credentials for the target resource.</p>
  */
 export interface UnauthorizedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UnauthorizedException";
   $fault: "client";
@@ -739,7 +738,7 @@ export interface UnauthorizedException
 
 export namespace UnauthorizedException {
   export function isa(o: any): o is UnauthorizedException {
-    return _smithy.isa(o, "UnauthorizedException");
+    return __isa(o, "UnauthorizedException");
   }
 }
 
@@ -758,7 +757,7 @@ export interface UntagInput {
 
 export namespace UntagInput {
   export function isa(o: any): o is UntagInput {
-    return _smithy.isa(o, "UntagInput");
+    return __isa(o, "UntagInput");
   }
 }
 
@@ -777,7 +776,7 @@ export interface UntagOutput extends $MetadataBearer {
 
 export namespace UntagOutput {
   export function isa(o: any): o is UntagOutput {
-    return _smithy.isa(o, "UntagOutput");
+    return __isa(o, "UntagOutput");
   }
 }
 
@@ -797,7 +796,7 @@ export interface UpdateGroupInput {
 
 export namespace UpdateGroupInput {
   export function isa(o: any): o is UpdateGroupInput {
-    return _smithy.isa(o, "UpdateGroupInput");
+    return __isa(o, "UpdateGroupInput");
   }
 }
 
@@ -811,7 +810,7 @@ export interface UpdateGroupOutput extends $MetadataBearer {
 
 export namespace UpdateGroupOutput {
   export function isa(o: any): o is UpdateGroupOutput {
-    return _smithy.isa(o, "UpdateGroupOutput");
+    return __isa(o, "UpdateGroupOutput");
   }
 }
 
@@ -830,7 +829,7 @@ export interface UpdateGroupQueryInput {
 
 export namespace UpdateGroupQueryInput {
   export function isa(o: any): o is UpdateGroupQueryInput {
-    return _smithy.isa(o, "UpdateGroupQueryInput");
+    return __isa(o, "UpdateGroupQueryInput");
   }
 }
 
@@ -844,6 +843,6 @@ export interface UpdateGroupQueryOutput extends $MetadataBearer {
 
 export namespace UpdateGroupQueryOutput {
   export function isa(o: any): o is UpdateGroupQueryOutput {
-    return _smithy.isa(o, "UpdateGroupQueryOutput");
+    return __isa(o, "UpdateGroupQueryOutput");
   }
 }

--- a/clients/client-resource-groups/protocols/Aws_restJson1_1.ts
+++ b/clients/client-resource-groups/protocols/Aws_restJson1_1.ts
@@ -64,7 +64,10 @@ import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  extendedEncodeURIComponent as __extendedEncodeURIComponent
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -115,13 +118,13 @@ export async function serializeAws_restJson1_1DeleteGroupCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/groups/{GroupName}";
   if (input.GroupName !== undefined) {
-    const labelValue: string = input.GroupName.toString();
+    const labelValue: string = input.GroupName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: GroupName.");
     }
     resolvedPath = resolvedPath.replace(
       "{GroupName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: GroupName.");
@@ -143,13 +146,13 @@ export async function serializeAws_restJson1_1GetGroupCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/groups/{GroupName}";
   if (input.GroupName !== undefined) {
-    const labelValue: string = input.GroupName.toString();
+    const labelValue: string = input.GroupName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: GroupName.");
     }
     resolvedPath = resolvedPath.replace(
       "{GroupName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: GroupName.");
@@ -171,13 +174,13 @@ export async function serializeAws_restJson1_1GetGroupQueryCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/groups/{GroupName}/query";
   if (input.GroupName !== undefined) {
-    const labelValue: string = input.GroupName.toString();
+    const labelValue: string = input.GroupName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: GroupName.");
     }
     resolvedPath = resolvedPath.replace(
       "{GroupName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: GroupName.");
@@ -199,13 +202,13 @@ export async function serializeAws_restJson1_1GetTagsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/resources/{Arn}/tags";
   if (input.Arn !== undefined) {
-    const labelValue: string = input.Arn.toString();
+    const labelValue: string = input.Arn;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Arn.");
     }
     resolvedPath = resolvedPath.replace(
       "{Arn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Arn.");
@@ -227,23 +230,27 @@ export async function serializeAws_restJson1_1ListGroupResourcesCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/groups/{GroupName}/resource-identifiers-list";
   if (input.GroupName !== undefined) {
-    const labelValue: string = input.GroupName.toString();
+    const labelValue: string = input.GroupName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: GroupName.");
     }
     resolvedPath = resolvedPath.replace(
       "{GroupName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: GroupName.");
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   let body: any;
   const bodyParams: any = {};
@@ -274,10 +281,14 @@ export async function serializeAws_restJson1_1ListGroupsCommand(
   let resolvedPath = "/groups-list";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   let body: any;
   const bodyParams: any = {};
@@ -339,13 +350,13 @@ export async function serializeAws_restJson1_1TagCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/resources/{Arn}/tags";
   if (input.Arn !== undefined) {
-    const labelValue: string = input.Arn.toString();
+    const labelValue: string = input.Arn;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Arn.");
     }
     resolvedPath = resolvedPath.replace(
       "{Arn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Arn.");
@@ -374,13 +385,13 @@ export async function serializeAws_restJson1_1UntagCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/resources/{Arn}/tags";
   if (input.Arn !== undefined) {
-    const labelValue: string = input.Arn.toString();
+    const labelValue: string = input.Arn;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Arn.");
     }
     resolvedPath = resolvedPath.replace(
       "{Arn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Arn.");
@@ -412,13 +423,13 @@ export async function serializeAws_restJson1_1UpdateGroupCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/groups/{GroupName}";
   if (input.GroupName !== undefined) {
-    const labelValue: string = input.GroupName.toString();
+    const labelValue: string = input.GroupName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: GroupName.");
     }
     resolvedPath = resolvedPath.replace(
       "{GroupName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: GroupName.");
@@ -447,13 +458,13 @@ export async function serializeAws_restJson1_1UpdateGroupQueryCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/groups/{GroupName}/query";
   if (input.GroupName !== undefined) {
-    const labelValue: string = input.GroupName.toString();
+    const labelValue: string = input.GroupName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: GroupName.");
     }
     resolvedPath = resolvedPath.replace(
       "{GroupName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: GroupName.");

--- a/clients/client-robomaker/models/index.ts
+++ b/clients/client-robomaker/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export enum Architecture {
@@ -17,7 +20,7 @@ export interface BatchDescribeSimulationJobRequest {
 
 export namespace BatchDescribeSimulationJobRequest {
   export function isa(o: any): o is BatchDescribeSimulationJobRequest {
-    return _smithy.isa(o, "BatchDescribeSimulationJobRequest");
+    return __isa(o, "BatchDescribeSimulationJobRequest");
   }
 }
 
@@ -36,7 +39,7 @@ export interface BatchDescribeSimulationJobResponse extends $MetadataBearer {
 
 export namespace BatchDescribeSimulationJobResponse {
   export function isa(o: any): o is BatchDescribeSimulationJobResponse {
-    return _smithy.isa(o, "BatchDescribeSimulationJobResponse");
+    return __isa(o, "BatchDescribeSimulationJobResponse");
   }
 }
 
@@ -50,7 +53,7 @@ export interface CancelDeploymentJobRequest {
 
 export namespace CancelDeploymentJobRequest {
   export function isa(o: any): o is CancelDeploymentJobRequest {
-    return _smithy.isa(o, "CancelDeploymentJobRequest");
+    return __isa(o, "CancelDeploymentJobRequest");
   }
 }
 
@@ -60,7 +63,7 @@ export interface CancelDeploymentJobResponse extends $MetadataBearer {
 
 export namespace CancelDeploymentJobResponse {
   export function isa(o: any): o is CancelDeploymentJobResponse {
-    return _smithy.isa(o, "CancelDeploymentJobResponse");
+    return __isa(o, "CancelDeploymentJobResponse");
   }
 }
 
@@ -74,7 +77,7 @@ export interface CancelSimulationJobRequest {
 
 export namespace CancelSimulationJobRequest {
   export function isa(o: any): o is CancelSimulationJobRequest {
-    return _smithy.isa(o, "CancelSimulationJobRequest");
+    return __isa(o, "CancelSimulationJobRequest");
   }
 }
 
@@ -84,7 +87,7 @@ export interface CancelSimulationJobResponse extends $MetadataBearer {
 
 export namespace CancelSimulationJobResponse {
   export function isa(o: any): o is CancelSimulationJobResponse {
-    return _smithy.isa(o, "CancelSimulationJobResponse");
+    return __isa(o, "CancelSimulationJobResponse");
   }
 }
 
@@ -92,7 +95,7 @@ export namespace CancelSimulationJobResponse {
  * <p>The failure percentage threshold percentage was met.</p>
  */
 export interface ConcurrentDeploymentException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ConcurrentDeploymentException";
   $fault: "client";
@@ -101,7 +104,7 @@ export interface ConcurrentDeploymentException
 
 export namespace ConcurrentDeploymentException {
   export function isa(o: any): o is ConcurrentDeploymentException {
-    return _smithy.isa(o, "ConcurrentDeploymentException");
+    return __isa(o, "ConcurrentDeploymentException");
   }
 }
 
@@ -135,7 +138,7 @@ export interface CreateDeploymentJobRequest {
 
 export namespace CreateDeploymentJobRequest {
   export function isa(o: any): o is CreateDeploymentJobRequest {
-    return _smithy.isa(o, "CreateDeploymentJobRequest");
+    return __isa(o, "CreateDeploymentJobRequest");
   }
 }
 
@@ -250,7 +253,7 @@ export interface CreateDeploymentJobResponse extends $MetadataBearer {
 
 export namespace CreateDeploymentJobResponse {
   export function isa(o: any): o is CreateDeploymentJobResponse {
-    return _smithy.isa(o, "CreateDeploymentJobResponse");
+    return __isa(o, "CreateDeploymentJobResponse");
   }
 }
 
@@ -269,7 +272,7 @@ export interface CreateFleetRequest {
 
 export namespace CreateFleetRequest {
   export function isa(o: any): o is CreateFleetRequest {
-    return _smithy.isa(o, "CreateFleetRequest");
+    return __isa(o, "CreateFleetRequest");
   }
 }
 
@@ -298,7 +301,7 @@ export interface CreateFleetResponse extends $MetadataBearer {
 
 export namespace CreateFleetResponse {
   export function isa(o: any): o is CreateFleetResponse {
-    return _smithy.isa(o, "CreateFleetResponse");
+    return __isa(o, "CreateFleetResponse");
   }
 }
 
@@ -327,7 +330,7 @@ export interface CreateRobotApplicationRequest {
 
 export namespace CreateRobotApplicationRequest {
   export function isa(o: any): o is CreateRobotApplicationRequest {
-    return _smithy.isa(o, "CreateRobotApplicationRequest");
+    return __isa(o, "CreateRobotApplicationRequest");
   }
 }
 
@@ -376,7 +379,7 @@ export interface CreateRobotApplicationResponse extends $MetadataBearer {
 
 export namespace CreateRobotApplicationResponse {
   export function isa(o: any): o is CreateRobotApplicationResponse {
-    return _smithy.isa(o, "CreateRobotApplicationResponse");
+    return __isa(o, "CreateRobotApplicationResponse");
   }
 }
 
@@ -396,7 +399,7 @@ export interface CreateRobotApplicationVersionRequest {
 
 export namespace CreateRobotApplicationVersionRequest {
   export function isa(o: any): o is CreateRobotApplicationVersionRequest {
-    return _smithy.isa(o, "CreateRobotApplicationVersionRequest");
+    return __isa(o, "CreateRobotApplicationVersionRequest");
   }
 }
 
@@ -440,7 +443,7 @@ export interface CreateRobotApplicationVersionResponse extends $MetadataBearer {
 
 export namespace CreateRobotApplicationVersionResponse {
   export function isa(o: any): o is CreateRobotApplicationVersionResponse {
-    return _smithy.isa(o, "CreateRobotApplicationVersionResponse");
+    return __isa(o, "CreateRobotApplicationVersionResponse");
   }
 }
 
@@ -469,7 +472,7 @@ export interface CreateRobotRequest {
 
 export namespace CreateRobotRequest {
   export function isa(o: any): o is CreateRobotRequest {
-    return _smithy.isa(o, "CreateRobotRequest");
+    return __isa(o, "CreateRobotRequest");
   }
 }
 
@@ -508,7 +511,7 @@ export interface CreateRobotResponse extends $MetadataBearer {
 
 export namespace CreateRobotResponse {
   export function isa(o: any): o is CreateRobotResponse {
-    return _smithy.isa(o, "CreateRobotResponse");
+    return __isa(o, "CreateRobotResponse");
   }
 }
 
@@ -547,7 +550,7 @@ export interface CreateSimulationApplicationRequest {
 
 export namespace CreateSimulationApplicationRequest {
   export function isa(o: any): o is CreateSimulationApplicationRequest {
-    return _smithy.isa(o, "CreateSimulationApplicationRequest");
+    return __isa(o, "CreateSimulationApplicationRequest");
   }
 }
 
@@ -606,7 +609,7 @@ export interface CreateSimulationApplicationResponse extends $MetadataBearer {
 
 export namespace CreateSimulationApplicationResponse {
   export function isa(o: any): o is CreateSimulationApplicationResponse {
-    return _smithy.isa(o, "CreateSimulationApplicationResponse");
+    return __isa(o, "CreateSimulationApplicationResponse");
   }
 }
 
@@ -626,7 +629,7 @@ export interface CreateSimulationApplicationVersionRequest {
 
 export namespace CreateSimulationApplicationVersionRequest {
   export function isa(o: any): o is CreateSimulationApplicationVersionRequest {
-    return _smithy.isa(o, "CreateSimulationApplicationVersionRequest");
+    return __isa(o, "CreateSimulationApplicationVersionRequest");
   }
 }
 
@@ -681,7 +684,7 @@ export interface CreateSimulationApplicationVersionResponse
 
 export namespace CreateSimulationApplicationVersionResponse {
   export function isa(o: any): o is CreateSimulationApplicationVersionResponse {
-    return _smithy.isa(o, "CreateSimulationApplicationVersionResponse");
+    return __isa(o, "CreateSimulationApplicationVersionResponse");
   }
 }
 
@@ -766,7 +769,7 @@ export interface CreateSimulationJobRequest {
 
 export namespace CreateSimulationJobRequest {
   export function isa(o: any): o is CreateSimulationJobRequest {
-    return _smithy.isa(o, "CreateSimulationJobRequest");
+    return __isa(o, "CreateSimulationJobRequest");
   }
 }
 
@@ -920,7 +923,7 @@ export interface CreateSimulationJobResponse extends $MetadataBearer {
 
 export namespace CreateSimulationJobResponse {
   export function isa(o: any): o is CreateSimulationJobResponse {
-    return _smithy.isa(o, "CreateSimulationJobResponse");
+    return __isa(o, "CreateSimulationJobResponse");
   }
 }
 
@@ -947,7 +950,7 @@ export interface DataSource {
 
 export namespace DataSource {
   export function isa(o: any): o is DataSource {
-    return _smithy.isa(o, "DataSource");
+    return __isa(o, "DataSource");
   }
 }
 
@@ -974,7 +977,7 @@ export interface DataSourceConfig {
 
 export namespace DataSourceConfig {
   export function isa(o: any): o is DataSourceConfig {
-    return _smithy.isa(o, "DataSourceConfig");
+    return __isa(o, "DataSourceConfig");
   }
 }
 
@@ -988,7 +991,7 @@ export interface DeleteFleetRequest {
 
 export namespace DeleteFleetRequest {
   export function isa(o: any): o is DeleteFleetRequest {
-    return _smithy.isa(o, "DeleteFleetRequest");
+    return __isa(o, "DeleteFleetRequest");
   }
 }
 
@@ -998,7 +1001,7 @@ export interface DeleteFleetResponse extends $MetadataBearer {
 
 export namespace DeleteFleetResponse {
   export function isa(o: any): o is DeleteFleetResponse {
-    return _smithy.isa(o, "DeleteFleetResponse");
+    return __isa(o, "DeleteFleetResponse");
   }
 }
 
@@ -1017,7 +1020,7 @@ export interface DeleteRobotApplicationRequest {
 
 export namespace DeleteRobotApplicationRequest {
   export function isa(o: any): o is DeleteRobotApplicationRequest {
-    return _smithy.isa(o, "DeleteRobotApplicationRequest");
+    return __isa(o, "DeleteRobotApplicationRequest");
   }
 }
 
@@ -1027,7 +1030,7 @@ export interface DeleteRobotApplicationResponse extends $MetadataBearer {
 
 export namespace DeleteRobotApplicationResponse {
   export function isa(o: any): o is DeleteRobotApplicationResponse {
-    return _smithy.isa(o, "DeleteRobotApplicationResponse");
+    return __isa(o, "DeleteRobotApplicationResponse");
   }
 }
 
@@ -1041,7 +1044,7 @@ export interface DeleteRobotRequest {
 
 export namespace DeleteRobotRequest {
   export function isa(o: any): o is DeleteRobotRequest {
-    return _smithy.isa(o, "DeleteRobotRequest");
+    return __isa(o, "DeleteRobotRequest");
   }
 }
 
@@ -1051,7 +1054,7 @@ export interface DeleteRobotResponse extends $MetadataBearer {
 
 export namespace DeleteRobotResponse {
   export function isa(o: any): o is DeleteRobotResponse {
-    return _smithy.isa(o, "DeleteRobotResponse");
+    return __isa(o, "DeleteRobotResponse");
   }
 }
 
@@ -1070,7 +1073,7 @@ export interface DeleteSimulationApplicationRequest {
 
 export namespace DeleteSimulationApplicationRequest {
   export function isa(o: any): o is DeleteSimulationApplicationRequest {
-    return _smithy.isa(o, "DeleteSimulationApplicationRequest");
+    return __isa(o, "DeleteSimulationApplicationRequest");
   }
 }
 
@@ -1080,7 +1083,7 @@ export interface DeleteSimulationApplicationResponse extends $MetadataBearer {
 
 export namespace DeleteSimulationApplicationResponse {
   export function isa(o: any): o is DeleteSimulationApplicationResponse {
-    return _smithy.isa(o, "DeleteSimulationApplicationResponse");
+    return __isa(o, "DeleteSimulationApplicationResponse");
   }
 }
 
@@ -1107,7 +1110,7 @@ export interface DeploymentApplicationConfig {
 
 export namespace DeploymentApplicationConfig {
   export function isa(o: any): o is DeploymentApplicationConfig {
-    return _smithy.isa(o, "DeploymentApplicationConfig");
+    return __isa(o, "DeploymentApplicationConfig");
   }
 }
 
@@ -1140,7 +1143,7 @@ export interface DeploymentConfig {
 
 export namespace DeploymentConfig {
   export function isa(o: any): o is DeploymentConfig {
-    return _smithy.isa(o, "DeploymentConfig");
+    return __isa(o, "DeploymentConfig");
   }
 }
 
@@ -1192,7 +1195,7 @@ export interface DeploymentJob {
 
 export namespace DeploymentJob {
   export function isa(o: any): o is DeploymentJob {
-    return _smithy.isa(o, "DeploymentJob");
+    return __isa(o, "DeploymentJob");
   }
 }
 
@@ -1250,7 +1253,7 @@ export interface DeploymentLaunchConfig {
 
 export namespace DeploymentLaunchConfig {
   export function isa(o: any): o is DeploymentLaunchConfig {
-    return _smithy.isa(o, "DeploymentLaunchConfig");
+    return __isa(o, "DeploymentLaunchConfig");
   }
 }
 
@@ -1278,7 +1281,7 @@ export interface DeregisterRobotRequest {
 
 export namespace DeregisterRobotRequest {
   export function isa(o: any): o is DeregisterRobotRequest {
-    return _smithy.isa(o, "DeregisterRobotRequest");
+    return __isa(o, "DeregisterRobotRequest");
   }
 }
 
@@ -1297,7 +1300,7 @@ export interface DeregisterRobotResponse extends $MetadataBearer {
 
 export namespace DeregisterRobotResponse {
   export function isa(o: any): o is DeregisterRobotResponse {
-    return _smithy.isa(o, "DeregisterRobotResponse");
+    return __isa(o, "DeregisterRobotResponse");
   }
 }
 
@@ -1311,7 +1314,7 @@ export interface DescribeDeploymentJobRequest {
 
 export namespace DescribeDeploymentJobRequest {
   export function isa(o: any): o is DescribeDeploymentJobRequest {
-    return _smithy.isa(o, "DescribeDeploymentJobRequest");
+    return __isa(o, "DescribeDeploymentJobRequest");
   }
 }
 
@@ -1370,7 +1373,7 @@ export interface DescribeDeploymentJobResponse extends $MetadataBearer {
 
 export namespace DescribeDeploymentJobResponse {
   export function isa(o: any): o is DescribeDeploymentJobResponse {
-    return _smithy.isa(o, "DescribeDeploymentJobResponse");
+    return __isa(o, "DescribeDeploymentJobResponse");
   }
 }
 
@@ -1384,7 +1387,7 @@ export interface DescribeFleetRequest {
 
 export namespace DescribeFleetRequest {
   export function isa(o: any): o is DescribeFleetRequest {
-    return _smithy.isa(o, "DescribeFleetRequest");
+    return __isa(o, "DescribeFleetRequest");
   }
 }
 
@@ -1433,7 +1436,7 @@ export interface DescribeFleetResponse extends $MetadataBearer {
 
 export namespace DescribeFleetResponse {
   export function isa(o: any): o is DescribeFleetResponse {
-    return _smithy.isa(o, "DescribeFleetResponse");
+    return __isa(o, "DescribeFleetResponse");
   }
 }
 
@@ -1452,7 +1455,7 @@ export interface DescribeRobotApplicationRequest {
 
 export namespace DescribeRobotApplicationRequest {
   export function isa(o: any): o is DescribeRobotApplicationRequest {
-    return _smithy.isa(o, "DescribeRobotApplicationRequest");
+    return __isa(o, "DescribeRobotApplicationRequest");
   }
 }
 
@@ -1501,7 +1504,7 @@ export interface DescribeRobotApplicationResponse extends $MetadataBearer {
 
 export namespace DescribeRobotApplicationResponse {
   export function isa(o: any): o is DescribeRobotApplicationResponse {
-    return _smithy.isa(o, "DescribeRobotApplicationResponse");
+    return __isa(o, "DescribeRobotApplicationResponse");
   }
 }
 
@@ -1515,7 +1518,7 @@ export interface DescribeRobotRequest {
 
 export namespace DescribeRobotRequest {
   export function isa(o: any): o is DescribeRobotRequest {
-    return _smithy.isa(o, "DescribeRobotRequest");
+    return __isa(o, "DescribeRobotRequest");
   }
 }
 
@@ -1574,7 +1577,7 @@ export interface DescribeRobotResponse extends $MetadataBearer {
 
 export namespace DescribeRobotResponse {
   export function isa(o: any): o is DescribeRobotResponse {
-    return _smithy.isa(o, "DescribeRobotResponse");
+    return __isa(o, "DescribeRobotResponse");
   }
 }
 
@@ -1593,7 +1596,7 @@ export interface DescribeSimulationApplicationRequest {
 
 export namespace DescribeSimulationApplicationRequest {
   export function isa(o: any): o is DescribeSimulationApplicationRequest {
-    return _smithy.isa(o, "DescribeSimulationApplicationRequest");
+    return __isa(o, "DescribeSimulationApplicationRequest");
   }
 }
 
@@ -1652,7 +1655,7 @@ export interface DescribeSimulationApplicationResponse extends $MetadataBearer {
 
 export namespace DescribeSimulationApplicationResponse {
   export function isa(o: any): o is DescribeSimulationApplicationResponse {
-    return _smithy.isa(o, "DescribeSimulationApplicationResponse");
+    return __isa(o, "DescribeSimulationApplicationResponse");
   }
 }
 
@@ -1666,7 +1669,7 @@ export interface DescribeSimulationJobRequest {
 
 export namespace DescribeSimulationJobRequest {
   export function isa(o: any): o is DescribeSimulationJobRequest {
-    return _smithy.isa(o, "DescribeSimulationJobRequest");
+    return __isa(o, "DescribeSimulationJobRequest");
   }
 }
 
@@ -1835,7 +1838,7 @@ export interface DescribeSimulationJobResponse extends $MetadataBearer {
 
 export namespace DescribeSimulationJobResponse {
   export function isa(o: any): o is DescribeSimulationJobResponse {
-    return _smithy.isa(o, "DescribeSimulationJobResponse");
+    return __isa(o, "DescribeSimulationJobResponse");
   }
 }
 
@@ -1862,7 +1865,7 @@ export interface Filter {
 
 export namespace Filter {
   export function isa(o: any): o is Filter {
-    return _smithy.isa(o, "Filter");
+    return __isa(o, "Filter");
   }
 }
 
@@ -1904,7 +1907,7 @@ export interface Fleet {
 
 export namespace Fleet {
   export function isa(o: any): o is Fleet {
-    return _smithy.isa(o, "Fleet");
+    return __isa(o, "Fleet");
   }
 }
 
@@ -1913,7 +1916,7 @@ export namespace Fleet {
  *          Do not reuse a client token with different requests, unless the requests are identical. </p>
  */
 export interface IdempotentParameterMismatchException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "IdempotentParameterMismatchException";
   $fault: "client";
@@ -1922,7 +1925,7 @@ export interface IdempotentParameterMismatchException
 
 export namespace IdempotentParameterMismatchException {
   export function isa(o: any): o is IdempotentParameterMismatchException {
-    return _smithy.isa(o, "IdempotentParameterMismatchException");
+    return __isa(o, "IdempotentParameterMismatchException");
   }
 }
 
@@ -1930,7 +1933,7 @@ export namespace IdempotentParameterMismatchException {
  * <p>AWS RoboMaker experienced a service issue. Try your call again.</p>
  */
 export interface InternalServerException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalServerException";
   $fault: "server";
@@ -1939,7 +1942,7 @@ export interface InternalServerException
 
 export namespace InternalServerException {
   export function isa(o: any): o is InternalServerException {
-    return _smithy.isa(o, "InternalServerException");
+    return __isa(o, "InternalServerException");
   }
 }
 
@@ -1948,7 +1951,7 @@ export namespace InternalServerException {
  *          The returned message provides an explanation of the error value.</p>
  */
 export interface InvalidParameterException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidParameterException";
   $fault: "client";
@@ -1957,7 +1960,7 @@ export interface InvalidParameterException
 
 export namespace InvalidParameterException {
   export function isa(o: any): o is InvalidParameterException {
-    return _smithy.isa(o, "InvalidParameterException");
+    return __isa(o, "InvalidParameterException");
   }
 }
 
@@ -1989,7 +1992,7 @@ export interface LaunchConfig {
 
 export namespace LaunchConfig {
   export function isa(o: any): o is LaunchConfig {
-    return _smithy.isa(o, "LaunchConfig");
+    return __isa(o, "LaunchConfig");
   }
 }
 
@@ -1998,7 +2001,7 @@ export namespace LaunchConfig {
  *          stream requests exceeds the maximum number allowed. </p>
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -2007,7 +2010,7 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
@@ -2050,7 +2053,7 @@ export interface ListDeploymentJobsRequest {
 
 export namespace ListDeploymentJobsRequest {
   export function isa(o: any): o is ListDeploymentJobsRequest {
-    return _smithy.isa(o, "ListDeploymentJobsRequest");
+    return __isa(o, "ListDeploymentJobsRequest");
   }
 }
 
@@ -2072,7 +2075,7 @@ export interface ListDeploymentJobsResponse extends $MetadataBearer {
 
 export namespace ListDeploymentJobsResponse {
   export function isa(o: any): o is ListDeploymentJobsResponse {
-    return _smithy.isa(o, "ListDeploymentJobsResponse");
+    return __isa(o, "ListDeploymentJobsResponse");
   }
 }
 
@@ -2113,7 +2116,7 @@ export interface ListFleetsRequest {
 
 export namespace ListFleetsRequest {
   export function isa(o: any): o is ListFleetsRequest {
-    return _smithy.isa(o, "ListFleetsRequest");
+    return __isa(o, "ListFleetsRequest");
   }
 }
 
@@ -2135,7 +2138,7 @@ export interface ListFleetsResponse extends $MetadataBearer {
 
 export namespace ListFleetsResponse {
   export function isa(o: any): o is ListFleetsResponse {
-    return _smithy.isa(o, "ListFleetsResponse");
+    return __isa(o, "ListFleetsResponse");
   }
 }
 
@@ -2181,7 +2184,7 @@ export interface ListRobotApplicationsRequest {
 
 export namespace ListRobotApplicationsRequest {
   export function isa(o: any): o is ListRobotApplicationsRequest {
-    return _smithy.isa(o, "ListRobotApplicationsRequest");
+    return __isa(o, "ListRobotApplicationsRequest");
   }
 }
 
@@ -2203,7 +2206,7 @@ export interface ListRobotApplicationsResponse extends $MetadataBearer {
 
 export namespace ListRobotApplicationsResponse {
   export function isa(o: any): o is ListRobotApplicationsResponse {
-    return _smithy.isa(o, "ListRobotApplicationsResponse");
+    return __isa(o, "ListRobotApplicationsResponse");
   }
 }
 
@@ -2246,7 +2249,7 @@ export interface ListRobotsRequest {
 
 export namespace ListRobotsRequest {
   export function isa(o: any): o is ListRobotsRequest {
-    return _smithy.isa(o, "ListRobotsRequest");
+    return __isa(o, "ListRobotsRequest");
   }
 }
 
@@ -2268,7 +2271,7 @@ export interface ListRobotsResponse extends $MetadataBearer {
 
 export namespace ListRobotsResponse {
   export function isa(o: any): o is ListRobotsResponse {
-    return _smithy.isa(o, "ListRobotsResponse");
+    return __isa(o, "ListRobotsResponse");
   }
 }
 
@@ -2314,7 +2317,7 @@ export interface ListSimulationApplicationsRequest {
 
 export namespace ListSimulationApplicationsRequest {
   export function isa(o: any): o is ListSimulationApplicationsRequest {
-    return _smithy.isa(o, "ListSimulationApplicationsRequest");
+    return __isa(o, "ListSimulationApplicationsRequest");
   }
 }
 
@@ -2336,7 +2339,7 @@ export interface ListSimulationApplicationsResponse extends $MetadataBearer {
 
 export namespace ListSimulationApplicationsResponse {
   export function isa(o: any): o is ListSimulationApplicationsResponse {
-    return _smithy.isa(o, "ListSimulationApplicationsResponse");
+    return __isa(o, "ListSimulationApplicationsResponse");
   }
 }
 
@@ -2380,7 +2383,7 @@ export interface ListSimulationJobsRequest {
 
 export namespace ListSimulationJobsRequest {
   export function isa(o: any): o is ListSimulationJobsRequest {
-    return _smithy.isa(o, "ListSimulationJobsRequest");
+    return __isa(o, "ListSimulationJobsRequest");
   }
 }
 
@@ -2402,7 +2405,7 @@ export interface ListSimulationJobsResponse extends $MetadataBearer {
 
 export namespace ListSimulationJobsResponse {
   export function isa(o: any): o is ListSimulationJobsResponse {
-    return _smithy.isa(o, "ListSimulationJobsResponse");
+    return __isa(o, "ListSimulationJobsResponse");
   }
 }
 
@@ -2416,7 +2419,7 @@ export interface ListTagsForResourceRequest {
 
 export namespace ListTagsForResourceRequest {
   export function isa(o: any): o is ListTagsForResourceRequest {
-    return _smithy.isa(o, "ListTagsForResourceRequest");
+    return __isa(o, "ListTagsForResourceRequest");
   }
 }
 
@@ -2430,7 +2433,7 @@ export interface ListTagsForResourceResponse extends $MetadataBearer {
 
 export namespace ListTagsForResourceResponse {
   export function isa(o: any): o is ListTagsForResourceResponse {
-    return _smithy.isa(o, "ListTagsForResourceResponse");
+    return __isa(o, "ListTagsForResourceResponse");
   }
 }
 
@@ -2447,7 +2450,7 @@ export interface LoggingConfig {
 
 export namespace LoggingConfig {
   export function isa(o: any): o is LoggingConfig {
-    return _smithy.isa(o, "LoggingConfig");
+    return __isa(o, "LoggingConfig");
   }
 }
 
@@ -2474,7 +2477,7 @@ export interface NetworkInterface {
 
 export namespace NetworkInterface {
   export function isa(o: any): o is NetworkInterface {
-    return _smithy.isa(o, "NetworkInterface");
+    return __isa(o, "NetworkInterface");
   }
 }
 
@@ -2496,7 +2499,7 @@ export interface OutputLocation {
 
 export namespace OutputLocation {
   export function isa(o: any): o is OutputLocation {
-    return _smithy.isa(o, "OutputLocation");
+    return __isa(o, "OutputLocation");
   }
 }
 
@@ -2513,7 +2516,7 @@ export interface PortForwardingConfig {
 
 export namespace PortForwardingConfig {
   export function isa(o: any): o is PortForwardingConfig {
-    return _smithy.isa(o, "PortForwardingConfig");
+    return __isa(o, "PortForwardingConfig");
   }
 }
 
@@ -2540,7 +2543,7 @@ export interface PortMapping {
 
 export namespace PortMapping {
   export function isa(o: any): o is PortMapping {
-    return _smithy.isa(o, "PortMapping");
+    return __isa(o, "PortMapping");
   }
 }
 
@@ -2600,7 +2603,7 @@ export interface ProgressDetail {
 
 export namespace ProgressDetail {
   export function isa(o: any): o is ProgressDetail {
-    return _smithy.isa(o, "ProgressDetail");
+    return __isa(o, "ProgressDetail");
   }
 }
 
@@ -2619,7 +2622,7 @@ export interface RegisterRobotRequest {
 
 export namespace RegisterRobotRequest {
   export function isa(o: any): o is RegisterRobotRequest {
-    return _smithy.isa(o, "RegisterRobotRequest");
+    return __isa(o, "RegisterRobotRequest");
   }
 }
 
@@ -2638,7 +2641,7 @@ export interface RegisterRobotResponse extends $MetadataBearer {
 
 export namespace RegisterRobotResponse {
   export function isa(o: any): o is RegisterRobotResponse {
-    return _smithy.isa(o, "RegisterRobotResponse");
+    return __isa(o, "RegisterRobotResponse");
   }
 }
 
@@ -2660,7 +2663,7 @@ export interface RenderingEngine {
 
 export namespace RenderingEngine {
   export function isa(o: any): o is RenderingEngine {
-    return _smithy.isa(o, "RenderingEngine");
+    return __isa(o, "RenderingEngine");
   }
 }
 
@@ -2672,7 +2675,7 @@ export enum RenderingEngineType {
  * <p>The specified resource already exists.</p>
  */
 export interface ResourceAlreadyExistsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceAlreadyExistsException";
   $fault: "client";
@@ -2681,7 +2684,7 @@ export interface ResourceAlreadyExistsException
 
 export namespace ResourceAlreadyExistsException {
   export function isa(o: any): o is ResourceAlreadyExistsException {
-    return _smithy.isa(o, "ResourceAlreadyExistsException");
+    return __isa(o, "ResourceAlreadyExistsException");
   }
 }
 
@@ -2689,7 +2692,7 @@ export namespace ResourceAlreadyExistsException {
  * <p>The specified resource does not exist.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -2698,7 +2701,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -2712,7 +2715,7 @@ export interface RestartSimulationJobRequest {
 
 export namespace RestartSimulationJobRequest {
   export function isa(o: any): o is RestartSimulationJobRequest {
-    return _smithy.isa(o, "RestartSimulationJobRequest");
+    return __isa(o, "RestartSimulationJobRequest");
   }
 }
 
@@ -2722,7 +2725,7 @@ export interface RestartSimulationJobResponse extends $MetadataBearer {
 
 export namespace RestartSimulationJobResponse {
   export function isa(o: any): o is RestartSimulationJobResponse {
-    return _smithy.isa(o, "RestartSimulationJobResponse");
+    return __isa(o, "RestartSimulationJobResponse");
   }
 }
 
@@ -2779,7 +2782,7 @@ export interface Robot {
 
 export namespace Robot {
   export function isa(o: any): o is Robot {
-    return _smithy.isa(o, "Robot");
+    return __isa(o, "Robot");
   }
 }
 
@@ -2806,7 +2809,7 @@ export interface RobotApplicationConfig {
 
 export namespace RobotApplicationConfig {
   export function isa(o: any): o is RobotApplicationConfig {
-    return _smithy.isa(o, "RobotApplicationConfig");
+    return __isa(o, "RobotApplicationConfig");
   }
 }
 
@@ -2843,7 +2846,7 @@ export interface RobotApplicationSummary {
 
 export namespace RobotApplicationSummary {
   export function isa(o: any): o is RobotApplicationSummary {
-    return _smithy.isa(o, "RobotApplicationSummary");
+    return __isa(o, "RobotApplicationSummary");
   }
 }
 
@@ -2890,7 +2893,7 @@ export interface RobotDeployment {
 
 export namespace RobotDeployment {
   export function isa(o: any): o is RobotDeployment {
-    return _smithy.isa(o, "RobotDeployment");
+    return __isa(o, "RobotDeployment");
   }
 }
 
@@ -2922,7 +2925,7 @@ export interface RobotSoftwareSuite {
 
 export namespace RobotSoftwareSuite {
   export function isa(o: any): o is RobotSoftwareSuite {
-    return _smithy.isa(o, "RobotSoftwareSuite");
+    return __isa(o, "RobotSoftwareSuite");
   }
 }
 
@@ -2965,7 +2968,7 @@ export interface S3KeyOutput {
 
 export namespace S3KeyOutput {
   export function isa(o: any): o is S3KeyOutput {
-    return _smithy.isa(o, "S3KeyOutput");
+    return __isa(o, "S3KeyOutput");
   }
 }
 
@@ -2992,7 +2995,7 @@ export interface S3Object {
 
 export namespace S3Object {
   export function isa(o: any): o is S3Object {
-    return _smithy.isa(o, "S3Object");
+    return __isa(o, "S3Object");
   }
 }
 
@@ -3000,7 +3003,7 @@ export namespace S3Object {
  * <p>The request has failed due to a temporary failure of the server.</p>
  */
 export interface ServiceUnavailableException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ServiceUnavailableException";
   $fault: "server";
@@ -3009,7 +3012,7 @@ export interface ServiceUnavailableException
 
 export namespace ServiceUnavailableException {
   export function isa(o: any): o is ServiceUnavailableException {
-    return _smithy.isa(o, "ServiceUnavailableException");
+    return __isa(o, "ServiceUnavailableException");
   }
 }
 
@@ -3036,7 +3039,7 @@ export interface SimulationApplicationConfig {
 
 export namespace SimulationApplicationConfig {
   export function isa(o: any): o is SimulationApplicationConfig {
-    return _smithy.isa(o, "SimulationApplicationConfig");
+    return __isa(o, "SimulationApplicationConfig");
   }
 }
 
@@ -3078,7 +3081,7 @@ export interface SimulationApplicationSummary {
 
 export namespace SimulationApplicationSummary {
   export function isa(o: any): o is SimulationApplicationSummary {
-    return _smithy.isa(o, "SimulationApplicationSummary");
+    return __isa(o, "SimulationApplicationSummary");
   }
 }
 
@@ -3203,7 +3206,7 @@ export interface SimulationJob {
 
 export namespace SimulationJob {
   export function isa(o: any): o is SimulationJob {
-    return _smithy.isa(o, "SimulationJob");
+    return __isa(o, "SimulationJob");
   }
 }
 
@@ -3289,7 +3292,7 @@ export interface SimulationJobSummary {
 
 export namespace SimulationJobSummary {
   export function isa(o: any): o is SimulationJobSummary {
-    return _smithy.isa(o, "SimulationJobSummary");
+    return __isa(o, "SimulationJobSummary");
   }
 }
 
@@ -3311,7 +3314,7 @@ export interface SimulationSoftwareSuite {
 
 export namespace SimulationSoftwareSuite {
   export function isa(o: any): o is SimulationSoftwareSuite {
-    return _smithy.isa(o, "SimulationSoftwareSuite");
+    return __isa(o, "SimulationSoftwareSuite");
   }
 }
 
@@ -3348,7 +3351,7 @@ export interface Source {
 
 export namespace Source {
   export function isa(o: any): o is Source {
-    return _smithy.isa(o, "Source");
+    return __isa(o, "Source");
   }
 }
 
@@ -3375,7 +3378,7 @@ export interface SourceConfig {
 
 export namespace SourceConfig {
   export function isa(o: any): o is SourceConfig {
-    return _smithy.isa(o, "SourceConfig");
+    return __isa(o, "SourceConfig");
   }
 }
 
@@ -3394,7 +3397,7 @@ export interface SyncDeploymentJobRequest {
 
 export namespace SyncDeploymentJobRequest {
   export function isa(o: any): o is SyncDeploymentJobRequest {
-    return _smithy.isa(o, "SyncDeploymentJobRequest");
+    return __isa(o, "SyncDeploymentJobRequest");
   }
 }
 
@@ -3501,7 +3504,7 @@ export interface SyncDeploymentJobResponse extends $MetadataBearer {
 
 export namespace SyncDeploymentJobResponse {
   export function isa(o: any): o is SyncDeploymentJobResponse {
-    return _smithy.isa(o, "SyncDeploymentJobResponse");
+    return __isa(o, "SyncDeploymentJobResponse");
   }
 }
 
@@ -3520,7 +3523,7 @@ export interface TagResourceRequest {
 
 export namespace TagResourceRequest {
   export function isa(o: any): o is TagResourceRequest {
-    return _smithy.isa(o, "TagResourceRequest");
+    return __isa(o, "TagResourceRequest");
   }
 }
 
@@ -3530,7 +3533,7 @@ export interface TagResourceResponse extends $MetadataBearer {
 
 export namespace TagResourceResponse {
   export function isa(o: any): o is TagResourceResponse {
-    return _smithy.isa(o, "TagResourceResponse");
+    return __isa(o, "TagResourceResponse");
   }
 }
 
@@ -3538,7 +3541,7 @@ export namespace TagResourceResponse {
  * <p>AWS RoboMaker is temporarily unable to process the request. Try your call again.</p>
  */
 export interface ThrottlingException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ThrottlingException";
   $fault: "client";
@@ -3547,7 +3550,7 @@ export interface ThrottlingException
 
 export namespace ThrottlingException {
   export function isa(o: any): o is ThrottlingException {
-    return _smithy.isa(o, "ThrottlingException");
+    return __isa(o, "ThrottlingException");
   }
 }
 
@@ -3566,7 +3569,7 @@ export interface UntagResourceRequest {
 
 export namespace UntagResourceRequest {
   export function isa(o: any): o is UntagResourceRequest {
-    return _smithy.isa(o, "UntagResourceRequest");
+    return __isa(o, "UntagResourceRequest");
   }
 }
 
@@ -3576,7 +3579,7 @@ export interface UntagResourceResponse extends $MetadataBearer {
 
 export namespace UntagResourceResponse {
   export function isa(o: any): o is UntagResourceResponse {
-    return _smithy.isa(o, "UntagResourceResponse");
+    return __isa(o, "UntagResourceResponse");
   }
 }
 
@@ -3605,7 +3608,7 @@ export interface UpdateRobotApplicationRequest {
 
 export namespace UpdateRobotApplicationRequest {
   export function isa(o: any): o is UpdateRobotApplicationRequest {
-    return _smithy.isa(o, "UpdateRobotApplicationRequest");
+    return __isa(o, "UpdateRobotApplicationRequest");
   }
 }
 
@@ -3649,7 +3652,7 @@ export interface UpdateRobotApplicationResponse extends $MetadataBearer {
 
 export namespace UpdateRobotApplicationResponse {
   export function isa(o: any): o is UpdateRobotApplicationResponse {
-    return _smithy.isa(o, "UpdateRobotApplicationResponse");
+    return __isa(o, "UpdateRobotApplicationResponse");
   }
 }
 
@@ -3688,7 +3691,7 @@ export interface UpdateSimulationApplicationRequest {
 
 export namespace UpdateSimulationApplicationRequest {
   export function isa(o: any): o is UpdateSimulationApplicationRequest {
-    return _smithy.isa(o, "UpdateSimulationApplicationRequest");
+    return __isa(o, "UpdateSimulationApplicationRequest");
   }
 }
 
@@ -3742,7 +3745,7 @@ export interface UpdateSimulationApplicationResponse extends $MetadataBearer {
 
 export namespace UpdateSimulationApplicationResponse {
   export function isa(o: any): o is UpdateSimulationApplicationResponse {
-    return _smithy.isa(o, "UpdateSimulationApplicationResponse");
+    return __isa(o, "UpdateSimulationApplicationResponse");
   }
 }
 
@@ -3771,7 +3774,7 @@ export interface VPCConfig {
 
 export namespace VPCConfig {
   export function isa(o: any): o is VPCConfig {
-    return _smithy.isa(o, "VPCConfig");
+    return __isa(o, "VPCConfig");
   }
 }
 
@@ -3803,6 +3806,6 @@ export interface VPCConfigResponse {
 
 export namespace VPCConfigResponse {
   export function isa(o: any): o is VPCConfigResponse {
-    return _smithy.isa(o, "VPCConfigResponse");
+    return __isa(o, "VPCConfigResponse");
   }
 }

--- a/clients/client-robomaker/protocols/Aws_restJson1_1.ts
+++ b/clients/client-robomaker/protocols/Aws_restJson1_1.ts
@@ -189,7 +189,10 @@ import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  extendedEncodeURIComponent as __extendedEncodeURIComponent
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -1069,7 +1072,7 @@ export async function serializeAws_restJson1_1ListTagsForResourceCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/tags/{resourceArn}";
   if (input.resourceArn !== undefined) {
-    const labelValue: string = input.resourceArn.toString();
+    const labelValue: string = input.resourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: resourceArn."
@@ -1077,7 +1080,7 @@ export async function serializeAws_restJson1_1ListTagsForResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{resourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: resourceArn.");
@@ -1177,7 +1180,7 @@ export async function serializeAws_restJson1_1TagResourceCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/tags/{resourceArn}";
   if (input.resourceArn !== undefined) {
-    const labelValue: string = input.resourceArn.toString();
+    const labelValue: string = input.resourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: resourceArn."
@@ -1185,7 +1188,7 @@ export async function serializeAws_restJson1_1TagResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{resourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: resourceArn.");
@@ -1214,7 +1217,7 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/tags/{resourceArn}";
   if (input.resourceArn !== undefined) {
-    const labelValue: string = input.resourceArn.toString();
+    const labelValue: string = input.resourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: resourceArn."
@@ -1222,14 +1225,16 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{resourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: resourceArn.");
   }
   const query: any = {};
   if (input.tagKeys !== undefined) {
-    query["tagKeys"] = input.tagKeys;
+    query[__extendedEncodeURIComponent("tagKeys")] = input.tagKeys.map(entry =>
+      __extendedEncodeURIComponent(entry)
+    );
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1436,6 +1441,7 @@ export async function deserializeAws_restJson1_1CancelDeploymentJobCommand(
     $metadata: deserializeMetadata(output),
     __type: "CancelDeploymentJobResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -1508,6 +1514,7 @@ export async function deserializeAws_restJson1_1CancelSimulationJobCommand(
     $metadata: deserializeMetadata(output),
     __type: "CancelSimulationJobResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2607,6 +2614,7 @@ export async function deserializeAws_restJson1_1DeleteFleetCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeleteFleetResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2669,6 +2677,7 @@ export async function deserializeAws_restJson1_1DeleteRobotCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeleteRobotResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2734,6 +2743,7 @@ export async function deserializeAws_restJson1_1DeleteRobotApplicationCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeleteRobotApplicationResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2799,6 +2809,7 @@ export async function deserializeAws_restJson1_1DeleteSimulationApplicationComma
     $metadata: deserializeMetadata(output),
     __type: "DeleteSimulationApplicationResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -4368,6 +4379,7 @@ export async function deserializeAws_restJson1_1RestartSimulationJobCommand(
     $metadata: deserializeMetadata(output),
     __type: "RestartSimulationJobResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -4579,6 +4591,7 @@ export async function deserializeAws_restJson1_1TagResourceCommand(
     $metadata: deserializeMetadata(output),
     __type: "TagResourceResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -4648,6 +4661,7 @@ export async function deserializeAws_restJson1_1UntagResourceCommand(
     $metadata: deserializeMetadata(output),
     __type: "UntagResourceResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 

--- a/clients/client-route-53-domains/models/index.ts
+++ b/clients/client-route-53-domains/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -39,7 +42,7 @@ export interface BillingRecord {
 
 export namespace BillingRecord {
   export function isa(o: any): o is BillingRecord {
-    return _smithy.isa(o, "BillingRecord");
+    return __isa(o, "BillingRecord");
   }
 }
 
@@ -63,7 +66,7 @@ export interface CheckDomainAvailabilityRequest {
 
 export namespace CheckDomainAvailabilityRequest {
   export function isa(o: any): o is CheckDomainAvailabilityRequest {
-    return _smithy.isa(o, "CheckDomainAvailabilityRequest");
+    return __isa(o, "CheckDomainAvailabilityRequest");
   }
 }
 
@@ -125,7 +128,7 @@ export interface CheckDomainAvailabilityResponse extends $MetadataBearer {
 
 export namespace CheckDomainAvailabilityResponse {
   export function isa(o: any): o is CheckDomainAvailabilityResponse {
-    return _smithy.isa(o, "CheckDomainAvailabilityResponse");
+    return __isa(o, "CheckDomainAvailabilityResponse");
   }
 }
 
@@ -150,7 +153,7 @@ export interface CheckDomainTransferabilityRequest {
 
 export namespace CheckDomainTransferabilityRequest {
   export function isa(o: any): o is CheckDomainTransferabilityRequest {
-    return _smithy.isa(o, "CheckDomainTransferabilityRequest");
+    return __isa(o, "CheckDomainTransferabilityRequest");
   }
 }
 
@@ -167,7 +170,7 @@ export interface CheckDomainTransferabilityResponse extends $MetadataBearer {
 
 export namespace CheckDomainTransferabilityResponse {
   export function isa(o: any): o is CheckDomainTransferabilityResponse {
-    return _smithy.isa(o, "CheckDomainTransferabilityResponse");
+    return __isa(o, "CheckDomainTransferabilityResponse");
   }
 }
 
@@ -255,7 +258,7 @@ export interface ContactDetail {
 
 export namespace ContactDetail {
   export function isa(o: any): o is ContactDetail {
-    return _smithy.isa(o, "ContactDetail");
+    return __isa(o, "ContactDetail");
   }
 }
 
@@ -515,7 +518,7 @@ export interface DeleteTagsForDomainRequest {
 
 export namespace DeleteTagsForDomainRequest {
   export function isa(o: any): o is DeleteTagsForDomainRequest {
-    return _smithy.isa(o, "DeleteTagsForDomainRequest");
+    return __isa(o, "DeleteTagsForDomainRequest");
   }
 }
 
@@ -525,7 +528,7 @@ export interface DeleteTagsForDomainResponse extends $MetadataBearer {
 
 export namespace DeleteTagsForDomainResponse {
   export function isa(o: any): o is DeleteTagsForDomainResponse {
-    return _smithy.isa(o, "DeleteTagsForDomainResponse");
+    return __isa(o, "DeleteTagsForDomainResponse");
   }
 }
 
@@ -539,7 +542,7 @@ export interface DisableDomainAutoRenewRequest {
 
 export namespace DisableDomainAutoRenewRequest {
   export function isa(o: any): o is DisableDomainAutoRenewRequest {
-    return _smithy.isa(o, "DisableDomainAutoRenewRequest");
+    return __isa(o, "DisableDomainAutoRenewRequest");
   }
 }
 
@@ -549,7 +552,7 @@ export interface DisableDomainAutoRenewResponse extends $MetadataBearer {
 
 export namespace DisableDomainAutoRenewResponse {
   export function isa(o: any): o is DisableDomainAutoRenewResponse {
-    return _smithy.isa(o, "DisableDomainAutoRenewResponse");
+    return __isa(o, "DisableDomainAutoRenewResponse");
   }
 }
 
@@ -566,7 +569,7 @@ export interface DisableDomainTransferLockRequest {
 
 export namespace DisableDomainTransferLockRequest {
   export function isa(o: any): o is DisableDomainTransferLockRequest {
-    return _smithy.isa(o, "DisableDomainTransferLockRequest");
+    return __isa(o, "DisableDomainTransferLockRequest");
   }
 }
 
@@ -584,7 +587,7 @@ export interface DisableDomainTransferLockResponse extends $MetadataBearer {
 
 export namespace DisableDomainTransferLockResponse {
   export function isa(o: any): o is DisableDomainTransferLockResponse {
-    return _smithy.isa(o, "DisableDomainTransferLockResponse");
+    return __isa(o, "DisableDomainTransferLockResponse");
   }
 }
 
@@ -602,7 +605,7 @@ export type DomainAvailability =
  * <p>The number of domains has exceeded the allowed threshold for the account.</p>
  */
 export interface DomainLimitExceeded
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DomainLimitExceeded";
   $fault: "client";
@@ -614,7 +617,7 @@ export interface DomainLimitExceeded
 
 export namespace DomainLimitExceeded {
   export function isa(o: any): o is DomainLimitExceeded {
-    return _smithy.isa(o, "DomainLimitExceeded");
+    return __isa(o, "DomainLimitExceeded");
   }
 }
 
@@ -681,7 +684,7 @@ export interface DomainSuggestion {
 
 export namespace DomainSuggestion {
   export function isa(o: any): o is DomainSuggestion {
-    return _smithy.isa(o, "DomainSuggestion");
+    return __isa(o, "DomainSuggestion");
   }
 }
 
@@ -713,7 +716,7 @@ export interface DomainSummary {
 
 export namespace DomainSummary {
   export function isa(o: any): o is DomainSummary {
-    return _smithy.isa(o, "DomainSummary");
+    return __isa(o, "DomainSummary");
   }
 }
 
@@ -749,16 +752,14 @@ export interface DomainTransferability {
 
 export namespace DomainTransferability {
   export function isa(o: any): o is DomainTransferability {
-    return _smithy.isa(o, "DomainTransferability");
+    return __isa(o, "DomainTransferability");
   }
 }
 
 /**
  * <p>The request is already in progress for the domain.</p>
  */
-export interface DuplicateRequest
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface DuplicateRequest extends __SmithyException, $MetadataBearer {
   name: "DuplicateRequest";
   $fault: "client";
   /**
@@ -769,7 +770,7 @@ export interface DuplicateRequest
 
 export namespace DuplicateRequest {
   export function isa(o: any): o is DuplicateRequest {
-    return _smithy.isa(o, "DuplicateRequest");
+    return __isa(o, "DuplicateRequest");
   }
 }
 
@@ -783,7 +784,7 @@ export interface EnableDomainAutoRenewRequest {
 
 export namespace EnableDomainAutoRenewRequest {
   export function isa(o: any): o is EnableDomainAutoRenewRequest {
-    return _smithy.isa(o, "EnableDomainAutoRenewRequest");
+    return __isa(o, "EnableDomainAutoRenewRequest");
   }
 }
 
@@ -793,7 +794,7 @@ export interface EnableDomainAutoRenewResponse extends $MetadataBearer {
 
 export namespace EnableDomainAutoRenewResponse {
   export function isa(o: any): o is EnableDomainAutoRenewResponse {
-    return _smithy.isa(o, "EnableDomainAutoRenewResponse");
+    return __isa(o, "EnableDomainAutoRenewResponse");
   }
 }
 
@@ -810,7 +811,7 @@ export interface EnableDomainTransferLockRequest {
 
 export namespace EnableDomainTransferLockRequest {
   export function isa(o: any): o is EnableDomainTransferLockRequest {
-    return _smithy.isa(o, "EnableDomainTransferLockRequest");
+    return __isa(o, "EnableDomainTransferLockRequest");
   }
 }
 
@@ -827,7 +828,7 @@ export interface EnableDomainTransferLockResponse extends $MetadataBearer {
 
 export namespace EnableDomainTransferLockResponse {
   export function isa(o: any): o is EnableDomainTransferLockResponse {
-    return _smithy.isa(o, "EnableDomainTransferLockResponse");
+    return __isa(o, "EnableDomainTransferLockResponse");
   }
 }
 
@@ -920,7 +921,7 @@ export interface ExtraParam {
 
 export namespace ExtraParam {
   export function isa(o: any): o is ExtraParam {
-    return _smithy.isa(o, "ExtraParam");
+    return __isa(o, "ExtraParam");
   }
 }
 
@@ -963,7 +964,7 @@ export interface GetContactReachabilityStatusRequest {
 
 export namespace GetContactReachabilityStatusRequest {
   export function isa(o: any): o is GetContactReachabilityStatusRequest {
-    return _smithy.isa(o, "GetContactReachabilityStatusRequest");
+    return __isa(o, "GetContactReachabilityStatusRequest");
   }
 }
 
@@ -996,7 +997,7 @@ export interface GetContactReachabilityStatusResponse extends $MetadataBearer {
 
 export namespace GetContactReachabilityStatusResponse {
   export function isa(o: any): o is GetContactReachabilityStatusResponse {
-    return _smithy.isa(o, "GetContactReachabilityStatusResponse");
+    return __isa(o, "GetContactReachabilityStatusResponse");
   }
 }
 
@@ -1013,7 +1014,7 @@ export interface GetDomainDetailRequest {
 
 export namespace GetDomainDetailRequest {
   export function isa(o: any): o is GetDomainDetailRequest {
-    return _smithy.isa(o, "GetDomainDetailRequest");
+    return __isa(o, "GetDomainDetailRequest");
   }
 }
 
@@ -1152,7 +1153,7 @@ export interface GetDomainDetailResponse extends $MetadataBearer {
 
 export namespace GetDomainDetailResponse {
   export function isa(o: any): o is GetDomainDetailResponse {
-    return _smithy.isa(o, "GetDomainDetailResponse");
+    return __isa(o, "GetDomainDetailResponse");
   }
 }
 
@@ -1182,7 +1183,7 @@ export interface GetDomainSuggestionsRequest {
 
 export namespace GetDomainSuggestionsRequest {
   export function isa(o: any): o is GetDomainSuggestionsRequest {
-    return _smithy.isa(o, "GetDomainSuggestionsRequest");
+    return __isa(o, "GetDomainSuggestionsRequest");
   }
 }
 
@@ -1197,7 +1198,7 @@ export interface GetDomainSuggestionsResponse extends $MetadataBearer {
 
 export namespace GetDomainSuggestionsResponse {
   export function isa(o: any): o is GetDomainSuggestionsResponse {
-    return _smithy.isa(o, "GetDomainSuggestionsResponse");
+    return __isa(o, "GetDomainSuggestionsResponse");
   }
 }
 
@@ -1215,7 +1216,7 @@ export interface GetOperationDetailRequest {
 
 export namespace GetOperationDetailRequest {
   export function isa(o: any): o is GetOperationDetailRequest {
-    return _smithy.isa(o, "GetOperationDetailRequest");
+    return __isa(o, "GetOperationDetailRequest");
   }
 }
 
@@ -1257,7 +1258,7 @@ export interface GetOperationDetailResponse extends $MetadataBearer {
 
 export namespace GetOperationDetailResponse {
   export function isa(o: any): o is GetOperationDetailResponse {
-    return _smithy.isa(o, "GetOperationDetailResponse");
+    return __isa(o, "GetOperationDetailResponse");
   }
 }
 
@@ -1265,7 +1266,7 @@ export namespace GetOperationDetailResponse {
  * <p>The requested item is not acceptable. For example, for an OperationId it might refer to the ID of an operation
  * 			that is already completed. For a domain name, it might not be a valid domain name or belong to the requester account.</p>
  */
-export interface InvalidInput extends _smithy.SmithyException, $MetadataBearer {
+export interface InvalidInput extends __SmithyException, $MetadataBearer {
   name: "InvalidInput";
   $fault: "client";
   /**
@@ -1277,7 +1278,7 @@ export interface InvalidInput extends _smithy.SmithyException, $MetadataBearer {
 
 export namespace InvalidInput {
   export function isa(o: any): o is InvalidInput {
-    return _smithy.isa(o, "InvalidInput");
+    return __isa(o, "InvalidInput");
   }
 }
 
@@ -1305,7 +1306,7 @@ export interface ListDomainsRequest {
 
 export namespace ListDomainsRequest {
   export function isa(o: any): o is ListDomainsRequest {
-    return _smithy.isa(o, "ListDomainsRequest");
+    return __isa(o, "ListDomainsRequest");
   }
 }
 
@@ -1328,7 +1329,7 @@ export interface ListDomainsResponse extends $MetadataBearer {
 
 export namespace ListDomainsResponse {
   export function isa(o: any): o is ListDomainsResponse {
-    return _smithy.isa(o, "ListDomainsResponse");
+    return __isa(o, "ListDomainsResponse");
   }
 }
 
@@ -1360,7 +1361,7 @@ export interface ListOperationsRequest {
 
 export namespace ListOperationsRequest {
   export function isa(o: any): o is ListOperationsRequest {
-    return _smithy.isa(o, "ListOperationsRequest");
+    return __isa(o, "ListOperationsRequest");
   }
 }
 
@@ -1383,7 +1384,7 @@ export interface ListOperationsResponse extends $MetadataBearer {
 
 export namespace ListOperationsResponse {
   export function isa(o: any): o is ListOperationsResponse {
-    return _smithy.isa(o, "ListOperationsResponse");
+    return __isa(o, "ListOperationsResponse");
   }
 }
 
@@ -1400,7 +1401,7 @@ export interface ListTagsForDomainRequest {
 
 export namespace ListTagsForDomainRequest {
   export function isa(o: any): o is ListTagsForDomainRequest {
-    return _smithy.isa(o, "ListTagsForDomainRequest");
+    return __isa(o, "ListTagsForDomainRequest");
   }
 }
 
@@ -1417,7 +1418,7 @@ export interface ListTagsForDomainResponse extends $MetadataBearer {
 
 export namespace ListTagsForDomainResponse {
   export function isa(o: any): o is ListTagsForDomainResponse {
-    return _smithy.isa(o, "ListTagsForDomainResponse");
+    return __isa(o, "ListTagsForDomainResponse");
   }
 }
 
@@ -1441,7 +1442,7 @@ export interface Nameserver {
 
 export namespace Nameserver {
   export function isa(o: any): o is Nameserver {
-    return _smithy.isa(o, "Nameserver");
+    return __isa(o, "Nameserver");
   }
 }
 
@@ -1449,7 +1450,7 @@ export namespace Nameserver {
  * <p>The number of operations or jobs running exceeded the allowed threshold for the account.</p>
  */
 export interface OperationLimitExceeded
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "OperationLimitExceeded";
   $fault: "client";
@@ -1461,7 +1462,7 @@ export interface OperationLimitExceeded
 
 export namespace OperationLimitExceeded {
   export function isa(o: any): o is OperationLimitExceeded {
-    return _smithy.isa(o, "OperationLimitExceeded");
+    return __isa(o, "OperationLimitExceeded");
   }
 }
 
@@ -1500,7 +1501,7 @@ export interface OperationSummary {
 
 export namespace OperationSummary {
   export function isa(o: any): o is OperationSummary {
-    return _smithy.isa(o, "OperationSummary");
+    return __isa(o, "OperationSummary");
   }
 }
 
@@ -1611,7 +1612,7 @@ export interface RegisterDomainRequest {
 
 export namespace RegisterDomainRequest {
   export function isa(o: any): o is RegisterDomainRequest {
-    return _smithy.isa(o, "RegisterDomainRequest");
+    return __isa(o, "RegisterDomainRequest");
   }
 }
 
@@ -1629,7 +1630,7 @@ export interface RegisterDomainResponse extends $MetadataBearer {
 
 export namespace RegisterDomainResponse {
   export function isa(o: any): o is RegisterDomainResponse {
-    return _smithy.isa(o, "RegisterDomainResponse");
+    return __isa(o, "RegisterDomainResponse");
   }
 }
 
@@ -1660,7 +1661,7 @@ export interface RenewDomainRequest {
 
 export namespace RenewDomainRequest {
   export function isa(o: any): o is RenewDomainRequest {
-    return _smithy.isa(o, "RenewDomainRequest");
+    return __isa(o, "RenewDomainRequest");
   }
 }
 
@@ -1675,7 +1676,7 @@ export interface RenewDomainResponse extends $MetadataBearer {
 
 export namespace RenewDomainResponse {
   export function isa(o: any): o is RenewDomainResponse {
-    return _smithy.isa(o, "RenewDomainResponse");
+    return __isa(o, "RenewDomainResponse");
   }
 }
 
@@ -1689,7 +1690,7 @@ export interface ResendContactReachabilityEmailRequest {
 
 export namespace ResendContactReachabilityEmailRequest {
   export function isa(o: any): o is ResendContactReachabilityEmailRequest {
-    return _smithy.isa(o, "ResendContactReachabilityEmailRequest");
+    return __isa(o, "ResendContactReachabilityEmailRequest");
   }
 }
 
@@ -1716,7 +1717,7 @@ export interface ResendContactReachabilityEmailResponse
 
 export namespace ResendContactReachabilityEmailResponse {
   export function isa(o: any): o is ResendContactReachabilityEmailResponse {
-    return _smithy.isa(o, "ResendContactReachabilityEmailResponse");
+    return __isa(o, "ResendContactReachabilityEmailResponse");
   }
 }
 
@@ -1734,7 +1735,7 @@ export interface RetrieveDomainAuthCodeRequest {
 
 export namespace RetrieveDomainAuthCodeRequest {
   export function isa(o: any): o is RetrieveDomainAuthCodeRequest {
-    return _smithy.isa(o, "RetrieveDomainAuthCodeRequest");
+    return __isa(o, "RetrieveDomainAuthCodeRequest");
   }
 }
 
@@ -1751,16 +1752,14 @@ export interface RetrieveDomainAuthCodeResponse extends $MetadataBearer {
 
 export namespace RetrieveDomainAuthCodeResponse {
   export function isa(o: any): o is RetrieveDomainAuthCodeResponse {
-    return _smithy.isa(o, "RetrieveDomainAuthCodeResponse");
+    return __isa(o, "RetrieveDomainAuthCodeResponse");
   }
 }
 
 /**
  * <p>The top-level domain does not support this operation.</p>
  */
-export interface TLDRulesViolation
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface TLDRulesViolation extends __SmithyException, $MetadataBearer {
   name: "TLDRulesViolation";
   $fault: "client";
   /**
@@ -1771,7 +1770,7 @@ export interface TLDRulesViolation
 
 export namespace TLDRulesViolation {
   export function isa(o: any): o is TLDRulesViolation {
-    return _smithy.isa(o, "TLDRulesViolation");
+    return __isa(o, "TLDRulesViolation");
   }
 }
 
@@ -1797,7 +1796,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -1890,7 +1889,7 @@ export interface TransferDomainRequest {
 
 export namespace TransferDomainRequest {
   export function isa(o: any): o is TransferDomainRequest {
-    return _smithy.isa(o, "TransferDomainRequest");
+    return __isa(o, "TransferDomainRequest");
   }
 }
 
@@ -1908,7 +1907,7 @@ export interface TransferDomainResponse extends $MetadataBearer {
 
 export namespace TransferDomainResponse {
   export function isa(o: any): o is TransferDomainResponse {
-    return _smithy.isa(o, "TransferDomainResponse");
+    return __isa(o, "TransferDomainResponse");
   }
 }
 
@@ -1921,9 +1920,7 @@ export enum Transferable {
 /**
  * <p>Amazon Route 53 does not support this top-level domain (TLD).</p>
  */
-export interface UnsupportedTLD
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface UnsupportedTLD extends __SmithyException, $MetadataBearer {
   name: "UnsupportedTLD";
   $fault: "client";
   /**
@@ -1934,7 +1931,7 @@ export interface UnsupportedTLD
 
 export namespace UnsupportedTLD {
   export function isa(o: any): o is UnsupportedTLD {
-    return _smithy.isa(o, "UnsupportedTLD");
+    return __isa(o, "UnsupportedTLD");
   }
 }
 
@@ -1975,7 +1972,7 @@ export interface UpdateDomainContactPrivacyRequest {
 
 export namespace UpdateDomainContactPrivacyRequest {
   export function isa(o: any): o is UpdateDomainContactPrivacyRequest {
-    return _smithy.isa(o, "UpdateDomainContactPrivacyRequest");
+    return __isa(o, "UpdateDomainContactPrivacyRequest");
   }
 }
 
@@ -1992,7 +1989,7 @@ export interface UpdateDomainContactPrivacyResponse extends $MetadataBearer {
 
 export namespace UpdateDomainContactPrivacyResponse {
   export function isa(o: any): o is UpdateDomainContactPrivacyResponse {
-    return _smithy.isa(o, "UpdateDomainContactPrivacyResponse");
+    return __isa(o, "UpdateDomainContactPrivacyResponse");
   }
 }
 
@@ -2024,7 +2021,7 @@ export interface UpdateDomainContactRequest {
 
 export namespace UpdateDomainContactRequest {
   export function isa(o: any): o is UpdateDomainContactRequest {
-    return _smithy.isa(o, "UpdateDomainContactRequest");
+    return __isa(o, "UpdateDomainContactRequest");
   }
 }
 
@@ -2042,7 +2039,7 @@ export interface UpdateDomainContactResponse extends $MetadataBearer {
 
 export namespace UpdateDomainContactResponse {
   export function isa(o: any): o is UpdateDomainContactResponse {
-    return _smithy.isa(o, "UpdateDomainContactResponse");
+    return __isa(o, "UpdateDomainContactResponse");
   }
 }
 
@@ -2072,7 +2069,7 @@ export interface UpdateDomainNameserversRequest {
 
 export namespace UpdateDomainNameserversRequest {
   export function isa(o: any): o is UpdateDomainNameserversRequest {
-    return _smithy.isa(o, "UpdateDomainNameserversRequest");
+    return __isa(o, "UpdateDomainNameserversRequest");
   }
 }
 
@@ -2090,7 +2087,7 @@ export interface UpdateDomainNameserversResponse extends $MetadataBearer {
 
 export namespace UpdateDomainNameserversResponse {
   export function isa(o: any): o is UpdateDomainNameserversResponse {
-    return _smithy.isa(o, "UpdateDomainNameserversResponse");
+    return __isa(o, "UpdateDomainNameserversResponse");
   }
 }
 
@@ -2113,7 +2110,7 @@ export interface UpdateTagsForDomainRequest {
 
 export namespace UpdateTagsForDomainRequest {
   export function isa(o: any): o is UpdateTagsForDomainRequest {
-    return _smithy.isa(o, "UpdateTagsForDomainRequest");
+    return __isa(o, "UpdateTagsForDomainRequest");
   }
 }
 
@@ -2123,7 +2120,7 @@ export interface UpdateTagsForDomainResponse extends $MetadataBearer {
 
 export namespace UpdateTagsForDomainResponse {
   export function isa(o: any): o is UpdateTagsForDomainResponse {
-    return _smithy.isa(o, "UpdateTagsForDomainResponse");
+    return __isa(o, "UpdateTagsForDomainResponse");
   }
 }
 
@@ -2164,7 +2161,7 @@ export interface ViewBillingRequest {
 
 export namespace ViewBillingRequest {
   export function isa(o: any): o is ViewBillingRequest {
-    return _smithy.isa(o, "ViewBillingRequest");
+    return __isa(o, "ViewBillingRequest");
   }
 }
 
@@ -2187,6 +2184,6 @@ export interface ViewBillingResponse extends $MetadataBearer {
 
 export namespace ViewBillingResponse {
   export function isa(o: any): o is ViewBillingResponse {
-    return _smithy.isa(o, "ViewBillingResponse");
+    return __isa(o, "ViewBillingResponse");
   }
 }

--- a/clients/client-route-53/models/index.ts
+++ b/clients/client-route-53/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -48,7 +51,7 @@ export interface AccountLimit {
 
 export namespace AccountLimit {
   export function isa(o: any): o is AccountLimit {
-    return _smithy.isa(o, "AccountLimit");
+    return __isa(o, "AccountLimit");
   }
 }
 
@@ -94,7 +97,7 @@ export interface AlarmIdentifier {
 
 export namespace AlarmIdentifier {
   export function isa(o: any): o is AlarmIdentifier {
-    return _smithy.isa(o, "AlarmIdentifier");
+    return __isa(o, "AlarmIdentifier");
   }
 }
 
@@ -453,7 +456,7 @@ export interface AliasTarget {
 
 export namespace AliasTarget {
   export function isa(o: any): o is AliasTarget {
-    return _smithy.isa(o, "AliasTarget");
+    return __isa(o, "AliasTarget");
   }
 }
 
@@ -482,7 +485,7 @@ export interface AssociateVPCWithHostedZoneRequest {
 
 export namespace AssociateVPCWithHostedZoneRequest {
   export function isa(o: any): o is AssociateVPCWithHostedZoneRequest {
-    return _smithy.isa(o, "AssociateVPCWithHostedZoneRequest");
+    return __isa(o, "AssociateVPCWithHostedZoneRequest");
   }
 }
 
@@ -499,7 +502,7 @@ export interface AssociateVPCWithHostedZoneResponse extends $MetadataBearer {
 
 export namespace AssociateVPCWithHostedZoneResponse {
   export function isa(o: any): o is AssociateVPCWithHostedZoneResponse {
-    return _smithy.isa(o, "AssociateVPCWithHostedZoneResponse");
+    return __isa(o, "AssociateVPCWithHostedZoneResponse");
   }
 }
 
@@ -543,7 +546,7 @@ export interface Change {
 
 export namespace Change {
   export function isa(o: any): o is Change {
-    return _smithy.isa(o, "Change");
+    return __isa(o, "Change");
   }
 }
 
@@ -569,7 +572,7 @@ export interface ChangeBatch {
 
 export namespace ChangeBatch {
   export function isa(o: any): o is ChangeBatch {
-    return _smithy.isa(o, "ChangeBatch");
+    return __isa(o, "ChangeBatch");
   }
 }
 
@@ -609,7 +612,7 @@ export interface ChangeInfo {
 
 export namespace ChangeInfo {
   export function isa(o: any): o is ChangeInfo {
-    return _smithy.isa(o, "ChangeInfo");
+    return __isa(o, "ChangeInfo");
   }
 }
 
@@ -631,7 +634,7 @@ export interface ChangeResourceRecordSetsRequest {
 
 export namespace ChangeResourceRecordSetsRequest {
   export function isa(o: any): o is ChangeResourceRecordSetsRequest {
-    return _smithy.isa(o, "ChangeResourceRecordSetsRequest");
+    return __isa(o, "ChangeResourceRecordSetsRequest");
   }
 }
 
@@ -651,7 +654,7 @@ export interface ChangeResourceRecordSetsResponse extends $MetadataBearer {
 
 export namespace ChangeResourceRecordSetsResponse {
   export function isa(o: any): o is ChangeResourceRecordSetsResponse {
-    return _smithy.isa(o, "ChangeResourceRecordSetsResponse");
+    return __isa(o, "ChangeResourceRecordSetsResponse");
   }
 }
 
@@ -696,7 +699,7 @@ export interface ChangeTagsForResourceRequest {
 
 export namespace ChangeTagsForResourceRequest {
   export function isa(o: any): o is ChangeTagsForResourceRequest {
-    return _smithy.isa(o, "ChangeTagsForResourceRequest");
+    return __isa(o, "ChangeTagsForResourceRequest");
   }
 }
 
@@ -709,7 +712,7 @@ export interface ChangeTagsForResourceResponse extends $MetadataBearer {
 
 export namespace ChangeTagsForResourceResponse {
   export function isa(o: any): o is ChangeTagsForResourceResponse {
-    return _smithy.isa(o, "ChangeTagsForResourceResponse");
+    return __isa(o, "ChangeTagsForResourceResponse");
   }
 }
 
@@ -765,7 +768,7 @@ export interface CloudWatchAlarmConfiguration {
 
 export namespace CloudWatchAlarmConfiguration {
   export function isa(o: any): o is CloudWatchAlarmConfiguration {
-    return _smithy.isa(o, "CloudWatchAlarmConfiguration");
+    return __isa(o, "CloudWatchAlarmConfiguration");
   }
 }
 
@@ -802,7 +805,7 @@ export type ComparisonOperator =
  * <p>Another user submitted a request to create, update, or delete the object at the same time that you did. Retry the request. </p>
  */
 export interface ConcurrentModification
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ConcurrentModification";
   $fault: "client";
@@ -814,7 +817,7 @@ export interface ConcurrentModification
 
 export namespace ConcurrentModification {
   export function isa(o: any): o is ConcurrentModification {
-    return _smithy.isa(o, "ConcurrentModification");
+    return __isa(o, "ConcurrentModification");
   }
 }
 
@@ -838,7 +841,7 @@ export namespace ConcurrentModification {
  *          </ul>
  */
 export interface ConflictingDomainExists
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ConflictingDomainExists";
   $fault: "client";
@@ -847,7 +850,7 @@ export interface ConflictingDomainExists
 
 export namespace ConflictingDomainExists {
   export function isa(o: any): o is ConflictingDomainExists {
-    return _smithy.isa(o, "ConflictingDomainExists");
+    return __isa(o, "ConflictingDomainExists");
   }
 }
 
@@ -856,9 +859,7 @@ export namespace ConflictingDomainExists {
  * 			than the current type for the instance. You specified the type in the JSON document in the <code>CreateTrafficPolicy</code> or
  * 			<code>CreateTrafficPolicyVersion</code>request. </p>
  */
-export interface ConflictingTypes
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface ConflictingTypes extends __SmithyException, $MetadataBearer {
   name: "ConflictingTypes";
   $fault: "client";
   /**
@@ -869,7 +870,7 @@ export interface ConflictingTypes
 
 export namespace ConflictingTypes {
   export function isa(o: any): o is ConflictingTypes {
-    return _smithy.isa(o, "ConflictingTypes");
+    return __isa(o, "ConflictingTypes");
   }
 }
 
@@ -911,7 +912,7 @@ export interface CreateHealthCheckRequest {
 
 export namespace CreateHealthCheckRequest {
   export function isa(o: any): o is CreateHealthCheckRequest {
-    return _smithy.isa(o, "CreateHealthCheckRequest");
+    return __isa(o, "CreateHealthCheckRequest");
   }
 }
 
@@ -933,7 +934,7 @@ export interface CreateHealthCheckResponse extends $MetadataBearer {
 
 export namespace CreateHealthCheckResponse {
   export function isa(o: any): o is CreateHealthCheckResponse {
-    return _smithy.isa(o, "CreateHealthCheckResponse");
+    return __isa(o, "CreateHealthCheckResponse");
   }
 }
 
@@ -992,7 +993,7 @@ export interface CreateHostedZoneRequest {
 
 export namespace CreateHostedZoneRequest {
   export function isa(o: any): o is CreateHostedZoneRequest {
-    return _smithy.isa(o, "CreateHostedZoneRequest");
+    return __isa(o, "CreateHostedZoneRequest");
   }
 }
 
@@ -1029,7 +1030,7 @@ export interface CreateHostedZoneResponse extends $MetadataBearer {
 
 export namespace CreateHostedZoneResponse {
   export function isa(o: any): o is CreateHostedZoneResponse {
-    return _smithy.isa(o, "CreateHostedZoneResponse");
+    return __isa(o, "CreateHostedZoneResponse");
   }
 }
 
@@ -1057,7 +1058,7 @@ export interface CreateQueryLoggingConfigRequest {
 
 export namespace CreateQueryLoggingConfigRequest {
   export function isa(o: any): o is CreateQueryLoggingConfigRequest {
-    return _smithy.isa(o, "CreateQueryLoggingConfigRequest");
+    return __isa(o, "CreateQueryLoggingConfigRequest");
   }
 }
 
@@ -1077,7 +1078,7 @@ export interface CreateQueryLoggingConfigResponse extends $MetadataBearer {
 
 export namespace CreateQueryLoggingConfigResponse {
   export function isa(o: any): o is CreateQueryLoggingConfigResponse {
-    return _smithy.isa(o, "CreateQueryLoggingConfigResponse");
+    return __isa(o, "CreateQueryLoggingConfigResponse");
   }
 }
 
@@ -1101,7 +1102,7 @@ export interface CreateReusableDelegationSetRequest {
 
 export namespace CreateReusableDelegationSetRequest {
   export function isa(o: any): o is CreateReusableDelegationSetRequest {
-    return _smithy.isa(o, "CreateReusableDelegationSetRequest");
+    return __isa(o, "CreateReusableDelegationSetRequest");
   }
 }
 
@@ -1120,7 +1121,7 @@ export interface CreateReusableDelegationSetResponse extends $MetadataBearer {
 
 export namespace CreateReusableDelegationSetResponse {
   export function isa(o: any): o is CreateReusableDelegationSetResponse {
-    return _smithy.isa(o, "CreateReusableDelegationSetResponse");
+    return __isa(o, "CreateReusableDelegationSetResponse");
   }
 }
 
@@ -1158,7 +1159,7 @@ export interface CreateTrafficPolicyInstanceRequest {
 
 export namespace CreateTrafficPolicyInstanceRequest {
   export function isa(o: any): o is CreateTrafficPolicyInstanceRequest {
-    return _smithy.isa(o, "CreateTrafficPolicyInstanceRequest");
+    return __isa(o, "CreateTrafficPolicyInstanceRequest");
   }
 }
 
@@ -1180,7 +1181,7 @@ export interface CreateTrafficPolicyInstanceResponse extends $MetadataBearer {
 
 export namespace CreateTrafficPolicyInstanceResponse {
   export function isa(o: any): o is CreateTrafficPolicyInstanceResponse {
-    return _smithy.isa(o, "CreateTrafficPolicyInstanceResponse");
+    return __isa(o, "CreateTrafficPolicyInstanceResponse");
   }
 }
 
@@ -1208,7 +1209,7 @@ export interface CreateTrafficPolicyRequest {
 
 export namespace CreateTrafficPolicyRequest {
   export function isa(o: any): o is CreateTrafficPolicyRequest {
-    return _smithy.isa(o, "CreateTrafficPolicyRequest");
+    return __isa(o, "CreateTrafficPolicyRequest");
   }
 }
 
@@ -1230,7 +1231,7 @@ export interface CreateTrafficPolicyResponse extends $MetadataBearer {
 
 export namespace CreateTrafficPolicyResponse {
   export function isa(o: any): o is CreateTrafficPolicyResponse {
-    return _smithy.isa(o, "CreateTrafficPolicyResponse");
+    return __isa(o, "CreateTrafficPolicyResponse");
   }
 }
 
@@ -1259,7 +1260,7 @@ export interface CreateTrafficPolicyVersionRequest {
 
 export namespace CreateTrafficPolicyVersionRequest {
   export function isa(o: any): o is CreateTrafficPolicyVersionRequest {
-    return _smithy.isa(o, "CreateTrafficPolicyVersionRequest");
+    return __isa(o, "CreateTrafficPolicyVersionRequest");
   }
 }
 
@@ -1281,7 +1282,7 @@ export interface CreateTrafficPolicyVersionResponse extends $MetadataBearer {
 
 export namespace CreateTrafficPolicyVersionResponse {
   export function isa(o: any): o is CreateTrafficPolicyVersionResponse {
-    return _smithy.isa(o, "CreateTrafficPolicyVersionResponse");
+    return __isa(o, "CreateTrafficPolicyVersionResponse");
   }
 }
 
@@ -1305,7 +1306,7 @@ export interface CreateVPCAssociationAuthorizationRequest {
 
 export namespace CreateVPCAssociationAuthorizationRequest {
   export function isa(o: any): o is CreateVPCAssociationAuthorizationRequest {
-    return _smithy.isa(o, "CreateVPCAssociationAuthorizationRequest");
+    return __isa(o, "CreateVPCAssociationAuthorizationRequest");
   }
 }
 
@@ -1328,7 +1329,7 @@ export interface CreateVPCAssociationAuthorizationResponse
 
 export namespace CreateVPCAssociationAuthorizationResponse {
   export function isa(o: any): o is CreateVPCAssociationAuthorizationResponse {
-    return _smithy.isa(o, "CreateVPCAssociationAuthorizationResponse");
+    return __isa(o, "CreateVPCAssociationAuthorizationResponse");
   }
 }
 
@@ -1356,7 +1357,7 @@ export interface DelegationSet {
 
 export namespace DelegationSet {
   export function isa(o: any): o is DelegationSet {
-    return _smithy.isa(o, "DelegationSet");
+    return __isa(o, "DelegationSet");
   }
 }
 
@@ -1364,7 +1365,7 @@ export namespace DelegationSet {
  * <p>A delegation set with the same owner and caller reference combination has already been created.</p>
  */
 export interface DelegationSetAlreadyCreated
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DelegationSetAlreadyCreated";
   $fault: "client";
@@ -1376,7 +1377,7 @@ export interface DelegationSetAlreadyCreated
 
 export namespace DelegationSetAlreadyCreated {
   export function isa(o: any): o is DelegationSetAlreadyCreated {
-    return _smithy.isa(o, "DelegationSetAlreadyCreated");
+    return __isa(o, "DelegationSetAlreadyCreated");
   }
 }
 
@@ -1384,7 +1385,7 @@ export namespace DelegationSetAlreadyCreated {
  * <p>The specified delegation set has already been marked as reusable.</p>
  */
 export interface DelegationSetAlreadyReusable
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DelegationSetAlreadyReusable";
   $fault: "client";
@@ -1396,7 +1397,7 @@ export interface DelegationSetAlreadyReusable
 
 export namespace DelegationSetAlreadyReusable {
   export function isa(o: any): o is DelegationSetAlreadyReusable {
-    return _smithy.isa(o, "DelegationSetAlreadyReusable");
+    return __isa(o, "DelegationSetAlreadyReusable");
   }
 }
 
@@ -1404,9 +1405,7 @@ export namespace DelegationSetAlreadyReusable {
  * <p>The specified delegation contains associated hosted zones which must be deleted before the reusable delegation set
  * 			can be deleted.</p>
  */
-export interface DelegationSetInUse
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface DelegationSetInUse extends __SmithyException, $MetadataBearer {
   name: "DelegationSetInUse";
   $fault: "client";
   /**
@@ -1417,7 +1416,7 @@ export interface DelegationSetInUse
 
 export namespace DelegationSetInUse {
   export function isa(o: any): o is DelegationSetInUse {
-    return _smithy.isa(o, "DelegationSetInUse");
+    return __isa(o, "DelegationSetInUse");
   }
 }
 
@@ -1427,7 +1426,7 @@ export namespace DelegationSetInUse {
  * 			the domain name and Route 53 generates this error, contact Customer Support.</p>
  */
 export interface DelegationSetNotAvailable
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DelegationSetNotAvailable";
   $fault: "client";
@@ -1439,7 +1438,7 @@ export interface DelegationSetNotAvailable
 
 export namespace DelegationSetNotAvailable {
   export function isa(o: any): o is DelegationSetNotAvailable {
-    return _smithy.isa(o, "DelegationSetNotAvailable");
+    return __isa(o, "DelegationSetNotAvailable");
   }
 }
 
@@ -1447,7 +1446,7 @@ export namespace DelegationSetNotAvailable {
  * <p>A reusable delegation set with the specified ID does not exist.</p>
  */
 export interface DelegationSetNotReusable
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DelegationSetNotReusable";
   $fault: "client";
@@ -1459,7 +1458,7 @@ export interface DelegationSetNotReusable
 
 export namespace DelegationSetNotReusable {
   export function isa(o: any): o is DelegationSetNotReusable {
-    return _smithy.isa(o, "DelegationSetNotReusable");
+    return __isa(o, "DelegationSetNotReusable");
   }
 }
 
@@ -1476,7 +1475,7 @@ export interface DeleteHealthCheckRequest {
 
 export namespace DeleteHealthCheckRequest {
   export function isa(o: any): o is DeleteHealthCheckRequest {
-    return _smithy.isa(o, "DeleteHealthCheckRequest");
+    return __isa(o, "DeleteHealthCheckRequest");
   }
 }
 
@@ -1489,7 +1488,7 @@ export interface DeleteHealthCheckResponse extends $MetadataBearer {
 
 export namespace DeleteHealthCheckResponse {
   export function isa(o: any): o is DeleteHealthCheckResponse {
-    return _smithy.isa(o, "DeleteHealthCheckResponse");
+    return __isa(o, "DeleteHealthCheckResponse");
   }
 }
 
@@ -1506,7 +1505,7 @@ export interface DeleteHostedZoneRequest {
 
 export namespace DeleteHostedZoneRequest {
   export function isa(o: any): o is DeleteHostedZoneRequest {
-    return _smithy.isa(o, "DeleteHostedZoneRequest");
+    return __isa(o, "DeleteHostedZoneRequest");
   }
 }
 
@@ -1523,7 +1522,7 @@ export interface DeleteHostedZoneResponse extends $MetadataBearer {
 
 export namespace DeleteHostedZoneResponse {
   export function isa(o: any): o is DeleteHostedZoneResponse {
-    return _smithy.isa(o, "DeleteHostedZoneResponse");
+    return __isa(o, "DeleteHostedZoneResponse");
   }
 }
 
@@ -1537,7 +1536,7 @@ export interface DeleteQueryLoggingConfigRequest {
 
 export namespace DeleteQueryLoggingConfigRequest {
   export function isa(o: any): o is DeleteQueryLoggingConfigRequest {
-    return _smithy.isa(o, "DeleteQueryLoggingConfigRequest");
+    return __isa(o, "DeleteQueryLoggingConfigRequest");
   }
 }
 
@@ -1547,7 +1546,7 @@ export interface DeleteQueryLoggingConfigResponse extends $MetadataBearer {
 
 export namespace DeleteQueryLoggingConfigResponse {
   export function isa(o: any): o is DeleteQueryLoggingConfigResponse {
-    return _smithy.isa(o, "DeleteQueryLoggingConfigResponse");
+    return __isa(o, "DeleteQueryLoggingConfigResponse");
   }
 }
 
@@ -1564,7 +1563,7 @@ export interface DeleteReusableDelegationSetRequest {
 
 export namespace DeleteReusableDelegationSetRequest {
   export function isa(o: any): o is DeleteReusableDelegationSetRequest {
-    return _smithy.isa(o, "DeleteReusableDelegationSetRequest");
+    return __isa(o, "DeleteReusableDelegationSetRequest");
   }
 }
 
@@ -1577,7 +1576,7 @@ export interface DeleteReusableDelegationSetResponse extends $MetadataBearer {
 
 export namespace DeleteReusableDelegationSetResponse {
   export function isa(o: any): o is DeleteReusableDelegationSetResponse {
-    return _smithy.isa(o, "DeleteReusableDelegationSetResponse");
+    return __isa(o, "DeleteReusableDelegationSetResponse");
   }
 }
 
@@ -1598,7 +1597,7 @@ export interface DeleteTrafficPolicyInstanceRequest {
 
 export namespace DeleteTrafficPolicyInstanceRequest {
   export function isa(o: any): o is DeleteTrafficPolicyInstanceRequest {
-    return _smithy.isa(o, "DeleteTrafficPolicyInstanceRequest");
+    return __isa(o, "DeleteTrafficPolicyInstanceRequest");
   }
 }
 
@@ -1611,7 +1610,7 @@ export interface DeleteTrafficPolicyInstanceResponse extends $MetadataBearer {
 
 export namespace DeleteTrafficPolicyInstanceResponse {
   export function isa(o: any): o is DeleteTrafficPolicyInstanceResponse {
-    return _smithy.isa(o, "DeleteTrafficPolicyInstanceResponse");
+    return __isa(o, "DeleteTrafficPolicyInstanceResponse");
   }
 }
 
@@ -1633,7 +1632,7 @@ export interface DeleteTrafficPolicyRequest {
 
 export namespace DeleteTrafficPolicyRequest {
   export function isa(o: any): o is DeleteTrafficPolicyRequest {
-    return _smithy.isa(o, "DeleteTrafficPolicyRequest");
+    return __isa(o, "DeleteTrafficPolicyRequest");
   }
 }
 
@@ -1646,7 +1645,7 @@ export interface DeleteTrafficPolicyResponse extends $MetadataBearer {
 
 export namespace DeleteTrafficPolicyResponse {
   export function isa(o: any): o is DeleteTrafficPolicyResponse {
-    return _smithy.isa(o, "DeleteTrafficPolicyResponse");
+    return __isa(o, "DeleteTrafficPolicyResponse");
   }
 }
 
@@ -1671,7 +1670,7 @@ export interface DeleteVPCAssociationAuthorizationRequest {
 
 export namespace DeleteVPCAssociationAuthorizationRequest {
   export function isa(o: any): o is DeleteVPCAssociationAuthorizationRequest {
-    return _smithy.isa(o, "DeleteVPCAssociationAuthorizationRequest");
+    return __isa(o, "DeleteVPCAssociationAuthorizationRequest");
   }
 }
 
@@ -1685,7 +1684,7 @@ export interface DeleteVPCAssociationAuthorizationResponse
 
 export namespace DeleteVPCAssociationAuthorizationResponse {
   export function isa(o: any): o is DeleteVPCAssociationAuthorizationResponse {
-    return _smithy.isa(o, "DeleteVPCAssociationAuthorizationResponse");
+    return __isa(o, "DeleteVPCAssociationAuthorizationResponse");
   }
 }
 
@@ -1707,7 +1706,7 @@ export interface Dimension {
 
 export namespace Dimension {
   export function isa(o: any): o is Dimension {
-    return _smithy.isa(o, "Dimension");
+    return __isa(o, "Dimension");
   }
 }
 
@@ -1737,7 +1736,7 @@ export interface DisassociateVPCFromHostedZoneRequest {
 
 export namespace DisassociateVPCFromHostedZoneRequest {
   export function isa(o: any): o is DisassociateVPCFromHostedZoneRequest {
-    return _smithy.isa(o, "DisassociateVPCFromHostedZoneRequest");
+    return __isa(o, "DisassociateVPCFromHostedZoneRequest");
   }
 }
 
@@ -1754,7 +1753,7 @@ export interface DisassociateVPCFromHostedZoneResponse extends $MetadataBearer {
 
 export namespace DisassociateVPCFromHostedZoneResponse {
   export function isa(o: any): o is DisassociateVPCFromHostedZoneResponse {
-    return _smithy.isa(o, "DisassociateVPCFromHostedZoneResponse");
+    return __isa(o, "DisassociateVPCFromHostedZoneResponse");
   }
 }
 
@@ -1785,7 +1784,7 @@ export interface GeoLocation {
 
 export namespace GeoLocation {
   export function isa(o: any): o is GeoLocation {
-    return _smithy.isa(o, "GeoLocation");
+    return __isa(o, "GeoLocation");
   }
 }
 
@@ -1827,7 +1826,7 @@ export interface GeoLocationDetails {
 
 export namespace GeoLocationDetails {
   export function isa(o: any): o is GeoLocationDetails {
-    return _smithy.isa(o, "GeoLocationDetails");
+    return __isa(o, "GeoLocationDetails");
   }
 }
 
@@ -1872,7 +1871,7 @@ export interface GetAccountLimitRequest {
 
 export namespace GetAccountLimitRequest {
   export function isa(o: any): o is GetAccountLimitRequest {
-    return _smithy.isa(o, "GetAccountLimitRequest");
+    return __isa(o, "GetAccountLimitRequest");
   }
 }
 
@@ -1898,7 +1897,7 @@ export interface GetAccountLimitResponse extends $MetadataBearer {
 
 export namespace GetAccountLimitResponse {
   export function isa(o: any): o is GetAccountLimitResponse {
-    return _smithy.isa(o, "GetAccountLimitResponse");
+    return __isa(o, "GetAccountLimitResponse");
   }
 }
 
@@ -1916,7 +1915,7 @@ export interface GetChangeRequest {
 
 export namespace GetChangeRequest {
   export function isa(o: any): o is GetChangeRequest {
-    return _smithy.isa(o, "GetChangeRequest");
+    return __isa(o, "GetChangeRequest");
   }
 }
 
@@ -1933,7 +1932,7 @@ export interface GetChangeResponse extends $MetadataBearer {
 
 export namespace GetChangeResponse {
   export function isa(o: any): o is GetChangeResponse {
-    return _smithy.isa(o, "GetChangeResponse");
+    return __isa(o, "GetChangeResponse");
   }
 }
 
@@ -1946,7 +1945,7 @@ export interface GetCheckerIpRangesRequest {
 
 export namespace GetCheckerIpRangesRequest {
   export function isa(o: any): o is GetCheckerIpRangesRequest {
-    return _smithy.isa(o, "GetCheckerIpRangesRequest");
+    return __isa(o, "GetCheckerIpRangesRequest");
   }
 }
 
@@ -1964,7 +1963,7 @@ export interface GetCheckerIpRangesResponse extends $MetadataBearer {
 
 export namespace GetCheckerIpRangesResponse {
   export function isa(o: any): o is GetCheckerIpRangesResponse {
-    return _smithy.isa(o, "GetCheckerIpRangesResponse");
+    return __isa(o, "GetCheckerIpRangesResponse");
   }
 }
 
@@ -2024,7 +2023,7 @@ export interface GetGeoLocationRequest {
 
 export namespace GetGeoLocationRequest {
   export function isa(o: any): o is GetGeoLocationRequest {
-    return _smithy.isa(o, "GetGeoLocationRequest");
+    return __isa(o, "GetGeoLocationRequest");
   }
 }
 
@@ -2041,7 +2040,7 @@ export interface GetGeoLocationResponse extends $MetadataBearer {
 
 export namespace GetGeoLocationResponse {
   export function isa(o: any): o is GetGeoLocationResponse {
-    return _smithy.isa(o, "GetGeoLocationResponse");
+    return __isa(o, "GetGeoLocationResponse");
   }
 }
 
@@ -2054,7 +2053,7 @@ export interface GetHealthCheckCountRequest {
 
 export namespace GetHealthCheckCountRequest {
   export function isa(o: any): o is GetHealthCheckCountRequest {
-    return _smithy.isa(o, "GetHealthCheckCountRequest");
+    return __isa(o, "GetHealthCheckCountRequest");
   }
 }
 
@@ -2071,7 +2070,7 @@ export interface GetHealthCheckCountResponse extends $MetadataBearer {
 
 export namespace GetHealthCheckCountResponse {
   export function isa(o: any): o is GetHealthCheckCountResponse {
-    return _smithy.isa(o, "GetHealthCheckCountResponse");
+    return __isa(o, "GetHealthCheckCountResponse");
   }
 }
 
@@ -2093,7 +2092,7 @@ export interface GetHealthCheckLastFailureReasonRequest {
 
 export namespace GetHealthCheckLastFailureReasonRequest {
   export function isa(o: any): o is GetHealthCheckLastFailureReasonRequest {
-    return _smithy.isa(o, "GetHealthCheckLastFailureReasonRequest");
+    return __isa(o, "GetHealthCheckLastFailureReasonRequest");
   }
 }
 
@@ -2111,7 +2110,7 @@ export interface GetHealthCheckLastFailureReasonResponse
 
 export namespace GetHealthCheckLastFailureReasonResponse {
   export function isa(o: any): o is GetHealthCheckLastFailureReasonResponse {
-    return _smithy.isa(o, "GetHealthCheckLastFailureReasonResponse");
+    return __isa(o, "GetHealthCheckLastFailureReasonResponse");
   }
 }
 
@@ -2129,7 +2128,7 @@ export interface GetHealthCheckRequest {
 
 export namespace GetHealthCheckRequest {
   export function isa(o: any): o is GetHealthCheckRequest {
-    return _smithy.isa(o, "GetHealthCheckRequest");
+    return __isa(o, "GetHealthCheckRequest");
   }
 }
 
@@ -2147,7 +2146,7 @@ export interface GetHealthCheckResponse extends $MetadataBearer {
 
 export namespace GetHealthCheckResponse {
   export function isa(o: any): o is GetHealthCheckResponse {
-    return _smithy.isa(o, "GetHealthCheckResponse");
+    return __isa(o, "GetHealthCheckResponse");
   }
 }
 
@@ -2169,7 +2168,7 @@ export interface GetHealthCheckStatusRequest {
 
 export namespace GetHealthCheckStatusRequest {
   export function isa(o: any): o is GetHealthCheckStatusRequest {
-    return _smithy.isa(o, "GetHealthCheckStatusRequest");
+    return __isa(o, "GetHealthCheckStatusRequest");
   }
 }
 
@@ -2188,7 +2187,7 @@ export interface GetHealthCheckStatusResponse extends $MetadataBearer {
 
 export namespace GetHealthCheckStatusResponse {
   export function isa(o: any): o is GetHealthCheckStatusResponse {
-    return _smithy.isa(o, "GetHealthCheckStatusResponse");
+    return __isa(o, "GetHealthCheckStatusResponse");
   }
 }
 
@@ -2201,7 +2200,7 @@ export interface GetHostedZoneCountRequest {
 
 export namespace GetHostedZoneCountRequest {
   export function isa(o: any): o is GetHostedZoneCountRequest {
-    return _smithy.isa(o, "GetHostedZoneCountRequest");
+    return __isa(o, "GetHostedZoneCountRequest");
   }
 }
 
@@ -2218,7 +2217,7 @@ export interface GetHostedZoneCountResponse extends $MetadataBearer {
 
 export namespace GetHostedZoneCountResponse {
   export function isa(o: any): o is GetHostedZoneCountResponse {
-    return _smithy.isa(o, "GetHostedZoneCountResponse");
+    return __isa(o, "GetHostedZoneCountResponse");
   }
 }
 
@@ -2252,7 +2251,7 @@ export interface GetHostedZoneLimitRequest {
 
 export namespace GetHostedZoneLimitRequest {
   export function isa(o: any): o is GetHostedZoneLimitRequest {
-    return _smithy.isa(o, "GetHostedZoneLimitRequest");
+    return __isa(o, "GetHostedZoneLimitRequest");
   }
 }
 
@@ -2278,7 +2277,7 @@ export interface GetHostedZoneLimitResponse extends $MetadataBearer {
 
 export namespace GetHostedZoneLimitResponse {
   export function isa(o: any): o is GetHostedZoneLimitResponse {
-    return _smithy.isa(o, "GetHostedZoneLimitResponse");
+    return __isa(o, "GetHostedZoneLimitResponse");
   }
 }
 
@@ -2295,7 +2294,7 @@ export interface GetHostedZoneRequest {
 
 export namespace GetHostedZoneRequest {
   export function isa(o: any): o is GetHostedZoneRequest {
-    return _smithy.isa(o, "GetHostedZoneRequest");
+    return __isa(o, "GetHostedZoneRequest");
   }
 }
 
@@ -2322,7 +2321,7 @@ export interface GetHostedZoneResponse extends $MetadataBearer {
 
 export namespace GetHostedZoneResponse {
   export function isa(o: any): o is GetHostedZoneResponse {
-    return _smithy.isa(o, "GetHostedZoneResponse");
+    return __isa(o, "GetHostedZoneResponse");
   }
 }
 
@@ -2336,7 +2335,7 @@ export interface GetQueryLoggingConfigRequest {
 
 export namespace GetQueryLoggingConfigRequest {
   export function isa(o: any): o is GetQueryLoggingConfigRequest {
-    return _smithy.isa(o, "GetQueryLoggingConfigRequest");
+    return __isa(o, "GetQueryLoggingConfigRequest");
   }
 }
 
@@ -2351,7 +2350,7 @@ export interface GetQueryLoggingConfigResponse extends $MetadataBearer {
 
 export namespace GetQueryLoggingConfigResponse {
   export function isa(o: any): o is GetQueryLoggingConfigResponse {
-    return _smithy.isa(o, "GetQueryLoggingConfigResponse");
+    return __isa(o, "GetQueryLoggingConfigResponse");
   }
 }
 
@@ -2374,7 +2373,7 @@ export interface GetReusableDelegationSetLimitRequest {
 
 export namespace GetReusableDelegationSetLimitRequest {
   export function isa(o: any): o is GetReusableDelegationSetLimitRequest {
-    return _smithy.isa(o, "GetReusableDelegationSetLimitRequest");
+    return __isa(o, "GetReusableDelegationSetLimitRequest");
   }
 }
 
@@ -2396,7 +2395,7 @@ export interface GetReusableDelegationSetLimitResponse extends $MetadataBearer {
 
 export namespace GetReusableDelegationSetLimitResponse {
   export function isa(o: any): o is GetReusableDelegationSetLimitResponse {
-    return _smithy.isa(o, "GetReusableDelegationSetLimitResponse");
+    return __isa(o, "GetReusableDelegationSetLimitResponse");
   }
 }
 
@@ -2413,7 +2412,7 @@ export interface GetReusableDelegationSetRequest {
 
 export namespace GetReusableDelegationSetRequest {
   export function isa(o: any): o is GetReusableDelegationSetRequest {
-    return _smithy.isa(o, "GetReusableDelegationSetRequest");
+    return __isa(o, "GetReusableDelegationSetRequest");
   }
 }
 
@@ -2430,7 +2429,7 @@ export interface GetReusableDelegationSetResponse extends $MetadataBearer {
 
 export namespace GetReusableDelegationSetResponse {
   export function isa(o: any): o is GetReusableDelegationSetResponse {
-    return _smithy.isa(o, "GetReusableDelegationSetResponse");
+    return __isa(o, "GetReusableDelegationSetResponse");
   }
 }
 
@@ -2443,7 +2442,7 @@ export interface GetTrafficPolicyInstanceCountRequest {
 
 export namespace GetTrafficPolicyInstanceCountRequest {
   export function isa(o: any): o is GetTrafficPolicyInstanceCountRequest {
-    return _smithy.isa(o, "GetTrafficPolicyInstanceCountRequest");
+    return __isa(o, "GetTrafficPolicyInstanceCountRequest");
   }
 }
 
@@ -2460,7 +2459,7 @@ export interface GetTrafficPolicyInstanceCountResponse extends $MetadataBearer {
 
 export namespace GetTrafficPolicyInstanceCountResponse {
   export function isa(o: any): o is GetTrafficPolicyInstanceCountResponse {
-    return _smithy.isa(o, "GetTrafficPolicyInstanceCountResponse");
+    return __isa(o, "GetTrafficPolicyInstanceCountResponse");
   }
 }
 
@@ -2477,7 +2476,7 @@ export interface GetTrafficPolicyInstanceRequest {
 
 export namespace GetTrafficPolicyInstanceRequest {
   export function isa(o: any): o is GetTrafficPolicyInstanceRequest {
-    return _smithy.isa(o, "GetTrafficPolicyInstanceRequest");
+    return __isa(o, "GetTrafficPolicyInstanceRequest");
   }
 }
 
@@ -2494,7 +2493,7 @@ export interface GetTrafficPolicyInstanceResponse extends $MetadataBearer {
 
 export namespace GetTrafficPolicyInstanceResponse {
   export function isa(o: any): o is GetTrafficPolicyInstanceResponse {
-    return _smithy.isa(o, "GetTrafficPolicyInstanceResponse");
+    return __isa(o, "GetTrafficPolicyInstanceResponse");
   }
 }
 
@@ -2516,7 +2515,7 @@ export interface GetTrafficPolicyRequest {
 
 export namespace GetTrafficPolicyRequest {
   export function isa(o: any): o is GetTrafficPolicyRequest {
-    return _smithy.isa(o, "GetTrafficPolicyRequest");
+    return __isa(o, "GetTrafficPolicyRequest");
   }
 }
 
@@ -2533,7 +2532,7 @@ export interface GetTrafficPolicyResponse extends $MetadataBearer {
 
 export namespace GetTrafficPolicyResponse {
   export function isa(o: any): o is GetTrafficPolicyResponse {
-    return _smithy.isa(o, "GetTrafficPolicyResponse");
+    return __isa(o, "GetTrafficPolicyResponse");
   }
 }
 
@@ -2578,7 +2577,7 @@ export interface HealthCheck {
 
 export namespace HealthCheck {
   export function isa(o: any): o is HealthCheck {
-    return _smithy.isa(o, "HealthCheck");
+    return __isa(o, "HealthCheck");
   }
 }
 
@@ -2597,7 +2596,7 @@ export namespace HealthCheck {
  *          </ul>
  */
 export interface HealthCheckAlreadyExists
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "HealthCheckAlreadyExists";
   $fault: "client";
@@ -2609,7 +2608,7 @@ export interface HealthCheckAlreadyExists
 
 export namespace HealthCheckAlreadyExists {
   export function isa(o: any): o is HealthCheckAlreadyExists {
-    return _smithy.isa(o, "HealthCheckAlreadyExists");
+    return __isa(o, "HealthCheckAlreadyExists");
   }
 }
 
@@ -2939,16 +2938,14 @@ export interface HealthCheckConfig {
 
 export namespace HealthCheckConfig {
   export function isa(o: any): o is HealthCheckConfig {
-    return _smithy.isa(o, "HealthCheckConfig");
+    return __isa(o, "HealthCheckConfig");
   }
 }
 
 /**
  * <p>This error code is not in use.</p>
  */
-export interface HealthCheckInUse
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface HealthCheckInUse extends __SmithyException, $MetadataBearer {
   name: "HealthCheckInUse";
   $fault: "client";
   /**
@@ -2959,7 +2956,7 @@ export interface HealthCheckInUse
 
 export namespace HealthCheckInUse {
   export function isa(o: any): o is HealthCheckInUse {
-    return _smithy.isa(o, "HealthCheckInUse");
+    return __isa(o, "HealthCheckInUse");
   }
 }
 
@@ -2986,7 +2983,7 @@ export interface HealthCheckObservation {
 
 export namespace HealthCheckObservation {
   export function isa(o: any): o is HealthCheckObservation {
-    return _smithy.isa(o, "HealthCheckObservation");
+    return __isa(o, "HealthCheckObservation");
   }
 }
 
@@ -3015,7 +3012,7 @@ export enum HealthCheckType {
  * 			in the health check.</p>
  */
 export interface HealthCheckVersionMismatch
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "HealthCheckVersionMismatch";
   $fault: "client";
@@ -3024,7 +3021,7 @@ export interface HealthCheckVersionMismatch
 
 export namespace HealthCheckVersionMismatch {
   export function isa(o: any): o is HealthCheckVersionMismatch {
-    return _smithy.isa(o, "HealthCheckVersionMismatch");
+    return __isa(o, "HealthCheckVersionMismatch");
   }
 }
 
@@ -3075,7 +3072,7 @@ export interface HostedZone {
 
 export namespace HostedZone {
   export function isa(o: any): o is HostedZone {
-    return _smithy.isa(o, "HostedZone");
+    return __isa(o, "HostedZone");
   }
 }
 
@@ -3084,7 +3081,7 @@ export namespace HostedZone {
  * 			with the specified <code>CallerReference</code>.</p>
  */
 export interface HostedZoneAlreadyExists
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "HostedZoneAlreadyExists";
   $fault: "client";
@@ -3096,7 +3093,7 @@ export interface HostedZoneAlreadyExists
 
 export namespace HostedZoneAlreadyExists {
   export function isa(o: any): o is HostedZoneAlreadyExists {
-    return _smithy.isa(o, "HostedZoneAlreadyExists");
+    return __isa(o, "HostedZoneAlreadyExists");
   }
 }
 
@@ -3120,7 +3117,7 @@ export interface HostedZoneConfig {
 
 export namespace HostedZoneConfig {
   export function isa(o: any): o is HostedZoneConfig {
-    return _smithy.isa(o, "HostedZoneConfig");
+    return __isa(o, "HostedZoneConfig");
   }
 }
 
@@ -3154,7 +3151,7 @@ export interface HostedZoneLimit {
 
 export namespace HostedZoneLimit {
   export function isa(o: any): o is HostedZoneLimit {
-    return _smithy.isa(o, "HostedZoneLimit");
+    return __isa(o, "HostedZoneLimit");
   }
 }
 
@@ -3165,9 +3162,7 @@ export type HostedZoneLimitType =
 /**
  * <p>The hosted zone contains resource records that are not SOA or NS records.</p>
  */
-export interface HostedZoneNotEmpty
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface HostedZoneNotEmpty extends __SmithyException, $MetadataBearer {
   name: "HostedZoneNotEmpty";
   $fault: "client";
   /**
@@ -3178,16 +3173,14 @@ export interface HostedZoneNotEmpty
 
 export namespace HostedZoneNotEmpty {
   export function isa(o: any): o is HostedZoneNotEmpty {
-    return _smithy.isa(o, "HostedZoneNotEmpty");
+    return __isa(o, "HostedZoneNotEmpty");
   }
 }
 
 /**
  * <p>The specified HostedZone can't be found.</p>
  */
-export interface HostedZoneNotFound
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface HostedZoneNotFound extends __SmithyException, $MetadataBearer {
   name: "HostedZoneNotFound";
   $fault: "client";
   /**
@@ -3198,7 +3191,7 @@ export interface HostedZoneNotFound
 
 export namespace HostedZoneNotFound {
   export function isa(o: any): o is HostedZoneNotFound {
-    return _smithy.isa(o, "HostedZoneNotFound");
+    return __isa(o, "HostedZoneNotFound");
   }
 }
 
@@ -3206,7 +3199,7 @@ export namespace HostedZoneNotFound {
  * <p>The specified hosted zone is a public hosted zone, not a private hosted zone.</p>
  */
 export interface HostedZoneNotPrivate
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "HostedZoneNotPrivate";
   $fault: "client";
@@ -3218,7 +3211,7 @@ export interface HostedZoneNotPrivate
 
 export namespace HostedZoneNotPrivate {
   export function isa(o: any): o is HostedZoneNotPrivate {
-    return _smithy.isa(o, "HostedZoneNotPrivate");
+    return __isa(o, "HostedZoneNotPrivate");
   }
 }
 
@@ -3226,7 +3219,7 @@ export namespace HostedZoneNotPrivate {
  * <p>The resource you're trying to access is unsupported on this Amazon Route 53 endpoint.</p>
  */
 export interface IncompatibleVersion
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "IncompatibleVersion";
   $fault: "client";
@@ -3235,7 +3228,7 @@ export interface IncompatibleVersion
 
 export namespace IncompatibleVersion {
   export function isa(o: any): o is IncompatibleVersion {
-    return _smithy.isa(o, "IncompatibleVersion");
+    return __isa(o, "IncompatibleVersion");
   }
 }
 
@@ -3256,7 +3249,7 @@ export namespace IncompatibleVersion {
  *          </ul>
  */
 export interface InsufficientCloudWatchLogsResourcePolicy
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InsufficientCloudWatchLogsResourcePolicy";
   $fault: "client";
@@ -3265,7 +3258,7 @@ export interface InsufficientCloudWatchLogsResourcePolicy
 
 export namespace InsufficientCloudWatchLogsResourcePolicy {
   export function isa(o: any): o is InsufficientCloudWatchLogsResourcePolicy {
-    return _smithy.isa(o, "InsufficientCloudWatchLogsResourcePolicy");
+    return __isa(o, "InsufficientCloudWatchLogsResourcePolicy");
   }
 }
 
@@ -3277,9 +3270,7 @@ export type InsufficientDataHealthStatus =
 /**
  * <p>Parameter name is invalid.</p>
  */
-export interface InvalidArgument
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface InvalidArgument extends __SmithyException, $MetadataBearer {
   name: "InvalidArgument";
   $fault: "client";
   /**
@@ -3290,7 +3281,7 @@ export interface InvalidArgument
 
 export namespace InvalidArgument {
   export function isa(o: any): o is InvalidArgument {
-    return _smithy.isa(o, "InvalidArgument");
+    return __isa(o, "InvalidArgument");
   }
 }
 
@@ -3298,9 +3289,7 @@ export namespace InvalidArgument {
  * <p>This exception contains a list of messages that might contain one or more error messages. Each error message indicates
  * 			one error in the change batch.</p>
  */
-export interface InvalidChangeBatch
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface InvalidChangeBatch extends __SmithyException, $MetadataBearer {
   name: "InvalidChangeBatch";
   $fault: "client";
   message?: string;
@@ -3312,16 +3301,14 @@ export interface InvalidChangeBatch
 
 export namespace InvalidChangeBatch {
   export function isa(o: any): o is InvalidChangeBatch {
-    return _smithy.isa(o, "InvalidChangeBatch");
+    return __isa(o, "InvalidChangeBatch");
   }
 }
 
 /**
  * <p>The specified domain name is not valid.</p>
  */
-export interface InvalidDomainName
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface InvalidDomainName extends __SmithyException, $MetadataBearer {
   name: "InvalidDomainName";
   $fault: "client";
   /**
@@ -3332,14 +3319,14 @@ export interface InvalidDomainName
 
 export namespace InvalidDomainName {
   export function isa(o: any): o is InvalidDomainName {
-    return _smithy.isa(o, "InvalidDomainName");
+    return __isa(o, "InvalidDomainName");
   }
 }
 
 /**
  * <p>The input is not valid.</p>
  */
-export interface InvalidInput extends _smithy.SmithyException, $MetadataBearer {
+export interface InvalidInput extends __SmithyException, $MetadataBearer {
   name: "InvalidInput";
   $fault: "client";
   /**
@@ -3350,7 +3337,7 @@ export interface InvalidInput extends _smithy.SmithyException, $MetadataBearer {
 
 export namespace InvalidInput {
   export function isa(o: any): o is InvalidInput {
-    return _smithy.isa(o, "InvalidInput");
+    return __isa(o, "InvalidInput");
   }
 }
 
@@ -3358,7 +3345,7 @@ export namespace InvalidInput {
  * <p>The value that you specified to get the second or subsequent page of results is invalid.</p>
  */
 export interface InvalidPaginationToken
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidPaginationToken";
   $fault: "client";
@@ -3367,7 +3354,7 @@ export interface InvalidPaginationToken
 
 export namespace InvalidPaginationToken {
   export function isa(o: any): o is InvalidPaginationToken {
-    return _smithy.isa(o, "InvalidPaginationToken");
+    return __isa(o, "InvalidPaginationToken");
   }
 }
 
@@ -3375,7 +3362,7 @@ export namespace InvalidPaginationToken {
  * <p>The format of the traffic policy document that you specified in the <code>Document</code> element is invalid.</p>
  */
 export interface InvalidTrafficPolicyDocument
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidTrafficPolicyDocument";
   $fault: "client";
@@ -3387,14 +3374,14 @@ export interface InvalidTrafficPolicyDocument
 
 export namespace InvalidTrafficPolicyDocument {
   export function isa(o: any): o is InvalidTrafficPolicyDocument {
-    return _smithy.isa(o, "InvalidTrafficPolicyDocument");
+    return __isa(o, "InvalidTrafficPolicyDocument");
   }
 }
 
 /**
  * <p>The VPC ID that you specified either isn't a valid ID or the current account is not authorized to access this VPC.</p>
  */
-export interface InvalidVPCId extends _smithy.SmithyException, $MetadataBearer {
+export interface InvalidVPCId extends __SmithyException, $MetadataBearer {
   name: "InvalidVPCId";
   $fault: "client";
   /**
@@ -3405,7 +3392,7 @@ export interface InvalidVPCId extends _smithy.SmithyException, $MetadataBearer {
 
 export namespace InvalidVPCId {
   export function isa(o: any): o is InvalidVPCId {
-    return _smithy.isa(o, "InvalidVPCId");
+    return __isa(o, "InvalidVPCId");
   }
 }
 
@@ -3413,9 +3400,7 @@ export namespace InvalidVPCId {
  * <p>The VPC that you're trying to disassociate from the private hosted zone is the last VPC that is associated with
  * 			the hosted zone. Amazon Route 53 doesn't support disassociating the last VPC from a hosted zone.</p>
  */
-export interface LastVPCAssociation
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface LastVPCAssociation extends __SmithyException, $MetadataBearer {
   name: "LastVPCAssociation";
   $fault: "client";
   /**
@@ -3426,7 +3411,7 @@ export interface LastVPCAssociation
 
 export namespace LastVPCAssociation {
   export function isa(o: any): o is LastVPCAssociation {
-    return _smithy.isa(o, "LastVPCAssociation");
+    return __isa(o, "LastVPCAssociation");
   }
 }
 
@@ -3439,9 +3424,7 @@ export namespace LastVPCAssociation {
  * 			<a href="https://docs.aws.amazon.com/Route53/latest/APIReference/API_GetHostedZoneLimit.html">GetHostedZoneLimit</a>.
  * 			To request a higher limit, <a href="http://aws.amazon.com/route53-request">create a case</a> with the AWS Support Center.</p>
  */
-export interface LimitsExceeded
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface LimitsExceeded extends __SmithyException, $MetadataBearer {
   name: "LimitsExceeded";
   $fault: "client";
   /**
@@ -3452,7 +3435,7 @@ export interface LimitsExceeded
 
 export namespace LimitsExceeded {
   export function isa(o: any): o is LimitsExceeded {
-    return _smithy.isa(o, "LimitsExceeded");
+    return __isa(o, "LimitsExceeded");
   }
 }
 
@@ -3477,7 +3460,7 @@ export interface LinkedService {
 
 export namespace LinkedService {
   export function isa(o: any): o is LinkedService {
-    return _smithy.isa(o, "LinkedService");
+    return __isa(o, "LinkedService");
   }
 }
 
@@ -3522,7 +3505,7 @@ export interface ListGeoLocationsRequest {
 
 export namespace ListGeoLocationsRequest {
   export function isa(o: any): o is ListGeoLocationsRequest {
-    return _smithy.isa(o, "ListGeoLocationsRequest");
+    return __isa(o, "ListGeoLocationsRequest");
   }
 }
 
@@ -3570,7 +3553,7 @@ export interface ListGeoLocationsResponse extends $MetadataBearer {
 
 export namespace ListGeoLocationsResponse {
   export function isa(o: any): o is ListGeoLocationsResponse {
-    return _smithy.isa(o, "ListGeoLocationsResponse");
+    return __isa(o, "ListGeoLocationsResponse");
   }
 }
 
@@ -3597,7 +3580,7 @@ export interface ListHealthChecksRequest {
 
 export namespace ListHealthChecksRequest {
   export function isa(o: any): o is ListHealthChecksRequest {
-    return _smithy.isa(o, "ListHealthChecksRequest");
+    return __isa(o, "ListHealthChecksRequest");
   }
 }
 
@@ -3641,7 +3624,7 @@ export interface ListHealthChecksResponse extends $MetadataBearer {
 
 export namespace ListHealthChecksResponse {
   export function isa(o: any): o is ListHealthChecksResponse {
-    return _smithy.isa(o, "ListHealthChecksResponse");
+    return __isa(o, "ListHealthChecksResponse");
   }
 }
 
@@ -3678,7 +3661,7 @@ export interface ListHostedZonesByNameRequest {
 
 export namespace ListHostedZonesByNameRequest {
   export function isa(o: any): o is ListHostedZonesByNameRequest {
-    return _smithy.isa(o, "ListHostedZonesByNameRequest");
+    return __isa(o, "ListHostedZonesByNameRequest");
   }
 }
 
@@ -3735,7 +3718,7 @@ export interface ListHostedZonesByNameResponse extends $MetadataBearer {
 
 export namespace ListHostedZonesByNameResponse {
   export function isa(o: any): o is ListHostedZonesByNameResponse {
-    return _smithy.isa(o, "ListHostedZonesByNameResponse");
+    return __isa(o, "ListHostedZonesByNameResponse");
   }
 }
 
@@ -3769,7 +3752,7 @@ export interface ListHostedZonesRequest {
 
 export namespace ListHostedZonesRequest {
   export function isa(o: any): o is ListHostedZonesRequest {
-    return _smithy.isa(o, "ListHostedZonesRequest");
+    return __isa(o, "ListHostedZonesRequest");
   }
 }
 
@@ -3810,7 +3793,7 @@ export interface ListHostedZonesResponse extends $MetadataBearer {
 
 export namespace ListHostedZonesResponse {
   export function isa(o: any): o is ListHostedZonesResponse {
-    return _smithy.isa(o, "ListHostedZonesResponse");
+    return __isa(o, "ListHostedZonesResponse");
   }
 }
 
@@ -3845,7 +3828,7 @@ export interface ListQueryLoggingConfigsRequest {
 
 export namespace ListQueryLoggingConfigsRequest {
   export function isa(o: any): o is ListQueryLoggingConfigsRequest {
-    return _smithy.isa(o, "ListQueryLoggingConfigsRequest");
+    return __isa(o, "ListQueryLoggingConfigsRequest");
   }
 }
 
@@ -3871,7 +3854,7 @@ export interface ListQueryLoggingConfigsResponse extends $MetadataBearer {
 
 export namespace ListQueryLoggingConfigsResponse {
   export function isa(o: any): o is ListQueryLoggingConfigsResponse {
-    return _smithy.isa(o, "ListQueryLoggingConfigsResponse");
+    return __isa(o, "ListQueryLoggingConfigsResponse");
   }
 }
 
@@ -3953,7 +3936,7 @@ export interface ListResourceRecordSetsRequest {
 
 export namespace ListResourceRecordSetsRequest {
   export function isa(o: any): o is ListResourceRecordSetsRequest {
-    return _smithy.isa(o, "ListResourceRecordSetsRequest");
+    return __isa(o, "ListResourceRecordSetsRequest");
   }
 }
 
@@ -4003,7 +3986,7 @@ export interface ListResourceRecordSetsResponse extends $MetadataBearer {
 
 export namespace ListResourceRecordSetsResponse {
   export function isa(o: any): o is ListResourceRecordSetsResponse {
-    return _smithy.isa(o, "ListResourceRecordSetsResponse");
+    return __isa(o, "ListResourceRecordSetsResponse");
   }
 }
 
@@ -4030,7 +4013,7 @@ export interface ListReusableDelegationSetsRequest {
 
 export namespace ListReusableDelegationSetsRequest {
   export function isa(o: any): o is ListReusableDelegationSetsRequest {
-    return _smithy.isa(o, "ListReusableDelegationSetsRequest");
+    return __isa(o, "ListReusableDelegationSetsRequest");
   }
 }
 
@@ -4072,7 +4055,7 @@ export interface ListReusableDelegationSetsResponse extends $MetadataBearer {
 
 export namespace ListReusableDelegationSetsResponse {
   export function isa(o: any): o is ListReusableDelegationSetsResponse {
-    return _smithy.isa(o, "ListReusableDelegationSetsResponse");
+    return __isa(o, "ListReusableDelegationSetsResponse");
   }
 }
 
@@ -4102,7 +4085,7 @@ export interface ListTagsForResourceRequest {
 
 export namespace ListTagsForResourceRequest {
   export function isa(o: any): o is ListTagsForResourceRequest {
-    return _smithy.isa(o, "ListTagsForResourceRequest");
+    return __isa(o, "ListTagsForResourceRequest");
   }
 }
 
@@ -4119,7 +4102,7 @@ export interface ListTagsForResourceResponse extends $MetadataBearer {
 
 export namespace ListTagsForResourceResponse {
   export function isa(o: any): o is ListTagsForResourceResponse {
-    return _smithy.isa(o, "ListTagsForResourceResponse");
+    return __isa(o, "ListTagsForResourceResponse");
   }
 }
 
@@ -4149,7 +4132,7 @@ export interface ListTagsForResourcesRequest {
 
 export namespace ListTagsForResourcesRequest {
   export function isa(o: any): o is ListTagsForResourcesRequest {
-    return _smithy.isa(o, "ListTagsForResourcesRequest");
+    return __isa(o, "ListTagsForResourcesRequest");
   }
 }
 
@@ -4166,7 +4149,7 @@ export interface ListTagsForResourcesResponse extends $MetadataBearer {
 
 export namespace ListTagsForResourcesResponse {
   export function isa(o: any): o is ListTagsForResourcesResponse {
-    return _smithy.isa(o, "ListTagsForResourcesResponse");
+    return __isa(o, "ListTagsForResourcesResponse");
   }
 }
 
@@ -4196,7 +4179,7 @@ export interface ListTrafficPoliciesRequest {
 
 export namespace ListTrafficPoliciesRequest {
   export function isa(o: any): o is ListTrafficPoliciesRequest {
-    return _smithy.isa(o, "ListTrafficPoliciesRequest");
+    return __isa(o, "ListTrafficPoliciesRequest");
   }
 }
 
@@ -4232,7 +4215,7 @@ export interface ListTrafficPoliciesResponse extends $MetadataBearer {
 
 export namespace ListTrafficPoliciesResponse {
   export function isa(o: any): o is ListTrafficPoliciesResponse {
-    return _smithy.isa(o, "ListTrafficPoliciesResponse");
+    return __isa(o, "ListTrafficPoliciesResponse");
   }
 }
 
@@ -4277,7 +4260,7 @@ export namespace ListTrafficPolicyInstancesByHostedZoneRequest {
   export function isa(
     o: any
   ): o is ListTrafficPolicyInstancesByHostedZoneRequest {
-    return _smithy.isa(o, "ListTrafficPolicyInstancesByHostedZoneRequest");
+    return __isa(o, "ListTrafficPolicyInstancesByHostedZoneRequest");
   }
 }
 
@@ -4323,7 +4306,7 @@ export namespace ListTrafficPolicyInstancesByHostedZoneResponse {
   export function isa(
     o: any
   ): o is ListTrafficPolicyInstancesByHostedZoneResponse {
-    return _smithy.isa(o, "ListTrafficPolicyInstancesByHostedZoneResponse");
+    return __isa(o, "ListTrafficPolicyInstancesByHostedZoneResponse");
   }
 }
 
@@ -4381,7 +4364,7 @@ export interface ListTrafficPolicyInstancesByPolicyRequest {
 
 export namespace ListTrafficPolicyInstancesByPolicyRequest {
   export function isa(o: any): o is ListTrafficPolicyInstancesByPolicyRequest {
-    return _smithy.isa(o, "ListTrafficPolicyInstancesByPolicyRequest");
+    return __isa(o, "ListTrafficPolicyInstancesByPolicyRequest");
   }
 }
 
@@ -4430,7 +4413,7 @@ export interface ListTrafficPolicyInstancesByPolicyResponse
 
 export namespace ListTrafficPolicyInstancesByPolicyResponse {
   export function isa(o: any): o is ListTrafficPolicyInstancesByPolicyResponse {
-    return _smithy.isa(o, "ListTrafficPolicyInstancesByPolicyResponse");
+    return __isa(o, "ListTrafficPolicyInstancesByPolicyResponse");
   }
 }
 
@@ -4478,7 +4461,7 @@ export interface ListTrafficPolicyInstancesRequest {
 
 export namespace ListTrafficPolicyInstancesRequest {
   export function isa(o: any): o is ListTrafficPolicyInstancesRequest {
-    return _smithy.isa(o, "ListTrafficPolicyInstancesRequest");
+    return __isa(o, "ListTrafficPolicyInstancesRequest");
   }
 }
 
@@ -4528,7 +4511,7 @@ export interface ListTrafficPolicyInstancesResponse extends $MetadataBearer {
 
 export namespace ListTrafficPolicyInstancesResponse {
   export function isa(o: any): o is ListTrafficPolicyInstancesResponse {
-    return _smithy.isa(o, "ListTrafficPolicyInstancesResponse");
+    return __isa(o, "ListTrafficPolicyInstancesResponse");
   }
 }
 
@@ -4563,7 +4546,7 @@ export interface ListTrafficPolicyVersionsRequest {
 
 export namespace ListTrafficPolicyVersionsRequest {
   export function isa(o: any): o is ListTrafficPolicyVersionsRequest {
-    return _smithy.isa(o, "ListTrafficPolicyVersionsRequest");
+    return __isa(o, "ListTrafficPolicyVersionsRequest");
   }
 }
 
@@ -4602,7 +4585,7 @@ export interface ListTrafficPolicyVersionsResponse extends $MetadataBearer {
 
 export namespace ListTrafficPolicyVersionsResponse {
   export function isa(o: any): o is ListTrafficPolicyVersionsResponse {
-    return _smithy.isa(o, "ListTrafficPolicyVersionsResponse");
+    return __isa(o, "ListTrafficPolicyVersionsResponse");
   }
 }
 
@@ -4635,7 +4618,7 @@ export interface ListVPCAssociationAuthorizationsRequest {
 
 export namespace ListVPCAssociationAuthorizationsRequest {
   export function isa(o: any): o is ListVPCAssociationAuthorizationsRequest {
-    return _smithy.isa(o, "ListVPCAssociationAuthorizationsRequest");
+    return __isa(o, "ListVPCAssociationAuthorizationsRequest");
   }
 }
 
@@ -4665,14 +4648,14 @@ export interface ListVPCAssociationAuthorizationsResponse
 
 export namespace ListVPCAssociationAuthorizationsResponse {
   export function isa(o: any): o is ListVPCAssociationAuthorizationsResponse {
-    return _smithy.isa(o, "ListVPCAssociationAuthorizationsResponse");
+    return __isa(o, "ListVPCAssociationAuthorizationsResponse");
   }
 }
 
 /**
  * <p>A change with the specified change ID does not exist.</p>
  */
-export interface NoSuchChange extends _smithy.SmithyException, $MetadataBearer {
+export interface NoSuchChange extends __SmithyException, $MetadataBearer {
   name: "NoSuchChange";
   $fault: "client";
   message?: string;
@@ -4680,7 +4663,7 @@ export interface NoSuchChange extends _smithy.SmithyException, $MetadataBearer {
 
 export namespace NoSuchChange {
   export function isa(o: any): o is NoSuchChange {
-    return _smithy.isa(o, "NoSuchChange");
+    return __isa(o, "NoSuchChange");
   }
 }
 
@@ -4688,7 +4671,7 @@ export namespace NoSuchChange {
  * <p>There is no CloudWatch Logs log group with the specified ARN.</p>
  */
 export interface NoSuchCloudWatchLogsLogGroup
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "NoSuchCloudWatchLogsLogGroup";
   $fault: "client";
@@ -4697,7 +4680,7 @@ export interface NoSuchCloudWatchLogsLogGroup
 
 export namespace NoSuchCloudWatchLogsLogGroup {
   export function isa(o: any): o is NoSuchCloudWatchLogsLogGroup {
-    return _smithy.isa(o, "NoSuchCloudWatchLogsLogGroup");
+    return __isa(o, "NoSuchCloudWatchLogsLogGroup");
   }
 }
 
@@ -4705,7 +4688,7 @@ export namespace NoSuchCloudWatchLogsLogGroup {
  * <p>A reusable delegation set with the specified ID does not exist.</p>
  */
 export interface NoSuchDelegationSet
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "NoSuchDelegationSet";
   $fault: "client";
@@ -4717,16 +4700,14 @@ export interface NoSuchDelegationSet
 
 export namespace NoSuchDelegationSet {
   export function isa(o: any): o is NoSuchDelegationSet {
-    return _smithy.isa(o, "NoSuchDelegationSet");
+    return __isa(o, "NoSuchDelegationSet");
   }
 }
 
 /**
  * <p>Amazon Route 53 doesn't support the specified geographic location.</p>
  */
-export interface NoSuchGeoLocation
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface NoSuchGeoLocation extends __SmithyException, $MetadataBearer {
   name: "NoSuchGeoLocation";
   $fault: "client";
   /**
@@ -4737,16 +4718,14 @@ export interface NoSuchGeoLocation
 
 export namespace NoSuchGeoLocation {
   export function isa(o: any): o is NoSuchGeoLocation {
-    return _smithy.isa(o, "NoSuchGeoLocation");
+    return __isa(o, "NoSuchGeoLocation");
   }
 }
 
 /**
  * <p>No health check exists with the specified ID.</p>
  */
-export interface NoSuchHealthCheck
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface NoSuchHealthCheck extends __SmithyException, $MetadataBearer {
   name: "NoSuchHealthCheck";
   $fault: "client";
   /**
@@ -4757,16 +4736,14 @@ export interface NoSuchHealthCheck
 
 export namespace NoSuchHealthCheck {
   export function isa(o: any): o is NoSuchHealthCheck {
-    return _smithy.isa(o, "NoSuchHealthCheck");
+    return __isa(o, "NoSuchHealthCheck");
   }
 }
 
 /**
  * <p>No hosted zone exists with the ID that you specified.</p>
  */
-export interface NoSuchHostedZone
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface NoSuchHostedZone extends __SmithyException, $MetadataBearer {
   name: "NoSuchHostedZone";
   $fault: "client";
   /**
@@ -4777,7 +4754,7 @@ export interface NoSuchHostedZone
 
 export namespace NoSuchHostedZone {
   export function isa(o: any): o is NoSuchHostedZone {
-    return _smithy.isa(o, "NoSuchHostedZone");
+    return __isa(o, "NoSuchHostedZone");
   }
 }
 
@@ -4785,7 +4762,7 @@ export namespace NoSuchHostedZone {
  * <p>There is no DNS query logging configuration with the specified ID.</p>
  */
 export interface NoSuchQueryLoggingConfig
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "NoSuchQueryLoggingConfig";
   $fault: "client";
@@ -4794,7 +4771,7 @@ export interface NoSuchQueryLoggingConfig
 
 export namespace NoSuchQueryLoggingConfig {
   export function isa(o: any): o is NoSuchQueryLoggingConfig {
-    return _smithy.isa(o, "NoSuchQueryLoggingConfig");
+    return __isa(o, "NoSuchQueryLoggingConfig");
   }
 }
 
@@ -4802,7 +4779,7 @@ export namespace NoSuchQueryLoggingConfig {
  * <p>No traffic policy exists with the specified ID.</p>
  */
 export interface NoSuchTrafficPolicy
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "NoSuchTrafficPolicy";
   $fault: "client";
@@ -4814,7 +4791,7 @@ export interface NoSuchTrafficPolicy
 
 export namespace NoSuchTrafficPolicy {
   export function isa(o: any): o is NoSuchTrafficPolicy {
-    return _smithy.isa(o, "NoSuchTrafficPolicy");
+    return __isa(o, "NoSuchTrafficPolicy");
   }
 }
 
@@ -4822,7 +4799,7 @@ export namespace NoSuchTrafficPolicy {
  * <p>No traffic policy instance exists with the specified ID.</p>
  */
 export interface NoSuchTrafficPolicyInstance
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "NoSuchTrafficPolicyInstance";
   $fault: "client";
@@ -4834,7 +4811,7 @@ export interface NoSuchTrafficPolicyInstance
 
 export namespace NoSuchTrafficPolicyInstance {
   export function isa(o: any): o is NoSuchTrafficPolicyInstance {
-    return _smithy.isa(o, "NoSuchTrafficPolicyInstance");
+    return __isa(o, "NoSuchTrafficPolicyInstance");
   }
 }
 
@@ -4842,7 +4819,7 @@ export namespace NoSuchTrafficPolicyInstance {
  * <p>Associating the specified VPC with the specified hosted zone has not been authorized.</p>
  */
 export interface NotAuthorizedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "NotAuthorizedException";
   $fault: "client";
@@ -4854,7 +4831,7 @@ export interface NotAuthorizedException
 
 export namespace NotAuthorizedException {
   export function isa(o: any): o is NotAuthorizedException {
-    return _smithy.isa(o, "NotAuthorizedException");
+    return __isa(o, "NotAuthorizedException");
   }
 }
 
@@ -4866,7 +4843,7 @@ export namespace NotAuthorizedException {
  * 			again.</p>
  */
 export interface PriorRequestNotComplete
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "PriorRequestNotComplete";
   $fault: "client";
@@ -4875,7 +4852,7 @@ export interface PriorRequestNotComplete
 
 export namespace PriorRequestNotComplete {
   export function isa(o: any): o is PriorRequestNotComplete {
-    return _smithy.isa(o, "PriorRequestNotComplete");
+    return __isa(o, "PriorRequestNotComplete");
   }
 }
 
@@ -4884,7 +4861,7 @@ export namespace PriorRequestNotComplete {
  * 			VPC with a public hosted zone.</p>
  */
 export interface PublicZoneVPCAssociation
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "PublicZoneVPCAssociation";
   $fault: "client";
@@ -4896,7 +4873,7 @@ export interface PublicZoneVPCAssociation
 
 export namespace PublicZoneVPCAssociation {
   export function isa(o: any): o is PublicZoneVPCAssociation {
-    return _smithy.isa(o, "PublicZoneVPCAssociation");
+    return __isa(o, "PublicZoneVPCAssociation");
   }
 }
 
@@ -4923,7 +4900,7 @@ export interface QueryLoggingConfig {
 
 export namespace QueryLoggingConfig {
   export function isa(o: any): o is QueryLoggingConfig {
-    return _smithy.isa(o, "QueryLoggingConfig");
+    return __isa(o, "QueryLoggingConfig");
   }
 }
 
@@ -4932,7 +4909,7 @@ export namespace QueryLoggingConfig {
  * 			for this hosted zone.</p>
  */
 export interface QueryLoggingConfigAlreadyExists
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "QueryLoggingConfigAlreadyExists";
   $fault: "client";
@@ -4941,7 +4918,7 @@ export interface QueryLoggingConfigAlreadyExists
 
 export namespace QueryLoggingConfigAlreadyExists {
   export function isa(o: any): o is QueryLoggingConfigAlreadyExists {
-    return _smithy.isa(o, "QueryLoggingConfigAlreadyExists");
+    return __isa(o, "QueryLoggingConfigAlreadyExists");
   }
 }
 
@@ -4989,7 +4966,7 @@ export interface ResourceRecord {
 
 export namespace ResourceRecord {
   export function isa(o: any): o is ResourceRecord {
-    return _smithy.isa(o, "ResourceRecord");
+    return __isa(o, "ResourceRecord");
   }
 }
 
@@ -5493,7 +5470,7 @@ export interface ResourceRecordSet {
 
 export namespace ResourceRecordSet {
   export function isa(o: any): o is ResourceRecordSet {
-    return _smithy.isa(o, "ResourceRecordSet");
+    return __isa(o, "ResourceRecordSet");
   }
 }
 
@@ -5553,7 +5530,7 @@ export interface ResourceTagSet {
 
 export namespace ResourceTagSet {
   export function isa(o: any): o is ResourceTagSet {
-    return _smithy.isa(o, "ResourceTagSet");
+    return __isa(o, "ResourceTagSet");
   }
 }
 
@@ -5576,7 +5553,7 @@ export interface ReusableDelegationSetLimit {
 
 export namespace ReusableDelegationSetLimit {
   export function isa(o: any): o is ReusableDelegationSetLimit {
-    return _smithy.isa(o, "ReusableDelegationSetLimit");
+    return __isa(o, "ReusableDelegationSetLimit");
   }
 }
 
@@ -5609,7 +5586,7 @@ export interface StatusReport {
 
 export namespace StatusReport {
   export function isa(o: any): o is StatusReport {
-    return _smithy.isa(o, "StatusReport");
+    return __isa(o, "StatusReport");
   }
 }
 
@@ -5662,7 +5639,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -5724,7 +5701,7 @@ export interface TestDNSAnswerRequest {
 
 export namespace TestDNSAnswerRequest {
   export function isa(o: any): o is TestDNSAnswerRequest {
-    return _smithy.isa(o, "TestDNSAnswerRequest");
+    return __isa(o, "TestDNSAnswerRequest");
   }
 }
 
@@ -5769,7 +5746,7 @@ export interface TestDNSAnswerResponse extends $MetadataBearer {
 
 export namespace TestDNSAnswerResponse {
   export function isa(o: any): o is TestDNSAnswerResponse {
-    return _smithy.isa(o, "TestDNSAnswerResponse");
+    return __isa(o, "TestDNSAnswerResponse");
   }
 }
 
@@ -5777,7 +5754,7 @@ export namespace TestDNSAnswerResponse {
  * <p>The limit on the number of requests per second was exceeded.</p>
  */
 export interface ThrottlingException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ThrottlingException";
   $fault: "client";
@@ -5786,7 +5763,7 @@ export interface ThrottlingException
 
 export namespace ThrottlingException {
   export function isa(o: any): o is ThrottlingException {
-    return _smithy.isa(o, "ThrottlingException");
+    return __isa(o, "ThrottlingException");
   }
 }
 
@@ -5802,7 +5779,7 @@ export namespace ThrottlingException {
  * 			<a href="http://aws.amazon.com/route53-request">create a case</a> with the AWS Support Center.</p>
  */
 export interface TooManyHealthChecks
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyHealthChecks";
   $fault: "client";
@@ -5811,7 +5788,7 @@ export interface TooManyHealthChecks
 
 export namespace TooManyHealthChecks {
   export function isa(o: any): o is TooManyHealthChecks {
-    return _smithy.isa(o, "TooManyHealthChecks");
+    return __isa(o, "TooManyHealthChecks");
   }
 }
 
@@ -5826,9 +5803,7 @@ export namespace TooManyHealthChecks {
  * 			<a href="https://docs.aws.amazon.com/Route53/latest/APIReference/API_GetReusableDelegationSetLimit.html">GetReusableDelegationSetLimit</a>.</p>
  * 		       <p>To request a higher limit, <a href="http://aws.amazon.com/route53-request">create a case</a> with the AWS Support Center.</p>
  */
-export interface TooManyHostedZones
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface TooManyHostedZones extends __SmithyException, $MetadataBearer {
   name: "TooManyHostedZones";
   $fault: "client";
   /**
@@ -5839,7 +5814,7 @@ export interface TooManyHostedZones
 
 export namespace TooManyHostedZones {
   export function isa(o: any): o is TooManyHostedZones {
-    return _smithy.isa(o, "TooManyHostedZones");
+    return __isa(o, "TooManyHostedZones");
   }
 }
 
@@ -5853,7 +5828,7 @@ export namespace TooManyHostedZones {
  * 		       <p>To request a higher limit, <a href="http://aws.amazon.com/route53-request">create a case</a> with the AWS Support Center.</p>
  */
 export interface TooManyTrafficPolicies
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyTrafficPolicies";
   $fault: "client";
@@ -5865,7 +5840,7 @@ export interface TooManyTrafficPolicies
 
 export namespace TooManyTrafficPolicies {
   export function isa(o: any): o is TooManyTrafficPolicies {
-    return _smithy.isa(o, "TooManyTrafficPolicies");
+    return __isa(o, "TooManyTrafficPolicies");
   }
 }
 
@@ -5880,7 +5855,7 @@ export namespace TooManyTrafficPolicies {
  * 		       <p>To request a higher limit, <a href="http://aws.amazon.com/route53-request">create a case</a> with the AWS Support Center.</p>
  */
 export interface TooManyTrafficPolicyInstances
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyTrafficPolicyInstances";
   $fault: "client";
@@ -5892,7 +5867,7 @@ export interface TooManyTrafficPolicyInstances
 
 export namespace TooManyTrafficPolicyInstances {
   export function isa(o: any): o is TooManyTrafficPolicyInstances {
-    return _smithy.isa(o, "TooManyTrafficPolicyInstances");
+    return __isa(o, "TooManyTrafficPolicyInstances");
   }
 }
 
@@ -5906,7 +5881,7 @@ export namespace TooManyTrafficPolicyInstances {
  * 			to create a new traffic policy using the traffic policy document.</p>
  */
 export interface TooManyTrafficPolicyVersionsForCurrentPolicy
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyTrafficPolicyVersionsForCurrentPolicy";
   $fault: "client";
@@ -5920,7 +5895,7 @@ export namespace TooManyTrafficPolicyVersionsForCurrentPolicy {
   export function isa(
     o: any
   ): o is TooManyTrafficPolicyVersionsForCurrentPolicy {
-    return _smithy.isa(o, "TooManyTrafficPolicyVersionsForCurrentPolicy");
+    return __isa(o, "TooManyTrafficPolicyVersionsForCurrentPolicy");
   }
 }
 
@@ -5931,7 +5906,7 @@ export namespace TooManyTrafficPolicyVersionsForCurrentPolicy {
  * 			<code>ListVPCAssociationAuthorizations</code> request.</p>
  */
 export interface TooManyVPCAssociationAuthorizations
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyVPCAssociationAuthorizations";
   $fault: "client";
@@ -5943,7 +5918,7 @@ export interface TooManyVPCAssociationAuthorizations
 
 export namespace TooManyVPCAssociationAuthorizations {
   export function isa(o: any): o is TooManyVPCAssociationAuthorizations {
-    return _smithy.isa(o, "TooManyVPCAssociationAuthorizations");
+    return __isa(o, "TooManyVPCAssociationAuthorizations");
   }
 }
 
@@ -5989,7 +5964,7 @@ export interface TrafficPolicy {
 
 export namespace TrafficPolicy {
   export function isa(o: any): o is TrafficPolicy {
-    return _smithy.isa(o, "TrafficPolicy");
+    return __isa(o, "TrafficPolicy");
   }
 }
 
@@ -5997,7 +5972,7 @@ export namespace TrafficPolicy {
  * <p>A traffic policy that has the same value for <code>Name</code> already exists.</p>
  */
 export interface TrafficPolicyAlreadyExists
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TrafficPolicyAlreadyExists";
   $fault: "client";
@@ -6009,16 +5984,14 @@ export interface TrafficPolicyAlreadyExists
 
 export namespace TrafficPolicyAlreadyExists {
   export function isa(o: any): o is TrafficPolicyAlreadyExists {
-    return _smithy.isa(o, "TrafficPolicyAlreadyExists");
+    return __isa(o, "TrafficPolicyAlreadyExists");
   }
 }
 
 /**
  * <p>One or more traffic policy instances were created by using the specified traffic policy.</p>
  */
-export interface TrafficPolicyInUse
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface TrafficPolicyInUse extends __SmithyException, $MetadataBearer {
   name: "TrafficPolicyInUse";
   $fault: "client";
   /**
@@ -6029,7 +6002,7 @@ export interface TrafficPolicyInUse
 
 export namespace TrafficPolicyInUse {
   export function isa(o: any): o is TrafficPolicyInUse {
-    return _smithy.isa(o, "TrafficPolicyInUse");
+    return __isa(o, "TrafficPolicyInUse");
   }
 }
 
@@ -6104,7 +6077,7 @@ export interface TrafficPolicyInstance {
 
 export namespace TrafficPolicyInstance {
   export function isa(o: any): o is TrafficPolicyInstance {
-    return _smithy.isa(o, "TrafficPolicyInstance");
+    return __isa(o, "TrafficPolicyInstance");
   }
 }
 
@@ -6112,7 +6085,7 @@ export namespace TrafficPolicyInstance {
  * <p>There is already a traffic policy instance with the specified ID.</p>
  */
 export interface TrafficPolicyInstanceAlreadyExists
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TrafficPolicyInstanceAlreadyExists";
   $fault: "client";
@@ -6124,7 +6097,7 @@ export interface TrafficPolicyInstanceAlreadyExists
 
 export namespace TrafficPolicyInstanceAlreadyExists {
   export function isa(o: any): o is TrafficPolicyInstanceAlreadyExists {
-    return _smithy.isa(o, "TrafficPolicyInstanceAlreadyExists");
+    return __isa(o, "TrafficPolicyInstanceAlreadyExists");
   }
 }
 
@@ -6163,7 +6136,7 @@ export interface TrafficPolicySummary {
 
 export namespace TrafficPolicySummary {
   export function isa(o: any): o is TrafficPolicySummary {
-    return _smithy.isa(o, "TrafficPolicySummary");
+    return __isa(o, "TrafficPolicySummary");
   }
 }
 
@@ -6491,7 +6464,7 @@ export interface UpdateHealthCheckRequest {
 
 export namespace UpdateHealthCheckRequest {
   export function isa(o: any): o is UpdateHealthCheckRequest {
-    return _smithy.isa(o, "UpdateHealthCheckRequest");
+    return __isa(o, "UpdateHealthCheckRequest");
   }
 }
 
@@ -6508,7 +6481,7 @@ export interface UpdateHealthCheckResponse extends $MetadataBearer {
 
 export namespace UpdateHealthCheckResponse {
   export function isa(o: any): o is UpdateHealthCheckResponse {
-    return _smithy.isa(o, "UpdateHealthCheckResponse");
+    return __isa(o, "UpdateHealthCheckResponse");
   }
 }
 
@@ -6531,7 +6504,7 @@ export interface UpdateHostedZoneCommentRequest {
 
 export namespace UpdateHostedZoneCommentRequest {
   export function isa(o: any): o is UpdateHostedZoneCommentRequest {
-    return _smithy.isa(o, "UpdateHostedZoneCommentRequest");
+    return __isa(o, "UpdateHostedZoneCommentRequest");
   }
 }
 
@@ -6548,7 +6521,7 @@ export interface UpdateHostedZoneCommentResponse extends $MetadataBearer {
 
 export namespace UpdateHostedZoneCommentResponse {
   export function isa(o: any): o is UpdateHostedZoneCommentResponse {
-    return _smithy.isa(o, "UpdateHostedZoneCommentResponse");
+    return __isa(o, "UpdateHostedZoneCommentResponse");
   }
 }
 
@@ -6575,7 +6548,7 @@ export interface UpdateTrafficPolicyCommentRequest {
 
 export namespace UpdateTrafficPolicyCommentRequest {
   export function isa(o: any): o is UpdateTrafficPolicyCommentRequest {
-    return _smithy.isa(o, "UpdateTrafficPolicyCommentRequest");
+    return __isa(o, "UpdateTrafficPolicyCommentRequest");
   }
 }
 
@@ -6592,7 +6565,7 @@ export interface UpdateTrafficPolicyCommentResponse extends $MetadataBearer {
 
 export namespace UpdateTrafficPolicyCommentResponse {
   export function isa(o: any): o is UpdateTrafficPolicyCommentResponse {
-    return _smithy.isa(o, "UpdateTrafficPolicyCommentResponse");
+    return __isa(o, "UpdateTrafficPolicyCommentResponse");
   }
 }
 
@@ -6624,7 +6597,7 @@ export interface UpdateTrafficPolicyInstanceRequest {
 
 export namespace UpdateTrafficPolicyInstanceRequest {
   export function isa(o: any): o is UpdateTrafficPolicyInstanceRequest {
-    return _smithy.isa(o, "UpdateTrafficPolicyInstanceRequest");
+    return __isa(o, "UpdateTrafficPolicyInstanceRequest");
   }
 }
 
@@ -6642,7 +6615,7 @@ export interface UpdateTrafficPolicyInstanceResponse extends $MetadataBearer {
 
 export namespace UpdateTrafficPolicyInstanceResponse {
   export function isa(o: any): o is UpdateTrafficPolicyInstanceResponse {
-    return _smithy.isa(o, "UpdateTrafficPolicyInstanceResponse");
+    return __isa(o, "UpdateTrafficPolicyInstanceResponse");
   }
 }
 
@@ -6664,7 +6637,7 @@ export interface VPC {
 
 export namespace VPC {
   export function isa(o: any): o is VPC {
-    return _smithy.isa(o, "VPC");
+    return __isa(o, "VPC");
   }
 }
 
@@ -6672,7 +6645,7 @@ export namespace VPC {
  * <p>The VPC that you specified is not authorized to be associated with the hosted zone.</p>
  */
 export interface VPCAssociationAuthorizationNotFound
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "VPCAssociationAuthorizationNotFound";
   $fault: "client";
@@ -6684,7 +6657,7 @@ export interface VPCAssociationAuthorizationNotFound
 
 export namespace VPCAssociationAuthorizationNotFound {
   export function isa(o: any): o is VPCAssociationAuthorizationNotFound {
-    return _smithy.isa(o, "VPCAssociationAuthorizationNotFound");
+    return __isa(o, "VPCAssociationAuthorizationNotFound");
   }
 }
 
@@ -6692,7 +6665,7 @@ export namespace VPCAssociationAuthorizationNotFound {
  * <p>The specified VPC and hosted zone are not currently associated.</p>
  */
 export interface VPCAssociationNotFound
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "VPCAssociationNotFound";
   $fault: "client";
@@ -6704,7 +6677,7 @@ export interface VPCAssociationNotFound
 
 export namespace VPCAssociationNotFound {
   export function isa(o: any): o is VPCAssociationNotFound {
-    return _smithy.isa(o, "VPCAssociationNotFound");
+    return __isa(o, "VPCAssociationNotFound");
   }
 }
 

--- a/clients/client-route-53/protocols/Aws_restXml.ts
+++ b/clients/client-route-53/protocols/Aws_restXml.ts
@@ -310,7 +310,10 @@ import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  extendedEncodeURIComponent as __extendedEncodeURIComponent
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -331,7 +334,7 @@ export async function serializeAws_restXmlAssociateVPCWithHostedZoneCommand(
   headers["Content-Type"] = "application/xml";
   let resolvedPath = "/2013-04-01/hostedzone/{HostedZoneId}/associatevpc";
   if (input.HostedZoneId !== undefined) {
-    const labelValue: string = input.HostedZoneId.toString();
+    const labelValue: string = input.HostedZoneId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: HostedZoneId."
@@ -339,7 +342,7 @@ export async function serializeAws_restXmlAssociateVPCWithHostedZoneCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{HostedZoneId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: HostedZoneId.");
@@ -380,7 +383,7 @@ export async function serializeAws_restXmlChangeResourceRecordSetsCommand(
   headers["Content-Type"] = "application/xml";
   let resolvedPath = "/2013-04-01/hostedzone/{HostedZoneId}/rrset";
   if (input.HostedZoneId !== undefined) {
-    const labelValue: string = input.HostedZoneId.toString();
+    const labelValue: string = input.HostedZoneId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: HostedZoneId."
@@ -388,7 +391,7 @@ export async function serializeAws_restXmlChangeResourceRecordSetsCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{HostedZoneId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: HostedZoneId.");
@@ -426,19 +429,19 @@ export async function serializeAws_restXmlChangeTagsForResourceCommand(
   headers["Content-Type"] = "application/xml";
   let resolvedPath = "/2013-04-01/tags/{ResourceType}/{ResourceId}";
   if (input.ResourceId !== undefined) {
-    const labelValue: string = input.ResourceId.toString();
+    const labelValue: string = input.ResourceId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ResourceId.");
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ResourceId.");
   }
   if (input.ResourceType !== undefined) {
-    const labelValue: string = input.ResourceType.toString();
+    const labelValue: string = input.ResourceType;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ResourceType."
@@ -446,7 +449,7 @@ export async function serializeAws_restXmlChangeTagsForResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceType}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ResourceType.");
@@ -757,11 +760,14 @@ export async function serializeAws_restXmlCreateTrafficPolicyVersionCommand(
   headers["Content-Type"] = "application/xml";
   let resolvedPath = "/2013-04-01/trafficpolicy/{Id}";
   if (input.Id !== undefined) {
-    const labelValue: string = input.Id.toString();
+    const labelValue: string = input.Id;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Id.");
     }
-    resolvedPath = resolvedPath.replace("{Id}", encodeURIComponent(labelValue));
+    resolvedPath = resolvedPath.replace(
+      "{Id}",
+      __extendedEncodeURIComponent(labelValue)
+    );
   } else {
     throw new Error("No value provided for input HTTP label: Id.");
   }
@@ -804,7 +810,7 @@ export async function serializeAws_restXmlCreateVPCAssociationAuthorizationComma
   let resolvedPath =
     "/2013-04-01/hostedzone/{HostedZoneId}/authorizevpcassociation";
   if (input.HostedZoneId !== undefined) {
-    const labelValue: string = input.HostedZoneId.toString();
+    const labelValue: string = input.HostedZoneId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: HostedZoneId."
@@ -812,7 +818,7 @@ export async function serializeAws_restXmlCreateVPCAssociationAuthorizationComma
     }
     resolvedPath = resolvedPath.replace(
       "{HostedZoneId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: HostedZoneId.");
@@ -847,7 +853,7 @@ export async function serializeAws_restXmlDeleteHealthCheckCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/2013-04-01/healthcheck/{HealthCheckId}";
   if (input.HealthCheckId !== undefined) {
-    const labelValue: string = input.HealthCheckId.toString();
+    const labelValue: string = input.HealthCheckId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: HealthCheckId."
@@ -855,7 +861,7 @@ export async function serializeAws_restXmlDeleteHealthCheckCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{HealthCheckId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: HealthCheckId.");
@@ -877,11 +883,14 @@ export async function serializeAws_restXmlDeleteHostedZoneCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/2013-04-01/hostedzone/{Id}";
   if (input.Id !== undefined) {
-    const labelValue: string = input.Id.toString();
+    const labelValue: string = input.Id;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Id.");
     }
-    resolvedPath = resolvedPath.replace("{Id}", encodeURIComponent(labelValue));
+    resolvedPath = resolvedPath.replace(
+      "{Id}",
+      __extendedEncodeURIComponent(labelValue)
+    );
   } else {
     throw new Error("No value provided for input HTTP label: Id.");
   }
@@ -902,11 +911,14 @@ export async function serializeAws_restXmlDeleteQueryLoggingConfigCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/2013-04-01/queryloggingconfig/{Id}";
   if (input.Id !== undefined) {
-    const labelValue: string = input.Id.toString();
+    const labelValue: string = input.Id;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Id.");
     }
-    resolvedPath = resolvedPath.replace("{Id}", encodeURIComponent(labelValue));
+    resolvedPath = resolvedPath.replace(
+      "{Id}",
+      __extendedEncodeURIComponent(labelValue)
+    );
   } else {
     throw new Error("No value provided for input HTTP label: Id.");
   }
@@ -927,11 +939,14 @@ export async function serializeAws_restXmlDeleteReusableDelegationSetCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/2013-04-01/delegationset/{Id}";
   if (input.Id !== undefined) {
-    const labelValue: string = input.Id.toString();
+    const labelValue: string = input.Id;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Id.");
     }
-    resolvedPath = resolvedPath.replace("{Id}", encodeURIComponent(labelValue));
+    resolvedPath = resolvedPath.replace(
+      "{Id}",
+      __extendedEncodeURIComponent(labelValue)
+    );
   } else {
     throw new Error("No value provided for input HTTP label: Id.");
   }
@@ -952,11 +967,14 @@ export async function serializeAws_restXmlDeleteTrafficPolicyCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/2013-04-01/trafficpolicy/{Id}/{Version}";
   if (input.Id !== undefined) {
-    const labelValue: string = input.Id.toString();
+    const labelValue: string = input.Id;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Id.");
     }
-    resolvedPath = resolvedPath.replace("{Id}", encodeURIComponent(labelValue));
+    resolvedPath = resolvedPath.replace(
+      "{Id}",
+      __extendedEncodeURIComponent(labelValue)
+    );
   } else {
     throw new Error("No value provided for input HTTP label: Id.");
   }
@@ -967,7 +985,7 @@ export async function serializeAws_restXmlDeleteTrafficPolicyCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{Version}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Version.");
@@ -989,11 +1007,14 @@ export async function serializeAws_restXmlDeleteTrafficPolicyInstanceCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/2013-04-01/trafficpolicyinstance/{Id}";
   if (input.Id !== undefined) {
-    const labelValue: string = input.Id.toString();
+    const labelValue: string = input.Id;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Id.");
     }
-    resolvedPath = resolvedPath.replace("{Id}", encodeURIComponent(labelValue));
+    resolvedPath = resolvedPath.replace(
+      "{Id}",
+      __extendedEncodeURIComponent(labelValue)
+    );
   } else {
     throw new Error("No value provided for input HTTP label: Id.");
   }
@@ -1015,7 +1036,7 @@ export async function serializeAws_restXmlDeleteVPCAssociationAuthorizationComma
   let resolvedPath =
     "/2013-04-01/hostedzone/{HostedZoneId}/deauthorizevpcassociation";
   if (input.HostedZoneId !== undefined) {
-    const labelValue: string = input.HostedZoneId.toString();
+    const labelValue: string = input.HostedZoneId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: HostedZoneId."
@@ -1023,7 +1044,7 @@ export async function serializeAws_restXmlDeleteVPCAssociationAuthorizationComma
     }
     resolvedPath = resolvedPath.replace(
       "{HostedZoneId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: HostedZoneId.");
@@ -1058,7 +1079,7 @@ export async function serializeAws_restXmlDisassociateVPCFromHostedZoneCommand(
   headers["Content-Type"] = "application/xml";
   let resolvedPath = "/2013-04-01/hostedzone/{HostedZoneId}/disassociatevpc";
   if (input.HostedZoneId !== undefined) {
-    const labelValue: string = input.HostedZoneId.toString();
+    const labelValue: string = input.HostedZoneId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: HostedZoneId."
@@ -1066,7 +1087,7 @@ export async function serializeAws_restXmlDisassociateVPCFromHostedZoneCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{HostedZoneId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: HostedZoneId.");
@@ -1107,13 +1128,13 @@ export async function serializeAws_restXmlGetAccountLimitCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/2013-04-01/accountlimit/{Type}";
   if (input.Type !== undefined) {
-    const labelValue: string = input.Type.toString();
+    const labelValue: string = input.Type;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Type.");
     }
     resolvedPath = resolvedPath.replace(
       "{Type}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Type.");
@@ -1135,11 +1156,14 @@ export async function serializeAws_restXmlGetChangeCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/2013-04-01/change/{Id}";
   if (input.Id !== undefined) {
-    const labelValue: string = input.Id.toString();
+    const labelValue: string = input.Id;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Id.");
     }
-    resolvedPath = resolvedPath.replace("{Id}", encodeURIComponent(labelValue));
+    resolvedPath = resolvedPath.replace(
+      "{Id}",
+      __extendedEncodeURIComponent(labelValue)
+    );
   } else {
     throw new Error("No value provided for input HTTP label: Id.");
   }
@@ -1177,13 +1201,19 @@ export async function serializeAws_restXmlGetGeoLocationCommand(
   let resolvedPath = "/2013-04-01/geolocation";
   const query: any = {};
   if (input.ContinentCode !== undefined) {
-    query["continentcode"] = input.ContinentCode.toString();
+    query[
+      __extendedEncodeURIComponent("continentcode")
+    ] = __extendedEncodeURIComponent(input.ContinentCode);
   }
   if (input.CountryCode !== undefined) {
-    query["countrycode"] = input.CountryCode.toString();
+    query[
+      __extendedEncodeURIComponent("countrycode")
+    ] = __extendedEncodeURIComponent(input.CountryCode);
   }
   if (input.SubdivisionCode !== undefined) {
-    query["subdivisioncode"] = input.SubdivisionCode.toString();
+    query[
+      __extendedEncodeURIComponent("subdivisioncode")
+    ] = __extendedEncodeURIComponent(input.SubdivisionCode);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1203,7 +1233,7 @@ export async function serializeAws_restXmlGetHealthCheckCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/2013-04-01/healthcheck/{HealthCheckId}";
   if (input.HealthCheckId !== undefined) {
-    const labelValue: string = input.HealthCheckId.toString();
+    const labelValue: string = input.HealthCheckId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: HealthCheckId."
@@ -1211,7 +1241,7 @@ export async function serializeAws_restXmlGetHealthCheckCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{HealthCheckId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: HealthCheckId.");
@@ -1250,7 +1280,7 @@ export async function serializeAws_restXmlGetHealthCheckLastFailureReasonCommand
   let resolvedPath =
     "/2013-04-01/healthcheck/{HealthCheckId}/lastfailurereason";
   if (input.HealthCheckId !== undefined) {
-    const labelValue: string = input.HealthCheckId.toString();
+    const labelValue: string = input.HealthCheckId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: HealthCheckId."
@@ -1258,7 +1288,7 @@ export async function serializeAws_restXmlGetHealthCheckLastFailureReasonCommand
     }
     resolvedPath = resolvedPath.replace(
       "{HealthCheckId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: HealthCheckId.");
@@ -1280,7 +1310,7 @@ export async function serializeAws_restXmlGetHealthCheckStatusCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/2013-04-01/healthcheck/{HealthCheckId}/status";
   if (input.HealthCheckId !== undefined) {
-    const labelValue: string = input.HealthCheckId.toString();
+    const labelValue: string = input.HealthCheckId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: HealthCheckId."
@@ -1288,7 +1318,7 @@ export async function serializeAws_restXmlGetHealthCheckStatusCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{HealthCheckId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: HealthCheckId.");
@@ -1310,11 +1340,14 @@ export async function serializeAws_restXmlGetHostedZoneCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/2013-04-01/hostedzone/{Id}";
   if (input.Id !== undefined) {
-    const labelValue: string = input.Id.toString();
+    const labelValue: string = input.Id;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Id.");
     }
-    resolvedPath = resolvedPath.replace("{Id}", encodeURIComponent(labelValue));
+    resolvedPath = resolvedPath.replace(
+      "{Id}",
+      __extendedEncodeURIComponent(labelValue)
+    );
   } else {
     throw new Error("No value provided for input HTTP label: Id.");
   }
@@ -1351,7 +1384,7 @@ export async function serializeAws_restXmlGetHostedZoneLimitCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/2013-04-01/hostedzonelimit/{HostedZoneId}/{Type}";
   if (input.HostedZoneId !== undefined) {
-    const labelValue: string = input.HostedZoneId.toString();
+    const labelValue: string = input.HostedZoneId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: HostedZoneId."
@@ -1359,19 +1392,19 @@ export async function serializeAws_restXmlGetHostedZoneLimitCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{HostedZoneId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: HostedZoneId.");
   }
   if (input.Type !== undefined) {
-    const labelValue: string = input.Type.toString();
+    const labelValue: string = input.Type;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Type.");
     }
     resolvedPath = resolvedPath.replace(
       "{Type}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Type.");
@@ -1393,11 +1426,14 @@ export async function serializeAws_restXmlGetQueryLoggingConfigCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/2013-04-01/queryloggingconfig/{Id}";
   if (input.Id !== undefined) {
-    const labelValue: string = input.Id.toString();
+    const labelValue: string = input.Id;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Id.");
     }
-    resolvedPath = resolvedPath.replace("{Id}", encodeURIComponent(labelValue));
+    resolvedPath = resolvedPath.replace(
+      "{Id}",
+      __extendedEncodeURIComponent(labelValue)
+    );
   } else {
     throw new Error("No value provided for input HTTP label: Id.");
   }
@@ -1418,11 +1454,14 @@ export async function serializeAws_restXmlGetReusableDelegationSetCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/2013-04-01/delegationset/{Id}";
   if (input.Id !== undefined) {
-    const labelValue: string = input.Id.toString();
+    const labelValue: string = input.Id;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Id.");
     }
-    resolvedPath = resolvedPath.replace("{Id}", encodeURIComponent(labelValue));
+    resolvedPath = resolvedPath.replace(
+      "{Id}",
+      __extendedEncodeURIComponent(labelValue)
+    );
   } else {
     throw new Error("No value provided for input HTTP label: Id.");
   }
@@ -1444,7 +1483,7 @@ export async function serializeAws_restXmlGetReusableDelegationSetLimitCommand(
   let resolvedPath =
     "/2013-04-01/reusabledelegationsetlimit/{DelegationSetId}/{Type}";
   if (input.DelegationSetId !== undefined) {
-    const labelValue: string = input.DelegationSetId.toString();
+    const labelValue: string = input.DelegationSetId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: DelegationSetId."
@@ -1452,19 +1491,19 @@ export async function serializeAws_restXmlGetReusableDelegationSetLimitCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{DelegationSetId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DelegationSetId.");
   }
   if (input.Type !== undefined) {
-    const labelValue: string = input.Type.toString();
+    const labelValue: string = input.Type;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Type.");
     }
     resolvedPath = resolvedPath.replace(
       "{Type}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Type.");
@@ -1486,11 +1525,14 @@ export async function serializeAws_restXmlGetTrafficPolicyCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/2013-04-01/trafficpolicy/{Id}/{Version}";
   if (input.Id !== undefined) {
-    const labelValue: string = input.Id.toString();
+    const labelValue: string = input.Id;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Id.");
     }
-    resolvedPath = resolvedPath.replace("{Id}", encodeURIComponent(labelValue));
+    resolvedPath = resolvedPath.replace(
+      "{Id}",
+      __extendedEncodeURIComponent(labelValue)
+    );
   } else {
     throw new Error("No value provided for input HTTP label: Id.");
   }
@@ -1501,7 +1543,7 @@ export async function serializeAws_restXmlGetTrafficPolicyCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{Version}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Version.");
@@ -1523,11 +1565,14 @@ export async function serializeAws_restXmlGetTrafficPolicyInstanceCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/2013-04-01/trafficpolicyinstance/{Id}";
   if (input.Id !== undefined) {
-    const labelValue: string = input.Id.toString();
+    const labelValue: string = input.Id;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Id.");
     }
-    resolvedPath = resolvedPath.replace("{Id}", encodeURIComponent(labelValue));
+    resolvedPath = resolvedPath.replace(
+      "{Id}",
+      __extendedEncodeURIComponent(labelValue)
+    );
   } else {
     throw new Error("No value provided for input HTTP label: Id.");
   }
@@ -1565,16 +1610,24 @@ export async function serializeAws_restXmlListGeoLocationsCommand(
   let resolvedPath = "/2013-04-01/geolocations";
   const query: any = {};
   if (input.MaxItems !== undefined) {
-    query["maxitems"] = input.MaxItems.toString();
+    query[
+      __extendedEncodeURIComponent("maxitems")
+    ] = __extendedEncodeURIComponent(input.MaxItems);
   }
   if (input.StartContinentCode !== undefined) {
-    query["startcontinentcode"] = input.StartContinentCode.toString();
+    query[
+      __extendedEncodeURIComponent("startcontinentcode")
+    ] = __extendedEncodeURIComponent(input.StartContinentCode);
   }
   if (input.StartCountryCode !== undefined) {
-    query["startcountrycode"] = input.StartCountryCode.toString();
+    query[
+      __extendedEncodeURIComponent("startcountrycode")
+    ] = __extendedEncodeURIComponent(input.StartCountryCode);
   }
   if (input.StartSubdivisionCode !== undefined) {
-    query["startsubdivisioncode"] = input.StartSubdivisionCode.toString();
+    query[
+      __extendedEncodeURIComponent("startsubdivisioncode")
+    ] = __extendedEncodeURIComponent(input.StartSubdivisionCode);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1595,10 +1648,14 @@ export async function serializeAws_restXmlListHealthChecksCommand(
   let resolvedPath = "/2013-04-01/healthcheck";
   const query: any = {};
   if (input.Marker !== undefined) {
-    query["marker"] = input.Marker.toString();
+    query[
+      __extendedEncodeURIComponent("marker")
+    ] = __extendedEncodeURIComponent(input.Marker);
   }
   if (input.MaxItems !== undefined) {
-    query["maxitems"] = input.MaxItems.toString();
+    query[
+      __extendedEncodeURIComponent("maxitems")
+    ] = __extendedEncodeURIComponent(input.MaxItems);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1619,13 +1676,19 @@ export async function serializeAws_restXmlListHostedZonesCommand(
   let resolvedPath = "/2013-04-01/hostedzone";
   const query: any = {};
   if (input.DelegationSetId !== undefined) {
-    query["delegationsetid"] = input.DelegationSetId.toString();
+    query[
+      __extendedEncodeURIComponent("delegationsetid")
+    ] = __extendedEncodeURIComponent(input.DelegationSetId);
   }
   if (input.Marker !== undefined) {
-    query["marker"] = input.Marker.toString();
+    query[
+      __extendedEncodeURIComponent("marker")
+    ] = __extendedEncodeURIComponent(input.Marker);
   }
   if (input.MaxItems !== undefined) {
-    query["maxitems"] = input.MaxItems.toString();
+    query[
+      __extendedEncodeURIComponent("maxitems")
+    ] = __extendedEncodeURIComponent(input.MaxItems);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1646,13 +1709,19 @@ export async function serializeAws_restXmlListHostedZonesByNameCommand(
   let resolvedPath = "/2013-04-01/hostedzonesbyname";
   const query: any = {};
   if (input.DNSName !== undefined) {
-    query["dnsname"] = input.DNSName.toString();
+    query[
+      __extendedEncodeURIComponent("dnsname")
+    ] = __extendedEncodeURIComponent(input.DNSName);
   }
   if (input.HostedZoneId !== undefined) {
-    query["hostedzoneid"] = input.HostedZoneId.toString();
+    query[
+      __extendedEncodeURIComponent("hostedzoneid")
+    ] = __extendedEncodeURIComponent(input.HostedZoneId);
   }
   if (input.MaxItems !== undefined) {
-    query["maxitems"] = input.MaxItems.toString();
+    query[
+      __extendedEncodeURIComponent("maxitems")
+    ] = __extendedEncodeURIComponent(input.MaxItems);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1673,13 +1742,19 @@ export async function serializeAws_restXmlListQueryLoggingConfigsCommand(
   let resolvedPath = "/2013-04-01/queryloggingconfig";
   const query: any = {};
   if (input.HostedZoneId !== undefined) {
-    query["hostedzoneid"] = input.HostedZoneId.toString();
+    query[
+      __extendedEncodeURIComponent("hostedzoneid")
+    ] = __extendedEncodeURIComponent(input.HostedZoneId);
   }
   if (input.MaxResults !== undefined) {
-    query["maxresults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxresults")
+    ] = __extendedEncodeURIComponent(input.MaxResults);
   }
   if (input.NextToken !== undefined) {
-    query["nexttoken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nexttoken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1699,7 +1774,7 @@ export async function serializeAws_restXmlListResourceRecordSetsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/2013-04-01/hostedzone/{HostedZoneId}/rrset";
   if (input.HostedZoneId !== undefined) {
-    const labelValue: string = input.HostedZoneId.toString();
+    const labelValue: string = input.HostedZoneId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: HostedZoneId."
@@ -1707,23 +1782,31 @@ export async function serializeAws_restXmlListResourceRecordSetsCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{HostedZoneId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: HostedZoneId.");
   }
   const query: any = {};
   if (input.MaxItems !== undefined) {
-    query["maxitems"] = input.MaxItems.toString();
+    query[
+      __extendedEncodeURIComponent("maxitems")
+    ] = __extendedEncodeURIComponent(input.MaxItems);
   }
   if (input.StartRecordIdentifier !== undefined) {
-    query["identifier"] = input.StartRecordIdentifier.toString();
+    query[
+      __extendedEncodeURIComponent("identifier")
+    ] = __extendedEncodeURIComponent(input.StartRecordIdentifier);
   }
   if (input.StartRecordName !== undefined) {
-    query["name"] = input.StartRecordName.toString();
+    query[__extendedEncodeURIComponent("name")] = __extendedEncodeURIComponent(
+      input.StartRecordName
+    );
   }
   if (input.StartRecordType !== undefined) {
-    query["type"] = input.StartRecordType.toString();
+    query[__extendedEncodeURIComponent("type")] = __extendedEncodeURIComponent(
+      input.StartRecordType
+    );
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1744,10 +1827,14 @@ export async function serializeAws_restXmlListReusableDelegationSetsCommand(
   let resolvedPath = "/2013-04-01/delegationset";
   const query: any = {};
   if (input.Marker !== undefined) {
-    query["marker"] = input.Marker.toString();
+    query[
+      __extendedEncodeURIComponent("marker")
+    ] = __extendedEncodeURIComponent(input.Marker);
   }
   if (input.MaxItems !== undefined) {
-    query["maxitems"] = input.MaxItems.toString();
+    query[
+      __extendedEncodeURIComponent("maxitems")
+    ] = __extendedEncodeURIComponent(input.MaxItems);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1767,19 +1854,19 @@ export async function serializeAws_restXmlListTagsForResourceCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/2013-04-01/tags/{ResourceType}/{ResourceId}";
   if (input.ResourceId !== undefined) {
-    const labelValue: string = input.ResourceId.toString();
+    const labelValue: string = input.ResourceId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ResourceId.");
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ResourceId.");
   }
   if (input.ResourceType !== undefined) {
-    const labelValue: string = input.ResourceType.toString();
+    const labelValue: string = input.ResourceType;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ResourceType."
@@ -1787,7 +1874,7 @@ export async function serializeAws_restXmlListTagsForResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceType}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ResourceType.");
@@ -1809,7 +1896,7 @@ export async function serializeAws_restXmlListTagsForResourcesCommand(
   headers["Content-Type"] = "application/xml";
   let resolvedPath = "/2013-04-01/tags/{ResourceType}";
   if (input.ResourceType !== undefined) {
-    const labelValue: string = input.ResourceType.toString();
+    const labelValue: string = input.ResourceType;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ResourceType."
@@ -1817,7 +1904,7 @@ export async function serializeAws_restXmlListTagsForResourcesCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceType}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ResourceType.");
@@ -1860,10 +1947,14 @@ export async function serializeAws_restXmlListTrafficPoliciesCommand(
   let resolvedPath = "/2013-04-01/trafficpolicies";
   const query: any = {};
   if (input.MaxItems !== undefined) {
-    query["maxitems"] = input.MaxItems.toString();
+    query[
+      __extendedEncodeURIComponent("maxitems")
+    ] = __extendedEncodeURIComponent(input.MaxItems);
   }
   if (input.TrafficPolicyIdMarker !== undefined) {
-    query["trafficpolicyid"] = input.TrafficPolicyIdMarker.toString();
+    query[
+      __extendedEncodeURIComponent("trafficpolicyid")
+    ] = __extendedEncodeURIComponent(input.TrafficPolicyIdMarker);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1884,20 +1975,24 @@ export async function serializeAws_restXmlListTrafficPolicyInstancesCommand(
   let resolvedPath = "/2013-04-01/trafficpolicyinstances";
   const query: any = {};
   if (input.HostedZoneIdMarker !== undefined) {
-    query["hostedzoneid"] = input.HostedZoneIdMarker.toString();
+    query[
+      __extendedEncodeURIComponent("hostedzoneid")
+    ] = __extendedEncodeURIComponent(input.HostedZoneIdMarker);
   }
   if (input.MaxItems !== undefined) {
-    query["maxitems"] = input.MaxItems.toString();
+    query[
+      __extendedEncodeURIComponent("maxitems")
+    ] = __extendedEncodeURIComponent(input.MaxItems);
   }
   if (input.TrafficPolicyInstanceNameMarker !== undefined) {
     query[
-      "trafficpolicyinstancename"
-    ] = input.TrafficPolicyInstanceNameMarker.toString();
+      __extendedEncodeURIComponent("trafficpolicyinstancename")
+    ] = __extendedEncodeURIComponent(input.TrafficPolicyInstanceNameMarker);
   }
   if (input.TrafficPolicyInstanceTypeMarker !== undefined) {
     query[
-      "trafficpolicyinstancetype"
-    ] = input.TrafficPolicyInstanceTypeMarker.toString();
+      __extendedEncodeURIComponent("trafficpolicyinstancetype")
+    ] = __extendedEncodeURIComponent(input.TrafficPolicyInstanceTypeMarker);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1918,20 +2013,24 @@ export async function serializeAws_restXmlListTrafficPolicyInstancesByHostedZone
   let resolvedPath = "/2013-04-01/trafficpolicyinstances/hostedzone";
   const query: any = {};
   if (input.HostedZoneId !== undefined) {
-    query["id"] = input.HostedZoneId.toString();
+    query[__extendedEncodeURIComponent("id")] = __extendedEncodeURIComponent(
+      input.HostedZoneId
+    );
   }
   if (input.MaxItems !== undefined) {
-    query["maxitems"] = input.MaxItems.toString();
+    query[
+      __extendedEncodeURIComponent("maxitems")
+    ] = __extendedEncodeURIComponent(input.MaxItems);
   }
   if (input.TrafficPolicyInstanceNameMarker !== undefined) {
     query[
-      "trafficpolicyinstancename"
-    ] = input.TrafficPolicyInstanceNameMarker.toString();
+      __extendedEncodeURIComponent("trafficpolicyinstancename")
+    ] = __extendedEncodeURIComponent(input.TrafficPolicyInstanceNameMarker);
   }
   if (input.TrafficPolicyInstanceTypeMarker !== undefined) {
     query[
-      "trafficpolicyinstancetype"
-    ] = input.TrafficPolicyInstanceTypeMarker.toString();
+      __extendedEncodeURIComponent("trafficpolicyinstancetype")
+    ] = __extendedEncodeURIComponent(input.TrafficPolicyInstanceTypeMarker);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1952,26 +2051,34 @@ export async function serializeAws_restXmlListTrafficPolicyInstancesByPolicyComm
   let resolvedPath = "/2013-04-01/trafficpolicyinstances/trafficpolicy";
   const query: any = {};
   if (input.HostedZoneIdMarker !== undefined) {
-    query["hostedzoneid"] = input.HostedZoneIdMarker.toString();
+    query[
+      __extendedEncodeURIComponent("hostedzoneid")
+    ] = __extendedEncodeURIComponent(input.HostedZoneIdMarker);
   }
   if (input.MaxItems !== undefined) {
-    query["maxitems"] = input.MaxItems.toString();
+    query[
+      __extendedEncodeURIComponent("maxitems")
+    ] = __extendedEncodeURIComponent(input.MaxItems);
   }
   if (input.TrafficPolicyId !== undefined) {
-    query["id"] = input.TrafficPolicyId.toString();
+    query[__extendedEncodeURIComponent("id")] = __extendedEncodeURIComponent(
+      input.TrafficPolicyId
+    );
   }
   if (input.TrafficPolicyInstanceNameMarker !== undefined) {
     query[
-      "trafficpolicyinstancename"
-    ] = input.TrafficPolicyInstanceNameMarker.toString();
+      __extendedEncodeURIComponent("trafficpolicyinstancename")
+    ] = __extendedEncodeURIComponent(input.TrafficPolicyInstanceNameMarker);
   }
   if (input.TrafficPolicyInstanceTypeMarker !== undefined) {
     query[
-      "trafficpolicyinstancetype"
-    ] = input.TrafficPolicyInstanceTypeMarker.toString();
+      __extendedEncodeURIComponent("trafficpolicyinstancetype")
+    ] = __extendedEncodeURIComponent(input.TrafficPolicyInstanceTypeMarker);
   }
   if (input.TrafficPolicyVersion !== undefined) {
-    query["version"] = input.TrafficPolicyVersion.toString();
+    query[
+      __extendedEncodeURIComponent("version")
+    ] = __extendedEncodeURIComponent(input.TrafficPolicyVersion.toString());
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1991,20 +2098,27 @@ export async function serializeAws_restXmlListTrafficPolicyVersionsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/2013-04-01/trafficpolicies/{Id}/versions";
   if (input.Id !== undefined) {
-    const labelValue: string = input.Id.toString();
+    const labelValue: string = input.Id;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Id.");
     }
-    resolvedPath = resolvedPath.replace("{Id}", encodeURIComponent(labelValue));
+    resolvedPath = resolvedPath.replace(
+      "{Id}",
+      __extendedEncodeURIComponent(labelValue)
+    );
   } else {
     throw new Error("No value provided for input HTTP label: Id.");
   }
   const query: any = {};
   if (input.MaxItems !== undefined) {
-    query["maxitems"] = input.MaxItems.toString();
+    query[
+      __extendedEncodeURIComponent("maxitems")
+    ] = __extendedEncodeURIComponent(input.MaxItems);
   }
   if (input.TrafficPolicyVersionMarker !== undefined) {
-    query["trafficpolicyversion"] = input.TrafficPolicyVersionMarker.toString();
+    query[
+      __extendedEncodeURIComponent("trafficpolicyversion")
+    ] = __extendedEncodeURIComponent(input.TrafficPolicyVersionMarker);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2025,7 +2139,7 @@ export async function serializeAws_restXmlListVPCAssociationAuthorizationsComman
   let resolvedPath =
     "/2013-04-01/hostedzone/{HostedZoneId}/authorizevpcassociation";
   if (input.HostedZoneId !== undefined) {
-    const labelValue: string = input.HostedZoneId.toString();
+    const labelValue: string = input.HostedZoneId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: HostedZoneId."
@@ -2033,17 +2147,21 @@ export async function serializeAws_restXmlListVPCAssociationAuthorizationsComman
     }
     resolvedPath = resolvedPath.replace(
       "{HostedZoneId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: HostedZoneId.");
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["maxresults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxresults")
+    ] = __extendedEncodeURIComponent(input.MaxResults);
   }
   if (input.NextToken !== undefined) {
-    query["nexttoken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nexttoken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2064,22 +2182,34 @@ export async function serializeAws_restXmlTestDNSAnswerCommand(
   let resolvedPath = "/2013-04-01/testdnsanswer";
   const query: any = {};
   if (input.EDNS0ClientSubnetIP !== undefined) {
-    query["edns0clientsubnetip"] = input.EDNS0ClientSubnetIP.toString();
+    query[
+      __extendedEncodeURIComponent("edns0clientsubnetip")
+    ] = __extendedEncodeURIComponent(input.EDNS0ClientSubnetIP);
   }
   if (input.EDNS0ClientSubnetMask !== undefined) {
-    query["edns0clientsubnetmask"] = input.EDNS0ClientSubnetMask.toString();
+    query[
+      __extendedEncodeURIComponent("edns0clientsubnetmask")
+    ] = __extendedEncodeURIComponent(input.EDNS0ClientSubnetMask);
   }
   if (input.HostedZoneId !== undefined) {
-    query["hostedzoneid"] = input.HostedZoneId.toString();
+    query[
+      __extendedEncodeURIComponent("hostedzoneid")
+    ] = __extendedEncodeURIComponent(input.HostedZoneId);
   }
   if (input.RecordName !== undefined) {
-    query["recordname"] = input.RecordName.toString();
+    query[
+      __extendedEncodeURIComponent("recordname")
+    ] = __extendedEncodeURIComponent(input.RecordName);
   }
   if (input.RecordType !== undefined) {
-    query["recordtype"] = input.RecordType.toString();
+    query[
+      __extendedEncodeURIComponent("recordtype")
+    ] = __extendedEncodeURIComponent(input.RecordType);
   }
   if (input.ResolverIP !== undefined) {
-    query["resolverip"] = input.ResolverIP.toString();
+    query[
+      __extendedEncodeURIComponent("resolverip")
+    ] = __extendedEncodeURIComponent(input.ResolverIP);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2099,7 +2229,7 @@ export async function serializeAws_restXmlUpdateHealthCheckCommand(
   headers["Content-Type"] = "application/xml";
   let resolvedPath = "/2013-04-01/healthcheck/{HealthCheckId}";
   if (input.HealthCheckId !== undefined) {
-    const labelValue: string = input.HealthCheckId.toString();
+    const labelValue: string = input.HealthCheckId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: HealthCheckId."
@@ -2107,7 +2237,7 @@ export async function serializeAws_restXmlUpdateHealthCheckCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{HealthCheckId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: HealthCheckId.");
@@ -2250,11 +2380,14 @@ export async function serializeAws_restXmlUpdateHostedZoneCommentCommand(
   headers["Content-Type"] = "application/xml";
   let resolvedPath = "/2013-04-01/hostedzone/{Id}";
   if (input.Id !== undefined) {
-    const labelValue: string = input.Id.toString();
+    const labelValue: string = input.Id;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Id.");
     }
-    resolvedPath = resolvedPath.replace("{Id}", encodeURIComponent(labelValue));
+    resolvedPath = resolvedPath.replace(
+      "{Id}",
+      __extendedEncodeURIComponent(labelValue)
+    );
   } else {
     throw new Error("No value provided for input HTTP label: Id.");
   }
@@ -2290,11 +2423,14 @@ export async function serializeAws_restXmlUpdateTrafficPolicyCommentCommand(
   headers["Content-Type"] = "application/xml";
   let resolvedPath = "/2013-04-01/trafficpolicy/{Id}/{Version}";
   if (input.Id !== undefined) {
-    const labelValue: string = input.Id.toString();
+    const labelValue: string = input.Id;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Id.");
     }
-    resolvedPath = resolvedPath.replace("{Id}", encodeURIComponent(labelValue));
+    resolvedPath = resolvedPath.replace(
+      "{Id}",
+      __extendedEncodeURIComponent(labelValue)
+    );
   } else {
     throw new Error("No value provided for input HTTP label: Id.");
   }
@@ -2305,7 +2441,7 @@ export async function serializeAws_restXmlUpdateTrafficPolicyCommentCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{Version}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Version.");
@@ -2342,11 +2478,14 @@ export async function serializeAws_restXmlUpdateTrafficPolicyInstanceCommand(
   headers["Content-Type"] = "application/xml";
   let resolvedPath = "/2013-04-01/trafficpolicyinstance/{Id}";
   if (input.Id !== undefined) {
-    const labelValue: string = input.Id.toString();
+    const labelValue: string = input.Id;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Id.");
     }
-    resolvedPath = resolvedPath.replace("{Id}", encodeURIComponent(labelValue));
+    resolvedPath = resolvedPath.replace(
+      "{Id}",
+      __extendedEncodeURIComponent(labelValue)
+    );
   } else {
     throw new Error("No value provided for input HTTP label: Id.");
   }
@@ -2594,6 +2733,7 @@ export async function deserializeAws_restXmlChangeTagsForResourceCommand(
     $metadata: deserializeMetadata(output),
     __type: "ChangeTagsForResourceResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -3462,6 +3602,7 @@ export async function deserializeAws_restXmlDeleteHealthCheckCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeleteHealthCheckResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -3617,6 +3758,7 @@ export async function deserializeAws_restXmlDeleteQueryLoggingConfigCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeleteQueryLoggingConfigResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -3685,6 +3827,7 @@ export async function deserializeAws_restXmlDeleteReusableDelegationSetCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeleteReusableDelegationSetResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -3760,6 +3903,7 @@ export async function deserializeAws_restXmlDeleteTrafficPolicyCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeleteTrafficPolicyResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -3835,6 +3979,7 @@ export async function deserializeAws_restXmlDeleteTrafficPolicyInstanceCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeleteTrafficPolicyInstanceResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -3903,6 +4048,7 @@ export async function deserializeAws_restXmlDeleteVPCAssociationAuthorizationCom
     $metadata: deserializeMetadata(output),
     __type: "DeleteVPCAssociationAuthorizationResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 

--- a/clients/client-route53resolver/models/index.ts
+++ b/clients/client-route53resolver/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export interface AssociateResolverEndpointIpAddressRequest {
@@ -17,7 +20,7 @@ export interface AssociateResolverEndpointIpAddressRequest {
 
 export namespace AssociateResolverEndpointIpAddressRequest {
   export function isa(o: any): o is AssociateResolverEndpointIpAddressRequest {
-    return _smithy.isa(o, "AssociateResolverEndpointIpAddressRequest");
+    return __isa(o, "AssociateResolverEndpointIpAddressRequest");
   }
 }
 
@@ -32,7 +35,7 @@ export interface AssociateResolverEndpointIpAddressResponse
 
 export namespace AssociateResolverEndpointIpAddressResponse {
   export function isa(o: any): o is AssociateResolverEndpointIpAddressResponse {
-    return _smithy.isa(o, "AssociateResolverEndpointIpAddressResponse");
+    return __isa(o, "AssociateResolverEndpointIpAddressResponse");
   }
 }
 
@@ -57,7 +60,7 @@ export interface AssociateResolverRuleRequest {
 
 export namespace AssociateResolverRuleRequest {
   export function isa(o: any): o is AssociateResolverRuleRequest {
-    return _smithy.isa(o, "AssociateResolverRuleRequest");
+    return __isa(o, "AssociateResolverRuleRequest");
   }
 }
 
@@ -71,7 +74,7 @@ export interface AssociateResolverRuleResponse extends $MetadataBearer {
 
 export namespace AssociateResolverRuleResponse {
   export function isa(o: any): o is AssociateResolverRuleResponse {
-    return _smithy.isa(o, "AssociateResolverRuleResponse");
+    return __isa(o, "AssociateResolverRuleResponse");
   }
 }
 
@@ -123,7 +126,7 @@ export interface CreateResolverEndpointRequest {
 
 export namespace CreateResolverEndpointRequest {
   export function isa(o: any): o is CreateResolverEndpointRequest {
-    return _smithy.isa(o, "CreateResolverEndpointRequest");
+    return __isa(o, "CreateResolverEndpointRequest");
   }
 }
 
@@ -137,7 +140,7 @@ export interface CreateResolverEndpointResponse extends $MetadataBearer {
 
 export namespace CreateResolverEndpointResponse {
   export function isa(o: any): o is CreateResolverEndpointResponse {
-    return _smithy.isa(o, "CreateResolverEndpointResponse");
+    return __isa(o, "CreateResolverEndpointResponse");
   }
 }
 
@@ -185,7 +188,7 @@ export interface CreateResolverRuleRequest {
 
 export namespace CreateResolverRuleRequest {
   export function isa(o: any): o is CreateResolverRuleRequest {
-    return _smithy.isa(o, "CreateResolverRuleRequest");
+    return __isa(o, "CreateResolverRuleRequest");
   }
 }
 
@@ -199,7 +202,7 @@ export interface CreateResolverRuleResponse extends $MetadataBearer {
 
 export namespace CreateResolverRuleResponse {
   export function isa(o: any): o is CreateResolverRuleResponse {
-    return _smithy.isa(o, "CreateResolverRuleResponse");
+    return __isa(o, "CreateResolverRuleResponse");
   }
 }
 
@@ -213,7 +216,7 @@ export interface DeleteResolverEndpointRequest {
 
 export namespace DeleteResolverEndpointRequest {
   export function isa(o: any): o is DeleteResolverEndpointRequest {
-    return _smithy.isa(o, "DeleteResolverEndpointRequest");
+    return __isa(o, "DeleteResolverEndpointRequest");
   }
 }
 
@@ -227,7 +230,7 @@ export interface DeleteResolverEndpointResponse extends $MetadataBearer {
 
 export namespace DeleteResolverEndpointResponse {
   export function isa(o: any): o is DeleteResolverEndpointResponse {
-    return _smithy.isa(o, "DeleteResolverEndpointResponse");
+    return __isa(o, "DeleteResolverEndpointResponse");
   }
 }
 
@@ -241,7 +244,7 @@ export interface DeleteResolverRuleRequest {
 
 export namespace DeleteResolverRuleRequest {
   export function isa(o: any): o is DeleteResolverRuleRequest {
-    return _smithy.isa(o, "DeleteResolverRuleRequest");
+    return __isa(o, "DeleteResolverRuleRequest");
   }
 }
 
@@ -255,7 +258,7 @@ export interface DeleteResolverRuleResponse extends $MetadataBearer {
 
 export namespace DeleteResolverRuleResponse {
   export function isa(o: any): o is DeleteResolverRuleResponse {
-    return _smithy.isa(o, "DeleteResolverRuleResponse");
+    return __isa(o, "DeleteResolverRuleResponse");
   }
 }
 
@@ -276,7 +279,7 @@ export namespace DisassociateResolverEndpointIpAddressRequest {
   export function isa(
     o: any
   ): o is DisassociateResolverEndpointIpAddressRequest {
-    return _smithy.isa(o, "DisassociateResolverEndpointIpAddressRequest");
+    return __isa(o, "DisassociateResolverEndpointIpAddressRequest");
   }
 }
 
@@ -293,7 +296,7 @@ export namespace DisassociateResolverEndpointIpAddressResponse {
   export function isa(
     o: any
   ): o is DisassociateResolverEndpointIpAddressResponse {
-    return _smithy.isa(o, "DisassociateResolverEndpointIpAddressResponse");
+    return __isa(o, "DisassociateResolverEndpointIpAddressResponse");
   }
 }
 
@@ -312,7 +315,7 @@ export interface DisassociateResolverRuleRequest {
 
 export namespace DisassociateResolverRuleRequest {
   export function isa(o: any): o is DisassociateResolverRuleRequest {
-    return _smithy.isa(o, "DisassociateResolverRuleRequest");
+    return __isa(o, "DisassociateResolverRuleRequest");
   }
 }
 
@@ -326,7 +329,7 @@ export interface DisassociateResolverRuleResponse extends $MetadataBearer {
 
 export namespace DisassociateResolverRuleResponse {
   export function isa(o: any): o is DisassociateResolverRuleResponse {
-    return _smithy.isa(o, "DisassociateResolverRuleResponse");
+    return __isa(o, "DisassociateResolverRuleResponse");
   }
 }
 
@@ -352,7 +355,7 @@ export interface Filter {
 
 export namespace Filter {
   export function isa(o: any): o is Filter {
-    return _smithy.isa(o, "Filter");
+    return __isa(o, "Filter");
   }
 }
 
@@ -366,7 +369,7 @@ export interface GetResolverEndpointRequest {
 
 export namespace GetResolverEndpointRequest {
   export function isa(o: any): o is GetResolverEndpointRequest {
-    return _smithy.isa(o, "GetResolverEndpointRequest");
+    return __isa(o, "GetResolverEndpointRequest");
   }
 }
 
@@ -380,7 +383,7 @@ export interface GetResolverEndpointResponse extends $MetadataBearer {
 
 export namespace GetResolverEndpointResponse {
   export function isa(o: any): o is GetResolverEndpointResponse {
-    return _smithy.isa(o, "GetResolverEndpointResponse");
+    return __isa(o, "GetResolverEndpointResponse");
   }
 }
 
@@ -394,7 +397,7 @@ export interface GetResolverRuleAssociationRequest {
 
 export namespace GetResolverRuleAssociationRequest {
   export function isa(o: any): o is GetResolverRuleAssociationRequest {
-    return _smithy.isa(o, "GetResolverRuleAssociationRequest");
+    return __isa(o, "GetResolverRuleAssociationRequest");
   }
 }
 
@@ -408,7 +411,7 @@ export interface GetResolverRuleAssociationResponse extends $MetadataBearer {
 
 export namespace GetResolverRuleAssociationResponse {
   export function isa(o: any): o is GetResolverRuleAssociationResponse {
-    return _smithy.isa(o, "GetResolverRuleAssociationResponse");
+    return __isa(o, "GetResolverRuleAssociationResponse");
   }
 }
 
@@ -422,7 +425,7 @@ export interface GetResolverRulePolicyRequest {
 
 export namespace GetResolverRulePolicyRequest {
   export function isa(o: any): o is GetResolverRulePolicyRequest {
-    return _smithy.isa(o, "GetResolverRulePolicyRequest");
+    return __isa(o, "GetResolverRulePolicyRequest");
   }
 }
 
@@ -436,7 +439,7 @@ export interface GetResolverRulePolicyResponse extends $MetadataBearer {
 
 export namespace GetResolverRulePolicyResponse {
   export function isa(o: any): o is GetResolverRulePolicyResponse {
-    return _smithy.isa(o, "GetResolverRulePolicyResponse");
+    return __isa(o, "GetResolverRulePolicyResponse");
   }
 }
 
@@ -450,7 +453,7 @@ export interface GetResolverRuleRequest {
 
 export namespace GetResolverRuleRequest {
   export function isa(o: any): o is GetResolverRuleRequest {
-    return _smithy.isa(o, "GetResolverRuleRequest");
+    return __isa(o, "GetResolverRuleRequest");
   }
 }
 
@@ -464,7 +467,7 @@ export interface GetResolverRuleResponse extends $MetadataBearer {
 
 export namespace GetResolverRuleResponse {
   export function isa(o: any): o is GetResolverRuleResponse {
-    return _smithy.isa(o, "GetResolverRuleResponse");
+    return __isa(o, "GetResolverRuleResponse");
   }
 }
 
@@ -472,7 +475,7 @@ export namespace GetResolverRuleResponse {
  * <p>We encountered an unknown error. Try again in a few minutes.</p>
  */
 export interface InternalServiceErrorException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalServiceErrorException";
   $fault: "client";
@@ -481,7 +484,7 @@ export interface InternalServiceErrorException
 
 export namespace InternalServiceErrorException {
   export function isa(o: any): o is InternalServiceErrorException {
-    return _smithy.isa(o, "InternalServiceErrorException");
+    return __isa(o, "InternalServiceErrorException");
   }
 }
 
@@ -489,7 +492,7 @@ export namespace InternalServiceErrorException {
  * <p>The value that you specified for <code>NextToken</code> in a <code>List</code> request isn't valid.</p>
  */
 export interface InvalidNextTokenException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidNextTokenException";
   $fault: "client";
@@ -498,7 +501,7 @@ export interface InvalidNextTokenException
 
 export namespace InvalidNextTokenException {
   export function isa(o: any): o is InvalidNextTokenException {
-    return _smithy.isa(o, "InvalidNextTokenException");
+    return __isa(o, "InvalidNextTokenException");
   }
 }
 
@@ -506,7 +509,7 @@ export namespace InvalidNextTokenException {
  * <p>One or more parameters in this request are not valid.</p>
  */
 export interface InvalidParameterException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidParameterException";
   $fault: "client";
@@ -520,7 +523,7 @@ export interface InvalidParameterException
 
 export namespace InvalidParameterException {
   export function isa(o: any): o is InvalidParameterException {
-    return _smithy.isa(o, "InvalidParameterException");
+    return __isa(o, "InvalidParameterException");
   }
 }
 
@@ -528,7 +531,7 @@ export namespace InvalidParameterException {
  * <p>The specified resolver rule policy is invalid.</p>
  */
 export interface InvalidPolicyDocument
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidPolicyDocument";
   $fault: "client";
@@ -537,7 +540,7 @@ export interface InvalidPolicyDocument
 
 export namespace InvalidPolicyDocument {
   export function isa(o: any): o is InvalidPolicyDocument {
-    return _smithy.isa(o, "InvalidPolicyDocument");
+    return __isa(o, "InvalidPolicyDocument");
   }
 }
 
@@ -545,7 +548,7 @@ export namespace InvalidPolicyDocument {
  * <p>The request is invalid.</p>
  */
 export interface InvalidRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidRequestException";
   $fault: "client";
@@ -554,7 +557,7 @@ export interface InvalidRequestException
 
 export namespace InvalidRequestException {
   export function isa(o: any): o is InvalidRequestException {
-    return _smithy.isa(o, "InvalidRequestException");
+    return __isa(o, "InvalidRequestException");
   }
 }
 
@@ -562,7 +565,7 @@ export namespace InvalidRequestException {
  * <p>The specified tag is invalid.</p>
  */
 export interface InvalidTagException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidTagException";
   $fault: "client";
@@ -571,7 +574,7 @@ export interface InvalidTagException
 
 export namespace InvalidTagException {
   export function isa(o: any): o is InvalidTagException {
-    return _smithy.isa(o, "InvalidTagException");
+    return __isa(o, "InvalidTagException");
   }
 }
 
@@ -593,7 +596,7 @@ export interface IpAddressRequest {
 
 export namespace IpAddressRequest {
   export function isa(o: any): o is IpAddressRequest {
-    return _smithy.isa(o, "IpAddressRequest");
+    return __isa(o, "IpAddressRequest");
   }
 }
 
@@ -641,7 +644,7 @@ export interface IpAddressResponse {
 
 export namespace IpAddressResponse {
   export function isa(o: any): o is IpAddressResponse {
-    return _smithy.isa(o, "IpAddressResponse");
+    return __isa(o, "IpAddressResponse");
   }
 }
 
@@ -683,7 +686,7 @@ export interface IpAddressUpdate {
 
 export namespace IpAddressUpdate {
   export function isa(o: any): o is IpAddressUpdate {
-    return _smithy.isa(o, "IpAddressUpdate");
+    return __isa(o, "IpAddressUpdate");
   }
 }
 
@@ -691,7 +694,7 @@ export namespace IpAddressUpdate {
  * <p>The request caused one or more limits to be exceeded.</p>
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -704,7 +707,7 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
@@ -732,7 +735,7 @@ export interface ListResolverEndpointIpAddressesRequest {
 
 export namespace ListResolverEndpointIpAddressesRequest {
   export function isa(o: any): o is ListResolverEndpointIpAddressesRequest {
-    return _smithy.isa(o, "ListResolverEndpointIpAddressesRequest");
+    return __isa(o, "ListResolverEndpointIpAddressesRequest");
   }
 }
 
@@ -760,7 +763,7 @@ export interface ListResolverEndpointIpAddressesResponse
 
 export namespace ListResolverEndpointIpAddressesResponse {
   export function isa(o: any): o is ListResolverEndpointIpAddressesResponse {
-    return _smithy.isa(o, "ListResolverEndpointIpAddressesResponse");
+    return __isa(o, "ListResolverEndpointIpAddressesResponse");
   }
 }
 
@@ -791,7 +794,7 @@ export interface ListResolverEndpointsRequest {
 
 export namespace ListResolverEndpointsRequest {
   export function isa(o: any): o is ListResolverEndpointsRequest {
-    return _smithy.isa(o, "ListResolverEndpointsRequest");
+    return __isa(o, "ListResolverEndpointsRequest");
   }
 }
 
@@ -816,7 +819,7 @@ export interface ListResolverEndpointsResponse extends $MetadataBearer {
 
 export namespace ListResolverEndpointsResponse {
   export function isa(o: any): o is ListResolverEndpointsResponse {
-    return _smithy.isa(o, "ListResolverEndpointsResponse");
+    return __isa(o, "ListResolverEndpointsResponse");
   }
 }
 
@@ -847,7 +850,7 @@ export interface ListResolverRuleAssociationsRequest {
 
 export namespace ListResolverRuleAssociationsRequest {
   export function isa(o: any): o is ListResolverRuleAssociationsRequest {
-    return _smithy.isa(o, "ListResolverRuleAssociationsRequest");
+    return __isa(o, "ListResolverRuleAssociationsRequest");
   }
 }
 
@@ -874,7 +877,7 @@ export interface ListResolverRuleAssociationsResponse extends $MetadataBearer {
 
 export namespace ListResolverRuleAssociationsResponse {
   export function isa(o: any): o is ListResolverRuleAssociationsResponse {
-    return _smithy.isa(o, "ListResolverRuleAssociationsResponse");
+    return __isa(o, "ListResolverRuleAssociationsResponse");
   }
 }
 
@@ -905,7 +908,7 @@ export interface ListResolverRulesRequest {
 
 export namespace ListResolverRulesRequest {
   export function isa(o: any): o is ListResolverRulesRequest {
-    return _smithy.isa(o, "ListResolverRulesRequest");
+    return __isa(o, "ListResolverRulesRequest");
   }
 }
 
@@ -931,7 +934,7 @@ export interface ListResolverRulesResponse extends $MetadataBearer {
 
 export namespace ListResolverRulesResponse {
   export function isa(o: any): o is ListResolverRulesResponse {
-    return _smithy.isa(o, "ListResolverRulesResponse");
+    return __isa(o, "ListResolverRulesResponse");
   }
 }
 
@@ -958,7 +961,7 @@ export interface ListTagsForResourceRequest {
 
 export namespace ListTagsForResourceRequest {
   export function isa(o: any): o is ListTagsForResourceRequest {
-    return _smithy.isa(o, "ListTagsForResourceRequest");
+    return __isa(o, "ListTagsForResourceRequest");
   }
 }
 
@@ -979,7 +982,7 @@ export interface ListTagsForResourceResponse extends $MetadataBearer {
 
 export namespace ListTagsForResourceResponse {
   export function isa(o: any): o is ListTagsForResourceResponse {
-    return _smithy.isa(o, "ListTagsForResourceResponse");
+    return __isa(o, "ListTagsForResourceResponse");
   }
 }
 
@@ -998,7 +1001,7 @@ export interface PutResolverRulePolicyRequest {
 
 export namespace PutResolverRulePolicyRequest {
   export function isa(o: any): o is PutResolverRulePolicyRequest {
-    return _smithy.isa(o, "PutResolverRulePolicyRequest");
+    return __isa(o, "PutResolverRulePolicyRequest");
   }
 }
 
@@ -1015,7 +1018,7 @@ export interface PutResolverRulePolicyResponse extends $MetadataBearer {
 
 export namespace PutResolverRulePolicyResponse {
   export function isa(o: any): o is PutResolverRulePolicyResponse {
-    return _smithy.isa(o, "PutResolverRulePolicyResponse");
+    return __isa(o, "PutResolverRulePolicyResponse");
   }
 }
 
@@ -1100,7 +1103,7 @@ export interface ResolverEndpoint {
 
 export namespace ResolverEndpoint {
   export function isa(o: any): o is ResolverEndpoint {
-    return _smithy.isa(o, "ResolverEndpoint");
+    return __isa(o, "ResolverEndpoint");
   }
 }
 
@@ -1193,7 +1196,7 @@ export interface ResolverRule {
 
 export namespace ResolverRule {
   export function isa(o: any): o is ResolverRule {
-    return _smithy.isa(o, "ResolverRule");
+    return __isa(o, "ResolverRule");
   }
 }
 
@@ -1238,7 +1241,7 @@ export interface ResolverRuleAssociation {
 
 export namespace ResolverRuleAssociation {
   export function isa(o: any): o is ResolverRuleAssociation {
-    return _smithy.isa(o, "ResolverRuleAssociation");
+    return __isa(o, "ResolverRuleAssociation");
   }
 }
 
@@ -1274,7 +1277,7 @@ export interface ResolverRuleConfig {
 
 export namespace ResolverRuleConfig {
   export function isa(o: any): o is ResolverRuleConfig {
-    return _smithy.isa(o, "ResolverRuleConfig");
+    return __isa(o, "ResolverRuleConfig");
   }
 }
 
@@ -1289,7 +1292,7 @@ export enum ResolverRuleStatus {
  * <p>The resource that you tried to create already exists.</p>
  */
 export interface ResourceExistsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceExistsException";
   $fault: "client";
@@ -1302,7 +1305,7 @@ export interface ResourceExistsException
 
 export namespace ResourceExistsException {
   export function isa(o: any): o is ResourceExistsException {
-    return _smithy.isa(o, "ResourceExistsException");
+    return __isa(o, "ResourceExistsException");
   }
 }
 
@@ -1310,7 +1313,7 @@ export namespace ResourceExistsException {
  * <p>The resource that you tried to update or delete is currently in use.</p>
  */
 export interface ResourceInUseException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceInUseException";
   $fault: "client";
@@ -1323,7 +1326,7 @@ export interface ResourceInUseException
 
 export namespace ResourceInUseException {
   export function isa(o: any): o is ResourceInUseException {
-    return _smithy.isa(o, "ResourceInUseException");
+    return __isa(o, "ResourceInUseException");
   }
 }
 
@@ -1331,7 +1334,7 @@ export namespace ResourceInUseException {
  * <p>The specified resource doesn't exist.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -1344,7 +1347,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -1352,7 +1355,7 @@ export namespace ResourceNotFoundException {
  * <p>The specified resource isn't available.</p>
  */
 export interface ResourceUnavailableException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceUnavailableException";
   $fault: "client";
@@ -1365,7 +1368,7 @@ export interface ResourceUnavailableException
 
 export namespace ResourceUnavailableException {
   export function isa(o: any): o is ResourceUnavailableException {
-    return _smithy.isa(o, "ResourceUnavailableException");
+    return __isa(o, "ResourceUnavailableException");
   }
 }
 
@@ -1401,7 +1404,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -1453,7 +1456,7 @@ export interface TagResourceRequest {
 
 export namespace TagResourceRequest {
   export function isa(o: any): o is TagResourceRequest {
-    return _smithy.isa(o, "TagResourceRequest");
+    return __isa(o, "TagResourceRequest");
   }
 }
 
@@ -1463,7 +1466,7 @@ export interface TagResourceResponse extends $MetadataBearer {
 
 export namespace TagResourceResponse {
   export function isa(o: any): o is TagResourceResponse {
-    return _smithy.isa(o, "TagResourceResponse");
+    return __isa(o, "TagResourceResponse");
   }
 }
 
@@ -1485,7 +1488,7 @@ export interface TargetAddress {
 
 export namespace TargetAddress {
   export function isa(o: any): o is TargetAddress {
-    return _smithy.isa(o, "TargetAddress");
+    return __isa(o, "TargetAddress");
   }
 }
 
@@ -1493,7 +1496,7 @@ export namespace TargetAddress {
  * <p>The request was throttled. Try again in a few minutes.</p>
  */
 export interface ThrottlingException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ThrottlingException";
   $fault: "client";
@@ -1502,7 +1505,7 @@ export interface ThrottlingException
 
 export namespace ThrottlingException {
   export function isa(o: any): o is ThrottlingException {
-    return _smithy.isa(o, "ThrottlingException");
+    return __isa(o, "ThrottlingException");
   }
 }
 
@@ -1510,7 +1513,7 @@ export namespace ThrottlingException {
  * <p>The specified resource doesn't exist.</p>
  */
 export interface UnknownResourceException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UnknownResourceException";
   $fault: "client";
@@ -1519,7 +1522,7 @@ export interface UnknownResourceException
 
 export namespace UnknownResourceException {
   export function isa(o: any): o is UnknownResourceException {
-    return _smithy.isa(o, "UnknownResourceException");
+    return __isa(o, "UnknownResourceException");
   }
 }
 
@@ -1571,7 +1574,7 @@ export interface UntagResourceRequest {
 
 export namespace UntagResourceRequest {
   export function isa(o: any): o is UntagResourceRequest {
-    return _smithy.isa(o, "UntagResourceRequest");
+    return __isa(o, "UntagResourceRequest");
   }
 }
 
@@ -1581,7 +1584,7 @@ export interface UntagResourceResponse extends $MetadataBearer {
 
 export namespace UntagResourceResponse {
   export function isa(o: any): o is UntagResourceResponse {
-    return _smithy.isa(o, "UntagResourceResponse");
+    return __isa(o, "UntagResourceResponse");
   }
 }
 
@@ -1600,7 +1603,7 @@ export interface UpdateResolverEndpointRequest {
 
 export namespace UpdateResolverEndpointRequest {
   export function isa(o: any): o is UpdateResolverEndpointRequest {
-    return _smithy.isa(o, "UpdateResolverEndpointRequest");
+    return __isa(o, "UpdateResolverEndpointRequest");
   }
 }
 
@@ -1614,7 +1617,7 @@ export interface UpdateResolverEndpointResponse extends $MetadataBearer {
 
 export namespace UpdateResolverEndpointResponse {
   export function isa(o: any): o is UpdateResolverEndpointResponse {
-    return _smithy.isa(o, "UpdateResolverEndpointResponse");
+    return __isa(o, "UpdateResolverEndpointResponse");
   }
 }
 
@@ -1633,7 +1636,7 @@ export interface UpdateResolverRuleRequest {
 
 export namespace UpdateResolverRuleRequest {
   export function isa(o: any): o is UpdateResolverRuleRequest {
-    return _smithy.isa(o, "UpdateResolverRuleRequest");
+    return __isa(o, "UpdateResolverRuleRequest");
   }
 }
 
@@ -1647,6 +1650,6 @@ export interface UpdateResolverRuleResponse extends $MetadataBearer {
 
 export namespace UpdateResolverRuleResponse {
   export function isa(o: any): o is UpdateResolverRuleResponse {
-    return _smithy.isa(o, "UpdateResolverRuleResponse");
+    return __isa(o, "UpdateResolverRuleResponse");
   }
 }

--- a/clients/client-s3-control/models/index.ts
+++ b/clients/client-s3-control/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -30,7 +33,7 @@ export interface AccessPoint {
 
 export namespace AccessPoint {
   export function isa(o: any): o is AccessPoint {
-    return _smithy.isa(o, "AccessPoint");
+    return __isa(o, "AccessPoint");
   }
 }
 
@@ -38,7 +41,7 @@ export namespace AccessPoint {
  * <p></p>
  */
 export interface BadRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "BadRequestException";
   $fault: "client";
@@ -47,7 +50,7 @@ export interface BadRequestException
 
 export namespace BadRequestException {
   export function isa(o: any): o is BadRequestException {
-    return _smithy.isa(o, "BadRequestException");
+    return __isa(o, "BadRequestException");
   }
 }
 
@@ -83,7 +86,7 @@ export interface CreateAccessPointRequest {
 
 export namespace CreateAccessPointRequest {
   export function isa(o: any): o is CreateAccessPointRequest {
-    return _smithy.isa(o, "CreateAccessPointRequest");
+    return __isa(o, "CreateAccessPointRequest");
   }
 }
 
@@ -138,7 +141,7 @@ export interface CreateJobRequest {
 
 export namespace CreateJobRequest {
   export function isa(o: any): o is CreateJobRequest {
-    return _smithy.isa(o, "CreateJobRequest");
+    return __isa(o, "CreateJobRequest");
   }
 }
 
@@ -153,7 +156,7 @@ export interface CreateJobResult extends $MetadataBearer {
 
 export namespace CreateJobResult {
   export function isa(o: any): o is CreateJobResult {
-    return _smithy.isa(o, "CreateJobResult");
+    return __isa(o, "CreateJobResult");
   }
 }
 
@@ -172,7 +175,7 @@ export interface DeleteAccessPointPolicyRequest {
 
 export namespace DeleteAccessPointPolicyRequest {
   export function isa(o: any): o is DeleteAccessPointPolicyRequest {
-    return _smithy.isa(o, "DeleteAccessPointPolicyRequest");
+    return __isa(o, "DeleteAccessPointPolicyRequest");
   }
 }
 
@@ -191,7 +194,7 @@ export interface DeleteAccessPointRequest {
 
 export namespace DeleteAccessPointRequest {
   export function isa(o: any): o is DeleteAccessPointRequest {
-    return _smithy.isa(o, "DeleteAccessPointRequest");
+    return __isa(o, "DeleteAccessPointRequest");
   }
 }
 
@@ -206,7 +209,7 @@ export interface DeletePublicAccessBlockRequest {
 
 export namespace DeletePublicAccessBlockRequest {
   export function isa(o: any): o is DeletePublicAccessBlockRequest {
-    return _smithy.isa(o, "DeletePublicAccessBlockRequest");
+    return __isa(o, "DeletePublicAccessBlockRequest");
   }
 }
 
@@ -225,7 +228,7 @@ export interface DescribeJobRequest {
 
 export namespace DescribeJobRequest {
   export function isa(o: any): o is DescribeJobRequest {
-    return _smithy.isa(o, "DescribeJobRequest");
+    return __isa(o, "DescribeJobRequest");
   }
 }
 
@@ -239,7 +242,7 @@ export interface DescribeJobResult extends $MetadataBearer {
 
 export namespace DescribeJobResult {
   export function isa(o: any): o is DescribeJobResult {
-    return _smithy.isa(o, "DescribeJobResult");
+    return __isa(o, "DescribeJobResult");
   }
 }
 
@@ -258,7 +261,7 @@ export interface GetAccessPointPolicyRequest {
 
 export namespace GetAccessPointPolicyRequest {
   export function isa(o: any): o is GetAccessPointPolicyRequest {
-    return _smithy.isa(o, "GetAccessPointPolicyRequest");
+    return __isa(o, "GetAccessPointPolicyRequest");
   }
 }
 
@@ -272,7 +275,7 @@ export interface GetAccessPointPolicyResult extends $MetadataBearer {
 
 export namespace GetAccessPointPolicyResult {
   export function isa(o: any): o is GetAccessPointPolicyResult {
-    return _smithy.isa(o, "GetAccessPointPolicyResult");
+    return __isa(o, "GetAccessPointPolicyResult");
   }
 }
 
@@ -291,7 +294,7 @@ export interface GetAccessPointPolicyStatusRequest {
 
 export namespace GetAccessPointPolicyStatusRequest {
   export function isa(o: any): o is GetAccessPointPolicyStatusRequest {
-    return _smithy.isa(o, "GetAccessPointPolicyStatusRequest");
+    return __isa(o, "GetAccessPointPolicyStatusRequest");
   }
 }
 
@@ -305,7 +308,7 @@ export interface GetAccessPointPolicyStatusResult extends $MetadataBearer {
 
 export namespace GetAccessPointPolicyStatusResult {
   export function isa(o: any): o is GetAccessPointPolicyStatusResult {
-    return _smithy.isa(o, "GetAccessPointPolicyStatusResult");
+    return __isa(o, "GetAccessPointPolicyStatusResult");
   }
 }
 
@@ -324,7 +327,7 @@ export interface GetAccessPointRequest {
 
 export namespace GetAccessPointRequest {
   export function isa(o: any): o is GetAccessPointRequest {
-    return _smithy.isa(o, "GetAccessPointRequest");
+    return __isa(o, "GetAccessPointRequest");
   }
 }
 
@@ -366,7 +369,7 @@ export interface GetAccessPointResult extends $MetadataBearer {
 
 export namespace GetAccessPointResult {
   export function isa(o: any): o is GetAccessPointResult {
-    return _smithy.isa(o, "GetAccessPointResult");
+    return __isa(o, "GetAccessPointResult");
   }
 }
 
@@ -381,7 +384,7 @@ export interface GetPublicAccessBlockOutput extends $MetadataBearer {
 
 export namespace GetPublicAccessBlockOutput {
   export function isa(o: any): o is GetPublicAccessBlockOutput {
-    return _smithy.isa(o, "GetPublicAccessBlockOutput");
+    return __isa(o, "GetPublicAccessBlockOutput");
   }
 }
 
@@ -396,7 +399,7 @@ export interface GetPublicAccessBlockRequest {
 
 export namespace GetPublicAccessBlockRequest {
   export function isa(o: any): o is GetPublicAccessBlockRequest {
-    return _smithy.isa(o, "GetPublicAccessBlockRequest");
+    return __isa(o, "GetPublicAccessBlockRequest");
   }
 }
 
@@ -404,7 +407,7 @@ export namespace GetPublicAccessBlockRequest {
  * <p></p>
  */
 export interface IdempotencyException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "IdempotencyException";
   $fault: "client";
@@ -413,7 +416,7 @@ export interface IdempotencyException
 
 export namespace IdempotencyException {
   export function isa(o: any): o is IdempotencyException {
-    return _smithy.isa(o, "IdempotencyException");
+    return __isa(o, "IdempotencyException");
   }
 }
 
@@ -421,7 +424,7 @@ export namespace IdempotencyException {
  * <p></p>
  */
 export interface InternalServiceException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalServiceException";
   $fault: "server";
@@ -430,7 +433,7 @@ export interface InternalServiceException
 
 export namespace InternalServiceException {
   export function isa(o: any): o is InternalServiceException {
-    return _smithy.isa(o, "InternalServiceException");
+    return __isa(o, "InternalServiceException");
   }
 }
 
@@ -438,7 +441,7 @@ export namespace InternalServiceException {
  * <p></p>
  */
 export interface InvalidNextTokenException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidNextTokenException";
   $fault: "client";
@@ -447,7 +450,7 @@ export interface InvalidNextTokenException
 
 export namespace InvalidNextTokenException {
   export function isa(o: any): o is InvalidNextTokenException {
-    return _smithy.isa(o, "InvalidNextTokenException");
+    return __isa(o, "InvalidNextTokenException");
   }
 }
 
@@ -455,7 +458,7 @@ export namespace InvalidNextTokenException {
  * <p></p>
  */
 export interface InvalidRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidRequestException";
   $fault: "client";
@@ -464,7 +467,7 @@ export interface InvalidRequestException
 
 export namespace InvalidRequestException {
   export function isa(o: any): o is InvalidRequestException {
-    return _smithy.isa(o, "InvalidRequestException");
+    return __isa(o, "InvalidRequestException");
   }
 }
 
@@ -562,7 +565,7 @@ export interface JobDescriptor {
 
 export namespace JobDescriptor {
   export function isa(o: any): o is JobDescriptor {
-    return _smithy.isa(o, "JobDescriptor");
+    return __isa(o, "JobDescriptor");
   }
 }
 
@@ -584,7 +587,7 @@ export interface JobFailure {
 
 export namespace JobFailure {
   export function isa(o: any): o is JobFailure {
-    return _smithy.isa(o, "JobFailure");
+    return __isa(o, "JobFailure");
   }
 }
 
@@ -636,7 +639,7 @@ export interface JobListDescriptor {
 
 export namespace JobListDescriptor {
   export function isa(o: any): o is JobListDescriptor {
-    return _smithy.isa(o, "JobListDescriptor");
+    return __isa(o, "JobListDescriptor");
   }
 }
 
@@ -658,7 +661,7 @@ export interface JobManifest {
 
 export namespace JobManifest {
   export function isa(o: any): o is JobManifest {
-    return _smithy.isa(o, "JobManifest");
+    return __isa(o, "JobManifest");
   }
 }
 
@@ -697,7 +700,7 @@ export interface JobManifestLocation {
 
 export namespace JobManifestLocation {
   export function isa(o: any): o is JobManifestLocation {
-    return _smithy.isa(o, "JobManifestLocation");
+    return __isa(o, "JobManifestLocation");
   }
 }
 
@@ -719,7 +722,7 @@ export interface JobManifestSpec {
 
 export namespace JobManifestSpec {
   export function isa(o: any): o is JobManifestSpec {
-    return _smithy.isa(o, "JobManifestSpec");
+    return __isa(o, "JobManifestSpec");
   }
 }
 
@@ -757,7 +760,7 @@ export interface JobOperation {
 
 export namespace JobOperation {
   export function isa(o: any): o is JobOperation {
-    return _smithy.isa(o, "JobOperation");
+    return __isa(o, "JobOperation");
   }
 }
 
@@ -784,7 +787,7 @@ export interface JobProgressSummary {
 
 export namespace JobProgressSummary {
   export function isa(o: any): o is JobProgressSummary {
-    return _smithy.isa(o, "JobProgressSummary");
+    return __isa(o, "JobProgressSummary");
   }
 }
 
@@ -821,7 +824,7 @@ export interface JobReport {
 
 export namespace JobReport {
   export function isa(o: any): o is JobReport {
-    return _smithy.isa(o, "JobReport");
+    return __isa(o, "JobReport");
   }
 }
 
@@ -853,9 +856,7 @@ export enum JobStatus {
 /**
  * <p></p>
  */
-export interface JobStatusException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface JobStatusException extends __SmithyException, $MetadataBearer {
   name: "JobStatusException";
   $fault: "client";
   Message?: string;
@@ -863,7 +864,7 @@ export interface JobStatusException
 
 export namespace JobStatusException {
   export function isa(o: any): o is JobStatusException {
-    return _smithy.isa(o, "JobStatusException");
+    return __isa(o, "JobStatusException");
   }
 }
 
@@ -880,7 +881,7 @@ export interface LambdaInvokeOperation {
 
 export namespace LambdaInvokeOperation {
   export function isa(o: any): o is LambdaInvokeOperation {
-    return _smithy.isa(o, "LambdaInvokeOperation");
+    return __isa(o, "LambdaInvokeOperation");
   }
 }
 
@@ -909,7 +910,7 @@ export interface ListAccessPointsRequest {
 
 export namespace ListAccessPointsRequest {
   export function isa(o: any): o is ListAccessPointsRequest {
-    return _smithy.isa(o, "ListAccessPointsRequest");
+    return __isa(o, "ListAccessPointsRequest");
   }
 }
 
@@ -928,7 +929,7 @@ export interface ListAccessPointsResult extends $MetadataBearer {
 
 export namespace ListAccessPointsResult {
   export function isa(o: any): o is ListAccessPointsResult {
-    return _smithy.isa(o, "ListAccessPointsResult");
+    return __isa(o, "ListAccessPointsResult");
   }
 }
 
@@ -957,7 +958,7 @@ export interface ListJobsRequest {
 
 export namespace ListJobsRequest {
   export function isa(o: any): o is ListJobsRequest {
-    return _smithy.isa(o, "ListJobsRequest");
+    return __isa(o, "ListJobsRequest");
   }
 }
 
@@ -977,7 +978,7 @@ export interface ListJobsResult extends $MetadataBearer {
 
 export namespace ListJobsResult {
   export function isa(o: any): o is ListJobsResult {
-    return _smithy.isa(o, "ListJobsResult");
+    return __isa(o, "ListJobsResult");
   }
 }
 
@@ -991,7 +992,7 @@ export enum NetworkOrigin {
  *       against an account that doesn't have a <code>PublicAccessBlockConfiguration</code> set.</p>
  */
 export interface NoSuchPublicAccessBlockConfiguration
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "NoSuchPublicAccessBlockConfiguration";
   $fault: "client";
@@ -1000,16 +1001,14 @@ export interface NoSuchPublicAccessBlockConfiguration
 
 export namespace NoSuchPublicAccessBlockConfiguration {
   export function isa(o: any): o is NoSuchPublicAccessBlockConfiguration {
-    return _smithy.isa(o, "NoSuchPublicAccessBlockConfiguration");
+    return __isa(o, "NoSuchPublicAccessBlockConfiguration");
   }
 }
 
 /**
  * <p></p>
  */
-export interface NotFoundException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface NotFoundException extends __SmithyException, $MetadataBearer {
   name: "NotFoundException";
   $fault: "client";
   Message?: string;
@@ -1017,7 +1016,7 @@ export interface NotFoundException
 
 export namespace NotFoundException {
   export function isa(o: any): o is NotFoundException {
-    return _smithy.isa(o, "NotFoundException");
+    return __isa(o, "NotFoundException");
   }
 }
 
@@ -1045,7 +1044,7 @@ export interface PolicyStatus {
 
 export namespace PolicyStatus {
   export function isa(o: any): o is PolicyStatus {
-    return _smithy.isa(o, "PolicyStatus");
+    return __isa(o, "PolicyStatus");
   }
 }
 
@@ -1104,7 +1103,7 @@ export interface PublicAccessBlockConfiguration {
 
 export namespace PublicAccessBlockConfiguration {
   export function isa(o: any): o is PublicAccessBlockConfiguration {
-    return _smithy.isa(o, "PublicAccessBlockConfiguration");
+    return __isa(o, "PublicAccessBlockConfiguration");
   }
 }
 
@@ -1128,7 +1127,7 @@ export interface PutAccessPointPolicyRequest {
 
 export namespace PutAccessPointPolicyRequest {
   export function isa(o: any): o is PutAccessPointPolicyRequest {
-    return _smithy.isa(o, "PutAccessPointPolicyRequest");
+    return __isa(o, "PutAccessPointPolicyRequest");
   }
 }
 
@@ -1149,7 +1148,7 @@ export interface PutPublicAccessBlockRequest {
 
 export namespace PutPublicAccessBlockRequest {
   export function isa(o: any): o is PutPublicAccessBlockRequest {
-    return _smithy.isa(o, "PutPublicAccessBlockRequest");
+    return __isa(o, "PutPublicAccessBlockRequest");
   }
 }
 
@@ -1176,7 +1175,7 @@ export interface S3AccessControlList {
 
 export namespace S3AccessControlList {
   export function isa(o: any): o is S3AccessControlList {
-    return _smithy.isa(o, "S3AccessControlList");
+    return __isa(o, "S3AccessControlList");
   }
 }
 
@@ -1198,7 +1197,7 @@ export interface S3AccessControlPolicy {
 
 export namespace S3AccessControlPolicy {
   export function isa(o: any): o is S3AccessControlPolicy {
-    return _smithy.isa(o, "S3AccessControlPolicy");
+    return __isa(o, "S3AccessControlPolicy");
   }
 }
 
@@ -1301,7 +1300,7 @@ export interface S3CopyObjectOperation {
 
 export namespace S3CopyObjectOperation {
   export function isa(o: any): o is S3CopyObjectOperation {
-    return _smithy.isa(o, "S3CopyObjectOperation");
+    return __isa(o, "S3CopyObjectOperation");
   }
 }
 
@@ -1328,7 +1327,7 @@ export interface S3Grant {
 
 export namespace S3Grant {
   export function isa(o: any): o is S3Grant {
-    return _smithy.isa(o, "S3Grant");
+    return __isa(o, "S3Grant");
   }
 }
 
@@ -1355,7 +1354,7 @@ export interface S3Grantee {
 
 export namespace S3Grantee {
   export function isa(o: any): o is S3Grantee {
-    return _smithy.isa(o, "S3Grantee");
+    return __isa(o, "S3Grantee");
   }
 }
 
@@ -1384,7 +1383,7 @@ export interface S3InitiateRestoreObjectOperation {
 
 export namespace S3InitiateRestoreObjectOperation {
   export function isa(o: any): o is S3InitiateRestoreObjectOperation {
-    return _smithy.isa(o, "S3InitiateRestoreObjectOperation");
+    return __isa(o, "S3InitiateRestoreObjectOperation");
   }
 }
 
@@ -1466,7 +1465,7 @@ export interface S3ObjectMetadata {
 
 export namespace S3ObjectMetadata {
   export function isa(o: any): o is S3ObjectMetadata {
-    return _smithy.isa(o, "S3ObjectMetadata");
+    return __isa(o, "S3ObjectMetadata");
   }
 }
 
@@ -1488,7 +1487,7 @@ export interface S3ObjectOwner {
 
 export namespace S3ObjectOwner {
   export function isa(o: any): o is S3ObjectOwner {
-    return _smithy.isa(o, "S3ObjectOwner");
+    return __isa(o, "S3ObjectOwner");
   }
 }
 
@@ -1519,7 +1518,7 @@ export interface S3SetObjectAclOperation {
 
 export namespace S3SetObjectAclOperation {
   export function isa(o: any): o is S3SetObjectAclOperation {
-    return _smithy.isa(o, "S3SetObjectAclOperation");
+    return __isa(o, "S3SetObjectAclOperation");
   }
 }
 
@@ -1537,7 +1536,7 @@ export interface S3SetObjectTaggingOperation {
 
 export namespace S3SetObjectTaggingOperation {
   export function isa(o: any): o is S3SetObjectTaggingOperation {
-    return _smithy.isa(o, "S3SetObjectTaggingOperation");
+    return __isa(o, "S3SetObjectTaggingOperation");
   }
 }
 
@@ -1568,7 +1567,7 @@ export interface S3Tag {
 
 export namespace S3Tag {
   export function isa(o: any): o is S3Tag {
-    return _smithy.isa(o, "S3Tag");
+    return __isa(o, "S3Tag");
   }
 }
 
@@ -1576,7 +1575,7 @@ export namespace S3Tag {
  * <p></p>
  */
 export interface TooManyRequestsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyRequestsException";
   $fault: "client";
@@ -1585,7 +1584,7 @@ export interface TooManyRequestsException
 
 export namespace TooManyRequestsException {
   export function isa(o: any): o is TooManyRequestsException {
-    return _smithy.isa(o, "TooManyRequestsException");
+    return __isa(o, "TooManyRequestsException");
   }
 }
 
@@ -1609,7 +1608,7 @@ export interface UpdateJobPriorityRequest {
 
 export namespace UpdateJobPriorityRequest {
   export function isa(o: any): o is UpdateJobPriorityRequest {
-    return _smithy.isa(o, "UpdateJobPriorityRequest");
+    return __isa(o, "UpdateJobPriorityRequest");
   }
 }
 
@@ -1628,7 +1627,7 @@ export interface UpdateJobPriorityResult extends $MetadataBearer {
 
 export namespace UpdateJobPriorityResult {
   export function isa(o: any): o is UpdateJobPriorityResult {
-    return _smithy.isa(o, "UpdateJobPriorityResult");
+    return __isa(o, "UpdateJobPriorityResult");
   }
 }
 
@@ -1657,7 +1656,7 @@ export interface UpdateJobStatusRequest {
 
 export namespace UpdateJobStatusRequest {
   export function isa(o: any): o is UpdateJobStatusRequest {
-    return _smithy.isa(o, "UpdateJobStatusRequest");
+    return __isa(o, "UpdateJobStatusRequest");
   }
 }
 
@@ -1681,7 +1680,7 @@ export interface UpdateJobStatusResult extends $MetadataBearer {
 
 export namespace UpdateJobStatusResult {
   export function isa(o: any): o is UpdateJobStatusResult {
-    return _smithy.isa(o, "UpdateJobStatusResult");
+    return __isa(o, "UpdateJobStatusResult");
   }
 }
 
@@ -1698,6 +1697,6 @@ export interface VpcConfiguration {
 
 export namespace VpcConfiguration {
   export function isa(o: any): o is VpcConfiguration {
-    return _smithy.isa(o, "VpcConfiguration");
+    return __isa(o, "VpcConfiguration");
   }
 }

--- a/clients/client-s3-control/protocols/Aws_restXml.ts
+++ b/clients/client-s3-control/protocols/Aws_restXml.ts
@@ -103,7 +103,10 @@ import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  extendedEncodeURIComponent as __extendedEncodeURIComponent
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -124,17 +127,17 @@ export async function serializeAws_restXmlCreateAccessPointCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/xml";
   if (input.AccountId !== undefined) {
-    headers["x-amz-account-id"] = input.AccountId.toString();
+    headers["x-amz-account-id"] = input.AccountId;
   }
   let resolvedPath = "/v20180820/accesspoint/{Name}";
   if (input.Name !== undefined) {
-    const labelValue: string = input.Name.toString();
+    const labelValue: string = input.Name;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Name.");
     }
     resolvedPath = resolvedPath.replace(
       "{Name}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Name.");
@@ -186,7 +189,7 @@ export async function serializeAws_restXmlCreateJobCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/xml";
   if (input.AccountId !== undefined) {
-    headers["x-amz-account-id"] = input.AccountId.toString();
+    headers["x-amz-account-id"] = input.AccountId;
   }
   let resolvedPath = "/v20180820/jobs";
   let body: any;
@@ -262,17 +265,17 @@ export async function serializeAws_restXmlDeleteAccessPointCommand(
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.AccountId !== undefined) {
-    headers["x-amz-account-id"] = input.AccountId.toString();
+    headers["x-amz-account-id"] = input.AccountId;
   }
   let resolvedPath = "/v20180820/accesspoint/{Name}";
   if (input.Name !== undefined) {
-    const labelValue: string = input.Name.toString();
+    const labelValue: string = input.Name;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Name.");
     }
     resolvedPath = resolvedPath.replace(
       "{Name}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Name.");
@@ -293,17 +296,17 @@ export async function serializeAws_restXmlDeleteAccessPointPolicyCommand(
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.AccountId !== undefined) {
-    headers["x-amz-account-id"] = input.AccountId.toString();
+    headers["x-amz-account-id"] = input.AccountId;
   }
   let resolvedPath = "/v20180820/accesspoint/{Name}/policy";
   if (input.Name !== undefined) {
-    const labelValue: string = input.Name.toString();
+    const labelValue: string = input.Name;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Name.");
     }
     resolvedPath = resolvedPath.replace(
       "{Name}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Name.");
@@ -324,7 +327,7 @@ export async function serializeAws_restXmlDeletePublicAccessBlockCommand(
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.AccountId !== undefined) {
-    headers["x-amz-account-id"] = input.AccountId.toString();
+    headers["x-amz-account-id"] = input.AccountId;
   }
   let resolvedPath = "/v20180820/configuration/publicAccessBlock";
   return new __HttpRequest({
@@ -343,17 +346,17 @@ export async function serializeAws_restXmlDescribeJobCommand(
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.AccountId !== undefined) {
-    headers["x-amz-account-id"] = input.AccountId.toString();
+    headers["x-amz-account-id"] = input.AccountId;
   }
   let resolvedPath = "/v20180820/jobs/{JobId}";
   if (input.JobId !== undefined) {
-    const labelValue: string = input.JobId.toString();
+    const labelValue: string = input.JobId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: JobId.");
     }
     resolvedPath = resolvedPath.replace(
       "{JobId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: JobId.");
@@ -374,17 +377,17 @@ export async function serializeAws_restXmlGetAccessPointCommand(
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.AccountId !== undefined) {
-    headers["x-amz-account-id"] = input.AccountId.toString();
+    headers["x-amz-account-id"] = input.AccountId;
   }
   let resolvedPath = "/v20180820/accesspoint/{Name}";
   if (input.Name !== undefined) {
-    const labelValue: string = input.Name.toString();
+    const labelValue: string = input.Name;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Name.");
     }
     resolvedPath = resolvedPath.replace(
       "{Name}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Name.");
@@ -405,17 +408,17 @@ export async function serializeAws_restXmlGetAccessPointPolicyCommand(
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.AccountId !== undefined) {
-    headers["x-amz-account-id"] = input.AccountId.toString();
+    headers["x-amz-account-id"] = input.AccountId;
   }
   let resolvedPath = "/v20180820/accesspoint/{Name}/policy";
   if (input.Name !== undefined) {
-    const labelValue: string = input.Name.toString();
+    const labelValue: string = input.Name;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Name.");
     }
     resolvedPath = resolvedPath.replace(
       "{Name}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Name.");
@@ -436,17 +439,17 @@ export async function serializeAws_restXmlGetAccessPointPolicyStatusCommand(
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.AccountId !== undefined) {
-    headers["x-amz-account-id"] = input.AccountId.toString();
+    headers["x-amz-account-id"] = input.AccountId;
   }
   let resolvedPath = "/v20180820/accesspoint/{Name}/policyStatus";
   if (input.Name !== undefined) {
-    const labelValue: string = input.Name.toString();
+    const labelValue: string = input.Name;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Name.");
     }
     resolvedPath = resolvedPath.replace(
       "{Name}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Name.");
@@ -467,7 +470,7 @@ export async function serializeAws_restXmlGetPublicAccessBlockCommand(
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.AccountId !== undefined) {
-    headers["x-amz-account-id"] = input.AccountId.toString();
+    headers["x-amz-account-id"] = input.AccountId;
   }
   let resolvedPath = "/v20180820/configuration/publicAccessBlock";
   return new __HttpRequest({
@@ -486,18 +489,24 @@ export async function serializeAws_restXmlListAccessPointsCommand(
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.AccountId !== undefined) {
-    headers["x-amz-account-id"] = input.AccountId.toString();
+    headers["x-amz-account-id"] = input.AccountId;
   }
   let resolvedPath = "/v20180820/accesspoint";
   const query: any = {};
   if (input.Bucket !== undefined) {
-    query["bucket"] = input.Bucket.toString();
+    query[
+      __extendedEncodeURIComponent("bucket")
+    ] = __extendedEncodeURIComponent(input.Bucket);
   }
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -516,18 +525,24 @@ export async function serializeAws_restXmlListJobsCommand(
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.AccountId !== undefined) {
-    headers["x-amz-account-id"] = input.AccountId.toString();
+    headers["x-amz-account-id"] = input.AccountId;
   }
   let resolvedPath = "/v20180820/jobs";
   const query: any = {};
   if (input.JobStatuses !== undefined) {
-    query["jobStatuses"] = input.JobStatuses;
+    query[
+      __extendedEncodeURIComponent("jobStatuses")
+    ] = input.JobStatuses.map(entry => __extendedEncodeURIComponent(entry));
   }
   if (input.MaxResults !== undefined) {
-    query["maxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -546,17 +561,17 @@ export async function serializeAws_restXmlPutAccessPointPolicyCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/xml";
   if (input.AccountId !== undefined) {
-    headers["x-amz-account-id"] = input.AccountId.toString();
+    headers["x-amz-account-id"] = input.AccountId;
   }
   let resolvedPath = "/v20180820/accesspoint/{Name}/policy";
   if (input.Name !== undefined) {
-    const labelValue: string = input.Name.toString();
+    const labelValue: string = input.Name;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Name.");
     }
     resolvedPath = resolvedPath.replace(
       "{Name}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Name.");
@@ -592,7 +607,7 @@ export async function serializeAws_restXmlPutPublicAccessBlockCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/xml";
   if (input.AccountId !== undefined) {
-    headers["x-amz-account-id"] = input.AccountId.toString();
+    headers["x-amz-account-id"] = input.AccountId;
   }
   let resolvedPath = "/v20180820/configuration/publicAccessBlock";
   let body: any;
@@ -626,24 +641,26 @@ export async function serializeAws_restXmlUpdateJobPriorityCommand(
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.AccountId !== undefined) {
-    headers["x-amz-account-id"] = input.AccountId.toString();
+    headers["x-amz-account-id"] = input.AccountId;
   }
   let resolvedPath = "/v20180820/jobs/{JobId}/priority";
   if (input.JobId !== undefined) {
-    const labelValue: string = input.JobId.toString();
+    const labelValue: string = input.JobId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: JobId.");
     }
     resolvedPath = resolvedPath.replace(
       "{JobId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: JobId.");
   }
   const query: any = {};
   if (input.Priority !== undefined) {
-    query["priority"] = input.Priority.toString();
+    query[
+      __extendedEncodeURIComponent("priority")
+    ] = __extendedEncodeURIComponent(input.Priority.toString());
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -662,27 +679,31 @@ export async function serializeAws_restXmlUpdateJobStatusCommand(
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.AccountId !== undefined) {
-    headers["x-amz-account-id"] = input.AccountId.toString();
+    headers["x-amz-account-id"] = input.AccountId;
   }
   let resolvedPath = "/v20180820/jobs/{JobId}/status";
   if (input.JobId !== undefined) {
-    const labelValue: string = input.JobId.toString();
+    const labelValue: string = input.JobId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: JobId.");
     }
     resolvedPath = resolvedPath.replace(
       "{JobId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: JobId.");
   }
   const query: any = {};
   if (input.RequestedJobStatus !== undefined) {
-    query["requestedJobStatus"] = input.RequestedJobStatus.toString();
+    query[
+      __extendedEncodeURIComponent("requestedJobStatus")
+    ] = __extendedEncodeURIComponent(input.RequestedJobStatus);
   }
   if (input.StatusUpdateReason !== undefined) {
-    query["statusUpdateReason"] = input.StatusUpdateReason.toString();
+    query[
+      __extendedEncodeURIComponent("statusUpdateReason")
+    ] = __extendedEncodeURIComponent(input.StatusUpdateReason);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -704,6 +725,7 @@ export async function deserializeAws_restXmlCreateAccessPointCommand(
   const contents: CreateAccessPointCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -824,6 +846,7 @@ export async function deserializeAws_restXmlDeleteAccessPointCommand(
   const contents: DeleteAccessPointCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -870,6 +893,7 @@ export async function deserializeAws_restXmlDeleteAccessPointPolicyCommand(
   const contents: DeleteAccessPointPolicyCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -916,6 +940,7 @@ export async function deserializeAws_restXmlDeletePublicAccessBlockCommand(
   const contents: DeletePublicAccessBlockCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -1433,6 +1458,7 @@ export async function deserializeAws_restXmlPutAccessPointPolicyCommand(
   const contents: PutAccessPointPolicyCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -1479,6 +1505,7 @@ export async function deserializeAws_restXmlPutPublicAccessBlockCommand(
   const contents: PutPublicAccessBlockCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 

--- a/clients/client-s3/models/index.ts
+++ b/clients/client-s3/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -16,7 +19,7 @@ export interface AbortIncompleteMultipartUpload {
 
 export namespace AbortIncompleteMultipartUpload {
   export function isa(o: any): o is AbortIncompleteMultipartUpload {
-    return _smithy.isa(o, "AbortIncompleteMultipartUpload");
+    return __isa(o, "AbortIncompleteMultipartUpload");
   }
 }
 
@@ -30,7 +33,7 @@ export interface AbortMultipartUploadOutput extends $MetadataBearer {
 
 export namespace AbortMultipartUploadOutput {
   export function isa(o: any): o is AbortMultipartUploadOutput {
-    return _smithy.isa(o, "AbortMultipartUploadOutput");
+    return __isa(o, "AbortMultipartUploadOutput");
   }
 }
 
@@ -63,7 +66,7 @@ export interface AbortMultipartUploadRequest {
 
 export namespace AbortMultipartUploadRequest {
   export function isa(o: any): o is AbortMultipartUploadRequest {
-    return _smithy.isa(o, "AbortMultipartUploadRequest");
+    return __isa(o, "AbortMultipartUploadRequest");
   }
 }
 
@@ -82,7 +85,7 @@ export interface AccelerateConfiguration {
 
 export namespace AccelerateConfiguration {
   export function isa(o: any): o is AccelerateConfiguration {
-    return _smithy.isa(o, "AccelerateConfiguration");
+    return __isa(o, "AccelerateConfiguration");
   }
 }
 
@@ -104,7 +107,7 @@ export interface AccessControlPolicy {
 
 export namespace AccessControlPolicy {
   export function isa(o: any): o is AccessControlPolicy {
-    return _smithy.isa(o, "AccessControlPolicy");
+    return __isa(o, "AccessControlPolicy");
   }
 }
 
@@ -122,7 +125,7 @@ export interface AccessControlTranslation {
 
 export namespace AccessControlTranslation {
   export function isa(o: any): o is AccessControlTranslation {
-    return _smithy.isa(o, "AccessControlTranslation");
+    return __isa(o, "AccessControlTranslation");
   }
 }
 
@@ -144,7 +147,7 @@ export interface AnalyticsAndOperator {
 
 export namespace AnalyticsAndOperator {
   export function isa(o: any): o is AnalyticsAndOperator {
-    return _smithy.isa(o, "AnalyticsAndOperator");
+    return __isa(o, "AnalyticsAndOperator");
   }
 }
 
@@ -174,7 +177,7 @@ export interface AnalyticsConfiguration {
 
 export namespace AnalyticsConfiguration {
   export function isa(o: any): o is AnalyticsConfiguration {
-    return _smithy.isa(o, "AnalyticsConfiguration");
+    return __isa(o, "AnalyticsConfiguration");
   }
 }
 
@@ -191,7 +194,7 @@ export interface AnalyticsExportDestination {
 
 export namespace AnalyticsExportDestination {
   export function isa(o: any): o is AnalyticsExportDestination {
-    return _smithy.isa(o, "AnalyticsExportDestination");
+    return __isa(o, "AnalyticsExportDestination");
   }
 }
 
@@ -218,7 +221,7 @@ export interface AnalyticsFilter {
 
 export namespace AnalyticsFilter {
   export function isa(o: any): o is AnalyticsFilter {
-    return _smithy.isa(o, "AnalyticsFilter");
+    return __isa(o, "AnalyticsFilter");
   }
 }
 
@@ -250,7 +253,7 @@ export interface AnalyticsS3BucketDestination {
 
 export namespace AnalyticsS3BucketDestination {
   export function isa(o: any): o is AnalyticsS3BucketDestination {
-    return _smithy.isa(o, "AnalyticsS3BucketDestination");
+    return __isa(o, "AnalyticsS3BucketDestination");
   }
 }
 
@@ -275,7 +278,7 @@ export interface Bucket {
 
 export namespace Bucket {
   export function isa(o: any): o is Bucket {
-    return _smithy.isa(o, "Bucket");
+    return __isa(o, "Bucket");
   }
 }
 
@@ -285,7 +288,7 @@ export type BucketAccelerateStatus = "Enabled" | "Suspended";
  * <p>The requested bucket name is not available. The bucket namespace is shared by all users of the system. Please select a different name and try again.</p>
  */
 export interface BucketAlreadyExists
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "BucketAlreadyExists";
   $fault: "client";
@@ -293,7 +296,7 @@ export interface BucketAlreadyExists
 
 export namespace BucketAlreadyExists {
   export function isa(o: any): o is BucketAlreadyExists {
-    return _smithy.isa(o, "BucketAlreadyExists");
+    return __isa(o, "BucketAlreadyExists");
   }
 }
 
@@ -304,7 +307,7 @@ export namespace BucketAlreadyExists {
  *          returns 200 OK and resets the bucket access control lists (ACLs).</p>
  */
 export interface BucketAlreadyOwnedByYou
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "BucketAlreadyOwnedByYou";
   $fault: "client";
@@ -312,7 +315,7 @@ export interface BucketAlreadyOwnedByYou
 
 export namespace BucketAlreadyOwnedByYou {
   export function isa(o: any): o is BucketAlreadyOwnedByYou {
-    return _smithy.isa(o, "BucketAlreadyOwnedByYou");
+    return __isa(o, "BucketAlreadyOwnedByYou");
   }
 }
 
@@ -337,7 +340,7 @@ export interface BucketLifecycleConfiguration {
 
 export namespace BucketLifecycleConfiguration {
   export function isa(o: any): o is BucketLifecycleConfiguration {
-    return _smithy.isa(o, "BucketLifecycleConfiguration");
+    return __isa(o, "BucketLifecycleConfiguration");
   }
 }
 
@@ -369,7 +372,7 @@ export interface BucketLoggingStatus {
 
 export namespace BucketLoggingStatus {
   export function isa(o: any): o is BucketLoggingStatus {
-    return _smithy.isa(o, "BucketLoggingStatus");
+    return __isa(o, "BucketLoggingStatus");
   }
 }
 
@@ -392,7 +395,7 @@ export interface CORSConfiguration {
 
 export namespace CORSConfiguration {
   export function isa(o: any): o is CORSConfiguration {
-    return _smithy.isa(o, "CORSConfiguration");
+    return __isa(o, "CORSConfiguration");
   }
 }
 
@@ -434,7 +437,7 @@ export interface CORSRule {
 
 export namespace CORSRule {
   export function isa(o: any): o is CORSRule {
-    return _smithy.isa(o, "CORSRule");
+    return __isa(o, "CORSRule");
   }
 }
 
@@ -509,7 +512,7 @@ export interface CSVInput {
 
 export namespace CSVInput {
   export function isa(o: any): o is CSVInput {
-    return _smithy.isa(o, "CSVInput");
+    return __isa(o, "CSVInput");
   }
 }
 
@@ -559,7 +562,7 @@ export interface CSVOutput {
 
 export namespace CSVOutput {
   export function isa(o: any): o is CSVOutput {
-    return _smithy.isa(o, "CSVOutput");
+    return __isa(o, "CSVOutput");
   }
 }
 
@@ -580,7 +583,7 @@ export interface CommonPrefix {
 
 export namespace CommonPrefix {
   export function isa(o: any): o is CommonPrefix {
-    return _smithy.isa(o, "CommonPrefix");
+    return __isa(o, "CommonPrefix");
   }
 }
 
@@ -635,7 +638,7 @@ export interface CompleteMultipartUploadOutput extends $MetadataBearer {
 
 export namespace CompleteMultipartUploadOutput {
   export function isa(o: any): o is CompleteMultipartUploadOutput {
-    return _smithy.isa(o, "CompleteMultipartUploadOutput");
+    return __isa(o, "CompleteMultipartUploadOutput");
   }
 }
 
@@ -672,7 +675,7 @@ export interface CompleteMultipartUploadRequest {
 
 export namespace CompleteMultipartUploadRequest {
   export function isa(o: any): o is CompleteMultipartUploadRequest {
-    return _smithy.isa(o, "CompleteMultipartUploadRequest");
+    return __isa(o, "CompleteMultipartUploadRequest");
   }
 }
 
@@ -689,7 +692,7 @@ export interface CompletedMultipartUpload {
 
 export namespace CompletedMultipartUpload {
   export function isa(o: any): o is CompletedMultipartUpload {
-    return _smithy.isa(o, "CompletedMultipartUpload");
+    return __isa(o, "CompletedMultipartUpload");
   }
 }
 
@@ -711,7 +714,7 @@ export interface CompletedPart {
 
 export namespace CompletedPart {
   export function isa(o: any): o is CompletedPart {
-    return _smithy.isa(o, "CompletedPart");
+    return __isa(o, "CompletedPart");
   }
 }
 
@@ -741,7 +744,7 @@ export interface Condition {
 
 export namespace Condition {
   export function isa(o: any): o is Condition {
-    return _smithy.isa(o, "Condition");
+    return __isa(o, "Condition");
   }
 }
 
@@ -754,7 +757,7 @@ export interface ContinuationEvent {
 
 export namespace ContinuationEvent {
   export function isa(o: any): o is ContinuationEvent {
-    return _smithy.isa(o, "ContinuationEvent");
+    return __isa(o, "ContinuationEvent");
   }
 }
 
@@ -817,7 +820,7 @@ export interface CopyObjectOutput extends $MetadataBearer {
 
 export namespace CopyObjectOutput {
   export function isa(o: any): o is CopyObjectOutput {
-    return _smithy.isa(o, "CopyObjectOutput");
+    return __isa(o, "CopyObjectOutput");
   }
 }
 
@@ -1027,7 +1030,7 @@ export interface CopyObjectRequest {
 
 export namespace CopyObjectRequest {
   export function isa(o: any): o is CopyObjectRequest {
-    return _smithy.isa(o, "CopyObjectRequest");
+    return __isa(o, "CopyObjectRequest");
   }
 }
 
@@ -1049,7 +1052,7 @@ export interface CopyObjectResult {
 
 export namespace CopyObjectResult {
   export function isa(o: any): o is CopyObjectResult {
-    return _smithy.isa(o, "CopyObjectResult");
+    return __isa(o, "CopyObjectResult");
   }
 }
 
@@ -1071,7 +1074,7 @@ export interface CopyPartResult {
 
 export namespace CopyPartResult {
   export function isa(o: any): o is CopyPartResult {
-    return _smithy.isa(o, "CopyPartResult");
+    return __isa(o, "CopyPartResult");
   }
 }
 
@@ -1089,7 +1092,7 @@ export interface CreateBucketConfiguration {
 
 export namespace CreateBucketConfiguration {
   export function isa(o: any): o is CreateBucketConfiguration {
-    return _smithy.isa(o, "CreateBucketConfiguration");
+    return __isa(o, "CreateBucketConfiguration");
   }
 }
 
@@ -1105,7 +1108,7 @@ export interface CreateBucketOutput extends $MetadataBearer {
 
 export namespace CreateBucketOutput {
   export function isa(o: any): o is CreateBucketOutput {
-    return _smithy.isa(o, "CreateBucketOutput");
+    return __isa(o, "CreateBucketOutput");
   }
 }
 
@@ -1159,7 +1162,7 @@ export interface CreateBucketRequest {
 
 export namespace CreateBucketRequest {
   export function isa(o: any): o is CreateBucketRequest {
-    return _smithy.isa(o, "CreateBucketRequest");
+    return __isa(o, "CreateBucketRequest");
   }
 }
 
@@ -1234,7 +1237,7 @@ export interface CreateMultipartUploadOutput extends $MetadataBearer {
 
 export namespace CreateMultipartUploadOutput {
   export function isa(o: any): o is CreateMultipartUploadOutput {
-    return _smithy.isa(o, "CreateMultipartUploadOutput");
+    return __isa(o, "CreateMultipartUploadOutput");
   }
 }
 
@@ -1390,7 +1393,7 @@ export interface CreateMultipartUploadRequest {
 
 export namespace CreateMultipartUploadRequest {
   export function isa(o: any): o is CreateMultipartUploadRequest {
-    return _smithy.isa(o, "CreateMultipartUploadRequest");
+    return __isa(o, "CreateMultipartUploadRequest");
   }
 }
 
@@ -1417,7 +1420,7 @@ export interface DefaultRetention {
 
 export namespace DefaultRetention {
   export function isa(o: any): o is DefaultRetention {
-    return _smithy.isa(o, "DefaultRetention");
+    return __isa(o, "DefaultRetention");
   }
 }
 
@@ -1439,7 +1442,7 @@ export interface Delete {
 
 export namespace Delete {
   export function isa(o: any): o is Delete {
-    return _smithy.isa(o, "Delete");
+    return __isa(o, "Delete");
   }
 }
 
@@ -1458,7 +1461,7 @@ export interface DeleteBucketAnalyticsConfigurationRequest {
 
 export namespace DeleteBucketAnalyticsConfigurationRequest {
   export function isa(o: any): o is DeleteBucketAnalyticsConfigurationRequest {
-    return _smithy.isa(o, "DeleteBucketAnalyticsConfigurationRequest");
+    return __isa(o, "DeleteBucketAnalyticsConfigurationRequest");
   }
 }
 
@@ -1472,7 +1475,7 @@ export interface DeleteBucketCorsRequest {
 
 export namespace DeleteBucketCorsRequest {
   export function isa(o: any): o is DeleteBucketCorsRequest {
-    return _smithy.isa(o, "DeleteBucketCorsRequest");
+    return __isa(o, "DeleteBucketCorsRequest");
   }
 }
 
@@ -1486,7 +1489,7 @@ export interface DeleteBucketEncryptionRequest {
 
 export namespace DeleteBucketEncryptionRequest {
   export function isa(o: any): o is DeleteBucketEncryptionRequest {
-    return _smithy.isa(o, "DeleteBucketEncryptionRequest");
+    return __isa(o, "DeleteBucketEncryptionRequest");
   }
 }
 
@@ -1505,7 +1508,7 @@ export interface DeleteBucketInventoryConfigurationRequest {
 
 export namespace DeleteBucketInventoryConfigurationRequest {
   export function isa(o: any): o is DeleteBucketInventoryConfigurationRequest {
-    return _smithy.isa(o, "DeleteBucketInventoryConfigurationRequest");
+    return __isa(o, "DeleteBucketInventoryConfigurationRequest");
   }
 }
 
@@ -1519,7 +1522,7 @@ export interface DeleteBucketLifecycleRequest {
 
 export namespace DeleteBucketLifecycleRequest {
   export function isa(o: any): o is DeleteBucketLifecycleRequest {
-    return _smithy.isa(o, "DeleteBucketLifecycleRequest");
+    return __isa(o, "DeleteBucketLifecycleRequest");
   }
 }
 
@@ -1538,7 +1541,7 @@ export interface DeleteBucketMetricsConfigurationRequest {
 
 export namespace DeleteBucketMetricsConfigurationRequest {
   export function isa(o: any): o is DeleteBucketMetricsConfigurationRequest {
-    return _smithy.isa(o, "DeleteBucketMetricsConfigurationRequest");
+    return __isa(o, "DeleteBucketMetricsConfigurationRequest");
   }
 }
 
@@ -1552,7 +1555,7 @@ export interface DeleteBucketPolicyRequest {
 
 export namespace DeleteBucketPolicyRequest {
   export function isa(o: any): o is DeleteBucketPolicyRequest {
-    return _smithy.isa(o, "DeleteBucketPolicyRequest");
+    return __isa(o, "DeleteBucketPolicyRequest");
   }
 }
 
@@ -1568,7 +1571,7 @@ export interface DeleteBucketReplicationRequest {
 
 export namespace DeleteBucketReplicationRequest {
   export function isa(o: any): o is DeleteBucketReplicationRequest {
-    return _smithy.isa(o, "DeleteBucketReplicationRequest");
+    return __isa(o, "DeleteBucketReplicationRequest");
   }
 }
 
@@ -1582,7 +1585,7 @@ export interface DeleteBucketRequest {
 
 export namespace DeleteBucketRequest {
   export function isa(o: any): o is DeleteBucketRequest {
-    return _smithy.isa(o, "DeleteBucketRequest");
+    return __isa(o, "DeleteBucketRequest");
   }
 }
 
@@ -1596,7 +1599,7 @@ export interface DeleteBucketTaggingRequest {
 
 export namespace DeleteBucketTaggingRequest {
   export function isa(o: any): o is DeleteBucketTaggingRequest {
-    return _smithy.isa(o, "DeleteBucketTaggingRequest");
+    return __isa(o, "DeleteBucketTaggingRequest");
   }
 }
 
@@ -1610,7 +1613,7 @@ export interface DeleteBucketWebsiteRequest {
 
 export namespace DeleteBucketWebsiteRequest {
   export function isa(o: any): o is DeleteBucketWebsiteRequest {
-    return _smithy.isa(o, "DeleteBucketWebsiteRequest");
+    return __isa(o, "DeleteBucketWebsiteRequest");
   }
 }
 
@@ -1647,7 +1650,7 @@ export interface DeleteMarkerEntry {
 
 export namespace DeleteMarkerEntry {
   export function isa(o: any): o is DeleteMarkerEntry {
-    return _smithy.isa(o, "DeleteMarkerEntry");
+    return __isa(o, "DeleteMarkerEntry");
   }
 }
 
@@ -1675,7 +1678,7 @@ export interface DeleteMarkerReplication {
 
 export namespace DeleteMarkerReplication {
   export function isa(o: any): o is DeleteMarkerReplication {
-    return _smithy.isa(o, "DeleteMarkerReplication");
+    return __isa(o, "DeleteMarkerReplication");
   }
 }
 
@@ -1701,7 +1704,7 @@ export interface DeleteObjectOutput extends $MetadataBearer {
 
 export namespace DeleteObjectOutput {
   export function isa(o: any): o is DeleteObjectOutput {
-    return _smithy.isa(o, "DeleteObjectOutput");
+    return __isa(o, "DeleteObjectOutput");
   }
 }
 
@@ -1746,7 +1749,7 @@ export interface DeleteObjectRequest {
 
 export namespace DeleteObjectRequest {
   export function isa(o: any): o is DeleteObjectRequest {
-    return _smithy.isa(o, "DeleteObjectRequest");
+    return __isa(o, "DeleteObjectRequest");
   }
 }
 
@@ -1760,7 +1763,7 @@ export interface DeleteObjectTaggingOutput extends $MetadataBearer {
 
 export namespace DeleteObjectTaggingOutput {
   export function isa(o: any): o is DeleteObjectTaggingOutput {
-    return _smithy.isa(o, "DeleteObjectTaggingOutput");
+    return __isa(o, "DeleteObjectTaggingOutput");
   }
 }
 
@@ -1785,7 +1788,7 @@ export interface DeleteObjectTaggingRequest {
 
 export namespace DeleteObjectTaggingRequest {
   export function isa(o: any): o is DeleteObjectTaggingRequest {
-    return _smithy.isa(o, "DeleteObjectTaggingRequest");
+    return __isa(o, "DeleteObjectTaggingRequest");
   }
 }
 
@@ -1809,7 +1812,7 @@ export interface DeleteObjectsOutput extends $MetadataBearer {
 
 export namespace DeleteObjectsOutput {
   export function isa(o: any): o is DeleteObjectsOutput {
-    return _smithy.isa(o, "DeleteObjectsOutput");
+    return __isa(o, "DeleteObjectsOutput");
   }
 }
 
@@ -1849,7 +1852,7 @@ export interface DeleteObjectsRequest {
 
 export namespace DeleteObjectsRequest {
   export function isa(o: any): o is DeleteObjectsRequest {
-    return _smithy.isa(o, "DeleteObjectsRequest");
+    return __isa(o, "DeleteObjectsRequest");
   }
 }
 
@@ -1864,7 +1867,7 @@ export interface DeletePublicAccessBlockRequest {
 
 export namespace DeletePublicAccessBlockRequest {
   export function isa(o: any): o is DeletePublicAccessBlockRequest {
-    return _smithy.isa(o, "DeletePublicAccessBlockRequest");
+    return __isa(o, "DeletePublicAccessBlockRequest");
   }
 }
 
@@ -1896,7 +1899,7 @@ export interface DeletedObject {
 
 export namespace DeletedObject {
   export function isa(o: any): o is DeletedObject {
-    return _smithy.isa(o, "DeletedObject");
+    return __isa(o, "DeletedObject");
   }
 }
 
@@ -1961,7 +1964,7 @@ export interface Destination {
 
 export namespace Destination {
   export function isa(o: any): o is Destination {
-    return _smithy.isa(o, "Destination");
+    return __isa(o, "Destination");
   }
 }
 
@@ -1993,7 +1996,7 @@ export interface Encryption {
 
 export namespace Encryption {
   export function isa(o: any): o is Encryption {
-    return _smithy.isa(o, "Encryption");
+    return __isa(o, "Encryption");
   }
 }
 
@@ -2011,7 +2014,7 @@ export interface EncryptionConfiguration {
 
 export namespace EncryptionConfiguration {
   export function isa(o: any): o is EncryptionConfiguration {
-    return _smithy.isa(o, "EncryptionConfiguration");
+    return __isa(o, "EncryptionConfiguration");
   }
 }
 
@@ -2024,7 +2027,7 @@ export interface EndEvent {
 
 export namespace EndEvent {
   export function isa(o: any): o is EndEvent {
-    return _smithy.isa(o, "EndEvent");
+    return __isa(o, "EndEvent");
   }
 }
 
@@ -3872,7 +3875,7 @@ export interface _Error {
 
 export namespace _Error {
   export function isa(o: any): o is _Error {
-    return _smithy.isa(o, "Error");
+    return __isa(o, "Error");
   }
 }
 
@@ -3889,7 +3892,7 @@ export interface ErrorDocument {
 
 export namespace ErrorDocument {
   export function isa(o: any): o is ErrorDocument {
-    return _smithy.isa(o, "ErrorDocument");
+    return __isa(o, "ErrorDocument");
   }
 }
 
@@ -3927,7 +3930,7 @@ export interface ExistingObjectReplication {
 
 export namespace ExistingObjectReplication {
   export function isa(o: any): o is ExistingObjectReplication {
-    return _smithy.isa(o, "ExistingObjectReplication");
+    return __isa(o, "ExistingObjectReplication");
   }
 }
 
@@ -3966,7 +3969,7 @@ export interface FilterRule {
 
 export namespace FilterRule {
   export function isa(o: any): o is FilterRule {
-    return _smithy.isa(o, "FilterRule");
+    return __isa(o, "FilterRule");
   }
 }
 
@@ -3983,7 +3986,7 @@ export interface GetBucketAccelerateConfigurationOutput
 
 export namespace GetBucketAccelerateConfigurationOutput {
   export function isa(o: any): o is GetBucketAccelerateConfigurationOutput {
-    return _smithy.isa(o, "GetBucketAccelerateConfigurationOutput");
+    return __isa(o, "GetBucketAccelerateConfigurationOutput");
   }
 }
 
@@ -3997,7 +4000,7 @@ export interface GetBucketAccelerateConfigurationRequest {
 
 export namespace GetBucketAccelerateConfigurationRequest {
   export function isa(o: any): o is GetBucketAccelerateConfigurationRequest {
-    return _smithy.isa(o, "GetBucketAccelerateConfigurationRequest");
+    return __isa(o, "GetBucketAccelerateConfigurationRequest");
   }
 }
 
@@ -4016,7 +4019,7 @@ export interface GetBucketAclOutput extends $MetadataBearer {
 
 export namespace GetBucketAclOutput {
   export function isa(o: any): o is GetBucketAclOutput {
-    return _smithy.isa(o, "GetBucketAclOutput");
+    return __isa(o, "GetBucketAclOutput");
   }
 }
 
@@ -4030,7 +4033,7 @@ export interface GetBucketAclRequest {
 
 export namespace GetBucketAclRequest {
   export function isa(o: any): o is GetBucketAclRequest {
-    return _smithy.isa(o, "GetBucketAclRequest");
+    return __isa(o, "GetBucketAclRequest");
   }
 }
 
@@ -4044,7 +4047,7 @@ export interface GetBucketAnalyticsConfigurationOutput extends $MetadataBearer {
 
 export namespace GetBucketAnalyticsConfigurationOutput {
   export function isa(o: any): o is GetBucketAnalyticsConfigurationOutput {
-    return _smithy.isa(o, "GetBucketAnalyticsConfigurationOutput");
+    return __isa(o, "GetBucketAnalyticsConfigurationOutput");
   }
 }
 
@@ -4063,7 +4066,7 @@ export interface GetBucketAnalyticsConfigurationRequest {
 
 export namespace GetBucketAnalyticsConfigurationRequest {
   export function isa(o: any): o is GetBucketAnalyticsConfigurationRequest {
-    return _smithy.isa(o, "GetBucketAnalyticsConfigurationRequest");
+    return __isa(o, "GetBucketAnalyticsConfigurationRequest");
   }
 }
 
@@ -4077,7 +4080,7 @@ export interface GetBucketCorsOutput extends $MetadataBearer {
 
 export namespace GetBucketCorsOutput {
   export function isa(o: any): o is GetBucketCorsOutput {
-    return _smithy.isa(o, "GetBucketCorsOutput");
+    return __isa(o, "GetBucketCorsOutput");
   }
 }
 
@@ -4091,7 +4094,7 @@ export interface GetBucketCorsRequest {
 
 export namespace GetBucketCorsRequest {
   export function isa(o: any): o is GetBucketCorsRequest {
-    return _smithy.isa(o, "GetBucketCorsRequest");
+    return __isa(o, "GetBucketCorsRequest");
   }
 }
 
@@ -4105,7 +4108,7 @@ export interface GetBucketEncryptionOutput extends $MetadataBearer {
 
 export namespace GetBucketEncryptionOutput {
   export function isa(o: any): o is GetBucketEncryptionOutput {
-    return _smithy.isa(o, "GetBucketEncryptionOutput");
+    return __isa(o, "GetBucketEncryptionOutput");
   }
 }
 
@@ -4119,7 +4122,7 @@ export interface GetBucketEncryptionRequest {
 
 export namespace GetBucketEncryptionRequest {
   export function isa(o: any): o is GetBucketEncryptionRequest {
-    return _smithy.isa(o, "GetBucketEncryptionRequest");
+    return __isa(o, "GetBucketEncryptionRequest");
   }
 }
 
@@ -4133,7 +4136,7 @@ export interface GetBucketInventoryConfigurationOutput extends $MetadataBearer {
 
 export namespace GetBucketInventoryConfigurationOutput {
   export function isa(o: any): o is GetBucketInventoryConfigurationOutput {
-    return _smithy.isa(o, "GetBucketInventoryConfigurationOutput");
+    return __isa(o, "GetBucketInventoryConfigurationOutput");
   }
 }
 
@@ -4152,7 +4155,7 @@ export interface GetBucketInventoryConfigurationRequest {
 
 export namespace GetBucketInventoryConfigurationRequest {
   export function isa(o: any): o is GetBucketInventoryConfigurationRequest {
-    return _smithy.isa(o, "GetBucketInventoryConfigurationRequest");
+    return __isa(o, "GetBucketInventoryConfigurationRequest");
   }
 }
 
@@ -4166,7 +4169,7 @@ export interface GetBucketLifecycleConfigurationOutput extends $MetadataBearer {
 
 export namespace GetBucketLifecycleConfigurationOutput {
   export function isa(o: any): o is GetBucketLifecycleConfigurationOutput {
-    return _smithy.isa(o, "GetBucketLifecycleConfigurationOutput");
+    return __isa(o, "GetBucketLifecycleConfigurationOutput");
   }
 }
 
@@ -4180,7 +4183,7 @@ export interface GetBucketLifecycleConfigurationRequest {
 
 export namespace GetBucketLifecycleConfigurationRequest {
   export function isa(o: any): o is GetBucketLifecycleConfigurationRequest {
-    return _smithy.isa(o, "GetBucketLifecycleConfigurationRequest");
+    return __isa(o, "GetBucketLifecycleConfigurationRequest");
   }
 }
 
@@ -4196,7 +4199,7 @@ export interface GetBucketLocationOutput extends $MetadataBearer {
 
 export namespace GetBucketLocationOutput {
   export function isa(o: any): o is GetBucketLocationOutput {
-    return _smithy.isa(o, "GetBucketLocationOutput");
+    return __isa(o, "GetBucketLocationOutput");
   }
 }
 
@@ -4210,7 +4213,7 @@ export interface GetBucketLocationRequest {
 
 export namespace GetBucketLocationRequest {
   export function isa(o: any): o is GetBucketLocationRequest {
-    return _smithy.isa(o, "GetBucketLocationRequest");
+    return __isa(o, "GetBucketLocationRequest");
   }
 }
 
@@ -4226,7 +4229,7 @@ export interface GetBucketLoggingOutput extends $MetadataBearer {
 
 export namespace GetBucketLoggingOutput {
   export function isa(o: any): o is GetBucketLoggingOutput {
-    return _smithy.isa(o, "GetBucketLoggingOutput");
+    return __isa(o, "GetBucketLoggingOutput");
   }
 }
 
@@ -4240,7 +4243,7 @@ export interface GetBucketLoggingRequest {
 
 export namespace GetBucketLoggingRequest {
   export function isa(o: any): o is GetBucketLoggingRequest {
-    return _smithy.isa(o, "GetBucketLoggingRequest");
+    return __isa(o, "GetBucketLoggingRequest");
   }
 }
 
@@ -4254,7 +4257,7 @@ export interface GetBucketMetricsConfigurationOutput extends $MetadataBearer {
 
 export namespace GetBucketMetricsConfigurationOutput {
   export function isa(o: any): o is GetBucketMetricsConfigurationOutput {
-    return _smithy.isa(o, "GetBucketMetricsConfigurationOutput");
+    return __isa(o, "GetBucketMetricsConfigurationOutput");
   }
 }
 
@@ -4273,7 +4276,7 @@ export interface GetBucketMetricsConfigurationRequest {
 
 export namespace GetBucketMetricsConfigurationRequest {
   export function isa(o: any): o is GetBucketMetricsConfigurationRequest {
-    return _smithy.isa(o, "GetBucketMetricsConfigurationRequest");
+    return __isa(o, "GetBucketMetricsConfigurationRequest");
   }
 }
 
@@ -4287,7 +4290,7 @@ export interface GetBucketNotificationConfigurationRequest {
 
 export namespace GetBucketNotificationConfigurationRequest {
   export function isa(o: any): o is GetBucketNotificationConfigurationRequest {
-    return _smithy.isa(o, "GetBucketNotificationConfigurationRequest");
+    return __isa(o, "GetBucketNotificationConfigurationRequest");
   }
 }
 
@@ -4301,7 +4304,7 @@ export interface GetBucketPolicyOutput extends $MetadataBearer {
 
 export namespace GetBucketPolicyOutput {
   export function isa(o: any): o is GetBucketPolicyOutput {
-    return _smithy.isa(o, "GetBucketPolicyOutput");
+    return __isa(o, "GetBucketPolicyOutput");
   }
 }
 
@@ -4315,7 +4318,7 @@ export interface GetBucketPolicyRequest {
 
 export namespace GetBucketPolicyRequest {
   export function isa(o: any): o is GetBucketPolicyRequest {
-    return _smithy.isa(o, "GetBucketPolicyRequest");
+    return __isa(o, "GetBucketPolicyRequest");
   }
 }
 
@@ -4329,7 +4332,7 @@ export interface GetBucketPolicyStatusOutput extends $MetadataBearer {
 
 export namespace GetBucketPolicyStatusOutput {
   export function isa(o: any): o is GetBucketPolicyStatusOutput {
-    return _smithy.isa(o, "GetBucketPolicyStatusOutput");
+    return __isa(o, "GetBucketPolicyStatusOutput");
   }
 }
 
@@ -4343,7 +4346,7 @@ export interface GetBucketPolicyStatusRequest {
 
 export namespace GetBucketPolicyStatusRequest {
   export function isa(o: any): o is GetBucketPolicyStatusRequest {
-    return _smithy.isa(o, "GetBucketPolicyStatusRequest");
+    return __isa(o, "GetBucketPolicyStatusRequest");
   }
 }
 
@@ -4358,7 +4361,7 @@ export interface GetBucketReplicationOutput extends $MetadataBearer {
 
 export namespace GetBucketReplicationOutput {
   export function isa(o: any): o is GetBucketReplicationOutput {
-    return _smithy.isa(o, "GetBucketReplicationOutput");
+    return __isa(o, "GetBucketReplicationOutput");
   }
 }
 
@@ -4372,7 +4375,7 @@ export interface GetBucketReplicationRequest {
 
 export namespace GetBucketReplicationRequest {
   export function isa(o: any): o is GetBucketReplicationRequest {
-    return _smithy.isa(o, "GetBucketReplicationRequest");
+    return __isa(o, "GetBucketReplicationRequest");
   }
 }
 
@@ -4386,7 +4389,7 @@ export interface GetBucketRequestPaymentOutput extends $MetadataBearer {
 
 export namespace GetBucketRequestPaymentOutput {
   export function isa(o: any): o is GetBucketRequestPaymentOutput {
-    return _smithy.isa(o, "GetBucketRequestPaymentOutput");
+    return __isa(o, "GetBucketRequestPaymentOutput");
   }
 }
 
@@ -4400,7 +4403,7 @@ export interface GetBucketRequestPaymentRequest {
 
 export namespace GetBucketRequestPaymentRequest {
   export function isa(o: any): o is GetBucketRequestPaymentRequest {
-    return _smithy.isa(o, "GetBucketRequestPaymentRequest");
+    return __isa(o, "GetBucketRequestPaymentRequest");
   }
 }
 
@@ -4414,7 +4417,7 @@ export interface GetBucketTaggingOutput extends $MetadataBearer {
 
 export namespace GetBucketTaggingOutput {
   export function isa(o: any): o is GetBucketTaggingOutput {
-    return _smithy.isa(o, "GetBucketTaggingOutput");
+    return __isa(o, "GetBucketTaggingOutput");
   }
 }
 
@@ -4428,7 +4431,7 @@ export interface GetBucketTaggingRequest {
 
 export namespace GetBucketTaggingRequest {
   export function isa(o: any): o is GetBucketTaggingRequest {
-    return _smithy.isa(o, "GetBucketTaggingRequest");
+    return __isa(o, "GetBucketTaggingRequest");
   }
 }
 
@@ -4447,7 +4450,7 @@ export interface GetBucketVersioningOutput extends $MetadataBearer {
 
 export namespace GetBucketVersioningOutput {
   export function isa(o: any): o is GetBucketVersioningOutput {
-    return _smithy.isa(o, "GetBucketVersioningOutput");
+    return __isa(o, "GetBucketVersioningOutput");
   }
 }
 
@@ -4461,7 +4464,7 @@ export interface GetBucketVersioningRequest {
 
 export namespace GetBucketVersioningRequest {
   export function isa(o: any): o is GetBucketVersioningRequest {
-    return _smithy.isa(o, "GetBucketVersioningRequest");
+    return __isa(o, "GetBucketVersioningRequest");
   }
 }
 
@@ -4490,7 +4493,7 @@ export interface GetBucketWebsiteOutput extends $MetadataBearer {
 
 export namespace GetBucketWebsiteOutput {
   export function isa(o: any): o is GetBucketWebsiteOutput {
-    return _smithy.isa(o, "GetBucketWebsiteOutput");
+    return __isa(o, "GetBucketWebsiteOutput");
   }
 }
 
@@ -4504,7 +4507,7 @@ export interface GetBucketWebsiteRequest {
 
 export namespace GetBucketWebsiteRequest {
   export function isa(o: any): o is GetBucketWebsiteRequest {
-    return _smithy.isa(o, "GetBucketWebsiteRequest");
+    return __isa(o, "GetBucketWebsiteRequest");
   }
 }
 
@@ -4529,7 +4532,7 @@ export interface GetObjectAclOutput extends $MetadataBearer {
 
 export namespace GetObjectAclOutput {
   export function isa(o: any): o is GetObjectAclOutput {
-    return _smithy.isa(o, "GetObjectAclOutput");
+    return __isa(o, "GetObjectAclOutput");
   }
 }
 
@@ -4562,7 +4565,7 @@ export interface GetObjectAclRequest {
 
 export namespace GetObjectAclRequest {
   export function isa(o: any): o is GetObjectAclRequest {
-    return _smithy.isa(o, "GetObjectAclRequest");
+    return __isa(o, "GetObjectAclRequest");
   }
 }
 
@@ -4576,7 +4579,7 @@ export interface GetObjectLegalHoldOutput extends $MetadataBearer {
 
 export namespace GetObjectLegalHoldOutput {
   export function isa(o: any): o is GetObjectLegalHoldOutput {
-    return _smithy.isa(o, "GetObjectLegalHoldOutput");
+    return __isa(o, "GetObjectLegalHoldOutput");
   }
 }
 
@@ -4611,7 +4614,7 @@ export interface GetObjectLegalHoldRequest {
 
 export namespace GetObjectLegalHoldRequest {
   export function isa(o: any): o is GetObjectLegalHoldRequest {
-    return _smithy.isa(o, "GetObjectLegalHoldRequest");
+    return __isa(o, "GetObjectLegalHoldRequest");
   }
 }
 
@@ -4625,7 +4628,7 @@ export interface GetObjectLockConfigurationOutput extends $MetadataBearer {
 
 export namespace GetObjectLockConfigurationOutput {
   export function isa(o: any): o is GetObjectLockConfigurationOutput {
-    return _smithy.isa(o, "GetObjectLockConfigurationOutput");
+    return __isa(o, "GetObjectLockConfigurationOutput");
   }
 }
 
@@ -4639,7 +4642,7 @@ export interface GetObjectLockConfigurationRequest {
 
 export namespace GetObjectLockConfigurationRequest {
   export function isa(o: any): o is GetObjectLockConfigurationRequest {
-    return _smithy.isa(o, "GetObjectLockConfigurationRequest");
+    return __isa(o, "GetObjectLockConfigurationRequest");
   }
 }
 
@@ -4813,7 +4816,7 @@ export interface GetObjectOutput extends $MetadataBearer {
 
 export namespace GetObjectOutput {
   export function isa(o: any): o is GetObjectOutput {
-    return _smithy.isa(o, "GetObjectOutput");
+    return __isa(o, "GetObjectOutput");
   }
 }
 
@@ -4927,7 +4930,7 @@ export interface GetObjectRequest {
 
 export namespace GetObjectRequest {
   export function isa(o: any): o is GetObjectRequest {
-    return _smithy.isa(o, "GetObjectRequest");
+    return __isa(o, "GetObjectRequest");
   }
 }
 
@@ -4941,7 +4944,7 @@ export interface GetObjectRetentionOutput extends $MetadataBearer {
 
 export namespace GetObjectRetentionOutput {
   export function isa(o: any): o is GetObjectRetentionOutput {
-    return _smithy.isa(o, "GetObjectRetentionOutput");
+    return __isa(o, "GetObjectRetentionOutput");
   }
 }
 
@@ -4974,7 +4977,7 @@ export interface GetObjectRetentionRequest {
 
 export namespace GetObjectRetentionRequest {
   export function isa(o: any): o is GetObjectRetentionRequest {
-    return _smithy.isa(o, "GetObjectRetentionRequest");
+    return __isa(o, "GetObjectRetentionRequest");
   }
 }
 
@@ -4993,7 +4996,7 @@ export interface GetObjectTaggingOutput extends $MetadataBearer {
 
 export namespace GetObjectTaggingOutput {
   export function isa(o: any): o is GetObjectTaggingOutput {
-    return _smithy.isa(o, "GetObjectTaggingOutput");
+    return __isa(o, "GetObjectTaggingOutput");
   }
 }
 
@@ -5018,7 +5021,7 @@ export interface GetObjectTaggingRequest {
 
 export namespace GetObjectTaggingRequest {
   export function isa(o: any): o is GetObjectTaggingRequest {
-    return _smithy.isa(o, "GetObjectTaggingRequest");
+    return __isa(o, "GetObjectTaggingRequest");
   }
 }
 
@@ -5037,7 +5040,7 @@ export interface GetObjectTorrentOutput extends $MetadataBearer {
 
 export namespace GetObjectTorrentOutput {
   export function isa(o: any): o is GetObjectTorrentOutput {
-    return _smithy.isa(o, "GetObjectTorrentOutput");
+    return __isa(o, "GetObjectTorrentOutput");
   }
 }
 
@@ -5064,7 +5067,7 @@ export interface GetObjectTorrentRequest {
 
 export namespace GetObjectTorrentRequest {
   export function isa(o: any): o is GetObjectTorrentRequest {
-    return _smithy.isa(o, "GetObjectTorrentRequest");
+    return __isa(o, "GetObjectTorrentRequest");
   }
 }
 
@@ -5079,7 +5082,7 @@ export interface GetPublicAccessBlockOutput extends $MetadataBearer {
 
 export namespace GetPublicAccessBlockOutput {
   export function isa(o: any): o is GetPublicAccessBlockOutput {
-    return _smithy.isa(o, "GetPublicAccessBlockOutput");
+    return __isa(o, "GetPublicAccessBlockOutput");
   }
 }
 
@@ -5094,7 +5097,7 @@ export interface GetPublicAccessBlockRequest {
 
 export namespace GetPublicAccessBlockRequest {
   export function isa(o: any): o is GetPublicAccessBlockRequest {
-    return _smithy.isa(o, "GetPublicAccessBlockRequest");
+    return __isa(o, "GetPublicAccessBlockRequest");
   }
 }
 
@@ -5111,7 +5114,7 @@ export interface GlacierJobParameters {
 
 export namespace GlacierJobParameters {
   export function isa(o: any): o is GlacierJobParameters {
-    return _smithy.isa(o, "GlacierJobParameters");
+    return __isa(o, "GlacierJobParameters");
   }
 }
 
@@ -5133,7 +5136,7 @@ export interface Grant {
 
 export namespace Grant {
   export function isa(o: any): o is Grant {
-    return _smithy.isa(o, "Grant");
+    return __isa(o, "Grant");
   }
 }
 
@@ -5170,7 +5173,7 @@ export interface Grantee {
 
 export namespace Grantee {
   export function isa(o: any): o is Grantee {
-    return _smithy.isa(o, "Grantee");
+    return __isa(o, "Grantee");
   }
 }
 
@@ -5184,7 +5187,7 @@ export interface HeadBucketRequest {
 
 export namespace HeadBucketRequest {
   export function isa(o: any): o is HeadBucketRequest {
-    return _smithy.isa(o, "HeadBucketRequest");
+    return __isa(o, "HeadBucketRequest");
   }
 }
 
@@ -5384,7 +5387,7 @@ export interface HeadObjectOutput extends $MetadataBearer {
 
 export namespace HeadObjectOutput {
   export function isa(o: any): o is HeadObjectOutput {
-    return _smithy.isa(o, "HeadObjectOutput");
+    return __isa(o, "HeadObjectOutput");
   }
 }
 
@@ -5467,7 +5470,7 @@ export interface HeadObjectRequest {
 
 export namespace HeadObjectRequest {
   export function isa(o: any): o is HeadObjectRequest {
-    return _smithy.isa(o, "HeadObjectRequest");
+    return __isa(o, "HeadObjectRequest");
   }
 }
 
@@ -5487,7 +5490,7 @@ export interface IndexDocument {
 
 export namespace IndexDocument {
   export function isa(o: any): o is IndexDocument {
-    return _smithy.isa(o, "IndexDocument");
+    return __isa(o, "IndexDocument");
   }
 }
 
@@ -5509,7 +5512,7 @@ export interface Initiator {
 
 export namespace Initiator {
   export function isa(o: any): o is Initiator {
-    return _smithy.isa(o, "Initiator");
+    return __isa(o, "Initiator");
   }
 }
 
@@ -5541,7 +5544,7 @@ export interface InputSerialization {
 
 export namespace InputSerialization {
   export function isa(o: any): o is InputSerialization {
-    return _smithy.isa(o, "InputSerialization");
+    return __isa(o, "InputSerialization");
   }
 }
 
@@ -5590,7 +5593,7 @@ export interface InventoryConfiguration {
 
 export namespace InventoryConfiguration {
   export function isa(o: any): o is InventoryConfiguration {
-    return _smithy.isa(o, "InventoryConfiguration");
+    return __isa(o, "InventoryConfiguration");
   }
 }
 
@@ -5607,7 +5610,7 @@ export interface InventoryDestination {
 
 export namespace InventoryDestination {
   export function isa(o: any): o is InventoryDestination {
-    return _smithy.isa(o, "InventoryDestination");
+    return __isa(o, "InventoryDestination");
   }
 }
 
@@ -5629,7 +5632,7 @@ export interface InventoryEncryption {
 
 export namespace InventoryEncryption {
   export function isa(o: any): o is InventoryEncryption {
-    return _smithy.isa(o, "InventoryEncryption");
+    return __isa(o, "InventoryEncryption");
   }
 }
 
@@ -5646,7 +5649,7 @@ export interface InventoryFilter {
 
 export namespace InventoryFilter {
   export function isa(o: any): o is InventoryFilter {
-    return _smithy.isa(o, "InventoryFilter");
+    return __isa(o, "InventoryFilter");
   }
 }
 
@@ -5703,7 +5706,7 @@ export interface InventoryS3BucketDestination {
 
 export namespace InventoryS3BucketDestination {
   export function isa(o: any): o is InventoryS3BucketDestination {
-    return _smithy.isa(o, "InventoryS3BucketDestination");
+    return __isa(o, "InventoryS3BucketDestination");
   }
 }
 
@@ -5720,7 +5723,7 @@ export interface InventorySchedule {
 
 export namespace InventorySchedule {
   export function isa(o: any): o is InventorySchedule {
-    return _smithy.isa(o, "InventorySchedule");
+    return __isa(o, "InventorySchedule");
   }
 }
 
@@ -5737,7 +5740,7 @@ export interface JSONInput {
 
 export namespace JSONInput {
   export function isa(o: any): o is JSONInput {
-    return _smithy.isa(o, "JSONInput");
+    return __isa(o, "JSONInput");
   }
 }
 
@@ -5754,7 +5757,7 @@ export interface JSONOutput {
 
 export namespace JSONOutput {
   export function isa(o: any): o is JSONOutput {
-    return _smithy.isa(o, "JSONOutput");
+    return __isa(o, "JSONOutput");
   }
 }
 
@@ -5797,7 +5800,7 @@ export interface LambdaFunctionConfiguration {
 
 export namespace LambdaFunctionConfiguration {
   export function isa(o: any): o is LambdaFunctionConfiguration {
-    return _smithy.isa(o, "LambdaFunctionConfiguration");
+    return __isa(o, "LambdaFunctionConfiguration");
   }
 }
 
@@ -5824,7 +5827,7 @@ export interface LifecycleExpiration {
 
 export namespace LifecycleExpiration {
   export function isa(o: any): o is LifecycleExpiration {
-    return _smithy.isa(o, "LifecycleExpiration");
+    return __isa(o, "LifecycleExpiration");
   }
 }
 
@@ -5892,7 +5895,7 @@ export interface LifecycleRule {
 
 export namespace LifecycleRule {
   export function isa(o: any): o is LifecycleRule {
-    return _smithy.isa(o, "LifecycleRule");
+    return __isa(o, "LifecycleRule");
   }
 }
 
@@ -5914,7 +5917,7 @@ export interface LifecycleRuleAndOperator {
 
 export namespace LifecycleRuleAndOperator {
   export function isa(o: any): o is LifecycleRuleAndOperator {
-    return _smithy.isa(o, "LifecycleRuleAndOperator");
+    return __isa(o, "LifecycleRuleAndOperator");
   }
 }
 
@@ -5943,7 +5946,7 @@ export interface LifecycleRuleFilter {
 
 export namespace LifecycleRuleFilter {
   export function isa(o: any): o is LifecycleRuleFilter {
-    return _smithy.isa(o, "LifecycleRuleFilter");
+    return __isa(o, "LifecycleRuleFilter");
   }
 }
 
@@ -5977,7 +5980,7 @@ export interface ListBucketAnalyticsConfigurationsOutput
 
 export namespace ListBucketAnalyticsConfigurationsOutput {
   export function isa(o: any): o is ListBucketAnalyticsConfigurationsOutput {
-    return _smithy.isa(o, "ListBucketAnalyticsConfigurationsOutput");
+    return __isa(o, "ListBucketAnalyticsConfigurationsOutput");
   }
 }
 
@@ -5996,7 +5999,7 @@ export interface ListBucketAnalyticsConfigurationsRequest {
 
 export namespace ListBucketAnalyticsConfigurationsRequest {
   export function isa(o: any): o is ListBucketAnalyticsConfigurationsRequest {
-    return _smithy.isa(o, "ListBucketAnalyticsConfigurationsRequest");
+    return __isa(o, "ListBucketAnalyticsConfigurationsRequest");
   }
 }
 
@@ -6029,7 +6032,7 @@ export interface ListBucketInventoryConfigurationsOutput
 
 export namespace ListBucketInventoryConfigurationsOutput {
   export function isa(o: any): o is ListBucketInventoryConfigurationsOutput {
-    return _smithy.isa(o, "ListBucketInventoryConfigurationsOutput");
+    return __isa(o, "ListBucketInventoryConfigurationsOutput");
   }
 }
 
@@ -6048,7 +6051,7 @@ export interface ListBucketInventoryConfigurationsRequest {
 
 export namespace ListBucketInventoryConfigurationsRequest {
   export function isa(o: any): o is ListBucketInventoryConfigurationsRequest {
-    return _smithy.isa(o, "ListBucketInventoryConfigurationsRequest");
+    return __isa(o, "ListBucketInventoryConfigurationsRequest");
   }
 }
 
@@ -6079,7 +6082,7 @@ export interface ListBucketMetricsConfigurationsOutput extends $MetadataBearer {
 
 export namespace ListBucketMetricsConfigurationsOutput {
   export function isa(o: any): o is ListBucketMetricsConfigurationsOutput {
-    return _smithy.isa(o, "ListBucketMetricsConfigurationsOutput");
+    return __isa(o, "ListBucketMetricsConfigurationsOutput");
   }
 }
 
@@ -6098,7 +6101,7 @@ export interface ListBucketMetricsConfigurationsRequest {
 
 export namespace ListBucketMetricsConfigurationsRequest {
   export function isa(o: any): o is ListBucketMetricsConfigurationsRequest {
-    return _smithy.isa(o, "ListBucketMetricsConfigurationsRequest");
+    return __isa(o, "ListBucketMetricsConfigurationsRequest");
   }
 }
 
@@ -6117,7 +6120,7 @@ export interface ListBucketsOutput extends $MetadataBearer {
 
 export namespace ListBucketsOutput {
   export function isa(o: any): o is ListBucketsOutput {
-    return _smithy.isa(o, "ListBucketsOutput");
+    return __isa(o, "ListBucketsOutput");
   }
 }
 
@@ -6194,7 +6197,7 @@ export interface ListMultipartUploadsOutput extends $MetadataBearer {
 
 export namespace ListMultipartUploadsOutput {
   export function isa(o: any): o is ListMultipartUploadsOutput {
-    return _smithy.isa(o, "ListMultipartUploadsOutput");
+    return __isa(o, "ListMultipartUploadsOutput");
   }
 }
 
@@ -6247,7 +6250,7 @@ export interface ListMultipartUploadsRequest {
 
 export namespace ListMultipartUploadsRequest {
   export function isa(o: any): o is ListMultipartUploadsRequest {
-    return _smithy.isa(o, "ListMultipartUploadsRequest");
+    return __isa(o, "ListMultipartUploadsRequest");
   }
 }
 
@@ -6340,7 +6343,7 @@ export interface ListObjectVersionsOutput extends $MetadataBearer {
 
 export namespace ListObjectVersionsOutput {
   export function isa(o: any): o is ListObjectVersionsOutput {
-    return _smithy.isa(o, "ListObjectVersionsOutput");
+    return __isa(o, "ListObjectVersionsOutput");
   }
 }
 
@@ -6385,7 +6388,7 @@ export interface ListObjectVersionsRequest {
 
 export namespace ListObjectVersionsRequest {
   export function isa(o: any): o is ListObjectVersionsRequest {
-    return _smithy.isa(o, "ListObjectVersionsRequest");
+    return __isa(o, "ListObjectVersionsRequest");
   }
 }
 
@@ -6457,7 +6460,7 @@ export interface ListObjectsOutput extends $MetadataBearer {
 
 export namespace ListObjectsOutput {
   export function isa(o: any): o is ListObjectsOutput {
-    return _smithy.isa(o, "ListObjectsOutput");
+    return __isa(o, "ListObjectsOutput");
   }
 }
 
@@ -6501,7 +6504,7 @@ export interface ListObjectsRequest {
 
 export namespace ListObjectsRequest {
   export function isa(o: any): o is ListObjectsRequest {
-    return _smithy.isa(o, "ListObjectsRequest");
+    return __isa(o, "ListObjectsRequest");
   }
 }
 
@@ -6595,7 +6598,7 @@ export interface ListObjectsV2Output extends $MetadataBearer {
 
 export namespace ListObjectsV2Output {
   export function isa(o: any): o is ListObjectsV2Output {
-    return _smithy.isa(o, "ListObjectsV2Output");
+    return __isa(o, "ListObjectsV2Output");
   }
 }
 
@@ -6651,7 +6654,7 @@ export interface ListObjectsV2Request {
 
 export namespace ListObjectsV2Request {
   export function isa(o: any): o is ListObjectsV2Request {
-    return _smithy.isa(o, "ListObjectsV2Request");
+    return __isa(o, "ListObjectsV2Request");
   }
 }
 
@@ -6741,7 +6744,7 @@ export interface ListPartsOutput extends $MetadataBearer {
 
 export namespace ListPartsOutput {
   export function isa(o: any): o is ListPartsOutput {
-    return _smithy.isa(o, "ListPartsOutput");
+    return __isa(o, "ListPartsOutput");
   }
 }
 
@@ -6784,7 +6787,7 @@ export interface ListPartsRequest {
 
 export namespace ListPartsRequest {
   export function isa(o: any): o is ListPartsRequest {
-    return _smithy.isa(o, "ListPartsRequest");
+    return __isa(o, "ListPartsRequest");
   }
 }
 
@@ -6819,7 +6822,7 @@ export interface LoggingEnabled {
 
 export namespace LoggingEnabled {
   export function isa(o: any): o is LoggingEnabled {
-    return _smithy.isa(o, "LoggingEnabled");
+    return __isa(o, "LoggingEnabled");
   }
 }
 
@@ -6847,7 +6850,7 @@ export interface MetadataEntry {
 
 export namespace MetadataEntry {
   export function isa(o: any): o is MetadataEntry {
-    return _smithy.isa(o, "MetadataEntry");
+    return __isa(o, "MetadataEntry");
   }
 }
 
@@ -6875,7 +6878,7 @@ export interface Metrics {
 
 export namespace Metrics {
   export function isa(o: any): o is Metrics {
-    return _smithy.isa(o, "Metrics");
+    return __isa(o, "Metrics");
   }
 }
 
@@ -6899,7 +6902,7 @@ export interface MetricsAndOperator {
 
 export namespace MetricsAndOperator {
   export function isa(o: any): o is MetricsAndOperator {
-    return _smithy.isa(o, "MetricsAndOperator");
+    return __isa(o, "MetricsAndOperator");
   }
 }
 
@@ -6924,7 +6927,7 @@ export interface MetricsConfiguration {
 
 export namespace MetricsConfiguration {
   export function isa(o: any): o is MetricsConfiguration {
-    return _smithy.isa(o, "MetricsConfiguration");
+    return __isa(o, "MetricsConfiguration");
   }
 }
 
@@ -6953,7 +6956,7 @@ export interface MetricsFilter {
 
 export namespace MetricsFilter {
   export function isa(o: any): o is MetricsFilter {
-    return _smithy.isa(o, "MetricsFilter");
+    return __isa(o, "MetricsFilter");
   }
 }
 
@@ -6997,49 +7000,49 @@ export interface MultipartUpload {
 
 export namespace MultipartUpload {
   export function isa(o: any): o is MultipartUpload {
-    return _smithy.isa(o, "MultipartUpload");
+    return __isa(o, "MultipartUpload");
   }
 }
 
 /**
  * <p>The specified bucket does not exist.</p>
  */
-export interface NoSuchBucket extends _smithy.SmithyException, $MetadataBearer {
+export interface NoSuchBucket extends __SmithyException, $MetadataBearer {
   name: "NoSuchBucket";
   $fault: "client";
 }
 
 export namespace NoSuchBucket {
   export function isa(o: any): o is NoSuchBucket {
-    return _smithy.isa(o, "NoSuchBucket");
+    return __isa(o, "NoSuchBucket");
   }
 }
 
 /**
  * <p>The specified key does not exist.</p>
  */
-export interface NoSuchKey extends _smithy.SmithyException, $MetadataBearer {
+export interface NoSuchKey extends __SmithyException, $MetadataBearer {
   name: "NoSuchKey";
   $fault: "client";
 }
 
 export namespace NoSuchKey {
   export function isa(o: any): o is NoSuchKey {
-    return _smithy.isa(o, "NoSuchKey");
+    return __isa(o, "NoSuchKey");
   }
 }
 
 /**
  * <p>The specified multipart upload does not exist.</p>
  */
-export interface NoSuchUpload extends _smithy.SmithyException, $MetadataBearer {
+export interface NoSuchUpload extends __SmithyException, $MetadataBearer {
   name: "NoSuchUpload";
   $fault: "client";
 }
 
 export namespace NoSuchUpload {
   export function isa(o: any): o is NoSuchUpload {
-    return _smithy.isa(o, "NoSuchUpload");
+    return __isa(o, "NoSuchUpload");
   }
 }
 
@@ -7061,7 +7064,7 @@ export interface NoncurrentVersionExpiration {
 
 export namespace NoncurrentVersionExpiration {
   export function isa(o: any): o is NoncurrentVersionExpiration {
-    return _smithy.isa(o, "NoncurrentVersionExpiration");
+    return __isa(o, "NoncurrentVersionExpiration");
   }
 }
 
@@ -7085,7 +7088,7 @@ export interface NoncurrentVersionTransition {
 
 export namespace NoncurrentVersionTransition {
   export function isa(o: any): o is NoncurrentVersionTransition {
-    return _smithy.isa(o, "NoncurrentVersionTransition");
+    return __isa(o, "NoncurrentVersionTransition");
   }
 }
 
@@ -7113,7 +7116,7 @@ export interface NotificationConfiguration extends $MetadataBearer {
 
 export namespace NotificationConfiguration {
   export function isa(o: any): o is NotificationConfiguration {
-    return _smithy.isa(o, "NotificationConfiguration");
+    return __isa(o, "NotificationConfiguration");
   }
 }
 
@@ -7133,7 +7136,7 @@ export interface NotificationConfigurationFilter {
 
 export namespace NotificationConfigurationFilter {
   export function isa(o: any): o is NotificationConfigurationFilter {
-    return _smithy.isa(o, "NotificationConfigurationFilter");
+    return __isa(o, "NotificationConfigurationFilter");
   }
 }
 
@@ -7176,7 +7179,7 @@ export interface _Object {
 
 export namespace _Object {
   export function isa(o: any): o is _Object {
-    return _smithy.isa(o, "Object");
+    return __isa(o, "Object");
   }
 }
 
@@ -7184,7 +7187,7 @@ export namespace _Object {
  * <p>This operation is not allowed against this storage tier.</p>
  */
 export interface ObjectAlreadyInActiveTierError
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ObjectAlreadyInActiveTierError";
   $fault: "client";
@@ -7192,7 +7195,7 @@ export interface ObjectAlreadyInActiveTierError
 
 export namespace ObjectAlreadyInActiveTierError {
   export function isa(o: any): o is ObjectAlreadyInActiveTierError {
-    return _smithy.isa(o, "ObjectAlreadyInActiveTierError");
+    return __isa(o, "ObjectAlreadyInActiveTierError");
   }
 }
 
@@ -7223,7 +7226,7 @@ export interface ObjectIdentifier {
 
 export namespace ObjectIdentifier {
   export function isa(o: any): o is ObjectIdentifier {
-    return _smithy.isa(o, "ObjectIdentifier");
+    return __isa(o, "ObjectIdentifier");
   }
 }
 
@@ -7245,7 +7248,7 @@ export interface ObjectLockConfiguration {
 
 export namespace ObjectLockConfiguration {
   export function isa(o: any): o is ObjectLockConfiguration {
-    return _smithy.isa(o, "ObjectLockConfiguration");
+    return __isa(o, "ObjectLockConfiguration");
   }
 }
 
@@ -7264,7 +7267,7 @@ export interface ObjectLockLegalHold {
 
 export namespace ObjectLockLegalHold {
   export function isa(o: any): o is ObjectLockLegalHold {
-    return _smithy.isa(o, "ObjectLockLegalHold");
+    return __isa(o, "ObjectLockLegalHold");
   }
 }
 
@@ -7290,7 +7293,7 @@ export interface ObjectLockRetention {
 
 export namespace ObjectLockRetention {
   export function isa(o: any): o is ObjectLockRetention {
-    return _smithy.isa(o, "ObjectLockRetention");
+    return __isa(o, "ObjectLockRetention");
   }
 }
 
@@ -7309,7 +7312,7 @@ export interface ObjectLockRule {
 
 export namespace ObjectLockRule {
   export function isa(o: any): o is ObjectLockRule {
-    return _smithy.isa(o, "ObjectLockRule");
+    return __isa(o, "ObjectLockRule");
   }
 }
 
@@ -7318,7 +7321,7 @@ export namespace ObjectLockRule {
  *          S3 Glacier.</p>
  */
 export interface ObjectNotInActiveTierError
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ObjectNotInActiveTierError";
   $fault: "client";
@@ -7326,7 +7329,7 @@ export interface ObjectNotInActiveTierError
 
 export namespace ObjectNotInActiveTierError {
   export function isa(o: any): o is ObjectNotInActiveTierError {
-    return _smithy.isa(o, "ObjectNotInActiveTierError");
+    return __isa(o, "ObjectNotInActiveTierError");
   }
 }
 
@@ -7387,7 +7390,7 @@ export interface ObjectVersion {
 
 export namespace ObjectVersion {
   export function isa(o: any): o is ObjectVersion {
-    return _smithy.isa(o, "ObjectVersion");
+    return __isa(o, "ObjectVersion");
   }
 }
 
@@ -7406,7 +7409,7 @@ export interface OutputLocation {
 
 export namespace OutputLocation {
   export function isa(o: any): o is OutputLocation {
-    return _smithy.isa(o, "OutputLocation");
+    return __isa(o, "OutputLocation");
   }
 }
 
@@ -7428,7 +7431,7 @@ export interface OutputSerialization {
 
 export namespace OutputSerialization {
   export function isa(o: any): o is OutputSerialization {
-    return _smithy.isa(o, "OutputSerialization");
+    return __isa(o, "OutputSerialization");
   }
 }
 
@@ -7450,7 +7453,7 @@ export interface Owner {
 
 export namespace Owner {
   export function isa(o: any): o is Owner {
-    return _smithy.isa(o, "Owner");
+    return __isa(o, "Owner");
   }
 }
 
@@ -7465,7 +7468,7 @@ export interface ParquetInput {
 
 export namespace ParquetInput {
   export function isa(o: any): o is ParquetInput {
-    return _smithy.isa(o, "ParquetInput");
+    return __isa(o, "ParquetInput");
   }
 }
 
@@ -7497,7 +7500,7 @@ export interface Part {
 
 export namespace Part {
   export function isa(o: any): o is Part {
-    return _smithy.isa(o, "Part");
+    return __isa(o, "Part");
   }
 }
 
@@ -7524,7 +7527,7 @@ export interface PolicyStatus {
 
 export namespace PolicyStatus {
   export function isa(o: any): o is PolicyStatus {
-    return _smithy.isa(o, "PolicyStatus");
+    return __isa(o, "PolicyStatus");
   }
 }
 
@@ -7551,7 +7554,7 @@ export interface Progress {
 
 export namespace Progress {
   export function isa(o: any): o is Progress {
-    return _smithy.isa(o, "Progress");
+    return __isa(o, "Progress");
   }
 }
 
@@ -7568,7 +7571,7 @@ export interface ProgressEvent {
 
 export namespace ProgressEvent {
   export function isa(o: any): o is ProgressEvent {
-    return _smithy.isa(o, "ProgressEvent");
+    return __isa(o, "ProgressEvent");
   }
 }
 
@@ -7630,7 +7633,7 @@ export interface PublicAccessBlockConfiguration {
 
 export namespace PublicAccessBlockConfiguration {
   export function isa(o: any): o is PublicAccessBlockConfiguration {
-    return _smithy.isa(o, "PublicAccessBlockConfiguration");
+    return __isa(o, "PublicAccessBlockConfiguration");
   }
 }
 
@@ -7649,7 +7652,7 @@ export interface PutBucketAccelerateConfigurationRequest {
 
 export namespace PutBucketAccelerateConfigurationRequest {
   export function isa(o: any): o is PutBucketAccelerateConfigurationRequest {
-    return _smithy.isa(o, "PutBucketAccelerateConfigurationRequest");
+    return __isa(o, "PutBucketAccelerateConfigurationRequest");
   }
 }
 
@@ -7706,7 +7709,7 @@ export interface PutBucketAclRequest {
 
 export namespace PutBucketAclRequest {
   export function isa(o: any): o is PutBucketAclRequest {
-    return _smithy.isa(o, "PutBucketAclRequest");
+    return __isa(o, "PutBucketAclRequest");
   }
 }
 
@@ -7730,7 +7733,7 @@ export interface PutBucketAnalyticsConfigurationRequest {
 
 export namespace PutBucketAnalyticsConfigurationRequest {
   export function isa(o: any): o is PutBucketAnalyticsConfigurationRequest {
-    return _smithy.isa(o, "PutBucketAnalyticsConfigurationRequest");
+    return __isa(o, "PutBucketAnalyticsConfigurationRequest");
   }
 }
 
@@ -7759,7 +7762,7 @@ export interface PutBucketCorsRequest {
 
 export namespace PutBucketCorsRequest {
   export function isa(o: any): o is PutBucketCorsRequest {
-    return _smithy.isa(o, "PutBucketCorsRequest");
+    return __isa(o, "PutBucketCorsRequest");
   }
 }
 
@@ -7786,7 +7789,7 @@ export interface PutBucketEncryptionRequest {
 
 export namespace PutBucketEncryptionRequest {
   export function isa(o: any): o is PutBucketEncryptionRequest {
-    return _smithy.isa(o, "PutBucketEncryptionRequest");
+    return __isa(o, "PutBucketEncryptionRequest");
   }
 }
 
@@ -7810,7 +7813,7 @@ export interface PutBucketInventoryConfigurationRequest {
 
 export namespace PutBucketInventoryConfigurationRequest {
   export function isa(o: any): o is PutBucketInventoryConfigurationRequest {
-    return _smithy.isa(o, "PutBucketInventoryConfigurationRequest");
+    return __isa(o, "PutBucketInventoryConfigurationRequest");
   }
 }
 
@@ -7829,7 +7832,7 @@ export interface PutBucketLifecycleConfigurationRequest {
 
 export namespace PutBucketLifecycleConfigurationRequest {
   export function isa(o: any): o is PutBucketLifecycleConfigurationRequest {
-    return _smithy.isa(o, "PutBucketLifecycleConfigurationRequest");
+    return __isa(o, "PutBucketLifecycleConfigurationRequest");
   }
 }
 
@@ -7853,7 +7856,7 @@ export interface PutBucketLoggingRequest {
 
 export namespace PutBucketLoggingRequest {
   export function isa(o: any): o is PutBucketLoggingRequest {
-    return _smithy.isa(o, "PutBucketLoggingRequest");
+    return __isa(o, "PutBucketLoggingRequest");
   }
 }
 
@@ -7877,7 +7880,7 @@ export interface PutBucketMetricsConfigurationRequest {
 
 export namespace PutBucketMetricsConfigurationRequest {
   export function isa(o: any): o is PutBucketMetricsConfigurationRequest {
-    return _smithy.isa(o, "PutBucketMetricsConfigurationRequest");
+    return __isa(o, "PutBucketMetricsConfigurationRequest");
   }
 }
 
@@ -7897,7 +7900,7 @@ export interface PutBucketNotificationConfigurationRequest {
 
 export namespace PutBucketNotificationConfigurationRequest {
   export function isa(o: any): o is PutBucketNotificationConfigurationRequest {
-    return _smithy.isa(o, "PutBucketNotificationConfigurationRequest");
+    return __isa(o, "PutBucketNotificationConfigurationRequest");
   }
 }
 
@@ -7926,7 +7929,7 @@ export interface PutBucketPolicyRequest {
 
 export namespace PutBucketPolicyRequest {
   export function isa(o: any): o is PutBucketPolicyRequest {
-    return _smithy.isa(o, "PutBucketPolicyRequest");
+    return __isa(o, "PutBucketPolicyRequest");
   }
 }
 
@@ -7956,7 +7959,7 @@ export interface PutBucketReplicationRequest {
 
 export namespace PutBucketReplicationRequest {
   export function isa(o: any): o is PutBucketReplicationRequest {
-    return _smithy.isa(o, "PutBucketReplicationRequest");
+    return __isa(o, "PutBucketReplicationRequest");
   }
 }
 
@@ -7980,7 +7983,7 @@ export interface PutBucketRequestPaymentRequest {
 
 export namespace PutBucketRequestPaymentRequest {
   export function isa(o: any): o is PutBucketRequestPaymentRequest {
-    return _smithy.isa(o, "PutBucketRequestPaymentRequest");
+    return __isa(o, "PutBucketRequestPaymentRequest");
   }
 }
 
@@ -8004,7 +8007,7 @@ export interface PutBucketTaggingRequest {
 
 export namespace PutBucketTaggingRequest {
   export function isa(o: any): o is PutBucketTaggingRequest {
-    return _smithy.isa(o, "PutBucketTaggingRequest");
+    return __isa(o, "PutBucketTaggingRequest");
   }
 }
 
@@ -8033,7 +8036,7 @@ export interface PutBucketVersioningRequest {
 
 export namespace PutBucketVersioningRequest {
   export function isa(o: any): o is PutBucketVersioningRequest {
-    return _smithy.isa(o, "PutBucketVersioningRequest");
+    return __isa(o, "PutBucketVersioningRequest");
   }
 }
 
@@ -8057,7 +8060,7 @@ export interface PutBucketWebsiteRequest {
 
 export namespace PutBucketWebsiteRequest {
   export function isa(o: any): o is PutBucketWebsiteRequest {
-    return _smithy.isa(o, "PutBucketWebsiteRequest");
+    return __isa(o, "PutBucketWebsiteRequest");
   }
 }
 
@@ -8071,7 +8074,7 @@ export interface PutObjectAclOutput extends $MetadataBearer {
 
 export namespace PutObjectAclOutput {
   export function isa(o: any): o is PutObjectAclOutput {
-    return _smithy.isa(o, "PutObjectAclOutput");
+    return __isa(o, "PutObjectAclOutput");
   }
 }
 
@@ -8148,7 +8151,7 @@ export interface PutObjectAclRequest {
 
 export namespace PutObjectAclRequest {
   export function isa(o: any): o is PutObjectAclRequest {
-    return _smithy.isa(o, "PutObjectAclRequest");
+    return __isa(o, "PutObjectAclRequest");
   }
 }
 
@@ -8162,7 +8165,7 @@ export interface PutObjectLegalHoldOutput extends $MetadataBearer {
 
 export namespace PutObjectLegalHoldOutput {
   export function isa(o: any): o is PutObjectLegalHoldOutput {
-    return _smithy.isa(o, "PutObjectLegalHoldOutput");
+    return __isa(o, "PutObjectLegalHoldOutput");
   }
 }
 
@@ -8205,7 +8208,7 @@ export interface PutObjectLegalHoldRequest {
 
 export namespace PutObjectLegalHoldRequest {
   export function isa(o: any): o is PutObjectLegalHoldRequest {
-    return _smithy.isa(o, "PutObjectLegalHoldRequest");
+    return __isa(o, "PutObjectLegalHoldRequest");
   }
 }
 
@@ -8219,7 +8222,7 @@ export interface PutObjectLockConfigurationOutput extends $MetadataBearer {
 
 export namespace PutObjectLockConfigurationOutput {
   export function isa(o: any): o is PutObjectLockConfigurationOutput {
-    return _smithy.isa(o, "PutObjectLockConfigurationOutput");
+    return __isa(o, "PutObjectLockConfigurationOutput");
   }
 }
 
@@ -8256,7 +8259,7 @@ export interface PutObjectLockConfigurationRequest {
 
 export namespace PutObjectLockConfigurationRequest {
   export function isa(o: any): o is PutObjectLockConfigurationRequest {
-    return _smithy.isa(o, "PutObjectLockConfigurationRequest");
+    return __isa(o, "PutObjectLockConfigurationRequest");
   }
 }
 
@@ -8315,7 +8318,7 @@ export interface PutObjectOutput extends $MetadataBearer {
 
 export namespace PutObjectOutput {
   export function isa(o: any): o is PutObjectOutput {
-    return _smithy.isa(o, "PutObjectOutput");
+    return __isa(o, "PutObjectOutput");
   }
 }
 
@@ -8508,7 +8511,7 @@ export interface PutObjectRequest {
 
 export namespace PutObjectRequest {
   export function isa(o: any): o is PutObjectRequest {
-    return _smithy.isa(o, "PutObjectRequest");
+    return __isa(o, "PutObjectRequest");
   }
 }
 
@@ -8522,7 +8525,7 @@ export interface PutObjectRetentionOutput extends $MetadataBearer {
 
 export namespace PutObjectRetentionOutput {
   export function isa(o: any): o is PutObjectRetentionOutput {
-    return _smithy.isa(o, "PutObjectRetentionOutput");
+    return __isa(o, "PutObjectRetentionOutput");
   }
 }
 
@@ -8570,7 +8573,7 @@ export interface PutObjectRetentionRequest {
 
 export namespace PutObjectRetentionRequest {
   export function isa(o: any): o is PutObjectRetentionRequest {
-    return _smithy.isa(o, "PutObjectRetentionRequest");
+    return __isa(o, "PutObjectRetentionRequest");
   }
 }
 
@@ -8584,7 +8587,7 @@ export interface PutObjectTaggingOutput extends $MetadataBearer {
 
 export namespace PutObjectTaggingOutput {
   export function isa(o: any): o is PutObjectTaggingOutput {
-    return _smithy.isa(o, "PutObjectTaggingOutput");
+    return __isa(o, "PutObjectTaggingOutput");
   }
 }
 
@@ -8619,7 +8622,7 @@ export interface PutObjectTaggingRequest {
 
 export namespace PutObjectTaggingRequest {
   export function isa(o: any): o is PutObjectTaggingRequest {
-    return _smithy.isa(o, "PutObjectTaggingRequest");
+    return __isa(o, "PutObjectTaggingRequest");
   }
 }
 
@@ -8647,7 +8650,7 @@ export interface PutPublicAccessBlockRequest {
 
 export namespace PutPublicAccessBlockRequest {
   export function isa(o: any): o is PutPublicAccessBlockRequest {
-    return _smithy.isa(o, "PutPublicAccessBlockRequest");
+    return __isa(o, "PutPublicAccessBlockRequest");
   }
 }
 
@@ -8685,7 +8688,7 @@ export interface QueueConfiguration {
 
 export namespace QueueConfiguration {
   export function isa(o: any): o is QueueConfiguration {
-    return _smithy.isa(o, "QueueConfiguration");
+    return __isa(o, "QueueConfiguration");
   }
 }
 
@@ -8707,7 +8710,7 @@ export interface RecordsEvent {
 
 export namespace RecordsEvent {
   export function isa(o: any): o is RecordsEvent {
-    return _smithy.isa(o, "RecordsEvent");
+    return __isa(o, "RecordsEvent");
   }
 }
 
@@ -8744,7 +8747,7 @@ export interface Redirect {
 
 export namespace Redirect {
   export function isa(o: any): o is Redirect {
-    return _smithy.isa(o, "Redirect");
+    return __isa(o, "Redirect");
   }
 }
 
@@ -8766,7 +8769,7 @@ export interface RedirectAllRequestsTo {
 
 export namespace RedirectAllRequestsTo {
   export function isa(o: any): o is RedirectAllRequestsTo {
-    return _smithy.isa(o, "RedirectAllRequestsTo");
+    return __isa(o, "RedirectAllRequestsTo");
   }
 }
 
@@ -8791,7 +8794,7 @@ export interface ReplicationConfiguration {
 
 export namespace ReplicationConfiguration {
   export function isa(o: any): o is ReplicationConfiguration {
-    return _smithy.isa(o, "ReplicationConfiguration");
+    return __isa(o, "ReplicationConfiguration");
   }
 }
 
@@ -8877,7 +8880,7 @@ export interface ReplicationRule {
 
 export namespace ReplicationRule {
   export function isa(o: any): o is ReplicationRule {
-    return _smithy.isa(o, "ReplicationRule");
+    return __isa(o, "ReplicationRule");
   }
 }
 
@@ -8912,7 +8915,7 @@ export interface ReplicationRuleAndOperator {
 
 export namespace ReplicationRuleAndOperator {
   export function isa(o: any): o is ReplicationRuleAndOperator {
-    return _smithy.isa(o, "ReplicationRuleAndOperator");
+    return __isa(o, "ReplicationRuleAndOperator");
   }
 }
 
@@ -8955,7 +8958,7 @@ export interface ReplicationRuleFilter {
 
 export namespace ReplicationRuleFilter {
   export function isa(o: any): o is ReplicationRuleFilter {
-    return _smithy.isa(o, "ReplicationRuleFilter");
+    return __isa(o, "ReplicationRuleFilter");
   }
 }
 
@@ -8987,7 +8990,7 @@ export interface ReplicationTime {
 
 export namespace ReplicationTime {
   export function isa(o: any): o is ReplicationTime {
-    return _smithy.isa(o, "ReplicationTime");
+    return __isa(o, "ReplicationTime");
   }
 }
 
@@ -9011,7 +9014,7 @@ export interface ReplicationTimeValue {
 
 export namespace ReplicationTimeValue {
   export function isa(o: any): o is ReplicationTimeValue {
-    return _smithy.isa(o, "ReplicationTimeValue");
+    return __isa(o, "ReplicationTimeValue");
   }
 }
 
@@ -9032,7 +9035,7 @@ export interface RequestPaymentConfiguration {
 
 export namespace RequestPaymentConfiguration {
   export function isa(o: any): o is RequestPaymentConfiguration {
-    return _smithy.isa(o, "RequestPaymentConfiguration");
+    return __isa(o, "RequestPaymentConfiguration");
   }
 }
 
@@ -9050,7 +9053,7 @@ export interface RequestProgress {
 
 export namespace RequestProgress {
   export function isa(o: any): o is RequestProgress {
-    return _smithy.isa(o, "RequestProgress");
+    return __isa(o, "RequestProgress");
   }
 }
 
@@ -9069,7 +9072,7 @@ export interface RestoreObjectOutput extends $MetadataBearer {
 
 export namespace RestoreObjectOutput {
   export function isa(o: any): o is RestoreObjectOutput {
-    return _smithy.isa(o, "RestoreObjectOutput");
+    return __isa(o, "RestoreObjectOutput");
   }
 }
 
@@ -9107,7 +9110,7 @@ export interface RestoreObjectRequest {
 
 export namespace RestoreObjectRequest {
   export function isa(o: any): o is RestoreObjectRequest {
-    return _smithy.isa(o, "RestoreObjectRequest");
+    return __isa(o, "RestoreObjectRequest");
   }
 }
 
@@ -9156,7 +9159,7 @@ export interface RestoreRequest {
 
 export namespace RestoreRequest {
   export function isa(o: any): o is RestoreRequest {
-    return _smithy.isa(o, "RestoreRequest");
+    return __isa(o, "RestoreRequest");
   }
 }
 
@@ -9184,7 +9187,7 @@ export interface RoutingRule {
 
 export namespace RoutingRule {
   export function isa(o: any): o is RoutingRule {
-    return _smithy.isa(o, "RoutingRule");
+    return __isa(o, "RoutingRule");
   }
 }
 
@@ -9202,7 +9205,7 @@ export interface S3KeyFilter {
 
 export namespace S3KeyFilter {
   export function isa(o: any): o is S3KeyFilter {
-    return _smithy.isa(o, "S3KeyFilter");
+    return __isa(o, "S3KeyFilter");
   }
 }
 
@@ -9254,7 +9257,7 @@ export interface S3Location {
 
 export namespace S3Location {
   export function isa(o: any): o is S3Location {
-    return _smithy.isa(o, "S3Location");
+    return __isa(o, "S3Location");
   }
 }
 
@@ -9272,7 +9275,7 @@ export interface SSEKMS {
 
 export namespace SSEKMS {
   export function isa(o: any): o is SSEKMS {
-    return _smithy.isa(o, "SSEKMS");
+    return __isa(o, "SSEKMS");
   }
 }
 
@@ -9285,7 +9288,7 @@ export interface SSES3 {
 
 export namespace SSES3 {
   export function isa(o: any): o is SSES3 {
-    return _smithy.isa(o, "SSES3");
+    return __isa(o, "SSES3");
   }
 }
 
@@ -9313,7 +9316,7 @@ export interface ScanRange {
 
 export namespace ScanRange {
   export function isa(o: any): o is ScanRange {
-    return _smithy.isa(o, "ScanRange");
+    return __isa(o, "ScanRange");
   }
 }
 
@@ -9426,7 +9429,7 @@ export interface SelectObjectContentOutput extends $MetadataBearer {
 
 export namespace SelectObjectContentOutput {
   export function isa(o: any): o is SelectObjectContentOutput {
-    return _smithy.isa(o, "SelectObjectContentOutput");
+    return __isa(o, "SelectObjectContentOutput");
   }
 }
 
@@ -9517,7 +9520,7 @@ export interface SelectObjectContentRequest {
 
 export namespace SelectObjectContentRequest {
   export function isa(o: any): o is SelectObjectContentRequest {
-    return _smithy.isa(o, "SelectObjectContentRequest");
+    return __isa(o, "SelectObjectContentRequest");
   }
 }
 
@@ -9549,7 +9552,7 @@ export interface SelectParameters {
 
 export namespace SelectParameters {
   export function isa(o: any): o is SelectParameters {
-    return _smithy.isa(o, "SelectParameters");
+    return __isa(o, "SelectParameters");
   }
 }
 
@@ -9573,7 +9576,7 @@ export interface ServerSideEncryptionByDefault {
 
 export namespace ServerSideEncryptionByDefault {
   export function isa(o: any): o is ServerSideEncryptionByDefault {
-    return _smithy.isa(o, "ServerSideEncryptionByDefault");
+    return __isa(o, "ServerSideEncryptionByDefault");
   }
 }
 
@@ -9590,7 +9593,7 @@ export interface ServerSideEncryptionConfiguration {
 
 export namespace ServerSideEncryptionConfiguration {
   export function isa(o: any): o is ServerSideEncryptionConfiguration {
-    return _smithy.isa(o, "ServerSideEncryptionConfiguration");
+    return __isa(o, "ServerSideEncryptionConfiguration");
   }
 }
 
@@ -9607,7 +9610,7 @@ export interface ServerSideEncryptionRule {
 
 export namespace ServerSideEncryptionRule {
   export function isa(o: any): o is ServerSideEncryptionRule {
-    return _smithy.isa(o, "ServerSideEncryptionRule");
+    return __isa(o, "ServerSideEncryptionRule");
   }
 }
 
@@ -9629,7 +9632,7 @@ export interface SourceSelectionCriteria {
 
 export namespace SourceSelectionCriteria {
   export function isa(o: any): o is SourceSelectionCriteria {
-    return _smithy.isa(o, "SourceSelectionCriteria");
+    return __isa(o, "SourceSelectionCriteria");
   }
 }
 
@@ -9647,7 +9650,7 @@ export interface SseKmsEncryptedObjects {
 
 export namespace SseKmsEncryptedObjects {
   export function isa(o: any): o is SseKmsEncryptedObjects {
-    return _smithy.isa(o, "SseKmsEncryptedObjects");
+    return __isa(o, "SseKmsEncryptedObjects");
   }
 }
 
@@ -9676,7 +9679,7 @@ export interface Stats {
 
 export namespace Stats {
   export function isa(o: any): o is Stats {
-    return _smithy.isa(o, "Stats");
+    return __isa(o, "Stats");
   }
 }
 
@@ -9693,7 +9696,7 @@ export interface StatsEvent {
 
 export namespace StatsEvent {
   export function isa(o: any): o is StatsEvent {
-    return _smithy.isa(o, "StatsEvent");
+    return __isa(o, "StatsEvent");
   }
 }
 
@@ -9719,7 +9722,7 @@ export interface StorageClassAnalysis {
 
 export namespace StorageClassAnalysis {
   export function isa(o: any): o is StorageClassAnalysis {
-    return _smithy.isa(o, "StorageClassAnalysis");
+    return __isa(o, "StorageClassAnalysis");
   }
 }
 
@@ -9741,7 +9744,7 @@ export interface StorageClassAnalysisDataExport {
 
 export namespace StorageClassAnalysisDataExport {
   export function isa(o: any): o is StorageClassAnalysisDataExport {
-    return _smithy.isa(o, "StorageClassAnalysisDataExport");
+    return __isa(o, "StorageClassAnalysisDataExport");
   }
 }
 
@@ -9765,7 +9768,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -9782,7 +9785,7 @@ export interface Tagging {
 
 export namespace Tagging {
   export function isa(o: any): o is Tagging {
-    return _smithy.isa(o, "Tagging");
+    return __isa(o, "Tagging");
   }
 }
 
@@ -9806,7 +9809,7 @@ export interface TargetGrant {
 
 export namespace TargetGrant {
   export function isa(o: any): o is TargetGrant {
-    return _smithy.isa(o, "TargetGrant");
+    return __isa(o, "TargetGrant");
   }
 }
 
@@ -9848,7 +9851,7 @@ export interface TopicConfiguration {
 
 export namespace TopicConfiguration {
   export function isa(o: any): o is TopicConfiguration {
-    return _smithy.isa(o, "TopicConfiguration");
+    return __isa(o, "TopicConfiguration");
   }
 }
 
@@ -9875,7 +9878,7 @@ export interface Transition {
 
 export namespace Transition {
   export function isa(o: any): o is Transition {
-    return _smithy.isa(o, "Transition");
+    return __isa(o, "Transition");
   }
 }
 
@@ -9932,7 +9935,7 @@ export interface UploadPartCopyOutput extends $MetadataBearer {
 
 export namespace UploadPartCopyOutput {
   export function isa(o: any): o is UploadPartCopyOutput {
-    return _smithy.isa(o, "UploadPartCopyOutput");
+    return __isa(o, "UploadPartCopyOutput");
   }
 }
 
@@ -10040,7 +10043,7 @@ export interface UploadPartCopyRequest {
 
 export namespace UploadPartCopyRequest {
   export function isa(o: any): o is UploadPartCopyRequest {
-    return _smithy.isa(o, "UploadPartCopyRequest");
+    return __isa(o, "UploadPartCopyRequest");
   }
 }
 
@@ -10083,7 +10086,7 @@ export interface UploadPartOutput extends $MetadataBearer {
 
 export namespace UploadPartOutput {
   export function isa(o: any): o is UploadPartOutput {
-    return _smithy.isa(o, "UploadPartOutput");
+    return __isa(o, "UploadPartOutput");
   }
 }
 
@@ -10158,7 +10161,7 @@ export interface UploadPartRequest {
 
 export namespace UploadPartRequest {
   export function isa(o: any): o is UploadPartRequest {
-    return _smithy.isa(o, "UploadPartRequest");
+    return __isa(o, "UploadPartRequest");
   }
 }
 
@@ -10181,7 +10184,7 @@ export interface VersioningConfiguration {
 
 export namespace VersioningConfiguration {
   export function isa(o: any): o is VersioningConfiguration {
-    return _smithy.isa(o, "VersioningConfiguration");
+    return __isa(o, "VersioningConfiguration");
   }
 }
 
@@ -10216,6 +10219,6 @@ export interface WebsiteConfiguration {
 
 export namespace WebsiteConfiguration {
   export function isa(o: any): o is WebsiteConfiguration {
-    return _smithy.isa(o, "WebsiteConfiguration");
+    return __isa(o, "WebsiteConfiguration");
   }
 }

--- a/clients/client-s3/protocols/Aws_restXml.ts
+++ b/clients/client-s3/protocols/Aws_restXml.ts
@@ -469,7 +469,10 @@ import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  extendedEncodeURIComponent as __extendedEncodeURIComponent
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -489,23 +492,23 @@ export async function serializeAws_restXmlAbortMultipartUploadCommand(
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.RequestPayer !== undefined) {
-    headers["x-amz-request-payer"] = input.RequestPayer.toString();
+    headers["x-amz-request-payer"] = input.RequestPayer;
   }
   let resolvedPath = "/{Bucket}/{Key+}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
   }
   if (input.Key !== undefined) {
-    const labelValue: string = input.Key.toString();
+    const labelValue: string = input.Key;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Key.");
     }
@@ -513,7 +516,7 @@ export async function serializeAws_restXmlAbortMultipartUploadCommand(
       "{Key+}",
       labelValue
         .split("/")
-        .map(segment => encodeURIComponent(segment))
+        .map(segment => __extendedEncodeURIComponent(segment))
         .join("/")
     );
   } else {
@@ -523,7 +526,9 @@ export async function serializeAws_restXmlAbortMultipartUploadCommand(
     "x-id": "AbortMultipartUpload"
   };
   if (input.UploadId !== undefined) {
-    query["uploadId"] = input.UploadId.toString();
+    query[
+      __extendedEncodeURIComponent("uploadId")
+    ] = __extendedEncodeURIComponent(input.UploadId);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -542,23 +547,23 @@ export async function serializeAws_restXmlCompleteMultipartUploadCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/xml";
   if (input.RequestPayer !== undefined) {
-    headers["x-amz-request-payer"] = input.RequestPayer.toString();
+    headers["x-amz-request-payer"] = input.RequestPayer;
   }
   let resolvedPath = "/{Bucket}/{Key+}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
   }
   if (input.Key !== undefined) {
-    const labelValue: string = input.Key.toString();
+    const labelValue: string = input.Key;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Key.");
     }
@@ -566,7 +571,7 @@ export async function serializeAws_restXmlCompleteMultipartUploadCommand(
       "{Key+}",
       labelValue
         .split("/")
-        .map(segment => encodeURIComponent(segment))
+        .map(segment => __extendedEncodeURIComponent(segment))
         .join("/")
     );
   } else {
@@ -574,7 +579,9 @@ export async function serializeAws_restXmlCompleteMultipartUploadCommand(
   }
   const query: any = {};
   if (input.UploadId !== undefined) {
-    query["uploadId"] = input.UploadId.toString();
+    query[
+      __extendedEncodeURIComponent("uploadId")
+    ] = __extendedEncodeURIComponent(input.UploadId);
   }
   let body: any;
   let contents: any;
@@ -605,28 +612,28 @@ export async function serializeAws_restXmlCopyObjectCommand(
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.ACL !== undefined) {
-    headers["x-amz-acl"] = input.ACL.toString();
+    headers["x-amz-acl"] = input.ACL;
   }
   if (input.CacheControl !== undefined) {
-    headers["Cache-Control"] = input.CacheControl.toString();
+    headers["Cache-Control"] = input.CacheControl;
   }
   if (input.ContentDisposition !== undefined) {
-    headers["Content-Disposition"] = input.ContentDisposition.toString();
+    headers["Content-Disposition"] = input.ContentDisposition;
   }
   if (input.ContentEncoding !== undefined) {
-    headers["Content-Encoding"] = input.ContentEncoding.toString();
+    headers["Content-Encoding"] = input.ContentEncoding;
   }
   if (input.ContentLanguage !== undefined) {
-    headers["Content-Language"] = input.ContentLanguage.toString();
+    headers["Content-Language"] = input.ContentLanguage;
   }
   if (input.ContentType !== undefined) {
-    headers["Content-Type"] = input.ContentType.toString();
+    headers["Content-Type"] = input.ContentType;
   }
   if (input.CopySource !== undefined) {
-    headers["x-amz-copy-source"] = input.CopySource.toString();
+    headers["x-amz-copy-source"] = input.CopySource;
   }
   if (input.CopySourceIfMatch !== undefined) {
-    headers["x-amz-copy-source-if-match"] = input.CopySourceIfMatch.toString();
+    headers["x-amz-copy-source-if-match"] = input.CopySourceIfMatch;
   }
   if (input.CopySourceIfModifiedSince !== undefined) {
     headers[
@@ -634,9 +641,7 @@ export async function serializeAws_restXmlCopyObjectCommand(
     ] = input.CopySourceIfModifiedSince.toUTCString();
   }
   if (input.CopySourceIfNoneMatch !== undefined) {
-    headers[
-      "x-amz-copy-source-if-none-match"
-    ] = input.CopySourceIfNoneMatch.toString();
+    headers["x-amz-copy-source-if-none-match"] = input.CopySourceIfNoneMatch;
   }
   if (input.CopySourceIfUnmodifiedSince !== undefined) {
     headers[
@@ -644,45 +649,40 @@ export async function serializeAws_restXmlCopyObjectCommand(
     ] = input.CopySourceIfUnmodifiedSince.toUTCString();
   }
   if (input.CopySourceSSECustomerAlgorithm !== undefined) {
-    headers[
-      "x-amz-copy-source-server-side-encryption-customer-algorithm"
-    ] = input.CopySourceSSECustomerAlgorithm.toString();
+    headers["x-amz-copy-source-server-side-encryption-customer-algorithm"] =
+      input.CopySourceSSECustomerAlgorithm;
   }
   if (input.CopySourceSSECustomerKey !== undefined) {
-    headers[
-      "x-amz-copy-source-server-side-encryption-customer-key"
-    ] = input.CopySourceSSECustomerKey.toString();
+    headers["x-amz-copy-source-server-side-encryption-customer-key"] =
+      input.CopySourceSSECustomerKey;
   }
   if (input.CopySourceSSECustomerKeyMD5 !== undefined) {
-    headers[
-      "x-amz-copy-source-server-side-encryption-customer-key-MD5"
-    ] = input.CopySourceSSECustomerKeyMD5.toString();
+    headers["x-amz-copy-source-server-side-encryption-customer-key-MD5"] =
+      input.CopySourceSSECustomerKeyMD5;
   }
   if (input.Expires !== undefined) {
     headers["Expires"] = input.Expires.toUTCString();
   }
   if (input.GrantFullControl !== undefined) {
-    headers["x-amz-grant-full-control"] = input.GrantFullControl.toString();
+    headers["x-amz-grant-full-control"] = input.GrantFullControl;
   }
   if (input.GrantRead !== undefined) {
-    headers["x-amz-grant-read"] = input.GrantRead.toString();
+    headers["x-amz-grant-read"] = input.GrantRead;
   }
   if (input.GrantReadACP !== undefined) {
-    headers["x-amz-grant-read-acp"] = input.GrantReadACP.toString();
+    headers["x-amz-grant-read-acp"] = input.GrantReadACP;
   }
   if (input.GrantWriteACP !== undefined) {
-    headers["x-amz-grant-write-acp"] = input.GrantWriteACP.toString();
+    headers["x-amz-grant-write-acp"] = input.GrantWriteACP;
   }
   if (input.MetadataDirective !== undefined) {
-    headers["x-amz-metadata-directive"] = input.MetadataDirective.toString();
+    headers["x-amz-metadata-directive"] = input.MetadataDirective;
   }
   if (input.ObjectLockLegalHoldStatus !== undefined) {
-    headers[
-      "x-amz-object-lock-legal-hold"
-    ] = input.ObjectLockLegalHoldStatus.toString();
+    headers["x-amz-object-lock-legal-hold"] = input.ObjectLockLegalHoldStatus;
   }
   if (input.ObjectLockMode !== undefined) {
-    headers["x-amz-object-lock-mode"] = input.ObjectLockMode.toString();
+    headers["x-amz-object-lock-mode"] = input.ObjectLockMode;
   }
   if (input.ObjectLockRetainUntilDate !== undefined) {
     headers[
@@ -690,72 +690,61 @@ export async function serializeAws_restXmlCopyObjectCommand(
     ] = input.ObjectLockRetainUntilDate.toISOString();
   }
   if (input.RequestPayer !== undefined) {
-    headers["x-amz-request-payer"] = input.RequestPayer.toString();
+    headers["x-amz-request-payer"] = input.RequestPayer;
   }
   if (input.SSECustomerAlgorithm !== undefined) {
-    headers[
-      "x-amz-server-side-encryption-customer-algorithm"
-    ] = input.SSECustomerAlgorithm.toString();
+    headers["x-amz-server-side-encryption-customer-algorithm"] =
+      input.SSECustomerAlgorithm;
   }
   if (input.SSECustomerKey !== undefined) {
-    headers[
-      "x-amz-server-side-encryption-customer-key"
-    ] = input.SSECustomerKey.toString();
+    headers["x-amz-server-side-encryption-customer-key"] = input.SSECustomerKey;
   }
   if (input.SSECustomerKeyMD5 !== undefined) {
-    headers[
-      "x-amz-server-side-encryption-customer-key-MD5"
-    ] = input.SSECustomerKeyMD5.toString();
+    headers["x-amz-server-side-encryption-customer-key-MD5"] =
+      input.SSECustomerKeyMD5;
   }
   if (input.SSEKMSEncryptionContext !== undefined) {
-    headers[
-      "x-amz-server-side-encryption-context"
-    ] = input.SSEKMSEncryptionContext.toString();
+    headers["x-amz-server-side-encryption-context"] =
+      input.SSEKMSEncryptionContext;
   }
   if (input.SSEKMSKeyId !== undefined) {
-    headers[
-      "x-amz-server-side-encryption-aws-kms-key-id"
-    ] = input.SSEKMSKeyId.toString();
+    headers["x-amz-server-side-encryption-aws-kms-key-id"] = input.SSEKMSKeyId;
   }
   if (input.ServerSideEncryption !== undefined) {
-    headers[
-      "x-amz-server-side-encryption"
-    ] = input.ServerSideEncryption.toString();
+    headers["x-amz-server-side-encryption"] = input.ServerSideEncryption;
   }
   if (input.StorageClass !== undefined) {
-    headers["x-amz-storage-class"] = input.StorageClass.toString();
+    headers["x-amz-storage-class"] = input.StorageClass;
   }
   if (input.Tagging !== undefined) {
-    headers["x-amz-tagging"] = input.Tagging.toString();
+    headers["x-amz-tagging"] = input.Tagging;
   }
   if (input.TaggingDirective !== undefined) {
-    headers["x-amz-tagging-directive"] = input.TaggingDirective.toString();
+    headers["x-amz-tagging-directive"] = input.TaggingDirective;
   }
   if (input.WebsiteRedirectLocation !== undefined) {
-    headers[
-      "x-amz-website-redirect-location"
-    ] = input.WebsiteRedirectLocation.toString();
+    headers["x-amz-website-redirect-location"] = input.WebsiteRedirectLocation;
   }
   if (input.Metadata !== undefined) {
     Object.keys(input.Metadata).forEach(suffix => {
-      headers["x-amz-meta-" + suffix] = input.Metadata![suffix].toString();
+      headers["x-amz-meta-" + suffix] = input.Metadata![suffix];
     });
   }
   let resolvedPath = "/{Bucket}/{Key+}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
   }
   if (input.Key !== undefined) {
-    const labelValue: string = input.Key.toString();
+    const labelValue: string = input.Key;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Key.");
     }
@@ -763,7 +752,7 @@ export async function serializeAws_restXmlCopyObjectCommand(
       "{Key+}",
       labelValue
         .split("/")
-        .map(segment => encodeURIComponent(segment))
+        .map(segment => __extendedEncodeURIComponent(segment))
         .join("/")
     );
   } else {
@@ -789,22 +778,22 @@ export async function serializeAws_restXmlCreateBucketCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/xml";
   if (input.ACL !== undefined) {
-    headers["x-amz-acl"] = input.ACL.toString();
+    headers["x-amz-acl"] = input.ACL;
   }
   if (input.GrantFullControl !== undefined) {
-    headers["x-amz-grant-full-control"] = input.GrantFullControl.toString();
+    headers["x-amz-grant-full-control"] = input.GrantFullControl;
   }
   if (input.GrantRead !== undefined) {
-    headers["x-amz-grant-read"] = input.GrantRead.toString();
+    headers["x-amz-grant-read"] = input.GrantRead;
   }
   if (input.GrantReadACP !== undefined) {
-    headers["x-amz-grant-read-acp"] = input.GrantReadACP.toString();
+    headers["x-amz-grant-read-acp"] = input.GrantReadACP;
   }
   if (input.GrantWrite !== undefined) {
-    headers["x-amz-grant-write"] = input.GrantWrite.toString();
+    headers["x-amz-grant-write"] = input.GrantWrite;
   }
   if (input.GrantWriteACP !== undefined) {
-    headers["x-amz-grant-write-acp"] = input.GrantWriteACP.toString();
+    headers["x-amz-grant-write-acp"] = input.GrantWriteACP;
   }
   if (input.ObjectLockEnabledForBucket !== undefined) {
     headers[
@@ -813,13 +802,13 @@ export async function serializeAws_restXmlCreateBucketCommand(
   }
   let resolvedPath = "/{Bucket}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
@@ -852,45 +841,43 @@ export async function serializeAws_restXmlCreateMultipartUploadCommand(
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.ACL !== undefined) {
-    headers["x-amz-acl"] = input.ACL.toString();
+    headers["x-amz-acl"] = input.ACL;
   }
   if (input.CacheControl !== undefined) {
-    headers["Cache-Control"] = input.CacheControl.toString();
+    headers["Cache-Control"] = input.CacheControl;
   }
   if (input.ContentDisposition !== undefined) {
-    headers["Content-Disposition"] = input.ContentDisposition.toString();
+    headers["Content-Disposition"] = input.ContentDisposition;
   }
   if (input.ContentEncoding !== undefined) {
-    headers["Content-Encoding"] = input.ContentEncoding.toString();
+    headers["Content-Encoding"] = input.ContentEncoding;
   }
   if (input.ContentLanguage !== undefined) {
-    headers["Content-Language"] = input.ContentLanguage.toString();
+    headers["Content-Language"] = input.ContentLanguage;
   }
   if (input.ContentType !== undefined) {
-    headers["Content-Type"] = input.ContentType.toString();
+    headers["Content-Type"] = input.ContentType;
   }
   if (input.Expires !== undefined) {
     headers["Expires"] = input.Expires.toUTCString();
   }
   if (input.GrantFullControl !== undefined) {
-    headers["x-amz-grant-full-control"] = input.GrantFullControl.toString();
+    headers["x-amz-grant-full-control"] = input.GrantFullControl;
   }
   if (input.GrantRead !== undefined) {
-    headers["x-amz-grant-read"] = input.GrantRead.toString();
+    headers["x-amz-grant-read"] = input.GrantRead;
   }
   if (input.GrantReadACP !== undefined) {
-    headers["x-amz-grant-read-acp"] = input.GrantReadACP.toString();
+    headers["x-amz-grant-read-acp"] = input.GrantReadACP;
   }
   if (input.GrantWriteACP !== undefined) {
-    headers["x-amz-grant-write-acp"] = input.GrantWriteACP.toString();
+    headers["x-amz-grant-write-acp"] = input.GrantWriteACP;
   }
   if (input.ObjectLockLegalHoldStatus !== undefined) {
-    headers[
-      "x-amz-object-lock-legal-hold"
-    ] = input.ObjectLockLegalHoldStatus.toString();
+    headers["x-amz-object-lock-legal-hold"] = input.ObjectLockLegalHoldStatus;
   }
   if (input.ObjectLockMode !== undefined) {
-    headers["x-amz-object-lock-mode"] = input.ObjectLockMode.toString();
+    headers["x-amz-object-lock-mode"] = input.ObjectLockMode;
   }
   if (input.ObjectLockRetainUntilDate !== undefined) {
     headers[
@@ -898,69 +885,58 @@ export async function serializeAws_restXmlCreateMultipartUploadCommand(
     ] = input.ObjectLockRetainUntilDate.toISOString();
   }
   if (input.RequestPayer !== undefined) {
-    headers["x-amz-request-payer"] = input.RequestPayer.toString();
+    headers["x-amz-request-payer"] = input.RequestPayer;
   }
   if (input.SSECustomerAlgorithm !== undefined) {
-    headers[
-      "x-amz-server-side-encryption-customer-algorithm"
-    ] = input.SSECustomerAlgorithm.toString();
+    headers["x-amz-server-side-encryption-customer-algorithm"] =
+      input.SSECustomerAlgorithm;
   }
   if (input.SSECustomerKey !== undefined) {
-    headers[
-      "x-amz-server-side-encryption-customer-key"
-    ] = input.SSECustomerKey.toString();
+    headers["x-amz-server-side-encryption-customer-key"] = input.SSECustomerKey;
   }
   if (input.SSECustomerKeyMD5 !== undefined) {
-    headers[
-      "x-amz-server-side-encryption-customer-key-MD5"
-    ] = input.SSECustomerKeyMD5.toString();
+    headers["x-amz-server-side-encryption-customer-key-MD5"] =
+      input.SSECustomerKeyMD5;
   }
   if (input.SSEKMSEncryptionContext !== undefined) {
-    headers[
-      "x-amz-server-side-encryption-context"
-    ] = input.SSEKMSEncryptionContext.toString();
+    headers["x-amz-server-side-encryption-context"] =
+      input.SSEKMSEncryptionContext;
   }
   if (input.SSEKMSKeyId !== undefined) {
-    headers[
-      "x-amz-server-side-encryption-aws-kms-key-id"
-    ] = input.SSEKMSKeyId.toString();
+    headers["x-amz-server-side-encryption-aws-kms-key-id"] = input.SSEKMSKeyId;
   }
   if (input.ServerSideEncryption !== undefined) {
-    headers[
-      "x-amz-server-side-encryption"
-    ] = input.ServerSideEncryption.toString();
+    headers["x-amz-server-side-encryption"] = input.ServerSideEncryption;
   }
   if (input.StorageClass !== undefined) {
-    headers["x-amz-storage-class"] = input.StorageClass.toString();
+    headers["x-amz-storage-class"] = input.StorageClass;
   }
   if (input.Tagging !== undefined) {
-    headers["x-amz-tagging"] = input.Tagging.toString();
+    headers["x-amz-tagging"] = input.Tagging;
   }
   if (input.WebsiteRedirectLocation !== undefined) {
-    headers[
-      "x-amz-website-redirect-location"
-    ] = input.WebsiteRedirectLocation.toString();
+    headers["x-amz-website-redirect-location"] = input.WebsiteRedirectLocation;
   }
   if (input.Metadata !== undefined) {
     Object.keys(input.Metadata).forEach(suffix => {
-      headers["x-amz-meta-" + suffix] = input.Metadata![suffix].toString();
+      headers["x-amz-meta-" + suffix] = input.Metadata![suffix];
     });
   }
   let resolvedPath = "/{Bucket}/{Key+}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
   }
   if (input.Key !== undefined) {
-    const labelValue: string = input.Key.toString();
+    const labelValue: string = input.Key;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Key.");
     }
@@ -968,7 +944,7 @@ export async function serializeAws_restXmlCreateMultipartUploadCommand(
       "{Key+}",
       labelValue
         .split("/")
-        .map(segment => encodeURIComponent(segment))
+        .map(segment => __extendedEncodeURIComponent(segment))
         .join("/")
     );
   } else {
@@ -995,13 +971,13 @@ export async function serializeAws_restXmlDeleteBucketCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/{Bucket}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
@@ -1023,13 +999,13 @@ export async function serializeAws_restXmlDeleteBucketAnalyticsConfigurationComm
   headers["Content-Type"] = "";
   let resolvedPath = "/{Bucket}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
@@ -1038,7 +1014,9 @@ export async function serializeAws_restXmlDeleteBucketAnalyticsConfigurationComm
     analytics: ""
   };
   if (input.Id !== undefined) {
-    query["id"] = input.Id.toString();
+    query[__extendedEncodeURIComponent("id")] = __extendedEncodeURIComponent(
+      input.Id
+    );
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1058,13 +1036,13 @@ export async function serializeAws_restXmlDeleteBucketCorsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/{Bucket}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
@@ -1090,13 +1068,13 @@ export async function serializeAws_restXmlDeleteBucketEncryptionCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/{Bucket}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
@@ -1122,13 +1100,13 @@ export async function serializeAws_restXmlDeleteBucketInventoryConfigurationComm
   headers["Content-Type"] = "";
   let resolvedPath = "/{Bucket}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
@@ -1137,7 +1115,9 @@ export async function serializeAws_restXmlDeleteBucketInventoryConfigurationComm
     inventory: ""
   };
   if (input.Id !== undefined) {
-    query["id"] = input.Id.toString();
+    query[__extendedEncodeURIComponent("id")] = __extendedEncodeURIComponent(
+      input.Id
+    );
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1157,13 +1137,13 @@ export async function serializeAws_restXmlDeleteBucketLifecycleCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/{Bucket}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
@@ -1189,13 +1169,13 @@ export async function serializeAws_restXmlDeleteBucketMetricsConfigurationComman
   headers["Content-Type"] = "";
   let resolvedPath = "/{Bucket}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
@@ -1204,7 +1184,9 @@ export async function serializeAws_restXmlDeleteBucketMetricsConfigurationComman
     metrics: ""
   };
   if (input.Id !== undefined) {
-    query["id"] = input.Id.toString();
+    query[__extendedEncodeURIComponent("id")] = __extendedEncodeURIComponent(
+      input.Id
+    );
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1224,13 +1206,13 @@ export async function serializeAws_restXmlDeleteBucketPolicyCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/{Bucket}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
@@ -1256,13 +1238,13 @@ export async function serializeAws_restXmlDeleteBucketReplicationCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/{Bucket}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
@@ -1288,13 +1270,13 @@ export async function serializeAws_restXmlDeleteBucketTaggingCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/{Bucket}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
@@ -1320,13 +1302,13 @@ export async function serializeAws_restXmlDeleteBucketWebsiteCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/{Bucket}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
@@ -1356,26 +1338,26 @@ export async function serializeAws_restXmlDeleteObjectCommand(
     ] = input.BypassGovernanceRetention.toString();
   }
   if (input.MFA !== undefined) {
-    headers["x-amz-mfa"] = input.MFA.toString();
+    headers["x-amz-mfa"] = input.MFA;
   }
   if (input.RequestPayer !== undefined) {
-    headers["x-amz-request-payer"] = input.RequestPayer.toString();
+    headers["x-amz-request-payer"] = input.RequestPayer;
   }
   let resolvedPath = "/{Bucket}/{Key+}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
   }
   if (input.Key !== undefined) {
-    const labelValue: string = input.Key.toString();
+    const labelValue: string = input.Key;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Key.");
     }
@@ -1383,7 +1365,7 @@ export async function serializeAws_restXmlDeleteObjectCommand(
       "{Key+}",
       labelValue
         .split("/")
-        .map(segment => encodeURIComponent(segment))
+        .map(segment => __extendedEncodeURIComponent(segment))
         .join("/")
     );
   } else {
@@ -1393,7 +1375,9 @@ export async function serializeAws_restXmlDeleteObjectCommand(
     "x-id": "DeleteObject"
   };
   if (input.VersionId !== undefined) {
-    query["versionId"] = input.VersionId.toString();
+    query[
+      __extendedEncodeURIComponent("versionId")
+    ] = __extendedEncodeURIComponent(input.VersionId);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1413,19 +1397,19 @@ export async function serializeAws_restXmlDeleteObjectTaggingCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/{Bucket}/{Key+}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
   }
   if (input.Key !== undefined) {
-    const labelValue: string = input.Key.toString();
+    const labelValue: string = input.Key;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Key.");
     }
@@ -1433,7 +1417,7 @@ export async function serializeAws_restXmlDeleteObjectTaggingCommand(
       "{Key+}",
       labelValue
         .split("/")
-        .map(segment => encodeURIComponent(segment))
+        .map(segment => __extendedEncodeURIComponent(segment))
         .join("/")
     );
   } else {
@@ -1443,7 +1427,9 @@ export async function serializeAws_restXmlDeleteObjectTaggingCommand(
     tagging: ""
   };
   if (input.VersionId !== undefined) {
-    query["versionId"] = input.VersionId.toString();
+    query[
+      __extendedEncodeURIComponent("versionId")
+    ] = __extendedEncodeURIComponent(input.VersionId);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1467,20 +1453,20 @@ export async function serializeAws_restXmlDeleteObjectsCommand(
     ] = input.BypassGovernanceRetention.toString();
   }
   if (input.MFA !== undefined) {
-    headers["x-amz-mfa"] = input.MFA.toString();
+    headers["x-amz-mfa"] = input.MFA;
   }
   if (input.RequestPayer !== undefined) {
-    headers["x-amz-request-payer"] = input.RequestPayer.toString();
+    headers["x-amz-request-payer"] = input.RequestPayer;
   }
   let resolvedPath = "/{Bucket}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
@@ -1515,13 +1501,13 @@ export async function serializeAws_restXmlDeletePublicAccessBlockCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/{Bucket}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
@@ -1547,13 +1533,13 @@ export async function serializeAws_restXmlGetBucketAccelerateConfigurationComman
   headers["Content-Type"] = "";
   let resolvedPath = "/{Bucket}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
@@ -1579,13 +1565,13 @@ export async function serializeAws_restXmlGetBucketAclCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/{Bucket}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
@@ -1611,13 +1597,13 @@ export async function serializeAws_restXmlGetBucketAnalyticsConfigurationCommand
   headers["Content-Type"] = "";
   let resolvedPath = "/{Bucket}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
@@ -1627,7 +1613,9 @@ export async function serializeAws_restXmlGetBucketAnalyticsConfigurationCommand
     "x-id": "GetBucketAnalyticsConfiguration"
   };
   if (input.Id !== undefined) {
-    query["id"] = input.Id.toString();
+    query[__extendedEncodeURIComponent("id")] = __extendedEncodeURIComponent(
+      input.Id
+    );
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1647,13 +1635,13 @@ export async function serializeAws_restXmlGetBucketCorsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/{Bucket}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
@@ -1679,13 +1667,13 @@ export async function serializeAws_restXmlGetBucketEncryptionCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/{Bucket}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
@@ -1711,13 +1699,13 @@ export async function serializeAws_restXmlGetBucketInventoryConfigurationCommand
   headers["Content-Type"] = "";
   let resolvedPath = "/{Bucket}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
@@ -1727,7 +1715,9 @@ export async function serializeAws_restXmlGetBucketInventoryConfigurationCommand
     "x-id": "GetBucketInventoryConfiguration"
   };
   if (input.Id !== undefined) {
-    query["id"] = input.Id.toString();
+    query[__extendedEncodeURIComponent("id")] = __extendedEncodeURIComponent(
+      input.Id
+    );
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1747,13 +1737,13 @@ export async function serializeAws_restXmlGetBucketLifecycleConfigurationCommand
   headers["Content-Type"] = "";
   let resolvedPath = "/{Bucket}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
@@ -1779,13 +1769,13 @@ export async function serializeAws_restXmlGetBucketLocationCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/{Bucket}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
@@ -1811,13 +1801,13 @@ export async function serializeAws_restXmlGetBucketLoggingCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/{Bucket}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
@@ -1843,13 +1833,13 @@ export async function serializeAws_restXmlGetBucketMetricsConfigurationCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/{Bucket}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
@@ -1859,7 +1849,9 @@ export async function serializeAws_restXmlGetBucketMetricsConfigurationCommand(
     "x-id": "GetBucketMetricsConfiguration"
   };
   if (input.Id !== undefined) {
-    query["id"] = input.Id.toString();
+    query[__extendedEncodeURIComponent("id")] = __extendedEncodeURIComponent(
+      input.Id
+    );
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1879,13 +1871,13 @@ export async function serializeAws_restXmlGetBucketNotificationConfigurationComm
   headers["Content-Type"] = "";
   let resolvedPath = "/{Bucket}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
@@ -1911,13 +1903,13 @@ export async function serializeAws_restXmlGetBucketPolicyCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/{Bucket}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
@@ -1943,13 +1935,13 @@ export async function serializeAws_restXmlGetBucketPolicyStatusCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/{Bucket}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
@@ -1975,13 +1967,13 @@ export async function serializeAws_restXmlGetBucketReplicationCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/{Bucket}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
@@ -2007,13 +1999,13 @@ export async function serializeAws_restXmlGetBucketRequestPaymentCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/{Bucket}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
@@ -2039,13 +2031,13 @@ export async function serializeAws_restXmlGetBucketTaggingCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/{Bucket}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
@@ -2071,13 +2063,13 @@ export async function serializeAws_restXmlGetBucketVersioningCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/{Bucket}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
@@ -2103,13 +2095,13 @@ export async function serializeAws_restXmlGetBucketWebsiteCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/{Bucket}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
@@ -2134,53 +2126,49 @@ export async function serializeAws_restXmlGetObjectCommand(
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.IfMatch !== undefined) {
-    headers["If-Match"] = input.IfMatch.toString();
+    headers["If-Match"] = input.IfMatch;
   }
   if (input.IfModifiedSince !== undefined) {
     headers["If-Modified-Since"] = input.IfModifiedSince.toUTCString();
   }
   if (input.IfNoneMatch !== undefined) {
-    headers["If-None-Match"] = input.IfNoneMatch.toString();
+    headers["If-None-Match"] = input.IfNoneMatch;
   }
   if (input.IfUnmodifiedSince !== undefined) {
     headers["If-Unmodified-Since"] = input.IfUnmodifiedSince.toUTCString();
   }
   if (input.Range !== undefined) {
-    headers["Range"] = input.Range.toString();
+    headers["Range"] = input.Range;
   }
   if (input.RequestPayer !== undefined) {
-    headers["x-amz-request-payer"] = input.RequestPayer.toString();
+    headers["x-amz-request-payer"] = input.RequestPayer;
   }
   if (input.SSECustomerAlgorithm !== undefined) {
-    headers[
-      "x-amz-server-side-encryption-customer-algorithm"
-    ] = input.SSECustomerAlgorithm.toString();
+    headers["x-amz-server-side-encryption-customer-algorithm"] =
+      input.SSECustomerAlgorithm;
   }
   if (input.SSECustomerKey !== undefined) {
-    headers[
-      "x-amz-server-side-encryption-customer-key"
-    ] = input.SSECustomerKey.toString();
+    headers["x-amz-server-side-encryption-customer-key"] = input.SSECustomerKey;
   }
   if (input.SSECustomerKeyMD5 !== undefined) {
-    headers[
-      "x-amz-server-side-encryption-customer-key-MD5"
-    ] = input.SSECustomerKeyMD5.toString();
+    headers["x-amz-server-side-encryption-customer-key-MD5"] =
+      input.SSECustomerKeyMD5;
   }
   let resolvedPath = "/{Bucket}/{Key+}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
   }
   if (input.Key !== undefined) {
-    const labelValue: string = input.Key.toString();
+    const labelValue: string = input.Key;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Key.");
     }
@@ -2188,7 +2176,7 @@ export async function serializeAws_restXmlGetObjectCommand(
       "{Key+}",
       labelValue
         .split("/")
-        .map(segment => encodeURIComponent(segment))
+        .map(segment => __extendedEncodeURIComponent(segment))
         .join("/")
     );
   } else {
@@ -2198,34 +2186,44 @@ export async function serializeAws_restXmlGetObjectCommand(
     "x-id": "GetObject"
   };
   if (input.PartNumber !== undefined) {
-    query["partNumber"] = input.PartNumber.toString();
+    query[
+      __extendedEncodeURIComponent("partNumber")
+    ] = __extendedEncodeURIComponent(input.PartNumber.toString());
   }
   if (input.ResponseCacheControl !== undefined) {
-    query["response-cache-control"] = input.ResponseCacheControl.toString();
+    query[
+      __extendedEncodeURIComponent("response-cache-control")
+    ] = __extendedEncodeURIComponent(input.ResponseCacheControl);
   }
   if (input.ResponseContentDisposition !== undefined) {
     query[
-      "response-content-disposition"
-    ] = input.ResponseContentDisposition.toString();
+      __extendedEncodeURIComponent("response-content-disposition")
+    ] = __extendedEncodeURIComponent(input.ResponseContentDisposition);
   }
   if (input.ResponseContentEncoding !== undefined) {
     query[
-      "response-content-encoding"
-    ] = input.ResponseContentEncoding.toString();
+      __extendedEncodeURIComponent("response-content-encoding")
+    ] = __extendedEncodeURIComponent(input.ResponseContentEncoding);
   }
   if (input.ResponseContentLanguage !== undefined) {
     query[
-      "response-content-language"
-    ] = input.ResponseContentLanguage.toString();
+      __extendedEncodeURIComponent("response-content-language")
+    ] = __extendedEncodeURIComponent(input.ResponseContentLanguage);
   }
   if (input.ResponseContentType !== undefined) {
-    query["response-content-type"] = input.ResponseContentType.toString();
+    query[
+      __extendedEncodeURIComponent("response-content-type")
+    ] = __extendedEncodeURIComponent(input.ResponseContentType);
   }
   if (input.ResponseExpires !== undefined) {
-    query["response-expires"] = input.ResponseExpires.toISOString();
+    query[
+      __extendedEncodeURIComponent("response-expires")
+    ] = __extendedEncodeURIComponent(input.ResponseExpires.toISOString());
   }
   if (input.VersionId !== undefined) {
-    query["versionId"] = input.VersionId.toString();
+    query[
+      __extendedEncodeURIComponent("versionId")
+    ] = __extendedEncodeURIComponent(input.VersionId);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2244,23 +2242,23 @@ export async function serializeAws_restXmlGetObjectAclCommand(
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.RequestPayer !== undefined) {
-    headers["x-amz-request-payer"] = input.RequestPayer.toString();
+    headers["x-amz-request-payer"] = input.RequestPayer;
   }
   let resolvedPath = "/{Bucket}/{Key+}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
   }
   if (input.Key !== undefined) {
-    const labelValue: string = input.Key.toString();
+    const labelValue: string = input.Key;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Key.");
     }
@@ -2268,7 +2266,7 @@ export async function serializeAws_restXmlGetObjectAclCommand(
       "{Key+}",
       labelValue
         .split("/")
-        .map(segment => encodeURIComponent(segment))
+        .map(segment => __extendedEncodeURIComponent(segment))
         .join("/")
     );
   } else {
@@ -2278,7 +2276,9 @@ export async function serializeAws_restXmlGetObjectAclCommand(
     acl: ""
   };
   if (input.VersionId !== undefined) {
-    query["versionId"] = input.VersionId.toString();
+    query[
+      __extendedEncodeURIComponent("versionId")
+    ] = __extendedEncodeURIComponent(input.VersionId);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2297,23 +2297,23 @@ export async function serializeAws_restXmlGetObjectLegalHoldCommand(
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.RequestPayer !== undefined) {
-    headers["x-amz-request-payer"] = input.RequestPayer.toString();
+    headers["x-amz-request-payer"] = input.RequestPayer;
   }
   let resolvedPath = "/{Bucket}/{Key+}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
   }
   if (input.Key !== undefined) {
-    const labelValue: string = input.Key.toString();
+    const labelValue: string = input.Key;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Key.");
     }
@@ -2321,7 +2321,7 @@ export async function serializeAws_restXmlGetObjectLegalHoldCommand(
       "{Key+}",
       labelValue
         .split("/")
-        .map(segment => encodeURIComponent(segment))
+        .map(segment => __extendedEncodeURIComponent(segment))
         .join("/")
     );
   } else {
@@ -2331,7 +2331,9 @@ export async function serializeAws_restXmlGetObjectLegalHoldCommand(
     "legal-hold": ""
   };
   if (input.VersionId !== undefined) {
-    query["versionId"] = input.VersionId.toString();
+    query[
+      __extendedEncodeURIComponent("versionId")
+    ] = __extendedEncodeURIComponent(input.VersionId);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2351,13 +2353,13 @@ export async function serializeAws_restXmlGetObjectLockConfigurationCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/{Bucket}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
@@ -2382,23 +2384,23 @@ export async function serializeAws_restXmlGetObjectRetentionCommand(
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.RequestPayer !== undefined) {
-    headers["x-amz-request-payer"] = input.RequestPayer.toString();
+    headers["x-amz-request-payer"] = input.RequestPayer;
   }
   let resolvedPath = "/{Bucket}/{Key+}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
   }
   if (input.Key !== undefined) {
-    const labelValue: string = input.Key.toString();
+    const labelValue: string = input.Key;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Key.");
     }
@@ -2406,7 +2408,7 @@ export async function serializeAws_restXmlGetObjectRetentionCommand(
       "{Key+}",
       labelValue
         .split("/")
-        .map(segment => encodeURIComponent(segment))
+        .map(segment => __extendedEncodeURIComponent(segment))
         .join("/")
     );
   } else {
@@ -2416,7 +2418,9 @@ export async function serializeAws_restXmlGetObjectRetentionCommand(
     retention: ""
   };
   if (input.VersionId !== undefined) {
-    query["versionId"] = input.VersionId.toString();
+    query[
+      __extendedEncodeURIComponent("versionId")
+    ] = __extendedEncodeURIComponent(input.VersionId);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2436,19 +2440,19 @@ export async function serializeAws_restXmlGetObjectTaggingCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/{Bucket}/{Key+}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
   }
   if (input.Key !== undefined) {
-    const labelValue: string = input.Key.toString();
+    const labelValue: string = input.Key;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Key.");
     }
@@ -2456,7 +2460,7 @@ export async function serializeAws_restXmlGetObjectTaggingCommand(
       "{Key+}",
       labelValue
         .split("/")
-        .map(segment => encodeURIComponent(segment))
+        .map(segment => __extendedEncodeURIComponent(segment))
         .join("/")
     );
   } else {
@@ -2466,7 +2470,9 @@ export async function serializeAws_restXmlGetObjectTaggingCommand(
     tagging: ""
   };
   if (input.VersionId !== undefined) {
-    query["versionId"] = input.VersionId.toString();
+    query[
+      __extendedEncodeURIComponent("versionId")
+    ] = __extendedEncodeURIComponent(input.VersionId);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2485,23 +2491,23 @@ export async function serializeAws_restXmlGetObjectTorrentCommand(
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.RequestPayer !== undefined) {
-    headers["x-amz-request-payer"] = input.RequestPayer.toString();
+    headers["x-amz-request-payer"] = input.RequestPayer;
   }
   let resolvedPath = "/{Bucket}/{Key+}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
   }
   if (input.Key !== undefined) {
-    const labelValue: string = input.Key.toString();
+    const labelValue: string = input.Key;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Key.");
     }
@@ -2509,7 +2515,7 @@ export async function serializeAws_restXmlGetObjectTorrentCommand(
       "{Key+}",
       labelValue
         .split("/")
-        .map(segment => encodeURIComponent(segment))
+        .map(segment => __extendedEncodeURIComponent(segment))
         .join("/")
     );
   } else {
@@ -2536,13 +2542,13 @@ export async function serializeAws_restXmlGetPublicAccessBlockCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/{Bucket}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
@@ -2568,13 +2574,13 @@ export async function serializeAws_restXmlHeadBucketCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/{Bucket}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
@@ -2595,53 +2601,49 @@ export async function serializeAws_restXmlHeadObjectCommand(
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.IfMatch !== undefined) {
-    headers["If-Match"] = input.IfMatch.toString();
+    headers["If-Match"] = input.IfMatch;
   }
   if (input.IfModifiedSince !== undefined) {
     headers["If-Modified-Since"] = input.IfModifiedSince.toUTCString();
   }
   if (input.IfNoneMatch !== undefined) {
-    headers["If-None-Match"] = input.IfNoneMatch.toString();
+    headers["If-None-Match"] = input.IfNoneMatch;
   }
   if (input.IfUnmodifiedSince !== undefined) {
     headers["If-Unmodified-Since"] = input.IfUnmodifiedSince.toUTCString();
   }
   if (input.Range !== undefined) {
-    headers["Range"] = input.Range.toString();
+    headers["Range"] = input.Range;
   }
   if (input.RequestPayer !== undefined) {
-    headers["x-amz-request-payer"] = input.RequestPayer.toString();
+    headers["x-amz-request-payer"] = input.RequestPayer;
   }
   if (input.SSECustomerAlgorithm !== undefined) {
-    headers[
-      "x-amz-server-side-encryption-customer-algorithm"
-    ] = input.SSECustomerAlgorithm.toString();
+    headers["x-amz-server-side-encryption-customer-algorithm"] =
+      input.SSECustomerAlgorithm;
   }
   if (input.SSECustomerKey !== undefined) {
-    headers[
-      "x-amz-server-side-encryption-customer-key"
-    ] = input.SSECustomerKey.toString();
+    headers["x-amz-server-side-encryption-customer-key"] = input.SSECustomerKey;
   }
   if (input.SSECustomerKeyMD5 !== undefined) {
-    headers[
-      "x-amz-server-side-encryption-customer-key-MD5"
-    ] = input.SSECustomerKeyMD5.toString();
+    headers["x-amz-server-side-encryption-customer-key-MD5"] =
+      input.SSECustomerKeyMD5;
   }
   let resolvedPath = "/{Bucket}/{Key+}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
   }
   if (input.Key !== undefined) {
-    const labelValue: string = input.Key.toString();
+    const labelValue: string = input.Key;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Key.");
     }
@@ -2649,7 +2651,7 @@ export async function serializeAws_restXmlHeadObjectCommand(
       "{Key+}",
       labelValue
         .split("/")
-        .map(segment => encodeURIComponent(segment))
+        .map(segment => __extendedEncodeURIComponent(segment))
         .join("/")
     );
   } else {
@@ -2657,10 +2659,14 @@ export async function serializeAws_restXmlHeadObjectCommand(
   }
   const query: any = {};
   if (input.PartNumber !== undefined) {
-    query["partNumber"] = input.PartNumber.toString();
+    query[
+      __extendedEncodeURIComponent("partNumber")
+    ] = __extendedEncodeURIComponent(input.PartNumber.toString());
   }
   if (input.VersionId !== undefined) {
-    query["versionId"] = input.VersionId.toString();
+    query[
+      __extendedEncodeURIComponent("versionId")
+    ] = __extendedEncodeURIComponent(input.VersionId);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2680,13 +2686,13 @@ export async function serializeAws_restXmlListBucketAnalyticsConfigurationsComma
   headers["Content-Type"] = "";
   let resolvedPath = "/{Bucket}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
@@ -2696,7 +2702,9 @@ export async function serializeAws_restXmlListBucketAnalyticsConfigurationsComma
     "x-id": "ListBucketAnalyticsConfigurations"
   };
   if (input.ContinuationToken !== undefined) {
-    query["continuation-token"] = input.ContinuationToken.toString();
+    query[
+      __extendedEncodeURIComponent("continuation-token")
+    ] = __extendedEncodeURIComponent(input.ContinuationToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2716,13 +2724,13 @@ export async function serializeAws_restXmlListBucketInventoryConfigurationsComma
   headers["Content-Type"] = "";
   let resolvedPath = "/{Bucket}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
@@ -2732,7 +2740,9 @@ export async function serializeAws_restXmlListBucketInventoryConfigurationsComma
     "x-id": "ListBucketInventoryConfigurations"
   };
   if (input.ContinuationToken !== undefined) {
-    query["continuation-token"] = input.ContinuationToken.toString();
+    query[
+      __extendedEncodeURIComponent("continuation-token")
+    ] = __extendedEncodeURIComponent(input.ContinuationToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2752,13 +2762,13 @@ export async function serializeAws_restXmlListBucketMetricsConfigurationsCommand
   headers["Content-Type"] = "";
   let resolvedPath = "/{Bucket}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
@@ -2768,7 +2778,9 @@ export async function serializeAws_restXmlListBucketMetricsConfigurationsCommand
     "x-id": "ListBucketMetricsConfigurations"
   };
   if (input.ContinuationToken !== undefined) {
-    query["continuation-token"] = input.ContinuationToken.toString();
+    query[
+      __extendedEncodeURIComponent("continuation-token")
+    ] = __extendedEncodeURIComponent(input.ContinuationToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2804,13 +2816,13 @@ export async function serializeAws_restXmlListMultipartUploadsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/{Bucket}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
@@ -2819,22 +2831,34 @@ export async function serializeAws_restXmlListMultipartUploadsCommand(
     uploads: ""
   };
   if (input.Delimiter !== undefined) {
-    query["delimiter"] = input.Delimiter.toString();
+    query[
+      __extendedEncodeURIComponent("delimiter")
+    ] = __extendedEncodeURIComponent(input.Delimiter);
   }
   if (input.EncodingType !== undefined) {
-    query["encoding-type"] = input.EncodingType.toString();
+    query[
+      __extendedEncodeURIComponent("encoding-type")
+    ] = __extendedEncodeURIComponent(input.EncodingType);
   }
   if (input.KeyMarker !== undefined) {
-    query["key-marker"] = input.KeyMarker.toString();
+    query[
+      __extendedEncodeURIComponent("key-marker")
+    ] = __extendedEncodeURIComponent(input.KeyMarker);
   }
   if (input.MaxUploads !== undefined) {
-    query["max-uploads"] = input.MaxUploads.toString();
+    query[
+      __extendedEncodeURIComponent("max-uploads")
+    ] = __extendedEncodeURIComponent(input.MaxUploads.toString());
   }
   if (input.Prefix !== undefined) {
-    query["prefix"] = input.Prefix.toString();
+    query[
+      __extendedEncodeURIComponent("prefix")
+    ] = __extendedEncodeURIComponent(input.Prefix);
   }
   if (input.UploadIdMarker !== undefined) {
-    query["upload-id-marker"] = input.UploadIdMarker.toString();
+    query[
+      __extendedEncodeURIComponent("upload-id-marker")
+    ] = __extendedEncodeURIComponent(input.UploadIdMarker);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2854,13 +2878,13 @@ export async function serializeAws_restXmlListObjectVersionsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/{Bucket}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
@@ -2869,22 +2893,34 @@ export async function serializeAws_restXmlListObjectVersionsCommand(
     versions: ""
   };
   if (input.Delimiter !== undefined) {
-    query["delimiter"] = input.Delimiter.toString();
+    query[
+      __extendedEncodeURIComponent("delimiter")
+    ] = __extendedEncodeURIComponent(input.Delimiter);
   }
   if (input.EncodingType !== undefined) {
-    query["encoding-type"] = input.EncodingType.toString();
+    query[
+      __extendedEncodeURIComponent("encoding-type")
+    ] = __extendedEncodeURIComponent(input.EncodingType);
   }
   if (input.KeyMarker !== undefined) {
-    query["key-marker"] = input.KeyMarker.toString();
+    query[
+      __extendedEncodeURIComponent("key-marker")
+    ] = __extendedEncodeURIComponent(input.KeyMarker);
   }
   if (input.MaxKeys !== undefined) {
-    query["max-keys"] = input.MaxKeys.toString();
+    query[
+      __extendedEncodeURIComponent("max-keys")
+    ] = __extendedEncodeURIComponent(input.MaxKeys.toString());
   }
   if (input.Prefix !== undefined) {
-    query["prefix"] = input.Prefix.toString();
+    query[
+      __extendedEncodeURIComponent("prefix")
+    ] = __extendedEncodeURIComponent(input.Prefix);
   }
   if (input.VersionIdMarker !== undefined) {
-    query["version-id-marker"] = input.VersionIdMarker.toString();
+    query[
+      __extendedEncodeURIComponent("version-id-marker")
+    ] = __extendedEncodeURIComponent(input.VersionIdMarker);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2903,36 +2939,46 @@ export async function serializeAws_restXmlListObjectsCommand(
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.RequestPayer !== undefined) {
-    headers["x-amz-request-payer"] = input.RequestPayer.toString();
+    headers["x-amz-request-payer"] = input.RequestPayer;
   }
   let resolvedPath = "/{Bucket}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
   }
   const query: any = {};
   if (input.Delimiter !== undefined) {
-    query["delimiter"] = input.Delimiter.toString();
+    query[
+      __extendedEncodeURIComponent("delimiter")
+    ] = __extendedEncodeURIComponent(input.Delimiter);
   }
   if (input.EncodingType !== undefined) {
-    query["encoding-type"] = input.EncodingType.toString();
+    query[
+      __extendedEncodeURIComponent("encoding-type")
+    ] = __extendedEncodeURIComponent(input.EncodingType);
   }
   if (input.Marker !== undefined) {
-    query["marker"] = input.Marker.toString();
+    query[
+      __extendedEncodeURIComponent("marker")
+    ] = __extendedEncodeURIComponent(input.Marker);
   }
   if (input.MaxKeys !== undefined) {
-    query["max-keys"] = input.MaxKeys.toString();
+    query[
+      __extendedEncodeURIComponent("max-keys")
+    ] = __extendedEncodeURIComponent(input.MaxKeys.toString());
   }
   if (input.Prefix !== undefined) {
-    query["prefix"] = input.Prefix.toString();
+    query[
+      __extendedEncodeURIComponent("prefix")
+    ] = __extendedEncodeURIComponent(input.Prefix);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -2951,17 +2997,17 @@ export async function serializeAws_restXmlListObjectsV2Command(
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.RequestPayer !== undefined) {
-    headers["x-amz-request-payer"] = input.RequestPayer.toString();
+    headers["x-amz-request-payer"] = input.RequestPayer;
   }
   let resolvedPath = "/{Bucket}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
@@ -2970,25 +3016,39 @@ export async function serializeAws_restXmlListObjectsV2Command(
     "list-type": "2"
   };
   if (input.ContinuationToken !== undefined) {
-    query["continuation-token"] = input.ContinuationToken.toString();
+    query[
+      __extendedEncodeURIComponent("continuation-token")
+    ] = __extendedEncodeURIComponent(input.ContinuationToken);
   }
   if (input.Delimiter !== undefined) {
-    query["delimiter"] = input.Delimiter.toString();
+    query[
+      __extendedEncodeURIComponent("delimiter")
+    ] = __extendedEncodeURIComponent(input.Delimiter);
   }
   if (input.EncodingType !== undefined) {
-    query["encoding-type"] = input.EncodingType.toString();
+    query[
+      __extendedEncodeURIComponent("encoding-type")
+    ] = __extendedEncodeURIComponent(input.EncodingType);
   }
   if (input.FetchOwner !== undefined) {
-    query["fetch-owner"] = input.FetchOwner.toString();
+    query[
+      __extendedEncodeURIComponent("fetch-owner")
+    ] = __extendedEncodeURIComponent(input.FetchOwner.toString());
   }
   if (input.MaxKeys !== undefined) {
-    query["max-keys"] = input.MaxKeys.toString();
+    query[
+      __extendedEncodeURIComponent("max-keys")
+    ] = __extendedEncodeURIComponent(input.MaxKeys.toString());
   }
   if (input.Prefix !== undefined) {
-    query["prefix"] = input.Prefix.toString();
+    query[
+      __extendedEncodeURIComponent("prefix")
+    ] = __extendedEncodeURIComponent(input.Prefix);
   }
   if (input.StartAfter !== undefined) {
-    query["start-after"] = input.StartAfter.toString();
+    query[
+      __extendedEncodeURIComponent("start-after")
+    ] = __extendedEncodeURIComponent(input.StartAfter);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -3007,23 +3067,23 @@ export async function serializeAws_restXmlListPartsCommand(
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.RequestPayer !== undefined) {
-    headers["x-amz-request-payer"] = input.RequestPayer.toString();
+    headers["x-amz-request-payer"] = input.RequestPayer;
   }
   let resolvedPath = "/{Bucket}/{Key+}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
   }
   if (input.Key !== undefined) {
-    const labelValue: string = input.Key.toString();
+    const labelValue: string = input.Key;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Key.");
     }
@@ -3031,7 +3091,7 @@ export async function serializeAws_restXmlListPartsCommand(
       "{Key+}",
       labelValue
         .split("/")
-        .map(segment => encodeURIComponent(segment))
+        .map(segment => __extendedEncodeURIComponent(segment))
         .join("/")
     );
   } else {
@@ -3041,13 +3101,19 @@ export async function serializeAws_restXmlListPartsCommand(
     "x-id": "ListParts"
   };
   if (input.MaxParts !== undefined) {
-    query["max-parts"] = input.MaxParts.toString();
+    query[
+      __extendedEncodeURIComponent("max-parts")
+    ] = __extendedEncodeURIComponent(input.MaxParts.toString());
   }
   if (input.PartNumberMarker !== undefined) {
-    query["part-number-marker"] = input.PartNumberMarker.toString();
+    query[
+      __extendedEncodeURIComponent("part-number-marker")
+    ] = __extendedEncodeURIComponent(input.PartNumberMarker.toString());
   }
   if (input.UploadId !== undefined) {
-    query["uploadId"] = input.UploadId.toString();
+    query[
+      __extendedEncodeURIComponent("uploadId")
+    ] = __extendedEncodeURIComponent(input.UploadId);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -3067,13 +3133,13 @@ export async function serializeAws_restXmlPutBucketAccelerateConfigurationComman
   headers["Content-Type"] = "application/xml";
   let resolvedPath = "/{Bucket}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
@@ -3110,35 +3176,35 @@ export async function serializeAws_restXmlPutBucketAclCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/xml";
   if (input.ACL !== undefined) {
-    headers["x-amz-acl"] = input.ACL.toString();
+    headers["x-amz-acl"] = input.ACL;
   }
   if (input.ContentMD5 !== undefined) {
-    headers["Content-MD5"] = input.ContentMD5.toString();
+    headers["Content-MD5"] = input.ContentMD5;
   }
   if (input.GrantFullControl !== undefined) {
-    headers["x-amz-grant-full-control"] = input.GrantFullControl.toString();
+    headers["x-amz-grant-full-control"] = input.GrantFullControl;
   }
   if (input.GrantRead !== undefined) {
-    headers["x-amz-grant-read"] = input.GrantRead.toString();
+    headers["x-amz-grant-read"] = input.GrantRead;
   }
   if (input.GrantReadACP !== undefined) {
-    headers["x-amz-grant-read-acp"] = input.GrantReadACP.toString();
+    headers["x-amz-grant-read-acp"] = input.GrantReadACP;
   }
   if (input.GrantWrite !== undefined) {
-    headers["x-amz-grant-write"] = input.GrantWrite.toString();
+    headers["x-amz-grant-write"] = input.GrantWrite;
   }
   if (input.GrantWriteACP !== undefined) {
-    headers["x-amz-grant-write-acp"] = input.GrantWriteACP.toString();
+    headers["x-amz-grant-write-acp"] = input.GrantWriteACP;
   }
   let resolvedPath = "/{Bucket}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
@@ -3176,13 +3242,13 @@ export async function serializeAws_restXmlPutBucketAnalyticsConfigurationCommand
   headers["Content-Type"] = "application/xml";
   let resolvedPath = "/{Bucket}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
@@ -3191,7 +3257,9 @@ export async function serializeAws_restXmlPutBucketAnalyticsConfigurationCommand
     analytics: ""
   };
   if (input.Id !== undefined) {
-    query["id"] = input.Id.toString();
+    query[__extendedEncodeURIComponent("id")] = __extendedEncodeURIComponent(
+      input.Id
+    );
   }
   let body: any;
   let contents: any;
@@ -3222,17 +3290,17 @@ export async function serializeAws_restXmlPutBucketCorsCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/xml";
   if (input.ContentMD5 !== undefined) {
-    headers["Content-MD5"] = input.ContentMD5.toString();
+    headers["Content-MD5"] = input.ContentMD5;
   }
   let resolvedPath = "/{Bucket}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
@@ -3269,17 +3337,17 @@ export async function serializeAws_restXmlPutBucketEncryptionCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/xml";
   if (input.ContentMD5 !== undefined) {
-    headers["Content-MD5"] = input.ContentMD5.toString();
+    headers["Content-MD5"] = input.ContentMD5;
   }
   let resolvedPath = "/{Bucket}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
@@ -3317,13 +3385,13 @@ export async function serializeAws_restXmlPutBucketInventoryConfigurationCommand
   headers["Content-Type"] = "application/xml";
   let resolvedPath = "/{Bucket}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
@@ -3332,7 +3400,9 @@ export async function serializeAws_restXmlPutBucketInventoryConfigurationCommand
     inventory: ""
   };
   if (input.Id !== undefined) {
-    query["id"] = input.Id.toString();
+    query[__extendedEncodeURIComponent("id")] = __extendedEncodeURIComponent(
+      input.Id
+    );
   }
   let body: any;
   let contents: any;
@@ -3364,13 +3434,13 @@ export async function serializeAws_restXmlPutBucketLifecycleConfigurationCommand
   headers["Content-Type"] = "application/xml";
   let resolvedPath = "/{Bucket}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
@@ -3407,17 +3477,17 @@ export async function serializeAws_restXmlPutBucketLoggingCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/xml";
   if (input.ContentMD5 !== undefined) {
-    headers["Content-MD5"] = input.ContentMD5.toString();
+    headers["Content-MD5"] = input.ContentMD5;
   }
   let resolvedPath = "/{Bucket}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
@@ -3455,13 +3525,13 @@ export async function serializeAws_restXmlPutBucketMetricsConfigurationCommand(
   headers["Content-Type"] = "application/xml";
   let resolvedPath = "/{Bucket}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
@@ -3470,7 +3540,9 @@ export async function serializeAws_restXmlPutBucketMetricsConfigurationCommand(
     metrics: ""
   };
   if (input.Id !== undefined) {
-    query["id"] = input.Id.toString();
+    query[__extendedEncodeURIComponent("id")] = __extendedEncodeURIComponent(
+      input.Id
+    );
   }
   let body: any;
   let contents: any;
@@ -3502,13 +3574,13 @@ export async function serializeAws_restXmlPutBucketNotificationConfigurationComm
   headers["Content-Type"] = "application/xml";
   let resolvedPath = "/{Bucket}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
@@ -3550,17 +3622,17 @@ export async function serializeAws_restXmlPutBucketPolicyCommand(
     ] = input.ConfirmRemoveSelfBucketAccess.toString();
   }
   if (input.ContentMD5 !== undefined) {
-    headers["Content-MD5"] = input.ContentMD5.toString();
+    headers["Content-MD5"] = input.ContentMD5;
   }
   let resolvedPath = "/{Bucket}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
@@ -3597,20 +3669,20 @@ export async function serializeAws_restXmlPutBucketReplicationCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/xml";
   if (input.ContentMD5 !== undefined) {
-    headers["Content-MD5"] = input.ContentMD5.toString();
+    headers["Content-MD5"] = input.ContentMD5;
   }
   if (input.Token !== undefined) {
-    headers["x-amz-bucket-object-lock-token"] = input.Token.toString();
+    headers["x-amz-bucket-object-lock-token"] = input.Token;
   }
   let resolvedPath = "/{Bucket}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
@@ -3647,17 +3719,17 @@ export async function serializeAws_restXmlPutBucketRequestPaymentCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/xml";
   if (input.ContentMD5 !== undefined) {
-    headers["Content-MD5"] = input.ContentMD5.toString();
+    headers["Content-MD5"] = input.ContentMD5;
   }
   let resolvedPath = "/{Bucket}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
@@ -3694,17 +3766,17 @@ export async function serializeAws_restXmlPutBucketTaggingCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/xml";
   if (input.ContentMD5 !== undefined) {
-    headers["Content-MD5"] = input.ContentMD5.toString();
+    headers["Content-MD5"] = input.ContentMD5;
   }
   let resolvedPath = "/{Bucket}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
@@ -3738,20 +3810,20 @@ export async function serializeAws_restXmlPutBucketVersioningCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/xml";
   if (input.ContentMD5 !== undefined) {
-    headers["Content-MD5"] = input.ContentMD5.toString();
+    headers["Content-MD5"] = input.ContentMD5;
   }
   if (input.MFA !== undefined) {
-    headers["x-amz-mfa"] = input.MFA.toString();
+    headers["x-amz-mfa"] = input.MFA;
   }
   let resolvedPath = "/{Bucket}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
@@ -3788,17 +3860,17 @@ export async function serializeAws_restXmlPutBucketWebsiteCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/xml";
   if (input.ContentMD5 !== undefined) {
-    headers["Content-MD5"] = input.ContentMD5.toString();
+    headers["Content-MD5"] = input.ContentMD5;
   }
   let resolvedPath = "/{Bucket}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
@@ -3835,51 +3907,49 @@ export async function serializeAws_restXmlPutObjectCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/octet-stream";
   if (input.ACL !== undefined) {
-    headers["x-amz-acl"] = input.ACL.toString();
+    headers["x-amz-acl"] = input.ACL;
   }
   if (input.CacheControl !== undefined) {
-    headers["Cache-Control"] = input.CacheControl.toString();
+    headers["Cache-Control"] = input.CacheControl;
   }
   if (input.ContentDisposition !== undefined) {
-    headers["Content-Disposition"] = input.ContentDisposition.toString();
+    headers["Content-Disposition"] = input.ContentDisposition;
   }
   if (input.ContentEncoding !== undefined) {
-    headers["Content-Encoding"] = input.ContentEncoding.toString();
+    headers["Content-Encoding"] = input.ContentEncoding;
   }
   if (input.ContentLanguage !== undefined) {
-    headers["Content-Language"] = input.ContentLanguage.toString();
+    headers["Content-Language"] = input.ContentLanguage;
   }
   if (input.ContentLength !== undefined) {
     headers["Content-Length"] = input.ContentLength.toString();
   }
   if (input.ContentMD5 !== undefined) {
-    headers["Content-MD5"] = input.ContentMD5.toString();
+    headers["Content-MD5"] = input.ContentMD5;
   }
   if (input.ContentType !== undefined) {
-    headers["Content-Type"] = input.ContentType.toString();
+    headers["Content-Type"] = input.ContentType;
   }
   if (input.Expires !== undefined) {
     headers["Expires"] = input.Expires.toUTCString();
   }
   if (input.GrantFullControl !== undefined) {
-    headers["x-amz-grant-full-control"] = input.GrantFullControl.toString();
+    headers["x-amz-grant-full-control"] = input.GrantFullControl;
   }
   if (input.GrantRead !== undefined) {
-    headers["x-amz-grant-read"] = input.GrantRead.toString();
+    headers["x-amz-grant-read"] = input.GrantRead;
   }
   if (input.GrantReadACP !== undefined) {
-    headers["x-amz-grant-read-acp"] = input.GrantReadACP.toString();
+    headers["x-amz-grant-read-acp"] = input.GrantReadACP;
   }
   if (input.GrantWriteACP !== undefined) {
-    headers["x-amz-grant-write-acp"] = input.GrantWriteACP.toString();
+    headers["x-amz-grant-write-acp"] = input.GrantWriteACP;
   }
   if (input.ObjectLockLegalHoldStatus !== undefined) {
-    headers[
-      "x-amz-object-lock-legal-hold"
-    ] = input.ObjectLockLegalHoldStatus.toString();
+    headers["x-amz-object-lock-legal-hold"] = input.ObjectLockLegalHoldStatus;
   }
   if (input.ObjectLockMode !== undefined) {
-    headers["x-amz-object-lock-mode"] = input.ObjectLockMode.toString();
+    headers["x-amz-object-lock-mode"] = input.ObjectLockMode;
   }
   if (input.ObjectLockRetainUntilDate !== undefined) {
     headers[
@@ -3887,69 +3957,58 @@ export async function serializeAws_restXmlPutObjectCommand(
     ] = input.ObjectLockRetainUntilDate.toISOString();
   }
   if (input.RequestPayer !== undefined) {
-    headers["x-amz-request-payer"] = input.RequestPayer.toString();
+    headers["x-amz-request-payer"] = input.RequestPayer;
   }
   if (input.SSECustomerAlgorithm !== undefined) {
-    headers[
-      "x-amz-server-side-encryption-customer-algorithm"
-    ] = input.SSECustomerAlgorithm.toString();
+    headers["x-amz-server-side-encryption-customer-algorithm"] =
+      input.SSECustomerAlgorithm;
   }
   if (input.SSECustomerKey !== undefined) {
-    headers[
-      "x-amz-server-side-encryption-customer-key"
-    ] = input.SSECustomerKey.toString();
+    headers["x-amz-server-side-encryption-customer-key"] = input.SSECustomerKey;
   }
   if (input.SSECustomerKeyMD5 !== undefined) {
-    headers[
-      "x-amz-server-side-encryption-customer-key-MD5"
-    ] = input.SSECustomerKeyMD5.toString();
+    headers["x-amz-server-side-encryption-customer-key-MD5"] =
+      input.SSECustomerKeyMD5;
   }
   if (input.SSEKMSEncryptionContext !== undefined) {
-    headers[
-      "x-amz-server-side-encryption-context"
-    ] = input.SSEKMSEncryptionContext.toString();
+    headers["x-amz-server-side-encryption-context"] =
+      input.SSEKMSEncryptionContext;
   }
   if (input.SSEKMSKeyId !== undefined) {
-    headers[
-      "x-amz-server-side-encryption-aws-kms-key-id"
-    ] = input.SSEKMSKeyId.toString();
+    headers["x-amz-server-side-encryption-aws-kms-key-id"] = input.SSEKMSKeyId;
   }
   if (input.ServerSideEncryption !== undefined) {
-    headers[
-      "x-amz-server-side-encryption"
-    ] = input.ServerSideEncryption.toString();
+    headers["x-amz-server-side-encryption"] = input.ServerSideEncryption;
   }
   if (input.StorageClass !== undefined) {
-    headers["x-amz-storage-class"] = input.StorageClass.toString();
+    headers["x-amz-storage-class"] = input.StorageClass;
   }
   if (input.Tagging !== undefined) {
-    headers["x-amz-tagging"] = input.Tagging.toString();
+    headers["x-amz-tagging"] = input.Tagging;
   }
   if (input.WebsiteRedirectLocation !== undefined) {
-    headers[
-      "x-amz-website-redirect-location"
-    ] = input.WebsiteRedirectLocation.toString();
+    headers["x-amz-website-redirect-location"] = input.WebsiteRedirectLocation;
   }
   if (input.Metadata !== undefined) {
     Object.keys(input.Metadata).forEach(suffix => {
-      headers["x-amz-meta-" + suffix] = input.Metadata![suffix].toString();
+      headers["x-amz-meta-" + suffix] = input.Metadata![suffix];
     });
   }
   let resolvedPath = "/{Bucket}/{Key+}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
   }
   if (input.Key !== undefined) {
-    const labelValue: string = input.Key.toString();
+    const labelValue: string = input.Key;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Key.");
     }
@@ -3957,7 +4016,7 @@ export async function serializeAws_restXmlPutObjectCommand(
       "{Key+}",
       labelValue
         .split("/")
-        .map(segment => encodeURIComponent(segment))
+        .map(segment => __extendedEncodeURIComponent(segment))
         .join("/")
     );
   } else {
@@ -3990,44 +4049,44 @@ export async function serializeAws_restXmlPutObjectAclCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/xml";
   if (input.ACL !== undefined) {
-    headers["x-amz-acl"] = input.ACL.toString();
+    headers["x-amz-acl"] = input.ACL;
   }
   if (input.ContentMD5 !== undefined) {
-    headers["Content-MD5"] = input.ContentMD5.toString();
+    headers["Content-MD5"] = input.ContentMD5;
   }
   if (input.GrantFullControl !== undefined) {
-    headers["x-amz-grant-full-control"] = input.GrantFullControl.toString();
+    headers["x-amz-grant-full-control"] = input.GrantFullControl;
   }
   if (input.GrantRead !== undefined) {
-    headers["x-amz-grant-read"] = input.GrantRead.toString();
+    headers["x-amz-grant-read"] = input.GrantRead;
   }
   if (input.GrantReadACP !== undefined) {
-    headers["x-amz-grant-read-acp"] = input.GrantReadACP.toString();
+    headers["x-amz-grant-read-acp"] = input.GrantReadACP;
   }
   if (input.GrantWrite !== undefined) {
-    headers["x-amz-grant-write"] = input.GrantWrite.toString();
+    headers["x-amz-grant-write"] = input.GrantWrite;
   }
   if (input.GrantWriteACP !== undefined) {
-    headers["x-amz-grant-write-acp"] = input.GrantWriteACP.toString();
+    headers["x-amz-grant-write-acp"] = input.GrantWriteACP;
   }
   if (input.RequestPayer !== undefined) {
-    headers["x-amz-request-payer"] = input.RequestPayer.toString();
+    headers["x-amz-request-payer"] = input.RequestPayer;
   }
   let resolvedPath = "/{Bucket}/{Key+}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
   }
   if (input.Key !== undefined) {
-    const labelValue: string = input.Key.toString();
+    const labelValue: string = input.Key;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Key.");
     }
@@ -4035,7 +4094,7 @@ export async function serializeAws_restXmlPutObjectAclCommand(
       "{Key+}",
       labelValue
         .split("/")
-        .map(segment => encodeURIComponent(segment))
+        .map(segment => __extendedEncodeURIComponent(segment))
         .join("/")
     );
   } else {
@@ -4045,7 +4104,9 @@ export async function serializeAws_restXmlPutObjectAclCommand(
     acl: ""
   };
   if (input.VersionId !== undefined) {
-    query["versionId"] = input.VersionId.toString();
+    query[
+      __extendedEncodeURIComponent("versionId")
+    ] = __extendedEncodeURIComponent(input.VersionId);
   }
   let body: any;
   let contents: any;
@@ -4076,26 +4137,26 @@ export async function serializeAws_restXmlPutObjectLegalHoldCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/xml";
   if (input.ContentMD5 !== undefined) {
-    headers["Content-MD5"] = input.ContentMD5.toString();
+    headers["Content-MD5"] = input.ContentMD5;
   }
   if (input.RequestPayer !== undefined) {
-    headers["x-amz-request-payer"] = input.RequestPayer.toString();
+    headers["x-amz-request-payer"] = input.RequestPayer;
   }
   let resolvedPath = "/{Bucket}/{Key+}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
   }
   if (input.Key !== undefined) {
-    const labelValue: string = input.Key.toString();
+    const labelValue: string = input.Key;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Key.");
     }
@@ -4103,7 +4164,7 @@ export async function serializeAws_restXmlPutObjectLegalHoldCommand(
       "{Key+}",
       labelValue
         .split("/")
-        .map(segment => encodeURIComponent(segment))
+        .map(segment => __extendedEncodeURIComponent(segment))
         .join("/")
     );
   } else {
@@ -4113,7 +4174,9 @@ export async function serializeAws_restXmlPutObjectLegalHoldCommand(
     "legal-hold": ""
   };
   if (input.VersionId !== undefined) {
-    query["versionId"] = input.VersionId.toString();
+    query[
+      __extendedEncodeURIComponent("versionId")
+    ] = __extendedEncodeURIComponent(input.VersionId);
   }
   let body: any;
   let contents: any;
@@ -4144,23 +4207,23 @@ export async function serializeAws_restXmlPutObjectLockConfigurationCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/xml";
   if (input.ContentMD5 !== undefined) {
-    headers["Content-MD5"] = input.ContentMD5.toString();
+    headers["Content-MD5"] = input.ContentMD5;
   }
   if (input.RequestPayer !== undefined) {
-    headers["x-amz-request-payer"] = input.RequestPayer.toString();
+    headers["x-amz-request-payer"] = input.RequestPayer;
   }
   if (input.Token !== undefined) {
-    headers["x-amz-bucket-object-lock-token"] = input.Token.toString();
+    headers["x-amz-bucket-object-lock-token"] = input.Token;
   }
   let resolvedPath = "/{Bucket}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
@@ -4202,26 +4265,26 @@ export async function serializeAws_restXmlPutObjectRetentionCommand(
     ] = input.BypassGovernanceRetention.toString();
   }
   if (input.ContentMD5 !== undefined) {
-    headers["Content-MD5"] = input.ContentMD5.toString();
+    headers["Content-MD5"] = input.ContentMD5;
   }
   if (input.RequestPayer !== undefined) {
-    headers["x-amz-request-payer"] = input.RequestPayer.toString();
+    headers["x-amz-request-payer"] = input.RequestPayer;
   }
   let resolvedPath = "/{Bucket}/{Key+}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
   }
   if (input.Key !== undefined) {
-    const labelValue: string = input.Key.toString();
+    const labelValue: string = input.Key;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Key.");
     }
@@ -4229,7 +4292,7 @@ export async function serializeAws_restXmlPutObjectRetentionCommand(
       "{Key+}",
       labelValue
         .split("/")
-        .map(segment => encodeURIComponent(segment))
+        .map(segment => __extendedEncodeURIComponent(segment))
         .join("/")
     );
   } else {
@@ -4239,7 +4302,9 @@ export async function serializeAws_restXmlPutObjectRetentionCommand(
     retention: ""
   };
   if (input.VersionId !== undefined) {
-    query["versionId"] = input.VersionId.toString();
+    query[
+      __extendedEncodeURIComponent("versionId")
+    ] = __extendedEncodeURIComponent(input.VersionId);
   }
   let body: any;
   let contents: any;
@@ -4270,23 +4335,23 @@ export async function serializeAws_restXmlPutObjectTaggingCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/xml";
   if (input.ContentMD5 !== undefined) {
-    headers["Content-MD5"] = input.ContentMD5.toString();
+    headers["Content-MD5"] = input.ContentMD5;
   }
   let resolvedPath = "/{Bucket}/{Key+}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
   }
   if (input.Key !== undefined) {
-    const labelValue: string = input.Key.toString();
+    const labelValue: string = input.Key;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Key.");
     }
@@ -4294,7 +4359,7 @@ export async function serializeAws_restXmlPutObjectTaggingCommand(
       "{Key+}",
       labelValue
         .split("/")
-        .map(segment => encodeURIComponent(segment))
+        .map(segment => __extendedEncodeURIComponent(segment))
         .join("/")
     );
   } else {
@@ -4304,7 +4369,9 @@ export async function serializeAws_restXmlPutObjectTaggingCommand(
     tagging: ""
   };
   if (input.VersionId !== undefined) {
-    query["versionId"] = input.VersionId.toString();
+    query[
+      __extendedEncodeURIComponent("versionId")
+    ] = __extendedEncodeURIComponent(input.VersionId);
   }
   let body: any;
   let contents: any;
@@ -4332,17 +4399,17 @@ export async function serializeAws_restXmlPutPublicAccessBlockCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/xml";
   if (input.ContentMD5 !== undefined) {
-    headers["Content-MD5"] = input.ContentMD5.toString();
+    headers["Content-MD5"] = input.ContentMD5;
   }
   let resolvedPath = "/{Bucket}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
@@ -4379,23 +4446,23 @@ export async function serializeAws_restXmlRestoreObjectCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/xml";
   if (input.RequestPayer !== undefined) {
-    headers["x-amz-request-payer"] = input.RequestPayer.toString();
+    headers["x-amz-request-payer"] = input.RequestPayer;
   }
   let resolvedPath = "/{Bucket}/{Key+}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
   }
   if (input.Key !== undefined) {
-    const labelValue: string = input.Key.toString();
+    const labelValue: string = input.Key;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Key.");
     }
@@ -4403,7 +4470,7 @@ export async function serializeAws_restXmlRestoreObjectCommand(
       "{Key+}",
       labelValue
         .split("/")
-        .map(segment => encodeURIComponent(segment))
+        .map(segment => __extendedEncodeURIComponent(segment))
         .join("/")
     );
   } else {
@@ -4413,7 +4480,9 @@ export async function serializeAws_restXmlRestoreObjectCommand(
     restore: ""
   };
   if (input.VersionId !== undefined) {
-    query["versionId"] = input.VersionId.toString();
+    query[
+      __extendedEncodeURIComponent("versionId")
+    ] = __extendedEncodeURIComponent(input.VersionId);
   }
   let body: any;
   let contents: any;
@@ -4444,35 +4513,31 @@ export async function serializeAws_restXmlSelectObjectContentCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/xml";
   if (input.SSECustomerAlgorithm !== undefined) {
-    headers[
-      "x-amz-server-side-encryption-customer-algorithm"
-    ] = input.SSECustomerAlgorithm.toString();
+    headers["x-amz-server-side-encryption-customer-algorithm"] =
+      input.SSECustomerAlgorithm;
   }
   if (input.SSECustomerKey !== undefined) {
-    headers[
-      "x-amz-server-side-encryption-customer-key"
-    ] = input.SSECustomerKey.toString();
+    headers["x-amz-server-side-encryption-customer-key"] = input.SSECustomerKey;
   }
   if (input.SSECustomerKeyMD5 !== undefined) {
-    headers[
-      "x-amz-server-side-encryption-customer-key-MD5"
-    ] = input.SSECustomerKeyMD5.toString();
+    headers["x-amz-server-side-encryption-customer-key-MD5"] =
+      input.SSECustomerKeyMD5;
   }
   let resolvedPath = "/{Bucket}/{Key+}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
   }
   if (input.Key !== undefined) {
-    const labelValue: string = input.Key.toString();
+    const labelValue: string = input.Key;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Key.");
     }
@@ -4480,7 +4545,7 @@ export async function serializeAws_restXmlSelectObjectContentCommand(
       "{Key+}",
       labelValue
         .split("/")
-        .map(segment => encodeURIComponent(segment))
+        .map(segment => __extendedEncodeURIComponent(segment))
         .join("/")
     );
   } else {
@@ -4553,41 +4618,37 @@ export async function serializeAws_restXmlUploadPartCommand(
     headers["Content-Length"] = input.ContentLength.toString();
   }
   if (input.ContentMD5 !== undefined) {
-    headers["Content-MD5"] = input.ContentMD5.toString();
+    headers["Content-MD5"] = input.ContentMD5;
   }
   if (input.RequestPayer !== undefined) {
-    headers["x-amz-request-payer"] = input.RequestPayer.toString();
+    headers["x-amz-request-payer"] = input.RequestPayer;
   }
   if (input.SSECustomerAlgorithm !== undefined) {
-    headers[
-      "x-amz-server-side-encryption-customer-algorithm"
-    ] = input.SSECustomerAlgorithm.toString();
+    headers["x-amz-server-side-encryption-customer-algorithm"] =
+      input.SSECustomerAlgorithm;
   }
   if (input.SSECustomerKey !== undefined) {
-    headers[
-      "x-amz-server-side-encryption-customer-key"
-    ] = input.SSECustomerKey.toString();
+    headers["x-amz-server-side-encryption-customer-key"] = input.SSECustomerKey;
   }
   if (input.SSECustomerKeyMD5 !== undefined) {
-    headers[
-      "x-amz-server-side-encryption-customer-key-MD5"
-    ] = input.SSECustomerKeyMD5.toString();
+    headers["x-amz-server-side-encryption-customer-key-MD5"] =
+      input.SSECustomerKeyMD5;
   }
   let resolvedPath = "/{Bucket}/{Key+}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
   }
   if (input.Key !== undefined) {
-    const labelValue: string = input.Key.toString();
+    const labelValue: string = input.Key;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Key.");
     }
@@ -4595,7 +4656,7 @@ export async function serializeAws_restXmlUploadPartCommand(
       "{Key+}",
       labelValue
         .split("/")
-        .map(segment => encodeURIComponent(segment))
+        .map(segment => __extendedEncodeURIComponent(segment))
         .join("/")
     );
   } else {
@@ -4605,10 +4666,14 @@ export async function serializeAws_restXmlUploadPartCommand(
     "x-id": "UploadPart"
   };
   if (input.PartNumber !== undefined) {
-    query["partNumber"] = input.PartNumber.toString();
+    query[
+      __extendedEncodeURIComponent("partNumber")
+    ] = __extendedEncodeURIComponent(input.PartNumber.toString());
   }
   if (input.UploadId !== undefined) {
-    query["uploadId"] = input.UploadId.toString();
+    query[
+      __extendedEncodeURIComponent("uploadId")
+    ] = __extendedEncodeURIComponent(input.UploadId);
   }
   let body: any;
   let contents: any;
@@ -4634,10 +4699,10 @@ export async function serializeAws_restXmlUploadPartCopyCommand(
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.CopySource !== undefined) {
-    headers["x-amz-copy-source"] = input.CopySource.toString();
+    headers["x-amz-copy-source"] = input.CopySource;
   }
   if (input.CopySourceIfMatch !== undefined) {
-    headers["x-amz-copy-source-if-match"] = input.CopySourceIfMatch.toString();
+    headers["x-amz-copy-source-if-match"] = input.CopySourceIfMatch;
   }
   if (input.CopySourceIfModifiedSince !== undefined) {
     headers[
@@ -4645,9 +4710,7 @@ export async function serializeAws_restXmlUploadPartCopyCommand(
     ] = input.CopySourceIfModifiedSince.toUTCString();
   }
   if (input.CopySourceIfNoneMatch !== undefined) {
-    headers[
-      "x-amz-copy-source-if-none-match"
-    ] = input.CopySourceIfNoneMatch.toString();
+    headers["x-amz-copy-source-if-none-match"] = input.CopySourceIfNoneMatch;
   }
   if (input.CopySourceIfUnmodifiedSince !== undefined) {
     headers[
@@ -4655,56 +4718,49 @@ export async function serializeAws_restXmlUploadPartCopyCommand(
     ] = input.CopySourceIfUnmodifiedSince.toUTCString();
   }
   if (input.CopySourceRange !== undefined) {
-    headers["x-amz-copy-source-range"] = input.CopySourceRange.toString();
+    headers["x-amz-copy-source-range"] = input.CopySourceRange;
   }
   if (input.CopySourceSSECustomerAlgorithm !== undefined) {
-    headers[
-      "x-amz-copy-source-server-side-encryption-customer-algorithm"
-    ] = input.CopySourceSSECustomerAlgorithm.toString();
+    headers["x-amz-copy-source-server-side-encryption-customer-algorithm"] =
+      input.CopySourceSSECustomerAlgorithm;
   }
   if (input.CopySourceSSECustomerKey !== undefined) {
-    headers[
-      "x-amz-copy-source-server-side-encryption-customer-key"
-    ] = input.CopySourceSSECustomerKey.toString();
+    headers["x-amz-copy-source-server-side-encryption-customer-key"] =
+      input.CopySourceSSECustomerKey;
   }
   if (input.CopySourceSSECustomerKeyMD5 !== undefined) {
-    headers[
-      "x-amz-copy-source-server-side-encryption-customer-key-MD5"
-    ] = input.CopySourceSSECustomerKeyMD5.toString();
+    headers["x-amz-copy-source-server-side-encryption-customer-key-MD5"] =
+      input.CopySourceSSECustomerKeyMD5;
   }
   if (input.RequestPayer !== undefined) {
-    headers["x-amz-request-payer"] = input.RequestPayer.toString();
+    headers["x-amz-request-payer"] = input.RequestPayer;
   }
   if (input.SSECustomerAlgorithm !== undefined) {
-    headers[
-      "x-amz-server-side-encryption-customer-algorithm"
-    ] = input.SSECustomerAlgorithm.toString();
+    headers["x-amz-server-side-encryption-customer-algorithm"] =
+      input.SSECustomerAlgorithm;
   }
   if (input.SSECustomerKey !== undefined) {
-    headers[
-      "x-amz-server-side-encryption-customer-key"
-    ] = input.SSECustomerKey.toString();
+    headers["x-amz-server-side-encryption-customer-key"] = input.SSECustomerKey;
   }
   if (input.SSECustomerKeyMD5 !== undefined) {
-    headers[
-      "x-amz-server-side-encryption-customer-key-MD5"
-    ] = input.SSECustomerKeyMD5.toString();
+    headers["x-amz-server-side-encryption-customer-key-MD5"] =
+      input.SSECustomerKeyMD5;
   }
   let resolvedPath = "/{Bucket}/{Key+}";
   if (input.Bucket !== undefined) {
-    const labelValue: string = input.Bucket.toString();
+    const labelValue: string = input.Bucket;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Bucket.");
     }
     resolvedPath = resolvedPath.replace(
       "{Bucket}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Bucket.");
   }
   if (input.Key !== undefined) {
-    const labelValue: string = input.Key.toString();
+    const labelValue: string = input.Key;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Key.");
     }
@@ -4712,7 +4768,7 @@ export async function serializeAws_restXmlUploadPartCopyCommand(
       "{Key+}",
       labelValue
         .split("/")
-        .map(segment => encodeURIComponent(segment))
+        .map(segment => __extendedEncodeURIComponent(segment))
         .join("/")
     );
   } else {
@@ -4722,10 +4778,14 @@ export async function serializeAws_restXmlUploadPartCopyCommand(
     "x-id": "UploadPartCopy"
   };
   if (input.PartNumber !== undefined) {
-    query["partNumber"] = input.PartNumber.toString();
+    query[
+      __extendedEncodeURIComponent("partNumber")
+    ] = __extendedEncodeURIComponent(input.PartNumber.toString());
   }
   if (input.UploadId !== undefined) {
-    query["uploadId"] = input.UploadId.toString();
+    query[
+      __extendedEncodeURIComponent("uploadId")
+    ] = __extendedEncodeURIComponent(input.UploadId);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -4755,6 +4815,7 @@ export async function deserializeAws_restXmlAbortMultipartUploadCommand(
   if (output.headers["x-amz-request-charged"] !== undefined) {
     contents.RequestCharged = output.headers["x-amz-request-charged"];
   }
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -5002,6 +5063,7 @@ export async function deserializeAws_restXmlCreateBucketCommand(
   if (output.headers["location"] !== undefined) {
     contents.Location = output.headers["location"];
   }
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -5162,6 +5224,7 @@ export async function deserializeAws_restXmlDeleteBucketCommand(
   const contents: DeleteBucketCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -5207,6 +5270,7 @@ export async function deserializeAws_restXmlDeleteBucketAnalyticsConfigurationCo
   const contents: DeleteBucketAnalyticsConfigurationCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -5249,6 +5313,7 @@ export async function deserializeAws_restXmlDeleteBucketCorsCommand(
   const contents: DeleteBucketCorsCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -5294,6 +5359,7 @@ export async function deserializeAws_restXmlDeleteBucketEncryptionCommand(
   const contents: DeleteBucketEncryptionCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -5339,6 +5405,7 @@ export async function deserializeAws_restXmlDeleteBucketInventoryConfigurationCo
   const contents: DeleteBucketInventoryConfigurationCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -5384,6 +5451,7 @@ export async function deserializeAws_restXmlDeleteBucketLifecycleCommand(
   const contents: DeleteBucketLifecycleCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -5429,6 +5497,7 @@ export async function deserializeAws_restXmlDeleteBucketMetricsConfigurationComm
   const contents: DeleteBucketMetricsConfigurationCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -5474,6 +5543,7 @@ export async function deserializeAws_restXmlDeleteBucketPolicyCommand(
   const contents: DeleteBucketPolicyCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -5519,6 +5589,7 @@ export async function deserializeAws_restXmlDeleteBucketReplicationCommand(
   const contents: DeleteBucketReplicationCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -5564,6 +5635,7 @@ export async function deserializeAws_restXmlDeleteBucketTaggingCommand(
   const contents: DeleteBucketTaggingCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -5609,6 +5681,7 @@ export async function deserializeAws_restXmlDeleteBucketWebsiteCommand(
   const contents: DeleteBucketWebsiteCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -5664,6 +5737,7 @@ export async function deserializeAws_restXmlDeleteObjectCommand(
   if (output.headers["x-amz-version-id"] !== undefined) {
     contents.VersionId = output.headers["x-amz-version-id"];
   }
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -5714,6 +5788,7 @@ export async function deserializeAws_restXmlDeleteObjectTaggingCommand(
   if (output.headers["x-amz-version-id"] !== undefined) {
     contents.VersionId = output.headers["x-amz-version-id"];
   }
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -5830,6 +5905,7 @@ export async function deserializeAws_restXmlDeletePublicAccessBlockCommand(
   const contents: DeletePublicAccessBlockCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -7470,6 +7546,7 @@ export async function deserializeAws_restXmlHeadBucketCommand(
   const contents: HeadBucketCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -7653,6 +7730,7 @@ export async function deserializeAws_restXmlHeadObjectCommand(
       contents.Metadata[header.substring(11)] = output.headers[header];
     }
   });
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -8568,6 +8646,7 @@ export async function deserializeAws_restXmlPutBucketAccelerateConfigurationComm
   const contents: PutBucketAccelerateConfigurationCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -8610,6 +8689,7 @@ export async function deserializeAws_restXmlPutBucketAclCommand(
   const contents: PutBucketAclCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -8655,6 +8735,7 @@ export async function deserializeAws_restXmlPutBucketAnalyticsConfigurationComma
   const contents: PutBucketAnalyticsConfigurationCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -8697,6 +8778,7 @@ export async function deserializeAws_restXmlPutBucketCorsCommand(
   const contents: PutBucketCorsCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -8742,6 +8824,7 @@ export async function deserializeAws_restXmlPutBucketEncryptionCommand(
   const contents: PutBucketEncryptionCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -8787,6 +8870,7 @@ export async function deserializeAws_restXmlPutBucketInventoryConfigurationComma
   const contents: PutBucketInventoryConfigurationCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -8832,6 +8916,7 @@ export async function deserializeAws_restXmlPutBucketLifecycleConfigurationComma
   const contents: PutBucketLifecycleConfigurationCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -8874,6 +8959,7 @@ export async function deserializeAws_restXmlPutBucketLoggingCommand(
   const contents: PutBucketLoggingCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -8919,6 +9005,7 @@ export async function deserializeAws_restXmlPutBucketMetricsConfigurationCommand
   const contents: PutBucketMetricsConfigurationCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -8964,6 +9051,7 @@ export async function deserializeAws_restXmlPutBucketNotificationConfigurationCo
   const contents: PutBucketNotificationConfigurationCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -9006,6 +9094,7 @@ export async function deserializeAws_restXmlPutBucketPolicyCommand(
   const contents: PutBucketPolicyCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -9051,6 +9140,7 @@ export async function deserializeAws_restXmlPutBucketReplicationCommand(
   const contents: PutBucketReplicationCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -9096,6 +9186,7 @@ export async function deserializeAws_restXmlPutBucketRequestPaymentCommand(
   const contents: PutBucketRequestPaymentCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -9138,6 +9229,7 @@ export async function deserializeAws_restXmlPutBucketTaggingCommand(
   const contents: PutBucketTaggingCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -9183,6 +9275,7 @@ export async function deserializeAws_restXmlPutBucketVersioningCommand(
   const contents: PutBucketVersioningCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -9225,6 +9318,7 @@ export async function deserializeAws_restXmlPutBucketWebsiteCommand(
   const contents: PutBucketWebsiteCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -9317,6 +9411,7 @@ export async function deserializeAws_restXmlPutObjectCommand(
   if (output.headers["x-amz-version-id"] !== undefined) {
     contents.VersionId = output.headers["x-amz-version-id"];
   }
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -9364,6 +9459,7 @@ export async function deserializeAws_restXmlPutObjectAclCommand(
   if (output.headers["x-amz-request-charged"] !== undefined) {
     contents.RequestCharged = output.headers["x-amz-request-charged"];
   }
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -9421,6 +9517,7 @@ export async function deserializeAws_restXmlPutObjectLegalHoldCommand(
   if (output.headers["x-amz-request-charged"] !== undefined) {
     contents.RequestCharged = output.headers["x-amz-request-charged"];
   }
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -9471,6 +9568,7 @@ export async function deserializeAws_restXmlPutObjectLockConfigurationCommand(
   if (output.headers["x-amz-request-charged"] !== undefined) {
     contents.RequestCharged = output.headers["x-amz-request-charged"];
   }
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -9521,6 +9619,7 @@ export async function deserializeAws_restXmlPutObjectRetentionCommand(
   if (output.headers["x-amz-request-charged"] !== undefined) {
     contents.RequestCharged = output.headers["x-amz-request-charged"];
   }
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -9568,6 +9667,7 @@ export async function deserializeAws_restXmlPutObjectTaggingCommand(
   if (output.headers["x-amz-version-id"] !== undefined) {
     contents.VersionId = output.headers["x-amz-version-id"];
   }
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -9613,6 +9713,7 @@ export async function deserializeAws_restXmlPutPublicAccessBlockCommand(
   const contents: PutPublicAccessBlockCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -9664,6 +9765,7 @@ export async function deserializeAws_restXmlRestoreObjectCommand(
   if (output.headers["x-amz-restore-output-path"] !== undefined) {
     contents.RestoreOutputPath = output.headers["x-amz-restore-output-path"];
   }
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -9802,6 +9904,7 @@ export async function deserializeAws_restXmlUploadPartCommand(
     contents.ServerSideEncryption =
       output.headers["x-amz-server-side-encryption"];
   }
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 

--- a/clients/client-sagemaker-a2i-runtime/models/index.ts
+++ b/clients/client-sagemaker-a2i-runtime/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export enum ContentClassifier {
@@ -16,7 +19,7 @@ export interface DeleteHumanLoopRequest {
 
 export namespace DeleteHumanLoopRequest {
   export function isa(o: any): o is DeleteHumanLoopRequest {
-    return _smithy.isa(o, "DeleteHumanLoopRequest");
+    return __isa(o, "DeleteHumanLoopRequest");
   }
 }
 
@@ -26,7 +29,7 @@ export interface DeleteHumanLoopResponse extends $MetadataBearer {
 
 export namespace DeleteHumanLoopResponse {
   export function isa(o: any): o is DeleteHumanLoopResponse {
-    return _smithy.isa(o, "DeleteHumanLoopResponse");
+    return __isa(o, "DeleteHumanLoopResponse");
   }
 }
 
@@ -40,7 +43,7 @@ export interface DescribeHumanLoopRequest {
 
 export namespace DescribeHumanLoopRequest {
   export function isa(o: any): o is DescribeHumanLoopRequest {
-    return _smithy.isa(o, "DescribeHumanLoopRequest");
+    return __isa(o, "DescribeHumanLoopRequest");
   }
 }
 
@@ -94,7 +97,7 @@ export interface DescribeHumanLoopResponse extends $MetadataBearer {
 
 export namespace DescribeHumanLoopResponse {
   export function isa(o: any): o is DescribeHumanLoopResponse {
-    return _smithy.isa(o, "DescribeHumanLoopResponse");
+    return __isa(o, "DescribeHumanLoopResponse");
   }
 }
 
@@ -111,7 +114,7 @@ export interface HumanLoopActivationReason {
 
 export namespace HumanLoopActivationReason {
   export function isa(o: any): o is HumanLoopActivationReason {
-    return _smithy.isa(o, "HumanLoopActivationReason");
+    return __isa(o, "HumanLoopActivationReason");
   }
 }
 
@@ -133,7 +136,7 @@ export interface HumanLoopActivationResults {
 
 export namespace HumanLoopActivationResults {
   export function isa(o: any): o is HumanLoopActivationResults {
-    return _smithy.isa(o, "HumanLoopActivationResults");
+    return __isa(o, "HumanLoopActivationResults");
   }
 }
 
@@ -150,7 +153,7 @@ export interface HumanLoopInputContent {
 
 export namespace HumanLoopInputContent {
   export function isa(o: any): o is HumanLoopInputContent {
-    return _smithy.isa(o, "HumanLoopInputContent");
+    return __isa(o, "HumanLoopInputContent");
   }
 }
 
@@ -168,7 +171,7 @@ export interface HumanLoopOutputContent {
 
 export namespace HumanLoopOutputContent {
   export function isa(o: any): o is HumanLoopOutputContent {
-    return _smithy.isa(o, "HumanLoopOutputContent");
+    return __isa(o, "HumanLoopOutputContent");
   }
 }
 
@@ -213,7 +216,7 @@ export interface HumanLoopSummary {
 
 export namespace HumanLoopSummary {
   export function isa(o: any): o is HumanLoopSummary {
-    return _smithy.isa(o, "HumanLoopSummary");
+    return __isa(o, "HumanLoopSummary");
   }
 }
 
@@ -231,7 +234,7 @@ export interface HumanReviewDataAttributes {
 
 export namespace HumanReviewDataAttributes {
   export function isa(o: any): o is HumanReviewDataAttributes {
-    return _smithy.isa(o, "HumanReviewDataAttributes");
+    return __isa(o, "HumanReviewDataAttributes");
   }
 }
 
@@ -239,7 +242,7 @@ export namespace HumanReviewDataAttributes {
  * <p>Your request could not be processed.</p>
  */
 export interface InternalServerException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalServerException";
   $fault: "server";
@@ -248,7 +251,7 @@ export interface InternalServerException
 
 export namespace InternalServerException {
   export function isa(o: any): o is InternalServerException {
-    return _smithy.isa(o, "InternalServerException");
+    return __isa(o, "InternalServerException");
   }
 }
 
@@ -282,7 +285,7 @@ export interface ListHumanLoopsRequest {
 
 export namespace ListHumanLoopsRequest {
   export function isa(o: any): o is ListHumanLoopsRequest {
-    return _smithy.isa(o, "ListHumanLoopsRequest");
+    return __isa(o, "ListHumanLoopsRequest");
   }
 }
 
@@ -301,7 +304,7 @@ export interface ListHumanLoopsResponse extends $MetadataBearer {
 
 export namespace ListHumanLoopsResponse {
   export function isa(o: any): o is ListHumanLoopsResponse {
-    return _smithy.isa(o, "ListHumanLoopsResponse");
+    return __isa(o, "ListHumanLoopsResponse");
   }
 }
 
@@ -309,7 +312,7 @@ export namespace ListHumanLoopsResponse {
  * <p>We were unable to find the requested resource.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -318,7 +321,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -326,7 +329,7 @@ export namespace ResourceNotFoundException {
  * <p>You have exceeded your service quota. To perform the requested action, remove some of the relevant resources, or request a service quota increase.</p>
  */
 export interface ServiceQuotaExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ServiceQuotaExceededException";
   $fault: "client";
@@ -335,7 +338,7 @@ export interface ServiceQuotaExceededException
 
 export namespace ServiceQuotaExceededException {
   export function isa(o: any): o is ServiceQuotaExceededException {
-    return _smithy.isa(o, "ServiceQuotaExceededException");
+    return __isa(o, "ServiceQuotaExceededException");
   }
 }
 
@@ -369,7 +372,7 @@ export interface StartHumanLoopRequest {
 
 export namespace StartHumanLoopRequest {
   export function isa(o: any): o is StartHumanLoopRequest {
-    return _smithy.isa(o, "StartHumanLoopRequest");
+    return __isa(o, "StartHumanLoopRequest");
   }
 }
 
@@ -388,7 +391,7 @@ export interface StartHumanLoopResponse extends $MetadataBearer {
 
 export namespace StartHumanLoopResponse {
   export function isa(o: any): o is StartHumanLoopResponse {
-    return _smithy.isa(o, "StartHumanLoopResponse");
+    return __isa(o, "StartHumanLoopResponse");
   }
 }
 
@@ -402,7 +405,7 @@ export interface StopHumanLoopRequest {
 
 export namespace StopHumanLoopRequest {
   export function isa(o: any): o is StopHumanLoopRequest {
-    return _smithy.isa(o, "StopHumanLoopRequest");
+    return __isa(o, "StopHumanLoopRequest");
   }
 }
 
@@ -412,7 +415,7 @@ export interface StopHumanLoopResponse extends $MetadataBearer {
 
 export namespace StopHumanLoopResponse {
   export function isa(o: any): o is StopHumanLoopResponse {
-    return _smithy.isa(o, "StopHumanLoopResponse");
+    return __isa(o, "StopHumanLoopResponse");
   }
 }
 
@@ -420,7 +423,7 @@ export namespace StopHumanLoopResponse {
  * <p>Your request has exceeded the allowed amount of requests.</p>
  */
 export interface ThrottlingException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ThrottlingException";
   $fault: "client";
@@ -429,7 +432,7 @@ export interface ThrottlingException
 
 export namespace ThrottlingException {
   export function isa(o: any): o is ThrottlingException {
-    return _smithy.isa(o, "ThrottlingException");
+    return __isa(o, "ThrottlingException");
   }
 }
 
@@ -437,7 +440,7 @@ export namespace ThrottlingException {
  * <p>Your request was not valid. Check the syntax and try again.</p>
  */
 export interface ValidationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ValidationException";
   $fault: "client";
@@ -446,6 +449,6 @@ export interface ValidationException
 
 export namespace ValidationException {
   export function isa(o: any): o is ValidationException {
-    return _smithy.isa(o, "ValidationException");
+    return __isa(o, "ValidationException");
   }
 }

--- a/clients/client-sagemaker-a2i-runtime/protocols/Aws_restJson1_1.ts
+++ b/clients/client-sagemaker-a2i-runtime/protocols/Aws_restJson1_1.ts
@@ -36,7 +36,10 @@ import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  extendedEncodeURIComponent as __extendedEncodeURIComponent
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -52,7 +55,7 @@ export async function serializeAws_restJson1_1DeleteHumanLoopCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/human-loops/{HumanLoopName}";
   if (input.HumanLoopName !== undefined) {
-    const labelValue: string = input.HumanLoopName.toString();
+    const labelValue: string = input.HumanLoopName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: HumanLoopName."
@@ -60,7 +63,7 @@ export async function serializeAws_restJson1_1DeleteHumanLoopCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{HumanLoopName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: HumanLoopName.");
@@ -82,7 +85,7 @@ export async function serializeAws_restJson1_1DescribeHumanLoopCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/human-loops/{HumanLoopName}";
   if (input.HumanLoopName !== undefined) {
-    const labelValue: string = input.HumanLoopName.toString();
+    const labelValue: string = input.HumanLoopName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: HumanLoopName."
@@ -90,7 +93,7 @@ export async function serializeAws_restJson1_1DescribeHumanLoopCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{HumanLoopName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: HumanLoopName.");
@@ -113,19 +116,29 @@ export async function serializeAws_restJson1_1ListHumanLoopsCommand(
   let resolvedPath = "/human-loops";
   const query: any = {};
   if (input.CreationTimeAfter !== undefined) {
-    query["CreationTimeAfter"] = input.CreationTimeAfter.toISOString();
+    query[
+      __extendedEncodeURIComponent("CreationTimeAfter")
+    ] = __extendedEncodeURIComponent(input.CreationTimeAfter.toISOString());
   }
   if (input.CreationTimeBefore !== undefined) {
-    query["CreationTimeBefore"] = input.CreationTimeBefore.toISOString();
+    query[
+      __extendedEncodeURIComponent("CreationTimeBefore")
+    ] = __extendedEncodeURIComponent(input.CreationTimeBefore.toISOString());
   }
   if (input.MaxResults !== undefined) {
-    query["MaxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("MaxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["NextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("NextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   if (input.SortOrder !== undefined) {
-    query["SortOrder"] = input.SortOrder.toString();
+    query[
+      __extendedEncodeURIComponent("SortOrder")
+    ] = __extendedEncodeURIComponent(input.SortOrder);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -216,6 +229,7 @@ export async function deserializeAws_restJson1_1DeleteHumanLoopCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeleteHumanLoopResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -569,6 +583,7 @@ export async function deserializeAws_restJson1_1StopHumanLoopCommand(
     $metadata: deserializeMetadata(output),
     __type: "StopHumanLoopResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 

--- a/clients/client-sagemaker-runtime/models/index.ts
+++ b/clients/client-sagemaker-runtime/models/index.ts
@@ -1,12 +1,13 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
  * <p> An internal failure occurred. </p>
  */
-export interface InternalFailure
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface InternalFailure extends __SmithyException, $MetadataBearer {
   name: "InternalFailure";
   $fault: "server";
   Message?: string;
@@ -14,7 +15,7 @@ export interface InternalFailure
 
 export namespace InternalFailure {
   export function isa(o: any): o is InternalFailure {
-    return _smithy.isa(o, "InternalFailure");
+    return __isa(o, "InternalFailure");
   }
 }
 
@@ -64,7 +65,7 @@ export interface InvokeEndpointInput {
 
 export namespace InvokeEndpointInput {
   export function isa(o: any): o is InvokeEndpointInput {
-    return _smithy.isa(o, "InvokeEndpointInput");
+    return __isa(o, "InvokeEndpointInput");
   }
 }
 
@@ -105,7 +106,7 @@ export interface InvokeEndpointOutput extends $MetadataBearer {
 
 export namespace InvokeEndpointOutput {
   export function isa(o: any): o is InvokeEndpointOutput {
-    return _smithy.isa(o, "InvokeEndpointOutput");
+    return __isa(o, "InvokeEndpointOutput");
   }
 }
 
@@ -113,7 +114,7 @@ export namespace InvokeEndpointOutput {
  * <p> Model (owned by the customer in the container) returned 4xx or 5xx error code.
  *         </p>
  */
-export interface ModelError extends _smithy.SmithyException, $MetadataBearer {
+export interface ModelError extends __SmithyException, $MetadataBearer {
   name: "ModelError";
   $fault: "client";
   /**
@@ -135,16 +136,14 @@ export interface ModelError extends _smithy.SmithyException, $MetadataBearer {
 
 export namespace ModelError {
   export function isa(o: any): o is ModelError {
-    return _smithy.isa(o, "ModelError");
+    return __isa(o, "ModelError");
   }
 }
 
 /**
  * <p> The service is unavailable. Try your call again. </p>
  */
-export interface ServiceUnavailable
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface ServiceUnavailable extends __SmithyException, $MetadataBearer {
   name: "ServiceUnavailable";
   $fault: "server";
   Message?: string;
@@ -152,16 +151,14 @@ export interface ServiceUnavailable
 
 export namespace ServiceUnavailable {
   export function isa(o: any): o is ServiceUnavailable {
-    return _smithy.isa(o, "ServiceUnavailable");
+    return __isa(o, "ServiceUnavailable");
   }
 }
 
 /**
  * <p> Inspect your request and try again. </p>
  */
-export interface ValidationError
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface ValidationError extends __SmithyException, $MetadataBearer {
   name: "ValidationError";
   $fault: "client";
   Message?: string;
@@ -169,6 +166,6 @@ export interface ValidationError
 
 export namespace ValidationError {
   export function isa(o: any): o is ValidationError {
-    return _smithy.isa(o, "ValidationError");
+    return __isa(o, "ValidationError");
   }
 }

--- a/clients/client-sagemaker-runtime/protocols/Aws_restJson1_1.ts
+++ b/clients/client-sagemaker-runtime/protocols/Aws_restJson1_1.ts
@@ -12,7 +12,10 @@ import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  extendedEncodeURIComponent as __extendedEncodeURIComponent
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -27,22 +30,20 @@ export async function serializeAws_restJson1_1InvokeEndpointCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/octet-stream";
   if (input.Accept !== undefined) {
-    headers["Accept"] = input.Accept.toString();
+    headers["Accept"] = input.Accept;
   }
   if (input.ContentType !== undefined) {
-    headers["Content-Type"] = input.ContentType.toString();
+    headers["Content-Type"] = input.ContentType;
   }
   if (input.CustomAttributes !== undefined) {
-    headers[
-      "X-Amzn-SageMaker-Custom-Attributes"
-    ] = input.CustomAttributes.toString();
+    headers["X-Amzn-SageMaker-Custom-Attributes"] = input.CustomAttributes;
   }
   if (input.TargetModel !== undefined) {
-    headers["X-Amzn-SageMaker-Target-Model"] = input.TargetModel.toString();
+    headers["X-Amzn-SageMaker-Target-Model"] = input.TargetModel;
   }
   let resolvedPath = "/endpoints/{EndpointName}/invocations";
   if (input.EndpointName !== undefined) {
-    const labelValue: string = input.EndpointName.toString();
+    const labelValue: string = input.EndpointName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: EndpointName."
@@ -50,7 +51,7 @@ export async function serializeAws_restJson1_1InvokeEndpointCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{EndpointName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: EndpointName.");

--- a/clients/client-sagemaker/models/index.ts
+++ b/clients/client-sagemaker/models/index.ts
@@ -1,4 +1,8 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  LazyJsonString as __LazyJsonString,
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export interface AddTagsInput {
@@ -18,7 +22,7 @@ export interface AddTagsInput {
 
 export namespace AddTagsInput {
   export function isa(o: any): o is AddTagsInput {
-    return _smithy.isa(o, "AddTagsInput");
+    return __isa(o, "AddTagsInput");
   }
 }
 
@@ -32,7 +36,7 @@ export interface AddTagsOutput extends $MetadataBearer {
 
 export namespace AddTagsOutput {
   export function isa(o: any): o is AddTagsOutput {
-    return _smithy.isa(o, "AddTagsOutput");
+    return __isa(o, "AddTagsOutput");
   }
 }
 
@@ -126,7 +130,7 @@ export interface AlgorithmSpecification {
 
 export namespace AlgorithmSpecification {
   export function isa(o: any): o is AlgorithmSpecification {
-    return _smithy.isa(o, "AlgorithmSpecification");
+    return __isa(o, "AlgorithmSpecification");
   }
 }
 
@@ -156,7 +160,7 @@ export interface AlgorithmStatusDetails {
 
 export namespace AlgorithmStatusDetails {
   export function isa(o: any): o is AlgorithmStatusDetails {
-    return _smithy.isa(o, "AlgorithmStatusDetails");
+    return __isa(o, "AlgorithmStatusDetails");
   }
 }
 
@@ -183,7 +187,7 @@ export interface AlgorithmStatusItem {
 
 export namespace AlgorithmStatusItem {
   export function isa(o: any): o is AlgorithmStatusItem {
-    return _smithy.isa(o, "AlgorithmStatusItem");
+    return __isa(o, "AlgorithmStatusItem");
   }
 }
 
@@ -220,7 +224,7 @@ export interface AlgorithmSummary {
 
 export namespace AlgorithmSummary {
   export function isa(o: any): o is AlgorithmSummary {
-    return _smithy.isa(o, "AlgorithmSummary");
+    return __isa(o, "AlgorithmSummary");
   }
 }
 
@@ -253,7 +257,7 @@ export interface AlgorithmValidationProfile {
 
 export namespace AlgorithmValidationProfile {
   export function isa(o: any): o is AlgorithmValidationProfile {
-    return _smithy.isa(o, "AlgorithmValidationProfile");
+    return __isa(o, "AlgorithmValidationProfile");
   }
 }
 
@@ -277,7 +281,7 @@ export interface AlgorithmValidationSpecification {
 
 export namespace AlgorithmValidationSpecification {
   export function isa(o: any): o is AlgorithmValidationSpecification {
-    return _smithy.isa(o, "AlgorithmValidationSpecification");
+    return __isa(o, "AlgorithmValidationSpecification");
   }
 }
 
@@ -679,7 +683,7 @@ export interface AnnotationConsolidationConfig {
 
 export namespace AnnotationConsolidationConfig {
   export function isa(o: any): o is AnnotationConsolidationConfig {
-    return _smithy.isa(o, "AnnotationConsolidationConfig");
+    return __isa(o, "AnnotationConsolidationConfig");
   }
 }
 
@@ -721,7 +725,7 @@ export interface AppDetails {
 
 export namespace AppDetails {
   export function isa(o: any): o is AppDetails {
-    return _smithy.isa(o, "AppDetails");
+    return __isa(o, "AppDetails");
   }
 }
 
@@ -787,7 +791,7 @@ export interface AppSpecification {
 
 export namespace AppSpecification {
   export function isa(o: any): o is AppSpecification {
-    return _smithy.isa(o, "AppSpecification");
+    return __isa(o, "AppSpecification");
   }
 }
 
@@ -825,7 +829,7 @@ export interface AssociateTrialComponentRequest {
 
 export namespace AssociateTrialComponentRequest {
   export function isa(o: any): o is AssociateTrialComponentRequest {
-    return _smithy.isa(o, "AssociateTrialComponentRequest");
+    return __isa(o, "AssociateTrialComponentRequest");
   }
 }
 
@@ -844,7 +848,7 @@ export interface AssociateTrialComponentResponse extends $MetadataBearer {
 
 export namespace AssociateTrialComponentResponse {
   export function isa(o: any): o is AssociateTrialComponentResponse {
-    return _smithy.isa(o, "AssociateTrialComponentResponse");
+    return __isa(o, "AssociateTrialComponentResponse");
   }
 }
 
@@ -912,7 +916,7 @@ export interface AutoMLCandidate {
 
 export namespace AutoMLCandidate {
   export function isa(o: any): o is AutoMLCandidate {
-    return _smithy.isa(o, "AutoMLCandidate");
+    return __isa(o, "AutoMLCandidate");
   }
 }
 
@@ -939,7 +943,7 @@ export interface AutoMLCandidateStep {
 
 export namespace AutoMLCandidateStep {
   export function isa(o: any): o is AutoMLCandidateStep {
-    return _smithy.isa(o, "AutoMLCandidateStep");
+    return __isa(o, "AutoMLCandidateStep");
   }
 }
 
@@ -968,7 +972,7 @@ export interface AutoMLChannel {
 
 export namespace AutoMLChannel {
   export function isa(o: any): o is AutoMLChannel {
-    return _smithy.isa(o, "AutoMLChannel");
+    return __isa(o, "AutoMLChannel");
   }
 }
 
@@ -999,7 +1003,7 @@ export interface AutoMLContainerDefinition {
 
 export namespace AutoMLContainerDefinition {
   export function isa(o: any): o is AutoMLContainerDefinition {
-    return _smithy.isa(o, "AutoMLContainerDefinition");
+    return __isa(o, "AutoMLContainerDefinition");
   }
 }
 
@@ -1016,7 +1020,7 @@ export interface AutoMLDataSource {
 
 export namespace AutoMLDataSource {
   export function isa(o: any): o is AutoMLDataSource {
-    return _smithy.isa(o, "AutoMLDataSource");
+    return __isa(o, "AutoMLDataSource");
   }
 }
 
@@ -1038,7 +1042,7 @@ export interface AutoMLJobArtifacts {
 
 export namespace AutoMLJobArtifacts {
   export function isa(o: any): o is AutoMLJobArtifacts {
-    return _smithy.isa(o, "AutoMLJobArtifacts");
+    return __isa(o, "AutoMLJobArtifacts");
   }
 }
 
@@ -1066,7 +1070,7 @@ export interface AutoMLJobCompletionCriteria {
 
 export namespace AutoMLJobCompletionCriteria {
   export function isa(o: any): o is AutoMLJobCompletionCriteria {
-    return _smithy.isa(o, "AutoMLJobCompletionCriteria");
+    return __isa(o, "AutoMLJobCompletionCriteria");
   }
 }
 
@@ -1088,7 +1092,7 @@ export interface AutoMLJobConfig {
 
 export namespace AutoMLJobConfig {
   export function isa(o: any): o is AutoMLJobConfig {
-    return _smithy.isa(o, "AutoMLJobConfig");
+    return __isa(o, "AutoMLJobConfig");
   }
 }
 
@@ -1105,7 +1109,7 @@ export interface AutoMLJobObjective {
 
 export namespace AutoMLJobObjective {
   export function isa(o: any): o is AutoMLJobObjective {
-    return _smithy.isa(o, "AutoMLJobObjective");
+    return __isa(o, "AutoMLJobObjective");
   }
 }
 
@@ -1183,7 +1187,7 @@ export interface AutoMLJobSummary {
 
 export namespace AutoMLJobSummary {
   export function isa(o: any): o is AutoMLJobSummary {
-    return _smithy.isa(o, "AutoMLJobSummary");
+    return __isa(o, "AutoMLJobSummary");
   }
 }
 
@@ -1212,7 +1216,7 @@ export interface AutoMLOutputDataConfig {
 
 export namespace AutoMLOutputDataConfig {
   export function isa(o: any): o is AutoMLOutputDataConfig {
-    return _smithy.isa(o, "AutoMLOutputDataConfig");
+    return __isa(o, "AutoMLOutputDataConfig");
   }
 }
 
@@ -1234,7 +1238,7 @@ export interface AutoMLS3DataSource {
 
 export namespace AutoMLS3DataSource {
   export function isa(o: any): o is AutoMLS3DataSource {
-    return _smithy.isa(o, "AutoMLS3DataSource");
+    return __isa(o, "AutoMLS3DataSource");
   }
 }
 
@@ -1266,7 +1270,7 @@ export interface AutoMLSecurityConfig {
 
 export namespace AutoMLSecurityConfig {
   export function isa(o: any): o is AutoMLSecurityConfig {
-    return _smithy.isa(o, "AutoMLSecurityConfig");
+    return __isa(o, "AutoMLSecurityConfig");
   }
 }
 
@@ -1334,7 +1338,7 @@ export interface CaptureContentTypeHeader {
 
 export namespace CaptureContentTypeHeader {
   export function isa(o: any): o is CaptureContentTypeHeader {
-    return _smithy.isa(o, "CaptureContentTypeHeader");
+    return __isa(o, "CaptureContentTypeHeader");
   }
 }
 
@@ -1356,7 +1360,7 @@ export interface CaptureOption {
 
 export namespace CaptureOption {
   export function isa(o: any): o is CaptureOption {
-    return _smithy.isa(o, "CaptureOption");
+    return __isa(o, "CaptureOption");
   }
 }
 
@@ -1385,7 +1389,7 @@ export interface CategoricalParameterRange {
 
 export namespace CategoricalParameterRange {
   export function isa(o: any): o is CategoricalParameterRange {
-    return _smithy.isa(o, "CategoricalParameterRange");
+    return __isa(o, "CategoricalParameterRange");
   }
 }
 
@@ -1402,7 +1406,7 @@ export interface CategoricalParameterRangeSpecification {
 
 export namespace CategoricalParameterRangeSpecification {
   export function isa(o: any): o is CategoricalParameterRangeSpecification {
-    return _smithy.isa(o, "CategoricalParameterRangeSpecification");
+    return __isa(o, "CategoricalParameterRangeSpecification");
   }
 }
 
@@ -1479,7 +1483,7 @@ export interface Channel {
 
 export namespace Channel {
   export function isa(o: any): o is Channel {
-    return _smithy.isa(o, "Channel");
+    return __isa(o, "Channel");
   }
 }
 
@@ -1526,7 +1530,7 @@ export interface ChannelSpecification {
 
 export namespace ChannelSpecification {
   export function isa(o: any): o is ChannelSpecification {
-    return _smithy.isa(o, "ChannelSpecification");
+    return __isa(o, "ChannelSpecification");
   }
 }
 
@@ -1551,7 +1555,7 @@ export interface CheckpointConfig {
 
 export namespace CheckpointConfig {
   export function isa(o: any): o is CheckpointConfig {
-    return _smithy.isa(o, "CheckpointConfig");
+    return __isa(o, "CheckpointConfig");
   }
 }
 
@@ -1601,7 +1605,7 @@ export interface CodeRepositorySummary {
 
 export namespace CodeRepositorySummary {
   export function isa(o: any): o is CodeRepositorySummary {
-    return _smithy.isa(o, "CodeRepositorySummary");
+    return __isa(o, "CodeRepositorySummary");
   }
 }
 
@@ -1631,7 +1635,7 @@ export interface CognitoMemberDefinition {
 
 export namespace CognitoMemberDefinition {
   export function isa(o: any): o is CognitoMemberDefinition {
-    return _smithy.isa(o, "CognitoMemberDefinition");
+    return __isa(o, "CognitoMemberDefinition");
   }
 }
 
@@ -1656,7 +1660,7 @@ export interface CollectionConfiguration {
 
 export namespace CollectionConfiguration {
   export function isa(o: any): o is CollectionConfiguration {
-    return _smithy.isa(o, "CollectionConfiguration");
+    return __isa(o, "CollectionConfiguration");
   }
 }
 
@@ -1717,7 +1721,7 @@ export interface CompilationJobSummary {
 
 export namespace CompilationJobSummary {
   export function isa(o: any): o is CompilationJobSummary {
-    return _smithy.isa(o, "CompilationJobSummary");
+    return __isa(o, "CompilationJobSummary");
   }
 }
 
@@ -1729,9 +1733,7 @@ export enum CompressionType {
 /**
  * <p>There was a conflict when you attempted to modify an experiment, trial, or trial component.</p>
  */
-export interface ConflictException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface ConflictException extends __SmithyException, $MetadataBearer {
   name: "ConflictException";
   $fault: "client";
   Message?: string;
@@ -1739,7 +1741,7 @@ export interface ConflictException
 
 export namespace ConflictException {
   export function isa(o: any): o is ConflictException {
-    return _smithy.isa(o, "ConflictException");
+    return __isa(o, "ConflictException");
   }
 }
 
@@ -1816,7 +1818,7 @@ export interface ContainerDefinition {
 
 export namespace ContainerDefinition {
   export function isa(o: any): o is ContainerDefinition {
-    return _smithy.isa(o, "ContainerDefinition");
+    return __isa(o, "ContainerDefinition");
   }
 }
 
@@ -1889,7 +1891,7 @@ export interface ContinuousParameterRange {
 
 export namespace ContinuousParameterRange {
   export function isa(o: any): o is ContinuousParameterRange {
-    return _smithy.isa(o, "ContinuousParameterRange");
+    return __isa(o, "ContinuousParameterRange");
   }
 }
 
@@ -1911,7 +1913,7 @@ export interface ContinuousParameterRangeSpecification {
 
 export namespace ContinuousParameterRangeSpecification {
   export function isa(o: any): o is ContinuousParameterRangeSpecification {
-    return _smithy.isa(o, "ContinuousParameterRangeSpecification");
+    return __isa(o, "ContinuousParameterRangeSpecification");
   }
 }
 
@@ -1995,7 +1997,7 @@ export interface CreateAlgorithmInput {
 
 export namespace CreateAlgorithmInput {
   export function isa(o: any): o is CreateAlgorithmInput {
-    return _smithy.isa(o, "CreateAlgorithmInput");
+    return __isa(o, "CreateAlgorithmInput");
   }
 }
 
@@ -2009,7 +2011,7 @@ export interface CreateAlgorithmOutput extends $MetadataBearer {
 
 export namespace CreateAlgorithmOutput {
   export function isa(o: any): o is CreateAlgorithmOutput {
-    return _smithy.isa(o, "CreateAlgorithmOutput");
+    return __isa(o, "CreateAlgorithmOutput");
   }
 }
 
@@ -2049,7 +2051,7 @@ export interface CreateAppRequest {
 
 export namespace CreateAppRequest {
   export function isa(o: any): o is CreateAppRequest {
-    return _smithy.isa(o, "CreateAppRequest");
+    return __isa(o, "CreateAppRequest");
   }
 }
 
@@ -2063,7 +2065,7 @@ export interface CreateAppResponse extends $MetadataBearer {
 
 export namespace CreateAppResponse {
   export function isa(o: any): o is CreateAppResponse {
-    return _smithy.isa(o, "CreateAppResponse");
+    return __isa(o, "CreateAppResponse");
   }
 }
 
@@ -2124,7 +2126,7 @@ export interface CreateAutoMLJobRequest {
 
 export namespace CreateAutoMLJobRequest {
   export function isa(o: any): o is CreateAutoMLJobRequest {
-    return _smithy.isa(o, "CreateAutoMLJobRequest");
+    return __isa(o, "CreateAutoMLJobRequest");
   }
 }
 
@@ -2138,7 +2140,7 @@ export interface CreateAutoMLJobResponse extends $MetadataBearer {
 
 export namespace CreateAutoMLJobResponse {
   export function isa(o: any): o is CreateAutoMLJobResponse {
-    return _smithy.isa(o, "CreateAutoMLJobResponse");
+    return __isa(o, "CreateAutoMLJobResponse");
   }
 }
 
@@ -2159,7 +2161,7 @@ export interface CreateCodeRepositoryInput {
 
 export namespace CreateCodeRepositoryInput {
   export function isa(o: any): o is CreateCodeRepositoryInput {
-    return _smithy.isa(o, "CreateCodeRepositoryInput");
+    return __isa(o, "CreateCodeRepositoryInput");
   }
 }
 
@@ -2173,7 +2175,7 @@ export interface CreateCodeRepositoryOutput extends $MetadataBearer {
 
 export namespace CreateCodeRepositoryOutput {
   export function isa(o: any): o is CreateCodeRepositoryOutput {
-    return _smithy.isa(o, "CreateCodeRepositoryOutput");
+    return __isa(o, "CreateCodeRepositoryOutput");
   }
 }
 
@@ -2233,7 +2235,7 @@ export interface CreateCompilationJobRequest {
 
 export namespace CreateCompilationJobRequest {
   export function isa(o: any): o is CreateCompilationJobRequest {
-    return _smithy.isa(o, "CreateCompilationJobRequest");
+    return __isa(o, "CreateCompilationJobRequest");
   }
 }
 
@@ -2255,7 +2257,7 @@ export interface CreateCompilationJobResponse extends $MetadataBearer {
 
 export namespace CreateCompilationJobResponse {
   export function isa(o: any): o is CreateCompilationJobResponse {
-    return _smithy.isa(o, "CreateCompilationJobResponse");
+    return __isa(o, "CreateCompilationJobResponse");
   }
 }
 
@@ -2300,7 +2302,7 @@ export interface CreateDomainRequest {
 
 export namespace CreateDomainRequest {
   export function isa(o: any): o is CreateDomainRequest {
-    return _smithy.isa(o, "CreateDomainRequest");
+    return __isa(o, "CreateDomainRequest");
   }
 }
 
@@ -2319,7 +2321,7 @@ export interface CreateDomainResponse extends $MetadataBearer {
 
 export namespace CreateDomainResponse {
   export function isa(o: any): o is CreateDomainResponse {
-    return _smithy.isa(o, "CreateDomainResponse");
+    return __isa(o, "CreateDomainResponse");
   }
 }
 
@@ -2396,7 +2398,7 @@ export interface CreateEndpointConfigInput {
 
 export namespace CreateEndpointConfigInput {
   export function isa(o: any): o is CreateEndpointConfigInput {
-    return _smithy.isa(o, "CreateEndpointConfigInput");
+    return __isa(o, "CreateEndpointConfigInput");
   }
 }
 
@@ -2410,7 +2412,7 @@ export interface CreateEndpointConfigOutput extends $MetadataBearer {
 
 export namespace CreateEndpointConfigOutput {
   export function isa(o: any): o is CreateEndpointConfigOutput {
-    return _smithy.isa(o, "CreateEndpointConfigOutput");
+    return __isa(o, "CreateEndpointConfigOutput");
   }
 }
 
@@ -2440,7 +2442,7 @@ export interface CreateEndpointInput {
 
 export namespace CreateEndpointInput {
   export function isa(o: any): o is CreateEndpointInput {
-    return _smithy.isa(o, "CreateEndpointInput");
+    return __isa(o, "CreateEndpointInput");
   }
 }
 
@@ -2454,7 +2456,7 @@ export interface CreateEndpointOutput extends $MetadataBearer {
 
 export namespace CreateEndpointOutput {
   export function isa(o: any): o is CreateEndpointOutput {
-    return _smithy.isa(o, "CreateEndpointOutput");
+    return __isa(o, "CreateEndpointOutput");
   }
 }
 
@@ -2487,7 +2489,7 @@ export interface CreateExperimentRequest {
 
 export namespace CreateExperimentRequest {
   export function isa(o: any): o is CreateExperimentRequest {
-    return _smithy.isa(o, "CreateExperimentRequest");
+    return __isa(o, "CreateExperimentRequest");
   }
 }
 
@@ -2501,7 +2503,7 @@ export interface CreateExperimentResponse extends $MetadataBearer {
 
 export namespace CreateExperimentResponse {
   export function isa(o: any): o is CreateExperimentResponse {
-    return _smithy.isa(o, "CreateExperimentResponse");
+    return __isa(o, "CreateExperimentResponse");
   }
 }
 
@@ -2540,7 +2542,7 @@ export interface CreateFlowDefinitionRequest {
 
 export namespace CreateFlowDefinitionRequest {
   export function isa(o: any): o is CreateFlowDefinitionRequest {
-    return _smithy.isa(o, "CreateFlowDefinitionRequest");
+    return __isa(o, "CreateFlowDefinitionRequest");
   }
 }
 
@@ -2554,7 +2556,7 @@ export interface CreateFlowDefinitionResponse extends $MetadataBearer {
 
 export namespace CreateFlowDefinitionResponse {
   export function isa(o: any): o is CreateFlowDefinitionResponse {
-    return _smithy.isa(o, "CreateFlowDefinitionResponse");
+    return __isa(o, "CreateFlowDefinitionResponse");
   }
 }
 
@@ -2578,7 +2580,7 @@ export interface CreateHumanTaskUiRequest {
 
 export namespace CreateHumanTaskUiRequest {
   export function isa(o: any): o is CreateHumanTaskUiRequest {
-    return _smithy.isa(o, "CreateHumanTaskUiRequest");
+    return __isa(o, "CreateHumanTaskUiRequest");
   }
 }
 
@@ -2592,7 +2594,7 @@ export interface CreateHumanTaskUiResponse extends $MetadataBearer {
 
 export namespace CreateHumanTaskUiResponse {
   export function isa(o: any): o is CreateHumanTaskUiResponse {
-    return _smithy.isa(o, "CreateHumanTaskUiResponse");
+    return __isa(o, "CreateHumanTaskUiResponse");
   }
 }
 
@@ -2661,7 +2663,7 @@ export interface CreateHyperParameterTuningJobRequest {
 
 export namespace CreateHyperParameterTuningJobRequest {
   export function isa(o: any): o is CreateHyperParameterTuningJobRequest {
-    return _smithy.isa(o, "CreateHyperParameterTuningJobRequest");
+    return __isa(o, "CreateHyperParameterTuningJobRequest");
   }
 }
 
@@ -2676,7 +2678,7 @@ export interface CreateHyperParameterTuningJobResponse extends $MetadataBearer {
 
 export namespace CreateHyperParameterTuningJobResponse {
   export function isa(o: any): o is CreateHyperParameterTuningJobResponse {
-    return _smithy.isa(o, "CreateHyperParameterTuningJobResponse");
+    return __isa(o, "CreateHyperParameterTuningJobResponse");
   }
 }
 
@@ -2794,7 +2796,7 @@ export interface CreateLabelingJobRequest {
 
 export namespace CreateLabelingJobRequest {
   export function isa(o: any): o is CreateLabelingJobRequest {
-    return _smithy.isa(o, "CreateLabelingJobRequest");
+    return __isa(o, "CreateLabelingJobRequest");
   }
 }
 
@@ -2809,7 +2811,7 @@ export interface CreateLabelingJobResponse extends $MetadataBearer {
 
 export namespace CreateLabelingJobResponse {
   export function isa(o: any): o is CreateLabelingJobResponse {
-    return _smithy.isa(o, "CreateLabelingJobResponse");
+    return __isa(o, "CreateLabelingJobResponse");
   }
 }
 
@@ -2871,7 +2873,7 @@ export interface CreateModelInput {
 
 export namespace CreateModelInput {
   export function isa(o: any): o is CreateModelInput {
-    return _smithy.isa(o, "CreateModelInput");
+    return __isa(o, "CreateModelInput");
   }
 }
 
@@ -2885,7 +2887,7 @@ export interface CreateModelOutput extends $MetadataBearer {
 
 export namespace CreateModelOutput {
   export function isa(o: any): o is CreateModelOutput {
-    return _smithy.isa(o, "CreateModelOutput");
+    return __isa(o, "CreateModelOutput");
   }
 }
 
@@ -2941,7 +2943,7 @@ export interface CreateModelPackageInput {
 
 export namespace CreateModelPackageInput {
   export function isa(o: any): o is CreateModelPackageInput {
-    return _smithy.isa(o, "CreateModelPackageInput");
+    return __isa(o, "CreateModelPackageInput");
   }
 }
 
@@ -2955,7 +2957,7 @@ export interface CreateModelPackageOutput extends $MetadataBearer {
 
 export namespace CreateModelPackageOutput {
   export function isa(o: any): o is CreateModelPackageOutput {
-    return _smithy.isa(o, "CreateModelPackageOutput");
+    return __isa(o, "CreateModelPackageOutput");
   }
 }
 
@@ -2982,7 +2984,7 @@ export interface CreateMonitoringScheduleRequest {
 
 export namespace CreateMonitoringScheduleRequest {
   export function isa(o: any): o is CreateMonitoringScheduleRequest {
-    return _smithy.isa(o, "CreateMonitoringScheduleRequest");
+    return __isa(o, "CreateMonitoringScheduleRequest");
   }
 }
 
@@ -2996,7 +2998,7 @@ export interface CreateMonitoringScheduleResponse extends $MetadataBearer {
 
 export namespace CreateMonitoringScheduleResponse {
   export function isa(o: any): o is CreateMonitoringScheduleResponse {
-    return _smithy.isa(o, "CreateMonitoringScheduleResponse");
+    return __isa(o, "CreateMonitoringScheduleResponse");
   }
 }
 
@@ -3117,7 +3119,7 @@ export interface CreateNotebookInstanceInput {
 
 export namespace CreateNotebookInstanceInput {
   export function isa(o: any): o is CreateNotebookInstanceInput {
-    return _smithy.isa(o, "CreateNotebookInstanceInput");
+    return __isa(o, "CreateNotebookInstanceInput");
   }
 }
 
@@ -3143,7 +3145,7 @@ export interface CreateNotebookInstanceLifecycleConfigInput {
 
 export namespace CreateNotebookInstanceLifecycleConfigInput {
   export function isa(o: any): o is CreateNotebookInstanceLifecycleConfigInput {
-    return _smithy.isa(o, "CreateNotebookInstanceLifecycleConfigInput");
+    return __isa(o, "CreateNotebookInstanceLifecycleConfigInput");
   }
 }
 
@@ -3160,7 +3162,7 @@ export namespace CreateNotebookInstanceLifecycleConfigOutput {
   export function isa(
     o: any
   ): o is CreateNotebookInstanceLifecycleConfigOutput {
-    return _smithy.isa(o, "CreateNotebookInstanceLifecycleConfigOutput");
+    return __isa(o, "CreateNotebookInstanceLifecycleConfigOutput");
   }
 }
 
@@ -3174,7 +3176,7 @@ export interface CreateNotebookInstanceOutput extends $MetadataBearer {
 
 export namespace CreateNotebookInstanceOutput {
   export function isa(o: any): o is CreateNotebookInstanceOutput {
-    return _smithy.isa(o, "CreateNotebookInstanceOutput");
+    return __isa(o, "CreateNotebookInstanceOutput");
   }
 }
 
@@ -3198,7 +3200,7 @@ export interface CreatePresignedDomainUrlRequest {
 
 export namespace CreatePresignedDomainUrlRequest {
   export function isa(o: any): o is CreatePresignedDomainUrlRequest {
-    return _smithy.isa(o, "CreatePresignedDomainUrlRequest");
+    return __isa(o, "CreatePresignedDomainUrlRequest");
   }
 }
 
@@ -3212,7 +3214,7 @@ export interface CreatePresignedDomainUrlResponse extends $MetadataBearer {
 
 export namespace CreatePresignedDomainUrlResponse {
   export function isa(o: any): o is CreatePresignedDomainUrlResponse {
-    return _smithy.isa(o, "CreatePresignedDomainUrlResponse");
+    return __isa(o, "CreatePresignedDomainUrlResponse");
   }
 }
 
@@ -3231,7 +3233,7 @@ export interface CreatePresignedNotebookInstanceUrlInput {
 
 export namespace CreatePresignedNotebookInstanceUrlInput {
   export function isa(o: any): o is CreatePresignedNotebookInstanceUrlInput {
-    return _smithy.isa(o, "CreatePresignedNotebookInstanceUrlInput");
+    return __isa(o, "CreatePresignedNotebookInstanceUrlInput");
   }
 }
 
@@ -3246,7 +3248,7 @@ export interface CreatePresignedNotebookInstanceUrlOutput
 
 export namespace CreatePresignedNotebookInstanceUrlOutput {
   export function isa(o: any): o is CreatePresignedNotebookInstanceUrlOutput {
-    return _smithy.isa(o, "CreatePresignedNotebookInstanceUrlOutput");
+    return __isa(o, "CreatePresignedNotebookInstanceUrlOutput");
   }
 }
 
@@ -3315,7 +3317,7 @@ export interface CreateProcessingJobRequest {
 
 export namespace CreateProcessingJobRequest {
   export function isa(o: any): o is CreateProcessingJobRequest {
-    return _smithy.isa(o, "CreateProcessingJobRequest");
+    return __isa(o, "CreateProcessingJobRequest");
   }
 }
 
@@ -3329,7 +3331,7 @@ export interface CreateProcessingJobResponse extends $MetadataBearer {
 
 export namespace CreateProcessingJobResponse {
   export function isa(o: any): o is CreateProcessingJobResponse {
-    return _smithy.isa(o, "CreateProcessingJobResponse");
+    return __isa(o, "CreateProcessingJobResponse");
   }
 }
 
@@ -3498,7 +3500,7 @@ export interface CreateTrainingJobRequest {
 
 export namespace CreateTrainingJobRequest {
   export function isa(o: any): o is CreateTrainingJobRequest {
-    return _smithy.isa(o, "CreateTrainingJobRequest");
+    return __isa(o, "CreateTrainingJobRequest");
   }
 }
 
@@ -3512,7 +3514,7 @@ export interface CreateTrainingJobResponse extends $MetadataBearer {
 
 export namespace CreateTrainingJobResponse {
   export function isa(o: any): o is CreateTrainingJobResponse {
-    return _smithy.isa(o, "CreateTrainingJobResponse");
+    return __isa(o, "CreateTrainingJobResponse");
   }
 }
 
@@ -3628,7 +3630,7 @@ export interface CreateTransformJobRequest {
 
 export namespace CreateTransformJobRequest {
   export function isa(o: any): o is CreateTransformJobRequest {
-    return _smithy.isa(o, "CreateTransformJobRequest");
+    return __isa(o, "CreateTransformJobRequest");
   }
 }
 
@@ -3642,7 +3644,7 @@ export interface CreateTransformJobResponse extends $MetadataBearer {
 
 export namespace CreateTransformJobResponse {
   export function isa(o: any): o is CreateTransformJobResponse {
-    return _smithy.isa(o, "CreateTransformJobResponse");
+    return __isa(o, "CreateTransformJobResponse");
   }
 }
 
@@ -3713,7 +3715,7 @@ export interface CreateTrialComponentRequest {
 
 export namespace CreateTrialComponentRequest {
   export function isa(o: any): o is CreateTrialComponentRequest {
-    return _smithy.isa(o, "CreateTrialComponentRequest");
+    return __isa(o, "CreateTrialComponentRequest");
   }
 }
 
@@ -3727,7 +3729,7 @@ export interface CreateTrialComponentResponse extends $MetadataBearer {
 
 export namespace CreateTrialComponentResponse {
   export function isa(o: any): o is CreateTrialComponentResponse {
-    return _smithy.isa(o, "CreateTrialComponentResponse");
+    return __isa(o, "CreateTrialComponentResponse");
   }
 }
 
@@ -3760,7 +3762,7 @@ export interface CreateTrialRequest {
 
 export namespace CreateTrialRequest {
   export function isa(o: any): o is CreateTrialRequest {
-    return _smithy.isa(o, "CreateTrialRequest");
+    return __isa(o, "CreateTrialRequest");
   }
 }
 
@@ -3774,7 +3776,7 @@ export interface CreateTrialResponse extends $MetadataBearer {
 
 export namespace CreateTrialResponse {
   export function isa(o: any): o is CreateTrialResponse {
-    return _smithy.isa(o, "CreateTrialResponse");
+    return __isa(o, "CreateTrialResponse");
   }
 }
 
@@ -3818,7 +3820,7 @@ export interface CreateUserProfileRequest {
 
 export namespace CreateUserProfileRequest {
   export function isa(o: any): o is CreateUserProfileRequest {
-    return _smithy.isa(o, "CreateUserProfileRequest");
+    return __isa(o, "CreateUserProfileRequest");
   }
 }
 
@@ -3832,7 +3834,7 @@ export interface CreateUserProfileResponse extends $MetadataBearer {
 
 export namespace CreateUserProfileResponse {
   export function isa(o: any): o is CreateUserProfileResponse {
-    return _smithy.isa(o, "CreateUserProfileResponse");
+    return __isa(o, "CreateUserProfileResponse");
   }
 }
 
@@ -3875,7 +3877,7 @@ export interface CreateWorkteamRequest {
 
 export namespace CreateWorkteamRequest {
   export function isa(o: any): o is CreateWorkteamRequest {
-    return _smithy.isa(o, "CreateWorkteamRequest");
+    return __isa(o, "CreateWorkteamRequest");
   }
 }
 
@@ -3890,7 +3892,7 @@ export interface CreateWorkteamResponse extends $MetadataBearer {
 
 export namespace CreateWorkteamResponse {
   export function isa(o: any): o is CreateWorkteamResponse {
-    return _smithy.isa(o, "CreateWorkteamResponse");
+    return __isa(o, "CreateWorkteamResponse");
   }
 }
 
@@ -3932,7 +3934,7 @@ export interface DataCaptureConfig {
 
 export namespace DataCaptureConfig {
   export function isa(o: any): o is DataCaptureConfig {
-    return _smithy.isa(o, "DataCaptureConfig");
+    return __isa(o, "DataCaptureConfig");
   }
 }
 
@@ -3969,7 +3971,7 @@ export interface DataCaptureConfigSummary {
 
 export namespace DataCaptureConfigSummary {
   export function isa(o: any): o is DataCaptureConfigSummary {
-    return _smithy.isa(o, "DataCaptureConfigSummary");
+    return __isa(o, "DataCaptureConfigSummary");
   }
 }
 
@@ -4028,7 +4030,7 @@ export interface DataProcessing {
 
 export namespace DataProcessing {
   export function isa(o: any): o is DataProcessing {
-    return _smithy.isa(o, "DataProcessing");
+    return __isa(o, "DataProcessing");
   }
 }
 
@@ -4050,7 +4052,7 @@ export interface DataSource {
 
 export namespace DataSource {
   export function isa(o: any): o is DataSource {
-    return _smithy.isa(o, "DataSource");
+    return __isa(o, "DataSource");
   }
 }
 
@@ -4084,7 +4086,7 @@ export interface DebugHookConfig {
 
 export namespace DebugHookConfig {
   export function isa(o: any): o is DebugHookConfig {
-    return _smithy.isa(o, "DebugHookConfig");
+    return __isa(o, "DebugHookConfig");
   }
 }
 
@@ -4133,7 +4135,7 @@ export interface DebugRuleConfiguration {
 
 export namespace DebugRuleConfiguration {
   export function isa(o: any): o is DebugRuleConfiguration {
-    return _smithy.isa(o, "DebugRuleConfiguration");
+    return __isa(o, "DebugRuleConfiguration");
   }
 }
 
@@ -4170,7 +4172,7 @@ export interface DebugRuleEvaluationStatus {
 
 export namespace DebugRuleEvaluationStatus {
   export function isa(o: any): o is DebugRuleEvaluationStatus {
-    return _smithy.isa(o, "DebugRuleEvaluationStatus");
+    return __isa(o, "DebugRuleEvaluationStatus");
   }
 }
 
@@ -4184,7 +4186,7 @@ export interface DeleteAlgorithmInput {
 
 export namespace DeleteAlgorithmInput {
   export function isa(o: any): o is DeleteAlgorithmInput {
-    return _smithy.isa(o, "DeleteAlgorithmInput");
+    return __isa(o, "DeleteAlgorithmInput");
   }
 }
 
@@ -4213,7 +4215,7 @@ export interface DeleteAppRequest {
 
 export namespace DeleteAppRequest {
   export function isa(o: any): o is DeleteAppRequest {
-    return _smithy.isa(o, "DeleteAppRequest");
+    return __isa(o, "DeleteAppRequest");
   }
 }
 
@@ -4227,7 +4229,7 @@ export interface DeleteCodeRepositoryInput {
 
 export namespace DeleteCodeRepositoryInput {
   export function isa(o: any): o is DeleteCodeRepositoryInput {
-    return _smithy.isa(o, "DeleteCodeRepositoryInput");
+    return __isa(o, "DeleteCodeRepositoryInput");
   }
 }
 
@@ -4248,7 +4250,7 @@ export interface DeleteDomainRequest {
 
 export namespace DeleteDomainRequest {
   export function isa(o: any): o is DeleteDomainRequest {
-    return _smithy.isa(o, "DeleteDomainRequest");
+    return __isa(o, "DeleteDomainRequest");
   }
 }
 
@@ -4262,7 +4264,7 @@ export interface DeleteEndpointConfigInput {
 
 export namespace DeleteEndpointConfigInput {
   export function isa(o: any): o is DeleteEndpointConfigInput {
-    return _smithy.isa(o, "DeleteEndpointConfigInput");
+    return __isa(o, "DeleteEndpointConfigInput");
   }
 }
 
@@ -4276,7 +4278,7 @@ export interface DeleteEndpointInput {
 
 export namespace DeleteEndpointInput {
   export function isa(o: any): o is DeleteEndpointInput {
-    return _smithy.isa(o, "DeleteEndpointInput");
+    return __isa(o, "DeleteEndpointInput");
   }
 }
 
@@ -4290,7 +4292,7 @@ export interface DeleteExperimentRequest {
 
 export namespace DeleteExperimentRequest {
   export function isa(o: any): o is DeleteExperimentRequest {
-    return _smithy.isa(o, "DeleteExperimentRequest");
+    return __isa(o, "DeleteExperimentRequest");
   }
 }
 
@@ -4304,7 +4306,7 @@ export interface DeleteExperimentResponse extends $MetadataBearer {
 
 export namespace DeleteExperimentResponse {
   export function isa(o: any): o is DeleteExperimentResponse {
-    return _smithy.isa(o, "DeleteExperimentResponse");
+    return __isa(o, "DeleteExperimentResponse");
   }
 }
 
@@ -4318,7 +4320,7 @@ export interface DeleteFlowDefinitionRequest {
 
 export namespace DeleteFlowDefinitionRequest {
   export function isa(o: any): o is DeleteFlowDefinitionRequest {
-    return _smithy.isa(o, "DeleteFlowDefinitionRequest");
+    return __isa(o, "DeleteFlowDefinitionRequest");
   }
 }
 
@@ -4328,7 +4330,7 @@ export interface DeleteFlowDefinitionResponse extends $MetadataBearer {
 
 export namespace DeleteFlowDefinitionResponse {
   export function isa(o: any): o is DeleteFlowDefinitionResponse {
-    return _smithy.isa(o, "DeleteFlowDefinitionResponse");
+    return __isa(o, "DeleteFlowDefinitionResponse");
   }
 }
 
@@ -4342,7 +4344,7 @@ export interface DeleteModelInput {
 
 export namespace DeleteModelInput {
   export function isa(o: any): o is DeleteModelInput {
-    return _smithy.isa(o, "DeleteModelInput");
+    return __isa(o, "DeleteModelInput");
   }
 }
 
@@ -4357,7 +4359,7 @@ export interface DeleteModelPackageInput {
 
 export namespace DeleteModelPackageInput {
   export function isa(o: any): o is DeleteModelPackageInput {
-    return _smithy.isa(o, "DeleteModelPackageInput");
+    return __isa(o, "DeleteModelPackageInput");
   }
 }
 
@@ -4371,7 +4373,7 @@ export interface DeleteMonitoringScheduleRequest {
 
 export namespace DeleteMonitoringScheduleRequest {
   export function isa(o: any): o is DeleteMonitoringScheduleRequest {
-    return _smithy.isa(o, "DeleteMonitoringScheduleRequest");
+    return __isa(o, "DeleteMonitoringScheduleRequest");
   }
 }
 
@@ -4385,7 +4387,7 @@ export interface DeleteNotebookInstanceInput {
 
 export namespace DeleteNotebookInstanceInput {
   export function isa(o: any): o is DeleteNotebookInstanceInput {
-    return _smithy.isa(o, "DeleteNotebookInstanceInput");
+    return __isa(o, "DeleteNotebookInstanceInput");
   }
 }
 
@@ -4399,7 +4401,7 @@ export interface DeleteNotebookInstanceLifecycleConfigInput {
 
 export namespace DeleteNotebookInstanceLifecycleConfigInput {
   export function isa(o: any): o is DeleteNotebookInstanceLifecycleConfigInput {
-    return _smithy.isa(o, "DeleteNotebookInstanceLifecycleConfigInput");
+    return __isa(o, "DeleteNotebookInstanceLifecycleConfigInput");
   }
 }
 
@@ -4419,7 +4421,7 @@ export interface DeleteTagsInput {
 
 export namespace DeleteTagsInput {
   export function isa(o: any): o is DeleteTagsInput {
-    return _smithy.isa(o, "DeleteTagsInput");
+    return __isa(o, "DeleteTagsInput");
   }
 }
 
@@ -4429,7 +4431,7 @@ export interface DeleteTagsOutput extends $MetadataBearer {
 
 export namespace DeleteTagsOutput {
   export function isa(o: any): o is DeleteTagsOutput {
-    return _smithy.isa(o, "DeleteTagsOutput");
+    return __isa(o, "DeleteTagsOutput");
   }
 }
 
@@ -4443,7 +4445,7 @@ export interface DeleteTrialComponentRequest {
 
 export namespace DeleteTrialComponentRequest {
   export function isa(o: any): o is DeleteTrialComponentRequest {
-    return _smithy.isa(o, "DeleteTrialComponentRequest");
+    return __isa(o, "DeleteTrialComponentRequest");
   }
 }
 
@@ -4457,7 +4459,7 @@ export interface DeleteTrialComponentResponse extends $MetadataBearer {
 
 export namespace DeleteTrialComponentResponse {
   export function isa(o: any): o is DeleteTrialComponentResponse {
-    return _smithy.isa(o, "DeleteTrialComponentResponse");
+    return __isa(o, "DeleteTrialComponentResponse");
   }
 }
 
@@ -4471,7 +4473,7 @@ export interface DeleteTrialRequest {
 
 export namespace DeleteTrialRequest {
   export function isa(o: any): o is DeleteTrialRequest {
-    return _smithy.isa(o, "DeleteTrialRequest");
+    return __isa(o, "DeleteTrialRequest");
   }
 }
 
@@ -4485,7 +4487,7 @@ export interface DeleteTrialResponse extends $MetadataBearer {
 
 export namespace DeleteTrialResponse {
   export function isa(o: any): o is DeleteTrialResponse {
-    return _smithy.isa(o, "DeleteTrialResponse");
+    return __isa(o, "DeleteTrialResponse");
   }
 }
 
@@ -4504,7 +4506,7 @@ export interface DeleteUserProfileRequest {
 
 export namespace DeleteUserProfileRequest {
   export function isa(o: any): o is DeleteUserProfileRequest {
-    return _smithy.isa(o, "DeleteUserProfileRequest");
+    return __isa(o, "DeleteUserProfileRequest");
   }
 }
 
@@ -4518,7 +4520,7 @@ export interface DeleteWorkteamRequest {
 
 export namespace DeleteWorkteamRequest {
   export function isa(o: any): o is DeleteWorkteamRequest {
-    return _smithy.isa(o, "DeleteWorkteamRequest");
+    return __isa(o, "DeleteWorkteamRequest");
   }
 }
 
@@ -4533,7 +4535,7 @@ export interface DeleteWorkteamResponse extends $MetadataBearer {
 
 export namespace DeleteWorkteamResponse {
   export function isa(o: any): o is DeleteWorkteamResponse {
-    return _smithy.isa(o, "DeleteWorkteamResponse");
+    return __isa(o, "DeleteWorkteamResponse");
   }
 }
 
@@ -4568,7 +4570,7 @@ export interface DeployedImage {
 
 export namespace DeployedImage {
   export function isa(o: any): o is DeployedImage {
-    return _smithy.isa(o, "DeployedImage");
+    return __isa(o, "DeployedImage");
   }
 }
 
@@ -4582,7 +4584,7 @@ export interface DescribeAlgorithmInput {
 
 export namespace DescribeAlgorithmInput {
   export function isa(o: any): o is DescribeAlgorithmInput {
-    return _smithy.isa(o, "DescribeAlgorithmInput");
+    return __isa(o, "DescribeAlgorithmInput");
   }
 }
 
@@ -4647,7 +4649,7 @@ export interface DescribeAlgorithmOutput extends $MetadataBearer {
 
 export namespace DescribeAlgorithmOutput {
   export function isa(o: any): o is DescribeAlgorithmOutput {
-    return _smithy.isa(o, "DescribeAlgorithmOutput");
+    return __isa(o, "DescribeAlgorithmOutput");
   }
 }
 
@@ -4676,7 +4678,7 @@ export interface DescribeAppRequest {
 
 export namespace DescribeAppRequest {
   export function isa(o: any): o is DescribeAppRequest {
-    return _smithy.isa(o, "DescribeAppRequest");
+    return __isa(o, "DescribeAppRequest");
   }
 }
 
@@ -4740,7 +4742,7 @@ export interface DescribeAppResponse extends $MetadataBearer {
 
 export namespace DescribeAppResponse {
   export function isa(o: any): o is DescribeAppResponse {
-    return _smithy.isa(o, "DescribeAppResponse");
+    return __isa(o, "DescribeAppResponse");
   }
 }
 
@@ -4754,7 +4756,7 @@ export interface DescribeAutoMLJobRequest {
 
 export namespace DescribeAutoMLJobRequest {
   export function isa(o: any): o is DescribeAutoMLJobRequest {
-    return _smithy.isa(o, "DescribeAutoMLJobRequest");
+    return __isa(o, "DescribeAutoMLJobRequest");
   }
 }
 
@@ -4856,7 +4858,7 @@ export interface DescribeAutoMLJobResponse extends $MetadataBearer {
 
 export namespace DescribeAutoMLJobResponse {
   export function isa(o: any): o is DescribeAutoMLJobResponse {
-    return _smithy.isa(o, "DescribeAutoMLJobResponse");
+    return __isa(o, "DescribeAutoMLJobResponse");
   }
 }
 
@@ -4870,7 +4872,7 @@ export interface DescribeCodeRepositoryInput {
 
 export namespace DescribeCodeRepositoryInput {
   export function isa(o: any): o is DescribeCodeRepositoryInput {
-    return _smithy.isa(o, "DescribeCodeRepositoryInput");
+    return __isa(o, "DescribeCodeRepositoryInput");
   }
 }
 
@@ -4906,7 +4908,7 @@ export interface DescribeCodeRepositoryOutput extends $MetadataBearer {
 
 export namespace DescribeCodeRepositoryOutput {
   export function isa(o: any): o is DescribeCodeRepositoryOutput {
-    return _smithy.isa(o, "DescribeCodeRepositoryOutput");
+    return __isa(o, "DescribeCodeRepositoryOutput");
   }
 }
 
@@ -4920,7 +4922,7 @@ export interface DescribeCompilationJobRequest {
 
 export namespace DescribeCompilationJobRequest {
   export function isa(o: any): o is DescribeCompilationJobRequest {
-    return _smithy.isa(o, "DescribeCompilationJobRequest");
+    return __isa(o, "DescribeCompilationJobRequest");
   }
 }
 
@@ -5009,7 +5011,7 @@ export interface DescribeCompilationJobResponse extends $MetadataBearer {
 
 export namespace DescribeCompilationJobResponse {
   export function isa(o: any): o is DescribeCompilationJobResponse {
-    return _smithy.isa(o, "DescribeCompilationJobResponse");
+    return __isa(o, "DescribeCompilationJobResponse");
   }
 }
 
@@ -5023,7 +5025,7 @@ export interface DescribeDomainRequest {
 
 export namespace DescribeDomainRequest {
   export function isa(o: any): o is DescribeDomainRequest {
-    return _smithy.isa(o, "DescribeDomainRequest");
+    return __isa(o, "DescribeDomainRequest");
   }
 }
 
@@ -5109,7 +5111,7 @@ export interface DescribeDomainResponse extends $MetadataBearer {
 
 export namespace DescribeDomainResponse {
   export function isa(o: any): o is DescribeDomainResponse {
-    return _smithy.isa(o, "DescribeDomainResponse");
+    return __isa(o, "DescribeDomainResponse");
   }
 }
 
@@ -5123,7 +5125,7 @@ export interface DescribeEndpointConfigInput {
 
 export namespace DescribeEndpointConfigInput {
   export function isa(o: any): o is DescribeEndpointConfigInput {
-    return _smithy.isa(o, "DescribeEndpointConfigInput");
+    return __isa(o, "DescribeEndpointConfigInput");
   }
 }
 
@@ -5164,7 +5166,7 @@ export interface DescribeEndpointConfigOutput extends $MetadataBearer {
 
 export namespace DescribeEndpointConfigOutput {
   export function isa(o: any): o is DescribeEndpointConfigOutput {
-    return _smithy.isa(o, "DescribeEndpointConfigOutput");
+    return __isa(o, "DescribeEndpointConfigOutput");
   }
 }
 
@@ -5178,7 +5180,7 @@ export interface DescribeEndpointInput {
 
 export namespace DescribeEndpointInput {
   export function isa(o: any): o is DescribeEndpointInput {
-    return _smithy.isa(o, "DescribeEndpointInput");
+    return __isa(o, "DescribeEndpointInput");
   }
 }
 
@@ -5282,7 +5284,7 @@ export interface DescribeEndpointOutput extends $MetadataBearer {
 
 export namespace DescribeEndpointOutput {
   export function isa(o: any): o is DescribeEndpointOutput {
-    return _smithy.isa(o, "DescribeEndpointOutput");
+    return __isa(o, "DescribeEndpointOutput");
   }
 }
 
@@ -5296,7 +5298,7 @@ export interface DescribeExperimentRequest {
 
 export namespace DescribeExperimentRequest {
   export function isa(o: any): o is DescribeExperimentRequest {
-    return _smithy.isa(o, "DescribeExperimentRequest");
+    return __isa(o, "DescribeExperimentRequest");
   }
 }
 
@@ -5351,7 +5353,7 @@ export interface DescribeExperimentResponse extends $MetadataBearer {
 
 export namespace DescribeExperimentResponse {
   export function isa(o: any): o is DescribeExperimentResponse {
-    return _smithy.isa(o, "DescribeExperimentResponse");
+    return __isa(o, "DescribeExperimentResponse");
   }
 }
 
@@ -5365,7 +5367,7 @@ export interface DescribeFlowDefinitionRequest {
 
 export namespace DescribeFlowDefinitionRequest {
   export function isa(o: any): o is DescribeFlowDefinitionRequest {
-    return _smithy.isa(o, "DescribeFlowDefinitionRequest");
+    return __isa(o, "DescribeFlowDefinitionRequest");
   }
 }
 
@@ -5419,7 +5421,7 @@ export interface DescribeFlowDefinitionResponse extends $MetadataBearer {
 
 export namespace DescribeFlowDefinitionResponse {
   export function isa(o: any): o is DescribeFlowDefinitionResponse {
-    return _smithy.isa(o, "DescribeFlowDefinitionResponse");
+    return __isa(o, "DescribeFlowDefinitionResponse");
   }
 }
 
@@ -5433,7 +5435,7 @@ export interface DescribeHumanTaskUiRequest {
 
 export namespace DescribeHumanTaskUiRequest {
   export function isa(o: any): o is DescribeHumanTaskUiRequest {
-    return _smithy.isa(o, "DescribeHumanTaskUiRequest");
+    return __isa(o, "DescribeHumanTaskUiRequest");
   }
 }
 
@@ -5462,7 +5464,7 @@ export interface DescribeHumanTaskUiResponse extends $MetadataBearer {
 
 export namespace DescribeHumanTaskUiResponse {
   export function isa(o: any): o is DescribeHumanTaskUiResponse {
-    return _smithy.isa(o, "DescribeHumanTaskUiResponse");
+    return __isa(o, "DescribeHumanTaskUiResponse");
   }
 }
 
@@ -5476,7 +5478,7 @@ export interface DescribeHyperParameterTuningJobRequest {
 
 export namespace DescribeHyperParameterTuningJobRequest {
   export function isa(o: any): o is DescribeHyperParameterTuningJobRequest {
-    return _smithy.isa(o, "DescribeHyperParameterTuningJobRequest");
+    return __isa(o, "DescribeHyperParameterTuningJobRequest");
   }
 }
 
@@ -5579,7 +5581,7 @@ export interface DescribeHyperParameterTuningJobResponse
 
 export namespace DescribeHyperParameterTuningJobResponse {
   export function isa(o: any): o is DescribeHyperParameterTuningJobResponse {
-    return _smithy.isa(o, "DescribeHyperParameterTuningJobResponse");
+    return __isa(o, "DescribeHyperParameterTuningJobResponse");
   }
 }
 
@@ -5593,7 +5595,7 @@ export interface DescribeLabelingJobRequest {
 
 export namespace DescribeLabelingJobRequest {
   export function isa(o: any): o is DescribeLabelingJobRequest {
-    return _smithy.isa(o, "DescribeLabelingJobRequest");
+    return __isa(o, "DescribeLabelingJobRequest");
   }
 }
 
@@ -5757,7 +5759,7 @@ export interface DescribeLabelingJobResponse extends $MetadataBearer {
 
 export namespace DescribeLabelingJobResponse {
   export function isa(o: any): o is DescribeLabelingJobResponse {
-    return _smithy.isa(o, "DescribeLabelingJobResponse");
+    return __isa(o, "DescribeLabelingJobResponse");
   }
 }
 
@@ -5771,7 +5773,7 @@ export interface DescribeModelInput {
 
 export namespace DescribeModelInput {
   export function isa(o: any): o is DescribeModelInput {
-    return _smithy.isa(o, "DescribeModelInput");
+    return __isa(o, "DescribeModelInput");
   }
 }
 
@@ -5827,7 +5829,7 @@ export interface DescribeModelOutput extends $MetadataBearer {
 
 export namespace DescribeModelOutput {
   export function isa(o: any): o is DescribeModelOutput {
-    return _smithy.isa(o, "DescribeModelOutput");
+    return __isa(o, "DescribeModelOutput");
   }
 }
 
@@ -5841,7 +5843,7 @@ export interface DescribeModelPackageInput {
 
 export namespace DescribeModelPackageInput {
   export function isa(o: any): o is DescribeModelPackageInput {
-    return _smithy.isa(o, "DescribeModelPackageInput");
+    return __isa(o, "DescribeModelPackageInput");
   }
 }
 
@@ -5902,7 +5904,7 @@ export interface DescribeModelPackageOutput extends $MetadataBearer {
 
 export namespace DescribeModelPackageOutput {
   export function isa(o: any): o is DescribeModelPackageOutput {
-    return _smithy.isa(o, "DescribeModelPackageOutput");
+    return __isa(o, "DescribeModelPackageOutput");
   }
 }
 
@@ -5916,7 +5918,7 @@ export interface DescribeMonitoringScheduleRequest {
 
 export namespace DescribeMonitoringScheduleRequest {
   export function isa(o: any): o is DescribeMonitoringScheduleRequest {
-    return _smithy.isa(o, "DescribeMonitoringScheduleRequest");
+    return __isa(o, "DescribeMonitoringScheduleRequest");
   }
 }
 
@@ -5972,7 +5974,7 @@ export interface DescribeMonitoringScheduleResponse extends $MetadataBearer {
 
 export namespace DescribeMonitoringScheduleResponse {
   export function isa(o: any): o is DescribeMonitoringScheduleResponse {
-    return _smithy.isa(o, "DescribeMonitoringScheduleResponse");
+    return __isa(o, "DescribeMonitoringScheduleResponse");
   }
 }
 
@@ -5986,7 +5988,7 @@ export interface DescribeNotebookInstanceInput {
 
 export namespace DescribeNotebookInstanceInput {
   export function isa(o: any): o is DescribeNotebookInstanceInput {
-    return _smithy.isa(o, "DescribeNotebookInstanceInput");
+    return __isa(o, "DescribeNotebookInstanceInput");
   }
 }
 
@@ -6002,7 +6004,7 @@ export namespace DescribeNotebookInstanceLifecycleConfigInput {
   export function isa(
     o: any
   ): o is DescribeNotebookInstanceLifecycleConfigInput {
-    return _smithy.isa(o, "DescribeNotebookInstanceLifecycleConfigInput");
+    return __isa(o, "DescribeNotebookInstanceLifecycleConfigInput");
   }
 }
 
@@ -6045,7 +6047,7 @@ export namespace DescribeNotebookInstanceLifecycleConfigOutput {
   export function isa(
     o: any
   ): o is DescribeNotebookInstanceLifecycleConfigOutput {
-    return _smithy.isa(o, "DescribeNotebookInstanceLifecycleConfigOutput");
+    return __isa(o, "DescribeNotebookInstanceLifecycleConfigOutput");
   }
 }
 
@@ -6185,7 +6187,7 @@ export interface DescribeNotebookInstanceOutput extends $MetadataBearer {
 
 export namespace DescribeNotebookInstanceOutput {
   export function isa(o: any): o is DescribeNotebookInstanceOutput {
-    return _smithy.isa(o, "DescribeNotebookInstanceOutput");
+    return __isa(o, "DescribeNotebookInstanceOutput");
   }
 }
 
@@ -6200,7 +6202,7 @@ export interface DescribeProcessingJobRequest {
 
 export namespace DescribeProcessingJobRequest {
   export function isa(o: any): o is DescribeProcessingJobRequest {
-    return _smithy.isa(o, "DescribeProcessingJobRequest");
+    return __isa(o, "DescribeProcessingJobRequest");
   }
 }
 
@@ -6320,7 +6322,7 @@ export interface DescribeProcessingJobResponse extends $MetadataBearer {
 
 export namespace DescribeProcessingJobResponse {
   export function isa(o: any): o is DescribeProcessingJobResponse {
-    return _smithy.isa(o, "DescribeProcessingJobResponse");
+    return __isa(o, "DescribeProcessingJobResponse");
   }
 }
 
@@ -6334,7 +6336,7 @@ export interface DescribeSubscribedWorkteamRequest {
 
 export namespace DescribeSubscribedWorkteamRequest {
   export function isa(o: any): o is DescribeSubscribedWorkteamRequest {
-    return _smithy.isa(o, "DescribeSubscribedWorkteamRequest");
+    return __isa(o, "DescribeSubscribedWorkteamRequest");
   }
 }
 
@@ -6348,7 +6350,7 @@ export interface DescribeSubscribedWorkteamResponse extends $MetadataBearer {
 
 export namespace DescribeSubscribedWorkteamResponse {
   export function isa(o: any): o is DescribeSubscribedWorkteamResponse {
-    return _smithy.isa(o, "DescribeSubscribedWorkteamResponse");
+    return __isa(o, "DescribeSubscribedWorkteamResponse");
   }
 }
 
@@ -6362,7 +6364,7 @@ export interface DescribeTrainingJobRequest {
 
 export namespace DescribeTrainingJobRequest {
   export function isa(o: any): o is DescribeTrainingJobRequest {
-    return _smithy.isa(o, "DescribeTrainingJobRequest");
+    return __isa(o, "DescribeTrainingJobRequest");
   }
 }
 
@@ -6715,7 +6717,7 @@ export interface DescribeTrainingJobResponse extends $MetadataBearer {
 
 export namespace DescribeTrainingJobResponse {
   export function isa(o: any): o is DescribeTrainingJobResponse {
-    return _smithy.isa(o, "DescribeTrainingJobResponse");
+    return __isa(o, "DescribeTrainingJobResponse");
   }
 }
 
@@ -6729,7 +6731,7 @@ export interface DescribeTransformJobRequest {
 
 export namespace DescribeTransformJobRequest {
   export function isa(o: any): o is DescribeTransformJobRequest {
-    return _smithy.isa(o, "DescribeTransformJobRequest");
+    return __isa(o, "DescribeTransformJobRequest");
   }
 }
 
@@ -6877,7 +6879,7 @@ export interface DescribeTransformJobResponse extends $MetadataBearer {
 
 export namespace DescribeTransformJobResponse {
   export function isa(o: any): o is DescribeTransformJobResponse {
-    return _smithy.isa(o, "DescribeTransformJobResponse");
+    return __isa(o, "DescribeTransformJobResponse");
   }
 }
 
@@ -6891,7 +6893,7 @@ export interface DescribeTrialComponentRequest {
 
 export namespace DescribeTrialComponentRequest {
   export function isa(o: any): o is DescribeTrialComponentRequest {
-    return _smithy.isa(o, "DescribeTrialComponentRequest");
+    return __isa(o, "DescribeTrialComponentRequest");
   }
 }
 
@@ -6988,7 +6990,7 @@ export interface DescribeTrialComponentResponse extends $MetadataBearer {
 
 export namespace DescribeTrialComponentResponse {
   export function isa(o: any): o is DescribeTrialComponentResponse {
-    return _smithy.isa(o, "DescribeTrialComponentResponse");
+    return __isa(o, "DescribeTrialComponentResponse");
   }
 }
 
@@ -7002,7 +7004,7 @@ export interface DescribeTrialRequest {
 
 export namespace DescribeTrialRequest {
   export function isa(o: any): o is DescribeTrialRequest {
-    return _smithy.isa(o, "DescribeTrialRequest");
+    return __isa(o, "DescribeTrialRequest");
   }
 }
 
@@ -7058,7 +7060,7 @@ export interface DescribeTrialResponse extends $MetadataBearer {
 
 export namespace DescribeTrialResponse {
   export function isa(o: any): o is DescribeTrialResponse {
-    return _smithy.isa(o, "DescribeTrialResponse");
+    return __isa(o, "DescribeTrialResponse");
   }
 }
 
@@ -7077,7 +7079,7 @@ export interface DescribeUserProfileRequest {
 
 export namespace DescribeUserProfileRequest {
   export function isa(o: any): o is DescribeUserProfileRequest {
-    return _smithy.isa(o, "DescribeUserProfileRequest");
+    return __isa(o, "DescribeUserProfileRequest");
   }
 }
 
@@ -7141,7 +7143,7 @@ export interface DescribeUserProfileResponse extends $MetadataBearer {
 
 export namespace DescribeUserProfileResponse {
   export function isa(o: any): o is DescribeUserProfileResponse {
-    return _smithy.isa(o, "DescribeUserProfileResponse");
+    return __isa(o, "DescribeUserProfileResponse");
   }
 }
 
@@ -7157,7 +7159,7 @@ export interface DescribeWorkforceRequest {
 
 export namespace DescribeWorkforceRequest {
   export function isa(o: any): o is DescribeWorkforceRequest {
-    return _smithy.isa(o, "DescribeWorkforceRequest");
+    return __isa(o, "DescribeWorkforceRequest");
   }
 }
 
@@ -7174,7 +7176,7 @@ export interface DescribeWorkforceResponse extends $MetadataBearer {
 
 export namespace DescribeWorkforceResponse {
   export function isa(o: any): o is DescribeWorkforceResponse {
-    return _smithy.isa(o, "DescribeWorkforceResponse");
+    return __isa(o, "DescribeWorkforceResponse");
   }
 }
 
@@ -7188,7 +7190,7 @@ export interface DescribeWorkteamRequest {
 
 export namespace DescribeWorkteamRequest {
   export function isa(o: any): o is DescribeWorkteamRequest {
-    return _smithy.isa(o, "DescribeWorkteamRequest");
+    return __isa(o, "DescribeWorkteamRequest");
   }
 }
 
@@ -7203,7 +7205,7 @@ export interface DescribeWorkteamResponse extends $MetadataBearer {
 
 export namespace DescribeWorkteamResponse {
   export function isa(o: any): o is DescribeWorkteamResponse {
-    return _smithy.isa(o, "DescribeWorkteamResponse");
+    return __isa(o, "DescribeWorkteamResponse");
   }
 }
 
@@ -7232,7 +7234,7 @@ export interface DesiredWeightAndCapacity {
 
 export namespace DesiredWeightAndCapacity {
   export function isa(o: any): o is DesiredWeightAndCapacity {
-    return _smithy.isa(o, "DesiredWeightAndCapacity");
+    return __isa(o, "DesiredWeightAndCapacity");
   }
 }
 
@@ -7270,7 +7272,7 @@ export interface DisassociateTrialComponentRequest {
 
 export namespace DisassociateTrialComponentRequest {
   export function isa(o: any): o is DisassociateTrialComponentRequest {
-    return _smithy.isa(o, "DisassociateTrialComponentRequest");
+    return __isa(o, "DisassociateTrialComponentRequest");
   }
 }
 
@@ -7289,7 +7291,7 @@ export interface DisassociateTrialComponentResponse extends $MetadataBearer {
 
 export namespace DisassociateTrialComponentResponse {
   export function isa(o: any): o is DisassociateTrialComponentResponse {
-    return _smithy.isa(o, "DisassociateTrialComponentResponse");
+    return __isa(o, "DisassociateTrialComponentResponse");
   }
 }
 
@@ -7336,7 +7338,7 @@ export interface DomainDetails {
 
 export namespace DomainDetails {
   export function isa(o: any): o is DomainDetails {
-    return _smithy.isa(o, "DomainDetails");
+    return __isa(o, "DomainDetails");
   }
 }
 
@@ -7375,7 +7377,7 @@ export interface EndpointConfigSummary {
 
 export namespace EndpointConfigSummary {
   export function isa(o: any): o is EndpointConfigSummary {
-    return _smithy.isa(o, "EndpointConfigSummary");
+    return __isa(o, "EndpointConfigSummary");
   }
 }
 
@@ -7413,7 +7415,7 @@ export interface EndpointInput {
 
 export namespace EndpointInput {
   export function isa(o: any): o is EndpointInput {
-    return _smithy.isa(o, "EndpointInput");
+    return __isa(o, "EndpointInput");
   }
 }
 
@@ -7516,7 +7518,7 @@ export interface EndpointSummary {
 
 export namespace EndpointSummary {
   export function isa(o: any): o is EndpointSummary {
-    return _smithy.isa(o, "EndpointSummary");
+    return __isa(o, "EndpointSummary");
   }
 }
 
@@ -7593,7 +7595,7 @@ export interface Experiment {
 
 export namespace Experiment {
   export function isa(o: any): o is Experiment {
-    return _smithy.isa(o, "Experiment");
+    return __isa(o, "Experiment");
   }
 }
 
@@ -7620,7 +7622,7 @@ export interface ExperimentConfig {
 
 export namespace ExperimentConfig {
   export function isa(o: any): o is ExperimentConfig {
-    return _smithy.isa(o, "ExperimentConfig");
+    return __isa(o, "ExperimentConfig");
   }
 }
 
@@ -7642,7 +7644,7 @@ export interface ExperimentSource {
 
 export namespace ExperimentSource {
   export function isa(o: any): o is ExperimentSource {
-    return _smithy.isa(o, "ExperimentSource");
+    return __isa(o, "ExperimentSource");
   }
 }
 
@@ -7687,7 +7689,7 @@ export interface ExperimentSummary {
 
 export namespace ExperimentSummary {
   export function isa(o: any): o is ExperimentSummary {
-    return _smithy.isa(o, "ExperimentSummary");
+    return __isa(o, "ExperimentSummary");
   }
 }
 
@@ -7726,7 +7728,7 @@ export interface FileSystemDataSource {
 
 export namespace FileSystemDataSource {
   export function isa(o: any): o is FileSystemDataSource {
-    return _smithy.isa(o, "FileSystemDataSource");
+    return __isa(o, "FileSystemDataSource");
   }
 }
 
@@ -7872,7 +7874,7 @@ export interface Filter {
 
 export namespace Filter {
   export function isa(o: any): o is Filter {
-    return _smithy.isa(o, "Filter");
+    return __isa(o, "Filter");
   }
 }
 
@@ -7899,7 +7901,7 @@ export interface FinalAutoMLJobObjectiveMetric {
 
 export namespace FinalAutoMLJobObjectiveMetric {
   export function isa(o: any): o is FinalAutoMLJobObjectiveMetric {
-    return _smithy.isa(o, "FinalAutoMLJobObjectiveMetric");
+    return __isa(o, "FinalAutoMLJobObjectiveMetric");
   }
 }
 
@@ -7937,7 +7939,7 @@ export namespace FinalHyperParameterTuningJobObjectiveMetric {
   export function isa(
     o: any
   ): o is FinalHyperParameterTuningJobObjectiveMetric {
-    return _smithy.isa(o, "FinalHyperParameterTuningJobObjectiveMetric");
+    return __isa(o, "FinalHyperParameterTuningJobObjectiveMetric");
   }
 }
 
@@ -7959,7 +7961,7 @@ export interface FlowDefinitionOutputConfig {
 
 export namespace FlowDefinitionOutputConfig {
   export function isa(o: any): o is FlowDefinitionOutputConfig {
-    return _smithy.isa(o, "FlowDefinitionOutputConfig");
+    return __isa(o, "FlowDefinitionOutputConfig");
   }
 }
 
@@ -8004,7 +8006,7 @@ export interface FlowDefinitionSummary {
 
 export namespace FlowDefinitionSummary {
   export function isa(o: any): o is FlowDefinitionSummary {
-    return _smithy.isa(o, "FlowDefinitionSummary");
+    return __isa(o, "FlowDefinitionSummary");
   }
 }
 
@@ -8032,7 +8034,7 @@ export interface GetSearchSuggestionsRequest {
 
 export namespace GetSearchSuggestionsRequest {
   export function isa(o: any): o is GetSearchSuggestionsRequest {
-    return _smithy.isa(o, "GetSearchSuggestionsRequest");
+    return __isa(o, "GetSearchSuggestionsRequest");
   }
 }
 
@@ -8047,7 +8049,7 @@ export interface GetSearchSuggestionsResponse extends $MetadataBearer {
 
 export namespace GetSearchSuggestionsResponse {
   export function isa(o: any): o is GetSearchSuggestionsResponse {
-    return _smithy.isa(o, "GetSearchSuggestionsResponse");
+    return __isa(o, "GetSearchSuggestionsResponse");
   }
 }
 
@@ -8080,7 +8082,7 @@ export interface GitConfig {
 
 export namespace GitConfig {
   export function isa(o: any): o is GitConfig {
-    return _smithy.isa(o, "GitConfig");
+    return __isa(o, "GitConfig");
   }
 }
 
@@ -8104,7 +8106,7 @@ export interface GitConfigForUpdate {
 
 export namespace GitConfigForUpdate {
   export function isa(o: any): o is GitConfigForUpdate {
-    return _smithy.isa(o, "GitConfigForUpdate");
+    return __isa(o, "GitConfigForUpdate");
   }
 }
 
@@ -8116,12 +8118,12 @@ export interface HumanLoopActivationConditionsConfig {
   /**
    * <p>JSON expressing use-case specific conditions declaratively. If any condition is matched, atomic tasks are created against the configured work team. The set of conditions is different for Rekognition and Textract.</p>
    */
-  HumanLoopActivationConditions: string | undefined;
+  HumanLoopActivationConditions: __LazyJsonString | string | undefined;
 }
 
 export namespace HumanLoopActivationConditionsConfig {
   export function isa(o: any): o is HumanLoopActivationConditionsConfig {
-    return _smithy.isa(o, "HumanLoopActivationConditionsConfig");
+    return __isa(o, "HumanLoopActivationConditionsConfig");
   }
 }
 
@@ -8145,7 +8147,7 @@ export interface HumanLoopActivationConfig {
 
 export namespace HumanLoopActivationConfig {
   export function isa(o: any): o is HumanLoopActivationConfig {
-    return _smithy.isa(o, "HumanLoopActivationConfig");
+    return __isa(o, "HumanLoopActivationConfig");
   }
 }
 
@@ -8503,7 +8505,7 @@ export interface HumanLoopConfig {
 
 export namespace HumanLoopConfig {
   export function isa(o: any): o is HumanLoopConfig {
-    return _smithy.isa(o, "HumanLoopConfig");
+    return __isa(o, "HumanLoopConfig");
   }
 }
 
@@ -8523,7 +8525,7 @@ export interface HumanLoopRequestSource {
 
 export namespace HumanLoopRequestSource {
   export function isa(o: any): o is HumanLoopRequestSource {
-    return _smithy.isa(o, "HumanLoopRequestSource");
+    return __isa(o, "HumanLoopRequestSource");
   }
 }
 
@@ -9206,7 +9208,7 @@ export interface HumanTaskConfig {
 
 export namespace HumanTaskConfig {
   export function isa(o: any): o is HumanTaskConfig {
-    return _smithy.isa(o, "HumanTaskConfig");
+    return __isa(o, "HumanTaskConfig");
   }
 }
 
@@ -9233,7 +9235,7 @@ export interface HumanTaskUiSummary {
 
 export namespace HumanTaskUiSummary {
   export function isa(o: any): o is HumanTaskUiSummary {
-    return _smithy.isa(o, "HumanTaskUiSummary");
+    return __isa(o, "HumanTaskUiSummary");
   }
 }
 
@@ -9292,7 +9294,7 @@ export interface HyperParameterAlgorithmSpecification {
 
 export namespace HyperParameterAlgorithmSpecification {
   export function isa(o: any): o is HyperParameterAlgorithmSpecification {
-    return _smithy.isa(o, "HyperParameterAlgorithmSpecification");
+    return __isa(o, "HyperParameterAlgorithmSpecification");
   }
 }
 
@@ -9349,7 +9351,7 @@ export interface HyperParameterSpecification {
 
 export namespace HyperParameterSpecification {
   export function isa(o: any): o is HyperParameterSpecification {
-    return _smithy.isa(o, "HyperParameterSpecification");
+    return __isa(o, "HyperParameterSpecification");
   }
 }
 
@@ -9495,7 +9497,7 @@ export interface HyperParameterTrainingJobDefinition {
 
 export namespace HyperParameterTrainingJobDefinition {
   export function isa(o: any): o is HyperParameterTrainingJobDefinition {
-    return _smithy.isa(o, "HyperParameterTrainingJobDefinition");
+    return __isa(o, "HyperParameterTrainingJobDefinition");
   }
 }
 
@@ -9609,7 +9611,7 @@ export interface HyperParameterTrainingJobSummary {
 
 export namespace HyperParameterTrainingJobSummary {
   export function isa(o: any): o is HyperParameterTrainingJobSummary {
-    return _smithy.isa(o, "HyperParameterTrainingJobSummary");
+    return __isa(o, "HyperParameterTrainingJobSummary");
   }
 }
 
@@ -9677,7 +9679,7 @@ export interface HyperParameterTuningJobConfig {
 
 export namespace HyperParameterTuningJobConfig {
   export function isa(o: any): o is HyperParameterTuningJobConfig {
-    return _smithy.isa(o, "HyperParameterTuningJobConfig");
+    return __isa(o, "HyperParameterTuningJobConfig");
   }
 }
 
@@ -9707,7 +9709,7 @@ export interface HyperParameterTuningJobObjective {
 
 export namespace HyperParameterTuningJobObjective {
   export function isa(o: any): o is HyperParameterTuningJobObjective {
-    return _smithy.isa(o, "HyperParameterTuningJobObjective");
+    return __isa(o, "HyperParameterTuningJobObjective");
   }
 }
 
@@ -9809,7 +9811,7 @@ export interface HyperParameterTuningJobSummary {
 
 export namespace HyperParameterTuningJobSummary {
   export function isa(o: any): o is HyperParameterTuningJobSummary {
-    return _smithy.isa(o, "HyperParameterTuningJobSummary");
+    return __isa(o, "HyperParameterTuningJobSummary");
   }
 }
 
@@ -9879,7 +9881,7 @@ export interface HyperParameterTuningJobWarmStartConfig {
 
 export namespace HyperParameterTuningJobWarmStartConfig {
   export function isa(o: any): o is HyperParameterTuningJobWarmStartConfig {
-    return _smithy.isa(o, "HyperParameterTuningJobWarmStartConfig");
+    return __isa(o, "HyperParameterTuningJobWarmStartConfig");
   }
 }
 
@@ -9926,7 +9928,7 @@ export interface InferenceSpecification {
 
 export namespace InferenceSpecification {
   export function isa(o: any): o is InferenceSpecification {
-    return _smithy.isa(o, "InferenceSpecification");
+    return __isa(o, "InferenceSpecification");
   }
 }
 
@@ -10133,7 +10135,7 @@ export interface InputConfig {
 
 export namespace InputConfig {
   export function isa(o: any): o is InputConfig {
-    return _smithy.isa(o, "InputConfig");
+    return __isa(o, "InputConfig");
   }
 }
 
@@ -10232,7 +10234,7 @@ export interface IntegerParameterRange {
 
 export namespace IntegerParameterRange {
   export function isa(o: any): o is IntegerParameterRange {
-    return _smithy.isa(o, "IntegerParameterRange");
+    return __isa(o, "IntegerParameterRange");
   }
 }
 
@@ -10254,7 +10256,7 @@ export interface IntegerParameterRangeSpecification {
 
 export namespace IntegerParameterRangeSpecification {
   export function isa(o: any): o is IntegerParameterRangeSpecification {
-    return _smithy.isa(o, "IntegerParameterRangeSpecification");
+    return __isa(o, "IntegerParameterRangeSpecification");
   }
 }
 
@@ -10276,7 +10278,7 @@ export interface JupyterServerAppSettings {
 
 export namespace JupyterServerAppSettings {
   export function isa(o: any): o is JupyterServerAppSettings {
-    return _smithy.isa(o, "JupyterServerAppSettings");
+    return __isa(o, "JupyterServerAppSettings");
   }
 }
 
@@ -10293,7 +10295,7 @@ export interface KernelGatewayAppSettings {
 
 export namespace KernelGatewayAppSettings {
   export function isa(o: any): o is KernelGatewayAppSettings {
-    return _smithy.isa(o, "KernelGatewayAppSettings");
+    return __isa(o, "KernelGatewayAppSettings");
   }
 }
 
@@ -10330,7 +10332,7 @@ export interface LabelCounters {
 
 export namespace LabelCounters {
   export function isa(o: any): o is LabelCounters {
-    return _smithy.isa(o, "LabelCounters");
+    return __isa(o, "LabelCounters");
   }
 }
 
@@ -10357,7 +10359,7 @@ export interface LabelCountersForWorkteam {
 
 export namespace LabelCountersForWorkteam {
   export function isa(o: any): o is LabelCountersForWorkteam {
-    return _smithy.isa(o, "LabelCountersForWorkteam");
+    return __isa(o, "LabelCountersForWorkteam");
   }
 }
 
@@ -10423,7 +10425,7 @@ export interface LabelingJobAlgorithmsConfig {
 
 export namespace LabelingJobAlgorithmsConfig {
   export function isa(o: any): o is LabelingJobAlgorithmsConfig {
-    return _smithy.isa(o, "LabelingJobAlgorithmsConfig");
+    return __isa(o, "LabelingJobAlgorithmsConfig");
   }
 }
 
@@ -10443,7 +10445,7 @@ export interface LabelingJobDataAttributes {
 
 export namespace LabelingJobDataAttributes {
   export function isa(o: any): o is LabelingJobDataAttributes {
-    return _smithy.isa(o, "LabelingJobDataAttributes");
+    return __isa(o, "LabelingJobDataAttributes");
   }
 }
 
@@ -10460,7 +10462,7 @@ export interface LabelingJobDataSource {
 
 export namespace LabelingJobDataSource {
   export function isa(o: any): o is LabelingJobDataSource {
-    return _smithy.isa(o, "LabelingJobDataSource");
+    return __isa(o, "LabelingJobDataSource");
   }
 }
 
@@ -10503,7 +10505,7 @@ export interface LabelingJobForWorkteamSummary {
 
 export namespace LabelingJobForWorkteamSummary {
   export function isa(o: any): o is LabelingJobForWorkteamSummary {
-    return _smithy.isa(o, "LabelingJobForWorkteamSummary");
+    return __isa(o, "LabelingJobForWorkteamSummary");
   }
 }
 
@@ -10525,7 +10527,7 @@ export interface LabelingJobInputConfig {
 
 export namespace LabelingJobInputConfig {
   export function isa(o: any): o is LabelingJobInputConfig {
-    return _smithy.isa(o, "LabelingJobInputConfig");
+    return __isa(o, "LabelingJobInputConfig");
   }
 }
 
@@ -10548,7 +10550,7 @@ export interface LabelingJobOutput {
 
 export namespace LabelingJobOutput {
   export function isa(o: any): o is LabelingJobOutput {
-    return _smithy.isa(o, "LabelingJobOutput");
+    return __isa(o, "LabelingJobOutput");
   }
 }
 
@@ -10584,7 +10586,7 @@ export interface LabelingJobOutputConfig {
 
 export namespace LabelingJobOutputConfig {
   export function isa(o: any): o is LabelingJobOutputConfig {
-    return _smithy.isa(o, "LabelingJobOutputConfig");
+    return __isa(o, "LabelingJobOutputConfig");
   }
 }
 
@@ -10617,7 +10619,7 @@ export interface LabelingJobResourceConfig {
 
 export namespace LabelingJobResourceConfig {
   export function isa(o: any): o is LabelingJobResourceConfig {
-    return _smithy.isa(o, "LabelingJobResourceConfig");
+    return __isa(o, "LabelingJobResourceConfig");
   }
 }
 
@@ -10634,7 +10636,7 @@ export interface LabelingJobS3DataSource {
 
 export namespace LabelingJobS3DataSource {
   export function isa(o: any): o is LabelingJobS3DataSource {
-    return _smithy.isa(o, "LabelingJobS3DataSource");
+    return __isa(o, "LabelingJobS3DataSource");
   }
 }
 
@@ -10669,7 +10671,7 @@ export interface LabelingJobStoppingConditions {
 
 export namespace LabelingJobStoppingConditions {
   export function isa(o: any): o is LabelingJobStoppingConditions {
-    return _smithy.isa(o, "LabelingJobStoppingConditions");
+    return __isa(o, "LabelingJobStoppingConditions");
   }
 }
 
@@ -10747,7 +10749,7 @@ export interface LabelingJobSummary {
 
 export namespace LabelingJobSummary {
   export function isa(o: any): o is LabelingJobSummary {
-    return _smithy.isa(o, "LabelingJobSummary");
+    return __isa(o, "LabelingJobSummary");
   }
 }
 
@@ -10797,7 +10799,7 @@ export interface ListAlgorithmsInput {
 
 export namespace ListAlgorithmsInput {
   export function isa(o: any): o is ListAlgorithmsInput {
-    return _smithy.isa(o, "ListAlgorithmsInput");
+    return __isa(o, "ListAlgorithmsInput");
   }
 }
 
@@ -10818,7 +10820,7 @@ export interface ListAlgorithmsOutput extends $MetadataBearer {
 
 export namespace ListAlgorithmsOutput {
   export function isa(o: any): o is ListAlgorithmsOutput {
-    return _smithy.isa(o, "ListAlgorithmsOutput");
+    return __isa(o, "ListAlgorithmsOutput");
   }
 }
 
@@ -10858,7 +10860,7 @@ export interface ListAppsRequest {
 
 export namespace ListAppsRequest {
   export function isa(o: any): o is ListAppsRequest {
-    return _smithy.isa(o, "ListAppsRequest");
+    return __isa(o, "ListAppsRequest");
   }
 }
 
@@ -10878,7 +10880,7 @@ export interface ListAppsResponse extends $MetadataBearer {
 
 export namespace ListAppsResponse {
   export function isa(o: any): o is ListAppsResponse {
-    return _smithy.isa(o, "ListAppsResponse");
+    return __isa(o, "ListAppsResponse");
   }
 }
 
@@ -10938,7 +10940,7 @@ export interface ListAutoMLJobsRequest {
 
 export namespace ListAutoMLJobsRequest {
   export function isa(o: any): o is ListAutoMLJobsRequest {
-    return _smithy.isa(o, "ListAutoMLJobsRequest");
+    return __isa(o, "ListAutoMLJobsRequest");
   }
 }
 
@@ -10958,7 +10960,7 @@ export interface ListAutoMLJobsResponse extends $MetadataBearer {
 
 export namespace ListAutoMLJobsResponse {
   export function isa(o: any): o is ListAutoMLJobsResponse {
-    return _smithy.isa(o, "ListAutoMLJobsResponse");
+    return __isa(o, "ListAutoMLJobsResponse");
   }
 }
 
@@ -11003,7 +11005,7 @@ export interface ListCandidatesForAutoMLJobRequest {
 
 export namespace ListCandidatesForAutoMLJobRequest {
   export function isa(o: any): o is ListCandidatesForAutoMLJobRequest {
-    return _smithy.isa(o, "ListCandidatesForAutoMLJobRequest");
+    return __isa(o, "ListCandidatesForAutoMLJobRequest");
   }
 }
 
@@ -11023,7 +11025,7 @@ export interface ListCandidatesForAutoMLJobResponse extends $MetadataBearer {
 
 export namespace ListCandidatesForAutoMLJobResponse {
   export function isa(o: any): o is ListCandidatesForAutoMLJobResponse {
-    return _smithy.isa(o, "ListCandidatesForAutoMLJobResponse");
+    return __isa(o, "ListCandidatesForAutoMLJobResponse");
   }
 }
 
@@ -11084,7 +11086,7 @@ export interface ListCodeRepositoriesInput {
 
 export namespace ListCodeRepositoriesInput {
   export function isa(o: any): o is ListCodeRepositoriesInput {
-    return _smithy.isa(o, "ListCodeRepositoriesInput");
+    return __isa(o, "ListCodeRepositoriesInput");
   }
 }
 
@@ -11125,7 +11127,7 @@ export interface ListCodeRepositoriesOutput extends $MetadataBearer {
 
 export namespace ListCodeRepositoriesOutput {
   export function isa(o: any): o is ListCodeRepositoriesOutput {
-    return _smithy.isa(o, "ListCodeRepositoriesOutput");
+    return __isa(o, "ListCodeRepositoriesOutput");
   }
 }
 
@@ -11191,7 +11193,7 @@ export interface ListCompilationJobsRequest {
 
 export namespace ListCompilationJobsRequest {
   export function isa(o: any): o is ListCompilationJobsRequest {
-    return _smithy.isa(o, "ListCompilationJobsRequest");
+    return __isa(o, "ListCompilationJobsRequest");
   }
 }
 
@@ -11212,7 +11214,7 @@ export interface ListCompilationJobsResponse extends $MetadataBearer {
 
 export namespace ListCompilationJobsResponse {
   export function isa(o: any): o is ListCompilationJobsResponse {
-    return _smithy.isa(o, "ListCompilationJobsResponse");
+    return __isa(o, "ListCompilationJobsResponse");
   }
 }
 
@@ -11238,7 +11240,7 @@ export interface ListDomainsRequest {
 
 export namespace ListDomainsRequest {
   export function isa(o: any): o is ListDomainsRequest {
-    return _smithy.isa(o, "ListDomainsRequest");
+    return __isa(o, "ListDomainsRequest");
   }
 }
 
@@ -11258,7 +11260,7 @@ export interface ListDomainsResponse extends $MetadataBearer {
 
 export namespace ListDomainsResponse {
   export function isa(o: any): o is ListDomainsResponse {
-    return _smithy.isa(o, "ListDomainsResponse");
+    return __isa(o, "ListDomainsResponse");
   }
 }
 
@@ -11307,7 +11309,7 @@ export interface ListEndpointConfigsInput {
 
 export namespace ListEndpointConfigsInput {
   export function isa(o: any): o is ListEndpointConfigsInput {
-    return _smithy.isa(o, "ListEndpointConfigsInput");
+    return __isa(o, "ListEndpointConfigsInput");
   }
 }
 
@@ -11327,7 +11329,7 @@ export interface ListEndpointConfigsOutput extends $MetadataBearer {
 
 export namespace ListEndpointConfigsOutput {
   export function isa(o: any): o is ListEndpointConfigsOutput {
-    return _smithy.isa(o, "ListEndpointConfigsOutput");
+    return __isa(o, "ListEndpointConfigsOutput");
   }
 }
 
@@ -11393,7 +11395,7 @@ export interface ListEndpointsInput {
 
 export namespace ListEndpointsInput {
   export function isa(o: any): o is ListEndpointsInput {
-    return _smithy.isa(o, "ListEndpointsInput");
+    return __isa(o, "ListEndpointsInput");
   }
 }
 
@@ -11413,7 +11415,7 @@ export interface ListEndpointsOutput extends $MetadataBearer {
 
 export namespace ListEndpointsOutput {
   export function isa(o: any): o is ListEndpointsOutput {
-    return _smithy.isa(o, "ListEndpointsOutput");
+    return __isa(o, "ListEndpointsOutput");
   }
 }
 
@@ -11453,7 +11455,7 @@ export interface ListExperimentsRequest {
 
 export namespace ListExperimentsRequest {
   export function isa(o: any): o is ListExperimentsRequest {
-    return _smithy.isa(o, "ListExperimentsRequest");
+    return __isa(o, "ListExperimentsRequest");
   }
 }
 
@@ -11472,7 +11474,7 @@ export interface ListExperimentsResponse extends $MetadataBearer {
 
 export namespace ListExperimentsResponse {
   export function isa(o: any): o is ListExperimentsResponse {
-    return _smithy.isa(o, "ListExperimentsResponse");
+    return __isa(o, "ListExperimentsResponse");
   }
 }
 
@@ -11506,7 +11508,7 @@ export interface ListFlowDefinitionsRequest {
 
 export namespace ListFlowDefinitionsRequest {
   export function isa(o: any): o is ListFlowDefinitionsRequest {
-    return _smithy.isa(o, "ListFlowDefinitionsRequest");
+    return __isa(o, "ListFlowDefinitionsRequest");
   }
 }
 
@@ -11525,7 +11527,7 @@ export interface ListFlowDefinitionsResponse extends $MetadataBearer {
 
 export namespace ListFlowDefinitionsResponse {
   export function isa(o: any): o is ListFlowDefinitionsResponse {
-    return _smithy.isa(o, "ListFlowDefinitionsResponse");
+    return __isa(o, "ListFlowDefinitionsResponse");
   }
 }
 
@@ -11559,7 +11561,7 @@ export interface ListHumanTaskUisRequest {
 
 export namespace ListHumanTaskUisRequest {
   export function isa(o: any): o is ListHumanTaskUisRequest {
-    return _smithy.isa(o, "ListHumanTaskUisRequest");
+    return __isa(o, "ListHumanTaskUisRequest");
   }
 }
 
@@ -11578,7 +11580,7 @@ export interface ListHumanTaskUisResponse extends $MetadataBearer {
 
 export namespace ListHumanTaskUisResponse {
   export function isa(o: any): o is ListHumanTaskUisResponse {
-    return _smithy.isa(o, "ListHumanTaskUisResponse");
+    return __isa(o, "ListHumanTaskUisResponse");
   }
 }
 
@@ -11654,7 +11656,7 @@ export interface ListHyperParameterTuningJobsRequest {
 
 export namespace ListHyperParameterTuningJobsRequest {
   export function isa(o: any): o is ListHyperParameterTuningJobsRequest {
-    return _smithy.isa(o, "ListHyperParameterTuningJobsRequest");
+    return __isa(o, "ListHyperParameterTuningJobsRequest");
   }
 }
 
@@ -11680,7 +11682,7 @@ export interface ListHyperParameterTuningJobsResponse extends $MetadataBearer {
 
 export namespace ListHyperParameterTuningJobsResponse {
   export function isa(o: any): o is ListHyperParameterTuningJobsResponse {
-    return _smithy.isa(o, "ListHyperParameterTuningJobsResponse");
+    return __isa(o, "ListHyperParameterTuningJobsResponse");
   }
 }
 
@@ -11735,7 +11737,7 @@ export interface ListLabelingJobsForWorkteamRequest {
 
 export namespace ListLabelingJobsForWorkteamRequest {
   export function isa(o: any): o is ListLabelingJobsForWorkteamRequest {
-    return _smithy.isa(o, "ListLabelingJobsForWorkteamRequest");
+    return __isa(o, "ListLabelingJobsForWorkteamRequest");
   }
 }
 
@@ -11756,7 +11758,7 @@ export interface ListLabelingJobsForWorkteamResponse extends $MetadataBearer {
 
 export namespace ListLabelingJobsForWorkteamResponse {
   export function isa(o: any): o is ListLabelingJobsForWorkteamResponse {
-    return _smithy.isa(o, "ListLabelingJobsForWorkteamResponse");
+    return __isa(o, "ListLabelingJobsForWorkteamResponse");
   }
 }
 
@@ -11826,7 +11828,7 @@ export interface ListLabelingJobsRequest {
 
 export namespace ListLabelingJobsRequest {
   export function isa(o: any): o is ListLabelingJobsRequest {
-    return _smithy.isa(o, "ListLabelingJobsRequest");
+    return __isa(o, "ListLabelingJobsRequest");
   }
 }
 
@@ -11847,7 +11849,7 @@ export interface ListLabelingJobsResponse extends $MetadataBearer {
 
 export namespace ListLabelingJobsResponse {
   export function isa(o: any): o is ListLabelingJobsResponse {
-    return _smithy.isa(o, "ListLabelingJobsResponse");
+    return __isa(o, "ListLabelingJobsResponse");
   }
 }
 
@@ -11897,7 +11899,7 @@ export interface ListModelPackagesInput {
 
 export namespace ListModelPackagesInput {
   export function isa(o: any): o is ListModelPackagesInput {
-    return _smithy.isa(o, "ListModelPackagesInput");
+    return __isa(o, "ListModelPackagesInput");
   }
 }
 
@@ -11918,7 +11920,7 @@ export interface ListModelPackagesOutput extends $MetadataBearer {
 
 export namespace ListModelPackagesOutput {
   export function isa(o: any): o is ListModelPackagesOutput {
-    return _smithy.isa(o, "ListModelPackagesOutput");
+    return __isa(o, "ListModelPackagesOutput");
   }
 }
 
@@ -11967,7 +11969,7 @@ export interface ListModelsInput {
 
 export namespace ListModelsInput {
   export function isa(o: any): o is ListModelsInput {
-    return _smithy.isa(o, "ListModelsInput");
+    return __isa(o, "ListModelsInput");
   }
 }
 
@@ -11988,7 +11990,7 @@ export interface ListModelsOutput extends $MetadataBearer {
 
 export namespace ListModelsOutput {
   export function isa(o: any): o is ListModelsOutput {
-    return _smithy.isa(o, "ListModelsOutput");
+    return __isa(o, "ListModelsOutput");
   }
 }
 
@@ -12065,7 +12067,7 @@ export interface ListMonitoringExecutionsRequest {
 
 export namespace ListMonitoringExecutionsRequest {
   export function isa(o: any): o is ListMonitoringExecutionsRequest {
-    return _smithy.isa(o, "ListMonitoringExecutionsRequest");
+    return __isa(o, "ListMonitoringExecutionsRequest");
   }
 }
 
@@ -12085,7 +12087,7 @@ export interface ListMonitoringExecutionsResponse extends $MetadataBearer {
 
 export namespace ListMonitoringExecutionsResponse {
   export function isa(o: any): o is ListMonitoringExecutionsResponse {
-    return _smithy.isa(o, "ListMonitoringExecutionsResponse");
+    return __isa(o, "ListMonitoringExecutionsResponse");
   }
 }
 
@@ -12152,7 +12154,7 @@ export interface ListMonitoringSchedulesRequest {
 
 export namespace ListMonitoringSchedulesRequest {
   export function isa(o: any): o is ListMonitoringSchedulesRequest {
-    return _smithy.isa(o, "ListMonitoringSchedulesRequest");
+    return __isa(o, "ListMonitoringSchedulesRequest");
   }
 }
 
@@ -12172,7 +12174,7 @@ export interface ListMonitoringSchedulesResponse extends $MetadataBearer {
 
 export namespace ListMonitoringSchedulesResponse {
   export function isa(o: any): o is ListMonitoringSchedulesResponse {
-    return _smithy.isa(o, "ListMonitoringSchedulesResponse");
+    return __isa(o, "ListMonitoringSchedulesResponse");
   }
 }
 
@@ -12233,7 +12235,7 @@ export interface ListNotebookInstanceLifecycleConfigsInput {
 
 export namespace ListNotebookInstanceLifecycleConfigsInput {
   export function isa(o: any): o is ListNotebookInstanceLifecycleConfigsInput {
-    return _smithy.isa(o, "ListNotebookInstanceLifecycleConfigsInput");
+    return __isa(o, "ListNotebookInstanceLifecycleConfigsInput");
   }
 }
 
@@ -12257,7 +12259,7 @@ export interface ListNotebookInstanceLifecycleConfigsOutput
 
 export namespace ListNotebookInstanceLifecycleConfigsOutput {
   export function isa(o: any): o is ListNotebookInstanceLifecycleConfigsOutput {
-    return _smithy.isa(o, "ListNotebookInstanceLifecycleConfigsOutput");
+    return __isa(o, "ListNotebookInstanceLifecycleConfigsOutput");
   }
 }
 
@@ -12349,7 +12351,7 @@ export interface ListNotebookInstancesInput {
 
 export namespace ListNotebookInstancesInput {
   export function isa(o: any): o is ListNotebookInstancesInput {
-    return _smithy.isa(o, "ListNotebookInstancesInput");
+    return __isa(o, "ListNotebookInstancesInput");
   }
 }
 
@@ -12371,7 +12373,7 @@ export interface ListNotebookInstancesOutput extends $MetadataBearer {
 
 export namespace ListNotebookInstancesOutput {
   export function isa(o: any): o is ListNotebookInstancesOutput {
-    return _smithy.isa(o, "ListNotebookInstancesOutput");
+    return __isa(o, "ListNotebookInstancesOutput");
   }
 }
 
@@ -12433,7 +12435,7 @@ export interface ListProcessingJobsRequest {
 
 export namespace ListProcessingJobsRequest {
   export function isa(o: any): o is ListProcessingJobsRequest {
-    return _smithy.isa(o, "ListProcessingJobsRequest");
+    return __isa(o, "ListProcessingJobsRequest");
   }
 }
 
@@ -12454,7 +12456,7 @@ export interface ListProcessingJobsResponse extends $MetadataBearer {
 
 export namespace ListProcessingJobsResponse {
   export function isa(o: any): o is ListProcessingJobsResponse {
-    return _smithy.isa(o, "ListProcessingJobsResponse");
+    return __isa(o, "ListProcessingJobsResponse");
   }
 }
 
@@ -12481,7 +12483,7 @@ export interface ListSubscribedWorkteamsRequest {
 
 export namespace ListSubscribedWorkteamsRequest {
   export function isa(o: any): o is ListSubscribedWorkteamsRequest {
-    return _smithy.isa(o, "ListSubscribedWorkteamsRequest");
+    return __isa(o, "ListSubscribedWorkteamsRequest");
   }
 }
 
@@ -12501,7 +12503,7 @@ export interface ListSubscribedWorkteamsResponse extends $MetadataBearer {
 
 export namespace ListSubscribedWorkteamsResponse {
   export function isa(o: any): o is ListSubscribedWorkteamsResponse {
-    return _smithy.isa(o, "ListSubscribedWorkteamsResponse");
+    return __isa(o, "ListSubscribedWorkteamsResponse");
   }
 }
 
@@ -12528,7 +12530,7 @@ export interface ListTagsInput {
 
 export namespace ListTagsInput {
   export function isa(o: any): o is ListTagsInput {
-    return _smithy.isa(o, "ListTagsInput");
+    return __isa(o, "ListTagsInput");
   }
 }
 
@@ -12548,7 +12550,7 @@ export interface ListTagsOutput extends $MetadataBearer {
 
 export namespace ListTagsOutput {
   export function isa(o: any): o is ListTagsOutput {
-    return _smithy.isa(o, "ListTagsOutput");
+    return __isa(o, "ListTagsOutput");
   }
 }
 
@@ -12599,7 +12601,7 @@ export namespace ListTrainingJobsForHyperParameterTuningJobRequest {
   export function isa(
     o: any
   ): o is ListTrainingJobsForHyperParameterTuningJobRequest {
-    return _smithy.isa(o, "ListTrainingJobsForHyperParameterTuningJobRequest");
+    return __isa(o, "ListTrainingJobsForHyperParameterTuningJobRequest");
   }
 }
 
@@ -12626,7 +12628,7 @@ export namespace ListTrainingJobsForHyperParameterTuningJobResponse {
   export function isa(
     o: any
   ): o is ListTrainingJobsForHyperParameterTuningJobResponse {
-    return _smithy.isa(o, "ListTrainingJobsForHyperParameterTuningJobResponse");
+    return __isa(o, "ListTrainingJobsForHyperParameterTuningJobResponse");
   }
 }
 
@@ -12692,7 +12694,7 @@ export interface ListTrainingJobsRequest {
 
 export namespace ListTrainingJobsRequest {
   export function isa(o: any): o is ListTrainingJobsRequest {
-    return _smithy.isa(o, "ListTrainingJobsRequest");
+    return __isa(o, "ListTrainingJobsRequest");
   }
 }
 
@@ -12713,7 +12715,7 @@ export interface ListTrainingJobsResponse extends $MetadataBearer {
 
 export namespace ListTrainingJobsResponse {
   export function isa(o: any): o is ListTrainingJobsResponse {
-    return _smithy.isa(o, "ListTrainingJobsResponse");
+    return __isa(o, "ListTrainingJobsResponse");
   }
 }
 
@@ -12778,7 +12780,7 @@ export interface ListTransformJobsRequest {
 
 export namespace ListTransformJobsRequest {
   export function isa(o: any): o is ListTransformJobsRequest {
-    return _smithy.isa(o, "ListTransformJobsRequest");
+    return __isa(o, "ListTransformJobsRequest");
   }
 }
 
@@ -12800,7 +12802,7 @@ export interface ListTransformJobsResponse extends $MetadataBearer {
 
 export namespace ListTransformJobsResponse {
   export function isa(o: any): o is ListTransformJobsResponse {
-    return _smithy.isa(o, "ListTransformJobsResponse");
+    return __isa(o, "ListTransformJobsResponse");
   }
 }
 
@@ -12861,7 +12863,7 @@ export interface ListTrialComponentsRequest {
 
 export namespace ListTrialComponentsRequest {
   export function isa(o: any): o is ListTrialComponentsRequest {
-    return _smithy.isa(o, "ListTrialComponentsRequest");
+    return __isa(o, "ListTrialComponentsRequest");
   }
 }
 
@@ -12880,7 +12882,7 @@ export interface ListTrialComponentsResponse extends $MetadataBearer {
 
 export namespace ListTrialComponentsResponse {
   export function isa(o: any): o is ListTrialComponentsResponse {
-    return _smithy.isa(o, "ListTrialComponentsResponse");
+    return __isa(o, "ListTrialComponentsResponse");
   }
 }
 
@@ -12925,7 +12927,7 @@ export interface ListTrialsRequest {
 
 export namespace ListTrialsRequest {
   export function isa(o: any): o is ListTrialsRequest {
-    return _smithy.isa(o, "ListTrialsRequest");
+    return __isa(o, "ListTrialsRequest");
   }
 }
 
@@ -12944,7 +12946,7 @@ export interface ListTrialsResponse extends $MetadataBearer {
 
 export namespace ListTrialsResponse {
   export function isa(o: any): o is ListTrialsResponse {
-    return _smithy.isa(o, "ListTrialsResponse");
+    return __isa(o, "ListTrialsResponse");
   }
 }
 
@@ -12984,7 +12986,7 @@ export interface ListUserProfilesRequest {
 
 export namespace ListUserProfilesRequest {
   export function isa(o: any): o is ListUserProfilesRequest {
-    return _smithy.isa(o, "ListUserProfilesRequest");
+    return __isa(o, "ListUserProfilesRequest");
   }
 }
 
@@ -13004,7 +13006,7 @@ export interface ListUserProfilesResponse extends $MetadataBearer {
 
 export namespace ListUserProfilesResponse {
   export function isa(o: any): o is ListUserProfilesResponse {
-    return _smithy.isa(o, "ListUserProfilesResponse");
+    return __isa(o, "ListUserProfilesResponse");
   }
 }
 
@@ -13041,7 +13043,7 @@ export interface ListWorkteamsRequest {
 
 export namespace ListWorkteamsRequest {
   export function isa(o: any): o is ListWorkteamsRequest {
-    return _smithy.isa(o, "ListWorkteamsRequest");
+    return __isa(o, "ListWorkteamsRequest");
   }
 }
 
@@ -13061,7 +13063,7 @@ export interface ListWorkteamsResponse extends $MetadataBearer {
 
 export namespace ListWorkteamsResponse {
   export function isa(o: any): o is ListWorkteamsResponse {
-    return _smithy.isa(o, "ListWorkteamsResponse");
+    return __isa(o, "ListWorkteamsResponse");
   }
 }
 
@@ -13083,7 +13085,7 @@ export interface MemberDefinition {
 
 export namespace MemberDefinition {
   export function isa(o: any): o is MemberDefinition {
-    return _smithy.isa(o, "MemberDefinition");
+    return __isa(o, "MemberDefinition");
   }
 }
 
@@ -13110,7 +13112,7 @@ export interface MetricData {
 
 export namespace MetricData {
   export function isa(o: any): o is MetricData {
-    return _smithy.isa(o, "MetricData");
+    return __isa(o, "MetricData");
   }
 }
 
@@ -13144,7 +13146,7 @@ export interface MetricDefinition {
 
 export namespace MetricDefinition {
   export function isa(o: any): o is MetricDefinition {
-    return _smithy.isa(o, "MetricDefinition");
+    return __isa(o, "MetricDefinition");
   }
 }
 
@@ -13163,7 +13165,7 @@ export interface ModelArtifacts {
 
 export namespace ModelArtifacts {
   export function isa(o: any): o is ModelArtifacts {
-    return _smithy.isa(o, "ModelArtifacts");
+    return __isa(o, "ModelArtifacts");
   }
 }
 
@@ -13208,7 +13210,7 @@ export interface ModelPackageContainerDefinition {
 
 export namespace ModelPackageContainerDefinition {
   export function isa(o: any): o is ModelPackageContainerDefinition {
-    return _smithy.isa(o, "ModelPackageContainerDefinition");
+    return __isa(o, "ModelPackageContainerDefinition");
   }
 }
 
@@ -13243,7 +13245,7 @@ export interface ModelPackageStatusDetails {
 
 export namespace ModelPackageStatusDetails {
   export function isa(o: any): o is ModelPackageStatusDetails {
-    return _smithy.isa(o, "ModelPackageStatusDetails");
+    return __isa(o, "ModelPackageStatusDetails");
   }
 }
 
@@ -13270,7 +13272,7 @@ export interface ModelPackageStatusItem {
 
 export namespace ModelPackageStatusItem {
   export function isa(o: any): o is ModelPackageStatusItem {
-    return _smithy.isa(o, "ModelPackageStatusItem");
+    return __isa(o, "ModelPackageStatusItem");
   }
 }
 
@@ -13307,7 +13309,7 @@ export interface ModelPackageSummary {
 
 export namespace ModelPackageSummary {
   export function isa(o: any): o is ModelPackageSummary {
-    return _smithy.isa(o, "ModelPackageSummary");
+    return __isa(o, "ModelPackageSummary");
   }
 }
 
@@ -13333,7 +13335,7 @@ export interface ModelPackageValidationProfile {
 
 export namespace ModelPackageValidationProfile {
   export function isa(o: any): o is ModelPackageValidationProfile {
-    return _smithy.isa(o, "ModelPackageValidationProfile");
+    return __isa(o, "ModelPackageValidationProfile");
   }
 }
 
@@ -13356,7 +13358,7 @@ export interface ModelPackageValidationSpecification {
 
 export namespace ModelPackageValidationSpecification {
   export function isa(o: any): o is ModelPackageValidationSpecification {
-    return _smithy.isa(o, "ModelPackageValidationSpecification");
+    return __isa(o, "ModelPackageValidationSpecification");
   }
 }
 
@@ -13388,7 +13390,7 @@ export interface ModelSummary {
 
 export namespace ModelSummary {
   export function isa(o: any): o is ModelSummary {
-    return _smithy.isa(o, "ModelSummary");
+    return __isa(o, "ModelSummary");
   }
 }
 
@@ -13429,7 +13431,7 @@ export interface MonitoringAppSpecification {
 
 export namespace MonitoringAppSpecification {
   export function isa(o: any): o is MonitoringAppSpecification {
-    return _smithy.isa(o, "MonitoringAppSpecification");
+    return __isa(o, "MonitoringAppSpecification");
   }
 }
 
@@ -13455,7 +13457,7 @@ export interface MonitoringBaselineConfig {
 
 export namespace MonitoringBaselineConfig {
   export function isa(o: any): o is MonitoringBaselineConfig {
-    return _smithy.isa(o, "MonitoringBaselineConfig");
+    return __isa(o, "MonitoringBaselineConfig");
   }
 }
 
@@ -13491,7 +13493,7 @@ export interface MonitoringClusterConfig {
 
 export namespace MonitoringClusterConfig {
   export function isa(o: any): o is MonitoringClusterConfig {
-    return _smithy.isa(o, "MonitoringClusterConfig");
+    return __isa(o, "MonitoringClusterConfig");
   }
 }
 
@@ -13508,7 +13510,7 @@ export interface MonitoringConstraintsResource {
 
 export namespace MonitoringConstraintsResource {
   export function isa(o: any): o is MonitoringConstraintsResource {
-    return _smithy.isa(o, "MonitoringConstraintsResource");
+    return __isa(o, "MonitoringConstraintsResource");
   }
 }
 
@@ -13566,7 +13568,7 @@ export interface MonitoringExecutionSummary {
 
 export namespace MonitoringExecutionSummary {
   export function isa(o: any): o is MonitoringExecutionSummary {
-    return _smithy.isa(o, "MonitoringExecutionSummary");
+    return __isa(o, "MonitoringExecutionSummary");
   }
 }
 
@@ -13583,7 +13585,7 @@ export interface MonitoringInput {
 
 export namespace MonitoringInput {
   export function isa(o: any): o is MonitoringInput {
-    return _smithy.isa(o, "MonitoringInput");
+    return __isa(o, "MonitoringInput");
   }
 }
 
@@ -13645,7 +13647,7 @@ export interface MonitoringJobDefinition {
 
 export namespace MonitoringJobDefinition {
   export function isa(o: any): o is MonitoringJobDefinition {
-    return _smithy.isa(o, "MonitoringJobDefinition");
+    return __isa(o, "MonitoringJobDefinition");
   }
 }
 
@@ -13662,7 +13664,7 @@ export interface MonitoringOutput {
 
 export namespace MonitoringOutput {
   export function isa(o: any): o is MonitoringOutput {
-    return _smithy.isa(o, "MonitoringOutput");
+    return __isa(o, "MonitoringOutput");
   }
 }
 
@@ -13686,7 +13688,7 @@ export interface MonitoringOutputConfig {
 
 export namespace MonitoringOutputConfig {
   export function isa(o: any): o is MonitoringOutputConfig {
-    return _smithy.isa(o, "MonitoringOutputConfig");
+    return __isa(o, "MonitoringOutputConfig");
   }
 }
 
@@ -13703,7 +13705,7 @@ export interface MonitoringResources {
 
 export namespace MonitoringResources {
   export function isa(o: any): o is MonitoringResources {
-    return _smithy.isa(o, "MonitoringResources");
+    return __isa(o, "MonitoringResources");
   }
 }
 
@@ -13734,7 +13736,7 @@ export interface MonitoringS3Output {
 
 export namespace MonitoringS3Output {
   export function isa(o: any): o is MonitoringS3Output {
-    return _smithy.isa(o, "MonitoringS3Output");
+    return __isa(o, "MonitoringS3Output");
   }
 }
 
@@ -13756,7 +13758,7 @@ export interface MonitoringScheduleConfig {
 
 export namespace MonitoringScheduleConfig {
   export function isa(o: any): o is MonitoringScheduleConfig {
-    return _smithy.isa(o, "MonitoringScheduleConfig");
+    return __isa(o, "MonitoringScheduleConfig");
   }
 }
 
@@ -13804,7 +13806,7 @@ export interface MonitoringScheduleSummary {
 
 export namespace MonitoringScheduleSummary {
   export function isa(o: any): o is MonitoringScheduleSummary {
-    return _smithy.isa(o, "MonitoringScheduleSummary");
+    return __isa(o, "MonitoringScheduleSummary");
   }
 }
 
@@ -13821,7 +13823,7 @@ export interface MonitoringStatisticsResource {
 
 export namespace MonitoringStatisticsResource {
   export function isa(o: any): o is MonitoringStatisticsResource {
-    return _smithy.isa(o, "MonitoringStatisticsResource");
+    return __isa(o, "MonitoringStatisticsResource");
   }
 }
 
@@ -13838,7 +13840,7 @@ export interface MonitoringStoppingCondition {
 
 export namespace MonitoringStoppingCondition {
   export function isa(o: any): o is MonitoringStoppingCondition {
-    return _smithy.isa(o, "MonitoringStoppingCondition");
+    return __isa(o, "MonitoringStoppingCondition");
   }
 }
 
@@ -13886,7 +13888,7 @@ export interface NestedFilters {
 
 export namespace NestedFilters {
   export function isa(o: any): o is NestedFilters {
-    return _smithy.isa(o, "NestedFilters");
+    return __isa(o, "NestedFilters");
   }
 }
 
@@ -13914,7 +13916,7 @@ export interface NetworkConfig {
 
 export namespace NetworkConfig {
   export function isa(o: any): o is NetworkConfig {
-    return _smithy.isa(o, "NetworkConfig");
+    return __isa(o, "NetworkConfig");
   }
 }
 
@@ -13966,7 +13968,7 @@ export interface NotebookInstanceLifecycleConfigSummary {
 
 export namespace NotebookInstanceLifecycleConfigSummary {
   export function isa(o: any): o is NotebookInstanceLifecycleConfigSummary {
-    return _smithy.isa(o, "NotebookInstanceLifecycleConfigSummary");
+    return __isa(o, "NotebookInstanceLifecycleConfigSummary");
   }
 }
 
@@ -13995,7 +13997,7 @@ export interface NotebookInstanceLifecycleHook {
 
 export namespace NotebookInstanceLifecycleHook {
   export function isa(o: any): o is NotebookInstanceLifecycleHook {
-    return _smithy.isa(o, "NotebookInstanceLifecycleHook");
+    return __isa(o, "NotebookInstanceLifecycleHook");
   }
 }
 
@@ -14093,7 +14095,7 @@ export interface NotebookInstanceSummary {
 
 export namespace NotebookInstanceSummary {
   export function isa(o: any): o is NotebookInstanceSummary {
-    return _smithy.isa(o, "NotebookInstanceSummary");
+    return __isa(o, "NotebookInstanceSummary");
   }
 }
 
@@ -14116,7 +14118,7 @@ export interface NotificationConfiguration {
 
 export namespace NotificationConfiguration {
   export function isa(o: any): o is NotificationConfiguration {
-    return _smithy.isa(o, "NotificationConfiguration");
+    return __isa(o, "NotificationConfiguration");
   }
 }
 
@@ -14158,7 +14160,7 @@ export interface ObjectiveStatusCounters {
 
 export namespace ObjectiveStatusCounters {
   export function isa(o: any): o is ObjectiveStatusCounters {
-    return _smithy.isa(o, "ObjectiveStatusCounters");
+    return __isa(o, "ObjectiveStatusCounters");
   }
 }
 
@@ -14204,7 +14206,7 @@ export interface OutputConfig {
 
 export namespace OutputConfig {
   export function isa(o: any): o is OutputConfig {
-    return _smithy.isa(o, "OutputConfig");
+    return __isa(o, "OutputConfig");
   }
 }
 
@@ -14272,7 +14274,7 @@ export interface OutputDataConfig {
 
 export namespace OutputDataConfig {
   export function isa(o: any): o is OutputDataConfig {
-    return _smithy.isa(o, "OutputDataConfig");
+    return __isa(o, "OutputDataConfig");
   }
 }
 
@@ -14303,7 +14305,7 @@ export interface ParameterRange {
 
 export namespace ParameterRange {
   export function isa(o: any): o is ParameterRange {
-    return _smithy.isa(o, "ParameterRange");
+    return __isa(o, "ParameterRange");
   }
 }
 
@@ -14342,7 +14344,7 @@ export interface ParameterRanges {
 
 export namespace ParameterRanges {
   export function isa(o: any): o is ParameterRanges {
-    return _smithy.isa(o, "ParameterRanges");
+    return __isa(o, "ParameterRanges");
   }
 }
 
@@ -14373,7 +14375,7 @@ export interface Parent {
 
 export namespace Parent {
   export function isa(o: any): o is Parent {
-    return _smithy.isa(o, "Parent");
+    return __isa(o, "Parent");
   }
 }
 
@@ -14392,7 +14394,7 @@ export interface ParentHyperParameterTuningJob {
 
 export namespace ParentHyperParameterTuningJob {
   export function isa(o: any): o is ParentHyperParameterTuningJob {
-    return _smithy.isa(o, "ParentHyperParameterTuningJob");
+    return __isa(o, "ParentHyperParameterTuningJob");
   }
 }
 
@@ -14434,7 +14436,7 @@ export interface ProcessingClusterConfig {
 
 export namespace ProcessingClusterConfig {
   export function isa(o: any): o is ProcessingClusterConfig {
-    return _smithy.isa(o, "ProcessingClusterConfig");
+    return __isa(o, "ProcessingClusterConfig");
   }
 }
 
@@ -14456,7 +14458,7 @@ export interface ProcessingInput {
 
 export namespace ProcessingInput {
   export function isa(o: any): o is ProcessingInput {
-    return _smithy.isa(o, "ProcessingInput");
+    return __isa(o, "ProcessingInput");
   }
 }
 
@@ -14559,7 +14561,7 @@ export interface ProcessingJobSummary {
 
 export namespace ProcessingJobSummary {
   export function isa(o: any): o is ProcessingJobSummary {
-    return _smithy.isa(o, "ProcessingJobSummary");
+    return __isa(o, "ProcessingJobSummary");
   }
 }
 
@@ -14581,7 +14583,7 @@ export interface ProcessingOutput {
 
 export namespace ProcessingOutput {
   export function isa(o: any): o is ProcessingOutput {
-    return _smithy.isa(o, "ProcessingOutput");
+    return __isa(o, "ProcessingOutput");
   }
 }
 
@@ -14606,7 +14608,7 @@ export interface ProcessingOutputConfig {
 
 export namespace ProcessingOutputConfig {
   export function isa(o: any): o is ProcessingOutputConfig {
-    return _smithy.isa(o, "ProcessingOutputConfig");
+    return __isa(o, "ProcessingOutputConfig");
   }
 }
 
@@ -14625,7 +14627,7 @@ export interface ProcessingResources {
 
 export namespace ProcessingResources {
   export function isa(o: any): o is ProcessingResources {
-    return _smithy.isa(o, "ProcessingResources");
+    return __isa(o, "ProcessingResources");
   }
 }
 
@@ -14696,7 +14698,7 @@ export interface ProcessingS3Input {
 
 export namespace ProcessingS3Input {
   export function isa(o: any): o is ProcessingS3Input {
-    return _smithy.isa(o, "ProcessingS3Input");
+    return __isa(o, "ProcessingS3Input");
   }
 }
 
@@ -14732,7 +14734,7 @@ export interface ProcessingS3Output {
 
 export namespace ProcessingS3Output {
   export function isa(o: any): o is ProcessingS3Output {
-    return _smithy.isa(o, "ProcessingS3Output");
+    return __isa(o, "ProcessingS3Output");
   }
 }
 
@@ -14754,7 +14756,7 @@ export interface ProcessingStoppingCondition {
 
 export namespace ProcessingStoppingCondition {
   export function isa(o: any): o is ProcessingStoppingCondition {
-    return _smithy.isa(o, "ProcessingStoppingCondition");
+    return __isa(o, "ProcessingStoppingCondition");
   }
 }
 
@@ -14807,7 +14809,7 @@ export interface ProductionVariant {
 
 export namespace ProductionVariant {
   export function isa(o: any): o is ProductionVariant {
-    return _smithy.isa(o, "ProductionVariant");
+    return __isa(o, "ProductionVariant");
   }
 }
 
@@ -14933,7 +14935,7 @@ export interface ProductionVariantSummary {
 
 export namespace ProductionVariantSummary {
   export function isa(o: any): o is ProductionVariantSummary {
-    return _smithy.isa(o, "ProductionVariantSummary");
+    return __isa(o, "ProductionVariantSummary");
   }
 }
 
@@ -14951,7 +14953,7 @@ export interface PropertyNameQuery {
 
 export namespace PropertyNameQuery {
   export function isa(o: any): o is PropertyNameQuery {
-    return _smithy.isa(o, "PropertyNameQuery");
+    return __isa(o, "PropertyNameQuery");
   }
 }
 
@@ -14970,7 +14972,7 @@ export interface PropertyNameSuggestion {
 
 export namespace PropertyNameSuggestion {
   export function isa(o: any): o is PropertyNameSuggestion {
-    return _smithy.isa(o, "PropertyNameSuggestion");
+    return __isa(o, "PropertyNameSuggestion");
   }
 }
 
@@ -15288,7 +15290,7 @@ export interface PublicWorkforceTaskPrice {
 
 export namespace PublicWorkforceTaskPrice {
   export function isa(o: any): o is PublicWorkforceTaskPrice {
-    return _smithy.isa(o, "PublicWorkforceTaskPrice");
+    return __isa(o, "PublicWorkforceTaskPrice");
   }
 }
 
@@ -15319,7 +15321,7 @@ export interface RenderUiTemplateRequest {
 
 export namespace RenderUiTemplateRequest {
   export function isa(o: any): o is RenderUiTemplateRequest {
-    return _smithy.isa(o, "RenderUiTemplateRequest");
+    return __isa(o, "RenderUiTemplateRequest");
   }
 }
 
@@ -15339,7 +15341,7 @@ export interface RenderUiTemplateResponse extends $MetadataBearer {
 
 export namespace RenderUiTemplateResponse {
   export function isa(o: any): o is RenderUiTemplateResponse {
-    return _smithy.isa(o, "RenderUiTemplateResponse");
+    return __isa(o, "RenderUiTemplateResponse");
   }
 }
 
@@ -15359,7 +15361,7 @@ export interface RenderableTask {
 
 export namespace RenderableTask {
   export function isa(o: any): o is RenderableTask {
-    return _smithy.isa(o, "RenderableTask");
+    return __isa(o, "RenderableTask");
   }
 }
 
@@ -15381,7 +15383,7 @@ export interface RenderingError {
 
 export namespace RenderingError {
   export function isa(o: any): o is RenderingError {
-    return _smithy.isa(o, "RenderingError");
+    return __isa(o, "RenderingError");
   }
 }
 
@@ -15408,7 +15410,7 @@ export interface ResolvedAttributes {
 
 export namespace ResolvedAttributes {
   export function isa(o: any): o is ResolvedAttributes {
-    return _smithy.isa(o, "ResolvedAttributes");
+    return __isa(o, "ResolvedAttributes");
   }
 }
 
@@ -15485,16 +15487,14 @@ export interface ResourceConfig {
 
 export namespace ResourceConfig {
   export function isa(o: any): o is ResourceConfig {
-    return _smithy.isa(o, "ResourceConfig");
+    return __isa(o, "ResourceConfig");
   }
 }
 
 /**
  * <p>Resource being accessed is in use.</p>
  */
-export interface ResourceInUse
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface ResourceInUse extends __SmithyException, $MetadataBearer {
   name: "ResourceInUse";
   $fault: "client";
   Message?: string;
@@ -15502,7 +15502,7 @@ export interface ResourceInUse
 
 export namespace ResourceInUse {
   export function isa(o: any): o is ResourceInUse {
-    return _smithy.isa(o, "ResourceInUse");
+    return __isa(o, "ResourceInUse");
   }
 }
 
@@ -15511,7 +15511,7 @@ export namespace ResourceInUse {
  *             training jobs created. </p>
  */
 export interface ResourceLimitExceeded
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceLimitExceeded";
   $fault: "client";
@@ -15520,7 +15520,7 @@ export interface ResourceLimitExceeded
 
 export namespace ResourceLimitExceeded {
   export function isa(o: any): o is ResourceLimitExceeded {
-    return _smithy.isa(o, "ResourceLimitExceeded");
+    return __isa(o, "ResourceLimitExceeded");
   }
 }
 
@@ -15551,16 +15551,14 @@ export interface ResourceLimits {
 
 export namespace ResourceLimits {
   export function isa(o: any): o is ResourceLimits {
-    return _smithy.isa(o, "ResourceLimits");
+    return __isa(o, "ResourceLimits");
   }
 }
 
 /**
  * <p>Resource being access is not found.</p>
  */
-export interface ResourceNotFound
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface ResourceNotFound extends __SmithyException, $MetadataBearer {
   name: "ResourceNotFound";
   $fault: "client";
   Message?: string;
@@ -15568,7 +15566,7 @@ export interface ResourceNotFound
 
 export namespace ResourceNotFound {
   export function isa(o: any): o is ResourceNotFound {
-    return _smithy.isa(o, "ResourceNotFound");
+    return __isa(o, "ResourceNotFound");
   }
 }
 
@@ -15590,7 +15588,7 @@ export interface ResourceSpec {
 
 export namespace ResourceSpec {
   export function isa(o: any): o is ResourceSpec {
-    return _smithy.isa(o, "ResourceSpec");
+    return __isa(o, "ResourceSpec");
   }
 }
 
@@ -15614,7 +15612,7 @@ export interface RetentionPolicy {
 
 export namespace RetentionPolicy {
   export function isa(o: any): o is RetentionPolicy {
-    return _smithy.isa(o, "RetentionPolicy");
+    return __isa(o, "RetentionPolicy");
   }
 }
 
@@ -15745,7 +15743,7 @@ export interface S3DataSource {
 
 export namespace S3DataSource {
   export function isa(o: any): o is S3DataSource {
-    return _smithy.isa(o, "S3DataSource");
+    return __isa(o, "S3DataSource");
   }
 }
 
@@ -15825,7 +15823,7 @@ export interface ScheduleConfig {
 
 export namespace ScheduleConfig {
   export function isa(o: any): o is ScheduleConfig {
-    return _smithy.isa(o, "ScheduleConfig");
+    return __isa(o, "ScheduleConfig");
   }
 }
 
@@ -15893,7 +15891,7 @@ export interface SearchExpression {
 
 export namespace SearchExpression {
   export function isa(o: any): o is SearchExpression {
-    return _smithy.isa(o, "SearchExpression");
+    return __isa(o, "SearchExpression");
   }
 }
 
@@ -15926,7 +15924,7 @@ export interface SearchRecord {
 
 export namespace SearchRecord {
   export function isa(o: any): o is SearchRecord {
-    return _smithy.isa(o, "SearchRecord");
+    return __isa(o, "SearchRecord");
   }
 }
 
@@ -15975,7 +15973,7 @@ export interface SearchRequest {
 
 export namespace SearchRequest {
   export function isa(o: any): o is SearchRequest {
-    return _smithy.isa(o, "SearchRequest");
+    return __isa(o, "SearchRequest");
   }
 }
 
@@ -15996,7 +15994,7 @@ export interface SearchResponse extends $MetadataBearer {
 
 export namespace SearchResponse {
   export function isa(o: any): o is SearchResponse {
-    return _smithy.isa(o, "SearchResponse");
+    return __isa(o, "SearchResponse");
   }
 }
 
@@ -16215,7 +16213,7 @@ export interface SecondaryStatusTransition {
 
 export namespace SecondaryStatusTransition {
   export function isa(o: any): o is SecondaryStatusTransition {
-    return _smithy.isa(o, "SecondaryStatusTransition");
+    return __isa(o, "SecondaryStatusTransition");
   }
 }
 
@@ -16242,7 +16240,7 @@ export interface SharingSettings {
 
 export namespace SharingSettings {
   export function isa(o: any): o is SharingSettings {
-    return _smithy.isa(o, "SharingSettings");
+    return __isa(o, "SharingSettings");
   }
 }
 
@@ -16272,7 +16270,7 @@ export interface ShuffleConfig {
 
 export namespace ShuffleConfig {
   export function isa(o: any): o is ShuffleConfig {
-    return _smithy.isa(o, "ShuffleConfig");
+    return __isa(o, "ShuffleConfig");
   }
 }
 
@@ -16326,7 +16324,7 @@ export interface SourceAlgorithm {
 
 export namespace SourceAlgorithm {
   export function isa(o: any): o is SourceAlgorithm {
-    return _smithy.isa(o, "SourceAlgorithm");
+    return __isa(o, "SourceAlgorithm");
   }
 }
 
@@ -16343,7 +16341,7 @@ export interface SourceAlgorithmSpecification {
 
 export namespace SourceAlgorithmSpecification {
   export function isa(o: any): o is SourceAlgorithmSpecification {
-    return _smithy.isa(o, "SourceAlgorithmSpecification");
+    return __isa(o, "SourceAlgorithmSpecification");
   }
 }
 
@@ -16366,7 +16364,7 @@ export interface SourceIpConfig {
 
 export namespace SourceIpConfig {
   export function isa(o: any): o is SourceIpConfig {
-    return _smithy.isa(o, "SourceIpConfig");
+    return __isa(o, "SourceIpConfig");
   }
 }
 
@@ -16387,7 +16385,7 @@ export interface StartMonitoringScheduleRequest {
 
 export namespace StartMonitoringScheduleRequest {
   export function isa(o: any): o is StartMonitoringScheduleRequest {
-    return _smithy.isa(o, "StartMonitoringScheduleRequest");
+    return __isa(o, "StartMonitoringScheduleRequest");
   }
 }
 
@@ -16401,7 +16399,7 @@ export interface StartNotebookInstanceInput {
 
 export namespace StartNotebookInstanceInput {
   export function isa(o: any): o is StartNotebookInstanceInput {
-    return _smithy.isa(o, "StartNotebookInstanceInput");
+    return __isa(o, "StartNotebookInstanceInput");
   }
 }
 
@@ -16415,7 +16413,7 @@ export interface StopAutoMLJobRequest {
 
 export namespace StopAutoMLJobRequest {
   export function isa(o: any): o is StopAutoMLJobRequest {
-    return _smithy.isa(o, "StopAutoMLJobRequest");
+    return __isa(o, "StopAutoMLJobRequest");
   }
 }
 
@@ -16429,7 +16427,7 @@ export interface StopCompilationJobRequest {
 
 export namespace StopCompilationJobRequest {
   export function isa(o: any): o is StopCompilationJobRequest {
-    return _smithy.isa(o, "StopCompilationJobRequest");
+    return __isa(o, "StopCompilationJobRequest");
   }
 }
 
@@ -16443,7 +16441,7 @@ export interface StopHyperParameterTuningJobRequest {
 
 export namespace StopHyperParameterTuningJobRequest {
   export function isa(o: any): o is StopHyperParameterTuningJobRequest {
-    return _smithy.isa(o, "StopHyperParameterTuningJobRequest");
+    return __isa(o, "StopHyperParameterTuningJobRequest");
   }
 }
 
@@ -16457,7 +16455,7 @@ export interface StopLabelingJobRequest {
 
 export namespace StopLabelingJobRequest {
   export function isa(o: any): o is StopLabelingJobRequest {
-    return _smithy.isa(o, "StopLabelingJobRequest");
+    return __isa(o, "StopLabelingJobRequest");
   }
 }
 
@@ -16471,7 +16469,7 @@ export interface StopMonitoringScheduleRequest {
 
 export namespace StopMonitoringScheduleRequest {
   export function isa(o: any): o is StopMonitoringScheduleRequest {
-    return _smithy.isa(o, "StopMonitoringScheduleRequest");
+    return __isa(o, "StopMonitoringScheduleRequest");
   }
 }
 
@@ -16485,7 +16483,7 @@ export interface StopNotebookInstanceInput {
 
 export namespace StopNotebookInstanceInput {
   export function isa(o: any): o is StopNotebookInstanceInput {
-    return _smithy.isa(o, "StopNotebookInstanceInput");
+    return __isa(o, "StopNotebookInstanceInput");
   }
 }
 
@@ -16499,7 +16497,7 @@ export interface StopProcessingJobRequest {
 
 export namespace StopProcessingJobRequest {
   export function isa(o: any): o is StopProcessingJobRequest {
-    return _smithy.isa(o, "StopProcessingJobRequest");
+    return __isa(o, "StopProcessingJobRequest");
   }
 }
 
@@ -16513,7 +16511,7 @@ export interface StopTrainingJobRequest {
 
 export namespace StopTrainingJobRequest {
   export function isa(o: any): o is StopTrainingJobRequest {
-    return _smithy.isa(o, "StopTrainingJobRequest");
+    return __isa(o, "StopTrainingJobRequest");
   }
 }
 
@@ -16527,7 +16525,7 @@ export interface StopTransformJobRequest {
 
 export namespace StopTransformJobRequest {
   export function isa(o: any): o is StopTransformJobRequest {
-    return _smithy.isa(o, "StopTransformJobRequest");
+    return __isa(o, "StopTransformJobRequest");
   }
 }
 
@@ -16571,7 +16569,7 @@ export interface StoppingCondition {
 
 export namespace StoppingCondition {
   export function isa(o: any): o is StoppingCondition {
-    return _smithy.isa(o, "StoppingCondition");
+    return __isa(o, "StoppingCondition");
   }
 }
 
@@ -16608,7 +16606,7 @@ export interface SubscribedWorkteam {
 
 export namespace SubscribedWorkteam {
   export function isa(o: any): o is SubscribedWorkteam {
-    return _smithy.isa(o, "SubscribedWorkteam");
+    return __isa(o, "SubscribedWorkteam");
   }
 }
 
@@ -16627,7 +16625,7 @@ export interface SuggestionQuery {
 
 export namespace SuggestionQuery {
   export function isa(o: any): o is SuggestionQuery {
-    return _smithy.isa(o, "SuggestionQuery");
+    return __isa(o, "SuggestionQuery");
   }
 }
 
@@ -16649,7 +16647,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -16688,7 +16686,7 @@ export interface TensorBoardAppSettings {
 
 export namespace TensorBoardAppSettings {
   export function isa(o: any): o is TensorBoardAppSettings {
-    return _smithy.isa(o, "TensorBoardAppSettings");
+    return __isa(o, "TensorBoardAppSettings");
   }
 }
 
@@ -16711,7 +16709,7 @@ export interface TensorBoardOutputConfig {
 
 export namespace TensorBoardOutputConfig {
   export function isa(o: any): o is TensorBoardOutputConfig {
-    return _smithy.isa(o, "TensorBoardOutputConfig");
+    return __isa(o, "TensorBoardOutputConfig");
   }
 }
 
@@ -17094,7 +17092,7 @@ export interface TrainingJob {
 
 export namespace TrainingJob {
   export function isa(o: any): o is TrainingJob {
-    return _smithy.isa(o, "TrainingJob");
+    return __isa(o, "TrainingJob");
   }
 }
 
@@ -17148,7 +17146,7 @@ export interface TrainingJobDefinition {
 
 export namespace TrainingJobDefinition {
   export function isa(o: any): o is TrainingJobDefinition {
-    return _smithy.isa(o, "TrainingJobDefinition");
+    return __isa(o, "TrainingJobDefinition");
   }
 }
 
@@ -17212,7 +17210,7 @@ export interface TrainingJobStatusCounters {
 
 export namespace TrainingJobStatusCounters {
   export function isa(o: any): o is TrainingJobStatusCounters {
-    return _smithy.isa(o, "TrainingJobStatusCounters");
+    return __isa(o, "TrainingJobStatusCounters");
   }
 }
 
@@ -17256,7 +17254,7 @@ export interface TrainingJobSummary {
 
 export namespace TrainingJobSummary {
   export function isa(o: any): o is TrainingJobSummary {
-    return _smithy.isa(o, "TrainingJobSummary");
+    return __isa(o, "TrainingJobSummary");
   }
 }
 
@@ -17318,7 +17316,7 @@ export interface TrainingSpecification {
 
 export namespace TrainingSpecification {
   export function isa(o: any): o is TrainingSpecification {
-    return _smithy.isa(o, "TrainingSpecification");
+    return __isa(o, "TrainingSpecification");
   }
 }
 
@@ -17335,7 +17333,7 @@ export interface TransformDataSource {
 
 export namespace TransformDataSource {
   export function isa(o: any): o is TransformDataSource {
-    return _smithy.isa(o, "TransformDataSource");
+    return __isa(o, "TransformDataSource");
   }
 }
 
@@ -17402,7 +17400,7 @@ export interface TransformInput {
 
 export namespace TransformInput {
   export function isa(o: any): o is TransformInput {
-    return _smithy.isa(o, "TransformInput");
+    return __isa(o, "TransformInput");
   }
 }
 
@@ -17487,7 +17485,7 @@ export interface TransformJobDefinition {
 
 export namespace TransformJobDefinition {
   export function isa(o: any): o is TransformJobDefinition {
-    return _smithy.isa(o, "TransformJobDefinition");
+    return __isa(o, "TransformJobDefinition");
   }
 }
 
@@ -17553,7 +17551,7 @@ export interface TransformJobSummary {
 
 export namespace TransformJobSummary {
   export function isa(o: any): o is TransformJobSummary {
-    return _smithy.isa(o, "TransformJobSummary");
+    return __isa(o, "TransformJobSummary");
   }
 }
 
@@ -17637,7 +17635,7 @@ export interface TransformOutput {
 
 export namespace TransformOutput {
   export function isa(o: any): o is TransformOutput {
-    return _smithy.isa(o, "TransformOutput");
+    return __isa(o, "TransformOutput");
   }
 }
 
@@ -17696,7 +17694,7 @@ export interface TransformResources {
 
 export namespace TransformResources {
   export function isa(o: any): o is TransformResources {
-    return _smithy.isa(o, "TransformResources");
+    return __isa(o, "TransformResources");
   }
 }
 
@@ -17775,7 +17773,7 @@ export interface TransformS3DataSource {
 
 export namespace TransformS3DataSource {
   export function isa(o: any): o is TransformS3DataSource {
-    return _smithy.isa(o, "TransformS3DataSource");
+    return __isa(o, "TransformS3DataSource");
   }
 }
 
@@ -17848,7 +17846,7 @@ export interface Trial {
 
 export namespace Trial {
   export function isa(o: any): o is Trial {
-    return _smithy.isa(o, "Trial");
+    return __isa(o, "Trial");
   }
 }
 
@@ -17957,7 +17955,7 @@ export interface TrialComponent {
 
 export namespace TrialComponent {
   export function isa(o: any): o is TrialComponent {
-    return _smithy.isa(o, "TrialComponent");
+    return __isa(o, "TrialComponent");
   }
 }
 
@@ -17987,7 +17985,7 @@ export interface TrialComponentArtifact {
 
 export namespace TrialComponentArtifact {
   export function isa(o: any): o is TrialComponentArtifact {
-    return _smithy.isa(o, "TrialComponentArtifact");
+    return __isa(o, "TrialComponentArtifact");
   }
 }
 
@@ -18044,7 +18042,7 @@ export interface TrialComponentMetricSummary {
 
 export namespace TrialComponentMetricSummary {
   export function isa(o: any): o is TrialComponentMetricSummary {
-    return _smithy.isa(o, "TrialComponentMetricSummary");
+    return __isa(o, "TrialComponentMetricSummary");
   }
 }
 
@@ -18070,7 +18068,7 @@ export interface TrialComponentParameterValue {
 
 export namespace TrialComponentParameterValue {
   export function isa(o: any): o is TrialComponentParameterValue {
-    return _smithy.isa(o, "TrialComponentParameterValue");
+    return __isa(o, "TrialComponentParameterValue");
   }
 }
 
@@ -18114,7 +18112,7 @@ export interface TrialComponentSimpleSummary {
 
 export namespace TrialComponentSimpleSummary {
   export function isa(o: any): o is TrialComponentSimpleSummary {
-    return _smithy.isa(o, "TrialComponentSimpleSummary");
+    return __isa(o, "TrialComponentSimpleSummary");
   }
 }
 
@@ -18136,7 +18134,7 @@ export interface TrialComponentSource {
 
 export namespace TrialComponentSource {
   export function isa(o: any): o is TrialComponentSource {
-    return _smithy.isa(o, "TrialComponentSource");
+    return __isa(o, "TrialComponentSource");
   }
 }
 
@@ -18158,7 +18156,7 @@ export interface TrialComponentSourceDetail {
 
 export namespace TrialComponentSourceDetail {
   export function isa(o: any): o is TrialComponentSourceDetail {
-    return _smithy.isa(o, "TrialComponentSourceDetail");
+    return __isa(o, "TrialComponentSourceDetail");
   }
 }
 
@@ -18180,7 +18178,7 @@ export interface TrialComponentStatus {
 
 export namespace TrialComponentStatus {
   export function isa(o: any): o is TrialComponentStatus {
-    return _smithy.isa(o, "TrialComponentStatus");
+    return __isa(o, "TrialComponentStatus");
   }
 }
 
@@ -18261,7 +18259,7 @@ export interface TrialComponentSummary {
 
 export namespace TrialComponentSummary {
   export function isa(o: any): o is TrialComponentSummary {
-    return _smithy.isa(o, "TrialComponentSummary");
+    return __isa(o, "TrialComponentSummary");
   }
 }
 
@@ -18283,7 +18281,7 @@ export interface TrialSource {
 
 export namespace TrialSource {
   export function isa(o: any): o is TrialSource {
-    return _smithy.isa(o, "TrialSource");
+    return __isa(o, "TrialSource");
   }
 }
 
@@ -18327,7 +18325,7 @@ export interface TrialSummary {
 
 export namespace TrialSummary {
   export function isa(o: any): o is TrialSummary {
-    return _smithy.isa(o, "TrialSummary");
+    return __isa(o, "TrialSummary");
   }
 }
 
@@ -18344,7 +18342,7 @@ export interface TuningJobCompletionCriteria {
 
 export namespace TuningJobCompletionCriteria {
   export function isa(o: any): o is TuningJobCompletionCriteria {
-    return _smithy.isa(o, "TuningJobCompletionCriteria");
+    return __isa(o, "TuningJobCompletionCriteria");
   }
 }
 
@@ -18371,7 +18369,7 @@ export interface USD {
 
 export namespace USD {
   export function isa(o: any): o is USD {
-    return _smithy.isa(o, "USD");
+    return __isa(o, "USD");
   }
 }
 
@@ -18390,7 +18388,7 @@ export interface UiConfig {
 
 export namespace UiConfig {
   export function isa(o: any): o is UiConfig {
-    return _smithy.isa(o, "UiConfig");
+    return __isa(o, "UiConfig");
   }
 }
 
@@ -18407,7 +18405,7 @@ export interface UiTemplate {
 
 export namespace UiTemplate {
   export function isa(o: any): o is UiTemplate {
-    return _smithy.isa(o, "UiTemplate");
+    return __isa(o, "UiTemplate");
   }
 }
 
@@ -18429,7 +18427,7 @@ export interface UiTemplateInfo {
 
 export namespace UiTemplateInfo {
   export function isa(o: any): o is UiTemplateInfo {
-    return _smithy.isa(o, "UiTemplateInfo");
+    return __isa(o, "UiTemplateInfo");
   }
 }
 
@@ -18455,7 +18453,7 @@ export interface UpdateCodeRepositoryInput {
 
 export namespace UpdateCodeRepositoryInput {
   export function isa(o: any): o is UpdateCodeRepositoryInput {
-    return _smithy.isa(o, "UpdateCodeRepositoryInput");
+    return __isa(o, "UpdateCodeRepositoryInput");
   }
 }
 
@@ -18469,7 +18467,7 @@ export interface UpdateCodeRepositoryOutput extends $MetadataBearer {
 
 export namespace UpdateCodeRepositoryOutput {
   export function isa(o: any): o is UpdateCodeRepositoryOutput {
-    return _smithy.isa(o, "UpdateCodeRepositoryOutput");
+    return __isa(o, "UpdateCodeRepositoryOutput");
   }
 }
 
@@ -18488,7 +18486,7 @@ export interface UpdateDomainRequest {
 
 export namespace UpdateDomainRequest {
   export function isa(o: any): o is UpdateDomainRequest {
-    return _smithy.isa(o, "UpdateDomainRequest");
+    return __isa(o, "UpdateDomainRequest");
   }
 }
 
@@ -18502,7 +18500,7 @@ export interface UpdateDomainResponse extends $MetadataBearer {
 
 export namespace UpdateDomainResponse {
   export function isa(o: any): o is UpdateDomainResponse {
-    return _smithy.isa(o, "UpdateDomainResponse");
+    return __isa(o, "UpdateDomainResponse");
   }
 }
 
@@ -18521,7 +18519,7 @@ export interface UpdateEndpointInput {
 
 export namespace UpdateEndpointInput {
   export function isa(o: any): o is UpdateEndpointInput {
-    return _smithy.isa(o, "UpdateEndpointInput");
+    return __isa(o, "UpdateEndpointInput");
   }
 }
 
@@ -18535,7 +18533,7 @@ export interface UpdateEndpointOutput extends $MetadataBearer {
 
 export namespace UpdateEndpointOutput {
   export function isa(o: any): o is UpdateEndpointOutput {
-    return _smithy.isa(o, "UpdateEndpointOutput");
+    return __isa(o, "UpdateEndpointOutput");
   }
 }
 
@@ -18554,7 +18552,7 @@ export interface UpdateEndpointWeightsAndCapacitiesInput {
 
 export namespace UpdateEndpointWeightsAndCapacitiesInput {
   export function isa(o: any): o is UpdateEndpointWeightsAndCapacitiesInput {
-    return _smithy.isa(o, "UpdateEndpointWeightsAndCapacitiesInput");
+    return __isa(o, "UpdateEndpointWeightsAndCapacitiesInput");
   }
 }
 
@@ -18569,7 +18567,7 @@ export interface UpdateEndpointWeightsAndCapacitiesOutput
 
 export namespace UpdateEndpointWeightsAndCapacitiesOutput {
   export function isa(o: any): o is UpdateEndpointWeightsAndCapacitiesOutput {
-    return _smithy.isa(o, "UpdateEndpointWeightsAndCapacitiesOutput");
+    return __isa(o, "UpdateEndpointWeightsAndCapacitiesOutput");
   }
 }
 
@@ -18595,7 +18593,7 @@ export interface UpdateExperimentRequest {
 
 export namespace UpdateExperimentRequest {
   export function isa(o: any): o is UpdateExperimentRequest {
-    return _smithy.isa(o, "UpdateExperimentRequest");
+    return __isa(o, "UpdateExperimentRequest");
   }
 }
 
@@ -18609,7 +18607,7 @@ export interface UpdateExperimentResponse extends $MetadataBearer {
 
 export namespace UpdateExperimentResponse {
   export function isa(o: any): o is UpdateExperimentResponse {
-    return _smithy.isa(o, "UpdateExperimentResponse");
+    return __isa(o, "UpdateExperimentResponse");
   }
 }
 
@@ -18630,7 +18628,7 @@ export interface UpdateMonitoringScheduleRequest {
 
 export namespace UpdateMonitoringScheduleRequest {
   export function isa(o: any): o is UpdateMonitoringScheduleRequest {
-    return _smithy.isa(o, "UpdateMonitoringScheduleRequest");
+    return __isa(o, "UpdateMonitoringScheduleRequest");
   }
 }
 
@@ -18644,7 +18642,7 @@ export interface UpdateMonitoringScheduleResponse extends $MetadataBearer {
 
 export namespace UpdateMonitoringScheduleResponse {
   export function isa(o: any): o is UpdateMonitoringScheduleResponse {
-    return _smithy.isa(o, "UpdateMonitoringScheduleResponse");
+    return __isa(o, "UpdateMonitoringScheduleResponse");
   }
 }
 
@@ -18760,7 +18758,7 @@ export interface UpdateNotebookInstanceInput {
 
 export namespace UpdateNotebookInstanceInput {
   export function isa(o: any): o is UpdateNotebookInstanceInput {
-    return _smithy.isa(o, "UpdateNotebookInstanceInput");
+    return __isa(o, "UpdateNotebookInstanceInput");
   }
 }
 
@@ -18787,7 +18785,7 @@ export interface UpdateNotebookInstanceLifecycleConfigInput {
 
 export namespace UpdateNotebookInstanceLifecycleConfigInput {
   export function isa(o: any): o is UpdateNotebookInstanceLifecycleConfigInput {
-    return _smithy.isa(o, "UpdateNotebookInstanceLifecycleConfigInput");
+    return __isa(o, "UpdateNotebookInstanceLifecycleConfigInput");
   }
 }
 
@@ -18800,7 +18798,7 @@ export namespace UpdateNotebookInstanceLifecycleConfigOutput {
   export function isa(
     o: any
   ): o is UpdateNotebookInstanceLifecycleConfigOutput {
-    return _smithy.isa(o, "UpdateNotebookInstanceLifecycleConfigOutput");
+    return __isa(o, "UpdateNotebookInstanceLifecycleConfigOutput");
   }
 }
 
@@ -18810,7 +18808,7 @@ export interface UpdateNotebookInstanceOutput extends $MetadataBearer {
 
 export namespace UpdateNotebookInstanceOutput {
   export function isa(o: any): o is UpdateNotebookInstanceOutput {
-    return _smithy.isa(o, "UpdateNotebookInstanceOutput");
+    return __isa(o, "UpdateNotebookInstanceOutput");
   }
 }
 
@@ -18876,7 +18874,7 @@ export interface UpdateTrialComponentRequest {
 
 export namespace UpdateTrialComponentRequest {
   export function isa(o: any): o is UpdateTrialComponentRequest {
-    return _smithy.isa(o, "UpdateTrialComponentRequest");
+    return __isa(o, "UpdateTrialComponentRequest");
   }
 }
 
@@ -18890,7 +18888,7 @@ export interface UpdateTrialComponentResponse extends $MetadataBearer {
 
 export namespace UpdateTrialComponentResponse {
   export function isa(o: any): o is UpdateTrialComponentResponse {
-    return _smithy.isa(o, "UpdateTrialComponentResponse");
+    return __isa(o, "UpdateTrialComponentResponse");
   }
 }
 
@@ -18911,7 +18909,7 @@ export interface UpdateTrialRequest {
 
 export namespace UpdateTrialRequest {
   export function isa(o: any): o is UpdateTrialRequest {
-    return _smithy.isa(o, "UpdateTrialRequest");
+    return __isa(o, "UpdateTrialRequest");
   }
 }
 
@@ -18925,7 +18923,7 @@ export interface UpdateTrialResponse extends $MetadataBearer {
 
 export namespace UpdateTrialResponse {
   export function isa(o: any): o is UpdateTrialResponse {
-    return _smithy.isa(o, "UpdateTrialResponse");
+    return __isa(o, "UpdateTrialResponse");
   }
 }
 
@@ -18949,7 +18947,7 @@ export interface UpdateUserProfileRequest {
 
 export namespace UpdateUserProfileRequest {
   export function isa(o: any): o is UpdateUserProfileRequest {
-    return _smithy.isa(o, "UpdateUserProfileRequest");
+    return __isa(o, "UpdateUserProfileRequest");
   }
 }
 
@@ -18963,7 +18961,7 @@ export interface UpdateUserProfileResponse extends $MetadataBearer {
 
 export namespace UpdateUserProfileResponse {
   export function isa(o: any): o is UpdateUserProfileResponse {
-    return _smithy.isa(o, "UpdateUserProfileResponse");
+    return __isa(o, "UpdateUserProfileResponse");
   }
 }
 
@@ -18986,7 +18984,7 @@ export interface UpdateWorkforceRequest {
 
 export namespace UpdateWorkforceRequest {
   export function isa(o: any): o is UpdateWorkforceRequest {
-    return _smithy.isa(o, "UpdateWorkforceRequest");
+    return __isa(o, "UpdateWorkforceRequest");
   }
 }
 
@@ -19003,7 +19001,7 @@ export interface UpdateWorkforceResponse extends $MetadataBearer {
 
 export namespace UpdateWorkforceResponse {
   export function isa(o: any): o is UpdateWorkforceResponse {
-    return _smithy.isa(o, "UpdateWorkforceResponse");
+    return __isa(o, "UpdateWorkforceResponse");
   }
 }
 
@@ -19033,7 +19031,7 @@ export interface UpdateWorkteamRequest {
 
 export namespace UpdateWorkteamRequest {
   export function isa(o: any): o is UpdateWorkteamRequest {
-    return _smithy.isa(o, "UpdateWorkteamRequest");
+    return __isa(o, "UpdateWorkteamRequest");
   }
 }
 
@@ -19047,7 +19045,7 @@ export interface UpdateWorkteamResponse extends $MetadataBearer {
 
 export namespace UpdateWorkteamResponse {
   export function isa(o: any): o is UpdateWorkteamResponse {
-    return _smithy.isa(o, "UpdateWorkteamResponse");
+    return __isa(o, "UpdateWorkteamResponse");
   }
 }
 
@@ -19075,7 +19073,7 @@ export interface UserContext {
 
 export namespace UserContext {
   export function isa(o: any): o is UserContext {
-    return _smithy.isa(o, "UserContext");
+    return __isa(o, "UserContext");
   }
 }
 
@@ -19112,7 +19110,7 @@ export interface UserProfileDetails {
 
 export namespace UserProfileDetails {
   export function isa(o: any): o is UserProfileDetails {
-    return _smithy.isa(o, "UserProfileDetails");
+    return __isa(o, "UserProfileDetails");
   }
 }
 
@@ -19166,7 +19164,7 @@ export interface UserSettings {
 
 export namespace UserSettings {
   export function isa(o: any): o is UserSettings {
-    return _smithy.isa(o, "UserSettings");
+    return __isa(o, "UserSettings");
   }
 }
 
@@ -19199,7 +19197,7 @@ export interface VpcConfig {
 
 export namespace VpcConfig {
   export function isa(o: any): o is VpcConfig {
-    return _smithy.isa(o, "VpcConfig");
+    return __isa(o, "VpcConfig");
   }
 }
 
@@ -19239,7 +19237,7 @@ export interface Workforce {
 
 export namespace Workforce {
   export function isa(o: any): o is Workforce {
-    return _smithy.isa(o, "Workforce");
+    return __isa(o, "Workforce");
   }
 }
 
@@ -19298,6 +19296,6 @@ export interface Workteam {
 
 export namespace Workteam {
   export function isa(o: any): o is Workteam {
-    return _smithy.isa(o, "Workteam");
+    return __isa(o, "Workteam");
   }
 }

--- a/clients/client-sagemaker/protocols/Aws_json1_1.ts
+++ b/clients/client-sagemaker/protocols/Aws_json1_1.ts
@@ -995,7 +995,10 @@ import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  LazyJsonString as __LazyJsonString,
+  SmithyException as __SmithyException
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -4641,6 +4644,7 @@ export async function deserializeAws_json1_1DeleteAlgorithmCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1DeleteAlgorithmCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteAlgorithmCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -4685,6 +4689,7 @@ export async function deserializeAws_json1_1DeleteAppCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1DeleteAppCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteAppCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -4746,6 +4751,7 @@ export async function deserializeAws_json1_1DeleteCodeRepositoryCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteCodeRepositoryCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -4790,6 +4796,7 @@ export async function deserializeAws_json1_1DeleteDomainCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1DeleteDomainCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteDomainCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -4848,6 +4855,7 @@ export async function deserializeAws_json1_1DeleteEndpointCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1DeleteEndpointCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteEndpointCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -4895,6 +4903,7 @@ export async function deserializeAws_json1_1DeleteEndpointConfigCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteEndpointConfigCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -5054,6 +5063,7 @@ export async function deserializeAws_json1_1DeleteModelCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1DeleteModelCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteModelCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -5101,6 +5111,7 @@ export async function deserializeAws_json1_1DeleteModelPackageCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteModelPackageCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -5148,6 +5159,7 @@ export async function deserializeAws_json1_1DeleteMonitoringScheduleCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteMonitoringScheduleCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -5202,6 +5214,7 @@ export async function deserializeAws_json1_1DeleteNotebookInstanceCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteNotebookInstanceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -5249,6 +5262,7 @@ export async function deserializeAws_json1_1DeleteNotebookInstanceLifecycleConfi
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteNotebookInstanceLifecycleConfigCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -5457,6 +5471,7 @@ export async function deserializeAws_json1_1DeleteUserProfileCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1DeleteUserProfileCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteUserProfileCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -8922,6 +8937,7 @@ export async function deserializeAws_json1_1StartMonitoringScheduleCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: StartMonitoringScheduleCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -8976,6 +8992,7 @@ export async function deserializeAws_json1_1StartNotebookInstanceCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: StartNotebookInstanceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -9027,6 +9044,7 @@ export async function deserializeAws_json1_1StopAutoMLJobCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1StopAutoMLJobCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: StopAutoMLJobCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -9081,6 +9099,7 @@ export async function deserializeAws_json1_1StopCompilationJobCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: StopCompilationJobCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -9135,6 +9154,7 @@ export async function deserializeAws_json1_1StopHyperParameterTuningJobCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: StopHyperParameterTuningJobCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -9186,6 +9206,7 @@ export async function deserializeAws_json1_1StopLabelingJobCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1StopLabelingJobCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: StopLabelingJobCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -9240,6 +9261,7 @@ export async function deserializeAws_json1_1StopMonitoringScheduleCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: StopMonitoringScheduleCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -9294,6 +9316,7 @@ export async function deserializeAws_json1_1StopNotebookInstanceCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: StopNotebookInstanceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -9338,6 +9361,7 @@ export async function deserializeAws_json1_1StopProcessingJobCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1StopProcessingJobCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: StopProcessingJobCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -9389,6 +9413,7 @@ export async function deserializeAws_json1_1StopTrainingJobCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1StopTrainingJobCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: StopTrainingJobCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -9440,6 +9465,7 @@ export async function deserializeAws_json1_1StopTransformJobCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1StopTransformJobCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: StopTransformJobCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -12924,8 +12950,9 @@ const serializeAws_json1_1HumanLoopActivationConditionsConfig = (
 ): any => {
   const bodyParams: any = {};
   if (input.HumanLoopActivationConditions !== undefined) {
-    bodyParams["HumanLoopActivationConditions"] =
-      input.HumanLoopActivationConditions;
+    bodyParams["HumanLoopActivationConditions"] = __LazyJsonString.fromObject(
+      input.HumanLoopActivationConditions
+    );
   }
   return bodyParams;
 };
@@ -21940,8 +21967,9 @@ const deserializeAws_json1_1HumanLoopActivationConditionsConfig = (
     output.HumanLoopActivationConditions !== undefined &&
     output.HumanLoopActivationConditions !== null
   ) {
-    contents.HumanLoopActivationConditions =
-      output.HumanLoopActivationConditions;
+    contents.HumanLoopActivationConditions = new __LazyJsonString(
+      output.HumanLoopActivationConditions
+    );
   }
   return contents;
 };

--- a/clients/client-savingsplans/models/index.ts
+++ b/clients/client-savingsplans/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export interface DescribeSavingsPlansOfferingRatesRequest {
@@ -57,7 +60,7 @@ export interface DescribeSavingsPlansOfferingRatesRequest {
 
 export namespace DescribeSavingsPlansOfferingRatesRequest {
   export function isa(o: any): o is DescribeSavingsPlansOfferingRatesRequest {
-    return _smithy.isa(o, "DescribeSavingsPlansOfferingRatesRequest");
+    return __isa(o, "DescribeSavingsPlansOfferingRatesRequest");
   }
 }
 
@@ -78,7 +81,7 @@ export interface DescribeSavingsPlansOfferingRatesResponse
 
 export namespace DescribeSavingsPlansOfferingRatesResponse {
   export function isa(o: any): o is DescribeSavingsPlansOfferingRatesResponse {
-    return _smithy.isa(o, "DescribeSavingsPlansOfferingRatesResponse");
+    return __isa(o, "DescribeSavingsPlansOfferingRatesResponse");
   }
 }
 
@@ -153,7 +156,7 @@ export interface DescribeSavingsPlansOfferingsRequest {
 
 export namespace DescribeSavingsPlansOfferingsRequest {
   export function isa(o: any): o is DescribeSavingsPlansOfferingsRequest {
-    return _smithy.isa(o, "DescribeSavingsPlansOfferingsRequest");
+    return __isa(o, "DescribeSavingsPlansOfferingsRequest");
   }
 }
 
@@ -173,7 +176,7 @@ export interface DescribeSavingsPlansOfferingsResponse extends $MetadataBearer {
 
 export namespace DescribeSavingsPlansOfferingsResponse {
   export function isa(o: any): o is DescribeSavingsPlansOfferingsResponse {
-    return _smithy.isa(o, "DescribeSavingsPlansOfferingsResponse");
+    return __isa(o, "DescribeSavingsPlansOfferingsResponse");
   }
 }
 
@@ -215,7 +218,7 @@ export interface ParentSavingsPlanOffering {
 
 export namespace ParentSavingsPlanOffering {
   export function isa(o: any): o is ParentSavingsPlanOffering {
-    return _smithy.isa(o, "ParentSavingsPlanOffering");
+    return __isa(o, "ParentSavingsPlanOffering");
   }
 }
 
@@ -282,7 +285,7 @@ export interface SavingsPlanOffering {
 
 export namespace SavingsPlanOffering {
   export function isa(o: any): o is SavingsPlanOffering {
-    return _smithy.isa(o, "SavingsPlanOffering");
+    return __isa(o, "SavingsPlanOffering");
   }
 }
 
@@ -309,7 +312,7 @@ export interface SavingsPlanOfferingFilterElement {
 
 export namespace SavingsPlanOfferingFilterElement {
   export function isa(o: any): o is SavingsPlanOfferingFilterElement {
-    return _smithy.isa(o, "SavingsPlanOfferingFilterElement");
+    return __isa(o, "SavingsPlanOfferingFilterElement");
   }
 }
 
@@ -331,7 +334,7 @@ export interface SavingsPlanOfferingProperty {
 
 export namespace SavingsPlanOfferingProperty {
   export function isa(o: any): o is SavingsPlanOfferingProperty {
-    return _smithy.isa(o, "SavingsPlanOfferingProperty");
+    return __isa(o, "SavingsPlanOfferingProperty");
   }
 }
 
@@ -388,7 +391,7 @@ export interface SavingsPlanOfferingRate {
 
 export namespace SavingsPlanOfferingRate {
   export function isa(o: any): o is SavingsPlanOfferingRate {
-    return _smithy.isa(o, "SavingsPlanOfferingRate");
+    return __isa(o, "SavingsPlanOfferingRate");
   }
 }
 
@@ -410,7 +413,7 @@ export interface SavingsPlanOfferingRateFilterElement {
 
 export namespace SavingsPlanOfferingRateFilterElement {
   export function isa(o: any): o is SavingsPlanOfferingRateFilterElement {
-    return _smithy.isa(o, "SavingsPlanOfferingRateFilterElement");
+    return __isa(o, "SavingsPlanOfferingRateFilterElement");
   }
 }
 
@@ -432,7 +435,7 @@ export interface SavingsPlanOfferingRateProperty {
 
 export namespace SavingsPlanOfferingRateProperty {
   export function isa(o: any): o is SavingsPlanOfferingRateProperty {
-    return _smithy.isa(o, "SavingsPlanOfferingRateProperty");
+    return __isa(o, "SavingsPlanOfferingRateProperty");
   }
 }
 
@@ -480,7 +483,7 @@ export interface SavingsPlanRateProperty {
 
 export namespace SavingsPlanRateProperty {
   export function isa(o: any): o is SavingsPlanRateProperty {
-    return _smithy.isa(o, "SavingsPlanRateProperty");
+    return __isa(o, "SavingsPlanRateProperty");
   }
 }
 
@@ -534,7 +537,7 @@ export interface CreateSavingsPlanRequest {
 
 export namespace CreateSavingsPlanRequest {
   export function isa(o: any): o is CreateSavingsPlanRequest {
-    return _smithy.isa(o, "CreateSavingsPlanRequest");
+    return __isa(o, "CreateSavingsPlanRequest");
   }
 }
 
@@ -548,7 +551,7 @@ export interface CreateSavingsPlanResponse extends $MetadataBearer {
 
 export namespace CreateSavingsPlanResponse {
   export function isa(o: any): o is CreateSavingsPlanResponse {
-    return _smithy.isa(o, "CreateSavingsPlanResponse");
+    return __isa(o, "CreateSavingsPlanResponse");
   }
 }
 
@@ -578,7 +581,7 @@ export interface DescribeSavingsPlanRatesRequest {
 
 export namespace DescribeSavingsPlanRatesRequest {
   export function isa(o: any): o is DescribeSavingsPlanRatesRequest {
-    return _smithy.isa(o, "DescribeSavingsPlanRatesRequest");
+    return __isa(o, "DescribeSavingsPlanRatesRequest");
   }
 }
 
@@ -603,7 +606,7 @@ export interface DescribeSavingsPlanRatesResponse extends $MetadataBearer {
 
 export namespace DescribeSavingsPlanRatesResponse {
   export function isa(o: any): o is DescribeSavingsPlanRatesResponse {
-    return _smithy.isa(o, "DescribeSavingsPlanRatesResponse");
+    return __isa(o, "DescribeSavingsPlanRatesResponse");
   }
 }
 
@@ -643,7 +646,7 @@ export interface DescribeSavingsPlansRequest {
 
 export namespace DescribeSavingsPlansRequest {
   export function isa(o: any): o is DescribeSavingsPlansRequest {
-    return _smithy.isa(o, "DescribeSavingsPlansRequest");
+    return __isa(o, "DescribeSavingsPlansRequest");
   }
 }
 
@@ -663,7 +666,7 @@ export interface DescribeSavingsPlansResponse extends $MetadataBearer {
 
 export namespace DescribeSavingsPlansResponse {
   export function isa(o: any): o is DescribeSavingsPlansResponse {
-    return _smithy.isa(o, "DescribeSavingsPlansResponse");
+    return __isa(o, "DescribeSavingsPlansResponse");
   }
 }
 
@@ -671,7 +674,7 @@ export namespace DescribeSavingsPlansResponse {
  * <p>An unexpected error occurred.</p>
  */
 export interface InternalServerException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalServerException";
   $fault: "server";
@@ -680,7 +683,7 @@ export interface InternalServerException
 
 export namespace InternalServerException {
   export function isa(o: any): o is InternalServerException {
-    return _smithy.isa(o, "InternalServerException");
+    return __isa(o, "InternalServerException");
   }
 }
 
@@ -694,7 +697,7 @@ export interface ListTagsForResourceRequest {
 
 export namespace ListTagsForResourceRequest {
   export function isa(o: any): o is ListTagsForResourceRequest {
-    return _smithy.isa(o, "ListTagsForResourceRequest");
+    return __isa(o, "ListTagsForResourceRequest");
   }
 }
 
@@ -708,7 +711,7 @@ export interface ListTagsForResourceResponse extends $MetadataBearer {
 
 export namespace ListTagsForResourceResponse {
   export function isa(o: any): o is ListTagsForResourceResponse {
-    return _smithy.isa(o, "ListTagsForResourceResponse");
+    return __isa(o, "ListTagsForResourceResponse");
   }
 }
 
@@ -716,7 +719,7 @@ export namespace ListTagsForResourceResponse {
  * <p>The specified resource was not found.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -725,7 +728,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -827,7 +830,7 @@ export interface SavingsPlan {
 
 export namespace SavingsPlan {
   export function isa(o: any): o is SavingsPlan {
-    return _smithy.isa(o, "SavingsPlan");
+    return __isa(o, "SavingsPlan");
   }
 }
 
@@ -849,7 +852,7 @@ export interface SavingsPlanFilter {
 
 export namespace SavingsPlanFilter {
   export function isa(o: any): o is SavingsPlanFilter {
-    return _smithy.isa(o, "SavingsPlanFilter");
+    return __isa(o, "SavingsPlanFilter");
   }
 }
 
@@ -901,7 +904,7 @@ export interface SavingsPlanRate {
 
 export namespace SavingsPlanRate {
   export function isa(o: any): o is SavingsPlanRate {
-    return _smithy.isa(o, "SavingsPlanRate");
+    return __isa(o, "SavingsPlanRate");
   }
 }
 
@@ -923,7 +926,7 @@ export interface SavingsPlanRateFilter {
 
 export namespace SavingsPlanRateFilter {
   export function isa(o: any): o is SavingsPlanRateFilter {
-    return _smithy.isa(o, "SavingsPlanRateFilter");
+    return __isa(o, "SavingsPlanRateFilter");
   }
 }
 
@@ -961,7 +964,7 @@ export enum SavingsPlansFilterName {
  * <p>A service quota has been exceeded.</p>
  */
 export interface ServiceQuotaExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ServiceQuotaExceededException";
   $fault: "client";
@@ -970,7 +973,7 @@ export interface ServiceQuotaExceededException
 
 export namespace ServiceQuotaExceededException {
   export function isa(o: any): o is ServiceQuotaExceededException {
-    return _smithy.isa(o, "ServiceQuotaExceededException");
+    return __isa(o, "ServiceQuotaExceededException");
   }
 }
 
@@ -989,7 +992,7 @@ export interface TagResourceRequest {
 
 export namespace TagResourceRequest {
   export function isa(o: any): o is TagResourceRequest {
-    return _smithy.isa(o, "TagResourceRequest");
+    return __isa(o, "TagResourceRequest");
   }
 }
 
@@ -999,7 +1002,7 @@ export interface TagResourceResponse extends $MetadataBearer {
 
 export namespace TagResourceResponse {
   export function isa(o: any): o is TagResourceResponse {
-    return _smithy.isa(o, "TagResourceResponse");
+    return __isa(o, "TagResourceResponse");
   }
 }
 
@@ -1018,7 +1021,7 @@ export interface UntagResourceRequest {
 
 export namespace UntagResourceRequest {
   export function isa(o: any): o is UntagResourceRequest {
-    return _smithy.isa(o, "UntagResourceRequest");
+    return __isa(o, "UntagResourceRequest");
   }
 }
 
@@ -1028,7 +1031,7 @@ export interface UntagResourceResponse extends $MetadataBearer {
 
 export namespace UntagResourceResponse {
   export function isa(o: any): o is UntagResourceResponse {
-    return _smithy.isa(o, "UntagResourceResponse");
+    return __isa(o, "UntagResourceResponse");
   }
 }
 
@@ -1036,7 +1039,7 @@ export namespace UntagResourceResponse {
  * <p>One of the input parameters is not valid.</p>
  */
 export interface ValidationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ValidationException";
   $fault: "client";
@@ -1045,6 +1048,6 @@ export interface ValidationException
 
 export namespace ValidationException {
   export function isa(o: any): o is ValidationException {
-    return _smithy.isa(o, "ValidationException");
+    return __isa(o, "ValidationException");
   }
 }

--- a/clients/client-savingsplans/protocols/Aws_restJson1_1.ts
+++ b/clients/client-savingsplans/protocols/Aws_restJson1_1.ts
@@ -893,6 +893,7 @@ export async function deserializeAws_restJson1_1TagResourceCommand(
     $metadata: deserializeMetadata(output),
     __type: "TagResourceResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -962,6 +963,7 @@ export async function deserializeAws_restJson1_1UntagResourceCommand(
     $metadata: deserializeMetadata(output),
     __type: "UntagResourceResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 

--- a/clients/client-schemas/models/index.ts
+++ b/clients/client-schemas/models/index.ts
@@ -1,8 +1,11 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export interface BadRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "BadRequestException";
   $fault: "client";
@@ -19,7 +22,7 @@ export interface BadRequestException
 
 export namespace BadRequestException {
   export function isa(o: any): o is BadRequestException {
-    return _smithy.isa(o, "BadRequestException");
+    return __isa(o, "BadRequestException");
   }
 }
 
@@ -29,9 +32,7 @@ export enum CodeGenerationStatus {
   CREATE_IN_PROGRESS = "CREATE_IN_PROGRESS"
 }
 
-export interface ConflictException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface ConflictException extends __SmithyException, $MetadataBearer {
   name: "ConflictException";
   $fault: "client";
   /**
@@ -47,7 +48,7 @@ export interface ConflictException
 
 export namespace ConflictException {
   export function isa(o: any): o is ConflictException {
-    return _smithy.isa(o, "ConflictException");
+    return __isa(o, "ConflictException");
   }
 }
 
@@ -71,7 +72,7 @@ export interface CreateDiscovererRequest {
 
 export namespace CreateDiscovererRequest {
   export function isa(o: any): o is CreateDiscovererRequest {
-    return _smithy.isa(o, "CreateDiscovererRequest");
+    return __isa(o, "CreateDiscovererRequest");
   }
 }
 
@@ -110,7 +111,7 @@ export interface CreateDiscovererResponse extends $MetadataBearer {
 
 export namespace CreateDiscovererResponse {
   export function isa(o: any): o is CreateDiscovererResponse {
-    return _smithy.isa(o, "CreateDiscovererResponse");
+    return __isa(o, "CreateDiscovererResponse");
   }
 }
 
@@ -130,7 +131,7 @@ export interface CreateRegistryRequest {
 
 export namespace CreateRegistryRequest {
   export function isa(o: any): o is CreateRegistryRequest {
-    return _smithy.isa(o, "CreateRegistryRequest");
+    return __isa(o, "CreateRegistryRequest");
   }
 }
 
@@ -159,7 +160,7 @@ export interface CreateRegistryResponse extends $MetadataBearer {
 
 export namespace CreateRegistryResponse {
   export function isa(o: any): o is CreateRegistryResponse {
-    return _smithy.isa(o, "CreateRegistryResponse");
+    return __isa(o, "CreateRegistryResponse");
   }
 }
 
@@ -183,7 +184,7 @@ export interface CreateSchemaRequest {
 
 export namespace CreateSchemaRequest {
   export function isa(o: any): o is CreateSchemaRequest {
-    return _smithy.isa(o, "CreateSchemaRequest");
+    return __isa(o, "CreateSchemaRequest");
   }
 }
 
@@ -232,7 +233,7 @@ export interface CreateSchemaResponse extends $MetadataBearer {
 
 export namespace CreateSchemaResponse {
   export function isa(o: any): o is CreateSchemaResponse {
-    return _smithy.isa(o, "CreateSchemaResponse");
+    return __isa(o, "CreateSchemaResponse");
   }
 }
 
@@ -243,7 +244,7 @@ export interface DeleteDiscovererRequest {
 
 export namespace DeleteDiscovererRequest {
   export function isa(o: any): o is DeleteDiscovererRequest {
-    return _smithy.isa(o, "DeleteDiscovererRequest");
+    return __isa(o, "DeleteDiscovererRequest");
   }
 }
 
@@ -254,7 +255,7 @@ export interface DeleteRegistryRequest {
 
 export namespace DeleteRegistryRequest {
   export function isa(o: any): o is DeleteRegistryRequest {
-    return _smithy.isa(o, "DeleteRegistryRequest");
+    return __isa(o, "DeleteRegistryRequest");
   }
 }
 
@@ -266,7 +267,7 @@ export interface DeleteSchemaRequest {
 
 export namespace DeleteSchemaRequest {
   export function isa(o: any): o is DeleteSchemaRequest {
-    return _smithy.isa(o, "DeleteSchemaRequest");
+    return __isa(o, "DeleteSchemaRequest");
   }
 }
 
@@ -279,7 +280,7 @@ export interface DeleteSchemaVersionRequest {
 
 export namespace DeleteSchemaVersionRequest {
   export function isa(o: any): o is DeleteSchemaVersionRequest {
-    return _smithy.isa(o, "DeleteSchemaVersionRequest");
+    return __isa(o, "DeleteSchemaVersionRequest");
   }
 }
 
@@ -293,7 +294,7 @@ export interface DescribeCodeBindingRequest {
 
 export namespace DescribeCodeBindingRequest {
   export function isa(o: any): o is DescribeCodeBindingRequest {
-    return _smithy.isa(o, "DescribeCodeBindingRequest");
+    return __isa(o, "DescribeCodeBindingRequest");
   }
 }
 
@@ -322,7 +323,7 @@ export interface DescribeCodeBindingResponse extends $MetadataBearer {
 
 export namespace DescribeCodeBindingResponse {
   export function isa(o: any): o is DescribeCodeBindingResponse {
-    return _smithy.isa(o, "DescribeCodeBindingResponse");
+    return __isa(o, "DescribeCodeBindingResponse");
   }
 }
 
@@ -333,7 +334,7 @@ export interface DescribeDiscovererRequest {
 
 export namespace DescribeDiscovererRequest {
   export function isa(o: any): o is DescribeDiscovererRequest {
-    return _smithy.isa(o, "DescribeDiscovererRequest");
+    return __isa(o, "DescribeDiscovererRequest");
   }
 }
 
@@ -372,7 +373,7 @@ export interface DescribeDiscovererResponse extends $MetadataBearer {
 
 export namespace DescribeDiscovererResponse {
   export function isa(o: any): o is DescribeDiscovererResponse {
-    return _smithy.isa(o, "DescribeDiscovererResponse");
+    return __isa(o, "DescribeDiscovererResponse");
   }
 }
 
@@ -383,7 +384,7 @@ export interface DescribeRegistryRequest {
 
 export namespace DescribeRegistryRequest {
   export function isa(o: any): o is DescribeRegistryRequest {
-    return _smithy.isa(o, "DescribeRegistryRequest");
+    return __isa(o, "DescribeRegistryRequest");
   }
 }
 
@@ -412,7 +413,7 @@ export interface DescribeRegistryResponse extends $MetadataBearer {
 
 export namespace DescribeRegistryResponse {
   export function isa(o: any): o is DescribeRegistryResponse {
-    return _smithy.isa(o, "DescribeRegistryResponse");
+    return __isa(o, "DescribeRegistryResponse");
   }
 }
 
@@ -425,7 +426,7 @@ export interface DescribeSchemaRequest {
 
 export namespace DescribeSchemaRequest {
   export function isa(o: any): o is DescribeSchemaRequest {
-    return _smithy.isa(o, "DescribeSchemaRequest");
+    return __isa(o, "DescribeSchemaRequest");
   }
 }
 
@@ -475,7 +476,7 @@ export interface DescribeSchemaResponse extends $MetadataBearer {
 
 export namespace DescribeSchemaResponse {
   export function isa(o: any): o is DescribeSchemaResponse {
-    return _smithy.isa(o, "DescribeSchemaResponse");
+    return __isa(o, "DescribeSchemaResponse");
   }
 }
 
@@ -510,13 +511,11 @@ export interface DiscovererSummary {
 
 export namespace DiscovererSummary {
   export function isa(o: any): o is DiscovererSummary {
-    return _smithy.isa(o, "DiscovererSummary");
+    return __isa(o, "DiscovererSummary");
   }
 }
 
-export interface ForbiddenException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface ForbiddenException extends __SmithyException, $MetadataBearer {
   name: "ForbiddenException";
   $fault: "client";
   /**
@@ -532,7 +531,7 @@ export interface ForbiddenException
 
 export namespace ForbiddenException {
   export function isa(o: any): o is ForbiddenException {
-    return _smithy.isa(o, "ForbiddenException");
+    return __isa(o, "ForbiddenException");
   }
 }
 
@@ -546,7 +545,7 @@ export interface GetCodeBindingSourceRequest {
 
 export namespace GetCodeBindingSourceRequest {
   export function isa(o: any): o is GetCodeBindingSourceRequest {
-    return _smithy.isa(o, "GetCodeBindingSourceRequest");
+    return __isa(o, "GetCodeBindingSourceRequest");
   }
 }
 
@@ -557,7 +556,7 @@ export interface GetCodeBindingSourceResponse extends $MetadataBearer {
 
 export namespace GetCodeBindingSourceResponse {
   export function isa(o: any): o is GetCodeBindingSourceResponse {
-    return _smithy.isa(o, "GetCodeBindingSourceResponse");
+    return __isa(o, "GetCodeBindingSourceResponse");
   }
 }
 
@@ -576,7 +575,7 @@ export interface GetDiscoveredSchemaRequest {
 
 export namespace GetDiscoveredSchemaRequest {
   export function isa(o: any): o is GetDiscoveredSchemaRequest {
-    return _smithy.isa(o, "GetDiscoveredSchemaRequest");
+    return __isa(o, "GetDiscoveredSchemaRequest");
   }
 }
 
@@ -587,13 +586,11 @@ export interface GetDiscoveredSchemaResponse extends $MetadataBearer {
 
 export namespace GetDiscoveredSchemaResponse {
   export function isa(o: any): o is GetDiscoveredSchemaResponse {
-    return _smithy.isa(o, "GetDiscoveredSchemaResponse");
+    return __isa(o, "GetDiscoveredSchemaResponse");
   }
 }
 
-export interface GoneException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface GoneException extends __SmithyException, $MetadataBearer {
   name: "GoneException";
   $fault: "client";
   /**
@@ -609,12 +606,12 @@ export interface GoneException
 
 export namespace GoneException {
   export function isa(o: any): o is GoneException {
-    return _smithy.isa(o, "GoneException");
+    return __isa(o, "GoneException");
   }
 }
 
 export interface InternalServerErrorException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalServerErrorException";
   $fault: "server";
@@ -631,7 +628,7 @@ export interface InternalServerErrorException
 
 export namespace InternalServerErrorException {
   export function isa(o: any): o is InternalServerErrorException {
-    return _smithy.isa(o, "InternalServerErrorException");
+    return __isa(o, "InternalServerErrorException");
   }
 }
 
@@ -645,7 +642,7 @@ export interface ListDiscoverersRequest {
 
 export namespace ListDiscoverersRequest {
   export function isa(o: any): o is ListDiscoverersRequest {
-    return _smithy.isa(o, "ListDiscoverersRequest");
+    return __isa(o, "ListDiscoverersRequest");
   }
 }
 
@@ -664,7 +661,7 @@ export interface ListDiscoverersResponse extends $MetadataBearer {
 
 export namespace ListDiscoverersResponse {
   export function isa(o: any): o is ListDiscoverersResponse {
-    return _smithy.isa(o, "ListDiscoverersResponse");
+    return __isa(o, "ListDiscoverersResponse");
   }
 }
 
@@ -678,7 +675,7 @@ export interface ListRegistriesRequest {
 
 export namespace ListRegistriesRequest {
   export function isa(o: any): o is ListRegistriesRequest {
-    return _smithy.isa(o, "ListRegistriesRequest");
+    return __isa(o, "ListRegistriesRequest");
   }
 }
 
@@ -697,7 +694,7 @@ export interface ListRegistriesResponse extends $MetadataBearer {
 
 export namespace ListRegistriesResponse {
   export function isa(o: any): o is ListRegistriesResponse {
-    return _smithy.isa(o, "ListRegistriesResponse");
+    return __isa(o, "ListRegistriesResponse");
   }
 }
 
@@ -711,7 +708,7 @@ export interface ListSchemaVersionsRequest {
 
 export namespace ListSchemaVersionsRequest {
   export function isa(o: any): o is ListSchemaVersionsRequest {
-    return _smithy.isa(o, "ListSchemaVersionsRequest");
+    return __isa(o, "ListSchemaVersionsRequest");
   }
 }
 
@@ -730,7 +727,7 @@ export interface ListSchemaVersionsResponse extends $MetadataBearer {
 
 export namespace ListSchemaVersionsResponse {
   export function isa(o: any): o is ListSchemaVersionsResponse {
-    return _smithy.isa(o, "ListSchemaVersionsResponse");
+    return __isa(o, "ListSchemaVersionsResponse");
   }
 }
 
@@ -744,7 +741,7 @@ export interface ListSchemasRequest {
 
 export namespace ListSchemasRequest {
   export function isa(o: any): o is ListSchemasRequest {
-    return _smithy.isa(o, "ListSchemasRequest");
+    return __isa(o, "ListSchemasRequest");
   }
 }
 
@@ -763,7 +760,7 @@ export interface ListSchemasResponse extends $MetadataBearer {
 
 export namespace ListSchemasResponse {
   export function isa(o: any): o is ListSchemasResponse {
-    return _smithy.isa(o, "ListSchemasResponse");
+    return __isa(o, "ListSchemasResponse");
   }
 }
 
@@ -774,7 +771,7 @@ export interface ListTagsForResourceRequest {
 
 export namespace ListTagsForResourceRequest {
   export function isa(o: any): o is ListTagsForResourceRequest {
-    return _smithy.isa(o, "ListTagsForResourceRequest");
+    return __isa(o, "ListTagsForResourceRequest");
   }
 }
 
@@ -788,7 +785,7 @@ export interface ListTagsForResourceResponse extends $MetadataBearer {
 
 export namespace ListTagsForResourceResponse {
   export function isa(o: any): o is ListTagsForResourceResponse {
-    return _smithy.isa(o, "ListTagsForResourceResponse");
+    return __isa(o, "ListTagsForResourceResponse");
   }
 }
 
@@ -800,7 +797,7 @@ export interface LockServiceLinkedRoleRequest {
 
 export namespace LockServiceLinkedRoleRequest {
   export function isa(o: any): o is LockServiceLinkedRoleRequest {
-    return _smithy.isa(o, "LockServiceLinkedRoleRequest");
+    return __isa(o, "LockServiceLinkedRoleRequest");
   }
 }
 
@@ -813,13 +810,11 @@ export interface LockServiceLinkedRoleResponse extends $MetadataBearer {
 
 export namespace LockServiceLinkedRoleResponse {
   export function isa(o: any): o is LockServiceLinkedRoleResponse {
-    return _smithy.isa(o, "LockServiceLinkedRoleResponse");
+    return __isa(o, "LockServiceLinkedRoleResponse");
   }
 }
 
-export interface NotFoundException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface NotFoundException extends __SmithyException, $MetadataBearer {
   name: "NotFoundException";
   $fault: "client";
   /**
@@ -835,7 +830,7 @@ export interface NotFoundException
 
 export namespace NotFoundException {
   export function isa(o: any): o is NotFoundException {
-    return _smithy.isa(o, "NotFoundException");
+    return __isa(o, "NotFoundException");
   }
 }
 
@@ -849,7 +844,7 @@ export interface PutCodeBindingRequest {
 
 export namespace PutCodeBindingRequest {
   export function isa(o: any): o is PutCodeBindingRequest {
-    return _smithy.isa(o, "PutCodeBindingRequest");
+    return __isa(o, "PutCodeBindingRequest");
   }
 }
 
@@ -878,7 +873,7 @@ export interface PutCodeBindingResponse extends $MetadataBearer {
 
 export namespace PutCodeBindingResponse {
   export function isa(o: any): o is PutCodeBindingResponse {
-    return _smithy.isa(o, "PutCodeBindingResponse");
+    return __isa(o, "PutCodeBindingResponse");
   }
 }
 
@@ -902,7 +897,7 @@ export interface RegistrySummary {
 
 export namespace RegistrySummary {
   export function isa(o: any): o is RegistrySummary {
-    return _smithy.isa(o, "RegistrySummary");
+    return __isa(o, "RegistrySummary");
   }
 }
 
@@ -939,7 +934,7 @@ export interface SchemaSummary {
 
 export namespace SchemaSummary {
   export function isa(o: any): o is SchemaSummary {
-    return _smithy.isa(o, "SchemaSummary");
+    return __isa(o, "SchemaSummary");
   }
 }
 
@@ -963,7 +958,7 @@ export interface SchemaVersionSummary {
 
 export namespace SchemaVersionSummary {
   export function isa(o: any): o is SchemaVersionSummary {
-    return _smithy.isa(o, "SchemaVersionSummary");
+    return __isa(o, "SchemaVersionSummary");
   }
 }
 
@@ -992,7 +987,7 @@ export interface SearchSchemaSummary {
 
 export namespace SearchSchemaSummary {
   export function isa(o: any): o is SearchSchemaSummary {
-    return _smithy.isa(o, "SearchSchemaSummary");
+    return __isa(o, "SearchSchemaSummary");
   }
 }
 
@@ -1007,7 +1002,7 @@ export interface SearchSchemaVersionSummary {
 
 export namespace SearchSchemaVersionSummary {
   export function isa(o: any): o is SearchSchemaVersionSummary {
-    return _smithy.isa(o, "SearchSchemaVersionSummary");
+    return __isa(o, "SearchSchemaVersionSummary");
   }
 }
 
@@ -1021,7 +1016,7 @@ export interface SearchSchemasRequest {
 
 export namespace SearchSchemasRequest {
   export function isa(o: any): o is SearchSchemasRequest {
-    return _smithy.isa(o, "SearchSchemasRequest");
+    return __isa(o, "SearchSchemasRequest");
   }
 }
 
@@ -1040,12 +1035,12 @@ export interface SearchSchemasResponse extends $MetadataBearer {
 
 export namespace SearchSchemasResponse {
   export function isa(o: any): o is SearchSchemasResponse {
-    return _smithy.isa(o, "SearchSchemasResponse");
+    return __isa(o, "SearchSchemasResponse");
   }
 }
 
 export interface ServiceUnavailableException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ServiceUnavailableException";
   $fault: "server";
@@ -1062,7 +1057,7 @@ export interface ServiceUnavailableException
 
 export namespace ServiceUnavailableException {
   export function isa(o: any): o is ServiceUnavailableException {
-    return _smithy.isa(o, "ServiceUnavailableException");
+    return __isa(o, "ServiceUnavailableException");
   }
 }
 
@@ -1073,7 +1068,7 @@ export interface StartDiscovererRequest {
 
 export namespace StartDiscovererRequest {
   export function isa(o: any): o is StartDiscovererRequest {
-    return _smithy.isa(o, "StartDiscovererRequest");
+    return __isa(o, "StartDiscovererRequest");
   }
 }
 
@@ -1092,7 +1087,7 @@ export interface StartDiscovererResponse extends $MetadataBearer {
 
 export namespace StartDiscovererResponse {
   export function isa(o: any): o is StartDiscovererResponse {
-    return _smithy.isa(o, "StartDiscovererResponse");
+    return __isa(o, "StartDiscovererResponse");
   }
 }
 
@@ -1103,7 +1098,7 @@ export interface StopDiscovererRequest {
 
 export namespace StopDiscovererRequest {
   export function isa(o: any): o is StopDiscovererRequest {
-    return _smithy.isa(o, "StopDiscovererRequest");
+    return __isa(o, "StopDiscovererRequest");
   }
 }
 
@@ -1122,7 +1117,7 @@ export interface StopDiscovererResponse extends $MetadataBearer {
 
 export namespace StopDiscovererResponse {
   export function isa(o: any): o is StopDiscovererResponse {
-    return _smithy.isa(o, "StopDiscovererResponse");
+    return __isa(o, "StopDiscovererResponse");
   }
 }
 
@@ -1137,12 +1132,12 @@ export interface TagResourceRequest {
 
 export namespace TagResourceRequest {
   export function isa(o: any): o is TagResourceRequest {
-    return _smithy.isa(o, "TagResourceRequest");
+    return __isa(o, "TagResourceRequest");
   }
 }
 
 export interface TooManyRequestsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyRequestsException";
   $fault: "client";
@@ -1159,7 +1154,7 @@ export interface TooManyRequestsException
 
 export namespace TooManyRequestsException {
   export function isa(o: any): o is TooManyRequestsException {
-    return _smithy.isa(o, "TooManyRequestsException");
+    return __isa(o, "TooManyRequestsException");
   }
 }
 
@@ -1168,7 +1163,7 @@ export enum Type {
 }
 
 export interface UnauthorizedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UnauthorizedException";
   $fault: "client";
@@ -1185,7 +1180,7 @@ export interface UnauthorizedException
 
 export namespace UnauthorizedException {
   export function isa(o: any): o is UnauthorizedException {
-    return _smithy.isa(o, "UnauthorizedException");
+    return __isa(o, "UnauthorizedException");
   }
 }
 
@@ -1196,7 +1191,7 @@ export interface UnlockServiceLinkedRoleRequest {
 
 export namespace UnlockServiceLinkedRoleRequest {
   export function isa(o: any): o is UnlockServiceLinkedRoleRequest {
-    return _smithy.isa(o, "UnlockServiceLinkedRoleRequest");
+    return __isa(o, "UnlockServiceLinkedRoleRequest");
   }
 }
 
@@ -1206,7 +1201,7 @@ export interface UnlockServiceLinkedRoleResponse extends $MetadataBearer {
 
 export namespace UnlockServiceLinkedRoleResponse {
   export function isa(o: any): o is UnlockServiceLinkedRoleResponse {
-    return _smithy.isa(o, "UnlockServiceLinkedRoleResponse");
+    return __isa(o, "UnlockServiceLinkedRoleResponse");
   }
 }
 
@@ -1218,7 +1213,7 @@ export interface UntagResourceRequest {
 
 export namespace UntagResourceRequest {
   export function isa(o: any): o is UntagResourceRequest {
-    return _smithy.isa(o, "UntagResourceRequest");
+    return __isa(o, "UntagResourceRequest");
   }
 }
 
@@ -1234,7 +1229,7 @@ export interface UpdateDiscovererRequest {
 
 export namespace UpdateDiscovererRequest {
   export function isa(o: any): o is UpdateDiscovererRequest {
-    return _smithy.isa(o, "UpdateDiscovererRequest");
+    return __isa(o, "UpdateDiscovererRequest");
   }
 }
 
@@ -1273,7 +1268,7 @@ export interface UpdateDiscovererResponse extends $MetadataBearer {
 
 export namespace UpdateDiscovererResponse {
   export function isa(o: any): o is UpdateDiscovererResponse {
-    return _smithy.isa(o, "UpdateDiscovererResponse");
+    return __isa(o, "UpdateDiscovererResponse");
   }
 }
 
@@ -1289,7 +1284,7 @@ export interface UpdateRegistryRequest {
 
 export namespace UpdateRegistryRequest {
   export function isa(o: any): o is UpdateRegistryRequest {
-    return _smithy.isa(o, "UpdateRegistryRequest");
+    return __isa(o, "UpdateRegistryRequest");
   }
 }
 
@@ -1318,7 +1313,7 @@ export interface UpdateRegistryResponse extends $MetadataBearer {
 
 export namespace UpdateRegistryResponse {
   export function isa(o: any): o is UpdateRegistryResponse {
-    return _smithy.isa(o, "UpdateRegistryResponse");
+    return __isa(o, "UpdateRegistryResponse");
   }
 }
 
@@ -1349,7 +1344,7 @@ export interface UpdateSchemaRequest {
 
 export namespace UpdateSchemaRequest {
   export function isa(o: any): o is UpdateSchemaRequest {
-    return _smithy.isa(o, "UpdateSchemaRequest");
+    return __isa(o, "UpdateSchemaRequest");
   }
 }
 
@@ -1398,6 +1393,6 @@ export interface UpdateSchemaResponse extends $MetadataBearer {
 
 export namespace UpdateSchemaResponse {
   export function isa(o: any): o is UpdateSchemaResponse {
-    return _smithy.isa(o, "UpdateSchemaResponse");
+    return __isa(o, "UpdateSchemaResponse");
   }
 }

--- a/clients/client-schemas/protocols/Aws_restJson1_1.ts
+++ b/clients/client-schemas/protocols/Aws_restJson1_1.ts
@@ -135,7 +135,10 @@ import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  extendedEncodeURIComponent as __extendedEncodeURIComponent
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -181,7 +184,7 @@ export async function serializeAws_restJson1_1CreateRegistryCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v1/registries/name/{RegistryName}";
   if (input.RegistryName !== undefined) {
-    const labelValue: string = input.RegistryName.toString();
+    const labelValue: string = input.RegistryName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: RegistryName."
@@ -189,7 +192,7 @@ export async function serializeAws_restJson1_1CreateRegistryCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{RegistryName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: RegistryName.");
@@ -222,7 +225,7 @@ export async function serializeAws_restJson1_1CreateSchemaCommand(
   let resolvedPath =
     "/v1/registries/name/{RegistryName}/schemas/name/{SchemaName}";
   if (input.RegistryName !== undefined) {
-    const labelValue: string = input.RegistryName.toString();
+    const labelValue: string = input.RegistryName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: RegistryName."
@@ -230,19 +233,19 @@ export async function serializeAws_restJson1_1CreateSchemaCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{RegistryName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: RegistryName.");
   }
   if (input.SchemaName !== undefined) {
-    const labelValue: string = input.SchemaName.toString();
+    const labelValue: string = input.SchemaName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: SchemaName.");
     }
     resolvedPath = resolvedPath.replace(
       "{SchemaName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: SchemaName.");
@@ -280,7 +283,7 @@ export async function serializeAws_restJson1_1DeleteDiscovererCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/discoverers/id/{DiscovererId}";
   if (input.DiscovererId !== undefined) {
-    const labelValue: string = input.DiscovererId.toString();
+    const labelValue: string = input.DiscovererId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: DiscovererId."
@@ -288,7 +291,7 @@ export async function serializeAws_restJson1_1DeleteDiscovererCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{DiscovererId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DiscovererId.");
@@ -310,7 +313,7 @@ export async function serializeAws_restJson1_1DeleteRegistryCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/registries/name/{RegistryName}";
   if (input.RegistryName !== undefined) {
-    const labelValue: string = input.RegistryName.toString();
+    const labelValue: string = input.RegistryName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: RegistryName."
@@ -318,7 +321,7 @@ export async function serializeAws_restJson1_1DeleteRegistryCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{RegistryName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: RegistryName.");
@@ -341,7 +344,7 @@ export async function serializeAws_restJson1_1DeleteSchemaCommand(
   let resolvedPath =
     "/v1/registries/name/{RegistryName}/schemas/name/{SchemaName}";
   if (input.RegistryName !== undefined) {
-    const labelValue: string = input.RegistryName.toString();
+    const labelValue: string = input.RegistryName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: RegistryName."
@@ -349,19 +352,19 @@ export async function serializeAws_restJson1_1DeleteSchemaCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{RegistryName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: RegistryName.");
   }
   if (input.SchemaName !== undefined) {
-    const labelValue: string = input.SchemaName.toString();
+    const labelValue: string = input.SchemaName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: SchemaName.");
     }
     resolvedPath = resolvedPath.replace(
       "{SchemaName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: SchemaName.");
@@ -384,7 +387,7 @@ export async function serializeAws_restJson1_1DeleteSchemaVersionCommand(
   let resolvedPath =
     "/v1/registries/name/{RegistryName}/schemas/name/{SchemaName}/version/{SchemaVersion}";
   if (input.RegistryName !== undefined) {
-    const labelValue: string = input.RegistryName.toString();
+    const labelValue: string = input.RegistryName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: RegistryName."
@@ -392,25 +395,25 @@ export async function serializeAws_restJson1_1DeleteSchemaVersionCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{RegistryName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: RegistryName.");
   }
   if (input.SchemaName !== undefined) {
-    const labelValue: string = input.SchemaName.toString();
+    const labelValue: string = input.SchemaName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: SchemaName.");
     }
     resolvedPath = resolvedPath.replace(
       "{SchemaName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: SchemaName.");
   }
   if (input.SchemaVersion !== undefined) {
-    const labelValue: string = input.SchemaVersion.toString();
+    const labelValue: string = input.SchemaVersion;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: SchemaVersion."
@@ -418,7 +421,7 @@ export async function serializeAws_restJson1_1DeleteSchemaVersionCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{SchemaVersion}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: SchemaVersion.");
@@ -441,19 +444,19 @@ export async function serializeAws_restJson1_1DescribeCodeBindingCommand(
   let resolvedPath =
     "/v1/registries/name/{RegistryName}/schemas/name/{SchemaName}/language/{Language}";
   if (input.Language !== undefined) {
-    const labelValue: string = input.Language.toString();
+    const labelValue: string = input.Language;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Language.");
     }
     resolvedPath = resolvedPath.replace(
       "{Language}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Language.");
   }
   if (input.RegistryName !== undefined) {
-    const labelValue: string = input.RegistryName.toString();
+    const labelValue: string = input.RegistryName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: RegistryName."
@@ -461,26 +464,28 @@ export async function serializeAws_restJson1_1DescribeCodeBindingCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{RegistryName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: RegistryName.");
   }
   if (input.SchemaName !== undefined) {
-    const labelValue: string = input.SchemaName.toString();
+    const labelValue: string = input.SchemaName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: SchemaName.");
     }
     resolvedPath = resolvedPath.replace(
       "{SchemaName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: SchemaName.");
   }
   const query: any = {};
   if (input.SchemaVersion !== undefined) {
-    query["schemaVersion"] = input.SchemaVersion.toString();
+    query[
+      __extendedEncodeURIComponent("schemaVersion")
+    ] = __extendedEncodeURIComponent(input.SchemaVersion);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -500,7 +505,7 @@ export async function serializeAws_restJson1_1DescribeDiscovererCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/discoverers/id/{DiscovererId}";
   if (input.DiscovererId !== undefined) {
-    const labelValue: string = input.DiscovererId.toString();
+    const labelValue: string = input.DiscovererId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: DiscovererId."
@@ -508,7 +513,7 @@ export async function serializeAws_restJson1_1DescribeDiscovererCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{DiscovererId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DiscovererId.");
@@ -530,7 +535,7 @@ export async function serializeAws_restJson1_1DescribeRegistryCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/registries/name/{RegistryName}";
   if (input.RegistryName !== undefined) {
-    const labelValue: string = input.RegistryName.toString();
+    const labelValue: string = input.RegistryName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: RegistryName."
@@ -538,7 +543,7 @@ export async function serializeAws_restJson1_1DescribeRegistryCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{RegistryName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: RegistryName.");
@@ -561,7 +566,7 @@ export async function serializeAws_restJson1_1DescribeSchemaCommand(
   let resolvedPath =
     "/v1/registries/name/{RegistryName}/schemas/name/{SchemaName}";
   if (input.RegistryName !== undefined) {
-    const labelValue: string = input.RegistryName.toString();
+    const labelValue: string = input.RegistryName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: RegistryName."
@@ -569,26 +574,28 @@ export async function serializeAws_restJson1_1DescribeSchemaCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{RegistryName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: RegistryName.");
   }
   if (input.SchemaName !== undefined) {
-    const labelValue: string = input.SchemaName.toString();
+    const labelValue: string = input.SchemaName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: SchemaName.");
     }
     resolvedPath = resolvedPath.replace(
       "{SchemaName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: SchemaName.");
   }
   const query: any = {};
   if (input.SchemaVersion !== undefined) {
-    query["schemaVersion"] = input.SchemaVersion.toString();
+    query[
+      __extendedEncodeURIComponent("schemaVersion")
+    ] = __extendedEncodeURIComponent(input.SchemaVersion);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -609,19 +616,19 @@ export async function serializeAws_restJson1_1GetCodeBindingSourceCommand(
   let resolvedPath =
     "/v1/registries/name/{RegistryName}/schemas/name/{SchemaName}/language/{Language}/source";
   if (input.Language !== undefined) {
-    const labelValue: string = input.Language.toString();
+    const labelValue: string = input.Language;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Language.");
     }
     resolvedPath = resolvedPath.replace(
       "{Language}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Language.");
   }
   if (input.RegistryName !== undefined) {
-    const labelValue: string = input.RegistryName.toString();
+    const labelValue: string = input.RegistryName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: RegistryName."
@@ -629,26 +636,28 @@ export async function serializeAws_restJson1_1GetCodeBindingSourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{RegistryName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: RegistryName.");
   }
   if (input.SchemaName !== undefined) {
-    const labelValue: string = input.SchemaName.toString();
+    const labelValue: string = input.SchemaName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: SchemaName.");
     }
     resolvedPath = resolvedPath.replace(
       "{SchemaName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: SchemaName.");
   }
   const query: any = {};
   if (input.SchemaVersion !== undefined) {
-    query["schemaVersion"] = input.SchemaVersion.toString();
+    query[
+      __extendedEncodeURIComponent("schemaVersion")
+    ] = __extendedEncodeURIComponent(input.SchemaVersion);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -700,16 +709,24 @@ export async function serializeAws_restJson1_1ListDiscoverersCommand(
   let resolvedPath = "/v1/discoverers";
   const query: any = {};
   if (input.DiscovererIdPrefix !== undefined) {
-    query["discovererIdPrefix"] = input.DiscovererIdPrefix.toString();
+    query[
+      __extendedEncodeURIComponent("discovererIdPrefix")
+    ] = __extendedEncodeURIComponent(input.DiscovererIdPrefix);
   }
   if (input.Limit !== undefined) {
-    query["limit"] = input.Limit.toString();
+    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
+      input.Limit.toString()
+    );
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   if (input.SourceArnPrefix !== undefined) {
-    query["sourceArnPrefix"] = input.SourceArnPrefix.toString();
+    query[
+      __extendedEncodeURIComponent("sourceArnPrefix")
+    ] = __extendedEncodeURIComponent(input.SourceArnPrefix);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -730,16 +747,24 @@ export async function serializeAws_restJson1_1ListRegistriesCommand(
   let resolvedPath = "/v1/registries";
   const query: any = {};
   if (input.Limit !== undefined) {
-    query["limit"] = input.Limit.toString();
+    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
+      input.Limit.toString()
+    );
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   if (input.RegistryNamePrefix !== undefined) {
-    query["registryNamePrefix"] = input.RegistryNamePrefix.toString();
+    query[
+      __extendedEncodeURIComponent("registryNamePrefix")
+    ] = __extendedEncodeURIComponent(input.RegistryNamePrefix);
   }
   if (input.Scope !== undefined) {
-    query["scope"] = input.Scope.toString();
+    query[__extendedEncodeURIComponent("scope")] = __extendedEncodeURIComponent(
+      input.Scope
+    );
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -760,7 +785,7 @@ export async function serializeAws_restJson1_1ListSchemaVersionsCommand(
   let resolvedPath =
     "/v1/registries/name/{RegistryName}/schemas/name/{SchemaName}/versions";
   if (input.RegistryName !== undefined) {
-    const labelValue: string = input.RegistryName.toString();
+    const labelValue: string = input.RegistryName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: RegistryName."
@@ -768,29 +793,33 @@ export async function serializeAws_restJson1_1ListSchemaVersionsCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{RegistryName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: RegistryName.");
   }
   if (input.SchemaName !== undefined) {
-    const labelValue: string = input.SchemaName.toString();
+    const labelValue: string = input.SchemaName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: SchemaName.");
     }
     resolvedPath = resolvedPath.replace(
       "{SchemaName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: SchemaName.");
   }
   const query: any = {};
   if (input.Limit !== undefined) {
-    query["limit"] = input.Limit.toString();
+    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
+      input.Limit.toString()
+    );
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -810,7 +839,7 @@ export async function serializeAws_restJson1_1ListSchemasCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/registries/name/{RegistryName}/schemas";
   if (input.RegistryName !== undefined) {
-    const labelValue: string = input.RegistryName.toString();
+    const labelValue: string = input.RegistryName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: RegistryName."
@@ -818,20 +847,26 @@ export async function serializeAws_restJson1_1ListSchemasCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{RegistryName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: RegistryName.");
   }
   const query: any = {};
   if (input.Limit !== undefined) {
-    query["limit"] = input.Limit.toString();
+    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
+      input.Limit.toString()
+    );
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   if (input.SchemaNamePrefix !== undefined) {
-    query["schemaNamePrefix"] = input.SchemaNamePrefix.toString();
+    query[
+      __extendedEncodeURIComponent("schemaNamePrefix")
+    ] = __extendedEncodeURIComponent(input.SchemaNamePrefix);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -851,7 +886,7 @@ export async function serializeAws_restJson1_1ListTagsForResourceCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/tags/{ResourceArn}";
   if (input.ResourceArn !== undefined) {
-    const labelValue: string = input.ResourceArn.toString();
+    const labelValue: string = input.ResourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ResourceArn."
@@ -859,7 +894,7 @@ export async function serializeAws_restJson1_1ListTagsForResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ResourceArn.");
@@ -908,19 +943,19 @@ export async function serializeAws_restJson1_1PutCodeBindingCommand(
   let resolvedPath =
     "/v1/registries/name/{RegistryName}/schemas/name/{SchemaName}/language/{Language}";
   if (input.Language !== undefined) {
-    const labelValue: string = input.Language.toString();
+    const labelValue: string = input.Language;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Language.");
     }
     resolvedPath = resolvedPath.replace(
       "{Language}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Language.");
   }
   if (input.RegistryName !== undefined) {
-    const labelValue: string = input.RegistryName.toString();
+    const labelValue: string = input.RegistryName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: RegistryName."
@@ -928,26 +963,28 @@ export async function serializeAws_restJson1_1PutCodeBindingCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{RegistryName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: RegistryName.");
   }
   if (input.SchemaName !== undefined) {
-    const labelValue: string = input.SchemaName.toString();
+    const labelValue: string = input.SchemaName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: SchemaName.");
     }
     resolvedPath = resolvedPath.replace(
       "{SchemaName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: SchemaName.");
   }
   const query: any = {};
   if (input.SchemaVersion !== undefined) {
-    query["schemaVersion"] = input.SchemaVersion.toString();
+    query[
+      __extendedEncodeURIComponent("schemaVersion")
+    ] = __extendedEncodeURIComponent(input.SchemaVersion);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -967,7 +1004,7 @@ export async function serializeAws_restJson1_1SearchSchemasCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/registries/name/{RegistryName}/schemas/search";
   if (input.RegistryName !== undefined) {
-    const labelValue: string = input.RegistryName.toString();
+    const labelValue: string = input.RegistryName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: RegistryName."
@@ -975,20 +1012,26 @@ export async function serializeAws_restJson1_1SearchSchemasCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{RegistryName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: RegistryName.");
   }
   const query: any = {};
   if (input.Keywords !== undefined) {
-    query["keywords"] = input.Keywords.toString();
+    query[
+      __extendedEncodeURIComponent("keywords")
+    ] = __extendedEncodeURIComponent(input.Keywords);
   }
   if (input.Limit !== undefined) {
-    query["limit"] = input.Limit.toString();
+    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
+      input.Limit.toString()
+    );
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1008,7 +1051,7 @@ export async function serializeAws_restJson1_1StartDiscovererCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/discoverers/id/{DiscovererId}/start";
   if (input.DiscovererId !== undefined) {
-    const labelValue: string = input.DiscovererId.toString();
+    const labelValue: string = input.DiscovererId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: DiscovererId."
@@ -1016,7 +1059,7 @@ export async function serializeAws_restJson1_1StartDiscovererCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{DiscovererId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DiscovererId.");
@@ -1038,7 +1081,7 @@ export async function serializeAws_restJson1_1StopDiscovererCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v1/discoverers/id/{DiscovererId}/stop";
   if (input.DiscovererId !== undefined) {
-    const labelValue: string = input.DiscovererId.toString();
+    const labelValue: string = input.DiscovererId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: DiscovererId."
@@ -1046,7 +1089,7 @@ export async function serializeAws_restJson1_1StopDiscovererCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{DiscovererId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DiscovererId.");
@@ -1068,7 +1111,7 @@ export async function serializeAws_restJson1_1TagResourceCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/tags/{ResourceArn}";
   if (input.ResourceArn !== undefined) {
-    const labelValue: string = input.ResourceArn.toString();
+    const labelValue: string = input.ResourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ResourceArn."
@@ -1076,7 +1119,7 @@ export async function serializeAws_restJson1_1TagResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ResourceArn.");
@@ -1128,7 +1171,7 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/tags/{ResourceArn}";
   if (input.ResourceArn !== undefined) {
-    const labelValue: string = input.ResourceArn.toString();
+    const labelValue: string = input.ResourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ResourceArn."
@@ -1136,14 +1179,16 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ResourceArn.");
   }
   const query: any = {};
   if (input.TagKeys !== undefined) {
-    query["tagKeys"] = input.TagKeys;
+    query[__extendedEncodeURIComponent("tagKeys")] = input.TagKeys.map(entry =>
+      __extendedEncodeURIComponent(entry)
+    );
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1163,7 +1208,7 @@ export async function serializeAws_restJson1_1UpdateDiscovererCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v1/discoverers/id/{DiscovererId}";
   if (input.DiscovererId !== undefined) {
-    const labelValue: string = input.DiscovererId.toString();
+    const labelValue: string = input.DiscovererId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: DiscovererId."
@@ -1171,7 +1216,7 @@ export async function serializeAws_restJson1_1UpdateDiscovererCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{DiscovererId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DiscovererId.");
@@ -1200,7 +1245,7 @@ export async function serializeAws_restJson1_1UpdateRegistryCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v1/registries/name/{RegistryName}";
   if (input.RegistryName !== undefined) {
-    const labelValue: string = input.RegistryName.toString();
+    const labelValue: string = input.RegistryName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: RegistryName."
@@ -1208,7 +1253,7 @@ export async function serializeAws_restJson1_1UpdateRegistryCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{RegistryName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: RegistryName.");
@@ -1238,7 +1283,7 @@ export async function serializeAws_restJson1_1UpdateSchemaCommand(
   let resolvedPath =
     "/v1/registries/name/{RegistryName}/schemas/name/{SchemaName}";
   if (input.RegistryName !== undefined) {
-    const labelValue: string = input.RegistryName.toString();
+    const labelValue: string = input.RegistryName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: RegistryName."
@@ -1246,19 +1291,19 @@ export async function serializeAws_restJson1_1UpdateSchemaCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{RegistryName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: RegistryName.");
   }
   if (input.SchemaName !== undefined) {
-    const labelValue: string = input.SchemaName.toString();
+    const labelValue: string = input.SchemaName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: SchemaName.");
     }
     resolvedPath = resolvedPath.replace(
       "{SchemaName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: SchemaName.");
@@ -1623,6 +1668,7 @@ export async function deserializeAws_restJson1_1DeleteDiscovererCommand(
   const contents: DeleteDiscovererCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -1708,6 +1754,7 @@ export async function deserializeAws_restJson1_1DeleteRegistryCommand(
   const contents: DeleteRegistryCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -1790,6 +1837,7 @@ export async function deserializeAws_restJson1_1DeleteSchemaCommand(
   const contents: DeleteSchemaCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -1875,6 +1923,7 @@ export async function deserializeAws_restJson1_1DeleteSchemaVersionCommand(
   const contents: DeleteSchemaVersionCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -3501,6 +3550,7 @@ export async function deserializeAws_restJson1_1TagResourceCommand(
   const contents: TagResourceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -3573,6 +3623,7 @@ export async function deserializeAws_restJson1_1UnlockServiceLinkedRoleCommand(
     $metadata: deserializeMetadata(output),
     __type: "UnlockServiceLinkedRoleResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -3648,6 +3699,7 @@ export async function deserializeAws_restJson1_1UntagResourceCommand(
   const contents: UntagResourceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 

--- a/clients/client-secrets-manager/models/index.ts
+++ b/clients/client-secrets-manager/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export interface CancelRotateSecretRequest {
@@ -23,7 +26,7 @@ export interface CancelRotateSecretRequest {
 
 export namespace CancelRotateSecretRequest {
   export function isa(o: any): o is CancelRotateSecretRequest {
-    return _smithy.isa(o, "CancelRotateSecretRequest");
+    return __isa(o, "CancelRotateSecretRequest");
   }
 }
 
@@ -51,7 +54,7 @@ export interface CancelRotateSecretResponse extends $MetadataBearer {
 
 export namespace CancelRotateSecretResponse {
   export function isa(o: any): o is CancelRotateSecretResponse {
-    return _smithy.isa(o, "CancelRotateSecretResponse");
+    return __isa(o, "CancelRotateSecretResponse");
   }
 }
 
@@ -223,7 +226,7 @@ export interface CreateSecretRequest {
 
 export namespace CreateSecretRequest {
   export function isa(o: any): o is CreateSecretRequest {
-    return _smithy.isa(o, "CreateSecretRequest");
+    return __isa(o, "CreateSecretRequest");
   }
 }
 
@@ -255,16 +258,14 @@ export interface CreateSecretResponse extends $MetadataBearer {
 
 export namespace CreateSecretResponse {
   export function isa(o: any): o is CreateSecretResponse {
-    return _smithy.isa(o, "CreateSecretResponse");
+    return __isa(o, "CreateSecretResponse");
   }
 }
 
 /**
  * <p>Secrets Manager can't decrypt the protected secret text using the provided KMS key. </p>
  */
-export interface DecryptionFailure
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface DecryptionFailure extends __SmithyException, $MetadataBearer {
   name: "DecryptionFailure";
   $fault: "client";
   Message?: string;
@@ -272,7 +273,7 @@ export interface DecryptionFailure
 
 export namespace DecryptionFailure {
   export function isa(o: any): o is DecryptionFailure {
-    return _smithy.isa(o, "DecryptionFailure");
+    return __isa(o, "DecryptionFailure");
   }
 }
 
@@ -298,7 +299,7 @@ export interface DeleteResourcePolicyRequest {
 
 export namespace DeleteResourcePolicyRequest {
   export function isa(o: any): o is DeleteResourcePolicyRequest {
-    return _smithy.isa(o, "DeleteResourcePolicyRequest");
+    return __isa(o, "DeleteResourcePolicyRequest");
   }
 }
 
@@ -317,7 +318,7 @@ export interface DeleteResourcePolicyResponse extends $MetadataBearer {
 
 export namespace DeleteResourcePolicyResponse {
   export function isa(o: any): o is DeleteResourcePolicyResponse {
-    return _smithy.isa(o, "DeleteResourcePolicyResponse");
+    return __isa(o, "DeleteResourcePolicyResponse");
   }
 }
 
@@ -369,7 +370,7 @@ export interface DeleteSecretRequest {
 
 export namespace DeleteSecretRequest {
   export function isa(o: any): o is DeleteSecretRequest {
-    return _smithy.isa(o, "DeleteSecretRequest");
+    return __isa(o, "DeleteSecretRequest");
   }
 }
 
@@ -395,7 +396,7 @@ export interface DeleteSecretResponse extends $MetadataBearer {
 
 export namespace DeleteSecretResponse {
   export function isa(o: any): o is DeleteSecretResponse {
-    return _smithy.isa(o, "DeleteSecretResponse");
+    return __isa(o, "DeleteSecretResponse");
   }
 }
 
@@ -421,7 +422,7 @@ export interface DescribeSecretRequest {
 
 export namespace DescribeSecretRequest {
   export function isa(o: any): o is DescribeSecretRequest {
-    return _smithy.isa(o, "DescribeSecretRequest");
+    return __isa(o, "DescribeSecretRequest");
   }
 }
 
@@ -516,7 +517,7 @@ export interface DescribeSecretResponse extends $MetadataBearer {
 
 export namespace DescribeSecretResponse {
   export function isa(o: any): o is DescribeSecretResponse {
-    return _smithy.isa(o, "DescribeSecretResponse");
+    return __isa(o, "DescribeSecretResponse");
   }
 }
 
@@ -526,9 +527,7 @@ export namespace DescribeSecretResponse {
  *       information, see <a href="http://docs.aws.amazon.com/kms/latest/developerguide/key-state.html">How Key State Affects Use of a
  *         Customer Master Key</a>.</p>
  */
-export interface EncryptionFailure
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface EncryptionFailure extends __SmithyException, $MetadataBearer {
   name: "EncryptionFailure";
   $fault: "client";
   Message?: string;
@@ -536,7 +535,7 @@ export interface EncryptionFailure
 
 export namespace EncryptionFailure {
   export function isa(o: any): o is EncryptionFailure {
-    return _smithy.isa(o, "EncryptionFailure");
+    return __isa(o, "EncryptionFailure");
   }
 }
 
@@ -602,7 +601,7 @@ export interface GetRandomPasswordRequest {
 
 export namespace GetRandomPasswordRequest {
   export function isa(o: any): o is GetRandomPasswordRequest {
-    return _smithy.isa(o, "GetRandomPasswordRequest");
+    return __isa(o, "GetRandomPasswordRequest");
   }
 }
 
@@ -616,7 +615,7 @@ export interface GetRandomPasswordResponse extends $MetadataBearer {
 
 export namespace GetRandomPasswordResponse {
   export function isa(o: any): o is GetRandomPasswordResponse {
-    return _smithy.isa(o, "GetRandomPasswordResponse");
+    return __isa(o, "GetRandomPasswordResponse");
   }
 }
 
@@ -642,7 +641,7 @@ export interface GetResourcePolicyRequest {
 
 export namespace GetResourcePolicyRequest {
   export function isa(o: any): o is GetResourcePolicyRequest {
-    return _smithy.isa(o, "GetResourcePolicyRequest");
+    return __isa(o, "GetResourcePolicyRequest");
   }
 }
 
@@ -670,7 +669,7 @@ export interface GetResourcePolicyResponse extends $MetadataBearer {
 
 export namespace GetResourcePolicyResponse {
   export function isa(o: any): o is GetResourcePolicyResponse {
-    return _smithy.isa(o, "GetResourcePolicyResponse");
+    return __isa(o, "GetResourcePolicyResponse");
   }
 }
 
@@ -718,7 +717,7 @@ export interface GetSecretValueRequest {
 
 export namespace GetSecretValueRequest {
   export function isa(o: any): o is GetSecretValueRequest {
-    return _smithy.isa(o, "GetSecretValueRequest");
+    return __isa(o, "GetSecretValueRequest");
   }
 }
 
@@ -779,7 +778,7 @@ export interface GetSecretValueResponse extends $MetadataBearer {
 
 export namespace GetSecretValueResponse {
   export function isa(o: any): o is GetSecretValueResponse {
-    return _smithy.isa(o, "GetSecretValueResponse");
+    return __isa(o, "GetSecretValueResponse");
   }
 }
 
@@ -787,7 +786,7 @@ export namespace GetSecretValueResponse {
  * <p>An error occurred on the server side.</p>
  */
 export interface InternalServiceError
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalServiceError";
   $fault: "server";
@@ -796,7 +795,7 @@ export interface InternalServiceError
 
 export namespace InternalServiceError {
   export function isa(o: any): o is InternalServiceError {
-    return _smithy.isa(o, "InternalServiceError");
+    return __isa(o, "InternalServiceError");
   }
 }
 
@@ -804,7 +803,7 @@ export namespace InternalServiceError {
  * <p>You provided an invalid <code>NextToken</code> value.</p>
  */
 export interface InvalidNextTokenException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidNextTokenException";
   $fault: "client";
@@ -813,7 +812,7 @@ export interface InvalidNextTokenException
 
 export namespace InvalidNextTokenException {
   export function isa(o: any): o is InvalidNextTokenException {
-    return _smithy.isa(o, "InvalidNextTokenException");
+    return __isa(o, "InvalidNextTokenException");
   }
 }
 
@@ -821,7 +820,7 @@ export namespace InvalidNextTokenException {
  * <p>You provided an invalid value for a parameter.</p>
  */
 export interface InvalidParameterException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidParameterException";
   $fault: "client";
@@ -830,7 +829,7 @@ export interface InvalidParameterException
 
 export namespace InvalidParameterException {
   export function isa(o: any): o is InvalidParameterException {
-    return _smithy.isa(o, "InvalidParameterException");
+    return __isa(o, "InvalidParameterException");
   }
 }
 
@@ -849,7 +848,7 @@ export namespace InvalidParameterException {
  *          </ul>
  */
 export interface InvalidRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidRequestException";
   $fault: "client";
@@ -858,7 +857,7 @@ export interface InvalidRequestException
 
 export namespace InvalidRequestException {
   export function isa(o: any): o is InvalidRequestException {
-    return _smithy.isa(o, "InvalidRequestException");
+    return __isa(o, "InvalidRequestException");
   }
 }
 
@@ -866,7 +865,7 @@ export namespace InvalidRequestException {
  * <p>The request failed because it would exceed one of the Secrets Manager internal limits.</p>
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -875,7 +874,7 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
@@ -928,7 +927,7 @@ export interface ListSecretVersionIdsRequest {
 
 export namespace ListSecretVersionIdsRequest {
   export function isa(o: any): o is ListSecretVersionIdsRequest {
-    return _smithy.isa(o, "ListSecretVersionIdsRequest");
+    return __isa(o, "ListSecretVersionIdsRequest");
   }
 }
 
@@ -970,7 +969,7 @@ export interface ListSecretVersionIdsResponse extends $MetadataBearer {
 
 export namespace ListSecretVersionIdsResponse {
   export function isa(o: any): o is ListSecretVersionIdsResponse {
-    return _smithy.isa(o, "ListSecretVersionIdsResponse");
+    return __isa(o, "ListSecretVersionIdsResponse");
   }
 }
 
@@ -999,7 +998,7 @@ export interface ListSecretsRequest {
 
 export namespace ListSecretsRequest {
   export function isa(o: any): o is ListSecretsRequest {
-    return _smithy.isa(o, "ListSecretsRequest");
+    return __isa(o, "ListSecretsRequest");
   }
 }
 
@@ -1024,7 +1023,7 @@ export interface ListSecretsResponse extends $MetadataBearer {
 
 export namespace ListSecretsResponse {
   export function isa(o: any): o is ListSecretsResponse {
-    return _smithy.isa(o, "ListSecretsResponse");
+    return __isa(o, "ListSecretsResponse");
   }
 }
 
@@ -1032,7 +1031,7 @@ export namespace ListSecretsResponse {
  * <p>The policy document that you provided isn't valid.</p>
  */
 export interface MalformedPolicyDocumentException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "MalformedPolicyDocumentException";
   $fault: "client";
@@ -1041,7 +1040,7 @@ export interface MalformedPolicyDocumentException
 
 export namespace MalformedPolicyDocumentException {
   export function isa(o: any): o is MalformedPolicyDocumentException {
-    return _smithy.isa(o, "MalformedPolicyDocumentException");
+    return __isa(o, "MalformedPolicyDocumentException");
   }
 }
 
@@ -1049,7 +1048,7 @@ export namespace MalformedPolicyDocumentException {
  * <p>The request failed because you did not complete all the prerequisite steps.</p>
  */
 export interface PreconditionNotMetException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "PreconditionNotMetException";
   $fault: "client";
@@ -1058,7 +1057,7 @@ export interface PreconditionNotMetException
 
 export namespace PreconditionNotMetException {
   export function isa(o: any): o is PreconditionNotMetException {
-    return _smithy.isa(o, "PreconditionNotMetException");
+    return __isa(o, "PreconditionNotMetException");
   }
 }
 
@@ -1093,7 +1092,7 @@ export interface PutResourcePolicyRequest {
 
 export namespace PutResourcePolicyRequest {
   export function isa(o: any): o is PutResourcePolicyRequest {
-    return _smithy.isa(o, "PutResourcePolicyRequest");
+    return __isa(o, "PutResourcePolicyRequest");
   }
 }
 
@@ -1112,7 +1111,7 @@ export interface PutResourcePolicyResponse extends $MetadataBearer {
 
 export namespace PutResourcePolicyResponse {
   export function isa(o: any): o is PutResourcePolicyResponse {
-    return _smithy.isa(o, "PutResourcePolicyResponse");
+    return __isa(o, "PutResourcePolicyResponse");
   }
 }
 
@@ -1219,7 +1218,7 @@ export interface PutSecretValueRequest {
 
 export namespace PutSecretValueRequest {
   export function isa(o: any): o is PutSecretValueRequest {
-    return _smithy.isa(o, "PutSecretValueRequest");
+    return __isa(o, "PutSecretValueRequest");
   }
 }
 
@@ -1250,7 +1249,7 @@ export interface PutSecretValueResponse extends $MetadataBearer {
 
 export namespace PutSecretValueResponse {
   export function isa(o: any): o is PutSecretValueResponse {
-    return _smithy.isa(o, "PutSecretValueResponse");
+    return __isa(o, "PutSecretValueResponse");
   }
 }
 
@@ -1258,7 +1257,7 @@ export namespace PutSecretValueResponse {
  * <p>A resource with the ID you requested already exists.</p>
  */
 export interface ResourceExistsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceExistsException";
   $fault: "client";
@@ -1267,7 +1266,7 @@ export interface ResourceExistsException
 
 export namespace ResourceExistsException {
   export function isa(o: any): o is ResourceExistsException {
-    return _smithy.isa(o, "ResourceExistsException");
+    return __isa(o, "ResourceExistsException");
   }
 }
 
@@ -1275,7 +1274,7 @@ export namespace ResourceExistsException {
  * <p>We can't find the resource that you asked for.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -1284,7 +1283,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -1310,7 +1309,7 @@ export interface RestoreSecretRequest {
 
 export namespace RestoreSecretRequest {
   export function isa(o: any): o is RestoreSecretRequest {
-    return _smithy.isa(o, "RestoreSecretRequest");
+    return __isa(o, "RestoreSecretRequest");
   }
 }
 
@@ -1329,7 +1328,7 @@ export interface RestoreSecretResponse extends $MetadataBearer {
 
 export namespace RestoreSecretResponse {
   export function isa(o: any): o is RestoreSecretResponse {
-    return _smithy.isa(o, "RestoreSecretResponse");
+    return __isa(o, "RestoreSecretResponse");
   }
 }
 
@@ -1384,7 +1383,7 @@ export interface RotateSecretRequest {
 
 export namespace RotateSecretRequest {
   export function isa(o: any): o is RotateSecretRequest {
-    return _smithy.isa(o, "RotateSecretRequest");
+    return __isa(o, "RotateSecretRequest");
   }
 }
 
@@ -1409,7 +1408,7 @@ export interface RotateSecretResponse extends $MetadataBearer {
 
 export namespace RotateSecretResponse {
   export function isa(o: any): o is RotateSecretResponse {
-    return _smithy.isa(o, "RotateSecretResponse");
+    return __isa(o, "RotateSecretResponse");
   }
 }
 
@@ -1431,7 +1430,7 @@ export interface RotationRulesType {
 
 export namespace RotationRulesType {
   export function isa(o: any): o is RotationRulesType {
-    return _smithy.isa(o, "RotationRulesType");
+    return __isa(o, "RotationRulesType");
   }
 }
 
@@ -1530,7 +1529,7 @@ export interface SecretListEntry {
 
 export namespace SecretListEntry {
   export function isa(o: any): o is SecretListEntry {
-    return _smithy.isa(o, "SecretListEntry");
+    return __isa(o, "SecretListEntry");
   }
 }
 
@@ -1564,7 +1563,7 @@ export interface SecretVersionsListEntry {
 
 export namespace SecretVersionsListEntry {
   export function isa(o: any): o is SecretVersionsListEntry {
-    return _smithy.isa(o, "SecretVersionsListEntry");
+    return __isa(o, "SecretVersionsListEntry");
   }
 }
 
@@ -1586,7 +1585,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -1623,7 +1622,7 @@ export interface TagResourceRequest {
 
 export namespace TagResourceRequest {
   export function isa(o: any): o is TagResourceRequest {
-    return _smithy.isa(o, "TagResourceRequest");
+    return __isa(o, "TagResourceRequest");
   }
 }
 
@@ -1657,7 +1656,7 @@ export interface UntagResourceRequest {
 
 export namespace UntagResourceRequest {
   export function isa(o: any): o is UntagResourceRequest {
-    return _smithy.isa(o, "UntagResourceRequest");
+    return __isa(o, "UntagResourceRequest");
   }
 }
 
@@ -1772,7 +1771,7 @@ export interface UpdateSecretRequest {
 
 export namespace UpdateSecretRequest {
   export function isa(o: any): o is UpdateSecretRequest {
-    return _smithy.isa(o, "UpdateSecretRequest");
+    return __isa(o, "UpdateSecretRequest");
   }
 }
 
@@ -1804,7 +1803,7 @@ export interface UpdateSecretResponse extends $MetadataBearer {
 
 export namespace UpdateSecretResponse {
   export function isa(o: any): o is UpdateSecretResponse {
-    return _smithy.isa(o, "UpdateSecretResponse");
+    return __isa(o, "UpdateSecretResponse");
   }
 }
 
@@ -1852,7 +1851,7 @@ export interface UpdateSecretVersionStageRequest {
 
 export namespace UpdateSecretVersionStageRequest {
   export function isa(o: any): o is UpdateSecretVersionStageRequest {
-    return _smithy.isa(o, "UpdateSecretVersionStageRequest");
+    return __isa(o, "UpdateSecretVersionStageRequest");
   }
 }
 
@@ -1871,6 +1870,6 @@ export interface UpdateSecretVersionStageResponse extends $MetadataBearer {
 
 export namespace UpdateSecretVersionStageResponse {
   export function isa(o: any): o is UpdateSecretVersionStageResponse {
-    return _smithy.isa(o, "UpdateSecretVersionStageResponse");
+    return __isa(o, "UpdateSecretVersionStageResponse");
   }
 }

--- a/clients/client-secrets-manager/protocols/Aws_json1_1.ts
+++ b/clients/client-secrets-manager/protocols/Aws_json1_1.ts
@@ -1498,6 +1498,7 @@ export async function deserializeAws_json1_1TagResourceCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1TagResourceCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: TagResourceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1570,6 +1571,7 @@ export async function deserializeAws_json1_1UntagResourceCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1UntagResourceCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: UntagResourceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };

--- a/clients/client-securityhub/models/index.ts
+++ b/clients/client-securityhub/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export interface AcceptInvitationRequest {
@@ -16,7 +19,7 @@ export interface AcceptInvitationRequest {
 
 export namespace AcceptInvitationRequest {
   export function isa(o: any): o is AcceptInvitationRequest {
-    return _smithy.isa(o, "AcceptInvitationRequest");
+    return __isa(o, "AcceptInvitationRequest");
   }
 }
 
@@ -26,7 +29,7 @@ export interface AcceptInvitationResponse extends $MetadataBearer {
 
 export namespace AcceptInvitationResponse {
   export function isa(o: any): o is AcceptInvitationResponse {
-    return _smithy.isa(o, "AcceptInvitationResponse");
+    return __isa(o, "AcceptInvitationResponse");
   }
 }
 
@@ -34,7 +37,7 @@ export namespace AcceptInvitationResponse {
  * <p>You don't have permission to perform the action specified in the request.</p>
  */
 export interface AccessDeniedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AccessDeniedException";
   $fault: "client";
@@ -44,7 +47,7 @@ export interface AccessDeniedException
 
 export namespace AccessDeniedException {
   export function isa(o: any): o is AccessDeniedException {
-    return _smithy.isa(o, "AccessDeniedException");
+    return __isa(o, "AccessDeniedException");
   }
 }
 
@@ -66,7 +69,7 @@ export interface AccountDetails {
 
 export namespace AccountDetails {
   export function isa(o: any): o is AccountDetails {
-    return _smithy.isa(o, "AccountDetails");
+    return __isa(o, "AccountDetails");
   }
 }
 
@@ -93,7 +96,7 @@ export interface ActionTarget {
 
 export namespace ActionTarget {
   export function isa(o: any): o is ActionTarget {
-    return _smithy.isa(o, "ActionTarget");
+    return __isa(o, "ActionTarget");
   }
 }
 
@@ -115,7 +118,7 @@ export interface AvailabilityZone {
 
 export namespace AvailabilityZone {
   export function isa(o: any): o is AvailabilityZone {
-    return _smithy.isa(o, "AvailabilityZone");
+    return __isa(o, "AvailabilityZone");
   }
 }
 
@@ -162,7 +165,7 @@ export interface AwsCloudFrontDistributionDetails {
 
 export namespace AwsCloudFrontDistributionDetails {
   export function isa(o: any): o is AwsCloudFrontDistributionDetails {
-    return _smithy.isa(o, "AwsCloudFrontDistributionDetails");
+    return __isa(o, "AwsCloudFrontDistributionDetails");
   }
 }
 
@@ -194,7 +197,7 @@ export interface AwsCloudFrontDistributionLogging {
 
 export namespace AwsCloudFrontDistributionLogging {
   export function isa(o: any): o is AwsCloudFrontDistributionLogging {
-    return _smithy.isa(o, "AwsCloudFrontDistributionLogging");
+    return __isa(o, "AwsCloudFrontDistributionLogging");
   }
 }
 
@@ -221,7 +224,7 @@ export interface AwsCloudFrontDistributionOriginItem {
 
 export namespace AwsCloudFrontDistributionOriginItem {
   export function isa(o: any): o is AwsCloudFrontDistributionOriginItem {
-    return _smithy.isa(o, "AwsCloudFrontDistributionOriginItem");
+    return __isa(o, "AwsCloudFrontDistributionOriginItem");
   }
 }
 
@@ -238,7 +241,7 @@ export interface AwsCloudFrontDistributionOrigins {
 
 export namespace AwsCloudFrontDistributionOrigins {
   export function isa(o: any): o is AwsCloudFrontDistributionOrigins {
-    return _smithy.isa(o, "AwsCloudFrontDistributionOrigins");
+    return __isa(o, "AwsCloudFrontDistributionOrigins");
   }
 }
 
@@ -295,7 +298,7 @@ export interface AwsEc2InstanceDetails {
 
 export namespace AwsEc2InstanceDetails {
   export function isa(o: any): o is AwsEc2InstanceDetails {
-    return _smithy.isa(o, "AwsEc2InstanceDetails");
+    return __isa(o, "AwsEc2InstanceDetails");
   }
 }
 
@@ -357,7 +360,7 @@ export interface AwsElbv2LoadBalancerDetails {
 
 export namespace AwsElbv2LoadBalancerDetails {
   export function isa(o: any): o is AwsElbv2LoadBalancerDetails {
-    return _smithy.isa(o, "AwsElbv2LoadBalancerDetails");
+    return __isa(o, "AwsElbv2LoadBalancerDetails");
   }
 }
 
@@ -400,7 +403,7 @@ export interface AwsIamAccessKeyDetails {
 
 export namespace AwsIamAccessKeyDetails {
   export function isa(o: any): o is AwsIamAccessKeyDetails {
-    return _smithy.isa(o, "AwsIamAccessKeyDetails");
+    return __isa(o, "AwsIamAccessKeyDetails");
   }
 }
 
@@ -447,7 +450,7 @@ export interface AwsIamRoleDetails {
 
 export namespace AwsIamRoleDetails {
   export function isa(o: any): o is AwsIamRoleDetails {
-    return _smithy.isa(o, "AwsIamRoleDetails");
+    return __isa(o, "AwsIamRoleDetails");
   }
 }
 
@@ -489,7 +492,7 @@ export interface AwsKmsKeyDetails {
 
 export namespace AwsKmsKeyDetails {
   export function isa(o: any): o is AwsKmsKeyDetails {
-    return _smithy.isa(o, "AwsKmsKeyDetails");
+    return __isa(o, "AwsKmsKeyDetails");
   }
 }
 
@@ -521,7 +524,7 @@ export interface AwsLambdaFunctionCode {
 
 export namespace AwsLambdaFunctionCode {
   export function isa(o: any): o is AwsLambdaFunctionCode {
-    return _smithy.isa(o, "AwsLambdaFunctionCode");
+    return __isa(o, "AwsLambdaFunctionCode");
   }
 }
 
@@ -538,7 +541,7 @@ export interface AwsLambdaFunctionDeadLetterConfig {
 
 export namespace AwsLambdaFunctionDeadLetterConfig {
   export function isa(o: any): o is AwsLambdaFunctionDeadLetterConfig {
-    return _smithy.isa(o, "AwsLambdaFunctionDeadLetterConfig");
+    return __isa(o, "AwsLambdaFunctionDeadLetterConfig");
   }
 }
 
@@ -640,7 +643,7 @@ export interface AwsLambdaFunctionDetails {
 
 export namespace AwsLambdaFunctionDetails {
   export function isa(o: any): o is AwsLambdaFunctionDetails {
-    return _smithy.isa(o, "AwsLambdaFunctionDetails");
+    return __isa(o, "AwsLambdaFunctionDetails");
   }
 }
 
@@ -662,7 +665,7 @@ export interface AwsLambdaFunctionEnvironment {
 
 export namespace AwsLambdaFunctionEnvironment {
   export function isa(o: any): o is AwsLambdaFunctionEnvironment {
-    return _smithy.isa(o, "AwsLambdaFunctionEnvironment");
+    return __isa(o, "AwsLambdaFunctionEnvironment");
   }
 }
 
@@ -684,7 +687,7 @@ export interface AwsLambdaFunctionEnvironmentError {
 
 export namespace AwsLambdaFunctionEnvironmentError {
   export function isa(o: any): o is AwsLambdaFunctionEnvironmentError {
-    return _smithy.isa(o, "AwsLambdaFunctionEnvironmentError");
+    return __isa(o, "AwsLambdaFunctionEnvironmentError");
   }
 }
 
@@ -706,7 +709,7 @@ export interface AwsLambdaFunctionLayer {
 
 export namespace AwsLambdaFunctionLayer {
   export function isa(o: any): o is AwsLambdaFunctionLayer {
-    return _smithy.isa(o, "AwsLambdaFunctionLayer");
+    return __isa(o, "AwsLambdaFunctionLayer");
   }
 }
 
@@ -723,7 +726,7 @@ export interface AwsLambdaFunctionTracingConfig {
 
 export namespace AwsLambdaFunctionTracingConfig {
   export function isa(o: any): o is AwsLambdaFunctionTracingConfig {
-    return _smithy.isa(o, "AwsLambdaFunctionTracingConfig");
+    return __isa(o, "AwsLambdaFunctionTracingConfig");
   }
 }
 
@@ -750,7 +753,7 @@ export interface AwsLambdaFunctionVpcConfig {
 
 export namespace AwsLambdaFunctionVpcConfig {
   export function isa(o: any): o is AwsLambdaFunctionVpcConfig {
-    return _smithy.isa(o, "AwsLambdaFunctionVpcConfig");
+    return __isa(o, "AwsLambdaFunctionVpcConfig");
   }
 }
 
@@ -772,7 +775,7 @@ export interface AwsS3BucketDetails {
 
 export namespace AwsS3BucketDetails {
   export function isa(o: any): o is AwsS3BucketDetails {
-    return _smithy.isa(o, "AwsS3BucketDetails");
+    return __isa(o, "AwsS3BucketDetails");
   }
 }
 
@@ -969,7 +972,7 @@ export interface AwsSecurityFinding {
 
 export namespace AwsSecurityFinding {
   export function isa(o: any): o is AwsSecurityFinding {
-    return _smithy.isa(o, "AwsSecurityFinding");
+    return __isa(o, "AwsSecurityFinding");
   }
 }
 
@@ -1421,7 +1424,7 @@ export interface AwsSecurityFindingFilters {
 
 export namespace AwsSecurityFindingFilters {
   export function isa(o: any): o is AwsSecurityFindingFilters {
-    return _smithy.isa(o, "AwsSecurityFindingFilters");
+    return __isa(o, "AwsSecurityFindingFilters");
   }
 }
 
@@ -1453,7 +1456,7 @@ export interface AwsSnsTopicDetails {
 
 export namespace AwsSnsTopicDetails {
   export function isa(o: any): o is AwsSnsTopicDetails {
-    return _smithy.isa(o, "AwsSnsTopicDetails");
+    return __isa(o, "AwsSnsTopicDetails");
   }
 }
 
@@ -1475,7 +1478,7 @@ export interface AwsSnsTopicSubscription {
 
 export namespace AwsSnsTopicSubscription {
   export function isa(o: any): o is AwsSnsTopicSubscription {
-    return _smithy.isa(o, "AwsSnsTopicSubscription");
+    return __isa(o, "AwsSnsTopicSubscription");
   }
 }
 
@@ -1507,7 +1510,7 @@ export interface AwsSqsQueueDetails {
 
 export namespace AwsSqsQueueDetails {
   export function isa(o: any): o is AwsSqsQueueDetails {
-    return _smithy.isa(o, "AwsSqsQueueDetails");
+    return __isa(o, "AwsSqsQueueDetails");
   }
 }
 
@@ -1521,7 +1524,7 @@ export interface BatchDisableStandardsRequest {
 
 export namespace BatchDisableStandardsRequest {
   export function isa(o: any): o is BatchDisableStandardsRequest {
-    return _smithy.isa(o, "BatchDisableStandardsRequest");
+    return __isa(o, "BatchDisableStandardsRequest");
   }
 }
 
@@ -1535,7 +1538,7 @@ export interface BatchDisableStandardsResponse extends $MetadataBearer {
 
 export namespace BatchDisableStandardsResponse {
   export function isa(o: any): o is BatchDisableStandardsResponse {
-    return _smithy.isa(o, "BatchDisableStandardsResponse");
+    return __isa(o, "BatchDisableStandardsResponse");
   }
 }
 
@@ -1556,7 +1559,7 @@ export interface BatchEnableStandardsRequest {
 
 export namespace BatchEnableStandardsRequest {
   export function isa(o: any): o is BatchEnableStandardsRequest {
-    return _smithy.isa(o, "BatchEnableStandardsRequest");
+    return __isa(o, "BatchEnableStandardsRequest");
   }
 }
 
@@ -1570,7 +1573,7 @@ export interface BatchEnableStandardsResponse extends $MetadataBearer {
 
 export namespace BatchEnableStandardsResponse {
   export function isa(o: any): o is BatchEnableStandardsResponse {
-    return _smithy.isa(o, "BatchEnableStandardsResponse");
+    return __isa(o, "BatchEnableStandardsResponse");
   }
 }
 
@@ -1585,7 +1588,7 @@ export interface BatchImportFindingsRequest {
 
 export namespace BatchImportFindingsRequest {
   export function isa(o: any): o is BatchImportFindingsRequest {
-    return _smithy.isa(o, "BatchImportFindingsRequest");
+    return __isa(o, "BatchImportFindingsRequest");
   }
 }
 
@@ -1609,7 +1612,7 @@ export interface BatchImportFindingsResponse extends $MetadataBearer {
 
 export namespace BatchImportFindingsResponse {
   export function isa(o: any): o is BatchImportFindingsResponse {
-    return _smithy.isa(o, "BatchImportFindingsResponse");
+    return __isa(o, "BatchImportFindingsResponse");
   }
 }
 
@@ -1652,7 +1655,7 @@ export interface Compliance {
 
 export namespace Compliance {
   export function isa(o: any): o is Compliance {
-    return _smithy.isa(o, "Compliance");
+    return __isa(o, "Compliance");
   }
 }
 
@@ -1691,7 +1694,7 @@ export interface ContainerDetails {
 
 export namespace ContainerDetails {
   export function isa(o: any): o is ContainerDetails {
-    return _smithy.isa(o, "ContainerDetails");
+    return __isa(o, "ContainerDetails");
   }
 }
 
@@ -1720,7 +1723,7 @@ export interface CreateActionTargetRequest {
 
 export namespace CreateActionTargetRequest {
   export function isa(o: any): o is CreateActionTargetRequest {
-    return _smithy.isa(o, "CreateActionTargetRequest");
+    return __isa(o, "CreateActionTargetRequest");
   }
 }
 
@@ -1734,7 +1737,7 @@ export interface CreateActionTargetResponse extends $MetadataBearer {
 
 export namespace CreateActionTargetResponse {
   export function isa(o: any): o is CreateActionTargetResponse {
-    return _smithy.isa(o, "CreateActionTargetResponse");
+    return __isa(o, "CreateActionTargetResponse");
   }
 }
 
@@ -1759,7 +1762,7 @@ export interface CreateInsightRequest {
 
 export namespace CreateInsightRequest {
   export function isa(o: any): o is CreateInsightRequest {
-    return _smithy.isa(o, "CreateInsightRequest");
+    return __isa(o, "CreateInsightRequest");
   }
 }
 
@@ -1773,7 +1776,7 @@ export interface CreateInsightResponse extends $MetadataBearer {
 
 export namespace CreateInsightResponse {
   export function isa(o: any): o is CreateInsightResponse {
-    return _smithy.isa(o, "CreateInsightResponse");
+    return __isa(o, "CreateInsightResponse");
   }
 }
 
@@ -1788,7 +1791,7 @@ export interface CreateMembersRequest {
 
 export namespace CreateMembersRequest {
   export function isa(o: any): o is CreateMembersRequest {
-    return _smithy.isa(o, "CreateMembersRequest");
+    return __isa(o, "CreateMembersRequest");
   }
 }
 
@@ -1803,7 +1806,7 @@ export interface CreateMembersResponse extends $MetadataBearer {
 
 export namespace CreateMembersResponse {
   export function isa(o: any): o is CreateMembersResponse {
-    return _smithy.isa(o, "CreateMembersResponse");
+    return __isa(o, "CreateMembersResponse");
   }
 }
 
@@ -1830,7 +1833,7 @@ export interface DateFilter {
 
 export namespace DateFilter {
   export function isa(o: any): o is DateFilter {
-    return _smithy.isa(o, "DateFilter");
+    return __isa(o, "DateFilter");
   }
 }
 
@@ -1852,7 +1855,7 @@ export interface DateRange {
 
 export namespace DateRange {
   export function isa(o: any): o is DateRange {
-    return _smithy.isa(o, "DateRange");
+    return __isa(o, "DateRange");
   }
 }
 
@@ -1871,7 +1874,7 @@ export interface DeclineInvitationsRequest {
 
 export namespace DeclineInvitationsRequest {
   export function isa(o: any): o is DeclineInvitationsRequest {
-    return _smithy.isa(o, "DeclineInvitationsRequest");
+    return __isa(o, "DeclineInvitationsRequest");
   }
 }
 
@@ -1886,7 +1889,7 @@ export interface DeclineInvitationsResponse extends $MetadataBearer {
 
 export namespace DeclineInvitationsResponse {
   export function isa(o: any): o is DeclineInvitationsResponse {
-    return _smithy.isa(o, "DeclineInvitationsResponse");
+    return __isa(o, "DeclineInvitationsResponse");
   }
 }
 
@@ -1900,7 +1903,7 @@ export interface DeleteActionTargetRequest {
 
 export namespace DeleteActionTargetRequest {
   export function isa(o: any): o is DeleteActionTargetRequest {
-    return _smithy.isa(o, "DeleteActionTargetRequest");
+    return __isa(o, "DeleteActionTargetRequest");
   }
 }
 
@@ -1914,7 +1917,7 @@ export interface DeleteActionTargetResponse extends $MetadataBearer {
 
 export namespace DeleteActionTargetResponse {
   export function isa(o: any): o is DeleteActionTargetResponse {
-    return _smithy.isa(o, "DeleteActionTargetResponse");
+    return __isa(o, "DeleteActionTargetResponse");
   }
 }
 
@@ -1928,7 +1931,7 @@ export interface DeleteInsightRequest {
 
 export namespace DeleteInsightRequest {
   export function isa(o: any): o is DeleteInsightRequest {
-    return _smithy.isa(o, "DeleteInsightRequest");
+    return __isa(o, "DeleteInsightRequest");
   }
 }
 
@@ -1942,7 +1945,7 @@ export interface DeleteInsightResponse extends $MetadataBearer {
 
 export namespace DeleteInsightResponse {
   export function isa(o: any): o is DeleteInsightResponse {
-    return _smithy.isa(o, "DeleteInsightResponse");
+    return __isa(o, "DeleteInsightResponse");
   }
 }
 
@@ -1956,7 +1959,7 @@ export interface DeleteInvitationsRequest {
 
 export namespace DeleteInvitationsRequest {
   export function isa(o: any): o is DeleteInvitationsRequest {
-    return _smithy.isa(o, "DeleteInvitationsRequest");
+    return __isa(o, "DeleteInvitationsRequest");
   }
 }
 
@@ -1971,7 +1974,7 @@ export interface DeleteInvitationsResponse extends $MetadataBearer {
 
 export namespace DeleteInvitationsResponse {
   export function isa(o: any): o is DeleteInvitationsResponse {
-    return _smithy.isa(o, "DeleteInvitationsResponse");
+    return __isa(o, "DeleteInvitationsResponse");
   }
 }
 
@@ -1985,7 +1988,7 @@ export interface DeleteMembersRequest {
 
 export namespace DeleteMembersRequest {
   export function isa(o: any): o is DeleteMembersRequest {
-    return _smithy.isa(o, "DeleteMembersRequest");
+    return __isa(o, "DeleteMembersRequest");
   }
 }
 
@@ -2000,7 +2003,7 @@ export interface DeleteMembersResponse extends $MetadataBearer {
 
 export namespace DeleteMembersResponse {
   export function isa(o: any): o is DeleteMembersResponse {
-    return _smithy.isa(o, "DeleteMembersResponse");
+    return __isa(o, "DeleteMembersResponse");
   }
 }
 
@@ -2024,7 +2027,7 @@ export interface DescribeActionTargetsRequest {
 
 export namespace DescribeActionTargetsRequest {
   export function isa(o: any): o is DescribeActionTargetsRequest {
-    return _smithy.isa(o, "DescribeActionTargetsRequest");
+    return __isa(o, "DescribeActionTargetsRequest");
   }
 }
 
@@ -2045,7 +2048,7 @@ export interface DescribeActionTargetsResponse extends $MetadataBearer {
 
 export namespace DescribeActionTargetsResponse {
   export function isa(o: any): o is DescribeActionTargetsResponse {
-    return _smithy.isa(o, "DescribeActionTargetsResponse");
+    return __isa(o, "DescribeActionTargetsResponse");
   }
 }
 
@@ -2059,7 +2062,7 @@ export interface DescribeHubRequest {
 
 export namespace DescribeHubRequest {
   export function isa(o: any): o is DescribeHubRequest {
-    return _smithy.isa(o, "DescribeHubRequest");
+    return __isa(o, "DescribeHubRequest");
   }
 }
 
@@ -2078,7 +2081,7 @@ export interface DescribeHubResponse extends $MetadataBearer {
 
 export namespace DescribeHubResponse {
   export function isa(o: any): o is DescribeHubResponse {
-    return _smithy.isa(o, "DescribeHubResponse");
+    return __isa(o, "DescribeHubResponse");
   }
 }
 
@@ -2097,7 +2100,7 @@ export interface DescribeProductsRequest {
 
 export namespace DescribeProductsRequest {
   export function isa(o: any): o is DescribeProductsRequest {
-    return _smithy.isa(o, "DescribeProductsRequest");
+    return __isa(o, "DescribeProductsRequest");
   }
 }
 
@@ -2116,7 +2119,7 @@ export interface DescribeProductsResponse extends $MetadataBearer {
 
 export namespace DescribeProductsResponse {
   export function isa(o: any): o is DescribeProductsResponse {
-    return _smithy.isa(o, "DescribeProductsResponse");
+    return __isa(o, "DescribeProductsResponse");
   }
 }
 
@@ -2142,7 +2145,7 @@ export interface DescribeStandardsControlsRequest {
 
 export namespace DescribeStandardsControlsRequest {
   export function isa(o: any): o is DescribeStandardsControlsRequest {
-    return _smithy.isa(o, "DescribeStandardsControlsRequest");
+    return __isa(o, "DescribeStandardsControlsRequest");
   }
 }
 
@@ -2163,7 +2166,7 @@ export interface DescribeStandardsControlsResponse extends $MetadataBearer {
 
 export namespace DescribeStandardsControlsResponse {
   export function isa(o: any): o is DescribeStandardsControlsResponse {
-    return _smithy.isa(o, "DescribeStandardsControlsResponse");
+    return __isa(o, "DescribeStandardsControlsResponse");
   }
 }
 
@@ -2177,7 +2180,7 @@ export interface DisableImportFindingsForProductRequest {
 
 export namespace DisableImportFindingsForProductRequest {
   export function isa(o: any): o is DisableImportFindingsForProductRequest {
-    return _smithy.isa(o, "DisableImportFindingsForProductRequest");
+    return __isa(o, "DisableImportFindingsForProductRequest");
   }
 }
 
@@ -2188,7 +2191,7 @@ export interface DisableImportFindingsForProductResponse
 
 export namespace DisableImportFindingsForProductResponse {
   export function isa(o: any): o is DisableImportFindingsForProductResponse {
-    return _smithy.isa(o, "DisableImportFindingsForProductResponse");
+    return __isa(o, "DisableImportFindingsForProductResponse");
   }
 }
 
@@ -2198,7 +2201,7 @@ export interface DisableSecurityHubRequest {
 
 export namespace DisableSecurityHubRequest {
   export function isa(o: any): o is DisableSecurityHubRequest {
-    return _smithy.isa(o, "DisableSecurityHubRequest");
+    return __isa(o, "DisableSecurityHubRequest");
   }
 }
 
@@ -2208,7 +2211,7 @@ export interface DisableSecurityHubResponse extends $MetadataBearer {
 
 export namespace DisableSecurityHubResponse {
   export function isa(o: any): o is DisableSecurityHubResponse {
-    return _smithy.isa(o, "DisableSecurityHubResponse");
+    return __isa(o, "DisableSecurityHubResponse");
   }
 }
 
@@ -2218,7 +2221,7 @@ export interface DisassociateFromMasterAccountRequest {
 
 export namespace DisassociateFromMasterAccountRequest {
   export function isa(o: any): o is DisassociateFromMasterAccountRequest {
-    return _smithy.isa(o, "DisassociateFromMasterAccountRequest");
+    return __isa(o, "DisassociateFromMasterAccountRequest");
   }
 }
 
@@ -2228,7 +2231,7 @@ export interface DisassociateFromMasterAccountResponse extends $MetadataBearer {
 
 export namespace DisassociateFromMasterAccountResponse {
   export function isa(o: any): o is DisassociateFromMasterAccountResponse {
-    return _smithy.isa(o, "DisassociateFromMasterAccountResponse");
+    return __isa(o, "DisassociateFromMasterAccountResponse");
   }
 }
 
@@ -2242,7 +2245,7 @@ export interface DisassociateMembersRequest {
 
 export namespace DisassociateMembersRequest {
   export function isa(o: any): o is DisassociateMembersRequest {
-    return _smithy.isa(o, "DisassociateMembersRequest");
+    return __isa(o, "DisassociateMembersRequest");
   }
 }
 
@@ -2252,7 +2255,7 @@ export interface DisassociateMembersResponse extends $MetadataBearer {
 
 export namespace DisassociateMembersResponse {
   export function isa(o: any): o is DisassociateMembersResponse {
-    return _smithy.isa(o, "DisassociateMembersResponse");
+    return __isa(o, "DisassociateMembersResponse");
   }
 }
 
@@ -2266,7 +2269,7 @@ export interface EnableImportFindingsForProductRequest {
 
 export namespace EnableImportFindingsForProductRequest {
   export function isa(o: any): o is EnableImportFindingsForProductRequest {
-    return _smithy.isa(o, "EnableImportFindingsForProductRequest");
+    return __isa(o, "EnableImportFindingsForProductRequest");
   }
 }
 
@@ -2281,7 +2284,7 @@ export interface EnableImportFindingsForProductResponse
 
 export namespace EnableImportFindingsForProductResponse {
   export function isa(o: any): o is EnableImportFindingsForProductResponse {
-    return _smithy.isa(o, "EnableImportFindingsForProductResponse");
+    return __isa(o, "EnableImportFindingsForProductResponse");
   }
 }
 
@@ -2295,7 +2298,7 @@ export interface EnableSecurityHubRequest {
 
 export namespace EnableSecurityHubRequest {
   export function isa(o: any): o is EnableSecurityHubRequest {
-    return _smithy.isa(o, "EnableSecurityHubRequest");
+    return __isa(o, "EnableSecurityHubRequest");
   }
 }
 
@@ -2305,7 +2308,7 @@ export interface EnableSecurityHubResponse extends $MetadataBearer {
 
 export namespace EnableSecurityHubResponse {
   export function isa(o: any): o is EnableSecurityHubResponse {
-    return _smithy.isa(o, "EnableSecurityHubResponse");
+    return __isa(o, "EnableSecurityHubResponse");
   }
 }
 
@@ -2332,7 +2335,7 @@ export interface GetEnabledStandardsRequest {
 
 export namespace GetEnabledStandardsRequest {
   export function isa(o: any): o is GetEnabledStandardsRequest {
-    return _smithy.isa(o, "GetEnabledStandardsRequest");
+    return __isa(o, "GetEnabledStandardsRequest");
   }
 }
 
@@ -2351,7 +2354,7 @@ export interface GetEnabledStandardsResponse extends $MetadataBearer {
 
 export namespace GetEnabledStandardsResponse {
   export function isa(o: any): o is GetEnabledStandardsResponse {
-    return _smithy.isa(o, "GetEnabledStandardsResponse");
+    return __isa(o, "GetEnabledStandardsResponse");
   }
 }
 
@@ -2383,7 +2386,7 @@ export interface GetFindingsRequest {
 
 export namespace GetFindingsRequest {
   export function isa(o: any): o is GetFindingsRequest {
-    return _smithy.isa(o, "GetFindingsRequest");
+    return __isa(o, "GetFindingsRequest");
   }
 }
 
@@ -2402,7 +2405,7 @@ export interface GetFindingsResponse extends $MetadataBearer {
 
 export namespace GetFindingsResponse {
   export function isa(o: any): o is GetFindingsResponse {
-    return _smithy.isa(o, "GetFindingsResponse");
+    return __isa(o, "GetFindingsResponse");
   }
 }
 
@@ -2416,7 +2419,7 @@ export interface GetInsightResultsRequest {
 
 export namespace GetInsightResultsRequest {
   export function isa(o: any): o is GetInsightResultsRequest {
-    return _smithy.isa(o, "GetInsightResultsRequest");
+    return __isa(o, "GetInsightResultsRequest");
   }
 }
 
@@ -2430,7 +2433,7 @@ export interface GetInsightResultsResponse extends $MetadataBearer {
 
 export namespace GetInsightResultsResponse {
   export function isa(o: any): o is GetInsightResultsResponse {
-    return _smithy.isa(o, "GetInsightResultsResponse");
+    return __isa(o, "GetInsightResultsResponse");
   }
 }
 
@@ -2457,7 +2460,7 @@ export interface GetInsightsRequest {
 
 export namespace GetInsightsRequest {
   export function isa(o: any): o is GetInsightsRequest {
-    return _smithy.isa(o, "GetInsightsRequest");
+    return __isa(o, "GetInsightsRequest");
   }
 }
 
@@ -2476,7 +2479,7 @@ export interface GetInsightsResponse extends $MetadataBearer {
 
 export namespace GetInsightsResponse {
   export function isa(o: any): o is GetInsightsResponse {
-    return _smithy.isa(o, "GetInsightsResponse");
+    return __isa(o, "GetInsightsResponse");
   }
 }
 
@@ -2486,7 +2489,7 @@ export interface GetInvitationsCountRequest {
 
 export namespace GetInvitationsCountRequest {
   export function isa(o: any): o is GetInvitationsCountRequest {
-    return _smithy.isa(o, "GetInvitationsCountRequest");
+    return __isa(o, "GetInvitationsCountRequest");
   }
 }
 
@@ -2501,7 +2504,7 @@ export interface GetInvitationsCountResponse extends $MetadataBearer {
 
 export namespace GetInvitationsCountResponse {
   export function isa(o: any): o is GetInvitationsCountResponse {
-    return _smithy.isa(o, "GetInvitationsCountResponse");
+    return __isa(o, "GetInvitationsCountResponse");
   }
 }
 
@@ -2511,7 +2514,7 @@ export interface GetMasterAccountRequest {
 
 export namespace GetMasterAccountRequest {
   export function isa(o: any): o is GetMasterAccountRequest {
-    return _smithy.isa(o, "GetMasterAccountRequest");
+    return __isa(o, "GetMasterAccountRequest");
   }
 }
 
@@ -2526,7 +2529,7 @@ export interface GetMasterAccountResponse extends $MetadataBearer {
 
 export namespace GetMasterAccountResponse {
   export function isa(o: any): o is GetMasterAccountResponse {
-    return _smithy.isa(o, "GetMasterAccountResponse");
+    return __isa(o, "GetMasterAccountResponse");
   }
 }
 
@@ -2541,7 +2544,7 @@ export interface GetMembersRequest {
 
 export namespace GetMembersRequest {
   export function isa(o: any): o is GetMembersRequest {
-    return _smithy.isa(o, "GetMembersRequest");
+    return __isa(o, "GetMembersRequest");
   }
 }
 
@@ -2561,7 +2564,7 @@ export interface GetMembersResponse extends $MetadataBearer {
 
 export namespace GetMembersResponse {
   export function isa(o: any): o is GetMembersResponse {
-    return _smithy.isa(o, "GetMembersResponse");
+    return __isa(o, "GetMembersResponse");
   }
 }
 
@@ -2588,7 +2591,7 @@ export interface ImportFindingsError {
 
 export namespace ImportFindingsError {
   export function isa(o: any): o is ImportFindingsError {
-    return _smithy.isa(o, "ImportFindingsError");
+    return __isa(o, "ImportFindingsError");
   }
 }
 
@@ -2623,7 +2626,7 @@ export interface Insight {
 
 export namespace Insight {
   export function isa(o: any): o is Insight {
-    return _smithy.isa(o, "Insight");
+    return __isa(o, "Insight");
   }
 }
 
@@ -2647,7 +2650,7 @@ export interface InsightResultValue {
 
 export namespace InsightResultValue {
   export function isa(o: any): o is InsightResultValue {
-    return _smithy.isa(o, "InsightResultValue");
+    return __isa(o, "InsightResultValue");
   }
 }
 
@@ -2677,16 +2680,14 @@ export interface InsightResults {
 
 export namespace InsightResults {
   export function isa(o: any): o is InsightResults {
-    return _smithy.isa(o, "InsightResults");
+    return __isa(o, "InsightResults");
   }
 }
 
 /**
  * <p>Internal server error.</p>
  */
-export interface InternalException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface InternalException extends __SmithyException, $MetadataBearer {
   name: "InternalException";
   $fault: "server";
   Code?: string;
@@ -2695,7 +2696,7 @@ export interface InternalException
 
 export namespace InternalException {
   export function isa(o: any): o is InternalException {
-    return _smithy.isa(o, "InternalException");
+    return __isa(o, "InternalException");
   }
 }
 
@@ -2703,7 +2704,7 @@ export namespace InternalException {
  * <p>AWS Security Hub isn't enabled for the account used to make this request.</p>
  */
 export interface InvalidAccessException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidAccessException";
   $fault: "client";
@@ -2713,7 +2714,7 @@ export interface InvalidAccessException
 
 export namespace InvalidAccessException {
   export function isa(o: any): o is InvalidAccessException {
-    return _smithy.isa(o, "InvalidAccessException");
+    return __isa(o, "InvalidAccessException");
   }
 }
 
@@ -2722,7 +2723,7 @@ export namespace InvalidAccessException {
  *          input parameter.</p>
  */
 export interface InvalidInputException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidInputException";
   $fault: "client";
@@ -2732,7 +2733,7 @@ export interface InvalidInputException
 
 export namespace InvalidInputException {
   export function isa(o: any): o is InvalidInputException {
-    return _smithy.isa(o, "InvalidInputException");
+    return __isa(o, "InvalidInputException");
   }
 }
 
@@ -2764,7 +2765,7 @@ export interface Invitation {
 
 export namespace Invitation {
   export function isa(o: any): o is Invitation {
-    return _smithy.isa(o, "Invitation");
+    return __isa(o, "Invitation");
   }
 }
 
@@ -2779,7 +2780,7 @@ export interface InviteMembersRequest {
 
 export namespace InviteMembersRequest {
   export function isa(o: any): o is InviteMembersRequest {
-    return _smithy.isa(o, "InviteMembersRequest");
+    return __isa(o, "InviteMembersRequest");
   }
 }
 
@@ -2794,7 +2795,7 @@ export interface InviteMembersResponse extends $MetadataBearer {
 
 export namespace InviteMembersResponse {
   export function isa(o: any): o is InviteMembersResponse {
-    return _smithy.isa(o, "InviteMembersResponse");
+    return __isa(o, "InviteMembersResponse");
   }
 }
 
@@ -2811,7 +2812,7 @@ export interface IpFilter {
 
 export namespace IpFilter {
   export function isa(o: any): o is IpFilter {
-    return _smithy.isa(o, "IpFilter");
+    return __isa(o, "IpFilter");
   }
 }
 
@@ -2828,7 +2829,7 @@ export interface KeywordFilter {
 
 export namespace KeywordFilter {
   export function isa(o: any): o is KeywordFilter {
-    return _smithy.isa(o, "KeywordFilter");
+    return __isa(o, "KeywordFilter");
   }
 }
 
@@ -2837,7 +2838,7 @@ export namespace KeywordFilter {
  *          account limits. The error code describes the limit exceeded.</p>
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -2847,7 +2848,7 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
@@ -2869,7 +2870,7 @@ export interface ListEnabledProductsForImportRequest {
 
 export namespace ListEnabledProductsForImportRequest {
   export function isa(o: any): o is ListEnabledProductsForImportRequest {
-    return _smithy.isa(o, "ListEnabledProductsForImportRequest");
+    return __isa(o, "ListEnabledProductsForImportRequest");
   }
 }
 
@@ -2888,7 +2889,7 @@ export interface ListEnabledProductsForImportResponse extends $MetadataBearer {
 
 export namespace ListEnabledProductsForImportResponse {
   export function isa(o: any): o is ListEnabledProductsForImportResponse {
-    return _smithy.isa(o, "ListEnabledProductsForImportResponse");
+    return __isa(o, "ListEnabledProductsForImportResponse");
   }
 }
 
@@ -2910,7 +2911,7 @@ export interface ListInvitationsRequest {
 
 export namespace ListInvitationsRequest {
   export function isa(o: any): o is ListInvitationsRequest {
-    return _smithy.isa(o, "ListInvitationsRequest");
+    return __isa(o, "ListInvitationsRequest");
   }
 }
 
@@ -2929,7 +2930,7 @@ export interface ListInvitationsResponse extends $MetadataBearer {
 
 export namespace ListInvitationsResponse {
   export function isa(o: any): o is ListInvitationsResponse {
-    return _smithy.isa(o, "ListInvitationsResponse");
+    return __isa(o, "ListInvitationsResponse");
   }
 }
 
@@ -2961,7 +2962,7 @@ export interface ListMembersRequest {
 
 export namespace ListMembersRequest {
   export function isa(o: any): o is ListMembersRequest {
-    return _smithy.isa(o, "ListMembersRequest");
+    return __isa(o, "ListMembersRequest");
   }
 }
 
@@ -2980,7 +2981,7 @@ export interface ListMembersResponse extends $MetadataBearer {
 
 export namespace ListMembersResponse {
   export function isa(o: any): o is ListMembersResponse {
-    return _smithy.isa(o, "ListMembersResponse");
+    return __isa(o, "ListMembersResponse");
   }
 }
 
@@ -2994,7 +2995,7 @@ export interface ListTagsForResourceRequest {
 
 export namespace ListTagsForResourceRequest {
   export function isa(o: any): o is ListTagsForResourceRequest {
-    return _smithy.isa(o, "ListTagsForResourceRequest");
+    return __isa(o, "ListTagsForResourceRequest");
   }
 }
 
@@ -3008,7 +3009,7 @@ export interface ListTagsForResourceResponse extends $MetadataBearer {
 
 export namespace ListTagsForResourceResponse {
   export function isa(o: any): o is ListTagsForResourceResponse {
-    return _smithy.isa(o, "ListTagsForResourceResponse");
+    return __isa(o, "ListTagsForResourceResponse");
   }
 }
 
@@ -3030,7 +3031,7 @@ export interface LoadBalancerState {
 
 export namespace LoadBalancerState {
   export function isa(o: any): o is LoadBalancerState {
-    return _smithy.isa(o, "LoadBalancerState");
+    return __isa(o, "LoadBalancerState");
   }
 }
 
@@ -3062,7 +3063,7 @@ export interface Malware {
 
 export namespace Malware {
   export function isa(o: any): o is Malware {
-    return _smithy.isa(o, "Malware");
+    return __isa(o, "Malware");
   }
 }
 
@@ -3114,7 +3115,7 @@ export interface MapFilter {
 
 export namespace MapFilter {
   export function isa(o: any): o is MapFilter {
-    return _smithy.isa(o, "MapFilter");
+    return __isa(o, "MapFilter");
   }
 }
 
@@ -3162,7 +3163,7 @@ export interface Member {
 
 export namespace Member {
   export function isa(o: any): o is Member {
-    return _smithy.isa(o, "Member");
+    return __isa(o, "Member");
   }
 }
 
@@ -3230,7 +3231,7 @@ export interface Network {
 
 export namespace Network {
   export function isa(o: any): o is Network {
-    return _smithy.isa(o, "Network");
+    return __isa(o, "Network");
   }
 }
 
@@ -3262,7 +3263,7 @@ export interface Note {
 
 export namespace Note {
   export function isa(o: any): o is Note {
-    return _smithy.isa(o, "Note");
+    return __isa(o, "Note");
   }
 }
 
@@ -3284,7 +3285,7 @@ export interface NoteUpdate {
 
 export namespace NoteUpdate {
   export function isa(o: any): o is NoteUpdate {
-    return _smithy.isa(o, "NoteUpdate");
+    return __isa(o, "NoteUpdate");
   }
 }
 
@@ -3314,7 +3315,7 @@ export interface NumberFilter {
 
 export namespace NumberFilter {
   export function isa(o: any): o is NumberFilter {
-    return _smithy.isa(o, "NumberFilter");
+    return __isa(o, "NumberFilter");
   }
 }
 
@@ -3362,7 +3363,7 @@ export interface ProcessDetails {
 
 export namespace ProcessDetails {
   export function isa(o: any): o is ProcessDetails {
-    return _smithy.isa(o, "ProcessDetails");
+    return __isa(o, "ProcessDetails");
   }
 }
 
@@ -3414,7 +3415,7 @@ export interface Product {
 
 export namespace Product {
   export function isa(o: any): o is Product {
-    return _smithy.isa(o, "Product");
+    return __isa(o, "Product");
   }
 }
 
@@ -3436,7 +3437,7 @@ export interface Recommendation {
 
 export namespace Recommendation {
   export function isa(o: any): o is Recommendation {
-    return _smithy.isa(o, "Recommendation");
+    return __isa(o, "Recommendation");
   }
 }
 
@@ -3463,7 +3464,7 @@ export interface RelatedFinding {
 
 export namespace RelatedFinding {
   export function isa(o: any): o is RelatedFinding {
-    return _smithy.isa(o, "RelatedFinding");
+    return __isa(o, "RelatedFinding");
   }
 }
 
@@ -3480,7 +3481,7 @@ export interface Remediation {
 
 export namespace Remediation {
   export function isa(o: any): o is Remediation {
-    return _smithy.isa(o, "Remediation");
+    return __isa(o, "Remediation");
   }
 }
 
@@ -3523,7 +3524,7 @@ export interface Resource {
 
 export namespace Resource {
   export function isa(o: any): o is Resource {
-    return _smithy.isa(o, "Resource");
+    return __isa(o, "Resource");
   }
 }
 
@@ -3531,7 +3532,7 @@ export namespace Resource {
  * <p>The resource specified in the request conflicts with an existing resource.</p>
  */
 export interface ResourceConflictException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceConflictException";
   $fault: "client";
@@ -3541,7 +3542,7 @@ export interface ResourceConflictException
 
 export namespace ResourceConflictException {
   export function isa(o: any): o is ResourceConflictException {
-    return _smithy.isa(o, "ResourceConflictException");
+    return __isa(o, "ResourceConflictException");
   }
 }
 
@@ -3614,7 +3615,7 @@ export interface ResourceDetails {
 
 export namespace ResourceDetails {
   export function isa(o: any): o is ResourceDetails {
-    return _smithy.isa(o, "ResourceDetails");
+    return __isa(o, "ResourceDetails");
   }
 }
 
@@ -3622,7 +3623,7 @@ export namespace ResourceDetails {
  * <p>The request was rejected because we can't find the specified resource.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -3632,7 +3633,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -3654,7 +3655,7 @@ export interface Result {
 
 export namespace Result {
   export function isa(o: any): o is Result {
-    return _smithy.isa(o, "Result");
+    return __isa(o, "Result");
   }
 }
 
@@ -3677,7 +3678,7 @@ export interface Severity {
 
 export namespace Severity {
   export function isa(o: any): o is Severity {
-    return _smithy.isa(o, "Severity");
+    return __isa(o, "Severity");
   }
 }
 
@@ -3706,7 +3707,7 @@ export interface SortCriterion {
 
 export namespace SortCriterion {
   export function isa(o: any): o is SortCriterion {
-    return _smithy.isa(o, "SortCriterion");
+    return __isa(o, "SortCriterion");
   }
 }
 
@@ -3773,7 +3774,7 @@ export interface StandardsControl {
 
 export namespace StandardsControl {
   export function isa(o: any): o is StandardsControl {
-    return _smithy.isa(o, "StandardsControl");
+    return __isa(o, "StandardsControl");
   }
 }
 
@@ -3816,7 +3817,7 @@ export interface StandardsSubscription {
 
 export namespace StandardsSubscription {
   export function isa(o: any): o is StandardsSubscription {
-    return _smithy.isa(o, "StandardsSubscription");
+    return __isa(o, "StandardsSubscription");
   }
 }
 
@@ -3843,7 +3844,7 @@ export interface StandardsSubscriptionRequest {
 
 export namespace StandardsSubscriptionRequest {
   export function isa(o: any): o is StandardsSubscriptionRequest {
-    return _smithy.isa(o, "StandardsSubscriptionRequest");
+    return __isa(o, "StandardsSubscriptionRequest");
   }
 }
 
@@ -3865,7 +3866,7 @@ export interface StringFilter {
 
 export namespace StringFilter {
   export function isa(o: any): o is StringFilter {
-    return _smithy.isa(o, "StringFilter");
+    return __isa(o, "StringFilter");
   }
 }
 
@@ -3889,7 +3890,7 @@ export interface TagResourceRequest {
 
 export namespace TagResourceRequest {
   export function isa(o: any): o is TagResourceRequest {
-    return _smithy.isa(o, "TagResourceRequest");
+    return __isa(o, "TagResourceRequest");
   }
 }
 
@@ -3899,7 +3900,7 @@ export interface TagResourceResponse extends $MetadataBearer {
 
 export namespace TagResourceResponse {
   export function isa(o: any): o is TagResourceResponse {
-    return _smithy.isa(o, "TagResourceResponse");
+    return __isa(o, "TagResourceResponse");
   }
 }
 
@@ -3943,7 +3944,7 @@ export interface ThreatIntelIndicator {
 
 export namespace ThreatIntelIndicator {
   export function isa(o: any): o is ThreatIntelIndicator {
-    return _smithy.isa(o, "ThreatIntelIndicator");
+    return __isa(o, "ThreatIntelIndicator");
   }
 }
 
@@ -3985,7 +3986,7 @@ export interface UntagResourceRequest {
 
 export namespace UntagResourceRequest {
   export function isa(o: any): o is UntagResourceRequest {
-    return _smithy.isa(o, "UntagResourceRequest");
+    return __isa(o, "UntagResourceRequest");
   }
 }
 
@@ -3995,7 +3996,7 @@ export interface UntagResourceResponse extends $MetadataBearer {
 
 export namespace UntagResourceResponse {
   export function isa(o: any): o is UntagResourceResponse {
-    return _smithy.isa(o, "UntagResourceResponse");
+    return __isa(o, "UntagResourceResponse");
   }
 }
 
@@ -4019,7 +4020,7 @@ export interface UpdateActionTargetRequest {
 
 export namespace UpdateActionTargetRequest {
   export function isa(o: any): o is UpdateActionTargetRequest {
-    return _smithy.isa(o, "UpdateActionTargetRequest");
+    return __isa(o, "UpdateActionTargetRequest");
   }
 }
 
@@ -4029,7 +4030,7 @@ export interface UpdateActionTargetResponse extends $MetadataBearer {
 
 export namespace UpdateActionTargetResponse {
   export function isa(o: any): o is UpdateActionTargetResponse {
-    return _smithy.isa(o, "UpdateActionTargetResponse");
+    return __isa(o, "UpdateActionTargetResponse");
   }
 }
 
@@ -4053,7 +4054,7 @@ export interface UpdateFindingsRequest {
 
 export namespace UpdateFindingsRequest {
   export function isa(o: any): o is UpdateFindingsRequest {
-    return _smithy.isa(o, "UpdateFindingsRequest");
+    return __isa(o, "UpdateFindingsRequest");
   }
 }
 
@@ -4063,7 +4064,7 @@ export interface UpdateFindingsResponse extends $MetadataBearer {
 
 export namespace UpdateFindingsResponse {
   export function isa(o: any): o is UpdateFindingsResponse {
-    return _smithy.isa(o, "UpdateFindingsResponse");
+    return __isa(o, "UpdateFindingsResponse");
   }
 }
 
@@ -4092,7 +4093,7 @@ export interface UpdateInsightRequest {
 
 export namespace UpdateInsightRequest {
   export function isa(o: any): o is UpdateInsightRequest {
-    return _smithy.isa(o, "UpdateInsightRequest");
+    return __isa(o, "UpdateInsightRequest");
   }
 }
 
@@ -4102,7 +4103,7 @@ export interface UpdateInsightResponse extends $MetadataBearer {
 
 export namespace UpdateInsightResponse {
   export function isa(o: any): o is UpdateInsightResponse {
-    return _smithy.isa(o, "UpdateInsightResponse");
+    return __isa(o, "UpdateInsightResponse");
   }
 }
 
@@ -4126,7 +4127,7 @@ export interface UpdateStandardsControlRequest {
 
 export namespace UpdateStandardsControlRequest {
   export function isa(o: any): o is UpdateStandardsControlRequest {
-    return _smithy.isa(o, "UpdateStandardsControlRequest");
+    return __isa(o, "UpdateStandardsControlRequest");
   }
 }
 
@@ -4136,7 +4137,7 @@ export interface UpdateStandardsControlResponse extends $MetadataBearer {
 
 export namespace UpdateStandardsControlResponse {
   export function isa(o: any): o is UpdateStandardsControlResponse {
-    return _smithy.isa(o, "UpdateStandardsControlResponse");
+    return __isa(o, "UpdateStandardsControlResponse");
   }
 }
 

--- a/clients/client-securityhub/protocols/Aws_restJson1_1.ts
+++ b/clients/client-securityhub/protocols/Aws_restJson1_1.ts
@@ -231,7 +231,10 @@ import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  extendedEncodeURIComponent as __extendedEncodeURIComponent
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -468,7 +471,7 @@ export async function serializeAws_restJson1_1DeleteActionTargetCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/actionTargets/{ActionTargetArn+}";
   if (input.ActionTargetArn !== undefined) {
-    const labelValue: string = input.ActionTargetArn.toString();
+    const labelValue: string = input.ActionTargetArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ActionTargetArn."
@@ -478,7 +481,7 @@ export async function serializeAws_restJson1_1DeleteActionTargetCommand(
       "{ActionTargetArn+}",
       labelValue
         .split("/")
-        .map(segment => encodeURIComponent(segment))
+        .map(segment => __extendedEncodeURIComponent(segment))
         .join("/")
     );
   } else {
@@ -501,7 +504,7 @@ export async function serializeAws_restJson1_1DeleteInsightCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/insights/{InsightArn+}";
   if (input.InsightArn !== undefined) {
-    const labelValue: string = input.InsightArn.toString();
+    const labelValue: string = input.InsightArn;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: InsightArn.");
     }
@@ -509,7 +512,7 @@ export async function serializeAws_restJson1_1DeleteInsightCommand(
       "{InsightArn+}",
       labelValue
         .split("/")
-        .map(segment => encodeURIComponent(segment))
+        .map(segment => __extendedEncodeURIComponent(segment))
         .join("/")
     );
   } else {
@@ -617,7 +620,9 @@ export async function serializeAws_restJson1_1DescribeHubCommand(
   let resolvedPath = "/accounts";
   const query: any = {};
   if (input.HubArn !== undefined) {
-    query["HubArn"] = input.HubArn.toString();
+    query[
+      __extendedEncodeURIComponent("HubArn")
+    ] = __extendedEncodeURIComponent(input.HubArn);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -638,10 +643,14 @@ export async function serializeAws_restJson1_1DescribeProductsCommand(
   let resolvedPath = "/products";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["MaxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("MaxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["NextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("NextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -661,7 +670,7 @@ export async function serializeAws_restJson1_1DescribeStandardsControlsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/standards/controls/{StandardsSubscriptionArn+}";
   if (input.StandardsSubscriptionArn !== undefined) {
-    const labelValue: string = input.StandardsSubscriptionArn.toString();
+    const labelValue: string = input.StandardsSubscriptionArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: StandardsSubscriptionArn."
@@ -671,7 +680,7 @@ export async function serializeAws_restJson1_1DescribeStandardsControlsCommand(
       "{StandardsSubscriptionArn+}",
       labelValue
         .split("/")
-        .map(segment => encodeURIComponent(segment))
+        .map(segment => __extendedEncodeURIComponent(segment))
         .join("/")
     );
   } else {
@@ -681,10 +690,14 @@ export async function serializeAws_restJson1_1DescribeStandardsControlsCommand(
   }
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["MaxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("MaxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["NextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("NextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -704,7 +717,7 @@ export async function serializeAws_restJson1_1DisableImportFindingsForProductCom
   headers["Content-Type"] = "";
   let resolvedPath = "/productSubscriptions/{ProductSubscriptionArn+}";
   if (input.ProductSubscriptionArn !== undefined) {
-    const labelValue: string = input.ProductSubscriptionArn.toString();
+    const labelValue: string = input.ProductSubscriptionArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ProductSubscriptionArn."
@@ -714,7 +727,7 @@ export async function serializeAws_restJson1_1DisableImportFindingsForProductCom
       "{ProductSubscriptionArn+}",
       labelValue
         .split("/")
-        .map(segment => encodeURIComponent(segment))
+        .map(segment => __extendedEncodeURIComponent(segment))
         .join("/")
     );
   } else {
@@ -915,7 +928,7 @@ export async function serializeAws_restJson1_1GetInsightResultsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/insights/results/{InsightArn+}";
   if (input.InsightArn !== undefined) {
-    const labelValue: string = input.InsightArn.toString();
+    const labelValue: string = input.InsightArn;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: InsightArn.");
     }
@@ -923,7 +936,7 @@ export async function serializeAws_restJson1_1GetInsightResultsCommand(
       "{InsightArn+}",
       labelValue
         .split("/")
-        .map(segment => encodeURIComponent(segment))
+        .map(segment => __extendedEncodeURIComponent(segment))
         .join("/")
     );
   } else {
@@ -1063,10 +1076,14 @@ export async function serializeAws_restJson1_1ListEnabledProductsForImportComman
   let resolvedPath = "/productSubscriptions";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["MaxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("MaxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["NextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("NextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1087,10 +1104,14 @@ export async function serializeAws_restJson1_1ListInvitationsCommand(
   let resolvedPath = "/invitations";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["MaxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("MaxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["NextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("NextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1111,13 +1132,19 @@ export async function serializeAws_restJson1_1ListMembersCommand(
   let resolvedPath = "/members";
   const query: any = {};
   if (input.MaxResults !== undefined) {
-    query["MaxResults"] = input.MaxResults.toString();
+    query[
+      __extendedEncodeURIComponent("MaxResults")
+    ] = __extendedEncodeURIComponent(input.MaxResults.toString());
   }
   if (input.NextToken !== undefined) {
-    query["NextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("NextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   if (input.OnlyAssociated !== undefined) {
-    query["OnlyAssociated"] = input.OnlyAssociated.toString();
+    query[
+      __extendedEncodeURIComponent("OnlyAssociated")
+    ] = __extendedEncodeURIComponent(input.OnlyAssociated.toString());
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1137,7 +1164,7 @@ export async function serializeAws_restJson1_1ListTagsForResourceCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/tags/{ResourceArn}";
   if (input.ResourceArn !== undefined) {
-    const labelValue: string = input.ResourceArn.toString();
+    const labelValue: string = input.ResourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ResourceArn."
@@ -1145,7 +1172,7 @@ export async function serializeAws_restJson1_1ListTagsForResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ResourceArn.");
@@ -1167,7 +1194,7 @@ export async function serializeAws_restJson1_1TagResourceCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/tags/{ResourceArn}";
   if (input.ResourceArn !== undefined) {
-    const labelValue: string = input.ResourceArn.toString();
+    const labelValue: string = input.ResourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ResourceArn."
@@ -1175,7 +1202,7 @@ export async function serializeAws_restJson1_1TagResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ResourceArn.");
@@ -1204,7 +1231,7 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/tags/{ResourceArn}";
   if (input.ResourceArn !== undefined) {
-    const labelValue: string = input.ResourceArn.toString();
+    const labelValue: string = input.ResourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ResourceArn."
@@ -1212,14 +1239,16 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ResourceArn.");
   }
   const query: any = {};
   if (input.TagKeys !== undefined) {
-    query["tagKeys"] = input.TagKeys;
+    query[__extendedEncodeURIComponent("tagKeys")] = input.TagKeys.map(entry =>
+      __extendedEncodeURIComponent(entry)
+    );
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1239,7 +1268,7 @@ export async function serializeAws_restJson1_1UpdateActionTargetCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/actionTargets/{ActionTargetArn+}";
   if (input.ActionTargetArn !== undefined) {
-    const labelValue: string = input.ActionTargetArn.toString();
+    const labelValue: string = input.ActionTargetArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ActionTargetArn."
@@ -1249,7 +1278,7 @@ export async function serializeAws_restJson1_1UpdateActionTargetCommand(
       "{ActionTargetArn+}",
       labelValue
         .split("/")
-        .map(segment => encodeURIComponent(segment))
+        .map(segment => __extendedEncodeURIComponent(segment))
         .join("/")
     );
   } else {
@@ -1317,7 +1346,7 @@ export async function serializeAws_restJson1_1UpdateInsightCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/insights/{InsightArn+}";
   if (input.InsightArn !== undefined) {
-    const labelValue: string = input.InsightArn.toString();
+    const labelValue: string = input.InsightArn;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: InsightArn.");
     }
@@ -1325,7 +1354,7 @@ export async function serializeAws_restJson1_1UpdateInsightCommand(
       "{InsightArn+}",
       labelValue
         .split("/")
-        .map(segment => encodeURIComponent(segment))
+        .map(segment => __extendedEncodeURIComponent(segment))
         .join("/")
     );
   } else {
@@ -1364,7 +1393,7 @@ export async function serializeAws_restJson1_1UpdateStandardsControlCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/standards/control/{StandardsControlArn+}";
   if (input.StandardsControlArn !== undefined) {
-    const labelValue: string = input.StandardsControlArn.toString();
+    const labelValue: string = input.StandardsControlArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: StandardsControlArn."
@@ -1374,7 +1403,7 @@ export async function serializeAws_restJson1_1UpdateStandardsControlCommand(
       "{StandardsControlArn+}",
       labelValue
         .split("/")
-        .map(segment => encodeURIComponent(segment))
+        .map(segment => __extendedEncodeURIComponent(segment))
         .join("/")
     );
   } else {
@@ -1415,6 +1444,7 @@ export async function deserializeAws_restJson1_1AcceptInvitationCommand(
     $metadata: deserializeMetadata(output),
     __type: "AcceptInvitationResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2755,6 +2785,7 @@ export async function deserializeAws_restJson1_1DisableImportFindingsForProductC
     $metadata: deserializeMetadata(output),
     __type: "DisableImportFindingsForProductResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2834,6 +2865,7 @@ export async function deserializeAws_restJson1_1DisableSecurityHubCommand(
     $metadata: deserializeMetadata(output),
     __type: "DisableSecurityHubResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2906,6 +2938,7 @@ export async function deserializeAws_restJson1_1DisassociateFromMasterAccountCom
     $metadata: deserializeMetadata(output),
     __type: "DisassociateFromMasterAccountResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2985,6 +3018,7 @@ export async function deserializeAws_restJson1_1DisassociateMembersCommand(
     $metadata: deserializeMetadata(output),
     __type: "DisassociateMembersResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -3151,6 +3185,7 @@ export async function deserializeAws_restJson1_1EnableSecurityHubCommand(
     $metadata: deserializeMetadata(output),
     __type: "EnableSecurityHubResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -4230,6 +4265,7 @@ export async function deserializeAws_restJson1_1TagResourceCommand(
     $metadata: deserializeMetadata(output),
     __type: "TagResourceResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -4292,6 +4328,7 @@ export async function deserializeAws_restJson1_1UntagResourceCommand(
     $metadata: deserializeMetadata(output),
     __type: "UntagResourceResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -4357,6 +4394,7 @@ export async function deserializeAws_restJson1_1UpdateActionTargetCommand(
     $metadata: deserializeMetadata(output),
     __type: "UpdateActionTargetResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -4429,6 +4467,7 @@ export async function deserializeAws_restJson1_1UpdateFindingsCommand(
     $metadata: deserializeMetadata(output),
     __type: "UpdateFindingsResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -4505,6 +4544,7 @@ export async function deserializeAws_restJson1_1UpdateInsightCommand(
     $metadata: deserializeMetadata(output),
     __type: "UpdateInsightResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -4584,6 +4624,7 @@ export async function deserializeAws_restJson1_1UpdateStandardsControlCommand(
     $metadata: deserializeMetadata(output),
     __type: "UpdateStandardsControlResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 

--- a/clients/client-serverlessapplicationrepository/models/index.ts
+++ b/clients/client-serverlessapplicationrepository/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -19,7 +22,7 @@ export interface ApplicationDependencySummary {
 
 export namespace ApplicationDependencySummary {
   export function isa(o: any): o is ApplicationDependencySummary {
-    return _smithy.isa(o, "ApplicationDependencySummary");
+    return __isa(o, "ApplicationDependencySummary");
   }
 }
 
@@ -47,7 +50,7 @@ export interface ApplicationPolicyStatement {
 
 export namespace ApplicationPolicyStatement {
   export function isa(o: any): o is ApplicationPolicyStatement {
-    return _smithy.isa(o, "ApplicationPolicyStatement");
+    return __isa(o, "ApplicationPolicyStatement");
   }
 }
 
@@ -99,7 +102,7 @@ export interface ApplicationSummary {
 
 export namespace ApplicationSummary {
   export function isa(o: any): o is ApplicationSummary {
-    return _smithy.isa(o, "ApplicationSummary");
+    return __isa(o, "ApplicationSummary");
   }
 }
 
@@ -107,7 +110,7 @@ export namespace ApplicationSummary {
  * <p>One of the parameters in the request is invalid.</p>
  */
 export interface BadRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "BadRequestException";
   $fault: "client";
@@ -124,7 +127,7 @@ export interface BadRequestException
 
 export namespace BadRequestException {
   export function isa(o: any): o is BadRequestException {
-    return _smithy.isa(o, "BadRequestException");
+    return __isa(o, "BadRequestException");
   }
 }
 
@@ -138,9 +141,7 @@ export enum Capability {
 /**
  * <p>The resource already exists.</p>
  */
-export interface ConflictException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface ConflictException extends __SmithyException, $MetadataBearer {
   name: "ConflictException";
   $fault: "client";
   /**
@@ -156,7 +157,7 @@ export interface ConflictException
 
 export namespace ConflictException {
   export function isa(o: any): o is ConflictException {
-    return _smithy.isa(o, "ConflictException");
+    return __isa(o, "ConflictException");
   }
 }
 
@@ -245,7 +246,7 @@ export interface CreateApplicationRequest {
 
 export namespace CreateApplicationRequest {
   export function isa(o: any): o is CreateApplicationRequest {
-    return _smithy.isa(o, "CreateApplicationRequest");
+    return __isa(o, "CreateApplicationRequest");
   }
 }
 
@@ -319,7 +320,7 @@ export interface CreateApplicationResponse extends $MetadataBearer {
 
 export namespace CreateApplicationResponse {
   export function isa(o: any): o is CreateApplicationResponse {
-    return _smithy.isa(o, "CreateApplicationResponse");
+    return __isa(o, "CreateApplicationResponse");
   }
 }
 
@@ -358,7 +359,7 @@ export interface CreateApplicationVersionRequest {
 
 export namespace CreateApplicationVersionRequest {
   export function isa(o: any): o is CreateApplicationVersionRequest {
-    return _smithy.isa(o, "CreateApplicationVersionRequest");
+    return __isa(o, "CreateApplicationVersionRequest");
   }
 }
 
@@ -437,7 +438,7 @@ export interface CreateApplicationVersionResponse extends $MetadataBearer {
 
 export namespace CreateApplicationVersionResponse {
   export function isa(o: any): o is CreateApplicationVersionResponse {
-    return _smithy.isa(o, "CreateApplicationVersionResponse");
+    return __isa(o, "CreateApplicationVersionResponse");
   }
 }
 
@@ -543,7 +544,7 @@ export interface CreateCloudFormationChangeSetRequest {
 
 export namespace CreateCloudFormationChangeSetRequest {
   export function isa(o: any): o is CreateCloudFormationChangeSetRequest {
-    return _smithy.isa(o, "CreateCloudFormationChangeSetRequest");
+    return __isa(o, "CreateCloudFormationChangeSetRequest");
   }
 }
 
@@ -574,7 +575,7 @@ export interface CreateCloudFormationChangeSetResponse extends $MetadataBearer {
 
 export namespace CreateCloudFormationChangeSetResponse {
   export function isa(o: any): o is CreateCloudFormationChangeSetResponse {
-    return _smithy.isa(o, "CreateCloudFormationChangeSetResponse");
+    return __isa(o, "CreateCloudFormationChangeSetResponse");
   }
 }
 
@@ -595,7 +596,7 @@ export interface CreateCloudFormationTemplateRequest {
 
 export namespace CreateCloudFormationTemplateRequest {
   export function isa(o: any): o is CreateCloudFormationTemplateRequest {
-    return _smithy.isa(o, "CreateCloudFormationTemplateRequest");
+    return __isa(o, "CreateCloudFormationTemplateRequest");
   }
 }
 
@@ -644,7 +645,7 @@ export interface CreateCloudFormationTemplateResponse extends $MetadataBearer {
 
 export namespace CreateCloudFormationTemplateResponse {
   export function isa(o: any): o is CreateCloudFormationTemplateResponse {
-    return _smithy.isa(o, "CreateCloudFormationTemplateResponse");
+    return __isa(o, "CreateCloudFormationTemplateResponse");
   }
 }
 
@@ -658,16 +659,14 @@ export interface DeleteApplicationRequest {
 
 export namespace DeleteApplicationRequest {
   export function isa(o: any): o is DeleteApplicationRequest {
-    return _smithy.isa(o, "DeleteApplicationRequest");
+    return __isa(o, "DeleteApplicationRequest");
   }
 }
 
 /**
  * <p>The client is not authenticated.</p>
  */
-export interface ForbiddenException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface ForbiddenException extends __SmithyException, $MetadataBearer {
   name: "ForbiddenException";
   $fault: "client";
   /**
@@ -683,7 +682,7 @@ export interface ForbiddenException
 
 export namespace ForbiddenException {
   export function isa(o: any): o is ForbiddenException {
-    return _smithy.isa(o, "ForbiddenException");
+    return __isa(o, "ForbiddenException");
   }
 }
 
@@ -697,7 +696,7 @@ export interface GetApplicationPolicyRequest {
 
 export namespace GetApplicationPolicyRequest {
   export function isa(o: any): o is GetApplicationPolicyRequest {
-    return _smithy.isa(o, "GetApplicationPolicyRequest");
+    return __isa(o, "GetApplicationPolicyRequest");
   }
 }
 
@@ -711,7 +710,7 @@ export interface GetApplicationPolicyResponse extends $MetadataBearer {
 
 export namespace GetApplicationPolicyResponse {
   export function isa(o: any): o is GetApplicationPolicyResponse {
-    return _smithy.isa(o, "GetApplicationPolicyResponse");
+    return __isa(o, "GetApplicationPolicyResponse");
   }
 }
 
@@ -730,7 +729,7 @@ export interface GetApplicationRequest {
 
 export namespace GetApplicationRequest {
   export function isa(o: any): o is GetApplicationRequest {
-    return _smithy.isa(o, "GetApplicationRequest");
+    return __isa(o, "GetApplicationRequest");
   }
 }
 
@@ -804,7 +803,7 @@ export interface GetApplicationResponse extends $MetadataBearer {
 
 export namespace GetApplicationResponse {
   export function isa(o: any): o is GetApplicationResponse {
-    return _smithy.isa(o, "GetApplicationResponse");
+    return __isa(o, "GetApplicationResponse");
   }
 }
 
@@ -823,7 +822,7 @@ export interface GetCloudFormationTemplateRequest {
 
 export namespace GetCloudFormationTemplateRequest {
   export function isa(o: any): o is GetCloudFormationTemplateRequest {
-    return _smithy.isa(o, "GetCloudFormationTemplateRequest");
+    return __isa(o, "GetCloudFormationTemplateRequest");
   }
 }
 
@@ -872,7 +871,7 @@ export interface GetCloudFormationTemplateResponse extends $MetadataBearer {
 
 export namespace GetCloudFormationTemplateResponse {
   export function isa(o: any): o is GetCloudFormationTemplateResponse {
-    return _smithy.isa(o, "GetCloudFormationTemplateResponse");
+    return __isa(o, "GetCloudFormationTemplateResponse");
   }
 }
 
@@ -880,7 +879,7 @@ export namespace GetCloudFormationTemplateResponse {
  * <p>The AWS Serverless Application Repository service encountered an internal error.</p>
  */
 export interface InternalServerErrorException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalServerErrorException";
   $fault: "server";
@@ -897,7 +896,7 @@ export interface InternalServerErrorException
 
 export namespace InternalServerErrorException {
   export function isa(o: any): o is InternalServerErrorException {
-    return _smithy.isa(o, "InternalServerErrorException");
+    return __isa(o, "InternalServerErrorException");
   }
 }
 
@@ -926,7 +925,7 @@ export interface ListApplicationDependenciesRequest {
 
 export namespace ListApplicationDependenciesRequest {
   export function isa(o: any): o is ListApplicationDependenciesRequest {
-    return _smithy.isa(o, "ListApplicationDependenciesRequest");
+    return __isa(o, "ListApplicationDependenciesRequest");
   }
 }
 
@@ -945,7 +944,7 @@ export interface ListApplicationDependenciesResponse extends $MetadataBearer {
 
 export namespace ListApplicationDependenciesResponse {
   export function isa(o: any): o is ListApplicationDependenciesResponse {
-    return _smithy.isa(o, "ListApplicationDependenciesResponse");
+    return __isa(o, "ListApplicationDependenciesResponse");
   }
 }
 
@@ -969,7 +968,7 @@ export interface ListApplicationVersionsRequest {
 
 export namespace ListApplicationVersionsRequest {
   export function isa(o: any): o is ListApplicationVersionsRequest {
-    return _smithy.isa(o, "ListApplicationVersionsRequest");
+    return __isa(o, "ListApplicationVersionsRequest");
   }
 }
 
@@ -988,7 +987,7 @@ export interface ListApplicationVersionsResponse extends $MetadataBearer {
 
 export namespace ListApplicationVersionsResponse {
   export function isa(o: any): o is ListApplicationVersionsResponse {
-    return _smithy.isa(o, "ListApplicationVersionsResponse");
+    return __isa(o, "ListApplicationVersionsResponse");
   }
 }
 
@@ -1007,7 +1006,7 @@ export interface ListApplicationsRequest {
 
 export namespace ListApplicationsRequest {
   export function isa(o: any): o is ListApplicationsRequest {
-    return _smithy.isa(o, "ListApplicationsRequest");
+    return __isa(o, "ListApplicationsRequest");
   }
 }
 
@@ -1026,16 +1025,14 @@ export interface ListApplicationsResponse extends $MetadataBearer {
 
 export namespace ListApplicationsResponse {
   export function isa(o: any): o is ListApplicationsResponse {
-    return _smithy.isa(o, "ListApplicationsResponse");
+    return __isa(o, "ListApplicationsResponse");
   }
 }
 
 /**
  * <p>The resource (for example, an access policy statement) specified in the request doesn't exist.</p>
  */
-export interface NotFoundException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface NotFoundException extends __SmithyException, $MetadataBearer {
   name: "NotFoundException";
   $fault: "client";
   /**
@@ -1051,7 +1048,7 @@ export interface NotFoundException
 
 export namespace NotFoundException {
   export function isa(o: any): o is NotFoundException {
-    return _smithy.isa(o, "NotFoundException");
+    return __isa(o, "NotFoundException");
   }
 }
 
@@ -1145,7 +1142,7 @@ export interface ParameterDefinition {
 
 export namespace ParameterDefinition {
   export function isa(o: any): o is ParameterDefinition {
-    return _smithy.isa(o, "ParameterDefinition");
+    return __isa(o, "ParameterDefinition");
   }
 }
 
@@ -1168,7 +1165,7 @@ export interface ParameterValue {
 
 export namespace ParameterValue {
   export function isa(o: any): o is ParameterValue {
-    return _smithy.isa(o, "ParameterValue");
+    return __isa(o, "ParameterValue");
   }
 }
 
@@ -1187,7 +1184,7 @@ export interface PutApplicationPolicyRequest {
 
 export namespace PutApplicationPolicyRequest {
   export function isa(o: any): o is PutApplicationPolicyRequest {
-    return _smithy.isa(o, "PutApplicationPolicyRequest");
+    return __isa(o, "PutApplicationPolicyRequest");
   }
 }
 
@@ -1201,7 +1198,7 @@ export interface PutApplicationPolicyResponse extends $MetadataBearer {
 
 export namespace PutApplicationPolicyResponse {
   export function isa(o: any): o is PutApplicationPolicyResponse {
-    return _smithy.isa(o, "PutApplicationPolicyResponse");
+    return __isa(o, "PutApplicationPolicyResponse");
   }
 }
 
@@ -1226,7 +1223,7 @@ export interface RollbackConfiguration {
 
 export namespace RollbackConfiguration {
   export function isa(o: any): o is RollbackConfiguration {
-    return _smithy.isa(o, "RollbackConfiguration");
+    return __isa(o, "RollbackConfiguration");
   }
 }
 
@@ -1251,7 +1248,7 @@ export interface RollbackTrigger {
 
 export namespace RollbackTrigger {
   export function isa(o: any): o is RollbackTrigger {
-    return _smithy.isa(o, "RollbackTrigger");
+    return __isa(o, "RollbackTrigger");
   }
 }
 
@@ -1284,7 +1281,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -1292,7 +1289,7 @@ export namespace Tag {
  * <p>The client is sending more than the allowed number of requests per unit of time.</p>
  */
 export interface TooManyRequestsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyRequestsException";
   $fault: "client";
@@ -1309,7 +1306,7 @@ export interface TooManyRequestsException
 
 export namespace TooManyRequestsException {
   export function isa(o: any): o is TooManyRequestsException {
-    return _smithy.isa(o, "TooManyRequestsException");
+    return __isa(o, "TooManyRequestsException");
   }
 }
 
@@ -1353,7 +1350,7 @@ export interface UpdateApplicationRequest {
 
 export namespace UpdateApplicationRequest {
   export function isa(o: any): o is UpdateApplicationRequest {
-    return _smithy.isa(o, "UpdateApplicationRequest");
+    return __isa(o, "UpdateApplicationRequest");
   }
 }
 
@@ -1427,7 +1424,7 @@ export interface UpdateApplicationResponse extends $MetadataBearer {
 
 export namespace UpdateApplicationResponse {
   export function isa(o: any): o is UpdateApplicationResponse {
-    return _smithy.isa(o, "UpdateApplicationResponse");
+    return __isa(o, "UpdateApplicationResponse");
   }
 }
 
@@ -1509,7 +1506,7 @@ export interface Version {
 
 export namespace Version {
   export function isa(o: any): o is Version {
-    return _smithy.isa(o, "Version");
+    return __isa(o, "Version");
   }
 }
 
@@ -1543,6 +1540,6 @@ export interface VersionSummary {
 
 export namespace VersionSummary {
   export function isa(o: any): o is VersionSummary {
-    return _smithy.isa(o, "VersionSummary");
+    return __isa(o, "VersionSummary");
   }
 }

--- a/clients/client-serverlessapplicationrepository/protocols/Aws_restJson1_1.ts
+++ b/clients/client-serverlessapplicationrepository/protocols/Aws_restJson1_1.ts
@@ -73,7 +73,10 @@ import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  extendedEncodeURIComponent as __extendedEncodeURIComponent
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -157,7 +160,7 @@ export async function serializeAws_restJson1_1CreateApplicationVersionCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/applications/{ApplicationId}/versions/{SemanticVersion}";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -165,13 +168,13 @@ export async function serializeAws_restJson1_1CreateApplicationVersionCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
   }
   if (input.SemanticVersion !== undefined) {
-    const labelValue: string = input.SemanticVersion.toString();
+    const labelValue: string = input.SemanticVersion;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: SemanticVersion."
@@ -179,7 +182,7 @@ export async function serializeAws_restJson1_1CreateApplicationVersionCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{SemanticVersion}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: SemanticVersion.");
@@ -217,7 +220,7 @@ export async function serializeAws_restJson1_1CreateCloudFormationChangeSetComma
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/applications/{ApplicationId}/changesets";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -225,7 +228,7 @@ export async function serializeAws_restJson1_1CreateCloudFormationChangeSetComma
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
@@ -309,7 +312,7 @@ export async function serializeAws_restJson1_1CreateCloudFormationTemplateComman
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/applications/{ApplicationId}/templates";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -317,7 +320,7 @@ export async function serializeAws_restJson1_1CreateCloudFormationTemplateComman
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
@@ -346,7 +349,7 @@ export async function serializeAws_restJson1_1DeleteApplicationCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/applications/{ApplicationId}";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -354,7 +357,7 @@ export async function serializeAws_restJson1_1DeleteApplicationCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
@@ -376,7 +379,7 @@ export async function serializeAws_restJson1_1GetApplicationCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/applications/{ApplicationId}";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -384,14 +387,16 @@ export async function serializeAws_restJson1_1GetApplicationCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
   }
   const query: any = {};
   if (input.SemanticVersion !== undefined) {
-    query["semanticVersion"] = input.SemanticVersion.toString();
+    query[
+      __extendedEncodeURIComponent("semanticVersion")
+    ] = __extendedEncodeURIComponent(input.SemanticVersion);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -411,7 +416,7 @@ export async function serializeAws_restJson1_1GetApplicationPolicyCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/applications/{ApplicationId}/policy";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -419,7 +424,7 @@ export async function serializeAws_restJson1_1GetApplicationPolicyCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
@@ -441,7 +446,7 @@ export async function serializeAws_restJson1_1GetCloudFormationTemplateCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/applications/{ApplicationId}/templates/{TemplateId}";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -449,19 +454,19 @@ export async function serializeAws_restJson1_1GetCloudFormationTemplateCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
   }
   if (input.TemplateId !== undefined) {
-    const labelValue: string = input.TemplateId.toString();
+    const labelValue: string = input.TemplateId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: TemplateId.");
     }
     resolvedPath = resolvedPath.replace(
       "{TemplateId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: TemplateId.");
@@ -483,7 +488,7 @@ export async function serializeAws_restJson1_1ListApplicationDependenciesCommand
   headers["Content-Type"] = "";
   let resolvedPath = "/applications/{ApplicationId}/dependencies";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -491,20 +496,26 @@ export async function serializeAws_restJson1_1ListApplicationDependenciesCommand
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
   }
   const query: any = {};
   if (input.MaxItems !== undefined) {
-    query["maxItems"] = input.MaxItems.toString();
+    query[
+      __extendedEncodeURIComponent("maxItems")
+    ] = __extendedEncodeURIComponent(input.MaxItems.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   if (input.SemanticVersion !== undefined) {
-    query["semanticVersion"] = input.SemanticVersion.toString();
+    query[
+      __extendedEncodeURIComponent("semanticVersion")
+    ] = __extendedEncodeURIComponent(input.SemanticVersion);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -524,7 +535,7 @@ export async function serializeAws_restJson1_1ListApplicationVersionsCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/applications/{ApplicationId}/versions";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -532,17 +543,21 @@ export async function serializeAws_restJson1_1ListApplicationVersionsCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
   }
   const query: any = {};
   if (input.MaxItems !== undefined) {
-    query["maxItems"] = input.MaxItems.toString();
+    query[
+      __extendedEncodeURIComponent("maxItems")
+    ] = __extendedEncodeURIComponent(input.MaxItems.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -563,10 +578,14 @@ export async function serializeAws_restJson1_1ListApplicationsCommand(
   let resolvedPath = "/applications";
   const query: any = {};
   if (input.MaxItems !== undefined) {
-    query["maxItems"] = input.MaxItems.toString();
+    query[
+      __extendedEncodeURIComponent("maxItems")
+    ] = __extendedEncodeURIComponent(input.MaxItems.toString());
   }
   if (input.NextToken !== undefined) {
-    query["nextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -586,7 +605,7 @@ export async function serializeAws_restJson1_1PutApplicationPolicyCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/applications/{ApplicationId}/policy";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -594,7 +613,7 @@ export async function serializeAws_restJson1_1PutApplicationPolicyCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
@@ -628,7 +647,7 @@ export async function serializeAws_restJson1_1UpdateApplicationCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/applications/{ApplicationId}";
   if (input.ApplicationId !== undefined) {
-    const labelValue: string = input.ApplicationId.toString();
+    const labelValue: string = input.ApplicationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ApplicationId."
@@ -636,7 +655,7 @@ export async function serializeAws_restJson1_1UpdateApplicationCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ApplicationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ApplicationId.");
@@ -1154,6 +1173,7 @@ export async function deserializeAws_restJson1_1DeleteApplicationCommand(
   const contents: DeleteApplicationCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 

--- a/clients/client-service-catalog/models/index.ts
+++ b/clients/client-service-catalog/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export interface AssociateTagOptionWithResourceInput {
@@ -16,7 +19,7 @@ export interface AssociateTagOptionWithResourceInput {
 
 export namespace AssociateTagOptionWithResourceInput {
   export function isa(o: any): o is AssociateTagOptionWithResourceInput {
-    return _smithy.isa(o, "AssociateTagOptionWithResourceInput");
+    return __isa(o, "AssociateTagOptionWithResourceInput");
   }
 }
 
@@ -26,7 +29,7 @@ export interface AssociateTagOptionWithResourceOutput extends $MetadataBearer {
 
 export namespace AssociateTagOptionWithResourceOutput {
   export function isa(o: any): o is AssociateTagOptionWithResourceOutput {
-    return _smithy.isa(o, "AssociateTagOptionWithResourceOutput");
+    return __isa(o, "AssociateTagOptionWithResourceOutput");
   }
 }
 
@@ -45,7 +48,7 @@ export interface CreateTagOptionInput {
 
 export namespace CreateTagOptionInput {
   export function isa(o: any): o is CreateTagOptionInput {
-    return _smithy.isa(o, "CreateTagOptionInput");
+    return __isa(o, "CreateTagOptionInput");
   }
 }
 
@@ -59,7 +62,7 @@ export interface CreateTagOptionOutput extends $MetadataBearer {
 
 export namespace CreateTagOptionOutput {
   export function isa(o: any): o is CreateTagOptionOutput {
-    return _smithy.isa(o, "CreateTagOptionOutput");
+    return __isa(o, "CreateTagOptionOutput");
   }
 }
 
@@ -73,7 +76,7 @@ export interface DeleteTagOptionInput {
 
 export namespace DeleteTagOptionInput {
   export function isa(o: any): o is DeleteTagOptionInput {
-    return _smithy.isa(o, "DeleteTagOptionInput");
+    return __isa(o, "DeleteTagOptionInput");
   }
 }
 
@@ -83,7 +86,7 @@ export interface DeleteTagOptionOutput extends $MetadataBearer {
 
 export namespace DeleteTagOptionOutput {
   export function isa(o: any): o is DeleteTagOptionOutput {
-    return _smithy.isa(o, "DeleteTagOptionOutput");
+    return __isa(o, "DeleteTagOptionOutput");
   }
 }
 
@@ -97,7 +100,7 @@ export interface DescribeTagOptionInput {
 
 export namespace DescribeTagOptionInput {
   export function isa(o: any): o is DescribeTagOptionInput {
-    return _smithy.isa(o, "DescribeTagOptionInput");
+    return __isa(o, "DescribeTagOptionInput");
   }
 }
 
@@ -111,7 +114,7 @@ export interface DescribeTagOptionOutput extends $MetadataBearer {
 
 export namespace DescribeTagOptionOutput {
   export function isa(o: any): o is DescribeTagOptionOutput {
-    return _smithy.isa(o, "DescribeTagOptionOutput");
+    return __isa(o, "DescribeTagOptionOutput");
   }
 }
 
@@ -130,7 +133,7 @@ export interface DisassociateTagOptionFromResourceInput {
 
 export namespace DisassociateTagOptionFromResourceInput {
   export function isa(o: any): o is DisassociateTagOptionFromResourceInput {
-    return _smithy.isa(o, "DisassociateTagOptionFromResourceInput");
+    return __isa(o, "DisassociateTagOptionFromResourceInput");
   }
 }
 
@@ -141,7 +144,7 @@ export interface DisassociateTagOptionFromResourceOutput
 
 export namespace DisassociateTagOptionFromResourceOutput {
   export function isa(o: any): o is DisassociateTagOptionFromResourceOutput {
-    return _smithy.isa(o, "DisassociateTagOptionFromResourceOutput");
+    return __isa(o, "DisassociateTagOptionFromResourceOutput");
   }
 }
 
@@ -182,7 +185,7 @@ export interface ListResourcesForTagOptionInput {
 
 export namespace ListResourcesForTagOptionInput {
   export function isa(o: any): o is ListResourcesForTagOptionInput {
-    return _smithy.isa(o, "ListResourcesForTagOptionInput");
+    return __isa(o, "ListResourcesForTagOptionInput");
   }
 }
 
@@ -201,7 +204,7 @@ export interface ListResourcesForTagOptionOutput extends $MetadataBearer {
 
 export namespace ListResourcesForTagOptionOutput {
   export function isa(o: any): o is ListResourcesForTagOptionOutput {
-    return _smithy.isa(o, "ListResourcesForTagOptionOutput");
+    return __isa(o, "ListResourcesForTagOptionOutput");
   }
 }
 
@@ -228,7 +231,7 @@ export interface ListTagOptionsFilters {
 
 export namespace ListTagOptionsFilters {
   export function isa(o: any): o is ListTagOptionsFilters {
-    return _smithy.isa(o, "ListTagOptionsFilters");
+    return __isa(o, "ListTagOptionsFilters");
   }
 }
 
@@ -252,7 +255,7 @@ export interface ListTagOptionsInput {
 
 export namespace ListTagOptionsInput {
   export function isa(o: any): o is ListTagOptionsInput {
-    return _smithy.isa(o, "ListTagOptionsInput");
+    return __isa(o, "ListTagOptionsInput");
   }
 }
 
@@ -271,7 +274,7 @@ export interface ListTagOptionsOutput extends $MetadataBearer {
 
 export namespace ListTagOptionsOutput {
   export function isa(o: any): o is ListTagOptionsOutput {
-    return _smithy.isa(o, "ListTagOptionsOutput");
+    return __isa(o, "ListTagOptionsOutput");
   }
 }
 
@@ -308,7 +311,7 @@ export interface ResourceDetail {
 
 export namespace ResourceDetail {
   export function isa(o: any): o is ResourceDetail {
-    return _smithy.isa(o, "ResourceDetail");
+    return __isa(o, "ResourceDetail");
   }
 }
 
@@ -340,7 +343,7 @@ export interface TagOptionDetail {
 
 export namespace TagOptionDetail {
   export function isa(o: any): o is TagOptionDetail {
-    return _smithy.isa(o, "TagOptionDetail");
+    return __isa(o, "TagOptionDetail");
   }
 }
 
@@ -364,7 +367,7 @@ export interface UpdateTagOptionInput {
 
 export namespace UpdateTagOptionInput {
   export function isa(o: any): o is UpdateTagOptionInput {
-    return _smithy.isa(o, "UpdateTagOptionInput");
+    return __isa(o, "UpdateTagOptionInput");
   }
 }
 
@@ -378,7 +381,7 @@ export interface UpdateTagOptionOutput extends $MetadataBearer {
 
 export namespace UpdateTagOptionOutput {
   export function isa(o: any): o is UpdateTagOptionOutput {
-    return _smithy.isa(o, "UpdateTagOptionOutput");
+    return __isa(o, "UpdateTagOptionOutput");
   }
 }
 
@@ -432,7 +435,7 @@ export interface AcceptPortfolioShareInput {
 
 export namespace AcceptPortfolioShareInput {
   export function isa(o: any): o is AcceptPortfolioShareInput {
-    return _smithy.isa(o, "AcceptPortfolioShareInput");
+    return __isa(o, "AcceptPortfolioShareInput");
   }
 }
 
@@ -442,7 +445,7 @@ export interface AcceptPortfolioShareOutput extends $MetadataBearer {
 
 export namespace AcceptPortfolioShareOutput {
   export function isa(o: any): o is AcceptPortfolioShareOutput {
-    return _smithy.isa(o, "AcceptPortfolioShareOutput");
+    return __isa(o, "AcceptPortfolioShareOutput");
   }
 }
 
@@ -478,7 +481,7 @@ export interface AccessLevelFilter {
 
 export namespace AccessLevelFilter {
   export function isa(o: any): o is AccessLevelFilter {
-    return _smithy.isa(o, "AccessLevelFilter");
+    return __isa(o, "AccessLevelFilter");
   }
 }
 
@@ -509,7 +512,7 @@ export interface AssociateBudgetWithResourceInput {
 
 export namespace AssociateBudgetWithResourceInput {
   export function isa(o: any): o is AssociateBudgetWithResourceInput {
-    return _smithy.isa(o, "AssociateBudgetWithResourceInput");
+    return __isa(o, "AssociateBudgetWithResourceInput");
   }
 }
 
@@ -519,7 +522,7 @@ export interface AssociateBudgetWithResourceOutput extends $MetadataBearer {
 
 export namespace AssociateBudgetWithResourceOutput {
   export function isa(o: any): o is AssociateBudgetWithResourceOutput {
-    return _smithy.isa(o, "AssociateBudgetWithResourceOutput");
+    return __isa(o, "AssociateBudgetWithResourceOutput");
   }
 }
 
@@ -562,7 +565,7 @@ export interface AssociatePrincipalWithPortfolioInput {
 
 export namespace AssociatePrincipalWithPortfolioInput {
   export function isa(o: any): o is AssociatePrincipalWithPortfolioInput {
-    return _smithy.isa(o, "AssociatePrincipalWithPortfolioInput");
+    return __isa(o, "AssociatePrincipalWithPortfolioInput");
   }
 }
 
@@ -572,7 +575,7 @@ export interface AssociatePrincipalWithPortfolioOutput extends $MetadataBearer {
 
 export namespace AssociatePrincipalWithPortfolioOutput {
   export function isa(o: any): o is AssociatePrincipalWithPortfolioOutput {
-    return _smithy.isa(o, "AssociatePrincipalWithPortfolioOutput");
+    return __isa(o, "AssociatePrincipalWithPortfolioOutput");
   }
 }
 
@@ -615,7 +618,7 @@ export interface AssociateProductWithPortfolioInput {
 
 export namespace AssociateProductWithPortfolioInput {
   export function isa(o: any): o is AssociateProductWithPortfolioInput {
-    return _smithy.isa(o, "AssociateProductWithPortfolioInput");
+    return __isa(o, "AssociateProductWithPortfolioInput");
   }
 }
 
@@ -625,7 +628,7 @@ export interface AssociateProductWithPortfolioOutput extends $MetadataBearer {
 
 export namespace AssociateProductWithPortfolioOutput {
   export function isa(o: any): o is AssociateProductWithPortfolioOutput {
-    return _smithy.isa(o, "AssociateProductWithPortfolioOutput");
+    return __isa(o, "AssociateProductWithPortfolioOutput");
   }
 }
 
@@ -670,10 +673,7 @@ export namespace AssociateServiceActionWithProvisioningArtifactInput {
   export function isa(
     o: any
   ): o is AssociateServiceActionWithProvisioningArtifactInput {
-    return _smithy.isa(
-      o,
-      "AssociateServiceActionWithProvisioningArtifactInput"
-    );
+    return __isa(o, "AssociateServiceActionWithProvisioningArtifactInput");
   }
 }
 
@@ -686,10 +686,7 @@ export namespace AssociateServiceActionWithProvisioningArtifactOutput {
   export function isa(
     o: any
   ): o is AssociateServiceActionWithProvisioningArtifactOutput {
-    return _smithy.isa(
-      o,
-      "AssociateServiceActionWithProvisioningArtifactOutput"
-    );
+    return __isa(o, "AssociateServiceActionWithProvisioningArtifactOutput");
   }
 }
 
@@ -724,10 +721,7 @@ export namespace BatchAssociateServiceActionWithProvisioningArtifactInput {
   export function isa(
     o: any
   ): o is BatchAssociateServiceActionWithProvisioningArtifactInput {
-    return _smithy.isa(
-      o,
-      "BatchAssociateServiceActionWithProvisioningArtifactInput"
-    );
+    return __isa(o, "BatchAssociateServiceActionWithProvisioningArtifactInput");
   }
 }
 
@@ -744,7 +738,7 @@ export namespace BatchAssociateServiceActionWithProvisioningArtifactOutput {
   export function isa(
     o: any
   ): o is BatchAssociateServiceActionWithProvisioningArtifactOutput {
-    return _smithy.isa(
+    return __isa(
       o,
       "BatchAssociateServiceActionWithProvisioningArtifactOutput"
     );
@@ -782,7 +776,7 @@ export namespace BatchDisassociateServiceActionFromProvisioningArtifactInput {
   export function isa(
     o: any
   ): o is BatchDisassociateServiceActionFromProvisioningArtifactInput {
-    return _smithy.isa(
+    return __isa(
       o,
       "BatchDisassociateServiceActionFromProvisioningArtifactInput"
     );
@@ -802,7 +796,7 @@ export namespace BatchDisassociateServiceActionFromProvisioningArtifactOutput {
   export function isa(
     o: any
   ): o is BatchDisassociateServiceActionFromProvisioningArtifactOutput {
-    return _smithy.isa(
+    return __isa(
       o,
       "BatchDisassociateServiceActionFromProvisioningArtifactOutput"
     );
@@ -822,7 +816,7 @@ export interface BudgetDetail {
 
 export namespace BudgetDetail {
   export function isa(o: any): o is BudgetDetail {
-    return _smithy.isa(o, "BudgetDetail");
+    return __isa(o, "BudgetDetail");
   }
 }
 
@@ -845,7 +839,7 @@ export interface CloudWatchDashboard {
 
 export namespace CloudWatchDashboard {
   export function isa(o: any): o is CloudWatchDashboard {
-    return _smithy.isa(o, "CloudWatchDashboard");
+    return __isa(o, "CloudWatchDashboard");
   }
 }
 
@@ -897,7 +891,7 @@ export interface ConstraintDetail {
 
 export namespace ConstraintDetail {
   export function isa(o: any): o is ConstraintDetail {
-    return _smithy.isa(o, "ConstraintDetail");
+    return __isa(o, "ConstraintDetail");
   }
 }
 
@@ -939,7 +933,7 @@ export interface ConstraintSummary {
 
 export namespace ConstraintSummary {
   export function isa(o: any): o is ConstraintSummary {
-    return _smithy.isa(o, "ConstraintSummary");
+    return __isa(o, "ConstraintSummary");
   }
 }
 
@@ -1004,7 +998,7 @@ export interface CopyProductInput {
 
 export namespace CopyProductInput {
   export function isa(o: any): o is CopyProductInput {
-    return _smithy.isa(o, "CopyProductInput");
+    return __isa(o, "CopyProductInput");
   }
 }
 
@@ -1018,7 +1012,7 @@ export interface CopyProductOutput extends $MetadataBearer {
 
 export namespace CopyProductOutput {
   export function isa(o: any): o is CopyProductOutput {
-    return _smithy.isa(o, "CopyProductOutput");
+    return __isa(o, "CopyProductOutput");
   }
 }
 
@@ -1151,7 +1145,7 @@ export interface CreateConstraintInput {
 
 export namespace CreateConstraintInput {
   export function isa(o: any): o is CreateConstraintInput {
-    return _smithy.isa(o, "CreateConstraintInput");
+    return __isa(o, "CreateConstraintInput");
   }
 }
 
@@ -1175,7 +1169,7 @@ export interface CreateConstraintOutput extends $MetadataBearer {
 
 export namespace CreateConstraintOutput {
   export function isa(o: any): o is CreateConstraintOutput {
-    return _smithy.isa(o, "CreateConstraintOutput");
+    return __isa(o, "CreateConstraintOutput");
   }
 }
 
@@ -1229,7 +1223,7 @@ export interface CreatePortfolioInput {
 
 export namespace CreatePortfolioInput {
   export function isa(o: any): o is CreatePortfolioInput {
-    return _smithy.isa(o, "CreatePortfolioInput");
+    return __isa(o, "CreatePortfolioInput");
   }
 }
 
@@ -1248,7 +1242,7 @@ export interface CreatePortfolioOutput extends $MetadataBearer {
 
 export namespace CreatePortfolioOutput {
   export function isa(o: any): o is CreatePortfolioOutput {
-    return _smithy.isa(o, "CreatePortfolioOutput");
+    return __isa(o, "CreatePortfolioOutput");
   }
 }
 
@@ -1291,7 +1285,7 @@ export interface CreatePortfolioShareInput {
 
 export namespace CreatePortfolioShareInput {
   export function isa(o: any): o is CreatePortfolioShareInput {
-    return _smithy.isa(o, "CreatePortfolioShareInput");
+    return __isa(o, "CreatePortfolioShareInput");
   }
 }
 
@@ -1305,7 +1299,7 @@ export interface CreatePortfolioShareOutput extends $MetadataBearer {
 
 export namespace CreatePortfolioShareOutput {
   export function isa(o: any): o is CreatePortfolioShareOutput {
-    return _smithy.isa(o, "CreatePortfolioShareOutput");
+    return __isa(o, "CreatePortfolioShareOutput");
   }
 }
 
@@ -1389,7 +1383,7 @@ export interface CreateProductInput {
 
 export namespace CreateProductInput {
   export function isa(o: any): o is CreateProductInput {
-    return _smithy.isa(o, "CreateProductInput");
+    return __isa(o, "CreateProductInput");
   }
 }
 
@@ -1413,7 +1407,7 @@ export interface CreateProductOutput extends $MetadataBearer {
 
 export namespace CreateProductOutput {
   export function isa(o: any): o is CreateProductOutput {
-    return _smithy.isa(o, "CreateProductOutput");
+    return __isa(o, "CreateProductOutput");
   }
 }
 
@@ -1498,7 +1492,7 @@ export interface CreateProvisionedProductPlanInput {
 
 export namespace CreateProvisionedProductPlanInput {
   export function isa(o: any): o is CreateProvisionedProductPlanInput {
-    return _smithy.isa(o, "CreateProvisionedProductPlanInput");
+    return __isa(o, "CreateProvisionedProductPlanInput");
   }
 }
 
@@ -1532,7 +1526,7 @@ export interface CreateProvisionedProductPlanOutput extends $MetadataBearer {
 
 export namespace CreateProvisionedProductPlanOutput {
   export function isa(o: any): o is CreateProvisionedProductPlanOutput {
-    return _smithy.isa(o, "CreateProvisionedProductPlanOutput");
+    return __isa(o, "CreateProvisionedProductPlanOutput");
   }
 }
 
@@ -1576,7 +1570,7 @@ export interface CreateProvisioningArtifactInput {
 
 export namespace CreateProvisioningArtifactInput {
   export function isa(o: any): o is CreateProvisioningArtifactInput {
-    return _smithy.isa(o, "CreateProvisioningArtifactInput");
+    return __isa(o, "CreateProvisioningArtifactInput");
   }
 }
 
@@ -1600,7 +1594,7 @@ export interface CreateProvisioningArtifactOutput extends $MetadataBearer {
 
 export namespace CreateProvisioningArtifactOutput {
   export function isa(o: any): o is CreateProvisioningArtifactOutput {
-    return _smithy.isa(o, "CreateProvisioningArtifactOutput");
+    return __isa(o, "CreateProvisioningArtifactOutput");
   }
 }
 
@@ -1675,7 +1669,7 @@ export interface CreateServiceActionInput {
 
 export namespace CreateServiceActionInput {
   export function isa(o: any): o is CreateServiceActionInput {
-    return _smithy.isa(o, "CreateServiceActionInput");
+    return __isa(o, "CreateServiceActionInput");
   }
 }
 
@@ -1689,7 +1683,7 @@ export interface CreateServiceActionOutput extends $MetadataBearer {
 
 export namespace CreateServiceActionOutput {
   export function isa(o: any): o is CreateServiceActionOutput {
-    return _smithy.isa(o, "CreateServiceActionOutput");
+    return __isa(o, "CreateServiceActionOutput");
   }
 }
 
@@ -1722,7 +1716,7 @@ export interface DeleteConstraintInput {
 
 export namespace DeleteConstraintInput {
   export function isa(o: any): o is DeleteConstraintInput {
-    return _smithy.isa(o, "DeleteConstraintInput");
+    return __isa(o, "DeleteConstraintInput");
   }
 }
 
@@ -1732,7 +1726,7 @@ export interface DeleteConstraintOutput extends $MetadataBearer {
 
 export namespace DeleteConstraintOutput {
   export function isa(o: any): o is DeleteConstraintOutput {
-    return _smithy.isa(o, "DeleteConstraintOutput");
+    return __isa(o, "DeleteConstraintOutput");
   }
 }
 
@@ -1765,7 +1759,7 @@ export interface DeletePortfolioInput {
 
 export namespace DeletePortfolioInput {
   export function isa(o: any): o is DeletePortfolioInput {
-    return _smithy.isa(o, "DeletePortfolioInput");
+    return __isa(o, "DeletePortfolioInput");
   }
 }
 
@@ -1775,7 +1769,7 @@ export interface DeletePortfolioOutput extends $MetadataBearer {
 
 export namespace DeletePortfolioOutput {
   export function isa(o: any): o is DeletePortfolioOutput {
-    return _smithy.isa(o, "DeletePortfolioOutput");
+    return __isa(o, "DeletePortfolioOutput");
   }
 }
 
@@ -1818,7 +1812,7 @@ export interface DeletePortfolioShareInput {
 
 export namespace DeletePortfolioShareInput {
   export function isa(o: any): o is DeletePortfolioShareInput {
-    return _smithy.isa(o, "DeletePortfolioShareInput");
+    return __isa(o, "DeletePortfolioShareInput");
   }
 }
 
@@ -1832,7 +1826,7 @@ export interface DeletePortfolioShareOutput extends $MetadataBearer {
 
 export namespace DeletePortfolioShareOutput {
   export function isa(o: any): o is DeletePortfolioShareOutput {
-    return _smithy.isa(o, "DeletePortfolioShareOutput");
+    return __isa(o, "DeletePortfolioShareOutput");
   }
 }
 
@@ -1865,7 +1859,7 @@ export interface DeleteProductInput {
 
 export namespace DeleteProductInput {
   export function isa(o: any): o is DeleteProductInput {
-    return _smithy.isa(o, "DeleteProductInput");
+    return __isa(o, "DeleteProductInput");
   }
 }
 
@@ -1875,7 +1869,7 @@ export interface DeleteProductOutput extends $MetadataBearer {
 
 export namespace DeleteProductOutput {
   export function isa(o: any): o is DeleteProductOutput {
-    return _smithy.isa(o, "DeleteProductOutput");
+    return __isa(o, "DeleteProductOutput");
   }
 }
 
@@ -1914,7 +1908,7 @@ export interface DeleteProvisionedProductPlanInput {
 
 export namespace DeleteProvisionedProductPlanInput {
   export function isa(o: any): o is DeleteProvisionedProductPlanInput {
-    return _smithy.isa(o, "DeleteProvisionedProductPlanInput");
+    return __isa(o, "DeleteProvisionedProductPlanInput");
   }
 }
 
@@ -1924,7 +1918,7 @@ export interface DeleteProvisionedProductPlanOutput extends $MetadataBearer {
 
 export namespace DeleteProvisionedProductPlanOutput {
   export function isa(o: any): o is DeleteProvisionedProductPlanOutput {
-    return _smithy.isa(o, "DeleteProvisionedProductPlanOutput");
+    return __isa(o, "DeleteProvisionedProductPlanOutput");
   }
 }
 
@@ -1962,7 +1956,7 @@ export interface DeleteProvisioningArtifactInput {
 
 export namespace DeleteProvisioningArtifactInput {
   export function isa(o: any): o is DeleteProvisioningArtifactInput {
-    return _smithy.isa(o, "DeleteProvisioningArtifactInput");
+    return __isa(o, "DeleteProvisioningArtifactInput");
   }
 }
 
@@ -1972,7 +1966,7 @@ export interface DeleteProvisioningArtifactOutput extends $MetadataBearer {
 
 export namespace DeleteProvisioningArtifactOutput {
   export function isa(o: any): o is DeleteProvisioningArtifactOutput {
-    return _smithy.isa(o, "DeleteProvisioningArtifactOutput");
+    return __isa(o, "DeleteProvisioningArtifactOutput");
   }
 }
 
@@ -2005,7 +1999,7 @@ export interface DeleteServiceActionInput {
 
 export namespace DeleteServiceActionInput {
   export function isa(o: any): o is DeleteServiceActionInput {
-    return _smithy.isa(o, "DeleteServiceActionInput");
+    return __isa(o, "DeleteServiceActionInput");
   }
 }
 
@@ -2015,7 +2009,7 @@ export interface DeleteServiceActionOutput extends $MetadataBearer {
 
 export namespace DeleteServiceActionOutput {
   export function isa(o: any): o is DeleteServiceActionOutput {
-    return _smithy.isa(o, "DeleteServiceActionOutput");
+    return __isa(o, "DeleteServiceActionOutput");
   }
 }
 
@@ -2048,7 +2042,7 @@ export interface DescribeConstraintInput {
 
 export namespace DescribeConstraintInput {
   export function isa(o: any): o is DescribeConstraintInput {
-    return _smithy.isa(o, "DescribeConstraintInput");
+    return __isa(o, "DescribeConstraintInput");
   }
 }
 
@@ -2072,7 +2066,7 @@ export interface DescribeConstraintOutput extends $MetadataBearer {
 
 export namespace DescribeConstraintOutput {
   export function isa(o: any): o is DescribeConstraintOutput {
-    return _smithy.isa(o, "DescribeConstraintOutput");
+    return __isa(o, "DescribeConstraintOutput");
   }
 }
 
@@ -2105,7 +2099,7 @@ export interface DescribeCopyProductStatusInput {
 
 export namespace DescribeCopyProductStatusInput {
   export function isa(o: any): o is DescribeCopyProductStatusInput {
-    return _smithy.isa(o, "DescribeCopyProductStatusInput");
+    return __isa(o, "DescribeCopyProductStatusInput");
   }
 }
 
@@ -2129,7 +2123,7 @@ export interface DescribeCopyProductStatusOutput extends $MetadataBearer {
 
 export namespace DescribeCopyProductStatusOutput {
   export function isa(o: any): o is DescribeCopyProductStatusOutput {
-    return _smithy.isa(o, "DescribeCopyProductStatusOutput");
+    return __isa(o, "DescribeCopyProductStatusOutput");
   }
 }
 
@@ -2162,7 +2156,7 @@ export interface DescribePortfolioInput {
 
 export namespace DescribePortfolioInput {
   export function isa(o: any): o is DescribePortfolioInput {
-    return _smithy.isa(o, "DescribePortfolioInput");
+    return __isa(o, "DescribePortfolioInput");
   }
 }
 
@@ -2191,7 +2185,7 @@ export interface DescribePortfolioOutput extends $MetadataBearer {
 
 export namespace DescribePortfolioOutput {
   export function isa(o: any): o is DescribePortfolioOutput {
-    return _smithy.isa(o, "DescribePortfolioOutput");
+    return __isa(o, "DescribePortfolioOutput");
   }
 }
 
@@ -2205,7 +2199,7 @@ export interface DescribePortfolioShareStatusInput {
 
 export namespace DescribePortfolioShareStatusInput {
   export function isa(o: any): o is DescribePortfolioShareStatusInput {
-    return _smithy.isa(o, "DescribePortfolioShareStatusInput");
+    return __isa(o, "DescribePortfolioShareStatusInput");
   }
 }
 
@@ -2239,7 +2233,7 @@ export interface DescribePortfolioShareStatusOutput extends $MetadataBearer {
 
 export namespace DescribePortfolioShareStatusOutput {
   export function isa(o: any): o is DescribePortfolioShareStatusOutput {
-    return _smithy.isa(o, "DescribePortfolioShareStatusOutput");
+    return __isa(o, "DescribePortfolioShareStatusOutput");
   }
 }
 
@@ -2272,7 +2266,7 @@ export interface DescribeProductAsAdminInput {
 
 export namespace DescribeProductAsAdminInput {
   export function isa(o: any): o is DescribeProductAsAdminInput {
-    return _smithy.isa(o, "DescribeProductAsAdminInput");
+    return __isa(o, "DescribeProductAsAdminInput");
   }
 }
 
@@ -2306,7 +2300,7 @@ export interface DescribeProductAsAdminOutput extends $MetadataBearer {
 
 export namespace DescribeProductAsAdminOutput {
   export function isa(o: any): o is DescribeProductAsAdminOutput {
-    return _smithy.isa(o, "DescribeProductAsAdminOutput");
+    return __isa(o, "DescribeProductAsAdminOutput");
   }
 }
 
@@ -2339,7 +2333,7 @@ export interface DescribeProductInput {
 
 export namespace DescribeProductInput {
   export function isa(o: any): o is DescribeProductInput {
-    return _smithy.isa(o, "DescribeProductInput");
+    return __isa(o, "DescribeProductInput");
   }
 }
 
@@ -2363,7 +2357,7 @@ export interface DescribeProductOutput extends $MetadataBearer {
 
 export namespace DescribeProductOutput {
   export function isa(o: any): o is DescribeProductOutput {
-    return _smithy.isa(o, "DescribeProductOutput");
+    return __isa(o, "DescribeProductOutput");
   }
 }
 
@@ -2396,7 +2390,7 @@ export interface DescribeProductViewInput {
 
 export namespace DescribeProductViewInput {
   export function isa(o: any): o is DescribeProductViewInput {
-    return _smithy.isa(o, "DescribeProductViewInput");
+    return __isa(o, "DescribeProductViewInput");
   }
 }
 
@@ -2415,7 +2409,7 @@ export interface DescribeProductViewOutput extends $MetadataBearer {
 
 export namespace DescribeProductViewOutput {
   export function isa(o: any): o is DescribeProductViewOutput {
-    return _smithy.isa(o, "DescribeProductViewOutput");
+    return __isa(o, "DescribeProductViewOutput");
   }
 }
 
@@ -2448,7 +2442,7 @@ export interface DescribeProvisionedProductInput {
 
 export namespace DescribeProvisionedProductInput {
   export function isa(o: any): o is DescribeProvisionedProductInput {
-    return _smithy.isa(o, "DescribeProvisionedProductInput");
+    return __isa(o, "DescribeProvisionedProductInput");
   }
 }
 
@@ -2467,7 +2461,7 @@ export interface DescribeProvisionedProductOutput extends $MetadataBearer {
 
 export namespace DescribeProvisionedProductOutput {
   export function isa(o: any): o is DescribeProvisionedProductOutput {
-    return _smithy.isa(o, "DescribeProvisionedProductOutput");
+    return __isa(o, "DescribeProvisionedProductOutput");
   }
 }
 
@@ -2510,7 +2504,7 @@ export interface DescribeProvisionedProductPlanInput {
 
 export namespace DescribeProvisionedProductPlanInput {
   export function isa(o: any): o is DescribeProvisionedProductPlanInput {
-    return _smithy.isa(o, "DescribeProvisionedProductPlanInput");
+    return __isa(o, "DescribeProvisionedProductPlanInput");
   }
 }
 
@@ -2534,7 +2528,7 @@ export interface DescribeProvisionedProductPlanOutput extends $MetadataBearer {
 
 export namespace DescribeProvisionedProductPlanOutput {
   export function isa(o: any): o is DescribeProvisionedProductPlanOutput {
-    return _smithy.isa(o, "DescribeProvisionedProductPlanOutput");
+    return __isa(o, "DescribeProvisionedProductPlanOutput");
   }
 }
 
@@ -2577,7 +2571,7 @@ export interface DescribeProvisioningArtifactInput {
 
 export namespace DescribeProvisioningArtifactInput {
   export function isa(o: any): o is DescribeProvisioningArtifactInput {
-    return _smithy.isa(o, "DescribeProvisioningArtifactInput");
+    return __isa(o, "DescribeProvisioningArtifactInput");
   }
 }
 
@@ -2601,7 +2595,7 @@ export interface DescribeProvisioningArtifactOutput extends $MetadataBearer {
 
 export namespace DescribeProvisioningArtifactOutput {
   export function isa(o: any): o is DescribeProvisioningArtifactOutput {
-    return _smithy.isa(o, "DescribeProvisioningArtifactOutput");
+    return __isa(o, "DescribeProvisioningArtifactOutput");
   }
 }
 
@@ -2646,7 +2640,7 @@ export interface DescribeProvisioningParametersInput {
 
 export namespace DescribeProvisioningParametersInput {
   export function isa(o: any): o is DescribeProvisioningParametersInput {
-    return _smithy.isa(o, "DescribeProvisioningParametersInput");
+    return __isa(o, "DescribeProvisioningParametersInput");
   }
 }
 
@@ -2681,7 +2675,7 @@ export interface DescribeProvisioningParametersOutput extends $MetadataBearer {
 
 export namespace DescribeProvisioningParametersOutput {
   export function isa(o: any): o is DescribeProvisioningParametersOutput {
-    return _smithy.isa(o, "DescribeProvisioningParametersOutput");
+    return __isa(o, "DescribeProvisioningParametersOutput");
   }
 }
 
@@ -2725,7 +2719,7 @@ export interface DescribeRecordInput {
 
 export namespace DescribeRecordInput {
   export function isa(o: any): o is DescribeRecordInput {
-    return _smithy.isa(o, "DescribeRecordInput");
+    return __isa(o, "DescribeRecordInput");
   }
 }
 
@@ -2750,7 +2744,7 @@ export interface DescribeRecordOutput extends $MetadataBearer {
 
 export namespace DescribeRecordOutput {
   export function isa(o: any): o is DescribeRecordOutput {
-    return _smithy.isa(o, "DescribeRecordOutput");
+    return __isa(o, "DescribeRecordOutput");
   }
 }
 
@@ -2765,7 +2759,7 @@ export namespace DescribeServiceActionExecutionParametersInput {
   export function isa(
     o: any
   ): o is DescribeServiceActionExecutionParametersInput {
-    return _smithy.isa(o, "DescribeServiceActionExecutionParametersInput");
+    return __isa(o, "DescribeServiceActionExecutionParametersInput");
   }
 }
 
@@ -2779,7 +2773,7 @@ export namespace DescribeServiceActionExecutionParametersOutput {
   export function isa(
     o: any
   ): o is DescribeServiceActionExecutionParametersOutput {
-    return _smithy.isa(o, "DescribeServiceActionExecutionParametersOutput");
+    return __isa(o, "DescribeServiceActionExecutionParametersOutput");
   }
 }
 
@@ -2812,7 +2806,7 @@ export interface DescribeServiceActionInput {
 
 export namespace DescribeServiceActionInput {
   export function isa(o: any): o is DescribeServiceActionInput {
-    return _smithy.isa(o, "DescribeServiceActionInput");
+    return __isa(o, "DescribeServiceActionInput");
   }
 }
 
@@ -2826,7 +2820,7 @@ export interface DescribeServiceActionOutput extends $MetadataBearer {
 
 export namespace DescribeServiceActionOutput {
   export function isa(o: any): o is DescribeServiceActionOutput {
-    return _smithy.isa(o, "DescribeServiceActionOutput");
+    return __isa(o, "DescribeServiceActionOutput");
   }
 }
 
@@ -2836,7 +2830,7 @@ export interface DisableAWSOrganizationsAccessInput {
 
 export namespace DisableAWSOrganizationsAccessInput {
   export function isa(o: any): o is DisableAWSOrganizationsAccessInput {
-    return _smithy.isa(o, "DisableAWSOrganizationsAccessInput");
+    return __isa(o, "DisableAWSOrganizationsAccessInput");
   }
 }
 
@@ -2846,7 +2840,7 @@ export interface DisableAWSOrganizationsAccessOutput extends $MetadataBearer {
 
 export namespace DisableAWSOrganizationsAccessOutput {
   export function isa(o: any): o is DisableAWSOrganizationsAccessOutput {
-    return _smithy.isa(o, "DisableAWSOrganizationsAccessOutput");
+    return __isa(o, "DisableAWSOrganizationsAccessOutput");
   }
 }
 
@@ -2865,7 +2859,7 @@ export interface DisassociateBudgetFromResourceInput {
 
 export namespace DisassociateBudgetFromResourceInput {
   export function isa(o: any): o is DisassociateBudgetFromResourceInput {
-    return _smithy.isa(o, "DisassociateBudgetFromResourceInput");
+    return __isa(o, "DisassociateBudgetFromResourceInput");
   }
 }
 
@@ -2875,7 +2869,7 @@ export interface DisassociateBudgetFromResourceOutput extends $MetadataBearer {
 
 export namespace DisassociateBudgetFromResourceOutput {
   export function isa(o: any): o is DisassociateBudgetFromResourceOutput {
-    return _smithy.isa(o, "DisassociateBudgetFromResourceOutput");
+    return __isa(o, "DisassociateBudgetFromResourceOutput");
   }
 }
 
@@ -2913,7 +2907,7 @@ export interface DisassociatePrincipalFromPortfolioInput {
 
 export namespace DisassociatePrincipalFromPortfolioInput {
   export function isa(o: any): o is DisassociatePrincipalFromPortfolioInput {
-    return _smithy.isa(o, "DisassociatePrincipalFromPortfolioInput");
+    return __isa(o, "DisassociatePrincipalFromPortfolioInput");
   }
 }
 
@@ -2924,7 +2918,7 @@ export interface DisassociatePrincipalFromPortfolioOutput
 
 export namespace DisassociatePrincipalFromPortfolioOutput {
   export function isa(o: any): o is DisassociatePrincipalFromPortfolioOutput {
-    return _smithy.isa(o, "DisassociatePrincipalFromPortfolioOutput");
+    return __isa(o, "DisassociatePrincipalFromPortfolioOutput");
   }
 }
 
@@ -2962,7 +2956,7 @@ export interface DisassociateProductFromPortfolioInput {
 
 export namespace DisassociateProductFromPortfolioInput {
   export function isa(o: any): o is DisassociateProductFromPortfolioInput {
-    return _smithy.isa(o, "DisassociateProductFromPortfolioInput");
+    return __isa(o, "DisassociateProductFromPortfolioInput");
   }
 }
 
@@ -2973,7 +2967,7 @@ export interface DisassociateProductFromPortfolioOutput
 
 export namespace DisassociateProductFromPortfolioOutput {
   export function isa(o: any): o is DisassociateProductFromPortfolioOutput {
-    return _smithy.isa(o, "DisassociateProductFromPortfolioOutput");
+    return __isa(o, "DisassociateProductFromPortfolioOutput");
   }
 }
 
@@ -3018,10 +3012,7 @@ export namespace DisassociateServiceActionFromProvisioningArtifactInput {
   export function isa(
     o: any
   ): o is DisassociateServiceActionFromProvisioningArtifactInput {
-    return _smithy.isa(
-      o,
-      "DisassociateServiceActionFromProvisioningArtifactInput"
-    );
+    return __isa(o, "DisassociateServiceActionFromProvisioningArtifactInput");
   }
 }
 
@@ -3034,10 +3025,7 @@ export namespace DisassociateServiceActionFromProvisioningArtifactOutput {
   export function isa(
     o: any
   ): o is DisassociateServiceActionFromProvisioningArtifactOutput {
-    return _smithy.isa(
-      o,
-      "DisassociateServiceActionFromProvisioningArtifactOutput"
-    );
+    return __isa(o, "DisassociateServiceActionFromProvisioningArtifactOutput");
   }
 }
 
@@ -3045,7 +3033,7 @@ export namespace DisassociateServiceActionFromProvisioningArtifactOutput {
  * <p>The specified resource is a duplicate.</p>
  */
 export interface DuplicateResourceException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DuplicateResourceException";
   $fault: "client";
@@ -3054,7 +3042,7 @@ export interface DuplicateResourceException
 
 export namespace DuplicateResourceException {
   export function isa(o: any): o is DuplicateResourceException {
-    return _smithy.isa(o, "DuplicateResourceException");
+    return __isa(o, "DuplicateResourceException");
   }
 }
 
@@ -3064,7 +3052,7 @@ export interface EnableAWSOrganizationsAccessInput {
 
 export namespace EnableAWSOrganizationsAccessInput {
   export function isa(o: any): o is EnableAWSOrganizationsAccessInput {
-    return _smithy.isa(o, "EnableAWSOrganizationsAccessInput");
+    return __isa(o, "EnableAWSOrganizationsAccessInput");
   }
 }
 
@@ -3074,7 +3062,7 @@ export interface EnableAWSOrganizationsAccessOutput extends $MetadataBearer {
 
 export namespace EnableAWSOrganizationsAccessOutput {
   export function isa(o: any): o is EnableAWSOrganizationsAccessOutput {
-    return _smithy.isa(o, "EnableAWSOrganizationsAccessOutput");
+    return __isa(o, "EnableAWSOrganizationsAccessOutput");
   }
 }
 
@@ -3118,7 +3106,7 @@ export interface ExecuteProvisionedProductPlanInput {
 
 export namespace ExecuteProvisionedProductPlanInput {
   export function isa(o: any): o is ExecuteProvisionedProductPlanInput {
-    return _smithy.isa(o, "ExecuteProvisionedProductPlanInput");
+    return __isa(o, "ExecuteProvisionedProductPlanInput");
   }
 }
 
@@ -3132,7 +3120,7 @@ export interface ExecuteProvisionedProductPlanOutput extends $MetadataBearer {
 
 export namespace ExecuteProvisionedProductPlanOutput {
   export function isa(o: any): o is ExecuteProvisionedProductPlanOutput {
-    return _smithy.isa(o, "ExecuteProvisionedProductPlanOutput");
+    return __isa(o, "ExecuteProvisionedProductPlanOutput");
   }
 }
 
@@ -3178,7 +3166,7 @@ export namespace ExecuteProvisionedProductServiceActionInput {
   export function isa(
     o: any
   ): o is ExecuteProvisionedProductServiceActionInput {
-    return _smithy.isa(o, "ExecuteProvisionedProductServiceActionInput");
+    return __isa(o, "ExecuteProvisionedProductServiceActionInput");
   }
 }
 
@@ -3195,7 +3183,7 @@ export namespace ExecuteProvisionedProductServiceActionOutput {
   export function isa(
     o: any
   ): o is ExecuteProvisionedProductServiceActionOutput {
-    return _smithy.isa(o, "ExecuteProvisionedProductServiceActionOutput");
+    return __isa(o, "ExecuteProvisionedProductServiceActionOutput");
   }
 }
 
@@ -3208,7 +3196,7 @@ export interface ExecutionParameter {
 
 export namespace ExecutionParameter {
   export function isa(o: any): o is ExecutionParameter {
-    return _smithy.isa(o, "ExecutionParameter");
+    return __isa(o, "ExecutionParameter");
   }
 }
 
@@ -3245,7 +3233,7 @@ export interface FailedServiceActionAssociation {
 
 export namespace FailedServiceActionAssociation {
   export function isa(o: any): o is FailedServiceActionAssociation {
-    return _smithy.isa(o, "FailedServiceActionAssociation");
+    return __isa(o, "FailedServiceActionAssociation");
   }
 }
 
@@ -3255,7 +3243,7 @@ export interface GetAWSOrganizationsAccessStatusInput {
 
 export namespace GetAWSOrganizationsAccessStatusInput {
   export function isa(o: any): o is GetAWSOrganizationsAccessStatusInput {
-    return _smithy.isa(o, "GetAWSOrganizationsAccessStatusInput");
+    return __isa(o, "GetAWSOrganizationsAccessStatusInput");
   }
 }
 
@@ -3269,7 +3257,7 @@ export interface GetAWSOrganizationsAccessStatusOutput extends $MetadataBearer {
 
 export namespace GetAWSOrganizationsAccessStatusOutput {
   export function isa(o: any): o is GetAWSOrganizationsAccessStatusOutput {
-    return _smithy.isa(o, "GetAWSOrganizationsAccessStatusOutput");
+    return __isa(o, "GetAWSOrganizationsAccessStatusOutput");
   }
 }
 
@@ -3277,7 +3265,7 @@ export namespace GetAWSOrganizationsAccessStatusOutput {
  * <p>One or more parameters provided to the operation are not valid.</p>
  */
 export interface InvalidParametersException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidParametersException";
   $fault: "client";
@@ -3286,7 +3274,7 @@ export interface InvalidParametersException
 
 export namespace InvalidParametersException {
   export function isa(o: any): o is InvalidParametersException {
-    return _smithy.isa(o, "InvalidParametersException");
+    return __isa(o, "InvalidParametersException");
   }
 }
 
@@ -3295,7 +3283,7 @@ export namespace InvalidParametersException {
  *          Check your resources to ensure that they are in valid states before retrying the operation.</p>
  */
 export interface InvalidStateException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidStateException";
   $fault: "client";
@@ -3304,7 +3292,7 @@ export interface InvalidStateException
 
 export namespace InvalidStateException {
   export function isa(o: any): o is InvalidStateException {
-    return _smithy.isa(o, "InvalidStateException");
+    return __isa(o, "InvalidStateException");
   }
 }
 
@@ -3336,7 +3324,7 @@ export interface LaunchPathSummary {
 
 export namespace LaunchPathSummary {
   export function isa(o: any): o is LaunchPathSummary {
-    return _smithy.isa(o, "LaunchPathSummary");
+    return __isa(o, "LaunchPathSummary");
   }
 }
 
@@ -3345,7 +3333,7 @@ export namespace LaunchPathSummary {
  *          resource use or increase your service limits and retry the operation.</p>
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -3354,7 +3342,7 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
@@ -3411,7 +3399,7 @@ export interface ListAcceptedPortfolioSharesInput {
 
 export namespace ListAcceptedPortfolioSharesInput {
   export function isa(o: any): o is ListAcceptedPortfolioSharesInput {
-    return _smithy.isa(o, "ListAcceptedPortfolioSharesInput");
+    return __isa(o, "ListAcceptedPortfolioSharesInput");
   }
 }
 
@@ -3430,7 +3418,7 @@ export interface ListAcceptedPortfolioSharesOutput extends $MetadataBearer {
 
 export namespace ListAcceptedPortfolioSharesOutput {
   export function isa(o: any): o is ListAcceptedPortfolioSharesOutput {
-    return _smithy.isa(o, "ListAcceptedPortfolioSharesOutput");
+    return __isa(o, "ListAcceptedPortfolioSharesOutput");
   }
 }
 
@@ -3473,7 +3461,7 @@ export interface ListBudgetsForResourceInput {
 
 export namespace ListBudgetsForResourceInput {
   export function isa(o: any): o is ListBudgetsForResourceInput {
-    return _smithy.isa(o, "ListBudgetsForResourceInput");
+    return __isa(o, "ListBudgetsForResourceInput");
   }
 }
 
@@ -3492,7 +3480,7 @@ export interface ListBudgetsForResourceOutput extends $MetadataBearer {
 
 export namespace ListBudgetsForResourceOutput {
   export function isa(o: any): o is ListBudgetsForResourceOutput {
-    return _smithy.isa(o, "ListBudgetsForResourceOutput");
+    return __isa(o, "ListBudgetsForResourceOutput");
   }
 }
 
@@ -3540,7 +3528,7 @@ export interface ListConstraintsForPortfolioInput {
 
 export namespace ListConstraintsForPortfolioInput {
   export function isa(o: any): o is ListConstraintsForPortfolioInput {
-    return _smithy.isa(o, "ListConstraintsForPortfolioInput");
+    return __isa(o, "ListConstraintsForPortfolioInput");
   }
 }
 
@@ -3559,7 +3547,7 @@ export interface ListConstraintsForPortfolioOutput extends $MetadataBearer {
 
 export namespace ListConstraintsForPortfolioOutput {
   export function isa(o: any): o is ListConstraintsForPortfolioOutput {
-    return _smithy.isa(o, "ListConstraintsForPortfolioOutput");
+    return __isa(o, "ListConstraintsForPortfolioOutput");
   }
 }
 
@@ -3602,7 +3590,7 @@ export interface ListLaunchPathsInput {
 
 export namespace ListLaunchPathsInput {
   export function isa(o: any): o is ListLaunchPathsInput {
-    return _smithy.isa(o, "ListLaunchPathsInput");
+    return __isa(o, "ListLaunchPathsInput");
   }
 }
 
@@ -3621,7 +3609,7 @@ export interface ListLaunchPathsOutput extends $MetadataBearer {
 
 export namespace ListLaunchPathsOutput {
   export function isa(o: any): o is ListLaunchPathsOutput {
-    return _smithy.isa(o, "ListLaunchPathsOutput");
+    return __isa(o, "ListLaunchPathsOutput");
   }
 }
 
@@ -3683,7 +3671,7 @@ export interface ListOrganizationPortfolioAccessInput {
 
 export namespace ListOrganizationPortfolioAccessInput {
   export function isa(o: any): o is ListOrganizationPortfolioAccessInput {
-    return _smithy.isa(o, "ListOrganizationPortfolioAccessInput");
+    return __isa(o, "ListOrganizationPortfolioAccessInput");
   }
 }
 
@@ -3702,7 +3690,7 @@ export interface ListOrganizationPortfolioAccessOutput extends $MetadataBearer {
 
 export namespace ListOrganizationPortfolioAccessOutput {
   export function isa(o: any): o is ListOrganizationPortfolioAccessOutput {
-    return _smithy.isa(o, "ListOrganizationPortfolioAccessOutput");
+    return __isa(o, "ListOrganizationPortfolioAccessOutput");
   }
 }
 
@@ -3735,7 +3723,7 @@ export interface ListPortfolioAccessInput {
 
 export namespace ListPortfolioAccessInput {
   export function isa(o: any): o is ListPortfolioAccessInput {
-    return _smithy.isa(o, "ListPortfolioAccessInput");
+    return __isa(o, "ListPortfolioAccessInput");
   }
 }
 
@@ -3754,7 +3742,7 @@ export interface ListPortfolioAccessOutput extends $MetadataBearer {
 
 export namespace ListPortfolioAccessOutput {
   export function isa(o: any): o is ListPortfolioAccessOutput {
-    return _smithy.isa(o, "ListPortfolioAccessOutput");
+    return __isa(o, "ListPortfolioAccessOutput");
   }
 }
 
@@ -3797,7 +3785,7 @@ export interface ListPortfoliosForProductInput {
 
 export namespace ListPortfoliosForProductInput {
   export function isa(o: any): o is ListPortfoliosForProductInput {
-    return _smithy.isa(o, "ListPortfoliosForProductInput");
+    return __isa(o, "ListPortfoliosForProductInput");
   }
 }
 
@@ -3816,7 +3804,7 @@ export interface ListPortfoliosForProductOutput extends $MetadataBearer {
 
 export namespace ListPortfoliosForProductOutput {
   export function isa(o: any): o is ListPortfoliosForProductOutput {
-    return _smithy.isa(o, "ListPortfoliosForProductOutput");
+    return __isa(o, "ListPortfoliosForProductOutput");
   }
 }
 
@@ -3854,7 +3842,7 @@ export interface ListPortfoliosInput {
 
 export namespace ListPortfoliosInput {
   export function isa(o: any): o is ListPortfoliosInput {
-    return _smithy.isa(o, "ListPortfoliosInput");
+    return __isa(o, "ListPortfoliosInput");
   }
 }
 
@@ -3873,7 +3861,7 @@ export interface ListPortfoliosOutput extends $MetadataBearer {
 
 export namespace ListPortfoliosOutput {
   export function isa(o: any): o is ListPortfoliosOutput {
-    return _smithy.isa(o, "ListPortfoliosOutput");
+    return __isa(o, "ListPortfoliosOutput");
   }
 }
 
@@ -3916,7 +3904,7 @@ export interface ListPrincipalsForPortfolioInput {
 
 export namespace ListPrincipalsForPortfolioInput {
   export function isa(o: any): o is ListPrincipalsForPortfolioInput {
-    return _smithy.isa(o, "ListPrincipalsForPortfolioInput");
+    return __isa(o, "ListPrincipalsForPortfolioInput");
   }
 }
 
@@ -3935,7 +3923,7 @@ export interface ListPrincipalsForPortfolioOutput extends $MetadataBearer {
 
 export namespace ListPrincipalsForPortfolioOutput {
   export function isa(o: any): o is ListPrincipalsForPortfolioOutput {
-    return _smithy.isa(o, "ListPrincipalsForPortfolioOutput");
+    return __isa(o, "ListPrincipalsForPortfolioOutput");
   }
 }
 
@@ -3983,7 +3971,7 @@ export interface ListProvisionedProductPlansInput {
 
 export namespace ListProvisionedProductPlansInput {
   export function isa(o: any): o is ListProvisionedProductPlansInput {
-    return _smithy.isa(o, "ListProvisionedProductPlansInput");
+    return __isa(o, "ListProvisionedProductPlansInput");
   }
 }
 
@@ -4002,7 +3990,7 @@ export interface ListProvisionedProductPlansOutput extends $MetadataBearer {
 
 export namespace ListProvisionedProductPlansOutput {
   export function isa(o: any): o is ListProvisionedProductPlansOutput {
-    return _smithy.isa(o, "ListProvisionedProductPlansOutput");
+    return __isa(o, "ListProvisionedProductPlansOutput");
   }
 }
 
@@ -4047,7 +4035,7 @@ export namespace ListProvisioningArtifactsForServiceActionInput {
   export function isa(
     o: any
   ): o is ListProvisioningArtifactsForServiceActionInput {
-    return _smithy.isa(o, "ListProvisioningArtifactsForServiceActionInput");
+    return __isa(o, "ListProvisioningArtifactsForServiceActionInput");
   }
 }
 
@@ -4069,7 +4057,7 @@ export namespace ListProvisioningArtifactsForServiceActionOutput {
   export function isa(
     o: any
   ): o is ListProvisioningArtifactsForServiceActionOutput {
-    return _smithy.isa(o, "ListProvisioningArtifactsForServiceActionOutput");
+    return __isa(o, "ListProvisioningArtifactsForServiceActionOutput");
   }
 }
 
@@ -4102,7 +4090,7 @@ export interface ListProvisioningArtifactsInput {
 
 export namespace ListProvisioningArtifactsInput {
   export function isa(o: any): o is ListProvisioningArtifactsInput {
-    return _smithy.isa(o, "ListProvisioningArtifactsInput");
+    return __isa(o, "ListProvisioningArtifactsInput");
   }
 }
 
@@ -4121,7 +4109,7 @@ export interface ListProvisioningArtifactsOutput extends $MetadataBearer {
 
 export namespace ListProvisioningArtifactsOutput {
   export function isa(o: any): o is ListProvisioningArtifactsOutput {
-    return _smithy.isa(o, "ListProvisioningArtifactsOutput");
+    return __isa(o, "ListProvisioningArtifactsOutput");
   }
 }
 
@@ -4169,7 +4157,7 @@ export interface ListRecordHistoryInput {
 
 export namespace ListRecordHistoryInput {
   export function isa(o: any): o is ListRecordHistoryInput {
-    return _smithy.isa(o, "ListRecordHistoryInput");
+    return __isa(o, "ListRecordHistoryInput");
   }
 }
 
@@ -4188,7 +4176,7 @@ export interface ListRecordHistoryOutput extends $MetadataBearer {
 
 export namespace ListRecordHistoryOutput {
   export function isa(o: any): o is ListRecordHistoryOutput {
-    return _smithy.isa(o, "ListRecordHistoryOutput");
+    return __isa(o, "ListRecordHistoryOutput");
   }
 }
 
@@ -4220,7 +4208,7 @@ export interface ListRecordHistorySearchFilter {
 
 export namespace ListRecordHistorySearchFilter {
   export function isa(o: any): o is ListRecordHistorySearchFilter {
-    return _smithy.isa(o, "ListRecordHistorySearchFilter");
+    return __isa(o, "ListRecordHistorySearchFilter");
   }
 }
 
@@ -4270,7 +4258,7 @@ export namespace ListServiceActionsForProvisioningArtifactInput {
   export function isa(
     o: any
   ): o is ListServiceActionsForProvisioningArtifactInput {
-    return _smithy.isa(o, "ListServiceActionsForProvisioningArtifactInput");
+    return __isa(o, "ListServiceActionsForProvisioningArtifactInput");
   }
 }
 
@@ -4292,7 +4280,7 @@ export namespace ListServiceActionsForProvisioningArtifactOutput {
   export function isa(
     o: any
   ): o is ListServiceActionsForProvisioningArtifactOutput {
-    return _smithy.isa(o, "ListServiceActionsForProvisioningArtifactOutput");
+    return __isa(o, "ListServiceActionsForProvisioningArtifactOutput");
   }
 }
 
@@ -4330,7 +4318,7 @@ export interface ListServiceActionsInput {
 
 export namespace ListServiceActionsInput {
   export function isa(o: any): o is ListServiceActionsInput {
-    return _smithy.isa(o, "ListServiceActionsInput");
+    return __isa(o, "ListServiceActionsInput");
   }
 }
 
@@ -4349,7 +4337,7 @@ export interface ListServiceActionsOutput extends $MetadataBearer {
 
 export namespace ListServiceActionsOutput {
   export function isa(o: any): o is ListServiceActionsOutput {
-    return _smithy.isa(o, "ListServiceActionsOutput");
+    return __isa(o, "ListServiceActionsOutput");
   }
 }
 
@@ -4394,7 +4382,7 @@ export namespace ListStackInstancesForProvisionedProductInput {
   export function isa(
     o: any
   ): o is ListStackInstancesForProvisionedProductInput {
-    return _smithy.isa(o, "ListStackInstancesForProvisionedProductInput");
+    return __isa(o, "ListStackInstancesForProvisionedProductInput");
   }
 }
 
@@ -4416,7 +4404,7 @@ export namespace ListStackInstancesForProvisionedProductOutput {
   export function isa(
     o: any
   ): o is ListStackInstancesForProvisionedProductOutput {
-    return _smithy.isa(o, "ListStackInstancesForProvisionedProductOutput");
+    return __isa(o, "ListStackInstancesForProvisionedProductOutput");
   }
 }
 
@@ -4424,7 +4412,7 @@ export namespace ListStackInstancesForProvisionedProductOutput {
  * <p>The operation is not supported.</p>
  */
 export interface OperationNotSupportedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "OperationNotSupportedException";
   $fault: "client";
@@ -4433,7 +4421,7 @@ export interface OperationNotSupportedException
 
 export namespace OperationNotSupportedException {
   export function isa(o: any): o is OperationNotSupportedException {
-    return _smithy.isa(o, "OperationNotSupportedException");
+    return __isa(o, "OperationNotSupportedException");
   }
 }
 
@@ -4455,7 +4443,7 @@ export interface OrganizationNode {
 
 export namespace OrganizationNode {
   export function isa(o: any): o is OrganizationNode {
-    return _smithy.isa(o, "OrganizationNode");
+    return __isa(o, "OrganizationNode");
   }
 }
 
@@ -4478,7 +4466,7 @@ export interface ParameterConstraints {
 
 export namespace ParameterConstraints {
   export function isa(o: any): o is ParameterConstraints {
-    return _smithy.isa(o, "ParameterConstraints");
+    return __isa(o, "ParameterConstraints");
   }
 }
 
@@ -4520,7 +4508,7 @@ export interface PortfolioDetail {
 
 export namespace PortfolioDetail {
   export function isa(o: any): o is PortfolioDetail {
-    return _smithy.isa(o, "PortfolioDetail");
+    return __isa(o, "PortfolioDetail");
   }
 }
 
@@ -4548,7 +4536,7 @@ export interface Principal {
 
 export namespace Principal {
   export function isa(o: any): o is Principal {
-    return _smithy.isa(o, "Principal");
+    return __isa(o, "Principal");
   }
 }
 
@@ -4584,7 +4572,7 @@ export interface ProductViewAggregationValue {
 
 export namespace ProductViewAggregationValue {
   export function isa(o: any): o is ProductViewAggregationValue {
-    return _smithy.isa(o, "ProductViewAggregationValue");
+    return __isa(o, "ProductViewAggregationValue");
   }
 }
 
@@ -4630,7 +4618,7 @@ export interface ProductViewDetail {
 
 export namespace ProductViewDetail {
   export function isa(o: any): o is ProductViewDetail {
-    return _smithy.isa(o, "ProductViewDetail");
+    return __isa(o, "ProductViewDetail");
   }
 }
 
@@ -4718,7 +4706,7 @@ export interface ProductViewSummary {
 
 export namespace ProductViewSummary {
   export function isa(o: any): o is ProductViewSummary {
-    return _smithy.isa(o, "ProductViewSummary");
+    return __isa(o, "ProductViewSummary");
   }
 }
 
@@ -4800,7 +4788,7 @@ export interface ProvisionProductInput {
 
 export namespace ProvisionProductInput {
   export function isa(o: any): o is ProvisionProductInput {
-    return _smithy.isa(o, "ProvisionProductInput");
+    return __isa(o, "ProvisionProductInput");
   }
 }
 
@@ -4814,7 +4802,7 @@ export interface ProvisionProductOutput extends $MetadataBearer {
 
 export namespace ProvisionProductOutput {
   export function isa(o: any): o is ProvisionProductOutput {
-    return _smithy.isa(o, "ProvisionProductOutput");
+    return __isa(o, "ProvisionProductOutput");
   }
 }
 
@@ -4930,7 +4918,7 @@ export interface ProvisionedProductAttribute {
 
 export namespace ProvisionedProductAttribute {
   export function isa(o: any): o is ProvisionedProductAttribute {
-    return _smithy.isa(o, "ProvisionedProductAttribute");
+    return __isa(o, "ProvisionedProductAttribute");
   }
 }
 
@@ -5026,7 +5014,7 @@ export interface ProvisionedProductDetail {
 
 export namespace ProvisionedProductDetail {
   export function isa(o: any): o is ProvisionedProductDetail {
-    return _smithy.isa(o, "ProvisionedProductDetail");
+    return __isa(o, "ProvisionedProductDetail");
   }
 }
 
@@ -5117,7 +5105,7 @@ export interface ProvisionedProductPlanDetails {
 
 export namespace ProvisionedProductPlanDetails {
   export function isa(o: any): o is ProvisionedProductPlanDetails {
-    return _smithy.isa(o, "ProvisionedProductPlanDetails");
+    return __isa(o, "ProvisionedProductPlanDetails");
   }
 }
 
@@ -5168,7 +5156,7 @@ export interface ProvisionedProductPlanSummary {
 
 export namespace ProvisionedProductPlanSummary {
   export function isa(o: any): o is ProvisionedProductPlanSummary {
-    return _smithy.isa(o, "ProvisionedProductPlanSummary");
+    return __isa(o, "ProvisionedProductPlanSummary");
   }
 }
 
@@ -5221,7 +5209,7 @@ export interface ProvisioningArtifact {
 
 export namespace ProvisioningArtifact {
   export function isa(o: any): o is ProvisioningArtifact {
-    return _smithy.isa(o, "ProvisioningArtifact");
+    return __isa(o, "ProvisioningArtifact");
   }
 }
 
@@ -5282,7 +5270,7 @@ export interface ProvisioningArtifactDetail {
 
 export namespace ProvisioningArtifactDetail {
   export function isa(o: any): o is ProvisioningArtifactDetail {
-    return _smithy.isa(o, "ProvisioningArtifactDetail");
+    return __isa(o, "ProvisioningArtifactDetail");
   }
 }
 
@@ -5330,7 +5318,7 @@ export interface ProvisioningArtifactParameter {
 
 export namespace ProvisioningArtifactParameter {
   export function isa(o: any): o is ProvisioningArtifactParameter {
-    return _smithy.isa(o, "ProvisioningArtifactParameter");
+    return __isa(o, "ProvisioningArtifactParameter");
   }
 }
 
@@ -5355,7 +5343,7 @@ export interface ProvisioningArtifactPreferences {
 
 export namespace ProvisioningArtifactPreferences {
   export function isa(o: any): o is ProvisioningArtifactPreferences {
-    return _smithy.isa(o, "ProvisioningArtifactPreferences");
+    return __isa(o, "ProvisioningArtifactPreferences");
   }
 }
 
@@ -5409,7 +5397,7 @@ export interface ProvisioningArtifactProperties {
 
 export namespace ProvisioningArtifactProperties {
   export function isa(o: any): o is ProvisioningArtifactProperties {
-    return _smithy.isa(o, "ProvisioningArtifactProperties");
+    return __isa(o, "ProvisioningArtifactProperties");
   }
 }
 
@@ -5450,7 +5438,7 @@ export interface ProvisioningArtifactSummary {
 
 export namespace ProvisioningArtifactSummary {
   export function isa(o: any): o is ProvisioningArtifactSummary {
-    return _smithy.isa(o, "ProvisioningArtifactSummary");
+    return __isa(o, "ProvisioningArtifactSummary");
   }
 }
 
@@ -5478,7 +5466,7 @@ export interface ProvisioningArtifactView {
 
 export namespace ProvisioningArtifactView {
   export function isa(o: any): o is ProvisioningArtifactView {
-    return _smithy.isa(o, "ProvisioningArtifactView");
+    return __isa(o, "ProvisioningArtifactView");
   }
 }
 
@@ -5500,7 +5488,7 @@ export interface ProvisioningParameter {
 
 export namespace ProvisioningParameter {
   export function isa(o: any): o is ProvisioningParameter {
-    return _smithy.isa(o, "ProvisioningParameter");
+    return __isa(o, "ProvisioningParameter");
   }
 }
 
@@ -5561,7 +5549,7 @@ export interface ProvisioningPreferences {
 
 export namespace ProvisioningPreferences {
   export function isa(o: any): o is ProvisioningPreferences {
-    return _smithy.isa(o, "ProvisioningPreferences");
+    return __isa(o, "ProvisioningPreferences");
   }
 }
 
@@ -5679,7 +5667,7 @@ export interface RecordDetail {
 
 export namespace RecordDetail {
   export function isa(o: any): o is RecordDetail {
-    return _smithy.isa(o, "RecordDetail");
+    return __isa(o, "RecordDetail");
   }
 }
 
@@ -5701,7 +5689,7 @@ export interface RecordError {
 
 export namespace RecordError {
   export function isa(o: any): o is RecordError {
-    return _smithy.isa(o, "RecordError");
+    return __isa(o, "RecordError");
   }
 }
 
@@ -5729,7 +5717,7 @@ export interface RecordOutput {
 
 export namespace RecordOutput {
   export function isa(o: any): o is RecordOutput {
-    return _smithy.isa(o, "RecordOutput");
+    return __isa(o, "RecordOutput");
   }
 }
 
@@ -5759,7 +5747,7 @@ export interface RecordTag {
 
 export namespace RecordTag {
   export function isa(o: any): o is RecordTag {
-    return _smithy.isa(o, "RecordTag");
+    return __isa(o, "RecordTag");
   }
 }
 
@@ -5813,7 +5801,7 @@ export interface RejectPortfolioShareInput {
 
 export namespace RejectPortfolioShareInput {
   export function isa(o: any): o is RejectPortfolioShareInput {
-    return _smithy.isa(o, "RejectPortfolioShareInput");
+    return __isa(o, "RejectPortfolioShareInput");
   }
 }
 
@@ -5823,7 +5811,7 @@ export interface RejectPortfolioShareOutput extends $MetadataBearer {
 
 export namespace RejectPortfolioShareOutput {
   export function isa(o: any): o is RejectPortfolioShareOutput {
-    return _smithy.isa(o, "RejectPortfolioShareOutput");
+    return __isa(o, "RejectPortfolioShareOutput");
   }
 }
 
@@ -5892,7 +5880,7 @@ export interface ResourceChange {
 
 export namespace ResourceChange {
   export function isa(o: any): o is ResourceChange {
-    return _smithy.isa(o, "ResourceChange");
+    return __isa(o, "ResourceChange");
   }
 }
 
@@ -5920,7 +5908,7 @@ export interface ResourceChangeDetail {
 
 export namespace ResourceChangeDetail {
   export function isa(o: any): o is ResourceChangeDetail {
-    return _smithy.isa(o, "ResourceChangeDetail");
+    return __isa(o, "ResourceChangeDetail");
   }
 }
 
@@ -5928,7 +5916,7 @@ export namespace ResourceChangeDetail {
  * <p>A resource that is currently in use. Ensure that the resource is not in use and retry the operation.</p>
  */
 export interface ResourceInUseException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceInUseException";
   $fault: "client";
@@ -5937,7 +5925,7 @@ export interface ResourceInUseException
 
 export namespace ResourceInUseException {
   export function isa(o: any): o is ResourceInUseException {
-    return _smithy.isa(o, "ResourceInUseException");
+    return __isa(o, "ResourceInUseException");
   }
 }
 
@@ -5945,7 +5933,7 @@ export namespace ResourceInUseException {
  * <p>The specified resource was not found.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -5954,7 +5942,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -5983,7 +5971,7 @@ export interface ResourceTargetDefinition {
 
 export namespace ResourceTargetDefinition {
   export function isa(o: any): o is ResourceTargetDefinition {
-    return _smithy.isa(o, "ResourceTargetDefinition");
+    return __isa(o, "ResourceTargetDefinition");
   }
 }
 
@@ -6026,7 +6014,7 @@ export interface ScanProvisionedProductsInput {
 
 export namespace ScanProvisionedProductsInput {
   export function isa(o: any): o is ScanProvisionedProductsInput {
-    return _smithy.isa(o, "ScanProvisionedProductsInput");
+    return __isa(o, "ScanProvisionedProductsInput");
   }
 }
 
@@ -6045,7 +6033,7 @@ export interface ScanProvisionedProductsOutput extends $MetadataBearer {
 
 export namespace ScanProvisionedProductsOutput {
   export function isa(o: any): o is ScanProvisionedProductsOutput {
-    return _smithy.isa(o, "ScanProvisionedProductsOutput");
+    return __isa(o, "ScanProvisionedProductsOutput");
   }
 }
 
@@ -6109,7 +6097,7 @@ export interface SearchProductsAsAdminInput {
 
 export namespace SearchProductsAsAdminInput {
   export function isa(o: any): o is SearchProductsAsAdminInput {
-    return _smithy.isa(o, "SearchProductsAsAdminInput");
+    return __isa(o, "SearchProductsAsAdminInput");
   }
 }
 
@@ -6128,7 +6116,7 @@ export interface SearchProductsAsAdminOutput extends $MetadataBearer {
 
 export namespace SearchProductsAsAdminOutput {
   export function isa(o: any): o is SearchProductsAsAdminOutput {
-    return _smithy.isa(o, "SearchProductsAsAdminOutput");
+    return __isa(o, "SearchProductsAsAdminOutput");
   }
 }
 
@@ -6182,7 +6170,7 @@ export interface SearchProductsInput {
 
 export namespace SearchProductsInput {
   export function isa(o: any): o is SearchProductsInput {
-    return _smithy.isa(o, "SearchProductsInput");
+    return __isa(o, "SearchProductsInput");
   }
 }
 
@@ -6208,7 +6196,7 @@ export interface SearchProductsOutput extends $MetadataBearer {
 
 export namespace SearchProductsOutput {
   export function isa(o: any): o is SearchProductsOutput {
-    return _smithy.isa(o, "SearchProductsOutput");
+    return __isa(o, "SearchProductsOutput");
   }
 }
 
@@ -6274,7 +6262,7 @@ export interface SearchProvisionedProductsInput {
 
 export namespace SearchProvisionedProductsInput {
   export function isa(o: any): o is SearchProvisionedProductsInput {
-    return _smithy.isa(o, "SearchProvisionedProductsInput");
+    return __isa(o, "SearchProvisionedProductsInput");
   }
 }
 
@@ -6298,7 +6286,7 @@ export interface SearchProvisionedProductsOutput extends $MetadataBearer {
 
 export namespace SearchProvisionedProductsOutput {
   export function isa(o: any): o is SearchProvisionedProductsOutput {
-    return _smithy.isa(o, "SearchProvisionedProductsOutput");
+    return __isa(o, "SearchProvisionedProductsOutput");
   }
 }
 
@@ -6325,7 +6313,7 @@ export interface ServiceActionAssociation {
 
 export namespace ServiceActionAssociation {
   export function isa(o: any): o is ServiceActionAssociation {
-    return _smithy.isa(o, "ServiceActionAssociation");
+    return __isa(o, "ServiceActionAssociation");
   }
 }
 
@@ -6366,7 +6354,7 @@ export interface ServiceActionDetail {
 
 export namespace ServiceActionDetail {
   export function isa(o: any): o is ServiceActionDetail {
-    return _smithy.isa(o, "ServiceActionDetail");
+    return __isa(o, "ServiceActionDetail");
   }
 }
 
@@ -6398,7 +6386,7 @@ export interface ServiceActionSummary {
 
 export namespace ServiceActionSummary {
   export function isa(o: any): o is ServiceActionSummary {
-    return _smithy.isa(o, "ServiceActionSummary");
+    return __isa(o, "ServiceActionSummary");
   }
 }
 
@@ -6420,7 +6408,7 @@ export interface ShareDetails {
 
 export namespace ShareDetails {
   export function isa(o: any): o is ShareDetails {
-    return _smithy.isa(o, "ShareDetails");
+    return __isa(o, "ShareDetails");
   }
 }
 
@@ -6447,7 +6435,7 @@ export interface ShareError {
 
 export namespace ShareError {
   export function isa(o: any): o is ShareError {
-    return _smithy.isa(o, "ShareError");
+    return __isa(o, "ShareError");
   }
 }
 
@@ -6503,7 +6491,7 @@ export interface StackInstance {
 
 export namespace StackInstance {
   export function isa(o: any): o is StackInstance {
-    return _smithy.isa(o, "StackInstance");
+    return __isa(o, "StackInstance");
   }
 }
 
@@ -6540,7 +6528,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -6550,7 +6538,7 @@ export namespace Tag {
  *          process before retrying the operation.</p>
  */
 export interface TagOptionNotMigratedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TagOptionNotMigratedException";
   $fault: "client";
@@ -6559,7 +6547,7 @@ export interface TagOptionNotMigratedException
 
 export namespace TagOptionNotMigratedException {
   export function isa(o: any): o is TagOptionNotMigratedException {
-    return _smithy.isa(o, "TagOptionNotMigratedException");
+    return __isa(o, "TagOptionNotMigratedException");
   }
 }
 
@@ -6581,7 +6569,7 @@ export interface TagOptionSummary {
 
 export namespace TagOptionSummary {
   export function isa(o: any): o is TagOptionSummary {
-    return _smithy.isa(o, "TagOptionSummary");
+    return __isa(o, "TagOptionSummary");
   }
 }
 
@@ -6635,7 +6623,7 @@ export interface TerminateProvisionedProductInput {
 
 export namespace TerminateProvisionedProductInput {
   export function isa(o: any): o is TerminateProvisionedProductInput {
-    return _smithy.isa(o, "TerminateProvisionedProductInput");
+    return __isa(o, "TerminateProvisionedProductInput");
   }
 }
 
@@ -6649,7 +6637,7 @@ export interface TerminateProvisionedProductOutput extends $MetadataBearer {
 
 export namespace TerminateProvisionedProductOutput {
   export function isa(o: any): o is TerminateProvisionedProductOutput {
-    return _smithy.isa(o, "TerminateProvisionedProductOutput");
+    return __isa(o, "TerminateProvisionedProductOutput");
   }
 }
 
@@ -6733,7 +6721,7 @@ export interface UpdateConstraintInput {
 
 export namespace UpdateConstraintInput {
   export function isa(o: any): o is UpdateConstraintInput {
-    return _smithy.isa(o, "UpdateConstraintInput");
+    return __isa(o, "UpdateConstraintInput");
   }
 }
 
@@ -6757,7 +6745,7 @@ export interface UpdateConstraintOutput extends $MetadataBearer {
 
 export namespace UpdateConstraintOutput {
   export function isa(o: any): o is UpdateConstraintOutput {
-    return _smithy.isa(o, "UpdateConstraintOutput");
+    return __isa(o, "UpdateConstraintOutput");
   }
 }
 
@@ -6815,7 +6803,7 @@ export interface UpdatePortfolioInput {
 
 export namespace UpdatePortfolioInput {
   export function isa(o: any): o is UpdatePortfolioInput {
-    return _smithy.isa(o, "UpdatePortfolioInput");
+    return __isa(o, "UpdatePortfolioInput");
   }
 }
 
@@ -6834,7 +6822,7 @@ export interface UpdatePortfolioOutput extends $MetadataBearer {
 
 export namespace UpdatePortfolioOutput {
   export function isa(o: any): o is UpdatePortfolioOutput {
-    return _smithy.isa(o, "UpdatePortfolioOutput");
+    return __isa(o, "UpdatePortfolioOutput");
   }
 }
 
@@ -6912,7 +6900,7 @@ export interface UpdateProductInput {
 
 export namespace UpdateProductInput {
   export function isa(o: any): o is UpdateProductInput {
-    return _smithy.isa(o, "UpdateProductInput");
+    return __isa(o, "UpdateProductInput");
   }
 }
 
@@ -6931,7 +6919,7 @@ export interface UpdateProductOutput extends $MetadataBearer {
 
 export namespace UpdateProductOutput {
   export function isa(o: any): o is UpdateProductOutput {
-    return _smithy.isa(o, "UpdateProductOutput");
+    return __isa(o, "UpdateProductOutput");
   }
 }
 
@@ -7007,7 +6995,7 @@ export interface UpdateProvisionedProductInput {
 
 export namespace UpdateProvisionedProductInput {
   export function isa(o: any): o is UpdateProvisionedProductInput {
-    return _smithy.isa(o, "UpdateProvisionedProductInput");
+    return __isa(o, "UpdateProvisionedProductInput");
   }
 }
 
@@ -7021,7 +7009,7 @@ export interface UpdateProvisionedProductOutput extends $MetadataBearer {
 
 export namespace UpdateProvisionedProductOutput {
   export function isa(o: any): o is UpdateProvisionedProductOutput {
-    return _smithy.isa(o, "UpdateProvisionedProductOutput");
+    return __isa(o, "UpdateProvisionedProductOutput");
   }
 }
 
@@ -7074,7 +7062,7 @@ export interface UpdateProvisionedProductPropertiesInput {
 
 export namespace UpdateProvisionedProductPropertiesInput {
   export function isa(o: any): o is UpdateProvisionedProductPropertiesInput {
-    return _smithy.isa(o, "UpdateProvisionedProductPropertiesInput");
+    return __isa(o, "UpdateProvisionedProductPropertiesInput");
   }
 }
 
@@ -7104,7 +7092,7 @@ export interface UpdateProvisionedProductPropertiesOutput
 
 export namespace UpdateProvisionedProductPropertiesOutput {
   export function isa(o: any): o is UpdateProvisionedProductPropertiesOutput {
-    return _smithy.isa(o, "UpdateProvisionedProductPropertiesOutput");
+    return __isa(o, "UpdateProvisionedProductPropertiesOutput");
   }
 }
 
@@ -7166,7 +7154,7 @@ export interface UpdateProvisioningArtifactInput {
 
 export namespace UpdateProvisioningArtifactInput {
   export function isa(o: any): o is UpdateProvisioningArtifactInput {
-    return _smithy.isa(o, "UpdateProvisioningArtifactInput");
+    return __isa(o, "UpdateProvisioningArtifactInput");
   }
 }
 
@@ -7190,7 +7178,7 @@ export interface UpdateProvisioningArtifactOutput extends $MetadataBearer {
 
 export namespace UpdateProvisioningArtifactOutput {
   export function isa(o: any): o is UpdateProvisioningArtifactOutput {
-    return _smithy.isa(o, "UpdateProvisioningArtifactOutput");
+    return __isa(o, "UpdateProvisioningArtifactOutput");
   }
 }
 
@@ -7217,7 +7205,7 @@ export interface UpdateProvisioningParameter {
 
 export namespace UpdateProvisioningParameter {
   export function isa(o: any): o is UpdateProvisioningParameter {
-    return _smithy.isa(o, "UpdateProvisioningParameter");
+    return __isa(o, "UpdateProvisioningParameter");
   }
 }
 
@@ -7298,7 +7286,7 @@ export interface UpdateProvisioningPreferences {
 
 export namespace UpdateProvisioningPreferences {
   export function isa(o: any): o is UpdateProvisioningPreferences {
-    return _smithy.isa(o, "UpdateProvisioningPreferences");
+    return __isa(o, "UpdateProvisioningPreferences");
   }
 }
 
@@ -7346,7 +7334,7 @@ export interface UpdateServiceActionInput {
 
 export namespace UpdateServiceActionInput {
   export function isa(o: any): o is UpdateServiceActionInput {
-    return _smithy.isa(o, "UpdateServiceActionInput");
+    return __isa(o, "UpdateServiceActionInput");
   }
 }
 
@@ -7360,7 +7348,7 @@ export interface UpdateServiceActionOutput extends $MetadataBearer {
 
 export namespace UpdateServiceActionOutput {
   export function isa(o: any): o is UpdateServiceActionOutput {
-    return _smithy.isa(o, "UpdateServiceActionOutput");
+    return __isa(o, "UpdateServiceActionOutput");
   }
 }
 
@@ -7382,6 +7370,6 @@ export interface UsageInstruction {
 
 export namespace UsageInstruction {
   export function isa(o: any): o is UsageInstruction {
-    return _smithy.isa(o, "UsageInstruction");
+    return __isa(o, "UsageInstruction");
   }
 }

--- a/clients/client-service-quotas/models/index.ts
+++ b/clients/client-service-quotas/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -6,7 +9,7 @@ import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
  *       enabled in your organization. To enable, call <a>AssociateServiceQuotaTemplate</a>.</p>
  */
 export interface AWSServiceAccessNotEnabledException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AWSServiceAccessNotEnabledException";
   $fault: "client";
@@ -15,7 +18,7 @@ export interface AWSServiceAccessNotEnabledException
 
 export namespace AWSServiceAccessNotEnabledException {
   export function isa(o: any): o is AWSServiceAccessNotEnabledException {
-    return _smithy.isa(o, "AWSServiceAccessNotEnabledException");
+    return __isa(o, "AWSServiceAccessNotEnabledException");
   }
 }
 
@@ -23,7 +26,7 @@ export namespace AWSServiceAccessNotEnabledException {
  * <p>You do not have sufficient access to perform this action.</p>
  */
 export interface AccessDeniedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AccessDeniedException";
   $fault: "client";
@@ -32,7 +35,7 @@ export interface AccessDeniedException
 
 export namespace AccessDeniedException {
   export function isa(o: any): o is AccessDeniedException {
-    return _smithy.isa(o, "AccessDeniedException");
+    return __isa(o, "AccessDeniedException");
   }
 }
 
@@ -42,7 +45,7 @@ export interface AssociateServiceQuotaTemplateRequest {
 
 export namespace AssociateServiceQuotaTemplateRequest {
   export function isa(o: any): o is AssociateServiceQuotaTemplateRequest {
-    return _smithy.isa(o, "AssociateServiceQuotaTemplateRequest");
+    return __isa(o, "AssociateServiceQuotaTemplateRequest");
   }
 }
 
@@ -52,7 +55,7 @@ export interface AssociateServiceQuotaTemplateResponse extends $MetadataBearer {
 
 export namespace AssociateServiceQuotaTemplateResponse {
   export function isa(o: any): o is AssociateServiceQuotaTemplateResponse {
-    return _smithy.isa(o, "AssociateServiceQuotaTemplateResponse");
+    return __isa(o, "AssociateServiceQuotaTemplateResponse");
   }
 }
 
@@ -78,10 +81,7 @@ export namespace DeleteServiceQuotaIncreaseRequestFromTemplateRequest {
   export function isa(
     o: any
   ): o is DeleteServiceQuotaIncreaseRequestFromTemplateRequest {
-    return _smithy.isa(
-      o,
-      "DeleteServiceQuotaIncreaseRequestFromTemplateRequest"
-    );
+    return __isa(o, "DeleteServiceQuotaIncreaseRequestFromTemplateRequest");
   }
 }
 
@@ -94,10 +94,7 @@ export namespace DeleteServiceQuotaIncreaseRequestFromTemplateResponse {
   export function isa(
     o: any
   ): o is DeleteServiceQuotaIncreaseRequestFromTemplateResponse {
-    return _smithy.isa(
-      o,
-      "DeleteServiceQuotaIncreaseRequestFromTemplateResponse"
-    );
+    return __isa(o, "DeleteServiceQuotaIncreaseRequestFromTemplateResponse");
   }
 }
 
@@ -105,7 +102,7 @@ export namespace DeleteServiceQuotaIncreaseRequestFromTemplateResponse {
  * <p>You can't perform this action because a dependency does not have access.</p>
  */
 export interface DependencyAccessDeniedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DependencyAccessDeniedException";
   $fault: "client";
@@ -114,7 +111,7 @@ export interface DependencyAccessDeniedException
 
 export namespace DependencyAccessDeniedException {
   export function isa(o: any): o is DependencyAccessDeniedException {
-    return _smithy.isa(o, "DependencyAccessDeniedException");
+    return __isa(o, "DependencyAccessDeniedException");
   }
 }
 
@@ -124,7 +121,7 @@ export interface DisassociateServiceQuotaTemplateRequest {
 
 export namespace DisassociateServiceQuotaTemplateRequest {
   export function isa(o: any): o is DisassociateServiceQuotaTemplateRequest {
-    return _smithy.isa(o, "DisassociateServiceQuotaTemplateRequest");
+    return __isa(o, "DisassociateServiceQuotaTemplateRequest");
   }
 }
 
@@ -135,7 +132,7 @@ export interface DisassociateServiceQuotaTemplateResponse
 
 export namespace DisassociateServiceQuotaTemplateResponse {
   export function isa(o: any): o is DisassociateServiceQuotaTemplateResponse {
-    return _smithy.isa(o, "DisassociateServiceQuotaTemplateResponse");
+    return __isa(o, "DisassociateServiceQuotaTemplateResponse");
   }
 }
 
@@ -178,7 +175,7 @@ export interface ErrorReason {
 
 export namespace ErrorReason {
   export function isa(o: any): o is ErrorReason {
-    return _smithy.isa(o, "ErrorReason");
+    return __isa(o, "ErrorReason");
   }
 }
 
@@ -197,7 +194,7 @@ export interface GetAWSDefaultServiceQuotaRequest {
 
 export namespace GetAWSDefaultServiceQuotaRequest {
   export function isa(o: any): o is GetAWSDefaultServiceQuotaRequest {
-    return _smithy.isa(o, "GetAWSDefaultServiceQuotaRequest");
+    return __isa(o, "GetAWSDefaultServiceQuotaRequest");
   }
 }
 
@@ -212,7 +209,7 @@ export interface GetAWSDefaultServiceQuotaResponse extends $MetadataBearer {
 
 export namespace GetAWSDefaultServiceQuotaResponse {
   export function isa(o: any): o is GetAWSDefaultServiceQuotaResponse {
-    return _smithy.isa(o, "GetAWSDefaultServiceQuotaResponse");
+    return __isa(o, "GetAWSDefaultServiceQuotaResponse");
   }
 }
 
@@ -224,7 +221,7 @@ export namespace GetAssociationForServiceQuotaTemplateRequest {
   export function isa(
     o: any
   ): o is GetAssociationForServiceQuotaTemplateRequest {
-    return _smithy.isa(o, "GetAssociationForServiceQuotaTemplateRequest");
+    return __isa(o, "GetAssociationForServiceQuotaTemplateRequest");
   }
 }
 
@@ -245,7 +242,7 @@ export namespace GetAssociationForServiceQuotaTemplateResponse {
   export function isa(
     o: any
   ): o is GetAssociationForServiceQuotaTemplateResponse {
-    return _smithy.isa(o, "GetAssociationForServiceQuotaTemplateResponse");
+    return __isa(o, "GetAssociationForServiceQuotaTemplateResponse");
   }
 }
 
@@ -259,7 +256,7 @@ export interface GetRequestedServiceQuotaChangeRequest {
 
 export namespace GetRequestedServiceQuotaChangeRequest {
   export function isa(o: any): o is GetRequestedServiceQuotaChangeRequest {
-    return _smithy.isa(o, "GetRequestedServiceQuotaChangeRequest");
+    return __isa(o, "GetRequestedServiceQuotaChangeRequest");
   }
 }
 
@@ -275,7 +272,7 @@ export interface GetRequestedServiceQuotaChangeResponse
 
 export namespace GetRequestedServiceQuotaChangeResponse {
   export function isa(o: any): o is GetRequestedServiceQuotaChangeResponse {
-    return _smithy.isa(o, "GetRequestedServiceQuotaChangeResponse");
+    return __isa(o, "GetRequestedServiceQuotaChangeResponse");
   }
 }
 
@@ -301,7 +298,7 @@ export namespace GetServiceQuotaIncreaseRequestFromTemplateRequest {
   export function isa(
     o: any
   ): o is GetServiceQuotaIncreaseRequestFromTemplateRequest {
-    return _smithy.isa(o, "GetServiceQuotaIncreaseRequestFromTemplateRequest");
+    return __isa(o, "GetServiceQuotaIncreaseRequestFromTemplateRequest");
   }
 }
 
@@ -318,7 +315,7 @@ export namespace GetServiceQuotaIncreaseRequestFromTemplateResponse {
   export function isa(
     o: any
   ): o is GetServiceQuotaIncreaseRequestFromTemplateResponse {
-    return _smithy.isa(o, "GetServiceQuotaIncreaseRequestFromTemplateResponse");
+    return __isa(o, "GetServiceQuotaIncreaseRequestFromTemplateResponse");
   }
 }
 
@@ -337,7 +334,7 @@ export interface GetServiceQuotaRequest {
 
 export namespace GetServiceQuotaRequest {
   export function isa(o: any): o is GetServiceQuotaRequest {
-    return _smithy.isa(o, "GetServiceQuotaRequest");
+    return __isa(o, "GetServiceQuotaRequest");
   }
 }
 
@@ -352,7 +349,7 @@ export interface GetServiceQuotaResponse extends $MetadataBearer {
 
 export namespace GetServiceQuotaResponse {
   export function isa(o: any): o is GetServiceQuotaResponse {
-    return _smithy.isa(o, "GetServiceQuotaResponse");
+    return __isa(o, "GetServiceQuotaResponse");
   }
 }
 
@@ -360,7 +357,7 @@ export namespace GetServiceQuotaResponse {
  * <p>Invalid input was provided. </p>
  */
 export interface IllegalArgumentException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "IllegalArgumentException";
   $fault: "client";
@@ -369,7 +366,7 @@ export interface IllegalArgumentException
 
 export namespace IllegalArgumentException {
   export function isa(o: any): o is IllegalArgumentException {
-    return _smithy.isa(o, "IllegalArgumentException");
+    return __isa(o, "IllegalArgumentException");
   }
 }
 
@@ -377,7 +374,7 @@ export namespace IllegalArgumentException {
  * <p>Invalid input was provided.</p>
  */
 export interface InvalidPaginationTokenException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidPaginationTokenException";
   $fault: "client";
@@ -386,7 +383,7 @@ export interface InvalidPaginationTokenException
 
 export namespace InvalidPaginationTokenException {
   export function isa(o: any): o is InvalidPaginationTokenException {
-    return _smithy.isa(o, "InvalidPaginationTokenException");
+    return __isa(o, "InvalidPaginationTokenException");
   }
 }
 
@@ -394,7 +391,7 @@ export namespace InvalidPaginationTokenException {
  * <p>Invalid input was provided for the . </p>
  */
 export interface InvalidResourceStateException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidResourceStateException";
   $fault: "client";
@@ -403,7 +400,7 @@ export interface InvalidResourceStateException
 
 export namespace InvalidResourceStateException {
   export function isa(o: any): o is InvalidResourceStateException {
-    return _smithy.isa(o, "InvalidResourceStateException");
+    return __isa(o, "InvalidResourceStateException");
   }
 }
 
@@ -440,7 +437,7 @@ export interface ListAWSDefaultServiceQuotasRequest {
 
 export namespace ListAWSDefaultServiceQuotasRequest {
   export function isa(o: any): o is ListAWSDefaultServiceQuotasRequest {
-    return _smithy.isa(o, "ListAWSDefaultServiceQuotasRequest");
+    return __isa(o, "ListAWSDefaultServiceQuotasRequest");
   }
 }
 
@@ -462,7 +459,7 @@ export interface ListAWSDefaultServiceQuotasResponse extends $MetadataBearer {
 
 export namespace ListAWSDefaultServiceQuotasResponse {
   export function isa(o: any): o is ListAWSDefaultServiceQuotasResponse {
-    return _smithy.isa(o, "ListAWSDefaultServiceQuotasResponse");
+    return __isa(o, "ListAWSDefaultServiceQuotasResponse");
   }
 }
 
@@ -507,10 +504,7 @@ export namespace ListRequestedServiceQuotaChangeHistoryByQuotaRequest {
   export function isa(
     o: any
   ): o is ListRequestedServiceQuotaChangeHistoryByQuotaRequest {
-    return _smithy.isa(
-      o,
-      "ListRequestedServiceQuotaChangeHistoryByQuotaRequest"
-    );
+    return __isa(o, "ListRequestedServiceQuotaChangeHistoryByQuotaRequest");
   }
 }
 
@@ -537,10 +531,7 @@ export namespace ListRequestedServiceQuotaChangeHistoryByQuotaResponse {
   export function isa(
     o: any
   ): o is ListRequestedServiceQuotaChangeHistoryByQuotaResponse {
-    return _smithy.isa(
-      o,
-      "ListRequestedServiceQuotaChangeHistoryByQuotaResponse"
-    );
+    return __isa(o, "ListRequestedServiceQuotaChangeHistoryByQuotaResponse");
   }
 }
 
@@ -580,7 +571,7 @@ export namespace ListRequestedServiceQuotaChangeHistoryRequest {
   export function isa(
     o: any
   ): o is ListRequestedServiceQuotaChangeHistoryRequest {
-    return _smithy.isa(o, "ListRequestedServiceQuotaChangeHistoryRequest");
+    return __isa(o, "ListRequestedServiceQuotaChangeHistoryRequest");
   }
 }
 
@@ -607,7 +598,7 @@ export namespace ListRequestedServiceQuotaChangeHistoryResponse {
   export function isa(
     o: any
   ): o is ListRequestedServiceQuotaChangeHistoryResponse {
-    return _smithy.isa(o, "ListRequestedServiceQuotaChangeHistoryResponse");
+    return __isa(o, "ListRequestedServiceQuotaChangeHistoryResponse");
   }
 }
 
@@ -648,7 +639,7 @@ export namespace ListServiceQuotaIncreaseRequestsInTemplateRequest {
   export function isa(
     o: any
   ): o is ListServiceQuotaIncreaseRequestsInTemplateRequest {
-    return _smithy.isa(o, "ListServiceQuotaIncreaseRequestsInTemplateRequest");
+    return __isa(o, "ListServiceQuotaIncreaseRequestsInTemplateRequest");
   }
 }
 
@@ -677,7 +668,7 @@ export namespace ListServiceQuotaIncreaseRequestsInTemplateResponse {
   export function isa(
     o: any
   ): o is ListServiceQuotaIncreaseRequestsInTemplateResponse {
-    return _smithy.isa(o, "ListServiceQuotaIncreaseRequestsInTemplateResponse");
+    return __isa(o, "ListServiceQuotaIncreaseRequestsInTemplateResponse");
   }
 }
 
@@ -711,7 +702,7 @@ export interface ListServiceQuotasRequest {
 
 export namespace ListServiceQuotasRequest {
   export function isa(o: any): o is ListServiceQuotasRequest {
-    return _smithy.isa(o, "ListServiceQuotasRequest");
+    return __isa(o, "ListServiceQuotasRequest");
   }
 }
 
@@ -736,7 +727,7 @@ export interface ListServiceQuotasResponse extends $MetadataBearer {
 
 export namespace ListServiceQuotasResponse {
   export function isa(o: any): o is ListServiceQuotasResponse {
-    return _smithy.isa(o, "ListServiceQuotasResponse");
+    return __isa(o, "ListServiceQuotasResponse");
   }
 }
 
@@ -764,7 +755,7 @@ export interface ListServicesRequest {
 
 export namespace ListServicesRequest {
   export function isa(o: any): o is ListServicesRequest {
-    return _smithy.isa(o, "ListServicesRequest");
+    return __isa(o, "ListServicesRequest");
   }
 }
 
@@ -788,7 +779,7 @@ export interface ListServicesResponse extends $MetadataBearer {
 
 export namespace ListServicesResponse {
   export function isa(o: any): o is ListServicesResponse {
-    return _smithy.isa(o, "ListServicesResponse");
+    return __isa(o, "ListServicesResponse");
   }
 }
 
@@ -827,7 +818,7 @@ export interface MetricInfo {
 
 export namespace MetricInfo {
   export function isa(o: any): o is MetricInfo {
-    return _smithy.isa(o, "MetricInfo");
+    return __isa(o, "MetricInfo");
   }
 }
 
@@ -835,7 +826,7 @@ export namespace MetricInfo {
  * <p>The account making this call is not a member of an organization.</p>
  */
 export interface NoAvailableOrganizationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "NoAvailableOrganizationException";
   $fault: "client";
@@ -844,7 +835,7 @@ export interface NoAvailableOrganizationException
 
 export namespace NoAvailableOrganizationException {
   export function isa(o: any): o is NoAvailableOrganizationException {
-    return _smithy.isa(o, "NoAvailableOrganizationException");
+    return __isa(o, "NoAvailableOrganizationException");
   }
 }
 
@@ -852,7 +843,7 @@ export namespace NoAvailableOrganizationException {
  * <p>The specified resource does not exist.</p>
  */
 export interface NoSuchResourceException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "NoSuchResourceException";
   $fault: "client";
@@ -861,7 +852,7 @@ export interface NoSuchResourceException
 
 export namespace NoSuchResourceException {
   export function isa(o: any): o is NoSuchResourceException {
-    return _smithy.isa(o, "NoSuchResourceException");
+    return __isa(o, "NoSuchResourceException");
   }
 }
 
@@ -870,7 +861,7 @@ export namespace NoSuchResourceException {
  *       features mode, see <a href="https://docs.aws.amazon.com/organizations/latest/APIReference/API_EnableAllFeatures.html">EnableAllFeatures</a>.</p>
  */
 export interface OrganizationNotInAllFeaturesModeException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "OrganizationNotInAllFeaturesModeException";
   $fault: "client";
@@ -879,7 +870,7 @@ export interface OrganizationNotInAllFeaturesModeException
 
 export namespace OrganizationNotInAllFeaturesModeException {
   export function isa(o: any): o is OrganizationNotInAllFeaturesModeException {
-    return _smithy.isa(o, "OrganizationNotInAllFeaturesModeException");
+    return __isa(o, "OrganizationNotInAllFeaturesModeException");
   }
 }
 
@@ -920,7 +911,7 @@ export namespace PutServiceQuotaIncreaseRequestIntoTemplateRequest {
   export function isa(
     o: any
   ): o is PutServiceQuotaIncreaseRequestIntoTemplateRequest {
-    return _smithy.isa(o, "PutServiceQuotaIncreaseRequestIntoTemplateRequest");
+    return __isa(o, "PutServiceQuotaIncreaseRequestIntoTemplateRequest");
   }
 }
 
@@ -937,7 +928,7 @@ export namespace PutServiceQuotaIncreaseRequestIntoTemplateResponse {
   export function isa(
     o: any
   ): o is PutServiceQuotaIncreaseRequestIntoTemplateResponse {
-    return _smithy.isa(o, "PutServiceQuotaIncreaseRequestIntoTemplateResponse");
+    return __isa(o, "PutServiceQuotaIncreaseRequestIntoTemplateResponse");
   }
 }
 
@@ -946,7 +937,7 @@ export namespace PutServiceQuotaIncreaseRequestIntoTemplateResponse {
  *       relevant resources, or use Service Quotas to request a service quota increase.</p>
  */
 export interface QuotaExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "QuotaExceededException";
   $fault: "client";
@@ -955,7 +946,7 @@ export interface QuotaExceededException
 
 export namespace QuotaExceededException {
   export function isa(o: any): o is QuotaExceededException {
-    return _smithy.isa(o, "QuotaExceededException");
+    return __isa(o, "QuotaExceededException");
   }
 }
 
@@ -977,7 +968,7 @@ export interface QuotaPeriod {
 
 export namespace QuotaPeriod {
   export function isa(o: any): o is QuotaPeriod {
-    return _smithy.isa(o, "QuotaPeriod");
+    return __isa(o, "QuotaPeriod");
   }
 }
 
@@ -1001,7 +992,7 @@ export interface RequestServiceQuotaIncreaseRequest {
 
 export namespace RequestServiceQuotaIncreaseRequest {
   export function isa(o: any): o is RequestServiceQuotaIncreaseRequest {
-    return _smithy.isa(o, "RequestServiceQuotaIncreaseRequest");
+    return __isa(o, "RequestServiceQuotaIncreaseRequest");
   }
 }
 
@@ -1015,7 +1006,7 @@ export interface RequestServiceQuotaIncreaseResponse extends $MetadataBearer {
 
 export namespace RequestServiceQuotaIncreaseResponse {
   export function isa(o: any): o is RequestServiceQuotaIncreaseResponse {
-    return _smithy.isa(o, "RequestServiceQuotaIncreaseResponse");
+    return __isa(o, "RequestServiceQuotaIncreaseResponse");
   }
 }
 
@@ -1106,7 +1097,7 @@ export interface RequestedServiceQuotaChange {
 
 export namespace RequestedServiceQuotaChange {
   export function isa(o: any): o is RequestedServiceQuotaChange {
-    return _smithy.isa(o, "RequestedServiceQuotaChange");
+    return __isa(o, "RequestedServiceQuotaChange");
   }
 }
 
@@ -1114,7 +1105,7 @@ export namespace RequestedServiceQuotaChange {
  * <p>The specified resource already exists.</p>
  */
 export interface ResourceAlreadyExistsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceAlreadyExistsException";
   $fault: "client";
@@ -1123,16 +1114,14 @@ export interface ResourceAlreadyExistsException
 
 export namespace ResourceAlreadyExistsException {
   export function isa(o: any): o is ResourceAlreadyExistsException {
-    return _smithy.isa(o, "ResourceAlreadyExistsException");
+    return __isa(o, "ResourceAlreadyExistsException");
   }
 }
 
 /**
  * <p>Something went wrong. </p>
  */
-export interface ServiceException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface ServiceException extends __SmithyException, $MetadataBearer {
   name: "ServiceException";
   $fault: "server";
   Message?: string;
@@ -1140,7 +1129,7 @@ export interface ServiceException
 
 export namespace ServiceException {
   export function isa(o: any): o is ServiceException {
-    return _smithy.isa(o, "ServiceException");
+    return __isa(o, "ServiceException");
   }
 }
 
@@ -1163,7 +1152,7 @@ export interface ServiceInfo {
 
 export namespace ServiceInfo {
   export function isa(o: any): o is ServiceInfo {
-    return _smithy.isa(o, "ServiceInfo");
+    return __isa(o, "ServiceInfo");
   }
 }
 
@@ -1236,7 +1225,7 @@ export interface ServiceQuota {
 
 export namespace ServiceQuota {
   export function isa(o: any): o is ServiceQuota {
-    return _smithy.isa(o, "ServiceQuota");
+    return __isa(o, "ServiceQuota");
   }
 }
 
@@ -1288,7 +1277,7 @@ export interface ServiceQuotaIncreaseRequestInTemplate {
 
 export namespace ServiceQuotaIncreaseRequestInTemplate {
   export function isa(o: any): o is ServiceQuotaIncreaseRequestInTemplate {
-    return _smithy.isa(o, "ServiceQuotaIncreaseRequestInTemplate");
+    return __isa(o, "ServiceQuotaIncreaseRequestInTemplate");
   }
 }
 
@@ -1302,7 +1291,7 @@ export enum ServiceQuotaTemplateAssociationStatus {
  *          <p>To use the template, call <a>AssociateServiceQuotaTemplate</a>. </p>
  */
 export interface ServiceQuotaTemplateNotInUseException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ServiceQuotaTemplateNotInUseException";
   $fault: "client";
@@ -1311,7 +1300,7 @@ export interface ServiceQuotaTemplateNotInUseException
 
 export namespace ServiceQuotaTemplateNotInUseException {
   export function isa(o: any): o is ServiceQuotaTemplateNotInUseException {
-    return _smithy.isa(o, "ServiceQuotaTemplateNotInUseException");
+    return __isa(o, "ServiceQuotaTemplateNotInUseException");
   }
 }
 
@@ -1320,7 +1309,7 @@ export namespace ServiceQuotaTemplateNotInUseException {
  *       request. Please make the request in us-east-1. </p>
  */
 export interface TemplatesNotAvailableInRegionException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TemplatesNotAvailableInRegionException";
   $fault: "client";
@@ -1329,7 +1318,7 @@ export interface TemplatesNotAvailableInRegionException
 
 export namespace TemplatesNotAvailableInRegionException {
   export function isa(o: any): o is TemplatesNotAvailableInRegionException {
-    return _smithy.isa(o, "TemplatesNotAvailableInRegionException");
+    return __isa(o, "TemplatesNotAvailableInRegionException");
   }
 }
 
@@ -1338,7 +1327,7 @@ export namespace TemplatesNotAvailableInRegionException {
  *       an increase for this quota. </p>
  */
 export interface TooManyRequestsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyRequestsException";
   $fault: "client";
@@ -1347,6 +1336,6 @@ export interface TooManyRequestsException
 
 export namespace TooManyRequestsException {
   export function isa(o: any): o is TooManyRequestsException {
-    return _smithy.isa(o, "TooManyRequestsException");
+    return __isa(o, "TooManyRequestsException");
   }
 }

--- a/clients/client-servicediscovery/models/index.ts
+++ b/clients/client-servicediscovery/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export interface CreateHttpNamespaceRequest {
@@ -22,7 +25,7 @@ export interface CreateHttpNamespaceRequest {
 
 export namespace CreateHttpNamespaceRequest {
   export function isa(o: any): o is CreateHttpNamespaceRequest {
-    return _smithy.isa(o, "CreateHttpNamespaceRequest");
+    return __isa(o, "CreateHttpNamespaceRequest");
   }
 }
 
@@ -37,7 +40,7 @@ export interface CreateHttpNamespaceResponse extends $MetadataBearer {
 
 export namespace CreateHttpNamespaceResponse {
   export function isa(o: any): o is CreateHttpNamespaceResponse {
-    return _smithy.isa(o, "CreateHttpNamespaceResponse");
+    return __isa(o, "CreateHttpNamespaceResponse");
   }
 }
 
@@ -68,7 +71,7 @@ export interface CreatePrivateDnsNamespaceRequest {
 
 export namespace CreatePrivateDnsNamespaceRequest {
   export function isa(o: any): o is CreatePrivateDnsNamespaceRequest {
-    return _smithy.isa(o, "CreatePrivateDnsNamespaceRequest");
+    return __isa(o, "CreatePrivateDnsNamespaceRequest");
   }
 }
 
@@ -83,7 +86,7 @@ export interface CreatePrivateDnsNamespaceResponse extends $MetadataBearer {
 
 export namespace CreatePrivateDnsNamespaceResponse {
   export function isa(o: any): o is CreatePrivateDnsNamespaceResponse {
-    return _smithy.isa(o, "CreatePrivateDnsNamespaceResponse");
+    return __isa(o, "CreatePrivateDnsNamespaceResponse");
   }
 }
 
@@ -108,7 +111,7 @@ export interface CreatePublicDnsNamespaceRequest {
 
 export namespace CreatePublicDnsNamespaceRequest {
   export function isa(o: any): o is CreatePublicDnsNamespaceRequest {
-    return _smithy.isa(o, "CreatePublicDnsNamespaceRequest");
+    return __isa(o, "CreatePublicDnsNamespaceRequest");
   }
 }
 
@@ -123,7 +126,7 @@ export interface CreatePublicDnsNamespaceResponse extends $MetadataBearer {
 
 export namespace CreatePublicDnsNamespaceResponse {
   export function isa(o: any): o is CreatePublicDnsNamespaceResponse {
-    return _smithy.isa(o, "CreatePublicDnsNamespaceResponse");
+    return __isa(o, "CreatePublicDnsNamespaceResponse");
   }
 }
 
@@ -180,7 +183,7 @@ export interface CreateServiceRequest {
 
 export namespace CreateServiceRequest {
   export function isa(o: any): o is CreateServiceRequest {
-    return _smithy.isa(o, "CreateServiceRequest");
+    return __isa(o, "CreateServiceRequest");
   }
 }
 
@@ -194,7 +197,7 @@ export interface CreateServiceResponse extends $MetadataBearer {
 
 export namespace CreateServiceResponse {
   export function isa(o: any): o is CreateServiceResponse {
-    return _smithy.isa(o, "CreateServiceResponse");
+    return __isa(o, "CreateServiceResponse");
   }
 }
 
@@ -202,7 +205,7 @@ export namespace CreateServiceResponse {
  * <p>The health check for the instance that is specified by <code>ServiceId</code> and <code>InstanceId</code> is not a custom health check. </p>
  */
 export interface CustomHealthNotFound
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CustomHealthNotFound";
   $fault: "client";
@@ -211,7 +214,7 @@ export interface CustomHealthNotFound
 
 export namespace CustomHealthNotFound {
   export function isa(o: any): o is CustomHealthNotFound {
-    return _smithy.isa(o, "CustomHealthNotFound");
+    return __isa(o, "CustomHealthNotFound");
   }
 }
 
@@ -230,7 +233,7 @@ export interface DeleteNamespaceRequest {
 
 export namespace DeleteNamespaceRequest {
   export function isa(o: any): o is DeleteNamespaceRequest {
-    return _smithy.isa(o, "DeleteNamespaceRequest");
+    return __isa(o, "DeleteNamespaceRequest");
   }
 }
 
@@ -245,7 +248,7 @@ export interface DeleteNamespaceResponse extends $MetadataBearer {
 
 export namespace DeleteNamespaceResponse {
   export function isa(o: any): o is DeleteNamespaceResponse {
-    return _smithy.isa(o, "DeleteNamespaceResponse");
+    return __isa(o, "DeleteNamespaceResponse");
   }
 }
 
@@ -259,7 +262,7 @@ export interface DeleteServiceRequest {
 
 export namespace DeleteServiceRequest {
   export function isa(o: any): o is DeleteServiceRequest {
-    return _smithy.isa(o, "DeleteServiceRequest");
+    return __isa(o, "DeleteServiceRequest");
   }
 }
 
@@ -269,7 +272,7 @@ export interface DeleteServiceResponse extends $MetadataBearer {
 
 export namespace DeleteServiceResponse {
   export function isa(o: any): o is DeleteServiceResponse {
-    return _smithy.isa(o, "DeleteServiceResponse");
+    return __isa(o, "DeleteServiceResponse");
   }
 }
 
@@ -288,7 +291,7 @@ export interface DeregisterInstanceRequest {
 
 export namespace DeregisterInstanceRequest {
   export function isa(o: any): o is DeregisterInstanceRequest {
-    return _smithy.isa(o, "DeregisterInstanceRequest");
+    return __isa(o, "DeregisterInstanceRequest");
   }
 }
 
@@ -302,7 +305,7 @@ export interface DeregisterInstanceResponse extends $MetadataBearer {
 
 export namespace DeregisterInstanceResponse {
   export function isa(o: any): o is DeregisterInstanceResponse {
-    return _smithy.isa(o, "DeregisterInstanceResponse");
+    return __isa(o, "DeregisterInstanceResponse");
   }
 }
 
@@ -338,7 +341,7 @@ export interface DiscoverInstancesRequest {
 
 export namespace DiscoverInstancesRequest {
   export function isa(o: any): o is DiscoverInstancesRequest {
-    return _smithy.isa(o, "DiscoverInstancesRequest");
+    return __isa(o, "DiscoverInstancesRequest");
   }
 }
 
@@ -352,7 +355,7 @@ export interface DiscoverInstancesResponse extends $MetadataBearer {
 
 export namespace DiscoverInstancesResponse {
   export function isa(o: any): o is DiscoverInstancesResponse {
-    return _smithy.isa(o, "DiscoverInstancesResponse");
+    return __isa(o, "DiscoverInstancesResponse");
   }
 }
 
@@ -414,7 +417,7 @@ export interface DnsConfig {
 
 export namespace DnsConfig {
   export function isa(o: any): o is DnsConfig {
-    return _smithy.isa(o, "DnsConfig");
+    return __isa(o, "DnsConfig");
   }
 }
 
@@ -433,7 +436,7 @@ export interface DnsConfigChange {
 
 export namespace DnsConfigChange {
   export function isa(o: any): o is DnsConfigChange {
-    return _smithy.isa(o, "DnsConfigChange");
+    return __isa(o, "DnsConfigChange");
   }
 }
 
@@ -450,7 +453,7 @@ export interface DnsProperties {
 
 export namespace DnsProperties {
   export function isa(o: any): o is DnsProperties {
-    return _smithy.isa(o, "DnsProperties");
+    return __isa(o, "DnsProperties");
   }
 }
 
@@ -572,16 +575,14 @@ export interface DnsRecord {
 
 export namespace DnsRecord {
   export function isa(o: any): o is DnsRecord {
-    return _smithy.isa(o, "DnsRecord");
+    return __isa(o, "DnsRecord");
   }
 }
 
 /**
  * <p>The operation is already in progress.</p>
  */
-export interface DuplicateRequest
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface DuplicateRequest extends __SmithyException, $MetadataBearer {
   name: "DuplicateRequest";
   $fault: "client";
   /**
@@ -594,7 +595,7 @@ export interface DuplicateRequest
 
 export namespace DuplicateRequest {
   export function isa(o: any): o is DuplicateRequest {
-    return _smithy.isa(o, "DuplicateRequest");
+    return __isa(o, "DuplicateRequest");
   }
 }
 
@@ -619,7 +620,7 @@ export interface GetInstanceRequest {
 
 export namespace GetInstanceRequest {
   export function isa(o: any): o is GetInstanceRequest {
-    return _smithy.isa(o, "GetInstanceRequest");
+    return __isa(o, "GetInstanceRequest");
   }
 }
 
@@ -633,7 +634,7 @@ export interface GetInstanceResponse extends $MetadataBearer {
 
 export namespace GetInstanceResponse {
   export function isa(o: any): o is GetInstanceResponse {
-    return _smithy.isa(o, "GetInstanceResponse");
+    return __isa(o, "GetInstanceResponse");
   }
 }
 
@@ -671,7 +672,7 @@ export interface GetInstancesHealthStatusRequest {
 
 export namespace GetInstancesHealthStatusRequest {
   export function isa(o: any): o is GetInstancesHealthStatusRequest {
-    return _smithy.isa(o, "GetInstancesHealthStatusRequest");
+    return __isa(o, "GetInstancesHealthStatusRequest");
   }
 }
 
@@ -692,7 +693,7 @@ export interface GetInstancesHealthStatusResponse extends $MetadataBearer {
 
 export namespace GetInstancesHealthStatusResponse {
   export function isa(o: any): o is GetInstancesHealthStatusResponse {
-    return _smithy.isa(o, "GetInstancesHealthStatusResponse");
+    return __isa(o, "GetInstancesHealthStatusResponse");
   }
 }
 
@@ -706,7 +707,7 @@ export interface GetNamespaceRequest {
 
 export namespace GetNamespaceRequest {
   export function isa(o: any): o is GetNamespaceRequest {
-    return _smithy.isa(o, "GetNamespaceRequest");
+    return __isa(o, "GetNamespaceRequest");
   }
 }
 
@@ -720,7 +721,7 @@ export interface GetNamespaceResponse extends $MetadataBearer {
 
 export namespace GetNamespaceResponse {
   export function isa(o: any): o is GetNamespaceResponse {
-    return _smithy.isa(o, "GetNamespaceResponse");
+    return __isa(o, "GetNamespaceResponse");
   }
 }
 
@@ -734,7 +735,7 @@ export interface GetOperationRequest {
 
 export namespace GetOperationRequest {
   export function isa(o: any): o is GetOperationRequest {
-    return _smithy.isa(o, "GetOperationRequest");
+    return __isa(o, "GetOperationRequest");
   }
 }
 
@@ -748,7 +749,7 @@ export interface GetOperationResponse extends $MetadataBearer {
 
 export namespace GetOperationResponse {
   export function isa(o: any): o is GetOperationResponse {
-    return _smithy.isa(o, "GetOperationResponse");
+    return __isa(o, "GetOperationResponse");
   }
 }
 
@@ -762,7 +763,7 @@ export interface GetServiceRequest {
 
 export namespace GetServiceRequest {
   export function isa(o: any): o is GetServiceRequest {
-    return _smithy.isa(o, "GetServiceRequest");
+    return __isa(o, "GetServiceRequest");
   }
 }
 
@@ -776,7 +777,7 @@ export interface GetServiceResponse extends $MetadataBearer {
 
 export namespace GetServiceResponse {
   export function isa(o: any): o is GetServiceResponse {
-    return _smithy.isa(o, "GetServiceResponse");
+    return __isa(o, "GetServiceResponse");
   }
 }
 
@@ -902,7 +903,7 @@ export interface HealthCheckConfig {
 
 export namespace HealthCheckConfig {
   export function isa(o: any): o is HealthCheckConfig {
-    return _smithy.isa(o, "HealthCheckConfig");
+    return __isa(o, "HealthCheckConfig");
   }
 }
 
@@ -979,7 +980,7 @@ export interface HealthCheckCustomConfig {
 
 export namespace HealthCheckCustomConfig {
   export function isa(o: any): o is HealthCheckCustomConfig {
-    return _smithy.isa(o, "HealthCheckCustomConfig");
+    return __isa(o, "HealthCheckCustomConfig");
   }
 }
 
@@ -1035,7 +1036,7 @@ export interface HttpInstanceSummary {
 
 export namespace HttpInstanceSummary {
   export function isa(o: any): o is HttpInstanceSummary {
-    return _smithy.isa(o, "HttpInstanceSummary");
+    return __isa(o, "HttpInstanceSummary");
   }
 }
 
@@ -1052,7 +1053,7 @@ export interface HttpProperties {
 
 export namespace HttpProperties {
   export function isa(o: any): o is HttpProperties {
-    return _smithy.isa(o, "HttpProperties");
+    return __isa(o, "HttpProperties");
   }
 }
 
@@ -1178,16 +1179,14 @@ export interface Instance {
 
 export namespace Instance {
   export function isa(o: any): o is Instance {
-    return _smithy.isa(o, "Instance");
+    return __isa(o, "Instance");
   }
 }
 
 /**
  * <p>No instance exists with the specified ID, or the instance was recently registered, and information about the instance hasn't propagated yet.</p>
  */
-export interface InstanceNotFound
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface InstanceNotFound extends __SmithyException, $MetadataBearer {
   name: "InstanceNotFound";
   $fault: "client";
   Message?: string;
@@ -1195,7 +1194,7 @@ export interface InstanceNotFound
 
 export namespace InstanceNotFound {
   export function isa(o: any): o is InstanceNotFound {
-    return _smithy.isa(o, "InstanceNotFound");
+    return __isa(o, "InstanceNotFound");
   }
 }
 
@@ -1254,7 +1253,7 @@ export interface InstanceSummary {
 
 export namespace InstanceSummary {
   export function isa(o: any): o is InstanceSummary {
-    return _smithy.isa(o, "InstanceSummary");
+    return __isa(o, "InstanceSummary");
   }
 }
 
@@ -1262,7 +1261,7 @@ export namespace InstanceSummary {
  * <p>One or more specified values aren't valid. For example, a required value might be missing, a numeric value might be outside the allowed range,
  * 			or a string value might exceed length constraints.</p>
  */
-export interface InvalidInput extends _smithy.SmithyException, $MetadataBearer {
+export interface InvalidInput extends __SmithyException, $MetadataBearer {
   name: "InvalidInput";
   $fault: "client";
   Message?: string;
@@ -1270,7 +1269,7 @@ export interface InvalidInput extends _smithy.SmithyException, $MetadataBearer {
 
 export namespace InvalidInput {
   export function isa(o: any): o is InvalidInput {
-    return _smithy.isa(o, "InvalidInput");
+    return __isa(o, "InvalidInput");
   }
 }
 
@@ -1297,7 +1296,7 @@ export interface ListInstancesRequest {
 
 export namespace ListInstancesRequest {
   export function isa(o: any): o is ListInstancesRequest {
-    return _smithy.isa(o, "ListInstancesRequest");
+    return __isa(o, "ListInstancesRequest");
   }
 }
 
@@ -1317,7 +1316,7 @@ export interface ListInstancesResponse extends $MetadataBearer {
 
 export namespace ListInstancesResponse {
   export function isa(o: any): o is ListInstancesResponse {
-    return _smithy.isa(o, "ListInstancesResponse");
+    return __isa(o, "ListInstancesResponse");
   }
 }
 
@@ -1350,7 +1349,7 @@ export interface ListNamespacesRequest {
 
 export namespace ListNamespacesRequest {
   export function isa(o: any): o is ListNamespacesRequest {
-    return _smithy.isa(o, "ListNamespacesRequest");
+    return __isa(o, "ListNamespacesRequest");
   }
 }
 
@@ -1375,7 +1374,7 @@ export interface ListNamespacesResponse extends $MetadataBearer {
 
 export namespace ListNamespacesResponse {
   export function isa(o: any): o is ListNamespacesResponse {
-    return _smithy.isa(o, "ListNamespacesResponse");
+    return __isa(o, "ListNamespacesResponse");
   }
 }
 
@@ -1409,7 +1408,7 @@ export interface ListOperationsRequest {
 
 export namespace ListOperationsRequest {
   export function isa(o: any): o is ListOperationsRequest {
-    return _smithy.isa(o, "ListOperationsRequest");
+    return __isa(o, "ListOperationsRequest");
   }
 }
 
@@ -1434,7 +1433,7 @@ export interface ListOperationsResponse extends $MetadataBearer {
 
 export namespace ListOperationsResponse {
   export function isa(o: any): o is ListOperationsResponse {
-    return _smithy.isa(o, "ListOperationsResponse");
+    return __isa(o, "ListOperationsResponse");
   }
 }
 
@@ -1467,7 +1466,7 @@ export interface ListServicesRequest {
 
 export namespace ListServicesRequest {
   export function isa(o: any): o is ListServicesRequest {
-    return _smithy.isa(o, "ListServicesRequest");
+    return __isa(o, "ListServicesRequest");
   }
 }
 
@@ -1492,7 +1491,7 @@ export interface ListServicesResponse extends $MetadataBearer {
 
 export namespace ListServicesResponse {
   export function isa(o: any): o is ListServicesResponse {
-    return _smithy.isa(o, "ListServicesResponse");
+    return __isa(o, "ListServicesResponse");
   }
 }
 
@@ -1550,7 +1549,7 @@ export interface Namespace {
 
 export namespace Namespace {
   export function isa(o: any): o is Namespace {
-    return _smithy.isa(o, "Namespace");
+    return __isa(o, "Namespace");
   }
 }
 
@@ -1558,7 +1557,7 @@ export namespace Namespace {
  * <p>The namespace that you're trying to create already exists.</p>
  */
 export interface NamespaceAlreadyExists
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "NamespaceAlreadyExists";
   $fault: "client";
@@ -1576,7 +1575,7 @@ export interface NamespaceAlreadyExists
 
 export namespace NamespaceAlreadyExists {
   export function isa(o: any): o is NamespaceAlreadyExists {
-    return _smithy.isa(o, "NamespaceAlreadyExists");
+    return __isa(o, "NamespaceAlreadyExists");
   }
 }
 
@@ -1622,7 +1621,7 @@ export interface NamespaceFilter {
 
 export namespace NamespaceFilter {
   export function isa(o: any): o is NamespaceFilter {
-    return _smithy.isa(o, "NamespaceFilter");
+    return __isa(o, "NamespaceFilter");
   }
 }
 
@@ -1633,9 +1632,7 @@ export enum NamespaceFilterName {
 /**
  * <p>No namespace exists with the specified ID.</p>
  */
-export interface NamespaceNotFound
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface NamespaceNotFound extends __SmithyException, $MetadataBearer {
   name: "NamespaceNotFound";
   $fault: "client";
   Message?: string;
@@ -1643,7 +1640,7 @@ export interface NamespaceNotFound
 
 export namespace NamespaceNotFound {
   export function isa(o: any): o is NamespaceNotFound {
-    return _smithy.isa(o, "NamespaceNotFound");
+    return __isa(o, "NamespaceNotFound");
   }
 }
 
@@ -1665,7 +1662,7 @@ export interface NamespaceProperties {
 
 export namespace NamespaceProperties {
   export function isa(o: any): o is NamespaceProperties {
-    return _smithy.isa(o, "NamespaceProperties");
+    return __isa(o, "NamespaceProperties");
   }
 }
 
@@ -1718,7 +1715,7 @@ export interface NamespaceSummary {
 
 export namespace NamespaceSummary {
   export function isa(o: any): o is NamespaceSummary {
-    return _smithy.isa(o, "NamespaceSummary");
+    return __isa(o, "NamespaceSummary");
   }
 }
 
@@ -1848,7 +1845,7 @@ export interface Operation {
 
 export namespace Operation {
   export function isa(o: any): o is Operation {
-    return _smithy.isa(o, "Operation");
+    return __isa(o, "Operation");
   }
 }
 
@@ -1944,7 +1941,7 @@ export interface OperationFilter {
 
 export namespace OperationFilter {
   export function isa(o: any): o is OperationFilter {
-    return _smithy.isa(o, "OperationFilter");
+    return __isa(o, "OperationFilter");
   }
 }
 
@@ -1959,9 +1956,7 @@ export enum OperationFilterName {
 /**
  * <p>No operation exists with the specified ID.</p>
  */
-export interface OperationNotFound
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface OperationNotFound extends __SmithyException, $MetadataBearer {
   name: "OperationNotFound";
   $fault: "client";
   Message?: string;
@@ -1969,7 +1964,7 @@ export interface OperationNotFound
 
 export namespace OperationNotFound {
   export function isa(o: any): o is OperationNotFound {
-    return _smithy.isa(o, "OperationNotFound");
+    return __isa(o, "OperationNotFound");
   }
 }
 
@@ -2017,7 +2012,7 @@ export interface OperationSummary {
 
 export namespace OperationSummary {
   export function isa(o: any): o is OperationSummary {
-    return _smithy.isa(o, "OperationSummary");
+    return __isa(o, "OperationSummary");
   }
 }
 
@@ -2180,7 +2175,7 @@ export interface RegisterInstanceRequest {
 
 export namespace RegisterInstanceRequest {
   export function isa(o: any): o is RegisterInstanceRequest {
-    return _smithy.isa(o, "RegisterInstanceRequest");
+    return __isa(o, "RegisterInstanceRequest");
   }
 }
 
@@ -2195,7 +2190,7 @@ export interface RegisterInstanceResponse extends $MetadataBearer {
 
 export namespace RegisterInstanceResponse {
   export function isa(o: any): o is RegisterInstanceResponse {
-    return _smithy.isa(o, "RegisterInstanceResponse");
+    return __isa(o, "RegisterInstanceResponse");
   }
 }
 
@@ -2203,9 +2198,7 @@ export namespace RegisterInstanceResponse {
  * <p>The specified resource can't be deleted because it contains other resources. For example, you can't delete a service that
  * 			contains any instances.</p>
  */
-export interface ResourceInUse
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface ResourceInUse extends __SmithyException, $MetadataBearer {
   name: "ResourceInUse";
   $fault: "client";
   Message?: string;
@@ -2213,7 +2206,7 @@ export interface ResourceInUse
 
 export namespace ResourceInUse {
   export function isa(o: any): o is ResourceInUse {
-    return _smithy.isa(o, "ResourceInUse");
+    return __isa(o, "ResourceInUse");
   }
 }
 
@@ -2221,7 +2214,7 @@ export namespace ResourceInUse {
  * <p>The resource can't be created because you've reached the limit on the number of resources.</p>
  */
 export interface ResourceLimitExceeded
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceLimitExceeded";
   $fault: "client";
@@ -2230,7 +2223,7 @@ export interface ResourceLimitExceeded
 
 export namespace ResourceLimitExceeded {
   export function isa(o: any): o is ResourceLimitExceeded {
-    return _smithy.isa(o, "ResourceLimitExceeded");
+    return __isa(o, "ResourceLimitExceeded");
   }
 }
 
@@ -2313,7 +2306,7 @@ export interface Service {
 
 export namespace Service {
   export function isa(o: any): o is Service {
-    return _smithy.isa(o, "Service");
+    return __isa(o, "Service");
   }
 }
 
@@ -2321,7 +2314,7 @@ export namespace Service {
  * <p>The service can't be created because a service with the same name already exists.</p>
  */
 export interface ServiceAlreadyExists
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ServiceAlreadyExists";
   $fault: "client";
@@ -2339,7 +2332,7 @@ export interface ServiceAlreadyExists
 
 export namespace ServiceAlreadyExists {
   export function isa(o: any): o is ServiceAlreadyExists {
-    return _smithy.isa(o, "ServiceAlreadyExists");
+    return __isa(o, "ServiceAlreadyExists");
   }
 }
 
@@ -2428,7 +2421,7 @@ export interface ServiceChange {
 
 export namespace ServiceChange {
   export function isa(o: any): o is ServiceChange {
-    return _smithy.isa(o, "ServiceChange");
+    return __isa(o, "ServiceChange");
   }
 }
 
@@ -2472,7 +2465,7 @@ export interface ServiceFilter {
 
 export namespace ServiceFilter {
   export function isa(o: any): o is ServiceFilter {
-    return _smithy.isa(o, "ServiceFilter");
+    return __isa(o, "ServiceFilter");
   }
 }
 
@@ -2483,9 +2476,7 @@ export enum ServiceFilterName {
 /**
  * <p>No service exists with the specified ID.</p>
  */
-export interface ServiceNotFound
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface ServiceNotFound extends __SmithyException, $MetadataBearer {
   name: "ServiceNotFound";
   $fault: "client";
   Message?: string;
@@ -2493,7 +2484,7 @@ export interface ServiceNotFound
 
 export namespace ServiceNotFound {
   export function isa(o: any): o is ServiceNotFound {
-    return _smithy.isa(o, "ServiceNotFound");
+    return __isa(o, "ServiceNotFound");
   }
 }
 
@@ -2667,7 +2658,7 @@ export interface ServiceSummary {
 
 export namespace ServiceSummary {
   export function isa(o: any): o is ServiceSummary {
-    return _smithy.isa(o, "ServiceSummary");
+    return __isa(o, "ServiceSummary");
   }
 }
 
@@ -2691,7 +2682,7 @@ export interface UpdateInstanceCustomHealthStatusRequest {
 
 export namespace UpdateInstanceCustomHealthStatusRequest {
   export function isa(o: any): o is UpdateInstanceCustomHealthStatusRequest {
-    return _smithy.isa(o, "UpdateInstanceCustomHealthStatusRequest");
+    return __isa(o, "UpdateInstanceCustomHealthStatusRequest");
   }
 }
 
@@ -2710,7 +2701,7 @@ export interface UpdateServiceRequest {
 
 export namespace UpdateServiceRequest {
   export function isa(o: any): o is UpdateServiceRequest {
-    return _smithy.isa(o, "UpdateServiceRequest");
+    return __isa(o, "UpdateServiceRequest");
   }
 }
 
@@ -2725,6 +2716,6 @@ export interface UpdateServiceResponse extends $MetadataBearer {
 
 export namespace UpdateServiceResponse {
   export function isa(o: any): o is UpdateServiceResponse {
-    return _smithy.isa(o, "UpdateServiceResponse");
+    return __isa(o, "UpdateServiceResponse");
   }
 }

--- a/clients/client-servicediscovery/protocols/Aws_json1_1.ts
+++ b/clients/client-servicediscovery/protocols/Aws_json1_1.ts
@@ -1743,6 +1743,7 @@ export async function deserializeAws_json1_1UpdateInstanceCustomHealthStatusComm
       context
     );
   }
+  await collectBody(output.body, context);
   const response: UpdateInstanceCustomHealthStatusCommandOutput = {
     $metadata: deserializeMetadata(output)
   };

--- a/clients/client-ses/models/index.ts
+++ b/clients/client-ses/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -40,7 +43,7 @@ export interface MessageTag {
 
 export namespace MessageTag {
   export function isa(o: any): o is MessageTag {
-    return _smithy.isa(o, "MessageTag");
+    return __isa(o, "MessageTag");
   }
 }
 
@@ -49,7 +52,7 @@ export namespace MessageTag {
  *         <p>You can enable or disable email sending for your Amazon SES account using <a>UpdateAccountSendingEnabled</a>.</p>
  */
 export interface AccountSendingPausedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AccountSendingPausedException";
   $fault: "client";
@@ -58,7 +61,7 @@ export interface AccountSendingPausedException
 
 export namespace AccountSendingPausedException {
   export function isa(o: any): o is AccountSendingPausedException {
-    return _smithy.isa(o, "AccountSendingPausedException");
+    return __isa(o, "AccountSendingPausedException");
   }
 }
 
@@ -85,7 +88,7 @@ export interface AddHeaderAction {
 
 export namespace AddHeaderAction {
   export function isa(o: any): o is AddHeaderAction {
-    return _smithy.isa(o, "AddHeaderAction");
+    return __isa(o, "AddHeaderAction");
   }
 }
 
@@ -93,7 +96,7 @@ export namespace AddHeaderAction {
  * <p>Indicates that a resource could not be created because of a naming conflict.</p>
  */
 export interface AlreadyExistsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AlreadyExistsException";
   $fault: "client";
@@ -108,7 +111,7 @@ export interface AlreadyExistsException
 
 export namespace AlreadyExistsException {
   export function isa(o: any): o is AlreadyExistsException {
-    return _smithy.isa(o, "AlreadyExistsException");
+    return __isa(o, "AlreadyExistsException");
   }
 }
 
@@ -140,7 +143,7 @@ export interface Body {
 
 export namespace Body {
   export function isa(o: any): o is Body {
-    return _smithy.isa(o, "Body");
+    return __isa(o, "Body");
   }
 }
 
@@ -186,7 +189,7 @@ export interface BounceAction {
 
 export namespace BounceAction {
   export function isa(o: any): o is BounceAction {
-    return _smithy.isa(o, "BounceAction");
+    return __isa(o, "BounceAction");
   }
 }
 
@@ -237,7 +240,7 @@ export interface BouncedRecipientInfo {
 
 export namespace BouncedRecipientInfo {
   export function isa(o: any): o is BouncedRecipientInfo {
-    return _smithy.isa(o, "BouncedRecipientInfo");
+    return __isa(o, "BouncedRecipientInfo");
   }
 }
 
@@ -278,7 +281,7 @@ export interface BulkEmailDestination {
 
 export namespace BulkEmailDestination {
   export function isa(o: any): o is BulkEmailDestination {
-    return _smithy.isa(o, "BulkEmailDestination");
+    return __isa(o, "BulkEmailDestination");
   }
 }
 
@@ -385,7 +388,7 @@ export interface BulkEmailDestinationStatus {
 
 export namespace BulkEmailDestinationStatus {
   export function isa(o: any): o is BulkEmailDestinationStatus {
-    return _smithy.isa(o, "BulkEmailDestinationStatus");
+    return __isa(o, "BulkEmailDestinationStatus");
   }
 }
 
@@ -410,7 +413,7 @@ export enum BulkEmailStatus {
  * <p>Indicates that the delete operation could not be completed.</p>
  */
 export interface CannotDeleteException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CannotDeleteException";
   $fault: "client";
@@ -425,7 +428,7 @@ export interface CannotDeleteException
 
 export namespace CannotDeleteException {
   export function isa(o: any): o is CannotDeleteException {
-    return _smithy.isa(o, "CannotDeleteException");
+    return __isa(o, "CannotDeleteException");
   }
 }
 
@@ -460,7 +463,7 @@ export interface CloneReceiptRuleSetRequest {
 
 export namespace CloneReceiptRuleSetRequest {
   export function isa(o: any): o is CloneReceiptRuleSetRequest {
-    return _smithy.isa(o, "CloneReceiptRuleSetRequest");
+    return __isa(o, "CloneReceiptRuleSetRequest");
   }
 }
 
@@ -473,7 +476,7 @@ export interface CloneReceiptRuleSetResponse extends $MetadataBearer {
 
 export namespace CloneReceiptRuleSetResponse {
   export function isa(o: any): o is CloneReceiptRuleSetResponse {
-    return _smithy.isa(o, "CloneReceiptRuleSetResponse");
+    return __isa(o, "CloneReceiptRuleSetResponse");
   }
 }
 
@@ -496,7 +499,7 @@ export interface CloudWatchDestination {
 
 export namespace CloudWatchDestination {
   export function isa(o: any): o is CloudWatchDestination {
-    return _smithy.isa(o, "CloudWatchDestination");
+    return __isa(o, "CloudWatchDestination");
   }
 }
 
@@ -550,7 +553,7 @@ export interface CloudWatchDimensionConfiguration {
 
 export namespace CloudWatchDimensionConfiguration {
   export function isa(o: any): o is CloudWatchDimensionConfiguration {
-    return _smithy.isa(o, "CloudWatchDimensionConfiguration");
+    return __isa(o, "CloudWatchDimensionConfiguration");
   }
 }
 
@@ -579,7 +582,7 @@ export interface ConfigurationSet {
 
 export namespace ConfigurationSet {
   export function isa(o: any): o is ConfigurationSet {
-    return _smithy.isa(o, "ConfigurationSet");
+    return __isa(o, "ConfigurationSet");
   }
 }
 
@@ -588,7 +591,7 @@ export namespace ConfigurationSet {
  *             conflict.</p>
  */
 export interface ConfigurationSetAlreadyExistsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ConfigurationSetAlreadyExistsException";
   $fault: "client";
@@ -602,7 +605,7 @@ export interface ConfigurationSetAlreadyExistsException
 
 export namespace ConfigurationSetAlreadyExistsException {
   export function isa(o: any): o is ConfigurationSetAlreadyExistsException {
-    return _smithy.isa(o, "ConfigurationSetAlreadyExistsException");
+    return __isa(o, "ConfigurationSetAlreadyExistsException");
   }
 }
 
@@ -617,7 +620,7 @@ export enum ConfigurationSetAttribute {
  * <p>Indicates that the configuration set does not exist.</p>
  */
 export interface ConfigurationSetDoesNotExistException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ConfigurationSetDoesNotExistException";
   $fault: "client";
@@ -631,7 +634,7 @@ export interface ConfigurationSetDoesNotExistException
 
 export namespace ConfigurationSetDoesNotExistException {
   export function isa(o: any): o is ConfigurationSetDoesNotExistException {
-    return _smithy.isa(o, "ConfigurationSetDoesNotExistException");
+    return __isa(o, "ConfigurationSetDoesNotExistException");
   }
 }
 
@@ -640,7 +643,7 @@ export namespace ConfigurationSetDoesNotExistException {
  *         <p>You can enable or disable email sending for a configuration set using <a>UpdateConfigurationSetSendingEnabled</a>.</p>
  */
 export interface ConfigurationSetSendingPausedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ConfigurationSetSendingPausedException";
   $fault: "client";
@@ -654,7 +657,7 @@ export interface ConfigurationSetSendingPausedException
 
 export namespace ConfigurationSetSendingPausedException {
   export function isa(o: any): o is ConfigurationSetSendingPausedException {
-    return _smithy.isa(o, "ConfigurationSetSendingPausedException");
+    return __isa(o, "ConfigurationSetSendingPausedException");
   }
 }
 
@@ -679,7 +682,7 @@ export interface Content {
 
 export namespace Content {
   export function isa(o: any): o is Content {
-    return _smithy.isa(o, "Content");
+    return __isa(o, "Content");
   }
 }
 
@@ -709,7 +712,7 @@ export namespace CreateConfigurationSetEventDestinationRequest {
   export function isa(
     o: any
   ): o is CreateConfigurationSetEventDestinationRequest {
-    return _smithy.isa(o, "CreateConfigurationSetEventDestinationRequest");
+    return __isa(o, "CreateConfigurationSetEventDestinationRequest");
   }
 }
 
@@ -725,7 +728,7 @@ export namespace CreateConfigurationSetEventDestinationResponse {
   export function isa(
     o: any
   ): o is CreateConfigurationSetEventDestinationResponse {
-    return _smithy.isa(o, "CreateConfigurationSetEventDestinationResponse");
+    return __isa(o, "CreateConfigurationSetEventDestinationResponse");
   }
 }
 
@@ -745,7 +748,7 @@ export interface CreateConfigurationSetRequest {
 
 export namespace CreateConfigurationSetRequest {
   export function isa(o: any): o is CreateConfigurationSetRequest {
-    return _smithy.isa(o, "CreateConfigurationSetRequest");
+    return __isa(o, "CreateConfigurationSetRequest");
   }
 }
 
@@ -758,7 +761,7 @@ export interface CreateConfigurationSetResponse extends $MetadataBearer {
 
 export namespace CreateConfigurationSetResponse {
   export function isa(o: any): o is CreateConfigurationSetResponse {
-    return _smithy.isa(o, "CreateConfigurationSetResponse");
+    return __isa(o, "CreateConfigurationSetResponse");
   }
 }
 
@@ -788,7 +791,7 @@ export namespace CreateConfigurationSetTrackingOptionsRequest {
   export function isa(
     o: any
   ): o is CreateConfigurationSetTrackingOptionsRequest {
-    return _smithy.isa(o, "CreateConfigurationSetTrackingOptionsRequest");
+    return __isa(o, "CreateConfigurationSetTrackingOptionsRequest");
   }
 }
 
@@ -804,7 +807,7 @@ export namespace CreateConfigurationSetTrackingOptionsResponse {
   export function isa(
     o: any
   ): o is CreateConfigurationSetTrackingOptionsResponse {
-    return _smithy.isa(o, "CreateConfigurationSetTrackingOptionsResponse");
+    return __isa(o, "CreateConfigurationSetTrackingOptionsResponse");
   }
 }
 
@@ -853,7 +856,7 @@ export namespace CreateCustomVerificationEmailTemplateRequest {
   export function isa(
     o: any
   ): o is CreateCustomVerificationEmailTemplateRequest {
-    return _smithy.isa(o, "CreateCustomVerificationEmailTemplateRequest");
+    return __isa(o, "CreateCustomVerificationEmailTemplateRequest");
   }
 }
 
@@ -872,7 +875,7 @@ export interface CreateReceiptFilterRequest {
 
 export namespace CreateReceiptFilterRequest {
   export function isa(o: any): o is CreateReceiptFilterRequest {
-    return _smithy.isa(o, "CreateReceiptFilterRequest");
+    return __isa(o, "CreateReceiptFilterRequest");
   }
 }
 
@@ -885,7 +888,7 @@ export interface CreateReceiptFilterResponse extends $MetadataBearer {
 
 export namespace CreateReceiptFilterResponse {
   export function isa(o: any): o is CreateReceiptFilterResponse {
-    return _smithy.isa(o, "CreateReceiptFilterResponse");
+    return __isa(o, "CreateReceiptFilterResponse");
   }
 }
 
@@ -917,7 +920,7 @@ export interface CreateReceiptRuleRequest {
 
 export namespace CreateReceiptRuleRequest {
   export function isa(o: any): o is CreateReceiptRuleRequest {
-    return _smithy.isa(o, "CreateReceiptRuleRequest");
+    return __isa(o, "CreateReceiptRuleRequest");
   }
 }
 
@@ -930,7 +933,7 @@ export interface CreateReceiptRuleResponse extends $MetadataBearer {
 
 export namespace CreateReceiptRuleResponse {
   export function isa(o: any): o is CreateReceiptRuleResponse {
-    return _smithy.isa(o, "CreateReceiptRuleResponse");
+    return __isa(o, "CreateReceiptRuleResponse");
   }
 }
 
@@ -961,7 +964,7 @@ export interface CreateReceiptRuleSetRequest {
 
 export namespace CreateReceiptRuleSetRequest {
   export function isa(o: any): o is CreateReceiptRuleSetRequest {
-    return _smithy.isa(o, "CreateReceiptRuleSetRequest");
+    return __isa(o, "CreateReceiptRuleSetRequest");
   }
 }
 
@@ -974,7 +977,7 @@ export interface CreateReceiptRuleSetResponse extends $MetadataBearer {
 
 export namespace CreateReceiptRuleSetResponse {
   export function isa(o: any): o is CreateReceiptRuleSetResponse {
-    return _smithy.isa(o, "CreateReceiptRuleSetResponse");
+    return __isa(o, "CreateReceiptRuleSetResponse");
   }
 }
 
@@ -993,7 +996,7 @@ export interface CreateTemplateRequest {
 
 export namespace CreateTemplateRequest {
   export function isa(o: any): o is CreateTemplateRequest {
-    return _smithy.isa(o, "CreateTemplateRequest");
+    return __isa(o, "CreateTemplateRequest");
   }
 }
 
@@ -1003,7 +1006,7 @@ export interface CreateTemplateResponse extends $MetadataBearer {
 
 export namespace CreateTemplateResponse {
   export function isa(o: any): o is CreateTemplateResponse {
-    return _smithy.isa(o, "CreateTemplateResponse");
+    return __isa(o, "CreateTemplateResponse");
   }
 }
 
@@ -1018,7 +1021,7 @@ export enum CustomMailFromStatus {
  * <p>Indicates that custom verification email template provided content is invalid.</p>
  */
 export interface CustomVerificationEmailInvalidContentException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CustomVerificationEmailInvalidContentException";
   $fault: "client";
@@ -1029,7 +1032,7 @@ export namespace CustomVerificationEmailInvalidContentException {
   export function isa(
     o: any
   ): o is CustomVerificationEmailInvalidContentException {
-    return _smithy.isa(o, "CustomVerificationEmailInvalidContentException");
+    return __isa(o, "CustomVerificationEmailInvalidContentException");
   }
 }
 
@@ -1068,7 +1071,7 @@ export interface CustomVerificationEmailTemplate {
 
 export namespace CustomVerificationEmailTemplate {
   export function isa(o: any): o is CustomVerificationEmailTemplate {
-    return _smithy.isa(o, "CustomVerificationEmailTemplate");
+    return __isa(o, "CustomVerificationEmailTemplate");
   }
 }
 
@@ -1077,7 +1080,7 @@ export namespace CustomVerificationEmailTemplate {
  *             already exists.</p>
  */
 export interface CustomVerificationEmailTemplateAlreadyExistsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CustomVerificationEmailTemplateAlreadyExistsException";
   $fault: "client";
@@ -1094,10 +1097,7 @@ export namespace CustomVerificationEmailTemplateAlreadyExistsException {
   export function isa(
     o: any
   ): o is CustomVerificationEmailTemplateAlreadyExistsException {
-    return _smithy.isa(
-      o,
-      "CustomVerificationEmailTemplateAlreadyExistsException"
-    );
+    return __isa(o, "CustomVerificationEmailTemplateAlreadyExistsException");
   }
 }
 
@@ -1106,7 +1106,7 @@ export namespace CustomVerificationEmailTemplateAlreadyExistsException {
  *             not exist.</p>
  */
 export interface CustomVerificationEmailTemplateDoesNotExistException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CustomVerificationEmailTemplateDoesNotExistException";
   $fault: "client";
@@ -1122,10 +1122,7 @@ export namespace CustomVerificationEmailTemplateDoesNotExistException {
   export function isa(
     o: any
   ): o is CustomVerificationEmailTemplateDoesNotExistException {
-    return _smithy.isa(
-      o,
-      "CustomVerificationEmailTemplateDoesNotExistException"
-    );
+    return __isa(o, "CustomVerificationEmailTemplateDoesNotExistException");
   }
 }
 
@@ -1153,7 +1150,7 @@ export namespace DeleteConfigurationSetEventDestinationRequest {
   export function isa(
     o: any
   ): o is DeleteConfigurationSetEventDestinationRequest {
-    return _smithy.isa(o, "DeleteConfigurationSetEventDestinationRequest");
+    return __isa(o, "DeleteConfigurationSetEventDestinationRequest");
   }
 }
 
@@ -1169,7 +1166,7 @@ export namespace DeleteConfigurationSetEventDestinationResponse {
   export function isa(
     o: any
   ): o is DeleteConfigurationSetEventDestinationResponse {
-    return _smithy.isa(o, "DeleteConfigurationSetEventDestinationResponse");
+    return __isa(o, "DeleteConfigurationSetEventDestinationResponse");
   }
 }
 
@@ -1189,7 +1186,7 @@ export interface DeleteConfigurationSetRequest {
 
 export namespace DeleteConfigurationSetRequest {
   export function isa(o: any): o is DeleteConfigurationSetRequest {
-    return _smithy.isa(o, "DeleteConfigurationSetRequest");
+    return __isa(o, "DeleteConfigurationSetRequest");
   }
 }
 
@@ -1202,7 +1199,7 @@ export interface DeleteConfigurationSetResponse extends $MetadataBearer {
 
 export namespace DeleteConfigurationSetResponse {
   export function isa(o: any): o is DeleteConfigurationSetResponse {
-    return _smithy.isa(o, "DeleteConfigurationSetResponse");
+    return __isa(o, "DeleteConfigurationSetResponse");
   }
 }
 
@@ -1223,7 +1220,7 @@ export namespace DeleteConfigurationSetTrackingOptionsRequest {
   export function isa(
     o: any
   ): o is DeleteConfigurationSetTrackingOptionsRequest {
-    return _smithy.isa(o, "DeleteConfigurationSetTrackingOptionsRequest");
+    return __isa(o, "DeleteConfigurationSetTrackingOptionsRequest");
   }
 }
 
@@ -1239,7 +1236,7 @@ export namespace DeleteConfigurationSetTrackingOptionsResponse {
   export function isa(
     o: any
   ): o is DeleteConfigurationSetTrackingOptionsResponse {
-    return _smithy.isa(o, "DeleteConfigurationSetTrackingOptionsResponse");
+    return __isa(o, "DeleteConfigurationSetTrackingOptionsResponse");
   }
 }
 
@@ -1258,7 +1255,7 @@ export namespace DeleteCustomVerificationEmailTemplateRequest {
   export function isa(
     o: any
   ): o is DeleteCustomVerificationEmailTemplateRequest {
-    return _smithy.isa(o, "DeleteCustomVerificationEmailTemplateRequest");
+    return __isa(o, "DeleteCustomVerificationEmailTemplateRequest");
   }
 }
 
@@ -1287,7 +1284,7 @@ export interface DeleteIdentityPolicyRequest {
 
 export namespace DeleteIdentityPolicyRequest {
   export function isa(o: any): o is DeleteIdentityPolicyRequest {
-    return _smithy.isa(o, "DeleteIdentityPolicyRequest");
+    return __isa(o, "DeleteIdentityPolicyRequest");
   }
 }
 
@@ -1300,7 +1297,7 @@ export interface DeleteIdentityPolicyResponse extends $MetadataBearer {
 
 export namespace DeleteIdentityPolicyResponse {
   export function isa(o: any): o is DeleteIdentityPolicyResponse {
-    return _smithy.isa(o, "DeleteIdentityPolicyResponse");
+    return __isa(o, "DeleteIdentityPolicyResponse");
   }
 }
 
@@ -1318,7 +1315,7 @@ export interface DeleteIdentityRequest {
 
 export namespace DeleteIdentityRequest {
   export function isa(o: any): o is DeleteIdentityRequest {
-    return _smithy.isa(o, "DeleteIdentityRequest");
+    return __isa(o, "DeleteIdentityRequest");
   }
 }
 
@@ -1331,7 +1328,7 @@ export interface DeleteIdentityResponse extends $MetadataBearer {
 
 export namespace DeleteIdentityResponse {
   export function isa(o: any): o is DeleteIdentityResponse {
-    return _smithy.isa(o, "DeleteIdentityResponse");
+    return __isa(o, "DeleteIdentityResponse");
   }
 }
 
@@ -1350,7 +1347,7 @@ export interface DeleteReceiptFilterRequest {
 
 export namespace DeleteReceiptFilterRequest {
   export function isa(o: any): o is DeleteReceiptFilterRequest {
-    return _smithy.isa(o, "DeleteReceiptFilterRequest");
+    return __isa(o, "DeleteReceiptFilterRequest");
   }
 }
 
@@ -1363,7 +1360,7 @@ export interface DeleteReceiptFilterResponse extends $MetadataBearer {
 
 export namespace DeleteReceiptFilterResponse {
   export function isa(o: any): o is DeleteReceiptFilterResponse {
-    return _smithy.isa(o, "DeleteReceiptFilterResponse");
+    return __isa(o, "DeleteReceiptFilterResponse");
   }
 }
 
@@ -1387,7 +1384,7 @@ export interface DeleteReceiptRuleRequest {
 
 export namespace DeleteReceiptRuleRequest {
   export function isa(o: any): o is DeleteReceiptRuleRequest {
-    return _smithy.isa(o, "DeleteReceiptRuleRequest");
+    return __isa(o, "DeleteReceiptRuleRequest");
   }
 }
 
@@ -1400,7 +1397,7 @@ export interface DeleteReceiptRuleResponse extends $MetadataBearer {
 
 export namespace DeleteReceiptRuleResponse {
   export function isa(o: any): o is DeleteReceiptRuleResponse {
-    return _smithy.isa(o, "DeleteReceiptRuleResponse");
+    return __isa(o, "DeleteReceiptRuleResponse");
   }
 }
 
@@ -1420,7 +1417,7 @@ export interface DeleteReceiptRuleSetRequest {
 
 export namespace DeleteReceiptRuleSetRequest {
   export function isa(o: any): o is DeleteReceiptRuleSetRequest {
-    return _smithy.isa(o, "DeleteReceiptRuleSetRequest");
+    return __isa(o, "DeleteReceiptRuleSetRequest");
   }
 }
 
@@ -1433,7 +1430,7 @@ export interface DeleteReceiptRuleSetResponse extends $MetadataBearer {
 
 export namespace DeleteReceiptRuleSetResponse {
   export function isa(o: any): o is DeleteReceiptRuleSetResponse {
-    return _smithy.isa(o, "DeleteReceiptRuleSetResponse");
+    return __isa(o, "DeleteReceiptRuleSetResponse");
   }
 }
 
@@ -1451,7 +1448,7 @@ export interface DeleteTemplateRequest {
 
 export namespace DeleteTemplateRequest {
   export function isa(o: any): o is DeleteTemplateRequest {
-    return _smithy.isa(o, "DeleteTemplateRequest");
+    return __isa(o, "DeleteTemplateRequest");
   }
 }
 
@@ -1461,7 +1458,7 @@ export interface DeleteTemplateResponse extends $MetadataBearer {
 
 export namespace DeleteTemplateResponse {
   export function isa(o: any): o is DeleteTemplateResponse {
-    return _smithy.isa(o, "DeleteTemplateResponse");
+    return __isa(o, "DeleteTemplateResponse");
   }
 }
 
@@ -1479,7 +1476,7 @@ export interface DeleteVerifiedEmailAddressRequest {
 
 export namespace DeleteVerifiedEmailAddressRequest {
   export function isa(o: any): o is DeleteVerifiedEmailAddressRequest {
-    return _smithy.isa(o, "DeleteVerifiedEmailAddressRequest");
+    return __isa(o, "DeleteVerifiedEmailAddressRequest");
   }
 }
 
@@ -1500,7 +1497,7 @@ export interface DeliveryOptions {
 
 export namespace DeliveryOptions {
   export function isa(o: any): o is DeliveryOptions {
-    return _smithy.isa(o, "DeliveryOptions");
+    return __isa(o, "DeliveryOptions");
   }
 }
 
@@ -1516,7 +1513,7 @@ export interface DescribeActiveReceiptRuleSetRequest {
 
 export namespace DescribeActiveReceiptRuleSetRequest {
   export function isa(o: any): o is DescribeActiveReceiptRuleSetRequest {
-    return _smithy.isa(o, "DescribeActiveReceiptRuleSetRequest");
+    return __isa(o, "DescribeActiveReceiptRuleSetRequest");
   }
 }
 
@@ -1540,7 +1537,7 @@ export interface DescribeActiveReceiptRuleSetResponse extends $MetadataBearer {
 
 export namespace DescribeActiveReceiptRuleSetResponse {
   export function isa(o: any): o is DescribeActiveReceiptRuleSetResponse {
-    return _smithy.isa(o, "DescribeActiveReceiptRuleSetResponse");
+    return __isa(o, "DescribeActiveReceiptRuleSetResponse");
   }
 }
 
@@ -1565,7 +1562,7 @@ export interface DescribeConfigurationSetRequest {
 
 export namespace DescribeConfigurationSetRequest {
   export function isa(o: any): o is DescribeConfigurationSetRequest {
-    return _smithy.isa(o, "DescribeConfigurationSetRequest");
+    return __isa(o, "DescribeConfigurationSetRequest");
   }
 }
 
@@ -1607,7 +1604,7 @@ export interface DescribeConfigurationSetResponse extends $MetadataBearer {
 
 export namespace DescribeConfigurationSetResponse {
   export function isa(o: any): o is DescribeConfigurationSetResponse {
-    return _smithy.isa(o, "DescribeConfigurationSetResponse");
+    return __isa(o, "DescribeConfigurationSetResponse");
   }
 }
 
@@ -1631,7 +1628,7 @@ export interface DescribeReceiptRuleRequest {
 
 export namespace DescribeReceiptRuleRequest {
   export function isa(o: any): o is DescribeReceiptRuleRequest {
-    return _smithy.isa(o, "DescribeReceiptRuleRequest");
+    return __isa(o, "DescribeReceiptRuleRequest");
   }
 }
 
@@ -1649,7 +1646,7 @@ export interface DescribeReceiptRuleResponse extends $MetadataBearer {
 
 export namespace DescribeReceiptRuleResponse {
   export function isa(o: any): o is DescribeReceiptRuleResponse {
-    return _smithy.isa(o, "DescribeReceiptRuleResponse");
+    return __isa(o, "DescribeReceiptRuleResponse");
   }
 }
 
@@ -1667,7 +1664,7 @@ export interface DescribeReceiptRuleSetRequest {
 
 export namespace DescribeReceiptRuleSetRequest {
   export function isa(o: any): o is DescribeReceiptRuleSetRequest {
-    return _smithy.isa(o, "DescribeReceiptRuleSetRequest");
+    return __isa(o, "DescribeReceiptRuleSetRequest");
   }
 }
 
@@ -1690,7 +1687,7 @@ export interface DescribeReceiptRuleSetResponse extends $MetadataBearer {
 
 export namespace DescribeReceiptRuleSetResponse {
   export function isa(o: any): o is DescribeReceiptRuleSetResponse {
-    return _smithy.isa(o, "DescribeReceiptRuleSetResponse");
+    return __isa(o, "DescribeReceiptRuleSetResponse");
   }
 }
 
@@ -1726,7 +1723,7 @@ export interface Destination {
 
 export namespace Destination {
   export function isa(o: any): o is Destination {
-    return _smithy.isa(o, "Destination");
+    return __isa(o, "Destination");
   }
 }
 
@@ -1806,7 +1803,7 @@ export interface EventDestination {
 
 export namespace EventDestination {
   export function isa(o: any): o is EventDestination {
-    return _smithy.isa(o, "EventDestination");
+    return __isa(o, "EventDestination");
   }
 }
 
@@ -1815,7 +1812,7 @@ export namespace EventDestination {
  *             conflict.</p>
  */
 export interface EventDestinationAlreadyExistsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "EventDestinationAlreadyExistsException";
   $fault: "client";
@@ -1834,7 +1831,7 @@ export interface EventDestinationAlreadyExistsException
 
 export namespace EventDestinationAlreadyExistsException {
   export function isa(o: any): o is EventDestinationAlreadyExistsException {
-    return _smithy.isa(o, "EventDestinationAlreadyExistsException");
+    return __isa(o, "EventDestinationAlreadyExistsException");
   }
 }
 
@@ -1842,7 +1839,7 @@ export namespace EventDestinationAlreadyExistsException {
  * <p>Indicates that the event destination does not exist.</p>
  */
 export interface EventDestinationDoesNotExistException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "EventDestinationDoesNotExistException";
   $fault: "client";
@@ -1861,7 +1858,7 @@ export interface EventDestinationDoesNotExistException
 
 export namespace EventDestinationDoesNotExistException {
   export function isa(o: any): o is EventDestinationDoesNotExistException {
-    return _smithy.isa(o, "EventDestinationDoesNotExistException");
+    return __isa(o, "EventDestinationDoesNotExistException");
   }
 }
 
@@ -1899,7 +1896,7 @@ export interface ExtensionField {
 
 export namespace ExtensionField {
   export function isa(o: any): o is ExtensionField {
-    return _smithy.isa(o, "ExtensionField");
+    return __isa(o, "ExtensionField");
   }
 }
 
@@ -1908,7 +1905,7 @@ export namespace ExtensionField {
  *             verified, and is therefore not eligible to send the custom verification email. </p>
  */
 export interface FromEmailAddressNotVerifiedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "FromEmailAddressNotVerifiedException";
   $fault: "client";
@@ -1923,7 +1920,7 @@ export interface FromEmailAddressNotVerifiedException
 
 export namespace FromEmailAddressNotVerifiedException {
   export function isa(o: any): o is FromEmailAddressNotVerifiedException {
-    return _smithy.isa(o, "FromEmailAddressNotVerifiedException");
+    return __isa(o, "FromEmailAddressNotVerifiedException");
   }
 }
 
@@ -1942,7 +1939,7 @@ export interface GetAccountSendingEnabledResponse extends $MetadataBearer {
 
 export namespace GetAccountSendingEnabledResponse {
   export function isa(o: any): o is GetAccountSendingEnabledResponse {
-    return _smithy.isa(o, "GetAccountSendingEnabledResponse");
+    return __isa(o, "GetAccountSendingEnabledResponse");
   }
 }
 
@@ -1960,7 +1957,7 @@ export interface GetCustomVerificationEmailTemplateRequest {
 
 export namespace GetCustomVerificationEmailTemplateRequest {
   export function isa(o: any): o is GetCustomVerificationEmailTemplateRequest {
-    return _smithy.isa(o, "GetCustomVerificationEmailTemplateRequest");
+    return __isa(o, "GetCustomVerificationEmailTemplateRequest");
   }
 }
 
@@ -2005,7 +2002,7 @@ export interface GetCustomVerificationEmailTemplateResponse
 
 export namespace GetCustomVerificationEmailTemplateResponse {
   export function isa(o: any): o is GetCustomVerificationEmailTemplateResponse {
-    return _smithy.isa(o, "GetCustomVerificationEmailTemplateResponse");
+    return __isa(o, "GetCustomVerificationEmailTemplateResponse");
   }
 }
 
@@ -2025,7 +2022,7 @@ export interface GetIdentityDkimAttributesRequest {
 
 export namespace GetIdentityDkimAttributesRequest {
   export function isa(o: any): o is GetIdentityDkimAttributesRequest {
-    return _smithy.isa(o, "GetIdentityDkimAttributesRequest");
+    return __isa(o, "GetIdentityDkimAttributesRequest");
   }
 }
 
@@ -2045,7 +2042,7 @@ export interface GetIdentityDkimAttributesResponse extends $MetadataBearer {
 
 export namespace GetIdentityDkimAttributesResponse {
   export function isa(o: any): o is GetIdentityDkimAttributesResponse {
-    return _smithy.isa(o, "GetIdentityDkimAttributesResponse");
+    return __isa(o, "GetIdentityDkimAttributesResponse");
   }
 }
 
@@ -2064,7 +2061,7 @@ export interface GetIdentityMailFromDomainAttributesRequest {
 
 export namespace GetIdentityMailFromDomainAttributesRequest {
   export function isa(o: any): o is GetIdentityMailFromDomainAttributesRequest {
-    return _smithy.isa(o, "GetIdentityMailFromDomainAttributesRequest");
+    return __isa(o, "GetIdentityMailFromDomainAttributesRequest");
   }
 }
 
@@ -2086,7 +2083,7 @@ export namespace GetIdentityMailFromDomainAttributesResponse {
   export function isa(
     o: any
   ): o is GetIdentityMailFromDomainAttributesResponse {
-    return _smithy.isa(o, "GetIdentityMailFromDomainAttributesResponse");
+    return __isa(o, "GetIdentityMailFromDomainAttributesResponse");
   }
 }
 
@@ -2108,7 +2105,7 @@ export interface GetIdentityNotificationAttributesRequest {
 
 export namespace GetIdentityNotificationAttributesRequest {
   export function isa(o: any): o is GetIdentityNotificationAttributesRequest {
-    return _smithy.isa(o, "GetIdentityNotificationAttributesRequest");
+    return __isa(o, "GetIdentityNotificationAttributesRequest");
   }
 }
 
@@ -2128,7 +2125,7 @@ export interface GetIdentityNotificationAttributesResponse
 
 export namespace GetIdentityNotificationAttributesResponse {
   export function isa(o: any): o is GetIdentityNotificationAttributesResponse {
-    return _smithy.isa(o, "GetIdentityNotificationAttributesResponse");
+    return __isa(o, "GetIdentityNotificationAttributesResponse");
   }
 }
 
@@ -2159,7 +2156,7 @@ export interface GetIdentityPoliciesRequest {
 
 export namespace GetIdentityPoliciesRequest {
   export function isa(o: any): o is GetIdentityPoliciesRequest {
-    return _smithy.isa(o, "GetIdentityPoliciesRequest");
+    return __isa(o, "GetIdentityPoliciesRequest");
   }
 }
 
@@ -2176,7 +2173,7 @@ export interface GetIdentityPoliciesResponse extends $MetadataBearer {
 
 export namespace GetIdentityPoliciesResponse {
   export function isa(o: any): o is GetIdentityPoliciesResponse {
-    return _smithy.isa(o, "GetIdentityPoliciesResponse");
+    return __isa(o, "GetIdentityPoliciesResponse");
   }
 }
 
@@ -2196,7 +2193,7 @@ export interface GetIdentityVerificationAttributesRequest {
 
 export namespace GetIdentityVerificationAttributesRequest {
   export function isa(o: any): o is GetIdentityVerificationAttributesRequest {
-    return _smithy.isa(o, "GetIdentityVerificationAttributesRequest");
+    return __isa(o, "GetIdentityVerificationAttributesRequest");
   }
 }
 
@@ -2217,7 +2214,7 @@ export interface GetIdentityVerificationAttributesResponse
 
 export namespace GetIdentityVerificationAttributesResponse {
   export function isa(o: any): o is GetIdentityVerificationAttributesResponse {
-    return _smithy.isa(o, "GetIdentityVerificationAttributesResponse");
+    return __isa(o, "GetIdentityVerificationAttributesResponse");
   }
 }
 
@@ -2251,7 +2248,7 @@ export interface GetSendQuotaResponse extends $MetadataBearer {
 
 export namespace GetSendQuotaResponse {
   export function isa(o: any): o is GetSendQuotaResponse {
-    return _smithy.isa(o, "GetSendQuotaResponse");
+    return __isa(o, "GetSendQuotaResponse");
   }
 }
 
@@ -2269,7 +2266,7 @@ export interface GetSendStatisticsResponse extends $MetadataBearer {
 
 export namespace GetSendStatisticsResponse {
   export function isa(o: any): o is GetSendStatisticsResponse {
-    return _smithy.isa(o, "GetSendStatisticsResponse");
+    return __isa(o, "GetSendStatisticsResponse");
   }
 }
 
@@ -2283,7 +2280,7 @@ export interface GetTemplateRequest {
 
 export namespace GetTemplateRequest {
   export function isa(o: any): o is GetTemplateRequest {
-    return _smithy.isa(o, "GetTemplateRequest");
+    return __isa(o, "GetTemplateRequest");
   }
 }
 
@@ -2298,7 +2295,7 @@ export interface GetTemplateResponse extends $MetadataBearer {
 
 export namespace GetTemplateResponse {
   export function isa(o: any): o is GetTemplateResponse {
-    return _smithy.isa(o, "GetTemplateResponse");
+    return __isa(o, "GetTemplateResponse");
   }
 }
 
@@ -2335,7 +2332,7 @@ export interface IdentityDkimAttributes {
 
 export namespace IdentityDkimAttributes {
   export function isa(o: any): o is IdentityDkimAttributes {
-    return _smithy.isa(o, "IdentityDkimAttributes");
+    return __isa(o, "IdentityDkimAttributes");
   }
 }
 
@@ -2374,7 +2371,7 @@ export interface IdentityMailFromDomainAttributes {
 
 export namespace IdentityMailFromDomainAttributes {
   export function isa(o: any): o is IdentityMailFromDomainAttributes {
-    return _smithy.isa(o, "IdentityMailFromDomainAttributes");
+    return __isa(o, "IdentityMailFromDomainAttributes");
   }
 }
 
@@ -2440,7 +2437,7 @@ export interface IdentityNotificationAttributes {
 
 export namespace IdentityNotificationAttributes {
   export function isa(o: any): o is IdentityNotificationAttributes {
-    return _smithy.isa(o, "IdentityNotificationAttributes");
+    return __isa(o, "IdentityNotificationAttributes");
   }
 }
 
@@ -2466,7 +2463,7 @@ export interface IdentityVerificationAttributes {
 
 export namespace IdentityVerificationAttributes {
   export function isa(o: any): o is IdentityVerificationAttributes {
-    return _smithy.isa(o, "IdentityVerificationAttributes");
+    return __isa(o, "IdentityVerificationAttributes");
   }
 }
 
@@ -2475,7 +2472,7 @@ export namespace IdentityVerificationAttributes {
  *             details.</p>
  */
 export interface InvalidCloudWatchDestinationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidCloudWatchDestinationException";
   $fault: "client";
@@ -2494,7 +2491,7 @@ export interface InvalidCloudWatchDestinationException
 
 export namespace InvalidCloudWatchDestinationException {
   export function isa(o: any): o is InvalidCloudWatchDestinationException {
-    return _smithy.isa(o, "InvalidCloudWatchDestinationException");
+    return __isa(o, "InvalidCloudWatchDestinationException");
   }
 }
 
@@ -2503,7 +2500,7 @@ export namespace InvalidCloudWatchDestinationException {
  *             details.</p>
  */
 export interface InvalidConfigurationSetException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidConfigurationSetException";
   $fault: "client";
@@ -2512,7 +2509,7 @@ export interface InvalidConfigurationSetException
 
 export namespace InvalidConfigurationSetException {
   export function isa(o: any): o is InvalidConfigurationSetException {
-    return _smithy.isa(o, "InvalidConfigurationSetException");
+    return __isa(o, "InvalidConfigurationSetException");
   }
 }
 
@@ -2520,7 +2517,7 @@ export namespace InvalidConfigurationSetException {
  * <p>Indicates that provided delivery option is invalid.</p>
  */
 export interface InvalidDeliveryOptionsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidDeliveryOptionsException";
   $fault: "client";
@@ -2529,7 +2526,7 @@ export interface InvalidDeliveryOptionsException
 
 export namespace InvalidDeliveryOptionsException {
   export function isa(o: any): o is InvalidDeliveryOptionsException {
-    return _smithy.isa(o, "InvalidDeliveryOptionsException");
+    return __isa(o, "InvalidDeliveryOptionsException");
   }
 }
 
@@ -2538,7 +2535,7 @@ export namespace InvalidDeliveryOptionsException {
  *             message for details.</p>
  */
 export interface InvalidFirehoseDestinationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidFirehoseDestinationException";
   $fault: "client";
@@ -2557,7 +2554,7 @@ export interface InvalidFirehoseDestinationException
 
 export namespace InvalidFirehoseDestinationException {
   export function isa(o: any): o is InvalidFirehoseDestinationException {
-    return _smithy.isa(o, "InvalidFirehoseDestinationException");
+    return __isa(o, "InvalidFirehoseDestinationException");
   }
 }
 
@@ -2568,7 +2565,7 @@ export namespace InvalidFirehoseDestinationException {
  *                 Developer Guide</a>.</p>
  */
 export interface InvalidLambdaFunctionException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidLambdaFunctionException";
   $fault: "client";
@@ -2582,7 +2579,7 @@ export interface InvalidLambdaFunctionException
 
 export namespace InvalidLambdaFunctionException {
   export function isa(o: any): o is InvalidLambdaFunctionException {
-    return _smithy.isa(o, "InvalidLambdaFunctionException");
+    return __isa(o, "InvalidLambdaFunctionException");
   }
 }
 
@@ -2591,7 +2588,7 @@ export namespace InvalidLambdaFunctionException {
  *             information about what caused the error.</p>
  */
 export interface InvalidPolicyException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidPolicyException";
   $fault: "client";
@@ -2600,7 +2597,7 @@ export interface InvalidPolicyException
 
 export namespace InvalidPolicyException {
   export function isa(o: any): o is InvalidPolicyException {
-    return _smithy.isa(o, "InvalidPolicyException");
+    return __isa(o, "InvalidPolicyException");
   }
 }
 
@@ -2609,7 +2606,7 @@ export namespace InvalidPolicyException {
  *             error may occur when the TemplateData object contains invalid JSON.</p>
  */
 export interface InvalidRenderingParameterException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidRenderingParameterException";
   $fault: "client";
@@ -2619,7 +2616,7 @@ export interface InvalidRenderingParameterException
 
 export namespace InvalidRenderingParameterException {
   export function isa(o: any): o is InvalidRenderingParameterException {
-    return _smithy.isa(o, "InvalidRenderingParameterException");
+    return __isa(o, "InvalidRenderingParameterException");
   }
 }
 
@@ -2630,7 +2627,7 @@ export namespace InvalidRenderingParameterException {
  *                 Developer Guide</a>.</p>
  */
 export interface InvalidS3ConfigurationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidS3ConfigurationException";
   $fault: "client";
@@ -2644,7 +2641,7 @@ export interface InvalidS3ConfigurationException
 
 export namespace InvalidS3ConfigurationException {
   export function isa(o: any): o is InvalidS3ConfigurationException {
-    return _smithy.isa(o, "InvalidS3ConfigurationException");
+    return __isa(o, "InvalidS3ConfigurationException");
   }
 }
 
@@ -2653,7 +2650,7 @@ export namespace InvalidS3ConfigurationException {
  *             invalid. See the error message for details.</p>
  */
 export interface InvalidSNSDestinationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidSNSDestinationException";
   $fault: "client";
@@ -2672,7 +2669,7 @@ export interface InvalidSNSDestinationException
 
 export namespace InvalidSNSDestinationException {
   export function isa(o: any): o is InvalidSNSDestinationException {
-    return _smithy.isa(o, "InvalidSNSDestinationException");
+    return __isa(o, "InvalidSNSDestinationException");
   }
 }
 
@@ -2683,7 +2680,7 @@ export namespace InvalidSNSDestinationException {
  *                 Developer Guide</a>.</p>
  */
 export interface InvalidSnsTopicException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidSnsTopicException";
   $fault: "client";
@@ -2697,7 +2694,7 @@ export interface InvalidSnsTopicException
 
 export namespace InvalidSnsTopicException {
   export function isa(o: any): o is InvalidSnsTopicException {
-    return _smithy.isa(o, "InvalidSnsTopicException");
+    return __isa(o, "InvalidSnsTopicException");
   }
 }
 
@@ -2706,7 +2703,7 @@ export namespace InvalidSnsTopicException {
  *             occur when a template refers to a partial that does not exist.</p>
  */
 export interface InvalidTemplateException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidTemplateException";
   $fault: "client";
@@ -2716,7 +2713,7 @@ export interface InvalidTemplateException
 
 export namespace InvalidTemplateException {
   export function isa(o: any): o is InvalidTemplateException {
-    return _smithy.isa(o, "InvalidTemplateException");
+    return __isa(o, "InvalidTemplateException");
   }
 }
 
@@ -2734,7 +2731,7 @@ export namespace InvalidTemplateException {
  *          </ul>
  */
 export interface InvalidTrackingOptionsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidTrackingOptionsException";
   $fault: "client";
@@ -2743,7 +2740,7 @@ export interface InvalidTrackingOptionsException
 
 export namespace InvalidTrackingOptionsException {
   export function isa(o: any): o is InvalidTrackingOptionsException {
-    return _smithy.isa(o, "InvalidTrackingOptionsException");
+    return __isa(o, "InvalidTrackingOptionsException");
   }
 }
 
@@ -2773,7 +2770,7 @@ export interface KinesisFirehoseDestination {
 
 export namespace KinesisFirehoseDestination {
   export function isa(o: any): o is KinesisFirehoseDestination {
-    return _smithy.isa(o, "KinesisFirehoseDestination");
+    return __isa(o, "KinesisFirehoseDestination");
   }
 }
 
@@ -2822,7 +2819,7 @@ export interface LambdaAction {
 
 export namespace LambdaAction {
   export function isa(o: any): o is LambdaAction {
-    return _smithy.isa(o, "LambdaAction");
+    return __isa(o, "LambdaAction");
   }
 }
 
@@ -2832,7 +2829,7 @@ export namespace LambdaAction {
  *             Guide</a>.</p>
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -2841,7 +2838,7 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
@@ -2867,7 +2864,7 @@ export interface ListConfigurationSetsRequest {
 
 export namespace ListConfigurationSetsRequest {
   export function isa(o: any): o is ListConfigurationSetsRequest {
-    return _smithy.isa(o, "ListConfigurationSetsRequest");
+    return __isa(o, "ListConfigurationSetsRequest");
   }
 }
 
@@ -2894,7 +2891,7 @@ export interface ListConfigurationSetsResponse extends $MetadataBearer {
 
 export namespace ListConfigurationSetsResponse {
   export function isa(o: any): o is ListConfigurationSetsResponse {
-    return _smithy.isa(o, "ListConfigurationSetsResponse");
+    return __isa(o, "ListConfigurationSetsResponse");
   }
 }
 
@@ -2926,7 +2923,7 @@ export namespace ListCustomVerificationEmailTemplatesRequest {
   export function isa(
     o: any
   ): o is ListCustomVerificationEmailTemplatesRequest {
-    return _smithy.isa(o, "ListCustomVerificationEmailTemplatesRequest");
+    return __isa(o, "ListCustomVerificationEmailTemplatesRequest");
   }
 }
 
@@ -2954,7 +2951,7 @@ export namespace ListCustomVerificationEmailTemplatesResponse {
   export function isa(
     o: any
   ): o is ListCustomVerificationEmailTemplatesResponse {
-    return _smithy.isa(o, "ListCustomVerificationEmailTemplatesResponse");
+    return __isa(o, "ListCustomVerificationEmailTemplatesResponse");
   }
 }
 
@@ -2985,7 +2982,7 @@ export interface ListIdentitiesRequest {
 
 export namespace ListIdentitiesRequest {
   export function isa(o: any): o is ListIdentitiesRequest {
-    return _smithy.isa(o, "ListIdentitiesRequest");
+    return __isa(o, "ListIdentitiesRequest");
   }
 }
 
@@ -3008,7 +3005,7 @@ export interface ListIdentitiesResponse extends $MetadataBearer {
 
 export namespace ListIdentitiesResponse {
   export function isa(o: any): o is ListIdentitiesResponse {
-    return _smithy.isa(o, "ListIdentitiesResponse");
+    return __isa(o, "ListIdentitiesResponse");
   }
 }
 
@@ -3031,7 +3028,7 @@ export interface ListIdentityPoliciesRequest {
 
 export namespace ListIdentityPoliciesRequest {
   export function isa(o: any): o is ListIdentityPoliciesRequest {
-    return _smithy.isa(o, "ListIdentityPoliciesRequest");
+    return __isa(o, "ListIdentityPoliciesRequest");
   }
 }
 
@@ -3048,7 +3045,7 @@ export interface ListIdentityPoliciesResponse extends $MetadataBearer {
 
 export namespace ListIdentityPoliciesResponse {
   export function isa(o: any): o is ListIdentityPoliciesResponse {
-    return _smithy.isa(o, "ListIdentityPoliciesResponse");
+    return __isa(o, "ListIdentityPoliciesResponse");
   }
 }
 
@@ -3064,7 +3061,7 @@ export interface ListReceiptFiltersRequest {
 
 export namespace ListReceiptFiltersRequest {
   export function isa(o: any): o is ListReceiptFiltersRequest {
-    return _smithy.isa(o, "ListReceiptFiltersRequest");
+    return __isa(o, "ListReceiptFiltersRequest");
   }
 }
 
@@ -3082,7 +3079,7 @@ export interface ListReceiptFiltersResponse extends $MetadataBearer {
 
 export namespace ListReceiptFiltersResponse {
   export function isa(o: any): o is ListReceiptFiltersResponse {
-    return _smithy.isa(o, "ListReceiptFiltersResponse");
+    return __isa(o, "ListReceiptFiltersResponse");
   }
 }
 
@@ -3103,7 +3100,7 @@ export interface ListReceiptRuleSetsRequest {
 
 export namespace ListReceiptRuleSetsRequest {
   export function isa(o: any): o is ListReceiptRuleSetsRequest {
-    return _smithy.isa(o, "ListReceiptRuleSetsRequest");
+    return __isa(o, "ListReceiptRuleSetsRequest");
   }
 }
 
@@ -3128,7 +3125,7 @@ export interface ListReceiptRuleSetsResponse extends $MetadataBearer {
 
 export namespace ListReceiptRuleSetsResponse {
   export function isa(o: any): o is ListReceiptRuleSetsResponse {
-    return _smithy.isa(o, "ListReceiptRuleSetsResponse");
+    return __isa(o, "ListReceiptRuleSetsResponse");
   }
 }
 
@@ -3150,7 +3147,7 @@ export interface ListTemplatesRequest {
 
 export namespace ListTemplatesRequest {
   export function isa(o: any): o is ListTemplatesRequest {
-    return _smithy.isa(o, "ListTemplatesRequest");
+    return __isa(o, "ListTemplatesRequest");
   }
 }
 
@@ -3172,7 +3169,7 @@ export interface ListTemplatesResponse extends $MetadataBearer {
 
 export namespace ListTemplatesResponse {
   export function isa(o: any): o is ListTemplatesResponse {
-    return _smithy.isa(o, "ListTemplatesResponse");
+    return __isa(o, "ListTemplatesResponse");
   }
 }
 
@@ -3190,7 +3187,7 @@ export interface ListVerifiedEmailAddressesResponse extends $MetadataBearer {
 
 export namespace ListVerifiedEmailAddressesResponse {
   export function isa(o: any): o is ListVerifiedEmailAddressesResponse {
-    return _smithy.isa(o, "ListVerifiedEmailAddressesResponse");
+    return __isa(o, "ListVerifiedEmailAddressesResponse");
   }
 }
 
@@ -3201,7 +3198,7 @@ export namespace ListVerifiedEmailAddressesResponse {
  *                 Guide</a>.</p>
  */
 export interface MailFromDomainNotVerifiedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "MailFromDomainNotVerifiedException";
   $fault: "client";
@@ -3210,7 +3207,7 @@ export interface MailFromDomainNotVerifiedException
 
 export namespace MailFromDomainNotVerifiedException {
   export function isa(o: any): o is MailFromDomainNotVerifiedException {
-    return _smithy.isa(o, "MailFromDomainNotVerifiedException");
+    return __isa(o, "MailFromDomainNotVerifiedException");
   }
 }
 
@@ -3233,7 +3230,7 @@ export interface Message {
 
 export namespace Message {
   export function isa(o: any): o is Message {
-    return _smithy.isa(o, "Message");
+    return __isa(o, "Message");
   }
 }
 
@@ -3266,7 +3263,7 @@ export interface MessageDsn {
 
 export namespace MessageDsn {
   export function isa(o: any): o is MessageDsn {
-    return _smithy.isa(o, "MessageDsn");
+    return __isa(o, "MessageDsn");
   }
 }
 
@@ -3274,9 +3271,7 @@ export namespace MessageDsn {
  * <p>Indicates that the action failed, and the message could not be sent. Check the error
  *             stack for more information about what caused the error.</p>
  */
-export interface MessageRejected
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface MessageRejected extends __SmithyException, $MetadataBearer {
   name: "MessageRejected";
   $fault: "client";
   message?: string;
@@ -3284,7 +3279,7 @@ export interface MessageRejected
 
 export namespace MessageRejected {
   export function isa(o: any): o is MessageRejected {
-    return _smithy.isa(o, "MessageRejected");
+    return __isa(o, "MessageRejected");
   }
 }
 
@@ -3294,7 +3289,7 @@ export namespace MessageRejected {
  *             replacement tags in the specified template.</p>
  */
 export interface MissingRenderingAttributeException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "MissingRenderingAttributeException";
   $fault: "client";
@@ -3304,7 +3299,7 @@ export interface MissingRenderingAttributeException
 
 export namespace MissingRenderingAttributeException {
   export function isa(o: any): o is MissingRenderingAttributeException {
-    return _smithy.isa(o, "MissingRenderingAttributeException");
+    return __isa(o, "MissingRenderingAttributeException");
   }
 }
 
@@ -3314,7 +3309,7 @@ export type NotificationType = "Bounce" | "Complaint" | "Delivery";
  * <p>Indicates that the account has not been granted production access.</p>
  */
 export interface ProductionAccessNotGrantedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ProductionAccessNotGrantedException";
   $fault: "client";
@@ -3323,7 +3318,7 @@ export interface ProductionAccessNotGrantedException
 
 export namespace ProductionAccessNotGrantedException {
   export function isa(o: any): o is ProductionAccessNotGrantedException {
-    return _smithy.isa(o, "ProductionAccessNotGrantedException");
+    return __isa(o, "ProductionAccessNotGrantedException");
   }
 }
 
@@ -3347,7 +3342,7 @@ export interface PutConfigurationSetDeliveryOptionsRequest {
 
 export namespace PutConfigurationSetDeliveryOptionsRequest {
   export function isa(o: any): o is PutConfigurationSetDeliveryOptionsRequest {
-    return _smithy.isa(o, "PutConfigurationSetDeliveryOptionsRequest");
+    return __isa(o, "PutConfigurationSetDeliveryOptionsRequest");
   }
 }
 
@@ -3362,7 +3357,7 @@ export interface PutConfigurationSetDeliveryOptionsResponse
 
 export namespace PutConfigurationSetDeliveryOptionsResponse {
   export function isa(o: any): o is PutConfigurationSetDeliveryOptionsResponse {
-    return _smithy.isa(o, "PutConfigurationSetDeliveryOptionsResponse");
+    return __isa(o, "PutConfigurationSetDeliveryOptionsResponse");
   }
 }
 
@@ -3400,7 +3395,7 @@ export interface PutIdentityPolicyRequest {
 
 export namespace PutIdentityPolicyRequest {
   export function isa(o: any): o is PutIdentityPolicyRequest {
-    return _smithy.isa(o, "PutIdentityPolicyRequest");
+    return __isa(o, "PutIdentityPolicyRequest");
   }
 }
 
@@ -3413,7 +3408,7 @@ export interface PutIdentityPolicyResponse extends $MetadataBearer {
 
 export namespace PutIdentityPolicyResponse {
   export function isa(o: any): o is PutIdentityPolicyResponse {
-    return _smithy.isa(o, "PutIdentityPolicyResponse");
+    return __isa(o, "PutIdentityPolicyResponse");
   }
 }
 
@@ -3444,7 +3439,7 @@ export interface RawMessage {
 
 export namespace RawMessage {
   export function isa(o: any): o is RawMessage {
-    return _smithy.isa(o, "RawMessage");
+    return __isa(o, "RawMessage");
   }
 }
 
@@ -3499,7 +3494,7 @@ export interface ReceiptAction {
 
 export namespace ReceiptAction {
   export function isa(o: any): o is ReceiptAction {
-    return _smithy.isa(o, "ReceiptAction");
+    return __isa(o, "ReceiptAction");
   }
 }
 
@@ -3536,7 +3531,7 @@ export interface ReceiptFilter {
 
 export namespace ReceiptFilter {
   export function isa(o: any): o is ReceiptFilter {
-    return _smithy.isa(o, "ReceiptFilter");
+    return __isa(o, "ReceiptFilter");
   }
 }
 
@@ -3569,7 +3564,7 @@ export interface ReceiptIpFilter {
 
 export namespace ReceiptIpFilter {
   export function isa(o: any): o is ReceiptIpFilter {
-    return _smithy.isa(o, "ReceiptIpFilter");
+    return __isa(o, "ReceiptIpFilter");
   }
 }
 
@@ -3637,7 +3632,7 @@ export interface ReceiptRule {
 
 export namespace ReceiptRule {
   export function isa(o: any): o is ReceiptRule {
-    return _smithy.isa(o, "ReceiptRule");
+    return __isa(o, "ReceiptRule");
   }
 }
 
@@ -3675,7 +3670,7 @@ export interface ReceiptRuleSetMetadata {
 
 export namespace ReceiptRuleSetMetadata {
   export function isa(o: any): o is ReceiptRuleSetMetadata {
-    return _smithy.isa(o, "ReceiptRuleSetMetadata");
+    return __isa(o, "ReceiptRuleSetMetadata");
   }
 }
 
@@ -3740,7 +3735,7 @@ export interface RecipientDsnFields {
 
 export namespace RecipientDsnFields {
   export function isa(o: any): o is RecipientDsnFields {
-    return _smithy.isa(o, "RecipientDsnFields");
+    return __isa(o, "RecipientDsnFields");
   }
 }
 
@@ -3764,7 +3759,7 @@ export interface ReorderReceiptRuleSetRequest {
 
 export namespace ReorderReceiptRuleSetRequest {
   export function isa(o: any): o is ReorderReceiptRuleSetRequest {
-    return _smithy.isa(o, "ReorderReceiptRuleSetRequest");
+    return __isa(o, "ReorderReceiptRuleSetRequest");
   }
 }
 
@@ -3777,7 +3772,7 @@ export interface ReorderReceiptRuleSetResponse extends $MetadataBearer {
 
 export namespace ReorderReceiptRuleSetResponse {
   export function isa(o: any): o is ReorderReceiptRuleSetResponse {
-    return _smithy.isa(o, "ReorderReceiptRuleSetResponse");
+    return __isa(o, "ReorderReceiptRuleSetResponse");
   }
 }
 
@@ -3818,7 +3813,7 @@ export interface ReputationOptions {
 
 export namespace ReputationOptions {
   export function isa(o: any): o is ReputationOptions {
-    return _smithy.isa(o, "ReputationOptions");
+    return __isa(o, "ReputationOptions");
   }
 }
 
@@ -3826,7 +3821,7 @@ export namespace ReputationOptions {
  * <p>Indicates that the provided receipt rule does not exist.</p>
  */
 export interface RuleDoesNotExistException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "RuleDoesNotExistException";
   $fault: "client";
@@ -3840,7 +3835,7 @@ export interface RuleDoesNotExistException
 
 export namespace RuleDoesNotExistException {
   export function isa(o: any): o is RuleDoesNotExistException {
-    return _smithy.isa(o, "RuleDoesNotExistException");
+    return __isa(o, "RuleDoesNotExistException");
   }
 }
 
@@ -3848,7 +3843,7 @@ export namespace RuleDoesNotExistException {
  * <p>Indicates that the provided receipt rule set does not exist.</p>
  */
 export interface RuleSetDoesNotExistException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "RuleSetDoesNotExistException";
   $fault: "client";
@@ -3862,7 +3857,7 @@ export interface RuleSetDoesNotExistException
 
 export namespace RuleSetDoesNotExistException {
   export function isa(o: any): o is RuleSetDoesNotExistException {
-    return _smithy.isa(o, "RuleSetDoesNotExistException");
+    return __isa(o, "RuleSetDoesNotExistException");
   }
 }
 
@@ -3939,7 +3934,7 @@ export interface S3Action {
 
 export namespace S3Action {
   export function isa(o: any): o is S3Action {
-    return _smithy.isa(o, "S3Action");
+    return __isa(o, "S3Action");
   }
 }
 
@@ -3982,7 +3977,7 @@ export interface SNSAction {
 
 export namespace SNSAction {
   export function isa(o: any): o is SNSAction {
-    return _smithy.isa(o, "SNSAction");
+    return __isa(o, "SNSAction");
   }
 }
 
@@ -4010,7 +4005,7 @@ export interface SNSDestination {
 
 export namespace SNSDestination {
   export function isa(o: any): o is SNSDestination {
-    return _smithy.isa(o, "SNSDestination");
+    return __isa(o, "SNSDestination");
   }
 }
 
@@ -4061,7 +4056,7 @@ export interface SendBounceRequest {
 
 export namespace SendBounceRequest {
   export function isa(o: any): o is SendBounceRequest {
-    return _smithy.isa(o, "SendBounceRequest");
+    return __isa(o, "SendBounceRequest");
   }
 }
 
@@ -4078,7 +4073,7 @@ export interface SendBounceResponse extends $MetadataBearer {
 
 export namespace SendBounceResponse {
   export function isa(o: any): o is SendBounceResponse {
-    return _smithy.isa(o, "SendBounceResponse");
+    return __isa(o, "SendBounceResponse");
   }
 }
 
@@ -4201,7 +4196,7 @@ export interface SendBulkTemplatedEmailRequest {
 
 export namespace SendBulkTemplatedEmailRequest {
   export function isa(o: any): o is SendBulkTemplatedEmailRequest {
-    return _smithy.isa(o, "SendBulkTemplatedEmailRequest");
+    return __isa(o, "SendBulkTemplatedEmailRequest");
   }
 }
 
@@ -4216,7 +4211,7 @@ export interface SendBulkTemplatedEmailResponse extends $MetadataBearer {
 
 export namespace SendBulkTemplatedEmailResponse {
   export function isa(o: any): o is SendBulkTemplatedEmailResponse {
-    return _smithy.isa(o, "SendBulkTemplatedEmailResponse");
+    return __isa(o, "SendBulkTemplatedEmailResponse");
   }
 }
 
@@ -4245,7 +4240,7 @@ export interface SendCustomVerificationEmailRequest {
 
 export namespace SendCustomVerificationEmailRequest {
   export function isa(o: any): o is SendCustomVerificationEmailRequest {
-    return _smithy.isa(o, "SendCustomVerificationEmailRequest");
+    return __isa(o, "SendCustomVerificationEmailRequest");
   }
 }
 
@@ -4263,7 +4258,7 @@ export interface SendCustomVerificationEmailResponse extends $MetadataBearer {
 
 export namespace SendCustomVerificationEmailResponse {
   export function isa(o: any): o is SendCustomVerificationEmailResponse {
-    return _smithy.isa(o, "SendCustomVerificationEmailResponse");
+    return __isa(o, "SendCustomVerificationEmailResponse");
   }
 }
 
@@ -4301,7 +4296,7 @@ export interface SendDataPoint {
 
 export namespace SendDataPoint {
   export function isa(o: any): o is SendDataPoint {
-    return _smithy.isa(o, "SendDataPoint");
+    return __isa(o, "SendDataPoint");
   }
 }
 
@@ -4408,7 +4403,7 @@ export interface SendEmailRequest {
 
 export namespace SendEmailRequest {
   export function isa(o: any): o is SendEmailRequest {
-    return _smithy.isa(o, "SendEmailRequest");
+    return __isa(o, "SendEmailRequest");
   }
 }
 
@@ -4425,7 +4420,7 @@ export interface SendEmailResponse extends $MetadataBearer {
 
 export namespace SendEmailResponse {
   export function isa(o: any): o is SendEmailResponse {
-    return _smithy.isa(o, "SendEmailResponse");
+    return __isa(o, "SendEmailResponse");
   }
 }
 
@@ -4574,7 +4569,7 @@ export interface SendRawEmailRequest {
 
 export namespace SendRawEmailRequest {
   export function isa(o: any): o is SendRawEmailRequest {
-    return _smithy.isa(o, "SendRawEmailRequest");
+    return __isa(o, "SendRawEmailRequest");
   }
 }
 
@@ -4592,7 +4587,7 @@ export interface SendRawEmailResponse extends $MetadataBearer {
 
 export namespace SendRawEmailResponse {
   export function isa(o: any): o is SendRawEmailResponse {
-    return _smithy.isa(o, "SendRawEmailResponse");
+    return __isa(o, "SendRawEmailResponse");
   }
 }
 
@@ -4712,7 +4707,7 @@ export interface SendTemplatedEmailRequest {
 
 export namespace SendTemplatedEmailRequest {
   export function isa(o: any): o is SendTemplatedEmailRequest {
-    return _smithy.isa(o, "SendTemplatedEmailRequest");
+    return __isa(o, "SendTemplatedEmailRequest");
   }
 }
 
@@ -4727,7 +4722,7 @@ export interface SendTemplatedEmailResponse extends $MetadataBearer {
 
 export namespace SendTemplatedEmailResponse {
   export function isa(o: any): o is SendTemplatedEmailResponse {
-    return _smithy.isa(o, "SendTemplatedEmailResponse");
+    return __isa(o, "SendTemplatedEmailResponse");
   }
 }
 
@@ -4746,7 +4741,7 @@ export interface SetActiveReceiptRuleSetRequest {
 
 export namespace SetActiveReceiptRuleSetRequest {
   export function isa(o: any): o is SetActiveReceiptRuleSetRequest {
-    return _smithy.isa(o, "SetActiveReceiptRuleSetRequest");
+    return __isa(o, "SetActiveReceiptRuleSetRequest");
   }
 }
 
@@ -4759,7 +4754,7 @@ export interface SetActiveReceiptRuleSetResponse extends $MetadataBearer {
 
 export namespace SetActiveReceiptRuleSetResponse {
   export function isa(o: any): o is SetActiveReceiptRuleSetResponse {
-    return _smithy.isa(o, "SetActiveReceiptRuleSetResponse");
+    return __isa(o, "SetActiveReceiptRuleSetResponse");
   }
 }
 
@@ -4783,7 +4778,7 @@ export interface SetIdentityDkimEnabledRequest {
 
 export namespace SetIdentityDkimEnabledRequest {
   export function isa(o: any): o is SetIdentityDkimEnabledRequest {
-    return _smithy.isa(o, "SetIdentityDkimEnabledRequest");
+    return __isa(o, "SetIdentityDkimEnabledRequest");
   }
 }
 
@@ -4796,7 +4791,7 @@ export interface SetIdentityDkimEnabledResponse extends $MetadataBearer {
 
 export namespace SetIdentityDkimEnabledResponse {
   export function isa(o: any): o is SetIdentityDkimEnabledResponse {
-    return _smithy.isa(o, "SetIdentityDkimEnabledResponse");
+    return __isa(o, "SetIdentityDkimEnabledResponse");
   }
 }
 
@@ -4830,7 +4825,7 @@ export namespace SetIdentityFeedbackForwardingEnabledRequest {
   export function isa(
     o: any
   ): o is SetIdentityFeedbackForwardingEnabledRequest {
-    return _smithy.isa(o, "SetIdentityFeedbackForwardingEnabledRequest");
+    return __isa(o, "SetIdentityFeedbackForwardingEnabledRequest");
   }
 }
 
@@ -4846,7 +4841,7 @@ export namespace SetIdentityFeedbackForwardingEnabledResponse {
   export function isa(
     o: any
   ): o is SetIdentityFeedbackForwardingEnabledResponse {
-    return _smithy.isa(o, "SetIdentityFeedbackForwardingEnabledResponse");
+    return __isa(o, "SetIdentityFeedbackForwardingEnabledResponse");
   }
 }
 
@@ -4884,7 +4879,7 @@ export namespace SetIdentityHeadersInNotificationsEnabledRequest {
   export function isa(
     o: any
   ): o is SetIdentityHeadersInNotificationsEnabledRequest {
-    return _smithy.isa(o, "SetIdentityHeadersInNotificationsEnabledRequest");
+    return __isa(o, "SetIdentityHeadersInNotificationsEnabledRequest");
   }
 }
 
@@ -4900,7 +4895,7 @@ export namespace SetIdentityHeadersInNotificationsEnabledResponse {
   export function isa(
     o: any
   ): o is SetIdentityHeadersInNotificationsEnabledResponse {
-    return _smithy.isa(o, "SetIdentityHeadersInNotificationsEnabledResponse");
+    return __isa(o, "SetIdentityHeadersInNotificationsEnabledResponse");
   }
 }
 
@@ -4943,7 +4938,7 @@ export interface SetIdentityMailFromDomainRequest {
 
 export namespace SetIdentityMailFromDomainRequest {
   export function isa(o: any): o is SetIdentityMailFromDomainRequest {
-    return _smithy.isa(o, "SetIdentityMailFromDomainRequest");
+    return __isa(o, "SetIdentityMailFromDomainRequest");
   }
 }
 
@@ -4956,7 +4951,7 @@ export interface SetIdentityMailFromDomainResponse extends $MetadataBearer {
 
 export namespace SetIdentityMailFromDomainResponse {
   export function isa(o: any): o is SetIdentityMailFromDomainResponse {
-    return _smithy.isa(o, "SetIdentityMailFromDomainResponse");
+    return __isa(o, "SetIdentityMailFromDomainResponse");
   }
 }
 
@@ -4996,7 +4991,7 @@ export interface SetIdentityNotificationTopicRequest {
 
 export namespace SetIdentityNotificationTopicRequest {
   export function isa(o: any): o is SetIdentityNotificationTopicRequest {
-    return _smithy.isa(o, "SetIdentityNotificationTopicRequest");
+    return __isa(o, "SetIdentityNotificationTopicRequest");
   }
 }
 
@@ -5009,7 +5004,7 @@ export interface SetIdentityNotificationTopicResponse extends $MetadataBearer {
 
 export namespace SetIdentityNotificationTopicResponse {
   export function isa(o: any): o is SetIdentityNotificationTopicResponse {
-    return _smithy.isa(o, "SetIdentityNotificationTopicResponse");
+    return __isa(o, "SetIdentityNotificationTopicResponse");
   }
 }
 
@@ -5037,7 +5032,7 @@ export interface SetReceiptRulePositionRequest {
 
 export namespace SetReceiptRulePositionRequest {
   export function isa(o: any): o is SetReceiptRulePositionRequest {
-    return _smithy.isa(o, "SetReceiptRulePositionRequest");
+    return __isa(o, "SetReceiptRulePositionRequest");
   }
 }
 
@@ -5050,7 +5045,7 @@ export interface SetReceiptRulePositionResponse extends $MetadataBearer {
 
 export namespace SetReceiptRulePositionResponse {
   export function isa(o: any): o is SetReceiptRulePositionResponse {
-    return _smithy.isa(o, "SetReceiptRulePositionResponse");
+    return __isa(o, "SetReceiptRulePositionResponse");
   }
 }
 
@@ -5078,7 +5073,7 @@ export interface StopAction {
 
 export namespace StopAction {
   export function isa(o: any): o is StopAction {
-    return _smithy.isa(o, "StopAction");
+    return __isa(o, "StopAction");
   }
 }
 
@@ -5118,7 +5113,7 @@ export interface Template {
 
 export namespace Template {
   export function isa(o: any): o is Template {
-    return _smithy.isa(o, "Template");
+    return __isa(o, "Template");
   }
 }
 
@@ -5127,7 +5122,7 @@ export namespace Template {
  *             account.</p>
  */
 export interface TemplateDoesNotExistException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TemplateDoesNotExistException";
   $fault: "client";
@@ -5137,7 +5132,7 @@ export interface TemplateDoesNotExistException
 
 export namespace TemplateDoesNotExistException {
   export function isa(o: any): o is TemplateDoesNotExistException {
-    return _smithy.isa(o, "TemplateDoesNotExistException");
+    return __isa(o, "TemplateDoesNotExistException");
   }
 }
 
@@ -5159,7 +5154,7 @@ export interface TemplateMetadata {
 
 export namespace TemplateMetadata {
   export function isa(o: any): o is TemplateMetadata {
-    return _smithy.isa(o, "TemplateMetadata");
+    return __isa(o, "TemplateMetadata");
   }
 }
 
@@ -5180,7 +5175,7 @@ export interface TestRenderTemplateRequest {
 
 export namespace TestRenderTemplateRequest {
   export function isa(o: any): o is TestRenderTemplateRequest {
-    return _smithy.isa(o, "TestRenderTemplateRequest");
+    return __isa(o, "TestRenderTemplateRequest");
   }
 }
 
@@ -5195,7 +5190,7 @@ export interface TestRenderTemplateResponse extends $MetadataBearer {
 
 export namespace TestRenderTemplateResponse {
   export function isa(o: any): o is TestRenderTemplateResponse {
-    return _smithy.isa(o, "TestRenderTemplateResponse");
+    return __isa(o, "TestRenderTemplateResponse");
   }
 }
 
@@ -5222,7 +5217,7 @@ export interface TrackingOptions {
 
 export namespace TrackingOptions {
   export function isa(o: any): o is TrackingOptions {
-    return _smithy.isa(o, "TrackingOptions");
+    return __isa(o, "TrackingOptions");
   }
 }
 
@@ -5231,7 +5226,7 @@ export namespace TrackingOptions {
  *             object.</p>
  */
 export interface TrackingOptionsAlreadyExistsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TrackingOptionsAlreadyExistsException";
   $fault: "client";
@@ -5246,7 +5241,7 @@ export interface TrackingOptionsAlreadyExistsException
 
 export namespace TrackingOptionsAlreadyExistsException {
   export function isa(o: any): o is TrackingOptionsAlreadyExistsException {
-    return _smithy.isa(o, "TrackingOptionsAlreadyExistsException");
+    return __isa(o, "TrackingOptionsAlreadyExistsException");
   }
 }
 
@@ -5254,7 +5249,7 @@ export namespace TrackingOptionsAlreadyExistsException {
  * <p>Indicates that the TrackingOptions object you specified does not exist.</p>
  */
 export interface TrackingOptionsDoesNotExistException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TrackingOptionsDoesNotExistException";
   $fault: "client";
@@ -5269,7 +5264,7 @@ export interface TrackingOptionsDoesNotExistException
 
 export namespace TrackingOptionsDoesNotExistException {
   export function isa(o: any): o is TrackingOptionsDoesNotExistException {
-    return _smithy.isa(o, "TrackingOptionsDoesNotExistException");
+    return __isa(o, "TrackingOptionsDoesNotExistException");
   }
 }
 
@@ -5288,7 +5283,7 @@ export interface UpdateAccountSendingEnabledRequest {
 
 export namespace UpdateAccountSendingEnabledRequest {
   export function isa(o: any): o is UpdateAccountSendingEnabledRequest {
-    return _smithy.isa(o, "UpdateAccountSendingEnabledRequest");
+    return __isa(o, "UpdateAccountSendingEnabledRequest");
   }
 }
 
@@ -5317,7 +5312,7 @@ export namespace UpdateConfigurationSetEventDestinationRequest {
   export function isa(
     o: any
   ): o is UpdateConfigurationSetEventDestinationRequest {
-    return _smithy.isa(o, "UpdateConfigurationSetEventDestinationRequest");
+    return __isa(o, "UpdateConfigurationSetEventDestinationRequest");
   }
 }
 
@@ -5333,7 +5328,7 @@ export namespace UpdateConfigurationSetEventDestinationResponse {
   export function isa(
     o: any
   ): o is UpdateConfigurationSetEventDestinationResponse {
-    return _smithy.isa(o, "UpdateConfigurationSetEventDestinationResponse");
+    return __isa(o, "UpdateConfigurationSetEventDestinationResponse");
   }
 }
 
@@ -5359,10 +5354,7 @@ export namespace UpdateConfigurationSetReputationMetricsEnabledRequest {
   export function isa(
     o: any
   ): o is UpdateConfigurationSetReputationMetricsEnabledRequest {
-    return _smithy.isa(
-      o,
-      "UpdateConfigurationSetReputationMetricsEnabledRequest"
-    );
+    return __isa(o, "UpdateConfigurationSetReputationMetricsEnabledRequest");
   }
 }
 
@@ -5388,7 +5380,7 @@ export namespace UpdateConfigurationSetSendingEnabledRequest {
   export function isa(
     o: any
   ): o is UpdateConfigurationSetSendingEnabledRequest {
-    return _smithy.isa(o, "UpdateConfigurationSetSendingEnabledRequest");
+    return __isa(o, "UpdateConfigurationSetSendingEnabledRequest");
   }
 }
 
@@ -5417,7 +5409,7 @@ export namespace UpdateConfigurationSetTrackingOptionsRequest {
   export function isa(
     o: any
   ): o is UpdateConfigurationSetTrackingOptionsRequest {
-    return _smithy.isa(o, "UpdateConfigurationSetTrackingOptionsRequest");
+    return __isa(o, "UpdateConfigurationSetTrackingOptionsRequest");
   }
 }
 
@@ -5433,7 +5425,7 @@ export namespace UpdateConfigurationSetTrackingOptionsResponse {
   export function isa(
     o: any
   ): o is UpdateConfigurationSetTrackingOptionsResponse {
-    return _smithy.isa(o, "UpdateConfigurationSetTrackingOptionsResponse");
+    return __isa(o, "UpdateConfigurationSetTrackingOptionsResponse");
   }
 }
 
@@ -5482,7 +5474,7 @@ export namespace UpdateCustomVerificationEmailTemplateRequest {
   export function isa(
     o: any
   ): o is UpdateCustomVerificationEmailTemplateRequest {
-    return _smithy.isa(o, "UpdateCustomVerificationEmailTemplateRequest");
+    return __isa(o, "UpdateCustomVerificationEmailTemplateRequest");
   }
 }
 
@@ -5506,7 +5498,7 @@ export interface UpdateReceiptRuleRequest {
 
 export namespace UpdateReceiptRuleRequest {
   export function isa(o: any): o is UpdateReceiptRuleRequest {
-    return _smithy.isa(o, "UpdateReceiptRuleRequest");
+    return __isa(o, "UpdateReceiptRuleRequest");
   }
 }
 
@@ -5519,7 +5511,7 @@ export interface UpdateReceiptRuleResponse extends $MetadataBearer {
 
 export namespace UpdateReceiptRuleResponse {
   export function isa(o: any): o is UpdateReceiptRuleResponse {
-    return _smithy.isa(o, "UpdateReceiptRuleResponse");
+    return __isa(o, "UpdateReceiptRuleResponse");
   }
 }
 
@@ -5534,7 +5526,7 @@ export interface UpdateTemplateRequest {
 
 export namespace UpdateTemplateRequest {
   export function isa(o: any): o is UpdateTemplateRequest {
-    return _smithy.isa(o, "UpdateTemplateRequest");
+    return __isa(o, "UpdateTemplateRequest");
   }
 }
 
@@ -5544,7 +5536,7 @@ export interface UpdateTemplateResponse extends $MetadataBearer {
 
 export namespace UpdateTemplateResponse {
   export function isa(o: any): o is UpdateTemplateResponse {
-    return _smithy.isa(o, "UpdateTemplateResponse");
+    return __isa(o, "UpdateTemplateResponse");
   }
 }
 
@@ -5570,7 +5562,7 @@ export interface VerifyDomainDkimRequest {
 
 export namespace VerifyDomainDkimRequest {
   export function isa(o: any): o is VerifyDomainDkimRequest {
-    return _smithy.isa(o, "VerifyDomainDkimRequest");
+    return __isa(o, "VerifyDomainDkimRequest");
   }
 }
 
@@ -5596,7 +5588,7 @@ export interface VerifyDomainDkimResponse extends $MetadataBearer {
 
 export namespace VerifyDomainDkimResponse {
   export function isa(o: any): o is VerifyDomainDkimResponse {
-    return _smithy.isa(o, "VerifyDomainDkimResponse");
+    return __isa(o, "VerifyDomainDkimResponse");
   }
 }
 
@@ -5616,7 +5608,7 @@ export interface VerifyDomainIdentityRequest {
 
 export namespace VerifyDomainIdentityRequest {
   export function isa(o: any): o is VerifyDomainIdentityRequest {
-    return _smithy.isa(o, "VerifyDomainIdentityRequest");
+    return __isa(o, "VerifyDomainIdentityRequest");
   }
 }
 
@@ -5640,7 +5632,7 @@ export interface VerifyDomainIdentityResponse extends $MetadataBearer {
 
 export namespace VerifyDomainIdentityResponse {
   export function isa(o: any): o is VerifyDomainIdentityResponse {
-    return _smithy.isa(o, "VerifyDomainIdentityResponse");
+    return __isa(o, "VerifyDomainIdentityResponse");
   }
 }
 
@@ -5659,7 +5651,7 @@ export interface VerifyEmailAddressRequest {
 
 export namespace VerifyEmailAddressRequest {
   export function isa(o: any): o is VerifyEmailAddressRequest {
-    return _smithy.isa(o, "VerifyEmailAddressRequest");
+    return __isa(o, "VerifyEmailAddressRequest");
   }
 }
 
@@ -5678,7 +5670,7 @@ export interface VerifyEmailIdentityRequest {
 
 export namespace VerifyEmailIdentityRequest {
   export function isa(o: any): o is VerifyEmailIdentityRequest {
-    return _smithy.isa(o, "VerifyEmailIdentityRequest");
+    return __isa(o, "VerifyEmailIdentityRequest");
   }
 }
 
@@ -5691,7 +5683,7 @@ export interface VerifyEmailIdentityResponse extends $MetadataBearer {
 
 export namespace VerifyEmailIdentityResponse {
   export function isa(o: any): o is VerifyEmailIdentityResponse {
-    return _smithy.isa(o, "VerifyEmailIdentityResponse");
+    return __isa(o, "VerifyEmailIdentityResponse");
   }
 }
 
@@ -5725,6 +5717,6 @@ export interface WorkmailAction {
 
 export namespace WorkmailAction {
   export function isa(o: any): o is WorkmailAction {
-    return _smithy.isa(o, "WorkmailAction");
+    return __isa(o, "WorkmailAction");
   }
 }

--- a/clients/client-ses/protocols/Aws_query.ts
+++ b/clients/client-ses/protocols/Aws_query.ts
@@ -2068,6 +2068,7 @@ export async function deserializeAws_queryCreateCustomVerificationEmailTemplateC
       context
     );
   }
+  await collectBody(output.body, context);
   const response: CreateCustomVerificationEmailTemplateCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2644,6 +2645,7 @@ export async function deserializeAws_queryDeleteCustomVerificationEmailTemplateC
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteCustomVerificationEmailTemplateCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -3016,6 +3018,7 @@ export async function deserializeAws_queryDeleteVerifiedEmailAddressCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteVerifiedEmailAddressCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -5438,6 +5441,7 @@ export async function deserializeAws_queryUpdateAccountSendingEnabledCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: UpdateAccountSendingEnabledCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -5573,6 +5577,7 @@ export async function deserializeAws_queryUpdateConfigurationSetReputationMetric
       context
     );
   }
+  await collectBody(output.body, context);
   const response: UpdateConfigurationSetReputationMetricsEnabledCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -5626,6 +5631,7 @@ export async function deserializeAws_queryUpdateConfigurationSetSendingEnabledCo
       context
     );
   }
+  await collectBody(output.body, context);
   const response: UpdateConfigurationSetSendingEnabledCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -5754,6 +5760,7 @@ export async function deserializeAws_queryUpdateCustomVerificationEmailTemplateC
       context
     );
   }
+  await collectBody(output.body, context);
   const response: UpdateCustomVerificationEmailTemplateCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -6081,6 +6088,7 @@ export async function deserializeAws_queryVerifyEmailAddressCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_queryVerifyEmailAddressCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: VerifyEmailAddressCommandOutput = {
     $metadata: deserializeMetadata(output)
   };

--- a/clients/client-sesv2/models/index.ts
+++ b/clients/client-sesv2/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -31,7 +34,7 @@ export interface SuppressionAttributes {
 
 export namespace SuppressionAttributes {
   export function isa(o: any): o is SuppressionAttributes {
-    return _smithy.isa(o, "SuppressionAttributes");
+    return __isa(o, "SuppressionAttributes");
   }
 }
 
@@ -70,7 +73,7 @@ export interface SuppressionOptions {
 
 export namespace SuppressionOptions {
   export function isa(o: any): o is SuppressionOptions {
-    return _smithy.isa(o, "SuppressionOptions");
+    return __isa(o, "SuppressionOptions");
   }
 }
 
@@ -128,7 +131,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -137,7 +140,7 @@ export namespace Tag {
  *             permanently restricted.</p>
  */
 export interface AccountSuspendedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AccountSuspendedException";
   $fault: "client";
@@ -146,7 +149,7 @@ export interface AccountSuspendedException
 
 export namespace AccountSuspendedException {
   export function isa(o: any): o is AccountSuspendedException {
-    return _smithy.isa(o, "AccountSuspendedException");
+    return __isa(o, "AccountSuspendedException");
   }
 }
 
@@ -154,7 +157,7 @@ export namespace AccountSuspendedException {
  * <p>The resource specified in your request already exists.</p>
  */
 export interface AlreadyExistsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AlreadyExistsException";
   $fault: "client";
@@ -163,7 +166,7 @@ export interface AlreadyExistsException
 
 export namespace AlreadyExistsException {
   export function isa(o: any): o is AlreadyExistsException {
-    return _smithy.isa(o, "AlreadyExistsException");
+    return __isa(o, "AlreadyExistsException");
   }
 }
 
@@ -171,7 +174,7 @@ export namespace AlreadyExistsException {
  * <p>The input you provided is invalid.</p>
  */
 export interface BadRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "BadRequestException";
   $fault: "client";
@@ -180,7 +183,7 @@ export interface BadRequestException
 
 export namespace BadRequestException {
   export function isa(o: any): o is BadRequestException {
-    return _smithy.isa(o, "BadRequestException");
+    return __isa(o, "BadRequestException");
   }
 }
 
@@ -214,7 +217,7 @@ export interface BlacklistEntry {
 
 export namespace BlacklistEntry {
   export function isa(o: any): o is BlacklistEntry {
-    return _smithy.isa(o, "BlacklistEntry");
+    return __isa(o, "BlacklistEntry");
   }
 }
 
@@ -240,7 +243,7 @@ export interface Body {
 
 export namespace Body {
   export function isa(o: any): o is Body {
-    return _smithy.isa(o, "Body");
+    return __isa(o, "Body");
   }
 }
 
@@ -259,7 +262,7 @@ export interface CloudWatchDestination {
 
 export namespace CloudWatchDestination {
   export function isa(o: any): o is CloudWatchDestination {
-    return _smithy.isa(o, "CloudWatchDestination");
+    return __isa(o, "CloudWatchDestination");
   }
 }
 
@@ -313,7 +316,7 @@ export interface CloudWatchDimensionConfiguration {
 
 export namespace CloudWatchDimensionConfiguration {
   export function isa(o: any): o is CloudWatchDimensionConfiguration {
-    return _smithy.isa(o, "CloudWatchDimensionConfiguration");
+    return __isa(o, "CloudWatchDimensionConfiguration");
   }
 }
 
@@ -321,7 +324,7 @@ export namespace CloudWatchDimensionConfiguration {
  * <p>The resource is being modified by another operation or thread.</p>
  */
 export interface ConcurrentModificationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ConcurrentModificationException";
   $fault: "server";
@@ -330,7 +333,7 @@ export interface ConcurrentModificationException
 
 export namespace ConcurrentModificationException {
   export function isa(o: any): o is ConcurrentModificationException {
-    return _smithy.isa(o, "ConcurrentModificationException");
+    return __isa(o, "ConcurrentModificationException");
   }
 }
 
@@ -356,7 +359,7 @@ export interface Content {
 
 export namespace Content {
   export function isa(o: any): o is Content {
-    return _smithy.isa(o, "Content");
+    return __isa(o, "Content");
   }
 }
 
@@ -385,7 +388,7 @@ export namespace CreateConfigurationSetEventDestinationRequest {
   export function isa(
     o: any
   ): o is CreateConfigurationSetEventDestinationRequest {
-    return _smithy.isa(o, "CreateConfigurationSetEventDestinationRequest");
+    return __isa(o, "CreateConfigurationSetEventDestinationRequest");
   }
 }
 
@@ -402,7 +405,7 @@ export namespace CreateConfigurationSetEventDestinationResponse {
   export function isa(
     o: any
   ): o is CreateConfigurationSetEventDestinationResponse {
-    return _smithy.isa(o, "CreateConfigurationSetEventDestinationResponse");
+    return __isa(o, "CreateConfigurationSetEventDestinationResponse");
   }
 }
 
@@ -455,7 +458,7 @@ export interface CreateConfigurationSetRequest {
 
 export namespace CreateConfigurationSetRequest {
   export function isa(o: any): o is CreateConfigurationSetRequest {
-    return _smithy.isa(o, "CreateConfigurationSetRequest");
+    return __isa(o, "CreateConfigurationSetRequest");
   }
 }
 
@@ -469,7 +472,7 @@ export interface CreateConfigurationSetResponse extends $MetadataBearer {
 
 export namespace CreateConfigurationSetResponse {
   export function isa(o: any): o is CreateConfigurationSetResponse {
-    return _smithy.isa(o, "CreateConfigurationSetResponse");
+    return __isa(o, "CreateConfigurationSetResponse");
   }
 }
 
@@ -492,7 +495,7 @@ export interface CreateDedicatedIpPoolRequest {
 
 export namespace CreateDedicatedIpPoolRequest {
   export function isa(o: any): o is CreateDedicatedIpPoolRequest {
-    return _smithy.isa(o, "CreateDedicatedIpPoolRequest");
+    return __isa(o, "CreateDedicatedIpPoolRequest");
   }
 }
 
@@ -506,7 +509,7 @@ export interface CreateDedicatedIpPoolResponse extends $MetadataBearer {
 
 export namespace CreateDedicatedIpPoolResponse {
   export function isa(o: any): o is CreateDedicatedIpPoolResponse {
-    return _smithy.isa(o, "CreateDedicatedIpPoolResponse");
+    return __isa(o, "CreateDedicatedIpPoolResponse");
   }
 }
 
@@ -546,7 +549,7 @@ export interface CreateDeliverabilityTestReportRequest {
 
 export namespace CreateDeliverabilityTestReportRequest {
   export function isa(o: any): o is CreateDeliverabilityTestReportRequest {
-    return _smithy.isa(o, "CreateDeliverabilityTestReportRequest");
+    return __isa(o, "CreateDeliverabilityTestReportRequest");
   }
 }
 
@@ -572,7 +575,7 @@ export interface CreateDeliverabilityTestReportResponse
 
 export namespace CreateDeliverabilityTestReportResponse {
   export function isa(o: any): o is CreateDeliverabilityTestReportResponse {
-    return _smithy.isa(o, "CreateDeliverabilityTestReportResponse");
+    return __isa(o, "CreateDeliverabilityTestReportResponse");
   }
 }
 
@@ -606,7 +609,7 @@ export interface CreateEmailIdentityRequest {
 
 export namespace CreateEmailIdentityRequest {
   export function isa(o: any): o is CreateEmailIdentityRequest {
-    return _smithy.isa(o, "CreateEmailIdentityRequest");
+    return __isa(o, "CreateEmailIdentityRequest");
   }
 }
 
@@ -637,7 +640,7 @@ export interface CreateEmailIdentityResponse extends $MetadataBearer {
 
 export namespace CreateEmailIdentityResponse {
   export function isa(o: any): o is CreateEmailIdentityResponse {
-    return _smithy.isa(o, "CreateEmailIdentityResponse");
+    return __isa(o, "CreateEmailIdentityResponse");
   }
 }
 
@@ -667,7 +670,7 @@ export interface DailyVolume {
 
 export namespace DailyVolume {
   export function isa(o: any): o is DailyVolume {
-    return _smithy.isa(o, "DailyVolume");
+    return __isa(o, "DailyVolume");
   }
 }
 
@@ -717,7 +720,7 @@ export interface DedicatedIp {
 
 export namespace DedicatedIp {
   export function isa(o: any): o is DedicatedIp {
-    return _smithy.isa(o, "DedicatedIp");
+    return __isa(o, "DedicatedIp");
   }
 }
 
@@ -742,7 +745,7 @@ export namespace DeleteConfigurationSetEventDestinationRequest {
   export function isa(
     o: any
   ): o is DeleteConfigurationSetEventDestinationRequest {
-    return _smithy.isa(o, "DeleteConfigurationSetEventDestinationRequest");
+    return __isa(o, "DeleteConfigurationSetEventDestinationRequest");
   }
 }
 
@@ -759,7 +762,7 @@ export namespace DeleteConfigurationSetEventDestinationResponse {
   export function isa(
     o: any
   ): o is DeleteConfigurationSetEventDestinationResponse {
-    return _smithy.isa(o, "DeleteConfigurationSetEventDestinationResponse");
+    return __isa(o, "DeleteConfigurationSetEventDestinationResponse");
   }
 }
 
@@ -776,7 +779,7 @@ export interface DeleteConfigurationSetRequest {
 
 export namespace DeleteConfigurationSetRequest {
   export function isa(o: any): o is DeleteConfigurationSetRequest {
-    return _smithy.isa(o, "DeleteConfigurationSetRequest");
+    return __isa(o, "DeleteConfigurationSetRequest");
   }
 }
 
@@ -790,7 +793,7 @@ export interface DeleteConfigurationSetResponse extends $MetadataBearer {
 
 export namespace DeleteConfigurationSetResponse {
   export function isa(o: any): o is DeleteConfigurationSetResponse {
-    return _smithy.isa(o, "DeleteConfigurationSetResponse");
+    return __isa(o, "DeleteConfigurationSetResponse");
   }
 }
 
@@ -807,7 +810,7 @@ export interface DeleteDedicatedIpPoolRequest {
 
 export namespace DeleteDedicatedIpPoolRequest {
   export function isa(o: any): o is DeleteDedicatedIpPoolRequest {
-    return _smithy.isa(o, "DeleteDedicatedIpPoolRequest");
+    return __isa(o, "DeleteDedicatedIpPoolRequest");
   }
 }
 
@@ -821,7 +824,7 @@ export interface DeleteDedicatedIpPoolResponse extends $MetadataBearer {
 
 export namespace DeleteDedicatedIpPoolResponse {
   export function isa(o: any): o is DeleteDedicatedIpPoolResponse {
-    return _smithy.isa(o, "DeleteDedicatedIpPoolResponse");
+    return __isa(o, "DeleteDedicatedIpPoolResponse");
   }
 }
 
@@ -840,7 +843,7 @@ export interface DeleteEmailIdentityRequest {
 
 export namespace DeleteEmailIdentityRequest {
   export function isa(o: any): o is DeleteEmailIdentityRequest {
-    return _smithy.isa(o, "DeleteEmailIdentityRequest");
+    return __isa(o, "DeleteEmailIdentityRequest");
   }
 }
 
@@ -854,7 +857,7 @@ export interface DeleteEmailIdentityResponse extends $MetadataBearer {
 
 export namespace DeleteEmailIdentityResponse {
   export function isa(o: any): o is DeleteEmailIdentityResponse {
-    return _smithy.isa(o, "DeleteEmailIdentityResponse");
+    return __isa(o, "DeleteEmailIdentityResponse");
   }
 }
 
@@ -872,7 +875,7 @@ export interface DeleteSuppressedDestinationRequest {
 
 export namespace DeleteSuppressedDestinationRequest {
   export function isa(o: any): o is DeleteSuppressedDestinationRequest {
-    return _smithy.isa(o, "DeleteSuppressedDestinationRequest");
+    return __isa(o, "DeleteSuppressedDestinationRequest");
   }
 }
 
@@ -886,7 +889,7 @@ export interface DeleteSuppressedDestinationResponse extends $MetadataBearer {
 
 export namespace DeleteSuppressedDestinationResponse {
   export function isa(o: any): o is DeleteSuppressedDestinationResponse {
-    return _smithy.isa(o, "DeleteSuppressedDestinationResponse");
+    return __isa(o, "DeleteSuppressedDestinationResponse");
   }
 }
 
@@ -937,7 +940,7 @@ export interface DeliverabilityTestReport {
 
 export namespace DeliverabilityTestReport {
   export function isa(o: any): o is DeliverabilityTestReport {
-    return _smithy.isa(o, "DeliverabilityTestReport");
+    return __isa(o, "DeliverabilityTestReport");
   }
 }
 
@@ -968,7 +971,7 @@ export interface DeliveryOptions {
 
 export namespace DeliveryOptions {
   export function isa(o: any): o is DeliveryOptions {
-    return _smithy.isa(o, "DeliveryOptions");
+    return __isa(o, "DeliveryOptions");
   }
 }
 
@@ -998,7 +1001,7 @@ export interface Destination {
 
 export namespace Destination {
   export function isa(o: any): o is Destination {
-    return _smithy.isa(o, "Destination");
+    return __isa(o, "Destination");
   }
 }
 
@@ -1097,7 +1100,7 @@ export interface DkimAttributes {
 
 export namespace DkimAttributes {
   export function isa(o: any): o is DkimAttributes {
-    return _smithy.isa(o, "DkimAttributes");
+    return __isa(o, "DkimAttributes");
   }
 }
 
@@ -1123,7 +1126,7 @@ export interface DkimSigningAttributes {
 
 export namespace DkimSigningAttributes {
   export function isa(o: any): o is DkimSigningAttributes {
-    return _smithy.isa(o, "DkimSigningAttributes");
+    return __isa(o, "DkimSigningAttributes");
   }
 }
 
@@ -1234,7 +1237,7 @@ export interface DomainDeliverabilityCampaign {
 
 export namespace DomainDeliverabilityCampaign {
   export function isa(o: any): o is DomainDeliverabilityCampaign {
-    return _smithy.isa(o, "DomainDeliverabilityCampaign");
+    return __isa(o, "DomainDeliverabilityCampaign");
   }
 }
 
@@ -1267,7 +1270,7 @@ export interface DomainDeliverabilityTrackingOption {
 
 export namespace DomainDeliverabilityTrackingOption {
   export function isa(o: any): o is DomainDeliverabilityTrackingOption {
-    return _smithy.isa(o, "DomainDeliverabilityTrackingOption");
+    return __isa(o, "DomainDeliverabilityTrackingOption");
   }
 }
 
@@ -1309,7 +1312,7 @@ export interface DomainIspPlacement {
 
 export namespace DomainIspPlacement {
   export function isa(o: any): o is DomainIspPlacement {
-    return _smithy.isa(o, "DomainIspPlacement");
+    return __isa(o, "DomainIspPlacement");
   }
 }
 
@@ -1369,7 +1372,7 @@ export interface EmailContent {
 
 export namespace EmailContent {
   export function isa(o: any): o is EmailContent {
-    return _smithy.isa(o, "EmailContent");
+    return __isa(o, "EmailContent");
   }
 }
 
@@ -1430,7 +1433,7 @@ export interface EventDestination {
 
 export namespace EventDestination {
   export function isa(o: any): o is EventDestination {
-    return _smithy.isa(o, "EventDestination");
+    return __isa(o, "EventDestination");
   }
 }
 
@@ -1486,7 +1489,7 @@ export interface EventDestinationDefinition {
 
 export namespace EventDestinationDefinition {
   export function isa(o: any): o is EventDestinationDefinition {
-    return _smithy.isa(o, "EventDestinationDefinition");
+    return __isa(o, "EventDestinationDefinition");
   }
 }
 
@@ -1511,7 +1514,7 @@ export interface GetAccountRequest {
 
 export namespace GetAccountRequest {
   export function isa(o: any): o is GetAccountRequest {
-    return _smithy.isa(o, "GetAccountRequest");
+    return __isa(o, "GetAccountRequest");
   }
 }
 
@@ -1588,7 +1591,7 @@ export interface GetAccountResponse extends $MetadataBearer {
 
 export namespace GetAccountResponse {
   export function isa(o: any): o is GetAccountResponse {
-    return _smithy.isa(o, "GetAccountResponse");
+    return __isa(o, "GetAccountResponse");
   }
 }
 
@@ -1608,7 +1611,7 @@ export interface GetBlacklistReportsRequest {
 
 export namespace GetBlacklistReportsRequest {
   export function isa(o: any): o is GetBlacklistReportsRequest {
-    return _smithy.isa(o, "GetBlacklistReportsRequest");
+    return __isa(o, "GetBlacklistReportsRequest");
   }
 }
 
@@ -1626,7 +1629,7 @@ export interface GetBlacklistReportsResponse extends $MetadataBearer {
 
 export namespace GetBlacklistReportsResponse {
   export function isa(o: any): o is GetBlacklistReportsResponse {
-    return _smithy.isa(o, "GetBlacklistReportsResponse");
+    return __isa(o, "GetBlacklistReportsResponse");
   }
 }
 
@@ -1646,7 +1649,7 @@ export namespace GetConfigurationSetEventDestinationsRequest {
   export function isa(
     o: any
   ): o is GetConfigurationSetEventDestinationsRequest {
-    return _smithy.isa(o, "GetConfigurationSetEventDestinationsRequest");
+    return __isa(o, "GetConfigurationSetEventDestinationsRequest");
   }
 }
 
@@ -1667,7 +1670,7 @@ export namespace GetConfigurationSetEventDestinationsResponse {
   export function isa(
     o: any
   ): o is GetConfigurationSetEventDestinationsResponse {
-    return _smithy.isa(o, "GetConfigurationSetEventDestinationsResponse");
+    return __isa(o, "GetConfigurationSetEventDestinationsResponse");
   }
 }
 
@@ -1685,7 +1688,7 @@ export interface GetConfigurationSetRequest {
 
 export namespace GetConfigurationSetRequest {
   export function isa(o: any): o is GetConfigurationSetRequest {
-    return _smithy.isa(o, "GetConfigurationSetRequest");
+    return __isa(o, "GetConfigurationSetRequest");
   }
 }
 
@@ -1738,7 +1741,7 @@ export interface GetConfigurationSetResponse extends $MetadataBearer {
 
 export namespace GetConfigurationSetResponse {
   export function isa(o: any): o is GetConfigurationSetResponse {
-    return _smithy.isa(o, "GetConfigurationSetResponse");
+    return __isa(o, "GetConfigurationSetResponse");
   }
 }
 
@@ -1756,7 +1759,7 @@ export interface GetDedicatedIpRequest {
 
 export namespace GetDedicatedIpRequest {
   export function isa(o: any): o is GetDedicatedIpRequest {
-    return _smithy.isa(o, "GetDedicatedIpRequest");
+    return __isa(o, "GetDedicatedIpRequest");
   }
 }
 
@@ -1773,7 +1776,7 @@ export interface GetDedicatedIpResponse extends $MetadataBearer {
 
 export namespace GetDedicatedIpResponse {
   export function isa(o: any): o is GetDedicatedIpResponse {
-    return _smithy.isa(o, "GetDedicatedIpResponse");
+    return __isa(o, "GetDedicatedIpResponse");
   }
 }
 
@@ -1804,7 +1807,7 @@ export interface GetDedicatedIpsRequest {
 
 export namespace GetDedicatedIpsRequest {
   export function isa(o: any): o is GetDedicatedIpsRequest {
-    return _smithy.isa(o, "GetDedicatedIpsRequest");
+    return __isa(o, "GetDedicatedIpsRequest");
   }
 }
 
@@ -1829,7 +1832,7 @@ export interface GetDedicatedIpsResponse extends $MetadataBearer {
 
 export namespace GetDedicatedIpsResponse {
   export function isa(o: any): o is GetDedicatedIpsResponse {
-    return _smithy.isa(o, "GetDedicatedIpsResponse");
+    return __isa(o, "GetDedicatedIpsResponse");
   }
 }
 
@@ -1848,7 +1851,7 @@ export interface GetDeliverabilityDashboardOptionsRequest {
 
 export namespace GetDeliverabilityDashboardOptionsRequest {
   export function isa(o: any): o is GetDeliverabilityDashboardOptionsRequest {
-    return _smithy.isa(o, "GetDeliverabilityDashboardOptionsRequest");
+    return __isa(o, "GetDeliverabilityDashboardOptionsRequest");
   }
 }
 
@@ -1898,7 +1901,7 @@ export interface GetDeliverabilityDashboardOptionsResponse
 
 export namespace GetDeliverabilityDashboardOptionsResponse {
   export function isa(o: any): o is GetDeliverabilityDashboardOptionsResponse {
-    return _smithy.isa(o, "GetDeliverabilityDashboardOptionsResponse");
+    return __isa(o, "GetDeliverabilityDashboardOptionsResponse");
   }
 }
 
@@ -1915,7 +1918,7 @@ export interface GetDeliverabilityTestReportRequest {
 
 export namespace GetDeliverabilityTestReportRequest {
   export function isa(o: any): o is GetDeliverabilityTestReportRequest {
-    return _smithy.isa(o, "GetDeliverabilityTestReportRequest");
+    return __isa(o, "GetDeliverabilityTestReportRequest");
   }
 }
 
@@ -1957,7 +1960,7 @@ export interface GetDeliverabilityTestReportResponse extends $MetadataBearer {
 
 export namespace GetDeliverabilityTestReportResponse {
   export function isa(o: any): o is GetDeliverabilityTestReportResponse {
-    return _smithy.isa(o, "GetDeliverabilityTestReportResponse");
+    return __isa(o, "GetDeliverabilityTestReportResponse");
   }
 }
 
@@ -1978,7 +1981,7 @@ export interface GetDomainDeliverabilityCampaignRequest {
 
 export namespace GetDomainDeliverabilityCampaignRequest {
   export function isa(o: any): o is GetDomainDeliverabilityCampaignRequest {
-    return _smithy.isa(o, "GetDomainDeliverabilityCampaignRequest");
+    return __isa(o, "GetDomainDeliverabilityCampaignRequest");
   }
 }
 
@@ -1998,7 +2001,7 @@ export interface GetDomainDeliverabilityCampaignResponse
 
 export namespace GetDomainDeliverabilityCampaignResponse {
   export function isa(o: any): o is GetDomainDeliverabilityCampaignResponse {
-    return _smithy.isa(o, "GetDomainDeliverabilityCampaignResponse");
+    return __isa(o, "GetDomainDeliverabilityCampaignResponse");
   }
 }
 
@@ -2028,7 +2031,7 @@ export interface GetDomainStatisticsReportRequest {
 
 export namespace GetDomainStatisticsReportRequest {
   export function isa(o: any): o is GetDomainStatisticsReportRequest {
-    return _smithy.isa(o, "GetDomainStatisticsReportRequest");
+    return __isa(o, "GetDomainStatisticsReportRequest");
   }
 }
 
@@ -2055,7 +2058,7 @@ export interface GetDomainStatisticsReportResponse extends $MetadataBearer {
 
 export namespace GetDomainStatisticsReportResponse {
   export function isa(o: any): o is GetDomainStatisticsReportResponse {
-    return _smithy.isa(o, "GetDomainStatisticsReportResponse");
+    return __isa(o, "GetDomainStatisticsReportResponse");
   }
 }
 
@@ -2072,7 +2075,7 @@ export interface GetEmailIdentityRequest {
 
 export namespace GetEmailIdentityRequest {
   export function isa(o: any): o is GetEmailIdentityRequest {
-    return _smithy.isa(o, "GetEmailIdentityRequest");
+    return __isa(o, "GetEmailIdentityRequest");
   }
 }
 
@@ -2125,7 +2128,7 @@ export interface GetEmailIdentityResponse extends $MetadataBearer {
 
 export namespace GetEmailIdentityResponse {
   export function isa(o: any): o is GetEmailIdentityResponse {
-    return _smithy.isa(o, "GetEmailIdentityResponse");
+    return __isa(o, "GetEmailIdentityResponse");
   }
 }
 
@@ -2143,7 +2146,7 @@ export interface GetSuppressedDestinationRequest {
 
 export namespace GetSuppressedDestinationRequest {
   export function isa(o: any): o is GetSuppressedDestinationRequest {
-    return _smithy.isa(o, "GetSuppressedDestinationRequest");
+    return __isa(o, "GetSuppressedDestinationRequest");
   }
 }
 
@@ -2160,7 +2163,7 @@ export interface GetSuppressedDestinationResponse extends $MetadataBearer {
 
 export namespace GetSuppressedDestinationResponse {
   export function isa(o: any): o is GetSuppressedDestinationResponse {
-    return _smithy.isa(o, "GetSuppressedDestinationResponse");
+    return __isa(o, "GetSuppressedDestinationResponse");
   }
 }
 
@@ -2205,7 +2208,7 @@ export interface IdentityInfo {
 
 export namespace IdentityInfo {
   export function isa(o: any): o is IdentityInfo {
-    return _smithy.isa(o, "IdentityInfo");
+    return __isa(o, "IdentityInfo");
   }
 }
 
@@ -2236,7 +2239,7 @@ export interface InboxPlacementTrackingOption {
 
 export namespace InboxPlacementTrackingOption {
   export function isa(o: any): o is InboxPlacementTrackingOption {
-    return _smithy.isa(o, "InboxPlacementTrackingOption");
+    return __isa(o, "InboxPlacementTrackingOption");
   }
 }
 
@@ -2244,7 +2247,7 @@ export namespace InboxPlacementTrackingOption {
  * <p>The specified request includes an invalid or expired token.</p>
  */
 export interface InvalidNextTokenException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidNextTokenException";
   $fault: "client";
@@ -2253,7 +2256,7 @@ export interface InvalidNextTokenException
 
 export namespace InvalidNextTokenException {
   export function isa(o: any): o is InvalidNextTokenException {
-    return _smithy.isa(o, "InvalidNextTokenException");
+    return __isa(o, "InvalidNextTokenException");
   }
 }
 
@@ -2276,7 +2279,7 @@ export interface IspPlacement {
 
 export namespace IspPlacement {
   export function isa(o: any): o is IspPlacement {
-    return _smithy.isa(o, "IspPlacement");
+    return __isa(o, "IspPlacement");
   }
 }
 
@@ -2301,7 +2304,7 @@ export interface KinesisFirehoseDestination {
 
 export namespace KinesisFirehoseDestination {
   export function isa(o: any): o is KinesisFirehoseDestination {
-    return _smithy.isa(o, "KinesisFirehoseDestination");
+    return __isa(o, "KinesisFirehoseDestination");
   }
 }
 
@@ -2309,7 +2312,7 @@ export namespace KinesisFirehoseDestination {
  * <p>There are too many instances of the specified resource type.</p>
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -2318,7 +2321,7 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
@@ -2345,7 +2348,7 @@ export interface ListConfigurationSetsRequest {
 
 export namespace ListConfigurationSetsRequest {
   export function isa(o: any): o is ListConfigurationSetsRequest {
-    return _smithy.isa(o, "ListConfigurationSetsRequest");
+    return __isa(o, "ListConfigurationSetsRequest");
   }
 }
 
@@ -2371,7 +2374,7 @@ export interface ListConfigurationSetsResponse extends $MetadataBearer {
 
 export namespace ListConfigurationSetsResponse {
   export function isa(o: any): o is ListConfigurationSetsResponse {
-    return _smithy.isa(o, "ListConfigurationSetsResponse");
+    return __isa(o, "ListConfigurationSetsResponse");
   }
 }
 
@@ -2397,7 +2400,7 @@ export interface ListDedicatedIpPoolsRequest {
 
 export namespace ListDedicatedIpPoolsRequest {
   export function isa(o: any): o is ListDedicatedIpPoolsRequest {
-    return _smithy.isa(o, "ListDedicatedIpPoolsRequest");
+    return __isa(o, "ListDedicatedIpPoolsRequest");
   }
 }
 
@@ -2422,7 +2425,7 @@ export interface ListDedicatedIpPoolsResponse extends $MetadataBearer {
 
 export namespace ListDedicatedIpPoolsResponse {
   export function isa(o: any): o is ListDedicatedIpPoolsResponse {
-    return _smithy.isa(o, "ListDedicatedIpPoolsResponse");
+    return __isa(o, "ListDedicatedIpPoolsResponse");
   }
 }
 
@@ -2450,7 +2453,7 @@ export interface ListDeliverabilityTestReportsRequest {
 
 export namespace ListDeliverabilityTestReportsRequest {
   export function isa(o: any): o is ListDeliverabilityTestReportsRequest {
-    return _smithy.isa(o, "ListDeliverabilityTestReportsRequest");
+    return __isa(o, "ListDeliverabilityTestReportsRequest");
   }
 }
 
@@ -2475,7 +2478,7 @@ export interface ListDeliverabilityTestReportsResponse extends $MetadataBearer {
 
 export namespace ListDeliverabilityTestReportsResponse {
   export function isa(o: any): o is ListDeliverabilityTestReportsResponse {
-    return _smithy.isa(o, "ListDeliverabilityTestReportsResponse");
+    return __isa(o, "ListDeliverabilityTestReportsResponse");
   }
 }
 
@@ -2523,7 +2526,7 @@ export interface ListDomainDeliverabilityCampaignsRequest {
 
 export namespace ListDomainDeliverabilityCampaignsRequest {
   export function isa(o: any): o is ListDomainDeliverabilityCampaignsRequest {
-    return _smithy.isa(o, "ListDomainDeliverabilityCampaignsRequest");
+    return __isa(o, "ListDomainDeliverabilityCampaignsRequest");
   }
 }
 
@@ -2553,7 +2556,7 @@ export interface ListDomainDeliverabilityCampaignsResponse
 
 export namespace ListDomainDeliverabilityCampaignsResponse {
   export function isa(o: any): o is ListDomainDeliverabilityCampaignsResponse {
-    return _smithy.isa(o, "ListDomainDeliverabilityCampaignsResponse");
+    return __isa(o, "ListDomainDeliverabilityCampaignsResponse");
   }
 }
 
@@ -2582,7 +2585,7 @@ export interface ListEmailIdentitiesRequest {
 
 export namespace ListEmailIdentitiesRequest {
   export function isa(o: any): o is ListEmailIdentitiesRequest {
-    return _smithy.isa(o, "ListEmailIdentitiesRequest");
+    return __isa(o, "ListEmailIdentitiesRequest");
   }
 }
 
@@ -2609,7 +2612,7 @@ export interface ListEmailIdentitiesResponse extends $MetadataBearer {
 
 export namespace ListEmailIdentitiesResponse {
   export function isa(o: any): o is ListEmailIdentitiesResponse {
-    return _smithy.isa(o, "ListEmailIdentitiesResponse");
+    return __isa(o, "ListEmailIdentitiesResponse");
   }
 }
 
@@ -2656,7 +2659,7 @@ export interface ListSuppressedDestinationsRequest {
 
 export namespace ListSuppressedDestinationsRequest {
   export function isa(o: any): o is ListSuppressedDestinationsRequest {
-    return _smithy.isa(o, "ListSuppressedDestinationsRequest");
+    return __isa(o, "ListSuppressedDestinationsRequest");
   }
 }
 
@@ -2682,7 +2685,7 @@ export interface ListSuppressedDestinationsResponse extends $MetadataBearer {
 
 export namespace ListSuppressedDestinationsResponse {
   export function isa(o: any): o is ListSuppressedDestinationsResponse {
-    return _smithy.isa(o, "ListSuppressedDestinationsResponse");
+    return __isa(o, "ListSuppressedDestinationsResponse");
   }
 }
 
@@ -2697,7 +2700,7 @@ export interface ListTagsForResourceRequest {
 
 export namespace ListTagsForResourceRequest {
   export function isa(o: any): o is ListTagsForResourceRequest {
-    return _smithy.isa(o, "ListTagsForResourceRequest");
+    return __isa(o, "ListTagsForResourceRequest");
   }
 }
 
@@ -2713,7 +2716,7 @@ export interface ListTagsForResourceResponse extends $MetadataBearer {
 
 export namespace ListTagsForResourceResponse {
   export function isa(o: any): o is ListTagsForResourceResponse {
-    return _smithy.isa(o, "ListTagsForResourceResponse");
+    return __isa(o, "ListTagsForResourceResponse");
   }
 }
 
@@ -2770,7 +2773,7 @@ export interface MailFromAttributes {
 
 export namespace MailFromAttributes {
   export function isa(o: any): o is MailFromAttributes {
-    return _smithy.isa(o, "MailFromAttributes");
+    return __isa(o, "MailFromAttributes");
   }
 }
 
@@ -2778,7 +2781,7 @@ export namespace MailFromAttributes {
  * <p>The message can't be sent because the sending domain isn't verified.</p>
  */
 export interface MailFromDomainNotVerifiedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "MailFromDomainNotVerifiedException";
   $fault: "client";
@@ -2787,7 +2790,7 @@ export interface MailFromDomainNotVerifiedException
 
 export namespace MailFromDomainNotVerifiedException {
   export function isa(o: any): o is MailFromDomainNotVerifiedException {
-    return _smithy.isa(o, "MailFromDomainNotVerifiedException");
+    return __isa(o, "MailFromDomainNotVerifiedException");
   }
 }
 
@@ -2820,16 +2823,14 @@ export interface Message {
 
 export namespace Message {
   export function isa(o: any): o is Message {
-    return _smithy.isa(o, "Message");
+    return __isa(o, "Message");
   }
 }
 
 /**
  * <p>The message can't be sent because it contains invalid content.</p>
  */
-export interface MessageRejected
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface MessageRejected extends __SmithyException, $MetadataBearer {
   name: "MessageRejected";
   $fault: "client";
   message?: string;
@@ -2837,7 +2838,7 @@ export interface MessageRejected
 
 export namespace MessageRejected {
   export function isa(o: any): o is MessageRejected {
-    return _smithy.isa(o, "MessageRejected");
+    return __isa(o, "MessageRejected");
   }
 }
 
@@ -2881,16 +2882,14 @@ export interface MessageTag {
 
 export namespace MessageTag {
   export function isa(o: any): o is MessageTag {
-    return _smithy.isa(o, "MessageTag");
+    return __isa(o, "MessageTag");
   }
 }
 
 /**
  * <p>The resource you attempted to access doesn't exist.</p>
  */
-export interface NotFoundException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface NotFoundException extends __SmithyException, $MetadataBearer {
   name: "NotFoundException";
   $fault: "client";
   message?: string;
@@ -2898,7 +2897,7 @@ export interface NotFoundException
 
 export namespace NotFoundException {
   export function isa(o: any): o is NotFoundException {
-    return _smithy.isa(o, "NotFoundException");
+    return __isa(o, "NotFoundException");
   }
 }
 
@@ -2929,7 +2928,7 @@ export interface OverallVolume {
 
 export namespace OverallVolume {
   export function isa(o: any): o is OverallVolume {
-    return _smithy.isa(o, "OverallVolume");
+    return __isa(o, "OverallVolume");
   }
 }
 
@@ -2950,7 +2949,7 @@ export interface PinpointDestination {
 
 export namespace PinpointDestination {
   export function isa(o: any): o is PinpointDestination {
-    return _smithy.isa(o, "PinpointDestination");
+    return __isa(o, "PinpointDestination");
   }
 }
 
@@ -2991,7 +2990,7 @@ export interface PlacementStatistics {
 
 export namespace PlacementStatistics {
   export function isa(o: any): o is PlacementStatistics {
-    return _smithy.isa(o, "PlacementStatistics");
+    return __isa(o, "PlacementStatistics");
   }
 }
 
@@ -3013,7 +3012,7 @@ export namespace PutAccountDedicatedIpWarmupAttributesRequest {
   export function isa(
     o: any
   ): o is PutAccountDedicatedIpWarmupAttributesRequest {
-    return _smithy.isa(o, "PutAccountDedicatedIpWarmupAttributesRequest");
+    return __isa(o, "PutAccountDedicatedIpWarmupAttributesRequest");
   }
 }
 
@@ -3030,7 +3029,7 @@ export namespace PutAccountDedicatedIpWarmupAttributesResponse {
   export function isa(
     o: any
   ): o is PutAccountDedicatedIpWarmupAttributesResponse {
-    return _smithy.isa(o, "PutAccountDedicatedIpWarmupAttributesResponse");
+    return __isa(o, "PutAccountDedicatedIpWarmupAttributesResponse");
   }
 }
 
@@ -3052,7 +3051,7 @@ export interface PutAccountSendingAttributesRequest {
 
 export namespace PutAccountSendingAttributesRequest {
   export function isa(o: any): o is PutAccountSendingAttributesRequest {
-    return _smithy.isa(o, "PutAccountSendingAttributesRequest");
+    return __isa(o, "PutAccountSendingAttributesRequest");
   }
 }
 
@@ -3066,7 +3065,7 @@ export interface PutAccountSendingAttributesResponse extends $MetadataBearer {
 
 export namespace PutAccountSendingAttributesResponse {
   export function isa(o: any): o is PutAccountSendingAttributesResponse {
-    return _smithy.isa(o, "PutAccountSendingAttributesResponse");
+    return __isa(o, "PutAccountSendingAttributesResponse");
   }
 }
 
@@ -3099,7 +3098,7 @@ export interface PutAccountSuppressionAttributesRequest {
 
 export namespace PutAccountSuppressionAttributesRequest {
   export function isa(o: any): o is PutAccountSuppressionAttributesRequest {
-    return _smithy.isa(o, "PutAccountSuppressionAttributesRequest");
+    return __isa(o, "PutAccountSuppressionAttributesRequest");
   }
 }
 
@@ -3114,7 +3113,7 @@ export interface PutAccountSuppressionAttributesResponse
 
 export namespace PutAccountSuppressionAttributesResponse {
   export function isa(o: any): o is PutAccountSuppressionAttributesResponse {
-    return _smithy.isa(o, "PutAccountSuppressionAttributesResponse");
+    return __isa(o, "PutAccountSuppressionAttributesResponse");
   }
 }
 
@@ -3146,7 +3145,7 @@ export interface PutConfigurationSetDeliveryOptionsRequest {
 
 export namespace PutConfigurationSetDeliveryOptionsRequest {
   export function isa(o: any): o is PutConfigurationSetDeliveryOptionsRequest {
-    return _smithy.isa(o, "PutConfigurationSetDeliveryOptionsRequest");
+    return __isa(o, "PutConfigurationSetDeliveryOptionsRequest");
   }
 }
 
@@ -3161,7 +3160,7 @@ export interface PutConfigurationSetDeliveryOptionsResponse
 
 export namespace PutConfigurationSetDeliveryOptionsResponse {
   export function isa(o: any): o is PutConfigurationSetDeliveryOptionsResponse {
-    return _smithy.isa(o, "PutConfigurationSetDeliveryOptionsResponse");
+    return __isa(o, "PutConfigurationSetDeliveryOptionsResponse");
   }
 }
 
@@ -3189,7 +3188,7 @@ export namespace PutConfigurationSetReputationOptionsRequest {
   export function isa(
     o: any
   ): o is PutConfigurationSetReputationOptionsRequest {
-    return _smithy.isa(o, "PutConfigurationSetReputationOptionsRequest");
+    return __isa(o, "PutConfigurationSetReputationOptionsRequest");
   }
 }
 
@@ -3206,7 +3205,7 @@ export namespace PutConfigurationSetReputationOptionsResponse {
   export function isa(
     o: any
   ): o is PutConfigurationSetReputationOptionsResponse {
-    return _smithy.isa(o, "PutConfigurationSetReputationOptionsResponse");
+    return __isa(o, "PutConfigurationSetReputationOptionsResponse");
   }
 }
 
@@ -3231,7 +3230,7 @@ export interface PutConfigurationSetSendingOptionsRequest {
 
 export namespace PutConfigurationSetSendingOptionsRequest {
   export function isa(o: any): o is PutConfigurationSetSendingOptionsRequest {
-    return _smithy.isa(o, "PutConfigurationSetSendingOptionsRequest");
+    return __isa(o, "PutConfigurationSetSendingOptionsRequest");
   }
 }
 
@@ -3246,7 +3245,7 @@ export interface PutConfigurationSetSendingOptionsResponse
 
 export namespace PutConfigurationSetSendingOptionsResponse {
   export function isa(o: any): o is PutConfigurationSetSendingOptionsResponse {
-    return _smithy.isa(o, "PutConfigurationSetSendingOptionsResponse");
+    return __isa(o, "PutConfigurationSetSendingOptionsResponse");
   }
 }
 
@@ -3288,7 +3287,7 @@ export namespace PutConfigurationSetSuppressionOptionsRequest {
   export function isa(
     o: any
   ): o is PutConfigurationSetSuppressionOptionsRequest {
-    return _smithy.isa(o, "PutConfigurationSetSuppressionOptionsRequest");
+    return __isa(o, "PutConfigurationSetSuppressionOptionsRequest");
   }
 }
 
@@ -3305,7 +3304,7 @@ export namespace PutConfigurationSetSuppressionOptionsResponse {
   export function isa(
     o: any
   ): o is PutConfigurationSetSuppressionOptionsResponse {
-    return _smithy.isa(o, "PutConfigurationSetSuppressionOptionsResponse");
+    return __isa(o, "PutConfigurationSetSuppressionOptionsResponse");
   }
 }
 
@@ -3329,7 +3328,7 @@ export interface PutConfigurationSetTrackingOptionsRequest {
 
 export namespace PutConfigurationSetTrackingOptionsRequest {
   export function isa(o: any): o is PutConfigurationSetTrackingOptionsRequest {
-    return _smithy.isa(o, "PutConfigurationSetTrackingOptionsRequest");
+    return __isa(o, "PutConfigurationSetTrackingOptionsRequest");
   }
 }
 
@@ -3344,7 +3343,7 @@ export interface PutConfigurationSetTrackingOptionsResponse
 
 export namespace PutConfigurationSetTrackingOptionsResponse {
   export function isa(o: any): o is PutConfigurationSetTrackingOptionsResponse {
-    return _smithy.isa(o, "PutConfigurationSetTrackingOptionsResponse");
+    return __isa(o, "PutConfigurationSetTrackingOptionsResponse");
   }
 }
 
@@ -3368,7 +3367,7 @@ export interface PutDedicatedIpInPoolRequest {
 
 export namespace PutDedicatedIpInPoolRequest {
   export function isa(o: any): o is PutDedicatedIpInPoolRequest {
-    return _smithy.isa(o, "PutDedicatedIpInPoolRequest");
+    return __isa(o, "PutDedicatedIpInPoolRequest");
   }
 }
 
@@ -3382,7 +3381,7 @@ export interface PutDedicatedIpInPoolResponse extends $MetadataBearer {
 
 export namespace PutDedicatedIpInPoolResponse {
   export function isa(o: any): o is PutDedicatedIpInPoolResponse {
-    return _smithy.isa(o, "PutDedicatedIpInPoolResponse");
+    return __isa(o, "PutDedicatedIpInPoolResponse");
   }
 }
 
@@ -3406,7 +3405,7 @@ export interface PutDedicatedIpWarmupAttributesRequest {
 
 export namespace PutDedicatedIpWarmupAttributesRequest {
   export function isa(o: any): o is PutDedicatedIpWarmupAttributesRequest {
-    return _smithy.isa(o, "PutDedicatedIpWarmupAttributesRequest");
+    return __isa(o, "PutDedicatedIpWarmupAttributesRequest");
   }
 }
 
@@ -3421,7 +3420,7 @@ export interface PutDedicatedIpWarmupAttributesResponse
 
 export namespace PutDedicatedIpWarmupAttributesResponse {
   export function isa(o: any): o is PutDedicatedIpWarmupAttributesResponse {
-    return _smithy.isa(o, "PutDedicatedIpWarmupAttributesResponse");
+    return __isa(o, "PutDedicatedIpWarmupAttributesResponse");
   }
 }
 
@@ -3450,7 +3449,7 @@ export interface PutDeliverabilityDashboardOptionRequest {
 
 export namespace PutDeliverabilityDashboardOptionRequest {
   export function isa(o: any): o is PutDeliverabilityDashboardOptionRequest {
-    return _smithy.isa(o, "PutDeliverabilityDashboardOptionRequest");
+    return __isa(o, "PutDeliverabilityDashboardOptionRequest");
   }
 }
 
@@ -3464,7 +3463,7 @@ export interface PutDeliverabilityDashboardOptionResponse
 
 export namespace PutDeliverabilityDashboardOptionResponse {
   export function isa(o: any): o is PutDeliverabilityDashboardOptionResponse {
-    return _smithy.isa(o, "PutDeliverabilityDashboardOptionResponse");
+    return __isa(o, "PutDeliverabilityDashboardOptionResponse");
   }
 }
 
@@ -3490,7 +3489,7 @@ export interface PutEmailIdentityDkimAttributesRequest {
 
 export namespace PutEmailIdentityDkimAttributesRequest {
   export function isa(o: any): o is PutEmailIdentityDkimAttributesRequest {
-    return _smithy.isa(o, "PutEmailIdentityDkimAttributesRequest");
+    return __isa(o, "PutEmailIdentityDkimAttributesRequest");
   }
 }
 
@@ -3505,7 +3504,7 @@ export interface PutEmailIdentityDkimAttributesResponse
 
 export namespace PutEmailIdentityDkimAttributesResponse {
   export function isa(o: any): o is PutEmailIdentityDkimAttributesResponse {
-    return _smithy.isa(o, "PutEmailIdentityDkimAttributesResponse");
+    return __isa(o, "PutEmailIdentityDkimAttributesResponse");
   }
 }
 
@@ -3549,7 +3548,7 @@ export namespace PutEmailIdentityDkimSigningAttributesRequest {
   export function isa(
     o: any
   ): o is PutEmailIdentityDkimSigningAttributesRequest {
-    return _smithy.isa(o, "PutEmailIdentityDkimSigningAttributesRequest");
+    return __isa(o, "PutEmailIdentityDkimSigningAttributesRequest");
   }
 }
 
@@ -3621,7 +3620,7 @@ export namespace PutEmailIdentityDkimSigningAttributesResponse {
   export function isa(
     o: any
   ): o is PutEmailIdentityDkimSigningAttributesResponse {
-    return _smithy.isa(o, "PutEmailIdentityDkimSigningAttributesResponse");
+    return __isa(o, "PutEmailIdentityDkimSigningAttributesResponse");
   }
 }
 
@@ -3652,7 +3651,7 @@ export interface PutEmailIdentityFeedbackAttributesRequest {
 
 export namespace PutEmailIdentityFeedbackAttributesRequest {
   export function isa(o: any): o is PutEmailIdentityFeedbackAttributesRequest {
-    return _smithy.isa(o, "PutEmailIdentityFeedbackAttributesRequest");
+    return __isa(o, "PutEmailIdentityFeedbackAttributesRequest");
   }
 }
 
@@ -3667,7 +3666,7 @@ export interface PutEmailIdentityFeedbackAttributesResponse
 
 export namespace PutEmailIdentityFeedbackAttributesResponse {
   export function isa(o: any): o is PutEmailIdentityFeedbackAttributesResponse {
-    return _smithy.isa(o, "PutEmailIdentityFeedbackAttributesResponse");
+    return __isa(o, "PutEmailIdentityFeedbackAttributesResponse");
   }
 }
 
@@ -3716,7 +3715,7 @@ export interface PutEmailIdentityMailFromAttributesRequest {
 
 export namespace PutEmailIdentityMailFromAttributesRequest {
   export function isa(o: any): o is PutEmailIdentityMailFromAttributesRequest {
-    return _smithy.isa(o, "PutEmailIdentityMailFromAttributesRequest");
+    return __isa(o, "PutEmailIdentityMailFromAttributesRequest");
   }
 }
 
@@ -3731,7 +3730,7 @@ export interface PutEmailIdentityMailFromAttributesResponse
 
 export namespace PutEmailIdentityMailFromAttributesResponse {
   export function isa(o: any): o is PutEmailIdentityMailFromAttributesResponse {
-    return _smithy.isa(o, "PutEmailIdentityMailFromAttributesResponse");
+    return __isa(o, "PutEmailIdentityMailFromAttributesResponse");
   }
 }
 
@@ -3755,7 +3754,7 @@ export interface PutSuppressedDestinationRequest {
 
 export namespace PutSuppressedDestinationRequest {
   export function isa(o: any): o is PutSuppressedDestinationRequest {
-    return _smithy.isa(o, "PutSuppressedDestinationRequest");
+    return __isa(o, "PutSuppressedDestinationRequest");
   }
 }
 
@@ -3769,7 +3768,7 @@ export interface PutSuppressedDestinationResponse extends $MetadataBearer {
 
 export namespace PutSuppressedDestinationResponse {
   export function isa(o: any): o is PutSuppressedDestinationResponse {
-    return _smithy.isa(o, "PutSuppressedDestinationResponse");
+    return __isa(o, "PutSuppressedDestinationResponse");
   }
 }
 
@@ -3813,7 +3812,7 @@ export interface RawMessage {
 
 export namespace RawMessage {
   export function isa(o: any): o is RawMessage {
-    return _smithy.isa(o, "RawMessage");
+    return __isa(o, "RawMessage");
   }
 }
 
@@ -3840,7 +3839,7 @@ export interface ReputationOptions {
 
 export namespace ReputationOptions {
   export function isa(o: any): o is ReputationOptions {
-    return _smithy.isa(o, "ReputationOptions");
+    return __isa(o, "ReputationOptions");
   }
 }
 
@@ -3893,7 +3892,7 @@ export interface SendEmailRequest {
 
 export namespace SendEmailRequest {
   export function isa(o: any): o is SendEmailRequest {
-    return _smithy.isa(o, "SendEmailRequest");
+    return __isa(o, "SendEmailRequest");
   }
 }
 
@@ -3917,7 +3916,7 @@ export interface SendEmailResponse extends $MetadataBearer {
 
 export namespace SendEmailResponse {
   export function isa(o: any): o is SendEmailResponse {
-    return _smithy.isa(o, "SendEmailResponse");
+    return __isa(o, "SendEmailResponse");
   }
 }
 
@@ -3950,7 +3949,7 @@ export interface SendQuota {
 
 export namespace SendQuota {
   export function isa(o: any): o is SendQuota {
-    return _smithy.isa(o, "SendQuota");
+    return __isa(o, "SendQuota");
   }
 }
 
@@ -3969,7 +3968,7 @@ export interface SendingOptions {
 
 export namespace SendingOptions {
   export function isa(o: any): o is SendingOptions {
-    return _smithy.isa(o, "SendingOptions");
+    return __isa(o, "SendingOptions");
   }
 }
 
@@ -3978,7 +3977,7 @@ export namespace SendingOptions {
  *             paused.</p>
  */
 export interface SendingPausedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "SendingPausedException";
   $fault: "client";
@@ -3987,7 +3986,7 @@ export interface SendingPausedException
 
 export namespace SendingPausedException {
   export function isa(o: any): o is SendingPausedException {
-    return _smithy.isa(o, "SendingPausedException");
+    return __isa(o, "SendingPausedException");
   }
 }
 
@@ -4007,7 +4006,7 @@ export interface SnsDestination {
 
 export namespace SnsDestination {
   export function isa(o: any): o is SnsDestination {
-    return _smithy.isa(o, "SnsDestination");
+    return __isa(o, "SnsDestination");
   }
 }
 
@@ -4042,7 +4041,7 @@ export interface SuppressedDestination {
 
 export namespace SuppressedDestination {
   export function isa(o: any): o is SuppressedDestination {
-    return _smithy.isa(o, "SuppressedDestination");
+    return __isa(o, "SuppressedDestination");
   }
 }
 
@@ -4067,7 +4066,7 @@ export interface SuppressedDestinationAttributes {
 
 export namespace SuppressedDestinationAttributes {
   export function isa(o: any): o is SuppressedDestinationAttributes {
-    return _smithy.isa(o, "SuppressedDestinationAttributes");
+    return __isa(o, "SuppressedDestinationAttributes");
   }
 }
 
@@ -4095,7 +4094,7 @@ export interface SuppressedDestinationSummary {
 
 export namespace SuppressedDestinationSummary {
   export function isa(o: any): o is SuppressedDestinationSummary {
-    return _smithy.isa(o, "SuppressedDestinationSummary");
+    return __isa(o, "SuppressedDestinationSummary");
   }
 }
 
@@ -4118,7 +4117,7 @@ export interface TagResourceRequest {
 
 export namespace TagResourceRequest {
   export function isa(o: any): o is TagResourceRequest {
-    return _smithy.isa(o, "TagResourceRequest");
+    return __isa(o, "TagResourceRequest");
   }
 }
 
@@ -4128,7 +4127,7 @@ export interface TagResourceResponse extends $MetadataBearer {
 
 export namespace TagResourceResponse {
   export function isa(o: any): o is TagResourceResponse {
-    return _smithy.isa(o, "TagResourceResponse");
+    return __isa(o, "TagResourceResponse");
   }
 }
 
@@ -4155,7 +4154,7 @@ export interface Template {
 
 export namespace Template {
   export function isa(o: any): o is Template {
-    return _smithy.isa(o, "Template");
+    return __isa(o, "Template");
   }
 }
 
@@ -4168,7 +4167,7 @@ export enum TlsPolicy {
  * <p>Too many requests have been made to the operation.</p>
  */
 export interface TooManyRequestsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyRequestsException";
   $fault: "client";
@@ -4177,7 +4176,7 @@ export interface TooManyRequestsException
 
 export namespace TooManyRequestsException {
   export function isa(o: any): o is TooManyRequestsException {
-    return _smithy.isa(o, "TooManyRequestsException");
+    return __isa(o, "TooManyRequestsException");
   }
 }
 
@@ -4200,7 +4199,7 @@ export interface TrackingOptions {
 
 export namespace TrackingOptions {
   export function isa(o: any): o is TrackingOptions {
-    return _smithy.isa(o, "TrackingOptions");
+    return __isa(o, "TrackingOptions");
   }
 }
 
@@ -4226,7 +4225,7 @@ export interface UntagResourceRequest {
 
 export namespace UntagResourceRequest {
   export function isa(o: any): o is UntagResourceRequest {
-    return _smithy.isa(o, "UntagResourceRequest");
+    return __isa(o, "UntagResourceRequest");
   }
 }
 
@@ -4236,7 +4235,7 @@ export interface UntagResourceResponse extends $MetadataBearer {
 
 export namespace UntagResourceResponse {
   export function isa(o: any): o is UntagResourceResponse {
-    return _smithy.isa(o, "UntagResourceResponse");
+    return __isa(o, "UntagResourceResponse");
   }
 }
 
@@ -4267,7 +4266,7 @@ export namespace UpdateConfigurationSetEventDestinationRequest {
   export function isa(
     o: any
   ): o is UpdateConfigurationSetEventDestinationRequest {
-    return _smithy.isa(o, "UpdateConfigurationSetEventDestinationRequest");
+    return __isa(o, "UpdateConfigurationSetEventDestinationRequest");
   }
 }
 
@@ -4284,7 +4283,7 @@ export namespace UpdateConfigurationSetEventDestinationResponse {
   export function isa(
     o: any
   ): o is UpdateConfigurationSetEventDestinationResponse {
-    return _smithy.isa(o, "UpdateConfigurationSetEventDestinationResponse");
+    return __isa(o, "UpdateConfigurationSetEventDestinationResponse");
   }
 }
 
@@ -4320,7 +4319,7 @@ export interface VolumeStatistics {
 
 export namespace VolumeStatistics {
   export function isa(o: any): o is VolumeStatistics {
-    return _smithy.isa(o, "VolumeStatistics");
+    return __isa(o, "VolumeStatistics");
   }
 }
 

--- a/clients/client-sesv2/protocols/Aws_restJson1_1.ts
+++ b/clients/client-sesv2/protocols/Aws_restJson1_1.ts
@@ -255,7 +255,10 @@ import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  extendedEncodeURIComponent as __extendedEncodeURIComponent
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -330,7 +333,7 @@ export async function serializeAws_restJson1_1CreateConfigurationSetEventDestina
   let resolvedPath =
     "/v2/email/configuration-sets/{ConfigurationSetName}/event-destinations";
   if (input.ConfigurationSetName !== undefined) {
-    const labelValue: string = input.ConfigurationSetName.toString();
+    const labelValue: string = input.ConfigurationSetName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ConfigurationSetName."
@@ -338,7 +341,7 @@ export async function serializeAws_restJson1_1CreateConfigurationSetEventDestina
     }
     resolvedPath = resolvedPath.replace(
       "{ConfigurationSetName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -472,7 +475,7 @@ export async function serializeAws_restJson1_1DeleteConfigurationSetCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v2/email/configuration-sets/{ConfigurationSetName}";
   if (input.ConfigurationSetName !== undefined) {
-    const labelValue: string = input.ConfigurationSetName.toString();
+    const labelValue: string = input.ConfigurationSetName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ConfigurationSetName."
@@ -480,7 +483,7 @@ export async function serializeAws_restJson1_1DeleteConfigurationSetCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ConfigurationSetName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -505,7 +508,7 @@ export async function serializeAws_restJson1_1DeleteConfigurationSetEventDestina
   let resolvedPath =
     "/v2/email/configuration-sets/{ConfigurationSetName}/event-destinations/{EventDestinationName}";
   if (input.ConfigurationSetName !== undefined) {
-    const labelValue: string = input.ConfigurationSetName.toString();
+    const labelValue: string = input.ConfigurationSetName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ConfigurationSetName."
@@ -513,7 +516,7 @@ export async function serializeAws_restJson1_1DeleteConfigurationSetEventDestina
     }
     resolvedPath = resolvedPath.replace(
       "{ConfigurationSetName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -521,7 +524,7 @@ export async function serializeAws_restJson1_1DeleteConfigurationSetEventDestina
     );
   }
   if (input.EventDestinationName !== undefined) {
-    const labelValue: string = input.EventDestinationName.toString();
+    const labelValue: string = input.EventDestinationName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: EventDestinationName."
@@ -529,7 +532,7 @@ export async function serializeAws_restJson1_1DeleteConfigurationSetEventDestina
     }
     resolvedPath = resolvedPath.replace(
       "{EventDestinationName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -553,13 +556,13 @@ export async function serializeAws_restJson1_1DeleteDedicatedIpPoolCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v2/email/dedicated-ip-pools/{PoolName}";
   if (input.PoolName !== undefined) {
-    const labelValue: string = input.PoolName.toString();
+    const labelValue: string = input.PoolName;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: PoolName.");
     }
     resolvedPath = resolvedPath.replace(
       "{PoolName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: PoolName.");
@@ -581,7 +584,7 @@ export async function serializeAws_restJson1_1DeleteEmailIdentityCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v2/email/identities/{EmailIdentity}";
   if (input.EmailIdentity !== undefined) {
-    const labelValue: string = input.EmailIdentity.toString();
+    const labelValue: string = input.EmailIdentity;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: EmailIdentity."
@@ -589,7 +592,7 @@ export async function serializeAws_restJson1_1DeleteEmailIdentityCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{EmailIdentity}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: EmailIdentity.");
@@ -611,7 +614,7 @@ export async function serializeAws_restJson1_1DeleteSuppressedDestinationCommand
   headers["Content-Type"] = "";
   let resolvedPath = "/v2/email/suppression/addresses/{EmailAddress}";
   if (input.EmailAddress !== undefined) {
-    const labelValue: string = input.EmailAddress.toString();
+    const labelValue: string = input.EmailAddress;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: EmailAddress."
@@ -619,7 +622,7 @@ export async function serializeAws_restJson1_1DeleteSuppressedDestinationCommand
     }
     resolvedPath = resolvedPath.replace(
       "{EmailAddress}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: EmailAddress.");
@@ -658,7 +661,11 @@ export async function serializeAws_restJson1_1GetBlacklistReportsCommand(
   let resolvedPath = "/v2/email/deliverability-dashboard/blacklist-report";
   const query: any = {};
   if (input.BlacklistItemNames !== undefined) {
-    query["BlacklistItemNames"] = input.BlacklistItemNames;
+    query[
+      __extendedEncodeURIComponent("BlacklistItemNames")
+    ] = input.BlacklistItemNames.map(entry =>
+      __extendedEncodeURIComponent(entry)
+    );
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -678,7 +685,7 @@ export async function serializeAws_restJson1_1GetConfigurationSetCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v2/email/configuration-sets/{ConfigurationSetName}";
   if (input.ConfigurationSetName !== undefined) {
-    const labelValue: string = input.ConfigurationSetName.toString();
+    const labelValue: string = input.ConfigurationSetName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ConfigurationSetName."
@@ -686,7 +693,7 @@ export async function serializeAws_restJson1_1GetConfigurationSetCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{ConfigurationSetName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -711,7 +718,7 @@ export async function serializeAws_restJson1_1GetConfigurationSetEventDestinatio
   let resolvedPath =
     "/v2/email/configuration-sets/{ConfigurationSetName}/event-destinations";
   if (input.ConfigurationSetName !== undefined) {
-    const labelValue: string = input.ConfigurationSetName.toString();
+    const labelValue: string = input.ConfigurationSetName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ConfigurationSetName."
@@ -719,7 +726,7 @@ export async function serializeAws_restJson1_1GetConfigurationSetEventDestinatio
     }
     resolvedPath = resolvedPath.replace(
       "{ConfigurationSetName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -743,11 +750,14 @@ export async function serializeAws_restJson1_1GetDedicatedIpCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v2/email/dedicated-ips/{Ip}";
   if (input.Ip !== undefined) {
-    const labelValue: string = input.Ip.toString();
+    const labelValue: string = input.Ip;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Ip.");
     }
-    resolvedPath = resolvedPath.replace("{Ip}", encodeURIComponent(labelValue));
+    resolvedPath = resolvedPath.replace(
+      "{Ip}",
+      __extendedEncodeURIComponent(labelValue)
+    );
   } else {
     throw new Error("No value provided for input HTTP label: Ip.");
   }
@@ -769,13 +779,19 @@ export async function serializeAws_restJson1_1GetDedicatedIpsCommand(
   let resolvedPath = "/v2/email/dedicated-ips";
   const query: any = {};
   if (input.NextToken !== undefined) {
-    query["NextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("NextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   if (input.PageSize !== undefined) {
-    query["PageSize"] = input.PageSize.toString();
+    query[
+      __extendedEncodeURIComponent("PageSize")
+    ] = __extendedEncodeURIComponent(input.PageSize.toString());
   }
   if (input.PoolName !== undefined) {
-    query["PoolName"] = input.PoolName.toString();
+    query[
+      __extendedEncodeURIComponent("PoolName")
+    ] = __extendedEncodeURIComponent(input.PoolName);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -812,13 +828,13 @@ export async function serializeAws_restJson1_1GetDeliverabilityTestReportCommand
   let resolvedPath =
     "/v2/email/deliverability-dashboard/test-reports/{ReportId}";
   if (input.ReportId !== undefined) {
-    const labelValue: string = input.ReportId.toString();
+    const labelValue: string = input.ReportId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ReportId.");
     }
     resolvedPath = resolvedPath.replace(
       "{ReportId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ReportId.");
@@ -841,13 +857,13 @@ export async function serializeAws_restJson1_1GetDomainDeliverabilityCampaignCom
   let resolvedPath =
     "/v2/email/deliverability-dashboard/campaigns/{CampaignId}";
   if (input.CampaignId !== undefined) {
-    const labelValue: string = input.CampaignId.toString();
+    const labelValue: string = input.CampaignId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: CampaignId.");
     }
     resolvedPath = resolvedPath.replace(
       "{CampaignId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: CampaignId.");
@@ -870,23 +886,27 @@ export async function serializeAws_restJson1_1GetDomainStatisticsReportCommand(
   let resolvedPath =
     "/v2/email/deliverability-dashboard/statistics-report/{Domain}";
   if (input.Domain !== undefined) {
-    const labelValue: string = input.Domain.toString();
+    const labelValue: string = input.Domain;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Domain.");
     }
     resolvedPath = resolvedPath.replace(
       "{Domain}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: Domain.");
   }
   const query: any = {};
   if (input.EndDate !== undefined) {
-    query["EndDate"] = input.EndDate.toISOString();
+    query[
+      __extendedEncodeURIComponent("EndDate")
+    ] = __extendedEncodeURIComponent(input.EndDate.toISOString());
   }
   if (input.StartDate !== undefined) {
-    query["StartDate"] = input.StartDate.toISOString();
+    query[
+      __extendedEncodeURIComponent("StartDate")
+    ] = __extendedEncodeURIComponent(input.StartDate.toISOString());
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -906,7 +926,7 @@ export async function serializeAws_restJson1_1GetEmailIdentityCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v2/email/identities/{EmailIdentity}";
   if (input.EmailIdentity !== undefined) {
-    const labelValue: string = input.EmailIdentity.toString();
+    const labelValue: string = input.EmailIdentity;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: EmailIdentity."
@@ -914,7 +934,7 @@ export async function serializeAws_restJson1_1GetEmailIdentityCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{EmailIdentity}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: EmailIdentity.");
@@ -936,7 +956,7 @@ export async function serializeAws_restJson1_1GetSuppressedDestinationCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/v2/email/suppression/addresses/{EmailAddress}";
   if (input.EmailAddress !== undefined) {
-    const labelValue: string = input.EmailAddress.toString();
+    const labelValue: string = input.EmailAddress;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: EmailAddress."
@@ -944,7 +964,7 @@ export async function serializeAws_restJson1_1GetSuppressedDestinationCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{EmailAddress}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: EmailAddress.");
@@ -967,10 +987,14 @@ export async function serializeAws_restJson1_1ListConfigurationSetsCommand(
   let resolvedPath = "/v2/email/configuration-sets";
   const query: any = {};
   if (input.NextToken !== undefined) {
-    query["NextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("NextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   if (input.PageSize !== undefined) {
-    query["PageSize"] = input.PageSize.toString();
+    query[
+      __extendedEncodeURIComponent("PageSize")
+    ] = __extendedEncodeURIComponent(input.PageSize.toString());
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -991,10 +1015,14 @@ export async function serializeAws_restJson1_1ListDedicatedIpPoolsCommand(
   let resolvedPath = "/v2/email/dedicated-ip-pools";
   const query: any = {};
   if (input.NextToken !== undefined) {
-    query["NextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("NextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   if (input.PageSize !== undefined) {
-    query["PageSize"] = input.PageSize.toString();
+    query[
+      __extendedEncodeURIComponent("PageSize")
+    ] = __extendedEncodeURIComponent(input.PageSize.toString());
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1015,10 +1043,14 @@ export async function serializeAws_restJson1_1ListDeliverabilityTestReportsComma
   let resolvedPath = "/v2/email/deliverability-dashboard/test-reports";
   const query: any = {};
   if (input.NextToken !== undefined) {
-    query["NextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("NextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   if (input.PageSize !== undefined) {
-    query["PageSize"] = input.PageSize.toString();
+    query[
+      __extendedEncodeURIComponent("PageSize")
+    ] = __extendedEncodeURIComponent(input.PageSize.toString());
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1039,7 +1071,7 @@ export async function serializeAws_restJson1_1ListDomainDeliverabilityCampaignsC
   let resolvedPath =
     "/v2/email/deliverability-dashboard/domains/{SubscribedDomain}/campaigns";
   if (input.SubscribedDomain !== undefined) {
-    const labelValue: string = input.SubscribedDomain.toString();
+    const labelValue: string = input.SubscribedDomain;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: SubscribedDomain."
@@ -1047,7 +1079,7 @@ export async function serializeAws_restJson1_1ListDomainDeliverabilityCampaignsC
     }
     resolvedPath = resolvedPath.replace(
       "{SubscribedDomain}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -1056,16 +1088,24 @@ export async function serializeAws_restJson1_1ListDomainDeliverabilityCampaignsC
   }
   const query: any = {};
   if (input.EndDate !== undefined) {
-    query["EndDate"] = input.EndDate.toISOString();
+    query[
+      __extendedEncodeURIComponent("EndDate")
+    ] = __extendedEncodeURIComponent(input.EndDate.toISOString());
   }
   if (input.NextToken !== undefined) {
-    query["NextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("NextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   if (input.PageSize !== undefined) {
-    query["PageSize"] = input.PageSize.toString();
+    query[
+      __extendedEncodeURIComponent("PageSize")
+    ] = __extendedEncodeURIComponent(input.PageSize.toString());
   }
   if (input.StartDate !== undefined) {
-    query["StartDate"] = input.StartDate.toISOString();
+    query[
+      __extendedEncodeURIComponent("StartDate")
+    ] = __extendedEncodeURIComponent(input.StartDate.toISOString());
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1086,10 +1126,14 @@ export async function serializeAws_restJson1_1ListEmailIdentitiesCommand(
   let resolvedPath = "/v2/email/identities";
   const query: any = {};
   if (input.NextToken !== undefined) {
-    query["NextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("NextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   if (input.PageSize !== undefined) {
-    query["PageSize"] = input.PageSize.toString();
+    query[
+      __extendedEncodeURIComponent("PageSize")
+    ] = __extendedEncodeURIComponent(input.PageSize.toString());
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1110,19 +1154,29 @@ export async function serializeAws_restJson1_1ListSuppressedDestinationsCommand(
   let resolvedPath = "/v2/email/suppression/addresses";
   const query: any = {};
   if (input.EndDate !== undefined) {
-    query["EndDate"] = input.EndDate.toISOString();
+    query[
+      __extendedEncodeURIComponent("EndDate")
+    ] = __extendedEncodeURIComponent(input.EndDate.toISOString());
   }
   if (input.NextToken !== undefined) {
-    query["NextToken"] = input.NextToken.toString();
+    query[
+      __extendedEncodeURIComponent("NextToken")
+    ] = __extendedEncodeURIComponent(input.NextToken);
   }
   if (input.PageSize !== undefined) {
-    query["PageSize"] = input.PageSize.toString();
+    query[
+      __extendedEncodeURIComponent("PageSize")
+    ] = __extendedEncodeURIComponent(input.PageSize.toString());
   }
   if (input.Reasons !== undefined) {
-    query["Reason"] = input.Reasons;
+    query[__extendedEncodeURIComponent("Reason")] = input.Reasons.map(entry =>
+      __extendedEncodeURIComponent(entry)
+    );
   }
   if (input.StartDate !== undefined) {
-    query["StartDate"] = input.StartDate.toISOString();
+    query[
+      __extendedEncodeURIComponent("StartDate")
+    ] = __extendedEncodeURIComponent(input.StartDate.toISOString());
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1143,7 +1197,9 @@ export async function serializeAws_restJson1_1ListTagsForResourceCommand(
   let resolvedPath = "/v2/email/tags";
   const query: any = {};
   if (input.ResourceArn !== undefined) {
-    query["ResourceArn"] = input.ResourceArn.toString();
+    query[
+      __extendedEncodeURIComponent("ResourceArn")
+    ] = __extendedEncodeURIComponent(input.ResourceArn);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1238,7 +1294,7 @@ export async function serializeAws_restJson1_1PutConfigurationSetDeliveryOptions
   let resolvedPath =
     "/v2/email/configuration-sets/{ConfigurationSetName}/delivery-options";
   if (input.ConfigurationSetName !== undefined) {
-    const labelValue: string = input.ConfigurationSetName.toString();
+    const labelValue: string = input.ConfigurationSetName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ConfigurationSetName."
@@ -1246,7 +1302,7 @@ export async function serializeAws_restJson1_1PutConfigurationSetDeliveryOptions
     }
     resolvedPath = resolvedPath.replace(
       "{ConfigurationSetName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -1281,7 +1337,7 @@ export async function serializeAws_restJson1_1PutConfigurationSetReputationOptio
   let resolvedPath =
     "/v2/email/configuration-sets/{ConfigurationSetName}/reputation-options";
   if (input.ConfigurationSetName !== undefined) {
-    const labelValue: string = input.ConfigurationSetName.toString();
+    const labelValue: string = input.ConfigurationSetName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ConfigurationSetName."
@@ -1289,7 +1345,7 @@ export async function serializeAws_restJson1_1PutConfigurationSetReputationOptio
     }
     resolvedPath = resolvedPath.replace(
       "{ConfigurationSetName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -1321,7 +1377,7 @@ export async function serializeAws_restJson1_1PutConfigurationSetSendingOptionsC
   let resolvedPath =
     "/v2/email/configuration-sets/{ConfigurationSetName}/sending";
   if (input.ConfigurationSetName !== undefined) {
-    const labelValue: string = input.ConfigurationSetName.toString();
+    const labelValue: string = input.ConfigurationSetName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ConfigurationSetName."
@@ -1329,7 +1385,7 @@ export async function serializeAws_restJson1_1PutConfigurationSetSendingOptionsC
     }
     resolvedPath = resolvedPath.replace(
       "{ConfigurationSetName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -1361,7 +1417,7 @@ export async function serializeAws_restJson1_1PutConfigurationSetSuppressionOpti
   let resolvedPath =
     "/v2/email/configuration-sets/{ConfigurationSetName}/suppression-options";
   if (input.ConfigurationSetName !== undefined) {
-    const labelValue: string = input.ConfigurationSetName.toString();
+    const labelValue: string = input.ConfigurationSetName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ConfigurationSetName."
@@ -1369,7 +1425,7 @@ export async function serializeAws_restJson1_1PutConfigurationSetSuppressionOpti
     }
     resolvedPath = resolvedPath.replace(
       "{ConfigurationSetName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -1406,7 +1462,7 @@ export async function serializeAws_restJson1_1PutConfigurationSetTrackingOptions
   let resolvedPath =
     "/v2/email/configuration-sets/{ConfigurationSetName}/tracking-options";
   if (input.ConfigurationSetName !== undefined) {
-    const labelValue: string = input.ConfigurationSetName.toString();
+    const labelValue: string = input.ConfigurationSetName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ConfigurationSetName."
@@ -1414,7 +1470,7 @@ export async function serializeAws_restJson1_1PutConfigurationSetTrackingOptions
     }
     resolvedPath = resolvedPath.replace(
       "{ConfigurationSetName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -1445,11 +1501,14 @@ export async function serializeAws_restJson1_1PutDedicatedIpInPoolCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v2/email/dedicated-ips/{Ip}/pool";
   if (input.Ip !== undefined) {
-    const labelValue: string = input.Ip.toString();
+    const labelValue: string = input.Ip;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Ip.");
     }
-    resolvedPath = resolvedPath.replace("{Ip}", encodeURIComponent(labelValue));
+    resolvedPath = resolvedPath.replace(
+      "{Ip}",
+      __extendedEncodeURIComponent(labelValue)
+    );
   } else {
     throw new Error("No value provided for input HTTP label: Ip.");
   }
@@ -1477,11 +1536,14 @@ export async function serializeAws_restJson1_1PutDedicatedIpWarmupAttributesComm
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v2/email/dedicated-ips/{Ip}/warmup";
   if (input.Ip !== undefined) {
-    const labelValue: string = input.Ip.toString();
+    const labelValue: string = input.Ip;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: Ip.");
     }
-    resolvedPath = resolvedPath.replace("{Ip}", encodeURIComponent(labelValue));
+    resolvedPath = resolvedPath.replace(
+      "{Ip}",
+      __extendedEncodeURIComponent(labelValue)
+    );
   } else {
     throw new Error("No value provided for input HTTP label: Ip.");
   }
@@ -1540,7 +1602,7 @@ export async function serializeAws_restJson1_1PutEmailIdentityDkimAttributesComm
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v2/email/identities/{EmailIdentity}/dkim";
   if (input.EmailIdentity !== undefined) {
-    const labelValue: string = input.EmailIdentity.toString();
+    const labelValue: string = input.EmailIdentity;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: EmailIdentity."
@@ -1548,7 +1610,7 @@ export async function serializeAws_restJson1_1PutEmailIdentityDkimAttributesComm
     }
     resolvedPath = resolvedPath.replace(
       "{EmailIdentity}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: EmailIdentity.");
@@ -1577,7 +1639,7 @@ export async function serializeAws_restJson1_1PutEmailIdentityDkimSigningAttribu
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v1/email/identities/{EmailIdentity}/dkim/signing";
   if (input.EmailIdentity !== undefined) {
-    const labelValue: string = input.EmailIdentity.toString();
+    const labelValue: string = input.EmailIdentity;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: EmailIdentity."
@@ -1585,7 +1647,7 @@ export async function serializeAws_restJson1_1PutEmailIdentityDkimSigningAttribu
     }
     resolvedPath = resolvedPath.replace(
       "{EmailIdentity}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: EmailIdentity.");
@@ -1622,7 +1684,7 @@ export async function serializeAws_restJson1_1PutEmailIdentityFeedbackAttributes
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v2/email/identities/{EmailIdentity}/feedback";
   if (input.EmailIdentity !== undefined) {
-    const labelValue: string = input.EmailIdentity.toString();
+    const labelValue: string = input.EmailIdentity;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: EmailIdentity."
@@ -1630,7 +1692,7 @@ export async function serializeAws_restJson1_1PutEmailIdentityFeedbackAttributes
     }
     resolvedPath = resolvedPath.replace(
       "{EmailIdentity}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: EmailIdentity.");
@@ -1659,7 +1721,7 @@ export async function serializeAws_restJson1_1PutEmailIdentityMailFromAttributes
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/v2/email/identities/{EmailIdentity}/mail-from";
   if (input.EmailIdentity !== undefined) {
-    const labelValue: string = input.EmailIdentity.toString();
+    const labelValue: string = input.EmailIdentity;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: EmailIdentity."
@@ -1667,7 +1729,7 @@ export async function serializeAws_restJson1_1PutEmailIdentityMailFromAttributes
     }
     resolvedPath = resolvedPath.replace(
       "{EmailIdentity}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: EmailIdentity.");
@@ -1806,10 +1868,14 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
   let resolvedPath = "/v2/email/tags";
   const query: any = {};
   if (input.ResourceArn !== undefined) {
-    query["ResourceArn"] = input.ResourceArn.toString();
+    query[
+      __extendedEncodeURIComponent("ResourceArn")
+    ] = __extendedEncodeURIComponent(input.ResourceArn);
   }
   if (input.TagKeys !== undefined) {
-    query["TagKeys"] = input.TagKeys;
+    query[__extendedEncodeURIComponent("TagKeys")] = input.TagKeys.map(entry =>
+      __extendedEncodeURIComponent(entry)
+    );
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1830,7 +1896,7 @@ export async function serializeAws_restJson1_1UpdateConfigurationSetEventDestina
   let resolvedPath =
     "/v2/email/configuration-sets/{ConfigurationSetName}/event-destinations/{EventDestinationName}";
   if (input.ConfigurationSetName !== undefined) {
-    const labelValue: string = input.ConfigurationSetName.toString();
+    const labelValue: string = input.ConfigurationSetName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: ConfigurationSetName."
@@ -1838,7 +1904,7 @@ export async function serializeAws_restJson1_1UpdateConfigurationSetEventDestina
     }
     resolvedPath = resolvedPath.replace(
       "{ConfigurationSetName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -1846,7 +1912,7 @@ export async function serializeAws_restJson1_1UpdateConfigurationSetEventDestina
     );
   }
   if (input.EventDestinationName !== undefined) {
-    const labelValue: string = input.EventDestinationName.toString();
+    const labelValue: string = input.EventDestinationName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: EventDestinationName."
@@ -1854,7 +1920,7 @@ export async function serializeAws_restJson1_1UpdateConfigurationSetEventDestina
     }
     resolvedPath = resolvedPath.replace(
       "{EventDestinationName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error(
@@ -1896,6 +1962,7 @@ export async function deserializeAws_restJson1_1CreateConfigurationSetCommand(
     $metadata: deserializeMetadata(output),
     __type: "CreateConfigurationSetResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -1982,6 +2049,7 @@ export async function deserializeAws_restJson1_1CreateConfigurationSetEventDesti
     $metadata: deserializeMetadata(output),
     __type: "CreateConfigurationSetEventDestinationResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2061,6 +2129,7 @@ export async function deserializeAws_restJson1_1CreateDedicatedIpPoolCommand(
     $metadata: deserializeMetadata(output),
     __type: "CreateDedicatedIpPoolResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2357,6 +2426,7 @@ export async function deserializeAws_restJson1_1DeleteConfigurationSetCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeleteConfigurationSetResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2429,6 +2499,7 @@ export async function deserializeAws_restJson1_1DeleteConfigurationSetEventDesti
     $metadata: deserializeMetadata(output),
     __type: "DeleteConfigurationSetEventDestinationResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2494,6 +2565,7 @@ export async function deserializeAws_restJson1_1DeleteDedicatedIpPoolCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeleteDedicatedIpPoolResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2566,6 +2638,7 @@ export async function deserializeAws_restJson1_1DeleteEmailIdentityCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeleteEmailIdentityResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2638,6 +2711,7 @@ export async function deserializeAws_restJson1_1DeleteSuppressedDestinationComma
     $metadata: deserializeMetadata(output),
     __type: "DeleteSuppressedDestinationResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -4267,6 +4341,7 @@ export async function deserializeAws_restJson1_1PutAccountDedicatedIpWarmupAttri
     $metadata: deserializeMetadata(output),
     __type: "PutAccountDedicatedIpWarmupAttributesResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -4325,6 +4400,7 @@ export async function deserializeAws_restJson1_1PutAccountSendingAttributesComma
     $metadata: deserializeMetadata(output),
     __type: "PutAccountSendingAttributesResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -4383,6 +4459,7 @@ export async function deserializeAws_restJson1_1PutAccountSuppressionAttributesC
     $metadata: deserializeMetadata(output),
     __type: "PutAccountSuppressionAttributesResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -4441,6 +4518,7 @@ export async function deserializeAws_restJson1_1PutConfigurationSetDeliveryOptio
     $metadata: deserializeMetadata(output),
     __type: "PutConfigurationSetDeliveryOptionsResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -4506,6 +4584,7 @@ export async function deserializeAws_restJson1_1PutConfigurationSetReputationOpt
     $metadata: deserializeMetadata(output),
     __type: "PutConfigurationSetReputationOptionsResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -4571,6 +4650,7 @@ export async function deserializeAws_restJson1_1PutConfigurationSetSendingOption
     $metadata: deserializeMetadata(output),
     __type: "PutConfigurationSetSendingOptionsResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -4636,6 +4716,7 @@ export async function deserializeAws_restJson1_1PutConfigurationSetSuppressionOp
     $metadata: deserializeMetadata(output),
     __type: "PutConfigurationSetSuppressionOptionsResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -4701,6 +4782,7 @@ export async function deserializeAws_restJson1_1PutConfigurationSetTrackingOptio
     $metadata: deserializeMetadata(output),
     __type: "PutConfigurationSetTrackingOptionsResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -4766,6 +4848,7 @@ export async function deserializeAws_restJson1_1PutDedicatedIpInPoolCommand(
     $metadata: deserializeMetadata(output),
     __type: "PutDedicatedIpInPoolResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -4831,6 +4914,7 @@ export async function deserializeAws_restJson1_1PutDedicatedIpWarmupAttributesCo
     $metadata: deserializeMetadata(output),
     __type: "PutDedicatedIpWarmupAttributesResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -4896,6 +4980,7 @@ export async function deserializeAws_restJson1_1PutDeliverabilityDashboardOption
     $metadata: deserializeMetadata(output),
     __type: "PutDeliverabilityDashboardOptionResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -4975,6 +5060,7 @@ export async function deserializeAws_restJson1_1PutEmailIdentityDkimAttributesCo
     $metadata: deserializeMetadata(output),
     __type: "PutEmailIdentityDkimAttributesResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -5117,6 +5203,7 @@ export async function deserializeAws_restJson1_1PutEmailIdentityFeedbackAttribut
     $metadata: deserializeMetadata(output),
     __type: "PutEmailIdentityFeedbackAttributesResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -5182,6 +5269,7 @@ export async function deserializeAws_restJson1_1PutEmailIdentityMailFromAttribut
     $metadata: deserializeMetadata(output),
     __type: "PutEmailIdentityMailFromAttributesResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -5247,6 +5335,7 @@ export async function deserializeAws_restJson1_1PutSuppressedDestinationCommand(
     $metadata: deserializeMetadata(output),
     __type: "PutSuppressedDestinationResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -5404,6 +5493,7 @@ export async function deserializeAws_restJson1_1TagResourceCommand(
     $metadata: deserializeMetadata(output),
     __type: "TagResourceResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -5473,6 +5563,7 @@ export async function deserializeAws_restJson1_1UntagResourceCommand(
     $metadata: deserializeMetadata(output),
     __type: "UntagResourceResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -5545,6 +5636,7 @@ export async function deserializeAws_restJson1_1UpdateConfigurationSetEventDesti
     $metadata: deserializeMetadata(output),
     __type: "UpdateConfigurationSetEventDestinationResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 

--- a/clients/client-sfn/models/index.ts
+++ b/clients/client-sfn/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -19,7 +22,7 @@ export interface ActivityFailedEventDetails {
 
 export namespace ActivityFailedEventDetails {
   export function isa(o: any): o is ActivityFailedEventDetails {
-    return _smithy.isa(o, "ActivityFailedEventDetails");
+    return __isa(o, "ActivityFailedEventDetails");
   }
 }
 
@@ -42,7 +45,7 @@ export interface ActivityScheduleFailedEventDetails {
 
 export namespace ActivityScheduleFailedEventDetails {
   export function isa(o: any): o is ActivityScheduleFailedEventDetails {
-    return _smithy.isa(o, "ActivityScheduleFailedEventDetails");
+    return __isa(o, "ActivityScheduleFailedEventDetails");
   }
 }
 
@@ -74,7 +77,7 @@ export interface ActivityScheduledEventDetails {
 
 export namespace ActivityScheduledEventDetails {
   export function isa(o: any): o is ActivityScheduledEventDetails {
-    return _smithy.isa(o, "ActivityScheduledEventDetails");
+    return __isa(o, "ActivityScheduledEventDetails");
   }
 }
 
@@ -92,7 +95,7 @@ export interface ActivityStartedEventDetails {
 
 export namespace ActivityStartedEventDetails {
   export function isa(o: any): o is ActivityStartedEventDetails {
-    return _smithy.isa(o, "ActivityStartedEventDetails");
+    return __isa(o, "ActivityStartedEventDetails");
   }
 }
 
@@ -110,7 +113,7 @@ export interface ActivitySucceededEventDetails {
 
 export namespace ActivitySucceededEventDetails {
   export function isa(o: any): o is ActivitySucceededEventDetails {
-    return _smithy.isa(o, "ActivitySucceededEventDetails");
+    return __isa(o, "ActivitySucceededEventDetails");
   }
 }
 
@@ -132,7 +135,7 @@ export interface ActivityTimedOutEventDetails {
 
 export namespace ActivityTimedOutEventDetails {
   export function isa(o: any): o is ActivityTimedOutEventDetails {
-    return _smithy.isa(o, "ActivityTimedOutEventDetails");
+    return __isa(o, "ActivityTimedOutEventDetails");
   }
 }
 
@@ -150,7 +153,7 @@ export interface CloudWatchLogsLogGroup {
 
 export namespace CloudWatchLogsLogGroup {
   export function isa(o: any): o is CloudWatchLogsLogGroup {
-    return _smithy.isa(o, "CloudWatchLogsLogGroup");
+    return __isa(o, "CloudWatchLogsLogGroup");
   }
 }
 
@@ -172,7 +175,7 @@ export interface ExecutionAbortedEventDetails {
 
 export namespace ExecutionAbortedEventDetails {
   export function isa(o: any): o is ExecutionAbortedEventDetails {
-    return _smithy.isa(o, "ExecutionAbortedEventDetails");
+    return __isa(o, "ExecutionAbortedEventDetails");
   }
 }
 
@@ -194,7 +197,7 @@ export interface ExecutionFailedEventDetails {
 
 export namespace ExecutionFailedEventDetails {
   export function isa(o: any): o is ExecutionFailedEventDetails {
-    return _smithy.isa(o, "ExecutionFailedEventDetails");
+    return __isa(o, "ExecutionFailedEventDetails");
   }
 }
 
@@ -216,7 +219,7 @@ export interface ExecutionStartedEventDetails {
 
 export namespace ExecutionStartedEventDetails {
   export function isa(o: any): o is ExecutionStartedEventDetails {
-    return _smithy.isa(o, "ExecutionStartedEventDetails");
+    return __isa(o, "ExecutionStartedEventDetails");
   }
 }
 
@@ -233,7 +236,7 @@ export interface ExecutionSucceededEventDetails {
 
 export namespace ExecutionSucceededEventDetails {
   export function isa(o: any): o is ExecutionSucceededEventDetails {
-    return _smithy.isa(o, "ExecutionSucceededEventDetails");
+    return __isa(o, "ExecutionSucceededEventDetails");
   }
 }
 
@@ -255,7 +258,7 @@ export interface ExecutionTimedOutEventDetails {
 
 export namespace ExecutionTimedOutEventDetails {
   export function isa(o: any): o is ExecutionTimedOutEventDetails {
-    return _smithy.isa(o, "ExecutionTimedOutEventDetails");
+    return __isa(o, "ExecutionTimedOutEventDetails");
   }
 }
 
@@ -450,7 +453,7 @@ export interface HistoryEvent {
 
 export namespace HistoryEvent {
   export function isa(o: any): o is HistoryEvent {
-    return _smithy.isa(o, "HistoryEvent");
+    return __isa(o, "HistoryEvent");
   }
 }
 
@@ -529,7 +532,7 @@ export interface LambdaFunctionFailedEventDetails {
 
 export namespace LambdaFunctionFailedEventDetails {
   export function isa(o: any): o is LambdaFunctionFailedEventDetails {
-    return _smithy.isa(o, "LambdaFunctionFailedEventDetails");
+    return __isa(o, "LambdaFunctionFailedEventDetails");
   }
 }
 
@@ -552,7 +555,7 @@ export interface LambdaFunctionScheduleFailedEventDetails {
 
 export namespace LambdaFunctionScheduleFailedEventDetails {
   export function isa(o: any): o is LambdaFunctionScheduleFailedEventDetails {
-    return _smithy.isa(o, "LambdaFunctionScheduleFailedEventDetails");
+    return __isa(o, "LambdaFunctionScheduleFailedEventDetails");
   }
 }
 
@@ -579,7 +582,7 @@ export interface LambdaFunctionScheduledEventDetails {
 
 export namespace LambdaFunctionScheduledEventDetails {
   export function isa(o: any): o is LambdaFunctionScheduledEventDetails {
-    return _smithy.isa(o, "LambdaFunctionScheduledEventDetails");
+    return __isa(o, "LambdaFunctionScheduledEventDetails");
   }
 }
 
@@ -601,7 +604,7 @@ export interface LambdaFunctionStartFailedEventDetails {
 
 export namespace LambdaFunctionStartFailedEventDetails {
   export function isa(o: any): o is LambdaFunctionStartFailedEventDetails {
-    return _smithy.isa(o, "LambdaFunctionStartFailedEventDetails");
+    return __isa(o, "LambdaFunctionStartFailedEventDetails");
   }
 }
 
@@ -619,7 +622,7 @@ export interface LambdaFunctionSucceededEventDetails {
 
 export namespace LambdaFunctionSucceededEventDetails {
   export function isa(o: any): o is LambdaFunctionSucceededEventDetails {
-    return _smithy.isa(o, "LambdaFunctionSucceededEventDetails");
+    return __isa(o, "LambdaFunctionSucceededEventDetails");
   }
 }
 
@@ -641,7 +644,7 @@ export interface LambdaFunctionTimedOutEventDetails {
 
 export namespace LambdaFunctionTimedOutEventDetails {
   export function isa(o: any): o is LambdaFunctionTimedOutEventDetails {
-    return _smithy.isa(o, "LambdaFunctionTimedOutEventDetails");
+    return __isa(o, "LambdaFunctionTimedOutEventDetails");
   }
 }
 
@@ -658,7 +661,7 @@ export interface LogDestination {
 
 export namespace LogDestination {
   export function isa(o: any): o is LogDestination {
-    return _smithy.isa(o, "LogDestination");
+    return __isa(o, "LogDestination");
   }
 }
 
@@ -689,7 +692,7 @@ export interface LoggingConfiguration {
 
 export namespace LoggingConfiguration {
   export function isa(o: any): o is LoggingConfiguration {
-    return _smithy.isa(o, "LoggingConfiguration");
+    return __isa(o, "LoggingConfiguration");
   }
 }
 
@@ -711,7 +714,7 @@ export interface MapIterationEventDetails {
 
 export namespace MapIterationEventDetails {
   export function isa(o: any): o is MapIterationEventDetails {
-    return _smithy.isa(o, "MapIterationEventDetails");
+    return __isa(o, "MapIterationEventDetails");
   }
 }
 
@@ -728,7 +731,7 @@ export interface MapStateStartedEventDetails {
 
 export namespace MapStateStartedEventDetails {
   export function isa(o: any): o is MapStateStartedEventDetails {
-    return _smithy.isa(o, "MapStateStartedEventDetails");
+    return __isa(o, "MapStateStartedEventDetails");
   }
 }
 
@@ -750,7 +753,7 @@ export interface StateEnteredEventDetails {
 
 export namespace StateEnteredEventDetails {
   export function isa(o: any): o is StateEnteredEventDetails {
-    return _smithy.isa(o, "StateEnteredEventDetails");
+    return __isa(o, "StateEnteredEventDetails");
   }
 }
 
@@ -793,7 +796,7 @@ export interface StateExitedEventDetails {
 
 export namespace StateExitedEventDetails {
   export function isa(o: any): o is StateExitedEventDetails {
-    return _smithy.isa(o, "StateExitedEventDetails");
+    return __isa(o, "StateExitedEventDetails");
   }
 }
 
@@ -827,7 +830,7 @@ export interface TaskFailedEventDetails {
 
 export namespace TaskFailedEventDetails {
   export function isa(o: any): o is TaskFailedEventDetails {
-    return _smithy.isa(o, "TaskFailedEventDetails");
+    return __isa(o, "TaskFailedEventDetails");
   }
 }
 
@@ -864,7 +867,7 @@ export interface TaskScheduledEventDetails {
 
 export namespace TaskScheduledEventDetails {
   export function isa(o: any): o is TaskScheduledEventDetails {
-    return _smithy.isa(o, "TaskScheduledEventDetails");
+    return __isa(o, "TaskScheduledEventDetails");
   }
 }
 
@@ -896,7 +899,7 @@ export interface TaskStartFailedEventDetails {
 
 export namespace TaskStartFailedEventDetails {
   export function isa(o: any): o is TaskStartFailedEventDetails {
-    return _smithy.isa(o, "TaskStartFailedEventDetails");
+    return __isa(o, "TaskStartFailedEventDetails");
   }
 }
 
@@ -918,7 +921,7 @@ export interface TaskStartedEventDetails {
 
 export namespace TaskStartedEventDetails {
   export function isa(o: any): o is TaskStartedEventDetails {
-    return _smithy.isa(o, "TaskStartedEventDetails");
+    return __isa(o, "TaskStartedEventDetails");
   }
 }
 
@@ -950,7 +953,7 @@ export interface TaskSubmitFailedEventDetails {
 
 export namespace TaskSubmitFailedEventDetails {
   export function isa(o: any): o is TaskSubmitFailedEventDetails {
-    return _smithy.isa(o, "TaskSubmitFailedEventDetails");
+    return __isa(o, "TaskSubmitFailedEventDetails");
   }
 }
 
@@ -977,7 +980,7 @@ export interface TaskSubmittedEventDetails {
 
 export namespace TaskSubmittedEventDetails {
   export function isa(o: any): o is TaskSubmittedEventDetails {
-    return _smithy.isa(o, "TaskSubmittedEventDetails");
+    return __isa(o, "TaskSubmittedEventDetails");
   }
 }
 
@@ -1005,7 +1008,7 @@ export interface TaskSucceededEventDetails {
 
 export namespace TaskSucceededEventDetails {
   export function isa(o: any): o is TaskSucceededEventDetails {
-    return _smithy.isa(o, "TaskSucceededEventDetails");
+    return __isa(o, "TaskSucceededEventDetails");
   }
 }
 
@@ -1037,7 +1040,7 @@ export interface TaskTimedOutEventDetails {
 
 export namespace TaskTimedOutEventDetails {
   export function isa(o: any): o is TaskTimedOutEventDetails {
-    return _smithy.isa(o, "TaskTimedOutEventDetails");
+    return __isa(o, "TaskTimedOutEventDetails");
   }
 }
 
@@ -1045,7 +1048,7 @@ export namespace TaskTimedOutEventDetails {
  * <p>The specified activity does not exist.</p>
  */
 export interface ActivityDoesNotExist
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ActivityDoesNotExist";
   $fault: "client";
@@ -1054,7 +1057,7 @@ export interface ActivityDoesNotExist
 
 export namespace ActivityDoesNotExist {
   export function isa(o: any): o is ActivityDoesNotExist {
-    return _smithy.isa(o, "ActivityDoesNotExist");
+    return __isa(o, "ActivityDoesNotExist");
   }
 }
 
@@ -1063,7 +1066,7 @@ export namespace ActivityDoesNotExist {
  *       before a new activity can be created.</p>
  */
 export interface ActivityLimitExceeded
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ActivityLimitExceeded";
   $fault: "client";
@@ -1072,7 +1075,7 @@ export interface ActivityLimitExceeded
 
 export namespace ActivityLimitExceeded {
   export function isa(o: any): o is ActivityLimitExceeded {
-    return _smithy.isa(o, "ActivityLimitExceeded");
+    return __isa(o, "ActivityLimitExceeded");
   }
 }
 
@@ -1120,7 +1123,7 @@ export interface ActivityListItem {
 
 export namespace ActivityListItem {
   export function isa(o: any): o is ActivityListItem {
-    return _smithy.isa(o, "ActivityListItem");
+    return __isa(o, "ActivityListItem");
   }
 }
 
@@ -1129,7 +1132,7 @@ export namespace ActivityListItem {
  *       reached.</p>
  */
 export interface ActivityWorkerLimitExceeded
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ActivityWorkerLimitExceeded";
   $fault: "client";
@@ -1138,7 +1141,7 @@ export interface ActivityWorkerLimitExceeded
 
 export namespace ActivityWorkerLimitExceeded {
   export function isa(o: any): o is ActivityWorkerLimitExceeded {
-    return _smithy.isa(o, "ActivityWorkerLimitExceeded");
+    return __isa(o, "ActivityWorkerLimitExceeded");
   }
 }
 
@@ -1185,7 +1188,7 @@ export interface CreateActivityInput {
 
 export namespace CreateActivityInput {
   export function isa(o: any): o is CreateActivityInput {
-    return _smithy.isa(o, "CreateActivityInput");
+    return __isa(o, "CreateActivityInput");
   }
 }
 
@@ -1204,7 +1207,7 @@ export interface CreateActivityOutput extends $MetadataBearer {
 
 export namespace CreateActivityOutput {
   export function isa(o: any): o is CreateActivityOutput {
-    return _smithy.isa(o, "CreateActivityOutput");
+    return __isa(o, "CreateActivityOutput");
   }
 }
 
@@ -1269,7 +1272,7 @@ export interface CreateStateMachineInput {
 
 export namespace CreateStateMachineInput {
   export function isa(o: any): o is CreateStateMachineInput {
-    return _smithy.isa(o, "CreateStateMachineInput");
+    return __isa(o, "CreateStateMachineInput");
   }
 }
 
@@ -1288,7 +1291,7 @@ export interface CreateStateMachineOutput extends $MetadataBearer {
 
 export namespace CreateStateMachineOutput {
   export function isa(o: any): o is CreateStateMachineOutput {
-    return _smithy.isa(o, "CreateStateMachineOutput");
+    return __isa(o, "CreateStateMachineOutput");
   }
 }
 
@@ -1302,7 +1305,7 @@ export interface DeleteActivityInput {
 
 export namespace DeleteActivityInput {
   export function isa(o: any): o is DeleteActivityInput {
-    return _smithy.isa(o, "DeleteActivityInput");
+    return __isa(o, "DeleteActivityInput");
   }
 }
 
@@ -1312,7 +1315,7 @@ export interface DeleteActivityOutput extends $MetadataBearer {
 
 export namespace DeleteActivityOutput {
   export function isa(o: any): o is DeleteActivityOutput {
-    return _smithy.isa(o, "DeleteActivityOutput");
+    return __isa(o, "DeleteActivityOutput");
   }
 }
 
@@ -1326,7 +1329,7 @@ export interface DeleteStateMachineInput {
 
 export namespace DeleteStateMachineInput {
   export function isa(o: any): o is DeleteStateMachineInput {
-    return _smithy.isa(o, "DeleteStateMachineInput");
+    return __isa(o, "DeleteStateMachineInput");
   }
 }
 
@@ -1336,7 +1339,7 @@ export interface DeleteStateMachineOutput extends $MetadataBearer {
 
 export namespace DeleteStateMachineOutput {
   export function isa(o: any): o is DeleteStateMachineOutput {
-    return _smithy.isa(o, "DeleteStateMachineOutput");
+    return __isa(o, "DeleteStateMachineOutput");
   }
 }
 
@@ -1350,7 +1353,7 @@ export interface DescribeActivityInput {
 
 export namespace DescribeActivityInput {
   export function isa(o: any): o is DescribeActivityInput {
-    return _smithy.isa(o, "DescribeActivityInput");
+    return __isa(o, "DescribeActivityInput");
   }
 }
 
@@ -1395,7 +1398,7 @@ export interface DescribeActivityOutput extends $MetadataBearer {
 
 export namespace DescribeActivityOutput {
   export function isa(o: any): o is DescribeActivityOutput {
-    return _smithy.isa(o, "DescribeActivityOutput");
+    return __isa(o, "DescribeActivityOutput");
   }
 }
 
@@ -1409,7 +1412,7 @@ export interface DescribeExecutionInput {
 
 export namespace DescribeExecutionInput {
   export function isa(o: any): o is DescribeExecutionInput {
-    return _smithy.isa(o, "DescribeExecutionInput");
+    return __isa(o, "DescribeExecutionInput");
   }
 }
 
@@ -1483,7 +1486,7 @@ export interface DescribeExecutionOutput extends $MetadataBearer {
 
 export namespace DescribeExecutionOutput {
   export function isa(o: any): o is DescribeExecutionOutput {
-    return _smithy.isa(o, "DescribeExecutionOutput");
+    return __isa(o, "DescribeExecutionOutput");
   }
 }
 
@@ -1497,7 +1500,7 @@ export interface DescribeStateMachineForExecutionInput {
 
 export namespace DescribeStateMachineForExecutionInput {
   export function isa(o: any): o is DescribeStateMachineForExecutionInput {
-    return _smithy.isa(o, "DescribeStateMachineForExecutionInput");
+    return __isa(o, "DescribeStateMachineForExecutionInput");
   }
 }
 
@@ -1533,7 +1536,7 @@ export interface DescribeStateMachineForExecutionOutput
 
 export namespace DescribeStateMachineForExecutionOutput {
   export function isa(o: any): o is DescribeStateMachineForExecutionOutput {
-    return _smithy.isa(o, "DescribeStateMachineForExecutionOutput");
+    return __isa(o, "DescribeStateMachineForExecutionOutput");
   }
 }
 
@@ -1547,7 +1550,7 @@ export interface DescribeStateMachineInput {
 
 export namespace DescribeStateMachineInput {
   export function isa(o: any): o is DescribeStateMachineInput {
-    return _smithy.isa(o, "DescribeStateMachineInput");
+    return __isa(o, "DescribeStateMachineInput");
   }
 }
 
@@ -1618,7 +1621,7 @@ export interface DescribeStateMachineOutput extends $MetadataBearer {
 
 export namespace DescribeStateMachineOutput {
   export function isa(o: any): o is DescribeStateMachineOutput {
-    return _smithy.isa(o, "DescribeStateMachineOutput");
+    return __isa(o, "DescribeStateMachineOutput");
   }
 }
 
@@ -1631,7 +1634,7 @@ export namespace DescribeStateMachineOutput {
  *          </note>
  */
 export interface ExecutionAlreadyExists
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ExecutionAlreadyExists";
   $fault: "client";
@@ -1640,7 +1643,7 @@ export interface ExecutionAlreadyExists
 
 export namespace ExecutionAlreadyExists {
   export function isa(o: any): o is ExecutionAlreadyExists {
-    return _smithy.isa(o, "ExecutionAlreadyExists");
+    return __isa(o, "ExecutionAlreadyExists");
   }
 }
 
@@ -1648,7 +1651,7 @@ export namespace ExecutionAlreadyExists {
  * <p>The specified execution does not exist.</p>
  */
 export interface ExecutionDoesNotExist
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ExecutionDoesNotExist";
   $fault: "client";
@@ -1657,7 +1660,7 @@ export interface ExecutionDoesNotExist
 
 export namespace ExecutionDoesNotExist {
   export function isa(o: any): o is ExecutionDoesNotExist {
-    return _smithy.isa(o, "ExecutionDoesNotExist");
+    return __isa(o, "ExecutionDoesNotExist");
   }
 }
 
@@ -1666,7 +1669,7 @@ export namespace ExecutionDoesNotExist {
  *       be stopped before a new execution can be started.</p>
  */
 export interface ExecutionLimitExceeded
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ExecutionLimitExceeded";
   $fault: "client";
@@ -1675,7 +1678,7 @@ export interface ExecutionLimitExceeded
 
 export namespace ExecutionLimitExceeded {
   export function isa(o: any): o is ExecutionLimitExceeded {
-    return _smithy.isa(o, "ExecutionLimitExceeded");
+    return __isa(o, "ExecutionLimitExceeded");
   }
 }
 
@@ -1738,7 +1741,7 @@ export interface ExecutionListItem {
 
 export namespace ExecutionListItem {
   export function isa(o: any): o is ExecutionListItem {
-    return _smithy.isa(o, "ExecutionListItem");
+    return __isa(o, "ExecutionListItem");
   }
 }
 
@@ -1766,7 +1769,7 @@ export interface GetActivityTaskInput {
 
 export namespace GetActivityTaskInput {
   export function isa(o: any): o is GetActivityTaskInput {
-    return _smithy.isa(o, "GetActivityTaskInput");
+    return __isa(o, "GetActivityTaskInput");
   }
 }
 
@@ -1788,7 +1791,7 @@ export interface GetActivityTaskOutput extends $MetadataBearer {
 
 export namespace GetActivityTaskOutput {
   export function isa(o: any): o is GetActivityTaskOutput {
-    return _smithy.isa(o, "GetActivityTaskOutput");
+    return __isa(o, "GetActivityTaskOutput");
   }
 }
 
@@ -1820,7 +1823,7 @@ export interface GetExecutionHistoryInput {
 
 export namespace GetExecutionHistoryInput {
   export function isa(o: any): o is GetExecutionHistoryInput {
-    return _smithy.isa(o, "GetExecutionHistoryInput");
+    return __isa(o, "GetExecutionHistoryInput");
   }
 }
 
@@ -1840,14 +1843,14 @@ export interface GetExecutionHistoryOutput extends $MetadataBearer {
 
 export namespace GetExecutionHistoryOutput {
   export function isa(o: any): o is GetExecutionHistoryOutput {
-    return _smithy.isa(o, "GetExecutionHistoryOutput");
+    return __isa(o, "GetExecutionHistoryOutput");
   }
 }
 
 /**
  * <p>The provided Amazon Resource Name (ARN) is invalid.</p>
  */
-export interface InvalidArn extends _smithy.SmithyException, $MetadataBearer {
+export interface InvalidArn extends __SmithyException, $MetadataBearer {
   name: "InvalidArn";
   $fault: "client";
   message?: string;
@@ -1855,16 +1858,14 @@ export interface InvalidArn extends _smithy.SmithyException, $MetadataBearer {
 
 export namespace InvalidArn {
   export function isa(o: any): o is InvalidArn {
-    return _smithy.isa(o, "InvalidArn");
+    return __isa(o, "InvalidArn");
   }
 }
 
 /**
  * <p>The provided Amazon States Language definition is invalid.</p>
  */
-export interface InvalidDefinition
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface InvalidDefinition extends __SmithyException, $MetadataBearer {
   name: "InvalidDefinition";
   $fault: "client";
   message?: string;
@@ -1872,7 +1873,7 @@ export interface InvalidDefinition
 
 export namespace InvalidDefinition {
   export function isa(o: any): o is InvalidDefinition {
-    return _smithy.isa(o, "InvalidDefinition");
+    return __isa(o, "InvalidDefinition");
   }
 }
 
@@ -1880,7 +1881,7 @@ export namespace InvalidDefinition {
  * <p>The provided JSON input data is invalid.</p>
  */
 export interface InvalidExecutionInput
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidExecutionInput";
   $fault: "client";
@@ -1889,7 +1890,7 @@ export interface InvalidExecutionInput
 
 export namespace InvalidExecutionInput {
   export function isa(o: any): o is InvalidExecutionInput {
-    return _smithy.isa(o, "InvalidExecutionInput");
+    return __isa(o, "InvalidExecutionInput");
   }
 }
 
@@ -1897,7 +1898,7 @@ export namespace InvalidExecutionInput {
  * <p></p>
  */
 export interface InvalidLoggingConfiguration
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidLoggingConfiguration";
   $fault: "client";
@@ -1906,14 +1907,14 @@ export interface InvalidLoggingConfiguration
 
 export namespace InvalidLoggingConfiguration {
   export function isa(o: any): o is InvalidLoggingConfiguration {
-    return _smithy.isa(o, "InvalidLoggingConfiguration");
+    return __isa(o, "InvalidLoggingConfiguration");
   }
 }
 
 /**
  * <p>The provided name is invalid.</p>
  */
-export interface InvalidName extends _smithy.SmithyException, $MetadataBearer {
+export interface InvalidName extends __SmithyException, $MetadataBearer {
   name: "InvalidName";
   $fault: "client";
   message?: string;
@@ -1921,16 +1922,14 @@ export interface InvalidName extends _smithy.SmithyException, $MetadataBearer {
 
 export namespace InvalidName {
   export function isa(o: any): o is InvalidName {
-    return _smithy.isa(o, "InvalidName");
+    return __isa(o, "InvalidName");
   }
 }
 
 /**
  * <p>The provided JSON output data is invalid.</p>
  */
-export interface InvalidOutput
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface InvalidOutput extends __SmithyException, $MetadataBearer {
   name: "InvalidOutput";
   $fault: "client";
   message?: string;
@@ -1938,14 +1937,14 @@ export interface InvalidOutput
 
 export namespace InvalidOutput {
   export function isa(o: any): o is InvalidOutput {
-    return _smithy.isa(o, "InvalidOutput");
+    return __isa(o, "InvalidOutput");
   }
 }
 
 /**
  * <p>The provided token is invalid.</p>
  */
-export interface InvalidToken extends _smithy.SmithyException, $MetadataBearer {
+export interface InvalidToken extends __SmithyException, $MetadataBearer {
   name: "InvalidToken";
   $fault: "client";
   message?: string;
@@ -1953,7 +1952,7 @@ export interface InvalidToken extends _smithy.SmithyException, $MetadataBearer {
 
 export namespace InvalidToken {
   export function isa(o: any): o is InvalidToken {
-    return _smithy.isa(o, "InvalidToken");
+    return __isa(o, "InvalidToken");
   }
 }
 
@@ -1975,7 +1974,7 @@ export interface ListActivitiesInput {
 
 export namespace ListActivitiesInput {
   export function isa(o: any): o is ListActivitiesInput {
-    return _smithy.isa(o, "ListActivitiesInput");
+    return __isa(o, "ListActivitiesInput");
   }
 }
 
@@ -1995,7 +1994,7 @@ export interface ListActivitiesOutput extends $MetadataBearer {
 
 export namespace ListActivitiesOutput {
   export function isa(o: any): o is ListActivitiesOutput {
-    return _smithy.isa(o, "ListActivitiesOutput");
+    return __isa(o, "ListActivitiesOutput");
   }
 }
 
@@ -2028,7 +2027,7 @@ export interface ListExecutionsInput {
 
 export namespace ListExecutionsInput {
   export function isa(o: any): o is ListExecutionsInput {
-    return _smithy.isa(o, "ListExecutionsInput");
+    return __isa(o, "ListExecutionsInput");
   }
 }
 
@@ -2048,7 +2047,7 @@ export interface ListExecutionsOutput extends $MetadataBearer {
 
 export namespace ListExecutionsOutput {
   export function isa(o: any): o is ListExecutionsOutput {
-    return _smithy.isa(o, "ListExecutionsOutput");
+    return __isa(o, "ListExecutionsOutput");
   }
 }
 
@@ -2070,7 +2069,7 @@ export interface ListStateMachinesInput {
 
 export namespace ListStateMachinesInput {
   export function isa(o: any): o is ListStateMachinesInput {
-    return _smithy.isa(o, "ListStateMachinesInput");
+    return __isa(o, "ListStateMachinesInput");
   }
 }
 
@@ -2087,7 +2086,7 @@ export interface ListStateMachinesOutput extends $MetadataBearer {
 
 export namespace ListStateMachinesOutput {
   export function isa(o: any): o is ListStateMachinesOutput {
-    return _smithy.isa(o, "ListStateMachinesOutput");
+    return __isa(o, "ListStateMachinesOutput");
   }
 }
 
@@ -2101,7 +2100,7 @@ export interface ListTagsForResourceInput {
 
 export namespace ListTagsForResourceInput {
   export function isa(o: any): o is ListTagsForResourceInput {
-    return _smithy.isa(o, "ListTagsForResourceInput");
+    return __isa(o, "ListTagsForResourceInput");
   }
 }
 
@@ -2115,7 +2114,7 @@ export interface ListTagsForResourceOutput extends $MetadataBearer {
 
 export namespace ListTagsForResourceOutput {
   export function isa(o: any): o is ListTagsForResourceOutput {
-    return _smithy.isa(o, "ListTagsForResourceOutput");
+    return __isa(o, "ListTagsForResourceOutput");
   }
 }
 
@@ -2124,7 +2123,7 @@ export namespace ListTagsForResourceOutput {
  *       and <code>roleArn</code> are not specified.</p>
  */
 export interface MissingRequiredParameter
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "MissingRequiredParameter";
   $fault: "client";
@@ -2133,7 +2132,7 @@ export interface MissingRequiredParameter
 
 export namespace MissingRequiredParameter {
   export function isa(o: any): o is MissingRequiredParameter {
-    return _smithy.isa(o, "MissingRequiredParameter");
+    return __isa(o, "MissingRequiredParameter");
   }
 }
 
@@ -2141,9 +2140,7 @@ export namespace MissingRequiredParameter {
  * <p>Could not find the referenced resource. Only state machine and activity ARNs are
  *       supported.</p>
  */
-export interface ResourceNotFound
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface ResourceNotFound extends __SmithyException, $MetadataBearer {
   name: "ResourceNotFound";
   $fault: "client";
   message?: string;
@@ -2152,7 +2149,7 @@ export interface ResourceNotFound
 
 export namespace ResourceNotFound {
   export function isa(o: any): o is ResourceNotFound {
-    return _smithy.isa(o, "ResourceNotFound");
+    return __isa(o, "ResourceNotFound");
   }
 }
 
@@ -2178,7 +2175,7 @@ export interface SendTaskFailureInput {
 
 export namespace SendTaskFailureInput {
   export function isa(o: any): o is SendTaskFailureInput {
-    return _smithy.isa(o, "SendTaskFailureInput");
+    return __isa(o, "SendTaskFailureInput");
   }
 }
 
@@ -2188,7 +2185,7 @@ export interface SendTaskFailureOutput extends $MetadataBearer {
 
 export namespace SendTaskFailureOutput {
   export function isa(o: any): o is SendTaskFailureOutput {
-    return _smithy.isa(o, "SendTaskFailureOutput");
+    return __isa(o, "SendTaskFailureOutput");
   }
 }
 
@@ -2204,7 +2201,7 @@ export interface SendTaskHeartbeatInput {
 
 export namespace SendTaskHeartbeatInput {
   export function isa(o: any): o is SendTaskHeartbeatInput {
-    return _smithy.isa(o, "SendTaskHeartbeatInput");
+    return __isa(o, "SendTaskHeartbeatInput");
   }
 }
 
@@ -2214,7 +2211,7 @@ export interface SendTaskHeartbeatOutput extends $MetadataBearer {
 
 export namespace SendTaskHeartbeatOutput {
   export function isa(o: any): o is SendTaskHeartbeatOutput {
-    return _smithy.isa(o, "SendTaskHeartbeatOutput");
+    return __isa(o, "SendTaskHeartbeatOutput");
   }
 }
 
@@ -2235,7 +2232,7 @@ export interface SendTaskSuccessInput {
 
 export namespace SendTaskSuccessInput {
   export function isa(o: any): o is SendTaskSuccessInput {
-    return _smithy.isa(o, "SendTaskSuccessInput");
+    return __isa(o, "SendTaskSuccessInput");
   }
 }
 
@@ -2245,7 +2242,7 @@ export interface SendTaskSuccessOutput extends $MetadataBearer {
 
 export namespace SendTaskSuccessOutput {
   export function isa(o: any): o is SendTaskSuccessOutput {
-    return _smithy.isa(o, "SendTaskSuccessOutput");
+    return __isa(o, "SendTaskSuccessOutput");
   }
 }
 
@@ -2300,7 +2297,7 @@ export interface StartExecutionInput {
 
 export namespace StartExecutionInput {
   export function isa(o: any): o is StartExecutionInput {
-    return _smithy.isa(o, "StartExecutionInput");
+    return __isa(o, "StartExecutionInput");
   }
 }
 
@@ -2319,7 +2316,7 @@ export interface StartExecutionOutput extends $MetadataBearer {
 
 export namespace StartExecutionOutput {
   export function isa(o: any): o is StartExecutionOutput {
-    return _smithy.isa(o, "StartExecutionOutput");
+    return __isa(o, "StartExecutionOutput");
   }
 }
 
@@ -2328,7 +2325,7 @@ export namespace StartExecutionOutput {
  *       exists.</p>
  */
 export interface StateMachineAlreadyExists
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "StateMachineAlreadyExists";
   $fault: "client";
@@ -2337,7 +2334,7 @@ export interface StateMachineAlreadyExists
 
 export namespace StateMachineAlreadyExists {
   export function isa(o: any): o is StateMachineAlreadyExists {
-    return _smithy.isa(o, "StateMachineAlreadyExists");
+    return __isa(o, "StateMachineAlreadyExists");
   }
 }
 
@@ -2345,7 +2342,7 @@ export namespace StateMachineAlreadyExists {
  * <p>The specified state machine is being deleted.</p>
  */
 export interface StateMachineDeleting
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "StateMachineDeleting";
   $fault: "client";
@@ -2354,7 +2351,7 @@ export interface StateMachineDeleting
 
 export namespace StateMachineDeleting {
   export function isa(o: any): o is StateMachineDeleting {
-    return _smithy.isa(o, "StateMachineDeleting");
+    return __isa(o, "StateMachineDeleting");
   }
 }
 
@@ -2362,7 +2359,7 @@ export namespace StateMachineDeleting {
  * <p>The specified state machine does not exist.</p>
  */
 export interface StateMachineDoesNotExist
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "StateMachineDoesNotExist";
   $fault: "client";
@@ -2371,7 +2368,7 @@ export interface StateMachineDoesNotExist
 
 export namespace StateMachineDoesNotExist {
   export function isa(o: any): o is StateMachineDoesNotExist {
-    return _smithy.isa(o, "StateMachineDoesNotExist");
+    return __isa(o, "StateMachineDoesNotExist");
   }
 }
 
@@ -2380,7 +2377,7 @@ export namespace StateMachineDoesNotExist {
  *       deleted before a new state machine can be created.</p>
  */
 export interface StateMachineLimitExceeded
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "StateMachineLimitExceeded";
   $fault: "client";
@@ -2389,7 +2386,7 @@ export interface StateMachineLimitExceeded
 
 export namespace StateMachineLimitExceeded {
   export function isa(o: any): o is StateMachineLimitExceeded {
-    return _smithy.isa(o, "StateMachineLimitExceeded");
+    return __isa(o, "StateMachineLimitExceeded");
   }
 }
 
@@ -2442,7 +2439,7 @@ export interface StateMachineListItem {
 
 export namespace StateMachineListItem {
   export function isa(o: any): o is StateMachineListItem {
-    return _smithy.isa(o, "StateMachineListItem");
+    return __isa(o, "StateMachineListItem");
   }
 }
 
@@ -2452,7 +2449,7 @@ export type StateMachineStatus = "ACTIVE" | "DELETING";
  * <p></p>
  */
 export interface StateMachineTypeNotSupported
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "StateMachineTypeNotSupported";
   $fault: "client";
@@ -2461,7 +2458,7 @@ export interface StateMachineTypeNotSupported
 
 export namespace StateMachineTypeNotSupported {
   export function isa(o: any): o is StateMachineTypeNotSupported {
-    return _smithy.isa(o, "StateMachineTypeNotSupported");
+    return __isa(o, "StateMachineTypeNotSupported");
   }
 }
 
@@ -2485,7 +2482,7 @@ export interface StopExecutionInput {
 
 export namespace StopExecutionInput {
   export function isa(o: any): o is StopExecutionInput {
-    return _smithy.isa(o, "StopExecutionInput");
+    return __isa(o, "StopExecutionInput");
   }
 }
 
@@ -2499,7 +2496,7 @@ export interface StopExecutionOutput extends $MetadataBearer {
 
 export namespace StopExecutionOutput {
   export function isa(o: any): o is StopExecutionOutput {
-    return _smithy.isa(o, "StopExecutionOutput");
+    return __isa(o, "StopExecutionOutput");
   }
 }
 
@@ -2527,7 +2524,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -2547,7 +2544,7 @@ export interface TagResourceInput {
 
 export namespace TagResourceInput {
   export function isa(o: any): o is TagResourceInput {
-    return _smithy.isa(o, "TagResourceInput");
+    return __isa(o, "TagResourceInput");
   }
 }
 
@@ -2557,13 +2554,11 @@ export interface TagResourceOutput extends $MetadataBearer {
 
 export namespace TagResourceOutput {
   export function isa(o: any): o is TagResourceOutput {
-    return _smithy.isa(o, "TagResourceOutput");
+    return __isa(o, "TagResourceOutput");
   }
 }
 
-export interface TaskDoesNotExist
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface TaskDoesNotExist extends __SmithyException, $MetadataBearer {
   name: "TaskDoesNotExist";
   $fault: "client";
   message?: string;
@@ -2571,11 +2566,11 @@ export interface TaskDoesNotExist
 
 export namespace TaskDoesNotExist {
   export function isa(o: any): o is TaskDoesNotExist {
-    return _smithy.isa(o, "TaskDoesNotExist");
+    return __isa(o, "TaskDoesNotExist");
   }
 }
 
-export interface TaskTimedOut extends _smithy.SmithyException, $MetadataBearer {
+export interface TaskTimedOut extends __SmithyException, $MetadataBearer {
   name: "TaskTimedOut";
   $fault: "client";
   message?: string;
@@ -2583,7 +2578,7 @@ export interface TaskTimedOut extends _smithy.SmithyException, $MetadataBearer {
 
 export namespace TaskTimedOut {
   export function isa(o: any): o is TaskTimedOut {
-    return _smithy.isa(o, "TaskTimedOut");
+    return __isa(o, "TaskTimedOut");
   }
 }
 
@@ -2591,7 +2586,7 @@ export namespace TaskTimedOut {
  * <p>You've exceeded the number of tags allowed for a resource. See the <a href="https://docs.aws.amazon.com/step-functions/latest/dg/limits.html"> Limits Topic</a> in the
  *       AWS Step Functions Developer Guide.</p>
  */
-export interface TooManyTags extends _smithy.SmithyException, $MetadataBearer {
+export interface TooManyTags extends __SmithyException, $MetadataBearer {
   name: "TooManyTags";
   $fault: "client";
   message?: string;
@@ -2600,7 +2595,7 @@ export interface TooManyTags extends _smithy.SmithyException, $MetadataBearer {
 
 export namespace TooManyTags {
   export function isa(o: any): o is TooManyTags {
-    return _smithy.isa(o, "TooManyTags");
+    return __isa(o, "TooManyTags");
   }
 }
 
@@ -2619,7 +2614,7 @@ export interface UntagResourceInput {
 
 export namespace UntagResourceInput {
   export function isa(o: any): o is UntagResourceInput {
-    return _smithy.isa(o, "UntagResourceInput");
+    return __isa(o, "UntagResourceInput");
   }
 }
 
@@ -2629,7 +2624,7 @@ export interface UntagResourceOutput extends $MetadataBearer {
 
 export namespace UntagResourceOutput {
   export function isa(o: any): o is UntagResourceOutput {
-    return _smithy.isa(o, "UntagResourceOutput");
+    return __isa(o, "UntagResourceOutput");
   }
 }
 
@@ -2658,7 +2653,7 @@ export interface UpdateStateMachineInput {
 
 export namespace UpdateStateMachineInput {
   export function isa(o: any): o is UpdateStateMachineInput {
-    return _smithy.isa(o, "UpdateStateMachineInput");
+    return __isa(o, "UpdateStateMachineInput");
   }
 }
 
@@ -2672,6 +2667,6 @@ export interface UpdateStateMachineOutput extends $MetadataBearer {
 
 export namespace UpdateStateMachineOutput {
   export function isa(o: any): o is UpdateStateMachineOutput {
-    return _smithy.isa(o, "UpdateStateMachineOutput");
+    return __isa(o, "UpdateStateMachineOutput");
   }
 }

--- a/clients/client-shield/models/index.ts
+++ b/clients/client-shield/models/index.ts
@@ -1,11 +1,14 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
  * <p>Exception that indicates the specified <code>AttackId</code> does not exist, or the requester does not have the appropriate permissions to access the <code>AttackId</code>.</p>
  */
 export interface AccessDeniedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AccessDeniedException";
   $fault: "client";
@@ -14,7 +17,7 @@ export interface AccessDeniedException
 
 export namespace AccessDeniedException {
   export function isa(o: any): o is AccessDeniedException {
-    return _smithy.isa(o, "AccessDeniedException");
+    return __isa(o, "AccessDeniedException");
   }
 }
 
@@ -22,7 +25,7 @@ export namespace AccessDeniedException {
  * <p>In order to grant the necessary access to the DDoS Response Team, the user submitting  <code>AssociateDRTRole</code> must have the <code>iam:PassRole</code> permission. This error indicates the user did not have the appropriate permissions. For more information, see <a href="https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_passrole.html">Granting a User Permissions to Pass a Role to an AWS Service</a>. </p>
  */
 export interface AccessDeniedForDependencyException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AccessDeniedForDependencyException";
   $fault: "client";
@@ -31,7 +34,7 @@ export interface AccessDeniedForDependencyException
 
 export namespace AccessDeniedForDependencyException {
   export function isa(o: any): o is AccessDeniedForDependencyException {
-    return _smithy.isa(o, "AccessDeniedForDependencyException");
+    return __isa(o, "AccessDeniedForDependencyException");
   }
 }
 
@@ -45,7 +48,7 @@ export interface AssociateDRTLogBucketRequest {
 
 export namespace AssociateDRTLogBucketRequest {
   export function isa(o: any): o is AssociateDRTLogBucketRequest {
-    return _smithy.isa(o, "AssociateDRTLogBucketRequest");
+    return __isa(o, "AssociateDRTLogBucketRequest");
   }
 }
 
@@ -55,7 +58,7 @@ export interface AssociateDRTLogBucketResponse extends $MetadataBearer {
 
 export namespace AssociateDRTLogBucketResponse {
   export function isa(o: any): o is AssociateDRTLogBucketResponse {
-    return _smithy.isa(o, "AssociateDRTLogBucketResponse");
+    return __isa(o, "AssociateDRTLogBucketResponse");
   }
 }
 
@@ -70,7 +73,7 @@ export interface AssociateDRTRoleRequest {
 
 export namespace AssociateDRTRoleRequest {
   export function isa(o: any): o is AssociateDRTRoleRequest {
-    return _smithy.isa(o, "AssociateDRTRoleRequest");
+    return __isa(o, "AssociateDRTRoleRequest");
   }
 }
 
@@ -80,7 +83,7 @@ export interface AssociateDRTRoleResponse extends $MetadataBearer {
 
 export namespace AssociateDRTRoleResponse {
   export function isa(o: any): o is AssociateDRTRoleResponse {
-    return _smithy.isa(o, "AssociateDRTRoleResponse");
+    return __isa(o, "AssociateDRTRoleResponse");
   }
 }
 
@@ -133,7 +136,7 @@ export interface AttackDetail {
 
 export namespace AttackDetail {
   export function isa(o: any): o is AttackDetail {
-    return _smithy.isa(o, "AttackDetail");
+    return __isa(o, "AttackDetail");
   }
 }
 
@@ -179,7 +182,7 @@ export interface AttackProperty {
 
 export namespace AttackProperty {
   export function isa(o: any): o is AttackProperty {
-    return _smithy.isa(o, "AttackProperty");
+    return __isa(o, "AttackProperty");
   }
 }
 
@@ -227,7 +230,7 @@ export interface AttackSummary {
 
 export namespace AttackSummary {
   export function isa(o: any): o is AttackSummary {
-    return _smithy.isa(o, "AttackSummary");
+    return __isa(o, "AttackSummary");
   }
 }
 
@@ -300,7 +303,7 @@ export interface AttackVectorDescription {
 
 export namespace AttackVectorDescription {
   export function isa(o: any): o is AttackVectorDescription {
-    return _smithy.isa(o, "AttackVectorDescription");
+    return __isa(o, "AttackVectorDescription");
   }
 }
 
@@ -327,7 +330,7 @@ export interface Contributor {
 
 export namespace Contributor {
   export function isa(o: any): o is Contributor {
-    return _smithy.isa(o, "Contributor");
+    return __isa(o, "Contributor");
   }
 }
 
@@ -379,7 +382,7 @@ export interface CreateProtectionRequest {
 
 export namespace CreateProtectionRequest {
   export function isa(o: any): o is CreateProtectionRequest {
-    return _smithy.isa(o, "CreateProtectionRequest");
+    return __isa(o, "CreateProtectionRequest");
   }
 }
 
@@ -394,7 +397,7 @@ export interface CreateProtectionResponse extends $MetadataBearer {
 
 export namespace CreateProtectionResponse {
   export function isa(o: any): o is CreateProtectionResponse {
-    return _smithy.isa(o, "CreateProtectionResponse");
+    return __isa(o, "CreateProtectionResponse");
   }
 }
 
@@ -404,7 +407,7 @@ export interface CreateSubscriptionRequest {
 
 export namespace CreateSubscriptionRequest {
   export function isa(o: any): o is CreateSubscriptionRequest {
-    return _smithy.isa(o, "CreateSubscriptionRequest");
+    return __isa(o, "CreateSubscriptionRequest");
   }
 }
 
@@ -414,7 +417,7 @@ export interface CreateSubscriptionResponse extends $MetadataBearer {
 
 export namespace CreateSubscriptionResponse {
   export function isa(o: any): o is CreateSubscriptionResponse {
-    return _smithy.isa(o, "CreateSubscriptionResponse");
+    return __isa(o, "CreateSubscriptionResponse");
   }
 }
 
@@ -429,7 +432,7 @@ export interface DeleteProtectionRequest {
 
 export namespace DeleteProtectionRequest {
   export function isa(o: any): o is DeleteProtectionRequest {
-    return _smithy.isa(o, "DeleteProtectionRequest");
+    return __isa(o, "DeleteProtectionRequest");
   }
 }
 
@@ -439,7 +442,7 @@ export interface DeleteProtectionResponse extends $MetadataBearer {
 
 export namespace DeleteProtectionResponse {
   export function isa(o: any): o is DeleteProtectionResponse {
-    return _smithy.isa(o, "DeleteProtectionResponse");
+    return __isa(o, "DeleteProtectionResponse");
   }
 }
 
@@ -449,7 +452,7 @@ export interface DeleteSubscriptionRequest {
 
 export namespace DeleteSubscriptionRequest {
   export function isa(o: any): o is DeleteSubscriptionRequest {
-    return _smithy.isa(o, "DeleteSubscriptionRequest");
+    return __isa(o, "DeleteSubscriptionRequest");
   }
 }
 
@@ -459,7 +462,7 @@ export interface DeleteSubscriptionResponse extends $MetadataBearer {
 
 export namespace DeleteSubscriptionResponse {
   export function isa(o: any): o is DeleteSubscriptionResponse {
-    return _smithy.isa(o, "DeleteSubscriptionResponse");
+    return __isa(o, "DeleteSubscriptionResponse");
   }
 }
 
@@ -473,7 +476,7 @@ export interface DescribeAttackRequest {
 
 export namespace DescribeAttackRequest {
   export function isa(o: any): o is DescribeAttackRequest {
-    return _smithy.isa(o, "DescribeAttackRequest");
+    return __isa(o, "DescribeAttackRequest");
   }
 }
 
@@ -487,7 +490,7 @@ export interface DescribeAttackResponse extends $MetadataBearer {
 
 export namespace DescribeAttackResponse {
   export function isa(o: any): o is DescribeAttackResponse {
-    return _smithy.isa(o, "DescribeAttackResponse");
+    return __isa(o, "DescribeAttackResponse");
   }
 }
 
@@ -497,7 +500,7 @@ export interface DescribeDRTAccessRequest {
 
 export namespace DescribeDRTAccessRequest {
   export function isa(o: any): o is DescribeDRTAccessRequest {
-    return _smithy.isa(o, "DescribeDRTAccessRequest");
+    return __isa(o, "DescribeDRTAccessRequest");
   }
 }
 
@@ -516,7 +519,7 @@ export interface DescribeDRTAccessResponse extends $MetadataBearer {
 
 export namespace DescribeDRTAccessResponse {
   export function isa(o: any): o is DescribeDRTAccessResponse {
-    return _smithy.isa(o, "DescribeDRTAccessResponse");
+    return __isa(o, "DescribeDRTAccessResponse");
   }
 }
 
@@ -526,7 +529,7 @@ export interface DescribeEmergencyContactSettingsRequest {
 
 export namespace DescribeEmergencyContactSettingsRequest {
   export function isa(o: any): o is DescribeEmergencyContactSettingsRequest {
-    return _smithy.isa(o, "DescribeEmergencyContactSettingsRequest");
+    return __isa(o, "DescribeEmergencyContactSettingsRequest");
   }
 }
 
@@ -541,7 +544,7 @@ export interface DescribeEmergencyContactSettingsResponse
 
 export namespace DescribeEmergencyContactSettingsResponse {
   export function isa(o: any): o is DescribeEmergencyContactSettingsResponse {
-    return _smithy.isa(o, "DescribeEmergencyContactSettingsResponse");
+    return __isa(o, "DescribeEmergencyContactSettingsResponse");
   }
 }
 
@@ -562,7 +565,7 @@ export interface DescribeProtectionRequest {
 
 export namespace DescribeProtectionRequest {
   export function isa(o: any): o is DescribeProtectionRequest {
-    return _smithy.isa(o, "DescribeProtectionRequest");
+    return __isa(o, "DescribeProtectionRequest");
   }
 }
 
@@ -576,7 +579,7 @@ export interface DescribeProtectionResponse extends $MetadataBearer {
 
 export namespace DescribeProtectionResponse {
   export function isa(o: any): o is DescribeProtectionResponse {
-    return _smithy.isa(o, "DescribeProtectionResponse");
+    return __isa(o, "DescribeProtectionResponse");
   }
 }
 
@@ -586,7 +589,7 @@ export interface DescribeSubscriptionRequest {
 
 export namespace DescribeSubscriptionRequest {
   export function isa(o: any): o is DescribeSubscriptionRequest {
-    return _smithy.isa(o, "DescribeSubscriptionRequest");
+    return __isa(o, "DescribeSubscriptionRequest");
   }
 }
 
@@ -600,7 +603,7 @@ export interface DescribeSubscriptionResponse extends $MetadataBearer {
 
 export namespace DescribeSubscriptionResponse {
   export function isa(o: any): o is DescribeSubscriptionResponse {
-    return _smithy.isa(o, "DescribeSubscriptionResponse");
+    return __isa(o, "DescribeSubscriptionResponse");
   }
 }
 
@@ -614,7 +617,7 @@ export interface DisassociateDRTLogBucketRequest {
 
 export namespace DisassociateDRTLogBucketRequest {
   export function isa(o: any): o is DisassociateDRTLogBucketRequest {
-    return _smithy.isa(o, "DisassociateDRTLogBucketRequest");
+    return __isa(o, "DisassociateDRTLogBucketRequest");
   }
 }
 
@@ -624,7 +627,7 @@ export interface DisassociateDRTLogBucketResponse extends $MetadataBearer {
 
 export namespace DisassociateDRTLogBucketResponse {
   export function isa(o: any): o is DisassociateDRTLogBucketResponse {
-    return _smithy.isa(o, "DisassociateDRTLogBucketResponse");
+    return __isa(o, "DisassociateDRTLogBucketResponse");
   }
 }
 
@@ -634,7 +637,7 @@ export interface DisassociateDRTRoleRequest {
 
 export namespace DisassociateDRTRoleRequest {
   export function isa(o: any): o is DisassociateDRTRoleRequest {
-    return _smithy.isa(o, "DisassociateDRTRoleRequest");
+    return __isa(o, "DisassociateDRTRoleRequest");
   }
 }
 
@@ -644,7 +647,7 @@ export interface DisassociateDRTRoleResponse extends $MetadataBearer {
 
 export namespace DisassociateDRTRoleResponse {
   export function isa(o: any): o is DisassociateDRTRoleResponse {
-    return _smithy.isa(o, "DisassociateDRTRoleResponse");
+    return __isa(o, "DisassociateDRTRoleResponse");
   }
 }
 
@@ -661,7 +664,7 @@ export interface EmergencyContact {
 
 export namespace EmergencyContact {
   export function isa(o: any): o is EmergencyContact {
-    return _smithy.isa(o, "EmergencyContact");
+    return __isa(o, "EmergencyContact");
   }
 }
 
@@ -671,7 +674,7 @@ export interface GetSubscriptionStateRequest {
 
 export namespace GetSubscriptionStateRequest {
   export function isa(o: any): o is GetSubscriptionStateRequest {
-    return _smithy.isa(o, "GetSubscriptionStateRequest");
+    return __isa(o, "GetSubscriptionStateRequest");
   }
 }
 
@@ -685,7 +688,7 @@ export interface GetSubscriptionStateResponse extends $MetadataBearer {
 
 export namespace GetSubscriptionStateResponse {
   export function isa(o: any): o is GetSubscriptionStateResponse {
-    return _smithy.isa(o, "GetSubscriptionStateResponse");
+    return __isa(o, "GetSubscriptionStateResponse");
   }
 }
 
@@ -694,7 +697,7 @@ export namespace GetSubscriptionStateResponse {
  *          can retry the request.</p>
  */
 export interface InternalErrorException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalErrorException";
   $fault: "server";
@@ -703,7 +706,7 @@ export interface InternalErrorException
 
 export namespace InternalErrorException {
   export function isa(o: any): o is InternalErrorException {
-    return _smithy.isa(o, "InternalErrorException");
+    return __isa(o, "InternalErrorException");
   }
 }
 
@@ -711,7 +714,7 @@ export namespace InternalErrorException {
  * <p>Exception that indicates that the operation would not cause any change to occur.</p>
  */
 export interface InvalidOperationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidOperationException";
   $fault: "client";
@@ -720,7 +723,7 @@ export interface InvalidOperationException
 
 export namespace InvalidOperationException {
   export function isa(o: any): o is InvalidOperationException {
-    return _smithy.isa(o, "InvalidOperationException");
+    return __isa(o, "InvalidOperationException");
   }
 }
 
@@ -728,7 +731,7 @@ export namespace InvalidOperationException {
  * <p>Exception that indicates that the NextToken specified in the request is invalid. Submit the request using the NextToken value that was returned in the response.</p>
  */
 export interface InvalidPaginationTokenException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidPaginationTokenException";
   $fault: "client";
@@ -737,7 +740,7 @@ export interface InvalidPaginationTokenException
 
 export namespace InvalidPaginationTokenException {
   export function isa(o: any): o is InvalidPaginationTokenException {
-    return _smithy.isa(o, "InvalidPaginationTokenException");
+    return __isa(o, "InvalidPaginationTokenException");
   }
 }
 
@@ -745,7 +748,7 @@ export namespace InvalidPaginationTokenException {
  * <p>Exception that indicates that the parameters passed to the API are invalid. </p>
  */
 export interface InvalidParameterException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidParameterException";
   $fault: "client";
@@ -754,7 +757,7 @@ export interface InvalidParameterException
 
 export namespace InvalidParameterException {
   export function isa(o: any): o is InvalidParameterException {
-    return _smithy.isa(o, "InvalidParameterException");
+    return __isa(o, "InvalidParameterException");
   }
 }
 
@@ -762,7 +765,7 @@ export namespace InvalidParameterException {
  * <p>Exception that indicates that the resource is invalid. You might not have access to the resource, or the resource might not exist.</p>
  */
 export interface InvalidResourceException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidResourceException";
   $fault: "client";
@@ -771,7 +774,7 @@ export interface InvalidResourceException
 
 export namespace InvalidResourceException {
   export function isa(o: any): o is InvalidResourceException {
-    return _smithy.isa(o, "InvalidResourceException");
+    return __isa(o, "InvalidResourceException");
   }
 }
 
@@ -793,7 +796,7 @@ export interface Limit {
 
 export namespace Limit {
   export function isa(o: any): o is Limit {
-    return _smithy.isa(o, "Limit");
+    return __isa(o, "Limit");
   }
 }
 
@@ -805,7 +808,7 @@ export namespace Limit {
  *             <code>Limit</code> is the threshold that would be exceeded.</p>
  */
 export interface LimitsExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitsExceededException";
   $fault: "client";
@@ -816,7 +819,7 @@ export interface LimitsExceededException
 
 export namespace LimitsExceededException {
   export function isa(o: any): o is LimitsExceededException {
-    return _smithy.isa(o, "LimitsExceededException");
+    return __isa(o, "LimitsExceededException");
   }
 }
 
@@ -852,7 +855,7 @@ export interface ListAttacksRequest {
 
 export namespace ListAttacksRequest {
   export function isa(o: any): o is ListAttacksRequest {
-    return _smithy.isa(o, "ListAttacksRequest");
+    return __isa(o, "ListAttacksRequest");
   }
 }
 
@@ -875,7 +878,7 @@ export interface ListAttacksResponse extends $MetadataBearer {
 
 export namespace ListAttacksResponse {
   export function isa(o: any): o is ListAttacksResponse {
-    return _smithy.isa(o, "ListAttacksResponse");
+    return __isa(o, "ListAttacksResponse");
   }
 }
 
@@ -896,7 +899,7 @@ export interface ListProtectionsRequest {
 
 export namespace ListProtectionsRequest {
   export function isa(o: any): o is ListProtectionsRequest {
-    return _smithy.isa(o, "ListProtectionsRequest");
+    return __isa(o, "ListProtectionsRequest");
   }
 }
 
@@ -916,7 +919,7 @@ export interface ListProtectionsResponse extends $MetadataBearer {
 
 export namespace ListProtectionsResponse {
   export function isa(o: any): o is ListProtectionsResponse {
-    return _smithy.isa(o, "ListProtectionsResponse");
+    return __isa(o, "ListProtectionsResponse");
   }
 }
 
@@ -924,7 +927,7 @@ export namespace ListProtectionsResponse {
  * <p>You are trying to update a subscription that has not yet completed the 1-year commitment. You can change the <code>AutoRenew</code> parameter during the last 30 days of your subscription. This exception indicates that you are attempting to change <code>AutoRenew</code> prior to that period.</p>
  */
 export interface LockedSubscriptionException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LockedSubscriptionException";
   $fault: "client";
@@ -933,7 +936,7 @@ export interface LockedSubscriptionException
 
 export namespace LockedSubscriptionException {
   export function isa(o: any): o is LockedSubscriptionException {
-    return _smithy.isa(o, "LockedSubscriptionException");
+    return __isa(o, "LockedSubscriptionException");
   }
 }
 
@@ -950,7 +953,7 @@ export interface Mitigation {
 
 export namespace Mitigation {
   export function isa(o: any): o is Mitigation {
-    return _smithy.isa(o, "Mitigation");
+    return __isa(o, "Mitigation");
   }
 }
 
@@ -958,7 +961,7 @@ export namespace Mitigation {
  * <p>The ARN of the role that you specifed does not exist.</p>
  */
 export interface NoAssociatedRoleException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "NoAssociatedRoleException";
   $fault: "client";
@@ -967,7 +970,7 @@ export interface NoAssociatedRoleException
 
 export namespace NoAssociatedRoleException {
   export function isa(o: any): o is NoAssociatedRoleException {
-    return _smithy.isa(o, "NoAssociatedRoleException");
+    return __isa(o, "NoAssociatedRoleException");
   }
 }
 
@@ -976,7 +979,7 @@ export namespace NoAssociatedRoleException {
  *          client. You can retry the request.</p>
  */
 export interface OptimisticLockException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "OptimisticLockException";
   $fault: "client";
@@ -985,7 +988,7 @@ export interface OptimisticLockException
 
 export namespace OptimisticLockException {
   export function isa(o: any): o is OptimisticLockException {
-    return _smithy.isa(o, "OptimisticLockException");
+    return __isa(o, "OptimisticLockException");
   }
 }
 
@@ -1012,7 +1015,7 @@ export interface Protection {
 
 export namespace Protection {
   export function isa(o: any): o is Protection {
-    return _smithy.isa(o, "Protection");
+    return __isa(o, "Protection");
   }
 }
 
@@ -1020,7 +1023,7 @@ export namespace Protection {
  * <p>Exception indicating the specified resource already exists.</p>
  */
 export interface ResourceAlreadyExistsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceAlreadyExistsException";
   $fault: "client";
@@ -1029,7 +1032,7 @@ export interface ResourceAlreadyExistsException
 
 export namespace ResourceAlreadyExistsException {
   export function isa(o: any): o is ResourceAlreadyExistsException {
-    return _smithy.isa(o, "ResourceAlreadyExistsException");
+    return __isa(o, "ResourceAlreadyExistsException");
   }
 }
 
@@ -1037,7 +1040,7 @@ export namespace ResourceAlreadyExistsException {
  * <p>Exception indicating the specified resource does not exist.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -1046,7 +1049,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -1078,7 +1081,7 @@ export interface SubResourceSummary {
 
 export namespace SubResourceSummary {
   export function isa(o: any): o is SubResourceSummary {
-    return _smithy.isa(o, "SubResourceSummary");
+    return __isa(o, "SubResourceSummary");
   }
 }
 
@@ -1121,7 +1124,7 @@ export interface Subscription {
 
 export namespace Subscription {
   export function isa(o: any): o is Subscription {
-    return _smithy.isa(o, "Subscription");
+    return __isa(o, "Subscription");
   }
 }
 
@@ -1148,7 +1151,7 @@ export interface SummarizedAttackVector {
 
 export namespace SummarizedAttackVector {
   export function isa(o: any): o is SummarizedAttackVector {
-    return _smithy.isa(o, "SummarizedAttackVector");
+    return __isa(o, "SummarizedAttackVector");
   }
 }
 
@@ -1190,7 +1193,7 @@ export interface SummarizedCounter {
 
 export namespace SummarizedCounter {
   export function isa(o: any): o is SummarizedCounter {
-    return _smithy.isa(o, "SummarizedCounter");
+    return __isa(o, "SummarizedCounter");
   }
 }
 
@@ -1212,7 +1215,7 @@ export interface TimeRange {
 
 export namespace TimeRange {
   export function isa(o: any): o is TimeRange {
-    return _smithy.isa(o, "TimeRange");
+    return __isa(o, "TimeRange");
   }
 }
 
@@ -1233,7 +1236,7 @@ export interface UpdateEmergencyContactSettingsRequest {
 
 export namespace UpdateEmergencyContactSettingsRequest {
   export function isa(o: any): o is UpdateEmergencyContactSettingsRequest {
-    return _smithy.isa(o, "UpdateEmergencyContactSettingsRequest");
+    return __isa(o, "UpdateEmergencyContactSettingsRequest");
   }
 }
 
@@ -1244,7 +1247,7 @@ export interface UpdateEmergencyContactSettingsResponse
 
 export namespace UpdateEmergencyContactSettingsResponse {
   export function isa(o: any): o is UpdateEmergencyContactSettingsResponse {
-    return _smithy.isa(o, "UpdateEmergencyContactSettingsResponse");
+    return __isa(o, "UpdateEmergencyContactSettingsResponse");
   }
 }
 
@@ -1258,7 +1261,7 @@ export interface UpdateSubscriptionRequest {
 
 export namespace UpdateSubscriptionRequest {
   export function isa(o: any): o is UpdateSubscriptionRequest {
-    return _smithy.isa(o, "UpdateSubscriptionRequest");
+    return __isa(o, "UpdateSubscriptionRequest");
   }
 }
 
@@ -1268,6 +1271,6 @@ export interface UpdateSubscriptionResponse extends $MetadataBearer {
 
 export namespace UpdateSubscriptionResponse {
   export function isa(o: any): o is UpdateSubscriptionResponse {
-    return _smithy.isa(o, "UpdateSubscriptionResponse");
+    return __isa(o, "UpdateSubscriptionResponse");
   }
 }

--- a/clients/client-signer/models/index.ts
+++ b/clients/client-signer/models/index.ts
@@ -1,11 +1,14 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
  * <p>You do not have sufficient access to perform this action.</p>
  */
 export interface AccessDeniedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AccessDeniedException";
   $fault: "client";
@@ -14,7 +17,7 @@ export interface AccessDeniedException
 
 export namespace AccessDeniedException {
   export function isa(o: any): o is AccessDeniedException {
-    return _smithy.isa(o, "AccessDeniedException");
+    return __isa(o, "AccessDeniedException");
   }
 }
 
@@ -25,7 +28,7 @@ export namespace AccessDeniedException {
  * 			profile.</p>
  */
 export interface BadRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "BadRequestException";
   $fault: "client";
@@ -34,7 +37,7 @@ export interface BadRequestException
 
 export namespace BadRequestException {
   export function isa(o: any): o is BadRequestException {
-    return _smithy.isa(o, "BadRequestException");
+    return __isa(o, "BadRequestException");
   }
 }
 
@@ -48,7 +51,7 @@ export interface CancelSigningProfileRequest {
 
 export namespace CancelSigningProfileRequest {
   export function isa(o: any): o is CancelSigningProfileRequest {
-    return _smithy.isa(o, "CancelSigningProfileRequest");
+    return __isa(o, "CancelSigningProfileRequest");
   }
 }
 
@@ -64,7 +67,7 @@ export interface DescribeSigningJobRequest {
 
 export namespace DescribeSigningJobRequest {
   export function isa(o: any): o is DescribeSigningJobRequest {
-    return _smithy.isa(o, "DescribeSigningJobRequest");
+    return __isa(o, "DescribeSigningJobRequest");
   }
 }
 
@@ -140,7 +143,7 @@ export interface DescribeSigningJobResponse extends $MetadataBearer {
 
 export namespace DescribeSigningJobResponse {
   export function isa(o: any): o is DescribeSigningJobResponse {
-    return _smithy.isa(o, "DescribeSigningJobResponse");
+    return __isa(o, "DescribeSigningJobResponse");
   }
 }
 
@@ -158,7 +161,7 @@ export interface Destination {
 
 export namespace Destination {
   export function isa(o: any): o is Destination {
-    return _smithy.isa(o, "Destination");
+    return __isa(o, "Destination");
   }
 }
 
@@ -182,7 +185,7 @@ export interface EncryptionAlgorithmOptions {
 
 export namespace EncryptionAlgorithmOptions {
   export function isa(o: any): o is EncryptionAlgorithmOptions {
-    return _smithy.isa(o, "EncryptionAlgorithmOptions");
+    return __isa(o, "EncryptionAlgorithmOptions");
   }
 }
 
@@ -196,7 +199,7 @@ export interface GetSigningPlatformRequest {
 
 export namespace GetSigningPlatformRequest {
   export function isa(o: any): o is GetSigningPlatformRequest {
-    return _smithy.isa(o, "GetSigningPlatformRequest");
+    return __isa(o, "GetSigningPlatformRequest");
   }
 }
 
@@ -246,7 +249,7 @@ export interface GetSigningPlatformResponse extends $MetadataBearer {
 
 export namespace GetSigningPlatformResponse {
   export function isa(o: any): o is GetSigningPlatformResponse {
-    return _smithy.isa(o, "GetSigningPlatformResponse");
+    return __isa(o, "GetSigningPlatformResponse");
   }
 }
 
@@ -260,7 +263,7 @@ export interface GetSigningProfileRequest {
 
 export namespace GetSigningProfileRequest {
   export function isa(o: any): o is GetSigningProfileRequest {
-    return _smithy.isa(o, "GetSigningProfileRequest");
+    return __isa(o, "GetSigningProfileRequest");
   }
 }
 
@@ -315,7 +318,7 @@ export interface GetSigningProfileResponse extends $MetadataBearer {
 
 export namespace GetSigningProfileResponse {
   export function isa(o: any): o is GetSigningProfileResponse {
-    return _smithy.isa(o, "GetSigningProfileResponse");
+    return __isa(o, "GetSigningProfileResponse");
   }
 }
 
@@ -339,7 +342,7 @@ export interface HashAlgorithmOptions {
 
 export namespace HashAlgorithmOptions {
   export function isa(o: any): o is HashAlgorithmOptions {
-    return _smithy.isa(o, "HashAlgorithmOptions");
+    return __isa(o, "HashAlgorithmOptions");
   }
 }
 
@@ -349,7 +352,7 @@ export type ImageFormat = "JSON";
  * <p>An internal error occurred.</p>
  */
 export interface InternalServiceErrorException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalServiceErrorException";
   $fault: "server";
@@ -358,7 +361,7 @@ export interface InternalServiceErrorException
 
 export namespace InternalServiceErrorException {
   export function isa(o: any): o is InternalServiceErrorException {
-    return _smithy.isa(o, "InternalServiceErrorException");
+    return __isa(o, "InternalServiceErrorException");
   }
 }
 
@@ -399,7 +402,7 @@ export interface ListSigningJobsRequest {
 
 export namespace ListSigningJobsRequest {
   export function isa(o: any): o is ListSigningJobsRequest {
-    return _smithy.isa(o, "ListSigningJobsRequest");
+    return __isa(o, "ListSigningJobsRequest");
   }
 }
 
@@ -418,7 +421,7 @@ export interface ListSigningJobsResponse extends $MetadataBearer {
 
 export namespace ListSigningJobsResponse {
   export function isa(o: any): o is ListSigningJobsResponse {
-    return _smithy.isa(o, "ListSigningJobsResponse");
+    return __isa(o, "ListSigningJobsResponse");
   }
 }
 
@@ -454,7 +457,7 @@ export interface ListSigningPlatformsRequest {
 
 export namespace ListSigningPlatformsRequest {
   export function isa(o: any): o is ListSigningPlatformsRequest {
-    return _smithy.isa(o, "ListSigningPlatformsRequest");
+    return __isa(o, "ListSigningPlatformsRequest");
   }
 }
 
@@ -473,7 +476,7 @@ export interface ListSigningPlatformsResponse extends $MetadataBearer {
 
 export namespace ListSigningPlatformsResponse {
   export function isa(o: any): o is ListSigningPlatformsResponse {
-    return _smithy.isa(o, "ListSigningPlatformsResponse");
+    return __isa(o, "ListSigningPlatformsResponse");
   }
 }
 
@@ -500,7 +503,7 @@ export interface ListSigningProfilesRequest {
 
 export namespace ListSigningProfilesRequest {
   export function isa(o: any): o is ListSigningProfilesRequest {
-    return _smithy.isa(o, "ListSigningProfilesRequest");
+    return __isa(o, "ListSigningProfilesRequest");
   }
 }
 
@@ -521,7 +524,7 @@ export interface ListSigningProfilesResponse extends $MetadataBearer {
 
 export namespace ListSigningProfilesResponse {
   export function isa(o: any): o is ListSigningProfilesResponse {
-    return _smithy.isa(o, "ListSigningProfilesResponse");
+    return __isa(o, "ListSigningProfilesResponse");
   }
 }
 
@@ -537,7 +540,7 @@ export interface ListTagsForResourceRequest {
 
 export namespace ListTagsForResourceRequest {
   export function isa(o: any): o is ListTagsForResourceRequest {
-    return _smithy.isa(o, "ListTagsForResourceRequest");
+    return __isa(o, "ListTagsForResourceRequest");
   }
 }
 
@@ -553,7 +556,7 @@ export interface ListTagsForResourceResponse extends $MetadataBearer {
 
 export namespace ListTagsForResourceResponse {
   export function isa(o: any): o is ListTagsForResourceResponse {
-    return _smithy.isa(o, "ListTagsForResourceResponse");
+    return __isa(o, "ListTagsForResourceResponse");
   }
 }
 
@@ -562,9 +565,7 @@ export namespace ListTagsForResourceResponse {
  * 			profile was not
  * 			found.</p>
  */
-export interface NotFoundException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface NotFoundException extends __SmithyException, $MetadataBearer {
   name: "NotFoundException";
   $fault: "client";
   message?: string;
@@ -572,7 +573,7 @@ export interface NotFoundException
 
 export namespace NotFoundException {
   export function isa(o: any): o is NotFoundException {
-    return _smithy.isa(o, "NotFoundException");
+    return __isa(o, "NotFoundException");
   }
 }
 
@@ -617,7 +618,7 @@ export interface PutSigningProfileRequest {
 
 export namespace PutSigningProfileRequest {
   export function isa(o: any): o is PutSigningProfileRequest {
-    return _smithy.isa(o, "PutSigningProfileRequest");
+    return __isa(o, "PutSigningProfileRequest");
   }
 }
 
@@ -631,7 +632,7 @@ export interface PutSigningProfileResponse extends $MetadataBearer {
 
 export namespace PutSigningProfileResponse {
   export function isa(o: any): o is PutSigningProfileResponse {
-    return _smithy.isa(o, "PutSigningProfileResponse");
+    return __isa(o, "PutSigningProfileResponse");
   }
 }
 
@@ -639,7 +640,7 @@ export namespace PutSigningProfileResponse {
  * <p>A specified resource could not be found.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -648,7 +649,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -671,7 +672,7 @@ export interface S3Destination {
 
 export namespace S3Destination {
   export function isa(o: any): o is S3Destination {
-    return _smithy.isa(o, "S3Destination");
+    return __isa(o, "S3Destination");
   }
 }
 
@@ -693,7 +694,7 @@ export interface S3SignedObject {
 
 export namespace S3SignedObject {
   export function isa(o: any): o is S3SignedObject {
-    return _smithy.isa(o, "S3SignedObject");
+    return __isa(o, "S3SignedObject");
   }
 }
 
@@ -720,7 +721,7 @@ export interface S3Source {
 
 export namespace S3Source {
   export function isa(o: any): o is S3Source {
-    return _smithy.isa(o, "S3Source");
+    return __isa(o, "S3Source");
   }
 }
 
@@ -738,7 +739,7 @@ export interface SignedObject {
 
 export namespace SignedObject {
   export function isa(o: any): o is SignedObject {
-    return _smithy.isa(o, "SignedObject");
+    return __isa(o, "SignedObject");
   }
 }
 
@@ -760,7 +761,7 @@ export interface SigningConfiguration {
 
 export namespace SigningConfiguration {
   export function isa(o: any): o is SigningConfiguration {
-    return _smithy.isa(o, "SigningConfiguration");
+    return __isa(o, "SigningConfiguration");
   }
 }
 
@@ -785,7 +786,7 @@ export interface SigningConfigurationOverrides {
 
 export namespace SigningConfigurationOverrides {
   export function isa(o: any): o is SigningConfigurationOverrides {
-    return _smithy.isa(o, "SigningConfigurationOverrides");
+    return __isa(o, "SigningConfigurationOverrides");
   }
 }
 
@@ -807,7 +808,7 @@ export interface SigningImageFormat {
 
 export namespace SigningImageFormat {
   export function isa(o: any): o is SigningImageFormat {
-    return _smithy.isa(o, "SigningImageFormat");
+    return __isa(o, "SigningImageFormat");
   }
 }
 
@@ -852,7 +853,7 @@ export interface SigningJob {
 
 export namespace SigningJob {
   export function isa(o: any): o is SigningJob {
-    return _smithy.isa(o, "SigningJob");
+    return __isa(o, "SigningJob");
   }
 }
 
@@ -870,7 +871,7 @@ export interface SigningMaterial {
 
 export namespace SigningMaterial {
   export function isa(o: any): o is SigningMaterial {
-    return _smithy.isa(o, "SigningMaterial");
+    return __isa(o, "SigningMaterial");
   }
 }
 
@@ -924,7 +925,7 @@ export interface SigningPlatform {
 
 export namespace SigningPlatform {
   export function isa(o: any): o is SigningPlatform {
-    return _smithy.isa(o, "SigningPlatform");
+    return __isa(o, "SigningPlatform");
   }
 }
 
@@ -943,7 +944,7 @@ export interface SigningPlatformOverrides {
 
 export namespace SigningPlatformOverrides {
   export function isa(o: any): o is SigningPlatformOverrides {
-    return _smithy.isa(o, "SigningPlatformOverrides");
+    return __isa(o, "SigningPlatformOverrides");
   }
 }
 
@@ -997,7 +998,7 @@ export interface SigningProfile {
 
 export namespace SigningProfile {
   export function isa(o: any): o is SigningProfile {
-    return _smithy.isa(o, "SigningProfile");
+    return __isa(o, "SigningProfile");
   }
 }
 
@@ -1019,7 +1020,7 @@ export interface Source {
 
 export namespace Source {
   export function isa(o: any): o is Source {
-    return _smithy.isa(o, "Source");
+    return __isa(o, "Source");
   }
 }
 
@@ -1051,7 +1052,7 @@ export interface StartSigningJobRequest {
 
 export namespace StartSigningJobRequest {
   export function isa(o: any): o is StartSigningJobRequest {
-    return _smithy.isa(o, "StartSigningJobRequest");
+    return __isa(o, "StartSigningJobRequest");
   }
 }
 
@@ -1065,7 +1066,7 @@ export interface StartSigningJobResponse extends $MetadataBearer {
 
 export namespace StartSigningJobResponse {
   export function isa(o: any): o is StartSigningJobResponse {
-    return _smithy.isa(o, "StartSigningJobResponse");
+    return __isa(o, "StartSigningJobResponse");
   }
 }
 
@@ -1088,7 +1089,7 @@ export interface TagResourceRequest {
 
 export namespace TagResourceRequest {
   export function isa(o: any): o is TagResourceRequest {
-    return _smithy.isa(o, "TagResourceRequest");
+    return __isa(o, "TagResourceRequest");
   }
 }
 
@@ -1098,7 +1099,7 @@ export interface TagResourceResponse extends $MetadataBearer {
 
 export namespace TagResourceResponse {
   export function isa(o: any): o is TagResourceResponse {
-    return _smithy.isa(o, "TagResourceResponse");
+    return __isa(o, "TagResourceResponse");
   }
 }
 
@@ -1106,7 +1107,7 @@ export namespace TagResourceResponse {
  * <p>The signing job has been throttled.</p>
  */
 export interface ThrottlingException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ThrottlingException";
   $fault: "client";
@@ -1115,7 +1116,7 @@ export interface ThrottlingException
 
 export namespace ThrottlingException {
   export function isa(o: any): o is ThrottlingException {
-    return _smithy.isa(o, "ThrottlingException");
+    return __isa(o, "ThrottlingException");
   }
 }
 
@@ -1138,7 +1139,7 @@ export interface UntagResourceRequest {
 
 export namespace UntagResourceRequest {
   export function isa(o: any): o is UntagResourceRequest {
-    return _smithy.isa(o, "UntagResourceRequest");
+    return __isa(o, "UntagResourceRequest");
   }
 }
 
@@ -1148,7 +1149,7 @@ export interface UntagResourceResponse extends $MetadataBearer {
 
 export namespace UntagResourceResponse {
   export function isa(o: any): o is UntagResourceResponse {
-    return _smithy.isa(o, "UntagResourceResponse");
+    return __isa(o, "UntagResourceResponse");
   }
 }
 
@@ -1156,7 +1157,7 @@ export namespace UntagResourceResponse {
  * <p>You signing certificate could not be validated.</p>
  */
 export interface ValidationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ValidationException";
   $fault: "client";
@@ -1165,6 +1166,6 @@ export interface ValidationException
 
 export namespace ValidationException {
   export function isa(o: any): o is ValidationException {
-    return _smithy.isa(o, "ValidationException");
+    return __isa(o, "ValidationException");
   }
 }

--- a/clients/client-signer/protocols/Aws_restJson1_1.ts
+++ b/clients/client-signer/protocols/Aws_restJson1_1.ts
@@ -78,7 +78,10 @@ import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  extendedEncodeURIComponent as __extendedEncodeURIComponent
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -95,7 +98,7 @@ export async function serializeAws_restJson1_1CancelSigningProfileCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/signing-profiles/{profileName}";
   if (input.profileName !== undefined) {
-    const labelValue: string = input.profileName.toString();
+    const labelValue: string = input.profileName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: profileName."
@@ -103,7 +106,7 @@ export async function serializeAws_restJson1_1CancelSigningProfileCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{profileName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: profileName.");
@@ -125,13 +128,13 @@ export async function serializeAws_restJson1_1DescribeSigningJobCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/signing-jobs/{jobId}";
   if (input.jobId !== undefined) {
-    const labelValue: string = input.jobId.toString();
+    const labelValue: string = input.jobId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: jobId.");
     }
     resolvedPath = resolvedPath.replace(
       "{jobId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: jobId.");
@@ -153,13 +156,13 @@ export async function serializeAws_restJson1_1GetSigningPlatformCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/signing-platforms/{platformId}";
   if (input.platformId !== undefined) {
-    const labelValue: string = input.platformId.toString();
+    const labelValue: string = input.platformId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: platformId.");
     }
     resolvedPath = resolvedPath.replace(
       "{platformId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: platformId.");
@@ -181,7 +184,7 @@ export async function serializeAws_restJson1_1GetSigningProfileCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/signing-profiles/{profileName}";
   if (input.profileName !== undefined) {
-    const labelValue: string = input.profileName.toString();
+    const labelValue: string = input.profileName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: profileName."
@@ -189,7 +192,7 @@ export async function serializeAws_restJson1_1GetSigningProfileCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{profileName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: profileName.");
@@ -212,19 +215,29 @@ export async function serializeAws_restJson1_1ListSigningJobsCommand(
   let resolvedPath = "/signing-jobs";
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   if (input.platformId !== undefined) {
-    query["platformId"] = input.platformId.toString();
+    query[
+      __extendedEncodeURIComponent("platformId")
+    ] = __extendedEncodeURIComponent(input.platformId);
   }
   if (input.requestedBy !== undefined) {
-    query["requestedBy"] = input.requestedBy.toString();
+    query[
+      __extendedEncodeURIComponent("requestedBy")
+    ] = __extendedEncodeURIComponent(input.requestedBy);
   }
   if (input.status !== undefined) {
-    query["status"] = input.status.toString();
+    query[
+      __extendedEncodeURIComponent("status")
+    ] = __extendedEncodeURIComponent(input.status);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -245,19 +258,29 @@ export async function serializeAws_restJson1_1ListSigningPlatformsCommand(
   let resolvedPath = "/signing-platforms";
   const query: any = {};
   if (input.category !== undefined) {
-    query["category"] = input.category.toString();
+    query[
+      __extendedEncodeURIComponent("category")
+    ] = __extendedEncodeURIComponent(input.category);
   }
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   if (input.partner !== undefined) {
-    query["partner"] = input.partner.toString();
+    query[
+      __extendedEncodeURIComponent("partner")
+    ] = __extendedEncodeURIComponent(input.partner);
   }
   if (input.target !== undefined) {
-    query["target"] = input.target.toString();
+    query[
+      __extendedEncodeURIComponent("target")
+    ] = __extendedEncodeURIComponent(input.target);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -278,13 +301,19 @@ export async function serializeAws_restJson1_1ListSigningProfilesCommand(
   let resolvedPath = "/signing-profiles";
   const query: any = {};
   if (input.includeCanceled !== undefined) {
-    query["includeCanceled"] = input.includeCanceled.toString();
+    query[
+      __extendedEncodeURIComponent("includeCanceled")
+    ] = __extendedEncodeURIComponent(input.includeCanceled.toString());
   }
   if (input.maxResults !== undefined) {
-    query["maxResults"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("maxResults")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nextToken !== undefined) {
-    query["nextToken"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("nextToken")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -304,7 +333,7 @@ export async function serializeAws_restJson1_1ListTagsForResourceCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/tags/{resourceArn}";
   if (input.resourceArn !== undefined) {
-    const labelValue: string = input.resourceArn.toString();
+    const labelValue: string = input.resourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: resourceArn."
@@ -312,7 +341,7 @@ export async function serializeAws_restJson1_1ListTagsForResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{resourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: resourceArn.");
@@ -334,7 +363,7 @@ export async function serializeAws_restJson1_1PutSigningProfileCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/signing-profiles/{profileName}";
   if (input.profileName !== undefined) {
-    const labelValue: string = input.profileName.toString();
+    const labelValue: string = input.profileName;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: profileName."
@@ -342,7 +371,7 @@ export async function serializeAws_restJson1_1PutSigningProfileCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{profileName}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: profileName.");
@@ -433,7 +462,7 @@ export async function serializeAws_restJson1_1TagResourceCommand(
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/tags/{resourceArn}";
   if (input.resourceArn !== undefined) {
-    const labelValue: string = input.resourceArn.toString();
+    const labelValue: string = input.resourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: resourceArn."
@@ -441,7 +470,7 @@ export async function serializeAws_restJson1_1TagResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{resourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: resourceArn.");
@@ -470,7 +499,7 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/tags/{resourceArn}";
   if (input.resourceArn !== undefined) {
-    const labelValue: string = input.resourceArn.toString();
+    const labelValue: string = input.resourceArn;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: resourceArn."
@@ -478,14 +507,16 @@ export async function serializeAws_restJson1_1UntagResourceCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{resourceArn}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: resourceArn.");
   }
   const query: any = {};
   if (input.tagKeys !== undefined) {
-    query["tagKeys"] = input.tagKeys;
+    query[__extendedEncodeURIComponent("tagKeys")] = input.tagKeys.map(entry =>
+      __extendedEncodeURIComponent(entry)
+    );
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -510,6 +541,7 @@ export async function deserializeAws_restJson1_1CancelSigningProfileCommand(
   const contents: CancelSigningProfileCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -1413,6 +1445,7 @@ export async function deserializeAws_restJson1_1TagResourceCommand(
     $metadata: deserializeMetadata(output),
     __type: "TagResourceResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -1475,6 +1508,7 @@ export async function deserializeAws_restJson1_1UntagResourceCommand(
     $metadata: deserializeMetadata(output),
     __type: "UntagResourceResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 

--- a/clients/client-sms/models/index.ts
+++ b/clients/client-sms/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export enum AppLaunchStatus {
@@ -133,7 +136,7 @@ export interface AppSummary {
 
 export namespace AppSummary {
   export function isa(o: any): o is AppSummary {
-    return _smithy.isa(o, "AppSummary");
+    return __isa(o, "AppSummary");
   }
 }
 
@@ -195,7 +198,7 @@ export interface Connector {
 
 export namespace Connector {
   export function isa(o: any): o is Connector {
-    return _smithy.isa(o, "Connector");
+    return __isa(o, "Connector");
   }
 }
 
@@ -247,7 +250,7 @@ export interface CreateAppRequest {
 
 export namespace CreateAppRequest {
   export function isa(o: any): o is CreateAppRequest {
-    return _smithy.isa(o, "CreateAppRequest");
+    return __isa(o, "CreateAppRequest");
   }
 }
 
@@ -271,7 +274,7 @@ export interface CreateAppResponse extends $MetadataBearer {
 
 export namespace CreateAppResponse {
   export function isa(o: any): o is CreateAppResponse {
-    return _smithy.isa(o, "CreateAppResponse");
+    return __isa(o, "CreateAppResponse");
   }
 }
 
@@ -350,7 +353,7 @@ export interface CreateReplicationJobRequest {
 
 export namespace CreateReplicationJobRequest {
   export function isa(o: any): o is CreateReplicationJobRequest {
-    return _smithy.isa(o, "CreateReplicationJobRequest");
+    return __isa(o, "CreateReplicationJobRequest");
   }
 }
 
@@ -364,7 +367,7 @@ export interface CreateReplicationJobResponse extends $MetadataBearer {
 
 export namespace CreateReplicationJobResponse {
   export function isa(o: any): o is CreateReplicationJobResponse {
-    return _smithy.isa(o, "CreateReplicationJobResponse");
+    return __isa(o, "CreateReplicationJobResponse");
   }
 }
 
@@ -378,7 +381,7 @@ export interface DeleteAppLaunchConfigurationRequest {
 
 export namespace DeleteAppLaunchConfigurationRequest {
   export function isa(o: any): o is DeleteAppLaunchConfigurationRequest {
-    return _smithy.isa(o, "DeleteAppLaunchConfigurationRequest");
+    return __isa(o, "DeleteAppLaunchConfigurationRequest");
   }
 }
 
@@ -388,7 +391,7 @@ export interface DeleteAppLaunchConfigurationResponse extends $MetadataBearer {
 
 export namespace DeleteAppLaunchConfigurationResponse {
   export function isa(o: any): o is DeleteAppLaunchConfigurationResponse {
-    return _smithy.isa(o, "DeleteAppLaunchConfigurationResponse");
+    return __isa(o, "DeleteAppLaunchConfigurationResponse");
   }
 }
 
@@ -402,7 +405,7 @@ export interface DeleteAppReplicationConfigurationRequest {
 
 export namespace DeleteAppReplicationConfigurationRequest {
   export function isa(o: any): o is DeleteAppReplicationConfigurationRequest {
-    return _smithy.isa(o, "DeleteAppReplicationConfigurationRequest");
+    return __isa(o, "DeleteAppReplicationConfigurationRequest");
   }
 }
 
@@ -413,7 +416,7 @@ export interface DeleteAppReplicationConfigurationResponse
 
 export namespace DeleteAppReplicationConfigurationResponse {
   export function isa(o: any): o is DeleteAppReplicationConfigurationResponse {
-    return _smithy.isa(o, "DeleteAppReplicationConfigurationResponse");
+    return __isa(o, "DeleteAppReplicationConfigurationResponse");
   }
 }
 
@@ -439,7 +442,7 @@ export interface DeleteAppRequest {
 
 export namespace DeleteAppRequest {
   export function isa(o: any): o is DeleteAppRequest {
-    return _smithy.isa(o, "DeleteAppRequest");
+    return __isa(o, "DeleteAppRequest");
   }
 }
 
@@ -449,7 +452,7 @@ export interface DeleteAppResponse extends $MetadataBearer {
 
 export namespace DeleteAppResponse {
   export function isa(o: any): o is DeleteAppResponse {
-    return _smithy.isa(o, "DeleteAppResponse");
+    return __isa(o, "DeleteAppResponse");
   }
 }
 
@@ -463,7 +466,7 @@ export interface DeleteReplicationJobRequest {
 
 export namespace DeleteReplicationJobRequest {
   export function isa(o: any): o is DeleteReplicationJobRequest {
-    return _smithy.isa(o, "DeleteReplicationJobRequest");
+    return __isa(o, "DeleteReplicationJobRequest");
   }
 }
 
@@ -473,7 +476,7 @@ export interface DeleteReplicationJobResponse extends $MetadataBearer {
 
 export namespace DeleteReplicationJobResponse {
   export function isa(o: any): o is DeleteReplicationJobResponse {
-    return _smithy.isa(o, "DeleteReplicationJobResponse");
+    return __isa(o, "DeleteReplicationJobResponse");
   }
 }
 
@@ -483,7 +486,7 @@ export interface DeleteServerCatalogRequest {
 
 export namespace DeleteServerCatalogRequest {
   export function isa(o: any): o is DeleteServerCatalogRequest {
-    return _smithy.isa(o, "DeleteServerCatalogRequest");
+    return __isa(o, "DeleteServerCatalogRequest");
   }
 }
 
@@ -493,7 +496,7 @@ export interface DeleteServerCatalogResponse extends $MetadataBearer {
 
 export namespace DeleteServerCatalogResponse {
   export function isa(o: any): o is DeleteServerCatalogResponse {
-    return _smithy.isa(o, "DeleteServerCatalogResponse");
+    return __isa(o, "DeleteServerCatalogResponse");
   }
 }
 
@@ -507,7 +510,7 @@ export interface DisassociateConnectorRequest {
 
 export namespace DisassociateConnectorRequest {
   export function isa(o: any): o is DisassociateConnectorRequest {
-    return _smithy.isa(o, "DisassociateConnectorRequest");
+    return __isa(o, "DisassociateConnectorRequest");
   }
 }
 
@@ -517,7 +520,7 @@ export interface DisassociateConnectorResponse extends $MetadataBearer {
 
 export namespace DisassociateConnectorResponse {
   export function isa(o: any): o is DisassociateConnectorResponse {
-    return _smithy.isa(o, "DisassociateConnectorResponse");
+    return __isa(o, "DisassociateConnectorResponse");
   }
 }
 
@@ -536,7 +539,7 @@ export interface GenerateChangeSetRequest {
 
 export namespace GenerateChangeSetRequest {
   export function isa(o: any): o is GenerateChangeSetRequest {
-    return _smithy.isa(o, "GenerateChangeSetRequest");
+    return __isa(o, "GenerateChangeSetRequest");
   }
 }
 
@@ -550,7 +553,7 @@ export interface GenerateChangeSetResponse extends $MetadataBearer {
 
 export namespace GenerateChangeSetResponse {
   export function isa(o: any): o is GenerateChangeSetResponse {
-    return _smithy.isa(o, "GenerateChangeSetResponse");
+    return __isa(o, "GenerateChangeSetResponse");
   }
 }
 
@@ -569,7 +572,7 @@ export interface GenerateTemplateRequest {
 
 export namespace GenerateTemplateRequest {
   export function isa(o: any): o is GenerateTemplateRequest {
-    return _smithy.isa(o, "GenerateTemplateRequest");
+    return __isa(o, "GenerateTemplateRequest");
   }
 }
 
@@ -583,7 +586,7 @@ export interface GenerateTemplateResponse extends $MetadataBearer {
 
 export namespace GenerateTemplateResponse {
   export function isa(o: any): o is GenerateTemplateResponse {
-    return _smithy.isa(o, "GenerateTemplateResponse");
+    return __isa(o, "GenerateTemplateResponse");
   }
 }
 
@@ -597,7 +600,7 @@ export interface GetAppLaunchConfigurationRequest {
 
 export namespace GetAppLaunchConfigurationRequest {
   export function isa(o: any): o is GetAppLaunchConfigurationRequest {
-    return _smithy.isa(o, "GetAppLaunchConfigurationRequest");
+    return __isa(o, "GetAppLaunchConfigurationRequest");
   }
 }
 
@@ -622,7 +625,7 @@ export interface GetAppLaunchConfigurationResponse extends $MetadataBearer {
 
 export namespace GetAppLaunchConfigurationResponse {
   export function isa(o: any): o is GetAppLaunchConfigurationResponse {
-    return _smithy.isa(o, "GetAppLaunchConfigurationResponse");
+    return __isa(o, "GetAppLaunchConfigurationResponse");
   }
 }
 
@@ -636,7 +639,7 @@ export interface GetAppReplicationConfigurationRequest {
 
 export namespace GetAppReplicationConfigurationRequest {
   export function isa(o: any): o is GetAppReplicationConfigurationRequest {
-    return _smithy.isa(o, "GetAppReplicationConfigurationRequest");
+    return __isa(o, "GetAppReplicationConfigurationRequest");
   }
 }
 
@@ -653,7 +656,7 @@ export interface GetAppReplicationConfigurationResponse
 
 export namespace GetAppReplicationConfigurationResponse {
   export function isa(o: any): o is GetAppReplicationConfigurationResponse {
-    return _smithy.isa(o, "GetAppReplicationConfigurationResponse");
+    return __isa(o, "GetAppReplicationConfigurationResponse");
   }
 }
 
@@ -667,7 +670,7 @@ export interface GetAppRequest {
 
 export namespace GetAppRequest {
   export function isa(o: any): o is GetAppRequest {
-    return _smithy.isa(o, "GetAppRequest");
+    return __isa(o, "GetAppRequest");
   }
 }
 
@@ -691,7 +694,7 @@ export interface GetAppResponse extends $MetadataBearer {
 
 export namespace GetAppResponse {
   export function isa(o: any): o is GetAppResponse {
-    return _smithy.isa(o, "GetAppResponse");
+    return __isa(o, "GetAppResponse");
   }
 }
 
@@ -712,7 +715,7 @@ export interface GetConnectorsRequest {
 
 export namespace GetConnectorsRequest {
   export function isa(o: any): o is GetConnectorsRequest {
-    return _smithy.isa(o, "GetConnectorsRequest");
+    return __isa(o, "GetConnectorsRequest");
   }
 }
 
@@ -732,7 +735,7 @@ export interface GetConnectorsResponse extends $MetadataBearer {
 
 export namespace GetConnectorsResponse {
   export function isa(o: any): o is GetConnectorsResponse {
-    return _smithy.isa(o, "GetConnectorsResponse");
+    return __isa(o, "GetConnectorsResponse");
   }
 }
 
@@ -758,7 +761,7 @@ export interface GetReplicationJobsRequest {
 
 export namespace GetReplicationJobsRequest {
   export function isa(o: any): o is GetReplicationJobsRequest {
-    return _smithy.isa(o, "GetReplicationJobsRequest");
+    return __isa(o, "GetReplicationJobsRequest");
   }
 }
 
@@ -778,7 +781,7 @@ export interface GetReplicationJobsResponse extends $MetadataBearer {
 
 export namespace GetReplicationJobsResponse {
   export function isa(o: any): o is GetReplicationJobsResponse {
-    return _smithy.isa(o, "GetReplicationJobsResponse");
+    return __isa(o, "GetReplicationJobsResponse");
   }
 }
 
@@ -804,7 +807,7 @@ export interface GetReplicationRunsRequest {
 
 export namespace GetReplicationRunsRequest {
   export function isa(o: any): o is GetReplicationRunsRequest {
-    return _smithy.isa(o, "GetReplicationRunsRequest");
+    return __isa(o, "GetReplicationRunsRequest");
   }
 }
 
@@ -829,7 +832,7 @@ export interface GetReplicationRunsResponse extends $MetadataBearer {
 
 export namespace GetReplicationRunsResponse {
   export function isa(o: any): o is GetReplicationRunsResponse {
-    return _smithy.isa(o, "GetReplicationRunsResponse");
+    return __isa(o, "GetReplicationRunsResponse");
   }
 }
 
@@ -855,7 +858,7 @@ export interface GetServersRequest {
 
 export namespace GetServersRequest {
   export function isa(o: any): o is GetServersRequest {
-    return _smithy.isa(o, "GetServersRequest");
+    return __isa(o, "GetServersRequest");
   }
 }
 
@@ -885,7 +888,7 @@ export interface GetServersResponse extends $MetadataBearer {
 
 export namespace GetServersResponse {
   export function isa(o: any): o is GetServersResponse {
-    return _smithy.isa(o, "GetServersResponse");
+    return __isa(o, "GetServersResponse");
   }
 }
 
@@ -895,7 +898,7 @@ export interface ImportServerCatalogRequest {
 
 export namespace ImportServerCatalogRequest {
   export function isa(o: any): o is ImportServerCatalogRequest {
-    return _smithy.isa(o, "ImportServerCatalogRequest");
+    return __isa(o, "ImportServerCatalogRequest");
   }
 }
 
@@ -905,16 +908,14 @@ export interface ImportServerCatalogResponse extends $MetadataBearer {
 
 export namespace ImportServerCatalogResponse {
   export function isa(o: any): o is ImportServerCatalogResponse {
-    return _smithy.isa(o, "ImportServerCatalogResponse");
+    return __isa(o, "ImportServerCatalogResponse");
   }
 }
 
 /**
  * <p>An internal error occurred.</p>
  */
-export interface InternalError
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface InternalError extends __SmithyException, $MetadataBearer {
   name: "InternalError";
   $fault: "server";
   message?: string;
@@ -922,7 +923,7 @@ export interface InternalError
 
 export namespace InternalError {
   export function isa(o: any): o is InternalError {
-    return _smithy.isa(o, "InternalError");
+    return __isa(o, "InternalError");
   }
 }
 
@@ -930,7 +931,7 @@ export namespace InternalError {
  * <p>A specified parameter is not valid.</p>
  */
 export interface InvalidParameterException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidParameterException";
   $fault: "client";
@@ -939,7 +940,7 @@ export interface InvalidParameterException
 
 export namespace InvalidParameterException {
   export function isa(o: any): o is InvalidParameterException {
-    return _smithy.isa(o, "InvalidParameterException");
+    return __isa(o, "InvalidParameterException");
   }
 }
 
@@ -953,7 +954,7 @@ export interface LaunchAppRequest {
 
 export namespace LaunchAppRequest {
   export function isa(o: any): o is LaunchAppRequest {
-    return _smithy.isa(o, "LaunchAppRequest");
+    return __isa(o, "LaunchAppRequest");
   }
 }
 
@@ -963,7 +964,7 @@ export interface LaunchAppResponse extends $MetadataBearer {
 
 export namespace LaunchAppResponse {
   export function isa(o: any): o is LaunchAppResponse {
-    return _smithy.isa(o, "LaunchAppResponse");
+    return __isa(o, "LaunchAppResponse");
   }
 }
 
@@ -990,7 +991,7 @@ export interface LaunchDetails {
 
 export namespace LaunchDetails {
   export function isa(o: any): o is LaunchDetails {
-    return _smithy.isa(o, "LaunchDetails");
+    return __isa(o, "LaunchDetails");
   }
 }
 
@@ -1022,7 +1023,7 @@ export interface ListAppsRequest {
 
 export namespace ListAppsRequest {
   export function isa(o: any): o is ListAppsRequest {
-    return _smithy.isa(o, "ListAppsRequest");
+    return __isa(o, "ListAppsRequest");
   }
 }
 
@@ -1042,7 +1043,7 @@ export interface ListAppsResponse extends $MetadataBearer {
 
 export namespace ListAppsResponse {
   export function isa(o: any): o is ListAppsResponse {
-    return _smithy.isa(o, "ListAppsResponse");
+    return __isa(o, "ListAppsResponse");
   }
 }
 
@@ -1050,7 +1051,7 @@ export namespace ListAppsResponse {
  * <p>A required parameter is missing.</p>
  */
 export interface MissingRequiredParameterException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "MissingRequiredParameterException";
   $fault: "client";
@@ -1059,7 +1060,7 @@ export interface MissingRequiredParameterException
 
 export namespace MissingRequiredParameterException {
   export function isa(o: any): o is MissingRequiredParameterException {
-    return _smithy.isa(o, "MissingRequiredParameterException");
+    return __isa(o, "MissingRequiredParameterException");
   }
 }
 
@@ -1067,7 +1068,7 @@ export namespace MissingRequiredParameterException {
  * <p>There are no connectors available.</p>
  */
 export interface NoConnectorsAvailableException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "NoConnectorsAvailableException";
   $fault: "client";
@@ -1076,7 +1077,7 @@ export interface NoConnectorsAvailableException
 
 export namespace NoConnectorsAvailableException {
   export function isa(o: any): o is NoConnectorsAvailableException {
-    return _smithy.isa(o, "NoConnectorsAvailableException");
+    return __isa(o, "NoConnectorsAvailableException");
   }
 }
 
@@ -1084,7 +1085,7 @@ export namespace NoConnectorsAvailableException {
  * <p>This operation is not allowed.</p>
  */
 export interface OperationNotPermittedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "OperationNotPermittedException";
   $fault: "client";
@@ -1093,7 +1094,7 @@ export interface OperationNotPermittedException
 
 export namespace OperationNotPermittedException {
   export function isa(o: any): o is OperationNotPermittedException {
-    return _smithy.isa(o, "OperationNotPermittedException");
+    return __isa(o, "OperationNotPermittedException");
   }
 }
 
@@ -1123,7 +1124,7 @@ export interface PutAppLaunchConfigurationRequest {
 
 export namespace PutAppLaunchConfigurationRequest {
   export function isa(o: any): o is PutAppLaunchConfigurationRequest {
-    return _smithy.isa(o, "PutAppLaunchConfigurationRequest");
+    return __isa(o, "PutAppLaunchConfigurationRequest");
   }
 }
 
@@ -1133,7 +1134,7 @@ export interface PutAppLaunchConfigurationResponse extends $MetadataBearer {
 
 export namespace PutAppLaunchConfigurationResponse {
   export function isa(o: any): o is PutAppLaunchConfigurationResponse {
-    return _smithy.isa(o, "PutAppLaunchConfigurationResponse");
+    return __isa(o, "PutAppLaunchConfigurationResponse");
   }
 }
 
@@ -1154,7 +1155,7 @@ export interface PutAppReplicationConfigurationRequest {
 
 export namespace PutAppReplicationConfigurationRequest {
   export function isa(o: any): o is PutAppReplicationConfigurationRequest {
-    return _smithy.isa(o, "PutAppReplicationConfigurationRequest");
+    return __isa(o, "PutAppReplicationConfigurationRequest");
   }
 }
 
@@ -1165,7 +1166,7 @@ export interface PutAppReplicationConfigurationResponse
 
 export namespace PutAppReplicationConfigurationResponse {
   export function isa(o: any): o is PutAppReplicationConfigurationResponse {
-    return _smithy.isa(o, "PutAppReplicationConfigurationResponse");
+    return __isa(o, "PutAppReplicationConfigurationResponse");
   }
 }
 
@@ -1287,7 +1288,7 @@ export interface ReplicationJob {
 
 export namespace ReplicationJob {
   export function isa(o: any): o is ReplicationJob {
-    return _smithy.isa(o, "ReplicationJob");
+    return __isa(o, "ReplicationJob");
   }
 }
 
@@ -1295,7 +1296,7 @@ export namespace ReplicationJob {
  * <p>The specified replication job already exists.</p>
  */
 export interface ReplicationJobAlreadyExistsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ReplicationJobAlreadyExistsException";
   $fault: "client";
@@ -1304,7 +1305,7 @@ export interface ReplicationJobAlreadyExistsException
 
 export namespace ReplicationJobAlreadyExistsException {
   export function isa(o: any): o is ReplicationJobAlreadyExistsException {
-    return _smithy.isa(o, "ReplicationJobAlreadyExistsException");
+    return __isa(o, "ReplicationJobAlreadyExistsException");
   }
 }
 
@@ -1312,7 +1313,7 @@ export namespace ReplicationJobAlreadyExistsException {
  * <p>The specified replication job does not exist.</p>
  */
 export interface ReplicationJobNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ReplicationJobNotFoundException";
   $fault: "client";
@@ -1321,7 +1322,7 @@ export interface ReplicationJobNotFoundException
 
 export namespace ReplicationJobNotFoundException {
   export function isa(o: any): o is ReplicationJobNotFoundException {
-    return _smithy.isa(o, "ReplicationJobNotFoundException");
+    return __isa(o, "ReplicationJobNotFoundException");
   }
 }
 
@@ -1418,7 +1419,7 @@ export interface ReplicationRun {
 
 export namespace ReplicationRun {
   export function isa(o: any): o is ReplicationRun {
-    return _smithy.isa(o, "ReplicationRun");
+    return __isa(o, "ReplicationRun");
   }
 }
 
@@ -1427,7 +1428,7 @@ export namespace ReplicationRun {
  *             24-hour period.</p>
  */
 export interface ReplicationRunLimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ReplicationRunLimitExceededException";
   $fault: "client";
@@ -1436,7 +1437,7 @@ export interface ReplicationRunLimitExceededException
 
 export namespace ReplicationRunLimitExceededException {
   export function isa(o: any): o is ReplicationRunLimitExceededException {
-    return _smithy.isa(o, "ReplicationRunLimitExceededException");
+    return __isa(o, "ReplicationRunLimitExceededException");
   }
 }
 
@@ -1458,7 +1459,7 @@ export interface ReplicationRunStageDetails {
 
 export namespace ReplicationRunStageDetails {
   export function isa(o: any): o is ReplicationRunStageDetails {
-    return _smithy.isa(o, "ReplicationRunStageDetails");
+    return __isa(o, "ReplicationRunStageDetails");
   }
 }
 
@@ -1495,7 +1496,7 @@ export interface S3Location {
 
 export namespace S3Location {
   export function isa(o: any): o is S3Location {
-    return _smithy.isa(o, "S3Location");
+    return __isa(o, "S3Location");
   }
 }
 
@@ -1532,7 +1533,7 @@ export interface Server {
 
 export namespace Server {
   export function isa(o: any): o is Server {
-    return _smithy.isa(o, "Server");
+    return __isa(o, "Server");
   }
 }
 
@@ -1540,7 +1541,7 @@ export namespace Server {
  * <p>The specified server cannot be replicated.</p>
  */
 export interface ServerCannotBeReplicatedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ServerCannotBeReplicatedException";
   $fault: "client";
@@ -1549,7 +1550,7 @@ export interface ServerCannotBeReplicatedException
 
 export namespace ServerCannotBeReplicatedException {
   export function isa(o: any): o is ServerCannotBeReplicatedException {
-    return _smithy.isa(o, "ServerCannotBeReplicatedException");
+    return __isa(o, "ServerCannotBeReplicatedException");
   }
 }
 
@@ -1584,7 +1585,7 @@ export interface ServerGroup {
 
 export namespace ServerGroup {
   export function isa(o: any): o is ServerGroup {
-    return _smithy.isa(o, "ServerGroup");
+    return __isa(o, "ServerGroup");
   }
 }
 
@@ -1611,7 +1612,7 @@ export interface ServerGroupLaunchConfiguration {
 
 export namespace ServerGroupLaunchConfiguration {
   export function isa(o: any): o is ServerGroupLaunchConfiguration {
-    return _smithy.isa(o, "ServerGroupLaunchConfiguration");
+    return __isa(o, "ServerGroupLaunchConfiguration");
   }
 }
 
@@ -1634,7 +1635,7 @@ export interface ServerGroupReplicationConfiguration {
 
 export namespace ServerGroupReplicationConfiguration {
   export function isa(o: any): o is ServerGroupReplicationConfiguration {
-    return _smithy.isa(o, "ServerGroupReplicationConfiguration");
+    return __isa(o, "ServerGroupReplicationConfiguration");
   }
 }
 
@@ -1691,7 +1692,7 @@ export interface ServerLaunchConfiguration {
 
 export namespace ServerLaunchConfiguration {
   export function isa(o: any): o is ServerLaunchConfiguration {
-    return _smithy.isa(o, "ServerLaunchConfiguration");
+    return __isa(o, "ServerLaunchConfiguration");
   }
 }
 
@@ -1713,7 +1714,7 @@ export interface ServerReplicationConfiguration {
 
 export namespace ServerReplicationConfiguration {
   export function isa(o: any): o is ServerReplicationConfiguration {
-    return _smithy.isa(o, "ServerReplicationConfiguration");
+    return __isa(o, "ServerReplicationConfiguration");
   }
 }
 
@@ -1779,7 +1780,7 @@ export interface ServerReplicationParameters {
 
 export namespace ServerReplicationParameters {
   export function isa(o: any): o is ServerReplicationParameters {
-    return _smithy.isa(o, "ServerReplicationParameters");
+    return __isa(o, "ServerReplicationParameters");
   }
 }
 
@@ -1797,7 +1798,7 @@ export interface StartAppReplicationRequest {
 
 export namespace StartAppReplicationRequest {
   export function isa(o: any): o is StartAppReplicationRequest {
-    return _smithy.isa(o, "StartAppReplicationRequest");
+    return __isa(o, "StartAppReplicationRequest");
   }
 }
 
@@ -1807,7 +1808,7 @@ export interface StartAppReplicationResponse extends $MetadataBearer {
 
 export namespace StartAppReplicationResponse {
   export function isa(o: any): o is StartAppReplicationResponse {
-    return _smithy.isa(o, "StartAppReplicationResponse");
+    return __isa(o, "StartAppReplicationResponse");
   }
 }
 
@@ -1826,7 +1827,7 @@ export interface StartOnDemandReplicationRunRequest {
 
 export namespace StartOnDemandReplicationRunRequest {
   export function isa(o: any): o is StartOnDemandReplicationRunRequest {
-    return _smithy.isa(o, "StartOnDemandReplicationRunRequest");
+    return __isa(o, "StartOnDemandReplicationRunRequest");
   }
 }
 
@@ -1840,7 +1841,7 @@ export interface StartOnDemandReplicationRunResponse extends $MetadataBearer {
 
 export namespace StartOnDemandReplicationRunResponse {
   export function isa(o: any): o is StartOnDemandReplicationRunResponse {
-    return _smithy.isa(o, "StartOnDemandReplicationRunResponse");
+    return __isa(o, "StartOnDemandReplicationRunResponse");
   }
 }
 
@@ -1854,7 +1855,7 @@ export interface StopAppReplicationRequest {
 
 export namespace StopAppReplicationRequest {
   export function isa(o: any): o is StopAppReplicationRequest {
-    return _smithy.isa(o, "StopAppReplicationRequest");
+    return __isa(o, "StopAppReplicationRequest");
   }
 }
 
@@ -1864,7 +1865,7 @@ export interface StopAppReplicationResponse extends $MetadataBearer {
 
 export namespace StopAppReplicationResponse {
   export function isa(o: any): o is StopAppReplicationResponse {
-    return _smithy.isa(o, "StopAppReplicationResponse");
+    return __isa(o, "StopAppReplicationResponse");
   }
 }
 
@@ -1886,7 +1887,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -1894,7 +1895,7 @@ export namespace Tag {
  * <p>The service is temporarily unavailable.</p>
  */
 export interface TemporarilyUnavailableException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TemporarilyUnavailableException";
   $fault: "server";
@@ -1902,7 +1903,7 @@ export interface TemporarilyUnavailableException
 
 export namespace TemporarilyUnavailableException {
   export function isa(o: any): o is TemporarilyUnavailableException {
-    return _smithy.isa(o, "TemporarilyUnavailableException");
+    return __isa(o, "TemporarilyUnavailableException");
   }
 }
 
@@ -1916,7 +1917,7 @@ export interface TerminateAppRequest {
 
 export namespace TerminateAppRequest {
   export function isa(o: any): o is TerminateAppRequest {
-    return _smithy.isa(o, "TerminateAppRequest");
+    return __isa(o, "TerminateAppRequest");
   }
 }
 
@@ -1926,7 +1927,7 @@ export interface TerminateAppResponse extends $MetadataBearer {
 
 export namespace TerminateAppResponse {
   export function isa(o: any): o is TerminateAppResponse {
-    return _smithy.isa(o, "TerminateAppResponse");
+    return __isa(o, "TerminateAppResponse");
   }
 }
 
@@ -1935,7 +1936,7 @@ export namespace TerminateAppResponse {
  *             ensure that you are using the correct access keys.</p>
  */
 export interface UnauthorizedOperationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UnauthorizedOperationException";
   $fault: "client";
@@ -1944,7 +1945,7 @@ export interface UnauthorizedOperationException
 
 export namespace UnauthorizedOperationException {
   export function isa(o: any): o is UnauthorizedOperationException {
-    return _smithy.isa(o, "UnauthorizedOperationException");
+    return __isa(o, "UnauthorizedOperationException");
   }
 }
 
@@ -1983,7 +1984,7 @@ export interface UpdateAppRequest {
 
 export namespace UpdateAppRequest {
   export function isa(o: any): o is UpdateAppRequest {
-    return _smithy.isa(o, "UpdateAppRequest");
+    return __isa(o, "UpdateAppRequest");
   }
 }
 
@@ -2007,7 +2008,7 @@ export interface UpdateAppResponse extends $MetadataBearer {
 
 export namespace UpdateAppResponse {
   export function isa(o: any): o is UpdateAppResponse {
-    return _smithy.isa(o, "UpdateAppResponse");
+    return __isa(o, "UpdateAppResponse");
   }
 }
 
@@ -2082,7 +2083,7 @@ export interface UpdateReplicationJobRequest {
 
 export namespace UpdateReplicationJobRequest {
   export function isa(o: any): o is UpdateReplicationJobRequest {
-    return _smithy.isa(o, "UpdateReplicationJobRequest");
+    return __isa(o, "UpdateReplicationJobRequest");
   }
 }
 
@@ -2092,7 +2093,7 @@ export interface UpdateReplicationJobResponse extends $MetadataBearer {
 
 export namespace UpdateReplicationJobResponse {
   export function isa(o: any): o is UpdateReplicationJobResponse {
-    return _smithy.isa(o, "UpdateReplicationJobResponse");
+    return __isa(o, "UpdateReplicationJobResponse");
   }
 }
 
@@ -2110,7 +2111,7 @@ export interface UserData {
 
 export namespace UserData {
   export function isa(o: any): o is UserData {
-    return _smithy.isa(o, "UserData");
+    return __isa(o, "UserData");
   }
 }
 
@@ -2153,7 +2154,7 @@ export interface VmServer {
 
 export namespace VmServer {
   export function isa(o: any): o is VmServer {
-    return _smithy.isa(o, "VmServer");
+    return __isa(o, "VmServer");
   }
 }
 
@@ -2175,6 +2176,6 @@ export interface VmServerAddress {
 
 export namespace VmServerAddress {
   export function isa(o: any): o is VmServerAddress {
-    return _smithy.isa(o, "VmServerAddress");
+    return __isa(o, "VmServerAddress");
   }
 }

--- a/clients/client-snowball/models/index.ts
+++ b/clients/client-snowball/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -88,7 +91,7 @@ export interface Address {
 
 export namespace Address {
   export function isa(o: any): o is Address {
-    return _smithy.isa(o, "Address");
+    return __isa(o, "Address");
   }
 }
 
@@ -103,7 +106,7 @@ export interface CancelClusterRequest {
 
 export namespace CancelClusterRequest {
   export function isa(o: any): o is CancelClusterRequest {
-    return _smithy.isa(o, "CancelClusterRequest");
+    return __isa(o, "CancelClusterRequest");
   }
 }
 
@@ -113,7 +116,7 @@ export interface CancelClusterResult extends $MetadataBearer {
 
 export namespace CancelClusterResult {
   export function isa(o: any): o is CancelClusterResult {
-    return _smithy.isa(o, "CancelClusterResult");
+    return __isa(o, "CancelClusterResult");
   }
 }
 
@@ -128,7 +131,7 @@ export interface CancelJobRequest {
 
 export namespace CancelJobRequest {
   export function isa(o: any): o is CancelJobRequest {
-    return _smithy.isa(o, "CancelJobRequest");
+    return __isa(o, "CancelJobRequest");
   }
 }
 
@@ -138,7 +141,7 @@ export interface CancelJobResult extends $MetadataBearer {
 
 export namespace CancelJobResult {
   export function isa(o: any): o is CancelJobResult {
-    return _smithy.isa(o, "CancelJobResult");
+    return __isa(o, "CancelJobResult");
   }
 }
 
@@ -148,7 +151,7 @@ export namespace CancelJobResult {
  *       create jobs until your cluster has exactly five notes.</p>
  */
 export interface ClusterLimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ClusterLimitExceededException";
   $fault: "client";
@@ -157,7 +160,7 @@ export interface ClusterLimitExceededException
 
 export namespace ClusterLimitExceededException {
   export function isa(o: any): o is ClusterLimitExceededException {
-    return _smithy.isa(o, "ClusterLimitExceededException");
+    return __isa(o, "ClusterLimitExceededException");
   }
 }
 
@@ -192,7 +195,7 @@ export interface ClusterListEntry {
 
 export namespace ClusterListEntry {
   export function isa(o: any): o is ClusterListEntry {
-    return _smithy.isa(o, "ClusterListEntry");
+    return __isa(o, "ClusterListEntry");
   }
 }
 
@@ -297,7 +300,7 @@ export interface ClusterMetadata {
 
 export namespace ClusterMetadata {
   export function isa(o: any): o is ClusterMetadata {
-    return _smithy.isa(o, "ClusterMetadata");
+    return __isa(o, "ClusterMetadata");
   }
 }
 
@@ -330,7 +333,7 @@ export interface CompatibleImage {
 
 export namespace CompatibleImage {
   export function isa(o: any): o is CompatibleImage {
-    return _smithy.isa(o, "CompatibleImage");
+    return __isa(o, "CompatibleImage");
   }
 }
 
@@ -344,7 +347,7 @@ export interface CreateAddressRequest {
 
 export namespace CreateAddressRequest {
   export function isa(o: any): o is CreateAddressRequest {
-    return _smithy.isa(o, "CreateAddressRequest");
+    return __isa(o, "CreateAddressRequest");
   }
 }
 
@@ -359,7 +362,7 @@ export interface CreateAddressResult extends $MetadataBearer {
 
 export namespace CreateAddressResult {
   export function isa(o: any): o is CreateAddressResult {
-    return _smithy.isa(o, "CreateAddressResult");
+    return __isa(o, "CreateAddressResult");
   }
 }
 
@@ -449,7 +452,7 @@ export interface CreateClusterRequest {
 
 export namespace CreateClusterRequest {
   export function isa(o: any): o is CreateClusterRequest {
-    return _smithy.isa(o, "CreateClusterRequest");
+    return __isa(o, "CreateClusterRequest");
   }
 }
 
@@ -463,7 +466,7 @@ export interface CreateClusterResult extends $MetadataBearer {
 
 export namespace CreateClusterResult {
   export function isa(o: any): o is CreateClusterResult {
-    return _smithy.isa(o, "CreateClusterResult");
+    return __isa(o, "CreateClusterResult");
   }
 }
 
@@ -575,7 +578,7 @@ export interface CreateJobRequest {
 
 export namespace CreateJobRequest {
   export function isa(o: any): o is CreateJobRequest {
-    return _smithy.isa(o, "CreateJobRequest");
+    return __isa(o, "CreateJobRequest");
   }
 }
 
@@ -590,7 +593,7 @@ export interface CreateJobResult extends $MetadataBearer {
 
 export namespace CreateJobResult {
   export function isa(o: any): o is CreateJobResult {
-    return _smithy.isa(o, "CreateJobResult");
+    return __isa(o, "CreateJobResult");
   }
 }
 
@@ -626,7 +629,7 @@ export interface DataTransfer {
 
 export namespace DataTransfer {
   export function isa(o: any): o is DataTransfer {
-    return _smithy.isa(o, "DataTransfer");
+    return __isa(o, "DataTransfer");
   }
 }
 
@@ -640,7 +643,7 @@ export interface DescribeAddressRequest {
 
 export namespace DescribeAddressRequest {
   export function isa(o: any): o is DescribeAddressRequest {
-    return _smithy.isa(o, "DescribeAddressRequest");
+    return __isa(o, "DescribeAddressRequest");
   }
 }
 
@@ -655,7 +658,7 @@ export interface DescribeAddressResult extends $MetadataBearer {
 
 export namespace DescribeAddressResult {
   export function isa(o: any): o is DescribeAddressResult {
-    return _smithy.isa(o, "DescribeAddressResult");
+    return __isa(o, "DescribeAddressResult");
   }
 }
 
@@ -676,7 +679,7 @@ export interface DescribeAddressesRequest {
 
 export namespace DescribeAddressesRequest {
   export function isa(o: any): o is DescribeAddressesRequest {
-    return _smithy.isa(o, "DescribeAddressesRequest");
+    return __isa(o, "DescribeAddressesRequest");
   }
 }
 
@@ -697,7 +700,7 @@ export interface DescribeAddressesResult extends $MetadataBearer {
 
 export namespace DescribeAddressesResult {
   export function isa(o: any): o is DescribeAddressesResult {
-    return _smithy.isa(o, "DescribeAddressesResult");
+    return __isa(o, "DescribeAddressesResult");
   }
 }
 
@@ -711,7 +714,7 @@ export interface DescribeClusterRequest {
 
 export namespace DescribeClusterRequest {
   export function isa(o: any): o is DescribeClusterRequest {
-    return _smithy.isa(o, "DescribeClusterRequest");
+    return __isa(o, "DescribeClusterRequest");
   }
 }
 
@@ -726,7 +729,7 @@ export interface DescribeClusterResult extends $MetadataBearer {
 
 export namespace DescribeClusterResult {
   export function isa(o: any): o is DescribeClusterResult {
-    return _smithy.isa(o, "DescribeClusterResult");
+    return __isa(o, "DescribeClusterResult");
   }
 }
 
@@ -741,7 +744,7 @@ export interface DescribeJobRequest {
 
 export namespace DescribeJobRequest {
   export function isa(o: any): o is DescribeJobRequest {
-    return _smithy.isa(o, "DescribeJobRequest");
+    return __isa(o, "DescribeJobRequest");
   }
 }
 
@@ -762,7 +765,7 @@ export interface DescribeJobResult extends $MetadataBearer {
 
 export namespace DescribeJobResult {
   export function isa(o: any): o is DescribeJobResult {
-    return _smithy.isa(o, "DescribeJobResult");
+    return __isa(o, "DescribeJobResult");
   }
 }
 
@@ -786,7 +789,7 @@ export interface Ec2AmiResource {
 
 export namespace Ec2AmiResource {
   export function isa(o: any): o is Ec2AmiResource {
-    return _smithy.isa(o, "Ec2AmiResource");
+    return __isa(o, "Ec2AmiResource");
   }
 }
 
@@ -795,7 +798,7 @@ export namespace Ec2AmiResource {
  *       action.</p>
  */
 export interface Ec2RequestFailedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "Ec2RequestFailedException";
   $fault: "client";
@@ -804,7 +807,7 @@ export interface Ec2RequestFailedException
 
 export namespace Ec2RequestFailedException {
   export function isa(o: any): o is Ec2RequestFailedException {
-    return _smithy.isa(o, "Ec2RequestFailedException");
+    return __isa(o, "Ec2RequestFailedException");
   }
 }
 
@@ -822,7 +825,7 @@ export interface EventTriggerDefinition {
 
 export namespace EventTriggerDefinition {
   export function isa(o: any): o is EventTriggerDefinition {
-    return _smithy.isa(o, "EventTriggerDefinition");
+    return __isa(o, "EventTriggerDefinition");
   }
 }
 
@@ -837,7 +840,7 @@ export interface GetJobManifestRequest {
 
 export namespace GetJobManifestRequest {
   export function isa(o: any): o is GetJobManifestRequest {
-    return _smithy.isa(o, "GetJobManifestRequest");
+    return __isa(o, "GetJobManifestRequest");
   }
 }
 
@@ -852,7 +855,7 @@ export interface GetJobManifestResult extends $MetadataBearer {
 
 export namespace GetJobManifestResult {
   export function isa(o: any): o is GetJobManifestResult {
-    return _smithy.isa(o, "GetJobManifestResult");
+    return __isa(o, "GetJobManifestResult");
   }
 }
 
@@ -867,7 +870,7 @@ export interface GetJobUnlockCodeRequest {
 
 export namespace GetJobUnlockCodeRequest {
   export function isa(o: any): o is GetJobUnlockCodeRequest {
-    return _smithy.isa(o, "GetJobUnlockCodeRequest");
+    return __isa(o, "GetJobUnlockCodeRequest");
   }
 }
 
@@ -882,7 +885,7 @@ export interface GetJobUnlockCodeResult extends $MetadataBearer {
 
 export namespace GetJobUnlockCodeResult {
   export function isa(o: any): o is GetJobUnlockCodeResult {
-    return _smithy.isa(o, "GetJobUnlockCodeResult");
+    return __isa(o, "GetJobUnlockCodeResult");
   }
 }
 
@@ -892,7 +895,7 @@ export interface GetSnowballUsageRequest {
 
 export namespace GetSnowballUsageRequest {
   export function isa(o: any): o is GetSnowballUsageRequest {
-    return _smithy.isa(o, "GetSnowballUsageRequest");
+    return __isa(o, "GetSnowballUsageRequest");
   }
 }
 
@@ -912,7 +915,7 @@ export interface GetSnowballUsageResult extends $MetadataBearer {
 
 export namespace GetSnowballUsageResult {
   export function isa(o: any): o is GetSnowballUsageResult {
-    return _smithy.isa(o, "GetSnowballUsageResult");
+    return __isa(o, "GetSnowballUsageResult");
   }
 }
 
@@ -927,7 +930,7 @@ export interface GetSoftwareUpdatesRequest {
 
 export namespace GetSoftwareUpdatesRequest {
   export function isa(o: any): o is GetSoftwareUpdatesRequest {
-    return _smithy.isa(o, "GetSoftwareUpdatesRequest");
+    return __isa(o, "GetSoftwareUpdatesRequest");
   }
 }
 
@@ -943,7 +946,7 @@ export interface GetSoftwareUpdatesResult extends $MetadataBearer {
 
 export namespace GetSoftwareUpdatesResult {
   export function isa(o: any): o is GetSoftwareUpdatesResult {
-    return _smithy.isa(o, "GetSoftwareUpdatesResult");
+    return __isa(o, "GetSoftwareUpdatesResult");
   }
 }
 
@@ -952,7 +955,7 @@ export namespace GetSoftwareUpdatesResult {
  *       again.</p>
  */
 export interface InvalidAddressException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidAddressException";
   $fault: "client";
@@ -961,7 +964,7 @@ export interface InvalidAddressException
 
 export namespace InvalidAddressException {
   export function isa(o: any): o is InvalidAddressException {
-    return _smithy.isa(o, "InvalidAddressException");
+    return __isa(o, "InvalidAddressException");
   }
 }
 
@@ -970,7 +973,7 @@ export namespace InvalidAddressException {
  *         <a>CreateClusterRequest$SnowballType</a> value supports your <a>CreateJobRequest$JobType</a>, and try again.</p>
  */
 export interface InvalidInputCombinationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidInputCombinationException";
   $fault: "client";
@@ -979,7 +982,7 @@ export interface InvalidInputCombinationException
 
 export namespace InvalidInputCombinationException {
   export function isa(o: any): o is InvalidInputCombinationException {
-    return _smithy.isa(o, "InvalidInputCombinationException");
+    return __isa(o, "InvalidInputCombinationException");
   }
 }
 
@@ -988,7 +991,7 @@ export namespace InvalidInputCombinationException {
  *       to be performed.</p>
  */
 export interface InvalidJobStateException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidJobStateException";
   $fault: "client";
@@ -997,7 +1000,7 @@ export interface InvalidJobStateException
 
 export namespace InvalidJobStateException {
   export function isa(o: any): o is InvalidJobStateException {
-    return _smithy.isa(o, "InvalidJobStateException");
+    return __isa(o, "InvalidJobStateException");
   }
 }
 
@@ -1007,7 +1010,7 @@ export namespace InvalidJobStateException {
  *       again.</p>
  */
 export interface InvalidNextTokenException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidNextTokenException";
   $fault: "client";
@@ -1016,7 +1019,7 @@ export interface InvalidNextTokenException
 
 export namespace InvalidNextTokenException {
   export function isa(o: any): o is InvalidNextTokenException {
-    return _smithy.isa(o, "InvalidNextTokenException");
+    return __isa(o, "InvalidNextTokenException");
   }
 }
 
@@ -1025,7 +1028,7 @@ export namespace InvalidNextTokenException {
  *       request, and try again.</p>
  */
 export interface InvalidResourceException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidResourceException";
   $fault: "client";
@@ -1038,7 +1041,7 @@ export interface InvalidResourceException
 
 export namespace InvalidResourceException {
   export function isa(o: any): o is InvalidResourceException {
-    return _smithy.isa(o, "InvalidResourceException");
+    return __isa(o, "InvalidResourceException");
   }
 }
 
@@ -1092,7 +1095,7 @@ export interface JobListEntry {
 
 export namespace JobListEntry {
   export function isa(o: any): o is JobListEntry {
-    return _smithy.isa(o, "JobListEntry");
+    return __isa(o, "JobListEntry");
   }
 }
 
@@ -1137,7 +1140,7 @@ export interface JobLogs {
 
 export namespace JobLogs {
   export function isa(o: any): o is JobLogs {
-    return _smithy.isa(o, "JobLogs");
+    return __isa(o, "JobLogs");
   }
 }
 
@@ -1255,7 +1258,7 @@ export interface JobMetadata {
 
 export namespace JobMetadata {
   export function isa(o: any): o is JobMetadata {
-    return _smithy.isa(o, "JobMetadata");
+    return __isa(o, "JobMetadata");
   }
 }
 
@@ -1284,7 +1287,7 @@ export interface JobResource {
 
 export namespace JobResource {
   export function isa(o: any): o is JobResource {
-    return _smithy.isa(o, "JobResource");
+    return __isa(o, "JobResource");
   }
 }
 
@@ -1315,7 +1318,7 @@ export enum JobType {
  *       specified <a>CreateJob</a> or <a>UpdateJob</a> action.</p>
  */
 export interface KMSRequestFailedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "KMSRequestFailedException";
   $fault: "client";
@@ -1324,7 +1327,7 @@ export interface KMSRequestFailedException
 
 export namespace KMSRequestFailedException {
   export function isa(o: any): o is KMSRequestFailedException {
-    return _smithy.isa(o, "KMSRequestFailedException");
+    return __isa(o, "KMSRequestFailedException");
   }
 }
 
@@ -1351,7 +1354,7 @@ export interface KeyRange {
 
 export namespace KeyRange {
   export function isa(o: any): o is KeyRange {
-    return _smithy.isa(o, "KeyRange");
+    return __isa(o, "KeyRange");
   }
 }
 
@@ -1374,7 +1377,7 @@ export interface LambdaResource {
 
 export namespace LambdaResource {
   export function isa(o: any): o is LambdaResource {
-    return _smithy.isa(o, "LambdaResource");
+    return __isa(o, "LambdaResource");
   }
 }
 
@@ -1401,7 +1404,7 @@ export interface ListClusterJobsRequest {
 
 export namespace ListClusterJobsRequest {
   export function isa(o: any): o is ListClusterJobsRequest {
-    return _smithy.isa(o, "ListClusterJobsRequest");
+    return __isa(o, "ListClusterJobsRequest");
   }
 }
 
@@ -1423,7 +1426,7 @@ export interface ListClusterJobsResult extends $MetadataBearer {
 
 export namespace ListClusterJobsResult {
   export function isa(o: any): o is ListClusterJobsResult {
-    return _smithy.isa(o, "ListClusterJobsResult");
+    return __isa(o, "ListClusterJobsResult");
   }
 }
 
@@ -1444,7 +1447,7 @@ export interface ListClustersRequest {
 
 export namespace ListClustersRequest {
   export function isa(o: any): o is ListClustersRequest {
-    return _smithy.isa(o, "ListClustersRequest");
+    return __isa(o, "ListClustersRequest");
   }
 }
 
@@ -1466,7 +1469,7 @@ export interface ListClustersResult extends $MetadataBearer {
 
 export namespace ListClustersResult {
   export function isa(o: any): o is ListClustersResult {
-    return _smithy.isa(o, "ListClustersResult");
+    return __isa(o, "ListClustersResult");
   }
 }
 
@@ -1488,7 +1491,7 @@ export interface ListCompatibleImagesRequest {
 
 export namespace ListCompatibleImagesRequest {
   export function isa(o: any): o is ListCompatibleImagesRequest {
-    return _smithy.isa(o, "ListCompatibleImagesRequest");
+    return __isa(o, "ListCompatibleImagesRequest");
   }
 }
 
@@ -1509,7 +1512,7 @@ export interface ListCompatibleImagesResult extends $MetadataBearer {
 
 export namespace ListCompatibleImagesResult {
   export function isa(o: any): o is ListCompatibleImagesResult {
-    return _smithy.isa(o, "ListCompatibleImagesResult");
+    return __isa(o, "ListCompatibleImagesResult");
   }
 }
 
@@ -1530,7 +1533,7 @@ export interface ListJobsRequest {
 
 export namespace ListJobsRequest {
   export function isa(o: any): o is ListJobsRequest {
-    return _smithy.isa(o, "ListJobsRequest");
+    return __isa(o, "ListJobsRequest");
   }
 }
 
@@ -1552,7 +1555,7 @@ export interface ListJobsResult extends $MetadataBearer {
 
 export namespace ListJobsResult {
   export function isa(o: any): o is ListJobsResult {
-    return _smithy.isa(o, "ListJobsResult");
+    return __isa(o, "ListJobsResult");
   }
 }
 
@@ -1592,7 +1595,7 @@ export interface Notification {
 
 export namespace Notification {
   export function isa(o: any): o is Notification {
-    return _smithy.isa(o, "Notification");
+    return __isa(o, "Notification");
   }
 }
 
@@ -1621,7 +1624,7 @@ export interface S3Resource {
 
 export namespace S3Resource {
   export function isa(o: any): o is S3Resource {
-    return _smithy.isa(o, "S3Resource");
+    return __isa(o, "S3Resource");
   }
 }
 
@@ -1647,7 +1650,7 @@ export interface Shipment {
 
 export namespace Shipment {
   export function isa(o: any): o is Shipment {
-    return _smithy.isa(o, "Shipment");
+    return __isa(o, "Shipment");
   }
 }
 
@@ -1699,7 +1702,7 @@ export interface ShippingDetails {
 
 export namespace ShippingDetails {
   export function isa(o: any): o is ShippingDetails {
-    return _smithy.isa(o, "ShippingDetails");
+    return __isa(o, "ShippingDetails");
   }
 }
 
@@ -1731,7 +1734,7 @@ export enum SnowballType {
  *       contact AWS Support.</p>
  */
 export interface UnsupportedAddressException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UnsupportedAddressException";
   $fault: "client";
@@ -1740,7 +1743,7 @@ export interface UnsupportedAddressException
 
 export namespace UnsupportedAddressException {
   export function isa(o: any): o is UnsupportedAddressException {
-    return _smithy.isa(o, "UnsupportedAddressException");
+    return __isa(o, "UnsupportedAddressException");
   }
 }
 
@@ -1795,7 +1798,7 @@ export interface UpdateClusterRequest {
 
 export namespace UpdateClusterRequest {
   export function isa(o: any): o is UpdateClusterRequest {
-    return _smithy.isa(o, "UpdateClusterRequest");
+    return __isa(o, "UpdateClusterRequest");
   }
 }
 
@@ -1805,7 +1808,7 @@ export interface UpdateClusterResult extends $MetadataBearer {
 
 export namespace UpdateClusterResult {
   export function isa(o: any): o is UpdateClusterResult {
-    return _smithy.isa(o, "UpdateClusterResult");
+    return __isa(o, "UpdateClusterResult");
   }
 }
 
@@ -1865,7 +1868,7 @@ export interface UpdateJobRequest {
 
 export namespace UpdateJobRequest {
   export function isa(o: any): o is UpdateJobRequest {
-    return _smithy.isa(o, "UpdateJobRequest");
+    return __isa(o, "UpdateJobRequest");
   }
 }
 
@@ -1875,6 +1878,6 @@ export interface UpdateJobResult extends $MetadataBearer {
 
 export namespace UpdateJobResult {
   export function isa(o: any): o is UpdateJobResult {
-    return _smithy.isa(o, "UpdateJobResult");
+    return __isa(o, "UpdateJobResult");
   }
 }

--- a/clients/client-sns/models/index.ts
+++ b/clients/client-sns/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export interface AddPermissionInput {
@@ -29,7 +32,7 @@ export interface AddPermissionInput {
 
 export namespace AddPermissionInput {
   export function isa(o: any): o is AddPermissionInput {
-    return _smithy.isa(o, "AddPermissionInput");
+    return __isa(o, "AddPermissionInput");
   }
 }
 
@@ -37,7 +40,7 @@ export namespace AddPermissionInput {
  * <p>Indicates that the user has been denied access to the requested resource.</p>
  */
 export interface AuthorizationErrorException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AuthorizationErrorException";
   $fault: "client";
@@ -46,7 +49,7 @@ export interface AuthorizationErrorException
 
 export namespace AuthorizationErrorException {
   export function isa(o: any): o is AuthorizationErrorException {
-    return _smithy.isa(o, "AuthorizationErrorException");
+    return __isa(o, "AuthorizationErrorException");
   }
 }
 
@@ -63,7 +66,7 @@ export interface CheckIfPhoneNumberIsOptedOutInput {
 
 export namespace CheckIfPhoneNumberIsOptedOutInput {
   export function isa(o: any): o is CheckIfPhoneNumberIsOptedOutInput {
-    return _smithy.isa(o, "CheckIfPhoneNumberIsOptedOutInput");
+    return __isa(o, "CheckIfPhoneNumberIsOptedOutInput");
   }
 }
 
@@ -92,7 +95,7 @@ export interface CheckIfPhoneNumberIsOptedOutResponse extends $MetadataBearer {
 
 export namespace CheckIfPhoneNumberIsOptedOutResponse {
   export function isa(o: any): o is CheckIfPhoneNumberIsOptedOutResponse {
-    return _smithy.isa(o, "CheckIfPhoneNumberIsOptedOutResponse");
+    return __isa(o, "CheckIfPhoneNumberIsOptedOutResponse");
   }
 }
 
@@ -101,7 +104,7 @@ export namespace CheckIfPhoneNumberIsOptedOutResponse {
  *             sequentially.</p>
  */
 export interface ConcurrentAccessException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ConcurrentAccessException";
   $fault: "client";
@@ -110,7 +113,7 @@ export interface ConcurrentAccessException
 
 export namespace ConcurrentAccessException {
   export function isa(o: any): o is ConcurrentAccessException {
-    return _smithy.isa(o, "ConcurrentAccessException");
+    return __isa(o, "ConcurrentAccessException");
   }
 }
 
@@ -140,7 +143,7 @@ export interface ConfirmSubscriptionInput {
 
 export namespace ConfirmSubscriptionInput {
   export function isa(o: any): o is ConfirmSubscriptionInput {
-    return _smithy.isa(o, "ConfirmSubscriptionInput");
+    return __isa(o, "ConfirmSubscriptionInput");
   }
 }
 
@@ -157,7 +160,7 @@ export interface ConfirmSubscriptionResponse extends $MetadataBearer {
 
 export namespace ConfirmSubscriptionResponse {
   export function isa(o: any): o is ConfirmSubscriptionResponse {
-    return _smithy.isa(o, "ConfirmSubscriptionResponse");
+    return __isa(o, "ConfirmSubscriptionResponse");
   }
 }
 
@@ -174,7 +177,7 @@ export interface CreateEndpointResponse extends $MetadataBearer {
 
 export namespace CreateEndpointResponse {
   export function isa(o: any): o is CreateEndpointResponse {
-    return _smithy.isa(o, "CreateEndpointResponse");
+    return __isa(o, "CreateEndpointResponse");
   }
 }
 
@@ -205,7 +208,7 @@ export interface CreatePlatformApplicationInput {
 
 export namespace CreatePlatformApplicationInput {
   export function isa(o: any): o is CreatePlatformApplicationInput {
-    return _smithy.isa(o, "CreatePlatformApplicationInput");
+    return __isa(o, "CreatePlatformApplicationInput");
   }
 }
 
@@ -222,7 +225,7 @@ export interface CreatePlatformApplicationResponse extends $MetadataBearer {
 
 export namespace CreatePlatformApplicationResponse {
   export function isa(o: any): o is CreatePlatformApplicationResponse {
-    return _smithy.isa(o, "CreatePlatformApplicationResponse");
+    return __isa(o, "CreatePlatformApplicationResponse");
   }
 }
 
@@ -260,7 +263,7 @@ export interface CreatePlatformEndpointInput {
 
 export namespace CreatePlatformEndpointInput {
   export function isa(o: any): o is CreatePlatformEndpointInput {
-    return _smithy.isa(o, "CreatePlatformEndpointInput");
+    return __isa(o, "CreatePlatformEndpointInput");
   }
 }
 
@@ -324,7 +327,7 @@ export interface CreateTopicInput {
 
 export namespace CreateTopicInput {
   export function isa(o: any): o is CreateTopicInput {
-    return _smithy.isa(o, "CreateTopicInput");
+    return __isa(o, "CreateTopicInput");
   }
 }
 
@@ -341,7 +344,7 @@ export interface CreateTopicResponse extends $MetadataBearer {
 
 export namespace CreateTopicResponse {
   export function isa(o: any): o is CreateTopicResponse {
-    return _smithy.isa(o, "CreateTopicResponse");
+    return __isa(o, "CreateTopicResponse");
   }
 }
 
@@ -358,7 +361,7 @@ export interface DeleteEndpointInput {
 
 export namespace DeleteEndpointInput {
   export function isa(o: any): o is DeleteEndpointInput {
-    return _smithy.isa(o, "DeleteEndpointInput");
+    return __isa(o, "DeleteEndpointInput");
   }
 }
 
@@ -375,7 +378,7 @@ export interface DeletePlatformApplicationInput {
 
 export namespace DeletePlatformApplicationInput {
   export function isa(o: any): o is DeletePlatformApplicationInput {
-    return _smithy.isa(o, "DeletePlatformApplicationInput");
+    return __isa(o, "DeletePlatformApplicationInput");
   }
 }
 
@@ -389,7 +392,7 @@ export interface DeleteTopicInput {
 
 export namespace DeleteTopicInput {
   export function isa(o: any): o is DeleteTopicInput {
-    return _smithy.isa(o, "DeleteTopicInput");
+    return __isa(o, "DeleteTopicInput");
   }
 }
 
@@ -411,7 +414,7 @@ export interface Endpoint {
 
 export namespace Endpoint {
   export function isa(o: any): o is Endpoint {
-    return _smithy.isa(o, "Endpoint");
+    return __isa(o, "Endpoint");
   }
 }
 
@@ -419,7 +422,7 @@ export namespace Endpoint {
  * <p>Exception error indicating endpoint disabled.</p>
  */
 export interface EndpointDisabledException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "EndpointDisabledException";
   $fault: "client";
@@ -431,7 +434,7 @@ export interface EndpointDisabledException
 
 export namespace EndpointDisabledException {
   export function isa(o: any): o is EndpointDisabledException {
-    return _smithy.isa(o, "EndpointDisabledException");
+    return __isa(o, "EndpointDisabledException");
   }
 }
 
@@ -441,7 +444,7 @@ export namespace EndpointDisabledException {
  *             Center.</p>
  */
 export interface FilterPolicyLimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "FilterPolicyLimitExceededException";
   $fault: "client";
@@ -450,7 +453,7 @@ export interface FilterPolicyLimitExceededException
 
 export namespace FilterPolicyLimitExceededException {
   export function isa(o: any): o is FilterPolicyLimitExceededException {
-    return _smithy.isa(o, "FilterPolicyLimitExceededException");
+    return __isa(o, "FilterPolicyLimitExceededException");
   }
 }
 
@@ -467,7 +470,7 @@ export interface GetEndpointAttributesInput {
 
 export namespace GetEndpointAttributesInput {
   export function isa(o: any): o is GetEndpointAttributesInput {
-    return _smithy.isa(o, "GetEndpointAttributesInput");
+    return __isa(o, "GetEndpointAttributesInput");
   }
 }
 
@@ -509,7 +512,7 @@ export interface GetEndpointAttributesResponse extends $MetadataBearer {
 
 export namespace GetEndpointAttributesResponse {
   export function isa(o: any): o is GetEndpointAttributesResponse {
-    return _smithy.isa(o, "GetEndpointAttributesResponse");
+    return __isa(o, "GetEndpointAttributesResponse");
   }
 }
 
@@ -526,7 +529,7 @@ export interface GetPlatformApplicationAttributesInput {
 
 export namespace GetPlatformApplicationAttributesInput {
   export function isa(o: any): o is GetPlatformApplicationAttributesInput {
-    return _smithy.isa(o, "GetPlatformApplicationAttributesInput");
+    return __isa(o, "GetPlatformApplicationAttributesInput");
   }
 }
 
@@ -567,7 +570,7 @@ export interface GetPlatformApplicationAttributesResponse
 
 export namespace GetPlatformApplicationAttributesResponse {
   export function isa(o: any): o is GetPlatformApplicationAttributesResponse {
-    return _smithy.isa(o, "GetPlatformApplicationAttributesResponse");
+    return __isa(o, "GetPlatformApplicationAttributesResponse");
   }
 }
 
@@ -587,7 +590,7 @@ export interface GetSMSAttributesInput {
 
 export namespace GetSMSAttributesInput {
   export function isa(o: any): o is GetSMSAttributesInput {
-    return _smithy.isa(o, "GetSMSAttributesInput");
+    return __isa(o, "GetSMSAttributesInput");
   }
 }
 
@@ -604,7 +607,7 @@ export interface GetSMSAttributesResponse extends $MetadataBearer {
 
 export namespace GetSMSAttributesResponse {
   export function isa(o: any): o is GetSMSAttributesResponse {
-    return _smithy.isa(o, "GetSMSAttributesResponse");
+    return __isa(o, "GetSMSAttributesResponse");
   }
 }
 
@@ -621,7 +624,7 @@ export interface GetSubscriptionAttributesInput {
 
 export namespace GetSubscriptionAttributesInput {
   export function isa(o: any): o is GetSubscriptionAttributesInput {
-    return _smithy.isa(o, "GetSubscriptionAttributesInput");
+    return __isa(o, "GetSubscriptionAttributesInput");
   }
 }
 
@@ -695,7 +698,7 @@ export interface GetSubscriptionAttributesResponse extends $MetadataBearer {
 
 export namespace GetSubscriptionAttributesResponse {
   export function isa(o: any): o is GetSubscriptionAttributesResponse {
-    return _smithy.isa(o, "GetSubscriptionAttributesResponse");
+    return __isa(o, "GetSubscriptionAttributesResponse");
   }
 }
 
@@ -712,7 +715,7 @@ export interface GetTopicAttributesInput {
 
 export namespace GetTopicAttributesInput {
   export function isa(o: any): o is GetTopicAttributesInput {
-    return _smithy.isa(o, "GetTopicAttributesInput");
+    return __isa(o, "GetTopicAttributesInput");
   }
 }
 
@@ -785,7 +788,7 @@ export interface GetTopicAttributesResponse extends $MetadataBearer {
 
 export namespace GetTopicAttributesResponse {
   export function isa(o: any): o is GetTopicAttributesResponse {
-    return _smithy.isa(o, "GetTopicAttributesResponse");
+    return __isa(o, "GetTopicAttributesResponse");
   }
 }
 
@@ -793,7 +796,7 @@ export namespace GetTopicAttributesResponse {
  * <p>Indicates an internal service error.</p>
  */
 export interface InternalErrorException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalErrorException";
   $fault: "server";
@@ -802,7 +805,7 @@ export interface InternalErrorException
 
 export namespace InternalErrorException {
   export function isa(o: any): o is InternalErrorException {
-    return _smithy.isa(o, "InternalErrorException");
+    return __isa(o, "InternalErrorException");
   }
 }
 
@@ -811,7 +814,7 @@ export namespace InternalErrorException {
  *             constraints.</p>
  */
 export interface InvalidParameterException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidParameterException";
   $fault: "client";
@@ -820,7 +823,7 @@ export interface InvalidParameterException
 
 export namespace InvalidParameterException {
   export function isa(o: any): o is InvalidParameterException {
-    return _smithy.isa(o, "InvalidParameterException");
+    return __isa(o, "InvalidParameterException");
   }
 }
 
@@ -829,7 +832,7 @@ export namespace InvalidParameterException {
  *             constraints.</p>
  */
 export interface InvalidParameterValueException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidParameterValueException";
   $fault: "client";
@@ -841,7 +844,7 @@ export interface InvalidParameterValueException
 
 export namespace InvalidParameterValueException {
   export function isa(o: any): o is InvalidParameterValueException {
-    return _smithy.isa(o, "InvalidParameterValueException");
+    return __isa(o, "InvalidParameterValueException");
   }
 }
 
@@ -850,7 +853,7 @@ export namespace InvalidParameterValueException {
  *             request using Signature Version 4.</p>
  */
 export interface InvalidSecurityException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidSecurityException";
   $fault: "client";
@@ -859,7 +862,7 @@ export interface InvalidSecurityException
 
 export namespace InvalidSecurityException {
   export function isa(o: any): o is InvalidSecurityException {
-    return _smithy.isa(o, "InvalidSecurityException");
+    return __isa(o, "InvalidSecurityException");
   }
 }
 
@@ -868,7 +871,7 @@ export namespace InvalidSecurityException {
  *             to.</p>
  */
 export interface KMSAccessDeniedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "KMSAccessDeniedException";
   $fault: "client";
@@ -877,7 +880,7 @@ export interface KMSAccessDeniedException
 
 export namespace KMSAccessDeniedException {
   export function isa(o: any): o is KMSAccessDeniedException {
-    return _smithy.isa(o, "KMSAccessDeniedException");
+    return __isa(o, "KMSAccessDeniedException");
   }
 }
 
@@ -886,7 +889,7 @@ export namespace KMSAccessDeniedException {
  *             enabled.</p>
  */
 export interface KMSDisabledException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "KMSDisabledException";
   $fault: "client";
@@ -895,7 +898,7 @@ export interface KMSDisabledException
 
 export namespace KMSDisabledException {
   export function isa(o: any): o is KMSDisabledException {
-    return _smithy.isa(o, "KMSDisabledException");
+    return __isa(o, "KMSDisabledException");
   }
 }
 
@@ -906,7 +909,7 @@ export namespace KMSDisabledException {
  *                 Guide</i>.</p>
  */
 export interface KMSInvalidStateException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "KMSInvalidStateException";
   $fault: "client";
@@ -915,7 +918,7 @@ export interface KMSInvalidStateException
 
 export namespace KMSInvalidStateException {
   export function isa(o: any): o is KMSInvalidStateException {
-    return _smithy.isa(o, "KMSInvalidStateException");
+    return __isa(o, "KMSInvalidStateException");
   }
 }
 
@@ -924,7 +927,7 @@ export namespace KMSInvalidStateException {
  *             found.</p>
  */
 export interface KMSNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "KMSNotFoundException";
   $fault: "client";
@@ -933,16 +936,14 @@ export interface KMSNotFoundException
 
 export namespace KMSNotFoundException {
   export function isa(o: any): o is KMSNotFoundException {
-    return _smithy.isa(o, "KMSNotFoundException");
+    return __isa(o, "KMSNotFoundException");
   }
 }
 
 /**
  * <p>The AWS access key ID needs a subscription for the service.</p>
  */
-export interface KMSOptInRequired
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface KMSOptInRequired extends __SmithyException, $MetadataBearer {
   name: "KMSOptInRequired";
   $fault: "client";
   message?: string;
@@ -950,7 +951,7 @@ export interface KMSOptInRequired
 
 export namespace KMSOptInRequired {
   export function isa(o: any): o is KMSOptInRequired {
-    return _smithy.isa(o, "KMSOptInRequired");
+    return __isa(o, "KMSOptInRequired");
   }
 }
 
@@ -961,7 +962,7 @@ export namespace KMSOptInRequired {
  *          </p>
  */
 export interface KMSThrottlingException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "KMSThrottlingException";
   $fault: "client";
@@ -970,7 +971,7 @@ export interface KMSThrottlingException
 
 export namespace KMSThrottlingException {
   export function isa(o: any): o is KMSThrottlingException {
-    return _smithy.isa(o, "KMSThrottlingException");
+    return __isa(o, "KMSThrottlingException");
   }
 }
 
@@ -993,7 +994,7 @@ export interface ListEndpointsByPlatformApplicationInput {
 
 export namespace ListEndpointsByPlatformApplicationInput {
   export function isa(o: any): o is ListEndpointsByPlatformApplicationInput {
-    return _smithy.isa(o, "ListEndpointsByPlatformApplicationInput");
+    return __isa(o, "ListEndpointsByPlatformApplicationInput");
   }
 }
 
@@ -1017,7 +1018,7 @@ export interface ListEndpointsByPlatformApplicationResponse
 
 export namespace ListEndpointsByPlatformApplicationResponse {
   export function isa(o: any): o is ListEndpointsByPlatformApplicationResponse {
-    return _smithy.isa(o, "ListEndpointsByPlatformApplicationResponse");
+    return __isa(o, "ListEndpointsByPlatformApplicationResponse");
   }
 }
 
@@ -1036,7 +1037,7 @@ export interface ListPhoneNumbersOptedOutInput {
 
 export namespace ListPhoneNumbersOptedOutInput {
   export function isa(o: any): o is ListPhoneNumbersOptedOutInput {
-    return _smithy.isa(o, "ListPhoneNumbersOptedOutInput");
+    return __isa(o, "ListPhoneNumbersOptedOutInput");
   }
 }
 
@@ -1061,7 +1062,7 @@ export interface ListPhoneNumbersOptedOutResponse extends $MetadataBearer {
 
 export namespace ListPhoneNumbersOptedOutResponse {
   export function isa(o: any): o is ListPhoneNumbersOptedOutResponse {
-    return _smithy.isa(o, "ListPhoneNumbersOptedOutResponse");
+    return __isa(o, "ListPhoneNumbersOptedOutResponse");
   }
 }
 
@@ -1079,7 +1080,7 @@ export interface ListPlatformApplicationsInput {
 
 export namespace ListPlatformApplicationsInput {
   export function isa(o: any): o is ListPlatformApplicationsInput {
-    return _smithy.isa(o, "ListPlatformApplicationsInput");
+    return __isa(o, "ListPlatformApplicationsInput");
   }
 }
 
@@ -1102,7 +1103,7 @@ export interface ListPlatformApplicationsResponse extends $MetadataBearer {
 
 export namespace ListPlatformApplicationsResponse {
   export function isa(o: any): o is ListPlatformApplicationsResponse {
-    return _smithy.isa(o, "ListPlatformApplicationsResponse");
+    return __isa(o, "ListPlatformApplicationsResponse");
   }
 }
 
@@ -1124,7 +1125,7 @@ export interface ListSubscriptionsByTopicInput {
 
 export namespace ListSubscriptionsByTopicInput {
   export function isa(o: any): o is ListSubscriptionsByTopicInput {
-    return _smithy.isa(o, "ListSubscriptionsByTopicInput");
+    return __isa(o, "ListSubscriptionsByTopicInput");
   }
 }
 
@@ -1147,7 +1148,7 @@ export interface ListSubscriptionsByTopicResponse extends $MetadataBearer {
 
 export namespace ListSubscriptionsByTopicResponse {
   export function isa(o: any): o is ListSubscriptionsByTopicResponse {
-    return _smithy.isa(o, "ListSubscriptionsByTopicResponse");
+    return __isa(o, "ListSubscriptionsByTopicResponse");
   }
 }
 
@@ -1164,7 +1165,7 @@ export interface ListSubscriptionsInput {
 
 export namespace ListSubscriptionsInput {
   export function isa(o: any): o is ListSubscriptionsInput {
-    return _smithy.isa(o, "ListSubscriptionsInput");
+    return __isa(o, "ListSubscriptionsInput");
   }
 }
 
@@ -1187,7 +1188,7 @@ export interface ListSubscriptionsResponse extends $MetadataBearer {
 
 export namespace ListSubscriptionsResponse {
   export function isa(o: any): o is ListSubscriptionsResponse {
-    return _smithy.isa(o, "ListSubscriptionsResponse");
+    return __isa(o, "ListSubscriptionsResponse");
   }
 }
 
@@ -1201,7 +1202,7 @@ export interface ListTagsForResourceRequest {
 
 export namespace ListTagsForResourceRequest {
   export function isa(o: any): o is ListTagsForResourceRequest {
-    return _smithy.isa(o, "ListTagsForResourceRequest");
+    return __isa(o, "ListTagsForResourceRequest");
   }
 }
 
@@ -1215,7 +1216,7 @@ export interface ListTagsForResourceResponse extends $MetadataBearer {
 
 export namespace ListTagsForResourceResponse {
   export function isa(o: any): o is ListTagsForResourceResponse {
-    return _smithy.isa(o, "ListTagsForResourceResponse");
+    return __isa(o, "ListTagsForResourceResponse");
   }
 }
 
@@ -1229,7 +1230,7 @@ export interface ListTopicsInput {
 
 export namespace ListTopicsInput {
   export function isa(o: any): o is ListTopicsInput {
-    return _smithy.isa(o, "ListTopicsInput");
+    return __isa(o, "ListTopicsInput");
   }
 }
 
@@ -1252,7 +1253,7 @@ export interface ListTopicsResponse extends $MetadataBearer {
 
 export namespace ListTopicsResponse {
   export function isa(o: any): o is ListTopicsResponse {
-    return _smithy.isa(o, "ListTopicsResponse");
+    return __isa(o, "ListTopicsResponse");
   }
 }
 
@@ -1290,16 +1291,14 @@ export interface MessageAttributeValue {
 
 export namespace MessageAttributeValue {
   export function isa(o: any): o is MessageAttributeValue {
-    return _smithy.isa(o, "MessageAttributeValue");
+    return __isa(o, "MessageAttributeValue");
   }
 }
 
 /**
  * <p>Indicates that the requested resource does not exist.</p>
  */
-export interface NotFoundException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface NotFoundException extends __SmithyException, $MetadataBearer {
   name: "NotFoundException";
   $fault: "client";
   message?: string;
@@ -1307,7 +1306,7 @@ export interface NotFoundException
 
 export namespace NotFoundException {
   export function isa(o: any): o is NotFoundException {
-    return _smithy.isa(o, "NotFoundException");
+    return __isa(o, "NotFoundException");
   }
 }
 
@@ -1324,7 +1323,7 @@ export interface OptInPhoneNumberInput {
 
 export namespace OptInPhoneNumberInput {
   export function isa(o: any): o is OptInPhoneNumberInput {
-    return _smithy.isa(o, "OptInPhoneNumberInput");
+    return __isa(o, "OptInPhoneNumberInput");
   }
 }
 
@@ -1337,7 +1336,7 @@ export interface OptInPhoneNumberResponse extends $MetadataBearer {
 
 export namespace OptInPhoneNumberResponse {
   export function isa(o: any): o is OptInPhoneNumberResponse {
-    return _smithy.isa(o, "OptInPhoneNumberResponse");
+    return __isa(o, "OptInPhoneNumberResponse");
   }
 }
 
@@ -1359,7 +1358,7 @@ export interface PlatformApplication {
 
 export namespace PlatformApplication {
   export function isa(o: any): o is PlatformApplication {
-    return _smithy.isa(o, "PlatformApplication");
+    return __isa(o, "PlatformApplication");
   }
 }
 
@@ -1367,7 +1366,7 @@ export namespace PlatformApplication {
  * <p>Exception error indicating platform application disabled.</p>
  */
 export interface PlatformApplicationDisabledException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "PlatformApplicationDisabledException";
   $fault: "client";
@@ -1379,7 +1378,7 @@ export interface PlatformApplicationDisabledException
 
 export namespace PlatformApplicationDisabledException {
   export function isa(o: any): o is PlatformApplicationDisabledException {
-    return _smithy.isa(o, "PlatformApplicationDisabledException");
+    return __isa(o, "PlatformApplicationDisabledException");
   }
 }
 
@@ -1515,7 +1514,7 @@ export interface PublishInput {
 
 export namespace PublishInput {
   export function isa(o: any): o is PublishInput {
-    return _smithy.isa(o, "PublishInput");
+    return __isa(o, "PublishInput");
   }
 }
 
@@ -1533,7 +1532,7 @@ export interface PublishResponse extends $MetadataBearer {
 
 export namespace PublishResponse {
   export function isa(o: any): o is PublishResponse {
-    return _smithy.isa(o, "PublishResponse");
+    return __isa(o, "PublishResponse");
   }
 }
 
@@ -1555,7 +1554,7 @@ export interface RemovePermissionInput {
 
 export namespace RemovePermissionInput {
   export function isa(o: any): o is RemovePermissionInput {
-    return _smithy.isa(o, "RemovePermissionInput");
+    return __isa(o, "RemovePermissionInput");
   }
 }
 
@@ -1563,7 +1562,7 @@ export namespace RemovePermissionInput {
  * <p>Can't tag resource. Verify that the topic exists.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -1572,7 +1571,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -1616,7 +1615,7 @@ export interface SetEndpointAttributesInput {
 
 export namespace SetEndpointAttributesInput {
   export function isa(o: any): o is SetEndpointAttributesInput {
-    return _smithy.isa(o, "SetEndpointAttributesInput");
+    return __isa(o, "SetEndpointAttributesInput");
   }
 }
 
@@ -1691,7 +1690,7 @@ export interface SetPlatformApplicationAttributesInput {
 
 export namespace SetPlatformApplicationAttributesInput {
   export function isa(o: any): o is SetPlatformApplicationAttributesInput {
-    return _smithy.isa(o, "SetPlatformApplicationAttributesInput");
+    return __isa(o, "SetPlatformApplicationAttributesInput");
   }
 }
 
@@ -1793,7 +1792,7 @@ export interface SetSMSAttributesInput {
 
 export namespace SetSMSAttributesInput {
   export function isa(o: any): o is SetSMSAttributesInput {
-    return _smithy.isa(o, "SetSMSAttributesInput");
+    return __isa(o, "SetSMSAttributesInput");
   }
 }
 
@@ -1806,7 +1805,7 @@ export interface SetSMSAttributesResponse extends $MetadataBearer {
 
 export namespace SetSMSAttributesResponse {
   export function isa(o: any): o is SetSMSAttributesResponse {
-    return _smithy.isa(o, "SetSMSAttributesResponse");
+    return __isa(o, "SetSMSAttributesResponse");
   }
 }
 
@@ -1862,7 +1861,7 @@ export interface SetSubscriptionAttributesInput {
 
 export namespace SetSubscriptionAttributesInput {
   export function isa(o: any): o is SetSubscriptionAttributesInput {
-    return _smithy.isa(o, "SetSubscriptionAttributesInput");
+    return __isa(o, "SetSubscriptionAttributesInput");
   }
 }
 
@@ -1920,7 +1919,7 @@ export interface SetTopicAttributesInput {
 
 export namespace SetTopicAttributesInput {
   export function isa(o: any): o is SetTopicAttributesInput {
-    return _smithy.isa(o, "SetTopicAttributesInput");
+    return __isa(o, "SetTopicAttributesInput");
   }
 }
 
@@ -1928,9 +1927,7 @@ export namespace SetTopicAttributesInput {
  * <p>A tag has been added to a resource with the same ARN as a deleted resource.
  *             Wait a short while and then retry the operation.</p>
  */
-export interface StaleTagException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface StaleTagException extends __SmithyException, $MetadataBearer {
   name: "StaleTagException";
   $fault: "client";
   message?: string;
@@ -1938,7 +1935,7 @@ export interface StaleTagException
 
 export namespace StaleTagException {
   export function isa(o: any): o is StaleTagException {
-    return _smithy.isa(o, "StaleTagException");
+    return __isa(o, "StaleTagException");
   }
 }
 
@@ -2095,7 +2092,7 @@ export interface SubscribeInput {
 
 export namespace SubscribeInput {
   export function isa(o: any): o is SubscribeInput {
-    return _smithy.isa(o, "SubscribeInput");
+    return __isa(o, "SubscribeInput");
   }
 }
 
@@ -2115,7 +2112,7 @@ export interface SubscribeResponse extends $MetadataBearer {
 
 export namespace SubscribeResponse {
   export function isa(o: any): o is SubscribeResponse {
-    return _smithy.isa(o, "SubscribeResponse");
+    return __isa(o, "SubscribeResponse");
   }
 }
 
@@ -2152,7 +2149,7 @@ export interface Subscription {
 
 export namespace Subscription {
   export function isa(o: any): o is Subscription {
-    return _smithy.isa(o, "Subscription");
+    return __isa(o, "Subscription");
   }
 }
 
@@ -2161,7 +2158,7 @@ export namespace Subscription {
  *             subscriptions.</p>
  */
 export interface SubscriptionLimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "SubscriptionLimitExceededException";
   $fault: "client";
@@ -2170,7 +2167,7 @@ export interface SubscriptionLimitExceededException
 
 export namespace SubscriptionLimitExceededException {
   export function isa(o: any): o is SubscriptionLimitExceededException {
-    return _smithy.isa(o, "SubscriptionLimitExceededException");
+    return __isa(o, "SubscriptionLimitExceededException");
   }
 }
 
@@ -2192,7 +2189,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -2200,7 +2197,7 @@ export namespace Tag {
  * <p>Can't add more than 50 tags to a topic.</p>
  */
 export interface TagLimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TagLimitExceededException";
   $fault: "client";
@@ -2209,7 +2206,7 @@ export interface TagLimitExceededException
 
 export namespace TagLimitExceededException {
   export function isa(o: any): o is TagLimitExceededException {
-    return _smithy.isa(o, "TagLimitExceededException");
+    return __isa(o, "TagLimitExceededException");
   }
 }
 
@@ -2217,9 +2214,7 @@ export namespace TagLimitExceededException {
  * <p>The request doesn't comply with the IAM tag policy. Correct your request and then
  *             retry it.</p>
  */
-export interface TagPolicyException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface TagPolicyException extends __SmithyException, $MetadataBearer {
   name: "TagPolicyException";
   $fault: "client";
   message?: string;
@@ -2227,7 +2222,7 @@ export interface TagPolicyException
 
 export namespace TagPolicyException {
   export function isa(o: any): o is TagPolicyException {
-    return _smithy.isa(o, "TagPolicyException");
+    return __isa(o, "TagPolicyException");
   }
 }
 
@@ -2247,7 +2242,7 @@ export interface TagResourceRequest {
 
 export namespace TagResourceRequest {
   export function isa(o: any): o is TagResourceRequest {
-    return _smithy.isa(o, "TagResourceRequest");
+    return __isa(o, "TagResourceRequest");
   }
 }
 
@@ -2257,7 +2252,7 @@ export interface TagResourceResponse extends $MetadataBearer {
 
 export namespace TagResourceResponse {
   export function isa(o: any): o is TagResourceResponse {
-    return _smithy.isa(o, "TagResourceResponse");
+    return __isa(o, "TagResourceResponse");
   }
 }
 
@@ -2265,9 +2260,7 @@ export namespace TagResourceResponse {
  * <p>Indicates that the rate at which requests have been submitted for this action exceeds
  *             the limit for your account.</p>
  */
-export interface ThrottledException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface ThrottledException extends __SmithyException, $MetadataBearer {
   name: "ThrottledException";
   $fault: "client";
   /**
@@ -2278,7 +2271,7 @@ export interface ThrottledException
 
 export namespace ThrottledException {
   export function isa(o: any): o is ThrottledException {
-    return _smithy.isa(o, "ThrottledException");
+    return __isa(o, "ThrottledException");
   }
 }
 
@@ -2296,7 +2289,7 @@ export interface Topic {
 
 export namespace Topic {
   export function isa(o: any): o is Topic {
-    return _smithy.isa(o, "Topic");
+    return __isa(o, "Topic");
   }
 }
 
@@ -2304,7 +2297,7 @@ export namespace Topic {
  * <p>Indicates that the customer already owns the maximum allowed number of topics.</p>
  */
 export interface TopicLimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TopicLimitExceededException";
   $fault: "client";
@@ -2313,7 +2306,7 @@ export interface TopicLimitExceededException
 
 export namespace TopicLimitExceededException {
   export function isa(o: any): o is TopicLimitExceededException {
-    return _smithy.isa(o, "TopicLimitExceededException");
+    return __isa(o, "TopicLimitExceededException");
   }
 }
 
@@ -2330,7 +2323,7 @@ export interface UnsubscribeInput {
 
 export namespace UnsubscribeInput {
   export function isa(o: any): o is UnsubscribeInput {
-    return _smithy.isa(o, "UnsubscribeInput");
+    return __isa(o, "UnsubscribeInput");
   }
 }
 
@@ -2349,7 +2342,7 @@ export interface UntagResourceRequest {
 
 export namespace UntagResourceRequest {
   export function isa(o: any): o is UntagResourceRequest {
-    return _smithy.isa(o, "UntagResourceRequest");
+    return __isa(o, "UntagResourceRequest");
   }
 }
 
@@ -2359,6 +2352,6 @@ export interface UntagResourceResponse extends $MetadataBearer {
 
 export namespace UntagResourceResponse {
   export function isa(o: any): o is UntagResourceResponse {
-    return _smithy.isa(o, "UntagResourceResponse");
+    return __isa(o, "UntagResourceResponse");
   }
 }

--- a/clients/client-sns/protocols/Aws_query.ts
+++ b/clients/client-sns/protocols/Aws_query.ts
@@ -802,6 +802,7 @@ export async function deserializeAws_queryAddPermissionCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_queryAddPermissionCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: AddPermissionCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1319,6 +1320,7 @@ export async function deserializeAws_queryDeleteEndpointCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_queryDeleteEndpointCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteEndpointCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1386,6 +1388,7 @@ export async function deserializeAws_queryDeletePlatformApplicationCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeletePlatformApplicationCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1450,6 +1453,7 @@ export async function deserializeAws_queryDeleteTopicCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_queryDeleteTopicCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteTopicCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2729,6 +2733,7 @@ export async function deserializeAws_queryRemovePermissionCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_queryRemovePermissionCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: RemovePermissionCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2803,6 +2808,7 @@ export async function deserializeAws_querySetEndpointAttributesCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: SetEndpointAttributesCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2877,6 +2883,7 @@ export async function deserializeAws_querySetPlatformApplicationAttributesComman
       context
     );
   }
+  await collectBody(output.body, context);
   const response: SetPlatformApplicationAttributesCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -3030,6 +3037,7 @@ export async function deserializeAws_querySetSubscriptionAttributesCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: SetSubscriptionAttributesCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -3108,6 +3116,7 @@ export async function deserializeAws_querySetTopicAttributesCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_querySetTopicAttributesCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: SetTopicAttributesCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -3386,6 +3395,7 @@ export async function deserializeAws_queryUnsubscribeCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_queryUnsubscribeCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: UnsubscribeCommandOutput = {
     $metadata: deserializeMetadata(output)
   };

--- a/clients/client-sqs/models/index.ts
+++ b/clients/client-sqs/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -35,7 +38,7 @@ export interface AddPermissionRequest {
 
 export namespace AddPermissionRequest {
   export function isa(o: any): o is AddPermissionRequest {
-    return _smithy.isa(o, "AddPermissionRequest");
+    return __isa(o, "AddPermissionRequest");
   }
 }
 
@@ -43,7 +46,7 @@ export namespace AddPermissionRequest {
  * <p>Two or more batch entries in the request have the same <code>Id</code>.</p>
  */
 export interface BatchEntryIdsNotDistinct
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "BatchEntryIdsNotDistinct";
   $fault: "client";
@@ -51,7 +54,7 @@ export interface BatchEntryIdsNotDistinct
 
 export namespace BatchEntryIdsNotDistinct {
   export function isa(o: any): o is BatchEntryIdsNotDistinct {
-    return _smithy.isa(o, "BatchEntryIdsNotDistinct");
+    return __isa(o, "BatchEntryIdsNotDistinct");
   }
 }
 
@@ -59,7 +62,7 @@ export namespace BatchEntryIdsNotDistinct {
  * <p>The length of all the messages put together is more than the limit.</p>
  */
 export interface BatchRequestTooLong
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "BatchRequestTooLong";
   $fault: "client";
@@ -67,7 +70,7 @@ export interface BatchRequestTooLong
 
 export namespace BatchRequestTooLong {
   export function isa(o: any): o is BatchRequestTooLong {
-    return _smithy.isa(o, "BatchRequestTooLong");
+    return __isa(o, "BatchRequestTooLong");
   }
 }
 
@@ -100,7 +103,7 @@ export interface BatchResultErrorEntry {
 
 export namespace BatchResultErrorEntry {
   export function isa(o: any): o is BatchResultErrorEntry {
-    return _smithy.isa(o, "BatchResultErrorEntry");
+    return __isa(o, "BatchResultErrorEntry");
   }
 }
 
@@ -123,7 +126,7 @@ export interface ChangeMessageVisibilityBatchRequest {
 
 export namespace ChangeMessageVisibilityBatchRequest {
   export function isa(o: any): o is ChangeMessageVisibilityBatchRequest {
-    return _smithy.isa(o, "ChangeMessageVisibilityBatchRequest");
+    return __isa(o, "ChangeMessageVisibilityBatchRequest");
   }
 }
 
@@ -167,7 +170,7 @@ export interface ChangeMessageVisibilityBatchRequestEntry {
 
 export namespace ChangeMessageVisibilityBatchRequestEntry {
   export function isa(o: any): o is ChangeMessageVisibilityBatchRequestEntry {
-    return _smithy.isa(o, "ChangeMessageVisibilityBatchRequestEntry");
+    return __isa(o, "ChangeMessageVisibilityBatchRequestEntry");
   }
 }
 
@@ -197,7 +200,7 @@ export interface ChangeMessageVisibilityBatchResult extends $MetadataBearer {
 
 export namespace ChangeMessageVisibilityBatchResult {
   export function isa(o: any): o is ChangeMessageVisibilityBatchResult {
-    return _smithy.isa(o, "ChangeMessageVisibilityBatchResult");
+    return __isa(o, "ChangeMessageVisibilityBatchResult");
   }
 }
 
@@ -216,7 +219,7 @@ export interface ChangeMessageVisibilityBatchResultEntry {
 
 export namespace ChangeMessageVisibilityBatchResultEntry {
   export function isa(o: any): o is ChangeMessageVisibilityBatchResultEntry {
-    return _smithy.isa(o, "ChangeMessageVisibilityBatchResultEntry");
+    return __isa(o, "ChangeMessageVisibilityBatchResultEntry");
   }
 }
 
@@ -243,7 +246,7 @@ export interface ChangeMessageVisibilityRequest {
 
 export namespace ChangeMessageVisibilityRequest {
   export function isa(o: any): o is ChangeMessageVisibilityRequest {
-    return _smithy.isa(o, "ChangeMessageVisibilityRequest");
+    return __isa(o, "ChangeMessageVisibilityRequest");
   }
 }
 
@@ -431,7 +434,7 @@ export interface CreateQueueRequest {
 
 export namespace CreateQueueRequest {
   export function isa(o: any): o is CreateQueueRequest {
-    return _smithy.isa(o, "CreateQueueRequest");
+    return __isa(o, "CreateQueueRequest");
   }
 }
 
@@ -448,7 +451,7 @@ export interface CreateQueueResult extends $MetadataBearer {
 
 export namespace CreateQueueResult {
   export function isa(o: any): o is CreateQueueResult {
-    return _smithy.isa(o, "CreateQueueResult");
+    return __isa(o, "CreateQueueResult");
   }
 }
 
@@ -471,7 +474,7 @@ export interface DeleteMessageBatchRequest {
 
 export namespace DeleteMessageBatchRequest {
   export function isa(o: any): o is DeleteMessageBatchRequest {
-    return _smithy.isa(o, "DeleteMessageBatchRequest");
+    return __isa(o, "DeleteMessageBatchRequest");
   }
 }
 
@@ -496,7 +499,7 @@ export interface DeleteMessageBatchRequestEntry {
 
 export namespace DeleteMessageBatchRequestEntry {
   export function isa(o: any): o is DeleteMessageBatchRequestEntry {
-    return _smithy.isa(o, "DeleteMessageBatchRequestEntry");
+    return __isa(o, "DeleteMessageBatchRequestEntry");
   }
 }
 
@@ -526,7 +529,7 @@ export interface DeleteMessageBatchResult extends $MetadataBearer {
 
 export namespace DeleteMessageBatchResult {
   export function isa(o: any): o is DeleteMessageBatchResult {
-    return _smithy.isa(o, "DeleteMessageBatchResult");
+    return __isa(o, "DeleteMessageBatchResult");
   }
 }
 
@@ -545,7 +548,7 @@ export interface DeleteMessageBatchResultEntry {
 
 export namespace DeleteMessageBatchResultEntry {
   export function isa(o: any): o is DeleteMessageBatchResultEntry {
-    return _smithy.isa(o, "DeleteMessageBatchResultEntry");
+    return __isa(o, "DeleteMessageBatchResultEntry");
   }
 }
 
@@ -568,7 +571,7 @@ export interface DeleteMessageRequest {
 
 export namespace DeleteMessageRequest {
   export function isa(o: any): o is DeleteMessageRequest {
-    return _smithy.isa(o, "DeleteMessageRequest");
+    return __isa(o, "DeleteMessageRequest");
   }
 }
 
@@ -586,23 +589,21 @@ export interface DeleteQueueRequest {
 
 export namespace DeleteQueueRequest {
   export function isa(o: any): o is DeleteQueueRequest {
-    return _smithy.isa(o, "DeleteQueueRequest");
+    return __isa(o, "DeleteQueueRequest");
   }
 }
 
 /**
  * <p>The batch request doesn't contain any entries.</p>
  */
-export interface EmptyBatchRequest
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface EmptyBatchRequest extends __SmithyException, $MetadataBearer {
   name: "EmptyBatchRequest";
   $fault: "client";
 }
 
 export namespace EmptyBatchRequest {
   export function isa(o: any): o is EmptyBatchRequest {
-    return _smithy.isa(o, "EmptyBatchRequest");
+    return __isa(o, "EmptyBatchRequest");
   }
 }
 
@@ -751,7 +752,7 @@ export interface GetQueueAttributesRequest {
 
 export namespace GetQueueAttributesRequest {
   export function isa(o: any): o is GetQueueAttributesRequest {
-    return _smithy.isa(o, "GetQueueAttributesRequest");
+    return __isa(o, "GetQueueAttributesRequest");
   }
 }
 
@@ -768,7 +769,7 @@ export interface GetQueueAttributesResult extends $MetadataBearer {
 
 export namespace GetQueueAttributesResult {
   export function isa(o: any): o is GetQueueAttributesResult {
-    return _smithy.isa(o, "GetQueueAttributesResult");
+    return __isa(o, "GetQueueAttributesResult");
   }
 }
 
@@ -791,7 +792,7 @@ export interface GetQueueUrlRequest {
 
 export namespace GetQueueUrlRequest {
   export function isa(o: any): o is GetQueueUrlRequest {
-    return _smithy.isa(o, "GetQueueUrlRequest");
+    return __isa(o, "GetQueueUrlRequest");
   }
 }
 
@@ -808,7 +809,7 @@ export interface GetQueueUrlResult extends $MetadataBearer {
 
 export namespace GetQueueUrlResult {
   export function isa(o: any): o is GetQueueUrlResult {
-    return _smithy.isa(o, "GetQueueUrlResult");
+    return __isa(o, "GetQueueUrlResult");
   }
 }
 
@@ -816,7 +817,7 @@ export namespace GetQueueUrlResult {
  * <p>The specified attribute doesn't exist.</p>
  */
 export interface InvalidAttributeName
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidAttributeName";
   $fault: "client";
@@ -824,7 +825,7 @@ export interface InvalidAttributeName
 
 export namespace InvalidAttributeName {
   export function isa(o: any): o is InvalidAttributeName {
-    return _smithy.isa(o, "InvalidAttributeName");
+    return __isa(o, "InvalidAttributeName");
   }
 }
 
@@ -832,7 +833,7 @@ export namespace InvalidAttributeName {
  * <p>The <code>Id</code> of a batch entry in a batch request doesn't abide by the specification.</p>
  */
 export interface InvalidBatchEntryId
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidBatchEntryId";
   $fault: "client";
@@ -840,23 +841,21 @@ export interface InvalidBatchEntryId
 
 export namespace InvalidBatchEntryId {
   export function isa(o: any): o is InvalidBatchEntryId {
-    return _smithy.isa(o, "InvalidBatchEntryId");
+    return __isa(o, "InvalidBatchEntryId");
   }
 }
 
 /**
  * <p>The specified receipt handle isn't valid for the current version.</p>
  */
-export interface InvalidIdFormat
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface InvalidIdFormat extends __SmithyException, $MetadataBearer {
   name: "InvalidIdFormat";
   $fault: "client";
 }
 
 export namespace InvalidIdFormat {
   export function isa(o: any): o is InvalidIdFormat {
-    return _smithy.isa(o, "InvalidIdFormat");
+    return __isa(o, "InvalidIdFormat");
   }
 }
 
@@ -864,7 +863,7 @@ export namespace InvalidIdFormat {
  * <p>The message contains characters outside the allowed set.</p>
  */
 export interface InvalidMessageContents
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidMessageContents";
   $fault: "client";
@@ -872,7 +871,7 @@ export interface InvalidMessageContents
 
 export namespace InvalidMessageContents {
   export function isa(o: any): o is InvalidMessageContents {
-    return _smithy.isa(o, "InvalidMessageContents");
+    return __isa(o, "InvalidMessageContents");
   }
 }
 
@@ -890,7 +889,7 @@ export interface ListDeadLetterSourceQueuesRequest {
 
 export namespace ListDeadLetterSourceQueuesRequest {
   export function isa(o: any): o is ListDeadLetterSourceQueuesRequest {
-    return _smithy.isa(o, "ListDeadLetterSourceQueuesRequest");
+    return __isa(o, "ListDeadLetterSourceQueuesRequest");
   }
 }
 
@@ -907,7 +906,7 @@ export interface ListDeadLetterSourceQueuesResult extends $MetadataBearer {
 
 export namespace ListDeadLetterSourceQueuesResult {
   export function isa(o: any): o is ListDeadLetterSourceQueuesResult {
-    return _smithy.isa(o, "ListDeadLetterSourceQueuesResult");
+    return __isa(o, "ListDeadLetterSourceQueuesResult");
   }
 }
 
@@ -921,7 +920,7 @@ export interface ListQueueTagsRequest {
 
 export namespace ListQueueTagsRequest {
   export function isa(o: any): o is ListQueueTagsRequest {
-    return _smithy.isa(o, "ListQueueTagsRequest");
+    return __isa(o, "ListQueueTagsRequest");
   }
 }
 
@@ -935,7 +934,7 @@ export interface ListQueueTagsResult extends $MetadataBearer {
 
 export namespace ListQueueTagsResult {
   export function isa(o: any): o is ListQueueTagsResult {
-    return _smithy.isa(o, "ListQueueTagsResult");
+    return __isa(o, "ListQueueTagsResult");
   }
 }
 
@@ -953,7 +952,7 @@ export interface ListQueuesRequest {
 
 export namespace ListQueuesRequest {
   export function isa(o: any): o is ListQueuesRequest {
-    return _smithy.isa(o, "ListQueuesRequest");
+    return __isa(o, "ListQueuesRequest");
   }
 }
 
@@ -970,7 +969,7 @@ export interface ListQueuesResult extends $MetadataBearer {
 
 export namespace ListQueuesResult {
   export function isa(o: any): o is ListQueuesResult {
-    return _smithy.isa(o, "ListQueuesResult");
+    return __isa(o, "ListQueuesResult");
   }
 }
 
@@ -1060,7 +1059,7 @@ export interface Message {
 
 export namespace Message {
   export function isa(o: any): o is Message {
-    return _smithy.isa(o, "Message");
+    return __isa(o, "Message");
   }
 }
 
@@ -1102,23 +1101,21 @@ export interface MessageAttributeValue {
 
 export namespace MessageAttributeValue {
   export function isa(o: any): o is MessageAttributeValue {
-    return _smithy.isa(o, "MessageAttributeValue");
+    return __isa(o, "MessageAttributeValue");
   }
 }
 
 /**
  * <p>The specified message isn't in flight.</p>
  */
-export interface MessageNotInflight
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface MessageNotInflight extends __SmithyException, $MetadataBearer {
   name: "MessageNotInflight";
   $fault: "client";
 }
 
 export namespace MessageNotInflight {
   export function isa(o: any): o is MessageNotInflight {
-    return _smithy.isa(o, "MessageNotInflight");
+    return __isa(o, "MessageNotInflight");
   }
 }
 
@@ -1172,7 +1169,7 @@ export interface MessageSystemAttributeValue {
 
 export namespace MessageSystemAttributeValue {
   export function isa(o: any): o is MessageSystemAttributeValue {
-    return _smithy.isa(o, "MessageSystemAttributeValue");
+    return __isa(o, "MessageSystemAttributeValue");
   }
 }
 
@@ -1182,14 +1179,14 @@ export namespace MessageSystemAttributeValue {
  *                 <code>AddPermission</code> returns this error if the maximum number of permissions
  *             for the queue is reached.</p>
  */
-export interface OverLimit extends _smithy.SmithyException, $MetadataBearer {
+export interface OverLimit extends __SmithyException, $MetadataBearer {
   name: "OverLimit";
   $fault: "client";
 }
 
 export namespace OverLimit {
   export function isa(o: any): o is OverLimit {
-    return _smithy.isa(o, "OverLimit");
+    return __isa(o, "OverLimit");
   }
 }
 
@@ -1197,7 +1194,7 @@ export namespace OverLimit {
  * <p>Indicates that the specified queue previously received a <code>PurgeQueue</code> request within the last 60 seconds (the time it can take to delete the messages in the queue).</p>
  */
 export interface PurgeQueueInProgress
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "PurgeQueueInProgress";
   $fault: "client";
@@ -1205,7 +1202,7 @@ export interface PurgeQueueInProgress
 
 export namespace PurgeQueueInProgress {
   export function isa(o: any): o is PurgeQueueInProgress {
-    return _smithy.isa(o, "PurgeQueueInProgress");
+    return __isa(o, "PurgeQueueInProgress");
   }
 }
 
@@ -1223,7 +1220,7 @@ export interface PurgeQueueRequest {
 
 export namespace PurgeQueueRequest {
   export function isa(o: any): o is PurgeQueueRequest {
-    return _smithy.isa(o, "PurgeQueueRequest");
+    return __isa(o, "PurgeQueueRequest");
   }
 }
 
@@ -1252,7 +1249,7 @@ export type QueueAttributeName =
  *             with the same name.</p>
  */
 export interface QueueDeletedRecently
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "QueueDeletedRecently";
   $fault: "client";
@@ -1260,23 +1257,21 @@ export interface QueueDeletedRecently
 
 export namespace QueueDeletedRecently {
   export function isa(o: any): o is QueueDeletedRecently {
-    return _smithy.isa(o, "QueueDeletedRecently");
+    return __isa(o, "QueueDeletedRecently");
   }
 }
 
 /**
  * <p>The specified queue doesn't exist.</p>
  */
-export interface QueueDoesNotExist
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface QueueDoesNotExist extends __SmithyException, $MetadataBearer {
   name: "QueueDoesNotExist";
   $fault: "client";
 }
 
 export namespace QueueDoesNotExist {
   export function isa(o: any): o is QueueDoesNotExist {
-    return _smithy.isa(o, "QueueDoesNotExist");
+    return __isa(o, "QueueDoesNotExist");
   }
 }
 
@@ -1284,16 +1279,14 @@ export namespace QueueDoesNotExist {
  * <p>A queue with this name already exists. Amazon SQS returns this error only if the request
  *             includes attributes whose values differ from those of the existing queue.</p>
  */
-export interface QueueNameExists
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface QueueNameExists extends __SmithyException, $MetadataBearer {
   name: "QueueNameExists";
   $fault: "client";
 }
 
 export namespace QueueNameExists {
   export function isa(o: any): o is QueueNameExists {
-    return _smithy.isa(o, "QueueNameExists");
+    return __isa(o, "QueueNameExists");
   }
 }
 
@@ -1301,7 +1294,7 @@ export namespace QueueNameExists {
  * <p>The specified receipt handle isn't valid.</p>
  */
 export interface ReceiptHandleIsInvalid
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ReceiptHandleIsInvalid";
   $fault: "client";
@@ -1309,7 +1302,7 @@ export interface ReceiptHandleIsInvalid
 
 export namespace ReceiptHandleIsInvalid {
   export function isa(o: any): o is ReceiptHandleIsInvalid {
-    return _smithy.isa(o, "ReceiptHandleIsInvalid");
+    return __isa(o, "ReceiptHandleIsInvalid");
   }
 }
 
@@ -1479,7 +1472,7 @@ export interface ReceiveMessageRequest {
 
 export namespace ReceiveMessageRequest {
   export function isa(o: any): o is ReceiveMessageRequest {
-    return _smithy.isa(o, "ReceiveMessageRequest");
+    return __isa(o, "ReceiveMessageRequest");
   }
 }
 
@@ -1496,7 +1489,7 @@ export interface ReceiveMessageResult extends $MetadataBearer {
 
 export namespace ReceiveMessageResult {
   export function isa(o: any): o is ReceiveMessageResult {
-    return _smithy.isa(o, "ReceiveMessageResult");
+    return __isa(o, "ReceiveMessageResult");
   }
 }
 
@@ -1521,7 +1514,7 @@ export interface RemovePermissionRequest {
 
 export namespace RemovePermissionRequest {
   export function isa(o: any): o is RemovePermissionRequest {
-    return _smithy.isa(o, "RemovePermissionRequest");
+    return __isa(o, "RemovePermissionRequest");
   }
 }
 
@@ -1546,7 +1539,7 @@ export interface SendMessageBatchRequest {
 
 export namespace SendMessageBatchRequest {
   export function isa(o: any): o is SendMessageBatchRequest {
-    return _smithy.isa(o, "SendMessageBatchRequest");
+    return __isa(o, "SendMessageBatchRequest");
   }
 }
 
@@ -1686,7 +1679,7 @@ export interface SendMessageBatchRequestEntry {
 
 export namespace SendMessageBatchRequestEntry {
   export function isa(o: any): o is SendMessageBatchRequestEntry {
-    return _smithy.isa(o, "SendMessageBatchRequestEntry");
+    return __isa(o, "SendMessageBatchRequestEntry");
   }
 }
 
@@ -1716,7 +1709,7 @@ export interface SendMessageBatchResult extends $MetadataBearer {
 
 export namespace SendMessageBatchResult {
   export function isa(o: any): o is SendMessageBatchResult {
-    return _smithy.isa(o, "SendMessageBatchResult");
+    return __isa(o, "SendMessageBatchResult");
   }
 }
 
@@ -1762,7 +1755,7 @@ export interface SendMessageBatchResultEntry {
 
 export namespace SendMessageBatchResultEntry {
   export function isa(o: any): o is SendMessageBatchResultEntry {
-    return _smithy.isa(o, "SendMessageBatchResultEntry");
+    return __isa(o, "SendMessageBatchResultEntry");
   }
 }
 
@@ -1906,7 +1899,7 @@ export interface SendMessageRequest {
 
 export namespace SendMessageRequest {
   export function isa(o: any): o is SendMessageRequest {
-    return _smithy.isa(o, "SendMessageRequest");
+    return __isa(o, "SendMessageRequest");
   }
 }
 
@@ -1947,7 +1940,7 @@ export interface SendMessageResult extends $MetadataBearer {
 
 export namespace SendMessageResult {
   export function isa(o: any): o is SendMessageResult {
-    return _smithy.isa(o, "SendMessageResult");
+    return __isa(o, "SendMessageResult");
   }
 }
 
@@ -2089,7 +2082,7 @@ export interface SetQueueAttributesRequest {
 
 export namespace SetQueueAttributesRequest {
   export function isa(o: any): o is SetQueueAttributesRequest {
-    return _smithy.isa(o, "SetQueueAttributesRequest");
+    return __isa(o, "SetQueueAttributesRequest");
   }
 }
 
@@ -2108,7 +2101,7 @@ export interface TagQueueRequest {
 
 export namespace TagQueueRequest {
   export function isa(o: any): o is TagQueueRequest {
-    return _smithy.isa(o, "TagQueueRequest");
+    return __isa(o, "TagQueueRequest");
   }
 }
 
@@ -2116,7 +2109,7 @@ export namespace TagQueueRequest {
  * <p>The batch request contains more entries than permissible.</p>
  */
 export interface TooManyEntriesInBatchRequest
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyEntriesInBatchRequest";
   $fault: "client";
@@ -2124,7 +2117,7 @@ export interface TooManyEntriesInBatchRequest
 
 export namespace TooManyEntriesInBatchRequest {
   export function isa(o: any): o is TooManyEntriesInBatchRequest {
-    return _smithy.isa(o, "TooManyEntriesInBatchRequest");
+    return __isa(o, "TooManyEntriesInBatchRequest");
   }
 }
 
@@ -2132,7 +2125,7 @@ export namespace TooManyEntriesInBatchRequest {
  * <p>Error code 400. Unsupported operation.</p>
  */
 export interface UnsupportedOperation
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UnsupportedOperation";
   $fault: "client";
@@ -2140,7 +2133,7 @@ export interface UnsupportedOperation
 
 export namespace UnsupportedOperation {
   export function isa(o: any): o is UnsupportedOperation {
-    return _smithy.isa(o, "UnsupportedOperation");
+    return __isa(o, "UnsupportedOperation");
   }
 }
 
@@ -2159,6 +2152,6 @@ export interface UntagQueueRequest {
 
 export namespace UntagQueueRequest {
   export function isa(o: any): o is UntagQueueRequest {
-    return _smithy.isa(o, "UntagQueueRequest");
+    return __isa(o, "UntagQueueRequest");
   }
 }

--- a/clients/client-sqs/protocols/Aws_query.ts
+++ b/clients/client-sqs/protocols/Aws_query.ts
@@ -491,6 +491,7 @@ export async function deserializeAws_queryAddPermissionCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_queryAddPermissionCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: AddPermissionCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -544,6 +545,7 @@ export async function deserializeAws_queryChangeMessageVisibilityCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: ChangeMessageVisibilityCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -748,6 +750,7 @@ export async function deserializeAws_queryDeleteMessageCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_queryDeleteMessageCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteMessageCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -884,6 +887,7 @@ export async function deserializeAws_queryDeleteQueueCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_queryDeleteQueueCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteQueueCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1206,6 +1210,7 @@ export async function deserializeAws_queryPurgeQueueCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_queryPurgeQueueCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: PurgeQueueCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1321,6 +1326,7 @@ export async function deserializeAws_queryRemovePermissionCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_queryRemovePermissionCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: RemovePermissionCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1522,6 +1528,7 @@ export async function deserializeAws_querySetQueueAttributesCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_querySetQueueAttributesCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: SetQueueAttributesCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1572,6 +1579,7 @@ export async function deserializeAws_queryTagQueueCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_queryTagQueueCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: TagQueueCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1615,6 +1623,7 @@ export async function deserializeAws_queryUntagQueueCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_queryUntagQueueCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: UntagQueueCommandOutput = {
     $metadata: deserializeMetadata(output)
   };

--- a/clients/client-ssm/models/index.ts
+++ b/clients/client-ssm/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -20,7 +23,7 @@ export interface AccountSharingInfo {
 
 export namespace AccountSharingInfo {
   export function isa(o: any): o is AccountSharingInfo {
-    return _smithy.isa(o, "AccountSharingInfo");
+    return __isa(o, "AccountSharingInfo");
   }
 }
 
@@ -85,7 +88,7 @@ export interface Activation {
 
 export namespace Activation {
   export function isa(o: any): o is Activation {
-    return _smithy.isa(o, "Activation");
+    return __isa(o, "Activation");
   }
 }
 
@@ -128,7 +131,7 @@ export interface AddTagsToResourceRequest {
 
 export namespace AddTagsToResourceRequest {
   export function isa(o: any): o is AddTagsToResourceRequest {
-    return _smithy.isa(o, "AddTagsToResourceRequest");
+    return __isa(o, "AddTagsToResourceRequest");
   }
 }
 
@@ -138,7 +141,7 @@ export interface AddTagsToResourceResult extends $MetadataBearer {
 
 export namespace AddTagsToResourceResult {
   export function isa(o: any): o is AddTagsToResourceResult {
-    return _smithy.isa(o, "AddTagsToResourceResult");
+    return __isa(o, "AddTagsToResourceResult");
   }
 }
 
@@ -147,7 +150,7 @@ export namespace AddTagsToResourceResult {
  *    already registered with a different patch baseline.</p>
  */
 export interface AlreadyExistsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AlreadyExistsException";
   $fault: "client";
@@ -156,7 +159,7 @@ export interface AlreadyExistsException
 
 export namespace AlreadyExistsException {
   export function isa(o: any): o is AlreadyExistsException {
-    return _smithy.isa(o, "AlreadyExistsException");
+    return __isa(o, "AlreadyExistsException");
   }
 }
 
@@ -164,7 +167,7 @@ export namespace AlreadyExistsException {
  * <p>You must disassociate a document from all instances before you can delete it.</p>
  */
 export interface AssociatedInstances
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AssociatedInstances";
   $fault: "client";
@@ -172,7 +175,7 @@ export interface AssociatedInstances
 
 export namespace AssociatedInstances {
   export function isa(o: any): o is AssociatedInstances {
-    return _smithy.isa(o, "AssociatedInstances");
+    return __isa(o, "AssociatedInstances");
   }
 }
 
@@ -235,7 +238,7 @@ export interface Association {
 
 export namespace Association {
   export function isa(o: any): o is Association {
-    return _smithy.isa(o, "Association");
+    return __isa(o, "Association");
   }
 }
 
@@ -243,7 +246,7 @@ export namespace Association {
  * <p>The specified association already exists.</p>
  */
 export interface AssociationAlreadyExists
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AssociationAlreadyExists";
   $fault: "client";
@@ -251,7 +254,7 @@ export interface AssociationAlreadyExists
 
 export namespace AssociationAlreadyExists {
   export function isa(o: any): o is AssociationAlreadyExists {
-    return _smithy.isa(o, "AssociationAlreadyExists");
+    return __isa(o, "AssociationAlreadyExists");
   }
 }
 
@@ -388,7 +391,7 @@ export interface AssociationDescription {
 
 export namespace AssociationDescription {
   export function isa(o: any): o is AssociationDescription {
-    return _smithy.isa(o, "AssociationDescription");
+    return __isa(o, "AssociationDescription");
   }
 }
 
@@ -396,7 +399,7 @@ export namespace AssociationDescription {
  * <p>The specified association does not exist.</p>
  */
 export interface AssociationDoesNotExist
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AssociationDoesNotExist";
   $fault: "client";
@@ -405,7 +408,7 @@ export interface AssociationDoesNotExist
 
 export namespace AssociationDoesNotExist {
   export function isa(o: any): o is AssociationDoesNotExist {
-    return _smithy.isa(o, "AssociationDoesNotExist");
+    return __isa(o, "AssociationDoesNotExist");
   }
 }
 
@@ -457,7 +460,7 @@ export interface AssociationExecution {
 
 export namespace AssociationExecution {
   export function isa(o: any): o is AssociationExecution {
-    return _smithy.isa(o, "AssociationExecution");
+    return __isa(o, "AssociationExecution");
   }
 }
 
@@ -465,7 +468,7 @@ export namespace AssociationExecution {
  * <p>The specified execution ID does not exist. Verify the ID number and try again.</p>
  */
 export interface AssociationExecutionDoesNotExist
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AssociationExecutionDoesNotExist";
   $fault: "client";
@@ -474,7 +477,7 @@ export interface AssociationExecutionDoesNotExist
 
 export namespace AssociationExecutionDoesNotExist {
   export function isa(o: any): o is AssociationExecutionDoesNotExist {
-    return _smithy.isa(o, "AssociationExecutionDoesNotExist");
+    return __isa(o, "AssociationExecutionDoesNotExist");
   }
 }
 
@@ -501,7 +504,7 @@ export interface AssociationExecutionFilter {
 
 export namespace AssociationExecutionFilter {
   export function isa(o: any): o is AssociationExecutionFilter {
-    return _smithy.isa(o, "AssociationExecutionFilter");
+    return __isa(o, "AssociationExecutionFilter");
   }
 }
 
@@ -564,7 +567,7 @@ export interface AssociationExecutionTarget {
 
 export namespace AssociationExecutionTarget {
   export function isa(o: any): o is AssociationExecutionTarget {
-    return _smithy.isa(o, "AssociationExecutionTarget");
+    return __isa(o, "AssociationExecutionTarget");
   }
 }
 
@@ -586,7 +589,7 @@ export interface AssociationExecutionTargetsFilter {
 
 export namespace AssociationExecutionTargetsFilter {
   export function isa(o: any): o is AssociationExecutionTargetsFilter {
-    return _smithy.isa(o, "AssociationExecutionTargetsFilter");
+    return __isa(o, "AssociationExecutionTargetsFilter");
   }
 }
 
@@ -614,7 +617,7 @@ export interface AssociationFilter {
 
 export namespace AssociationFilter {
   export function isa(o: any): o is AssociationFilter {
-    return _smithy.isa(o, "AssociationFilter");
+    return __isa(o, "AssociationFilter");
   }
 }
 
@@ -638,7 +641,7 @@ export enum AssociationFilterOperatorType {
  * <p>You can have at most 2,000 active associations.</p>
  */
 export interface AssociationLimitExceeded
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AssociationLimitExceeded";
   $fault: "client";
@@ -646,7 +649,7 @@ export interface AssociationLimitExceeded
 
 export namespace AssociationLimitExceeded {
   export function isa(o: any): o is AssociationLimitExceeded {
-    return _smithy.isa(o, "AssociationLimitExceeded");
+    return __isa(o, "AssociationLimitExceeded");
   }
 }
 
@@ -675,7 +678,7 @@ export interface AssociationOverview {
 
 export namespace AssociationOverview {
   export function isa(o: any): o is AssociationOverview {
-    return _smithy.isa(o, "AssociationOverview");
+    return __isa(o, "AssociationOverview");
   }
 }
 
@@ -707,7 +710,7 @@ export interface AssociationStatus {
 
 export namespace AssociationStatus {
   export function isa(o: any): o is AssociationStatus {
-    return _smithy.isa(o, "AssociationStatus");
+    return __isa(o, "AssociationStatus");
   }
 }
 
@@ -809,7 +812,7 @@ export interface AssociationVersionInfo {
 
 export namespace AssociationVersionInfo {
   export function isa(o: any): o is AssociationVersionInfo {
-    return _smithy.isa(o, "AssociationVersionInfo");
+    return __isa(o, "AssociationVersionInfo");
   }
 }
 
@@ -818,7 +821,7 @@ export namespace AssociationVersionInfo {
  *    has a limit of 1,000 versions. </p>
  */
 export interface AssociationVersionLimitExceeded
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AssociationVersionLimitExceeded";
   $fault: "client";
@@ -827,7 +830,7 @@ export interface AssociationVersionLimitExceeded
 
 export namespace AssociationVersionLimitExceeded {
   export function isa(o: any): o is AssociationVersionLimitExceeded {
-    return _smithy.isa(o, "AssociationVersionLimitExceeded");
+    return __isa(o, "AssociationVersionLimitExceeded");
   }
 }
 
@@ -864,7 +867,7 @@ export interface AttachmentContent {
 
 export namespace AttachmentContent {
   export function isa(o: any): o is AttachmentContent {
-    return _smithy.isa(o, "AttachmentContent");
+    return __isa(o, "AttachmentContent");
   }
 }
 
@@ -885,7 +888,7 @@ export interface AttachmentInformation {
 
 export namespace AttachmentInformation {
   export function isa(o: any): o is AttachmentInformation {
-    return _smithy.isa(o, "AttachmentInformation");
+    return __isa(o, "AttachmentInformation");
   }
 }
 
@@ -947,7 +950,7 @@ export interface AttachmentsSource {
 
 export namespace AttachmentsSource {
   export function isa(o: any): o is AttachmentsSource {
-    return _smithy.isa(o, "AttachmentsSource");
+    return __isa(o, "AttachmentsSource");
   }
 }
 
@@ -961,7 +964,7 @@ export enum AttachmentsSourceKey {
  * <p>An Automation document with the specified name could not be found.</p>
  */
 export interface AutomationDefinitionNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AutomationDefinitionNotFoundException";
   $fault: "client";
@@ -970,7 +973,7 @@ export interface AutomationDefinitionNotFoundException
 
 export namespace AutomationDefinitionNotFoundException {
   export function isa(o: any): o is AutomationDefinitionNotFoundException {
-    return _smithy.isa(o, "AutomationDefinitionNotFoundException");
+    return __isa(o, "AutomationDefinitionNotFoundException");
   }
 }
 
@@ -978,7 +981,7 @@ export namespace AutomationDefinitionNotFoundException {
  * <p>An Automation document with the specified name and version could not be found.</p>
  */
 export interface AutomationDefinitionVersionNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AutomationDefinitionVersionNotFoundException";
   $fault: "client";
@@ -989,7 +992,7 @@ export namespace AutomationDefinitionVersionNotFoundException {
   export function isa(
     o: any
   ): o is AutomationDefinitionVersionNotFoundException {
-    return _smithy.isa(o, "AutomationDefinitionVersionNotFoundException");
+    return __isa(o, "AutomationDefinitionVersionNotFoundException");
   }
 }
 
@@ -1132,7 +1135,7 @@ export interface AutomationExecution {
 
 export namespace AutomationExecution {
   export function isa(o: any): o is AutomationExecution {
-    return _smithy.isa(o, "AutomationExecution");
+    return __isa(o, "AutomationExecution");
   }
 }
 
@@ -1157,7 +1160,7 @@ export interface AutomationExecutionFilter {
 
 export namespace AutomationExecutionFilter {
   export function isa(o: any): o is AutomationExecutionFilter {
-    return _smithy.isa(o, "AutomationExecutionFilter");
+    return __isa(o, "AutomationExecutionFilter");
   }
 }
 
@@ -1178,7 +1181,7 @@ export enum AutomationExecutionFilterKey {
  *    limit.</p>
  */
 export interface AutomationExecutionLimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AutomationExecutionLimitExceededException";
   $fault: "client";
@@ -1187,7 +1190,7 @@ export interface AutomationExecutionLimitExceededException
 
 export namespace AutomationExecutionLimitExceededException {
   export function isa(o: any): o is AutomationExecutionLimitExceededException {
-    return _smithy.isa(o, "AutomationExecutionLimitExceededException");
+    return __isa(o, "AutomationExecutionLimitExceededException");
   }
 }
 
@@ -1314,7 +1317,7 @@ export interface AutomationExecutionMetadata {
 
 export namespace AutomationExecutionMetadata {
   export function isa(o: any): o is AutomationExecutionMetadata {
-    return _smithy.isa(o, "AutomationExecutionMetadata");
+    return __isa(o, "AutomationExecutionMetadata");
   }
 }
 
@@ -1323,7 +1326,7 @@ export namespace AutomationExecutionMetadata {
  *    ID.</p>
  */
 export interface AutomationExecutionNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AutomationExecutionNotFoundException";
   $fault: "client";
@@ -1332,7 +1335,7 @@ export interface AutomationExecutionNotFoundException
 
 export namespace AutomationExecutionNotFoundException {
   export function isa(o: any): o is AutomationExecutionNotFoundException {
-    return _smithy.isa(o, "AutomationExecutionNotFoundException");
+    return __isa(o, "AutomationExecutionNotFoundException");
   }
 }
 
@@ -1352,7 +1355,7 @@ export enum AutomationExecutionStatus {
  *    again.</p>
  */
 export interface AutomationStepNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AutomationStepNotFoundException";
   $fault: "client";
@@ -1361,7 +1364,7 @@ export interface AutomationStepNotFoundException
 
 export namespace AutomationStepNotFoundException {
   export function isa(o: any): o is AutomationStepNotFoundException {
-    return _smithy.isa(o, "AutomationStepNotFoundException");
+    return __isa(o, "AutomationStepNotFoundException");
   }
 }
 
@@ -1394,7 +1397,7 @@ export interface CancelCommandRequest {
 
 export namespace CancelCommandRequest {
   export function isa(o: any): o is CancelCommandRequest {
-    return _smithy.isa(o, "CancelCommandRequest");
+    return __isa(o, "CancelCommandRequest");
   }
 }
 
@@ -1408,7 +1411,7 @@ export interface CancelCommandResult extends $MetadataBearer {
 
 export namespace CancelCommandResult {
   export function isa(o: any): o is CancelCommandResult {
-    return _smithy.isa(o, "CancelCommandResult");
+    return __isa(o, "CancelCommandResult");
   }
 }
 
@@ -1422,7 +1425,7 @@ export interface CancelMaintenanceWindowExecutionRequest {
 
 export namespace CancelMaintenanceWindowExecutionRequest {
   export function isa(o: any): o is CancelMaintenanceWindowExecutionRequest {
-    return _smithy.isa(o, "CancelMaintenanceWindowExecutionRequest");
+    return __isa(o, "CancelMaintenanceWindowExecutionRequest");
   }
 }
 
@@ -1437,7 +1440,7 @@ export interface CancelMaintenanceWindowExecutionResult
 
 export namespace CancelMaintenanceWindowExecutionResult {
   export function isa(o: any): o is CancelMaintenanceWindowExecutionResult {
-    return _smithy.isa(o, "CancelMaintenanceWindowExecutionResult");
+    return __isa(o, "CancelMaintenanceWindowExecutionResult");
   }
 }
 
@@ -1461,7 +1464,7 @@ export interface CloudWatchOutputConfig {
 
 export namespace CloudWatchOutputConfig {
   export function isa(o: any): o is CloudWatchOutputConfig {
-    return _smithy.isa(o, "CloudWatchOutputConfig");
+    return __isa(o, "CloudWatchOutputConfig");
   }
 }
 
@@ -1646,7 +1649,7 @@ export interface Command {
 
 export namespace Command {
   export function isa(o: any): o is Command {
-    return _smithy.isa(o, "Command");
+    return __isa(o, "Command");
   }
 }
 
@@ -1748,7 +1751,7 @@ export interface CommandFilter {
 
 export namespace CommandFilter {
   export function isa(o: any): o is CommandFilter {
-    return _smithy.isa(o, "CommandFilter");
+    return __isa(o, "CommandFilter");
   }
 }
 
@@ -1904,7 +1907,7 @@ export interface CommandInvocation {
 
 export namespace CommandInvocation {
   export function isa(o: any): o is CommandInvocation {
-    return _smithy.isa(o, "CommandInvocation");
+    return __isa(o, "CommandInvocation");
   }
 }
 
@@ -2055,7 +2058,7 @@ export interface CommandPlugin {
 
 export namespace CommandPlugin {
   export function isa(o: any): o is CommandPlugin {
-    return _smithy.isa(o, "CommandPlugin");
+    return __isa(o, "CommandPlugin");
   }
 }
 
@@ -2105,7 +2108,7 @@ export interface ComplianceExecutionSummary {
 
 export namespace ComplianceExecutionSummary {
   export function isa(o: any): o is ComplianceExecutionSummary {
-    return _smithy.isa(o, "ComplianceExecutionSummary");
+    return __isa(o, "ComplianceExecutionSummary");
   }
 }
 
@@ -2171,7 +2174,7 @@ export interface ComplianceItem {
 
 export namespace ComplianceItem {
   export function isa(o: any): o is ComplianceItem {
-    return _smithy.isa(o, "ComplianceItem");
+    return __isa(o, "ComplianceItem");
   }
 }
 
@@ -2212,7 +2215,7 @@ export interface ComplianceItemEntry {
 
 export namespace ComplianceItemEntry {
   export function isa(o: any): o is ComplianceItemEntry {
-    return _smithy.isa(o, "ComplianceItemEntry");
+    return __isa(o, "ComplianceItemEntry");
   }
 }
 
@@ -2262,7 +2265,7 @@ export interface ComplianceStringFilter {
 
 export namespace ComplianceStringFilter {
   export function isa(o: any): o is ComplianceStringFilter {
-    return _smithy.isa(o, "ComplianceStringFilter");
+    return __isa(o, "ComplianceStringFilter");
   }
 }
 
@@ -2290,7 +2293,7 @@ export interface ComplianceSummaryItem {
 
 export namespace ComplianceSummaryItem {
   export function isa(o: any): o is ComplianceSummaryItem {
-    return _smithy.isa(o, "ComplianceSummaryItem");
+    return __isa(o, "ComplianceSummaryItem");
   }
 }
 
@@ -2299,7 +2302,7 @@ export namespace ComplianceSummaryItem {
  *    types. </p>
  */
 export interface ComplianceTypeCountLimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ComplianceTypeCountLimitExceededException";
   $fault: "client";
@@ -2308,7 +2311,7 @@ export interface ComplianceTypeCountLimitExceededException
 
 export namespace ComplianceTypeCountLimitExceededException {
   export function isa(o: any): o is ComplianceTypeCountLimitExceededException {
-    return _smithy.isa(o, "ComplianceTypeCountLimitExceededException");
+    return __isa(o, "ComplianceTypeCountLimitExceededException");
   }
 }
 
@@ -2331,7 +2334,7 @@ export interface CompliantSummary {
 
 export namespace CompliantSummary {
   export function isa(o: any): o is CompliantSummary {
-    return _smithy.isa(o, "CompliantSummary");
+    return __isa(o, "CompliantSummary");
   }
 }
 
@@ -2414,7 +2417,7 @@ export interface CreateActivationRequest {
 
 export namespace CreateActivationRequest {
   export function isa(o: any): o is CreateActivationRequest {
-    return _smithy.isa(o, "CreateActivationRequest");
+    return __isa(o, "CreateActivationRequest");
   }
 }
 
@@ -2435,7 +2438,7 @@ export interface CreateActivationResult extends $MetadataBearer {
 
 export namespace CreateActivationResult {
   export function isa(o: any): o is CreateActivationResult {
-    return _smithy.isa(o, "CreateActivationResult");
+    return __isa(o, "CreateActivationResult");
   }
 }
 
@@ -2449,7 +2452,7 @@ export interface CreateAssociationBatchRequest {
 
 export namespace CreateAssociationBatchRequest {
   export function isa(o: any): o is CreateAssociationBatchRequest {
-    return _smithy.isa(o, "CreateAssociationBatchRequest");
+    return __isa(o, "CreateAssociationBatchRequest");
   }
 }
 
@@ -2554,7 +2557,7 @@ export interface CreateAssociationBatchRequestEntry {
 
 export namespace CreateAssociationBatchRequestEntry {
   export function isa(o: any): o is CreateAssociationBatchRequestEntry {
-    return _smithy.isa(o, "CreateAssociationBatchRequestEntry");
+    return __isa(o, "CreateAssociationBatchRequestEntry");
   }
 }
 
@@ -2573,7 +2576,7 @@ export interface CreateAssociationBatchResult extends $MetadataBearer {
 
 export namespace CreateAssociationBatchResult {
   export function isa(o: any): o is CreateAssociationBatchResult {
-    return _smithy.isa(o, "CreateAssociationBatchResult");
+    return __isa(o, "CreateAssociationBatchResult");
   }
 }
 
@@ -2688,7 +2691,7 @@ export interface CreateAssociationRequest {
 
 export namespace CreateAssociationRequest {
   export function isa(o: any): o is CreateAssociationRequest {
-    return _smithy.isa(o, "CreateAssociationRequest");
+    return __isa(o, "CreateAssociationRequest");
   }
 }
 
@@ -2702,7 +2705,7 @@ export interface CreateAssociationResult extends $MetadataBearer {
 
 export namespace CreateAssociationResult {
   export function isa(o: any): o is CreateAssociationResult {
-    return _smithy.isa(o, "CreateAssociationResult");
+    return __isa(o, "CreateAssociationResult");
   }
 }
 
@@ -2806,7 +2809,7 @@ export interface CreateDocumentRequest {
 
 export namespace CreateDocumentRequest {
   export function isa(o: any): o is CreateDocumentRequest {
-    return _smithy.isa(o, "CreateDocumentRequest");
+    return __isa(o, "CreateDocumentRequest");
   }
 }
 
@@ -2820,7 +2823,7 @@ export interface CreateDocumentResult extends $MetadataBearer {
 
 export namespace CreateDocumentResult {
   export function isa(o: any): o is CreateDocumentResult {
-    return _smithy.isa(o, "CreateDocumentResult");
+    return __isa(o, "CreateDocumentResult");
   }
 }
 
@@ -2922,7 +2925,7 @@ export interface CreateMaintenanceWindowRequest {
 
 export namespace CreateMaintenanceWindowRequest {
   export function isa(o: any): o is CreateMaintenanceWindowRequest {
-    return _smithy.isa(o, "CreateMaintenanceWindowRequest");
+    return __isa(o, "CreateMaintenanceWindowRequest");
   }
 }
 
@@ -2936,7 +2939,7 @@ export interface CreateMaintenanceWindowResult extends $MetadataBearer {
 
 export namespace CreateMaintenanceWindowResult {
   export function isa(o: any): o is CreateMaintenanceWindowResult {
-    return _smithy.isa(o, "CreateMaintenanceWindowResult");
+    return __isa(o, "CreateMaintenanceWindowResult");
   }
 }
 
@@ -3026,7 +3029,7 @@ export interface CreateOpsItemRequest {
 
 export namespace CreateOpsItemRequest {
   export function isa(o: any): o is CreateOpsItemRequest {
-    return _smithy.isa(o, "CreateOpsItemRequest");
+    return __isa(o, "CreateOpsItemRequest");
   }
 }
 
@@ -3040,7 +3043,7 @@ export interface CreateOpsItemResponse extends $MetadataBearer {
 
 export namespace CreateOpsItemResponse {
   export function isa(o: any): o is CreateOpsItemResponse {
-    return _smithy.isa(o, "CreateOpsItemResponse");
+    return __isa(o, "CreateOpsItemResponse");
   }
 }
 
@@ -3162,7 +3165,7 @@ export interface CreatePatchBaselineRequest {
 
 export namespace CreatePatchBaselineRequest {
   export function isa(o: any): o is CreatePatchBaselineRequest {
-    return _smithy.isa(o, "CreatePatchBaselineRequest");
+    return __isa(o, "CreatePatchBaselineRequest");
   }
 }
 
@@ -3176,7 +3179,7 @@ export interface CreatePatchBaselineResult extends $MetadataBearer {
 
 export namespace CreatePatchBaselineResult {
   export function isa(o: any): o is CreatePatchBaselineResult {
-    return _smithy.isa(o, "CreatePatchBaselineResult");
+    return __isa(o, "CreatePatchBaselineResult");
   }
 }
 
@@ -3207,7 +3210,7 @@ export interface CreateResourceDataSyncRequest {
 
 export namespace CreateResourceDataSyncRequest {
   export function isa(o: any): o is CreateResourceDataSyncRequest {
-    return _smithy.isa(o, "CreateResourceDataSyncRequest");
+    return __isa(o, "CreateResourceDataSyncRequest");
   }
 }
 
@@ -3217,7 +3220,7 @@ export interface CreateResourceDataSyncResult extends $MetadataBearer {
 
 export namespace CreateResourceDataSyncResult {
   export function isa(o: any): o is CreateResourceDataSyncResult {
-    return _smithy.isa(o, "CreateResourceDataSyncResult");
+    return __isa(o, "CreateResourceDataSyncResult");
   }
 }
 
@@ -3226,7 +3229,7 @@ export namespace CreateResourceDataSyncResult {
  *    again.</p>
  */
 export interface CustomSchemaCountLimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CustomSchemaCountLimitExceededException";
   $fault: "client";
@@ -3235,7 +3238,7 @@ export interface CustomSchemaCountLimitExceededException
 
 export namespace CustomSchemaCountLimitExceededException {
   export function isa(o: any): o is CustomSchemaCountLimitExceededException {
-    return _smithy.isa(o, "CustomSchemaCountLimitExceededException");
+    return __isa(o, "CustomSchemaCountLimitExceededException");
   }
 }
 
@@ -3249,7 +3252,7 @@ export interface DeleteActivationRequest {
 
 export namespace DeleteActivationRequest {
   export function isa(o: any): o is DeleteActivationRequest {
-    return _smithy.isa(o, "DeleteActivationRequest");
+    return __isa(o, "DeleteActivationRequest");
   }
 }
 
@@ -3259,7 +3262,7 @@ export interface DeleteActivationResult extends $MetadataBearer {
 
 export namespace DeleteActivationResult {
   export function isa(o: any): o is DeleteActivationResult {
-    return _smithy.isa(o, "DeleteActivationResult");
+    return __isa(o, "DeleteActivationResult");
   }
 }
 
@@ -3283,7 +3286,7 @@ export interface DeleteAssociationRequest {
 
 export namespace DeleteAssociationRequest {
   export function isa(o: any): o is DeleteAssociationRequest {
-    return _smithy.isa(o, "DeleteAssociationRequest");
+    return __isa(o, "DeleteAssociationRequest");
   }
 }
 
@@ -3293,7 +3296,7 @@ export interface DeleteAssociationResult extends $MetadataBearer {
 
 export namespace DeleteAssociationResult {
   export function isa(o: any): o is DeleteAssociationResult {
-    return _smithy.isa(o, "DeleteAssociationResult");
+    return __isa(o, "DeleteAssociationResult");
   }
 }
 
@@ -3327,7 +3330,7 @@ export interface DeleteDocumentRequest {
 
 export namespace DeleteDocumentRequest {
   export function isa(o: any): o is DeleteDocumentRequest {
-    return _smithy.isa(o, "DeleteDocumentRequest");
+    return __isa(o, "DeleteDocumentRequest");
   }
 }
 
@@ -3337,7 +3340,7 @@ export interface DeleteDocumentResult extends $MetadataBearer {
 
 export namespace DeleteDocumentResult {
   export function isa(o: any): o is DeleteDocumentResult {
-    return _smithy.isa(o, "DeleteDocumentResult");
+    return __isa(o, "DeleteDocumentResult");
   }
 }
 
@@ -3377,7 +3380,7 @@ export interface DeleteInventoryRequest {
 
 export namespace DeleteInventoryRequest {
   export function isa(o: any): o is DeleteInventoryRequest {
-    return _smithy.isa(o, "DeleteInventoryRequest");
+    return __isa(o, "DeleteInventoryRequest");
   }
 }
 
@@ -3404,7 +3407,7 @@ export interface DeleteInventoryResult extends $MetadataBearer {
 
 export namespace DeleteInventoryResult {
   export function isa(o: any): o is DeleteInventoryResult {
-    return _smithy.isa(o, "DeleteInventoryResult");
+    return __isa(o, "DeleteInventoryResult");
   }
 }
 
@@ -3418,7 +3421,7 @@ export interface DeleteMaintenanceWindowRequest {
 
 export namespace DeleteMaintenanceWindowRequest {
   export function isa(o: any): o is DeleteMaintenanceWindowRequest {
-    return _smithy.isa(o, "DeleteMaintenanceWindowRequest");
+    return __isa(o, "DeleteMaintenanceWindowRequest");
   }
 }
 
@@ -3432,7 +3435,7 @@ export interface DeleteMaintenanceWindowResult extends $MetadataBearer {
 
 export namespace DeleteMaintenanceWindowResult {
   export function isa(o: any): o is DeleteMaintenanceWindowResult {
-    return _smithy.isa(o, "DeleteMaintenanceWindowResult");
+    return __isa(o, "DeleteMaintenanceWindowResult");
   }
 }
 
@@ -3446,7 +3449,7 @@ export interface DeleteParameterRequest {
 
 export namespace DeleteParameterRequest {
   export function isa(o: any): o is DeleteParameterRequest {
-    return _smithy.isa(o, "DeleteParameterRequest");
+    return __isa(o, "DeleteParameterRequest");
   }
 }
 
@@ -3456,7 +3459,7 @@ export interface DeleteParameterResult extends $MetadataBearer {
 
 export namespace DeleteParameterResult {
   export function isa(o: any): o is DeleteParameterResult {
-    return _smithy.isa(o, "DeleteParameterResult");
+    return __isa(o, "DeleteParameterResult");
   }
 }
 
@@ -3470,7 +3473,7 @@ export interface DeleteParametersRequest {
 
 export namespace DeleteParametersRequest {
   export function isa(o: any): o is DeleteParametersRequest {
-    return _smithy.isa(o, "DeleteParametersRequest");
+    return __isa(o, "DeleteParametersRequest");
   }
 }
 
@@ -3489,7 +3492,7 @@ export interface DeleteParametersResult extends $MetadataBearer {
 
 export namespace DeleteParametersResult {
   export function isa(o: any): o is DeleteParametersResult {
-    return _smithy.isa(o, "DeleteParametersResult");
+    return __isa(o, "DeleteParametersResult");
   }
 }
 
@@ -3503,7 +3506,7 @@ export interface DeletePatchBaselineRequest {
 
 export namespace DeletePatchBaselineRequest {
   export function isa(o: any): o is DeletePatchBaselineRequest {
-    return _smithy.isa(o, "DeletePatchBaselineRequest");
+    return __isa(o, "DeletePatchBaselineRequest");
   }
 }
 
@@ -3517,7 +3520,7 @@ export interface DeletePatchBaselineResult extends $MetadataBearer {
 
 export namespace DeletePatchBaselineResult {
   export function isa(o: any): o is DeletePatchBaselineResult {
-    return _smithy.isa(o, "DeletePatchBaselineResult");
+    return __isa(o, "DeletePatchBaselineResult");
   }
 }
 
@@ -3536,7 +3539,7 @@ export interface DeleteResourceDataSyncRequest {
 
 export namespace DeleteResourceDataSyncRequest {
   export function isa(o: any): o is DeleteResourceDataSyncRequest {
-    return _smithy.isa(o, "DeleteResourceDataSyncRequest");
+    return __isa(o, "DeleteResourceDataSyncRequest");
   }
 }
 
@@ -3546,7 +3549,7 @@ export interface DeleteResourceDataSyncResult extends $MetadataBearer {
 
 export namespace DeleteResourceDataSyncResult {
   export function isa(o: any): o is DeleteResourceDataSyncResult {
-    return _smithy.isa(o, "DeleteResourceDataSyncResult");
+    return __isa(o, "DeleteResourceDataSyncResult");
   }
 }
 
@@ -3561,7 +3564,7 @@ export interface DeregisterManagedInstanceRequest {
 
 export namespace DeregisterManagedInstanceRequest {
   export function isa(o: any): o is DeregisterManagedInstanceRequest {
-    return _smithy.isa(o, "DeregisterManagedInstanceRequest");
+    return __isa(o, "DeregisterManagedInstanceRequest");
   }
 }
 
@@ -3571,7 +3574,7 @@ export interface DeregisterManagedInstanceResult extends $MetadataBearer {
 
 export namespace DeregisterManagedInstanceResult {
   export function isa(o: any): o is DeregisterManagedInstanceResult {
-    return _smithy.isa(o, "DeregisterManagedInstanceResult");
+    return __isa(o, "DeregisterManagedInstanceResult");
   }
 }
 
@@ -3592,7 +3595,7 @@ export namespace DeregisterPatchBaselineForPatchGroupRequest {
   export function isa(
     o: any
   ): o is DeregisterPatchBaselineForPatchGroupRequest {
-    return _smithy.isa(o, "DeregisterPatchBaselineForPatchGroupRequest");
+    return __isa(o, "DeregisterPatchBaselineForPatchGroupRequest");
   }
 }
 
@@ -3612,7 +3615,7 @@ export interface DeregisterPatchBaselineForPatchGroupResult
 
 export namespace DeregisterPatchBaselineForPatchGroupResult {
   export function isa(o: any): o is DeregisterPatchBaselineForPatchGroupResult {
-    return _smithy.isa(o, "DeregisterPatchBaselineForPatchGroupResult");
+    return __isa(o, "DeregisterPatchBaselineForPatchGroupResult");
   }
 }
 
@@ -3640,7 +3643,7 @@ export namespace DeregisterTargetFromMaintenanceWindowRequest {
   export function isa(
     o: any
   ): o is DeregisterTargetFromMaintenanceWindowRequest {
-    return _smithy.isa(o, "DeregisterTargetFromMaintenanceWindowRequest");
+    return __isa(o, "DeregisterTargetFromMaintenanceWindowRequest");
   }
 }
 
@@ -3662,7 +3665,7 @@ export namespace DeregisterTargetFromMaintenanceWindowResult {
   export function isa(
     o: any
   ): o is DeregisterTargetFromMaintenanceWindowResult {
-    return _smithy.isa(o, "DeregisterTargetFromMaintenanceWindowResult");
+    return __isa(o, "DeregisterTargetFromMaintenanceWindowResult");
   }
 }
 
@@ -3681,7 +3684,7 @@ export interface DeregisterTaskFromMaintenanceWindowRequest {
 
 export namespace DeregisterTaskFromMaintenanceWindowRequest {
   export function isa(o: any): o is DeregisterTaskFromMaintenanceWindowRequest {
-    return _smithy.isa(o, "DeregisterTaskFromMaintenanceWindowRequest");
+    return __isa(o, "DeregisterTaskFromMaintenanceWindowRequest");
   }
 }
 
@@ -3701,7 +3704,7 @@ export interface DeregisterTaskFromMaintenanceWindowResult
 
 export namespace DeregisterTaskFromMaintenanceWindowResult {
   export function isa(o: any): o is DeregisterTaskFromMaintenanceWindowResult {
-    return _smithy.isa(o, "DeregisterTaskFromMaintenanceWindowResult");
+    return __isa(o, "DeregisterTaskFromMaintenanceWindowResult");
   }
 }
 
@@ -3723,7 +3726,7 @@ export interface DescribeActivationsFilter {
 
 export namespace DescribeActivationsFilter {
   export function isa(o: any): o is DescribeActivationsFilter {
-    return _smithy.isa(o, "DescribeActivationsFilter");
+    return __isa(o, "DescribeActivationsFilter");
   }
 }
 
@@ -3754,7 +3757,7 @@ export interface DescribeActivationsRequest {
 
 export namespace DescribeActivationsRequest {
   export function isa(o: any): o is DescribeActivationsRequest {
-    return _smithy.isa(o, "DescribeActivationsRequest");
+    return __isa(o, "DescribeActivationsRequest");
   }
 }
 
@@ -3774,7 +3777,7 @@ export interface DescribeActivationsResult extends $MetadataBearer {
 
 export namespace DescribeActivationsResult {
   export function isa(o: any): o is DescribeActivationsResult {
-    return _smithy.isa(o, "DescribeActivationsResult");
+    return __isa(o, "DescribeActivationsResult");
   }
 }
 
@@ -3812,7 +3815,7 @@ export interface DescribeAssociationExecutionTargetsRequest {
 
 export namespace DescribeAssociationExecutionTargetsRequest {
   export function isa(o: any): o is DescribeAssociationExecutionTargetsRequest {
-    return _smithy.isa(o, "DescribeAssociationExecutionTargetsRequest");
+    return __isa(o, "DescribeAssociationExecutionTargetsRequest");
   }
 }
 
@@ -3833,7 +3836,7 @@ export interface DescribeAssociationExecutionTargetsResult
 
 export namespace DescribeAssociationExecutionTargetsResult {
   export function isa(o: any): o is DescribeAssociationExecutionTargetsResult {
-    return _smithy.isa(o, "DescribeAssociationExecutionTargetsResult");
+    return __isa(o, "DescribeAssociationExecutionTargetsResult");
   }
 }
 
@@ -3866,7 +3869,7 @@ export interface DescribeAssociationExecutionsRequest {
 
 export namespace DescribeAssociationExecutionsRequest {
   export function isa(o: any): o is DescribeAssociationExecutionsRequest {
-    return _smithy.isa(o, "DescribeAssociationExecutionsRequest");
+    return __isa(o, "DescribeAssociationExecutionsRequest");
   }
 }
 
@@ -3886,7 +3889,7 @@ export interface DescribeAssociationExecutionsResult extends $MetadataBearer {
 
 export namespace DescribeAssociationExecutionsResult {
   export function isa(o: any): o is DescribeAssociationExecutionsResult {
-    return _smithy.isa(o, "DescribeAssociationExecutionsResult");
+    return __isa(o, "DescribeAssociationExecutionsResult");
   }
 }
 
@@ -3918,7 +3921,7 @@ export interface DescribeAssociationRequest {
 
 export namespace DescribeAssociationRequest {
   export function isa(o: any): o is DescribeAssociationRequest {
-    return _smithy.isa(o, "DescribeAssociationRequest");
+    return __isa(o, "DescribeAssociationRequest");
   }
 }
 
@@ -3932,7 +3935,7 @@ export interface DescribeAssociationResult extends $MetadataBearer {
 
 export namespace DescribeAssociationResult {
   export function isa(o: any): o is DescribeAssociationResult {
-    return _smithy.isa(o, "DescribeAssociationResult");
+    return __isa(o, "DescribeAssociationResult");
   }
 }
 
@@ -3958,7 +3961,7 @@ export interface DescribeAutomationExecutionsRequest {
 
 export namespace DescribeAutomationExecutionsRequest {
   export function isa(o: any): o is DescribeAutomationExecutionsRequest {
-    return _smithy.isa(o, "DescribeAutomationExecutionsRequest");
+    return __isa(o, "DescribeAutomationExecutionsRequest");
   }
 }
 
@@ -3979,7 +3982,7 @@ export interface DescribeAutomationExecutionsResult extends $MetadataBearer {
 
 export namespace DescribeAutomationExecutionsResult {
   export function isa(o: any): o is DescribeAutomationExecutionsResult {
-    return _smithy.isa(o, "DescribeAutomationExecutionsResult");
+    return __isa(o, "DescribeAutomationExecutionsResult");
   }
 }
 
@@ -4016,7 +4019,7 @@ export interface DescribeAutomationStepExecutionsRequest {
 
 export namespace DescribeAutomationStepExecutionsRequest {
   export function isa(o: any): o is DescribeAutomationStepExecutionsRequest {
-    return _smithy.isa(o, "DescribeAutomationStepExecutionsRequest");
+    return __isa(o, "DescribeAutomationStepExecutionsRequest");
   }
 }
 
@@ -4037,7 +4040,7 @@ export interface DescribeAutomationStepExecutionsResult
 
 export namespace DescribeAutomationStepExecutionsResult {
   export function isa(o: any): o is DescribeAutomationStepExecutionsResult {
-    return _smithy.isa(o, "DescribeAutomationStepExecutionsResult");
+    return __isa(o, "DescribeAutomationStepExecutionsResult");
   }
 }
 
@@ -4062,7 +4065,7 @@ export interface DescribeAvailablePatchesRequest {
 
 export namespace DescribeAvailablePatchesRequest {
   export function isa(o: any): o is DescribeAvailablePatchesRequest {
-    return _smithy.isa(o, "DescribeAvailablePatchesRequest");
+    return __isa(o, "DescribeAvailablePatchesRequest");
   }
 }
 
@@ -4082,7 +4085,7 @@ export interface DescribeAvailablePatchesResult extends $MetadataBearer {
 
 export namespace DescribeAvailablePatchesResult {
   export function isa(o: any): o is DescribeAvailablePatchesResult {
-    return _smithy.isa(o, "DescribeAvailablePatchesResult");
+    return __isa(o, "DescribeAvailablePatchesResult");
   }
 }
 
@@ -4102,7 +4105,7 @@ export interface DescribeDocumentPermissionRequest {
 
 export namespace DescribeDocumentPermissionRequest {
   export function isa(o: any): o is DescribeDocumentPermissionRequest {
-    return _smithy.isa(o, "DescribeDocumentPermissionRequest");
+    return __isa(o, "DescribeDocumentPermissionRequest");
   }
 }
 
@@ -4123,7 +4126,7 @@ export interface DescribeDocumentPermissionResponse extends $MetadataBearer {
 
 export namespace DescribeDocumentPermissionResponse {
   export function isa(o: any): o is DescribeDocumentPermissionResponse {
-    return _smithy.isa(o, "DescribeDocumentPermissionResponse");
+    return __isa(o, "DescribeDocumentPermissionResponse");
   }
 }
 
@@ -4150,7 +4153,7 @@ export interface DescribeDocumentRequest {
 
 export namespace DescribeDocumentRequest {
   export function isa(o: any): o is DescribeDocumentRequest {
-    return _smithy.isa(o, "DescribeDocumentRequest");
+    return __isa(o, "DescribeDocumentRequest");
   }
 }
 
@@ -4164,7 +4167,7 @@ export interface DescribeDocumentResult extends $MetadataBearer {
 
 export namespace DescribeDocumentResult {
   export function isa(o: any): o is DescribeDocumentResult {
-    return _smithy.isa(o, "DescribeDocumentResult");
+    return __isa(o, "DescribeDocumentResult");
   }
 }
 
@@ -4192,7 +4195,7 @@ export namespace DescribeEffectiveInstanceAssociationsRequest {
   export function isa(
     o: any
   ): o is DescribeEffectiveInstanceAssociationsRequest {
-    return _smithy.isa(o, "DescribeEffectiveInstanceAssociationsRequest");
+    return __isa(o, "DescribeEffectiveInstanceAssociationsRequest");
   }
 }
 
@@ -4215,7 +4218,7 @@ export namespace DescribeEffectiveInstanceAssociationsResult {
   export function isa(
     o: any
   ): o is DescribeEffectiveInstanceAssociationsResult {
-    return _smithy.isa(o, "DescribeEffectiveInstanceAssociationsResult");
+    return __isa(o, "DescribeEffectiveInstanceAssociationsResult");
   }
 }
 
@@ -4242,7 +4245,7 @@ export namespace DescribeEffectivePatchesForPatchBaselineRequest {
   export function isa(
     o: any
   ): o is DescribeEffectivePatchesForPatchBaselineRequest {
-    return _smithy.isa(o, "DescribeEffectivePatchesForPatchBaselineRequest");
+    return __isa(o, "DescribeEffectivePatchesForPatchBaselineRequest");
   }
 }
 
@@ -4265,7 +4268,7 @@ export namespace DescribeEffectivePatchesForPatchBaselineResult {
   export function isa(
     o: any
   ): o is DescribeEffectivePatchesForPatchBaselineResult {
-    return _smithy.isa(o, "DescribeEffectivePatchesForPatchBaselineResult");
+    return __isa(o, "DescribeEffectivePatchesForPatchBaselineResult");
   }
 }
 
@@ -4291,7 +4294,7 @@ export interface DescribeInstanceAssociationsStatusRequest {
 
 export namespace DescribeInstanceAssociationsStatusRequest {
   export function isa(o: any): o is DescribeInstanceAssociationsStatusRequest {
-    return _smithy.isa(o, "DescribeInstanceAssociationsStatusRequest");
+    return __isa(o, "DescribeInstanceAssociationsStatusRequest");
   }
 }
 
@@ -4312,7 +4315,7 @@ export interface DescribeInstanceAssociationsStatusResult
 
 export namespace DescribeInstanceAssociationsStatusResult {
   export function isa(o: any): o is DescribeInstanceAssociationsStatusResult {
-    return _smithy.isa(o, "DescribeInstanceAssociationsStatusResult");
+    return __isa(o, "DescribeInstanceAssociationsStatusResult");
   }
 }
 
@@ -4349,7 +4352,7 @@ export interface DescribeInstanceInformationRequest {
 
 export namespace DescribeInstanceInformationRequest {
   export function isa(o: any): o is DescribeInstanceInformationRequest {
-    return _smithy.isa(o, "DescribeInstanceInformationRequest");
+    return __isa(o, "DescribeInstanceInformationRequest");
   }
 }
 
@@ -4369,7 +4372,7 @@ export interface DescribeInstanceInformationResult extends $MetadataBearer {
 
 export namespace DescribeInstanceInformationResult {
   export function isa(o: any): o is DescribeInstanceInformationResult {
-    return _smithy.isa(o, "DescribeInstanceInformationResult");
+    return __isa(o, "DescribeInstanceInformationResult");
   }
 }
 
@@ -4405,7 +4408,7 @@ export namespace DescribeInstancePatchStatesForPatchGroupRequest {
   export function isa(
     o: any
   ): o is DescribeInstancePatchStatesForPatchGroupRequest {
-    return _smithy.isa(o, "DescribeInstancePatchStatesForPatchGroupRequest");
+    return __isa(o, "DescribeInstancePatchStatesForPatchGroupRequest");
   }
 }
 
@@ -4428,7 +4431,7 @@ export namespace DescribeInstancePatchStatesForPatchGroupResult {
   export function isa(
     o: any
   ): o is DescribeInstancePatchStatesForPatchGroupResult {
-    return _smithy.isa(o, "DescribeInstancePatchStatesForPatchGroupResult");
+    return __isa(o, "DescribeInstancePatchStatesForPatchGroupResult");
   }
 }
 
@@ -4453,7 +4456,7 @@ export interface DescribeInstancePatchStatesRequest {
 
 export namespace DescribeInstancePatchStatesRequest {
   export function isa(o: any): o is DescribeInstancePatchStatesRequest {
-    return _smithy.isa(o, "DescribeInstancePatchStatesRequest");
+    return __isa(o, "DescribeInstancePatchStatesRequest");
   }
 }
 
@@ -4473,7 +4476,7 @@ export interface DescribeInstancePatchStatesResult extends $MetadataBearer {
 
 export namespace DescribeInstancePatchStatesResult {
   export function isa(o: any): o is DescribeInstancePatchStatesResult {
-    return _smithy.isa(o, "DescribeInstancePatchStatesResult");
+    return __isa(o, "DescribeInstancePatchStatesResult");
   }
 }
 
@@ -4505,7 +4508,7 @@ export interface DescribeInstancePatchesRequest {
 
 export namespace DescribeInstancePatchesRequest {
   export function isa(o: any): o is DescribeInstancePatchesRequest {
-    return _smithy.isa(o, "DescribeInstancePatchesRequest");
+    return __isa(o, "DescribeInstancePatchesRequest");
   }
 }
 
@@ -4532,7 +4535,7 @@ export interface DescribeInstancePatchesResult extends $MetadataBearer {
 
 export namespace DescribeInstancePatchesResult {
   export function isa(o: any): o is DescribeInstancePatchesResult {
-    return _smithy.isa(o, "DescribeInstancePatchesResult");
+    return __isa(o, "DescribeInstancePatchesResult");
   }
 }
 
@@ -4558,7 +4561,7 @@ export interface DescribeInventoryDeletionsRequest {
 
 export namespace DescribeInventoryDeletionsRequest {
   export function isa(o: any): o is DescribeInventoryDeletionsRequest {
-    return _smithy.isa(o, "DescribeInventoryDeletionsRequest");
+    return __isa(o, "DescribeInventoryDeletionsRequest");
   }
 }
 
@@ -4578,7 +4581,7 @@ export interface DescribeInventoryDeletionsResult extends $MetadataBearer {
 
 export namespace DescribeInventoryDeletionsResult {
   export function isa(o: any): o is DescribeInventoryDeletionsResult {
-    return _smithy.isa(o, "DescribeInventoryDeletionsResult");
+    return __isa(o, "DescribeInventoryDeletionsResult");
   }
 }
 
@@ -4618,10 +4621,7 @@ export namespace DescribeMaintenanceWindowExecutionTaskInvocationsRequest {
   export function isa(
     o: any
   ): o is DescribeMaintenanceWindowExecutionTaskInvocationsRequest {
-    return _smithy.isa(
-      o,
-      "DescribeMaintenanceWindowExecutionTaskInvocationsRequest"
-    );
+    return __isa(o, "DescribeMaintenanceWindowExecutionTaskInvocationsRequest");
   }
 }
 
@@ -4646,10 +4646,7 @@ export namespace DescribeMaintenanceWindowExecutionTaskInvocationsResult {
   export function isa(
     o: any
   ): o is DescribeMaintenanceWindowExecutionTaskInvocationsResult {
-    return _smithy.isa(
-      o,
-      "DescribeMaintenanceWindowExecutionTaskInvocationsResult"
-    );
+    return __isa(o, "DescribeMaintenanceWindowExecutionTaskInvocationsResult");
   }
 }
 
@@ -4684,7 +4681,7 @@ export namespace DescribeMaintenanceWindowExecutionTasksRequest {
   export function isa(
     o: any
   ): o is DescribeMaintenanceWindowExecutionTasksRequest {
-    return _smithy.isa(o, "DescribeMaintenanceWindowExecutionTasksRequest");
+    return __isa(o, "DescribeMaintenanceWindowExecutionTasksRequest");
   }
 }
 
@@ -4707,7 +4704,7 @@ export namespace DescribeMaintenanceWindowExecutionTasksResult {
   export function isa(
     o: any
   ): o is DescribeMaintenanceWindowExecutionTasksResult {
-    return _smithy.isa(o, "DescribeMaintenanceWindowExecutionTasksResult");
+    return __isa(o, "DescribeMaintenanceWindowExecutionTasksResult");
   }
 }
 
@@ -4742,7 +4739,7 @@ export interface DescribeMaintenanceWindowExecutionsRequest {
 
 export namespace DescribeMaintenanceWindowExecutionsRequest {
   export function isa(o: any): o is DescribeMaintenanceWindowExecutionsRequest {
-    return _smithy.isa(o, "DescribeMaintenanceWindowExecutionsRequest");
+    return __isa(o, "DescribeMaintenanceWindowExecutionsRequest");
   }
 }
 
@@ -4763,7 +4760,7 @@ export interface DescribeMaintenanceWindowExecutionsResult
 
 export namespace DescribeMaintenanceWindowExecutionsResult {
   export function isa(o: any): o is DescribeMaintenanceWindowExecutionsResult {
-    return _smithy.isa(o, "DescribeMaintenanceWindowExecutionsResult");
+    return __isa(o, "DescribeMaintenanceWindowExecutionsResult");
   }
 }
 
@@ -4805,7 +4802,7 @@ export interface DescribeMaintenanceWindowScheduleRequest {
 
 export namespace DescribeMaintenanceWindowScheduleRequest {
   export function isa(o: any): o is DescribeMaintenanceWindowScheduleRequest {
-    return _smithy.isa(o, "DescribeMaintenanceWindowScheduleRequest");
+    return __isa(o, "DescribeMaintenanceWindowScheduleRequest");
   }
 }
 
@@ -4826,7 +4823,7 @@ export interface DescribeMaintenanceWindowScheduleResult
 
 export namespace DescribeMaintenanceWindowScheduleResult {
   export function isa(o: any): o is DescribeMaintenanceWindowScheduleResult {
-    return _smithy.isa(o, "DescribeMaintenanceWindowScheduleResult");
+    return __isa(o, "DescribeMaintenanceWindowScheduleResult");
   }
 }
 
@@ -4858,7 +4855,7 @@ export interface DescribeMaintenanceWindowTargetsRequest {
 
 export namespace DescribeMaintenanceWindowTargetsRequest {
   export function isa(o: any): o is DescribeMaintenanceWindowTargetsRequest {
-    return _smithy.isa(o, "DescribeMaintenanceWindowTargetsRequest");
+    return __isa(o, "DescribeMaintenanceWindowTargetsRequest");
   }
 }
 
@@ -4879,7 +4876,7 @@ export interface DescribeMaintenanceWindowTargetsResult
 
 export namespace DescribeMaintenanceWindowTargetsResult {
   export function isa(o: any): o is DescribeMaintenanceWindowTargetsResult {
-    return _smithy.isa(o, "DescribeMaintenanceWindowTargetsResult");
+    return __isa(o, "DescribeMaintenanceWindowTargetsResult");
   }
 }
 
@@ -4911,7 +4908,7 @@ export interface DescribeMaintenanceWindowTasksRequest {
 
 export namespace DescribeMaintenanceWindowTasksRequest {
   export function isa(o: any): o is DescribeMaintenanceWindowTasksRequest {
-    return _smithy.isa(o, "DescribeMaintenanceWindowTasksRequest");
+    return __isa(o, "DescribeMaintenanceWindowTasksRequest");
   }
 }
 
@@ -4931,7 +4928,7 @@ export interface DescribeMaintenanceWindowTasksResult extends $MetadataBearer {
 
 export namespace DescribeMaintenanceWindowTasksResult {
   export function isa(o: any): o is DescribeMaintenanceWindowTasksResult {
-    return _smithy.isa(o, "DescribeMaintenanceWindowTasksResult");
+    return __isa(o, "DescribeMaintenanceWindowTasksResult");
   }
 }
 
@@ -4962,7 +4959,7 @@ export interface DescribeMaintenanceWindowsForTargetRequest {
 
 export namespace DescribeMaintenanceWindowsForTargetRequest {
   export function isa(o: any): o is DescribeMaintenanceWindowsForTargetRequest {
-    return _smithy.isa(o, "DescribeMaintenanceWindowsForTargetRequest");
+    return __isa(o, "DescribeMaintenanceWindowsForTargetRequest");
   }
 }
 
@@ -4983,7 +4980,7 @@ export interface DescribeMaintenanceWindowsForTargetResult
 
 export namespace DescribeMaintenanceWindowsForTargetResult {
   export function isa(o: any): o is DescribeMaintenanceWindowsForTargetResult {
-    return _smithy.isa(o, "DescribeMaintenanceWindowsForTargetResult");
+    return __isa(o, "DescribeMaintenanceWindowsForTargetResult");
   }
 }
 
@@ -5010,7 +5007,7 @@ export interface DescribeMaintenanceWindowsRequest {
 
 export namespace DescribeMaintenanceWindowsRequest {
   export function isa(o: any): o is DescribeMaintenanceWindowsRequest {
-    return _smithy.isa(o, "DescribeMaintenanceWindowsRequest");
+    return __isa(o, "DescribeMaintenanceWindowsRequest");
   }
 }
 
@@ -5030,7 +5027,7 @@ export interface DescribeMaintenanceWindowsResult extends $MetadataBearer {
 
 export namespace DescribeMaintenanceWindowsResult {
   export function isa(o: any): o is DescribeMaintenanceWindowsResult {
-    return _smithy.isa(o, "DescribeMaintenanceWindowsResult");
+    return __isa(o, "DescribeMaintenanceWindowsResult");
   }
 }
 
@@ -5111,7 +5108,7 @@ export interface DescribeOpsItemsRequest {
 
 export namespace DescribeOpsItemsRequest {
   export function isa(o: any): o is DescribeOpsItemsRequest {
-    return _smithy.isa(o, "DescribeOpsItemsRequest");
+    return __isa(o, "DescribeOpsItemsRequest");
   }
 }
 
@@ -5131,7 +5128,7 @@ export interface DescribeOpsItemsResponse extends $MetadataBearer {
 
 export namespace DescribeOpsItemsResponse {
   export function isa(o: any): o is DescribeOpsItemsResponse {
-    return _smithy.isa(o, "DescribeOpsItemsResponse");
+    return __isa(o, "DescribeOpsItemsResponse");
   }
 }
 
@@ -5162,7 +5159,7 @@ export interface DescribeParametersRequest {
 
 export namespace DescribeParametersRequest {
   export function isa(o: any): o is DescribeParametersRequest {
-    return _smithy.isa(o, "DescribeParametersRequest");
+    return __isa(o, "DescribeParametersRequest");
   }
 }
 
@@ -5182,7 +5179,7 @@ export interface DescribeParametersResult extends $MetadataBearer {
 
 export namespace DescribeParametersResult {
   export function isa(o: any): o is DescribeParametersResult {
-    return _smithy.isa(o, "DescribeParametersResult");
+    return __isa(o, "DescribeParametersResult");
   }
 }
 
@@ -5209,7 +5206,7 @@ export interface DescribePatchBaselinesRequest {
 
 export namespace DescribePatchBaselinesRequest {
   export function isa(o: any): o is DescribePatchBaselinesRequest {
-    return _smithy.isa(o, "DescribePatchBaselinesRequest");
+    return __isa(o, "DescribePatchBaselinesRequest");
   }
 }
 
@@ -5229,7 +5226,7 @@ export interface DescribePatchBaselinesResult extends $MetadataBearer {
 
 export namespace DescribePatchBaselinesResult {
   export function isa(o: any): o is DescribePatchBaselinesResult {
-    return _smithy.isa(o, "DescribePatchBaselinesResult");
+    return __isa(o, "DescribePatchBaselinesResult");
   }
 }
 
@@ -5243,7 +5240,7 @@ export interface DescribePatchGroupStateRequest {
 
 export namespace DescribePatchGroupStateRequest {
   export function isa(o: any): o is DescribePatchGroupStateRequest {
-    return _smithy.isa(o, "DescribePatchGroupStateRequest");
+    return __isa(o, "DescribePatchGroupStateRequest");
   }
 }
 
@@ -5306,7 +5303,7 @@ export interface DescribePatchGroupStateResult extends $MetadataBearer {
 
 export namespace DescribePatchGroupStateResult {
   export function isa(o: any): o is DescribePatchGroupStateResult {
-    return _smithy.isa(o, "DescribePatchGroupStateResult");
+    return __isa(o, "DescribePatchGroupStateResult");
   }
 }
 
@@ -5331,7 +5328,7 @@ export interface DescribePatchGroupsRequest {
 
 export namespace DescribePatchGroupsRequest {
   export function isa(o: any): o is DescribePatchGroupsRequest {
-    return _smithy.isa(o, "DescribePatchGroupsRequest");
+    return __isa(o, "DescribePatchGroupsRequest");
   }
 }
 
@@ -5354,7 +5351,7 @@ export interface DescribePatchGroupsResult extends $MetadataBearer {
 
 export namespace DescribePatchGroupsResult {
   export function isa(o: any): o is DescribePatchGroupsResult {
-    return _smithy.isa(o, "DescribePatchGroupsResult");
+    return __isa(o, "DescribePatchGroupsResult");
   }
 }
 
@@ -5391,7 +5388,7 @@ export interface DescribePatchPropertiesRequest {
 
 export namespace DescribePatchPropertiesRequest {
   export function isa(o: any): o is DescribePatchPropertiesRequest {
-    return _smithy.isa(o, "DescribePatchPropertiesRequest");
+    return __isa(o, "DescribePatchPropertiesRequest");
   }
 }
 
@@ -5410,7 +5407,7 @@ export interface DescribePatchPropertiesResult extends $MetadataBearer {
 
 export namespace DescribePatchPropertiesResult {
   export function isa(o: any): o is DescribePatchPropertiesResult {
-    return _smithy.isa(o, "DescribePatchPropertiesResult");
+    return __isa(o, "DescribePatchPropertiesResult");
   }
 }
 
@@ -5441,7 +5438,7 @@ export interface DescribeSessionsRequest {
 
 export namespace DescribeSessionsRequest {
   export function isa(o: any): o is DescribeSessionsRequest {
-    return _smithy.isa(o, "DescribeSessionsRequest");
+    return __isa(o, "DescribeSessionsRequest");
   }
 }
 
@@ -5461,7 +5458,7 @@ export interface DescribeSessionsResponse extends $MetadataBearer {
 
 export namespace DescribeSessionsResponse {
   export function isa(o: any): o is DescribeSessionsResponse {
-    return _smithy.isa(o, "DescribeSessionsResponse");
+    return __isa(o, "DescribeSessionsResponse");
   }
 }
 
@@ -5469,7 +5466,7 @@ export namespace DescribeSessionsResponse {
  * <p>The specified document already exists.</p>
  */
 export interface DocumentAlreadyExists
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DocumentAlreadyExists";
   $fault: "client";
@@ -5478,7 +5475,7 @@ export interface DocumentAlreadyExists
 
 export namespace DocumentAlreadyExists {
   export function isa(o: any): o is DocumentAlreadyExists {
-    return _smithy.isa(o, "DocumentAlreadyExists");
+    return __isa(o, "DocumentAlreadyExists");
   }
 }
 
@@ -5505,7 +5502,7 @@ export interface DocumentDefaultVersionDescription {
 
 export namespace DocumentDefaultVersionDescription {
   export function isa(o: any): o is DocumentDefaultVersionDescription {
-    return _smithy.isa(o, "DocumentDefaultVersionDescription");
+    return __isa(o, "DocumentDefaultVersionDescription");
   }
 }
 
@@ -5640,7 +5637,7 @@ export interface DocumentDescription {
 
 export namespace DocumentDescription {
   export function isa(o: any): o is DocumentDescription {
-    return _smithy.isa(o, "DocumentDescription");
+    return __isa(o, "DocumentDescription");
   }
 }
 
@@ -5662,7 +5659,7 @@ export interface DocumentFilter {
 
 export namespace DocumentFilter {
   export function isa(o: any): o is DocumentFilter {
-    return _smithy.isa(o, "DocumentFilter");
+    return __isa(o, "DocumentFilter");
   }
 }
 
@@ -5753,7 +5750,7 @@ export interface DocumentIdentifier {
 
 export namespace DocumentIdentifier {
   export function isa(o: any): o is DocumentIdentifier {
-    return _smithy.isa(o, "DocumentIdentifier");
+    return __isa(o, "DocumentIdentifier");
   }
 }
 
@@ -5796,7 +5793,7 @@ export interface DocumentKeyValuesFilter {
 
 export namespace DocumentKeyValuesFilter {
   export function isa(o: any): o is DocumentKeyValuesFilter {
-    return _smithy.isa(o, "DocumentKeyValuesFilter");
+    return __isa(o, "DocumentKeyValuesFilter");
   }
 }
 
@@ -5804,7 +5801,7 @@ export namespace DocumentKeyValuesFilter {
  * <p>You can have at most 500 active Systems Manager documents.</p>
  */
 export interface DocumentLimitExceeded
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DocumentLimitExceeded";
   $fault: "client";
@@ -5813,7 +5810,7 @@ export interface DocumentLimitExceeded
 
 export namespace DocumentLimitExceeded {
   export function isa(o: any): o is DocumentLimitExceeded {
-    return _smithy.isa(o, "DocumentLimitExceeded");
+    return __isa(o, "DocumentLimitExceeded");
   }
 }
 
@@ -5848,7 +5845,7 @@ export interface DocumentParameter {
 
 export namespace DocumentParameter {
   export function isa(o: any): o is DocumentParameter {
-    return _smithy.isa(o, "DocumentParameter");
+    return __isa(o, "DocumentParameter");
   }
 }
 
@@ -5860,7 +5857,7 @@ export type DocumentParameterType = "String" | "StringList";
  *    limit, contact AWS Support.</p>
  */
 export interface DocumentPermissionLimit
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DocumentPermissionLimit";
   $fault: "client";
@@ -5869,7 +5866,7 @@ export interface DocumentPermissionLimit
 
 export namespace DocumentPermissionLimit {
   export function isa(o: any): o is DocumentPermissionLimit {
-    return _smithy.isa(o, "DocumentPermissionLimit");
+    return __isa(o, "DocumentPermissionLimit");
   }
 }
 
@@ -5895,7 +5892,7 @@ export interface DocumentRequires {
 
 export namespace DocumentRequires {
   export function isa(o: any): o is DocumentRequires {
-    return _smithy.isa(o, "DocumentRequires");
+    return __isa(o, "DocumentRequires");
   }
 }
 
@@ -5971,7 +5968,7 @@ export interface DocumentVersionInfo {
 
 export namespace DocumentVersionInfo {
   export function isa(o: any): o is DocumentVersionInfo {
-    return _smithy.isa(o, "DocumentVersionInfo");
+    return __isa(o, "DocumentVersionInfo");
   }
 }
 
@@ -5980,7 +5977,7 @@ export namespace DocumentVersionInfo {
  *    again.</p>
  */
 export interface DocumentVersionLimitExceeded
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DocumentVersionLimitExceeded";
   $fault: "client";
@@ -5989,7 +5986,7 @@ export interface DocumentVersionLimitExceeded
 
 export namespace DocumentVersionLimitExceeded {
   export function isa(o: any): o is DocumentVersionLimitExceeded {
-    return _smithy.isa(o, "DocumentVersionLimitExceeded");
+    return __isa(o, "DocumentVersionLimitExceeded");
   }
 }
 
@@ -6000,7 +5997,7 @@ export namespace DocumentVersionLimitExceeded {
  *         <i>AWS General Reference</i>.</p>
  */
 export interface DoesNotExistException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DoesNotExistException";
   $fault: "client";
@@ -6009,7 +6006,7 @@ export interface DoesNotExistException
 
 export namespace DoesNotExistException {
   export function isa(o: any): o is DoesNotExistException {
-    return _smithy.isa(o, "DoesNotExistException");
+    return __isa(o, "DoesNotExistException");
   }
 }
 
@@ -6018,7 +6015,7 @@ export namespace DoesNotExistException {
  *    document and try again.</p>
  */
 export interface DuplicateDocumentContent
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DuplicateDocumentContent";
   $fault: "client";
@@ -6027,7 +6024,7 @@ export interface DuplicateDocumentContent
 
 export namespace DuplicateDocumentContent {
   export function isa(o: any): o is DuplicateDocumentContent {
-    return _smithy.isa(o, "DuplicateDocumentContent");
+    return __isa(o, "DuplicateDocumentContent");
   }
 }
 
@@ -6036,7 +6033,7 @@ export namespace DuplicateDocumentContent {
  *    and then try again.</p>
  */
 export interface DuplicateDocumentVersionName
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DuplicateDocumentVersionName";
   $fault: "client";
@@ -6045,7 +6042,7 @@ export interface DuplicateDocumentVersionName
 
 export namespace DuplicateDocumentVersionName {
   export function isa(o: any): o is DuplicateDocumentVersionName {
-    return _smithy.isa(o, "DuplicateDocumentVersionName");
+    return __isa(o, "DuplicateDocumentVersionName");
   }
 }
 
@@ -6053,7 +6050,7 @@ export namespace DuplicateDocumentVersionName {
  * <p>You cannot specify an instance ID in more than one association.</p>
  */
 export interface DuplicateInstanceId
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DuplicateInstanceId";
   $fault: "client";
@@ -6061,7 +6058,7 @@ export interface DuplicateInstanceId
 
 export namespace DuplicateInstanceId {
   export function isa(o: any): o is DuplicateInstanceId {
-    return _smithy.isa(o, "DuplicateInstanceId");
+    return __isa(o, "DuplicateInstanceId");
   }
 }
 
@@ -6089,7 +6086,7 @@ export interface EffectivePatch {
 
 export namespace EffectivePatch {
   export function isa(o: any): o is EffectivePatch {
-    return _smithy.isa(o, "EffectivePatch");
+    return __isa(o, "EffectivePatch");
   }
 }
 
@@ -6121,7 +6118,7 @@ export interface FailedCreateAssociation {
 
 export namespace FailedCreateAssociation {
   export function isa(o: any): o is FailedCreateAssociation {
-    return _smithy.isa(o, "FailedCreateAssociation");
+    return __isa(o, "FailedCreateAssociation");
   }
 }
 
@@ -6150,7 +6147,7 @@ export interface FailureDetails {
 
 export namespace FailureDetails {
   export function isa(o: any): o is FailureDetails {
-    return _smithy.isa(o, "FailureDetails");
+    return __isa(o, "FailureDetails");
   }
 }
 
@@ -6161,7 +6158,7 @@ export type Fault = "Client" | "Server" | "Unknown";
  *    corresponding service is not available. </p>
  */
 export interface FeatureNotAvailableException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "FeatureNotAvailableException";
   $fault: "client";
@@ -6170,7 +6167,7 @@ export interface FeatureNotAvailableException
 
 export namespace FeatureNotAvailableException {
   export function isa(o: any): o is FeatureNotAvailableException {
-    return _smithy.isa(o, "FeatureNotAvailableException");
+    return __isa(o, "FeatureNotAvailableException");
   }
 }
 
@@ -6186,7 +6183,7 @@ export interface GetAutomationExecutionRequest {
 
 export namespace GetAutomationExecutionRequest {
   export function isa(o: any): o is GetAutomationExecutionRequest {
-    return _smithy.isa(o, "GetAutomationExecutionRequest");
+    return __isa(o, "GetAutomationExecutionRequest");
   }
 }
 
@@ -6200,7 +6197,7 @@ export interface GetAutomationExecutionResult extends $MetadataBearer {
 
 export namespace GetAutomationExecutionResult {
   export function isa(o: any): o is GetAutomationExecutionResult {
-    return _smithy.isa(o, "GetAutomationExecutionResult");
+    return __isa(o, "GetAutomationExecutionResult");
   }
 }
 
@@ -6221,7 +6218,7 @@ export interface GetCalendarStateRequest {
 
 export namespace GetCalendarStateRequest {
   export function isa(o: any): o is GetCalendarStateRequest {
-    return _smithy.isa(o, "GetCalendarStateRequest");
+    return __isa(o, "GetCalendarStateRequest");
   }
 }
 
@@ -6252,7 +6249,7 @@ export interface GetCalendarStateResponse extends $MetadataBearer {
 
 export namespace GetCalendarStateResponse {
   export function isa(o: any): o is GetCalendarStateResponse {
-    return _smithy.isa(o, "GetCalendarStateResponse");
+    return __isa(o, "GetCalendarStateResponse");
   }
 }
 
@@ -6279,7 +6276,7 @@ export interface GetCommandInvocationRequest {
 
 export namespace GetCommandInvocationRequest {
   export function isa(o: any): o is GetCommandInvocationRequest {
-    return _smithy.isa(o, "GetCommandInvocationRequest");
+    return __isa(o, "GetCommandInvocationRequest");
   }
 }
 
@@ -6447,7 +6444,7 @@ export interface GetCommandInvocationResult extends $MetadataBearer {
 
 export namespace GetCommandInvocationResult {
   export function isa(o: any): o is GetCommandInvocationResult {
-    return _smithy.isa(o, "GetCommandInvocationResult");
+    return __isa(o, "GetCommandInvocationResult");
   }
 }
 
@@ -6461,7 +6458,7 @@ export interface GetConnectionStatusRequest {
 
 export namespace GetConnectionStatusRequest {
   export function isa(o: any): o is GetConnectionStatusRequest {
-    return _smithy.isa(o, "GetConnectionStatusRequest");
+    return __isa(o, "GetConnectionStatusRequest");
   }
 }
 
@@ -6481,7 +6478,7 @@ export interface GetConnectionStatusResponse extends $MetadataBearer {
 
 export namespace GetConnectionStatusResponse {
   export function isa(o: any): o is GetConnectionStatusResponse {
-    return _smithy.isa(o, "GetConnectionStatusResponse");
+    return __isa(o, "GetConnectionStatusResponse");
   }
 }
 
@@ -6495,7 +6492,7 @@ export interface GetDefaultPatchBaselineRequest {
 
 export namespace GetDefaultPatchBaselineRequest {
   export function isa(o: any): o is GetDefaultPatchBaselineRequest {
-    return _smithy.isa(o, "GetDefaultPatchBaselineRequest");
+    return __isa(o, "GetDefaultPatchBaselineRequest");
   }
 }
 
@@ -6514,7 +6511,7 @@ export interface GetDefaultPatchBaselineResult extends $MetadataBearer {
 
 export namespace GetDefaultPatchBaselineResult {
   export function isa(o: any): o is GetDefaultPatchBaselineResult {
-    return _smithy.isa(o, "GetDefaultPatchBaselineResult");
+    return __isa(o, "GetDefaultPatchBaselineResult");
   }
 }
 
@@ -6535,7 +6532,7 @@ export namespace GetDeployablePatchSnapshotForInstanceRequest {
   export function isa(
     o: any
   ): o is GetDeployablePatchSnapshotForInstanceRequest {
-    return _smithy.isa(o, "GetDeployablePatchSnapshotForInstanceRequest");
+    return __isa(o, "GetDeployablePatchSnapshotForInstanceRequest");
   }
 }
 
@@ -6568,7 +6565,7 @@ export namespace GetDeployablePatchSnapshotForInstanceResult {
   export function isa(
     o: any
   ): o is GetDeployablePatchSnapshotForInstanceResult {
-    return _smithy.isa(o, "GetDeployablePatchSnapshotForInstanceResult");
+    return __isa(o, "GetDeployablePatchSnapshotForInstanceResult");
   }
 }
 
@@ -6600,7 +6597,7 @@ export interface GetDocumentRequest {
 
 export namespace GetDocumentRequest {
   export function isa(o: any): o is GetDocumentRequest {
-    return _smithy.isa(o, "GetDocumentRequest");
+    return __isa(o, "GetDocumentRequest");
   }
 }
 
@@ -6665,7 +6662,7 @@ export interface GetDocumentResult extends $MetadataBearer {
 
 export namespace GetDocumentResult {
   export function isa(o: any): o is GetDocumentResult {
-    return _smithy.isa(o, "GetDocumentResult");
+    return __isa(o, "GetDocumentResult");
   }
 }
 
@@ -6704,7 +6701,7 @@ export interface GetInventoryRequest {
 
 export namespace GetInventoryRequest {
   export function isa(o: any): o is GetInventoryRequest {
-    return _smithy.isa(o, "GetInventoryRequest");
+    return __isa(o, "GetInventoryRequest");
   }
 }
 
@@ -6724,7 +6721,7 @@ export interface GetInventoryResult extends $MetadataBearer {
 
 export namespace GetInventoryResult {
   export function isa(o: any): o is GetInventoryResult {
-    return _smithy.isa(o, "GetInventoryResult");
+    return __isa(o, "GetInventoryResult");
   }
 }
 
@@ -6763,7 +6760,7 @@ export interface GetInventorySchemaRequest {
 
 export namespace GetInventorySchemaRequest {
   export function isa(o: any): o is GetInventorySchemaRequest {
-    return _smithy.isa(o, "GetInventorySchemaRequest");
+    return __isa(o, "GetInventorySchemaRequest");
   }
 }
 
@@ -6783,7 +6780,7 @@ export interface GetInventorySchemaResult extends $MetadataBearer {
 
 export namespace GetInventorySchemaResult {
   export function isa(o: any): o is GetInventorySchemaResult {
-    return _smithy.isa(o, "GetInventorySchemaResult");
+    return __isa(o, "GetInventorySchemaResult");
   }
 }
 
@@ -6797,7 +6794,7 @@ export interface GetMaintenanceWindowExecutionRequest {
 
 export namespace GetMaintenanceWindowExecutionRequest {
   export function isa(o: any): o is GetMaintenanceWindowExecutionRequest {
-    return _smithy.isa(o, "GetMaintenanceWindowExecutionRequest");
+    return __isa(o, "GetMaintenanceWindowExecutionRequest");
   }
 }
 
@@ -6836,7 +6833,7 @@ export interface GetMaintenanceWindowExecutionResult extends $MetadataBearer {
 
 export namespace GetMaintenanceWindowExecutionResult {
   export function isa(o: any): o is GetMaintenanceWindowExecutionResult {
-    return _smithy.isa(o, "GetMaintenanceWindowExecutionResult");
+    return __isa(o, "GetMaintenanceWindowExecutionResult");
   }
 }
 
@@ -6862,7 +6859,7 @@ export namespace GetMaintenanceWindowExecutionTaskInvocationRequest {
   export function isa(
     o: any
   ): o is GetMaintenanceWindowExecutionTaskInvocationRequest {
-    return _smithy.isa(o, "GetMaintenanceWindowExecutionTaskInvocationRequest");
+    return __isa(o, "GetMaintenanceWindowExecutionTaskInvocationRequest");
   }
 }
 
@@ -6937,7 +6934,7 @@ export namespace GetMaintenanceWindowExecutionTaskInvocationResult {
   export function isa(
     o: any
   ): o is GetMaintenanceWindowExecutionTaskInvocationResult {
-    return _smithy.isa(o, "GetMaintenanceWindowExecutionTaskInvocationResult");
+    return __isa(o, "GetMaintenanceWindowExecutionTaskInvocationResult");
   }
 }
 
@@ -6957,7 +6954,7 @@ export interface GetMaintenanceWindowExecutionTaskRequest {
 
 export namespace GetMaintenanceWindowExecutionTaskRequest {
   export function isa(o: any): o is GetMaintenanceWindowExecutionTaskRequest {
-    return _smithy.isa(o, "GetMaintenanceWindowExecutionTaskRequest");
+    return __isa(o, "GetMaintenanceWindowExecutionTaskRequest");
   }
 }
 
@@ -7046,7 +7043,7 @@ export interface GetMaintenanceWindowExecutionTaskResult
 
 export namespace GetMaintenanceWindowExecutionTaskResult {
   export function isa(o: any): o is GetMaintenanceWindowExecutionTaskResult {
-    return _smithy.isa(o, "GetMaintenanceWindowExecutionTaskResult");
+    return __isa(o, "GetMaintenanceWindowExecutionTaskResult");
   }
 }
 
@@ -7060,7 +7057,7 @@ export interface GetMaintenanceWindowRequest {
 
 export namespace GetMaintenanceWindowRequest {
   export function isa(o: any): o is GetMaintenanceWindowRequest {
-    return _smithy.isa(o, "GetMaintenanceWindowRequest");
+    return __isa(o, "GetMaintenanceWindowRequest");
   }
 }
 
@@ -7147,7 +7144,7 @@ export interface GetMaintenanceWindowResult extends $MetadataBearer {
 
 export namespace GetMaintenanceWindowResult {
   export function isa(o: any): o is GetMaintenanceWindowResult {
-    return _smithy.isa(o, "GetMaintenanceWindowResult");
+    return __isa(o, "GetMaintenanceWindowResult");
   }
 }
 
@@ -7166,7 +7163,7 @@ export interface GetMaintenanceWindowTaskRequest {
 
 export namespace GetMaintenanceWindowTaskRequest {
   export function isa(o: any): o is GetMaintenanceWindowTaskRequest {
-    return _smithy.isa(o, "GetMaintenanceWindowTaskRequest");
+    return __isa(o, "GetMaintenanceWindowTaskRequest");
   }
 }
 
@@ -7265,7 +7262,7 @@ export interface GetMaintenanceWindowTaskResult extends $MetadataBearer {
 
 export namespace GetMaintenanceWindowTaskResult {
   export function isa(o: any): o is GetMaintenanceWindowTaskResult {
-    return _smithy.isa(o, "GetMaintenanceWindowTaskResult");
+    return __isa(o, "GetMaintenanceWindowTaskResult");
   }
 }
 
@@ -7279,7 +7276,7 @@ export interface GetOpsItemRequest {
 
 export namespace GetOpsItemRequest {
   export function isa(o: any): o is GetOpsItemRequest {
-    return _smithy.isa(o, "GetOpsItemRequest");
+    return __isa(o, "GetOpsItemRequest");
   }
 }
 
@@ -7293,7 +7290,7 @@ export interface GetOpsItemResponse extends $MetadataBearer {
 
 export namespace GetOpsItemResponse {
   export function isa(o: any): o is GetOpsItemResponse {
-    return _smithy.isa(o, "GetOpsItemResponse");
+    return __isa(o, "GetOpsItemResponse");
   }
 }
 
@@ -7333,7 +7330,7 @@ export interface GetOpsSummaryRequest {
 
 export namespace GetOpsSummaryRequest {
   export function isa(o: any): o is GetOpsSummaryRequest {
-    return _smithy.isa(o, "GetOpsSummaryRequest");
+    return __isa(o, "GetOpsSummaryRequest");
   }
 }
 
@@ -7353,7 +7350,7 @@ export interface GetOpsSummaryResult extends $MetadataBearer {
 
 export namespace GetOpsSummaryResult {
   export function isa(o: any): o is GetOpsSummaryResult {
-    return _smithy.isa(o, "GetOpsSummaryResult");
+    return __isa(o, "GetOpsSummaryResult");
   }
 }
 
@@ -7385,7 +7382,7 @@ export interface GetParameterHistoryRequest {
 
 export namespace GetParameterHistoryRequest {
   export function isa(o: any): o is GetParameterHistoryRequest {
-    return _smithy.isa(o, "GetParameterHistoryRequest");
+    return __isa(o, "GetParameterHistoryRequest");
   }
 }
 
@@ -7405,7 +7402,7 @@ export interface GetParameterHistoryResult extends $MetadataBearer {
 
 export namespace GetParameterHistoryResult {
   export function isa(o: any): o is GetParameterHistoryResult {
-    return _smithy.isa(o, "GetParameterHistoryResult");
+    return __isa(o, "GetParameterHistoryResult");
   }
 }
 
@@ -7425,7 +7422,7 @@ export interface GetParameterRequest {
 
 export namespace GetParameterRequest {
   export function isa(o: any): o is GetParameterRequest {
-    return _smithy.isa(o, "GetParameterRequest");
+    return __isa(o, "GetParameterRequest");
   }
 }
 
@@ -7439,7 +7436,7 @@ export interface GetParameterResult extends $MetadataBearer {
 
 export namespace GetParameterResult {
   export function isa(o: any): o is GetParameterResult {
-    return _smithy.isa(o, "GetParameterResult");
+    return __isa(o, "GetParameterResult");
   }
 }
 
@@ -7489,7 +7486,7 @@ export interface GetParametersByPathRequest {
 
 export namespace GetParametersByPathRequest {
   export function isa(o: any): o is GetParametersByPathRequest {
-    return _smithy.isa(o, "GetParametersByPathRequest");
+    return __isa(o, "GetParametersByPathRequest");
   }
 }
 
@@ -7509,7 +7506,7 @@ export interface GetParametersByPathResult extends $MetadataBearer {
 
 export namespace GetParametersByPathResult {
   export function isa(o: any): o is GetParametersByPathResult {
-    return _smithy.isa(o, "GetParametersByPathResult");
+    return __isa(o, "GetParametersByPathResult");
   }
 }
 
@@ -7529,7 +7526,7 @@ export interface GetParametersRequest {
 
 export namespace GetParametersRequest {
   export function isa(o: any): o is GetParametersRequest {
-    return _smithy.isa(o, "GetParametersRequest");
+    return __isa(o, "GetParametersRequest");
   }
 }
 
@@ -7549,7 +7546,7 @@ export interface GetParametersResult extends $MetadataBearer {
 
 export namespace GetParametersResult {
   export function isa(o: any): o is GetParametersResult {
-    return _smithy.isa(o, "GetParametersResult");
+    return __isa(o, "GetParametersResult");
   }
 }
 
@@ -7568,7 +7565,7 @@ export interface GetPatchBaselineForPatchGroupRequest {
 
 export namespace GetPatchBaselineForPatchGroupRequest {
   export function isa(o: any): o is GetPatchBaselineForPatchGroupRequest {
-    return _smithy.isa(o, "GetPatchBaselineForPatchGroupRequest");
+    return __isa(o, "GetPatchBaselineForPatchGroupRequest");
   }
 }
 
@@ -7592,7 +7589,7 @@ export interface GetPatchBaselineForPatchGroupResult extends $MetadataBearer {
 
 export namespace GetPatchBaselineForPatchGroupResult {
   export function isa(o: any): o is GetPatchBaselineForPatchGroupResult {
-    return _smithy.isa(o, "GetPatchBaselineForPatchGroupResult");
+    return __isa(o, "GetPatchBaselineForPatchGroupResult");
   }
 }
 
@@ -7606,7 +7603,7 @@ export interface GetPatchBaselineRequest {
 
 export namespace GetPatchBaselineRequest {
   export function isa(o: any): o is GetPatchBaselineRequest {
-    return _smithy.isa(o, "GetPatchBaselineRequest");
+    return __isa(o, "GetPatchBaselineRequest");
   }
 }
 
@@ -7695,7 +7692,7 @@ export interface GetPatchBaselineResult extends $MetadataBearer {
 
 export namespace GetPatchBaselineResult {
   export function isa(o: any): o is GetPatchBaselineResult {
-    return _smithy.isa(o, "GetPatchBaselineResult");
+    return __isa(o, "GetPatchBaselineResult");
   }
 }
 
@@ -7712,7 +7709,7 @@ export interface GetServiceSettingRequest {
 
 export namespace GetServiceSettingRequest {
   export function isa(o: any): o is GetServiceSettingRequest {
-    return _smithy.isa(o, "GetServiceSettingRequest");
+    return __isa(o, "GetServiceSettingRequest");
   }
 }
 
@@ -7729,7 +7726,7 @@ export interface GetServiceSettingResult extends $MetadataBearer {
 
 export namespace GetServiceSettingResult {
   export function isa(o: any): o is GetServiceSettingResult {
-    return _smithy.isa(o, "GetServiceSettingResult");
+    return __isa(o, "GetServiceSettingResult");
   }
 }
 
@@ -7738,7 +7735,7 @@ export namespace GetServiceSettingResult {
  *     Parameter Names</a> in the <i>AWS Systems Manager User Guide</i>. </p>
  */
 export interface HierarchyLevelLimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "HierarchyLevelLimitExceededException";
   $fault: "client";
@@ -7751,7 +7748,7 @@ export interface HierarchyLevelLimitExceededException
 
 export namespace HierarchyLevelLimitExceededException {
   export function isa(o: any): o is HierarchyLevelLimitExceededException {
-    return _smithy.isa(o, "HierarchyLevelLimitExceededException");
+    return __isa(o, "HierarchyLevelLimitExceededException");
   }
 }
 
@@ -7761,7 +7758,7 @@ export namespace HierarchyLevelLimitExceededException {
  *    parameter.</p>
  */
 export interface HierarchyTypeMismatchException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "HierarchyTypeMismatchException";
   $fault: "client";
@@ -7775,7 +7772,7 @@ export interface HierarchyTypeMismatchException
 
 export namespace HierarchyTypeMismatchException {
   export function isa(o: any): o is HierarchyTypeMismatchException {
-    return _smithy.isa(o, "HierarchyTypeMismatchException");
+    return __isa(o, "HierarchyTypeMismatchException");
   }
 }
 
@@ -7784,7 +7781,7 @@ export namespace HierarchyTypeMismatchException {
  *    original call to the API with the same idempotency token. </p>
  */
 export interface IdempotentParameterMismatch
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "IdempotentParameterMismatch";
   $fault: "client";
@@ -7793,7 +7790,7 @@ export interface IdempotentParameterMismatch
 
 export namespace IdempotentParameterMismatch {
   export function isa(o: any): o is IdempotentParameterMismatch {
-    return _smithy.isa(o, "IdempotentParameterMismatch");
+    return __isa(o, "IdempotentParameterMismatch");
   }
 }
 
@@ -7802,7 +7799,7 @@ export namespace IdempotentParameterMismatch {
  *    specify two Expiration policies for a parameter. Review your policies, and try again.</p>
  */
 export interface IncompatiblePolicyException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "IncompatiblePolicyException";
   $fault: "client";
@@ -7811,7 +7808,7 @@ export interface IncompatiblePolicyException
 
 export namespace IncompatiblePolicyException {
   export function isa(o: any): o is IncompatiblePolicyException {
-    return _smithy.isa(o, "IncompatiblePolicyException");
+    return __isa(o, "IncompatiblePolicyException");
   }
 }
 
@@ -7833,7 +7830,7 @@ export interface InstanceAggregatedAssociationOverview {
 
 export namespace InstanceAggregatedAssociationOverview {
   export function isa(o: any): o is InstanceAggregatedAssociationOverview {
-    return _smithy.isa(o, "InstanceAggregatedAssociationOverview");
+    return __isa(o, "InstanceAggregatedAssociationOverview");
   }
 }
 
@@ -7865,7 +7862,7 @@ export interface InstanceAssociation {
 
 export namespace InstanceAssociation {
   export function isa(o: any): o is InstanceAssociation {
-    return _smithy.isa(o, "InstanceAssociation");
+    return __isa(o, "InstanceAssociation");
   }
 }
 
@@ -7882,7 +7879,7 @@ export interface InstanceAssociationOutputLocation {
 
 export namespace InstanceAssociationOutputLocation {
   export function isa(o: any): o is InstanceAssociationOutputLocation {
-    return _smithy.isa(o, "InstanceAssociationOutputLocation");
+    return __isa(o, "InstanceAssociationOutputLocation");
   }
 }
 
@@ -7899,7 +7896,7 @@ export interface InstanceAssociationOutputUrl {
 
 export namespace InstanceAssociationOutputUrl {
   export function isa(o: any): o is InstanceAssociationOutputUrl {
-    return _smithy.isa(o, "InstanceAssociationOutputUrl");
+    return __isa(o, "InstanceAssociationOutputUrl");
   }
 }
 
@@ -7971,7 +7968,7 @@ export interface InstanceAssociationStatusInfo {
 
 export namespace InstanceAssociationStatusInfo {
   export function isa(o: any): o is InstanceAssociationStatusInfo {
-    return _smithy.isa(o, "InstanceAssociationStatusInfo");
+    return __isa(o, "InstanceAssociationStatusInfo");
   }
 }
 
@@ -8082,7 +8079,7 @@ export interface InstanceInformation {
 
 export namespace InstanceInformation {
   export function isa(o: any): o is InstanceInformation {
-    return _smithy.isa(o, "InstanceInformation");
+    return __isa(o, "InstanceInformation");
   }
 }
 
@@ -8108,7 +8105,7 @@ export interface InstanceInformationFilter {
 
 export namespace InstanceInformationFilter {
   export function isa(o: any): o is InstanceInformationFilter {
-    return _smithy.isa(o, "InstanceInformationFilter");
+    return __isa(o, "InstanceInformationFilter");
   }
 }
 
@@ -8143,7 +8140,7 @@ export interface InstanceInformationStringFilter {
 
 export namespace InstanceInformationStringFilter {
   export function isa(o: any): o is InstanceInformationStringFilter {
-    return _smithy.isa(o, "InstanceInformationStringFilter");
+    return __isa(o, "InstanceInformationStringFilter");
   }
 }
 
@@ -8295,7 +8292,7 @@ export interface InstancePatchState {
 
 export namespace InstancePatchState {
   export function isa(o: any): o is InstancePatchState {
-    return _smithy.isa(o, "InstancePatchState");
+    return __isa(o, "InstancePatchState");
   }
 }
 
@@ -8325,7 +8322,7 @@ export interface InstancePatchStateFilter {
 
 export namespace InstancePatchStateFilter {
   export function isa(o: any): o is InstancePatchStateFilter {
-    return _smithy.isa(o, "InstancePatchStateFilter");
+    return __isa(o, "InstancePatchStateFilter");
   }
 }
 
@@ -8340,7 +8337,7 @@ export enum InstancePatchStateOperatorType {
  * <p>An error occurred on the server side.</p>
  */
 export interface InternalServerError
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalServerError";
   $fault: "server";
@@ -8349,7 +8346,7 @@ export interface InternalServerError
 
 export namespace InternalServerError {
   export function isa(o: any): o is InternalServerError {
-    return _smithy.isa(o, "InternalServerError");
+    return __isa(o, "InternalServerError");
   }
 }
 
@@ -8357,9 +8354,7 @@ export namespace InternalServerError {
  * <p>The activation is not valid. The activation might have been deleted, or the ActivationId and
  *    the ActivationCode do not match.</p>
  */
-export interface InvalidActivation
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface InvalidActivation extends __SmithyException, $MetadataBearer {
   name: "InvalidActivation";
   $fault: "client";
   Message?: string;
@@ -8367,7 +8362,7 @@ export interface InvalidActivation
 
 export namespace InvalidActivation {
   export function isa(o: any): o is InvalidActivation {
-    return _smithy.isa(o, "InvalidActivation");
+    return __isa(o, "InvalidActivation");
   }
 }
 
@@ -8376,7 +8371,7 @@ export namespace InvalidActivation {
  *    ActivationCode and try again.</p>
  */
 export interface InvalidActivationId
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidActivationId";
   $fault: "client";
@@ -8385,7 +8380,7 @@ export interface InvalidActivationId
 
 export namespace InvalidActivationId {
   export function isa(o: any): o is InvalidActivationId {
-    return _smithy.isa(o, "InvalidActivationId");
+    return __isa(o, "InvalidActivationId");
   }
 }
 
@@ -8395,7 +8390,7 @@ export namespace InvalidActivationId {
  *     <code>AWS:InstanceInformation</code>.</p>
  */
 export interface InvalidAggregatorException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidAggregatorException";
   $fault: "client";
@@ -8404,7 +8399,7 @@ export interface InvalidAggregatorException
 
 export namespace InvalidAggregatorException {
   export function isa(o: any): o is InvalidAggregatorException {
-    return _smithy.isa(o, "InvalidAggregatorException");
+    return __isa(o, "InvalidAggregatorException");
   }
 }
 
@@ -8412,7 +8407,7 @@ export namespace InvalidAggregatorException {
  * <p>The request does not meet the regular expression requirement.</p>
  */
 export interface InvalidAllowedPatternException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidAllowedPatternException";
   $fault: "client";
@@ -8424,16 +8419,14 @@ export interface InvalidAllowedPatternException
 
 export namespace InvalidAllowedPatternException {
   export function isa(o: any): o is InvalidAllowedPatternException {
-    return _smithy.isa(o, "InvalidAllowedPatternException");
+    return __isa(o, "InvalidAllowedPatternException");
   }
 }
 
 /**
  * <p>The association is not valid or does not exist. </p>
  */
-export interface InvalidAssociation
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface InvalidAssociation extends __SmithyException, $MetadataBearer {
   name: "InvalidAssociation";
   $fault: "client";
   Message?: string;
@@ -8441,7 +8434,7 @@ export interface InvalidAssociation
 
 export namespace InvalidAssociation {
   export function isa(o: any): o is InvalidAssociation {
-    return _smithy.isa(o, "InvalidAssociation");
+    return __isa(o, "InvalidAssociation");
   }
 }
 
@@ -8451,7 +8444,7 @@ export namespace InvalidAssociation {
  *    view the latest version of the association.</p>
  */
 export interface InvalidAssociationVersion
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidAssociationVersion";
   $fault: "client";
@@ -8460,7 +8453,7 @@ export interface InvalidAssociationVersion
 
 export namespace InvalidAssociationVersion {
   export function isa(o: any): o is InvalidAssociationVersion {
-    return _smithy.isa(o, "InvalidAssociationVersion");
+    return __isa(o, "InvalidAssociationVersion");
   }
 }
 
@@ -8470,7 +8463,7 @@ export namespace InvalidAssociationVersion {
  *    document.</p>
  */
 export interface InvalidAutomationExecutionParametersException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidAutomationExecutionParametersException";
   $fault: "client";
@@ -8481,7 +8474,7 @@ export namespace InvalidAutomationExecutionParametersException {
   export function isa(
     o: any
   ): o is InvalidAutomationExecutionParametersException {
-    return _smithy.isa(o, "InvalidAutomationExecutionParametersException");
+    return __isa(o, "InvalidAutomationExecutionParametersException");
   }
 }
 
@@ -8489,7 +8482,7 @@ export namespace InvalidAutomationExecutionParametersException {
  * <p>The signal is not valid for the current Automation execution.</p>
  */
 export interface InvalidAutomationSignalException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidAutomationSignalException";
   $fault: "client";
@@ -8498,7 +8491,7 @@ export interface InvalidAutomationSignalException
 
 export namespace InvalidAutomationSignalException {
   export function isa(o: any): o is InvalidAutomationSignalException {
-    return _smithy.isa(o, "InvalidAutomationSignalException");
+    return __isa(o, "InvalidAutomationSignalException");
   }
 }
 
@@ -8506,7 +8499,7 @@ export namespace InvalidAutomationSignalException {
  * <p>The specified update status operation is not valid.</p>
  */
 export interface InvalidAutomationStatusUpdateException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidAutomationStatusUpdateException";
   $fault: "client";
@@ -8515,20 +8508,18 @@ export interface InvalidAutomationStatusUpdateException
 
 export namespace InvalidAutomationStatusUpdateException {
   export function isa(o: any): o is InvalidAutomationStatusUpdateException {
-    return _smithy.isa(o, "InvalidAutomationStatusUpdateException");
+    return __isa(o, "InvalidAutomationStatusUpdateException");
   }
 }
 
-export interface InvalidCommandId
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface InvalidCommandId extends __SmithyException, $MetadataBearer {
   name: "InvalidCommandId";
   $fault: "client";
 }
 
 export namespace InvalidCommandId {
   export function isa(o: any): o is InvalidCommandId {
-    return _smithy.isa(o, "InvalidCommandId");
+    return __isa(o, "InvalidCommandId");
   }
 }
 
@@ -8537,7 +8528,7 @@ export namespace InvalidCommandId {
  *    parameters and try again.</p>
  */
 export interface InvalidDeleteInventoryParametersException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidDeleteInventoryParametersException";
   $fault: "client";
@@ -8546,7 +8537,7 @@ export interface InvalidDeleteInventoryParametersException
 
 export namespace InvalidDeleteInventoryParametersException {
   export function isa(o: any): o is InvalidDeleteInventoryParametersException {
-    return _smithy.isa(o, "InvalidDeleteInventoryParametersException");
+    return __isa(o, "InvalidDeleteInventoryParametersException");
   }
 }
 
@@ -8555,7 +8546,7 @@ export namespace InvalidDeleteInventoryParametersException {
  *    try again.</p>
  */
 export interface InvalidDeletionIdException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidDeletionIdException";
   $fault: "client";
@@ -8564,16 +8555,14 @@ export interface InvalidDeletionIdException
 
 export namespace InvalidDeletionIdException {
   export function isa(o: any): o is InvalidDeletionIdException {
-    return _smithy.isa(o, "InvalidDeletionIdException");
+    return __isa(o, "InvalidDeletionIdException");
   }
 }
 
 /**
  * <p>The specified document does not exist.</p>
  */
-export interface InvalidDocument
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface InvalidDocument extends __SmithyException, $MetadataBearer {
   name: "InvalidDocument";
   $fault: "client";
   /**
@@ -8587,7 +8576,7 @@ export interface InvalidDocument
 
 export namespace InvalidDocument {
   export function isa(o: any): o is InvalidDocument {
-    return _smithy.isa(o, "InvalidDocument");
+    return __isa(o, "InvalidDocument");
   }
 }
 
@@ -8595,7 +8584,7 @@ export namespace InvalidDocument {
  * <p>The content for the document is not valid.</p>
  */
 export interface InvalidDocumentContent
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidDocumentContent";
   $fault: "client";
@@ -8607,7 +8596,7 @@ export interface InvalidDocumentContent
 
 export namespace InvalidDocumentContent {
   export function isa(o: any): o is InvalidDocumentContent {
-    return _smithy.isa(o, "InvalidDocumentContent");
+    return __isa(o, "InvalidDocumentContent");
   }
 }
 
@@ -8616,7 +8605,7 @@ export namespace InvalidDocumentContent {
  *    document before you can delete it.</p>
  */
 export interface InvalidDocumentOperation
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidDocumentOperation";
   $fault: "client";
@@ -8625,7 +8614,7 @@ export interface InvalidDocumentOperation
 
 export namespace InvalidDocumentOperation {
   export function isa(o: any): o is InvalidDocumentOperation {
-    return _smithy.isa(o, "InvalidDocumentOperation");
+    return __isa(o, "InvalidDocumentOperation");
   }
 }
 
@@ -8633,7 +8622,7 @@ export namespace InvalidDocumentOperation {
  * <p>The version of the document schema is not supported.</p>
  */
 export interface InvalidDocumentSchemaVersion
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidDocumentSchemaVersion";
   $fault: "client";
@@ -8642,7 +8631,7 @@ export interface InvalidDocumentSchemaVersion
 
 export namespace InvalidDocumentSchemaVersion {
   export function isa(o: any): o is InvalidDocumentSchemaVersion {
-    return _smithy.isa(o, "InvalidDocumentSchemaVersion");
+    return __isa(o, "InvalidDocumentSchemaVersion");
   }
 }
 
@@ -8651,7 +8640,7 @@ export namespace InvalidDocumentSchemaVersion {
  *     <code>DocumentType</code> property.</p>
  */
 export interface InvalidDocumentType
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidDocumentType";
   $fault: "client";
@@ -8660,7 +8649,7 @@ export interface InvalidDocumentType
 
 export namespace InvalidDocumentType {
   export function isa(o: any): o is InvalidDocumentType {
-    return _smithy.isa(o, "InvalidDocumentType");
+    return __isa(o, "InvalidDocumentType");
   }
 }
 
@@ -8668,7 +8657,7 @@ export namespace InvalidDocumentType {
  * <p>The document version is not valid or does not exist.</p>
  */
 export interface InvalidDocumentVersion
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidDocumentVersion";
   $fault: "client";
@@ -8677,16 +8666,14 @@ export interface InvalidDocumentVersion
 
 export namespace InvalidDocumentVersion {
   export function isa(o: any): o is InvalidDocumentVersion {
-    return _smithy.isa(o, "InvalidDocumentVersion");
+    return __isa(o, "InvalidDocumentVersion");
   }
 }
 
 /**
  * <p>The filter name is not valid. Verify the you entered the correct name and try again.</p>
  */
-export interface InvalidFilter
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface InvalidFilter extends __SmithyException, $MetadataBearer {
   name: "InvalidFilter";
   $fault: "client";
   Message?: string;
@@ -8694,23 +8681,21 @@ export interface InvalidFilter
 
 export namespace InvalidFilter {
   export function isa(o: any): o is InvalidFilter {
-    return _smithy.isa(o, "InvalidFilter");
+    return __isa(o, "InvalidFilter");
   }
 }
 
 /**
  * <p>The specified key is not valid.</p>
  */
-export interface InvalidFilterKey
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface InvalidFilterKey extends __SmithyException, $MetadataBearer {
   name: "InvalidFilterKey";
   $fault: "client";
 }
 
 export namespace InvalidFilterKey {
   export function isa(o: any): o is InvalidFilterKey {
-    return _smithy.isa(o, "InvalidFilterKey");
+    return __isa(o, "InvalidFilterKey");
   }
 }
 
@@ -8719,7 +8704,7 @@ export namespace InvalidFilterKey {
  *    filter, valid options are Recursive and OneLevel.</p>
  */
 export interface InvalidFilterOption
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidFilterOption";
   $fault: "client";
@@ -8732,16 +8717,14 @@ export interface InvalidFilterOption
 
 export namespace InvalidFilterOption {
   export function isa(o: any): o is InvalidFilterOption {
-    return _smithy.isa(o, "InvalidFilterOption");
+    return __isa(o, "InvalidFilterOption");
   }
 }
 
 /**
  * <p>The filter value is not valid. Verify the value and try again.</p>
  */
-export interface InvalidFilterValue
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface InvalidFilterValue extends __SmithyException, $MetadataBearer {
   name: "InvalidFilterValue";
   $fault: "client";
   Message?: string;
@@ -8749,7 +8732,7 @@ export interface InvalidFilterValue
 
 export namespace InvalidFilterValue {
   export function isa(o: any): o is InvalidFilterValue {
-    return _smithy.isa(o, "InvalidFilterValue");
+    return __isa(o, "InvalidFilterValue");
   }
 }
 
@@ -8761,9 +8744,7 @@ export namespace InvalidFilterValue {
  *          <p>The instance is not in valid state. Valid states are: Running, Pending, Stopped, Stopping.
  *    Invalid states are: Shutting-down and Terminated.</p>
  */
-export interface InvalidInstanceId
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface InvalidInstanceId extends __SmithyException, $MetadataBearer {
   name: "InvalidInstanceId";
   $fault: "client";
   Message?: string;
@@ -8771,7 +8752,7 @@ export interface InvalidInstanceId
 
 export namespace InvalidInstanceId {
   export function isa(o: any): o is InvalidInstanceId {
-    return _smithy.isa(o, "InvalidInstanceId");
+    return __isa(o, "InvalidInstanceId");
   }
 }
 
@@ -8779,7 +8760,7 @@ export namespace InvalidInstanceId {
  * <p>The specified filter value is not valid.</p>
  */
 export interface InvalidInstanceInformationFilterValue
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidInstanceInformationFilterValue";
   $fault: "client";
@@ -8788,7 +8769,7 @@ export interface InvalidInstanceInformationFilterValue
 
 export namespace InvalidInstanceInformationFilterValue {
   export function isa(o: any): o is InvalidInstanceInformationFilterValue {
-    return _smithy.isa(o, "InvalidInstanceInformationFilterValue");
+    return __isa(o, "InvalidInstanceInformationFilterValue");
   }
 }
 
@@ -8796,7 +8777,7 @@ export namespace InvalidInstanceInformationFilterValue {
  * <p>The specified inventory group is not valid.</p>
  */
 export interface InvalidInventoryGroupException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidInventoryGroupException";
   $fault: "client";
@@ -8805,7 +8786,7 @@ export interface InvalidInventoryGroupException
 
 export namespace InvalidInventoryGroupException {
   export function isa(o: any): o is InvalidInventoryGroupException {
-    return _smithy.isa(o, "InvalidInventoryGroupException");
+    return __isa(o, "InvalidInventoryGroupException");
   }
 }
 
@@ -8814,7 +8795,7 @@ export namespace InvalidInventoryGroupException {
  *     <code>InventoryItem</code>. Verify the keys and values, and try again.</p>
  */
 export interface InvalidInventoryItemContextException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidInventoryItemContextException";
   $fault: "client";
@@ -8823,7 +8804,7 @@ export interface InvalidInventoryItemContextException
 
 export namespace InvalidInventoryItemContextException {
   export function isa(o: any): o is InvalidInventoryItemContextException {
-    return _smithy.isa(o, "InvalidInventoryItemContextException");
+    return __isa(o, "InvalidInventoryItemContextException");
   }
 }
 
@@ -8831,7 +8812,7 @@ export namespace InvalidInventoryItemContextException {
  * <p>The request is not valid.</p>
  */
 export interface InvalidInventoryRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidInventoryRequestException";
   $fault: "client";
@@ -8840,7 +8821,7 @@ export interface InvalidInventoryRequestException
 
 export namespace InvalidInventoryRequestException {
   export function isa(o: any): o is InvalidInventoryRequestException {
-    return _smithy.isa(o, "InvalidInventoryRequestException");
+    return __isa(o, "InvalidInventoryRequestException");
   }
 }
 
@@ -8848,7 +8829,7 @@ export namespace InvalidInventoryRequestException {
  * <p>One or more content items is not valid.</p>
  */
 export interface InvalidItemContentException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidItemContentException";
   $fault: "client";
@@ -8858,14 +8839,14 @@ export interface InvalidItemContentException
 
 export namespace InvalidItemContentException {
   export function isa(o: any): o is InvalidItemContentException {
-    return _smithy.isa(o, "InvalidItemContentException");
+    return __isa(o, "InvalidItemContentException");
   }
 }
 
 /**
  * <p>The query key ID is not valid.</p>
  */
-export interface InvalidKeyId extends _smithy.SmithyException, $MetadataBearer {
+export interface InvalidKeyId extends __SmithyException, $MetadataBearer {
   name: "InvalidKeyId";
   $fault: "client";
   message?: string;
@@ -8873,16 +8854,14 @@ export interface InvalidKeyId extends _smithy.SmithyException, $MetadataBearer {
 
 export namespace InvalidKeyId {
   export function isa(o: any): o is InvalidKeyId {
-    return _smithy.isa(o, "InvalidKeyId");
+    return __isa(o, "InvalidKeyId");
   }
 }
 
 /**
  * <p>The specified token is not valid.</p>
  */
-export interface InvalidNextToken
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface InvalidNextToken extends __SmithyException, $MetadataBearer {
   name: "InvalidNextToken";
   $fault: "client";
   Message?: string;
@@ -8890,7 +8869,7 @@ export interface InvalidNextToken
 
 export namespace InvalidNextToken {
   export function isa(o: any): o is InvalidNextToken {
-    return _smithy.isa(o, "InvalidNextToken");
+    return __isa(o, "InvalidNextToken");
   }
 }
 
@@ -8899,7 +8878,7 @@ export namespace InvalidNextToken {
  *    was provided for an Amazon SNS topic.</p>
  */
 export interface InvalidNotificationConfig
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidNotificationConfig";
   $fault: "client";
@@ -8908,7 +8887,7 @@ export interface InvalidNotificationConfig
 
 export namespace InvalidNotificationConfig {
   export function isa(o: any): o is InvalidNotificationConfig {
-    return _smithy.isa(o, "InvalidNotificationConfig");
+    return __isa(o, "InvalidNotificationConfig");
   }
 }
 
@@ -8916,7 +8895,7 @@ export namespace InvalidNotificationConfig {
  * <p>The delete inventory option specified is not valid. Verify the option and try again.</p>
  */
 export interface InvalidOptionException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidOptionException";
   $fault: "client";
@@ -8925,7 +8904,7 @@ export interface InvalidOptionException
 
 export namespace InvalidOptionException {
   export function isa(o: any): o is InvalidOptionException {
-    return _smithy.isa(o, "InvalidOptionException");
+    return __isa(o, "InvalidOptionException");
   }
 }
 
@@ -8933,7 +8912,7 @@ export namespace InvalidOptionException {
  * <p>The S3 bucket does not exist.</p>
  */
 export interface InvalidOutputFolder
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidOutputFolder";
   $fault: "client";
@@ -8941,7 +8920,7 @@ export interface InvalidOutputFolder
 
 export namespace InvalidOutputFolder {
   export function isa(o: any): o is InvalidOutputFolder {
-    return _smithy.isa(o, "InvalidOutputFolder");
+    return __isa(o, "InvalidOutputFolder");
   }
 }
 
@@ -8949,7 +8928,7 @@ export namespace InvalidOutputFolder {
  * <p>The output location is not valid or does not exist.</p>
  */
 export interface InvalidOutputLocation
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidOutputLocation";
   $fault: "client";
@@ -8957,7 +8936,7 @@ export interface InvalidOutputLocation
 
 export namespace InvalidOutputLocation {
   export function isa(o: any): o is InvalidOutputLocation {
-    return _smithy.isa(o, "InvalidOutputLocation");
+    return __isa(o, "InvalidOutputLocation");
   }
 }
 
@@ -8965,9 +8944,7 @@ export namespace InvalidOutputLocation {
  * <p>You must specify values for all required parameters in the Systems Manager document. You can only
  *    supply values to parameters defined in the Systems Manager document.</p>
  */
-export interface InvalidParameters
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface InvalidParameters extends __SmithyException, $MetadataBearer {
   name: "InvalidParameters";
   $fault: "client";
   Message?: string;
@@ -8975,7 +8952,7 @@ export interface InvalidParameters
 
 export namespace InvalidParameters {
   export function isa(o: any): o is InvalidParameters {
-    return _smithy.isa(o, "InvalidParameters");
+    return __isa(o, "InvalidParameters");
   }
 }
 
@@ -8984,7 +8961,7 @@ export namespace InvalidParameters {
  *    permission type.</p>
  */
 export interface InvalidPermissionType
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidPermissionType";
   $fault: "client";
@@ -8993,23 +8970,21 @@ export interface InvalidPermissionType
 
 export namespace InvalidPermissionType {
   export function isa(o: any): o is InvalidPermissionType {
-    return _smithy.isa(o, "InvalidPermissionType");
+    return __isa(o, "InvalidPermissionType");
   }
 }
 
 /**
  * <p>The plugin name is not valid.</p>
  */
-export interface InvalidPluginName
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface InvalidPluginName extends __SmithyException, $MetadataBearer {
   name: "InvalidPluginName";
   $fault: "client";
 }
 
 export namespace InvalidPluginName {
   export function isa(o: any): o is InvalidPluginName {
-    return _smithy.isa(o, "InvalidPluginName");
+    return __isa(o, "InvalidPluginName");
   }
 }
 
@@ -9017,7 +8992,7 @@ export namespace InvalidPluginName {
  * <p>A policy attribute or its value is invalid. </p>
  */
 export interface InvalidPolicyAttributeException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidPolicyAttributeException";
   $fault: "client";
@@ -9026,7 +9001,7 @@ export interface InvalidPolicyAttributeException
 
 export namespace InvalidPolicyAttributeException {
   export function isa(o: any): o is InvalidPolicyAttributeException {
-    return _smithy.isa(o, "InvalidPolicyAttributeException");
+    return __isa(o, "InvalidPolicyAttributeException");
   }
 }
 
@@ -9035,7 +9010,7 @@ export namespace InvalidPolicyAttributeException {
  *    Expiration, ExpirationNotification, and NoChangeNotification.</p>
  */
 export interface InvalidPolicyTypeException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidPolicyTypeException";
   $fault: "client";
@@ -9044,23 +9019,21 @@ export interface InvalidPolicyTypeException
 
 export namespace InvalidPolicyTypeException {
   export function isa(o: any): o is InvalidPolicyTypeException {
-    return _smithy.isa(o, "InvalidPolicyTypeException");
+    return __isa(o, "InvalidPolicyTypeException");
   }
 }
 
 /**
  * <p>The resource ID is not valid. Verify that you entered the correct ID and try again.</p>
  */
-export interface InvalidResourceId
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface InvalidResourceId extends __SmithyException, $MetadataBearer {
   name: "InvalidResourceId";
   $fault: "client";
 }
 
 export namespace InvalidResourceId {
   export function isa(o: any): o is InvalidResourceId {
-    return _smithy.isa(o, "InvalidResourceId");
+    return __isa(o, "InvalidResourceId");
   }
 }
 
@@ -9069,7 +9042,7 @@ export namespace InvalidResourceId {
  *    instance must be a registered, managed instance.</p>
  */
 export interface InvalidResourceType
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidResourceType";
   $fault: "client";
@@ -9077,7 +9050,7 @@ export interface InvalidResourceType
 
 export namespace InvalidResourceType {
   export function isa(o: any): o is InvalidResourceType {
-    return _smithy.isa(o, "InvalidResourceType");
+    return __isa(o, "InvalidResourceType");
   }
 }
 
@@ -9085,7 +9058,7 @@ export namespace InvalidResourceType {
  * <p>The specified inventory item result attribute is not valid.</p>
  */
 export interface InvalidResultAttributeException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidResultAttributeException";
   $fault: "client";
@@ -9094,7 +9067,7 @@ export interface InvalidResultAttributeException
 
 export namespace InvalidResultAttributeException {
   export function isa(o: any): o is InvalidResultAttributeException {
-    return _smithy.isa(o, "InvalidResultAttributeException");
+    return __isa(o, "InvalidResultAttributeException");
   }
 }
 
@@ -9104,7 +9077,7 @@ export namespace InvalidResultAttributeException {
  *    IAM role for Run Command notifications, see <a href="http://docs.aws.amazon.com/systems-manager/latest/userguide/rc-sns-notifications.html">Configuring Amazon SNS Notifications for Run Command</a> in the
  *     <i>AWS Systems Manager User Guide</i>.</p>
  */
-export interface InvalidRole extends _smithy.SmithyException, $MetadataBearer {
+export interface InvalidRole extends __SmithyException, $MetadataBearer {
   name: "InvalidRole";
   $fault: "client";
   Message?: string;
@@ -9112,16 +9085,14 @@ export interface InvalidRole extends _smithy.SmithyException, $MetadataBearer {
 
 export namespace InvalidRole {
   export function isa(o: any): o is InvalidRole {
-    return _smithy.isa(o, "InvalidRole");
+    return __isa(o, "InvalidRole");
   }
 }
 
 /**
  * <p>The schedule is invalid. Verify your cron or rate expression and try again.</p>
  */
-export interface InvalidSchedule
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface InvalidSchedule extends __SmithyException, $MetadataBearer {
   name: "InvalidSchedule";
   $fault: "client";
   Message?: string;
@@ -9129,7 +9100,7 @@ export interface InvalidSchedule
 
 export namespace InvalidSchedule {
   export function isa(o: any): o is InvalidSchedule {
-    return _smithy.isa(o, "InvalidSchedule");
+    return __isa(o, "InvalidSchedule");
   }
 }
 
@@ -9137,9 +9108,7 @@ export namespace InvalidSchedule {
  * <p>The target is not valid or does not exist. It might not be configured for EC2 Systems
  *    Manager or you might not have permission to perform the operation.</p>
  */
-export interface InvalidTarget
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface InvalidTarget extends __SmithyException, $MetadataBearer {
   name: "InvalidTarget";
   $fault: "client";
   Message?: string;
@@ -9147,7 +9116,7 @@ export interface InvalidTarget
 
 export namespace InvalidTarget {
   export function isa(o: any): o is InvalidTarget {
-    return _smithy.isa(o, "InvalidTarget");
+    return __isa(o, "InvalidTarget");
   }
 }
 
@@ -9155,7 +9124,7 @@ export namespace InvalidTarget {
  * <p>The parameter type name is not valid.</p>
  */
 export interface InvalidTypeNameException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidTypeNameException";
   $fault: "client";
@@ -9164,16 +9133,14 @@ export interface InvalidTypeNameException
 
 export namespace InvalidTypeNameException {
   export function isa(o: any): o is InvalidTypeNameException {
-    return _smithy.isa(o, "InvalidTypeNameException");
+    return __isa(o, "InvalidTypeNameException");
   }
 }
 
 /**
  * <p>The update is not valid.</p>
  */
-export interface InvalidUpdate
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface InvalidUpdate extends __SmithyException, $MetadataBearer {
   name: "InvalidUpdate";
   $fault: "client";
   Message?: string;
@@ -9181,7 +9148,7 @@ export interface InvalidUpdate
 
 export namespace InvalidUpdate {
   export function isa(o: any): o is InvalidUpdate {
-    return _smithy.isa(o, "InvalidUpdate");
+    return __isa(o, "InvalidUpdate");
   }
 }
 
@@ -9209,7 +9176,7 @@ export interface InventoryAggregator {
 
 export namespace InventoryAggregator {
   export function isa(o: any): o is InventoryAggregator {
-    return _smithy.isa(o, "InventoryAggregator");
+    return __isa(o, "InventoryAggregator");
   }
 }
 
@@ -9267,7 +9234,7 @@ export interface InventoryDeletionStatusItem {
 
 export namespace InventoryDeletionStatusItem {
   export function isa(o: any): o is InventoryDeletionStatusItem {
-    return _smithy.isa(o, "InventoryDeletionStatusItem");
+    return __isa(o, "InventoryDeletionStatusItem");
   }
 }
 
@@ -9295,7 +9262,7 @@ export interface InventoryDeletionSummary {
 
 export namespace InventoryDeletionSummary {
   export function isa(o: any): o is InventoryDeletionSummary {
-    return _smithy.isa(o, "InventoryDeletionSummary");
+    return __isa(o, "InventoryDeletionSummary");
   }
 }
 
@@ -9322,7 +9289,7 @@ export interface InventoryDeletionSummaryItem {
 
 export namespace InventoryDeletionSummaryItem {
   export function isa(o: any): o is InventoryDeletionSummaryItem {
-    return _smithy.isa(o, "InventoryDeletionSummaryItem");
+    return __isa(o, "InventoryDeletionSummaryItem");
   }
 }
 
@@ -9351,7 +9318,7 @@ export interface InventoryFilter {
 
 export namespace InventoryFilter {
   export function isa(o: any): o is InventoryFilter {
-    return _smithy.isa(o, "InventoryFilter");
+    return __isa(o, "InventoryFilter");
   }
 }
 
@@ -9376,7 +9343,7 @@ export interface InventoryGroup {
 
 export namespace InventoryGroup {
   export function isa(o: any): o is InventoryGroup {
-    return _smithy.isa(o, "InventoryGroup");
+    return __isa(o, "InventoryGroup");
   }
 }
 
@@ -9425,7 +9392,7 @@ export interface InventoryItem {
 
 export namespace InventoryItem {
   export function isa(o: any): o is InventoryItem {
-    return _smithy.isa(o, "InventoryItem");
+    return __isa(o, "InventoryItem");
   }
 }
 
@@ -9448,7 +9415,7 @@ export interface InventoryItemAttribute {
 
 export namespace InventoryItemAttribute {
   export function isa(o: any): o is InventoryItemAttribute {
-    return _smithy.isa(o, "InventoryItemAttribute");
+    return __isa(o, "InventoryItemAttribute");
   }
 }
 
@@ -9484,7 +9451,7 @@ export interface InventoryItemSchema {
 
 export namespace InventoryItemSchema {
   export function isa(o: any): o is InventoryItemSchema {
-    return _smithy.isa(o, "InventoryItemSchema");
+    return __isa(o, "InventoryItemSchema");
   }
 }
 
@@ -9517,7 +9484,7 @@ export interface InventoryResultEntity {
 
 export namespace InventoryResultEntity {
   export function isa(o: any): o is InventoryResultEntity {
-    return _smithy.isa(o, "InventoryResultEntity");
+    return __isa(o, "InventoryResultEntity");
   }
 }
 
@@ -9557,7 +9524,7 @@ export interface InventoryResultItem {
 
 export namespace InventoryResultItem {
   export function isa(o: any): o is InventoryResultItem {
-    return _smithy.isa(o, "InventoryResultItem");
+    return __isa(o, "InventoryResultItem");
   }
 }
 
@@ -9571,7 +9538,7 @@ export enum InventorySchemaDeleteOption {
  *    command ID and the instance ID and try again. </p>
  */
 export interface InvocationDoesNotExist
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvocationDoesNotExist";
   $fault: "client";
@@ -9579,7 +9546,7 @@ export interface InvocationDoesNotExist
 
 export namespace InvocationDoesNotExist {
   export function isa(o: any): o is InvocationDoesNotExist {
-    return _smithy.isa(o, "InvocationDoesNotExist");
+    return __isa(o, "InvocationDoesNotExist");
   }
 }
 
@@ -9587,7 +9554,7 @@ export namespace InvocationDoesNotExist {
  * <p>The inventory item has invalid content. </p>
  */
 export interface ItemContentMismatchException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ItemContentMismatchException";
   $fault: "client";
@@ -9597,7 +9564,7 @@ export interface ItemContentMismatchException
 
 export namespace ItemContentMismatchException {
   export function isa(o: any): o is ItemContentMismatchException {
-    return _smithy.isa(o, "ItemContentMismatchException");
+    return __isa(o, "ItemContentMismatchException");
   }
 }
 
@@ -9605,7 +9572,7 @@ export namespace ItemContentMismatchException {
  * <p>The inventory item size has exceeded the size limit.</p>
  */
 export interface ItemSizeLimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ItemSizeLimitExceededException";
   $fault: "client";
@@ -9615,7 +9582,7 @@ export interface ItemSizeLimitExceededException
 
 export namespace ItemSizeLimitExceededException {
   export function isa(o: any): o is ItemSizeLimitExceededException {
-    return _smithy.isa(o, "ItemSizeLimitExceededException");
+    return __isa(o, "ItemSizeLimitExceededException");
   }
 }
 
@@ -9640,7 +9607,7 @@ export interface LabelParameterVersionRequest {
 
 export namespace LabelParameterVersionRequest {
   export function isa(o: any): o is LabelParameterVersionRequest {
-    return _smithy.isa(o, "LabelParameterVersionRequest");
+    return __isa(o, "LabelParameterVersionRequest");
   }
 }
 
@@ -9661,7 +9628,7 @@ export interface LabelParameterVersionResult extends $MetadataBearer {
 
 export namespace LabelParameterVersionResult {
   export function isa(o: any): o is LabelParameterVersionResult {
-    return _smithy.isa(o, "LabelParameterVersionResult");
+    return __isa(o, "LabelParameterVersionResult");
   }
 }
 
@@ -9692,7 +9659,7 @@ export interface ListAssociationVersionsRequest {
 
 export namespace ListAssociationVersionsRequest {
   export function isa(o: any): o is ListAssociationVersionsRequest {
-    return _smithy.isa(o, "ListAssociationVersionsRequest");
+    return __isa(o, "ListAssociationVersionsRequest");
   }
 }
 
@@ -9712,7 +9679,7 @@ export interface ListAssociationVersionsResult extends $MetadataBearer {
 
 export namespace ListAssociationVersionsResult {
   export function isa(o: any): o is ListAssociationVersionsResult {
-    return _smithy.isa(o, "ListAssociationVersionsResult");
+    return __isa(o, "ListAssociationVersionsResult");
   }
 }
 
@@ -9738,7 +9705,7 @@ export interface ListAssociationsRequest {
 
 export namespace ListAssociationsRequest {
   export function isa(o: any): o is ListAssociationsRequest {
-    return _smithy.isa(o, "ListAssociationsRequest");
+    return __isa(o, "ListAssociationsRequest");
   }
 }
 
@@ -9758,7 +9725,7 @@ export interface ListAssociationsResult extends $MetadataBearer {
 
 export namespace ListAssociationsResult {
   export function isa(o: any): o is ListAssociationsResult {
-    return _smithy.isa(o, "ListAssociationsResult");
+    return __isa(o, "ListAssociationsResult");
   }
 }
 
@@ -9801,7 +9768,7 @@ export interface ListCommandInvocationsRequest {
 
 export namespace ListCommandInvocationsRequest {
   export function isa(o: any): o is ListCommandInvocationsRequest {
-    return _smithy.isa(o, "ListCommandInvocationsRequest");
+    return __isa(o, "ListCommandInvocationsRequest");
   }
 }
 
@@ -9821,7 +9788,7 @@ export interface ListCommandInvocationsResult extends $MetadataBearer {
 
 export namespace ListCommandInvocationsResult {
   export function isa(o: any): o is ListCommandInvocationsResult {
-    return _smithy.isa(o, "ListCommandInvocationsResult");
+    return __isa(o, "ListCommandInvocationsResult");
   }
 }
 
@@ -9858,7 +9825,7 @@ export interface ListCommandsRequest {
 
 export namespace ListCommandsRequest {
   export function isa(o: any): o is ListCommandsRequest {
-    return _smithy.isa(o, "ListCommandsRequest");
+    return __isa(o, "ListCommandsRequest");
   }
 }
 
@@ -9878,7 +9845,7 @@ export interface ListCommandsResult extends $MetadataBearer {
 
 export namespace ListCommandsResult {
   export function isa(o: any): o is ListCommandsResult {
-    return _smithy.isa(o, "ListCommandsResult");
+    return __isa(o, "ListCommandsResult");
   }
 }
 
@@ -9916,7 +9883,7 @@ export interface ListComplianceItemsRequest {
 
 export namespace ListComplianceItemsRequest {
   export function isa(o: any): o is ListComplianceItemsRequest {
-    return _smithy.isa(o, "ListComplianceItemsRequest");
+    return __isa(o, "ListComplianceItemsRequest");
   }
 }
 
@@ -9936,7 +9903,7 @@ export interface ListComplianceItemsResult extends $MetadataBearer {
 
 export namespace ListComplianceItemsResult {
   export function isa(o: any): o is ListComplianceItemsResult {
-    return _smithy.isa(o, "ListComplianceItemsResult");
+    return __isa(o, "ListComplianceItemsResult");
   }
 }
 
@@ -9963,7 +9930,7 @@ export interface ListComplianceSummariesRequest {
 
 export namespace ListComplianceSummariesRequest {
   export function isa(o: any): o is ListComplianceSummariesRequest {
-    return _smithy.isa(o, "ListComplianceSummariesRequest");
+    return __isa(o, "ListComplianceSummariesRequest");
   }
 }
 
@@ -9985,7 +9952,7 @@ export interface ListComplianceSummariesResult extends $MetadataBearer {
 
 export namespace ListComplianceSummariesResult {
   export function isa(o: any): o is ListComplianceSummariesResult {
-    return _smithy.isa(o, "ListComplianceSummariesResult");
+    return __isa(o, "ListComplianceSummariesResult");
   }
 }
 
@@ -10011,7 +9978,7 @@ export interface ListDocumentVersionsRequest {
 
 export namespace ListDocumentVersionsRequest {
   export function isa(o: any): o is ListDocumentVersionsRequest {
-    return _smithy.isa(o, "ListDocumentVersionsRequest");
+    return __isa(o, "ListDocumentVersionsRequest");
   }
 }
 
@@ -10031,7 +9998,7 @@ export interface ListDocumentVersionsResult extends $MetadataBearer {
 
 export namespace ListDocumentVersionsResult {
   export function isa(o: any): o is ListDocumentVersionsResult {
-    return _smithy.isa(o, "ListDocumentVersionsResult");
+    return __isa(o, "ListDocumentVersionsResult");
   }
 }
 
@@ -10062,7 +10029,7 @@ export interface ListDocumentsRequest {
 
 export namespace ListDocumentsRequest {
   export function isa(o: any): o is ListDocumentsRequest {
-    return _smithy.isa(o, "ListDocumentsRequest");
+    return __isa(o, "ListDocumentsRequest");
   }
 }
 
@@ -10082,7 +10049,7 @@ export interface ListDocumentsResult extends $MetadataBearer {
 
 export namespace ListDocumentsResult {
   export function isa(o: any): o is ListDocumentsResult {
-    return _smithy.isa(o, "ListDocumentsResult");
+    return __isa(o, "ListDocumentsResult");
   }
 }
 
@@ -10118,7 +10085,7 @@ export interface ListInventoryEntriesRequest {
 
 export namespace ListInventoryEntriesRequest {
   export function isa(o: any): o is ListInventoryEntriesRequest {
-    return _smithy.isa(o, "ListInventoryEntriesRequest");
+    return __isa(o, "ListInventoryEntriesRequest");
   }
 }
 
@@ -10158,7 +10125,7 @@ export interface ListInventoryEntriesResult extends $MetadataBearer {
 
 export namespace ListInventoryEntriesResult {
   export function isa(o: any): o is ListInventoryEntriesResult {
-    return _smithy.isa(o, "ListInventoryEntriesResult");
+    return __isa(o, "ListInventoryEntriesResult");
   }
 }
 
@@ -10183,7 +10150,7 @@ export interface ListResourceComplianceSummariesRequest {
 
 export namespace ListResourceComplianceSummariesRequest {
   export function isa(o: any): o is ListResourceComplianceSummariesRequest {
-    return _smithy.isa(o, "ListResourceComplianceSummariesRequest");
+    return __isa(o, "ListResourceComplianceSummariesRequest");
   }
 }
 
@@ -10205,7 +10172,7 @@ export interface ListResourceComplianceSummariesResult extends $MetadataBearer {
 
 export namespace ListResourceComplianceSummariesResult {
   export function isa(o: any): o is ListResourceComplianceSummariesResult {
-    return _smithy.isa(o, "ListResourceComplianceSummariesResult");
+    return __isa(o, "ListResourceComplianceSummariesResult");
   }
 }
 
@@ -10233,7 +10200,7 @@ export interface ListResourceDataSyncRequest {
 
 export namespace ListResourceDataSyncRequest {
   export function isa(o: any): o is ListResourceDataSyncRequest {
-    return _smithy.isa(o, "ListResourceDataSyncRequest");
+    return __isa(o, "ListResourceDataSyncRequest");
   }
 }
 
@@ -10253,7 +10220,7 @@ export interface ListResourceDataSyncResult extends $MetadataBearer {
 
 export namespace ListResourceDataSyncResult {
   export function isa(o: any): o is ListResourceDataSyncResult {
-    return _smithy.isa(o, "ListResourceDataSyncResult");
+    return __isa(o, "ListResourceDataSyncResult");
   }
 }
 
@@ -10272,7 +10239,7 @@ export interface ListTagsForResourceRequest {
 
 export namespace ListTagsForResourceRequest {
   export function isa(o: any): o is ListTagsForResourceRequest {
-    return _smithy.isa(o, "ListTagsForResourceRequest");
+    return __isa(o, "ListTagsForResourceRequest");
   }
 }
 
@@ -10286,7 +10253,7 @@ export interface ListTagsForResourceResult extends $MetadataBearer {
 
 export namespace ListTagsForResourceResult {
   export function isa(o: any): o is ListTagsForResourceResult {
-    return _smithy.isa(o, "ListTagsForResourceResult");
+    return __isa(o, "ListTagsForResourceResult");
   }
 }
 
@@ -10320,7 +10287,7 @@ export interface LoggingInfo {
 
 export namespace LoggingInfo {
   export function isa(o: any): o is LoggingInfo {
-    return _smithy.isa(o, "LoggingInfo");
+    return __isa(o, "LoggingInfo");
   }
 }
 
@@ -10358,7 +10325,7 @@ export interface MaintenanceWindowAutomationParameters {
 
 export namespace MaintenanceWindowAutomationParameters {
   export function isa(o: any): o is MaintenanceWindowAutomationParameters {
-    return _smithy.isa(o, "MaintenanceWindowAutomationParameters");
+    return __isa(o, "MaintenanceWindowAutomationParameters");
   }
 }
 
@@ -10400,7 +10367,7 @@ export interface MaintenanceWindowExecution {
 
 export namespace MaintenanceWindowExecution {
   export function isa(o: any): o is MaintenanceWindowExecution {
-    return _smithy.isa(o, "MaintenanceWindowExecution");
+    return __isa(o, "MaintenanceWindowExecution");
   }
 }
 
@@ -10465,7 +10432,7 @@ export interface MaintenanceWindowExecutionTaskIdentity {
 
 export namespace MaintenanceWindowExecutionTaskIdentity {
   export function isa(o: any): o is MaintenanceWindowExecutionTaskIdentity {
-    return _smithy.isa(o, "MaintenanceWindowExecutionTaskIdentity");
+    return __isa(o, "MaintenanceWindowExecutionTaskIdentity");
   }
 }
 
@@ -10544,7 +10511,7 @@ export namespace MaintenanceWindowExecutionTaskInvocationIdentity {
   export function isa(
     o: any
   ): o is MaintenanceWindowExecutionTaskInvocationIdentity {
-    return _smithy.isa(o, "MaintenanceWindowExecutionTaskInvocationIdentity");
+    return __isa(o, "MaintenanceWindowExecutionTaskInvocationIdentity");
   }
 }
 
@@ -10566,7 +10533,7 @@ export interface MaintenanceWindowFilter {
 
 export namespace MaintenanceWindowFilter {
   export function isa(o: any): o is MaintenanceWindowFilter {
-    return _smithy.isa(o, "MaintenanceWindowFilter");
+    return __isa(o, "MaintenanceWindowFilter");
   }
 }
 
@@ -10638,7 +10605,7 @@ export interface MaintenanceWindowIdentity {
 
 export namespace MaintenanceWindowIdentity {
   export function isa(o: any): o is MaintenanceWindowIdentity {
-    return _smithy.isa(o, "MaintenanceWindowIdentity");
+    return __isa(o, "MaintenanceWindowIdentity");
   }
 }
 
@@ -10660,7 +10627,7 @@ export interface MaintenanceWindowIdentityForTarget {
 
 export namespace MaintenanceWindowIdentityForTarget {
   export function isa(o: any): o is MaintenanceWindowIdentityForTarget {
-    return _smithy.isa(o, "MaintenanceWindowIdentityForTarget");
+    return __isa(o, "MaintenanceWindowIdentityForTarget");
   }
 }
 
@@ -10707,7 +10674,7 @@ export interface MaintenanceWindowLambdaParameters {
 
 export namespace MaintenanceWindowLambdaParameters {
   export function isa(o: any): o is MaintenanceWindowLambdaParameters {
-    return _smithy.isa(o, "MaintenanceWindowLambdaParameters");
+    return __isa(o, "MaintenanceWindowLambdaParameters");
   }
 }
 
@@ -10805,7 +10772,7 @@ export interface MaintenanceWindowRunCommandParameters {
 
 export namespace MaintenanceWindowRunCommandParameters {
   export function isa(o: any): o is MaintenanceWindowRunCommandParameters {
-    return _smithy.isa(o, "MaintenanceWindowRunCommandParameters");
+    return __isa(o, "MaintenanceWindowRunCommandParameters");
   }
 }
 
@@ -10843,7 +10810,7 @@ export interface MaintenanceWindowStepFunctionsParameters {
 
 export namespace MaintenanceWindowStepFunctionsParameters {
   export function isa(o: any): o is MaintenanceWindowStepFunctionsParameters {
-    return _smithy.isa(o, "MaintenanceWindowStepFunctionsParameters");
+    return __isa(o, "MaintenanceWindowStepFunctionsParameters");
   }
 }
 
@@ -10898,7 +10865,7 @@ export interface MaintenanceWindowTarget {
 
 export namespace MaintenanceWindowTarget {
   export function isa(o: any): o is MaintenanceWindowTarget {
-    return _smithy.isa(o, "MaintenanceWindowTarget");
+    return __isa(o, "MaintenanceWindowTarget");
   }
 }
 
@@ -10998,7 +10965,7 @@ export interface MaintenanceWindowTask {
 
 export namespace MaintenanceWindowTask {
   export function isa(o: any): o is MaintenanceWindowTask {
-    return _smithy.isa(o, "MaintenanceWindowTask");
+    return __isa(o, "MaintenanceWindowTask");
   }
 }
 
@@ -11030,7 +10997,7 @@ export interface MaintenanceWindowTaskInvocationParameters {
 
 export namespace MaintenanceWindowTaskInvocationParameters {
   export function isa(o: any): o is MaintenanceWindowTaskInvocationParameters {
-    return _smithy.isa(o, "MaintenanceWindowTaskInvocationParameters");
+    return __isa(o, "MaintenanceWindowTaskInvocationParameters");
   }
 }
 
@@ -11050,7 +11017,7 @@ export namespace MaintenanceWindowTaskParameterValueExpression {
   export function isa(
     o: any
   ): o is MaintenanceWindowTaskParameterValueExpression {
-    return _smithy.isa(o, "MaintenanceWindowTaskParameterValueExpression");
+    return __isa(o, "MaintenanceWindowTaskParameterValueExpression");
   }
 }
 
@@ -11065,7 +11032,7 @@ export enum MaintenanceWindowTaskType {
  * <p>The size limit of a document is 64 KB.</p>
  */
 export interface MaxDocumentSizeExceeded
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "MaxDocumentSizeExceeded";
   $fault: "client";
@@ -11074,7 +11041,7 @@ export interface MaxDocumentSizeExceeded
 
 export namespace MaxDocumentSizeExceeded {
   export function isa(o: any): o is MaxDocumentSizeExceeded {
-    return _smithy.isa(o, "MaxDocumentSizeExceeded");
+    return __isa(o, "MaxDocumentSizeExceeded");
   }
 }
 
@@ -11114,7 +11081,7 @@ export interface ModifyDocumentPermissionRequest {
 
 export namespace ModifyDocumentPermissionRequest {
   export function isa(o: any): o is ModifyDocumentPermissionRequest {
-    return _smithy.isa(o, "ModifyDocumentPermissionRequest");
+    return __isa(o, "ModifyDocumentPermissionRequest");
   }
 }
 
@@ -11124,7 +11091,7 @@ export interface ModifyDocumentPermissionResponse extends $MetadataBearer {
 
 export namespace ModifyDocumentPermissionResponse {
   export function isa(o: any): o is ModifyDocumentPermissionResponse {
-    return _smithy.isa(o, "ModifyDocumentPermissionResponse");
+    return __isa(o, "ModifyDocumentPermissionResponse");
   }
 }
 
@@ -11147,7 +11114,7 @@ export interface NonCompliantSummary {
 
 export namespace NonCompliantSummary {
   export function isa(o: any): o is NonCompliantSummary {
-    return _smithy.isa(o, "NonCompliantSummary");
+    return __isa(o, "NonCompliantSummary");
   }
 }
 
@@ -11180,7 +11147,7 @@ export interface NotificationConfig {
 
 export namespace NotificationConfig {
   export function isa(o: any): o is NotificationConfig {
-    return _smithy.isa(o, "NotificationConfig");
+    return __isa(o, "NotificationConfig");
   }
 }
 
@@ -11248,7 +11215,7 @@ export interface OpsAggregator {
 
 export namespace OpsAggregator {
   export function isa(o: any): o is OpsAggregator {
-    return _smithy.isa(o, "OpsAggregator");
+    return __isa(o, "OpsAggregator");
   }
 }
 
@@ -11270,7 +11237,7 @@ export interface OpsEntity {
 
 export namespace OpsEntity {
   export function isa(o: any): o is OpsEntity {
-    return _smithy.isa(o, "OpsEntity");
+    return __isa(o, "OpsEntity");
   }
 }
 
@@ -11292,7 +11259,7 @@ export interface OpsEntityItem {
 
 export namespace OpsEntityItem {
   export function isa(o: any): o is OpsEntityItem {
-    return _smithy.isa(o, "OpsEntityItem");
+    return __isa(o, "OpsEntityItem");
   }
 }
 
@@ -11319,7 +11286,7 @@ export interface OpsFilter {
 
 export namespace OpsFilter {
   export function isa(o: any): o is OpsFilter {
-    return _smithy.isa(o, "OpsFilter");
+    return __isa(o, "OpsFilter");
   }
 }
 
@@ -11448,7 +11415,7 @@ export interface OpsItem {
 
 export namespace OpsItem {
   export function isa(o: any): o is OpsItem {
-    return _smithy.isa(o, "OpsItem");
+    return __isa(o, "OpsItem");
   }
 }
 
@@ -11456,7 +11423,7 @@ export namespace OpsItem {
  * <p>The OpsItem already exists.</p>
  */
 export interface OpsItemAlreadyExistsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "OpsItemAlreadyExistsException";
   $fault: "client";
@@ -11466,7 +11433,7 @@ export interface OpsItemAlreadyExistsException
 
 export namespace OpsItemAlreadyExistsException {
   export function isa(o: any): o is OpsItemAlreadyExistsException {
-    return _smithy.isa(o, "OpsItemAlreadyExistsException");
+    return __isa(o, "OpsItemAlreadyExistsException");
   }
 }
 
@@ -11494,7 +11461,7 @@ export interface OpsItemDataValue {
 
 export namespace OpsItemDataValue {
   export function isa(o: any): o is OpsItemDataValue {
-    return _smithy.isa(o, "OpsItemDataValue");
+    return __isa(o, "OpsItemDataValue");
   }
 }
 
@@ -11521,7 +11488,7 @@ export interface OpsItemFilter {
 
 export namespace OpsItemFilter {
   export function isa(o: any): o is OpsItemFilter {
-    return _smithy.isa(o, "OpsItemFilter");
+    return __isa(o, "OpsItemFilter");
   }
 }
 
@@ -11555,7 +11522,7 @@ export enum OpsItemFilterOperator {
  *    again.</p>
  */
 export interface OpsItemInvalidParameterException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "OpsItemInvalidParameterException";
   $fault: "client";
@@ -11565,7 +11532,7 @@ export interface OpsItemInvalidParameterException
 
 export namespace OpsItemInvalidParameterException {
   export function isa(o: any): o is OpsItemInvalidParameterException {
-    return _smithy.isa(o, "OpsItemInvalidParameterException");
+    return __isa(o, "OpsItemInvalidParameterException");
   }
 }
 
@@ -11575,7 +11542,7 @@ export namespace OpsItemInvalidParameterException {
  *     are the resource limits for OpsCenter?</a>.</p>
  */
 export interface OpsItemLimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "OpsItemLimitExceededException";
   $fault: "client";
@@ -11587,7 +11554,7 @@ export interface OpsItemLimitExceededException
 
 export namespace OpsItemLimitExceededException {
   export function isa(o: any): o is OpsItemLimitExceededException {
-    return _smithy.isa(o, "OpsItemLimitExceededException");
+    return __isa(o, "OpsItemLimitExceededException");
   }
 }
 
@@ -11595,7 +11562,7 @@ export namespace OpsItemLimitExceededException {
  * <p>The specified OpsItem ID doesn't exist. Verify the ID and try again.</p>
  */
 export interface OpsItemNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "OpsItemNotFoundException";
   $fault: "client";
@@ -11604,7 +11571,7 @@ export interface OpsItemNotFoundException
 
 export namespace OpsItemNotFoundException {
   export function isa(o: any): o is OpsItemNotFoundException {
-    return _smithy.isa(o, "OpsItemNotFoundException");
+    return __isa(o, "OpsItemNotFoundException");
   }
 }
 
@@ -11622,7 +11589,7 @@ export interface OpsItemNotification {
 
 export namespace OpsItemNotification {
   export function isa(o: any): o is OpsItemNotification {
-    return _smithy.isa(o, "OpsItemNotification");
+    return __isa(o, "OpsItemNotification");
   }
 }
 
@@ -11702,7 +11669,7 @@ export interface OpsItemSummary {
 
 export namespace OpsItemSummary {
   export function isa(o: any): o is OpsItemSummary {
-    return _smithy.isa(o, "OpsItemSummary");
+    return __isa(o, "OpsItemSummary");
   }
 }
 
@@ -11720,7 +11687,7 @@ export interface OpsResultAttribute {
 
 export namespace OpsResultAttribute {
   export function isa(o: any): o is OpsResultAttribute {
-    return _smithy.isa(o, "OpsResultAttribute");
+    return __isa(o, "OpsResultAttribute");
   }
 }
 
@@ -11743,7 +11710,7 @@ export interface OutputSource {
 
 export namespace OutputSource {
   export function isa(o: any): o is OutputSource {
-    return _smithy.isa(o, "OutputSource");
+    return __isa(o, "OutputSource");
   }
 }
 
@@ -11800,7 +11767,7 @@ export interface Parameter {
 
 export namespace Parameter {
   export function isa(o: any): o is Parameter {
-    return _smithy.isa(o, "Parameter");
+    return __isa(o, "Parameter");
   }
 }
 
@@ -11808,7 +11775,7 @@ export namespace Parameter {
  * <p>The parameter already exists. You can't create duplicate parameters.</p>
  */
 export interface ParameterAlreadyExists
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ParameterAlreadyExists";
   $fault: "client";
@@ -11817,7 +11784,7 @@ export interface ParameterAlreadyExists
 
 export namespace ParameterAlreadyExists {
   export function isa(o: any): o is ParameterAlreadyExists {
-    return _smithy.isa(o, "ParameterAlreadyExists");
+    return __isa(o, "ParameterAlreadyExists");
   }
 }
 
@@ -11893,7 +11860,7 @@ export interface ParameterHistory {
 
 export namespace ParameterHistory {
   export function isa(o: any): o is ParameterHistory {
-    return _smithy.isa(o, "ParameterHistory");
+    return __isa(o, "ParameterHistory");
   }
 }
 
@@ -11923,7 +11890,7 @@ export interface ParameterInlinePolicy {
 
 export namespace ParameterInlinePolicy {
   export function isa(o: any): o is ParameterInlinePolicy {
-    return _smithy.isa(o, "ParameterInlinePolicy");
+    return __isa(o, "ParameterInlinePolicy");
   }
 }
 
@@ -11932,7 +11899,7 @@ export namespace ParameterInlinePolicy {
  *    parameters and try again.</p>
  */
 export interface ParameterLimitExceeded
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ParameterLimitExceeded";
   $fault: "client";
@@ -11941,7 +11908,7 @@ export interface ParameterLimitExceeded
 
 export namespace ParameterLimitExceeded {
   export function isa(o: any): o is ParameterLimitExceeded {
-    return _smithy.isa(o, "ParameterLimitExceeded");
+    return __isa(o, "ParameterLimitExceeded");
   }
 }
 
@@ -11949,7 +11916,7 @@ export namespace ParameterLimitExceeded {
  * <p>The parameter exceeded the maximum number of allowed versions.</p>
  */
 export interface ParameterMaxVersionLimitExceeded
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ParameterMaxVersionLimitExceeded";
   $fault: "client";
@@ -11958,7 +11925,7 @@ export interface ParameterMaxVersionLimitExceeded
 
 export namespace ParameterMaxVersionLimitExceeded {
   export function isa(o: any): o is ParameterMaxVersionLimitExceeded {
-    return _smithy.isa(o, "ParameterMaxVersionLimitExceeded");
+    return __isa(o, "ParameterMaxVersionLimitExceeded");
   }
 }
 
@@ -12023,16 +11990,14 @@ export interface ParameterMetadata {
 
 export namespace ParameterMetadata {
   export function isa(o: any): o is ParameterMetadata {
-    return _smithy.isa(o, "ParameterMetadata");
+    return __isa(o, "ParameterMetadata");
   }
 }
 
 /**
  * <p>The parameter could not be found. Verify the name and try again.</p>
  */
-export interface ParameterNotFound
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface ParameterNotFound extends __SmithyException, $MetadataBearer {
   name: "ParameterNotFound";
   $fault: "client";
   message?: string;
@@ -12040,7 +12005,7 @@ export interface ParameterNotFound
 
 export namespace ParameterNotFound {
   export function isa(o: any): o is ParameterNotFound {
-    return _smithy.isa(o, "ParameterNotFound");
+    return __isa(o, "ParameterNotFound");
   }
 }
 
@@ -12048,7 +12013,7 @@ export namespace ParameterNotFound {
  * <p>The parameter name is not valid.</p>
  */
 export interface ParameterPatternMismatchException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ParameterPatternMismatchException";
   $fault: "client";
@@ -12060,7 +12025,7 @@ export interface ParameterPatternMismatchException
 
 export namespace ParameterPatternMismatchException {
   export function isa(o: any): o is ParameterPatternMismatchException {
-    return _smithy.isa(o, "ParameterPatternMismatchException");
+    return __isa(o, "ParameterPatternMismatchException");
   }
 }
 
@@ -12104,7 +12069,7 @@ export interface ParameterStringFilter {
 
 export namespace ParameterStringFilter {
   export function isa(o: any): o is ParameterStringFilter {
-    return _smithy.isa(o, "ParameterStringFilter");
+    return __isa(o, "ParameterStringFilter");
   }
 }
 
@@ -12124,7 +12089,7 @@ export enum ParameterType {
  * <p>A parameter version can have a maximum of ten labels.</p>
  */
 export interface ParameterVersionLabelLimitExceeded
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ParameterVersionLabelLimitExceeded";
   $fault: "client";
@@ -12133,7 +12098,7 @@ export interface ParameterVersionLabelLimitExceeded
 
 export namespace ParameterVersionLabelLimitExceeded {
   export function isa(o: any): o is ParameterVersionLabelLimitExceeded {
-    return _smithy.isa(o, "ParameterVersionLabelLimitExceeded");
+    return __isa(o, "ParameterVersionLabelLimitExceeded");
   }
 }
 
@@ -12142,7 +12107,7 @@ export namespace ParameterVersionLabelLimitExceeded {
  *    try again.</p>
  */
 export interface ParameterVersionNotFound
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ParameterVersionNotFound";
   $fault: "client";
@@ -12151,7 +12116,7 @@ export interface ParameterVersionNotFound
 
 export namespace ParameterVersionNotFound {
   export function isa(o: any): o is ParameterVersionNotFound {
-    return _smithy.isa(o, "ParameterVersionNotFound");
+    return __isa(o, "ParameterVersionNotFound");
   }
 }
 
@@ -12173,7 +12138,7 @@ export interface ParametersFilter {
 
 export namespace ParametersFilter {
   export function isa(o: any): o is ParametersFilter {
-    return _smithy.isa(o, "ParametersFilter");
+    return __isa(o, "ParametersFilter");
   }
 }
 
@@ -12257,7 +12222,7 @@ export interface Patch {
 
 export namespace Patch {
   export function isa(o: any): o is Patch {
-    return _smithy.isa(o, "Patch");
+    return __isa(o, "Patch");
   }
 }
 
@@ -12302,7 +12267,7 @@ export interface PatchBaselineIdentity {
 
 export namespace PatchBaselineIdentity {
   export function isa(o: any): o is PatchBaselineIdentity {
-    return _smithy.isa(o, "PatchBaselineIdentity");
+    return __isa(o, "PatchBaselineIdentity");
   }
 }
 
@@ -12349,7 +12314,7 @@ export interface PatchComplianceData {
 
 export namespace PatchComplianceData {
   export function isa(o: any): o is PatchComplianceData {
-    return _smithy.isa(o, "PatchComplianceData");
+    return __isa(o, "PatchComplianceData");
   }
 }
 
@@ -12411,7 +12376,7 @@ export interface PatchFilter {
 
 export namespace PatchFilter {
   export function isa(o: any): o is PatchFilter {
-    return _smithy.isa(o, "PatchFilter");
+    return __isa(o, "PatchFilter");
   }
 }
 
@@ -12428,7 +12393,7 @@ export interface PatchFilterGroup {
 
 export namespace PatchFilterGroup {
   export function isa(o: any): o is PatchFilterGroup {
-    return _smithy.isa(o, "PatchFilterGroup");
+    return __isa(o, "PatchFilterGroup");
   }
 }
 
@@ -12463,7 +12428,7 @@ export interface PatchGroupPatchBaselineMapping {
 
 export namespace PatchGroupPatchBaselineMapping {
   export function isa(o: any): o is PatchGroupPatchBaselineMapping {
-    return _smithy.isa(o, "PatchGroupPatchBaselineMapping");
+    return __isa(o, "PatchGroupPatchBaselineMapping");
   }
 }
 
@@ -12490,7 +12455,7 @@ export interface PatchOrchestratorFilter {
 
 export namespace PatchOrchestratorFilter {
   export function isa(o: any): o is PatchOrchestratorFilter {
-    return _smithy.isa(o, "PatchOrchestratorFilter");
+    return __isa(o, "PatchOrchestratorFilter");
   }
 }
 
@@ -12537,7 +12502,7 @@ export interface PatchRule {
 
 export namespace PatchRule {
   export function isa(o: any): o is PatchRule {
-    return _smithy.isa(o, "PatchRule");
+    return __isa(o, "PatchRule");
   }
 }
 
@@ -12554,7 +12519,7 @@ export interface PatchRuleGroup {
 
 export namespace PatchRuleGroup {
   export function isa(o: any): o is PatchRuleGroup {
-    return _smithy.isa(o, "PatchRuleGroup");
+    return __isa(o, "PatchRuleGroup");
   }
 }
 
@@ -12601,7 +12566,7 @@ export interface PatchSource {
 
 export namespace PatchSource {
   export function isa(o: any): o is PatchSource {
-    return _smithy.isa(o, "PatchSource");
+    return __isa(o, "PatchSource");
   }
 }
 
@@ -12630,7 +12595,7 @@ export interface PatchStatus {
 
 export namespace PatchStatus {
   export function isa(o: any): o is PatchStatus {
-    return _smithy.isa(o, "PatchStatus");
+    return __isa(o, "PatchStatus");
   }
 }
 
@@ -12650,7 +12615,7 @@ export enum PlatformType {
  *    maximum is 10.</p>
  */
 export interface PoliciesLimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "PoliciesLimitExceededException";
   $fault: "client";
@@ -12659,7 +12624,7 @@ export interface PoliciesLimitExceededException
 
 export namespace PoliciesLimitExceededException {
   export function isa(o: any): o is PoliciesLimitExceededException {
-    return _smithy.isa(o, "PoliciesLimitExceededException");
+    return __isa(o, "PoliciesLimitExceededException");
   }
 }
 
@@ -12702,7 +12667,7 @@ export interface ProgressCounters {
 
 export namespace ProgressCounters {
   export function isa(o: any): o is ProgressCounters {
-    return _smithy.isa(o, "ProgressCounters");
+    return __isa(o, "ProgressCounters");
   }
 }
 
@@ -12749,7 +12714,7 @@ export interface PutComplianceItemsRequest {
 
 export namespace PutComplianceItemsRequest {
   export function isa(o: any): o is PutComplianceItemsRequest {
-    return _smithy.isa(o, "PutComplianceItemsRequest");
+    return __isa(o, "PutComplianceItemsRequest");
   }
 }
 
@@ -12759,7 +12724,7 @@ export interface PutComplianceItemsResult extends $MetadataBearer {
 
 export namespace PutComplianceItemsResult {
   export function isa(o: any): o is PutComplianceItemsResult {
-    return _smithy.isa(o, "PutComplianceItemsResult");
+    return __isa(o, "PutComplianceItemsResult");
   }
 }
 
@@ -12778,7 +12743,7 @@ export interface PutInventoryRequest {
 
 export namespace PutInventoryRequest {
   export function isa(o: any): o is PutInventoryRequest {
-    return _smithy.isa(o, "PutInventoryRequest");
+    return __isa(o, "PutInventoryRequest");
   }
 }
 
@@ -12792,7 +12757,7 @@ export interface PutInventoryResult extends $MetadataBearer {
 
 export namespace PutInventoryResult {
   export function isa(o: any): o is PutInventoryResult {
-    return _smithy.isa(o, "PutInventoryResult");
+    return __isa(o, "PutInventoryResult");
   }
 }
 
@@ -13018,7 +12983,7 @@ export interface PutParameterRequest {
 
 export namespace PutParameterRequest {
   export function isa(o: any): o is PutParameterRequest {
-    return _smithy.isa(o, "PutParameterRequest");
+    return __isa(o, "PutParameterRequest");
   }
 }
 
@@ -13041,7 +13006,7 @@ export interface PutParameterResult extends $MetadataBearer {
 
 export namespace PutParameterResult {
   export function isa(o: any): o is PutParameterResult {
-    return _smithy.isa(o, "PutParameterResult");
+    return __isa(o, "PutParameterResult");
   }
 }
 
@@ -13060,7 +13025,7 @@ export interface RegisterDefaultPatchBaselineRequest {
 
 export namespace RegisterDefaultPatchBaselineRequest {
   export function isa(o: any): o is RegisterDefaultPatchBaselineRequest {
-    return _smithy.isa(o, "RegisterDefaultPatchBaselineRequest");
+    return __isa(o, "RegisterDefaultPatchBaselineRequest");
   }
 }
 
@@ -13074,7 +13039,7 @@ export interface RegisterDefaultPatchBaselineResult extends $MetadataBearer {
 
 export namespace RegisterDefaultPatchBaselineResult {
   export function isa(o: any): o is RegisterDefaultPatchBaselineResult {
-    return _smithy.isa(o, "RegisterDefaultPatchBaselineResult");
+    return __isa(o, "RegisterDefaultPatchBaselineResult");
   }
 }
 
@@ -13093,7 +13058,7 @@ export interface RegisterPatchBaselineForPatchGroupRequest {
 
 export namespace RegisterPatchBaselineForPatchGroupRequest {
   export function isa(o: any): o is RegisterPatchBaselineForPatchGroupRequest {
-    return _smithy.isa(o, "RegisterPatchBaselineForPatchGroupRequest");
+    return __isa(o, "RegisterPatchBaselineForPatchGroupRequest");
   }
 }
 
@@ -13113,7 +13078,7 @@ export interface RegisterPatchBaselineForPatchGroupResult
 
 export namespace RegisterPatchBaselineForPatchGroupResult {
   export function isa(o: any): o is RegisterPatchBaselineForPatchGroupResult {
-    return _smithy.isa(o, "RegisterPatchBaselineForPatchGroupResult");
+    return __isa(o, "RegisterPatchBaselineForPatchGroupResult");
   }
 }
 
@@ -13205,7 +13170,7 @@ export interface RegisterTargetWithMaintenanceWindowRequest {
 
 export namespace RegisterTargetWithMaintenanceWindowRequest {
   export function isa(o: any): o is RegisterTargetWithMaintenanceWindowRequest {
-    return _smithy.isa(o, "RegisterTargetWithMaintenanceWindowRequest");
+    return __isa(o, "RegisterTargetWithMaintenanceWindowRequest");
   }
 }
 
@@ -13220,7 +13185,7 @@ export interface RegisterTargetWithMaintenanceWindowResult
 
 export namespace RegisterTargetWithMaintenanceWindowResult {
   export function isa(o: any): o is RegisterTargetWithMaintenanceWindowResult {
-    return _smithy.isa(o, "RegisterTargetWithMaintenanceWindowResult");
+    return __isa(o, "RegisterTargetWithMaintenanceWindowResult");
   }
 }
 
@@ -13344,7 +13309,7 @@ export interface RegisterTaskWithMaintenanceWindowRequest {
 
 export namespace RegisterTaskWithMaintenanceWindowRequest {
   export function isa(o: any): o is RegisterTaskWithMaintenanceWindowRequest {
-    return _smithy.isa(o, "RegisterTaskWithMaintenanceWindowRequest");
+    return __isa(o, "RegisterTaskWithMaintenanceWindowRequest");
   }
 }
 
@@ -13359,7 +13324,7 @@ export interface RegisterTaskWithMaintenanceWindowResult
 
 export namespace RegisterTaskWithMaintenanceWindowResult {
   export function isa(o: any): o is RegisterTaskWithMaintenanceWindowResult {
-    return _smithy.isa(o, "RegisterTaskWithMaintenanceWindowResult");
+    return __isa(o, "RegisterTaskWithMaintenanceWindowResult");
   }
 }
 
@@ -13378,7 +13343,7 @@ export interface RelatedOpsItem {
 
 export namespace RelatedOpsItem {
   export function isa(o: any): o is RelatedOpsItem {
-    return _smithy.isa(o, "RelatedOpsItem");
+    return __isa(o, "RelatedOpsItem");
   }
 }
 
@@ -13416,7 +13381,7 @@ export interface RemoveTagsFromResourceRequest {
 
 export namespace RemoveTagsFromResourceRequest {
   export function isa(o: any): o is RemoveTagsFromResourceRequest {
-    return _smithy.isa(o, "RemoveTagsFromResourceRequest");
+    return __isa(o, "RemoveTagsFromResourceRequest");
   }
 }
 
@@ -13426,7 +13391,7 @@ export interface RemoveTagsFromResourceResult extends $MetadataBearer {
 
 export namespace RemoveTagsFromResourceResult {
   export function isa(o: any): o is RemoveTagsFromResourceResult {
-    return _smithy.isa(o, "RemoveTagsFromResourceResult");
+    return __isa(o, "RemoveTagsFromResourceResult");
   }
 }
 
@@ -13443,7 +13408,7 @@ export interface ResetServiceSettingRequest {
 
 export namespace ResetServiceSettingRequest {
   export function isa(o: any): o is ResetServiceSettingRequest {
-    return _smithy.isa(o, "ResetServiceSettingRequest");
+    return __isa(o, "ResetServiceSettingRequest");
   }
 }
 
@@ -13461,7 +13426,7 @@ export interface ResetServiceSettingResult extends $MetadataBearer {
 
 export namespace ResetServiceSettingResult {
   export function isa(o: any): o is ResetServiceSettingResult {
-    return _smithy.isa(o, "ResetServiceSettingResult");
+    return __isa(o, "ResetServiceSettingResult");
   }
 }
 
@@ -13484,7 +13449,7 @@ export interface ResolvedTargets {
 
 export namespace ResolvedTargets {
   export function isa(o: any): o is ResolvedTargets {
-    return _smithy.isa(o, "ResolvedTargets");
+    return __isa(o, "ResolvedTargets");
   }
 }
 
@@ -13537,7 +13502,7 @@ export interface ResourceComplianceSummaryItem {
 
 export namespace ResourceComplianceSummaryItem {
   export function isa(o: any): o is ResourceComplianceSummaryItem {
-    return _smithy.isa(o, "ResourceComplianceSummaryItem");
+    return __isa(o, "ResourceComplianceSummaryItem");
   }
 }
 
@@ -13545,7 +13510,7 @@ export namespace ResourceComplianceSummaryItem {
  * <p>A sync configuration with the same name already exists.</p>
  */
 export interface ResourceDataSyncAlreadyExistsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceDataSyncAlreadyExistsException";
   $fault: "client";
@@ -13554,7 +13519,7 @@ export interface ResourceDataSyncAlreadyExistsException
 
 export namespace ResourceDataSyncAlreadyExistsException {
   export function isa(o: any): o is ResourceDataSyncAlreadyExistsException {
-    return _smithy.isa(o, "ResourceDataSyncAlreadyExistsException");
+    return __isa(o, "ResourceDataSyncAlreadyExistsException");
   }
 }
 
@@ -13581,7 +13546,7 @@ export interface ResourceDataSyncAwsOrganizationsSource {
 
 export namespace ResourceDataSyncAwsOrganizationsSource {
   export function isa(o: any): o is ResourceDataSyncAwsOrganizationsSource {
-    return _smithy.isa(o, "ResourceDataSyncAwsOrganizationsSource");
+    return __isa(o, "ResourceDataSyncAwsOrganizationsSource");
   }
 }
 
@@ -13590,7 +13555,7 @@ export namespace ResourceDataSyncAwsOrganizationsSource {
  *    and try again.</p>
  */
 export interface ResourceDataSyncConflictException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceDataSyncConflictException";
   $fault: "client";
@@ -13599,7 +13564,7 @@ export interface ResourceDataSyncConflictException
 
 export namespace ResourceDataSyncConflictException {
   export function isa(o: any): o is ResourceDataSyncConflictException {
-    return _smithy.isa(o, "ResourceDataSyncConflictException");
+    return __isa(o, "ResourceDataSyncConflictException");
   }
 }
 
@@ -13607,7 +13572,7 @@ export namespace ResourceDataSyncConflictException {
  * <p>You have exceeded the allowed maximum sync configurations.</p>
  */
 export interface ResourceDataSyncCountExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceDataSyncCountExceededException";
   $fault: "client";
@@ -13616,7 +13581,7 @@ export interface ResourceDataSyncCountExceededException
 
 export namespace ResourceDataSyncCountExceededException {
   export function isa(o: any): o is ResourceDataSyncCountExceededException {
-    return _smithy.isa(o, "ResourceDataSyncCountExceededException");
+    return __isa(o, "ResourceDataSyncCountExceededException");
   }
 }
 
@@ -13624,7 +13589,7 @@ export namespace ResourceDataSyncCountExceededException {
  * <p>The specified sync configuration is invalid.</p>
  */
 export interface ResourceDataSyncInvalidConfigurationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceDataSyncInvalidConfigurationException";
   $fault: "client";
@@ -13635,7 +13600,7 @@ export namespace ResourceDataSyncInvalidConfigurationException {
   export function isa(
     o: any
   ): o is ResourceDataSyncInvalidConfigurationException {
-    return _smithy.isa(o, "ResourceDataSyncInvalidConfigurationException");
+    return __isa(o, "ResourceDataSyncInvalidConfigurationException");
   }
 }
 
@@ -13701,7 +13666,7 @@ export interface ResourceDataSyncItem {
 
 export namespace ResourceDataSyncItem {
   export function isa(o: any): o is ResourceDataSyncItem {
-    return _smithy.isa(o, "ResourceDataSyncItem");
+    return __isa(o, "ResourceDataSyncItem");
   }
 }
 
@@ -13709,7 +13674,7 @@ export namespace ResourceDataSyncItem {
  * <p>The specified sync name was not found.</p>
  */
 export interface ResourceDataSyncNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceDataSyncNotFoundException";
   $fault: "client";
@@ -13720,7 +13685,7 @@ export interface ResourceDataSyncNotFoundException
 
 export namespace ResourceDataSyncNotFoundException {
   export function isa(o: any): o is ResourceDataSyncNotFoundException {
-    return _smithy.isa(o, "ResourceDataSyncNotFoundException");
+    return __isa(o, "ResourceDataSyncNotFoundException");
   }
 }
 
@@ -13737,7 +13702,7 @@ export interface ResourceDataSyncOrganizationalUnit {
 
 export namespace ResourceDataSyncOrganizationalUnit {
   export function isa(o: any): o is ResourceDataSyncOrganizationalUnit {
-    return _smithy.isa(o, "ResourceDataSyncOrganizationalUnit");
+    return __isa(o, "ResourceDataSyncOrganizationalUnit");
   }
 }
 
@@ -13775,7 +13740,7 @@ export interface ResourceDataSyncS3Destination {
 
 export namespace ResourceDataSyncS3Destination {
   export function isa(o: any): o is ResourceDataSyncS3Destination {
-    return _smithy.isa(o, "ResourceDataSyncS3Destination");
+    return __isa(o, "ResourceDataSyncS3Destination");
   }
 }
 
@@ -13815,7 +13780,7 @@ export interface ResourceDataSyncSource {
 
 export namespace ResourceDataSyncSource {
   export function isa(o: any): o is ResourceDataSyncSource {
-    return _smithy.isa(o, "ResourceDataSyncSource");
+    return __isa(o, "ResourceDataSyncSource");
   }
 }
 
@@ -13882,7 +13847,7 @@ export interface ResourceDataSyncSourceWithState {
 
 export namespace ResourceDataSyncSourceWithState {
   export function isa(o: any): o is ResourceDataSyncSourceWithState {
-    return _smithy.isa(o, "ResourceDataSyncSourceWithState");
+    return __isa(o, "ResourceDataSyncSourceWithState");
   }
 }
 
@@ -13891,7 +13856,7 @@ export namespace ResourceDataSyncSourceWithState {
  *    patch group.</p>
  */
 export interface ResourceInUseException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceInUseException";
   $fault: "client";
@@ -13900,7 +13865,7 @@ export interface ResourceInUseException
 
 export namespace ResourceInUseException {
   export function isa(o: any): o is ResourceInUseException {
-    return _smithy.isa(o, "ResourceInUseException");
+    return __isa(o, "ResourceInUseException");
   }
 }
 
@@ -13911,7 +13876,7 @@ export namespace ResourceInUseException {
  *         <i>AWS General Reference</i>.</p>
  */
 export interface ResourceLimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceLimitExceededException";
   $fault: "client";
@@ -13920,7 +13885,7 @@ export interface ResourceLimitExceededException
 
 export namespace ResourceLimitExceededException {
   export function isa(o: any): o is ResourceLimitExceededException {
-    return _smithy.isa(o, "ResourceLimitExceededException");
+    return __isa(o, "ResourceLimitExceededException");
   }
 }
 
@@ -13953,7 +13918,7 @@ export interface ResultAttribute {
 
 export namespace ResultAttribute {
   export function isa(o: any): o is ResultAttribute {
-    return _smithy.isa(o, "ResultAttribute");
+    return __isa(o, "ResultAttribute");
   }
 }
 
@@ -13967,7 +13932,7 @@ export interface ResumeSessionRequest {
 
 export namespace ResumeSessionRequest {
   export function isa(o: any): o is ResumeSessionRequest {
-    return _smithy.isa(o, "ResumeSessionRequest");
+    return __isa(o, "ResumeSessionRequest");
   }
 }
 
@@ -14001,7 +13966,7 @@ export interface ResumeSessionResponse extends $MetadataBearer {
 
 export namespace ResumeSessionResponse {
   export function isa(o: any): o is ResumeSessionResponse {
-    return _smithy.isa(o, "ResumeSessionResponse");
+    return __isa(o, "ResumeSessionResponse");
   }
 }
 
@@ -14029,7 +13994,7 @@ export interface S3OutputLocation {
 
 export namespace S3OutputLocation {
   export function isa(o: any): o is S3OutputLocation {
-    return _smithy.isa(o, "S3OutputLocation");
+    return __isa(o, "S3OutputLocation");
   }
 }
 
@@ -14046,7 +14011,7 @@ export interface S3OutputUrl {
 
 export namespace S3OutputUrl {
   export function isa(o: any): o is S3OutputUrl {
-    return _smithy.isa(o, "S3OutputUrl");
+    return __isa(o, "S3OutputUrl");
   }
 }
 
@@ -14074,7 +14039,7 @@ export interface ScheduledWindowExecution {
 
 export namespace ScheduledWindowExecution {
   export function isa(o: any): o is ScheduledWindowExecution {
-    return _smithy.isa(o, "ScheduledWindowExecution");
+    return __isa(o, "ScheduledWindowExecution");
   }
 }
 
@@ -14115,7 +14080,7 @@ export interface SendAutomationSignalRequest {
 
 export namespace SendAutomationSignalRequest {
   export function isa(o: any): o is SendAutomationSignalRequest {
-    return _smithy.isa(o, "SendAutomationSignalRequest");
+    return __isa(o, "SendAutomationSignalRequest");
   }
 }
 
@@ -14125,7 +14090,7 @@ export interface SendAutomationSignalResult extends $MetadataBearer {
 
 export namespace SendAutomationSignalResult {
   export function isa(o: any): o is SendAutomationSignalResult {
-    return _smithy.isa(o, "SendAutomationSignalResult");
+    return __isa(o, "SendAutomationSignalResult");
   }
 }
 
@@ -14250,7 +14215,7 @@ export interface SendCommandRequest {
 
 export namespace SendCommandRequest {
   export function isa(o: any): o is SendCommandRequest {
-    return _smithy.isa(o, "SendCommandRequest");
+    return __isa(o, "SendCommandRequest");
   }
 }
 
@@ -14265,7 +14230,7 @@ export interface SendCommandResult extends $MetadataBearer {
 
 export namespace SendCommandResult {
   export function isa(o: any): o is SendCommandResult {
-    return _smithy.isa(o, "SendCommandResult");
+    return __isa(o, "SendCommandResult");
   }
 }
 
@@ -14335,7 +14300,7 @@ export interface ServiceSetting {
 
 export namespace ServiceSetting {
   export function isa(o: any): o is ServiceSetting {
-    return _smithy.isa(o, "ServiceSetting");
+    return __isa(o, "ServiceSetting");
   }
 }
 
@@ -14344,7 +14309,7 @@ export namespace ServiceSetting {
  *    been provisioned by the AWS service team.</p>
  */
 export interface ServiceSettingNotFound
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ServiceSettingNotFound";
   $fault: "client";
@@ -14353,7 +14318,7 @@ export interface ServiceSettingNotFound
 
 export namespace ServiceSettingNotFound {
   export function isa(o: any): o is ServiceSettingNotFound {
-    return _smithy.isa(o, "ServiceSettingNotFound");
+    return __isa(o, "ServiceSettingNotFound");
   }
 }
 
@@ -14411,7 +14376,7 @@ export interface Session {
 
 export namespace Session {
   export function isa(o: any): o is Session {
-    return _smithy.isa(o, "Session");
+    return __isa(o, "Session");
   }
 }
 
@@ -14473,7 +14438,7 @@ export interface SessionFilter {
 
 export namespace SessionFilter {
   export function isa(o: any): o is SessionFilter {
-    return _smithy.isa(o, "SessionFilter");
+    return __isa(o, "SessionFilter");
   }
 }
 
@@ -14503,7 +14468,7 @@ export interface SessionManagerOutputUrl {
 
 export namespace SessionManagerOutputUrl {
   export function isa(o: any): o is SessionManagerOutputUrl {
-    return _smithy.isa(o, "SessionManagerOutputUrl");
+    return __isa(o, "SessionManagerOutputUrl");
   }
 }
 
@@ -14568,7 +14533,7 @@ export interface SeveritySummary {
 
 export namespace SeveritySummary {
   export function isa(o: any): o is SeveritySummary {
-    return _smithy.isa(o, "SeveritySummary");
+    return __isa(o, "SeveritySummary");
   }
 }
 
@@ -14590,7 +14555,7 @@ export interface StartAssociationsOnceRequest {
 
 export namespace StartAssociationsOnceRequest {
   export function isa(o: any): o is StartAssociationsOnceRequest {
-    return _smithy.isa(o, "StartAssociationsOnceRequest");
+    return __isa(o, "StartAssociationsOnceRequest");
   }
 }
 
@@ -14600,7 +14565,7 @@ export interface StartAssociationsOnceResult extends $MetadataBearer {
 
 export namespace StartAssociationsOnceResult {
   export function isa(o: any): o is StartAssociationsOnceResult {
-    return _smithy.isa(o, "StartAssociationsOnceResult");
+    return __isa(o, "StartAssociationsOnceResult");
   }
 }
 
@@ -14709,7 +14674,7 @@ export interface StartAutomationExecutionRequest {
 
 export namespace StartAutomationExecutionRequest {
   export function isa(o: any): o is StartAutomationExecutionRequest {
-    return _smithy.isa(o, "StartAutomationExecutionRequest");
+    return __isa(o, "StartAutomationExecutionRequest");
   }
 }
 
@@ -14723,7 +14688,7 @@ export interface StartAutomationExecutionResult extends $MetadataBearer {
 
 export namespace StartAutomationExecutionResult {
   export function isa(o: any): o is StartAutomationExecutionResult {
-    return _smithy.isa(o, "StartAutomationExecutionResult");
+    return __isa(o, "StartAutomationExecutionResult");
   }
 }
 
@@ -14749,7 +14714,7 @@ export interface StartSessionRequest {
 
 export namespace StartSessionRequest {
   export function isa(o: any): o is StartSessionRequest {
-    return _smithy.isa(o, "StartSessionRequest");
+    return __isa(o, "StartSessionRequest");
   }
 }
 
@@ -14784,23 +14749,21 @@ export interface StartSessionResponse extends $MetadataBearer {
 
 export namespace StartSessionResponse {
   export function isa(o: any): o is StartSessionResponse {
-    return _smithy.isa(o, "StartSessionResponse");
+    return __isa(o, "StartSessionResponse");
   }
 }
 
 /**
  * <p>The updated status is the same as the current status.</p>
  */
-export interface StatusUnchanged
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface StatusUnchanged extends __SmithyException, $MetadataBearer {
   name: "StatusUnchanged";
   $fault: "client";
 }
 
 export namespace StatusUnchanged {
   export function isa(o: any): o is StatusUnchanged {
-    return _smithy.isa(o, "StatusUnchanged");
+    return __isa(o, "StatusUnchanged");
   }
 }
 
@@ -14930,7 +14893,7 @@ export interface StepExecution {
 
 export namespace StepExecution {
   export function isa(o: any): o is StepExecution {
-    return _smithy.isa(o, "StepExecution");
+    return __isa(o, "StepExecution");
   }
 }
 
@@ -14953,7 +14916,7 @@ export interface StepExecutionFilter {
 
 export namespace StepExecutionFilter {
   export function isa(o: any): o is StepExecutionFilter {
-    return _smithy.isa(o, "StepExecutionFilter");
+    return __isa(o, "StepExecutionFilter");
   }
 }
 
@@ -14982,7 +14945,7 @@ export interface StopAutomationExecutionRequest {
 
 export namespace StopAutomationExecutionRequest {
   export function isa(o: any): o is StopAutomationExecutionRequest {
-    return _smithy.isa(o, "StopAutomationExecutionRequest");
+    return __isa(o, "StopAutomationExecutionRequest");
   }
 }
 
@@ -14992,7 +14955,7 @@ export interface StopAutomationExecutionResult extends $MetadataBearer {
 
 export namespace StopAutomationExecutionResult {
   export function isa(o: any): o is StopAutomationExecutionResult {
-    return _smithy.isa(o, "StopAutomationExecutionResult");
+    return __isa(o, "StopAutomationExecutionResult");
   }
 }
 
@@ -15005,7 +14968,7 @@ export enum StopType {
  * <p>The sub-type count exceeded the limit for the inventory type.</p>
  */
 export interface SubTypeCountLimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "SubTypeCountLimitExceededException";
   $fault: "client";
@@ -15014,7 +14977,7 @@ export interface SubTypeCountLimitExceededException
 
 export namespace SubTypeCountLimitExceededException {
   export function isa(o: any): o is SubTypeCountLimitExceededException {
-    return _smithy.isa(o, "SubTypeCountLimitExceededException");
+    return __isa(o, "SubTypeCountLimitExceededException");
   }
 }
 
@@ -15039,7 +15002,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -15143,7 +15106,7 @@ export interface Target {
 
 export namespace Target {
   export function isa(o: any): o is Target {
-    return _smithy.isa(o, "Target");
+    return __isa(o, "Target");
   }
 }
 
@@ -15152,7 +15115,7 @@ export namespace Target {
  *    operation, but the target is still referenced in a task.</p>
  */
 export interface TargetInUseException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TargetInUseException";
   $fault: "client";
@@ -15161,7 +15124,7 @@ export interface TargetInUseException
 
 export namespace TargetInUseException {
   export function isa(o: any): o is TargetInUseException {
-    return _smithy.isa(o, "TargetInUseException");
+    return __isa(o, "TargetInUseException");
   }
 }
 
@@ -15201,7 +15164,7 @@ export interface TargetLocation {
 
 export namespace TargetLocation {
   export function isa(o: any): o is TargetLocation {
-    return _smithy.isa(o, "TargetLocation");
+    return __isa(o, "TargetLocation");
   }
 }
 
@@ -15210,9 +15173,7 @@ export namespace TargetLocation {
  *    For more information, see <a href="http://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-getting-started.html">Getting
  *     Started with Session Manager</a> in the <i>AWS Systems Manager User Guide</i>.</p>
  */
-export interface TargetNotConnected
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface TargetNotConnected extends __SmithyException, $MetadataBearer {
   name: "TargetNotConnected";
   $fault: "client";
   Message?: string;
@@ -15220,7 +15181,7 @@ export interface TargetNotConnected
 
 export namespace TargetNotConnected {
   export function isa(o: any): o is TargetNotConnected {
-    return _smithy.isa(o, "TargetNotConnected");
+    return __isa(o, "TargetNotConnected");
   }
 }
 
@@ -15234,7 +15195,7 @@ export interface TerminateSessionRequest {
 
 export namespace TerminateSessionRequest {
   export function isa(o: any): o is TerminateSessionRequest {
-    return _smithy.isa(o, "TerminateSessionRequest");
+    return __isa(o, "TerminateSessionRequest");
   }
 }
 
@@ -15248,7 +15209,7 @@ export interface TerminateSessionResponse extends $MetadataBearer {
 
 export namespace TerminateSessionResponse {
   export function isa(o: any): o is TerminateSessionResponse {
-    return _smithy.isa(o, "TerminateSessionResponse");
+    return __isa(o, "TerminateSessionResponse");
   }
 }
 
@@ -15256,25 +15217,21 @@ export namespace TerminateSessionResponse {
  * <p>The <code>Targets</code> parameter includes too many tags. Remove one or more tags and try
  *    the command again.</p>
  */
-export interface TooManyTagsError
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface TooManyTagsError extends __SmithyException, $MetadataBearer {
   name: "TooManyTagsError";
   $fault: "client";
 }
 
 export namespace TooManyTagsError {
   export function isa(o: any): o is TooManyTagsError {
-    return _smithy.isa(o, "TooManyTagsError");
+    return __isa(o, "TooManyTagsError");
   }
 }
 
 /**
  * <p>There are concurrent updates for a resource that supports one update at a time.</p>
  */
-export interface TooManyUpdates
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface TooManyUpdates extends __SmithyException, $MetadataBearer {
   name: "TooManyUpdates";
   $fault: "client";
   Message?: string;
@@ -15282,7 +15239,7 @@ export interface TooManyUpdates
 
 export namespace TooManyUpdates {
   export function isa(o: any): o is TooManyUpdates {
-    return _smithy.isa(o, "TooManyUpdates");
+    return __isa(o, "TooManyUpdates");
   }
 }
 
@@ -15290,7 +15247,7 @@ export namespace TooManyUpdates {
  * <p>The size of inventory data has exceeded the total size limit for the resource.</p>
  */
 export interface TotalSizeLimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TotalSizeLimitExceededException";
   $fault: "client";
@@ -15299,7 +15256,7 @@ export interface TotalSizeLimitExceededException
 
 export namespace TotalSizeLimitExceededException {
   export function isa(o: any): o is TotalSizeLimitExceededException {
-    return _smithy.isa(o, "TotalSizeLimitExceededException");
+    return __isa(o, "TotalSizeLimitExceededException");
   }
 }
 
@@ -15307,7 +15264,7 @@ export namespace TotalSizeLimitExceededException {
  * <p>The calendar entry contained in the specified Systems Manager document is not supported.</p>
  */
 export interface UnsupportedCalendarException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UnsupportedCalendarException";
   $fault: "client";
@@ -15316,7 +15273,7 @@ export interface UnsupportedCalendarException
 
 export namespace UnsupportedCalendarException {
   export function isa(o: any): o is UnsupportedCalendarException {
-    return _smithy.isa(o, "UnsupportedCalendarException");
+    return __isa(o, "UnsupportedCalendarException");
   }
 }
 
@@ -15327,7 +15284,7 @@ export namespace UnsupportedCalendarException {
  *     Tier</a> in the <i>AWS Systems Manager User Guide</i>.</p>
  */
 export interface UnsupportedFeatureRequiredException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UnsupportedFeatureRequiredException";
   $fault: "client";
@@ -15336,7 +15293,7 @@ export interface UnsupportedFeatureRequiredException
 
 export namespace UnsupportedFeatureRequiredException {
   export function isa(o: any): o is UnsupportedFeatureRequiredException {
-    return _smithy.isa(o, "UnsupportedFeatureRequiredException");
+    return __isa(o, "UnsupportedFeatureRequiredException");
   }
 }
 
@@ -15346,7 +15303,7 @@ export namespace UnsupportedFeatureRequiredException {
  *    inventory types like <code>AWS:ComplianceItem</code>.</p>
  */
 export interface UnsupportedInventoryItemContextException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UnsupportedInventoryItemContextException";
   $fault: "client";
@@ -15356,7 +15313,7 @@ export interface UnsupportedInventoryItemContextException
 
 export namespace UnsupportedInventoryItemContextException {
   export function isa(o: any): o is UnsupportedInventoryItemContextException {
-    return _smithy.isa(o, "UnsupportedInventoryItemContextException");
+    return __isa(o, "UnsupportedInventoryItemContextException");
   }
 }
 
@@ -15365,7 +15322,7 @@ export namespace UnsupportedInventoryItemContextException {
  *    output of GetInventorySchema to see the available schema version for each type.</p>
  */
 export interface UnsupportedInventorySchemaVersionException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UnsupportedInventorySchemaVersionException";
   $fault: "client";
@@ -15374,7 +15331,7 @@ export interface UnsupportedInventorySchemaVersionException
 
 export namespace UnsupportedInventorySchemaVersionException {
   export function isa(o: any): o is UnsupportedInventorySchemaVersionException {
-    return _smithy.isa(o, "UnsupportedInventorySchemaVersionException");
+    return __isa(o, "UnsupportedInventorySchemaVersionException");
   }
 }
 
@@ -15384,7 +15341,7 @@ export namespace UnsupportedInventorySchemaVersionException {
  *    RedhatEnterpriseLinux, and Ubuntu.</p>
  */
 export interface UnsupportedOperatingSystem
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UnsupportedOperatingSystem";
   $fault: "client";
@@ -15393,7 +15350,7 @@ export interface UnsupportedOperatingSystem
 
 export namespace UnsupportedOperatingSystem {
   export function isa(o: any): o is UnsupportedOperatingSystem {
-    return _smithy.isa(o, "UnsupportedOperatingSystem");
+    return __isa(o, "UnsupportedOperatingSystem");
   }
 }
 
@@ -15401,7 +15358,7 @@ export namespace UnsupportedOperatingSystem {
  * <p>The parameter type is not supported.</p>
  */
 export interface UnsupportedParameterType
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UnsupportedParameterType";
   $fault: "client";
@@ -15410,7 +15367,7 @@ export interface UnsupportedParameterType
 
 export namespace UnsupportedParameterType {
   export function isa(o: any): o is UnsupportedParameterType {
-    return _smithy.isa(o, "UnsupportedParameterType");
+    return __isa(o, "UnsupportedParameterType");
   }
 }
 
@@ -15419,7 +15376,7 @@ export namespace UnsupportedParameterType {
  *    you sent an document for a Windows instance to a Linux instance.</p>
  */
 export interface UnsupportedPlatformType
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UnsupportedPlatformType";
   $fault: "client";
@@ -15428,7 +15385,7 @@ export interface UnsupportedPlatformType
 
 export namespace UnsupportedPlatformType {
   export function isa(o: any): o is UnsupportedPlatformType {
-    return _smithy.isa(o, "UnsupportedPlatformType");
+    return __isa(o, "UnsupportedPlatformType");
   }
 }
 
@@ -15538,7 +15495,7 @@ export interface UpdateAssociationRequest {
 
 export namespace UpdateAssociationRequest {
   export function isa(o: any): o is UpdateAssociationRequest {
-    return _smithy.isa(o, "UpdateAssociationRequest");
+    return __isa(o, "UpdateAssociationRequest");
   }
 }
 
@@ -15552,7 +15509,7 @@ export interface UpdateAssociationResult extends $MetadataBearer {
 
 export namespace UpdateAssociationResult {
   export function isa(o: any): o is UpdateAssociationResult {
-    return _smithy.isa(o, "UpdateAssociationResult");
+    return __isa(o, "UpdateAssociationResult");
   }
 }
 
@@ -15576,7 +15533,7 @@ export interface UpdateAssociationStatusRequest {
 
 export namespace UpdateAssociationStatusRequest {
   export function isa(o: any): o is UpdateAssociationStatusRequest {
-    return _smithy.isa(o, "UpdateAssociationStatusRequest");
+    return __isa(o, "UpdateAssociationStatusRequest");
   }
 }
 
@@ -15590,7 +15547,7 @@ export interface UpdateAssociationStatusResult extends $MetadataBearer {
 
 export namespace UpdateAssociationStatusResult {
   export function isa(o: any): o is UpdateAssociationStatusResult {
-    return _smithy.isa(o, "UpdateAssociationStatusResult");
+    return __isa(o, "UpdateAssociationStatusResult");
   }
 }
 
@@ -15609,7 +15566,7 @@ export interface UpdateDocumentDefaultVersionRequest {
 
 export namespace UpdateDocumentDefaultVersionRequest {
   export function isa(o: any): o is UpdateDocumentDefaultVersionRequest {
-    return _smithy.isa(o, "UpdateDocumentDefaultVersionRequest");
+    return __isa(o, "UpdateDocumentDefaultVersionRequest");
   }
 }
 
@@ -15623,7 +15580,7 @@ export interface UpdateDocumentDefaultVersionResult extends $MetadataBearer {
 
 export namespace UpdateDocumentDefaultVersionResult {
   export function isa(o: any): o is UpdateDocumentDefaultVersionResult {
-    return _smithy.isa(o, "UpdateDocumentDefaultVersionResult");
+    return __isa(o, "UpdateDocumentDefaultVersionResult");
   }
 }
 
@@ -15670,7 +15627,7 @@ export interface UpdateDocumentRequest {
 
 export namespace UpdateDocumentRequest {
   export function isa(o: any): o is UpdateDocumentRequest {
-    return _smithy.isa(o, "UpdateDocumentRequest");
+    return __isa(o, "UpdateDocumentRequest");
   }
 }
 
@@ -15684,7 +15641,7 @@ export interface UpdateDocumentResult extends $MetadataBearer {
 
 export namespace UpdateDocumentResult {
   export function isa(o: any): o is UpdateDocumentResult {
-    return _smithy.isa(o, "UpdateDocumentResult");
+    return __isa(o, "UpdateDocumentResult");
   }
 }
 
@@ -15764,7 +15721,7 @@ export interface UpdateMaintenanceWindowRequest {
 
 export namespace UpdateMaintenanceWindowRequest {
   export function isa(o: any): o is UpdateMaintenanceWindowRequest {
-    return _smithy.isa(o, "UpdateMaintenanceWindowRequest");
+    return __isa(o, "UpdateMaintenanceWindowRequest");
   }
 }
 
@@ -15835,7 +15792,7 @@ export interface UpdateMaintenanceWindowResult extends $MetadataBearer {
 
 export namespace UpdateMaintenanceWindowResult {
   export function isa(o: any): o is UpdateMaintenanceWindowResult {
-    return _smithy.isa(o, "UpdateMaintenanceWindowResult");
+    return __isa(o, "UpdateMaintenanceWindowResult");
   }
 }
 
@@ -15882,7 +15839,7 @@ export interface UpdateMaintenanceWindowTargetRequest {
 
 export namespace UpdateMaintenanceWindowTargetRequest {
   export function isa(o: any): o is UpdateMaintenanceWindowTargetRequest {
-    return _smithy.isa(o, "UpdateMaintenanceWindowTargetRequest");
+    return __isa(o, "UpdateMaintenanceWindowTargetRequest");
   }
 }
 
@@ -15921,7 +15878,7 @@ export interface UpdateMaintenanceWindowTargetResult extends $MetadataBearer {
 
 export namespace UpdateMaintenanceWindowTargetResult {
   export function isa(o: any): o is UpdateMaintenanceWindowTargetResult {
-    return _smithy.isa(o, "UpdateMaintenanceWindowTargetResult");
+    return __isa(o, "UpdateMaintenanceWindowTargetResult");
   }
 }
 
@@ -16045,7 +16002,7 @@ export interface UpdateMaintenanceWindowTaskRequest {
 
 export namespace UpdateMaintenanceWindowTaskRequest {
   export function isa(o: any): o is UpdateMaintenanceWindowTaskRequest {
-    return _smithy.isa(o, "UpdateMaintenanceWindowTaskRequest");
+    return __isa(o, "UpdateMaintenanceWindowTaskRequest");
   }
 }
 
@@ -16136,7 +16093,7 @@ export interface UpdateMaintenanceWindowTaskResult extends $MetadataBearer {
 
 export namespace UpdateMaintenanceWindowTaskResult {
   export function isa(o: any): o is UpdateMaintenanceWindowTaskResult {
-    return _smithy.isa(o, "UpdateMaintenanceWindowTaskResult");
+    return __isa(o, "UpdateMaintenanceWindowTaskResult");
   }
 }
 
@@ -16155,7 +16112,7 @@ export interface UpdateManagedInstanceRoleRequest {
 
 export namespace UpdateManagedInstanceRoleRequest {
   export function isa(o: any): o is UpdateManagedInstanceRoleRequest {
-    return _smithy.isa(o, "UpdateManagedInstanceRoleRequest");
+    return __isa(o, "UpdateManagedInstanceRoleRequest");
   }
 }
 
@@ -16165,7 +16122,7 @@ export interface UpdateManagedInstanceRoleResult extends $MetadataBearer {
 
 export namespace UpdateManagedInstanceRoleResult {
   export function isa(o: any): o is UpdateManagedInstanceRoleResult {
-    return _smithy.isa(o, "UpdateManagedInstanceRoleResult");
+    return __isa(o, "UpdateManagedInstanceRoleResult");
   }
 }
 
@@ -16256,7 +16213,7 @@ export interface UpdateOpsItemRequest {
 
 export namespace UpdateOpsItemRequest {
   export function isa(o: any): o is UpdateOpsItemRequest {
-    return _smithy.isa(o, "UpdateOpsItemRequest");
+    return __isa(o, "UpdateOpsItemRequest");
   }
 }
 
@@ -16266,7 +16223,7 @@ export interface UpdateOpsItemResponse extends $MetadataBearer {
 
 export namespace UpdateOpsItemResponse {
   export function isa(o: any): o is UpdateOpsItemResponse {
-    return _smithy.isa(o, "UpdateOpsItemResponse");
+    return __isa(o, "UpdateOpsItemResponse");
   }
 }
 
@@ -16362,7 +16319,7 @@ export interface UpdatePatchBaselineRequest {
 
 export namespace UpdatePatchBaselineRequest {
   export function isa(o: any): o is UpdatePatchBaselineRequest {
-    return _smithy.isa(o, "UpdatePatchBaselineRequest");
+    return __isa(o, "UpdatePatchBaselineRequest");
   }
 }
 
@@ -16446,7 +16403,7 @@ export interface UpdatePatchBaselineResult extends $MetadataBearer {
 
 export namespace UpdatePatchBaselineResult {
   export function isa(o: any): o is UpdatePatchBaselineResult {
-    return _smithy.isa(o, "UpdatePatchBaselineResult");
+    return __isa(o, "UpdatePatchBaselineResult");
   }
 }
 
@@ -16473,7 +16430,7 @@ export interface UpdateResourceDataSyncRequest {
 
 export namespace UpdateResourceDataSyncRequest {
   export function isa(o: any): o is UpdateResourceDataSyncRequest {
-    return _smithy.isa(o, "UpdateResourceDataSyncRequest");
+    return __isa(o, "UpdateResourceDataSyncRequest");
   }
 }
 
@@ -16483,7 +16440,7 @@ export interface UpdateResourceDataSyncResult extends $MetadataBearer {
 
 export namespace UpdateResourceDataSyncResult {
   export function isa(o: any): o is UpdateResourceDataSyncResult {
-    return _smithy.isa(o, "UpdateResourceDataSyncResult");
+    return __isa(o, "UpdateResourceDataSyncResult");
   }
 }
 
@@ -16505,7 +16462,7 @@ export interface UpdateServiceSettingRequest {
 
 export namespace UpdateServiceSettingRequest {
   export function isa(o: any): o is UpdateServiceSettingRequest {
-    return _smithy.isa(o, "UpdateServiceSettingRequest");
+    return __isa(o, "UpdateServiceSettingRequest");
   }
 }
 
@@ -16518,6 +16475,6 @@ export interface UpdateServiceSettingResult extends $MetadataBearer {
 
 export namespace UpdateServiceSettingResult {
   export function isa(o: any): o is UpdateServiceSettingResult {
-    return _smithy.isa(o, "UpdateServiceSettingResult");
+    return __isa(o, "UpdateServiceSettingResult");
   }
 }

--- a/clients/client-sso-oidc/models/index.ts
+++ b/clients/client-sso-oidc/models/index.ts
@@ -1,11 +1,14 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
  * <p>You do not have sufficient access to perform this action.</p>
  */
 export interface AccessDeniedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AccessDeniedException";
   $fault: "client";
@@ -15,7 +18,7 @@ export interface AccessDeniedException
 
 export namespace AccessDeniedException {
   export function isa(o: any): o is AccessDeniedException {
-    return _smithy.isa(o, "AccessDeniedException");
+    return __isa(o, "AccessDeniedException");
   }
 }
 
@@ -23,7 +26,7 @@ export namespace AccessDeniedException {
  * <p>Indicates that a request to authorize a client with an access user session token is pending.</p>
  */
 export interface AuthorizationPendingException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AuthorizationPendingException";
   $fault: "client";
@@ -33,7 +36,7 @@ export interface AuthorizationPendingException
 
 export namespace AuthorizationPendingException {
   export function isa(o: any): o is AuthorizationPendingException {
-    return _smithy.isa(o, "AuthorizationPendingException");
+    return __isa(o, "AuthorizationPendingException");
   }
 }
 
@@ -86,7 +89,7 @@ export interface CreateTokenRequest {
 
 export namespace CreateTokenRequest {
   export function isa(o: any): o is CreateTokenRequest {
-    return _smithy.isa(o, "CreateTokenRequest");
+    return __isa(o, "CreateTokenRequest");
   }
 }
 
@@ -122,7 +125,7 @@ export interface CreateTokenResponse extends $MetadataBearer {
 
 export namespace CreateTokenResponse {
   export function isa(o: any): o is CreateTokenResponse {
-    return _smithy.isa(o, "CreateTokenResponse");
+    return __isa(o, "CreateTokenResponse");
   }
 }
 
@@ -130,7 +133,7 @@ export namespace CreateTokenResponse {
  * <p>Indicates that the token issued by the service is expired and is no longer valid.</p>
  */
 export interface ExpiredTokenException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ExpiredTokenException";
   $fault: "client";
@@ -140,7 +143,7 @@ export interface ExpiredTokenException
 
 export namespace ExpiredTokenException {
   export function isa(o: any): o is ExpiredTokenException {
-    return _smithy.isa(o, "ExpiredTokenException");
+    return __isa(o, "ExpiredTokenException");
   }
 }
 
@@ -148,7 +151,7 @@ export namespace ExpiredTokenException {
  * <p>Indicates that an error from the service occurred while trying to process a request.</p>
  */
 export interface InternalServerException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalServerException";
   $fault: "server";
@@ -158,7 +161,7 @@ export interface InternalServerException
 
 export namespace InternalServerException {
   export function isa(o: any): o is InternalServerException {
-    return _smithy.isa(o, "InternalServerException");
+    return __isa(o, "InternalServerException");
   }
 }
 
@@ -168,7 +171,7 @@ export namespace InternalServerException {
  *       an expired <code>clientSecret</code>.</p>
  */
 export interface InvalidClientException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidClientException";
   $fault: "client";
@@ -178,7 +181,7 @@ export interface InvalidClientException
 
 export namespace InvalidClientException {
   export function isa(o: any): o is InvalidClientException {
-    return _smithy.isa(o, "InvalidClientException");
+    return __isa(o, "InvalidClientException");
   }
 }
 
@@ -186,7 +189,7 @@ export namespace InvalidClientException {
  * <p>Indicates that the client information sent in the request during registration is invalid.</p>
  */
 export interface InvalidClientMetadataException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidClientMetadataException";
   $fault: "client";
@@ -196,7 +199,7 @@ export interface InvalidClientMetadataException
 
 export namespace InvalidClientMetadataException {
   export function isa(o: any): o is InvalidClientMetadataException {
-    return _smithy.isa(o, "InvalidClientMetadataException");
+    return __isa(o, "InvalidClientMetadataException");
   }
 }
 
@@ -204,7 +207,7 @@ export namespace InvalidClientMetadataException {
  * <p>Indicates that a request contains an invalid grant. This can occur if a client makes a <a>CreateToken</a> request with an invalid grant type.</p>
  */
 export interface InvalidGrantException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidGrantException";
   $fault: "client";
@@ -214,7 +217,7 @@ export interface InvalidGrantException
 
 export namespace InvalidGrantException {
   export function isa(o: any): o is InvalidGrantException {
-    return _smithy.isa(o, "InvalidGrantException");
+    return __isa(o, "InvalidGrantException");
   }
 }
 
@@ -223,7 +226,7 @@ export namespace InvalidGrantException {
  *       parameter might be missing or out of range.</p>
  */
 export interface InvalidRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidRequestException";
   $fault: "client";
@@ -233,7 +236,7 @@ export interface InvalidRequestException
 
 export namespace InvalidRequestException {
   export function isa(o: any): o is InvalidRequestException {
-    return _smithy.isa(o, "InvalidRequestException");
+    return __isa(o, "InvalidRequestException");
   }
 }
 
@@ -241,7 +244,7 @@ export namespace InvalidRequestException {
  * <p>Indicates that the scope provided in the request is invalid.</p>
  */
 export interface InvalidScopeException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidScopeException";
   $fault: "client";
@@ -251,7 +254,7 @@ export interface InvalidScopeException
 
 export namespace InvalidScopeException {
   export function isa(o: any): o is InvalidScopeException {
-    return _smithy.isa(o, "InvalidScopeException");
+    return __isa(o, "InvalidScopeException");
   }
 }
 
@@ -276,7 +279,7 @@ export interface RegisterClientRequest {
 
 export namespace RegisterClientRequest {
   export function isa(o: any): o is RegisterClientRequest {
-    return _smithy.isa(o, "RegisterClientRequest");
+    return __isa(o, "RegisterClientRequest");
   }
 }
 
@@ -317,16 +320,14 @@ export interface RegisterClientResponse extends $MetadataBearer {
 
 export namespace RegisterClientResponse {
   export function isa(o: any): o is RegisterClientResponse {
-    return _smithy.isa(o, "RegisterClientResponse");
+    return __isa(o, "RegisterClientResponse");
   }
 }
 
 /**
  * <p>Indicates that the client is making the request too frequently and is more than the service can handle. </p>
  */
-export interface SlowDownException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface SlowDownException extends __SmithyException, $MetadataBearer {
   name: "SlowDownException";
   $fault: "client";
   error?: string;
@@ -335,7 +336,7 @@ export interface SlowDownException
 
 export namespace SlowDownException {
   export function isa(o: any): o is SlowDownException {
-    return _smithy.isa(o, "SlowDownException");
+    return __isa(o, "SlowDownException");
   }
 }
 
@@ -363,7 +364,7 @@ export interface StartDeviceAuthorizationRequest {
 
 export namespace StartDeviceAuthorizationRequest {
   export function isa(o: any): o is StartDeviceAuthorizationRequest {
-    return _smithy.isa(o, "StartDeviceAuthorizationRequest");
+    return __isa(o, "StartDeviceAuthorizationRequest");
   }
 }
 
@@ -404,7 +405,7 @@ export interface StartDeviceAuthorizationResponse extends $MetadataBearer {
 
 export namespace StartDeviceAuthorizationResponse {
   export function isa(o: any): o is StartDeviceAuthorizationResponse {
-    return _smithy.isa(o, "StartDeviceAuthorizationResponse");
+    return __isa(o, "StartDeviceAuthorizationResponse");
   }
 }
 
@@ -413,7 +414,7 @@ export namespace StartDeviceAuthorizationResponse {
  *       when a <code>clientId</code> is not issued for a public client.</p>
  */
 export interface UnauthorizedClientException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UnauthorizedClientException";
   $fault: "client";
@@ -423,7 +424,7 @@ export interface UnauthorizedClientException
 
 export namespace UnauthorizedClientException {
   export function isa(o: any): o is UnauthorizedClientException {
-    return _smithy.isa(o, "UnauthorizedClientException");
+    return __isa(o, "UnauthorizedClientException");
   }
 }
 
@@ -431,7 +432,7 @@ export namespace UnauthorizedClientException {
  * <p>Indicates that the grant type in the request is not supported by the service.</p>
  */
 export interface UnsupportedGrantTypeException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UnsupportedGrantTypeException";
   $fault: "client";
@@ -441,6 +442,6 @@ export interface UnsupportedGrantTypeException
 
 export namespace UnsupportedGrantTypeException {
   export function isa(o: any): o is UnsupportedGrantTypeException {
-    return _smithy.isa(o, "UnsupportedGrantTypeException");
+    return __isa(o, "UnsupportedGrantTypeException");
   }
 }

--- a/clients/client-sso/models/index.ts
+++ b/clients/client-sso/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -24,7 +27,7 @@ export interface AccountInfo {
 
 export namespace AccountInfo {
   export function isa(o: any): o is AccountInfo {
-    return _smithy.isa(o, "AccountInfo");
+    return __isa(o, "AccountInfo");
   }
 }
 
@@ -49,7 +52,7 @@ export interface GetRoleCredentialsRequest {
 
 export namespace GetRoleCredentialsRequest {
   export function isa(o: any): o is GetRoleCredentialsRequest {
-    return _smithy.isa(o, "GetRoleCredentialsRequest");
+    return __isa(o, "GetRoleCredentialsRequest");
   }
 }
 
@@ -63,7 +66,7 @@ export interface GetRoleCredentialsResponse extends $MetadataBearer {
 
 export namespace GetRoleCredentialsResponse {
   export function isa(o: any): o is GetRoleCredentialsResponse {
-    return _smithy.isa(o, "GetRoleCredentialsResponse");
+    return __isa(o, "GetRoleCredentialsResponse");
   }
 }
 
@@ -72,7 +75,7 @@ export namespace GetRoleCredentialsResponse {
  *       parameter might be missing or out of range.</p>
  */
 export interface InvalidRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidRequestException";
   $fault: "client";
@@ -81,7 +84,7 @@ export interface InvalidRequestException
 
 export namespace InvalidRequestException {
   export function isa(o: any): o is InvalidRequestException {
-    return _smithy.isa(o, "InvalidRequestException");
+    return __isa(o, "InvalidRequestException");
   }
 }
 
@@ -111,7 +114,7 @@ export interface ListAccountRolesRequest {
 
 export namespace ListAccountRolesRequest {
   export function isa(o: any): o is ListAccountRolesRequest {
-    return _smithy.isa(o, "ListAccountRolesRequest");
+    return __isa(o, "ListAccountRolesRequest");
   }
 }
 
@@ -130,7 +133,7 @@ export interface ListAccountRolesResponse extends $MetadataBearer {
 
 export namespace ListAccountRolesResponse {
   export function isa(o: any): o is ListAccountRolesResponse {
-    return _smithy.isa(o, "ListAccountRolesResponse");
+    return __isa(o, "ListAccountRolesResponse");
   }
 }
 
@@ -155,7 +158,7 @@ export interface ListAccountsRequest {
 
 export namespace ListAccountsRequest {
   export function isa(o: any): o is ListAccountsRequest {
-    return _smithy.isa(o, "ListAccountsRequest");
+    return __isa(o, "ListAccountsRequest");
   }
 }
 
@@ -174,7 +177,7 @@ export interface ListAccountsResponse extends $MetadataBearer {
 
 export namespace ListAccountsResponse {
   export function isa(o: any): o is ListAccountsResponse {
-    return _smithy.isa(o, "ListAccountsResponse");
+    return __isa(o, "ListAccountsResponse");
   }
 }
 
@@ -189,7 +192,7 @@ export interface LogoutRequest {
 
 export namespace LogoutRequest {
   export function isa(o: any): o is LogoutRequest {
-    return _smithy.isa(o, "LogoutRequest");
+    return __isa(o, "LogoutRequest");
   }
 }
 
@@ -197,7 +200,7 @@ export namespace LogoutRequest {
  * <p>The specified resource doesn't exist.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -206,7 +209,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -242,7 +245,7 @@ export interface RoleCredentials {
 
 export namespace RoleCredentials {
   export function isa(o: any): o is RoleCredentials {
-    return _smithy.isa(o, "RoleCredentials");
+    return __isa(o, "RoleCredentials");
   }
 }
 
@@ -264,7 +267,7 @@ export interface RoleInfo {
 
 export namespace RoleInfo {
   export function isa(o: any): o is RoleInfo {
-    return _smithy.isa(o, "RoleInfo");
+    return __isa(o, "RoleInfo");
   }
 }
 
@@ -272,7 +275,7 @@ export namespace RoleInfo {
  * <p>Indicates that the request is being made too frequently and is more than what the server can handle.</p>
  */
 export interface TooManyRequestsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyRequestsException";
   $fault: "client";
@@ -281,7 +284,7 @@ export interface TooManyRequestsException
 
 export namespace TooManyRequestsException {
   export function isa(o: any): o is TooManyRequestsException {
-    return _smithy.isa(o, "TooManyRequestsException");
+    return __isa(o, "TooManyRequestsException");
   }
 }
 
@@ -289,7 +292,7 @@ export namespace TooManyRequestsException {
  * <p>Indicates that the request is not authorized. This can happen due to an invalid access token in the request.</p>
  */
 export interface UnauthorizedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UnauthorizedException";
   $fault: "client";
@@ -298,6 +301,6 @@ export interface UnauthorizedException
 
 export namespace UnauthorizedException {
   export function isa(o: any): o is UnauthorizedException {
-    return _smithy.isa(o, "UnauthorizedException");
+    return __isa(o, "UnauthorizedException");
   }
 }

--- a/clients/client-sso/protocols/Aws_restJson1_1.ts
+++ b/clients/client-sso/protocols/Aws_restJson1_1.ts
@@ -27,7 +27,10 @@ import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  extendedEncodeURIComponent as __extendedEncodeURIComponent
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -42,15 +45,19 @@ export async function serializeAws_restJson1_1GetRoleCredentialsCommand(
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.accessToken !== undefined) {
-    headers["x-amz-sso_bearer_token"] = input.accessToken.toString();
+    headers["x-amz-sso_bearer_token"] = input.accessToken;
   }
   let resolvedPath = "/federation/credentials";
   const query: any = {};
   if (input.accountId !== undefined) {
-    query["account_id"] = input.accountId.toString();
+    query[
+      __extendedEncodeURIComponent("account_id")
+    ] = __extendedEncodeURIComponent(input.accountId);
   }
   if (input.roleName !== undefined) {
-    query["role_name"] = input.roleName.toString();
+    query[
+      __extendedEncodeURIComponent("role_name")
+    ] = __extendedEncodeURIComponent(input.roleName);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -69,18 +76,24 @@ export async function serializeAws_restJson1_1ListAccountRolesCommand(
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.accessToken !== undefined) {
-    headers["x-amz-sso_bearer_token"] = input.accessToken.toString();
+    headers["x-amz-sso_bearer_token"] = input.accessToken;
   }
   let resolvedPath = "/assignment/roles";
   const query: any = {};
   if (input.accountId !== undefined) {
-    query["account_id"] = input.accountId.toString();
+    query[
+      __extendedEncodeURIComponent("account_id")
+    ] = __extendedEncodeURIComponent(input.accountId);
   }
   if (input.maxResults !== undefined) {
-    query["max_result"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("max_result")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nextToken !== undefined) {
-    query["next_token"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("next_token")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -99,15 +112,19 @@ export async function serializeAws_restJson1_1ListAccountsCommand(
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.accessToken !== undefined) {
-    headers["x-amz-sso_bearer_token"] = input.accessToken.toString();
+    headers["x-amz-sso_bearer_token"] = input.accessToken;
   }
   let resolvedPath = "/assignment/accounts";
   const query: any = {};
   if (input.maxResults !== undefined) {
-    query["max_result"] = input.maxResults.toString();
+    query[
+      __extendedEncodeURIComponent("max_result")
+    ] = __extendedEncodeURIComponent(input.maxResults.toString());
   }
   if (input.nextToken !== undefined) {
-    query["next_token"] = input.nextToken.toString();
+    query[
+      __extendedEncodeURIComponent("next_token")
+    ] = __extendedEncodeURIComponent(input.nextToken);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -126,7 +143,7 @@ export async function serializeAws_restJson1_1LogoutCommand(
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.accessToken !== undefined) {
-    headers["x-amz-sso_bearer_token"] = input.accessToken.toString();
+    headers["x-amz-sso_bearer_token"] = input.accessToken;
   }
   let resolvedPath = "/logout";
   return new __HttpRequest({
@@ -393,6 +410,7 @@ export async function deserializeAws_restJson1_1LogoutCommand(
   const contents: LogoutCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 

--- a/clients/client-storage-gateway/models/index.ts
+++ b/clients/client-storage-gateway/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -23,7 +26,7 @@ export interface ActivateGatewayOutput extends $MetadataBearer {
 
 export namespace ActivateGatewayOutput {
   export function isa(o: any): o is ActivateGatewayOutput {
-    return _smithy.isa(o, "ActivateGatewayOutput");
+    return __isa(o, "ActivateGatewayOutput");
   }
 }
 
@@ -55,7 +58,7 @@ export interface AddWorkingStorageInput {
 
 export namespace AddWorkingStorageInput {
   export function isa(o: any): o is AddWorkingStorageInput {
-    return _smithy.isa(o, "AddWorkingStorageInput");
+    return __isa(o, "AddWorkingStorageInput");
   }
 }
 
@@ -74,7 +77,7 @@ export interface AddWorkingStorageOutput extends $MetadataBearer {
 
 export namespace AddWorkingStorageOutput {
   export function isa(o: any): o is AddWorkingStorageOutput {
-    return _smithy.isa(o, "AddWorkingStorageOutput");
+    return __isa(o, "AddWorkingStorageOutput");
   }
 }
 
@@ -111,7 +114,7 @@ export interface ChapInfo {
 
 export namespace ChapInfo {
   export function isa(o: any): o is ChapInfo {
-    return _smithy.isa(o, "ChapInfo");
+    return __isa(o, "ChapInfo");
   }
 }
 
@@ -160,7 +163,7 @@ export interface CreateSnapshotInput {
 
 export namespace CreateSnapshotInput {
   export function isa(o: any): o is CreateSnapshotInput {
-    return _smithy.isa(o, "CreateSnapshotInput");
+    return __isa(o, "CreateSnapshotInput");
   }
 }
 
@@ -185,7 +188,7 @@ export interface CreateSnapshotOutput extends $MetadataBearer {
 
 export namespace CreateSnapshotOutput {
   export function isa(o: any): o is CreateSnapshotOutput {
-    return _smithy.isa(o, "CreateSnapshotOutput");
+    return __isa(o, "CreateSnapshotOutput");
   }
 }
 
@@ -294,7 +297,7 @@ export interface CreateStorediSCSIVolumeInput {
 
 export namespace CreateStorediSCSIVolumeInput {
   export function isa(o: any): o is CreateStorediSCSIVolumeInput {
-    return _smithy.isa(o, "CreateStorediSCSIVolumeInput");
+    return __isa(o, "CreateStorediSCSIVolumeInput");
   }
 }
 
@@ -322,7 +325,7 @@ export interface CreateStorediSCSIVolumeOutput extends $MetadataBearer {
 
 export namespace CreateStorediSCSIVolumeOutput {
   export function isa(o: any): o is CreateStorediSCSIVolumeOutput {
-    return _smithy.isa(o, "CreateStorediSCSIVolumeOutput");
+    return __isa(o, "CreateStorediSCSIVolumeOutput");
   }
 }
 
@@ -341,7 +344,7 @@ export interface DeleteBandwidthRateLimitOutput extends $MetadataBearer {
 
 export namespace DeleteBandwidthRateLimitOutput {
   export function isa(o: any): o is DeleteBandwidthRateLimitOutput {
-    return _smithy.isa(o, "DeleteBandwidthRateLimitOutput");
+    return __isa(o, "DeleteBandwidthRateLimitOutput");
   }
 }
 
@@ -376,7 +379,7 @@ export interface DeleteChapCredentialsInput {
 
 export namespace DeleteChapCredentialsInput {
   export function isa(o: any): o is DeleteChapCredentialsInput {
-    return _smithy.isa(o, "DeleteChapCredentialsInput");
+    return __isa(o, "DeleteChapCredentialsInput");
   }
 }
 
@@ -398,7 +401,7 @@ export interface DeleteChapCredentialsOutput extends $MetadataBearer {
 
 export namespace DeleteChapCredentialsOutput {
   export function isa(o: any): o is DeleteChapCredentialsOutput {
-    return _smithy.isa(o, "DeleteChapCredentialsOutput");
+    return __isa(o, "DeleteChapCredentialsOutput");
   }
 }
 
@@ -416,7 +419,7 @@ export interface DeleteGatewayInput {
 
 export namespace DeleteGatewayInput {
   export function isa(o: any): o is DeleteGatewayInput {
-    return _smithy.isa(o, "DeleteGatewayInput");
+    return __isa(o, "DeleteGatewayInput");
   }
 }
 
@@ -434,7 +437,7 @@ export interface DeleteGatewayOutput extends $MetadataBearer {
 
 export namespace DeleteGatewayOutput {
   export function isa(o: any): o is DeleteGatewayOutput {
-    return _smithy.isa(o, "DeleteGatewayOutput");
+    return __isa(o, "DeleteGatewayOutput");
   }
 }
 
@@ -453,7 +456,7 @@ export interface DeleteVolumeInput {
 
 export namespace DeleteVolumeInput {
   export function isa(o: any): o is DeleteVolumeInput {
-    return _smithy.isa(o, "DeleteVolumeInput");
+    return __isa(o, "DeleteVolumeInput");
   }
 }
 
@@ -471,7 +474,7 @@ export interface DeleteVolumeOutput extends $MetadataBearer {
 
 export namespace DeleteVolumeOutput {
   export function isa(o: any): o is DeleteVolumeOutput {
-    return _smithy.isa(o, "DeleteVolumeOutput");
+    return __isa(o, "DeleteVolumeOutput");
   }
 }
 
@@ -489,7 +492,7 @@ export interface DescribeBandwidthRateLimitInput {
 
 export namespace DescribeBandwidthRateLimitInput {
   export function isa(o: any): o is DescribeBandwidthRateLimitInput {
-    return _smithy.isa(o, "DescribeBandwidthRateLimitInput");
+    return __isa(o, "DescribeBandwidthRateLimitInput");
   }
 }
 
@@ -519,7 +522,7 @@ export interface DescribeBandwidthRateLimitOutput extends $MetadataBearer {
 
 export namespace DescribeBandwidthRateLimitOutput {
   export function isa(o: any): o is DescribeBandwidthRateLimitOutput {
-    return _smithy.isa(o, "DescribeBandwidthRateLimitOutput");
+    return __isa(o, "DescribeBandwidthRateLimitOutput");
   }
 }
 
@@ -538,7 +541,7 @@ export interface DescribeChapCredentialsInput {
 
 export namespace DescribeChapCredentialsInput {
   export function isa(o: any): o is DescribeChapCredentialsInput {
-    return _smithy.isa(o, "DescribeChapCredentialsInput");
+    return __isa(o, "DescribeChapCredentialsInput");
   }
 }
 
@@ -586,7 +589,7 @@ export interface DescribeChapCredentialsOutput extends $MetadataBearer {
 
 export namespace DescribeChapCredentialsOutput {
   export function isa(o: any): o is DescribeChapCredentialsOutput {
-    return _smithy.isa(o, "DescribeChapCredentialsOutput");
+    return __isa(o, "DescribeChapCredentialsOutput");
   }
 }
 
@@ -604,7 +607,7 @@ export interface DescribeGatewayInformationInput {
 
 export namespace DescribeGatewayInformationInput {
   export function isa(o: any): o is DescribeGatewayInformationInput {
-    return _smithy.isa(o, "DescribeGatewayInformationInput");
+    return __isa(o, "DescribeGatewayInformationInput");
   }
 }
 
@@ -622,7 +625,7 @@ export interface DescribeMaintenanceStartTimeInput {
 
 export namespace DescribeMaintenanceStartTimeInput {
   export function isa(o: any): o is DescribeMaintenanceStartTimeInput {
-    return _smithy.isa(o, "DescribeMaintenanceStartTimeInput");
+    return __isa(o, "DescribeMaintenanceStartTimeInput");
   }
 }
 
@@ -640,7 +643,7 @@ export interface DescribeSnapshotScheduleInput {
 
 export namespace DescribeSnapshotScheduleInput {
   export function isa(o: any): o is DescribeSnapshotScheduleInput {
-    return _smithy.isa(o, "DescribeSnapshotScheduleInput");
+    return __isa(o, "DescribeSnapshotScheduleInput");
   }
 }
 
@@ -658,7 +661,7 @@ export interface DescribeStorediSCSIVolumesInput {
 
 export namespace DescribeStorediSCSIVolumesInput {
   export function isa(o: any): o is DescribeStorediSCSIVolumesInput {
-    return _smithy.isa(o, "DescribeStorediSCSIVolumesInput");
+    return __isa(o, "DescribeStorediSCSIVolumesInput");
   }
 }
 
@@ -676,7 +679,7 @@ export interface DescribeWorkingStorageInput {
 
 export namespace DescribeWorkingStorageInput {
   export function isa(o: any): o is DescribeWorkingStorageInput {
-    return _smithy.isa(o, "DescribeWorkingStorageInput");
+    return __isa(o, "DescribeWorkingStorageInput");
   }
 }
 
@@ -714,7 +717,7 @@ export interface DescribeWorkingStorageOutput extends $MetadataBearer {
 
 export namespace DescribeWorkingStorageOutput {
   export function isa(o: any): o is DescribeWorkingStorageOutput {
-    return _smithy.isa(o, "DescribeWorkingStorageOutput");
+    return __isa(o, "DescribeWorkingStorageOutput");
   }
 }
 
@@ -787,7 +790,7 @@ export type ErrorCode =
  *          the error and message fields.</p>
  */
 export interface InternalServerError
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalServerError";
   $fault: "server";
@@ -805,7 +808,7 @@ export interface InternalServerError
 
 export namespace InternalServerError {
   export function isa(o: any): o is InternalServerError {
-    return _smithy.isa(o, "InternalServerError");
+    return __isa(o, "InternalServerError");
   }
 }
 
@@ -814,7 +817,7 @@ export namespace InternalServerError {
  *          For more information, see the error and message fields.</p>
  */
 export interface InvalidGatewayRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidGatewayRequestException";
   $fault: "client";
@@ -832,7 +835,7 @@ export interface InvalidGatewayRequestException
 
 export namespace InvalidGatewayRequestException {
   export function isa(o: any): o is InvalidGatewayRequestException {
-    return _smithy.isa(o, "InvalidGatewayRequestException");
+    return __isa(o, "InvalidGatewayRequestException");
   }
 }
 
@@ -868,7 +871,7 @@ export interface ListGatewaysInput {
 
 export namespace ListGatewaysInput {
   export function isa(o: any): o is ListGatewaysInput {
-    return _smithy.isa(o, "ListGatewaysInput");
+    return __isa(o, "ListGatewaysInput");
   }
 }
 
@@ -886,7 +889,7 @@ export interface ListLocalDisksInput {
 
 export namespace ListLocalDisksInput {
   export function isa(o: any): o is ListLocalDisksInput {
-    return _smithy.isa(o, "ListLocalDisksInput");
+    return __isa(o, "ListLocalDisksInput");
   }
 }
 
@@ -928,7 +931,7 @@ export interface ListVolumesInput {
 
 export namespace ListVolumesInput {
   export function isa(o: any): o is ListVolumesInput {
-    return _smithy.isa(o, "ListVolumesInput");
+    return __isa(o, "ListVolumesInput");
   }
 }
 
@@ -959,7 +962,7 @@ export interface NetworkInterface {
 
 export namespace NetworkInterface {
   export function isa(o: any): o is NetworkInterface {
-    return _smithy.isa(o, "NetworkInterface");
+    return __isa(o, "NetworkInterface");
   }
 }
 
@@ -968,7 +971,7 @@ export namespace NetworkInterface {
  *          information, see the error and message fields.</p>
  */
 export interface ServiceUnavailableError
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ServiceUnavailableError";
   $fault: "server";
@@ -986,7 +989,7 @@ export interface ServiceUnavailableError
 
 export namespace ServiceUnavailableError {
   export function isa(o: any): o is ServiceUnavailableError {
-    return _smithy.isa(o, "ServiceUnavailableError");
+    return __isa(o, "ServiceUnavailableError");
   }
 }
 
@@ -1004,7 +1007,7 @@ export interface ShutdownGatewayInput {
 
 export namespace ShutdownGatewayInput {
   export function isa(o: any): o is ShutdownGatewayInput {
-    return _smithy.isa(o, "ShutdownGatewayInput");
+    return __isa(o, "ShutdownGatewayInput");
   }
 }
 
@@ -1022,7 +1025,7 @@ export interface ShutdownGatewayOutput extends $MetadataBearer {
 
 export namespace ShutdownGatewayOutput {
   export function isa(o: any): o is ShutdownGatewayOutput {
-    return _smithy.isa(o, "ShutdownGatewayOutput");
+    return __isa(o, "ShutdownGatewayOutput");
   }
 }
 
@@ -1040,7 +1043,7 @@ export interface StartGatewayInput {
 
 export namespace StartGatewayInput {
   export function isa(o: any): o is StartGatewayInput {
-    return _smithy.isa(o, "StartGatewayInput");
+    return __isa(o, "StartGatewayInput");
   }
 }
 
@@ -1058,7 +1061,7 @@ export interface StartGatewayOutput extends $MetadataBearer {
 
 export namespace StartGatewayOutput {
   export function isa(o: any): o is StartGatewayOutput {
-    return _smithy.isa(o, "StartGatewayOutput");
+    return __isa(o, "StartGatewayOutput");
   }
 }
 
@@ -1082,7 +1085,7 @@ export interface StorageGatewayError {
 
 export namespace StorageGatewayError {
   export function isa(o: any): o is StorageGatewayError {
-    return _smithy.isa(o, "StorageGatewayError");
+    return __isa(o, "StorageGatewayError");
   }
 }
 
@@ -1122,7 +1125,7 @@ export interface UpdateBandwidthRateLimitInput {
 
 export namespace UpdateBandwidthRateLimitInput {
   export function isa(o: any): o is UpdateBandwidthRateLimitInput {
-    return _smithy.isa(o, "UpdateBandwidthRateLimitInput");
+    return __isa(o, "UpdateBandwidthRateLimitInput");
   }
 }
 
@@ -1141,7 +1144,7 @@ export interface UpdateBandwidthRateLimitOutput extends $MetadataBearer {
 
 export namespace UpdateBandwidthRateLimitOutput {
   export function isa(o: any): o is UpdateBandwidthRateLimitOutput {
-    return _smithy.isa(o, "UpdateBandwidthRateLimitOutput");
+    return __isa(o, "UpdateBandwidthRateLimitOutput");
   }
 }
 
@@ -1206,7 +1209,7 @@ export interface UpdateChapCredentialsInput {
 
 export namespace UpdateChapCredentialsInput {
   export function isa(o: any): o is UpdateChapCredentialsInput {
-    return _smithy.isa(o, "UpdateChapCredentialsInput");
+    return __isa(o, "UpdateChapCredentialsInput");
   }
 }
 
@@ -1230,7 +1233,7 @@ export interface UpdateChapCredentialsOutput extends $MetadataBearer {
 
 export namespace UpdateChapCredentialsOutput {
   export function isa(o: any): o is UpdateChapCredentialsOutput {
-    return _smithy.isa(o, "UpdateChapCredentialsOutput");
+    return __isa(o, "UpdateChapCredentialsOutput");
   }
 }
 
@@ -1253,7 +1256,7 @@ export interface UpdateGatewayInformationOutput extends $MetadataBearer {
 
 export namespace UpdateGatewayInformationOutput {
   export function isa(o: any): o is UpdateGatewayInformationOutput {
-    return _smithy.isa(o, "UpdateGatewayInformationOutput");
+    return __isa(o, "UpdateGatewayInformationOutput");
   }
 }
 
@@ -1271,7 +1274,7 @@ export interface UpdateGatewaySoftwareNowInput {
 
 export namespace UpdateGatewaySoftwareNowInput {
   export function isa(o: any): o is UpdateGatewaySoftwareNowInput {
-    return _smithy.isa(o, "UpdateGatewaySoftwareNowInput");
+    return __isa(o, "UpdateGatewaySoftwareNowInput");
   }
 }
 
@@ -1289,7 +1292,7 @@ export interface UpdateGatewaySoftwareNowOutput extends $MetadataBearer {
 
 export namespace UpdateGatewaySoftwareNowOutput {
   export function isa(o: any): o is UpdateGatewaySoftwareNowOutput {
-    return _smithy.isa(o, "UpdateGatewaySoftwareNowOutput");
+    return __isa(o, "UpdateGatewaySoftwareNowOutput");
   }
 }
 
@@ -1359,7 +1362,7 @@ export interface UpdateMaintenanceStartTimeInput {
 
 export namespace UpdateMaintenanceStartTimeInput {
   export function isa(o: any): o is UpdateMaintenanceStartTimeInput {
-    return _smithy.isa(o, "UpdateMaintenanceStartTimeInput");
+    return __isa(o, "UpdateMaintenanceStartTimeInput");
   }
 }
 
@@ -1378,7 +1381,7 @@ export interface UpdateMaintenanceStartTimeOutput extends $MetadataBearer {
 
 export namespace UpdateMaintenanceStartTimeOutput {
   export function isa(o: any): o is UpdateMaintenanceStartTimeOutput {
-    return _smithy.isa(o, "UpdateMaintenanceStartTimeOutput");
+    return __isa(o, "UpdateMaintenanceStartTimeOutput");
   }
 }
 
@@ -1447,7 +1450,7 @@ export interface UpdateSnapshotScheduleInput {
 
 export namespace UpdateSnapshotScheduleInput {
   export function isa(o: any): o is UpdateSnapshotScheduleInput {
-    return _smithy.isa(o, "UpdateSnapshotScheduleInput");
+    return __isa(o, "UpdateSnapshotScheduleInput");
   }
 }
 
@@ -1465,7 +1468,7 @@ export interface UpdateSnapshotScheduleOutput extends $MetadataBearer {
 
 export namespace UpdateSnapshotScheduleOutput {
   export function isa(o: any): o is UpdateSnapshotScheduleOutput {
-    return _smithy.isa(o, "UpdateSnapshotScheduleOutput");
+    return __isa(o, "UpdateSnapshotScheduleOutput");
   }
 }
 
@@ -1502,7 +1505,7 @@ export interface VolumeiSCSIAttributes {
 
 export namespace VolumeiSCSIAttributes {
   export function isa(o: any): o is VolumeiSCSIAttributes {
-    return _smithy.isa(o, "VolumeiSCSIAttributes");
+    return __isa(o, "VolumeiSCSIAttributes");
   }
 }
 
@@ -1524,7 +1527,7 @@ export interface AddCacheInput {
 
 export namespace AddCacheInput {
   export function isa(o: any): o is AddCacheInput {
-    return _smithy.isa(o, "AddCacheInput");
+    return __isa(o, "AddCacheInput");
   }
 }
 
@@ -1539,7 +1542,7 @@ export interface AddCacheOutput extends $MetadataBearer {
 
 export namespace AddCacheOutput {
   export function isa(o: any): o is AddCacheOutput {
-    return _smithy.isa(o, "AddCacheOutput");
+    return __isa(o, "AddCacheOutput");
   }
 }
 
@@ -1561,7 +1564,7 @@ export interface AddUploadBufferInput {
 
 export namespace AddUploadBufferInput {
   export function isa(o: any): o is AddUploadBufferInput {
-    return _smithy.isa(o, "AddUploadBufferInput");
+    return __isa(o, "AddUploadBufferInput");
   }
 }
 
@@ -1576,7 +1579,7 @@ export interface AddUploadBufferOutput extends $MetadataBearer {
 
 export namespace AddUploadBufferOutput {
   export function isa(o: any): o is AddUploadBufferOutput {
-    return _smithy.isa(o, "AddUploadBufferOutput");
+    return __isa(o, "AddUploadBufferOutput");
   }
 }
 
@@ -1661,7 +1664,7 @@ export interface CreateCachediSCSIVolumeInput {
 
 export namespace CreateCachediSCSIVolumeInput {
   export function isa(o: any): o is CreateCachediSCSIVolumeInput {
-    return _smithy.isa(o, "CreateCachediSCSIVolumeInput");
+    return __isa(o, "CreateCachediSCSIVolumeInput");
   }
 }
 
@@ -1681,7 +1684,7 @@ export interface CreateCachediSCSIVolumeOutput extends $MetadataBearer {
 
 export namespace CreateCachediSCSIVolumeOutput {
   export function isa(o: any): o is CreateCachediSCSIVolumeOutput {
-    return _smithy.isa(o, "CreateCachediSCSIVolumeOutput");
+    return __isa(o, "CreateCachediSCSIVolumeOutput");
   }
 }
 
@@ -1709,7 +1712,7 @@ export namespace CreateSnapshotFromVolumeRecoveryPointOutput {
   export function isa(
     o: any
   ): o is CreateSnapshotFromVolumeRecoveryPointOutput {
-    return _smithy.isa(o, "CreateSnapshotFromVolumeRecoveryPointOutput");
+    return __isa(o, "CreateSnapshotFromVolumeRecoveryPointOutput");
   }
 }
 
@@ -1723,7 +1726,7 @@ export interface DeleteSnapshotScheduleInput {
 
 export namespace DeleteSnapshotScheduleInput {
   export function isa(o: any): o is DeleteSnapshotScheduleInput {
-    return _smithy.isa(o, "DeleteSnapshotScheduleInput");
+    return __isa(o, "DeleteSnapshotScheduleInput");
   }
 }
 
@@ -1737,7 +1740,7 @@ export interface DeleteSnapshotScheduleOutput extends $MetadataBearer {
 
 export namespace DeleteSnapshotScheduleOutput {
   export function isa(o: any): o is DeleteSnapshotScheduleOutput {
-    return _smithy.isa(o, "DeleteSnapshotScheduleOutput");
+    return __isa(o, "DeleteSnapshotScheduleOutput");
   }
 }
 
@@ -1752,7 +1755,7 @@ export interface DescribeCacheInput {
 
 export namespace DescribeCacheInput {
   export function isa(o: any): o is DescribeCacheInput {
-    return _smithy.isa(o, "DescribeCacheInput");
+    return __isa(o, "DescribeCacheInput");
   }
 }
 
@@ -1803,7 +1806,7 @@ export interface DescribeCacheOutput extends $MetadataBearer {
 
 export namespace DescribeCacheOutput {
   export function isa(o: any): o is DescribeCacheOutput {
-    return _smithy.isa(o, "DescribeCacheOutput");
+    return __isa(o, "DescribeCacheOutput");
   }
 }
 
@@ -1818,7 +1821,7 @@ export interface DescribeCachediSCSIVolumesInput {
 
 export namespace DescribeCachediSCSIVolumesInput {
   export function isa(o: any): o is DescribeCachediSCSIVolumesInput {
-    return _smithy.isa(o, "DescribeCachediSCSIVolumesInput");
+    return __isa(o, "DescribeCachediSCSIVolumesInput");
   }
 }
 
@@ -1833,7 +1836,7 @@ export interface DescribeUploadBufferInput {
 
 export namespace DescribeUploadBufferInput {
   export function isa(o: any): o is DescribeUploadBufferInput {
-    return _smithy.isa(o, "DescribeUploadBufferInput");
+    return __isa(o, "DescribeUploadBufferInput");
   }
 }
 
@@ -1866,7 +1869,7 @@ export interface DescribeUploadBufferOutput extends $MetadataBearer {
 
 export namespace DescribeUploadBufferOutput {
   export function isa(o: any): o is DescribeUploadBufferOutput {
-    return _smithy.isa(o, "DescribeUploadBufferOutput");
+    return __isa(o, "DescribeUploadBufferOutput");
   }
 }
 
@@ -1881,7 +1884,7 @@ export interface ListVolumeRecoveryPointsInput {
 
 export namespace ListVolumeRecoveryPointsInput {
   export function isa(o: any): o is ListVolumeRecoveryPointsInput {
-    return _smithy.isa(o, "ListVolumeRecoveryPointsInput");
+    return __isa(o, "ListVolumeRecoveryPointsInput");
   }
 }
 
@@ -1901,7 +1904,7 @@ export interface ListVolumeRecoveryPointsOutput extends $MetadataBearer {
 
 export namespace ListVolumeRecoveryPointsOutput {
   export function isa(o: any): o is ListVolumeRecoveryPointsOutput {
-    return _smithy.isa(o, "ListVolumeRecoveryPointsOutput");
+    return __isa(o, "ListVolumeRecoveryPointsOutput");
   }
 }
 
@@ -1937,7 +1940,7 @@ export interface VolumeRecoveryPointInfo {
 
 export namespace VolumeRecoveryPointInfo {
   export function isa(o: any): o is VolumeRecoveryPointInfo {
-    return _smithy.isa(o, "VolumeRecoveryPointInfo");
+    return __isa(o, "VolumeRecoveryPointInfo");
   }
 }
 
@@ -2062,7 +2065,7 @@ export interface ActivateGatewayInput {
 
 export namespace ActivateGatewayInput {
   export function isa(o: any): o is ActivateGatewayInput {
-    return _smithy.isa(o, "ActivateGatewayInput");
+    return __isa(o, "ActivateGatewayInput");
   }
 }
 
@@ -2100,7 +2103,7 @@ export interface AddTagsToResourceInput {
 
 export namespace AddTagsToResourceInput {
   export function isa(o: any): o is AddTagsToResourceInput {
-    return _smithy.isa(o, "AddTagsToResourceInput");
+    return __isa(o, "AddTagsToResourceInput");
   }
 }
 
@@ -2117,7 +2120,7 @@ export interface AddTagsToResourceOutput extends $MetadataBearer {
 
 export namespace AddTagsToResourceOutput {
   export function isa(o: any): o is AddTagsToResourceOutput {
-    return _smithy.isa(o, "AddTagsToResourceOutput");
+    return __isa(o, "AddTagsToResourceOutput");
   }
 }
 
@@ -2139,7 +2142,7 @@ export interface AssignTapePoolInput {
 
 export namespace AssignTapePoolInput {
   export function isa(o: any): o is AssignTapePoolInput {
-    return _smithy.isa(o, "AssignTapePoolInput");
+    return __isa(o, "AssignTapePoolInput");
   }
 }
 
@@ -2154,7 +2157,7 @@ export interface AssignTapePoolOutput extends $MetadataBearer {
 
 export namespace AssignTapePoolOutput {
   export function isa(o: any): o is AssignTapePoolOutput {
-    return _smithy.isa(o, "AssignTapePoolOutput");
+    return __isa(o, "AssignTapePoolOutput");
   }
 }
 
@@ -2204,7 +2207,7 @@ export interface AttachVolumeInput {
 
 export namespace AttachVolumeInput {
   export function isa(o: any): o is AttachVolumeInput {
-    return _smithy.isa(o, "AttachVolumeInput");
+    return __isa(o, "AttachVolumeInput");
   }
 }
 
@@ -2228,7 +2231,7 @@ export interface AttachVolumeOutput extends $MetadataBearer {
 
 export namespace AttachVolumeOutput {
   export function isa(o: any): o is AttachVolumeOutput {
-    return _smithy.isa(o, "AttachVolumeOutput");
+    return __isa(o, "AttachVolumeOutput");
   }
 }
 
@@ -2332,7 +2335,7 @@ export interface CachediSCSIVolume {
 
 export namespace CachediSCSIVolume {
   export function isa(o: any): o is CachediSCSIVolume {
-    return _smithy.isa(o, "CachediSCSIVolume");
+    return __isa(o, "CachediSCSIVolume");
   }
 }
 
@@ -2356,7 +2359,7 @@ export interface CancelArchivalInput {
 
 export namespace CancelArchivalInput {
   export function isa(o: any): o is CancelArchivalInput {
-    return _smithy.isa(o, "CancelArchivalInput");
+    return __isa(o, "CancelArchivalInput");
   }
 }
 
@@ -2374,7 +2377,7 @@ export interface CancelArchivalOutput extends $MetadataBearer {
 
 export namespace CancelArchivalOutput {
   export function isa(o: any): o is CancelArchivalOutput {
-    return _smithy.isa(o, "CancelArchivalOutput");
+    return __isa(o, "CancelArchivalOutput");
   }
 }
 
@@ -2398,7 +2401,7 @@ export interface CancelRetrievalInput {
 
 export namespace CancelRetrievalInput {
   export function isa(o: any): o is CancelRetrievalInput {
-    return _smithy.isa(o, "CancelRetrievalInput");
+    return __isa(o, "CancelRetrievalInput");
   }
 }
 
@@ -2416,7 +2419,7 @@ export interface CancelRetrievalOutput extends $MetadataBearer {
 
 export namespace CancelRetrievalOutput {
   export function isa(o: any): o is CancelRetrievalOutput {
-    return _smithy.isa(o, "CancelRetrievalOutput");
+    return __isa(o, "CancelRetrievalOutput");
   }
 }
 
@@ -2543,7 +2546,7 @@ export interface CreateNFSFileShareInput {
 
 export namespace CreateNFSFileShareInput {
   export function isa(o: any): o is CreateNFSFileShareInput {
-    return _smithy.isa(o, "CreateNFSFileShareInput");
+    return __isa(o, "CreateNFSFileShareInput");
   }
 }
 
@@ -2560,7 +2563,7 @@ export interface CreateNFSFileShareOutput extends $MetadataBearer {
 
 export namespace CreateNFSFileShareOutput {
   export function isa(o: any): o is CreateNFSFileShareOutput {
-    return _smithy.isa(o, "CreateNFSFileShareOutput");
+    return __isa(o, "CreateNFSFileShareOutput");
   }
 }
 
@@ -2700,7 +2703,7 @@ export interface CreateSMBFileShareInput {
 
 export namespace CreateSMBFileShareInput {
   export function isa(o: any): o is CreateSMBFileShareInput {
-    return _smithy.isa(o, "CreateSMBFileShareInput");
+    return __isa(o, "CreateSMBFileShareInput");
   }
 }
 
@@ -2717,7 +2720,7 @@ export interface CreateSMBFileShareOutput extends $MetadataBearer {
 
 export namespace CreateSMBFileShareOutput {
   export function isa(o: any): o is CreateSMBFileShareOutput {
-    return _smithy.isa(o, "CreateSMBFileShareOutput");
+    return __isa(o, "CreateSMBFileShareOutput");
   }
 }
 
@@ -2751,7 +2754,7 @@ export interface CreateSnapshotFromVolumeRecoveryPointInput {
 
 export namespace CreateSnapshotFromVolumeRecoveryPointInput {
   export function isa(o: any): o is CreateSnapshotFromVolumeRecoveryPointInput {
-    return _smithy.isa(o, "CreateSnapshotFromVolumeRecoveryPointInput");
+    return __isa(o, "CreateSnapshotFromVolumeRecoveryPointInput");
   }
 }
 
@@ -2818,7 +2821,7 @@ export interface CreateTapeWithBarcodeInput {
 
 export namespace CreateTapeWithBarcodeInput {
   export function isa(o: any): o is CreateTapeWithBarcodeInput {
-    return _smithy.isa(o, "CreateTapeWithBarcodeInput");
+    return __isa(o, "CreateTapeWithBarcodeInput");
   }
 }
 
@@ -2836,7 +2839,7 @@ export interface CreateTapeWithBarcodeOutput extends $MetadataBearer {
 
 export namespace CreateTapeWithBarcodeOutput {
   export function isa(o: any): o is CreateTapeWithBarcodeOutput {
-    return _smithy.isa(o, "CreateTapeWithBarcodeOutput");
+    return __isa(o, "CreateTapeWithBarcodeOutput");
   }
 }
 
@@ -2919,7 +2922,7 @@ export interface CreateTapesInput {
 
 export namespace CreateTapesInput {
   export function isa(o: any): o is CreateTapesInput {
-    return _smithy.isa(o, "CreateTapesInput");
+    return __isa(o, "CreateTapesInput");
   }
 }
 
@@ -2937,7 +2940,7 @@ export interface CreateTapesOutput extends $MetadataBearer {
 
 export namespace CreateTapesOutput {
   export function isa(o: any): o is CreateTapesOutput {
-    return _smithy.isa(o, "CreateTapesOutput");
+    return __isa(o, "CreateTapesOutput");
   }
 }
 
@@ -2969,7 +2972,7 @@ export interface DeleteBandwidthRateLimitInput {
 
 export namespace DeleteBandwidthRateLimitInput {
   export function isa(o: any): o is DeleteBandwidthRateLimitInput {
-    return _smithy.isa(o, "DeleteBandwidthRateLimitInput");
+    return __isa(o, "DeleteBandwidthRateLimitInput");
   }
 }
 
@@ -2994,7 +2997,7 @@ export interface DeleteFileShareInput {
 
 export namespace DeleteFileShareInput {
   export function isa(o: any): o is DeleteFileShareInput {
-    return _smithy.isa(o, "DeleteFileShareInput");
+    return __isa(o, "DeleteFileShareInput");
   }
 }
 
@@ -3011,7 +3014,7 @@ export interface DeleteFileShareOutput extends $MetadataBearer {
 
 export namespace DeleteFileShareOutput {
   export function isa(o: any): o is DeleteFileShareOutput {
-    return _smithy.isa(o, "DeleteFileShareOutput");
+    return __isa(o, "DeleteFileShareOutput");
   }
 }
 
@@ -3029,7 +3032,7 @@ export interface DeleteTapeArchiveInput {
 
 export namespace DeleteTapeArchiveInput {
   export function isa(o: any): o is DeleteTapeArchiveInput {
-    return _smithy.isa(o, "DeleteTapeArchiveInput");
+    return __isa(o, "DeleteTapeArchiveInput");
   }
 }
 
@@ -3047,7 +3050,7 @@ export interface DeleteTapeArchiveOutput extends $MetadataBearer {
 
 export namespace DeleteTapeArchiveOutput {
   export function isa(o: any): o is DeleteTapeArchiveOutput {
-    return _smithy.isa(o, "DeleteTapeArchiveOutput");
+    return __isa(o, "DeleteTapeArchiveOutput");
   }
 }
 
@@ -3071,7 +3074,7 @@ export interface DeleteTapeInput {
 
 export namespace DeleteTapeInput {
   export function isa(o: any): o is DeleteTapeInput {
-    return _smithy.isa(o, "DeleteTapeInput");
+    return __isa(o, "DeleteTapeInput");
   }
 }
 
@@ -3088,7 +3091,7 @@ export interface DeleteTapeOutput extends $MetadataBearer {
 
 export namespace DeleteTapeOutput {
   export function isa(o: any): o is DeleteTapeOutput {
-    return _smithy.isa(o, "DeleteTapeOutput");
+    return __isa(o, "DeleteTapeOutput");
   }
 }
 
@@ -3103,7 +3106,7 @@ export interface DescribeAvailabilityMonitorTestInput {
 
 export namespace DescribeAvailabilityMonitorTestInput {
   export function isa(o: any): o is DescribeAvailabilityMonitorTestInput {
-    return _smithy.isa(o, "DescribeAvailabilityMonitorTestInput");
+    return __isa(o, "DescribeAvailabilityMonitorTestInput");
   }
 }
 
@@ -3130,7 +3133,7 @@ export interface DescribeAvailabilityMonitorTestOutput extends $MetadataBearer {
 
 export namespace DescribeAvailabilityMonitorTestOutput {
   export function isa(o: any): o is DescribeAvailabilityMonitorTestOutput {
-    return _smithy.isa(o, "DescribeAvailabilityMonitorTestOutput");
+    return __isa(o, "DescribeAvailabilityMonitorTestOutput");
   }
 }
 
@@ -3148,7 +3151,7 @@ export interface DescribeCachediSCSIVolumesOutput extends $MetadataBearer {
 
 export namespace DescribeCachediSCSIVolumesOutput {
   export function isa(o: any): o is DescribeCachediSCSIVolumesOutput {
-    return _smithy.isa(o, "DescribeCachediSCSIVolumesOutput");
+    return __isa(o, "DescribeCachediSCSIVolumesOutput");
   }
 }
 
@@ -3245,7 +3248,7 @@ export interface DescribeGatewayInformationOutput extends $MetadataBearer {
 
 export namespace DescribeGatewayInformationOutput {
   export function isa(o: any): o is DescribeGatewayInformationOutput {
-    return _smithy.isa(o, "DescribeGatewayInformationOutput");
+    return __isa(o, "DescribeGatewayInformationOutput");
   }
 }
 
@@ -3327,7 +3330,7 @@ export interface DescribeMaintenanceStartTimeOutput extends $MetadataBearer {
 
 export namespace DescribeMaintenanceStartTimeOutput {
   export function isa(o: any): o is DescribeMaintenanceStartTimeOutput {
-    return _smithy.isa(o, "DescribeMaintenanceStartTimeOutput");
+    return __isa(o, "DescribeMaintenanceStartTimeOutput");
   }
 }
 
@@ -3345,7 +3348,7 @@ export interface DescribeNFSFileSharesInput {
 
 export namespace DescribeNFSFileSharesInput {
   export function isa(o: any): o is DescribeNFSFileSharesInput {
-    return _smithy.isa(o, "DescribeNFSFileSharesInput");
+    return __isa(o, "DescribeNFSFileSharesInput");
   }
 }
 
@@ -3362,7 +3365,7 @@ export interface DescribeNFSFileSharesOutput extends $MetadataBearer {
 
 export namespace DescribeNFSFileSharesOutput {
   export function isa(o: any): o is DescribeNFSFileSharesOutput {
-    return _smithy.isa(o, "DescribeNFSFileSharesOutput");
+    return __isa(o, "DescribeNFSFileSharesOutput");
   }
 }
 
@@ -3380,7 +3383,7 @@ export interface DescribeSMBFileSharesInput {
 
 export namespace DescribeSMBFileSharesInput {
   export function isa(o: any): o is DescribeSMBFileSharesInput {
-    return _smithy.isa(o, "DescribeSMBFileSharesInput");
+    return __isa(o, "DescribeSMBFileSharesInput");
   }
 }
 
@@ -3397,7 +3400,7 @@ export interface DescribeSMBFileSharesOutput extends $MetadataBearer {
 
 export namespace DescribeSMBFileSharesOutput {
   export function isa(o: any): o is DescribeSMBFileSharesOutput {
-    return _smithy.isa(o, "DescribeSMBFileSharesOutput");
+    return __isa(o, "DescribeSMBFileSharesOutput");
   }
 }
 
@@ -3412,7 +3415,7 @@ export interface DescribeSMBSettingsInput {
 
 export namespace DescribeSMBSettingsInput {
   export function isa(o: any): o is DescribeSMBSettingsInput {
-    return _smithy.isa(o, "DescribeSMBSettingsInput");
+    return __isa(o, "DescribeSMBSettingsInput");
   }
 }
 
@@ -3486,7 +3489,7 @@ export interface DescribeSMBSettingsOutput extends $MetadataBearer {
 
 export namespace DescribeSMBSettingsOutput {
   export function isa(o: any): o is DescribeSMBSettingsOutput {
-    return _smithy.isa(o, "DescribeSMBSettingsOutput");
+    return __isa(o, "DescribeSMBSettingsOutput");
   }
 }
 
@@ -3530,7 +3533,7 @@ export interface DescribeSnapshotScheduleOutput extends $MetadataBearer {
 
 export namespace DescribeSnapshotScheduleOutput {
   export function isa(o: any): o is DescribeSnapshotScheduleOutput {
-    return _smithy.isa(o, "DescribeSnapshotScheduleOutput");
+    return __isa(o, "DescribeSnapshotScheduleOutput");
   }
 }
 
@@ -3645,7 +3648,7 @@ export interface DescribeStorediSCSIVolumesOutput extends $MetadataBearer {
 
 export namespace DescribeStorediSCSIVolumesOutput {
   export function isa(o: any): o is DescribeStorediSCSIVolumesOutput {
-    return _smithy.isa(o, "DescribeStorediSCSIVolumesOutput");
+    return __isa(o, "DescribeStorediSCSIVolumesOutput");
   }
 }
 
@@ -3675,7 +3678,7 @@ export interface DescribeTapeArchivesInput {
 
 export namespace DescribeTapeArchivesInput {
   export function isa(o: any): o is DescribeTapeArchivesInput {
-    return _smithy.isa(o, "DescribeTapeArchivesInput");
+    return __isa(o, "DescribeTapeArchivesInput");
   }
 }
 
@@ -3703,7 +3706,7 @@ export interface DescribeTapeArchivesOutput extends $MetadataBearer {
 
 export namespace DescribeTapeArchivesOutput {
   export function isa(o: any): o is DescribeTapeArchivesOutput {
-    return _smithy.isa(o, "DescribeTapeArchivesOutput");
+    return __isa(o, "DescribeTapeArchivesOutput");
   }
 }
 
@@ -3733,7 +3736,7 @@ export interface DescribeTapeRecoveryPointsInput {
 
 export namespace DescribeTapeRecoveryPointsInput {
   export function isa(o: any): o is DescribeTapeRecoveryPointsInput {
-    return _smithy.isa(o, "DescribeTapeRecoveryPointsInput");
+    return __isa(o, "DescribeTapeRecoveryPointsInput");
   }
 }
 
@@ -3766,7 +3769,7 @@ export interface DescribeTapeRecoveryPointsOutput extends $MetadataBearer {
 
 export namespace DescribeTapeRecoveryPointsOutput {
   export function isa(o: any): o is DescribeTapeRecoveryPointsOutput {
-    return _smithy.isa(o, "DescribeTapeRecoveryPointsOutput");
+    return __isa(o, "DescribeTapeRecoveryPointsOutput");
   }
 }
 
@@ -3807,7 +3810,7 @@ export interface DescribeTapesInput {
 
 export namespace DescribeTapesInput {
   export function isa(o: any): o is DescribeTapesInput {
-    return _smithy.isa(o, "DescribeTapesInput");
+    return __isa(o, "DescribeTapesInput");
   }
 }
 
@@ -3832,7 +3835,7 @@ export interface DescribeTapesOutput extends $MetadataBearer {
 
 export namespace DescribeTapesOutput {
   export function isa(o: any): o is DescribeTapesOutput {
-    return _smithy.isa(o, "DescribeTapesOutput");
+    return __isa(o, "DescribeTapesOutput");
   }
 }
 
@@ -3872,7 +3875,7 @@ export interface DescribeVTLDevicesInput {
 
 export namespace DescribeVTLDevicesInput {
   export function isa(o: any): o is DescribeVTLDevicesInput {
-    return _smithy.isa(o, "DescribeVTLDevicesInput");
+    return __isa(o, "DescribeVTLDevicesInput");
   }
 }
 
@@ -3904,7 +3907,7 @@ export interface DescribeVTLDevicesOutput extends $MetadataBearer {
 
 export namespace DescribeVTLDevicesOutput {
   export function isa(o: any): o is DescribeVTLDevicesOutput {
-    return _smithy.isa(o, "DescribeVTLDevicesOutput");
+    return __isa(o, "DescribeVTLDevicesOutput");
   }
 }
 
@@ -3929,7 +3932,7 @@ export interface DetachVolumeInput {
 
 export namespace DetachVolumeInput {
   export function isa(o: any): o is DetachVolumeInput {
-    return _smithy.isa(o, "DetachVolumeInput");
+    return __isa(o, "DetachVolumeInput");
   }
 }
 
@@ -3946,7 +3949,7 @@ export interface DetachVolumeOutput extends $MetadataBearer {
 
 export namespace DetachVolumeOutput {
   export function isa(o: any): o is DetachVolumeOutput {
-    return _smithy.isa(o, "DetachVolumeOutput");
+    return __isa(o, "DetachVolumeOutput");
   }
 }
 
@@ -3979,7 +3982,7 @@ export interface DeviceiSCSIAttributes {
 
 export namespace DeviceiSCSIAttributes {
   export function isa(o: any): o is DeviceiSCSIAttributes {
-    return _smithy.isa(o, "DeviceiSCSIAttributes");
+    return __isa(o, "DeviceiSCSIAttributes");
   }
 }
 
@@ -3997,7 +4000,7 @@ export interface DisableGatewayInput {
 
 export namespace DisableGatewayInput {
   export function isa(o: any): o is DisableGatewayInput {
-    return _smithy.isa(o, "DisableGatewayInput");
+    return __isa(o, "DisableGatewayInput");
   }
 }
 
@@ -4014,7 +4017,7 @@ export interface DisableGatewayOutput extends $MetadataBearer {
 
 export namespace DisableGatewayOutput {
   export function isa(o: any): o is DisableGatewayOutput {
-    return _smithy.isa(o, "DisableGatewayOutput");
+    return __isa(o, "DisableGatewayOutput");
   }
 }
 
@@ -4073,7 +4076,7 @@ export interface Disk {
 
 export namespace Disk {
   export function isa(o: any): o is Disk {
-    return _smithy.isa(o, "Disk");
+    return __isa(o, "Disk");
   }
 }
 
@@ -4112,7 +4115,7 @@ export interface FileShareInfo {
 
 export namespace FileShareInfo {
   export function isa(o: any): o is FileShareInfo {
-    return _smithy.isa(o, "FileShareInfo");
+    return __isa(o, "FileShareInfo");
   }
 }
 
@@ -4165,7 +4168,7 @@ export interface GatewayInfo {
 
 export namespace GatewayInfo {
   export function isa(o: any): o is GatewayInfo {
-    return _smithy.isa(o, "GatewayInfo");
+    return __isa(o, "GatewayInfo");
   }
 }
 
@@ -4223,7 +4226,7 @@ export interface JoinDomainInput {
 
 export namespace JoinDomainInput {
   export function isa(o: any): o is JoinDomainInput {
-    return _smithy.isa(o, "JoinDomainInput");
+    return __isa(o, "JoinDomainInput");
   }
 }
 
@@ -4273,7 +4276,7 @@ export interface JoinDomainOutput extends $MetadataBearer {
 
 export namespace JoinDomainOutput {
   export function isa(o: any): o is JoinDomainOutput {
-    return _smithy.isa(o, "JoinDomainOutput");
+    return __isa(o, "JoinDomainOutput");
   }
 }
 
@@ -4304,7 +4307,7 @@ export interface ListFileSharesInput {
 
 export namespace ListFileSharesInput {
   export function isa(o: any): o is ListFileSharesInput {
-    return _smithy.isa(o, "ListFileSharesInput");
+    return __isa(o, "ListFileSharesInput");
   }
 }
 
@@ -4334,7 +4337,7 @@ export interface ListFileSharesOutput extends $MetadataBearer {
 
 export namespace ListFileSharesOutput {
   export function isa(o: any): o is ListFileSharesOutput {
-    return _smithy.isa(o, "ListFileSharesOutput");
+    return __isa(o, "ListFileSharesOutput");
   }
 }
 
@@ -4354,7 +4357,7 @@ export interface ListGatewaysOutput extends $MetadataBearer {
 
 export namespace ListGatewaysOutput {
   export function isa(o: any): o is ListGatewaysOutput {
-    return _smithy.isa(o, "ListGatewaysOutput");
+    return __isa(o, "ListGatewaysOutput");
   }
 }
 
@@ -4381,7 +4384,7 @@ export interface ListLocalDisksOutput extends $MetadataBearer {
 
 export namespace ListLocalDisksOutput {
   export function isa(o: any): o is ListLocalDisksOutput {
-    return _smithy.isa(o, "ListLocalDisksOutput");
+    return __isa(o, "ListLocalDisksOutput");
   }
 }
 
@@ -4411,7 +4414,7 @@ export interface ListTagsForResourceInput {
 
 export namespace ListTagsForResourceInput {
   export function isa(o: any): o is ListTagsForResourceInput {
-    return _smithy.isa(o, "ListTagsForResourceInput");
+    return __isa(o, "ListTagsForResourceInput");
   }
 }
 
@@ -4440,7 +4443,7 @@ export interface ListTagsForResourceOutput extends $MetadataBearer {
 
 export namespace ListTagsForResourceOutput {
   export function isa(o: any): o is ListTagsForResourceOutput {
-    return _smithy.isa(o, "ListTagsForResourceOutput");
+    return __isa(o, "ListTagsForResourceOutput");
   }
 }
 
@@ -4486,7 +4489,7 @@ export interface ListTapesInput {
 
 export namespace ListTapesInput {
   export function isa(o: any): o is ListTapesInput {
-    return _smithy.isa(o, "ListTapesInput");
+    return __isa(o, "ListTapesInput");
   }
 }
 
@@ -4524,7 +4527,7 @@ export interface ListTapesOutput extends $MetadataBearer {
 
 export namespace ListTapesOutput {
   export function isa(o: any): o is ListTapesOutput {
-    return _smithy.isa(o, "ListTapesOutput");
+    return __isa(o, "ListTapesOutput");
   }
 }
 
@@ -4542,7 +4545,7 @@ export interface ListVolumeInitiatorsInput {
 
 export namespace ListVolumeInitiatorsInput {
   export function isa(o: any): o is ListVolumeInitiatorsInput {
-    return _smithy.isa(o, "ListVolumeInitiatorsInput");
+    return __isa(o, "ListVolumeInitiatorsInput");
   }
 }
 
@@ -4560,7 +4563,7 @@ export interface ListVolumeInitiatorsOutput extends $MetadataBearer {
 
 export namespace ListVolumeInitiatorsOutput {
   export function isa(o: any): o is ListVolumeInitiatorsOutput {
-    return _smithy.isa(o, "ListVolumeInitiatorsOutput");
+    return __isa(o, "ListVolumeInitiatorsOutput");
   }
 }
 
@@ -4603,7 +4606,7 @@ export interface ListVolumesOutput extends $MetadataBearer {
 
 export namespace ListVolumesOutput {
   export function isa(o: any): o is ListVolumesOutput {
-    return _smithy.isa(o, "ListVolumesOutput");
+    return __isa(o, "ListVolumesOutput");
   }
 }
 
@@ -4644,7 +4647,7 @@ export interface NFSFileShareDefaults {
 
 export namespace NFSFileShareDefaults {
   export function isa(o: any): o is NFSFileShareDefaults {
-    return _smithy.isa(o, "NFSFileShareDefaults");
+    return __isa(o, "NFSFileShareDefaults");
   }
 }
 
@@ -4789,7 +4792,7 @@ export interface NFSFileShareInfo {
 
 export namespace NFSFileShareInfo {
   export function isa(o: any): o is NFSFileShareInfo {
-    return _smithy.isa(o, "NFSFileShareInfo");
+    return __isa(o, "NFSFileShareInfo");
   }
 }
 
@@ -4803,7 +4806,7 @@ export interface NotifyWhenUploadedInput {
 
 export namespace NotifyWhenUploadedInput {
   export function isa(o: any): o is NotifyWhenUploadedInput {
-    return _smithy.isa(o, "NotifyWhenUploadedInput");
+    return __isa(o, "NotifyWhenUploadedInput");
   }
 }
 
@@ -4823,7 +4826,7 @@ export interface NotifyWhenUploadedOutput extends $MetadataBearer {
 
 export namespace NotifyWhenUploadedOutput {
   export function isa(o: any): o is NotifyWhenUploadedOutput {
-    return _smithy.isa(o, "NotifyWhenUploadedOutput");
+    return __isa(o, "NotifyWhenUploadedOutput");
   }
 }
 
@@ -4868,7 +4871,7 @@ export interface RefreshCacheInput {
 
 export namespace RefreshCacheInput {
   export function isa(o: any): o is RefreshCacheInput {
-    return _smithy.isa(o, "RefreshCacheInput");
+    return __isa(o, "RefreshCacheInput");
   }
 }
 
@@ -4891,7 +4894,7 @@ export interface RefreshCacheOutput extends $MetadataBearer {
 
 export namespace RefreshCacheOutput {
   export function isa(o: any): o is RefreshCacheOutput {
-    return _smithy.isa(o, "RefreshCacheOutput");
+    return __isa(o, "RefreshCacheOutput");
   }
 }
 
@@ -4915,7 +4918,7 @@ export interface RemoveTagsFromResourceInput {
 
 export namespace RemoveTagsFromResourceInput {
   export function isa(o: any): o is RemoveTagsFromResourceInput {
-    return _smithy.isa(o, "RemoveTagsFromResourceInput");
+    return __isa(o, "RemoveTagsFromResourceInput");
   }
 }
 
@@ -4933,7 +4936,7 @@ export interface RemoveTagsFromResourceOutput extends $MetadataBearer {
 
 export namespace RemoveTagsFromResourceOutput {
   export function isa(o: any): o is RemoveTagsFromResourceOutput {
-    return _smithy.isa(o, "RemoveTagsFromResourceOutput");
+    return __isa(o, "RemoveTagsFromResourceOutput");
   }
 }
 
@@ -4948,7 +4951,7 @@ export interface ResetCacheInput {
 
 export namespace ResetCacheInput {
   export function isa(o: any): o is ResetCacheInput {
-    return _smithy.isa(o, "ResetCacheInput");
+    return __isa(o, "ResetCacheInput");
   }
 }
 
@@ -4963,7 +4966,7 @@ export interface ResetCacheOutput extends $MetadataBearer {
 
 export namespace ResetCacheOutput {
   export function isa(o: any): o is ResetCacheOutput {
-    return _smithy.isa(o, "ResetCacheOutput");
+    return __isa(o, "ResetCacheOutput");
   }
 }
 
@@ -4990,7 +4993,7 @@ export interface RetrieveTapeArchiveInput {
 
 export namespace RetrieveTapeArchiveInput {
   export function isa(o: any): o is RetrieveTapeArchiveInput {
-    return _smithy.isa(o, "RetrieveTapeArchiveInput");
+    return __isa(o, "RetrieveTapeArchiveInput");
   }
 }
 
@@ -5007,7 +5010,7 @@ export interface RetrieveTapeArchiveOutput extends $MetadataBearer {
 
 export namespace RetrieveTapeArchiveOutput {
   export function isa(o: any): o is RetrieveTapeArchiveOutput {
-    return _smithy.isa(o, "RetrieveTapeArchiveOutput");
+    return __isa(o, "RetrieveTapeArchiveOutput");
   }
 }
 
@@ -5031,7 +5034,7 @@ export interface RetrieveTapeRecoveryPointInput {
 
 export namespace RetrieveTapeRecoveryPointInput {
   export function isa(o: any): o is RetrieveTapeRecoveryPointInput {
-    return _smithy.isa(o, "RetrieveTapeRecoveryPointInput");
+    return __isa(o, "RetrieveTapeRecoveryPointInput");
   }
 }
 
@@ -5049,7 +5052,7 @@ export interface RetrieveTapeRecoveryPointOutput extends $MetadataBearer {
 
 export namespace RetrieveTapeRecoveryPointOutput {
   export function isa(o: any): o is RetrieveTapeRecoveryPointOutput {
-    return _smithy.isa(o, "RetrieveTapeRecoveryPointOutput");
+    return __isa(o, "RetrieveTapeRecoveryPointOutput");
   }
 }
 
@@ -5200,7 +5203,7 @@ export interface SMBFileShareInfo {
 
 export namespace SMBFileShareInfo {
   export function isa(o: any): o is SMBFileShareInfo {
-    return _smithy.isa(o, "SMBFileShareInfo");
+    return __isa(o, "SMBFileShareInfo");
   }
 }
 
@@ -5228,7 +5231,7 @@ export interface SetLocalConsolePasswordInput {
 
 export namespace SetLocalConsolePasswordInput {
   export function isa(o: any): o is SetLocalConsolePasswordInput {
-    return _smithy.isa(o, "SetLocalConsolePasswordInput");
+    return __isa(o, "SetLocalConsolePasswordInput");
   }
 }
 
@@ -5243,7 +5246,7 @@ export interface SetLocalConsolePasswordOutput extends $MetadataBearer {
 
 export namespace SetLocalConsolePasswordOutput {
   export function isa(o: any): o is SetLocalConsolePasswordOutput {
-    return _smithy.isa(o, "SetLocalConsolePasswordOutput");
+    return __isa(o, "SetLocalConsolePasswordOutput");
   }
 }
 
@@ -5266,7 +5269,7 @@ export interface SetSMBGuestPasswordInput {
 
 export namespace SetSMBGuestPasswordInput {
   export function isa(o: any): o is SetSMBGuestPasswordInput {
-    return _smithy.isa(o, "SetSMBGuestPasswordInput");
+    return __isa(o, "SetSMBGuestPasswordInput");
   }
 }
 
@@ -5281,7 +5284,7 @@ export interface SetSMBGuestPasswordOutput extends $MetadataBearer {
 
 export namespace SetSMBGuestPasswordOutput {
   export function isa(o: any): o is SetSMBGuestPasswordOutput {
-    return _smithy.isa(o, "SetSMBGuestPasswordOutput");
+    return __isa(o, "SetSMBGuestPasswordOutput");
   }
 }
 
@@ -5296,7 +5299,7 @@ export interface StartAvailabilityMonitorTestInput {
 
 export namespace StartAvailabilityMonitorTestInput {
   export function isa(o: any): o is StartAvailabilityMonitorTestInput {
-    return _smithy.isa(o, "StartAvailabilityMonitorTestInput");
+    return __isa(o, "StartAvailabilityMonitorTestInput");
   }
 }
 
@@ -5311,7 +5314,7 @@ export interface StartAvailabilityMonitorTestOutput extends $MetadataBearer {
 
 export namespace StartAvailabilityMonitorTestOutput {
   export function isa(o: any): o is StartAvailabilityMonitorTestOutput {
-    return _smithy.isa(o, "StartAvailabilityMonitorTestOutput");
+    return __isa(o, "StartAvailabilityMonitorTestOutput");
   }
 }
 
@@ -5423,7 +5426,7 @@ export interface StorediSCSIVolume {
 
 export namespace StorediSCSIVolume {
   export function isa(o: any): o is StorediSCSIVolume {
-    return _smithy.isa(o, "StorediSCSIVolume");
+    return __isa(o, "StorediSCSIVolume");
   }
 }
 
@@ -5447,7 +5450,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -5518,7 +5521,7 @@ export interface Tape {
 
 export namespace Tape {
   export function isa(o: any): o is Tape {
-    return _smithy.isa(o, "Tape");
+    return __isa(o, "Tape");
   }
 }
 
@@ -5589,7 +5592,7 @@ export interface TapeArchive {
 
 export namespace TapeArchive {
   export function isa(o: any): o is TapeArchive {
-    return _smithy.isa(o, "TapeArchive");
+    return __isa(o, "TapeArchive");
   }
 }
 
@@ -5635,7 +5638,7 @@ export interface TapeInfo {
 
 export namespace TapeInfo {
   export function isa(o: any): o is TapeInfo {
-    return _smithy.isa(o, "TapeInfo");
+    return __isa(o, "TapeInfo");
   }
 }
 
@@ -5670,7 +5673,7 @@ export interface TapeRecoveryPointInfo {
 
 export namespace TapeRecoveryPointInfo {
   export function isa(o: any): o is TapeRecoveryPointInfo {
-    return _smithy.isa(o, "TapeRecoveryPointInfo");
+    return __isa(o, "TapeRecoveryPointInfo");
   }
 }
 
@@ -5701,7 +5704,7 @@ export interface UpdateGatewayInformationInput {
 
 export namespace UpdateGatewayInformationInput {
   export function isa(o: any): o is UpdateGatewayInformationInput {
-    return _smithy.isa(o, "UpdateGatewayInformationInput");
+    return __isa(o, "UpdateGatewayInformationInput");
   }
 }
 
@@ -5799,7 +5802,7 @@ export interface UpdateNFSFileShareInput {
 
 export namespace UpdateNFSFileShareInput {
   export function isa(o: any): o is UpdateNFSFileShareInput {
-    return _smithy.isa(o, "UpdateNFSFileShareInput");
+    return __isa(o, "UpdateNFSFileShareInput");
   }
 }
 
@@ -5816,7 +5819,7 @@ export interface UpdateNFSFileShareOutput extends $MetadataBearer {
 
 export namespace UpdateNFSFileShareOutput {
   export function isa(o: any): o is UpdateNFSFileShareOutput {
-    return _smithy.isa(o, "UpdateNFSFileShareOutput");
+    return __isa(o, "UpdateNFSFileShareOutput");
   }
 }
 
@@ -5918,7 +5921,7 @@ export interface UpdateSMBFileShareInput {
 
 export namespace UpdateSMBFileShareInput {
   export function isa(o: any): o is UpdateSMBFileShareInput {
-    return _smithy.isa(o, "UpdateSMBFileShareInput");
+    return __isa(o, "UpdateSMBFileShareInput");
   }
 }
 
@@ -5935,7 +5938,7 @@ export interface UpdateSMBFileShareOutput extends $MetadataBearer {
 
 export namespace UpdateSMBFileShareOutput {
   export function isa(o: any): o is UpdateSMBFileShareOutput {
-    return _smithy.isa(o, "UpdateSMBFileShareOutput");
+    return __isa(o, "UpdateSMBFileShareOutput");
   }
 }
 
@@ -5965,7 +5968,7 @@ export interface UpdateSMBSecurityStrategyInput {
 
 export namespace UpdateSMBSecurityStrategyInput {
   export function isa(o: any): o is UpdateSMBSecurityStrategyInput {
-    return _smithy.isa(o, "UpdateSMBSecurityStrategyInput");
+    return __isa(o, "UpdateSMBSecurityStrategyInput");
   }
 }
 
@@ -5980,7 +5983,7 @@ export interface UpdateSMBSecurityStrategyOutput extends $MetadataBearer {
 
 export namespace UpdateSMBSecurityStrategyOutput {
   export function isa(o: any): o is UpdateSMBSecurityStrategyOutput {
-    return _smithy.isa(o, "UpdateSMBSecurityStrategyOutput");
+    return __isa(o, "UpdateSMBSecurityStrategyOutput");
   }
 }
 
@@ -6000,7 +6003,7 @@ export interface UpdateVTLDeviceTypeInput {
 
 export namespace UpdateVTLDeviceTypeInput {
   export function isa(o: any): o is UpdateVTLDeviceTypeInput {
-    return _smithy.isa(o, "UpdateVTLDeviceTypeInput");
+    return __isa(o, "UpdateVTLDeviceTypeInput");
   }
 }
 
@@ -6017,7 +6020,7 @@ export interface UpdateVTLDeviceTypeOutput extends $MetadataBearer {
 
 export namespace UpdateVTLDeviceTypeOutput {
   export function isa(o: any): o is UpdateVTLDeviceTypeOutput {
-    return _smithy.isa(o, "UpdateVTLDeviceTypeOutput");
+    return __isa(o, "UpdateVTLDeviceTypeOutput");
   }
 }
 
@@ -6055,7 +6058,7 @@ export interface VTLDevice {
 
 export namespace VTLDevice {
   export function isa(o: any): o is VTLDevice {
-    return _smithy.isa(o, "VTLDevice");
+    return __isa(o, "VTLDevice");
   }
 }
 
@@ -6118,6 +6121,6 @@ export interface VolumeInfo {
 
 export namespace VolumeInfo {
   export function isa(o: any): o is VolumeInfo {
-    return _smithy.isa(o, "VolumeInfo");
+    return __isa(o, "VolumeInfo");
   }
 }

--- a/clients/client-sts/models/index.ts
+++ b/clients/client-sts/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export interface AssumeRoleRequest {
@@ -188,7 +191,7 @@ export interface AssumeRoleRequest {
 
 export namespace AssumeRoleRequest {
   export function isa(o: any): o is AssumeRoleRequest {
-    return _smithy.isa(o, "AssumeRoleRequest");
+    return __isa(o, "AssumeRoleRequest");
   }
 }
 
@@ -227,7 +230,7 @@ export interface AssumeRoleResponse extends $MetadataBearer {
 
 export namespace AssumeRoleResponse {
   export function isa(o: any): o is AssumeRoleResponse {
-    return _smithy.isa(o, "AssumeRoleResponse");
+    return __isa(o, "AssumeRoleResponse");
   }
 }
 
@@ -332,7 +335,7 @@ export interface AssumeRoleWithSAMLRequest {
 
 export namespace AssumeRoleWithSAMLRequest {
   export function isa(o: any): o is AssumeRoleWithSAMLRequest {
-    return _smithy.isa(o, "AssumeRoleWithSAMLRequest");
+    return __isa(o, "AssumeRoleWithSAMLRequest");
   }
 }
 
@@ -409,7 +412,7 @@ export interface AssumeRoleWithSAMLResponse extends $MetadataBearer {
 
 export namespace AssumeRoleWithSAMLResponse {
   export function isa(o: any): o is AssumeRoleWithSAMLResponse {
-    return _smithy.isa(o, "AssumeRoleWithSAMLResponse");
+    return __isa(o, "AssumeRoleWithSAMLResponse");
   }
 }
 
@@ -528,7 +531,7 @@ export interface AssumeRoleWithWebIdentityRequest {
 
 export namespace AssumeRoleWithWebIdentityRequest {
   export function isa(o: any): o is AssumeRoleWithWebIdentityRequest {
-    return _smithy.isa(o, "AssumeRoleWithWebIdentityRequest");
+    return __isa(o, "AssumeRoleWithWebIdentityRequest");
   }
 }
 
@@ -592,7 +595,7 @@ export interface AssumeRoleWithWebIdentityResponse extends $MetadataBearer {
 
 export namespace AssumeRoleWithWebIdentityResponse {
   export function isa(o: any): o is AssumeRoleWithWebIdentityResponse {
-    return _smithy.isa(o, "AssumeRoleWithWebIdentityResponse");
+    return __isa(o, "AssumeRoleWithWebIdentityResponse");
   }
 }
 
@@ -618,7 +621,7 @@ export interface AssumedRoleUser {
 
 export namespace AssumedRoleUser {
   export function isa(o: any): o is AssumedRoleUser {
-    return _smithy.isa(o, "AssumedRoleUser");
+    return __isa(o, "AssumedRoleUser");
   }
 }
 
@@ -651,7 +654,7 @@ export interface Credentials {
 
 export namespace Credentials {
   export function isa(o: any): o is Credentials {
-    return _smithy.isa(o, "Credentials");
+    return __isa(o, "Credentials");
   }
 }
 
@@ -665,7 +668,7 @@ export interface DecodeAuthorizationMessageRequest {
 
 export namespace DecodeAuthorizationMessageRequest {
   export function isa(o: any): o is DecodeAuthorizationMessageRequest {
-    return _smithy.isa(o, "DecodeAuthorizationMessageRequest");
+    return __isa(o, "DecodeAuthorizationMessageRequest");
   }
 }
 
@@ -683,7 +686,7 @@ export interface DecodeAuthorizationMessageResponse extends $MetadataBearer {
 
 export namespace DecodeAuthorizationMessageResponse {
   export function isa(o: any): o is DecodeAuthorizationMessageResponse {
-    return _smithy.isa(o, "DecodeAuthorizationMessageResponse");
+    return __isa(o, "DecodeAuthorizationMessageResponse");
   }
 }
 
@@ -692,7 +695,7 @@ export namespace DecodeAuthorizationMessageResponse {
  *             token from the identity provider and then retry the request.</p>
  */
 export interface ExpiredTokenException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ExpiredTokenException";
   $fault: "client";
@@ -701,7 +704,7 @@ export interface ExpiredTokenException
 
 export namespace ExpiredTokenException {
   export function isa(o: any): o is ExpiredTokenException {
-    return _smithy.isa(o, "ExpiredTokenException");
+    return __isa(o, "ExpiredTokenException");
   }
 }
 
@@ -726,7 +729,7 @@ export interface FederatedUser {
 
 export namespace FederatedUser {
   export function isa(o: any): o is FederatedUser {
-    return _smithy.isa(o, "FederatedUser");
+    return __isa(o, "FederatedUser");
   }
 }
 
@@ -742,7 +745,7 @@ export interface GetAccessKeyInfoRequest {
 
 export namespace GetAccessKeyInfoRequest {
   export function isa(o: any): o is GetAccessKeyInfoRequest {
-    return _smithy.isa(o, "GetAccessKeyInfoRequest");
+    return __isa(o, "GetAccessKeyInfoRequest");
   }
 }
 
@@ -756,7 +759,7 @@ export interface GetAccessKeyInfoResponse extends $MetadataBearer {
 
 export namespace GetAccessKeyInfoResponse {
   export function isa(o: any): o is GetAccessKeyInfoResponse {
-    return _smithy.isa(o, "GetAccessKeyInfoResponse");
+    return __isa(o, "GetAccessKeyInfoResponse");
   }
 }
 
@@ -766,7 +769,7 @@ export interface GetCallerIdentityRequest {
 
 export namespace GetCallerIdentityRequest {
   export function isa(o: any): o is GetCallerIdentityRequest {
-    return _smithy.isa(o, "GetCallerIdentityRequest");
+    return __isa(o, "GetCallerIdentityRequest");
   }
 }
 
@@ -798,7 +801,7 @@ export interface GetCallerIdentityResponse extends $MetadataBearer {
 
 export namespace GetCallerIdentityResponse {
   export function isa(o: any): o is GetCallerIdentityResponse {
-    return _smithy.isa(o, "GetCallerIdentityResponse");
+    return __isa(o, "GetCallerIdentityResponse");
   }
 }
 
@@ -926,7 +929,7 @@ export interface GetFederationTokenRequest {
 
 export namespace GetFederationTokenRequest {
   export function isa(o: any): o is GetFederationTokenRequest {
-    return _smithy.isa(o, "GetFederationTokenRequest");
+    return __isa(o, "GetFederationTokenRequest");
   }
 }
 
@@ -964,7 +967,7 @@ export interface GetFederationTokenResponse extends $MetadataBearer {
 
 export namespace GetFederationTokenResponse {
   export function isa(o: any): o is GetFederationTokenResponse {
-    return _smithy.isa(o, "GetFederationTokenResponse");
+    return __isa(o, "GetFederationTokenResponse");
   }
 }
 
@@ -1007,7 +1010,7 @@ export interface GetSessionTokenRequest {
 
 export namespace GetSessionTokenRequest {
   export function isa(o: any): o is GetSessionTokenRequest {
-    return _smithy.isa(o, "GetSessionTokenRequest");
+    return __isa(o, "GetSessionTokenRequest");
   }
 }
 
@@ -1030,7 +1033,7 @@ export interface GetSessionTokenResponse extends $MetadataBearer {
 
 export namespace GetSessionTokenResponse {
   export function isa(o: any): o is GetSessionTokenResponse {
-    return _smithy.isa(o, "GetSessionTokenResponse");
+    return __isa(o, "GetSessionTokenResponse");
   }
 }
 
@@ -1042,7 +1045,7 @@ export namespace GetSessionTokenResponse {
  *             identity provider might be down or not responding.</p>
  */
 export interface IDPCommunicationErrorException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "IDPCommunicationErrorException";
   $fault: "client";
@@ -1051,7 +1054,7 @@ export interface IDPCommunicationErrorException
 
 export namespace IDPCommunicationErrorException {
   export function isa(o: any): o is IDPCommunicationErrorException {
-    return _smithy.isa(o, "IDPCommunicationErrorException");
+    return __isa(o, "IDPCommunicationErrorException");
   }
 }
 
@@ -1062,7 +1065,7 @@ export namespace IDPCommunicationErrorException {
  *             can also mean that the claim has expired or has been explicitly revoked. </p>
  */
 export interface IDPRejectedClaimException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "IDPRejectedClaimException";
   $fault: "client";
@@ -1071,7 +1074,7 @@ export interface IDPRejectedClaimException
 
 export namespace IDPRejectedClaimException {
   export function isa(o: any): o is IDPRejectedClaimException {
-    return _smithy.isa(o, "IDPRejectedClaimException");
+    return __isa(o, "IDPRejectedClaimException");
   }
 }
 
@@ -1081,7 +1084,7 @@ export namespace IDPRejectedClaimException {
  *             linebreaks. </p>
  */
 export interface InvalidAuthorizationMessageException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidAuthorizationMessageException";
   $fault: "client";
@@ -1090,7 +1093,7 @@ export interface InvalidAuthorizationMessageException
 
 export namespace InvalidAuthorizationMessageException {
   export function isa(o: any): o is InvalidAuthorizationMessageException {
-    return _smithy.isa(o, "InvalidAuthorizationMessageException");
+    return __isa(o, "InvalidAuthorizationMessageException");
   }
 }
 
@@ -1099,7 +1102,7 @@ export namespace InvalidAuthorizationMessageException {
  *             identity token from the identity provider and then retry the request.</p>
  */
 export interface InvalidIdentityTokenException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidIdentityTokenException";
   $fault: "client";
@@ -1108,7 +1111,7 @@ export interface InvalidIdentityTokenException
 
 export namespace InvalidIdentityTokenException {
   export function isa(o: any): o is InvalidIdentityTokenException {
-    return _smithy.isa(o, "InvalidIdentityTokenException");
+    return __isa(o, "InvalidIdentityTokenException");
   }
 }
 
@@ -1117,7 +1120,7 @@ export namespace InvalidIdentityTokenException {
  *             describes the specific error.</p>
  */
 export interface MalformedPolicyDocumentException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "MalformedPolicyDocumentException";
   $fault: "client";
@@ -1126,7 +1129,7 @@ export interface MalformedPolicyDocumentException
 
 export namespace MalformedPolicyDocumentException {
   export function isa(o: any): o is MalformedPolicyDocumentException {
-    return _smithy.isa(o, "MalformedPolicyDocumentException");
+    return __isa(o, "MalformedPolicyDocumentException");
   }
 }
 
@@ -1142,7 +1145,7 @@ export namespace MalformedPolicyDocumentException {
  *                 Character Limits</a> in the <i>IAM User Guide</i>.</p>
  */
 export interface PackedPolicyTooLargeException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "PackedPolicyTooLargeException";
   $fault: "client";
@@ -1151,7 +1154,7 @@ export interface PackedPolicyTooLargeException
 
 export namespace PackedPolicyTooLargeException {
   export function isa(o: any): o is PackedPolicyTooLargeException {
-    return _smithy.isa(o, "PackedPolicyTooLargeException");
+    return __isa(o, "PackedPolicyTooLargeException");
   }
 }
 
@@ -1171,7 +1174,7 @@ export interface PolicyDescriptorType {
 
 export namespace PolicyDescriptorType {
   export function isa(o: any): o is PolicyDescriptorType {
-    return _smithy.isa(o, "PolicyDescriptorType");
+    return __isa(o, "PolicyDescriptorType");
   }
 }
 
@@ -1183,7 +1186,7 @@ export namespace PolicyDescriptorType {
  *                     Guide</i>.</p>
  */
 export interface RegionDisabledException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "RegionDisabledException";
   $fault: "client";
@@ -1192,7 +1195,7 @@ export interface RegionDisabledException
 
 export namespace RegionDisabledException {
   export function isa(o: any): o is RegionDisabledException {
-    return _smithy.isa(o, "RegionDisabledException");
+    return __isa(o, "RegionDisabledException");
   }
 }
 
@@ -1223,6 +1226,6 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }

--- a/clients/client-support/models/index.ts
+++ b/clients/client-support/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -20,7 +23,7 @@ export interface Attachment {
 
 export namespace Attachment {
   export function isa(o: any): o is Attachment {
-    return _smithy.isa(o, "Attachment");
+    return __isa(o, "Attachment");
   }
 }
 
@@ -44,7 +47,7 @@ export interface AttachmentDetails {
 
 export namespace AttachmentDetails {
   export function isa(o: any): o is AttachmentDetails {
-    return _smithy.isa(o, "AttachmentDetails");
+    return __isa(o, "AttachmentDetails");
   }
 }
 
@@ -200,7 +203,7 @@ export interface CaseDetails {
 
 export namespace CaseDetails {
   export function isa(o: any): o is CaseDetails {
-    return _smithy.isa(o, "CaseDetails");
+    return __isa(o, "CaseDetails");
   }
 }
 
@@ -224,7 +227,7 @@ export interface Category {
 
 export namespace Category {
   export function isa(o: any): o is Category {
-    return _smithy.isa(o, "Category");
+    return __isa(o, "Category");
   }
 }
 
@@ -270,7 +273,7 @@ export interface Communication {
 
 export namespace Communication {
   export function isa(o: any): o is Communication {
-    return _smithy.isa(o, "Communication");
+    return __isa(o, "Communication");
   }
 }
 
@@ -292,7 +295,7 @@ export interface RecentCaseCommunications {
 
 export namespace RecentCaseCommunications {
   export function isa(o: any): o is RecentCaseCommunications {
-    return _smithy.isa(o, "RecentCaseCommunications");
+    return __isa(o, "RecentCaseCommunications");
   }
 }
 
@@ -325,7 +328,7 @@ export interface Service {
 
 export namespace Service {
   export function isa(o: any): o is Service {
-    return _smithy.isa(o, "Service");
+    return __isa(o, "Service");
   }
 }
 
@@ -333,7 +336,7 @@ export namespace Service {
  * <p>An attachment with the specified ID could not be found.</p>
  */
 export interface AttachmentIdNotFound
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AttachmentIdNotFound";
   $fault: "client";
@@ -345,7 +348,7 @@ export interface AttachmentIdNotFound
 
 export namespace AttachmentIdNotFound {
   export function isa(o: any): o is AttachmentIdNotFound {
-    return _smithy.isa(o, "AttachmentIdNotFound");
+    return __isa(o, "AttachmentIdNotFound");
   }
 }
 
@@ -354,7 +357,7 @@ export namespace AttachmentIdNotFound {
  *             been exceeded.</p>
  */
 export interface AttachmentLimitExceeded
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AttachmentLimitExceeded";
   $fault: "client";
@@ -367,7 +370,7 @@ export interface AttachmentLimitExceeded
 
 export namespace AttachmentLimitExceeded {
   export function isa(o: any): o is AttachmentLimitExceeded {
-    return _smithy.isa(o, "AttachmentLimitExceeded");
+    return __isa(o, "AttachmentLimitExceeded");
   }
 }
 
@@ -376,7 +379,7 @@ export namespace AttachmentLimitExceeded {
  *             it is created.</p>
  */
 export interface AttachmentSetExpired
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AttachmentSetExpired";
   $fault: "client";
@@ -389,7 +392,7 @@ export interface AttachmentSetExpired
 
 export namespace AttachmentSetExpired {
   export function isa(o: any): o is AttachmentSetExpired {
-    return _smithy.isa(o, "AttachmentSetExpired");
+    return __isa(o, "AttachmentSetExpired");
   }
 }
 
@@ -397,7 +400,7 @@ export namespace AttachmentSetExpired {
  * <p>An attachment set with the specified ID could not be found.</p>
  */
 export interface AttachmentSetIdNotFound
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AttachmentSetIdNotFound";
   $fault: "client";
@@ -409,7 +412,7 @@ export interface AttachmentSetIdNotFound
 
 export namespace AttachmentSetIdNotFound {
   export function isa(o: any): o is AttachmentSetIdNotFound {
-    return _smithy.isa(o, "AttachmentSetIdNotFound");
+    return __isa(o, "AttachmentSetIdNotFound");
   }
 }
 
@@ -418,7 +421,7 @@ export namespace AttachmentSetIdNotFound {
  *             attachments and 5 MB per attachment.</p>
  */
 export interface AttachmentSetSizeLimitExceeded
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AttachmentSetSizeLimitExceeded";
   $fault: "client";
@@ -431,7 +434,7 @@ export interface AttachmentSetSizeLimitExceeded
 
 export namespace AttachmentSetSizeLimitExceeded {
   export function isa(o: any): o is AttachmentSetSizeLimitExceeded {
-    return _smithy.isa(o, "AttachmentSetSizeLimitExceeded");
+    return __isa(o, "AttachmentSetSizeLimitExceeded");
   }
 }
 
@@ -439,7 +442,7 @@ export namespace AttachmentSetSizeLimitExceeded {
  * <p>The case creation limit for the account has been exceeded.</p>
  */
 export interface CaseCreationLimitExceeded
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CaseCreationLimitExceeded";
   $fault: "client";
@@ -452,16 +455,14 @@ export interface CaseCreationLimitExceeded
 
 export namespace CaseCreationLimitExceeded {
   export function isa(o: any): o is CaseCreationLimitExceeded {
-    return _smithy.isa(o, "CaseCreationLimitExceeded");
+    return __isa(o, "CaseCreationLimitExceeded");
   }
 }
 
 /**
  * <p>The requested <code>caseId</code> could not be located.</p>
  */
-export interface CaseIdNotFound
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface CaseIdNotFound extends __SmithyException, $MetadataBearer {
   name: "CaseIdNotFound";
   $fault: "client";
   /**
@@ -472,7 +473,7 @@ export interface CaseIdNotFound
 
 export namespace CaseIdNotFound {
   export function isa(o: any): o is CaseIdNotFound {
-    return _smithy.isa(o, "CaseIdNotFound");
+    return __isa(o, "CaseIdNotFound");
   }
 }
 
@@ -481,7 +482,7 @@ export namespace CaseIdNotFound {
  *             short period of time has been exceeded.</p>
  */
 export interface DescribeAttachmentLimitExceeded
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DescribeAttachmentLimitExceeded";
   $fault: "client";
@@ -494,7 +495,7 @@ export interface DescribeAttachmentLimitExceeded
 
 export namespace DescribeAttachmentLimitExceeded {
   export function isa(o: any): o is DescribeAttachmentLimitExceeded {
-    return _smithy.isa(o, "DescribeAttachmentLimitExceeded");
+    return __isa(o, "DescribeAttachmentLimitExceeded");
   }
 }
 
@@ -502,7 +503,7 @@ export namespace DescribeAttachmentLimitExceeded {
  * <p>An internal server error occurred.</p>
  */
 export interface InternalServerError
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalServerError";
   $fault: "server";
@@ -514,7 +515,7 @@ export interface InternalServerError
 
 export namespace InternalServerError {
   export function isa(o: any): o is InternalServerError {
-    return _smithy.isa(o, "InternalServerError");
+    return __isa(o, "InternalServerError");
   }
 }
 
@@ -540,7 +541,7 @@ export interface AddAttachmentsToSetRequest {
 
 export namespace AddAttachmentsToSetRequest {
   export function isa(o: any): o is AddAttachmentsToSetRequest {
-    return _smithy.isa(o, "AddAttachmentsToSetRequest");
+    return __isa(o, "AddAttachmentsToSetRequest");
   }
 }
 
@@ -565,7 +566,7 @@ export interface AddAttachmentsToSetResponse extends $MetadataBearer {
 
 export namespace AddAttachmentsToSetResponse {
   export function isa(o: any): o is AddAttachmentsToSetResponse {
-    return _smithy.isa(o, "AddAttachmentsToSetResponse");
+    return __isa(o, "AddAttachmentsToSetResponse");
   }
 }
 
@@ -603,7 +604,7 @@ export interface AddCommunicationToCaseRequest {
 
 export namespace AddCommunicationToCaseRequest {
   export function isa(o: any): o is AddCommunicationToCaseRequest {
-    return _smithy.isa(o, "AddCommunicationToCaseRequest");
+    return __isa(o, "AddCommunicationToCaseRequest");
   }
 }
 
@@ -621,7 +622,7 @@ export interface AddCommunicationToCaseResponse extends $MetadataBearer {
 
 export namespace AddCommunicationToCaseResponse {
   export function isa(o: any): o is AddCommunicationToCaseResponse {
-    return _smithy.isa(o, "AddCommunicationToCaseResponse");
+    return __isa(o, "AddCommunicationToCaseResponse");
   }
 }
 
@@ -688,7 +689,7 @@ export interface CreateCaseRequest {
 
 export namespace CreateCaseRequest {
   export function isa(o: any): o is CreateCaseRequest {
-    return _smithy.isa(o, "CreateCaseRequest");
+    return __isa(o, "CreateCaseRequest");
   }
 }
 
@@ -708,7 +709,7 @@ export interface CreateCaseResponse extends $MetadataBearer {
 
 export namespace CreateCaseResponse {
   export function isa(o: any): o is CreateCaseResponse {
-    return _smithy.isa(o, "CreateCaseResponse");
+    return __isa(o, "CreateCaseResponse");
   }
 }
 
@@ -722,7 +723,7 @@ export interface DescribeAttachmentRequest {
 
 export namespace DescribeAttachmentRequest {
   export function isa(o: any): o is DescribeAttachmentRequest {
-    return _smithy.isa(o, "DescribeAttachmentRequest");
+    return __isa(o, "DescribeAttachmentRequest");
   }
 }
 
@@ -739,7 +740,7 @@ export interface DescribeAttachmentResponse extends $MetadataBearer {
 
 export namespace DescribeAttachmentResponse {
   export function isa(o: any): o is DescribeAttachmentResponse {
-    return _smithy.isa(o, "DescribeAttachmentResponse");
+    return __isa(o, "DescribeAttachmentResponse");
   }
 }
 
@@ -800,7 +801,7 @@ export interface DescribeCasesRequest {
 
 export namespace DescribeCasesRequest {
   export function isa(o: any): o is DescribeCasesRequest {
-    return _smithy.isa(o, "DescribeCasesRequest");
+    return __isa(o, "DescribeCasesRequest");
   }
 }
 
@@ -824,7 +825,7 @@ export interface DescribeCasesResponse extends $MetadataBearer {
 
 export namespace DescribeCasesResponse {
   export function isa(o: any): o is DescribeCasesResponse {
-    return _smithy.isa(o, "DescribeCasesResponse");
+    return __isa(o, "DescribeCasesResponse");
   }
 }
 
@@ -863,7 +864,7 @@ export interface DescribeCommunicationsRequest {
 
 export namespace DescribeCommunicationsRequest {
   export function isa(o: any): o is DescribeCommunicationsRequest {
-    return _smithy.isa(o, "DescribeCommunicationsRequest");
+    return __isa(o, "DescribeCommunicationsRequest");
   }
 }
 
@@ -886,7 +887,7 @@ export interface DescribeCommunicationsResponse extends $MetadataBearer {
 
 export namespace DescribeCommunicationsResponse {
   export function isa(o: any): o is DescribeCommunicationsResponse {
-    return _smithy.isa(o, "DescribeCommunicationsResponse");
+    return __isa(o, "DescribeCommunicationsResponse");
   }
 }
 
@@ -907,7 +908,7 @@ export interface DescribeServicesRequest {
 
 export namespace DescribeServicesRequest {
   export function isa(o: any): o is DescribeServicesRequest {
-    return _smithy.isa(o, "DescribeServicesRequest");
+    return __isa(o, "DescribeServicesRequest");
   }
 }
 
@@ -925,7 +926,7 @@ export interface DescribeServicesResponse extends $MetadataBearer {
 
 export namespace DescribeServicesResponse {
   export function isa(o: any): o is DescribeServicesResponse {
-    return _smithy.isa(o, "DescribeServicesResponse");
+    return __isa(o, "DescribeServicesResponse");
   }
 }
 
@@ -941,7 +942,7 @@ export interface DescribeSeverityLevelsRequest {
 
 export namespace DescribeSeverityLevelsRequest {
   export function isa(o: any): o is DescribeSeverityLevelsRequest {
-    return _smithy.isa(o, "DescribeSeverityLevelsRequest");
+    return __isa(o, "DescribeSeverityLevelsRequest");
   }
 }
 
@@ -959,7 +960,7 @@ export interface DescribeSeverityLevelsResponse extends $MetadataBearer {
 
 export namespace DescribeSeverityLevelsResponse {
   export function isa(o: any): o is DescribeSeverityLevelsResponse {
-    return _smithy.isa(o, "DescribeSeverityLevelsResponse");
+    return __isa(o, "DescribeSeverityLevelsResponse");
   }
 }
 
@@ -976,7 +977,7 @@ export interface ResolveCaseRequest {
 
 export namespace ResolveCaseRequest {
   export function isa(o: any): o is ResolveCaseRequest {
-    return _smithy.isa(o, "ResolveCaseRequest");
+    return __isa(o, "ResolveCaseRequest");
   }
 }
 
@@ -1001,7 +1002,7 @@ export interface ResolveCaseResponse extends $MetadataBearer {
 
 export namespace ResolveCaseResponse {
   export function isa(o: any): o is ResolveCaseResponse {
-    return _smithy.isa(o, "ResolveCaseResponse");
+    return __isa(o, "ResolveCaseResponse");
   }
 }
 
@@ -1061,7 +1062,7 @@ export interface SeverityLevel {
 
 export namespace SeverityLevel {
   export function isa(o: any): o is SeverityLevel {
-    return _smithy.isa(o, "SeverityLevel");
+    return __isa(o, "SeverityLevel");
   }
 }
 
@@ -1081,7 +1082,7 @@ export namespace DescribeTrustedAdvisorCheckRefreshStatusesRequest {
   export function isa(
     o: any
   ): o is DescribeTrustedAdvisorCheckRefreshStatusesRequest {
-    return _smithy.isa(o, "DescribeTrustedAdvisorCheckRefreshStatusesRequest");
+    return __isa(o, "DescribeTrustedAdvisorCheckRefreshStatusesRequest");
   }
 }
 
@@ -1101,7 +1102,7 @@ export namespace DescribeTrustedAdvisorCheckRefreshStatusesResponse {
   export function isa(
     o: any
   ): o is DescribeTrustedAdvisorCheckRefreshStatusesResponse {
-    return _smithy.isa(o, "DescribeTrustedAdvisorCheckRefreshStatusesResponse");
+    return __isa(o, "DescribeTrustedAdvisorCheckRefreshStatusesResponse");
   }
 }
 
@@ -1125,7 +1126,7 @@ export interface DescribeTrustedAdvisorCheckResultRequest {
 
 export namespace DescribeTrustedAdvisorCheckResultRequest {
   export function isa(o: any): o is DescribeTrustedAdvisorCheckResultRequest {
-    return _smithy.isa(o, "DescribeTrustedAdvisorCheckResultRequest");
+    return __isa(o, "DescribeTrustedAdvisorCheckResultRequest");
   }
 }
 
@@ -1143,7 +1144,7 @@ export interface DescribeTrustedAdvisorCheckResultResponse
 
 export namespace DescribeTrustedAdvisorCheckResultResponse {
   export function isa(o: any): o is DescribeTrustedAdvisorCheckResultResponse {
-    return _smithy.isa(o, "DescribeTrustedAdvisorCheckResultResponse");
+    return __isa(o, "DescribeTrustedAdvisorCheckResultResponse");
   }
 }
 
@@ -1159,7 +1160,7 @@ export namespace DescribeTrustedAdvisorCheckSummariesRequest {
   export function isa(
     o: any
   ): o is DescribeTrustedAdvisorCheckSummariesRequest {
-    return _smithy.isa(o, "DescribeTrustedAdvisorCheckSummariesRequest");
+    return __isa(o, "DescribeTrustedAdvisorCheckSummariesRequest");
   }
 }
 
@@ -1179,7 +1180,7 @@ export namespace DescribeTrustedAdvisorCheckSummariesResponse {
   export function isa(
     o: any
   ): o is DescribeTrustedAdvisorCheckSummariesResponse {
-    return _smithy.isa(o, "DescribeTrustedAdvisorCheckSummariesResponse");
+    return __isa(o, "DescribeTrustedAdvisorCheckSummariesResponse");
   }
 }
 
@@ -1198,7 +1199,7 @@ export interface DescribeTrustedAdvisorChecksRequest {
 
 export namespace DescribeTrustedAdvisorChecksRequest {
   export function isa(o: any): o is DescribeTrustedAdvisorChecksRequest {
-    return _smithy.isa(o, "DescribeTrustedAdvisorChecksRequest");
+    return __isa(o, "DescribeTrustedAdvisorChecksRequest");
   }
 }
 
@@ -1215,7 +1216,7 @@ export interface DescribeTrustedAdvisorChecksResponse extends $MetadataBearer {
 
 export namespace DescribeTrustedAdvisorChecksResponse {
   export function isa(o: any): o is DescribeTrustedAdvisorChecksResponse {
-    return _smithy.isa(o, "DescribeTrustedAdvisorChecksResponse");
+    return __isa(o, "DescribeTrustedAdvisorChecksResponse");
   }
 }
 
@@ -1233,7 +1234,7 @@ export interface RefreshTrustedAdvisorCheckRequest {
 
 export namespace RefreshTrustedAdvisorCheckRequest {
   export function isa(o: any): o is RefreshTrustedAdvisorCheckRequest {
-    return _smithy.isa(o, "RefreshTrustedAdvisorCheckRequest");
+    return __isa(o, "RefreshTrustedAdvisorCheckRequest");
   }
 }
 
@@ -1251,7 +1252,7 @@ export interface RefreshTrustedAdvisorCheckResponse extends $MetadataBearer {
 
 export namespace RefreshTrustedAdvisorCheckResponse {
   export function isa(o: any): o is RefreshTrustedAdvisorCheckResponse {
-    return _smithy.isa(o, "RefreshTrustedAdvisorCheckResponse");
+    return __isa(o, "RefreshTrustedAdvisorCheckResponse");
   }
 }
 
@@ -1270,7 +1271,7 @@ export interface TrustedAdvisorCategorySpecificSummary {
 
 export namespace TrustedAdvisorCategorySpecificSummary {
   export function isa(o: any): o is TrustedAdvisorCategorySpecificSummary {
-    return _smithy.isa(o, "TrustedAdvisorCategorySpecificSummary");
+    return __isa(o, "TrustedAdvisorCategorySpecificSummary");
   }
 }
 
@@ -1312,7 +1313,7 @@ export interface TrustedAdvisorCheckDescription {
 
 export namespace TrustedAdvisorCheckDescription {
   export function isa(o: any): o is TrustedAdvisorCheckDescription {
-    return _smithy.isa(o, "TrustedAdvisorCheckDescription");
+    return __isa(o, "TrustedAdvisorCheckDescription");
   }
 }
 
@@ -1366,7 +1367,7 @@ export interface TrustedAdvisorCheckRefreshStatus {
 
 export namespace TrustedAdvisorCheckRefreshStatus {
   export function isa(o: any): o is TrustedAdvisorCheckRefreshStatus {
-    return _smithy.isa(o, "TrustedAdvisorCheckRefreshStatus");
+    return __isa(o, "TrustedAdvisorCheckRefreshStatus");
   }
 }
 
@@ -1410,7 +1411,7 @@ export interface TrustedAdvisorCheckResult {
 
 export namespace TrustedAdvisorCheckResult {
   export function isa(o: any): o is TrustedAdvisorCheckResult {
-    return _smithy.isa(o, "TrustedAdvisorCheckResult");
+    return __isa(o, "TrustedAdvisorCheckResult");
   }
 }
 
@@ -1455,7 +1456,7 @@ export interface TrustedAdvisorCheckSummary {
 
 export namespace TrustedAdvisorCheckSummary {
   export function isa(o: any): o is TrustedAdvisorCheckSummary {
-    return _smithy.isa(o, "TrustedAdvisorCheckSummary");
+    return __isa(o, "TrustedAdvisorCheckSummary");
   }
 }
 
@@ -1480,7 +1481,7 @@ export interface TrustedAdvisorCostOptimizingSummary {
 
 export namespace TrustedAdvisorCostOptimizingSummary {
   export function isa(o: any): o is TrustedAdvisorCostOptimizingSummary {
-    return _smithy.isa(o, "TrustedAdvisorCostOptimizingSummary");
+    return __isa(o, "TrustedAdvisorCostOptimizingSummary");
   }
 }
 
@@ -1522,7 +1523,7 @@ export interface TrustedAdvisorResourceDetail {
 
 export namespace TrustedAdvisorResourceDetail {
   export function isa(o: any): o is TrustedAdvisorResourceDetail {
-    return _smithy.isa(o, "TrustedAdvisorResourceDetail");
+    return __isa(o, "TrustedAdvisorResourceDetail");
   }
 }
 
@@ -1558,6 +1559,6 @@ export interface TrustedAdvisorResourcesSummary {
 
 export namespace TrustedAdvisorResourcesSummary {
   export function isa(o: any): o is TrustedAdvisorResourcesSummary {
-    return _smithy.isa(o, "TrustedAdvisorResourcesSummary");
+    return __isa(o, "TrustedAdvisorResourcesSummary");
   }
 }

--- a/clients/client-swf/models/index.ts
+++ b/clients/client-swf/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -39,7 +42,7 @@ export interface ActivityTask extends $MetadataBearer {
 
 export namespace ActivityTask {
   export function isa(o: any): o is ActivityTask {
-    return _smithy.isa(o, "ActivityTask");
+    return __isa(o, "ActivityTask");
   }
 }
 
@@ -62,7 +65,7 @@ export interface ActivityTaskCancelRequestedEventAttributes {
 
 export namespace ActivityTaskCancelRequestedEventAttributes {
   export function isa(o: any): o is ActivityTaskCancelRequestedEventAttributes {
-    return _smithy.isa(o, "ActivityTaskCancelRequestedEventAttributes");
+    return __isa(o, "ActivityTaskCancelRequestedEventAttributes");
   }
 }
 
@@ -96,7 +99,7 @@ export interface ActivityTaskCanceledEventAttributes {
 
 export namespace ActivityTaskCanceledEventAttributes {
   export function isa(o: any): o is ActivityTaskCanceledEventAttributes {
-    return _smithy.isa(o, "ActivityTaskCanceledEventAttributes");
+    return __isa(o, "ActivityTaskCanceledEventAttributes");
   }
 }
 
@@ -125,7 +128,7 @@ export interface ActivityTaskCompletedEventAttributes {
 
 export namespace ActivityTaskCompletedEventAttributes {
   export function isa(o: any): o is ActivityTaskCompletedEventAttributes {
-    return _smithy.isa(o, "ActivityTaskCompletedEventAttributes");
+    return __isa(o, "ActivityTaskCompletedEventAttributes");
   }
 }
 
@@ -159,7 +162,7 @@ export interface ActivityTaskFailedEventAttributes {
 
 export namespace ActivityTaskFailedEventAttributes {
   export function isa(o: any): o is ActivityTaskFailedEventAttributes {
-    return _smithy.isa(o, "ActivityTaskFailedEventAttributes");
+    return __isa(o, "ActivityTaskFailedEventAttributes");
   }
 }
 
@@ -233,7 +236,7 @@ export interface ActivityTaskScheduledEventAttributes {
 
 export namespace ActivityTaskScheduledEventAttributes {
   export function isa(o: any): o is ActivityTaskScheduledEventAttributes {
-    return _smithy.isa(o, "ActivityTaskScheduledEventAttributes");
+    return __isa(o, "ActivityTaskScheduledEventAttributes");
   }
 }
 
@@ -255,7 +258,7 @@ export interface ActivityTaskStartedEventAttributes {
 
 export namespace ActivityTaskStartedEventAttributes {
   export function isa(o: any): o is ActivityTaskStartedEventAttributes {
-    return _smithy.isa(o, "ActivityTaskStartedEventAttributes");
+    return __isa(o, "ActivityTaskStartedEventAttributes");
   }
 }
 
@@ -272,7 +275,7 @@ export interface ActivityTaskStatus extends $MetadataBearer {
 
 export namespace ActivityTaskStatus {
   export function isa(o: any): o is ActivityTaskStatus {
-    return _smithy.isa(o, "ActivityTaskStatus");
+    return __isa(o, "ActivityTaskStatus");
   }
 }
 
@@ -307,7 +310,7 @@ export interface ActivityTaskTimedOutEventAttributes {
 
 export namespace ActivityTaskTimedOutEventAttributes {
   export function isa(o: any): o is ActivityTaskTimedOutEventAttributes {
-    return _smithy.isa(o, "ActivityTaskTimedOutEventAttributes");
+    return __isa(o, "ActivityTaskTimedOutEventAttributes");
   }
 }
 
@@ -341,7 +344,7 @@ export interface ActivityType {
 
 export namespace ActivityType {
   export function isa(o: any): o is ActivityType {
-    return _smithy.isa(o, "ActivityType");
+    return __isa(o, "ActivityType");
   }
 }
 
@@ -416,7 +419,7 @@ export interface ActivityTypeConfiguration {
 
 export namespace ActivityTypeConfiguration {
   export function isa(o: any): o is ActivityTypeConfiguration {
-    return _smithy.isa(o, "ActivityTypeConfiguration");
+    return __isa(o, "ActivityTypeConfiguration");
   }
 }
 
@@ -454,7 +457,7 @@ export interface ActivityTypeDetail extends $MetadataBearer {
 
 export namespace ActivityTypeDetail {
   export function isa(o: any): o is ActivityTypeDetail {
-    return _smithy.isa(o, "ActivityTypeDetail");
+    return __isa(o, "ActivityTypeDetail");
   }
 }
 
@@ -491,7 +494,7 @@ export interface ActivityTypeInfo {
 
 export namespace ActivityTypeInfo {
   export function isa(o: any): o is ActivityTypeInfo {
-    return _smithy.isa(o, "ActivityTypeInfo");
+    return __isa(o, "ActivityTypeInfo");
   }
 }
 
@@ -516,7 +519,7 @@ export interface ActivityTypeInfos extends $MetadataBearer {
 
 export namespace ActivityTypeInfos {
   export function isa(o: any): o is ActivityTypeInfos {
-    return _smithy.isa(o, "ActivityTypeInfos");
+    return __isa(o, "ActivityTypeInfos");
   }
 }
 
@@ -554,7 +557,7 @@ export interface CancelTimerDecisionAttributes {
 
 export namespace CancelTimerDecisionAttributes {
   export function isa(o: any): o is CancelTimerDecisionAttributes {
-    return _smithy.isa(o, "CancelTimerDecisionAttributes");
+    return __isa(o, "CancelTimerDecisionAttributes");
   }
 }
 
@@ -590,7 +593,7 @@ export interface CancelTimerFailedEventAttributes {
 
 export namespace CancelTimerFailedEventAttributes {
   export function isa(o: any): o is CancelTimerFailedEventAttributes {
-    return _smithy.isa(o, "CancelTimerFailedEventAttributes");
+    return __isa(o, "CancelTimerFailedEventAttributes");
   }
 }
 
@@ -628,7 +631,7 @@ export interface CancelWorkflowExecutionDecisionAttributes {
 
 export namespace CancelWorkflowExecutionDecisionAttributes {
   export function isa(o: any): o is CancelWorkflowExecutionDecisionAttributes {
-    return _smithy.isa(o, "CancelWorkflowExecutionDecisionAttributes");
+    return __isa(o, "CancelWorkflowExecutionDecisionAttributes");
   }
 }
 
@@ -661,7 +664,7 @@ export namespace CancelWorkflowExecutionFailedEventAttributes {
   export function isa(
     o: any
   ): o is CancelWorkflowExecutionFailedEventAttributes {
-    return _smithy.isa(o, "CancelWorkflowExecutionFailedEventAttributes");
+    return __isa(o, "CancelWorkflowExecutionFailedEventAttributes");
   }
 }
 
@@ -708,7 +711,7 @@ export namespace ChildWorkflowExecutionCanceledEventAttributes {
   export function isa(
     o: any
   ): o is ChildWorkflowExecutionCanceledEventAttributes {
-    return _smithy.isa(o, "ChildWorkflowExecutionCanceledEventAttributes");
+    return __isa(o, "ChildWorkflowExecutionCanceledEventAttributes");
   }
 }
 
@@ -750,7 +753,7 @@ export namespace ChildWorkflowExecutionCompletedEventAttributes {
   export function isa(
     o: any
   ): o is ChildWorkflowExecutionCompletedEventAttributes {
-    return _smithy.isa(o, "ChildWorkflowExecutionCompletedEventAttributes");
+    return __isa(o, "ChildWorkflowExecutionCompletedEventAttributes");
   }
 }
 
@@ -800,7 +803,7 @@ export namespace ChildWorkflowExecutionFailedEventAttributes {
   export function isa(
     o: any
   ): o is ChildWorkflowExecutionFailedEventAttributes {
-    return _smithy.isa(o, "ChildWorkflowExecutionFailedEventAttributes");
+    return __isa(o, "ChildWorkflowExecutionFailedEventAttributes");
   }
 }
 
@@ -833,7 +836,7 @@ export namespace ChildWorkflowExecutionStartedEventAttributes {
   export function isa(
     o: any
   ): o is ChildWorkflowExecutionStartedEventAttributes {
-    return _smithy.isa(o, "ChildWorkflowExecutionStartedEventAttributes");
+    return __isa(o, "ChildWorkflowExecutionStartedEventAttributes");
   }
 }
 
@@ -873,7 +876,7 @@ export namespace ChildWorkflowExecutionTerminatedEventAttributes {
   export function isa(
     o: any
   ): o is ChildWorkflowExecutionTerminatedEventAttributes {
-    return _smithy.isa(o, "ChildWorkflowExecutionTerminatedEventAttributes");
+    return __isa(o, "ChildWorkflowExecutionTerminatedEventAttributes");
   }
 }
 
@@ -917,7 +920,7 @@ export namespace ChildWorkflowExecutionTimedOutEventAttributes {
   export function isa(
     o: any
   ): o is ChildWorkflowExecutionTimedOutEventAttributes {
-    return _smithy.isa(o, "ChildWorkflowExecutionTimedOutEventAttributes");
+    return __isa(o, "ChildWorkflowExecutionTimedOutEventAttributes");
   }
 }
 
@@ -944,7 +947,7 @@ export interface CloseStatusFilter {
 
 export namespace CloseStatusFilter {
   export function isa(o: any): o is CloseStatusFilter {
-    return _smithy.isa(o, "CloseStatusFilter");
+    return __isa(o, "CloseStatusFilter");
   }
 }
 
@@ -983,7 +986,7 @@ export namespace CompleteWorkflowExecutionDecisionAttributes {
   export function isa(
     o: any
   ): o is CompleteWorkflowExecutionDecisionAttributes {
-    return _smithy.isa(o, "CompleteWorkflowExecutionDecisionAttributes");
+    return __isa(o, "CompleteWorkflowExecutionDecisionAttributes");
   }
 }
 
@@ -1018,7 +1021,7 @@ export namespace CompleteWorkflowExecutionFailedEventAttributes {
   export function isa(
     o: any
   ): o is CompleteWorkflowExecutionFailedEventAttributes {
-    return _smithy.isa(o, "CompleteWorkflowExecutionFailedEventAttributes");
+    return __isa(o, "CompleteWorkflowExecutionFailedEventAttributes");
   }
 }
 
@@ -1154,7 +1157,7 @@ export namespace ContinueAsNewWorkflowExecutionDecisionAttributes {
   export function isa(
     o: any
   ): o is ContinueAsNewWorkflowExecutionDecisionAttributes {
-    return _smithy.isa(o, "ContinueAsNewWorkflowExecutionDecisionAttributes");
+    return __isa(o, "ContinueAsNewWorkflowExecutionDecisionAttributes");
   }
 }
 
@@ -1196,10 +1199,7 @@ export namespace ContinueAsNewWorkflowExecutionFailedEventAttributes {
   export function isa(
     o: any
   ): o is ContinueAsNewWorkflowExecutionFailedEventAttributes {
-    return _smithy.isa(
-      o,
-      "ContinueAsNewWorkflowExecutionFailedEventAttributes"
-    );
+    return __isa(o, "ContinueAsNewWorkflowExecutionFailedEventAttributes");
   }
 }
 
@@ -1556,7 +1556,7 @@ export interface Decision {
 
 export namespace Decision {
   export function isa(o: any): o is Decision {
-    return _smithy.isa(o, "Decision");
+    return __isa(o, "Decision");
   }
 }
 
@@ -1606,7 +1606,7 @@ export interface DecisionTask extends $MetadataBearer {
 
 export namespace DecisionTask {
   export function isa(o: any): o is DecisionTask {
-    return _smithy.isa(o, "DecisionTask");
+    return __isa(o, "DecisionTask");
   }
 }
 
@@ -1637,7 +1637,7 @@ export interface DecisionTaskCompletedEventAttributes {
 
 export namespace DecisionTaskCompletedEventAttributes {
   export function isa(o: any): o is DecisionTaskCompletedEventAttributes {
-    return _smithy.isa(o, "DecisionTaskCompletedEventAttributes");
+    return __isa(o, "DecisionTaskCompletedEventAttributes");
   }
 }
 
@@ -1669,7 +1669,7 @@ export interface DecisionTaskScheduledEventAttributes {
 
 export namespace DecisionTaskScheduledEventAttributes {
   export function isa(o: any): o is DecisionTaskScheduledEventAttributes {
-    return _smithy.isa(o, "DecisionTaskScheduledEventAttributes");
+    return __isa(o, "DecisionTaskScheduledEventAttributes");
   }
 }
 
@@ -1693,7 +1693,7 @@ export interface DecisionTaskStartedEventAttributes {
 
 export namespace DecisionTaskStartedEventAttributes {
   export function isa(o: any): o is DecisionTaskStartedEventAttributes {
-    return _smithy.isa(o, "DecisionTaskStartedEventAttributes");
+    return __isa(o, "DecisionTaskStartedEventAttributes");
   }
 }
 
@@ -1724,7 +1724,7 @@ export interface DecisionTaskTimedOutEventAttributes {
 
 export namespace DecisionTaskTimedOutEventAttributes {
   export function isa(o: any): o is DecisionTaskTimedOutEventAttributes {
-    return _smithy.isa(o, "DecisionTaskTimedOutEventAttributes");
+    return __isa(o, "DecisionTaskTimedOutEventAttributes");
   }
 }
 
@@ -1759,7 +1759,7 @@ export type DecisionType =
  *          </note>
  */
 export interface DefaultUndefinedFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DefaultUndefinedFault";
   $fault: "client";
@@ -1768,7 +1768,7 @@ export interface DefaultUndefinedFault
 
 export namespace DefaultUndefinedFault {
   export function isa(o: any): o is DefaultUndefinedFault {
-    return _smithy.isa(o, "DefaultUndefinedFault");
+    return __isa(o, "DefaultUndefinedFault");
   }
 }
 
@@ -1776,7 +1776,7 @@ export namespace DefaultUndefinedFault {
  * <p>Returned if the domain already exists. You may get this fault if you are registering a domain that is either already registered or deprecated, or if you undeprecate a domain that is currently registered.</p>
  */
 export interface DomainAlreadyExistsFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DomainAlreadyExistsFault";
   $fault: "client";
@@ -1788,7 +1788,7 @@ export interface DomainAlreadyExistsFault
 
 export namespace DomainAlreadyExistsFault {
   export function isa(o: any): o is DomainAlreadyExistsFault {
-    return _smithy.isa(o, "DomainAlreadyExistsFault");
+    return __isa(o, "DomainAlreadyExistsFault");
   }
 }
 
@@ -1805,7 +1805,7 @@ export interface DomainConfiguration {
 
 export namespace DomainConfiguration {
   export function isa(o: any): o is DomainConfiguration {
-    return _smithy.isa(o, "DomainConfiguration");
+    return __isa(o, "DomainConfiguration");
   }
 }
 
@@ -1813,7 +1813,7 @@ export namespace DomainConfiguration {
  * <p>Returned when the specified domain has been deprecated.</p>
  */
 export interface DomainDeprecatedFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DomainDeprecatedFault";
   $fault: "client";
@@ -1825,7 +1825,7 @@ export interface DomainDeprecatedFault
 
 export namespace DomainDeprecatedFault {
   export function isa(o: any): o is DomainDeprecatedFault {
-    return _smithy.isa(o, "DomainDeprecatedFault");
+    return __isa(o, "DomainDeprecatedFault");
   }
 }
 
@@ -1849,7 +1849,7 @@ export interface DomainDetail extends $MetadataBearer {
 
 export namespace DomainDetail {
   export function isa(o: any): o is DomainDetail {
-    return _smithy.isa(o, "DomainDetail");
+    return __isa(o, "DomainDetail");
   }
 }
 
@@ -1895,7 +1895,7 @@ export interface DomainInfo {
 
 export namespace DomainInfo {
   export function isa(o: any): o is DomainInfo {
-    return _smithy.isa(o, "DomainInfo");
+    return __isa(o, "DomainInfo");
   }
 }
 
@@ -1920,7 +1920,7 @@ export interface DomainInfos extends $MetadataBearer {
 
 export namespace DomainInfos {
   export function isa(o: any): o is DomainInfos {
-    return _smithy.isa(o, "DomainInfos");
+    return __isa(o, "DomainInfos");
   }
 }
 
@@ -2003,7 +2003,7 @@ export interface ExecutionTimeFilter {
 
 export namespace ExecutionTimeFilter {
   export function isa(o: any): o is ExecutionTimeFilter {
-    return _smithy.isa(o, "ExecutionTimeFilter");
+    return __isa(o, "ExecutionTimeFilter");
   }
 }
 
@@ -2030,10 +2030,7 @@ export namespace ExternalWorkflowExecutionCancelRequestedEventAttributes {
   export function isa(
     o: any
   ): o is ExternalWorkflowExecutionCancelRequestedEventAttributes {
-    return _smithy.isa(
-      o,
-      "ExternalWorkflowExecutionCancelRequestedEventAttributes"
-    );
+    return __isa(o, "ExternalWorkflowExecutionCancelRequestedEventAttributes");
   }
 }
 
@@ -2059,7 +2056,7 @@ export namespace ExternalWorkflowExecutionSignaledEventAttributes {
   export function isa(
     o: any
   ): o is ExternalWorkflowExecutionSignaledEventAttributes {
-    return _smithy.isa(o, "ExternalWorkflowExecutionSignaledEventAttributes");
+    return __isa(o, "ExternalWorkflowExecutionSignaledEventAttributes");
   }
 }
 
@@ -2103,7 +2100,7 @@ export interface FailWorkflowExecutionDecisionAttributes {
 
 export namespace FailWorkflowExecutionDecisionAttributes {
   export function isa(o: any): o is FailWorkflowExecutionDecisionAttributes {
-    return _smithy.isa(o, "FailWorkflowExecutionDecisionAttributes");
+    return __isa(o, "FailWorkflowExecutionDecisionAttributes");
   }
 }
 
@@ -2136,7 +2133,7 @@ export interface FailWorkflowExecutionFailedEventAttributes {
 
 export namespace FailWorkflowExecutionFailedEventAttributes {
   export function isa(o: any): o is FailWorkflowExecutionFailedEventAttributes {
-    return _smithy.isa(o, "FailWorkflowExecutionFailedEventAttributes");
+    return __isa(o, "FailWorkflowExecutionFailedEventAttributes");
   }
 }
 
@@ -2161,7 +2158,7 @@ export interface History extends $MetadataBearer {
 
 export namespace History {
   export function isa(o: any): o is History {
-    return _smithy.isa(o, "History");
+    return __isa(o, "History");
   }
 }
 
@@ -2729,7 +2726,7 @@ export interface HistoryEvent {
 
 export namespace HistoryEvent {
   export function isa(o: any): o is HistoryEvent {
-    return _smithy.isa(o, "HistoryEvent");
+    return __isa(o, "HistoryEvent");
   }
 }
 
@@ -2759,7 +2756,7 @@ export interface LambdaFunctionCompletedEventAttributes {
 
 export namespace LambdaFunctionCompletedEventAttributes {
   export function isa(o: any): o is LambdaFunctionCompletedEventAttributes {
-    return _smithy.isa(o, "LambdaFunctionCompletedEventAttributes");
+    return __isa(o, "LambdaFunctionCompletedEventAttributes");
   }
 }
 
@@ -2794,7 +2791,7 @@ export interface LambdaFunctionFailedEventAttributes {
 
 export namespace LambdaFunctionFailedEventAttributes {
   export function isa(o: any): o is LambdaFunctionFailedEventAttributes {
-    return _smithy.isa(o, "LambdaFunctionFailedEventAttributes");
+    return __isa(o, "LambdaFunctionFailedEventAttributes");
   }
 }
 
@@ -2839,7 +2836,7 @@ export interface LambdaFunctionScheduledEventAttributes {
 
 export namespace LambdaFunctionScheduledEventAttributes {
   export function isa(o: any): o is LambdaFunctionScheduledEventAttributes {
-    return _smithy.isa(o, "LambdaFunctionScheduledEventAttributes");
+    return __isa(o, "LambdaFunctionScheduledEventAttributes");
   }
 }
 
@@ -2858,7 +2855,7 @@ export interface LambdaFunctionStartedEventAttributes {
 
 export namespace LambdaFunctionStartedEventAttributes {
   export function isa(o: any): o is LambdaFunctionStartedEventAttributes {
-    return _smithy.isa(o, "LambdaFunctionStartedEventAttributes");
+    return __isa(o, "LambdaFunctionStartedEventAttributes");
   }
 }
 
@@ -2887,7 +2884,7 @@ export interface LambdaFunctionTimedOutEventAttributes {
 
 export namespace LambdaFunctionTimedOutEventAttributes {
   export function isa(o: any): o is LambdaFunctionTimedOutEventAttributes {
-    return _smithy.isa(o, "LambdaFunctionTimedOutEventAttributes");
+    return __isa(o, "LambdaFunctionTimedOutEventAttributes");
   }
 }
 
@@ -2896,9 +2893,7 @@ export type LambdaFunctionTimeoutType = "START_TO_CLOSE";
 /**
  * <p>Returned by any operation if a system imposed limitation has been reached. To address this fault you should either clean up unused resources or increase the limit by contacting AWS.</p>
  */
-export interface LimitExceededFault
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface LimitExceededFault extends __SmithyException, $MetadataBearer {
   name: "LimitExceededFault";
   $fault: "client";
   /**
@@ -2909,7 +2904,7 @@ export interface LimitExceededFault
 
 export namespace LimitExceededFault {
   export function isa(o: any): o is LimitExceededFault {
-    return _smithy.isa(o, "LimitExceededFault");
+    return __isa(o, "LimitExceededFault");
   }
 }
 
@@ -2938,7 +2933,7 @@ export interface MarkerRecordedEventAttributes {
 
 export namespace MarkerRecordedEventAttributes {
   export function isa(o: any): o is MarkerRecordedEventAttributes {
-    return _smithy.isa(o, "MarkerRecordedEventAttributes");
+    return __isa(o, "MarkerRecordedEventAttributes");
   }
 }
 
@@ -2946,7 +2941,7 @@ export namespace MarkerRecordedEventAttributes {
  * <p>Returned when the caller doesn't have sufficient permissions to invoke the action.</p>
  */
 export interface OperationNotPermittedFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "OperationNotPermittedFault";
   $fault: "client";
@@ -2958,7 +2953,7 @@ export interface OperationNotPermittedFault
 
 export namespace OperationNotPermittedFault {
   export function isa(o: any): o is OperationNotPermittedFault {
-    return _smithy.isa(o, "OperationNotPermittedFault");
+    return __isa(o, "OperationNotPermittedFault");
   }
 }
 
@@ -2980,7 +2975,7 @@ export interface PendingTaskCount extends $MetadataBearer {
 
 export namespace PendingTaskCount {
   export function isa(o: any): o is PendingTaskCount {
-    return _smithy.isa(o, "PendingTaskCount");
+    return __isa(o, "PendingTaskCount");
   }
 }
 
@@ -3024,7 +3019,7 @@ export interface RecordMarkerDecisionAttributes {
 
 export namespace RecordMarkerDecisionAttributes {
   export function isa(o: any): o is RecordMarkerDecisionAttributes {
-    return _smithy.isa(o, "RecordMarkerDecisionAttributes");
+    return __isa(o, "RecordMarkerDecisionAttributes");
   }
 }
 
@@ -3060,7 +3055,7 @@ export interface RecordMarkerFailedEventAttributes {
 
 export namespace RecordMarkerFailedEventAttributes {
   export function isa(o: any): o is RecordMarkerFailedEventAttributes {
-    return _smithy.isa(o, "RecordMarkerFailedEventAttributes");
+    return __isa(o, "RecordMarkerFailedEventAttributes");
   }
 }
 
@@ -3102,7 +3097,7 @@ export namespace RequestCancelActivityTaskDecisionAttributes {
   export function isa(
     o: any
   ): o is RequestCancelActivityTaskDecisionAttributes {
-    return _smithy.isa(o, "RequestCancelActivityTaskDecisionAttributes");
+    return __isa(o, "RequestCancelActivityTaskDecisionAttributes");
   }
 }
 
@@ -3142,7 +3137,7 @@ export namespace RequestCancelActivityTaskFailedEventAttributes {
   export function isa(
     o: any
   ): o is RequestCancelActivityTaskFailedEventAttributes {
-    return _smithy.isa(o, "RequestCancelActivityTaskFailedEventAttributes");
+    return __isa(o, "RequestCancelActivityTaskFailedEventAttributes");
   }
 }
 
@@ -3192,10 +3187,7 @@ export namespace RequestCancelExternalWorkflowExecutionDecisionAttributes {
   export function isa(
     o: any
   ): o is RequestCancelExternalWorkflowExecutionDecisionAttributes {
-    return _smithy.isa(
-      o,
-      "RequestCancelExternalWorkflowExecutionDecisionAttributes"
-    );
+    return __isa(o, "RequestCancelExternalWorkflowExecutionDecisionAttributes");
   }
 }
 
@@ -3255,7 +3247,7 @@ export namespace RequestCancelExternalWorkflowExecutionFailedEventAttributes {
   export function isa(
     o: any
   ): o is RequestCancelExternalWorkflowExecutionFailedEventAttributes {
-    return _smithy.isa(
+    return __isa(
       o,
       "RequestCancelExternalWorkflowExecutionFailedEventAttributes"
     );
@@ -3295,7 +3287,7 @@ export namespace RequestCancelExternalWorkflowExecutionInitiatedEventAttributes 
   export function isa(
     o: any
   ): o is RequestCancelExternalWorkflowExecutionInitiatedEventAttributes {
-    return _smithy.isa(
+    return __isa(
       o,
       "RequestCancelExternalWorkflowExecutionInitiatedEventAttributes"
     );
@@ -3322,7 +3314,7 @@ export interface ResourceTag {
 
 export namespace ResourceTag {
   export function isa(o: any): o is ResourceTag {
-    return _smithy.isa(o, "ResourceTag");
+    return __isa(o, "ResourceTag");
   }
 }
 
@@ -3456,7 +3448,7 @@ export interface ScheduleActivityTaskDecisionAttributes {
 
 export namespace ScheduleActivityTaskDecisionAttributes {
   export function isa(o: any): o is ScheduleActivityTaskDecisionAttributes {
-    return _smithy.isa(o, "ScheduleActivityTaskDecisionAttributes");
+    return __isa(o, "ScheduleActivityTaskDecisionAttributes");
   }
 }
 
@@ -3508,7 +3500,7 @@ export interface ScheduleActivityTaskFailedEventAttributes {
 
 export namespace ScheduleActivityTaskFailedEventAttributes {
   export function isa(o: any): o is ScheduleActivityTaskFailedEventAttributes {
-    return _smithy.isa(o, "ScheduleActivityTaskFailedEventAttributes");
+    return __isa(o, "ScheduleActivityTaskFailedEventAttributes");
   }
 }
 
@@ -3547,7 +3539,7 @@ export interface ScheduleLambdaFunctionDecisionAttributes {
 
 export namespace ScheduleLambdaFunctionDecisionAttributes {
   export function isa(o: any): o is ScheduleLambdaFunctionDecisionAttributes {
-    return _smithy.isa(o, "ScheduleLambdaFunctionDecisionAttributes");
+    return __isa(o, "ScheduleLambdaFunctionDecisionAttributes");
   }
 }
 
@@ -3597,7 +3589,7 @@ export namespace ScheduleLambdaFunctionFailedEventAttributes {
   export function isa(
     o: any
   ): o is ScheduleLambdaFunctionFailedEventAttributes {
-    return _smithy.isa(o, "ScheduleLambdaFunctionFailedEventAttributes");
+    return __isa(o, "ScheduleLambdaFunctionFailedEventAttributes");
   }
 }
 
@@ -3661,7 +3653,7 @@ export namespace SignalExternalWorkflowExecutionDecisionAttributes {
   export function isa(
     o: any
   ): o is SignalExternalWorkflowExecutionDecisionAttributes {
-    return _smithy.isa(o, "SignalExternalWorkflowExecutionDecisionAttributes");
+    return __isa(o, "SignalExternalWorkflowExecutionDecisionAttributes");
   }
 }
 
@@ -3720,10 +3712,7 @@ export namespace SignalExternalWorkflowExecutionFailedEventAttributes {
   export function isa(
     o: any
   ): o is SignalExternalWorkflowExecutionFailedEventAttributes {
-    return _smithy.isa(
-      o,
-      "SignalExternalWorkflowExecutionFailedEventAttributes"
-    );
+    return __isa(o, "SignalExternalWorkflowExecutionFailedEventAttributes");
   }
 }
 
@@ -3769,10 +3758,7 @@ export namespace SignalExternalWorkflowExecutionInitiatedEventAttributes {
   export function isa(
     o: any
   ): o is SignalExternalWorkflowExecutionInitiatedEventAttributes {
-    return _smithy.isa(
-      o,
-      "SignalExternalWorkflowExecutionInitiatedEventAttributes"
-    );
+    return __isa(o, "SignalExternalWorkflowExecutionInitiatedEventAttributes");
   }
 }
 
@@ -3931,7 +3917,7 @@ export namespace StartChildWorkflowExecutionDecisionAttributes {
   export function isa(
     o: any
   ): o is StartChildWorkflowExecutionDecisionAttributes {
-    return _smithy.isa(o, "StartChildWorkflowExecutionDecisionAttributes");
+    return __isa(o, "StartChildWorkflowExecutionDecisionAttributes");
   }
 }
 
@@ -4001,7 +3987,7 @@ export namespace StartChildWorkflowExecutionFailedEventAttributes {
   export function isa(
     o: any
   ): o is StartChildWorkflowExecutionFailedEventAttributes {
-    return _smithy.isa(o, "StartChildWorkflowExecutionFailedEventAttributes");
+    return __isa(o, "StartChildWorkflowExecutionFailedEventAttributes");
   }
 }
 
@@ -4102,10 +4088,7 @@ export namespace StartChildWorkflowExecutionInitiatedEventAttributes {
   export function isa(
     o: any
   ): o is StartChildWorkflowExecutionInitiatedEventAttributes {
-    return _smithy.isa(
-      o,
-      "StartChildWorkflowExecutionInitiatedEventAttributes"
-    );
+    return __isa(o, "StartChildWorkflowExecutionInitiatedEventAttributes");
   }
 }
 
@@ -4142,7 +4125,7 @@ export interface StartLambdaFunctionFailedEventAttributes {
 
 export namespace StartLambdaFunctionFailedEventAttributes {
   export function isa(o: any): o is StartLambdaFunctionFailedEventAttributes {
-    return _smithy.isa(o, "StartLambdaFunctionFailedEventAttributes");
+    return __isa(o, "StartLambdaFunctionFailedEventAttributes");
   }
 }
 
@@ -4194,7 +4177,7 @@ export interface StartTimerDecisionAttributes {
 
 export namespace StartTimerDecisionAttributes {
   export function isa(o: any): o is StartTimerDecisionAttributes {
-    return _smithy.isa(o, "StartTimerDecisionAttributes");
+    return __isa(o, "StartTimerDecisionAttributes");
   }
 }
 
@@ -4234,7 +4217,7 @@ export interface StartTimerFailedEventAttributes {
 
 export namespace StartTimerFailedEventAttributes {
   export function isa(o: any): o is StartTimerFailedEventAttributes {
-    return _smithy.isa(o, "StartTimerFailedEventAttributes");
+    return __isa(o, "StartTimerFailedEventAttributes");
   }
 }
 
@@ -4254,7 +4237,7 @@ export interface TagFilter {
 
 export namespace TagFilter {
   export function isa(o: any): o is TagFilter {
-    return _smithy.isa(o, "TagFilter");
+    return __isa(o, "TagFilter");
   }
 }
 
@@ -4271,7 +4254,7 @@ export interface TaskList {
 
 export namespace TaskList {
   export function isa(o: any): o is TaskList {
-    return _smithy.isa(o, "TaskList");
+    return __isa(o, "TaskList");
   }
 }
 
@@ -4304,7 +4287,7 @@ export interface TimerCanceledEventAttributes {
 
 export namespace TimerCanceledEventAttributes {
   export function isa(o: any): o is TimerCanceledEventAttributes {
-    return _smithy.isa(o, "TimerCanceledEventAttributes");
+    return __isa(o, "TimerCanceledEventAttributes");
   }
 }
 
@@ -4328,7 +4311,7 @@ export interface TimerFiredEventAttributes {
 
 export namespace TimerFiredEventAttributes {
   export function isa(o: any): o is TimerFiredEventAttributes {
-    return _smithy.isa(o, "TimerFiredEventAttributes");
+    return __isa(o, "TimerFiredEventAttributes");
   }
 }
 
@@ -4363,16 +4346,14 @@ export interface TimerStartedEventAttributes {
 
 export namespace TimerStartedEventAttributes {
   export function isa(o: any): o is TimerStartedEventAttributes {
-    return _smithy.isa(o, "TimerStartedEventAttributes");
+    return __isa(o, "TimerStartedEventAttributes");
   }
 }
 
 /**
  * <p>You've exceeded the number of tags allowed for a domain.</p>
  */
-export interface TooManyTagsFault
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface TooManyTagsFault extends __SmithyException, $MetadataBearer {
   name: "TooManyTagsFault";
   $fault: "client";
   message?: string;
@@ -4380,7 +4361,7 @@ export interface TooManyTagsFault
 
 export namespace TooManyTagsFault {
   export function isa(o: any): o is TooManyTagsFault {
-    return _smithy.isa(o, "TooManyTagsFault");
+    return __isa(o, "TooManyTagsFault");
   }
 }
 
@@ -4388,7 +4369,7 @@ export namespace TooManyTagsFault {
  * <p>Returned if the type already exists in the specified domain. You may get this fault if you are registering a type that is either already registered or deprecated, or if you undeprecate a type that is currently registered.</p>
  */
 export interface TypeAlreadyExistsFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TypeAlreadyExistsFault";
   $fault: "client";
@@ -4400,7 +4381,7 @@ export interface TypeAlreadyExistsFault
 
 export namespace TypeAlreadyExistsFault {
   export function isa(o: any): o is TypeAlreadyExistsFault {
-    return _smithy.isa(o, "TypeAlreadyExistsFault");
+    return __isa(o, "TypeAlreadyExistsFault");
   }
 }
 
@@ -4408,7 +4389,7 @@ export namespace TypeAlreadyExistsFault {
  * <p>Returned when the specified activity or workflow type was already deprecated.</p>
  */
 export interface TypeDeprecatedFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TypeDeprecatedFault";
   $fault: "client";
@@ -4420,7 +4401,7 @@ export interface TypeDeprecatedFault
 
 export namespace TypeDeprecatedFault {
   export function isa(o: any): o is TypeDeprecatedFault {
-    return _smithy.isa(o, "TypeDeprecatedFault");
+    return __isa(o, "TypeDeprecatedFault");
   }
 }
 
@@ -4428,7 +4409,7 @@ export namespace TypeDeprecatedFault {
  * <p>Returned when the named resource cannot be found with in the scope of this operation (region or domain). This could happen if the named resource was never created or is no longer available for this operation.</p>
  */
 export interface UnknownResourceFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UnknownResourceFault";
   $fault: "client";
@@ -4440,7 +4421,7 @@ export interface UnknownResourceFault
 
 export namespace UnknownResourceFault {
   export function isa(o: any): o is UnknownResourceFault {
-    return _smithy.isa(o, "UnknownResourceFault");
+    return __isa(o, "UnknownResourceFault");
   }
 }
 
@@ -4462,7 +4443,7 @@ export interface WorkflowExecution {
 
 export namespace WorkflowExecution {
   export function isa(o: any): o is WorkflowExecution {
-    return _smithy.isa(o, "WorkflowExecution");
+    return __isa(o, "WorkflowExecution");
   }
 }
 
@@ -4471,7 +4452,7 @@ export namespace WorkflowExecution {
  *       the specified domain.</p>
  */
 export interface WorkflowExecutionAlreadyStartedFault
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "WorkflowExecutionAlreadyStartedFault";
   $fault: "client";
@@ -4483,7 +4464,7 @@ export interface WorkflowExecutionAlreadyStartedFault
 
 export namespace WorkflowExecutionAlreadyStartedFault {
   export function isa(o: any): o is WorkflowExecutionAlreadyStartedFault {
-    return _smithy.isa(o, "WorkflowExecutionAlreadyStartedFault");
+    return __isa(o, "WorkflowExecutionAlreadyStartedFault");
   }
 }
 
@@ -4517,7 +4498,7 @@ export namespace WorkflowExecutionCancelRequestedEventAttributes {
   export function isa(
     o: any
   ): o is WorkflowExecutionCancelRequestedEventAttributes {
-    return _smithy.isa(o, "WorkflowExecutionCancelRequestedEventAttributes");
+    return __isa(o, "WorkflowExecutionCancelRequestedEventAttributes");
   }
 }
 
@@ -4541,7 +4522,7 @@ export interface WorkflowExecutionCanceledEventAttributes {
 
 export namespace WorkflowExecutionCanceledEventAttributes {
   export function isa(o: any): o is WorkflowExecutionCanceledEventAttributes {
-    return _smithy.isa(o, "WorkflowExecutionCanceledEventAttributes");
+    return __isa(o, "WorkflowExecutionCanceledEventAttributes");
   }
 }
 
@@ -4565,7 +4546,7 @@ export interface WorkflowExecutionCompletedEventAttributes {
 
 export namespace WorkflowExecutionCompletedEventAttributes {
   export function isa(o: any): o is WorkflowExecutionCompletedEventAttributes {
-    return _smithy.isa(o, "WorkflowExecutionCompletedEventAttributes");
+    return __isa(o, "WorkflowExecutionCompletedEventAttributes");
   }
 }
 
@@ -4629,7 +4610,7 @@ export interface WorkflowExecutionConfiguration {
 
 export namespace WorkflowExecutionConfiguration {
   export function isa(o: any): o is WorkflowExecutionConfiguration {
-    return _smithy.isa(o, "WorkflowExecutionConfiguration");
+    return __isa(o, "WorkflowExecutionConfiguration");
   }
 }
 
@@ -4722,7 +4703,7 @@ export namespace WorkflowExecutionContinuedAsNewEventAttributes {
   export function isa(
     o: any
   ): o is WorkflowExecutionContinuedAsNewEventAttributes {
-    return _smithy.isa(o, "WorkflowExecutionContinuedAsNewEventAttributes");
+    return __isa(o, "WorkflowExecutionContinuedAsNewEventAttributes");
   }
 }
 
@@ -4746,7 +4727,7 @@ export interface WorkflowExecutionCount extends $MetadataBearer {
 
 export namespace WorkflowExecutionCount {
   export function isa(o: any): o is WorkflowExecutionCount {
-    return _smithy.isa(o, "WorkflowExecutionCount");
+    return __isa(o, "WorkflowExecutionCount");
   }
 }
 
@@ -4784,7 +4765,7 @@ export interface WorkflowExecutionDetail extends $MetadataBearer {
 
 export namespace WorkflowExecutionDetail {
   export function isa(o: any): o is WorkflowExecutionDetail {
-    return _smithy.isa(o, "WorkflowExecutionDetail");
+    return __isa(o, "WorkflowExecutionDetail");
   }
 }
 
@@ -4813,7 +4794,7 @@ export interface WorkflowExecutionFailedEventAttributes {
 
 export namespace WorkflowExecutionFailedEventAttributes {
   export function isa(o: any): o is WorkflowExecutionFailedEventAttributes {
-    return _smithy.isa(o, "WorkflowExecutionFailedEventAttributes");
+    return __isa(o, "WorkflowExecutionFailedEventAttributes");
   }
 }
 
@@ -4830,7 +4811,7 @@ export interface WorkflowExecutionFilter {
 
 export namespace WorkflowExecutionFilter {
   export function isa(o: any): o is WorkflowExecutionFilter {
-    return _smithy.isa(o, "WorkflowExecutionFilter");
+    return __isa(o, "WorkflowExecutionFilter");
   }
 }
 
@@ -4916,7 +4897,7 @@ export interface WorkflowExecutionInfo {
 
 export namespace WorkflowExecutionInfo {
   export function isa(o: any): o is WorkflowExecutionInfo {
-    return _smithy.isa(o, "WorkflowExecutionInfo");
+    return __isa(o, "WorkflowExecutionInfo");
   }
 }
 
@@ -4941,7 +4922,7 @@ export interface WorkflowExecutionInfos extends $MetadataBearer {
 
 export namespace WorkflowExecutionInfos {
   export function isa(o: any): o is WorkflowExecutionInfos {
-    return _smithy.isa(o, "WorkflowExecutionInfos");
+    return __isa(o, "WorkflowExecutionInfos");
   }
 }
 
@@ -4978,7 +4959,7 @@ export interface WorkflowExecutionOpenCounts {
 
 export namespace WorkflowExecutionOpenCounts {
   export function isa(o: any): o is WorkflowExecutionOpenCounts {
-    return _smithy.isa(o, "WorkflowExecutionOpenCounts");
+    return __isa(o, "WorkflowExecutionOpenCounts");
   }
 }
 
@@ -5014,7 +4995,7 @@ export interface WorkflowExecutionSignaledEventAttributes {
 
 export namespace WorkflowExecutionSignaledEventAttributes {
   export function isa(o: any): o is WorkflowExecutionSignaledEventAttributes {
-    return _smithy.isa(o, "WorkflowExecutionSignaledEventAttributes");
+    return __isa(o, "WorkflowExecutionSignaledEventAttributes");
   }
 }
 
@@ -5112,7 +5093,7 @@ export interface WorkflowExecutionStartedEventAttributes {
 
 export namespace WorkflowExecutionStartedEventAttributes {
   export function isa(o: any): o is WorkflowExecutionStartedEventAttributes {
-    return _smithy.isa(o, "WorkflowExecutionStartedEventAttributes");
+    return __isa(o, "WorkflowExecutionStartedEventAttributes");
   }
 }
 
@@ -5166,7 +5147,7 @@ export interface WorkflowExecutionTerminatedEventAttributes {
 
 export namespace WorkflowExecutionTerminatedEventAttributes {
   export function isa(o: any): o is WorkflowExecutionTerminatedEventAttributes {
-    return _smithy.isa(o, "WorkflowExecutionTerminatedEventAttributes");
+    return __isa(o, "WorkflowExecutionTerminatedEventAttributes");
   }
 }
 
@@ -5205,7 +5186,7 @@ export interface WorkflowExecutionTimedOutEventAttributes {
 
 export namespace WorkflowExecutionTimedOutEventAttributes {
   export function isa(o: any): o is WorkflowExecutionTimedOutEventAttributes {
-    return _smithy.isa(o, "WorkflowExecutionTimedOutEventAttributes");
+    return __isa(o, "WorkflowExecutionTimedOutEventAttributes");
   }
 }
 
@@ -5237,7 +5218,7 @@ export interface WorkflowType {
 
 export namespace WorkflowType {
   export function isa(o: any): o is WorkflowType {
-    return _smithy.isa(o, "WorkflowType");
+    return __isa(o, "WorkflowType");
   }
 }
 
@@ -5329,7 +5310,7 @@ export interface WorkflowTypeConfiguration {
 
 export namespace WorkflowTypeConfiguration {
   export function isa(o: any): o is WorkflowTypeConfiguration {
-    return _smithy.isa(o, "WorkflowTypeConfiguration");
+    return __isa(o, "WorkflowTypeConfiguration");
   }
 }
 
@@ -5364,7 +5345,7 @@ export interface WorkflowTypeDetail extends $MetadataBearer {
 
 export namespace WorkflowTypeDetail {
   export function isa(o: any): o is WorkflowTypeDetail {
-    return _smithy.isa(o, "WorkflowTypeDetail");
+    return __isa(o, "WorkflowTypeDetail");
   }
 }
 
@@ -5387,7 +5368,7 @@ export interface WorkflowTypeFilter {
 
 export namespace WorkflowTypeFilter {
   export function isa(o: any): o is WorkflowTypeFilter {
-    return _smithy.isa(o, "WorkflowTypeFilter");
+    return __isa(o, "WorkflowTypeFilter");
   }
 }
 
@@ -5424,7 +5405,7 @@ export interface WorkflowTypeInfo {
 
 export namespace WorkflowTypeInfo {
   export function isa(o: any): o is WorkflowTypeInfo {
-    return _smithy.isa(o, "WorkflowTypeInfo");
+    return __isa(o, "WorkflowTypeInfo");
   }
 }
 
@@ -5449,7 +5430,7 @@ export interface WorkflowTypeInfos extends $MetadataBearer {
 
 export namespace WorkflowTypeInfos {
   export function isa(o: any): o is WorkflowTypeInfos {
-    return _smithy.isa(o, "WorkflowTypeInfos");
+    return __isa(o, "WorkflowTypeInfos");
   }
 }
 
@@ -5533,7 +5514,7 @@ export interface CountClosedWorkflowExecutionsInput {
 
 export namespace CountClosedWorkflowExecutionsInput {
   export function isa(o: any): o is CountClosedWorkflowExecutionsInput {
-    return _smithy.isa(o, "CountClosedWorkflowExecutionsInput");
+    return __isa(o, "CountClosedWorkflowExecutionsInput");
   }
 }
 
@@ -5585,7 +5566,7 @@ export interface CountOpenWorkflowExecutionsInput {
 
 export namespace CountOpenWorkflowExecutionsInput {
   export function isa(o: any): o is CountOpenWorkflowExecutionsInput {
-    return _smithy.isa(o, "CountOpenWorkflowExecutionsInput");
+    return __isa(o, "CountOpenWorkflowExecutionsInput");
   }
 }
 
@@ -5604,7 +5585,7 @@ export interface CountPendingActivityTasksInput {
 
 export namespace CountPendingActivityTasksInput {
   export function isa(o: any): o is CountPendingActivityTasksInput {
-    return _smithy.isa(o, "CountPendingActivityTasksInput");
+    return __isa(o, "CountPendingActivityTasksInput");
   }
 }
 
@@ -5623,7 +5604,7 @@ export interface CountPendingDecisionTasksInput {
 
 export namespace CountPendingDecisionTasksInput {
   export function isa(o: any): o is CountPendingDecisionTasksInput {
-    return _smithy.isa(o, "CountPendingDecisionTasksInput");
+    return __isa(o, "CountPendingDecisionTasksInput");
   }
 }
 
@@ -5642,7 +5623,7 @@ export interface DeprecateActivityTypeInput {
 
 export namespace DeprecateActivityTypeInput {
   export function isa(o: any): o is DeprecateActivityTypeInput {
-    return _smithy.isa(o, "DeprecateActivityTypeInput");
+    return __isa(o, "DeprecateActivityTypeInput");
   }
 }
 
@@ -5656,7 +5637,7 @@ export interface DeprecateDomainInput {
 
 export namespace DeprecateDomainInput {
   export function isa(o: any): o is DeprecateDomainInput {
-    return _smithy.isa(o, "DeprecateDomainInput");
+    return __isa(o, "DeprecateDomainInput");
   }
 }
 
@@ -5675,7 +5656,7 @@ export interface DeprecateWorkflowTypeInput {
 
 export namespace DeprecateWorkflowTypeInput {
   export function isa(o: any): o is DeprecateWorkflowTypeInput {
-    return _smithy.isa(o, "DeprecateWorkflowTypeInput");
+    return __isa(o, "DeprecateWorkflowTypeInput");
   }
 }
 
@@ -5696,7 +5677,7 @@ export interface DescribeActivityTypeInput {
 
 export namespace DescribeActivityTypeInput {
   export function isa(o: any): o is DescribeActivityTypeInput {
-    return _smithy.isa(o, "DescribeActivityTypeInput");
+    return __isa(o, "DescribeActivityTypeInput");
   }
 }
 
@@ -5710,7 +5691,7 @@ export interface DescribeDomainInput {
 
 export namespace DescribeDomainInput {
   export function isa(o: any): o is DescribeDomainInput {
-    return _smithy.isa(o, "DescribeDomainInput");
+    return __isa(o, "DescribeDomainInput");
   }
 }
 
@@ -5729,7 +5710,7 @@ export interface DescribeWorkflowExecutionInput {
 
 export namespace DescribeWorkflowExecutionInput {
   export function isa(o: any): o is DescribeWorkflowExecutionInput {
-    return _smithy.isa(o, "DescribeWorkflowExecutionInput");
+    return __isa(o, "DescribeWorkflowExecutionInput");
   }
 }
 
@@ -5748,7 +5729,7 @@ export interface DescribeWorkflowTypeInput {
 
 export namespace DescribeWorkflowTypeInput {
   export function isa(o: any): o is DescribeWorkflowTypeInput {
-    return _smithy.isa(o, "DescribeWorkflowTypeInput");
+    return __isa(o, "DescribeWorkflowTypeInput");
   }
 }
 
@@ -5792,7 +5773,7 @@ export interface GetWorkflowExecutionHistoryInput {
 
 export namespace GetWorkflowExecutionHistoryInput {
   export function isa(o: any): o is GetWorkflowExecutionHistoryInput {
-    return _smithy.isa(o, "GetWorkflowExecutionHistoryInput");
+    return __isa(o, "GetWorkflowExecutionHistoryInput");
   }
 }
 
@@ -5841,7 +5822,7 @@ export interface ListActivityTypesInput {
 
 export namespace ListActivityTypesInput {
   export function isa(o: any): o is ListActivityTypesInput {
-    return _smithy.isa(o, "ListActivityTypesInput");
+    return __isa(o, "ListActivityTypesInput");
   }
 }
 
@@ -5952,7 +5933,7 @@ export interface ListClosedWorkflowExecutionsInput {
 
 export namespace ListClosedWorkflowExecutionsInput {
   export function isa(o: any): o is ListClosedWorkflowExecutionsInput {
-    return _smithy.isa(o, "ListClosedWorkflowExecutionsInput");
+    return __isa(o, "ListClosedWorkflowExecutionsInput");
   }
 }
 
@@ -5991,7 +5972,7 @@ export interface ListDomainsInput {
 
 export namespace ListDomainsInput {
   export function isa(o: any): o is ListDomainsInput {
-    return _smithy.isa(o, "ListDomainsInput");
+    return __isa(o, "ListDomainsInput");
   }
 }
 
@@ -6067,7 +6048,7 @@ export interface ListOpenWorkflowExecutionsInput {
 
 export namespace ListOpenWorkflowExecutionsInput {
   export function isa(o: any): o is ListOpenWorkflowExecutionsInput {
-    return _smithy.isa(o, "ListOpenWorkflowExecutionsInput");
+    return __isa(o, "ListOpenWorkflowExecutionsInput");
   }
 }
 
@@ -6081,7 +6062,7 @@ export interface ListTagsForResourceInput {
 
 export namespace ListTagsForResourceInput {
   export function isa(o: any): o is ListTagsForResourceInput {
-    return _smithy.isa(o, "ListTagsForResourceInput");
+    return __isa(o, "ListTagsForResourceInput");
   }
 }
 
@@ -6095,7 +6076,7 @@ export interface ListTagsForResourceOutput extends $MetadataBearer {
 
 export namespace ListTagsForResourceOutput {
   export function isa(o: any): o is ListTagsForResourceOutput {
-    return _smithy.isa(o, "ListTagsForResourceOutput");
+    return __isa(o, "ListTagsForResourceOutput");
   }
 }
 
@@ -6144,7 +6125,7 @@ export interface ListWorkflowTypesInput {
 
 export namespace ListWorkflowTypesInput {
   export function isa(o: any): o is ListWorkflowTypesInput {
-    return _smithy.isa(o, "ListWorkflowTypesInput");
+    return __isa(o, "ListWorkflowTypesInput");
   }
 }
 
@@ -6175,7 +6156,7 @@ export interface PollForActivityTaskInput {
 
 export namespace PollForActivityTaskInput {
   export function isa(o: any): o is PollForActivityTaskInput {
-    return _smithy.isa(o, "PollForActivityTaskInput");
+    return __isa(o, "PollForActivityTaskInput");
   }
 }
 
@@ -6239,7 +6220,7 @@ export interface PollForDecisionTaskInput {
 
 export namespace PollForDecisionTaskInput {
   export function isa(o: any): o is PollForDecisionTaskInput {
-    return _smithy.isa(o, "PollForDecisionTaskInput");
+    return __isa(o, "PollForDecisionTaskInput");
   }
 }
 
@@ -6264,7 +6245,7 @@ export interface RecordActivityTaskHeartbeatInput {
 
 export namespace RecordActivityTaskHeartbeatInput {
   export function isa(o: any): o is RecordActivityTaskHeartbeatInput {
-    return _smithy.isa(o, "RecordActivityTaskHeartbeatInput");
+    return __isa(o, "RecordActivityTaskHeartbeatInput");
   }
 }
 
@@ -6370,7 +6351,7 @@ export interface RegisterActivityTypeInput {
 
 export namespace RegisterActivityTypeInput {
   export function isa(o: any): o is RegisterActivityTypeInput {
-    return _smithy.isa(o, "RegisterActivityTypeInput");
+    return __isa(o, "RegisterActivityTypeInput");
   }
 }
 
@@ -6414,7 +6395,7 @@ export interface RegisterDomainInput {
 
 export namespace RegisterDomainInput {
   export function isa(o: any): o is RegisterDomainInput {
-    return _smithy.isa(o, "RegisterDomainInput");
+    return __isa(o, "RegisterDomainInput");
   }
 }
 
@@ -6537,7 +6518,7 @@ export interface RegisterWorkflowTypeInput {
 
 export namespace RegisterWorkflowTypeInput {
   export function isa(o: any): o is RegisterWorkflowTypeInput {
-    return _smithy.isa(o, "RegisterWorkflowTypeInput");
+    return __isa(o, "RegisterWorkflowTypeInput");
   }
 }
 
@@ -6561,7 +6542,7 @@ export interface RequestCancelWorkflowExecutionInput {
 
 export namespace RequestCancelWorkflowExecutionInput {
   export function isa(o: any): o is RequestCancelWorkflowExecutionInput {
-    return _smithy.isa(o, "RequestCancelWorkflowExecutionInput");
+    return __isa(o, "RequestCancelWorkflowExecutionInput");
   }
 }
 
@@ -6586,7 +6567,7 @@ export interface RespondActivityTaskCanceledInput {
 
 export namespace RespondActivityTaskCanceledInput {
   export function isa(o: any): o is RespondActivityTaskCanceledInput {
-    return _smithy.isa(o, "RespondActivityTaskCanceledInput");
+    return __isa(o, "RespondActivityTaskCanceledInput");
   }
 }
 
@@ -6612,7 +6593,7 @@ export interface RespondActivityTaskCompletedInput {
 
 export namespace RespondActivityTaskCompletedInput {
   export function isa(o: any): o is RespondActivityTaskCompletedInput {
-    return _smithy.isa(o, "RespondActivityTaskCompletedInput");
+    return __isa(o, "RespondActivityTaskCompletedInput");
   }
 }
 
@@ -6643,7 +6624,7 @@ export interface RespondActivityTaskFailedInput {
 
 export namespace RespondActivityTaskFailedInput {
   export function isa(o: any): o is RespondActivityTaskFailedInput {
-    return _smithy.isa(o, "RespondActivityTaskFailedInput");
+    return __isa(o, "RespondActivityTaskFailedInput");
   }
 }
 
@@ -6678,7 +6659,7 @@ export interface RespondDecisionTaskCompletedInput {
 
 export namespace RespondDecisionTaskCompletedInput {
   export function isa(o: any): o is RespondDecisionTaskCompletedInput {
-    return _smithy.isa(o, "RespondDecisionTaskCompletedInput");
+    return __isa(o, "RespondDecisionTaskCompletedInput");
   }
 }
 
@@ -6696,7 +6677,7 @@ export interface Run extends $MetadataBearer {
 
 export namespace Run {
   export function isa(o: any): o is Run {
-    return _smithy.isa(o, "Run");
+    return __isa(o, "Run");
   }
 }
 
@@ -6731,7 +6712,7 @@ export interface SignalWorkflowExecutionInput {
 
 export namespace SignalWorkflowExecutionInput {
   export function isa(o: any): o is SignalWorkflowExecutionInput {
-    return _smithy.isa(o, "SignalWorkflowExecutionInput");
+    return __isa(o, "SignalWorkflowExecutionInput");
   }
 }
 
@@ -6882,7 +6863,7 @@ export interface StartWorkflowExecutionInput {
 
 export namespace StartWorkflowExecutionInput {
   export function isa(o: any): o is StartWorkflowExecutionInput {
-    return _smithy.isa(o, "StartWorkflowExecutionInput");
+    return __isa(o, "StartWorkflowExecutionInput");
   }
 }
 
@@ -6902,7 +6883,7 @@ export interface TagResourceInput {
 
 export namespace TagResourceInput {
   export function isa(o: any): o is TagResourceInput {
-    return _smithy.isa(o, "TagResourceInput");
+    return __isa(o, "TagResourceInput");
   }
 }
 
@@ -6967,7 +6948,7 @@ export interface TerminateWorkflowExecutionInput {
 
 export namespace TerminateWorkflowExecutionInput {
   export function isa(o: any): o is TerminateWorkflowExecutionInput {
-    return _smithy.isa(o, "TerminateWorkflowExecutionInput");
+    return __isa(o, "TerminateWorkflowExecutionInput");
   }
 }
 
@@ -6986,7 +6967,7 @@ export interface UndeprecateActivityTypeInput {
 
 export namespace UndeprecateActivityTypeInput {
   export function isa(o: any): o is UndeprecateActivityTypeInput {
-    return _smithy.isa(o, "UndeprecateActivityTypeInput");
+    return __isa(o, "UndeprecateActivityTypeInput");
   }
 }
 
@@ -7000,7 +6981,7 @@ export interface UndeprecateDomainInput {
 
 export namespace UndeprecateDomainInput {
   export function isa(o: any): o is UndeprecateDomainInput {
-    return _smithy.isa(o, "UndeprecateDomainInput");
+    return __isa(o, "UndeprecateDomainInput");
   }
 }
 
@@ -7019,7 +7000,7 @@ export interface UndeprecateWorkflowTypeInput {
 
 export namespace UndeprecateWorkflowTypeInput {
   export function isa(o: any): o is UndeprecateWorkflowTypeInput {
-    return _smithy.isa(o, "UndeprecateWorkflowTypeInput");
+    return __isa(o, "UndeprecateWorkflowTypeInput");
   }
 }
 
@@ -7038,6 +7019,6 @@ export interface UntagResourceInput {
 
 export namespace UntagResourceInput {
   export function isa(o: any): o is UntagResourceInput {
-    return _smithy.isa(o, "UntagResourceInput");
+    return __isa(o, "UntagResourceInput");
   }
 }

--- a/clients/client-swf/protocols/Aws_json1_0.ts
+++ b/clients/client-swf/protocols/Aws_json1_0.ts
@@ -1103,6 +1103,7 @@ export async function deserializeAws_json1_0DeprecateActivityTypeCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeprecateActivityTypeCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1168,6 +1169,7 @@ export async function deserializeAws_json1_0DeprecateDomainCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_0DeprecateDomainCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeprecateDomainCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1236,6 +1238,7 @@ export async function deserializeAws_json1_0DeprecateWorkflowTypeCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeprecateWorkflowTypeCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2230,6 +2233,7 @@ export async function deserializeAws_json1_0RegisterActivityTypeCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: RegisterActivityTypeCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2302,6 +2306,7 @@ export async function deserializeAws_json1_0RegisterDomainCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_0RegisterDomainCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: RegisterDomainCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2377,6 +2382,7 @@ export async function deserializeAws_json1_0RegisterWorkflowTypeCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: RegisterWorkflowTypeCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2452,6 +2458,7 @@ export async function deserializeAws_json1_0RequestCancelWorkflowExecutionComman
       context
     );
   }
+  await collectBody(output.body, context);
   const response: RequestCancelWorkflowExecutionCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2513,6 +2520,7 @@ export async function deserializeAws_json1_0RespondActivityTaskCanceledCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: RespondActivityTaskCanceledCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2574,6 +2582,7 @@ export async function deserializeAws_json1_0RespondActivityTaskCompletedCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: RespondActivityTaskCompletedCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2635,6 +2644,7 @@ export async function deserializeAws_json1_0RespondActivityTaskFailedCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: RespondActivityTaskFailedCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2696,6 +2706,7 @@ export async function deserializeAws_json1_0RespondDecisionTaskCompletedCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: RespondDecisionTaskCompletedCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2757,6 +2768,7 @@ export async function deserializeAws_json1_0SignalWorkflowExecutionCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: SignalWorkflowExecutionCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2909,6 +2921,7 @@ export async function deserializeAws_json1_0TagResourceCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_0TagResourceCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: TagResourceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -2984,6 +2997,7 @@ export async function deserializeAws_json1_0TerminateWorkflowExecutionCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: TerminateWorkflowExecutionCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -3045,6 +3059,7 @@ export async function deserializeAws_json1_0UndeprecateActivityTypeCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: UndeprecateActivityTypeCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -3110,6 +3125,7 @@ export async function deserializeAws_json1_0UndeprecateDomainCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_0UndeprecateDomainCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: UndeprecateDomainCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -3178,6 +3194,7 @@ export async function deserializeAws_json1_0UndeprecateWorkflowTypeCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: UndeprecateWorkflowTypeCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -3243,6 +3260,7 @@ export async function deserializeAws_json1_0UntagResourceCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_0UntagResourceCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: UntagResourceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };

--- a/clients/client-textract/models/index.ts
+++ b/clients/client-textract/models/index.ts
@@ -1,11 +1,15 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  LazyJsonString as __LazyJsonString,
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
  * <p>You aren't authorized to perform the action.</p>
  */
 export interface AccessDeniedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AccessDeniedException";
   $fault: "client";
@@ -15,7 +19,7 @@ export interface AccessDeniedException
 
 export namespace AccessDeniedException {
   export function isa(o: any): o is AccessDeniedException {
-    return _smithy.isa(o, "AccessDeniedException");
+    return __isa(o, "AccessDeniedException");
   }
 }
 
@@ -47,7 +51,7 @@ export interface AnalyzeDocumentRequest {
 
 export namespace AnalyzeDocumentRequest {
   export function isa(o: any): o is AnalyzeDocumentRequest {
-    return _smithy.isa(o, "AnalyzeDocumentRequest");
+    return __isa(o, "AnalyzeDocumentRequest");
   }
 }
 
@@ -76,7 +80,7 @@ export interface AnalyzeDocumentResponse extends $MetadataBearer {
 
 export namespace AnalyzeDocumentResponse {
   export function isa(o: any): o is AnalyzeDocumentResponse {
-    return _smithy.isa(o, "AnalyzeDocumentResponse");
+    return __isa(o, "AnalyzeDocumentResponse");
   }
 }
 
@@ -84,7 +88,7 @@ export namespace AnalyzeDocumentResponse {
  * <p>Amazon Textract isn't able to read the document.</p>
  */
 export interface BadDocumentException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "BadDocumentException";
   $fault: "client";
@@ -94,7 +98,7 @@ export interface BadDocumentException
 
 export namespace BadDocumentException {
   export function isa(o: any): o is BadDocumentException {
-    return _smithy.isa(o, "BadDocumentException");
+    return __isa(o, "BadDocumentException");
   }
 }
 
@@ -284,7 +288,7 @@ export interface Block {
 
 export namespace Block {
   export function isa(o: any): o is Block {
-    return _smithy.isa(o, "Block");
+    return __isa(o, "Block");
   }
 }
 
@@ -341,7 +345,7 @@ export interface BoundingBox {
 
 export namespace BoundingBox {
   export function isa(o: any): o is BoundingBox {
-    return _smithy.isa(o, "BoundingBox");
+    return __isa(o, "BoundingBox");
   }
 }
 
@@ -364,7 +368,7 @@ export interface DetectDocumentTextRequest {
 
 export namespace DetectDocumentTextRequest {
   export function isa(o: any): o is DetectDocumentTextRequest {
-    return _smithy.isa(o, "DetectDocumentTextRequest");
+    return __isa(o, "DetectDocumentTextRequest");
   }
 }
 
@@ -390,7 +394,7 @@ export interface DetectDocumentTextResponse extends $MetadataBearer {
 
 export namespace DetectDocumentTextResponse {
   export function isa(o: any): o is DetectDocumentTextResponse {
-    return _smithy.isa(o, "DetectDocumentTextResponse");
+    return __isa(o, "DetectDocumentTextResponse");
   }
 }
 
@@ -432,7 +436,7 @@ export interface Document {
 
 export namespace Document {
   export function isa(o: any): o is Document {
-    return _smithy.isa(o, "Document");
+    return __isa(o, "Document");
   }
 }
 
@@ -452,7 +456,7 @@ export interface DocumentLocation {
 
 export namespace DocumentLocation {
   export function isa(o: any): o is DocumentLocation {
-    return _smithy.isa(o, "DocumentLocation");
+    return __isa(o, "DocumentLocation");
   }
 }
 
@@ -469,7 +473,7 @@ export interface DocumentMetadata {
 
 export namespace DocumentMetadata {
   export function isa(o: any): o is DocumentMetadata {
-    return _smithy.isa(o, "DocumentMetadata");
+    return __isa(o, "DocumentMetadata");
   }
 }
 
@@ -479,7 +483,7 @@ export namespace DocumentMetadata {
  *          MB for PDF files.</p>
  */
 export interface DocumentTooLargeException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DocumentTooLargeException";
   $fault: "client";
@@ -489,7 +493,7 @@ export interface DocumentTooLargeException
 
 export namespace DocumentTooLargeException {
   export function isa(o: any): o is DocumentTooLargeException {
-    return _smithy.isa(o, "DocumentTooLargeException");
+    return __isa(o, "DocumentTooLargeException");
   }
 }
 
@@ -523,7 +527,7 @@ export interface Geometry {
 
 export namespace Geometry {
   export function isa(o: any): o is Geometry {
-    return _smithy.isa(o, "Geometry");
+    return __isa(o, "Geometry");
   }
 }
 
@@ -551,7 +555,7 @@ export interface GetDocumentAnalysisRequest {
 
 export namespace GetDocumentAnalysisRequest {
   export function isa(o: any): o is GetDocumentAnalysisRequest {
-    return _smithy.isa(o, "GetDocumentAnalysisRequest");
+    return __isa(o, "GetDocumentAnalysisRequest");
   }
 }
 
@@ -597,7 +601,7 @@ export interface GetDocumentAnalysisResponse extends $MetadataBearer {
 
 export namespace GetDocumentAnalysisResponse {
   export function isa(o: any): o is GetDocumentAnalysisResponse {
-    return _smithy.isa(o, "GetDocumentAnalysisResponse");
+    return __isa(o, "GetDocumentAnalysisResponse");
   }
 }
 
@@ -625,7 +629,7 @@ export interface GetDocumentTextDetectionRequest {
 
 export namespace GetDocumentTextDetectionRequest {
   export function isa(o: any): o is GetDocumentTextDetectionRequest {
-    return _smithy.isa(o, "GetDocumentTextDetectionRequest");
+    return __isa(o, "GetDocumentTextDetectionRequest");
   }
 }
 
@@ -672,7 +676,7 @@ export interface GetDocumentTextDetectionResponse extends $MetadataBearer {
 
 export namespace GetDocumentTextDetectionResponse {
   export function isa(o: any): o is GetDocumentTextDetectionResponse {
-    return _smithy.isa(o, "GetDocumentTextDetectionResponse");
+    return __isa(o, "GetDocumentTextDetectionResponse");
   }
 }
 
@@ -685,7 +689,7 @@ export interface HumanLoopActivationOutput {
   /**
    * <p>Shows the result of condition evaluations, including those conditions which activated a human review.</p>
    */
-  HumanLoopActivationConditionsEvaluationResults?: string;
+  HumanLoopActivationConditionsEvaluationResults?: __LazyJsonString | string;
 
   /**
    * <p>Shows if and why human review was needed.</p>
@@ -700,7 +704,7 @@ export interface HumanLoopActivationOutput {
 
 export namespace HumanLoopActivationOutput {
   export function isa(o: any): o is HumanLoopActivationOutput {
-    return _smithy.isa(o, "HumanLoopActivationOutput");
+    return __isa(o, "HumanLoopActivationOutput");
   }
 }
 
@@ -728,7 +732,7 @@ export interface HumanLoopConfig {
 
 export namespace HumanLoopConfig {
   export function isa(o: any): o is HumanLoopConfig {
-    return _smithy.isa(o, "HumanLoopConfig");
+    return __isa(o, "HumanLoopConfig");
   }
 }
 
@@ -746,7 +750,7 @@ export interface HumanLoopDataAttributes {
 
 export namespace HumanLoopDataAttributes {
   export function isa(o: any): o is HumanLoopDataAttributes {
-    return _smithy.isa(o, "HumanLoopDataAttributes");
+    return __isa(o, "HumanLoopDataAttributes");
   }
 }
 
@@ -754,7 +758,7 @@ export namespace HumanLoopDataAttributes {
  * <p>Indicates you have exceeded the maximum number of active human in the loop workflows available</p>
  */
 export interface HumanLoopQuotaExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "HumanLoopQuotaExceededException";
   $fault: "client";
@@ -767,7 +771,7 @@ export interface HumanLoopQuotaExceededException
 
 export namespace HumanLoopQuotaExceededException {
   export function isa(o: any): o is HumanLoopQuotaExceededException {
-    return _smithy.isa(o, "HumanLoopQuotaExceededException");
+    return __isa(o, "HumanLoopQuotaExceededException");
   }
 }
 
@@ -777,7 +781,7 @@ export namespace HumanLoopQuotaExceededException {
  *          operation. </p>
  */
 export interface IdempotentParameterMismatchException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "IdempotentParameterMismatchException";
   $fault: "client";
@@ -787,7 +791,7 @@ export interface IdempotentParameterMismatchException
 
 export namespace IdempotentParameterMismatchException {
   export function isa(o: any): o is IdempotentParameterMismatchException {
-    return _smithy.isa(o, "IdempotentParameterMismatchException");
+    return __isa(o, "IdempotentParameterMismatchException");
   }
 }
 
@@ -795,7 +799,7 @@ export namespace IdempotentParameterMismatchException {
  * <p>Amazon Textract experienced a service issue. Try your call again.</p>
  */
 export interface InternalServerError
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalServerError";
   $fault: "server";
@@ -805,7 +809,7 @@ export interface InternalServerError
 
 export namespace InternalServerError {
   export function isa(o: any): o is InternalServerError {
-    return _smithy.isa(o, "InternalServerError");
+    return __isa(o, "InternalServerError");
   }
 }
 
@@ -814,7 +818,7 @@ export namespace InternalServerError {
  *       <a>GetDocumentAnalysis</a>.</p>
  */
 export interface InvalidJobIdException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidJobIdException";
   $fault: "client";
@@ -824,7 +828,7 @@ export interface InvalidJobIdException
 
 export namespace InvalidJobIdException {
   export function isa(o: any): o is InvalidJobIdException {
-    return _smithy.isa(o, "InvalidJobIdException");
+    return __isa(o, "InvalidJobIdException");
   }
 }
 
@@ -836,7 +840,7 @@ export namespace InvalidJobIdException {
  *        Validate your parameter before calling the API operation again.</p>
  */
 export interface InvalidParameterException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidParameterException";
   $fault: "client";
@@ -846,7 +850,7 @@ export interface InvalidParameterException
 
 export namespace InvalidParameterException {
   export function isa(o: any): o is InvalidParameterException {
-    return _smithy.isa(o, "InvalidParameterException");
+    return __isa(o, "InvalidParameterException");
   }
 }
 
@@ -854,7 +858,7 @@ export namespace InvalidParameterException {
  * <p>Amazon Textract is unable to access the S3 object that's specified in the request.</p>
  */
 export interface InvalidS3ObjectException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidS3ObjectException";
   $fault: "client";
@@ -864,7 +868,7 @@ export interface InvalidS3ObjectException
 
 export namespace InvalidS3ObjectException {
   export function isa(o: any): o is InvalidS3ObjectException {
-    return _smithy.isa(o, "InvalidS3ObjectException");
+    return __isa(o, "InvalidS3ObjectException");
   }
 }
 
@@ -883,7 +887,7 @@ export enum JobStatus {
  *          the Amazon Textract service limit. </p>
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -893,7 +897,7 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
@@ -916,7 +920,7 @@ export interface NotificationChannel {
 
 export namespace NotificationChannel {
   export function isa(o: any): o is NotificationChannel {
-    return _smithy.isa(o, "NotificationChannel");
+    return __isa(o, "NotificationChannel");
   }
 }
 
@@ -946,7 +950,7 @@ export interface Point {
 
 export namespace Point {
   export function isa(o: any): o is Point {
-    return _smithy.isa(o, "Point");
+    return __isa(o, "Point");
   }
 }
 
@@ -955,7 +959,7 @@ export namespace Point {
  *          contact Amazon Textract.</p>
  */
 export interface ProvisionedThroughputExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ProvisionedThroughputExceededException";
   $fault: "client";
@@ -965,7 +969,7 @@ export interface ProvisionedThroughputExceededException
 
 export namespace ProvisionedThroughputExceededException {
   export function isa(o: any): o is ProvisionedThroughputExceededException {
-    return _smithy.isa(o, "ProvisionedThroughputExceededException");
+    return __isa(o, "ProvisionedThroughputExceededException");
   }
 }
 
@@ -996,7 +1000,7 @@ export interface Relationship {
 
 export namespace Relationship {
   export function isa(o: any): o is Relationship {
-    return _smithy.isa(o, "Relationship");
+    return __isa(o, "Relationship");
   }
 }
 
@@ -1036,7 +1040,7 @@ export interface S3Object {
 
 export namespace S3Object {
   export function isa(o: any): o is S3Object {
-    return _smithy.isa(o, "S3Object");
+    return __isa(o, "S3Object");
   }
 }
 
@@ -1088,7 +1092,7 @@ export interface StartDocumentAnalysisRequest {
 
 export namespace StartDocumentAnalysisRequest {
   export function isa(o: any): o is StartDocumentAnalysisRequest {
-    return _smithy.isa(o, "StartDocumentAnalysisRequest");
+    return __isa(o, "StartDocumentAnalysisRequest");
   }
 }
 
@@ -1104,7 +1108,7 @@ export interface StartDocumentAnalysisResponse extends $MetadataBearer {
 
 export namespace StartDocumentAnalysisResponse {
   export function isa(o: any): o is StartDocumentAnalysisResponse {
-    return _smithy.isa(o, "StartDocumentAnalysisResponse");
+    return __isa(o, "StartDocumentAnalysisResponse");
   }
 }
 
@@ -1141,7 +1145,7 @@ export interface StartDocumentTextDetectionRequest {
 
 export namespace StartDocumentTextDetectionRequest {
   export function isa(o: any): o is StartDocumentTextDetectionRequest {
-    return _smithy.isa(o, "StartDocumentTextDetectionRequest");
+    return __isa(o, "StartDocumentTextDetectionRequest");
   }
 }
 
@@ -1157,7 +1161,7 @@ export interface StartDocumentTextDetectionResponse extends $MetadataBearer {
 
 export namespace StartDocumentTextDetectionResponse {
   export function isa(o: any): o is StartDocumentTextDetectionResponse {
-    return _smithy.isa(o, "StartDocumentTextDetectionResponse");
+    return __isa(o, "StartDocumentTextDetectionResponse");
   }
 }
 
@@ -1165,7 +1169,7 @@ export namespace StartDocumentTextDetectionResponse {
  * <p>Amazon Textract is temporarily unable to process the request. Try your call again.</p>
  */
 export interface ThrottlingException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ThrottlingException";
   $fault: "server";
@@ -1175,7 +1179,7 @@ export interface ThrottlingException
 
 export namespace ThrottlingException {
   export function isa(o: any): o is ThrottlingException {
-    return _smithy.isa(o, "ThrottlingException");
+    return __isa(o, "ThrottlingException");
   }
 }
 
@@ -1184,7 +1188,7 @@ export namespace ThrottlingException {
  *          PNG or JPEG format. Documents for asynchronous operations can also be in PDF format.</p>
  */
 export interface UnsupportedDocumentException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UnsupportedDocumentException";
   $fault: "client";
@@ -1194,7 +1198,7 @@ export interface UnsupportedDocumentException
 
 export namespace UnsupportedDocumentException {
   export function isa(o: any): o is UnsupportedDocumentException {
-    return _smithy.isa(o, "UnsupportedDocumentException");
+    return __isa(o, "UnsupportedDocumentException");
   }
 }
 
@@ -1216,6 +1220,6 @@ export interface Warning {
 
 export namespace Warning {
   export function isa(o: any): o is Warning {
-    return _smithy.isa(o, "Warning");
+    return __isa(o, "Warning");
   }
 }

--- a/clients/client-textract/protocols/Aws_json1_1.ts
+++ b/clients/client-textract/protocols/Aws_json1_1.ts
@@ -70,7 +70,10 @@ import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  LazyJsonString as __LazyJsonString,
+  SmithyException as __SmithyException
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -1715,8 +1718,9 @@ const deserializeAws_json1_1HumanLoopActivationOutput = (
     output.HumanLoopActivationConditionsEvaluationResults !== undefined &&
     output.HumanLoopActivationConditionsEvaluationResults !== null
   ) {
-    contents.HumanLoopActivationConditionsEvaluationResults =
-      output.HumanLoopActivationConditionsEvaluationResults;
+    contents.HumanLoopActivationConditionsEvaluationResults = new __LazyJsonString(
+      output.HumanLoopActivationConditionsEvaluationResults
+    );
   }
   if (
     output.HumanLoopActivationReasons !== undefined &&

--- a/clients/client-transcribe-streaming/models/index.ts
+++ b/clients/client-transcribe-streaming/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -19,7 +22,7 @@ export interface Alternative {
 
 export namespace Alternative {
   export function isa(o: any): o is Alternative {
-    return _smithy.isa(o, "Alternative");
+    return __isa(o, "Alternative");
   }
 }
 
@@ -36,7 +39,7 @@ export interface AudioEvent {
 
 export namespace AudioEvent {
   export function isa(o: any): o is AudioEvent {
-    return _smithy.isa(o, "AudioEvent");
+    return __isa(o, "AudioEvent");
   }
 }
 
@@ -81,7 +84,7 @@ export namespace AudioStream {
  *       request again.</p>
  */
 export interface BadRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "BadRequestException";
   $fault: "client";
@@ -90,7 +93,7 @@ export interface BadRequestException
 
 export namespace BadRequestException {
   export function isa(o: any): o is BadRequestException {
-    return _smithy.isa(o, "BadRequestException");
+    return __isa(o, "BadRequestException");
   }
 }
 
@@ -98,9 +101,7 @@ export namespace BadRequestException {
  * <p>A new stream started with the same session ID. The current stream has been
  *       terminated.</p>
  */
-export interface ConflictException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface ConflictException extends __SmithyException, $MetadataBearer {
   name: "ConflictException";
   $fault: "client";
   Message?: string;
@@ -108,7 +109,7 @@ export interface ConflictException
 
 export namespace ConflictException {
   export function isa(o: any): o is ConflictException {
-    return _smithy.isa(o, "ConflictException");
+    return __isa(o, "ConflictException");
   }
 }
 
@@ -117,7 +118,7 @@ export namespace ConflictException {
  *       request again.</p>
  */
 export interface InternalFailureException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalFailureException";
   $fault: "server";
@@ -126,7 +127,7 @@ export interface InternalFailureException
 
 export namespace InternalFailureException {
   export function isa(o: any): o is InternalFailureException {
-    return _smithy.isa(o, "InternalFailureException");
+    return __isa(o, "InternalFailureException");
   }
 }
 
@@ -162,7 +163,7 @@ export interface Item {
 
 export namespace Item {
   export function isa(o: any): o is Item {
-    return _smithy.isa(o, "Item");
+    return __isa(o, "Item");
   }
 }
 
@@ -187,7 +188,7 @@ export enum LanguageCode {
  *       again.</p>
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -196,7 +197,7 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
@@ -240,7 +241,7 @@ export interface Result {
 
 export namespace Result {
   export function isa(o: any): o is Result {
-    return _smithy.isa(o, "Result");
+    return __isa(o, "Result");
   }
 }
 
@@ -283,7 +284,7 @@ export interface StartStreamTranscriptionRequest {
 
 export namespace StartStreamTranscriptionRequest {
   export function isa(o: any): o is StartStreamTranscriptionRequest {
-    return _smithy.isa(o, "StartStreamTranscriptionRequest");
+    return __isa(o, "StartStreamTranscriptionRequest");
   }
 }
 
@@ -328,7 +329,7 @@ export interface StartStreamTranscriptionResponse extends $MetadataBearer {
 
 export namespace StartStreamTranscriptionResponse {
   export function isa(o: any): o is StartStreamTranscriptionResponse {
-    return _smithy.isa(o, "StartStreamTranscriptionResponse");
+    return __isa(o, "StartStreamTranscriptionResponse");
   }
 }
 
@@ -347,7 +348,7 @@ export interface Transcript {
 
 export namespace Transcript {
   export function isa(o: any): o is Transcript {
-    return _smithy.isa(o, "Transcript");
+    return __isa(o, "Transcript");
   }
 }
 
@@ -366,7 +367,7 @@ export interface TranscriptEvent {
 
 export namespace TranscriptEvent {
   export function isa(o: any): o is TranscriptEvent {
-    return _smithy.isa(o, "TranscriptEvent");
+    return __isa(o, "TranscriptEvent");
   }
 }
 

--- a/clients/client-transcribe-streaming/protocols/Aws_restJson1_1.ts
+++ b/clients/client-transcribe-streaming/protocols/Aws_restJson1_1.ts
@@ -35,12 +35,10 @@ export async function serializeAws_restJson1_1StartStreamTranscriptionCommand(
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.LanguageCode !== undefined) {
-    headers["x-amzn-transcribe-language-code"] = input.LanguageCode.toString();
+    headers["x-amzn-transcribe-language-code"] = input.LanguageCode;
   }
   if (input.MediaEncoding !== undefined) {
-    headers[
-      "x-amzn-transcribe-media-encoding"
-    ] = input.MediaEncoding.toString();
+    headers["x-amzn-transcribe-media-encoding"] = input.MediaEncoding;
   }
   if (input.MediaSampleRateHertz !== undefined) {
     headers[
@@ -48,12 +46,10 @@ export async function serializeAws_restJson1_1StartStreamTranscriptionCommand(
     ] = input.MediaSampleRateHertz.toString();
   }
   if (input.SessionId !== undefined) {
-    headers["x-amzn-transcribe-session-id"] = input.SessionId.toString();
+    headers["x-amzn-transcribe-session-id"] = input.SessionId;
   }
   if (input.VocabularyName !== undefined) {
-    headers[
-      "x-amzn-transcribe-vocabulary-name"
-    ] = input.VocabularyName.toString();
+    headers["x-amzn-transcribe-vocabulary-name"] = input.VocabularyName;
   }
   let resolvedPath = "/stream-transcription";
   let body: any;

--- a/clients/client-transcribe/models/index.ts
+++ b/clients/client-transcribe/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -8,7 +11,7 @@ import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
  *             information.</p>
  */
 export interface BadRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "BadRequestException";
   $fault: "client";
@@ -17,7 +20,7 @@ export interface BadRequestException
 
 export namespace BadRequestException {
   export function isa(o: any): o is BadRequestException {
-    return _smithy.isa(o, "BadRequestException");
+    return __isa(o, "BadRequestException");
   }
 }
 
@@ -28,9 +31,7 @@ export namespace BadRequestException {
  *         <p>When you are using the <code>UpdateVocabulary</code> operation, there are two jobs
  *             running at the same time. Resend the second request later.</p>
  */
-export interface ConflictException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface ConflictException extends __SmithyException, $MetadataBearer {
   name: "ConflictException";
   $fault: "client";
   Message?: string;
@@ -38,7 +39,7 @@ export interface ConflictException
 
 export namespace ConflictException {
   export function isa(o: any): o is ConflictException {
-    return _smithy.isa(o, "ConflictException");
+    return __isa(o, "ConflictException");
   }
 }
 
@@ -80,7 +81,7 @@ export interface CreateVocabularyFilterRequest {
 
 export namespace CreateVocabularyFilterRequest {
   export function isa(o: any): o is CreateVocabularyFilterRequest {
-    return _smithy.isa(o, "CreateVocabularyFilterRequest");
+    return __isa(o, "CreateVocabularyFilterRequest");
   }
 }
 
@@ -104,7 +105,7 @@ export interface CreateVocabularyFilterResponse extends $MetadataBearer {
 
 export namespace CreateVocabularyFilterResponse {
   export function isa(o: any): o is CreateVocabularyFilterResponse {
-    return _smithy.isa(o, "CreateVocabularyFilterResponse");
+    return __isa(o, "CreateVocabularyFilterResponse");
   }
 }
 
@@ -147,7 +148,7 @@ export interface CreateVocabularyRequest {
 
 export namespace CreateVocabularyRequest {
   export function isa(o: any): o is CreateVocabularyRequest {
-    return _smithy.isa(o, "CreateVocabularyRequest");
+    return __isa(o, "CreateVocabularyRequest");
   }
 }
 
@@ -184,7 +185,7 @@ export interface CreateVocabularyResponse extends $MetadataBearer {
 
 export namespace CreateVocabularyResponse {
   export function isa(o: any): o is CreateVocabularyResponse {
-    return _smithy.isa(o, "CreateVocabularyResponse");
+    return __isa(o, "CreateVocabularyResponse");
   }
 }
 
@@ -198,7 +199,7 @@ export interface DeleteTranscriptionJobRequest {
 
 export namespace DeleteTranscriptionJobRequest {
   export function isa(o: any): o is DeleteTranscriptionJobRequest {
-    return _smithy.isa(o, "DeleteTranscriptionJobRequest");
+    return __isa(o, "DeleteTranscriptionJobRequest");
   }
 }
 
@@ -212,7 +213,7 @@ export interface DeleteVocabularyFilterRequest {
 
 export namespace DeleteVocabularyFilterRequest {
   export function isa(o: any): o is DeleteVocabularyFilterRequest {
-    return _smithy.isa(o, "DeleteVocabularyFilterRequest");
+    return __isa(o, "DeleteVocabularyFilterRequest");
   }
 }
 
@@ -226,7 +227,7 @@ export interface DeleteVocabularyRequest {
 
 export namespace DeleteVocabularyRequest {
   export function isa(o: any): o is DeleteVocabularyRequest {
-    return _smithy.isa(o, "DeleteVocabularyRequest");
+    return __isa(o, "DeleteVocabularyRequest");
   }
 }
 
@@ -240,7 +241,7 @@ export interface GetTranscriptionJobRequest {
 
 export namespace GetTranscriptionJobRequest {
   export function isa(o: any): o is GetTranscriptionJobRequest {
-    return _smithy.isa(o, "GetTranscriptionJobRequest");
+    return __isa(o, "GetTranscriptionJobRequest");
   }
 }
 
@@ -254,7 +255,7 @@ export interface GetTranscriptionJobResponse extends $MetadataBearer {
 
 export namespace GetTranscriptionJobResponse {
   export function isa(o: any): o is GetTranscriptionJobResponse {
-    return _smithy.isa(o, "GetTranscriptionJobResponse");
+    return __isa(o, "GetTranscriptionJobResponse");
   }
 }
 
@@ -268,7 +269,7 @@ export interface GetVocabularyFilterRequest {
 
 export namespace GetVocabularyFilterRequest {
   export function isa(o: any): o is GetVocabularyFilterRequest {
-    return _smithy.isa(o, "GetVocabularyFilterRequest");
+    return __isa(o, "GetVocabularyFilterRequest");
   }
 }
 
@@ -298,7 +299,7 @@ export interface GetVocabularyFilterResponse extends $MetadataBearer {
 
 export namespace GetVocabularyFilterResponse {
   export function isa(o: any): o is GetVocabularyFilterResponse {
-    return _smithy.isa(o, "GetVocabularyFilterResponse");
+    return __isa(o, "GetVocabularyFilterResponse");
   }
 }
 
@@ -313,7 +314,7 @@ export interface GetVocabularyRequest {
 
 export namespace GetVocabularyRequest {
   export function isa(o: any): o is GetVocabularyRequest {
-    return _smithy.isa(o, "GetVocabularyRequest");
+    return __isa(o, "GetVocabularyRequest");
   }
 }
 
@@ -354,7 +355,7 @@ export interface GetVocabularyResponse extends $MetadataBearer {
 
 export namespace GetVocabularyResponse {
   export function isa(o: any): o is GetVocabularyResponse {
-    return _smithy.isa(o, "GetVocabularyResponse");
+    return __isa(o, "GetVocabularyResponse");
   }
 }
 
@@ -363,7 +364,7 @@ export namespace GetVocabularyResponse {
  *             again.</p>
  */
 export interface InternalFailureException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalFailureException";
   $fault: "server";
@@ -372,7 +373,7 @@ export interface InternalFailureException
 
 export namespace InternalFailureException {
   export function isa(o: any): o is InternalFailureException {
-    return _smithy.isa(o, "InternalFailureException");
+    return __isa(o, "InternalFailureException");
   }
 }
 
@@ -405,7 +406,7 @@ export interface JobExecutionSettings {
 
 export namespace JobExecutionSettings {
   export function isa(o: any): o is JobExecutionSettings {
-    return _smithy.isa(o, "JobExecutionSettings");
+    return __isa(o, "JobExecutionSettings");
   }
 }
 
@@ -448,7 +449,7 @@ export enum LanguageCode {
  *             resend your request, or use a smaller file and resend the request.</p>
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -457,7 +458,7 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
@@ -491,7 +492,7 @@ export interface ListTranscriptionJobsRequest {
 
 export namespace ListTranscriptionJobsRequest {
   export function isa(o: any): o is ListTranscriptionJobsRequest {
-    return _smithy.isa(o, "ListTranscriptionJobsRequest");
+    return __isa(o, "ListTranscriptionJobsRequest");
   }
 }
 
@@ -519,7 +520,7 @@ export interface ListTranscriptionJobsResponse extends $MetadataBearer {
 
 export namespace ListTranscriptionJobsResponse {
   export function isa(o: any): o is ListTranscriptionJobsResponse {
-    return _smithy.isa(o, "ListTranscriptionJobsResponse");
+    return __isa(o, "ListTranscriptionJobsResponse");
   }
 }
 
@@ -554,7 +555,7 @@ export interface ListVocabulariesRequest {
 
 export namespace ListVocabulariesRequest {
   export function isa(o: any): o is ListVocabulariesRequest {
-    return _smithy.isa(o, "ListVocabulariesRequest");
+    return __isa(o, "ListVocabulariesRequest");
   }
 }
 
@@ -583,7 +584,7 @@ export interface ListVocabulariesResponse extends $MetadataBearer {
 
 export namespace ListVocabulariesResponse {
   export function isa(o: any): o is ListVocabulariesResponse {
-    return _smithy.isa(o, "ListVocabulariesResponse");
+    return __isa(o, "ListVocabulariesResponse");
   }
 }
 
@@ -611,7 +612,7 @@ export interface ListVocabularyFiltersRequest {
 
 export namespace ListVocabularyFiltersRequest {
   export function isa(o: any): o is ListVocabularyFiltersRequest {
-    return _smithy.isa(o, "ListVocabularyFiltersRequest");
+    return __isa(o, "ListVocabularyFiltersRequest");
   }
 }
 
@@ -638,7 +639,7 @@ export interface ListVocabularyFiltersResponse extends $MetadataBearer {
 
 export namespace ListVocabularyFiltersResponse {
   export function isa(o: any): o is ListVocabularyFiltersResponse {
-    return _smithy.isa(o, "ListVocabularyFiltersResponse");
+    return __isa(o, "ListVocabularyFiltersResponse");
   }
 }
 
@@ -669,7 +670,7 @@ export interface Media {
 
 export namespace Media {
   export function isa(o: any): o is Media {
-    return _smithy.isa(o, "Media");
+    return __isa(o, "Media");
   }
 }
 
@@ -684,9 +685,7 @@ export enum MediaFormat {
  * <p>We can't find the requested resource. Check the name and try your request
  *             again.</p>
  */
-export interface NotFoundException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface NotFoundException extends __SmithyException, $MetadataBearer {
   name: "NotFoundException";
   $fault: "client";
   Message?: string;
@@ -694,7 +693,7 @@ export interface NotFoundException
 
 export namespace NotFoundException {
   export function isa(o: any): o is NotFoundException {
-    return _smithy.isa(o, "NotFoundException");
+    return __isa(o, "NotFoundException");
   }
 }
 
@@ -776,7 +775,7 @@ export interface Settings {
 
 export namespace Settings {
   export function isa(o: any): o is Settings {
-    return _smithy.isa(o, "Settings");
+    return __isa(o, "Settings");
   }
 }
 
@@ -880,7 +879,7 @@ export interface StartTranscriptionJobRequest {
 
 export namespace StartTranscriptionJobRequest {
   export function isa(o: any): o is StartTranscriptionJobRequest {
-    return _smithy.isa(o, "StartTranscriptionJobRequest");
+    return __isa(o, "StartTranscriptionJobRequest");
   }
 }
 
@@ -894,7 +893,7 @@ export interface StartTranscriptionJobResponse extends $MetadataBearer {
 
 export namespace StartTranscriptionJobResponse {
   export function isa(o: any): o is StartTranscriptionJobResponse {
-    return _smithy.isa(o, "StartTranscriptionJobResponse");
+    return __isa(o, "StartTranscriptionJobResponse");
   }
 }
 
@@ -915,7 +914,7 @@ export interface Transcript {
 
 export namespace Transcript {
   export function isa(o: any): o is Transcript {
-    return _smithy.isa(o, "Transcript");
+    return __isa(o, "Transcript");
   }
 }
 
@@ -1038,7 +1037,7 @@ export interface TranscriptionJob {
 
 export namespace TranscriptionJob {
   export function isa(o: any): o is TranscriptionJob {
-    return _smithy.isa(o, "TranscriptionJob");
+    return __isa(o, "TranscriptionJob");
   }
 }
 
@@ -1106,7 +1105,7 @@ export interface TranscriptionJobSummary {
 
 export namespace TranscriptionJobSummary {
   export function isa(o: any): o is TranscriptionJobSummary {
-    return _smithy.isa(o, "TranscriptionJobSummary");
+    return __isa(o, "TranscriptionJobSummary");
   }
 }
 
@@ -1140,7 +1139,7 @@ export interface UpdateVocabularyFilterRequest {
 
 export namespace UpdateVocabularyFilterRequest {
   export function isa(o: any): o is UpdateVocabularyFilterRequest {
-    return _smithy.isa(o, "UpdateVocabularyFilterRequest");
+    return __isa(o, "UpdateVocabularyFilterRequest");
   }
 }
 
@@ -1164,7 +1163,7 @@ export interface UpdateVocabularyFilterResponse extends $MetadataBearer {
 
 export namespace UpdateVocabularyFilterResponse {
   export function isa(o: any): o is UpdateVocabularyFilterResponse {
-    return _smithy.isa(o, "UpdateVocabularyFilterResponse");
+    return __isa(o, "UpdateVocabularyFilterResponse");
   }
 }
 
@@ -1206,7 +1205,7 @@ export interface UpdateVocabularyRequest {
 
 export namespace UpdateVocabularyRequest {
   export function isa(o: any): o is UpdateVocabularyRequest {
-    return _smithy.isa(o, "UpdateVocabularyRequest");
+    return __isa(o, "UpdateVocabularyRequest");
   }
 }
 
@@ -1237,7 +1236,7 @@ export interface UpdateVocabularyResponse extends $MetadataBearer {
 
 export namespace UpdateVocabularyResponse {
   export function isa(o: any): o is UpdateVocabularyResponse {
-    return _smithy.isa(o, "UpdateVocabularyResponse");
+    return __isa(o, "UpdateVocabularyResponse");
   }
 }
 
@@ -1265,7 +1264,7 @@ export interface VocabularyFilterInfo {
 
 export namespace VocabularyFilterInfo {
   export function isa(o: any): o is VocabularyFilterInfo {
-    return _smithy.isa(o, "VocabularyFilterInfo");
+    return __isa(o, "VocabularyFilterInfo");
   }
 }
 
@@ -1303,7 +1302,7 @@ export interface VocabularyInfo {
 
 export namespace VocabularyInfo {
   export function isa(o: any): o is VocabularyInfo {
-    return _smithy.isa(o, "VocabularyInfo");
+    return __isa(o, "VocabularyInfo");
   }
 }
 

--- a/clients/client-transcribe/protocols/Aws_json1_1.ts
+++ b/clients/client-transcribe/protocols/Aws_json1_1.ts
@@ -473,6 +473,7 @@ export async function deserializeAws_json1_1DeleteTranscriptionJobCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteTranscriptionJobCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -538,6 +539,7 @@ export async function deserializeAws_json1_1DeleteVocabularyCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1DeleteVocabularyCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteVocabularyCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -613,6 +615,7 @@ export async function deserializeAws_json1_1DeleteVocabularyFilterCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteVocabularyFilterCommandOutput = {
     $metadata: deserializeMetadata(output)
   };

--- a/clients/client-transfer/models/index.ts
+++ b/clients/client-transfer/models/index.ts
@@ -1,11 +1,14 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
  * <p>The request has failed because the AWS Transfer for SFTP service is not available.</p>
  */
 export interface ServiceUnavailableException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ServiceUnavailableException";
   $fault: "server";
@@ -14,7 +17,7 @@ export interface ServiceUnavailableException
 
 export namespace ServiceUnavailableException {
   export function isa(o: any): o is ServiceUnavailableException {
-    return _smithy.isa(o, "ServiceUnavailableException");
+    return __isa(o, "ServiceUnavailableException");
   }
 }
 
@@ -23,9 +26,7 @@ export namespace ServiceUnavailableException {
  *       VPC as the endpoint type and the server's <code>VpcEndpointID</code> is not in the available
  *       state.</p>
  */
-export interface ConflictException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface ConflictException extends __SmithyException, $MetadataBearer {
   name: "ConflictException";
   $fault: "client";
   Message: string | undefined;
@@ -33,7 +34,7 @@ export interface ConflictException
 
 export namespace ConflictException {
   export function isa(o: any): o is ConflictException {
-    return _smithy.isa(o, "ConflictException");
+    return __isa(o, "ConflictException");
   }
 }
 
@@ -100,7 +101,7 @@ export interface CreateServerRequest {
 
 export namespace CreateServerRequest {
   export function isa(o: any): o is CreateServerRequest {
-    return _smithy.isa(o, "CreateServerRequest");
+    return __isa(o, "CreateServerRequest");
   }
 }
 
@@ -114,7 +115,7 @@ export interface CreateServerResponse extends $MetadataBearer {
 
 export namespace CreateServerResponse {
   export function isa(o: any): o is CreateServerResponse {
-    return _smithy.isa(o, "CreateServerResponse");
+    return __isa(o, "CreateServerResponse");
   }
 }
 
@@ -225,7 +226,7 @@ export interface CreateUserRequest {
 
 export namespace CreateUserRequest {
   export function isa(o: any): o is CreateUserRequest {
-    return _smithy.isa(o, "CreateUserRequest");
+    return __isa(o, "CreateUserRequest");
   }
 }
 
@@ -244,7 +245,7 @@ export interface CreateUserResponse extends $MetadataBearer {
 
 export namespace CreateUserResponse {
   export function isa(o: any): o is CreateUserResponse {
-    return _smithy.isa(o, "CreateUserResponse");
+    return __isa(o, "CreateUserResponse");
   }
 }
 
@@ -258,7 +259,7 @@ export interface DeleteServerRequest {
 
 export namespace DeleteServerRequest {
   export function isa(o: any): o is DeleteServerRequest {
-    return _smithy.isa(o, "DeleteServerRequest");
+    return __isa(o, "DeleteServerRequest");
   }
 }
 
@@ -283,7 +284,7 @@ export interface DeleteSshPublicKeyRequest {
 
 export namespace DeleteSshPublicKeyRequest {
   export function isa(o: any): o is DeleteSshPublicKeyRequest {
-    return _smithy.isa(o, "DeleteSshPublicKeyRequest");
+    return __isa(o, "DeleteSshPublicKeyRequest");
   }
 }
 
@@ -303,7 +304,7 @@ export interface DeleteUserRequest {
 
 export namespace DeleteUserRequest {
   export function isa(o: any): o is DeleteUserRequest {
-    return _smithy.isa(o, "DeleteUserRequest");
+    return __isa(o, "DeleteUserRequest");
   }
 }
 
@@ -317,7 +318,7 @@ export interface DescribeServerRequest {
 
 export namespace DescribeServerRequest {
   export function isa(o: any): o is DescribeServerRequest {
-    return _smithy.isa(o, "DescribeServerRequest");
+    return __isa(o, "DescribeServerRequest");
   }
 }
 
@@ -332,7 +333,7 @@ export interface DescribeServerResponse extends $MetadataBearer {
 
 export namespace DescribeServerResponse {
   export function isa(o: any): o is DescribeServerResponse {
-    return _smithy.isa(o, "DescribeServerResponse");
+    return __isa(o, "DescribeServerResponse");
   }
 }
 
@@ -352,7 +353,7 @@ export interface DescribeUserRequest {
 
 export namespace DescribeUserRequest {
   export function isa(o: any): o is DescribeUserRequest {
-    return _smithy.isa(o, "DescribeUserRequest");
+    return __isa(o, "DescribeUserRequest");
   }
 }
 
@@ -372,7 +373,7 @@ export interface DescribeUserResponse extends $MetadataBearer {
 
 export namespace DescribeUserResponse {
   export function isa(o: any): o is DescribeUserResponse {
-    return _smithy.isa(o, "DescribeUserResponse");
+    return __isa(o, "DescribeUserResponse");
   }
 }
 
@@ -463,7 +464,7 @@ export interface DescribedServer {
 
 export namespace DescribedServer {
   export function isa(o: any): o is DescribedServer {
-    return _smithy.isa(o, "DescribedServer");
+    return __isa(o, "DescribedServer");
   }
 }
 
@@ -549,7 +550,7 @@ export interface DescribedUser {
 
 export namespace DescribedUser {
   export function isa(o: any): o is DescribedUser {
-    return _smithy.isa(o, "DescribedUser");
+    return __isa(o, "DescribedUser");
   }
 }
 
@@ -589,7 +590,7 @@ export interface EndpointDetails {
 
 export namespace EndpointDetails {
   export function isa(o: any): o is EndpointDetails {
-    return _smithy.isa(o, "EndpointDetails");
+    return __isa(o, "EndpointDetails");
   }
 }
 
@@ -618,7 +619,7 @@ export interface HomeDirectoryMapEntry {
 
 export namespace HomeDirectoryMapEntry {
   export function isa(o: any): o is HomeDirectoryMapEntry {
-    return _smithy.isa(o, "HomeDirectoryMapEntry");
+    return __isa(o, "HomeDirectoryMapEntry");
   }
 }
 
@@ -648,7 +649,7 @@ export interface IdentityProviderDetails {
 
 export namespace IdentityProviderDetails {
   export function isa(o: any): o is IdentityProviderDetails {
-    return _smithy.isa(o, "IdentityProviderDetails");
+    return __isa(o, "IdentityProviderDetails");
   }
 }
 
@@ -677,7 +678,7 @@ export interface ImportSshPublicKeyRequest {
 
 export namespace ImportSshPublicKeyRequest {
   export function isa(o: any): o is ImportSshPublicKeyRequest {
-    return _smithy.isa(o, "ImportSshPublicKeyRequest");
+    return __isa(o, "ImportSshPublicKeyRequest");
   }
 }
 
@@ -706,7 +707,7 @@ export interface ImportSshPublicKeyResponse extends $MetadataBearer {
 
 export namespace ImportSshPublicKeyResponse {
   export function isa(o: any): o is ImportSshPublicKeyResponse {
-    return _smithy.isa(o, "ImportSshPublicKeyResponse");
+    return __isa(o, "ImportSshPublicKeyResponse");
   }
 }
 
@@ -714,7 +715,7 @@ export namespace ImportSshPublicKeyResponse {
  * <p>This exception is thrown when an error occurs in the AWS Transfer for SFTP service.</p>
  */
 export interface InternalServiceError
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalServiceError";
   $fault: "server";
@@ -723,7 +724,7 @@ export interface InternalServiceError
 
 export namespace InternalServiceError {
   export function isa(o: any): o is InternalServiceError {
-    return _smithy.isa(o, "InternalServiceError");
+    return __isa(o, "InternalServiceError");
   }
 }
 
@@ -731,7 +732,7 @@ export namespace InternalServiceError {
  * <p>The <code>NextToken</code> parameter that was passed is invalid.</p>
  */
 export interface InvalidNextTokenException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidNextTokenException";
   $fault: "client";
@@ -740,7 +741,7 @@ export interface InvalidNextTokenException
 
 export namespace InvalidNextTokenException {
   export function isa(o: any): o is InvalidNextTokenException {
-    return _smithy.isa(o, "InvalidNextTokenException");
+    return __isa(o, "InvalidNextTokenException");
   }
 }
 
@@ -748,7 +749,7 @@ export namespace InvalidNextTokenException {
  * <p>This exception is thrown when the client submits a malformed request.</p>
  */
 export interface InvalidRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidRequestException";
   $fault: "client";
@@ -757,7 +758,7 @@ export interface InvalidRequestException
 
 export namespace InvalidRequestException {
   export function isa(o: any): o is InvalidRequestException {
-    return _smithy.isa(o, "InvalidRequestException");
+    return __isa(o, "InvalidRequestException");
   }
 }
 
@@ -781,7 +782,7 @@ export interface ListServersRequest {
 
 export namespace ListServersRequest {
   export function isa(o: any): o is ListServersRequest {
-    return _smithy.isa(o, "ListServersRequest");
+    return __isa(o, "ListServersRequest");
   }
 }
 
@@ -802,7 +803,7 @@ export interface ListServersResponse extends $MetadataBearer {
 
 export namespace ListServersResponse {
   export function isa(o: any): o is ListServersResponse {
-    return _smithy.isa(o, "ListServersResponse");
+    return __isa(o, "ListServersResponse");
   }
 }
 
@@ -830,7 +831,7 @@ export interface ListTagsForResourceRequest {
 
 export namespace ListTagsForResourceRequest {
   export function isa(o: any): o is ListTagsForResourceRequest {
-    return _smithy.isa(o, "ListTagsForResourceRequest");
+    return __isa(o, "ListTagsForResourceRequest");
   }
 }
 
@@ -858,7 +859,7 @@ export interface ListTagsForResourceResponse extends $MetadataBearer {
 
 export namespace ListTagsForResourceResponse {
   export function isa(o: any): o is ListTagsForResourceResponse {
-    return _smithy.isa(o, "ListTagsForResourceResponse");
+    return __isa(o, "ListTagsForResourceResponse");
   }
 }
 
@@ -887,7 +888,7 @@ export interface ListUsersRequest {
 
 export namespace ListUsersRequest {
   export function isa(o: any): o is ListUsersRequest {
-    return _smithy.isa(o, "ListUsersRequest");
+    return __isa(o, "ListUsersRequest");
   }
 }
 
@@ -916,7 +917,7 @@ export interface ListUsersResponse extends $MetadataBearer {
 
 export namespace ListUsersResponse {
   export function isa(o: any): o is ListUsersResponse {
-    return _smithy.isa(o, "ListUsersResponse");
+    return __isa(o, "ListUsersResponse");
   }
 }
 
@@ -978,7 +979,7 @@ export interface ListedServer {
 
 export namespace ListedServer {
   export function isa(o: any): o is ListedServer {
-    return _smithy.isa(o, "ListedServer");
+    return __isa(o, "ListedServer");
   }
 }
 
@@ -1034,7 +1035,7 @@ export interface ListedUser {
 
 export namespace ListedUser {
   export function isa(o: any): o is ListedUser {
-    return _smithy.isa(o, "ListedUser");
+    return __isa(o, "ListedUser");
   }
 }
 
@@ -1042,7 +1043,7 @@ export namespace ListedUser {
  * <p>The requested resource does not exist.</p>
  */
 export interface ResourceExistsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceExistsException";
   $fault: "client";
@@ -1053,7 +1054,7 @@ export interface ResourceExistsException
 
 export namespace ResourceExistsException {
   export function isa(o: any): o is ResourceExistsException {
-    return _smithy.isa(o, "ResourceExistsException");
+    return __isa(o, "ResourceExistsException");
   }
 }
 
@@ -1062,7 +1063,7 @@ export namespace ResourceExistsException {
  *       service.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -1073,7 +1074,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -1105,7 +1106,7 @@ export interface SshPublicKey {
 
 export namespace SshPublicKey {
   export function isa(o: any): o is SshPublicKey {
-    return _smithy.isa(o, "SshPublicKey");
+    return __isa(o, "SshPublicKey");
   }
 }
 
@@ -1119,7 +1120,7 @@ export interface StartServerRequest {
 
 export namespace StartServerRequest {
   export function isa(o: any): o is StartServerRequest {
-    return _smithy.isa(o, "StartServerRequest");
+    return __isa(o, "StartServerRequest");
   }
 }
 
@@ -1142,7 +1143,7 @@ export interface StopServerRequest {
 
 export namespace StopServerRequest {
   export function isa(o: any): o is StopServerRequest {
-    return _smithy.isa(o, "StopServerRequest");
+    return __isa(o, "StopServerRequest");
   }
 }
 
@@ -1169,7 +1170,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -1190,7 +1191,7 @@ export interface TagResourceRequest {
 
 export namespace TagResourceRequest {
   export function isa(o: any): o is TagResourceRequest {
-    return _smithy.isa(o, "TagResourceRequest");
+    return __isa(o, "TagResourceRequest");
   }
 }
 
@@ -1215,7 +1216,7 @@ export interface TestIdentityProviderRequest {
 
 export namespace TestIdentityProviderRequest {
   export function isa(o: any): o is TestIdentityProviderRequest {
-    return _smithy.isa(o, "TestIdentityProviderRequest");
+    return __isa(o, "TestIdentityProviderRequest");
   }
 }
 
@@ -1244,7 +1245,7 @@ export interface TestIdentityProviderResponse extends $MetadataBearer {
 
 export namespace TestIdentityProviderResponse {
   export function isa(o: any): o is TestIdentityProviderResponse {
-    return _smithy.isa(o, "TestIdentityProviderResponse");
+    return __isa(o, "TestIdentityProviderResponse");
   }
 }
 
@@ -1253,7 +1254,7 @@ export namespace TestIdentityProviderResponse {
  *          <p> HTTP Status Code: 400</p>
  */
 export interface ThrottlingException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ThrottlingException";
   $fault: "client";
@@ -1262,7 +1263,7 @@ export interface ThrottlingException
 
 export namespace ThrottlingException {
   export function isa(o: any): o is ThrottlingException {
-    return _smithy.isa(o, "ThrottlingException");
+    return __isa(o, "ThrottlingException");
   }
 }
 
@@ -1283,7 +1284,7 @@ export interface UntagResourceRequest {
 
 export namespace UntagResourceRequest {
   export function isa(o: any): o is UntagResourceRequest {
-    return _smithy.isa(o, "UntagResourceRequest");
+    return __isa(o, "UntagResourceRequest");
   }
 }
 
@@ -1338,7 +1339,7 @@ export interface UpdateServerRequest {
 
 export namespace UpdateServerRequest {
   export function isa(o: any): o is UpdateServerRequest {
-    return _smithy.isa(o, "UpdateServerRequest");
+    return __isa(o, "UpdateServerRequest");
   }
 }
 
@@ -1353,7 +1354,7 @@ export interface UpdateServerResponse extends $MetadataBearer {
 
 export namespace UpdateServerResponse {
   export function isa(o: any): o is UpdateServerResponse {
-    return _smithy.isa(o, "UpdateServerResponse");
+    return __isa(o, "UpdateServerResponse");
   }
 }
 
@@ -1449,7 +1450,7 @@ export interface UpdateUserRequest {
 
 export namespace UpdateUserRequest {
   export function isa(o: any): o is UpdateUserRequest {
-    return _smithy.isa(o, "UpdateUserRequest");
+    return __isa(o, "UpdateUserRequest");
   }
 }
 
@@ -1475,6 +1476,6 @@ export interface UpdateUserResponse extends $MetadataBearer {
 
 export namespace UpdateUserResponse {
   export function isa(o: any): o is UpdateUserResponse {
-    return _smithy.isa(o, "UpdateUserResponse");
+    return __isa(o, "UpdateUserResponse");
   }
 }

--- a/clients/client-transfer/protocols/Aws_json1_1.ts
+++ b/clients/client-transfer/protocols/Aws_json1_1.ts
@@ -535,6 +535,7 @@ export async function deserializeAws_json1_1DeleteServerCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1DeleteServerCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteServerCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -610,6 +611,7 @@ export async function deserializeAws_json1_1DeleteSshPublicKeyCommand(
       context
     );
   }
+  await collectBody(output.body, context);
   const response: DeleteSshPublicKeyCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -689,6 +691,7 @@ export async function deserializeAws_json1_1DeleteUserCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1DeleteUserCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteUserCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1250,6 +1253,7 @@ export async function deserializeAws_json1_1StartServerCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1StartServerCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: StartServerCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1329,6 +1333,7 @@ export async function deserializeAws_json1_1StopServerCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1StopServerCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: StopServerCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1408,6 +1413,7 @@ export async function deserializeAws_json1_1TagResourceCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1TagResourceCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: TagResourceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
@@ -1560,6 +1566,7 @@ export async function deserializeAws_json1_1UntagResourceCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1UntagResourceCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: UntagResourceCommandOutput = {
     $metadata: deserializeMetadata(output)
   };

--- a/clients/client-translate/models/index.ts
+++ b/clients/client-translate/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -25,7 +28,7 @@ export interface AppliedTerminology {
 
 export namespace AppliedTerminology {
   export function isa(o: any): o is AppliedTerminology {
-    return _smithy.isa(o, "AppliedTerminology");
+    return __isa(o, "AppliedTerminology");
   }
 }
 
@@ -39,7 +42,7 @@ export interface DeleteTerminologyRequest {
 
 export namespace DeleteTerminologyRequest {
   export function isa(o: any): o is DeleteTerminologyRequest {
-    return _smithy.isa(o, "DeleteTerminologyRequest");
+    return __isa(o, "DeleteTerminologyRequest");
   }
 }
 
@@ -54,7 +57,7 @@ export interface DescribeTextTranslationJobRequest {
 
 export namespace DescribeTextTranslationJobRequest {
   export function isa(o: any): o is DescribeTextTranslationJobRequest {
-    return _smithy.isa(o, "DescribeTextTranslationJobRequest");
+    return __isa(o, "DescribeTextTranslationJobRequest");
   }
 }
 
@@ -69,7 +72,7 @@ export interface DescribeTextTranslationJobResponse extends $MetadataBearer {
 
 export namespace DescribeTextTranslationJobResponse {
   export function isa(o: any): o is DescribeTextTranslationJobResponse {
-    return _smithy.isa(o, "DescribeTextTranslationJobResponse");
+    return __isa(o, "DescribeTextTranslationJobResponse");
   }
 }
 
@@ -80,7 +83,7 @@ export namespace DescribeTextTranslationJobResponse {
  *         Guide</i>. </p>
  */
 export interface DetectedLanguageLowConfidenceException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DetectedLanguageLowConfidenceException";
   $fault: "client";
@@ -94,7 +97,7 @@ export interface DetectedLanguageLowConfidenceException
 
 export namespace DetectedLanguageLowConfidenceException {
   export function isa(o: any): o is DetectedLanguageLowConfidenceException {
-    return _smithy.isa(o, "DetectedLanguageLowConfidenceException");
+    return __isa(o, "DetectedLanguageLowConfidenceException");
   }
 }
 
@@ -117,7 +120,7 @@ export interface EncryptionKey {
 
 export namespace EncryptionKey {
   export function isa(o: any): o is EncryptionKey {
-    return _smithy.isa(o, "EncryptionKey");
+    return __isa(o, "EncryptionKey");
   }
 }
 
@@ -140,7 +143,7 @@ export interface GetTerminologyRequest {
 
 export namespace GetTerminologyRequest {
   export function isa(o: any): o is GetTerminologyRequest {
-    return _smithy.isa(o, "GetTerminologyRequest");
+    return __isa(o, "GetTerminologyRequest");
   }
 }
 
@@ -160,7 +163,7 @@ export interface GetTerminologyResponse extends $MetadataBearer {
 
 export namespace GetTerminologyResponse {
   export function isa(o: any): o is GetTerminologyResponse {
-    return _smithy.isa(o, "GetTerminologyResponse");
+    return __isa(o, "GetTerminologyResponse");
   }
 }
 
@@ -196,7 +199,7 @@ export interface ImportTerminologyRequest {
 
 export namespace ImportTerminologyRequest {
   export function isa(o: any): o is ImportTerminologyRequest {
-    return _smithy.isa(o, "ImportTerminologyRequest");
+    return __isa(o, "ImportTerminologyRequest");
   }
 }
 
@@ -210,7 +213,7 @@ export interface ImportTerminologyResponse extends $MetadataBearer {
 
 export namespace ImportTerminologyResponse {
   export function isa(o: any): o is ImportTerminologyResponse {
-    return _smithy.isa(o, "ImportTerminologyResponse");
+    return __isa(o, "ImportTerminologyResponse");
   }
 }
 
@@ -235,7 +238,7 @@ export interface InputDataConfig {
 
 export namespace InputDataConfig {
   export function isa(o: any): o is InputDataConfig {
-    return _smithy.isa(o, "InputDataConfig");
+    return __isa(o, "InputDataConfig");
   }
 }
 
@@ -243,7 +246,7 @@ export namespace InputDataConfig {
  * <p>An internal server error occurred. Retry your request.</p>
  */
 export interface InternalServerException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalServerException";
   $fault: "server";
@@ -252,7 +255,7 @@ export interface InternalServerException
 
 export namespace InternalServerException {
   export function isa(o: any): o is InternalServerException {
-    return _smithy.isa(o, "InternalServerException");
+    return __isa(o, "InternalServerException");
   }
 }
 
@@ -260,7 +263,7 @@ export namespace InternalServerException {
  * <p>The filter specified for the operation is invalid. Specify a different filter.</p>
  */
 export interface InvalidFilterException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidFilterException";
   $fault: "client";
@@ -269,7 +272,7 @@ export interface InvalidFilterException
 
 export namespace InvalidFilterException {
   export function isa(o: any): o is InvalidFilterException {
-    return _smithy.isa(o, "InvalidFilterException");
+    return __isa(o, "InvalidFilterException");
   }
 }
 
@@ -278,7 +281,7 @@ export namespace InvalidFilterException {
  *       correct it, and then retry your operation.</p>
  */
 export interface InvalidParameterValueException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidParameterValueException";
   $fault: "client";
@@ -287,7 +290,7 @@ export interface InvalidParameterValueException
 
 export namespace InvalidParameterValueException {
   export function isa(o: any): o is InvalidParameterValueException {
-    return _smithy.isa(o, "InvalidParameterValueException");
+    return __isa(o, "InvalidParameterValueException");
   }
 }
 
@@ -296,7 +299,7 @@ export namespace InvalidParameterValueException {
  *       and then retry the request. </p>
  */
 export interface InvalidRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidRequestException";
   $fault: "client";
@@ -305,7 +308,7 @@ export interface InvalidRequestException
 
 export namespace InvalidRequestException {
   export function isa(o: any): o is InvalidRequestException {
-    return _smithy.isa(o, "InvalidRequestException");
+    return __isa(o, "InvalidRequestException");
   }
 }
 
@@ -333,7 +336,7 @@ export interface JobDetails {
 
 export namespace JobDetails {
   export function isa(o: any): o is JobDetails {
-    return _smithy.isa(o, "JobDetails");
+    return __isa(o, "JobDetails");
   }
 }
 
@@ -352,7 +355,7 @@ export enum JobStatus {
  *       below the stated limit.</p>
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -361,7 +364,7 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
@@ -381,7 +384,7 @@ export interface ListTerminologiesRequest {
 
 export namespace ListTerminologiesRequest {
   export function isa(o: any): o is ListTerminologiesRequest {
-    return _smithy.isa(o, "ListTerminologiesRequest");
+    return __isa(o, "ListTerminologiesRequest");
   }
 }
 
@@ -401,7 +404,7 @@ export interface ListTerminologiesResponse extends $MetadataBearer {
 
 export namespace ListTerminologiesResponse {
   export function isa(o: any): o is ListTerminologiesResponse {
-    return _smithy.isa(o, "ListTerminologiesResponse");
+    return __isa(o, "ListTerminologiesResponse");
   }
 }
 
@@ -426,7 +429,7 @@ export interface ListTextTranslationJobsRequest {
 
 export namespace ListTextTranslationJobsRequest {
   export function isa(o: any): o is ListTextTranslationJobsRequest {
-    return _smithy.isa(o, "ListTextTranslationJobsRequest");
+    return __isa(o, "ListTextTranslationJobsRequest");
   }
 }
 
@@ -446,7 +449,7 @@ export interface ListTextTranslationJobsResponse extends $MetadataBearer {
 
 export namespace ListTextTranslationJobsResponse {
   export function isa(o: any): o is ListTextTranslationJobsResponse {
-    return _smithy.isa(o, "ListTextTranslationJobsResponse");
+    return __isa(o, "ListTextTranslationJobsResponse");
   }
 }
 
@@ -468,7 +471,7 @@ export interface OutputDataConfig {
 
 export namespace OutputDataConfig {
   export function isa(o: any): o is OutputDataConfig {
-    return _smithy.isa(o, "OutputDataConfig");
+    return __isa(o, "OutputDataConfig");
   }
 }
 
@@ -478,7 +481,7 @@ export namespace OutputDataConfig {
  *       request.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -487,7 +490,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -496,7 +499,7 @@ export namespace ResourceNotFoundException {
  *       request.</p>
  */
 export interface ServiceUnavailableException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ServiceUnavailableException";
   $fault: "server";
@@ -505,7 +508,7 @@ export interface ServiceUnavailableException
 
 export namespace ServiceUnavailableException {
   export function isa(o: any): o is ServiceUnavailableException {
-    return _smithy.isa(o, "ServiceUnavailableException");
+    return __isa(o, "ServiceUnavailableException");
   }
 }
 
@@ -563,7 +566,7 @@ export interface StartTextTranslationJobRequest {
 
 export namespace StartTextTranslationJobRequest {
   export function isa(o: any): o is StartTextTranslationJobRequest {
-    return _smithy.isa(o, "StartTextTranslationJobRequest");
+    return __isa(o, "StartTextTranslationJobRequest");
   }
 }
 
@@ -617,7 +620,7 @@ export interface StartTextTranslationJobResponse extends $MetadataBearer {
 
 export namespace StartTextTranslationJobResponse {
   export function isa(o: any): o is StartTextTranslationJobResponse {
-    return _smithy.isa(o, "StartTextTranslationJobResponse");
+    return __isa(o, "StartTextTranslationJobResponse");
   }
 }
 
@@ -631,7 +634,7 @@ export interface StopTextTranslationJobRequest {
 
 export namespace StopTextTranslationJobRequest {
   export function isa(o: any): o is StopTextTranslationJobRequest {
-    return _smithy.isa(o, "StopTextTranslationJobRequest");
+    return __isa(o, "StopTextTranslationJobRequest");
   }
 }
 
@@ -651,7 +654,7 @@ export interface StopTextTranslationJobResponse extends $MetadataBearer {
 
 export namespace StopTextTranslationJobResponse {
   export function isa(o: any): o is StopTextTranslationJobResponse {
-    return _smithy.isa(o, "StopTextTranslationJobResponse");
+    return __isa(o, "StopTextTranslationJobResponse");
   }
 }
 
@@ -673,7 +676,7 @@ export interface Term {
 
 export namespace Term {
   export function isa(o: any): o is Term {
-    return _smithy.isa(o, "Term");
+    return __isa(o, "Term");
   }
 }
 
@@ -697,7 +700,7 @@ export interface TerminologyData {
 
 export namespace TerminologyData {
   export function isa(o: any): o is TerminologyData {
-    return _smithy.isa(o, "TerminologyData");
+    return __isa(o, "TerminologyData");
   }
 }
 
@@ -724,7 +727,7 @@ export interface TerminologyDataLocation {
 
 export namespace TerminologyDataLocation {
   export function isa(o: any): o is TerminologyDataLocation {
-    return _smithy.isa(o, "TerminologyDataLocation");
+    return __isa(o, "TerminologyDataLocation");
   }
 }
 
@@ -788,7 +791,7 @@ export interface TerminologyProperties {
 
 export namespace TerminologyProperties {
   export function isa(o: any): o is TerminologyProperties {
-    return _smithy.isa(o, "TerminologyProperties");
+    return __isa(o, "TerminologyProperties");
   }
 }
 
@@ -797,7 +800,7 @@ export namespace TerminologyProperties {
  *       use a smaller document and then retry your request. </p>
  */
 export interface TextSizeLimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TextSizeLimitExceededException";
   $fault: "client";
@@ -806,7 +809,7 @@ export interface TextSizeLimitExceededException
 
 export namespace TextSizeLimitExceededException {
   export function isa(o: any): o is TextSizeLimitExceededException {
-    return _smithy.isa(o, "TextSizeLimitExceededException");
+    return __isa(o, "TextSizeLimitExceededException");
   }
 }
 
@@ -843,7 +846,7 @@ export interface TextTranslationJobFilter {
 
 export namespace TextTranslationJobFilter {
   export function isa(o: any): o is TextTranslationJobFilter {
-    return _smithy.isa(o, "TextTranslationJobFilter");
+    return __isa(o, "TextTranslationJobFilter");
   }
 }
 
@@ -926,7 +929,7 @@ export interface TextTranslationJobProperties {
 
 export namespace TextTranslationJobProperties {
   export function isa(o: any): o is TextTranslationJobProperties {
-    return _smithy.isa(o, "TextTranslationJobProperties");
+    return __isa(o, "TextTranslationJobProperties");
   }
 }
 
@@ -935,7 +938,7 @@ export namespace TextTranslationJobProperties {
  *       then try your request again.</p>
  */
 export interface TooManyRequestsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyRequestsException";
   $fault: "client";
@@ -944,7 +947,7 @@ export interface TooManyRequestsException
 
 export namespace TooManyRequestsException {
   export function isa(o: any): o is TooManyRequestsException {
-    return _smithy.isa(o, "TooManyRequestsException");
+    return __isa(o, "TooManyRequestsException");
   }
 }
 
@@ -982,7 +985,7 @@ export interface TranslateTextRequest {
 
 export namespace TranslateTextRequest {
   export function isa(o: any): o is TranslateTextRequest {
-    return _smithy.isa(o, "TranslateTextRequest");
+    return __isa(o, "TranslateTextRequest");
   }
 }
 
@@ -1012,7 +1015,7 @@ export interface TranslateTextResponse extends $MetadataBearer {
 
 export namespace TranslateTextResponse {
   export function isa(o: any): o is TranslateTextResponse {
-    return _smithy.isa(o, "TranslateTextResponse");
+    return __isa(o, "TranslateTextResponse");
   }
 }
 
@@ -1021,7 +1024,7 @@ export namespace TranslateTextResponse {
  *       target language. For more information, see <a>how-to-error-msg</a>. </p>
  */
 export interface UnsupportedLanguagePairException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UnsupportedLanguagePairException";
   $fault: "client";
@@ -1039,6 +1042,6 @@ export interface UnsupportedLanguagePairException
 
 export namespace UnsupportedLanguagePairException {
   export function isa(o: any): o is UnsupportedLanguagePairException {
-    return _smithy.isa(o, "UnsupportedLanguagePairException");
+    return __isa(o, "UnsupportedLanguagePairException");
   }
 }

--- a/clients/client-translate/protocols/Aws_json1_1.ts
+++ b/clients/client-translate/protocols/Aws_json1_1.ts
@@ -229,6 +229,7 @@ export async function deserializeAws_json1_1DeleteTerminologyCommand(
   if (output.statusCode >= 400) {
     return deserializeAws_json1_1DeleteTerminologyCommandError(output, context);
   }
+  await collectBody(output.body, context);
   const response: DeleteTerminologyCommandOutput = {
     $metadata: deserializeMetadata(output)
   };

--- a/clients/client-waf-regional/models/index.ts
+++ b/clients/client-waf-regional/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export interface AssociateWebACLRequest {
@@ -29,7 +32,7 @@ export interface AssociateWebACLRequest {
 
 export namespace AssociateWebACLRequest {
   export function isa(o: any): o is AssociateWebACLRequest {
-    return _smithy.isa(o, "AssociateWebACLRequest");
+    return __isa(o, "AssociateWebACLRequest");
   }
 }
 
@@ -39,7 +42,7 @@ export interface AssociateWebACLResponse extends $MetadataBearer {
 
 export namespace AssociateWebACLResponse {
   export function isa(o: any): o is AssociateWebACLResponse {
-    return _smithy.isa(o, "AssociateWebACLResponse");
+    return __isa(o, "AssociateWebACLResponse");
   }
 }
 
@@ -66,7 +69,7 @@ export interface DisassociateWebACLRequest {
 
 export namespace DisassociateWebACLRequest {
   export function isa(o: any): o is DisassociateWebACLRequest {
-    return _smithy.isa(o, "DisassociateWebACLRequest");
+    return __isa(o, "DisassociateWebACLRequest");
   }
 }
 
@@ -76,7 +79,7 @@ export interface DisassociateWebACLResponse extends $MetadataBearer {
 
 export namespace DisassociateWebACLResponse {
   export function isa(o: any): o is DisassociateWebACLResponse {
-    return _smithy.isa(o, "DisassociateWebACLResponse");
+    return __isa(o, "DisassociateWebACLResponse");
   }
 }
 
@@ -103,7 +106,7 @@ export interface GetWebACLForResourceRequest {
 
 export namespace GetWebACLForResourceRequest {
   export function isa(o: any): o is GetWebACLForResourceRequest {
-    return _smithy.isa(o, "GetWebACLForResourceRequest");
+    return __isa(o, "GetWebACLForResourceRequest");
   }
 }
 
@@ -117,7 +120,7 @@ export interface GetWebACLForResourceResponse extends $MetadataBearer {
 
 export namespace GetWebACLForResourceResponse {
   export function isa(o: any): o is GetWebACLForResourceResponse {
-    return _smithy.isa(o, "GetWebACLForResourceResponse");
+    return __isa(o, "GetWebACLForResourceResponse");
   }
 }
 
@@ -136,7 +139,7 @@ export interface ListResourcesForWebACLRequest {
 
 export namespace ListResourcesForWebACLRequest {
   export function isa(o: any): o is ListResourcesForWebACLRequest {
-    return _smithy.isa(o, "ListResourcesForWebACLRequest");
+    return __isa(o, "ListResourcesForWebACLRequest");
   }
 }
 
@@ -150,7 +153,7 @@ export interface ListResourcesForWebACLResponse extends $MetadataBearer {
 
 export namespace ListResourcesForWebACLResponse {
   export function isa(o: any): o is ListResourcesForWebACLResponse {
-    return _smithy.isa(o, "ListResourcesForWebACLResponse");
+    return __isa(o, "ListResourcesForWebACLResponse");
   }
 }
 
@@ -268,7 +271,7 @@ export interface ActivatedRule {
 
 export namespace ActivatedRule {
   export function isa(o: any): o is ActivatedRule {
-    return _smithy.isa(o, "ActivatedRule");
+    return __isa(o, "ActivatedRule");
   }
 }
 
@@ -305,7 +308,7 @@ export interface ByteMatchSet {
 
 export namespace ByteMatchSet {
   export function isa(o: any): o is ByteMatchSet {
-    return _smithy.isa(o, "ByteMatchSet");
+    return __isa(o, "ByteMatchSet");
   }
 }
 
@@ -331,7 +334,7 @@ export interface ByteMatchSetSummary {
 
 export namespace ByteMatchSetSummary {
   export function isa(o: any): o is ByteMatchSetSummary {
-    return _smithy.isa(o, "ByteMatchSetSummary");
+    return __isa(o, "ByteMatchSetSummary");
   }
 }
 
@@ -356,7 +359,7 @@ export interface ByteMatchSetUpdate {
 
 export namespace ByteMatchSetUpdate {
   export function isa(o: any): o is ByteMatchSetUpdate {
-    return _smithy.isa(o, "ByteMatchSetUpdate");
+    return __isa(o, "ByteMatchSetUpdate");
   }
 }
 
@@ -587,7 +590,7 @@ export interface ByteMatchTuple {
 
 export namespace ByteMatchTuple {
   export function isa(o: any): o is ByteMatchTuple {
-    return _smithy.isa(o, "ByteMatchTuple");
+    return __isa(o, "ByteMatchTuple");
   }
 }
 
@@ -627,7 +630,7 @@ export interface CreateByteMatchSetRequest {
 
 export namespace CreateByteMatchSetRequest {
   export function isa(o: any): o is CreateByteMatchSetRequest {
-    return _smithy.isa(o, "CreateByteMatchSetRequest");
+    return __isa(o, "CreateByteMatchSetRequest");
   }
 }
 
@@ -647,7 +650,7 @@ export interface CreateByteMatchSetResponse extends $MetadataBearer {
 
 export namespace CreateByteMatchSetResponse {
   export function isa(o: any): o is CreateByteMatchSetResponse {
-    return _smithy.isa(o, "CreateByteMatchSetResponse");
+    return __isa(o, "CreateByteMatchSetResponse");
   }
 }
 
@@ -666,7 +669,7 @@ export interface CreateGeoMatchSetRequest {
 
 export namespace CreateGeoMatchSetRequest {
   export function isa(o: any): o is CreateGeoMatchSetRequest {
-    return _smithy.isa(o, "CreateGeoMatchSetRequest");
+    return __isa(o, "CreateGeoMatchSetRequest");
   }
 }
 
@@ -686,7 +689,7 @@ export interface CreateGeoMatchSetResponse extends $MetadataBearer {
 
 export namespace CreateGeoMatchSetResponse {
   export function isa(o: any): o is CreateGeoMatchSetResponse {
-    return _smithy.isa(o, "CreateGeoMatchSetResponse");
+    return __isa(o, "CreateGeoMatchSetResponse");
   }
 }
 
@@ -705,7 +708,7 @@ export interface CreateIPSetRequest {
 
 export namespace CreateIPSetRequest {
   export function isa(o: any): o is CreateIPSetRequest {
-    return _smithy.isa(o, "CreateIPSetRequest");
+    return __isa(o, "CreateIPSetRequest");
   }
 }
 
@@ -725,7 +728,7 @@ export interface CreateIPSetResponse extends $MetadataBearer {
 
 export namespace CreateIPSetResponse {
   export function isa(o: any): o is CreateIPSetResponse {
-    return _smithy.isa(o, "CreateIPSetResponse");
+    return __isa(o, "CreateIPSetResponse");
   }
 }
 
@@ -774,7 +777,7 @@ export interface CreateRateBasedRuleRequest {
 
 export namespace CreateRateBasedRuleRequest {
   export function isa(o: any): o is CreateRateBasedRuleRequest {
-    return _smithy.isa(o, "CreateRateBasedRuleRequest");
+    return __isa(o, "CreateRateBasedRuleRequest");
   }
 }
 
@@ -796,7 +799,7 @@ export interface CreateRateBasedRuleResponse extends $MetadataBearer {
 
 export namespace CreateRateBasedRuleResponse {
   export function isa(o: any): o is CreateRateBasedRuleResponse {
-    return _smithy.isa(o, "CreateRateBasedRuleResponse");
+    return __isa(o, "CreateRateBasedRuleResponse");
   }
 }
 
@@ -816,7 +819,7 @@ export interface CreateRegexMatchSetRequest {
 
 export namespace CreateRegexMatchSetRequest {
   export function isa(o: any): o is CreateRegexMatchSetRequest {
-    return _smithy.isa(o, "CreateRegexMatchSetRequest");
+    return __isa(o, "CreateRegexMatchSetRequest");
   }
 }
 
@@ -836,7 +839,7 @@ export interface CreateRegexMatchSetResponse extends $MetadataBearer {
 
 export namespace CreateRegexMatchSetResponse {
   export function isa(o: any): o is CreateRegexMatchSetResponse {
-    return _smithy.isa(o, "CreateRegexMatchSetResponse");
+    return __isa(o, "CreateRegexMatchSetResponse");
   }
 }
 
@@ -856,7 +859,7 @@ export interface CreateRegexPatternSetRequest {
 
 export namespace CreateRegexPatternSetRequest {
   export function isa(o: any): o is CreateRegexPatternSetRequest {
-    return _smithy.isa(o, "CreateRegexPatternSetRequest");
+    return __isa(o, "CreateRegexPatternSetRequest");
   }
 }
 
@@ -876,7 +879,7 @@ export interface CreateRegexPatternSetResponse extends $MetadataBearer {
 
 export namespace CreateRegexPatternSetResponse {
   export function isa(o: any): o is CreateRegexPatternSetResponse {
-    return _smithy.isa(o, "CreateRegexPatternSetResponse");
+    return __isa(o, "CreateRegexPatternSetResponse");
   }
 }
 
@@ -904,7 +907,7 @@ export interface CreateRuleGroupRequest {
 
 export namespace CreateRuleGroupRequest {
   export function isa(o: any): o is CreateRuleGroupRequest {
-    return _smithy.isa(o, "CreateRuleGroupRequest");
+    return __isa(o, "CreateRuleGroupRequest");
   }
 }
 
@@ -924,7 +927,7 @@ export interface CreateRuleGroupResponse extends $MetadataBearer {
 
 export namespace CreateRuleGroupResponse {
   export function isa(o: any): o is CreateRuleGroupResponse {
-    return _smithy.isa(o, "CreateRuleGroupResponse");
+    return __isa(o, "CreateRuleGroupResponse");
   }
 }
 
@@ -952,7 +955,7 @@ export interface CreateRuleRequest {
 
 export namespace CreateRuleRequest {
   export function isa(o: any): o is CreateRuleRequest {
-    return _smithy.isa(o, "CreateRuleRequest");
+    return __isa(o, "CreateRuleRequest");
   }
 }
 
@@ -972,7 +975,7 @@ export interface CreateRuleResponse extends $MetadataBearer {
 
 export namespace CreateRuleResponse {
   export function isa(o: any): o is CreateRuleResponse {
-    return _smithy.isa(o, "CreateRuleResponse");
+    return __isa(o, "CreateRuleResponse");
   }
 }
 
@@ -992,7 +995,7 @@ export interface CreateSizeConstraintSetRequest {
 
 export namespace CreateSizeConstraintSetRequest {
   export function isa(o: any): o is CreateSizeConstraintSetRequest {
-    return _smithy.isa(o, "CreateSizeConstraintSetRequest");
+    return __isa(o, "CreateSizeConstraintSetRequest");
   }
 }
 
@@ -1012,7 +1015,7 @@ export interface CreateSizeConstraintSetResponse extends $MetadataBearer {
 
 export namespace CreateSizeConstraintSetResponse {
   export function isa(o: any): o is CreateSizeConstraintSetResponse {
-    return _smithy.isa(o, "CreateSizeConstraintSetResponse");
+    return __isa(o, "CreateSizeConstraintSetResponse");
   }
 }
 
@@ -1035,7 +1038,7 @@ export interface CreateSqlInjectionMatchSetRequest {
 
 export namespace CreateSqlInjectionMatchSetRequest {
   export function isa(o: any): o is CreateSqlInjectionMatchSetRequest {
-    return _smithy.isa(o, "CreateSqlInjectionMatchSetRequest");
+    return __isa(o, "CreateSqlInjectionMatchSetRequest");
   }
 }
 
@@ -1058,7 +1061,7 @@ export interface CreateSqlInjectionMatchSetResponse extends $MetadataBearer {
 
 export namespace CreateSqlInjectionMatchSetResponse {
   export function isa(o: any): o is CreateSqlInjectionMatchSetResponse {
-    return _smithy.isa(o, "CreateSqlInjectionMatchSetResponse");
+    return __isa(o, "CreateSqlInjectionMatchSetResponse");
   }
 }
 
@@ -1092,7 +1095,7 @@ export interface CreateWebACLRequest {
 
 export namespace CreateWebACLRequest {
   export function isa(o: any): o is CreateWebACLRequest {
-    return _smithy.isa(o, "CreateWebACLRequest");
+    return __isa(o, "CreateWebACLRequest");
   }
 }
 
@@ -1112,7 +1115,7 @@ export interface CreateWebACLResponse extends $MetadataBearer {
 
 export namespace CreateWebACLResponse {
   export function isa(o: any): o is CreateWebACLResponse {
-    return _smithy.isa(o, "CreateWebACLResponse");
+    return __isa(o, "CreateWebACLResponse");
   }
 }
 
@@ -1135,7 +1138,7 @@ export interface CreateXssMatchSetRequest {
 
 export namespace CreateXssMatchSetRequest {
   export function isa(o: any): o is CreateXssMatchSetRequest {
-    return _smithy.isa(o, "CreateXssMatchSetRequest");
+    return __isa(o, "CreateXssMatchSetRequest");
   }
 }
 
@@ -1158,7 +1161,7 @@ export interface CreateXssMatchSetResponse extends $MetadataBearer {
 
 export namespace CreateXssMatchSetResponse {
   export function isa(o: any): o is CreateXssMatchSetResponse {
-    return _smithy.isa(o, "CreateXssMatchSetResponse");
+    return __isa(o, "CreateXssMatchSetResponse");
   }
 }
 
@@ -1178,7 +1181,7 @@ export interface DeleteByteMatchSetRequest {
 
 export namespace DeleteByteMatchSetRequest {
   export function isa(o: any): o is DeleteByteMatchSetRequest {
-    return _smithy.isa(o, "DeleteByteMatchSetRequest");
+    return __isa(o, "DeleteByteMatchSetRequest");
   }
 }
 
@@ -1193,7 +1196,7 @@ export interface DeleteByteMatchSetResponse extends $MetadataBearer {
 
 export namespace DeleteByteMatchSetResponse {
   export function isa(o: any): o is DeleteByteMatchSetResponse {
-    return _smithy.isa(o, "DeleteByteMatchSetResponse");
+    return __isa(o, "DeleteByteMatchSetResponse");
   }
 }
 
@@ -1213,7 +1216,7 @@ export interface DeleteGeoMatchSetRequest {
 
 export namespace DeleteGeoMatchSetRequest {
   export function isa(o: any): o is DeleteGeoMatchSetRequest {
-    return _smithy.isa(o, "DeleteGeoMatchSetRequest");
+    return __isa(o, "DeleteGeoMatchSetRequest");
   }
 }
 
@@ -1228,7 +1231,7 @@ export interface DeleteGeoMatchSetResponse extends $MetadataBearer {
 
 export namespace DeleteGeoMatchSetResponse {
   export function isa(o: any): o is DeleteGeoMatchSetResponse {
-    return _smithy.isa(o, "DeleteGeoMatchSetResponse");
+    return __isa(o, "DeleteGeoMatchSetResponse");
   }
 }
 
@@ -1248,7 +1251,7 @@ export interface DeleteIPSetRequest {
 
 export namespace DeleteIPSetRequest {
   export function isa(o: any): o is DeleteIPSetRequest {
-    return _smithy.isa(o, "DeleteIPSetRequest");
+    return __isa(o, "DeleteIPSetRequest");
   }
 }
 
@@ -1263,7 +1266,7 @@ export interface DeleteIPSetResponse extends $MetadataBearer {
 
 export namespace DeleteIPSetResponse {
   export function isa(o: any): o is DeleteIPSetResponse {
-    return _smithy.isa(o, "DeleteIPSetResponse");
+    return __isa(o, "DeleteIPSetResponse");
   }
 }
 
@@ -1277,7 +1280,7 @@ export interface DeleteLoggingConfigurationRequest {
 
 export namespace DeleteLoggingConfigurationRequest {
   export function isa(o: any): o is DeleteLoggingConfigurationRequest {
-    return _smithy.isa(o, "DeleteLoggingConfigurationRequest");
+    return __isa(o, "DeleteLoggingConfigurationRequest");
   }
 }
 
@@ -1287,7 +1290,7 @@ export interface DeleteLoggingConfigurationResponse extends $MetadataBearer {
 
 export namespace DeleteLoggingConfigurationResponse {
   export function isa(o: any): o is DeleteLoggingConfigurationResponse {
-    return _smithy.isa(o, "DeleteLoggingConfigurationResponse");
+    return __isa(o, "DeleteLoggingConfigurationResponse");
   }
 }
 
@@ -1302,7 +1305,7 @@ export interface DeletePermissionPolicyRequest {
 
 export namespace DeletePermissionPolicyRequest {
   export function isa(o: any): o is DeletePermissionPolicyRequest {
-    return _smithy.isa(o, "DeletePermissionPolicyRequest");
+    return __isa(o, "DeletePermissionPolicyRequest");
   }
 }
 
@@ -1312,7 +1315,7 @@ export interface DeletePermissionPolicyResponse extends $MetadataBearer {
 
 export namespace DeletePermissionPolicyResponse {
   export function isa(o: any): o is DeletePermissionPolicyResponse {
-    return _smithy.isa(o, "DeletePermissionPolicyResponse");
+    return __isa(o, "DeletePermissionPolicyResponse");
   }
 }
 
@@ -1333,7 +1336,7 @@ export interface DeleteRateBasedRuleRequest {
 
 export namespace DeleteRateBasedRuleRequest {
   export function isa(o: any): o is DeleteRateBasedRuleRequest {
-    return _smithy.isa(o, "DeleteRateBasedRuleRequest");
+    return __isa(o, "DeleteRateBasedRuleRequest");
   }
 }
 
@@ -1349,7 +1352,7 @@ export interface DeleteRateBasedRuleResponse extends $MetadataBearer {
 
 export namespace DeleteRateBasedRuleResponse {
   export function isa(o: any): o is DeleteRateBasedRuleResponse {
-    return _smithy.isa(o, "DeleteRateBasedRuleResponse");
+    return __isa(o, "DeleteRateBasedRuleResponse");
   }
 }
 
@@ -1369,7 +1372,7 @@ export interface DeleteRegexMatchSetRequest {
 
 export namespace DeleteRegexMatchSetRequest {
   export function isa(o: any): o is DeleteRegexMatchSetRequest {
-    return _smithy.isa(o, "DeleteRegexMatchSetRequest");
+    return __isa(o, "DeleteRegexMatchSetRequest");
   }
 }
 
@@ -1384,7 +1387,7 @@ export interface DeleteRegexMatchSetResponse extends $MetadataBearer {
 
 export namespace DeleteRegexMatchSetResponse {
   export function isa(o: any): o is DeleteRegexMatchSetResponse {
-    return _smithy.isa(o, "DeleteRegexMatchSetResponse");
+    return __isa(o, "DeleteRegexMatchSetResponse");
   }
 }
 
@@ -1404,7 +1407,7 @@ export interface DeleteRegexPatternSetRequest {
 
 export namespace DeleteRegexPatternSetRequest {
   export function isa(o: any): o is DeleteRegexPatternSetRequest {
-    return _smithy.isa(o, "DeleteRegexPatternSetRequest");
+    return __isa(o, "DeleteRegexPatternSetRequest");
   }
 }
 
@@ -1419,7 +1422,7 @@ export interface DeleteRegexPatternSetResponse extends $MetadataBearer {
 
 export namespace DeleteRegexPatternSetResponse {
   export function isa(o: any): o is DeleteRegexPatternSetResponse {
-    return _smithy.isa(o, "DeleteRegexPatternSetResponse");
+    return __isa(o, "DeleteRegexPatternSetResponse");
   }
 }
 
@@ -1439,7 +1442,7 @@ export interface DeleteRuleGroupRequest {
 
 export namespace DeleteRuleGroupRequest {
   export function isa(o: any): o is DeleteRuleGroupRequest {
-    return _smithy.isa(o, "DeleteRuleGroupRequest");
+    return __isa(o, "DeleteRuleGroupRequest");
   }
 }
 
@@ -1454,7 +1457,7 @@ export interface DeleteRuleGroupResponse extends $MetadataBearer {
 
 export namespace DeleteRuleGroupResponse {
   export function isa(o: any): o is DeleteRuleGroupResponse {
-    return _smithy.isa(o, "DeleteRuleGroupResponse");
+    return __isa(o, "DeleteRuleGroupResponse");
   }
 }
 
@@ -1474,7 +1477,7 @@ export interface DeleteRuleRequest {
 
 export namespace DeleteRuleRequest {
   export function isa(o: any): o is DeleteRuleRequest {
-    return _smithy.isa(o, "DeleteRuleRequest");
+    return __isa(o, "DeleteRuleRequest");
   }
 }
 
@@ -1489,7 +1492,7 @@ export interface DeleteRuleResponse extends $MetadataBearer {
 
 export namespace DeleteRuleResponse {
   export function isa(o: any): o is DeleteRuleResponse {
-    return _smithy.isa(o, "DeleteRuleResponse");
+    return __isa(o, "DeleteRuleResponse");
   }
 }
 
@@ -1509,7 +1512,7 @@ export interface DeleteSizeConstraintSetRequest {
 
 export namespace DeleteSizeConstraintSetRequest {
   export function isa(o: any): o is DeleteSizeConstraintSetRequest {
-    return _smithy.isa(o, "DeleteSizeConstraintSetRequest");
+    return __isa(o, "DeleteSizeConstraintSetRequest");
   }
 }
 
@@ -1524,7 +1527,7 @@ export interface DeleteSizeConstraintSetResponse extends $MetadataBearer {
 
 export namespace DeleteSizeConstraintSetResponse {
   export function isa(o: any): o is DeleteSizeConstraintSetResponse {
-    return _smithy.isa(o, "DeleteSizeConstraintSetResponse");
+    return __isa(o, "DeleteSizeConstraintSetResponse");
   }
 }
 
@@ -1547,7 +1550,7 @@ export interface DeleteSqlInjectionMatchSetRequest {
 
 export namespace DeleteSqlInjectionMatchSetRequest {
   export function isa(o: any): o is DeleteSqlInjectionMatchSetRequest {
-    return _smithy.isa(o, "DeleteSqlInjectionMatchSetRequest");
+    return __isa(o, "DeleteSqlInjectionMatchSetRequest");
   }
 }
 
@@ -1565,7 +1568,7 @@ export interface DeleteSqlInjectionMatchSetResponse extends $MetadataBearer {
 
 export namespace DeleteSqlInjectionMatchSetResponse {
   export function isa(o: any): o is DeleteSqlInjectionMatchSetResponse {
-    return _smithy.isa(o, "DeleteSqlInjectionMatchSetResponse");
+    return __isa(o, "DeleteSqlInjectionMatchSetResponse");
   }
 }
 
@@ -1585,7 +1588,7 @@ export interface DeleteWebACLRequest {
 
 export namespace DeleteWebACLRequest {
   export function isa(o: any): o is DeleteWebACLRequest {
-    return _smithy.isa(o, "DeleteWebACLRequest");
+    return __isa(o, "DeleteWebACLRequest");
   }
 }
 
@@ -1600,7 +1603,7 @@ export interface DeleteWebACLResponse extends $MetadataBearer {
 
 export namespace DeleteWebACLResponse {
   export function isa(o: any): o is DeleteWebACLResponse {
-    return _smithy.isa(o, "DeleteWebACLResponse");
+    return __isa(o, "DeleteWebACLResponse");
   }
 }
 
@@ -1623,7 +1626,7 @@ export interface DeleteXssMatchSetRequest {
 
 export namespace DeleteXssMatchSetRequest {
   export function isa(o: any): o is DeleteXssMatchSetRequest {
-    return _smithy.isa(o, "DeleteXssMatchSetRequest");
+    return __isa(o, "DeleteXssMatchSetRequest");
   }
 }
 
@@ -1641,7 +1644,7 @@ export interface DeleteXssMatchSetResponse extends $MetadataBearer {
 
 export namespace DeleteXssMatchSetResponse {
   export function isa(o: any): o is DeleteXssMatchSetResponse {
-    return _smithy.isa(o, "DeleteXssMatchSetResponse");
+    return __isa(o, "DeleteXssMatchSetResponse");
   }
 }
 
@@ -1660,7 +1663,7 @@ export interface ExcludedRule {
 
 export namespace ExcludedRule {
   export function isa(o: any): o is ExcludedRule {
-    return _smithy.isa(o, "ExcludedRule");
+    return __isa(o, "ExcludedRule");
   }
 }
 
@@ -1724,7 +1727,7 @@ export interface FieldToMatch {
 
 export namespace FieldToMatch {
   export function isa(o: any): o is FieldToMatch {
-    return _smithy.isa(o, "FieldToMatch");
+    return __isa(o, "FieldToMatch");
   }
 }
 
@@ -1746,7 +1749,7 @@ export interface GeoMatchConstraint {
 
 export namespace GeoMatchConstraint {
   export function isa(o: any): o is GeoMatchConstraint {
-    return _smithy.isa(o, "GeoMatchConstraint");
+    return __isa(o, "GeoMatchConstraint");
   }
 }
 
@@ -2032,7 +2035,7 @@ export interface GeoMatchSet {
 
 export namespace GeoMatchSet {
   export function isa(o: any): o is GeoMatchSet {
-    return _smithy.isa(o, "GeoMatchSet");
+    return __isa(o, "GeoMatchSet");
   }
 }
 
@@ -2054,7 +2057,7 @@ export interface GeoMatchSetSummary {
 
 export namespace GeoMatchSetSummary {
   export function isa(o: any): o is GeoMatchSetSummary {
-    return _smithy.isa(o, "GeoMatchSetSummary");
+    return __isa(o, "GeoMatchSetSummary");
   }
 }
 
@@ -2076,7 +2079,7 @@ export interface GeoMatchSetUpdate {
 
 export namespace GeoMatchSetUpdate {
   export function isa(o: any): o is GeoMatchSetUpdate {
-    return _smithy.isa(o, "GeoMatchSetUpdate");
+    return __isa(o, "GeoMatchSetUpdate");
   }
 }
 
@@ -2091,7 +2094,7 @@ export interface GetByteMatchSetRequest {
 
 export namespace GetByteMatchSetRequest {
   export function isa(o: any): o is GetByteMatchSetRequest {
-    return _smithy.isa(o, "GetByteMatchSetRequest");
+    return __isa(o, "GetByteMatchSetRequest");
   }
 }
 
@@ -2125,7 +2128,7 @@ export interface GetByteMatchSetResponse extends $MetadataBearer {
 
 export namespace GetByteMatchSetResponse {
   export function isa(o: any): o is GetByteMatchSetResponse {
-    return _smithy.isa(o, "GetByteMatchSetResponse");
+    return __isa(o, "GetByteMatchSetResponse");
   }
 }
 
@@ -2135,7 +2138,7 @@ export interface GetChangeTokenRequest {
 
 export namespace GetChangeTokenRequest {
   export function isa(o: any): o is GetChangeTokenRequest {
-    return _smithy.isa(o, "GetChangeTokenRequest");
+    return __isa(o, "GetChangeTokenRequest");
   }
 }
 
@@ -2150,7 +2153,7 @@ export interface GetChangeTokenResponse extends $MetadataBearer {
 
 export namespace GetChangeTokenResponse {
   export function isa(o: any): o is GetChangeTokenResponse {
-    return _smithy.isa(o, "GetChangeTokenResponse");
+    return __isa(o, "GetChangeTokenResponse");
   }
 }
 
@@ -2164,7 +2167,7 @@ export interface GetChangeTokenStatusRequest {
 
 export namespace GetChangeTokenStatusRequest {
   export function isa(o: any): o is GetChangeTokenStatusRequest {
-    return _smithy.isa(o, "GetChangeTokenStatusRequest");
+    return __isa(o, "GetChangeTokenStatusRequest");
   }
 }
 
@@ -2178,7 +2181,7 @@ export interface GetChangeTokenStatusResponse extends $MetadataBearer {
 
 export namespace GetChangeTokenStatusResponse {
   export function isa(o: any): o is GetChangeTokenStatusResponse {
-    return _smithy.isa(o, "GetChangeTokenStatusResponse");
+    return __isa(o, "GetChangeTokenStatusResponse");
   }
 }
 
@@ -2193,7 +2196,7 @@ export interface GetGeoMatchSetRequest {
 
 export namespace GetGeoMatchSetRequest {
   export function isa(o: any): o is GetGeoMatchSetRequest {
-    return _smithy.isa(o, "GetGeoMatchSetRequest");
+    return __isa(o, "GetGeoMatchSetRequest");
   }
 }
 
@@ -2207,7 +2210,7 @@ export interface GetGeoMatchSetResponse extends $MetadataBearer {
 
 export namespace GetGeoMatchSetResponse {
   export function isa(o: any): o is GetGeoMatchSetResponse {
-    return _smithy.isa(o, "GetGeoMatchSetResponse");
+    return __isa(o, "GetGeoMatchSetResponse");
   }
 }
 
@@ -2222,7 +2225,7 @@ export interface GetIPSetRequest {
 
 export namespace GetIPSetRequest {
   export function isa(o: any): o is GetIPSetRequest {
-    return _smithy.isa(o, "GetIPSetRequest");
+    return __isa(o, "GetIPSetRequest");
   }
 }
 
@@ -2250,7 +2253,7 @@ export interface GetIPSetResponse extends $MetadataBearer {
 
 export namespace GetIPSetResponse {
   export function isa(o: any): o is GetIPSetResponse {
-    return _smithy.isa(o, "GetIPSetResponse");
+    return __isa(o, "GetIPSetResponse");
   }
 }
 
@@ -2264,7 +2267,7 @@ export interface GetLoggingConfigurationRequest {
 
 export namespace GetLoggingConfigurationRequest {
   export function isa(o: any): o is GetLoggingConfigurationRequest {
-    return _smithy.isa(o, "GetLoggingConfigurationRequest");
+    return __isa(o, "GetLoggingConfigurationRequest");
   }
 }
 
@@ -2278,7 +2281,7 @@ export interface GetLoggingConfigurationResponse extends $MetadataBearer {
 
 export namespace GetLoggingConfigurationResponse {
   export function isa(o: any): o is GetLoggingConfigurationResponse {
-    return _smithy.isa(o, "GetLoggingConfigurationResponse");
+    return __isa(o, "GetLoggingConfigurationResponse");
   }
 }
 
@@ -2292,7 +2295,7 @@ export interface GetPermissionPolicyRequest {
 
 export namespace GetPermissionPolicyRequest {
   export function isa(o: any): o is GetPermissionPolicyRequest {
-    return _smithy.isa(o, "GetPermissionPolicyRequest");
+    return __isa(o, "GetPermissionPolicyRequest");
   }
 }
 
@@ -2306,7 +2309,7 @@ export interface GetPermissionPolicyResponse extends $MetadataBearer {
 
 export namespace GetPermissionPolicyResponse {
   export function isa(o: any): o is GetPermissionPolicyResponse {
-    return _smithy.isa(o, "GetPermissionPolicyResponse");
+    return __isa(o, "GetPermissionPolicyResponse");
   }
 }
 
@@ -2326,7 +2329,7 @@ export interface GetRateBasedRuleManagedKeysRequest {
 
 export namespace GetRateBasedRuleManagedKeysRequest {
   export function isa(o: any): o is GetRateBasedRuleManagedKeysRequest {
-    return _smithy.isa(o, "GetRateBasedRuleManagedKeysRequest");
+    return __isa(o, "GetRateBasedRuleManagedKeysRequest");
   }
 }
 
@@ -2345,7 +2348,7 @@ export interface GetRateBasedRuleManagedKeysResponse extends $MetadataBearer {
 
 export namespace GetRateBasedRuleManagedKeysResponse {
   export function isa(o: any): o is GetRateBasedRuleManagedKeysResponse {
-    return _smithy.isa(o, "GetRateBasedRuleManagedKeysResponse");
+    return __isa(o, "GetRateBasedRuleManagedKeysResponse");
   }
 }
 
@@ -2360,7 +2363,7 @@ export interface GetRateBasedRuleRequest {
 
 export namespace GetRateBasedRuleRequest {
   export function isa(o: any): o is GetRateBasedRuleRequest {
-    return _smithy.isa(o, "GetRateBasedRuleRequest");
+    return __isa(o, "GetRateBasedRuleRequest");
   }
 }
 
@@ -2375,7 +2378,7 @@ export interface GetRateBasedRuleResponse extends $MetadataBearer {
 
 export namespace GetRateBasedRuleResponse {
   export function isa(o: any): o is GetRateBasedRuleResponse {
-    return _smithy.isa(o, "GetRateBasedRuleResponse");
+    return __isa(o, "GetRateBasedRuleResponse");
   }
 }
 
@@ -2390,7 +2393,7 @@ export interface GetRegexMatchSetRequest {
 
 export namespace GetRegexMatchSetRequest {
   export function isa(o: any): o is GetRegexMatchSetRequest {
-    return _smithy.isa(o, "GetRegexMatchSetRequest");
+    return __isa(o, "GetRegexMatchSetRequest");
   }
 }
 
@@ -2404,7 +2407,7 @@ export interface GetRegexMatchSetResponse extends $MetadataBearer {
 
 export namespace GetRegexMatchSetResponse {
   export function isa(o: any): o is GetRegexMatchSetResponse {
-    return _smithy.isa(o, "GetRegexMatchSetResponse");
+    return __isa(o, "GetRegexMatchSetResponse");
   }
 }
 
@@ -2419,7 +2422,7 @@ export interface GetRegexPatternSetRequest {
 
 export namespace GetRegexPatternSetRequest {
   export function isa(o: any): o is GetRegexPatternSetRequest {
-    return _smithy.isa(o, "GetRegexPatternSetRequest");
+    return __isa(o, "GetRegexPatternSetRequest");
   }
 }
 
@@ -2433,7 +2436,7 @@ export interface GetRegexPatternSetResponse extends $MetadataBearer {
 
 export namespace GetRegexPatternSetResponse {
   export function isa(o: any): o is GetRegexPatternSetResponse {
-    return _smithy.isa(o, "GetRegexPatternSetResponse");
+    return __isa(o, "GetRegexPatternSetResponse");
   }
 }
 
@@ -2448,7 +2451,7 @@ export interface GetRuleGroupRequest {
 
 export namespace GetRuleGroupRequest {
   export function isa(o: any): o is GetRuleGroupRequest {
-    return _smithy.isa(o, "GetRuleGroupRequest");
+    return __isa(o, "GetRuleGroupRequest");
   }
 }
 
@@ -2462,7 +2465,7 @@ export interface GetRuleGroupResponse extends $MetadataBearer {
 
 export namespace GetRuleGroupResponse {
   export function isa(o: any): o is GetRuleGroupResponse {
-    return _smithy.isa(o, "GetRuleGroupResponse");
+    return __isa(o, "GetRuleGroupResponse");
   }
 }
 
@@ -2477,7 +2480,7 @@ export interface GetRuleRequest {
 
 export namespace GetRuleRequest {
   export function isa(o: any): o is GetRuleRequest {
-    return _smithy.isa(o, "GetRuleRequest");
+    return __isa(o, "GetRuleRequest");
   }
 }
 
@@ -2506,7 +2509,7 @@ export interface GetRuleResponse extends $MetadataBearer {
 
 export namespace GetRuleResponse {
   export function isa(o: any): o is GetRuleResponse {
-    return _smithy.isa(o, "GetRuleResponse");
+    return __isa(o, "GetRuleResponse");
   }
 }
 
@@ -2550,7 +2553,7 @@ export interface GetSampledRequestsRequest {
 
 export namespace GetSampledRequestsRequest {
   export function isa(o: any): o is GetSampledRequestsRequest {
-    return _smithy.isa(o, "GetSampledRequestsRequest");
+    return __isa(o, "GetSampledRequestsRequest");
   }
 }
 
@@ -2578,7 +2581,7 @@ export interface GetSampledRequestsResponse extends $MetadataBearer {
 
 export namespace GetSampledRequestsResponse {
   export function isa(o: any): o is GetSampledRequestsResponse {
-    return _smithy.isa(o, "GetSampledRequestsResponse");
+    return __isa(o, "GetSampledRequestsResponse");
   }
 }
 
@@ -2593,7 +2596,7 @@ export interface GetSizeConstraintSetRequest {
 
 export namespace GetSizeConstraintSetRequest {
   export function isa(o: any): o is GetSizeConstraintSetRequest {
-    return _smithy.isa(o, "GetSizeConstraintSetRequest");
+    return __isa(o, "GetSizeConstraintSetRequest");
   }
 }
 
@@ -2627,7 +2630,7 @@ export interface GetSizeConstraintSetResponse extends $MetadataBearer {
 
 export namespace GetSizeConstraintSetResponse {
   export function isa(o: any): o is GetSizeConstraintSetResponse {
-    return _smithy.isa(o, "GetSizeConstraintSetResponse");
+    return __isa(o, "GetSizeConstraintSetResponse");
   }
 }
 
@@ -2645,7 +2648,7 @@ export interface GetSqlInjectionMatchSetRequest {
 
 export namespace GetSqlInjectionMatchSetRequest {
   export function isa(o: any): o is GetSqlInjectionMatchSetRequest {
-    return _smithy.isa(o, "GetSqlInjectionMatchSetRequest");
+    return __isa(o, "GetSqlInjectionMatchSetRequest");
   }
 }
 
@@ -2681,7 +2684,7 @@ export interface GetSqlInjectionMatchSetResponse extends $MetadataBearer {
 
 export namespace GetSqlInjectionMatchSetResponse {
   export function isa(o: any): o is GetSqlInjectionMatchSetResponse {
-    return _smithy.isa(o, "GetSqlInjectionMatchSetResponse");
+    return __isa(o, "GetSqlInjectionMatchSetResponse");
   }
 }
 
@@ -2696,7 +2699,7 @@ export interface GetWebACLRequest {
 
 export namespace GetWebACLRequest {
   export function isa(o: any): o is GetWebACLRequest {
-    return _smithy.isa(o, "GetWebACLRequest");
+    return __isa(o, "GetWebACLRequest");
   }
 }
 
@@ -2735,7 +2738,7 @@ export interface GetWebACLResponse extends $MetadataBearer {
 
 export namespace GetWebACLResponse {
   export function isa(o: any): o is GetWebACLResponse {
-    return _smithy.isa(o, "GetWebACLResponse");
+    return __isa(o, "GetWebACLResponse");
   }
 }
 
@@ -2753,7 +2756,7 @@ export interface GetXssMatchSetRequest {
 
 export namespace GetXssMatchSetRequest {
   export function isa(o: any): o is GetXssMatchSetRequest {
-    return _smithy.isa(o, "GetXssMatchSetRequest");
+    return __isa(o, "GetXssMatchSetRequest");
   }
 }
 
@@ -2789,7 +2792,7 @@ export interface GetXssMatchSetResponse extends $MetadataBearer {
 
 export namespace GetXssMatchSetResponse {
   export function isa(o: any): o is GetXssMatchSetResponse {
-    return _smithy.isa(o, "GetXssMatchSetResponse");
+    return __isa(o, "GetXssMatchSetResponse");
   }
 }
 
@@ -2813,7 +2816,7 @@ export interface HTTPHeader {
 
 export namespace HTTPHeader {
   export function isa(o: any): o is HTTPHeader {
-    return _smithy.isa(o, "HTTPHeader");
+    return __isa(o, "HTTPHeader");
   }
 }
 
@@ -2870,7 +2873,7 @@ export interface HTTPRequest {
 
 export namespace HTTPRequest {
   export function isa(o: any): o is HTTPRequest {
-    return _smithy.isa(o, "HTTPRequest");
+    return __isa(o, "HTTPRequest");
   }
 }
 
@@ -2908,7 +2911,7 @@ export interface IPSet {
 
 export namespace IPSet {
   export function isa(o: any): o is IPSet {
-    return _smithy.isa(o, "IPSet");
+    return __isa(o, "IPSet");
   }
 }
 
@@ -2951,7 +2954,7 @@ export interface IPSetDescriptor {
 
 export namespace IPSetDescriptor {
   export function isa(o: any): o is IPSetDescriptor {
-    return _smithy.isa(o, "IPSetDescriptor");
+    return __isa(o, "IPSetDescriptor");
   }
 }
 
@@ -2979,7 +2982,7 @@ export interface IPSetSummary {
 
 export namespace IPSetSummary {
   export function isa(o: any): o is IPSetSummary {
-    return _smithy.isa(o, "IPSetSummary");
+    return __isa(o, "IPSetSummary");
   }
 }
 
@@ -3001,7 +3004,7 @@ export interface IPSetUpdate {
 
 export namespace IPSetUpdate {
   export function isa(o: any): o is IPSetUpdate {
-    return _smithy.isa(o, "IPSetUpdate");
+    return __isa(o, "IPSetUpdate");
   }
 }
 
@@ -3029,7 +3032,7 @@ export interface ListActivatedRulesInRuleGroupRequest {
 
 export namespace ListActivatedRulesInRuleGroupRequest {
   export function isa(o: any): o is ListActivatedRulesInRuleGroupRequest {
-    return _smithy.isa(o, "ListActivatedRulesInRuleGroupRequest");
+    return __isa(o, "ListActivatedRulesInRuleGroupRequest");
   }
 }
 
@@ -3048,7 +3051,7 @@ export interface ListActivatedRulesInRuleGroupResponse extends $MetadataBearer {
 
 export namespace ListActivatedRulesInRuleGroupResponse {
   export function isa(o: any): o is ListActivatedRulesInRuleGroupResponse {
-    return _smithy.isa(o, "ListActivatedRulesInRuleGroupResponse");
+    return __isa(o, "ListActivatedRulesInRuleGroupResponse");
   }
 }
 
@@ -3072,7 +3075,7 @@ export interface ListByteMatchSetsRequest {
 
 export namespace ListByteMatchSetsRequest {
   export function isa(o: any): o is ListByteMatchSetsRequest {
-    return _smithy.isa(o, "ListByteMatchSetsRequest");
+    return __isa(o, "ListByteMatchSetsRequest");
   }
 }
 
@@ -3094,7 +3097,7 @@ export interface ListByteMatchSetsResponse extends $MetadataBearer {
 
 export namespace ListByteMatchSetsResponse {
   export function isa(o: any): o is ListByteMatchSetsResponse {
-    return _smithy.isa(o, "ListByteMatchSetsResponse");
+    return __isa(o, "ListByteMatchSetsResponse");
   }
 }
 
@@ -3118,7 +3121,7 @@ export interface ListGeoMatchSetsRequest {
 
 export namespace ListGeoMatchSetsRequest {
   export function isa(o: any): o is ListGeoMatchSetsRequest {
-    return _smithy.isa(o, "ListGeoMatchSetsRequest");
+    return __isa(o, "ListGeoMatchSetsRequest");
   }
 }
 
@@ -3140,7 +3143,7 @@ export interface ListGeoMatchSetsResponse extends $MetadataBearer {
 
 export namespace ListGeoMatchSetsResponse {
   export function isa(o: any): o is ListGeoMatchSetsResponse {
-    return _smithy.isa(o, "ListGeoMatchSetsResponse");
+    return __isa(o, "ListGeoMatchSetsResponse");
   }
 }
 
@@ -3164,7 +3167,7 @@ export interface ListIPSetsRequest {
 
 export namespace ListIPSetsRequest {
   export function isa(o: any): o is ListIPSetsRequest {
-    return _smithy.isa(o, "ListIPSetsRequest");
+    return __isa(o, "ListIPSetsRequest");
   }
 }
 
@@ -3185,7 +3188,7 @@ export interface ListIPSetsResponse extends $MetadataBearer {
 
 export namespace ListIPSetsResponse {
   export function isa(o: any): o is ListIPSetsResponse {
-    return _smithy.isa(o, "ListIPSetsResponse");
+    return __isa(o, "ListIPSetsResponse");
   }
 }
 
@@ -3207,7 +3210,7 @@ export interface ListLoggingConfigurationsRequest {
 
 export namespace ListLoggingConfigurationsRequest {
   export function isa(o: any): o is ListLoggingConfigurationsRequest {
-    return _smithy.isa(o, "ListLoggingConfigurationsRequest");
+    return __isa(o, "ListLoggingConfigurationsRequest");
   }
 }
 
@@ -3226,7 +3229,7 @@ export interface ListLoggingConfigurationsResponse extends $MetadataBearer {
 
 export namespace ListLoggingConfigurationsResponse {
   export function isa(o: any): o is ListLoggingConfigurationsResponse {
-    return _smithy.isa(o, "ListLoggingConfigurationsResponse");
+    return __isa(o, "ListLoggingConfigurationsResponse");
   }
 }
 
@@ -3253,7 +3256,7 @@ export interface ListRateBasedRulesRequest {
 
 export namespace ListRateBasedRulesRequest {
   export function isa(o: any): o is ListRateBasedRulesRequest {
-    return _smithy.isa(o, "ListRateBasedRulesRequest");
+    return __isa(o, "ListRateBasedRulesRequest");
   }
 }
 
@@ -3276,7 +3279,7 @@ export interface ListRateBasedRulesResponse extends $MetadataBearer {
 
 export namespace ListRateBasedRulesResponse {
   export function isa(o: any): o is ListRateBasedRulesResponse {
-    return _smithy.isa(o, "ListRateBasedRulesResponse");
+    return __isa(o, "ListRateBasedRulesResponse");
   }
 }
 
@@ -3300,7 +3303,7 @@ export interface ListRegexMatchSetsRequest {
 
 export namespace ListRegexMatchSetsRequest {
   export function isa(o: any): o is ListRegexMatchSetsRequest {
-    return _smithy.isa(o, "ListRegexMatchSetsRequest");
+    return __isa(o, "ListRegexMatchSetsRequest");
   }
 }
 
@@ -3322,7 +3325,7 @@ export interface ListRegexMatchSetsResponse extends $MetadataBearer {
 
 export namespace ListRegexMatchSetsResponse {
   export function isa(o: any): o is ListRegexMatchSetsResponse {
-    return _smithy.isa(o, "ListRegexMatchSetsResponse");
+    return __isa(o, "ListRegexMatchSetsResponse");
   }
 }
 
@@ -3346,7 +3349,7 @@ export interface ListRegexPatternSetsRequest {
 
 export namespace ListRegexPatternSetsRequest {
   export function isa(o: any): o is ListRegexPatternSetsRequest {
-    return _smithy.isa(o, "ListRegexPatternSetsRequest");
+    return __isa(o, "ListRegexPatternSetsRequest");
   }
 }
 
@@ -3368,7 +3371,7 @@ export interface ListRegexPatternSetsResponse extends $MetadataBearer {
 
 export namespace ListRegexPatternSetsResponse {
   export function isa(o: any): o is ListRegexPatternSetsResponse {
-    return _smithy.isa(o, "ListRegexPatternSetsResponse");
+    return __isa(o, "ListRegexPatternSetsResponse");
   }
 }
 
@@ -3390,7 +3393,7 @@ export interface ListRuleGroupsRequest {
 
 export namespace ListRuleGroupsRequest {
   export function isa(o: any): o is ListRuleGroupsRequest {
-    return _smithy.isa(o, "ListRuleGroupsRequest");
+    return __isa(o, "ListRuleGroupsRequest");
   }
 }
 
@@ -3409,7 +3412,7 @@ export interface ListRuleGroupsResponse extends $MetadataBearer {
 
 export namespace ListRuleGroupsResponse {
   export function isa(o: any): o is ListRuleGroupsResponse {
-    return _smithy.isa(o, "ListRuleGroupsResponse");
+    return __isa(o, "ListRuleGroupsResponse");
   }
 }
 
@@ -3432,7 +3435,7 @@ export interface ListRulesRequest {
 
 export namespace ListRulesRequest {
   export function isa(o: any): o is ListRulesRequest {
-    return _smithy.isa(o, "ListRulesRequest");
+    return __isa(o, "ListRulesRequest");
   }
 }
 
@@ -3453,7 +3456,7 @@ export interface ListRulesResponse extends $MetadataBearer {
 
 export namespace ListRulesResponse {
   export function isa(o: any): o is ListRulesResponse {
-    return _smithy.isa(o, "ListRulesResponse");
+    return __isa(o, "ListRulesResponse");
   }
 }
 
@@ -3476,7 +3479,7 @@ export interface ListSizeConstraintSetsRequest {
 
 export namespace ListSizeConstraintSetsRequest {
   export function isa(o: any): o is ListSizeConstraintSetsRequest {
-    return _smithy.isa(o, "ListSizeConstraintSetsRequest");
+    return __isa(o, "ListSizeConstraintSetsRequest");
   }
 }
 
@@ -3498,7 +3501,7 @@ export interface ListSizeConstraintSetsResponse extends $MetadataBearer {
 
 export namespace ListSizeConstraintSetsResponse {
   export function isa(o: any): o is ListSizeConstraintSetsResponse {
-    return _smithy.isa(o, "ListSizeConstraintSetsResponse");
+    return __isa(o, "ListSizeConstraintSetsResponse");
   }
 }
 
@@ -3525,7 +3528,7 @@ export interface ListSqlInjectionMatchSetsRequest {
 
 export namespace ListSqlInjectionMatchSetsRequest {
   export function isa(o: any): o is ListSqlInjectionMatchSetsRequest {
-    return _smithy.isa(o, "ListSqlInjectionMatchSetsRequest");
+    return __isa(o, "ListSqlInjectionMatchSetsRequest");
   }
 }
 
@@ -3550,7 +3553,7 @@ export interface ListSqlInjectionMatchSetsResponse extends $MetadataBearer {
 
 export namespace ListSqlInjectionMatchSetsResponse {
   export function isa(o: any): o is ListSqlInjectionMatchSetsResponse {
-    return _smithy.isa(o, "ListSqlInjectionMatchSetsResponse");
+    return __isa(o, "ListSqlInjectionMatchSetsResponse");
   }
 }
 
@@ -3574,7 +3577,7 @@ export interface ListSubscribedRuleGroupsRequest {
 
 export namespace ListSubscribedRuleGroupsRequest {
   export function isa(o: any): o is ListSubscribedRuleGroupsRequest {
-    return _smithy.isa(o, "ListSubscribedRuleGroupsRequest");
+    return __isa(o, "ListSubscribedRuleGroupsRequest");
   }
 }
 
@@ -3596,7 +3599,7 @@ export interface ListSubscribedRuleGroupsResponse extends $MetadataBearer {
 
 export namespace ListSubscribedRuleGroupsResponse {
   export function isa(o: any): o is ListSubscribedRuleGroupsResponse {
-    return _smithy.isa(o, "ListSubscribedRuleGroupsResponse");
+    return __isa(o, "ListSubscribedRuleGroupsResponse");
   }
 }
 
@@ -3609,7 +3612,7 @@ export interface ListTagsForResourceRequest {
 
 export namespace ListTagsForResourceRequest {
   export function isa(o: any): o is ListTagsForResourceRequest {
-    return _smithy.isa(o, "ListTagsForResourceRequest");
+    return __isa(o, "ListTagsForResourceRequest");
   }
 }
 
@@ -3621,7 +3624,7 @@ export interface ListTagsForResourceResponse extends $MetadataBearer {
 
 export namespace ListTagsForResourceResponse {
   export function isa(o: any): o is ListTagsForResourceResponse {
-    return _smithy.isa(o, "ListTagsForResourceResponse");
+    return __isa(o, "ListTagsForResourceResponse");
   }
 }
 
@@ -3645,7 +3648,7 @@ export interface ListWebACLsRequest {
 
 export namespace ListWebACLsRequest {
   export function isa(o: any): o is ListWebACLsRequest {
-    return _smithy.isa(o, "ListWebACLsRequest");
+    return __isa(o, "ListWebACLsRequest");
   }
 }
 
@@ -3667,7 +3670,7 @@ export interface ListWebACLsResponse extends $MetadataBearer {
 
 export namespace ListWebACLsResponse {
   export function isa(o: any): o is ListWebACLsResponse {
-    return _smithy.isa(o, "ListWebACLsResponse");
+    return __isa(o, "ListWebACLsResponse");
   }
 }
 
@@ -3694,7 +3697,7 @@ export interface ListXssMatchSetsRequest {
 
 export namespace ListXssMatchSetsRequest {
   export function isa(o: any): o is ListXssMatchSetsRequest {
-    return _smithy.isa(o, "ListXssMatchSetsRequest");
+    return __isa(o, "ListXssMatchSetsRequest");
   }
 }
 
@@ -3719,7 +3722,7 @@ export interface ListXssMatchSetsResponse extends $MetadataBearer {
 
 export namespace ListXssMatchSetsResponse {
   export function isa(o: any): o is ListXssMatchSetsResponse {
-    return _smithy.isa(o, "ListXssMatchSetsResponse");
+    return __isa(o, "ListXssMatchSetsResponse");
   }
 }
 
@@ -3751,7 +3754,7 @@ export interface LoggingConfiguration {
 
 export namespace LoggingConfiguration {
   export function isa(o: any): o is LoggingConfiguration {
-    return _smithy.isa(o, "LoggingConfiguration");
+    return __isa(o, "LoggingConfiguration");
   }
 }
 
@@ -3834,7 +3837,7 @@ export interface Predicate {
 
 export namespace Predicate {
   export function isa(o: any): o is Predicate {
-    return _smithy.isa(o, "Predicate");
+    return __isa(o, "Predicate");
   }
 }
 
@@ -3865,7 +3868,7 @@ export interface PutLoggingConfigurationRequest {
 
 export namespace PutLoggingConfigurationRequest {
   export function isa(o: any): o is PutLoggingConfigurationRequest {
-    return _smithy.isa(o, "PutLoggingConfigurationRequest");
+    return __isa(o, "PutLoggingConfigurationRequest");
   }
 }
 
@@ -3879,7 +3882,7 @@ export interface PutLoggingConfigurationResponse extends $MetadataBearer {
 
 export namespace PutLoggingConfigurationResponse {
   export function isa(o: any): o is PutLoggingConfigurationResponse {
-    return _smithy.isa(o, "PutLoggingConfigurationResponse");
+    return __isa(o, "PutLoggingConfigurationResponse");
   }
 }
 
@@ -3898,7 +3901,7 @@ export interface PutPermissionPolicyRequest {
 
 export namespace PutPermissionPolicyRequest {
   export function isa(o: any): o is PutPermissionPolicyRequest {
-    return _smithy.isa(o, "PutPermissionPolicyRequest");
+    return __isa(o, "PutPermissionPolicyRequest");
   }
 }
 
@@ -3908,7 +3911,7 @@ export interface PutPermissionPolicyResponse extends $MetadataBearer {
 
 export namespace PutPermissionPolicyResponse {
   export function isa(o: any): o is PutPermissionPolicyResponse {
-    return _smithy.isa(o, "PutPermissionPolicyResponse");
+    return __isa(o, "PutPermissionPolicyResponse");
   }
 }
 
@@ -3981,7 +3984,7 @@ export interface RateBasedRule {
 
 export namespace RateBasedRule {
   export function isa(o: any): o is RateBasedRule {
-    return _smithy.isa(o, "RateBasedRule");
+    return __isa(o, "RateBasedRule");
   }
 }
 
@@ -4034,7 +4037,7 @@ export interface RegexMatchSet {
 
 export namespace RegexMatchSet {
   export function isa(o: any): o is RegexMatchSet {
-    return _smithy.isa(o, "RegexMatchSet");
+    return __isa(o, "RegexMatchSet");
   }
 }
 
@@ -4060,7 +4063,7 @@ export interface RegexMatchSetSummary {
 
 export namespace RegexMatchSetSummary {
   export function isa(o: any): o is RegexMatchSetSummary {
-    return _smithy.isa(o, "RegexMatchSetSummary");
+    return __isa(o, "RegexMatchSetSummary");
   }
 }
 
@@ -4085,7 +4088,7 @@ export interface RegexMatchSetUpdate {
 
 export namespace RegexMatchSetUpdate {
   export function isa(o: any): o is RegexMatchSetUpdate {
-    return _smithy.isa(o, "RegexMatchSetUpdate");
+    return __isa(o, "RegexMatchSetUpdate");
   }
 }
 
@@ -4219,7 +4222,7 @@ export interface RegexMatchTuple {
 
 export namespace RegexMatchTuple {
   export function isa(o: any): o is RegexMatchTuple {
-    return _smithy.isa(o, "RegexMatchTuple");
+    return __isa(o, "RegexMatchTuple");
   }
 }
 
@@ -4249,7 +4252,7 @@ export interface RegexPatternSet {
 
 export namespace RegexPatternSet {
   export function isa(o: any): o is RegexPatternSet {
-    return _smithy.isa(o, "RegexPatternSet");
+    return __isa(o, "RegexPatternSet");
   }
 }
 
@@ -4275,7 +4278,7 @@ export interface RegexPatternSetSummary {
 
 export namespace RegexPatternSetSummary {
   export function isa(o: any): o is RegexPatternSetSummary {
-    return _smithy.isa(o, "RegexPatternSetSummary");
+    return __isa(o, "RegexPatternSetSummary");
   }
 }
 
@@ -4298,7 +4301,7 @@ export interface RegexPatternSetUpdate {
 
 export namespace RegexPatternSetUpdate {
   export function isa(o: any): o is RegexPatternSetUpdate {
-    return _smithy.isa(o, "RegexPatternSetUpdate");
+    return __isa(o, "RegexPatternSetUpdate");
   }
 }
 
@@ -4354,7 +4357,7 @@ export interface Rule {
 
 export namespace Rule {
   export function isa(o: any): o is Rule {
-    return _smithy.isa(o, "Rule");
+    return __isa(o, "Rule");
   }
 }
 
@@ -4398,7 +4401,7 @@ export interface RuleGroup {
 
 export namespace RuleGroup {
   export function isa(o: any): o is RuleGroup {
-    return _smithy.isa(o, "RuleGroup");
+    return __isa(o, "RuleGroup");
   }
 }
 
@@ -4424,7 +4427,7 @@ export interface RuleGroupSummary {
 
 export namespace RuleGroupSummary {
   export function isa(o: any): o is RuleGroupSummary {
-    return _smithy.isa(o, "RuleGroupSummary");
+    return __isa(o, "RuleGroupSummary");
   }
 }
 
@@ -4450,7 +4453,7 @@ export interface RuleGroupUpdate {
 
 export namespace RuleGroupUpdate {
   export function isa(o: any): o is RuleGroupUpdate {
-    return _smithy.isa(o, "RuleGroupUpdate");
+    return __isa(o, "RuleGroupUpdate");
   }
 }
 
@@ -4476,7 +4479,7 @@ export interface RuleSummary {
 
 export namespace RuleSummary {
   export function isa(o: any): o is RuleSummary {
-    return _smithy.isa(o, "RuleSummary");
+    return __isa(o, "RuleSummary");
   }
 }
 
@@ -4500,7 +4503,7 @@ export interface RuleUpdate {
 
 export namespace RuleUpdate {
   export function isa(o: any): o is RuleUpdate {
-    return _smithy.isa(o, "RuleUpdate");
+    return __isa(o, "RuleUpdate");
   }
 }
 
@@ -4541,7 +4544,7 @@ export interface SampledHTTPRequest {
 
 export namespace SampledHTTPRequest {
   export function isa(o: any): o is SampledHTTPRequest {
-    return _smithy.isa(o, "SampledHTTPRequest");
+    return __isa(o, "SampledHTTPRequest");
   }
 }
 
@@ -4695,7 +4698,7 @@ export interface SizeConstraint {
 
 export namespace SizeConstraint {
   export function isa(o: any): o is SizeConstraint {
-    return _smithy.isa(o, "SizeConstraint");
+    return __isa(o, "SizeConstraint");
   }
 }
 
@@ -4730,7 +4733,7 @@ export interface SizeConstraintSet {
 
 export namespace SizeConstraintSet {
   export function isa(o: any): o is SizeConstraintSet {
-    return _smithy.isa(o, "SizeConstraintSet");
+    return __isa(o, "SizeConstraintSet");
   }
 }
 
@@ -4758,7 +4761,7 @@ export interface SizeConstraintSetSummary {
 
 export namespace SizeConstraintSetSummary {
   export function isa(o: any): o is SizeConstraintSetSummary {
-    return _smithy.isa(o, "SizeConstraintSetSummary");
+    return __isa(o, "SizeConstraintSetSummary");
   }
 }
 
@@ -4785,7 +4788,7 @@ export interface SizeConstraintSetUpdate {
 
 export namespace SizeConstraintSetUpdate {
   export function isa(o: any): o is SizeConstraintSetUpdate {
-    return _smithy.isa(o, "SizeConstraintSetUpdate");
+    return __isa(o, "SizeConstraintSetUpdate");
   }
 }
 
@@ -4821,7 +4824,7 @@ export interface SqlInjectionMatchSet {
 
 export namespace SqlInjectionMatchSet {
   export function isa(o: any): o is SqlInjectionMatchSet {
-    return _smithy.isa(o, "SqlInjectionMatchSet");
+    return __isa(o, "SqlInjectionMatchSet");
   }
 }
 
@@ -4849,7 +4852,7 @@ export interface SqlInjectionMatchSetSummary {
 
 export namespace SqlInjectionMatchSetSummary {
   export function isa(o: any): o is SqlInjectionMatchSetSummary {
-    return _smithy.isa(o, "SqlInjectionMatchSetSummary");
+    return __isa(o, "SqlInjectionMatchSetSummary");
   }
 }
 
@@ -4873,7 +4876,7 @@ export interface SqlInjectionMatchSetUpdate {
 
 export namespace SqlInjectionMatchSetUpdate {
   export function isa(o: any): o is SqlInjectionMatchSetUpdate {
-    return _smithy.isa(o, "SqlInjectionMatchSetUpdate");
+    return __isa(o, "SqlInjectionMatchSetUpdate");
   }
 }
 
@@ -4987,7 +4990,7 @@ export interface SqlInjectionMatchTuple {
 
 export namespace SqlInjectionMatchTuple {
   export function isa(o: any): o is SqlInjectionMatchTuple {
-    return _smithy.isa(o, "SqlInjectionMatchTuple");
+    return __isa(o, "SqlInjectionMatchTuple");
   }
 }
 
@@ -5015,7 +5018,7 @@ export interface SubscribedRuleGroupSummary {
 
 export namespace SubscribedRuleGroupSummary {
   export function isa(o: any): o is SubscribedRuleGroupSummary {
-    return _smithy.isa(o, "SubscribedRuleGroupSummary");
+    return __isa(o, "SubscribedRuleGroupSummary");
   }
 }
 
@@ -5027,7 +5030,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -5039,7 +5042,7 @@ export interface TagInfoForResource {
 
 export namespace TagInfoForResource {
   export function isa(o: any): o is TagInfoForResource {
-    return _smithy.isa(o, "TagInfoForResource");
+    return __isa(o, "TagInfoForResource");
   }
 }
 
@@ -5051,7 +5054,7 @@ export interface TagResourceRequest {
 
 export namespace TagResourceRequest {
   export function isa(o: any): o is TagResourceRequest {
-    return _smithy.isa(o, "TagResourceRequest");
+    return __isa(o, "TagResourceRequest");
   }
 }
 
@@ -5061,7 +5064,7 @@ export interface TagResourceResponse extends $MetadataBearer {
 
 export namespace TagResourceResponse {
   export function isa(o: any): o is TagResourceResponse {
-    return _smithy.isa(o, "TagResourceResponse");
+    return __isa(o, "TagResourceResponse");
   }
 }
 
@@ -5100,7 +5103,7 @@ export interface TimeWindow {
 
 export namespace TimeWindow {
   export function isa(o: any): o is TimeWindow {
-    return _smithy.isa(o, "TimeWindow");
+    return __isa(o, "TimeWindow");
   }
 }
 
@@ -5112,7 +5115,7 @@ export interface UntagResourceRequest {
 
 export namespace UntagResourceRequest {
   export function isa(o: any): o is UntagResourceRequest {
-    return _smithy.isa(o, "UntagResourceRequest");
+    return __isa(o, "UntagResourceRequest");
   }
 }
 
@@ -5122,7 +5125,7 @@ export interface UntagResourceResponse extends $MetadataBearer {
 
 export namespace UntagResourceResponse {
   export function isa(o: any): o is UntagResourceResponse {
-    return _smithy.isa(o, "UntagResourceResponse");
+    return __isa(o, "UntagResourceResponse");
   }
 }
 
@@ -5166,7 +5169,7 @@ export interface UpdateByteMatchSetRequest {
 
 export namespace UpdateByteMatchSetRequest {
   export function isa(o: any): o is UpdateByteMatchSetRequest {
-    return _smithy.isa(o, "UpdateByteMatchSetRequest");
+    return __isa(o, "UpdateByteMatchSetRequest");
   }
 }
 
@@ -5181,7 +5184,7 @@ export interface UpdateByteMatchSetResponse extends $MetadataBearer {
 
 export namespace UpdateByteMatchSetResponse {
   export function isa(o: any): o is UpdateByteMatchSetResponse {
-    return _smithy.isa(o, "UpdateByteMatchSetResponse");
+    return __isa(o, "UpdateByteMatchSetResponse");
   }
 }
 
@@ -5220,7 +5223,7 @@ export interface UpdateGeoMatchSetRequest {
 
 export namespace UpdateGeoMatchSetRequest {
   export function isa(o: any): o is UpdateGeoMatchSetRequest {
-    return _smithy.isa(o, "UpdateGeoMatchSetRequest");
+    return __isa(o, "UpdateGeoMatchSetRequest");
   }
 }
 
@@ -5235,7 +5238,7 @@ export interface UpdateGeoMatchSetResponse extends $MetadataBearer {
 
 export namespace UpdateGeoMatchSetResponse {
   export function isa(o: any): o is UpdateGeoMatchSetResponse {
-    return _smithy.isa(o, "UpdateGeoMatchSetResponse");
+    return __isa(o, "UpdateGeoMatchSetResponse");
   }
 }
 
@@ -5274,7 +5277,7 @@ export interface UpdateIPSetRequest {
 
 export namespace UpdateIPSetRequest {
   export function isa(o: any): o is UpdateIPSetRequest {
-    return _smithy.isa(o, "UpdateIPSetRequest");
+    return __isa(o, "UpdateIPSetRequest");
   }
 }
 
@@ -5289,7 +5292,7 @@ export interface UpdateIPSetResponse extends $MetadataBearer {
 
 export namespace UpdateIPSetResponse {
   export function isa(o: any): o is UpdateIPSetResponse {
-    return _smithy.isa(o, "UpdateIPSetResponse");
+    return __isa(o, "UpdateIPSetResponse");
   }
 }
 
@@ -5323,7 +5326,7 @@ export interface UpdateRateBasedRuleRequest {
 
 export namespace UpdateRateBasedRuleRequest {
   export function isa(o: any): o is UpdateRateBasedRuleRequest {
-    return _smithy.isa(o, "UpdateRateBasedRuleRequest");
+    return __isa(o, "UpdateRateBasedRuleRequest");
   }
 }
 
@@ -5339,7 +5342,7 @@ export interface UpdateRateBasedRuleResponse extends $MetadataBearer {
 
 export namespace UpdateRateBasedRuleResponse {
   export function isa(o: any): o is UpdateRateBasedRuleResponse {
-    return _smithy.isa(o, "UpdateRateBasedRuleResponse");
+    return __isa(o, "UpdateRateBasedRuleResponse");
   }
 }
 
@@ -5365,7 +5368,7 @@ export interface UpdateRegexMatchSetRequest {
 
 export namespace UpdateRegexMatchSetRequest {
   export function isa(o: any): o is UpdateRegexMatchSetRequest {
-    return _smithy.isa(o, "UpdateRegexMatchSetRequest");
+    return __isa(o, "UpdateRegexMatchSetRequest");
   }
 }
 
@@ -5380,7 +5383,7 @@ export interface UpdateRegexMatchSetResponse extends $MetadataBearer {
 
 export namespace UpdateRegexMatchSetResponse {
   export function isa(o: any): o is UpdateRegexMatchSetResponse {
-    return _smithy.isa(o, "UpdateRegexMatchSetResponse");
+    return __isa(o, "UpdateRegexMatchSetResponse");
   }
 }
 
@@ -5405,7 +5408,7 @@ export interface UpdateRegexPatternSetRequest {
 
 export namespace UpdateRegexPatternSetRequest {
   export function isa(o: any): o is UpdateRegexPatternSetRequest {
-    return _smithy.isa(o, "UpdateRegexPatternSetRequest");
+    return __isa(o, "UpdateRegexPatternSetRequest");
   }
 }
 
@@ -5420,7 +5423,7 @@ export interface UpdateRegexPatternSetResponse extends $MetadataBearer {
 
 export namespace UpdateRegexPatternSetResponse {
   export function isa(o: any): o is UpdateRegexPatternSetResponse {
-    return _smithy.isa(o, "UpdateRegexPatternSetResponse");
+    return __isa(o, "UpdateRegexPatternSetResponse");
   }
 }
 
@@ -5449,7 +5452,7 @@ export interface UpdateRuleGroupRequest {
 
 export namespace UpdateRuleGroupRequest {
   export function isa(o: any): o is UpdateRuleGroupRequest {
-    return _smithy.isa(o, "UpdateRuleGroupRequest");
+    return __isa(o, "UpdateRuleGroupRequest");
   }
 }
 
@@ -5464,7 +5467,7 @@ export interface UpdateRuleGroupResponse extends $MetadataBearer {
 
 export namespace UpdateRuleGroupResponse {
   export function isa(o: any): o is UpdateRuleGroupResponse {
-    return _smithy.isa(o, "UpdateRuleGroupResponse");
+    return __isa(o, "UpdateRuleGroupResponse");
   }
 }
 
@@ -5507,7 +5510,7 @@ export interface UpdateRuleRequest {
 
 export namespace UpdateRuleRequest {
   export function isa(o: any): o is UpdateRuleRequest {
-    return _smithy.isa(o, "UpdateRuleRequest");
+    return __isa(o, "UpdateRuleRequest");
   }
 }
 
@@ -5522,7 +5525,7 @@ export interface UpdateRuleResponse extends $MetadataBearer {
 
 export namespace UpdateRuleResponse {
   export function isa(o: any): o is UpdateRuleResponse {
-    return _smithy.isa(o, "UpdateRuleResponse");
+    return __isa(o, "UpdateRuleResponse");
   }
 }
 
@@ -5566,7 +5569,7 @@ export interface UpdateSizeConstraintSetRequest {
 
 export namespace UpdateSizeConstraintSetRequest {
   export function isa(o: any): o is UpdateSizeConstraintSetRequest {
-    return _smithy.isa(o, "UpdateSizeConstraintSetRequest");
+    return __isa(o, "UpdateSizeConstraintSetRequest");
   }
 }
 
@@ -5581,7 +5584,7 @@ export interface UpdateSizeConstraintSetResponse extends $MetadataBearer {
 
 export namespace UpdateSizeConstraintSetResponse {
   export function isa(o: any): o is UpdateSizeConstraintSetResponse {
-    return _smithy.isa(o, "UpdateSizeConstraintSetResponse");
+    return __isa(o, "UpdateSizeConstraintSetResponse");
   }
 }
 
@@ -5627,7 +5630,7 @@ export interface UpdateSqlInjectionMatchSetRequest {
 
 export namespace UpdateSqlInjectionMatchSetRequest {
   export function isa(o: any): o is UpdateSqlInjectionMatchSetRequest {
-    return _smithy.isa(o, "UpdateSqlInjectionMatchSetRequest");
+    return __isa(o, "UpdateSqlInjectionMatchSetRequest");
   }
 }
 
@@ -5645,7 +5648,7 @@ export interface UpdateSqlInjectionMatchSetResponse extends $MetadataBearer {
 
 export namespace UpdateSqlInjectionMatchSetResponse {
   export function isa(o: any): o is UpdateSqlInjectionMatchSetResponse {
-    return _smithy.isa(o, "UpdateSqlInjectionMatchSetResponse");
+    return __isa(o, "UpdateSqlInjectionMatchSetResponse");
   }
 }
 
@@ -5701,7 +5704,7 @@ export interface UpdateWebACLRequest {
 
 export namespace UpdateWebACLRequest {
   export function isa(o: any): o is UpdateWebACLRequest {
-    return _smithy.isa(o, "UpdateWebACLRequest");
+    return __isa(o, "UpdateWebACLRequest");
   }
 }
 
@@ -5716,7 +5719,7 @@ export interface UpdateWebACLResponse extends $MetadataBearer {
 
 export namespace UpdateWebACLResponse {
   export function isa(o: any): o is UpdateWebACLResponse {
-    return _smithy.isa(o, "UpdateWebACLResponse");
+    return __isa(o, "UpdateWebACLResponse");
   }
 }
 
@@ -5764,7 +5767,7 @@ export interface UpdateXssMatchSetRequest {
 
 export namespace UpdateXssMatchSetRequest {
   export function isa(o: any): o is UpdateXssMatchSetRequest {
-    return _smithy.isa(o, "UpdateXssMatchSetRequest");
+    return __isa(o, "UpdateXssMatchSetRequest");
   }
 }
 
@@ -5782,12 +5785,12 @@ export interface UpdateXssMatchSetResponse extends $MetadataBearer {
 
 export namespace UpdateXssMatchSetResponse {
   export function isa(o: any): o is UpdateXssMatchSetResponse {
-    return _smithy.isa(o, "UpdateXssMatchSetResponse");
+    return __isa(o, "UpdateXssMatchSetResponse");
   }
 }
 
 export interface WAFBadRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "WAFBadRequestException";
   $fault: "client";
@@ -5796,7 +5799,7 @@ export interface WAFBadRequestException
 
 export namespace WAFBadRequestException {
   export function isa(o: any): o is WAFBadRequestException {
-    return _smithy.isa(o, "WAFBadRequestException");
+    return __isa(o, "WAFBadRequestException");
   }
 }
 
@@ -5804,7 +5807,7 @@ export namespace WAFBadRequestException {
  * <p>The name specified is invalid.</p>
  */
 export interface WAFDisallowedNameException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "WAFDisallowedNameException";
   $fault: "client";
@@ -5813,7 +5816,7 @@ export interface WAFDisallowedNameException
 
 export namespace WAFDisallowedNameException {
   export function isa(o: any): o is WAFDisallowedNameException {
-    return _smithy.isa(o, "WAFDisallowedNameException");
+    return __isa(o, "WAFDisallowedNameException");
   }
 }
 
@@ -5821,7 +5824,7 @@ export namespace WAFDisallowedNameException {
  * <p>The operation failed because of a system problem, even though the request was valid. Retry your request.</p>
  */
 export interface WAFInternalErrorException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "WAFInternalErrorException";
   $fault: "server";
@@ -5830,7 +5833,7 @@ export interface WAFInternalErrorException
 
 export namespace WAFInternalErrorException {
   export function isa(o: any): o is WAFInternalErrorException {
-    return _smithy.isa(o, "WAFInternalErrorException");
+    return __isa(o, "WAFInternalErrorException");
   }
 }
 
@@ -5838,7 +5841,7 @@ export namespace WAFInternalErrorException {
  * <p>The operation failed because you tried to create, update, or delete an object by using an invalid account identifier.</p>
  */
 export interface WAFInvalidAccountException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "WAFInvalidAccountException";
   $fault: "client";
@@ -5846,7 +5849,7 @@ export interface WAFInvalidAccountException
 
 export namespace WAFInvalidAccountException {
   export function isa(o: any): o is WAFInvalidAccountException {
-    return _smithy.isa(o, "WAFInvalidAccountException");
+    return __isa(o, "WAFInvalidAccountException");
   }
 }
 
@@ -5874,7 +5877,7 @@ export namespace WAFInvalidAccountException {
  *          </ul>
  */
 export interface WAFInvalidOperationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "WAFInvalidOperationException";
   $fault: "client";
@@ -5883,7 +5886,7 @@ export interface WAFInvalidOperationException
 
 export namespace WAFInvalidOperationException {
   export function isa(o: any): o is WAFInvalidOperationException {
-    return _smithy.isa(o, "WAFInvalidOperationException");
+    return __isa(o, "WAFInvalidOperationException");
   }
 }
 
@@ -5928,7 +5931,7 @@ export namespace WAFInvalidOperationException {
  *          </ul>
  */
 export interface WAFInvalidParameterException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "WAFInvalidParameterException";
   $fault: "client";
@@ -5939,7 +5942,7 @@ export interface WAFInvalidParameterException
 
 export namespace WAFInvalidParameterException {
   export function isa(o: any): o is WAFInvalidParameterException {
-    return _smithy.isa(o, "WAFInvalidParameterException");
+    return __isa(o, "WAFInvalidParameterException");
   }
 }
 
@@ -5976,7 +5979,7 @@ export namespace WAFInvalidParameterException {
  *          </ul>
  */
 export interface WAFInvalidPermissionPolicyException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "WAFInvalidPermissionPolicyException";
   $fault: "client";
@@ -5985,7 +5988,7 @@ export interface WAFInvalidPermissionPolicyException
 
 export namespace WAFInvalidPermissionPolicyException {
   export function isa(o: any): o is WAFInvalidPermissionPolicyException {
-    return _smithy.isa(o, "WAFInvalidPermissionPolicyException");
+    return __isa(o, "WAFInvalidPermissionPolicyException");
   }
 }
 
@@ -5993,7 +5996,7 @@ export namespace WAFInvalidPermissionPolicyException {
  * <p>The regular expression (regex) you specified in <code>RegexPatternString</code> is invalid.</p>
  */
 export interface WAFInvalidRegexPatternException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "WAFInvalidRegexPatternException";
   $fault: "client";
@@ -6002,7 +6005,7 @@ export interface WAFInvalidRegexPatternException
 
 export namespace WAFInvalidRegexPatternException {
   export function isa(o: any): o is WAFInvalidRegexPatternException {
-    return _smithy.isa(o, "WAFInvalidRegexPatternException");
+    return __isa(o, "WAFInvalidRegexPatternException");
   }
 }
 
@@ -6012,7 +6015,7 @@ export namespace WAFInvalidRegexPatternException {
  * 			<a href="https://docs.aws.amazon.com/waf/latest/developerguide/limits.html">Limits</a> in the <i>AWS WAF Developer Guide</i>.</p>
  */
 export interface WAFLimitsExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "WAFLimitsExceededException";
   $fault: "client";
@@ -6021,7 +6024,7 @@ export interface WAFLimitsExceededException
 
 export namespace WAFLimitsExceededException {
   export function isa(o: any): o is WAFLimitsExceededException {
-    return _smithy.isa(o, "WAFLimitsExceededException");
+    return __isa(o, "WAFLimitsExceededException");
   }
 }
 
@@ -6044,7 +6047,7 @@ export namespace WAFLimitsExceededException {
  *          </ul>
  */
 export interface WAFNonEmptyEntityException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "WAFNonEmptyEntityException";
   $fault: "client";
@@ -6053,7 +6056,7 @@ export interface WAFNonEmptyEntityException
 
 export namespace WAFNonEmptyEntityException {
   export function isa(o: any): o is WAFNonEmptyEntityException {
-    return _smithy.isa(o, "WAFNonEmptyEntityException");
+    return __isa(o, "WAFNonEmptyEntityException");
   }
 }
 
@@ -6076,7 +6079,7 @@ export namespace WAFNonEmptyEntityException {
  *          </ul>
  */
 export interface WAFNonexistentContainerException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "WAFNonexistentContainerException";
   $fault: "client";
@@ -6085,7 +6088,7 @@ export interface WAFNonexistentContainerException
 
 export namespace WAFNonexistentContainerException {
   export function isa(o: any): o is WAFNonexistentContainerException {
-    return _smithy.isa(o, "WAFNonexistentContainerException");
+    return __isa(o, "WAFNonexistentContainerException");
   }
 }
 
@@ -6093,7 +6096,7 @@ export namespace WAFNonexistentContainerException {
  * <p>The operation failed because the referenced object doesn't exist.</p>
  */
 export interface WAFNonexistentItemException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "WAFNonexistentItemException";
   $fault: "client";
@@ -6102,7 +6105,7 @@ export interface WAFNonexistentItemException
 
 export namespace WAFNonexistentItemException {
   export function isa(o: any): o is WAFNonexistentItemException {
-    return _smithy.isa(o, "WAFNonexistentItemException");
+    return __isa(o, "WAFNonexistentItemException");
   }
 }
 
@@ -6118,7 +6121,7 @@ export namespace WAFNonexistentItemException {
  *          </ul>
  */
 export interface WAFReferencedItemException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "WAFReferencedItemException";
   $fault: "client";
@@ -6127,7 +6130,7 @@ export interface WAFReferencedItemException
 
 export namespace WAFReferencedItemException {
   export function isa(o: any): o is WAFReferencedItemException {
-    return _smithy.isa(o, "WAFReferencedItemException");
+    return __isa(o, "WAFReferencedItemException");
   }
 }
 
@@ -6135,7 +6138,7 @@ export namespace WAFReferencedItemException {
  * <p>AWS WAF is not able to access the service linked role. This can be caused by a previous <code>PutLoggingConfiguration</code> request, which can lock the service linked role for about 20 seconds. Please try your request again. The service linked role can also be locked by a previous <code>DeleteServiceLinkedRole</code> request, which can lock the role for 15 minutes or more. If you recently made a <code>DeleteServiceLinkedRole</code>, wait at least 15 minutes and try the request again. If you receive this same exception again, you will have to wait additional time until the role is unlocked.</p>
  */
 export interface WAFServiceLinkedRoleErrorException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "WAFServiceLinkedRoleErrorException";
   $fault: "client";
@@ -6144,7 +6147,7 @@ export interface WAFServiceLinkedRoleErrorException
 
 export namespace WAFServiceLinkedRoleErrorException {
   export function isa(o: any): o is WAFServiceLinkedRoleErrorException {
-    return _smithy.isa(o, "WAFServiceLinkedRoleErrorException");
+    return __isa(o, "WAFServiceLinkedRoleErrorException");
   }
 }
 
@@ -6152,7 +6155,7 @@ export namespace WAFServiceLinkedRoleErrorException {
  * <p>The operation failed because you tried to create, update, or delete an object by using a change token that has already been used.</p>
  */
 export interface WAFStaleDataException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "WAFStaleDataException";
   $fault: "client";
@@ -6161,7 +6164,7 @@ export interface WAFStaleDataException
 
 export namespace WAFStaleDataException {
   export function isa(o: any): o is WAFStaleDataException {
-    return _smithy.isa(o, "WAFStaleDataException");
+    return __isa(o, "WAFStaleDataException");
   }
 }
 
@@ -6169,7 +6172,7 @@ export namespace WAFStaleDataException {
  * <p>The specified subscription does not exist.</p>
  */
 export interface WAFSubscriptionNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "WAFSubscriptionNotFoundException";
   $fault: "client";
@@ -6178,12 +6181,12 @@ export interface WAFSubscriptionNotFoundException
 
 export namespace WAFSubscriptionNotFoundException {
   export function isa(o: any): o is WAFSubscriptionNotFoundException {
-    return _smithy.isa(o, "WAFSubscriptionNotFoundException");
+    return __isa(o, "WAFSubscriptionNotFoundException");
   }
 }
 
 export interface WAFTagOperationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "WAFTagOperationException";
   $fault: "client";
@@ -6192,12 +6195,12 @@ export interface WAFTagOperationException
 
 export namespace WAFTagOperationException {
   export function isa(o: any): o is WAFTagOperationException {
-    return _smithy.isa(o, "WAFTagOperationException");
+    return __isa(o, "WAFTagOperationException");
   }
 }
 
 export interface WAFTagOperationInternalErrorException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "WAFTagOperationInternalErrorException";
   $fault: "server";
@@ -6206,7 +6209,7 @@ export interface WAFTagOperationInternalErrorException
 
 export namespace WAFTagOperationInternalErrorException {
   export function isa(o: any): o is WAFTagOperationInternalErrorException {
-    return _smithy.isa(o, "WAFTagOperationInternalErrorException");
+    return __isa(o, "WAFTagOperationInternalErrorException");
   }
 }
 
@@ -6215,7 +6218,7 @@ export namespace WAFTagOperationInternalErrorException {
  *       referenced is temporarily unavailable. Retry your request.</p>
  */
 export interface WAFUnavailableEntityException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "WAFUnavailableEntityException";
   $fault: "client";
@@ -6224,7 +6227,7 @@ export interface WAFUnavailableEntityException
 
 export namespace WAFUnavailableEntityException {
   export function isa(o: any): o is WAFUnavailableEntityException {
-    return _smithy.isa(o, "WAFUnavailableEntityException");
+    return __isa(o, "WAFUnavailableEntityException");
   }
 }
 
@@ -6259,7 +6262,7 @@ export interface WafAction {
 
 export namespace WafAction {
   export function isa(o: any): o is WafAction {
-    return _smithy.isa(o, "WafAction");
+    return __isa(o, "WafAction");
   }
 }
 
@@ -6283,7 +6286,7 @@ export interface WafOverrideAction {
 
 export namespace WafOverrideAction {
   export function isa(o: any): o is WafOverrideAction {
-    return _smithy.isa(o, "WafOverrideAction");
+    return __isa(o, "WafOverrideAction");
   }
 }
 
@@ -6348,7 +6351,7 @@ export interface WebACL {
 
 export namespace WebACL {
   export function isa(o: any): o is WebACL {
-    return _smithy.isa(o, "WebACL");
+    return __isa(o, "WebACL");
   }
 }
 
@@ -6374,7 +6377,7 @@ export interface WebACLSummary {
 
 export namespace WebACLSummary {
   export function isa(o: any): o is WebACLSummary {
-    return _smithy.isa(o, "WebACLSummary");
+    return __isa(o, "WebACLSummary");
   }
 }
 
@@ -6398,7 +6401,7 @@ export interface WebACLUpdate {
 
 export namespace WebACLUpdate {
   export function isa(o: any): o is WebACLUpdate {
-    return _smithy.isa(o, "WebACLUpdate");
+    return __isa(o, "WebACLUpdate");
   }
 }
 
@@ -6434,7 +6437,7 @@ export interface XssMatchSet {
 
 export namespace XssMatchSet {
   export function isa(o: any): o is XssMatchSet {
-    return _smithy.isa(o, "XssMatchSet");
+    return __isa(o, "XssMatchSet");
   }
 }
 
@@ -6462,7 +6465,7 @@ export interface XssMatchSetSummary {
 
 export namespace XssMatchSetSummary {
   export function isa(o: any): o is XssMatchSetSummary {
-    return _smithy.isa(o, "XssMatchSetSummary");
+    return __isa(o, "XssMatchSetSummary");
   }
 }
 
@@ -6488,7 +6491,7 @@ export interface XssMatchSetUpdate {
 
 export namespace XssMatchSetUpdate {
   export function isa(o: any): o is XssMatchSetUpdate {
-    return _smithy.isa(o, "XssMatchSetUpdate");
+    return __isa(o, "XssMatchSetUpdate");
   }
 }
 
@@ -6602,6 +6605,6 @@ export interface XssMatchTuple {
 
 export namespace XssMatchTuple {
   export function isa(o: any): o is XssMatchTuple {
-    return _smithy.isa(o, "XssMatchTuple");
+    return __isa(o, "XssMatchTuple");
   }
 }

--- a/clients/client-waf/models/index.ts
+++ b/clients/client-waf/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -115,7 +118,7 @@ export interface ActivatedRule {
 
 export namespace ActivatedRule {
   export function isa(o: any): o is ActivatedRule {
-    return _smithy.isa(o, "ActivatedRule");
+    return __isa(o, "ActivatedRule");
   }
 }
 
@@ -152,7 +155,7 @@ export interface ByteMatchSet {
 
 export namespace ByteMatchSet {
   export function isa(o: any): o is ByteMatchSet {
-    return _smithy.isa(o, "ByteMatchSet");
+    return __isa(o, "ByteMatchSet");
   }
 }
 
@@ -178,7 +181,7 @@ export interface ByteMatchSetSummary {
 
 export namespace ByteMatchSetSummary {
   export function isa(o: any): o is ByteMatchSetSummary {
-    return _smithy.isa(o, "ByteMatchSetSummary");
+    return __isa(o, "ByteMatchSetSummary");
   }
 }
 
@@ -203,7 +206,7 @@ export interface ByteMatchSetUpdate {
 
 export namespace ByteMatchSetUpdate {
   export function isa(o: any): o is ByteMatchSetUpdate {
-    return _smithy.isa(o, "ByteMatchSetUpdate");
+    return __isa(o, "ByteMatchSetUpdate");
   }
 }
 
@@ -434,7 +437,7 @@ export interface ByteMatchTuple {
 
 export namespace ByteMatchTuple {
   export function isa(o: any): o is ByteMatchTuple {
-    return _smithy.isa(o, "ByteMatchTuple");
+    return __isa(o, "ByteMatchTuple");
   }
 }
 
@@ -474,7 +477,7 @@ export interface CreateByteMatchSetRequest {
 
 export namespace CreateByteMatchSetRequest {
   export function isa(o: any): o is CreateByteMatchSetRequest {
-    return _smithy.isa(o, "CreateByteMatchSetRequest");
+    return __isa(o, "CreateByteMatchSetRequest");
   }
 }
 
@@ -494,7 +497,7 @@ export interface CreateByteMatchSetResponse extends $MetadataBearer {
 
 export namespace CreateByteMatchSetResponse {
   export function isa(o: any): o is CreateByteMatchSetResponse {
-    return _smithy.isa(o, "CreateByteMatchSetResponse");
+    return __isa(o, "CreateByteMatchSetResponse");
   }
 }
 
@@ -513,7 +516,7 @@ export interface CreateGeoMatchSetRequest {
 
 export namespace CreateGeoMatchSetRequest {
   export function isa(o: any): o is CreateGeoMatchSetRequest {
-    return _smithy.isa(o, "CreateGeoMatchSetRequest");
+    return __isa(o, "CreateGeoMatchSetRequest");
   }
 }
 
@@ -533,7 +536,7 @@ export interface CreateGeoMatchSetResponse extends $MetadataBearer {
 
 export namespace CreateGeoMatchSetResponse {
   export function isa(o: any): o is CreateGeoMatchSetResponse {
-    return _smithy.isa(o, "CreateGeoMatchSetResponse");
+    return __isa(o, "CreateGeoMatchSetResponse");
   }
 }
 
@@ -552,7 +555,7 @@ export interface CreateIPSetRequest {
 
 export namespace CreateIPSetRequest {
   export function isa(o: any): o is CreateIPSetRequest {
-    return _smithy.isa(o, "CreateIPSetRequest");
+    return __isa(o, "CreateIPSetRequest");
   }
 }
 
@@ -572,7 +575,7 @@ export interface CreateIPSetResponse extends $MetadataBearer {
 
 export namespace CreateIPSetResponse {
   export function isa(o: any): o is CreateIPSetResponse {
-    return _smithy.isa(o, "CreateIPSetResponse");
+    return __isa(o, "CreateIPSetResponse");
   }
 }
 
@@ -621,7 +624,7 @@ export interface CreateRateBasedRuleRequest {
 
 export namespace CreateRateBasedRuleRequest {
   export function isa(o: any): o is CreateRateBasedRuleRequest {
-    return _smithy.isa(o, "CreateRateBasedRuleRequest");
+    return __isa(o, "CreateRateBasedRuleRequest");
   }
 }
 
@@ -643,7 +646,7 @@ export interface CreateRateBasedRuleResponse extends $MetadataBearer {
 
 export namespace CreateRateBasedRuleResponse {
   export function isa(o: any): o is CreateRateBasedRuleResponse {
-    return _smithy.isa(o, "CreateRateBasedRuleResponse");
+    return __isa(o, "CreateRateBasedRuleResponse");
   }
 }
 
@@ -663,7 +666,7 @@ export interface CreateRegexMatchSetRequest {
 
 export namespace CreateRegexMatchSetRequest {
   export function isa(o: any): o is CreateRegexMatchSetRequest {
-    return _smithy.isa(o, "CreateRegexMatchSetRequest");
+    return __isa(o, "CreateRegexMatchSetRequest");
   }
 }
 
@@ -683,7 +686,7 @@ export interface CreateRegexMatchSetResponse extends $MetadataBearer {
 
 export namespace CreateRegexMatchSetResponse {
   export function isa(o: any): o is CreateRegexMatchSetResponse {
-    return _smithy.isa(o, "CreateRegexMatchSetResponse");
+    return __isa(o, "CreateRegexMatchSetResponse");
   }
 }
 
@@ -703,7 +706,7 @@ export interface CreateRegexPatternSetRequest {
 
 export namespace CreateRegexPatternSetRequest {
   export function isa(o: any): o is CreateRegexPatternSetRequest {
-    return _smithy.isa(o, "CreateRegexPatternSetRequest");
+    return __isa(o, "CreateRegexPatternSetRequest");
   }
 }
 
@@ -723,7 +726,7 @@ export interface CreateRegexPatternSetResponse extends $MetadataBearer {
 
 export namespace CreateRegexPatternSetResponse {
   export function isa(o: any): o is CreateRegexPatternSetResponse {
-    return _smithy.isa(o, "CreateRegexPatternSetResponse");
+    return __isa(o, "CreateRegexPatternSetResponse");
   }
 }
 
@@ -751,7 +754,7 @@ export interface CreateRuleGroupRequest {
 
 export namespace CreateRuleGroupRequest {
   export function isa(o: any): o is CreateRuleGroupRequest {
-    return _smithy.isa(o, "CreateRuleGroupRequest");
+    return __isa(o, "CreateRuleGroupRequest");
   }
 }
 
@@ -771,7 +774,7 @@ export interface CreateRuleGroupResponse extends $MetadataBearer {
 
 export namespace CreateRuleGroupResponse {
   export function isa(o: any): o is CreateRuleGroupResponse {
-    return _smithy.isa(o, "CreateRuleGroupResponse");
+    return __isa(o, "CreateRuleGroupResponse");
   }
 }
 
@@ -799,7 +802,7 @@ export interface CreateRuleRequest {
 
 export namespace CreateRuleRequest {
   export function isa(o: any): o is CreateRuleRequest {
-    return _smithy.isa(o, "CreateRuleRequest");
+    return __isa(o, "CreateRuleRequest");
   }
 }
 
@@ -819,7 +822,7 @@ export interface CreateRuleResponse extends $MetadataBearer {
 
 export namespace CreateRuleResponse {
   export function isa(o: any): o is CreateRuleResponse {
-    return _smithy.isa(o, "CreateRuleResponse");
+    return __isa(o, "CreateRuleResponse");
   }
 }
 
@@ -839,7 +842,7 @@ export interface CreateSizeConstraintSetRequest {
 
 export namespace CreateSizeConstraintSetRequest {
   export function isa(o: any): o is CreateSizeConstraintSetRequest {
-    return _smithy.isa(o, "CreateSizeConstraintSetRequest");
+    return __isa(o, "CreateSizeConstraintSetRequest");
   }
 }
 
@@ -859,7 +862,7 @@ export interface CreateSizeConstraintSetResponse extends $MetadataBearer {
 
 export namespace CreateSizeConstraintSetResponse {
   export function isa(o: any): o is CreateSizeConstraintSetResponse {
-    return _smithy.isa(o, "CreateSizeConstraintSetResponse");
+    return __isa(o, "CreateSizeConstraintSetResponse");
   }
 }
 
@@ -882,7 +885,7 @@ export interface CreateSqlInjectionMatchSetRequest {
 
 export namespace CreateSqlInjectionMatchSetRequest {
   export function isa(o: any): o is CreateSqlInjectionMatchSetRequest {
-    return _smithy.isa(o, "CreateSqlInjectionMatchSetRequest");
+    return __isa(o, "CreateSqlInjectionMatchSetRequest");
   }
 }
 
@@ -905,7 +908,7 @@ export interface CreateSqlInjectionMatchSetResponse extends $MetadataBearer {
 
 export namespace CreateSqlInjectionMatchSetResponse {
   export function isa(o: any): o is CreateSqlInjectionMatchSetResponse {
-    return _smithy.isa(o, "CreateSqlInjectionMatchSetResponse");
+    return __isa(o, "CreateSqlInjectionMatchSetResponse");
   }
 }
 
@@ -939,7 +942,7 @@ export interface CreateWebACLRequest {
 
 export namespace CreateWebACLRequest {
   export function isa(o: any): o is CreateWebACLRequest {
-    return _smithy.isa(o, "CreateWebACLRequest");
+    return __isa(o, "CreateWebACLRequest");
   }
 }
 
@@ -959,7 +962,7 @@ export interface CreateWebACLResponse extends $MetadataBearer {
 
 export namespace CreateWebACLResponse {
   export function isa(o: any): o is CreateWebACLResponse {
-    return _smithy.isa(o, "CreateWebACLResponse");
+    return __isa(o, "CreateWebACLResponse");
   }
 }
 
@@ -982,7 +985,7 @@ export interface CreateXssMatchSetRequest {
 
 export namespace CreateXssMatchSetRequest {
   export function isa(o: any): o is CreateXssMatchSetRequest {
-    return _smithy.isa(o, "CreateXssMatchSetRequest");
+    return __isa(o, "CreateXssMatchSetRequest");
   }
 }
 
@@ -1005,7 +1008,7 @@ export interface CreateXssMatchSetResponse extends $MetadataBearer {
 
 export namespace CreateXssMatchSetResponse {
   export function isa(o: any): o is CreateXssMatchSetResponse {
-    return _smithy.isa(o, "CreateXssMatchSetResponse");
+    return __isa(o, "CreateXssMatchSetResponse");
   }
 }
 
@@ -1025,7 +1028,7 @@ export interface DeleteByteMatchSetRequest {
 
 export namespace DeleteByteMatchSetRequest {
   export function isa(o: any): o is DeleteByteMatchSetRequest {
-    return _smithy.isa(o, "DeleteByteMatchSetRequest");
+    return __isa(o, "DeleteByteMatchSetRequest");
   }
 }
 
@@ -1040,7 +1043,7 @@ export interface DeleteByteMatchSetResponse extends $MetadataBearer {
 
 export namespace DeleteByteMatchSetResponse {
   export function isa(o: any): o is DeleteByteMatchSetResponse {
-    return _smithy.isa(o, "DeleteByteMatchSetResponse");
+    return __isa(o, "DeleteByteMatchSetResponse");
   }
 }
 
@@ -1060,7 +1063,7 @@ export interface DeleteGeoMatchSetRequest {
 
 export namespace DeleteGeoMatchSetRequest {
   export function isa(o: any): o is DeleteGeoMatchSetRequest {
-    return _smithy.isa(o, "DeleteGeoMatchSetRequest");
+    return __isa(o, "DeleteGeoMatchSetRequest");
   }
 }
 
@@ -1075,7 +1078,7 @@ export interface DeleteGeoMatchSetResponse extends $MetadataBearer {
 
 export namespace DeleteGeoMatchSetResponse {
   export function isa(o: any): o is DeleteGeoMatchSetResponse {
-    return _smithy.isa(o, "DeleteGeoMatchSetResponse");
+    return __isa(o, "DeleteGeoMatchSetResponse");
   }
 }
 
@@ -1095,7 +1098,7 @@ export interface DeleteIPSetRequest {
 
 export namespace DeleteIPSetRequest {
   export function isa(o: any): o is DeleteIPSetRequest {
-    return _smithy.isa(o, "DeleteIPSetRequest");
+    return __isa(o, "DeleteIPSetRequest");
   }
 }
 
@@ -1110,7 +1113,7 @@ export interface DeleteIPSetResponse extends $MetadataBearer {
 
 export namespace DeleteIPSetResponse {
   export function isa(o: any): o is DeleteIPSetResponse {
-    return _smithy.isa(o, "DeleteIPSetResponse");
+    return __isa(o, "DeleteIPSetResponse");
   }
 }
 
@@ -1124,7 +1127,7 @@ export interface DeleteLoggingConfigurationRequest {
 
 export namespace DeleteLoggingConfigurationRequest {
   export function isa(o: any): o is DeleteLoggingConfigurationRequest {
-    return _smithy.isa(o, "DeleteLoggingConfigurationRequest");
+    return __isa(o, "DeleteLoggingConfigurationRequest");
   }
 }
 
@@ -1134,7 +1137,7 @@ export interface DeleteLoggingConfigurationResponse extends $MetadataBearer {
 
 export namespace DeleteLoggingConfigurationResponse {
   export function isa(o: any): o is DeleteLoggingConfigurationResponse {
-    return _smithy.isa(o, "DeleteLoggingConfigurationResponse");
+    return __isa(o, "DeleteLoggingConfigurationResponse");
   }
 }
 
@@ -1149,7 +1152,7 @@ export interface DeletePermissionPolicyRequest {
 
 export namespace DeletePermissionPolicyRequest {
   export function isa(o: any): o is DeletePermissionPolicyRequest {
-    return _smithy.isa(o, "DeletePermissionPolicyRequest");
+    return __isa(o, "DeletePermissionPolicyRequest");
   }
 }
 
@@ -1159,7 +1162,7 @@ export interface DeletePermissionPolicyResponse extends $MetadataBearer {
 
 export namespace DeletePermissionPolicyResponse {
   export function isa(o: any): o is DeletePermissionPolicyResponse {
-    return _smithy.isa(o, "DeletePermissionPolicyResponse");
+    return __isa(o, "DeletePermissionPolicyResponse");
   }
 }
 
@@ -1180,7 +1183,7 @@ export interface DeleteRateBasedRuleRequest {
 
 export namespace DeleteRateBasedRuleRequest {
   export function isa(o: any): o is DeleteRateBasedRuleRequest {
-    return _smithy.isa(o, "DeleteRateBasedRuleRequest");
+    return __isa(o, "DeleteRateBasedRuleRequest");
   }
 }
 
@@ -1196,7 +1199,7 @@ export interface DeleteRateBasedRuleResponse extends $MetadataBearer {
 
 export namespace DeleteRateBasedRuleResponse {
   export function isa(o: any): o is DeleteRateBasedRuleResponse {
-    return _smithy.isa(o, "DeleteRateBasedRuleResponse");
+    return __isa(o, "DeleteRateBasedRuleResponse");
   }
 }
 
@@ -1216,7 +1219,7 @@ export interface DeleteRegexMatchSetRequest {
 
 export namespace DeleteRegexMatchSetRequest {
   export function isa(o: any): o is DeleteRegexMatchSetRequest {
-    return _smithy.isa(o, "DeleteRegexMatchSetRequest");
+    return __isa(o, "DeleteRegexMatchSetRequest");
   }
 }
 
@@ -1231,7 +1234,7 @@ export interface DeleteRegexMatchSetResponse extends $MetadataBearer {
 
 export namespace DeleteRegexMatchSetResponse {
   export function isa(o: any): o is DeleteRegexMatchSetResponse {
-    return _smithy.isa(o, "DeleteRegexMatchSetResponse");
+    return __isa(o, "DeleteRegexMatchSetResponse");
   }
 }
 
@@ -1251,7 +1254,7 @@ export interface DeleteRegexPatternSetRequest {
 
 export namespace DeleteRegexPatternSetRequest {
   export function isa(o: any): o is DeleteRegexPatternSetRequest {
-    return _smithy.isa(o, "DeleteRegexPatternSetRequest");
+    return __isa(o, "DeleteRegexPatternSetRequest");
   }
 }
 
@@ -1266,7 +1269,7 @@ export interface DeleteRegexPatternSetResponse extends $MetadataBearer {
 
 export namespace DeleteRegexPatternSetResponse {
   export function isa(o: any): o is DeleteRegexPatternSetResponse {
-    return _smithy.isa(o, "DeleteRegexPatternSetResponse");
+    return __isa(o, "DeleteRegexPatternSetResponse");
   }
 }
 
@@ -1286,7 +1289,7 @@ export interface DeleteRuleGroupRequest {
 
 export namespace DeleteRuleGroupRequest {
   export function isa(o: any): o is DeleteRuleGroupRequest {
-    return _smithy.isa(o, "DeleteRuleGroupRequest");
+    return __isa(o, "DeleteRuleGroupRequest");
   }
 }
 
@@ -1301,7 +1304,7 @@ export interface DeleteRuleGroupResponse extends $MetadataBearer {
 
 export namespace DeleteRuleGroupResponse {
   export function isa(o: any): o is DeleteRuleGroupResponse {
-    return _smithy.isa(o, "DeleteRuleGroupResponse");
+    return __isa(o, "DeleteRuleGroupResponse");
   }
 }
 
@@ -1321,7 +1324,7 @@ export interface DeleteRuleRequest {
 
 export namespace DeleteRuleRequest {
   export function isa(o: any): o is DeleteRuleRequest {
-    return _smithy.isa(o, "DeleteRuleRequest");
+    return __isa(o, "DeleteRuleRequest");
   }
 }
 
@@ -1336,7 +1339,7 @@ export interface DeleteRuleResponse extends $MetadataBearer {
 
 export namespace DeleteRuleResponse {
   export function isa(o: any): o is DeleteRuleResponse {
-    return _smithy.isa(o, "DeleteRuleResponse");
+    return __isa(o, "DeleteRuleResponse");
   }
 }
 
@@ -1356,7 +1359,7 @@ export interface DeleteSizeConstraintSetRequest {
 
 export namespace DeleteSizeConstraintSetRequest {
   export function isa(o: any): o is DeleteSizeConstraintSetRequest {
-    return _smithy.isa(o, "DeleteSizeConstraintSetRequest");
+    return __isa(o, "DeleteSizeConstraintSetRequest");
   }
 }
 
@@ -1371,7 +1374,7 @@ export interface DeleteSizeConstraintSetResponse extends $MetadataBearer {
 
 export namespace DeleteSizeConstraintSetResponse {
   export function isa(o: any): o is DeleteSizeConstraintSetResponse {
-    return _smithy.isa(o, "DeleteSizeConstraintSetResponse");
+    return __isa(o, "DeleteSizeConstraintSetResponse");
   }
 }
 
@@ -1394,7 +1397,7 @@ export interface DeleteSqlInjectionMatchSetRequest {
 
 export namespace DeleteSqlInjectionMatchSetRequest {
   export function isa(o: any): o is DeleteSqlInjectionMatchSetRequest {
-    return _smithy.isa(o, "DeleteSqlInjectionMatchSetRequest");
+    return __isa(o, "DeleteSqlInjectionMatchSetRequest");
   }
 }
 
@@ -1412,7 +1415,7 @@ export interface DeleteSqlInjectionMatchSetResponse extends $MetadataBearer {
 
 export namespace DeleteSqlInjectionMatchSetResponse {
   export function isa(o: any): o is DeleteSqlInjectionMatchSetResponse {
-    return _smithy.isa(o, "DeleteSqlInjectionMatchSetResponse");
+    return __isa(o, "DeleteSqlInjectionMatchSetResponse");
   }
 }
 
@@ -1432,7 +1435,7 @@ export interface DeleteWebACLRequest {
 
 export namespace DeleteWebACLRequest {
   export function isa(o: any): o is DeleteWebACLRequest {
-    return _smithy.isa(o, "DeleteWebACLRequest");
+    return __isa(o, "DeleteWebACLRequest");
   }
 }
 
@@ -1447,7 +1450,7 @@ export interface DeleteWebACLResponse extends $MetadataBearer {
 
 export namespace DeleteWebACLResponse {
   export function isa(o: any): o is DeleteWebACLResponse {
-    return _smithy.isa(o, "DeleteWebACLResponse");
+    return __isa(o, "DeleteWebACLResponse");
   }
 }
 
@@ -1470,7 +1473,7 @@ export interface DeleteXssMatchSetRequest {
 
 export namespace DeleteXssMatchSetRequest {
   export function isa(o: any): o is DeleteXssMatchSetRequest {
-    return _smithy.isa(o, "DeleteXssMatchSetRequest");
+    return __isa(o, "DeleteXssMatchSetRequest");
   }
 }
 
@@ -1488,7 +1491,7 @@ export interface DeleteXssMatchSetResponse extends $MetadataBearer {
 
 export namespace DeleteXssMatchSetResponse {
   export function isa(o: any): o is DeleteXssMatchSetResponse {
-    return _smithy.isa(o, "DeleteXssMatchSetResponse");
+    return __isa(o, "DeleteXssMatchSetResponse");
   }
 }
 
@@ -1507,7 +1510,7 @@ export interface ExcludedRule {
 
 export namespace ExcludedRule {
   export function isa(o: any): o is ExcludedRule {
-    return _smithy.isa(o, "ExcludedRule");
+    return __isa(o, "ExcludedRule");
   }
 }
 
@@ -1571,7 +1574,7 @@ export interface FieldToMatch {
 
 export namespace FieldToMatch {
   export function isa(o: any): o is FieldToMatch {
-    return _smithy.isa(o, "FieldToMatch");
+    return __isa(o, "FieldToMatch");
   }
 }
 
@@ -1593,7 +1596,7 @@ export interface GeoMatchConstraint {
 
 export namespace GeoMatchConstraint {
   export function isa(o: any): o is GeoMatchConstraint {
-    return _smithy.isa(o, "GeoMatchConstraint");
+    return __isa(o, "GeoMatchConstraint");
   }
 }
 
@@ -1879,7 +1882,7 @@ export interface GeoMatchSet {
 
 export namespace GeoMatchSet {
   export function isa(o: any): o is GeoMatchSet {
-    return _smithy.isa(o, "GeoMatchSet");
+    return __isa(o, "GeoMatchSet");
   }
 }
 
@@ -1901,7 +1904,7 @@ export interface GeoMatchSetSummary {
 
 export namespace GeoMatchSetSummary {
   export function isa(o: any): o is GeoMatchSetSummary {
-    return _smithy.isa(o, "GeoMatchSetSummary");
+    return __isa(o, "GeoMatchSetSummary");
   }
 }
 
@@ -1923,7 +1926,7 @@ export interface GeoMatchSetUpdate {
 
 export namespace GeoMatchSetUpdate {
   export function isa(o: any): o is GeoMatchSetUpdate {
-    return _smithy.isa(o, "GeoMatchSetUpdate");
+    return __isa(o, "GeoMatchSetUpdate");
   }
 }
 
@@ -1938,7 +1941,7 @@ export interface GetByteMatchSetRequest {
 
 export namespace GetByteMatchSetRequest {
   export function isa(o: any): o is GetByteMatchSetRequest {
-    return _smithy.isa(o, "GetByteMatchSetRequest");
+    return __isa(o, "GetByteMatchSetRequest");
   }
 }
 
@@ -1972,7 +1975,7 @@ export interface GetByteMatchSetResponse extends $MetadataBearer {
 
 export namespace GetByteMatchSetResponse {
   export function isa(o: any): o is GetByteMatchSetResponse {
-    return _smithy.isa(o, "GetByteMatchSetResponse");
+    return __isa(o, "GetByteMatchSetResponse");
   }
 }
 
@@ -1982,7 +1985,7 @@ export interface GetChangeTokenRequest {
 
 export namespace GetChangeTokenRequest {
   export function isa(o: any): o is GetChangeTokenRequest {
-    return _smithy.isa(o, "GetChangeTokenRequest");
+    return __isa(o, "GetChangeTokenRequest");
   }
 }
 
@@ -1997,7 +2000,7 @@ export interface GetChangeTokenResponse extends $MetadataBearer {
 
 export namespace GetChangeTokenResponse {
   export function isa(o: any): o is GetChangeTokenResponse {
-    return _smithy.isa(o, "GetChangeTokenResponse");
+    return __isa(o, "GetChangeTokenResponse");
   }
 }
 
@@ -2011,7 +2014,7 @@ export interface GetChangeTokenStatusRequest {
 
 export namespace GetChangeTokenStatusRequest {
   export function isa(o: any): o is GetChangeTokenStatusRequest {
-    return _smithy.isa(o, "GetChangeTokenStatusRequest");
+    return __isa(o, "GetChangeTokenStatusRequest");
   }
 }
 
@@ -2025,7 +2028,7 @@ export interface GetChangeTokenStatusResponse extends $MetadataBearer {
 
 export namespace GetChangeTokenStatusResponse {
   export function isa(o: any): o is GetChangeTokenStatusResponse {
-    return _smithy.isa(o, "GetChangeTokenStatusResponse");
+    return __isa(o, "GetChangeTokenStatusResponse");
   }
 }
 
@@ -2040,7 +2043,7 @@ export interface GetGeoMatchSetRequest {
 
 export namespace GetGeoMatchSetRequest {
   export function isa(o: any): o is GetGeoMatchSetRequest {
-    return _smithy.isa(o, "GetGeoMatchSetRequest");
+    return __isa(o, "GetGeoMatchSetRequest");
   }
 }
 
@@ -2054,7 +2057,7 @@ export interface GetGeoMatchSetResponse extends $MetadataBearer {
 
 export namespace GetGeoMatchSetResponse {
   export function isa(o: any): o is GetGeoMatchSetResponse {
-    return _smithy.isa(o, "GetGeoMatchSetResponse");
+    return __isa(o, "GetGeoMatchSetResponse");
   }
 }
 
@@ -2069,7 +2072,7 @@ export interface GetIPSetRequest {
 
 export namespace GetIPSetRequest {
   export function isa(o: any): o is GetIPSetRequest {
-    return _smithy.isa(o, "GetIPSetRequest");
+    return __isa(o, "GetIPSetRequest");
   }
 }
 
@@ -2097,7 +2100,7 @@ export interface GetIPSetResponse extends $MetadataBearer {
 
 export namespace GetIPSetResponse {
   export function isa(o: any): o is GetIPSetResponse {
-    return _smithy.isa(o, "GetIPSetResponse");
+    return __isa(o, "GetIPSetResponse");
   }
 }
 
@@ -2111,7 +2114,7 @@ export interface GetLoggingConfigurationRequest {
 
 export namespace GetLoggingConfigurationRequest {
   export function isa(o: any): o is GetLoggingConfigurationRequest {
-    return _smithy.isa(o, "GetLoggingConfigurationRequest");
+    return __isa(o, "GetLoggingConfigurationRequest");
   }
 }
 
@@ -2125,7 +2128,7 @@ export interface GetLoggingConfigurationResponse extends $MetadataBearer {
 
 export namespace GetLoggingConfigurationResponse {
   export function isa(o: any): o is GetLoggingConfigurationResponse {
-    return _smithy.isa(o, "GetLoggingConfigurationResponse");
+    return __isa(o, "GetLoggingConfigurationResponse");
   }
 }
 
@@ -2139,7 +2142,7 @@ export interface GetPermissionPolicyRequest {
 
 export namespace GetPermissionPolicyRequest {
   export function isa(o: any): o is GetPermissionPolicyRequest {
-    return _smithy.isa(o, "GetPermissionPolicyRequest");
+    return __isa(o, "GetPermissionPolicyRequest");
   }
 }
 
@@ -2153,7 +2156,7 @@ export interface GetPermissionPolicyResponse extends $MetadataBearer {
 
 export namespace GetPermissionPolicyResponse {
   export function isa(o: any): o is GetPermissionPolicyResponse {
-    return _smithy.isa(o, "GetPermissionPolicyResponse");
+    return __isa(o, "GetPermissionPolicyResponse");
   }
 }
 
@@ -2173,7 +2176,7 @@ export interface GetRateBasedRuleManagedKeysRequest {
 
 export namespace GetRateBasedRuleManagedKeysRequest {
   export function isa(o: any): o is GetRateBasedRuleManagedKeysRequest {
-    return _smithy.isa(o, "GetRateBasedRuleManagedKeysRequest");
+    return __isa(o, "GetRateBasedRuleManagedKeysRequest");
   }
 }
 
@@ -2192,7 +2195,7 @@ export interface GetRateBasedRuleManagedKeysResponse extends $MetadataBearer {
 
 export namespace GetRateBasedRuleManagedKeysResponse {
   export function isa(o: any): o is GetRateBasedRuleManagedKeysResponse {
-    return _smithy.isa(o, "GetRateBasedRuleManagedKeysResponse");
+    return __isa(o, "GetRateBasedRuleManagedKeysResponse");
   }
 }
 
@@ -2207,7 +2210,7 @@ export interface GetRateBasedRuleRequest {
 
 export namespace GetRateBasedRuleRequest {
   export function isa(o: any): o is GetRateBasedRuleRequest {
-    return _smithy.isa(o, "GetRateBasedRuleRequest");
+    return __isa(o, "GetRateBasedRuleRequest");
   }
 }
 
@@ -2222,7 +2225,7 @@ export interface GetRateBasedRuleResponse extends $MetadataBearer {
 
 export namespace GetRateBasedRuleResponse {
   export function isa(o: any): o is GetRateBasedRuleResponse {
-    return _smithy.isa(o, "GetRateBasedRuleResponse");
+    return __isa(o, "GetRateBasedRuleResponse");
   }
 }
 
@@ -2237,7 +2240,7 @@ export interface GetRegexMatchSetRequest {
 
 export namespace GetRegexMatchSetRequest {
   export function isa(o: any): o is GetRegexMatchSetRequest {
-    return _smithy.isa(o, "GetRegexMatchSetRequest");
+    return __isa(o, "GetRegexMatchSetRequest");
   }
 }
 
@@ -2251,7 +2254,7 @@ export interface GetRegexMatchSetResponse extends $MetadataBearer {
 
 export namespace GetRegexMatchSetResponse {
   export function isa(o: any): o is GetRegexMatchSetResponse {
-    return _smithy.isa(o, "GetRegexMatchSetResponse");
+    return __isa(o, "GetRegexMatchSetResponse");
   }
 }
 
@@ -2266,7 +2269,7 @@ export interface GetRegexPatternSetRequest {
 
 export namespace GetRegexPatternSetRequest {
   export function isa(o: any): o is GetRegexPatternSetRequest {
-    return _smithy.isa(o, "GetRegexPatternSetRequest");
+    return __isa(o, "GetRegexPatternSetRequest");
   }
 }
 
@@ -2280,7 +2283,7 @@ export interface GetRegexPatternSetResponse extends $MetadataBearer {
 
 export namespace GetRegexPatternSetResponse {
   export function isa(o: any): o is GetRegexPatternSetResponse {
-    return _smithy.isa(o, "GetRegexPatternSetResponse");
+    return __isa(o, "GetRegexPatternSetResponse");
   }
 }
 
@@ -2295,7 +2298,7 @@ export interface GetRuleGroupRequest {
 
 export namespace GetRuleGroupRequest {
   export function isa(o: any): o is GetRuleGroupRequest {
-    return _smithy.isa(o, "GetRuleGroupRequest");
+    return __isa(o, "GetRuleGroupRequest");
   }
 }
 
@@ -2309,7 +2312,7 @@ export interface GetRuleGroupResponse extends $MetadataBearer {
 
 export namespace GetRuleGroupResponse {
   export function isa(o: any): o is GetRuleGroupResponse {
-    return _smithy.isa(o, "GetRuleGroupResponse");
+    return __isa(o, "GetRuleGroupResponse");
   }
 }
 
@@ -2324,7 +2327,7 @@ export interface GetRuleRequest {
 
 export namespace GetRuleRequest {
   export function isa(o: any): o is GetRuleRequest {
-    return _smithy.isa(o, "GetRuleRequest");
+    return __isa(o, "GetRuleRequest");
   }
 }
 
@@ -2353,7 +2356,7 @@ export interface GetRuleResponse extends $MetadataBearer {
 
 export namespace GetRuleResponse {
   export function isa(o: any): o is GetRuleResponse {
-    return _smithy.isa(o, "GetRuleResponse");
+    return __isa(o, "GetRuleResponse");
   }
 }
 
@@ -2397,7 +2400,7 @@ export interface GetSampledRequestsRequest {
 
 export namespace GetSampledRequestsRequest {
   export function isa(o: any): o is GetSampledRequestsRequest {
-    return _smithy.isa(o, "GetSampledRequestsRequest");
+    return __isa(o, "GetSampledRequestsRequest");
   }
 }
 
@@ -2425,7 +2428,7 @@ export interface GetSampledRequestsResponse extends $MetadataBearer {
 
 export namespace GetSampledRequestsResponse {
   export function isa(o: any): o is GetSampledRequestsResponse {
-    return _smithy.isa(o, "GetSampledRequestsResponse");
+    return __isa(o, "GetSampledRequestsResponse");
   }
 }
 
@@ -2440,7 +2443,7 @@ export interface GetSizeConstraintSetRequest {
 
 export namespace GetSizeConstraintSetRequest {
   export function isa(o: any): o is GetSizeConstraintSetRequest {
-    return _smithy.isa(o, "GetSizeConstraintSetRequest");
+    return __isa(o, "GetSizeConstraintSetRequest");
   }
 }
 
@@ -2474,7 +2477,7 @@ export interface GetSizeConstraintSetResponse extends $MetadataBearer {
 
 export namespace GetSizeConstraintSetResponse {
   export function isa(o: any): o is GetSizeConstraintSetResponse {
-    return _smithy.isa(o, "GetSizeConstraintSetResponse");
+    return __isa(o, "GetSizeConstraintSetResponse");
   }
 }
 
@@ -2492,7 +2495,7 @@ export interface GetSqlInjectionMatchSetRequest {
 
 export namespace GetSqlInjectionMatchSetRequest {
   export function isa(o: any): o is GetSqlInjectionMatchSetRequest {
-    return _smithy.isa(o, "GetSqlInjectionMatchSetRequest");
+    return __isa(o, "GetSqlInjectionMatchSetRequest");
   }
 }
 
@@ -2528,7 +2531,7 @@ export interface GetSqlInjectionMatchSetResponse extends $MetadataBearer {
 
 export namespace GetSqlInjectionMatchSetResponse {
   export function isa(o: any): o is GetSqlInjectionMatchSetResponse {
-    return _smithy.isa(o, "GetSqlInjectionMatchSetResponse");
+    return __isa(o, "GetSqlInjectionMatchSetResponse");
   }
 }
 
@@ -2543,7 +2546,7 @@ export interface GetWebACLRequest {
 
 export namespace GetWebACLRequest {
   export function isa(o: any): o is GetWebACLRequest {
-    return _smithy.isa(o, "GetWebACLRequest");
+    return __isa(o, "GetWebACLRequest");
   }
 }
 
@@ -2582,7 +2585,7 @@ export interface GetWebACLResponse extends $MetadataBearer {
 
 export namespace GetWebACLResponse {
   export function isa(o: any): o is GetWebACLResponse {
-    return _smithy.isa(o, "GetWebACLResponse");
+    return __isa(o, "GetWebACLResponse");
   }
 }
 
@@ -2600,7 +2603,7 @@ export interface GetXssMatchSetRequest {
 
 export namespace GetXssMatchSetRequest {
   export function isa(o: any): o is GetXssMatchSetRequest {
-    return _smithy.isa(o, "GetXssMatchSetRequest");
+    return __isa(o, "GetXssMatchSetRequest");
   }
 }
 
@@ -2636,7 +2639,7 @@ export interface GetXssMatchSetResponse extends $MetadataBearer {
 
 export namespace GetXssMatchSetResponse {
   export function isa(o: any): o is GetXssMatchSetResponse {
-    return _smithy.isa(o, "GetXssMatchSetResponse");
+    return __isa(o, "GetXssMatchSetResponse");
   }
 }
 
@@ -2660,7 +2663,7 @@ export interface HTTPHeader {
 
 export namespace HTTPHeader {
   export function isa(o: any): o is HTTPHeader {
-    return _smithy.isa(o, "HTTPHeader");
+    return __isa(o, "HTTPHeader");
   }
 }
 
@@ -2717,7 +2720,7 @@ export interface HTTPRequest {
 
 export namespace HTTPRequest {
   export function isa(o: any): o is HTTPRequest {
-    return _smithy.isa(o, "HTTPRequest");
+    return __isa(o, "HTTPRequest");
   }
 }
 
@@ -2755,7 +2758,7 @@ export interface IPSet {
 
 export namespace IPSet {
   export function isa(o: any): o is IPSet {
-    return _smithy.isa(o, "IPSet");
+    return __isa(o, "IPSet");
   }
 }
 
@@ -2798,7 +2801,7 @@ export interface IPSetDescriptor {
 
 export namespace IPSetDescriptor {
   export function isa(o: any): o is IPSetDescriptor {
-    return _smithy.isa(o, "IPSetDescriptor");
+    return __isa(o, "IPSetDescriptor");
   }
 }
 
@@ -2826,7 +2829,7 @@ export interface IPSetSummary {
 
 export namespace IPSetSummary {
   export function isa(o: any): o is IPSetSummary {
-    return _smithy.isa(o, "IPSetSummary");
+    return __isa(o, "IPSetSummary");
   }
 }
 
@@ -2848,7 +2851,7 @@ export interface IPSetUpdate {
 
 export namespace IPSetUpdate {
   export function isa(o: any): o is IPSetUpdate {
-    return _smithy.isa(o, "IPSetUpdate");
+    return __isa(o, "IPSetUpdate");
   }
 }
 
@@ -2876,7 +2879,7 @@ export interface ListActivatedRulesInRuleGroupRequest {
 
 export namespace ListActivatedRulesInRuleGroupRequest {
   export function isa(o: any): o is ListActivatedRulesInRuleGroupRequest {
-    return _smithy.isa(o, "ListActivatedRulesInRuleGroupRequest");
+    return __isa(o, "ListActivatedRulesInRuleGroupRequest");
   }
 }
 
@@ -2895,7 +2898,7 @@ export interface ListActivatedRulesInRuleGroupResponse extends $MetadataBearer {
 
 export namespace ListActivatedRulesInRuleGroupResponse {
   export function isa(o: any): o is ListActivatedRulesInRuleGroupResponse {
-    return _smithy.isa(o, "ListActivatedRulesInRuleGroupResponse");
+    return __isa(o, "ListActivatedRulesInRuleGroupResponse");
   }
 }
 
@@ -2919,7 +2922,7 @@ export interface ListByteMatchSetsRequest {
 
 export namespace ListByteMatchSetsRequest {
   export function isa(o: any): o is ListByteMatchSetsRequest {
-    return _smithy.isa(o, "ListByteMatchSetsRequest");
+    return __isa(o, "ListByteMatchSetsRequest");
   }
 }
 
@@ -2941,7 +2944,7 @@ export interface ListByteMatchSetsResponse extends $MetadataBearer {
 
 export namespace ListByteMatchSetsResponse {
   export function isa(o: any): o is ListByteMatchSetsResponse {
-    return _smithy.isa(o, "ListByteMatchSetsResponse");
+    return __isa(o, "ListByteMatchSetsResponse");
   }
 }
 
@@ -2965,7 +2968,7 @@ export interface ListGeoMatchSetsRequest {
 
 export namespace ListGeoMatchSetsRequest {
   export function isa(o: any): o is ListGeoMatchSetsRequest {
-    return _smithy.isa(o, "ListGeoMatchSetsRequest");
+    return __isa(o, "ListGeoMatchSetsRequest");
   }
 }
 
@@ -2987,7 +2990,7 @@ export interface ListGeoMatchSetsResponse extends $MetadataBearer {
 
 export namespace ListGeoMatchSetsResponse {
   export function isa(o: any): o is ListGeoMatchSetsResponse {
-    return _smithy.isa(o, "ListGeoMatchSetsResponse");
+    return __isa(o, "ListGeoMatchSetsResponse");
   }
 }
 
@@ -3011,7 +3014,7 @@ export interface ListIPSetsRequest {
 
 export namespace ListIPSetsRequest {
   export function isa(o: any): o is ListIPSetsRequest {
-    return _smithy.isa(o, "ListIPSetsRequest");
+    return __isa(o, "ListIPSetsRequest");
   }
 }
 
@@ -3032,7 +3035,7 @@ export interface ListIPSetsResponse extends $MetadataBearer {
 
 export namespace ListIPSetsResponse {
   export function isa(o: any): o is ListIPSetsResponse {
-    return _smithy.isa(o, "ListIPSetsResponse");
+    return __isa(o, "ListIPSetsResponse");
   }
 }
 
@@ -3054,7 +3057,7 @@ export interface ListLoggingConfigurationsRequest {
 
 export namespace ListLoggingConfigurationsRequest {
   export function isa(o: any): o is ListLoggingConfigurationsRequest {
-    return _smithy.isa(o, "ListLoggingConfigurationsRequest");
+    return __isa(o, "ListLoggingConfigurationsRequest");
   }
 }
 
@@ -3073,7 +3076,7 @@ export interface ListLoggingConfigurationsResponse extends $MetadataBearer {
 
 export namespace ListLoggingConfigurationsResponse {
   export function isa(o: any): o is ListLoggingConfigurationsResponse {
-    return _smithy.isa(o, "ListLoggingConfigurationsResponse");
+    return __isa(o, "ListLoggingConfigurationsResponse");
   }
 }
 
@@ -3100,7 +3103,7 @@ export interface ListRateBasedRulesRequest {
 
 export namespace ListRateBasedRulesRequest {
   export function isa(o: any): o is ListRateBasedRulesRequest {
-    return _smithy.isa(o, "ListRateBasedRulesRequest");
+    return __isa(o, "ListRateBasedRulesRequest");
   }
 }
 
@@ -3123,7 +3126,7 @@ export interface ListRateBasedRulesResponse extends $MetadataBearer {
 
 export namespace ListRateBasedRulesResponse {
   export function isa(o: any): o is ListRateBasedRulesResponse {
-    return _smithy.isa(o, "ListRateBasedRulesResponse");
+    return __isa(o, "ListRateBasedRulesResponse");
   }
 }
 
@@ -3147,7 +3150,7 @@ export interface ListRegexMatchSetsRequest {
 
 export namespace ListRegexMatchSetsRequest {
   export function isa(o: any): o is ListRegexMatchSetsRequest {
-    return _smithy.isa(o, "ListRegexMatchSetsRequest");
+    return __isa(o, "ListRegexMatchSetsRequest");
   }
 }
 
@@ -3169,7 +3172,7 @@ export interface ListRegexMatchSetsResponse extends $MetadataBearer {
 
 export namespace ListRegexMatchSetsResponse {
   export function isa(o: any): o is ListRegexMatchSetsResponse {
-    return _smithy.isa(o, "ListRegexMatchSetsResponse");
+    return __isa(o, "ListRegexMatchSetsResponse");
   }
 }
 
@@ -3193,7 +3196,7 @@ export interface ListRegexPatternSetsRequest {
 
 export namespace ListRegexPatternSetsRequest {
   export function isa(o: any): o is ListRegexPatternSetsRequest {
-    return _smithy.isa(o, "ListRegexPatternSetsRequest");
+    return __isa(o, "ListRegexPatternSetsRequest");
   }
 }
 
@@ -3215,7 +3218,7 @@ export interface ListRegexPatternSetsResponse extends $MetadataBearer {
 
 export namespace ListRegexPatternSetsResponse {
   export function isa(o: any): o is ListRegexPatternSetsResponse {
-    return _smithy.isa(o, "ListRegexPatternSetsResponse");
+    return __isa(o, "ListRegexPatternSetsResponse");
   }
 }
 
@@ -3237,7 +3240,7 @@ export interface ListRuleGroupsRequest {
 
 export namespace ListRuleGroupsRequest {
   export function isa(o: any): o is ListRuleGroupsRequest {
-    return _smithy.isa(o, "ListRuleGroupsRequest");
+    return __isa(o, "ListRuleGroupsRequest");
   }
 }
 
@@ -3256,7 +3259,7 @@ export interface ListRuleGroupsResponse extends $MetadataBearer {
 
 export namespace ListRuleGroupsResponse {
   export function isa(o: any): o is ListRuleGroupsResponse {
-    return _smithy.isa(o, "ListRuleGroupsResponse");
+    return __isa(o, "ListRuleGroupsResponse");
   }
 }
 
@@ -3279,7 +3282,7 @@ export interface ListRulesRequest {
 
 export namespace ListRulesRequest {
   export function isa(o: any): o is ListRulesRequest {
-    return _smithy.isa(o, "ListRulesRequest");
+    return __isa(o, "ListRulesRequest");
   }
 }
 
@@ -3300,7 +3303,7 @@ export interface ListRulesResponse extends $MetadataBearer {
 
 export namespace ListRulesResponse {
   export function isa(o: any): o is ListRulesResponse {
-    return _smithy.isa(o, "ListRulesResponse");
+    return __isa(o, "ListRulesResponse");
   }
 }
 
@@ -3323,7 +3326,7 @@ export interface ListSizeConstraintSetsRequest {
 
 export namespace ListSizeConstraintSetsRequest {
   export function isa(o: any): o is ListSizeConstraintSetsRequest {
-    return _smithy.isa(o, "ListSizeConstraintSetsRequest");
+    return __isa(o, "ListSizeConstraintSetsRequest");
   }
 }
 
@@ -3345,7 +3348,7 @@ export interface ListSizeConstraintSetsResponse extends $MetadataBearer {
 
 export namespace ListSizeConstraintSetsResponse {
   export function isa(o: any): o is ListSizeConstraintSetsResponse {
-    return _smithy.isa(o, "ListSizeConstraintSetsResponse");
+    return __isa(o, "ListSizeConstraintSetsResponse");
   }
 }
 
@@ -3372,7 +3375,7 @@ export interface ListSqlInjectionMatchSetsRequest {
 
 export namespace ListSqlInjectionMatchSetsRequest {
   export function isa(o: any): o is ListSqlInjectionMatchSetsRequest {
-    return _smithy.isa(o, "ListSqlInjectionMatchSetsRequest");
+    return __isa(o, "ListSqlInjectionMatchSetsRequest");
   }
 }
 
@@ -3397,7 +3400,7 @@ export interface ListSqlInjectionMatchSetsResponse extends $MetadataBearer {
 
 export namespace ListSqlInjectionMatchSetsResponse {
   export function isa(o: any): o is ListSqlInjectionMatchSetsResponse {
-    return _smithy.isa(o, "ListSqlInjectionMatchSetsResponse");
+    return __isa(o, "ListSqlInjectionMatchSetsResponse");
   }
 }
 
@@ -3421,7 +3424,7 @@ export interface ListSubscribedRuleGroupsRequest {
 
 export namespace ListSubscribedRuleGroupsRequest {
   export function isa(o: any): o is ListSubscribedRuleGroupsRequest {
-    return _smithy.isa(o, "ListSubscribedRuleGroupsRequest");
+    return __isa(o, "ListSubscribedRuleGroupsRequest");
   }
 }
 
@@ -3443,7 +3446,7 @@ export interface ListSubscribedRuleGroupsResponse extends $MetadataBearer {
 
 export namespace ListSubscribedRuleGroupsResponse {
   export function isa(o: any): o is ListSubscribedRuleGroupsResponse {
-    return _smithy.isa(o, "ListSubscribedRuleGroupsResponse");
+    return __isa(o, "ListSubscribedRuleGroupsResponse");
   }
 }
 
@@ -3456,7 +3459,7 @@ export interface ListTagsForResourceRequest {
 
 export namespace ListTagsForResourceRequest {
   export function isa(o: any): o is ListTagsForResourceRequest {
-    return _smithy.isa(o, "ListTagsForResourceRequest");
+    return __isa(o, "ListTagsForResourceRequest");
   }
 }
 
@@ -3468,7 +3471,7 @@ export interface ListTagsForResourceResponse extends $MetadataBearer {
 
 export namespace ListTagsForResourceResponse {
   export function isa(o: any): o is ListTagsForResourceResponse {
-    return _smithy.isa(o, "ListTagsForResourceResponse");
+    return __isa(o, "ListTagsForResourceResponse");
   }
 }
 
@@ -3492,7 +3495,7 @@ export interface ListWebACLsRequest {
 
 export namespace ListWebACLsRequest {
   export function isa(o: any): o is ListWebACLsRequest {
-    return _smithy.isa(o, "ListWebACLsRequest");
+    return __isa(o, "ListWebACLsRequest");
   }
 }
 
@@ -3514,7 +3517,7 @@ export interface ListWebACLsResponse extends $MetadataBearer {
 
 export namespace ListWebACLsResponse {
   export function isa(o: any): o is ListWebACLsResponse {
-    return _smithy.isa(o, "ListWebACLsResponse");
+    return __isa(o, "ListWebACLsResponse");
   }
 }
 
@@ -3541,7 +3544,7 @@ export interface ListXssMatchSetsRequest {
 
 export namespace ListXssMatchSetsRequest {
   export function isa(o: any): o is ListXssMatchSetsRequest {
-    return _smithy.isa(o, "ListXssMatchSetsRequest");
+    return __isa(o, "ListXssMatchSetsRequest");
   }
 }
 
@@ -3566,7 +3569,7 @@ export interface ListXssMatchSetsResponse extends $MetadataBearer {
 
 export namespace ListXssMatchSetsResponse {
   export function isa(o: any): o is ListXssMatchSetsResponse {
-    return _smithy.isa(o, "ListXssMatchSetsResponse");
+    return __isa(o, "ListXssMatchSetsResponse");
   }
 }
 
@@ -3598,7 +3601,7 @@ export interface LoggingConfiguration {
 
 export namespace LoggingConfiguration {
   export function isa(o: any): o is LoggingConfiguration {
-    return _smithy.isa(o, "LoggingConfiguration");
+    return __isa(o, "LoggingConfiguration");
   }
 }
 
@@ -3681,7 +3684,7 @@ export interface Predicate {
 
 export namespace Predicate {
   export function isa(o: any): o is Predicate {
-    return _smithy.isa(o, "Predicate");
+    return __isa(o, "Predicate");
   }
 }
 
@@ -3712,7 +3715,7 @@ export interface PutLoggingConfigurationRequest {
 
 export namespace PutLoggingConfigurationRequest {
   export function isa(o: any): o is PutLoggingConfigurationRequest {
-    return _smithy.isa(o, "PutLoggingConfigurationRequest");
+    return __isa(o, "PutLoggingConfigurationRequest");
   }
 }
 
@@ -3726,7 +3729,7 @@ export interface PutLoggingConfigurationResponse extends $MetadataBearer {
 
 export namespace PutLoggingConfigurationResponse {
   export function isa(o: any): o is PutLoggingConfigurationResponse {
-    return _smithy.isa(o, "PutLoggingConfigurationResponse");
+    return __isa(o, "PutLoggingConfigurationResponse");
   }
 }
 
@@ -3745,7 +3748,7 @@ export interface PutPermissionPolicyRequest {
 
 export namespace PutPermissionPolicyRequest {
   export function isa(o: any): o is PutPermissionPolicyRequest {
-    return _smithy.isa(o, "PutPermissionPolicyRequest");
+    return __isa(o, "PutPermissionPolicyRequest");
   }
 }
 
@@ -3755,7 +3758,7 @@ export interface PutPermissionPolicyResponse extends $MetadataBearer {
 
 export namespace PutPermissionPolicyResponse {
   export function isa(o: any): o is PutPermissionPolicyResponse {
-    return _smithy.isa(o, "PutPermissionPolicyResponse");
+    return __isa(o, "PutPermissionPolicyResponse");
   }
 }
 
@@ -3828,7 +3831,7 @@ export interface RateBasedRule {
 
 export namespace RateBasedRule {
   export function isa(o: any): o is RateBasedRule {
-    return _smithy.isa(o, "RateBasedRule");
+    return __isa(o, "RateBasedRule");
   }
 }
 
@@ -3881,7 +3884,7 @@ export interface RegexMatchSet {
 
 export namespace RegexMatchSet {
   export function isa(o: any): o is RegexMatchSet {
-    return _smithy.isa(o, "RegexMatchSet");
+    return __isa(o, "RegexMatchSet");
   }
 }
 
@@ -3907,7 +3910,7 @@ export interface RegexMatchSetSummary {
 
 export namespace RegexMatchSetSummary {
   export function isa(o: any): o is RegexMatchSetSummary {
-    return _smithy.isa(o, "RegexMatchSetSummary");
+    return __isa(o, "RegexMatchSetSummary");
   }
 }
 
@@ -3932,7 +3935,7 @@ export interface RegexMatchSetUpdate {
 
 export namespace RegexMatchSetUpdate {
   export function isa(o: any): o is RegexMatchSetUpdate {
-    return _smithy.isa(o, "RegexMatchSetUpdate");
+    return __isa(o, "RegexMatchSetUpdate");
   }
 }
 
@@ -4066,7 +4069,7 @@ export interface RegexMatchTuple {
 
 export namespace RegexMatchTuple {
   export function isa(o: any): o is RegexMatchTuple {
-    return _smithy.isa(o, "RegexMatchTuple");
+    return __isa(o, "RegexMatchTuple");
   }
 }
 
@@ -4096,7 +4099,7 @@ export interface RegexPatternSet {
 
 export namespace RegexPatternSet {
   export function isa(o: any): o is RegexPatternSet {
-    return _smithy.isa(o, "RegexPatternSet");
+    return __isa(o, "RegexPatternSet");
   }
 }
 
@@ -4122,7 +4125,7 @@ export interface RegexPatternSetSummary {
 
 export namespace RegexPatternSetSummary {
   export function isa(o: any): o is RegexPatternSetSummary {
-    return _smithy.isa(o, "RegexPatternSetSummary");
+    return __isa(o, "RegexPatternSetSummary");
   }
 }
 
@@ -4145,7 +4148,7 @@ export interface RegexPatternSetUpdate {
 
 export namespace RegexPatternSetUpdate {
   export function isa(o: any): o is RegexPatternSetUpdate {
-    return _smithy.isa(o, "RegexPatternSetUpdate");
+    return __isa(o, "RegexPatternSetUpdate");
   }
 }
 
@@ -4196,7 +4199,7 @@ export interface Rule {
 
 export namespace Rule {
   export function isa(o: any): o is Rule {
-    return _smithy.isa(o, "Rule");
+    return __isa(o, "Rule");
   }
 }
 
@@ -4240,7 +4243,7 @@ export interface RuleGroup {
 
 export namespace RuleGroup {
   export function isa(o: any): o is RuleGroup {
-    return _smithy.isa(o, "RuleGroup");
+    return __isa(o, "RuleGroup");
   }
 }
 
@@ -4266,7 +4269,7 @@ export interface RuleGroupSummary {
 
 export namespace RuleGroupSummary {
   export function isa(o: any): o is RuleGroupSummary {
-    return _smithy.isa(o, "RuleGroupSummary");
+    return __isa(o, "RuleGroupSummary");
   }
 }
 
@@ -4292,7 +4295,7 @@ export interface RuleGroupUpdate {
 
 export namespace RuleGroupUpdate {
   export function isa(o: any): o is RuleGroupUpdate {
-    return _smithy.isa(o, "RuleGroupUpdate");
+    return __isa(o, "RuleGroupUpdate");
   }
 }
 
@@ -4318,7 +4321,7 @@ export interface RuleSummary {
 
 export namespace RuleSummary {
   export function isa(o: any): o is RuleSummary {
-    return _smithy.isa(o, "RuleSummary");
+    return __isa(o, "RuleSummary");
   }
 }
 
@@ -4342,7 +4345,7 @@ export interface RuleUpdate {
 
 export namespace RuleUpdate {
   export function isa(o: any): o is RuleUpdate {
-    return _smithy.isa(o, "RuleUpdate");
+    return __isa(o, "RuleUpdate");
   }
 }
 
@@ -4383,7 +4386,7 @@ export interface SampledHTTPRequest {
 
 export namespace SampledHTTPRequest {
   export function isa(o: any): o is SampledHTTPRequest {
-    return _smithy.isa(o, "SampledHTTPRequest");
+    return __isa(o, "SampledHTTPRequest");
   }
 }
 
@@ -4537,7 +4540,7 @@ export interface SizeConstraint {
 
 export namespace SizeConstraint {
   export function isa(o: any): o is SizeConstraint {
-    return _smithy.isa(o, "SizeConstraint");
+    return __isa(o, "SizeConstraint");
   }
 }
 
@@ -4572,7 +4575,7 @@ export interface SizeConstraintSet {
 
 export namespace SizeConstraintSet {
   export function isa(o: any): o is SizeConstraintSet {
-    return _smithy.isa(o, "SizeConstraintSet");
+    return __isa(o, "SizeConstraintSet");
   }
 }
 
@@ -4600,7 +4603,7 @@ export interface SizeConstraintSetSummary {
 
 export namespace SizeConstraintSetSummary {
   export function isa(o: any): o is SizeConstraintSetSummary {
-    return _smithy.isa(o, "SizeConstraintSetSummary");
+    return __isa(o, "SizeConstraintSetSummary");
   }
 }
 
@@ -4627,7 +4630,7 @@ export interface SizeConstraintSetUpdate {
 
 export namespace SizeConstraintSetUpdate {
   export function isa(o: any): o is SizeConstraintSetUpdate {
-    return _smithy.isa(o, "SizeConstraintSetUpdate");
+    return __isa(o, "SizeConstraintSetUpdate");
   }
 }
 
@@ -4663,7 +4666,7 @@ export interface SqlInjectionMatchSet {
 
 export namespace SqlInjectionMatchSet {
   export function isa(o: any): o is SqlInjectionMatchSet {
-    return _smithy.isa(o, "SqlInjectionMatchSet");
+    return __isa(o, "SqlInjectionMatchSet");
   }
 }
 
@@ -4691,7 +4694,7 @@ export interface SqlInjectionMatchSetSummary {
 
 export namespace SqlInjectionMatchSetSummary {
   export function isa(o: any): o is SqlInjectionMatchSetSummary {
-    return _smithy.isa(o, "SqlInjectionMatchSetSummary");
+    return __isa(o, "SqlInjectionMatchSetSummary");
   }
 }
 
@@ -4715,7 +4718,7 @@ export interface SqlInjectionMatchSetUpdate {
 
 export namespace SqlInjectionMatchSetUpdate {
   export function isa(o: any): o is SqlInjectionMatchSetUpdate {
-    return _smithy.isa(o, "SqlInjectionMatchSetUpdate");
+    return __isa(o, "SqlInjectionMatchSetUpdate");
   }
 }
 
@@ -4829,7 +4832,7 @@ export interface SqlInjectionMatchTuple {
 
 export namespace SqlInjectionMatchTuple {
   export function isa(o: any): o is SqlInjectionMatchTuple {
-    return _smithy.isa(o, "SqlInjectionMatchTuple");
+    return __isa(o, "SqlInjectionMatchTuple");
   }
 }
 
@@ -4857,7 +4860,7 @@ export interface SubscribedRuleGroupSummary {
 
 export namespace SubscribedRuleGroupSummary {
   export function isa(o: any): o is SubscribedRuleGroupSummary {
-    return _smithy.isa(o, "SubscribedRuleGroupSummary");
+    return __isa(o, "SubscribedRuleGroupSummary");
   }
 }
 
@@ -4869,7 +4872,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -4881,7 +4884,7 @@ export interface TagInfoForResource {
 
 export namespace TagInfoForResource {
   export function isa(o: any): o is TagInfoForResource {
-    return _smithy.isa(o, "TagInfoForResource");
+    return __isa(o, "TagInfoForResource");
   }
 }
 
@@ -4893,7 +4896,7 @@ export interface TagResourceRequest {
 
 export namespace TagResourceRequest {
   export function isa(o: any): o is TagResourceRequest {
-    return _smithy.isa(o, "TagResourceRequest");
+    return __isa(o, "TagResourceRequest");
   }
 }
 
@@ -4903,7 +4906,7 @@ export interface TagResourceResponse extends $MetadataBearer {
 
 export namespace TagResourceResponse {
   export function isa(o: any): o is TagResourceResponse {
-    return _smithy.isa(o, "TagResourceResponse");
+    return __isa(o, "TagResourceResponse");
   }
 }
 
@@ -4942,7 +4945,7 @@ export interface TimeWindow {
 
 export namespace TimeWindow {
   export function isa(o: any): o is TimeWindow {
-    return _smithy.isa(o, "TimeWindow");
+    return __isa(o, "TimeWindow");
   }
 }
 
@@ -4954,7 +4957,7 @@ export interface UntagResourceRequest {
 
 export namespace UntagResourceRequest {
   export function isa(o: any): o is UntagResourceRequest {
-    return _smithy.isa(o, "UntagResourceRequest");
+    return __isa(o, "UntagResourceRequest");
   }
 }
 
@@ -4964,7 +4967,7 @@ export interface UntagResourceResponse extends $MetadataBearer {
 
 export namespace UntagResourceResponse {
   export function isa(o: any): o is UntagResourceResponse {
-    return _smithy.isa(o, "UntagResourceResponse");
+    return __isa(o, "UntagResourceResponse");
   }
 }
 
@@ -5008,7 +5011,7 @@ export interface UpdateByteMatchSetRequest {
 
 export namespace UpdateByteMatchSetRequest {
   export function isa(o: any): o is UpdateByteMatchSetRequest {
-    return _smithy.isa(o, "UpdateByteMatchSetRequest");
+    return __isa(o, "UpdateByteMatchSetRequest");
   }
 }
 
@@ -5023,7 +5026,7 @@ export interface UpdateByteMatchSetResponse extends $MetadataBearer {
 
 export namespace UpdateByteMatchSetResponse {
   export function isa(o: any): o is UpdateByteMatchSetResponse {
-    return _smithy.isa(o, "UpdateByteMatchSetResponse");
+    return __isa(o, "UpdateByteMatchSetResponse");
   }
 }
 
@@ -5062,7 +5065,7 @@ export interface UpdateGeoMatchSetRequest {
 
 export namespace UpdateGeoMatchSetRequest {
   export function isa(o: any): o is UpdateGeoMatchSetRequest {
-    return _smithy.isa(o, "UpdateGeoMatchSetRequest");
+    return __isa(o, "UpdateGeoMatchSetRequest");
   }
 }
 
@@ -5077,7 +5080,7 @@ export interface UpdateGeoMatchSetResponse extends $MetadataBearer {
 
 export namespace UpdateGeoMatchSetResponse {
   export function isa(o: any): o is UpdateGeoMatchSetResponse {
-    return _smithy.isa(o, "UpdateGeoMatchSetResponse");
+    return __isa(o, "UpdateGeoMatchSetResponse");
   }
 }
 
@@ -5116,7 +5119,7 @@ export interface UpdateIPSetRequest {
 
 export namespace UpdateIPSetRequest {
   export function isa(o: any): o is UpdateIPSetRequest {
-    return _smithy.isa(o, "UpdateIPSetRequest");
+    return __isa(o, "UpdateIPSetRequest");
   }
 }
 
@@ -5131,7 +5134,7 @@ export interface UpdateIPSetResponse extends $MetadataBearer {
 
 export namespace UpdateIPSetResponse {
   export function isa(o: any): o is UpdateIPSetResponse {
-    return _smithy.isa(o, "UpdateIPSetResponse");
+    return __isa(o, "UpdateIPSetResponse");
   }
 }
 
@@ -5165,7 +5168,7 @@ export interface UpdateRateBasedRuleRequest {
 
 export namespace UpdateRateBasedRuleRequest {
   export function isa(o: any): o is UpdateRateBasedRuleRequest {
-    return _smithy.isa(o, "UpdateRateBasedRuleRequest");
+    return __isa(o, "UpdateRateBasedRuleRequest");
   }
 }
 
@@ -5181,7 +5184,7 @@ export interface UpdateRateBasedRuleResponse extends $MetadataBearer {
 
 export namespace UpdateRateBasedRuleResponse {
   export function isa(o: any): o is UpdateRateBasedRuleResponse {
-    return _smithy.isa(o, "UpdateRateBasedRuleResponse");
+    return __isa(o, "UpdateRateBasedRuleResponse");
   }
 }
 
@@ -5207,7 +5210,7 @@ export interface UpdateRegexMatchSetRequest {
 
 export namespace UpdateRegexMatchSetRequest {
   export function isa(o: any): o is UpdateRegexMatchSetRequest {
-    return _smithy.isa(o, "UpdateRegexMatchSetRequest");
+    return __isa(o, "UpdateRegexMatchSetRequest");
   }
 }
 
@@ -5222,7 +5225,7 @@ export interface UpdateRegexMatchSetResponse extends $MetadataBearer {
 
 export namespace UpdateRegexMatchSetResponse {
   export function isa(o: any): o is UpdateRegexMatchSetResponse {
-    return _smithy.isa(o, "UpdateRegexMatchSetResponse");
+    return __isa(o, "UpdateRegexMatchSetResponse");
   }
 }
 
@@ -5247,7 +5250,7 @@ export interface UpdateRegexPatternSetRequest {
 
 export namespace UpdateRegexPatternSetRequest {
   export function isa(o: any): o is UpdateRegexPatternSetRequest {
-    return _smithy.isa(o, "UpdateRegexPatternSetRequest");
+    return __isa(o, "UpdateRegexPatternSetRequest");
   }
 }
 
@@ -5262,7 +5265,7 @@ export interface UpdateRegexPatternSetResponse extends $MetadataBearer {
 
 export namespace UpdateRegexPatternSetResponse {
   export function isa(o: any): o is UpdateRegexPatternSetResponse {
-    return _smithy.isa(o, "UpdateRegexPatternSetResponse");
+    return __isa(o, "UpdateRegexPatternSetResponse");
   }
 }
 
@@ -5291,7 +5294,7 @@ export interface UpdateRuleGroupRequest {
 
 export namespace UpdateRuleGroupRequest {
   export function isa(o: any): o is UpdateRuleGroupRequest {
-    return _smithy.isa(o, "UpdateRuleGroupRequest");
+    return __isa(o, "UpdateRuleGroupRequest");
   }
 }
 
@@ -5306,7 +5309,7 @@ export interface UpdateRuleGroupResponse extends $MetadataBearer {
 
 export namespace UpdateRuleGroupResponse {
   export function isa(o: any): o is UpdateRuleGroupResponse {
-    return _smithy.isa(o, "UpdateRuleGroupResponse");
+    return __isa(o, "UpdateRuleGroupResponse");
   }
 }
 
@@ -5349,7 +5352,7 @@ export interface UpdateRuleRequest {
 
 export namespace UpdateRuleRequest {
   export function isa(o: any): o is UpdateRuleRequest {
-    return _smithy.isa(o, "UpdateRuleRequest");
+    return __isa(o, "UpdateRuleRequest");
   }
 }
 
@@ -5364,7 +5367,7 @@ export interface UpdateRuleResponse extends $MetadataBearer {
 
 export namespace UpdateRuleResponse {
   export function isa(o: any): o is UpdateRuleResponse {
-    return _smithy.isa(o, "UpdateRuleResponse");
+    return __isa(o, "UpdateRuleResponse");
   }
 }
 
@@ -5408,7 +5411,7 @@ export interface UpdateSizeConstraintSetRequest {
 
 export namespace UpdateSizeConstraintSetRequest {
   export function isa(o: any): o is UpdateSizeConstraintSetRequest {
-    return _smithy.isa(o, "UpdateSizeConstraintSetRequest");
+    return __isa(o, "UpdateSizeConstraintSetRequest");
   }
 }
 
@@ -5423,7 +5426,7 @@ export interface UpdateSizeConstraintSetResponse extends $MetadataBearer {
 
 export namespace UpdateSizeConstraintSetResponse {
   export function isa(o: any): o is UpdateSizeConstraintSetResponse {
-    return _smithy.isa(o, "UpdateSizeConstraintSetResponse");
+    return __isa(o, "UpdateSizeConstraintSetResponse");
   }
 }
 
@@ -5469,7 +5472,7 @@ export interface UpdateSqlInjectionMatchSetRequest {
 
 export namespace UpdateSqlInjectionMatchSetRequest {
   export function isa(o: any): o is UpdateSqlInjectionMatchSetRequest {
-    return _smithy.isa(o, "UpdateSqlInjectionMatchSetRequest");
+    return __isa(o, "UpdateSqlInjectionMatchSetRequest");
   }
 }
 
@@ -5487,7 +5490,7 @@ export interface UpdateSqlInjectionMatchSetResponse extends $MetadataBearer {
 
 export namespace UpdateSqlInjectionMatchSetResponse {
   export function isa(o: any): o is UpdateSqlInjectionMatchSetResponse {
-    return _smithy.isa(o, "UpdateSqlInjectionMatchSetResponse");
+    return __isa(o, "UpdateSqlInjectionMatchSetResponse");
   }
 }
 
@@ -5543,7 +5546,7 @@ export interface UpdateWebACLRequest {
 
 export namespace UpdateWebACLRequest {
   export function isa(o: any): o is UpdateWebACLRequest {
-    return _smithy.isa(o, "UpdateWebACLRequest");
+    return __isa(o, "UpdateWebACLRequest");
   }
 }
 
@@ -5558,7 +5561,7 @@ export interface UpdateWebACLResponse extends $MetadataBearer {
 
 export namespace UpdateWebACLResponse {
   export function isa(o: any): o is UpdateWebACLResponse {
-    return _smithy.isa(o, "UpdateWebACLResponse");
+    return __isa(o, "UpdateWebACLResponse");
   }
 }
 
@@ -5606,7 +5609,7 @@ export interface UpdateXssMatchSetRequest {
 
 export namespace UpdateXssMatchSetRequest {
   export function isa(o: any): o is UpdateXssMatchSetRequest {
-    return _smithy.isa(o, "UpdateXssMatchSetRequest");
+    return __isa(o, "UpdateXssMatchSetRequest");
   }
 }
 
@@ -5624,12 +5627,12 @@ export interface UpdateXssMatchSetResponse extends $MetadataBearer {
 
 export namespace UpdateXssMatchSetResponse {
   export function isa(o: any): o is UpdateXssMatchSetResponse {
-    return _smithy.isa(o, "UpdateXssMatchSetResponse");
+    return __isa(o, "UpdateXssMatchSetResponse");
   }
 }
 
 export interface WAFBadRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "WAFBadRequestException";
   $fault: "client";
@@ -5638,7 +5641,7 @@ export interface WAFBadRequestException
 
 export namespace WAFBadRequestException {
   export function isa(o: any): o is WAFBadRequestException {
-    return _smithy.isa(o, "WAFBadRequestException");
+    return __isa(o, "WAFBadRequestException");
   }
 }
 
@@ -5646,7 +5649,7 @@ export namespace WAFBadRequestException {
  * <p>The name specified is invalid.</p>
  */
 export interface WAFDisallowedNameException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "WAFDisallowedNameException";
   $fault: "client";
@@ -5655,7 +5658,7 @@ export interface WAFDisallowedNameException
 
 export namespace WAFDisallowedNameException {
   export function isa(o: any): o is WAFDisallowedNameException {
-    return _smithy.isa(o, "WAFDisallowedNameException");
+    return __isa(o, "WAFDisallowedNameException");
   }
 }
 
@@ -5663,7 +5666,7 @@ export namespace WAFDisallowedNameException {
  * <p>The operation failed because of a system problem, even though the request was valid. Retry your request.</p>
  */
 export interface WAFInternalErrorException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "WAFInternalErrorException";
   $fault: "server";
@@ -5672,7 +5675,7 @@ export interface WAFInternalErrorException
 
 export namespace WAFInternalErrorException {
   export function isa(o: any): o is WAFInternalErrorException {
-    return _smithy.isa(o, "WAFInternalErrorException");
+    return __isa(o, "WAFInternalErrorException");
   }
 }
 
@@ -5680,7 +5683,7 @@ export namespace WAFInternalErrorException {
  * <p>The operation failed because you tried to create, update, or delete an object by using an invalid account identifier.</p>
  */
 export interface WAFInvalidAccountException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "WAFInvalidAccountException";
   $fault: "client";
@@ -5688,7 +5691,7 @@ export interface WAFInvalidAccountException
 
 export namespace WAFInvalidAccountException {
   export function isa(o: any): o is WAFInvalidAccountException {
-    return _smithy.isa(o, "WAFInvalidAccountException");
+    return __isa(o, "WAFInvalidAccountException");
   }
 }
 
@@ -5716,7 +5719,7 @@ export namespace WAFInvalidAccountException {
  *          </ul>
  */
 export interface WAFInvalidOperationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "WAFInvalidOperationException";
   $fault: "client";
@@ -5725,7 +5728,7 @@ export interface WAFInvalidOperationException
 
 export namespace WAFInvalidOperationException {
   export function isa(o: any): o is WAFInvalidOperationException {
-    return _smithy.isa(o, "WAFInvalidOperationException");
+    return __isa(o, "WAFInvalidOperationException");
   }
 }
 
@@ -5770,7 +5773,7 @@ export namespace WAFInvalidOperationException {
  *          </ul>
  */
 export interface WAFInvalidParameterException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "WAFInvalidParameterException";
   $fault: "client";
@@ -5781,7 +5784,7 @@ export interface WAFInvalidParameterException
 
 export namespace WAFInvalidParameterException {
   export function isa(o: any): o is WAFInvalidParameterException {
-    return _smithy.isa(o, "WAFInvalidParameterException");
+    return __isa(o, "WAFInvalidParameterException");
   }
 }
 
@@ -5818,7 +5821,7 @@ export namespace WAFInvalidParameterException {
  *          </ul>
  */
 export interface WAFInvalidPermissionPolicyException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "WAFInvalidPermissionPolicyException";
   $fault: "client";
@@ -5827,7 +5830,7 @@ export interface WAFInvalidPermissionPolicyException
 
 export namespace WAFInvalidPermissionPolicyException {
   export function isa(o: any): o is WAFInvalidPermissionPolicyException {
-    return _smithy.isa(o, "WAFInvalidPermissionPolicyException");
+    return __isa(o, "WAFInvalidPermissionPolicyException");
   }
 }
 
@@ -5835,7 +5838,7 @@ export namespace WAFInvalidPermissionPolicyException {
  * <p>The regular expression (regex) you specified in <code>RegexPatternString</code> is invalid.</p>
  */
 export interface WAFInvalidRegexPatternException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "WAFInvalidRegexPatternException";
   $fault: "client";
@@ -5844,7 +5847,7 @@ export interface WAFInvalidRegexPatternException
 
 export namespace WAFInvalidRegexPatternException {
   export function isa(o: any): o is WAFInvalidRegexPatternException {
-    return _smithy.isa(o, "WAFInvalidRegexPatternException");
+    return __isa(o, "WAFInvalidRegexPatternException");
   }
 }
 
@@ -5854,7 +5857,7 @@ export namespace WAFInvalidRegexPatternException {
  * 			<a href="https://docs.aws.amazon.com/waf/latest/developerguide/limits.html">Limits</a> in the <i>AWS WAF Developer Guide</i>.</p>
  */
 export interface WAFLimitsExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "WAFLimitsExceededException";
   $fault: "client";
@@ -5863,7 +5866,7 @@ export interface WAFLimitsExceededException
 
 export namespace WAFLimitsExceededException {
   export function isa(o: any): o is WAFLimitsExceededException {
-    return _smithy.isa(o, "WAFLimitsExceededException");
+    return __isa(o, "WAFLimitsExceededException");
   }
 }
 
@@ -5886,7 +5889,7 @@ export namespace WAFLimitsExceededException {
  *          </ul>
  */
 export interface WAFNonEmptyEntityException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "WAFNonEmptyEntityException";
   $fault: "client";
@@ -5895,7 +5898,7 @@ export interface WAFNonEmptyEntityException
 
 export namespace WAFNonEmptyEntityException {
   export function isa(o: any): o is WAFNonEmptyEntityException {
-    return _smithy.isa(o, "WAFNonEmptyEntityException");
+    return __isa(o, "WAFNonEmptyEntityException");
   }
 }
 
@@ -5918,7 +5921,7 @@ export namespace WAFNonEmptyEntityException {
  *          </ul>
  */
 export interface WAFNonexistentContainerException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "WAFNonexistentContainerException";
   $fault: "client";
@@ -5927,7 +5930,7 @@ export interface WAFNonexistentContainerException
 
 export namespace WAFNonexistentContainerException {
   export function isa(o: any): o is WAFNonexistentContainerException {
-    return _smithy.isa(o, "WAFNonexistentContainerException");
+    return __isa(o, "WAFNonexistentContainerException");
   }
 }
 
@@ -5935,7 +5938,7 @@ export namespace WAFNonexistentContainerException {
  * <p>The operation failed because the referenced object doesn't exist.</p>
  */
 export interface WAFNonexistentItemException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "WAFNonexistentItemException";
   $fault: "client";
@@ -5944,7 +5947,7 @@ export interface WAFNonexistentItemException
 
 export namespace WAFNonexistentItemException {
   export function isa(o: any): o is WAFNonexistentItemException {
-    return _smithy.isa(o, "WAFNonexistentItemException");
+    return __isa(o, "WAFNonexistentItemException");
   }
 }
 
@@ -5960,7 +5963,7 @@ export namespace WAFNonexistentItemException {
  *          </ul>
  */
 export interface WAFReferencedItemException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "WAFReferencedItemException";
   $fault: "client";
@@ -5969,7 +5972,7 @@ export interface WAFReferencedItemException
 
 export namespace WAFReferencedItemException {
   export function isa(o: any): o is WAFReferencedItemException {
-    return _smithy.isa(o, "WAFReferencedItemException");
+    return __isa(o, "WAFReferencedItemException");
   }
 }
 
@@ -5977,7 +5980,7 @@ export namespace WAFReferencedItemException {
  * <p>AWS WAF is not able to access the service linked role. This can be caused by a previous <code>PutLoggingConfiguration</code> request, which can lock the service linked role for about 20 seconds. Please try your request again. The service linked role can also be locked by a previous <code>DeleteServiceLinkedRole</code> request, which can lock the role for 15 minutes or more. If you recently made a <code>DeleteServiceLinkedRole</code>, wait at least 15 minutes and try the request again. If you receive this same exception again, you will have to wait additional time until the role is unlocked.</p>
  */
 export interface WAFServiceLinkedRoleErrorException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "WAFServiceLinkedRoleErrorException";
   $fault: "client";
@@ -5986,7 +5989,7 @@ export interface WAFServiceLinkedRoleErrorException
 
 export namespace WAFServiceLinkedRoleErrorException {
   export function isa(o: any): o is WAFServiceLinkedRoleErrorException {
-    return _smithy.isa(o, "WAFServiceLinkedRoleErrorException");
+    return __isa(o, "WAFServiceLinkedRoleErrorException");
   }
 }
 
@@ -5994,7 +5997,7 @@ export namespace WAFServiceLinkedRoleErrorException {
  * <p>The operation failed because you tried to create, update, or delete an object by using a change token that has already been used.</p>
  */
 export interface WAFStaleDataException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "WAFStaleDataException";
   $fault: "client";
@@ -6003,7 +6006,7 @@ export interface WAFStaleDataException
 
 export namespace WAFStaleDataException {
   export function isa(o: any): o is WAFStaleDataException {
-    return _smithy.isa(o, "WAFStaleDataException");
+    return __isa(o, "WAFStaleDataException");
   }
 }
 
@@ -6011,7 +6014,7 @@ export namespace WAFStaleDataException {
  * <p>The specified subscription does not exist.</p>
  */
 export interface WAFSubscriptionNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "WAFSubscriptionNotFoundException";
   $fault: "client";
@@ -6020,12 +6023,12 @@ export interface WAFSubscriptionNotFoundException
 
 export namespace WAFSubscriptionNotFoundException {
   export function isa(o: any): o is WAFSubscriptionNotFoundException {
-    return _smithy.isa(o, "WAFSubscriptionNotFoundException");
+    return __isa(o, "WAFSubscriptionNotFoundException");
   }
 }
 
 export interface WAFTagOperationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "WAFTagOperationException";
   $fault: "client";
@@ -6034,12 +6037,12 @@ export interface WAFTagOperationException
 
 export namespace WAFTagOperationException {
   export function isa(o: any): o is WAFTagOperationException {
-    return _smithy.isa(o, "WAFTagOperationException");
+    return __isa(o, "WAFTagOperationException");
   }
 }
 
 export interface WAFTagOperationInternalErrorException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "WAFTagOperationInternalErrorException";
   $fault: "server";
@@ -6048,7 +6051,7 @@ export interface WAFTagOperationInternalErrorException
 
 export namespace WAFTagOperationInternalErrorException {
   export function isa(o: any): o is WAFTagOperationInternalErrorException {
-    return _smithy.isa(o, "WAFTagOperationInternalErrorException");
+    return __isa(o, "WAFTagOperationInternalErrorException");
   }
 }
 
@@ -6083,7 +6086,7 @@ export interface WafAction {
 
 export namespace WafAction {
   export function isa(o: any): o is WafAction {
-    return _smithy.isa(o, "WafAction");
+    return __isa(o, "WafAction");
   }
 }
 
@@ -6107,7 +6110,7 @@ export interface WafOverrideAction {
 
 export namespace WafOverrideAction {
   export function isa(o: any): o is WafOverrideAction {
-    return _smithy.isa(o, "WafOverrideAction");
+    return __isa(o, "WafOverrideAction");
   }
 }
 
@@ -6172,7 +6175,7 @@ export interface WebACL {
 
 export namespace WebACL {
   export function isa(o: any): o is WebACL {
-    return _smithy.isa(o, "WebACL");
+    return __isa(o, "WebACL");
   }
 }
 
@@ -6198,7 +6201,7 @@ export interface WebACLSummary {
 
 export namespace WebACLSummary {
   export function isa(o: any): o is WebACLSummary {
-    return _smithy.isa(o, "WebACLSummary");
+    return __isa(o, "WebACLSummary");
   }
 }
 
@@ -6222,7 +6225,7 @@ export interface WebACLUpdate {
 
 export namespace WebACLUpdate {
   export function isa(o: any): o is WebACLUpdate {
-    return _smithy.isa(o, "WebACLUpdate");
+    return __isa(o, "WebACLUpdate");
   }
 }
 
@@ -6258,7 +6261,7 @@ export interface XssMatchSet {
 
 export namespace XssMatchSet {
   export function isa(o: any): o is XssMatchSet {
-    return _smithy.isa(o, "XssMatchSet");
+    return __isa(o, "XssMatchSet");
   }
 }
 
@@ -6286,7 +6289,7 @@ export interface XssMatchSetSummary {
 
 export namespace XssMatchSetSummary {
   export function isa(o: any): o is XssMatchSetSummary {
-    return _smithy.isa(o, "XssMatchSetSummary");
+    return __isa(o, "XssMatchSetSummary");
   }
 }
 
@@ -6312,7 +6315,7 @@ export interface XssMatchSetUpdate {
 
 export namespace XssMatchSetUpdate {
   export function isa(o: any): o is XssMatchSetUpdate {
-    return _smithy.isa(o, "XssMatchSetUpdate");
+    return __isa(o, "XssMatchSetUpdate");
   }
 }
 
@@ -6426,6 +6429,6 @@ export interface XssMatchTuple {
 
 export namespace XssMatchTuple {
   export function isa(o: any): o is XssMatchTuple {
-    return _smithy.isa(o, "XssMatchTuple");
+    return __isa(o, "XssMatchTuple");
   }
 }

--- a/clients/client-wafv2/models/index.ts
+++ b/clients/client-wafv2/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -13,7 +16,7 @@ export interface AllQueryArguments {
 
 export namespace AllQueryArguments {
   export function isa(o: any): o is AllQueryArguments {
-    return _smithy.isa(o, "AllQueryArguments");
+    return __isa(o, "AllQueryArguments");
   }
 }
 
@@ -29,7 +32,7 @@ export interface AllowAction {
 
 export namespace AllowAction {
   export function isa(o: any): o is AllowAction {
-    return _smithy.isa(o, "AllowAction");
+    return __isa(o, "AllowAction");
   }
 }
 
@@ -49,7 +52,7 @@ export interface AndStatement {
 
 export namespace AndStatement {
   export function isa(o: any): o is AndStatement {
-    return _smithy.isa(o, "AndStatement");
+    return __isa(o, "AndStatement");
   }
 }
 
@@ -87,7 +90,7 @@ export interface AssociateWebACLRequest {
 
 export namespace AssociateWebACLRequest {
   export function isa(o: any): o is AssociateWebACLRequest {
-    return _smithy.isa(o, "AssociateWebACLRequest");
+    return __isa(o, "AssociateWebACLRequest");
   }
 }
 
@@ -97,7 +100,7 @@ export interface AssociateWebACLResponse extends $MetadataBearer {
 
 export namespace AssociateWebACLResponse {
   export function isa(o: any): o is AssociateWebACLResponse {
-    return _smithy.isa(o, "AssociateWebACLResponse");
+    return __isa(o, "AssociateWebACLResponse");
   }
 }
 
@@ -113,7 +116,7 @@ export interface BlockAction {
 
 export namespace BlockAction {
   export function isa(o: any): o is BlockAction {
-    return _smithy.isa(o, "BlockAction");
+    return __isa(o, "BlockAction");
   }
 }
 
@@ -129,7 +132,7 @@ export interface Body {
 
 export namespace Body {
   export function isa(o: any): o is Body {
-    return _smithy.isa(o, "Body");
+    return __isa(o, "Body");
   }
 }
 
@@ -231,7 +234,7 @@ export interface ByteMatchStatement {
 
 export namespace ByteMatchStatement {
   export function isa(o: any): o is ByteMatchStatement {
-    return _smithy.isa(o, "ByteMatchStatement");
+    return __isa(o, "ByteMatchStatement");
   }
 }
 
@@ -259,7 +262,7 @@ export interface CheckCapacityRequest {
 
 export namespace CheckCapacityRequest {
   export function isa(o: any): o is CheckCapacityRequest {
-    return _smithy.isa(o, "CheckCapacityRequest");
+    return __isa(o, "CheckCapacityRequest");
   }
 }
 
@@ -273,7 +276,7 @@ export interface CheckCapacityResponse extends $MetadataBearer {
 
 export namespace CheckCapacityResponse {
   export function isa(o: any): o is CheckCapacityResponse {
-    return _smithy.isa(o, "CheckCapacityResponse");
+    return __isa(o, "CheckCapacityResponse");
   }
 }
 
@@ -298,7 +301,7 @@ export interface CountAction {
 
 export namespace CountAction {
   export function isa(o: any): o is CountAction {
-    return _smithy.isa(o, "CountAction");
+    return __isa(o, "CountAction");
   }
 }
 
@@ -616,7 +619,7 @@ export interface CreateIPSetRequest {
 
 export namespace CreateIPSetRequest {
   export function isa(o: any): o is CreateIPSetRequest {
-    return _smithy.isa(o, "CreateIPSetRequest");
+    return __isa(o, "CreateIPSetRequest");
   }
 }
 
@@ -630,7 +633,7 @@ export interface CreateIPSetResponse extends $MetadataBearer {
 
 export namespace CreateIPSetResponse {
   export function isa(o: any): o is CreateIPSetResponse {
-    return _smithy.isa(o, "CreateIPSetResponse");
+    return __isa(o, "CreateIPSetResponse");
   }
 }
 
@@ -673,7 +676,7 @@ export interface CreateRegexPatternSetRequest {
 
 export namespace CreateRegexPatternSetRequest {
   export function isa(o: any): o is CreateRegexPatternSetRequest {
-    return _smithy.isa(o, "CreateRegexPatternSetRequest");
+    return __isa(o, "CreateRegexPatternSetRequest");
   }
 }
 
@@ -687,7 +690,7 @@ export interface CreateRegexPatternSetResponse extends $MetadataBearer {
 
 export namespace CreateRegexPatternSetResponse {
   export function isa(o: any): o is CreateRegexPatternSetResponse {
-    return _smithy.isa(o, "CreateRegexPatternSetResponse");
+    return __isa(o, "CreateRegexPatternSetResponse");
   }
 }
 
@@ -754,7 +757,7 @@ export interface CreateRuleGroupRequest {
 
 export namespace CreateRuleGroupRequest {
   export function isa(o: any): o is CreateRuleGroupRequest {
-    return _smithy.isa(o, "CreateRuleGroupRequest");
+    return __isa(o, "CreateRuleGroupRequest");
   }
 }
 
@@ -768,7 +771,7 @@ export interface CreateRuleGroupResponse extends $MetadataBearer {
 
 export namespace CreateRuleGroupResponse {
   export function isa(o: any): o is CreateRuleGroupResponse {
-    return _smithy.isa(o, "CreateRuleGroupResponse");
+    return __isa(o, "CreateRuleGroupResponse");
   }
 }
 
@@ -824,7 +827,7 @@ export interface CreateWebACLRequest {
 
 export namespace CreateWebACLRequest {
   export function isa(o: any): o is CreateWebACLRequest {
-    return _smithy.isa(o, "CreateWebACLRequest");
+    return __isa(o, "CreateWebACLRequest");
   }
 }
 
@@ -838,7 +841,7 @@ export interface CreateWebACLResponse extends $MetadataBearer {
 
 export namespace CreateWebACLResponse {
   export function isa(o: any): o is CreateWebACLResponse {
-    return _smithy.isa(o, "CreateWebACLResponse");
+    return __isa(o, "CreateWebACLResponse");
   }
 }
 
@@ -864,7 +867,7 @@ export interface DefaultAction {
 
 export namespace DefaultAction {
   export function isa(o: any): o is DefaultAction {
-    return _smithy.isa(o, "DefaultAction");
+    return __isa(o, "DefaultAction");
   }
 }
 
@@ -902,7 +905,7 @@ export interface DeleteIPSetRequest {
 
 export namespace DeleteIPSetRequest {
   export function isa(o: any): o is DeleteIPSetRequest {
-    return _smithy.isa(o, "DeleteIPSetRequest");
+    return __isa(o, "DeleteIPSetRequest");
   }
 }
 
@@ -912,7 +915,7 @@ export interface DeleteIPSetResponse extends $MetadataBearer {
 
 export namespace DeleteIPSetResponse {
   export function isa(o: any): o is DeleteIPSetResponse {
-    return _smithy.isa(o, "DeleteIPSetResponse");
+    return __isa(o, "DeleteIPSetResponse");
   }
 }
 
@@ -926,7 +929,7 @@ export interface DeleteLoggingConfigurationRequest {
 
 export namespace DeleteLoggingConfigurationRequest {
   export function isa(o: any): o is DeleteLoggingConfigurationRequest {
-    return _smithy.isa(o, "DeleteLoggingConfigurationRequest");
+    return __isa(o, "DeleteLoggingConfigurationRequest");
   }
 }
 
@@ -936,7 +939,7 @@ export interface DeleteLoggingConfigurationResponse extends $MetadataBearer {
 
 export namespace DeleteLoggingConfigurationResponse {
   export function isa(o: any): o is DeleteLoggingConfigurationResponse {
-    return _smithy.isa(o, "DeleteLoggingConfigurationResponse");
+    return __isa(o, "DeleteLoggingConfigurationResponse");
   }
 }
 
@@ -974,7 +977,7 @@ export interface DeleteRegexPatternSetRequest {
 
 export namespace DeleteRegexPatternSetRequest {
   export function isa(o: any): o is DeleteRegexPatternSetRequest {
-    return _smithy.isa(o, "DeleteRegexPatternSetRequest");
+    return __isa(o, "DeleteRegexPatternSetRequest");
   }
 }
 
@@ -984,7 +987,7 @@ export interface DeleteRegexPatternSetResponse extends $MetadataBearer {
 
 export namespace DeleteRegexPatternSetResponse {
   export function isa(o: any): o is DeleteRegexPatternSetResponse {
-    return _smithy.isa(o, "DeleteRegexPatternSetResponse");
+    return __isa(o, "DeleteRegexPatternSetResponse");
   }
 }
 
@@ -1022,7 +1025,7 @@ export interface DeleteRuleGroupRequest {
 
 export namespace DeleteRuleGroupRequest {
   export function isa(o: any): o is DeleteRuleGroupRequest {
-    return _smithy.isa(o, "DeleteRuleGroupRequest");
+    return __isa(o, "DeleteRuleGroupRequest");
   }
 }
 
@@ -1032,7 +1035,7 @@ export interface DeleteRuleGroupResponse extends $MetadataBearer {
 
 export namespace DeleteRuleGroupResponse {
   export function isa(o: any): o is DeleteRuleGroupResponse {
-    return _smithy.isa(o, "DeleteRuleGroupResponse");
+    return __isa(o, "DeleteRuleGroupResponse");
   }
 }
 
@@ -1070,7 +1073,7 @@ export interface DeleteWebACLRequest {
 
 export namespace DeleteWebACLRequest {
   export function isa(o: any): o is DeleteWebACLRequest {
-    return _smithy.isa(o, "DeleteWebACLRequest");
+    return __isa(o, "DeleteWebACLRequest");
   }
 }
 
@@ -1080,7 +1083,7 @@ export interface DeleteWebACLResponse extends $MetadataBearer {
 
 export namespace DeleteWebACLResponse {
   export function isa(o: any): o is DeleteWebACLResponse {
-    return _smithy.isa(o, "DeleteWebACLResponse");
+    return __isa(o, "DeleteWebACLResponse");
   }
 }
 
@@ -1113,7 +1116,7 @@ export interface DescribeManagedRuleGroupRequest {
 
 export namespace DescribeManagedRuleGroupRequest {
   export function isa(o: any): o is DescribeManagedRuleGroupRequest {
-    return _smithy.isa(o, "DescribeManagedRuleGroupRequest");
+    return __isa(o, "DescribeManagedRuleGroupRequest");
   }
 }
 
@@ -1138,7 +1141,7 @@ export interface DescribeManagedRuleGroupResponse extends $MetadataBearer {
 
 export namespace DescribeManagedRuleGroupResponse {
   export function isa(o: any): o is DescribeManagedRuleGroupResponse {
-    return _smithy.isa(o, "DescribeManagedRuleGroupResponse");
+    return __isa(o, "DescribeManagedRuleGroupResponse");
   }
 }
 
@@ -1171,7 +1174,7 @@ export interface DisassociateWebACLRequest {
 
 export namespace DisassociateWebACLRequest {
   export function isa(o: any): o is DisassociateWebACLRequest {
-    return _smithy.isa(o, "DisassociateWebACLRequest");
+    return __isa(o, "DisassociateWebACLRequest");
   }
 }
 
@@ -1181,7 +1184,7 @@ export interface DisassociateWebACLResponse extends $MetadataBearer {
 
 export namespace DisassociateWebACLResponse {
   export function isa(o: any): o is DisassociateWebACLResponse {
-    return _smithy.isa(o, "DisassociateWebACLResponse");
+    return __isa(o, "DisassociateWebACLResponse");
   }
 }
 
@@ -1203,7 +1206,7 @@ export interface ExcludedRule {
 
 export namespace ExcludedRule {
   export function isa(o: any): o is ExcludedRule {
-    return _smithy.isa(o, "ExcludedRule");
+    return __isa(o, "ExcludedRule");
   }
 }
 
@@ -1255,7 +1258,7 @@ export interface FieldToMatch {
 
 export namespace FieldToMatch {
   export function isa(o: any): o is FieldToMatch {
-    return _smithy.isa(o, "FieldToMatch");
+    return __isa(o, "FieldToMatch");
   }
 }
 
@@ -1275,7 +1278,7 @@ export interface GeoMatchStatement {
 
 export namespace GeoMatchStatement {
   export function isa(o: any): o is GeoMatchStatement {
-    return _smithy.isa(o, "GeoMatchStatement");
+    return __isa(o, "GeoMatchStatement");
   }
 }
 
@@ -1308,7 +1311,7 @@ export interface GetIPSetRequest {
 
 export namespace GetIPSetRequest {
   export function isa(o: any): o is GetIPSetRequest {
-    return _smithy.isa(o, "GetIPSetRequest");
+    return __isa(o, "GetIPSetRequest");
   }
 }
 
@@ -1327,7 +1330,7 @@ export interface GetIPSetResponse extends $MetadataBearer {
 
 export namespace GetIPSetResponse {
   export function isa(o: any): o is GetIPSetResponse {
-    return _smithy.isa(o, "GetIPSetResponse");
+    return __isa(o, "GetIPSetResponse");
   }
 }
 
@@ -1341,7 +1344,7 @@ export interface GetLoggingConfigurationRequest {
 
 export namespace GetLoggingConfigurationRequest {
   export function isa(o: any): o is GetLoggingConfigurationRequest {
-    return _smithy.isa(o, "GetLoggingConfigurationRequest");
+    return __isa(o, "GetLoggingConfigurationRequest");
   }
 }
 
@@ -1355,7 +1358,7 @@ export interface GetLoggingConfigurationResponse extends $MetadataBearer {
 
 export namespace GetLoggingConfigurationResponse {
   export function isa(o: any): o is GetLoggingConfigurationResponse {
-    return _smithy.isa(o, "GetLoggingConfigurationResponse");
+    return __isa(o, "GetLoggingConfigurationResponse");
   }
 }
 
@@ -1393,7 +1396,7 @@ export interface GetRateBasedStatementManagedKeysRequest {
 
 export namespace GetRateBasedStatementManagedKeysRequest {
   export function isa(o: any): o is GetRateBasedStatementManagedKeysRequest {
-    return _smithy.isa(o, "GetRateBasedStatementManagedKeysRequest");
+    return __isa(o, "GetRateBasedStatementManagedKeysRequest");
   }
 }
 
@@ -1413,7 +1416,7 @@ export interface GetRateBasedStatementManagedKeysResponse
 
 export namespace GetRateBasedStatementManagedKeysResponse {
   export function isa(o: any): o is GetRateBasedStatementManagedKeysResponse {
-    return _smithy.isa(o, "GetRateBasedStatementManagedKeysResponse");
+    return __isa(o, "GetRateBasedStatementManagedKeysResponse");
   }
 }
 
@@ -1446,7 +1449,7 @@ export interface GetRegexPatternSetRequest {
 
 export namespace GetRegexPatternSetRequest {
   export function isa(o: any): o is GetRegexPatternSetRequest {
-    return _smithy.isa(o, "GetRegexPatternSetRequest");
+    return __isa(o, "GetRegexPatternSetRequest");
   }
 }
 
@@ -1465,7 +1468,7 @@ export interface GetRegexPatternSetResponse extends $MetadataBearer {
 
 export namespace GetRegexPatternSetResponse {
   export function isa(o: any): o is GetRegexPatternSetResponse {
-    return _smithy.isa(o, "GetRegexPatternSetResponse");
+    return __isa(o, "GetRegexPatternSetResponse");
   }
 }
 
@@ -1498,7 +1501,7 @@ export interface GetRuleGroupRequest {
 
 export namespace GetRuleGroupRequest {
   export function isa(o: any): o is GetRuleGroupRequest {
-    return _smithy.isa(o, "GetRuleGroupRequest");
+    return __isa(o, "GetRuleGroupRequest");
   }
 }
 
@@ -1517,7 +1520,7 @@ export interface GetRuleGroupResponse extends $MetadataBearer {
 
 export namespace GetRuleGroupResponse {
   export function isa(o: any): o is GetRuleGroupResponse {
-    return _smithy.isa(o, "GetRuleGroupResponse");
+    return __isa(o, "GetRuleGroupResponse");
   }
 }
 
@@ -1564,7 +1567,7 @@ export interface GetSampledRequestsRequest {
 
 export namespace GetSampledRequestsRequest {
   export function isa(o: any): o is GetSampledRequestsRequest {
-    return _smithy.isa(o, "GetSampledRequestsRequest");
+    return __isa(o, "GetSampledRequestsRequest");
   }
 }
 
@@ -1592,7 +1595,7 @@ export interface GetSampledRequestsResponse extends $MetadataBearer {
 
 export namespace GetSampledRequestsResponse {
   export function isa(o: any): o is GetSampledRequestsResponse {
-    return _smithy.isa(o, "GetSampledRequestsResponse");
+    return __isa(o, "GetSampledRequestsResponse");
   }
 }
 
@@ -1606,7 +1609,7 @@ export interface GetWebACLForResourceRequest {
 
 export namespace GetWebACLForResourceRequest {
   export function isa(o: any): o is GetWebACLForResourceRequest {
-    return _smithy.isa(o, "GetWebACLForResourceRequest");
+    return __isa(o, "GetWebACLForResourceRequest");
   }
 }
 
@@ -1620,7 +1623,7 @@ export interface GetWebACLForResourceResponse extends $MetadataBearer {
 
 export namespace GetWebACLForResourceResponse {
   export function isa(o: any): o is GetWebACLForResourceResponse {
-    return _smithy.isa(o, "GetWebACLForResourceResponse");
+    return __isa(o, "GetWebACLForResourceResponse");
   }
 }
 
@@ -1653,7 +1656,7 @@ export interface GetWebACLRequest {
 
 export namespace GetWebACLRequest {
   export function isa(o: any): o is GetWebACLRequest {
-    return _smithy.isa(o, "GetWebACLRequest");
+    return __isa(o, "GetWebACLRequest");
   }
 }
 
@@ -1672,7 +1675,7 @@ export interface GetWebACLResponse extends $MetadataBearer {
 
 export namespace GetWebACLResponse {
   export function isa(o: any): o is GetWebACLResponse {
-    return _smithy.isa(o, "GetWebACLResponse");
+    return __isa(o, "GetWebACLResponse");
   }
 }
 
@@ -1699,7 +1702,7 @@ export interface HTTPHeader {
 
 export namespace HTTPHeader {
   export function isa(o: any): o is HTTPHeader {
-    return _smithy.isa(o, "HTTPHeader");
+    return __isa(o, "HTTPHeader");
   }
 }
 
@@ -1758,7 +1761,7 @@ export interface HTTPRequest {
 
 export namespace HTTPRequest {
   export function isa(o: any): o is HTTPRequest {
-    return _smithy.isa(o, "HTTPRequest");
+    return __isa(o, "HTTPRequest");
   }
 }
 
@@ -1828,7 +1831,7 @@ export interface IPSet {
 
 export namespace IPSet {
   export function isa(o: any): o is IPSet {
-    return _smithy.isa(o, "IPSet");
+    return __isa(o, "IPSet");
   }
 }
 
@@ -1849,7 +1852,7 @@ export interface IPSetReferenceStatement {
 
 export namespace IPSetReferenceStatement {
   export function isa(o: any): o is IPSetReferenceStatement {
-    return _smithy.isa(o, "IPSetReferenceStatement");
+    return __isa(o, "IPSetReferenceStatement");
   }
 }
 
@@ -1889,7 +1892,7 @@ export interface IPSetSummary {
 
 export namespace IPSetSummary {
   export function isa(o: any): o is IPSetSummary {
-    return _smithy.isa(o, "IPSetSummary");
+    return __isa(o, "IPSetSummary");
   }
 }
 
@@ -1926,7 +1929,7 @@ export interface ListAvailableManagedRuleGroupsRequest {
 
 export namespace ListAvailableManagedRuleGroupsRequest {
   export function isa(o: any): o is ListAvailableManagedRuleGroupsRequest {
-    return _smithy.isa(o, "ListAvailableManagedRuleGroupsRequest");
+    return __isa(o, "ListAvailableManagedRuleGroupsRequest");
   }
 }
 
@@ -1948,7 +1951,7 @@ export interface ListAvailableManagedRuleGroupsResponse
 
 export namespace ListAvailableManagedRuleGroupsResponse {
   export function isa(o: any): o is ListAvailableManagedRuleGroupsResponse {
-    return _smithy.isa(o, "ListAvailableManagedRuleGroupsResponse");
+    return __isa(o, "ListAvailableManagedRuleGroupsResponse");
   }
 }
 
@@ -1985,7 +1988,7 @@ export interface ListIPSetsRequest {
 
 export namespace ListIPSetsRequest {
   export function isa(o: any): o is ListIPSetsRequest {
-    return _smithy.isa(o, "ListIPSetsRequest");
+    return __isa(o, "ListIPSetsRequest");
   }
 }
 
@@ -2006,7 +2009,7 @@ export interface ListIPSetsResponse extends $MetadataBearer {
 
 export namespace ListIPSetsResponse {
   export function isa(o: any): o is ListIPSetsResponse {
-    return _smithy.isa(o, "ListIPSetsResponse");
+    return __isa(o, "ListIPSetsResponse");
   }
 }
 
@@ -2043,7 +2046,7 @@ export interface ListLoggingConfigurationsRequest {
 
 export namespace ListLoggingConfigurationsRequest {
   export function isa(o: any): o is ListLoggingConfigurationsRequest {
-    return _smithy.isa(o, "ListLoggingConfigurationsRequest");
+    return __isa(o, "ListLoggingConfigurationsRequest");
   }
 }
 
@@ -2064,7 +2067,7 @@ export interface ListLoggingConfigurationsResponse extends $MetadataBearer {
 
 export namespace ListLoggingConfigurationsResponse {
   export function isa(o: any): o is ListLoggingConfigurationsResponse {
-    return _smithy.isa(o, "ListLoggingConfigurationsResponse");
+    return __isa(o, "ListLoggingConfigurationsResponse");
   }
 }
 
@@ -2101,7 +2104,7 @@ export interface ListRegexPatternSetsRequest {
 
 export namespace ListRegexPatternSetsRequest {
   export function isa(o: any): o is ListRegexPatternSetsRequest {
-    return _smithy.isa(o, "ListRegexPatternSetsRequest");
+    return __isa(o, "ListRegexPatternSetsRequest");
   }
 }
 
@@ -2122,7 +2125,7 @@ export interface ListRegexPatternSetsResponse extends $MetadataBearer {
 
 export namespace ListRegexPatternSetsResponse {
   export function isa(o: any): o is ListRegexPatternSetsResponse {
-    return _smithy.isa(o, "ListRegexPatternSetsResponse");
+    return __isa(o, "ListRegexPatternSetsResponse");
   }
 }
 
@@ -2141,7 +2144,7 @@ export interface ListResourcesForWebACLRequest {
 
 export namespace ListResourcesForWebACLRequest {
   export function isa(o: any): o is ListResourcesForWebACLRequest {
-    return _smithy.isa(o, "ListResourcesForWebACLRequest");
+    return __isa(o, "ListResourcesForWebACLRequest");
   }
 }
 
@@ -2155,7 +2158,7 @@ export interface ListResourcesForWebACLResponse extends $MetadataBearer {
 
 export namespace ListResourcesForWebACLResponse {
   export function isa(o: any): o is ListResourcesForWebACLResponse {
-    return _smithy.isa(o, "ListResourcesForWebACLResponse");
+    return __isa(o, "ListResourcesForWebACLResponse");
   }
 }
 
@@ -2192,7 +2195,7 @@ export interface ListRuleGroupsRequest {
 
 export namespace ListRuleGroupsRequest {
   export function isa(o: any): o is ListRuleGroupsRequest {
-    return _smithy.isa(o, "ListRuleGroupsRequest");
+    return __isa(o, "ListRuleGroupsRequest");
   }
 }
 
@@ -2213,7 +2216,7 @@ export interface ListRuleGroupsResponse extends $MetadataBearer {
 
 export namespace ListRuleGroupsResponse {
   export function isa(o: any): o is ListRuleGroupsResponse {
-    return _smithy.isa(o, "ListRuleGroupsResponse");
+    return __isa(o, "ListRuleGroupsResponse");
   }
 }
 
@@ -2241,7 +2244,7 @@ export interface ListTagsForResourceRequest {
 
 export namespace ListTagsForResourceRequest {
   export function isa(o: any): o is ListTagsForResourceRequest {
-    return _smithy.isa(o, "ListTagsForResourceRequest");
+    return __isa(o, "ListTagsForResourceRequest");
   }
 }
 
@@ -2262,7 +2265,7 @@ export interface ListTagsForResourceResponse extends $MetadataBearer {
 
 export namespace ListTagsForResourceResponse {
   export function isa(o: any): o is ListTagsForResourceResponse {
-    return _smithy.isa(o, "ListTagsForResourceResponse");
+    return __isa(o, "ListTagsForResourceResponse");
   }
 }
 
@@ -2299,7 +2302,7 @@ export interface ListWebACLsRequest {
 
 export namespace ListWebACLsRequest {
   export function isa(o: any): o is ListWebACLsRequest {
-    return _smithy.isa(o, "ListWebACLsRequest");
+    return __isa(o, "ListWebACLsRequest");
   }
 }
 
@@ -2320,7 +2323,7 @@ export interface ListWebACLsResponse extends $MetadataBearer {
 
 export namespace ListWebACLsResponse {
   export function isa(o: any): o is ListWebACLsResponse {
-    return _smithy.isa(o, "ListWebACLsResponse");
+    return __isa(o, "ListWebACLsResponse");
   }
 }
 
@@ -2356,7 +2359,7 @@ export interface LoggingConfiguration {
 
 export namespace LoggingConfiguration {
   export function isa(o: any): o is LoggingConfiguration {
-    return _smithy.isa(o, "LoggingConfiguration");
+    return __isa(o, "LoggingConfiguration");
   }
 }
 
@@ -2387,7 +2390,7 @@ export interface ManagedRuleGroupStatement {
 
 export namespace ManagedRuleGroupStatement {
   export function isa(o: any): o is ManagedRuleGroupStatement {
-    return _smithy.isa(o, "ManagedRuleGroupStatement");
+    return __isa(o, "ManagedRuleGroupStatement");
   }
 }
 
@@ -2417,7 +2420,7 @@ export interface ManagedRuleGroupSummary {
 
 export namespace ManagedRuleGroupSummary {
   export function isa(o: any): o is ManagedRuleGroupSummary {
-    return _smithy.isa(o, "ManagedRuleGroupSummary");
+    return __isa(o, "ManagedRuleGroupSummary");
   }
 }
 
@@ -2433,7 +2436,7 @@ export interface Method {
 
 export namespace Method {
   export function isa(o: any): o is Method {
-    return _smithy.isa(o, "Method");
+    return __isa(o, "Method");
   }
 }
 
@@ -2449,7 +2452,7 @@ export interface NoneAction {
 
 export namespace NoneAction {
   export function isa(o: any): o is NoneAction {
-    return _smithy.isa(o, "NoneAction");
+    return __isa(o, "NoneAction");
   }
 }
 
@@ -2469,7 +2472,7 @@ export interface NotStatement {
 
 export namespace NotStatement {
   export function isa(o: any): o is NotStatement {
-    return _smithy.isa(o, "NotStatement");
+    return __isa(o, "NotStatement");
   }
 }
 
@@ -2489,7 +2492,7 @@ export interface OrStatement {
 
 export namespace OrStatement {
   export function isa(o: any): o is OrStatement {
-    return _smithy.isa(o, "OrStatement");
+    return __isa(o, "OrStatement");
   }
 }
 
@@ -2514,7 +2517,7 @@ export interface OverrideAction {
 
 export namespace OverrideAction {
   export function isa(o: any): o is OverrideAction {
-    return _smithy.isa(o, "OverrideAction");
+    return __isa(o, "OverrideAction");
   }
 }
 
@@ -2575,7 +2578,7 @@ export interface PutLoggingConfigurationRequest {
 
 export namespace PutLoggingConfigurationRequest {
   export function isa(o: any): o is PutLoggingConfigurationRequest {
-    return _smithy.isa(o, "PutLoggingConfigurationRequest");
+    return __isa(o, "PutLoggingConfigurationRequest");
   }
 }
 
@@ -2589,7 +2592,7 @@ export interface PutLoggingConfigurationResponse extends $MetadataBearer {
 
 export namespace PutLoggingConfigurationResponse {
   export function isa(o: any): o is PutLoggingConfigurationResponse {
-    return _smithy.isa(o, "PutLoggingConfigurationResponse");
+    return __isa(o, "PutLoggingConfigurationResponse");
   }
 }
 
@@ -2605,7 +2608,7 @@ export interface QueryString {
 
 export namespace QueryString {
   export function isa(o: any): o is QueryString {
-    return _smithy.isa(o, "QueryString");
+    return __isa(o, "QueryString");
   }
 }
 
@@ -2647,7 +2650,7 @@ export interface RateBasedStatement {
 
 export namespace RateBasedStatement {
   export function isa(o: any): o is RateBasedStatement {
-    return _smithy.isa(o, "RateBasedStatement");
+    return __isa(o, "RateBasedStatement");
   }
 }
 
@@ -2673,7 +2676,7 @@ export interface RateBasedStatementManagedKeysIPSet {
 
 export namespace RateBasedStatementManagedKeysIPSet {
   export function isa(o: any): o is RateBasedStatementManagedKeysIPSet {
-    return _smithy.isa(o, "RateBasedStatementManagedKeysIPSet");
+    return __isa(o, "RateBasedStatementManagedKeysIPSet");
   }
 }
 
@@ -2693,7 +2696,7 @@ export interface Regex {
 
 export namespace Regex {
   export function isa(o: any): o is Regex {
-    return _smithy.isa(o, "Regex");
+    return __isa(o, "Regex");
   }
 }
 
@@ -2734,7 +2737,7 @@ export interface RegexPatternSet {
 
 export namespace RegexPatternSet {
   export function isa(o: any): o is RegexPatternSet {
-    return _smithy.isa(o, "RegexPatternSet");
+    return __isa(o, "RegexPatternSet");
   }
 }
 
@@ -2767,7 +2770,7 @@ export interface RegexPatternSetReferenceStatement {
 
 export namespace RegexPatternSetReferenceStatement {
   export function isa(o: any): o is RegexPatternSetReferenceStatement {
-    return _smithy.isa(o, "RegexPatternSetReferenceStatement");
+    return __isa(o, "RegexPatternSetReferenceStatement");
   }
 }
 
@@ -2807,7 +2810,7 @@ export interface RegexPatternSetSummary {
 
 export namespace RegexPatternSetSummary {
   export function isa(o: any): o is RegexPatternSetSummary {
-    return _smithy.isa(o, "RegexPatternSetSummary");
+    return __isa(o, "RegexPatternSetSummary");
   }
 }
 
@@ -2863,7 +2866,7 @@ export interface Rule {
 
 export namespace Rule {
   export function isa(o: any): o is Rule {
-    return _smithy.isa(o, "Rule");
+    return __isa(o, "Rule");
   }
 }
 
@@ -2893,7 +2896,7 @@ export interface RuleAction {
 
 export namespace RuleAction {
   export function isa(o: any): o is RuleAction {
-    return _smithy.isa(o, "RuleAction");
+    return __isa(o, "RuleAction");
   }
 }
 
@@ -2957,7 +2960,7 @@ export interface RuleGroup {
 
 export namespace RuleGroup {
   export function isa(o: any): o is RuleGroup {
-    return _smithy.isa(o, "RuleGroup");
+    return __isa(o, "RuleGroup");
   }
 }
 
@@ -2983,7 +2986,7 @@ export interface RuleGroupReferenceStatement {
 
 export namespace RuleGroupReferenceStatement {
   export function isa(o: any): o is RuleGroupReferenceStatement {
-    return _smithy.isa(o, "RuleGroupReferenceStatement");
+    return __isa(o, "RuleGroupReferenceStatement");
   }
 }
 
@@ -3023,7 +3026,7 @@ export interface RuleGroupSummary {
 
 export namespace RuleGroupSummary {
   export function isa(o: any): o is RuleGroupSummary {
-    return _smithy.isa(o, "RuleGroupSummary");
+    return __isa(o, "RuleGroupSummary");
   }
 }
 
@@ -3051,7 +3054,7 @@ export interface RuleSummary {
 
 export namespace RuleSummary {
   export function isa(o: any): o is RuleSummary {
-    return _smithy.isa(o, "RuleSummary");
+    return __isa(o, "RuleSummary");
   }
 }
 
@@ -3098,7 +3101,7 @@ export interface SampledHTTPRequest {
 
 export namespace SampledHTTPRequest {
   export function isa(o: any): o is SampledHTTPRequest {
-    return _smithy.isa(o, "SampledHTTPRequest");
+    return __isa(o, "SampledHTTPRequest");
   }
 }
 
@@ -3123,7 +3126,7 @@ export interface SingleHeader {
 
 export namespace SingleHeader {
   export function isa(o: any): o is SingleHeader {
-    return _smithy.isa(o, "SingleHeader");
+    return __isa(o, "SingleHeader");
   }
 }
 
@@ -3143,7 +3146,7 @@ export interface SingleQueryArgument {
 
 export namespace SingleQueryArgument {
   export function isa(o: any): o is SingleQueryArgument {
-    return _smithy.isa(o, "SingleQueryArgument");
+    return __isa(o, "SingleQueryArgument");
   }
 }
 
@@ -3182,7 +3185,7 @@ export interface SizeConstraintStatement {
 
 export namespace SizeConstraintStatement {
   export function isa(o: any): o is SizeConstraintStatement {
-    return _smithy.isa(o, "SizeConstraintStatement");
+    return __isa(o, "SizeConstraintStatement");
   }
 }
 
@@ -3209,7 +3212,7 @@ export interface SqliMatchStatement {
 
 export namespace SqliMatchStatement {
   export function isa(o: any): o is SqliMatchStatement {
-    return _smithy.isa(o, "SqliMatchStatement");
+    return __isa(o, "SqliMatchStatement");
   }
 }
 
@@ -3311,7 +3314,7 @@ export interface Statement {
 
 export namespace Statement {
   export function isa(o: any): o is Statement {
-    return _smithy.isa(o, "Statement");
+    return __isa(o, "Statement");
   }
 }
 
@@ -3336,7 +3339,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -3361,7 +3364,7 @@ export interface TagInfoForResource {
 
 export namespace TagInfoForResource {
   export function isa(o: any): o is TagInfoForResource {
-    return _smithy.isa(o, "TagInfoForResource");
+    return __isa(o, "TagInfoForResource");
   }
 }
 
@@ -3380,7 +3383,7 @@ export interface TagResourceRequest {
 
 export namespace TagResourceRequest {
   export function isa(o: any): o is TagResourceRequest {
-    return _smithy.isa(o, "TagResourceRequest");
+    return __isa(o, "TagResourceRequest");
   }
 }
 
@@ -3390,7 +3393,7 @@ export interface TagResourceResponse extends $MetadataBearer {
 
 export namespace TagResourceResponse {
   export function isa(o: any): o is TagResourceResponse {
-    return _smithy.isa(o, "TagResourceResponse");
+    return __isa(o, "TagResourceResponse");
   }
 }
 
@@ -3507,7 +3510,7 @@ export interface TextTransformation {
 
 export namespace TextTransformation {
   export function isa(o: any): o is TextTransformation {
-    return _smithy.isa(o, "TextTransformation");
+    return __isa(o, "TextTransformation");
   }
 }
 
@@ -3549,7 +3552,7 @@ export interface TimeWindow {
 
 export namespace TimeWindow {
   export function isa(o: any): o is TimeWindow {
-    return _smithy.isa(o, "TimeWindow");
+    return __isa(o, "TimeWindow");
   }
 }
 
@@ -3568,7 +3571,7 @@ export interface UntagResourceRequest {
 
 export namespace UntagResourceRequest {
   export function isa(o: any): o is UntagResourceRequest {
-    return _smithy.isa(o, "UntagResourceRequest");
+    return __isa(o, "UntagResourceRequest");
   }
 }
 
@@ -3578,7 +3581,7 @@ export interface UntagResourceResponse extends $MetadataBearer {
 
 export namespace UntagResourceResponse {
   export function isa(o: any): o is UntagResourceResponse {
-    return _smithy.isa(o, "UntagResourceResponse");
+    return __isa(o, "UntagResourceResponse");
   }
 }
 
@@ -3644,7 +3647,7 @@ export interface UpdateIPSetRequest {
 
 export namespace UpdateIPSetRequest {
   export function isa(o: any): o is UpdateIPSetRequest {
-    return _smithy.isa(o, "UpdateIPSetRequest");
+    return __isa(o, "UpdateIPSetRequest");
   }
 }
 
@@ -3658,7 +3661,7 @@ export interface UpdateIPSetResponse extends $MetadataBearer {
 
 export namespace UpdateIPSetResponse {
   export function isa(o: any): o is UpdateIPSetResponse {
-    return _smithy.isa(o, "UpdateIPSetResponse");
+    return __isa(o, "UpdateIPSetResponse");
   }
 }
 
@@ -3706,7 +3709,7 @@ export interface UpdateRegexPatternSetRequest {
 
 export namespace UpdateRegexPatternSetRequest {
   export function isa(o: any): o is UpdateRegexPatternSetRequest {
-    return _smithy.isa(o, "UpdateRegexPatternSetRequest");
+    return __isa(o, "UpdateRegexPatternSetRequest");
   }
 }
 
@@ -3720,7 +3723,7 @@ export interface UpdateRegexPatternSetResponse extends $MetadataBearer {
 
 export namespace UpdateRegexPatternSetResponse {
   export function isa(o: any): o is UpdateRegexPatternSetResponse {
-    return _smithy.isa(o, "UpdateRegexPatternSetResponse");
+    return __isa(o, "UpdateRegexPatternSetResponse");
   }
 }
 
@@ -3776,7 +3779,7 @@ export interface UpdateRuleGroupRequest {
 
 export namespace UpdateRuleGroupRequest {
   export function isa(o: any): o is UpdateRuleGroupRequest {
-    return _smithy.isa(o, "UpdateRuleGroupRequest");
+    return __isa(o, "UpdateRuleGroupRequest");
   }
 }
 
@@ -3790,7 +3793,7 @@ export interface UpdateRuleGroupResponse extends $MetadataBearer {
 
 export namespace UpdateRuleGroupResponse {
   export function isa(o: any): o is UpdateRuleGroupResponse {
-    return _smithy.isa(o, "UpdateRuleGroupResponse");
+    return __isa(o, "UpdateRuleGroupResponse");
   }
 }
 
@@ -3851,7 +3854,7 @@ export interface UpdateWebACLRequest {
 
 export namespace UpdateWebACLRequest {
   export function isa(o: any): o is UpdateWebACLRequest {
-    return _smithy.isa(o, "UpdateWebACLRequest");
+    return __isa(o, "UpdateWebACLRequest");
   }
 }
 
@@ -3865,7 +3868,7 @@ export interface UpdateWebACLResponse extends $MetadataBearer {
 
 export namespace UpdateWebACLResponse {
   export function isa(o: any): o is UpdateWebACLResponse {
-    return _smithy.isa(o, "UpdateWebACLResponse");
+    return __isa(o, "UpdateWebACLResponse");
   }
 }
 
@@ -3881,7 +3884,7 @@ export interface UriPath {
 
 export namespace UriPath {
   export function isa(o: any): o is UriPath {
-    return _smithy.isa(o, "UriPath");
+    return __isa(o, "UriPath");
   }
 }
 
@@ -3914,7 +3917,7 @@ export interface VisibilityConfig {
 
 export namespace VisibilityConfig {
   export function isa(o: any): o is VisibilityConfig {
-    return _smithy.isa(o, "VisibilityConfig");
+    return __isa(o, "VisibilityConfig");
   }
 }
 
@@ -3922,7 +3925,7 @@ export namespace VisibilityConfig {
  * <p>AWS WAF couldn’t perform the operation because your resource is being used by another resource or it’s associated with another resource. </p>
  */
 export interface WAFAssociatedItemException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "WAFAssociatedItemException";
   $fault: "client";
@@ -3931,7 +3934,7 @@ export interface WAFAssociatedItemException
 
 export namespace WAFAssociatedItemException {
   export function isa(o: any): o is WAFAssociatedItemException {
-    return _smithy.isa(o, "WAFAssociatedItemException");
+    return __isa(o, "WAFAssociatedItemException");
   }
 }
 
@@ -3939,7 +3942,7 @@ export namespace WAFAssociatedItemException {
  * <p>AWS WAF couldn’t perform the operation because the resource that you tried to save is a duplicate of an existing one.</p>
  */
 export interface WAFDuplicateItemException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "WAFDuplicateItemException";
   $fault: "client";
@@ -3948,7 +3951,7 @@ export interface WAFDuplicateItemException
 
 export namespace WAFDuplicateItemException {
   export function isa(o: any): o is WAFDuplicateItemException {
-    return _smithy.isa(o, "WAFDuplicateItemException");
+    return __isa(o, "WAFDuplicateItemException");
   }
 }
 
@@ -3956,7 +3959,7 @@ export namespace WAFDuplicateItemException {
  * <p>Your request is valid, but AWS WAF couldn’t perform the operation because of a system problem. Retry your request. </p>
  */
 export interface WAFInternalErrorException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "WAFInternalErrorException";
   $fault: "server";
@@ -3965,7 +3968,7 @@ export interface WAFInternalErrorException
 
 export namespace WAFInternalErrorException {
   export function isa(o: any): o is WAFInternalErrorException {
-    return _smithy.isa(o, "WAFInternalErrorException");
+    return __isa(o, "WAFInternalErrorException");
   }
 }
 
@@ -3988,7 +3991,7 @@ export namespace WAFInternalErrorException {
  *          </ul>
  */
 export interface WAFInvalidParameterException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "WAFInvalidParameterException";
   $fault: "client";
@@ -4000,7 +4003,7 @@ export interface WAFInvalidParameterException
 
 export namespace WAFInvalidParameterException {
   export function isa(o: any): o is WAFInvalidParameterException {
-    return _smithy.isa(o, "WAFInvalidParameterException");
+    return __isa(o, "WAFInvalidParameterException");
   }
 }
 
@@ -4008,7 +4011,7 @@ export namespace WAFInvalidParameterException {
  * <p>AWS WAF couldn’t perform the operation because the resource that you requested isn’t valid. Check the resource, and try again.</p>
  */
 export interface WAFInvalidResourceException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "WAFInvalidResourceException";
   $fault: "client";
@@ -4017,7 +4020,7 @@ export interface WAFInvalidResourceException
 
 export namespace WAFInvalidResourceException {
   export function isa(o: any): o is WAFInvalidResourceException {
-    return _smithy.isa(o, "WAFInvalidResourceException");
+    return __isa(o, "WAFInvalidResourceException");
   }
 }
 
@@ -4027,7 +4030,7 @@ export namespace WAFInvalidResourceException {
  *          <a href="https://docs.aws.amazon.com/waf/latest/developerguide/limits.html">Limits</a> in the <i>AWS WAF Developer Guide</i>.</p>
  */
 export interface WAFLimitsExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "WAFLimitsExceededException";
   $fault: "client";
@@ -4036,7 +4039,7 @@ export interface WAFLimitsExceededException
 
 export namespace WAFLimitsExceededException {
   export function isa(o: any): o is WAFLimitsExceededException {
-    return _smithy.isa(o, "WAFLimitsExceededException");
+    return __isa(o, "WAFLimitsExceededException");
   }
 }
 
@@ -4044,7 +4047,7 @@ export namespace WAFLimitsExceededException {
  * <p>AWS WAF couldn’t perform the operation because your resource doesn’t exist. </p>
  */
 export interface WAFNonexistentItemException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "WAFNonexistentItemException";
   $fault: "client";
@@ -4053,7 +4056,7 @@ export interface WAFNonexistentItemException
 
 export namespace WAFNonexistentItemException {
   export function isa(o: any): o is WAFNonexistentItemException {
-    return _smithy.isa(o, "WAFNonexistentItemException");
+    return __isa(o, "WAFNonexistentItemException");
   }
 }
 
@@ -4061,7 +4064,7 @@ export namespace WAFNonexistentItemException {
  * <p>AWS WAF couldn’t save your changes because you tried to update or delete a resource that has changed since you last retrieved it. Get the resource again, make any changes you need to make to the new copy, and retry your operation. </p>
  */
 export interface WAFOptimisticLockException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "WAFOptimisticLockException";
   $fault: "client";
@@ -4070,7 +4073,7 @@ export interface WAFOptimisticLockException
 
 export namespace WAFOptimisticLockException {
   export function isa(o: any): o is WAFOptimisticLockException {
-    return _smithy.isa(o, "WAFOptimisticLockException");
+    return __isa(o, "WAFOptimisticLockException");
   }
 }
 
@@ -4078,7 +4081,7 @@ export namespace WAFOptimisticLockException {
  * <p>AWS WAF is not able to access the service linked role. This can be caused by a previous <code>PutLoggingConfiguration</code> request, which can lock the service linked role for about 20 seconds. Please try your request again. The service linked role can also be locked by a previous <code>DeleteServiceLinkedRole</code> request, which can lock the role for 15 minutes or more. If you recently made a call to <code>DeleteServiceLinkedRole</code>, wait at least 15 minutes and try the request again. If you receive this same exception again, you will have to wait additional time until the role is unlocked.</p>
  */
 export interface WAFServiceLinkedRoleErrorException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "WAFServiceLinkedRoleErrorException";
   $fault: "client";
@@ -4087,7 +4090,7 @@ export interface WAFServiceLinkedRoleErrorException
 
 export namespace WAFServiceLinkedRoleErrorException {
   export function isa(o: any): o is WAFServiceLinkedRoleErrorException {
-    return _smithy.isa(o, "WAFServiceLinkedRoleErrorException");
+    return __isa(o, "WAFServiceLinkedRoleErrorException");
   }
 }
 
@@ -4095,7 +4098,7 @@ export namespace WAFServiceLinkedRoleErrorException {
  * <p>An error occurred during the tagging operation. Retry your request.</p>
  */
 export interface WAFTagOperationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "WAFTagOperationException";
   $fault: "client";
@@ -4104,7 +4107,7 @@ export interface WAFTagOperationException
 
 export namespace WAFTagOperationException {
   export function isa(o: any): o is WAFTagOperationException {
-    return _smithy.isa(o, "WAFTagOperationException");
+    return __isa(o, "WAFTagOperationException");
   }
 }
 
@@ -4112,7 +4115,7 @@ export namespace WAFTagOperationException {
  * <p>AWS WAF couldn’t perform your tagging operation because of an internal error. Retry your request.</p>
  */
 export interface WAFTagOperationInternalErrorException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "WAFTagOperationInternalErrorException";
   $fault: "server";
@@ -4121,7 +4124,7 @@ export interface WAFTagOperationInternalErrorException
 
 export namespace WAFTagOperationInternalErrorException {
   export function isa(o: any): o is WAFTagOperationInternalErrorException {
-    return _smithy.isa(o, "WAFTagOperationInternalErrorException");
+    return __isa(o, "WAFTagOperationInternalErrorException");
   }
 }
 
@@ -4129,7 +4132,7 @@ export namespace WAFTagOperationInternalErrorException {
  * <p>AWS WAF couldn’t retrieve the resource that you requested. Retry your request.</p>
  */
 export interface WAFUnavailableEntityException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "WAFUnavailableEntityException";
   $fault: "client";
@@ -4138,7 +4141,7 @@ export interface WAFUnavailableEntityException
 
 export namespace WAFUnavailableEntityException {
   export function isa(o: any): o is WAFUnavailableEntityException {
-    return _smithy.isa(o, "WAFUnavailableEntityException");
+    return __isa(o, "WAFUnavailableEntityException");
   }
 }
 
@@ -4204,7 +4207,7 @@ export interface WebACL {
 
 export namespace WebACL {
   export function isa(o: any): o is WebACL {
-    return _smithy.isa(o, "WebACL");
+    return __isa(o, "WebACL");
   }
 }
 
@@ -4244,7 +4247,7 @@ export interface WebACLSummary {
 
 export namespace WebACLSummary {
   export function isa(o: any): o is WebACLSummary {
-    return _smithy.isa(o, "WebACLSummary");
+    return __isa(o, "WebACLSummary");
   }
 }
 
@@ -4275,6 +4278,6 @@ export interface XssMatchStatement {
 
 export namespace XssMatchStatement {
   export function isa(o: any): o is XssMatchStatement {
-    return _smithy.isa(o, "XssMatchStatement");
+    return __isa(o, "XssMatchStatement");
   }
 }

--- a/clients/client-workdocs/models/index.ts
+++ b/clients/client-workdocs/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export interface AbortDocumentVersionUploadRequest {
@@ -22,7 +25,7 @@ export interface AbortDocumentVersionUploadRequest {
 
 export namespace AbortDocumentVersionUploadRequest {
   export function isa(o: any): o is AbortDocumentVersionUploadRequest {
-    return _smithy.isa(o, "AbortDocumentVersionUploadRequest");
+    return __isa(o, "AbortDocumentVersionUploadRequest");
   }
 }
 
@@ -42,7 +45,7 @@ export interface ActivateUserRequest {
 
 export namespace ActivateUserRequest {
   export function isa(o: any): o is ActivateUserRequest {
-    return _smithy.isa(o, "ActivateUserRequest");
+    return __isa(o, "ActivateUserRequest");
   }
 }
 
@@ -56,7 +59,7 @@ export interface ActivateUserResponse extends $MetadataBearer {
 
 export namespace ActivateUserResponse {
   export function isa(o: any): o is ActivateUserResponse {
-    return _smithy.isa(o, "ActivateUserResponse");
+    return __isa(o, "ActivateUserResponse");
   }
 }
 
@@ -120,7 +123,7 @@ export interface Activity {
 
 export namespace Activity {
   export function isa(o: any): o is Activity {
-    return _smithy.isa(o, "Activity");
+    return __isa(o, "Activity");
   }
 }
 
@@ -186,7 +189,7 @@ export interface AddResourcePermissionsRequest {
 
 export namespace AddResourcePermissionsRequest {
   export function isa(o: any): o is AddResourcePermissionsRequest {
-    return _smithy.isa(o, "AddResourcePermissionsRequest");
+    return __isa(o, "AddResourcePermissionsRequest");
   }
 }
 
@@ -200,7 +203,7 @@ export interface AddResourcePermissionsResponse extends $MetadataBearer {
 
 export namespace AddResourcePermissionsResponse {
   export function isa(o: any): o is AddResourcePermissionsResponse {
-    return _smithy.isa(o, "AddResourcePermissionsResponse");
+    return __isa(o, "AddResourcePermissionsResponse");
   }
 }
 
@@ -265,7 +268,7 @@ export interface Comment {
 
 export namespace Comment {
   export function isa(o: any): o is Comment {
-    return _smithy.isa(o, "Comment");
+    return __isa(o, "Comment");
   }
 }
 
@@ -302,7 +305,7 @@ export interface CommentMetadata {
 
 export namespace CommentMetadata {
   export function isa(o: any): o is CommentMetadata {
-    return _smithy.isa(o, "CommentMetadata");
+    return __isa(o, "CommentMetadata");
   }
 }
 
@@ -321,7 +324,7 @@ export enum CommentVisibilityType {
  * <p>The resource hierarchy is changing.</p>
  */
 export interface ConcurrentModificationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ConcurrentModificationException";
   $fault: "client";
@@ -330,7 +333,7 @@ export interface ConcurrentModificationException
 
 export namespace ConcurrentModificationException {
   export function isa(o: any): o is ConcurrentModificationException {
-    return _smithy.isa(o, "ConcurrentModificationException");
+    return __isa(o, "ConcurrentModificationException");
   }
 }
 
@@ -338,7 +341,7 @@ export namespace ConcurrentModificationException {
  * <p>Another operation is in progress on the resource that conflicts with the current operation.</p>
  */
 export interface ConflictingOperationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ConflictingOperationException";
   $fault: "client";
@@ -347,7 +350,7 @@ export interface ConflictingOperationException
 
 export namespace ConflictingOperationException {
   export function isa(o: any): o is ConflictingOperationException {
-    return _smithy.isa(o, "ConflictingOperationException");
+    return __isa(o, "ConflictingOperationException");
   }
 }
 
@@ -400,7 +403,7 @@ export interface CreateCommentRequest {
 
 export namespace CreateCommentRequest {
   export function isa(o: any): o is CreateCommentRequest {
-    return _smithy.isa(o, "CreateCommentRequest");
+    return __isa(o, "CreateCommentRequest");
   }
 }
 
@@ -414,7 +417,7 @@ export interface CreateCommentResponse extends $MetadataBearer {
 
 export namespace CreateCommentResponse {
   export function isa(o: any): o is CreateCommentResponse {
-    return _smithy.isa(o, "CreateCommentResponse");
+    return __isa(o, "CreateCommentResponse");
   }
 }
 
@@ -445,7 +448,7 @@ export interface CreateCustomMetadataRequest {
 
 export namespace CreateCustomMetadataRequest {
   export function isa(o: any): o is CreateCustomMetadataRequest {
-    return _smithy.isa(o, "CreateCustomMetadataRequest");
+    return __isa(o, "CreateCustomMetadataRequest");
   }
 }
 
@@ -455,7 +458,7 @@ export interface CreateCustomMetadataResponse extends $MetadataBearer {
 
 export namespace CreateCustomMetadataResponse {
   export function isa(o: any): o is CreateCustomMetadataResponse {
-    return _smithy.isa(o, "CreateCustomMetadataResponse");
+    return __isa(o, "CreateCustomMetadataResponse");
   }
 }
 
@@ -480,7 +483,7 @@ export interface CreateFolderRequest {
 
 export namespace CreateFolderRequest {
   export function isa(o: any): o is CreateFolderRequest {
-    return _smithy.isa(o, "CreateFolderRequest");
+    return __isa(o, "CreateFolderRequest");
   }
 }
 
@@ -494,7 +497,7 @@ export interface CreateFolderResponse extends $MetadataBearer {
 
 export namespace CreateFolderResponse {
   export function isa(o: any): o is CreateFolderResponse {
-    return _smithy.isa(o, "CreateFolderResponse");
+    return __isa(o, "CreateFolderResponse");
   }
 }
 
@@ -519,7 +522,7 @@ export interface CreateLabelsRequest {
 
 export namespace CreateLabelsRequest {
   export function isa(o: any): o is CreateLabelsRequest {
-    return _smithy.isa(o, "CreateLabelsRequest");
+    return __isa(o, "CreateLabelsRequest");
   }
 }
 
@@ -529,7 +532,7 @@ export interface CreateLabelsResponse extends $MetadataBearer {
 
 export namespace CreateLabelsResponse {
   export function isa(o: any): o is CreateLabelsResponse {
-    return _smithy.isa(o, "CreateLabelsResponse");
+    return __isa(o, "CreateLabelsResponse");
   }
 }
 
@@ -560,7 +563,7 @@ export interface CreateNotificationSubscriptionRequest {
 
 export namespace CreateNotificationSubscriptionRequest {
   export function isa(o: any): o is CreateNotificationSubscriptionRequest {
-    return _smithy.isa(o, "CreateNotificationSubscriptionRequest");
+    return __isa(o, "CreateNotificationSubscriptionRequest");
   }
 }
 
@@ -575,7 +578,7 @@ export interface CreateNotificationSubscriptionResponse
 
 export namespace CreateNotificationSubscriptionResponse {
   export function isa(o: any): o is CreateNotificationSubscriptionResponse {
-    return _smithy.isa(o, "CreateNotificationSubscriptionResponse");
+    return __isa(o, "CreateNotificationSubscriptionResponse");
   }
 }
 
@@ -630,7 +633,7 @@ export interface CreateUserRequest {
 
 export namespace CreateUserRequest {
   export function isa(o: any): o is CreateUserRequest {
-    return _smithy.isa(o, "CreateUserRequest");
+    return __isa(o, "CreateUserRequest");
   }
 }
 
@@ -644,7 +647,7 @@ export interface CreateUserResponse extends $MetadataBearer {
 
 export namespace CreateUserResponse {
   export function isa(o: any): o is CreateUserResponse {
-    return _smithy.isa(o, "CreateUserResponse");
+    return __isa(o, "CreateUserResponse");
   }
 }
 
@@ -653,7 +656,7 @@ export namespace CreateUserResponse {
  *             resource.</p>
  */
 export interface CustomMetadataLimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "CustomMetadataLimitExceededException";
   $fault: "client";
@@ -662,7 +665,7 @@ export interface CustomMetadataLimitExceededException
 
 export namespace CustomMetadataLimitExceededException {
   export function isa(o: any): o is CustomMetadataLimitExceededException {
-    return _smithy.isa(o, "CustomMetadataLimitExceededException");
+    return __isa(o, "CustomMetadataLimitExceededException");
   }
 }
 
@@ -682,7 +685,7 @@ export interface DeactivateUserRequest {
 
 export namespace DeactivateUserRequest {
   export function isa(o: any): o is DeactivateUserRequest {
-    return _smithy.isa(o, "DeactivateUserRequest");
+    return __isa(o, "DeactivateUserRequest");
   }
 }
 
@@ -690,7 +693,7 @@ export namespace DeactivateUserRequest {
  * <p>The last user in the organization is being deactivated.</p>
  */
 export interface DeactivatingLastSystemUserException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DeactivatingLastSystemUserException";
   $fault: "client";
@@ -700,7 +703,7 @@ export interface DeactivatingLastSystemUserException
 
 export namespace DeactivatingLastSystemUserException {
   export function isa(o: any): o is DeactivatingLastSystemUserException {
-    return _smithy.isa(o, "DeactivatingLastSystemUserException");
+    return __isa(o, "DeactivatingLastSystemUserException");
   }
 }
 
@@ -730,7 +733,7 @@ export interface DeleteCommentRequest {
 
 export namespace DeleteCommentRequest {
   export function isa(o: any): o is DeleteCommentRequest {
-    return _smithy.isa(o, "DeleteCommentRequest");
+    return __isa(o, "DeleteCommentRequest");
   }
 }
 
@@ -767,7 +770,7 @@ export interface DeleteCustomMetadataRequest {
 
 export namespace DeleteCustomMetadataRequest {
   export function isa(o: any): o is DeleteCustomMetadataRequest {
-    return _smithy.isa(o, "DeleteCustomMetadataRequest");
+    return __isa(o, "DeleteCustomMetadataRequest");
   }
 }
 
@@ -777,7 +780,7 @@ export interface DeleteCustomMetadataResponse extends $MetadataBearer {
 
 export namespace DeleteCustomMetadataResponse {
   export function isa(o: any): o is DeleteCustomMetadataResponse {
-    return _smithy.isa(o, "DeleteCustomMetadataResponse");
+    return __isa(o, "DeleteCustomMetadataResponse");
   }
 }
 
@@ -797,7 +800,7 @@ export interface DeleteDocumentRequest {
 
 export namespace DeleteDocumentRequest {
   export function isa(o: any): o is DeleteDocumentRequest {
-    return _smithy.isa(o, "DeleteDocumentRequest");
+    return __isa(o, "DeleteDocumentRequest");
   }
 }
 
@@ -817,7 +820,7 @@ export interface DeleteFolderContentsRequest {
 
 export namespace DeleteFolderContentsRequest {
   export function isa(o: any): o is DeleteFolderContentsRequest {
-    return _smithy.isa(o, "DeleteFolderContentsRequest");
+    return __isa(o, "DeleteFolderContentsRequest");
   }
 }
 
@@ -837,7 +840,7 @@ export interface DeleteFolderRequest {
 
 export namespace DeleteFolderRequest {
   export function isa(o: any): o is DeleteFolderRequest {
-    return _smithy.isa(o, "DeleteFolderRequest");
+    return __isa(o, "DeleteFolderRequest");
   }
 }
 
@@ -867,7 +870,7 @@ export interface DeleteLabelsRequest {
 
 export namespace DeleteLabelsRequest {
   export function isa(o: any): o is DeleteLabelsRequest {
-    return _smithy.isa(o, "DeleteLabelsRequest");
+    return __isa(o, "DeleteLabelsRequest");
   }
 }
 
@@ -877,7 +880,7 @@ export interface DeleteLabelsResponse extends $MetadataBearer {
 
 export namespace DeleteLabelsResponse {
   export function isa(o: any): o is DeleteLabelsResponse {
-    return _smithy.isa(o, "DeleteLabelsResponse");
+    return __isa(o, "DeleteLabelsResponse");
   }
 }
 
@@ -896,7 +899,7 @@ export interface DeleteNotificationSubscriptionRequest {
 
 export namespace DeleteNotificationSubscriptionRequest {
   export function isa(o: any): o is DeleteNotificationSubscriptionRequest {
-    return _smithy.isa(o, "DeleteNotificationSubscriptionRequest");
+    return __isa(o, "DeleteNotificationSubscriptionRequest");
   }
 }
 
@@ -916,7 +919,7 @@ export interface DeleteUserRequest {
 
 export namespace DeleteUserRequest {
   export function isa(o: any): o is DeleteUserRequest {
-    return _smithy.isa(o, "DeleteUserRequest");
+    return __isa(o, "DeleteUserRequest");
   }
 }
 
@@ -985,7 +988,7 @@ export interface DescribeActivitiesRequest {
 
 export namespace DescribeActivitiesRequest {
   export function isa(o: any): o is DescribeActivitiesRequest {
-    return _smithy.isa(o, "DescribeActivitiesRequest");
+    return __isa(o, "DescribeActivitiesRequest");
   }
 }
 
@@ -1004,7 +1007,7 @@ export interface DescribeActivitiesResponse extends $MetadataBearer {
 
 export namespace DescribeActivitiesResponse {
   export function isa(o: any): o is DescribeActivitiesResponse {
-    return _smithy.isa(o, "DescribeActivitiesResponse");
+    return __isa(o, "DescribeActivitiesResponse");
   }
 }
 
@@ -1040,7 +1043,7 @@ export interface DescribeCommentsRequest {
 
 export namespace DescribeCommentsRequest {
   export function isa(o: any): o is DescribeCommentsRequest {
-    return _smithy.isa(o, "DescribeCommentsRequest");
+    return __isa(o, "DescribeCommentsRequest");
   }
 }
 
@@ -1060,7 +1063,7 @@ export interface DescribeCommentsResponse extends $MetadataBearer {
 
 export namespace DescribeCommentsResponse {
   export function isa(o: any): o is DescribeCommentsResponse {
-    return _smithy.isa(o, "DescribeCommentsResponse");
+    return __isa(o, "DescribeCommentsResponse");
   }
 }
 
@@ -1103,7 +1106,7 @@ export interface DescribeDocumentVersionsRequest {
 
 export namespace DescribeDocumentVersionsRequest {
   export function isa(o: any): o is DescribeDocumentVersionsRequest {
-    return _smithy.isa(o, "DescribeDocumentVersionsRequest");
+    return __isa(o, "DescribeDocumentVersionsRequest");
   }
 }
 
@@ -1123,7 +1126,7 @@ export interface DescribeDocumentVersionsResponse extends $MetadataBearer {
 
 export namespace DescribeDocumentVersionsResponse {
   export function isa(o: any): o is DescribeDocumentVersionsResponse {
-    return _smithy.isa(o, "DescribeDocumentVersionsResponse");
+    return __isa(o, "DescribeDocumentVersionsResponse");
   }
 }
 
@@ -1175,7 +1178,7 @@ export interface DescribeFolderContentsRequest {
 
 export namespace DescribeFolderContentsRequest {
   export function isa(o: any): o is DescribeFolderContentsRequest {
-    return _smithy.isa(o, "DescribeFolderContentsRequest");
+    return __isa(o, "DescribeFolderContentsRequest");
   }
 }
 
@@ -1200,7 +1203,7 @@ export interface DescribeFolderContentsResponse extends $MetadataBearer {
 
 export namespace DescribeFolderContentsResponse {
   export function isa(o: any): o is DescribeFolderContentsResponse {
-    return _smithy.isa(o, "DescribeFolderContentsResponse");
+    return __isa(o, "DescribeFolderContentsResponse");
   }
 }
 
@@ -1236,7 +1239,7 @@ export interface DescribeGroupsRequest {
 
 export namespace DescribeGroupsRequest {
   export function isa(o: any): o is DescribeGroupsRequest {
-    return _smithy.isa(o, "DescribeGroupsRequest");
+    return __isa(o, "DescribeGroupsRequest");
   }
 }
 
@@ -1256,7 +1259,7 @@ export interface DescribeGroupsResponse extends $MetadataBearer {
 
 export namespace DescribeGroupsResponse {
   export function isa(o: any): o is DescribeGroupsResponse {
-    return _smithy.isa(o, "DescribeGroupsResponse");
+    return __isa(o, "DescribeGroupsResponse");
   }
 }
 
@@ -1281,7 +1284,7 @@ export interface DescribeNotificationSubscriptionsRequest {
 
 export namespace DescribeNotificationSubscriptionsRequest {
   export function isa(o: any): o is DescribeNotificationSubscriptionsRequest {
-    return _smithy.isa(o, "DescribeNotificationSubscriptionsRequest");
+    return __isa(o, "DescribeNotificationSubscriptionsRequest");
   }
 }
 
@@ -1302,7 +1305,7 @@ export interface DescribeNotificationSubscriptionsResponse
 
 export namespace DescribeNotificationSubscriptionsResponse {
   export function isa(o: any): o is DescribeNotificationSubscriptionsResponse {
-    return _smithy.isa(o, "DescribeNotificationSubscriptionsResponse");
+    return __isa(o, "DescribeNotificationSubscriptionsResponse");
   }
 }
 
@@ -1338,7 +1341,7 @@ export interface DescribeResourcePermissionsRequest {
 
 export namespace DescribeResourcePermissionsRequest {
   export function isa(o: any): o is DescribeResourcePermissionsRequest {
-    return _smithy.isa(o, "DescribeResourcePermissionsRequest");
+    return __isa(o, "DescribeResourcePermissionsRequest");
   }
 }
 
@@ -1358,7 +1361,7 @@ export interface DescribeResourcePermissionsResponse extends $MetadataBearer {
 
 export namespace DescribeResourcePermissionsResponse {
   export function isa(o: any): o is DescribeResourcePermissionsResponse {
-    return _smithy.isa(o, "DescribeResourcePermissionsResponse");
+    return __isa(o, "DescribeResourcePermissionsResponse");
   }
 }
 
@@ -1384,7 +1387,7 @@ export interface DescribeRootFoldersRequest {
 
 export namespace DescribeRootFoldersRequest {
   export function isa(o: any): o is DescribeRootFoldersRequest {
-    return _smithy.isa(o, "DescribeRootFoldersRequest");
+    return __isa(o, "DescribeRootFoldersRequest");
   }
 }
 
@@ -1403,7 +1406,7 @@ export interface DescribeRootFoldersResponse extends $MetadataBearer {
 
 export namespace DescribeRootFoldersResponse {
   export function isa(o: any): o is DescribeRootFoldersResponse {
-    return _smithy.isa(o, "DescribeRootFoldersResponse");
+    return __isa(o, "DescribeRootFoldersResponse");
   }
 }
 
@@ -1465,7 +1468,7 @@ export interface DescribeUsersRequest {
 
 export namespace DescribeUsersRequest {
   export function isa(o: any): o is DescribeUsersRequest {
-    return _smithy.isa(o, "DescribeUsersRequest");
+    return __isa(o, "DescribeUsersRequest");
   }
 }
 
@@ -1490,7 +1493,7 @@ export interface DescribeUsersResponse extends $MetadataBearer {
 
 export namespace DescribeUsersResponse {
   export function isa(o: any): o is DescribeUsersResponse {
-    return _smithy.isa(o, "DescribeUsersResponse");
+    return __isa(o, "DescribeUsersResponse");
   }
 }
 
@@ -1499,7 +1502,7 @@ export namespace DescribeUsersResponse {
  *             create or delete a comment on that document.</p>
  */
 export interface DocumentLockedForCommentsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DocumentLockedForCommentsException";
   $fault: "client";
@@ -1508,7 +1511,7 @@ export interface DocumentLockedForCommentsException
 
 export namespace DocumentLockedForCommentsException {
   export function isa(o: any): o is DocumentLockedForCommentsException {
-    return _smithy.isa(o, "DocumentLockedForCommentsException");
+    return __isa(o, "DocumentLockedForCommentsException");
   }
 }
 
@@ -1560,7 +1563,7 @@ export interface DocumentMetadata {
 
 export namespace DocumentMetadata {
   export function isa(o: any): o is DocumentMetadata {
-    return _smithy.isa(o, "DocumentMetadata");
+    return __isa(o, "DocumentMetadata");
   }
 }
 
@@ -1653,7 +1656,7 @@ export interface DocumentVersionMetadata {
 
 export namespace DocumentVersionMetadata {
   export function isa(o: any): o is DocumentVersionMetadata {
-    return _smithy.isa(o, "DocumentVersionMetadata");
+    return __isa(o, "DocumentVersionMetadata");
   }
 }
 
@@ -1666,7 +1669,7 @@ export enum DocumentVersionStatus {
  *             version upload calls for a document that has been checked out from Web client.</p>
  */
 export interface DraftUploadOutOfSyncException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DraftUploadOutOfSyncException";
   $fault: "client";
@@ -1675,7 +1678,7 @@ export interface DraftUploadOutOfSyncException
 
 export namespace DraftUploadOutOfSyncException {
   export function isa(o: any): o is DraftUploadOutOfSyncException {
-    return _smithy.isa(o, "DraftUploadOutOfSyncException");
+    return __isa(o, "DraftUploadOutOfSyncException");
   }
 }
 
@@ -1683,7 +1686,7 @@ export namespace DraftUploadOutOfSyncException {
  * <p>The resource already exists.</p>
  */
 export interface EntityAlreadyExistsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "EntityAlreadyExistsException";
   $fault: "client";
@@ -1692,7 +1695,7 @@ export interface EntityAlreadyExistsException
 
 export namespace EntityAlreadyExistsException {
   export function isa(o: any): o is EntityAlreadyExistsException {
-    return _smithy.isa(o, "EntityAlreadyExistsException");
+    return __isa(o, "EntityAlreadyExistsException");
   }
 }
 
@@ -1700,7 +1703,7 @@ export namespace EntityAlreadyExistsException {
  * <p>The resource does not exist.</p>
  */
 export interface EntityNotExistsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "EntityNotExistsException";
   $fault: "client";
@@ -1710,7 +1713,7 @@ export interface EntityNotExistsException
 
 export namespace EntityNotExistsException {
   export function isa(o: any): o is EntityNotExistsException {
-    return _smithy.isa(o, "EntityNotExistsException");
+    return __isa(o, "EntityNotExistsException");
   }
 }
 
@@ -1720,7 +1723,7 @@ export namespace EntityNotExistsException {
  *             Directory.</p>
  */
 export interface FailedDependencyException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "FailedDependencyException";
   $fault: "client";
@@ -1729,7 +1732,7 @@ export interface FailedDependencyException
 
 export namespace FailedDependencyException {
   export function isa(o: any): o is FailedDependencyException {
-    return _smithy.isa(o, "FailedDependencyException");
+    return __isa(o, "FailedDependencyException");
   }
 }
 
@@ -1803,7 +1806,7 @@ export interface FolderMetadata {
 
 export namespace FolderMetadata {
   export function isa(o: any): o is FolderMetadata {
-    return _smithy.isa(o, "FolderMetadata");
+    return __isa(o, "FolderMetadata");
   }
 }
 
@@ -1818,7 +1821,7 @@ export interface GetCurrentUserRequest {
 
 export namespace GetCurrentUserRequest {
   export function isa(o: any): o is GetCurrentUserRequest {
-    return _smithy.isa(o, "GetCurrentUserRequest");
+    return __isa(o, "GetCurrentUserRequest");
   }
 }
 
@@ -1832,7 +1835,7 @@ export interface GetCurrentUserResponse extends $MetadataBearer {
 
 export namespace GetCurrentUserResponse {
   export function isa(o: any): o is GetCurrentUserResponse {
-    return _smithy.isa(o, "GetCurrentUserResponse");
+    return __isa(o, "GetCurrentUserResponse");
   }
 }
 
@@ -1868,7 +1871,7 @@ export interface GetDocumentPathRequest {
 
 export namespace GetDocumentPathRequest {
   export function isa(o: any): o is GetDocumentPathRequest {
-    return _smithy.isa(o, "GetDocumentPathRequest");
+    return __isa(o, "GetDocumentPathRequest");
   }
 }
 
@@ -1882,7 +1885,7 @@ export interface GetDocumentPathResponse extends $MetadataBearer {
 
 export namespace GetDocumentPathResponse {
   export function isa(o: any): o is GetDocumentPathResponse {
-    return _smithy.isa(o, "GetDocumentPathResponse");
+    return __isa(o, "GetDocumentPathResponse");
   }
 }
 
@@ -1907,7 +1910,7 @@ export interface GetDocumentRequest {
 
 export namespace GetDocumentRequest {
   export function isa(o: any): o is GetDocumentRequest {
-    return _smithy.isa(o, "GetDocumentRequest");
+    return __isa(o, "GetDocumentRequest");
   }
 }
 
@@ -1926,7 +1929,7 @@ export interface GetDocumentResponse extends $MetadataBearer {
 
 export namespace GetDocumentResponse {
   export function isa(o: any): o is GetDocumentResponse {
-    return _smithy.isa(o, "GetDocumentResponse");
+    return __isa(o, "GetDocumentResponse");
   }
 }
 
@@ -1962,7 +1965,7 @@ export interface GetDocumentVersionRequest {
 
 export namespace GetDocumentVersionRequest {
   export function isa(o: any): o is GetDocumentVersionRequest {
-    return _smithy.isa(o, "GetDocumentVersionRequest");
+    return __isa(o, "GetDocumentVersionRequest");
   }
 }
 
@@ -1981,7 +1984,7 @@ export interface GetDocumentVersionResponse extends $MetadataBearer {
 
 export namespace GetDocumentVersionResponse {
   export function isa(o: any): o is GetDocumentVersionResponse {
-    return _smithy.isa(o, "GetDocumentVersionResponse");
+    return __isa(o, "GetDocumentVersionResponse");
   }
 }
 
@@ -2017,7 +2020,7 @@ export interface GetFolderPathRequest {
 
 export namespace GetFolderPathRequest {
   export function isa(o: any): o is GetFolderPathRequest {
-    return _smithy.isa(o, "GetFolderPathRequest");
+    return __isa(o, "GetFolderPathRequest");
   }
 }
 
@@ -2031,7 +2034,7 @@ export interface GetFolderPathResponse extends $MetadataBearer {
 
 export namespace GetFolderPathResponse {
   export function isa(o: any): o is GetFolderPathResponse {
-    return _smithy.isa(o, "GetFolderPathResponse");
+    return __isa(o, "GetFolderPathResponse");
   }
 }
 
@@ -2056,7 +2059,7 @@ export interface GetFolderRequest {
 
 export namespace GetFolderRequest {
   export function isa(o: any): o is GetFolderRequest {
-    return _smithy.isa(o, "GetFolderRequest");
+    return __isa(o, "GetFolderRequest");
   }
 }
 
@@ -2075,7 +2078,7 @@ export interface GetFolderResponse extends $MetadataBearer {
 
 export namespace GetFolderResponse {
   export function isa(o: any): o is GetFolderResponse {
-    return _smithy.isa(o, "GetFolderResponse");
+    return __isa(o, "GetFolderResponse");
   }
 }
 
@@ -2112,7 +2115,7 @@ export interface GetResourcesRequest {
 
 export namespace GetResourcesRequest {
   export function isa(o: any): o is GetResourcesRequest {
-    return _smithy.isa(o, "GetResourcesRequest");
+    return __isa(o, "GetResourcesRequest");
   }
 }
 
@@ -2136,7 +2139,7 @@ export interface GetResourcesResponse extends $MetadataBearer {
 
 export namespace GetResourcesResponse {
   export function isa(o: any): o is GetResourcesResponse {
-    return _smithy.isa(o, "GetResourcesResponse");
+    return __isa(o, "GetResourcesResponse");
   }
 }
 
@@ -2158,7 +2161,7 @@ export interface GroupMetadata {
 
 export namespace GroupMetadata {
   export function isa(o: any): o is GroupMetadata {
-    return _smithy.isa(o, "GroupMetadata");
+    return __isa(o, "GroupMetadata");
   }
 }
 
@@ -2166,7 +2169,7 @@ export namespace GroupMetadata {
  * <p>The user is undergoing transfer of ownership.</p>
  */
 export interface IllegalUserStateException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "IllegalUserStateException";
   $fault: "client";
@@ -2175,7 +2178,7 @@ export interface IllegalUserStateException
 
 export namespace IllegalUserStateException {
   export function isa(o: any): o is IllegalUserStateException {
-    return _smithy.isa(o, "IllegalUserStateException");
+    return __isa(o, "IllegalUserStateException");
   }
 }
 
@@ -2225,7 +2228,7 @@ export interface InitiateDocumentVersionUploadRequest {
 
 export namespace InitiateDocumentVersionUploadRequest {
   export function isa(o: any): o is InitiateDocumentVersionUploadRequest {
-    return _smithy.isa(o, "InitiateDocumentVersionUploadRequest");
+    return __isa(o, "InitiateDocumentVersionUploadRequest");
   }
 }
 
@@ -2244,7 +2247,7 @@ export interface InitiateDocumentVersionUploadResponse extends $MetadataBearer {
 
 export namespace InitiateDocumentVersionUploadResponse {
   export function isa(o: any): o is InitiateDocumentVersionUploadResponse {
-    return _smithy.isa(o, "InitiateDocumentVersionUploadResponse");
+    return __isa(o, "InitiateDocumentVersionUploadResponse");
   }
 }
 
@@ -2252,7 +2255,7 @@ export namespace InitiateDocumentVersionUploadResponse {
  * <p>The pagination marker or limit fields are not valid.</p>
  */
 export interface InvalidArgumentException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidArgumentException";
   $fault: "client";
@@ -2261,7 +2264,7 @@ export interface InvalidArgumentException
 
 export namespace InvalidArgumentException {
   export function isa(o: any): o is InvalidArgumentException {
-    return _smithy.isa(o, "InvalidArgumentException");
+    return __isa(o, "InvalidArgumentException");
   }
 }
 
@@ -2269,7 +2272,7 @@ export namespace InvalidArgumentException {
  * <p>The requested operation is not allowed on the specified comment object.</p>
  */
 export interface InvalidCommentOperationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidCommentOperationException";
   $fault: "client";
@@ -2278,7 +2281,7 @@ export interface InvalidCommentOperationException
 
 export namespace InvalidCommentOperationException {
   export function isa(o: any): o is InvalidCommentOperationException {
-    return _smithy.isa(o, "InvalidCommentOperationException");
+    return __isa(o, "InvalidCommentOperationException");
   }
 }
 
@@ -2286,7 +2289,7 @@ export namespace InvalidCommentOperationException {
  * <p>The operation is invalid.</p>
  */
 export interface InvalidOperationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidOperationException";
   $fault: "client";
@@ -2295,7 +2298,7 @@ export interface InvalidOperationException
 
 export namespace InvalidOperationException {
   export function isa(o: any): o is InvalidOperationException {
-    return _smithy.isa(o, "InvalidOperationException");
+    return __isa(o, "InvalidOperationException");
   }
 }
 
@@ -2303,7 +2306,7 @@ export namespace InvalidOperationException {
  * <p>The password is invalid.</p>
  */
 export interface InvalidPasswordException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidPasswordException";
   $fault: "client";
@@ -2312,7 +2315,7 @@ export interface InvalidPasswordException
 
 export namespace InvalidPasswordException {
   export function isa(o: any): o is InvalidPasswordException {
-    return _smithy.isa(o, "InvalidPasswordException");
+    return __isa(o, "InvalidPasswordException");
   }
 }
 
@@ -2320,7 +2323,7 @@ export namespace InvalidPasswordException {
  * <p>The maximum of 100,000 folders under the parent folder has been exceeded.</p>
  */
 export interface LimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "LimitExceededException";
   $fault: "client";
@@ -2329,7 +2332,7 @@ export interface LimitExceededException
 
 export namespace LimitExceededException {
   export function isa(o: any): o is LimitExceededException {
-    return _smithy.isa(o, "LimitExceededException");
+    return __isa(o, "LimitExceededException");
   }
 }
 
@@ -2366,7 +2369,7 @@ export interface NotificationOptions {
 
 export namespace NotificationOptions {
   export function isa(o: any): o is NotificationOptions {
-    return _smithy.isa(o, "NotificationOptions");
+    return __isa(o, "NotificationOptions");
   }
 }
 
@@ -2393,7 +2396,7 @@ export interface Participants {
 
 export namespace Participants {
   export function isa(o: any): o is Participants {
-    return _smithy.isa(o, "Participants");
+    return __isa(o, "Participants");
   }
 }
 
@@ -2415,7 +2418,7 @@ export interface PermissionInfo {
 
 export namespace PermissionInfo {
   export function isa(o: any): o is PermissionInfo {
-    return _smithy.isa(o, "PermissionInfo");
+    return __isa(o, "PermissionInfo");
   }
 }
 
@@ -2442,7 +2445,7 @@ export interface Principal {
 
 export namespace Principal {
   export function isa(o: any): o is Principal {
-    return _smithy.isa(o, "Principal");
+    return __isa(o, "Principal");
   }
 }
 
@@ -2458,7 +2461,7 @@ export enum PrincipalType {
  * <p>The specified document version is not in the INITIALIZED state.</p>
  */
 export interface ProhibitedStateException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ProhibitedStateException";
   $fault: "client";
@@ -2467,7 +2470,7 @@ export interface ProhibitedStateException
 
 export namespace ProhibitedStateException {
   export function isa(o: any): o is ProhibitedStateException {
-    return _smithy.isa(o, "ProhibitedStateException");
+    return __isa(o, "ProhibitedStateException");
   }
 }
 
@@ -2487,7 +2490,7 @@ export interface RemoveAllResourcePermissionsRequest {
 
 export namespace RemoveAllResourcePermissionsRequest {
   export function isa(o: any): o is RemoveAllResourcePermissionsRequest {
-    return _smithy.isa(o, "RemoveAllResourcePermissionsRequest");
+    return __isa(o, "RemoveAllResourcePermissionsRequest");
   }
 }
 
@@ -2517,7 +2520,7 @@ export interface RemoveResourcePermissionRequest {
 
 export namespace RemoveResourcePermissionRequest {
   export function isa(o: any): o is RemoveResourcePermissionRequest {
-    return _smithy.isa(o, "RemoveResourcePermissionRequest");
+    return __isa(o, "RemoveResourcePermissionRequest");
   }
 }
 
@@ -2525,7 +2528,7 @@ export namespace RemoveResourcePermissionRequest {
  * <p>The response is too large to return. The request must include a filter to reduce the size of the response.</p>
  */
 export interface RequestedEntityTooLargeException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "RequestedEntityTooLargeException";
   $fault: "client";
@@ -2534,7 +2537,7 @@ export interface RequestedEntityTooLargeException
 
 export namespace RequestedEntityTooLargeException {
   export function isa(o: any): o is RequestedEntityTooLargeException {
-    return _smithy.isa(o, "RequestedEntityTooLargeException");
+    return __isa(o, "RequestedEntityTooLargeException");
   }
 }
 
@@ -2542,7 +2545,7 @@ export namespace RequestedEntityTooLargeException {
  * <p>The resource is already checked out.</p>
  */
 export interface ResourceAlreadyCheckedOutException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceAlreadyCheckedOutException";
   $fault: "client";
@@ -2551,7 +2554,7 @@ export interface ResourceAlreadyCheckedOutException
 
 export namespace ResourceAlreadyCheckedOutException {
   export function isa(o: any): o is ResourceAlreadyCheckedOutException {
-    return _smithy.isa(o, "ResourceAlreadyCheckedOutException");
+    return __isa(o, "ResourceAlreadyCheckedOutException");
   }
 }
 
@@ -2603,7 +2606,7 @@ export interface ResourceMetadata {
 
 export namespace ResourceMetadata {
   export function isa(o: any): o is ResourceMetadata {
-    return _smithy.isa(o, "ResourceMetadata");
+    return __isa(o, "ResourceMetadata");
   }
 }
 
@@ -2620,7 +2623,7 @@ export interface ResourcePath {
 
 export namespace ResourcePath {
   export function isa(o: any): o is ResourcePath {
-    return _smithy.isa(o, "ResourcePath");
+    return __isa(o, "ResourcePath");
   }
 }
 
@@ -2642,7 +2645,7 @@ export interface ResourcePathComponent {
 
 export namespace ResourcePathComponent {
   export function isa(o: any): o is ResourcePathComponent {
-    return _smithy.isa(o, "ResourcePathComponent");
+    return __isa(o, "ResourcePathComponent");
   }
 }
 
@@ -2679,7 +2682,7 @@ export enum RoleType {
  * <p>One or more of the dependencies is unavailable.</p>
  */
 export interface ServiceUnavailableException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ServiceUnavailableException";
   $fault: "server";
@@ -2688,7 +2691,7 @@ export interface ServiceUnavailableException
 
 export namespace ServiceUnavailableException {
   export function isa(o: any): o is ServiceUnavailableException {
-    return _smithy.isa(o, "ServiceUnavailableException");
+    return __isa(o, "ServiceUnavailableException");
   }
 }
 
@@ -2715,7 +2718,7 @@ export interface SharePrincipal {
 
 export namespace SharePrincipal {
   export function isa(o: any): o is SharePrincipal {
-    return _smithy.isa(o, "SharePrincipal");
+    return __isa(o, "SharePrincipal");
   }
 }
 
@@ -2757,7 +2760,7 @@ export interface ShareResult {
 
 export namespace ShareResult {
   export function isa(o: any): o is ShareResult {
-    return _smithy.isa(o, "ShareResult");
+    return __isa(o, "ShareResult");
   }
 }
 
@@ -2770,7 +2773,7 @@ export enum ShareStatusType {
  * <p>The storage limit has been exceeded.</p>
  */
 export interface StorageLimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "StorageLimitExceededException";
   $fault: "client";
@@ -2779,7 +2782,7 @@ export interface StorageLimitExceededException
 
 export namespace StorageLimitExceededException {
   export function isa(o: any): o is StorageLimitExceededException {
-    return _smithy.isa(o, "StorageLimitExceededException");
+    return __isa(o, "StorageLimitExceededException");
   }
 }
 
@@ -2787,7 +2790,7 @@ export namespace StorageLimitExceededException {
  * <p>The storage limit will be exceeded.</p>
  */
 export interface StorageLimitWillExceedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "StorageLimitWillExceedException";
   $fault: "client";
@@ -2796,7 +2799,7 @@ export interface StorageLimitWillExceedException
 
 export namespace StorageLimitWillExceedException {
   export function isa(o: any): o is StorageLimitWillExceedException {
-    return _smithy.isa(o, "StorageLimitWillExceedException");
+    return __isa(o, "StorageLimitWillExceedException");
   }
 }
 
@@ -2818,7 +2821,7 @@ export interface StorageRuleType {
 
 export namespace StorageRuleType {
   export function isa(o: any): o is StorageRuleType {
-    return _smithy.isa(o, "StorageRuleType");
+    return __isa(o, "StorageRuleType");
   }
 }
 
@@ -2850,7 +2853,7 @@ export interface Subscription {
 
 export namespace Subscription {
   export function isa(o: any): o is Subscription {
-    return _smithy.isa(o, "Subscription");
+    return __isa(o, "Subscription");
   }
 }
 
@@ -2867,7 +2870,7 @@ export enum SubscriptionType {
  *             resource.</p>
  */
 export interface TooManyLabelsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyLabelsException";
   $fault: "client";
@@ -2876,7 +2879,7 @@ export interface TooManyLabelsException
 
 export namespace TooManyLabelsException {
   export function isa(o: any): o is TooManyLabelsException {
-    return _smithy.isa(o, "TooManyLabelsException");
+    return __isa(o, "TooManyLabelsException");
   }
 }
 
@@ -2885,7 +2888,7 @@ export namespace TooManyLabelsException {
  *             instance.</p>
  */
 export interface TooManySubscriptionsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManySubscriptionsException";
   $fault: "client";
@@ -2894,7 +2897,7 @@ export interface TooManySubscriptionsException
 
 export namespace TooManySubscriptionsException {
   export function isa(o: any): o is TooManySubscriptionsException {
-    return _smithy.isa(o, "TooManySubscriptionsException");
+    return __isa(o, "TooManySubscriptionsException");
   }
 }
 
@@ -2902,7 +2905,7 @@ export namespace TooManySubscriptionsException {
  * <p>The operation is not permitted.</p>
  */
 export interface UnauthorizedOperationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UnauthorizedOperationException";
   $fault: "client";
@@ -2912,7 +2915,7 @@ export interface UnauthorizedOperationException
 
 export namespace UnauthorizedOperationException {
   export function isa(o: any): o is UnauthorizedOperationException {
-    return _smithy.isa(o, "UnauthorizedOperationException");
+    return __isa(o, "UnauthorizedOperationException");
   }
 }
 
@@ -2920,7 +2923,7 @@ export namespace UnauthorizedOperationException {
  * <p>The caller does not have access to perform the action on the resource.</p>
  */
 export interface UnauthorizedResourceAccessException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UnauthorizedResourceAccessException";
   $fault: "client";
@@ -2929,7 +2932,7 @@ export interface UnauthorizedResourceAccessException
 
 export namespace UnauthorizedResourceAccessException {
   export function isa(o: any): o is UnauthorizedResourceAccessException {
-    return _smithy.isa(o, "UnauthorizedResourceAccessException");
+    return __isa(o, "UnauthorizedResourceAccessException");
   }
 }
 
@@ -2965,7 +2968,7 @@ export interface UpdateDocumentRequest {
 
 export namespace UpdateDocumentRequest {
   export function isa(o: any): o is UpdateDocumentRequest {
-    return _smithy.isa(o, "UpdateDocumentRequest");
+    return __isa(o, "UpdateDocumentRequest");
   }
 }
 
@@ -2995,7 +2998,7 @@ export interface UpdateDocumentVersionRequest {
 
 export namespace UpdateDocumentVersionRequest {
   export function isa(o: any): o is UpdateDocumentVersionRequest {
-    return _smithy.isa(o, "UpdateDocumentVersionRequest");
+    return __isa(o, "UpdateDocumentVersionRequest");
   }
 }
 
@@ -3031,7 +3034,7 @@ export interface UpdateFolderRequest {
 
 export namespace UpdateFolderRequest {
   export function isa(o: any): o is UpdateFolderRequest {
-    return _smithy.isa(o, "UpdateFolderRequest");
+    return __isa(o, "UpdateFolderRequest");
   }
 }
 
@@ -3086,7 +3089,7 @@ export interface UpdateUserRequest {
 
 export namespace UpdateUserRequest {
   export function isa(o: any): o is UpdateUserRequest {
-    return _smithy.isa(o, "UpdateUserRequest");
+    return __isa(o, "UpdateUserRequest");
   }
 }
 
@@ -3100,7 +3103,7 @@ export interface UpdateUserResponse extends $MetadataBearer {
 
 export namespace UpdateUserResponse {
   export function isa(o: any): o is UpdateUserResponse {
-    return _smithy.isa(o, "UpdateUserResponse");
+    return __isa(o, "UpdateUserResponse");
   }
 }
 
@@ -3122,7 +3125,7 @@ export interface UploadMetadata {
 
 export namespace UploadMetadata {
   export function isa(o: any): o is UploadMetadata {
-    return _smithy.isa(o, "UploadMetadata");
+    return __isa(o, "UploadMetadata");
   }
 }
 
@@ -3209,7 +3212,7 @@ export interface User {
 
 export namespace User {
   export function isa(o: any): o is User {
-    return _smithy.isa(o, "User");
+    return __isa(o, "User");
   }
 }
 
@@ -3251,7 +3254,7 @@ export interface UserMetadata {
 
 export namespace UserMetadata {
   export function isa(o: any): o is UserMetadata {
-    return _smithy.isa(o, "UserMetadata");
+    return __isa(o, "UserMetadata");
   }
 }
 
@@ -3287,7 +3290,7 @@ export interface UserStorageMetadata {
 
 export namespace UserStorageMetadata {
   export function isa(o: any): o is UserStorageMetadata {
-    return _smithy.isa(o, "UserStorageMetadata");
+    return __isa(o, "UserStorageMetadata");
   }
 }
 

--- a/clients/client-workdocs/protocols/Aws_restJson1_1.ts
+++ b/clients/client-workdocs/protocols/Aws_restJson1_1.ts
@@ -215,7 +215,10 @@ import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  extendedEncodeURIComponent as __extendedEncodeURIComponent
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -230,29 +233,29 @@ export async function serializeAws_restJson1_1AbortDocumentVersionUploadCommand(
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.AuthenticationToken !== undefined) {
-    headers["Authentication"] = input.AuthenticationToken.toString();
+    headers["Authentication"] = input.AuthenticationToken;
   }
   let resolvedPath = "/api/v1/documents/{DocumentId}/versions/{VersionId}";
   if (input.DocumentId !== undefined) {
-    const labelValue: string = input.DocumentId.toString();
+    const labelValue: string = input.DocumentId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DocumentId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DocumentId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DocumentId.");
   }
   if (input.VersionId !== undefined) {
-    const labelValue: string = input.VersionId.toString();
+    const labelValue: string = input.VersionId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: VersionId.");
     }
     resolvedPath = resolvedPath.replace(
       "{VersionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: VersionId.");
@@ -273,17 +276,17 @@ export async function serializeAws_restJson1_1ActivateUserCommand(
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.AuthenticationToken !== undefined) {
-    headers["Authentication"] = input.AuthenticationToken.toString();
+    headers["Authentication"] = input.AuthenticationToken;
   }
   let resolvedPath = "/api/v1/users/{UserId}/activation";
   if (input.UserId !== undefined) {
-    const labelValue: string = input.UserId.toString();
+    const labelValue: string = input.UserId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: UserId.");
     }
     resolvedPath = resolvedPath.replace(
       "{UserId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: UserId.");
@@ -304,17 +307,17 @@ export async function serializeAws_restJson1_1AddResourcePermissionsCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.AuthenticationToken !== undefined) {
-    headers["Authentication"] = input.AuthenticationToken.toString();
+    headers["Authentication"] = input.AuthenticationToken;
   }
   let resolvedPath = "/api/v1/resources/{ResourceId}/permissions";
   if (input.ResourceId !== undefined) {
-    const labelValue: string = input.ResourceId.toString();
+    const labelValue: string = input.ResourceId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ResourceId.");
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ResourceId.");
@@ -353,30 +356,30 @@ export async function serializeAws_restJson1_1CreateCommentCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.AuthenticationToken !== undefined) {
-    headers["Authentication"] = input.AuthenticationToken.toString();
+    headers["Authentication"] = input.AuthenticationToken;
   }
   let resolvedPath =
     "/api/v1/documents/{DocumentId}/versions/{VersionId}/comment";
   if (input.DocumentId !== undefined) {
-    const labelValue: string = input.DocumentId.toString();
+    const labelValue: string = input.DocumentId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DocumentId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DocumentId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DocumentId.");
   }
   if (input.VersionId !== undefined) {
-    const labelValue: string = input.VersionId.toString();
+    const labelValue: string = input.VersionId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: VersionId.");
     }
     resolvedPath = resolvedPath.replace(
       "{VersionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: VersionId.");
@@ -416,24 +419,26 @@ export async function serializeAws_restJson1_1CreateCustomMetadataCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.AuthenticationToken !== undefined) {
-    headers["Authentication"] = input.AuthenticationToken.toString();
+    headers["Authentication"] = input.AuthenticationToken;
   }
   let resolvedPath = "/api/v1/resources/{ResourceId}/customMetadata";
   if (input.ResourceId !== undefined) {
-    const labelValue: string = input.ResourceId.toString();
+    const labelValue: string = input.ResourceId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ResourceId.");
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ResourceId.");
   }
   const query: any = {};
   if (input.VersionId !== undefined) {
-    query["versionid"] = input.VersionId.toString();
+    query[
+      __extendedEncodeURIComponent("versionid")
+    ] = __extendedEncodeURIComponent(input.VersionId);
   }
   let body: any;
   const bodyParams: any = {};
@@ -462,7 +467,7 @@ export async function serializeAws_restJson1_1CreateFolderCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.AuthenticationToken !== undefined) {
-    headers["Authentication"] = input.AuthenticationToken.toString();
+    headers["Authentication"] = input.AuthenticationToken;
   }
   let resolvedPath = "/api/v1/folders";
   let body: any;
@@ -491,17 +496,17 @@ export async function serializeAws_restJson1_1CreateLabelsCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.AuthenticationToken !== undefined) {
-    headers["Authentication"] = input.AuthenticationToken.toString();
+    headers["Authentication"] = input.AuthenticationToken;
   }
   let resolvedPath = "/api/v1/resources/{ResourceId}/labels";
   if (input.ResourceId !== undefined) {
-    const labelValue: string = input.ResourceId.toString();
+    const labelValue: string = input.ResourceId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ResourceId.");
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ResourceId.");
@@ -533,7 +538,7 @@ export async function serializeAws_restJson1_1CreateNotificationSubscriptionComm
   headers["Content-Type"] = "application/json";
   let resolvedPath = "/api/v1/organizations/{OrganizationId}/subscriptions";
   if (input.OrganizationId !== undefined) {
-    const labelValue: string = input.OrganizationId.toString();
+    const labelValue: string = input.OrganizationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: OrganizationId."
@@ -541,7 +546,7 @@ export async function serializeAws_restJson1_1CreateNotificationSubscriptionComm
     }
     resolvedPath = resolvedPath.replace(
       "{OrganizationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: OrganizationId.");
@@ -575,7 +580,7 @@ export async function serializeAws_restJson1_1CreateUserCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.AuthenticationToken !== undefined) {
-    headers["Authentication"] = input.AuthenticationToken.toString();
+    headers["Authentication"] = input.AuthenticationToken;
   }
   let resolvedPath = "/api/v1/users";
   let body: any;
@@ -625,17 +630,17 @@ export async function serializeAws_restJson1_1DeactivateUserCommand(
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.AuthenticationToken !== undefined) {
-    headers["Authentication"] = input.AuthenticationToken.toString();
+    headers["Authentication"] = input.AuthenticationToken;
   }
   let resolvedPath = "/api/v1/users/{UserId}/activation";
   if (input.UserId !== undefined) {
-    const labelValue: string = input.UserId.toString();
+    const labelValue: string = input.UserId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: UserId.");
     }
     resolvedPath = resolvedPath.replace(
       "{UserId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: UserId.");
@@ -656,42 +661,42 @@ export async function serializeAws_restJson1_1DeleteCommentCommand(
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.AuthenticationToken !== undefined) {
-    headers["Authentication"] = input.AuthenticationToken.toString();
+    headers["Authentication"] = input.AuthenticationToken;
   }
   let resolvedPath =
     "/api/v1/documents/{DocumentId}/versions/{VersionId}/comment/{CommentId}";
   if (input.CommentId !== undefined) {
-    const labelValue: string = input.CommentId.toString();
+    const labelValue: string = input.CommentId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: CommentId.");
     }
     resolvedPath = resolvedPath.replace(
       "{CommentId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: CommentId.");
   }
   if (input.DocumentId !== undefined) {
-    const labelValue: string = input.DocumentId.toString();
+    const labelValue: string = input.DocumentId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DocumentId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DocumentId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DocumentId.");
   }
   if (input.VersionId !== undefined) {
-    const labelValue: string = input.VersionId.toString();
+    const labelValue: string = input.VersionId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: VersionId.");
     }
     resolvedPath = resolvedPath.replace(
       "{VersionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: VersionId.");
@@ -712,30 +717,36 @@ export async function serializeAws_restJson1_1DeleteCustomMetadataCommand(
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.AuthenticationToken !== undefined) {
-    headers["Authentication"] = input.AuthenticationToken.toString();
+    headers["Authentication"] = input.AuthenticationToken;
   }
   let resolvedPath = "/api/v1/resources/{ResourceId}/customMetadata";
   if (input.ResourceId !== undefined) {
-    const labelValue: string = input.ResourceId.toString();
+    const labelValue: string = input.ResourceId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ResourceId.");
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ResourceId.");
   }
   const query: any = {};
   if (input.DeleteAll !== undefined) {
-    query["deleteAll"] = input.DeleteAll.toString();
+    query[
+      __extendedEncodeURIComponent("deleteAll")
+    ] = __extendedEncodeURIComponent(input.DeleteAll.toString());
   }
   if (input.Keys !== undefined) {
-    query["keys"] = input.Keys;
+    query[__extendedEncodeURIComponent("keys")] = input.Keys.map(entry =>
+      __extendedEncodeURIComponent(entry)
+    );
   }
   if (input.VersionId !== undefined) {
-    query["versionId"] = input.VersionId.toString();
+    query[
+      __extendedEncodeURIComponent("versionId")
+    ] = __extendedEncodeURIComponent(input.VersionId);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -754,17 +765,17 @@ export async function serializeAws_restJson1_1DeleteDocumentCommand(
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.AuthenticationToken !== undefined) {
-    headers["Authentication"] = input.AuthenticationToken.toString();
+    headers["Authentication"] = input.AuthenticationToken;
   }
   let resolvedPath = "/api/v1/documents/{DocumentId}";
   if (input.DocumentId !== undefined) {
-    const labelValue: string = input.DocumentId.toString();
+    const labelValue: string = input.DocumentId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DocumentId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DocumentId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DocumentId.");
@@ -785,17 +796,17 @@ export async function serializeAws_restJson1_1DeleteFolderCommand(
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.AuthenticationToken !== undefined) {
-    headers["Authentication"] = input.AuthenticationToken.toString();
+    headers["Authentication"] = input.AuthenticationToken;
   }
   let resolvedPath = "/api/v1/folders/{FolderId}";
   if (input.FolderId !== undefined) {
-    const labelValue: string = input.FolderId.toString();
+    const labelValue: string = input.FolderId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: FolderId.");
     }
     resolvedPath = resolvedPath.replace(
       "{FolderId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: FolderId.");
@@ -816,17 +827,17 @@ export async function serializeAws_restJson1_1DeleteFolderContentsCommand(
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.AuthenticationToken !== undefined) {
-    headers["Authentication"] = input.AuthenticationToken.toString();
+    headers["Authentication"] = input.AuthenticationToken;
   }
   let resolvedPath = "/api/v1/folders/{FolderId}/contents";
   if (input.FolderId !== undefined) {
-    const labelValue: string = input.FolderId.toString();
+    const labelValue: string = input.FolderId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: FolderId.");
     }
     resolvedPath = resolvedPath.replace(
       "{FolderId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: FolderId.");
@@ -847,27 +858,31 @@ export async function serializeAws_restJson1_1DeleteLabelsCommand(
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.AuthenticationToken !== undefined) {
-    headers["Authentication"] = input.AuthenticationToken.toString();
+    headers["Authentication"] = input.AuthenticationToken;
   }
   let resolvedPath = "/api/v1/resources/{ResourceId}/labels";
   if (input.ResourceId !== undefined) {
-    const labelValue: string = input.ResourceId.toString();
+    const labelValue: string = input.ResourceId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ResourceId.");
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ResourceId.");
   }
   const query: any = {};
   if (input.DeleteAll !== undefined) {
-    query["deleteAll"] = input.DeleteAll.toString();
+    query[
+      __extendedEncodeURIComponent("deleteAll")
+    ] = __extendedEncodeURIComponent(input.DeleteAll.toString());
   }
   if (input.Labels !== undefined) {
-    query["labels"] = input.Labels;
+    query[__extendedEncodeURIComponent("labels")] = input.Labels.map(entry =>
+      __extendedEncodeURIComponent(entry)
+    );
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -888,7 +903,7 @@ export async function serializeAws_restJson1_1DeleteNotificationSubscriptionComm
   let resolvedPath =
     "/api/v1/organizations/{OrganizationId}/subscriptions/{SubscriptionId}";
   if (input.OrganizationId !== undefined) {
-    const labelValue: string = input.OrganizationId.toString();
+    const labelValue: string = input.OrganizationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: OrganizationId."
@@ -896,13 +911,13 @@ export async function serializeAws_restJson1_1DeleteNotificationSubscriptionComm
     }
     resolvedPath = resolvedPath.replace(
       "{OrganizationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: OrganizationId.");
   }
   if (input.SubscriptionId !== undefined) {
-    const labelValue: string = input.SubscriptionId.toString();
+    const labelValue: string = input.SubscriptionId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: SubscriptionId."
@@ -910,7 +925,7 @@ export async function serializeAws_restJson1_1DeleteNotificationSubscriptionComm
     }
     resolvedPath = resolvedPath.replace(
       "{SubscriptionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: SubscriptionId.");
@@ -931,17 +946,17 @@ export async function serializeAws_restJson1_1DeleteUserCommand(
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.AuthenticationToken !== undefined) {
-    headers["Authentication"] = input.AuthenticationToken.toString();
+    headers["Authentication"] = input.AuthenticationToken;
   }
   let resolvedPath = "/api/v1/users/{UserId}";
   if (input.UserId !== undefined) {
-    const labelValue: string = input.UserId.toString();
+    const labelValue: string = input.UserId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: UserId.");
     }
     resolvedPath = resolvedPath.replace(
       "{UserId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: UserId.");
@@ -962,38 +977,56 @@ export async function serializeAws_restJson1_1DescribeActivitiesCommand(
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.AuthenticationToken !== undefined) {
-    headers["Authentication"] = input.AuthenticationToken.toString();
+    headers["Authentication"] = input.AuthenticationToken;
   }
   let resolvedPath = "/api/v1/activities";
   const query: any = {};
   if (input.ActivityTypes !== undefined) {
-    query["activityTypes"] = input.ActivityTypes.toString();
+    query[
+      __extendedEncodeURIComponent("activityTypes")
+    ] = __extendedEncodeURIComponent(input.ActivityTypes);
   }
   if (input.EndTime !== undefined) {
-    query["endTime"] = input.EndTime.toISOString();
+    query[
+      __extendedEncodeURIComponent("endTime")
+    ] = __extendedEncodeURIComponent(input.EndTime.toISOString());
   }
   if (input.IncludeIndirectActivities !== undefined) {
     query[
-      "includeIndirectActivities"
-    ] = input.IncludeIndirectActivities.toString();
+      __extendedEncodeURIComponent("includeIndirectActivities")
+    ] = __extendedEncodeURIComponent(
+      input.IncludeIndirectActivities.toString()
+    );
   }
   if (input.Limit !== undefined) {
-    query["limit"] = input.Limit.toString();
+    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
+      input.Limit.toString()
+    );
   }
   if (input.Marker !== undefined) {
-    query["marker"] = input.Marker.toString();
+    query[
+      __extendedEncodeURIComponent("marker")
+    ] = __extendedEncodeURIComponent(input.Marker);
   }
   if (input.OrganizationId !== undefined) {
-    query["organizationId"] = input.OrganizationId.toString();
+    query[
+      __extendedEncodeURIComponent("organizationId")
+    ] = __extendedEncodeURIComponent(input.OrganizationId);
   }
   if (input.ResourceId !== undefined) {
-    query["resourceId"] = input.ResourceId.toString();
+    query[
+      __extendedEncodeURIComponent("resourceId")
+    ] = __extendedEncodeURIComponent(input.ResourceId);
   }
   if (input.StartTime !== undefined) {
-    query["startTime"] = input.StartTime.toISOString();
+    query[
+      __extendedEncodeURIComponent("startTime")
+    ] = __extendedEncodeURIComponent(input.StartTime.toISOString());
   }
   if (input.UserId !== undefined) {
-    query["userId"] = input.UserId.toString();
+    query[
+      __extendedEncodeURIComponent("userId")
+    ] = __extendedEncodeURIComponent(input.UserId);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1012,40 +1045,44 @@ export async function serializeAws_restJson1_1DescribeCommentsCommand(
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.AuthenticationToken !== undefined) {
-    headers["Authentication"] = input.AuthenticationToken.toString();
+    headers["Authentication"] = input.AuthenticationToken;
   }
   let resolvedPath =
     "/api/v1/documents/{DocumentId}/versions/{VersionId}/comments";
   if (input.DocumentId !== undefined) {
-    const labelValue: string = input.DocumentId.toString();
+    const labelValue: string = input.DocumentId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DocumentId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DocumentId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DocumentId.");
   }
   if (input.VersionId !== undefined) {
-    const labelValue: string = input.VersionId.toString();
+    const labelValue: string = input.VersionId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: VersionId.");
     }
     resolvedPath = resolvedPath.replace(
       "{VersionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: VersionId.");
   }
   const query: any = {};
   if (input.Limit !== undefined) {
-    query["limit"] = input.Limit.toString();
+    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
+      input.Limit.toString()
+    );
   }
   if (input.Marker !== undefined) {
-    query["marker"] = input.Marker.toString();
+    query[
+      __extendedEncodeURIComponent("marker")
+    ] = __extendedEncodeURIComponent(input.Marker);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1064,33 +1101,41 @@ export async function serializeAws_restJson1_1DescribeDocumentVersionsCommand(
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.AuthenticationToken !== undefined) {
-    headers["Authentication"] = input.AuthenticationToken.toString();
+    headers["Authentication"] = input.AuthenticationToken;
   }
   let resolvedPath = "/api/v1/documents/{DocumentId}/versions";
   if (input.DocumentId !== undefined) {
-    const labelValue: string = input.DocumentId.toString();
+    const labelValue: string = input.DocumentId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DocumentId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DocumentId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DocumentId.");
   }
   const query: any = {};
   if (input.Fields !== undefined) {
-    query["fields"] = input.Fields.toString();
+    query[
+      __extendedEncodeURIComponent("fields")
+    ] = __extendedEncodeURIComponent(input.Fields);
   }
   if (input.Include !== undefined) {
-    query["include"] = input.Include.toString();
+    query[
+      __extendedEncodeURIComponent("include")
+    ] = __extendedEncodeURIComponent(input.Include);
   }
   if (input.Limit !== undefined) {
-    query["limit"] = input.Limit.toString();
+    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
+      input.Limit.toString()
+    );
   }
   if (input.Marker !== undefined) {
-    query["marker"] = input.Marker.toString();
+    query[
+      __extendedEncodeURIComponent("marker")
+    ] = __extendedEncodeURIComponent(input.Marker);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1109,39 +1154,51 @@ export async function serializeAws_restJson1_1DescribeFolderContentsCommand(
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.AuthenticationToken !== undefined) {
-    headers["Authentication"] = input.AuthenticationToken.toString();
+    headers["Authentication"] = input.AuthenticationToken;
   }
   let resolvedPath = "/api/v1/folders/{FolderId}/contents";
   if (input.FolderId !== undefined) {
-    const labelValue: string = input.FolderId.toString();
+    const labelValue: string = input.FolderId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: FolderId.");
     }
     resolvedPath = resolvedPath.replace(
       "{FolderId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: FolderId.");
   }
   const query: any = {};
   if (input.Include !== undefined) {
-    query["include"] = input.Include.toString();
+    query[
+      __extendedEncodeURIComponent("include")
+    ] = __extendedEncodeURIComponent(input.Include);
   }
   if (input.Limit !== undefined) {
-    query["limit"] = input.Limit.toString();
+    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
+      input.Limit.toString()
+    );
   }
   if (input.Marker !== undefined) {
-    query["marker"] = input.Marker.toString();
+    query[
+      __extendedEncodeURIComponent("marker")
+    ] = __extendedEncodeURIComponent(input.Marker);
   }
   if (input.Order !== undefined) {
-    query["order"] = input.Order.toString();
+    query[__extendedEncodeURIComponent("order")] = __extendedEncodeURIComponent(
+      input.Order
+    );
   }
   if (input.Sort !== undefined) {
-    query["sort"] = input.Sort.toString();
+    query[__extendedEncodeURIComponent("sort")] = __extendedEncodeURIComponent(
+      input.Sort
+    );
   }
   if (input.Type !== undefined) {
-    query["type"] = input.Type.toString();
+    query[__extendedEncodeURIComponent("type")] = __extendedEncodeURIComponent(
+      input.Type
+    );
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1160,21 +1217,29 @@ export async function serializeAws_restJson1_1DescribeGroupsCommand(
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.AuthenticationToken !== undefined) {
-    headers["Authentication"] = input.AuthenticationToken.toString();
+    headers["Authentication"] = input.AuthenticationToken;
   }
   let resolvedPath = "/api/v1/groups";
   const query: any = {};
   if (input.Limit !== undefined) {
-    query["limit"] = input.Limit.toString();
+    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
+      input.Limit.toString()
+    );
   }
   if (input.Marker !== undefined) {
-    query["marker"] = input.Marker.toString();
+    query[
+      __extendedEncodeURIComponent("marker")
+    ] = __extendedEncodeURIComponent(input.Marker);
   }
   if (input.OrganizationId !== undefined) {
-    query["organizationId"] = input.OrganizationId.toString();
+    query[
+      __extendedEncodeURIComponent("organizationId")
+    ] = __extendedEncodeURIComponent(input.OrganizationId);
   }
   if (input.SearchQuery !== undefined) {
-    query["searchQuery"] = input.SearchQuery.toString();
+    query[
+      __extendedEncodeURIComponent("searchQuery")
+    ] = __extendedEncodeURIComponent(input.SearchQuery);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1194,7 +1259,7 @@ export async function serializeAws_restJson1_1DescribeNotificationSubscriptionsC
   headers["Content-Type"] = "";
   let resolvedPath = "/api/v1/organizations/{OrganizationId}/subscriptions";
   if (input.OrganizationId !== undefined) {
-    const labelValue: string = input.OrganizationId.toString();
+    const labelValue: string = input.OrganizationId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: OrganizationId."
@@ -1202,17 +1267,21 @@ export async function serializeAws_restJson1_1DescribeNotificationSubscriptionsC
     }
     resolvedPath = resolvedPath.replace(
       "{OrganizationId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: OrganizationId.");
   }
   const query: any = {};
   if (input.Limit !== undefined) {
-    query["limit"] = input.Limit.toString();
+    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
+      input.Limit.toString()
+    );
   }
   if (input.Marker !== undefined) {
-    query["marker"] = input.Marker.toString();
+    query[
+      __extendedEncodeURIComponent("marker")
+    ] = __extendedEncodeURIComponent(input.Marker);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1231,30 +1300,36 @@ export async function serializeAws_restJson1_1DescribeResourcePermissionsCommand
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.AuthenticationToken !== undefined) {
-    headers["Authentication"] = input.AuthenticationToken.toString();
+    headers["Authentication"] = input.AuthenticationToken;
   }
   let resolvedPath = "/api/v1/resources/{ResourceId}/permissions";
   if (input.ResourceId !== undefined) {
-    const labelValue: string = input.ResourceId.toString();
+    const labelValue: string = input.ResourceId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ResourceId.");
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ResourceId.");
   }
   const query: any = {};
   if (input.Limit !== undefined) {
-    query["limit"] = input.Limit.toString();
+    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
+      input.Limit.toString()
+    );
   }
   if (input.Marker !== undefined) {
-    query["marker"] = input.Marker.toString();
+    query[
+      __extendedEncodeURIComponent("marker")
+    ] = __extendedEncodeURIComponent(input.Marker);
   }
   if (input.PrincipalId !== undefined) {
-    query["principalId"] = input.PrincipalId.toString();
+    query[
+      __extendedEncodeURIComponent("principalId")
+    ] = __extendedEncodeURIComponent(input.PrincipalId);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1273,15 +1348,19 @@ export async function serializeAws_restJson1_1DescribeRootFoldersCommand(
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.AuthenticationToken !== undefined) {
-    headers["Authentication"] = input.AuthenticationToken.toString();
+    headers["Authentication"] = input.AuthenticationToken;
   }
   let resolvedPath = "/api/v1/me/root";
   const query: any = {};
   if (input.Limit !== undefined) {
-    query["limit"] = input.Limit.toString();
+    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
+      input.Limit.toString()
+    );
   }
   if (input.Marker !== undefined) {
-    query["marker"] = input.Marker.toString();
+    query[
+      __extendedEncodeURIComponent("marker")
+    ] = __extendedEncodeURIComponent(input.Marker);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1300,36 +1379,54 @@ export async function serializeAws_restJson1_1DescribeUsersCommand(
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.AuthenticationToken !== undefined) {
-    headers["Authentication"] = input.AuthenticationToken.toString();
+    headers["Authentication"] = input.AuthenticationToken;
   }
   let resolvedPath = "/api/v1/users";
   const query: any = {};
   if (input.Fields !== undefined) {
-    query["fields"] = input.Fields.toString();
+    query[
+      __extendedEncodeURIComponent("fields")
+    ] = __extendedEncodeURIComponent(input.Fields);
   }
   if (input.Include !== undefined) {
-    query["include"] = input.Include.toString();
+    query[
+      __extendedEncodeURIComponent("include")
+    ] = __extendedEncodeURIComponent(input.Include);
   }
   if (input.Limit !== undefined) {
-    query["limit"] = input.Limit.toString();
+    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
+      input.Limit.toString()
+    );
   }
   if (input.Marker !== undefined) {
-    query["marker"] = input.Marker.toString();
+    query[
+      __extendedEncodeURIComponent("marker")
+    ] = __extendedEncodeURIComponent(input.Marker);
   }
   if (input.Order !== undefined) {
-    query["order"] = input.Order.toString();
+    query[__extendedEncodeURIComponent("order")] = __extendedEncodeURIComponent(
+      input.Order
+    );
   }
   if (input.OrganizationId !== undefined) {
-    query["organizationId"] = input.OrganizationId.toString();
+    query[
+      __extendedEncodeURIComponent("organizationId")
+    ] = __extendedEncodeURIComponent(input.OrganizationId);
   }
   if (input.Query !== undefined) {
-    query["query"] = input.Query.toString();
+    query[__extendedEncodeURIComponent("query")] = __extendedEncodeURIComponent(
+      input.Query
+    );
   }
   if (input.Sort !== undefined) {
-    query["sort"] = input.Sort.toString();
+    query[__extendedEncodeURIComponent("sort")] = __extendedEncodeURIComponent(
+      input.Sort
+    );
   }
   if (input.UserIds !== undefined) {
-    query["userIds"] = input.UserIds.toString();
+    query[
+      __extendedEncodeURIComponent("userIds")
+    ] = __extendedEncodeURIComponent(input.UserIds);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1348,7 +1445,7 @@ export async function serializeAws_restJson1_1GetCurrentUserCommand(
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.AuthenticationToken !== undefined) {
-    headers["Authentication"] = input.AuthenticationToken.toString();
+    headers["Authentication"] = input.AuthenticationToken;
   }
   let resolvedPath = "/api/v1/me";
   return new __HttpRequest({
@@ -1367,24 +1464,26 @@ export async function serializeAws_restJson1_1GetDocumentCommand(
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.AuthenticationToken !== undefined) {
-    headers["Authentication"] = input.AuthenticationToken.toString();
+    headers["Authentication"] = input.AuthenticationToken;
   }
   let resolvedPath = "/api/v1/documents/{DocumentId}";
   if (input.DocumentId !== undefined) {
-    const labelValue: string = input.DocumentId.toString();
+    const labelValue: string = input.DocumentId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DocumentId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DocumentId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DocumentId.");
   }
   const query: any = {};
   if (input.IncludeCustomMetadata !== undefined) {
-    query["includeCustomMetadata"] = input.IncludeCustomMetadata.toString();
+    query[
+      __extendedEncodeURIComponent("includeCustomMetadata")
+    ] = __extendedEncodeURIComponent(input.IncludeCustomMetadata.toString());
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1403,30 +1502,36 @@ export async function serializeAws_restJson1_1GetDocumentPathCommand(
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.AuthenticationToken !== undefined) {
-    headers["Authentication"] = input.AuthenticationToken.toString();
+    headers["Authentication"] = input.AuthenticationToken;
   }
   let resolvedPath = "/api/v1/documents/{DocumentId}/path";
   if (input.DocumentId !== undefined) {
-    const labelValue: string = input.DocumentId.toString();
+    const labelValue: string = input.DocumentId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DocumentId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DocumentId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DocumentId.");
   }
   const query: any = {};
   if (input.Fields !== undefined) {
-    query["fields"] = input.Fields.toString();
+    query[
+      __extendedEncodeURIComponent("fields")
+    ] = __extendedEncodeURIComponent(input.Fields);
   }
   if (input.Limit !== undefined) {
-    query["limit"] = input.Limit.toString();
+    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
+      input.Limit.toString()
+    );
   }
   if (input.Marker !== undefined) {
-    query["marker"] = input.Marker.toString();
+    query[
+      __extendedEncodeURIComponent("marker")
+    ] = __extendedEncodeURIComponent(input.Marker);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1445,39 +1550,43 @@ export async function serializeAws_restJson1_1GetDocumentVersionCommand(
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.AuthenticationToken !== undefined) {
-    headers["Authentication"] = input.AuthenticationToken.toString();
+    headers["Authentication"] = input.AuthenticationToken;
   }
   let resolvedPath = "/api/v1/documents/{DocumentId}/versions/{VersionId}";
   if (input.DocumentId !== undefined) {
-    const labelValue: string = input.DocumentId.toString();
+    const labelValue: string = input.DocumentId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DocumentId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DocumentId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DocumentId.");
   }
   if (input.VersionId !== undefined) {
-    const labelValue: string = input.VersionId.toString();
+    const labelValue: string = input.VersionId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: VersionId.");
     }
     resolvedPath = resolvedPath.replace(
       "{VersionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: VersionId.");
   }
   const query: any = {};
   if (input.Fields !== undefined) {
-    query["fields"] = input.Fields.toString();
+    query[
+      __extendedEncodeURIComponent("fields")
+    ] = __extendedEncodeURIComponent(input.Fields);
   }
   if (input.IncludeCustomMetadata !== undefined) {
-    query["includeCustomMetadata"] = input.IncludeCustomMetadata.toString();
+    query[
+      __extendedEncodeURIComponent("includeCustomMetadata")
+    ] = __extendedEncodeURIComponent(input.IncludeCustomMetadata.toString());
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1496,24 +1605,26 @@ export async function serializeAws_restJson1_1GetFolderCommand(
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.AuthenticationToken !== undefined) {
-    headers["Authentication"] = input.AuthenticationToken.toString();
+    headers["Authentication"] = input.AuthenticationToken;
   }
   let resolvedPath = "/api/v1/folders/{FolderId}";
   if (input.FolderId !== undefined) {
-    const labelValue: string = input.FolderId.toString();
+    const labelValue: string = input.FolderId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: FolderId.");
     }
     resolvedPath = resolvedPath.replace(
       "{FolderId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: FolderId.");
   }
   const query: any = {};
   if (input.IncludeCustomMetadata !== undefined) {
-    query["includeCustomMetadata"] = input.IncludeCustomMetadata.toString();
+    query[
+      __extendedEncodeURIComponent("includeCustomMetadata")
+    ] = __extendedEncodeURIComponent(input.IncludeCustomMetadata.toString());
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1532,30 +1643,36 @@ export async function serializeAws_restJson1_1GetFolderPathCommand(
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.AuthenticationToken !== undefined) {
-    headers["Authentication"] = input.AuthenticationToken.toString();
+    headers["Authentication"] = input.AuthenticationToken;
   }
   let resolvedPath = "/api/v1/folders/{FolderId}/path";
   if (input.FolderId !== undefined) {
-    const labelValue: string = input.FolderId.toString();
+    const labelValue: string = input.FolderId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: FolderId.");
     }
     resolvedPath = resolvedPath.replace(
       "{FolderId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: FolderId.");
   }
   const query: any = {};
   if (input.Fields !== undefined) {
-    query["fields"] = input.Fields.toString();
+    query[
+      __extendedEncodeURIComponent("fields")
+    ] = __extendedEncodeURIComponent(input.Fields);
   }
   if (input.Limit !== undefined) {
-    query["limit"] = input.Limit.toString();
+    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
+      input.Limit.toString()
+    );
   }
   if (input.Marker !== undefined) {
-    query["marker"] = input.Marker.toString();
+    query[
+      __extendedEncodeURIComponent("marker")
+    ] = __extendedEncodeURIComponent(input.Marker);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1574,21 +1691,29 @@ export async function serializeAws_restJson1_1GetResourcesCommand(
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.AuthenticationToken !== undefined) {
-    headers["Authentication"] = input.AuthenticationToken.toString();
+    headers["Authentication"] = input.AuthenticationToken;
   }
   let resolvedPath = "/api/v1/resources";
   const query: any = {};
   if (input.CollectionType !== undefined) {
-    query["collectionType"] = input.CollectionType.toString();
+    query[
+      __extendedEncodeURIComponent("collectionType")
+    ] = __extendedEncodeURIComponent(input.CollectionType);
   }
   if (input.Limit !== undefined) {
-    query["limit"] = input.Limit.toString();
+    query[__extendedEncodeURIComponent("limit")] = __extendedEncodeURIComponent(
+      input.Limit.toString()
+    );
   }
   if (input.Marker !== undefined) {
-    query["marker"] = input.Marker.toString();
+    query[
+      __extendedEncodeURIComponent("marker")
+    ] = __extendedEncodeURIComponent(input.Marker);
   }
   if (input.UserId !== undefined) {
-    query["userId"] = input.UserId.toString();
+    query[
+      __extendedEncodeURIComponent("userId")
+    ] = __extendedEncodeURIComponent(input.UserId);
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1607,7 +1732,7 @@ export async function serializeAws_restJson1_1InitiateDocumentVersionUploadComma
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.AuthenticationToken !== undefined) {
-    headers["Authentication"] = input.AuthenticationToken.toString();
+    headers["Authentication"] = input.AuthenticationToken;
   }
   let resolvedPath = "/api/v1/documents";
   let body: any;
@@ -1655,17 +1780,17 @@ export async function serializeAws_restJson1_1RemoveAllResourcePermissionsComman
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.AuthenticationToken !== undefined) {
-    headers["Authentication"] = input.AuthenticationToken.toString();
+    headers["Authentication"] = input.AuthenticationToken;
   }
   let resolvedPath = "/api/v1/resources/{ResourceId}/permissions";
   if (input.ResourceId !== undefined) {
-    const labelValue: string = input.ResourceId.toString();
+    const labelValue: string = input.ResourceId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ResourceId.");
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ResourceId.");
@@ -1686,11 +1811,11 @@ export async function serializeAws_restJson1_1RemoveResourcePermissionCommand(
   const headers: any = {};
   headers["Content-Type"] = "";
   if (input.AuthenticationToken !== undefined) {
-    headers["Authentication"] = input.AuthenticationToken.toString();
+    headers["Authentication"] = input.AuthenticationToken;
   }
   let resolvedPath = "/api/v1/resources/{ResourceId}/permissions/{PrincipalId}";
   if (input.PrincipalId !== undefined) {
-    const labelValue: string = input.PrincipalId.toString();
+    const labelValue: string = input.PrincipalId;
     if (labelValue.length <= 0) {
       throw new Error(
         "Empty value provided for input HTTP label: PrincipalId."
@@ -1698,26 +1823,28 @@ export async function serializeAws_restJson1_1RemoveResourcePermissionCommand(
     }
     resolvedPath = resolvedPath.replace(
       "{PrincipalId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: PrincipalId.");
   }
   if (input.ResourceId !== undefined) {
-    const labelValue: string = input.ResourceId.toString();
+    const labelValue: string = input.ResourceId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: ResourceId.");
     }
     resolvedPath = resolvedPath.replace(
       "{ResourceId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: ResourceId.");
   }
   const query: any = {};
   if (input.PrincipalType !== undefined) {
-    query["type"] = input.PrincipalType.toString();
+    query[__extendedEncodeURIComponent("type")] = __extendedEncodeURIComponent(
+      input.PrincipalType
+    );
   }
   return new __HttpRequest({
     ...context.endpoint,
@@ -1736,17 +1863,17 @@ export async function serializeAws_restJson1_1UpdateDocumentCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.AuthenticationToken !== undefined) {
-    headers["Authentication"] = input.AuthenticationToken.toString();
+    headers["Authentication"] = input.AuthenticationToken;
   }
   let resolvedPath = "/api/v1/documents/{DocumentId}";
   if (input.DocumentId !== undefined) {
-    const labelValue: string = input.DocumentId.toString();
+    const labelValue: string = input.DocumentId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DocumentId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DocumentId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DocumentId.");
@@ -1780,29 +1907,29 @@ export async function serializeAws_restJson1_1UpdateDocumentVersionCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.AuthenticationToken !== undefined) {
-    headers["Authentication"] = input.AuthenticationToken.toString();
+    headers["Authentication"] = input.AuthenticationToken;
   }
   let resolvedPath = "/api/v1/documents/{DocumentId}/versions/{VersionId}";
   if (input.DocumentId !== undefined) {
-    const labelValue: string = input.DocumentId.toString();
+    const labelValue: string = input.DocumentId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: DocumentId.");
     }
     resolvedPath = resolvedPath.replace(
       "{DocumentId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: DocumentId.");
   }
   if (input.VersionId !== undefined) {
-    const labelValue: string = input.VersionId.toString();
+    const labelValue: string = input.VersionId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: VersionId.");
     }
     resolvedPath = resolvedPath.replace(
       "{VersionId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: VersionId.");
@@ -1830,17 +1957,17 @@ export async function serializeAws_restJson1_1UpdateFolderCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.AuthenticationToken !== undefined) {
-    headers["Authentication"] = input.AuthenticationToken.toString();
+    headers["Authentication"] = input.AuthenticationToken;
   }
   let resolvedPath = "/api/v1/folders/{FolderId}";
   if (input.FolderId !== undefined) {
-    const labelValue: string = input.FolderId.toString();
+    const labelValue: string = input.FolderId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: FolderId.");
     }
     resolvedPath = resolvedPath.replace(
       "{FolderId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: FolderId.");
@@ -1874,17 +2001,17 @@ export async function serializeAws_restJson1_1UpdateUserCommand(
   const headers: any = {};
   headers["Content-Type"] = "application/json";
   if (input.AuthenticationToken !== undefined) {
-    headers["Authentication"] = input.AuthenticationToken.toString();
+    headers["Authentication"] = input.AuthenticationToken;
   }
   let resolvedPath = "/api/v1/users/{UserId}";
   if (input.UserId !== undefined) {
-    const labelValue: string = input.UserId.toString();
+    const labelValue: string = input.UserId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: UserId.");
     }
     resolvedPath = resolvedPath.replace(
       "{UserId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: UserId.");
@@ -1939,6 +2066,7 @@ export async function deserializeAws_restJson1_1AbortDocumentVersionUploadComman
   const contents: AbortDocumentVersionUploadCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2288,6 +2416,7 @@ export async function deserializeAws_restJson1_1CreateCustomMetadataCommand(
     $metadata: deserializeMetadata(output),
     __type: "CreateCustomMetadataResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2490,6 +2619,7 @@ export async function deserializeAws_restJson1_1CreateLabelsCommand(
     $metadata: deserializeMetadata(output),
     __type: "CreateLabelsResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2729,6 +2859,7 @@ export async function deserializeAws_restJson1_1DeactivateUserCommand(
   const contents: DeactivateUserCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2804,6 +2935,7 @@ export async function deserializeAws_restJson1_1DeleteCommentCommand(
   const contents: DeleteCommentCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2897,6 +3029,7 @@ export async function deserializeAws_restJson1_1DeleteCustomMetadataCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeleteCustomMetadataResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2982,6 +3115,7 @@ export async function deserializeAws_restJson1_1DeleteDocumentCommand(
   const contents: DeleteDocumentCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -3078,6 +3212,7 @@ export async function deserializeAws_restJson1_1DeleteFolderCommand(
   const contents: DeleteFolderCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -3177,6 +3312,7 @@ export async function deserializeAws_restJson1_1DeleteFolderContentsCommand(
   const contents: DeleteFolderContentsCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -3267,6 +3403,7 @@ export async function deserializeAws_restJson1_1DeleteLabelsCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeleteLabelsResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -3345,6 +3482,7 @@ export async function deserializeAws_restJson1_1DeleteNotificationSubscriptionCo
   const contents: DeleteNotificationSubscriptionCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -3413,6 +3551,7 @@ export async function deserializeAws_restJson1_1DeleteUserCommand(
   const contents: DeleteUserCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -5133,6 +5272,7 @@ export async function deserializeAws_restJson1_1RemoveAllResourcePermissionsComm
   const contents: RemoveAllResourcePermissionsCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -5204,6 +5344,7 @@ export async function deserializeAws_restJson1_1RemoveResourcePermissionCommand(
   const contents: RemoveResourcePermissionCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -5275,6 +5416,7 @@ export async function deserializeAws_restJson1_1UpdateDocumentCommand(
   const contents: UpdateDocumentCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -5388,6 +5530,7 @@ export async function deserializeAws_restJson1_1UpdateDocumentVersionCommand(
   const contents: UpdateDocumentVersionCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -5484,6 +5627,7 @@ export async function deserializeAws_restJson1_1UpdateFolderCommand(
   const contents: UpdateFolderCommandOutput = {
     $metadata: deserializeMetadata(output)
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 

--- a/clients/client-worklink/models/index.ts
+++ b/clients/client-worklink/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export interface AssociateDomainRequest {
@@ -26,7 +29,7 @@ export interface AssociateDomainRequest {
 
 export namespace AssociateDomainRequest {
   export function isa(o: any): o is AssociateDomainRequest {
-    return _smithy.isa(o, "AssociateDomainRequest");
+    return __isa(o, "AssociateDomainRequest");
   }
 }
 
@@ -36,7 +39,7 @@ export interface AssociateDomainResponse extends $MetadataBearer {
 
 export namespace AssociateDomainResponse {
   export function isa(o: any): o is AssociateDomainResponse {
-    return _smithy.isa(o, "AssociateDomainResponse");
+    return __isa(o, "AssociateDomainResponse");
   }
 }
 
@@ -63,7 +66,7 @@ export namespace AssociateWebsiteAuthorizationProviderRequest {
   export function isa(
     o: any
   ): o is AssociateWebsiteAuthorizationProviderRequest {
-    return _smithy.isa(o, "AssociateWebsiteAuthorizationProviderRequest");
+    return __isa(o, "AssociateWebsiteAuthorizationProviderRequest");
   }
 }
 
@@ -80,7 +83,7 @@ export namespace AssociateWebsiteAuthorizationProviderResponse {
   export function isa(
     o: any
   ): o is AssociateWebsiteAuthorizationProviderResponse {
-    return _smithy.isa(o, "AssociateWebsiteAuthorizationProviderResponse");
+    return __isa(o, "AssociateWebsiteAuthorizationProviderResponse");
   }
 }
 
@@ -106,7 +109,7 @@ export namespace AssociateWebsiteCertificateAuthorityRequest {
   export function isa(
     o: any
   ): o is AssociateWebsiteCertificateAuthorityRequest {
-    return _smithy.isa(o, "AssociateWebsiteCertificateAuthorityRequest");
+    return __isa(o, "AssociateWebsiteCertificateAuthorityRequest");
   }
 }
 
@@ -123,7 +126,7 @@ export namespace AssociateWebsiteCertificateAuthorityResponse {
   export function isa(
     o: any
   ): o is AssociateWebsiteCertificateAuthorityResponse {
-    return _smithy.isa(o, "AssociateWebsiteCertificateAuthorityResponse");
+    return __isa(o, "AssociateWebsiteCertificateAuthorityResponse");
   }
 }
 
@@ -152,7 +155,7 @@ export interface CreateFleetRequest {
 
 export namespace CreateFleetRequest {
   export function isa(o: any): o is CreateFleetRequest {
-    return _smithy.isa(o, "CreateFleetRequest");
+    return __isa(o, "CreateFleetRequest");
   }
 }
 
@@ -166,7 +169,7 @@ export interface CreateFleetResponse extends $MetadataBearer {
 
 export namespace CreateFleetResponse {
   export function isa(o: any): o is CreateFleetResponse {
-    return _smithy.isa(o, "CreateFleetResponse");
+    return __isa(o, "CreateFleetResponse");
   }
 }
 
@@ -180,7 +183,7 @@ export interface DeleteFleetRequest {
 
 export namespace DeleteFleetRequest {
   export function isa(o: any): o is DeleteFleetRequest {
-    return _smithy.isa(o, "DeleteFleetRequest");
+    return __isa(o, "DeleteFleetRequest");
   }
 }
 
@@ -190,7 +193,7 @@ export interface DeleteFleetResponse extends $MetadataBearer {
 
 export namespace DeleteFleetResponse {
   export function isa(o: any): o is DeleteFleetResponse {
-    return _smithy.isa(o, "DeleteFleetResponse");
+    return __isa(o, "DeleteFleetResponse");
   }
 }
 
@@ -204,7 +207,7 @@ export interface DescribeAuditStreamConfigurationRequest {
 
 export namespace DescribeAuditStreamConfigurationRequest {
   export function isa(o: any): o is DescribeAuditStreamConfigurationRequest {
-    return _smithy.isa(o, "DescribeAuditStreamConfigurationRequest");
+    return __isa(o, "DescribeAuditStreamConfigurationRequest");
   }
 }
 
@@ -219,7 +222,7 @@ export interface DescribeAuditStreamConfigurationResponse
 
 export namespace DescribeAuditStreamConfigurationResponse {
   export function isa(o: any): o is DescribeAuditStreamConfigurationResponse {
-    return _smithy.isa(o, "DescribeAuditStreamConfigurationResponse");
+    return __isa(o, "DescribeAuditStreamConfigurationResponse");
   }
 }
 
@@ -233,7 +236,7 @@ export interface DescribeCompanyNetworkConfigurationRequest {
 
 export namespace DescribeCompanyNetworkConfigurationRequest {
   export function isa(o: any): o is DescribeCompanyNetworkConfigurationRequest {
-    return _smithy.isa(o, "DescribeCompanyNetworkConfigurationRequest");
+    return __isa(o, "DescribeCompanyNetworkConfigurationRequest");
   }
 }
 
@@ -262,7 +265,7 @@ export namespace DescribeCompanyNetworkConfigurationResponse {
   export function isa(
     o: any
   ): o is DescribeCompanyNetworkConfigurationResponse {
-    return _smithy.isa(o, "DescribeCompanyNetworkConfigurationResponse");
+    return __isa(o, "DescribeCompanyNetworkConfigurationResponse");
   }
 }
 
@@ -276,7 +279,7 @@ export interface DescribeDevicePolicyConfigurationRequest {
 
 export namespace DescribeDevicePolicyConfigurationRequest {
   export function isa(o: any): o is DescribeDevicePolicyConfigurationRequest {
-    return _smithy.isa(o, "DescribeDevicePolicyConfigurationRequest");
+    return __isa(o, "DescribeDevicePolicyConfigurationRequest");
   }
 }
 
@@ -291,7 +294,7 @@ export interface DescribeDevicePolicyConfigurationResponse
 
 export namespace DescribeDevicePolicyConfigurationResponse {
   export function isa(o: any): o is DescribeDevicePolicyConfigurationResponse {
-    return _smithy.isa(o, "DescribeDevicePolicyConfigurationResponse");
+    return __isa(o, "DescribeDevicePolicyConfigurationResponse");
   }
 }
 
@@ -310,7 +313,7 @@ export interface DescribeDeviceRequest {
 
 export namespace DescribeDeviceRequest {
   export function isa(o: any): o is DescribeDeviceRequest {
-    return _smithy.isa(o, "DescribeDeviceRequest");
+    return __isa(o, "DescribeDeviceRequest");
   }
 }
 
@@ -364,7 +367,7 @@ export interface DescribeDeviceResponse extends $MetadataBearer {
 
 export namespace DescribeDeviceResponse {
   export function isa(o: any): o is DescribeDeviceResponse {
-    return _smithy.isa(o, "DescribeDeviceResponse");
+    return __isa(o, "DescribeDeviceResponse");
   }
 }
 
@@ -383,7 +386,7 @@ export interface DescribeDomainRequest {
 
 export namespace DescribeDomainRequest {
   export function isa(o: any): o is DescribeDomainRequest {
-    return _smithy.isa(o, "DescribeDomainRequest");
+    return __isa(o, "DescribeDomainRequest");
   }
 }
 
@@ -417,7 +420,7 @@ export interface DescribeDomainResponse extends $MetadataBearer {
 
 export namespace DescribeDomainResponse {
   export function isa(o: any): o is DescribeDomainResponse {
-    return _smithy.isa(o, "DescribeDomainResponse");
+    return __isa(o, "DescribeDomainResponse");
   }
 }
 
@@ -431,7 +434,7 @@ export interface DescribeFleetMetadataRequest {
 
 export namespace DescribeFleetMetadataRequest {
   export function isa(o: any): o is DescribeFleetMetadataRequest {
-    return _smithy.isa(o, "DescribeFleetMetadataRequest");
+    return __isa(o, "DescribeFleetMetadataRequest");
   }
 }
 
@@ -476,7 +479,7 @@ export interface DescribeFleetMetadataResponse extends $MetadataBearer {
 
 export namespace DescribeFleetMetadataResponse {
   export function isa(o: any): o is DescribeFleetMetadataResponse {
-    return _smithy.isa(o, "DescribeFleetMetadataResponse");
+    return __isa(o, "DescribeFleetMetadataResponse");
   }
 }
 
@@ -492,7 +495,7 @@ export namespace DescribeIdentityProviderConfigurationRequest {
   export function isa(
     o: any
   ): o is DescribeIdentityProviderConfigurationRequest {
-    return _smithy.isa(o, "DescribeIdentityProviderConfigurationRequest");
+    return __isa(o, "DescribeIdentityProviderConfigurationRequest");
   }
 }
 
@@ -519,7 +522,7 @@ export namespace DescribeIdentityProviderConfigurationResponse {
   export function isa(
     o: any
   ): o is DescribeIdentityProviderConfigurationResponse {
-    return _smithy.isa(o, "DescribeIdentityProviderConfigurationResponse");
+    return __isa(o, "DescribeIdentityProviderConfigurationResponse");
   }
 }
 
@@ -538,7 +541,7 @@ export interface DescribeWebsiteCertificateAuthorityRequest {
 
 export namespace DescribeWebsiteCertificateAuthorityRequest {
   export function isa(o: any): o is DescribeWebsiteCertificateAuthorityRequest {
-    return _smithy.isa(o, "DescribeWebsiteCertificateAuthorityRequest");
+    return __isa(o, "DescribeWebsiteCertificateAuthorityRequest");
   }
 }
 
@@ -565,7 +568,7 @@ export namespace DescribeWebsiteCertificateAuthorityResponse {
   export function isa(
     o: any
   ): o is DescribeWebsiteCertificateAuthorityResponse {
-    return _smithy.isa(o, "DescribeWebsiteCertificateAuthorityResponse");
+    return __isa(o, "DescribeWebsiteCertificateAuthorityResponse");
   }
 }
 
@@ -592,7 +595,7 @@ export interface DeviceSummary {
 
 export namespace DeviceSummary {
   export function isa(o: any): o is DeviceSummary {
-    return _smithy.isa(o, "DeviceSummary");
+    return __isa(o, "DeviceSummary");
   }
 }
 
@@ -611,7 +614,7 @@ export interface DisassociateDomainRequest {
 
 export namespace DisassociateDomainRequest {
   export function isa(o: any): o is DisassociateDomainRequest {
-    return _smithy.isa(o, "DisassociateDomainRequest");
+    return __isa(o, "DisassociateDomainRequest");
   }
 }
 
@@ -621,7 +624,7 @@ export interface DisassociateDomainResponse extends $MetadataBearer {
 
 export namespace DisassociateDomainResponse {
   export function isa(o: any): o is DisassociateDomainResponse {
-    return _smithy.isa(o, "DisassociateDomainResponse");
+    return __isa(o, "DisassociateDomainResponse");
   }
 }
 
@@ -642,7 +645,7 @@ export namespace DisassociateWebsiteAuthorizationProviderRequest {
   export function isa(
     o: any
   ): o is DisassociateWebsiteAuthorizationProviderRequest {
-    return _smithy.isa(o, "DisassociateWebsiteAuthorizationProviderRequest");
+    return __isa(o, "DisassociateWebsiteAuthorizationProviderRequest");
   }
 }
 
@@ -655,7 +658,7 @@ export namespace DisassociateWebsiteAuthorizationProviderResponse {
   export function isa(
     o: any
   ): o is DisassociateWebsiteAuthorizationProviderResponse {
-    return _smithy.isa(o, "DisassociateWebsiteAuthorizationProviderResponse");
+    return __isa(o, "DisassociateWebsiteAuthorizationProviderResponse");
   }
 }
 
@@ -676,7 +679,7 @@ export namespace DisassociateWebsiteCertificateAuthorityRequest {
   export function isa(
     o: any
   ): o is DisassociateWebsiteCertificateAuthorityRequest {
-    return _smithy.isa(o, "DisassociateWebsiteCertificateAuthorityRequest");
+    return __isa(o, "DisassociateWebsiteCertificateAuthorityRequest");
   }
 }
 
@@ -689,7 +692,7 @@ export namespace DisassociateWebsiteCertificateAuthorityResponse {
   export function isa(
     o: any
   ): o is DisassociateWebsiteCertificateAuthorityResponse {
-    return _smithy.isa(o, "DisassociateWebsiteCertificateAuthorityResponse");
+    return __isa(o, "DisassociateWebsiteCertificateAuthorityResponse");
   }
 }
 
@@ -732,7 +735,7 @@ export interface DomainSummary {
 
 export namespace DomainSummary {
   export function isa(o: any): o is DomainSummary {
-    return _smithy.isa(o, "DomainSummary");
+    return __isa(o, "DomainSummary");
   }
 }
 
@@ -788,7 +791,7 @@ export interface FleetSummary {
 
 export namespace FleetSummary {
   export function isa(o: any): o is FleetSummary {
-    return _smithy.isa(o, "FleetSummary");
+    return __isa(o, "FleetSummary");
   }
 }
 
@@ -800,7 +803,7 @@ export enum IdentityProviderType {
  * <p>The service is temporarily unavailable.</p>
  */
 export interface InternalServerErrorException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InternalServerErrorException";
   $fault: "server";
@@ -809,7 +812,7 @@ export interface InternalServerErrorException
 
 export namespace InternalServerErrorException {
   export function isa(o: any): o is InternalServerErrorException {
-    return _smithy.isa(o, "InternalServerErrorException");
+    return __isa(o, "InternalServerErrorException");
   }
 }
 
@@ -817,7 +820,7 @@ export namespace InternalServerErrorException {
  * <p>The request is not valid.</p>
  */
 export interface InvalidRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidRequestException";
   $fault: "client";
@@ -826,7 +829,7 @@ export interface InvalidRequestException
 
 export namespace InvalidRequestException {
   export function isa(o: any): o is InvalidRequestException {
-    return _smithy.isa(o, "InvalidRequestException");
+    return __isa(o, "InvalidRequestException");
   }
 }
 
@@ -851,7 +854,7 @@ export interface ListDevicesRequest {
 
 export namespace ListDevicesRequest {
   export function isa(o: any): o is ListDevicesRequest {
-    return _smithy.isa(o, "ListDevicesRequest");
+    return __isa(o, "ListDevicesRequest");
   }
 }
 
@@ -871,7 +874,7 @@ export interface ListDevicesResponse extends $MetadataBearer {
 
 export namespace ListDevicesResponse {
   export function isa(o: any): o is ListDevicesResponse {
-    return _smithy.isa(o, "ListDevicesResponse");
+    return __isa(o, "ListDevicesResponse");
   }
 }
 
@@ -896,7 +899,7 @@ export interface ListDomainsRequest {
 
 export namespace ListDomainsRequest {
   export function isa(o: any): o is ListDomainsRequest {
-    return _smithy.isa(o, "ListDomainsRequest");
+    return __isa(o, "ListDomainsRequest");
   }
 }
 
@@ -916,7 +919,7 @@ export interface ListDomainsResponse extends $MetadataBearer {
 
 export namespace ListDomainsResponse {
   export function isa(o: any): o is ListDomainsResponse {
-    return _smithy.isa(o, "ListDomainsResponse");
+    return __isa(o, "ListDomainsResponse");
   }
 }
 
@@ -936,7 +939,7 @@ export interface ListFleetsRequest {
 
 export namespace ListFleetsRequest {
   export function isa(o: any): o is ListFleetsRequest {
-    return _smithy.isa(o, "ListFleetsRequest");
+    return __isa(o, "ListFleetsRequest");
   }
 }
 
@@ -956,7 +959,7 @@ export interface ListFleetsResponse extends $MetadataBearer {
 
 export namespace ListFleetsResponse {
   export function isa(o: any): o is ListFleetsResponse {
-    return _smithy.isa(o, "ListFleetsResponse");
+    return __isa(o, "ListFleetsResponse");
   }
 }
 
@@ -980,7 +983,7 @@ export interface ListWebsiteAuthorizationProvidersRequest {
 
 export namespace ListWebsiteAuthorizationProvidersRequest {
   export function isa(o: any): o is ListWebsiteAuthorizationProvidersRequest {
-    return _smithy.isa(o, "ListWebsiteAuthorizationProvidersRequest");
+    return __isa(o, "ListWebsiteAuthorizationProvidersRequest");
   }
 }
 
@@ -1000,7 +1003,7 @@ export interface ListWebsiteAuthorizationProvidersResponse
 
 export namespace ListWebsiteAuthorizationProvidersResponse {
   export function isa(o: any): o is ListWebsiteAuthorizationProvidersResponse {
-    return _smithy.isa(o, "ListWebsiteAuthorizationProvidersResponse");
+    return __isa(o, "ListWebsiteAuthorizationProvidersResponse");
   }
 }
 
@@ -1025,7 +1028,7 @@ export interface ListWebsiteCertificateAuthoritiesRequest {
 
 export namespace ListWebsiteCertificateAuthoritiesRequest {
   export function isa(o: any): o is ListWebsiteCertificateAuthoritiesRequest {
-    return _smithy.isa(o, "ListWebsiteCertificateAuthoritiesRequest");
+    return __isa(o, "ListWebsiteCertificateAuthoritiesRequest");
   }
 }
 
@@ -1047,7 +1050,7 @@ export interface ListWebsiteCertificateAuthoritiesResponse
 
 export namespace ListWebsiteCertificateAuthoritiesResponse {
   export function isa(o: any): o is ListWebsiteCertificateAuthoritiesResponse {
-    return _smithy.isa(o, "ListWebsiteCertificateAuthoritiesResponse");
+    return __isa(o, "ListWebsiteCertificateAuthoritiesResponse");
   }
 }
 
@@ -1055,7 +1058,7 @@ export namespace ListWebsiteCertificateAuthoritiesResponse {
  * <p>The resource already exists.</p>
  */
 export interface ResourceAlreadyExistsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceAlreadyExistsException";
   $fault: "client";
@@ -1064,7 +1067,7 @@ export interface ResourceAlreadyExistsException
 
 export namespace ResourceAlreadyExistsException {
   export function isa(o: any): o is ResourceAlreadyExistsException {
-    return _smithy.isa(o, "ResourceAlreadyExistsException");
+    return __isa(o, "ResourceAlreadyExistsException");
   }
 }
 
@@ -1072,7 +1075,7 @@ export namespace ResourceAlreadyExistsException {
  * <p>The requested resource was not found.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -1081,7 +1084,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -1100,7 +1103,7 @@ export interface RestoreDomainAccessRequest {
 
 export namespace RestoreDomainAccessRequest {
   export function isa(o: any): o is RestoreDomainAccessRequest {
-    return _smithy.isa(o, "RestoreDomainAccessRequest");
+    return __isa(o, "RestoreDomainAccessRequest");
   }
 }
 
@@ -1110,7 +1113,7 @@ export interface RestoreDomainAccessResponse extends $MetadataBearer {
 
 export namespace RestoreDomainAccessResponse {
   export function isa(o: any): o is RestoreDomainAccessResponse {
-    return _smithy.isa(o, "RestoreDomainAccessResponse");
+    return __isa(o, "RestoreDomainAccessResponse");
   }
 }
 
@@ -1129,7 +1132,7 @@ export interface RevokeDomainAccessRequest {
 
 export namespace RevokeDomainAccessRequest {
   export function isa(o: any): o is RevokeDomainAccessRequest {
-    return _smithy.isa(o, "RevokeDomainAccessRequest");
+    return __isa(o, "RevokeDomainAccessRequest");
   }
 }
 
@@ -1139,7 +1142,7 @@ export interface RevokeDomainAccessResponse extends $MetadataBearer {
 
 export namespace RevokeDomainAccessResponse {
   export function isa(o: any): o is RevokeDomainAccessResponse {
-    return _smithy.isa(o, "RevokeDomainAccessResponse");
+    return __isa(o, "RevokeDomainAccessResponse");
   }
 }
 
@@ -1158,7 +1161,7 @@ export interface SignOutUserRequest {
 
 export namespace SignOutUserRequest {
   export function isa(o: any): o is SignOutUserRequest {
-    return _smithy.isa(o, "SignOutUserRequest");
+    return __isa(o, "SignOutUserRequest");
   }
 }
 
@@ -1168,7 +1171,7 @@ export interface SignOutUserResponse extends $MetadataBearer {
 
 export namespace SignOutUserResponse {
   export function isa(o: any): o is SignOutUserResponse {
-    return _smithy.isa(o, "SignOutUserResponse");
+    return __isa(o, "SignOutUserResponse");
   }
 }
 
@@ -1176,7 +1179,7 @@ export namespace SignOutUserResponse {
  * <p>The number of requests exceeds the limit.</p>
  */
 export interface TooManyRequestsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "TooManyRequestsException";
   $fault: "client";
@@ -1185,7 +1188,7 @@ export interface TooManyRequestsException
 
 export namespace TooManyRequestsException {
   export function isa(o: any): o is TooManyRequestsException {
-    return _smithy.isa(o, "TooManyRequestsException");
+    return __isa(o, "TooManyRequestsException");
   }
 }
 
@@ -1193,7 +1196,7 @@ export namespace TooManyRequestsException {
  * <p>You are not authorized to perform this action.</p>
  */
 export interface UnauthorizedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UnauthorizedException";
   $fault: "client";
@@ -1202,7 +1205,7 @@ export interface UnauthorizedException
 
 export namespace UnauthorizedException {
   export function isa(o: any): o is UnauthorizedException {
-    return _smithy.isa(o, "UnauthorizedException");
+    return __isa(o, "UnauthorizedException");
   }
 }
 
@@ -1221,7 +1224,7 @@ export interface UpdateAuditStreamConfigurationRequest {
 
 export namespace UpdateAuditStreamConfigurationRequest {
   export function isa(o: any): o is UpdateAuditStreamConfigurationRequest {
-    return _smithy.isa(o, "UpdateAuditStreamConfigurationRequest");
+    return __isa(o, "UpdateAuditStreamConfigurationRequest");
   }
 }
 
@@ -1232,7 +1235,7 @@ export interface UpdateAuditStreamConfigurationResponse
 
 export namespace UpdateAuditStreamConfigurationResponse {
   export function isa(o: any): o is UpdateAuditStreamConfigurationResponse {
-    return _smithy.isa(o, "UpdateAuditStreamConfigurationResponse");
+    return __isa(o, "UpdateAuditStreamConfigurationResponse");
   }
 }
 
@@ -1263,7 +1266,7 @@ export interface UpdateCompanyNetworkConfigurationRequest {
 
 export namespace UpdateCompanyNetworkConfigurationRequest {
   export function isa(o: any): o is UpdateCompanyNetworkConfigurationRequest {
-    return _smithy.isa(o, "UpdateCompanyNetworkConfigurationRequest");
+    return __isa(o, "UpdateCompanyNetworkConfigurationRequest");
   }
 }
 
@@ -1274,7 +1277,7 @@ export interface UpdateCompanyNetworkConfigurationResponse
 
 export namespace UpdateCompanyNetworkConfigurationResponse {
   export function isa(o: any): o is UpdateCompanyNetworkConfigurationResponse {
-    return _smithy.isa(o, "UpdateCompanyNetworkConfigurationResponse");
+    return __isa(o, "UpdateCompanyNetworkConfigurationResponse");
   }
 }
 
@@ -1293,7 +1296,7 @@ export interface UpdateDevicePolicyConfigurationRequest {
 
 export namespace UpdateDevicePolicyConfigurationRequest {
   export function isa(o: any): o is UpdateDevicePolicyConfigurationRequest {
-    return _smithy.isa(o, "UpdateDevicePolicyConfigurationRequest");
+    return __isa(o, "UpdateDevicePolicyConfigurationRequest");
   }
 }
 
@@ -1304,7 +1307,7 @@ export interface UpdateDevicePolicyConfigurationResponse
 
 export namespace UpdateDevicePolicyConfigurationResponse {
   export function isa(o: any): o is UpdateDevicePolicyConfigurationResponse {
-    return _smithy.isa(o, "UpdateDevicePolicyConfigurationResponse");
+    return __isa(o, "UpdateDevicePolicyConfigurationResponse");
   }
 }
 
@@ -1328,7 +1331,7 @@ export interface UpdateDomainMetadataRequest {
 
 export namespace UpdateDomainMetadataRequest {
   export function isa(o: any): o is UpdateDomainMetadataRequest {
-    return _smithy.isa(o, "UpdateDomainMetadataRequest");
+    return __isa(o, "UpdateDomainMetadataRequest");
   }
 }
 
@@ -1338,7 +1341,7 @@ export interface UpdateDomainMetadataResponse extends $MetadataBearer {
 
 export namespace UpdateDomainMetadataResponse {
   export function isa(o: any): o is UpdateDomainMetadataResponse {
-    return _smithy.isa(o, "UpdateDomainMetadataResponse");
+    return __isa(o, "UpdateDomainMetadataResponse");
   }
 }
 
@@ -1363,7 +1366,7 @@ export interface UpdateFleetMetadataRequest {
 
 export namespace UpdateFleetMetadataRequest {
   export function isa(o: any): o is UpdateFleetMetadataRequest {
-    return _smithy.isa(o, "UpdateFleetMetadataRequest");
+    return __isa(o, "UpdateFleetMetadataRequest");
   }
 }
 
@@ -1373,7 +1376,7 @@ export interface UpdateFleetMetadataResponse extends $MetadataBearer {
 
 export namespace UpdateFleetMetadataResponse {
   export function isa(o: any): o is UpdateFleetMetadataResponse {
-    return _smithy.isa(o, "UpdateFleetMetadataResponse");
+    return __isa(o, "UpdateFleetMetadataResponse");
   }
 }
 
@@ -1398,7 +1401,7 @@ export interface UpdateIdentityProviderConfigurationRequest {
 
 export namespace UpdateIdentityProviderConfigurationRequest {
   export function isa(o: any): o is UpdateIdentityProviderConfigurationRequest {
-    return _smithy.isa(o, "UpdateIdentityProviderConfigurationRequest");
+    return __isa(o, "UpdateIdentityProviderConfigurationRequest");
   }
 }
 
@@ -1411,7 +1414,7 @@ export namespace UpdateIdentityProviderConfigurationResponse {
   export function isa(
     o: any
   ): o is UpdateIdentityProviderConfigurationResponse {
-    return _smithy.isa(o, "UpdateIdentityProviderConfigurationResponse");
+    return __isa(o, "UpdateIdentityProviderConfigurationResponse");
   }
 }
 
@@ -1444,7 +1447,7 @@ export interface WebsiteAuthorizationProviderSummary {
 
 export namespace WebsiteAuthorizationProviderSummary {
   export function isa(o: any): o is WebsiteAuthorizationProviderSummary {
-    return _smithy.isa(o, "WebsiteAuthorizationProviderSummary");
+    return __isa(o, "WebsiteAuthorizationProviderSummary");
   }
 }
 
@@ -1471,6 +1474,6 @@ export interface WebsiteCaSummary {
 
 export namespace WebsiteCaSummary {
   export function isa(o: any): o is WebsiteCaSummary {
-    return _smithy.isa(o, "WebsiteCaSummary");
+    return __isa(o, "WebsiteCaSummary");
   }
 }

--- a/clients/client-worklink/protocols/Aws_restJson1_1.ts
+++ b/clients/client-worklink/protocols/Aws_restJson1_1.ts
@@ -968,6 +968,7 @@ export async function deserializeAws_restJson1_1AssociateDomainCommand(
     $metadata: deserializeMetadata(output),
     __type: "AssociateDomainResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -1324,6 +1325,7 @@ export async function deserializeAws_restJson1_1DeleteFleetCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeleteFleetResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2201,6 +2203,7 @@ export async function deserializeAws_restJson1_1DisassociateDomainCommand(
     $metadata: deserializeMetadata(output),
     __type: "DisassociateDomainResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2280,6 +2283,7 @@ export async function deserializeAws_restJson1_1DisassociateWebsiteAuthorization
     $metadata: deserializeMetadata(output),
     __type: "DisassociateWebsiteAuthorizationProviderResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2366,6 +2370,7 @@ export async function deserializeAws_restJson1_1DisassociateWebsiteCertificateAu
     $metadata: deserializeMetadata(output),
     __type: "DisassociateWebsiteCertificateAuthorityResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2876,6 +2881,7 @@ export async function deserializeAws_restJson1_1RestoreDomainAccessCommand(
     $metadata: deserializeMetadata(output),
     __type: "RestoreDomainAccessResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -2955,6 +2961,7 @@ export async function deserializeAws_restJson1_1RevokeDomainAccessCommand(
     $metadata: deserializeMetadata(output),
     __type: "RevokeDomainAccessResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -3031,6 +3038,7 @@ export async function deserializeAws_restJson1_1SignOutUserCommand(
     $metadata: deserializeMetadata(output),
     __type: "SignOutUserResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -3110,6 +3118,7 @@ export async function deserializeAws_restJson1_1UpdateAuditStreamConfigurationCo
     $metadata: deserializeMetadata(output),
     __type: "UpdateAuditStreamConfigurationResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -3189,6 +3198,7 @@ export async function deserializeAws_restJson1_1UpdateCompanyNetworkConfiguratio
     $metadata: deserializeMetadata(output),
     __type: "UpdateCompanyNetworkConfigurationResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -3268,6 +3278,7 @@ export async function deserializeAws_restJson1_1UpdateDevicePolicyConfigurationC
     $metadata: deserializeMetadata(output),
     __type: "UpdateDevicePolicyConfigurationResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -3347,6 +3358,7 @@ export async function deserializeAws_restJson1_1UpdateDomainMetadataCommand(
     $metadata: deserializeMetadata(output),
     __type: "UpdateDomainMetadataResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -3426,6 +3438,7 @@ export async function deserializeAws_restJson1_1UpdateFleetMetadataCommand(
     $metadata: deserializeMetadata(output),
     __type: "UpdateFleetMetadataResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -3505,6 +3518,7 @@ export async function deserializeAws_restJson1_1UpdateIdentityProviderConfigurat
     $metadata: deserializeMetadata(output),
     __type: "UpdateIdentityProviderConfigurationResponse"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 

--- a/clients/client-workmail/models/index.ts
+++ b/clients/client-workmail/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export interface AssociateDelegateToResourceRequest {
@@ -21,7 +24,7 @@ export interface AssociateDelegateToResourceRequest {
 
 export namespace AssociateDelegateToResourceRequest {
   export function isa(o: any): o is AssociateDelegateToResourceRequest {
-    return _smithy.isa(o, "AssociateDelegateToResourceRequest");
+    return __isa(o, "AssociateDelegateToResourceRequest");
   }
 }
 
@@ -31,7 +34,7 @@ export interface AssociateDelegateToResourceResponse extends $MetadataBearer {
 
 export namespace AssociateDelegateToResourceResponse {
   export function isa(o: any): o is AssociateDelegateToResourceResponse {
-    return _smithy.isa(o, "AssociateDelegateToResourceResponse");
+    return __isa(o, "AssociateDelegateToResourceResponse");
   }
 }
 
@@ -55,7 +58,7 @@ export interface AssociateMemberToGroupRequest {
 
 export namespace AssociateMemberToGroupRequest {
   export function isa(o: any): o is AssociateMemberToGroupRequest {
-    return _smithy.isa(o, "AssociateMemberToGroupRequest");
+    return __isa(o, "AssociateMemberToGroupRequest");
   }
 }
 
@@ -65,7 +68,7 @@ export interface AssociateMemberToGroupResponse extends $MetadataBearer {
 
 export namespace AssociateMemberToGroupResponse {
   export function isa(o: any): o is AssociateMemberToGroupResponse {
-    return _smithy.isa(o, "AssociateMemberToGroupResponse");
+    return __isa(o, "AssociateMemberToGroupResponse");
   }
 }
 
@@ -93,7 +96,7 @@ export interface BookingOptions {
 
 export namespace BookingOptions {
   export function isa(o: any): o is BookingOptions {
-    return _smithy.isa(o, "BookingOptions");
+    return __isa(o, "BookingOptions");
   }
 }
 
@@ -117,7 +120,7 @@ export interface CreateAliasRequest {
 
 export namespace CreateAliasRequest {
   export function isa(o: any): o is CreateAliasRequest {
-    return _smithy.isa(o, "CreateAliasRequest");
+    return __isa(o, "CreateAliasRequest");
   }
 }
 
@@ -127,7 +130,7 @@ export interface CreateAliasResponse extends $MetadataBearer {
 
 export namespace CreateAliasResponse {
   export function isa(o: any): o is CreateAliasResponse {
-    return _smithy.isa(o, "CreateAliasResponse");
+    return __isa(o, "CreateAliasResponse");
   }
 }
 
@@ -146,7 +149,7 @@ export interface CreateGroupRequest {
 
 export namespace CreateGroupRequest {
   export function isa(o: any): o is CreateGroupRequest {
-    return _smithy.isa(o, "CreateGroupRequest");
+    return __isa(o, "CreateGroupRequest");
   }
 }
 
@@ -160,7 +163,7 @@ export interface CreateGroupResponse extends $MetadataBearer {
 
 export namespace CreateGroupResponse {
   export function isa(o: any): o is CreateGroupResponse {
-    return _smithy.isa(o, "CreateGroupResponse");
+    return __isa(o, "CreateGroupResponse");
   }
 }
 
@@ -186,7 +189,7 @@ export interface CreateResourceRequest {
 
 export namespace CreateResourceRequest {
   export function isa(o: any): o is CreateResourceRequest {
-    return _smithy.isa(o, "CreateResourceRequest");
+    return __isa(o, "CreateResourceRequest");
   }
 }
 
@@ -200,7 +203,7 @@ export interface CreateResourceResponse extends $MetadataBearer {
 
 export namespace CreateResourceResponse {
   export function isa(o: any): o is CreateResourceResponse {
-    return _smithy.isa(o, "CreateResourceResponse");
+    return __isa(o, "CreateResourceResponse");
   }
 }
 
@@ -229,7 +232,7 @@ export interface CreateUserRequest {
 
 export namespace CreateUserRequest {
   export function isa(o: any): o is CreateUserRequest {
-    return _smithy.isa(o, "CreateUserRequest");
+    return __isa(o, "CreateUserRequest");
   }
 }
 
@@ -243,7 +246,7 @@ export interface CreateUserResponse extends $MetadataBearer {
 
 export namespace CreateUserResponse {
   export function isa(o: any): o is CreateUserResponse {
-    return _smithy.isa(o, "CreateUserResponse");
+    return __isa(o, "CreateUserResponse");
   }
 }
 
@@ -266,7 +269,7 @@ export interface Delegate {
 
 export namespace Delegate {
   export function isa(o: any): o is Delegate {
-    return _smithy.isa(o, "Delegate");
+    return __isa(o, "Delegate");
   }
 }
 
@@ -292,7 +295,7 @@ export interface DeleteAliasRequest {
 
 export namespace DeleteAliasRequest {
   export function isa(o: any): o is DeleteAliasRequest {
-    return _smithy.isa(o, "DeleteAliasRequest");
+    return __isa(o, "DeleteAliasRequest");
   }
 }
 
@@ -302,7 +305,7 @@ export interface DeleteAliasResponse extends $MetadataBearer {
 
 export namespace DeleteAliasResponse {
   export function isa(o: any): o is DeleteAliasResponse {
-    return _smithy.isa(o, "DeleteAliasResponse");
+    return __isa(o, "DeleteAliasResponse");
   }
 }
 
@@ -321,7 +324,7 @@ export interface DeleteGroupRequest {
 
 export namespace DeleteGroupRequest {
   export function isa(o: any): o is DeleteGroupRequest {
-    return _smithy.isa(o, "DeleteGroupRequest");
+    return __isa(o, "DeleteGroupRequest");
   }
 }
 
@@ -331,7 +334,7 @@ export interface DeleteGroupResponse extends $MetadataBearer {
 
 export namespace DeleteGroupResponse {
   export function isa(o: any): o is DeleteGroupResponse {
-    return _smithy.isa(o, "DeleteGroupResponse");
+    return __isa(o, "DeleteGroupResponse");
   }
 }
 
@@ -357,7 +360,7 @@ export interface DeleteMailboxPermissionsRequest {
 
 export namespace DeleteMailboxPermissionsRequest {
   export function isa(o: any): o is DeleteMailboxPermissionsRequest {
-    return _smithy.isa(o, "DeleteMailboxPermissionsRequest");
+    return __isa(o, "DeleteMailboxPermissionsRequest");
   }
 }
 
@@ -367,7 +370,7 @@ export interface DeleteMailboxPermissionsResponse extends $MetadataBearer {
 
 export namespace DeleteMailboxPermissionsResponse {
   export function isa(o: any): o is DeleteMailboxPermissionsResponse {
-    return _smithy.isa(o, "DeleteMailboxPermissionsResponse");
+    return __isa(o, "DeleteMailboxPermissionsResponse");
   }
 }
 
@@ -387,7 +390,7 @@ export interface DeleteResourceRequest {
 
 export namespace DeleteResourceRequest {
   export function isa(o: any): o is DeleteResourceRequest {
-    return _smithy.isa(o, "DeleteResourceRequest");
+    return __isa(o, "DeleteResourceRequest");
   }
 }
 
@@ -397,7 +400,7 @@ export interface DeleteResourceResponse extends $MetadataBearer {
 
 export namespace DeleteResourceResponse {
   export function isa(o: any): o is DeleteResourceResponse {
-    return _smithy.isa(o, "DeleteResourceResponse");
+    return __isa(o, "DeleteResourceResponse");
   }
 }
 
@@ -416,7 +419,7 @@ export interface DeleteUserRequest {
 
 export namespace DeleteUserRequest {
   export function isa(o: any): o is DeleteUserRequest {
-    return _smithy.isa(o, "DeleteUserRequest");
+    return __isa(o, "DeleteUserRequest");
   }
 }
 
@@ -426,7 +429,7 @@ export interface DeleteUserResponse extends $MetadataBearer {
 
 export namespace DeleteUserResponse {
   export function isa(o: any): o is DeleteUserResponse {
-    return _smithy.isa(o, "DeleteUserResponse");
+    return __isa(o, "DeleteUserResponse");
   }
 }
 
@@ -446,7 +449,7 @@ export interface DeregisterFromWorkMailRequest {
 
 export namespace DeregisterFromWorkMailRequest {
   export function isa(o: any): o is DeregisterFromWorkMailRequest {
-    return _smithy.isa(o, "DeregisterFromWorkMailRequest");
+    return __isa(o, "DeregisterFromWorkMailRequest");
   }
 }
 
@@ -456,7 +459,7 @@ export interface DeregisterFromWorkMailResponse extends $MetadataBearer {
 
 export namespace DeregisterFromWorkMailResponse {
   export function isa(o: any): o is DeregisterFromWorkMailResponse {
-    return _smithy.isa(o, "DeregisterFromWorkMailResponse");
+    return __isa(o, "DeregisterFromWorkMailResponse");
   }
 }
 
@@ -475,7 +478,7 @@ export interface DescribeGroupRequest {
 
 export namespace DescribeGroupRequest {
   export function isa(o: any): o is DescribeGroupRequest {
-    return _smithy.isa(o, "DescribeGroupRequest");
+    return __isa(o, "DescribeGroupRequest");
   }
 }
 
@@ -517,7 +520,7 @@ export interface DescribeGroupResponse extends $MetadataBearer {
 
 export namespace DescribeGroupResponse {
   export function isa(o: any): o is DescribeGroupResponse {
-    return _smithy.isa(o, "DescribeGroupResponse");
+    return __isa(o, "DescribeGroupResponse");
   }
 }
 
@@ -531,7 +534,7 @@ export interface DescribeOrganizationRequest {
 
 export namespace DescribeOrganizationRequest {
   export function isa(o: any): o is DescribeOrganizationRequest {
-    return _smithy.isa(o, "DescribeOrganizationRequest");
+    return __isa(o, "DescribeOrganizationRequest");
   }
 }
 
@@ -583,7 +586,7 @@ export interface DescribeOrganizationResponse extends $MetadataBearer {
 
 export namespace DescribeOrganizationResponse {
   export function isa(o: any): o is DescribeOrganizationResponse {
-    return _smithy.isa(o, "DescribeOrganizationResponse");
+    return __isa(o, "DescribeOrganizationResponse");
   }
 }
 
@@ -603,7 +606,7 @@ export interface DescribeResourceRequest {
 
 export namespace DescribeResourceRequest {
   export function isa(o: any): o is DescribeResourceRequest {
-    return _smithy.isa(o, "DescribeResourceRequest");
+    return __isa(o, "DescribeResourceRequest");
   }
 }
 
@@ -655,7 +658,7 @@ export interface DescribeResourceResponse extends $MetadataBearer {
 
 export namespace DescribeResourceResponse {
   export function isa(o: any): o is DescribeResourceResponse {
-    return _smithy.isa(o, "DescribeResourceResponse");
+    return __isa(o, "DescribeResourceResponse");
   }
 }
 
@@ -674,7 +677,7 @@ export interface DescribeUserRequest {
 
 export namespace DescribeUserRequest {
   export function isa(o: any): o is DescribeUserRequest {
-    return _smithy.isa(o, "DescribeUserRequest");
+    return __isa(o, "DescribeUserRequest");
   }
 }
 
@@ -728,7 +731,7 @@ export interface DescribeUserResponse extends $MetadataBearer {
 
 export namespace DescribeUserResponse {
   export function isa(o: any): o is DescribeUserResponse {
-    return _smithy.isa(o, "DescribeUserResponse");
+    return __isa(o, "DescribeUserResponse");
   }
 }
 
@@ -737,7 +740,7 @@ export namespace DescribeUserResponse {
  *          WorkMail.</p>
  */
 export interface DirectoryServiceAuthenticationFailedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DirectoryServiceAuthenticationFailedException";
   $fault: "client";
@@ -748,7 +751,7 @@ export namespace DirectoryServiceAuthenticationFailedException {
   export function isa(
     o: any
   ): o is DirectoryServiceAuthenticationFailedException {
-    return _smithy.isa(o, "DirectoryServiceAuthenticationFailedException");
+    return __isa(o, "DirectoryServiceAuthenticationFailedException");
   }
 }
 
@@ -757,7 +760,7 @@ export namespace DirectoryServiceAuthenticationFailedException {
  *          available.</p>
  */
 export interface DirectoryUnavailableException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "DirectoryUnavailableException";
   $fault: "client";
@@ -766,7 +769,7 @@ export interface DirectoryUnavailableException
 
 export namespace DirectoryUnavailableException {
   export function isa(o: any): o is DirectoryUnavailableException {
-    return _smithy.isa(o, "DirectoryUnavailableException");
+    return __isa(o, "DirectoryUnavailableException");
   }
 }
 
@@ -790,7 +793,7 @@ export interface DisassociateDelegateFromResourceRequest {
 
 export namespace DisassociateDelegateFromResourceRequest {
   export function isa(o: any): o is DisassociateDelegateFromResourceRequest {
-    return _smithy.isa(o, "DisassociateDelegateFromResourceRequest");
+    return __isa(o, "DisassociateDelegateFromResourceRequest");
   }
 }
 
@@ -801,7 +804,7 @@ export interface DisassociateDelegateFromResourceResponse
 
 export namespace DisassociateDelegateFromResourceResponse {
   export function isa(o: any): o is DisassociateDelegateFromResourceResponse {
-    return _smithy.isa(o, "DisassociateDelegateFromResourceResponse");
+    return __isa(o, "DisassociateDelegateFromResourceResponse");
   }
 }
 
@@ -825,7 +828,7 @@ export interface DisassociateMemberFromGroupRequest {
 
 export namespace DisassociateMemberFromGroupRequest {
   export function isa(o: any): o is DisassociateMemberFromGroupRequest {
-    return _smithy.isa(o, "DisassociateMemberFromGroupRequest");
+    return __isa(o, "DisassociateMemberFromGroupRequest");
   }
 }
 
@@ -835,7 +838,7 @@ export interface DisassociateMemberFromGroupResponse extends $MetadataBearer {
 
 export namespace DisassociateMemberFromGroupResponse {
   export function isa(o: any): o is DisassociateMemberFromGroupResponse {
-    return _smithy.isa(o, "DisassociateMemberFromGroupResponse");
+    return __isa(o, "DisassociateMemberFromGroupResponse");
   }
 }
 
@@ -844,7 +847,7 @@ export namespace DisassociateMemberFromGroupResponse {
  *          user, group, or resource.</p>
  */
 export interface EmailAddressInUseException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "EmailAddressInUseException";
   $fault: "client";
@@ -853,7 +856,7 @@ export interface EmailAddressInUseException
 
 export namespace EmailAddressInUseException {
   export function isa(o: any): o is EmailAddressInUseException {
-    return _smithy.isa(o, "EmailAddressInUseException");
+    return __isa(o, "EmailAddressInUseException");
   }
 }
 
@@ -861,7 +864,7 @@ export namespace EmailAddressInUseException {
  * <p>The user, group, or resource that you're trying to register is already registered.</p>
  */
 export interface EntityAlreadyRegisteredException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "EntityAlreadyRegisteredException";
   $fault: "client";
@@ -870,7 +873,7 @@ export interface EntityAlreadyRegisteredException
 
 export namespace EntityAlreadyRegisteredException {
   export function isa(o: any): o is EntityAlreadyRegisteredException {
-    return _smithy.isa(o, "EntityAlreadyRegisteredException");
+    return __isa(o, "EntityAlreadyRegisteredException");
   }
 }
 
@@ -879,7 +882,7 @@ export namespace EntityAlreadyRegisteredException {
  *          exist in your organization.</p>
  */
 export interface EntityNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "EntityNotFoundException";
   $fault: "client";
@@ -888,7 +891,7 @@ export interface EntityNotFoundException
 
 export namespace EntityNotFoundException {
   export function isa(o: any): o is EntityNotFoundException {
-    return _smithy.isa(o, "EntityNotFoundException");
+    return __isa(o, "EntityNotFoundException");
   }
 }
 
@@ -903,7 +906,7 @@ export enum EntityState {
  *          expected state, such as trying to delete an active user.</p>
  */
 export interface EntityStateException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "EntityStateException";
   $fault: "client";
@@ -912,7 +915,7 @@ export interface EntityStateException
 
 export namespace EntityStateException {
   export function isa(o: any): o is EntityStateException {
-    return _smithy.isa(o, "EntityStateException");
+    return __isa(o, "EntityStateException");
   }
 }
 
@@ -932,7 +935,7 @@ export interface GetMailboxDetailsRequest {
 
 export namespace GetMailboxDetailsRequest {
   export function isa(o: any): o is GetMailboxDetailsRequest {
-    return _smithy.isa(o, "GetMailboxDetailsRequest");
+    return __isa(o, "GetMailboxDetailsRequest");
   }
 }
 
@@ -951,7 +954,7 @@ export interface GetMailboxDetailsResponse extends $MetadataBearer {
 
 export namespace GetMailboxDetailsResponse {
   export function isa(o: any): o is GetMailboxDetailsResponse {
-    return _smithy.isa(o, "GetMailboxDetailsResponse");
+    return __isa(o, "GetMailboxDetailsResponse");
   }
 }
 
@@ -993,7 +996,7 @@ export interface Group {
 
 export namespace Group {
   export function isa(o: any): o is Group {
-    return _smithy.isa(o, "Group");
+    return __isa(o, "Group");
   }
 }
 
@@ -1003,7 +1006,7 @@ export namespace Group {
  *          behalf.</p>
  */
 export interface InvalidConfigurationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidConfigurationException";
   $fault: "client";
@@ -1012,7 +1015,7 @@ export interface InvalidConfigurationException
 
 export namespace InvalidConfigurationException {
   export function isa(o: any): o is InvalidConfigurationException {
-    return _smithy.isa(o, "InvalidConfigurationException");
+    return __isa(o, "InvalidConfigurationException");
   }
 }
 
@@ -1020,7 +1023,7 @@ export namespace InvalidConfigurationException {
  * <p>One or more of the input parameters don't match the service's restrictions.</p>
  */
 export interface InvalidParameterException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidParameterException";
   $fault: "client";
@@ -1029,7 +1032,7 @@ export interface InvalidParameterException
 
 export namespace InvalidParameterException {
   export function isa(o: any): o is InvalidParameterException {
-    return _smithy.isa(o, "InvalidParameterException");
+    return __isa(o, "InvalidParameterException");
   }
 }
 
@@ -1038,7 +1041,7 @@ export namespace InvalidParameterException {
  *          or use of special characters.</p>
  */
 export interface InvalidPasswordException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidPasswordException";
   $fault: "client";
@@ -1047,7 +1050,7 @@ export interface InvalidPasswordException
 
 export namespace InvalidPasswordException {
   export function isa(o: any): o is InvalidPasswordException {
-    return _smithy.isa(o, "InvalidPasswordException");
+    return __isa(o, "InvalidPasswordException");
   }
 }
 
@@ -1077,7 +1080,7 @@ export interface ListAliasesRequest {
 
 export namespace ListAliasesRequest {
   export function isa(o: any): o is ListAliasesRequest {
-    return _smithy.isa(o, "ListAliasesRequest");
+    return __isa(o, "ListAliasesRequest");
   }
 }
 
@@ -1097,7 +1100,7 @@ export interface ListAliasesResponse extends $MetadataBearer {
 
 export namespace ListAliasesResponse {
   export function isa(o: any): o is ListAliasesResponse {
-    return _smithy.isa(o, "ListAliasesResponse");
+    return __isa(o, "ListAliasesResponse");
   }
 }
 
@@ -1127,7 +1130,7 @@ export interface ListGroupMembersRequest {
 
 export namespace ListGroupMembersRequest {
   export function isa(o: any): o is ListGroupMembersRequest {
-    return _smithy.isa(o, "ListGroupMembersRequest");
+    return __isa(o, "ListGroupMembersRequest");
   }
 }
 
@@ -1147,7 +1150,7 @@ export interface ListGroupMembersResponse extends $MetadataBearer {
 
 export namespace ListGroupMembersResponse {
   export function isa(o: any): o is ListGroupMembersResponse {
-    return _smithy.isa(o, "ListGroupMembersResponse");
+    return __isa(o, "ListGroupMembersResponse");
   }
 }
 
@@ -1172,7 +1175,7 @@ export interface ListGroupsRequest {
 
 export namespace ListGroupsRequest {
   export function isa(o: any): o is ListGroupsRequest {
-    return _smithy.isa(o, "ListGroupsRequest");
+    return __isa(o, "ListGroupsRequest");
   }
 }
 
@@ -1192,7 +1195,7 @@ export interface ListGroupsResponse extends $MetadataBearer {
 
 export namespace ListGroupsResponse {
   export function isa(o: any): o is ListGroupsResponse {
-    return _smithy.isa(o, "ListGroupsResponse");
+    return __isa(o, "ListGroupsResponse");
   }
 }
 
@@ -1223,7 +1226,7 @@ export interface ListMailboxPermissionsRequest {
 
 export namespace ListMailboxPermissionsRequest {
   export function isa(o: any): o is ListMailboxPermissionsRequest {
-    return _smithy.isa(o, "ListMailboxPermissionsRequest");
+    return __isa(o, "ListMailboxPermissionsRequest");
   }
 }
 
@@ -1242,7 +1245,7 @@ export interface ListMailboxPermissionsResponse extends $MetadataBearer {
 
 export namespace ListMailboxPermissionsResponse {
   export function isa(o: any): o is ListMailboxPermissionsResponse {
-    return _smithy.isa(o, "ListMailboxPermissionsResponse");
+    return __isa(o, "ListMailboxPermissionsResponse");
   }
 }
 
@@ -1262,7 +1265,7 @@ export interface ListOrganizationsRequest {
 
 export namespace ListOrganizationsRequest {
   export function isa(o: any): o is ListOrganizationsRequest {
-    return _smithy.isa(o, "ListOrganizationsRequest");
+    return __isa(o, "ListOrganizationsRequest");
   }
 }
 
@@ -1282,7 +1285,7 @@ export interface ListOrganizationsResponse extends $MetadataBearer {
 
 export namespace ListOrganizationsResponse {
   export function isa(o: any): o is ListOrganizationsResponse {
-    return _smithy.isa(o, "ListOrganizationsResponse");
+    return __isa(o, "ListOrganizationsResponse");
   }
 }
 
@@ -1312,7 +1315,7 @@ export interface ListResourceDelegatesRequest {
 
 export namespace ListResourceDelegatesRequest {
   export function isa(o: any): o is ListResourceDelegatesRequest {
-    return _smithy.isa(o, "ListResourceDelegatesRequest");
+    return __isa(o, "ListResourceDelegatesRequest");
   }
 }
 
@@ -1333,7 +1336,7 @@ export interface ListResourceDelegatesResponse extends $MetadataBearer {
 
 export namespace ListResourceDelegatesResponse {
   export function isa(o: any): o is ListResourceDelegatesResponse {
-    return _smithy.isa(o, "ListResourceDelegatesResponse");
+    return __isa(o, "ListResourceDelegatesResponse");
   }
 }
 
@@ -1358,7 +1361,7 @@ export interface ListResourcesRequest {
 
 export namespace ListResourcesRequest {
   export function isa(o: any): o is ListResourcesRequest {
-    return _smithy.isa(o, "ListResourcesRequest");
+    return __isa(o, "ListResourcesRequest");
   }
 }
 
@@ -1379,7 +1382,7 @@ export interface ListResourcesResponse extends $MetadataBearer {
 
 export namespace ListResourcesResponse {
   export function isa(o: any): o is ListResourcesResponse {
-    return _smithy.isa(o, "ListResourcesResponse");
+    return __isa(o, "ListResourcesResponse");
   }
 }
 
@@ -1403,7 +1406,7 @@ export interface ListUsersRequest {
 
 export namespace ListUsersRequest {
   export function isa(o: any): o is ListUsersRequest {
-    return _smithy.isa(o, "ListUsersRequest");
+    return __isa(o, "ListUsersRequest");
   }
 }
 
@@ -1422,7 +1425,7 @@ export interface ListUsersResponse extends $MetadataBearer {
 
 export namespace ListUsersResponse {
   export function isa(o: any): o is ListUsersResponse {
-    return _smithy.isa(o, "ListUsersResponse");
+    return __isa(o, "ListUsersResponse");
   }
 }
 
@@ -1431,7 +1434,7 @@ export namespace ListUsersResponse {
  *          defined in the organization.</p>
  */
 export interface MailDomainNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "MailDomainNotFoundException";
   $fault: "client";
@@ -1440,7 +1443,7 @@ export interface MailDomainNotFoundException
 
 export namespace MailDomainNotFoundException {
   export function isa(o: any): o is MailDomainNotFoundException {
-    return _smithy.isa(o, "MailDomainNotFoundException");
+    return __isa(o, "MailDomainNotFoundException");
   }
 }
 
@@ -1449,7 +1452,7 @@ export namespace MailDomainNotFoundException {
  *          not yet verified.</p>
  */
 export interface MailDomainStateException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "MailDomainStateException";
   $fault: "client";
@@ -1458,7 +1461,7 @@ export interface MailDomainStateException
 
 export namespace MailDomainStateException {
   export function isa(o: any): o is MailDomainStateException {
-    return _smithy.isa(o, "MailDomainStateException");
+    return __isa(o, "MailDomainStateException");
   }
 }
 
@@ -1502,7 +1505,7 @@ export interface Member {
 
 export namespace Member {
   export function isa(o: any): o is Member {
-    return _smithy.isa(o, "Member");
+    return __isa(o, "Member");
   }
 }
 
@@ -1515,7 +1518,7 @@ export enum MemberType {
  * <p>The user, group, or resource name isn't unique in Amazon WorkMail.</p>
  */
 export interface NameAvailabilityException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "NameAvailabilityException";
   $fault: "client";
@@ -1524,7 +1527,7 @@ export interface NameAvailabilityException
 
 export namespace NameAvailabilityException {
   export function isa(o: any): o is NameAvailabilityException {
-    return _smithy.isa(o, "NameAvailabilityException");
+    return __isa(o, "NameAvailabilityException");
   }
 }
 
@@ -1533,7 +1536,7 @@ export namespace NameAvailabilityException {
  *          exist in the system.</p>
  */
 export interface OrganizationNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "OrganizationNotFoundException";
   $fault: "client";
@@ -1542,7 +1545,7 @@ export interface OrganizationNotFoundException
 
 export namespace OrganizationNotFoundException {
   export function isa(o: any): o is OrganizationNotFoundException {
-    return _smithy.isa(o, "OrganizationNotFoundException");
+    return __isa(o, "OrganizationNotFoundException");
   }
 }
 
@@ -1551,7 +1554,7 @@ export namespace OrganizationNotFoundException {
  *          operations on the organization or its members.</p>
  */
 export interface OrganizationStateException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "OrganizationStateException";
   $fault: "client";
@@ -1560,7 +1563,7 @@ export interface OrganizationStateException
 
 export namespace OrganizationStateException {
   export function isa(o: any): o is OrganizationStateException {
-    return _smithy.isa(o, "OrganizationStateException");
+    return __isa(o, "OrganizationStateException");
   }
 }
 
@@ -1594,7 +1597,7 @@ export interface OrganizationSummary {
 
 export namespace OrganizationSummary {
   export function isa(o: any): o is OrganizationSummary {
-    return _smithy.isa(o, "OrganizationSummary");
+    return __isa(o, "OrganizationSummary");
   }
 }
 
@@ -1623,7 +1626,7 @@ export interface Permission {
 
 export namespace Permission {
   export function isa(o: any): o is Permission {
-    return _smithy.isa(o, "Permission");
+    return __isa(o, "Permission");
   }
 }
 
@@ -1661,7 +1664,7 @@ export interface PutMailboxPermissionsRequest {
 
 export namespace PutMailboxPermissionsRequest {
   export function isa(o: any): o is PutMailboxPermissionsRequest {
-    return _smithy.isa(o, "PutMailboxPermissionsRequest");
+    return __isa(o, "PutMailboxPermissionsRequest");
   }
 }
 
@@ -1671,7 +1674,7 @@ export interface PutMailboxPermissionsResponse extends $MetadataBearer {
 
 export namespace PutMailboxPermissionsResponse {
   export function isa(o: any): o is PutMailboxPermissionsResponse {
-    return _smithy.isa(o, "PutMailboxPermissionsResponse");
+    return __isa(o, "PutMailboxPermissionsResponse");
   }
 }
 
@@ -1696,7 +1699,7 @@ export interface RegisterToWorkMailRequest {
 
 export namespace RegisterToWorkMailRequest {
   export function isa(o: any): o is RegisterToWorkMailRequest {
-    return _smithy.isa(o, "RegisterToWorkMailRequest");
+    return __isa(o, "RegisterToWorkMailRequest");
   }
 }
 
@@ -1706,7 +1709,7 @@ export interface RegisterToWorkMailResponse extends $MetadataBearer {
 
 export namespace RegisterToWorkMailResponse {
   export function isa(o: any): o is RegisterToWorkMailResponse {
-    return _smithy.isa(o, "RegisterToWorkMailResponse");
+    return __isa(o, "RegisterToWorkMailResponse");
   }
 }
 
@@ -1714,7 +1717,7 @@ export namespace RegisterToWorkMailResponse {
  * <p>This user, group, or resource name is not allowed in Amazon WorkMail.</p>
  */
 export interface ReservedNameException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ReservedNameException";
   $fault: "client";
@@ -1723,7 +1726,7 @@ export interface ReservedNameException
 
 export namespace ReservedNameException {
   export function isa(o: any): o is ReservedNameException {
-    return _smithy.isa(o, "ReservedNameException");
+    return __isa(o, "ReservedNameException");
   }
 }
 
@@ -1748,7 +1751,7 @@ export interface ResetPasswordRequest {
 
 export namespace ResetPasswordRequest {
   export function isa(o: any): o is ResetPasswordRequest {
-    return _smithy.isa(o, "ResetPasswordRequest");
+    return __isa(o, "ResetPasswordRequest");
   }
 }
 
@@ -1758,7 +1761,7 @@ export interface ResetPasswordResponse extends $MetadataBearer {
 
 export namespace ResetPasswordResponse {
   export function isa(o: any): o is ResetPasswordResponse {
-    return _smithy.isa(o, "ResetPasswordResponse");
+    return __isa(o, "ResetPasswordResponse");
   }
 }
 
@@ -1806,7 +1809,7 @@ export interface Resource {
 
 export namespace Resource {
   export function isa(o: any): o is Resource {
-    return _smithy.isa(o, "Resource");
+    return __isa(o, "Resource");
   }
 }
 
@@ -1819,7 +1822,7 @@ export enum ResourceType {
  * <p>You can't perform a write operation against a read-only directory.</p>
  */
 export interface UnsupportedOperationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UnsupportedOperationException";
   $fault: "client";
@@ -1828,7 +1831,7 @@ export interface UnsupportedOperationException
 
 export namespace UnsupportedOperationException {
   export function isa(o: any): o is UnsupportedOperationException {
-    return _smithy.isa(o, "UnsupportedOperationException");
+    return __isa(o, "UnsupportedOperationException");
   }
 }
 
@@ -1852,7 +1855,7 @@ export interface UpdateMailboxQuotaRequest {
 
 export namespace UpdateMailboxQuotaRequest {
   export function isa(o: any): o is UpdateMailboxQuotaRequest {
-    return _smithy.isa(o, "UpdateMailboxQuotaRequest");
+    return __isa(o, "UpdateMailboxQuotaRequest");
   }
 }
 
@@ -1862,7 +1865,7 @@ export interface UpdateMailboxQuotaResponse extends $MetadataBearer {
 
 export namespace UpdateMailboxQuotaResponse {
   export function isa(o: any): o is UpdateMailboxQuotaResponse {
-    return _smithy.isa(o, "UpdateMailboxQuotaResponse");
+    return __isa(o, "UpdateMailboxQuotaResponse");
   }
 }
 
@@ -1886,7 +1889,7 @@ export interface UpdatePrimaryEmailAddressRequest {
 
 export namespace UpdatePrimaryEmailAddressRequest {
   export function isa(o: any): o is UpdatePrimaryEmailAddressRequest {
-    return _smithy.isa(o, "UpdatePrimaryEmailAddressRequest");
+    return __isa(o, "UpdatePrimaryEmailAddressRequest");
   }
 }
 
@@ -1896,7 +1899,7 @@ export interface UpdatePrimaryEmailAddressResponse extends $MetadataBearer {
 
 export namespace UpdatePrimaryEmailAddressResponse {
   export function isa(o: any): o is UpdatePrimaryEmailAddressResponse {
-    return _smithy.isa(o, "UpdatePrimaryEmailAddressResponse");
+    return __isa(o, "UpdatePrimaryEmailAddressResponse");
   }
 }
 
@@ -1926,7 +1929,7 @@ export interface UpdateResourceRequest {
 
 export namespace UpdateResourceRequest {
   export function isa(o: any): o is UpdateResourceRequest {
-    return _smithy.isa(o, "UpdateResourceRequest");
+    return __isa(o, "UpdateResourceRequest");
   }
 }
 
@@ -1936,7 +1939,7 @@ export interface UpdateResourceResponse extends $MetadataBearer {
 
 export namespace UpdateResourceResponse {
   export function isa(o: any): o is UpdateResourceResponse {
-    return _smithy.isa(o, "UpdateResourceResponse");
+    return __isa(o, "UpdateResourceResponse");
   }
 }
 
@@ -1988,7 +1991,7 @@ export interface User {
 
 export namespace User {
   export function isa(o: any): o is User {
-    return _smithy.isa(o, "User");
+    return __isa(o, "User");
   }
 }
 

--- a/clients/client-workmailmessageflow/models/index.ts
+++ b/clients/client-workmailmessageflow/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export interface GetRawMessageContentRequest {
@@ -11,7 +14,7 @@ export interface GetRawMessageContentRequest {
 
 export namespace GetRawMessageContentRequest {
   export function isa(o: any): o is GetRawMessageContentRequest {
-    return _smithy.isa(o, "GetRawMessageContentRequest");
+    return __isa(o, "GetRawMessageContentRequest");
   }
 }
 
@@ -25,7 +28,7 @@ export interface GetRawMessageContentResponse extends $MetadataBearer {
 
 export namespace GetRawMessageContentResponse {
   export function isa(o: any): o is GetRawMessageContentResponse {
-    return _smithy.isa(o, "GetRawMessageContentResponse");
+    return __isa(o, "GetRawMessageContentResponse");
   }
 }
 
@@ -33,7 +36,7 @@ export namespace GetRawMessageContentResponse {
  * <p>The requested email message is not found.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -42,6 +45,6 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }

--- a/clients/client-workmailmessageflow/protocols/Aws_restJson1_1.ts
+++ b/clients/client-workmailmessageflow/protocols/Aws_restJson1_1.ts
@@ -7,7 +7,10 @@ import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse
 } from "@aws-sdk/protocol-http";
-import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  extendedEncodeURIComponent as __extendedEncodeURIComponent
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -23,13 +26,13 @@ export async function serializeAws_restJson1_1GetRawMessageContentCommand(
   headers["Content-Type"] = "";
   let resolvedPath = "/messages/{messageId}";
   if (input.messageId !== undefined) {
-    const labelValue: string = input.messageId.toString();
+    const labelValue: string = input.messageId;
     if (labelValue.length <= 0) {
       throw new Error("Empty value provided for input HTTP label: messageId.");
     }
     resolvedPath = resolvedPath.replace(
       "{messageId}",
-      encodeURIComponent(labelValue)
+      __extendedEncodeURIComponent(labelValue)
     );
   } else {
     throw new Error("No value provided for input HTTP label: messageId.");

--- a/clients/client-workspaces/models/index.ts
+++ b/clients/client-workspaces/models/index.ts
@@ -1,11 +1,14 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
  * <p>The user is not authorized to access a resource.</p>
  */
 export interface AccessDeniedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "AccessDeniedException";
   $fault: "client";
@@ -14,7 +17,7 @@ export interface AccessDeniedException
 
 export namespace AccessDeniedException {
   export function isa(o: any): o is AccessDeniedException {
-    return _smithy.isa(o, "AccessDeniedException");
+    return __isa(o, "AccessDeniedException");
   }
 }
 
@@ -64,7 +67,7 @@ export interface AccountModification {
 
 export namespace AccountModification {
   export function isa(o: any): o is AccountModification {
-    return _smithy.isa(o, "AccountModification");
+    return __isa(o, "AccountModification");
   }
 }
 
@@ -83,7 +86,7 @@ export interface AssociateIpGroupsRequest {
 
 export namespace AssociateIpGroupsRequest {
   export function isa(o: any): o is AssociateIpGroupsRequest {
-    return _smithy.isa(o, "AssociateIpGroupsRequest");
+    return __isa(o, "AssociateIpGroupsRequest");
   }
 }
 
@@ -93,7 +96,7 @@ export interface AssociateIpGroupsResult extends $MetadataBearer {
 
 export namespace AssociateIpGroupsResult {
   export function isa(o: any): o is AssociateIpGroupsResult {
-    return _smithy.isa(o, "AssociateIpGroupsResult");
+    return __isa(o, "AssociateIpGroupsResult");
   }
 }
 
@@ -112,7 +115,7 @@ export interface AuthorizeIpRulesRequest {
 
 export namespace AuthorizeIpRulesRequest {
   export function isa(o: any): o is AuthorizeIpRulesRequest {
-    return _smithy.isa(o, "AuthorizeIpRulesRequest");
+    return __isa(o, "AuthorizeIpRulesRequest");
   }
 }
 
@@ -122,7 +125,7 @@ export interface AuthorizeIpRulesResult extends $MetadataBearer {
 
 export namespace AuthorizeIpRulesResult {
   export function isa(o: any): o is AuthorizeIpRulesResult {
-    return _smithy.isa(o, "AuthorizeIpRulesResult");
+    return __isa(o, "AuthorizeIpRulesResult");
   }
 }
 
@@ -141,7 +144,7 @@ export interface ClientProperties {
 
 export namespace ClientProperties {
   export function isa(o: any): o is ClientProperties {
-    return _smithy.isa(o, "ClientProperties");
+    return __isa(o, "ClientProperties");
   }
 }
 
@@ -163,7 +166,7 @@ export interface ClientPropertiesResult {
 
 export namespace ClientPropertiesResult {
   export function isa(o: any): o is ClientPropertiesResult {
-    return _smithy.isa(o, "ClientPropertiesResult");
+    return __isa(o, "ClientPropertiesResult");
   }
 }
 
@@ -190,7 +193,7 @@ export interface ComputeType {
 
 export namespace ComputeType {
   export function isa(o: any): o is ComputeType {
-    return _smithy.isa(o, "ComputeType");
+    return __isa(o, "ComputeType");
   }
 }
 
@@ -230,7 +233,7 @@ export interface CopyWorkspaceImageRequest {
 
 export namespace CopyWorkspaceImageRequest {
   export function isa(o: any): o is CopyWorkspaceImageRequest {
-    return _smithy.isa(o, "CopyWorkspaceImageRequest");
+    return __isa(o, "CopyWorkspaceImageRequest");
   }
 }
 
@@ -244,7 +247,7 @@ export interface CopyWorkspaceImageResult extends $MetadataBearer {
 
 export namespace CopyWorkspaceImageResult {
   export function isa(o: any): o is CopyWorkspaceImageResult {
-    return _smithy.isa(o, "CopyWorkspaceImageResult");
+    return __isa(o, "CopyWorkspaceImageResult");
   }
 }
 
@@ -273,7 +276,7 @@ export interface CreateIpGroupRequest {
 
 export namespace CreateIpGroupRequest {
   export function isa(o: any): o is CreateIpGroupRequest {
-    return _smithy.isa(o, "CreateIpGroupRequest");
+    return __isa(o, "CreateIpGroupRequest");
   }
 }
 
@@ -287,7 +290,7 @@ export interface CreateIpGroupResult extends $MetadataBearer {
 
 export namespace CreateIpGroupResult {
   export function isa(o: any): o is CreateIpGroupResult {
-    return _smithy.isa(o, "CreateIpGroupResult");
+    return __isa(o, "CreateIpGroupResult");
   }
 }
 
@@ -308,7 +311,7 @@ export interface CreateTagsRequest {
 
 export namespace CreateTagsRequest {
   export function isa(o: any): o is CreateTagsRequest {
-    return _smithy.isa(o, "CreateTagsRequest");
+    return __isa(o, "CreateTagsRequest");
   }
 }
 
@@ -318,7 +321,7 @@ export interface CreateTagsResult extends $MetadataBearer {
 
 export namespace CreateTagsResult {
   export function isa(o: any): o is CreateTagsResult {
-    return _smithy.isa(o, "CreateTagsResult");
+    return __isa(o, "CreateTagsResult");
   }
 }
 
@@ -332,7 +335,7 @@ export interface CreateWorkspacesRequest {
 
 export namespace CreateWorkspacesRequest {
   export function isa(o: any): o is CreateWorkspacesRequest {
-    return _smithy.isa(o, "CreateWorkspacesRequest");
+    return __isa(o, "CreateWorkspacesRequest");
   }
 }
 
@@ -354,7 +357,7 @@ export interface CreateWorkspacesResult extends $MetadataBearer {
 
 export namespace CreateWorkspacesResult {
   export function isa(o: any): o is CreateWorkspacesResult {
-    return _smithy.isa(o, "CreateWorkspacesResult");
+    return __isa(o, "CreateWorkspacesResult");
   }
 }
 
@@ -421,7 +424,7 @@ export interface DefaultWorkspaceCreationProperties {
 
 export namespace DefaultWorkspaceCreationProperties {
   export function isa(o: any): o is DefaultWorkspaceCreationProperties {
-    return _smithy.isa(o, "DefaultWorkspaceCreationProperties");
+    return __isa(o, "DefaultWorkspaceCreationProperties");
   }
 }
 
@@ -435,7 +438,7 @@ export interface DeleteIpGroupRequest {
 
 export namespace DeleteIpGroupRequest {
   export function isa(o: any): o is DeleteIpGroupRequest {
-    return _smithy.isa(o, "DeleteIpGroupRequest");
+    return __isa(o, "DeleteIpGroupRequest");
   }
 }
 
@@ -445,7 +448,7 @@ export interface DeleteIpGroupResult extends $MetadataBearer {
 
 export namespace DeleteIpGroupResult {
   export function isa(o: any): o is DeleteIpGroupResult {
-    return _smithy.isa(o, "DeleteIpGroupResult");
+    return __isa(o, "DeleteIpGroupResult");
   }
 }
 
@@ -465,7 +468,7 @@ export interface DeleteTagsRequest {
 
 export namespace DeleteTagsRequest {
   export function isa(o: any): o is DeleteTagsRequest {
-    return _smithy.isa(o, "DeleteTagsRequest");
+    return __isa(o, "DeleteTagsRequest");
   }
 }
 
@@ -475,7 +478,7 @@ export interface DeleteTagsResult extends $MetadataBearer {
 
 export namespace DeleteTagsResult {
   export function isa(o: any): o is DeleteTagsResult {
-    return _smithy.isa(o, "DeleteTagsResult");
+    return __isa(o, "DeleteTagsResult");
   }
 }
 
@@ -489,7 +492,7 @@ export interface DeleteWorkspaceImageRequest {
 
 export namespace DeleteWorkspaceImageRequest {
   export function isa(o: any): o is DeleteWorkspaceImageRequest {
-    return _smithy.isa(o, "DeleteWorkspaceImageRequest");
+    return __isa(o, "DeleteWorkspaceImageRequest");
   }
 }
 
@@ -499,7 +502,7 @@ export interface DeleteWorkspaceImageResult extends $MetadataBearer {
 
 export namespace DeleteWorkspaceImageResult {
   export function isa(o: any): o is DeleteWorkspaceImageResult {
-    return _smithy.isa(o, "DeleteWorkspaceImageResult");
+    return __isa(o, "DeleteWorkspaceImageResult");
   }
 }
 
@@ -515,7 +518,7 @@ export interface DeregisterWorkspaceDirectoryRequest {
 
 export namespace DeregisterWorkspaceDirectoryRequest {
   export function isa(o: any): o is DeregisterWorkspaceDirectoryRequest {
-    return _smithy.isa(o, "DeregisterWorkspaceDirectoryRequest");
+    return __isa(o, "DeregisterWorkspaceDirectoryRequest");
   }
 }
 
@@ -525,7 +528,7 @@ export interface DeregisterWorkspaceDirectoryResult extends $MetadataBearer {
 
 export namespace DeregisterWorkspaceDirectoryResult {
   export function isa(o: any): o is DeregisterWorkspaceDirectoryResult {
-    return _smithy.isa(o, "DeregisterWorkspaceDirectoryResult");
+    return __isa(o, "DeregisterWorkspaceDirectoryResult");
   }
 }
 
@@ -540,7 +543,7 @@ export interface DescribeAccountModificationsRequest {
 
 export namespace DescribeAccountModificationsRequest {
   export function isa(o: any): o is DescribeAccountModificationsRequest {
-    return _smithy.isa(o, "DescribeAccountModificationsRequest");
+    return __isa(o, "DescribeAccountModificationsRequest");
   }
 }
 
@@ -560,7 +563,7 @@ export interface DescribeAccountModificationsResult extends $MetadataBearer {
 
 export namespace DescribeAccountModificationsResult {
   export function isa(o: any): o is DescribeAccountModificationsResult {
-    return _smithy.isa(o, "DescribeAccountModificationsResult");
+    return __isa(o, "DescribeAccountModificationsResult");
   }
 }
 
@@ -570,7 +573,7 @@ export interface DescribeAccountRequest {
 
 export namespace DescribeAccountRequest {
   export function isa(o: any): o is DescribeAccountRequest {
-    return _smithy.isa(o, "DescribeAccountRequest");
+    return __isa(o, "DescribeAccountRequest");
   }
 }
 
@@ -593,7 +596,7 @@ export interface DescribeAccountResult extends $MetadataBearer {
 
 export namespace DescribeAccountResult {
   export function isa(o: any): o is DescribeAccountResult {
-    return _smithy.isa(o, "DescribeAccountResult");
+    return __isa(o, "DescribeAccountResult");
   }
 }
 
@@ -607,7 +610,7 @@ export interface DescribeClientPropertiesRequest {
 
 export namespace DescribeClientPropertiesRequest {
   export function isa(o: any): o is DescribeClientPropertiesRequest {
-    return _smithy.isa(o, "DescribeClientPropertiesRequest");
+    return __isa(o, "DescribeClientPropertiesRequest");
   }
 }
 
@@ -621,7 +624,7 @@ export interface DescribeClientPropertiesResult extends $MetadataBearer {
 
 export namespace DescribeClientPropertiesResult {
   export function isa(o: any): o is DescribeClientPropertiesResult {
-    return _smithy.isa(o, "DescribeClientPropertiesResult");
+    return __isa(o, "DescribeClientPropertiesResult");
   }
 }
 
@@ -646,7 +649,7 @@ export interface DescribeIpGroupsRequest {
 
 export namespace DescribeIpGroupsRequest {
   export function isa(o: any): o is DescribeIpGroupsRequest {
-    return _smithy.isa(o, "DescribeIpGroupsRequest");
+    return __isa(o, "DescribeIpGroupsRequest");
   }
 }
 
@@ -666,7 +669,7 @@ export interface DescribeIpGroupsResult extends $MetadataBearer {
 
 export namespace DescribeIpGroupsResult {
   export function isa(o: any): o is DescribeIpGroupsResult {
-    return _smithy.isa(o, "DescribeIpGroupsResult");
+    return __isa(o, "DescribeIpGroupsResult");
   }
 }
 
@@ -681,7 +684,7 @@ export interface DescribeTagsRequest {
 
 export namespace DescribeTagsRequest {
   export function isa(o: any): o is DescribeTagsRequest {
-    return _smithy.isa(o, "DescribeTagsRequest");
+    return __isa(o, "DescribeTagsRequest");
   }
 }
 
@@ -695,7 +698,7 @@ export interface DescribeTagsResult extends $MetadataBearer {
 
 export namespace DescribeTagsResult {
   export function isa(o: any): o is DescribeTagsResult {
-    return _smithy.isa(o, "DescribeTagsResult");
+    return __isa(o, "DescribeTagsResult");
   }
 }
 
@@ -721,7 +724,7 @@ export interface DescribeWorkspaceBundlesRequest {
 
 export namespace DescribeWorkspaceBundlesRequest {
   export function isa(o: any): o is DescribeWorkspaceBundlesRequest {
-    return _smithy.isa(o, "DescribeWorkspaceBundlesRequest");
+    return __isa(o, "DescribeWorkspaceBundlesRequest");
   }
 }
 
@@ -741,7 +744,7 @@ export interface DescribeWorkspaceBundlesResult extends $MetadataBearer {
 
 export namespace DescribeWorkspaceBundlesResult {
   export function isa(o: any): o is DescribeWorkspaceBundlesResult {
-    return _smithy.isa(o, "DescribeWorkspaceBundlesResult");
+    return __isa(o, "DescribeWorkspaceBundlesResult");
   }
 }
 
@@ -767,7 +770,7 @@ export interface DescribeWorkspaceDirectoriesRequest {
 
 export namespace DescribeWorkspaceDirectoriesRequest {
   export function isa(o: any): o is DescribeWorkspaceDirectoriesRequest {
-    return _smithy.isa(o, "DescribeWorkspaceDirectoriesRequest");
+    return __isa(o, "DescribeWorkspaceDirectoriesRequest");
   }
 }
 
@@ -787,7 +790,7 @@ export interface DescribeWorkspaceDirectoriesResult extends $MetadataBearer {
 
 export namespace DescribeWorkspaceDirectoriesResult {
   export function isa(o: any): o is DescribeWorkspaceDirectoriesResult {
-    return _smithy.isa(o, "DescribeWorkspaceDirectoriesResult");
+    return __isa(o, "DescribeWorkspaceDirectoriesResult");
   }
 }
 
@@ -812,7 +815,7 @@ export interface DescribeWorkspaceImagesRequest {
 
 export namespace DescribeWorkspaceImagesRequest {
   export function isa(o: any): o is DescribeWorkspaceImagesRequest {
-    return _smithy.isa(o, "DescribeWorkspaceImagesRequest");
+    return __isa(o, "DescribeWorkspaceImagesRequest");
   }
 }
 
@@ -832,7 +835,7 @@ export interface DescribeWorkspaceImagesResult extends $MetadataBearer {
 
 export namespace DescribeWorkspaceImagesResult {
   export function isa(o: any): o is DescribeWorkspaceImagesResult {
-    return _smithy.isa(o, "DescribeWorkspaceImagesResult");
+    return __isa(o, "DescribeWorkspaceImagesResult");
   }
 }
 
@@ -846,7 +849,7 @@ export interface DescribeWorkspaceSnapshotsRequest {
 
 export namespace DescribeWorkspaceSnapshotsRequest {
   export function isa(o: any): o is DescribeWorkspaceSnapshotsRequest {
-    return _smithy.isa(o, "DescribeWorkspaceSnapshotsRequest");
+    return __isa(o, "DescribeWorkspaceSnapshotsRequest");
   }
 }
 
@@ -867,7 +870,7 @@ export interface DescribeWorkspaceSnapshotsResult extends $MetadataBearer {
 
 export namespace DescribeWorkspaceSnapshotsResult {
   export function isa(o: any): o is DescribeWorkspaceSnapshotsResult {
-    return _smithy.isa(o, "DescribeWorkspaceSnapshotsResult");
+    return __isa(o, "DescribeWorkspaceSnapshotsResult");
   }
 }
 
@@ -887,7 +890,7 @@ export interface DescribeWorkspacesConnectionStatusRequest {
 
 export namespace DescribeWorkspacesConnectionStatusRequest {
   export function isa(o: any): o is DescribeWorkspacesConnectionStatusRequest {
-    return _smithy.isa(o, "DescribeWorkspacesConnectionStatusRequest");
+    return __isa(o, "DescribeWorkspacesConnectionStatusRequest");
   }
 }
 
@@ -908,7 +911,7 @@ export interface DescribeWorkspacesConnectionStatusResult
 
 export namespace DescribeWorkspacesConnectionStatusResult {
   export function isa(o: any): o is DescribeWorkspacesConnectionStatusResult {
-    return _smithy.isa(o, "DescribeWorkspacesConnectionStatusResult");
+    return __isa(o, "DescribeWorkspacesConnectionStatusResult");
   }
 }
 
@@ -955,7 +958,7 @@ export interface DescribeWorkspacesRequest {
 
 export namespace DescribeWorkspacesRequest {
   export function isa(o: any): o is DescribeWorkspacesRequest {
-    return _smithy.isa(o, "DescribeWorkspacesRequest");
+    return __isa(o, "DescribeWorkspacesRequest");
   }
 }
 
@@ -977,7 +980,7 @@ export interface DescribeWorkspacesResult extends $MetadataBearer {
 
 export namespace DescribeWorkspacesResult {
   export function isa(o: any): o is DescribeWorkspacesResult {
-    return _smithy.isa(o, "DescribeWorkspacesResult");
+    return __isa(o, "DescribeWorkspacesResult");
   }
 }
 
@@ -996,7 +999,7 @@ export interface DisassociateIpGroupsRequest {
 
 export namespace DisassociateIpGroupsRequest {
   export function isa(o: any): o is DisassociateIpGroupsRequest {
-    return _smithy.isa(o, "DisassociateIpGroupsRequest");
+    return __isa(o, "DisassociateIpGroupsRequest");
   }
 }
 
@@ -1006,7 +1009,7 @@ export interface DisassociateIpGroupsResult extends $MetadataBearer {
 
 export namespace DisassociateIpGroupsResult {
   export function isa(o: any): o is DisassociateIpGroupsResult {
-    return _smithy.isa(o, "DisassociateIpGroupsResult");
+    return __isa(o, "DisassociateIpGroupsResult");
   }
 }
 
@@ -1034,7 +1037,7 @@ export interface FailedCreateWorkspaceRequest {
 
 export namespace FailedCreateWorkspaceRequest {
   export function isa(o: any): o is FailedCreateWorkspaceRequest {
-    return _smithy.isa(o, "FailedCreateWorkspaceRequest");
+    return __isa(o, "FailedCreateWorkspaceRequest");
   }
 }
 
@@ -1064,7 +1067,7 @@ export interface FailedWorkspaceChangeRequest {
 
 export namespace FailedWorkspaceChangeRequest {
   export function isa(o: any): o is FailedWorkspaceChangeRequest {
-    return _smithy.isa(o, "FailedWorkspaceChangeRequest");
+    return __isa(o, "FailedWorkspaceChangeRequest");
   }
 }
 
@@ -1098,7 +1101,7 @@ export interface ImportWorkspaceImageRequest {
 
 export namespace ImportWorkspaceImageRequest {
   export function isa(o: any): o is ImportWorkspaceImageRequest {
-    return _smithy.isa(o, "ImportWorkspaceImageRequest");
+    return __isa(o, "ImportWorkspaceImageRequest");
   }
 }
 
@@ -1112,7 +1115,7 @@ export interface ImportWorkspaceImageResult extends $MetadataBearer {
 
 export namespace ImportWorkspaceImageResult {
   export function isa(o: any): o is ImportWorkspaceImageResult {
-    return _smithy.isa(o, "ImportWorkspaceImageResult");
+    return __isa(o, "ImportWorkspaceImageResult");
   }
 }
 
@@ -1120,7 +1123,7 @@ export namespace ImportWorkspaceImageResult {
  * <p>One or more parameter values are not valid.</p>
  */
 export interface InvalidParameterValuesException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidParameterValuesException";
   $fault: "client";
@@ -1132,7 +1135,7 @@ export interface InvalidParameterValuesException
 
 export namespace InvalidParameterValuesException {
   export function isa(o: any): o is InvalidParameterValuesException {
-    return _smithy.isa(o, "InvalidParameterValuesException");
+    return __isa(o, "InvalidParameterValuesException");
   }
 }
 
@@ -1140,7 +1143,7 @@ export namespace InvalidParameterValuesException {
  * <p>The state of the resource is not valid for this operation.</p>
  */
 export interface InvalidResourceStateException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidResourceStateException";
   $fault: "client";
@@ -1149,7 +1152,7 @@ export interface InvalidResourceStateException
 
 export namespace InvalidResourceStateException {
   export function isa(o: any): o is InvalidResourceStateException {
-    return _smithy.isa(o, "InvalidResourceStateException");
+    return __isa(o, "InvalidResourceStateException");
   }
 }
 
@@ -1171,7 +1174,7 @@ export interface IpRuleItem {
 
 export namespace IpRuleItem {
   export function isa(o: any): o is IpRuleItem {
-    return _smithy.isa(o, "IpRuleItem");
+    return __isa(o, "IpRuleItem");
   }
 }
 
@@ -1197,7 +1200,7 @@ export interface ListAvailableManagementCidrRangesRequest {
 
 export namespace ListAvailableManagementCidrRangesRequest {
   export function isa(o: any): o is ListAvailableManagementCidrRangesRequest {
-    return _smithy.isa(o, "ListAvailableManagementCidrRangesRequest");
+    return __isa(o, "ListAvailableManagementCidrRangesRequest");
   }
 }
 
@@ -1218,7 +1221,7 @@ export interface ListAvailableManagementCidrRangesResult
 
 export namespace ListAvailableManagementCidrRangesResult {
   export function isa(o: any): o is ListAvailableManagementCidrRangesResult {
-    return _smithy.isa(o, "ListAvailableManagementCidrRangesResult");
+    return __isa(o, "ListAvailableManagementCidrRangesResult");
   }
 }
 
@@ -1237,7 +1240,7 @@ export interface MigrateWorkspaceRequest {
 
 export namespace MigrateWorkspaceRequest {
   export function isa(o: any): o is MigrateWorkspaceRequest {
-    return _smithy.isa(o, "MigrateWorkspaceRequest");
+    return __isa(o, "MigrateWorkspaceRequest");
   }
 }
 
@@ -1257,7 +1260,7 @@ export interface MigrateWorkspaceResult extends $MetadataBearer {
 
 export namespace MigrateWorkspaceResult {
   export function isa(o: any): o is MigrateWorkspaceResult {
-    return _smithy.isa(o, "MigrateWorkspaceResult");
+    return __isa(o, "MigrateWorkspaceResult");
   }
 }
 
@@ -1285,7 +1288,7 @@ export interface ModificationState {
 
 export namespace ModificationState {
   export function isa(o: any): o is ModificationState {
-    return _smithy.isa(o, "ModificationState");
+    return __isa(o, "ModificationState");
   }
 }
 
@@ -1313,7 +1316,7 @@ export interface ModifyAccountRequest {
 
 export namespace ModifyAccountRequest {
   export function isa(o: any): o is ModifyAccountRequest {
-    return _smithy.isa(o, "ModifyAccountRequest");
+    return __isa(o, "ModifyAccountRequest");
   }
 }
 
@@ -1323,7 +1326,7 @@ export interface ModifyAccountResult extends $MetadataBearer {
 
 export namespace ModifyAccountResult {
   export function isa(o: any): o is ModifyAccountResult {
-    return _smithy.isa(o, "ModifyAccountResult");
+    return __isa(o, "ModifyAccountResult");
   }
 }
 
@@ -1342,7 +1345,7 @@ export interface ModifyClientPropertiesRequest {
 
 export namespace ModifyClientPropertiesRequest {
   export function isa(o: any): o is ModifyClientPropertiesRequest {
-    return _smithy.isa(o, "ModifyClientPropertiesRequest");
+    return __isa(o, "ModifyClientPropertiesRequest");
   }
 }
 
@@ -1352,7 +1355,7 @@ export interface ModifyClientPropertiesResult extends $MetadataBearer {
 
 export namespace ModifyClientPropertiesResult {
   export function isa(o: any): o is ModifyClientPropertiesResult {
-    return _smithy.isa(o, "ModifyClientPropertiesResult");
+    return __isa(o, "ModifyClientPropertiesResult");
   }
 }
 
@@ -1371,7 +1374,7 @@ export interface ModifySelfservicePermissionsRequest {
 
 export namespace ModifySelfservicePermissionsRequest {
   export function isa(o: any): o is ModifySelfservicePermissionsRequest {
-    return _smithy.isa(o, "ModifySelfservicePermissionsRequest");
+    return __isa(o, "ModifySelfservicePermissionsRequest");
   }
 }
 
@@ -1381,7 +1384,7 @@ export interface ModifySelfservicePermissionsResult extends $MetadataBearer {
 
 export namespace ModifySelfservicePermissionsResult {
   export function isa(o: any): o is ModifySelfservicePermissionsResult {
-    return _smithy.isa(o, "ModifySelfservicePermissionsResult");
+    return __isa(o, "ModifySelfservicePermissionsResult");
   }
 }
 
@@ -1400,7 +1403,7 @@ export interface ModifyWorkspaceAccessPropertiesRequest {
 
 export namespace ModifyWorkspaceAccessPropertiesRequest {
   export function isa(o: any): o is ModifyWorkspaceAccessPropertiesRequest {
-    return _smithy.isa(o, "ModifyWorkspaceAccessPropertiesRequest");
+    return __isa(o, "ModifyWorkspaceAccessPropertiesRequest");
   }
 }
 
@@ -1410,7 +1413,7 @@ export interface ModifyWorkspaceAccessPropertiesResult extends $MetadataBearer {
 
 export namespace ModifyWorkspaceAccessPropertiesResult {
   export function isa(o: any): o is ModifyWorkspaceAccessPropertiesResult {
-    return _smithy.isa(o, "ModifyWorkspaceAccessPropertiesResult");
+    return __isa(o, "ModifyWorkspaceAccessPropertiesResult");
   }
 }
 
@@ -1429,7 +1432,7 @@ export interface ModifyWorkspaceCreationPropertiesRequest {
 
 export namespace ModifyWorkspaceCreationPropertiesRequest {
   export function isa(o: any): o is ModifyWorkspaceCreationPropertiesRequest {
-    return _smithy.isa(o, "ModifyWorkspaceCreationPropertiesRequest");
+    return __isa(o, "ModifyWorkspaceCreationPropertiesRequest");
   }
 }
 
@@ -1440,7 +1443,7 @@ export interface ModifyWorkspaceCreationPropertiesResult
 
 export namespace ModifyWorkspaceCreationPropertiesResult {
   export function isa(o: any): o is ModifyWorkspaceCreationPropertiesResult {
-    return _smithy.isa(o, "ModifyWorkspaceCreationPropertiesResult");
+    return __isa(o, "ModifyWorkspaceCreationPropertiesResult");
   }
 }
 
@@ -1459,7 +1462,7 @@ export interface ModifyWorkspacePropertiesRequest {
 
 export namespace ModifyWorkspacePropertiesRequest {
   export function isa(o: any): o is ModifyWorkspacePropertiesRequest {
-    return _smithy.isa(o, "ModifyWorkspacePropertiesRequest");
+    return __isa(o, "ModifyWorkspacePropertiesRequest");
   }
 }
 
@@ -1469,7 +1472,7 @@ export interface ModifyWorkspacePropertiesResult extends $MetadataBearer {
 
 export namespace ModifyWorkspacePropertiesResult {
   export function isa(o: any): o is ModifyWorkspacePropertiesResult {
-    return _smithy.isa(o, "ModifyWorkspacePropertiesResult");
+    return __isa(o, "ModifyWorkspacePropertiesResult");
   }
 }
 
@@ -1488,7 +1491,7 @@ export interface ModifyWorkspaceStateRequest {
 
 export namespace ModifyWorkspaceStateRequest {
   export function isa(o: any): o is ModifyWorkspaceStateRequest {
-    return _smithy.isa(o, "ModifyWorkspaceStateRequest");
+    return __isa(o, "ModifyWorkspaceStateRequest");
   }
 }
 
@@ -1498,7 +1501,7 @@ export interface ModifyWorkspaceStateResult extends $MetadataBearer {
 
 export namespace ModifyWorkspaceStateResult {
   export function isa(o: any): o is ModifyWorkspaceStateResult {
-    return _smithy.isa(o, "ModifyWorkspaceStateResult");
+    return __isa(o, "ModifyWorkspaceStateResult");
   }
 }
 
@@ -1515,7 +1518,7 @@ export interface OperatingSystem {
 
 export namespace OperatingSystem {
   export function isa(o: any): o is OperatingSystem {
-    return _smithy.isa(o, "OperatingSystem");
+    return __isa(o, "OperatingSystem");
   }
 }
 
@@ -1528,7 +1531,7 @@ export enum OperatingSystemType {
  * <p>The properties of this WorkSpace are currently being modified. Try again in a moment.</p>
  */
 export interface OperationInProgressException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "OperationInProgressException";
   $fault: "client";
@@ -1537,7 +1540,7 @@ export interface OperationInProgressException
 
 export namespace OperationInProgressException {
   export function isa(o: any): o is OperationInProgressException {
-    return _smithy.isa(o, "OperationInProgressException");
+    return __isa(o, "OperationInProgressException");
   }
 }
 
@@ -1545,7 +1548,7 @@ export namespace OperationInProgressException {
  * <p>This operation is not supported.</p>
  */
 export interface OperationNotSupportedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "OperationNotSupportedException";
   $fault: "client";
@@ -1554,7 +1557,7 @@ export interface OperationNotSupportedException
 
 export namespace OperationNotSupportedException {
   export function isa(o: any): o is OperationNotSupportedException {
-    return _smithy.isa(o, "OperationNotSupportedException");
+    return __isa(o, "OperationNotSupportedException");
   }
 }
 
@@ -1571,7 +1574,7 @@ export interface RebootRequest {
 
 export namespace RebootRequest {
   export function isa(o: any): o is RebootRequest {
-    return _smithy.isa(o, "RebootRequest");
+    return __isa(o, "RebootRequest");
   }
 }
 
@@ -1585,7 +1588,7 @@ export interface RebootWorkspacesRequest {
 
 export namespace RebootWorkspacesRequest {
   export function isa(o: any): o is RebootWorkspacesRequest {
-    return _smithy.isa(o, "RebootWorkspacesRequest");
+    return __isa(o, "RebootWorkspacesRequest");
   }
 }
 
@@ -1599,7 +1602,7 @@ export interface RebootWorkspacesResult extends $MetadataBearer {
 
 export namespace RebootWorkspacesResult {
   export function isa(o: any): o is RebootWorkspacesResult {
-    return _smithy.isa(o, "RebootWorkspacesResult");
+    return __isa(o, "RebootWorkspacesResult");
   }
 }
 
@@ -1616,7 +1619,7 @@ export interface RebuildRequest {
 
 export namespace RebuildRequest {
   export function isa(o: any): o is RebuildRequest {
-    return _smithy.isa(o, "RebuildRequest");
+    return __isa(o, "RebuildRequest");
   }
 }
 
@@ -1630,7 +1633,7 @@ export interface RebuildWorkspacesRequest {
 
 export namespace RebuildWorkspacesRequest {
   export function isa(o: any): o is RebuildWorkspacesRequest {
-    return _smithy.isa(o, "RebuildWorkspacesRequest");
+    return __isa(o, "RebuildWorkspacesRequest");
   }
 }
 
@@ -1644,7 +1647,7 @@ export interface RebuildWorkspacesResult extends $MetadataBearer {
 
 export namespace RebuildWorkspacesResult {
   export function isa(o: any): o is RebuildWorkspacesResult {
-    return _smithy.isa(o, "RebuildWorkspacesResult");
+    return __isa(o, "RebuildWorkspacesResult");
   }
 }
 
@@ -1700,7 +1703,7 @@ export interface RegisterWorkspaceDirectoryRequest {
 
 export namespace RegisterWorkspaceDirectoryRequest {
   export function isa(o: any): o is RegisterWorkspaceDirectoryRequest {
-    return _smithy.isa(o, "RegisterWorkspaceDirectoryRequest");
+    return __isa(o, "RegisterWorkspaceDirectoryRequest");
   }
 }
 
@@ -1710,7 +1713,7 @@ export interface RegisterWorkspaceDirectoryResult extends $MetadataBearer {
 
 export namespace RegisterWorkspaceDirectoryResult {
   export function isa(o: any): o is RegisterWorkspaceDirectoryResult {
-    return _smithy.isa(o, "RegisterWorkspaceDirectoryResult");
+    return __isa(o, "RegisterWorkspaceDirectoryResult");
   }
 }
 
@@ -1718,7 +1721,7 @@ export namespace RegisterWorkspaceDirectoryResult {
  * <p>The specified resource already exists.</p>
  */
 export interface ResourceAlreadyExistsException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceAlreadyExistsException";
   $fault: "client";
@@ -1727,7 +1730,7 @@ export interface ResourceAlreadyExistsException
 
 export namespace ResourceAlreadyExistsException {
   export function isa(o: any): o is ResourceAlreadyExistsException {
-    return _smithy.isa(o, "ResourceAlreadyExistsException");
+    return __isa(o, "ResourceAlreadyExistsException");
   }
 }
 
@@ -1735,7 +1738,7 @@ export namespace ResourceAlreadyExistsException {
  * <p>The resource is associated with a directory.</p>
  */
 export interface ResourceAssociatedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceAssociatedException";
   $fault: "client";
@@ -1744,7 +1747,7 @@ export interface ResourceAssociatedException
 
 export namespace ResourceAssociatedException {
   export function isa(o: any): o is ResourceAssociatedException {
-    return _smithy.isa(o, "ResourceAssociatedException");
+    return __isa(o, "ResourceAssociatedException");
   }
 }
 
@@ -1752,7 +1755,7 @@ export namespace ResourceAssociatedException {
  * <p>The resource could not be created.</p>
  */
 export interface ResourceCreationFailedException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceCreationFailedException";
   $fault: "client";
@@ -1761,7 +1764,7 @@ export interface ResourceCreationFailedException
 
 export namespace ResourceCreationFailedException {
   export function isa(o: any): o is ResourceCreationFailedException {
-    return _smithy.isa(o, "ResourceCreationFailedException");
+    return __isa(o, "ResourceCreationFailedException");
   }
 }
 
@@ -1769,7 +1772,7 @@ export namespace ResourceCreationFailedException {
  * <p>Your resource limits have been exceeded.</p>
  */
 export interface ResourceLimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceLimitExceededException";
   $fault: "client";
@@ -1781,7 +1784,7 @@ export interface ResourceLimitExceededException
 
 export namespace ResourceLimitExceededException {
   export function isa(o: any): o is ResourceLimitExceededException {
-    return _smithy.isa(o, "ResourceLimitExceededException");
+    return __isa(o, "ResourceLimitExceededException");
   }
 }
 
@@ -1789,7 +1792,7 @@ export namespace ResourceLimitExceededException {
  * <p>The resource could not be found.</p>
  */
 export interface ResourceNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
@@ -1806,7 +1809,7 @@ export interface ResourceNotFoundException
 
 export namespace ResourceNotFoundException {
   export function isa(o: any): o is ResourceNotFoundException {
-    return _smithy.isa(o, "ResourceNotFoundException");
+    return __isa(o, "ResourceNotFoundException");
   }
 }
 
@@ -1814,7 +1817,7 @@ export namespace ResourceNotFoundException {
  * <p>The specified resource is not available.</p>
  */
 export interface ResourceUnavailableException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "ResourceUnavailableException";
   $fault: "client";
@@ -1831,7 +1834,7 @@ export interface ResourceUnavailableException
 
 export namespace ResourceUnavailableException {
   export function isa(o: any): o is ResourceUnavailableException {
-    return _smithy.isa(o, "ResourceUnavailableException");
+    return __isa(o, "ResourceUnavailableException");
   }
 }
 
@@ -1845,7 +1848,7 @@ export interface RestoreWorkspaceRequest {
 
 export namespace RestoreWorkspaceRequest {
   export function isa(o: any): o is RestoreWorkspaceRequest {
-    return _smithy.isa(o, "RestoreWorkspaceRequest");
+    return __isa(o, "RestoreWorkspaceRequest");
   }
 }
 
@@ -1855,7 +1858,7 @@ export interface RestoreWorkspaceResult extends $MetadataBearer {
 
 export namespace RestoreWorkspaceResult {
   export function isa(o: any): o is RestoreWorkspaceResult {
-    return _smithy.isa(o, "RestoreWorkspaceResult");
+    return __isa(o, "RestoreWorkspaceResult");
   }
 }
 
@@ -1874,7 +1877,7 @@ export interface RevokeIpRulesRequest {
 
 export namespace RevokeIpRulesRequest {
   export function isa(o: any): o is RevokeIpRulesRequest {
-    return _smithy.isa(o, "RevokeIpRulesRequest");
+    return __isa(o, "RevokeIpRulesRequest");
   }
 }
 
@@ -1884,7 +1887,7 @@ export interface RevokeIpRulesResult extends $MetadataBearer {
 
 export namespace RevokeIpRulesResult {
   export function isa(o: any): o is RevokeIpRulesResult {
-    return _smithy.isa(o, "RevokeIpRulesResult");
+    return __isa(o, "RevokeIpRulesResult");
   }
 }
 
@@ -1901,7 +1904,7 @@ export interface RootStorage {
 
 export namespace RootStorage {
   export function isa(o: any): o is RootStorage {
-    return _smithy.isa(o, "RootStorage");
+    return __isa(o, "RootStorage");
   }
 }
 
@@ -1945,7 +1948,7 @@ export interface SelfservicePermissions {
 
 export namespace SelfservicePermissions {
   export function isa(o: any): o is SelfservicePermissions {
-    return _smithy.isa(o, "SelfservicePermissions");
+    return __isa(o, "SelfservicePermissions");
   }
 }
 
@@ -1962,7 +1965,7 @@ export interface Snapshot {
 
 export namespace Snapshot {
   export function isa(o: any): o is Snapshot {
-    return _smithy.isa(o, "Snapshot");
+    return __isa(o, "Snapshot");
   }
 }
 
@@ -1979,7 +1982,7 @@ export interface StartRequest {
 
 export namespace StartRequest {
   export function isa(o: any): o is StartRequest {
-    return _smithy.isa(o, "StartRequest");
+    return __isa(o, "StartRequest");
   }
 }
 
@@ -1993,7 +1996,7 @@ export interface StartWorkspacesRequest {
 
 export namespace StartWorkspacesRequest {
   export function isa(o: any): o is StartWorkspacesRequest {
-    return _smithy.isa(o, "StartWorkspacesRequest");
+    return __isa(o, "StartWorkspacesRequest");
   }
 }
 
@@ -2007,7 +2010,7 @@ export interface StartWorkspacesResult extends $MetadataBearer {
 
 export namespace StartWorkspacesResult {
   export function isa(o: any): o is StartWorkspacesResult {
-    return _smithy.isa(o, "StartWorkspacesResult");
+    return __isa(o, "StartWorkspacesResult");
   }
 }
 
@@ -2024,7 +2027,7 @@ export interface StopRequest {
 
 export namespace StopRequest {
   export function isa(o: any): o is StopRequest {
-    return _smithy.isa(o, "StopRequest");
+    return __isa(o, "StopRequest");
   }
 }
 
@@ -2038,7 +2041,7 @@ export interface StopWorkspacesRequest {
 
 export namespace StopWorkspacesRequest {
   export function isa(o: any): o is StopWorkspacesRequest {
-    return _smithy.isa(o, "StopWorkspacesRequest");
+    return __isa(o, "StopWorkspacesRequest");
   }
 }
 
@@ -2052,7 +2055,7 @@ export interface StopWorkspacesResult extends $MetadataBearer {
 
 export namespace StopWorkspacesResult {
   export function isa(o: any): o is StopWorkspacesResult {
-    return _smithy.isa(o, "StopWorkspacesResult");
+    return __isa(o, "StopWorkspacesResult");
   }
 }
 
@@ -2074,7 +2077,7 @@ export interface Tag {
 
 export namespace Tag {
   export function isa(o: any): o is Tag {
-    return _smithy.isa(o, "Tag");
+    return __isa(o, "Tag");
   }
 }
 
@@ -2101,7 +2104,7 @@ export interface TerminateRequest {
 
 export namespace TerminateRequest {
   export function isa(o: any): o is TerminateRequest {
-    return _smithy.isa(o, "TerminateRequest");
+    return __isa(o, "TerminateRequest");
   }
 }
 
@@ -2115,7 +2118,7 @@ export interface TerminateWorkspacesRequest {
 
 export namespace TerminateWorkspacesRequest {
   export function isa(o: any): o is TerminateWorkspacesRequest {
-    return _smithy.isa(o, "TerminateWorkspacesRequest");
+    return __isa(o, "TerminateWorkspacesRequest");
   }
 }
 
@@ -2129,7 +2132,7 @@ export interface TerminateWorkspacesResult extends $MetadataBearer {
 
 export namespace TerminateWorkspacesResult {
   export function isa(o: any): o is TerminateWorkspacesResult {
-    return _smithy.isa(o, "TerminateWorkspacesResult");
+    return __isa(o, "TerminateWorkspacesResult");
   }
 }
 
@@ -2140,7 +2143,7 @@ export namespace TerminateWorkspacesResult {
  *             Configure a VPC for Amazon WorkSpaces</a>.</p>
  */
 export interface UnsupportedNetworkConfigurationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UnsupportedNetworkConfigurationException";
   $fault: "client";
@@ -2149,7 +2152,7 @@ export interface UnsupportedNetworkConfigurationException
 
 export namespace UnsupportedNetworkConfigurationException {
   export function isa(o: any): o is UnsupportedNetworkConfigurationException {
-    return _smithy.isa(o, "UnsupportedNetworkConfigurationException");
+    return __isa(o, "UnsupportedNetworkConfigurationException");
   }
 }
 
@@ -2159,7 +2162,7 @@ export namespace UnsupportedNetworkConfigurationException {
  *             Configuration and Service Components for WorkSpaces </a>.</p>
  */
 export interface UnsupportedWorkspaceConfigurationException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "UnsupportedWorkspaceConfigurationException";
   $fault: "client";
@@ -2168,7 +2171,7 @@ export interface UnsupportedWorkspaceConfigurationException
 
 export namespace UnsupportedWorkspaceConfigurationException {
   export function isa(o: any): o is UnsupportedWorkspaceConfigurationException {
-    return _smithy.isa(o, "UnsupportedWorkspaceConfigurationException");
+    return __isa(o, "UnsupportedWorkspaceConfigurationException");
   }
 }
 
@@ -2187,7 +2190,7 @@ export interface UpdateRulesOfIpGroupRequest {
 
 export namespace UpdateRulesOfIpGroupRequest {
   export function isa(o: any): o is UpdateRulesOfIpGroupRequest {
-    return _smithy.isa(o, "UpdateRulesOfIpGroupRequest");
+    return __isa(o, "UpdateRulesOfIpGroupRequest");
   }
 }
 
@@ -2197,7 +2200,7 @@ export interface UpdateRulesOfIpGroupResult extends $MetadataBearer {
 
 export namespace UpdateRulesOfIpGroupResult {
   export function isa(o: any): o is UpdateRulesOfIpGroupResult {
-    return _smithy.isa(o, "UpdateRulesOfIpGroupResult");
+    return __isa(o, "UpdateRulesOfIpGroupResult");
   }
 }
 
@@ -2214,7 +2217,7 @@ export interface UserStorage {
 
 export namespace UserStorage {
   export function isa(o: any): o is UserStorage {
-    return _smithy.isa(o, "UserStorage");
+    return __isa(o, "UserStorage");
   }
 }
 
@@ -2303,7 +2306,7 @@ export interface Workspace {
 
 export namespace Workspace {
   export function isa(o: any): o is Workspace {
-    return _smithy.isa(o, "Workspace");
+    return __isa(o, "Workspace");
   }
 }
 
@@ -2358,7 +2361,7 @@ export interface WorkspaceAccessProperties {
 
 export namespace WorkspaceAccessProperties {
   export function isa(o: any): o is WorkspaceAccessProperties {
-    return _smithy.isa(o, "WorkspaceAccessProperties");
+    return __isa(o, "WorkspaceAccessProperties");
   }
 }
 
@@ -2416,7 +2419,7 @@ export interface WorkspaceBundle {
 
 export namespace WorkspaceBundle {
   export function isa(o: any): o is WorkspaceBundle {
-    return _smithy.isa(o, "WorkspaceBundle");
+    return __isa(o, "WorkspaceBundle");
   }
 }
 
@@ -2449,7 +2452,7 @@ export interface WorkspaceConnectionStatus {
 
 export namespace WorkspaceConnectionStatus {
   export function isa(o: any): o is WorkspaceConnectionStatus {
-    return _smithy.isa(o, "WorkspaceConnectionStatus");
+    return __isa(o, "WorkspaceConnectionStatus");
   }
 }
 
@@ -2490,7 +2493,7 @@ export interface WorkspaceCreationProperties {
 
 export namespace WorkspaceCreationProperties {
   export function isa(o: any): o is WorkspaceCreationProperties {
-    return _smithy.isa(o, "WorkspaceCreationProperties");
+    return __isa(o, "WorkspaceCreationProperties");
   }
 }
 
@@ -2586,7 +2589,7 @@ export interface WorkspaceDirectory {
 
 export namespace WorkspaceDirectory {
   export function isa(o: any): o is WorkspaceDirectory {
-    return _smithy.isa(o, "WorkspaceDirectory");
+    return __isa(o, "WorkspaceDirectory");
   }
 }
 
@@ -2654,7 +2657,7 @@ export interface WorkspaceImage {
 
 export namespace WorkspaceImage {
   export function isa(o: any): o is WorkspaceImage {
-    return _smithy.isa(o, "WorkspaceImage");
+    return __isa(o, "WorkspaceImage");
   }
 }
 
@@ -2710,7 +2713,7 @@ export interface WorkspaceProperties {
 
 export namespace WorkspaceProperties {
   export function isa(o: any): o is WorkspaceProperties {
-    return _smithy.isa(o, "WorkspaceProperties");
+    return __isa(o, "WorkspaceProperties");
   }
 }
 
@@ -2765,7 +2768,7 @@ export interface WorkspaceRequest {
 
 export namespace WorkspaceRequest {
   export function isa(o: any): o is WorkspaceRequest {
-    return _smithy.isa(o, "WorkspaceRequest");
+    return __isa(o, "WorkspaceRequest");
   }
 }
 
@@ -2794,7 +2797,7 @@ export enum WorkspaceState {
  *          will need to create the workspaces_DefaultRole role before you can register a directory. For more information, see <a href="https://docs.aws.amazon.com/workspaces/latest/adminguide/workspaces-access-control.html#create-default-role">Creating the workspaces_DefaultRole Role</a>.</p>
  */
 export interface WorkspacesDefaultRoleNotFoundException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "WorkspacesDefaultRoleNotFoundException";
   $fault: "client";
@@ -2803,7 +2806,7 @@ export interface WorkspacesDefaultRoleNotFoundException
 
 export namespace WorkspacesDefaultRoleNotFoundException {
   export function isa(o: any): o is WorkspacesDefaultRoleNotFoundException {
-    return _smithy.isa(o, "WorkspacesDefaultRoleNotFoundException");
+    return __isa(o, "WorkspacesDefaultRoleNotFoundException");
   }
 }
 
@@ -2835,6 +2838,6 @@ export interface WorkspacesIpGroup {
 
 export namespace WorkspacesIpGroup {
   export function isa(o: any): o is WorkspacesIpGroup {
-    return _smithy.isa(o, "WorkspacesIpGroup");
+    return __isa(o, "WorkspacesIpGroup");
   }
 }

--- a/clients/client-xray/models/index.ts
+++ b/clients/client-xray/models/index.ts
@@ -1,4 +1,7 @@
-import * as _smithy from "@aws-sdk/smithy-client";
+import {
+  SmithyException as __SmithyException,
+  isa as __isa
+} from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**
@@ -24,7 +27,7 @@ export interface Alias {
 
 export namespace Alias {
   export function isa(o: any): o is Alias {
-    return _smithy.isa(o, "Alias");
+    return __isa(o, "Alias");
   }
 }
 
@@ -52,7 +55,7 @@ export interface AnnotationValue {
 
 export namespace AnnotationValue {
   export function isa(o: any): o is AnnotationValue {
-    return _smithy.isa(o, "AnnotationValue");
+    return __isa(o, "AnnotationValue");
   }
 }
 
@@ -69,7 +72,7 @@ export interface AvailabilityZoneDetail {
 
 export namespace AvailabilityZoneDetail {
   export function isa(o: any): o is AvailabilityZoneDetail {
-    return _smithy.isa(o, "AvailabilityZoneDetail");
+    return __isa(o, "AvailabilityZoneDetail");
   }
 }
 
@@ -111,7 +114,7 @@ export interface BackendConnectionErrors {
 
 export namespace BackendConnectionErrors {
   export function isa(o: any): o is BackendConnectionErrors {
-    return _smithy.isa(o, "BackendConnectionErrors");
+    return __isa(o, "BackendConnectionErrors");
   }
 }
 
@@ -130,7 +133,7 @@ export interface BatchGetTracesRequest {
 
 export namespace BatchGetTracesRequest {
   export function isa(o: any): o is BatchGetTracesRequest {
-    return _smithy.isa(o, "BatchGetTracesRequest");
+    return __isa(o, "BatchGetTracesRequest");
   }
 }
 
@@ -154,7 +157,7 @@ export interface BatchGetTracesResult extends $MetadataBearer {
 
 export namespace BatchGetTracesResult {
   export function isa(o: any): o is BatchGetTracesResult {
-    return _smithy.isa(o, "BatchGetTracesResult");
+    return __isa(o, "BatchGetTracesResult");
   }
 }
 
@@ -174,7 +177,7 @@ export interface CreateGroupRequest {
 
 export namespace CreateGroupRequest {
   export function isa(o: any): o is CreateGroupRequest {
-    return _smithy.isa(o, "CreateGroupRequest");
+    return __isa(o, "CreateGroupRequest");
   }
 }
 
@@ -190,7 +193,7 @@ export interface CreateGroupResult extends $MetadataBearer {
 
 export namespace CreateGroupResult {
   export function isa(o: any): o is CreateGroupResult {
-    return _smithy.isa(o, "CreateGroupResult");
+    return __isa(o, "CreateGroupResult");
   }
 }
 
@@ -204,7 +207,7 @@ export interface CreateSamplingRuleRequest {
 
 export namespace CreateSamplingRuleRequest {
   export function isa(o: any): o is CreateSamplingRuleRequest {
-    return _smithy.isa(o, "CreateSamplingRuleRequest");
+    return __isa(o, "CreateSamplingRuleRequest");
   }
 }
 
@@ -218,7 +221,7 @@ export interface CreateSamplingRuleResult extends $MetadataBearer {
 
 export namespace CreateSamplingRuleResult {
   export function isa(o: any): o is CreateSamplingRuleResult {
-    return _smithy.isa(o, "CreateSamplingRuleResult");
+    return __isa(o, "CreateSamplingRuleResult");
   }
 }
 
@@ -237,7 +240,7 @@ export interface DeleteGroupRequest {
 
 export namespace DeleteGroupRequest {
   export function isa(o: any): o is DeleteGroupRequest {
-    return _smithy.isa(o, "DeleteGroupRequest");
+    return __isa(o, "DeleteGroupRequest");
   }
 }
 
@@ -247,7 +250,7 @@ export interface DeleteGroupResult extends $MetadataBearer {
 
 export namespace DeleteGroupResult {
   export function isa(o: any): o is DeleteGroupResult {
-    return _smithy.isa(o, "DeleteGroupResult");
+    return __isa(o, "DeleteGroupResult");
   }
 }
 
@@ -266,7 +269,7 @@ export interface DeleteSamplingRuleRequest {
 
 export namespace DeleteSamplingRuleRequest {
   export function isa(o: any): o is DeleteSamplingRuleRequest {
-    return _smithy.isa(o, "DeleteSamplingRuleRequest");
+    return __isa(o, "DeleteSamplingRuleRequest");
   }
 }
 
@@ -280,7 +283,7 @@ export interface DeleteSamplingRuleResult extends $MetadataBearer {
 
 export namespace DeleteSamplingRuleResult {
   export function isa(o: any): o is DeleteSamplingRuleResult {
-    return _smithy.isa(o, "DeleteSamplingRuleResult");
+    return __isa(o, "DeleteSamplingRuleResult");
   }
 }
 
@@ -322,7 +325,7 @@ export interface Edge {
 
 export namespace Edge {
   export function isa(o: any): o is Edge {
-    return _smithy.isa(o, "Edge");
+    return __isa(o, "Edge");
   }
 }
 
@@ -359,7 +362,7 @@ export interface EdgeStatistics {
 
 export namespace EdgeStatistics {
   export function isa(o: any): o is EdgeStatistics {
-    return _smithy.isa(o, "EdgeStatistics");
+    return __isa(o, "EdgeStatistics");
   }
 }
 
@@ -387,7 +390,7 @@ export interface EncryptionConfig {
 
 export namespace EncryptionConfig {
   export function isa(o: any): o is EncryptionConfig {
-    return _smithy.isa(o, "EncryptionConfig");
+    return __isa(o, "EncryptionConfig");
   }
 }
 
@@ -415,7 +418,7 @@ export interface ErrorRootCause {
 
 export namespace ErrorRootCause {
   export function isa(o: any): o is ErrorRootCause {
-    return _smithy.isa(o, "ErrorRootCause");
+    return __isa(o, "ErrorRootCause");
   }
 }
 
@@ -443,7 +446,7 @@ export interface ErrorRootCauseEntity {
 
 export namespace ErrorRootCauseEntity {
   export function isa(o: any): o is ErrorRootCauseEntity {
-    return _smithy.isa(o, "ErrorRootCauseEntity");
+    return __isa(o, "ErrorRootCauseEntity");
   }
 }
 
@@ -485,7 +488,7 @@ export interface ErrorRootCauseService {
 
 export namespace ErrorRootCauseService {
   export function isa(o: any): o is ErrorRootCauseService {
-    return _smithy.isa(o, "ErrorRootCauseService");
+    return __isa(o, "ErrorRootCauseService");
   }
 }
 
@@ -513,7 +516,7 @@ export interface ErrorStatistics {
 
 export namespace ErrorStatistics {
   export function isa(o: any): o is ErrorStatistics {
-    return _smithy.isa(o, "ErrorStatistics");
+    return __isa(o, "ErrorStatistics");
   }
 }
 
@@ -531,7 +534,7 @@ export interface FaultRootCause {
 
 export namespace FaultRootCause {
   export function isa(o: any): o is FaultRootCause {
-    return _smithy.isa(o, "FaultRootCause");
+    return __isa(o, "FaultRootCause");
   }
 }
 
@@ -559,7 +562,7 @@ export interface FaultRootCauseEntity {
 
 export namespace FaultRootCauseEntity {
   export function isa(o: any): o is FaultRootCauseEntity {
-    return _smithy.isa(o, "FaultRootCauseEntity");
+    return __isa(o, "FaultRootCauseEntity");
   }
 }
 
@@ -601,7 +604,7 @@ export interface FaultRootCauseService {
 
 export namespace FaultRootCauseService {
   export function isa(o: any): o is FaultRootCauseService {
-    return _smithy.isa(o, "FaultRootCauseService");
+    return __isa(o, "FaultRootCauseService");
   }
 }
 
@@ -624,7 +627,7 @@ export interface FaultStatistics {
 
 export namespace FaultStatistics {
   export function isa(o: any): o is FaultStatistics {
-    return _smithy.isa(o, "FaultStatistics");
+    return __isa(o, "FaultStatistics");
   }
 }
 
@@ -634,7 +637,7 @@ export interface GetEncryptionConfigRequest {
 
 export namespace GetEncryptionConfigRequest {
   export function isa(o: any): o is GetEncryptionConfigRequest {
-    return _smithy.isa(o, "GetEncryptionConfigRequest");
+    return __isa(o, "GetEncryptionConfigRequest");
   }
 }
 
@@ -648,7 +651,7 @@ export interface GetEncryptionConfigResult extends $MetadataBearer {
 
 export namespace GetEncryptionConfigResult {
   export function isa(o: any): o is GetEncryptionConfigResult {
-    return _smithy.isa(o, "GetEncryptionConfigResult");
+    return __isa(o, "GetEncryptionConfigResult");
   }
 }
 
@@ -667,7 +670,7 @@ export interface GetGroupRequest {
 
 export namespace GetGroupRequest {
   export function isa(o: any): o is GetGroupRequest {
-    return _smithy.isa(o, "GetGroupRequest");
+    return __isa(o, "GetGroupRequest");
   }
 }
 
@@ -682,7 +685,7 @@ export interface GetGroupResult extends $MetadataBearer {
 
 export namespace GetGroupResult {
   export function isa(o: any): o is GetGroupResult {
-    return _smithy.isa(o, "GetGroupResult");
+    return __isa(o, "GetGroupResult");
   }
 }
 
@@ -696,7 +699,7 @@ export interface GetGroupsRequest {
 
 export namespace GetGroupsRequest {
   export function isa(o: any): o is GetGroupsRequest {
-    return _smithy.isa(o, "GetGroupsRequest");
+    return __isa(o, "GetGroupsRequest");
   }
 }
 
@@ -715,7 +718,7 @@ export interface GetGroupsResult extends $MetadataBearer {
 
 export namespace GetGroupsResult {
   export function isa(o: any): o is GetGroupsResult {
-    return _smithy.isa(o, "GetGroupsResult");
+    return __isa(o, "GetGroupsResult");
   }
 }
 
@@ -729,7 +732,7 @@ export interface GetSamplingRulesRequest {
 
 export namespace GetSamplingRulesRequest {
   export function isa(o: any): o is GetSamplingRulesRequest {
-    return _smithy.isa(o, "GetSamplingRulesRequest");
+    return __isa(o, "GetSamplingRulesRequest");
   }
 }
 
@@ -748,7 +751,7 @@ export interface GetSamplingRulesResult extends $MetadataBearer {
 
 export namespace GetSamplingRulesResult {
   export function isa(o: any): o is GetSamplingRulesResult {
-    return _smithy.isa(o, "GetSamplingRulesResult");
+    return __isa(o, "GetSamplingRulesResult");
   }
 }
 
@@ -762,7 +765,7 @@ export interface GetSamplingStatisticSummariesRequest {
 
 export namespace GetSamplingStatisticSummariesRequest {
   export function isa(o: any): o is GetSamplingStatisticSummariesRequest {
-    return _smithy.isa(o, "GetSamplingStatisticSummariesRequest");
+    return __isa(o, "GetSamplingStatisticSummariesRequest");
   }
 }
 
@@ -782,7 +785,7 @@ export interface GetSamplingStatisticSummariesResult extends $MetadataBearer {
 
 export namespace GetSamplingStatisticSummariesResult {
   export function isa(o: any): o is GetSamplingStatisticSummariesResult {
-    return _smithy.isa(o, "GetSamplingStatisticSummariesResult");
+    return __isa(o, "GetSamplingStatisticSummariesResult");
   }
 }
 
@@ -796,7 +799,7 @@ export interface GetSamplingTargetsRequest {
 
 export namespace GetSamplingTargetsRequest {
   export function isa(o: any): o is GetSamplingTargetsRequest {
-    return _smithy.isa(o, "GetSamplingTargetsRequest");
+    return __isa(o, "GetSamplingTargetsRequest");
   }
 }
 
@@ -823,7 +826,7 @@ export interface GetSamplingTargetsResult extends $MetadataBearer {
 
 export namespace GetSamplingTargetsResult {
   export function isa(o: any): o is GetSamplingTargetsResult {
-    return _smithy.isa(o, "GetSamplingTargetsResult");
+    return __isa(o, "GetSamplingTargetsResult");
   }
 }
 
@@ -857,7 +860,7 @@ export interface GetServiceGraphRequest {
 
 export namespace GetServiceGraphRequest {
   export function isa(o: any): o is GetServiceGraphRequest {
-    return _smithy.isa(o, "GetServiceGraphRequest");
+    return __isa(o, "GetServiceGraphRequest");
   }
 }
 
@@ -894,7 +897,7 @@ export interface GetServiceGraphResult extends $MetadataBearer {
 
 export namespace GetServiceGraphResult {
   export function isa(o: any): o is GetServiceGraphResult {
-    return _smithy.isa(o, "GetServiceGraphResult");
+    return __isa(o, "GetServiceGraphResult");
   }
 }
 
@@ -940,7 +943,7 @@ export interface GetTimeSeriesServiceStatisticsRequest {
 
 export namespace GetTimeSeriesServiceStatisticsRequest {
   export function isa(o: any): o is GetTimeSeriesServiceStatisticsRequest {
-    return _smithy.isa(o, "GetTimeSeriesServiceStatisticsRequest");
+    return __isa(o, "GetTimeSeriesServiceStatisticsRequest");
   }
 }
 
@@ -966,7 +969,7 @@ export interface GetTimeSeriesServiceStatisticsResult extends $MetadataBearer {
 
 export namespace GetTimeSeriesServiceStatisticsResult {
   export function isa(o: any): o is GetTimeSeriesServiceStatisticsResult {
-    return _smithy.isa(o, "GetTimeSeriesServiceStatisticsResult");
+    return __isa(o, "GetTimeSeriesServiceStatisticsResult");
   }
 }
 
@@ -985,7 +988,7 @@ export interface GetTraceGraphRequest {
 
 export namespace GetTraceGraphRequest {
   export function isa(o: any): o is GetTraceGraphRequest {
-    return _smithy.isa(o, "GetTraceGraphRequest");
+    return __isa(o, "GetTraceGraphRequest");
   }
 }
 
@@ -1004,7 +1007,7 @@ export interface GetTraceGraphResult extends $MetadataBearer {
 
 export namespace GetTraceGraphResult {
   export function isa(o: any): o is GetTraceGraphResult {
-    return _smithy.isa(o, "GetTraceGraphResult");
+    return __isa(o, "GetTraceGraphResult");
   }
 }
 
@@ -1052,7 +1055,7 @@ export interface GetTraceSummariesRequest {
 
 export namespace GetTraceSummariesRequest {
   export function isa(o: any): o is GetTraceSummariesRequest {
-    return _smithy.isa(o, "GetTraceSummariesRequest");
+    return __isa(o, "GetTraceSummariesRequest");
   }
 }
 
@@ -1085,7 +1088,7 @@ export interface GetTraceSummariesResult extends $MetadataBearer {
 
 export namespace GetTraceSummariesResult {
   export function isa(o: any): o is GetTraceSummariesResult {
-    return _smithy.isa(o, "GetTraceSummariesResult");
+    return __isa(o, "GetTraceSummariesResult");
   }
 }
 
@@ -1112,7 +1115,7 @@ export interface Group {
 
 export namespace Group {
   export function isa(o: any): o is Group {
-    return _smithy.isa(o, "Group");
+    return __isa(o, "Group");
   }
 }
 
@@ -1139,7 +1142,7 @@ export interface GroupSummary {
 
 export namespace GroupSummary {
   export function isa(o: any): o is GroupSummary {
-    return _smithy.isa(o, "GroupSummary");
+    return __isa(o, "GroupSummary");
   }
 }
 
@@ -1162,7 +1165,7 @@ export interface HistogramEntry {
 
 export namespace HistogramEntry {
   export function isa(o: any): o is HistogramEntry {
-    return _smithy.isa(o, "HistogramEntry");
+    return __isa(o, "HistogramEntry");
   }
 }
 
@@ -1199,7 +1202,7 @@ export interface Http {
 
 export namespace Http {
   export function isa(o: any): o is Http {
-    return _smithy.isa(o, "Http");
+    return __isa(o, "Http");
   }
 }
 
@@ -1216,7 +1219,7 @@ export interface InstanceIdDetail {
 
 export namespace InstanceIdDetail {
   export function isa(o: any): o is InstanceIdDetail {
-    return _smithy.isa(o, "InstanceIdDetail");
+    return __isa(o, "InstanceIdDetail");
   }
 }
 
@@ -1224,7 +1227,7 @@ export namespace InstanceIdDetail {
  * <p>The request is missing required parameters or has invalid parameters.</p>
  */
 export interface InvalidRequestException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "InvalidRequestException";
   $fault: "client";
@@ -1233,7 +1236,7 @@ export interface InvalidRequestException
 
 export namespace InvalidRequestException {
   export function isa(o: any): o is InvalidRequestException {
-    return _smithy.isa(o, "InvalidRequestException");
+    return __isa(o, "InvalidRequestException");
   }
 }
 
@@ -1273,7 +1276,7 @@ export interface PutEncryptionConfigRequest {
 
 export namespace PutEncryptionConfigRequest {
   export function isa(o: any): o is PutEncryptionConfigRequest {
-    return _smithy.isa(o, "PutEncryptionConfigRequest");
+    return __isa(o, "PutEncryptionConfigRequest");
   }
 }
 
@@ -1287,7 +1290,7 @@ export interface PutEncryptionConfigResult extends $MetadataBearer {
 
 export namespace PutEncryptionConfigResult {
   export function isa(o: any): o is PutEncryptionConfigResult {
-    return _smithy.isa(o, "PutEncryptionConfigResult");
+    return __isa(o, "PutEncryptionConfigResult");
   }
 }
 
@@ -1316,7 +1319,7 @@ export interface PutTelemetryRecordsRequest {
 
 export namespace PutTelemetryRecordsRequest {
   export function isa(o: any): o is PutTelemetryRecordsRequest {
-    return _smithy.isa(o, "PutTelemetryRecordsRequest");
+    return __isa(o, "PutTelemetryRecordsRequest");
   }
 }
 
@@ -1326,7 +1329,7 @@ export interface PutTelemetryRecordsResult extends $MetadataBearer {
 
 export namespace PutTelemetryRecordsResult {
   export function isa(o: any): o is PutTelemetryRecordsResult {
-    return _smithy.isa(o, "PutTelemetryRecordsResult");
+    return __isa(o, "PutTelemetryRecordsResult");
   }
 }
 
@@ -1341,7 +1344,7 @@ export interface PutTraceSegmentsRequest {
 
 export namespace PutTraceSegmentsRequest {
   export function isa(o: any): o is PutTraceSegmentsRequest {
-    return _smithy.isa(o, "PutTraceSegmentsRequest");
+    return __isa(o, "PutTraceSegmentsRequest");
   }
 }
 
@@ -1355,7 +1358,7 @@ export interface PutTraceSegmentsResult extends $MetadataBearer {
 
 export namespace PutTraceSegmentsResult {
   export function isa(o: any): o is PutTraceSegmentsResult {
-    return _smithy.isa(o, "PutTraceSegmentsResult");
+    return __isa(o, "PutTraceSegmentsResult");
   }
 }
 
@@ -1372,7 +1375,7 @@ export interface ResourceARNDetail {
 
 export namespace ResourceARNDetail {
   export function isa(o: any): o is ResourceARNDetail {
-    return _smithy.isa(o, "ResourceARNDetail");
+    return __isa(o, "ResourceARNDetail");
   }
 }
 
@@ -1390,7 +1393,7 @@ export interface ResponseTimeRootCause {
 
 export namespace ResponseTimeRootCause {
   export function isa(o: any): o is ResponseTimeRootCause {
-    return _smithy.isa(o, "ResponseTimeRootCause");
+    return __isa(o, "ResponseTimeRootCause");
   }
 }
 
@@ -1418,7 +1421,7 @@ export interface ResponseTimeRootCauseEntity {
 
 export namespace ResponseTimeRootCauseEntity {
   export function isa(o: any): o is ResponseTimeRootCauseEntity {
-    return _smithy.isa(o, "ResponseTimeRootCauseEntity");
+    return __isa(o, "ResponseTimeRootCauseEntity");
   }
 }
 
@@ -1460,7 +1463,7 @@ export interface ResponseTimeRootCauseService {
 
 export namespace ResponseTimeRootCauseService {
   export function isa(o: any): o is ResponseTimeRootCauseService {
-    return _smithy.isa(o, "ResponseTimeRootCauseService");
+    return __isa(o, "ResponseTimeRootCauseService");
   }
 }
 
@@ -1482,7 +1485,7 @@ export interface RootCauseException {
 
 export namespace RootCauseException {
   export function isa(o: any): o is RootCauseException {
-    return _smithy.isa(o, "RootCauseException");
+    return __isa(o, "RootCauseException");
   }
 }
 
@@ -1490,7 +1493,7 @@ export namespace RootCauseException {
  * <p>You have reached the maximum number of sampling rules.</p>
  */
 export interface RuleLimitExceededException
-  extends _smithy.SmithyException,
+  extends __SmithyException,
     $MetadataBearer {
   name: "RuleLimitExceededException";
   $fault: "client";
@@ -1499,7 +1502,7 @@ export interface RuleLimitExceededException
 
 export namespace RuleLimitExceededException {
   export function isa(o: any): o is RuleLimitExceededException {
-    return _smithy.isa(o, "RuleLimitExceededException");
+    return __isa(o, "RuleLimitExceededException");
   }
 }
 
@@ -1580,7 +1583,7 @@ export interface SamplingRule {
 
 export namespace SamplingRule {
   export function isa(o: any): o is SamplingRule {
-    return _smithy.isa(o, "SamplingRule");
+    return __isa(o, "SamplingRule");
   }
 }
 
@@ -1607,7 +1610,7 @@ export interface SamplingRuleRecord {
 
 export namespace SamplingRuleRecord {
   export function isa(o: any): o is SamplingRuleRecord {
-    return _smithy.isa(o, "SamplingRuleRecord");
+    return __isa(o, "SamplingRuleRecord");
   }
 }
 
@@ -1681,7 +1684,7 @@ export interface SamplingRuleUpdate {
 
 export namespace SamplingRuleUpdate {
   export function isa(o: any): o is SamplingRuleUpdate {
-    return _smithy.isa(o, "SamplingRuleUpdate");
+    return __isa(o, "SamplingRuleUpdate");
   }
 }
 
@@ -1719,7 +1722,7 @@ export interface SamplingStatisticSummary {
 
 export namespace SamplingStatisticSummary {
   export function isa(o: any): o is SamplingStatisticSummary {
-    return _smithy.isa(o, "SamplingStatisticSummary");
+    return __isa(o, "SamplingStatisticSummary");
   }
 }
 
@@ -1763,7 +1766,7 @@ export interface SamplingStatisticsDocument {
 
 export namespace SamplingStatisticsDocument {
   export function isa(o: any): o is SamplingStatisticsDocument {
-    return _smithy.isa(o, "SamplingStatisticsDocument");
+    return __isa(o, "SamplingStatisticsDocument");
   }
 }
 
@@ -1785,7 +1788,7 @@ export interface SamplingStrategy {
 
 export namespace SamplingStrategy {
   export function isa(o: any): o is SamplingStrategy {
-    return _smithy.isa(o, "SamplingStrategy");
+    return __isa(o, "SamplingStrategy");
   }
 }
 
@@ -1831,7 +1834,7 @@ export interface SamplingTargetDocument {
 
 export namespace SamplingTargetDocument {
   export function isa(o: any): o is SamplingTargetDocument {
-    return _smithy.isa(o, "SamplingTargetDocument");
+    return __isa(o, "SamplingTargetDocument");
   }
 }
 
@@ -1858,7 +1861,7 @@ export interface Segment {
 
 export namespace Segment {
   export function isa(o: any): o is Segment {
-    return _smithy.isa(o, "Segment");
+    return __isa(o, "Segment");
   }
 }
 
@@ -1957,7 +1960,7 @@ export interface Service {
 
 export namespace Service {
   export function isa(o: any): o is Service {
-    return _smithy.isa(o, "Service");
+    return __isa(o, "Service");
   }
 }
 
@@ -1989,7 +1992,7 @@ export interface ServiceId {
 
 export namespace ServiceId {
   export function isa(o: any): o is ServiceId {
-    return _smithy.isa(o, "ServiceId");
+    return __isa(o, "ServiceId");
   }
 }
 
@@ -2026,7 +2029,7 @@ export interface ServiceStatistics {
 
 export namespace ServiceStatistics {
   export function isa(o: any): o is ServiceStatistics {
-    return _smithy.isa(o, "ServiceStatistics");
+    return __isa(o, "ServiceStatistics");
   }
 }
 
@@ -2068,16 +2071,14 @@ export interface TelemetryRecord {
 
 export namespace TelemetryRecord {
   export function isa(o: any): o is TelemetryRecord {
-    return _smithy.isa(o, "TelemetryRecord");
+    return __isa(o, "TelemetryRecord");
   }
 }
 
 /**
  * <p>The request exceeds the maximum number of requests per second.</p>
  */
-export interface ThrottledException
-  extends _smithy.SmithyException,
-    $MetadataBearer {
+export interface ThrottledException extends __SmithyException, $MetadataBearer {
   name: "ThrottledException";
   $fault: "client";
   Message?: string;
@@ -2085,7 +2086,7 @@ export interface ThrottledException
 
 export namespace ThrottledException {
   export function isa(o: any): o is ThrottledException {
-    return _smithy.isa(o, "ThrottledException");
+    return __isa(o, "ThrottledException");
   }
 }
 
@@ -2122,7 +2123,7 @@ export interface TimeSeriesServiceStatistics {
 
 export namespace TimeSeriesServiceStatistics {
   export function isa(o: any): o is TimeSeriesServiceStatistics {
-    return _smithy.isa(o, "TimeSeriesServiceStatistics");
+    return __isa(o, "TimeSeriesServiceStatistics");
   }
 }
 
@@ -2151,7 +2152,7 @@ export interface Trace {
 
 export namespace Trace {
   export function isa(o: any): o is Trace {
-    return _smithy.isa(o, "Trace");
+    return __isa(o, "Trace");
   }
 }
 
@@ -2273,7 +2274,7 @@ export interface TraceSummary {
 
 export namespace TraceSummary {
   export function isa(o: any): o is TraceSummary {
-    return _smithy.isa(o, "TraceSummary");
+    return __isa(o, "TraceSummary");
   }
 }
 
@@ -2295,7 +2296,7 @@ export interface TraceUser {
 
 export namespace TraceUser {
   export function isa(o: any): o is TraceUser {
-    return _smithy.isa(o, "TraceUser");
+    return __isa(o, "TraceUser");
   }
 }
 
@@ -2323,7 +2324,7 @@ export interface UnprocessedStatistics {
 
 export namespace UnprocessedStatistics {
   export function isa(o: any): o is UnprocessedStatistics {
-    return _smithy.isa(o, "UnprocessedStatistics");
+    return __isa(o, "UnprocessedStatistics");
   }
 }
 
@@ -2350,7 +2351,7 @@ export interface UnprocessedTraceSegment {
 
 export namespace UnprocessedTraceSegment {
   export function isa(o: any): o is UnprocessedTraceSegment {
-    return _smithy.isa(o, "UnprocessedTraceSegment");
+    return __isa(o, "UnprocessedTraceSegment");
   }
 }
 
@@ -2374,7 +2375,7 @@ export interface UpdateGroupRequest {
 
 export namespace UpdateGroupRequest {
   export function isa(o: any): o is UpdateGroupRequest {
-    return _smithy.isa(o, "UpdateGroupRequest");
+    return __isa(o, "UpdateGroupRequest");
   }
 }
 
@@ -2390,7 +2391,7 @@ export interface UpdateGroupResult extends $MetadataBearer {
 
 export namespace UpdateGroupResult {
   export function isa(o: any): o is UpdateGroupResult {
-    return _smithy.isa(o, "UpdateGroupResult");
+    return __isa(o, "UpdateGroupResult");
   }
 }
 
@@ -2404,7 +2405,7 @@ export interface UpdateSamplingRuleRequest {
 
 export namespace UpdateSamplingRuleRequest {
   export function isa(o: any): o is UpdateSamplingRuleRequest {
-    return _smithy.isa(o, "UpdateSamplingRuleRequest");
+    return __isa(o, "UpdateSamplingRuleRequest");
   }
 }
 
@@ -2418,7 +2419,7 @@ export interface UpdateSamplingRuleResult extends $MetadataBearer {
 
 export namespace UpdateSamplingRuleResult {
   export function isa(o: any): o is UpdateSamplingRuleResult {
-    return _smithy.isa(o, "UpdateSamplingRuleResult");
+    return __isa(o, "UpdateSamplingRuleResult");
   }
 }
 
@@ -2440,6 +2441,6 @@ export interface ValueWithServiceIds {
 
 export namespace ValueWithServiceIds {
   export function isa(o: any): o is ValueWithServiceIds {
-    return _smithy.isa(o, "ValueWithServiceIds");
+    return __isa(o, "ValueWithServiceIds");
   }
 }

--- a/clients/client-xray/protocols/Aws_restJson1_1.ts
+++ b/clients/client-xray/protocols/Aws_restJson1_1.ts
@@ -932,6 +932,7 @@ export async function deserializeAws_restJson1_1DeleteGroupCommand(
     $metadata: deserializeMetadata(output),
     __type: "DeleteGroupResult"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 
@@ -1867,6 +1868,7 @@ export async function deserializeAws_restJson1_1PutTelemetryRecordsCommand(
     $metadata: deserializeMetadata(output),
     __type: "PutTelemetryRecordsResult"
   };
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 }
 


### PR DESCRIPTION
* fix: return empty array or map instead of undefined ([#885](https://github.com/aws/aws-sdk-js-v3/pull/885))
* fix: allow RPC protocols to set the body without input ([67c733a](https://github.com/awslabs/smithy-typescript/commit/67c733a6aa950ce074e1c2f3d66794efcdeb8eba))
* fix: use extended URI encoding([smtihy-typescript#130](https://github.com/awslabs/smithy-typescript/pull/130))([#915](https://github.com/aws/aws-sdk-js-v3/pull/915))
* fix: add bodies for undefined query/ec2 inputs([#917](https://github.com/aws/aws-sdk-js-v3/pull/917))
* fix: collect unused stream bodies([smithy-typescript#133](https://github.com/awslabs/smithy-typescript/pull/133))
* fix: query list encoding([smithy-typescript#134](https://github.com/awslabs/smithy-typescript/pull/134))
* fix: handle flattened xml with slf-closed tag([#919](https://github.com/aws/aws-sdk-js-v3/pull/919))
* fix: update smithy-client import strategy([smithy-typescript#135](https://github.com/awslabs/smithy-typescript/pull/135))

Replaces: #921 #911 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
